### PR TITLE
fix(model-files): scope file-settings validation and detect int8/mxfp8

### DIFF
--- a/src/components/Resource/Files.tsx
+++ b/src/components/Resource/Files.tsx
@@ -968,7 +968,7 @@ function FileEditForm({
   }, [versionFile.id]);
 
   const handleSave = () => {
-    const valid = validationCheck();
+    const valid = validationCheck(versionFile.uuid);
     if (valid && versionFile.id) {
       mutate({
         id: versionFile.id,

--- a/src/components/Resource/FilesProvider.tsx
+++ b/src/components/Resource/FilesProvider.tsx
@@ -336,13 +336,12 @@ export function FilesProvider({ model, version, children }: FilesProviderProps) 
 
     const validation = metadataSchema.safeParse(toValidate);
     if (!validation.success) {
-      const formatted = validation.error.format() as unknown as Array<{
-        [k: string]: ZodErrorSchema;
-      }>;
+      // format() returns an object keyed by failing index, not an array.
+      const formatted = validation.error.format() as unknown as Record<number, SchemaError>;
       const errors =
         targetIndex >= 0
           ? files.map((_, i) => (i === targetIndex ? formatted[0] : undefined))
-          : formatted;
+          : files.map((_, i) => formatted[i]);
       setErrors(errors);
 
       const missingFields: string[] = [];
@@ -366,7 +365,17 @@ export function FilesProvider({ model, version, children }: FilesProviderProps) 
       return false;
     }
 
-    if (targetIndex >= 0) return true;
+    if (targetIndex >= 0) {
+      // Only conflicts the edited file is part of — an unrelated pair of siblings
+      // that happen to share a key isn't this save's problem.
+      const target = files[targetIndex];
+      const conflicts = getConflictingFiles(files).filter((group) => group.includes(target));
+      if (conflicts.length) {
+        showConflictNotification(conflicts);
+        return false;
+      }
+      return true;
+    }
 
     // External-generation versions (mod-only, routed via external engines) intentionally
     // ship without files; skip the component-count requirement for them.
@@ -403,17 +412,7 @@ export function FilesProvider({ model, version, children }: FilesProviderProps) 
 
     const conflicts = getConflictingFiles(files);
     if (conflicts.length) {
-      showErrorNotification({
-        title: 'Duplicate file types',
-        error: new Error(
-          conflicts
-            .map(
-              (group) =>
-                `${group.map((f) => f.name).join(', ')}: same type and settings, please adjust`
-            )
-            .join('\n')
-        ),
-      });
+      showConflictNotification(conflicts);
       return false;
     }
     return true;
@@ -817,6 +816,17 @@ export const getConflictingFiles = (files: FileFromContextProps[]) => {
   return [...groups.values()].filter((group) => group.length > 1);
 };
 
+const showConflictNotification = (conflicts: FileFromContextProps[][]) => {
+  showErrorNotification({
+    title: 'Duplicate file types',
+    error: new Error(
+      conflicts
+        .map((group) => `${group.map((f) => f.name).join(', ')}: same type and settings`)
+        .join('\n')
+    ),
+  });
+};
+
 /** Model types whose primary file is an archive/config rather than model weights */
 const archivePrimaryModelTypes: ModelType[] = [
   ModelType.Workflows,
@@ -852,7 +862,6 @@ function inferFileType(fileName: string, modelType?: ModelType | null): ModelFil
       return undefined;
   }
 }
-
 
 /**
  * Pick a default type for a file dropped into the Additional Components section so

--- a/src/components/Resource/FilesProvider.tsx
+++ b/src/components/Resource/FilesProvider.tsx
@@ -35,6 +35,7 @@ type SchemaError = {
   format?: ZodErrorSchema;
   quantType?: ZodErrorSchema;
 };
+type FileErrors = Array<SchemaError | undefined>;
 
 // Both link mutations (the Meili picker and linkOfficialFileByHash) return the
 // same server shape; map it to a client LinkedComponent in one place.
@@ -76,7 +77,7 @@ export type FileFromContextProps = {
 
 type FilesContextState = {
   hasPending: boolean;
-  errors: SchemaError[] | null;
+  errors: FileErrors | null;
   files: FileFromContextProps[];
   linkedComponents: LinkedComponent[];
   modelId?: number;
@@ -88,7 +89,7 @@ type FilesContextState = {
   retry: (uuid: string) => Promise<void>;
   updateFile: (uuid: string, file: Partial<FileFromContextProps>) => void;
   removeFile: (uuid: string) => void;
-  validationCheck: () => boolean;
+  validationCheck: (uuid?: string) => boolean;
   addLinkedComponent: (
     component: LinkedComponent | Omit<LinkedComponent, 'fileId' | 'fileName' | 'sizeKB'>
   ) => Promise<void>;
@@ -117,7 +118,7 @@ export function FilesProvider({ model, version, children }: FilesProviderProps) 
   const upload = useS3UploadStore((state) => state.upload);
   const setItems = useS3UploadStore((state) => state.setItems);
 
-  const [errors, setErrors] = useState<SchemaError[] | null>(null);
+  const [errors, setErrors] = useState<FileErrors | null>(null);
   const [files, setFiles] = useState<FileFromContextProps[]>(() => {
     const initialFiles = (version?.files?.map((file) => ({
       id: file.id,
@@ -325,17 +326,25 @@ export function FilesProvider({ model, version, children }: FilesProviderProps) 
     }
   };
 
-  const checkValidation = () => {
+  // Passing a uuid validates only that file — editing one file's settings shouldn't
+  // fail because another file in the version is still missing metadata.
+  const checkValidation = (uuid?: string) => {
     setErrors(null);
 
-    const validation = metadataSchema.safeParse(files);
+    const targetIndex = uuid ? files.findIndex((x) => x.uuid === uuid) : -1;
+    const toValidate = targetIndex >= 0 ? [files[targetIndex]] : files;
+
+    const validation = metadataSchema.safeParse(toValidate);
     if (!validation.success) {
-      const errors = validation.error.format() as unknown as Array<{
+      const formatted = validation.error.format() as unknown as Array<{
         [k: string]: ZodErrorSchema;
       }>;
+      const errors =
+        targetIndex >= 0
+          ? files.map((_, i) => (i === targetIndex ? formatted[0] : undefined))
+          : formatted;
       setErrors(errors);
 
-      // Build user-friendly error messages per file
       const missingFields: string[] = [];
       errors.forEach((err, i) => {
         if (!err) return;
@@ -356,6 +365,8 @@ export function FilesProvider({ model, version, children }: FilesProviderProps) 
 
       return false;
     }
+
+    if (targetIndex >= 0) return true;
 
     // External-generation versions (mod-only, routed via external engines) intentionally
     // ship without files; skip the component-count requirement for them.
@@ -390,16 +401,22 @@ export function FilesProvider({ model, version, children }: FilesProviderProps) 
       }
     }
 
-    const noConflicts = checkConflictingFiles(files);
-    if (!noConflicts) {
+    const conflicts = getConflictingFiles(files);
+    if (conflicts.length) {
       showErrorNotification({
         title: 'Duplicate file types',
         error: new Error(
-          'There are multiple files with the same type and size, please adjust your files'
+          conflicts
+            .map(
+              (group) =>
+                `${group.map((f) => f.name).join(', ')}: same type and settings, please adjust`
+            )
+            .join('\n')
         ),
       });
+      return false;
     }
-    return noConflicts;
+    return true;
   };
 
   const createFileMutation = trpc.modelFile.create.useMutation({
@@ -785,19 +802,19 @@ const metadataSchema = modelFileMetadataSchema
   })
   .array();
 
-// TODO.manuel: This is a hacky way to check for duplicates
-export const checkConflictingFiles = (files: FileFromContextProps[]) => {
-  const conflictCount: Record<string, number> = {};
+// The key is positional so absent fields can't collapse two distinct files onto
+// the same key.
+export const getConflictingFiles = (files: FileFromContextProps[]) => {
+  const groups = new Map<string, FileFromContextProps[]>();
 
   files.forEach((item) => {
     const key = [item.size, item.type, item.fp, getModelFileFormat(item.name), item.quantType]
-      .filter(Boolean)
-      .join('-');
-    if (conflictCount[key]) conflictCount[key] += 1;
-    else conflictCount[key] = 1;
+      .map((value) => value ?? '')
+      .join('|');
+    groups.set(key, [...(groups.get(key) ?? []), item]);
   });
 
-  return Object.values(conflictCount).every((count) => count === 1);
+  return [...groups.values()].filter((group) => group.length > 1);
 };
 
 /** Model types whose primary file is an archive/config rather than model weights */

--- a/src/components/Resource/FilesProvider.tsx
+++ b/src/components/Resource/FilesProvider.tsx
@@ -813,7 +813,15 @@ export const getConflictingFiles = (files: FileFromContextProps[]) => {
     groups.set(key, [...(groups.get(key) ?? []), item]);
   });
 
-  return [...groups.values()].filter((group) => group.length > 1);
+  // Component files need none of size/fp/quantType, so a group where no member has
+  // any of them (e.g. two bare Text Encoders) has nothing to disambiguate on and
+  // isn't a real duplicate.
+  const hasDistinguishingSettings = (file: FileFromContextProps) =>
+    !!(file.size || file.fp || file.quantType);
+
+  return [...groups.values()].filter(
+    (group) => group.length > 1 && group.some(hasDistinguishingSettings)
+  );
 };
 
 const showConflictNotification = (conflicts: FileFromContextProps[][]) => {

--- a/src/utils/file-helpers.ts
+++ b/src/utils/file-helpers.ts
@@ -17,19 +17,17 @@ const SAFETENSORS_DTYPE_TO_FP: Record<string, string> = {
   F64: 'fp32',
   F8_E8M0: 'mxfp8',
   I8: 'int8',
-  U8: 'int8',
 };
 
 /**
  * Map a safetensors dtype string to a precision value. Scaling schemes
  * (fp8_scaled, nvfp4, …) aren't dtypes and can't be inferred from the header.
- * The cast covers precisions that are mod-managed at runtime but not yet in the
- * ModelFileFp union.
+ * U8 is deliberately unmapped: bitsandbytes packs nf4/fp4 weights as U8, so
+ * guessing int8 there would auto-fill the wrong supported value.
  */
-function safetensorsDtypeToFp(dtype: string): ModelFileFp | null {
+function safetensorsDtypeToFp(dtype: string): string | null {
   const d = dtype.toUpperCase();
-  const fp = SAFETENSORS_DTYPE_TO_FP[d] ?? (d.startsWith('F8') ? 'fp8' : null);
-  return fp as ModelFileFp | null;
+  return SAFETENSORS_DTYPE_TO_FP[d] ?? (d.startsWith('F8') ? 'fp8' : null);
 }
 
 /**
@@ -56,7 +54,7 @@ export async function inferSafetensorsPrecision(file: File): Promise<ModelFileFp
     >;
 
     // Pick the dtype that accounts for the most bytes of tensor data.
-    const bytesByFp = new Map<ModelFileFp, number>();
+    const bytesByFp = new Map<string, number>();
     for (const [key, value] of Object.entries(header)) {
       if (key === '__metadata__' || !value?.dtype) continue;
       const fp = safetensorsDtypeToFp(value.dtype);
@@ -66,7 +64,7 @@ export async function inferSafetensorsPrecision(file: File): Promise<ModelFileFp
       bytesByFp.set(fp, (bytesByFp.get(fp) ?? 0) + Math.max(size, 0));
     }
 
-    let best: ModelFileFp | null = null;
+    let best: string | null = null;
     let bestBytes = -1;
     for (const [fp, bytes] of bytesByFp) {
       if (bytes > bestBytes) {
@@ -74,7 +72,13 @@ export async function inferSafetensorsPrecision(file: File): Promise<ModelFileFp
         bestBytes = bytes;
       }
     }
-    return best;
+
+    // MXFP8 stores weights as F8_E4M3 with F8_E8M0 shared-exponent scales (~1 byte
+    // per 32 elements), so the scale tensors' presence identifies it, not byte share.
+    if (best === 'fp8' && bytesByFp.has('mxfp8')) best = 'mxfp8';
+
+    // Precision options are mod-managed at runtime; the union lags behind them.
+    return best as ModelFileFp | null;
   } catch {
     return null;
   }

--- a/src/utils/file-helpers.ts
+++ b/src/utils/file-helpers.ts
@@ -10,19 +10,31 @@ export function getModelFileFormat(filename: string): ModelFileFormat {
   return 'Other';
 }
 
-/** Map a safetensors dtype string to a ModelFileFp precision value. */
+const SAFETENSORS_DTYPE_TO_FP: Record<string, string> = {
+  F16: 'fp16',
+  BF16: 'bf16',
+  F32: 'fp32',
+  F64: 'fp32',
+  F8_E8M0: 'mxfp8',
+  I8: 'int8',
+  U8: 'int8',
+};
+
+/**
+ * Map a safetensors dtype string to a precision value. Scaling schemes
+ * (fp8_scaled, nvfp4, …) aren't dtypes and can't be inferred from the header.
+ * The cast covers precisions that are mod-managed at runtime but not yet in the
+ * ModelFileFp union.
+ */
 function safetensorsDtypeToFp(dtype: string): ModelFileFp | null {
   const d = dtype.toUpperCase();
-  if (d === 'F16') return 'fp16';
-  if (d === 'BF16') return 'bf16';
-  if (d === 'F32' || d === 'F64') return 'fp32';
-  if (d.startsWith('F8')) return 'fp8';
-  return null;
+  const fp = SAFETENSORS_DTYPE_TO_FP[d] ?? (d.startsWith('F8') ? 'fp8' : null);
+  return fp as ModelFileFp | null;
 }
 
 /**
  * Read a .safetensors file's header (client-side) and infer the dominant weight
- * precision (fp16/bf16/fp32/fp8). Returns null when it can't be determined.
+ * precision. Returns null when it can't be determined.
  * Only the JSON header is read — never the tensor data — so this is cheap.
  */
 export async function inferSafetensorsPrecision(file: File): Promise<ModelFileFp | null> {


### PR DESCRIPTION
## Reported symptoms

- **SubtleShader / MNeMiC**: "can't change a model file's precision to int8" — hitting Save on a file's settings fails and nothing persists.
- Related reports of file settings failing to save in other cases, sometimes surfacing as *"There are multiple files with the same type and size, please adjust your files"* for files that aren't actually duplicates.

## Root causes

**1. Per-file save validated the entire version.** `FileEditForm.handleSave` (`Files.tsx`) called `validationCheck()`, which parsed the *whole* `files` array against `metadataSchema`. Any other file in the version missing size / precision / quant type failed the parse, so the file you were actually editing could never be saved.

**2. The error-reporting path threw.** zod's `error.format()` returns a plain **object** keyed by failing index, not an array (verified against this repo's zod: `Array.isArray === false`, `typeof forEach === 'undefined'`). The result was cast to an array and iterated with `.forEach`, so a failed parse raised a `TypeError` instead of showing "Missing required fields" and returning false. Out of `handleSave`'s onClick that means the save silently does nothing — which matches the reports better than a visible validation error, and is very likely the actual mechanism users hit.

**3. The duplicate-file key collapsed absent fields.** `checkConflictingFiles` built its key with `.filter(Boolean)`, so two files that both lacked size/fp/quantType produced an identical key and registered as duplicates. The notification named no files, so it read as though the file being edited was rejected.

**4. safetensors precision auto-detect had no int8 mapping.** `safetensorsDtypeToFp` was a 4-branch allow-list (F16 / BF16 / F32-F64 / F8*) returning `null` otherwise. An int8 safetensors has dtype `I8`, so every tensor mapped to null and no `fp` was ever set (the caller only assigns `if (fp)`). The missing `fp` then trips the "Floating point is required for model files" refinement on the next save. `int8` and `mxfp8` are both live selectable options in prod (the dropdown lists are mod-managed at runtime), so the UI offered values the detector could never produce.

## Changes

- **`checkValidation(uuid?)`** — passing a uuid validates only that file, so a sibling that is still missing metadata can no longer block an unrelated edit. `handleSave` passes the edited file's uuid.
- **Duplicate detection is scoped, not dropped.** The scoped path still runs `getConflictingFiles(files)` and fails the save if the *edited* file is part of a conflicting group — you can't turn File A into a duplicate of File B — while a pair of metadata-less siblings you aren't touching no longer blocks you. (Worth knowing: the whole-array check in `startUpload` is reachable only while uploads are pending — `SaveButton` renders on `hasPending` — so on an already-uploaded version the scoped check is the one that actually runs. `modelFile.update` does no such validation server-side.)
- **Fixed the `format()` iteration** for both paths: errors are now rebuilt as a real array indexed by file position (`files.map((_, i) => formatted[i])`), so a failed whole-array parse reports "Missing required fields" instead of throwing.
- **Positional conflict key** (`join('|')` over `?? ''` placeholders) so absent fields can't alias distinct files. The key doesn't include the file name and component files require none of size/fp/quantType, so a group where *no* member has any of those (two bare `Text Encoder` files, say) is dropped rather than reported — there's nothing to disambiguate on. `checkConflictingFiles` became `getConflictingFiles`, returning the conflicting groups; the notification now names the offending files, matching the existing "missing required fields" message pattern.
- **`safetensorsDtypeToFp`** maps `I8` to `int8` and `F8_E8M0` to `mxfp8`, with the generic `F8*` to `fp8` fallback applied only after the lookup miss. `U8` is deliberately *not* mapped: bitsandbytes packs nf4/fp4 weights as `U8`, and `nf4` is itself a supported option, so guessing `int8` there would auto-fill a wrong value.
- **MXFP8 detection is presence-based.** Byte dominance alone can't find it — a real MXFP8 checkpoint stores weights as `F8_E4M3` with `F8_E8M0` shared-exponent scales at ~1 byte per 32 elements — so `F8_E8M0` tensors alongside fp8 weights now resolve to `mxfp8`.
- `fp8_scaled` / `fp8_mixed` / `nvfp4` are deliberately not inferred: they're scaling schemes, not dtypes, and aren't derivable from the safetensors header.

## Manual verification

1. **The main regression**: open a version that has one incomplete file (e.g. a Checkpoint `Model` file with no precision set) plus a second, complete file. Edit the *complete* file's settings and Save — it should now save. Before this change the save did nothing.
2. Set a file's precision to `int8` and Save — persists; reload the edit modal and confirm it stuck.
3. Drop a new int8 `.safetensors` — the Precision select should auto-fill `int8`. An MXFP8 checkpoint (F8_E4M3 weights + F8_E8M0 scales) should auto-fill `mxfp8`; ordinary fp8 variants still land on `fp8`; fp16/bf16/fp32 unchanged; an nf4 (bitsandbytes, U8) checkpoint should auto-fill nothing rather than a wrong value.
4. Editing a file so it becomes a true duplicate of another (same type, size, precision, format, quant) is still rejected, and the error now names both files.
5. Two bare component files of the **same** type (e.g. `clip_l.safetensors` and `t5xxl.safetensors` both typed `Text Encoder`, both with precision blank) no longer register as duplicates — toggling Required or changing the type on one saves fine. Set a precision on one of them and the pair stays non-conflicting; only genuinely-identical *complete* files are rejected.
6. With an upload still in flight, "Save Changes" on a version where some file is missing required metadata should show the per-file "Missing required fields" notification (previously this path threw and the button appeared to do nothing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
