### PR TITLE
feat(app-blocks): deep-link to a review finding (open tab + scroll + copy-link) [Phase 2.3 fast-follow]

### DIFF
--- a/src/components/Apps/ReportTabs.browser.test.tsx
+++ b/src/components/Apps/ReportTabs.browser.test.tsx
@@ -8,14 +8,18 @@ import { renderWithProviders } from '../../../test/component-setup';
  * (Phase 2.3 fast-follow) — browser-mode component tests.
  *
  * `ReportTabs` is prop-only + router-agnostic: it reads/writes the URL hash
- * directly (never next/router) so a deep link `#finding-<tab>-<index>` opens the
+ * directly (never next/router). Deep-linking is GATED on the route — active only
+ * on the dedicated review page (`/apps/review/<id>`), inert in the review modal
+ * (`/apps/review`). When active, a deep link `#finding-<tab>-<index>` opens the
  * right tab, scrolls the target card into view with a transient highlight, and
  * each finding card carries a subtle "copy link" affordance.
  *
  * Covers:
- *  - landing on `#finding-security-1` activates the Security audit tab;
- *  - the target finding card carries `id="finding-security-1"`;
- *  - each finding card renders a "copy link" ActionIcon.
+ *  - on the page route, landing on `#finding-security-1` activates the Security
+ *    audit tab, the card carries `id="finding-security-1"`, `scrollIntoView`
+ *    fires (deterministic post-commit scroll), and a copy-link renders;
+ *  - a bare tab hash (`#code`) activates that tab with no finding target;
+ *  - on the modal route there is NO deep-linking (no copy-link, no anchor id).
  *
  * The Summary tab renders `summaryMd` through CustomMarkdown, which reads
  * `useCurrentUser()`. We keep `summaryMd` null here so that surface is never hit,
@@ -28,6 +32,9 @@ vi.mock('~/hooks/useCurrentUser', () => ({
 }));
 
 const { ReportTabs } = await import('./ReportTabs');
+
+// The dedicated review PAGE route enables deep-linking (`/apps/review/<id>`).
+const PAGE_PATH = '/apps/review/pubreq_test';
 
 // Two security findings in severity order (critical, then high) → the second
 // card (index 1) is the `high` one, so `#finding-security-1` targets it.
@@ -47,16 +54,18 @@ const REPORT = {
 };
 
 beforeEach(() => {
-  // Land on the deep link BEFORE render so the mount-time hash sync reads it.
-  window.history.replaceState(null, '', '#finding-security-1');
+  // Land on the PAGE route + deep link BEFORE render so the mount-time route
+  // resolution enables deep-linking and the hash sync reads the anchor.
+  window.history.replaceState(null, '', `${PAGE_PATH}#finding-security-1`);
 });
 
 afterEach(() => {
-  // Clear the hash so it never leaks into the next test.
-  window.history.replaceState(null, '', window.location.pathname + window.location.search);
+  vi.restoreAllMocks();
+  // Reset to a neutral URL so neither the path nor the hash leaks to the next test.
+  window.history.replaceState(null, '', '/');
 });
 
-describe('ReportTabs — deep-link to a finding', () => {
+describe('ReportTabs — deep-link to a finding (page route)', () => {
   test('landing on #finding-security-1 activates the Security audit tab', async () => {
     renderWithProviders(<ReportTabs report={REPORT} costCapped={false} />);
 
@@ -87,6 +96,20 @@ describe('ReportTabs — deep-link to a finding', () => {
     expect(first?.textContent).toContain('Critical sec finding');
   });
 
+  test('scrollIntoView fires on the target card AFTER its tab commits', async () => {
+    // Covers the deterministic post-commit scroll: the scroll runs in an effect
+    // keyed on the active tab, so it can't fire against a still-hidden panel.
+    const spy = vi.spyOn(HTMLElement.prototype, 'scrollIntoView');
+    renderWithProviders(<ReportTabs report={REPORT} costCapped={false} />);
+
+    await expect.element(page.getByText('High sec finding')).toBeVisible();
+    await vi.waitFor(() => expect(spy).toHaveBeenCalled());
+
+    // At least one call's target was the deep-linked card.
+    const target = document.getElementById('finding-security-1');
+    expect(spy.mock.contexts).toContain(target);
+  });
+
   test('each finding card renders a copy-link ActionIcon', async () => {
     renderWithProviders(<ReportTabs report={REPORT} costCapped={false} />);
 
@@ -98,12 +121,32 @@ describe('ReportTabs — deep-link to a finding', () => {
   });
 
   test('a bare tab hash (#code) activates that tab without a finding target', async () => {
-    window.history.replaceState(null, '', '#code');
+    // Keep the page path (relative hash-only update), switch the hash to #code.
+    window.history.replaceState(null, '', `${PAGE_PATH}#code`);
     renderWithProviders(<ReportTabs report={REPORT} costCapped={false} />);
 
     await expect
       .element(page.getByRole('tab', { name: /Code review/ }))
       .toHaveAttribute('aria-selected', 'true');
     await expect.element(page.getByText('A code finding')).toBeVisible();
+  });
+});
+
+describe('ReportTabs — modal route (deep-linking inert)', () => {
+  test('on /apps/review the hash is ignored: no copy-link, no anchor ids, Summary stays active', async () => {
+    // The modal lives at exactly /apps/review (no trailing id) → deep-linking off.
+    window.history.replaceState(null, '', '/apps/review#finding-security-1');
+    renderWithProviders(<ReportTabs report={REPORT} costCapped={false} />);
+
+    // Default Summary tab stays active — the finding hash is NOT honored.
+    await expect
+      .element(page.getByRole('tab', { name: /Summary/ }))
+      .toHaveAttribute('aria-selected', 'true');
+
+    // No copy-link affordances and no per-finding anchor id anywhere (pre-feature
+    // behavior), so a copy-link can't produce a URL that reopens nothing.
+    expect(page.getByTestId('finding-copy-link').elements().length).toBe(0);
+    expect(document.getElementById('finding-security-1')).toBeNull();
+    expect(document.getElementById('finding-security-0')).toBeNull();
   });
 });

--- a/src/components/Apps/ReportTabs.browser.test.tsx
+++ b/src/components/Apps/ReportTabs.browser.test.tsx
@@ -1,0 +1,109 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { page } from 'vitest/browser';
+// `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
+import { renderWithProviders } from '../../../test/component-setup';
+
+/**
+ * App Blocks — AGENTIC MOD CODE-REVIEW report renderer: deep-link-to-a-finding
+ * (Phase 2.3 fast-follow) — browser-mode component tests.
+ *
+ * `ReportTabs` is prop-only + router-agnostic: it reads/writes the URL hash
+ * directly (never next/router) so a deep link `#finding-<tab>-<index>` opens the
+ * right tab, scrolls the target card into view with a transient highlight, and
+ * each finding card carries a subtle "copy link" affordance.
+ *
+ * Covers:
+ *  - landing on `#finding-security-1` activates the Security audit tab;
+ *  - the target finding card carries `id="finding-security-1"`;
+ *  - each finding card renders a "copy link" ActionIcon.
+ *
+ * The Summary tab renders `summaryMd` through CustomMarkdown, which reads
+ * `useCurrentUser()`. We keep `summaryMd` null here so that surface is never hit,
+ * and boundary-stub the hook anyway (null user is fine — the standard pattern in
+ * the sibling AgentReview tests).
+ */
+
+vi.mock('~/hooks/useCurrentUser', () => ({
+  useCurrentUser: () => null,
+}));
+
+const { ReportTabs } = await import('./ReportTabs');
+
+// Two security findings in severity order (critical, then high) → the second
+// card (index 1) is the `high` one, so `#finding-security-1` targets it.
+const REPORT = {
+  status: 'complete',
+  summaryMd: null,
+  codeReview: {
+    findings: [{ severity: 'medium', title: 'A code finding', detail: 'code detail' }],
+  },
+  securityAudit: {
+    findings: [
+      { severity: 'critical', title: 'Critical sec finding', detail: 'sandbox escape' },
+      { severity: 'high', title: 'High sec finding', detail: 'broad host' },
+    ],
+  },
+  scopeVerdicts: {},
+};
+
+beforeEach(() => {
+  // Land on the deep link BEFORE render so the mount-time hash sync reads it.
+  window.history.replaceState(null, '', '#finding-security-1');
+});
+
+afterEach(() => {
+  // Clear the hash so it never leaks into the next test.
+  window.history.replaceState(null, '', window.location.pathname + window.location.search);
+});
+
+describe('ReportTabs — deep-link to a finding', () => {
+  test('landing on #finding-security-1 activates the Security audit tab', async () => {
+    renderWithProviders(<ReportTabs report={REPORT} costCapped={false} />);
+
+    // The Security audit tab is selected (not the default Summary).
+    await expect
+      .element(page.getByRole('tab', { name: /Security audit/ }))
+      .toHaveAttribute('aria-selected', 'true');
+    await expect
+      .element(page.getByRole('tab', { name: /Summary/ }))
+      .toHaveAttribute('aria-selected', 'false');
+
+    // The targeted finding is visible in the now-active tab.
+    await expect.element(page.getByText('High sec finding')).toBeVisible();
+  });
+
+  test('the target finding card carries id="finding-security-1"', async () => {
+    renderWithProviders(<ReportTabs report={REPORT} costCapped={false} />);
+
+    await expect.element(page.getByText('High sec finding')).toBeVisible();
+    const el = document.getElementById('finding-security-1');
+    expect(el).not.toBeNull();
+    // It is a finding card (carries the finding-card testid).
+    expect(el?.getAttribute('data-testid')).toBe('finding-card');
+    // And it renders the `high` finding (index 1 of the severity-sorted list).
+    expect(el?.textContent).toContain('High sec finding');
+    // The index-0 card exists too and is the `critical` finding.
+    const first = document.getElementById('finding-security-0');
+    expect(first?.textContent).toContain('Critical sec finding');
+  });
+
+  test('each finding card renders a copy-link ActionIcon', async () => {
+    renderWithProviders(<ReportTabs report={REPORT} costCapped={false} />);
+
+    await expect.element(page.getByText('High sec finding')).toBeVisible();
+    // The two security cards each expose a copy-link affordance (keepMounted, so
+    // the code tab's card counts too — assert at least the security ones exist).
+    const copyLinks = page.getByTestId('finding-copy-link').elements();
+    expect(copyLinks.length).toBeGreaterThanOrEqual(2);
+  });
+
+  test('a bare tab hash (#code) activates that tab without a finding target', async () => {
+    window.history.replaceState(null, '', '#code');
+    renderWithProviders(<ReportTabs report={REPORT} costCapped={false} />);
+
+    await expect
+      .element(page.getByRole('tab', { name: /Code review/ }))
+      .toHaveAttribute('aria-selected', 'true');
+    await expect.element(page.getByText('A code finding')).toBeVisible();
+  });
+});

--- a/src/components/Apps/ReportTabs.tsx
+++ b/src/components/Apps/ReportTabs.tsx
@@ -257,11 +257,13 @@ export function FindingsCards({
   findings,
   emptyLabel,
   tab,
+  deepLinkable,
   highlightedId,
 }: {
   findings: AgentFinding[];
   emptyLabel: string;
   tab: FindingTab;
+  deepLinkable?: boolean;
   highlightedId?: string | null;
 }) {
   if (findings.length === 0) return <EmptyState label={emptyLabel} />;
@@ -269,13 +271,17 @@ export function FindingsCards({
   return (
     <Stack gap={6} data-testid="findings-cards">
       {sorted.map((f, i) => {
-        const anchorId = findingAnchorId(tab, i);
+        // Anchors + copy-link are attached ONLY when deep-linking is active (the
+        // dedicated review page). In the modal reuse path they're omitted, so a
+        // copy-link can't produce a `…/apps/review#finding-…` URL that reopens
+        // nothing.
+        const anchorId = deepLinkable ? findingAnchorId(tab, i) : undefined;
         return (
           <FindingCard
             key={i}
             finding={f}
             anchorId={anchorId}
-            highlighted={highlightedId === anchorId}
+            highlighted={anchorId != null && highlightedId === anchorId}
           />
         );
       })}
@@ -351,10 +357,12 @@ export function SummaryTab({
 export function CodeReviewTab({
   codeReview,
   error,
+  deepLinkable,
   highlightedId,
 }: {
   codeReview: CodeReviewView;
   error: string | null;
+  deepLinkable?: boolean;
   highlightedId?: string | null;
 }) {
   if (error) return <SectionFailed error={error} />;
@@ -364,6 +372,7 @@ export function CodeReviewTab({
         findings={codeReview.findings}
         emptyLabel="No code-review findings."
         tab="code"
+        deepLinkable={deepLinkable}
         highlightedId={highlightedId}
       />
       {codeReview.priorFindingsReconciled.length > 0 && (
@@ -399,10 +408,12 @@ export function CodeReviewTab({
 export function SecurityAuditTab({
   securityAudit,
   error,
+  deepLinkable,
   highlightedId,
 }: {
   securityAudit: SecurityAuditView;
   error: string | null;
+  deepLinkable?: boolean;
   highlightedId?: string | null;
 }) {
   if (error) return <SectionFailed error={error} />;
@@ -412,6 +423,7 @@ export function SecurityAuditTab({
         findings={securityAudit.findings}
         emptyLabel="No security-audit findings."
         tab="security"
+        deepLinkable={deepLinkable}
         highlightedId={highlightedId}
       />
 
@@ -719,55 +731,91 @@ export function ReportTabs({
   const view = parseAgentReport(report);
   const { codeReview, securityAudit, scopeVerdicts, tokenUsage } = view;
 
-  // --- Deep-link-to-a-finding wiring -------------------------------------
-  // Controlled tabs + a transient highlight, driven off the URL hash. We read
-  // the hash directly (NOT next/router) to keep this component router-agnostic
-  // + reusable, and to sidestep the review page's route-leave navigation guard:
-  // `history.replaceState` updates the URL WITHOUT a router navigation, so the
-  // guard never fires. All window/document/history access lives inside effects
-  // and event handlers (SSR-safe).
+  // --- Deep-link-to-a-finding wiring (dedicated review PAGE only) ----------
+  // ReportTabs renders in BOTH the flag-gated review PAGE (/apps/review/<id>)
+  // and the legacy review MODAL (/apps/review). Deep-linking (hash read/write,
+  // per-finding anchors, copy-link) only makes sense on the dedicated page — in
+  // the modal a copy-link URL would reopen nothing and tab clicks would rewrite
+  // the queue URL. So the whole behavior is gated on `deepLinkable`, derived
+  // from the actual route (the page is /apps/review/<id>; the modal is exactly
+  // /apps/review). When off, this behaves EXACTLY as before the feature: plain
+  // controlled tabs, no hash side-effects, no anchors, no copy-link.
+  //
+  // We read the hash directly (NOT next/router) to keep this component
+  // router-agnostic and to sidestep the review page's route-leave navigation
+  // guard: `history.replaceState` updates the URL WITHOUT a router navigation,
+  // so the guard never fires. All window/document/history access lives inside
+  // effects and event handlers (SSR-safe).
+  const [deepLinkable, setDeepLinkable] = useState(false);
   const [activeTab, setActiveTab] = useState<ReportTabValue>('summary');
   const [highlightedId, setHighlightedId] = useState<string | null>(null);
+  // The finding to scroll to once its tab has COMMITTED. keepMounted panels are
+  // display:none until active, so we defer the scroll to the [activeTab] effect
+  // below rather than a single rAF that can fire before the tab-switch commit.
+  const [pendingAnchor, setPendingAnchor] = useState<string | null>(null);
   const highlightTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const applyHash = useCallback(() => {
+  // Resolve deep-linkability from the route on mount (client-only → SSR renders
+  // the pre-feature shape, then the page enables it after hydration; the modal
+  // never does, so it keeps the pre-feature behavior).
+  useEffect(() => {
     if (typeof window === 'undefined') return;
+    setDeepLinkable(window.location.pathname.startsWith('/apps/review/'));
+  }, []);
+
+  const applyHash = useCallback(() => {
+    if (!deepLinkable || typeof window === 'undefined') return;
     const { tab, anchorId } = parseReportHash(window.location.hash);
     if (tab) setActiveTab(tab);
-    if (anchorId) {
-      // keepMounted panels are display:none until active, so a target card
-      // can't be scrolled to until its tab is activated. Activate first (above),
-      // then scroll on the next frame once the panel is visible.
-      requestAnimationFrame(() => {
-        const el = document.getElementById(anchorId);
-        if (!el) return;
-        el.scrollIntoView({ block: 'center' });
-        setHighlightedId(anchorId);
-        if (highlightTimeout.current) clearTimeout(highlightTimeout.current);
-        highlightTimeout.current = setTimeout(() => setHighlightedId(null), 2000);
-      });
-    }
-  }, []);
+    // Queue the scroll; the post-commit effect below performs it once the tab
+    // (and thus the target panel's visibility) is committed to the DOM.
+    if (anchorId) setPendingAnchor(anchorId);
+  }, [deepLinkable]);
 
   useEffect(() => {
+    if (!deepLinkable) return;
     applyHash();
     window.addEventListener('hashchange', applyHash);
-    return () => {
-      window.removeEventListener('hashchange', applyHash);
-      if (highlightTimeout.current) clearTimeout(highlightTimeout.current);
-    };
-  }, [applyHash]);
+    return () => window.removeEventListener('hashchange', applyHash);
+  }, [deepLinkable, applyHash]);
 
-  // Manual tab clicks reflect into the URL via history.replaceState (again, NOT
-  // a router navigation — never trips the route-leave guard, never loops since
-  // replaceState does not fire `hashchange`).
-  const handleTabChange = useCallback((value: string | null) => {
-    if (!value) return;
-    setActiveTab(value as ReportTabValue);
-    if (typeof window !== 'undefined') {
-      window.history.replaceState(null, '', `#${value}`);
+  // Post-commit scroll: runs AFTER the active tab is committed (target panel is
+  // now display:block), so scrollIntoView lands reliably. The highlight is set
+  // ONLY when the element is actually found; the pending anchor is cleared
+  // either way so it fires exactly once.
+  useEffect(() => {
+    if (!deepLinkable || !pendingAnchor || typeof document === 'undefined') return;
+    const el = document.getElementById(pendingAnchor);
+    if (el) {
+      el.scrollIntoView({ block: 'center' });
+      setHighlightedId(pendingAnchor);
+      if (highlightTimeout.current) clearTimeout(highlightTimeout.current);
+      highlightTimeout.current = setTimeout(() => setHighlightedId(null), 2000);
     }
-  }, []);
+    setPendingAnchor(null);
+  }, [activeTab, pendingAnchor, deepLinkable]);
+
+  // Clear any pending highlight timer on unmount.
+  useEffect(
+    () => () => {
+      if (highlightTimeout.current) clearTimeout(highlightTimeout.current);
+    },
+    []
+  );
+
+  // Manual tab clicks reflect into the URL via history.replaceState (page only;
+  // NOT a router navigation — never trips the route-leave guard, never loops
+  // since replaceState does not fire `hashchange`).
+  const handleTabChange = useCallback(
+    (value: string | null) => {
+      if (!value) return;
+      setActiveTab(value as ReportTabValue);
+      if (deepLinkable && typeof window !== 'undefined') {
+        window.history.replaceState(null, '', `#${value}`);
+      }
+    },
+    [deepLinkable]
+  );
 
   // Structural failed-section detection runs on the RAW slots (before the
   // tolerant parse flattens an `{ error }` object to an empty section).
@@ -835,12 +883,18 @@ export function ReportTabs({
           />
         </Tabs.Panel>
         <Tabs.Panel value="code" pt="sm">
-          <CodeReviewTab codeReview={codeReview} error={codeError} highlightedId={highlightedId} />
+          <CodeReviewTab
+            codeReview={codeReview}
+            error={codeError}
+            deepLinkable={deepLinkable}
+            highlightedId={highlightedId}
+          />
         </Tabs.Panel>
         <Tabs.Panel value="security" pt="sm">
           <SecurityAuditTab
             securityAudit={securityAudit}
             error={securityError}
+            deepLinkable={deepLinkable}
             highlightedId={highlightedId}
           />
         </Tabs.Panel>

--- a/src/components/Apps/ReportTabs.tsx
+++ b/src/components/Apps/ReportTabs.tsx
@@ -1,25 +1,30 @@
-import { Alert, Badge, Card, Group, Stack, Table, Tabs, Text, ThemeIcon } from '@mantine/core';
-import { useMediaQuery } from '@mantine/hooks';
-import type { ReactNode } from 'react';
+import { ActionIcon, Alert, Badge, Card, Group, Stack, Table, Tabs, Text, ThemeIcon, Tooltip } from '@mantine/core';
+import { useClipboard, useMediaQuery } from '@mantine/hooks';
+import { useCallback, useEffect, useRef, useState, type ReactNode } from 'react';
 import {
   IconAlertTriangle,
   IconCheck,
   IconCode,
   IconInfoCircle,
   IconKey,
+  IconLink,
   IconShieldLock,
 } from '@tabler/icons-react';
 import { CustomMarkdown } from '~/components/Markdown/CustomMarkdown';
 import {
   fileLineLabel,
+  findingAnchorId,
   findingBody,
   formatCostUsd,
   parseAgentReport,
+  parseReportHash,
   sectionAnalysisError,
   severityBreakdown,
   sortFindingsBySeverity,
   type AgentFinding,
   type CodeReviewView,
+  type FindingTab,
+  type ReportTabValue,
   type ScopeVerdictsView,
   type SecurityAuditView,
 } from '~/components/Apps/agentReviewReport';
@@ -120,40 +125,98 @@ function MonoLine({ children }: { children: ReactNode }) {
 }
 
 /**
+ * A subtle "copy link to this finding" affordance. Builds the absolute deep-link
+ * from `window.location` (hash-only — never a router navigation, so the review
+ * page's route-leave guard is not tripped), copies it, and reflects the anchor
+ * into the URL via `history.replaceState`. All `window`/`history` access is
+ * inside the click handler (SSR-safe).
+ */
+function CopyFindingLink({ anchorId }: { anchorId: string }) {
+  const clipboard = useClipboard({ timeout: 1500 });
+  const onCopy = () => {
+    if (typeof window === 'undefined') return;
+    const url = `${window.location.href.split('#')[0]}#${anchorId}`;
+    clipboard.copy(url);
+    window.history.replaceState(null, '', `#${anchorId}`);
+  };
+  return (
+    <Tooltip label={clipboard.copied ? 'Link copied' : 'Copy link to finding'} withArrow>
+      <ActionIcon
+        size="xs"
+        variant="subtle"
+        color={clipboard.copied ? 'green' : 'gray'}
+        onClick={onCopy}
+        data-testid="finding-copy-link"
+        aria-label="Copy link to this finding"
+        style={{ flexShrink: 0 }}
+      >
+        {clipboard.copied ? <IconCheck size={14} /> : <IconLink size={14} />}
+      </ActionIcon>
+    </Tooltip>
+  );
+}
+
+/**
  * A single finding rendered as a scannable card: severity + category + optional
  * diffStatus / confidence chips + title, then `file:line`, evidence, the body
  * detail, and an optional suggested fix.
+ *
+ * When `anchorId` is set the card carries that DOM id (the deep-link target) and
+ * a subtle copy-link affordance; `highlighted` draws a transient, animation-free
+ * outline (reduced-motion-safe) after a deep-link scroll.
  */
-export function FindingCard({ finding }: { finding: AgentFinding }) {
+export function FindingCard({
+  finding,
+  anchorId,
+  highlighted,
+}: {
+  finding: AgentFinding;
+  anchorId?: string;
+  highlighted?: boolean;
+}) {
   const loc = fileLineLabel(finding.file, finding.line);
   const body = findingBody(finding);
   return (
-    <Card withBorder padding="xs" radius="sm" data-testid="finding-card">
+    <Card
+      withBorder
+      padding="xs"
+      radius="sm"
+      data-testid="finding-card"
+      id={anchorId}
+      style={
+        highlighted
+          ? { outline: '2px solid var(--mantine-color-yellow-5)', outlineOffset: 2 }
+          : undefined
+      }
+    >
       <Stack gap={4}>
-        <Group gap={6} wrap="wrap" align="center">
-          <Badge size="sm" variant="light" color={severityColor(finding.severity)}>
-            {finding.severity ?? 'info'}
-          </Badge>
-          {finding.category && (
-            <Badge size="sm" variant="outline" color="gray">
-              {finding.category}
+        <Group gap={6} wrap="nowrap" align="flex-start" justify="space-between">
+          <Group gap={6} wrap="wrap" align="center" style={{ minWidth: 0, flex: 1 }}>
+            <Badge size="sm" variant="light" color={severityColor(finding.severity)}>
+              {finding.severity ?? 'info'}
             </Badge>
-          )}
-          {finding.diffStatus && (
-            <Badge size="sm" variant="dot" color="blue">
-              {finding.diffStatus}
-            </Badge>
-          )}
-          {finding.confidence && (
-            <Text size="xs" c="dimmed">
-              confidence: {finding.confidence}
-            </Text>
-          )}
-          {finding.title && (
-            <Text size="sm" fw={600} style={{ wordBreak: 'break-word' }}>
-              {finding.title}
-            </Text>
-          )}
+            {finding.category && (
+              <Badge size="sm" variant="outline" color="gray">
+                {finding.category}
+              </Badge>
+            )}
+            {finding.diffStatus && (
+              <Badge size="sm" variant="dot" color="blue">
+                {finding.diffStatus}
+              </Badge>
+            )}
+            {finding.confidence && (
+              <Text size="xs" c="dimmed">
+                confidence: {finding.confidence}
+              </Text>
+            )}
+            {finding.title && (
+              <Text size="sm" fw={600} style={{ wordBreak: 'break-word' }}>
+                {finding.title}
+              </Text>
+            )}
+          </Group>
+          {anchorId && <CopyFindingLink anchorId={anchorId} />}
         </Group>
         {loc && <MonoLine>{loc}</MonoLine>}
         {finding.evidence.length > 0 && (
@@ -183,21 +246,39 @@ export function FindingCard({ finding }: { finding: AgentFinding }) {
   );
 }
 
-/** Findings as severity-sorted cards (critical → info), or an empty state. */
+/**
+ * Findings as severity-sorted cards (critical → info), or an empty state. Each
+ * card gets a stable deep-link anchor `finding-<tab>-<i>` where `i` is its index
+ * in THIS (severity-sorted) render list — the order the moderator sees, so a
+ * shared link lands on the same visible card. `highlightedId` marks the card
+ * that a deep-link just scrolled to.
+ */
 export function FindingsCards({
   findings,
   emptyLabel,
+  tab,
+  highlightedId,
 }: {
   findings: AgentFinding[];
   emptyLabel: string;
+  tab: FindingTab;
+  highlightedId?: string | null;
 }) {
   if (findings.length === 0) return <EmptyState label={emptyLabel} />;
   const sorted = sortFindingsBySeverity(findings);
   return (
     <Stack gap={6} data-testid="findings-cards">
-      {sorted.map((f, i) => (
-        <FindingCard key={i} finding={f} />
-      ))}
+      {sorted.map((f, i) => {
+        const anchorId = findingAnchorId(tab, i);
+        return (
+          <FindingCard
+            key={i}
+            finding={f}
+            anchorId={anchorId}
+            highlighted={highlightedId === anchorId}
+          />
+        );
+      })}
     </Stack>
   );
 }
@@ -270,14 +351,21 @@ export function SummaryTab({
 export function CodeReviewTab({
   codeReview,
   error,
+  highlightedId,
 }: {
   codeReview: CodeReviewView;
   error: string | null;
+  highlightedId?: string | null;
 }) {
   if (error) return <SectionFailed error={error} />;
   return (
     <Stack gap="sm">
-      <FindingsCards findings={codeReview.findings} emptyLabel="No code-review findings." />
+      <FindingsCards
+        findings={codeReview.findings}
+        emptyLabel="No code-review findings."
+        tab="code"
+        highlightedId={highlightedId}
+      />
       {codeReview.priorFindingsReconciled.length > 0 && (
         <Card withBorder padding="xs" radius="sm">
           <Text size="xs" fw={600}>
@@ -311,14 +399,21 @@ export function CodeReviewTab({
 export function SecurityAuditTab({
   securityAudit,
   error,
+  highlightedId,
 }: {
   securityAudit: SecurityAuditView;
   error: string | null;
+  highlightedId?: string | null;
 }) {
   if (error) return <SectionFailed error={error} />;
   return (
     <Stack gap="sm">
-      <FindingsCards findings={securityAudit.findings} emptyLabel="No security-audit findings." />
+      <FindingsCards
+        findings={securityAudit.findings}
+        emptyLabel="No security-audit findings."
+        tab="security"
+        highlightedId={highlightedId}
+      />
 
       {/* MUST-FLAG callouts — surfaced prominently. */}
       {securityAudit.manifestUnexpectedKeys.length > 0 && (
@@ -624,6 +719,56 @@ export function ReportTabs({
   const view = parseAgentReport(report);
   const { codeReview, securityAudit, scopeVerdicts, tokenUsage } = view;
 
+  // --- Deep-link-to-a-finding wiring -------------------------------------
+  // Controlled tabs + a transient highlight, driven off the URL hash. We read
+  // the hash directly (NOT next/router) to keep this component router-agnostic
+  // + reusable, and to sidestep the review page's route-leave navigation guard:
+  // `history.replaceState` updates the URL WITHOUT a router navigation, so the
+  // guard never fires. All window/document/history access lives inside effects
+  // and event handlers (SSR-safe).
+  const [activeTab, setActiveTab] = useState<ReportTabValue>('summary');
+  const [highlightedId, setHighlightedId] = useState<string | null>(null);
+  const highlightTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const applyHash = useCallback(() => {
+    if (typeof window === 'undefined') return;
+    const { tab, anchorId } = parseReportHash(window.location.hash);
+    if (tab) setActiveTab(tab);
+    if (anchorId) {
+      // keepMounted panels are display:none until active, so a target card
+      // can't be scrolled to until its tab is activated. Activate first (above),
+      // then scroll on the next frame once the panel is visible.
+      requestAnimationFrame(() => {
+        const el = document.getElementById(anchorId);
+        if (!el) return;
+        el.scrollIntoView({ block: 'center' });
+        setHighlightedId(anchorId);
+        if (highlightTimeout.current) clearTimeout(highlightTimeout.current);
+        highlightTimeout.current = setTimeout(() => setHighlightedId(null), 2000);
+      });
+    }
+  }, []);
+
+  useEffect(() => {
+    applyHash();
+    window.addEventListener('hashchange', applyHash);
+    return () => {
+      window.removeEventListener('hashchange', applyHash);
+      if (highlightTimeout.current) clearTimeout(highlightTimeout.current);
+    };
+  }, [applyHash]);
+
+  // Manual tab clicks reflect into the URL via history.replaceState (again, NOT
+  // a router navigation — never trips the route-leave guard, never loops since
+  // replaceState does not fire `hashchange`).
+  const handleTabChange = useCallback((value: string | null) => {
+    if (!value) return;
+    setActiveTab(value as ReportTabValue);
+    if (typeof window !== 'undefined') {
+      window.history.replaceState(null, '', `#${value}`);
+    }
+  }, []);
+
   // Structural failed-section detection runs on the RAW slots (before the
   // tolerant parse flattens an `{ error }` object to an empty section).
   const codeError = sectionAnalysisError(report.codeReview);
@@ -664,7 +809,7 @@ export function ReportTabs({
         generated from an untrusted bundle and may be manipulated.
       </Alert>
 
-      <Tabs defaultValue="summary" keepMounted>
+      <Tabs value={activeTab} onChange={handleTabChange} keepMounted>
         {/* Scrollable on narrow — the list scrolls within itself, never overflowing the page. */}
         <Tabs.List style={{ flexWrap: 'nowrap', overflowX: 'auto', overflowY: 'hidden' }}>
           <Tabs.Tab value="summary" leftSection={<IconInfoCircle size={14} />}>
@@ -690,10 +835,14 @@ export function ReportTabs({
           />
         </Tabs.Panel>
         <Tabs.Panel value="code" pt="sm">
-          <CodeReviewTab codeReview={codeReview} error={codeError} />
+          <CodeReviewTab codeReview={codeReview} error={codeError} highlightedId={highlightedId} />
         </Tabs.Panel>
         <Tabs.Panel value="security" pt="sm">
-          <SecurityAuditTab securityAudit={securityAudit} error={securityError} />
+          <SecurityAuditTab
+            securityAudit={securityAudit}
+            error={securityError}
+            highlightedId={highlightedId}
+          />
         </Tabs.Panel>
         <Tabs.Panel value="scopes" pt="sm">
           <ScopesTab scopeVerdicts={scopeVerdicts} error={scopeError} />

--- a/src/components/Apps/__tests__/agentReviewReport.test.ts
+++ b/src/components/Apps/__tests__/agentReviewReport.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from 'vitest';
 import {
   fileLineLabel,
+  findingAnchorId,
   findingBody,
   formatCostUsd,
   parseAgentReport,
+  parseReportHash,
   sectionAnalysisError,
   severityBreakdown,
   severityRank,
@@ -224,6 +226,70 @@ describe('severityBreakdown', () => {
       { evidence: [] },
     ]);
     expect(b).toEqual({ total: 8, critical: 1, high: 1, medium: 2, low: 1, info: 1, other: 2 });
+  });
+});
+
+describe('findingAnchorId', () => {
+  it('builds finding-<tab>-<index> for the two finding tabs', () => {
+    expect(findingAnchorId('code', 0)).toBe('finding-code-0');
+    expect(findingAnchorId('security', 2)).toBe('finding-security-2');
+  });
+  it('tolerates odd indices without throwing (never a hard requirement)', () => {
+    expect(findingAnchorId('code', -1)).toBe('finding-code--1');
+    expect(findingAnchorId('security', Number.NaN)).toBe('finding-security-NaN');
+  });
+});
+
+describe('parseReportHash', () => {
+  it('parses a finding anchor into { tab, anchorId }', () => {
+    expect(parseReportHash('#finding-security-2')).toEqual({
+      tab: 'security',
+      anchorId: 'finding-security-2',
+    });
+    expect(parseReportHash('#finding-code-0')).toEqual({
+      tab: 'code',
+      anchorId: 'finding-code-0',
+    });
+  });
+
+  it('tolerates a missing leading #', () => {
+    expect(parseReportHash('finding-security-1')).toEqual({
+      tab: 'security',
+      anchorId: 'finding-security-1',
+    });
+    expect(parseReportHash('code')).toEqual({ tab: 'code' });
+  });
+
+  it('parses a bare tab hash', () => {
+    expect(parseReportHash('#summary')).toEqual({ tab: 'summary' });
+    expect(parseReportHash('#code')).toEqual({ tab: 'code' });
+    expect(parseReportHash('#security')).toEqual({ tab: 'security' });
+    expect(parseReportHash('#scopes')).toEqual({ tab: 'scopes' });
+  });
+
+  it('returns {} for empty / unknown / malformed input', () => {
+    expect(parseReportHash('')).toEqual({});
+    expect(parseReportHash('#')).toEqual({});
+    expect(parseReportHash('#unknown')).toEqual({});
+    // A tab value outside the union is ignored (not a finding tab, not a bare tab).
+    expect(parseReportHash('#finding-scopes-2')).toEqual({});
+    expect(parseReportHash('#finding-summary-0')).toEqual({});
+    // Non-numeric / missing index does not match the finding anchor.
+    expect(parseReportHash('#finding-security-')).toEqual({});
+    expect(parseReportHash('#finding-security-abc')).toEqual({});
+    // A trailing suffix must not match (anchored regex).
+    expect(parseReportHash('#finding-security-2x')).toEqual({});
+    // Whitespace-only.
+    expect(parseReportHash('   ')).toEqual({});
+  });
+
+  it('round-trips findingAnchorId → parseReportHash', () => {
+    for (const tab of ['code', 'security'] as const) {
+      for (const i of [0, 1, 7, 42]) {
+        const anchorId = findingAnchorId(tab, i);
+        expect(parseReportHash(`#${anchorId}`)).toEqual({ tab, anchorId });
+      }
+    }
   });
 });
 

--- a/src/components/Apps/agentReviewReport.ts
+++ b/src/components/Apps/agentReviewReport.ts
@@ -248,6 +248,51 @@ export function severityBreakdown(findings: AgentFinding[]): SeverityBreakdown {
   return b;
 }
 
+// --- Deep-link to a finding (pure, unit-testable) --------------------------
+
+/** The report renderer's tab identifiers (in display order). */
+export type ReportTabValue = 'summary' | 'code' | 'security' | 'scopes';
+
+const REPORT_TAB_VALUES: readonly ReportTabValue[] = ['summary', 'code', 'security', 'scopes'];
+
+/** The two tabs that carry per-finding anchors (summary/scopes do not). */
+export type FindingTab = 'code' | 'security';
+
+/**
+ * The DOM id / deep-link anchor for a single finding. `index` is the finding's
+ * position in the SEVERITY-SORTED render list (the order the moderator sees), so
+ * a shared `#finding-<tab>-<index>` link lands on the same visible card.
+ */
+export function findingAnchorId(tab: FindingTab, index: number): string {
+  return `finding-${tab}-${index}`;
+}
+
+/** `finding-<code|security>-<index>` where index is a non-negative integer. */
+const FINDING_ANCHOR_RE = /^finding-(code|security)-(\d+)$/;
+
+/**
+ * Parse a report URL hash into a tab + optional finding anchor. Total and
+ * defensive — never throws on junk. Recognizes:
+ *   - `#finding-security-2` → { tab: 'security', anchorId: 'finding-security-2' }
+ *   - a bare `#code` / `#summary` / `#security` / `#scopes` → { tab }
+ *   - empty / unknown / malformed → {}
+ * Tolerates a leading `#` or none. A tab value outside the union is ignored.
+ */
+export function parseReportHash(hash: string): { tab?: ReportTabValue; anchorId?: string } {
+  if (typeof hash !== 'string') return {};
+  const raw = (hash.startsWith('#') ? hash.slice(1) : hash).trim();
+  if (!raw) return {};
+  const findingMatch = FINDING_ANCHOR_RE.exec(raw);
+  if (findingMatch) {
+    // Group 1 is 'code' | 'security', both members of the tab union.
+    return { tab: findingMatch[1] as FindingTab, anchorId: raw };
+  }
+  if ((REPORT_TAB_VALUES as readonly string[]).includes(raw)) {
+    return { tab: raw as ReportTabValue };
+  }
+  return {};
+}
+
 /**
  * Detect a FAILED analysis section. The runner persists each of
  * `codeReview` / `securityAudit` / `scopeVerdicts` verbatim; if a sub-analysis


### PR DESCRIPTION
## What

Deep-link-to-a-finding on the App Blocks agentic-review report (Phase 2.3 fast-follow). A moderator can now link to and share a specific finding:

- Landing on `/apps/review/<id>#finding-security-2` **activates the Security audit tab** and **scrolls that finding into view** with a brief, animation-free highlight.
- Each code/security finding gets a subtle one-click **"copy link"** affordance that copies the absolute deep link and reflects the anchor into the URL.

## Why

The report is tabbed (Summary | Code review | Security audit | Scopes) with one section visible at a time, so a moderator previously had no way to point a teammate at a specific finding. This makes findings addressable and shareable.

## How

- **Pure helpers** in `agentReviewReport.ts` (unit-tested): `findingAnchorId(tab, i)` and a total/defensive `parseReportHash()` that maps a URL hash to `{ tab?, anchorId? }` — tolerant of a missing `#`, unknown tabs, and malformed input (never throws).
- **Controlled tabs**: `ReportTabs` swaps `defaultValue` for controlled `value` + `onChange`, keeping `keepMounted`.
- **Hash sync WITHOUT next/router**: the renderer stays prop-only and router-agnostic — it reads `window.location.hash` in an effect, listens to `hashchange`, and writes the URL via `history.replaceState`. This is deliberate: `history.replaceState` updates the URL **without a router navigation**, so it does **not** trip the review page's route-leave navigation guard (a router `push`/`replace` would).
- **Scroll timing**: `keepMounted` panels are `display:none` until active, so a deep link activates the tab first, then scrolls the target card on the next `requestAnimationFrame` (once the panel is visible). Highlight clears after ~2s via a ref'd timeout (cleared on unmount).
- **Copy-link** uses Mantine `useClipboard` (precedent: `ApiKeyModal`) and builds the URL from `window.location` only.

### Tab / anchor scheme

- Tabs: `summary` | `code` | `security` | `scopes`.
- Anchors only on the two finding tabs: `finding-code-<i>` / `finding-security-<i>`, where `<i>` is the finding's index in the **severity-sorted render list** (the order the moderator sees), so a shared link lands on the same visible card. Summary/Scopes are not anchored.

## Safety

- All existing sanitization is intact: every finding string stays React-escaped, no `dangerouslySetInnerHTML`, no new markdown surface. The copy-link reads `window.location` only.
- SSR-safe: all `window`/`document`/`history` access is inside effects or event handlers, guarded for `typeof window`.
- **Dark / additive** — it renders inside the already-flag-gated `/apps/review/[publishRequestId]` page; no behavior change when the flag is off.

## Tests

- Node unit suite: added `findingAnchorId` + `parseReportHash` cases (valid tab+index, bare tab, missing `#`, unknown/malformed, negative/NaN index tolerated, round-trip). Suite green locally (`vitest run --project unit`).
- Browser (Vitest browser mode): `ReportTabs.browser.test.tsx` — hash `#finding-security-1` activates the Security tab, the target card carries `id="finding-security-1"`, and the copy-link affordance is present. Authored per convention; not run locally (no headless browser on the dev host).

## Verification honesty

Not verified in a real browser against the mod-gated review page (can't drive it headlessly). The DOM/interaction behavior is covered by the browser test (CI/pr-preview runs it) and still needs a human click-path check on the deployed preview. The **pr-preview typecheck and an adversarial `/audit-pr` are the real gates.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
