### PR TITLE
fix(vault): stop OOM-and-infinite-retry loop in process-vault-items job

### DIFF
--- a/src/server/jobs/__tests__/process-vault-items.test.ts
+++ b/src/server/jobs/__tests__/process-vault-items.test.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const {
+  mockDbWrite,
+  mockGetModelVersionData,
+  mockGetPdf,
+  mockFetchBlob,
+  mockGetCustomPutUrl,
+  mockGetS3Client,
+  mockProcessedInc,
+  mockFailedInc,
+} = vi.hoisted(() => ({
+  mockDbWrite: {
+    vaultItem: { findMany: vi.fn(), update: vi.fn() },
+  },
+  mockGetModelVersionData: vi.fn(),
+  mockGetPdf: vi.fn(),
+  mockFetchBlob: vi.fn(),
+  mockGetCustomPutUrl: vi.fn(),
+  mockGetS3Client: vi.fn(),
+  mockProcessedInc: vi.fn(),
+  mockFailedInc: vi.fn(),
+}));
+
+vi.mock('@prisma/client', () => ({ Prisma: { AnyNull: Symbol('AnyNull') } }));
+vi.mock('~/shared/utils/prisma/enums', () => ({
+  VaultItemStatus: { Pending: 'Pending', Failed: 'Failed', Stored: 'Stored' },
+}));
+vi.mock('~/env/server', () => ({ env: { S3_VAULT_BUCKET: 'vault-bucket' } }));
+vi.mock('~/server/db/client', () => ({ dbWrite: mockDbWrite }));
+vi.mock('~/server/logging/client', () => ({ logToAxiom: () => ({ catch: () => {} }) }));
+vi.mock('~/server/jobs/job', () => ({
+  createJob: (_n: string, _c: string, fn: unknown) => fn,
+  getJobDate: async () => [new Date(0), async () => {}],
+}));
+vi.mock('~/server/prom/client', () => ({
+  vaultItemProcessedCounter: { inc: mockProcessedInc },
+  vaultItemFailedCounter: { inc: mockFailedInc },
+}));
+vi.mock('~/server/services/vault.service', () => ({
+  getModelVersionDataForVault: mockGetModelVersionData,
+}));
+vi.mock('~/server/utils/pdf-helpers', () => ({ getModelVersionDetailsPDF: mockGetPdf }));
+vi.mock('~/utils/file-utils', () => ({ fetchBlob: mockFetchBlob }));
+vi.mock('~/utils/s3-utils', () => ({
+  getCustomPutUrl: mockGetCustomPutUrl,
+  getS3Client: mockGetS3Client,
+}));
+vi.mock('~/client-utils/cf-images-utils', () => ({ getEdgeUrl: (url: string) => url }));
+vi.mock('~/server/utils/errorHandling', () => ({
+  withRetries: (fn: () => Promise<unknown>) => fn(),
+}));
+vi.mock('~/server/common/constants', () => ({
+  constants: {
+    vault: {
+      keys: {
+        details: ':userId/:modelVersionId/details.pdf',
+        images: ':userId/:modelVersionId/images.zip',
+        cover: ':userId/:modelVersionId/cover',
+      },
+    },
+  },
+}));
+vi.mock('jszip', () => ({
+  default: class {
+    file() {}
+    async generateAsync() {
+      return { size: 2048 };
+    }
+  },
+}));
+
+import {
+  processVaultItem,
+  getEligibleVaultItemsQuery,
+  MAX_FAILURES,
+  VAULT_ITEMS_BATCH_SIZE,
+} from '~/server/jobs/process-vault-items';
+
+const makeItem = (overrides: Record<string, unknown> = {}) => ({
+  id: 1,
+  vaultId: 10,
+  modelVersionId: 100,
+  meta: null,
+  ...overrides,
+});
+
+const ctx = { s3: {} as never, bucket: 'vault-bucket' };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.stubGlobal('fetch', vi.fn(async () => ({ ok: true })));
+  mockGetS3Client.mockResolvedValue({});
+  mockGetPdf.mockResolvedValue({ size: 512 });
+  mockGetCustomPutUrl.mockResolvedValue({ url: 'https://put.example/obj' });
+  mockGetModelVersionData.mockResolvedValue({
+    modelVersion: {},
+    images: [{ url: 'a', type: 'image', name: 'a.png' }],
+  });
+  mockFetchBlob.mockResolvedValue({ arrayBuffer: async () => new ArrayBuffer(8) });
+});
+
+describe('getEligibleVaultItemsQuery — bounded batch + retry-budget exclusion', () => {
+  it('caps the run at VAULT_ITEMS_BATCH_SIZE', () => {
+    const q = getEligibleVaultItemsQuery();
+    expect(q.take).toBe(VAULT_ITEMS_BATCH_SIZE);
+    // sanity: the batch is bounded, not unbounded
+    expect(q.take).toBeGreaterThan(0);
+    expect(Number.isFinite(q.take)).toBe(true);
+  });
+
+  it('only selects items whose failure count is within the retry budget', () => {
+    const q = getEligibleVaultItemsQuery();
+    const lteBranch = q.where.OR.find((b: any) => typeof b.meta?.lte === 'number');
+    expect(lteBranch?.meta?.path).toEqual(['failures']);
+    expect(lteBranch?.meta?.lte).toBe(MAX_FAILURES);
+
+    // The lte branch is the mechanism that drops a permanently-failing item:
+    // an item that has been (pre-)incremented past MAX_FAILURES no longer matches.
+    const withinBudget = (failures: number) => failures <= (lteBranch?.meta?.lte as number);
+    expect(withinBudget(MAX_FAILURES)).toBe(true);
+    expect(withinBudget(MAX_FAILURES + 1)).toBe(false); // OOM'd one time too many -> excluded
+  });
+});
+
+describe('processVaultItem — OOM-resilient failure accounting', () => {
+  it('persists the failure increment BEFORE the heavy download+zip work', async () => {
+    await processVaultItem(makeItem({ meta: { failures: 0 } }), ctx);
+
+    // First DB write is the pre-attempt marker.
+    const firstUpdate = mockDbWrite.vaultItem.update.mock.calls[0][0];
+    expect(firstUpdate.where).toEqual({ id: 1 });
+    expect(firstUpdate.data.meta.failures).toBe(1);
+    // It must NOT prematurely flip status — it's only an attempt marker.
+    expect(firstUpdate.data.status).toBeUndefined();
+
+    // Ordering: the pre-increment update ran before the first heavy call.
+    const preIncrementOrder = mockDbWrite.vaultItem.update.mock.invocationCallOrder[0];
+    const heavyWorkOrder = mockGetModelVersionData.mock.invocationCallOrder[0];
+    expect(preIncrementOrder).toBeLessThan(heavyWorkOrder);
+  });
+
+  it('treats a missing/null meta as 0 failures for the pre-increment', async () => {
+    await processVaultItem(makeItem({ meta: null }), ctx);
+    expect(mockDbWrite.vaultItem.update.mock.calls[0][0].data.meta.failures).toBe(1);
+  });
+
+  it('rolls the increment back to the prior value on success (no net failure counted)', async () => {
+    await processVaultItem(makeItem({ meta: { failures: 2 } }), ctx);
+
+    const calls = mockDbWrite.vaultItem.update.mock.calls;
+    // pre-increment optimistically bumps to 3...
+    expect(calls[0][0].data.meta.failures).toBe(3);
+    // ...and the successful Stored write rolls it back to the prior 2.
+    const storedWrite = calls[calls.length - 1][0];
+    expect(storedWrite.data.status).toBe('Stored');
+    expect(storedWrite.data.meta.failures).toBe(2);
+    expect(mockProcessedInc).toHaveBeenCalledTimes(1);
+    expect(mockFailedInc).not.toHaveBeenCalled();
+  });
+
+  it('counts exactly one failure on a catchable error (no double increment)', async () => {
+    mockGetModelVersionData.mockRejectedValueOnce(new Error('boom'));
+
+    await processVaultItem(makeItem({ meta: { failures: 1 } }), ctx);
+
+    const calls = mockDbWrite.vaultItem.update.mock.calls;
+    // pre-increment marker
+    expect(calls[0][0].data.meta.failures).toBe(2);
+    // catch path re-asserts the SAME count (prior+1), does not increment again
+    const failWrite = calls[calls.length - 1][0];
+    expect(failWrite.data.status).toBe('Failed');
+    expect(failWrite.data.meta.failures).toBe(2);
+    expect(failWrite.data.meta.latestError).toBe('boom');
+    expect(mockFailedInc).toHaveBeenCalledTimes(1);
+    expect(mockProcessedInc).not.toHaveBeenCalled();
+  });
+
+  it('climbs past MAX_FAILURES across repeated OOM-style attempts, then is excluded', () => {
+    // Simulate the uncatchable path: each run only the pre-increment persists.
+    const q = getEligibleVaultItemsQuery();
+    const budget = (q.where.OR.find((b: any) => typeof b.meta?.lte === 'number') as any).meta
+      .lte as number;
+    let failures = 0; // starts from null-meta -> 0
+    let runs = 0;
+    // Item stays eligible only while within budget; each attempt pre-increments.
+    while (failures <= budget) {
+      failures += 1; // the pre-attempt marker that survives an OOMKill
+      runs += 1;
+      if (runs > 100) throw new Error('did not converge'); // guard against infinite loop
+    }
+    expect(failures).toBe(MAX_FAILURES + 1);
+    expect(failures > budget).toBe(true); // now excluded from the next findMany
+  });
+});

--- a/src/server/jobs/process-vault-items.ts
+++ b/src/server/jobs/process-vault-items.ts
@@ -8,6 +8,7 @@ import { dbWrite } from '~/server/db/client';
 import { logToAxiom } from '~/server/logging/client';
 import { vaultItemFailedCounter, vaultItemProcessedCounter } from '~/server/prom/client';
 import { getModelVersionDataForVault } from '~/server/services/vault.service';
+import { limitConcurrency } from '~/server/utils/concurrency-helpers';
 import { withRetries } from '~/server/utils/errorHandling';
 import { getModelVersionDetailsPDF } from '~/server/utils/pdf-helpers';
 import { fetchBlob } from '~/utils/file-utils';
@@ -16,11 +17,192 @@ import { isDefined } from '~/utils/type-guards';
 import type { VaultItemMetadataSchema } from '../schema/vault.schema';
 import { createJob, getJobDate } from './job';
 
-const MAX_FAILURES = 3;
+export const MAX_FAILURES = 3;
+// Bound how many items a single run pulls + processes. The heavy per-item work
+// (download every gallery image into memory, then build the whole zip in memory)
+// makes an unbounded backlog an OOM risk, so cap the run like the sibling vault
+// job (clear-vault-items also uses batches of 50).
+export const VAULT_ITEMS_BATCH_SIZE = 50;
+// Cap simultaneous image downloads/buffers per item. The previous unbounded
+// Promise.all buffered every image of a gallery into memory at once — a large
+// gallery alone could exceed the container memory limit.
+export const IMAGE_DOWNLOAD_CONCURRENCY = 5;
 
 const logErrors = (data: MixedObject) => {
   logToAxiom({ name: 'process-vault-items', type: 'error', ...data }, 'webhooks').catch();
 };
+
+// Eligible = Pending/Failed items that have not yet exhausted their retry budget.
+// An item whose `failures` has climbed past MAX_FAILURES is excluded here so a
+// permanently-failing (e.g. repeatedly-OOMing) item eventually stops being retried.
+export const getEligibleVaultItemsQuery = () => ({
+  where: {
+    status: {
+      in: [VaultItemStatus.Pending, VaultItemStatus.Failed],
+    },
+    OR: [
+      {
+        meta: {
+          path: ['failures'],
+          lte: MAX_FAILURES,
+        },
+      },
+      {
+        meta: {
+          path: ['failures'],
+          equals: Prisma.AnyNull,
+        },
+      },
+    ],
+  },
+  take: VAULT_ITEMS_BATCH_SIZE,
+});
+
+type VaultItemRow = Awaited<ReturnType<typeof dbWrite.vaultItem.findMany>>[number];
+type ProcessContext = {
+  s3: Awaited<ReturnType<typeof getS3Client>>;
+  bucket: string;
+};
+
+export async function processVaultItem(vaultItem: VaultItemRow, ctx: ProcessContext) {
+  const { s3, bucket } = ctx;
+  const meta = (vaultItem.meta ?? { failures: 0 }) as VaultItemMetadataSchema;
+  const priorFailures = meta.failures ?? 0;
+
+  // OOM-resilient failure accounting: persist an attempt marker BEFORE the heavy
+  // download+zip work. A hard OOMKill (SIGKILL) during that work never runs the
+  // catch block below, so without this pre-increment the item's failure count
+  // would never advance and it would be retried on every run forever (an infinite
+  // OOM loop). By recording the attempt up front, a repeatedly-killing item climbs
+  // to MAX_FAILURES and drops out of getEligibleVaultItemsQuery(). A successful run
+  // rolls this back (see the Stored update), so normal semantics are unchanged.
+  await dbWrite.vaultItem.update({
+    where: { id: vaultItem.id },
+    data: {
+      meta: { ...meta, failures: priorFailures + 1 },
+    },
+  });
+
+  try {
+    // Get model version info:
+    const { modelVersion, images } = await getModelVersionDataForVault({
+      modelVersionId: vaultItem.modelVersionId,
+    });
+
+    // Now, prepare the PDF file:
+    const pdfFile = await getModelVersionDetailsPDF(modelVersion);
+    const zip = new JSZip();
+
+    let coverImage: { data: Blob; filename: string } | undefined;
+
+    // Bounded-concurrency download: only IMAGE_DOWNLOAD_CONCURRENCY images are
+    // buffered into memory at any one time instead of the whole gallery at once.
+    const imageTasks = images.map((img, idx) => async () => {
+      try {
+        const imageUrl = getEdgeUrl(img.url, { type: img.type });
+        const blob = await fetchBlob(imageUrl, 300_000);
+        const filename = img.name ?? imageUrl.split('/').pop();
+
+        if (filename && blob) {
+          if (idx === 0) {
+            coverImage = { data: blob, filename: `cover.${filename?.split('.').pop()}` };
+          }
+          const arrayBuffer = await blob.arrayBuffer();
+          zip.file(filename, arrayBuffer);
+        }
+      } catch (e) {
+        console.error('Error fetching image:', e);
+      }
+    });
+    await limitConcurrency(imageTasks, IMAGE_DOWNLOAD_CONCURRENCY);
+
+    const imagesZip = await zip.generateAsync({ type: 'blob' });
+
+    // Upload these to S3:
+    // Upload the PDF:
+    const keys = {
+      details: constants.vault.keys.details
+        .replace(':modelVersionId', vaultItem.modelVersionId.toString())
+        .replace(':userId', vaultItem.vaultId.toString()),
+      images: constants.vault.keys.images
+        .replace(':modelVersionId', vaultItem.modelVersionId.toString())
+        .replace(':userId', vaultItem.vaultId.toString()),
+      //  TODO: might wanna change the extension here, but we'll see.
+      coverImage: constants.vault.keys.cover
+        .replace(':modelVersionId', vaultItem.modelVersionId.toString())
+        .replace(':userId', vaultItem.vaultId.toString()),
+    };
+
+    const { url: detailsUploadUrl } = await getCustomPutUrl(bucket, keys.details, s3);
+    const { url: imagesUploadUrl } = await getCustomPutUrl(bucket, keys.images, s3);
+    const { url: coverImageUploadUrl } = await getCustomPutUrl(bucket, keys.coverImage, s3);
+
+    await Promise.all(
+      [
+        { url: detailsUploadUrl, data: pdfFile, headers: { 'Content-Type': 'application/pdf' } },
+        { url: imagesUploadUrl, data: imagesZip, headers: { 'Content-Type': 'application/zip' } },
+        !!coverImage
+          ? {
+              url: coverImageUploadUrl,
+              data: coverImage.data,
+              headers: { 'Content-Type': 'image/*' },
+            }
+          : undefined,
+      ]
+        .filter(isDefined)
+        .map((upload) =>
+          withRetries(() =>
+            fetch(upload.url, {
+              method: 'PUT',
+              body: upload.data,
+              headers: {
+                ...upload.headers,
+              },
+            })
+          )
+        )
+    );
+
+    // If everything above went out smoothly, the user can now download the files from the vault.
+    await dbWrite.vaultItem.update({
+      where: { id: vaultItem.id },
+      data: {
+        // Update with the actual zip size:
+        imagesSizeKb: imagesZip.size / 1024,
+        detailsSizeKb: pdfFile.size / 1024,
+        status: VaultItemStatus.Stored,
+        // Roll back the optimistic pre-attempt increment: a successful run must
+        // not count against the retry budget (preserves prior success semantics).
+        meta: { ...meta, failures: priorFailures },
+      },
+    });
+    vaultItemProcessedCounter.inc();
+  } catch (e) {
+    const error = e as Error;
+    await logErrors({
+      message: 'Error processing vault item',
+      error: error.message,
+      vaultItem,
+    });
+    vaultItemFailedCounter.inc();
+
+    // The failure was already counted before the heavy work (the pre-increment
+    // above), so we re-assert the same count here rather than incrementing again —
+    // that keeps exactly one failure per failed run, matching the prior behavior,
+    // while still marking latestError + the Failed status on the catchable path.
+    await dbWrite.vaultItem.update({
+      where: { id: vaultItem.id },
+      data: {
+        status: VaultItemStatus.Failed,
+        meta: {
+          ...meta,
+          failures: priorFailures + 1,
+          latestError: error.message,
+        },
+      },
+    });
+  }
+}
 
 export const processVaultItems = createJob('process-vault-items', '*/10 * * * *', async () => {
   const [, setLastRun] = await getJobDate('process-vault-items');
@@ -29,153 +211,11 @@ export const processVaultItems = createJob('process-vault-items', '*/10 * * * *'
     throw new Error('S3_VAULT_BUCKET is not defined');
   }
 
-  const vaultItems = await dbWrite.vaultItem.findMany({
-    where: {
-      status: {
-        in: [VaultItemStatus.Pending, VaultItemStatus.Failed],
-      },
-      OR: [
-        {
-          meta: {
-            path: ['failures'],
-            lte: MAX_FAILURES,
-          },
-        },
-        {
-          meta: {
-            path: ['failures'],
-            equals: Prisma.AnyNull,
-          },
-        },
-      ],
-    },
-  });
+  const vaultItems = await dbWrite.vaultItem.findMany(getEligibleVaultItemsQuery());
 
   const s3 = await getS3Client();
   for (const vaultItem of vaultItems) {
-    try {
-      // Get model version info:
-      const { modelVersion, images } = await getModelVersionDataForVault({
-        modelVersionId: vaultItem.modelVersionId,
-      });
-
-      // Now, prepare the PDF file:
-      const pdfFile = await getModelVersionDetailsPDF(modelVersion);
-      const zip = new JSZip();
-
-      let coverImage: { data: Blob; filename: string } | undefined;
-
-      await Promise.all(
-        images.map(async (img, idx) => {
-          try {
-            const imageUrl = getEdgeUrl(img.url, { type: img.type });
-            const blob = await fetchBlob(imageUrl, 300_000);
-            const filename = img.name ?? imageUrl.split('/').pop();
-
-            if (filename && blob) {
-              if (idx === 0) {
-                coverImage = { data: blob, filename: `cover.${filename?.split('.').pop()}` };
-              }
-              const arrayBuffer = await blob.arrayBuffer();
-              zip.file(filename, arrayBuffer);
-            }
-          } catch (e) {
-            console.error('Error fetching image:', e);
-          }
-        })
-      );
-
-      const imagesZip = await zip.generateAsync({ type: 'blob' });
-
-      // Upload these to S3:
-      // Upload the PDF:
-      const keys = {
-        details: constants.vault.keys.details
-          .replace(':modelVersionId', vaultItem.modelVersionId.toString())
-          .replace(':userId', vaultItem.vaultId.toString()),
-        images: constants.vault.keys.images
-          .replace(':modelVersionId', vaultItem.modelVersionId.toString())
-          .replace(':userId', vaultItem.vaultId.toString()),
-        //  TODO: might wanna change the extension here, but we'll see.
-        coverImage: constants.vault.keys.cover
-          .replace(':modelVersionId', vaultItem.modelVersionId.toString())
-          .replace(':userId', vaultItem.vaultId.toString()),
-      };
-
-      const { url: detailsUploadUrl } = await getCustomPutUrl(
-        env.S3_VAULT_BUCKET,
-        keys.details,
-        s3
-      );
-      const { url: imagesUploadUrl } = await getCustomPutUrl(env.S3_VAULT_BUCKET, keys.images, s3);
-      const { url: coverImageUploadUrl } = await getCustomPutUrl(
-        env.S3_VAULT_BUCKET,
-        keys.coverImage,
-        s3
-      );
-
-      await Promise.all(
-        [
-          { url: detailsUploadUrl, data: pdfFile, headers: { 'Content-Type': 'application/pdf' } },
-          { url: imagesUploadUrl, data: imagesZip, headers: { 'Content-Type': 'application/zip' } },
-          !!coverImage
-            ? {
-                url: coverImageUploadUrl,
-                data: coverImage.data,
-                headers: { 'Content-Type': 'image/*' },
-              }
-            : undefined,
-        ]
-          .filter(isDefined)
-          .map((upload) =>
-            withRetries(() =>
-              fetch(upload.url, {
-                method: 'PUT',
-                body: upload.data,
-                headers: {
-                  ...upload.headers,
-                },
-              })
-            )
-          )
-      );
-
-      // If everything above went out smoothly, the user can now download the files from the vault.
-      await dbWrite.vaultItem.update({
-        where: { id: vaultItem.id },
-        data: {
-          // Update with the actual zip size:
-          imagesSizeKb: imagesZip.size / 1024,
-          detailsSizeKb: pdfFile.size / 1024,
-          status: VaultItemStatus.Stored,
-        },
-      });
-      vaultItemProcessedCounter.inc();
-    } catch (e) {
-      const error = e as Error;
-      await logErrors({
-        message: 'Error processing vault item',
-        error: error.message,
-        vaultItem,
-      });
-      vaultItemFailedCounter.inc();
-
-      const meta = (vaultItem.meta ?? { failures: 0 }) as VaultItemMetadataSchema;
-
-      await dbWrite.vaultItem.update({
-        where: { id: vaultItem.id },
-        data: {
-          status: VaultItemStatus.Failed,
-          meta: {
-            ...meta,
-            failures: meta.failures + 1,
-            latestError: error.message,
-          },
-        },
-      });
-
-      continue;
-    }
+    await processVaultItem(vaultItem, { s3, bucket: env.S3_VAULT_BUCKET });
   }
 
   await setLastRun();


### PR DESCRIPTION
## Problem

The `process-vault-items` background job (builds the downloadable per-vault-item zip archives) could exhaust the process memory limit and then get stuck retrying the same item forever:

1. **Unbounded batch** — `dbWrite.vaultItem.findMany(...)` had no `take`, so every run pulled the *entire* eligible backlog at once.
2. **Unbounded in-memory buffering** — an uncapped `Promise.all` over a gallery's images fetched and buffered *every* image fully into memory simultaneously, then `zip.generateAsync({ type: 'blob' })` materialized the whole zip in memory as well (input buffers + output blob co-resident, ~2× the image bytes). A single large gallery could push memory past the limit.
3. **Failure counter unreachable on hard kill** — the `meta.failures` / `MAX_FAILURES` safety valve lived inside the `catch` block. A hard out-of-memory kill terminates the process without running `catch`, so `meta.failures` never incremented. The offending item stayed eligible in the query and was re-attempted on **every** run — an infinite memory-blowup loop.

## Fix

1. **Bounded batch** — added `take: 50` to the query (matches the sibling `clear-vault-items` job's batch size), so each run processes a bounded number of items.
2. **Capped download concurrency** — replaced the uncapped `Promise.all` over images with the repo's existing `limitConcurrency` helper, capped at 5 concurrent downloads/buffers. Only a bounded slice of a gallery is held in memory at a time. (No new dependency — reuses `~/server/utils/concurrency-helpers`.)
3. **Kill-resilient failure accounting** — the failure attempt is now recorded in the DB **before** the heavy download+zip work begins. An uncatchable kill can no longer produce an infinite retry: a repeatedly-failing item advances its failure count each run and eventually trips `MAX_FAILURES`, dropping out of eligibility. A successful run rolls the optimistic increment back, and the normal (catchable-error) path re-asserts the same count rather than incrementing again — so existing one-failure-per-failed-run success/failure semantics are unchanged.

Streaming zip generation/upload would be the largest memory win, but the current presigned single-`PUT` upload path makes it a substantially larger change — deferred as a follow-up.

## Tests

Extracted `processVaultItem` + `getEligibleVaultItemsQuery` so the batching and failure-accounting ordering are unit-testable. Added `src/server/jobs/__tests__/process-vault-items.test.ts` (vitest) covering:

- the run is bounded (`take === VAULT_ITEMS_BATCH_SIZE`);
- eligibility excludes items whose failure count exceeds the retry budget;
- the failure increment is **persisted before** the heavy download/zip work (asserted via mock call ordering), and treats missing/null meta as 0;
- a successful run rolls the increment back (no net failure counted);
- a catchable error counts exactly one failure (no double increment) and records `latestError`;
- a repeatedly-killing item climbs past `MAX_FAILURES` and is then excluded.

All 7 tests pass. Full `tsc --noEmit` shows no new type errors introduced by this change.
