### PR TITLE
feat(image-scan): reason-aware failure handling (capture expired + job reason, retry by class + absolute ceiling)

### DIFF
--- a/packages/civitai-redis/src/client.ts
+++ b/packages/civitai-redis/src/client.ts
@@ -1944,6 +1944,9 @@ export const REDIS_SYS_KEYS = {
   },
   WEBHOOKS: {
     MODEL_FILE_SCAN_PROCESSED: 'webhooks:model-file-scan:processed',
+    // Per-workflow job-level failure reason, stashed from `job:failed`/`job:expired`
+    // callbacks so the terminal workflow event can classify the failure. Short TTL.
+    IMAGE_SCAN_JOB_REASON: 'webhooks:image-scan:job-reason',
   },
   RETOOL_ENDPOINT: {
     RATE_LIMIT: 'retool-endpoint:rate-limit',

--- a/src/server/jobs/image-ingestion.ts
+++ b/src/server/jobs/image-ingestion.ts
@@ -10,6 +10,7 @@ import { deleteImages, ingestImage } from '~/server/services/image.service';
 import { imageIngestCronCounter, imageIngestCronQueueDepth } from '~/server/prom/client';
 import { limitConcurrency } from '~/server/utils/concurrency-helpers';
 import { EntityType, JobQueueType } from '~/shared/utils/prisma/enums';
+import { getImageScanRetryLimit } from '~/server/services/image-scan-failure';
 import { decreaseDate } from '~/utils/date-helpers';
 
 const IMAGE_SCANNING_ERROR_DELAY = 60 * 1; // 1 hour
@@ -19,6 +20,12 @@ type IngestImageRow = IngestImageInput & {
   scanRequestedAt: Date | null;
   ingestion: string;
   retryCount: number | null;
+  /**
+   * Reason-derived failure class stamped by the scan webhook
+   * (`scanJobs.error.failureClass`), used to pick the Error retry ceiling.
+   * Null for images that have never errored or errored before classification shipped.
+   */
+  failureClass: string | null;
   /**
    * True when the image is connected to an already-Published Article (via
    * ImageConnection) and therefore represents backfill work from the article
@@ -59,6 +66,7 @@ export const ingestImages = createJob('ingest-images', '*/5 * * * *', async () =
     SELECT i.id, i.url, i.type, i.width, i.height, i.meta->>'prompt' as prompt,
            i."scanRequestedAt", i.ingestion,
            (i."scanJobs"->>'retryCount')::int as "retryCount",
+           i."scanJobs"->'error'->>'failureClass' as "failureClass",
            EXISTS (
              SELECT 1 FROM "ImageConnection" ic
              JOIN "Article" a ON a.id = ic."entityId"
@@ -97,12 +105,17 @@ export const ingestImages = createJob('ingest-images', '*/5 * * * *', async () =
       Number(img.retryCount ?? 0) < IMAGE_SCANNING_RETRY_LIMIT
   );
 
+  // Error retries use a reason-aware ceiling: transient infra churn (Siglip
+  // container instability, 5xx, timeouts, expiry) keeps retrying under a higher
+  // bounded cap; permanent (unscannable media) gives up almost immediately;
+  // unknown keeps the historical 9-cap. retryCount always increments, so the cap
+  // is a hard backstop against re-flooding the scanner.
   const errorImages = images.filter(
     (img) =>
       img.ingestion === 'Error' &&
       img.scanRequestedAt &&
       new Date(img.scanRequestedAt).getTime() <= errorRetryDate &&
-      Number(img.retryCount ?? 0) < IMAGE_SCANNING_RETRY_LIMIT
+      Number(img.retryCount ?? 0) < getImageScanRetryLimit(img.failureClass)
   );
 
   // Categorize images for proper queue cleanup:
@@ -133,11 +146,13 @@ export const ingestImages = createJob('ingest-images', '*/5 * * * *', async () =
           const underRetryLimit = Number(img.retryCount ?? 0) < IMAGE_SCANNING_RETRY_LIMIT;
           return waitingForDelay && underRetryLimit;
         }
-        // Error but waiting for retry delay or under retry limit
+        // Error but waiting for retry delay or under retry limit. Mirror the
+        // reason-aware ceiling used by errorImages above.
         if (img.ingestion === 'Error') {
           const waitingForDelay =
             img.scanRequestedAt && new Date(img.scanRequestedAt).getTime() > errorRetryDate;
-          const underRetryLimit = Number(img.retryCount ?? 0) < IMAGE_SCANNING_RETRY_LIMIT;
+          const underRetryLimit =
+            Number(img.retryCount ?? 0) < getImageScanRetryLimit(img.failureClass);
           return waitingForDelay && underRetryLimit;
         }
         return false;

--- a/src/server/services/__tests__/image-scan-failure.test.ts
+++ b/src/server/services/__tests__/image-scan-failure.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect } from 'vitest';
+import {
+  classifyImageScanFailure,
+  getImageScanRetryLimit,
+  ImageScanFailureClass,
+  IMAGE_SCAN_TRANSIENT_RETRY_LIMIT,
+  IMAGE_SCAN_UNKNOWN_RETRY_LIMIT,
+  IMAGE_SCAN_PERMANENT_RETRY_LIMIT,
+} from '~/server/services/image-scan-failure';
+
+describe('classifyImageScanFailure', () => {
+  it('classifies container-create churn as transient', () => {
+    expect(
+      classifyImageScanFailure({
+        reason: 'Failed to create container. Giving up after 10 attempts',
+        failureType: 'workflow-failed',
+        failedSteps: ['tags'],
+      })
+    ).toBe(ImageScanFailureClass.Transient);
+  });
+
+  it('classifies a worker 5xx as transient', () => {
+    expect(
+      classifyImageScanFailure({
+        reason: 'Response status code does not indicate success: 500 (Internal Server Error).',
+        failureType: 'workflow-failed',
+        failedSteps: ['tags'],
+      })
+    ).toBe(ImageScanFailureClass.Transient);
+  });
+
+  it('classifies workflow expiry as transient regardless of reason', () => {
+    expect(
+      classifyImageScanFailure({ failureType: 'expired', reason: null, failedSteps: [] })
+    ).toBe(ImageScanFailureClass.Transient);
+  });
+
+  it('classifies a PrepareManagedContainer middleware failure as transient', () => {
+    expect(
+      classifyImageScanFailure({
+        reason: 'something went wrong',
+        middleware: 'PrepareManagedContainer',
+        failureType: 'workflow-failed',
+      })
+    ).toBe(ImageScanFailureClass.Transient);
+  });
+
+  it('classifies a download/decode failure as permanent', () => {
+    expect(
+      classifyImageScanFailure({
+        reason: 'Failed to download the media from the provided url',
+        failureType: 'workflow-failed',
+        failedSteps: ['rating'],
+      })
+    ).toBe(ImageScanFailureClass.Permanent);
+    expect(
+      classifyImageScanFailure({
+        reason: 'Unable to decode image: unsupported format',
+        failureType: 'workflow-failed',
+      })
+    ).toBe(ImageScanFailureClass.Permanent);
+  });
+
+  it('prefers transient when a 5xx occurs during a download (avoids permanent mislabel)', () => {
+    expect(
+      classifyImageScanFailure({
+        reason: 'Failed to download: 500 Internal Server Error',
+        failureType: 'workflow-failed',
+      })
+    ).toBe(ImageScanFailureClass.Transient);
+  });
+
+  it('falls back to unknown for an unrecognized reason', () => {
+    expect(
+      classifyImageScanFailure({
+        reason: 'some brand new error nobody has seen before',
+        failureType: 'workflow-failed',
+        failedSteps: ['tags'],
+      })
+    ).toBe(ImageScanFailureClass.Unknown);
+  });
+
+  it('falls back to unknown when no reason/steps are available', () => {
+    expect(
+      classifyImageScanFailure({ reason: null, failureType: 'workflow-failed', failedSteps: [] })
+    ).toBe(ImageScanFailureClass.Unknown);
+  });
+
+  it('is case-insensitive', () => {
+    expect(
+      classifyImageScanFailure({
+        reason: 'FAILED TO CREATE CONTAINER',
+        failureType: 'workflow-failed',
+      })
+    ).toBe(ImageScanFailureClass.Transient);
+  });
+});
+
+describe('getImageScanRetryLimit', () => {
+  it('maps each class to its ceiling', () => {
+    expect(getImageScanRetryLimit(ImageScanFailureClass.Transient)).toBe(
+      IMAGE_SCAN_TRANSIENT_RETRY_LIMIT
+    );
+    expect(getImageScanRetryLimit(ImageScanFailureClass.Permanent)).toBe(
+      IMAGE_SCAN_PERMANENT_RETRY_LIMIT
+    );
+    expect(getImageScanRetryLimit(ImageScanFailureClass.Unknown)).toBe(
+      IMAGE_SCAN_UNKNOWN_RETRY_LIMIT
+    );
+  });
+
+  it('defaults to the conservative unknown cap for null/unrecognized classes', () => {
+    expect(getImageScanRetryLimit(null)).toBe(IMAGE_SCAN_UNKNOWN_RETRY_LIMIT);
+    expect(getImageScanRetryLimit(undefined)).toBe(IMAGE_SCAN_UNKNOWN_RETRY_LIMIT);
+    expect(getImageScanRetryLimit('bogus')).toBe(IMAGE_SCAN_UNKNOWN_RETRY_LIMIT);
+  });
+
+  it('keeps transient strictly above the historical unknown cap and permanent minimal', () => {
+    expect(IMAGE_SCAN_TRANSIENT_RETRY_LIMIT).toBeGreaterThan(IMAGE_SCAN_UNKNOWN_RETRY_LIMIT);
+    expect(IMAGE_SCAN_PERMANENT_RETRY_LIMIT).toBeLessThan(IMAGE_SCAN_UNKNOWN_RETRY_LIMIT);
+  });
+});

--- a/src/server/services/image-scan-failure.ts
+++ b/src/server/services/image-scan-failure.ts
@@ -31,7 +31,9 @@ export type ImageScanFailureClass =
 // against that ever-incrementing count.
 export const IMAGE_SCAN_TRANSIENT_RETRY_LIMIT = 30; // bounded, but well above the old 9-cap
 export const IMAGE_SCAN_UNKNOWN_RETRY_LIMIT = 9; // historical flood-protection cap
-export const IMAGE_SCAN_PERMANENT_RETRY_LIMIT = 1; // one more attempt, then give up
+// Give up on the first failure: markImageScanError already bumped retryCount to 1, so
+// `retryCount < 1` is false on the next cron pass and the image is never re-queued.
+export const IMAGE_SCAN_PERMANENT_RETRY_LIMIT = 1;
 
 // Reason substrings that mark infra-transient failures. Matched case-insensitively.
 const TRANSIENT_REASON_PATTERNS = [
@@ -50,6 +52,10 @@ const TRANSIENT_REASON_PATTERNS = [
 ];
 
 // Orchestrator middleware / step markers that are infra-transient regardless of message.
+// Aspirational: the v2 job event doesn't expose `current_middleware` today, so in
+// practice container failures classify via the reason text ("Failed to create
+// container…") below. Kept so classification improves for free if middleware ever
+// arrives (via the passed `middleware` or a failing step named after it).
 const TRANSIENT_MIDDLEWARE_PATTERNS = ['preparemanagedcontainer', 'preparecontainer'];
 
 // Reason substrings that mark a permanently-bad input (the media can't be fetched/decoded).

--- a/src/server/services/image-scan-failure.ts
+++ b/src/server/services/image-scan-failure.ts
@@ -1,0 +1,111 @@
+/**
+ * Reason-aware classification of image-scan failures.
+ *
+ * Image scans submit an orchestrator workflow (wdTagging / mediaRating / mediaHash);
+ * on a non-success terminal event the webhook flips the image to `Error` and the
+ * `ingest-images` cron re-queues it until it succeeds or hits a ceiling. Historically
+ * that ceiling was a single flat 9-cap — which gives up on *transient infra churn*
+ * (e.g. Submodel/Siglip container instability: "Failed to create container…", 5xx on
+ * wdTagging) even though those succeed once the worker stabilizes.
+ *
+ * This module classifies a failure from its human `reason` string (captured off the
+ * job-level orchestrator callback) plus the failing step, so the cron can keep
+ * retrying transient failures under a higher — but still bounded — ceiling while
+ * giving up almost immediately on genuinely unscannable media. The ceilings are the
+ * hard backstop that stops any image re-flooding the scanner forever.
+ */
+
+export const ImageScanFailureClass = {
+  /** Infra churn that recovers on its own (container-create, 5xx, timeout, expiry). Keep retrying. */
+  Transient: 'transient',
+  /** The media itself can't be downloaded/decoded — it will never scan. Stop almost immediately. */
+  Permanent: 'permanent',
+  /** Unclassifiable reason. Retry conservatively under the historical cap. */
+  Unknown: 'unknown',
+} as const;
+export type ImageScanFailureClass =
+  (typeof ImageScanFailureClass)[keyof typeof ImageScanFailureClass];
+
+// Retry ceilings by class. The cron ALWAYS increments `scanJobs.retryCount` on every
+// failed attempt (see markImageScanError) — these are the absolute backstops applied
+// against that ever-incrementing count.
+export const IMAGE_SCAN_TRANSIENT_RETRY_LIMIT = 30; // bounded, but well above the old 9-cap
+export const IMAGE_SCAN_UNKNOWN_RETRY_LIMIT = 9; // historical flood-protection cap
+export const IMAGE_SCAN_PERMANENT_RETRY_LIMIT = 1; // one more attempt, then give up
+
+// Reason substrings that mark infra-transient failures. Matched case-insensitively.
+const TRANSIENT_REASON_PATTERNS = [
+  'failed to create container',
+  'giving up after', // "…Giving up after 10 attempts"
+  'does not indicate success: 5', // 5xx surfaced by a worker, e.g. "500 (Internal Server Error)"
+  'internal server error',
+  'bad gateway',
+  'service unavailable',
+  'gateway timeout',
+  'timed out',
+  'timeout',
+  'connection reset',
+  'connection refused',
+  'temporarily unavailable',
+];
+
+// Orchestrator middleware / step markers that are infra-transient regardless of message.
+const TRANSIENT_MIDDLEWARE_PATTERNS = ['preparemanagedcontainer', 'preparecontainer'];
+
+// Reason substrings that mark a permanently-bad input (the media can't be fetched/decoded).
+const PERMANENT_REASON_PATTERNS = [
+  'download',
+  'decode',
+  'corrupt',
+  'invalid image',
+  'invalid media',
+  'not a valid',
+  'unsupported',
+  'unscannable',
+];
+
+/**
+ * Classify a scan failure. Transient checks run first so a 5xx *while downloading*
+ * (which is recoverable) isn't mislabeled permanent by the `download` marker.
+ * Robust to empty/unknown reasons — falls back to `Unknown` (conservative retry).
+ */
+export function classifyImageScanFailure(input: {
+  reason?: string | null;
+  failureType?: string | null;
+  middleware?: string | null;
+  failedSteps?: string[] | null;
+}): ImageScanFailureClass {
+  const { reason, failureType, middleware, failedSteps } = input;
+
+  // Workflow expiry (the orchestrator's 10-min cap) is always a transient timeout:
+  // the work never ran to completion, so a re-scan can still succeed.
+  if (failureType === 'expired') return ImageScanFailureClass.Transient;
+
+  const haystack = [reason, middleware, ...(failedSteps ?? [])]
+    .filter((x): x is string => !!x)
+    .join(' ')
+    .toLowerCase();
+
+  if (!haystack) return ImageScanFailureClass.Unknown;
+
+  if (TRANSIENT_MIDDLEWARE_PATTERNS.some((p) => haystack.includes(p)))
+    return ImageScanFailureClass.Transient;
+  if (TRANSIENT_REASON_PATTERNS.some((p) => haystack.includes(p)))
+    return ImageScanFailureClass.Transient;
+  if (PERMANENT_REASON_PATTERNS.some((p) => haystack.includes(p)))
+    return ImageScanFailureClass.Permanent;
+
+  return ImageScanFailureClass.Unknown;
+}
+
+/** Absolute retry ceiling for a stored failure class (defaults to the conservative cap). */
+export function getImageScanRetryLimit(failureClass?: string | null): number {
+  switch (failureClass) {
+    case ImageScanFailureClass.Transient:
+      return IMAGE_SCAN_TRANSIENT_RETRY_LIMIT;
+    case ImageScanFailureClass.Permanent:
+      return IMAGE_SCAN_PERMANENT_RETRY_LIMIT;
+    default:
+      return IMAGE_SCAN_UNKNOWN_RETRY_LIMIT;
+  }
+}

--- a/src/server/services/image-scan-result.service.ts
+++ b/src/server/services/image-scan-result.service.ts
@@ -138,14 +138,16 @@ type OrchestratorJobEvent = {
   reason?: string | null;
 };
 
-// Job events carry a top-level `jobId`; workflow events never do. We only subscribe
-// to job:failed/expired/canceled, so any job event reaching us is a failure.
-function isJobEvent(event: unknown): event is OrchestratorJobEvent {
-  return typeof (event as OrchestratorJobEvent)?.jobId === 'string';
-}
-
 // Stash the job's failure `reason` keyed by workflowId. No DB/orchestrator round-trip:
 // just a short-lived Redis write so the terminal workflow event can classify.
+//
+// Correlation contract: job events fire before the terminal workflow event, so the
+// reason is stashed by the time the workflow event reads it. Across a workflow's
+// several jobs this is last-write-wins (fine — image scans typically have one failing
+// job; the reason strings we classify on are equivalent). If the reason is missing
+// (race, or a job event that never arrived) the failure classifies as Unknown, which
+// retries conservatively under the bounded cap — safe by construction. The TTL bounds
+// a stash that never gets a following workflow event so it can't linger.
 async function captureJobFailureReason(event: OrchestratorJobEvent) {
   const workflowId = event.workflowId;
   const reason = typeof event.reason === 'string' ? event.reason.trim() : '';
@@ -164,10 +166,14 @@ async function readJobFailureReason(workflowId: string): Promise<string | null> 
 export async function processImageScanResult(req: NextApiRequest) {
   const event: WorkflowEvent = req.body;
 
-  // A job-level failure event only carries the reason — capture it and return.
-  // The workflow-level terminal event (below) does the actual ingestion update.
-  if (isJobEvent(event)) {
-    await captureJobFailureReason(event);
+  // A job-level failure event only carries the reason — capture it and return; the
+  // workflow-level terminal event (below) does the actual ingestion update. Job
+  // events carry a top-level `jobId` (workflow events never do), and we only
+  // subscribe to job:failed/expired/canceled, so any job event here is a failure.
+  // Cast rather than a type predicate so `event` stays a WorkflowEvent afterwards.
+  const jobEvent = event as OrchestratorJobEvent;
+  if (typeof jobEvent.jobId === 'string') {
+    await captureJobFailureReason(jobEvent);
     return;
   }
 

--- a/src/server/services/image-scan-result.service.ts
+++ b/src/server/services/image-scan-result.service.ts
@@ -44,6 +44,9 @@ import {
   tagCacheByName,
   userImageVideoCountCaches,
 } from '~/server/redis/caches';
+import type { RedisKeyTemplateSys } from '~/server/redis/client';
+import { REDIS_SYS_KEYS, sysRedis } from '~/server/redis/client';
+import { classifyImageScanFailure } from '~/server/services/image-scan-failure';
 import type { MediaMetadata } from '~/server/schema/media.schema';
 import { deleteUserProfilePictureCache } from '~/server/services/user.service';
 import { bustCachesForPosts, updatePostNsfwLevel } from '~/server/services/post.service';
@@ -120,8 +123,53 @@ type ProcessedTag = {
   type: TagType;
 };
 
+// TTL for a stashed job reason. Comfortably longer than the orchestrator's 10-min
+// workflow expiry so the terminal workflow event can still read it.
+const JOB_REASON_TTL_SECONDS = 15 * 60;
+
+const jobReasonKey = (workflowId: string) =>
+  `${REDIS_SYS_KEYS.WEBHOOKS.IMAGE_SCAN_JOB_REASON}:${workflowId}` as RedisKeyTemplateSys;
+
+/** Orchestrator job-level event shape we care about (a subset of WorkflowStepJobEvent). */
+type OrchestratorJobEvent = {
+  $type?: string;
+  workflowId?: string;
+  jobId?: string;
+  reason?: string | null;
+};
+
+// Job events carry a top-level `jobId`; workflow events never do. We only subscribe
+// to job:failed/expired/canceled, so any job event reaching us is a failure.
+function isJobEvent(event: unknown): event is OrchestratorJobEvent {
+  return typeof (event as OrchestratorJobEvent)?.jobId === 'string';
+}
+
+// Stash the job's failure `reason` keyed by workflowId. No DB/orchestrator round-trip:
+// just a short-lived Redis write so the terminal workflow event can classify.
+async function captureJobFailureReason(event: OrchestratorJobEvent) {
+  const workflowId = event.workflowId;
+  const reason = typeof event.reason === 'string' ? event.reason.trim() : '';
+  if (!workflowId || !reason) return;
+  await sysRedis
+    .set(jobReasonKey(workflowId), reason, { EX: JOB_REASON_TTL_SECONDS })
+    .catch(() => null);
+}
+
+async function readJobFailureReason(workflowId: string): Promise<string | null> {
+  const reason = await sysRedis.get(jobReasonKey(workflowId)).catch(() => null);
+  if (reason) sysRedis.del(jobReasonKey(workflowId)).catch(() => null);
+  return reason ?? null;
+}
+
 export async function processImageScanResult(req: NextApiRequest) {
   const event: WorkflowEvent = req.body;
+
+  // A job-level failure event only carries the reason — capture it and return.
+  // The workflow-level terminal event (below) does the actual ingestion update.
+  if (isJobEvent(event)) {
+    await captureJobFailureReason(event);
+    return;
+  }
 
   const { data } = await getWorkflow({
     client: internalOrchestratorClient,
@@ -177,24 +225,24 @@ export async function processImageScanWorkflow({
   completedAt?: Date | string | null;
 }) {
   if (status !== 'succeeded') {
-    // Record WHICH orchestrator steps failed (wdTagging / mediaHash /
-    // mediaRating) — this is the key diagnostic. The orchestrator emits only a
-    // workflow-level status (`failed`/`canceled`; it never sends `expired`) with
-    // no per-job error reason on the wire, so the failing-step name is the only
-    // signal we have to tell transient decode/fetch churn apart from a genuine
-    // rating failure. NOTE: `markImageScanError` still ALWAYS bumps retryCount
-    // toward the 9-cap (see there). The expired-vs-failed "don't burn a retry"
-    // behavior is deferred: with no `expired` status and no per-job reason we
-    // can't yet distinguish a transient timeout from a real failure — this
-    // step/reason logging is the data needed to design that fix.
+    // Which orchestrator steps failed (wdTagging / mediaHash / mediaRating) plus
+    // the job-level `reason` — captured off the `job:failed`/`job:expired`
+    // callback (getWorkflow itself exposes no per-job error) — are how we tell
+    // transient infra churn (Siglip container instability, 5xx, timeouts,
+    // expiry) apart from a genuinely unscannable image. `markImageScanError`
+    // stamps a `failureClass` from those signals; the `ingest-images` cron uses
+    // it to pick a retry ceiling. retryCount ALWAYS bumps (the absolute backstop).
     const failedSteps = extractFailedSteps(steps);
-    const failureType = status === 'canceled' ? 'canceled' : 'workflow-failed';
-    const { retryCount, mediaType } = await markImageScanError({
+    const failureType =
+      status === 'expired' ? 'expired' : status === 'canceled' ? 'canceled' : 'workflow-failed';
+    const reason = await readJobFailureReason(workflowId);
+    const { retryCount, mediaType, failureClass } = await markImageScanError({
       workflowId,
       imageId,
       status,
       failureType,
       failedSteps,
+      reason,
     });
     logToAxiom(
       {
@@ -204,6 +252,8 @@ export async function processImageScanWorkflow({
         source: 'image-scan-result.service',
         failureType,
         failedSteps,
+        reason,
+        failureClass,
         imageId,
         mediaType,
         workflowId,
@@ -450,11 +500,14 @@ function extractFailedSteps(steps: ScanResultStep[]): string[] {
 
 /**
  * Flip an image to `Error`, increment its scan `retryCount`, and stamp a small
- * `scanJobs.error = { status, failureType, failedSteps, at }` so a plain
- * Postgres query can tell WHY a scan errored (and which step) without an
- * orchestrator lookup. Returns the new (post-increment) retryCount and the
- * image's mediaType so callers can log them; both are `null` when no row matched
- * (e.g. the image was deleted between scan request and callback).
+ * `scanJobs.error = { status, failureType, failedSteps, reason, failureClass, at }`
+ * so a plain Postgres query can tell WHY a scan errored (and which step) without an
+ * orchestrator lookup — and so the `ingest-images` cron can pick a retry ceiling
+ * from `failureClass`. retryCount ALWAYS increments: it's the absolute attempt
+ * count the per-class ceilings are applied against. Returns the new (post-increment)
+ * retryCount, the image's mediaType, and the computed failureClass; retryCount /
+ * mediaType are `null` when no row matched (e.g. the image was deleted between scan
+ * request and callback).
  */
 async function markImageScanError({
   workflowId,
@@ -462,17 +515,33 @@ async function markImageScanError({
   status,
   failureType,
   failedSteps,
+  reason,
+  middleware,
 }: {
   workflowId: string;
   imageId: number;
   status: string;
   failureType: string;
   failedSteps: string[];
-}): Promise<{ retryCount: number | null; mediaType: string | null }> {
+  /** Human failure reason from the job-level callback, if captured. */
+  reason?: string | null;
+  /** Orchestrator middleware locus, if known. Not exposed on the v2 job event today. */
+  middleware?: string | null;
+}): Promise<{
+  retryCount: number | null;
+  mediaType: string | null;
+  failureClass: string;
+}> {
+  const failureClass = classifyImageScanFailure({ reason, failureType, middleware, failedSteps });
+  // undefined keys are dropped by JSON.stringify, so absent reason/middleware
+  // simply don't appear in the stored blob.
   const errorJson = JSON.stringify({
     status,
     failureType,
     failedSteps,
+    reason: reason ?? undefined,
+    middleware: middleware ?? undefined,
+    failureClass,
     at: new Date().toISOString(),
   });
   const rows = await dbWrite.$queryRaw<{ retryCount: number | null; mediaType: string | null }[]>`
@@ -495,7 +564,11 @@ async function markImageScanError({
     WHERE id = ${imageId}
     RETURNING ("scanJobs"->>'retryCount')::int as "retryCount", type as "mediaType"
   `;
-  return { retryCount: rows[0]?.retryCount ?? null, mediaType: rows[0]?.mediaType ?? null };
+  return {
+    retryCount: rows[0]?.retryCount ?? null,
+    mediaType: rows[0]?.mediaType ?? null,
+    failureClass,
+  };
 }
 
 // Image loading

--- a/src/server/services/orchestrator/orchestrator.service.ts
+++ b/src/server/services/orchestrator/orchestrator.service.ts
@@ -157,11 +157,19 @@ export async function createImageIngestionRequest({
       ? [
           {
             url: `${callbackUrl}`,
+            // Job-level failure events (job:failed/expired/canceled) carry the
+            // human `reason` (e.g. "Failed to create container…", "…500 (Internal
+            // Server Error)") that workflow-level events + getWorkflow don't expose.
+            // The webhook stashes it so the terminal workflow event can classify
+            // the failure. Success path is unaffected — no job:succeeded here.
             type: [
               'workflow:succeeded',
               'workflow:failed',
               'workflow:expired',
               'workflow:canceled',
+              'job:failed',
+              'job:expired',
+              'job:canceled',
             ],
           },
         ]


### PR DESCRIPTION
Builds on #3339's scan-failure observability (`scanJobs.error`, `failedSteps`, Axiom events) to make image-scan retries **reason-aware** instead of a flat 9-cap that gives up on transient infra churn. Targets the current failure mode: Submodel/Siglip container instability ("Failed to create container. Giving up after 10 attempts", "…500 (Internal Server Error)" on wdTagging while mediaRating succeeds) — these recover once the container stabilizes and should keep retrying, not be abandoned.

## U1 — capture `expired`

`workflow:expired` **was** already subscribed and delivered, but `processImageScanWorkflow` collapsed everything that wasn't `canceled` into `failureType: 'workflow-failed'` — so expired workflows were silently mislabeled (that's why Axiom showed 0 expired despite the orchestrator's 10-min expiry firing). Now `status === 'expired'` is stamped `failureType: 'expired'`, flows the same Error (re-scannable) path, writes `scanJobs.error`, and emits the Axiom event. Expiry classifies as **transient** (the work never completed, so a re-scan can still succeed).

## U2 — capture the job-level reason

The failure reason is **not** in the workflow view our callback processes: `getWorkflow` returns `Workflow → steps → jobs (WorkflowStepJob)`, and `WorkflowStepJob` carries only `{ id, status }` — no error string anywhere. The reason lives on the job event as `WorkflowStepJobEvent.reason`.

**Approach chosen: (b) subscribe to job-level webhook events.** `createImageIngestionRequest` now registers `job:failed` / `job:expired` / `job:canceled` callbacks (success path untouched — no `job:succeeded`). On a job event the webhook stashes `reason` keyed by `workflowId` in `sysRedis` (15-min TTL > the 10-min workflow expiry); the terminal `workflow:*` event reads and clears it, then classifies.

**Why not (a) fetch job detail:** `@civitai/client`'s v2 surface has **no job getter** (`queryWorkflows` / `getWorkflow` / `getWorkflowStep` only), and `getWorkflow` exposes no per-job error — so (a) would mean dropping to the deprecated v1 `orchestrator.caller` **and** a per-failure round-trip under a flood. Approach (b) delivers the reason on the existing callback channel with **zero fetch** on the failure path (just one Redis SET on the job event, one GET on the workflow event). Tradeoff: it adds job-event traffic during failures (not on success) and relies on the job event arriving before/around the workflow event — if it doesn't, `reason` is absent and the failure classifies as **unknown** (conservative retry), which is safe. The v2 job event also doesn't carry `current_middleware`, so the failing **step** name (already extracted via `failedSteps`) serves as the middleware locus; `middleware` remains a plumbed-but-usually-null field for when it becomes available.

`reason` + `failureClass` are persisted into `scanJobs.error` and added to the Axiom event.

## U3 — reason-based retry with an absolute ceiling

New `classifyImageScanFailure` (pure, unit-tested) maps a failure to a class from its reason string + failing step + failureType (case-insensitive substring match, transient checked before permanent so a 5xx *during a download* isn't mislabeled):

| Class | Markers | Behavior |
|-------|---------|----------|
| **transient** | `failed to create container`, `giving up after`, `does not indicate success: 5xx` / `internal server error` / `bad gateway` / `service unavailable`, `timeout`/`timed out`, `connection reset/refused`, `PrepareManagedContainer`, **and all `expired`** | keep retrying, high bounded cap |
| **permanent** | `download`, `decode`, `corrupt`, `invalid image/media`, `not a valid`, `unsupported`, `unscannable` | stop almost immediately |
| **unknown** | anything unrecognized / no reason | retry conservatively under the historical cap |

`scanJobs.error.failureClass` is stamped at failure time; the `ingest-images` cron reads it (`scanJobs->'error'->>'failureClass'`) and applies a per-class ceiling against the **always-incrementing** `retryCount`:

- `IMAGE_SCAN_TRANSIENT_RETRY_LIMIT = 30` — the **absolute backstop** for transient churn (well above the old 9-cap, but bounded so it can't retry forever)
- `IMAGE_SCAN_UNKNOWN_RETRY_LIMIT = 9` — unchanged historical flood-protection cap
- `IMAGE_SCAN_PERMANENT_RETRY_LIMIT = 1` — one more attempt, then give up

`retryCount` still always increments (from #3339) — the caps are purely the give-up decision, so **flood protection is preserved**: a permanently-bad image stops after 1, an unclassifiable one stops at 9, and transient Siglip-container churn keeps retrying (via the low-priority error lane, 1-hour cooldown) up to 30 attempts and succeeds once the container recovers. The `Rescan` path keeps its own `IMAGE_SCANNING_RETRY_LIMIT = 9` (moderator-driven, not reason-classified) unchanged.

## How this fixes the current churn
Today a Siglip-container wdTagging failure flips the image to Error, bumps `retryCount`, and is abandoned at 9 even though the very next scan (post-recovery) would succeed. Now that failure is classified **transient** off its reason and keeps retrying to 30 — while genuinely unscannable media (bad download/decode) stops at 1 instead of wasting 9 attempts.

## Tests
`src/server/services/__tests__/image-scan-failure.test.ts` (12 cases): transient (container/5xx/expiry/middleware), permanent (download/decode), transient-precedence over download, unknown fallbacks, case-insensitivity, and the ceiling map (incl. transient > unknown > permanent invariant). All pass.

## Verification
- `pnpm typecheck` (`tsc --noEmit`): **No errors found**.
- New vitest suite: 12/12 pass. (The pre-existing `image-scan-result.test.ts` fails to load on the known `kysely` package-resolution noise, unrelated to this change.)
- prettier clean.

## Files
- `packages/civitai-redis/src/client.ts` — `REDIS_SYS_KEYS.WEBHOOKS.IMAGE_SCAN_JOB_REASON`
- `src/server/services/image-scan-failure.ts` (new) — classification + ceilings
- `src/server/services/orchestrator/orchestrator.service.ts` — register job-level callbacks
- `src/server/services/image-scan-result.service.ts` — capture reason, fix expired label, stamp `failureClass`
- `src/server/jobs/image-ingestion.ts` — per-class Error retry ceiling
- `src/server/services/__tests__/image-scan-failure.test.ts` (new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Post-deploy verification (preview / Axiom)
Two assumptions to confirm once deployed, since neither is observable pre-deploy:
1. The orchestrator actually delivers workflow-level `expired` events (so the expired -> transient relabel fires and Axiom starts showing non-zero `failureType:expired`).
2. The `job:failed`/`job:expired` event `reason` field really carries the container-create / 500 text we classify on (confirm captured `reason` + `failureClass` land in `scanJobs.error` and the Axiom event for real Siglip failures).
