### PR TITLE
fix(jobs): bound ingest-images per-run batch so it can't flood the image scanner

### DIFF
--- a/src/env/server-schema.ts
+++ b/src/env/server-schema.ts
@@ -370,6 +370,12 @@ export const serverSchema = z
     TEXT_MODERATION_CALLBACK: z.string().optional(),
     IMAGE_SCANNING_MODEL: z.string().optional(),
     IMAGE_SCANNING_RETRY_DELAY: z.coerce.number().default(5),
+    // Upper bound on how many queued images the `ingest-images` retry/backfill cron
+    // pulls (and therefore can submit) per run. Sized to the scanner's sustainable
+    // throughput so a large backlog drains gradually across runs instead of in one
+    // dump. New user uploads scan directly via ingestImage on creation and are NOT
+    // gated by this. Conservative default; tune via env without a redeploy.
+    IMAGE_SCANNING_MAX_PER_RUN: z.coerce.number().default(1000),
     IMAGE_SCANNER_NEW: zc.booleanString.default(false),
     DELIVERY_WORKER_ENDPOINT: z.string().optional(),
     DELIVERY_WORKER_TOKEN: z.string().optional(),

--- a/src/env/server-schema.ts
+++ b/src/env/server-schema.ts
@@ -375,7 +375,11 @@ export const serverSchema = z
     // throughput so a large backlog drains gradually across runs instead of in one
     // dump. New user uploads scan directly via ingestImage on creation and are NOT
     // gated by this. Conservative default; tune via env without a redeploy.
-    IMAGE_SCANNING_MAX_PER_RUN: z.coerce.number().default(1000),
+    // Positive integer guard: an empty/0 value would make findMany take:0 (all
+    // retries silently wedged) and a negative value would flip Prisma's take to
+    // newest-first (starving the oldest backlog) — a bad hand-tune must fail
+    // loudly at boot instead.
+    IMAGE_SCANNING_MAX_PER_RUN: z.coerce.number().int().positive().default(1000),
     IMAGE_SCANNER_NEW: zc.booleanString.default(false),
     DELIVERY_WORKER_ENDPOINT: z.string().optional(),
     DELIVERY_WORKER_TOKEN: z.string().optional(),

--- a/src/server/jobs/__tests__/ingest-images-cap.test.ts
+++ b/src/server/jobs/__tests__/ingest-images-cap.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// The scanner sustains only a limited throughput, so the `ingest-images` retry/
+// backfill cron must never submit more than IMAGE_SCANNING_MAX_PER_RUN images in
+// a single run — even when the JobQueue backlog is far larger. This test drives
+// the real job with a backlog larger than the cap and asserts the number of
+// scan submissions (ingestImage calls) is bounded by the cap.
+
+const {
+  MOCK_CAP,
+  TOTAL_QUEUE,
+  mockDbRead,
+  mockDbWrite,
+  mockIngestImage,
+  mockDeleteImages,
+  mockLimitConcurrency,
+} = vi.hoisted(() => {
+  const MOCK_CAP = 100; // IMAGE_SCANNING_MAX_PER_RUN under test
+  const TOTAL_QUEUE = 500; // simulated backlog, intentionally >> cap
+    // Shared between the findMany mock (which honors `take`) and the $queryRaw
+    // mock (which returns image rows for exactly the ids that were pulled).
+    const pulled: { ids: number[] } = { ids: [] };
+    return {
+      MOCK_CAP,
+      TOTAL_QUEUE,
+      mockDbRead: {
+        jobQueue: {
+          // Simulate a DB LIMIT: return at most `take` rows from a backlog of
+          // TOTAL_QUEUE, oldest-first. This is what bounds the run.
+          findMany: vi.fn(async ({ take }: { take: number }) => {
+            const n = Math.min(take, TOTAL_QUEUE);
+            pulled.ids = Array.from({ length: n }, (_, i) => i + 1);
+            return pulled.ids.map((entityId) => ({ entityId }));
+          }),
+        },
+      },
+      mockDbWrite: {
+        // Tagged-template: return a Pending, immediately-eligible image row for
+        // each pulled id so every pulled image is submitted this run.
+        $queryRaw: vi.fn(async () =>
+          pulled.ids.map((id) => ({
+            id,
+            url: `img-${id}`,
+            type: 'image',
+            width: 100,
+            height: 100,
+            prompt: null,
+            scanRequestedAt: null,
+            ingestion: 'Pending',
+            retryCount: 0,
+            isBackfill: false,
+          }))
+        ),
+        $executeRaw: vi.fn(async () => 0),
+      },
+      mockIngestImage: vi.fn(async () => true),
+      mockDeleteImages: vi.fn(async () => undefined),
+      // Run tasks sequentially for deterministic assertions.
+      mockLimitConcurrency: vi.fn(async (tasks: Array<() => Promise<unknown>>) => {
+        for (const t of tasks) await t();
+      }),
+    };
+  });
+
+vi.mock('~/server/db/client', () => ({ dbRead: mockDbRead, dbWrite: mockDbWrite }));
+vi.mock('~/server/services/image.service', () => ({
+  ingestImage: mockIngestImage,
+  deleteImages: mockDeleteImages,
+}));
+vi.mock('~/server/utils/concurrency-helpers', () => ({ limitConcurrency: mockLimitConcurrency }));
+vi.mock('~/env/other', () => ({ isProd: true }));
+vi.mock('~/env/server', () => ({
+  env: {
+    IMAGE_SCANNING_MAX_PER_RUN: MOCK_CAP,
+    IMAGE_SCANNING_RETRY_DELAY: 5,
+    DATABASE_IS_PROD: true,
+  },
+}));
+
+import { ingestImages } from '~/server/jobs/image-ingestion';
+
+const ctx = {} as Parameters<typeof ingestImages.run>[0];
+
+// createJob wraps the fn so .run() returns { result, cancel }; await `.result`.
+async function runJob<T extends { run: (ctx: any) => { result: Promise<unknown> } }>(
+  job: T
+): Promise<unknown> {
+  return await job.run(ctx).result;
+}
+
+beforeEach(() => {
+  mockDbRead.jobQueue.findMany.mockClear();
+  mockDbWrite.$queryRaw.mockClear();
+  mockDbWrite.$executeRaw.mockClear();
+  mockIngestImage.mockClear();
+});
+
+describe('ingest-images per-run cap', () => {
+  it('pulls the JobQueue with take = IMAGE_SCANNING_MAX_PER_RUN, oldest-first', async () => {
+    await runJob(ingestImages);
+    expect(mockDbRead.jobQueue.findMany).toHaveBeenCalledTimes(1);
+    const arg = mockDbRead.jobQueue.findMany.mock.calls[0][0];
+    expect(arg.take).toBe(MOCK_CAP);
+    expect(arg.orderBy).toEqual({ createdAt: 'asc' });
+  });
+
+  it('bounds scan submissions to the cap even when the backlog is much larger', async () => {
+    const result = (await runJob(ingestImages)) as { sent: number };
+
+    // Never submits more than the cap, despite TOTAL_QUEUE (500) waiting.
+    expect(mockIngestImage.mock.calls.length).toBeLessThanOrEqual(MOCK_CAP);
+    // All pulled images were eligible+submitted, so we hit the cap exactly.
+    expect(mockIngestImage.mock.calls.length).toBe(MOCK_CAP);
+    expect(result.sent).toBe(MOCK_CAP);
+  });
+});

--- a/src/server/jobs/__tests__/ingest-images-cap.test.ts
+++ b/src/server/jobs/__tests__/ingest-images-cap.test.ts
@@ -27,7 +27,7 @@ const {
         jobQueue: {
           // Simulate a DB LIMIT: return at most `take` rows from a backlog of
           // TOTAL_QUEUE, oldest-first. This is what bounds the run.
-          findMany: vi.fn(async ({ take }: { take: number }) => {
+          findMany: vi.fn(async ({ take }: { take: number; orderBy?: unknown; where?: unknown }) => {
             const n = Math.min(take, TOTAL_QUEUE);
             pulled.ids = Array.from({ length: n }, (_, i) => i + 1);
             return pulled.ids.map((entityId) => ({ entityId }));

--- a/src/server/jobs/image-ingestion.ts
+++ b/src/server/jobs/image-ingestion.ts
@@ -29,10 +29,24 @@ type IngestImageRow = IngestImageInput & {
 export const ingestImages = createJob('ingest-images', '*/5 * * * *', async () => {
   const now = new Date();
 
+  // Bound how many queued images we pull (and therefore can submit) per run. The
+  // media-rating scanner sustains only a limited throughput; pulling the whole
+  // queue at once (previously a hardcoded 10,000) can dump ~5x what the scanner
+  // can absorb, so bulk rating jobs expire before they run, workflows fail, and
+  // images flip to Error — which the cron then re-queues, amplifying the flood
+  // into a congestion collapse. Since every downstream step (filtering, the
+  // submission fan-out, and the JobQueue cleanup) is derived only from the rows
+  // pulled here, capping this pull caps per-run submissions AND leaves the rows
+  // we did NOT pull this run untouched in the queue. Oldest-first (createdAt asc)
+  // keeps draining fair, so a backlog drains gradually across runs. New user
+  // uploads scan directly via ingestImage on creation and are unaffected by this
+  // cap — this cron is only the retry/backfill path.
+  const maxPerRun = env.IMAGE_SCANNING_MAX_PER_RUN;
+
   // Pull from JobQueue instead of scanning Image table with partial indexes
   const jobQueue = await dbRead.jobQueue.findMany({
     where: { type: JobQueueType.ImageScan, entityType: EntityType.Image },
-    take: 10000,
+    take: maxPerRun,
     orderBy: { createdAt: 'asc' },
   });
 


### PR DESCRIPTION
## Problem

The `ingest-images` retry/backfill cron (`src/server/jobs/image-ingestion.ts`, `*/5 * * * *`) pulled a hardcoded **`take: 10000`** rows from `JobQueue` (type `ImageScan`) every run and submitted every eligible one to the media-rating scanner via `ingestImage`.

The scanner sustains only a limited throughput (on the order of ~1k submissions per 5-min run, ~6–7k / 30 min). When the queue is large, each run dumps roughly **5x** what the scanner can absorb → bulk rating jobs **expire before they run** → scan workflows fail → images flip to `Error` → the cron **re-queues those errored images** (retry amplification) → a self-sustaining congestion collapse where the failure rate *is* the load. This caused a multi-hour image-scan outage.

Key architecture fact: **new user uploads scan directly via `ingestImage` on image creation** (`image.service.ts`), independent of this cron. So this cron is purely the **retry/backfill** path — bounding it does **not** delay new-upload scanning, it only paces retries/backfill.

## Fix

Replace the hardcoded `take: 10000` with a scanner-matched, env-configurable cap:

- New env var **`IMAGE_SCANNING_MAX_PER_RUN`** (`src/env/server-schema.ts`, `z.coerce.number().default(1000)`) — conservative default, tunable without a redeploy.
- The cron now pulls at most `IMAGE_SCANNING_MAX_PER_RUN` rows.

Because **every** downstream step — the Pending/Rescan/Error filtering, the submission fan-out, and the `JobQueue` cleanup — is derived only from the rows pulled at the top of the run, capping the pull caps per-run submissions **and** leaves the rows we did *not* pull this run untouched in the queue. `orderBy createdAt asc` keeps the drain **oldest-first**, so a backlog drains gradually across runs instead of in one thundering-herd dump. That gradualness is itself the post-outage catch-up guard: a resumed cron with an accrued backlog bleeds it off at a rate the scanner can sustain rather than re-flooding it.

Preserved unchanged: the Pending/Rescan/Error filtering, the retry cooldowns (`IMAGE_SCANNING_RETRY_DELAY`, the 60-min error delay), the `retryCount < 9` cap, the backfill/low-priority split, and the processed→removed / waiting-for-retry→kept `JobQueue` cleanup semantics (rows we didn't process this run simply stay queued).

## Before / after

```diff
-    take: 10000,
+    take: env.IMAGE_SCANNING_MAX_PER_RUN, // default 1000
```

## Operational note

The cron is currently paused externally to stop the live flood; this change is what makes it safe to re-enable. On re-enable, the accrued backlog drains gradually (≤ the cap per run) instead of as a single dump.

## Test

Adds `src/server/jobs/__tests__/ingest-images-cap.test.ts`, which drives the real job with a simulated backlog (500) much larger than the cap (100) and asserts:
- the queue is pulled with `take = IMAGE_SCANNING_MAX_PER_RUN`, oldest-first;
- the number of scan submissions is bounded by the cap (100, not 500).

## Out of scope

Scheduler-side cron de-duplication is a separate change. The direct-upload `ingestImage` path and the webhook handler are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
