### PR TITLE
fix(articles): skip image scan when a moderator NSFW override is set

### DIFF
--- a/src/server/services/article.service.ts
+++ b/src/server/services/article.service.ts
@@ -948,6 +948,17 @@ export const upsertArticle = async ({
     // article is guaranteed non-null here since the `if (id)` block above fetches it
     if (!article) throw throwNotFoundError();
 
+    // A moderator-set NSFW override is the authoritative rating for the article
+    // (see updateArticleNsfwLevels), so editing an overridden article must not
+    // (re)trigger image scanning: a rescan would bounce the article into
+    // Pending/Processing — hiding it from the feed until a scan completes whose
+    // result the override supersedes anyway. Treat scanning as disabled whenever
+    // an override is (or is being) set. Clearing the override (setting it null)
+    // re-enables scanning and returns the article to auto-derivation.
+    const effectiveModeratorNsfwLevel =
+      data.moderatorNsfwLevel !== undefined ? data.moderatorNsfwLevel : article.moderatorNsfwLevel;
+    const scanContentEffective = scanContent && effectiveModeratorNsfwLevel == null;
+
     // userNsfwLevel is the user's preference and is preserved verbatim. The
     // effective article.nsfwLevel is derived by updateArticleNsfwLevels as
     // GREATEST(userNsfwLevel, cover, content images, moderation floor), so
@@ -971,7 +982,7 @@ export const upsertArticle = async ({
     // SECURITY: Validate image scan status before allowing publish
     // Prevent publishing articles with blocked or failed images
     // Note: Pending images are allowed - article will remain in Processing status until scan completes
-    if (!isModerator && data.status === ArticleStatus.Published && scanContent) {
+    if (!isModerator && data.status === ArticleStatus.Published && scanContentEffective) {
       const scanStatus = await getArticleScanStatus({ id });
       const hasProblematicImages = scanStatus.blocked > 0 || scanStatus.error > 0;
 
@@ -1157,7 +1168,7 @@ export const upsertArticle = async ({
             content: data.content,
             userId,
             coverId: coverId ?? article.coverId,
-            cleanupOnly: !scanContent,
+            cleanupOnly: !scanContentEffective,
           });
 
           // Delete truly orphaned images (DB + S3 + cache) post-transaction
@@ -1170,7 +1181,7 @@ export const upsertArticle = async ({
             });
           }
 
-          if (scanContent) {
+          if (scanContentEffective) {
             // Content changed and images need re-scanning — use Rescan to distinguish
             // user-edit-triggered rescans from initial pending scans.
             await dbWrite.article.update({
@@ -1967,6 +1978,7 @@ export async function recomputeArticleIngestionInTx(
       title: true,
       content: true,
       coverId: true,
+      moderatorNsfwLevel: true,
     },
   });
 
@@ -2021,8 +2033,21 @@ export async function recomputeArticleIngestionInTx(
   const textDone = !hasText || textModeration?.status === EntityModerationStatus.Succeeded;
 
   // --- Derive ingestion state ---
+  //
+  // A moderator-set NSFW override is authoritative: the article's rating comes
+  // from `moderatorNsfwLevel` (see updateArticleNsfwLevels), so its visibility
+  // must not hinge on image/text scan state. Force Scanned so an overridden
+  // article can't be trapped in Pending by unscanned/stuck images or bounced out
+  // of the feed on edit. If the override itself is Blocked-level, nsfwLevel
+  // carries that and the feed filters hide it — the ingestion path doesn't need
+  // to. This is the single choke point every scan/webhook/edit recompute flows
+  // through, so it also covers cover-image changes and stale Pending images.
+  const hasModeratorOverride = current.moderatorNsfwLevel != null;
+
   let next: ArticleIngestionStatus;
-  if (imageBlocked || textBlocked) {
+  if (hasModeratorOverride) {
+    next = ArticleIngestionStatus.Scanned;
+  } else if (imageBlocked || textBlocked) {
     next = ArticleIngestionStatus.Blocked;
   } else if (imageError || textError) {
     next = ArticleIngestionStatus.Error;

--- a/src/server/services/article.service.ts
+++ b/src/server/services/article.service.ts
@@ -948,17 +948,6 @@ export const upsertArticle = async ({
     // article is guaranteed non-null here since the `if (id)` block above fetches it
     if (!article) throw throwNotFoundError();
 
-    // A moderator-set NSFW override is the authoritative rating for the article
-    // (see updateArticleNsfwLevels), so editing an overridden article must not
-    // (re)trigger image scanning: a rescan would bounce the article into
-    // Pending/Processing — hiding it from the feed until a scan completes whose
-    // result the override supersedes anyway. Treat scanning as disabled whenever
-    // an override is (or is being) set. Clearing the override (setting it null)
-    // re-enables scanning and returns the article to auto-derivation.
-    const effectiveModeratorNsfwLevel =
-      data.moderatorNsfwLevel !== undefined ? data.moderatorNsfwLevel : article.moderatorNsfwLevel;
-    const scanContentEffective = scanContent && effectiveModeratorNsfwLevel == null;
-
     // userNsfwLevel is the user's preference and is preserved verbatim. The
     // effective article.nsfwLevel is derived by updateArticleNsfwLevels as
     // GREATEST(userNsfwLevel, cover, content images, moderation floor), so
@@ -982,7 +971,7 @@ export const upsertArticle = async ({
     // SECURITY: Validate image scan status before allowing publish
     // Prevent publishing articles with blocked or failed images
     // Note: Pending images are allowed - article will remain in Processing status until scan completes
-    if (!isModerator && data.status === ArticleStatus.Published && scanContentEffective) {
+    if (!isModerator && data.status === ArticleStatus.Published && scanContent) {
       const scanStatus = await getArticleScanStatus({ id });
       const hasProblematicImages = scanStatus.blocked > 0 || scanStatus.error > 0;
 
@@ -1168,7 +1157,7 @@ export const upsertArticle = async ({
             content: data.content,
             userId,
             coverId: coverId ?? article.coverId,
-            cleanupOnly: !scanContentEffective,
+            cleanupOnly: !scanContent,
           });
 
           // Delete truly orphaned images (DB + S3 + cache) post-transaction
@@ -1181,7 +1170,7 @@ export const upsertArticle = async ({
             });
           }
 
-          if (scanContentEffective) {
+          if (scanContent) {
             // Content changed and images need re-scanning — use Rescan to distinguish
             // user-edit-triggered rescans from initial pending scans.
             await dbWrite.article.update({
@@ -2034,24 +2023,25 @@ export async function recomputeArticleIngestionInTx(
 
   // --- Derive ingestion state ---
   //
-  // A moderator-set NSFW override is authoritative: the article's rating comes
-  // from `moderatorNsfwLevel` (see updateArticleNsfwLevels), so its visibility
-  // must not hinge on image/text scan state. Force Scanned so an overridden
-  // article can't be trapped in Pending by unscanned/stuck images or bounced out
-  // of the feed on edit. If the override itself is Blocked-level, nsfwLevel
-  // carries that and the feed filters hide it — the ingestion path doesn't need
-  // to. This is the single choke point every scan/webhook/edit recompute flows
-  // through, so it also covers cover-image changes and stale Pending images.
+  // A moderator-set NSFW override supplies the article's rating outright
+  // (updateArticleNsfwLevels COALESCEs it over the derived level), so an
+  // overridden article should not sit hidden in Pending waiting on a scan whose
+  // *rating* the override already supersedes — that's what bounced official
+  // articles out of the feed on every edit.
+  //
+  // It substitutes for Pending ONLY. Blocked and Error still win: an override is
+  // a rating decision, not a moderation bypass. A policy-blocked image can't
+  // surface through nsfwLevel either (the derivation joins `ingestion = 'Scanned'`
+  // images only, and the override COALESCEs over it), so `ingestion = Blocked` is
+  // the sole guard keeping it out of the feed and the search index.
   const hasModeratorOverride = current.moderatorNsfwLevel != null;
 
   let next: ArticleIngestionStatus;
-  if (hasModeratorOverride) {
-    next = ArticleIngestionStatus.Scanned;
-  } else if (imageBlocked || textBlocked) {
+  if (imageBlocked || textBlocked) {
     next = ArticleIngestionStatus.Blocked;
   } else if (imageError || textError) {
     next = ArticleIngestionStatus.Error;
-  } else if (imageDone && textDone) {
+  } else if ((imageDone && textDone) || hasModeratorOverride) {
     next = ArticleIngestionStatus.Scanned;
   } else {
     next = ArticleIngestionStatus.Pending;


### PR DESCRIPTION
## Problem

An article with a **moderator-set NSFW override** still had its visibility gated on image-scan state. Any edit (or any not-yet-finished / stuck image scan) left `ingestion = Pending`, which drops the article from the feed and the search index — even though `moderatorNsfwLevel` is already the authoritative rating. For official/curated articles a trivial edit effectively unpublished the article for the duration of a scan, and a stuck scan stranded it indefinitely.

## Fix

One change, in `recomputeArticleIngestionInTx` (`src/server/services/article.service.ts`) — the single choke point every scan webhook, text-moderation webhook, edit, and reconcile recompute flows through:

```diff
-  } else if (imageDone && textDone) {
+  } else if ((imageDone && textDone) || hasModeratorOverride) {
```

plus selecting `moderatorNsfwLevel` to derive `hasModeratorOverride`. **+16/-1.**

The override substitutes for the **`Pending` fallback only**. `Blocked` and `Error` still take precedence — an override is a rating decision, not a moderation bypass.

Because this sits at the recompute choke point, it also frees articles already stranded on stale Pending images, and covers cover-image changes, with no changes to the upsert path.

## Why not more than this

The first pass of this PR also skipped image linking/scanning in `upsertArticle` and put the override ahead of the blocked/error branches. Adversarial review (correctness + security lenses, independently) returned BLOCK on both:

1. **Forcing `Scanned` outranked `Blocked`.** A policy-blocked image — including the pHash CSAM path in `image-scan-result.service.ts` — could no longer drive `ingestion = Blocked`. The claim that "nsfwLevel carries the block instead" is **false**: `updateArticleNsfwLevels` joins only `ingestion = 'Scanned'` images and `COALESCE`s `moderatorNsfwLevel` over the derived level, so a blocked image's level never reaches `nsfwLevel`. `ingestion = Blocked` was the only remaining guard.
2. **`cleanupOnly` gating orphaned new uploads.** Images newly added to an overridden article got no `Image` row at all — never scanned, never blockable, and unrecoverable, since no cron revisits a `Published` + `Scanned` article. An owner can induce an override just by posting borderline content.

Both are reverted. Images link, create, and enqueue for scanning exactly as on `main`, and the publish-time blocked/error gate is restored.

## Behavior

| State | Before | After |
|---|---|---|
| Override + images Pending | `Pending` → hidden | `Scanned` → visible at override level |
| Override + an image `Blocked` | `Blocked` → hidden | `Blocked` → hidden (unchanged) |
| Override + scan `Error` | `Error` → hidden | `Error` → hidden (unchanged) |
| No override | unchanged | unchanged |

Scans still run in the background on overridden articles; if one comes back Blocked, the article correctly drops out of the feed.

## Test plan

- [x] `pnpm run typecheck`
- [ ] Edit an article with a mod override → stays Published and in-feed, no Processing bounce.
- [ ] Overridden article with a blocked image → still hidden (`ingestion = Blocked`).
- [ ] Article stranded on Pending images gets an override → next recompute flips it visible.
- [ ] No override → scan/publish behavior unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)