### PR TITLE
fix(jobs): job-queue cleanup casts to non-existent enum ModelVersionStatus

### DIFF
--- a/src/server/jobs/job-queue.ts
+++ b/src/server/jobs/job-queue.ts
@@ -265,7 +265,7 @@ const handleJobQueueCleanIfEmpty = createJob(
               JOIN "Model" m ON m.id = mv."modelId"
               WHERE mv.id = p."modelVersionId"
                 AND p."userId" = m."userId"
-                AND mv.status = 'Published'::"ModelVersionStatus"
+                AND mv.status = 'Published'::"ModelStatus"
             )
         `;
       });


### PR DESCRIPTION
The `CleanIfEmpty` job-queue maintenance job builds a raw-SQL predicate that casts `'Published'` to a Postgres enum type `"ModelVersionStatus"`. That enum type does not exist in the database (there is no `enum ModelVersionStatus` in the Prisma schema and no migration creating it), so at runtime the query fails hard with:

```
42704: type "ModelVersionStatus" does not exist
```

Because this predicate runs inside the job-queue cleanup, the job errored on **every** run. Found via runtime error logs.

## Fix

`ModelVersion.status` is typed `ModelStatus` in the Prisma schema (the enum shared with `Model.status`), and `ModelStatus` includes a `Published` value. The bug was a bad cast to a non-existent enum name; the fix casts to the correct enum:

```diff
-                AND mv.status = 'Published'::"ModelVersionStatus"
+                AND mv.status = 'Published'::"ModelStatus"
```

This was the only reference to `ModelVersionStatus` in the repository.

🤖 Generated with [Claude Code](https://claude.com/claude-code)