### PR TITLE
feat(moderation): split ban content removal into models + media toggles

### DIFF
--- a/src/pages/api/mod/ban-user.ts
+++ b/src/pages/api/mod/ban-user.ts
@@ -11,16 +11,21 @@ const schema = z.object({
   reasonCode: z.enum(BanReasonCode).optional(),
   detailsExternal: z.string().optional(),
   detailsInternal: z.string().optional(),
-  removeContent: z
+  // Explicit 'true'/'false' string enum, NOT z.coerce.boolean() — coercion
+  // makes the string "false" truthy, which would silently invert the opt-out.
+  removeMedia: z
+    .enum(['true', 'false'])
+    .optional()
+    .transform((v) => (v === undefined ? undefined : v === 'true')),
+  removeModels: z
     .enum(['true', 'false'])
     .optional()
     .transform((v) => (v === undefined ? undefined : v === 'true')),
 });
 
 export default WebhookEndpoint(async (req: NextApiRequest, res: NextApiResponse) => {
-  const { userId, reasonCode, detailsExternal, detailsInternal, removeContent } = schema.parse(
-    req.query
-  );
+  const { userId, reasonCode, detailsExternal, detailsInternal, removeMedia, removeModels } =
+    schema.parse(req.query);
 
   res.status(200).json({
     userId,
@@ -32,7 +37,8 @@ export default WebhookEndpoint(async (req: NextApiRequest, res: NextApiResponse)
       reasonCode,
       detailsExternal,
       detailsInternal,
-      removeContent,
+      removeMedia,
+      removeModels,
       userId: -1, // using civitai user for banning using webhook
     });
 

--- a/src/server/schema/user.schema.ts
+++ b/src/server/schema/user.schema.ts
@@ -453,7 +453,8 @@ export const toggleBanUserSchema = z.object({
   detailsInternal: z.string().optional(),
   detailsExternal: z.string().optional(),
   type: z.enum(['universal', 'contest']).default('universal').optional(),
-  removeContent: z.boolean().optional(),
+  removeMedia: z.boolean().optional(),
+  removeModels: z.boolean().optional(),
 });
 
 export type GetBanContentPreviewInput = z.infer<typeof getBanContentPreviewSchema>;

--- a/src/server/services/user.service.ts
+++ b/src/server/services/user.service.ts
@@ -1185,9 +1185,10 @@ export async function softDeleteUser({ id, userId }: { id: number; userId: numbe
     isModerator: false,
     userId,
     force: true,
-    // Skip toggleBan's Moderated block; softDeleteUser applies its own CSAM
-    // block below. Avoids a redundant double-write and a Moderated->CSAM flip.
-    removeContent: false,
+    // Skip toggleBan's Moderated media block; softDeleteUser applies its own
+    // CSAM block below. Avoids a redundant double-write and a Moderated->CSAM
+    // flip. Models still unpublish (removeModels defaults on).
+    removeMedia: false,
   });
 
   await dbWrite.image.updateMany({
@@ -1702,7 +1703,8 @@ export const toggleBan = async ({
   userId,
   isModerator,
   force,
-  removeContent,
+  removeMedia,
+  removeModels,
 }: ToggleBanUser & { userId: number; isModerator?: boolean; force?: boolean }) => {
   // Get user with username for search index deletion
   const user = await getUserById({
@@ -1740,16 +1742,22 @@ export const toggleBan = async ({
     // Run cleanup operations in parallel groups
     // Group A: DB-heavy operations (run together)
     // Group B: External API operations (run together)
+    // Unpublishing models defaults ON for every ban (historical behavior); a
+    // moderator can opt out per-ban. Only `removeModels === false` skips it.
+    const shouldRemoveModels = removeModels !== false;
+
     await Promise.all([
       // Group A: Bulk unpublish models and handle bids
-      bulkUnpublishModelsForBannedUser({ odRef: id, odRefuserId: userId }).catch((error) => {
-        logToAxiom({
-          type: 'error',
-          name: 'ban-user-bulk-unpublish',
-          message: error.message,
-          error,
-        });
-      }),
+      shouldRemoveModels
+        ? bulkUnpublishModelsForBannedUser({ odRef: id, odRefuserId: userId }).catch((error) => {
+            logToAxiom({
+              type: 'error',
+              name: 'ban-user-bulk-unpublish',
+              message: error.message,
+              error,
+            });
+          })
+        : Promise.resolve(),
 
       // Wipe public-profile UserLink rows so banned users' off-site links
       // disappear immediately (replaces a manual Retool DELETE step).
@@ -1788,14 +1796,13 @@ export const toggleBan = async ({
       ]),
     ]);
 
-    // Opt-in "remove all content": block (not delete) the banned user's images,
-    // defaulting ON for SexualMinor bans. Blocking (Moderated) preserves the
-    // 7-day appeal window — the remove-blocked-images job hard-deletes them
+    // Opt-in "remove all images & videos": block (not delete) the banned user's
+    // media, defaulting ON for SexualMinor bans. Blocking (Moderated) preserves
+    // the 7-day appeal window — the remove-blocked-images job hard-deletes them
     // after that. CSAM semantics stay reserved for the softDeleteUser path.
-    const shouldRemoveContent =
-      removeContent === true ||
-      (reasonCode === BanReasonCode.SexualMinor && removeContent !== false);
-    if (shouldRemoveContent) {
+    const shouldRemoveMedia =
+      removeMedia === true || (reasonCode === BanReasonCode.SexualMinor && removeMedia !== false);
+    if (shouldRemoveMedia) {
       try {
         await dbWrite.image.updateMany({
           where: { userId: id, ingestion: { not: 'Blocked' } },
@@ -1867,10 +1874,18 @@ export const toggleBan = async ({
 };
 
 export const getBanContentPreview = async ({ userId }: { userId: number }) => {
-  const imageCount = await dbRead.image.count({
-    where: { userId, ingestion: { not: 'Blocked' } },
-  });
-  return { imageCount };
+  const [imageCount, modelCount] = await Promise.all([
+    dbRead.image.count({
+      where: { userId, ingestion: { not: 'Blocked' } },
+    }),
+    dbRead.model.count({
+      where: {
+        userId,
+        status: { in: [ModelStatus.Published, ModelStatus.Scheduled] },
+      },
+    }),
+  ]);
+  return { imageCount, modelCount };
 };
 
 export const toggleContestBan = async ({


### PR DESCRIPTION
Follow-up on #3340 based on review feedback.

## Problem
"Remove all content" was ambiguous. In reality:
- **Models** were unpublished on *every* ban, unconditionally (`bulkUnpublishModelsForBannedUser`) — not a choice.
- The **`removeContent` toggle** only blocked the `Image` table — which is `MediaType` (image/**video**/audio), so it's media, not just images.
- Neither touched articles, bounties, posts, or comments.

So a mod reading "remove all content" would reasonably assume it covered models (handled elsewhere) and everything else (not touched at all).

## Change
Two independent, honestly-scoped controls on `toggleBan` + the Retool `ban-user` webhook:

| Param | Default | Behavior |
|---|---|---|
| `removeModels` | **ON** every ban (`removeModels === false` skips) | Gates the previously-unconditional model unpublish. Passing nothing = today's behavior, so no caller regresses. Mods can now opt out. |
| `removeMedia` (was `removeContent`) | **ON** for SexualMinor, else OFF | Blocks the user's images & videos as `Moderated` (7-day window). Unchanged from #3340. |

- `getBanContentPreview` now returns `{ imageCount, modelCount }` so each toggle can show its own affected count.
- `softDeleteUser` passes `removeMedia: false` (keeps its own CSAM block) and lets `removeModels` default on.
- Webhook exposes both as `'true'/'false'` string enums — never `z.coerce.boolean()` (which makes `"false"` truthy and inverts the opt-out).

## Safety note
The key invariant: gating the once-unconditional model unpublish behind a flag that **defaults true** in every path (tRPC via `...input`, webhook, `softDeleteUser`) so nothing silently stops removing models.

## Testing
- `pnpm typecheck` clean (full, unfiltered)
- prettier clean
- No stray `removeContent` refs remain (the unrelated `removeAllContent` button + CSAM job are untouched)

Frontend two-toggle UI lands separately on `feat/ban-remove-content-ui` (#3341), consuming this contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
