### PR TITLE
fix(creator-shop): drop "free" from Cosmetic Studio callout

### DIFF
--- a/src/components/CreatorShop/Submit/CosmeticStudioCallout.tsx
+++ b/src/components/CreatorShop/Submit/CosmeticStudioCallout.tsx
@@ -40,7 +40,7 @@ export function CosmeticStudioCallout() {
             Don&apos;t have cosmetic artwork yet?
           </Text>
           <Text size="xs" c="dimmed">
-            Design one that meets the standards in the free Cosmetic Studio, then upload it here.
+            Design one that meets the standards in the Cosmetic Studio, then upload it here.
           </Text>
         </Stack>
         <Button


### PR DESCRIPTION
Working in the Cosmetic Studio costs Buzz, so calling it "free" is misleading. One-word copy fix in the submit item modal callout.