### PR TITLE
feat(3d-models): add "Include PG-13" toggle to the 3D feed

### DIFF
--- a/src/components/Filters/FeedFilters/Model3DFeedFilters.tsx
+++ b/src/components/Filters/FeedFilters/Model3DFeedFilters.tsx
@@ -1,14 +1,5 @@
 import type { GroupProps } from '@mantine/core';
-import {
-  Chip,
-  Divider,
-  Drawer,
-  Group,
-  Indicator,
-  Popover,
-  ScrollArea,
-  Stack,
-} from '@mantine/core';
+import { Chip, Divider, Drawer, Group, Indicator, Popover, ScrollArea, Stack } from '@mantine/core';
 import { IconFilter } from '@tabler/icons-react';
 import { useRouter } from 'next/router';
 import { useCallback, useMemo } from 'react';
@@ -20,6 +11,7 @@ import { useStagedFilters } from '~/components/Filters/useStagedFilters';
 import { IsClient } from '~/components/IsClient/IsClient';
 import { SelectMenuV2 } from '~/components/SelectMenu/SelectMenu';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
+import { useDomainColor } from '~/hooks/useDomainColor';
 import useIsClient from '~/hooks/useIsClient';
 import { useIsMobile } from '~/hooks/useIsMobile';
 import { Model3DSort } from '~/server/schema/model3d.schema';
@@ -52,6 +44,7 @@ type Model3DFilterState = {
   period: MetricTimeframe;
   animated: boolean;
   unrated: boolean;
+  includePG13: boolean;
 };
 
 export function Model3DFeedFilters({ ...groupProps }: GroupProps) {
@@ -61,6 +54,11 @@ export function Model3DFeedFilters({ ...groupProps }: GroupProps) {
   const mobile = useIsMobile();
   const currentUser = useCurrentUser();
   const isModerator = !!currentUser?.isModerator;
+  const domainColor = useDomainColor();
+  // Anonymous users on green are hard-capped to PG by the domain rule, so the
+  // toggle would be a no-op for them. Only logged-in users actually have
+  // PG-13 access to opt in/out of.
+  const showPG13Toggle = domainColor === 'green' && !!currentUser;
 
   const sort = useMemo<Model3DSort>(() => {
     const raw = typeof query.sort === 'string' ? query.sort : undefined;
@@ -74,6 +72,7 @@ export function Model3DFeedFilters({ ...groupProps }: GroupProps) {
 
   const animated = query.animated === 'true';
   const unrated = isModerator && query.unrated === 'true';
+  const includePG13 = showPG13Toggle && query.includePG13 === 'true';
 
   const setQuery = useCallback(
     (patch: Record<string, string | undefined>) => {
@@ -88,8 +87,8 @@ export function Model3DFeedFilters({ ...groupProps }: GroupProps) {
 
   // Committed = URL-backed state. Apply writes back to URL via setQuery.
   const committed: Model3DFilterState = useMemo(
-    () => ({ period, animated, unrated }),
-    [period, animated, unrated]
+    () => ({ period, animated, unrated, includePG13 }),
+    [period, animated, unrated, includePG13]
   );
 
   const handleApply = useCallback(
@@ -98,6 +97,7 @@ export function Model3DFeedFilters({ ...groupProps }: GroupProps) {
         period: next.period === MetricTimeframe.AllTime ? undefined : next.period,
         animated: next.animated ? 'true' : undefined,
         unrated: next.unrated ? 'true' : undefined,
+        includePG13: next.includePG13 ? 'true' : undefined,
         // Clear any legacy `?rigged=` left in the URL from before the
         // rigging filter was removed (the Meshy API now binds rigging
         // to animation, so the filter is no longer meaningful).
@@ -108,20 +108,36 @@ export function Model3DFeedFilters({ ...groupProps }: GroupProps) {
   );
 
   const handleClear = useCallback(() => {
-    setQuery({ period: undefined, animated: undefined, unrated: undefined, rigged: undefined });
+    setQuery({
+      period: undefined,
+      animated: undefined,
+      unrated: undefined,
+      includePG13: undefined,
+      rigged: undefined,
+    });
   }, [setQuery]);
 
-  const { opened, toggle, close, mergedFilters, isDirty, patchPending, apply, reset, clearAndClose } =
-    useStagedFilters<Model3DFilterState>({
-      committed,
-      onApply: handleApply,
-      onClear: handleClear,
-    });
+  const {
+    opened,
+    toggle,
+    close,
+    mergedFilters,
+    isDirty,
+    patchPending,
+    apply,
+    reset,
+    clearAndClose,
+  } = useStagedFilters<Model3DFilterState>({
+    committed,
+    onApply: handleApply,
+    onClear: handleClear,
+  });
 
   const filterLength =
     (mergedFilters.period !== MetricTimeframe.AllTime ? 1 : 0) +
     (mergedFilters.animated ? 1 : 0) +
-    (mergedFilters.unrated ? 1 : 0);
+    (mergedFilters.unrated ? 1 : 0) +
+    (showPG13Toggle && mergedFilters.includePG13 ? 1 : 0);
 
   const target = (
     <Indicator
@@ -163,6 +179,14 @@ export function Model3DFeedFilters({ ...groupProps }: GroupProps) {
       <Stack gap="md">
         <Divider label="Modifiers" className="text-sm font-bold" mb={4} />
         <div className="flex flex-wrap gap-2">
+          {showPG13Toggle && (
+            <FilterChip
+              checked={!!mergedFilters.includePG13}
+              onChange={(checked) => patchPending({ includePG13: checked })}
+            >
+              <span>Include PG-13</span>
+            </FilterChip>
+          )}
           <FilterChip
             checked={mergedFilters.animated}
             onChange={(checked) => patchPending({ animated: checked })}
@@ -199,9 +223,7 @@ export function Model3DFeedFilters({ ...groupProps }: GroupProps) {
         label={sort}
         value={sort}
         options={sortOptions}
-        onClick={(value) =>
-          setQuery({ sort: value === Model3DSort.Newest ? undefined : value })
-        }
+        onClick={(value) => setQuery({ sort: value === Model3DSort.Newest ? undefined : value })}
       />
       {mobile ? (
         <>
@@ -246,10 +268,7 @@ export function Model3DFeedFilters({ ...groupProps }: GroupProps) {
         >
           <Popover.Target>{target}</Popover.Target>
           <Popover.Dropdown maw={468} p={0} w="100%">
-            <ScrollArea.Autosize
-              type="hover"
-              mah={'calc(90vh - var(--header-height) - 156px)'}
-            >
+            <ScrollArea.Autosize type="hover" mah={'calc(90vh - var(--header-height) - 156px)'}>
               {dropdownBody}
             </ScrollArea.Autosize>
             {dropdownFooter}

--- a/src/pages/3d-models/index.tsx
+++ b/src/pages/3d-models/index.tsx
@@ -14,8 +14,11 @@ import { MasonryGridVirtual } from '~/components/MasonryColumns/MasonryGridVirtu
 import { Meta } from '~/components/Meta/Meta';
 import { Model3DCategories } from '~/components/Model3D/Feed/Model3DCategories';
 import { NoContent } from '~/components/NoContent/NoContent';
+import { useDomainColor } from '~/hooks/useDomainColor';
 import { Model3DSort } from '~/server/schema/model3d.schema';
 import { createServerSideProps } from '~/server/utils/server-side-helpers';
+import { publicBrowsingLevelsFlag } from '~/shared/constants/browsingLevel.constants';
+import { Flags } from '~/shared/utils/flags';
 import { MetricTimeframe } from '~/shared/utils/prisma/enums';
 import { parseNumericStringArray } from '~/utils/query-string-helpers';
 import { trpc } from '~/utils/trpc';
@@ -38,6 +41,8 @@ import { trpc } from '~/utils/trpc';
  *     required when animation is enabled), so we now expose a single
  *     "Animate" affordance and `toMeshyPolyGenInput` pins
  *     `enableRigging = enableAnimation`.
+ *   - Include PG-13 toggle — green-domain, logged-in viewers only; opts the
+ *     feed out of the PG-only cap the domain otherwise forces.
  *
  * State lives on the URL (sort / period / tags / animated) so deep links +
  * back/forward retain filter context. Switching any filter resets the
@@ -72,11 +77,15 @@ function Model3DsPage() {
   // Category-tag selection now rides on the canonical `?tags=` array (the
   // `Model3DCategories` scroller emits + reads it, mirroring how the other
   // feed pages do it). The bespoke single `?tagId=` query param is gone.
-  const tagIds = useMemo(() => parseNumericStringArray(router.query.tags) ?? [], [router.query.tags]);
+  const tagIds = useMemo(
+    () => parseNumericStringArray(router.query.tags) ?? [],
+    [router.query.tags]
+  );
 
   const animated = query.animated === 'true';
   // Mod/owner-only "unrated" filter — the server ignores it for other viewers.
   const unrated = query.unrated === 'true';
+  const includePG13 = query.includePG13 === 'true';
 
   // ---- Feed -------------------------------------------------------------------
   // The server-side `getModel3DsInfinite` SQL filter clamps Model3D.nsfwLevel
@@ -84,7 +93,15 @@ function Model3DsPage() {
   // current browsing level here gives us paging-correct counts. The client-
   // side `useApplyHiddenPreferences` below applies the per-user hidden-image /
   // hidden-user / hidden-tag overlay that lives only in the browser session.
-  const browsingLevel = useBrowsingLevelDebounced();
+  const rawBrowsingLevel = useBrowsingLevelDebounced();
+  const domainColor = useDomainColor();
+  // On the green (SFW) domain we default to PG only; users opt in to PG-13 via
+  // the feed filter, which narrows the forced domain cap
+  // (sfwBrowsingLevelsFlag = PG | PG-13) down to PG. Mirrors `ImagesInfinite`.
+  const browsingLevel =
+    domainColor === 'green' && !includePG13
+      ? Flags.intersection(rawBrowsingLevel, publicBrowsingLevelsFlag)
+      : rawBrowsingLevel;
   const { data, isLoading, isFetching, isRefetching, hasNextPage, fetchNextPage } =
     trpc.model3d.getInfinite.useInfiniteQuery(
       {


### PR DESCRIPTION
## What

Adds an **Include PG-13** chip to the `/3d-models` feed filters, matching the one on the images feed (`MediaFiltersDropdown`).

## Why

On the green (SFW) domain the forced cap is `sfwBrowsingLevelsFlag` (PG | PG-13). The images feed narrows that to PG-only by default and lets users opt back into PG-13. The 3D feed passed the raw browsing level straight through, so the two feeds disagreed about what "SFW" meant.

## How

- `Model3DFeedFilters` gains an `includePG13` member in its staged filter state, URL-backed as `?includePG13=true`, counted in the filter-count indicator, and cleared by Clear.
- The chip renders only for logged-in viewers on the green domain — anonymous users are hard-capped to PG by the domain rule, so the toggle would be a no-op (same gate as the images feed).
- `/3d-models` intersects the debounced browsing level with `publicBrowsingLevelsFlag` unless the toggle is on, mirroring `ImagesInfinite`.

No server changes — `model3d.getInfinite` already clamps `Model3D.nsfwLevel` to the `browsingLevel` it's handed.

## Testing

- `pnpm typecheck` — no new errors (the kysely module-resolution and `BaseChallenge.createdBy` errors are pre-existing on `main`).
- `pnpm exec prettier --check` on both touched files — clean.
- Preview env requested via the `preview` label for a visual pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)