### PR TITLE
feat(articles): move "not visible to public" notice into the sidebar as a centered callout

### DIFF
--- a/src/components/Article/Detail/Sidebar.tsx
+++ b/src/components/Article/Detail/Sidebar.tsx
@@ -7,6 +7,7 @@ import {
 } from '@mantine/core';
 import { useLocalStorage } from '@mantine/hooks';
 import { IconList, IconPaperclip } from '@tabler/icons-react';
+import type { ReactNode } from 'react';
 
 import { AttachmentCard } from '~/components/Article/Detail/AttachmentCard';
 import { TableOfContent } from '~/components/Article/Detail/TableOfContent';
@@ -15,7 +16,7 @@ import { useHeadingsData } from '~/hooks/useHeadingsData';
 import type { ArticleGetById } from '~/server/services/article.service';
 import utilClasses from '~/libs/helpers.module.scss';
 
-export function Sidebar({ articleId, attachments, creator }: Props) {
+export function Sidebar({ articleId, attachments, creator, hiddenNotice }: Props) {
   const { nestedHeadings } = useHeadingsData();
   const theme = useMantineTheme();
   const colorScheme = useComputedColorScheme('dark');
@@ -36,6 +37,7 @@ export function Sidebar({ articleId, attachments, creator }: Props) {
       }}
     >
       <Stack>
+        {hiddenNotice}
         {(hasAttachments || hasHeadings) && (
           <Accordion
             variant="separated"
@@ -92,4 +94,5 @@ type Props = {
   articleId: number;
   attachments: ArticleGetById['attachments'];
   creator: ArticleGetById['user'];
+  hiddenNotice?: ReactNode;
 };

--- a/src/pages/articles/[id]/[[...slug]].tsx
+++ b/src/pages/articles/[id]/[[...slug]].tsx
@@ -437,22 +437,6 @@ function ArticleDetailsPage({ id }: InferGetServerSidePropsType<typeof getServer
               </div>
             </AlertWithIcon>
           )}
-          {isOwner &&
-            (article.ingestion === ArticleIngestionStatus.Error ||
-              article.ingestion === ArticleIngestionStatus.Blocked) && (
-              <AlertWithIcon size="lg" icon={<IconAlertCircle />} color="red" iconColor="red">
-                <div>
-                  <Text fw={600} size="lg" mb="xs">
-                    This article isn&apos;t visible to the public
-                  </Text>
-                  <Text size="sm">
-                    {article.ingestion === ArticleIngestionStatus.Blocked
-                      ? 'One or more images were blocked by our content policy, so the article stays hidden from the public until the issue is resolved.'
-                      : 'Image scanning failed for one or more images (ingestion error), so the article stays hidden from the public until the scan succeeds or a moderator resolves it.'}
-                  </Text>
-                </div>
-              </AlertWithIcon>
-            )}
           {isOwner && article.ingestion && article.ingestion !== ArticleIngestionStatus.Scanned && (
             <ArticleScanStatus
               articleId={article.id}
@@ -548,6 +532,24 @@ function ArticleDetailsPage({ id }: InferGetServerSidePropsType<typeof getServer
               creator={article.user}
               attachments={article.attachments}
               articleId={article.id}
+              hiddenNotice={
+                isOwner &&
+                (article.ingestion === ArticleIngestionStatus.Error ||
+                  article.ingestion === ArticleIngestionStatus.Blocked) ? (
+                  <AlertWithIcon
+                    align="center"
+                    color="red"
+                    iconColor="red"
+                    icon={<IconAlertCircle size={28} />}
+                    title="This article isn't visible to the public"
+                    size="sm"
+                  >
+                    {article.ingestion === ArticleIngestionStatus.Blocked
+                      ? 'One or more images were blocked by our content policy, so the article stays hidden from the public until the issue is resolved.'
+                      : 'Image scanning failed for one or more images (ingestion error), so the article stays hidden from the public until the scan succeeds or a moderator resolves it.'}
+                  </AlertWithIcon>
+                ) : null
+              }
             />
           </ContainerGrid2.Col>
         </ContainerGrid2>
@@ -609,10 +611,7 @@ function ArticleOwnerRatingControls({
   // pre-fill the dispute modal with an invalid level. Owner can still open
   // the dispute modal via the inline button in that case.
   const showStaleOverrideBanner =
-    derivedRatingDroppedBelowOverride &&
-    canResubmit &&
-    derivedLevel != null &&
-    derivedLevel >= 1;
+    derivedRatingDroppedBelowOverride && canResubmit && derivedLevel != null && derivedLevel >= 1;
 
   const handleOpen = (initialSuggestedLevel?: number) => {
     openArticleRatingReviewModal({ articleId, currentLevel: nsfwLevel, initialSuggestedLevel });
@@ -640,9 +639,7 @@ function ArticleOwnerRatingControls({
       </Tooltip>
     );
   } else if (isResolved && !canResubmit) {
-    const resolvedDate = myReview!.resolvedAt
-      ? formatDate(new Date(myReview!.resolvedAt))
-      : '';
+    const resolvedDate = myReview!.resolvedAt ? formatDate(new Date(myReview!.resolvedAt)) : '';
     const statusLabel =
       myReview!.status === 'Actioned'
         ? 'approved'


### PR DESCRIPTION
Cleanup of the owner/mod ingestion-hidden notice added in #3338.

## Problem
It rendered as a full-width `AlertWithIcon` at the top of the article body. The left variant vertically-centers its icon, and the title carried a manual bottom margin — so at container width it read as a lopsided red box with a visible gap between the title and the body text.

## Change
Moved it into the **right sidebar**, above the creator card, using `AlertWithIcon`'s **centered callout** variant (circular icon over centered title + message). The narrow sidebar suits the centered style, and the callout has no title/body gap.

- Added an optional `hiddenNotice` slot to the article `Sidebar` component.
- The page passes the callout in only when `isOwner && ingestion ∈ {Error, Blocked}` — same gating as before.

Same copy, same visibility rules (owner + mods only). Visually approved.

## Testing
- `pnpm typecheck` + prettier clean.
- Reviewed live as a mod on Error-state articles (e.g. /articles/32425).

Note: a follow-up PR will overhaul the actionable scan-status flow (full rescan incl. cover, class-aware cause, mod per-image override). This PR is just the visual cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
