### PR TITLE
fix(challenges): gate challenge feed on the challenge's own nsfwLevel

### DIFF
--- a/src/components/HiddenPreferences/useApplyHiddenPreferences.ts
+++ b/src/components/HiddenPreferences/useApplyHiddenPreferences.ts
@@ -716,8 +716,10 @@ export function filterPreferences<
         const isOwner = challenge.createdById === currentUser?.id;
         if (isOwner || isModerator) return true;
 
-        // Content allowed by the challenge must intersect the user's browsing level
-        if (!Flags.intersects(challenge.allowedNsfwLevel, browsingLevel)) {
+        // The challenge's own rating — the highest level its `allowedNsfwLevel` permits — must
+        // intersect the user's browsing level. Intersecting `allowedNsfwLevel` itself is too loose:
+        // it's a multi-bit mask, so an R challenge that also allows PG would pass for a PG viewer.
+        if (!Flags.intersects(challenge.nsfwLevel, browsingLevel)) {
           hidden.browsingLevel++;
           return false;
         }

--- a/src/pages/challenges/[id]/[[...slug]].tsx
+++ b/src/pages/challenges/[id]/[[...slug]].tsx
@@ -711,9 +711,11 @@ function ChallengeDetailsPage({ id }: InferGetServerSidePropsType<typeof getServ
         <ContainerGrid2 gutter={{ base: 16, md: 32, lg: 64 }}>
           <ContainerGrid2.Col span={{ base: 12, md: 8 }}>
             <Stack gap="md">
-              {/* Cover Image */}
+              {/* w-full is load-bearing: `mx-auto` cancels the parent Stack's cross-axis stretch,
+                  so without a definite width the box is fit-content — and the blurred branch's only
+                  content is MediaHash's absolutely-positioned canvas, collapsing the cover to 0x0. */}
               {challenge.coverImage && (
-                <div className="relative mx-auto max-w-2xl overflow-hidden rounded-lg">
+                <div className="relative mx-auto w-full max-w-2xl overflow-hidden rounded-lg">
                   <ImageGuard2 image={challenge.coverImage}>
                     {(safe) => (
                       <>

--- a/src/server/services/__tests__/challenge-feed-browsing-level.service.test.ts
+++ b/src/server/services/__tests__/challenge-feed-browsing-level.service.test.ts
@@ -1,0 +1,220 @@
+import type { Prisma } from '@prisma/client';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// getInfiniteChallenges: the content-level gate must test the CHALLENGE's own rating
+// (`Challenge.nsfwLevel` — the single highest level its `allowedNsfwLevel` permits) and not only
+// the cover image's level. Filtering on the cover alone let an X-rated challenge with an SFW cover
+// surface for a PG/PG-13 viewer. The cover predicate stays alongside it so a challenge that
+// under-declares its rating still can't leak an NSFW cover into an SFW feed. Mocking shape mirrors
+// challenge-feed-block-exclusion.service.test.ts.
+const {
+  mockDbRead,
+  mockHiddenUsersGetCached,
+  mockBlockedByUsersGetCached,
+  mockBlockedUsersGetCached,
+} = vi.hoisted(() => ({
+  mockDbRead: {
+    $queryRaw: vi.fn(),
+    modelVersion: { findMany: vi.fn() },
+    image: { findUnique: vi.fn(), findFirst: vi.fn(), findMany: vi.fn(() => []) },
+    challenge: { findUnique: vi.fn() },
+    collectionItem: { count: vi.fn() },
+  },
+  mockHiddenUsersGetCached: vi.fn(() => [] as { id: number }[]),
+  mockBlockedByUsersGetCached: vi.fn(() => [] as { id: number }[]),
+  mockBlockedUsersGetCached: vi.fn(() => [] as { id: number }[]),
+}));
+
+vi.mock('~/server/db/client', () => ({
+  dbRead: mockDbRead,
+  dbWrite: {},
+}));
+
+vi.mock('~/server/services/user-preferences.service', () => ({
+  HiddenUsers: { getCached: mockHiddenUsersGetCached },
+  BlockedByUsers: { getCached: mockBlockedByUsersGetCached },
+  BlockedUsers: { getCached: mockBlockedUsersGetCached },
+}));
+
+vi.mock('~/server/services/buzz.service', () => ({
+  createBuzzTransaction: vi.fn(),
+  createBuzzTransactionMany: vi.fn(),
+}));
+
+vi.mock('~/server/games/daily-challenge/daily-challenge.utils', () => ({
+  getChallengeConfig: vi.fn(() => ({
+    reviewMeTagId: 301770,
+    judgedTagId: 299729,
+    maxScoredPerUser: 5,
+    reviewAmount: { min: 6, max: 12 },
+  })),
+  setChallengeConfig: vi.fn(),
+  deriveChallengeNsfwLevel: vi.fn(() => 1),
+  getJudgingConfig: vi.fn(),
+}));
+
+vi.mock('~/server/games/daily-challenge/challenge-helpers', () => ({
+  getChallengeById: vi.fn(),
+  getChallengeWinners: vi.fn(() => []),
+  closeChallengeCollection: vi.fn(),
+  createChallengeWinner: vi.fn(),
+}));
+
+vi.mock('~/server/games/daily-challenge/generative-content', () => ({
+  generateWinners: vi.fn(),
+}));
+
+vi.mock('~/server/jobs/daily-challenge-processing', () => ({
+  getJudgedEntries: vi.fn(),
+}));
+
+vi.mock('~/server/search-index', () => ({
+  collectionsSearchIndex: { queueUpdate: vi.fn() },
+}));
+
+vi.mock('~/server/services/image.service', () => ({
+  createImage: vi.fn(),
+  imagesForModelVersionsCache: { bust: vi.fn(), fetch: vi.fn(() => ({})) },
+}));
+
+vi.mock('~/server/services/user.service', () => ({
+  getCosmeticsForUsers: vi.fn(() => ({})),
+  getProfilePicturesForUsers: vi.fn(() => ({})),
+  amIBlockedByUser: vi.fn(),
+}));
+
+vi.mock('~/server/services/notification.service', () => ({
+  createNotification: vi.fn(),
+}));
+
+vi.mock('~/server/services/challenge-eligibility.service', () => ({
+  assertCanCreateUserChallenge: vi.fn(),
+  assertUserInGoodStanding: vi.fn(),
+  assertUserAccountInGoodStanding: vi.fn(),
+}));
+
+vi.mock('~/server/services/challenge-category.service', () => ({
+  resolveJudgingCategories: vi.fn(() => []),
+}));
+
+vi.mock('~/server/services/challenge-judge.service', () => ({
+  getUserSelectableJudges: vi.fn(() => []),
+}));
+
+vi.mock('~/server/services/text-moderation.service', () => ({
+  submitTextModeration: vi.fn(),
+}));
+
+vi.mock('~/server/logging/client', () => ({
+  logToAxiom: vi.fn(),
+}));
+
+vi.mock('~/utils/errorHandling', () => ({
+  withRetries: vi.fn((fn: () => unknown) => fn()),
+}));
+
+vi.mock('~/utils/logging', () => ({
+  createLogger: vi.fn(() => vi.fn()),
+}));
+
+const { getInfiniteChallenges } = await import('~/server/services/challenge.service');
+
+// See challenge-feed-block-exclusion.service.test.ts for why Prisma.Sql is duck-typed rather than
+// detected with instanceof.
+function isSqlLike(x: unknown): x is Prisma.Sql {
+  return (
+    typeof x === 'object' &&
+    x !== null &&
+    Array.isArray((x as { values?: unknown }).values) &&
+    Array.isArray((x as { strings?: unknown }).strings) &&
+    typeof (x as { text?: unknown }).text === 'string'
+  );
+}
+
+function captureQuery() {
+  const call = mockDbRead.$queryRaw.mock.calls[0];
+  if (!call) throw new Error('dbRead.$queryRaw was not called');
+  const sqlFragments = call.filter(isSqlLike);
+  return {
+    text: sqlFragments.map((s) => s.text).join(' '),
+    values: sqlFragments.flatMap((s) => s.values),
+  };
+}
+
+const CHALLENGE_LEVEL_PREDICATE = 'c."nsfwLevel" &';
+const COVER_LEVEL_PREDICATE = 'i."nsfwLevel" &';
+
+describe('getInfiniteChallenges — content level filter', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockDbRead.$queryRaw.mockResolvedValue([]);
+    mockDbRead.image.findMany.mockResolvedValue([]);
+    mockHiddenUsersGetCached.mockResolvedValue([]);
+    mockBlockedByUsersGetCached.mockResolvedValue([]);
+    mockBlockedUsersGetCached.mockResolvedValue([]);
+  });
+
+  it("gates on the challenge's own level as well as the cover's", async () => {
+    await getInfiniteChallenges({
+      limit: 20,
+      includeEnded: false,
+      excludeEventChallenges: false,
+      canAccessUserChallenges: true,
+      currentUserId: 5,
+      isGreen: false,
+      browsingLevel: 7, // PG | PG13 | R
+    } as Parameters<typeof getInfiniteChallenges>[0]);
+
+    const { text, values } = captureQuery();
+    expect(text).toContain(CHALLENGE_LEVEL_PREDICATE);
+    expect(text).toContain(COVER_LEVEL_PREDICATE);
+    expect(values.filter((v) => v === 7).length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('applies the same gate to anonymous viewers', async () => {
+    await getInfiniteChallenges({
+      limit: 20,
+      includeEnded: false,
+      excludeEventChallenges: false,
+      canAccessUserChallenges: true,
+      isGreen: false,
+      browsingLevel: 7,
+    } as Parameters<typeof getInfiniteChallenges>[0]);
+
+    const { text } = captureQuery();
+    expect(text).toContain(CHALLENGE_LEVEL_PREDICATE);
+    expect(text).toContain(COVER_LEVEL_PREDICATE);
+  });
+
+  it('caps the level on green even when the client asks for NSFW', async () => {
+    await getInfiniteChallenges({
+      limit: 20,
+      includeEnded: false,
+      excludeEventChallenges: false,
+      canAccessUserChallenges: true,
+      currentUserId: 5,
+      isGreen: true,
+      browsingLevel: 31, // asks for everything; masked to the SFW cap (PG | PG13)
+    } as Parameters<typeof getInfiniteChallenges>[0]);
+
+    const { text, values } = captureQuery();
+    expect(text).toContain(CHALLENGE_LEVEL_PREDICATE);
+    expect(values).toContain(3);
+    expect(values).not.toContain(31);
+  });
+
+  it('adds no level predicate off green when no level is requested', async () => {
+    await getInfiniteChallenges({
+      limit: 20,
+      includeEnded: false,
+      excludeEventChallenges: false,
+      canAccessUserChallenges: true,
+      currentUserId: 5,
+      isGreen: false,
+    } as Parameters<typeof getInfiniteChallenges>[0]);
+
+    const { text } = captureQuery();
+    expect(text).not.toContain(CHALLENGE_LEVEL_PREDICATE);
+    expect(text).not.toContain(COVER_LEVEL_PREDICATE);
+  });
+});

--- a/src/server/services/challenge.service.ts
+++ b/src/server/services/challenge.service.ts
@@ -483,7 +483,7 @@ export async function getMyChallenges({
       ${blockSql ? Prisma.sql`AND ${blockSql}` : Prisma.empty}
       ${
         effectiveBrowsingLevel > 0
-          ? Prisma.sql`AND (c."createdById" = ${userId} OR EXISTS (SELECT 1 FROM "Image" i WHERE i.id = c."coverImageId" AND (i."nsfwLevel" & ${effectiveBrowsingLevel}) <> 0))`
+          ? Prisma.sql`AND (c."createdById" = ${userId} OR ((c."nsfwLevel" & ${effectiveBrowsingLevel}) <> 0 AND EXISTS (SELECT 1 FROM "Image" i WHERE i.id = c."coverImageId" AND (i."nsfwLevel" & ${effectiveBrowsingLevel}) <> 0)))`
           : Prisma.empty
       }
     ORDER BY COALESCE(my."myEnteredAt", c."createdAt") DESC
@@ -650,9 +650,10 @@ export async function getInfiniteChallenges(
     conditions.push(Prisma.sql`c."eventId" = ${challengeEventId}`);
   }
 
-  // Content level filter — models-style: exclude a challenge outright when its REAL cover image
-  // level doesn't intersect the viewer's effective browsing level, rather than trusting the
-  // challenge's declared `allowedNsfwLevel`. On green the level is capped server-side (see
+  // Content level filter — the challenge's own rating (`nsfwLevel`, the highest level its
+  // `allowedNsfwLevel` permits) must intersect the viewer's effective browsing level. The REAL
+  // cover level is required to intersect too, so a challenge that under-declares its rating can't
+  // leak an NSFW cover into an SFW feed. On green the level is capped server-side (see
   // getEffectiveBrowsingLevel) so a client can't bypass it by omitting `browsingLevel`. Creator
   // always sees their own. A challenge with no cover is already excluded by the IS NOT NULL gate
   // above.
@@ -662,10 +663,9 @@ export async function getInfiniteChallenges(
     requested: browsingLevel,
   });
   if (effectiveBrowsingLevel > 0) {
+    const levelSql = Prisma.sql`((c."nsfwLevel" & ${effectiveBrowsingLevel}) <> 0 AND EXISTS (SELECT 1 FROM "Image" i WHERE i.id = c."coverImageId" AND (i."nsfwLevel" & ${effectiveBrowsingLevel}) <> 0))`;
     conditions.push(
-      currentUserId
-        ? Prisma.sql`(c."createdById" = ${currentUserId} OR EXISTS (SELECT 1 FROM "Image" i WHERE i.id = c."coverImageId" AND (i."nsfwLevel" & ${effectiveBrowsingLevel}) <> 0))`
-        : Prisma.sql`EXISTS (SELECT 1 FROM "Image" i WHERE i.id = c."coverImageId" AND (i."nsfwLevel" & ${effectiveBrowsingLevel}) <> 0)`
+      currentUserId ? Prisma.sql`(c."createdById" = ${currentUserId} OR ${levelSql})` : levelSql
     );
   }
 
@@ -3675,19 +3675,18 @@ export async function getCompletedChallengesWithWinners(
   const blockSql = challengeCreatorBlockSql(await getChallengeExcludedUserIds(currentUserId));
   if (blockSql) conditions.push(blockSql);
 
-  // Content level filter — parity with the feed: exclude a challenge whose REAL cover image level
-  // doesn't intersect the viewer's effective (green-capped) browsing level, rather than trusting
-  // the declared allowedNsfwLevel. Creator sees their own.
+  // Content level filter — parity with the feed: the challenge's own rating and its REAL cover
+  // level must both intersect the viewer's effective (green-capped) browsing level. Creator sees
+  // their own.
   const effectiveBrowsingLevel = getEffectiveBrowsingLevel({
     isGreen: isGreen ?? false,
     isLoggedIn: currentUserId != null,
     requested: browsingLevel,
   });
   if (effectiveBrowsingLevel > 0) {
+    const levelSql = Prisma.sql`((c."nsfwLevel" & ${effectiveBrowsingLevel}) <> 0 AND EXISTS (SELECT 1 FROM "Image" i WHERE i.id = c."coverImageId" AND (i."nsfwLevel" & ${effectiveBrowsingLevel}) <> 0))`;
     conditions.push(
-      currentUserId
-        ? Prisma.sql`(c."createdById" = ${currentUserId} OR EXISTS (SELECT 1 FROM "Image" i WHERE i.id = c."coverImageId" AND (i."nsfwLevel" & ${effectiveBrowsingLevel}) <> 0))`
-        : Prisma.sql`EXISTS (SELECT 1 FROM "Image" i WHERE i.id = c."coverImageId" AND (i."nsfwLevel" & ${effectiveBrowsingLevel}) <> 0)`
+      currentUserId ? Prisma.sql`(c."createdById" = ${currentUserId} OR ${levelSql})` : levelSql
     );
   }
 


### PR DESCRIPTION
Two community-challenge bugs.

## 1. Feed filtered on the cover image's level, not the challenge's

The content-level gate only tested the cover image:

```sql
EXISTS (SELECT 1 FROM "Image" i WHERE i.id = c."coverImageId" AND (i."nsfwLevel" & $level) <> 0)
```

`Challenge.nsfwLevel` was never in the WHERE clause, so a challenge rated above the viewer's browsing level surfaced whenever its cover happened to be SFW — an X-rated challenge with a PG cover was visible to a PG/PG-13 viewer.

The client-side pass (`useApplyHiddenPreferences`, `case 'challenges'`) had the same hole from the other side: it tested `allowedNsfwLevel`, which is a **multi-bit mask** (`PG|PG13|R`), so it intersects a PG viewer's level for any challenge that merely also allows PG.

Now both gate on `Challenge.nsfwLevel` — the single highest level `allowedNsfwLevel` permits (`deriveChallengeNsfwLevel` = `Flags.maxValue`). The cover predicate is kept **alongside** it (ANDed) so a challenge that under-declares its rating still can't leak an NSFW cover into an SFW feed — `ChallengeCard` feeds `challenge.nsfwLevel` (not the cover's) to `ImageGuard2`, so the card wouldn't blur it.

Applied to `getInfiniteChallenges`, `getMyChallenges`, and `getCompletedChallengesWithWinners`.

## 2. Detail-page cover hidden entirely instead of blurred

Not a gating bug — a layout one. The cover container is `relative mx-auto max-w-2xl`; `mx-auto` cancels the parent `Stack`'s cross-axis stretch, making the box fit-content. The safe branch renders `EdgeMedia2` (an `<img>` with intrinsic width) so it's fine, but the blurred branch's only content is `MediaHash`'s `absolute inset-0` canvas → fit-content resolves to **0**, and `aspect-[4/3] w-full` collapses to 0 × 0. The overlay and canvas were in the DOM the whole time, just zero-sized.

`w-full` on the container fixes it. Articles avoid this by wrapping the cover in `<AspectRatio>`.

## Verification

Reproduced and verified in the browser against the local dev DB, using a test challenge cloned to match challenge 422's shape (`nsfwLevel=8` X, `allowedNsfwLevel=15`, PG cover, non-owner creator):

| browsingLevel | old predicate | new predicate | feed result |
|---|---|---|---|
| 1 (PG) | visible | hidden | hidden |
| 7 (PG/PG-13/R) | **visible** | hidden | hidden |
| 15 (incl. X) | visible | visible | shown |
| control, PG challenge | visible | visible | shown |

Detail page with blur on and an R cover: renders 672 × 504 with the blurhash + "This image is rated R / Show" instead of collapsing to 0 × 0. Safe path unchanged (672 × 504, `<img>` present).

New `challenge-feed-browsing-level.service.test.ts` (challenge + cover predicate present, anonymous parity, green cap clamping, no-level ⇒ no predicate). Challenge visibility suites: 49 passed, 0 failed.

The test challenge was deleted from the dev DB afterwards; no migrations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)