### PR TITLE
fix(prom): register image-ingestion gauges on scraped instrumentation registry

### DIFF
--- a/src/server/prom/client.ts
+++ b/src/server/prom/client.ts
@@ -4,6 +4,8 @@
 import client from 'prom-client';
 import {
   PROM_PREFIX,
+  instrumentationRegistry,
+  registerInstrumentationMetric,
   redisCommandsInflight,
   redisCommandDuration,
   sysredisSentinelTopologyChangesCounter,
@@ -44,8 +46,6 @@ declare global {
   var pgGaugeInitialized: boolean;
   // eslint-disable-next-line no-var
   var heavyBulkheadGaugeInitialized: boolean;
-  // eslint-disable-next-line no-var
-  var imageIngestionGaugeInitialized: boolean;
 }
 
 // Image-ingestion working-state backlog + oldest-age gauges. These are DB-derived,
@@ -126,30 +126,37 @@ function maybeRefreshIngestionBacklog() {
     void refreshIngestionBacklog();
 }
 
-if (!global.imageIngestionGaugeInitialized) {
-  new client.Gauge({
-    name: PROM_PREFIX + 'image_ingestion_backlog',
-    help: 'Images in a non-terminal working ingestion state (Pending/Error/Rescan/PendingManualAssignment)',
-    labelNames: ['status'],
-    collect() {
-      maybeRefreshIngestionBacklog();
-      this.reset();
-      for (const row of ingestionBacklogCache) this.set({ status: row.status }, row.backlog);
-    },
-  });
-  new client.Gauge({
-    name: PROM_PREFIX + 'image_ingestion_oldest_age_seconds',
-    help: 'Age in seconds of the oldest image (now - min(createdAt)) per non-terminal ingestion state',
-    labelNames: ['status'],
-    collect() {
-      maybeRefreshIngestionBacklog();
-      this.reset();
-      for (const row of ingestionBacklogCache)
-        this.set({ status: row.status }, row.oldestAgeSeconds);
-    },
-  });
-  global.imageIngestionGaugeInitialized = true;
-}
+registerInstrumentationMetric(
+  PROM_PREFIX + 'image_ingestion_backlog',
+  () =>
+    new client.Gauge({
+      name: PROM_PREFIX + 'image_ingestion_backlog',
+      help: 'Images in a non-terminal working ingestion state (Pending/Error/Rescan/PendingManualAssignment)',
+      labelNames: ['status'],
+      registers: [instrumentationRegistry],
+      collect() {
+        maybeRefreshIngestionBacklog();
+        this.reset();
+        for (const row of ingestionBacklogCache) this.set({ status: row.status }, row.backlog);
+      },
+    })
+);
+registerInstrumentationMetric(
+  PROM_PREFIX + 'image_ingestion_oldest_age_seconds',
+  () =>
+    new client.Gauge({
+      name: PROM_PREFIX + 'image_ingestion_oldest_age_seconds',
+      help: 'Age in seconds of the oldest image (now - min(createdAt)) per non-terminal ingestion state',
+      labelNames: ['status'],
+      registers: [instrumentationRegistry],
+      collect() {
+        maybeRefreshIngestionBacklog();
+        this.reset();
+        for (const row of ingestionBacklogCache)
+          this.set({ status: row.status }, row.oldestAgeSeconds);
+      },
+    })
+);
 
 // Heavy-route bulkhead observability (per pod). collect()-based so it reflects the
 // live in-process state on each scrape with no per-request work. This is the signal


### PR DESCRIPTION
## Problem

Two Prometheus gauges emit **0 series in prod** because they register on the wrong prom-client registry — the one `/api/metrics` never scrapes:

- `civitai_app_image_ingestion_backlog`
- `civitai_app_image_ingestion_oldest_age_seconds`

These back the ingestion dashboard's top row, so the panels read empty.

## Root cause

prom-client is **not** in `serverExternalPackages` (`next.config.mjs`), so Next's instrumentation webpack graph and the request graph each get their own module-default `client.register`.

At boot, `src/instrumentation.node.ts` -> `~/server/eventloop-longtask` statically imports `~/server/prom/client`, so the **instrumentation** graph evaluates `prom/client.ts` first: it constructs the two gauges with plain `new client.Gauge({...})` on *its* default register and flips the `global.imageIngestionGaugeInitialized` boolean (which *is* shared across graphs via `globalThis`). When the **request** graph later evaluates the file, the `if (!global.imageIngestionGaugeInitialized)` guard is already `true`, so the gauges never register on the request graph's `client.register` — the one `src/pages/api/metrics.ts` actually scrapes.

## Fix

`metrics.ts` scrapes `client.register` **and** a cross-graph shared `instrumentationRegistry` (pinned on `globalThis`). Register both gauges on `instrumentationRegistry` via the existing idempotent `registerInstrumentationMetric` helper (same pattern the eventloop-longtask metrics already use), and drop the now-unnecessary `imageIngestionGaugeInitialized` cross-graph boolean guard — the helper is idempotent (get-or-create via `getSingleMetric`), so whichever graph evaluates first wins and the other reuses the instance with no throw.

All DB logic is unchanged: the per-state `UNION ALL` query, the `SET LOCAL statement_timeout=10000` transaction wrapper, `pgDbRead`, the ~45s TTL cache, and the swallowed-error background refresh. Only the registration/registry changed.

## Verification

`vitest` with `vi.importActual('~/server/prom/client')` (the test setup mocks the module, so `importActual` loads the real one; pg pools construct lazily and don't connect at import) — after import, both `instrumentationRegistry.getSingleMetric('civitai_app_image_ingestion_backlog')` and `...oldest_age_seconds` are defined. Passes. Typecheck clean.

## Follow-up (pre-existing, not fixed here)

The pg-pool gauges (`node_postgres_*`) and heavy-bulkhead gauges (`civitai_app_heavy_bulkhead_*`) in the same file share this exact latent registry bug. They're intentionally left out of this PR to keep it minimal — and the pg-pool ones carry a caveat: moving their registration to the instrumentation graph would make their `collect()` closures capture the **instrumentation-graph** pg pool, not the request-serving pool, changing what they report. That needs its own careful change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
