### PR TITLE
fix(collections): stop collection select dropdown being clipped in modal

### DIFF
--- a/src/components/Collections/AddToCollectionModal.tsx
+++ b/src/components/Collections/AddToCollectionModal.tsx
@@ -148,7 +148,7 @@ function CollectionCheckboxItem({
           size="xs"
           label="Tag your entry"
           value={selectedItem.tagId?.toString() ?? null}
-          comboboxProps={{ withinPortal: false }}
+          comboboxProps={{ withinPortal: true, zIndex: 500 }}
           onChange={(value) => onTagChange(value ? parseInt(value, 10) : null)}
           clearable={false}
           allowDeselect={false}
@@ -157,7 +157,6 @@ function CollectionCheckboxItem({
             value: tag.id.toString(),
             label: tag.name,
           }))}
-          style={{ zIndex: 400 }}
         />
       )}
     </Stack>


### PR DESCRIPTION
## Bug

Reported by creator MNeMiC (with screenshot):

> The collection dropdown is cropped off by the modal section, so I cannot select the correct collection to submit it to. I have to navigate with arrows blindly.

In the add-to-collection modal, checking a contest collection reveals a "Tag your entry" `Select`. Its dropdown rendered but was sliced off partway down, so options could only be reached by blind arrow-key navigation.

## Root cause

`src/components/Collections/AddToCollectionModal.tsx` — the tag `Select` passed `comboboxProps={{ withinPortal: false }}`, so the Mantine dropdown rendered as a DOM child of the input. That input lives inside `ScrollArea.Autosize mah={200}` (owned collections) / `mah={300}` (contributed collections), whose viewport has `overflow: hidden/auto`. An in-flow dropdown is clipped by that overflow boundary regardless of stacking, which is why the pre-existing `style={{ zIndex: 400 }}` on the input root did nothing — it was a stacking fix for an overflow problem.

## Fix

One line: `comboboxProps={{ withinPortal: true, zIndex: 500 }}`.

- Portalling moves the dropdown to `document.body`, escaping the `ScrollArea` overflow boundary entirely.
- `zIndex: 500` clears the dialog layer — `DialogProvider` mounts modals at `300 + index` and `CustomModalsProvider` uses `400`. This matches the existing repo idiom (`Model3DLightbox` passes `comboboxZIndex={500}`).
- The now-dead `style={{ zIndex: 400 }}` on the input root is removed.

Mantine v7's `Popover` positions portalled dropdowns with floating-ui `autoUpdate`, so the dropdown tracks the input when the scroll area or the modal body scrolls.

Note: the explicit `withinPortal` is required here rather than relying on Mantine's default, because `ThemeProvider` sets `Popover.defaultProps = { withinPortal: false }` app-wide.

## Scope

Only this modal is touched. The `Select` is inline (not a shared wrapper), so no other surface changes behavior. Other `withinPortal: false` call sites in the repo are filter dropdowns that are intentionally inline and are not inside a clipping ancestor — left alone.

## Manual verification

1. Open an image/model/post and choose **Add to collection**.
2. Pick a contest collection that has entry tags (one that renders the "Tag your entry" select) — ideally one far enough down the list that the select sits near the bottom of the 200px scroll area.
3. Click the tag select. The full option list should render over the modal, unclipped, and every option should be clickable with the mouse.
4. Scroll the collection list and the modal body with the dropdown open — it should stay anchored to the input.
5. Confirm the dropdown paints above the modal (not behind it) and that picking an option still saves the tag on submit.

Verified: `pnpm run typecheck` clean. `pnpm run lint` fails at config-load time in this worktree (`eslint-config` circular-structure error while normalizing `.eslintrc.js`, before any file is linted) — pre-existing and unrelated to this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
