### PR TITLE
feat(challenge): Prometheus instrumentation for the Challenge funnel + economy + state

### DIFF
--- a/src/pages/api/metrics.ts
+++ b/src/pages/api/metrics.ts
@@ -3,6 +3,9 @@ import { EOL } from 'os';
 import client from 'prom-client';
 import { dbRead, dbWrite } from '~/server/db/client';
 import { instrumentationRegistry } from '~/server/prom/client';
+// Side-effect import: registers the challenge state gauges (collect()-based) on the default
+// registry so they are present + scraped even before the first challenge op runs this session.
+import '~/server/prom/challenge.metrics';
 import { WebhookEndpoint } from '~/server/utils/endpoint-helpers';
 
 const labels: Record<string, string> = {};

--- a/src/server/games/daily-challenge/challenge-funding.ts
+++ b/src/server/games/daily-challenge/challenge-funding.ts
@@ -45,6 +45,11 @@ import {
 } from '~/shared/constants/challenge.constants';
 import { ChallengeSource, CollectionItemStatus } from '~/shared/utils/prisma/enums';
 import { createLogger } from '~/utils/logging';
+import {
+  recordChallengeEntryFeesBuzz,
+  recordChallengeRefundBuzz,
+  recordChallengeRefundFailure,
+} from '~/server/prom/challenge.metrics';
 
 const log = createLogger('challenge-funding', 'yellow');
 
@@ -209,6 +214,15 @@ export async function chargeEntryFees({
     }).catch(() => {});
   }
 
+  // Economy telemetry: Buzz newly charged this call (house + pool legs charged for the FIRST time —
+  // conflicts/retries already counted on the original charge, so this can't double-count). Entry
+  // fees only exist on source=User challenges.
+  recordChallengeEntryFeesBuzz({
+    source: ChallengeSource.User,
+    buzzType: fromAccountType,
+    amount: houseResult.transactions.length * houseAmount + newPoolCharges * poolAmount,
+  });
+
   return { paidImageIds, unpaidImageIds };
 }
 
@@ -249,17 +263,22 @@ async function refundChallengeFundsByPrefix(input: {
   externalTransactionIdPrefix: string;
   description: string;
   details: { challengeId: number };
-}): Promise<number> {
+}): Promise<{ count: number; amount: number }> {
   try {
-    const { refundedTransactions } = await refundMultiAccountTransaction(input);
-    return refundedTransactions.length;
+    const { refundedTransactions, totalRefunded } = await refundMultiAccountTransaction(input);
+    return { count: refundedTransactions.length, amount: totalRefunded };
   } catch (e) {
-    if (e instanceof TRPCError && e.code === 'NOT_FOUND') return 0;
+    if (e instanceof TRPCError && e.code === 'NOT_FOUND') return { count: 0, amount: 0 };
     throw e;
   }
 }
 
-export async function refundUserChallengeFunds(challengeId: number) {
+export async function refundUserChallengeFunds(
+  challengeId: number,
+  // Telemetry-only: what triggered the refund. Normalized to void|delete|other in the metric
+  // helper; does not affect refund behavior.
+  reason: 'void' | 'delete' | 'completion' | 'other' = 'other'
+) {
   const challenge = await dbRead.challenge.findUnique({
     where: { id: challengeId },
     select: {
@@ -267,29 +286,48 @@ export async function refundUserChallengeFunds(challengeId: number) {
       basePrizePool: true,
       createdById: true,
       entryFee: true,
+      buzzType: true,
     },
   });
   if (!challenge || challenge.source !== ChallengeSource.User) return { refundedEntries: 0 };
 
   let refundedEntries = 0;
-  if (challenge.entryFee > 0) {
-    // The trailing `-` keeps this prefix from matching another challenge's fees (e.g. challenge 5's
-    // `challenge-entry-fee-5-` never matches challenge 50's `challenge-entry-fee-50-...`).
-    refundedEntries = await refundChallengeFundsByPrefix({
-      externalTransactionIdPrefix: `challenge-entry-fee-${challengeId}-`,
-      description: 'Challenge cancelled — entry fee refund',
-      details: { challengeId },
-    });
-  }
+  try {
+    let refundedAmount = 0;
+    if (challenge.entryFee > 0) {
+      // The trailing `-` keeps this prefix from matching another challenge's fees (e.g. challenge 5's
+      // `challenge-entry-fee-5-` never matches challenge 50's `challenge-entry-fee-50-...`).
+      const res = await refundChallengeFundsByPrefix({
+        externalTransactionIdPrefix: `challenge-entry-fee-${challengeId}-`,
+        description: 'Challenge cancelled — entry fee refund',
+        details: { challengeId },
+      });
+      refundedEntries = res.count;
+      refundedAmount += res.amount;
+    }
 
-  if (challenge.basePrizePool > 0 && challenge.createdById != null) {
-    // Reverse the actual escrow charge by its collision-safe prefix (mint-safe) — the `-creator`
-    // token makes this prefix unambiguous vs other challenge ids (5 vs 50, 51, ...).
-    await refundChallengeFundsByPrefix({
-      externalTransactionIdPrefix: `challenge-initial-prize-${challengeId}-creator`,
-      description: 'Challenge cancelled — initial prize refund',
-      details: { challengeId },
+    if (challenge.basePrizePool > 0 && challenge.createdById != null) {
+      // Reverse the actual escrow charge by its collision-safe prefix (mint-safe) — the `-creator`
+      // token makes this prefix unambiguous vs other challenge ids (5 vs 50, 51, ...).
+      const res = await refundChallengeFundsByPrefix({
+        externalTransactionIdPrefix: `challenge-initial-prize-${challengeId}-creator`,
+        description: 'Challenge cancelled — initial prize refund',
+        details: { challengeId },
+      });
+      refundedAmount += res.amount;
+    }
+
+    recordChallengeRefundBuzz({
+      source: challenge.source,
+      buzzType: challenge.buzzType,
+      reason,
+      amount: refundedAmount,
     });
+  } catch (e) {
+    // A real refund failure (NOT_FOUND is already swallowed as a no-op inside the prefix helper);
+    // count it, then rethrow so the caller's void/delete recovery path is unchanged.
+    recordChallengeRefundFailure({ source: challenge.source, reason });
+    throw e;
   }
 
   log(

--- a/src/server/games/daily-challenge/challenge-helpers.ts
+++ b/src/server/games/daily-challenge/challenge-helpers.ts
@@ -1,6 +1,7 @@
 import { Prisma } from '@prisma/client';
 import { dbRead, dbWrite } from '~/server/db/client';
 import { logToAxiom } from '~/server/logging/client';
+import { recordChallengeOperationSpentBuzz } from '~/server/prom/challenge.metrics';
 import { removeTags } from '~/utils/string-helpers';
 import type { ChallengeBuzzType } from '~/server/games/daily-challenge/challenge-currency';
 import { isImageHiddenFromGreenViewer } from '~/server/games/daily-challenge/challenge-visibility';
@@ -761,6 +762,23 @@ export async function incrementOperationSpent(challengeId: number, amount: numbe
     SET "operationSpent" = "operationSpent" + ${amount}
     WHERE id = ${challengeId}
   `;
+
+  // Economy telemetry (fully guarded — a metrics failure must never break the spend increment).
+  // A cheap PK read supplies the source/buzzType labels; operation-spend events are infrequent
+  // (judging batches), so the extra lookup is negligible.
+  try {
+    const challenge = await dbRead.challenge.findUnique({
+      where: { id: challengeId },
+      select: { source: true, buzzType: true },
+    });
+    recordChallengeOperationSpentBuzz({
+      source: challenge?.source,
+      buzzType: challenge?.buzzType,
+      amount,
+    });
+  } catch {
+    /* never throw from telemetry */
+  }
 }
 
 // =============================================================================

--- a/src/server/games/daily-challenge/challenge-nsfw-escalation.test.ts
+++ b/src/server/games/daily-challenge/challenge-nsfw-escalation.test.ts
@@ -88,7 +88,7 @@ describe('applyChallengeNsfwEscalation', () => {
     await applyChallengeNsfwEscalation({ entityId: 42, isNsfw: true });
 
     expect(order).toEqual(['void', 'update']);
-    expect(mockVoidChallenge).toHaveBeenCalledWith(42);
+    expect(mockVoidChallenge).toHaveBeenCalledWith(42, 'nsfw');
     const data = mockDbWrite.challenge.update.mock.calls[0][0].data;
     expect(data.ingestion).toBe('Scanned');
     expect(data.nsfwLevel).toBeUndefined(); // cancel path does not raise the level
@@ -128,7 +128,7 @@ describe('applyChallengeNsfwEscalation', () => {
 
     // voidChallenge owns the Active -> Cancelled claim that keeps the completion cron from paying
     // winners out of the pool being refunded, plus the entrant refund + cancellation notices.
-    expect(mockVoidChallenge).toHaveBeenCalledWith(77);
+    expect(mockVoidChallenge).toHaveBeenCalledWith(77, 'nsfw');
     const data = mockDbWrite.challenge.update.mock.calls[0][0].data;
     expect(data.ingestion).toBe('Blocked');
     expect(mockCreateNotification).toHaveBeenCalledWith(

--- a/src/server/games/daily-challenge/challenge-nsfw-escalation.ts
+++ b/src/server/games/daily-challenge/challenge-nsfw-escalation.ts
@@ -59,7 +59,7 @@ export async function applyChallengeNsfwEscalation({
     // collection closed + prize refunded, all idempotent) is always safe. Void FIRST so a crash
     // before the scan-state write leaves it Cancelled/hidden, never Scanned-and-visible.
     if (challenge.status === ChallengeStatus.Scheduled) {
-      await voidChallenge(entityId);
+      await voidChallenge(entityId, 'nsfw');
       await dbWrite.challenge.update({
         where: { id: entityId },
         data: { ingestion: ChallengeIngestionStatus.Scanned, scannedAt: new Date() },
@@ -91,7 +91,7 @@ export async function applyChallengeNsfwEscalation({
     if (challenge.status === ChallengeStatus.Active) {
       // A lost claim means the completion cron won the race and is paying out — fall through to
       // the hold branch rather than telling the creator about a refund that never happened.
-      const { voided } = await voidChallenge(entityId);
+      const { voided } = await voidChallenge(entityId, 'nsfw');
       if (voided) {
         await dbWrite.challenge.update({
           where: { id: entityId },

--- a/src/server/jobs/challenge-activation.ts
+++ b/src/server/jobs/challenge-activation.ts
@@ -54,7 +54,7 @@ export async function runChallengeActivation() {
             }
             if (rescanned !== ChallengeIngestionStatus.Blocked && !gracePassed) return;
           }
-          await voidChallenge(challengeId);
+          await voidChallenge(challengeId, 'activation');
           log(`Voided unscanned user challenge ${challengeId} (${ingestion})`);
         } catch (error) {
           const err = error as Error;

--- a/src/server/prom/__tests__/challenge.metrics.test.ts
+++ b/src/server/prom/__tests__/challenge.metrics.test.ts
@@ -1,0 +1,344 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import client from 'prom-client';
+import {
+  normSource,
+  normBuzzType,
+  normScanResult,
+  normStatus,
+  normPaid,
+  normVoidReason,
+  normRefundReason,
+  recordChallengeCreated,
+  recordChallengeScanResult,
+  recordChallengeEntrySubmitted,
+  recordChallengeReviewRequested,
+  recordChallengeCompleted,
+  recordChallengeVoided,
+  recordChallengeDeleted,
+  recordChallengeEntryFeesBuzz,
+  recordChallengePrizePaidBuzz,
+  recordChallengeOperationSpentBuzz,
+  recordChallengeRefundBuzz,
+  recordChallengeRefundFailure,
+  __resetChallengeMetricsForTest,
+  __setChallengeGaugeCacheForTest,
+} from '~/server/prom/challenge.metrics';
+
+// Pure unit test: challenge.metrics imports only prom-client + the prom-client-only telemetry
+// helpers, and the state-gauge DB read is a LAZY dynamic import — so nothing here boots pgDb/env or
+// the app graph. Counters are driven directly and read back off the default registry; the gauge
+// test injects cache rows (mocking the DB) via __setChallengeGaugeCacheForTest and reads the
+// collect()-emitted series.
+
+type MetricJSON = { values: { value: number; labels: Record<string, string> }[] };
+
+async function readMetric(name: string): Promise<MetricJSON['values']> {
+  const metric = client.register.getSingleMetric(name) as unknown as {
+    get: () => Promise<MetricJSON>;
+  };
+  const data = await metric.get();
+  return data.values;
+}
+
+async function valueFor(name: string, labels: Record<string, string>): Promise<number> {
+  const values = await readMetric(name);
+  const match = values.find((v) => Object.entries(labels).every(([k, val]) => v.labels[k] === val));
+  return match?.value ?? 0;
+}
+
+beforeEach(() => {
+  __resetChallengeMetricsForTest();
+});
+
+describe('label normalizers — enum-bound, never raw/free-text', () => {
+  it('normSource maps known → itself, everything else → unknown', () => {
+    expect(normSource('System')).toBe('System');
+    expect(normSource('Mod')).toBe('Mod');
+    expect(normSource('User')).toBe('User');
+    expect(normSource('Hacker')).toBe('unknown');
+    expect(normSource(undefined)).toBe('unknown');
+    expect(normSource(null)).toBe('unknown');
+    expect(normSource('')).toBe('unknown');
+  });
+
+  it('normBuzzType bounds to green|yellow, else unknown', () => {
+    expect(normBuzzType('green')).toBe('green');
+    expect(normBuzzType('yellow')).toBe('yellow');
+    expect(normBuzzType('blue')).toBe('unknown');
+    expect(normBuzzType(undefined)).toBe('unknown');
+  });
+
+  it('normScanResult bounds to scanned|blocked|error, unknown → error', () => {
+    expect(normScanResult('scanned')).toBe('scanned');
+    expect(normScanResult('blocked')).toBe('blocked');
+    expect(normScanResult('error')).toBe('error');
+    expect(normScanResult('weird-verdict')).toBe('error');
+    expect(normScanResult(undefined)).toBe('error');
+  });
+
+  it('normStatus bounds to the 5 ChallengeStatus values, else unknown', () => {
+    for (const s of ['Scheduled', 'Active', 'Completing', 'Completed', 'Cancelled']) {
+      expect(normStatus(s)).toBe(s);
+    }
+    expect(normStatus('Deleted')).toBe('unknown');
+    expect(normStatus(null)).toBe('unknown');
+  });
+
+  it('normPaid returns 1 for truthy, 0 otherwise', () => {
+    expect(normPaid(true)).toBe('1');
+    expect(normPaid(false)).toBe('0');
+    expect(normPaid(undefined)).toBe('0');
+    expect(normPaid(null)).toBe('0');
+  });
+
+  it('normVoidReason bounds to moderator|nsfw|activation, free-text → other', () => {
+    expect(normVoidReason('moderator')).toBe('moderator');
+    expect(normVoidReason('nsfw')).toBe('nsfw');
+    expect(normVoidReason('activation')).toBe('activation');
+    expect(normVoidReason('because-i-said-so')).toBe('other');
+    expect(normVoidReason(undefined)).toBe('other');
+  });
+
+  it('normRefundReason bounds to void|delete, everything else (incl. completion) → other', () => {
+    expect(normRefundReason('void')).toBe('void');
+    expect(normRefundReason('delete')).toBe('delete');
+    expect(normRefundReason('completion')).toBe('other');
+    expect(normRefundReason('anything')).toBe('other');
+    expect(normRefundReason(undefined)).toBe('other');
+  });
+});
+
+describe('funnel counters emit the expected series with normalized labels', () => {
+  it('challenge_created_total labels source/buzzType (bad values → unknown)', async () => {
+    recordChallengeCreated({ source: 'User', buzzType: 'yellow' });
+    recordChallengeCreated({ source: 'User', buzzType: 'yellow' });
+    recordChallengeCreated({ source: 'nope', buzzType: 'purple' });
+
+    expect(
+      await valueFor('civitai_app_challenge_created_total', { source: 'User', buzzType: 'yellow' })
+    ).toBe(2);
+    expect(
+      await valueFor('civitai_app_challenge_created_total', {
+        source: 'unknown',
+        buzzType: 'unknown',
+      })
+    ).toBe(1);
+  });
+
+  it('challenge_scan_result_total buckets by result', async () => {
+    recordChallengeScanResult({ source: 'User', result: 'scanned' });
+    recordChallengeScanResult({ source: 'User', result: 'blocked' });
+    recordChallengeScanResult({ source: 'System', result: 'error' });
+
+    expect(
+      await valueFor('civitai_app_challenge_scan_result_total', {
+        source: 'User',
+        result: 'scanned',
+      })
+    ).toBe(1);
+    expect(
+      await valueFor('civitai_app_challenge_scan_result_total', {
+        source: 'User',
+        result: 'blocked',
+      })
+    ).toBe(1);
+    expect(
+      await valueFor('civitai_app_challenge_scan_result_total', {
+        source: 'System',
+        result: 'error',
+      })
+    ).toBe(1);
+  });
+
+  it('challenge_entry_submitted_total increments by count with paid label', async () => {
+    recordChallengeEntrySubmitted({ source: 'User', buzzType: 'green', paid: true, count: 3 });
+    recordChallengeEntrySubmitted({ source: 'User', buzzType: 'green', paid: false, count: 2 });
+    // default count = 1 when omitted / non-positive
+    recordChallengeEntrySubmitted({ source: 'User', buzzType: 'yellow', paid: true });
+
+    expect(
+      await valueFor('civitai_app_challenge_entry_submitted_total', {
+        source: 'User',
+        buzzType: 'green',
+        paid: '1',
+      })
+    ).toBe(3);
+    expect(
+      await valueFor('civitai_app_challenge_entry_submitted_total', {
+        source: 'User',
+        buzzType: 'green',
+        paid: '0',
+      })
+    ).toBe(2);
+    expect(
+      await valueFor('civitai_app_challenge_entry_submitted_total', {
+        source: 'User',
+        buzzType: 'yellow',
+        paid: '1',
+      })
+    ).toBe(1);
+  });
+
+  it('review/completed/voided/deleted counters emit', async () => {
+    recordChallengeReviewRequested({ source: 'User' });
+    recordChallengeCompleted({ source: 'System' });
+    recordChallengeVoided({ source: 'User', reason: 'nsfw' });
+    recordChallengeVoided({ source: 'User', reason: 'made-up' }); // → other
+    recordChallengeDeleted({ source: 'User' });
+
+    expect(
+      await valueFor('civitai_app_challenge_review_requested_total', { source: 'User' })
+    ).toBe(1);
+    expect(await valueFor('civitai_app_challenge_completed_total', { source: 'System' })).toBe(1);
+    expect(
+      await valueFor('civitai_app_challenge_voided_total', { source: 'User', reason: 'nsfw' })
+    ).toBe(1);
+    expect(
+      await valueFor('civitai_app_challenge_voided_total', { source: 'User', reason: 'other' })
+    ).toBe(1);
+    expect(await valueFor('civitai_app_challenge_deleted_total', { source: 'User' })).toBe(1);
+  });
+});
+
+describe('economy counters — inc by buzz amount, skip non-positive', () => {
+  it('entry fees / prize paid / operation spent sum by amount', async () => {
+    recordChallengeEntryFeesBuzz({ source: 'User', buzzType: 'yellow', amount: 100 });
+    recordChallengeEntryFeesBuzz({ source: 'User', buzzType: 'yellow', amount: 50 });
+    recordChallengePrizePaidBuzz({ source: 'User', buzzType: 'green', amount: 5000 });
+    recordChallengeOperationSpentBuzz({ source: 'System', buzzType: 'yellow', amount: 42 });
+
+    expect(
+      await valueFor('civitai_app_challenge_entry_fees_buzz_total', {
+        source: 'User',
+        buzzType: 'yellow',
+      })
+    ).toBe(150);
+    expect(
+      await valueFor('civitai_app_challenge_prize_paid_buzz_total', {
+        source: 'User',
+        buzzType: 'green',
+      })
+    ).toBe(5000);
+    expect(
+      await valueFor('civitai_app_challenge_operation_spent_buzz_total', {
+        source: 'System',
+        buzzType: 'yellow',
+      })
+    ).toBe(42);
+  });
+
+  it('non-positive / non-finite amounts are ignored (no series, no NaN)', async () => {
+    recordChallengeEntryFeesBuzz({ source: 'User', buzzType: 'yellow', amount: 0 });
+    recordChallengeEntryFeesBuzz({ source: 'User', buzzType: 'yellow', amount: -10 });
+    recordChallengePrizePaidBuzz({ source: 'User', buzzType: 'yellow', amount: NaN });
+
+    expect(await readMetric('civitai_app_challenge_entry_fees_buzz_total')).toHaveLength(0);
+    expect(await readMetric('civitai_app_challenge_prize_paid_buzz_total')).toHaveLength(0);
+  });
+
+  it('refund buzz sums by reason; refund failures count by reason', async () => {
+    recordChallengeRefundBuzz({ source: 'User', buzzType: 'yellow', reason: 'void', amount: 300 });
+    recordChallengeRefundBuzz({ source: 'User', buzzType: 'yellow', reason: 'delete', amount: 75 });
+    // 'completion' normalizes to 'other'
+    recordChallengeRefundBuzz({
+      source: 'User',
+      buzzType: 'yellow',
+      reason: 'completion',
+      amount: 10,
+    });
+    recordChallengeRefundFailure({ source: 'User', reason: 'void' });
+    recordChallengeRefundFailure({ source: 'User', reason: 'void' });
+
+    expect(
+      await valueFor('civitai_app_challenge_refund_buzz_total', {
+        source: 'User',
+        buzzType: 'yellow',
+        reason: 'void',
+      })
+    ).toBe(300);
+    expect(
+      await valueFor('civitai_app_challenge_refund_buzz_total', {
+        source: 'User',
+        buzzType: 'yellow',
+        reason: 'delete',
+      })
+    ).toBe(75);
+    expect(
+      await valueFor('civitai_app_challenge_refund_buzz_total', {
+        source: 'User',
+        buzzType: 'yellow',
+        reason: 'other',
+      })
+    ).toBe(10);
+    expect(
+      await valueFor('civitai_app_challenge_refund_failures_total', {
+        source: 'User',
+        reason: 'void',
+      })
+    ).toBe(2);
+  });
+});
+
+describe('never-throw guarantee', () => {
+  it('a throwing counter.inc is swallowed — the record helper never throws', async () => {
+    const metric = client.register.getSingleMetric(
+      'civitai_app_challenge_created_total'
+    ) as unknown as { inc: (...a: unknown[]) => void };
+    const original = metric.inc;
+    metric.inc = () => {
+      throw new Error('boom — must never surface');
+    };
+    try {
+      expect(() => recordChallengeCreated({ source: 'User', buzzType: 'yellow' })).not.toThrow();
+    } finally {
+      metric.inc = original;
+    }
+  });
+
+  it('helpers tolerate undefined/null inputs without throwing', () => {
+    expect(() =>
+      recordChallengeCreated({ source: undefined, buzzType: null })
+    ).not.toThrow();
+    expect(() => recordChallengeScanResult({ result: undefined as unknown as string })).not.toThrow();
+    expect(() => recordChallengeVoided({})).not.toThrow();
+    expect(() =>
+      recordChallengeRefundBuzz({ amount: undefined as unknown as number })
+    ).not.toThrow();
+  });
+});
+
+describe('state gauges — collect() emits series from injected (mocked) cache', () => {
+  it('challenge_by_status / ingestion_pending / completing_stuck / budget_ratio', async () => {
+    __setChallengeGaugeCacheForTest({
+      byStatus: [
+        { source: 'User', status: 'Active', count: 4 },
+        { source: 'User', status: 'Scheduled', count: 2 },
+        { source: 'System', status: 'Completed', count: 9 },
+      ],
+      ingestionPending: [{ source: 'User', count: 3 }],
+      completingStuck: [{ source: 'System', count: 1 }],
+      budgetRatio: [{ source: 'System', ratio: 0.25 }],
+    });
+
+    expect(
+      await valueFor('civitai_app_challenge_by_status', { source: 'User', status: 'Active' })
+    ).toBe(4);
+    expect(
+      await valueFor('civitai_app_challenge_by_status', { source: 'System', status: 'Completed' })
+    ).toBe(9);
+    expect(await valueFor('civitai_app_challenge_ingestion_pending', { source: 'User' })).toBe(3);
+    expect(await valueFor('civitai_app_challenge_completing_stuck', { source: 'System' })).toBe(1);
+    expect(
+      await valueFor('civitai_app_challenge_operation_budget_used_ratio', { source: 'System' })
+    ).toBe(0.25);
+  });
+
+  it('gauge collect() normalizes an unexpected source/status value from the DB', async () => {
+    __setChallengeGaugeCacheForTest({
+      byStatus: [{ source: 'GARBAGE', status: 'WeirdState', count: 7 }],
+    });
+    expect(
+      await valueFor('civitai_app_challenge_by_status', { source: 'unknown', status: 'unknown' })
+    ).toBe(7);
+  });
+});

--- a/src/server/prom/challenge.metrics.ts
+++ b/src/server/prom/challenge.metrics.ts
@@ -282,19 +282,22 @@ export function recordChallengeRefundFailure(args: {
 }
 
 // ---------------------------------------------------------------------------
-// C. State gauges (async collect(), low cardinality, memoized ~20s)
+// C. State gauges (async collect(), low cardinality, memoized ~45s)
 // ---------------------------------------------------------------------------
 // The Challenge table is small (thousands of rows, not the Image-table millions), so the four
 // GROUP BYs are cheap — but /metrics is scraped ~15s and there can be several scrapers/pod, so a
-// single memoized read (TTL ~20s) refreshed lazily OFF the scrape path serves every gauge from
+// single memoized read (TTL ~45s) refreshed lazily OFF the scrape path serves every gauge from
 // last-known values. A scrape only ever kicks a background refresh, never blocks on it. A defensive
 // statement_timeout caps a replica cold-cache spike; on any error we keep the last-good values.
 //
 // GATING: this repo exposes no clean pod-role / jobs-pool signal (only PODNAME, a bare pod name),
-// so per the "don't invent a fragile gate" rule these gauges run on ALL pods behind the 20s memo.
+// so per the "don't invent a fragile gate" rule these gauges run on ALL pods behind the 45s memo.
 // The read hits the replica pool (pgDbRead). Follow-up: gate to the -jobs pool if a role signal is
 // added (e.g. an env POD_ROLE), so only a couple of pods query.
-const CHALLENGE_GAUGE_TTL_MS = 20_000;
+// Challenge table ~217 rows (2026-07), GROUP BYs are trivial seq/index scans; revisit fleet-wide
+// gauge gating only if the table grows orders of magnitude. TTL 45s matches the proven in-prod
+// image_ingestion_backlog gauge this pattern was modeled on.
+const CHALLENGE_GAUGE_TTL_MS = 45_000;
 const CHALLENGE_GAUGE_STATEMENT_TIMEOUT_MS = 5_000;
 const COMPLETING_STUCK_MINUTES = 30;
 

--- a/src/server/prom/challenge.metrics.ts
+++ b/src/server/prom/challenge.metrics.ts
@@ -1,0 +1,488 @@
+import client from 'prom-client';
+// Pure prom-client helpers (this import chain is prom-client-only — no env/DB), so the metric
+// definitions + record helpers stay a runtime-light leaf that a unit test can load without booting
+// the app graph. The DB used by the state gauges is pulled in LAZILY (dynamic import inside the
+// gauge refresh) so importing this module never statically drags in pgDb/env.
+import { registerCounterWithLabels } from '@civitai/telemetry/client';
+
+/**
+ * CHALLENGE observability (additive telemetry only — no behavior change).
+ *
+ * Prometheus coverage for the user-created Challenge funnel + Buzz economy + live state. Every
+ * metric is defined here and every emit site calls one of the never-throw `recordX()` helpers below,
+ * so a telemetry failure can NEVER break challenge business logic (each helper try/catch-swallows).
+ *
+ * Metric names all get the shared `civitai_app_` prefix via `registerCounterWithLabels`, so e.g.
+ * `challenge_created_total` is scraped as `civitai_app_challenge_created_total`.
+ *
+ * CARDINALITY: every label is normalized against a fixed allowed set INSIDE the record helpers —
+ * an unrecognized value maps to `'unknown'` (or `'other'` for reasons). Raw/free-text is never
+ * passed into a label, so the series count is bounded by construction.
+ */
+
+// ---------------------------------------------------------------------------
+// Label normalization (enum-bound — never emit raw/free-text)
+// ---------------------------------------------------------------------------
+const SOURCES = new Set(['System', 'Mod', 'User']);
+const BUZZ_TYPES = new Set(['green', 'yellow']);
+const SCAN_RESULTS = new Set(['scanned', 'blocked', 'error']);
+const STATUSES = new Set(['Scheduled', 'Active', 'Completing', 'Completed', 'Cancelled']);
+const VOID_REASONS = new Set(['moderator', 'nsfw', 'activation']);
+const REFUND_REASONS = new Set(['void', 'delete']);
+
+export function normSource(v: string | null | undefined): string {
+  return v && SOURCES.has(v) ? v : 'unknown';
+}
+export function normBuzzType(v: string | null | undefined): string {
+  return v && BUZZ_TYPES.has(v) ? v : 'unknown';
+}
+export function normScanResult(v: string | null | undefined): string {
+  // A scan callback resolves to exactly one of these; an unexpected value is bucketed as 'error'
+  // (the safe catch-all) rather than a new unbounded label.
+  return v && SCAN_RESULTS.has(v) ? v : 'error';
+}
+export function normStatus(v: string | null | undefined): string {
+  return v && STATUSES.has(v) ? v : 'unknown';
+}
+export function normPaid(paid: boolean | null | undefined): '0' | '1' {
+  return paid ? '1' : '0';
+}
+export function normVoidReason(v: string | null | undefined): string {
+  return v && VOID_REASONS.has(v) ? v : 'other';
+}
+export function normRefundReason(v: string | null | undefined): string {
+  return v && REFUND_REASONS.has(v) ? v : 'other';
+}
+
+// ---------------------------------------------------------------------------
+// A. Funnel counters
+// ---------------------------------------------------------------------------
+const createdCounter = registerCounterWithLabels({
+  name: 'challenge_created_total',
+  help: 'User-created challenges created, by source and buzzType (create path only, not edits)',
+  labelNames: ['source', 'buzzType'] as const,
+});
+const scanResultCounter = registerCounterWithLabels({
+  name: 'challenge_scan_result_total',
+  help: 'Challenge text-moderation scan outcomes by source and result (scanned=not-blocked verdict, blocked=ToS block, error=submit/terminal scan failure)',
+  labelNames: ['source', 'result'] as const,
+});
+const entrySubmittedCounter = registerCounterWithLabels({
+  name: 'challenge_entry_submitted_total',
+  help: 'Challenge entries accepted into a contest collection, by source, buzzType and paid (1=entry fee charged, 0=free)',
+  labelNames: ['source', 'buzzType', 'paid'] as const,
+});
+const reviewRequestedCounter = registerCounterWithLabels({
+  name: 'challenge_review_requested_total',
+  help: 'Paid AI-judge review requests that succeeded, by source',
+  labelNames: ['source'] as const,
+});
+const completedCounter = registerCounterWithLabels({
+  name: 'challenge_completed_total',
+  help: 'Challenges that completed (winners picked or zero-winner completion), by source',
+  labelNames: ['source'] as const,
+});
+const voidedCounter = registerCounterWithLabels({
+  name: 'challenge_voided_total',
+  help: 'Challenges voided/cancelled with a real refund (voided=true), by source and reason',
+  labelNames: ['source', 'reason'] as const,
+});
+const deletedCounter = registerCounterWithLabels({
+  name: 'challenge_deleted_total',
+  help: 'User-created challenges deleted by their creator, by source',
+  labelNames: ['source'] as const,
+});
+
+// ---------------------------------------------------------------------------
+// B. Economy counters (`.inc(buzzAmount)`)
+// ---------------------------------------------------------------------------
+const entryFeesBuzzCounter = registerCounterWithLabels({
+  name: 'challenge_entry_fees_buzz_total',
+  help: 'Buzz charged for challenge entry fees (house + pool legs, first-time charges only), by source and buzzType',
+  labelNames: ['source', 'buzzType'] as const,
+});
+const prizePaidBuzzCounter = registerCounterWithLabels({
+  name: 'challenge_prize_paid_buzz_total',
+  help: 'Buzz paid out to challenge winners (winner prizes), by source and buzzType',
+  labelNames: ['source', 'buzzType'] as const,
+});
+const operationSpentBuzzCounter = registerCounterWithLabels({
+  name: 'challenge_operation_spent_buzz_total',
+  help: 'Buzz spent on AI judge/review operations (operationSpent increments), by source and buzzType',
+  labelNames: ['source', 'buzzType'] as const,
+});
+const refundBuzzCounter = registerCounterWithLabels({
+  name: 'challenge_refund_buzz_total',
+  help: 'Buzz refunded on challenge void/delete (entry-fee pool + initial prize), by source, buzzType and reason',
+  labelNames: ['source', 'buzzType', 'reason'] as const,
+});
+const refundFailuresCounter = registerCounterWithLabels({
+  name: 'challenge_refund_failures_total',
+  help: 'Challenge refund attempts that threw (non NOT_FOUND), by source and reason',
+  labelNames: ['source', 'reason'] as const,
+});
+
+// ---------------------------------------------------------------------------
+// Never-throw record helpers — called from business logic emit sites
+// ---------------------------------------------------------------------------
+function isPositiveFinite(n: number | null | undefined): n is number {
+  return typeof n === 'number' && Number.isFinite(n) && n > 0;
+}
+
+export function recordChallengeCreated(args: { source?: string | null; buzzType?: string | null }) {
+  try {
+    createdCounter.inc({ source: normSource(args.source), buzzType: normBuzzType(args.buzzType) });
+  } catch {
+    /* never throw from telemetry */
+  }
+}
+
+export function recordChallengeScanResult(args: { source?: string | null; result: string }) {
+  try {
+    scanResultCounter.inc({ source: normSource(args.source), result: normScanResult(args.result) });
+  } catch {
+    /* never throw from telemetry */
+  }
+}
+
+export function recordChallengeEntrySubmitted(args: {
+  source?: string | null;
+  buzzType?: string | null;
+  paid?: boolean | null;
+  count?: number;
+}) {
+  try {
+    const count = isPositiveFinite(args.count) ? args.count : 1;
+    entrySubmittedCounter.inc(
+      {
+        source: normSource(args.source),
+        buzzType: normBuzzType(args.buzzType),
+        paid: normPaid(args.paid),
+      },
+      count
+    );
+  } catch {
+    /* never throw from telemetry */
+  }
+}
+
+export function recordChallengeReviewRequested(args: { source?: string | null }) {
+  try {
+    reviewRequestedCounter.inc({ source: normSource(args.source) });
+  } catch {
+    /* never throw from telemetry */
+  }
+}
+
+export function recordChallengeCompleted(args: { source?: string | null }) {
+  try {
+    completedCounter.inc({ source: normSource(args.source) });
+  } catch {
+    /* never throw from telemetry */
+  }
+}
+
+export function recordChallengeVoided(args: { source?: string | null; reason?: string | null }) {
+  try {
+    voidedCounter.inc({ source: normSource(args.source), reason: normVoidReason(args.reason) });
+  } catch {
+    /* never throw from telemetry */
+  }
+}
+
+export function recordChallengeDeleted(args: { source?: string | null }) {
+  try {
+    deletedCounter.inc({ source: normSource(args.source) });
+  } catch {
+    /* never throw from telemetry */
+  }
+}
+
+export function recordChallengeEntryFeesBuzz(args: {
+  source?: string | null;
+  buzzType?: string | null;
+  amount: number;
+}) {
+  try {
+    if (!isPositiveFinite(args.amount)) return;
+    entryFeesBuzzCounter.inc(
+      { source: normSource(args.source), buzzType: normBuzzType(args.buzzType) },
+      args.amount
+    );
+  } catch {
+    /* never throw from telemetry */
+  }
+}
+
+export function recordChallengePrizePaidBuzz(args: {
+  source?: string | null;
+  buzzType?: string | null;
+  amount: number;
+}) {
+  try {
+    if (!isPositiveFinite(args.amount)) return;
+    prizePaidBuzzCounter.inc(
+      { source: normSource(args.source), buzzType: normBuzzType(args.buzzType) },
+      args.amount
+    );
+  } catch {
+    /* never throw from telemetry */
+  }
+}
+
+export function recordChallengeOperationSpentBuzz(args: {
+  source?: string | null;
+  buzzType?: string | null;
+  amount: number;
+}) {
+  try {
+    if (!isPositiveFinite(args.amount)) return;
+    operationSpentBuzzCounter.inc(
+      { source: normSource(args.source), buzzType: normBuzzType(args.buzzType) },
+      args.amount
+    );
+  } catch {
+    /* never throw from telemetry */
+  }
+}
+
+export function recordChallengeRefundBuzz(args: {
+  source?: string | null;
+  buzzType?: string | null;
+  reason?: string | null;
+  amount: number;
+}) {
+  try {
+    if (!isPositiveFinite(args.amount)) return;
+    refundBuzzCounter.inc(
+      {
+        source: normSource(args.source),
+        buzzType: normBuzzType(args.buzzType),
+        reason: normRefundReason(args.reason),
+      },
+      args.amount
+    );
+  } catch {
+    /* never throw from telemetry */
+  }
+}
+
+export function recordChallengeRefundFailure(args: {
+  source?: string | null;
+  reason?: string | null;
+}) {
+  try {
+    refundFailuresCounter.inc({
+      source: normSource(args.source),
+      reason: normRefundReason(args.reason),
+    });
+  } catch {
+    /* never throw from telemetry */
+  }
+}
+
+// ---------------------------------------------------------------------------
+// C. State gauges (async collect(), low cardinality, memoized ~20s)
+// ---------------------------------------------------------------------------
+// The Challenge table is small (thousands of rows, not the Image-table millions), so the four
+// GROUP BYs are cheap — but /metrics is scraped ~15s and there can be several scrapers/pod, so a
+// single memoized read (TTL ~20s) refreshed lazily OFF the scrape path serves every gauge from
+// last-known values. A scrape only ever kicks a background refresh, never blocks on it. A defensive
+// statement_timeout caps a replica cold-cache spike; on any error we keep the last-good values.
+//
+// GATING: this repo exposes no clean pod-role / jobs-pool signal (only PODNAME, a bare pod name),
+// so per the "don't invent a fragile gate" rule these gauges run on ALL pods behind the 20s memo.
+// The read hits the replica pool (pgDbRead). Follow-up: gate to the -jobs pool if a role signal is
+// added (e.g. an env POD_ROLE), so only a couple of pods query.
+const CHALLENGE_GAUGE_TTL_MS = 20_000;
+const CHALLENGE_GAUGE_STATEMENT_TIMEOUT_MS = 5_000;
+const COMPLETING_STUCK_MINUTES = 30;
+
+type SourceCount = { source: string; count: number };
+type SourceStatusCount = { source: string; status: string; count: number };
+type SourceRatio = { source: string; ratio: number };
+
+type ChallengeGaugeData = {
+  byStatus: SourceStatusCount[];
+  ingestionPending: SourceCount[];
+  completingStuck: SourceCount[];
+  budgetRatio: SourceRatio[];
+};
+
+let challengeGaugeCache: ChallengeGaugeData = {
+  byStatus: [],
+  ingestionPending: [],
+  completingStuck: [],
+  budgetRatio: [],
+};
+let challengeGaugeFetchedAt = 0;
+let challengeGaugeInflight: Promise<void> | null = null;
+
+async function queryChallengeGauges(): Promise<ChallengeGaugeData> {
+  // Lazy import so this module stays DB-free until a real scrape needs the gauges (keeps the unit
+  // test light and avoids booting pgDb/env at import time).
+  const { pgDbRead } = await import('~/server/db/pgDb');
+  const dbClient = await pgDbRead.connect();
+  try {
+    await dbClient.query('BEGIN');
+    await dbClient.query(`SET LOCAL statement_timeout = ${CHALLENGE_GAUGE_STATEMENT_TIMEOUT_MS}`);
+
+    const byStatus = await dbClient.query<{ source: string; status: string; count: string }>(
+      `SELECT source::text AS source, status::text AS status, count(*)::text AS count
+         FROM "Challenge" GROUP BY source, status`
+    );
+    const ingestionPending = await dbClient.query<{ source: string; count: string }>(
+      `SELECT source::text AS source, count(*)::text AS count
+         FROM "Challenge" WHERE ingestion = 'Pending' GROUP BY source`
+    );
+    const completingStuck = await dbClient.query<{ source: string; count: string }>(
+      `SELECT source::text AS source, count(*)::text AS count
+         FROM "Challenge"
+        WHERE status = 'Completing'
+          AND "updatedAt" < now() - interval '${COMPLETING_STUCK_MINUTES} minutes'
+        GROUP BY source`
+    );
+    // Budget utilisation over challenges currently consuming their AI-review budget (Active or
+    // mid-completion) — a finished/scheduled challenge's ratio isn't an operational signal.
+    const budgetRatio = await dbClient.query<{ source: string; ratio: string | null }>(
+      `SELECT source::text AS source,
+              (SUM("operationSpent")::float / NULLIF(SUM("operationBudget"), 0)) AS ratio
+         FROM "Challenge"
+        WHERE status IN ('Active', 'Completing')
+        GROUP BY source`
+    );
+
+    await dbClient.query('COMMIT');
+    return {
+      byStatus: byStatus.rows.map((r) => ({
+        source: r.source,
+        status: r.status,
+        count: Number(r.count),
+      })),
+      ingestionPending: ingestionPending.rows.map((r) => ({
+        source: r.source,
+        count: Number(r.count),
+      })),
+      completingStuck: completingStuck.rows.map((r) => ({
+        source: r.source,
+        count: Number(r.count),
+      })),
+      budgetRatio: budgetRatio.rows
+        .filter((r) => r.ratio != null)
+        .map((r) => ({ source: r.source, ratio: Number(r.ratio) })),
+    };
+  } catch (e) {
+    await dbClient.query('ROLLBACK').catch(() => undefined);
+    throw e;
+  } finally {
+    dbClient.release();
+  }
+}
+
+function refreshChallengeGauges(): Promise<void> {
+  if (challengeGaugeInflight) return challengeGaugeInflight;
+  challengeGaugeInflight = queryChallengeGauges()
+    .then((data) => {
+      challengeGaugeCache = data;
+      challengeGaugeFetchedAt = Date.now();
+    })
+    .catch(() => {
+      // Swallow (incl. statement_timeout): keep last-known values so a DB hiccup can't break the
+      // /metrics scrape. A stale gauge beats a 500.
+    })
+    .finally(() => {
+      challengeGaugeInflight = null;
+    });
+  return challengeGaugeInflight;
+}
+
+function maybeRefreshChallengeGauges() {
+  if (Date.now() - challengeGaugeFetchedAt > CHALLENGE_GAUGE_TTL_MS) void refreshChallengeGauges();
+}
+
+declare global {
+  // eslint-disable-next-line no-var
+  var challengeGaugesInitialized: boolean | undefined;
+}
+
+if (!globalThis.challengeGaugesInitialized) {
+  new client.Gauge({
+    name: 'civitai_app_challenge_by_status',
+    help: 'Challenges by source and status (live count)',
+    labelNames: ['source', 'status'],
+    collect() {
+      maybeRefreshChallengeGauges();
+      this.reset();
+      for (const row of challengeGaugeCache.byStatus)
+        this.set({ source: normSource(row.source), status: normStatus(row.status) }, row.count);
+    },
+  });
+  new client.Gauge({
+    name: 'civitai_app_challenge_ingestion_pending',
+    help: 'Challenges awaiting a moderation scan (ingestion=Pending) by source',
+    labelNames: ['source'],
+    collect() {
+      maybeRefreshChallengeGauges();
+      this.reset();
+      for (const row of challengeGaugeCache.ingestionPending)
+        this.set({ source: normSource(row.source) }, row.count);
+    },
+  });
+  new client.Gauge({
+    name: 'civitai_app_challenge_completing_stuck',
+    help: `Challenges stuck in status=Completing for more than ${COMPLETING_STUCK_MINUTES} minutes, by source`,
+    labelNames: ['source'],
+    collect() {
+      maybeRefreshChallengeGauges();
+      this.reset();
+      for (const row of challengeGaugeCache.completingStuck)
+        this.set({ source: normSource(row.source) }, row.count);
+    },
+  });
+  new client.Gauge({
+    name: 'civitai_app_challenge_operation_budget_used_ratio',
+    help: 'SUM(operationSpent)/SUM(operationBudget) over Active+Completing challenges, by source',
+    labelNames: ['source'],
+    collect() {
+      maybeRefreshChallengeGauges();
+      this.reset();
+      for (const row of challengeGaugeCache.budgetRatio)
+        this.set({ source: normSource(row.source) }, row.ratio);
+    },
+  });
+  globalThis.challengeGaugesInitialized = true;
+}
+
+// ---------------------------------------------------------------------------
+// Test-only helpers
+// ---------------------------------------------------------------------------
+/** Reset all challenge counters between test cases. */
+export function __resetChallengeMetricsForTest(): void {
+  createdCounter.reset();
+  scanResultCounter.reset();
+  entrySubmittedCounter.reset();
+  reviewRequestedCounter.reset();
+  completedCounter.reset();
+  voidedCounter.reset();
+  deletedCounter.reset();
+  entryFeesBuzzCounter.reset();
+  prizePaidBuzzCounter.reset();
+  operationSpentBuzzCounter.reset();
+  refundBuzzCounter.reset();
+  refundFailuresCounter.reset();
+}
+
+/**
+ * Inject gauge cache values directly and mark them fresh, so the gauge `collect()` reads them
+ * WITHOUT firing the background DB query. This is how the gauge test mocks the DB — it feeds the
+ * exact rows a query would return and asserts the emitted series.
+ */
+export function __setChallengeGaugeCacheForTest(data: Partial<ChallengeGaugeData>): void {
+  challengeGaugeCache = {
+    byStatus: data.byStatus ?? [],
+    ingestionPending: data.ingestionPending ?? [],
+    completingStuck: data.completingStuck ?? [],
+    budgetRatio: data.budgetRatio ?? [],
+  };
+  challengeGaugeFetchedAt = Date.now();
+}

--- a/src/server/routers/challenge.router.ts
+++ b/src/server/routers/challenge.router.ts
@@ -271,7 +271,7 @@ export const challengeRouter = router({
   voidChallenge: moderatorProcedure
     .input(challengeQuickActionSchema)
     .use(isFlagProtected('challengePlatform'))
-    .mutation(({ input }) => voidChallenge(input.id)),
+    .mutation(({ input }) => voidChallenge(input.id, 'moderator')),
 
   // Moderator: Re-run the content scan (moderated text + cover image) for a challenge
   rescan: moderatorProcedure

--- a/src/server/services/__tests__/challenge-delete-user.service.test.ts
+++ b/src/server/services/__tests__/challenge-delete-user.service.test.ts
@@ -68,7 +68,7 @@ describe('deleteUserChallenge', () => {
       where: { id: 1, status: ChallengeStatus.Scheduled },
       data: { status: ChallengeStatus.Cancelled },
     });
-    expect(mockRefundUserChallengeFunds).toHaveBeenCalledWith(1);
+    expect(mockRefundUserChallengeFunds).toHaveBeenCalledWith(1, 'delete');
     expect(mockDbWrite.challenge.delete).toHaveBeenCalledWith({ where: { id: 1 } });
     expect(mockDbWrite.collection.delete).toHaveBeenCalledWith({ where: { id: 100 } });
   });
@@ -131,7 +131,7 @@ describe('deleteUserChallenge', () => {
     expect(mockDbRead.collectionItem.count).not.toHaveBeenCalled();
     // Already-Cancelled: no Scheduled->Cancelled claim; refund is the idempotent net-zero recovery.
     expect(mockDbWrite.challenge.updateMany).not.toHaveBeenCalled();
-    expect(mockRefundUserChallengeFunds).toHaveBeenCalledWith(1);
+    expect(mockRefundUserChallengeFunds).toHaveBeenCalledWith(1, 'delete');
     expect(mockDbWrite.challenge.delete).toHaveBeenCalledWith({ where: { id: 1 } });
     expect(mockDbWrite.collection.delete).toHaveBeenCalledWith({ where: { id: 100 } });
   });
@@ -158,7 +158,7 @@ describe('deleteChallenge (direct)', () => {
     await deleteChallenge(1);
     // No claim on an already-Cancelled row (nothing to flip); refund is the idempotent recovery.
     expect(mockDbWrite.challenge.updateMany).not.toHaveBeenCalled();
-    expect(mockRefundUserChallengeFunds).toHaveBeenCalledWith(1);
+    expect(mockRefundUserChallengeFunds).toHaveBeenCalledWith(1, 'delete');
     expect(mockDbWrite.challenge.delete).toHaveBeenCalledWith({ where: { id: 1 } });
   });
 

--- a/src/server/services/__tests__/challenge-moderation-adapter.test.ts
+++ b/src/server/services/__tests__/challenge-moderation-adapter.test.ts
@@ -16,8 +16,13 @@ vi.mock('~/server/logging/client', () => ({ logToAxiom: vi.fn(() => Promise.reso
 vi.mock('~/server/games/daily-challenge/challenge-nsfw-escalation', () => ({
   applyChallengeNsfwEscalation: vi.fn(),
 }));
+vi.mock('~/server/prom/challenge.metrics', () => ({ recordChallengeScanResult: vi.fn() }));
 
 const { challengeModerationAdapter } = await import('~/server/services/challenge-moderation.adapter');
+const { applyChallengeNsfwEscalation } = await import(
+  '~/server/games/daily-challenge/challenge-nsfw-escalation'
+);
+const { recordChallengeScanResult } = await import('~/server/prom/challenge.metrics');
 
 describe('challengeModerationAdapter.applyFailure', () => {
   beforeEach(() => {
@@ -53,5 +58,36 @@ describe('challengeModerationAdapter.applyFailure', () => {
         status: 'failed',
       })
     ).resolves.not.toThrow();
+  });
+});
+
+describe('challengeModerationAdapter.applyResult telemetry-read safety', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // The scanned (not-blocked) path fetches `source` ONLY to label the scan-result metric, guarded by
+  // `.catch(() => null)`. That guard is load-bearing: a transient DB failure on this telemetry read
+  // must NEVER throw out of applyResult and skip the real safety step (applyChallengeNsfwEscalation).
+  // Removing the `.catch(() => null)` makes this test fail (applyResult rejects, escalation is skipped).
+  it('still runs the NSFW escalation when the telemetry source read rejects', async () => {
+    mockDbRead.challenge.findUnique.mockRejectedValueOnce(new Error('transient db failure'));
+
+    await expect(
+      challengeModerationAdapter.applyResult({
+        entityId: 42,
+        blocked: false,
+        triggeredLabels: [],
+        output: undefined,
+      })
+    ).resolves.not.toThrow();
+
+    // Non-negotiable: the safety step still ran despite the failed telemetry read.
+    expect(applyChallengeNsfwEscalation).toHaveBeenCalledTimes(1);
+    expect(applyChallengeNsfwEscalation).toHaveBeenCalledWith({ entityId: 42, isNsfw: false });
+
+    // The failed read collapses to null → `source: undefined` is passed, which normSource maps to
+    // the 'unknown' bucket — the metric is still recorded, never skipped.
+    expect(recordChallengeScanResult).toHaveBeenCalledWith({ source: undefined, result: 'scanned' });
   });
 });

--- a/src/server/services/__tests__/challenge-moderation-adapter.test.ts
+++ b/src/server/services/__tests__/challenge-moderation-adapter.test.ts
@@ -23,6 +23,9 @@ describe('challengeModerationAdapter.applyFailure', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockDbWrite.challenge.updateMany.mockResolvedValue({ count: 1 });
+    // applyFailure now reads the challenge source (for the scan-result 'error' metric) after a real
+    // Pending→Error transition; give findUnique a resolved value so the chained .catch() is valid.
+    mockDbRead.challenge.findUnique.mockResolvedValue({ source: 'User' });
   });
 
   it('only marks Error on a challenge still Pending', async () => {

--- a/src/server/services/__tests__/challenge-void.service.test.ts
+++ b/src/server/services/__tests__/challenge-void.service.test.ts
@@ -47,7 +47,7 @@ describe('voidChallenge', () => {
       where: { id: 1, status: { in: [ChallengeStatus.Active, ChallengeStatus.Scheduled] } },
       data: { status: ChallengeStatus.Cancelled },
     });
-    expect(mockRefund).toHaveBeenCalledWith(1);
+    expect(mockRefund).toHaveBeenCalledWith(1, 'void');
   });
 
   it('claim lost (completion cron or a concurrent void won): does NOT refund', async () => {
@@ -63,7 +63,7 @@ describe('voidChallenge', () => {
     mockGetChallengeById.mockResolvedValue(makeChallenge(ChallengeStatus.Cancelled));
     await voidChallenge(1);
     expect(mockDbWrite.challenge.updateMany).not.toHaveBeenCalled();
-    expect(mockRefund).toHaveBeenCalledWith(1);
+    expect(mockRefund).toHaveBeenCalledWith(1, 'void');
   });
 
   it('rejects a Completed/Completing challenge (pool already paid out)', async () => {

--- a/src/server/services/__tests__/contest-entry-resource-gate.test.ts
+++ b/src/server/services/__tests__/contest-entry-resource-gate.test.ts
@@ -119,9 +119,10 @@ function wireChallengeFindFirst(opts: { hasResourceChallenge: boolean; hasFeeCha
     }
     if ('maxParticipants' in where) return null; // no participant cap configured
     if (where.source === 'User') {
-      // The fee-challenge lookup (collection.service.ts) is distinguished by `entryFee`
-      // in its where clause; select: { id, entryFee, buzzType }.
-      if ('entryFee' in where) {
+      // The fee-challenge lookup (collection.service.ts chargeContestEntryFeesForCollection) is the
+      // only source=User lookup that also filters `status: 'Active'` in its where;
+      // select: { id, entryFee, buzzType }.
+      if ('status' in where) {
         return opts.hasFeeChallenge ? { id: 1, entryFee: 100, buzzType: 'yellow' } : null;
       }
       // Otherwise this is the assertUserChallengeAcceptingEntries timing gate

--- a/src/server/services/challenge-moderation.adapter.ts
+++ b/src/server/services/challenge-moderation.adapter.ts
@@ -12,6 +12,7 @@ import { logToAxiom } from '~/server/logging/client';
 import { parseChallengeMetadata } from '~/server/schema/challenge.schema';
 import { applyChallengeNsfwEscalation } from '~/server/games/daily-challenge/challenge-nsfw-escalation';
 import { ChallengeIngestionStatus } from '~/shared/utils/prisma/enums';
+import { recordChallengeScanResult } from '~/server/prom/challenge.metrics';
 
 // Challenge-side hooks for the EntityModeration pipeline, mirroring the Article adapter. The
 // webhook and the retry cron route all `Challenge` entityType work through here via the central
@@ -55,7 +56,7 @@ export const challengeModerationAdapter: ModerationAdapter = {
     if (blocked) {
       const challenge = await dbRead.challenge.findUnique({
         where: { id: entityId },
-        select: { createdById: true },
+        select: { createdById: true, source: true },
       });
       // Deleted between submit and this webhook — nothing to hide or notify (a bare update would
       // throw P2025 and fail the moderation callback).
@@ -64,6 +65,7 @@ export const challengeModerationAdapter: ModerationAdapter = {
         where: { id: entityId },
         data: { ingestion: ChallengeIngestionStatus.Blocked, scannedAt: new Date() },
       });
+      recordChallengeScanResult({ source: challenge.source, result: 'blocked' });
       if (challenge?.createdById) {
         await createNotification({
           userId: challenge.createdById,
@@ -97,6 +99,16 @@ export const challengeModerationAdapter: ModerationAdapter = {
       })),
     });
 
+    // Scan verdict telemetry: a not-blocked callback is a 'scanned' outcome (the dominant terminal
+    // state). A green-user-challenge NSFW escalation may still hide/void it inside
+    // applyChallengeNsfwEscalation, but that void is captured separately by challenge_voided_total —
+    // this metric reflects the moderation CALLBACK verdict, not the final ingestion column.
+    const scanned = await dbRead.challenge.findUnique({
+      where: { id: entityId },
+      select: { source: true },
+    });
+    recordChallengeScanResult({ source: scanned?.source, result: 'scanned' });
+
     await applyChallengeNsfwEscalation({ entityId, isNsfw });
   },
 
@@ -108,11 +120,18 @@ export const challengeModerationAdapter: ModerationAdapter = {
   // Scanned challenge — that would hide a live one from feeds and 404 its detail page on a
   // transient orchestrator failure, rather than just leaving the prior verdict in place.
   applyFailure: async ({ entityId }) => {
-    await dbWrite.challenge
+    const res = await dbWrite.challenge
       .updateMany({
         where: { id: entityId, ingestion: ChallengeIngestionStatus.Pending },
         data: { ingestion: ChallengeIngestionStatus.Error },
       })
       .catch(() => undefined);
+    // Only count a real Pending→Error terminal transition (not a no-op on an already-Scanned row).
+    if (res?.count) {
+      const challenge = await dbRead.challenge
+        .findUnique({ where: { id: entityId }, select: { source: true } })
+        .catch(() => null);
+      recordChallengeScanResult({ source: challenge?.source, result: 'error' });
+    }
   },
 };

--- a/src/server/services/challenge-moderation.adapter.ts
+++ b/src/server/services/challenge-moderation.adapter.ts
@@ -103,10 +103,12 @@ export const challengeModerationAdapter: ModerationAdapter = {
     // state). A green-user-challenge NSFW escalation may still hide/void it inside
     // applyChallengeNsfwEscalation, but that void is captured separately by challenge_voided_total —
     // this metric reflects the moderation CALLBACK verdict, not the final ingestion column.
-    const scanned = await dbRead.challenge.findUnique({
-      where: { id: entityId },
-      select: { source: true },
-    });
+    // Guarded with `.catch(() => null)` (mirrors the applyFailure sibling) so a transient DB hiccup
+    // on this TELEMETRY-only read can never throw out of applyResult and skip the real safety step
+    // (applyChallengeNsfwEscalation) below. null → source 'unknown' via the normalizer.
+    const scanned = await dbRead.challenge
+      .findUnique({ where: { id: entityId }, select: { source: true } })
+      .catch(() => null);
     recordChallengeScanResult({ source: scanned?.source, result: 'scanned' });
 
     await applyChallengeNsfwEscalation({ entityId, isNsfw });

--- a/src/server/services/challenge.service.ts
+++ b/src/server/services/challenge.service.ts
@@ -19,6 +19,15 @@ import { resolveChallengeCollectionOwnerId } from '~/server/games/daily-challeng
 export { getChallengeWinners } from '~/server/games/daily-challenge/challenge-helpers';
 import { CHALLENGE_MODERATION_LABELS } from '~/server/games/daily-challenge/challenge-text-scan';
 import {
+  recordChallengeCreated,
+  recordChallengeScanResult,
+  recordChallengeReviewRequested,
+  recordChallengeCompleted,
+  recordChallengeVoided,
+  recordChallengeDeleted,
+  recordChallengePrizePaidBuzz,
+} from '~/server/prom/challenge.metrics';
+import {
   ChallengeParticipation,
   ChallengeSort,
   challengeJudgingCategoriesSchema,
@@ -1911,6 +1920,10 @@ export async function upsertUserChallenge({
   // Moderation scan (fail-soft) — flips Pending → Scanned/Blocked; hidden until Scanned.
   await scanUserChallenge(created.id);
 
+  // Funnel telemetry (create path only — edits return above). This function only ever creates
+  // source=User challenges (ChallengeSource.User is written into commonData above).
+  recordChallengeCreated({ source: ChallengeSource.User, buzzType });
+
   return created;
 }
 
@@ -1922,7 +1935,14 @@ export async function upsertUserChallenge({
 export async function scanUserChallenge(challengeId: number): Promise<void> {
   const challenge = await dbRead.challenge.findUnique({
     where: { id: challengeId },
-    select: { title: true, description: true, theme: true, invitation: true, metadata: true },
+    select: {
+      title: true,
+      description: true,
+      theme: true,
+      invitation: true,
+      metadata: true,
+      source: true,
+    },
   });
   if (!challenge) return;
 
@@ -1939,7 +1959,9 @@ export async function scanUserChallenge(challengeId: number): Promise<void> {
     });
   } catch (e) {
     // Submit failure already persists a Failed EntityModeration row (the retry cron re-submits);
-    // log but don't rethrow so create/edit isn't blocked on a moderation-gateway hiccup.
+    // log but don't rethrow so create/edit isn't blocked on a moderation-gateway hiccup. Counted as
+    // a scan 'error' — a distinct SUBMIT-time failure vs the adapter's terminal applyFailure error.
+    recordChallengeScanResult({ source: challenge.source, result: 'error' });
     logToAxiom({
       type: 'error',
       name: 'user-challenge-scan-failed',
@@ -2089,7 +2111,7 @@ export async function deleteChallenge(id: number) {
     }
     // Idempotent via deterministic externalTransactionId prefixes (the buzz service dedups), so
     // re-refunding an already-Cancelled challenge is a net-zero no-op, not a double-spend.
-    await refundUserChallengeFunds(id);
+    await refundUserChallengeFunds(id, 'delete');
   }
 
   const collectionId = challenge.collectionId;
@@ -2152,7 +2174,9 @@ export async function deleteUserChallenge({ id, userId }: { id: number; userId: 
   }
   // deleteChallenge re-reads status and only refunds/deletes a Scheduled or Cancelled row, so a race
   // with the activation job fails safe (blocks Active) rather than double-refunding.
-  return deleteChallenge(id);
+  const result = await deleteChallenge(id);
+  recordChallengeDeleted({ source: existing.source });
+  return result;
 }
 
 // User-safe fetch for the edit form. getChallengeForEdit is moderator-only; this guards ownership
@@ -2323,6 +2347,7 @@ export async function requestReview(
     `;
   }
 
+  recordChallengeReviewRequested({ source: challenge.source });
   return { queued: eligibleEntries.length, totalCost };
 }
 
@@ -2511,7 +2536,7 @@ export async function endChallengeAndPickWinners(challengeId: number) {
         // account 0 (no payout runs below). Reverse the actual charges (mint-safe + idempotent —
         // keyed off real charges) BEFORE marking Completed. No-op for daily/mod/system.
         if (challenge.source === ChallengeSource.User) {
-          const { refundedEntries } = await refundUserChallengeFunds(challengeId);
+          const { refundedEntries } = await refundUserChallengeFunds(challengeId, 'completion');
           log(`Refunded ${refundedEntries} entry fees (no winners)`);
           if (refundedEntries > 0) {
             await notifyEntrantsOfCancellation(challenge);
@@ -2522,6 +2547,7 @@ export async function endChallengeAndPickWinners(challengeId: number) {
           data: { status: ChallengeStatus.Completed },
         });
         log('No judged entries, challenge marked as completed without winners');
+        recordChallengeCompleted({ source: challenge.source });
         return { success: true, winnersCount: 0 };
       }
 
@@ -2588,6 +2614,14 @@ export async function endChallengeAndPickWinners(challengeId: number) {
       )
     );
     log('Prizes sent');
+
+    // Economy telemetry: total winner-prize Buzz paid this completion (paid in the challenge's
+    // stored currency). Entry-participation prizes below are a separate blue-Buzz reward, not counted.
+    recordChallengePrizePaidBuzz({
+      source: challenge.source,
+      buzzType: challenge.buzzType,
+      amount: winningEntries.reduce((sum, e) => sum + (e.prize ?? 0), 0),
+    });
 
     // Send entry participation prizes to all eligible users
     if (challenge.entryPrize && challenge.entryPrize.buzz > 0 && challenge.collectionId) {
@@ -2695,6 +2729,7 @@ export async function endChallengeAndPickWinners(challengeId: number) {
     }
     log('Winners notified');
 
+    recordChallengeCompleted({ source: challenge.source });
     return { success: true, winnersCount: winningEntries.length };
   } catch (error) {
     // On failure, challenge stays in 'Completing' for recovery to handle
@@ -2770,7 +2805,12 @@ async function notifyEntrantsOfCancellation(challenge: {
  * Void/cancel a challenge without picking winners.
  * Closes the collection and marks the challenge as Cancelled.
  */
-export async function voidChallenge(challengeId: number) {
+export async function voidChallenge(
+  challengeId: number,
+  // Telemetry-only: why the void was triggered. Normalized to a closed set in the metric helper
+  // (moderator|nsfw|activation|other); does not affect behavior.
+  reason: 'moderator' | 'nsfw' | 'activation' | 'other' = 'other'
+) {
   // Get the challenge
   const challenge = await getChallengeById(challengeId);
   if (!challenge) {
@@ -2822,12 +2862,13 @@ export async function voidChallenge(challengeId: number) {
   await closeChallengeCollection(challenge);
   log('Collection closed');
 
-  const { refundedEntries } = await refundUserChallengeFunds(challengeId);
+  const { refundedEntries } = await refundUserChallengeFunds(challengeId, 'void');
   log(`Refunded ${refundedEntries} entry fees`);
   if (refundedEntries > 0) {
     await notifyEntrantsOfCancellation(challenge);
   }
 
+  recordChallengeVoided({ source: challenge.source, reason });
   return { success: true, voided: true };
 }
 

--- a/src/server/services/collection.service.ts
+++ b/src/server/services/collection.service.ts
@@ -18,6 +18,7 @@ import { dbRead, dbWrite } from '~/server/db/client';
 import { logToAxiom } from '~/server/logging/client';
 import { getDbWithoutLag, preventReplicationLag } from '~/server/db/db-lag-helpers';
 import { dbReadFallbackCounter } from '~/server/prom/client';
+import { recordChallengeEntrySubmitted } from '~/server/prom/challenge.metrics';
 import { tagIdsForImagesCache, userCollectionCountCache } from '~/server/redis/caches';
 import { REDIS_SYS_KEYS, sysRedis, withSysReadDeadline } from '~/server/redis/client';
 import { logSysRedisFailOpen } from '~/server/redis/fail-open-log';
@@ -1934,19 +1935,35 @@ const chargeContestEntryFeesForCollection = async ({
   imageIds: number[];
 }) => {
   if (imageIds.length === 0) return undefined;
+  // Look up the active source=User challenge for this collection WITHOUT the old `entryFee > 0`
+  // filter, so free-entry User challenges are counted too (chargeEntryFees no-ops on entryFee<=0,
+  // returning every image as paid — so behavior is unchanged for the caller, which still commits
+  // when unpaidImageIds is empty). System/Mod (daily) + community-contest collections have no
+  // source=User row → null → undefined (unchanged, no metric).
   const feeChallenge = await dbRead.challenge.findFirst({
-    where: { collectionId, source: 'User', entryFee: { gt: 0 }, status: 'Active' },
+    where: { collectionId, source: 'User', status: 'Active' },
     select: { id: true, entryFee: true, buzzType: true },
   });
   if (!feeChallenge) return undefined;
   const { chargeEntryFees } = await import('~/server/games/daily-challenge/challenge-funding');
-  return chargeEntryFees({
+  const buzzType = feeChallenge.buzzType === 'green' ? 'green' : 'yellow';
+  const result = await chargeEntryFees({
     challengeId: feeChallenge.id,
     userId,
     imageIds,
     entryFee: feeChallenge.entryFee,
-    fromAccountType: feeChallenge.buzzType === 'green' ? 'green' : 'yellow',
+    fromAccountType: buzzType,
   });
+  // Single chokepoint for the entry funnel: count each committable entry once (both fee paths —
+  // the non-defer validate path and the deferred bulkSaveItems path — flow through here, so no
+  // double count). paidImageIds are the images actually charged (paid) or all images (free).
+  recordChallengeEntrySubmitted({
+    source: 'User',
+    buzzType,
+    paid: feeChallenge.entryFee > 0,
+    count: result.paidImageIds.length,
+  });
+  return result;
 };
 
 export const validateContestCollectionEntry = async ({


### PR DESCRIPTION
## What

Adds Prometheus instrumentation for the **Challenge** feature — funnel, Buzz economy, and live state — as additive telemetry only (no behavior change). All metrics live in a dedicated `src/server/prom/challenge.metrics.ts` module of never-throw `recordX()` helpers; emit sites call one helper each. A metrics failure can never break challenge business logic (every helper try/catch-swallows), mirroring `b2-put.metrics.ts`.

## Metrics (as deployed — all carry the `civitai_app_` prefix)

### A. Funnel counters
| Metric | Labels | Emit site |
|---|---|---|
| `civitai_app_challenge_created_total` | `source`, `buzzType` | `upsertUserChallenge`, create branch only (after the initial `scanUserChallenge`) |
| `civitai_app_challenge_scan_result_total` | `source`, `result` | moderation adapter (blocked/scanned) + `applyFailure` (error) + `scanUserChallenge` catch (error) |
| `civitai_app_challenge_entry_submitted_total` | `source`, `buzzType`, `paid` | `chargeContestEntryFeesForCollection` (single chokepoint — see below) |
| `civitai_app_challenge_review_requested_total` | `source` | `requestReview` on success |
| `civitai_app_challenge_completed_total` | `source` | `endChallengeAndPickWinners` both success returns (winners + zero-winner) |
| `civitai_app_challenge_voided_total` | `source`, `reason` | `voidChallenge` `voided:true` branch |
| `civitai_app_challenge_deleted_total` | `source` | `deleteUserChallenge` after `deleteChallenge` succeeds |

### B. Economy counters (`.inc(buzzAmount)`)
| Metric | Labels | Emit site |
|---|---|---|
| `civitai_app_challenge_entry_fees_buzz_total` | `source`, `buzzType` | `chargeEntryFees` — first-time house+pool legs only (retries/conflicts excluded, no double-count) |
| `civitai_app_challenge_prize_paid_buzz_total` | `source`, `buzzType` | `endChallengeAndPickWinners` after the winner payout (winner prizes only; entry-participation blue prizes excluded) |
| `civitai_app_challenge_operation_spent_buzz_total` | `source`, `buzzType` | inside `incrementOperationSpent` (guarded cheap PK read for labels) |
| `civitai_app_challenge_refund_buzz_total` | `source`, `buzzType`, `reason` | inside `refundUserChallengeFunds` (sum of `totalRefunded` across the entry-fee + initial-prize prefixes) |
| `civitai_app_challenge_refund_failures_total` | `source`, `reason` | `refundUserChallengeFunds` catch (a real refund throw; the swallowed NOT_FOUND no-op is not counted) |

### C. State gauges (async `collect()`, memoized ~20s)
| Metric | Labels | Query |
|---|---|---|
| `civitai_app_challenge_by_status` | `source`, `status` | `GROUP BY source, status` over `Challenge` |
| `civitai_app_challenge_ingestion_pending` | `source` | `WHERE ingestion='Pending' GROUP BY source` |
| `civitai_app_challenge_completing_stuck` | `source` | `WHERE status='Completing' AND updatedAt < now() - 30 min GROUP BY source` |
| `civitai_app_challenge_operation_budget_used_ratio` | `source` | `SUM(operationSpent)::float / NULLIF(SUM(operationBudget),0)` over `status IN ('Active','Completing')` |

## Cardinality

Every label value is normalized against a fixed allowed set **inside** the record helpers; unrecognized values map to `unknown` (or `other` for reasons). No raw/free-text ever reaches a label.
- `source` → System|Mod|User|unknown · `buzzType` → green|yellow|unknown · `status` → the 5 `ChallengeStatus` values|unknown · `paid` → `0`|`1`
- `result` → scanned|blocked|error (unexpected → error) · void `reason` → moderator|nsfw|activation|other · refund `reason` → void|delete|other

## Design decisions (per the review checklist)

- **`challenge_entry_submitted_total` chokepoint:** `chargeContestEntryFeesForCollection` (collection.service). Both entry paths — the non-deferred `validateContestCollectionEntry` charge and the deferred `bulkSaveItems` charge — flow through this one function, so counting here can't double-count paid vs free. Its challenge lookup was broadened (dropped the `entryFee > 0` filter) so **free-entry** User challenges are counted too; `chargeEntryFees` no-ops on `entryFee <= 0` (returning all images as paid), so the caller's commit behavior is unchanged. `paid='1'` when `entryFee > 0`, else `'0'`; count = `paidImageIds.length` (committable entries). Only `source=User` challenges have such a collection, so `source` is `User` in practice.
- **Scan-result emit-site deviation:** emitted from `challenge-moderation.adapter.ts` at the **callback verdict** level, not from `scanUserChallenge` (which doesn't yet know the outcome). A not-blocked callback is counted `scanned` — the dominant terminal state — even though a green-user-challenge NSFW escalation may subsequently void/hide it inside `applyChallengeNsfwEscalation`; that void is captured separately by `challenge_voided_total`, so the metric reflects the moderation callback verdict, not the final `ingestion` column. `blocked` and `error` (terminal `applyFailure`, only on a real Pending→Error transition) are emitted from the adapter; a distinct **submit-time** failure is also counted `error` in `scanUserChallenge`'s catch (a different failure event from the terminal `applyFailure`).
- **Gauge gating:** this repo exposes **no clean pod-role / jobs-pool signal** (only `PODNAME`, a bare pod name), so per "don't invent a fragile gate" the gauges **run on all pods behind a 20s in-process memo**, reading the **replica pool** (`pgDbRead`) with a 5s `statement_timeout` and last-good degradation. **Follow-up:** gate to a couple of pods if a role signal (e.g. an env `POD_ROLE`) is added.
- **Void `reason` closed set:** `moderator` (router action), `nsfw` (NSFW escalation), `activation` (grace-window void of an unscanned challenge past start), else `other`. Threaded as a telemetry-only optional arg on `voidChallenge` (default `other`); does not affect behavior.
- **Refund `reason`:** `void` / `delete` (per spec); the shared zero-winner completion refund passes `completion` which normalizes to `other`.

## Where the series land

The Grafana dashboard that consumes these lands **separately in `datapacket-talos`**. These series **won't exist until this deploys** via the `release` branch (civitai-prod → dp-prod).

## Tests

- New `src/server/prom/__tests__/challenge.metrics.test.ts` (18 tests): label normalization, never-throw (a throwing `counter.inc` is swallowed), counters/gauges emit expected series (gauge `collect()` fed via an injected cache that mocks the DB).
- Existing challenge suites kept green (void / delete-user / edit-rescan / upsert / moderation-adapter / nsfw-escalation / funding / contest-entry). A few assertions updated only for the new telemetry-only `reason` arg and the broadened entry-fee lookup.

Verified: targeted vitest run **137 passed / 0 failed** across 17 files; `tsc --noEmit` passes clean.
