### PR TITLE
feat(training): epoch-aware sample image viewer

### DIFF
--- a/src/components/Resource/Forms/TrainingSelectFile.module.css
+++ b/src/components/Resource/Forms/TrainingSelectFile.module.css
@@ -1,10 +1,7 @@
-.epochRow {
-  flex-wrap: nowrap;
-
-  @container (max-width: theme('screens.sm')) {
-    flex-direction: column;
-    gap: var(--mantine-spacing-md);
-  }
+.sampleGrid {
+  display: grid;
+  gap: var(--mantine-spacing-sm);
+  align-items: start;
 }
 
 .selectedRow {

--- a/src/components/Resource/Forms/TrainingSelectFile.tsx
+++ b/src/components/Resource/Forms/TrainingSelectFile.tsx
@@ -259,7 +259,7 @@ const EpochRow = ({
             </Group>
           )}
         </Group>
-        {columnCount === 0 ? (
+        {!epoch.sampleImages?.some(Boolean) ? (
           <Center p="md">
             <Text>No images available</Text>
           </Center>
@@ -309,7 +309,7 @@ const EpochRow = ({
                         </span>
                       </button>
                     ) : (
-                      <Center className="h-[200px] w-full rounded border border-dashed border-gray-4">
+                      <Center className="h-[200px] w-full rounded border border-dashed border-gray-4 dark:border-dark-4">
                         <Text size="xs" c="dimmed">
                           No sample
                         </Text>
@@ -722,12 +722,8 @@ export default function TrainingSelectFile({
   epochs = [...epochs].sort((a, b) => b.epochNumber - a.epochNumber);
 
   // Sample index N is the same prompt in every epoch (`sampleImagesPrompts` is stored once per
-  // run), so columns stay aligned even when an epoch emitted fewer samples than its neighbours.
-  const columnCount = Math.max(
-    0,
-    ...epochs.map((e) => e.sampleImages?.length ?? 0),
-    epochs.length ? samplePrompts.length : 0
-  );
+  // run), so columns stay aligned even when an epoch is missing a sample at some index.
+  const columnCount = Math.max(0, ...epochs.map((e) => e.sampleImages?.length ?? 0));
 
   const openSample = (epochIndex: number, sampleIndex: number) => {
     import('~/components/Training/TrainingSampleViewer/TrainingSampleViewer').then(

--- a/src/components/Resource/Forms/TrainingSelectFile.tsx
+++ b/src/components/Resource/Forms/TrainingSelectFile.tsx
@@ -4,7 +4,6 @@ import {
   Center,
   Flex,
   Group,
-  Image,
   Loader,
   Menu,
   Paper,
@@ -23,8 +22,10 @@ import {
   IconDotsVertical,
   IconFileDownload,
   IconRepeat,
+  IconZoomIn,
 } from '@tabler/icons-react';
 import { CopyButton } from '~/components/CopyButton/CopyButton';
+import { dialogStore } from '~/components/Dialog/dialogStore';
 import clsx from 'clsx';
 import dayjs from '~/shared/utils/dayjs';
 import { useRouter } from 'next/router';
@@ -66,6 +67,9 @@ const TRANSMITTER_KEY = 'trainer';
 
 const EpochRow = ({
   epoch,
+  epochIndex,
+  columnCount,
+  onOpenSample,
   prompts,
   selectedFile,
   setSelectedFile,
@@ -81,6 +85,9 @@ const EpochRow = ({
   modelName,
 }: {
   epoch: TrainingResultsV2['epochs'][number];
+  epochIndex: number;
+  columnCount: number;
+  onOpenSample: (epochIndex: number, sampleIndex: number) => void;
   prompts: TrainingResultsV2['sampleImagesPrompts'];
   selectedFile: string | undefined;
   setSelectedFile: React.Dispatch<React.SetStateAction<string | undefined>>;
@@ -252,55 +259,75 @@ const EpochRow = ({
             </Group>
           )}
         </Group>
-        <Group
-          className={classes.epochRow}
-          style={{ justifyContent: 'space-evenly', alignItems: 'flex-start' }}
-        >
-          {epoch.sampleImages && epoch.sampleImages.length > 0 ? (
-            epoch.sampleImages.map((url, index) => (
-              <Stack key={index} style={{ justifyContent: 'flex-start' }}>
-                {isVideo ? (
-                  <video
-                    loop
-                    playsInline
-                    disablePictureInPicture
-                    muted
-                    autoPlay
-                    controls={false}
-                    height={200}
-                    // width={180}
-                    className="w-full object-cover"
-                  >
-                    <source src={url} type="video/mp4" />
-                  </video>
-                ) : (
-                  <Image
-                    alt={`Sample image #${index}`}
-                    src={url}
-                    style={{
-                      height: '200px',
-                      // if we want to show full image, change objectFit to contain
-                      objectFit: 'cover',
-                      // object-position: top;
-                      width: '100%',
-                    }}
-                  />
-                )}
-                <Textarea
-                  autosize
-                  minRows={1}
-                  maxRows={4}
-                  value={prompts[index] || '(no prompt provided)'}
-                  readOnly
-                />
-              </Stack>
-            ))
-          ) : (
-            <Center p="md">
-              <Text>No images available</Text>
-            </Center>
-          )}
-        </Group>
+        {columnCount === 0 ? (
+          <Center p="md">
+            <Text>No images available</Text>
+          </Center>
+        ) : (
+          <div className="overflow-x-auto">
+            <div
+              className={classes.sampleGrid}
+              style={{ gridTemplateColumns: `repeat(${columnCount}, minmax(160px, 1fr))` }}
+            >
+              {Array.from({ length: columnCount }, (_, index) => {
+                const url = epoch.sampleImages?.[index];
+                return (
+                  <Stack key={index} gap="xs">
+                    {url ? (
+                      <button
+                        type="button"
+                        aria-label={`View epoch ${epoch.epochNumber} sample ${index + 1} full size`}
+                        className="group relative block h-[200px] w-full cursor-zoom-in overflow-hidden rounded p-0"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          onOpenSample(epochIndex, index);
+                        }}
+                      >
+                        {isVideo ? (
+                          <video
+                            loop
+                            playsInline
+                            disablePictureInPicture
+                            muted
+                            autoPlay
+                            controls={false}
+                            className="size-full object-cover"
+                          >
+                            <source src={url} type="video/mp4" />
+                          </video>
+                        ) : (
+                          // eslint-disable-next-line @next/next/no-img-element
+                          <img
+                            alt={`Epoch ${epoch.epochNumber} sample ${index + 1}`}
+                            src={url}
+                            loading="lazy"
+                            className="size-full object-cover"
+                          />
+                        )}
+                        <span className="absolute inset-0 flex items-center justify-center bg-black/40 opacity-0 transition-opacity group-hover:opacity-100">
+                          <IconZoomIn size={28} color="white" />
+                        </span>
+                      </button>
+                    ) : (
+                      <Center className="h-[200px] w-full rounded border border-dashed border-gray-4">
+                        <Text size="xs" c="dimmed">
+                          No sample
+                        </Text>
+                      </Center>
+                    )}
+                    <Textarea
+                      autosize
+                      minRows={1}
+                      maxRows={4}
+                      value={prompts[index] || '(no prompt provided)'}
+                      readOnly
+                    />
+                  </Stack>
+                );
+              })}
+            </div>
+          </div>
+        )}
       </Stack>
     </Paper>
   );
@@ -694,6 +721,25 @@ export default function TrainingSelectFile({
   }
   epochs = [...epochs].sort((a, b) => b.epochNumber - a.epochNumber);
 
+  // Sample index N is the same prompt in every epoch (`sampleImagesPrompts` is stored once per
+  // run), so columns stay aligned even when an epoch emitted fewer samples than its neighbours.
+  const columnCount = Math.max(
+    0,
+    ...epochs.map((e) => e.sampleImages?.length ?? 0),
+    epochs.length ? samplePrompts.length : 0
+  );
+
+  const openSample = (epochIndex: number, sampleIndex: number) => {
+    import('~/components/Training/TrainingSampleViewer/TrainingSampleViewer').then(
+      ({ default: TrainingSampleViewer }) => {
+        dialogStore.trigger({
+          component: TrainingSampleViewer,
+          props: { epochs, prompts: samplePrompts, isVideo, epochIndex, sampleIndex },
+        });
+      }
+    );
+  };
+
   // Check if epoch images may be blurred due to buzz type.
   // Images are blurred when paid with green buzz or blue buzz without a membership.
   // Images are NOT blurred when paid with yellow buzz or blue buzz with a membership.
@@ -703,7 +749,6 @@ export default function TrainingSelectFile({
       ? (trainingResults as unknown as TrainingResultsV2)
       : undefined;
   const buzzType = tResultsV2?.transactionData?.find((t) => t.accountType)?.accountType;
-  console.log({ tResultsV2, buzzType });
   // Show alert when NOT paid with yellow buzz (yellow is the only type that guarantees no blur)
   const epochImagesMayBeBlurred = buzzType !== 'yellow';
 
@@ -891,6 +936,9 @@ export default function TrainingSelectFile({
           </Center>
           <EpochRow
             epoch={epochs[0]}
+            epochIndex={0}
+            columnCount={columnCount}
+            onOpenSample={openSample}
             prompts={samplePrompts}
             selectedFile={selectedFile}
             setSelectedFile={setSelectedFile}
@@ -916,6 +964,9 @@ export default function TrainingSelectFile({
                 <EpochRow
                   key={idx}
                   epoch={e}
+                  epochIndex={idx + 1}
+                  columnCount={columnCount}
+                  onOpenSample={openSample}
                   prompts={samplePrompts}
                   selectedFile={selectedFile}
                   setSelectedFile={setSelectedFile}

--- a/src/components/Training/TrainingSampleViewer/TrainingSampleViewer.tsx
+++ b/src/components/Training/TrainingSampleViewer/TrainingSampleViewer.tsx
@@ -57,14 +57,25 @@ export default function TrainingSampleViewer({
   const [epochIndex, setEpochIndex] = useState(initialEpochIndex);
   const [sampleIndex, setSampleIndex] = useState(initialSampleIndex);
   const [zoomed, setZoomed] = useState(false);
-  const [status, setStatus] = useState<'loading' | 'loaded' | 'error'>('loading');
-  const [natural, setNatural] = useState<{ width: number; height: number } | null>(null);
+  // Keyed by url rather than reset in an effect, so a cached sample whose load event beats the
+  // effect can't have its measurements wiped and strand the viewer on the spinner.
+  const [loaded, setLoaded] = useState<{ url: string; width: number; height: number } | null>(null);
+  const [erroredUrl, setErroredUrl] = useState<string | null>(null);
   const paneRef = useRef<HTMLDivElement>(null);
+  const carriedRef = useRef<{
+    left: number;
+    top: number;
+    width: number;
+    height: number;
+  } | null>(null);
 
   const epoch = epochs[epochIndex];
   const samples = epoch?.sampleImages ?? [];
   const url = samples[sampleIndex];
   const prompt = prompts[sampleIndex];
+
+  const natural = loaded?.url === url ? loaded : null;
+  const status = natural ? 'loaded' : erroredUrl === url ? 'error' : 'loading';
 
   // Epochs are laid out newest-first, so "up" is a later epoch. Both axes skip past samples that
   // were never produced so navigation can never land on an empty frame.
@@ -90,22 +101,49 @@ export default function TrainingSampleViewer({
   const navigableCount = samples.filter(Boolean).length;
   const navigablePosition = samples.slice(0, sampleIndex + 1).filter(Boolean).length;
 
-  useEffect(() => {
-    setStatus('loading');
-    setZoomed(false);
-    setNatural(null);
-  }, [url]);
+  // Carry the pan offset onto the next sample so holding Up/Down walks the same magnified region
+  // through the epochs. Only honoured if the incoming sample measures the same.
+  const navigate = (move: () => void) => {
+    const pane = paneRef.current;
+    carriedRef.current =
+      pane && zoomed && natural
+        ? {
+            left: pane.scrollLeft,
+            top: pane.scrollTop,
+            width: natural.width,
+            height: natural.height,
+          }
+        : null;
+    move();
+  };
+  const goSample = (index: number | undefined) =>
+    index !== undefined && navigate(() => setSampleIndex(index));
+  const goEpoch = (index: number | undefined) =>
+    index !== undefined && navigate(() => setEpochIndex(index));
 
+  // Runs once the incoming sample has been measured, so scrollWidth already reflects its zoomed
+  // size — restoring any earlier would clamp to 0 and lose the offset.
   useEffect(() => {
     const pane = paneRef.current;
     if (!pane) return;
     if (!zoomed) {
+      carriedRef.current = null;
       pane.scrollTo(0, 0);
       return;
     }
-    pane.scrollLeft = (pane.scrollWidth - pane.clientWidth) / 2;
-    pane.scrollTop = (pane.scrollHeight - pane.clientHeight) / 2;
-  }, [zoomed, url]);
+    const dims = loaded?.url === url ? loaded : null;
+    if (!dims) return;
+
+    const carried = carriedRef.current;
+    carriedRef.current = null;
+    if (carried && carried.width === dims.width && carried.height === dims.height) {
+      pane.scrollLeft = carried.left;
+      pane.scrollTop = carried.top;
+    } else {
+      pane.scrollLeft = (pane.scrollWidth - pane.clientWidth) / 2;
+      pane.scrollTop = (pane.scrollHeight - pane.clientHeight) / 2;
+    }
+  }, [zoomed, loaded, url]);
 
   const missing = !epoch || !url;
   useEffect(() => {
@@ -118,22 +156,22 @@ export default function TrainingSampleViewer({
       ? [
           [
             'ArrowLeft',
-            () => prevSampleIndex !== undefined && setSampleIndex(prevSampleIndex),
+            () => goSample(prevSampleIndex),
             { preventDefault: prevSampleIndex !== undefined },
           ],
           [
             'ArrowRight',
-            () => nextSampleIndex !== undefined && setSampleIndex(nextSampleIndex),
+            () => goSample(nextSampleIndex),
             { preventDefault: nextSampleIndex !== undefined },
           ],
           [
             'ArrowUp',
-            () => prevEpochIndex !== undefined && setEpochIndex(prevEpochIndex),
+            () => goEpoch(prevEpochIndex),
             { preventDefault: prevEpochIndex !== undefined },
           ],
           [
             'ArrowDown',
-            () => nextEpochIndex !== undefined && setEpochIndex(nextEpochIndex),
+            () => goEpoch(nextEpochIndex),
             { preventDefault: nextEpochIndex !== undefined },
           ],
         ]
@@ -142,7 +180,7 @@ export default function TrainingSampleViewer({
 
   if (missing) return null;
 
-  const canZoom = status === 'loaded' && !!natural;
+  const canZoom = !!natural;
   const zoomActive = zoomed && !!natural;
 
   const mediaClassName = clsx(
@@ -178,8 +216,7 @@ export default function TrainingSampleViewer({
             Epoch #{epoch.epochNumber}
           </Badge>
           <Text size="sm" c="dimmed">
-            {epochIndex + 1} of {epochs.length} epochs &middot; sample {navigablePosition} of{' '}
-            {navigableCount}
+            sample {navigablePosition} of {navigableCount}
           </Text>
         </Group>
         {canZoom && (
@@ -233,11 +270,10 @@ export default function TrainingSampleViewer({
               style={zoomStyle}
               onLoadedData={(e) => {
                 const el = e.currentTarget;
-                setStatus('loaded');
                 if (el.videoWidth && el.videoHeight)
-                  setNatural({ width: el.videoWidth, height: el.videoHeight });
+                  setLoaded({ url, width: el.videoWidth, height: el.videoHeight });
               }}
-              onError={() => setStatus('error')}
+              onError={() => setErroredUrl(url)}
             />
           ) : (
             // eslint-disable-next-line @next/next/no-img-element
@@ -253,11 +289,10 @@ export default function TrainingSampleViewer({
               onClick={toggleZoom}
               onLoad={(e) => {
                 const el = e.currentTarget;
-                setStatus('loaded');
                 if (el.naturalWidth && el.naturalHeight)
-                  setNatural({ width: el.naturalWidth, height: el.naturalHeight });
+                  setLoaded({ url, width: el.naturalWidth, height: el.naturalHeight });
               }}
-              onError={() => setStatus('error')}
+              onError={() => setErroredUrl(url)}
             />
           )}
         </div>
@@ -270,7 +305,7 @@ export default function TrainingSampleViewer({
           }
           className="left-2 top-1/2 -translate-y-1/2"
           disabled={prevSampleIndex === undefined}
-          onClick={() => prevSampleIndex !== undefined && setSampleIndex(prevSampleIndex)}
+          onClick={() => goSample(prevSampleIndex)}
         >
           <IconChevronLeft size={24} />
         </NavButton>
@@ -280,7 +315,7 @@ export default function TrainingSampleViewer({
           }
           className="right-2 top-1/2 -translate-y-1/2"
           disabled={nextSampleIndex === undefined}
-          onClick={() => nextSampleIndex !== undefined && setSampleIndex(nextSampleIndex)}
+          onClick={() => goSample(nextSampleIndex)}
         >
           <IconChevronRight size={24} />
         </NavButton>
@@ -292,7 +327,7 @@ export default function TrainingSampleViewer({
           }
           className="left-1/2 top-2 -translate-x-1/2"
           disabled={prevEpochIndex === undefined}
-          onClick={() => prevEpochIndex !== undefined && setEpochIndex(prevEpochIndex)}
+          onClick={() => goEpoch(prevEpochIndex)}
         >
           <IconChevronUp size={24} />
         </NavButton>
@@ -304,7 +339,7 @@ export default function TrainingSampleViewer({
           }
           className="bottom-2 left-1/2 -translate-x-1/2"
           disabled={nextEpochIndex === undefined}
-          onClick={() => nextEpochIndex !== undefined && setEpochIndex(nextEpochIndex)}
+          onClick={() => goEpoch(nextEpochIndex)}
         >
           <IconChevronDown size={24} />
         </NavButton>

--- a/src/components/Training/TrainingSampleViewer/TrainingSampleViewer.tsx
+++ b/src/components/Training/TrainingSampleViewer/TrainingSampleViewer.tsx
@@ -20,7 +20,7 @@ import {
 } from '@tabler/icons-react';
 import { useHotkeys } from '@mantine/hooks';
 import clsx from 'clsx';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useDialogContext } from '~/components/Dialog/DialogProvider';
 import { CopyButton } from '~/components/CopyButton/CopyButton';
 
@@ -28,6 +28,10 @@ export type TrainingSampleEpoch = {
   epochNumber: number;
   sampleImages: string[];
 };
+
+// Unzoomed rendering is `object-contain` capped at natural size, so 2x the intrinsic pixels is
+// always a visible magnification — and never interpolates a sample beyond double its real detail.
+const ZOOM_FACTOR = 2;
 
 export type TrainingSampleViewerProps = {
   epochs: TrainingSampleEpoch[];
@@ -54,6 +58,8 @@ export default function TrainingSampleViewer({
   const [sampleIndex, setSampleIndex] = useState(initialSampleIndex);
   const [zoomed, setZoomed] = useState(false);
   const [status, setStatus] = useState<'loading' | 'loaded' | 'error'>('loading');
+  const [natural, setNatural] = useState<{ width: number; height: number } | null>(null);
+  const paneRef = useRef<HTMLDivElement>(null);
 
   const epoch = epochs[epochIndex];
   const samples = epoch?.sampleImages ?? [];
@@ -87,7 +93,19 @@ export default function TrainingSampleViewer({
   useEffect(() => {
     setStatus('loading');
     setZoomed(false);
+    setNatural(null);
   }, [url]);
+
+  useEffect(() => {
+    const pane = paneRef.current;
+    if (!pane) return;
+    if (!zoomed) {
+      pane.scrollTo(0, 0);
+      return;
+    }
+    pane.scrollLeft = (pane.scrollWidth - pane.clientWidth) / 2;
+    pane.scrollTop = (pane.scrollHeight - pane.clientHeight) / 2;
+  }, [zoomed, url]);
 
   const missing = !epoch || !url;
   useEffect(() => {
@@ -124,11 +142,21 @@ export default function TrainingSampleViewer({
 
   if (missing) return null;
 
+  const canZoom = status === 'loaded' && !!natural;
+  const zoomActive = zoomed && !!natural;
+
   const mediaClassName = clsx(
     'transition-opacity',
     status === 'loaded' ? 'opacity-100' : 'opacity-0',
-    zoomed ? 'm-auto max-w-none' : 'max-h-full max-w-full object-contain'
+    zoomActive ? 'm-auto max-w-none shrink-0' : 'max-h-full max-w-full object-contain'
   );
+
+  const zoomStyle = zoomActive
+    ? { width: natural.width * ZOOM_FACTOR, height: natural.height * ZOOM_FACTOR }
+    : undefined;
+
+  const zoomLabel = zoomed ? 'Fit to screen' : `Magnify ${ZOOM_FACTOR}x`;
+  const toggleZoom = () => canZoom && setZoomed((z) => !z);
 
   return (
     <Modal
@@ -154,14 +182,9 @@ export default function TrainingSampleViewer({
             {navigableCount}
           </Text>
         </Group>
-        {!isVideo && (
-          <Tooltip label={zoomed ? 'Fit to screen' : 'View at full size'} withArrow>
-            <ActionIcon
-              size="lg"
-              variant="light"
-              aria-label={zoomed ? 'Fit to screen' : 'View at full size'}
-              onClick={() => setZoomed((z) => !z)}
-            >
+        {canZoom && (
+          <Tooltip label={zoomLabel} withArrow>
+            <ActionIcon size="lg" variant="light" aria-label={zoomLabel} onClick={toggleZoom}>
               {zoomed ? <IconZoomOut size={20} /> : <IconZoomIn size={20} />}
             </ActionIcon>
           </Tooltip>
@@ -170,11 +193,12 @@ export default function TrainingSampleViewer({
 
       <div className="relative flex min-h-0 flex-1">
         <div
+          ref={paneRef}
           className={clsx(
             'flex flex-1',
             // `m-auto` on the media rather than flex centering — a centered flex item clamps
             // scrollLeft/Top at 0, making the start edge of a zoomed sample unreachable.
-            zoomed ? 'overflow-auto' : 'items-center justify-center overflow-hidden'
+            zoomActive ? 'overflow-auto' : 'items-center justify-center overflow-hidden'
           )}
         >
           {status === 'loading' && (
@@ -206,7 +230,13 @@ export default function TrainingSampleViewer({
               autoPlay
               controls
               className={mediaClassName}
-              onLoadedData={() => setStatus('loaded')}
+              style={zoomStyle}
+              onLoadedData={(e) => {
+                const el = e.currentTarget;
+                setStatus('loaded');
+                if (el.videoWidth && el.videoHeight)
+                  setNatural({ width: el.videoWidth, height: el.videoHeight });
+              }}
               onError={() => setStatus('error')}
             />
           ) : (
@@ -215,9 +245,18 @@ export default function TrainingSampleViewer({
               key={url}
               src={url}
               alt={`Epoch ${epoch.epochNumber} sample ${navigablePosition}`}
-              className={clsx(mediaClassName, 'cursor-zoom-in', zoomed && 'cursor-zoom-out')}
-              onClick={() => setZoomed((z) => !z)}
-              onLoad={() => setStatus('loaded')}
+              className={clsx(
+                mediaClassName,
+                canZoom && (zoomed ? 'cursor-zoom-out' : 'cursor-zoom-in')
+              )}
+              style={zoomStyle}
+              onClick={toggleZoom}
+              onLoad={(e) => {
+                const el = e.currentTarget;
+                setStatus('loaded');
+                if (el.naturalWidth && el.naturalHeight)
+                  setNatural({ width: el.naturalWidth, height: el.naturalHeight });
+              }}
               onError={() => setStatus('error')}
             />
           )}

--- a/src/components/Training/TrainingSampleViewer/TrainingSampleViewer.tsx
+++ b/src/components/Training/TrainingSampleViewer/TrainingSampleViewer.tsx
@@ -1,0 +1,288 @@
+import {
+  ActionIcon,
+  Badge,
+  Center,
+  Group,
+  Loader,
+  Modal,
+  Stack,
+  Text,
+  Tooltip,
+} from '@mantine/core';
+import {
+  IconAlertTriangle,
+  IconChevronDown,
+  IconChevronLeft,
+  IconChevronRight,
+  IconChevronUp,
+  IconZoomIn,
+  IconZoomOut,
+} from '@tabler/icons-react';
+import clsx from 'clsx';
+import { useCallback, useEffect, useState } from 'react';
+import { useDialogContext } from '~/components/Dialog/DialogProvider';
+import { CopyButton } from '~/components/CopyButton/CopyButton';
+
+export type TrainingSampleEpoch = {
+  epochNumber: number;
+  sampleImages: string[];
+};
+
+export type TrainingSampleViewerProps = {
+  epochs: TrainingSampleEpoch[];
+  prompts: string[];
+  isVideo: boolean;
+  epochIndex: number;
+  sampleIndex: number;
+};
+
+export const hasSampleAt = (epoch: TrainingSampleEpoch | undefined, index: number) =>
+  !!epoch?.sampleImages?.[index];
+
+export default function TrainingSampleViewer({
+  epochs,
+  prompts,
+  isVideo,
+  epochIndex: initialEpochIndex,
+  sampleIndex: initialSampleIndex,
+}: TrainingSampleViewerProps) {
+  const dialog = useDialogContext();
+  const [epochIndex, setEpochIndex] = useState(initialEpochIndex);
+  const [sampleIndex, setSampleIndex] = useState(initialSampleIndex);
+  const [zoomed, setZoomed] = useState(false);
+  const [status, setStatus] = useState<'loading' | 'loaded' | 'error'>('loading');
+
+  const epoch = epochs[epochIndex];
+  const url = epoch?.sampleImages?.[sampleIndex];
+  const prompt = prompts[sampleIndex];
+
+  // Epochs are laid out newest-first, so "up" is a later epoch. Epochs that never emitted a
+  // sample at this index are skipped so the vertical axis always lands on a comparable image.
+  const findEpochWithSample = useCallback(
+    (step: number) => {
+      for (let i = epochIndex + step; i >= 0 && i < epochs.length; i += step) {
+        if (hasSampleAt(epochs[i], sampleIndex)) return i;
+      }
+      return undefined;
+    },
+    [epochs, epochIndex, sampleIndex]
+  );
+
+  const prevEpochIndex = findEpochWithSample(-1);
+  const nextEpochIndex = findEpochWithSample(1);
+  const canPrevSample = sampleIndex > 0;
+  const canNextSample = sampleIndex < (epoch?.sampleImages?.length ?? 0) - 1;
+
+  useEffect(() => {
+    setStatus('loading');
+    setZoomed(false);
+  }, [url]);
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      const keys = ['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown'];
+      if (!keys.includes(e.key)) return;
+      e.preventDefault();
+      if (e.key === 'ArrowLeft' && canPrevSample) setSampleIndex((i) => i - 1);
+      else if (e.key === 'ArrowRight' && canNextSample) setSampleIndex((i) => i + 1);
+      else if (e.key === 'ArrowUp' && prevEpochIndex !== undefined) setEpochIndex(prevEpochIndex);
+      else if (e.key === 'ArrowDown' && nextEpochIndex !== undefined) setEpochIndex(nextEpochIndex);
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [canPrevSample, canNextSample, prevEpochIndex, nextEpochIndex]);
+
+  if (!epoch || !url) return null;
+
+  const mediaClassName = clsx(
+    'transition-opacity',
+    status === 'loaded' ? 'opacity-100' : 'opacity-0',
+    zoomed ? 'max-w-none' : 'max-h-full max-w-full object-contain'
+  );
+
+  return (
+    <Modal
+      {...dialog}
+      fullScreen
+      withOverlay={false}
+      withinPortal={!dialog.target}
+      zIndex={dialog.target ? undefined : 400}
+      closeButtonProps={{ 'aria-label': 'Close sample viewer' }}
+      styles={{
+        inner: { position: 'absolute' },
+        content: { display: 'flex', flexDirection: 'column', overflow: 'hidden' },
+        header: { position: 'absolute', right: 0, zIndex: 10 },
+        body: { flex: 1, minHeight: 0, display: 'flex', flexDirection: 'column', padding: 16 },
+      }}
+    >
+      <Group justify="space-between" wrap="nowrap" pr={48} mb="xs">
+        <Group gap="xs" wrap="nowrap">
+          <Badge size="lg" variant="filled">
+            Epoch #{epoch.epochNumber}
+          </Badge>
+          <Text size="sm" c="dimmed">
+            {epochIndex + 1} of {epochs.length} epochs &middot; sample {sampleIndex + 1} of{' '}
+            {epoch.sampleImages.length}
+          </Text>
+        </Group>
+        {!isVideo && (
+          <Tooltip label={zoomed ? 'Fit to screen' : 'View at full size'} withArrow>
+            <ActionIcon
+              size="lg"
+              variant="light"
+              aria-label={zoomed ? 'Fit to screen' : 'View at full size'}
+              onClick={() => setZoomed((z) => !z)}
+            >
+              {zoomed ? <IconZoomOut size={20} /> : <IconZoomIn size={20} />}
+            </ActionIcon>
+          </Tooltip>
+        )}
+      </Group>
+
+      <div className="relative flex min-h-0 flex-1">
+        <div
+          className={clsx(
+            'flex flex-1 items-center justify-center',
+            zoomed ? 'overflow-auto' : 'overflow-hidden'
+          )}
+        >
+          {status === 'loading' && (
+            <Center className="absolute inset-0">
+              <Loader />
+            </Center>
+          )}
+          {status === 'error' && (
+            <Center className="absolute inset-0">
+              <Stack align="center" gap="xs">
+                <IconAlertTriangle size={40} color="var(--mantine-color-yellow-6)" />
+                <Text>This sample could not be loaded.</Text>
+                <Text size="sm" c="dimmed">
+                  Sample media is removed 30 days after training completes.
+                </Text>
+              </Stack>
+            </Center>
+          )}
+          {isVideo ? (
+            <video
+              key={url}
+              loop
+              playsInline
+              disablePictureInPicture
+              muted
+              autoPlay
+              controls
+              className={mediaClassName}
+              onLoadedData={() => setStatus('loaded')}
+              onError={() => setStatus('error')}
+            >
+              <source src={url} type="video/mp4" />
+            </video>
+          ) : (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img
+              key={url}
+              src={url}
+              alt={`Epoch ${epoch.epochNumber} sample ${sampleIndex + 1}`}
+              className={clsx(mediaClassName, 'cursor-zoom-in', zoomed && 'cursor-zoom-out')}
+              onClick={() => setZoomed((z) => !z)}
+              onLoad={() => setStatus('loaded')}
+              onError={() => setStatus('error')}
+            />
+          )}
+        </div>
+
+        <NavButton
+          label="Previous sample (Left)"
+          className="left-2 top-1/2 -translate-y-1/2"
+          disabled={!canPrevSample}
+          onClick={() => setSampleIndex((i) => i - 1)}
+        >
+          <IconChevronLeft size={24} />
+        </NavButton>
+        <NavButton
+          label="Next sample (Right)"
+          className="right-2 top-1/2 -translate-y-1/2"
+          disabled={!canNextSample}
+          onClick={() => setSampleIndex((i) => i + 1)}
+        >
+          <IconChevronRight size={24} />
+        </NavButton>
+        <NavButton
+          label={
+            prevEpochIndex !== undefined
+              ? `Same sample in epoch #${epochs[prevEpochIndex].epochNumber} (Up)`
+              : 'No later epoch with this sample'
+          }
+          className="left-1/2 top-2 -translate-x-1/2"
+          disabled={prevEpochIndex === undefined}
+          onClick={() => prevEpochIndex !== undefined && setEpochIndex(prevEpochIndex)}
+        >
+          <IconChevronUp size={24} />
+        </NavButton>
+        <NavButton
+          label={
+            nextEpochIndex !== undefined
+              ? `Same sample in epoch #${epochs[nextEpochIndex].epochNumber} (Down)`
+              : 'No earlier epoch with this sample'
+          }
+          className="bottom-2 left-1/2 -translate-x-1/2"
+          disabled={nextEpochIndex === undefined}
+          onClick={() => nextEpochIndex !== undefined && setEpochIndex(nextEpochIndex)}
+        >
+          <IconChevronDown size={24} />
+        </NavButton>
+      </div>
+
+      <Group align="flex-start" wrap="nowrap" gap="xs" mt="xs">
+        <Text size="sm" c="dimmed" className="shrink-0">
+          Prompt
+        </Text>
+        <Text size="sm" className="flex-1 whitespace-pre-wrap break-words">
+          {prompt?.trim().length ? prompt : '(no prompt provided)'}
+        </Text>
+        {!!prompt?.trim().length && (
+          <CopyButton value={prompt}>
+            {({ copy, copied, Icon, color }) => (
+              <Tooltip label={copied ? 'Copied' : 'Copy prompt'} withArrow>
+                <ActionIcon variant="subtle" color={color} onClick={copy}>
+                  <Icon size={16} />
+                </ActionIcon>
+              </Tooltip>
+            )}
+          </CopyButton>
+        )}
+      </Group>
+    </Modal>
+  );
+}
+
+function NavButton({
+  label,
+  className,
+  disabled,
+  onClick,
+  children,
+}: {
+  label: string;
+  className: string;
+  disabled: boolean;
+  onClick: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <Tooltip label={label} withArrow>
+      <ActionIcon
+        size="xl"
+        radius="xl"
+        variant="filled"
+        color="dark"
+        aria-label={label}
+        disabled={disabled}
+        onClick={onClick}
+        className={clsx('absolute z-10 opacity-80', className)}
+      >
+        {children}
+      </ActionIcon>
+    </Tooltip>
+  );
+}

--- a/src/components/Training/TrainingSampleViewer/TrainingSampleViewer.tsx
+++ b/src/components/Training/TrainingSampleViewer/TrainingSampleViewer.tsx
@@ -18,8 +18,9 @@ import {
   IconZoomIn,
   IconZoomOut,
 } from '@tabler/icons-react';
+import { useHotkeys } from '@mantine/hooks';
 import clsx from 'clsx';
-import { useCallback, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useDialogContext } from '~/components/Dialog/DialogProvider';
 import { CopyButton } from '~/components/CopyButton/CopyButton';
 
@@ -36,6 +37,8 @@ export type TrainingSampleViewerProps = {
   sampleIndex: number;
 };
 
+// A sample that failed to render is stored as an empty string in place, so presence is
+// emptiness, never array length.
 export const hasSampleAt = (epoch: TrainingSampleEpoch | undefined, index: number) =>
   !!epoch?.sampleImages?.[index];
 
@@ -53,51 +56,78 @@ export default function TrainingSampleViewer({
   const [status, setStatus] = useState<'loading' | 'loaded' | 'error'>('loading');
 
   const epoch = epochs[epochIndex];
-  const url = epoch?.sampleImages?.[sampleIndex];
+  const samples = epoch?.sampleImages ?? [];
+  const url = samples[sampleIndex];
   const prompt = prompts[sampleIndex];
 
-  // Epochs are laid out newest-first, so "up" is a later epoch. Epochs that never emitted a
-  // sample at this index are skipped so the vertical axis always lands on a comparable image.
-  const findEpochWithSample = useCallback(
-    (step: number) => {
-      for (let i = epochIndex + step; i >= 0 && i < epochs.length; i += step) {
-        if (hasSampleAt(epochs[i], sampleIndex)) return i;
-      }
-      return undefined;
-    },
-    [epochs, epochIndex, sampleIndex]
-  );
+  // Epochs are laid out newest-first, so "up" is a later epoch. Both axes skip past samples that
+  // were never produced so navigation can never land on an empty frame.
+  const findEpochWithSample = (step: number) => {
+    for (let i = epochIndex + step; i >= 0 && i < epochs.length; i += step) {
+      if (hasSampleAt(epochs[i], sampleIndex)) return i;
+    }
+    return undefined;
+  };
+
+  const findSampleInEpoch = (step: number) => {
+    for (let i = sampleIndex + step; i >= 0 && i < samples.length; i += step) {
+      if (samples[i]) return i;
+    }
+    return undefined;
+  };
 
   const prevEpochIndex = findEpochWithSample(-1);
   const nextEpochIndex = findEpochWithSample(1);
-  const canPrevSample = sampleIndex > 0;
-  const canNextSample = sampleIndex < (epoch?.sampleImages?.length ?? 0) - 1;
+  const prevSampleIndex = findSampleInEpoch(-1);
+  const nextSampleIndex = findSampleInEpoch(1);
+
+  const navigableCount = samples.filter(Boolean).length;
+  const navigablePosition = samples.slice(0, sampleIndex + 1).filter(Boolean).length;
 
   useEffect(() => {
     setStatus('loading');
     setZoomed(false);
   }, [url]);
 
+  const missing = !epoch || !url;
   useEffect(() => {
-    const handler = (e: KeyboardEvent) => {
-      const keys = ['ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown'];
-      if (!keys.includes(e.key)) return;
-      e.preventDefault();
-      if (e.key === 'ArrowLeft' && canPrevSample) setSampleIndex((i) => i - 1);
-      else if (e.key === 'ArrowRight' && canNextSample) setSampleIndex((i) => i + 1);
-      else if (e.key === 'ArrowUp' && prevEpochIndex !== undefined) setEpochIndex(prevEpochIndex);
-      else if (e.key === 'ArrowDown' && nextEpochIndex !== undefined) setEpochIndex(nextEpochIndex);
-    };
-    window.addEventListener('keydown', handler);
-    return () => window.removeEventListener('keydown', handler);
-  }, [canPrevSample, canNextSample, prevEpochIndex, nextEpochIndex]);
+    if (missing) dialog.onClose();
+  }, [missing]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  if (!epoch || !url) return null;
+  const isTopLevel = dialog.closeOnEscape !== false;
+  useHotkeys(
+    isTopLevel
+      ? [
+          [
+            'ArrowLeft',
+            () => prevSampleIndex !== undefined && setSampleIndex(prevSampleIndex),
+            { preventDefault: prevSampleIndex !== undefined },
+          ],
+          [
+            'ArrowRight',
+            () => nextSampleIndex !== undefined && setSampleIndex(nextSampleIndex),
+            { preventDefault: nextSampleIndex !== undefined },
+          ],
+          [
+            'ArrowUp',
+            () => prevEpochIndex !== undefined && setEpochIndex(prevEpochIndex),
+            { preventDefault: prevEpochIndex !== undefined },
+          ],
+          [
+            'ArrowDown',
+            () => nextEpochIndex !== undefined && setEpochIndex(nextEpochIndex),
+            { preventDefault: nextEpochIndex !== undefined },
+          ],
+        ]
+      : []
+  );
+
+  if (missing) return null;
 
   const mediaClassName = clsx(
     'transition-opacity',
     status === 'loaded' ? 'opacity-100' : 'opacity-0',
-    zoomed ? 'max-w-none' : 'max-h-full max-w-full object-contain'
+    zoomed ? 'm-auto max-w-none' : 'max-h-full max-w-full object-contain'
   );
 
   return (
@@ -106,7 +136,6 @@ export default function TrainingSampleViewer({
       fullScreen
       withOverlay={false}
       withinPortal={!dialog.target}
-      zIndex={dialog.target ? undefined : 400}
       closeButtonProps={{ 'aria-label': 'Close sample viewer' }}
       styles={{
         inner: { position: 'absolute' },
@@ -121,8 +150,8 @@ export default function TrainingSampleViewer({
             Epoch #{epoch.epochNumber}
           </Badge>
           <Text size="sm" c="dimmed">
-            {epochIndex + 1} of {epochs.length} epochs &middot; sample {sampleIndex + 1} of{' '}
-            {epoch.sampleImages.length}
+            {epochIndex + 1} of {epochs.length} epochs &middot; sample {navigablePosition} of{' '}
+            {navigableCount}
           </Text>
         </Group>
         {!isVideo && (
@@ -142,8 +171,10 @@ export default function TrainingSampleViewer({
       <div className="relative flex min-h-0 flex-1">
         <div
           className={clsx(
-            'flex flex-1 items-center justify-center',
-            zoomed ? 'overflow-auto' : 'overflow-hidden'
+            'flex flex-1',
+            // `m-auto` on the media rather than flex centering — a centered flex item clamps
+            // scrollLeft/Top at 0, making the start edge of a zoomed sample unreachable.
+            zoomed ? 'overflow-auto' : 'items-center justify-center overflow-hidden'
           )}
         >
           {status === 'loading' && (
@@ -163,8 +194,11 @@ export default function TrainingSampleViewer({
             </Center>
           )}
           {isVideo ? (
+            // `src` on the element, not a child <source> — resource errors on <source> do not
+            // bubble, leaving a failed sample stuck on the loading spinner.
             <video
               key={url}
+              src={url}
               loop
               playsInline
               disablePictureInPicture
@@ -174,15 +208,13 @@ export default function TrainingSampleViewer({
               className={mediaClassName}
               onLoadedData={() => setStatus('loaded')}
               onError={() => setStatus('error')}
-            >
-              <source src={url} type="video/mp4" />
-            </video>
+            />
           ) : (
             // eslint-disable-next-line @next/next/no-img-element
             <img
               key={url}
               src={url}
-              alt={`Epoch ${epoch.epochNumber} sample ${sampleIndex + 1}`}
+              alt={`Epoch ${epoch.epochNumber} sample ${navigablePosition}`}
               className={clsx(mediaClassName, 'cursor-zoom-in', zoomed && 'cursor-zoom-out')}
               onClick={() => setZoomed((z) => !z)}
               onLoad={() => setStatus('loaded')}
@@ -192,18 +224,24 @@ export default function TrainingSampleViewer({
         </div>
 
         <NavButton
-          label="Previous sample (Left)"
+          label={
+            prevSampleIndex !== undefined
+              ? 'Previous sample (Left)'
+              : 'No earlier sample in this epoch'
+          }
           className="left-2 top-1/2 -translate-y-1/2"
-          disabled={!canPrevSample}
-          onClick={() => setSampleIndex((i) => i - 1)}
+          disabled={prevSampleIndex === undefined}
+          onClick={() => prevSampleIndex !== undefined && setSampleIndex(prevSampleIndex)}
         >
           <IconChevronLeft size={24} />
         </NavButton>
         <NavButton
-          label="Next sample (Right)"
+          label={
+            nextSampleIndex !== undefined ? 'Next sample (Right)' : 'No later sample in this epoch'
+          }
           className="right-2 top-1/2 -translate-y-1/2"
-          disabled={!canNextSample}
-          onClick={() => setSampleIndex((i) => i + 1)}
+          disabled={nextSampleIndex === undefined}
+          onClick={() => nextSampleIndex !== undefined && setSampleIndex(nextSampleIndex)}
         >
           <IconChevronRight size={24} />
         </NavButton>


### PR DESCRIPTION
## The request

From MNeMiC, in the Creator Studio review group:

> "When having trained a model on the site, let me view the images better. I cannot zoom in or view the images in full, nor compare reasonably.
> I would go with how AIToolkit does it. A vertical grid.
> If I click on an image, I view that, if I go Left/Right, I go to those images. If I go up/down, I go to the same image but in the epoch above/below."

## What the data actually looks like

The surface is `src/components/Resource/Forms/TrainingSelectFile.tsx` (the training wizard's "select file" step). It reads `modelFile.metadata.trainingResults`.

**V2 (`TrainingResultsV2`, current):**

```ts
epochs: { epochNumber: number; modelUrl: string; modelSize: number; sampleImages: string[] }[]
sampleImagesPrompts: string[]
```

**Cross-epoch sample consistency: yes, by construction.** `sampleImagesPrompts` is stored **once for the whole run**, not per epoch - it is written from the user's configured sample prompt list (`trainingStep.input.samples.prompts`) at workflow submit time and re-stamped on every webhook (`src/server/services/training.service.ts:555`, `:678`; `training.orch.ts:425`). Each epoch's `sampleImages` is `epoch.samples.map(s => s.url)` in orchestrator order (`training.service.ts:559-564`). So **sample index N is the same prompt in every epoch** - the existing UI already relied on this (it rendered `prompts[index]` under each epoch's image). The vertical axis is sound; no prompt-text keying needed.

The one real edge case is **ragged rows**: `sampleImages` entries are `s.url ?? ''`, and a partially-completed or failed epoch can carry fewer entries than its neighbours. Handled explicitly (see below) rather than assumed away.

**Legacy V1** stores `sample_images: { image_url, prompt }[]` per epoch; the existing normalization already flattens it to `epochs[0]`'s prompts, so both paths feed the same `{ epochs, prompts }` shape and the viewer needed no V1-specific code.

**URLs are orchestrator blob URLs, not Cloudflare Images IDs.** `getEdgeUrl` short-circuits on anything starting with `http` (`src/client-utils/cf-images-utils.ts:86`), so `EdgeImage`/`EdgeMedia` would be a pure pass-through here and buys nothing - using plain `img`/`video` (matching what this file already did) also lets the viewer own its own `onLoad`/`onError` states.

## What I built

**Grid (`TrainingSelectFile.tsx`)** - each epoch row is now a CSS grid with `repeat(columnCount, minmax(160px, 1fr))` inside a horizontally scrollable container, where `columnCount` is the max sample count across all epochs (and the prompt count). Columns therefore line up vertically across every epoch card, which is what makes the comparison readable. An epoch missing a sample at index N renders a dashed "No sample" placeholder in that cell instead of shifting its neighbours left. Thumbnails are buttons with a hover zoom affordance; the click `stopPropagation`s so opening the viewer doesn't also select that epoch's file.

**Viewer (`src/components/Training/TrainingSampleViewer/TrainingSampleViewer.tsx`, new)** - fullscreen Mantine `Modal` driven by `useDialogContext()`, opened via `dialogStore.trigger` behind a dynamic import.

- **Left / Right** - adjacent sample within the current epoch, clamped (no wrap).
- **Up / Down** - same sample index, adjacent epoch. Epochs that have no sample at that index are **skipped** to the nearest one that does, so the vertical axis never lands on an empty frame.
- **Escape** closes (Mantine default).
- Arrow keys are handled on a `window` `keydown` listener that calls `preventDefault()`, so the page behind the modal does not scroll.
- Header shows `Epoch #N`, position (`3 of 12 epochs`), and `sample 2 of 4`. Prompt is shown at the bottom with a copy button.
- Zoom: click the image (or the toolbar button) toggles fit-to-screen vs 1:1 natural size in a scrollable container. Reset on navigation.
- Loading spinner and an explicit error state for samples that 404 (sample media is purged 30 days after training).
- On-screen up/down/left/right buttons for mouse users, disabled + tooltip-explained at the edges. Video runs get `video` elements in both grid and viewer.

**Reused vs written:** reused `dialogStore` + `useDialogContext` (the same pattern `GeneratedOutputWrapper` uses for `GeneratedOutputLightbox`), Mantine `Modal`/`ActionIcon`/`Tooltip`/`Badge`, and the existing `CopyButton`. Written new: the viewer component and its navigation logic. I did **not** reuse `GeneratedOutputLightbox` - it is Embla-based and hardwired to the generation-queue request store, and Embla is a 1D carousel with no second axis, so retrofitting a vertical epoch axis onto it would have been more code than a purpose-built viewer.

**Drive-by:** removed a stray `console.log({ tResultsV2, buzzType })` that was shipping on every render of this step, and dropped the now-unused `.epochRow` CSS class.

## Verification

- `pnpm run typecheck` - clean (full output read, unfiltered).
- `pnpm exec eslint <changed files>` - no issues, no new warnings.
- `pnpm exec prettier --write <changed files>` - formatted.
- No dev server / browser automation was run, hence the checklist below.

## Human visual + interaction checklist

Open the training wizard for a completed run: `/models/train?modelId=<id>&step=4` (or Model -> version with `trainingStatus = InReview`/`Approved` -> "Select File" step).

**Grid**
1. Every epoch card shows its samples in a grid whose columns line up vertically with the cards above and below it - sample 1 sits directly under sample 1 of the previous epoch, including across the "Recommended" / "Other Results" heading split.
2. Prompt textarea still sits under each thumbnail and still reads the same prompt for a given column in every epoch.
3. Hovering a thumbnail dims it and shows a magnifier icon; the cursor is `zoom-in`.
4. Clicking a thumbnail opens the viewer and does **not** change which epoch is selected (green selected-row border should not move).
5. Clicking anywhere else on the card still selects that epoch as before.
6. On a narrow window the grid scrolls horizontally inside the card; the page body itself must not scroll sideways.
7. An epoch with zero samples still shows the "No images available" message.

**Viewer - keyboard matrix**

| Key | Expected |
|---|---|
| Right | next sample, same epoch; no-op at the last sample |
| Left | previous sample, same epoch; no-op at the first sample |
| Up | same sample index, next epoch **up** the page (higher epoch number) |
| Down | same sample index, next epoch **down** the page (lower epoch number) |
| Esc | closes the viewer |

8. Hold Down from the top epoch to the bottom and back with Up - the image should change but the prompt text at the bottom must stay identical the whole way. This is the core of the feature.
9. While any arrow is pressed, the page behind the modal must not scroll. Check with the grid scrolled partway down: the scroll position should be unchanged when you close.
10. Header reads e.g. `Epoch #14` + `1 of 12 epochs - sample 2 of 4`, and updates on every move.
11. Edge buttons: at the top epoch the Up button is disabled with a "No later epoch with this sample" tooltip; same for Down at the bottom, Left at sample 1, Right at the last sample.

**Ragged epochs (an epoch with a different sample count than its neighbour)**

This is the case worth deliberately hunting for - a failed/partial run, or a run where one sample errored. If you can't find one naturally, temporarily trim one epoch's `sampleImages` array in devtools.

12. In the grid, the short epoch shows a dashed **"No sample"** placeholder in the missing column - its remaining thumbnails must **not** slide left out of alignment with the other epochs.
13. In the viewer, sitting on the missing index and pressing Down must **skip over** that short epoch and land on the next epoch that actually has that sample; the tooltip should name the epoch number it will jump to.
14. If no epoch in that direction has the sample, the button is disabled and the key is a no-op - you must never see a blank/broken frame.
15. Navigating Right inside the short epoch clamps at its own last sample, not the global max.

**Media states**
16. Zoom: click the image (or the toolbar magnifier) - it switches to natural size and the container becomes scrollable; click again to fit. Zoom resets when you navigate to another sample.
17. A large sample at 1:1 should be pannable via scroll, and the nav buttons must stay visible on top of it.
18. Error state: for a run older than 30 days (sample media purged), the viewer shows the warning icon and "This sample could not be loaded." rather than a broken-image glyph. The grid thumbnail may still show the browser's broken-image icon - acceptable, flag it if it looks bad.
19. Spinner appears while a large sample loads and the image fades in rather than popping.
20. Video training runs (`mediaType: 'video'`): grid tiles autoplay muted as before; the viewer shows a single `video` element with controls, and the zoom button is hidden.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
