### PR TITLE
feat(apps): collapse moderator-removed apps into their own section on /apps/my-submissions

### DIFF
--- a/src/components/Apps/MySubmissionsList.browser.test.tsx
+++ b/src/components/Apps/MySubmissionsList.browser.test.tsx
@@ -762,6 +762,8 @@ describe('MySubmissionsList — P4 onsite owner status badge', () => {
     renderWithProviders(
       <MySubmissionsList submissions={[modRemoved()]} onWithdraw={vi.fn()} withdrawing={false} />
     );
+    // A mod-removed app now lives in its own default-collapsed section — expand it.
+    await page.getByTestId('apps-submissions-section-mod-removed-toggle').click();
     // The overridden status badge.
     await expect
       .element(page.getByText('removed by a moderator', { exact: true }))
@@ -772,6 +774,48 @@ describe('MySubmissionsList — P4 onsite owner status badge', () => {
     expect(page.getByTestId('apps-onsite-republish-gone-app').elements()).toHaveLength(0);
     expect(page.getByTestId('apps-onsite-unpublish-gone-app').elements()).toHaveLength(0);
     expect(page.getByTestId('apps-submissions-open-gone-app').elements()).toHaveLength(0);
+  });
+});
+
+describe('MySubmissionsList — mod-removed collapsed section', () => {
+  test('a moderator-removed app sits in its OWN section, collapsed by default (aria-expanded=false), NOT in Live', async () => {
+    renderWithProviders(
+      <MySubmissionsList
+        submissions={[live(), modRemoved()]}
+        onWithdraw={vi.fn()}
+        withdrawing={false}
+      />
+    );
+    // The Live app is visible (Live is always expanded); the moderator-removed app is
+    // NOT — it's in the default-collapsed "Removed by a moderator" section.
+    await expect.element(page.getByText('live-app', { exact: false })).toBeInTheDocument();
+    expect(page.getByText('gone-app', { exact: false }).elements()).toHaveLength(0);
+
+    // The section exists and its toggle starts collapsed.
+    await expect
+      .element(page.getByTestId('apps-submissions-section-mod-removed'))
+      .toBeInTheDocument();
+    const toggle = page.getByTestId('apps-submissions-section-mod-removed-toggle');
+    expect(toggle.element().getAttribute('aria-expanded')).toBe('false');
+    // The header uses the "removed by a moderator" wording.
+    await expect
+      .element(page.getByText('Removed by a moderator', { exact: false }))
+      .toBeInTheDocument();
+
+    // Expanding reveals the mod-removed app.
+    await toggle.click();
+    expect(toggle.element().getAttribute('aria-expanded')).toBe('true');
+    await expect.element(page.getByText('gone-app', { exact: false })).toBeInTheDocument();
+  });
+
+  test('an OWNER-hidden app stays in Live (never swept into the mod-removed section)', async () => {
+    renderWithProviders(
+      <MySubmissionsList submissions={[ownerHidden()]} onWithdraw={vi.fn()} withdrawing={false} />
+    );
+    // Owner-hidden is a distinct, republishable state — it keeps its Live placement
+    // (visible up-front) and the mod-removed section never renders.
+    await expect.element(page.getByText('hidden-app', { exact: false })).toBeInTheDocument();
+    expect(page.getByTestId('apps-submissions-section-mod-removed').elements()).toHaveLength(0);
   });
 });
 
@@ -820,6 +864,8 @@ describe('MySubmissionsList — P4 onsite unpublish / republish / history', () =
     renderWithProviders(
       <MySubmissionsList submissions={[modRemoved()]} onWithdraw={vi.fn()} withdrawing={false} />
     );
+    // Expand the default-collapsed moderator-removed section to reach the row.
+    await page.getByTestId('apps-submissions-section-mod-removed-toggle').click();
     await page.getByTestId('apps-onsite-history-gone-app').click();
     await expect.element(page.getByText('Reported for policy')).toBeInTheDocument();
     await expect.element(page.getByText('Delisted')).toBeInTheDocument();
@@ -861,6 +907,8 @@ describe('MySubmissionsList — P4 surfaced manage links', () => {
     renderWithProviders(
       <MySubmissionsList submissions={[modRemoved()]} onWithdraw={vi.fn()} withdrawing={false} />
     );
+    // Expand the default-collapsed moderator-removed section to reach the row.
+    await page.getByTestId('apps-submissions-section-mod-removed-toggle').click();
     await expect.element(page.getByTestId('apps-onsite-revenue-gone-app')).toBeInTheDocument();
     expect(page.getByTestId('apps-onsite-edit-gone-app').elements()).toHaveLength(0);
   });

--- a/src/components/Apps/MySubmissionsList.browser.test.tsx
+++ b/src/components/Apps/MySubmissionsList.browser.test.tsx
@@ -817,6 +817,44 @@ describe('MySubmissionsList — mod-removed collapsed section', () => {
     await expect.element(page.getByText('hidden-app', { exact: false })).toBeInTheDocument();
     expect(page.getByTestId('apps-submissions-section-mod-removed').elements()).toHaveLength(0);
   });
+
+  test('the collapsed header is an at-a-glance signal: shows the count in a RED accent while rows stay hidden', async () => {
+    // Two moderator-removed apps → the collapsed header must read "Removed by a
+    // moderator (2)" in red BEFORE expanding, with the two rows still out of the DOM.
+    const modRemoved2 = () => ({
+      ...modRemoved(),
+      id: 'm2',
+      slug: 'gone-app-2',
+      appBlockId: 'block-m2',
+      appListingId: 'l-m2',
+    });
+    renderWithProviders(
+      <MySubmissionsList
+        submissions={[live(), modRemoved(), modRemoved2()]}
+        onWithdraw={vi.fn()}
+        withdrawing={false}
+      />
+    );
+
+    const toggle = page.getByTestId('apps-submissions-section-mod-removed-toggle');
+    await expect.element(toggle).toBeInTheDocument();
+    // Collapsed by default, and both rows are hidden until expand.
+    expect(toggle.element().getAttribute('aria-expanded')).toBe('false');
+    expect(page.getByText('gone-app', { exact: false }).elements()).toHaveLength(0);
+    expect(page.getByText('gone-app-2', { exact: false }).elements()).toHaveLength(0);
+
+    // The header itself carries the label + the count (2) without expanding.
+    const headerText = toggle.element().textContent ?? '';
+    expect(headerText).toContain('Removed by a moderator');
+    expect(headerText).toContain('2');
+
+    // RED accent: the section is styled with the red/danger token — asserted via the
+    // deterministic `data-accent` (the visual `c="red"` label + red count badge need
+    // Mantine's theme CSS, which the browser-test env doesn't load, so the token is the
+    // stable signal). Ties the at-a-glance accent to the danger color, not a coincidence.
+    const section = page.getByTestId('apps-submissions-section-mod-removed');
+    expect(section.element().getAttribute('data-accent')).toBe('red');
+  });
 });
 
 describe('MySubmissionsList — P4 onsite unpublish / republish / history', () => {

--- a/src/components/Apps/MySubmissionsList.tsx
+++ b/src/components/Apps/MySubmissionsList.tsx
@@ -479,6 +479,10 @@ export function MySubmissionsList({
       ONSITE_ACCESSORS
     );
     return bucketGroupsByStatus(sorted, ONSITE_ACCESSORS.status, OWNER_STATUS_BUCKETS, (g) =>
+      // INVARIANT: the backing-listing fields (`listingStatus` + `lastModerationAction`)
+      // are keyed per APP (the single `AppListing`), not per version — the server
+      // projects the same values onto every publish-request row in the group — so
+      // reading them off `g.latest` is equivalent to reading them off any version.
       isModRemovedListing({
         listingStatus: g.latest.listingStatus,
         lastModerationAction: g.latest.lastModerationAction,

--- a/src/components/Apps/MySubmissionsList.tsx
+++ b/src/components/Apps/MySubmissionsList.tsx
@@ -24,6 +24,7 @@ import { isStaleDeploy } from '~/components/Apps/deploy-status';
 import {
   canOwnerRepublish,
   canOwnerUnpublish,
+  isModRemovedListing,
   ownerListingState,
   ownerStateChip,
   type OwnerListingState,
@@ -37,6 +38,7 @@ import {
   currentlyPublishedVersionId,
   filterGroups,
   groupSubmissionsByApp,
+  OWNER_STATUS_BUCKETS,
   sortGroups,
   toDate,
   type SubmissionAccessors,
@@ -458,9 +460,12 @@ export function MySubmissionsList({
   };
 
   // Group by app, apply the text filter, sort newest-first, then partition into
-  // status SECTIONS (Live / Pending / Rejected / Withdrawn). Status is now the
-  // section, so the column header is no longer sortable — a plain submittedAt-desc
-  // sort within each section keeps the newest request on top.
+  // status SECTIONS (Live / Pending / Rejected / Withdrawn / Removed-by-a-moderator).
+  // Status is now the section, so the column header is no longer sortable — a plain
+  // submittedAt-desc sort within each section keeps the newest request on top. The
+  // `overrideBucketOf` routes a moderator-removed listing into its own collapsed
+  // section, taking precedence over the any-approved→Live rule (a once-live app a mod
+  // took down would otherwise misfile under Live).
   const buckets = useMemo(() => {
     const grouped = groupSubmissionsByApp(
       submissions,
@@ -473,14 +478,22 @@ export function MySubmissionsList({
       { column: 'submitted', direction: 'desc' },
       ONSITE_ACCESSORS
     );
-    return bucketGroupsByStatus(sorted, ONSITE_ACCESSORS.status);
+    return bucketGroupsByStatus(sorted, ONSITE_ACCESSORS.status, OWNER_STATUS_BUCKETS, (g) =>
+      isModRemovedListing({
+        listingStatus: g.latest.listingStatus,
+        lastModerationAction: g.latest.lastModerationAction,
+      })
+        ? 'mod-removed'
+        : null
+    );
   }, [submissions, query]);
 
   const totalGroups =
     buckets.live.length +
     buckets.pending.length +
     buckets.rejected.length +
-    buckets.withdrawn.length;
+    buckets.withdrawn.length +
+    buckets['mod-removed'].length;
 
   const toggle = (identity: string) =>
     setExpanded((prev) => {

--- a/src/components/Apps/OffsiteSubmissionsList.browser.test.tsx
+++ b/src/components/Apps/OffsiteSubmissionsList.browser.test.tsx
@@ -232,6 +232,44 @@ describe('OffsiteSubmissionsList — status sections', () => {
     expect(editLink.element().getAttribute('href')).toBe('/apps/submit?edit=l-a');
   });
 
+  test('a moderator-removed listing sits in its OWN section, collapsed by default (aria-expanded=false), NOT in Live', async () => {
+    renderWithProviders(
+      <OffsiteSubmissionsList
+        submissions={[live(), modRemoved()]}
+        onWithdraw={vi.fn()}
+        withdrawing={false}
+      />
+    );
+    // Live listing is visible up-front; the moderator-removed one is hidden in its
+    // default-collapsed section.
+    await expect.element(page.getByText('live-off', { exact: false })).toBeInTheDocument();
+    expect(page.getByText('gone-off', { exact: false }).elements()).toHaveLength(0);
+
+    await expect
+      .element(page.getByTestId('apps-offsite-submissions-section-mod-removed'))
+      .toBeInTheDocument();
+    const toggle = page.getByTestId('apps-offsite-submissions-section-mod-removed-toggle');
+    expect(toggle.element().getAttribute('aria-expanded')).toBe('false');
+    await expect
+      .element(page.getByText('Removed by a moderator', { exact: false }))
+      .toBeInTheDocument();
+
+    // Expanding reveals the mod-removed listing.
+    await toggle.click();
+    expect(toggle.element().getAttribute('aria-expanded')).toBe('true');
+    await expect.element(page.getByText('gone-off', { exact: false })).toBeInTheDocument();
+  });
+
+  test('an OWNER-hidden listing stays in Live (never swept into the mod-removed section)', async () => {
+    renderWithProviders(
+      <OffsiteSubmissionsList submissions={[ownerHidden()]} onWithdraw={vi.fn()} withdrawing={false} />
+    );
+    await expect.element(page.getByText('hidden-off', { exact: false })).toBeInTheDocument();
+    expect(
+      page.getByTestId('apps-offsite-submissions-section-mod-removed').elements()
+    ).toHaveLength(0);
+  });
+
   test('the text filter narrows rows within their sections', async () => {
     renderWithProviders(
       <OffsiteSubmissionsList
@@ -313,6 +351,8 @@ describe('OffsiteSubmissionsList — owner republish vs moderator takedown (load
     renderWithProviders(
       <OffsiteSubmissionsList submissions={[modRemoved()]} onWithdraw={vi.fn()} withdrawing={false} />
     );
+    // A mod-removed listing now lives in its own default-collapsed section — expand it.
+    await page.getByTestId('apps-offsite-submissions-section-mod-removed-toggle').click();
     await expect.element(page.getByTestId('apps-offsite-mod-removed-gone-off')).toBeInTheDocument();
     // The load-bearing safety guard: NO republish affordance on a mod takedown.
     expect(page.getByTestId('apps-offsite-republish-gone-off').elements()).toHaveLength(0);
@@ -339,6 +379,8 @@ describe('OffsiteSubmissionsList — moderation history modal', () => {
     renderWithProviders(
       <OffsiteSubmissionsList submissions={[modRemoved()]} onWithdraw={vi.fn()} withdrawing={false} />
     );
+    // Expand the default-collapsed moderator-removed section to reach the row.
+    await page.getByTestId('apps-offsite-submissions-section-mod-removed-toggle').click();
     await page.getByTestId('apps-offsite-history-gone-off').click();
     // The timeline renders both events (verbatim reason + the action chip labels).
     await expect.element(page.getByText('Reported for spam')).toBeInTheDocument();

--- a/src/components/Apps/OffsiteSubmissionsList.tsx
+++ b/src/components/Apps/OffsiteSubmissionsList.tsx
@@ -26,6 +26,7 @@ import {
 import {
   canOwnerRepublish,
   canOwnerUnpublish,
+  isModRemovedListing,
   ownerListingState,
   ownerStateChip,
   type OwnerListingState,
@@ -40,6 +41,7 @@ import {
   bucketGroupsByStatus,
   filterGroups,
   groupSubmissionsByApp,
+  OWNER_STATUS_BUCKETS,
   sortGroups,
   toDate,
   type SubmissionAccessors,
@@ -418,9 +420,12 @@ export function OffsiteSubmissionsList({
     onViewHistory: (id, slug) => setHistoryTarget({ id, slug }),
   };
 
-  // Group → filter → sort newest-first → partition into status SECTIONS. Status is
-  // now the section (Live / Pending / Rejected / Withdrawn), so the header column is
-  // no longer sortable; a plain submittedAt-desc sort orders rows within a section.
+  // Group → filter → sort newest-first → partition into status SECTIONS (Live /
+  // Pending / Rejected / Withdrawn / Removed-by-a-moderator). Status is now the
+  // section, so the header column is no longer sortable; a plain submittedAt-desc sort
+  // orders rows within a section. `overrideBucketOf` routes a moderator-removed
+  // listing into its own collapsed section, taking precedence over the any-approved→
+  // Live rule (a once-live app a mod took down would otherwise misfile under Live).
   const buckets = useMemo(() => {
     const grouped = groupSubmissionsByApp(
       submissions,
@@ -433,14 +438,22 @@ export function OffsiteSubmissionsList({
       { column: 'submitted', direction: 'desc' },
       OFFSITE_ACCESSORS
     );
-    return bucketGroupsByStatus(sorted, OFFSITE_ACCESSORS.status);
+    return bucketGroupsByStatus(sorted, OFFSITE_ACCESSORS.status, OWNER_STATUS_BUCKETS, (g) =>
+      isModRemovedListing({
+        listingStatus: g.latest.appListing?.status,
+        lastModerationAction: g.latest.lastModerationAction,
+      })
+        ? 'mod-removed'
+        : null
+    );
   }, [submissions, query]);
 
   const totalGroups =
     buckets.live.length +
     buckets.pending.length +
     buckets.rejected.length +
-    buckets.withdrawn.length;
+    buckets.withdrawn.length +
+    buckets['mod-removed'].length;
 
   const toggle = (identity: string) =>
     setExpanded((prev) => {

--- a/src/components/Apps/OffsiteSubmissionsList.tsx
+++ b/src/components/Apps/OffsiteSubmissionsList.tsx
@@ -439,6 +439,10 @@ export function OffsiteSubmissionsList({
       OFFSITE_ACCESSORS
     );
     return bucketGroupsByStatus(sorted, OFFSITE_ACCESSORS.status, OWNER_STATUS_BUCKETS, (g) =>
+      // INVARIANT: the backing-listing fields (`appListing.status` + `lastModerationAction`)
+      // are keyed per APP (the single `AppListing`), not per version — the server
+      // projects the same values onto every publish-request row in the group — so
+      // reading them off `g.latest` is equivalent to reading them off any version.
       isModRemovedListing({
         listingStatus: g.latest.appListing?.status,
         lastModerationAction: g.latest.lastModerationAction,

--- a/src/components/Apps/__tests__/submissionsTable.test.ts
+++ b/src/components/Apps/__tests__/submissionsTable.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { isModRemovedListing } from '~/components/Apps/offsiteOwnerControls';
 import {
   ariaSortFor,
   bucketGroupsByStatus,
@@ -10,6 +11,7 @@ import {
   groupSubmissionsByApp,
   matchesQuery,
   nextSortState,
+  OWNER_STATUS_BUCKETS,
   sortGroups,
   statusBucket,
   statusRank,
@@ -17,6 +19,7 @@ import {
   toDate,
   type SortState,
   type SubmissionAccessors,
+  type SubmissionGroup,
 } from '~/components/Apps/submissionsTable';
 
 /**
@@ -27,6 +30,8 @@ import {
  */
 
 // A minimal row shape covering both lists' needs for these pure helpers.
+// `listingStatus` / `lastModerationAction` mirror the backing `AppListing` fields the
+// owner lists carry — they drive the `mod-removed` override (see below).
 type Row = {
   id: string;
   identity: string;
@@ -35,6 +40,8 @@ type Row = {
   status: string;
   submittedAt: string | Date | null;
   reviewedAt: string | Date | null;
+  listingStatus?: string | null;
+  lastModerationAction?: string | null;
 };
 
 const A: SubmissionAccessors<Row> = {
@@ -357,8 +364,14 @@ describe('statusBucket / bucketGroupsByStatus — status sections', () => {
     expect(statusBucket('')).toBe('withdrawn');
   });
 
-  it('the section order is Live → Pending → Rejected → Withdrawn', () => {
-    expect(STATUS_SECTION_ORDER).toEqual(['live', 'pending', 'rejected', 'withdrawn']);
+  it('the section order is Live → Pending → Rejected → Withdrawn → Removed-by-a-moderator', () => {
+    expect(STATUS_SECTION_ORDER).toEqual([
+      'live',
+      'pending',
+      'rejected',
+      'withdrawn',
+      'mod-removed',
+    ]);
   });
 
   it('buckets a never-approved group by its LATEST submission status', () => {
@@ -430,9 +443,137 @@ describe('statusBucket / bucketGroupsByStatus — status sections', () => {
     expect(buckets.pending.map((g) => g.identity)).toEqual(['p1', 'p2']);
   });
 
-  it('yields four empty buckets for no groups', () => {
+  it('yields all (empty) owner buckets for no groups', () => {
     const buckets = bucketGroupsByStatus([], A.status);
-    expect(buckets).toEqual({ live: [], pending: [], rejected: [], withdrawn: [] });
+    expect(buckets).toEqual({
+      live: [],
+      pending: [],
+      rejected: [],
+      withdrawn: [],
+      'mod-removed': [],
+    });
+  });
+});
+
+describe('bucketGroupsByStatus — mod-removed override (precedence fix)', () => {
+  // The owner lists supply this override; it reuses the REAL classifier
+  // (`isModRemovedListing` → `ownerListingState`), not a mocked shortcut, so the test
+  // pins the exact rule the UI ships: `AppListing.status='removed'` + a last
+  // moderation event that is NOT the owner's own `owner-unpublish`.
+  const modRemovedOverride = (g: SubmissionGroup<Row>): 'mod-removed' | null =>
+    isModRemovedListing({
+      listingStatus: g.latest.listingStatus,
+      lastModerationAction: g.latest.lastModerationAction,
+    })
+      ? 'mod-removed'
+      : null;
+
+  const bucketize = (rows: Row[]) =>
+    bucketGroupsByStatus(
+      groupSubmissionsByApp(rows, A.identity, A.submittedAt),
+      A.status,
+      OWNER_STATUS_BUCKETS,
+      modRemovedOverride
+    );
+
+  it('a mod-removed listing that ALSO has an approved version buckets to mod-removed, NOT live', () => {
+    // The bug this fixes: a once-live app a moderator took down (backing listing
+    // `removed`, last event a mod `delist`) has an approved version in its history, so
+    // the any-approved→Live rule would misfile it under Live. The override wins.
+    const rows = [
+      row({
+        id: 'v1',
+        identity: 'app',
+        status: 'approved',
+        submittedAt: '2026-01-01',
+      }),
+      row({
+        id: 'v2',
+        identity: 'app',
+        status: 'approved',
+        submittedAt: '2026-02-01',
+        listingStatus: 'removed',
+        lastModerationAction: 'delist',
+      }),
+    ];
+    const buckets = bucketize(rows);
+    expect(buckets['mod-removed'].map((g) => g.identity)).toEqual(['app']);
+    expect(buckets.live).toEqual([]);
+    expect(buckets.rejected).toEqual([]);
+    expect(buckets.withdrawn).toEqual([]);
+  });
+
+  it('an owner-hidden listing (last event owner-unpublish) does NOT land in mod-removed', () => {
+    // Owner-hidden stays DISTINCT + unchanged: it has an approved version, so it keeps
+    // its normal Live placement (the any-approved→Live rule), and never appears in the
+    // moderator-takedown section.
+    const rows = [
+      row({
+        id: 'v1',
+        identity: 'app',
+        status: 'approved',
+        submittedAt: '2026-01-01',
+        listingStatus: 'removed',
+        lastModerationAction: 'owner-unpublish',
+      }),
+    ];
+    const buckets = bucketize(rows);
+    expect(buckets['mod-removed']).toEqual([]);
+    expect(buckets.live.map((g) => g.identity)).toEqual(['app']);
+  });
+
+  it('rejected / withdrawn / pending groups are unchanged by the override', () => {
+    // No backing removed listing → the override returns null → the existing bucketing
+    // is untouched (a never-approved group follows its latest status).
+    const rows = [
+      row({ id: 'p', identity: 'pending-app', status: 'pending' }),
+      row({ id: 'r', identity: 'rejected-app', status: 'rejected' }),
+      row({ id: 'w', identity: 'withdrawn-app', status: 'withdrawn' }),
+    ];
+    const buckets = bucketize(rows);
+    expect(buckets.pending.map((g) => g.identity)).toEqual(['pending-app']);
+    expect(buckets.rejected.map((g) => g.identity)).toEqual(['rejected-app']);
+    expect(buckets.withdrawn.map((g) => g.identity)).toEqual(['withdrawn-app']);
+    expect(buckets['mod-removed']).toEqual([]);
+    expect(buckets.live).toEqual([]);
+  });
+
+  it('a mod-removed listing with NO recorded moderation event still buckets to mod-removed', () => {
+    // `ownerListingState` treats a `removed` listing with a null last action as a
+    // moderator takedown (a removed listing is not owner-hidden unless the last event
+    // is `owner-unpublish`), so it belongs in the section, not Live.
+    const rows = [
+      row({
+        id: 'x',
+        identity: 'app',
+        status: 'approved',
+        listingStatus: 'removed',
+        lastModerationAction: null,
+      }),
+    ];
+    const buckets = bucketize(rows);
+    expect(buckets['mod-removed'].map((g) => g.identity)).toEqual(['app']);
+    expect(buckets.live).toEqual([]);
+  });
+
+  it('WITHOUT the override, a mod-removed listing still misfiles under Live (proves the override is the fix)', () => {
+    // Mutation guard: the default call (no override) reproduces the pre-fix bug — an
+    // approved-in-history removed listing lands in Live. Only the override moves it.
+    const rows = [
+      row({
+        id: 'x',
+        identity: 'app',
+        status: 'approved',
+        listingStatus: 'removed',
+        lastModerationAction: 'delist',
+      }),
+    ];
+    const buckets = bucketGroupsByStatus(
+      groupSubmissionsByApp(rows, A.identity, A.submittedAt),
+      A.status
+    );
+    expect(buckets.live.map((g) => g.identity)).toEqual(['app']);
+    expect(buckets['mod-removed']).toEqual([]);
   });
 });
 

--- a/src/components/Apps/__tests__/submissionsTable.test.ts
+++ b/src/components/Apps/__tests__/submissionsTable.test.ts
@@ -575,6 +575,31 @@ describe('bucketGroupsByStatus — mod-removed override (precedence fix)', () =>
     expect(buckets.live.map((g: SubmissionGroup<Row>) => g.identity)).toEqual(['app']);
     expect(buckets['mod-removed']).toEqual([]);
   });
+
+  it('an in-flight update (latest pending/rejected) over an approved+mod-removed listing → mod-removed, not live', () => {
+    // The precedence must beat BOTH signals at once: the group has an approved version
+    // in history (would → Live via any-approved) AND its latest request is an in-flight
+    // pending/rejected update (would → Pending/Rejected via latest-status). Because the
+    // backing listing is a moderator takedown, the override wins over both.
+    for (const latestStatus of ['pending', 'rejected'] as const) {
+      const rows = [
+        row({ id: 'v1', identity: 'app', status: 'approved', submittedAt: '2026-01-01' }),
+        row({
+          id: 'v2',
+          identity: 'app',
+          status: latestStatus,
+          submittedAt: '2026-02-01',
+          listingStatus: 'removed',
+          lastModerationAction: 'delist',
+        }),
+      ];
+      const buckets = bucketize(rows);
+      expect(buckets['mod-removed'].map((g: SubmissionGroup<Row>) => g.identity)).toEqual(['app']);
+      expect(buckets.live).toEqual([]);
+      expect(buckets.pending).toEqual([]);
+      expect(buckets.rejected).toEqual([]);
+    }
+  });
 });
 
 describe('toDate', () => {

--- a/src/components/Apps/__tests__/submissionsTable.test.ts
+++ b/src/components/Apps/__tests__/submissionsTable.test.ts
@@ -45,12 +45,12 @@ type Row = {
 };
 
 const A: SubmissionAccessors<Row> = {
-  identity: (r) => r.identity,
-  name: (r) => r.name,
-  slug: (r) => r.slug,
-  status: (r) => r.status,
-  submittedAt: (r) => toDate(r.submittedAt),
-  reviewedAt: (r) => toDate(r.reviewedAt),
+  identity: (r: Row) => r.identity,
+  name: (r: Row) => r.name,
+  slug: (r: Row) => r.slug,
+  status: (r: Row) => r.status,
+  submittedAt: (r: Row) => toDate(r.submittedAt),
+  reviewedAt: (r: Row) => toDate(r.reviewedAt),
 };
 
 function row(overrides: Partial<Row>): Row {
@@ -139,7 +139,7 @@ describe('groupSubmissionsByApp — version collapse', () => {
     expect(groups).toHaveLength(1);
     expect(groups[0].versionCount).toBe(3);
     expect(groups[0].latest.id).toBe('v3'); // newest
-    expect(groups[0].older.map((r) => r.id)).toEqual(['v2', 'v1']); // newest-first
+    expect(groups[0].older.map((r: Row) => r.id)).toEqual(['v2', 'v1']); // newest-first
   });
 
   it('a single-version app yields one group with no older versions', () => {
@@ -160,7 +160,7 @@ describe('groupSubmissionsByApp — version collapse', () => {
       row({ id: 'a2', identity: 'alpha', submittedAt: '2026-05-01T00:00:00Z' }),
     ];
     const groups = groupSubmissionsByApp(rows, A.identity, A.submittedAt);
-    expect(groups.map((g) => g.identity)).toEqual(['bravo', 'alpha']);
+    expect(groups.map((g: SubmissionGroup<Row>) => g.identity)).toEqual(['bravo', 'alpha']);
     expect(groups[1].versionCount).toBe(2);
     expect(groups[1].latest.id).toBe('a2');
   });
@@ -175,17 +175,17 @@ describe('groupSubmissionsByApp — version collapse', () => {
     ];
     const groups = groupSubmissionsByApp(rows, A.identity, A.submittedAt);
     expect(groups).toHaveLength(2);
-    const block = groups.find((g) => g.identity === 'block-123');
+    const block = groups.find((g: SubmissionGroup<Row>) => g.identity === 'block-123');
     expect(block?.versionCount).toBe(2);
     expect(block?.latest.id).toBe('onsite-2');
-    expect(groups.find((g) => g.identity === 'my-slug')?.versionCount).toBe(1);
+    expect(groups.find((g: SubmissionGroup<Row>) => g.identity === 'my-slug')?.versionCount).toBe(1);
   });
 
   it('does not mutate the input array', () => {
     const rows = [row({ id: 'a' }), row({ id: 'b', identity: 'app', submittedAt: '2026-09-01' })];
-    const snapshot = rows.map((r) => r.id);
+    const snapshot = rows.map((r: Row) => r.id);
     groupSubmissionsByApp(rows, A.identity, A.submittedAt);
-    expect(rows.map((r) => r.id)).toEqual(snapshot);
+    expect(rows.map((r: Row) => r.id)).toEqual(snapshot);
   });
 });
 
@@ -207,7 +207,7 @@ describe('filterGroups — matches if ANY version matches', () => {
   });
 
   it('filters out a group when no version matches', () => {
-    expect(filterGroups(groups, 'Other', A).map((g) => g.identity)).toEqual(['other']);
+    expect(filterGroups(groups, 'Other', A).map((g: SubmissionGroup<Row>) => g.identity)).toEqual(['other']);
   });
 
   it('an empty query returns all groups', () => {
@@ -239,7 +239,7 @@ describe('sortGroups — by the latest version of each group', () => {
     A.submittedAt
   );
 
-  const ids = (s: SortState) => sortGroups(groups, s, A).map((g) => g.identity);
+  const ids = (s: SortState) => sortGroups(groups, s, A).map((g: SubmissionGroup<Row>) => g.identity);
 
   it('sorts by App text asc/desc', () => {
     expect(ids({ column: 'app', direction: 'asc' })).toEqual(['alpha', 'bravo']);
@@ -263,9 +263,9 @@ describe('sortGroups — by the latest version of each group', () => {
   });
 
   it('does not mutate the input group array', () => {
-    const before = groups.map((g) => g.identity);
+    const before = groups.map((g: SubmissionGroup<Row>) => g.identity);
     sortGroups(groups, { column: 'app', direction: 'desc' }, A);
-    expect(groups.map((g) => g.identity)).toEqual(before);
+    expect(groups.map((g: SubmissionGroup<Row>) => g.identity)).toEqual(before);
   });
 });
 
@@ -385,7 +385,7 @@ describe('statusBucket / bucketGroupsByStatus — status sections', () => {
       A.submittedAt
     );
     const buckets = bucketGroupsByStatus(groups, A.status);
-    expect(buckets.rejected.map((g) => g.identity)).toEqual(['app']);
+    expect(buckets.rejected.map((g: SubmissionGroup<Row>) => g.identity)).toEqual(['app']);
     expect(buckets.live).toEqual([]);
   });
 
@@ -403,7 +403,7 @@ describe('statusBucket / bucketGroupsByStatus — status sections', () => {
         A.submittedAt
       );
       const buckets = bucketGroupsByStatus(groups, A.status);
-      expect(buckets.live.map((g) => g.identity)).toEqual(['app']);
+      expect(buckets.live.map((g: SubmissionGroup<Row>) => g.identity)).toEqual(['app']);
       expect(buckets.pending).toEqual([]);
       expect(buckets.rejected).toEqual([]);
       expect(buckets.withdrawn).toEqual([]);
@@ -423,11 +423,11 @@ describe('statusBucket / bucketGroupsByStatus — status sections', () => {
       A.submittedAt
     );
     const buckets = bucketGroupsByStatus(groups, A.status);
-    expect(buckets.live.map((g) => g.identity)).toEqual(['live-app']);
-    expect(buckets.pending.map((g) => g.identity)).toEqual(['pending-app']);
-    expect(buckets.rejected.map((g) => g.identity)).toEqual(['rejected-app']);
+    expect(buckets.live.map((g: SubmissionGroup<Row>) => g.identity)).toEqual(['live-app']);
+    expect(buckets.pending.map((g: SubmissionGroup<Row>) => g.identity)).toEqual(['pending-app']);
+    expect(buckets.rejected.map((g: SubmissionGroup<Row>) => g.identity)).toEqual(['rejected-app']);
     // Unknown status ('archived') falls back into the closed Withdrawn section.
-    expect(buckets.withdrawn.map((g) => g.identity)).toEqual(['withdrawn-app', 'weird-app']);
+    expect(buckets.withdrawn.map((g: SubmissionGroup<Row>) => g.identity)).toEqual(['withdrawn-app', 'weird-app']);
   });
 
   it('preserves the incoming group order within a bucket (a pre-applied sort is kept)', () => {
@@ -440,7 +440,7 @@ describe('statusBucket / bucketGroupsByStatus — status sections', () => {
       A.submittedAt
     );
     const buckets = bucketGroupsByStatus(groups, A.status);
-    expect(buckets.pending.map((g) => g.identity)).toEqual(['p1', 'p2']);
+    expect(buckets.pending.map((g: SubmissionGroup<Row>) => g.identity)).toEqual(['p1', 'p2']);
   });
 
   it('yields all (empty) owner buckets for no groups', () => {
@@ -497,7 +497,7 @@ describe('bucketGroupsByStatus — mod-removed override (precedence fix)', () =>
       }),
     ];
     const buckets = bucketize(rows);
-    expect(buckets['mod-removed'].map((g) => g.identity)).toEqual(['app']);
+    expect(buckets['mod-removed'].map((g: SubmissionGroup<Row>) => g.identity)).toEqual(['app']);
     expect(buckets.live).toEqual([]);
     expect(buckets.rejected).toEqual([]);
     expect(buckets.withdrawn).toEqual([]);
@@ -519,7 +519,7 @@ describe('bucketGroupsByStatus — mod-removed override (precedence fix)', () =>
     ];
     const buckets = bucketize(rows);
     expect(buckets['mod-removed']).toEqual([]);
-    expect(buckets.live.map((g) => g.identity)).toEqual(['app']);
+    expect(buckets.live.map((g: SubmissionGroup<Row>) => g.identity)).toEqual(['app']);
   });
 
   it('rejected / withdrawn / pending groups are unchanged by the override', () => {
@@ -531,9 +531,9 @@ describe('bucketGroupsByStatus — mod-removed override (precedence fix)', () =>
       row({ id: 'w', identity: 'withdrawn-app', status: 'withdrawn' }),
     ];
     const buckets = bucketize(rows);
-    expect(buckets.pending.map((g) => g.identity)).toEqual(['pending-app']);
-    expect(buckets.rejected.map((g) => g.identity)).toEqual(['rejected-app']);
-    expect(buckets.withdrawn.map((g) => g.identity)).toEqual(['withdrawn-app']);
+    expect(buckets.pending.map((g: SubmissionGroup<Row>) => g.identity)).toEqual(['pending-app']);
+    expect(buckets.rejected.map((g: SubmissionGroup<Row>) => g.identity)).toEqual(['rejected-app']);
+    expect(buckets.withdrawn.map((g: SubmissionGroup<Row>) => g.identity)).toEqual(['withdrawn-app']);
     expect(buckets['mod-removed']).toEqual([]);
     expect(buckets.live).toEqual([]);
   });
@@ -552,7 +552,7 @@ describe('bucketGroupsByStatus — mod-removed override (precedence fix)', () =>
       }),
     ];
     const buckets = bucketize(rows);
-    expect(buckets['mod-removed'].map((g) => g.identity)).toEqual(['app']);
+    expect(buckets['mod-removed'].map((g: SubmissionGroup<Row>) => g.identity)).toEqual(['app']);
     expect(buckets.live).toEqual([]);
   });
 
@@ -572,7 +572,7 @@ describe('bucketGroupsByStatus — mod-removed override (precedence fix)', () =>
       groupSubmissionsByApp(rows, A.identity, A.submittedAt),
       A.status
     );
-    expect(buckets.live.map((g) => g.identity)).toEqual(['app']);
+    expect(buckets.live.map((g: SubmissionGroup<Row>) => g.identity)).toEqual(['app']);
     expect(buckets['mod-removed']).toEqual([]);
   });
 });

--- a/src/components/Apps/offsiteOwnerControls.ts
+++ b/src/components/Apps/offsiteOwnerControls.ts
@@ -47,6 +47,22 @@ export function ownerListingState(input: {
   return 'inactive';
 }
 
+/**
+ * True when a listing is a MODERATOR takedown — `AppListing.status='removed'` whose
+ * last moderation event is NOT the owner's own `owner-unpublish` (see
+ * {@link ownerListingState}). The /apps/my-submissions owner lists use this to route
+ * such a listing into its own default-collapsed "removed by a moderator" section,
+ * taking precedence over the any-approved→Live bucketing. Deliberately EXCLUDES an
+ * owner-hidden listing (last event = `owner-unpublish`), which stays Republish-able
+ * and keeps its normal (Live) placement.
+ */
+export function isModRemovedListing(input: {
+  listingStatus: string | null | undefined;
+  lastModerationAction: string | null | undefined;
+}): boolean {
+  return ownerListingState(input) === 'mod-removed';
+}
+
 /** True when the owner may unpublish (hide) the listing — only a live listing. */
 export function canOwnerUnpublish(state: OwnerListingState): boolean {
   return state === 'live';

--- a/src/components/Apps/submissionsTable.ts
+++ b/src/components/Apps/submissionsTable.ts
@@ -218,7 +218,7 @@ export function ariaSortFor(
 // ── status sections (UX pass) ──────────────────────────────────────────────────
 
 /**
- * The four status SECTIONS the /apps/my-submissions lists render, in display order.
+ * The status SECTIONS the /apps/my-submissions lists render, in display order.
  * A group is bucketed by its `latest` submission's status:
  *   - `approved` → **Live** (the row badge still distinguishes the onsite deploy
  *     sub-state building/deploying/live/failed — we DON'T split approved by it),
@@ -227,8 +227,15 @@ export function ariaSortFor(
  *   - `withdrawn` → **Withdrawn** (default-collapsed),
  *   - any other/unknown status → **Withdrawn** (a safe closed default so a future
  *     status degrades gracefully rather than vanishing).
+ *
+ * `mod-removed` is NOT derived from a submission status — it is an OVERRIDE bucket
+ * for a listing a moderator took down (backing `AppListing.status='removed'` whose
+ * last moderation event is a mod action, not the owner's own `owner-unpublish`).
+ * The caller supplies it via {@link bucketGroupsByStatus}'s `overrideBucketOf`; it
+ * takes precedence over the any-approved→Live rule so a once-live-now-removed app
+ * lands in its own default-collapsed section instead of masquerading as Live.
  */
-export type StatusBucket = 'live' | 'pending' | 'rejected' | 'withdrawn';
+export type StatusBucket = 'live' | 'pending' | 'rejected' | 'withdrawn' | 'mod-removed';
 
 /**
  * The MOD-view status buckets (Live / Pending / Rejected / **Removed** / Draft).
@@ -244,12 +251,18 @@ export type ModStatusBucket = 'live' | 'pending' | 'rejected' | 'removed' | 'dra
 /** Every bucket ANY consumer can render (owner ∪ mod) — the section-META key set. */
 export type AnyStatusBucket = StatusBucket | ModStatusBucket;
 
-/** The OWNER section render order (Live → Pending → Rejected → Withdrawn). */
+/**
+ * The OWNER section render order (Live → Pending → Rejected → Withdrawn →
+ * Removed-by-a-moderator). The moderator-takedown section sits LAST — it's the most
+ * terminal state (the owner can't self-republish), so it trails the other
+ * default-collapsed sections.
+ */
 export const STATUS_SECTION_ORDER: readonly StatusBucket[] = [
   'live',
   'pending',
   'rejected',
   'withdrawn',
+  'mod-removed',
 ];
 
 /**
@@ -352,15 +365,30 @@ export type BucketedGroups<T, B extends string = StatusBucket> = Record<
  * approved bucket by their `latest` submission's status (see the config's `bucketOf`).
  * (For the mod table each row is a single listing — one "version" — so the
  * any-approved→live rule reduces to "an `approved` listing is Live".)
+ *
+ * `overrideBucketOf` (optional) gets FIRST refusal on each group: when it returns a
+ * bucket, that wins over BOTH the any-approved→Live rule and the latest-status
+ * bucketing. The owner lists use it to route a moderator-removed listing (its backing
+ * `AppListing.status='removed'` + a non-owner last moderation event) into the
+ * `mod-removed` section even though the group still has an approved version — the fix
+ * for a taken-down-but-once-live app misfiling under Live. A bucket the config doesn't
+ * declare is ignored (defensively falls through to the default logic) so a stray
+ * override can never crash on an uninitialised key.
  */
 export function bucketGroupsByStatus<T, B extends string = StatusBucket>(
   groups: readonly SubmissionGroup<T>[],
   statusOf: (row: T) => string,
-  config: StatusBucketConfig<B> = OWNER_STATUS_BUCKETS as unknown as StatusBucketConfig<B>
+  config: StatusBucketConfig<B> = OWNER_STATUS_BUCKETS as unknown as StatusBucketConfig<B>,
+  overrideBucketOf?: (group: SubmissionGroup<T>) => B | null
 ): BucketedGroups<T, B> {
   const result = {} as BucketedGroups<T, B>;
   for (const b of config.buckets) result[b] = [];
   for (const group of groups) {
+    const override = overrideBucketOf?.(group) ?? null;
+    if (override !== null && result[override] !== undefined) {
+      result[override].push(group);
+      continue;
+    }
     const hasPublishedVersion = [group.latest, ...group.older].some(
       (v) => statusOf(v) === 'approved'
     );

--- a/src/components/Apps/submissionsTableUi.tsx
+++ b/src/components/Apps/submissionsTableUi.tsx
@@ -146,6 +146,11 @@ export const STATUS_SECTION_META: Record<
   pending: { label: 'Pending', color: 'blue', collapsible: false },
   rejected: { label: 'Rejected', color: 'red', collapsible: true },
   withdrawn: { label: 'Withdrawn', color: 'gray', collapsible: true },
+  // OWNER-view moderator-takedown section: a listing a moderator removed (distinct
+  // from the owner's own unpublish, which stays Republish-able in Live). Terminal +
+  // not self-recoverable, so it's default-COLLAPSED. Label mirrors the red
+  // `ownerStateChip` "removed by a moderator" wording.
+  'mod-removed': { label: 'Removed by a moderator', color: 'red', collapsible: true },
   // Mod-view sections (Live/Pending/Rejected reuse the entries above). `removed`
   // (the mod takedown state) stays ALWAYS-EXPANDED — a removed listing still has
   // relist/purge/claim actions a mod needs in view; `draft` is a quiet, terminal

--- a/src/components/Apps/submissionsTableUi.tsx
+++ b/src/components/Apps/submissionsTableUi.tsx
@@ -188,9 +188,13 @@ function StatusSection({
     </Badge>
   );
 
+  // `data-accent` surfaces the section's color TOKEN deterministically (the visual is
+  // the `c={color}` label + `color={color}` badge, which need Mantine's theme CSS to
+  // resolve — not loaded in the browser-test env). Tests assert this token to prove the
+  // red/danger accent without depending on computed-color resolution.
   if (!collapsible) {
     return (
-      <Stack gap="xs" data-testid={testId}>
+      <Stack gap="xs" data-testid={testId} data-accent={color}>
         <Group gap={6}>
           <Text size="sm" fw={700}>
             {label}
@@ -203,15 +207,24 @@ function StatusSection({
   }
 
   return (
-    <Stack gap="xs" data-testid={testId}>
+    <Stack gap="xs" data-testid={testId} data-accent={color}>
       <UnstyledButton
         onClick={() => setOpen((o) => !o)}
         aria-expanded={open}
         data-testid={`${testId}-toggle`}
         style={{ display: 'inline-flex', alignItems: 'center', gap: 6 }}
       >
-        {open ? <IconChevronDown size={16} /> : <IconChevronRight size={16} />}
-        <Text size="sm" fw={700}>
+        {/* Collapsible sections are the terminal/negative ones (Rejected / Withdrawn /
+            Removed-by-a-moderator). Their collapsed header adopts the section's color
+            token — chevron + label + count badge — so an owner reads e.g. "Removed by
+            a moderator (N)" in red AT A GLANCE without expanding (rows stay hidden in
+            the Collapse until opened). Mirrors the red `ownerStateChip` accent. */}
+        {open ? (
+          <IconChevronDown size={16} color={`var(--mantine-color-${color}-6)`} />
+        ) : (
+          <IconChevronRight size={16} color={`var(--mantine-color-${color}-6)`} />
+        )}
+        <Text size="sm" fw={700} c={color}>
           {label}
         </Text>
         {countBadge}


### PR DESCRIPTION
## What

On **/apps/my-submissions**, apps that a **moderator removed** now sort into their own **"Removed by a moderator"** section that is **collapsed by default** — in BOTH lists: on-site (`MySubmissionsList`) and off-site (`OffsiteSubmissionsList`).

## Bug fixed (precedence)

The owner bucketing sends *"any group with an approved version to Live"* (from #2996). A listing that was once live but is now moderator-removed still has an approved version in its history, so it **misfiled under the always-expanded Live section** — a takedown masquerading as Live. The new `mod-removed` bucket **takes precedence** over that any-approved→Live rule, so the removed app lands in its own collapsed section instead.

## How

- **New `mod-removed` owner-view bucket + default-collapsed section**, reusing the existing `STATUS_SECTION_META` / `StatusSection` convention (no hand-rolled accordion). Section order: Live → Pending → Rejected → Withdrawn → **Removed by a moderator** (most terminal, trailing). Label mirrors the red `ownerStateChip` "removed by a moderator" wording.
- `bucketGroupsByStatus` gains an optional **`overrideBucketOf`** that gets first refusal on each group and wins over *both* the any-approved→Live rule and the latest-status bucketing. Both lists supply it via the **reused** classifier (`isModRemovedListing` → `ownerListingState`), so the mod-removed rule is derived from `listingStatus` + `lastModerationAction`, not duplicated.
- **Owner-hidden** (the owner's own unpublish, Republish-able) stays **DISTINCT and UNCHANGED** — it is excluded from the section and keeps its normal Live placement.

## No backend change

Reuses `listingStatus` + `lastModerationAction` the list queries already return (`blocks.listMyPublishRequests` / `appListings.listMySubmissions`). **No tRPC/schema/migration** change — `removed` already exists. The whole surface is already author/mod-gated, so the change is additive/dark-safe (only re-bucketing existing rows).

## Tests

- **Pure unit (BLOCKING)** `submissionsTable.test.ts` — precedence fix: a mod-removed listing that *also* has an approved version buckets to `mod-removed`, NOT `live`; owner-hidden (last event `owner-unpublish`) does NOT land in the section; rejected/withdrawn/pending unchanged; a mutation guard proving that *without* the override the bug reproduces (misfiles under Live). Uses the real `ownerListingState` logic. **54 pass.**
- **Component browser (report-only)** `MySubmissionsList.browser.test.tsx` + `OffsiteSubmissionsList.browser.test.tsx` — the section renders collapsed by default (`aria-expanded=false`) and contains the mod-removed app after expansion; owner-hidden stays in Live and the section never renders; updated the existing mod-removed fixtures' assertions to expand the now-collapsed section. **49 pass.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)