### PR TITLE
feat(articles): surface ingestion-error state to owner + mods on the article page

### DIFF
--- a/src/pages/articles/[id]/[[...slug]].tsx
+++ b/src/pages/articles/[id]/[[...slug]].tsx
@@ -437,6 +437,22 @@ function ArticleDetailsPage({ id }: InferGetServerSidePropsType<typeof getServer
               </div>
             </AlertWithIcon>
           )}
+          {isOwner &&
+            (article.ingestion === ArticleIngestionStatus.Error ||
+              article.ingestion === ArticleIngestionStatus.Blocked) && (
+              <AlertWithIcon size="lg" icon={<IconAlertCircle />} color="red" iconColor="red">
+                <div>
+                  <Text fw={600} size="lg" mb="xs">
+                    This article isn&apos;t visible to the public
+                  </Text>
+                  <Text size="sm">
+                    {article.ingestion === ArticleIngestionStatus.Blocked
+                      ? 'One or more images were blocked by our content policy, so the article stays hidden from the public until the issue is resolved.'
+                      : 'Image scanning failed for one or more images (ingestion error), so the article stays hidden from the public until the scan succeeds or a moderator resolves it.'}
+                  </Text>
+                </div>
+              </AlertWithIcon>
+            )}
           {isOwner && article.ingestion && article.ingestion !== ArticleIngestionStatus.Scanned && (
             <ArticleScanStatus
               articleId={article.id}


### PR DESCRIPTION
## Problem

When an article's `ingestion` status is `Error` (image scanning failed), the article is **silently hidden from the public** — the feed, detail read, and search all require `ingestion = 'Scanned'`. But the article page itself showed **nothing** to explain the problem. The owner and moderators bypass the visibility gate and *can* load the page, yet had no idea why the public couldn't see it. Confusing and easy to mistake for a bug.

## Fix

Render a red Mantine `AlertWithIcon` near the top of the article detail body, shown **only to the article owner or a moderator** (`isOwner = isActualOwner || isModerator`), when the article is in a terminal hidden-from-public ingestion state:

- **`Error`** — "Image scanning failed for one or more images (ingestion error), so the article stays hidden from the public until the scan succeeds or a moderator resolves it."
- **`Blocked`** — "One or more images were blocked by our content policy, so the article stays hidden from the public until the issue is resolved."

`Pending`/`Rescan` are intentionally left to the existing `ArticleScanStatus` progress component (which renders scanning progress for non-`Scanned` states behind the `articleImageScanning` flag). The new banner is unconditional for the terminal states, so it shows even when that flag is off.

## Who sees it

Never shown to a non-owner non-mod — those users are already filtered out by the visibility gate and never reach the page in this state. Gating condition: `isOwner && (ingestion === 'Error' || ingestion === 'Blocked')`.

## Notes

- No select change needed: `ingestion` is already returned by `articleDetailSelect` (`src/server/selectors/article.selector.ts:55`), so it already flows to the client.
- `pnpm typecheck` clean on the touched file (only the pre-existing `kysely` module-resolution noise in `packages/civitai-db*` remains, unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)