### PR TITLE
fix(referral): bust creator-membership cache on referral grant for immediate consistency

### DIFF
--- a/src/server/services/__tests__/referral.service.test.ts
+++ b/src/server/services/__tests__/referral.service.test.ts
@@ -66,6 +66,9 @@ vi.mock('~/server/services/notification.service', () => ({
 vi.mock('~/server/services/cosmetic.service', () => ({
   grantCosmetics: vi.fn().mockResolvedValue(undefined),
 }));
+vi.mock('~/server/services/creator-membership.service', () => ({
+  bustCreatorMembershipValidCache: vi.fn().mockResolvedValue(undefined),
+}));
 
 import { Prisma } from '@prisma/client';
 import {
@@ -75,8 +78,10 @@ import {
   revokeForChargeback,
   awardMilestones,
   advanceReferralSubscriptions,
+  redeemTokens,
 } from '../referral.service';
 import { createBuzzTransaction } from '~/server/services/buzz.service';
+import { bustCreatorMembershipValidCache } from '~/server/services/creator-membership.service';
 import { ReferralRewardKind, ReferralRewardStatus } from '~/shared/utils/prisma/enums';
 import { TransactionType } from '~/shared/constants/buzz.constants';
 
@@ -111,6 +116,8 @@ const resetAllMocks = () => {
   (mockDbWrite.$queryRaw as any).mockReset();
   (createBuzzTransaction as any).mockReset();
   (createBuzzTransaction as any).mockResolvedValue({ transactionId: 't1' });
+  (bustCreatorMembershipValidCache as any).mockClear();
+  (bustCreatorMembershipValidCache as any).mockResolvedValue(undefined);
 };
 
 beforeEach(resetAllMocks);
@@ -975,5 +982,71 @@ describe('computeLifetimeReferralPoints', () => {
         ReferralRewardStatus.Expired,
       ])
     );
+  });
+});
+
+// -----------------------------------------------------------------------------
+// redeemTokens — busts the read-time creator-membership-validity cache (#3322)
+// so a referral-granted membership takes effect on the next read immediately,
+// instead of waiting out the cache's TTL backstop.
+// -----------------------------------------------------------------------------
+
+describe('redeemTokens — creator-membership cache invalidation', () => {
+  // Wire a successful redemption: enough settled tokens, no pre-existing referral
+  // sub (create path in grantReferralSubscription), and a grantable product for the
+  // offer's tier. offerIndex 0 = { cost: 1, tier: 'bronze', durationDays: 14 }.
+  const wireSuccessfulRedemption = () => {
+    // $queryRaw is called twice inside the tx: (1) redeemTokens' settled-token
+    // SELECT ... FOR UPDATE, then (2) grantReferralSubscription's row-lock SELECT
+    // (its result is ignored). One settled token of amount 1 covers the cost-1 offer.
+    (mockDbWrite.$queryRaw as any)
+      .mockResolvedValueOnce([{ id: 1, tokenAmount: 1 }])
+      .mockResolvedValueOnce([{ id: 'referral:42:1' }]);
+    // No existing referral subscription -> grantReferralSubscription create branch.
+    mockDbWrite.customerSubscription.findUnique.mockResolvedValue(null);
+    mockDbWrite.customerSubscription.create.mockResolvedValue({});
+    // findReferralProductForTier reads dbRead.product.findMany.
+    mockDbRead.product.findMany.mockResolvedValue([
+      {
+        id: 'prod_bronze',
+        defaultPriceId: 'price_bronze',
+        metadata: { tier: 'bronze', referralGrantable: true },
+      },
+    ]);
+    mockDbWrite.referralReward.updateMany.mockResolvedValue({ count: 1 });
+    mockDbWrite.referralReward.update.mockResolvedValue({});
+    mockDbWrite.referralRedemption.create.mockResolvedValue({
+      id: 99,
+      createdAt: new Date(),
+      tokensSpent: 1,
+      rewardType: 'MembershipPerks',
+      metadata: {},
+    });
+  };
+
+  it('busts the membership-validity cache once for the granted user after a successful redemption', async () => {
+    wireSuccessfulRedemption();
+
+    const result = await redeemTokens({ userId: 42, offerIndex: 0 });
+
+    expect(result.id).toBe(99);
+    // The grant committed (create ran); the cache was busted for exactly the
+    // granted user, exactly once.
+    expect(mockDbWrite.customerSubscription.create).toHaveBeenCalledTimes(1);
+    expect(bustCreatorMembershipValidCache).toHaveBeenCalledTimes(1);
+    expect(bustCreatorMembershipValidCache).toHaveBeenCalledWith(42);
+  });
+
+  it('does not bust the cache when the redemption transaction fails', async () => {
+    wireSuccessfulRedemption();
+    // Not enough settled tokens for the cost-1 offer -> redeemTokens throws inside
+    // the tx (rolls back), so no grant committed and no cache bust should fire.
+    (mockDbWrite.$queryRaw as any).mockReset();
+    (mockDbWrite.$queryRaw as any).mockResolvedValueOnce([]);
+
+    await expect(redeemTokens({ userId: 42, offerIndex: 0 })).rejects.toThrow(
+      /Insufficient tokens/
+    );
+    expect(bustCreatorMembershipValidCache).not.toHaveBeenCalled();
   });
 });

--- a/src/server/services/referral.service.ts
+++ b/src/server/services/referral.service.ts
@@ -7,7 +7,7 @@ import { SignalMessages } from '~/server/common/enums';
 import { signalClient } from '~/utils/signal-client';
 import { TransactionType } from '~/shared/constants/buzz.constants';
 import { createBuzzTransaction } from '~/server/services/buzz.service';
-import { bustCreatorMembershipValidCache } from '~/server/services/creator-membership.service';
+import { invalidateSubscriptionCaches } from '~/server/utils/subscription.utils';
 import type { ProductTier } from '~/server/schema/subscriptions.schema';
 import { logToAxiom } from '~/server/logging/client';
 
@@ -1238,14 +1238,13 @@ export async function redeemTokens(params: { userId: number; offerIndex: number 
   });
 
   // The referral grant just flipped this user's creator-membership validity: they
-  // now hold a valid, non-founder tier. Bust the read-time membership-validity cache
-  // (#3322) so any hidden-metric flags they've set take effect on the next read
-  // immediately, matching how stripe/paddle activation invalidates it via
-  // invalidateSubscriptionCaches — rather than waiting out the cache's short TTL
-  // backstop. Done AFTER the transaction commits (once, for the granted user) so the
-  // re-query reads a durable grant. Fail-open: the helper swallows Redis errors, so a
-  // bust failure can never surface to the caller after the grant has committed.
-  await bustCreatorMembershipValidCache(userId);
+  // now hold a valid, non-founder tier. Invalidate subscription caches so any
+  // hidden-metric flags they've set take effect on the next read immediately,
+  // matching how stripe/paddle activation invalidates them. Done AFTER the
+  // transaction commits (once, for the granted user) so the re-query reads a
+  // durable grant. Fail-open: the helper swallows errors so a bust failure can
+  // never surface to the caller after the grant has committed.
+  await invalidateSubscriptionCaches(userId);
 
   emitSignal(userId, SignalMessages.ReferralTierGranted, {
     redemptionId: redemption.id,

--- a/src/server/services/referral.service.ts
+++ b/src/server/services/referral.service.ts
@@ -7,6 +7,7 @@ import { SignalMessages } from '~/server/common/enums';
 import { signalClient } from '~/utils/signal-client';
 import { TransactionType } from '~/shared/constants/buzz.constants';
 import { createBuzzTransaction } from '~/server/services/buzz.service';
+import { bustCreatorMembershipValidCache } from '~/server/services/creator-membership.service';
 import type { ProductTier } from '~/server/schema/subscriptions.schema';
 import { logToAxiom } from '~/server/logging/client';
 
@@ -1235,6 +1236,16 @@ export async function redeemTokens(params: { userId: number; offerIndex: number 
       select: { id: true, createdAt: true, tokensSpent: true, rewardType: true, metadata: true },
     });
   });
+
+  // The referral grant just flipped this user's creator-membership validity: they
+  // now hold a valid, non-founder tier. Bust the read-time membership-validity cache
+  // (#3322) so any hidden-metric flags they've set take effect on the next read
+  // immediately, matching how stripe/paddle activation invalidates it via
+  // invalidateSubscriptionCaches — rather than waiting out the cache's short TTL
+  // backstop. Done AFTER the transaction commits (once, for the granted user) so the
+  // re-query reads a durable grant. Fail-open: the helper swallows Redis errors, so a
+  // bust failure can never surface to the caller after the grant has committed.
+  await bustCreatorMembershipValidCache(userId);
 
   emitSignal(userId, SignalMessages.ReferralTierGranted, {
     redemptionId: redemption.id,


### PR DESCRIPTION
The read-time creator-membership-validity cache (#3322) is invalidated on
stripe/paddle activation and mod tooling via invalidateSubscriptionCaches, but
referral grants write the subscription directly and bypass that fan-out. A user
who gains a membership via a referral redemption and has metric-hide flags set
therefore keeps showing metrics until the cache's short TTL backstop expires.

Bust the granted user's membership-validity key once, after redeemTokens'
transaction commits, so newly-acquired hiding takes effect on the next read
immediately — matching the stripe/paddle path. Behaviour-neutral otherwise: no
change to the grant logic, the cache, or the TTL. Fail-open (the helper swallows
Redis errors, so a bust failure never surfaces after the grant has committed).

Test: redeemTokens busts the membership-valid cache once for the granted user on
a successful redemption, and does not bust when the transaction rolls back.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
