### PR TITLE
perf(creator-controls): cache read-time metric-privacy default flags (kill the settings-blob longtask)

### DIFF
--- a/claudedocs/rca-readtime-metric-privacy-cpu-2026-07-24.md
+++ b/claudedocs/rca-readtime-metric-privacy-cpu-2026-07-24.md
@@ -1,0 +1,122 @@
+# RCA — read-time model-metric-privacy CPU regression (`model-metric-privacy-readtime`)
+
+Date: 2026-07-24
+Author: perf investigation (static source + measured A/B evidence)
+Repo: `civitai/civitai` @ `origin/main` (f5fe73fd5f)
+Branch: `zach/readtime-metric-privacy-cpu-fix`
+
+## Measured evidence (ground truth)
+- `civitai-dp-prod-api-primary`: per-request server CPU ~+35% and event-loop **longtask**
+  time ~+71% higher with the Flipt flag `model-metric-privacy-readtime` **ON** vs **OFF**,
+  via a clean load-normalized bracketed A/B (ON→OFF→ON).
+- The flag gates code introduced by **#3266** (creator-controls hide-metrics).
+- Fix **#3322** (`c3d924fc2`, live) cached creator-membership validity but delivered
+  ~zero CPU benefit — the ON/OFF gap is unchanged.
+- Longtask ⇒ the cost is **frequent synchronous event-loop blocking on a hot read path**.
+
+## Root cause (1 paragraph)
+The dominant flag-gated cost is **not** the membership lookup #3322 cached — it is an
+**unconditional, uncached `dbRead.user.findMany({ select: { settings } })` that fetches and
+synchronously deserializes every owner's FULL `settings` JSON blob, once per request, over
+every owner in the response**, on the highest-volume gated read path (the browse feed
+`model.getAll` → `getModelsRaw`). See `src/server/services/model.service.ts:1428-1447`
+(the `if (metricPrivacyEnabled) { … dbRead.user.findMany … }` block). The same anti-pattern
+is duplicated in the v1 models list (`model.service.ts:3350-3359`) and the associated-models
+controller (`model.controller.ts:1637-1647`). `User.settings` is a large accumulating JSON
+column (dismissed alerts, tour state, hidden tags, feature prefs, …); pulling it for up to
+~100 feed owners on every browse request and JSON-deserializing all of it synchronously to
+read **only three booleans** (`hideModelBuzz/Downloads/Generations`) is the synchronous
+longtask. Critically, the codebase already has a batched, Redis-backed, bust-wired
+`userSettingsCache` (`user.service.ts:2511`, 4h TTL) — these read-time paths **bypass it** with
+a raw per-request DB read. This is a net-new query #3266 added and #3322 never removed.
+
+## Why #3322 missed it (the key deliverable)
+`#3322` optimized `getValidCreatorMembershipMap` (Redis-cached the `id→isValidMember` boolean,
+skipping the `customerSubscription.findMany` + per-subscription
+`subscriptionProductMetadataSchema.parse` on hits). But on the **feed** path the membership
+lookup is only called for `membershipCandidates` — owners who **actually hide something**
+(`model.service.ts:1440-1447`). In the common case **nobody hides any metric**, so
+`membershipCandidates` is **empty**, and `getValidCreatorMembershipMap([])` returns
+immediately at `creator-membership.service.ts:88` without touching Redis or the DB. So the
+thing #3322 made cheaper **is not even invoked in the hot (nothing-hidden) case** — it could
+not possibly shrink that cost. Meanwhile the cost that IS paid on every request — the
+`dbRead.user.findMany({ settings })` at `model.service.ts:1431` — was left entirely in place.
+It is unconditional (needed to evaluate the very short-circuit that decides whether anyone
+hides), so #3322's "skip when nothing hidden" FIX 2 (added only to the single-model `getModel`
+path, `model.controller.ts:307-324`) cannot elide it on the feed: you must read settings to
+know if a default hides. #3322 fixed the branch that the hot path skips and left the branch the
+hot path always runs.
+
+### Ruled out (with code)
+- **Membership Zod parse per entity** (hint a): only runs on cache MISS inside
+  `queryValidCreatorMembership` (`creator-membership.service.ts:71`), and only for hide-owners;
+  not on the common hot path. Not the delta.
+- **Per-entity single-id membership calls** (hint b): the feed/v1/associated paths batch
+  membership once (`getValidCreatorMembershipMap([...candidates])`); no per-entity mGet.
+- **Membership cache never hitting** (hint c): irrelevant to the dominant case — membership is
+  not called when nothing is hidden. Even a perfect hit rate wouldn't reduce common-case cost.
+- **v1 model-versions `[id]` / OG card**: these call `hasValidCreatorMembershipCached` but are
+  **NOT flag-gated** (no `metricPrivacyEnabled` reference in `src/pages/api/og.tsx` or
+  `src/pages/api/v1/model-versions/[id].ts`), so they cannot contribute to the ON/OFF A/B delta.
+- **Pure resolvers** (`resolveModel/VersionHiddenMetrics`, `model-metric-privacy.ts`): allocation-
+  light boolean ORs; negligible per entity.
+
+## Exact hot cost & fan-out
+| Path | file:line | Gated by flag? | Per-request fan-out | Cost |
+|---|---|---|---|---|
+| Browse feed `model.getAll` → `getModelsRaw` | `model.service.ts:1428-1447` | **Yes** | 1 DB query + deserialize of full `settings` for **all N feed owners** (N up to ~100) | **Dominant** — highest volume on api-primary |
+| v1 models list `getModelsWithVersions` | `model.service.ts:3350-3359` | No (always-on) | same, all owners in page | always-on baseline cost |
+| associated models | `model.controller.ts:1637-1647` | Yes | same, all associated owners | lower volume |
+| single `getModel` | `model.controller.ts:307-324` | Yes | 1 owner `findUnique`, short-circuited | small — leave as-is |
+
+The synchronous longtask = JSON deserialization of N large `settings` blobs per request,
+attributed to the feed because it is the hottest gated caller.
+
+## Fix design (minimal, deterministic, byte-identical privacy)
+Add a tiny read-through per-user cache of the **three derived hide-default booleans only**,
+mirroring the proven `getValidCreatorMembershipMap` pattern in the same dependency-light module:
+
+- `getUserMetricPrivacyDefaultsMap(userIds): Promise<Map<number, UserMetricPrivacyDefaults>>`
+  in `creator-membership.service.ts` — packed Redis `mGet` of
+  `packed:caches:user-metric-privacy-defaults:<id>`; DB-query the **misses only**, deriving
+  `{ hideModelBuzz, hideModelDownloads, hideModelGenerations }` from `settings`; backfill; fail
+  open to the uncached DB path on any Redis error (a Redis stall must never 500 a read).
+  Value stored is a **tiny 3-boolean object**, shaped exactly like the slice of `settings` the
+  resolvers read.
+- Bust wired into `setUserSetting` (`user.service.ts:2595`, next to `userSettingsCache.bust`)
+  via `bustUserMetricPrivacyDefaultsCache`; `CacheTTL.md` (10 min) backstops any missed writer.
+- Swap the three raw `dbRead.user.findMany({ select:{settings} })` + map constructions
+  (feed / v1 / associated) to `await getUserMetricPrivacyDefaultsMap(ownerIds)`. The returned
+  map's values feed the **unchanged** downstream `getUserMetricPrivacyDefaults(...)` /
+  `resolveModel/VersionHiddenMetrics({ userSettings })` calls — those read only the three
+  `hideModel*` keys, so output is **byte-identical**.
+
+**Byte-identical privacy guarantee:** the resolvers still AND the stored hide flags with live
+membership; the defaults cache only replaces "how we read the 3 booleans off the owner", not
+"whether a metric is hidden". A default is `!!settings.hideModelX` before and after. The
+membership gate (which enforces lapse→revert-to-visible) is untouched. Worst-case staleness is a
+≤10-min-late reflection of a user toggling their own default — the same staleness class as the
+existing `userSettingsCache` and membership cache, and it can only make the cache lag a user's
+OWN setting change; it can never expose another creator's metric that membership would hide.
+
+## Verification plan
+1. **Compile:** `NODE_OPTIONS=--max_old_space_size=8192 npx tsc --noEmit` (default heap OOMs).
+2. **Unit tests:** cache hit/miss/batch-backfill/fail-open/bust + byte-identical-vs-raw-settings
+   (a stored 3-bool object resolves the same hidden metrics as reading full settings), and the
+   short-circuit still fires (nobody hides ⇒ empty membership candidates).
+3. **Prod A/B (authoritative):** re-run the same bracketed `model-metric-privacy-readtime`
+   ON→OFF→ON on api-primary AFTER this ships; the ON cost should now drop toward the OFF
+   baseline. Metrics: per-request CPU (Pyroscope / cpuprofile) and the event-loop **longtask**
+   metric (the +71% signal). Success = the ON/OFF gap collapses (longtask ON ≈ OFF).
+4. **Cache-hit confirmation:** watch the new key populate (`packed:caches:user-metric-privacy-
+   defaults:*`) and DB `user` findMany volume from these paths drop after warmup; confirm no
+   change in emitted hidden-metric values on a hide-owner model (spot-check a known CP member's
+   card + version stats look identical pre/post).
+
+## Residual uncertainty (honest)
+Static analysis proves the feed unconditionally does an uncached full-`settings` fetch per
+request that #3322 left in place and that the common hot path never calls membership — so this
+IS a real, dominant, always-run synchronous cost the A/B flag toggles. What static reading
+cannot prove is the exact split between DB latency and deserialize-CPU within the +35%/+71%.
+The fix removes both (cache hit ⇒ no DB query; tiny object ⇒ no large-blob deserialize), and the
+prod A/B in step 3 is the authoritative confirmation.

--- a/packages/civitai-redis/src/client.ts
+++ b/packages/civitai-redis/src/client.ts
@@ -2097,6 +2097,14 @@ export const REDIS_KEYS = {
     // change via `invalidateSubscriptionCaches`; TTL backstops the non-webhook paths.
     // See `getValidCreatorMembershipMap` in creator-membership.service.
     CREATOR_MEMBERSHIP_VALID: 'packed:caches:creator-membership-valid',
+    // Per-user `id -> { hideModelBuzz, hideModelDownloads, hideModelGenerations }` — the
+    // three model-metric-privacy DEFAULT flags read off `User.settings` at read time
+    // (#3266). A tiny derived slice so the hot model-read paths (feed / v1 list /
+    // associated) never fetch + synchronously deserialize the FULL `settings` blob per
+    // owner per request just to read three booleans. Busted on any settings write via
+    // `setUserSetting`; `CacheTTL.md` backstops any other writer. See
+    // `getUserMetricPrivacyDefaultsMap` in creator-membership.service.
+    USER_METRIC_PRIVACY_DEFAULTS: 'packed:caches:user-metric-privacy-defaults',
   },
   RESEARCH: {
     RATINGS_COUNT: 'research:ratings-count',

--- a/src/server/controllers/model.controller.ts
+++ b/src/server/controllers/model.controller.ts
@@ -15,6 +15,7 @@ import { eventEngine } from '~/server/events';
 import {
   getValidCreatorMembershipMap,
   hasValidCreatorMembershipCached,
+  getUserMetricPrivacyDefaultsMap,
 } from '~/server/services/creator-program.service';
 import {
   anyMetricHidden,
@@ -1637,15 +1638,9 @@ export const getAssociatedResourcesCardDataHandler = async ({
     let assocMembershipMap = new Map<number, boolean>();
     if (metricPrivacyEnabled) {
       const assocOwnerIds = [...new Set(models.map((m) => m.user.id))];
-      const assocOwnerSettings = assocOwnerIds.length
-        ? await dbRead.user.findMany({
-            where: { id: { in: assocOwnerIds } },
-            select: { id: true, settings: true },
-          })
-        : [];
-      assocOwnerSettingsMap = new Map<number, unknown>(
-        assocOwnerSettings.map((o) => [o.id, o.settings])
-      );
+      // Cache-backed per-owner metric-privacy DEFAULT flags — see the feed path in
+      // getModelsRaw; avoids deserializing every owner's full `settings` blob per request.
+      assocOwnerSettingsMap = await getUserMetricPrivacyDefaultsMap(assocOwnerIds);
       const assocMembershipCandidates = new Set<number>();
       for (const m of models) {
         const ownerId = m.user.id;

--- a/src/server/services/__tests__/creator-membership.service.test.ts
+++ b/src/server/services/__tests__/creator-membership.service.test.ts
@@ -14,7 +14,10 @@ import { CacheTTL } from '~/server/common/constants';
  */
 
 const { mockDbRead, mockRedis } = vi.hoisted(() => ({
-  mockDbRead: { customerSubscription: { findMany: vi.fn() } },
+  mockDbRead: {
+    customerSubscription: { findMany: vi.fn() },
+    user: { findMany: vi.fn() },
+  },
   mockRedis: {
     packed: { mGet: vi.fn(), set: vi.fn() },
     del: vi.fn(),
@@ -24,16 +27,25 @@ const { mockDbRead, mockRedis } = vi.hoisted(() => ({
 vi.mock('~/server/db/client', () => ({ dbRead: mockDbRead }));
 vi.mock('~/server/redis/client', () => ({
   redis: mockRedis,
-  REDIS_KEYS: { CACHES: { CREATOR_MEMBERSHIP_VALID: 'packed:caches:creator-membership-valid' } },
+  REDIS_KEYS: {
+    CACHES: {
+      CREATOR_MEMBERSHIP_VALID: 'packed:caches:creator-membership-valid',
+      USER_METRIC_PRIVACY_DEFAULTS: 'packed:caches:user-metric-privacy-defaults',
+    },
+  },
 }));
 
 import {
   bustCreatorMembershipValidCache,
+  bustUserMetricPrivacyDefaultsCache,
+  getUserMetricPrivacyDefaultsMap,
   getValidCreatorMembershipMap,
   hasValidCreatorMembershipCached,
 } from '~/server/services/creator-membership.service';
 
 const keyFor = (id: number) => `packed:caches:creator-membership-valid:${id}`;
+const defaultsKeyFor = (id: number) => `packed:caches:user-metric-privacy-defaults:${id}`;
+const ALL_FALSE = { hideModelBuzz: false, hideModelDownloads: false, hideModelGenerations: false };
 
 type SubRow = {
   userId: number;
@@ -225,5 +237,173 @@ describe('bustCreatorMembershipValidCache', () => {
   it('swallows a redis error (best-effort bust never throws)', async () => {
     mockRedis.del.mockRejectedValue(new Error('redis down'));
     await expect(bustCreatorMembershipValidCache(5)).resolves.toBeUndefined();
+  });
+});
+
+/**
+ * `getUserMetricPrivacyDefaultsMap` replaces the per-request full-`settings` findMany
+ * the read-time paths (feed / v1 list / associated) ran over every owner just to read
+ * three booleans — the measured api-primary longtask. It must return the SAME three
+ * `hideModel*` booleans as reading them straight off `settings` (byte-identical), and
+ * it must never over-hide: an unset flag is `false`.
+ */
+describe('getUserMetricPrivacyDefaultsMap — derived read-through cache', () => {
+  it('returns an empty map (touching neither redis nor db) for empty input', async () => {
+    const result = await getUserMetricPrivacyDefaultsMap([]);
+    expect(result.size).toBe(0);
+    expect(mockRedis.packed.mGet).not.toHaveBeenCalled();
+    expect(mockDbRead.user.findMany).not.toHaveBeenCalled();
+  });
+
+  it('derives only the three hideModel* flags off settings (ignores unrelated keys)', async () => {
+    mockDbRead.user.findMany.mockResolvedValue([
+      {
+        id: 1,
+        settings: {
+          hideModelBuzz: true,
+          hideModelDownloads: false,
+          hideModelGenerations: true,
+          // Unrelated settings that must NOT bloat the cached value:
+          dismissedAlerts: ['a', 'b', 'c'],
+          hideDonationGoals: true,
+          tourState: { seen: true },
+        },
+      },
+    ]);
+    const result = await getUserMetricPrivacyDefaultsMap([1]);
+    expect(result.get(1)).toEqual({
+      hideModelBuzz: true,
+      hideModelDownloads: false,
+      hideModelGenerations: true,
+    });
+    // Backfilled with exactly the tiny triple + TTL.
+    expect(mockRedis.packed.set).toHaveBeenCalledWith(
+      defaultsKeyFor(1),
+      { hideModelBuzz: true, hideModelDownloads: false, hideModelGenerations: true },
+      { EX: CacheTTL.md }
+    );
+  });
+
+  it('returns all-false for a user with no settings / no flags (never over-hides)', async () => {
+    mockDbRead.user.findMany.mockResolvedValue([
+      { id: 1, settings: null },
+      { id: 2, settings: {} },
+    ]);
+    const result = await getUserMetricPrivacyDefaultsMap([1, 2, 3]); // 3 absent from db
+    expect(result.get(1)).toEqual(ALL_FALSE);
+    expect(result.get(2)).toEqual(ALL_FALSE);
+    expect(result.get(3)).toEqual(ALL_FALSE); // total function: absent -> all false
+  });
+
+  it('serves a cached triple from redis without querying the db', async () => {
+    mockRedis.packed.mGet.mockResolvedValue([
+      { hideModelBuzz: true, hideModelDownloads: false, hideModelGenerations: false },
+    ]);
+    const result = await getUserMetricPrivacyDefaultsMap([1]);
+    expect(result.get(1)).toEqual({
+      hideModelBuzz: true,
+      hideModelDownloads: false,
+      hideModelGenerations: false,
+    });
+    expect(mockDbRead.user.findMany).not.toHaveBeenCalled();
+    expect(mockRedis.packed.set).not.toHaveBeenCalled();
+  });
+
+  it('batch miss-fill: queries ONLY the missing ids and backfills them', async () => {
+    mockRedis.packed.mGet.mockResolvedValue([
+      { hideModelBuzz: true, hideModelDownloads: false, hideModelGenerations: false }, // id 1 cached
+      null, // id 2 miss
+      null, // id 3 miss
+    ]);
+    mockDbRead.user.findMany.mockResolvedValue([
+      { id: 2, settings: { hideModelDownloads: true } },
+      // id 3 has no row -> all false
+    ]);
+    const result = await getUserMetricPrivacyDefaultsMap([1, 2, 3]);
+    expect(result.get(1)?.hideModelBuzz).toBe(true);
+    expect(result.get(2)).toEqual({
+      hideModelBuzz: false,
+      hideModelDownloads: true,
+      hideModelGenerations: false,
+    });
+    expect(result.get(3)).toEqual(ALL_FALSE);
+
+    const whereIn = mockDbRead.user.findMany.mock.calls[0][0].where.id.in;
+    expect([...whereIn].sort()).toEqual([2, 3]);
+    // Only the two misses were backfilled.
+    expect(mockRedis.packed.set).toHaveBeenCalledTimes(2);
+    expect(mockRedis.packed.set).not.toHaveBeenCalledWith(
+      defaultsKeyFor(1),
+      expect.anything(),
+      expect.anything()
+    );
+  });
+
+  it('fails open to the db when the cache read throws (redis down never 500s)', async () => {
+    mockRedis.packed.mGet.mockRejectedValue(new Error('redis down'));
+    mockDbRead.user.findMany.mockResolvedValue([{ id: 1, settings: { hideModelBuzz: true } }]);
+    const result = await getUserMetricPrivacyDefaultsMap([1]);
+    expect(result.get(1)?.hideModelBuzz).toBe(true);
+    expect(mockDbRead.user.findMany).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not fail the request when the backfill write throws', async () => {
+    mockRedis.packed.mGet.mockResolvedValue([null]);
+    mockRedis.packed.set.mockRejectedValue(new Error('redis write down'));
+    mockDbRead.user.findMany.mockResolvedValue([{ id: 1, settings: { hideModelGenerations: true } }]);
+    const result = await getUserMetricPrivacyDefaultsMap([1]);
+    expect(result.get(1)?.hideModelGenerations).toBe(true);
+  });
+
+  it('cache-served result is byte-identical to the uncached db result for a mixed batch', async () => {
+    const rows = [
+      { id: 1, settings: { hideModelBuzz: true } },
+      { id: 2, settings: {} },
+      { id: 3, settings: { hideModelDownloads: true, hideModelGenerations: true } },
+    ];
+    mockRedis.packed.mGet.mockResolvedValueOnce([null, null, null]);
+    mockDbRead.user.findMany.mockResolvedValue(rows);
+    const uncached = await getUserMetricPrivacyDefaultsMap([1, 2, 3]);
+
+    mockDbRead.user.findMany.mockClear();
+    mockRedis.packed.mGet.mockResolvedValueOnce([
+      uncached.get(1)!,
+      uncached.get(2)!,
+      uncached.get(3)!,
+    ]);
+    const cached = await getUserMetricPrivacyDefaultsMap([1, 2, 3]);
+
+    expect([...cached.entries()].sort()).toEqual([...uncached.entries()].sort());
+    expect(cached.get(3)).toEqual({
+      hideModelBuzz: false,
+      hideModelDownloads: true,
+      hideModelGenerations: true,
+    });
+    expect(mockDbRead.user.findMany).not.toHaveBeenCalled(); // fully served from cache
+  });
+
+  it('dedupes ids before the db query', async () => {
+    mockDbRead.user.findMany.mockResolvedValue([{ id: 1, settings: {} }]);
+    await getUserMetricPrivacyDefaultsMap([1, 1, 1]);
+    const whereIn = mockDbRead.user.findMany.mock.calls[0][0].where.id.in;
+    expect([...whereIn]).toEqual([1]);
+  });
+});
+
+describe('bustUserMetricPrivacyDefaultsCache', () => {
+  it('deletes the defaults key for a single user and an array of users', async () => {
+    await bustUserMetricPrivacyDefaultsCache(5);
+    expect(mockRedis.del).toHaveBeenCalledWith(defaultsKeyFor(5));
+    await bustUserMetricPrivacyDefaultsCache([6, 7]);
+    expect(mockRedis.del).toHaveBeenCalledWith(defaultsKeyFor(6));
+    expect(mockRedis.del).toHaveBeenCalledWith(defaultsKeyFor(7));
+  });
+
+  it('is a no-op for empty / falsy ids and swallows a redis error', async () => {
+    await bustUserMetricPrivacyDefaultsCache([]);
+    await bustUserMetricPrivacyDefaultsCache(0);
+    expect(mockRedis.del).not.toHaveBeenCalled();
+    mockRedis.del.mockRejectedValue(new Error('redis down'));
+    await expect(bustUserMetricPrivacyDefaultsCache(5)).resolves.toBeUndefined();
   });
 });

--- a/src/server/services/creator-membership.service.ts
+++ b/src/server/services/creator-membership.service.ts
@@ -145,6 +145,121 @@ export async function hasValidCreatorMembershipCached(userId: number): Promise<b
 }
 
 /**
+ * The three model-metric-privacy DEFAULT flags a user sets on their `User.settings`
+ * JSON. This is the ONLY slice of `settings` the read-time resolvers
+ * (`getUserMetricPrivacyDefaults` -> `resolveModel/VersionHiddenMetrics`) read, so it
+ * is byte-identical to feed them this tiny object instead of the full settings blob.
+ */
+export type UserMetricPrivacyDefaults = {
+  hideModelBuzz?: boolean;
+  hideModelDownloads?: boolean;
+  hideModelGenerations?: boolean;
+};
+
+const getUserMetricPrivacyDefaultsCacheKey = (userId: number) =>
+  `${REDIS_KEYS.CACHES.USER_METRIC_PRIVACY_DEFAULTS}:${userId}` as `${typeof REDIS_KEYS.CACHES.USER_METRIC_PRIVACY_DEFAULTS}:${string}`;
+
+/**
+ * Origin computation: ONE `dbRead.user.findMany` over `userIds`, reducing each user's
+ * `settings` to the three `hideModel*` booleans. Returns a TOTAL map — every input id
+ * gets a definite triple (a user with no settings / no flags resolves to all-false).
+ */
+async function queryUserMetricPrivacyDefaults(
+  userIds: number[]
+): Promise<Map<number, UserMetricPrivacyDefaults>> {
+  const result = new Map<number, UserMetricPrivacyDefaults>();
+  if (userIds.length === 0) return result;
+
+  const rows = await dbRead.user.findMany({
+    where: { id: { in: userIds } },
+    select: { id: true, settings: true },
+  });
+  const settingsById = new Map<number, unknown>(rows.map((r) => [r.id, r.settings]));
+
+  for (const id of userIds) {
+    const s = (settingsById.get(id) ?? {}) as UserMetricPrivacyDefaults;
+    result.set(id, {
+      hideModelBuzz: !!s.hideModelBuzz,
+      hideModelDownloads: !!s.hideModelDownloads,
+      hideModelGenerations: !!s.hideModelGenerations,
+    });
+  }
+  return result;
+}
+
+/**
+ * Batched, cache-backed read of the per-user model-metric-privacy DEFAULT flags for the
+ * read-time gate (feed / v1 list / associated-models). Replaces the per-request
+ * `dbRead.user.findMany({ select: { settings } })` those paths used to run over EVERY
+ * owner — which fetched + synchronously deserialized the full (large, accumulating)
+ * `settings` JSON blob per owner just to read three booleans (the measured api-primary
+ * longtask). Read-through Redis cache of the tiny derived triple; DB-query only the
+ * misses; fail-open to the uncached DB path on any Redis error (a Redis stall must not
+ * 500 a hot read). Byte-identical to reading the flags straight off `settings`.
+ */
+export async function getUserMetricPrivacyDefaultsMap(userIds: number[]) {
+  const unique = [...new Set(userIds.filter((id) => !!id))];
+  const result = new Map<number, UserMetricPrivacyDefaults>();
+  if (unique.length === 0) return result;
+
+  let cached: (UserMetricPrivacyDefaults | null)[];
+  try {
+    cached = await redis.packed.mGet<UserMetricPrivacyDefaults>(
+      unique.map(getUserMetricPrivacyDefaultsCacheKey)
+    );
+  } catch {
+    cached = unique.map(() => null);
+  }
+
+  const misses: number[] = [];
+  unique.forEach((id, i) => {
+    const hit = cached[i];
+    // A stored triple round-trips as a (non-null) object; a cache miss is `null`.
+    if (hit && typeof hit === 'object') result.set(id, hit);
+    else misses.push(id);
+  });
+
+  if (misses.length === 0) return result;
+
+  const fresh = await queryUserMetricPrivacyDefaults(misses);
+
+  await Promise.all(
+    misses.map(async (id) => {
+      const value = fresh.get(id) ?? {
+        hideModelBuzz: false,
+        hideModelDownloads: false,
+        hideModelGenerations: false,
+      };
+      result.set(id, value);
+      try {
+        await redis.packed.set(getUserMetricPrivacyDefaultsCacheKey(id), value, {
+          EX: MEMBERSHIP_CACHE_TTL,
+        });
+      } catch {
+        // Best-effort cache write; the TTL bounds any residual staleness.
+      }
+    })
+  );
+
+  return result;
+}
+
+/**
+ * Bust the cached metric-privacy defaults for one or more users. Wired into
+ * `setUserSetting` so any change to a user's `hideModel*` defaults takes effect on the
+ * next read; the TTL backstops any writer that bypasses `setUserSetting`.
+ */
+export async function bustUserMetricPrivacyDefaultsCache(userId: number | number[]) {
+  const ids = (Array.isArray(userId) ? userId : [userId]).filter((id) => !!id);
+  if (ids.length === 0) return;
+  try {
+    await Promise.all(ids.map((id) => redis.del(getUserMetricPrivacyDefaultsCacheKey(id))));
+  } catch {
+    // Best-effort bust; the TTL bounds any residual staleness.
+  }
+}
+
+/**
  * Bust the cached membership validity for one or more users. Hard delete (not a
  * staleness reset): the next read re-queries and re-populates the fresh boolean.
  * Wired into `invalidateSubscriptionCaches`, so every app-driven subscription change

--- a/src/server/services/creator-program.service.ts
+++ b/src/server/services/creator-program.service.ts
@@ -272,6 +272,7 @@ export async function hasValidCreatorMembership(userId: number) {
 export {
   getValidCreatorMembershipMap,
   hasValidCreatorMembershipCached,
+  getUserMetricPrivacyDefaultsMap,
 } from '~/server/services/creator-membership.service';
 
 export async function joinCreatorsProgram(userId: number) {

--- a/src/server/services/model.service.ts
+++ b/src/server/services/model.service.ts
@@ -125,7 +125,10 @@ import {
   resolveVersionHiddenMetrics,
   type HiddenModelMetrics,
 } from '~/server/utils/model-metric-privacy';
-import { getValidCreatorMembershipMap } from '~/server/services/creator-program.service';
+import {
+  getValidCreatorMembershipMap,
+  getUserMetricPrivacyDefaultsMap,
+} from '~/server/services/creator-program.service';
 import { getEarlyAccessDeadline } from '~/server/utils/early-access-helpers';
 import {
   throwAuthorizationError,
@@ -1422,19 +1425,16 @@ export const getModelsWithImagesAndModelVersions = async ({
   // owner-settings + `getValidCreatorMembershipMap` block is skipped and raw metrics
   // are emitted (pre-#3266 visibility).
   const isMod = !!user?.isModerator;
+  // Cache-backed per-owner metric-privacy DEFAULT flags (the three `hideModel*`
+  // booleans). Replaces a per-request `dbRead.user.findMany({ settings })` that
+  // deserialized every owner's full `settings` blob just to read three booleans — the
+  // measured api-primary read-time longtask (#3266). Values are the tiny derived slice,
+  // fed unchanged into the resolvers below (byte-identical).
   let feedOwnerSettingsMap = new Map<number, unknown>();
   let feedMembershipMap = new Map<number, boolean>();
   if (metricPrivacyEnabled) {
     const feedOwnerIds = [...new Set(items.map((m) => m.user.id))];
-    const feedOwnerSettings = feedOwnerIds.length
-      ? await dbRead.user.findMany({
-          where: { id: { in: feedOwnerIds } },
-          select: { id: true, settings: true },
-        })
-      : [];
-    feedOwnerSettingsMap = new Map<number, unknown>(
-      feedOwnerSettings.map((o) => [o.id, o.settings])
-    );
+    feedOwnerSettingsMap = await getUserMetricPrivacyDefaultsMap(feedOwnerIds);
     const membershipCandidates = new Set<number>();
     for (const it of items) {
       const ownerId = it.user.id;
@@ -3347,15 +3347,9 @@ export async function getModelsWithVersions({
   const isMod = !!user?.isModerator;
   const viewerId = user?.id;
   const apiOwnerIds = [...new Set(items.map((m) => m.user.id))];
-  const apiOwnerSettings = apiOwnerIds.length
-    ? await dbRead.user.findMany({
-        where: { id: { in: apiOwnerIds } },
-        select: { id: true, settings: true },
-      })
-    : [];
-  const apiOwnerSettingsMap = new Map<number, unknown>(
-    apiOwnerSettings.map((o) => [o.id, o.settings])
-  );
+  // Cache-backed per-owner metric-privacy DEFAULT flags — see the feed path above;
+  // avoids deserializing every owner's full `settings` blob per request.
+  const apiOwnerSettingsMap = await getUserMetricPrivacyDefaultsMap(apiOwnerIds);
   const apiMembershipCandidates = new Set<number>();
   for (const it of items) {
     const ownerId = it.user.id;

--- a/src/server/services/user.service.ts
+++ b/src/server/services/user.service.ts
@@ -66,6 +66,7 @@ import { purchasableRewardDetails } from '~/server/selectors/purchasableReward.s
 import { simpleUserSelect, userWithCosmeticsSelect } from '~/server/selectors/user.selector';
 import { deleteBidsForModel } from '~/server/services/auction.service';
 import { hasValidCreatorMembership } from '~/server/services/creator-program.service';
+import { bustUserMetricPrivacyDefaultsCache } from '~/server/services/creator-membership.service';
 import { isCosmeticAvailable } from '~/server/services/cosmetic.service';
 import { deleteImageById } from '~/server/services/image.service';
 import { userModelCountCache } from '~/server/redis/caches';
@@ -2593,6 +2594,9 @@ export async function setUserSetting(userId: number, settings: UserSettingsInput
   }
 
   await userSettingsCache.bust([userId]);
+  // Keep the read-time metric-privacy defaults cache consistent with a settings write
+  // (the `hideModel*` flags live in `settings`); TTL backstops any other writer.
+  await bustUserMetricPrivacyDefaultsCache(userId);
 }
 
 export async function setDismissedAlerts(userId: number, alertIds: string[]) {


### PR DESCRIPTION
## Problem (measured A/B — ground truth)
On `api-primary`, per-request server CPU is **~+35%** and event-loop **longtask time ~+71%** higher with the Flipt flag `model-metric-privacy-readtime` **ON** vs **OFF** (clean, load-normalized, bracketed ON→OFF→ON). The flag gates #3266's read-time metric-privacy resolution. Longtask ⇒ **frequent synchronous event-loop blocking on a hot read path**.

**#3322** cached creator-membership validity but delivered **~zero** CPU benefit — the ON/OFF gap is unchanged.

## Why #3322 missed it
On the hot feed path the membership lookup is only called for `membershipCandidates` — owners who *actually hide* a metric. In the common case **nobody hides**, so `membershipCandidates` is empty and `getValidCreatorMembershipMap([])` returns immediately without touching Redis or the DB. **#3322 optimized a branch the hot path skips.**

The real always-run cost is an **unconditional, uncached `dbRead.user.findMany({ select: { settings } })` over EVERY owner in the response**, which fetches and **synchronously deserializes each owner's full (large, accumulating) `settings` JSON blob just to read three booleans** (`hideModelBuzz/Downloads/Generations`). That per-request, per-owner large-blob deserialize is the synchronous longtask. #3322 left it in place (it must read settings to evaluate its own "skip when nothing hidden" short-circuit), and these paths bypassed the existing batched `userSettingsCache` entirely. Duplicated in the feed (`getModelsRaw`), v1 list (`getModelsWithVersions`), and associated-models controller.

## Fix (deterministic, structural)
`getUserMetricPrivacyDefaultsMap(userIds)` — a read-through **packed Redis cache of the tiny derived 3-boolean triple per user**, mirroring the proven `getValidCreatorMembershipMap` pattern in the same dependency-light module. DB-queries the misses only, fails open to the uncached DB path on any Redis error, and is busted on `setUserSetting` (TTL backstops other writers). The three hot paths now read the tiny triple instead of full settings, so the large-blob deserialize leaves the event loop.

## 🔴 Byte-identical privacy guarantee
The resolvers still AND the stored hide flags with **live membership**; a default is `!!settings.hideModelX` before and after. This PR only changes *how the three booleans are read off the owner*, never *whether a metric is hidden*. Worst-case staleness is a ≤10-min-late reflection of a user toggling **their OWN** default (same class as `userSettingsCache`/membership); it can **never** expose another creator's metric that membership would hide.

## Verification
- `tsc --noEmit` (8GB heap) clean; unit tests green (derived-cache hit/miss/batch-fill/fail-open/bust + byte-identical-vs-raw-settings + never-over-hides).
- **Authoritative (post-merge):** re-run the same flag A/B (ON→OFF→ON) on api-primary — the ON CPU + longtask should collapse toward the OFF baseline. Confirm the new key `packed:caches:user-metric-privacy-defaults:*` populates and `User` findMany volume from these paths drops; spot-check a known CP member's card + version stats are unchanged.

Full RCA: `claudedocs/rca-readtime-metric-privacy-cpu-2026-07-24.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)