### PR TITLE
fix(app-listings): bucket a draft listing with a live pending request as Pending in the mod table + filter

### DIFF
--- a/src/components/Apps/AppListingsModerationTable.browser.test.tsx
+++ b/src/components/Apps/AppListingsModerationTable.browser.test.tsx
@@ -66,6 +66,26 @@ const ROWS = [
   }),
 ];
 
+// Effective-status dataset: an EXTERNAL listing awaiting its first review is stored
+// as status='draft' WITH a live pending publish request → it must bucket under
+// Pending + badge "Pending". A draft with NO pending request is a true orphan and
+// stays under Draft.
+const DRAFT_ROWS = [
+  offsite({
+    id: 'apl_dp',
+    slug: 'draft-pending-ext',
+    name: 'Draft Pending Ext',
+    status: 'draft',
+    pendingRequest: {
+      id: 'alpr_dp',
+      submittedAt: new Date('2026-01-01T00:00:00Z'),
+      changelog: null,
+      submittedBy: { id: 1, username: 'dev', image: null },
+    },
+  }),
+  offsite({ id: 'apl_do', slug: 'draft-orphan-ext', name: 'Draft Orphan', status: 'draft' }),
+];
+
 // Two-page dataset (paged mode) — page 1 carries a nextCursor, page 2 does not.
 const PAGE1 = [offsite({ id: 'apl_a', slug: 'alpha-live', name: 'Alpha', status: 'approved' })];
 const PAGE2 = [offsite({ id: 'apl_z', slug: 'zebra-live', name: 'Zebra', status: 'approved' })];
@@ -108,6 +128,8 @@ const mocks = vi.hoisted(() => ({
   // D-stranding regression: page 1 is a FULL server page of on-site pending rows (all
   // filtered out client-side) but a next cursor exists; page 2 carries a visible row.
   strandedD: false,
+  // Effective-status: a draft-with-a-live-pending-request + a true orphan draft.
+  draftPending: false,
 }));
 
 vi.mock('~/providers/FeatureFlagsProvider', () => ({
@@ -158,6 +180,15 @@ vi.mock('~/utils/trpc', () => {
                 isLoading: false,
                 isFetching: false,
                 error,
+                refetch: mocks.refetch,
+              };
+            }
+            if (mocks.draftPending) {
+              return {
+                data: { items: DRAFT_ROWS, nextCursor: null },
+                isLoading: false,
+                isFetching: false,
+                error: null,
                 refetch: mocks.refetch,
               };
             }
@@ -225,6 +256,7 @@ beforeEach(() => {
   mocks.queryErrorCode = null;
   mocks.paged = false;
   mocks.strandedD = false;
+  mocks.draftPending = false;
   showError.mockClear();
 });
 
@@ -266,6 +298,35 @@ describe('AppListingsModerationTable — sections + kind-aware visibility', () =
     await expect.element(page.getByTestId('apps-mod-listing-row-pending-ext')).toBeInTheDocument();
     // On-site pending filtered out entirely (no row, no dead-end).
     expect(page.getByTestId('apps-mod-listing-row-onsite-pending').elements()).toHaveLength(0);
+  });
+});
+
+// A draft external listing awaiting its FIRST review (status='draft' + a live pending
+// request) must read as EFFECTIVELY Pending in the mod table: bucketed under the
+// Pending section + badged "Pending" (so it agrees with the submitter's my-submissions
+// view and a mod filtering by Pending sees it). A true orphan draft stays under Draft.
+describe('AppListingsModerationTable — effective status (draft-with-pending → Pending)', () => {
+  test('a draft-with-a-live-pending-request buckets under Pending; a true orphan draft stays Draft', async () => {
+    mocks.draftPending = true;
+    renderWithProviders(<AppListingsModerationTable />);
+
+    const pendingSection = page.getByTestId('apps-mod-listings-section-pending');
+    const draftSection = page.getByTestId('apps-mod-listings-section-draft');
+    await expect.element(pendingSection).toBeInTheDocument();
+    await expect.element(draftSection).toBeInTheDocument();
+
+    const draftPendingRow = page.getByTestId('apps-mod-listing-row-draft-pending-ext');
+    const orphanRow = page.getByTestId('apps-mod-listing-row-draft-orphan-ext');
+    await expect.element(draftPendingRow).toBeInTheDocument();
+    await expect.element(orphanRow).toBeInTheDocument();
+
+    // Bucketing: the draft-with-pending sits in the Pending section, the orphan in Draft.
+    expect(pendingSection.element().contains(draftPendingRow.element())).toBe(true);
+    expect(draftSection.element().contains(orphanRow.element())).toBe(true);
+
+    // Badge: the draft-with-pending badges "Pending" (effective), the orphan "Draft".
+    expect(draftPendingRow.element().textContent ?? '').toContain('Pending');
+    expect(orphanRow.element().textContent ?? '').toContain('Draft');
   });
 });
 

--- a/src/components/Apps/AppListingsModerationTable.tsx
+++ b/src/components/Apps/AppListingsModerationTable.tsx
@@ -23,6 +23,7 @@ import { ModQueryError, isModAuthzError } from '~/components/Apps/ModQuerySurfac
 import { ReasonGatedActionModal } from '~/components/Apps/ReasonGatedActionModal';
 import { listingStatusChip } from '~/components/Apps/appListingModerationView';
 import {
+  effectiveModerationStatus,
   isDestructiveListingModAction,
   listingKindChip,
   listingModActionLabel,
@@ -70,7 +71,9 @@ const MOD_ACCESSORS: SubmissionAccessors<ModerationListingRow> = {
   identity: (r) => r.id,
   name: (r) => r.name || r.slug,
   slug: (r) => r.slug,
-  status: (r) => r.status,
+  // Bucket by the EFFECTIVE status so a draft-with-a-live-pending-request lands in
+  // the Pending section (it's an external listing awaiting its first review).
+  status: (r) => effectiveModerationStatus(r),
   submittedAt: (r) => toDate(r.pendingRequest?.submittedAt ?? null),
   reviewedAt: () => null,
 };
@@ -200,7 +203,7 @@ export function AppListingsModerationTable() {
           const seen = new Set(accumulated.map((r) => r.id));
           return [...accumulated, ...page.filter((r) => !seen.has(r.id))];
         })();
-    return merged.filter((r) => !(r.kind === 'onsite' && r.status === 'pending'));
+    return merged.filter((r) => !(r.kind === 'onsite' && effectiveModerationStatus(r) === 'pending'));
   }, [accumulated, page, cursor]);
 
   // Group (one group per listing — the mod view isn't version-collapsed), apply the
@@ -265,7 +268,9 @@ export function AppListingsModerationTable() {
           {groups.map((g) => {
             const row = g.latest;
             const kindChip = listingKindChip(row.kind);
-            const statusChip = listingStatusChip(row.status);
+            // Badge reads the EFFECTIVE status ("Pending" for a draft-with-pending),
+            // matching the bucket. Actions below intentionally keep the REAL status.
+            const statusChip = listingStatusChip(effectiveModerationStatus(row));
             const actions = listingModActions({
               status: row.status,
               kind: row.kind,

--- a/src/components/Apps/__tests__/appListingModerationTableView.test.ts
+++ b/src/components/Apps/__tests__/appListingModerationTableView.test.ts
@@ -2,11 +2,19 @@ import { describe, expect, it } from 'vitest';
 
 import {
   actionRequiresReason,
+  effectiveModerationStatus,
   isDestructiveListingModAction,
   listingKindChip,
   listingModActionLabel,
   listingModActions,
 } from '~/components/Apps/appListingModerationTableView';
+
+const pendingReq = {
+  id: 'alpr_1',
+  submittedAt: new Date('2026-07-24T00:00:00Z'),
+  changelog: null,
+  submittedBy: null,
+};
 
 /**
  * W13 post-approval mgmt (P2) — the mod management-table action view model. The
@@ -98,5 +106,33 @@ describe('action metadata', () => {
   it('kind chip distinguishes external vs on-site', () => {
     expect(listingKindChip('offsite')).toEqual({ label: 'external', color: 'grape' });
     expect(listingKindChip('onsite')).toEqual({ label: 'on-site', color: 'blue' });
+  });
+});
+
+describe('effectiveModerationStatus', () => {
+  it('draft WITH a live pending request → pending (awaiting first review)', () => {
+    expect(effectiveModerationStatus({ status: 'draft', pendingRequest: pendingReq })).toBe(
+      'pending'
+    );
+  });
+
+  it('draft WITHOUT a pending request → draft (true orphan)', () => {
+    expect(effectiveModerationStatus({ status: 'draft', pendingRequest: null })).toBe('draft');
+  });
+
+  it('approved → approved (unchanged)', () => {
+    expect(effectiveModerationStatus({ status: 'approved', pendingRequest: null })).toBe('approved');
+  });
+
+  it('pending → pending (unchanged)', () => {
+    expect(effectiveModerationStatus({ status: 'pending', pendingRequest: pendingReq })).toBe(
+      'pending'
+    );
+  });
+
+  it('removed → removed (unchanged, even if a lingering pending request exists)', () => {
+    expect(effectiveModerationStatus({ status: 'removed', pendingRequest: pendingReq })).toBe(
+      'removed'
+    );
   });
 });

--- a/src/components/Apps/appListingModerationTableView.ts
+++ b/src/components/Apps/appListingModerationTableView.ts
@@ -18,6 +18,30 @@
  *     request) → off-site only, and only when a pending request exists.
  */
 
+import type { ModerationListingRow } from '~/server/services/blocks/app-listing.service';
+
+/**
+ * The DISPLAY status for the mod management table.
+ *
+ * An EXTERNAL listing awaiting its FIRST review is stored (atomically, by the
+ * submit path) as an AppListing with `status='draft'` PLUS a live pending
+ * AppListingPublishRequest. Its raw `status` reads 'draft', yet the submitter's
+ * own my-submissions surface shows 'pending' (the request status) — so the two
+ * surfaces disagree, and a mod filtering the mgmt table by "Pending" does NOT
+ * see the item that most needs reviewing. Treat such a draft-with-a-live-pending
+ * -request as EFFECTIVELY pending for the mod table's DISPLAY (bucket + badge)
+ * and its status filter, so both agree on "awaiting first review".
+ *
+ * DISPLAY-ONLY: action availability still keys off the REAL `row.status` (the
+ * caller passes `hasPendingRequest` to {@link listingModActions} separately).
+ * Total — never throws.
+ */
+export function effectiveModerationStatus(
+  row: Pick<ModerationListingRow, 'status' | 'pendingRequest'>
+): string {
+  return row.status === 'draft' && row.pendingRequest != null ? 'pending' : row.status;
+}
+
 /** The lifecycle actions a mod row can offer (a subset renders per row). */
 export type ListingModAction =
   | 'review'

--- a/src/server/services/blocks/__tests__/app-listing.service.test.ts
+++ b/src/server/services/blocks/__tests__/app-listing.service.test.ts
@@ -40,6 +40,7 @@ import {
   encodeListingCursor,
   getListingDetail,
   listAvailableListings,
+  moderationStatusWhere,
   projectListingCard,
   projectListingDetail,
   recommendRollup,
@@ -730,5 +731,40 @@ describe('getListingDetail — approved-only + maturity gate', () => {
     });
     const detail = await getListingDetail({ slug: 'cool-app' }, { redCapable: true });
     expect(detail?.contentRating).toBe('x');
+  });
+});
+
+/**
+ * The mod-table status filter, made EFFECTIVE-STATUS-AWARE: a draft external
+ * listing that has a live pending publish request is "awaiting first review", so
+ * the "Pending" filter must surface it and the "Draft" filter must exclude it.
+ */
+describe('moderationStatusWhere', () => {
+  it('undefined (all) → no status constraint', () => {
+    expect(moderationStatusWhere(undefined)).toEqual({});
+  });
+
+  it('pending → real-pending OR draft-with-a-live-pending-request', () => {
+    expect(moderationStatusWhere('pending')).toEqual({
+      OR: [
+        { status: 'pending' },
+        { status: 'draft', publishRequests: { some: { status: 'pending' } } },
+      ],
+    });
+  });
+
+  it('draft → only TRUE orphan drafts (no live pending request)', () => {
+    expect(moderationStatusWhere('draft')).toEqual({
+      status: 'draft',
+      publishRequests: { none: { status: 'pending' } },
+    });
+  });
+
+  it('approved → an exact status match', () => {
+    expect(moderationStatusWhere('approved')).toEqual({ status: 'approved' });
+  });
+
+  it('removed → an exact status match', () => {
+    expect(moderationStatusWhere('removed')).toEqual({ status: 'removed' });
   });
 });

--- a/src/server/services/blocks/app-listing.service.ts
+++ b/src/server/services/blocks/app-listing.service.ts
@@ -664,6 +664,40 @@ export function projectModerationListing(row: HydratedModerationRow): Moderation
 }
 
 /**
+ * The Prisma `where` fragment for the mod table's status filter, made
+ * EFFECTIVE-STATUS-AWARE so display and filter agree on "awaiting first review".
+ *
+ * An external listing awaiting its FIRST review is stored as `status='draft'`
+ * with a live pending publish request (see {@link effectiveModerationStatus}).
+ *
+ *   - undefined (all) → `{}` (no status constraint)
+ *   - 'pending'       → real-pending OR a draft WITH a live pending request
+ *   - 'draft'         → only TRUE orphan drafts (a draft with NO pending request,
+ *                        so a draft-with-pending isn't double-listed under Draft)
+ *   - anything else   → an exact `{ status }` match
+ *
+ * Pure, total. Returned as its own fragment so the caller composes it under `AND`
+ * (this clause may itself be an `OR`, which would collide with the `search` `OR`).
+ */
+export function moderationStatusWhere(
+  status: string | undefined
+): Prisma.AppListingWhereInput {
+  if (!status) return {};
+  if (status === 'pending') {
+    return {
+      OR: [
+        { status: 'pending' },
+        { status: 'draft', publishRequests: { some: { status: 'pending' } } },
+      ],
+    };
+  }
+  if (status === 'draft') {
+    return { status: 'draft', publishRequests: { none: { status: 'pending' } } };
+  }
+  return { status };
+}
+
+/**
  * List listings across ALL lifecycle statuses for the mod management table.
  * Filters (all optional): `status`, `kind`, and a server-side `search` over
  * name/slug (case-insensitive). Keyset-paginated by the ULID `id` DESC (newest
@@ -676,19 +710,24 @@ export async function listAllListingsForModeration(
   const limit = Math.min(input.limit ?? 25, 50);
   const search = input.search?.trim();
 
+  // Both the status filter and the search may each be an `OR` clause — composing
+  // them via `AND` (dropping the empty ones) keeps both `OR`s alive instead of one
+  // overwriting the other's `OR` key on the object.
+  const statusClause = moderationStatusWhere(input.status);
+  const searchClause: Prisma.AppListingWhereInput = search
+    ? {
+        OR: [
+          { name: { contains: search, mode: 'insensitive' } },
+          { slug: { contains: search, mode: 'insensitive' } },
+        ],
+      }
+    : {};
+
   const where: Prisma.AppListingWhereInput = {
     // Never surface a SHADOW revision draft as its own row (mirrors the read path).
     revisionOfId: null,
-    ...(input.status ? { status: input.status } : {}),
     ...(input.kind ? { kind: input.kind } : {}),
-    ...(search
-      ? {
-          OR: [
-            { name: { contains: search, mode: 'insensitive' } },
-            { slug: { contains: search, mode: 'insensitive' } },
-          ],
-        }
-      : {}),
+    AND: [statusClause, searchClause].filter((c) => Object.keys(c).length > 0),
   };
 
   const rows = await dbRead.appListing.findMany({


### PR DESCRIPTION
## Problem

An external (offsite) app listing awaiting its **first review** is stored as two rows created atomically at submit: an `AppListing` with `status='draft'` plus a live `AppListingPublishRequest` with `status='pending'`. Two moderator/dev surfaces read different fields, so they disagreed:

- the submitter's **my-submissions** showed **"pending"** (the request status), while
- the moderator **listings-management table** showed **"draft"** (the listing status).

Worse, a mod filtering the mgmt table by **"Pending"** did **not** see the item that most needs reviewing — it lived under `status='draft'`.

## Fix: effective status

Introduce an **effective status**: a `draft` listing that has a live pending publish request is treated as **effectively Pending**. (A rejected/withdrawn offsite request deletes its draft, so a non-revision draft essentially only exists while awaiting first review - this is the intended "awaiting first review" state.)

- `effectiveModerationStatus(row)` - a pure, total helper (`row.status === 'draft' && row.pendingRequest != null ? 'pending' : row.status`).
- **Mod table (display):** the status **bucket** and the status **badge** now read the effective status, so a draft-with-pending lands in the **Pending** section and badges **"Pending"**. The onsite hide-filter uses it too, preserving the existing onsite-pending hide invariant (#3167).
- **Actions unchanged:** the per-row action set still keys off the **real** `row.status` (action availability is status-specific, and `hasPendingRequest` is already passed separately). Effective status is **display-only**.
- **Server (filter):** `moderationStatusWhere(status)` makes the status filter effective-aware - **"Pending"** matches real-pending **OR** a draft with a live pending request; **"Draft"** matches only **true orphan** drafts (a draft with no live pending request, so a draft-with-pending doesn't double-appear).

Now the display bucket + badge and the server "Pending"/"Draft" filter **agree**.

### `where` composition

The existing `where` put `search` as a top-level `OR`. The status clause can **also** be an `OR`, which would collide (object-key overwrite). The status + search clauses are now composed under `AND` (empties dropped), keeping both `OR`s alive, with `revisionOfId` and `kind` as top-level keys:

```ts
const statusClause = moderationStatusWhere(input.status);
const searchClause = search
  ? { OR: [ { name: { contains: search, mode: 'insensitive' } },
            { slug: { contains: search, mode: 'insensitive' } } ] }
  : {};

const where: Prisma.AppListingWhereInput = {
  revisionOfId: null,
  ...(input.kind ? { kind: input.kind } : {}),
  AND: [statusClause, searchClause].filter((c) => Object.keys(c).length > 0),
};
```

## Safety

Dark, additive, **no migration**. `pr-preview` + an adversarial `/audit-pr` are the real gates. The mgmt-table DOM behavior is mod-gated and needs a human check on the preview (can't drive it headless).

## Tests

- Node (`unit`, blocking): `effectiveModerationStatus` (5 cases) + `moderationStatusWhere` (5 cases) - all green (79 passing in the two touched suites).
- Browser (report-only): a draft row **with** a pending request buckets under Pending + badges "Pending"; a draft **without** one stays Draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
