### PR TITLE
feat(image-scan): observability for scan failures (Axiom + failing-step + queryable reason)

### DIFF
--- a/src/pages/api/webhooks/image-scan-result.ts
+++ b/src/pages/api/webhooks/image-scan-result.ts
@@ -171,6 +171,17 @@ export default WebhookEndpoint(async (req, res) => {
           incrementRetryCount: true,
           whereIngestionIn: pendingStates,
         });
+        logToAxiom(
+          {
+            name: 'image-scan-result',
+            type: 'warning',
+            message: 'legacy scanner returned Unscannable',
+            source: 'webhook-legacy',
+            failureType: 'unscannable',
+            imageId: data.id,
+          },
+          'webhooks'
+        ).catch(() => null);
         break;
       case Status.Success:
         await handleSuccess(data, req);

--- a/src/server/jobs/image-ingestion.ts
+++ b/src/server/jobs/image-ingestion.ts
@@ -4,6 +4,7 @@ import { isProd } from '~/env/other';
 import { env } from '~/env/server';
 import { dbRead, dbWrite } from '~/server/db/client';
 import { createJob } from '~/server/jobs/job';
+import { logToAxiom } from '~/server/logging/client';
 import type { IngestImageInput } from '~/server/schema/image.schema';
 import { deleteImages, ingestImage } from '~/server/services/image.service';
 import { limitConcurrency } from '~/server/utils/concurrency-helpers';
@@ -187,6 +188,49 @@ export const ingestImages = createJob('ingest-images', '*/5 * * * *', async () =
 
   const totalSent =
     sentUserPendingIds.length + sentBackfillIds.length + sentRescanIds.length + sentErrorIds.length;
+
+  // Failed sends = attempted minus successfully-dispatched, across every lane.
+  // sendImagesForScanBulk returns only the ids it managed to send, so the
+  // difference is the count that exhausted their in-batch retries.
+  const failedSends =
+    pendingUserUploads.length -
+    sentUserPendingIds.length +
+    (pendingBackfill.length - sentBackfillIds.length) +
+    (rescanImages.length - sentRescanIds.length) +
+    (errorImages.length - sentErrorIds.length);
+
+  logToAxiom(
+    {
+      name: 'image-ingestion',
+      type: 'job-summary',
+      sent: totalSent,
+      sentUserPending: sentUserPendingIds.length,
+      sentBackfill: sentBackfillIds.length,
+      sentRescan: sentRescanIds.length,
+      sentError: sentErrorIds.length,
+      pending: pendingImages.length,
+      rescan: rescanImages.length,
+      error: errorImages.length,
+      waitingForRetry: waitingForRetryIds.size,
+      staleRemoved: staleIds.length,
+      failedSends,
+    },
+    'webhooks'
+  ).catch(() => null);
+
+  if (failedSends > 0) {
+    logToAxiom(
+      {
+        name: 'image-ingestion',
+        type: 'error',
+        message: 'image scan sends failed',
+        failureType: 'send-fail',
+        failedSends,
+      },
+      'webhooks'
+    ).catch(() => null);
+  }
+
   return {
     sent: totalSent,
     sentUserPending: sentUserPendingIds.length,
@@ -195,6 +239,7 @@ export const ingestImages = createJob('ingest-images', '*/5 * * * *', async () =
     sentError: sentErrorIds.length,
     waitingForRetry: waitingForRetryIds.size,
     staleRemoved: staleIds.length,
+    failedSends,
   };
 });
 

--- a/src/server/services/image-scan-result.service.ts
+++ b/src/server/services/image-scan-result.service.ts
@@ -178,10 +178,14 @@ export async function processImageScanWorkflow({
 }) {
   if (status !== 'succeeded') {
     // Classify the non-success so Axiom can group by failureType + mediaType.
-    // `expired` is an orchestrator timeout (transient) vs a genuine
-    // `workflow-failed`; both currently burn a retry identically — we only LOG
-    // the distinction here so the retry-budget behavior can be measured before
-    // it's changed. See docs/image-scan-reliability.md §5.1/§5.4.
+    // `expired` is an orchestrator timeout (transient) — the workflow ran out of
+    // wall-clock before its mediaRating step finished, common when the
+    // low-priority lane is starved during a backlog. That is NOT the image's
+    // fault, so `markImageScanError` re-queues it WITHOUT burning one of the 9
+    // retries (see there); only a genuine `workflow-failed` (real decode/rating
+    // failure) consumes a retry. The app can't change the orchestrator-side
+    // expiry, so not-giving-up is the only app-side lever to keep scanning
+    // through a backlog. See docs/image-scan-reliability.md §5.1/§5.4.
     const failureType = status === 'expired' ? 'expired' : 'workflow-failed';
     const { retryCount, mediaType } = await markImageScanError({
       workflowId,
@@ -427,12 +431,21 @@ async function blockImageFromRating({
 }
 
 /**
- * Flip an image to `Error`, increment its scan `retryCount`, and stamp a small
- * `scanJobs.error = { status, failureType, at }` so a plain Postgres query can
- * tell WHY a scan errored without an orchestrator lookup. Returns the new
- * (post-increment) retryCount and the image's mediaType so callers can log them;
- * both are `null` when no row matched (e.g. the image was deleted between scan
- * request and callback).
+ * Flip an image to `Error`, stamp a small `scanJobs.error = { status,
+ * failureType, at }` so a plain Postgres query can tell WHY a scan errored
+ * without an orchestrator lookup, and conditionally bump `scanJobs.retryCount`.
+ *
+ * Retry budget: only a genuine `workflow-failed` (real decode/rating failure)
+ * consumes one of the 9 retries. An `expired`/timeout is transient (orchestrator
+ * ran out of wall-clock, usually a starved lane during a backlog), so it is
+ * re-queued WITHOUT incrementing retryCount — `Error` is already a re-scannable
+ * state that `ingest-images` picks back up after the error-retry delay, so the
+ * image keeps getting rescanned until the backlog drains instead of hitting the
+ * cap and getting permanently stuck.
+ *
+ * Returns the (possibly-unchanged) retryCount and the image's mediaType so
+ * callers can log them; both are `null` when no row matched (e.g. the image was
+ * deleted between scan request and callback).
  */
 async function markImageScanError({
   workflowId,
@@ -446,26 +459,34 @@ async function markImageScanError({
   failureType: string;
 }): Promise<{ retryCount: number | null; mediaType: string | null }> {
   const errorJson = JSON.stringify({ status, failureType, at: new Date().toISOString() });
-  const rows = await dbWrite.$queryRaw<{ retryCount: number | null; mediaType: string | null }[]>`
-    UPDATE "Image"
-    SET
-      "ingestion" = ${ImageIngestionStatus.Error}::"ImageIngestionStatus",
-      "scanJobs" = jsonb_set(
-        jsonb_set(
+  const burnRetry = failureType !== 'expired';
+
+  const withRetryBump = Prisma.sql`
+    jsonb_set(
+      COALESCE("scanJobs", '{}'),
+      '{retryCount}',
+      to_jsonb(COALESCE(("scanJobs"->>'retryCount')::int, 0) + 1)
+    )`;
+  const scanJobsBase = burnRetry ? withRetryBump : Prisma.sql`COALESCE("scanJobs", '{}')`;
+
+  const rows = await dbWrite.$queryRaw<{ retryCount: number | null; mediaType: string | null }[]>(
+    Prisma.sql`
+      UPDATE "Image"
+      SET
+        "ingestion" = ${ImageIngestionStatus.Error}::"ImageIngestionStatus",
+        "scanJobs" = jsonb_set(
           jsonb_set(
-            COALESCE("scanJobs", '{}'),
-            '{retryCount}',
-            to_jsonb(COALESCE(("scanJobs"->>'retryCount')::int, 0) + 1)
+            ${scanJobsBase},
+            '{workflowId}',
+            ${JSON.stringify(workflowId)}::jsonb
           ),
-          '{workflowId}',
-          ${JSON.stringify(workflowId)}::jsonb
-        ),
-        '{error}',
-        ${errorJson}::jsonb
-      )
-    WHERE id = ${imageId}
-    RETURNING ("scanJobs"->>'retryCount')::int as "retryCount", type as "mediaType"
-  `;
+          '{error}',
+          ${errorJson}::jsonb
+        )
+      WHERE id = ${imageId}
+      RETURNING ("scanJobs"->>'retryCount')::int as "retryCount", type as "mediaType"
+    `
+  );
   return { retryCount: rows[0]?.retryCount ?? null, mediaType: rows[0]?.mediaType ?? null };
 }
 

--- a/src/server/services/image-scan-result.service.ts
+++ b/src/server/services/image-scan-result.service.ts
@@ -177,21 +177,24 @@ export async function processImageScanWorkflow({
   completedAt?: Date | string | null;
 }) {
   if (status !== 'succeeded') {
-    // Classify the non-success so Axiom can group by failureType + mediaType.
-    // `expired` is an orchestrator timeout (transient) — the workflow ran out of
-    // wall-clock before its mediaRating step finished, common when the
-    // low-priority lane is starved during a backlog. That is NOT the image's
-    // fault, so `markImageScanError` re-queues it WITHOUT burning one of the 9
-    // retries (see there); only a genuine `workflow-failed` (real decode/rating
-    // failure) consumes a retry. The app can't change the orchestrator-side
-    // expiry, so not-giving-up is the only app-side lever to keep scanning
-    // through a backlog. See docs/image-scan-reliability.md §5.1/§5.4.
-    const failureType = status === 'expired' ? 'expired' : 'workflow-failed';
+    // Record WHICH orchestrator steps failed (wdTagging / mediaHash /
+    // mediaRating) — this is the key diagnostic. The orchestrator emits only a
+    // workflow-level status (`failed`/`canceled`; it never sends `expired`) with
+    // no per-job error reason on the wire, so the failing-step name is the only
+    // signal we have to tell transient decode/fetch churn apart from a genuine
+    // rating failure. NOTE: `markImageScanError` still ALWAYS bumps retryCount
+    // toward the 9-cap (see there). The expired-vs-failed "don't burn a retry"
+    // behavior is deferred: with no `expired` status and no per-job reason we
+    // can't yet distinguish a transient timeout from a real failure — this
+    // step/reason logging is the data needed to design that fix.
+    const failedSteps = extractFailedSteps(steps);
+    const failureType = status === 'canceled' ? 'canceled' : 'workflow-failed';
     const { retryCount, mediaType } = await markImageScanError({
       workflowId,
       imageId,
       status,
       failureType,
+      failedSteps,
     });
     logToAxiom(
       {
@@ -200,6 +203,7 @@ export async function processImageScanWorkflow({
         message: `workflow not succeeded: ${status}`,
         source: 'image-scan-result.service',
         failureType,
+        failedSteps,
         imageId,
         mediaType,
         workflowId,
@@ -431,62 +435,66 @@ async function blockImageFromRating({
 }
 
 /**
- * Flip an image to `Error`, stamp a small `scanJobs.error = { status,
- * failureType, at }` so a plain Postgres query can tell WHY a scan errored
- * without an orchestrator lookup, and conditionally bump `scanJobs.retryCount`.
- *
- * Retry budget: only a genuine `workflow-failed` (real decode/rating failure)
- * consumes one of the 9 retries. An `expired`/timeout is transient (orchestrator
- * ran out of wall-clock, usually a starved lane during a backlog), so it is
- * re-queued WITHOUT incrementing retryCount — `Error` is already a re-scannable
- * state that `ingest-images` picks back up after the error-retry delay, so the
- * image keeps getting rescanned until the backlog drains instead of hitting the
- * cap and getting permanently stuck.
- *
- * Returns the (possibly-unchanged) retryCount and the image's mediaType so
- * callers can log them; both are `null` when no row matched (e.g. the image was
- * deleted between scan request and callback).
+ * Which orchestrator steps reported `failed`, by step name (falling back to
+ * `$type`). This is the only per-failure diagnostic we get — the workflow status
+ * itself is just `failed`/`canceled` with no reason — so it's what tells a
+ * tagging failure (`tags`/wdTagging) apart from a hash (`hash`/mediaHash) or
+ * rating (`rating`/mediaRating) failure. Reads `status` off the raw workflow
+ * steps (not modeled on `ScanResultStep`, which only carries outputs).
+ */
+function extractFailedSteps(steps: ScanResultStep[]): string[] {
+  return (steps as Array<{ name?: string; $type?: string; status?: string }>)
+    .filter((step) => step?.status === 'failed')
+    .map((step) => step.name ?? step.$type ?? 'unknown');
+}
+
+/**
+ * Flip an image to `Error`, increment its scan `retryCount`, and stamp a small
+ * `scanJobs.error = { status, failureType, failedSteps, at }` so a plain
+ * Postgres query can tell WHY a scan errored (and which step) without an
+ * orchestrator lookup. Returns the new (post-increment) retryCount and the
+ * image's mediaType so callers can log them; both are `null` when no row matched
+ * (e.g. the image was deleted between scan request and callback).
  */
 async function markImageScanError({
   workflowId,
   imageId,
   status,
   failureType,
+  failedSteps,
 }: {
   workflowId: string;
   imageId: number;
   status: string;
   failureType: string;
+  failedSteps: string[];
 }): Promise<{ retryCount: number | null; mediaType: string | null }> {
-  const errorJson = JSON.stringify({ status, failureType, at: new Date().toISOString() });
-  const burnRetry = failureType !== 'expired';
-
-  const withRetryBump = Prisma.sql`
-    jsonb_set(
-      COALESCE("scanJobs", '{}'),
-      '{retryCount}',
-      to_jsonb(COALESCE(("scanJobs"->>'retryCount')::int, 0) + 1)
-    )`;
-  const scanJobsBase = burnRetry ? withRetryBump : Prisma.sql`COALESCE("scanJobs", '{}')`;
-
-  const rows = await dbWrite.$queryRaw<{ retryCount: number | null; mediaType: string | null }[]>(
-    Prisma.sql`
-      UPDATE "Image"
-      SET
-        "ingestion" = ${ImageIngestionStatus.Error}::"ImageIngestionStatus",
-        "scanJobs" = jsonb_set(
+  const errorJson = JSON.stringify({
+    status,
+    failureType,
+    failedSteps,
+    at: new Date().toISOString(),
+  });
+  const rows = await dbWrite.$queryRaw<{ retryCount: number | null; mediaType: string | null }[]>`
+    UPDATE "Image"
+    SET
+      "ingestion" = ${ImageIngestionStatus.Error}::"ImageIngestionStatus",
+      "scanJobs" = jsonb_set(
+        jsonb_set(
           jsonb_set(
-            ${scanJobsBase},
-            '{workflowId}',
-            ${JSON.stringify(workflowId)}::jsonb
+            COALESCE("scanJobs", '{}'),
+            '{retryCount}',
+            to_jsonb(COALESCE(("scanJobs"->>'retryCount')::int, 0) + 1)
           ),
-          '{error}',
-          ${errorJson}::jsonb
-        )
-      WHERE id = ${imageId}
-      RETURNING ("scanJobs"->>'retryCount')::int as "retryCount", type as "mediaType"
-    `
-  );
+          '{workflowId}',
+          ${JSON.stringify(workflowId)}::jsonb
+        ),
+        '{error}',
+        ${errorJson}::jsonb
+      )
+    WHERE id = ${imageId}
+    RETURNING ("scanJobs"->>'retryCount')::int as "retryCount", type as "mediaType"
+  `;
   return { retryCount: rows[0]?.retryCount ?? null, mediaType: rows[0]?.mediaType ?? null };
 }
 

--- a/src/server/services/image-scan-result.service.ts
+++ b/src/server/services/image-scan-result.service.ts
@@ -177,19 +177,27 @@ export async function processImageScanWorkflow({
   completedAt?: Date | string | null;
 }) {
   if (status !== 'succeeded') {
-    const retryCount = await markImageScanError({ workflowId, imageId });
-    // This branch is otherwise silent: it flips the image to `Error` and burns a
-    // retry regardless of whether the workflow genuinely failed or merely timed
-    // out (`expired`). Log it so we can measure the status split and how often
-    // transient orchestrator failures eat an image's retry budget before deciding
-    // how to branch them. See docs/image-scan-reliability.md §5.1/§5.4.
+    // Classify the non-success so Axiom can group by failureType + mediaType.
+    // `expired` is an orchestrator timeout (transient) vs a genuine
+    // `workflow-failed`; both currently burn a retry identically — we only LOG
+    // the distinction here so the retry-budget behavior can be measured before
+    // it's changed. See docs/image-scan-reliability.md §5.1/§5.4.
+    const failureType = status === 'expired' ? 'expired' : 'workflow-failed';
+    const { retryCount, mediaType } = await markImageScanError({
+      workflowId,
+      imageId,
+      status,
+      failureType,
+    });
     logToAxiom(
       {
         name: 'image-scan-result',
         type: 'warning',
         message: `workflow not succeeded: ${status}`,
         source: 'image-scan-result.service',
+        failureType,
         imageId,
+        mediaType,
         workflowId,
         status,
         retryCount,
@@ -419,34 +427,46 @@ async function blockImageFromRating({
 }
 
 /**
- * Flip an image to `Error` and increment its scan `retryCount`. Returns the new
- * (post-increment) retryCount so callers can log it, or `null` when no row matched
- * (e.g. the image was deleted between scan request and callback).
+ * Flip an image to `Error`, increment its scan `retryCount`, and stamp a small
+ * `scanJobs.error = { status, failureType, at }` so a plain Postgres query can
+ * tell WHY a scan errored without an orchestrator lookup. Returns the new
+ * (post-increment) retryCount and the image's mediaType so callers can log them;
+ * both are `null` when no row matched (e.g. the image was deleted between scan
+ * request and callback).
  */
 async function markImageScanError({
   workflowId,
   imageId,
+  status,
+  failureType,
 }: {
   workflowId: string;
   imageId: number;
-}): Promise<number | null> {
-  const rows = await dbWrite.$queryRaw<{ retryCount: number | null }[]>`
+  status: string;
+  failureType: string;
+}): Promise<{ retryCount: number | null; mediaType: string | null }> {
+  const errorJson = JSON.stringify({ status, failureType, at: new Date().toISOString() });
+  const rows = await dbWrite.$queryRaw<{ retryCount: number | null; mediaType: string | null }[]>`
     UPDATE "Image"
     SET
       "ingestion" = ${ImageIngestionStatus.Error}::"ImageIngestionStatus",
       "scanJobs" = jsonb_set(
         jsonb_set(
-          COALESCE("scanJobs", '{}'),
-          '{retryCount}',
-          to_jsonb(COALESCE(("scanJobs"->>'retryCount')::int, 0) + 1)
+          jsonb_set(
+            COALESCE("scanJobs", '{}'),
+            '{retryCount}',
+            to_jsonb(COALESCE(("scanJobs"->>'retryCount')::int, 0) + 1)
+          ),
+          '{workflowId}',
+          ${JSON.stringify(workflowId)}::jsonb
         ),
-        '{workflowId}',
-        ${JSON.stringify(workflowId)}::jsonb
+        '{error}',
+        ${errorJson}::jsonb
       )
     WHERE id = ${imageId}
-    RETURNING ("scanJobs"->>'retryCount')::int as "retryCount"
+    RETURNING ("scanJobs"->>'retryCount')::int as "retryCount", type as "mediaType"
   `;
-  return rows[0]?.retryCount ?? null;
+  return { retryCount: rows[0]?.retryCount ?? null, mediaType: rows[0]?.mediaType ?? null };
 }
 
 // Image loading

--- a/src/server/services/image.service.ts
+++ b/src/server/services/image.service.ts
@@ -899,7 +899,21 @@ export const ingestImage = async ({
       callbackUrl,
       priority: lowPriority ? 'low' : undefined,
     });
-    if (!workflowResponse) return false;
+    if (!workflowResponse) {
+      // The orchestrator submit already logs the transient failure in
+      // createImageIngestionRequest, but from here it's otherwise a silent
+      // `return false` — surface it at the dispatch layer so the failure is
+      // attributable to a specific image + media type.
+      logToAxiom({
+        name: 'image-ingestion',
+        type: 'error',
+        reason: 'no-workflow-response',
+        failureType: 'send-fail',
+        imageId: id,
+        mediaType: type,
+      }).catch(() => null);
+      return false;
+    }
     const scanJobsJson = JSON.stringify({ workflowId: workflowResponse.id });
     await dbClient.$executeRaw`
         UPDATE "Image"


### PR DESCRIPTION
## What this does — observability for image-scan failures

Image-scan failures were largely invisible, so we couldn't tell **when**, **why**, or **at which step** they fail. This adds structured Axiom events at every failure point plus a queryable failure reason on the Image row. **Observability only — scan retry/backoff behavior is unchanged.**

### Failing step is the key diagnostic
When a scan workflow doesn't succeed, the orchestrator delivers a workflow-level status (`failed`/`canceled`) but **no per-job error reason on the wire**. The one signal that pinpoints the cause is *which step failed* — so we parse `data.steps[]` and record the failed step name(s):

```ts
function extractFailedSteps(steps: ScanResultStep[]): string[] {
  return (steps as Array<{ name?: string; $type?: string; status?: string }>)
    .filter((step) => step?.status === 'failed')
    .map((step) => step.name ?? step.$type ?? 'unknown');
}
```

This distinguishes a tagging failure (`tags`/wdTagging) from a hash (`hash`/mediaHash) or rating (`rating`/mediaRating) failure — the thing we most need to know.

### Axiom events

| Where | Axiom event (`name` / `type`) | Key fields |
|---|---|---|
| `image.service.ts` `ingestImage` — new-path no-workflow | `image-ingestion` / `error` | `reason:'no-workflow-response'`, `failureType:'send-fail'`, `imageId`, `mediaType` |
| `image-scan-result.service.ts` non-success workflow | `image-scan-result` / `warning` | `failureType` (`workflow-failed`\|`canceled`), **`failedSteps`**, `imageId`, `mediaType`, `retryCount`, `workflowId`, `status` |
| `image-scan-result.ts` legacy `Unscannable` | `image-scan-result` / `warning` | `failureType:'unscannable'`, `imageId`, `source:'webhook-legacy'` |
| `image-ingestion.ts` per-run summary | `image-ingestion` / `job-summary` | `sent`, `pending`, `rescan`, `error`, `staleRemoved`, `failedSends` (+ per-lane sent counts) |
| `image-ingestion.ts` failed sends | `image-ingestion` / `error` | `failureType:'send-fail'`, `failedSends` |

**`failureType` taxonomy** (consistent across dispatch + result paths): `send-fail` · `workflow-failed` · `canceled` · `unscannable`.

### Queryable reason on the row
`markImageScanError` writes a minimal JSON blob on the existing `scanJobs` field (no new column/migration):

```json
"error": { "status": "failed", "failureType": "workflow-failed", "failedSteps": ["tags"], "at": "2026-07-24T…Z" }
```

`SELECT "scanJobs"->'error' FROM "Image" WHERE ingestion='Error'` tells you why + which step, no orchestrator lookup. `mediaType` comes from the same `UPDATE ... RETURNING type`, so no extra query.

## NOTE — expired-vs-failed retry fix is deferred (intentionally not here)

An earlier revision tried to *not burn a retry on `expired`/timeout*. Adversarial review of Axiom killed it: the orchestrator **never emits an `expired` status** (0 occurrences in 14 days — it's always `failed`/`canceled`), and it exposes **no per-job error reason**, so there is currently **no wire signal to distinguish a transient timeout from a genuine failure**. That branch was dead code, so it's removed — `markImageScanError` **always increments `retryCount`** exactly as before, and genuine failures still hit the 9-cap unchanged.

This PR's `failedSteps` + reason logging is precisely the data needed to design that retry-budget fix on evidence. Any future not-burn-retry path will also need an **absolute attempt ceiling** so it can't re-flood the scanner during a backlog.

Optional ClickHouse recording of failures was skipped to keep surface area small — Axiom + the queryable row field cover the need; possible follow-up.

## Verification
`pnpm typecheck` clean on all touched files (only the pre-existing `kysely` module-resolution noise in `packages/civitai-db*` remains, unrelated to this change).

## Files touched
- `src/server/services/image-scan-result.service.ts` — `extractFailedSteps` + `failedSteps` on the Axiom event and `scanJobs.error`; `markImageScanError` always bumps `retryCount`.
- `src/server/services/image.service.ts` — silent new-path send-failure log.
- `src/pages/api/webhooks/image-scan-result.ts` — legacy `Unscannable` Axiom event.
- `src/server/jobs/image-ingestion.ts` — per-run job-summary + structured failed-send event.

🤖 Generated with [Claude Code](https://claude.com/claude-code)