### PR TITLE
fix(training): make training list rows real links

### DIFF
--- a/src/components/User/UserTrainingModels.tsx
+++ b/src/components/User/UserTrainingModels.tsx
@@ -301,8 +301,8 @@ export default function UserTrainingModels() {
   });
 
   const goToModel = (e: React.MouseEvent, href: string) => {
-    if (opened) return false;
-    if ((e.ctrlKey && e.button === 0) || e.button === 1) {
+    if (opened) return;
+    if (e.button === 1 || (e.button === 0 && (e.ctrlKey || e.metaKey))) {
       e.preventDefault();
       window.open(href, '_blank');
     } else if (e.button === 0) {
@@ -376,14 +376,22 @@ export default function UserTrainingModels() {
         id: 'name',
         enableSorting: false,
         Cell: ({ row }) => (
-          <Group gap={4} wrap="nowrap">
-            <Text lineClamp={1}>{row.original.model.name}</Text>
-            {row.original.name !== row.original.model.name && (
-              <Text c="dimmed" size="sm">
-                ({row.original.name})
-              </Text>
-            )}
-          </Group>
+          <Anchor
+            component={Link}
+            href={getModelTrainingWizardUrl(row.original)}
+            onClick={(e: React.MouseEvent<HTMLAnchorElement>) => e.stopPropagation()}
+            underline="never"
+            c="inherit"
+          >
+            <Group gap={4} wrap="nowrap">
+              <Text lineClamp={1}>{row.original.model.name}</Text>
+              {row.original.name !== row.original.model.name && (
+                <Text c="dimmed" size="sm">
+                  ({row.original.name})
+                </Text>
+              )}
+            </Group>
+          </Anchor>
         ),
       },
       {
@@ -948,6 +956,10 @@ export default function UserTrainingModels() {
           }}
           mantineTableBodyRowProps={({ row }) => ({
             onClick: (e) => goToModel(e, getModelTrainingWizardUrl(row.original)),
+            onAuxClick: (e) => goToModel(e, getModelTrainingWizardUrl(row.original)),
+            onMouseDown: (e) => {
+              if (e.button === 1) e.preventDefault();
+            },
             style: { cursor: 'pointer' },
           })}
           mantineTableHeadCellProps={{

--- a/src/components/User/UserTrainingModels.tsx
+++ b/src/components/User/UserTrainingModels.tsx
@@ -304,7 +304,7 @@ export default function UserTrainingModels() {
     if (opened) return;
     if (e.button === 1 || (e.button === 0 && (e.ctrlKey || e.metaKey))) {
       e.preventDefault();
-      window.open(href, '_blank');
+      window.open(href, '_blank', 'noopener');
     } else if (e.button === 0) {
       router.push(href).then();
     }
@@ -380,7 +380,7 @@ export default function UserTrainingModels() {
             component={Link}
             href={getModelTrainingWizardUrl(row.original)}
             onClick={(e: React.MouseEvent<HTMLAnchorElement>) => e.stopPropagation()}
-            underline="never"
+            underline="hover"
             c="inherit"
           >
             <Group gap={4} wrap="nowrap">
@@ -956,9 +956,13 @@ export default function UserTrainingModels() {
           }}
           mantineTableBodyRowProps={({ row }) => ({
             onClick: (e) => goToModel(e, getModelTrainingWizardUrl(row.original)),
-            onAuxClick: (e) => goToModel(e, getModelTrainingWizardUrl(row.original)),
+            onAuxClick: (e) => {
+              if (e.button !== 1) return;
+              if ((e.target as HTMLElement).closest('a,button')) return;
+              goToModel(e, getModelTrainingWizardUrl(row.original));
+            },
             onMouseDown: (e) => {
-              if (e.button === 1) e.preventDefault();
+              if (e.button === 1 && !(e.target as HTMLElement).closest('a')) e.preventDefault();
             },
             style: { cursor: 'pointer' },
           })}


### PR DESCRIPTION
## Request

From creator MNeMiC (about the models-in-training list on the user training page):

> The models in training list doesn't allow me to MMB click to open in new tab. This is annoying when I'm training multiple models and I want to open to preview all of them.

## Cause

Rows in `UserTrainingModels` navigated with `router.push` from the table row's `onClick`. `onClick` never fires for the middle mouse button, so the existing `e.button === 1` branch was dead code, and since no row content was an anchor there was nothing for the browser's right-click "Open link in new tab" to act on either.

## Changes

`src/components/User/UserTrainingModels.tsx`:

- The **Name** cell is now a real link (`Anchor component={NextLink}` to the same training wizard URL), styled to inherit the current look. Middle-click, ctrl/cmd+click, and right-click "Open link in new tab" all work on it natively. It stops propagation so the row handler doesn't double-navigate.
- Row props gained `onAuxClick` so middle-clicking **anywhere** in the row opens the wizard in a new tab, plus an `onMouseDown` guard that suppresses the browser's middle-click autoscroll.
- `goToModel` now also treats cmd+click (macOS) as open-in-new-tab.

Left-click behavior is unchanged, and the in-row buttons (Review / View Epochs / recheck / details / delete) keep their existing `stopPropagation`, so they still don't navigate.

## Manual verification

On `/user/<name>/models` -> Training tab (or wherever the training list renders):

1. Middle-click a row (on the name, and on an empty area of the row) -> opens the training wizard in a new background tab; no autoscroll cursor appears.
2. Ctrl+click (Windows) / Cmd+click (macOS) a row -> opens in a new tab.
3. Right-click the model name -> browser context menu shows "Open link in new tab" and it works.
4. Plain left-click anywhere on the row -> navigates in the same tab as before.
5. Click Review / View Epochs / the recheck, details, and delete icons -> each does its own thing and does **not** navigate the row.
6. Open the details modal, then click a row behind it -> still no navigation (the `opened` guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
