### PR TITLE
fix(vault): harden process-vault-items batch against per-item failures + overlapping runs

### DIFF
--- a/src/server/jobs/__tests__/process-vault-items.test.ts
+++ b/src/server/jobs/__tests__/process-vault-items.test.ts
@@ -72,10 +72,20 @@ vi.mock('jszip', () => ({
 
 import {
   processVaultItem,
+  processVaultItems,
   getEligibleVaultItemsQuery,
   MAX_FAILURES,
   VAULT_ITEMS_BATCH_SIZE,
+  LEASE_STALENESS_MS,
 } from '~/server/jobs/process-vault-items';
+
+// The eligibility WHERE ANDs two OR-groups: [0] = retry-budget, [1] = overlap
+// lease guard. Small helpers keep the assertions robust to ordering.
+const budgetOr = (q: any) =>
+  q.where.AND.find((g: any) => g.OR?.some((b: any) => b.meta?.path?.[0] === 'failures')).OR;
+const leaseOr = (q: any) =>
+  q.where.AND.find((g: any) => g.OR?.some((b: any) => b.meta?.path?.[0] === 'processingStartedAt'))
+    .OR;
 
 const makeItem = (overrides: Record<string, unknown> = {}) => ({
   id: 1,
@@ -111,7 +121,7 @@ describe('getEligibleVaultItemsQuery — bounded batch + retry-budget exclusion'
 
   it('only selects items whose failure count is within the retry budget', () => {
     const q = getEligibleVaultItemsQuery();
-    const lteBranch = q.where.OR.find((b: any) => typeof b.meta?.lte === 'number');
+    const lteBranch = budgetOr(q).find((b: any) => typeof b.meta?.lte === 'number');
     expect(lteBranch?.meta?.path).toEqual(['failures']);
     expect(lteBranch?.meta?.lte).toBe(MAX_FAILURES);
 
@@ -179,7 +189,7 @@ describe('processVaultItem — OOM-resilient failure accounting', () => {
   it('climbs past MAX_FAILURES across repeated OOM-style attempts, then is excluded', () => {
     // Simulate the uncatchable path: each run only the pre-increment persists.
     const q = getEligibleVaultItemsQuery();
-    const budget = (q.where.OR.find((b: any) => typeof b.meta?.lte === 'number') as any).meta
+    const budget = (budgetOr(q).find((b: any) => typeof b.meta?.lte === 'number') as any).meta
       .lte as number;
     let failures = 0; // starts from null-meta -> 0
     let runs = 0;
@@ -191,5 +201,113 @@ describe('processVaultItem — OOM-resilient failure accounting', () => {
     }
     expect(failures).toBe(MAX_FAILURES + 1);
     expect(failures > budget).toBe(true); // now excluded from the next findMany
+  });
+});
+
+// Fix A: a transient failure on ONE item must not abort the whole batch.
+describe('processVaultItems — per-item isolation (one failure never aborts the batch)', () => {
+  it('continues to the next item when a per-item processing error propagates', async () => {
+    const item1 = makeItem({ id: 1, modelVersionId: 100, meta: { failures: 0 } });
+    const item2 = makeItem({ id: 2, modelVersionId: 200, meta: { failures: 0 } });
+    mockDbWrite.vaultItem.findMany.mockResolvedValueOnce([item1, item2]);
+
+    // The FIRST update (item1's pre-attempt increment — which runs OUTSIDE
+    // processVaultItem's own try/catch) throws a transient DB error. Every
+    // subsequent update succeeds.
+    mockDbWrite.vaultItem.update
+      .mockRejectedValueOnce(new Error('transient db blip'))
+      .mockResolvedValue({});
+
+    // Must not reject: the batch swallows item1's error and moves on.
+    await expect(processVaultItems({} as never)).resolves.not.toThrow();
+
+    // item2 was still processed: its heavy work ran with item2's modelVersionId.
+    expect(mockGetModelVersionData).toHaveBeenCalledTimes(1);
+    expect(mockGetModelVersionData).toHaveBeenCalledWith({ modelVersionId: 200 });
+    // item2 reached its terminal Stored write (last update targets id 2).
+    const lastUpdate = mockDbWrite.vaultItem.update.mock.calls.at(-1)?.[0];
+    expect(lastUpdate.where).toEqual({ id: 2 });
+    expect(lastUpdate.data.status).toBe('Stored');
+  });
+
+  it('processes every remaining item even if an earlier one throws mid-batch', async () => {
+    const items = [1, 2, 3].map((id) => makeItem({ id, modelVersionId: id * 10, meta: null }));
+    mockDbWrite.vaultItem.findMany.mockResolvedValueOnce(items);
+
+    // Middle item's pre-increment update throws; the other two succeed.
+    mockDbWrite.vaultItem.update
+      .mockResolvedValueOnce({}) // item1 pre-increment
+      .mockImplementation(async (arg: any) => {
+        if (arg.where.id === 2 && arg.data.meta.processingStartedAt) {
+          throw new Error('transient db blip on item 2');
+        }
+        return {};
+      });
+
+    await expect(processVaultItems({} as never)).resolves.not.toThrow();
+
+    // Heavy work ran for item1 and item3 (not the throwing item2).
+    const processedVersionIds = mockGetModelVersionData.mock.calls.map((c) => c[0].modelVersionId);
+    expect(processedVersionIds).toContain(10);
+    expect(processedVersionIds).toContain(30);
+    expect(processedVersionIds).not.toContain(20);
+  });
+});
+
+// Fix B: overlap guard — an in-flight (freshly-leased) item is excluded from the
+// eligibility query; a stale lease (killed run) becomes eligible again.
+describe('getEligibleVaultItemsQuery — overlap lease guard', () => {
+  it('excludes freshly-leased in-flight items but includes stale/unleased ones', () => {
+    const before = Date.now();
+    const q = getEligibleVaultItemsQuery();
+    const after = Date.now();
+
+    const ltBranch = leaseOr(q).find((b: any) => typeof b.meta?.lt === 'number');
+    const nullBranch = leaseOr(q).find((b: any) => b.meta?.equals !== undefined);
+
+    // The lease cutoff = now - LEASE_STALENESS_MS (computed at query-build time).
+    expect(ltBranch?.meta?.path).toEqual(['processingStartedAt']);
+    expect(ltBranch?.meta?.lt).toBeGreaterThanOrEqual(before - LEASE_STALENESS_MS);
+    expect(ltBranch?.meta?.lt).toBeLessThanOrEqual(after - LEASE_STALENESS_MS);
+    // Unleased (absent/null) items stay eligible.
+    expect(nullBranch?.meta?.path).toEqual(['processingStartedAt']);
+
+    // Model the predicate the DB evaluates on `processingStartedAt`.
+    const cutoff = ltBranch?.meta?.lt as number;
+    const eligibleByLease = (leasedAt: number | null | undefined) =>
+      leasedAt == null || leasedAt < cutoff;
+
+    expect(eligibleByLease(undefined)).toBe(true); // never claimed
+    expect(eligibleByLease(null)).toBe(true); // lease cleared on completion
+    expect(eligibleByLease(Date.now())).toBe(false); // claimed just now -> in-flight -> skip
+    expect(eligibleByLease(Date.now() - LEASE_STALENESS_MS - 1000)).toBe(true); // stale -> re-eligible
+  });
+});
+
+describe('processVaultItem — lease claim/clear', () => {
+  it('stamps a fresh processingStartedAt lease on the pre-attempt (claim) write', async () => {
+    const before = Date.now();
+    await processVaultItem(makeItem({ meta: { failures: 0 } }), ctx);
+    const after = Date.now();
+
+    const claimWrite = mockDbWrite.vaultItem.update.mock.calls[0][0];
+    expect(typeof claimWrite.data.meta.processingStartedAt).toBe('number');
+    expect(claimWrite.data.meta.processingStartedAt).toBeGreaterThanOrEqual(before);
+    expect(claimWrite.data.meta.processingStartedAt).toBeLessThanOrEqual(after);
+  });
+
+  it('clears the lease on a successful (Stored) run', async () => {
+    await processVaultItem(makeItem({ meta: { failures: 0 } }), ctx);
+    const storedWrite = mockDbWrite.vaultItem.update.mock.calls.at(-1)?.[0];
+    expect(storedWrite.data.status).toBe('Stored');
+    expect(storedWrite.data.meta.processingStartedAt).toBeNull();
+  });
+
+  it('clears the lease on a caught failure so it retries next cycle', async () => {
+    mockGetModelVersionData.mockRejectedValueOnce(new Error('boom'));
+    await processVaultItem(makeItem({ meta: { failures: 0 } }), ctx);
+    const failWrite = mockDbWrite.vaultItem.update.mock.calls.at(-1)?.[0];
+    expect(failWrite.data.status).toBe('Failed');
+    expect(failWrite.data.meta.processingStartedAt).toBeNull();
   });
 });

--- a/src/server/jobs/__tests__/process-vault-items.test.ts
+++ b/src/server/jobs/__tests__/process-vault-items.test.ts
@@ -311,3 +311,30 @@ describe('processVaultItem — lease claim/clear', () => {
     expect(failWrite.data.meta.processingStartedAt).toBeNull();
   });
 });
+
+// 🟡-1: the S3 upload PUTs must be bounded so a hung upstream can't make a single
+// item outlive its lease. fetchBlob (the image download) is mocked, so the only
+// global `fetch` calls here are the S3 uploads — each must carry an AbortSignal.
+describe('processVaultItem — bounded S3 upload timeout', () => {
+  it('invokes every S3 upload PUT with an AbortSignal (per-attempt timeout)', async () => {
+    await processVaultItem(makeItem({ meta: { failures: 0 } }), ctx);
+
+    const uploadCalls = (fetch as unknown as { mock: { calls: any[][] } }).mock.calls;
+    // details PDF + images zip + cover (one image with idx 0 -> coverImage set).
+    expect(uploadCalls.length).toBeGreaterThanOrEqual(2);
+    for (const [, init] of uploadCalls) {
+      expect(init?.method).toBe('PUT');
+      // AbortSignal.timeout(...) yields an AbortSignal; assert the PUT is bounded.
+      expect(init?.signal).toBeInstanceOf(AbortSignal);
+    }
+  });
+
+  it('keeps the lease staleness window comfortably above the bounded worst-case item runtime', () => {
+    // Worst case (mirrors the code comment): 10-image downloads (2 waves x 5min)
+    // + pdf/zip generation (~2min) + parallel uploads (4 attempts x 60s = 4min).
+    const worstCaseMs = (2 * 5 + 2 + 4) * 60 * 1000; // ≈ 16 min
+    expect(LEASE_STALENESS_MS).toBeGreaterThan(worstCaseMs);
+    // ...with a clear (>2x) margin so a legit-slow item never ages out mid-run.
+    expect(LEASE_STALENESS_MS).toBeGreaterThan(2 * worstCaseMs);
+  });
+});

--- a/src/server/jobs/process-vault-items.ts
+++ b/src/server/jobs/process-vault-items.ts
@@ -27,6 +27,21 @@ export const VAULT_ITEMS_BATCH_SIZE = 50;
 // Promise.all buffered every image of a gallery into memory at once — a large
 // gallery alone could exceed the container memory limit.
 export const IMAGE_DOWNLOAD_CONCURRENCY = 5;
+// A run stamps each item it starts with a `processingStartedAt` lease timestamp
+// (see processVaultItem). The scheduler can start a new run before the previous
+// one finishes — a run is allowed to outlast the cron interval (a bounded batch
+// where a single item can still take a while: up to ~10 images each with a
+// multi-minute fetch timeout). Without a guard, two overlapping runs both do the
+// heavy download+zip work on the SAME item and last-writer-wins on the meta blob,
+// losing failure-count updates and duplicating the very work the batch cap exists
+// to bound. Excluding freshly-leased items from the eligibility query prevents
+// that overlap. The lease is advisory only: a run killed mid-item (e.g. OOM) can
+// never clear its lease, so a lease older than this staleness window is treated
+// as abandoned and the item becomes eligible again. The window is deliberately
+// generous (well past a normal run) so a still-working run is never pre-empted;
+// a pathological run that exceeds it can at worst be double-processed, which is
+// still strictly better than the previous no-guard behavior.
+export const LEASE_STALENESS_MS = 30 * 60 * 1000; // 30 minutes
 
 const logErrors = (data: MixedObject) => {
   logToAxiom({ name: 'process-vault-items', type: 'error', ...data }, 'webhooks').catch();
@@ -35,28 +50,66 @@ const logErrors = (data: MixedObject) => {
 // Eligible = Pending/Failed items that have not yet exhausted their retry budget.
 // An item whose `failures` has climbed past MAX_FAILURES is excluded here so a
 // permanently-failing (e.g. repeatedly-OOMing) item eventually stops being retried.
-export const getEligibleVaultItemsQuery = () => ({
-  where: {
-    status: {
-      in: [VaultItemStatus.Pending, VaultItemStatus.Failed],
+export const getEligibleVaultItemsQuery = () => {
+  // Items leased more recently than this are assumed to be actively in-flight in
+  // another (overlapping) run and are skipped; older leases are treated as
+  // abandoned. Computed per call so each run measures staleness from "now".
+  const leaseCutoff = Date.now() - LEASE_STALENESS_MS;
+  return {
+    where: {
+      status: {
+        in: [VaultItemStatus.Pending, VaultItemStatus.Failed],
+      },
+      // Both guards must hold (AND). Kept as an explicit AND of two OR-groups so
+      // the top-level `status` filter and each guard compose unambiguously.
+      AND: [
+        // Retry-budget guard: an item whose `failures` has climbed past
+        // MAX_FAILURES is excluded so a permanently-failing (e.g. repeatedly
+        // -OOMing) item eventually stops being retried. A missing `failures`
+        // (never attempted) is treated as within budget.
+        {
+          OR: [
+            {
+              meta: {
+                path: ['failures'],
+                lte: MAX_FAILURES,
+              },
+            },
+            {
+              meta: {
+                path: ['failures'],
+                equals: Prisma.AnyNull,
+              },
+            },
+          ],
+        },
+        // Overlap guard: skip items a concurrent run is (probably) still working
+        // on — i.e. leased within the staleness window. An absent/null lease, or
+        // a stale one (older than the window, so its run was likely killed),
+        // stays eligible. ISO/string comparison is avoided by storing the lease
+        // as epoch millis so this is a plain numeric JSON-path filter (mirrors
+        // the `failures` filter above, which is a proven-working pattern here).
+        {
+          OR: [
+            {
+              meta: {
+                path: ['processingStartedAt'],
+                equals: Prisma.AnyNull,
+              },
+            },
+            {
+              meta: {
+                path: ['processingStartedAt'],
+                lt: leaseCutoff,
+              },
+            },
+          ],
+        },
+      ],
     },
-    OR: [
-      {
-        meta: {
-          path: ['failures'],
-          lte: MAX_FAILURES,
-        },
-      },
-      {
-        meta: {
-          path: ['failures'],
-          equals: Prisma.AnyNull,
-        },
-      },
-    ],
-  },
-  take: VAULT_ITEMS_BATCH_SIZE,
-});
+    take: VAULT_ITEMS_BATCH_SIZE,
+  };
+};
 
 type VaultItemRow = Awaited<ReturnType<typeof dbWrite.vaultItem.findMany>>[number];
 type ProcessContext = {
@@ -76,10 +129,16 @@ export async function processVaultItem(vaultItem: VaultItemRow, ctx: ProcessCont
   // OOM loop). By recording the attempt up front, a repeatedly-killing item climbs
   // to MAX_FAILURES and drops out of getEligibleVaultItemsQuery(). A successful run
   // rolls this back (see the Stored update), so normal semantics are unchanged.
+  //
+  // This same write claims the item for this run by stamping `processingStartedAt`
+  // (epoch millis). getEligibleVaultItemsQuery() excludes items with a fresh lease,
+  // so an overlapping run started before this one finishes won't re-process the
+  // same item. Both terminal paths below clear the lease; a run killed here (OOM)
+  // leaves it set, and it ages out after LEASE_STALENESS_MS.
   await dbWrite.vaultItem.update({
     where: { id: vaultItem.id },
     data: {
-      meta: { ...meta, failures: priorFailures + 1 },
+      meta: { ...meta, failures: priorFailures + 1, processingStartedAt: Date.now() },
     },
   });
 
@@ -173,7 +232,8 @@ export async function processVaultItem(vaultItem: VaultItemRow, ctx: ProcessCont
         status: VaultItemStatus.Stored,
         // Roll back the optimistic pre-attempt increment: a successful run must
         // not count against the retry budget (preserves prior success semantics).
-        meta: { ...meta, failures: priorFailures },
+        // Clear the in-flight lease now that this run is done with the item.
+        meta: { ...meta, failures: priorFailures, processingStartedAt: null },
       },
     });
     vaultItemProcessedCounter.inc();
@@ -198,6 +258,10 @@ export async function processVaultItem(vaultItem: VaultItemRow, ctx: ProcessCont
           ...meta,
           failures: priorFailures + 1,
           latestError: error.message,
+          // Clear the in-flight lease: this run has finished with the item, so a
+          // caught failure is retried on the next cycle rather than waiting out
+          // the staleness window.
+          processingStartedAt: null,
         },
       },
     });
@@ -215,7 +279,23 @@ export const processVaultItems = createJob('process-vault-items', '*/10 * * * *'
 
   const s3 = await getS3Client();
   for (const vaultItem of vaultItems) {
-    await processVaultItem(vaultItem, { s3, bucket: env.S3_VAULT_BUCKET });
+    // Per-item isolation: one item's failure must never abort the whole batch.
+    // processVaultItem has its own try/catch around the heavy work, but the
+    // pre-attempt increment (and the catch-path bookkeeping write) run OUTSIDE
+    // it — a transient DB blip on that single update-by-PK would otherwise
+    // propagate out of this loop and skip every remaining item. Log and continue
+    // to the next item, matching the pre-existing "catch per item and move on"
+    // behavior.
+    try {
+      await processVaultItem(vaultItem, { s3, bucket: env.S3_VAULT_BUCKET });
+    } catch (e) {
+      const error = e as Error;
+      await logErrors({
+        message: 'Unhandled error processing vault item; skipping to next',
+        error: error?.message,
+        vaultItem,
+      });
+    }
   }
 
   await setLastRun();

--- a/src/server/jobs/process-vault-items.ts
+++ b/src/server/jobs/process-vault-items.ts
@@ -27,21 +27,42 @@ export const VAULT_ITEMS_BATCH_SIZE = 50;
 // Promise.all buffered every image of a gallery into memory at once — a large
 // gallery alone could exceed the container memory limit.
 export const IMAGE_DOWNLOAD_CONCURRENCY = 5;
+// Per-upload S3 PUT timeout. The S3 uploads (details PDF + images zip + optional
+// cover) previously had NO timeout, so a hung upstream could park an item for
+// undici's ~300s default PER attempt AND — via withRetries — across multiple
+// attempts, making a single item's wall-clock runtime effectively unbounded and
+// able to outlive the lease (see LEASE_STALENESS_MS). Bounding each PUT with an
+// AbortSignal.timeout makes the worst case computable. 60s is generous for an
+// internal S3 PUT of a details PDF or a ≤10-image zip; a slower-than-that upload
+// is aborted and retried by withRetries rather than hanging indefinitely.
+export const VAULT_UPLOAD_TIMEOUT_MS = 60 * 1000; // 60 seconds
 // A run stamps each item it starts with a `processingStartedAt` lease timestamp
 // (see processVaultItem). The scheduler can start a new run before the previous
-// one finishes — a run is allowed to outlast the cron interval (a bounded batch
-// where a single item can still take a while: up to ~10 images each with a
-// multi-minute fetch timeout). Without a guard, two overlapping runs both do the
-// heavy download+zip work on the SAME item and last-writer-wins on the meta blob,
-// losing failure-count updates and duplicating the very work the batch cap exists
-// to bound. Excluding freshly-leased items from the eligibility query prevents
-// that overlap. The lease is advisory only: a run killed mid-item (e.g. OOM) can
-// never clear its lease, so a lease older than this staleness window is treated
-// as abandoned and the item becomes eligible again. The window is deliberately
-// generous (well past a normal run) so a still-working run is never pre-empted;
-// a pathological run that exceeds it can at worst be double-processed, which is
-// still strictly better than the previous no-guard behavior.
-export const LEASE_STALENESS_MS = 30 * 60 * 1000; // 30 minutes
+// one finishes — a run is allowed to outlast the cron interval. Without a guard,
+// two overlapping runs both do the heavy download+zip work on the SAME item and
+// last-writer-wins on the meta blob, losing failure-count updates and duplicating
+// the very work the batch cap exists to bound. Excluding freshly-leased items from
+// the eligibility query prevents that overlap. The lease is advisory only: a run
+// killed mid-item (e.g. OOM) can never clear its lease, so a lease older than this
+// staleness window is treated as abandoned and the item becomes eligible again.
+//
+// This window must comfortably exceed the now-BOUNDED worst-case per-item runtime,
+// so a legit-slow item never ages out mid-run and gets re-claimed (which would
+// re-introduce the exact double-process / lost-update the lease prevents). The
+// lease is stamped at the START of each item (not at batch fetch), so only ONE
+// item's runtime matters here. Worst-case per item (all inputs at their caps):
+//   - image downloads: images are capped at 10/version (vault.service
+//     `imagesPerVersion: 10`), fetched at IMAGE_DOWNLOAD_CONCURRENCY=5 with a
+//     300s fetchBlob timeout each → ceil(10/5) × 300s = 2 waves × 5 min = 10 min
+//   - PDF + in-memory zip generation (bounded by the 10-image cap)     ≈  2 min
+//   - S3 uploads: 3 blobs in parallel, each withRetries(3) → worst-case
+//     4 attempts × VAULT_UPLOAD_TIMEOUT_MS (60s) = 240s = 4 min wall (parallel)
+//   ---------------------------------------------------------------------------
+//   worst-case per-item runtime ≈ 16 min
+// 45 min gives a comfortable ~2.8× margin (16 min << 45 min) so a still-working
+// run is never pre-empted; a pathological run that somehow exceeds even 45 min can
+// at worst be double-processed, still strictly better than the no-guard behavior.
+export const LEASE_STALENESS_MS = 45 * 60 * 1000; // 45 minutes (see worst-case math above)
 
 const logErrors = (data: MixedObject) => {
   logToAxiom({ name: 'process-vault-items', type: 'error', ...data }, 'webhooks').catch();
@@ -91,6 +112,16 @@ export const getEligibleVaultItemsQuery = () => {
         // the `failures` filter above, which is a proven-working pattern here).
         {
           OR: [
+            // JSON-path null semantics this design HINGES on: `path +
+            // equals: Prisma.AnyNull` matches rows where the key is ABSENT inside
+            // a non-null `meta` blob (SQL `jsonb #> path IS NULL`), so never-leased
+            // items AND legacy items predating this field stay eligible — they are
+            // NOT stranded out of the backlog. This is the same pattern a prod
+            // billing job relies on: process-subscriptions-requiring-renewal.ts
+            // uses `metadata: { path: ['renewalEmailSent'], equals: Prisma.AnyNull }`
+            // to select rows whose renewal-email key is absent. Do NOT "simplify"
+            // this to an explicit-null-only check on a Prisma upgrade — that would
+            // silently exclude every absent-key row and freeze the backlog.
             {
               meta: {
                 path: ['processingStartedAt'],
@@ -217,6 +248,10 @@ export async function processVaultItem(vaultItem: VaultItemRow, ctx: ProcessCont
               headers: {
                 ...upload.headers,
               },
+              // Bound each PUT so a hung upstream can't make this item outlive its
+              // lease (see VAULT_UPLOAD_TIMEOUT_MS / LEASE_STALENESS_MS). A timeout
+              // aborts this attempt and withRetries retries rather than hanging.
+              signal: AbortSignal.timeout(VAULT_UPLOAD_TIMEOUT_MS),
             })
           )
         )

--- a/src/server/schema/vault.schema.ts
+++ b/src/server/schema/vault.schema.ts
@@ -45,6 +45,12 @@ export const vaultItemsRemoveModelVersionsSchema = z.object({
 export type VaultItemMetadataSchema = z.infer<typeof vaultItemMetadataSchema>;
 export const vaultItemMetadataSchema = z.object({
   failures: z.number().default(0),
+  latestError: z.string().optional(),
+  // Advisory in-flight lease (epoch millis) set by the process-vault-items job
+  // while it works an item, so overlapping runs don't double-process it. Cleared
+  // on completion; a killed run's stale lease ages out. `nullish` because the job
+  // clears it by writing JSON null.
+  processingStartedAt: z.number().nullish(),
 });
 
 export type VaultItemFilesSchema = z.infer<typeof vaultItemFilesSchema>;


### PR DESCRIPTION
Follow-up to #3333 addressing two robustness gaps in the vault-items batch job (`src/server/jobs/process-vault-items.ts`) surfaced while reviewing that change.

## A) One item's transient failure could abort the whole batch

The per-attempt failure-count bookkeeping update runs *before/outside* `processVaultItem`'s own `try/catch`. If that single update-by-primary-key throws (e.g. a transient DB blip), the error propagated out of the batch `for` loop and every remaining item in the run was skipped. The pre-#3333 code caught per-item errors and continued.

Fix: wrap each item's processing in the loop so one item's failure is logged and the loop continues to the next item. The kill-resilient accounting semantics from #3333 are preserved unchanged — the pre-attempt increment still persists (so an uncatchable kill still counts against the retry budget), a successful run still rolls it back, and a caught error still re-asserts the same count.

## B) Overlapping runs could duplicate heavy work and lose bookkeeping

The job is scheduled on a fixed interval, but a single run can occasionally take longer than that interval (a bounded batch where each item may fetch several images, each with a multi-minute timeout). When a new run starts before the previous one finishes, both runs do the heavy download+zip work on the same item and last-writer-wins on the item's `meta` JSON blob — losing failure-count updates and duplicating exactly the work the batch cap exists to bound.

Fix (lightweight, no schema migration): stamp an advisory in-flight lease timestamp (epoch millis) into the existing `meta` field when a run claims an item, and exclude freshly-leased items from the eligibility query. A lease older than a staleness window — i.e. a run that was killed mid-item and could never clear its lease — ages out, and the item becomes eligible again. The lease is cleared on both terminal paths (success and caught failure). This uses only the existing `meta` JSON field and the same numeric JSON-path filtering already used for the failure counter, so there is no enum/schema change and the eligibility query is the only caller touched.

## Tests

`src/server/jobs/__tests__/process-vault-items.test.ts`:
- A per-item processing throw does not abort the batch — remaining items are still processed (single-throw and mid-batch-throw variants).
- A freshly-leased (in-flight) item is excluded from eligibility while a stale or unleased item stays eligible; the lease cutoff tracks `now - staleness window`.
- The lease is stamped on claim and cleared on both the success and caught-failure terminal writes.

All existing #3333 accounting tests remain green. `tsc --noEmit` is clean with respect to the touched files.
