### PR TITLE
fix(images): remove ImageScan JobQueue rows on terminal scan; prune stale before sends

### DIFF
--- a/src/__tests__/setup.ts
+++ b/src/__tests__/setup.ts
@@ -209,6 +209,12 @@ vi.mock('~/server/prom/client', () => ({
   // sysRedis sentinel observability counters (PR #2331 round-3).
   sysredisSentinelTopologyChangesCounter: promMetricStub(),
   sysredisSentinelClientErrorsCounter: promMetricStub(),
+  // Cron runner + image-ingestion cron metrics (job.ts / image-ingestion.ts).
+  jobDurationHistogram: promMetricStub(),
+  jobErrorsCounter: promMetricStub(),
+  imageIngestCronCounter: promMetricStub(),
+  imageIngestCronQueueDepth: promMetricStub(),
+  imageScanWebhookCounter: promMetricStub(),
 }));
 
 // Mock logging

--- a/src/pages/api/webhooks/image-scan-result.ts
+++ b/src/pages/api/webhooks/image-scan-result.ts
@@ -63,6 +63,7 @@ import { removeEmpty } from '~/utils/object-helpers';
 import { signalClient } from '~/utils/signal-client';
 import { isDefined } from '~/utils/type-guards';
 import { processImageScanResult } from '~/server/services/image-scan-result.service';
+import { removeImageScanJobQueue } from '~/server/services/job-queue.service';
 import { fanOutArticleImageUpdates } from '~/server/utils/webhook-debounce';
 import { getFeatureFlagsLazy } from '~/server/services/feature-flags.service';
 import type { NextApiRequest } from 'next';
@@ -275,6 +276,13 @@ async function updateImage(
   const { id } = image;
   try {
     await dbWrite.image.update({ where: { id }, data });
+
+    // Terminal outcome — drop the ImageScan JobQueue row so completed scans don't
+    // linger as stale entries the ingest-images cron has to prune. Non-terminal
+    // states (e.g. Error) stay queued for retry.
+    if (data.ingestion === 'Scanned' || data.ingestion === 'Blocked') {
+      await removeImageScanJobQueue([id]);
+    }
 
     if (data.ingestion === 'Scanned') {
       if (reviewKey) {

--- a/src/server/jobs/__tests__/ingest-images-prune-order.test.ts
+++ b/src/server/jobs/__tests__/ingest-images-prune-order.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// The stale-row prune must run BEFORE the scan-submission fan-out. Gating it behind
+// the (slow, sometimes-failing) send loop is what let stale rows accumulate faster
+// than they cleared and self-poison the queue. This drives the real job with a mix
+// of stale (non-scannable) and eligible (Pending) rows and asserts the JobQueue
+// DELETE happens before the first ingestImage call.
+
+const {
+  callLog,
+  mockDbRead,
+  mockDbWrite,
+  mockIngestImage,
+  mockDeleteImages,
+  mockLimitConcurrency,
+} = vi.hoisted(() => {
+  const callLog: string[] = [];
+  const pulled: { ids: number[] } = { ids: [] };
+  return {
+    callLog,
+    mockDbRead: {
+      jobQueue: {
+        findMany: vi.fn(async ({ take }: { take: number }) => {
+          pulled.ids = Array.from({ length: take }, (_, i) => i + 1);
+          return pulled.ids.map((entityId) => ({ entityId }));
+        }),
+      },
+    },
+    mockDbWrite: {
+      // Half the pulled ids come back Pending (eligible → submitted); the other
+      // half come back already Scanned (terminal → stale, to be pruned).
+      $queryRaw: vi.fn(async () =>
+        pulled.ids.map((id) => ({
+          id,
+          url: `img-${id}`,
+          type: 'image',
+          width: 100,
+          height: 100,
+          prompt: null,
+          scanRequestedAt: null,
+          ingestion: id % 2 === 0 ? 'Scanned' : 'Pending',
+          retryCount: 0,
+          isBackfill: false,
+        }))
+      ),
+      $executeRaw: vi.fn(async () => {
+        callLog.push('delete');
+        return 0;
+      }),
+    },
+    mockIngestImage: vi.fn(async () => {
+      callLog.push('ingest');
+      return true;
+    }),
+    mockDeleteImages: vi.fn(async () => undefined),
+    mockLimitConcurrency: vi.fn(async (tasks: Array<() => Promise<unknown>>) => {
+      for (const t of tasks) await t();
+    }),
+  };
+});
+
+vi.mock('~/server/db/client', () => ({ dbRead: mockDbRead, dbWrite: mockDbWrite }));
+vi.mock('~/server/services/image.service', () => ({
+  ingestImage: mockIngestImage,
+  deleteImages: mockDeleteImages,
+}));
+vi.mock('~/server/utils/concurrency-helpers', () => ({ limitConcurrency: mockLimitConcurrency }));
+vi.mock('~/env/other', () => ({ isProd: true }));
+vi.mock('~/env/server', () => ({
+  env: { IMAGE_SCANNING_MAX_PER_RUN: 10, IMAGE_SCANNING_RETRY_DELAY: 5, DATABASE_IS_PROD: true },
+}));
+
+import { ingestImages } from '~/server/jobs/image-ingestion';
+
+const ctx = {} as Parameters<typeof ingestImages.run>[0];
+async function runJob<T extends { run: (ctx: any) => { result: Promise<unknown> } }>(
+  job: T
+): Promise<unknown> {
+  return await job.run(ctx).result;
+}
+
+beforeEach(() => {
+  callLog.length = 0;
+  mockDbRead.jobQueue.findMany.mockClear();
+  mockDbWrite.$queryRaw.mockClear();
+  mockDbWrite.$executeRaw.mockClear();
+  mockIngestImage.mockClear();
+});
+
+describe('ingest-images stale prune ordering', () => {
+  it('deletes stale JobQueue rows before submitting any scans', async () => {
+    await runJob(ingestImages);
+
+    const firstDelete = callLog.indexOf('delete');
+    const firstIngest = callLog.indexOf('ingest');
+
+    expect(firstDelete).toBeGreaterThanOrEqual(0);
+    expect(firstIngest).toBeGreaterThanOrEqual(0);
+    expect(firstDelete).toBeLessThan(firstIngest);
+  });
+});

--- a/src/server/jobs/image-ingestion.ts
+++ b/src/server/jobs/image-ingestion.ts
@@ -199,15 +199,14 @@ export const ingestImages = createJob('ingest-images', '*/5 * * * *', async () =
 
   if (!isProd) return;
 
-  const sentUserPendingIds = await sendImagesForScanBulk(pendingUserUploads);
-  const sentBackfillIds = await sendImagesForScanBulk(pendingBackfill, { lowPriority: true });
-  const sentRescanIds = await sendImagesForScanBulk(rescanImages, { lowPriority: true });
-  const sentErrorIds = await sendImagesForScanBulk(errorImages, { lowPriority: true });
-
-  // Only remove stale items from queue (status changed to non-scannable or retry limit exceeded)
-  // Processed items stay in queue - if scan succeeds, they become stale next run
-  // This handles both immediate failures (ingestImage returns false) AND silent failures
-  // (scan sent but never completes) - items are retried after the delay passes
+  // Prune stale rows (status changed to non-scannable or retry limit exceeded)
+  // BEFORE the send loop, not after: the sends fan out hundreds–thousands of
+  // orchestrator calls and can be slow or error out, and gating the prune behind
+  // them lets stale rows accumulate faster than they clear — the queue bloats,
+  // runs get heavier, and the prune keeps not happening. The stale set is derived
+  // purely from the rows already loaded above, so it's safe to delete first.
+  // Processed items intentionally stay in the queue and become stale next run only
+  // if their scan never completes, which preserves retry-on-silent-failure.
   const idsToRemove = [...staleIds];
   if (idsToRemove.length > 0) {
     await dbWrite.$executeRaw`
@@ -217,6 +216,11 @@ export const ingestImages = createJob('ingest-images', '*/5 * * * *', async () =
         AND "entityId" = ANY(${idsToRemove})
     `;
   }
+
+  const sentUserPendingIds = await sendImagesForScanBulk(pendingUserUploads);
+  const sentBackfillIds = await sendImagesForScanBulk(pendingBackfill, { lowPriority: true });
+  const sentRescanIds = await sendImagesForScanBulk(rescanImages, { lowPriority: true });
+  const sentErrorIds = await sendImagesForScanBulk(errorImages, { lowPriority: true });
 
   const totalSent =
     sentUserPendingIds.length + sentBackfillIds.length + sentRescanIds.length + sentErrorIds.length;

--- a/src/server/services/__tests__/job-queue.service.test.ts
+++ b/src/server/services/__tests__/job-queue.service.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { mockDbWrite } = vi.hoisted(() => ({
+  mockDbWrite: { $executeRaw: vi.fn(async () => 0) },
+}));
+
+vi.mock('~/server/db/client', () => ({ dbRead: {}, dbWrite: mockDbWrite }));
+
+import { removeImageScanJobQueue } from '~/server/services/job-queue.service';
+
+beforeEach(() => {
+  mockDbWrite.$executeRaw.mockClear();
+});
+
+describe('removeImageScanJobQueue', () => {
+  it('issues a delete when given image ids', async () => {
+    await removeImageScanJobQueue([1, 2, 3]);
+    expect(mockDbWrite.$executeRaw).toHaveBeenCalledTimes(1);
+    // Tagged-template call: the interpolated ids array is the last binding.
+    const args = mockDbWrite.$executeRaw.mock.calls[0];
+    expect(args[args.length - 1]).toEqual([1, 2, 3]);
+  });
+
+  it('no-ops on an empty id list (no DB round-trip)', async () => {
+    await removeImageScanJobQueue([]);
+    expect(mockDbWrite.$executeRaw).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/services/image-scan-result.service.ts
+++ b/src/server/services/image-scan-result.service.ts
@@ -64,6 +64,7 @@ import { logToAxiom } from '~/server/logging/client';
 import { recordImageScan } from '~/server/services/scanner-audit.service';
 import { evaluateRules } from '~/server/utils/mod-rules';
 import { createNotification } from '~/server/services/notification.service';
+import { removeImageScanJobQueue } from '~/server/services/job-queue.service';
 import { decreaseDate } from '~/utils/date-helpers';
 
 export async function isExemptFromAiVerification(
@@ -304,6 +305,12 @@ export async function processImageScanWorkflow({
     prompt,
     negativePrompt,
   });
+
+  // Terminal outcome reached (resolveScanOutcome only ever returns Scanned or
+  // Blocked) — drop the ImageScan JobQueue row so it doesn't linger as a stale
+  // entry until the ingest-images cron happens to prune it. Error scans take the
+  // early-return branch above and stay queued for retry.
+  await removeImageScanJobQueue([image.id]);
 
   // --- side effects (run after the image row reflects the resolved outcome) ---
 

--- a/src/server/services/job-queue.service.ts
+++ b/src/server/services/job-queue.service.ts
@@ -1,7 +1,7 @@
-import type { EntityType, JobQueueType } from '~/shared/utils/prisma/enums';
-import { dbRead, dbWrite } from '~/server/db/client';
+import { dbWrite } from '~/server/db/client';
 import { chunk } from 'lodash-es';
 import { Prisma } from '@prisma/client';
+import { EntityType, JobQueueType } from '~/shared/utils/prisma/enums';
 
 export async function enqueueJobs(
   jobs: { entityId: number; entityType: EntityType; type: JobQueueType }[]
@@ -21,4 +21,23 @@ export async function enqueueJobs(
       ON CONFLICT DO NOTHING;
     `;
   }
+}
+
+/**
+ * Drop the ImageScan JobQueue rows for images that have reached a terminal scan
+ * outcome (Scanned/Blocked). Called from the scan-result webhook so completed
+ * scans clean up immediately instead of lingering as stale rows the ingest-images
+ * cron has to prune — stale rows bloat the queue and starve fresh work. Idempotent
+ * (composite-PK delete); safe to call with ids that were never queued. Error scans
+ * are intentionally left in place so the cron can retry them.
+ */
+export async function removeImageScanJobQueue(imageIds: number[]) {
+  if (!imageIds.length) return;
+
+  await dbWrite.$executeRaw`
+    DELETE FROM "JobQueue"
+    WHERE type = ${JobQueueType.ImageScan}::"JobQueueType"
+      AND "entityType" = ${EntityType.Image}::"EntityType"
+      AND "entityId" = ANY(${imageIds})
+  `;
 }


### PR DESCRIPTION
## The bug

The `ingest-images` cron (`src/server/jobs/image-ingestion.ts`, every 5 min) drains a `JobQueue` of `ImageScan`/`Image` rows. A queue row was **only** removed by the cron, and **only as its last step** — after an expensive submit loop (hundreds–thousands of `ingestImage` orchestrator calls).

When an image finished scanning via the normal webhook path, its `JobQueue` row was **not** removed at completion — it lingered as a stale `Scanned`/`Blocked` entry until the cron happened to prune it. These stale rows piled up (observed: **~3,641 stale `Scanned` of 4,466 queued = 81%**), and the queue **self-poisoned**: bloat → heavier runs → runs don't finish → prune doesn't happen → more bloat, while freshly-enqueued `Error` rows at the back starved.

Confirmed empirically: manually deleting the stale rows immediately let the cron reach real work and recover **~99%** of a test batch.

## The fix (two parts)

**Part 1 — root fix: dequeue on TERMINAL completion.** When an image reaches `Scanned` (success) or `Blocked` (moderation block), delete its `JobQueue` row so stale rows never form. Covered in **both** completion lanes:
- New workflow lane — `src/server/services/image-scan-result.service.ts` in `processImageScanWorkflow`, right after `resolveScanOutcome` (which only ever returns Scanned/Blocked).
- Legacy webhook lane — `src/pages/api/webhooks/image-scan-result.ts` in `updateImage`, guarded on `ingestion ∈ {Scanned, Blocked}`.

Both call a new shared, idempotent composite-PK delete helper `removeImageScanJobQueue()` in `job-queue.service.ts` (mirrors the existing `enqueueJobs` house style; batch-friendly signature taking `imageIds[]`).

**Part 2 — cron hardening: prune stale BEFORE the send loop.** The stale-row `DELETE` in `image-ingestion.ts` previously ran *after* the submit loop, so a slow/failing send blocked cleanup. Moved it to run before the sends. The stale-set logic is byte-for-byte identical — only the ordering changed.

## Invariant preserved: retry-on-silent-failure

The cron **intentionally keeps** processed/submitted rows in the queue so a silent failure (scan sent but never completes) gets retried after the delay. This PR **only deletes on a confirmed terminal outcome (Scanned/Blocked)** — never on mere submission, and never for `Error` (left to the cron's existing retry/cap logic). Retry semantics are untouched: no changes to the pending/rescan/error buckets, `getImageScanRetryLimit`, cooldowns, or the per-run take-cap.

## Tests

- `src/server/services/__tests__/job-queue.service.test.ts` — `removeImageScanJobQueue` issues the delete for given ids and no-ops on an empty list.
- `src/server/jobs/__tests__/ingest-images-prune-order.test.ts` — drives the real cron with a mix of stale + eligible rows and asserts the JobQueue `DELETE` happens **before** the first `ingestImage` call.
- Existing `ingest-images-cap.test.ts` and the webhook `image-scan-result.test.ts` still pass.

Also fixed a stale shared vitest mock (`src/__tests__/setup.ts`) that was missing `jobDurationHistogram`/`jobErrorsCounter`/cron/webhook counter exports — this already broke the existing cap test on `main`.

`pnpm typecheck` clean; `pnpm lint` clean on touched files (0 errors); prettier applied.

Closes the "ingest-images cron leaves stale JobQueue rows" issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)