### PR TITLE
fix(ui): unify dropdown portal and dropzone styling conventions

### DIFF
--- a/src/components/Dialog/Common/TosViolationDialog.tsx
+++ b/src/components/Dialog/Common/TosViolationDialog.tsx
@@ -48,7 +48,6 @@ export default function TosViolationDialog({
       title={<Text className="font-semibold">{title}</Text>}
       onClose={handleCancel}
       centered
-      styles={{ content: { overflow: 'visible' } }}
     >
       <Stack>
         {message && <Text>{message}</Text>}
@@ -59,12 +58,7 @@ export default function TosViolationDialog({
           data={TOS_REASONS}
           value={violationType}
           onChange={setViolationType}
-          comboboxProps={{
-            withinPortal: false,
-            zIndex: 1000,
-            position: 'bottom',
-            middlewares: { flip: false, shift: false },
-          }}
+          comboboxProps={{ withinPortal: true, zIndex: 500 }}
           allowDeselect={false}
           searchable
           required

--- a/src/components/Image/ImageDropzone/ImageDropzone.module.scss
+++ b/src/components/Image/ImageDropzone/ImageDropzone.module.scss
@@ -1,0 +1,18 @@
+// Error border is gated on [data-idle] so Mantine's accept/reject colors still
+// show through a drag over an errored dropzone: `*.module.scss` lands in
+// @layer modules, which outranks Mantine's @layer mantine drag rules.
+.dropzone {
+  &[data-idle].error {
+    border-color: var(--mantine-color-red-6);
+  }
+
+  &[data-disabled] {
+    cursor: not-allowed;
+    background-color: light-dark(var(--mantine-color-gray-0), var(--mantine-color-dark-6));
+    border-color: light-dark(var(--mantine-color-gray-2), var(--mantine-color-dark-5));
+
+    * {
+      color: light-dark(var(--mantine-color-gray-5), var(--mantine-color-dark-3));
+    }
+  }
+}

--- a/src/components/Image/ImageDropzone/ImageDropzone.tsx
+++ b/src/components/Image/ImageDropzone/ImageDropzone.tsx
@@ -11,6 +11,7 @@ import { formatBytes } from '~/utils/number-helpers';
 import clsx from 'clsx';
 import { isOrchestratorUrl } from '~/server/common/constants';
 import { isAndroidDevice } from '~/utils/device-helpers';
+import classes from './ImageDropzone.module.scss';
 
 export function ImageDropzone({
   disabled: initialDisabled,
@@ -75,15 +76,10 @@ export function ImageDropzone({
       <Dropzone
         {...props}
         accept={accept}
-        className={clsx({
-          ['bg-gray-0 dark:bg-dark-6 border-gray-2 dark:border-dark-5 cursor-not-allowed [&_*]:text-gray-5 [&_*]:dark:text-dark-3']:
-            disabled,
+        className={clsx('flex size-full items-center justify-center', classes.dropzone, {
+          [classes.error]: hasError || !!error,
+          'mb-1': hasError || !!error,
         })}
-        classNames={{
-          root: clsx('flex size-full items-center justify-center', {
-            ['border-red-6 mb-1']: hasError || !!error,
-          }),
-        }}
         disabled={!canAddFiles || disabled}
         onDrop={handleDrop}
         onDropCapture={handleDropCapture}

--- a/src/libs/form/components/MultiSelectWrapper.tsx
+++ b/src/libs/form/components/MultiSelectWrapper.tsx
@@ -160,6 +160,8 @@ type CreatableMultiSelectProps = Omit<PillsInputProps, 'onChange'> & {
   parsePaste?: boolean;
   clearable?: boolean;
   maxValues?: number;
+  /** Set false when rendered inside a popover the dropdown must stay within */
+  withinPortal?: boolean;
 };
 
 export function CreatableMultiSelect({
@@ -171,6 +173,7 @@ export function CreatableMultiSelect({
   clearable,
   parsePaste,
   maxValues = Infinity,
+  withinPortal = true,
   ...props
 }: CreatableMultiSelectProps) {
   const combobox = useCombobox({
@@ -234,7 +237,12 @@ export function CreatableMultiSelect({
   const reachedMaxValues = value.length >= maxValues;
 
   return (
-    <Combobox store={combobox} onOptionSubmit={handleValueSelect} withinPortal={false}>
+    <Combobox
+      store={combobox}
+      onOptionSubmit={handleValueSelect}
+      withinPortal={withinPortal}
+      zIndex={500}
+    >
       <Combobox.DropdownTarget>
         <PillsInput
           {...props}


### PR DESCRIPTION
Follow-up to #3350 (dropdown clipped inside a modal) and #3348 (dropzone drag state lost to unlayered Tailwind). Both bugs have siblings elsewhere in the repo solved by different, competing idioms. This unifies three of them.

## 1. `CreatableMultiSelect` — `withinPortal={false}` in a shared form wrapper

`src/libs/form/components/MultiSelectWrapper.tsx:237` hard-coded `withinPortal={false}` on its `<Combobox>`. (Note the file name is misleading: `MultiSelectWrapper` itself never sets `withinPortal`, so it already gets Mantine's portalled default. Only `CreatableMultiSelect`, exported from the same file, was pinned unportalled.)

Now `withinPortal` defaults to `true` with `zIndex: 500` to match the #3350 convention, and is exposed as a prop so a future consumer inside a popover can opt out rather than the default being wrong for everyone.

### Consumer analysis (the review-surface question)

Only four call sites, all through `InputCreatableMultiSelect`:

| Consumer | Container | Modal / scroll clipping? | Popover (would orphan if portalled)? |
|---|---|---|---|
| `src/components/Bug/Bugs.tsx:504` | `Collapse` -> `Form` -> `Paper`, mod-only page | Yes, latent — `Collapse` applies `overflow: hidden` while collapsed/transitioning | No |
| `src/components/Changelog/Changelogs.tsx:475` | Same `Collapse` -> `Form` -> `Paper` shape | Same | No |
| `src/components/Questions/QuestionForm.tsx:145` | Page-level `Paper` in a grid column | No | No |
| `src/components/Resource/Forms/ModelVersionUpsertForm.tsx:1051` | Model/model-version wizard + `/models/[id]/model-versions/[versionId]/edit` — all page-level | No | No |

**Verdict: low risk, strictly an improvement.** No consumer renders inside a Mantine `Popover`/`HoverCard`, which is the one case where portalling actually breaks something (the dropdown escapes the popover's outside-click boundary and the popover closes under it). No consumer relies on the dropdown living inside the `form` element — `Combobox.Dropdown` here contains only option divs, no form controls, so nothing leaves the form's submission scope.

The one behavior worth naming: the field closes its dropdown on `PillsInput.Field` `onBlur`, and clicking a portalled option is outside the input's DOM subtree. That is safe — `@mantine/core`'s `ComboboxOption` calls `event.preventDefault()` in `onMouseDown` (`node_modules/@mantine/core/cjs/components/Combobox/ComboboxOption/ComboboxOption.cjs:63-66`), so the input never blurs on option click, portalled or not. This is also why Mantine's own `Select`/`MultiSelect` work portalled by default.

Two of the four consumers are inside a `Collapse`, so they had the same latent clipping bug this fixes.

## 2. `TosViolationDialog` — competing workaround idiom

`src/components/Dialog/Common/TosViolationDialog.tsx` solved the identical clipping problem with three stacked hacks instead of a portal: `styles={{ content: { overflow: 'visible' } }}` on the `Modal`, `zIndex: 1000`, and `middlewares: { flip: false, shift: false }` with `position: 'bottom'`. All three are removed in favor of `comboboxProps={{ withinPortal: true, zIndex: 500 }}`.

Verified before removing:

- **`overflow: visible`** — the modal's only children are the `Select`, a `Textarea`, and a button `Group`. Nothing else overflowed the content box, so this existed solely to let the unportalled dropdown escape. With the dropdown in a portal, restoring Mantine's default `overflow` also restores normal modal scrolling if the content ever grows.
- **`middlewares: { flip: false, shift: false }` + `position: 'bottom'`** — these were compensating for the `overflow: visible` hack, not for a real layout constraint: a flipped-up or shifted dropdown would have rendered outside the modal's painted area. Floating-UI flip/shift are the desirable defaults for a portalled dropdown near the viewport edge, so re-enabling them is the point, not a regression.
- **`zIndex: 1000`** — arbitrary. This dialog is opened through `dialogStore.trigger` (`src/components/Image/hooks/useReportTosViolation.ts:19`) and spreads `{...dialog}` from `useDialogContext()`, so its actual z-index comes from `DialogProvider.tsx:43` — `300 + index`, i.e. **300+**, not Mantine's bare `Modal` default of 200. 500 still clears it at any realistic stack depth, and matches #3350.

  One honest caveat: 500 is *below* the local idiom for moderation modals, which sit at `zIndex: 1000` (`DeleteImage.tsx:51`, `UnblockImage.tsx:55`, `collections/[collectionId]/review.tsx:181`). None of those is ever co-open with the TOS dialog today, so nothing is broken — but if a mod flow ever stacked the TOS dialog underneath one of them, the dropdown would lose. Flagging rather than pre-emptively bumping, since inventing a fourth z-index tier is what got us here.

## 3. `ImageDropzone` — unlayered Tailwind on the dropzone root

`src/components/Image/ImageDropzone/ImageDropzone.tsx` styled its root with unlayered Tailwind (`border-red-6` for error, `bg-gray-0 dark:bg-dark-6 border-gray-2 dark:border-dark-5 ...` for disabled). Tailwind utilities are unlayered in this repo (`src/styles/globals.css:23-24`), so they outrank Mantine's `@layer mantine` drag rules — exactly what broke the model-file dropzone in #3348.

This one *looks* fine today only because `ImageDropzone` uses real `image/*` / `video/*` MIME accepts, so `[data-accept]` actually resolves during drag. But the error border is unconditional once `hasError` is set, so **dragging over a dropzone that is currently showing a validation error gets no drag feedback at all** — the red Tailwind border pins it.

Fixed the #3348 way, with a CSS module (`ImageDropzone.module.scss`) — CSS modules win by layer order, not by escaping layers (`postcss.config.js:20-24` wraps `*.module.scss` in `@layer modules`; `_document.tsx:22` declares `@layer tailwind-preflight, theme, mantine, modules;`). The error border is gated on `&[data-idle]`, so Mantine's accept/reject colors take over the moment a drag starts and the red border returns when it ends. Disabled styling keys off Mantine's own `[data-disabled]` instead of a duplicated `disabled` boolean, with identical colors via `light-dark()`.

No `[data-accept]` / `[data-reject]` styling was introduced — per #3348 that idiom is unsafe for extension-based accept maps, and there is no reason to hand-reimplement what Mantine already does correctly for MIME-based ones.

## Note on `ThemeProvider`

`src/providers/ThemeProvider.tsx:35` sets `Popover.defaultProps = { withinPortal: false }` app-wide. This does **not** reach combobox dropdowns: Mantine's `Combobox` has its own `withinPortal: true` default and always passes a resolved value down to `Popover`, so the theme default is shadowed. The explicit `withinPortal: true` in these files is for clarity at the call site, not because the theme forces it. No comment in this diff claims otherwise.

## Further instances found, deliberately left alone

Listed for a future pass; not touched here to keep this diff reviewable. Most are inside filter `Popover`s where unportalled is the correct choice — they need individual judgement, not a sweep:

- `src/components/Image/Filters/MediaFiltersDropdown.tsx:356,369,380`
- `src/components/Model/Infinite/ModelFiltersDropdown.tsx:340`
- `src/components/ImageGeneration/MarkerFiltersDropdown.tsx:238,250`
- `src/components/Changelog/ChangelogFiltersDropdown.tsx:32`
- `src/components/Collections/AddToCollectionModal.tsx:151` — this one is in a **modal**, so it is a genuine latent instance of the #3350 bug
- `src/pages/moderator/images.tsx:243,250`
- `src/pages/dev/onboarding.tsx:101`
- `src/components/ClearableAutoCompleteV2/ClearableAutoCompleteV2.tsx:37`
- `src/components/EdgeMedia/EdgeVideo.tsx:406`, `src/components/Image/Detail/ImageDetailModal.tsx:55`, `src/components/Modals/UserProfileEditModal.tsx:465` — `withinPortal` on non-combobox components

One more, surfaced in review and also left for later: `ImageDropzone.tsx:79` spreads `{...props}` and *then* sets `className=`, so a consumer-passed `className` is silently dropped even though it is a typed, accepted prop. Pre-existing and no current consumer passes one — but removing the `classNames` override here means `classNames` now passes through while `className` still doesn't, which is an inconsistent trap. Fixing it would change rendered output at call sites, so it does not belong in this diff.

## Verification

`pnpm typecheck` clean (full output read, not filtered). `pnpm exec eslint` on the changed files: no issues. Prettier clean.

## What a human needs to look at

This is UI and none of it was rendered. Ordered by consequence, per review — the first two are the ones that actually need eyes.

**Highest consequence — does the `.error` class exist at runtime?**

1. Drop an **oversized image** into any `ImageDropzone` (post editor, bounty form, training images) so the size error appears. Confirm the **red border still shows** alongside the `mb-1` gap, in both themes.

   This is the single riskiest line in the diff. `.error` is declared only inside the compound selector `&[data-idle].error`. CSS Modules does export class names that appear only in compound selectors — but if it ever didn't, `classes.error` would be `undefined`, `clsx` would silently drop it, and the red border would just vanish. No type error, no test failure, no build warning. It has to be looked at.

**Highest visual risk — delivery mechanism changed underneath identical colors**

2. `ImageDropzone` **idle** appearance, **light and dark**, side by side against `main`. The colors are provably identical (the repo overrides Mantine's `dark`/`gray` palettes with byte-identical values to the Tailwind tokens), but the styles now arrive via a layered CSS module instead of unlayered Tailwind, so precedence against anything else on that root has changed. Then the **disabled** state (e.g. at max file count): grey background, grey border, dimmed text, `not-allowed` cursor.

**The behavior this actually fixes**

3. With the size error from step 1 still showing, drag a valid image over the box -> it should now turn **blue** (Mantine's accept state) and return to red on drag-away. On `main` it stays red. Also confirm a normal, non-error dropzone still shows blue on drag — unchanged.

**TosViolationDialog** (moderator "Remove as TOS Violation" on an image)

4. Violation-type dropdown opens above the modal, not clipped; search/filter works; selecting closes and populates.
5. On a short viewport it should now **flip upward** (flip is re-enabled) instead of overflowing.
6. The modal itself still looks right without `overflow: visible` — no clipped shadow, border radius, or close button.

**CreatableMultiSelect — one smoke test is enough**

7. `/moderator/bugs` (or `/moderator/changelogs`): expand the create/edit form, open the **Tags** field, add and remove a tag. Confirm the dropdown renders fully rather than being clipped by the `Collapse`.

   The fuller interaction matrix — click-option, type-filter, `+ Create`, Backspace-to-remove-pill, paste-a-list — is **cleared by code inspection** and does not need manual coverage: those are all `PillsInput.Field` handlers with no coupling to where the dropdown renders, and `ComboboxOption`'s `preventDefault()` on `onMouseDown` makes the portal boundary irrelevant to blur. Structurally immune.

8. Optional spot-check on the other two surfaces (`/questions/create` Tags, model version wizard **Trigger Words**) — for Trigger Words, confirm the `maxValues` cap (1 for textual inversion) still hides the dropdown at the cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
