### PR TITLE
fix(build): use challenge.createdById (BaseChallenge scalar) — unblock releases

### DIFF
--- a/src/components/HiddenPreferences/useApplyHiddenPreferences.ts
+++ b/src/components/HiddenPreferences/useApplyHiddenPreferences.ts
@@ -711,9 +711,9 @@ export function filterPreferences<
       return { items: comics, hidden };
     case 'challenges':
       const challenges = value.filter((challenge) => {
-        // createdBy is the real creator now (the judge is a separate field), so this correctly
+        // createdById is the real creator now (the judge is a separate field), so this correctly
         // exempts the owner from their own challenge's browsing-level hide.
-        const isOwner = challenge.createdBy.id === currentUser?.id;
+        const isOwner = challenge.createdById === currentUser?.id;
         if (isOwner || isModerator) return true;
 
         // Content allowed by the challenge must intersect the user's browsing level


### PR DESCRIPTION
#3316 refactored `BaseChallenge` to a scalar `createdById` but left the owner check in `useApplyHiddenPreferences.ts:716` using `challenge.createdBy.id` → **TS2551 build breaker on `main`** (blocks `next build`, so no releases build). One-line fix: use the scalar `createdById`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)