### PR TITLE
feat(apps): auto-derive external-listing scopes from the OAuth client (drop the picker)

### DIFF
--- a/src/components/Apps/DerivedScopesDisclosure.tsx
+++ b/src/components/Apps/DerivedScopesDisclosure.tsx
@@ -1,0 +1,113 @@
+import { Alert, Group, Stack, Text, Textarea } from '@mantine/core';
+import { SensitiveScopeBadge } from '~/components/Apps/SensitiveScopeBadge';
+import {
+  SCOPE_JUSTIFICATION_MAX_LENGTH,
+  isSensitiveTokenScope,
+  tokenScopeKeyByBit,
+  tokenScopeLabels,
+  tokenScopeMaskToList,
+} from '~/shared/constants/token-scope.constants';
+
+/**
+ * DerivedScopesDisclosure — the AUTHOR-facing scope surface for the external-app
+ * submit + edit wizards (W13). The listing's requested scopes are AUTO-DERIVED from
+ * the selected OAuth client's `allowedScopes` (the client already declares them at
+ * creation), so this surface NO LONGER lets the author re-pick them — it renders the
+ * derived scope set READ-ONLY (with the shared `SensitiveScopeBadge` so sensitive
+ * scopes stay prominent) and keeps ONLY the per-scope justification inputs (the
+ * moderator-review + agentic scope-trace-verify signal the client-creation flow does
+ * not capture).
+ *
+ * `requestedScopes` is the derived mask (= the client's `allowedScopes`). An empty
+ * mask (a client that requests no scopes) renders a clear "no scopes" state with no
+ * justification inputs — a valid submission. The justification map is keyed by the
+ * TokenScope enum-key (via `tokenScopeKeyByBit`), matching the server-side
+ * `scopeJustifications` contract.
+ *
+ * The SERVER is authoritative: it re-snapshots `requestedScopes` from the client's
+ * CURRENT `allowedScopes` at submit time, so this display is disclosure/UX only.
+ */
+export function DerivedScopesDisclosure({
+  requestedScopes,
+  justifications,
+  onJustificationChange,
+  disabled = false,
+  intro,
+}: {
+  /** The derived requested-scope mask (= the selected client's `allowedScopes`). */
+  requestedScopes: number;
+  /** enum-key → rationale (prefilled + edited here). */
+  justifications: Record<string, string>;
+  onJustificationChange: (key: string, text: string) => void;
+  disabled?: boolean;
+  /** Optional lead-in copy above the scope list. */
+  intro?: React.ReactNode;
+}) {
+  const scopes = tokenScopeMaskToList(requestedScopes);
+
+  return (
+    <Stack gap="xs" data-testid="apps-offsite-scope-disclosure">
+      <div>
+        <Text size="sm" fw={500}>
+          Scopes this app requests
+        </Text>
+        <Text size="xs" c="dimmed">
+          {intro ??
+            "These are your OAuth app's allowed scopes — users grant them when they connect. They're derived from the app itself and can't be changed here."}
+        </Text>
+      </div>
+
+      {scopes.length === 0 ? (
+        <Alert color="gray" variant="light" data-testid="apps-offsite-scope-empty">
+          <Text size="sm">
+            This OAuth app requests no scopes — it connects without account access.
+          </Text>
+        </Alert>
+      ) : (
+        <>
+          <Stack gap={6} data-testid="apps-offsite-scope-readonly">
+            {scopes.map(({ bit, key, label }) => (
+              <Group key={bit} gap={8} wrap="nowrap" align="center">
+                <Text size="sm" fw={600} style={{ fontFamily: 'ui-monospace, monospace' }}>
+                  {key}
+                </Text>
+                {isSensitiveTokenScope(bit) && <SensitiveScopeBadge />}
+                {label && (
+                  <Text size="xs" c="dimmed">
+                    {label}
+                  </Text>
+                )}
+              </Group>
+            ))}
+          </Stack>
+
+          <Stack gap="sm" data-testid="apps-offsite-justifications">
+            <Text size="sm" fw={500}>
+              Why do you need each scope? (optional, helps review)
+            </Text>
+            {scopes.map(({ bit, key, label }) => {
+              const justificationKey = tokenScopeKeyByBit(bit) ?? String(bit);
+              const text = justifications[justificationKey] ?? '';
+              return (
+                <Textarea
+                  key={bit}
+                  label={label || tokenScopeLabels[bit] || key}
+                  placeholder="Explain why your app needs this scope…"
+                  autosize
+                  minRows={2}
+                  maxRows={4}
+                  value={text}
+                  onChange={(e) => onJustificationChange(justificationKey, e.currentTarget.value)}
+                  maxLength={SCOPE_JUSTIFICATION_MAX_LENGTH}
+                  disabled={disabled}
+                  description={`${text.length}/${SCOPE_JUSTIFICATION_MAX_LENGTH}`}
+                  data-testid={`apps-offsite-justification-${bit}`}
+                />
+              );
+            })}
+          </Stack>
+        </>
+      )}
+    </Stack>
+  );
+}

--- a/src/components/Apps/ExternalListingEditForm.tsx
+++ b/src/components/Apps/ExternalListingEditForm.tsx
@@ -30,6 +30,7 @@ import {
   type OffsiteSubmitFormErrors,
   type OffsiteSubmitFormValues,
 } from '~/components/Apps/offsiteSubmitFormConfig';
+import { DerivedScopesDisclosure } from '~/components/Apps/DerivedScopesDisclosure';
 import { ListingAssetStep, type MetaSuggestions } from '~/components/Apps/ListingAssetStep';
 import {
   buildScalarPatch,
@@ -126,6 +127,13 @@ export function ExternalListingEditForm({ edit }: { edit: ListingEditContext }) 
     value: OffsiteSubmitFormValues[K]
   ) {
     setValues((v) => ({ ...v, [key]: value }));
+  }
+
+  function handleJustificationChange(key: string, text: string) {
+    setValues((v) => ({
+      ...v,
+      scopeJustifications: { ...v.scopeJustifications, [key]: text },
+    }));
   }
 
   function handleUrlBlur() {
@@ -372,6 +380,16 @@ export function ExternalListingEditForm({ edit }: { edit: ListingEditContext }) 
                 data-testid="apps-offsite-edit-rating"
               />
             </Group>
+
+            {edit.connectClientId != null && (
+              <DerivedScopesDisclosure
+                requestedScopes={values.requestedScopes}
+                justifications={values.scopeJustifications}
+                onJustificationChange={handleJustificationChange}
+                disabled={saving}
+                intro="These are your OAuth app's allowed scopes — they're derived from the app and can't be changed here. Editing a justification (or a change to your app's scopes) is sent for review on a live listing."
+              />
+            )}
 
             <Group justify="space-between">
               <Button variant="default" onClick={() => setActive(STEP_URL)}>

--- a/src/components/Apps/ExternalSubmitForm.browser.test.tsx
+++ b/src/components/Apps/ExternalSubmitForm.browser.test.tsx
@@ -110,6 +110,35 @@ describe('ExternalSubmitForm — merged wizard', () => {
     await expect.element(page.getByRole('button', { name: 'Create draft' })).toBeInTheDocument();
   });
 
+  test('picking a client shows the derived scopes READ-ONLY (no checkbox picker) with the sensitive badge', async () => {
+    renderWithProviders(<ExternalSubmitForm />);
+    await pickClient();
+    // Scopes are auto-derived from the client — a read-only list, no picker.
+    await expect.element(page.getByTestId('apps-offsite-scope-readonly')).toBeInTheDocument();
+    expect(page.getByRole('checkbox').elements()).toHaveLength(0);
+    // 0xffff includes sensitive scopes (UserRead / *Write) → the badge is surfaced.
+    expect(page.getByTestId('sensitive-scope-badge').elements().length).toBeGreaterThan(0);
+    // A per-scope justification input is rendered (UserRead = bit 1).
+    await expect.element(page.getByTestId('apps-offsite-justification-1')).toBeInTheDocument();
+  });
+
+  test('an empty-scopes OAuth app shows the no-scopes state and submits cleanly', async () => {
+    mocks.clients = {
+      data: [{ id: 'oauth-client-1', name: 'My OAuth App', allowedScopes: 0 }],
+      isLoading: false,
+    };
+    renderWithProviders(<ExternalSubmitForm />);
+    await pickClient();
+    await expect.element(page.getByTestId('apps-offsite-scope-empty')).toBeInTheDocument();
+    // No justification inputs, still a valid submission.
+    expect(page.getByTestId('apps-offsite-justification-1').elements()).toHaveLength(0);
+    await page.getByTestId('apps-offsite-submit-url').fill('https://vitrine.civitai.com');
+    await page.getByTestId('apps-offsite-submit-url').element().blur();
+    await page.getByRole('button', { name: 'Next' }).click();
+    await page.getByRole('button', { name: 'Create draft' }).click();
+    expect(mocks.mutate).toHaveBeenCalledTimes(1);
+  });
+
   test('an optional homepage URL prefills name + slug on Details', async () => {
     renderWithProviders(<ExternalSubmitForm />);
     await pickClient();

--- a/src/components/Apps/ExternalSubmitForm.edit.browser.test.tsx
+++ b/src/components/Apps/ExternalSubmitForm.edit.browser.test.tsx
@@ -200,6 +200,45 @@ describe('ExternalSubmitForm — edit mode', () => {
     expect(mocks.removeScreenshot).toHaveBeenCalledWith({ screenshotId: 'shadow-ss-1' });
   });
 
+  test('shows the derived scopes READ-ONLY + editable justifications and saves the scope patch', async () => {
+    // A connect listing: the client currently allows UserRead(1)|ModelsRead(4)|ModelsWrite(8) = 13.
+    const ctx = makeCtx({
+      status: 'draft',
+      connectClientId: 'oauth-1',
+      connectAllowedScopes: 13,
+      connectRequestedScopes: 13,
+      connectScopeJustifications: { ModelsRead: 'original reason' },
+    });
+    renderWithProviders(<ExternalSubmitForm edit={ctx} />);
+    // URL → Details (the scope disclosure lives on Details).
+    await page.getByRole('button', { name: 'Next' }).click();
+    await expect.element(page.getByTestId('apps-offsite-scope-readonly')).toBeInTheDocument();
+    expect(page.getByTestId('sensitive-scope-badge').elements().length).toBeGreaterThan(0);
+
+    // Edit the ModelsRead (bit 4) justification, then save.
+    await page.getByTestId('apps-offsite-justification-4').fill('updated reason');
+    await page.getByTestId('apps-offsite-edit-save').click();
+
+    await vi.waitFor(() => expect(mocks.updateListing).toHaveBeenCalledTimes(1));
+    expect(mocks.updateListing).toHaveBeenCalledWith(
+      expect.objectContaining({
+        listingId: 'apl_parent',
+        patch: expect.objectContaining({
+          requestedScopes: 13,
+          scopeJustifications: { ModelsRead: 'updated reason' },
+        }),
+      })
+    );
+    // A justification-only edit on a DRAFT is in-place — no revision.
+    expect(mocks.submitRevision).not.toHaveBeenCalled();
+  });
+
+  test('a listing with no connect client shows no scope section', async () => {
+    renderWithProviders(<ExternalSubmitForm edit={makeCtx({ connectClientId: null })} />);
+    await page.getByRole('button', { name: 'Next' }).click();
+    expect(page.getByTestId('apps-offsite-scope-disclosure').elements()).toHaveLength(0);
+  });
+
   test('the OG auto-pull re-fire is non-destructive (a prefilled name is not clobbered)', async () => {
     // Simulate the auto-pull returning a different name suggestion.
     mocks.meta = {

--- a/src/components/Apps/ExternalSubmitForm.tsx
+++ b/src/components/Apps/ExternalSubmitForm.tsx
@@ -2,14 +2,12 @@ import {
   Alert,
   Badge,
   Button,
-  Checkbox,
   Code,
   Group,
   Loader,
   Select,
   Stack,
   Stepper,
-  Table,
   Text,
   TextInput,
   Textarea,
@@ -33,29 +31,23 @@ import {
   OFFSITE_CONTENT_RATING_OPTIONS,
   OFFSITE_SUBMIT_LIMITS,
   deriveListingFromUrl,
+  deriveScopesFromClient,
   emptyOffsiteSubmitForm,
   isClientStepComplete,
   isCreateDetailsStepComplete,
   normalizeLinkUrl,
-  scopeKeyForBit,
   toSubmitExternalInput,
-  toggleScopeBit,
   validateExternalCreateForm,
   type OffsiteSubmitFormErrors,
   type OffsiteSubmitFormValues,
 } from '~/components/Apps/offsiteSubmitFormConfig';
+import { DerivedScopesDisclosure } from '~/components/Apps/DerivedScopesDisclosure';
 import { ListingAssetStep, type MetaSuggestions } from '~/components/Apps/ListingAssetStep';
 import { ExternalListingEditForm } from '~/components/Apps/ExternalListingEditForm';
 import type { ListingEditContext } from '~/components/Apps/offsiteEditConfig';
 import type { MarketplaceCategory } from '~/server/services/blocks/marketplace-categories.constants';
 import type { OffsiteContentRating } from '~/server/schema/blocks/offsite-listing.schema';
 import { isAppBlockOauthClientId } from '~/shared/constants/block-scope.constants';
-import {
-  tokenScopeGrid,
-  tokenScopeLabels,
-  tokenScopeMaskToList,
-} from '~/shared/constants/token-scope.constants';
-import { Flags } from '~/shared/utils/flags';
 import { showErrorNotification, showSuccessNotification } from '~/utils/notifications';
 import { trpc } from '~/utils/trpc';
 
@@ -168,19 +160,13 @@ function ExternalCreateForm() {
   }
 
   function handleSelectClient(clientId: string | null) {
-    // Changing the client resets the requested scopes + justifications — the new
-    // client has a DIFFERENT ceiling, so a carried-over mask could exceed it.
-    setValues((v) => ({
-      ...v,
-      connectClientId: clientId,
-      requestedScopes: 0,
-      scopeJustifications: {},
-    }));
+    // Changing the client RE-DERIVES the requested scopes from the new client's
+    // `allowedScopes` (the listing requests exactly the client's set — no picker) and
+    // re-keys the justifications, dropping any whose scope the new client doesn't have.
+    const nextClient = clientId ? clients.find((c) => c.id === clientId) ?? null : null;
+    const nextAllowed = nextClient?.allowedScopes ?? 0;
+    setValues((v) => deriveScopesFromClient({ ...v, connectClientId: clientId }, nextAllowed));
     setErrors((prev) => ({ ...prev, connectClientId: undefined, requestedScopes: undefined }));
-  }
-
-  function handleToggleScope(bit: number) {
-    setValues((v) => toggleScopeBit(v, bit));
   }
 
   function handleJustificationChange(key: string, text: string) {
@@ -252,7 +238,6 @@ function ExternalCreateForm() {
   }
 
   const busy = submitMutation.isPending;
-  const requestedScopeList = tokenScopeMaskToList(values.requestedScopes);
   const clientOptions = clients.map((c) => ({ value: c.id, label: c.name }));
 
   return (
@@ -322,94 +307,12 @@ function ExternalCreateForm() {
                 />
 
                 {selectedClient && (
-                  <Stack gap="xs" data-testid="apps-offsite-scope-grid">
-                    <div>
-                      <Text size="sm" fw={500}>
-                        Requested scopes
-                      </Text>
-                      <Text size="xs" c="dimmed">
-                        Check only the scopes your app needs. Scopes greyed out aren’t in this app’s
-                        allowed set.
-                      </Text>
-                    </div>
-                    <Table withTableBorder withColumnBorders>
-                      <Table.Thead>
-                        <Table.Tr>
-                          <Table.Th>Resource</Table.Th>
-                          <Table.Th style={{ textAlign: 'center', width: 70 }}>Read</Table.Th>
-                          <Table.Th style={{ textAlign: 'center', width: 70 }}>Write</Table.Th>
-                          <Table.Th style={{ textAlign: 'center', width: 70 }}>Delete</Table.Th>
-                        </Table.Tr>
-                      </Table.Thead>
-                      <Table.Tbody>
-                        {tokenScopeGrid.map((row) => (
-                          <Table.Tr key={row.label}>
-                            <Table.Td>
-                              <Text size="sm">{row.label}</Text>
-                            </Table.Td>
-                            {(['read', 'write', 'delete'] as const).map((col) => {
-                              const bit = (row as { read?: number; write?: number; delete?: number })[
-                                col
-                              ];
-                              const available = bit != null && Flags.hasFlag(allowedScopes, bit);
-                              return (
-                                <Table.Td key={col} style={{ textAlign: 'center' }}>
-                                  {bit != null ? (
-                                    <Checkbox
-                                      checked={Flags.hasFlag(values.requestedScopes, bit)}
-                                      onChange={() => handleToggleScope(bit)}
-                                      disabled={!available || busy}
-                                      styles={{ input: { cursor: available ? 'pointer' : 'not-allowed' } }}
-                                      data-testid={`apps-offsite-scope-${bit}`}
-                                    />
-                                  ) : (
-                                    <Text size="xs" c="dimmed">
-                                      —
-                                    </Text>
-                                  )}
-                                </Table.Td>
-                              );
-                            })}
-                          </Table.Tr>
-                        ))}
-                      </Table.Tbody>
-                    </Table>
-                    {errors.requestedScopes && (
-                      <Text size="xs" c="red">
-                        {errors.requestedScopes}
-                      </Text>
-                    )}
-
-                    {requestedScopeList.length > 0 && (
-                      <Stack gap="sm" data-testid="apps-offsite-justifications">
-                        <Text size="sm" fw={500}>
-                          Why do you need each scope? (optional, helps review)
-                        </Text>
-                        {requestedScopeList.map(({ bit, key, label }) => {
-                          const justificationKey = scopeKeyForBit(bit);
-                          const text = values.scopeJustifications[justificationKey] ?? '';
-                          return (
-                            <Textarea
-                              key={bit}
-                              label={label || tokenScopeLabels[bit] || key}
-                              placeholder="Explain why your app needs this scope…"
-                              autosize
-                              minRows={2}
-                              maxRows={4}
-                              value={text}
-                              onChange={(e) =>
-                                handleJustificationChange(justificationKey, e.currentTarget.value)
-                              }
-                              maxLength={OFFSITE_SUBMIT_LIMITS.justificationMax}
-                              disabled={busy}
-                              description={`${text.length}/${OFFSITE_SUBMIT_LIMITS.justificationMax}`}
-                              data-testid={`apps-offsite-justification-${bit}`}
-                            />
-                          );
-                        })}
-                      </Stack>
-                    )}
-                  </Stack>
+                  <DerivedScopesDisclosure
+                    requestedScopes={values.requestedScopes}
+                    justifications={values.scopeJustifications}
+                    onJustificationChange={handleJustificationChange}
+                    disabled={busy}
+                  />
                 )}
 
                 <TextInput

--- a/src/components/Apps/__tests__/offsiteEditConfig.test.ts
+++ b/src/components/Apps/__tests__/offsiteEditConfig.test.ts
@@ -7,6 +7,7 @@ import {
   isApprovedEdit,
   type ListingEditContext,
 } from '~/components/Apps/offsiteEditConfig';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
 
 /**
  * W13 — dual-mode edit wizard PURE config. Covers the prefill mapping
@@ -97,6 +98,68 @@ describe('buildScalarPatch', () => {
     const ctx = makeCtx();
     expect(buildScalarPatch(ctx, { ...editContextToForm(ctx), category: 'games' }).category).toBe('games');
     expect(buildScalarPatch(ctx, { ...editContextToForm(ctx), category: null }).category).toBeNull();
+  });
+});
+
+describe('connect scope disclosure', () => {
+  // 13 = UserRead(1) | ModelsRead(4) | ModelsWrite(8).
+  const FULL = TokenScope.UserRead | TokenScope.ModelsRead | TokenScope.ModelsWrite;
+
+  function connectCtx(overrides: Partial<ListingEditContext> = {}): ListingEditContext {
+    return makeCtx({
+      connectClientId: 'oauth-1',
+      connectAllowedScopes: FULL,
+      connectRequestedScopes: FULL,
+      connectScopeJustifications: { ModelsRead: 'reason' },
+      ...overrides,
+    });
+  }
+
+  it('editContextToForm derives requestedScopes from the client + prunes stale justifications', () => {
+    const form = editContextToForm(
+      connectCtx({
+        connectAllowedScopes: TokenScope.ModelsRead, // client now only allows ModelsRead
+        connectScopeJustifications: { ModelsRead: 'a', ModelsWrite: 'b' },
+      })
+    );
+    expect(form.connectClientId).toBe('oauth-1');
+    expect(form.requestedScopes).toBe(TokenScope.ModelsRead);
+    // ModelsWrite is no longer in the derived set → its justification is pruned.
+    expect(form.scopeJustifications).toEqual({ ModelsRead: 'a' });
+  });
+
+  it('no scope patch when nothing changed', () => {
+    const ctx = connectCtx();
+    const patch = buildScalarPatch(ctx, editContextToForm(ctx));
+    expect('requestedScopes' in patch).toBe(false);
+    expect('scopeJustifications' in patch).toBe(false);
+  });
+
+  it('sends the derived mask + shaped justifications when a justification changed', () => {
+    const ctx = connectCtx();
+    const form = { ...editContextToForm(ctx), scopeJustifications: { ModelsRead: 'updated' } };
+    const patch = buildScalarPatch(ctx, form);
+    expect(patch.requestedScopes).toBe(FULL);
+    expect(patch.scopeJustifications).toEqual({ ModelsRead: 'updated' });
+  });
+
+  it('re-enters review when the client allowedScopes DRIFTED from the stored snapshot', () => {
+    // Approved snapshot was ModelsRead only; the client now allows FULL → the form
+    // shows/submits FULL, so even an untouched-justification save re-snapshots.
+    const ctx = connectCtx({
+      connectRequestedScopes: TokenScope.ModelsRead,
+      connectAllowedScopes: FULL,
+    });
+    const patch = buildScalarPatch(ctx, editContextToForm(ctx));
+    expect(patch.requestedScopes).toBe(FULL);
+  });
+
+  it('no scope fields for a listing without a connect client', () => {
+    const ctx = makeCtx({ connectClientId: null });
+    const form = { ...editContextToForm(ctx), scopeJustifications: { ModelsRead: 'x' } };
+    const patch = buildScalarPatch(ctx, form);
+    expect('requestedScopes' in patch).toBe(false);
+    expect('scopeJustifications' in patch).toBe(false);
   });
 });
 

--- a/src/components/Apps/__tests__/offsiteSubmitFormConfig.oauth-fields.test.ts
+++ b/src/components/Apps/__tests__/offsiteSubmitFormConfig.oauth-fields.test.ts
@@ -1,11 +1,13 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  deriveScopesFromClient,
   emptyOffsiteSubmitForm,
   isClientStepComplete,
   isCreateDetailsStepComplete,
+  pruneJustificationsToMask,
+  shapeScopeJustifications,
   toSubmitExternalInput,
-  toggleScopeBit,
   validateConnectFields,
   validateExternalCreateForm,
   type OffsiteSubmitFormValues,
@@ -32,20 +34,47 @@ function full(overrides: Partial<OffsiteSubmitFormValues> = {}): OffsiteSubmitFo
   };
 }
 
-describe('toggleScopeBit', () => {
-  it('sets and clears a bit', () => {
-    const on = toggleScopeBit(emptyOffsiteSubmitForm(), TokenScope.ModelsRead);
-    expect(on.requestedScopes).toBe(TokenScope.ModelsRead);
-    const off = toggleScopeBit(on, TokenScope.ModelsRead);
-    expect(off.requestedScopes).toBe(0);
+describe('deriveScopesFromClient', () => {
+  it('sets requestedScopes to EXACTLY the client allowedScopes (auto-derived, no picking)', () => {
+    const v = deriveScopesFromClient(emptyOffsiteSubmitForm(), CEILING);
+    expect(v.requestedScopes).toBe(CEILING);
   });
 
-  it('prunes a justification when its scope is unchecked', () => {
-    let v = toggleScopeBit(emptyOffsiteSubmitForm(), TokenScope.ModelsRead);
-    v = { ...v, scopeJustifications: { ModelsRead: 'reason' } };
-    const cleared = toggleScopeBit(v, TokenScope.ModelsRead);
-    expect(cleared.requestedScopes).toBe(0);
-    expect(cleared.scopeJustifications).toEqual({});
+  it('prunes a justification for a scope the (new) client does not allow', () => {
+    const start = {
+      ...emptyOffsiteSubmitForm(),
+      scopeJustifications: { ModelsRead: 'keep', MediaWrite: 'drop' },
+    };
+    // A client that only allows ModelsRead → MediaWrite justification is pruned.
+    const v = deriveScopesFromClient(start, TokenScope.ModelsRead);
+    expect(v.requestedScopes).toBe(TokenScope.ModelsRead);
+    expect(v.scopeJustifications).toEqual({ ModelsRead: 'keep' });
+  });
+
+  it('an empty-scopes client → 0 mask + no justifications (valid, disclosure-only)', () => {
+    const v = deriveScopesFromClient(
+      { ...emptyOffsiteSubmitForm(), scopeJustifications: { ModelsRead: 'x' } },
+      0
+    );
+    expect(v.requestedScopes).toBe(0);
+    expect(v.scopeJustifications).toEqual({});
+  });
+});
+
+describe('pruneJustificationsToMask / shapeScopeJustifications', () => {
+  it('prune keeps only keys in the mask (values untouched)', () => {
+    expect(
+      pruneJustificationsToMask({ ModelsRead: '  a  ', MediaWrite: 'b' }, TokenScope.ModelsRead)
+    ).toEqual({ ModelsRead: '  a  ' });
+  });
+
+  it('shape trims, drops empties, and keeps only mask keys', () => {
+    expect(
+      shapeScopeJustifications(
+        { ModelsRead: '  a  ', UserRead: '   ', MediaWrite: 'x' },
+        TokenScope.ModelsRead | TokenScope.UserRead
+      )
+    ).toEqual({ ModelsRead: 'a' });
   });
 });
 

--- a/src/components/Apps/offsiteEditConfig.ts
+++ b/src/components/Apps/offsiteEditConfig.ts
@@ -1,4 +1,9 @@
-import { emptyOffsiteSubmitForm, type OffsiteSubmitFormValues } from '~/components/Apps/offsiteSubmitFormConfig';
+import {
+  emptyOffsiteSubmitForm,
+  pruneJustificationsToMask,
+  shapeScopeJustifications,
+  type OffsiteSubmitFormValues,
+} from '~/components/Apps/offsiteSubmitFormConfig';
 import type { UpdateListingPatch } from '~/server/schema/blocks/offsite-listing.schema';
 import type { MarketplaceCategory } from '~/server/services/blocks/marketplace-categories.constants';
 import type { OffsiteContentRating } from '~/server/schema/blocks/offsite-listing.schema';
@@ -50,6 +55,19 @@ export type ListingEditContext = {
     cover: EditAsset;
     screenshots: EditScreenshot[];
   };
+  /**
+   * OAuth-connect scope disclosure (present for the merged external-app model;
+   * OPTIONAL so pre-existing non-connect edit contexts + tests still type-check):
+   *   - `connectClientId`            — the linked client (null → no scope section).
+   *   - `connectAllowedScopes`       — the client's CURRENT allowedScopes = the
+   *     DERIVED requested set the form shows read-only + submits.
+   *   - `connectRequestedScopes`     — the STORED snapshot (for drift detection).
+   *   - `connectScopeJustifications` — the STORED per-scope rationale (prefill).
+   */
+  connectClientId?: string | null;
+  connectAllowedScopes?: number | null;
+  connectRequestedScopes?: number | null;
+  connectScopeJustifications?: Record<string, string> | null;
 };
 
 /** True for an edit context whose live parent is APPROVED (→ shadow-revision path). */
@@ -66,6 +84,11 @@ export function isApprovedEdit(ctx: ListingEditContext): boolean {
 export function editContextToForm(ctx: ListingEditContext): OffsiteSubmitFormValues {
   const base = emptyOffsiteSubmitForm();
   const s = ctx.scalars;
+  // The requested scopes are DERIVED from the client's CURRENT allowedScopes (read-
+  // only in the form; the server re-snapshots them on save). Prefilled justifications
+  // are pruned to that derived set so a scope the client no longer has doesn't seed a
+  // dangling rationale.
+  const derivedScopes = ctx.connectAllowedScopes ?? 0;
   return {
     ...base,
     slug: ctx.slug,
@@ -76,7 +99,23 @@ export function editContextToForm(ctx: ListingEditContext): OffsiteSubmitFormVal
     category: (s.category as MarketplaceCategory | null) ?? null,
     contentRating: (s.contentRating as OffsiteContentRating | null) ?? 'g',
     changelog: '',
+    connectClientId: ctx.connectClientId ?? null,
+    requestedScopes: derivedScopes,
+    scopeJustifications: pruneJustificationsToMask(
+      ctx.connectScopeJustifications ?? {},
+      derivedScopes
+    ),
   };
+}
+
+/** True iff two string→string maps have identical keys + values. PURE. */
+function shallowEqualStringMap(
+  a: Record<string, string>,
+  b: Record<string, string>
+): boolean {
+  const ak = Object.keys(a);
+  if (ak.length !== Object.keys(b).length) return false;
+  return ak.every((k) => a[k] === b[k]);
 }
 
 /**
@@ -114,6 +153,27 @@ export function buildScalarPatch(
 
   if (current.contentRating !== original.contentRating) {
     patch.contentRating = current.contentRating;
+  }
+
+  // OAuth-connect scope disclosure: the server re-snapshots `requestedScopes` from
+  // the client's CURRENT allowedScopes whenever the patch touches scopes, so we send
+  // the (derived) mask + shaped justifications when EITHER the justifications changed
+  // OR the client's allowedScopes drifted from the stored snapshot. Both re-enter mod
+  // review on an approved listing (a scope change is material). No client → no scope
+  // section, nothing to diff.
+  if (ctx.connectClientId != null) {
+    const derived = ctx.connectAllowedScopes ?? 0;
+    const storedSnapshot = ctx.connectRequestedScopes ?? 0;
+    const storedJust = shapeScopeJustifications(
+      ctx.connectScopeJustifications ?? {},
+      storedSnapshot
+    );
+    const currentJust = shapeScopeJustifications(current.scopeJustifications, derived);
+    const drifted = derived !== storedSnapshot;
+    if (drifted || !shallowEqualStringMap(currentJust, storedJust)) {
+      patch.requestedScopes = derived;
+      patch.scopeJustifications = currentJust;
+    }
   }
 
   return patch;

--- a/src/components/Apps/offsiteSubmitFormConfig.ts
+++ b/src/components/Apps/offsiteSubmitFormConfig.ts
@@ -22,7 +22,6 @@ import {
   tokenScopeKeyByBit,
   tokenScopeMaskToList,
 } from '~/shared/constants/token-scope.constants';
-import { Flags } from '~/shared/utils/flags';
 
 /**
  * App Store Listings (W13) — external-app submit form field/validation config
@@ -65,9 +64,15 @@ export type OffsiteSubmitFormValues = {
   changelog: string;
   /** REQUIRED: the id of the caller's own OAuth client (chosen in the picker). */
   connectClientId: string | null;
-  /** The disclosed requested-scope bitmask (⊆ the selected client's allowedScopes). */
+  /**
+   * The requested-scope bitmask, AUTO-DERIVED from the selected client's
+   * `allowedScopes` (no longer author-picked). Kept in the view-model so the
+   * read-only display + justification inputs iterate it and the client mirror can
+   * assert the (now trivial) subset invariant; the SERVER re-snapshots it from the
+   * client's current `allowedScopes` at submit time (authoritative).
+   */
   requestedScopes: number;
-  /** enum-key → rationale (only checked scopes get an entry). */
+  /** enum-key → rationale (only derived scopes get an entry). */
   scopeJustifications: Record<string, string>;
 };
 
@@ -293,23 +298,57 @@ export function scopeKeyForBit(bit: number): string {
 }
 
 /**
- * Toggle a single scope bit in `requestedScopes`, pruning any justification whose
- * scope is no longer requested (so the payload never carries a dangling rationale the
- * server would reject). PURE.
+ * Drop every justification whose scope is NOT in `mask` (the derived requested set),
+ * so the payload never carries a dangling rationale for a scope the app no longer
+ * requests (which the server would reject). PURE.
  */
-export function toggleScopeBit(
-  values: OffsiteSubmitFormValues,
-  bit: number
-): OffsiteSubmitFormValues {
-  const requestedScopes = Flags.hasFlag(values.requestedScopes, bit)
-    ? values.requestedScopes & ~bit
-    : values.requestedScopes | bit;
-  const requestedKeys = new Set(tokenScopeMaskToList(requestedScopes).map((s) => s.key));
-  const scopeJustifications: Record<string, string> = {};
-  for (const [key, text] of Object.entries(values.scopeJustifications)) {
-    if (requestedKeys.has(key)) scopeJustifications[key] = text;
+export function pruneJustificationsToMask(
+  justifications: Record<string, string>,
+  mask: number
+): Record<string, string> {
+  const keys = new Set(tokenScopeMaskToList(mask).map((s) => s.key));
+  const out: Record<string, string> = {};
+  for (const [key, text] of Object.entries(justifications)) {
+    if (keys.has(key)) out[key] = text;
   }
-  return { ...values, requestedScopes, scopeJustifications };
+  return out;
+}
+
+/**
+ * AUTO-DERIVE the requested scopes from the selected client's `allowedScopes`: the
+ * listing requests EXACTLY the client's allowed set (no author picking), and any
+ * justification for a scope no longer present is pruned. Called on selecting /
+ * changing the OAuth client. PURE. (Replaces the removed `toggleScopeBit` — the
+ * picker is gone; scopes are derived, not toggled.)
+ */
+export function deriveScopesFromClient(
+  values: OffsiteSubmitFormValues,
+  allowedScopes: number
+): OffsiteSubmitFormValues {
+  return {
+    ...values,
+    requestedScopes: allowedScopes,
+    scopeJustifications: pruneJustificationsToMask(values.scopeJustifications, allowedScopes),
+  };
+}
+
+/**
+ * Shape a raw justification map into the SUBMIT/EDIT payload form: trim each value,
+ * DROP empties, and keep only keys whose scope is in `mask` (the derived requested
+ * set). PURE — the single source for both `toSubmitExternalInput` (create) and the
+ * edit scalar-patch diff, so the two produce byte-identical justification payloads.
+ */
+export function shapeScopeJustifications(
+  justifications: Record<string, string>,
+  mask: number
+): Record<string, string> {
+  const keys = new Set(tokenScopeMaskToList(mask).map((s) => s.key));
+  const out: Record<string, string> = {};
+  for (const [key, text] of Object.entries(justifications)) {
+    const trimmed = text.trim();
+    if (trimmed.length > 0 && keys.has(key)) out[key] = trimmed;
+  }
+  return out;
 }
 
 /**
@@ -397,12 +436,10 @@ export function toSubmitExternalInput(values: OffsiteSubmitFormValues): {
   contentRating: OffsiteContentRating;
   changelog?: string;
 } {
-  const requestedKeys = new Set(tokenScopeMaskToList(values.requestedScopes).map((s) => s.key));
-  const scopeJustifications: Record<string, string> = {};
-  for (const [key, text] of Object.entries(values.scopeJustifications)) {
-    const trimmed = text.trim();
-    if (trimmed.length > 0 && requestedKeys.has(key)) scopeJustifications[key] = trimmed;
-  }
+  const scopeJustifications = shapeScopeJustifications(
+    values.scopeJustifications,
+    values.requestedScopes
+  );
   return {
     slug: values.slug.trim(),
     name: values.name.trim(),

--- a/src/server/schema/blocks/__tests__/offsite-listing.oauth-fields.schema.test.ts
+++ b/src/server/schema/blocks/__tests__/offsite-listing.oauth-fields.schema.test.ts
@@ -42,6 +42,11 @@ describe('submitExternalListingSchema', () => {
     expect(submitExternalListingSchema.parse({ ...valid, scopeJustifications: {} })).toBeTruthy();
   });
 
+  it('accepts an OMITTED requestedScopes (now optional — the service derives it from the client)', () => {
+    const { requestedScopes, ...rest } = valid;
+    expect(submitExternalListingSchema.safeParse(rest).success).toBe(true);
+  });
+
   it('rejects a missing connectClientId', () => {
     const { connectClientId, ...rest } = valid;
     expect(submitExternalListingSchema.safeParse(rest).success).toBe(false);

--- a/src/server/schema/blocks/offsite-listing.schema.ts
+++ b/src/server/schema/blocks/offsite-listing.schema.ts
@@ -105,8 +105,14 @@ export const submitExternalListingSchema = z
     // AppBlocksDevTunnel bits, which a client's `allowedScopes` MAY legitimately carry,
     // so bounding at Full could reject a valid subset. The per-client subset check still
     // lives in the service (it needs the client's `allowedScopes`).
-    requestedScopes: z.number().int().nonnegative().max(ALL_SCOPES),
-    // Per-value length bound only; full key/subset validation is in the service.
+    // OPTIONAL + IGNORED by the service. The listing's requested scopes are
+    // AUTO-DERIVED server-side from the client's CURRENT `allowedScopes` at submit
+    // time (server-authoritative snapshot — a form-supplied mask is never trusted).
+    // Still bounded here (int/nonnegative/≤ALL_SCOPES) so a provided value can't
+    // overflow int4, but the stored value comes from the client, not this field.
+    requestedScopes: z.number().int().nonnegative().max(ALL_SCOPES).optional(),
+    // Per-value length bound only; full key/subset validation is in the service
+    // (validated against the DERIVED scope set = the client's allowedScopes).
     scopeJustifications: z.record(z.string(), z.string().max(SCOPE_JUSTIFICATION_MAX_LENGTH)),
     // OPTIONAL homepage / Visit link. Validated for the https-only shape only when present.
     externalUrl: z.string().min(1).max(MAX_EXTERNAL_URL_LENGTH).optional(),

--- a/src/server/services/blocks/__tests__/offsite-listing.edit-consolidate.service.test.ts
+++ b/src/server/services/blocks/__tests__/offsite-listing.edit-consolidate.service.test.ts
@@ -35,6 +35,9 @@ const { mockRead, mockWrite, seq } = vi.hoisted(() => {
     appListingPublishRequest: {
       findFirst: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
     },
+    oauthClient: {
+      findUnique: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
+    },
   });
   const mockRead = makeClient();
   const mockWrite = makeClient() as ReturnType<typeof makeClient> & {
@@ -113,6 +116,7 @@ beforeEach(() => {
   mockRead.appListing.findFirst.mockResolvedValue(null);
   mockRead.appListingScreenshot.findMany.mockResolvedValue([]);
   mockRead.appListingPublishRequest.findFirst.mockResolvedValue(null);
+  mockRead.oauthClient.findUnique.mockResolvedValue(null);
   mockWrite.appListing.findFirst.mockResolvedValue(null);
   mockWrite.appListing.update.mockImplementation(async (args: { data: unknown }) => args.data);
   mockWrite.$transaction.mockImplementation(async (cb: (tx: unknown) => Promise<unknown>) => cb(mockWrite));
@@ -134,6 +138,33 @@ describe('getMyListingForEdit', () => {
     // A draft never touches the revision machinery.
     expect(mockRead.appListing.findFirst).not.toHaveBeenCalled();
     expect(mockWrite.appListing.create).not.toHaveBeenCalled();
+  });
+
+  it('returns the connect scope disclosure: CURRENT client allowedScopes (derived set) + STORED snapshot/justifications', async () => {
+    wireFindUnique(ownedRow({ status: 'draft', connectClientId: 'oauth-1' }), {
+      apl_parent: editViewRow('ss_parent', {
+        connectRequestedScopes: 4,
+        connectScopeJustifications: { ModelsRead: 'reason' },
+      }),
+    });
+    // The client's allowedScopes drifted to 13 since the stored snapshot (4).
+    mockRead.oauthClient.findUnique.mockResolvedValue({ allowedScopes: 13 });
+
+    const res = await getMyListingForEdit({ listingId: 'apl_parent', userId: 7 });
+    expect(res.connectClientId).toBe('oauth-1');
+    expect(res.connectAllowedScopes).toBe(13); // derived = client's CURRENT allowedScopes
+    expect(res.connectRequestedScopes).toBe(4); // stored snapshot (drift detectable)
+    expect(res.connectScopeJustifications).toEqual({ ModelsRead: 'reason' });
+  });
+
+  it('a listing with no connect client → null connect fields, no client lookup', async () => {
+    wireFindUnique(ownedRow({ status: 'draft', connectClientId: null }), {
+      apl_parent: editViewRow('ss_parent'),
+    });
+    const res = await getMyListingForEdit({ listingId: 'apl_parent', userId: 7 });
+    expect(res.connectClientId).toBeNull();
+    expect(res.connectAllowedScopes).toBeNull();
+    expect(mockRead.oauthClient.findUnique).not.toHaveBeenCalled();
   });
 
   it('APPROVED with an existing shadow → reuses it; prefill + row ids come from the SHADOW', async () => {
@@ -239,6 +270,28 @@ describe('updateRevisionDraft', () => {
         data: expect.objectContaining({ name: 'New name', tagline: 'New tagline' }),
       })
     );
+  });
+
+  it('SNAPSHOTS requestedScopes from the client when the shadow patch edits scopes (form value ignored)', async () => {
+    mockRead.appListing.findUnique.mockResolvedValue(
+      ownedRow({
+        id: 'apl_shadow',
+        status: 'draft',
+        revisionOfId: 'apl_parent',
+        connectClientId: 'oauth-1',
+      })
+    );
+    // Client allowedScopes = 13 (UserRead|ModelsRead|ModelsWrite); the form's bogus
+    // requestedScopes:4 must be ignored and the derived 13 snapshotted.
+    mockRead.oauthClient.findUnique.mockResolvedValue({ userId: 7, allowedScopes: 13 });
+    await updateRevisionDraft({
+      shadowId: 'apl_shadow',
+      userId: 7,
+      patch: { requestedScopes: 4, scopeJustifications: { ModelsRead: 'reason' } },
+    });
+    const data = mockWrite.appListing.update.mock.calls[0][0].data as Record<string, unknown>;
+    expect(data.connectRequestedScopes).toBe(13);
+    expect(data.connectScopeJustifications).toEqual({ ModelsRead: 'reason' });
   });
 
   it('refuses a NON-shadow (top-level listing) → INVALID_REVISION, no write', async () => {

--- a/src/server/services/blocks/__tests__/offsite-listing.oauth-fields.service.test.ts
+++ b/src/server/services/blocks/__tests__/offsite-listing.oauth-fields.service.test.ts
@@ -115,7 +115,9 @@ describe('submitExternalListing', () => {
       slug: 'connect-app',
       externalUrl: null,
       connectClientId: CLIENT_ID,
-      connectRequestedScopes: TokenScope.ModelsRead,
+      // SERVER-DERIVED from the client's allowedScopes (= CEILING), NOT the form's
+      // requestedScopes (ModelsRead in baseInput).
+      connectRequestedScopes: CEILING,
       connectScopeJustifications: { ModelsRead: 'We download models to run them.' },
       appBlockId: null,
       userId: CALLER,
@@ -171,18 +173,26 @@ describe('submitExternalListing', () => {
     expect(mockWrite.$transaction).not.toHaveBeenCalled();
   });
 
-  it('requestedScopes NOT ⊆ allowedScopes → BAD_REQUEST, no write', async () => {
+  it('IGNORES the form-supplied requestedScopes and snapshots the client allowedScopes', async () => {
+    // A bogus form mask (MediaWrite, outside the client ceiling) must NOT reach the
+    // stored row — the service derives the disclosed set from the client instead.
+    await submitExternalListing({
+      input: { ...baseInput, requestedScopes: TokenScope.MediaWrite, scopeJustifications: {} },
+      userId: CALLER,
+    });
+    const listingData = mockWrite.appListing.create.mock.calls[0][0].data as Record<string, unknown>;
+    expect(listingData.connectRequestedScopes).toBe(CEILING);
+  });
+
+  it('a justification for a scope OUTSIDE the client allowedScopes → BAD_REQUEST, no write', async () => {
+    // The derived set is CEILING (13); MediaWrite (64) is not in it, so its
+    // justification is rejected (keys must be ⊆ the derived/requested scopes).
     await expect(
       submitExternalListing({
-        input: {
-          ...baseInput,
-          // MediaWrite (64) is outside the ceiling (13).
-          requestedScopes: TokenScope.MediaWrite,
-          scopeJustifications: { MediaWrite: 'why' },
-        },
+        input: { ...baseInput, scopeJustifications: { MediaWrite: 'why' } },
         userId: CALLER,
       })
-    ).rejects.toMatchObject({ code: 'BAD_REQUEST', message: expect.stringContaining('exceed') });
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
     expect(mockWrite.$transaction).not.toHaveBeenCalled();
   });
 
@@ -200,10 +210,11 @@ describe('submitExternalListing', () => {
       { requestedScopes: TokenScope.ModelsRead, scopeJustifications: { ModelsRead: '' } },
     ],
     [
-      'key not among requested scopes',
+      'key not among the derived (client) scopes',
       {
-        requestedScopes: TokenScope.ModelsRead,
-        scopeJustifications: { ModelsWrite: 'not requested' },
+        // MediaWrite (64) is outside the client ceiling (CEILING=13), so it is not in
+        // the derived requested set → its justification is rejected.
+        scopeJustifications: { MediaWrite: 'not in the client scopes' },
       },
     ],
   ])('bad justification (%s) → BAD_REQUEST, no write', async (_label, patch) => {
@@ -302,16 +313,34 @@ describe('updateListing (connect scope edit re-validation)', () => {
     coverId: 2,
   };
 
-  it('re-validates the subset on edit: a scope change beyond the ceiling → error, no shadow write', async () => {
+  it('rejects a justification for a scope OUTSIDE the client ceiling on edit → BAD_REQUEST', async () => {
+    // The form can no longer request a scope beyond the ceiling (the mask is derived),
+    // but a justification for a scope the client doesn't allow is still rejected.
     mockRead.appListing.findUnique.mockResolvedValue(approvedConnectListing);
     mockRead.oauthClient.findUnique.mockResolvedValue(ownedClient());
     await expect(
       updateListing({
         listingId: 'apl_live',
         userId: CALLER,
-        patch: { requestedScopes: TokenScope.MediaWrite, scopeJustifications: {} },
+        patch: { scopeJustifications: { MediaWrite: 'why' } },
       })
     ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+  });
+
+  it('SNAPSHOTS requestedScopes from the client on a pending-listing scope edit (form value ignored)', async () => {
+    mockRead.appListing.findUnique.mockResolvedValue({
+      ...approvedConnectListing,
+      status: 'pending',
+    });
+    mockRead.oauthClient.findUnique.mockResolvedValue(ownedClient()); // allowedScopes = CEILING
+    await updateListing({
+      listingId: 'apl_live',
+      userId: CALLER,
+      // A bogus form mask is supplied; the service must ignore it and snapshot CEILING.
+      patch: { requestedScopes: TokenScope.ModelsRead, scopeJustifications: { ModelsRead: 'reason' } },
+    });
+    const data = mockWrite.appListing.update.mock.calls[0][0].data as Record<string, unknown>;
+    expect(data.connectRequestedScopes).toBe(CEILING);
   });
 
   it('re-asserts client OWNERSHIP on edit: a client transferred to another user → FORBIDDEN, no shadow write', async () => {

--- a/src/server/services/blocks/__tests__/offsite-listing.service.test.ts
+++ b/src/server/services/blocks/__tests__/offsite-listing.service.test.ts
@@ -207,7 +207,9 @@ describe('submitExternalListing', () => {
       externalUrl: 'https://cool.example.com/app',
       // Merged model: the linked OAuth client + the (empty) disclosed scope set.
       connectClientId: CLIENT_ID,
-      connectRequestedScopes: 0,
+      // SERVER-DERIVED from the client's allowedScopes (CEILING), not the input's
+      // requestedScopes:0. The disclosed set is always the client's allowed set.
+      connectRequestedScopes: CEILING,
       connectScopeJustifications: {},
       appBlockId: null,
       contentRating: 'g',

--- a/src/server/services/blocks/offsite-listing.service.ts
+++ b/src/server/services/blocks/offsite-listing.service.ts
@@ -179,12 +179,19 @@ export async function submitExternalListing(opts: {
     });
   }
 
-  // Load + gate the caller's OAuth client (exists / owned / not-app-block), then
-  // validate the requested-scope subset + per-scope justifications against the
-  // client's ceiling. REQUIRED for every external listing (the merged model).
+  // Load + gate the caller's OAuth client (exists / owned / not-app-block). The
+  // listing's requested scopes are AUTO-DERIVED from the client's CURRENT
+  // `allowedScopes` — the client already declares its scopes at creation, so a
+  // form-supplied `input.requestedScopes` mask is IGNORED (server-authoritative
+  // snapshot). This snapshots the reviewed set: a later widening of the client's
+  // allowedScopes does NOT silently expand a live/approved listing (a re-submit /
+  // edit re-enters review). The subset check is trivially satisfied now (the set
+  // equals its own ceiling) but kept as a defensive assertion; the per-scope
+  // justifications are validated against the derived set.
   const client = await loadConnectClientForListing(input.connectClientId, userId);
+  const requestedScopes = client.allowedScopes;
   assertConnectScopesValid({
-    requestedScopes: input.requestedScopes,
+    requestedScopes,
     scopeJustifications: input.scopeJustifications,
     allowedScopes: client.allowedScopes,
   });
@@ -247,10 +254,10 @@ export async function submitExternalListing(opts: {
           contentRating,
           // OPTIONAL homepage / Visit link — canonicalized when provided, else null.
           externalUrl: url && url.ok ? url.url : null,
-          // REQUIRED OAuth client link + the disclosed (review-only) scope subset +
-          // per-scope justifications.
+          // REQUIRED OAuth client link + the disclosed (review-only) scope set
+          // (SERVER-DERIVED from the client's allowedScopes) + per-scope justifications.
           connectClientId: input.connectClientId,
-          connectRequestedScopes: input.requestedScopes,
+          connectRequestedScopes: requestedScopes,
           connectScopeJustifications: input.scopeJustifications,
           // A natively-created off-site listing has no backing AppBlock.
           appBlockId: null,
@@ -345,6 +352,63 @@ function assertConnectScopesValid(opts: {
   if (errors.length > 0) {
     throw new TRPCError({ code: 'BAD_REQUEST', message: errors.join('; ') });
   }
+}
+
+/**
+ * For an EDIT patch that touches the OAuth-connect scope disclosure (carries
+ * `requestedScopes` and/or `scopeJustifications`), resolve the listing's connect
+ * client and return an `effectivePatch` whose `requestedScopes` is DERIVED from the
+ * client's CURRENT `allowedScopes` (server-authoritative — a form-supplied mask is
+ * ignored) plus that ceiling. A non-scope patch is passed through unchanged.
+ *
+ * Re-asserts the caller still OWNS the client (mirrors `loadConnectClientForListing`):
+ * `connectClientId` is immutable on edit, but if the client were transferred after
+ * submit, the original listing owner must NOT be able to re-snapshot scopes against
+ * the new owner's ceiling. Validates the justifications against the derived set.
+ * Shared by `updateListing` (in-place / material-shadow) and `updateRevisionDraft`
+ * (approved shadow scalar write) so both snapshot scopes identically.
+ */
+async function deriveScopePatch(opts: {
+  connectClientId: string | null;
+  patch: UpdateListingPatch;
+  userId: number;
+}): Promise<{ effectivePatch: UpdateListingPatch; connectAllowedScopes: number | null }> {
+  const { connectClientId, patch, userId } = opts;
+  const editsScopes =
+    patch.requestedScopes !== undefined || patch.scopeJustifications !== undefined;
+  if (!editsScopes) return { effectivePatch: patch, connectAllowedScopes: null };
+
+  if (connectClientId == null) {
+    throw new TRPCError({
+      code: 'BAD_REQUEST',
+      message: 'this listing has no OAuth client, so it cannot request scopes',
+    });
+  }
+  const client = await dbRead.oauthClient.findUnique({
+    where: { id: connectClientId },
+    select: { userId: true, allowedScopes: true },
+  });
+  if (!client) {
+    throw new TRPCError({ code: 'NOT_FOUND', message: 'OAuth client not found' });
+  }
+  if (client.userId !== userId) {
+    throw new TRPCError({
+      code: 'FORBIDDEN',
+      message: 'you can only list an OAuth client you own',
+    });
+  }
+  const connectAllowedScopes = client.allowedScopes;
+  // SERVER-AUTHORITATIVE snapshot: the disclosed set is ALWAYS the client's CURRENT
+  // allowedScopes; the form-supplied `patch.requestedScopes` is overwritten. A drift
+  // from the stored snapshot is then a MATERIAL change (patchHasMaterialChange) → the
+  // approved edit re-enters mod review via a shadow revision.
+  const effectivePatch: UpdateListingPatch = { ...patch, requestedScopes: connectAllowedScopes };
+  assertConnectScopesValid({
+    requestedScopes: connectAllowedScopes,
+    scopeJustifications: patch.scopeJustifications ?? {},
+    allowedScopes: connectAllowedScopes,
+  });
+  return { effectivePatch, connectAllowedScopes };
 }
 
 // ---------------------------------------------------------------------------
@@ -779,53 +843,15 @@ export async function updateListing(opts: {
   }
 
   // If the patch touches the disclosed OAuth scopes, resolve the client's ceiling
-  // once (needed by buildListingPatchData's subset re-validation). A scope edit on a
-  // listing with no connect client → BAD_REQUEST.
-  const editsScopes =
-    patch.requestedScopes !== undefined || patch.scopeJustifications !== undefined;
-  let connectAllowedScopes: number | null = null;
-  if (editsScopes) {
-    if (listing.connectClientId == null) {
-      throw new TRPCError({
-        code: 'BAD_REQUEST',
-        message: 'this listing has no OAuth client, so it cannot request scopes',
-      });
-    }
-    const client = await dbRead.oauthClient.findUnique({
-      where: { id: listing.connectClientId },
-      select: { userId: true, allowedScopes: true },
-    });
-    if (!client) {
-      throw new TRPCError({ code: 'NOT_FOUND', message: 'OAuth client not found' });
-    }
-    // Defense in depth: re-assert the caller still OWNS the client (mirrors
-    // `loadConnectClientForListing`'s submit-time check). `connectClientId` is
-    // immutable on edit, so this is safe today — but if the client were transferred
-    // to another user after submit, the original listing owner must NOT be able to
-    // edit disclosed scopes against the new owner's ceiling. `userId` here is the
-    // authenticated caller (the listing was already owner-bound above).
-    if (client.userId !== userId) {
-      throw new TRPCError({
-        code: 'FORBIDDEN',
-        message: 'you can only list an OAuth client you own',
-      });
-    }
-    connectAllowedScopes = client.allowedScopes;
-    // Validate the scope edit UP-FRONT (before any shadow is opened) so an invalid
-    // subset/justification rejects cleanly and never leaves an orphan shadow draft.
-    // `buildListingPatchData` re-validates as defense-in-depth for direct callers.
-    if (patch.requestedScopes === undefined) {
-      throw new TRPCError({
-        code: 'BAD_REQUEST',
-        message: 'requestedScopes is required when editing scope justifications',
-      });
-    }
-    assertConnectScopesValid({
-      requestedScopes: patch.requestedScopes,
-      scopeJustifications: patch.scopeJustifications ?? {},
-      allowedScopes: connectAllowedScopes,
-    });
-  }
+  // and DERIVE the requested-scope snapshot from it (server-authoritative — a
+  // form-supplied mask is ignored). Validates UP-FRONT (before any shadow is opened)
+  // so an invalid justification set never leaves an orphan shadow draft. A scope edit
+  // on a listing with no connect client → BAD_REQUEST.
+  const { effectivePatch, connectAllowedScopes } = await deriveScopePatch({
+    connectClientId: listing.connectClientId,
+    patch,
+    userId,
+  });
   const patchOpts = { connectAllowedScopes };
 
   switch (listing.status) {
@@ -845,12 +871,12 @@ export async function updateListing(opts: {
     case 'pending': {
       // Edit IN PLACE — no re-review. A pending listing's existing pending request
       // keeps reviewing the now-updated row (it references the row, not a snapshot).
-      const data = buildListingPatchData(patch, patchOpts);
+      const data = buildListingPatchData(effectivePatch, patchOpts);
       await dbWrite.appListing.update({ where: { id: listingId }, data });
       return { listingId, status: listing.status, requiresReview: false, shadowId: null };
     }
     case 'approved': {
-      const material = patchHasMaterialChange(patch, {
+      const material = patchHasMaterialChange(effectivePatch, {
         externalUrl: listing.externalUrl,
         name: listing.name,
         contentRating: listing.contentRating,
@@ -860,7 +886,7 @@ export async function updateListing(opts: {
         // TRIVIAL-only edit → apply to the LIVE row in place (no re-review). Any
         // material key present is byte-identical to the live value (material ===
         // false), so writing it is a harmless no-op.
-        const data = buildListingPatchData(patch, patchOpts);
+        const data = buildListingPatchData(effectivePatch, patchOpts);
         await dbWrite.appListing.update({ where: { id: listingId }, data });
         return { listingId, status: listing.status, requiresReview: false, shadowId: null };
       }
@@ -868,7 +894,7 @@ export async function updateListing(opts: {
       // FULL patch (material + trivial) is written to the shadow. Assets are edited
       // separately against the shadow id, then submitListingRevision re-reviews it.
       const { shadowId } = await beginListingRevision({ listingId, userId });
-      const data = buildListingPatchData(patch, patchOpts);
+      const data = buildListingPatchData(effectivePatch, patchOpts);
       await dbWrite.appListing.update({ where: { id: shadowId }, data });
       return { listingId, status: listing.status, requiresReview: true, shadowId };
     }
@@ -1189,12 +1215,27 @@ export type GetMyListingForEditResult = {
     cover: ListingEditAsset;
     screenshots: ListingEditScreenshot[];
   };
+  /** The linked OAuth client id (null for a non-connect listing — none in the merged model). */
+  connectClientId: string | null;
+  /**
+   * The client's CURRENT `allowedScopes` (null when no client / not found). This IS
+   * the derived requested-scope set the edit form displays read-only + submits — the
+   * server re-snapshots `requestedScopes` from it on save.
+   */
+  connectAllowedScopes: number | null;
+  /** The STORED requested-scope snapshot on the effective row (for drift detection). */
+  connectRequestedScopes: number | null;
+  /** The STORED per-scope justifications (enum-key → rationale) on the effective row. */
+  connectScopeJustifications: Record<string, string> | null;
 };
 
-/** Load a listing's scalars + current assets (edge-resolved URLs) for edit prefill. */
+/** Load a listing's scalars + current assets (edge-resolved URLs) + connect scope
+ *  snapshot for edit prefill. */
 async function loadListingEditView(listingId: string): Promise<{
   scalars: ListingEditScalars;
   assets: GetMyListingForEditResult['assets'];
+  connectRequestedScopes: number | null;
+  connectScopeJustifications: Record<string, string> | null;
 }> {
   const { getEdgeUrl } = await import('~/client-utils/cf-images-utils');
   const row = (await dbRead.appListing.findUnique({
@@ -1206,6 +1247,8 @@ async function loadListingEditView(listingId: string): Promise<{
       category: true,
       contentRating: true,
       externalUrl: true,
+      connectRequestedScopes: true,
+      connectScopeJustifications: true,
       iconId: true,
       coverId: true,
       icon: { select: { url: true } },
@@ -1228,6 +1271,8 @@ async function loadListingEditView(listingId: string): Promise<{
     category: string | null;
     contentRating: string | null;
     externalUrl: string | null;
+    connectRequestedScopes: number | null;
+    connectScopeJustifications: Prisma.JsonValue | null;
     iconId: number | null;
     coverId: number | null;
     icon: { url: string | null } | null;
@@ -1252,6 +1297,9 @@ async function loadListingEditView(listingId: string): Promise<{
       contentRating: row.contentRating,
       externalUrl: row.externalUrl,
     },
+    connectRequestedScopes: row.connectRequestedScopes ?? null,
+    connectScopeJustifications:
+      (row.connectScopeJustifications as Record<string, string> | null) ?? null,
     assets: {
       icon: {
         imageId: row.iconId,
@@ -1349,6 +1397,20 @@ export async function getMyListingForEdit(opts: {
   }
 
   const view = await loadListingEditView(effectiveId);
+
+  // Resolve the connect client's CURRENT allowedScopes — this is the derived
+  // requested-scope set the edit form displays read-only + re-submits (the server
+  // re-snapshots `requestedScopes` from it on save). null when the listing has no
+  // client or the client no longer exists.
+  let connectAllowedScopes: number | null = null;
+  if (listing.connectClientId != null) {
+    const client = await dbRead.oauthClient.findUnique({
+      where: { id: listing.connectClientId },
+      select: { allowedScopes: true },
+    });
+    connectAllowedScopes = client?.allowedScopes ?? null;
+  }
+
   return {
     parentId: listingId,
     slug: listing.slug,
@@ -1357,6 +1419,10 @@ export async function getMyListingForEdit(opts: {
     shadowId,
     scalars: view.scalars,
     assets: view.assets,
+    connectClientId: listing.connectClientId,
+    connectAllowedScopes,
+    connectRequestedScopes: view.connectRequestedScopes,
+    connectScopeJustifications: view.connectScopeJustifications,
   };
 }
 
@@ -1387,7 +1453,16 @@ export async function updateRevisionDraft(opts: {
       `a revision draft can only be edited while draft (status is ${shadow.status})`
     );
   }
-  const data = buildListingPatchData(patch);
+  // Derive the requested-scope snapshot from the shadow's connect client (the shadow
+  // carries the parent's connectClientId) when the patch touches scopes — same
+  // server-authoritative rule as updateListing, so a scope justification staged on a
+  // shadow re-snapshots against the client's CURRENT allowedScopes.
+  const { effectivePatch, connectAllowedScopes } = await deriveScopePatch({
+    connectClientId: shadow.connectClientId,
+    patch,
+    userId,
+  });
+  const data = buildListingPatchData(effectivePatch, { connectAllowedScopes });
   await dbWrite.appListing.update({ where: { id: shadowId }, data });
   return { shadowId };
 }


### PR DESCRIPTION
## What & why

The external app-listing submit/edit flow made the submitter **re-pick** scopes (checkboxes) from their OAuth client's `allowedScopes` and justify each. The client already declares its scopes at creation, so the re-pick was duplicative. This change:

1. **Auto-derive, drop the picker.** A listing's `requestedScopes` is now exactly the selected OAuth client's `allowedScopes` — no checkbox selection. The scopes render **read-only** (the submitter still sees what they're requesting).
2. **Keep per-scope justifications.** Justifications stay — they're the moderator-review + scope-trace-verify signal, and client creation doesn't capture "why." Same required/optional + max-length rules.
3. **Server-authoritative snapshot.** On **create AND edit**, the service sets `requestedScopes` from the client's **current** `allowedScopes` at submit time — a form-supplied mask is ignored. This snapshots the reviewed set: a later widening of the client's `allowedScopes` does **not** silently expand a live/approved listing; the next edit re-snapshots and (being a scope change) re-enters mod review via the existing shadow-revision path.
4. **Both flows:** `ExternalSubmitForm` (create) and `ExternalListingEditForm` (edit), plus the shared `offsiteSubmitFormConfig` / `offsiteEditConfig`.

## How it works

**Client (`src/components/Apps/`)**
- New shared `DerivedScopesDisclosure` renders the derived scopes read-only (with `SensitiveScopeBadge` for sensitive scopes) + the per-scope justification inputs. An empty-scopes client (`allowedScopes === 0`) shows a clear "no scopes" state with no justification inputs — a valid submission.
- `offsiteSubmitFormConfig`: removed the `toggleScopeBit` picker helper; added `deriveScopesFromClient` (sets `requestedScopes = allowedScopes`, prunes justifications to the derived set) and shared `pruneJustificationsToMask` / `shapeScopeJustifications` helpers. Selecting/**changing the client** re-derives the mask and re-keys/prunes justifications.
- `ExternalSubmitForm`: `handleSelectClient` derives instead of resetting to 0; the checkbox grid is replaced by `DerivedScopesDisclosure`.
- `ExternalListingEditForm`: shows the derived scopes read-only + editable justifications on the Details step; on save the scalar patch carries the (derived) mask + shaped justifications when a justification changed **or** the client's scopes drifted from the stored snapshot.
- `offsiteEditConfig`: the edit context carries the connect fields; `editContextToForm` derives `requestedScopes` from the client's current `allowedScopes` (prefill justifications pruned to it); `buildScalarPatch` diffs justifications + drift.

**Server (`src/server/`)**
- `submitExternalListing` sets `connectRequestedScopes = client.allowedScopes` (ignores `input.requestedScopes`); keeps the subset-of-ceiling assertion (trivially true now) and validates justifications against the derived set.
- Both edit paths (`updateListing` in-place/material-shadow, `updateRevisionDraft`) derive `requestedScopes` from the client's current `allowedScopes` via a shared `deriveScopePatch` helper (also re-asserts client ownership) and feed it to material-change detection + `buildListingPatchData` — so a scope change/drift re-enters review.
- `getMyListingForEdit` now returns `connectClientId`, the client's current `allowedScopes` (the derived set), and the stored `connectRequestedScopes` / `connectScopeJustifications`.
- Schema: `requestedScopes` is now **optional/ignored** in `submitExternalListingSchema` (still int4-bounded when present); justification checks unchanged.
- Mod review + scope-trace-verify are **unchanged** — they read the stored `requestedScopes` + `scopeJustifications` snapshot (now always equal to the client's scopes at submit time).

## Tests

- **Unit** (config derive/prune/shape, schema `requestedScopes` optional, service snapshots from client + ignores the form value on create and both edit paths, edit-config mapping/diff): all green.
- **Browser** (create: read-only scopes, **no checkbox picker**, sensitive badge, empty-scopes submit; edit: read-only scopes + justification edit → patch): all green (7 + 8).
- `tsc --noEmit`: **zero errors in changed files**; the pre-existing repo/env errors are unchanged and untouched by this PR.

DARK behind `app-blocks-author`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
