### PR TITLE
fix(orchestrator): route RU blob fetches through Cloudflare proxy

### DIFF
--- a/src/server/orchestrator/__tests__/region-proxy.test.ts
+++ b/src/server/orchestrator/__tests__/region-proxy.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from 'vitest';
 import {
   ORCHESTRATOR_PROXY_HOST,
-  deepRewriteOrchestratorUrls,
   rewriteOrchestratorUrlToProxy,
+  rewriteOrchestratorUrlsDeep,
 } from '~/server/orchestrator/region-proxy';
 
 describe('rewriteOrchestratorUrlToProxy', () => {
@@ -35,7 +35,7 @@ describe('rewriteOrchestratorUrlToProxy', () => {
   });
 });
 
-describe('deepRewriteOrchestratorUrls', () => {
+describe('rewriteOrchestratorUrlsDeep', () => {
   it('rewrites orchestrator URLs nested in arrays and objects, in place', () => {
     const payload = {
       items: [
@@ -48,7 +48,8 @@ describe('deepRewriteOrchestratorUrls', () => {
       ],
       video: 'https://orchestration-new.civitai.com/v2/consumer/blobs/v.mp4?sig=3',
     };
-    deepRewriteOrchestratorUrls(payload);
+    const returned = rewriteOrchestratorUrlsDeep(payload);
+    expect(returned).toBe(payload);
     expect(payload.items[0].url).toBe(
       `https://${ORCHESTRATOR_PROXY_HOST}/v2/consumer/blobs/a.jpeg?sig=1`
     );
@@ -58,5 +59,19 @@ describe('deepRewriteOrchestratorUrls', () => {
     expect(payload.items[0].nsfwLevel).toBe(4);
     expect(payload.items[0].cdn).toBe('https://image.civitai.com/keep.jpeg');
     expect(payload.video).toBe(`https://${ORCHESTRATOR_PROXY_HOST}/v2/consumer/blobs/v.mp4?sig=3`);
+  });
+
+  it('rewrites a bare top-level string payload', () => {
+    expect(
+      rewriteOrchestratorUrlsDeep(
+        'https://orchestration-new.civitai.com/v2/consumer/blobs/a.jpeg?sig=1'
+      )
+    ).toBe(`https://${ORCHESTRATOR_PROXY_HOST}/v2/consumer/blobs/a.jpeg?sig=1`);
+  });
+
+  it('leaves primitives and null untouched', () => {
+    expect(rewriteOrchestratorUrlsDeep(null)).toBe(null);
+    expect(rewriteOrchestratorUrlsDeep(42)).toBe(42);
+    expect(rewriteOrchestratorUrlsDeep(undefined)).toBe(undefined);
   });
 });

--- a/src/server/orchestrator/__tests__/region-proxy.test.ts
+++ b/src/server/orchestrator/__tests__/region-proxy.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+import {
+  ORCHESTRATOR_PROXY_HOST,
+  deepRewriteOrchestratorUrls,
+  rewriteOrchestratorUrlToProxy,
+} from '~/server/orchestrator/region-proxy';
+
+describe('rewriteOrchestratorUrlToProxy', () => {
+  it('swaps the orchestrator host and preserves path + presign query', () => {
+    const url =
+      'https://orchestration-new.civitai.com/v2/consumer/blobs/ABC123.jpeg?sig=CfDJ8abc&exp=2027-02-26T17:34:23Z';
+    expect(rewriteOrchestratorUrlToProxy(url)).toBe(
+      `https://${ORCHESTRATOR_PROXY_HOST}/v2/consumer/blobs/ABC123.jpeg?sig=CfDJ8abc&exp=2027-02-26T17:34:23Z`
+    );
+  });
+
+  it('rewrites any orchestration* subdomain', () => {
+    expect(
+      rewriteOrchestratorUrlToProxy('https://orchestration.civitai.com/v2/consumer/blobs/x.mp4')
+    ).toBe(`https://${ORCHESTRATOR_PROXY_HOST}/v2/consumer/blobs/x.mp4`);
+  });
+
+  it('leaves the proxy host untouched (no double-rewrite)', () => {
+    const url = `https://${ORCHESTRATOR_PROXY_HOST}/v2/consumer/blobs/x.jpeg`;
+    expect(rewriteOrchestratorUrlToProxy(url)).toBe(url);
+  });
+
+  it('ignores non-orchestrator URLs', () => {
+    const url = 'https://image.civitai.com/xyz/width=450/x.jpeg';
+    expect(rewriteOrchestratorUrlToProxy(url)).toBe(url);
+  });
+
+  it('returns malformed input unchanged', () => {
+    expect(rewriteOrchestratorUrlToProxy('not a url')).toBe('not a url');
+  });
+});
+
+describe('deepRewriteOrchestratorUrls', () => {
+  it('rewrites orchestrator URLs nested in arrays and objects, in place', () => {
+    const payload = {
+      items: [
+        {
+          url: 'https://orchestration-new.civitai.com/v2/consumer/blobs/a.jpeg?sig=1',
+          thumbnailUrl: 'https://orchestration-new.civitai.com/v2/consumer/blobs/thumb.jpeg?sig=2',
+          nsfwLevel: 4,
+          cdn: 'https://image.civitai.com/keep.jpeg',
+        },
+      ],
+      video: 'https://orchestration-new.civitai.com/v2/consumer/blobs/v.mp4?sig=3',
+    };
+    deepRewriteOrchestratorUrls(payload);
+    expect(payload.items[0].url).toBe(
+      `https://${ORCHESTRATOR_PROXY_HOST}/v2/consumer/blobs/a.jpeg?sig=1`
+    );
+    expect(payload.items[0].thumbnailUrl).toBe(
+      `https://${ORCHESTRATOR_PROXY_HOST}/v2/consumer/blobs/thumb.jpeg?sig=2`
+    );
+    expect(payload.items[0].nsfwLevel).toBe(4);
+    expect(payload.items[0].cdn).toBe('https://image.civitai.com/keep.jpeg');
+    expect(payload.video).toBe(`https://${ORCHESTRATOR_PROXY_HOST}/v2/consumer/blobs/v.mp4?sig=3`);
+  });
+});

--- a/src/server/orchestrator/region-proxy.middleware.ts
+++ b/src/server/orchestrator/region-proxy.middleware.ts
@@ -1,0 +1,19 @@
+import { rewriteOrchestratorUrlsDeep } from '~/server/orchestrator/region-proxy';
+import { middleware } from '~/server/trpc';
+import { getRegion } from '~/server/utils/region-blocking';
+
+/**
+ * tRPC middleware that rewrites orchestrator URLs in the response to the
+ * Cloudflare-fronted proxy for RU requests. Gated on the `ruOrchestratorProxy`
+ * feature flag (fails closed / off) so it can be killed at runtime via Flipt.
+ * Non-RU requests and the flag-off path early-return with zero traversal cost.
+ * Attach to any procedure that can return orchestrator blob URLs to the browser.
+ * See ClickUp 868kdkv93 / 868ke4d0f.
+ */
+export const regionProxyMiddleware = middleware(async ({ ctx, next }) => {
+  const result = await next();
+  if (!result.ok || !ctx.req || !ctx.features?.ruOrchestratorProxy) return result;
+  if (getRegion(ctx.req).countryCode !== 'RU') return result;
+  result.data = rewriteOrchestratorUrlsDeep(result.data);
+  return result;
+});

--- a/src/server/orchestrator/region-proxy.ts
+++ b/src/server/orchestrator/region-proxy.ts
@@ -6,6 +6,10 @@ import { isOrchestratorUrl } from '~/server/common/constants';
 // host bypasses the block region-wide. See ClickUp 868kdkv93 / 868ke4d0f.
 export const ORCHESTRATOR_PROXY_HOST = 'orchestration-proxy.civitai.com';
 
+// Bounds the recursive walk. tRPC payloads are JSON-serializable (acyclic) in
+// practice, so this is a defense-in-depth stack-overflow guard, not a real limit.
+const MAX_REWRITE_DEPTH = 64;
+
 /**
  * Swap an orchestrator URL's host to the Cloudflare-fronted proxy. Path and
  * query (incl. the presign `sig`) are preserved — the proxy is a transparent CF
@@ -25,24 +29,24 @@ export function rewriteOrchestratorUrlToProxy(url: string): string {
 }
 
 /**
- * Recursively rewrite every orchestrator URL string found in a tRPC response
- * payload to the proxy host, in place. Only invoked for proxied regions (RU), so
+ * Recursively rewrite every orchestrator URL string in a value to the proxy
+ * host, returning the (in-place mutated) value. Handles a bare-string payload as
+ * well as strings nested in arrays/objects. Only invoked for proxied regions, so
  * the traversal cost never touches the common path.
  */
-export function deepRewriteOrchestratorUrls(value: unknown): void {
-  if (!value || typeof value !== 'object') return;
+export function rewriteOrchestratorUrlsDeep(value: unknown, depth = 0): unknown {
+  if (typeof value === 'string') return rewriteOrchestratorUrlToProxy(value);
+  if (!value || typeof value !== 'object' || depth >= MAX_REWRITE_DEPTH) return value;
   if (Array.isArray(value)) {
     for (let i = 0; i < value.length; i++) {
-      const item = value[i];
-      if (typeof item === 'string') value[i] = rewriteOrchestratorUrlToProxy(item);
-      else deepRewriteOrchestratorUrls(item);
+      value[i] = rewriteOrchestratorUrlsDeep(value[i], depth + 1);
     }
-    return;
+    return value;
   }
   const record = value as Record<string, unknown>;
   for (const key in record) {
-    const item = record[key];
-    if (typeof item === 'string') record[key] = rewriteOrchestratorUrlToProxy(item);
-    else deepRewriteOrchestratorUrls(item);
+    if (!Object.prototype.hasOwnProperty.call(record, key)) continue;
+    record[key] = rewriteOrchestratorUrlsDeep(record[key], depth + 1);
   }
+  return value;
 }

--- a/src/server/orchestrator/region-proxy.ts
+++ b/src/server/orchestrator/region-proxy.ts
@@ -1,0 +1,48 @@
+import { isOrchestratorUrl } from '~/server/common/constants';
+
+// Cloudflare-fronted reverse proxy to the orchestrator. Russian ISP DPI filters
+// the bare orchestration origin IP/SNI directly, so browser-direct blob fetches
+// die in RU (net::ERR_TIMED_OUT). Routing those fetches through this CF-fronted
+// host bypasses the block region-wide. See ClickUp 868kdkv93 / 868ke4d0f.
+export const ORCHESTRATOR_PROXY_HOST = 'orchestration-proxy.civitai.com';
+
+/**
+ * Swap an orchestrator URL's host to the Cloudflare-fronted proxy. Path and
+ * query (incl. the presign `sig`) are preserved — the proxy is a transparent CF
+ * route to the same service, so signatures stay valid. Non-orchestrator URLs and
+ * URLs already on the proxy host are returned unchanged.
+ */
+export function rewriteOrchestratorUrlToProxy(url: string): string {
+  if (!isOrchestratorUrl(url)) return url;
+  try {
+    const parsed = new URL(url);
+    if (parsed.host === ORCHESTRATOR_PROXY_HOST) return url;
+    parsed.host = ORCHESTRATOR_PROXY_HOST;
+    return parsed.toString();
+  } catch {
+    return url;
+  }
+}
+
+/**
+ * Recursively rewrite every orchestrator URL string found in a tRPC response
+ * payload to the proxy host, in place. Only invoked for proxied regions (RU), so
+ * the traversal cost never touches the common path.
+ */
+export function deepRewriteOrchestratorUrls(value: unknown): void {
+  if (!value || typeof value !== 'object') return;
+  if (Array.isArray(value)) {
+    for (let i = 0; i < value.length; i++) {
+      const item = value[i];
+      if (typeof item === 'string') value[i] = rewriteOrchestratorUrlToProxy(item);
+      else deepRewriteOrchestratorUrls(item);
+    }
+    return;
+  }
+  const record = value as Record<string, unknown>;
+  for (const key in record) {
+    const item = record[key];
+    if (typeof item === 'string') record[key] = rewriteOrchestratorUrlToProxy(item);
+    else deepRewriteOrchestratorUrls(item);
+  }
+}

--- a/src/server/routers/comics.router.ts
+++ b/src/server/routers/comics.router.ts
@@ -11,6 +11,7 @@ import {
 } from '~/server/trpc';
 import { dbRead, dbWrite } from '~/server/db/client';
 import { fetchTimeoutSignal } from '~/server/utils/fetch-timeout';
+import { regionProxyMiddleware } from '~/server/orchestrator/region-proxy.middleware';
 import {
   throwAuthorizationError,
   throwBadRequestError,
@@ -140,8 +141,11 @@ async function getComicMetricRows(projectIds: number[]) {
 }
 
 const comicFlag = isFlagProtected('comicCreator');
-const comicProtectedProcedure = protectedProcedure.use(comicFlag);
-const comicPublicProcedure = publicProcedure.use(comicFlag);
+// Comic panel responses can surface raw orchestrator blob URLs (e.g.
+// `blurredPreviewUrl` on a blocked panel), which RU ISPs DPI-block. Rewrite them
+// to the Cloudflare-fronted proxy for RU requests. See ClickUp 868kdkv93.
+const comicProtectedProcedure = protectedProcedure.use(comicFlag).use(regionProxyMiddleware);
+const comicPublicProcedure = publicProcedure.use(comicFlag).use(regionProxyMiddleware);
 const comicModeratorProcedure = moderatorProcedure.use(comicFlag);
 
 // Comic panel generation runs on the shared preset image-gen service

--- a/src/server/routers/orchestrator.router.ts
+++ b/src/server/routers/orchestrator.router.ts
@@ -59,8 +59,7 @@ import {
 } from '~/server/trpc';
 import { throwAuthorizationError } from '~/server/utils/errorHandling';
 import { getOrchestratorToken } from '~/server/orchestrator/get-orchestrator-token';
-import { deepRewriteOrchestratorUrls } from '~/server/orchestrator/region-proxy';
-import { getRegion } from '~/server/utils/region-blocking';
+import { regionProxyMiddleware } from '~/server/orchestrator/region-proxy.middleware';
 import { pollIterationWorkflow } from '~/server/services/orchestrator/poll-iteration';
 import {
   getPresetModelConfig,
@@ -152,17 +151,6 @@ const enforceGenerationVersion = middleware(async ({ ctx, next }) => {
       ctx.res?.setHeader('x-generation-update-notes', decodeRedisString(genClient.notes));
   }
 
-  return result;
-});
-
-// RU ISPs DPI-block the bare orchestration origin, so browser-direct blob
-// fetches time out region-wide. Rewrite orchestrator URLs in the response to the
-// Cloudflare-fronted proxy for RU requests. See ClickUp 868kdkv93 / 868ke4d0f.
-const regionProxyMiddleware = middleware(async ({ ctx, next }) => {
-  const result = await next();
-  if (!result.ok || !ctx.req) return result;
-  if (getRegion(ctx.req).countryCode !== 'RU') return result;
-  deepRewriteOrchestratorUrls(result.data);
   return result;
 });
 

--- a/src/server/routers/orchestrator.router.ts
+++ b/src/server/routers/orchestrator.router.ts
@@ -59,6 +59,8 @@ import {
 } from '~/server/trpc';
 import { throwAuthorizationError } from '~/server/utils/errorHandling';
 import { getOrchestratorToken } from '~/server/orchestrator/get-orchestrator-token';
+import { deepRewriteOrchestratorUrls } from '~/server/orchestrator/region-proxy';
+import { getRegion } from '~/server/utils/region-blocking';
 import { pollIterationWorkflow } from '~/server/services/orchestrator/poll-iteration';
 import {
   getPresetModelConfig,
@@ -153,13 +155,26 @@ const enforceGenerationVersion = middleware(async ({ ctx, next }) => {
   return result;
 });
 
+// RU ISPs DPI-block the bare orchestration origin, so browser-direct blob
+// fetches time out region-wide. Rewrite orchestrator URLs in the response to the
+// Cloudflare-fronted proxy for RU requests. See ClickUp 868kdkv93 / 868ke4d0f.
+const regionProxyMiddleware = middleware(async ({ ctx, next }) => {
+  const result = await next();
+  if (!result.ok || !ctx.req) return result;
+  if (getRegion(ctx.req).countryCode !== 'RU') return result;
+  deepRewriteOrchestratorUrls(result.data);
+  return result;
+});
+
 const orchestratorProcedure = protectedProcedure
   .use(orchestratorMiddleware)
-  .use(enforceGenerationVersion);
+  .use(enforceGenerationVersion)
+  .use(regionProxyMiddleware);
 const orchestratorGuardedProcedure = guardedProcedure
   .use(orchestratorMiddleware)
   .use(experimentalMiddleware)
-  .use(enforceGenerationVersion);
+  .use(enforceGenerationVersion)
+  .use(regionProxyMiddleware);
 const experimentalProcedure = protectedProcedure.use(experimentalMiddleware);
 
 // The iterative editor's default preset model. The model registry itself lives
@@ -477,8 +492,7 @@ export const orchestratorRouter = router({
             name: 'what-if-from-graph',
             type: 'info',
             payload: input,
-            error:
-              e instanceof TRPCError ? { code: e.code, name: e.name, message: e.message } : e,
+            error: e instanceof TRPCError ? { code: e.code, name: e.name, message: e.message } : e,
           }).catch();
         } else {
           logToAxiom({

--- a/src/server/services/feature-flags.service.ts
+++ b/src/server/services/feature-flags.service.ts
@@ -318,6 +318,16 @@ const featureFlags = createFeatureFlags({
     fliptKey: 'model-metric-privacy-readtime',
   },
   imageIndexFeed: { availability: ['public'], fliptKey: 'image-index-feed' },
+  // Rewrite orchestrator blob URLs to the Cloudflare-fronted proxy for RU users
+  // (their ISPs DPI-block the bare orchestration origin). `availability: []` =
+  // DARK by default and FAILS CLOSED (empty availability → static eval false when
+  // Flipt is absent/down), so the rewrite stays OFF unless the `ru-orchestrator-proxy`
+  // Flipt flag is enabled — the flag is both the on-switch at rollout AND the
+  // instant kill-switch if the proxy misbehaves. The rewrite itself additionally
+  // gates on cf-ipcountry === 'RU', so non-RU users are never affected either way.
+  // See ClickUp 868kdkv93 / 868ke4d0f. (Mirrors the `creatorControls` /
+  // `hiddenPrefsCompact` `availability: []` fail-closed precedent.)
+  ruOrchestratorProxy: { availability: [], fliptKey: 'ru-orchestrator-proxy' },
   // #region [Domain Specific Features]
   isGreen: ['public', 'green'],
   isBlue: ['public', 'blue', 'red'],


### PR DESCRIPTION
## Problem

Since ~2026-07-11, users on **Russian ISPs** can load the site and run generations, but **generated images/videos never display** — the browser's direct fetches to `orchestration-new.civitai.com/v2/consumer/blobs/…` time out with `net::ERR_TIMED_OUT`. Everything else works.

**Root cause** (support diagnosis, Freshdesk 69212):
- `civitai.red` is Cloudflare-fronted → Russian ISP DPI routes around it (this is why the May 2026 routing change restored RU access).
- `orchestration-new.civitai.com` is a **bare origin IP** (not Cloudflare), so RU DPI filters it directly by IP/SNI.
- Net effect: the app loads and generation succeeds (rides the `.red` edge), but the browser fetches the result blobs straight from the un-fronted orchestration host — and *those* fetches are what get blocked. Host is globally healthy; only RU is affected.

## Fix

Rewrite orchestrator URLs in tRPC responses to the **Cloudflare-fronted proxy** `orchestration-proxy.civitai.com` for RU requests, so the browser fetches ride the CF edge and bypass the DPI block. The proxy is a transparent CF route to the same service, so the presign `sig`/`exp` query is preserved and stays valid.

- **Detection** reuses the existing `CF-IPCountry` header (`getRegion()` in `region-blocking.ts`) — same signal behind the May `.red` fix. No new detection code.
- Applied as a **post-response middleware** (`regionProxyMiddleware`) on `orchestratorProcedure` + `orchestratorGuardedProcedure`, covering all user-facing generation traffic: feed (`queryGeneratedImages`), `getWorkflow`, `queryWorkflowsByTags`, `generateFromGraph`, `whatIfFromGraph`, `statusUpdate`, `patch`, etc. Also attached to the user-facing **comics** procedures (a blocked comic panel returns a raw orchestrator `blurredPreviewUrl` that would otherwise stay DPI-blocked in RU).
- **Non-RU requests and the flag-off path early-return with zero traversal cost** — the recursive URL walk only runs for RU with the flag on.
- **Cache-safe**: the per-user service cache is Redis (out-of-process); the rewrite runs on the freshly-deserialized in-memory copy, so cached payloads stay region-agnostic. Rewrite is idempotent.

## Feature flag / kill-switch

Gated behind a new `ruOrchestratorProxy` flag (`availability: []` → **fails closed / off**; the `ru-orchestrator-proxy` Flipt key is the on-switch **and** the instant runtime kill-switch).

- Flipt flag PR (enabled): **civitai/flipt-state#53**. It's a no-op until this deploys — the flag key is only read by this code — so it can merge any time.
- Flip it **off** to instantly disable the rewrite fleet-wide if the proxy misbehaves, no deploy.

## Scope notes

- **`pollIterationStatus` / `iterateGenerate` untouched** — they download from the orchestrator server-side (US, unblocked) and return **S3/CDN keys**, not orchestrator URLs, so they're not browser-direct paths (verified in review).
- **Mod-only endpoints** (`queryUserGeneratedImages`, `getWorkflowForModeration`) are not covered — there are no RU moderators.
- **No migration.**

## Adversarial review

Reviewed by a sub-agent tasked to refute correctness/safety. No Critical/High issues in the core change. It confirmed the sig-preserving swap, ruled out cache poisoning (Redis, out-of-process) and a SignalR leak (that path resolves URLs via `statusUpdate`, which is covered), and verified the `pollIterationStatus` S3-key claim. The **Medium** finding (comics `blurredPreviewUrl` bypass) and two **Low** hardening notes (bare-string payload, recursion depth guard) are all addressed in this PR.

## Testing

- `pnpm typecheck` clean.
- 8 unit tests in `region-proxy.test.ts` (host swap, sig preservation, proxy-host no-double-rewrite, non-orchestrator passthrough, malformed input, deep nested walk, bare-string payload, primitive/null passthrough) — all pass.

## Tickets

- CU-868kdkv93 — Infra: front orchestration blob host with Cloudflare (RU DPI block)
- CU-868ke4d0f — RU point to new Orch domain
