### PR TITLE
perf(images): drain blocked-image backlog hourly at take 15k

### DIFF
--- a/src/server/jobs/image-ingestion.ts
+++ b/src/server/jobs/image-ingestion.ts
@@ -328,96 +328,103 @@ async function sendImagesForScanBulk(
 
 const BLOCKED_IMAGE_RETENTION_DAYS = 7;
 
-export const removeBlockedImages = createJob('remove-blocked-images', '0 23 * * *', async () => {
-  // Pull from JobQueue instead of scanning Image table
-  const jobQueue = await dbRead.jobQueue.findMany({
-    where: { type: JobQueueType.BlockedImageDelete, entityType: EntityType.Image },
-    take: 10000,
-    orderBy: { createdAt: 'asc' },
-  });
+export const removeBlockedImages = createJob(
+  'remove-blocked-images',
+  '0 * * * *',
+  async () => {
+    // Pull from JobQueue instead of scanning Image table
+    const jobQueue = await dbRead.jobQueue.findMany({
+      where: { type: JobQueueType.BlockedImageDelete, entityType: EntityType.Image },
+      take: 15000,
+      orderBy: { createdAt: 'asc' },
+    });
 
-  if (!jobQueue.length) {
-    console.log('No blocked images in queue');
-    return { processed: 0 };
-  }
+    if (!jobQueue.length) {
+      console.log('No blocked images in queue');
+      return { processed: 0 };
+    }
 
-  const imageIds = jobQueue.map((j) => j.entityId);
-  console.log(`Found ${imageIds.length} blocked images in queue`);
+    const imageIds = jobQueue.map((j) => j.entityId);
+    console.log(`Found ${imageIds.length} blocked images in queue`);
 
-  // Fetch image data to check retention period and blockedFor status
-  const cutoff = decreaseDate(new Date(), BLOCKED_IMAGE_RETENTION_DAYS, 'days');
-  const images = await dbRead.$queryRaw<
-    { id: number; blockedFor: string | null; createdAt: Date; updatedAt: Date }[]
-  >`
+    // Fetch image data to check retention period and blockedFor status
+    const cutoff = decreaseDate(new Date(), BLOCKED_IMAGE_RETENTION_DAYS, 'days');
+    const images = await dbRead.$queryRaw<
+      { id: number; blockedFor: string | null; createdAt: Date; updatedAt: Date }[]
+    >`
     SELECT id, "blockedFor", "createdAt", "updatedAt"
     FROM "Image"
     WHERE id = ANY(${imageIds})
       AND ingestion = 'Blocked'::"ImageIngestionStatus"
   `;
 
-  // Filter images ready for deletion based on retention period
-  const imagesToDelete = images.filter((img) => {
-    // Skip AiNotVerified - these are handled differently
-    if (img.blockedFor === 'AiNotVerified') return false;
+    // Filter images ready for deletion based on retention period
+    const imagesToDelete = images.filter((img) => {
+      // Skip AiNotVerified - these are handled differently
+      if (img.blockedFor === 'AiNotVerified') return false;
 
-    // Moderated images use updatedAt for retention
-    if (img.blockedFor === 'moderated') {
-      return img.updatedAt <= cutoff;
+      // Moderated images use updatedAt for retention
+      if (img.blockedFor === 'moderated') {
+        return img.updatedAt <= cutoff;
+      }
+
+      // All other blocked images use createdAt for retention
+      return img.createdAt <= cutoff;
+    });
+
+    // Find stale queue entries (image deleted, status changed, or AiNotVerified)
+    const imageIdSet = new Set(images.map((img) => img.id));
+    const deleteReadyIds = new Set(imagesToDelete.map((img) => img.id));
+    const staleIds = imageIds.filter((id) => {
+      // Image was deleted or status changed from Blocked
+      if (!imageIdSet.has(id)) return true;
+      // AiNotVerified images should be removed from queue
+      const img = images.find((i) => i.id === id);
+      if (img?.blockedFor === 'AiNotVerified') return true;
+      return false;
+    });
+
+    // Find images still waiting for retention period
+    const waitingIds = imageIds.filter((id) => {
+      if (!imageIdSet.has(id)) return false;
+      if (deleteReadyIds.has(id)) return false;
+      if (staleIds.includes(id)) return false;
+      return true;
+    });
+
+    console.log({
+      imagesToDelete: imagesToDelete.length,
+      waitingForRetention: waitingIds.length,
+      staleIds: staleIds.length,
+    });
+
+    if (!isProd) return { imagesToDelete: imagesToDelete.length };
+
+    if (!env.DATABASE_IS_PROD) return { imagesToDelete: 0 };
+
+    // Delete images that are past retention period
+    if (imagesToDelete.length > 0) {
+      await deleteImages(imagesToDelete.map((x) => x.id));
     }
 
-    // All other blocked images use createdAt for retention
-    return img.createdAt <= cutoff;
-  });
-
-  // Find stale queue entries (image deleted, status changed, or AiNotVerified)
-  const imageIdSet = new Set(images.map((img) => img.id));
-  const deleteReadyIds = new Set(imagesToDelete.map((img) => img.id));
-  const staleIds = imageIds.filter((id) => {
-    // Image was deleted or status changed from Blocked
-    if (!imageIdSet.has(id)) return true;
-    // AiNotVerified images should be removed from queue
-    const img = images.find((i) => i.id === id);
-    if (img?.blockedFor === 'AiNotVerified') return true;
-    return false;
-  });
-
-  // Find images still waiting for retention period
-  const waitingIds = imageIds.filter((id) => {
-    if (!imageIdSet.has(id)) return false;
-    if (deleteReadyIds.has(id)) return false;
-    if (staleIds.includes(id)) return false;
-    return true;
-  });
-
-  console.log({
-    imagesToDelete: imagesToDelete.length,
-    waitingForRetention: waitingIds.length,
-    staleIds: staleIds.length,
-  });
-
-  if (!isProd) return { imagesToDelete: imagesToDelete.length };
-
-  if (!env.DATABASE_IS_PROD) return { imagesToDelete: 0 };
-
-  // Delete images that are past retention period
-  if (imagesToDelete.length > 0) {
-    await deleteImages(imagesToDelete.map((x) => x.id));
-  }
-
-  // Remove processed and stale entries from queue
-  const idsToRemove = [...imagesToDelete.map((x) => x.id), ...staleIds];
-  if (idsToRemove.length > 0) {
-    await dbWrite.$executeRaw`
+    // Remove processed and stale entries from queue
+    const idsToRemove = [...imagesToDelete.map((x) => x.id), ...staleIds];
+    if (idsToRemove.length > 0) {
+      await dbWrite.$executeRaw`
       DELETE FROM "JobQueue"
       WHERE type = ${JobQueueType.BlockedImageDelete}::"JobQueueType"
         AND "entityType" = ${EntityType.Image}::"EntityType"
         AND "entityId" = ANY(${idsToRemove})
     `;
-  }
+    }
 
-  return {
-    deleted: imagesToDelete.length,
-    staleRemoved: staleIds.length,
-    waitingForRetention: waitingIds.length,
-  };
-});
+    return {
+      deleted: imagesToDelete.length,
+      staleRemoved: staleIds.length,
+      waitingForRetention: waitingIds.length,
+    };
+  },
+  // Deleting 15k images per run can exceed the 5-min default lock; a second pod
+  // grabbing the lock mid-run would double-delete and hit S3/DB twice.
+  { lockExpiration: 20 * 60 }
+);


### PR DESCRIPTION
## Why

We backfill-blocked ~1,016,000 images as `moderated` (7-day appeal window, then deletion). The `remove-blocked-images` cron drained them at `take: 10000` **once daily** → ~100 days to clear. This makes it run **hourly** at **`take: 15000`** so the backlog clears in a few days and future backlogs self-heal.

## Changes
- cron `'0 23 * * *'` → `'0 * * * *'` (hourly)
- `take: 10000` → `15000`
- Added `lockExpiration: 20 * 60` (20 min) as the 4th `createJob` arg, with a one-line why.

## Scout findings (verified safe before editing)

**1. Lock vs run duration.** `deleteImages` (`image.service.ts:443`) processes in batches of 100 via `Limiter({batchSize:100})` (default `limit:5` → 5 batches concurrent), and S3 deletes run through a nested `Limiter({batchSize:5})` → ~125 `DeleteObject` calls in flight globally. A 15k run = 150 batches / 30 concurrent rounds; estimated wall-clock ~3-7 min typical. The 20-min lock comfortably exceeds even a 3-4x-pessimistic run. **The lock must exceed worst-case run**: `lockExpiration` is *not* the Redis TTL — the lock key has a short 10s TTL refreshed by an 8s heartbeat, hard-capped at `lockExpiration` (`run-jobs/[[...run]].ts:336-351`). While the run is alive it keeps refreshing (genuine cross-pod mutual exclusion via `SET NX`); but if a run exceeds `lockExpiration` the heartbeat stops, the 10s TTL lapses, and a second pod could acquire the lock and double-delete. 20 min > worst case, so this can't happen at 15k.

**2. Oldest-first read.** `findMany({where:{type:BlockedImageDelete, entityType:Image}, take, orderBy:{createdAt:'asc'}})` has no index on `JobQueue.createdAt` (PK is `[entityType, entityId, type]`) → parallel seq-scan + sort of the ~1M `BlockedImageDelete` set (~56k cost, sub-second per earlier EXPLAIN). Hourly = 24 sub-second seq-scans/day on the read replica; cost shrinks as the backlog drains. Acceptable. A partial/composite index on `(type, entityType, createdAt)` would turn it into an index scan but is **out of scope** (JobQueue churns heavily; not worth the write-side maintenance for a transient backlog).

**3. Concurrency / single-run.** No `dedicated: true` needed. The Redis job-lock (`SET NX` on a shared `sysRedis` key) already prevents concurrent runs across all pods, and with `lockExpiration` (20 min) exceeding the worst-case run the heartbeat never lapses mid-run, so the lock actually holds for the full duration at an hourly cadence.

**4. Retention correctness unaffected.** The 7-day gate is computed per-image inside the job (`moderated` → `updatedAt <= now-7d`, else `createdAt <= now-7d`; `AiNotVerified` skipped) from the live `Image` table, independent of cadence/take. More frequent/larger runs only make images eligible *sooner after* their window elapses — never before. Nothing can be deleted early.

**5. S3 / DB load.** 15k/hour ≈ 4.2 deletes/sec average, but bursty: ~125 concurrent S3 `DeleteObject` for a few minutes, then idle ~55 min. Well within S3 limits; DB side is 150 batched raw DELETEs of 100 rows + collection removals per run. The internal `Limiter` throttling caps the burst — no risk of overwhelming S3 or the DB.

**6. Other daily assumptions.** None. The job holds no date-window state (no `getJobDate`), accumulates nothing keyed on a daily cadence, and only returns/logs counts. The sole cadence coupling is throughput.

## Numbers chosen
- cron: `'0 * * * *'` (hourly)
- take: `15000`
- lockExpiration: `20 * 60` (1200s)

At 15k/hour the ~1.016M backlog drains in **~3 days** (15k × 24 = 360k/day), after which it stays drained and self-heals future spikes.

Typecheck: passing (full, unfiltered). Prettier: applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
