### PR TITLE
fix(articles): honor moderator NSFW override across all ingestion recompute paths

### DIFF
--- a/src/server/services/__tests__/article-ingestion.helpers.test.ts
+++ b/src/server/services/__tests__/article-ingestion.helpers.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest';
+import type { ArticleIngestionInputs } from '~/server/services/article-ingestion.helpers';
+import { deriveArticleIngestionState } from '~/server/services/article-ingestion.helpers';
+import { ArticleIngestionStatus } from '~/shared/utils/prisma/enums';
+
+// A fully-scanned, clean, no-override article. Each test overrides only the
+// fields relevant to the case it asserts.
+const base: ArticleIngestionInputs = {
+  imageBlocked: false,
+  imageError: false,
+  imageDone: true,
+  textBlocked: false,
+  textError: false,
+  textDone: true,
+  hasModeratorOverride: false,
+};
+
+describe('deriveArticleIngestionState', () => {
+  describe('moderator NSFW override in force', () => {
+    it('resolves Scanned when a content image errored (the unscannable animated-webp bug)', () => {
+      expect(
+        deriveArticleIngestionState({
+          ...base,
+          hasModeratorOverride: true,
+          imageError: true,
+          imageDone: true,
+        })
+      ).toBe(ArticleIngestionStatus.Scanned);
+    });
+
+    it('resolves Scanned while a content image is still Pending (not yet done)', () => {
+      expect(
+        deriveArticleIngestionState({
+          ...base,
+          hasModeratorOverride: true,
+          imageDone: false,
+        })
+      ).toBe(ArticleIngestionStatus.Scanned);
+    });
+
+    it('resolves Scanned when text moderation errored', () => {
+      expect(
+        deriveArticleIngestionState({
+          ...base,
+          hasModeratorOverride: true,
+          textError: true,
+        })
+      ).toBe(ArticleIngestionStatus.Scanned);
+    });
+
+    it('still resolves Blocked when a content image is policy-blocked (override is not a moderation bypass)', () => {
+      expect(
+        deriveArticleIngestionState({
+          ...base,
+          hasModeratorOverride: true,
+          imageBlocked: true,
+        })
+      ).toBe(ArticleIngestionStatus.Blocked);
+    });
+
+    it('still resolves Blocked when text is policy-blocked', () => {
+      expect(
+        deriveArticleIngestionState({
+          ...base,
+          hasModeratorOverride: true,
+          textBlocked: true,
+        })
+      ).toBe(ArticleIngestionStatus.Blocked);
+    });
+  });
+
+  describe('no override (default path unchanged)', () => {
+    it('resolves Error when a content image errored', () => {
+      expect(
+        deriveArticleIngestionState({ ...base, imageError: true })
+      ).toBe(ArticleIngestionStatus.Error);
+    });
+
+    it('resolves Error when text moderation errored', () => {
+      expect(
+        deriveArticleIngestionState({ ...base, textError: true })
+      ).toBe(ArticleIngestionStatus.Error);
+    });
+
+    it('resolves Blocked when a content image is policy-blocked', () => {
+      expect(
+        deriveArticleIngestionState({ ...base, imageBlocked: true })
+      ).toBe(ArticleIngestionStatus.Blocked);
+    });
+
+    it('resolves Pending while images are not yet all terminal', () => {
+      expect(
+        deriveArticleIngestionState({ ...base, imageDone: false })
+      ).toBe(ArticleIngestionStatus.Pending);
+    });
+
+    it('resolves Pending while text moderation is still outstanding', () => {
+      expect(
+        deriveArticleIngestionState({ ...base, textDone: false })
+      ).toBe(ArticleIngestionStatus.Pending);
+    });
+
+    it('resolves Scanned when everything is terminal and clean', () => {
+      expect(deriveArticleIngestionState(base)).toBe(ArticleIngestionStatus.Scanned);
+    });
+  });
+});

--- a/src/server/services/__tests__/article-ingestion.helpers.test.ts
+++ b/src/server/services/__tests__/article-ingestion.helpers.test.ts
@@ -67,6 +67,12 @@ describe('deriveArticleIngestionState', () => {
         })
       ).toBe(ArticleIngestionStatus.Blocked);
     });
+
+    it('resolves Scanned for a clean, fully-scanned article', () => {
+      expect(
+        deriveArticleIngestionState({ ...base, hasModeratorOverride: true })
+      ).toBe(ArticleIngestionStatus.Scanned);
+    });
   });
 
   describe('no override (default path unchanged)', () => {
@@ -85,6 +91,12 @@ describe('deriveArticleIngestionState', () => {
     it('resolves Blocked when a content image is policy-blocked', () => {
       expect(
         deriveArticleIngestionState({ ...base, imageBlocked: true })
+      ).toBe(ArticleIngestionStatus.Blocked);
+    });
+
+    it('resolves Blocked when an image is BOTH blocked and errored (Blocked beats Error — locks line order guarding the CSAM guard)', () => {
+      expect(
+        deriveArticleIngestionState({ ...base, imageBlocked: true, imageError: true })
       ).toBe(ArticleIngestionStatus.Blocked);
     });
 

--- a/src/server/services/article-ingestion.helpers.ts
+++ b/src/server/services/article-ingestion.helpers.ts
@@ -1,0 +1,52 @@
+import { ArticleIngestionStatus } from '~/shared/utils/prisma/enums';
+
+export type ArticleIngestionInputs = {
+  imageBlocked: boolean;
+  imageError: boolean;
+  imageDone: boolean;
+  textBlocked: boolean;
+  textError: boolean;
+  textDone: boolean;
+  hasModeratorOverride: boolean;
+};
+
+/**
+ * Pure decision for the article ingestion state machine, called from
+ * `recomputeArticleIngestionInTx` (the single choke point every scan/webhook/
+ * edit/reconcile recompute flows through). Lives in its own light module so the
+ * moderator-override precedence is unit-testable without dragging in the whole
+ * article.service dependency graph.
+ *
+ * Precedence, highest first:
+ *  1. Blocked — a policy-blocked image/text is a moderation signal, not a rating
+ *     question, so a moderator NSFW override never bypasses it. `ingestion =
+ *     Blocked` is the sole guard keeping a blocked image out of the feed and the
+ *     search index: `updateArticleNsfwLevels` derives the level from
+ *     `ingestion = 'Scanned'` images only and COALESCEs the override over it, so
+ *     a blocked (incl. pHash/CSAM) image's level never reaches `nsfwLevel`.
+ *  2. Override → Scanned — a moderator override supplies the article's rating
+ *     outright, so it supersedes both a still-Pending scan AND an Error. An
+ *     unscannable content image (e.g. animated webp, which the image scanner
+ *     errors on) must not drag an overridden article to Error and hide it; the
+ *     override is a human rating decision the scan can't reproduce. (#3314 only
+ *     let the override replace Pending, which is why an overridden article with
+ *     an unscannable embedded image still went Error.)
+ *  3. Error — an unresolvable scan/text failure with no override in force.
+ *  4. Scanned — everything terminal and clean.
+ *  5. Pending — still waiting on a scan/moderation callback.
+ */
+export function deriveArticleIngestionState({
+  imageBlocked,
+  imageError,
+  imageDone,
+  textBlocked,
+  textError,
+  textDone,
+  hasModeratorOverride,
+}: ArticleIngestionInputs): ArticleIngestionStatus {
+  if (imageBlocked || textBlocked) return ArticleIngestionStatus.Blocked;
+  if (hasModeratorOverride) return ArticleIngestionStatus.Scanned;
+  if (imageError || textError) return ArticleIngestionStatus.Error;
+  if (imageDone && textDone) return ArticleIngestionStatus.Scanned;
+  return ArticleIngestionStatus.Pending;
+}

--- a/src/server/services/article.service.ts
+++ b/src/server/services/article.service.ts
@@ -37,6 +37,7 @@ import { articleDetailSelect } from '~/server/selectors/article.selector';
 import type { ContentDecorationCosmetic, WithClaimKey } from '~/server/selectors/cosmetic.selector';
 import { imageSelect, profileImageSelect } from '~/server/selectors/image.selector';
 import { userWithCosmeticsSelect } from '~/server/selectors/user.selector';
+import { deriveArticleIngestionState } from '~/server/services/article-ingestion.helpers';
 import { throwOnBlockedLinkDomain } from '~/server/services/blocklist.service';
 import {
   getAvailableCollectionItemsFilterForUser,
@@ -2021,31 +2022,18 @@ export async function recomputeArticleIngestionInTx(
     hasText && !!textModeration && textErrorStatuses.includes(textModeration.status);
   const textDone = !hasText || textModeration?.status === EntityModerationStatus.Succeeded;
 
-  // --- Derive ingestion state ---
-  //
-  // A moderator-set NSFW override supplies the article's rating outright
-  // (updateArticleNsfwLevels COALESCEs it over the derived level), so an
-  // overridden article should not sit hidden in Pending waiting on a scan whose
-  // *rating* the override already supersedes — that's what bounced official
-  // articles out of the feed on every edit.
-  //
-  // It substitutes for Pending ONLY. Blocked and Error still win: an override is
-  // a rating decision, not a moderation bypass. A policy-blocked image can't
-  // surface through nsfwLevel either (the derivation joins `ingestion = 'Scanned'`
-  // images only, and the override COALESCEs over it), so `ingestion = Blocked` is
-  // the sole guard keeping it out of the feed and the search index.
+  // --- Derive ingestion state (precedence documented on deriveArticleIngestionState) ---
   const hasModeratorOverride = current.moderatorNsfwLevel != null;
 
-  let next: ArticleIngestionStatus;
-  if (imageBlocked || textBlocked) {
-    next = ArticleIngestionStatus.Blocked;
-  } else if (imageError || textError) {
-    next = ArticleIngestionStatus.Error;
-  } else if ((imageDone && textDone) || hasModeratorOverride) {
-    next = ArticleIngestionStatus.Scanned;
-  } else {
-    next = ArticleIngestionStatus.Pending;
-  }
+  const next = deriveArticleIngestionState({
+    imageBlocked,
+    imageError,
+    imageDone,
+    textBlocked,
+    textError,
+    textDone,
+    hasModeratorOverride,
+  });
 
   const flipToPublished =
     next === ArticleIngestionStatus.Scanned && current.status === ArticleStatus.Processing;


### PR DESCRIPTION
## The bug

An article with a moderator NSFW override set (`Article.moderatorNsfwLevel` NOT NULL) still gets its `ingestion` dragged to `Error` when an **embedded content image** fails scanning. Concretely: article 32939 embeds two animated-webp badge images that the image scanner errors on (animated webp is unscannable). The article aggregates its content images' ingestion, so it flips to `ingestion='Error'` — hiding it from feeds / marking it broken — even though a moderator override (`moderatorNsfwLevel=1`, `lockedProperties` includes `userNsfwLevel`) is in force and should make the scan result moot.

## Root cause / the gap I fixed

`recomputeArticleIngestionInTx` is the **single choke point** every scan/webhook/edit/reconcile recompute funnels through:
- image-scan webhooks and the `article-ingestion-reconcile` cron → `updateArticleImageScanStatus` → `recomputeArticleIngestionInTx`
- text-moderation webhooks + upsert → `recomputeArticleIngestion` → `recomputeArticleIngestionInTx`

It is also the **only** writer of `Article.ingestion = Error/Blocked` — there is **no bypass path**. PR #3314 added the override handling here, but its final pass narrowed the override to substitute for **`Pending` only**, so `imageError`/`textError` still won over the override. That is the exact path that dragged the override-set article to `Error`.

## The fix

Extract the state-machine decision into a pure, unit-tested `deriveArticleIngestionState` helper (`src/server/services/article-ingestion.helpers.ts`) and widen the override precedence. New precedence (highest first):

1. **Blocked** — a policy-blocked image/text wins even over an override. A block (incl. pHash/CSAM) is a moderation signal, not a rating question. `ingestion=Blocked` is the sole guard keeping a blocked image out of the feed + search index (`updateArticleNsfwLevels` derives level from `ingestion='Scanned'` images only and COALESCEs the override over it, so a blocked image's level never reaches `nsfwLevel`).
2. **Override → Scanned** — now supersedes both `Pending` **and** `Error`. An unscannable content image can no longer hide an overridden article.
3. **Error** — unresolvable scan/text failure, no override.
4. **Scanned** — everything terminal + clean.
5. **Pending** — still awaiting a callback.

### ⚠️ Deliberate scope decision — please confirm
The task named `Error/Blocked/Processing`. I made the override supersede **Error, Pending, and Processing (transient/technical states)** but **kept `Blocked` winning**, because #3314's adversarial review explicitly established that an override is "a rating decision, not a moderation bypass" and `ingestion=Blocked` is the only thing keeping a policy-blocked (potentially CSAM) image out of the feed and search index. Making the override supersede `Blocked` would reintroduce exactly the content-safety regression #3314's second pass reverted. The reported failure (unscannable animated webp) produces `Error`, never `Blocked`, so this fully fixes the reported bug. **If you do want `Blocked` overridden too, say so and I'll change one line** — but I'd advise against it.

## How to test
- Unit: `pnpm exec vitest run src/server/services/__tests__/article-ingestion.helpers.test.ts` (11 cases). Proves: override + content-image Error → `Scanned`; override + Pending → `Scanned`; override + Blocked → **still `Blocked`**; no-override + Error → `Error` (unchanged); no-override defaults unchanged.
- `pnpm typecheck` clean on touched files (only pre-existing `kysely` module-resolution noise in `packages/civitai-db*` remains, which is environmental worktree noise).

## Files changed
- `src/server/services/article-ingestion.helpers.ts` (new) — pure `deriveArticleIngestionState`
- `src/server/services/article.service.ts` — choke point now calls the helper
- `src/server/services/__tests__/article-ingestion.helpers.test.ts` (new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)