### PR TITLE
feat(app-blocks): sticky review action bar + route-leave guard + a11y on the review page [Phase 2.3]

### DIFF
--- a/src/components/Apps/OnsiteReviewModal.tsx
+++ b/src/components/Apps/OnsiteReviewModal.tsx
@@ -14,10 +14,10 @@ import {
   Stack,
   Switch,
   Text,
-  Textarea,
   ThemeIcon,
   Tooltip,
 } from '@mantine/core';
+import { ReviewActionBar } from '~/components/Apps/ReviewActionBar';
 import {
   IconAdjustmentsAlt,
   IconAlertTriangle,
@@ -42,14 +42,8 @@ import {
   ManifestDiffPreview,
   type FileLineDiff,
 } from '~/components/Apps/reviewDiffPanels';
-import {
-  ReasonGatedField,
-  ReasonGatedSubmitButton,
-  reasonMeetsMin,
-} from '~/components/Apps/ReasonGatedActionModal';
 import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
 import { isSensitiveBlockScope } from '~/shared/constants/block-scope.constants';
-import { OFFSITE_MOD_REASON_MIN } from '~/server/schema/blocks/offsite-moderation.schema';
 import {
   MARKETPLACE_CATEGORIES,
   MARKETPLACE_CATEGORY_LABELS,
@@ -259,60 +253,24 @@ export function OnsiteReviewModalBody({
   selection,
   onClose,
   busyRef,
+  hideInlineActions = false,
 }: {
   selection: NonNullable<OnsiteReviewSelection>;
   onClose: () => void;
-  busyRef: { current: boolean };
+  /** Modal shell close-guard ref, passed through to the inline action bar.
+   *  Omitted by the page, which renders its own (sticky) action bar. */
+  busyRef?: { current: boolean };
+  /** Suppress the inline approve/reject footer so the page can render the actions
+   *  in its own sticky bottom bar (the modal keeps them inline). */
+  hideInlineActions?: boolean;
 }) {
-  const utils = trpc.useUtils();
   const features = useFeatureFlags();
-  const [approvalNotes, setApprovalNotes] = useState('');
-  const [rejectionReason, setRejectionReason] = useState('');
-  const [actionMode, setActionMode] = useState<'view' | 'reject'>('view');
 
   const { request, mode } = selection;
-
-  const approveMut = trpc.blocks.approveRequest.useMutation({
-    onSuccess: async () => {
-      showSuccessNotification({
-        message: `Approved ${request.slug} v${request.version}. Build started.`,
-      });
-      await utils.blocks.listPendingRequests.invalidate();
-      await utils.blocks.listApprovedRequests.invalidate();
-      onClose();
-    },
-    onError: (e) => {
-      showErrorNotification({
-        title: 'Approve failed',
-        error: new Error(e.message),
-      });
-    },
-  });
-  const rejectMut = trpc.blocks.rejectRequest.useMutation({
-    onSuccess: async () => {
-      showSuccessNotification({
-        message: `Rejected ${request.slug} v${request.version}.`,
-      });
-      await utils.blocks.listPendingRequests.invalidate();
-      await utils.blocks.listRejectedRequests.invalidate();
-      onClose();
-    },
-    onError: (e) => {
-      showErrorNotification({
-        title: 'Reject failed',
-        error: new Error(e.message),
-      });
-    },
-  });
-
-  const readOnly = mode !== 'pending';
 
   const manifest = request.manifest as Record<string, unknown>;
   const fs = (request.fileSummary ?? {}) as FileSummary;
   const mds = (request.manifestDiffSummary ?? {}) as ManifestDiffSummary;
-  const busy = approveMut.isPending || rejectMut.isPending;
-  // Publish the in-flight state up to the shell so its onClose can guard on it.
-  busyRef.current = busy;
 
   const approved = mode === 'approved' ? (request as ApprovedRequest) : null;
   const rejected = mode === 'rejected' ? (request as RejectedRequest) : null;
@@ -482,76 +440,12 @@ export function OnsiteReviewModalBody({
           <ManifestView manifest={manifest} />
         </Stack>
 
-        {readOnly ? null : actionMode === 'reject' ? (
-          <Stack gap="xs">
-            <ReasonGatedField
-              value={rejectionReason}
-              onChange={setRejectionReason}
-              disabled={busy}
-              label="Rejection reason"
-              placeholder={`Explain what needs to change before this can be approved (≥${OFFSITE_MOD_REASON_MIN} chars, shown to the dev).`}
-              testId="apps-review-reject-reason"
-              minRows={3}
-              maxRows={10}
-            />
-            <Group justify="flex-end" gap="xs">
-              <Button variant="default" onClick={() => setActionMode('view')} disabled={busy}>
-                Cancel
-              </Button>
-              <ReasonGatedSubmitButton
-                onClick={() =>
-                  rejectMut.mutate({
-                    publishRequestId: request.id,
-                    rejectionReason: rejectionReason.trim(),
-                  })
-                }
-                gateOpen={reasonMeetsMin(rejectionReason)}
-                busy={rejectMut.isPending}
-                color="red"
-                leftSection={<IconX size={14} />}
-                label="Reject"
-                testId="apps-review-reject-confirm"
-              />
-            </Group>
-          </Stack>
-        ) : (
-          <Stack gap="xs">
-            <Textarea
-              label="Approval notes (optional)"
-              autosize
-              minRows={2}
-              maxRows={6}
-              placeholder="Optional notes attached to the approval record."
-              value={approvalNotes}
-              onChange={(e) => setApprovalNotes(e.currentTarget.value)}
-              disabled={busy}
-            />
-            <Group justify="flex-end" gap="xs">
-              <Button
-                color="red"
-                variant="default"
-                leftSection={<IconX size={14} />}
-                onClick={() => setActionMode('reject')}
-                disabled={busy}
-              >
-                Reject…
-              </Button>
-              <Button
-                color="green"
-                leftSection={<IconCheck size={14} />}
-                onClick={() =>
-                  approveMut.mutate({
-                    publishRequestId: request.id,
-                    approvalNotes: approvalNotes.trim() || undefined,
-                  })
-                }
-                disabled={busy}
-                loading={approveMut.isPending}
-              >
-                Approve + build
-              </Button>
-            </Group>
-          </Stack>
+        {/* Approve/reject controls. Rendered inline here for the modal (its
+            footer, unchanged), and SUPPRESSED on the page (`hideInlineActions`),
+            which renders the same `ReviewActionBar` pinned in a sticky bottom bar.
+            The bar self-suppresses for read-only approved/rejected history. */}
+        {!hideInlineActions && (
+          <ReviewActionBar selection={selection} onClose={onClose} busyRef={busyRef} />
         )}
       </Stack>
   );

--- a/src/components/Apps/ReviewActionBar.browser.test.tsx
+++ b/src/components/Apps/ReviewActionBar.browser.test.tsx
@@ -1,0 +1,221 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { page } from 'vitest/browser';
+// `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
+import { renderWithProviders } from '../../../test/component-setup';
+
+/**
+ * `ReviewActionBar` — the approve/reject control surface extracted from
+ * `OnsiteReviewModalBody` so the modal (inline footer) and the review PAGE (sticky
+ * bottom bar) render the SAME controls + mutations from one source.
+ *
+ * This suite is the proof the extraction is behaviour-preserving (it ports the
+ * modal's approve-fires / reject-gate / error / read-only assertions onto the bar
+ * directly) PLUS the NEW page-facing surface: the `onStatusChange` mutation-status
+ * callback (submitting / approved / rejected / error) the page uses to drive its
+ * aria-live region and route-leave guard, and the `busyRef` the modal still writes.
+ */
+
+const PENDING = {
+  id: 'req-1',
+  appBlockId: null as string | null,
+  slug: 'my-block',
+  version: '1.2.0',
+  submittedAt: new Date('2026-01-01T00:00:00Z'),
+  bundleSizeBytes: '2048',
+  bundleSha256: 'abc',
+  manifest: { name: 'My Block', scopes: ['user:read'], targets: [] },
+  fileSummary: { files: [], added: [], removed: [], changed: [] },
+  manifestDiffSummary: { kind: 'first-version', fields: ['name'] },
+  reviewRepoUrl: 'https://forgejo.example/repo',
+  pushCommitUrl: null as string | null,
+  submittedBy: { id: 7, username: 'dev-user', image: null },
+};
+
+const mocks = vi.hoisted(() => ({
+  invalidate: vi.fn().mockResolvedValue(undefined),
+  mutate: vi.fn(),
+  errorMode: false,
+  pending: false,
+}));
+
+const showError = vi.fn();
+vi.mock('~/utils/notifications', () => ({
+  showSuccessNotification: vi.fn(),
+  showErrorNotification: (...a: unknown[]) => showError(...a),
+}));
+
+vi.mock('~/utils/trpc', () => {
+  const mutation =
+    (name: string) =>
+    (opts?: { onSuccess?: () => void; onError?: (e: { message: string }) => void }) => ({
+      mutate: (vars: unknown) => {
+        mocks.mutate(name, vars);
+        if (mocks.errorMode) opts?.onError?.({ message: 'boom' });
+        else void opts?.onSuccess?.();
+      },
+      mutateAsync: vi.fn(),
+      isPending: mocks.pending,
+    });
+  const inert = { invalidate: mocks.invalidate };
+  const utils = {
+    blocks: {
+      listPendingRequests: inert,
+      listApprovedRequests: inert,
+      listRejectedRequests: inert,
+    },
+  };
+  return {
+    trpc: {
+      useUtils: () => utils,
+      blocks: {
+        approveRequest: { useMutation: mutation('approve') },
+        rejectRequest: { useMutation: mutation('reject') },
+      },
+    },
+  };
+});
+
+const { ReviewActionBar } = await import('./ReviewActionBar');
+
+beforeEach(() => {
+  mocks.invalidate.mockClear();
+  mocks.mutate.mockClear();
+  mocks.errorMode = false;
+  mocks.pending = false;
+  showError.mockClear();
+});
+
+describe('ReviewActionBar — approve', () => {
+  test('renders both action entry points on a pending request and Approve fires the mutation with the id + trimmed notes', async () => {
+    const onClose = vi.fn();
+    renderWithProviders(
+      <ReviewActionBar selection={{ request: PENDING, mode: 'pending' }} onClose={onClose} />
+    );
+    await expect.element(page.getByRole('button', { name: 'Approve + build' })).toBeInTheDocument();
+    await expect.element(page.getByRole('button', { name: 'Reject…' })).toBeInTheDocument();
+
+    // Optional approval notes are trimmed and threaded into the payload (the
+    // previously-uncovered path called out in the plan's test matrix).
+    await page.getByRole('textbox', { name: 'Approval notes (optional)' }).fill('  ship it  ');
+    await page.getByRole('button', { name: 'Approve + build' }).click();
+    expect(mocks.mutate).toHaveBeenCalledWith('approve', {
+      publishRequestId: 'req-1',
+      approvalNotes: 'ship it',
+    });
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  test('an approve error surfaces via showErrorNotification and does NOT close', async () => {
+    mocks.errorMode = true;
+    const onClose = vi.fn();
+    renderWithProviders(
+      <ReviewActionBar selection={{ request: PENDING, mode: 'pending' }} onClose={onClose} />
+    );
+    await page.getByRole('button', { name: 'Approve + build' }).click();
+    expect(showError).toHaveBeenCalledWith(expect.objectContaining({ title: 'Approve failed' }));
+    expect(onClose).not.toHaveBeenCalled();
+  });
+});
+
+describe('ReviewActionBar — reject reason gate', () => {
+  test('the reject confirm is gated under the 3-char floor, then fires with the trimmed reason', async () => {
+    renderWithProviders(
+      <ReviewActionBar selection={{ request: PENDING, mode: 'pending' }} onClose={vi.fn()} />
+    );
+    // No textarea until Reject… is clicked.
+    expect(page.getByTestId('apps-review-reject-reason').elements()).toHaveLength(0);
+    await page.getByRole('button', { name: 'Reject…' }).click();
+
+    const confirm = page.getByTestId('apps-review-reject-confirm');
+    await expect.element(confirm).toBeDisabled();
+    await page.getByTestId('apps-review-reject-reason').fill('no');
+    await expect.element(confirm).toBeDisabled();
+    // Whitespace padding doesn't satisfy the gate (trimmed length counts).
+    await page.getByTestId('apps-review-reject-reason').fill('  a  ');
+    await expect.element(confirm).toBeDisabled();
+    expect(mocks.mutate).not.toHaveBeenCalled();
+
+    await page.getByTestId('apps-review-reject-reason').fill('needs changes');
+    await expect.element(confirm).toBeEnabled();
+    await confirm.click();
+    expect(mocks.mutate).toHaveBeenCalledWith('reject', {
+      publishRequestId: 'req-1',
+      rejectionReason: 'needs changes',
+    });
+  });
+});
+
+describe('ReviewActionBar — read-only history renders nothing', () => {
+  test('an approved selection renders no approve/reject controls (self-suppresses)', async () => {
+    renderWithProviders(
+      <ReviewActionBar selection={{ request: PENDING, mode: 'approved' }} onClose={vi.fn()} />
+    );
+    expect(page.getByRole('button', { name: 'Approve + build' }).elements()).toHaveLength(0);
+    expect(page.getByRole('button', { name: 'Reject…' }).elements()).toHaveLength(0);
+  });
+});
+
+describe('ReviewActionBar — modal busyRef + page onStatusChange observers', () => {
+  test('writes busy=true to busyRef while a mutation is pending (the modal close-guard)', async () => {
+    mocks.pending = true;
+    const busyRef = { current: false };
+    renderWithProviders(
+      <ReviewActionBar
+        selection={{ request: PENDING, mode: 'pending' }}
+        onClose={vi.fn()}
+        busyRef={busyRef}
+      />
+    );
+    await expect.element(page.getByRole('button', { name: 'Approve + build' })).toBeInTheDocument();
+    expect(busyRef.current).toBe(true);
+  });
+
+  test('reports "submitting" via onStatusChange while a mutation is pending', async () => {
+    mocks.pending = true;
+    const onStatusChange = vi.fn();
+    renderWithProviders(
+      <ReviewActionBar
+        selection={{ request: PENDING, mode: 'pending' }}
+        onClose={vi.fn()}
+        onStatusChange={onStatusChange}
+      />
+    );
+    await expect.element(page.getByRole('button', { name: 'Approve + build' })).toBeInTheDocument();
+    expect(onStatusChange).toHaveBeenCalledWith('submitting');
+  });
+
+  test('reports "approved" on a successful approve and "error" on a failed one', async () => {
+    const onStatusChange = vi.fn();
+    const { rerender } = await renderWithProviders(
+      <ReviewActionBar
+        selection={{ request: PENDING, mode: 'pending' }}
+        onClose={vi.fn()}
+        onStatusChange={onStatusChange}
+      />
+    );
+    await page.getByRole('button', { name: 'Approve + build' }).click();
+    expect(onStatusChange).toHaveBeenCalledWith('approved');
+
+    // A failed approve reports 'error' (fresh render so the mock flips to errorMode).
+    onStatusChange.mockClear();
+    mocks.errorMode = true;
+    await rerender(
+      <ReviewActionBar
+        selection={{ request: PENDING, mode: 'pending' }}
+        onClose={vi.fn()}
+        onStatusChange={onStatusChange}
+      />
+    );
+    await page.getByRole('button', { name: 'Approve + build' }).click();
+    expect(onStatusChange).toHaveBeenCalledWith('error');
+  });
+
+  test('the sticky variant wraps the controls in a labelled action group', async () => {
+    renderWithProviders(
+      <ReviewActionBar selection={{ request: PENDING, mode: 'pending' }} onClose={vi.fn()} sticky />
+    );
+    // The pinned bar is a labelled group so screen readers announce it.
+    await expect.element(page.getByRole('group', { name: 'Review actions' })).toBeInTheDocument();
+    await expect.element(page.getByRole('button', { name: 'Approve + build' })).toBeInTheDocument();
+  });
+});

--- a/src/components/Apps/ReviewActionBar.tsx
+++ b/src/components/Apps/ReviewActionBar.tsx
@@ -1,0 +1,219 @@
+import { Box, Button, Group, Stack, Textarea } from '@mantine/core';
+import { IconCheck, IconX } from '@tabler/icons-react';
+import { useEffect, useState } from 'react';
+import {
+  ReasonGatedField,
+  ReasonGatedSubmitButton,
+  reasonMeetsMin,
+} from '~/components/Apps/ReasonGatedActionModal';
+import { OFFSITE_MOD_REASON_MIN } from '~/server/schema/blocks/offsite-moderation.schema';
+import { showErrorNotification, showSuccessNotification } from '~/utils/notifications';
+import { trpc } from '~/utils/trpc';
+import type { OnsiteReviewSelection } from '~/components/Apps/OnsiteReviewModal';
+
+/**
+ * The moderator approve/reject control surface for an App Block review — extracted
+ * from `OnsiteReviewModalBody` so BOTH the modal (inline footer, unchanged) and the
+ * per-submission review PAGE (a sticky, always-reachable bottom bar) render the
+ * exact same controls + mutations from ONE source.
+ *
+ * Owns the transient action state (`actionMode` / `approvalNotes` /
+ * `rejectionReason`) and the two mutations. It is keyed by its callers on
+ * `request.id` (the modal via the body's keyed remount; the page directly) so that
+ * state resets per submission — no manual reset. Read-only (approved/rejected)
+ * selections render nothing (there are no terminal actions to take), so a caller
+ * can mount it unconditionally and it self-suppresses.
+ *
+ * Deliberately prop-clean of any onsite-only assumption so the deferred off-site
+ * review page (Q7) can reuse it: it needs only a `selection` (request + mode), an
+ * `onClose` (what to do after a successful action — the modal closes, the page
+ * redirects to the queue), and two optional observers:
+ *  - `busyRef`  — the modal shell writes this to refuse an in-flight close (the
+ *                 pre-split `busyRef` close-guard). The page has no modal to guard,
+ *                 so it omits this and uses `onStatusChange` instead.
+ *  - `onStatusChange` — lets the page drive its `aria-live` status region and its
+ *                 route-leave navigation guard off the mutation lifecycle.
+ *
+ * SERVER-GRAPH-FREE (only pure constant/zod imports), so it stays browser-testable
+ * and never drags the tRPC server graph into the client bundle.
+ */
+
+export type ReviewActionStatus = 'idle' | 'submitting' | 'approved' | 'rejected' | 'error';
+
+export function ReviewActionBar({
+  selection,
+  onClose,
+  busyRef,
+  onStatusChange,
+  sticky = false,
+}: {
+  selection: NonNullable<OnsiteReviewSelection>;
+  /** Invoked after a successful approve/reject (modal closes / page redirects). */
+  onClose: () => void;
+  /** Modal-only: written each render so the shell can refuse an in-flight close. */
+  busyRef?: { current: boolean };
+  /** Page-only: mutation-lifecycle status for the aria-live region + leave-guard. */
+  onStatusChange?: (status: ReviewActionStatus) => void;
+  /** Render as a pinned bottom action bar (page) vs an inline footer (modal). */
+  sticky?: boolean;
+}) {
+  const utils = trpc.useUtils();
+  const { request, mode } = selection;
+  const [actionMode, setActionMode] = useState<'view' | 'reject'>('view');
+  const [approvalNotes, setApprovalNotes] = useState('');
+  const [rejectionReason, setRejectionReason] = useState('');
+
+  const approveMut = trpc.blocks.approveRequest.useMutation({
+    onSuccess: async () => {
+      showSuccessNotification({
+        message: `Approved ${request.slug} v${request.version}. Build started.`,
+      });
+      onStatusChange?.('approved');
+      await utils.blocks.listPendingRequests.invalidate();
+      await utils.blocks.listApprovedRequests.invalidate();
+      onClose();
+    },
+    onError: (e) => {
+      onStatusChange?.('error');
+      showErrorNotification({
+        title: 'Approve failed',
+        error: new Error(e.message),
+      });
+    },
+  });
+  const rejectMut = trpc.blocks.rejectRequest.useMutation({
+    onSuccess: async () => {
+      showSuccessNotification({
+        message: `Rejected ${request.slug} v${request.version}.`,
+      });
+      onStatusChange?.('rejected');
+      await utils.blocks.listPendingRequests.invalidate();
+      await utils.blocks.listRejectedRequests.invalidate();
+      onClose();
+    },
+    onError: (e) => {
+      onStatusChange?.('error');
+      showErrorNotification({
+        title: 'Reject failed',
+        error: new Error(e.message),
+      });
+    },
+  });
+
+  const busy = approveMut.isPending || rejectMut.isPending;
+  // Publish the in-flight state to the modal shell so its onClose can guard on it
+  // (written during render so it is current by the time a close fires).
+  if (busyRef) busyRef.current = busy;
+  // Drive the page's aria-live / leave-guard while a mutation is running. Success
+  // and error are reported explicitly from the mutation callbacks above; this only
+  // announces the submitting phase (and never overwrites a terminal status, since
+  // once busy the mutation is still pending).
+  useEffect(() => {
+    if (busy) onStatusChange?.('submitting');
+  }, [busy, onStatusChange]);
+
+  // Read-only history (approved/rejected) has no terminal action — render nothing
+  // so a page can mount the bar unconditionally without an empty sticky shell.
+  if (mode !== 'pending') return null;
+
+  const inner =
+    actionMode === 'reject' ? (
+      <Stack gap="xs">
+        <ReasonGatedField
+          value={rejectionReason}
+          onChange={setRejectionReason}
+          disabled={busy}
+          label="Rejection reason"
+          placeholder={`Explain what needs to change before this can be approved (≥${OFFSITE_MOD_REASON_MIN} chars, shown to the dev).`}
+          testId="apps-review-reject-reason"
+          minRows={3}
+          maxRows={10}
+        />
+        <Group justify="flex-end" gap="xs">
+          <Button variant="default" onClick={() => setActionMode('view')} disabled={busy}>
+            Cancel
+          </Button>
+          <ReasonGatedSubmitButton
+            onClick={() =>
+              rejectMut.mutate({
+                publishRequestId: request.id,
+                rejectionReason: rejectionReason.trim(),
+              })
+            }
+            gateOpen={reasonMeetsMin(rejectionReason)}
+            busy={rejectMut.isPending}
+            color="red"
+            leftSection={<IconX size={14} />}
+            label="Reject"
+            testId="apps-review-reject-confirm"
+          />
+        </Group>
+      </Stack>
+    ) : (
+      <Stack gap="xs">
+        <Textarea
+          label="Approval notes (optional)"
+          autosize
+          minRows={2}
+          maxRows={6}
+          placeholder="Optional notes attached to the approval record."
+          value={approvalNotes}
+          onChange={(e) => setApprovalNotes(e.currentTarget.value)}
+          disabled={busy}
+        />
+        <Group justify="flex-end" gap="xs">
+          <Button
+            color="red"
+            variant="default"
+            leftSection={<IconX size={14} />}
+            onClick={() => setActionMode('reject')}
+            disabled={busy}
+          >
+            Reject…
+          </Button>
+          <Button
+            color="green"
+            leftSection={<IconCheck size={14} />}
+            onClick={() =>
+              approveMut.mutate({
+                publishRequestId: request.id,
+                approvalNotes: approvalNotes.trim() || undefined,
+              })
+            }
+            disabled={busy}
+            loading={approveMut.isPending}
+          >
+            Approve + build
+          </Button>
+        </Group>
+      </Stack>
+    );
+
+  if (!sticky) return inner;
+
+  // Sticky bottom bar for the page: pinned to the viewport bottom so a mod never
+  // has to scroll the long tabbed report to act. Plain DOM controls in normal tab
+  // order (no focus trap); respects the mobile safe-area inset.
+  return (
+    <Box
+      role="group"
+      aria-label="Review actions"
+      style={{
+        position: 'sticky',
+        bottom: 0,
+        zIndex: 3,
+        background: 'var(--mantine-color-body)',
+        borderTop: '1px solid var(--mantine-color-default-border)',
+        marginLeft: 'calc(-1 * var(--mantine-spacing-md))',
+        marginRight: 'calc(-1 * var(--mantine-spacing-md))',
+        marginBottom: 'calc(-1 * var(--mantine-spacing-md))',
+        paddingLeft: 'var(--mantine-spacing-md)',
+        paddingRight: 'var(--mantine-spacing-md)',
+        paddingTop: 'var(--mantine-spacing-md)',
+        paddingBottom: 'max(var(--mantine-spacing-md), env(safe-area-inset-bottom))',
+      }}
+    >
+      {inner}
+    </Box>
+  );
+}

--- a/src/components/Apps/ReviewDetailView.browser.test.tsx
+++ b/src/components/Apps/ReviewDetailView.browser.test.tsx
@@ -130,6 +130,9 @@ beforeEach(() => {
   mocks.pending = false;
   showError.mockClear();
   (router.events.on as any).mockClear();
+  (router.beforePopState as any).mockClear();
+  (router.push as any).mockClear();
+  (router.push as any).mockResolvedValue(true);
 });
 
 describe('ReviewDetailView — sticky action bar', () => {
@@ -253,5 +256,56 @@ describe('ReviewDetailView — route-leave guard', () => {
       (c: unknown[]) => c[0] === 'routeChangeStart'
     );
     expect(regs).toHaveLength(0);
+  });
+
+  test('never clobbers the app-global beforePopState, even while a mutation is in flight', async () => {
+    // The reworked guard sits on useCatchNavigation, which does NOT touch the
+    // single-slot router.beforePopState (owned app-wide by RoutedDialogProvider).
+    // The old hand-rolled guard overwrote it with () => false while armed — this
+    // locks that regression out at the integration level.
+    mocks.pending = true;
+    renderWithProviders(
+      <ReviewDetailView selection={{ request: PENDING, mode: 'pending' }} onClose={vi.fn()} />
+    );
+    await vi.waitFor(() => {
+      const regs = (router.events.on as any).mock.calls.filter(
+        (c: unknown[]) => c[0] === 'routeChangeStart'
+      );
+      expect(regs.length).toBeGreaterThanOrEqual(1);
+    });
+    // Armed, yet beforePopState was never called.
+    expect(router.beforePopState).not.toHaveBeenCalled();
+  });
+
+  test('a successful approve redirects to /apps/review and the guard does NOT abort its own redirect', async () => {
+    // Make the mocked router.push behave like the real pages-router: it fires
+    // routeChangeStart at every registered handler. If the leave-guard treated
+    // this programmatic redirect as a user navigation it would prompt/throw here
+    // and strand the mod on the detail page — the exact bug this rework fixes.
+    const emitRouteChangeStart = (url: string) => {
+      for (const [evt, handler] of (router.events.on as any).mock.calls) {
+        if (evt === 'routeChangeStart') (handler as (u: string) => void)(url);
+      }
+    };
+    (router.push as any).mockImplementation(async (url: unknown) => {
+      emitRouteChangeStart(typeof url === 'string' ? url : String(url));
+      return true;
+    });
+    // If the guard wrongly treated the redirect as a user nav it would consult
+    // window.confirm; it must not.
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false);
+
+    renderWithProviders(
+      <ReviewDetailView
+        selection={{ request: PENDING, mode: 'pending' }}
+        onClose={() => void router.push('/apps/review')}
+      />
+    );
+    await page.getByRole('button', { name: 'Approve + build' }).click();
+    await vi.waitFor(() => expect(router.push).toHaveBeenCalledWith('/apps/review'));
+    // The programmatic redirect was NOT treated as a user navigation.
+    expect(confirmSpy).not.toHaveBeenCalled();
+
+    confirmSpy.mockRestore();
   });
 });

--- a/src/components/Apps/ReviewDetailView.browser.test.tsx
+++ b/src/components/Apps/ReviewDetailView.browser.test.tsx
@@ -1,0 +1,257 @@
+import { useRouter } from 'next/router';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { page } from 'vitest/browser';
+// `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
+import { renderWithProviders } from '../../../test/component-setup';
+
+/**
+ * `ReviewDetailView` — the per-submission review PAGE body (`/apps/review/<id>`),
+ * factored out of the page module so it is browser-testable without the server
+ * graph. This is the page-specific action + a11y layer (Phase 2.3):
+ *  - the approve/reject controls render in a STICKY bottom bar (not inline);
+ *  - focus moves to the main review region on mount (a page has no focus trap);
+ *  - an aria-live region announces mutation-status transitions;
+ *  - a route-leave guard registers while an approve/reject is in flight.
+ * Drives the real click → mutation → redirect path, not just a mount.
+ */
+
+const PENDING = {
+  id: 'req-1',
+  appBlockId: null as string | null,
+  slug: 'my-block',
+  version: '1.2.0',
+  submittedAt: new Date('2026-01-01T00:00:00Z'),
+  bundleSizeBytes: '2048',
+  bundleSha256: 'abc',
+  manifest: {
+    name: 'My Block',
+    blockId: 'blk_1',
+    version: '1.2.0',
+    scopes: ['user:read'],
+    targets: [{ slotId: 'model.sidebar_top', priority: 10 }],
+  },
+  fileSummary: { files: [], added: [], removed: [], changed: [] },
+  manifestDiffSummary: { kind: 'first-version', fields: ['name'] },
+  reviewRepoUrl: 'https://forgejo.example/repo',
+  pushCommitUrl: null as string | null,
+  submittedBy: { id: 7, username: 'dev-user', image: null },
+};
+
+const APPROVED = {
+  ...PENDING,
+  id: 'req-2',
+  slug: 'approved-block',
+  reviewedAt: new Date('2026-01-02T00:00:00Z'),
+  approvalNotes: 'looks good',
+  reviewedBy: { id: 99, username: 'mod-user', image: null },
+};
+
+const mocks = vi.hoisted(() => ({
+  invalidate: vi.fn().mockResolvedValue(undefined),
+  mutate: vi.fn(),
+  errorMode: false,
+  reviewStatus: undefined as unknown,
+  pending: false,
+}));
+
+vi.mock('~/providers/FeatureFlagsProvider', () => ({
+  useFeatureFlags: () => ({ appBlocks: true }),
+}));
+
+vi.mock('~/components/Apps/ReviewBlockPreviewHost', () => ({
+  ReviewBlockPreviewHost: () => <div data-testid="review-host-stub" />,
+}));
+
+const showError = vi.fn();
+vi.mock('~/utils/notifications', () => ({
+  showSuccessNotification: vi.fn(),
+  showErrorNotification: (...a: unknown[]) => showError(...a),
+}));
+
+vi.mock('~/utils/trpc', () => {
+  const mutation =
+    (name: string) =>
+    (opts?: { onSuccess?: () => void; onError?: (e: { message: string }) => void }) => ({
+      mutate: (vars: unknown) => {
+        mocks.mutate(name, vars);
+        if (mocks.errorMode) opts?.onError?.({ message: 'boom' });
+        else void opts?.onSuccess?.();
+      },
+      mutateAsync: vi.fn(),
+      isPending: mocks.pending,
+    });
+  const inert = { invalidate: mocks.invalidate };
+  const utils = {
+    blocks: {
+      listPendingRequests: inert,
+      listApprovedRequests: inert,
+      listRejectedRequests: inert,
+      getReviewStatus: inert,
+      listActivePreviews: inert,
+      getMarketplaceMeta: inert,
+      getFeaturedBlocks: inert,
+      listAvailable: inert,
+    },
+  };
+  return {
+    trpc: {
+      useUtils: () => utils,
+      blocks: {
+        approveRequest: { useMutation: mutation('approve') },
+        rejectRequest: { useMutation: mutation('reject') },
+        getReviewStatus: {
+          useQuery: () => ({ data: mocks.reviewStatus, isLoading: false, error: null }),
+        },
+        previewRequest: { useMutation: mutation('preview') },
+        teardownPreview: { useMutation: mutation('teardown') },
+        getPublishRequestScreenshots: {
+          useQuery: () => ({ data: { items: [] }, isLoading: false, error: null }),
+        },
+        getPublishRequestDiff: {
+          useQuery: () => ({ data: undefined, isLoading: false, error: null }),
+        },
+        getMarketplaceMeta: {
+          useQuery: () => ({ data: undefined, isLoading: false, isError: false, error: null }),
+        },
+        setMarketplaceMeta: { useMutation: mutation('setMeta') },
+      },
+    },
+  };
+});
+
+const { ReviewDetailView } = await import('./ReviewDetailView');
+const router = useRouter();
+
+beforeEach(() => {
+  mocks.invalidate.mockClear();
+  mocks.mutate.mockClear();
+  mocks.errorMode = false;
+  mocks.reviewStatus = undefined;
+  mocks.pending = false;
+  showError.mockClear();
+  (router.events.on as any).mockClear();
+});
+
+describe('ReviewDetailView — sticky action bar', () => {
+  test('a pending submission renders the review body AND the pinned approve/reject action bar', async () => {
+    renderWithProviders(
+      <ReviewDetailView selection={{ request: PENDING, mode: 'pending' }} onClose={vi.fn()} />
+    );
+    // Body content is present (shared review body).
+    await expect.element(page.getByText('View full source')).toBeInTheDocument();
+    // The pinned action bar (labelled group) with both terminal actions.
+    const bar = page.getByRole('group', { name: 'Review actions' });
+    await expect.element(bar).toBeInTheDocument();
+    await expect.element(page.getByRole('button', { name: 'Approve + build' })).toBeInTheDocument();
+    await expect.element(page.getByRole('button', { name: 'Reject…' })).toBeInTheDocument();
+  });
+
+  test('a read-only approved submission renders NO action bar', async () => {
+    renderWithProviders(
+      <ReviewDetailView selection={{ request: APPROVED, mode: 'approved' }} onClose={vi.fn()} />
+    );
+    await expect.element(page.getByText('Approved by @mod-user')).toBeInTheDocument();
+    expect(page.getByRole('group', { name: 'Review actions' }).elements()).toHaveLength(0);
+    expect(page.getByRole('button', { name: 'Approve + build' }).elements()).toHaveLength(0);
+  });
+});
+
+describe('ReviewDetailView — focus management', () => {
+  test('focus moves to the labelled main review region on mount (not left on <body>)', async () => {
+    renderWithProviders(
+      <ReviewDetailView selection={{ request: PENDING, mode: 'pending' }} onClose={vi.fn()} />
+    );
+    const region = page.getByRole('region', { name: /Review of my-block v1\.2\.0/ });
+    await expect.element(region).toBeInTheDocument();
+    const regionEl = region.element();
+    await vi.waitFor(() => expect(document.activeElement).toBe(regionEl));
+  });
+});
+
+describe('ReviewDetailView — approve fires the mutation and redirects', () => {
+  test('clicking Approve + build fires blocks.approveRequest and invokes onClose (redirect to queue)', async () => {
+    const onClose = vi.fn();
+    renderWithProviders(
+      <ReviewDetailView selection={{ request: PENDING, mode: 'pending' }} onClose={onClose} />
+    );
+    await page.getByRole('button', { name: 'Approve + build' }).click();
+    expect(mocks.mutate).toHaveBeenCalledWith(
+      'approve',
+      expect.objectContaining({ publishRequestId: 'req-1' })
+    );
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  test('reject goes through the reason gate then fires blocks.rejectRequest with the trimmed reason', async () => {
+    renderWithProviders(
+      <ReviewDetailView selection={{ request: PENDING, mode: 'pending' }} onClose={vi.fn()} />
+    );
+    await page.getByRole('button', { name: 'Reject…' }).click();
+    const confirm = page.getByTestId('apps-review-reject-confirm');
+    await expect.element(confirm).toBeDisabled();
+    await page.getByTestId('apps-review-reject-reason').fill('needs changes');
+    await expect.element(confirm).toBeEnabled();
+    await confirm.click();
+    expect(mocks.mutate).toHaveBeenCalledWith('reject', {
+      publishRequestId: 'req-1',
+      rejectionReason: 'needs changes',
+    });
+  });
+});
+
+describe('ReviewDetailView — aria-live status region', () => {
+  test('announces "approved" after a successful approve', async () => {
+    // onClose is a spy (no real navigation) so the component stays mounted and the
+    // live region can be asserted post-success.
+    renderWithProviders(
+      <ReviewDetailView selection={{ request: PENDING, mode: 'pending' }} onClose={vi.fn()} />
+    );
+    const live = page.getByTestId('apps-review-status-live');
+    // Wait for the async mount before touching the element (browser mode commits
+    // asynchronously); idle → empty.
+    await expect.element(live).toBeInTheDocument();
+    expect(live.element().textContent).toBe('');
+    await page.getByRole('button', { name: 'Approve + build' }).click();
+    await vi.waitFor(() =>
+      expect(live.element().textContent).toContain('Submission approved')
+    );
+  });
+
+  test('announces "submitting" while a mutation is in flight', async () => {
+    mocks.pending = true;
+    renderWithProviders(
+      <ReviewDetailView selection={{ request: PENDING, mode: 'pending' }} onClose={vi.fn()} />
+    );
+    const live = page.getByTestId('apps-review-status-live');
+    await vi.waitFor(() =>
+      expect(live.element().textContent).toContain('Submitting the review decision')
+    );
+  });
+});
+
+describe('ReviewDetailView — route-leave guard', () => {
+  test('registers a routeChangeStart guard while an approve/reject mutation is in flight', async () => {
+    mocks.pending = true;
+    renderWithProviders(
+      <ReviewDetailView selection={{ request: PENDING, mode: 'pending' }} onClose={vi.fn()} />
+    );
+    // The action bar reports "submitting" → the view arms the navigation guard.
+    await vi.waitFor(() => {
+      const regs = (router.events.on as any).mock.calls.filter(
+        (c: unknown[]) => c[0] === 'routeChangeStart'
+      );
+      expect(regs.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  test('does NOT register a routeChangeStart guard when idle', async () => {
+    renderWithProviders(
+      <ReviewDetailView selection={{ request: PENDING, mode: 'pending' }} onClose={vi.fn()} />
+    );
+    await expect.element(page.getByRole('button', { name: 'Approve + build' })).toBeInTheDocument();
+    const regs = (router.events.on as any).mock.calls.filter(
+      (c: unknown[]) => c[0] === 'routeChangeStart'
+    );
+    expect(regs).toHaveLength(0);
+  });
+});

--- a/src/components/Apps/ReviewDetailView.tsx
+++ b/src/components/Apps/ReviewDetailView.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { OnsiteReviewModalBody, type OnsiteReviewSelection } from '~/components/Apps/OnsiteReviewModal';
 import {
   ReviewActionBar,
@@ -44,8 +44,18 @@ export function ReviewDetailView({
 
   // Block navigation (link click / back button / tab close) while an approve or
   // reject mutation is running — the page's replacement for the modal's busyRef
-  // close-guard.
-  useReviewNavigationGuard(status === 'submitting');
+  // close-guard. Returns a `bypass()` we trip synchronously before the intended
+  // success-redirect so the guard never blocks its own `router.push`.
+  const bypassGuard = useReviewNavigationGuard(status === 'submitting');
+
+  // The action bar calls this after a successful approve/reject. Trip the guard's
+  // bypass SYNCHRONOUSLY (before the redirect fires in `onClose`) so the guard —
+  // which is still armed at this instant, since its disarm is a scheduled
+  // effect-cleanup — lets THIS navigation through instead of aborting it.
+  const handleActionSuccess = useCallback(() => {
+    bypassGuard();
+    onClose();
+  }, [bypassGuard, onClose]);
 
   // A page has no focus trap, so a screen-reader/keyboard user would otherwise be
   // stranded on <body> after the route change. Move focus to the main region once.
@@ -99,7 +109,7 @@ export function ReviewDetailView({
       <ReviewActionBar
         key={`actions-${selection.request.id}`}
         selection={selection}
-        onClose={onClose}
+        onClose={handleActionSuccess}
         onStatusChange={setStatus}
         sticky
       />

--- a/src/components/Apps/ReviewDetailView.tsx
+++ b/src/components/Apps/ReviewDetailView.tsx
@@ -1,0 +1,108 @@
+import { useEffect, useRef, useState } from 'react';
+import { OnsiteReviewModalBody, type OnsiteReviewSelection } from '~/components/Apps/OnsiteReviewModal';
+import {
+  ReviewActionBar,
+  type ReviewActionStatus,
+} from '~/components/Apps/ReviewActionBar';
+import { useReviewNavigationGuard } from '~/components/Apps/useReviewNavigationGuard';
+
+/**
+ * The per-submission review PAGE body (`/apps/review/<id>`), factored OUT of the
+ * page module so it carries no `getServerSideProps`/server graph and is browser-
+ * testable (same reason `OnsiteReviewModalBody` was extracted from the modal).
+ *
+ * It re-hosts the shared review body WITHOUT the modal footer (`hideInlineActions`)
+ * and instead pins the approve/reject controls in a sticky bottom `ReviewActionBar`
+ * so a mod never has to scroll the long tabbed report to act. Adds the a11y layer a
+ * page needs but a focus-trapping modal did not:
+ *  - focus moves to the main review region on mount (not left on `<body>`);
+ *  - an `aria-live="polite"` region announces mutation-status transitions;
+ *  - a route-leave guard blocks navigation while an approve/reject is in flight
+ *    (the page analogue of the modal's `busyRef` close-refusal).
+ *
+ * `selection` is already resolved by the page (SSR gate + client `getPublishRequest`
+ * fetch); this component is purely presentational + interaction.
+ */
+
+const STATUS_MESSAGE: Record<ReviewActionStatus, string> = {
+  idle: '',
+  submitting: 'Submitting the review decision…',
+  approved: 'Submission approved. Returning to the review queue.',
+  rejected: 'Submission rejected. Returning to the review queue.',
+  error: 'The review action failed. Please try again.',
+};
+
+export function ReviewDetailView({
+  selection,
+  onClose,
+}: {
+  selection: NonNullable<OnsiteReviewSelection>;
+  onClose: () => void;
+}) {
+  const mainRef = useRef<HTMLDivElement>(null);
+  const [status, setStatus] = useState<ReviewActionStatus>('idle');
+
+  // Block navigation (link click / back button / tab close) while an approve or
+  // reject mutation is running — the page's replacement for the modal's busyRef
+  // close-guard.
+  useReviewNavigationGuard(status === 'submitting');
+
+  // A page has no focus trap, so a screen-reader/keyboard user would otherwise be
+  // stranded on <body> after the route change. Move focus to the main region once.
+  useEffect(() => {
+    mainRef.current?.focus();
+  }, []);
+
+  return (
+    <>
+      {/* Polite status announcements (submitting / approved / rejected / error). A
+          modal never needed this — a page transition does. Kept visually hidden. */}
+      <div
+        aria-live="polite"
+        role="status"
+        style={{
+          position: 'absolute',
+          width: 1,
+          height: 1,
+          padding: 0,
+          margin: -1,
+          overflow: 'hidden',
+          clip: 'rect(0, 0, 0, 0)',
+          whiteSpace: 'nowrap',
+          border: 0,
+        }}
+        data-testid="apps-review-status-live"
+      >
+        {STATUS_MESSAGE[status]}
+      </div>
+
+      <div
+        ref={mainRef}
+        tabIndex={-1}
+        role="region"
+        aria-label={`Review of ${selection.request.slug} v${selection.request.version}`}
+        style={{ outline: 'none' }}
+      >
+        <OnsiteReviewModalBody
+          // Route param → keyed remount for a fresh per-submission body (parity
+          // with the modal). Actions are hidden here — the sticky bar owns them.
+          key={selection.request.id}
+          selection={selection}
+          onClose={onClose}
+          hideInlineActions
+        />
+      </div>
+
+      {/* Sticky approve/reject bar. Self-suppresses (renders null) for read-only
+          approved/rejected history, so no empty bar appears there. Keyed per
+          submission so its transient reject-mode/notes state resets on navigation. */}
+      <ReviewActionBar
+        key={`actions-${selection.request.id}`}
+        selection={selection}
+        onClose={onClose}
+        onStatusChange={setStatus}
+        sticky
+      />
+    </>
+  );
+}

--- a/src/components/Apps/useReviewNavigationGuard.browser.test.tsx
+++ b/src/components/Apps/useReviewNavigationGuard.browser.test.tsx
@@ -1,5 +1,5 @@
 import { useRouter } from 'next/router';
-import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { page } from 'vitest/browser';
 // `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
 import { renderWithProviders } from '../../../test/component-setup';
@@ -7,25 +7,37 @@ import { useReviewNavigationGuard } from './useReviewNavigationGuard';
 
 /**
  * `useReviewNavigationGuard` — blocks navigation while an approve/reject mutation
- * is in flight on the review PAGE (the page's replacement for the modal's busyRef
- * close-refusal). Asserts the guard REGISTERS its pages-router hooks only while
- * active and REMOVES them when it releases — the deterministic contract, driven by
- * toggling `active`, rather than trying to fire a real route change through the
- * scaffold's mocked router.
+ * is in flight on the review PAGE. Reworked (per audit) to sit on the repo's
+ * existing `useCatchNavigation` instead of a hand-rolled guard. These tests lock
+ * the two real bugs the rework fixes:
+ *  1. the guard must NOT block its OWN success-redirect — the returned `bypass()`
+ *     escape hatch lets the intended `router.push` through the still-armed guard;
+ *  2. the guard must NOT touch `router.beforePopState` (a single global slot owned
+ *     by the app's RoutedDialogProvider — the old guard clobbered it).
+ * Plus the retained contract: a genuine user navigation mid-mutation is blocked.
  */
 
-// The scaffold mocks `next/router` as a shared singleton; the same object backs
-// every `useRouter()` call, so we can inspect its on/off/beforePopState spies.
+// The scaffold mocks `next/router` as a shared singleton; `useRouter()`, the
+// default `Router` import (what `useCatchNavigation` uses), and `Router` all back
+// the SAME object, so its on/off/beforePopState spies observe the guard.
 const router = useRouter();
 const onSpy = router.events.on as ReturnType<typeof vi.fn>;
 const offSpy = router.events.off as ReturnType<typeof vi.fn>;
 const beforePopSpy = router.beforePopState as ReturnType<typeof vi.fn>;
 
-const routeChangeStartCalls = (spy: ReturnType<typeof vi.fn>) =>
+const routeChangeStartRegs = (spy: ReturnType<typeof vi.fn>) =>
   spy.mock.calls.filter((c: unknown[]) => c[0] === 'routeChangeStart');
 
+// The `routeChangeStart` handler `useCatchNavigation` last registered (it throws
+// to cancel a client navigation — the documented pages-router idiom).
+const lastRouteChangeStartHandler = () =>
+  routeChangeStartRegs(onSpy).at(-1)![1] as (url: string) => void;
+
+// Captured from the harness so a test can trip the success-redirect bypass.
+let bypass: () => void;
+
 function Harness({ active }: { active: boolean }) {
-  useReviewNavigationGuard(active);
+  bypass = useReviewNavigationGuard(active);
   // A visible node so the test can await the mount before reading mock.calls
   // (effects run after the async commit in browser mode).
   return <div data-testid="guard-harness" />;
@@ -35,44 +47,70 @@ beforeEach(() => {
   onSpy.mockClear();
   offSpy.mockClear();
   beforePopSpy.mockClear();
+  (router.events.emit as ReturnType<typeof vi.fn>).mockClear();
 });
 
 describe('useReviewNavigationGuard', () => {
-  test('registers NOTHING while inactive', async () => {
-    await renderWithProviders(<Harness active={false} />);
-    await expect.element(page.getByTestId('guard-harness')).toBeInTheDocument();
-    expect(routeChangeStartCalls(onSpy)).toHaveLength(0);
-    expect(beforePopSpy.mock.calls).toHaveLength(0);
-  });
-
-  test('registers the routeChangeStart + beforePopState guard while active, and removes it when it releases', async () => {
+  test('registers a routeChangeStart guard only while active — and NEVER touches beforePopState', async () => {
     const { rerender } = await renderWithProviders(<Harness active={false} />);
     await expect.element(page.getByTestId('guard-harness')).toBeInTheDocument();
+    // Inactive: nothing armed.
+    expect(routeChangeStartRegs(onSpy)).toHaveLength(0);
 
-    // Activate → guard installs a routeChangeStart handler and a popstate veto.
+    // Activate → a routeChangeStart handler installs (via useCatchNavigation).
     await rerender(<Harness active={true} />);
-    await vi.waitFor(() => expect(routeChangeStartCalls(onSpy)).toHaveLength(1));
+    await vi.waitFor(() => expect(routeChangeStartRegs(onSpy)).toHaveLength(1));
+    const registeredHandler = routeChangeStartRegs(onSpy)[0][1];
 
-    // beforePopState set to a veto (returns false while active).
-    expect(beforePopSpy.mock.calls.length).toBeGreaterThanOrEqual(1);
-    const vetoCb = beforePopSpy.mock.calls.at(-1)![0] as () => boolean;
-    expect(vetoCb()).toBe(false);
-    const registeredHandler = routeChangeStartCalls(onSpy)[0][1];
-
-    // Deactivate → the SAME handler is removed and popstate is reset to allow nav.
+    // Deactivate → the SAME handler is removed.
     await rerender(<Harness active={false} />);
-    await vi.waitFor(() => expect(routeChangeStartCalls(offSpy)).toHaveLength(1));
-    expect(routeChangeStartCalls(offSpy)[0][1]).toBe(registeredHandler);
-    const resetCb = beforePopSpy.mock.calls.at(-1)![0] as () => boolean;
-    expect(resetCb()).toBe(true);
+    await vi.waitFor(() =>
+      expect(routeChangeStartRegs(offSpy).some((c) => c[1] === registeredHandler)).toBe(true)
+    );
+
+    // Fix #2: the guard must not clobber the app-global beforePopState slot — it
+    // is never called across the whole arm→disarm cycle.
+    expect(beforePopSpy).not.toHaveBeenCalled();
   });
 
-  test('the registered routeChangeStart handler throws to abort the navigation', async () => {
+  test('blocks a genuine user-initiated navigation while active (prompts, then aborts on cancel)', async () => {
     await renderWithProviders(<Harness active={true} />);
     await expect.element(page.getByTestId('guard-harness')).toBeInTheDocument();
-    await vi.waitFor(() => expect(routeChangeStartCalls(onSpy).length).toBeGreaterThanOrEqual(1));
-    const handler = routeChangeStartCalls(onSpy).at(-1)![1] as () => void;
-    // Throwing is the documented pages-router way to cancel a client navigation.
-    expect(() => handler()).toThrow();
+    await vi.waitFor(() => expect(routeChangeStartRegs(onSpy).length).toBeGreaterThanOrEqual(1));
+
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false);
+    // Avoid a real URL mutation from the guard's history-resync.
+    const pushStateSpy = vi.spyOn(window.history, 'pushState').mockImplementation(() => {});
+
+    const handler = lastRouteChangeStartHandler();
+    // A user navigating AWAY (distinct target) mid-mutation is prompted; declining
+    // throws to cancel the navigation.
+    expect(() => handler('/some/other/path')).toThrow();
+    expect(confirmSpy).toHaveBeenCalled();
+
+    confirmSpy.mockRestore();
+    pushStateSpy.mockRestore();
   });
+
+  test('bypass() lets the intended programmatic redirect through the armed guard WITHOUT prompting', async () => {
+    await renderWithProviders(<Harness active={true} />);
+    await expect.element(page.getByTestId('guard-harness')).toBeInTheDocument();
+    await vi.waitFor(() => expect(routeChangeStartRegs(onSpy).length).toBeGreaterThanOrEqual(1));
+
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false);
+    const handler = lastRouteChangeStartHandler();
+
+    // Trip the success-redirect bypass SYNCHRONOUSLY (what ReviewDetailView does
+    // right before router.push). The still-armed guard must now let this
+    // navigation through: no confirm prompt, no throw-to-cancel.
+    bypass();
+    expect(() => handler('/apps/review')).not.toThrow();
+    expect(confirmSpy).not.toHaveBeenCalled();
+
+    confirmSpy.mockRestore();
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
 });

--- a/src/components/Apps/useReviewNavigationGuard.browser.test.tsx
+++ b/src/components/Apps/useReviewNavigationGuard.browser.test.tsx
@@ -1,0 +1,78 @@
+import { useRouter } from 'next/router';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { page } from 'vitest/browser';
+// `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
+import { renderWithProviders } from '../../../test/component-setup';
+import { useReviewNavigationGuard } from './useReviewNavigationGuard';
+
+/**
+ * `useReviewNavigationGuard` — blocks navigation while an approve/reject mutation
+ * is in flight on the review PAGE (the page's replacement for the modal's busyRef
+ * close-refusal). Asserts the guard REGISTERS its pages-router hooks only while
+ * active and REMOVES them when it releases — the deterministic contract, driven by
+ * toggling `active`, rather than trying to fire a real route change through the
+ * scaffold's mocked router.
+ */
+
+// The scaffold mocks `next/router` as a shared singleton; the same object backs
+// every `useRouter()` call, so we can inspect its on/off/beforePopState spies.
+const router = useRouter();
+const onSpy = router.events.on as ReturnType<typeof vi.fn>;
+const offSpy = router.events.off as ReturnType<typeof vi.fn>;
+const beforePopSpy = router.beforePopState as ReturnType<typeof vi.fn>;
+
+const routeChangeStartCalls = (spy: ReturnType<typeof vi.fn>) =>
+  spy.mock.calls.filter((c: unknown[]) => c[0] === 'routeChangeStart');
+
+function Harness({ active }: { active: boolean }) {
+  useReviewNavigationGuard(active);
+  // A visible node so the test can await the mount before reading mock.calls
+  // (effects run after the async commit in browser mode).
+  return <div data-testid="guard-harness" />;
+}
+
+beforeEach(() => {
+  onSpy.mockClear();
+  offSpy.mockClear();
+  beforePopSpy.mockClear();
+});
+
+describe('useReviewNavigationGuard', () => {
+  test('registers NOTHING while inactive', async () => {
+    await renderWithProviders(<Harness active={false} />);
+    await expect.element(page.getByTestId('guard-harness')).toBeInTheDocument();
+    expect(routeChangeStartCalls(onSpy)).toHaveLength(0);
+    expect(beforePopSpy.mock.calls).toHaveLength(0);
+  });
+
+  test('registers the routeChangeStart + beforePopState guard while active, and removes it when it releases', async () => {
+    const { rerender } = await renderWithProviders(<Harness active={false} />);
+    await expect.element(page.getByTestId('guard-harness')).toBeInTheDocument();
+
+    // Activate → guard installs a routeChangeStart handler and a popstate veto.
+    await rerender(<Harness active={true} />);
+    await vi.waitFor(() => expect(routeChangeStartCalls(onSpy)).toHaveLength(1));
+
+    // beforePopState set to a veto (returns false while active).
+    expect(beforePopSpy.mock.calls.length).toBeGreaterThanOrEqual(1);
+    const vetoCb = beforePopSpy.mock.calls.at(-1)![0] as () => boolean;
+    expect(vetoCb()).toBe(false);
+    const registeredHandler = routeChangeStartCalls(onSpy)[0][1];
+
+    // Deactivate → the SAME handler is removed and popstate is reset to allow nav.
+    await rerender(<Harness active={false} />);
+    await vi.waitFor(() => expect(routeChangeStartCalls(offSpy)).toHaveLength(1));
+    expect(routeChangeStartCalls(offSpy)[0][1]).toBe(registeredHandler);
+    const resetCb = beforePopSpy.mock.calls.at(-1)![0] as () => boolean;
+    expect(resetCb()).toBe(true);
+  });
+
+  test('the registered routeChangeStart handler throws to abort the navigation', async () => {
+    await renderWithProviders(<Harness active={true} />);
+    await expect.element(page.getByTestId('guard-harness')).toBeInTheDocument();
+    await vi.waitFor(() => expect(routeChangeStartCalls(onSpy).length).toBeGreaterThanOrEqual(1));
+    const handler = routeChangeStartCalls(onSpy).at(-1)![1] as () => void;
+    // Throwing is the documented pages-router way to cancel a client navigation.
+    expect(() => handler()).toThrow();
+  });
+});

--- a/src/components/Apps/useReviewNavigationGuard.ts
+++ b/src/components/Apps/useReviewNavigationGuard.ts
@@ -1,0 +1,56 @@
+import { useRouter } from 'next/router';
+import { useEffect } from 'react';
+
+/**
+ * Block navigation while `active` (an approve/reject mutation is in flight).
+ *
+ * On the review PAGE there is no `<Modal>` shell, so the modal's `busyRef`
+ * close-refusal has no analogue — a mod could click a nav link (or hit the
+ * browser back button, or close the tab) mid-mutation and lose the in-flight
+ * action's context. This installs the pages-router equivalent while `active`:
+ *
+ *  - `routeChangeStart` — throwing from the handler is the documented Next.js
+ *    pages-router idiom to CANCEL a client-side navigation (there is no
+ *    promise-returning veto). We emit `routeChangeError` first to clear the
+ *    NProgress/loading indicator, then throw a sentinel the router swallows.
+ *  - `beforePopState` — returns `false` to veto browser back/forward (which does
+ *    not go through `routeChangeStart`).
+ *  - `beforeunload` — the browser-native guard for a tab close / hard reload.
+ *
+ * All three are torn down when `active` flips false (or on unmount), so a settled
+ * mutation immediately releases navigation. Idempotent: mounting with
+ * `active === false` registers nothing.
+ */
+export function useReviewNavigationGuard(active: boolean, message = 'A review action is still in progress.') {
+  const router = useRouter();
+
+  useEffect(() => {
+    if (!active) return;
+
+    const abortRouteChange = () => {
+      // Clear the loading indicator the router already started, then abort.
+      router.events.emit('routeChangeError');
+      // The router catches this to cancel the navigation (documented pattern).
+      // eslint-disable-next-line @typescript-eslint/no-throw-literal
+      throw `Route change aborted: ${message}`;
+    };
+
+    const beforeUnload = (e: BeforeUnloadEvent) => {
+      e.preventDefault();
+      // Legacy browsers require returnValue to be set to show the prompt.
+      e.returnValue = message;
+      return message;
+    };
+
+    router.events.on('routeChangeStart', abortRouteChange);
+    router.beforePopState(() => false);
+    window.addEventListener('beforeunload', beforeUnload);
+
+    return () => {
+      router.events.off('routeChangeStart', abortRouteChange);
+      // Reset the popstate veto so history navigation works again.
+      router.beforePopState(() => true);
+      window.removeEventListener('beforeunload', beforeUnload);
+    };
+  }, [active, message, router]);
+}

--- a/src/components/Apps/useReviewNavigationGuard.ts
+++ b/src/components/Apps/useReviewNavigationGuard.ts
@@ -1,56 +1,38 @@
-import { useRouter } from 'next/router';
-import { useEffect } from 'react';
+import { useCallback, useRef } from 'react';
+import { useCatchNavigation } from '~/hooks/useCatchNavigation';
 
 /**
- * Block navigation while `active` (an approve/reject mutation is in flight).
+ * Block navigation while `active` (an approve/reject mutation is in flight) on the
+ * review PAGE. On the page there is no `<Modal>` shell, so the modal's `busyRef`
+ * close-refusal has no analogue — a mod could click a nav link (or hit the browser
+ * back button, or close the tab) mid-mutation and lose the in-flight action's
+ * context.
  *
- * On the review PAGE there is no `<Modal>` shell, so the modal's `busyRef`
- * close-refusal has no analogue — a mod could click a nav link (or hit the
- * browser back button, or close the tab) mid-mutation and lose the in-flight
- * action's context. This installs the pages-router equivalent while `active`:
+ * This is a THIN wrapper over the repo's existing `useCatchNavigation`, which
+ * already implements the correct pages-router pattern: a `beforeunload` guard for
+ * tab-close/reload, a `routeChangeStart` throw-to-cancel for client navigations
+ * (browser back/forward included — pages-router routes those through
+ * `routeChangeStart` too), the browser-history RESYNC (`history.pushState` back to
+ * the current path so the URL doesn't desync on a vetoed back-button), and a
+ * same-URL skip. Crucially it does NOT touch `router.beforePopState` — that setter
+ * is a single global slot owned by the app's `RoutedDialogProvider`, and the prior
+ * hand-rolled guard clobbered it (breaking app-wide routed-dialog back/forward
+ * after any approve/reject).
  *
- *  - `routeChangeStart` — throwing from the handler is the documented Next.js
- *    pages-router idiom to CANCEL a client-side navigation (there is no
- *    promise-returning veto). We emit `routeChangeError` first to clear the
- *    NProgress/loading indicator, then throw a sentinel the router swallows.
- *  - `beforePopState` — returns `false` to veto browser back/forward (which does
- *    not go through `routeChangeStart`).
- *  - `beforeunload` — the browser-native guard for a tab close / hard reload.
- *
- * All three are torn down when `active` flips false (or on unmount), so a settled
- * mutation immediately releases navigation. Idempotent: mounting with
- * `active === false` registers nothing.
+ * Returns a `bypass()` callback the caller trips SYNCHRONOUSLY immediately before
+ * its own success-redirect (`router.push('/apps/review')`). Without it the guard
+ * would block its OWN intended redirect — the guard is still armed at redirect time
+ * because the disarm is a scheduled effect-cleanup that runs a microtask too late —
+ * stranding the mod on the detail page. A genuine user-initiated navigation while a
+ * mutation is in flight still prompts; only the programmatic redirect bypasses.
  */
-export function useReviewNavigationGuard(active: boolean, message = 'A review action is still in progress.') {
-  const router = useRouter();
-
-  useEffect(() => {
-    if (!active) return;
-
-    const abortRouteChange = () => {
-      // Clear the loading indicator the router already started, then abort.
-      router.events.emit('routeChangeError');
-      // The router catches this to cancel the navigation (documented pattern).
-      // eslint-disable-next-line @typescript-eslint/no-throw-literal
-      throw `Route change aborted: ${message}`;
-    };
-
-    const beforeUnload = (e: BeforeUnloadEvent) => {
-      e.preventDefault();
-      // Legacy browsers require returnValue to be set to show the prompt.
-      e.returnValue = message;
-      return message;
-    };
-
-    router.events.on('routeChangeStart', abortRouteChange);
-    router.beforePopState(() => false);
-    window.addEventListener('beforeunload', beforeUnload);
-
-    return () => {
-      router.events.off('routeChangeStart', abortRouteChange);
-      // Reset the popstate veto so history navigation works again.
-      router.beforePopState(() => true);
-      window.removeEventListener('beforeunload', beforeUnload);
-    };
-  }, [active, message, router]);
+export function useReviewNavigationGuard(
+  active: boolean,
+  message = 'A review decision is still being submitted. Leave the page anyway?'
+) {
+  const bypassRef = useRef(false);
+  useCatchNavigation({ unsavedChanges: active, message, bypassRef });
+  return useCallback(() => {
+    bypassRef.current = true;
+  }, []);
 }

--- a/src/hooks/useCatchNavigation.tsx
+++ b/src/hooks/useCatchNavigation.tsx
@@ -1,11 +1,26 @@
 import Router from 'next/router';
 import { useEffect } from 'react';
 
-type Props = { unsavedChanges?: boolean; message?: string; eval?: () => boolean };
+type Props = {
+  unsavedChanges?: boolean;
+  message?: string;
+  eval?: () => boolean;
+  /**
+   * Live, synchronous escape hatch. When this ref reads `true` at navigation
+   * time, the guard lets the navigation through WITHOUT prompting — even while
+   * `unsavedChanges` is still true. A caller trips it (synchronously) right
+   * before its OWN programmatic `router.push` so the guard never blocks the
+   * redirect it intends, without depending on the `unsavedChanges` effect having
+   * re-run first (the effect-cleanup-vs-microtask race). Optional and
+   * backward-compatible: callers that omit it keep the exact prior behaviour.
+   */
+  bypassRef?: { current: boolean };
+};
 
 export function useCatchNavigation({
   unsavedChanges = false,
   message = 'All unsaved changes will be lost. Are you sure you want to exit?',
+  bypassRef,
 }: Props) {
   // Display alert when closing tab/window or navigating out,
   // if there are unsaved changes
@@ -18,6 +33,11 @@ export function useCatchNavigation({
     }
 
     function handleBrowsingAway(url: string) {
+      // Live escape hatch — a caller-owned programmatic redirect (which trips
+      // this synchronously just before router.push) is never treated as an
+      // unsaved-changes navigation, so the guard doesn't block its own redirect.
+      if (bypassRef?.current) return;
+
       const currentUrl = window.location.pathname;
       const nextUrl = url.split('?')[0];
 
@@ -50,5 +70,5 @@ export function useCatchNavigation({
       window.removeEventListener('beforeunload', handleWindowClose);
       Router.events.off('routeChangeStart', handleBrowsingAway);
     };
-  }, [message, unsavedChanges]);
+  }, [message, unsavedChanges, bypassRef]);
 }

--- a/src/pages/apps/review/[publishRequestId].tsx
+++ b/src/pages/apps/review/[publishRequestId].tsx
@@ -2,15 +2,14 @@ import { Button, Center, Loader } from '@mantine/core';
 import { IconArrowLeft } from '@tabler/icons-react';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
-import { useRef } from 'react';
 import { NotFound } from '~/components/AppLayout/NotFound';
 import { AppsPageLayout } from '~/components/Apps/AppsPageLayout';
 import {
-  OnsiteReviewModalBody,
   OnsiteReviewModalTitle,
   type AnyRequest,
   type OnsiteReviewMode,
 } from '~/components/Apps/OnsiteReviewModal';
+import { ReviewDetailView } from '~/components/Apps/ReviewDetailView';
 import { Meta } from '~/components/Meta/Meta';
 import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
 import { createServerSideProps } from '~/server/utils/server-side-helpers';
@@ -88,11 +87,6 @@ export const getServerSideProps = createServerSideProps<ReviewDetailPageProps>({
 export default function ReviewDetailPage({ publishRequestId }: ReviewDetailPageProps) {
   const features = useFeatureFlags();
   const router = useRouter();
-  // The page has no `<Modal>` shell, so `busyRef` (which the shell used to refuse
-  // an in-flight close) has no consumer here — a plain ref satisfies the body's
-  // contract. A route-leave busy-guard is a Phase 2 concern; Phase 1 keeps the
-  // body behaviour-identical.
-  const busyRef = useRef(false);
 
   const query = trpc.blocks.getPublishRequest.useQuery(
     { publishRequestId },
@@ -138,16 +132,15 @@ export default function ReviewDetailPage({ publishRequestId }: ReviewDetailPageP
           // gate uses — never a half-rendered review.
           <NotFound />
         ) : (
-          <OnsiteReviewModalBody
-            // Route param remounts the page per submission (fresh approve/reject
-            // state); key parity with the modal for defensiveness.
+          <ReviewDetailView
+            // Route param remounts per submission (fresh approve/reject state);
+            // key parity with the modal for defensiveness.
             key={selection.request.id}
             selection={selection}
             // Q6: after approve/reject, redirect to the queue (matches today's
             // modal-close-then-invalidate — the mutation already invalidates the
             // list queries, so the queue is fresh on arrival).
             onClose={() => void router.push('/apps/review')}
-            busyRef={busyRef}
           />
         )}
       </AppsPageLayout>

--- a/test/component-setup.tsx
+++ b/test/component-setup.tsx
@@ -59,6 +59,11 @@ vi.mock('next/router', () => {
     events: { on: vi.fn(), off: vi.fn(), emit: vi.fn() },
   };
   return {
+    // Real `next/router` is an ES module; flag the mock so a DEFAULT import
+    // (`import Router from 'next/router'`, used by `useCatchNavigation` and many
+    // other components) resolves to the singleton rather than the namespace
+    // object under esModuleInterop (whose `.events` would be undefined).
+    __esModule: true,
     useRouter: () => router,
     Router: router,
     default: router,


### PR DESCRIPTION
## Phase 2.3 — page action/a11y layer for the App Blocks review page

Phase 2 core (tabbed report redesign, #3303) already merged. This is the
page-specific action + accessibility layer for `/apps/review/<publishRequestId>`:
a sticky approve/reject action bar, a route-leave guard, and focus / aria-live
management.

### Sticky approve/reject action bar
The approve/reject controls used to render inline at the end of the (now long,
tabbed) review body, so a moderator had to scroll to the bottom to act. They are
now extracted into a reusable **`<ReviewActionBar>`** and, on the page, pinned in
a **sticky bottom bar** that is always reachable.

- **Shared body kept byte-behavior-unchanged for the modal.** `OnsiteReviewModalBody`
  gains a `hideInlineActions` prop; the modal renders `<ReviewActionBar>` inline
  in its footer exactly as before (keyed remount → per-request state reset
  preserved), the page passes `hideInlineActions` and renders the same bar itself.
  `busyRef` is now optional (modal-only close-guard). The reason-gate flow
  (`ReasonGatedField`/`ReasonGatedSubmitButton`, min 3), the approve/reject
  mutations, list-query invalidation, and the Q6 redirect-to-queue-on-success are
  all preserved exactly.
- **`ReviewActionBar` is prop-clean for Q7 offsite reuse** — it needs only a
  `selection`, an `onClose`, and two optional observers (`busyRef` for the modal,
  `onStatusChange` for the page). No onsite-only assumptions.

### Route-leave guard
`useReviewNavigationGuard` replaces the modal's `busyRef` close-refusal on the
page. While an approve/reject mutation is in flight it blocks navigation via the
pages-router idioms — `routeChangeStart` (throw-to-cancel), `beforePopState`
(veto back/forward) and `beforeunload` (tab close / reload) — and tears all three
down the moment the mutation settles. Router: **`next/router`** (pages router;
`[publishRequestId].tsx`).

### Focus + a11y
- On mount, focus moves to the labelled **main review region** (`role="region"`,
  `tabIndex={-1}`) instead of being stranded on `<body>` after the route change
  (a page has no focus trap like the modal did).
- An **`aria-live="polite"`** region announces status transitions (submitting /
  approved / rejected / error).
- The sticky bar is a keyboard-reachable labelled `role="group"`, in normal tab
  order, not a focus trap. Tabs a11y is already handled by Mantine.

`ReviewDetailView` was factored out of the page module (server-graph-free,
browser-testable); the page stays a thin SSR-gate + client-query wrapper.

### Modal path unchanged (behavior-preserving)
The 14 `OnsiteReviewModal.browser.test.tsx` tests pass **unchanged** — the proof
the shared extraction didn't regress the modal (approve fires, reject reason-gate,
per-request state reset, the busy close-guard, read-only posture).

### Tests
- **34 browser tests pass** (`--project component`): 14 modal (regression,
  unchanged) + 8 `ReviewActionBar` + 3 `useReviewNavigationGuard` + 9
  `ReviewDetailView`. Real behavior driven (click approve → reason-gate →
  mutation → redirect; in-flight → guard registers; focus lands on region;
  aria-live updates). Each new load-bearing behavior was mutation-checked
  (disabling focus / the guard fails exactly the tests that should).
- `NODE_OPTIONS=--max_old_space_size=8192 tsc --noEmit`: **zero errors in changed
  files** (only pre-existing env errors: `kysely`, `event-engine-common`
  submodule, `image.service.ts` implicit-any).

### Deferred
The deep-link-to-a-finding permalink (open the right report tab / scroll to a
finding) is deferred as a **fast-follow** — it adds tab-state + scroll-sync
complexity beyond this PR's action/a11y scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
