### PR TITLE
feat(moderation): ban modal — separate models + media removal toggles

### DIFF
--- a/src/components/Profile/UserBanModal.tsx
+++ b/src/components/Profile/UserBanModal.tsx
@@ -10,6 +10,7 @@ import {
   Text,
   Title,
 } from '@mantine/core';
+import { IconAlertTriangle } from '@tabler/icons-react';
 import { useMemo, useState } from 'react';
 import { useDialogContext } from '~/components/Dialog/DialogProvider';
 import { RichTextEditor } from '~/components/RichTextEditor/RichTextEditor';
@@ -152,7 +153,7 @@ export default function UserBanModal({ username, userId, onSuccess }: Props) {
             onChange={(event) => setRemoveMedia(event.currentTarget.checked)}
           />
           {banPreview && (removeModels || removeMedia) && (
-            <Alert color="red" p="xs">
+            <Alert color="red" p="xs" icon={<IconAlertTriangle size={18} />}>
               {[
                 removeModels
                   ? `${numberWithCommas(banPreview.modelCount)} model${

--- a/src/components/Profile/UserBanModal.tsx
+++ b/src/components/Profile/UserBanModal.tsx
@@ -16,6 +16,7 @@ import { RichTextEditor } from '~/components/RichTextEditor/RichTextEditor';
 import { SupportContent } from '~/components/Support/SupportContent';
 import { banReasonDetails } from '~/server/common/constants';
 import { BanReasonCode } from '~/server/common/enums';
+import { numberWithCommas } from '~/utils/number-helpers';
 import { showErrorNotification } from '~/utils/notifications';
 import { trpc } from '~/utils/trpc';
 
@@ -130,9 +131,9 @@ export default function UserBanModal({ username, userId, onSuccess }: Props) {
             label="Unpublish all models"
             description={
               banPreview
-                ? `Unpublishes this user's ${banPreview.modelCount} published model${
-                    banPreview.modelCount === 1 ? '' : 's'
-                  }.`
+                ? `Unpublishes this user's ${numberWithCommas(
+                    banPreview.modelCount
+                  )} published model${banPreview.modelCount === 1 ? '' : 's'}.`
                 : 'Unpublishes all of this user’s published models.'
             }
             checked={removeModels}
@@ -142,7 +143,7 @@ export default function UserBanModal({ username, userId, onSuccess }: Props) {
             label="Remove all images & videos"
             description={
               banPreview
-                ? `Blocks this user's ${banPreview.imageCount} image${
+                ? `Blocks this user's ${numberWithCommas(banPreview.imageCount)} image${
                     banPreview.imageCount === 1 ? '' : 's'
                   } & videos (7-day appeal window, then deleted).`
                 : 'Blocks all of this user’s images & videos.'
@@ -154,10 +155,12 @@ export default function UserBanModal({ username, userId, onSuccess }: Props) {
             <Alert color="red" p="xs">
               {[
                 removeModels
-                  ? `${banPreview.modelCount} model${banPreview.modelCount === 1 ? '' : 's'}`
+                  ? `${numberWithCommas(banPreview.modelCount)} model${
+                      banPreview.modelCount === 1 ? '' : 's'
+                    }`
                   : null,
                 removeMedia
-                  ? `${banPreview.imageCount} image${
+                  ? `${numberWithCommas(banPreview.imageCount)} image${
                       banPreview.imageCount === 1 ? '' : 's'
                     } & videos`
                   : null,

--- a/src/components/Profile/UserBanModal.tsx
+++ b/src/components/Profile/UserBanModal.tsx
@@ -150,11 +150,17 @@ export default function UserBanModal({ username, userId, onSuccess }: Props) {
             checked={removeMedia}
             onChange={(event) => setRemoveMedia(event.currentTarget.checked)}
           />
-          {(removeModels || removeMedia) && (
+          {banPreview && (removeModels || removeMedia) && (
             <Alert color="red" p="xs">
               {[
-                removeModels && banPreview ? `${banPreview.modelCount} models` : null,
-                removeMedia && banPreview ? `${banPreview.imageCount} images & videos` : null,
+                removeModels
+                  ? `${banPreview.modelCount} model${banPreview.modelCount === 1 ? '' : 's'}`
+                  : null,
+                removeMedia
+                  ? `${banPreview.imageCount} image${
+                      banPreview.imageCount === 1 ? '' : 's'
+                    } & videos`
+                  : null,
               ]
                 .filter(Boolean)
                 .join(' and ')}{' '}

--- a/src/components/Profile/UserBanModal.tsx
+++ b/src/components/Profile/UserBanModal.tsx
@@ -1,4 +1,15 @@
-import { Button, CloseButton, Group, Modal, Select, Stack, Text, Title } from '@mantine/core';
+import {
+  Alert,
+  Button,
+  CloseButton,
+  Group,
+  Modal,
+  Select,
+  Stack,
+  Switch,
+  Text,
+  Title,
+} from '@mantine/core';
 import { useMemo, useState } from 'react';
 import { useDialogContext } from '~/components/Dialog/DialogProvider';
 import { RichTextEditor } from '~/components/RichTextEditor/RichTextEditor';
@@ -20,6 +31,13 @@ export default function UserBanModal({ username, userId, onSuccess }: Props) {
   const [reasonCode, setReasonCode] = useState<BanReasonCode>(BanReasonCode.Other);
   const [detailsInternal, setDetailsInternal] = useState<string | undefined>('');
   const [detailsExternal, setDetailsExternal] = useState<string | undefined>('');
+  // Unpublishing models happens on every ban historically, so default it on.
+  // Blocking media defaults on only for SexualMinor (kept in sync as the reason
+  // changes, but a mod can still override either toggle).
+  const [removeModels, setRemoveModels] = useState(true);
+  const [removeMedia, setRemoveMedia] = useState(false);
+
+  const { data: banPreview } = trpc.user.getBanContentPreview.useQuery({ userId });
   const dataLabels = useMemo(() => {
     return Object.keys(BanReasonCode).map((r) => {
       const data = banReasonDetails[r as BanReasonCode];
@@ -67,7 +85,20 @@ export default function UserBanModal({ username, userId, onSuccess }: Props) {
       return;
     }
 
-    toggleBanMutation.mutate({ id: userId, reasonCode, detailsInternal, detailsExternal });
+    toggleBanMutation.mutate({
+      id: userId,
+      reasonCode,
+      detailsInternal,
+      detailsExternal,
+      removeModels,
+      removeMedia,
+    });
+  };
+
+  const handleReasonChange = (value: string | null) => {
+    const nextReason = value as BanReasonCode;
+    setReasonCode(nextReason);
+    setRemoveMedia(nextReason === BanReasonCode.SexualMinor);
   };
 
   return (
@@ -90,9 +121,47 @@ export default function UserBanModal({ username, userId, onSuccess }: Props) {
           placeholder="Select a ban reason"
           data={dataLabels}
           value={reasonCode}
-          onChange={(value) => setReasonCode(value as BanReasonCode)}
+          onChange={handleReasonChange}
           withAsterisk
         />
+
+        <Stack gap="sm">
+          <Switch
+            label="Unpublish all models"
+            description={
+              banPreview
+                ? `Unpublishes this user's ${banPreview.modelCount} published model${
+                    banPreview.modelCount === 1 ? '' : 's'
+                  }.`
+                : 'Unpublishes all of this user’s published models.'
+            }
+            checked={removeModels}
+            onChange={(event) => setRemoveModels(event.currentTarget.checked)}
+          />
+          <Switch
+            label="Remove all images & videos"
+            description={
+              banPreview
+                ? `Blocks this user's ${banPreview.imageCount} image${
+                    banPreview.imageCount === 1 ? '' : 's'
+                  } & videos (7-day appeal window, then deleted).`
+                : 'Blocks all of this user’s images & videos.'
+            }
+            checked={removeMedia}
+            onChange={(event) => setRemoveMedia(event.currentTarget.checked)}
+          />
+          {(removeModels || removeMedia) && (
+            <Alert color="red" p="xs">
+              {[
+                removeModels && banPreview ? `${banPreview.modelCount} models` : null,
+                removeMedia && banPreview ? `${banPreview.imageCount} images & videos` : null,
+              ]
+                .filter(Boolean)
+                .join(' and ')}{' '}
+              will be removed on ban.
+            </Alert>
+          )}
+        </Stack>
 
         <RichTextEditor
           label="Internal Details"


### PR DESCRIPTION
Frontend for the split-toggle ban flow, consuming the merged backend contract (#3349).

Replaces the single ambiguous "Remove all content" toggle with two clearly-scoped switches in `UserBanModal`:

| Switch | Default | Effect |
|---|---|---|
| **Unpublish all models** | ON (every ban) | Matches historical behavior; a mod can now opt out. |
| **Remove all images & videos** | ON for SexualMinor, else OFF | Blocks the user's media (7-day appeal window). Synced to the reason on change, still overridable. |

- Each switch shows its own count from `getBanContentPreview` → `{ imageCount, modelCount }`.
- A summary Alert states exactly what will be removed before the mod confirms.
- Passes `removeModels` / `removeMedia` into `toggleBan`.

Depends on #3349 (merged). Typecheck + prettier clean.

**Review locally:** pull this branch into the primary worktree, open a non-banned user's profile → ⋯ menu → "Ban user". Set reason to SexualMinor (both toggles ON) vs another reason (only models ON). Don't submit — dev server is on prod DB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
