### PR TITLE
refactor(challenges): separate challenge creator from judge in the API

### DIFF
--- a/src/components/Cards/ChallengeCard.tsx
+++ b/src/components/Cards/ChallengeCard.tsx
@@ -10,6 +10,7 @@ import {
 } from '@tabler/icons-react';
 import cardClasses from '~/components/Cards/Cards.module.css';
 import { ChallengeContextMenu } from '~/components/Challenge/ChallengeContextMenu';
+import { getChallengeDisplayUser } from '~/components/Challenge/challenge.utils';
 import { CurrencyBadge } from '~/components/Currency/CurrencyBadge';
 import { IconBadge } from '~/components/IconBadge/IconBadge';
 import { abbreviateNumber } from '~/utils/number-helpers';
@@ -94,9 +95,9 @@ export const ChallengeCard = memo(function ChallengeCard({ data }: Props) {
     buzzType,
     entryCount,
     commentCount,
-    createdBy,
   } = data;
 
+  const author = getChallengeDisplayUser(data);
   const isActive = status === ChallengeStatus.Active;
 
   const image = coverImage
@@ -158,11 +159,11 @@ export const ChallengeCard = memo(function ChallengeCard({ data }: Props) {
       footer={
         <div className="flex w-full flex-col gap-2">
           <UserAvatarSimple
-            id={createdBy.id}
-            username={createdBy.username}
-            profilePicture={createdBy.profilePicture}
-            cosmetics={createdBy.cosmetics}
-            deletedAt={createdBy.deletedAt}
+            id={author.id}
+            username={author.username}
+            profilePicture={author.profilePicture}
+            cosmetics={author.cosmetics}
+            deletedAt={author.deletedAt}
           />
           <div className="flex flex-col gap-1">
             {theme && (

--- a/src/components/Cards/MyChallengeCard.stories.tsx
+++ b/src/components/Cards/MyChallengeCard.stories.tsx
@@ -42,6 +42,7 @@ const baseChallenge: MyParticipatedChallengeItem = {
     cosmetics: null,
     deletedAt: null,
   },
+  judge: null,
   myEntryImage: baseImage,
   myPlace: null,
   myResult: 'entered',

--- a/src/components/Challenge/challenge.utils.test.ts
+++ b/src/components/Challenge/challenge.utils.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import { getChallengeDisplayUser } from './challenge.utils';
+import { ChallengeSource } from '~/shared/utils/prisma/enums';
+import type { ChallengeDisplayUser, ChallengeJudgeInfo } from '~/server/schema/challenge.schema';
+
+const creator: ChallengeDisplayUser = {
+  id: 10,
+  username: 'realCreator',
+  image: 'creator.png',
+  profilePicture: null,
+  cosmetics: null,
+  deletedAt: null,
+};
+
+const judge: ChallengeJudgeInfo = {
+  id: 1, // ChallengeJudge row id — must NOT leak into the author id
+  userId: 99,
+  name: 'CivBot the Judge',
+  bio: null,
+  username: 'CivBot',
+  image: 'civbot.png',
+  deletedAt: null,
+  profilePicture: null,
+  cosmetics: null,
+};
+
+describe('getChallengeDisplayUser', () => {
+  it('User challenge shows the real creator', () => {
+    expect(getChallengeDisplayUser({ source: ChallengeSource.User, createdBy: creator, judge })).toBe(
+      creator
+    );
+  });
+
+  it('Mod challenge shows the judge, keyed on the judge userId (not the ChallengeJudge id)', () => {
+    const author = getChallengeDisplayUser({ source: ChallengeSource.Mod, createdBy: creator, judge });
+    expect(author).toEqual({
+      id: 99,
+      username: 'CivBot',
+      image: 'civbot.png',
+      profilePicture: null,
+      cosmetics: null,
+      deletedAt: null,
+    });
+  });
+
+  it('System challenge shows the judge (its createdBy already is the judge account)', () => {
+    const systemCreator: ChallengeDisplayUser = { ...creator, id: 99, username: 'CivBot' };
+    const author = getChallengeDisplayUser({
+      source: ChallengeSource.System,
+      createdBy: systemCreator,
+      judge,
+    });
+    expect(author.id).toBe(99);
+    expect(author.username).toBe('CivBot');
+  });
+
+  it('non-User with no judge falls back to the creator', () => {
+    expect(
+      getChallengeDisplayUser({ source: ChallengeSource.Mod, createdBy: creator, judge: null })
+    ).toBe(creator);
+  });
+});

--- a/src/components/Challenge/challenge.utils.ts
+++ b/src/components/Challenge/challenge.utils.ts
@@ -6,11 +6,34 @@ import { trpc } from '~/utils/trpc';
 import { showErrorNotification, showSuccessNotification } from '~/utils/notifications';
 import type {
   ChallengeDetail,
+  ChallengeDisplayUser,
+  ChallengeJudgeInfo,
   GetInfiniteChallengesInput,
   GetCompletedChallengesWithWinnersInput,
 } from '~/server/schema/challenge.schema';
 import { ChallengeSort } from '~/server/schema/challenge.schema';
 import { ChallengeSource } from '~/shared/utils/prisma/enums';
+
+// The author to show on a card/detail. User challenges credit the real creator; System/Mod
+// challenges present the judge persona (e.g. CivBot) — System already stores the judge as its
+// creator, so this only diverges for Mod challenges, keeping the individual moderator unexposed.
+// Falls back to the creator when no judge is assigned.
+export function getChallengeDisplayUser(challenge: {
+  source: ChallengeSource;
+  createdBy: ChallengeDisplayUser;
+  judge?: ChallengeJudgeInfo | null;
+}): ChallengeDisplayUser {
+  const { source, createdBy, judge } = challenge;
+  if (source === ChallengeSource.User || !judge) return createdBy;
+  return {
+    id: judge.userId,
+    username: judge.username,
+    image: judge.image,
+    profilePicture: judge.profilePicture,
+    cosmetics: judge.cosmetics,
+    deletedAt: judge.deletedAt,
+  };
+}
 
 // Default filter values
 const defaultFilters: Partial<GetInfiniteChallengesInput> = {

--- a/src/components/HiddenPreferences/useApplyHiddenPreferences.ts
+++ b/src/components/HiddenPreferences/useApplyHiddenPreferences.ts
@@ -711,6 +711,8 @@ export function filterPreferences<
       return { items: comics, hidden };
     case 'challenges':
       const challenges = value.filter((challenge) => {
+        // createdBy is the real creator now (the judge is a separate field), so this correctly
+        // exempts the owner from their own challenge's browsing-level hide.
         const isOwner = challenge.createdBy.id === currentUser?.id;
         if (isOwner || isModerator) return true;
 

--- a/src/pages/challenges/[id]/[[...slug]].tsx
+++ b/src/pages/challenges/[id]/[[...slug]].tsx
@@ -82,6 +82,7 @@ import {
 import { useRouter } from 'next/router';
 import { abbreviateNumber } from '~/utils/number-helpers';
 import {
+  getChallengeDisplayUser,
   useDeleteUserChallenge,
   useIsChallengeOwner,
   useQueryChallenge,
@@ -694,7 +695,10 @@ function ChallengeDetailsPage({ id }: InferGetServerSidePropsType<typeof getServ
 
       {/* Discussion Section */}
       <Container size="xl" id="comments" py={32}>
-        <ChallengeDiscussion challengeId={challenge.id} userId={challenge.createdBy?.id} />
+        <ChallengeDiscussion
+          challengeId={challenge.id}
+          userId={getChallengeDisplayUser(challenge).id}
+        />
       </Container>
 
       {/* Entries Section */}
@@ -1458,12 +1462,15 @@ function ChallengeSidebar({ challenge }: { challenge: ChallengeDetail }) {
       </Accordion>
 
       <CreatorCardSimple
-        user={{
-          ...challenge.createdBy,
-          // Convert null to undefined for CreatorCardSimple compatibility
-          cosmetics: challenge.createdBy.cosmetics ?? undefined,
-          profilePicture: challenge.createdBy.profilePicture ?? undefined,
-        }}
+        user={(() => {
+          const author = getChallengeDisplayUser(challenge);
+          return {
+            ...author,
+            // Convert null to undefined for CreatorCardSimple compatibility
+            cosmetics: author.cosmetics ?? undefined,
+            profilePicture: author.profilePicture ?? undefined,
+          };
+        })()}
         statDisplayOverwrite={[]}
       />
     </Stack>

--- a/src/server/schema/challenge.schema.ts
+++ b/src/server/schema/challenge.schema.ts
@@ -87,16 +87,9 @@ export type ChallengeListItem = {
   commentCount: number;
   modelVersionIds: number[];
   collectionId: number | null;
-  // Real creator id, distinct from createdBy.id which displays the judge when one is assigned.
   createdById: number;
-  createdBy: {
-    id: number;
-    username: string | null;
-    image: string | null;
-    profilePicture?: ProfileImage | null;
-    cosmetics?: UserWithCosmetics['cosmetics'] | null;
-    deletedAt: Date | null;
-  };
+  createdBy: ChallengeDisplayUser;
+  judge: ChallengeJudgeInfo | null;
 };
 
 // Recently participated-in challenges for the current user (Challenges Center "My Participated" row)
@@ -146,11 +139,28 @@ export function parseChallengeMetadata(raw: unknown): ChallengeMetadata {
   return result.success ? result.data : {};
 }
 
+// The author shown on a challenge card/detail. For User challenges this is the real creator; for
+// System/Mod challenges the client swaps in the judge (see getChallengeDisplayUser). `createdBy`
+// always carries the real creator regardless — the swap is display-only.
+export type ChallengeDisplayUser = {
+  id: number;
+  username: string | null;
+  image: string | null;
+  profilePicture?: ProfileImage | null;
+  cosmetics?: UserWithCosmetics['cosmetics'] | null;
+  deletedAt?: Date | null;
+};
+
+// `id` is the ChallengeJudge row id; `userId` + the User fields identify the account the judge posts
+// as, so the judge can render as an author avatar.
 export type ChallengeJudgeInfo = {
   id: number;
   userId: number;
   name: string;
   bio: string | null;
+  username: string | null;
+  image: string | null;
+  deletedAt: Date | null;
   profilePicture?: ProfileImage | null;
   cosmetics?: UserWithCosmetics['cosmetics'] | null;
 };
@@ -204,16 +214,8 @@ export type ChallengeDetail = {
   reviewCostType: ChallengeReviewCostType;
   reviewCost: number;
   entryCount: number;
-  // Real creator id, distinct from createdBy.id which displays the judge when one is assigned.
   createdById: number;
-  createdBy: {
-    id: number;
-    username: string | null;
-    image: string | null;
-    profilePicture?: ProfileImage | null;
-    cosmetics?: UserWithCosmetics['cosmetics'] | null;
-    deletedAt?: Date | null;
-  };
+  createdBy: ChallengeDisplayUser;
   judge: ChallengeJudgeInfo | null;
   winners: Array<{
     place: number;

--- a/src/server/services/challenge.service.ts
+++ b/src/server/services/challenge.service.ts
@@ -255,6 +255,9 @@ type ChallengeCardRow = {
   creatorUsername: string | null;
   creatorImage: string | null;
   creatorDeletedAt: Date | null;
+  judgeId: number | null;
+  judgeName: string | null;
+  judgeBio: string | null;
   judgeUserId: number | null;
   judgeUsername: string | null;
   judgeImage: string | null;
@@ -288,6 +291,9 @@ const challengeCardQuery = Prisma.sql`
       u.username as "creatorUsername",
       u.image as "creatorImage",
       u."deletedAt" as "creatorDeletedAt",
+      cj.id as "judgeId",
+      cj.name as "judgeName",
+      cj.bio as "judgeBio",
       cj."userId" as "judgeUserId",
       ju.username as "judgeUsername",
       ju.image as "judgeImage",
@@ -297,24 +303,16 @@ const challengeCardQuery = Prisma.sql`
     LEFT JOIN "ChallengeJudge" cj ON cj.id = c."judgeId"
     LEFT JOIN "User" ju ON ju.id = cj."userId"`;
 
-// User challenges show the real creator; system/mod challenges keep the judge (e.g. CivBot persona)
-// as the shown author.
-const displayUidFor = (item: {
-  source: ChallengeSource;
-  judgeUserId: number | null;
-  createdById: number;
-}) =>
-  item.source !== ChallengeSource.User && item.judgeUserId != null
-    ? item.judgeUserId
-    : item.createdById;
-
-// Hydrate card rows with display user profile pictures/cosmetics and cover images, then shape into
-// ChallengeListItem.
+// Hydrate card rows with profile pictures/cosmetics and cover images, then shape into
+// ChallengeListItem. `createdBy` is always the real creator; the judge is a separate field. Which
+// of the two is shown as the author is a client concern (see getChallengeDisplayUser).
 async function mapChallengeRowsToCards(items: ChallengeCardRow[]): Promise<ChallengeListItem[]> {
-  const displayUserIds = [...new Set(items.map(displayUidFor))];
+  const userIds = [
+    ...new Set(items.flatMap((item) => [item.createdById, item.judgeUserId]).filter((id): id is number => id != null)),
+  ];
   const [profilePictures, cosmetics] = await Promise.all([
-    getProfilePicturesForUsers(displayUserIds),
-    getCosmeticsForUsers(displayUserIds),
+    getProfilePicturesForUsers(userIds),
+    getCosmeticsForUsers(userIds),
   ]);
 
   const coverImageIds = items.map((item) => item.coverImageId).filter((id): id is number => !!id);
@@ -327,9 +325,6 @@ async function mapChallengeRowsToCards(items: ChallengeCardRow[]): Promise<Chall
     const coverImage = item.coverImageId
       ? coverImages.find((img) => img.id === item.coverImageId)
       : null;
-
-    const displayUid = displayUidFor(item);
-    const showJudge = displayUid !== item.createdById;
 
     return {
       id: item.id,
@@ -361,13 +356,27 @@ async function mapChallengeRowsToCards(items: ChallengeCardRow[]): Promise<Chall
         : null,
       modelVersionIds: item.modelVersionIds ?? [],
       createdBy: {
-        id: displayUid,
-        username: showJudge ? item.judgeUsername : item.creatorUsername,
-        image: showJudge ? item.judgeImage : item.creatorImage,
-        profilePicture: profilePictures[displayUid] ?? null,
-        cosmetics: cosmetics[displayUid] ?? null,
-        deletedAt: showJudge ? item.judgeDeletedAt : item.creatorDeletedAt,
+        id: item.createdById,
+        username: item.creatorUsername,
+        image: item.creatorImage,
+        profilePicture: profilePictures[item.createdById] ?? null,
+        cosmetics: cosmetics[item.createdById] ?? null,
+        deletedAt: item.creatorDeletedAt,
       },
+      judge:
+        item.judgeId != null && item.judgeUserId != null
+          ? {
+              id: item.judgeId,
+              userId: item.judgeUserId,
+              name: item.judgeName ?? '',
+              bio: item.judgeBio,
+              username: item.judgeUsername,
+              image: item.judgeImage,
+              deletedAt: item.judgeDeletedAt,
+              profilePicture: profilePictures[item.judgeUserId] ?? null,
+              cosmetics: cosmetics[item.judgeUserId] ?? null,
+            }
+          : null,
     };
   });
 }
@@ -919,14 +928,28 @@ async function buildChallengeDetail(
     }));
   }
 
-  // Get judge info if challenge has a judge assigned
+  // Get judge info if challenge has a judge assigned. The judge carries the User fields so it can
+  // render as an author avatar; which of createdBy/judge is shown is a client concern
+  // (getChallengeDisplayUser).
   let judge: ChallengeDetail['judge'] = null;
   if (challenge.judgeId) {
     const [judgeRow] = await dbRead.$queryRaw<
-      [{ id: number; userId: number; name: string; bio: string | null } | undefined]
+      [
+        | {
+            id: number;
+            userId: number;
+            name: string;
+            bio: string | null;
+            username: string | null;
+            image: string | null;
+            deletedAt: Date | null;
+          }
+        | undefined
+      ]
     >`
-      SELECT cj.id, cj."userId", cj.name, cj.bio
+      SELECT cj.id, cj."userId", cj.name, cj.bio, u.username, u.image, u."deletedAt"
       FROM "ChallengeJudge" cj
+      JOIN "User" u ON u.id = cj."userId"
       WHERE cj.id = ${challenge.judgeId}
     `;
     if (judgeRow) {
@@ -940,36 +963,6 @@ async function buildChallengeDetail(
         cosmetics: judgeCosmetics[judgeRow.userId] ?? null,
       };
     }
-  }
-
-  // Display user: user challenges show the real creator; system/mod challenges keep the judge
-  // (e.g. CivBot persona) as the shown author.
-  const displayUserId =
-    challenge.source === ChallengeSource.User ? createdById : judge?.userId ?? createdById;
-  let displayUser: {
-    id: number;
-    username: string | null;
-    image: string | null;
-    deletedAt: Date | null;
-  };
-  let displayProfilePics: Awaited<ReturnType<typeof getProfilePicturesForUsers>>;
-  let displayCosmetics: Awaited<ReturnType<typeof getCosmeticsForUsers>>;
-
-  if (displayUserId !== createdById) {
-    const [judgeUser] = await dbRead.$queryRaw<
-      [{ id: number; username: string | null; image: string | null; deletedAt: Date | null }]
-    >`
-      SELECT id, username, image, "deletedAt" FROM "User" WHERE id = ${displayUserId}
-    `;
-    displayUser = judgeUser;
-    [displayProfilePics, displayCosmetics] = await Promise.all([
-      getProfilePicturesForUsers([displayUserId]),
-      getCosmeticsForUsers([displayUserId]),
-    ]);
-  } else {
-    displayUser = creator;
-    displayProfilePics = profilePictures;
-    displayCosmetics = cosmetics;
   }
 
   // Extract structured fields from metadata
@@ -1028,9 +1021,9 @@ async function buildChallengeDetail(
     entryCount,
     createdById,
     createdBy: {
-      ...displayUser,
-      profilePicture: displayProfilePics[displayUserId] ?? null,
-      cosmetics: displayCosmetics[displayUserId] ?? null,
+      ...creator,
+      profilePicture: profilePictures[createdById] ?? null,
+      cosmetics: cosmetics[createdById] ?? null,
     },
     judge,
     winners,
@@ -3088,29 +3081,25 @@ export async function getActiveEvents(viewerId?: number): Promise<ChallengeEvent
 
   // Get judge user IDs for challenges that have judges
   const judgeIds = [...new Set(allChallenges.map((c) => c.judgeId).filter(isDefined))];
-  const judgeUserMap = new Map<number, number>();
+  const judgeMap = new Map<number, { userId: number; name: string; bio: string | null }>();
   if (judgeIds.length > 0) {
     const judges = await dbRead.challengeJudge.findMany({
       where: { id: { in: judgeIds } },
-      select: { id: true, userId: true },
+      select: { id: true, userId: true, name: true, bio: true },
     });
-    for (const j of judges) judgeUserMap.set(j.id, j.userId);
+    for (const j of judges) judgeMap.set(j.id, { userId: j.userId, name: j.name, bio: j.bio });
   }
 
-  // Collect all display user IDs (creator for user challenges, else judge user)
+  // Hydrate both the real creator and the judge for every challenge; the client decides which to
+  // show as the author (getChallengeDisplayUser).
   const displayUserIds = [
     ...new Set(
-      allChallenges
-        .map((c) =>
-          displayUidFor({
-            source: c.source,
-            judgeUserId: c.judgeId ? judgeUserMap.get(c.judgeId) ?? null : null,
-            createdById: c.createdById ?? -1,
-          })
-        )
-        .filter(isDefined)
+      allChallenges.flatMap((c) => {
+        const judgeUserId = c.judgeId ? judgeMap.get(c.judgeId)?.userId : null;
+        return [c.createdById ?? -1, judgeUserId];
+      })
     ),
-  ];
+  ].filter(isDefined);
 
   // Batch-fetch users, profile pictures, cosmetics, cover images, entry counts
   const [users, profilePictures, cosmetics] = await Promise.all([
@@ -3166,12 +3155,10 @@ export async function getActiveEvents(viewerId?: number): Promise<ChallengeEvent
     coverImage: event.coverImageId ? eventCoverMap.get(event.coverImageId) ?? null : null,
     challenges: event.challenges.map((c) => {
       // createdById can be null (creator account deleted); fall back to the system user (-1).
-      const displayUserId = displayUidFor({
-        source: c.source,
-        judgeUserId: c.judgeId ? judgeUserMap.get(c.judgeId) ?? null : null,
-        createdById: c.createdById ?? -1,
-      });
-      const user = users.get(displayUserId);
+      const creatorId = c.createdById ?? -1;
+      const creator = users.get(creatorId);
+      const judgeInfo = c.judgeId ? judgeMap.get(c.judgeId) : null;
+      const judgeUser = judgeInfo ? users.get(judgeInfo.userId) : null;
       const coverImage = c.coverImageId ? coverImages.get(c.coverImageId) : null;
 
       return {
@@ -3184,9 +3171,7 @@ export async function getActiveEvents(viewerId?: number): Promise<ChallengeEvent
         status: c.status,
         source: c.source,
         buzzType: c.buzzType === 'green' ? ('green' as const) : ('yellow' as const),
-        // createdById can be null (creator account deleted); fall back to the system user (-1),
-        // matching the displayUserId fallback above.
-        createdById: c.createdById ?? -1,
+        createdById: creatorId,
         nsfwLevel: c.nsfwLevel,
         allowedNsfwLevel: c.allowedNsfwLevel,
         prizePool: c.prizePool,
@@ -3206,13 +3191,27 @@ export async function getActiveEvents(viewerId?: number): Promise<ChallengeEvent
           : null,
         modelVersionIds: c.modelVersionIds ?? [],
         createdBy: {
-          id: displayUserId,
-          username: user?.username ?? null,
-          image: user?.image ?? null,
-          profilePicture: profilePictures[displayUserId] ?? null,
-          cosmetics: cosmetics[displayUserId] ?? null,
-          deletedAt: user?.deletedAt ?? null,
+          id: creatorId,
+          username: creator?.username ?? null,
+          image: creator?.image ?? null,
+          profilePicture: profilePictures[creatorId] ?? null,
+          cosmetics: cosmetics[creatorId] ?? null,
+          deletedAt: creator?.deletedAt ?? null,
         },
+        judge:
+          judgeInfo && judgeUser
+            ? {
+                id: c.judgeId as number,
+                userId: judgeInfo.userId,
+                name: judgeInfo.name,
+                bio: judgeInfo.bio,
+                username: judgeUser.username,
+                image: judgeUser.image,
+                deletedAt: judgeUser.deletedAt,
+                profilePicture: profilePictures[judgeInfo.userId] ?? null,
+                cosmetics: cosmetics[judgeInfo.userId] ?? null,
+              }
+            : null,
       };
     }),
   }));
@@ -3690,6 +3689,9 @@ export async function getCompletedChallengesWithWinners(
       creatorUsername: string | null;
       creatorImage: string | null;
       creatorDeletedAt: Date | null;
+      judgeId: number | null;
+      judgeName: string | null;
+      judgeBio: string | null;
       judgeUserId: number | null;
       judgeUsername: string | null;
       judgeImage: string | null;
@@ -3719,6 +3721,9 @@ export async function getCompletedChallengesWithWinners(
       u.username as "creatorUsername",
       u.image as "creatorImage",
       u."deletedAt" as "creatorDeletedAt",
+      cj.id as "judgeId",
+      cj.name as "judgeName",
+      cj.bio as "judgeBio",
       cj."userId" as "judgeUserId",
       ju.username as "judgeUsername",
       ju.image as "judgeImage",
@@ -3785,10 +3790,12 @@ export async function getCompletedChallengesWithWinners(
     ORDER BY cw.place ASC
   `;
 
-  // Batch enrich: profile pictures + cosmetics for both display users (creators/judges) and winners
+  // Batch enrich: profile pictures + cosmetics for creators, judges, and winners
   const winnerUserIds = [...new Set(winnerRows.map((w) => w.userId))];
-  const displayUserIds = [...new Set(items.map(displayUidFor))];
-  const allUserIds = [...new Set([...displayUserIds, ...winnerUserIds])];
+  const authorUserIds = items.flatMap((i) => [i.createdById, i.judgeUserId]);
+  const allUserIds = [
+    ...new Set([...authorUserIds, ...winnerUserIds].filter((id): id is number => id != null)),
+  ];
   const [profilePictures, cosmetics] = await Promise.all([
     getProfilePicturesForUsers(allUserIds),
     getCosmeticsForUsers(allUserIds),
@@ -3835,9 +3842,6 @@ export async function getCompletedChallengesWithWinners(
     const coverImage = item.coverImageId ? coverImageMap.get(item.coverImageId) ?? null : null;
     const metadata = parseChallengeMetadata(item.metadata);
 
-    const displayUid = displayUidFor(item);
-    const showJudge = displayUid !== item.createdById;
-
     return {
       id: item.id,
       title: item.title,
@@ -3868,13 +3872,27 @@ export async function getCompletedChallengesWithWinners(
         : null,
       modelVersionIds: item.modelVersionIds ?? [],
       createdBy: {
-        id: displayUid,
-        username: showJudge ? item.judgeUsername : item.creatorUsername,
-        image: showJudge ? item.judgeImage : item.creatorImage,
-        profilePicture: profilePictures[displayUid] ?? null,
-        cosmetics: cosmetics[displayUid] ?? null,
-        deletedAt: showJudge ? item.judgeDeletedAt : item.creatorDeletedAt,
+        id: item.createdById,
+        username: item.creatorUsername,
+        image: item.creatorImage,
+        profilePicture: profilePictures[item.createdById] ?? null,
+        cosmetics: cosmetics[item.createdById] ?? null,
+        deletedAt: item.creatorDeletedAt,
       },
+      judge:
+        item.judgeId != null && item.judgeUserId != null
+          ? {
+              id: item.judgeId,
+              userId: item.judgeUserId,
+              name: item.judgeName ?? '',
+              bio: item.judgeBio,
+              username: item.judgeUsername,
+              image: item.judgeImage,
+              deletedAt: item.judgeDeletedAt,
+              profilePicture: profilePictures[item.judgeUserId] ?? null,
+              cosmetics: cosmetics[item.judgeUserId] ?? null,
+            }
+          : null,
       winners: winnersByChallengeId.get(item.id) ?? [],
       completionSummary: metadata.completionSummary ?? null,
     };


### PR DESCRIPTION
## Problem

The challenge card/detail API overloaded `createdBy` to mean *sometimes the real creator, sometimes the judge persona* (e.g. CivBot). For System/Mod challenges the projection swapped `createdBy` to the judge for display, so `createdBy.id !== createdById`. Every ownership check had to remember to use `createdById`, and it produced confusing invariants like the one in `useApplyHiddenPreferences`.

## Change

- `createdBy` / `createdById` now **always** carry the real creator, on both the list item and the detail.
- `judge` is a dedicated field on both (the detail already had it; the list item is new). `ChallengeJudgeInfo` is enriched with the judge user's `username` / `image` / `deletedAt` so it can render as an author avatar.
- `getChallengeDisplayUser` (in `challenge.utils.ts`) is the single place that decides the displayed author — the creator for `User` challenges, the judge otherwise. Used by the card, the detail creator card, and the discussion owner id.
- All four service projections (card feed, `getById`, events, completed-with-winners) drop the persona swap and hydrate creator + judge independently.

## No user-facing change

- `System` challenges already store the judge as their `createdById`, so nothing changes there.
- `Mod` challenges keep showing the judge (via the new `judge` field), so individual moderators stay unexposed.
- `User` challenges show the real creator, as before.

## No migration

The DB already has separate `createdById` and `judgeId` columns and stores the real creator — this is purely a projection/display refactor.

## Verification

- `pnpm typecheck` — 0 errors.
- New unit tests for `getChallengeDisplayUser` (User→creator, Mod→judge, System→judge, null-judge→creator fallback) + existing challenge unit tests pass.
- Runtime-checked `getById` and `getInfinite` against seed data: `createdBy` = real creator (User challenge → the creator, not CivBot), `judge` fully populated (username/image/deletedAt/profilePicture) — confirming the raw-SQL JOIN + aliases resolve correctly.

Independent refactor — based directly on `main`, not stacked on the open user-challenges or mod-charging work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)