### PR TITLE
fix(jobs): cast to ModelStatus in clean-if-empty post delete

### DIFF
--- a/src/server/jobs/job-queue.ts
+++ b/src/server/jobs/job-queue.ts
@@ -265,7 +265,7 @@ const handleJobQueueCleanIfEmpty = createJob(
               JOIN "Model" m ON m.id = mv."modelId"
               WHERE mv.id = p."modelVersionId"
                 AND p."userId" = m."userId"
-                AND mv.status = 'Published'::"ModelVersionStatus"
+                AND mv.status = 'Published'::"ModelStatus"
             )
         `;
       });


### PR DESCRIPTION
## Problem

`job-queue-clean-if-empty` has been aborting on every hourly run since the published-anchor guard landed:

```
PrismaClientKnownRequestError: Raw query failed. Code: `42704`.
Message: `ERROR: type "ModelVersionStatus" does not exist`
```

`ModelVersion.status` is the `ModelStatus` enum (`prisma/schema.prisma:1011`) — there is no `ModelVersionStatus` type in Postgres. The `$executeRaw` threw before the terminal `jobQueue.deleteMany`, so nothing drained.

## Fix

One line in `src/server/jobs/job-queue.ts`:

```diff
-                AND mv.status = 'Published'::"ModelVersionStatus"
+                AND mv.status = 'Published'::"ModelStatus"
```

Only occurrence of the bad name in the repo.

## Verification

`SELECT 'Published'::"ModelStatus"` returns `Published`, `pg_typeof` = `"ModelStatus"`.

Ran the DELETE's predicate rewritten as a read-only SELECT against the prod replica, over 2000 real backlog ids from `JobQueue`:

| metric | count |
| --- | --- |
| queued post ids | 2000 |
| posts still existing | 1214 |
| empty posts | 579 |
| preserved published anchors | 10 |
| would delete | 569 |

The anchor guard fires — 10 empty posts belonging to published versions are correctly preserved rather than deleted (which would cascade to auto-unpublishing the version).

## Post-merge note

Backlog is 29,150 `CleanIfEmpty` Post rows, oldest `2026-07-17`. The first run after deploy sweeps it in 30 chunks of 1000 at concurrency 5 — expect one heavy run, then normal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)