### PR TITLE
fix(security): escape embedding triggerWord before RegExp — kill ReDoS event-loop freeze

### DIFF
--- a/src/server/services/orchestrator/comfy/__tests__/comfy.utils.test.ts
+++ b/src/server/services/orchestrator/comfy/__tests__/comfy.utils.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from 'vitest';
+
+// Drive the embedding branch of applyResources deterministically. The vuln under
+// test is the triggerWord→RegExp construction inside that branch, not AIR parsing;
+// the real Air.parse needs a live-format URN, so we force the type here. The
+// functional assertions below only pass if the branch actually ran.
+vi.mock('~/utils/string-helpers', async (importActual) => {
+  const actual = await importActual<typeof import('~/utils/string-helpers')>();
+  return {
+    ...actual,
+    parseAIR: () => ({ type: 'embedding', source: 'civitai', model: 1234, version: 5678 }),
+  };
+});
+
+import { applyResources } from '~/server/services/orchestrator/comfy/comfy.utils';
+
+const EMBED_AIR = 'urn:air:sd1:embedding:civitai:1234@5678';
+
+const node = (text: string) => ({
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  workflow: { p: { class_type: 'CLIPTextEncode', inputs: { text } } } as any,
+});
+
+describe('applyResources — embedding trigger-word regex safety', () => {
+  it('does NOT ReDoS-freeze on a regex-metachar triggerWord (was ~14s pre-fix)', () => {
+    // Unescaped, "(x+x+)+y" compiled to \b(x+x+)+y\b backtracks exponentially on
+    // an x-run. Escaped, it is a literal — no backtracking. The literal prefix
+    // also passes the `.includes` gate so the vulnerable branch IS entered.
+    const triggerWord = '(x+x+)+y';
+    const { workflow } = node(`${triggerWord} ${'x'.repeat(40)}`);
+    const t0 = Date.now();
+    applyResources(workflow, [{ air: EMBED_AIR, triggerWord }]);
+    expect(Date.now() - t0).toBeLessThan(500);
+  });
+
+  it('still replaces a normal literal triggerWord with the embedding reference', () => {
+    const { workflow } = node('a myembed b');
+    applyResources(workflow, [{ air: EMBED_AIR, triggerWord: 'myembed' }]);
+    expect(workflow.p.inputs.text).toBe(`a embedding:${EMBED_AIR} b`);
+  });
+
+  it('treats regex metacharacters in the triggerWord LITERALLY (no injection)', () => {
+    // "a.b" must match only the literal "a.b", never "axb".
+    const { workflow } = node('a.b and axb');
+    applyResources(workflow, [{ air: EMBED_AIR, triggerWord: 'a.b' }]);
+    expect(workflow.p.inputs.text).toBe(`embedding:${EMBED_AIR} and axb`);
+  });
+});

--- a/src/server/services/orchestrator/comfy/comfy.utils.ts
+++ b/src/server/services/orchestrator/comfy/comfy.utils.ts
@@ -129,13 +129,20 @@ export function applyResources(
       };
     }
 
-    // If it's an embedding, replace trigger word with embedding reference
+    // If it's an embedding, replace trigger word with embedding reference.
+    // triggerWord is a LITERAL token (creator-supplied), not a pattern — it MUST
+    // be regex-escaped before interpolation. Unescaped, an attacker-chosen trigger
+    // like "(x+x+)+y" is (a) a regex injection and (b) catastrophic-backtracking
+    // ReDoS: measured ~14s of event-loop freeze on a ~35-char crafted prompt run,
+    // and no prompt-length cap helps (it's exponential). The `.includes` gate
+    // below still uses the raw literal (a substring check, correct).
     if (parsedAir.type === 'embedding' && resource.triggerWord) {
+      const tw = resource.triggerWord.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
       for (const node of Object.values(workflow)) {
         for (const [key, value] of Object.entries(node.inputs)) {
           if (typeof value === 'string' && value.includes(resource.triggerWord)) {
-            const negRegex = new RegExp(`\\b${resource.triggerWord}-neg\\b`, 'gi');
-            const regex = new RegExp(`\\b${resource.triggerWord}\\b`, 'gi');
+            const negRegex = new RegExp(`\\b${tw}-neg\\b`, 'gi');
+            const regex = new RegExp(`\\b${tw}\\b`, 'gi');
             node.inputs[key] = value
               .replace(negRegex, '')
               .replace(regex, `embedding:${resource.air}`);


### PR DESCRIPTION
## The bug (confirmed HIGH, measured)
`applyResources()` in `src/server/services/orchestrator/comfy/comfy.utils.ts` interpolated a **creator-supplied embedding `triggerWord` UNESCAPED** into a RegExp:
```js
const regex = new RegExp(`\\b${resource.triggerWord}\\b`, 'gi');
```
That is both a **regex injection** and a **catastrophic-backtracking ReDoS**. A trigger like `(x+x+)+y` compiles to `\b(x+x+)+y\b`, which backtracks exponentially on a crafted generation prompt.

**Measured, verbatim regex (prompt = literal trigger + an x-run):**

| x-run | time |
|---|---|
| n=28 | 0.9 s |
| n=30 | 3.5 s |
| **n=32** | **14.2 s** |

Exponential (each +2 chars ≈ ×4) — so **prompt-length caps do not help**. Reachable on the **authed self-serve generation-submit path** (runs on the dp-prod web event loop); the `value.includes(triggerWord)` gate is trivially satisfied because the attacker controls the prompt too. This is a sibling of the recently-fixed `og-metadata` O(n²) freeze, but worse (exponential vs quadratic).

## The fix
Regex-escape `triggerWord` before building the RegExp — it's a **literal token**, never a pattern. Uses the repo's standard escape (`.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')`, same as `blocklist.service.ts:124`). The `.includes` substring gate keeps using the raw literal (correct).

## Test (mutation-verified)
New `__tests__/comfy.utils.test.ts` (drives the embedding branch via a `parseAIR` mock):
- adversarial metachar `triggerWord` completes **instantly** (was ~14 s) — the ReDoS guard,
- a normal trigger still resolves to `embedding:<air>`,
- metacharacters matched **literally** (`a.b` does not match `axb`) — the injection guard.
**Mutation-checked:** the metachar test *fails* against the un-escaped code, so it genuinely guards the bug.

Found by the event-loop-freeze audit sweep across the codebase. `tsc` clean for the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)