### PR TITLE
perf(creator-controls): cache read-time membership validity + skip resolution when nothing hidden

### DIFF
--- a/packages/civitai-redis/src/client.ts
+++ b/packages/civitai-redis/src/client.ts
@@ -2091,6 +2091,12 @@ export const REDIS_KEYS = {
     // registered image resolves immediately), busted when `hideMeta` flips in
     // updatePostImage. See `getCachedImageDeliveryMetadata` in image-delivery.service.
     IMAGE_DELIVERY_METADATA: 'packed:caches:image-delivery-metadata',
+    // Per-user `id -> isValidCreatorMember(boolean)` for the read-time metric-privacy /
+    // donation-goal hide gate (#3266). Near-static per user; both TRUE and FALSE are
+    // cached (the resolver is a total function over the id). Busted on any subscription
+    // change via `invalidateSubscriptionCaches`; TTL backstops the non-webhook paths.
+    // See `getValidCreatorMembershipMap` in creator-membership.service.
+    CREATOR_MEMBERSHIP_VALID: 'packed:caches:creator-membership-valid',
   },
   RESEARCH: {
     RATINGS_COUNT: 'research:ratings-count',

--- a/src/pages/api/og.tsx
+++ b/src/pages/api/og.tsx
@@ -11,8 +11,13 @@ import type { MediaType } from '~/shared/utils/prisma/enums';
 import { abbreviateNumber } from '~/utils/number-helpers';
 import { removeTags } from '~/utils/string-helpers';
 import { buildOgCoverEdgeUrl, fetchImageAsDataUri } from '~/server/utils/og-image-helpers';
-import { hasValidCreatorMembership } from '~/server/services/creator-program.service';
-import { resolveModelHiddenMetrics } from '~/server/utils/model-metric-privacy';
+import { hasValidCreatorMembershipCached } from '~/server/services/creator-program.service';
+import {
+  anyMetricHidden,
+  getMetaMetricPrivacy,
+  getUserMetricPrivacyDefaults,
+  resolveModelHiddenMetrics,
+} from '~/server/utils/model-metric-privacy';
 import { isDefined } from '~/utils/type-guards';
 
 // --- Schema & Types ---
@@ -163,11 +168,19 @@ async function fetchModelData(id: number): Promise<EntityData | null> {
 
   // Creator Controls: the OG card is a public, shared asset — gate downloads /
   // generations by the owner's stored flags + active CP membership.
+  // Only resolve CP membership when the owner actually hides something. When nothing is
+  // hidden, the resolver returns NONE regardless of membership, so the cached membership
+  // read can be skipped — byte-identical. The check, when needed, uses the read-through cache.
+  const ownerHidesAnything =
+    anyMetricHidden(getMetaMetricPrivacy(model.meta)) ||
+    anyMetricHidden(getUserMetricPrivacyDefaults(model.user?.settings));
   const hidden = resolveModelHiddenMetrics({
     modelMeta: model.meta,
     userSettings: model.user?.settings,
     isOwnerOrModerator: false,
-    hasValidMembership: await hasValidCreatorMembership(model.userId),
+    hasValidMembership: ownerHidesAnything
+      ? await hasValidCreatorMembershipCached(model.userId)
+      : false,
   });
 
   // Run metric + image queries in parallel

--- a/src/pages/api/v1/model-versions/[id].ts
+++ b/src/pages/api/v1/model-versions/[id].ts
@@ -24,8 +24,13 @@ import {
 } from '~/shared/constants/browsingLevel.constants';
 import { getRegion, isRegionRestricted } from '~/server/utils/region-blocking';
 import { logToAxiom } from '~/server/logging/client';
-import { hasValidCreatorMembership } from '~/server/services/creator-program.service';
-import { resolveVersionHiddenMetrics } from '~/server/utils/model-metric-privacy';
+import { hasValidCreatorMembershipCached } from '~/server/services/creator-program.service';
+import {
+  anyMetricHidden,
+  getMetaMetricPrivacy,
+  getUserMetricPrivacyDefaults,
+  resolveVersionHiddenMetrics,
+} from '~/server/utils/model-metric-privacy';
 
 const hashesAsObject = (hashes: { type: ModelHashType; hash: string }[]) =>
   hashes.reduce((acc, { type, hash }) => ({ ...acc, [type]: hash }), {});
@@ -194,14 +199,23 @@ export async function prepareModelVersionResponse(
       model: { select: { meta: true, userId: true, user: { select: { settings: true } } } },
     },
   });
+  // Only resolve CP membership when something is actually hidden (version meta, model
+  // meta, or the owner's user default). When nothing is hidden, the resolver returns
+  // NONE regardless of membership, so the cached membership read can be skipped —
+  // byte-identical output. The check, when needed, is served from the read-through cache.
+  const ownerHidesAnything =
+    anyMetricHidden(getMetaMetricPrivacy(privacy?.meta)) ||
+    anyMetricHidden(getMetaMetricPrivacy(privacy?.model?.meta)) ||
+    anyMetricHidden(getUserMetricPrivacyDefaults(privacy?.model?.user?.settings));
   const hidden = resolveVersionHiddenMetrics({
     versionMeta: privacy?.meta,
     modelMeta: privacy?.model?.meta,
     userSettings: privacy?.model?.user?.settings,
     isOwnerOrModerator: false,
-    hasValidMembership: privacy?.model?.userId
-      ? await hasValidCreatorMembership(privacy.model.userId)
-      : false,
+    hasValidMembership:
+      ownerHidesAnything && privacy?.model?.userId
+        ? await hasValidCreatorMembershipCached(privacy.model.userId)
+        : false,
   });
 
   return {

--- a/src/server/__tests__/model-metric-privacy.test.ts
+++ b/src/server/__tests__/model-metric-privacy.test.ts
@@ -200,6 +200,64 @@ describe('anyMetricHidden', () => {
   });
 });
 
+/**
+ * Short-circuit invariant (the read-path cost optimization): when NO owner flag is set
+ * — no model/version meta flag AND no user default — the resolvers return NONE for BOTH
+ * membership values. This is what lets the hot read paths skip the membership lookup
+ * entirely (a redis/DB round-trip) whenever `anyMetricHidden(meta) || anyMetricHidden(
+ * userDefaults)` is false: the output is provably identical to running the full
+ * resolution. A regression here would break the "skip when nothing hidden" guarantee.
+ */
+describe('short-circuit: membership is irrelevant when nothing is hidden', () => {
+  it('resolveModelHiddenMetrics returns NONE for member AND non-member when no flags set', () => {
+    const asMember = resolveModelHiddenMetrics({
+      modelMeta: {},
+      userSettings: {},
+      isOwnerOrModerator: false,
+      hasValidMembership: true,
+    });
+    const asNonMember = resolveModelHiddenMetrics({
+      modelMeta: {},
+      userSettings: {},
+      isOwnerOrModerator: false,
+      hasValidMembership: false,
+    });
+    expect(asMember).toEqual(NONE);
+    expect(asNonMember).toEqual(NONE);
+    expect(asMember).toEqual(asNonMember); // membership value cannot change the output
+  });
+
+  it('resolveVersionHiddenMetrics returns NONE for member AND non-member when no flags set', () => {
+    const asMember = resolveVersionHiddenMetrics({
+      versionMeta: {},
+      modelMeta: {},
+      userSettings: {},
+      isOwnerOrModerator: false,
+      hasValidMembership: true,
+    });
+    const asNonMember = resolveVersionHiddenMetrics({
+      versionMeta: {},
+      modelMeta: {},
+      userSettings: {},
+      isOwnerOrModerator: false,
+      hasValidMembership: false,
+    });
+    expect(asMember).toEqual(NONE);
+    expect(asNonMember).toEqual(NONE);
+    expect(asMember).toEqual(asNonMember);
+  });
+
+  it('once ANY flag is set, membership DOES matter (so the short-circuit must not fire)', () => {
+    const gate = { modelMeta: { hideBuzz: true }, isOwnerOrModerator: false } as const;
+    expect(resolveModelHiddenMetrics({ ...gate, hasValidMembership: true })).toEqual({
+      buzz: true,
+      downloads: false,
+      generations: false,
+    });
+    expect(resolveModelHiddenMetrics({ ...gate, hasValidMembership: false })).toEqual(NONE);
+  });
+});
+
 describe('noHiddenMetrics', () => {
   it('returns an all-visible result', () => {
     expect(noHiddenMetrics()).toEqual(NONE);

--- a/src/server/controllers/model.controller.ts
+++ b/src/server/controllers/model.controller.ts
@@ -14,11 +14,12 @@ import { dbRead, dbWrite } from '~/server/db/client';
 import { eventEngine } from '~/server/events';
 import {
   getValidCreatorMembershipMap,
-  hasValidCreatorMembership,
+  hasValidCreatorMembershipCached,
 } from '~/server/services/creator-program.service';
 import {
   anyMetricHidden,
   gateHiddenMetrics,
+  getMetaMetricPrivacy,
   getUserMetricPrivacyDefaults,
   resolveModelHiddenMetrics,
   resolveVersionHiddenMetrics,
@@ -304,12 +305,22 @@ export const getModelHandler = async ({
     let ownerSettings: unknown = null;
     let ownerHasMembership = false;
     if (metricPrivacyEnabled && !isOwner) {
-      const [owner, membership] = await Promise.all([
-        dbRead.user.findUnique({ where: { id: model.user.id }, select: { settings: true } }),
-        hasValidCreatorMembership(model.user.id),
-      ]);
+      const owner = await dbRead.user.findUnique({
+        where: { id: model.user.id },
+        select: { settings: true },
+      });
       ownerSettings = owner?.settings ?? null;
-      ownerHasMembership = membership;
+      // Only resolve CP membership when the owner actually hides something (model meta,
+      // any version meta, or a user default). When nothing is hidden, resolveModel/Version
+      // return NONE regardless of membership, so the cached membership read (and the
+      // resolvers themselves) can be skipped — byte-identical raw metrics. The membership
+      // check, when needed, is served from the shared read-through cache.
+      const ownerHidesAnything =
+        anyMetricHidden(getMetaMetricPrivacy(model.meta)) ||
+        anyMetricHidden(getUserMetricPrivacyDefaults(ownerSettings)) ||
+        filteredVersions.some((v) => anyMetricHidden(getMetaMetricPrivacy(v.meta)));
+      if (ownerHidesAnything)
+        ownerHasMembership = await hasValidCreatorMembershipCached(model.user.id);
     }
     const modelHidden = gateHiddenMetrics(metricPrivacyEnabled, () =>
       resolveModelHiddenMetrics({

--- a/src/server/services/__tests__/creator-membership.service.test.ts
+++ b/src/server/services/__tests__/creator-membership.service.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { CacheTTL } from '~/server/common/constants';
 
 /**
  * `getValidCreatorMembershipMap` is the read-time gate every metric-privacy surface
@@ -6,15 +7,33 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
  * user is a valid Creator Program member only while they hold a paid, non-founder
  * tier. A regression here either leaks a lapsed creator's hidden metrics (false→true)
  * or wrongly hides an active member's stats (true→false).
+ *
+ * It is now a read-through Redis cache over the near-static per-user validity boolean:
+ * cached ids are served from Redis (no DB), only misses hit `customerSubscription`
+ * + the per-sub Zod parse, and the result is byte-identical to the uncached path.
  */
 
-const { mockDbRead } = vi.hoisted(() => ({
+const { mockDbRead, mockRedis } = vi.hoisted(() => ({
   mockDbRead: { customerSubscription: { findMany: vi.fn() } },
+  mockRedis: {
+    packed: { mGet: vi.fn(), set: vi.fn() },
+    del: vi.fn(),
+  },
 }));
 
 vi.mock('~/server/db/client', () => ({ dbRead: mockDbRead }));
+vi.mock('~/server/redis/client', () => ({
+  redis: mockRedis,
+  REDIS_KEYS: { CACHES: { CREATOR_MEMBERSHIP_VALID: 'packed:caches:creator-membership-valid' } },
+}));
 
-import { getValidCreatorMembershipMap } from '~/server/services/creator-membership.service';
+import {
+  bustCreatorMembershipValidCache,
+  getValidCreatorMembershipMap,
+  hasValidCreatorMembershipCached,
+} from '~/server/services/creator-membership.service';
+
+const keyFor = (id: number) => `packed:caches:creator-membership-valid:${id}`;
 
 type SubRow = {
   userId: number;
@@ -31,12 +50,20 @@ const sub = (userId: number, tier: string, over: Partial<SubRow> = {}): SubRow =
 
 beforeEach(() => {
   vi.clearAllMocks();
+  // Default: every key is a cache MISS, so tests exercising the origin query fall
+  // through to the DB. Cache-hit tests override this per case.
+  mockRedis.packed.mGet.mockImplementation((keys: string[]) =>
+    Promise.resolve(keys.map(() => null))
+  );
+  mockRedis.packed.set.mockResolvedValue(undefined);
+  mockRedis.del.mockResolvedValue(undefined);
 });
 
-describe('getValidCreatorMembershipMap', () => {
-  it('returns an empty map (and skips the db) for empty input', async () => {
+describe('getValidCreatorMembershipMap — origin computation (cache miss)', () => {
+  it('returns an empty map (and touches neither redis nor the db) for empty input', async () => {
     const result = await getValidCreatorMembershipMap([]);
     expect(result.size).toBe(0);
+    expect(mockRedis.packed.mGet).not.toHaveBeenCalled();
     expect(mockDbRead.customerSubscription.findMany).not.toHaveBeenCalled();
   });
 
@@ -60,5 +87,143 @@ describe('getValidCreatorMembershipMap', () => {
     const result = await getValidCreatorMembershipMap([1]);
     // Picks silver over free -> valid (a free-only pick would be invalid).
     expect(result.get(1)).toBe(true);
+  });
+
+  it('dedupes ids and returns a definite boolean for a user with no subscription', async () => {
+    mockDbRead.customerSubscription.findMany.mockResolvedValue([sub(1, 'gold')]);
+    const result = await getValidCreatorMembershipMap([1, 1, 2]);
+    expect(result.get(1)).toBe(true);
+    expect(result.get(2)).toBe(false); // total function: no sub -> false, not undefined
+    // deduped: the origin query is asked for the two distinct ids only
+    const whereIn = mockDbRead.customerSubscription.findMany.mock.calls[0][0].where.userId.in;
+    expect([...whereIn].sort()).toEqual([1, 2]);
+  });
+});
+
+describe('getValidCreatorMembershipMap — read-through cache', () => {
+  it('serves a cached TRUE from redis without querying the db', async () => {
+    mockRedis.packed.mGet.mockResolvedValue([true]);
+    const result = await getValidCreatorMembershipMap([1]);
+    expect(result.get(1)).toBe(true);
+    expect(mockDbRead.customerSubscription.findMany).not.toHaveBeenCalled();
+    expect(mockRedis.packed.set).not.toHaveBeenCalled();
+  });
+
+  it('serves a cached FALSE from redis (negatives are cached, not re-queried)', async () => {
+    mockRedis.packed.mGet.mockResolvedValue([false]);
+    const result = await getValidCreatorMembershipMap([1]);
+    expect(result.get(1)).toBe(false);
+    expect(mockDbRead.customerSubscription.findMany).not.toHaveBeenCalled();
+  });
+
+  it('batch miss-fill: queries ONLY the missing ids and backfills them', async () => {
+    // id 1 cached true, ids 2 & 3 miss.
+    mockRedis.packed.mGet.mockResolvedValue([true, null, null]);
+    mockDbRead.customerSubscription.findMany.mockResolvedValue([sub(2, 'gold')]); // 3 has no sub
+    const result = await getValidCreatorMembershipMap([1, 2, 3]);
+
+    expect(result.get(1)).toBe(true); // from cache
+    expect(result.get(2)).toBe(true); // from db
+    expect(result.get(3)).toBe(false); // db miss -> false
+
+    // The DB was asked for the misses only, never the cache hit.
+    const whereIn = mockDbRead.customerSubscription.findMany.mock.calls[0][0].where.userId.in;
+    expect([...whereIn].sort()).toEqual([2, 3]);
+
+    // Both misses were backfilled with the resolved boolean + the TTL; the hit was not.
+    expect(mockRedis.packed.set).toHaveBeenCalledTimes(2);
+    expect(mockRedis.packed.set).toHaveBeenCalledWith(keyFor(2), true, { EX: CacheTTL.md });
+    expect(mockRedis.packed.set).toHaveBeenCalledWith(keyFor(3), false, { EX: CacheTTL.md });
+    expect(mockRedis.packed.set).not.toHaveBeenCalledWith(
+      keyFor(1),
+      expect.anything(),
+      expect.anything()
+    );
+  });
+
+  it('fails open to the db when the cache read throws (redis down never 500s)', async () => {
+    mockRedis.packed.mGet.mockRejectedValue(new Error('redis down'));
+    mockDbRead.customerSubscription.findMany.mockResolvedValue([sub(1, 'silver')]);
+    const result = await getValidCreatorMembershipMap([1]);
+    expect(result.get(1)).toBe(true); // correct result despite the cache error
+    expect(mockDbRead.customerSubscription.findMany).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not fail the request when the backfill write throws', async () => {
+    mockRedis.packed.mGet.mockResolvedValue([null]);
+    mockRedis.packed.set.mockRejectedValue(new Error('redis write down'));
+    mockDbRead.customerSubscription.findMany.mockResolvedValue([sub(1, 'gold')]);
+    const result = await getValidCreatorMembershipMap([1]);
+    expect(result.get(1)).toBe(true);
+  });
+
+  it('cache-served result is byte-identical to the uncached db result for a mixed batch', async () => {
+    const rows = [sub(1, 'gold'), sub(2, 'founder'), sub(3, 'free'), sub(4, 'bronze')];
+
+    // Uncached pass (all miss -> db).
+    mockRedis.packed.mGet.mockResolvedValueOnce([null, null, null, null]);
+    mockDbRead.customerSubscription.findMany.mockResolvedValue(rows);
+    const uncached = await getValidCreatorMembershipMap([1, 2, 3, 4]);
+
+    // Fully-cached pass (redis returns exactly what the first pass backfilled).
+    mockDbRead.customerSubscription.findMany.mockClear();
+    mockRedis.packed.mGet.mockResolvedValueOnce([
+      uncached.get(1)!,
+      uncached.get(2)!,
+      uncached.get(3)!,
+      uncached.get(4)!,
+    ]);
+    const cached = await getValidCreatorMembershipMap([1, 2, 3, 4]);
+
+    expect([...cached.entries()].sort()).toEqual([...uncached.entries()].sort());
+    expect(cached.get(1)).toBe(true); // gold -> valid
+    expect(cached.get(2)).toBe(false); // founder -> invalid
+    expect(cached.get(3)).toBe(false); // free -> invalid
+    expect(cached.get(4)).toBe(true); // bronze -> valid
+    expect(mockDbRead.customerSubscription.findMany).not.toHaveBeenCalled(); // fully served from cache
+  });
+});
+
+describe('hasValidCreatorMembershipCached — single-user cache-backed check', () => {
+  it('returns false for a falsy userId without touching redis or the db', async () => {
+    expect(await hasValidCreatorMembershipCached(0)).toBe(false);
+    expect(mockRedis.packed.mGet).not.toHaveBeenCalled();
+    expect(mockDbRead.customerSubscription.findMany).not.toHaveBeenCalled();
+  });
+
+  it('serves a cache hit without the db', async () => {
+    mockRedis.packed.mGet.mockResolvedValue([true]);
+    expect(await hasValidCreatorMembershipCached(7)).toBe(true);
+    expect(mockDbRead.customerSubscription.findMany).not.toHaveBeenCalled();
+  });
+
+  it('falls through to the db on a miss and returns the same boolean the map computes', async () => {
+    mockRedis.packed.mGet.mockResolvedValue([null]);
+    mockDbRead.customerSubscription.findMany.mockResolvedValue([sub(7, 'gold')]);
+    expect(await hasValidCreatorMembershipCached(7)).toBe(true);
+  });
+});
+
+describe('bustCreatorMembershipValidCache', () => {
+  it('deletes the key for a single user', async () => {
+    await bustCreatorMembershipValidCache(5);
+    expect(mockRedis.del).toHaveBeenCalledWith(keyFor(5));
+  });
+
+  it('deletes every key for an array of users', async () => {
+    await bustCreatorMembershipValidCache([5, 6]);
+    expect(mockRedis.del).toHaveBeenCalledWith(keyFor(5));
+    expect(mockRedis.del).toHaveBeenCalledWith(keyFor(6));
+  });
+
+  it('is a no-op for empty / falsy ids', async () => {
+    await bustCreatorMembershipValidCache([]);
+    await bustCreatorMembershipValidCache(0);
+    expect(mockRedis.del).not.toHaveBeenCalled();
+  });
+
+  it('swallows a redis error (best-effort bust never throws)', async () => {
+    mockRedis.del.mockRejectedValue(new Error('redis down'));
+    await expect(bustCreatorMembershipValidCache(5)).resolves.toBeUndefined();
   });
 });

--- a/src/server/services/creator-membership.service.ts
+++ b/src/server/services/creator-membership.service.ts
@@ -1,6 +1,7 @@
+import { CacheTTL, constants } from '~/server/common/constants';
 import { env } from '~/env/server';
-import { constants } from '~/server/common/constants';
 import { dbRead } from '~/server/db/client';
+import { redis, REDIS_KEYS } from '~/server/redis/client';
 import { subscriptionProductMetadataSchema } from '~/server/schema/subscriptions.schema';
 
 /**
@@ -11,18 +12,48 @@ import { subscriptionProductMetadataSchema } from '~/server/schema/subscriptions
  * each user's highest tier (constants.memberships.tierOrder) and treat
  * non-free / non-founder as valid.
  *
- * Kept in this dependency-light module (dbRead + env + constants + the zod schema, no
- * clickhouse/buzz/notification graph) so the donation-goals lookup can gate on it
- * without dragging the heavy creator-program graph into that light, unit-tested path.
+ * Read-through Redis cache (Bucket A: cost/CPU reduction, no behaviour change): the
+ * per-user validity boolean is near-static, so we cache `id -> boolean` and only run
+ * the DB query + the per-subscription Zod parse for the cache MISSES. This removes the
+ * per-request `customerSubscription.findMany` + `subscriptionProductMetadataSchema.parse`
+ * from the hot model-read paths (the measured api-primary CPU / event-loop cost of
+ * #3266's read-time resolution). Fail-open: any Redis error degrades to the uncached
+ * DB path so a Redis stall never 500s a read. Both TRUE and FALSE are cached (the
+ * resolver is a total function over the id — every input gets a definite boolean).
+ *
+ * Kept in this dependency-light module (dbRead + env + constants + the zod schema +
+ * the redis client, no clickhouse/buzz/notification graph) so the donation-goals
+ * lookup can gate on it without dragging the heavy creator-program graph into that
+ * light, unit-tested path.
  */
-export async function getValidCreatorMembershipMap(userIds: number[]) {
-  const unique = [...new Set(userIds.filter((id) => !!id))];
+
+// TTL is a staleness BACKSTOP, not the primary invalidation. All app-driven
+// subscription changes (stripe/paddle webhooks, code redemption, cancel/reinstate,
+// mod tooling) bust the affected user's key immediately via `invalidateSubscriptionCaches`.
+// The TTL only bounds the non-webhook writers (referral grants, renewal/prepaid crons,
+// direct-DB edits) that don't route through that fan-out. Kept short (10 min) so any
+// missed path — including the one leak-direction gap, a referral-granted member who
+// also sets a metric-hide flag — self-heals quickly while still absorbing effectively
+// all hot-path read repetition (a creator's models are read many times per 10 min).
+const MEMBERSHIP_CACHE_TTL = CacheTTL.md;
+
+const getMembershipValidCacheKey = (userId: number) =>
+  `${REDIS_KEYS.CACHES.CREATOR_MEMBERSHIP_VALID}:${userId}` as `${typeof REDIS_KEYS.CACHES.CREATOR_MEMBERSHIP_VALID}:${string}`;
+
+/**
+ * The origin computation: ONE `dbRead.customerSubscription.findMany` over `userIds`,
+ * with a Zod parse per subscription, reducing to each user's highest tier. Returns a
+ * TOTAL map — every input id gets a definite boolean (users with no qualifying
+ * subscription resolve to `false`). This is exactly the pre-cache body, extracted so
+ * the read-through wrapper can call it for the miss set only.
+ */
+async function queryValidCreatorMembership(userIds: number[]): Promise<Map<number, boolean>> {
   const result = new Map<number, boolean>();
-  if (unique.length === 0) return result;
+  if (userIds.length === 0) return result;
 
   const subscriptions = await dbRead.customerSubscription.findMany({
     where: {
-      userId: { in: unique },
+      userId: { in: userIds },
       status: { notIn: ['canceled', 'incomplete_expired', 'past_due', 'unpaid'] },
     },
     select: {
@@ -44,9 +75,88 @@ export async function getValidCreatorMembershipMap(userIds: number[]) {
       highestTierByUser.set(sub.userId, tier);
   }
 
-  for (const id of unique) {
+  for (const id of userIds) {
     const tier = highestTierByUser.get(id);
     result.set(id, !!tier && tier !== 'free' && tier !== 'founder');
   }
   return result;
+}
+
+export async function getValidCreatorMembershipMap(userIds: number[]) {
+  const unique = [...new Set(userIds.filter((id) => !!id))];
+  const result = new Map<number, boolean>();
+  if (unique.length === 0) return result;
+
+  // 1. Read-through: batch-fetch the cached booleans. On any Redis error, treat every
+  //    id as a miss and fall through to the DB (fail-open — a Redis stall must not 500
+  //    a hot read).
+  let cached: (boolean | null)[];
+  try {
+    cached = await redis.packed.mGet<boolean>(unique.map(getMembershipValidCacheKey));
+  } catch {
+    cached = unique.map(() => null);
+  }
+
+  const misses: number[] = [];
+  unique.forEach((id, i) => {
+    const hit = cached[i];
+    // A stored `false` round-trips as `false` (a non-empty packed buffer), distinct
+    // from a `null` cache miss — so negatives are served from cache, not re-queried.
+    if (typeof hit === 'boolean') result.set(id, hit);
+    else misses.push(id);
+  });
+
+  if (misses.length === 0) return result;
+
+  // 2. DB-query + Zod-parse ONLY the misses.
+  const fresh = await queryValidCreatorMembership(misses);
+
+  // 3. Backfill each miss (best-effort; a Redis write stall never fails the request).
+  //    `mSet` is disabled on the packed client, so set per key — misses are rare after
+  //    warmup and small, and the sets run concurrently.
+  await Promise.all(
+    misses.map(async (id) => {
+      const value = fresh.get(id) ?? false;
+      result.set(id, value);
+      try {
+        await redis.packed.set(getMembershipValidCacheKey(id), value, {
+          EX: MEMBERSHIP_CACHE_TTL,
+        });
+      } catch {
+        // Best-effort cache write; the TTL bounds any residual staleness.
+      }
+    })
+  );
+
+  return result;
+}
+
+/**
+ * Single-user, cache-backed membership check for the read-time metric-privacy gate.
+ * Byte-identical (same validity boolean) to `hasValidCreatorMembership`, but served
+ * through the shared read-through cache above. Use ONLY on read-time display/gating
+ * paths (getModel, v1 version response, OG card) — NOT on the shop/creator-program
+ * action gates, which must read live subscription state.
+ */
+export async function hasValidCreatorMembershipCached(userId: number): Promise<boolean> {
+  if (!userId) return false;
+  const map = await getValidCreatorMembershipMap([userId]);
+  return map.get(userId) ?? false;
+}
+
+/**
+ * Bust the cached membership validity for one or more users. Hard delete (not a
+ * staleness reset): the next read re-queries and re-populates the fresh boolean.
+ * Wired into `invalidateSubscriptionCaches`, so every app-driven subscription change
+ * (stripe/paddle webhook, code redemption, cancel/reinstate, mod tooling) busts
+ * immediately. Best-effort — a Redis error never fails the mutation path.
+ */
+export async function bustCreatorMembershipValidCache(userId: number | number[]) {
+  const ids = (Array.isArray(userId) ? userId : [userId]).filter((id) => !!id);
+  if (ids.length === 0) return;
+  try {
+    await Promise.all(ids.map((id) => redis.del(getMembershipValidCacheKey(id))));
+  } catch {
+    // Best-effort bust; the TTL bounds any residual staleness.
+  }
 }

--- a/src/server/services/creator-program.service.ts
+++ b/src/server/services/creator-program.service.ts
@@ -266,8 +266,13 @@ export async function hasValidCreatorMembership(userId: number) {
 
 // Batched read-time membership gate lives in a dependency-light module so the
 // donation-goals lookup can reuse it without pulling this heavy graph. Re-exported
-// here for the existing metric-privacy callers.
-export { getValidCreatorMembershipMap } from '~/server/services/creator-membership.service';
+// here for the existing metric-privacy callers. `hasValidCreatorMembershipCached` is
+// the single-user, cache-backed variant for read-time display gating (byte-identical
+// validity to `hasValidCreatorMembership`, served from the shared read-through cache).
+export {
+  getValidCreatorMembershipMap,
+  hasValidCreatorMembershipCached,
+} from '~/server/services/creator-membership.service';
 
 export async function joinCreatorsProgram(userId: number) {
   const requirements = await getCreatorRequirements(userId);

--- a/src/server/utils/subscription.utils.ts
+++ b/src/server/utils/subscription.utils.ts
@@ -1,5 +1,6 @@
 import { getMultipliersForUser } from '~/server/services/buzz.service';
 import { getUserCapCache } from '~/server/services/creator-program.service';
+import { bustCreatorMembershipValidCache } from '~/server/services/creator-membership.service';
 import { invalidateCivitaiUser } from '~/server/services/orchestrator/civitai';
 import { setVaultFromSubscription } from '~/server/services/vault.service';
 import { refreshSession } from '~/server/auth/session-invalidation';
@@ -14,6 +15,11 @@ export const invalidateSubscriptionCaches = async (userId: number) => {
     ['setVaultFromSubscription', () => setVaultFromSubscription({ userId })],
     ['getUserCapCache.bust', () => getUserCapCache().bust(userId)],
     ['invalidateCivitaiUser', () => invalidateCivitaiUser({ userId })],
+    // Read-time metric-privacy / donation-goal hide gate (#3266): the owner's cached
+    // membership-validity determines whether their hidden metrics stay hidden. A
+    // subscription change here can flip that validity, so bust the key so the next
+    // read re-derives it (immediate, not TTL-bounded).
+    ['bustCreatorMembershipValidCache', () => bustCreatorMembershipValidCache(userId)],
   ] as const;
 
   // Run in parallel but surface individual failures — a silent rejection here


### PR DESCRIPTION
## What

Optimizes the read-time metric-privacy path (#3266) so it does far less synchronous work on hot model-read endpoints, with **byte-identical output** — the same metrics stay hidden for the same viewers. Pure cost optimization; no behaviour change.

The `#3308` `model-metric-privacy-readtime` flag/gate is left in place untouched (it stays the kill-switch; this change makes its ON path cheap).

## Why

The gate resolves per request on hot paths:
- `getValidCreatorMembershipMap` runs a per-request `customerSubscription.findMany` **plus a Zod `subscriptionProductMetadataSchema.parse()` per subscription**, and
- every gated surface resolves per-model / per-version hidden metrics.

Most creators don't hide any metric, so the vast majority of that work produces "nothing hidden".

## The two fixes (they compound)

**FIX 1 — read-through Redis cache for per-user membership validity.**
Membership validity is near-static per user, so `getValidCreatorMembershipMap` now:
- `mGet`s the cached `id -> boolean`,
- DB-queries + Zod-parses **only the misses**, then backfills them,
- **fails open** to the uncached DB path on any Redis error (a Redis stall never 500s a read),
- caches **both `true` and `false`** (the resolver is a total function over the id).

A single-user cache-backed helper `hasValidCreatorMembershipCached` routes the `getModel` / v1 version-response / OG-card paths through the same cache. The shop / creator-program **action gates keep reading live subscription state** (unchanged).

Cache key: `packed:caches:creator-membership-valid:<userId>`. Busted immediately on every app-driven subscription change via `invalidateSubscriptionCaches` (the existing subscription-cache fan-out: Stripe/Paddle webhooks, code redemption, cancel/reinstate, mod tooling). A short TTL (`CacheTTL.md`, 10 min) backstops the non-webhook writers (referral grants, renewal/prepaid crons, direct-DB edits).

**FIX 2 — short-circuit the resolution when nobody hides.**
Before any membership lookup, the single-model read paths check the cheap, already-fetched model/version-meta + owner-user-default hide flags. If nothing is hidden, the membership lookup **and** the resolvers are skipped and raw metrics are returned. (The batch feed / associated-resources / v1-list paths already filter membership candidates this way; FIX 1 caches the residual for them.)

This is provably byte-identical: when no flag is set, the resolvers return `NONE` for **both** membership values, so skipping the lookup cannot change the output.

## Paths covered

`getModelHandler`, `getAssociatedResourcesCardDataHandler`, `getModelsWithImagesAndModelVersions`, the v1 REST paths (`getModelsWithVersions` / `prepareModelVersionResponse`), `api/og.tsx`, and the donation-goal hide cache — all share `getValidCreatorMembershipMap`, so FIX 1 benefits every caller.

## Tests

- Membership cache: hit, miss, batch miss-fill (queries only the misses + backfills), fail-open on Redis error, negative caching, bust, and **cache-served == uncached-DB** for a mixed batch.
- Short-circuit invariant: resolvers return `NONE` for member **and** non-member when no flag is set (so the skip is byte-identical), and membership still matters once any flag is set.

`tsc --noEmit`: no new type errors.