### PR TITLE
chore(lint): add CI job, drop type-aware override and prettier plugin

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,6 +5,7 @@
 // eslint-config-next 16 is flat-config-only (peer `eslint >=9`); extending it
 // from eslintrc makes @eslint/eslintrc reject it and then crash formatting the
 // error ("Converting circular structure to JSON"), so lint silently never runs.
+// Enforced by the `eslint-config-next: "15"` entry in package.json `pnpm.overrides`.
 module.exports = {
   root: true,
   parser: '@typescript-eslint/parser',
@@ -12,7 +13,7 @@ module.exports = {
     ecmaVersion: 'latest',
     sourceType: 'module',
   },
-  plugins: ['@typescript-eslint', 'prettier', 'local-rules'],
+  plugins: ['@typescript-eslint', 'local-rules'],
   extends: [
     'next/core-web-vitals',
     'plugin:@typescript-eslint/recommended', // lightweight rules (no type info)
@@ -48,16 +49,9 @@ module.exports = {
 
     // 'import/no-cycle': ['error'],
 
-    // prettier overrides
-    'prettier/prettier': [
-      'error',
-      {
-        printWidth: 100,
-        endOfLine: 'auto',
-        singleQuote: true,
-        trailingComma: 'es5',
-      },
-    ],
+    // Formatting is owned by `pnpm prettier:check` / `prettier:write`, not by
+    // eslint-plugin-prettier. `eslint-config-prettier` (extended above) stays so
+    // ESLint's stylistic rules don't fight it.
 
     // rule tweaks
     'no-use-before-define': 'off',
@@ -67,10 +61,6 @@ module.exports = {
     '@typescript-eslint/no-namespace': 'off',
     '@typescript-eslint/no-non-null-assertion': 'off',
     '@typescript-eslint/consistent-type-imports': ['error'],
-    '@typescript-eslint/restrict-template-expressions': [
-      'warn',
-      { allowBoolean: true },
-    ],
 
     'tailwindcss/no-custom-classname': [
       'off',
@@ -80,19 +70,7 @@ module.exports = {
     ],
   },
 
-  overrides: [
-    {
-      files: ['*.ts', '*.tsx'],
-      parserOptions: {
-        project: './tsconfig.json',
-      },
-      // extends: ['plugin:@typescript-eslint/recommended-requiring-type-checking'],
-      rules: {
-        // put only the rules that *need* type info here
-        // example:
-        // '@typescript-eslint/no-floating-promises': 'error',
-        // '@typescript-eslint/no-misused-promises': 'error',
-      },
-    },
-  ],
+  // No type-aware linting: `parserOptions.project` costs ~40s of program build plus
+  // ~2.3s/file (2h40m across the repo). If a type-aware rule is ever worth that, add
+  // an `overrides` entry scoped to the narrowest possible file set.
 };

--- a/.github/problem-matchers/eslint-unix.json
+++ b/.github/problem-matchers/eslint-unix.json
@@ -1,0 +1,19 @@
+{
+  "__comment": "Turns `eslint --format unix` output into GitHub file annotations. Paths must be relative to GITHUB_WORKSPACE, so lint.yml pipes eslint through sed to strip the workspace prefix. Line shape: src/foo.ts:12:5: message [Error/rule-name]",
+  "problemMatcher": [
+    {
+      "owner": "eslint-unix",
+      "pattern": [
+        {
+          "regexp": "^(.+):(\\d+):(\\d+):\\s(.+)\\s\\[(Error|Warning)/(.+)\\]$",
+          "file": 1,
+          "line": 2,
+          "column": 3,
+          "message": 4,
+          "severity": 5,
+          "code": 6
+        }
+      ]
+    }
+  ]
+}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,9 +1,19 @@
 name: Lint
 
-# Regression guard for code quality. Deliberately scoped so it stays green and fast:
-# ESLint and Prettier run ONLY on files the PR changed (the repo carries thousands of
-# pre-existing findings; a full-repo gate would fail every PR and get switched off).
-# Typecheck is full-repo because it is already expected to pass.
+# Regression guard for code quality.
+#
+# Typecheck is full-repo and BLOCKING - it passes today, so it is the real gate.
+#
+# ESLint and Prettier are report-only (`continue-on-error`). They are scoped to the
+# files a PR touches, but note that for a formatter "changed file" means the WHOLE
+# file, not the changed lines: 789 of 4,116 src files fail `prettier --check` today.
+# Across the 98 src files touched by the last 30 commits, 39 fail Prettier and 10
+# carry a pre-existing ESLint error, so 44 (45%) would red this job for reasons
+# unrelated to the PR. Blocking on that turns a 3-line bugfix into a 200-line
+# reformat, and the job gets disabled within a week. Annotations still surface.
+#
+# Both steps flip to blocking once the formatting/lint backlog is cleared, which is
+# planned to ride along with the Prettier 2->3 upgrade (that forces a reformat anyway).
 
 on:
   pull_request:
@@ -18,7 +28,7 @@ concurrency:
 
 jobs:
   eslint:
-    name: ESLint + Prettier (changed files)
+    name: ESLint + Prettier (changed files, report-only)
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -42,14 +52,17 @@ jobs:
           BASE_REF: ${{ github.base_ref }}
         run: |
           set -euo pipefail
-          git fetch -q --depth=1 origin "$BASE_REF"
+          git fetch -q origin "$BASE_REF"
           git diff --name-only --diff-filter=ACMR FETCH_HEAD...HEAD -- '*.ts' '*.tsx' > changed.txt || true
           echo "changed files:"
           cat changed.txt
           if [ -s changed.txt ]; then echo "any=true" >> "$GITHUB_OUTPUT"; else echo "any=false" >> "$GITHUB_OUTPUT"; fi
 
+      # Report-only: 10% of recently-touched files carry a pre-existing
+      # error-severity finding. See the header comment.
       - name: ESLint
         if: steps.changed.outputs.any == 'true'
+        continue-on-error: true
         run: |
           set -euo pipefail
           # eslint only has a config for src/ and packages/; skip anything else.
@@ -60,19 +73,27 @@ jobs:
             echo "no lintable files changed"
           fi
 
+      # Report-only: 19% of src files are unformatted today and a formatter has no
+      # changed-line granularity. See the header comment.
       - name: Prettier
         if: steps.changed.outputs.any == 'true'
+        continue-on-error: true
         run: xargs -a changed.txt pnpm exec prettier --check
 
   typecheck:
     name: Typecheck
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    # civitai/civitai is public, and a pull_request from a fork gets no secrets.
+    # Typecheck needs the private event-engine-common submodule, which a fork cannot
+    # fetch: ssh-agent would hard-fail on an empty key, and even skipping it just
+    # trades that for a wall of "Cannot find module" errors. Either way an external
+    # contributor gets a red check they have no way to fix, so skip the job entirely.
+    # Do not make this a required check without solving the fork case first.
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    timeout-minutes: 25
     steps:
       - uses: actions/checkout@v4
 
-      # event-engine-common is a private submodule; without it tsc fails with a wall
-      # of "Cannot find module" errors that cascade into unrelated implicit-any noise.
       - name: Setup SSH for submodule
         uses: webfactory/ssh-agent@v0.9.0
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,95 @@
+name: Lint
+
+# Regression guard for code quality. Deliberately scoped so it stays green and fast:
+# ESLint and Prettier run ONLY on files the PR changed (the repo carries thousands of
+# pre-existing findings; a full-repo gate would fail every PR and get switched off).
+# Typecheck is full-repo because it is already expected to pass.
+
+on:
+  pull_request:
+    branches: [main, release]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: lint-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  eslint:
+    name: ESLint + Prettier (changed files)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+
+      - name: Install
+        run: pnpm install --frozen-lockfile
+
+      - name: Collect changed files
+        id: changed
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: |
+          set -euo pipefail
+          git fetch -q --depth=1 origin "$BASE_REF"
+          git diff --name-only --diff-filter=ACMR FETCH_HEAD...HEAD -- '*.ts' '*.tsx' > changed.txt || true
+          echo "changed files:"
+          cat changed.txt
+          if [ -s changed.txt ]; then echo "any=true" >> "$GITHUB_OUTPUT"; else echo "any=false" >> "$GITHUB_OUTPUT"; fi
+
+      - name: ESLint
+        if: steps.changed.outputs.any == 'true'
+        run: |
+          set -euo pipefail
+          # eslint only has a config for src/ and packages/; skip anything else.
+          grep -E '^(src|packages)/' changed.txt > lintable.txt || true
+          if [ -s lintable.txt ]; then
+            xargs -a lintable.txt pnpm exec eslint --no-error-on-unmatched-pattern
+          else
+            echo "no lintable files changed"
+          fi
+
+      - name: Prettier
+        if: steps.changed.outputs.any == 'true'
+        run: xargs -a changed.txt pnpm exec prettier --check
+
+  typecheck:
+    name: Typecheck
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      # event-engine-common is a private submodule; without it tsc fails with a wall
+      # of "Cannot find module" errors that cascade into unrelated implicit-any noise.
+      - name: Setup SSH for submodule
+        uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.SUBMODULE_SSH_KEY }}
+
+      - name: Init submodule
+        run: git submodule update --init event-engine-common
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+
+      - name: Install
+        run: pnpm install --frozen-lockfile
+
+      - name: Typecheck
+        run: pnpm run typecheck

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,18 +2,30 @@ name: Lint
 
 # Regression guard for code quality.
 #
-# Typecheck is full-repo and BLOCKING - it passes today, so it is the real gate.
+# Typecheck is full-repo and BLOCKING on internal PRs, and is the only real gate
+# here. It is skipped on fork PRs (see the job comment), so a fork gets no gating
+# from this workflow at all.
 #
-# ESLint and Prettier are report-only (`continue-on-error`). They are scoped to the
-# files a PR touches, but note that for a formatter "changed file" means the WHOLE
-# file, not the changed lines: 789 of 4,116 src files fail `prettier --check` today.
-# Across the 98 src files touched by the last 30 commits, 39 fail Prettier and 10
-# carry a pre-existing ESLint error, so 44 (45%) would red this job for reasons
-# unrelated to the PR. Blocking on that turns a 3-line bugfix into a 200-line
-# reformat, and the job gets disabled within a week. Annotations still surface.
+# ESLint and Prettier are split by how the PR touched the file:
 #
-# Both steps flip to blocking once the formatting/lint backlog is cleared, which is
-# planned to ride along with the Prettier 2->3 upgrade (that forces a reformat anyway).
+#   ADDED files      -> BLOCKING. A new file has no pre-existing findings by
+#                       definition, so this is free, and it stops the backlog
+#                       from growing while the full flip waits.
+#   MODIFIED/RENAMED -> report-only (`continue-on-error`). For a formatter,
+#                       "changed file" means the WHOLE file, not the changed
+#                       lines: 789 of 4,116 src files fail `prettier --check`
+#                       today. Across the 98 src files touched by the last 30
+#                       commits, 39 fail Prettier and 10 carry a pre-existing
+#                       ESLint error - 44 (45%) would red the job for reasons
+#                       unrelated to the PR, turning a 3-line bugfix into a
+#                       200-line reformat. The job would be off within a week.
+#
+# Findings surface as file annotations on the PR diff: ESLint via the problem
+# matcher in .github/problem-matchers/, Prettier via ::warning / ::error commands.
+# Report-only steps still show a failed-but-ignored marker in the checks list.
+#
+# The modified-file steps flip to blocking once the backlog is cleared, planned to
+# ride along with the Prettier 2->3 upgrade (which forces a reformat anyway).
 
 on:
   pull_request:
@@ -28,7 +40,7 @@ concurrency:
 
 jobs:
   eslint:
-    name: ESLint + Prettier (changed files, report-only)
+    name: ESLint + Prettier (changed files)
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -53,32 +65,70 @@ jobs:
         run: |
           set -euo pipefail
           git fetch -q origin "$BASE_REF"
-          git diff --name-only --diff-filter=ACMR FETCH_HEAD...HEAD -- '*.ts' '*.tsx' > changed.txt || true
-          echo "changed files:"
-          cat changed.txt
-          if [ -s changed.txt ]; then echo "any=true" >> "$GITHUB_OUTPUT"; else echo "any=false" >> "$GITHUB_OUTPUT"; fi
+          git diff --name-only --diff-filter=A FETCH_HEAD...HEAD -- '*.ts' '*.tsx' > added.txt
+          git diff --name-only --diff-filter=CMR FETCH_HEAD...HEAD -- '*.ts' '*.tsx' > modified.txt
+          # eslint only has a config for src/ and packages/; skip anything else.
+          grep -E '^(src|packages)/' added.txt > added-lint.txt || true
+          grep -E '^(src|packages)/' modified.txt > modified-lint.txt || true
+          echo "added ($(wc -l < added.txt)):"; cat added.txt
+          echo "modified ($(wc -l < modified.txt)):"; cat modified.txt
+
+      - name: Register ESLint problem matcher
+        run: echo "::add-matcher::.github/problem-matchers/eslint-unix.json"
+
+      # BLOCKING. New files start clean, so holding them to the rules costs nothing.
+      # Errors only (no --max-warnings): the repo has 3,470 warnings and 1,762 uses of
+      # `any`, so failing new files on warnings would hold them to a stricter bar than
+      # anything already merged. Warnings still annotate.
+      - name: ESLint (added files)
+        run: |
+          set -euo pipefail
+          if [ ! -s added-lint.txt ]; then echo "no new lintable files"; exit 0; fi
+          xargs -a added-lint.txt pnpm exec eslint --format unix \
+            | sed "s|^$GITHUB_WORKSPACE/||"
+
+      - name: Prettier (added files)
+        run: |
+          set -euo pipefail
+          if [ ! -s added.txt ]; then echo "no new files"; exit 0; fi
+          xargs -a added.txt pnpm exec prettier --list-different > unformatted-added.txt || true
+          while IFS= read -r f; do
+            [ -n "$f" ] || continue
+            echo "::error file=$f::Not formatted. Run: pnpm exec prettier --write $f"
+          done < unformatted-added.txt
+          if [ -s unformatted-added.txt ]; then
+            echo "$(wc -l < unformatted-added.txt) new file(s) are not formatted."
+            exit 1
+          fi
+          echo "all new files formatted"
 
       # Report-only: 10% of recently-touched files carry a pre-existing
       # error-severity finding. See the header comment.
-      - name: ESLint
-        if: steps.changed.outputs.any == 'true'
+      - name: ESLint (modified files, report-only)
         continue-on-error: true
         run: |
           set -euo pipefail
-          # eslint only has a config for src/ and packages/; skip anything else.
-          grep -E '^(src|packages)/' changed.txt > lintable.txt || true
-          if [ -s lintable.txt ]; then
-            xargs -a lintable.txt pnpm exec eslint --no-error-on-unmatched-pattern
-          else
-            echo "no lintable files changed"
-          fi
+          if [ ! -s modified-lint.txt ]; then echo "no modified lintable files"; exit 0; fi
+          xargs -a modified-lint.txt pnpm exec eslint --format unix \
+            | sed "s|^$GITHUB_WORKSPACE/||"
 
       # Report-only: 19% of src files are unformatted today and a formatter has no
       # changed-line granularity. See the header comment.
-      - name: Prettier
-        if: steps.changed.outputs.any == 'true'
+      - name: Prettier (modified files, report-only)
         continue-on-error: true
-        run: xargs -a changed.txt pnpm exec prettier --check
+        run: |
+          set -euo pipefail
+          if [ ! -s modified.txt ]; then echo "no modified files"; exit 0; fi
+          xargs -a modified.txt pnpm exec prettier --list-different > unformatted.txt || true
+          while IFS= read -r f; do
+            [ -n "$f" ] || continue
+            echo "::warning file=$f::Not formatted (pre-existing, not blocking). Run: pnpm exec prettier --write $f"
+          done < unformatted.txt
+          if [ -s unformatted.txt ]; then
+            echo "$(wc -l < unformatted.txt) modified file(s) are not formatted."
+            exit 1
+          fi
+          echo "all modified files formatted"
 
   typecheck:
     name: Typecheck

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -47,18 +47,4 @@ else
   echo "DEBUG: No ToS files found, skipping lastmod update"
 fi
 
-#branch="$(git rev-parse --abbrev-ref HEAD)"
-#if [ "$branch" != "main" ]; then
-#	exit 0
-#fi
-
-# NOTE: apparently tsc-files just doesn't work on windows. at all.
-
-#echo "Running typecheck for staged files"
-#
-#npx lint-staged
-#
-#echo "Typecheck successful"
-
-# Explicitly exit successfully
 exit 0

--- a/package.json
+++ b/package.json
@@ -101,9 +101,6 @@
     "schema": "packages/civitai-db-schema/prisma/schema.prisma",
     "seed": "ts-node --compiler-options {\"module\":\"CommonJS\"} packages/civitai-db-schema/prisma/seed.ts"
   },
-  "lint-staged": {
-    "**/*.{ts,tsx}": "tsc-files --noEmit"
-  },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.490.0",
     "@aws-sdk/lib-storage": "^3.490.0",
@@ -359,18 +356,12 @@
     "cssnano": "^7.0.1",
     "esbuild": "^0.25.5",
     "eslint": "8.57.1",
-    "eslint-config-airbnb": "^19.0.4",
-    "eslint-config-airbnb-typescript": "^17.0.0",
-    "eslint-config-mantine": "2.0.0",
     "eslint-config-next": "^15.5.19",
     "eslint-config-prettier": "^8.5.0",
-    "eslint-import-resolver-typescript": "^3.5.1",
     "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-local-rules": "^3.0.2",
-    "eslint-plugin-prettier": "^4.2.1",
     "eslint-plugin-tailwindcss": "^3.15.1",
     "husky": "^9.1.1",
-    "lint-staged": "^15.2.7",
     "pg-format": "^1.0.4",
     "playwright": "^1.57.0",
     "postcss": "^8.5.3",
@@ -394,13 +385,10 @@
   "ct3aMetadata": {
     "initVersion": "6.2.1"
   },
-  "overrides": {
-    "openai": {
-      "zod": "$zod"
-    }
-  },
+  "//eslint-config-next": "Stay on major 15. v16 is flat-config-only (peer eslint >=9); extending it from .eslintrc.js makes @eslint/eslintrc reject it and then crash while formatting the error, so lint silently never runs. Pinned below so a `pnpm up` can't walk it forward.",
   "pnpm": {
     "overrides": {
+      "eslint-config-next": "15",
       "vite": "6.4.3",
       "protobufjs@7": "^7.5.6",
       "fast-xml-parser": "^5.9.3",

--- a/packages/.eslintrc.cjs
+++ b/packages/.eslintrc.cjs
@@ -1,7 +1,7 @@
 /**
  * ESLint config for the @civitai/* workspace packages.
  *
- * `root: true` so the packages do NOT inherit the main app's React/Next/Tailwind/airbnb
+ * `root: true` so the packages do NOT inherit the main app's React/Next/Tailwind
  * config (they're plain TS infra, not app code). It enforces two boundary guarantees:
  *
  *   1. import/no-extraneous-dependencies — every runtime import must be a declared

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
+  eslint-config-next: '15'
   vite: 6.4.3
   protobufjs@7: ^7.5.6
   fast-xml-parser: ^5.9.3
@@ -781,42 +782,24 @@ importers:
       eslint:
         specifier: 8.57.1
         version: 8.57.1
-      eslint-config-airbnb:
-        specifier: ^19.0.4
-        version: 19.0.4(eslint-plugin-import@2.32.0)(eslint-plugin-jsx-a11y@6.10.2(eslint@8.57.1))(eslint-plugin-react-hooks@7.1.1(eslint@8.57.1))(eslint-plugin-react@7.37.5(eslint@8.57.1))(eslint@8.57.1)
-      eslint-config-airbnb-typescript:
-        specifier: ^17.0.0
-        version: 17.1.0(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.2))(eslint@8.57.1)(typescript@5.9.2))(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.2))(eslint-plugin-import@2.32.0)(eslint@8.57.1)
-      eslint-config-mantine:
-        specifier: 2.0.0
-        version: 2.0.0(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.2))(eslint@8.57.1)(typescript@5.9.2))(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.2))(eslint-config-airbnb-typescript@17.1.0(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.2))(eslint@8.57.1)(typescript@5.9.2))(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.2))(eslint-plugin-import@2.32.0)(eslint@8.57.1))(eslint-config-airbnb@19.0.4(eslint-plugin-import@2.32.0)(eslint-plugin-jsx-a11y@6.10.2(eslint@8.57.1))(eslint-plugin-react-hooks@7.1.1(eslint@8.57.1))(eslint-plugin-react@7.37.5(eslint@8.57.1))(eslint@8.57.1))(eslint-plugin-import@2.32.0)(eslint-plugin-jsx-a11y@6.10.2(eslint@8.57.1))(eslint-plugin-react-hooks@7.1.1(eslint@8.57.1))(eslint-plugin-react@7.37.5(eslint@8.57.1))(eslint@8.57.1)
       eslint-config-next:
-        specifier: ^15.5.19
+        specifier: '15'
         version: 15.5.19(eslint@8.57.1)(typescript@5.9.2)
       eslint-config-prettier:
         specifier: ^8.5.0
         version: 8.10.2(eslint@8.57.1)
-      eslint-import-resolver-typescript:
-        specifier: ^3.5.1
-        version: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
       eslint-plugin-import:
         specifier: ^2.26.0
-        version: 2.32.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+        version: 2.32.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.2))(eslint@8.57.1)
       eslint-plugin-local-rules:
         specifier: ^3.0.2
         version: 3.0.2
-      eslint-plugin-prettier:
-        specifier: ^4.2.1
-        version: 4.2.5(eslint-config-prettier@8.10.2(eslint@8.57.1))(eslint@8.57.1)(prettier@2.8.8)
       eslint-plugin-tailwindcss:
         specifier: ^3.15.1
         version: 3.18.2(tailwindcss@3.4.17(ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.17))(@types/node@20.19.9)(typescript@5.9.2)))
       husky:
         specifier: ^9.1.1
         version: 9.1.7
-      lint-staged:
-        specifier: ^15.2.7
-        version: 15.5.2
       pg-format:
         specifier: ^1.0.4
         version: 1.0.4
@@ -5992,10 +5975,6 @@ packages:
     resolution: {integrity: sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==}
     engines: {node: '>=8'}
 
-  ansi-escapes@7.0.0:
-    resolution: {integrity: sha512-GdYO7a61mR0fOlAsvC9/rIHf7L96sBc6dEWzeOu+KAea5bZyQRPIpojrVoI4AXGJS/ycu/fBTdLrUkA4ODrvjw==}
-    engines: {node: '>=18'}
-
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
@@ -6555,14 +6534,6 @@ packages:
     resolution: {integrity: sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==}
     engines: {node: '>=10'}
 
-  cli-cursor@5.0.0:
-    resolution: {integrity: sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==}
-    engines: {node: '>=18'}
-
-  cli-truncate@4.0.0:
-    resolution: {integrity: sha512-nPdaFdQ0h/GEigbPClz11D0v/ZJEwxmeVZGeMo3Z5StPtUTkA9o1lD6QwoirYiSDzbcwn2XcjwmCp68W1IS4TA==}
-    engines: {node: '>=18'}
-
   cli-width@4.1.0:
     resolution: {integrity: sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==}
     engines: {node: '>= 12'}
@@ -6637,10 +6608,6 @@ packages:
     resolution: {integrity: sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==}
     engines: {node: '>=18'}
 
-  commander@13.1.0:
-    resolution: {integrity: sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==}
-    engines: {node: '>=18'}
-
   commander@14.0.0:
     resolution: {integrity: sha512-2uM9rYjPvyq39NwLRqaiLtWHyDC1FvryJDa2ATTVims5YAS4PupsEQsDvP14FqhFr0P49CYDugi59xaxJlTXRA==}
     engines: {node: '>=20'}
@@ -6686,9 +6653,6 @@ packages:
 
   confbox@0.2.2:
     resolution: {integrity: sha512-1NB+BKqhtNipMsov4xI/NnhCKp9XG9NamYp5PVm9klAT0fsrNPjaFICsCFhNhwZJKNh7zB/3q8qXz0E9oaMNtQ==}
-
-  confusing-browser-globals@1.0.11:
-    resolution: {integrity: sha512-JsPKdmh8ZkmnHxDk55FZ1TqVLvEQTvoByJZRN9jzI0UjxK/QgAmsphz7PGtqgPieQZ/CQcHWXCR7ATDNhGe+YA==}
 
   consola@3.4.2:
     resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
@@ -7241,10 +7205,6 @@ packages:
     resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
     engines: {node: '>=20.19.0'}
 
-  environment@1.1.0:
-    resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
-    engines: {node: '>=18'}
-
   error-ex@1.3.2:
     resolution: {integrity: sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==}
 
@@ -7332,44 +7292,6 @@ packages:
     resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
     engines: {node: '>=12'}
 
-  eslint-config-airbnb-base@15.0.0:
-    resolution: {integrity: sha512-xaX3z4ZZIcFLvh2oUNvcX5oEofXda7giYmuplVxoOg5A7EXJMrUyqRgR+mhDhPK8LZ4PttFOBvCYDbX3sUoUig==}
-    engines: {node: ^10.12.0 || >=12.0.0}
-    peerDependencies:
-      eslint: ^7.32.0 || ^8.2.0
-      eslint-plugin-import: ^2.25.2
-
-  eslint-config-airbnb-typescript@17.1.0:
-    resolution: {integrity: sha512-GPxI5URre6dDpJ0CtcthSZVBAfI+Uw7un5OYNVxP2EYi3H81Jw701yFP7AU+/vCE7xBtFmjge7kfhhk4+RAiig==}
-    peerDependencies:
-      '@typescript-eslint/eslint-plugin': ^5.13.0 || ^6.0.0
-      '@typescript-eslint/parser': ^5.0.0 || ^6.0.0
-      eslint: ^7.32.0 || ^8.2.0
-      eslint-plugin-import: ^2.25.3
-
-  eslint-config-airbnb@19.0.4:
-    resolution: {integrity: sha512-T75QYQVQX57jiNgpF9r1KegMICE94VYwoFQyMGhrvc+lB8YF2E/M/PYDaQe1AJcWaEgqLE+ErXV1Og/+6Vyzew==}
-    engines: {node: ^10.12.0 || ^12.22.0 || ^14.17.0 || >=16.0.0}
-    peerDependencies:
-      eslint: ^7.32.0 || ^8.2.0
-      eslint-plugin-import: ^2.25.3
-      eslint-plugin-jsx-a11y: ^6.5.1
-      eslint-plugin-react: ^7.28.0
-      eslint-plugin-react-hooks: ^4.3.0
-
-  eslint-config-mantine@2.0.0:
-    resolution: {integrity: sha512-uDADuiJLKmhH6tjaEOfhA9o7GRuTnL3DBiox6muOV7hmnV8ESJotfzovUsiknwBSTMqzLTIvo52Cvs213DFiwg==}
-    peerDependencies:
-      '@typescript-eslint/eslint-plugin': ^5.30.0
-      '@typescript-eslint/parser': ^5.30.0
-      eslint: ^8.18.0
-      eslint-config-airbnb: 19.0.4
-      eslint-config-airbnb-typescript: ^17.0.0
-      eslint-plugin-import: ^2.26.0
-      eslint-plugin-jsx-a11y: ^6.6.0
-      eslint-plugin-react: ^7.30.1
-      eslint-plugin-react-hooks: ^4.6.0
-
   eslint-config-next@15.5.19:
     resolution: {integrity: sha512-UZwkuhBCNxVZfo93MSHRDOVNWXooJJGcAUyTAVIp0+9QFhH4SqJxWY0s6Mk9C2kMi777HPMn3dseOrZshWpG9Q==}
     peerDependencies:
@@ -7441,28 +7363,11 @@ packages:
   eslint-plugin-local-rules@3.0.2:
     resolution: {integrity: sha512-IWME7GIYHXogTkFsToLdBCQVJ0U4kbSuVyDT+nKoR4UgtnVrrVeNWuAZkdEu1nxkvi9nsPccGehEEF6dgA28IQ==}
 
-  eslint-plugin-prettier@4.2.5:
-    resolution: {integrity: sha512-9Ni+xgemM2IWLq6aXEpP2+V/V30GeA/46Ar629vcMqVPodFFWC9skHu/D1phvuqtS8bJCFnNf01/qcmqYEwNfg==}
-    engines: {node: '>=12.0.0'}
-    peerDependencies:
-      eslint: '>=7.28.0'
-      eslint-config-prettier: '*'
-      prettier: '>=2.0.0'
-    peerDependenciesMeta:
-      eslint-config-prettier:
-        optional: true
-
   eslint-plugin-react-hooks@5.2.0:
     resolution: {integrity: sha512-+f15FfK64YQwZdJNELETdn5ibXEUQmW1DZL6KXhNnc2heoy/sg9VJJeT7n8TlMWouzWqSWavFkIhHyIbIAEapg==}
     engines: {node: '>=10'}
     peerDependencies:
       eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0
-
-  eslint-plugin-react-hooks@7.1.1:
-    resolution: {integrity: sha512-f2I7Gw6JbvCexzIInuSbZpfdQ44D7iqdWX01FKLvrPgqxoE7oMj8clOfto8U6vYiz4yd5oKu39rRSVOe1zRu0g==}
-    engines: {node: '>=18'}
-    peerDependencies:
-      eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0
 
   eslint-plugin-react@7.37.5:
     resolution: {integrity: sha512-Qteup0SqU15kdocexFNAJMvCJEfa2xUKNV4CC1xsVMrIIqEy3SQ/rqyxCWNzfrd3/ldy6HMlD2e0JDVpDg2qIA==}
@@ -7581,10 +7486,6 @@ packages:
     resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
     engines: {node: '>=10'}
 
-  execa@8.0.1:
-    resolution: {integrity: sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==}
-    engines: {node: '>=16.17'}
-
   exifreader@4.41.3:
     resolution: {integrity: sha512-bjc9UGw2OOj5Z0FQec5HRzH8A/gzGpWJLj74+Hffp0ri6JnjmXKtPXa3Ok9qwSaBa3zFsqAdXo8cjAwtj0bD+Q==}
     hasBin: true
@@ -7635,9 +7536,6 @@ packages:
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
-
-  fast-diff@1.3.0:
-    resolution: {integrity: sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==}
 
   fast-equals@5.4.0:
     resolution: {integrity: sha512-jt2DW/aNFNwke7AUd+Z+e6pz39KO5rzdbbFCg2sGafS4mk13MI7Z8O5z9cADNn5lhGODIgLwug6TZO2ctf7kcw==}
@@ -7948,10 +7846,6 @@ packages:
     resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
     engines: {node: '>=10'}
 
-  get-stream@8.0.1:
-    resolution: {integrity: sha512-VaUJspBffn/LMCJVoMvSAdmscJyS1auj5Zulnn5UoYcY531UWmdwhRWkcGKnGU93m5HSXP9LP2usOryrBtQowA==}
-    engines: {node: '>=16'}
-
   get-symbol-description@1.1.0:
     resolution: {integrity: sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg==}
     engines: {node: '>= 0.4'}
@@ -8151,12 +8045,6 @@ packages:
   help-me@5.0.0:
     resolution: {integrity: sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==}
 
-  hermes-estree@0.25.1:
-    resolution: {integrity: sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==}
-
-  hermes-parser@0.25.1:
-    resolution: {integrity: sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==}
-
   hi-base32@0.5.1:
     resolution: {integrity: sha512-EmBBpvdYh/4XxsnUybsPag6VikPYnN30td+vQk+GI3qpahVEG9+gTkG0aXVxTjBqQ5T6ijbWIu77O+C5WFWsnA==}
 
@@ -8233,10 +8121,6 @@ packages:
   human-signals@2.1.0:
     resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
     engines: {node: '>=10.17.0'}
-
-  human-signals@5.0.0:
-    resolution: {integrity: sha512-AXcZb6vzzrFAUE61HnN4mpLqd/cSIwNQjtNWR0euPm6y0iqx3G4gOXaIDdtdDwZmhwe82LA6+zinmW4UBWVePQ==}
-    engines: {node: '>=16.17.0'}
 
   humanize-ms@1.2.1:
     resolution: {integrity: sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==}
@@ -8422,14 +8306,6 @@ packages:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
     engines: {node: '>=8'}
 
-  is-fullwidth-code-point@4.0.0:
-    resolution: {integrity: sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ==}
-    engines: {node: '>=12'}
-
-  is-fullwidth-code-point@5.0.0:
-    resolution: {integrity: sha512-OVa3u9kkBbw7b8Xw5F9P+D/T9X+Z4+JruYVNapTjPYZYUznQ5YfWeFkOj606XYYW8yugTfC8Pj0hYqvi4ryAhA==}
-    engines: {node: '>=18'}
-
   is-generator-fn@2.1.0:
     resolution: {integrity: sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==}
     engines: {node: '>=6'}
@@ -8533,10 +8409,6 @@ packages:
   is-stream@2.0.1:
     resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
     engines: {node: '>=8'}
-
-  is-stream@3.0.0:
-    resolution: {integrity: sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   is-string@1.1.1:
     resolution: {integrity: sha512-BtEeSsoaQjlSPBemMQIrY1MY0uM6vnS1g5fmufYOtnxLGUZM2178PKbhsk7Ffv58IX+ZtcvoGwccYsh0PglkAA==}
@@ -9055,17 +8927,8 @@ packages:
   linkifyjs@4.3.2:
     resolution: {integrity: sha512-NT1CJtq3hHIreOianA8aSXn6Cw0JzYOuDQbOrSPe7gqFnCpKP++MQe3ODgO3oh2GJFORkAAdqredOa60z63GbA==}
 
-  lint-staged@15.5.2:
-    resolution: {integrity: sha512-YUSOLq9VeRNAo/CTaVmhGDKG+LBtA8KF1X4K5+ykMSwWST1vDxJRB2kv2COgLb1fvpCo+A/y9A0G0znNVmdx4w==}
-    engines: {node: '>=18.12.0'}
-    hasBin: true
-
   listenercount@1.0.1:
     resolution: {integrity: sha512-3mk/Zag0+IJxeDrxSgaDPy4zZ3w05PRZeJNnlWhzFz5OkX49J4krc+A8X2d2M69vGMBEX0uyl8M+W+8gH+kBqQ==}
-
-  listr2@8.3.3:
-    resolution: {integrity: sha512-LWzX2KsqcB1wqQ4AHgYb4RsDXauQiqhjLk+6hjbaeHG4zpjjVAB6wC/gz6X0l+Du1cN3pUB5ZlrvTbhGSNnUQQ==}
-    engines: {node: '>=18.0.0'}
 
   load-script@1.0.0:
     resolution: {integrity: sha512-kPEjMFtZvwL9TaZo0uZ2ml+Ye9HUMmPwbYRJ324qF9tqMejwykJ5ggTyvzmrbBeapCAbk98BSbTeovHEEP1uCA==}
@@ -9165,10 +9028,6 @@ packages:
 
   lodash@4.17.21:
     resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
-
-  log-update@6.1.0:
-    resolution: {integrity: sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==}
-    engines: {node: '>=18'}
 
   logform@2.7.0:
     resolution: {integrity: sha512-TFYA4jnP7PVbmlBIfhlSe+WKxs9dklXMTEGcBCIvLhE/Tn3H6Gk1norupVW7m5Cnd4bLcr08AytbyV/xj7f/kQ==}
@@ -9495,14 +9354,6 @@ packages:
     resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
     engines: {node: '>=6'}
 
-  mimic-fn@4.0.0:
-    resolution: {integrity: sha512-vqiC06CuhBTUdZH+RYl8sFrL096vA45Ok5ISO6sE/Mr1jRbGH4Csnhi8f3wKVl7x8mO4Au7Ir9D3Oyv1VYMFJw==}
-    engines: {node: '>=12'}
-
-  mimic-function@5.0.1:
-    resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
-    engines: {node: '>=18'}
-
   mimic-response@3.1.0:
     resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
     engines: {node: '>=10'}
@@ -9745,10 +9596,6 @@ packages:
     resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
     engines: {node: '>=8'}
 
-  npm-run-path@5.3.0:
-    resolution: {integrity: sha512-ppwTtiJZq0O/ai0z7yfudtBpWIoxM8yE6nHi1X47eFR2EWORqfbu6CnPlNsjeN683eT0qG6H/Pyf9fCcvjnnnQ==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-
   nth-check@2.1.1:
     resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
 
@@ -9823,14 +9670,6 @@ packages:
   onetime@5.1.2:
     resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
     engines: {node: '>=6'}
-
-  onetime@6.0.0:
-    resolution: {integrity: sha512-1FlR+gjXK7X+AsAHso35MnyN5KqGwJRi/31ft6x0M194ht7S+rWAvd7PHss9xSKMzE0asv1pyIHaJYq+BbacAQ==}
-    engines: {node: '>=12'}
-
-  onetime@7.0.0:
-    resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
-    engines: {node: '>=18'}
 
   only@0.0.2:
     resolution: {integrity: sha512-Fvw+Jemq5fjjyWz6CpKx6w9s7xxqo3+JCyM0WXWeCSOboZ8ABkyvP8ID4CZuChA/wxSx+XSJmdOm8rGVyJ1hdQ==}
@@ -9973,10 +9812,6 @@ packages:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
 
-  path-key@4.0.0:
-    resolution: {integrity: sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==}
-    engines: {node: '>=12'}
-
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
 
@@ -10052,11 +9887,6 @@ packages:
   picomatch@4.0.3:
     resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
     engines: {node: '>=12'}
-
-  pidtree@0.6.0:
-    resolution: {integrity: sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g==}
-    engines: {node: '>=0.10'}
-    hasBin: true
 
   pify@2.3.0:
     resolution: {integrity: sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==}
@@ -10451,10 +10281,6 @@ packages:
   prepend-http@1.0.4:
     resolution: {integrity: sha512-PhmXi5XmoyKw1Un4E+opM2KcsJInDvKyuOumcjjw3waw86ZNjHwVUOOWLc4bCzLdcKNaWBH9e99sbWzDQsVaYg==}
     engines: {node: '>=0.10.0'}
-
-  prettier-linter-helpers@1.0.0:
-    resolution: {integrity: sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==}
-    engines: {node: '>=6.0.0'}
 
   prettier@2.8.8:
     resolution: {integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==}
@@ -11072,10 +10898,6 @@ packages:
     resolution: {integrity: sha512-U7WjGVG9sH8tvjW5SmGbQuui75FiyjAX72HX15DwBBwF9dNiQZRQAg9nnPhYy+TUnE0+VcrttuvNI8oSxZcocA==}
     hasBin: true
 
-  restore-cursor@5.1.0:
-    resolution: {integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==}
-    engines: {node: '>=18'}
-
   restructure@3.0.2:
     resolution: {integrity: sha512-gSfoiOEA0VPE6Tukkrr7I0RBdE0s7H1eFCDBk05l1KIQT1UIKNc5JZy6jdyW6eYH3aR3g5b3PuL77rq0hvwtAw==}
 
@@ -11374,14 +11196,6 @@ packages:
   slate@0.94.1:
     resolution: {integrity: sha512-GH/yizXr1ceBoZ9P9uebIaHe3dC/g6Plpf9nlUwnvoyf6V1UOYrRwkabtOCd3ZfIGxomY4P7lfgLr7FPH8/BKA==}
 
-  slice-ansi@5.0.0:
-    resolution: {integrity: sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ==}
-    engines: {node: '>=12'}
-
-  slice-ansi@7.1.0:
-    resolution: {integrity: sha512-bSiSngZ/jWeX93BqeIAbImyTbEihizcwNjFoRUIY/T1wWQsfsm2Vw1agPKylXvQTU7iASGdHhyqRlqQzfz+Htg==}
-    engines: {node: '>=18'}
-
   slugify@1.6.6:
     resolution: {integrity: sha512-h+z7HKHYXj6wJU+AnS/+IH8Uh9fdcX1Lrhg1/VMdf9PwoBQXFcXiAdsy2tSK0P6gKwJLXp02r90ahUCqHk9rrw==}
     engines: {node: '>=8.0.0'}
@@ -11516,10 +11330,6 @@ packages:
     resolution: {integrity: sha512-QwiXZgpRcKkhTj2Scnn++4PKtWsH0kpzZ62L2R6c/LUVYv7hVnZqcg2+sMuT6R7Jusu1vviK/MFsu6kNJfWlEQ==}
     engines: {node: '>=4'}
 
-  string-argv@0.3.2:
-    resolution: {integrity: sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==}
-    engines: {node: '>=0.6.19'}
-
   string-hash@1.1.3:
     resolution: {integrity: sha512-kJUvRUFK49aub+a7T1nNE66EJbZBMnBgoC1UbCZ5n6bsZKBRga4KgBRTMn/pFkeCZSYtNeSyMxPDM0AXWELk2A==}
 
@@ -11594,10 +11404,6 @@ packages:
   strip-final-newline@2.0.0:
     resolution: {integrity: sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==}
     engines: {node: '>=6'}
-
-  strip-final-newline@3.0.0:
-    resolution: {integrity: sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw==}
-    engines: {node: '>=12'}
 
   strip-json-comments@2.0.1:
     resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
@@ -12809,12 +12615,6 @@ packages:
   zip-stream@5.0.2:
     resolution: {integrity: sha512-LfOdrUvPB8ZoXtvOBz6DlNClfvi//b5d56mSWyJi7XbH/HfhOHfUhOqxhT/rUiR7yiktlunqRo+jY6y/cWC/5g==}
     engines: {node: '>= 12.0.0'}
-
-  zod-validation-error@4.0.2:
-    resolution: {integrity: sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==}
-    engines: {node: '>=18.0.0'}
-    peerDependencies:
-      zod: ^3.25.0 || ^4.0.0
 
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
@@ -18330,10 +18130,6 @@ snapshots:
     dependencies:
       type-fest: 0.21.3
 
-  ansi-escapes@7.0.0:
-    dependencies:
-      environment: 1.1.0
-
   ansi-regex@5.0.1: {}
 
   ansi-regex@6.1.0: {}
@@ -18993,15 +18789,6 @@ snapshots:
 
   cli-boxes@3.0.0: {}
 
-  cli-cursor@5.0.0:
-    dependencies:
-      restore-cursor: 5.1.0
-
-  cli-truncate@4.0.0:
-    dependencies:
-      slice-ansi: 5.0.0
-      string-width: 7.2.0
-
   cli-width@4.1.0: {}
 
   client-only@0.0.1: {}
@@ -19072,8 +18859,6 @@ snapshots:
 
   commander@12.1.0: {}
 
-  commander@13.1.0: {}
-
   commander@14.0.0: {}
 
   commander@2.20.3: {}
@@ -19113,8 +18898,6 @@ snapshots:
   confbox@0.1.8: {}
 
   confbox@0.2.2: {}
-
-  confusing-browser-globals@1.0.11: {}
 
   consola@3.4.2: {}
 
@@ -19651,8 +19434,6 @@ snapshots:
   entities@8.0.0:
     optional: true
 
-  environment@1.1.0: {}
-
   error-ex@1.3.2:
     dependencies:
       is-arrayish: 0.2.1
@@ -19875,46 +19656,6 @@ snapshots:
 
   escape-string-regexp@5.0.0: {}
 
-  eslint-config-airbnb-base@15.0.0(eslint-plugin-import@2.32.0)(eslint@8.57.1):
-    dependencies:
-      confusing-browser-globals: 1.0.11
-      eslint: 8.57.1
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
-      object.assign: 4.1.7
-      object.entries: 1.1.9
-      semver: 6.3.1
-
-  eslint-config-airbnb-typescript@17.1.0(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.2))(eslint@8.57.1)(typescript@5.9.2))(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.2))(eslint-plugin-import@2.32.0)(eslint@8.57.1):
-    dependencies:
-      '@typescript-eslint/eslint-plugin': 5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.2))(eslint@8.57.1)(typescript@5.9.2)
-      '@typescript-eslint/parser': 5.62.0(eslint@8.57.1)(typescript@5.9.2)
-      eslint: 8.57.1
-      eslint-config-airbnb-base: 15.0.0(eslint-plugin-import@2.32.0)(eslint@8.57.1)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
-
-  eslint-config-airbnb@19.0.4(eslint-plugin-import@2.32.0)(eslint-plugin-jsx-a11y@6.10.2(eslint@8.57.1))(eslint-plugin-react-hooks@7.1.1(eslint@8.57.1))(eslint-plugin-react@7.37.5(eslint@8.57.1))(eslint@8.57.1):
-    dependencies:
-      eslint: 8.57.1
-      eslint-config-airbnb-base: 15.0.0(eslint-plugin-import@2.32.0)(eslint@8.57.1)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
-      eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
-      eslint-plugin-react: 7.37.5(eslint@8.57.1)
-      eslint-plugin-react-hooks: 7.1.1(eslint@8.57.1)
-      object.assign: 4.1.7
-      object.entries: 1.1.9
-
-  eslint-config-mantine@2.0.0(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.2))(eslint@8.57.1)(typescript@5.9.2))(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.2))(eslint-config-airbnb-typescript@17.1.0(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.2))(eslint@8.57.1)(typescript@5.9.2))(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.2))(eslint-plugin-import@2.32.0)(eslint@8.57.1))(eslint-config-airbnb@19.0.4(eslint-plugin-import@2.32.0)(eslint-plugin-jsx-a11y@6.10.2(eslint@8.57.1))(eslint-plugin-react-hooks@7.1.1(eslint@8.57.1))(eslint-plugin-react@7.37.5(eslint@8.57.1))(eslint@8.57.1))(eslint-plugin-import@2.32.0)(eslint-plugin-jsx-a11y@6.10.2(eslint@8.57.1))(eslint-plugin-react-hooks@7.1.1(eslint@8.57.1))(eslint-plugin-react@7.37.5(eslint@8.57.1))(eslint@8.57.1):
-    dependencies:
-      '@typescript-eslint/eslint-plugin': 5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.2))(eslint@8.57.1)(typescript@5.9.2)
-      '@typescript-eslint/parser': 5.62.0(eslint@8.57.1)(typescript@5.9.2)
-      eslint: 8.57.1
-      eslint-config-airbnb: 19.0.4(eslint-plugin-import@2.32.0)(eslint-plugin-jsx-a11y@6.10.2(eslint@8.57.1))(eslint-plugin-react-hooks@7.1.1(eslint@8.57.1))(eslint-plugin-react@7.37.5(eslint@8.57.1))(eslint@8.57.1)
-      eslint-config-airbnb-typescript: 17.1.0(@typescript-eslint/eslint-plugin@5.62.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.2))(eslint@8.57.1)(typescript@5.9.2))(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.2))(eslint-plugin-import@2.32.0)(eslint@8.57.1)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
-      eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
-      eslint-plugin-react: 7.37.5(eslint@8.57.1)
-      eslint-plugin-react-hooks: 7.1.1(eslint@8.57.1)
-
   eslint-config-next@15.5.19(eslint@8.57.1)(typescript@5.9.2):
     dependencies:
       '@next/eslint-plugin-next': 15.5.19
@@ -19950,26 +19691,25 @@ snapshots:
   eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
-      debug: 4.4.1
+      debug: 4.4.3
       eslint: 8.57.1
       get-tsconfig: 4.10.1
       is-bun-module: 2.0.0
       stable-hash: 0.0.5
-      tinyglobby: 0.2.14
+      tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.2))(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 5.62.0(eslint@8.57.1)(typescript@5.9.2)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -19984,7 +19724,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.2))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.2))(eslint@8.57.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -19995,7 +19735,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@5.62.0(eslint@8.57.1)(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint@8.57.1)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -20063,28 +19803,9 @@ snapshots:
 
   eslint-plugin-local-rules@3.0.2: {}
 
-  eslint-plugin-prettier@4.2.5(eslint-config-prettier@8.10.2(eslint@8.57.1))(eslint@8.57.1)(prettier@2.8.8):
-    dependencies:
-      eslint: 8.57.1
-      prettier: 2.8.8
-      prettier-linter-helpers: 1.0.0
-    optionalDependencies:
-      eslint-config-prettier: 8.10.2(eslint@8.57.1)
-
   eslint-plugin-react-hooks@5.2.0(eslint@8.57.1):
     dependencies:
       eslint: 8.57.1
-
-  eslint-plugin-react-hooks@7.1.1(eslint@8.57.1):
-    dependencies:
-      '@babel/core': 7.29.0
-      '@babel/parser': 7.29.0
-      eslint: 8.57.1
-      hermes-parser: 0.25.1
-      zod: 4.4.3
-      zod-validation-error: 4.0.2(zod@4.4.3)
-    transitivePeerDependencies:
-      - supports-color
 
   eslint-plugin-react@7.37.5(eslint@8.57.1):
     dependencies:
@@ -20266,18 +19987,6 @@ snapshots:
       signal-exit: 3.0.7
       strip-final-newline: 2.0.0
 
-  execa@8.0.1:
-    dependencies:
-      cross-spawn: 7.0.6
-      get-stream: 8.0.1
-      human-signals: 5.0.0
-      is-stream: 3.0.0
-      merge-stream: 2.0.0
-      npm-run-path: 5.3.0
-      onetime: 6.0.0
-      signal-exit: 4.1.0
-      strip-final-newline: 3.0.0
-
   exifreader@4.41.3:
     optionalDependencies:
       '@xmldom/xmldom': 0.9.10
@@ -20320,8 +20029,6 @@ snapshots:
   fast-decode-uri-component@1.0.1: {}
 
   fast-deep-equal@3.1.3: {}
-
-  fast-diff@1.3.0: {}
 
   fast-equals@5.4.0: {}
 
@@ -20666,8 +20373,6 @@ snapshots:
   get-stream@3.0.0: {}
 
   get-stream@6.0.1: {}
-
-  get-stream@8.0.1: {}
 
   get-symbol-description@1.1.0:
     dependencies:
@@ -21040,12 +20745,6 @@ snapshots:
 
   help-me@5.0.0: {}
 
-  hermes-estree@0.25.1: {}
-
-  hermes-parser@0.25.1:
-    dependencies:
-      hermes-estree: 0.25.1
-
   hi-base32@0.5.1: {}
 
   history@5.3.0:
@@ -21147,8 +20846,6 @@ snapshots:
       - supports-color
 
   human-signals@2.1.0: {}
-
-  human-signals@5.0.0: {}
 
   humanize-ms@1.2.1:
     dependencies:
@@ -21341,12 +21038,6 @@ snapshots:
 
   is-fullwidth-code-point@3.0.0: {}
 
-  is-fullwidth-code-point@4.0.0: {}
-
-  is-fullwidth-code-point@5.0.0:
-    dependencies:
-      get-east-asian-width: 1.3.0
-
   is-generator-fn@2.1.0: {}
 
   is-generator-function@1.1.0:
@@ -21426,8 +21117,6 @@ snapshots:
   is-stream@1.1.0: {}
 
   is-stream@2.0.1: {}
-
-  is-stream@3.0.0: {}
 
   is-string@1.1.1:
     dependencies:
@@ -22178,31 +21867,7 @@ snapshots:
 
   linkifyjs@4.3.2: {}
 
-  lint-staged@15.5.2:
-    dependencies:
-      chalk: 5.5.0
-      commander: 13.1.0
-      debug: 4.4.1
-      execa: 8.0.1
-      lilconfig: 3.1.3
-      listr2: 8.3.3
-      micromatch: 4.0.8
-      pidtree: 0.6.0
-      string-argv: 0.3.2
-      yaml: 2.8.1
-    transitivePeerDependencies:
-      - supports-color
-
   listenercount@1.0.1: {}
-
-  listr2@8.3.3:
-    dependencies:
-      cli-truncate: 4.0.0
-      colorette: 2.0.20
-      eventemitter3: 5.0.1
-      log-update: 6.1.0
-      rfdc: 1.4.1
-      wrap-ansi: 9.0.0
 
   load-script@1.0.0: {}
 
@@ -22269,14 +21934,6 @@ snapshots:
   lodash.uniq@4.5.0: {}
 
   lodash@4.17.21: {}
-
-  log-update@6.1.0:
-    dependencies:
-      ansi-escapes: 7.0.0
-      cli-cursor: 5.0.0
-      slice-ansi: 7.1.0
-      strip-ansi: 7.1.0
-      wrap-ansi: 9.0.0
 
   logform@2.7.0:
     dependencies:
@@ -22881,10 +22538,6 @@ snapshots:
 
   mimic-fn@2.1.0: {}
 
-  mimic-fn@4.0.0: {}
-
-  mimic-function@5.0.1: {}
-
   mimic-response@3.1.0: {}
 
   minimatch@3.1.2:
@@ -23139,10 +22792,6 @@ snapshots:
     dependencies:
       path-key: 3.1.1
 
-  npm-run-path@5.3.0:
-    dependencies:
-      path-key: 4.0.0
-
   nth-check@2.1.1:
     dependencies:
       boolbase: 1.0.0
@@ -23226,14 +22875,6 @@ snapshots:
   onetime@5.1.2:
     dependencies:
       mimic-fn: 2.1.0
-
-  onetime@6.0.0:
-    dependencies:
-      mimic-fn: 4.0.0
-
-  onetime@7.0.0:
-    dependencies:
-      mimic-function: 5.0.1
 
   only@0.0.2: {}
 
@@ -23412,8 +23053,6 @@ snapshots:
 
   path-key@3.1.1: {}
 
-  path-key@4.0.0: {}
-
   path-parse@1.0.7: {}
 
   path-scurry@1.11.1:
@@ -23475,8 +23114,6 @@ snapshots:
   picomatch@2.3.1: {}
 
   picomatch@4.0.3: {}
-
-  pidtree@0.6.0: {}
 
   pify@2.3.0: {}
 
@@ -23878,10 +23515,6 @@ snapshots:
   prelude-ls@1.2.1: {}
 
   prepend-http@1.0.4: {}
-
-  prettier-linter-helpers@1.0.0:
-    dependencies:
-      fast-diff: 1.3.0
 
   prettier@2.8.8: {}
 
@@ -24680,11 +24313,6 @@ snapshots:
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
 
-  restore-cursor@5.1.0:
-    dependencies:
-      onetime: 7.0.0
-      signal-exit: 4.1.0
-
   restructure@3.0.2: {}
 
   ret@0.5.0: {}
@@ -25081,16 +24709,6 @@ snapshots:
       is-plain-object: 5.0.0
       tiny-warning: 1.0.3
 
-  slice-ansi@5.0.0:
-    dependencies:
-      ansi-styles: 6.2.1
-      is-fullwidth-code-point: 4.0.0
-
-  slice-ansi@7.1.0:
-    dependencies:
-      ansi-styles: 6.2.1
-      is-fullwidth-code-point: 5.0.0
-
   slugify@1.6.6: {}
 
   snake-case@3.0.4:
@@ -25223,8 +24841,6 @@ snapshots:
 
   strict-uri-encode@2.0.0: {}
 
-  string-argv@0.3.2: {}
-
   string-hash@1.1.3: {}
 
   string-length@4.0.2:
@@ -25328,8 +24944,6 @@ snapshots:
   strip-bom@4.0.0: {}
 
   strip-final-newline@2.0.0: {}
-
-  strip-final-newline@3.0.0: {}
 
   strip-json-comments@2.0.1: {}
 
@@ -26696,10 +26310,6 @@ snapshots:
       archiver-utils: 4.0.1
       compress-commons: 5.0.3
       readable-stream: 3.6.2
-
-  zod-validation-error@4.0.2(zod@4.4.3):
-    dependencies:
-      zod: 4.4.3
 
   zod@3.25.76: {}
 


### PR DESCRIPTION
Deletions and additive CI only. No lint findings were fixed.

## Timings

| | before | after |
|---|---|---|
| `eslint src/utils` (82 files, no cache) | **4m 34s** | **8.4s** |
| `pnpm run lint` (full `src/`, cold cache) | ~2h 40m (extrapolated) | **1m 07s** (measured) |

The full "before" number is extrapolated rather than measured — the sample works out to 42s of program build plus ~2.8s/file, so 4,113 files is ~3.2h. I did not sit through a real full run.

## Findings after the change

3,777 total (307 errors, 3,470 warnings) across 1,119 files. Was 9,594.

```
  1762  @typescript-eslint/no-explicit-any
  1375  @typescript-eslint/no-unused-vars
   154  react-hooks/exhaustive-deps
   144  @typescript-eslint/no-empty-function
   107  @typescript-eslint/consistent-type-imports
    92  tailwindcss/classnames-order
    57  @next/next/no-img-element
    23  tailwindcss/enforces-shorthand
    22  react/no-unescaped-entities
    10  prefer-const
     7  @typescript-eslint/ban-types
     6  react-hooks/rules-of-hooks
     5  tailwindcss/migration-from-tailwind-2
     5  @typescript-eslint/no-inferrable-types
     2  jsx-a11y/alt-text
     1  each: react/display-name, @typescript-eslint/no-empty-interface,
           react/jsx-closing-bracket-location, react/no-children-prop,
           @typescript-eslint/no-var-requires, @typescript-eslint/no-empty-object-type
```

## 1. Type-aware override removed

`.eslintrc.js` set `parserOptions: { project: './tsconfig.json' }` on every `.ts`/`.tsx` while its own `rules` block was empty. I read the whole config to confirm nothing else needed type information:

- `plugin:@typescript-eslint/recommended` (v5) is the non-type-checked preset; the type-aware companion `recommended-requiring-type-checking` was commented out.
- `next/core-web-vitals`, `plugin:tailwindcss/recommended`, `react/jsx-closing-bracket-location`, `consistent-type-imports`, and `no-unused-vars` are all syntax-only.
- The local `no-io-in-transaction` rule is a pure AST walk (`eslint-local-rules.js`) with no `getTypeChecker` usage.

The sole consumer was root-level `@typescript-eslint/restrict-template-expressions` at `warn`. Both it and the override are deleted.

## 2. CI lint job

New `.github/workflows/lint.yml`, on PRs into `main`/`release`, two parallel jobs:

- **ESLint + Prettier** — changed `.ts`/`.tsx` vs the PR base only. Full-repo would fail on all 3,777 pre-existing findings and be disabled within a week. ESLint is further filtered to `src/` and `packages/`, the only trees with a config.
- **Typecheck** — full `pnpm run typecheck`. Cheap and currently unenforced: `.husky/pre-push` early-exits for `Justin Maier` and `bkdiehl`, so in practice it never runs.

Both jobs skip the submodule except typecheck, which initializes `event-engine-common` via `webfactory/ssh-agent` and `SUBMODULE_SSH_KEY` (same secret the pin-guard workflow already uses). Without it tsc emits a wall of missing-module errors.

**Node version discrepancy, not resolved here:** `.nvmrc` says `24.18.0`, the Dockerfile builds on node 22. The workflow follows `.nvmrc` per instruction. Worth reconciling separately — CI type-checking on a different major than the one that ships is a real gap, just not this PR's.

## 3. Prettier split out of ESLint

`prettier/prettier` was 5,830 of 9,594 findings, all duplicated by `pnpm prettier:check`. Verified rather than assumed:

- **File set** — `prettier:check` globs `**/*.{ts,tsx}` and there is **no `.prettierignore` file at all** (the audit said "empty"; it does not exist, same practical effect — only prettier's built-in `node_modules` exclusion applies). `pnpm lint` covers `src/` only. Superset confirmed.
- **Options** — `.prettierrc` is `{trailingComma: es5, tabWidth: 2, printWidth: 100, singleQuote: true}`; the inline ESLint options were `{printWidth: 100, endOfLine: 'auto', singleQuote: true, trailingComma: 'es5'}`. `tabWidth: 2` is prettier's default, so the only real delta is `endOfLine` — `auto` in ESLint vs the default `lf` in `.prettierrc`. `prettier:check` (the surviving path) is the stricter of the two, so nothing is lost.

`eslint-config-prettier` kept in `extends` at its current version.

## 4. Dead dependencies

Each confirmed by grep across the repo excluding `package.json` and the lockfile — zero hits: `eslint-config-airbnb`, `eslint-config-airbnb-typescript`, `eslint-config-mantine`, `eslint-import-resolver-typescript` (its `import/resolver` block has been commented out), `lint-staged`.

The `lint-staged` config block ran `tsc-files --noEmit`, and `tsc-files` is not installed and not in the lockfile. Its husky call has been commented out since someone left the note "apparently tsc-files just doesn't work on windows. at all." Block removed with the dep.

`eslint-plugin-import` **kept** — `packages/.eslintrc.cjs` registers it for `pnpm lint:packages`. Also fixed that file's stale comment claiming packages don't inherit the app's "airbnb" config; airbnb was never in `extends`.

## 5. eslint-config-next pin

Added `"eslint-config-next": "15"` to `pnpm.overrides`, and a `//eslint-config-next` note beside it explaining why. The note lives at the top level rather than inline in `devDependencies` because pnpm rejects a `//`-prefixed key inside a dependency block (`ERR_PNPM_INVALID_PACKAGE_NAME`). `.eslintrc.js` now points at the override so the two stay linked.

## 6. openai to zod override — deleted, not moved

Confirmed the audit: `package.json` had a top-level npm-style `"overrides": {"openai": {"zod": "$zod"}}`, pnpm only reads `pnpm.overrides`, and the lockfile's `overrides:` block contained no `openai` entry. It has never applied.

I removed it rather than moving it. Installed `openai@4.104.0` declares `zod: ^3.23.8` as an **optional** peer with no `zod` in its own `dependencies`; the repo is on `zod ^4.0.17` and pnpm already reports `openai 4.104.0 -> unmet peer zod@^3.23.8: found 4.0.17`. Since openai has no nested `zod` to redirect, `$zod` would resolve to the same 4.0.17 that is already there — a no-op that also asserts a compatibility openai@4 does not claim. Moving it changes no resolved version; it just makes a broken peer look sanctioned. Happy to restore it under `pnpm.overrides` if someone wants the declaration on record.

## Verified

- `pnpm run typecheck` — clean, full output read, exit 0.
- `pnpm run lint` — 1m07s, counts above.
- `pnpm run lint:packages` — **fails identically before and after** this change (verified by stashing to a clean tree): 2 `import/no-extraneous-dependencies` errors on `packages/civitai-axiom/src/__tests__/*.test.ts` for `vitest`. This looks like a Windows-only artifact — the rule's `devDependencies: ['**/*.test.ts']` allowlist is minimatched against an absolute backslash path. Pre-existing and out of scope; flagging because it means the config's own gate is red on Windows today. It should pass on the Linux CI runner.
- `package.json` parses; `lint.yml` parses as YAML.

## What this workflow actually guards (honest accounting)

Worth recording plainly, because the CI job is easy to over-read:

- **Typecheck is 100% new coverage.** `.husky/pre-push:8` exits 0 when the branch isn't `main` **or** the user is Justin/bkdiehl. Everyone develops on feature branches, so that hook has effectively never run for anyone, and type errors currently reach the preview build before anything catches them. This job catches them at PR time. That alone justifies it. Caveat: it is skipped on fork PRs (private submodule + no secrets), so a fork gets no gating from this workflow.
- **The report-only ESLint/Prettier steps guard nothing today.** That is acceptable only if the flip to blocking actually happens, and the flip is pinned to a Prettier 2 to 3 upgrade that is not scheduled.
- **The added-files gate is what makes this not-nothing in the meantime.** Newly added files block on ESLint errors and Prettier. Measured over the last 30 commits: of 20 newly added src files, 6 fail Prettier and 4 carry ESLint errors, so 8 of 20 (40%) would have been blocked. It is not the "free" gate it looks like, but it does stop the 789-file formatting backlog from growing.

**Documented follow-up (not built here):** the better long-term shape is a **baseline diff** rather than a repo-wide reformat. For each changed file, also run the check against `FETCH_HEAD:$file` and report only if it got *worse* - exact for Prettier, error-count comparison for ESLint. Roughly 15 lines, gives a genuinely blocking regression gate without touching a single existing file, and does not depend on the Prettier upgrade ever happening.

## Out of scope

typescript-eslint v5 to v8, ESLint 8 to 9 / flat config, Prettier 2 to 3, Node and `@types/node` alignment, husky hook cleanup beyond removing the dead lint-staged block, and any repo-wide `prettier --write`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
