### PR TITLE
fix(apps): prefer page <title> over host name in external submit autofill (+ de-hyphenate host fallback)

### DIFF
--- a/src/components/Apps/ExternalSubmitForm.browser.test.tsx
+++ b/src/components/Apps/ExternalSubmitForm.browser.test.tsx
@@ -23,7 +23,12 @@ const READONLY_SCOPES = 4 | 32; // ModelsRead | MediaRead
 const mocks = vi.hoisted(() => ({
   submit: vi.fn(),
   mutate: vi.fn(),
-  meta: { data: undefined as unknown, isFetching: false, isSuccess: false },
+  meta: { data: undefined as unknown, isFetching: false, isSuccess: false } as {
+    data: unknown;
+    isFetching: boolean;
+    isSuccess: boolean;
+    isError?: boolean;
+  },
   clients: {
     data: [{ id: 'oauth-client-1', name: 'My OAuth App', allowedScopes: 4 | 32 }] as unknown,
     isLoading: false,
@@ -173,6 +178,9 @@ describe('ExternalSubmitForm — redesigned wizard', () => {
       data: [{ id: 'oauth-client-1', name: 'My OAuth App', allowedScopes: 0 }],
       isLoading: false,
     };
+    // Meta settles with no title → the Name autofills from the host fallback so the
+    // Details step is complete and "Create draft" is enabled.
+    mocks.meta = { data: {}, isFetching: false, isSuccess: true };
     renderWithProviders(<ExternalSubmitForm />);
     await advanceFromUrl();
     await pickClient();
@@ -183,10 +191,12 @@ describe('ExternalSubmitForm — redesigned wizard', () => {
     expect(mocks.mutate).toHaveBeenCalledTimes(1);
   });
 
-  test('the App URL prefills name + slug on Details, and og:description autofills the Description', async () => {
+  test('the page <title> (not the host) fills the Name; slug still derives from the host; og:description autofills the Description', async () => {
+    // Regression (bug report): cosmetic-studio.civitai.com must show the real page
+    // <title> "Civitai Cosmetic Studio" in Name, NOT the host-derived "Cosmetic Studio".
     mocks.meta = {
       data: {
-        name: 'OG Name',
+        name: 'Civitai Cosmetic Studio',
         tagline: 'short',
         description: 'A longer description pulled from the link.',
         coverImageUrl: undefined,
@@ -196,18 +206,83 @@ describe('ExternalSubmitForm — redesigned wizard', () => {
       isSuccess: true,
     };
     renderWithProviders(<ExternalSubmitForm />);
-    await advanceFromUrl('https://vitrine.civitai.com');
+    await advanceFromUrl('https://cosmetic-studio.civitai.com');
     await pickClient();
     await page.getByTestId('apps-offsite-wizard-next-app').click();
-    // Name/slug derive from the URL host (filled before the OG name, non-clobber).
-    await expect.element(page.getByRole('textbox', { name: /^Name/ })).toHaveValue('Vitrine');
-    await expect.element(page.getByRole('textbox', { name: /^Slug/ })).toHaveValue('vitrine');
+    // The extracted <title> WINS over the host-derived name ("Cosmetic Studio").
+    await expect
+      .element(page.getByTestId('apps-offsite-submit-name'))
+      .toHaveValue('Civitai Cosmetic Studio');
+    // Slug still derives from the URL host (hyphenated — slugs keep hyphens).
+    await expect.element(page.getByRole('textbox', { name: /^Slug/ })).toHaveValue('cosmetic-studio');
     // og:description autofills the (empty) Description field.
     await expect
       .element(page.getByTestId('apps-offsite-submit-description'))
       .toHaveValue('A longer description pulled from the link.');
     // The "we found your details" reveal is shown.
     await expect.element(page.getByTestId('apps-offsite-autofill-reveal')).toBeInTheDocument();
+  });
+
+  test('when the meta fetch returns NO title, the Name falls back to the de-hyphenated host name', async () => {
+    // Settled with data but no name/title → host fallback, de-hyphenated to a space.
+    mocks.meta = {
+      data: {
+        name: undefined,
+        tagline: undefined,
+        description: undefined,
+        coverImageUrl: undefined,
+        iconImageUrl: undefined,
+      },
+      isFetching: false,
+      isSuccess: true,
+    };
+    renderWithProviders(<ExternalSubmitForm />);
+    await advanceFromUrl('https://cosmetic-studio.civitai.com');
+    await pickClient();
+    await page.getByTestId('apps-offsite-wizard-next-app').click();
+    // No <title> → host-derived name, de-hyphenated ("Cosmetic Studio", not "Cosmetic-Studio").
+    await expect
+      .element(page.getByTestId('apps-offsite-submit-name'))
+      .toHaveValue('Cosmetic Studio');
+    await expect.element(page.getByRole('textbox', { name: /^Slug/ })).toHaveValue('cosmetic-studio');
+  });
+
+  test('when the meta fetch ERRORS, the Name still falls back to the de-hyphenated host name', async () => {
+    // The fetch settling as an error must not leave Name blank — host fallback applies.
+    mocks.meta = { data: undefined, isFetching: false, isSuccess: false, isError: true };
+    renderWithProviders(<ExternalSubmitForm />);
+    await advanceFromUrl('https://cosmetic-studio.civitai.com');
+    await pickClient();
+    await page.getByTestId('apps-offsite-wizard-next-app').click();
+    await expect
+      .element(page.getByTestId('apps-offsite-submit-name'))
+      .toHaveValue('Cosmetic Studio');
+  });
+
+  test('a Name the user already typed is never overwritten by the title or the host fallback', async () => {
+    // Meta has NOT settled yet when the author reaches Details and types a name.
+    mocks.meta = { data: undefined, isFetching: false, isSuccess: false, isError: false };
+    renderWithProviders(<ExternalSubmitForm />);
+    await advanceFromUrl('https://cosmetic-studio.civitai.com');
+    await pickClient();
+    await page.getByTestId('apps-offsite-wizard-next-app').click();
+    const name = page.getByTestId('apps-offsite-submit-name');
+    await name.fill('User Typed Name');
+    // The meta fetch now resolves WITH a <title>; force a re-render so the effect runs.
+    mocks.meta = {
+      data: {
+        name: 'Civitai Cosmetic Studio',
+        tagline: undefined,
+        description: undefined,
+        coverImageUrl: undefined,
+        iconImageUrl: undefined,
+      },
+      isFetching: false,
+      isSuccess: true,
+    };
+    await page.getByRole('textbox', { name: /^Tagline/ }).fill('trigger a re-render');
+    // Neither the title nor the host fallback clobbers the typed name.
+    await expect.element(name).toHaveValue('User Typed Name');
   });
 
   test('autofill does NOT clobber a description the user already typed', async () => {
@@ -229,6 +304,8 @@ describe('ExternalSubmitForm — redesigned wizard', () => {
   });
 
   test('submitting valid details calls submitExternalListing (server owns the draft)', async () => {
+    // Meta settles with no title → Name autofills from the host fallback, completing Details.
+    mocks.meta = { data: {}, isFetching: false, isSuccess: true };
     renderWithProviders(<ExternalSubmitForm />);
     await advanceFromUrl();
     await pickClient();

--- a/src/components/Apps/ExternalSubmitForm.tsx
+++ b/src/components/Apps/ExternalSubmitForm.tsx
@@ -115,6 +115,10 @@ function ExternalCreateForm() {
   const [suggestions, setSuggestions] = useState<MetaSuggestions>({});
   const [autofillApplied, setAutofillApplied] = useState(false);
   const appliedMetaRef = useRef<string | null>(null);
+  // Host-derived name kept as a FALLBACK only — used to fill `name` when the OG-meta
+  // fetch settles with no usable `<title>`. The real page title is preferred (see the
+  // meta effect); we never seed this up front so the title can win.
+  const hostNameFallbackRef = useRef<string>('');
 
   const clientsQuery = trpc.oauthClient.getAll.useQuery(undefined, {
     retry: false,
@@ -140,35 +144,47 @@ function ExternalCreateForm() {
     { enabled: !!metaUrl, retry: false, refetchOnWindowFocus: false, staleTime: Infinity }
   );
 
+  // Apply the OG-meta prefill ONCE per settled URL. Runs only after the fetch settles
+  // (success OR error) for the current `metaUrl`, so the real page `<title>`
+  // (`data.name`) has a chance to arrive before we touch the `name` field — the Name
+  // input lives on the later Details step, so the fetch has time. NAME precedence:
+  // prefer the extracted `<title>`; if the fetch yields none (or errors), fall back to
+  // the host-derived name. Every field is fill-if-empty, so typed text is never
+  // clobbered.
   useEffect(() => {
-    if (!metaQuery.data || appliedMetaRef.current === metaUrl) return;
-    appliedMetaRef.current = metaUrl;
+    if (!metaUrl || appliedMetaRef.current === metaUrl) return;
+    // Wait until the fetch settles for THIS url. With a per-url cache key + retry:false,
+    // `metaQuery.data` (when present) belongs to `metaUrl`, and `isError` is its result.
+    if (metaQuery.isFetching) return;
     const data = metaQuery.data;
+    const settled = !!data || metaQuery.isError;
+    if (!settled) return;
+    appliedMetaRef.current = metaUrl;
+
+    // Prefer the page <title> (data.name) over the host-derived fallback name.
+    const resolvedName = data?.name || hostNameFallbackRef.current;
     setValues((v) => ({
       ...v,
-      name: v.name.trim().length === 0 && data.name ? data.name : v.name,
-      tagline: v.tagline.trim().length === 0 && data.tagline ? data.tagline : v.tagline,
+      name: v.name.trim().length === 0 && resolvedName ? resolvedName : v.name,
+      tagline: v.tagline.trim().length === 0 && data?.tagline ? data.tagline : v.tagline,
       // Description autofill: fill ONLY when empty, truncated to the field bound —
       // a suggestion the author can freely edit or clear (never clobbers typed text).
       description:
-        v.description.trim().length === 0 && data.description
+        v.description.trim().length === 0 && data?.description
           ? data.description.slice(0, OFFSITE_SUBMIT_LIMITS.descriptionMax)
           : v.description,
     }));
-    setSuggestions({ coverImageUrl: data.coverImageUrl, iconImageUrl: data.iconImageUrl });
+    setSuggestions({ coverImageUrl: data?.coverImageUrl, iconImageUrl: data?.iconImageUrl });
     // Reveal the "we found your details" note whenever the link yielded anything the
     // author can accept (computed from `data` directly — NOT the async setValues
     // updater, whose side effects haven't run yet at this point).
     if (
-      data.name ||
-      data.tagline ||
-      data.description ||
-      data.coverImageUrl ||
-      data.iconImageUrl
+      data &&
+      (data.name || data.tagline || data.description || data.coverImageUrl || data.iconImageUrl)
     ) {
       setAutofillApplied(true);
     }
-  }, [metaQuery.data, metaUrl]);
+  }, [metaUrl, metaQuery.isFetching, metaQuery.data, metaQuery.isError]);
 
   const submitMutation = trpc.appListings.submitExternalListing.useMutation({
     onSuccess: (res: Submitted) => {
@@ -210,10 +226,15 @@ function ExternalCreateForm() {
 
   function applyNormalizedUrl(normalized: string) {
     const derived = deriveListingFromUrl(normalized);
+    // Stash the host-derived name as a FALLBACK for the meta effect — do NOT set the
+    // `name` field here. Setting it up front (this fires before the OG-meta fetch
+    // resolves) would make the meta effect's "only fill if empty" guard skip the real
+    // page `<title>`, so the uglier host name would preempt the better title. The slug
+    // IS set immediately (slugs are hyphenated + there's no better source for them).
+    hostNameFallbackRef.current = derived.name;
     setValues((v) => ({
       ...v,
       externalUrl: normalized,
-      name: v.name.trim().length === 0 && derived.name ? derived.name : v.name,
       slug: v.slug.trim().length === 0 && derived.slug ? derived.slug : v.slug,
     }));
   }

--- a/src/components/Apps/__tests__/deriveListingFromUrl.test.ts
+++ b/src/components/Apps/__tests__/deriveListingFromUrl.test.ts
@@ -23,11 +23,21 @@ describe('deriveListingFromUrl — happy paths', () => {
     });
   });
 
-  it('strips a leading www. and keeps the first label (hyphenated)', () => {
+  it('strips a leading www. and keeps the first label (name de-hyphenated to spaces)', () => {
     // hostname is lower-cased by the URL parser, so the title-case is deterministic.
+    // The human-readable NAME joins words with a space; the SLUG keeps its hyphens.
     expect(deriveListingFromUrl('https://www.My-App.io/path?q=1')).toEqual({
-      name: 'My-App',
+      name: 'My App',
       slug: 'my-app',
+    });
+  });
+
+  it('cosmetic-studio.civitai.com → "Cosmetic Studio" (space, not hyphen) / cosmetic-studio', () => {
+    // Regression: the host-fallback name must read naturally ("Cosmetic Studio"),
+    // never the hyphenated "Cosmetic-Studio"; the slug stays hyphenated.
+    expect(deriveListingFromUrl('https://cosmetic-studio.civitai.com')).toEqual({
+      name: 'Cosmetic Studio',
+      slug: 'cosmetic-studio',
     });
   });
 
@@ -40,14 +50,14 @@ describe('deriveListingFromUrl — happy paths', () => {
 
   it('uses only the FIRST dot-label (subdomain wins over apex)', () => {
     expect(deriveListingFromUrl('https://cool-tool.example.co.uk')).toEqual({
-      name: 'Cool-Tool',
+      name: 'Cool Tool',
       slug: 'cool-tool',
     });
   });
 
-  it('lower-cases the remainder of each hyphen word', () => {
+  it('lower-cases the remainder of each hyphen word (name space-joined)', () => {
     expect(deriveListingFromUrl('https://SUPER-APP.com')).toEqual({
-      name: 'Super-App',
+      name: 'Super App',
       slug: 'super-app',
     });
   });
@@ -133,7 +143,7 @@ describe('deriveListingFromUrl — hostile / edge hosts never throw', () => {
   it('IDN host is punycode-derived (no throw, regex-safe slug)', () => {
     // The URL parser converts `münchen.de` → `xn--mnchen-3ya.de` before we see it.
     const result = deriveListingFromUrl('https://münchen.de');
-    expect(result).toEqual({ name: 'Xn-Mnchen-3ya', slug: 'xn-mnchen-3ya' });
+    expect(result).toEqual({ name: 'Xn Mnchen 3ya', slug: 'xn-mnchen-3ya' });
     expect(SLUG_REGEX.test(result.slug)).toBe(true);
   });
 

--- a/src/components/Apps/offsiteSubmitFormConfig.ts
+++ b/src/components/Apps/offsiteSubmitFormConfig.ts
@@ -182,9 +182,15 @@ export function isOffsiteSubmitFormValid(values: OffsiteSubmitFormValues): boole
  *   - Take the hostname (already lowercased by the URL parser), strip a leading
  *     `www.`, and use the FIRST dot-label as the base
  *     (`vitrine.civitai.com` → `vitrine`; `www.my-app.io` → `my-app`).
- *   - `name`  = the base, hyphen-word title-cased: each `-`-separated word gets
- *     its first char upper-cased and the remainder lower-cased, rejoined with
- *     `-` (`vitrine` → `Vitrine`; `my-app` → `My-App`; `example` → `Example`).
+ *   - `name`  = the base, word title-cased: each `-`-separated word gets its
+ *     first char upper-cased and the remainder lower-cased, rejoined with a
+ *     SPACE so the human-readable name reads naturally
+ *     (`vitrine` → `Vitrine`; `my-app` → `My App`;
+ *     `cosmetic-studio` → `Cosmetic Studio`; `example` → `Example`). This name
+ *     is only a FALLBACK — the submit wizard prefers the page's real `<title>`
+ *     (from the OG-meta fetch) and uses this host-derived name solely when the
+ *     meta fetch yields no usable title. Only the `name` is de-hyphenated; the
+ *     `slug` below keeps hyphens (slugs need them).
  *   - `slug`  = the base kebab-cased + SLUG_REGEX-sanitized: lower-cased, every
  *     run of non `[a-z0-9]` chars collapsed to a single `-`, leading/trailing `-`
  *     trimmed, and any leading non-letters dropped (SLUG_REGEX requires a leading
@@ -212,7 +218,7 @@ export function deriveListingFromUrl(url: string): { name: string; slug: string 
     .split('-')
     .filter((word) => word.length > 0)
     .map((word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
-    .join('-');
+    .join(' ');
 
   const slugCandidate = base
     .toLowerCase()


### PR DESCRIPTION
## What

Two flaws in the external app-listing **submit wizard** name autofill (`src/components/Apps/ExternalSubmitForm.tsx` + `offsiteSubmitFormConfig.ts`), driven by a real bug report.

**Bug report:** For `https://cosmetic-studio.civitai.com` the page's real `<title>` is **"Civitai Cosmetic Studio"** (extracted server-side by the OG-meta fetch, `fetchListingMetaFromUrl` → `data.name`), but the form showed the uglier host-derived **"Cosmetic-Studio"**.

### Fix 1 — prefer the extracted `<title>` over the host-derived name
Previously `applyNormalizedUrl` (on URL-advance) set the `name` from the host **up front**, before the OG-meta fetch resolved — so the meta-apply effect (also guarded on `name` empty) could never fill the better `<title>`.

Now:
- `applyNormalizedUrl` sets the **slug** from the host immediately (kept — slugs need hyphens and there's no better source), but **no longer sets `name`**. It stashes the host-derived name in a `hostNameFallbackRef`.
- The meta effect runs once the fetch **settles** (success **or** error) for the current URL, and fills `name` from `data.name` (the `<title>`). It uses the host-derived name **only as a fallback** when the fetch yields no usable title.
- Every field stays **fill-if-empty**, so a name the user has typed is never clobbered (both the title and the host fallback pass through the same `v.name.trim().length === 0` guard).

The Name field lives on a later wizard step (Details) than the App URL step, so the fetch has time to resolve first.

### Fix 2 — de-hyphenate the host fallback name
`deriveListingFromUrl` joined name words with a hyphen (`base.split('-').map(capitalize).join('-')` → `"Cosmetic-Studio"`). It now joins with a **space** → `"Cosmetic Studio"`. The **slug** derivation stays hyphenated/unchanged.

### Scope
- CREATE submit wizard only. The **edit** form (`ExternalListingEditForm`) does not host-derive a name (it fills only from `data.name`), so it has no host-preempts-title bug — left unchanged.
- Description autofill (from `og:description`, fill-if-empty, truncated) and the cover/icon suggestion behavior are **unchanged**.

## Tests
- **`deriveListingFromUrl` unit** (`__tests__/deriveListingFromUrl.test.ts`): `cosmetic-studio.civitai.com` → name **"Cosmetic Studio"** (space) / slug **"cosmetic-studio"**; updated the other multi-word host cases (`My App`, `Cool Tool`, `Super App`, IDN `Xn Mnchen 3ya`); single-label hosts unaffected.
- **Form browser tests** (`ExternalSubmitForm.browser.test.tsx`): title wins over host (`"Civitai Cosmetic Studio"`); host de-hyphenated fallback when the meta returns **no title**; fallback also applies when the fetch **errors**; a **user-typed name is never overwritten** by either source. Two existing submit tests updated to settle the meta so the fallback fills the name.

### Verbatim results (honest)
- `deriveListingFromUrl.test.ts` (unit): **31 passed**.
- `ExternalSubmitForm.browser.test.tsx` (component/chromium): **13 passed**.
- Sibling suites `ExternalSubmitForm.reducedMotion` + `ExternalSubmitForm.edit` (component): **11 passed**.
- Related config suites `offsiteSubmitFormConfig` + `offsiteSubmitFormConfig.oauth-fields` + `normalizeLinkUrl` (unit): **57 passed**.
- `tsc --noEmit` (heap-bumped): **0 errors in changed files**; 16 remaining are the pre-existing env errors only (`kysely`, `event-engine-common`, `image.service.ts` implicit-any) — unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)