### PR TITLE
feat(api): include modelId in by-hash/ids batch results

### DIFF
--- a/src/pages/api/v1/model-versions/by-hash/ids.ts
+++ b/src/pages/api/v1/model-versions/by-hash/ids.ts
@@ -29,6 +29,11 @@ export default PublicEndpoint(
           },
           select: {
             modelVersionId: true,
+            modelVersion: {
+              select: {
+                modelId: true,
+              },
+            },
             hashes: {
               select: {
                 hash: true,
@@ -39,8 +44,11 @@ export default PublicEndpoint(
             },
           },
         })
-      )?.map((entry) => ({ modelVersionId: entry.modelVersionId, hash: entry.hashes[0].hash })) ??
-      [];
+      )?.map((entry) => ({
+        modelVersionId: entry.modelVersionId,
+        modelId: entry.modelVersion.modelId,
+        hash: entry.hashes[0].hash,
+      })) ?? [];
 
     res.status(200).json(ids);
   },

--- a/src/server/__tests__/by-hash-ids-endpoint.test.ts
+++ b/src/server/__tests__/by-hash-ids-endpoint.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+// Focused test for src/pages/api/v1/model-versions/by-hash/ids.ts.
+// Kept in src/server/__tests__ (NOT under src/pages) per CLAUDE.md: Next.js treats
+// every file under src/pages as a route and `next build` fails on test files there.
+
+const { mockFindMany } = vi.hoisted(() => ({ mockFindMany: vi.fn() }));
+
+vi.mock('~/server/db/client', () => ({
+  dbRead: { modelFile: { findMany: mockFindMany } },
+}));
+
+// Unwrap PublicEndpoint so we can invoke the raw handler directly (no CORS/cache side effects).
+vi.mock('~/server/utils/endpoint-helpers', () => ({
+  PublicEndpoint: (handler: Function) => handler,
+}));
+
+import handler from '~/pages/api/v1/model-versions/by-hash/ids';
+
+const HASH = 'A'.repeat(64);
+const HASH_2 = 'B'.repeat(64);
+
+const runRequest = (body: unknown) => {
+  const req = { method: 'POST', body } as unknown as NextApiRequest;
+  const json = vi.fn().mockReturnThis();
+  const res = {
+    status: vi.fn().mockReturnThis(),
+    json,
+  } as unknown as NextApiResponse;
+  return { promise: handler(req, res), res, json };
+};
+
+describe('by-hash/ids endpoint', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('includes modelId alongside modelVersionId and hash for each result', async () => {
+    mockFindMany.mockResolvedValue([
+      { modelVersionId: 101, modelVersion: { modelId: 11 }, hashes: [{ hash: HASH }] },
+      { modelVersionId: 202, modelVersion: { modelId: 22 }, hashes: [{ hash: HASH_2 }] },
+    ]);
+
+    const { promise, res, json } = runRequest([HASH, HASH_2]);
+    await promise;
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(json).toHaveBeenCalledWith([
+      { modelVersionId: 101, modelId: 11, hash: HASH },
+      { modelVersionId: 202, modelId: 22, hash: HASH_2 },
+    ]);
+  });
+
+  it('selects modelVersion.modelId in the query', async () => {
+    mockFindMany.mockResolvedValue([]);
+
+    const { promise } = runRequest([HASH]);
+    await promise;
+
+    const arg = mockFindMany.mock.calls[0][0];
+    expect(arg.select.modelVersion.select.modelId).toBe(true);
+    // Backward-compatible: existing fields still selected.
+    expect(arg.select.modelVersionId).toBe(true);
+    expect(arg.select.hashes.where.type).toBe('SHA256');
+  });
+
+  it('rejects a payload with an invalid (non-64-char) hash', async () => {
+    const { promise, res, json } = runRequest(['tooshort']);
+    await promise;
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(json).toHaveBeenCalledWith(
+      expect.objectContaining({ error: expect.stringContaining('SHA256') })
+    );
+    expect(mockFindMany).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Problem
`POST /api/v1/model-versions/by-hash/ids` returns only `{ modelVersionId, hash }` per match. A client that resolves a batch of file hashes has no way to identify the owning **model** without a second round-trip per version.

## Change
Extend the Prisma `select` to also pull `modelVersion.modelId` and include it in each result: `{ modelVersionId, modelId, hash }`.

The query already constrains `modelVersion: { model: { status: 'Published' }, status: 'Published' }`, so `modelId` is available with no extra query cost.

- **Additive & backward-compatible** — existing consumers that read `modelVersionId`/`hash` are unaffected; they simply ignore the new field.
- Preserves the <=10k hash cap, the `type: 'SHA256'` filter, the `hashes[0]` safety (`ModelFileHash` PK is `(fileId, type)`, so at most one SHA256 per file), and the response shape/order.

Adds a focused unit test in `src/server/__tests__/` (kept out of `src/pages` per CLAUDE.md, since `next build` treats files there as routes).

## Why
Unblocks a batch-consuming client that needs to map hashes -> model in one call instead of N follow-up lookups. Kept standalone so it can merge independently of the other two by-hash changes.

## Risk
Low. Single additive field on one public endpoint; no change to matching semantics, filters, or existing fields.

## Testing
- `vitest --project unit` on the new test: 3 passed.
- `tsc --noEmit` (full project): clean.
- `prettier --check` on touched files: clean.
- ESLint could not run in this local environment (ESLint 8.57 crashes on config load under the local Node 26); the change is trivial TS and prettier-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)