### PR TITLE
feat(app-store): kind-aware read scope for external-before-onsite GA (Phase 1, DARK)

### DIFF
--- a/src/server/routers/__tests__/app-listings.router.read-flag-gate.test.ts
+++ b/src/server/routers/__tests__/app-listings.router.read-flag-gate.test.ts
@@ -2,42 +2,50 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { TRPCError } from '@trpc/server';
 
 /**
- * W13 P2a — the DARK-POSTURE gate on the unified store read path.
+ * The DARK-POSTURE + external-before-onsite GA (Phase 1) gate on the unified store
+ * read path.
  *
- * `appListings.listAvailable` / `getAppDetail` are `publicProcedure`s behind
- * `enforceAppListingsReadFlag`. W13 (PR-W1a/D8) repointed that middleware onto
- * the DEDICATED store-visibility flag `isAppListingsEnabled` (which itself
- * OR-falls-back to `isAppBlocksEnabled`, so the current mods+testers cohort is
- * unchanged today). This is the SINGLE control that keeps the whole store dark
- * until the segment is widened at cutover. `isAppListingsEnabled` is mocked with
- * a FAITHFUL per-user impl (ON only when the caller is a moderator — matching the
- * live posture where the fallback grants mods), and the read service is mocked so
- * importing the router doesn't drag in the generated Prisma client (stale in a PR
- * worktree). We then drive the REAL router so the middleware's `{ user: ctx.user }`
- * wiring is what decides:
- *   - list:   anon/non-mod → EMPTY page, service NOT consulted; mod → served.
- *   - detail: anon/non-mod → NOT_FOUND, service NOT consulted; mod → served.
- *   - flag lit for anon → served (proves the path is anon-CAPABLE, no leftover
- *     isModerator gate) — the deliberate cutover widen.
+ * `appListings.listAvailable` / `getAppDetail` / `listReviews` are
+ * `publicProcedure`s behind `enforceAppListingsReadFlag`, which now resolves a
+ * STORE VISIBILITY SCOPE (`resolveStoreVisibilityScope(ctx.user)`) onto
+ * `ctx._storeScope` that the 3 procs branch on:
+ *   - `none`            → EMPTY page / NOT_FOUND, service NOT consulted (dark).
+ *   - `full`            → served with `scope: 'full'` (mods + testers, all kinds).
+ *   - `public-external` → served with `scope: 'public-external'` (offsite-only; the
+ *     onsite exclusion is enforced in the service — here we assert the SCOPE is
+ *     threaded down AND that a service-returned null/empty (onsite) becomes a
+ *     router-level 404/empty).
+ *
+ * `resolveStoreVisibilityScope` is mocked with a faithful per-caller impl (mod →
+ * `full`; a `publicExternal` toggle → `public-external`; else `none`). The read
+ * services are mocked so importing the router doesn't drag in the generated Prisma
+ * client, and so we can assert "NOT consulted" + the exact scope passed.
  */
 
-const { mockIsAppListingsEnabled, mockListAvailableListings, mockGetListingDetail } = vi.hoisted(
-  () => ({
-    mockIsAppListingsEnabled: vi.fn(),
-    mockListAvailableListings: vi.fn(),
-    mockGetListingDetail: vi.fn(),
-  })
-);
-
-// W13: the read middleware now gates on the dedicated `isAppListingsEnabled`.
-vi.mock('~/server/services/app-blocks-flag', () => ({
-  isAppListingsEnabled: mockIsAppListingsEnabled,
+const {
+  mockResolveStoreVisibilityScope,
+  mockListAvailableListings,
+  mockGetListingDetail,
+  mockListAppListingReviews,
+} = vi.hoisted(() => ({
+  mockResolveStoreVisibilityScope: vi.fn(),
+  mockListAvailableListings: vi.fn(),
+  mockGetListingDetail: vi.fn(),
+  mockListAppListingReviews: vi.fn(),
 }));
-// The read service is dynamically imported by the procs; mock it so the DB /
-// generated client is never loaded, and so we can assert "NOT consulted".
+
+// The read middleware now resolves a store-visibility SCOPE.
+vi.mock('~/server/services/app-blocks-flag', () => ({
+  resolveStoreVisibilityScope: mockResolveStoreVisibilityScope,
+}));
+// The read services are dynamically imported by the procs; mock them so the DB /
+// generated client is never loaded, and so we can assert "NOT consulted" + scope.
 vi.mock('~/server/services/blocks/app-listing.service', () => ({
   listAvailableListings: (...a: unknown[]) => mockListAvailableListings(...a),
   getListingDetail: (...a: unknown[]) => mockGetListingDetail(...a),
+}));
+vi.mock('~/server/services/blocks/app-listing-review.service', () => ({
+  listAppListingReviews: (...a: unknown[]) => mockListAppListingReviews(...a),
 }));
 // rateLimit pulls in redis; the gate under test is the flag middleware, so stub
 // it to a pass-through (mirrors blocks.router.flag-gate.test.ts).
@@ -54,13 +62,18 @@ vi.mock('~/server/utils/server-domain', () => ({
 import { appListingsRouter } from '../app-listings.router';
 import { TokenScope } from '~/shared/constants/token-scope.constants';
 
+type ScopeUser = { isModerator?: boolean } | undefined;
+
 /**
- * Faithful stand-in for the live `isAppListingsEnabled` posture today: ON iff the
- * caller is a moderator (anon/non-mod → false). This matches the OR-fallback to
- * `app-blocks-enabled` while the `app-listings` flag doesn't yet exist.
+ * Faithful stand-in for `resolveStoreVisibilityScope`: a moderator (or app-listings
+ * grantee, modeled here as `isModerator`) → `full`; else, when the public-external
+ * flag is toggled ON, any viewer (incl. anon) → `public-external`; else → `none`.
  */
-function fakePerUserFlag(opts?: { user?: { isModerator?: boolean } }) {
-  return Promise.resolve(!!opts?.user?.isModerator);
+let publicExternal = false;
+function fakeResolveScope(opts?: { user?: ScopeUser }): Promise<'full' | 'public-external' | 'none'> {
+  if (opts?.user?.isModerator) return Promise.resolve('full');
+  if (publicExternal) return Promise.resolve('public-external');
+  return Promise.resolve('none');
 }
 
 function fakeCtx(user: unknown) {
@@ -81,69 +94,147 @@ const modUser = { id: 1, isModerator: true, tier: 'free', username: 'mod' };
 const normalUser = { id: 2, isModerator: false, tier: 'free', username: 'user' };
 
 beforeEach(() => {
-  mockIsAppListingsEnabled.mockReset();
-  mockIsAppListingsEnabled.mockImplementation(fakePerUserFlag);
+  publicExternal = false;
+  mockResolveStoreVisibilityScope.mockReset();
+  mockResolveStoreVisibilityScope.mockImplementation(fakeResolveScope);
   mockListAvailableListings.mockReset();
   mockListAvailableListings.mockResolvedValue({ items: [{ id: 'apl_1' }], nextCursor: undefined });
   mockGetListingDetail.mockReset();
-  mockGetListingDetail.mockResolvedValue({ id: 'apl_1', slug: 'x', kind: 'onsite' });
+  mockGetListingDetail.mockResolvedValue({ id: 'apl_1', slug: 'x', kind: 'offsite' });
+  mockListAppListingReviews.mockReset();
+  mockListAppListingReviews.mockResolvedValue({ items: [{ id: 5 }], nextCursor: undefined });
 });
 
-describe('appListings.listAvailable — dark posture', () => {
-  it('anonymous (flag off): empty page, service NOT consulted', async () => {
+describe('appListings.listAvailable — scope gate', () => {
+  it('anonymous (none): empty page, service NOT consulted', async () => {
     const caller = appListingsRouter.createCaller(fakeCtx(undefined) as never);
     const result = await caller.listAvailable({ limit: 20 });
     expect(result).toEqual({ items: [], nextCursor: undefined });
     expect(mockListAvailableListings).not.toHaveBeenCalled();
-    expect(mockIsAppListingsEnabled).toHaveBeenCalledWith({ user: undefined });
+    expect(mockResolveStoreVisibilityScope).toHaveBeenCalledWith({ user: undefined });
   });
 
-  it('non-moderator (flag off): empty page, service NOT consulted', async () => {
+  it('non-moderator (none): empty page, service NOT consulted', async () => {
     const caller = appListingsRouter.createCaller(fakeCtx(normalUser) as never);
     const result = await caller.listAvailable({ limit: 20 });
     expect(result).toEqual({ items: [], nextCursor: undefined });
     expect(mockListAvailableListings).not.toHaveBeenCalled();
   });
 
-  it('moderator: gate passes, service IS consulted (mods-only is the live state)', async () => {
+  it('moderator (full): served with scope=full', async () => {
     const caller = appListingsRouter.createCaller(fakeCtx(modUser) as never);
     const result = await caller.listAvailable({ limit: 20 });
     expect(result).toEqual({ items: [{ id: 'apl_1' }], nextCursor: undefined });
     expect(mockListAvailableListings).toHaveBeenCalledTimes(1);
+    expect(mockListAvailableListings).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ scope: 'full' })
+    );
   });
 
-  it('anonymous WITH the flag widened (cutover): served — proves anon-capable', async () => {
-    mockIsAppListingsEnabled.mockResolvedValue(true);
+  it('public-external flag on, anon: served with scope=public-external (offsite-only, proves anon-capable)', async () => {
+    publicExternal = true;
     const caller = appListingsRouter.createCaller(fakeCtx(undefined) as never);
     const result = await caller.listAvailable({ limit: 20 });
     expect(result).toEqual({ items: [{ id: 'apl_1' }], nextCursor: undefined });
-    expect(mockListAvailableListings).toHaveBeenCalledTimes(1);
+    expect(mockListAvailableListings).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ scope: 'public-external' })
+    );
+  });
+
+  it('public-external flag on, MOD still resolves full (public flag never narrows a mod)', async () => {
+    publicExternal = true;
+    const caller = appListingsRouter.createCaller(fakeCtx(modUser) as never);
+    await caller.listAvailable({ limit: 20 });
+    expect(mockListAvailableListings).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ scope: 'full' })
+    );
   });
 });
 
-describe('appListings.getAppDetail — dark posture', () => {
-  it('anonymous (flag off): NOT_FOUND, service NOT consulted', async () => {
+describe('appListings.getAppDetail — scope gate', () => {
+  it('anonymous (none): NOT_FOUND, service NOT consulted', async () => {
     const caller = appListingsRouter.createCaller(fakeCtx(undefined) as never);
     await expect(caller.getAppDetail({ slug: 'foo' })).rejects.toBeInstanceOf(TRPCError);
     expect(mockGetListingDetail).not.toHaveBeenCalled();
   });
 
-  it('non-moderator (flag off): NOT_FOUND, service NOT consulted', async () => {
+  it('non-moderator (none): NOT_FOUND, service NOT consulted', async () => {
     const caller = appListingsRouter.createCaller(fakeCtx(normalUser) as never);
     await expect(caller.getAppDetail({ slug: 'foo' })).rejects.toBeInstanceOf(TRPCError);
     expect(mockGetListingDetail).not.toHaveBeenCalled();
   });
 
-  it('moderator: gate passes, detail served', async () => {
+  it('moderator (full): detail served with scope=full', async () => {
     const caller = appListingsRouter.createCaller(fakeCtx(modUser) as never);
     const result = await caller.getAppDetail({ slug: 'foo' });
     expect(result).toMatchObject({ id: 'apl_1' });
-    expect(mockGetListingDetail).toHaveBeenCalledTimes(1);
+    expect(mockGetListingDetail).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ scope: 'full' })
+    );
   });
 
-  it('moderator, listing not approved/found (service → null): NOT_FOUND', async () => {
+  it('public-external, offsite listing: served with scope=public-external', async () => {
+    publicExternal = true;
+    const caller = appListingsRouter.createCaller(fakeCtx(undefined) as never);
+    const result = await caller.getAppDetail({ slug: 'ext' });
+    expect(result).toMatchObject({ id: 'apl_1' });
+    expect(mockGetListingDetail).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ scope: 'public-external' })
+    );
+  });
+
+  it('public-external, ONSITE listing (service → null): NOT_FOUND', async () => {
+    // The service applies the kind gate: an onsite listing under public-external
+    // returns null → the router maps that to NOT_FOUND (no id/slug bypass).
+    publicExternal = true;
     mockGetListingDetail.mockResolvedValue(null);
+    const caller = appListingsRouter.createCaller(fakeCtx(undefined) as never);
+    await expect(caller.getAppDetail({ id: 'apl_onsite' })).rejects.toBeInstanceOf(TRPCError);
+    expect(mockGetListingDetail).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ scope: 'public-external' })
+    );
+  });
+});
+
+describe('appListings.listReviews — scope gate', () => {
+  it('anonymous (none): empty, service NOT consulted', async () => {
+    const caller = appListingsRouter.createCaller(fakeCtx(undefined) as never);
+    const result = await caller.listReviews({ appListingId: 'apl_1', limit: 20 });
+    expect(result).toEqual({ items: [], nextCursor: undefined });
+    expect(mockListAppListingReviews).not.toHaveBeenCalled();
+  });
+
+  it('moderator (full): served with scope=full', async () => {
     const caller = appListingsRouter.createCaller(fakeCtx(modUser) as never);
-    await expect(caller.getAppDetail({ id: 'apl_missing' })).rejects.toBeInstanceOf(TRPCError);
+    const result = await caller.listReviews({ appListingId: 'apl_1', limit: 20 });
+    expect(result).toEqual({ items: [{ id: 5 }], nextCursor: undefined });
+    expect(mockListAppListingReviews).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ scope: 'full' })
+    );
+  });
+
+  it('public-external: served with scope=public-external (offsite-only enforced in service)', async () => {
+    publicExternal = true;
+    const caller = appListingsRouter.createCaller(fakeCtx(undefined) as never);
+    await caller.listReviews({ appListingId: 'apl_1', limit: 20 });
+    expect(mockListAppListingReviews).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ scope: 'public-external' })
+    );
+  });
+
+  it('public-external, onsite listing (service → empty): empty page returned', async () => {
+    publicExternal = true;
+    mockListAppListingReviews.mockResolvedValue({ items: [], nextCursor: undefined });
+    const caller = appListingsRouter.createCaller(fakeCtx(undefined) as never);
+    const result = await caller.listReviews({ appListingId: 'apl_onsite', limit: 20 });
+    expect(result).toEqual({ items: [], nextCursor: undefined });
   });
 });

--- a/src/server/routers/__tests__/app-listings.router.review-write-gate.test.ts
+++ b/src/server/routers/__tests__/app-listings.router.review-write-gate.test.ts
@@ -30,24 +30,28 @@ const STORE_IDS = new Set([5]); // widened store cohort (non-mod, store-visible)
 const {
   mockIsAppListingsEnabled,
   mockIsAppBlocksEnabled,
+  mockResolveStoreVisibilityScope,
   mockUpsertReview,
   mockGetMyReview,
   mockListReviews,
 } = vi.hoisted(() => ({
   mockIsAppListingsEnabled: vi.fn(),
   mockIsAppBlocksEnabled: vi.fn(),
+  mockResolveStoreVisibilityScope: vi.fn(),
   mockUpsertReview: vi.fn(async () => ({ id: 1, recommended: true })),
   mockGetMyReview: vi.fn(async () => ({ id: 1, recommended: true, details: null, createdAt: new Date() })),
   mockListReviews: vi.fn(async () => ({ items: [{ id: 1 }], nextCursor: undefined })),
 }));
 
-// The write gate now reads `isAppListingsEnabled`; the router module ALSO
-// references `isAppBlocksEnabled`/`isAppBlocksAuthorEnabled` for OTHER procs'
-// middleware, so provide all three (only the two under test are exercised here).
+// The write gate reads `isAppListingsEnabled`; the READ gate now resolves a store
+// scope via `resolveStoreVisibilityScope`. The router module ALSO references
+// `isAppBlocksEnabled`/`isAppBlocksAuthorEnabled` for OTHER procs' middleware, so
+// provide all of them (only the ones under test are exercised here).
 vi.mock('~/server/services/app-blocks-flag', () => ({
   isAppListingsEnabled: mockIsAppListingsEnabled,
   isAppBlocksEnabled: mockIsAppBlocksEnabled,
   isAppBlocksAuthorEnabled: vi.fn(async () => false),
+  resolveStoreVisibilityScope: mockResolveStoreVisibilityScope,
 }));
 // The review service is dynamically imported by the procs; mock it so the DB /
 // generated client is never loaded, and so we can assert "NOT consulted".
@@ -78,6 +82,16 @@ function fakeListingsFlag(opts?: { user?: { id?: number; isModerator?: boolean }
 function fakeBlocksFlag(opts?: { user?: { isModerator?: boolean } }) {
   return Promise.resolve(!!opts?.user?.isModerator);
 }
+/**
+ * Store read scope: `full` iff the caller is store-visible (mod OR store cohort),
+ * else `none`. Mirrors the OR-fallback posture the read tests assert (listings ON
+ * → served; listings OFF → empty). The public-external axis stays dark here.
+ */
+function fakeResolveScope(opts?: { user?: { id?: number; isModerator?: boolean } }) {
+  const u = opts?.user;
+  const full = !!u && (!!u.isModerator || STORE_IDS.has(u.id ?? -1));
+  return Promise.resolve(full ? 'full' : 'none');
+}
 
 function fakeCtx(user: unknown) {
   return {
@@ -107,6 +121,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   mockIsAppListingsEnabled.mockImplementation(fakeListingsFlag);
   mockIsAppBlocksEnabled.mockImplementation(fakeBlocksFlag);
+  mockResolveStoreVisibilityScope.mockImplementation(fakeResolveScope);
 });
 
 // ---------------------------------------------------------------------------

--- a/src/server/routers/app-listings.router.ts
+++ b/src/server/routers/app-listings.router.ts
@@ -58,6 +58,8 @@ import {
   isAppBlocksAuthorEnabled,
   isAppBlocksEnabled,
   isAppListingsEnabled,
+  resolveStoreVisibilityScope,
+  type StoreVisibilityScope,
 } from '~/server/services/app-blocks-flag';
 import {
   appDeveloperProcedure,
@@ -112,22 +114,32 @@ const enforceAppBlocksAuthorFlag = middleware(async ({ ctx, next }) => {
 
 /**
  * Flag gate for the P2a PUBLIC READ procs (unified store). Anon-CAPABLE but DARK
- * until launch: for a real anon / non-mod viewer the flag never matches → mark
- * `_appBlocksDisabled` so the query returns an EMPTY page / NOT_FOUND (never an
+ * until launch: it resolves a STORE VISIBILITY SCOPE onto ctx (`_storeScope`) that
+ * the 3 read procs branch on — `none` returns an EMPTY page / NOT_FOUND (never an
  * error, mirroring `blocks.router`'s read gate) rather than throwing.
  *
- * W13 (PR-W1a / D8): repointed onto the DEDICATED store-visibility flag
- * `isAppListingsEnabled` — which itself OR-falls-back to `isAppBlocksEnabled`, so
- * the currently-visible cohort (mods + app-dev-testers via `app-blocks-enabled`)
- * is UNCHANGED today while the `app-listings` flag does not yet exist. A future
- * true-public flip widens ONLY `app-listings` (this store read path) WITHOUT
- * touching the held block-runtime gate. The AUTHOR gate
- * (`enforceAppBlocksAuthorFlag`) + the mod-only backfill (`enforceAppBlocksFlag`)
- * intentionally stay on their existing flags.
+ * ## External-before-onsite GA (Phase 1) — the kind-aware scope
+ *
+ * `resolveStoreVisibilityScope(ctx.user)` returns:
+ *   - `full`            — mods + app-dev-testers (`isAppListingsEnabled`, itself
+ *     OR-falling-back to `isAppBlocksEnabled`): sees ALL kinds, byte-identical to
+ *     today.
+ *   - `public-external` — the NEW global `app-listings-public-external` flag is on:
+ *     an anon/non-privileged viewer sees ONLY `kind='offsite'` listings (both
+ *     sub-kinds). Onsite App Blocks stay hidden. Threaded into the data-layer kind
+ *     predicate + the detail/reviews kind gate — the load-bearing boundary.
+ *   - `none`            — neither flag → dark (today's public default).
+ *
+ * 🔴 DARK / INERT as-merged: `app-listings-public-external` does NOT exist in Flipt
+ * yet, so a mod/tester still resolves `full` and everyone else `none` — ZERO change
+ * until that flag is created + enabled in a later phase. The AUTHOR gate
+ * (`enforceAppBlocksAuthorFlag`) + the mod-only backfill (`enforceAppBlocksFlag`) +
+ * the review WRITE gate (`enforceAppListingsWriteFlag`) intentionally stay on their
+ * existing flags — the public-external axis is READ-only.
  */
 const enforceAppListingsReadFlag = middleware(async ({ ctx, next }) => {
-  if (await isAppListingsEnabled({ user: ctx.user })) return next();
-  return next({ ctx: { _appBlocksDisabled: true } });
+  const _storeScope = await resolveStoreVisibilityScope({ user: ctx.user });
+  return next({ ctx: { _storeScope } });
 });
 
 /**
@@ -1048,13 +1060,14 @@ export const appListingsRouter = router({
     )
     .input(listAppListingsSchema)
     .query(async ({ ctx, input }) => {
-      if ((ctx as { _appBlocksDisabled?: boolean })._appBlocksDisabled) {
+      const scope = (ctx as { _storeScope?: StoreVisibilityScope })._storeScope ?? 'none';
+      if (scope === 'none') {
         return { items: [], nextCursor: undefined };
       }
       const { listAvailableListings } = await import(
         '~/server/services/blocks/app-listing.service'
       );
-      return listAvailableListings(input, { redCapable: isRedCapableRequest(ctx) });
+      return listAvailableListings(input, { redCapable: isRedCapableRequest(ctx), scope });
     }),
 
   /** Per-listing public detail, by EXACTLY ONE of slug or id (approved only). */
@@ -1069,11 +1082,12 @@ export const appListingsRouter = router({
     )
     .input(getAppListingDetailSchema)
     .query(async ({ ctx, input }) => {
-      if ((ctx as { _appBlocksDisabled?: boolean })._appBlocksDisabled) {
+      const scope = (ctx as { _storeScope?: StoreVisibilityScope })._storeScope ?? 'none';
+      if (scope === 'none') {
         throw throwNotFoundError('Listing not found');
       }
       const { getListingDetail } = await import('~/server/services/blocks/app-listing.service');
-      const detail = await getListingDetail(input, { redCapable: isRedCapableRequest(ctx) });
+      const detail = await getListingDetail(input, { redCapable: isRedCapableRequest(ctx), scope });
       if (!detail) throw throwNotFoundError('Listing not found');
       return detail;
     }),
@@ -1152,12 +1166,13 @@ export const appListingsRouter = router({
     )
     .input(listAppListingReviewsSchema)
     .query(async ({ ctx, input }) => {
-      if ((ctx as { _appBlocksDisabled?: boolean })._appBlocksDisabled) {
+      const scope = (ctx as { _storeScope?: StoreVisibilityScope })._storeScope ?? 'none';
+      if (scope === 'none') {
         return { items: [], nextCursor: undefined };
       }
       const { listAppListingReviews } = await import(
         '~/server/services/blocks/app-listing-review.service'
       );
-      return listAppListingReviews(input);
+      return listAppListingReviews(input, { scope });
     }),
 });

--- a/src/server/services/__tests__/app-blocks-flag.test.ts
+++ b/src/server/services/__tests__/app-blocks-flag.test.ts
@@ -30,6 +30,8 @@ import {
   isAppBlocksEnabled,
   isAppBlocksAuthorEnabled,
   isAppListingsEnabled,
+  isExternalListingsPublicEnabled,
+  resolveStoreVisibilityScope,
 } from '../app-blocks-flag';
 
 // Faithful stand-in for the live `app-blocks-enabled` rule: base OFF, with a
@@ -339,5 +341,120 @@ describe('isAppListingsEnabled — dedicated visibility flag + OR-fallback (W13)
     expect(mockIsFlipt).not.toHaveBeenCalledWith('app-blocks-pipeline-enabled');
     expect(mockIsFlipt).not.toHaveBeenCalledWith('app-blocks-runtime-enabled');
     expect(mockIsFlipt).not.toHaveBeenCalledWith('app-blocks-author');
+  });
+});
+
+/**
+ * External-before-onsite GA (Phase 1) — the PUBLIC EXTERNAL flag + scope resolver.
+ *
+ * `isExternalListingsPublicEnabled` is a PLAIN GLOBAL boolean (no user context).
+ * `resolveStoreVisibilityScope` composes it with `isAppListingsEnabled` on TWO
+ * independent axes, priority-ordered so a mod/tester ALWAYS gets `full`:
+ *   - mod/tester (app-listings/app-blocks-enabled ON)      → `full`
+ *   - public flag ON, non-privileged (or anon)             → `public-external`
+ *   - neither                                              → `none` (fail-closed)
+ *
+ * 🔴 DARK-by-default: with `app-listings-public-external` ABSENT (the as-merged
+ * state), a mod resolves `full` and everyone else `none` — byte-identical to today.
+ *
+ * The fake models all THREE keys: `app-blocks-enabled` = mod segment; `app-listings`
+ * = a per-user grant set (empty = dark window); `app-listings-public-external` = a
+ * configurable GLOBAL boolean.
+ */
+describe('resolveStoreVisibilityScope — external-before-onsite GA (Phase 1)', () => {
+  let appListingsGrants: Set<string>;
+  let publicExternalOn: boolean;
+
+  function fakeScopeFlags(
+    flag: string,
+    _entityId = 'global',
+    context: Record<string, string> = {}
+  ): boolean {
+    if (flag === 'app-blocks-enabled') return context.isModerator === 'true';
+    if (flag === 'app-listings') {
+      return typeof context.userId === 'string' && appListingsGrants.has(context.userId);
+    }
+    // Plain GLOBAL boolean — resolves the same regardless of entityId/context.
+    if (flag === 'app-listings-public-external') return publicExternalOn;
+    return false;
+  }
+
+  beforeEach(() => {
+    appListingsGrants = new Set();
+    publicExternalOn = false;
+    mockIsFlipt.mockReset();
+    mockIsFlipt.mockImplementation(async (...args: Parameters<typeof fakeScopeFlags>) =>
+      fakeScopeFlags(...args)
+    );
+  });
+
+  it('isExternalListingsPublicEnabled evaluates the plain global flag (no context)', async () => {
+    publicExternalOn = true;
+    await expect(isExternalListingsPublicEnabled()).resolves.toBe(true);
+    expect(mockIsFlipt).toHaveBeenCalledWith('app-listings-public-external');
+    publicExternalOn = false;
+    await expect(isExternalListingsPublicEnabled()).resolves.toBe(false);
+  });
+
+  it('DARK default (public flag absent): mod → full, non-mod/anon → none (byte-identical to today)', async () => {
+    // The as-merged state — `app-listings-public-external` grants nobody.
+    await expect(
+      resolveStoreVisibilityScope({ user: makeUser({ isModerator: true }) })
+    ).resolves.toBe('full');
+    await expect(
+      resolveStoreVisibilityScope({ user: makeUser({ id: 555, isModerator: false }) })
+    ).resolves.toBe('none');
+    await expect(resolveStoreVisibilityScope({ user: undefined })).resolves.toBe('none');
+    await expect(resolveStoreVisibilityScope()).resolves.toBe('none');
+  });
+
+  it('mod resolves full REGARDLESS of the public flag (public flag never narrows a mod)', async () => {
+    publicExternalOn = true;
+    await expect(
+      resolveStoreVisibilityScope({ user: makeUser({ isModerator: true }) })
+    ).resolves.toBe('full');
+    // The public flag is the SECOND axis — never consulted once `full` short-circuits.
+    expect(mockIsFlipt).not.toHaveBeenCalledWith('app-listings-public-external');
+  });
+
+  it('app-listings-granted tester resolves full REGARDLESS of the public flag', async () => {
+    appListingsGrants.add('888');
+    publicExternalOn = true;
+    await expect(
+      resolveStoreVisibilityScope({ user: makeUser({ id: 888, isModerator: false }) })
+    ).resolves.toBe('full');
+  });
+
+  it('public flag ON + non-privileged viewer → public-external', async () => {
+    publicExternalOn = true;
+    await expect(
+      resolveStoreVisibilityScope({ user: makeUser({ id: 555, isModerator: false }) })
+    ).resolves.toBe('public-external');
+  });
+
+  it('public flag ON + ANONYMOUS viewer → public-external (the anon audience)', async () => {
+    publicExternalOn = true;
+    await expect(resolveStoreVisibilityScope({ user: undefined })).resolves.toBe('public-external');
+    await expect(resolveStoreVisibilityScope()).resolves.toBe('public-external');
+  });
+
+  it('fail-closed: neither flag → none (public flag absent / Flipt down)', async () => {
+    mockIsFlipt.mockImplementation(async () => false);
+    await expect(
+      resolveStoreVisibilityScope({ user: makeUser({ id: 555, isModerator: false }) })
+    ).resolves.toBe('none');
+    await expect(resolveStoreVisibilityScope({ user: undefined })).resolves.toBe('none');
+  });
+
+  it('reads ONLY app-listings / app-blocks-enabled / app-listings-public-external keys', async () => {
+    publicExternalOn = true;
+    await resolveStoreVisibilityScope({ user: makeUser({ id: 555, isModerator: false }) });
+    for (const call of mockIsFlipt.mock.calls) {
+      expect(['app-listings', 'app-blocks-enabled', 'app-listings-public-external']).toContain(
+        call[0]
+      );
+    }
+    expect(mockIsFlipt).not.toHaveBeenCalledWith('app-blocks-pipeline-enabled');
+    expect(mockIsFlipt).not.toHaveBeenCalledWith('app-blocks-runtime-enabled');
   });
 });

--- a/src/server/services/__tests__/app-blocks-flag.test.ts
+++ b/src/server/services/__tests__/app-blocks-flag.test.ts
@@ -253,7 +253,7 @@ describe('isAppListingsEnabled — dedicated visibility flag + OR-fallback (W13)
 
   function fakeVisibilityFlags(
     flag: string,
-    entityId = 'global',
+    _entityId = 'global',
     context: Record<string, string> = {}
   ): boolean {
     if (flag === 'app-blocks-enabled') return context.isModerator === 'true';

--- a/src/server/services/app-blocks-flag.ts
+++ b/src/server/services/app-blocks-flag.ts
@@ -606,3 +606,79 @@ export async function isAppBlocksSharedStorageEnabled(opts?: {
   const user = opts.user;
   return isFlipt(APP_BLOCKS_SHARED_STORAGE_FLAG, String(user.id), buildFliptContext(user));
 }
+
+/**
+ * Dedicated GLOBAL flag for the PUBLIC EXTERNAL App-store read GA — the mechanism
+ * that lets the store serve `kind='offsite'` (external app) listings to the
+ * ANONYMOUS public while `kind='onsite'` App Blocks stay gated to the existing
+ * mods + app-dev-testers cohort. This is a SEPARATE, ORTHOGONAL axis from the
+ * `app-listings` catalog-visibility flag: `app-listings` gates WHO sees the FULL
+ * catalog (all kinds); this flag opens ONLY the offsite subset to EVERYONE.
+ *
+ * ## Why a GLOBAL boolean (not segmented)
+ *
+ * The audience is the anonymous public — an anon viewer carries NO user context,
+ * so a segment could never match and the flag would silently stay dark. It is
+ * therefore evaluated globally (entityId='global', empty context), mirroring
+ * `isAppBlocksPipelineEnabled` / `isAppBlocksRuntimeEnabled` exactly, and MUST be
+ * created in Flipt as a PLAIN base-`enabled` boolean (NO segment).
+ *
+ * ## Fail-closed / dark posture
+ *
+ * The flag does NOT exist in Flipt at merge time (it is created in a LATER phase,
+ * base `enabled: false`, only when the offsite store is ready to go public) or if
+ * Flipt is unreachable → `isFlipt` returns `false` → `resolveStoreVisibilityScope`
+ * returns `none` for a non-privileged viewer and `full` for a mod/tester — i.e.
+ * BYTE-IDENTICAL to today. This flag NEVER upgrades a mod/tester away from `full`;
+ * it only ever moves a non-privileged viewer from `none` → `public-external`.
+ */
+export const APP_LISTINGS_PUBLIC_EXTERNAL_FLAG = 'app-listings-public-external';
+
+/**
+ * GLOBAL gate for the PUBLIC EXTERNAL App-store read GA. Evaluates the dedicated
+ * `app-listings-public-external` flag with no user context (entityId='global',
+ * empty context), mirroring `isAppBlocksPipelineEnabled`. Fail-closed: absent flag
+ * / Flipt-down → `false`. See APP_LISTINGS_PUBLIC_EXTERNAL_FLAG.
+ */
+export async function isExternalListingsPublicEnabled(): Promise<boolean> {
+  return isFlipt(APP_LISTINGS_PUBLIC_EXTERNAL_FLAG);
+}
+
+/**
+ * The store read-path VISIBILITY SCOPE resolved once per request, then threaded
+ * into every store read proc + the data-layer kind predicate:
+ *   - `full`            — the caller sees ALL kinds (today's mod/tester gate).
+ *   - `public-external` — the caller sees ONLY `kind='offsite'` approved listings
+ *     (both `connect` and `external-link` sub-kinds); onsite is excluded.
+ *   - `none`            — the caller sees NOTHING (dark; today's public default).
+ */
+export type StoreVisibilityScope = 'full' | 'public-external' | 'none';
+
+/**
+ * Resolve the {@link StoreVisibilityScope} for a store read request. The two flags
+ * are INDEPENDENT axes and are checked in priority order so the mod/tester path is
+ * NEVER narrowed by the public flag:
+ *   1. `isAppListingsEnabled({ user })` (mods + app-dev-testers, OR-falling-back to
+ *      `app-blocks-enabled`) → `full` — sees every kind, byte-identical to today.
+ *   2. else `isExternalListingsPublicEnabled()` (the global public flag) →
+ *      `public-external` — sees only offsite listings.
+ *   3. else → `none` — dark.
+ *
+ * 🔴 DARK-by-default invariant: with `app-listings-public-external` ABSENT in Flipt
+ * (its as-merged state), a mod/tester still resolves `full` and everyone else
+ * resolves `none` — ZERO observable change until the public flag is created +
+ * enabled in a later phase.
+ */
+export async function resolveStoreVisibilityScope(opts?: {
+  user?: SessionUser;
+}): Promise<StoreVisibilityScope> {
+  // Axis 1 — the existing catalog-visibility gate (mods + app-dev-testers). MUST be
+  // checked FIRST so a privileged viewer always gets `full`, never `public-external`
+  // (the public flag can only ever LIFT a non-privileged viewer, never narrow a mod).
+  if (await isAppListingsEnabled(opts)) return 'full';
+  // Axis 2 — the global public-external flag (anon + everyone). Global eval; a
+  // non-privileged viewer sees ONLY offsite listings.
+  if (await isExternalListingsPublicEnabled()) return 'public-external';
+  // Fail-closed: neither flag → dark.
+  return 'none';
+}

--- a/src/server/services/blocks/__tests__/app-listing-review.service.test.ts
+++ b/src/server/services/blocks/__tests__/app-listing-review.service.test.ts
@@ -292,6 +292,25 @@ describe('listAppListingReviews', () => {
     expect(args.where).toMatchObject({ appListing: { is: { status: 'approved' } } });
   });
 
+  it('public-external scope → relation filter ANDs kind:offsite (an onsite listing\'s reviews are empty)', async () => {
+    mockRead.appListingReview.findMany.mockResolvedValue([]);
+    await listAppListingReviews({ appListingId: APP_ID, limit: 20 }, { scope: 'public-external' });
+    const args = mockRead.appListingReview.findMany.mock.calls[0][0];
+    // Under the public scope the target listing must ITSELF be offsite — so a
+    // crafted onsite appListingId matches nothing (empty), the review security gate.
+    expect(args.where).toMatchObject({
+      appListing: { is: { status: 'approved', kind: 'offsite' } },
+    });
+  });
+
+  it('full scope (default) → NO kind restriction on the relation filter (unchanged)', async () => {
+    mockRead.appListingReview.findMany.mockResolvedValue([]);
+    await listAppListingReviews({ appListingId: APP_ID, limit: 20 }, { scope: 'full' });
+    const args = mockRead.appListingReview.findMany.mock.calls[0][0];
+    expect(args.where.appListing.is).toEqual({ status: 'approved' });
+    expect(args.where.appListing.is.kind).toBeUndefined();
+  });
+
   it('emits a nextCursor when a full page + 1 comes back (keyset)', async () => {
     // limit 2 → take 3; return 3 rows → hasNext, cursor = last VISIBLE row id.
     mockRead.appListingReview.findMany.mockResolvedValue([row(5), row(4), row(3)]);

--- a/src/server/services/blocks/__tests__/app-listing-review.service.test.ts
+++ b/src/server/services/blocks/__tests__/app-listing-review.service.test.ts
@@ -315,7 +315,7 @@ describe('listAppListingReviews', () => {
     // limit 2 → take 3; return 3 rows → hasNext, cursor = last VISIBLE row id.
     mockRead.appListingReview.findMany.mockResolvedValue([row(5), row(4), row(3)]);
     const res = await listAppListingReviews({ appListingId: APP_ID, limit: 2 });
-    expect(res.items.map((i) => i.id)).toEqual([5, 4]);
+    expect(res.items.map((i: { id: number }) => i.id)).toEqual([5, 4]);
     expect(res.nextCursor).toBe(4);
   });
 

--- a/src/server/services/blocks/__tests__/app-listing.public-scope.test.ts
+++ b/src/server/services/blocks/__tests__/app-listing.public-scope.test.ts
@@ -1,0 +1,203 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * External-before-onsite GA (Phase 1) — the STORE-SCOPE kind gate on the
+ * AppListing-backed unified store read path (`app-listing.service`).
+ *
+ *   - listingPublicVisibilityFilter — the pure SQL drift-guard: `full` → TRUE,
+ *     `public-external` → `al.kind = 'offsite'` (BOTH sub-kinds), `none` → FALSE.
+ *   - listAvailableListings — under `public-external` the keyset WHERE carries the
+ *     offsite-only predicate; under `full` it carries TRUE (unchanged).
+ *   - getListingDetail — under `public-external` an ONSITE listing is treated as
+ *     MISSING (null), while an OFFSITE listing (either sub-kind, incl. a `connect`
+ *     listing with a `connectClientId`) is shown; `full` imposes no kind gate.
+ *
+ * No DB in unit tests: mock `dbRead.$queryRaw` (keyset id page — capture the SQL) +
+ * `dbRead.appListing.findFirst/findMany` (hydration — return seeded rows).
+ */
+
+const { mockDbRead } = vi.hoisted(() => ({
+  mockDbRead: {
+    $queryRaw: vi.fn(async (..._a: unknown[]): Promise<unknown[]> => []),
+    appListing: {
+      findMany: vi.fn(async (..._a: unknown[]): Promise<unknown[]> => []),
+      findFirst: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
+    },
+  },
+}));
+
+vi.mock('~/server/db/client', () => ({ dbRead: mockDbRead, dbWrite: mockDbRead }));
+vi.mock('~/client-utils/cf-images-utils', () => ({ getEdgeUrl: (src: string) => src }));
+vi.mock('~/env/server', () => ({ env: { APPS_DOMAIN: 'civit.ai' } }));
+vi.mock('~/server/common/constants', () => ({ CacheTTL: { hour: 3600 } }));
+vi.mock('~/server/utils/cache-helpers', () => ({
+  queryCache:
+    () =>
+    async (sql: unknown): Promise<unknown[]> =>
+      mockDbRead.$queryRaw(sql),
+}));
+
+import {
+  getListingDetail,
+  listAvailableListings,
+  listingPublicVisibilityFilter,
+} from '../app-listing.service';
+
+/** Reconstruct the SQL string Prisma received (single Prisma.Sql arg). */
+function capturedSql(): string {
+  const last = mockDbRead.$queryRaw.mock.calls.at(-1);
+  const first = last?.[0] as { sql?: unknown } | undefined;
+  return first && typeof first.sql === 'string' ? first.sql : '';
+}
+
+/** A hydrated ONSITE listing row (as `listingHydrateSelect` returns). */
+function onsiteRow(over: Record<string, unknown> = {}) {
+  return {
+    id: 'apl_1',
+    kind: 'onsite',
+    slug: 'cool-app',
+    name: 'Cool App',
+    tagline: 't',
+    description: 'body',
+    category: 'utility',
+    contentRating: 'pg',
+    externalUrl: null,
+    connectClientId: null,
+    appBlockId: 'ab_1',
+    icon: null,
+    cover: null,
+    user: { id: 7, username: 'dev', image: null },
+    metric: null,
+    appBlock: {
+      currentVersionDeployedAt: new Date('2026-01-01T00:00:00Z'),
+      manifest: { name: 'Cool App', page: { path: '/run' } },
+    },
+    screenshots: [],
+    ...over,
+  };
+}
+
+/** A hydrated OFFSITE external-link listing row — NO backing AppBlock. */
+function offsiteExternalRow(over: Record<string, unknown> = {}) {
+  return {
+    id: 'apl_2',
+    kind: 'offsite',
+    slug: 'ext-app',
+    name: 'Ext App',
+    tagline: 't',
+    description: 'body',
+    category: 'utility',
+    contentRating: 'pg',
+    externalUrl: 'https://example.com/ext',
+    connectClientId: null,
+    appBlockId: null,
+    icon: null,
+    cover: null,
+    user: { id: 7, username: 'dev', image: null },
+    metric: null,
+    appBlock: null,
+    screenshots: [],
+    ...over,
+  };
+}
+
+/** A hydrated OFFSITE CONNECT listing row (links an OAuth client) — still offsite. */
+function offsiteConnectRow(over: Record<string, unknown> = {}) {
+  return offsiteExternalRow({
+    id: 'apl_3',
+    slug: 'connect-app',
+    name: 'Connect App',
+    externalUrl: null,
+    connectClientId: 'oauthclient_abc',
+    ...over,
+  });
+}
+
+describe('listingPublicVisibilityFilter — SQL drift-guard', () => {
+  it('full → TRUE (no kind restriction, byte-identical to today)', () => {
+    expect(listingPublicVisibilityFilter('full').sql).toBe('TRUE');
+  });
+
+  it("public-external → al.kind = 'offsite' (both sub-kinds; NOT gated on connect_client_id)", () => {
+    const sql = listingPublicVisibilityFilter('public-external').sql;
+    expect(sql).toBe("al.kind = 'offsite'");
+    // 🔴 the merged model: the gate is kind='offsite', NEVER connect_client_id.
+    expect(sql).not.toMatch(/connect_client_id/i);
+  });
+
+  it('none → FALSE (fail-closed defense-in-depth)', () => {
+    expect(listingPublicVisibilityFilter('none').sql).toBe('FALSE');
+  });
+});
+
+describe('listAvailableListings — STORE-SCOPE kind gate in the keyset WHERE', () => {
+  beforeEach(() => {
+    mockDbRead.$queryRaw.mockReset();
+    mockDbRead.$queryRaw.mockResolvedValue([]);
+    mockDbRead.appListing.findMany.mockReset();
+    mockDbRead.appListing.findMany.mockResolvedValue([]);
+  });
+
+  it("public-external → WHERE carries al.kind = 'offsite'", async () => {
+    await listAvailableListings(
+      { kind: 'all', sort: 'newest', limit: 20 },
+      { scope: 'public-external' }
+    );
+    expect(capturedSql()).toMatch(/al\.kind = 'offsite'/i);
+  });
+
+  it('full → WHERE carries the TRUE predicate (no offsite narrowing)', async () => {
+    await listAvailableListings({ kind: 'all', sort: 'newest', limit: 20 }, { scope: 'full' });
+    const sql = capturedSql();
+    // The TRUE predicate is ANDed; the offsite-only clause must NOT appear.
+    expect(sql).not.toMatch(/al\.kind = 'offsite'/i);
+  });
+
+  it('no scope passed → defaults to full (offsite clause absent — back-compat)', async () => {
+    await listAvailableListings({ kind: 'all', sort: 'newest', limit: 20 });
+    expect(capturedSql()).not.toMatch(/al\.kind = 'offsite'/i);
+  });
+});
+
+describe('getListingDetail — STORE-SCOPE kind gate (app-layer)', () => {
+  beforeEach(() => {
+    mockDbRead.appListing.findFirst.mockReset();
+  });
+
+  it('public-external → HIDES (null) an ONSITE listing even by a crafted id/slug', async () => {
+    mockDbRead.appListing.findFirst.mockResolvedValueOnce({ ...onsiteRow(), status: 'approved' });
+    expect(await getListingDetail({ slug: 'cool-app' }, { scope: 'public-external' })).toBeNull();
+  });
+
+  it('public-external → SHOWS an OFFSITE external-link listing', async () => {
+    mockDbRead.appListing.findFirst.mockResolvedValueOnce({
+      ...offsiteExternalRow(),
+      status: 'approved',
+    });
+    const detail = await getListingDetail({ slug: 'ext-app' }, { scope: 'public-external' });
+    expect(detail).not.toBeNull();
+    expect(detail!.id).toBe('apl_2');
+  });
+
+  it('public-external → SHOWS an OFFSITE CONNECT listing (offsite = both sub-kinds)', async () => {
+    mockDbRead.appListing.findFirst.mockResolvedValueOnce({
+      ...offsiteConnectRow(),
+      status: 'approved',
+    });
+    const detail = await getListingDetail({ slug: 'connect-app' }, { scope: 'public-external' });
+    expect(detail).not.toBeNull();
+    expect(detail!.id).toBe('apl_3');
+  });
+
+  it('full → SHOWS an ONSITE listing (no kind gate — unchanged)', async () => {
+    mockDbRead.appListing.findFirst.mockResolvedValueOnce({ ...onsiteRow(), status: 'approved' });
+    const detail = await getListingDetail({ slug: 'cool-app' }, { scope: 'full' });
+    expect(detail).not.toBeNull();
+    expect(detail!.id).toBe('apl_1');
+  });
+
+  it('default scope (none passed) → full: ONSITE shown (back-compat)', async () => {
+    mockDbRead.appListing.findFirst.mockResolvedValueOnce({ ...onsiteRow(), status: 'approved' });
+    expect(await getListingDetail({ slug: 'cool-app' })).not.toBeNull();
+  });
+});

--- a/src/server/services/blocks/__tests__/app-listing.public-scope.test.ts
+++ b/src/server/services/blocks/__tests__/app-listing.public-scope.test.ts
@@ -157,6 +157,27 @@ describe('listAvailableListings — STORE-SCOPE kind gate in the keyset WHERE', 
     await listAvailableListings({ kind: 'all', sort: 'newest', limit: 20 });
     expect(capturedSql()).not.toMatch(/al\.kind = 'offsite'/i);
   });
+
+  it("public-external + client override input.kind='onsite' → offsite predicate STILL wins (empty)", async () => {
+    // Security-audit (a): a public viewer cannot escape the offsite-only gate by
+    // asking for onsite. The scope predicate `al.kind = 'offsite'` is emitted
+    // UNCONDITIONALLY, alongside the client kind filter (`al.kind = <onsite>`), so
+    // the WHERE self-contradicts (onsite AND offsite) → no onsite row can return.
+    mockDbRead.$queryRaw.mockResolvedValueOnce([]);
+    const result = await listAvailableListings(
+      { kind: 'onsite', sort: 'newest', limit: 20 },
+      { scope: 'public-external' }
+    );
+    const sql = capturedSql();
+    // The scope predicate is present regardless of the client-supplied kind...
+    expect(sql).toMatch(/al\.kind = 'offsite'/i);
+    // ...AND the client kind filter clause is ALSO applied (the parameterized
+    // `... IS NULL OR al.kind = ...`), so an onsite override can never DROP the
+    // offsite predicate — the two clauses AND together, never replace each other.
+    expect(sql).toMatch(/IS NULL OR al\.kind =/i);
+    // Net effect at the DB: contradictory WHERE → no onsite listing is returned.
+    expect(result).toEqual({ items: [], nextCursor: undefined });
+  });
 });
 
 describe('getListingDetail — STORE-SCOPE kind gate (app-layer)', () => {

--- a/src/server/services/blocks/app-listing-review.service.ts
+++ b/src/server/services/blocks/app-listing-review.service.ts
@@ -1,4 +1,5 @@
 import { dbRead, dbWrite } from '~/server/db/client';
+import type { StoreVisibilityScope } from '~/server/services/app-blocks-flag';
 import {
   LISTING_REVIEW_DETAILS_MAX,
   type AppListingReviewListItem,
@@ -229,9 +230,16 @@ export async function getMyAppListingReview(
  * id) when more rows exist.
  */
 export async function listAppListingReviews(
-  input: ListAppListingReviewsInput
+  input: ListAppListingReviewsInput,
+  opts: { scope?: StoreVisibilityScope } = {}
 ): Promise<{ items: AppListingReviewListItem[]; nextCursor?: number }> {
   const take = Math.min(Math.max(input.limit ?? 20, 1), 50);
+  // Default `full` for callers that don't pass a scope (the router ALWAYS passes an
+  // explicit scope and NEVER calls this with `none` — it short-circuits an empty
+  // page at the proc). Under `public-external` the target listing must ITSELF be
+  // offsite, else the relation filter matches nothing → empty: a public viewer must
+  // not read the reviews of an onsite listing even by a crafted appListingId.
+  const scope = opts.scope ?? 'full';
   const rows = await dbRead.appListingReview.findMany({
     where: {
       appListingId: input.appListingId,
@@ -239,7 +247,11 @@ export async function listAppListingReviews(
       // approved, but a listing can later be removed/rejected — its reviews must not
       // stay publicly enumerable by id once the read flag widens to anon at the P2d
       // cutover. Filtering on the relation also makes a missing listing return empty.
-      appListing: { is: { status: 'approved' } },
+      // The STORE-SCOPE kind gate ANDs onto that relation filter under
+      // `public-external` (offsite-only), so an onsite listing's reviews are empty.
+      appListing: {
+        is: { status: 'approved', ...(scope === 'public-external' ? { kind: 'offsite' } : {}) },
+      },
       exclude: false,
       tosViolation: false,
       ...(input.cursor ? { id: { lt: input.cursor } } : {}),

--- a/src/server/services/blocks/app-listing.service.ts
+++ b/src/server/services/blocks/app-listing.service.ts
@@ -527,14 +527,16 @@ export async function listAvailableListings(
 
   // Hydrate the public projection for the page, then re-apply the keyset order
   // (findMany does not preserve the `IN (...)` order).
-  const pageIds = trimmed.map((r) => r.id);
+  const pageIds = trimmed.map((r: { id: string; sort_key: string }) => r.id);
   const hydrated = await dbRead.appListing.findMany({
     where: { id: { in: pageIds } },
     select: listingHydrateSelect,
   });
-  const byId = new Map(hydrated.map((r) => [r.id, r]));
+  const byId = new Map(
+    hydrated.map((r: HydratedListing): [string, HydratedListing] => [r.id, r])
+  );
   const items = pageIds
-    .map((id) => byId.get(id))
+    .map((id: string) => byId.get(id))
     .filter((r): r is HydratedListing => r != null)
     .map(projectListingCard);
 

--- a/src/server/services/blocks/app-listing.service.ts
+++ b/src/server/services/blocks/app-listing.service.ts
@@ -6,6 +6,7 @@ import { CacheTTL } from '~/server/common/constants';
 import { dbRead } from '~/server/db/client';
 import { toPublicBlockManifest } from '~/server/schema/blocks/subscription.schema';
 import { isMatureContentRating } from '~/server/utils/server-domain';
+import type { StoreVisibilityScope } from '~/server/services/app-blocks-flag';
 import type {
   GetAppListingDetailInput,
   ListAllListingsForModerationInput,
@@ -398,6 +399,26 @@ export function listingMatureFilter(redCapable: boolean): Prisma.Sql {
   return Prisma.sql`COALESCE(LOWER(al.content_rating), '') NOT IN ('r', 'x')`;
 }
 
+/**
+ * The STORE-SCOPE kind predicate — the load-bearing security boundary for the
+ * public external App-store GA. Mirrors `listingMatureFilter`'s pure-`Prisma.Sql`
+ * shape (uses the `al` alias, safe to AND into the keyset WHERE):
+ *   - `full`            → `TRUE` (no kind restriction — byte-identical to today).
+ *   - `public-external` → `al.kind = 'offsite'` — the offsite subset ONLY, for BOTH
+ *     sub-kinds (`connect` AND `external-link`). Onsite App Blocks are excluded.
+ *     🔴 The kind gate is `kind='offsite'`, NOT `connect_client_id IS NULL` — an
+ *     offsite listing is public whether or not it links an OAuth connect client.
+ *   - `none`            → `FALSE` — fail-closed. (The router short-circuits `none`
+ *     before reaching SQL, so this is defense-in-depth, never the live path.)
+ *
+ * Exported so the drift-guard unit test can assert the exact SQL each scope emits.
+ */
+export function listingPublicVisibilityFilter(scope: StoreVisibilityScope): Prisma.Sql {
+  if (scope === 'full') return Prisma.sql`TRUE`;
+  if (scope === 'public-external') return Prisma.sql`al.kind = 'offsite'`;
+  return Prisma.sql`FALSE`;
+}
+
 // ---------------------------------------------------------------------------
 // Global recommend mean (the Bayesian prior mean `m`, 1h-cached scalar).
 // ---------------------------------------------------------------------------
@@ -439,10 +460,14 @@ export async function getGlobalRecommendMean(): Promise<number> {
  */
 export async function listAvailableListings(
   input: ListAppListingsInput,
-  opts: { redCapable?: boolean } = {}
+  opts: { redCapable?: boolean; scope?: StoreVisibilityScope } = {}
 ): Promise<{ items: ListingCard[]; nextCursor?: string }> {
   const { kind, category, sort, cursor, limit } = input;
   const redCapable = opts.redCapable ?? false;
+  // Default `full` for callers that don't pass a scope (the router ALWAYS passes
+  // an explicit scope and NEVER calls this with `none` — it short-circuits an
+  // empty page at the proc). `full` → `TRUE` predicate → byte-identical WHERE.
+  const scope = opts.scope ?? 'full';
 
   const { cursorSortKey, cursorId, cursorMean } = decodeListingCursor(cursor);
 
@@ -479,6 +504,9 @@ export async function listAvailableListings(
       AND (${kindParam}::text IS NULL OR al.kind = ${kindParam}::text)
       AND (${categoryParam}::text IS NULL OR al.category = ${categoryParam}::text)
       AND ${listingMatureFilter(redCapable)}
+      -- STORE-SCOPE kind gate: full scope emits TRUE (unchanged); public-external
+      -- emits offsite-only (onsite excluded) -- the whole public/onsite boundary.
+      AND ${listingPublicVisibilityFilter(scope)}
       AND (
         ${cursorSortKey}::text IS NULL
         OR (${sortKeyExpr}, al.id) ${keysetCmp} (${cursorSortKey}::text, ${cursorId}::text)
@@ -521,9 +549,11 @@ export async function listAvailableListings(
  */
 export async function getListingDetail(
   input: GetAppListingDetailInput,
-  opts: { redCapable?: boolean } = {}
+  opts: { redCapable?: boolean; scope?: StoreVisibilityScope } = {}
 ): Promise<ListingDetail | null> {
   const redCapable = opts.redCapable ?? false;
+  // Default `full` for callers that don't pass a scope (see listAvailableListings).
+  const scope = opts.scope ?? 'full';
   // Assert exactly-one selector in the SERVICE (the zod `.refine` only guards the
   // tRPC boundary, but this fn is exported). Neither → `findFirst({ slug:
   // undefined })` would return an ARBITRARY approved row (enumeration footgun);
@@ -544,6 +574,12 @@ export async function getListingDetail(
   // can't reuse this for a non-public path: a non-approved row returns null
   // exactly like a missing one — never its data.
   if (!row || row.status !== 'approved') return null;
+  // STORE-SCOPE kind gate (the public/onsite security boundary): under
+  // `public-external` an ONSITE listing is indistinguishable from a missing one —
+  // return null so no crafted id/slug can reach an onsite listing's detail. Both
+  // offsite sub-kinds (connect + external-link) remain visible (gate on `kind`,
+  // never `connectClientId`). `full` imposes no kind restriction (unchanged).
+  if (scope === 'public-external' && row.kind !== 'offsite') return null;
   // DEPLOY-GATE (generic, all app-blocks): an ONSITE listing whose backing
   // AppBlock has NEVER successfully deployed is indistinguishable from a missing
   // one — its `<slug>.<APPS_DOMAIN>` origin would 404. `currentVersionDeployedAt`


### PR DESCRIPTION
## Summary

Phase 1 of "external App-store listings before onsite" — introduces the **mechanism** to serve external (`kind='offsite'`) listings to the public while onsite App Blocks (`kind='onsite'`) stay gated to mods + testers. **Backend-only, additive, and shipped DARK/inert: zero behavior change today.**

The new global flag `app-listings-public-external` does **not** exist in Flipt yet, so `resolveStoreVisibilityScope` returns `full` for mods/testers (byte-identical to today) and `none` for everyone else. Nothing widens until that flag is created + enabled in a later phase.

## What's in

- **`app-blocks-flag.ts`** — `APP_LISTINGS_PUBLIC_EXTERNAL_FLAG` + `isExternalListingsPublicEnabled()` (plain global boolean, fail-closed, mirrors the existing pipeline/runtime global flags), and `resolveStoreVisibilityScope({ user })` → `'full' | 'public-external' | 'none'`. The two flags are **independent axes**, priority-ordered so the public flag can only ever lift a non-privileged viewer `none → public-external`, never narrow a mod away from `full`.
- **`app-listing.service.ts`** — pure `listingPublicVisibilityFilter(scope)` predicate (`full`→`TRUE`, `public-external`→`al.kind = 'offsite'`, `none`→`FALSE`) ANDed into the `listAvailableListings` keyset WHERE; an app-layer kind gate in `getListingDetail` (onsite → `null` under `public-external`).
- **`app-listing-review.service.ts`** — the scope threads into `listAppListingReviews` as a relation filter (`kind: 'offsite'` under `public-external`), so a crafted `appListingId` for an onsite listing returns empty.
- **`app-listings.router.ts`** — the read middleware resolves `_storeScope` onto ctx; the 3 read procs (`listAvailable` / `getAppDetail` / `listReviews`) branch on it (`none` → empty page / NOT_FOUND) and thread the scope down.

## The kind model (important)

The kind gate is **`kind='offsite'`**, covering **both** offsite sub-kinds (`connect` and `external-link`) — **not** `connect_client_id IS NULL`. Per the merged external+connect model, an offsite listing is public whether or not it links an OAuth client.

## Security boundary

The onsite exclusion is enforced **three ways** — list (SQL WHERE), detail (post-fetch app-layer gate on the resolved row), and reviews (relation filter) — so no crafted `id` / `slug` / `cursor` can reach an onsite listing under the public scope. The `full` path is byte-identical to today (predicate `TRUE`, no detail/reviews kind restriction). Fail-closed: flag absent / neither flag → `none`.

## Tests

- Resolver truth-table + fail-closed (mod→full, public-flag-on anon→public-external, neither→none; public flag never narrows a mod).
- Predicate SQL drift-guard.
- Service kind gate: onsite→null/empty, offsite (incl. a `connect` listing)→shown, `full` unchanged.
- Router scope threading, incl. onsite `getAppDetail` → 404 and `listReviews` → empty under `public-external`.

`tsc --noEmit` clean on all touched files (remaining errors are the pre-existing `kysely` / unbuilt-submodule env artifacts).

## Scope / follow-ups (out of Phase 1)

Reviews-write, submission, page/UI/deIndex/sitemap, and the actual flag creation + flip are **not** in this PR.

🔴 **Pre-flip gate:** before `app-listings-public-external` is ever enabled, the connect flow needs an end-to-end drive + a dedicated security audit (a connect listing surfaces a public OAuth `client_id` and a Connect affordance), and public-rendered creator imagery must have gone through real per-image scanning. This PR only ships the inert read mechanism.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
