### PR TITLE
fix(upload): show drag-over state on model file dropzone

### DIFF
--- a/src/components/Resource/Files.module.scss
+++ b/src/components/Resource/Files.module.scss
@@ -1,5 +1,7 @@
-// Mantine's own [data-accept]/[data-reject] rules live in @layer mantine and use
-// :where(), so any unlayered class or inline style on the root silently wins.
+// Keyed off [data-idle] rather than [data-accept]: on dragenter react-dropzone
+// only has DataTransferItems, which expose no filename and an empty type for
+// .safetensors/.ckpt/.pt, so an extension-based accept map can never match and
+// every drag reports as a reject until the actual drop.
 .dropzone {
   border: 2px dashed var(--mantine-color-dark-4);
   border-radius: var(--mantine-radius-md);
@@ -7,18 +9,15 @@
   cursor: pointer;
   transition: background-color 100ms ease, border-color 100ms ease;
 
-  &:hover {
-    border-color: var(--mantine-color-blue-5);
-    background-color: rgba(34, 139, 230, 0.05);
+  @media (hover: hover) {
+    &:where(:hover) {
+      border-color: var(--mantine-color-blue-5);
+      background-color: color-mix(in srgb, var(--mantine-color-blue-5) 5%, transparent);
+    }
   }
 
-  &[data-accept] {
+  &:not([data-idle]) {
     border-color: var(--mantine-color-blue-5);
-    background-color: rgba(34, 139, 230, 0.15);
-  }
-
-  &[data-reject] {
-    border-color: var(--mantine-color-red-6);
-    background-color: rgba(250, 82, 82, 0.15);
+    background-color: color-mix(in srgb, var(--mantine-color-blue-5) 15%, transparent);
   }
 }

--- a/src/components/Resource/Files.module.scss
+++ b/src/components/Resource/Files.module.scss
@@ -1,6 +1,24 @@
-.dropzoneReject {
+// Mantine's own [data-accept]/[data-reject] rules live in @layer mantine and use
+// :where(), so any unlayered class or inline style on the root silently wins.
+.dropzone {
+  border: 2px dashed var(--mantine-color-dark-4);
+  border-radius: var(--mantine-radius-md);
+  background-color: transparent;
+  cursor: pointer;
+  transition: background-color 100ms ease, border-color 100ms ease;
+
+  &:hover {
+    border-color: var(--mantine-color-blue-5);
+    background-color: rgba(34, 139, 230, 0.05);
+  }
+
+  &[data-accept] {
+    border-color: var(--mantine-color-blue-5);
+    background-color: rgba(34, 139, 230, 0.15);
+  }
+
   &[data-reject] {
-    background: var(--mantine-color-dark-5);
-    border-color: var(--mantine-color-dark-4);
+    border-color: var(--mantine-color-red-6);
+    background-color: rgba(250, 82, 82, 0.15);
   }
 }

--- a/src/components/Resource/Files.tsx
+++ b/src/components/Resource/Files.tsx
@@ -83,7 +83,7 @@ function InlineDropzone({
       maxFiles={maxFiles}
       onReject={onReject}
       useFsAccessApi={!isAndroidDevice()}
-      className="cursor-pointer rounded-lg border-2 border-dashed border-dark-4 bg-transparent hover:border-blue-5 hover:bg-blue-5/5"
+      className={classes.dropzone}
       p="md"
     >
       <Stack gap={4} align="center" style={{ pointerEvents: 'none' }}>
@@ -327,16 +327,8 @@ export function Files({ showRenameOnPrimary }: { showRenameOnPrimary?: boolean }
               }}
               maxFiles={primary.maxFiles}
               onReject={handleRejectPrimary}
-              className={classes.dropzoneReject}
+              className={classes.dropzone}
               useFsAccessApi={!isAndroidDevice()}
-              styles={{
-                root: {
-                  border: '2px dashed var(--mantine-color-dark-4)',
-                  borderRadius: 'var(--mantine-radius-md)',
-                  backgroundColor: 'transparent',
-                  cursor: 'pointer',
-                },
-              }}
             >
               <Stack gap="xs" align="center" py="lg" style={{ pointerEvents: 'none' }}>
                 <ThemeIcon size={48} radius="xl" variant="light" color="blue">


### PR DESCRIPTION
## Reported bug

> The drag/drop area is non-reactive when adding new files to this box. This is scary because sometimes drag/dropping to sites means you open the files instead.
> — MNeMiC, creator feedback

If you miss the drop target, the browser opens the file instead. There was no visual cue that the box was a valid target.

## Root cause

Two separate problems, and neither dropzone on the model-version file step actually reacted (the reporter's recollection that new-model creation highlights was mistaken — that surface just isn't where you land once files exist):

1. **`InlineDropzone`** ("Add another model file variant" / "Upload a component file") styled its root with **unlayered Tailwind** (`border-dark-4 bg-transparent`). Tailwind utilities are unlayered in this repo (`src/styles/globals.css:23-24`), so they beat Mantine's `@layer mantine` drag rules and pinned the box to its idle appearance mid-drag. Its `hover:` variants can't help — `:hover` doesn't apply while a drag is in progress.
2. **The empty-state `Dropzone`** used `styles={{ root: { border, backgroundColor } }}`, which Mantine emits as **inline** styles, beating every stylesheet rule.

## Why this doesn't use `[data-accept]` / `[data-reject]`

The obvious fix — style Mantine's accept/reject states — is wrong here, and an earlier revision of this PR got it wrong that way.

`Files.tsx:176-177` builds its accept maps as `{ 'mime/type': ['.safetensors', ...] }`, i.e. extension-only. During `dragenter`/`dragover`, `react-dropzone-esm` returns raw `DataTransferItem`s rather than `File`s (`file-selector.mjs:60-70`) — **browsers deliberately withhold filenames until drop**. So extension matching against `file.name || ''` is always false, and `item.type` is `''` for `.safetensors`/`.ckpt`/`.pt`/`.bin`. Both branches miss, `isDragReject` becomes `true`, and every valid model file would render **red**.

That is also why this PR deletes a rule that looked redundant: the old `&[data-reject] { background: dark-5; border-color: dark-4 }` was painting reject to look identical to idle, deliberately suppressing this false reject.

## Fix

One `.dropzone` class in `Files.module.scss`, applied to both dropzones, with the active state keyed off `&:not([data-idle])` — Mantine sets `data-idle` whenever neither accept nor reject applies, so its absence means \"files are being dragged over me\", with no dependence on the accept map. Removed the Tailwind override string and the inline `styles.root`.

CSS modules win here by **layer order**, not by escaping layers: `postcss.config.js:20-24` wraps `*.module.scss` in `@layer modules`, and `_document.tsx:22` declares `@layer tailwind-preflight, theme, mantine, modules;`.

Hover is gated behind `@media (hover: hover)` so it can't stick after a tap on touch devices, and wrapped in `:where()` so the drag state wins on specificity rather than source order. Tints use `color-mix` against `--mantine-color-blue-5` so they follow the palette instead of a hardcoded hex.

**Idle appearance is unchanged** (verified value-by-value against `main` in both themes). The empty-state box does gain a hover state it never had — the old inline `backgroundColor: transparent` was beating Mantine's hover rule.

## Behavior note

An unsupported file now shows the **same blue** active state as a valid one during drag; rejection surfaces on drop via the existing `onReject` notification, which already names what the section accepts. This is forced rather than chosen — the browser gives us nothing to judge a file by before drop, so any pre-drop accept/reject distinction would be guesswork, and guessing wrong means a red border on a file that uploads fine.

## Manual verification

Note the two model-file boxes are mutually exclusive: `Files.tsx:302-320` renders `InlineDropzone` when files exist and the empty-state `Dropzone` when none do.

1. On a model version with **at least one file present**, drag a real `.safetensors` over **\"Add another model file variant\"** → box turns blue, reverts cleanly on drag-away. Repeat for **\"Upload a component file\"** in Additional Components on the same page.
2. On a version with **no files yet**, repeat for the empty-state **\"Drop model files here\"**.
3. Drop it — the file still uploads (styling change shouldn't touch the drop path).
4. Drag a file the section doesn't accept → blue during drag, then the reject notification on drop. Confirm that notification carries the rejection on its own, since the border no longer distinguishes.
5. Compare idle appearance side-by-side against `main` in **both** light and dark mode.
6. Drag selected text over the box → should **not** light up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)