### PR TITLE
chore(runtime): roll base image Node 24 → 22 (server-CPU regression)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ##### DEPENDENCIES
 
-FROM node:24-alpine3.22 AS deps
+FROM node:22-alpine3.20 AS deps
 RUN apk add --no-cache libc6-compat
 WORKDIR /app
 
@@ -110,7 +110,7 @@ COPY --from=builder /app/server-maps/ /server-maps/
 
 ##### RUNNER
 
-FROM node:24-alpine3.22 AS runner
+FROM node:22-alpine3.20 AS runner
 WORKDIR /app
 
 ENV NODE_ENV=production


### PR DESCRIPTION
## Rollback: Node 24 → 22 base image

Reverts the Node half of #3242 (`node:24-alpine3.22` → `node:22-alpine3.20`, both build stages). **Node version only** — sharp stays at 0.34.5.

### Why
Node 24 (V8 13.6) introduced a **~2× per-request server-CPU regression** that showed up immediately at the cutover and is still live at peak days later, at unchanged request volume. Continuous CPU profiling localizes ~100% of the growth to **native / non-main-JS-thread CPU** (V8 background / JS↔C++ boundary), with **main-thread GC pause flat** and **every application JS frame flat** — i.e. it's the runtime, not app code.

This matches the known Node 24 / V8 13.6 native-boundary regression class:
- **nodejs/node#62939** (OPEN, unexplained) — high-throughput prod, CPU steps up on the V8-major bump, GC/semi-space tuning ineffective, Maglev ruled out, no app regression. Closest fingerprint match.
- **nodejs/node#60719** (root-caused) — ~2× `String`→`std::string` native-boundary slowdown on V8 13.x; its headline fix (V8 cherry-pick, PR #61712) likely already shipped in our 24.16.0, so we're seeing a residual/#62939-class case.

Ruled out as the cause (so this isn't a flag miss): AsyncContextFrame is default-on and fast on Node 24 (benchmarked), `--max-semi-space-size=64` is only ~15%, CppHeap is rejected by a Node maintainer. **There is no known NODE_OPTIONS recovery flag** — the evidence-backed mitigation across the upstream issues is to pin back to Node 22.

### Coupled change in the deploy repo (must be sequenced)
`--experimental-async-context-frame` was removed from `NODE_OPTIONS` as Phase A of the 22→24 migration (Node 24 rejects it, exit 9). It must be **re-added only after** every pod is confirmed on Node 22, or those pods crash on startup. That change is a separate, gated PR in the deploy repo (see the rollback runbook). **Do not re-add the flag until this image is fully rolled out.**

### Deploy path
Merge → promote to `release` (that's what builds the prod image) → Flux image automation picks up the new Node-22 tag → canary rollout. The Node-24 image sha stays on ghcr as the roll-*forward* pin for when the upstream regression is fixed.
