### PR TITLE
fix(api): make by-hash single lookup deterministic

### DIFF
--- a/src/pages/api/v1/model-versions/by-hash/[hash].ts
+++ b/src/pages/api/v1/model-versions/by-hash/[hash].ts
@@ -23,6 +23,13 @@ export default PublicEndpoint(async function handler(req: NextApiRequest, res: N
       hashes: { some: { hash } },
       modelVersion: { model: { status: 'Published' }, status: 'Published' },
     },
+    // Duplicate hashes are a known condition (see src/pages/moderator/duplicate-hashes.tsx):
+    // a single hash can map to multiple Published files/versions. Without an explicit order
+    // `findFirst` returns a plan-dependent, arbitrary row, so repeated calls for the same hash
+    // can resolve to different versions. Order deterministically by the oldest/canonical
+    // version (earliest publishedAt, then lowest version id as a stable tiebreaker) so the
+    // result is stable. This makes resolution deterministic, not disambiguated.
+    orderBy: [{ modelVersion: { publishedAt: 'asc' } }, { modelVersion: { id: 'asc' } }],
     take: 1,
     select: {
       modelVersion: {

--- a/src/server/__tests__/by-hash-single-endpoint.test.ts
+++ b/src/server/__tests__/by-hash-single-endpoint.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+// Focused test for src/pages/api/v1/model-versions/by-hash/[hash].ts.
+// Kept in src/server/__tests__ (NOT under src/pages) per CLAUDE.md.
+
+const { mockFindFirst, mockResDetails } = vi.hoisted(() => ({
+  mockFindFirst: vi.fn(),
+  mockResDetails: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('~/server/db/client', () => ({
+  dbRead: { modelFile: { findFirst: mockFindFirst } },
+}));
+
+vi.mock('~/server/utils/endpoint-helpers', () => ({
+  PublicEndpoint: (handler: Function) => handler,
+}));
+
+// Avoid pulling the heavy model-version response graph.
+vi.mock('~/pages/api/v1/model-versions/[id]', () => ({
+  resModelVersionDetails: mockResDetails,
+}));
+
+vi.mock('~/server/selectors/modelVersion.selector', () => ({
+  getModelVersionApiSelect: {},
+}));
+
+import handler from '~/pages/api/v1/model-versions/by-hash/[hash]';
+
+const HASH = 'a'.repeat(64);
+
+const runRequest = (query: Record<string, string>) => {
+  const req = { method: 'GET', query } as unknown as NextApiRequest;
+  const res = {
+    status: vi.fn().mockReturnThis(),
+    json: vi.fn().mockReturnThis(),
+  } as unknown as NextApiResponse;
+  return { promise: handler(req, res), res };
+};
+
+describe('by-hash/[hash] endpoint', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('queries with a deterministic orderBy (oldest published version, id tiebreak)', async () => {
+    mockFindFirst.mockResolvedValue({ modelVersion: { id: 1 } });
+
+    const { promise } = runRequest({ hash: HASH });
+    await promise;
+
+    expect(mockFindFirst).toHaveBeenCalledTimes(1);
+    const arg = mockFindFirst.mock.calls[0][0];
+    expect(arg.orderBy).toEqual([
+      { modelVersion: { publishedAt: 'asc' } },
+      { modelVersion: { id: 'asc' } },
+    ]);
+    // Matching semantics unchanged: still Published-only, any-hash-type.
+    expect(arg.where.modelVersion).toEqual({
+      model: { status: 'Published' },
+      status: 'Published',
+    });
+  });
+
+  it('passes null modelVersion through when no file matches', async () => {
+    mockFindFirst.mockResolvedValue(null);
+
+    const { promise } = runRequest({ hash: HASH });
+    await promise;
+
+    expect(mockResDetails).toHaveBeenCalledWith(expect.anything(), expect.anything(), null);
+  });
+});


### PR DESCRIPTION
## Problem
`GET /api/v1/model-versions/by-hash/[hash]` runs `dbRead.modelFile.findFirst({ ... })` with **no `orderBy`**. When a single hash maps to multiple Published files/versions — duplicate hashes are a known, tracked condition (see `src/pages/moderator/duplicate-hashes.tsx`) — the row `findFirst` returns is plan-dependent and arbitrary, so two identical requests can resolve to different model versions.

## Change
Add a deterministic `orderBy` that prefers the oldest / canonical version:

```ts
orderBy: [{ modelVersion: { publishedAt: 'asc' } }, { modelVersion: { id: 'asc' } }],
```

`publishedAt` is nullable, so `modelVersion.id asc` is a stable tiebreaker (and covers the ties-on-equal-publishedAt case). Matching semantics are otherwise unchanged — still any-hash-type, Published-only.

**This makes duplicate-hash resolution deterministic, not disambiguated:** callers still get a single version for a colliding hash; they now get the *same* one every time instead of a plan-dependent pick.

Adds a focused unit test (in `src/server/__tests__/`, outside `src/pages` per CLAUDE.md) asserting the `orderBy` is present and that the Published-only filter is preserved.

## Risk
Low. One added `orderBy` on a read path; no change to filters, selection, or response shape. For the common single-match case the result is identical to before.

## Testing
- `vitest --project unit` on the new test: 2 passed.
- `tsc --noEmit` (full project, complete monorepo install): clean.
- `prettier --check` on the touched file: clean.
- ESLint could not run locally (ESLint 8.57 crashes on config load under the local Node 26); change is trivial TS and prettier-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)