### PR TITLE
feat(apps-review): unify onsite+offsite review into one queue per tab + Manage listings tab

### DIFF
--- a/src/components/Apps/AppListingsModerationTable.browser.test.tsx
+++ b/src/components/Apps/AppListingsModerationTable.browser.test.tsx
@@ -119,6 +119,9 @@ const mocks = vi.hoisted(() => ({
   mutate: vi.fn(),
   queryInput: vi.fn(),
   refetch: vi.fn(),
+  // The off-site review modal is now PAGE-OWNED; the table calls this prop to open
+  // it (passing its own invalidate as the post-action callback).
+  openOffsiteReview: vi.fn(),
   errorMode: false,
   queryError: false,
   // null → a transient (non-authz) error (Alert + Retry); a code string → an authz
@@ -251,6 +254,7 @@ beforeEach(() => {
   mocks.mutate.mockClear();
   mocks.queryInput.mockClear();
   mocks.refetch.mockClear();
+  mocks.openOffsiteReview.mockClear();
   mocks.errorMode = false;
   mocks.queryError = false;
   mocks.queryErrorCode = null;
@@ -262,7 +266,7 @@ beforeEach(() => {
 
 describe('AppListingsModerationTable — sections + kind-aware visibility', () => {
   test('renders the mixed-status dataset into status sections', async () => {
-    renderWithProviders(<AppListingsModerationTable />);
+    renderWithProviders(<AppListingsModerationTable openOffsiteReview={mocks.openOffsiteReview} />);
     await expect.element(page.getByTestId('apps-mod-listings-section-live')).toBeInTheDocument();
     await expect.element(page.getByTestId('apps-mod-listings-section-pending')).toBeInTheDocument();
     await expect.element(page.getByTestId('apps-mod-listings-section-removed')).toBeInTheDocument();
@@ -273,7 +277,7 @@ describe('AppListingsModerationTable — sections + kind-aware visibility', () =
   });
 
   test('off-site-only actions are hidden on an on-site row (kind-aware)', async () => {
-    renderWithProviders(<AppListingsModerationTable />);
+    renderWithProviders(<AppListingsModerationTable openOffsiteReview={mocks.openOffsiteReview} />);
     // Off-site approved → BOTH reset-to-pending + hide.
     await expect.element(page.getByTestId('apps-mod-reset-to-pending-alpha-live')).toBeInTheDocument();
     await expect.element(page.getByTestId('apps-mod-hide-alpha-live')).toBeInTheDocument();
@@ -293,7 +297,7 @@ describe('AppListingsModerationTable — sections + kind-aware visibility', () =
   // mgmt table filters it out so it isn't a dead-end row. An OFF-SITE pending row (which
   // carries the Review action) still shows.
   test('an on-site + pending row is hidden from the table, while off-site pending shows', async () => {
-    renderWithProviders(<AppListingsModerationTable />);
+    renderWithProviders(<AppListingsModerationTable openOffsiteReview={mocks.openOffsiteReview} />);
     // Off-site pending still present (has the Review action).
     await expect.element(page.getByTestId('apps-mod-listing-row-pending-ext')).toBeInTheDocument();
     // On-site pending filtered out entirely (no row, no dead-end).
@@ -308,7 +312,7 @@ describe('AppListingsModerationTable — sections + kind-aware visibility', () =
 describe('AppListingsModerationTable — effective status (draft-with-pending → Pending)', () => {
   test('a draft-with-a-live-pending-request buckets under Pending; a true orphan draft stays Draft', async () => {
     mocks.draftPending = true;
-    renderWithProviders(<AppListingsModerationTable />);
+    renderWithProviders(<AppListingsModerationTable openOffsiteReview={mocks.openOffsiteReview} />);
 
     const pendingSection = page.getByTestId('apps-mod-listings-section-pending');
     const draftSection = page.getByTestId('apps-mod-listings-section-draft');
@@ -332,7 +336,7 @@ describe('AppListingsModerationTable — effective status (draft-with-pending �
 
 describe('AppListingsModerationTable — sort + server-side filter', () => {
   test('the App column client-sort reorders the loaded rows (server order → A→Z on click)', async () => {
-    renderWithProviders(<AppListingsModerationTable />);
+    renderWithProviders(<AppListingsModerationTable openOffsiteReview={mocks.openOffsiteReview} />);
     await expect.element(page.getByTestId('apps-mod-listing-row-alpha-live')).toBeInTheDocument();
     // Default = the server keyset order (Bravo precedes Alpha) — NOT a client A→Z.
     const before =
@@ -351,7 +355,7 @@ describe('AppListingsModerationTable — sort + server-side filter', () => {
   // F — the search is DEBOUNCED: the typed value reaches the server query (eventually),
   // rather than firing one query per keystroke.
   test('typing in the filter forwards the (debounced) `search` to the server query', async () => {
-    renderWithProviders(<AppListingsModerationTable />);
+    renderWithProviders(<AppListingsModerationTable openOffsiteReview={mocks.openOffsiteReview} />);
     await page.getByTestId('apps-mod-listings-filter').fill('cool');
     await vi.waitFor(() => {
       const lastInput = mocks.queryInput.mock.calls.at(-1)?.[0] as { search?: string };
@@ -363,7 +367,7 @@ describe('AppListingsModerationTable — sort + server-side filter', () => {
   // ever fires pairing the OLD cursor with the NEW filter (the stale-cursor window).
   test('changing a filter mid-pagination resets the cursor with no stale-cursor query', async () => {
     mocks.paged = true;
-    renderWithProviders(<AppListingsModerationTable />);
+    renderWithProviders(<AppListingsModerationTable openOffsiteReview={mocks.openOffsiteReview} />);
     // Page to cursor 'cur-2'.
     await page.getByTestId('apps-mod-load-more').click();
     await vi.waitFor(() => {
@@ -388,7 +392,7 @@ describe('AppListingsModerationTable — sort + server-side filter', () => {
 
 describe('AppListingsModerationTable — inline actions fire the right mutation', () => {
   test('Hide forwards {appListingId, reason} to delistListing (dual-kind)', async () => {
-    renderWithProviders(<AppListingsModerationTable />);
+    renderWithProviders(<AppListingsModerationTable openOffsiteReview={mocks.openOffsiteReview} />);
     await page.getByTestId('apps-mod-hide-alpha-live').click();
     await page.getByTestId('apps-mod-action-reason').fill('spammy content');
     await page.getByTestId('apps-mod-action-confirm').click();
@@ -399,7 +403,7 @@ describe('AppListingsModerationTable — inline actions fire the right mutation'
   });
 
   test('Reset to pending on an OFF-SITE row forwards {appListingId, reason} to the offsite proc', async () => {
-    renderWithProviders(<AppListingsModerationTable />);
+    renderWithProviders(<AppListingsModerationTable openOffsiteReview={mocks.openOffsiteReview} />);
     await page.getByTestId('apps-mod-reset-to-pending-alpha-live').click();
     await page.getByTestId('apps-mod-action-reason').fill('needs re-review');
     await page.getByTestId('apps-mod-action-confirm').click();
@@ -412,7 +416,7 @@ describe('AppListingsModerationTable — inline actions fire the right mutation'
   // Onsite reset UI wiring (#3165): an on-site approved row now offers Reset, and it
   // must route to the ON-SITE proc (resetOnsiteListingToPending), NOT the off-site one.
   test('Reset to pending on an ON-SITE row fires the ONSITE proc with {appListingId, reason}', async () => {
-    renderWithProviders(<AppListingsModerationTable />);
+    renderWithProviders(<AppListingsModerationTable openOffsiteReview={mocks.openOffsiteReview} />);
     await page.getByTestId('apps-mod-reset-to-pending-onsite-live').click();
     await page.getByTestId('apps-mod-action-reason').fill('re-review this block');
     await page.getByTestId('apps-mod-action-confirm').click();
@@ -428,7 +432,7 @@ describe('AppListingsModerationTable — inline actions fire the right mutation'
   // be restorable. The button's presence is covered above; here assert clicking it
   // through the reason gate actually FIRES relistListing with {appListingId, reason}.
   test('Relist on a removed row forwards {appListingId, reason} to relistListing', async () => {
-    renderWithProviders(<AppListingsModerationTable />);
+    renderWithProviders(<AppListingsModerationTable openOffsiteReview={mocks.openOffsiteReview} />);
     await page.getByTestId('apps-mod-relist-gone-ext').click();
     await page.getByTestId('apps-mod-action-reason').fill('takedown was a mistake');
     await page.getByTestId('apps-mod-action-confirm').click();
@@ -439,7 +443,7 @@ describe('AppListingsModerationTable — inline actions fire the right mutation'
   });
 
   test('Claim forwards the target owner id + reason', async () => {
-    renderWithProviders(<AppListingsModerationTable />);
+    renderWithProviders(<AppListingsModerationTable openOffsiteReview={mocks.openOffsiteReview} />);
     await page.getByTestId('apps-mod-claim-gone-ext').click();
     await page.getByTestId('apps-mod-claim-target').fill('555');
     await page.getByTestId('apps-mod-action-reason').fill('verified owner');
@@ -452,7 +456,7 @@ describe('AppListingsModerationTable — inline actions fire the right mutation'
   });
 
   test('Purge is typed-confirm gated: needs BOTH reason ≥3 AND the exact slug, then fires', async () => {
-    renderWithProviders(<AppListingsModerationTable />);
+    renderWithProviders(<AppListingsModerationTable openOffsiteReview={mocks.openOffsiteReview} />);
     await page.getByTestId('apps-mod-purge-gone-ext').click();
     // Destructive warning + a disabled confirm while nothing is entered.
     await expect.element(page.getByTestId('apps-mod-action-confirm')).toBeDisabled();
@@ -475,7 +479,7 @@ describe('AppListingsModerationTable — inline actions fire the right mutation'
   });
 
   test('a reason under the 3-char floor keeps the confirm disabled + shows the live counter', async () => {
-    renderWithProviders(<AppListingsModerationTable />);
+    renderWithProviders(<AppListingsModerationTable openOffsiteReview={mocks.openOffsiteReview} />);
     await page.getByTestId('apps-mod-hide-alpha-live').click();
     // The live counter is present from the empty state (matches the reject paths' UX).
     await expect.element(page.getByText('0/3 characters minimum')).toBeInTheDocument();
@@ -496,7 +500,7 @@ describe('AppListingsModerationTable — inline actions fire the right mutation'
     ['claim', 'gone-ext'],
     ['purge', 'gone-ext'],
   ])('the %s action shows the counter and disables the confirm under the floor', async (action, slug) => {
-    renderWithProviders(<AppListingsModerationTable />);
+    renderWithProviders(<AppListingsModerationTable openOffsiteReview={mocks.openOffsiteReview} />);
     await page.getByTestId(`apps-mod-${action}-${slug}`).click();
     await expect.element(page.getByText('0/3 characters minimum')).toBeInTheDocument();
     await expect.element(page.getByTestId('apps-mod-action-confirm')).toBeDisabled();
@@ -507,7 +511,7 @@ describe('AppListingsModerationTable — inline actions fire the right mutation'
 
   test('a mutation error surfaces via showErrorNotification', async () => {
     mocks.errorMode = true;
-    renderWithProviders(<AppListingsModerationTable />);
+    renderWithProviders(<AppListingsModerationTable openOffsiteReview={mocks.openOffsiteReview} />);
     await page.getByTestId('apps-mod-hide-alpha-live').click();
     await page.getByTestId('apps-mod-action-reason').fill('spammy content');
     await page.getByTestId('apps-mod-action-confirm').click();
@@ -517,28 +521,27 @@ describe('AppListingsModerationTable — inline actions fire the right mutation'
   });
 });
 
-describe('AppListingsModerationTable — pending Review opens the review modal', () => {
-  test('Review opens the off-site review modal and approve forwards the pending request id', async () => {
-    renderWithProviders(<AppListingsModerationTable />);
+describe('AppListingsModerationTable — pending Review delegates to the page-owned modal', () => {
+  test('Review calls openOffsiteReview with the row (pending request id, NOT the listing id) + a post-action callback', async () => {
+    renderWithProviders(<AppListingsModerationTable openOffsiteReview={mocks.openOffsiteReview} />);
     await page.getByTestId('apps-mod-review-pending-ext').click();
-    // The reused off-site review modal opened (content-only checklist).
-    await expect
-      .element(page.getByText('URL is https and opens externally'))
-      .toBeInTheDocument();
-    await page.getByTestId('apps-offsite-approve-open').click();
-    await page.getByTestId('apps-offsite-approve-confirm').click();
-    // Approve fires with the pending request id from the row (NOT the listing id).
-    expect(mocks.mutate).toHaveBeenCalledWith(
-      'approve',
-      expect.objectContaining({ publishRequestId: 'alpr_p' })
+    // The off-site review modal is now PAGE-OWNED: the table only routes to it. The
+    // review row carries the PENDING REQUEST id (alpr_p) — never the listing id
+    // (apl_p) — so the correct request is approved/rejected.
+    expect(mocks.openOffsiteReview).toHaveBeenCalledTimes(1);
+    const [row, onActioned] = mocks.openOffsiteReview.mock.calls[0];
+    expect(row).toEqual(
+      expect.objectContaining({ id: 'alpr_p', appListingId: 'apl_p', slug: 'pending-ext' })
     );
+    // The table passes its own invalidate callback so a successful action refreshes it.
+    expect(typeof onActioned).toBe('function');
   });
 });
 
 describe('AppListingsModerationTable — pagination, status filter + honest truncation', () => {
   test('Load more appends the next keyset page and hides once the cursor is exhausted', async () => {
     mocks.paged = true;
-    renderWithProviders(<AppListingsModerationTable />);
+    renderWithProviders(<AppListingsModerationTable openOffsiteReview={mocks.openOffsiteReview} />);
     // Page 1 only: alpha visible, zebra NOT yet, Load-more present.
     await expect.element(page.getByTestId('apps-mod-listing-row-alpha-live')).toBeInTheDocument();
     expect(page.getByTestId('apps-mod-listing-row-zebra-live').elements()).toHaveLength(0);
@@ -556,7 +559,7 @@ describe('AppListingsModerationTable — pagination, status filter + honest trun
   // page must not win the empty-state branch and strand the later (matching) pages.
   test('a fully-filtered page with a next cursor still renders Load-more (D does not strand later pages)', async () => {
     mocks.strandedD = true;
-    renderWithProviders(<AppListingsModerationTable />);
+    renderWithProviders(<AppListingsModerationTable openOffsiteReview={mocks.openOffsiteReview} />);
     // Load-more IS present (a next cursor exists), even though the page rendered no rows.
     await expect.element(page.getByTestId('apps-mod-load-more')).toBeInTheDocument();
     // Page 1: every row filtered out → NO rows, and the dead-end empty state must NOT show.
@@ -571,7 +574,7 @@ describe('AppListingsModerationTable — pagination, status filter + honest trun
 
   test('the truncation indicator shows a "+more" count + Load-more only while a next page exists', async () => {
     mocks.paged = true;
-    renderWithProviders(<AppListingsModerationTable />);
+    renderWithProviders(<AppListingsModerationTable openOffsiteReview={mocks.openOffsiteReview} />);
     // Page 1 truncated → the count flags that more exist, and Load-more shows.
     await expect
       .element(page.getByTestId('apps-mod-listings-count'))
@@ -580,7 +583,7 @@ describe('AppListingsModerationTable — pagination, status filter + honest trun
   });
 
   test('the count reads a plain total (no "+", no Load-more) when nothing is truncated', async () => {
-    renderWithProviders(<AppListingsModerationTable />);
+    renderWithProviders(<AppListingsModerationTable openOffsiteReview={mocks.openOffsiteReview} />);
     const count = page.getByTestId('apps-mod-listings-count');
     await expect.element(count).toHaveTextContent('Showing 5');
     expect((count.element().textContent ?? '').includes('+')).toBe(false);
@@ -588,7 +591,7 @@ describe('AppListingsModerationTable — pagination, status filter + honest trun
   });
 
   test('selecting a status re-queries the server with that `status` arg', async () => {
-    renderWithProviders(<AppListingsModerationTable />);
+    renderWithProviders(<AppListingsModerationTable openOffsiteReview={mocks.openOffsiteReview} />);
     await page.getByRole('radio', { name: 'Removed' }).click();
     const lastInput = mocks.queryInput.mock.calls.at(-1)?.[0] as { status?: string };
     expect(lastInput.status).toBe('removed');
@@ -599,7 +602,7 @@ describe('AppListingsModerationTable — dark posture + error resilience (C)', (
   test('renders nothing on an AUTHZ error (non-mod / flag off)', async () => {
     mocks.queryError = true;
     mocks.queryErrorCode = 'FORBIDDEN';
-    renderWithProviders(<AppListingsModerationTable />);
+    renderWithProviders(<AppListingsModerationTable openOffsiteReview={mocks.openOffsiteReview} />);
     // The component returns null on an authz error → none of its surface renders.
     expect(page.getByTestId('apps-mod-listings-filter').elements()).toHaveLength(0);
     expect(page.getByTestId('apps-mod-listing-row-alpha-live').elements()).toHaveLength(0);
@@ -612,7 +615,7 @@ describe('AppListingsModerationTable — dark posture + error resilience (C)', (
   test('a TRANSIENT (non-authz) error renders an Alert + a Retry that refetches', async () => {
     mocks.queryError = true;
     mocks.queryErrorCode = null; // → INTERNAL_SERVER_ERROR (non-authz)
-    renderWithProviders(<AppListingsModerationTable />);
+    renderWithProviders(<AppListingsModerationTable openOffsiteReview={mocks.openOffsiteReview} />);
     await expect.element(page.getByTestId('apps-mod-listings-error')).toBeInTheDocument();
     // The intended dark surface (filter/rows) is NOT rendered under an error.
     expect(page.getByTestId('apps-mod-listings-filter').elements()).toHaveLength(0);

--- a/src/components/Apps/AppListingsModerationTable.tsx
+++ b/src/components/Apps/AppListingsModerationTable.tsx
@@ -15,10 +15,7 @@ import { useDebouncedValue } from '@mantine/hooks';
 import { IconAlertTriangle, IconBox, IconThumbUp } from '@tabler/icons-react';
 import { keepPreviousData } from '@tanstack/react-query';
 import { Fragment, useMemo, useState } from 'react';
-import {
-  OffsiteReviewModal,
-  type OffsitePendingRow,
-} from '~/components/Apps/OffsiteReviewQueue';
+import type { OffsitePendingRow } from '~/components/Apps/OffsiteReviewQueue';
 import { ModQueryError, isModAuthzError } from '~/components/Apps/ModQuerySurface';
 import { ReasonGatedActionModal } from '~/components/Apps/ReasonGatedActionModal';
 import { listingStatusChip } from '~/components/Apps/appListingModerationView';
@@ -65,6 +62,12 @@ import { trpc } from '~/utils/trpc';
  * is `moderatorProcedure`, and a query error (non-mod / flag off) renders nothing.
  * Closes the "manage any listing without a report" gap (the report queue only
  * surfaces reported listings) + gives the pending review its table-parity home.
+ *
+ * The off-site review MODAL is PAGE-OWNED (lifted to `src/pages/apps/review.tsx`)
+ * so there is a single, non-divergent instance shared with the unified Pending
+ * list. A pending row's Review action calls the page's `openOffsiteReview` (passing
+ * this table's own `invalidate` as the post-action callback so the table refreshes).
+ * The lifecycle-action modal (`ListingModActionModal`) stays LOCAL to this table.
  */
 
 const MOD_ACCESSORS: SubmissionAccessors<ModerationListingRow> = {
@@ -123,7 +126,16 @@ function toReviewRow(row: ModerationListingRow): OffsitePendingRow | null {
   };
 }
 
-export function AppListingsModerationTable() {
+export function AppListingsModerationTable({
+  openOffsiteReview,
+}: {
+  /** Opens the PAGE-OWNED off-site review modal. The second arg is fired after a
+   *  successful approve/reject so this table can invalidate + reset its own paging. */
+  openOffsiteReview: (
+    row: OffsitePendingRow,
+    onActioned?: () => void | Promise<void>
+  ) => void;
+}) {
   const features = useFeatureFlags();
   const utils = trpc.useUtils();
   const [search, setSearch] = useState('');
@@ -136,7 +148,6 @@ export function AppListingsModerationTable() {
   // already loaded so "Load more" APPENDS rather than replaces.
   const [cursor, setCursor] = useState<string | undefined>(undefined);
   const [accumulated, setAccumulated] = useState<ModerationListingRow[]>([]);
-  const [reviewRow, setReviewRow] = useState<OffsitePendingRow | null>(null);
   const [pendingAction, setPendingAction] = useState<{
     action: ListingModAction;
     row: ModerationListingRow;
@@ -246,7 +257,9 @@ export function AppListingsModerationTable() {
   const openAction = (action: ListingModAction, row: ModerationListingRow) => {
     if (action === 'review') {
       const reviewable = toReviewRow(row);
-      if (reviewable) setReviewRow(reviewable);
+      // Route to the PAGE-OWNED off-site modal; pass this table's `invalidate` so a
+      // successful approve/reject refreshes + resets the table's paging.
+      if (reviewable) openOffsiteReview(reviewable, invalidate);
       return;
     }
     setPendingAction({ action, row });
@@ -464,11 +477,6 @@ export function AppListingsModerationTable() {
         </>
       )}
 
-      <OffsiteReviewModal
-        request={reviewRow}
-        onClose={() => setReviewRow(null)}
-        onActioned={invalidate}
-      />
       <ListingModActionModal
         pending={pendingAction}
         onClose={() => setPendingAction(null)}

--- a/src/components/Apps/OffsiteReviewQueue.browser.test.tsx
+++ b/src/components/Apps/OffsiteReviewQueue.browser.test.tsx
@@ -96,7 +96,7 @@ vi.mock('~/utils/trpc', () => {
   };
 });
 
-const { OffsiteReviewQueue } = await import('./OffsiteReviewQueue');
+const { OffsiteReviewQueue, OffsiteReviewModal } = await import('./OffsiteReviewQueue');
 
 beforeEach(() => {
   mocks.invalidate.mockClear();
@@ -234,6 +234,30 @@ describe('OffsiteReviewModal — approve-notes gating, friendly date, field labe
     // The badge values they label are still rendered.
     await expect.element(page.getByText('utility', { exact: true })).toBeInTheDocument();
     await expect.element(page.getByText('g', { exact: true })).toBeInTheDocument();
+  });
+});
+
+// History-tab parity: opening an offsite row from Approved/Rejected passes readOnly,
+// which HIDES the Approve.../Reject... action buttons (an already-decided request would
+// only error NOT_PENDING server-side) while keeping the detail view — matching the
+// on-site history read-only posture. Purely presentational (no handler change).
+describe('OffsiteReviewModal — readOnly (history) posture hides the action buttons', () => {
+  test('readOnly HIDES both entry action buttons but keeps the content detail view', async () => {
+    renderWithProviders(<OffsiteReviewModal request={OFFSITE_ROW} onClose={vi.fn()} readOnly />);
+    // Detail still renders — the external URL + the content checklist.
+    await expect
+      .element(page.getByText('URL is https and opens externally'))
+      .toBeInTheDocument();
+    await expect.element(page.getByText('Icon present')).toBeInTheDocument();
+    // But NEITHER Approve… nor Reject… action button renders in read-only mode.
+    expect(page.getByTestId('apps-offsite-approve-open').elements()).toHaveLength(0);
+    expect(page.getByTestId('apps-offsite-reject-open').elements()).toHaveLength(0);
+  });
+
+  test('default (readOnly omitted) still renders the Approve…/Reject… buttons', async () => {
+    renderWithProviders(<OffsiteReviewModal request={OFFSITE_ROW} onClose={vi.fn()} />);
+    await expect.element(page.getByTestId('apps-offsite-approve-open')).toBeInTheDocument();
+    await expect.element(page.getByTestId('apps-offsite-reject-open')).toBeInTheDocument();
   });
 });
 

--- a/src/components/Apps/OffsiteReviewQueue.tsx
+++ b/src/components/Apps/OffsiteReviewQueue.tsx
@@ -244,12 +244,20 @@ export function OffsiteReviewModal({
   request,
   onClose,
   onActioned,
+  readOnly = false,
 }: {
   request: OffsitePendingRow | null;
   onClose: () => void;
   /** Fired after a successful approve/reject — lets a host (e.g. the mod
    *  management table) invalidate its own query in addition to the review queues. */
   onActioned?: () => void | Promise<void>;
+  /** History-tab (Approved/Rejected) posture: HIDE the Approve.../Reject... action
+   *  buttons so the modal is a read-only detail view (an already-decided request
+   *  errors `NOT_PENDING` server-side — the buttons are misleading). Matches the
+   *  on-site history read-only view. Purely presentational: it only conditionally
+   *  RENDERS the buttons; the approve/reject handlers are unchanged. Default false so
+   *  the Pending tab + the mgmt table's pending Review keep full actions. */
+  readOnly?: boolean;
 }) {
   const utils = trpc.useUtils();
   const features = useFeatureFlags();
@@ -535,7 +543,8 @@ export function OffsiteReviewModal({
           </Alert>
         )}
 
-        {actionMode === 'reject' ? (
+        {!readOnly &&
+          (actionMode === 'reject' ? (
           <Stack gap="xs">
             <ReasonGatedField
               value={rejectionReason}
@@ -636,7 +645,7 @@ export function OffsiteReviewModal({
               Approve…
             </Button>
           </Group>
-        )}
+          ))}
       </Stack>
     </Modal>
   );

--- a/src/components/Apps/OnsiteReviewModal.browser.test.tsx
+++ b/src/components/Apps/OnsiteReviewModal.browser.test.tsx
@@ -387,6 +387,22 @@ describe('OnsiteReviewModal — onsite approve fires the mutation', () => {
     await page.getByRole('button', { name: 'Approve + build' }).click();
     expect(showError).toHaveBeenCalledWith(expect.objectContaining({ title: 'Approve failed' }));
   });
+
+  // The page threads the tab's `resetPaging` in as `onActioned` so a decided item
+  // leaves the accumulated Load-more list (ghost-row fix) — assert the modal forwards
+  // it to the action bar and it fires on a successful approve.
+  test('a successful approve invokes the optional onActioned callback', async () => {
+    const onActioned = vi.fn();
+    renderWithProviders(
+      <OnsiteReviewModal
+        selection={{ request: ONSITE_PENDING, mode: 'pending' }}
+        onClose={vi.fn()}
+        onActioned={onActioned}
+      />
+    );
+    await page.getByRole('button', { name: 'Approve + build' }).click();
+    expect(onActioned).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe('OnsiteReviewModal — onsite reject: reason gate + fired mutation', () => {

--- a/src/components/Apps/OnsiteReviewModal.tsx
+++ b/src/components/Apps/OnsiteReviewModal.tsx
@@ -166,9 +166,15 @@ export function formatDate(d: string | Date | null | undefined): string {
 export function OnsiteReviewModal({
   selection,
   onClose,
+  onActioned,
 }: {
   selection: OnsiteReviewSelection;
   onClose: () => void;
+  /** Fired after a successful approve/reject, forwarded to the inline
+   *  `ReviewActionBar`. The unified review page passes the tab's `resetPaging` so a
+   *  decided item leaves the accumulated list (mirrors the off-site modal). Optional
+   *  + additive — no approve/reject logic change. */
+  onActioned?: () => void | Promise<void>;
 }) {
   // Set by the body while an approve/reject mutation is in flight so this shell's
   // onClose (Escape / overlay click / the X) refuses to close mid-action — the
@@ -193,6 +199,7 @@ export function OnsiteReviewModal({
           key={selection.request.id}
           selection={selection}
           onClose={onClose}
+          onActioned={onActioned}
           busyRef={busyRef}
         />
       )}
@@ -253,6 +260,7 @@ export function OnsiteReviewModalBody({
   selection,
   onClose,
   busyRef,
+  onActioned,
   hideInlineActions = false,
 }: {
   selection: NonNullable<OnsiteReviewSelection>;
@@ -260,6 +268,9 @@ export function OnsiteReviewModalBody({
   /** Modal shell close-guard ref, passed through to the inline action bar.
    *  Omitted by the page, which renders its own (sticky) action bar. */
   busyRef?: { current: boolean };
+  /** Forwarded to the inline `ReviewActionBar` — fired after a successful
+   *  approve/reject (e.g. the review page's tab paging reset). Optional + additive. */
+  onActioned?: () => void | Promise<void>;
   /** Suppress the inline approve/reject footer so the page can render the actions
    *  in its own sticky bottom bar (the modal keeps them inline). */
   hideInlineActions?: boolean;
@@ -445,7 +456,12 @@ export function OnsiteReviewModalBody({
             which renders the same `ReviewActionBar` pinned in a sticky bottom bar.
             The bar self-suppresses for read-only approved/rejected history. */}
         {!hideInlineActions && (
-          <ReviewActionBar selection={selection} onClose={onClose} busyRef={busyRef} />
+          <ReviewActionBar
+            selection={selection}
+            onClose={onClose}
+            onActioned={onActioned}
+            busyRef={busyRef}
+          />
         )}
       </Stack>
   );

--- a/src/components/Apps/ReviewActionBar.browser.test.tsx
+++ b/src/components/Apps/ReviewActionBar.browser.test.tsx
@@ -105,6 +105,28 @@ describe('ReviewActionBar — approve', () => {
     expect(onClose).toHaveBeenCalled();
   });
 
+  test('fires onActioned after a successful approve, before onClose (paging-reset symmetry)', async () => {
+    const order: string[] = [];
+    const onActioned = vi.fn(() => {
+      order.push('actioned');
+    });
+    const onClose = vi.fn(() => {
+      order.push('close');
+    });
+    renderWithProviders(
+      <ReviewActionBar
+        selection={{ request: PENDING, mode: 'pending' }}
+        onClose={onClose}
+        onActioned={onActioned}
+      />
+    );
+    await page.getByRole('button', { name: 'Approve + build' }).click();
+    expect(onActioned).toHaveBeenCalledTimes(1);
+    expect(onClose).toHaveBeenCalledTimes(1);
+    // onActioned runs BEFORE the modal close so the queue is reset while still open.
+    expect(order).toEqual(['actioned', 'close']);
+  });
+
   test('an approve error surfaces via showErrorNotification and does NOT close', async () => {
     mocks.errorMode = true;
     const onClose = vi.fn();
@@ -142,6 +164,35 @@ describe('ReviewActionBar — reject reason gate', () => {
       publishRequestId: 'req-1',
       rejectionReason: 'needs changes',
     });
+  });
+
+  test('a successful reject also fires onActioned', async () => {
+    const onActioned = vi.fn();
+    renderWithProviders(
+      <ReviewActionBar
+        selection={{ request: PENDING, mode: 'pending' }}
+        onClose={vi.fn()}
+        onActioned={onActioned}
+      />
+    );
+    await page.getByRole('button', { name: 'Reject…' }).click();
+    await page.getByTestId('apps-review-reject-reason').fill('needs changes');
+    await page.getByTestId('apps-review-reject-confirm').click();
+    expect(onActioned).toHaveBeenCalledTimes(1);
+  });
+
+  test('a FAILED approve does NOT fire onActioned (no stale paging reset on error)', async () => {
+    mocks.errorMode = true;
+    const onActioned = vi.fn();
+    renderWithProviders(
+      <ReviewActionBar
+        selection={{ request: PENDING, mode: 'pending' }}
+        onClose={vi.fn()}
+        onActioned={onActioned}
+      />
+    );
+    await page.getByRole('button', { name: 'Approve + build' }).click();
+    expect(onActioned).not.toHaveBeenCalled();
   });
 });
 

--- a/src/components/Apps/ReviewActionBar.tsx
+++ b/src/components/Apps/ReviewActionBar.tsx
@@ -45,6 +45,7 @@ export function ReviewActionBar({
   onClose,
   busyRef,
   onStatusChange,
+  onActioned,
   sticky = false,
 }: {
   selection: NonNullable<OnsiteReviewSelection>;
@@ -54,6 +55,11 @@ export function ReviewActionBar({
   busyRef?: { current: boolean };
   /** Page-only: mutation-lifecycle status for the aria-live region + leave-guard. */
   onStatusChange?: (status: ReviewActionStatus) => void;
+  /** Fired after a successful approve/reject (before `onClose`). The unified review
+   *  page passes the tab's `resetPaging` so the decided item leaves the accumulated
+   *  list — symmetric with the off-site modal's `onActioned`. Purely additive: it
+   *  does NOT touch the approve/reject mutation logic. */
+  onActioned?: () => void | Promise<void>;
   /** Render as a pinned bottom action bar (page) vs an inline footer (modal). */
   sticky?: boolean;
 }) {
@@ -71,6 +77,7 @@ export function ReviewActionBar({
       onStatusChange?.('approved');
       await utils.blocks.listPendingRequests.invalidate();
       await utils.blocks.listApprovedRequests.invalidate();
+      await onActioned?.();
       onClose();
     },
     onError: (e) => {
@@ -89,6 +96,7 @@ export function ReviewActionBar({
       onStatusChange?.('rejected');
       await utils.blocks.listPendingRequests.invalidate();
       await utils.blocks.listRejectedRequests.invalidate();
+      await onActioned?.();
       onClose();
     },
     onError: (e) => {

--- a/src/components/Apps/UnifiedReviewList.browser.test.tsx
+++ b/src/components/Apps/UnifiedReviewList.browser.test.tsx
@@ -1,0 +1,118 @@
+import { describe, expect, test, vi } from 'vitest';
+import { page } from 'vitest/browser';
+// `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
+import { renderWithProviders } from '../../../test/component-setup';
+import type { OffsitePendingRow } from './OffsiteReviewQueue';
+import type { OffsiteReviewRequest, OnsiteReviewRequest } from './unifiedReviewRow';
+
+/**
+ * The unified moderator review LIST — browser-mode render test (report-only in
+ * Tekton; the pure adapters/merge in `unifiedReviewRow.test.ts` are the blocking
+ * gate). Asserts a list built from ONE on-site + ONE off-site row:
+ *  - renders BOTH rows with the correct kind badge (App / External);
+ *  - orders oldest-first for `direction="asc"` (pending);
+ *  - clicking a row's Review invokes the CORRECT opener (on-site → openOnsite with
+ *    the original request; off-site → openOffsite with the built OffsitePendingRow),
+ *    NEVER the other — the core no-cross-routing invariant.
+ */
+
+const ONSITE: OnsiteReviewRequest = {
+  id: 'or1',
+  appBlockId: null,
+  slug: 'my-onsite',
+  version: '1.0.0',
+  submittedAt: '2026-01-01T00:00:00Z', // older → first under asc
+  bundleSizeBytes: '10',
+  bundleSha256: 'sha',
+  manifest: { name: 'My Onsite App' },
+  fileSummary: {},
+  manifestDiffSummary: {},
+  reviewRepoUrl: 'https://forgejo.example/repo',
+  submittedBy: { id: 7, username: 'onsite-dev', image: null },
+} as OnsiteReviewRequest;
+
+const OFFSITE: OffsiteReviewRequest = {
+  id: 'fr1',
+  appListingId: 'apl_1',
+  slug: 'my-offsite',
+  status: 'pending',
+  submittedAt: '2026-02-01T00:00:00Z', // newer → second under asc
+  changelog: null,
+  appListing: {
+    name: 'My External App',
+    externalUrl: 'https://ex.com',
+    category: 'utility',
+    contentRating: 'g',
+  },
+  submittedBy: { id: 9, username: 'offsite-dev', image: null },
+};
+
+const { UnifiedReviewList } = await import('./UnifiedReviewList');
+
+function renderList(overrides?: {
+  openOnsite?: (r: OnsiteReviewRequest) => void;
+  openOffsite?: (r: OffsitePendingRow) => void;
+}) {
+  const openOnsite = overrides?.openOnsite ?? vi.fn();
+  const openOffsite = overrides?.openOffsite ?? vi.fn();
+  renderWithProviders(
+    <UnifiedReviewList
+      onsiteItems={[ONSITE]}
+      offsiteItems={[OFFSITE]}
+      direction="asc"
+      openOnsiteReview={openOnsite}
+      openOffsiteReview={openOffsite}
+      isLoading={false}
+      emptyLabel="empty"
+      dateLabel="Submitted"
+      actionLabel="Review"
+      hasMore={false}
+      onLoadMore={vi.fn()}
+    />
+  );
+  return { openOnsite, openOffsite };
+}
+
+describe('UnifiedReviewList — renders both kinds with correct badges', () => {
+  test('both rows render with App / External kind badges', async () => {
+    renderList();
+    await expect
+      .element(page.getByTestId('apps-unified-review-kind-onsite:or1'))
+      .toHaveTextContent('App');
+    await expect
+      .element(page.getByTestId('apps-unified-review-kind-offsite:fr1'))
+      .toHaveTextContent('External');
+    // Both apps' names surface.
+    await expect.element(page.getByText('My Onsite App')).toBeInTheDocument();
+    await expect.element(page.getByText('My External App')).toBeInTheDocument();
+  });
+
+  test('oldest-first order under direction="asc" (on-site row precedes off-site)', async () => {
+    renderList();
+    const rows = page.getByTestId(/^apps-unified-review-row-/).elements();
+    expect(rows).toHaveLength(2);
+    expect(rows[0].getAttribute('data-testid')).toBe('apps-unified-review-row-onsite:or1');
+    expect(rows[1].getAttribute('data-testid')).toBe('apps-unified-review-row-offsite:fr1');
+  });
+});
+
+describe('UnifiedReviewList — Review routes to the correct modal opener (no cross)', () => {
+  test('clicking the on-site row Review invokes openOnsite with the original request only', async () => {
+    const { openOnsite, openOffsite } = renderList();
+    await page.getByTestId('apps-unified-review-action-onsite:or1').click();
+    expect(openOnsite).toHaveBeenCalledTimes(1);
+    expect(openOnsite).toHaveBeenCalledWith(ONSITE);
+    expect(openOffsite).not.toHaveBeenCalled();
+  });
+
+  test('clicking the off-site row Review invokes openOffsite with the built row only', async () => {
+    const { openOnsite, openOffsite } = renderList();
+    await page.getByTestId('apps-unified-review-action-offsite:fr1').click();
+    expect(openOffsite).toHaveBeenCalledTimes(1);
+    const passed = (openOffsite as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(passed.id).toBe('fr1');
+    expect(passed.appListingId).toBe('apl_1');
+    expect(passed.slug).toBe('my-offsite');
+    expect(openOnsite).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/Apps/UnifiedReviewList.tsx
+++ b/src/components/Apps/UnifiedReviewList.tsx
@@ -1,0 +1,178 @@
+import { Alert, Badge, Button, Card, Code, Group, Stack, Table, Text } from '@mantine/core';
+import { IconAlertTriangle, IconCheck, IconClock, IconExternalLink } from '@tabler/icons-react';
+import { useMemo } from 'react';
+import type { OffsitePendingRow } from '~/components/Apps/OffsiteReviewQueue';
+import {
+  mergeReviewRows,
+  offsiteRequestToUnifiedRow,
+  onsiteRequestToUnifiedRow,
+  type OffsiteReviewRequest,
+  type OnsiteReviewRequest,
+  type UnifiedReviewRow,
+} from '~/components/Apps/unifiedReviewRow';
+
+/**
+ * ONE list interleaving the on-site + off-site moderator review sources for a tab
+ * (Pending / Approved / Rejected). Normalizes each source's rows through the pure
+ * adapters, merges + sorts them with `mergeReviewRows`, and renders a single table
+ * with a per-row KIND badge and a Review/View action wired to the CORRECT modal.
+ *
+ * Presentational: the two tRPC queries + their keyset pagination live in the
+ * per-tab wrapper (in `src/pages/apps/review.tsx`); this component receives the
+ * already-accumulated raw items + loading/error/hasMore state and the two
+ * page-owned open callbacks. Keep it server-graph-free so it is browser-testable.
+ */
+export function UnifiedReviewList({
+  onsiteItems,
+  offsiteItems,
+  direction,
+  openOnsiteReview,
+  openOffsiteReview,
+  isLoading,
+  errorMessage,
+  emptyLabel,
+  dateLabel,
+  actionLabel,
+  hasMore,
+  isLoadingMore,
+  onLoadMore,
+}: {
+  onsiteItems: OnsiteReviewRequest[];
+  offsiteItems: OffsiteReviewRequest[];
+  direction: 'asc' | 'desc';
+  /** Opens the ON-SITE modal for an on-site row (page-owned; may be pre-bound to
+   *  the tab's review mode). */
+  openOnsiteReview: (req: OnsiteReviewRequest) => void;
+  /** Opens the OFF-SITE modal for an off-site row (page-owned). */
+  openOffsiteReview: (row: OffsitePendingRow) => void;
+  isLoading: boolean;
+  /** Non-empty when EITHER source query errored transiently — surfaced as an Alert
+   *  rather than silently blanking the list. */
+  errorMessage?: string;
+  emptyLabel: string;
+  /** Column header for the row timestamp ("Submitted" for pending, "Reviewed" for
+   *  history) — the value itself is chosen by the adapter. */
+  dateLabel: string;
+  /** Row action label ("Review" for pending, "View" for history). */
+  actionLabel: string;
+  hasMore: boolean;
+  isLoadingMore?: boolean;
+  onLoadMore: () => void;
+}) {
+  const rows = useMemo(() => {
+    const onsiteRows = onsiteItems.map((r) => onsiteRequestToUnifiedRow(r, openOnsiteReview));
+    const offsiteRows = offsiteItems.map((r) => offsiteRequestToUnifiedRow(r, openOffsiteReview));
+    return mergeReviewRows(onsiteRows, offsiteRows, direction);
+  }, [onsiteItems, offsiteItems, direction, openOnsiteReview, openOffsiteReview]);
+
+  return (
+    <Stack gap="md">
+      <Text c="dimmed" size="sm" data-testid="apps-unified-review-count">
+        {isLoading && rows.length === 0
+          ? 'Loading…'
+          : `${rows.length}${hasMore ? '+' : ''} shown.`}
+      </Text>
+
+      {errorMessage && (
+        <Alert color="red" icon={<IconAlertTriangle size={16} />}>
+          {errorMessage}
+        </Alert>
+      )}
+
+      {!isLoading && rows.length === 0 && !errorMessage && (
+        <Card withBorder p="lg">
+          <Group gap="xs">
+            <IconCheck color="var(--mantine-color-green-6)" size={20} />
+            <Text>{emptyLabel}</Text>
+          </Group>
+        </Card>
+      )}
+
+      {rows.length > 0 && (
+        <Card withBorder p={0}>
+          <Table verticalSpacing="md" horizontalSpacing="md">
+            <Table.Thead>
+              <Table.Tr>
+                <Table.Th>Kind</Table.Th>
+                <Table.Th>App</Table.Th>
+                <Table.Th>Submitter</Table.Th>
+                <Table.Th>{dateLabel}</Table.Th>
+                <Table.Th />
+              </Table.Tr>
+            </Table.Thead>
+            <Table.Tbody>
+              {rows.map((row) => (
+                <UnifiedReviewRowView key={row.key} row={row} actionLabel={actionLabel} />
+              ))}
+            </Table.Tbody>
+          </Table>
+        </Card>
+      )}
+
+      {hasMore && (
+        <Group justify="center">
+          <Button
+            variant="default"
+            onClick={onLoadMore}
+            loading={isLoadingMore}
+            disabled={isLoadingMore}
+            data-testid="apps-unified-review-load-more"
+          >
+            Load more
+          </Button>
+        </Group>
+      )}
+    </Stack>
+  );
+}
+
+function UnifiedReviewRowView({ row, actionLabel }: { row: UnifiedReviewRow; actionLabel: string }) {
+  const isOnsite = row.kind === 'onsite';
+  const submitter = row.submitter;
+  return (
+    <Table.Tr style={{ cursor: 'pointer' }} data-testid={`apps-unified-review-row-${row.key}`}>
+      <Table.Td onClick={row.onReview}>
+        <Badge
+          size="sm"
+          variant="light"
+          color={isOnsite ? 'blue' : 'grape'}
+          data-testid={`apps-unified-review-kind-${row.key}`}
+        >
+          {isOnsite ? 'App' : 'External'}
+        </Badge>
+      </Table.Td>
+      <Table.Td onClick={row.onReview}>
+        <Group gap={6} wrap="nowrap">
+          {row.slug && <Code>{row.slug}</Code>}
+        </Group>
+        {row.title && row.title !== row.slug && (
+          <Text size="xs" c="dimmed">
+            {row.title}
+          </Text>
+        )}
+      </Table.Td>
+      <Table.Td onClick={row.onReview}>
+        <Text size="xs">
+          {submitter?.username ? submitter.username : `#${submitter?.id ?? '?'}`}
+        </Text>
+      </Table.Td>
+      <Table.Td onClick={row.onReview}>
+        <Group gap={4}>
+          <IconClock size={14} />
+          <Text size="xs">{row.submittedAt.toLocaleString()}</Text>
+        </Group>
+      </Table.Td>
+      <Table.Td>
+        <Button
+          size="xs"
+          variant="default"
+          onClick={row.onReview}
+          rightSection={<IconExternalLink size={12} />}
+          data-testid={`apps-unified-review-action-${row.key}`}
+        >
+          {actionLabel}
+        </Button>
+      </Table.Td>
+    </Table.Tr>
+  );
+}

--- a/src/components/Apps/__tests__/unifiedReviewRow.test.ts
+++ b/src/components/Apps/__tests__/unifiedReviewRow.test.ts
@@ -1,0 +1,312 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  mergeReviewRows,
+  offsiteRequestToUnifiedRow,
+  onsiteRequestToUnifiedRow,
+  type OffsiteReviewRequest,
+  type OnsiteReviewRequest,
+  type UnifiedReviewRow,
+} from '~/components/Apps/unifiedReviewRow';
+
+/**
+ * The CORRECTNESS CORE of the unified /apps/review queues: the pure adapters that
+ * map each proc's row → a unified row + the merge/sort/dedup. A mis-routed, dropped,
+ * or duplicated row here means a moderator reviews/approves the wrong thing, so this
+ * is the BLOCKING unit gate (the list's browser suite is report-only). Pins:
+ *  - globally-unique, kind-namespaced keys (on-site + off-site never collide);
+ *  - correct field mapping + the manifest-name / listing-name → slug fallbacks;
+ *  - `onReview` routes to the CORRECT modal opener with the CORRECT payload;
+ *  - the pending timestamp is `submittedAt`, the decided timestamp is `reviewedAt`;
+ *  - merge = no-drop + dedup-by-key + asc/desc sort + a stable, direction-
+ *    independent tiebreak.
+ */
+
+// ---------------------------------------------------------------------------
+// Fixtures — minimal structural rows (cast to the adapter input types; the
+// adapters only read a handful of fields).
+// ---------------------------------------------------------------------------
+
+function onsite(over: Partial<OnsiteReviewRequest> & { id: string }): OnsiteReviewRequest {
+  return {
+    id: over.id,
+    appBlockId: null,
+    slug: 'onsite-slug',
+    version: '1.0.0',
+    submittedAt: '2026-01-01T00:00:00Z',
+    bundleSizeBytes: '10',
+    bundleSha256: 'sha',
+    manifest: {},
+    fileSummary: {},
+    manifestDiffSummary: {},
+    reviewRepoUrl: 'https://forgejo.example/repo',
+    submittedBy: { id: 7, username: 'onsite-dev', image: null },
+    ...over,
+  } as OnsiteReviewRequest;
+}
+
+function offsite(over: Partial<OffsiteReviewRequest> & { id: string }): OffsiteReviewRequest {
+  return {
+    id: over.id,
+    appListingId: 'apl_1',
+    slug: 'offsite-slug',
+    status: 'pending',
+    submittedAt: '2026-01-02T00:00:00Z',
+    changelog: null,
+    appListing: {
+      name: 'External App',
+      externalUrl: 'https://ex.com',
+      category: 'utility',
+      contentRating: 'g',
+    },
+    submittedBy: { id: 9, username: 'offsite-dev', image: null },
+    ...over,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// onsiteRequestToUnifiedRow
+// ---------------------------------------------------------------------------
+
+describe('onsiteRequestToUnifiedRow', () => {
+  it('maps fields, namespaces the key, and prefers the manifest name for the title', () => {
+    const req = onsite({ id: 'r1', slug: 'my-block', manifest: { name: 'My Block' } });
+    const row = onsiteRequestToUnifiedRow(req, vi.fn());
+    expect(row.key).toBe('onsite:r1');
+    expect(row.kind).toBe('onsite');
+    expect(row.title).toBe('My Block');
+    expect(row.slug).toBe('my-block');
+    expect(row.submitter).toEqual({ id: 7, username: 'onsite-dev', image: null });
+  });
+
+  it('falls back to the slug when the manifest has no usable name', () => {
+    expect(onsiteRequestToUnifiedRow(onsite({ id: 'r1', slug: 's', manifest: {} }), vi.fn()).title).toBe('s');
+    expect(
+      onsiteRequestToUnifiedRow(onsite({ id: 'r2', slug: 's2', manifest: { name: '' } }), vi.fn()).title
+    ).toBe('s2');
+    expect(
+      onsiteRequestToUnifiedRow(onsite({ id: 'r3', slug: 's3', manifest: null as unknown as object }), vi.fn())
+        .title
+    ).toBe('s3');
+  });
+
+  it('uses submittedAt for a pending row and reviewedAt for a decided row', () => {
+    const pending = onsiteRequestToUnifiedRow(
+      onsite({ id: 'p', submittedAt: '2026-03-01T00:00:00Z' }),
+      vi.fn()
+    );
+    expect(pending.submittedAt.toISOString()).toBe('2026-03-01T00:00:00.000Z');
+
+    const approved = onsiteRequestToUnifiedRow(
+      onsite({
+        id: 'a',
+        submittedAt: '2026-03-01T00:00:00Z',
+        reviewedAt: '2026-03-05T00:00:00Z',
+      } as Partial<OnsiteReviewRequest> & { id: string }),
+      vi.fn()
+    );
+    expect(approved.submittedAt.toISOString()).toBe('2026-03-05T00:00:00.000Z');
+  });
+
+  it('wires onReview to the on-site opener with the ORIGINAL request', () => {
+    const open = vi.fn();
+    const req = onsite({ id: 'r1' });
+    const row = onsiteRequestToUnifiedRow(req, open);
+    row.onReview();
+    expect(open).toHaveBeenCalledTimes(1);
+    expect(open).toHaveBeenCalledWith(req);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// offsiteRequestToUnifiedRow
+// ---------------------------------------------------------------------------
+
+describe('offsiteRequestToUnifiedRow', () => {
+  it('maps fields, namespaces the key, and prefers the listing name for the title', () => {
+    const req = offsite({ id: 'o1', slug: 'ext-app' });
+    const row = offsiteRequestToUnifiedRow(req, vi.fn());
+    expect(row.key).toBe('offsite:o1');
+    expect(row.kind).toBe('offsite');
+    expect(row.title).toBe('External App');
+    expect(row.slug).toBe('ext-app');
+    expect(row.submitter).toEqual({ id: 9, username: 'offsite-dev', image: null });
+  });
+
+  it('falls back to the slug when the listing (or its name) is absent', () => {
+    expect(offsiteRequestToUnifiedRow(offsite({ id: 'o1', slug: 'sx', appListing: null }), vi.fn()).title).toBe(
+      'sx'
+    );
+    expect(
+      offsiteRequestToUnifiedRow(
+        offsite({
+          id: 'o2',
+          slug: 'sy',
+          appListing: { name: null, externalUrl: null, category: null, contentRating: null },
+        }),
+        vi.fn()
+      ).title
+    ).toBe('sy');
+  });
+
+  it('uses submittedAt for a pending row and reviewedAt for a decided row', () => {
+    const pending = offsiteRequestToUnifiedRow(
+      offsite({ id: 'p', submittedAt: '2026-04-01T00:00:00Z' }),
+      vi.fn()
+    );
+    expect(pending.submittedAt.toISOString()).toBe('2026-04-01T00:00:00.000Z');
+
+    const approved = offsiteRequestToUnifiedRow(
+      offsite({ id: 'a', submittedAt: '2026-04-01T00:00:00Z', reviewedAt: '2026-04-09T00:00:00Z' }),
+      vi.fn()
+    );
+    expect(approved.submittedAt.toISOString()).toBe('2026-04-09T00:00:00.000Z');
+  });
+
+  it('wires onReview to the off-site opener with an OffsitePendingRow (pending request id + listing id + connect fields)', () => {
+    const open = vi.fn();
+    const req = offsite({
+      id: 'alpr_9',
+      appListingId: 'apl_9',
+      slug: 'connect-app',
+      changelog: 'note',
+      appListing: {
+        name: 'Connect App',
+        externalUrl: null,
+        category: 'utility',
+        contentRating: 'g',
+        connectClientId: 'cc_1',
+        connectRequestedScopes: 3,
+        connectScopeJustifications: { READ: 'why' },
+        connectClient: { name: 'Client' },
+      },
+    });
+    const row = offsiteRequestToUnifiedRow(req, open);
+    row.onReview();
+    expect(open).toHaveBeenCalledTimes(1);
+    const passed = open.mock.calls[0][0];
+    // The modal is approve/reject-driven by the PUBLISH REQUEST id (not the listing id).
+    expect(passed.id).toBe('alpr_9');
+    expect(passed.appListingId).toBe('apl_9');
+    expect(passed.slug).toBe('connect-app');
+    expect(passed.changelog).toBe('note');
+    expect(passed.appListing).toMatchObject({
+      name: 'Connect App',
+      connectClientId: 'cc_1',
+      connectRequestedScopes: 3,
+      connectScopeJustifications: { READ: 'why' },
+      connectClient: { name: 'Client' },
+    });
+    expect(passed.submittedBy).toEqual({ id: 9, username: 'offsite-dev', image: null });
+  });
+
+  it('defaults absent connect fields to null (external-link listing)', () => {
+    const open = vi.fn();
+    offsiteRequestToUnifiedRow(offsite({ id: 'o1' }), open).onReview();
+    const passed = open.mock.calls[0][0];
+    expect(passed.appListing.connectClientId).toBeNull();
+    expect(passed.appListing.connectRequestedScopes).toBeNull();
+    expect(passed.appListing.connectScopeJustifications).toBeNull();
+    expect(passed.appListing.connectClient).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Cross-kind key uniqueness
+// ---------------------------------------------------------------------------
+
+describe('key namespacing', () => {
+  it('an on-site and an off-site request sharing a raw id get DISTINCT keys', () => {
+    const onsiteRow = onsiteRequestToUnifiedRow(onsite({ id: 'shared' }), vi.fn());
+    const offsiteRow = offsiteRequestToUnifiedRow(offsite({ id: 'shared' }), vi.fn());
+    expect(onsiteRow.key).toBe('onsite:shared');
+    expect(offsiteRow.key).toBe('offsite:shared');
+    expect(onsiteRow.key).not.toBe(offsiteRow.key);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// mergeReviewRows
+// ---------------------------------------------------------------------------
+
+function row(key: string, iso: string): UnifiedReviewRow {
+  return {
+    key,
+    kind: key.startsWith('onsite') ? 'onsite' : 'offsite',
+    title: key,
+    submitter: null,
+    submittedAt: new Date(iso),
+    onReview: () => undefined,
+  };
+}
+
+describe('mergeReviewRows', () => {
+  it('empty in → empty out', () => {
+    expect(mergeReviewRows([], [], 'asc')).toEqual([]);
+    expect(mergeReviewRows([], [], 'desc')).toEqual([]);
+  });
+
+  it('one-sided (only on-site, or only off-site) passes through, sorted', () => {
+    const a = row('onsite:a', '2026-01-03T00:00:00Z');
+    const b = row('onsite:b', '2026-01-01T00:00:00Z');
+    expect(mergeReviewRows([a, b], [], 'asc').map((r) => r.key)).toEqual(['onsite:b', 'onsite:a']);
+    expect(mergeReviewRows([], [a, b], 'desc').map((r) => r.key)).toEqual(['onsite:a', 'onsite:b']);
+  });
+
+  it('interleaves the two sources by date — ascending (oldest-first, pending)', () => {
+    const on = [row('onsite:1', '2026-01-01T00:00:00Z'), row('onsite:3', '2026-01-05T00:00:00Z')];
+    const off = [row('offsite:2', '2026-01-03T00:00:00Z')];
+    expect(mergeReviewRows(on, off, 'asc').map((r) => r.key)).toEqual([
+      'onsite:1',
+      'offsite:2',
+      'onsite:3',
+    ]);
+  });
+
+  it('interleaves the two sources by date — descending (newest-first, history)', () => {
+    const on = [row('onsite:1', '2026-01-01T00:00:00Z'), row('onsite:3', '2026-01-05T00:00:00Z')];
+    const off = [row('offsite:2', '2026-01-03T00:00:00Z')];
+    expect(mergeReviewRows(on, off, 'desc').map((r) => r.key)).toEqual([
+      'onsite:3',
+      'offsite:2',
+      'onsite:1',
+    ]);
+  });
+
+  it('dedups by key — a repeated key appears once (first occurrence wins)', () => {
+    const first = { ...row('onsite:x', '2026-01-01T00:00:00Z'), title: 'first' };
+    const dup = { ...row('onsite:x', '2026-01-09T00:00:00Z'), title: 'second' };
+    const merged = mergeReviewRows([first, dup], [], 'asc');
+    expect(merged).toHaveLength(1);
+    expect(merged[0].title).toBe('first');
+  });
+
+  it('never drops a row: N on-site + M off-site (distinct keys) → N+M rows', () => {
+    const on = Array.from({ length: 4 }, (_, i) => row(`onsite:${i}`, `2026-01-0${i + 1}T00:00:00Z`));
+    const off = Array.from({ length: 3 }, (_, i) => row(`offsite:${i}`, `2026-02-0${i + 1}T00:00:00Z`));
+    expect(mergeReviewRows(on, off, 'asc')).toHaveLength(7);
+  });
+
+  it('equal timestamps get a STABLE, direction-independent tiebreak by key', () => {
+    const ts = '2026-01-01T00:00:00Z';
+    const rows = [row('onsite:b', ts), row('offsite:a', ts), row('onsite:c', ts)];
+    // asc + desc must both tiebreak by key ascending (deterministic order).
+    expect(mergeReviewRows(rows, [], 'asc').map((r) => r.key)).toEqual([
+      'offsite:a',
+      'onsite:b',
+      'onsite:c',
+    ]);
+    expect(mergeReviewRows(rows, [], 'desc').map((r) => r.key)).toEqual([
+      'offsite:a',
+      'onsite:b',
+      'onsite:c',
+    ]);
+  });
+
+  it('does not mutate the input arrays', () => {
+    const on = [row('onsite:2', '2026-01-02T00:00:00Z'), row('onsite:1', '2026-01-01T00:00:00Z')];
+    const snapshot = on.map((r) => r.key);
+    mergeReviewRows(on, [], 'asc');
+    expect(on.map((r) => r.key)).toEqual(snapshot);
+  });
+});

--- a/src/components/Apps/unifiedReviewRow.ts
+++ b/src/components/Apps/unifiedReviewRow.ts
@@ -1,0 +1,182 @@
+import type { AnyRequest } from '~/components/Apps/OnsiteReviewModal';
+import type { OffsitePendingRow } from '~/components/Apps/OffsiteReviewQueue';
+
+/**
+ * Pure adapters + merge for the UNIFIED moderator review lists (/apps/review).
+ *
+ * The Pending / Approved / Rejected tabs each render ONE list that interleaves
+ * two independent sources:
+ *   - on-site (App Block) publish requests   → `blocks.list{Pending,Approved,Rejected}Requests`
+ *   - off-site (external listing) requests    → `appListings.list{Pending,Approved,Rejected}Requests`
+ *
+ * Everything here is SERVER-GRAPH-FREE and side-effect-free so it is exhaustively
+ * unit-tested (`__tests__/unifiedReviewRow.test.ts`) — this is the correctness core:
+ * a mis-routed or dropped row means a moderator reviews/approves the wrong thing.
+ *
+ * The two review MODALS are unchanged and page-owned; an adapter only wires each
+ * row's `onReview` to the CORRECT one (on-site → `OnsiteReviewModal`, off-site →
+ * `OffsiteReviewModal`) — the kinds never cross.
+ */
+
+export type UnifiedReviewKind = 'onsite' | 'offsite';
+
+/** Minimal user chip carried on a unified row (rendered by the list). */
+export type ReviewSubmitterChip = {
+  id: number;
+  username: string | null;
+  image: string | null;
+} | null;
+
+export type UnifiedReviewRow = {
+  /** GLOBALLY-unique dedup key across kinds — `onsite:<id>` / `offsite:<id>`.
+   *  The kind prefix guarantees an on-site and an off-site request that happen to
+   *  share a raw id can never collide (and so can never dedup each other away). */
+  key: string;
+  kind: UnifiedReviewKind;
+  /** App / listing display name (falls back to the slug). */
+  title: string;
+  slug?: string;
+  submitter: ReviewSubmitterChip;
+  /** The row's ordering + display timestamp. For a PENDING row this is the
+   *  submission time; for a decided (approved/rejected) HISTORY row it is the
+   *  review time (so "newest-first" history sorts most-recently-reviewed first,
+   *  matching the per-source server ordering). `mergeReviewRows` sorts on this. */
+  submittedAt: Date;
+  /** Opens the correct review modal for this row's kind. */
+  onReview: () => void;
+};
+
+function toDate(d: string | Date): Date {
+  return typeof d === 'string' ? new Date(d) : d;
+}
+
+/** The on-site request shape consumed by the adapter (a superset of the pending
+ *  shape; history rows additionally carry `reviewedAt`). Structurally `AnyRequest`. */
+export type OnsiteReviewRequest = AnyRequest;
+
+/**
+ * Map an on-site publish request → a unified row whose `onReview` opens the
+ * ON-SITE modal. `title` prefers the manifest name, else the slug.
+ */
+export function onsiteRequestToUnifiedRow(
+  req: OnsiteReviewRequest,
+  openOnsiteReview: (req: OnsiteReviewRequest) => void
+): UnifiedReviewRow {
+  const reviewedAt =
+    'reviewedAt' in req && req.reviewedAt != null ? req.reviewedAt : null;
+  const manifestName =
+    req.manifest && typeof req.manifest === 'object'
+      ? (req.manifest as Record<string, unknown>).name
+      : undefined;
+  const title = typeof manifestName === 'string' && manifestName.length > 0 ? manifestName : req.slug;
+  return {
+    key: `onsite:${req.id}`,
+    kind: 'onsite',
+    title,
+    slug: req.slug,
+    submitter: req.submittedBy,
+    submittedAt: toDate(reviewedAt ?? req.submittedAt),
+    onReview: () => openOnsiteReview(req),
+  };
+}
+
+/** The off-site request shape consumed by the adapter — the mod pending/history
+ *  procs (`appListings.list{Pending,Approved,Rejected}Requests`) share this shape.
+ *  A superset of `OffsitePendingRow`: history rows also carry `reviewedAt`. */
+export type OffsiteReviewRequest = {
+  id: string;
+  appListingId: string | null;
+  slug: string;
+  status: string;
+  submittedAt: string | Date;
+  reviewedAt?: string | Date | null;
+  changelog: string | null;
+  appListing:
+    | {
+        name: string | null;
+        externalUrl: string | null;
+        category: string | null;
+        contentRating: string | null;
+        connectClientId?: string | null;
+        connectRequestedScopes?: number | null;
+        connectScopeJustifications?: Record<string, string> | null;
+        connectClient?: { name: string | null } | null;
+      }
+    | null;
+  submittedBy: { id: number; username: string | null; image: string | null } | null;
+};
+
+/**
+ * Map an off-site request → a unified row whose `onReview` opens the OFF-SITE
+ * modal. Builds the exact `OffsitePendingRow` the modal expects so the modal's
+ * internals stay untouched. `title` prefers the listing name, else the slug.
+ */
+export function offsiteRequestToUnifiedRow(
+  req: OffsiteReviewRequest,
+  openOffsiteReview: (row: OffsitePendingRow) => void
+): UnifiedReviewRow {
+  const reviewedAt = req.reviewedAt != null ? req.reviewedAt : null;
+  const row: OffsitePendingRow = {
+    id: req.id,
+    appListingId: req.appListingId,
+    slug: req.slug,
+    status: req.status,
+    submittedAt: req.submittedAt,
+    changelog: req.changelog,
+    appListing: req.appListing
+      ? {
+          name: req.appListing.name,
+          externalUrl: req.appListing.externalUrl,
+          category: req.appListing.category,
+          contentRating: req.appListing.contentRating,
+          connectClientId: req.appListing.connectClientId ?? null,
+          connectRequestedScopes: req.appListing.connectRequestedScopes ?? null,
+          connectScopeJustifications: req.appListing.connectScopeJustifications ?? null,
+          connectClient: req.appListing.connectClient ?? null,
+        }
+      : null,
+    submittedBy: req.submittedBy,
+  };
+  return {
+    key: `offsite:${req.id}`,
+    kind: 'offsite',
+    title: req.appListing?.name ?? req.slug,
+    slug: req.slug,
+    submitter: req.submittedBy,
+    submittedAt: toDate(reviewedAt ?? req.submittedAt),
+    onReview: () => openOffsiteReview(row),
+  };
+}
+
+/**
+ * Merge two already-adapted row lists into one deterministic, de-duplicated,
+ * date-sorted list.
+ *   - dedup by `key` (first occurrence wins; on-site keys and off-site keys are
+ *     namespaced so cross-kind rows never collide — dedup is a within-kind guard);
+ *   - sort by `submittedAt` — `asc` = oldest-first (pending FIFO), `desc` =
+ *     newest-first (history);
+ *   - STABLE, direction-independent tiebreak by `key` so equal timestamps always
+ *     order identically (no render churn).
+ *
+ * Pure — no drops, no side effects. Every input row appears in the output exactly
+ * once.
+ */
+export function mergeReviewRows(
+  onsite: UnifiedReviewRow[],
+  offsite: UnifiedReviewRow[],
+  direction: 'asc' | 'desc'
+): UnifiedReviewRow[] {
+  const byKey = new Map<string, UnifiedReviewRow>();
+  for (const row of onsite) if (!byKey.has(row.key)) byKey.set(row.key, row);
+  for (const row of offsite) if (!byKey.has(row.key)) byKey.set(row.key, row);
+
+  const rows = Array.from(byKey.values());
+  rows.sort((a, b) => {
+    const ta = a.submittedAt.getTime();
+    const tb = b.submittedAt.getTime();
+    if (ta !== tb) return direction === 'asc' ? ta - tb : tb - ta;
+    // Deterministic, direction-independent tiebreak so the order is stable.
+    return a.key < b.key ? -1 : a.key > b.key ? 1 : 0;
+  });
+  return rows;
+}

--- a/src/pages/apps/review.tsx
+++ b/src/pages/apps/review.tsx
@@ -1,50 +1,37 @@
+import { Tabs } from '@mantine/core';
 import {
-  Alert,
-  Badge,
-  Button,
-  Card,
-  Code,
-  Group,
-  Stack,
-  Table,
-  Tabs,
-  Text,
-} from '@mantine/core';
-import {
-  IconAlertTriangle,
   IconCheck,
+  IconClipboardList,
   IconClock,
-  IconExternalLink,
   IconFlag,
   IconX,
 } from '@tabler/icons-react';
 import { useRouter } from 'next/router';
-import type { MouseEvent } from 'react';
-import { useMemo, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { NotFound } from '~/components/AppLayout/NotFound';
 import { ActivePreviewsPanel } from '~/components/Apps/ActivePreviewsPanel';
 import { AppListingsModerationTable } from '~/components/Apps/AppListingsModerationTable';
-// `OffsiteReviewQueue` (the flat pending-only off-site list) is SUPERSEDED by the
-// unified `AppListingsModerationTable` below (which covers pending too, via the
-// per-row Review action). It stays exported for a one-line rollback: swap the
-// `<AppListingsModerationTable />` in the Pending panel back to `<OffsiteReviewQueue />`.
-import { OffsiteReportsQueue } from '~/components/Apps/OffsiteReviewQueue';
-// The on-site (App Block) review modal + its request types and byte-formatters
-// were EXTRACTED to `OnsiteReviewModal.tsx` (mirrors the #3154 diff-panel
-// extraction) so the modal is importable into a browser test WITHOUT this page's
-// `getServerSideProps`/`createServerSideProps` tRPC-server graph. This page mounts
-// it identically to before.
+// The off-site review MODAL is now PAGE-OWNED (lifted here) so a single instance is
+// shared by the unified Pending list AND the `AppListingsModerationTable` — no
+// divergence. `OffsiteReportsQueue` still powers the Reports tab.
+import {
+  OffsiteReportsQueue,
+  OffsiteReviewModal,
+  type OffsitePendingRow,
+} from '~/components/Apps/OffsiteReviewQueue';
+// The on-site (App Block) review modal + its request types were EXTRACTED to
+// `OnsiteReviewModal.tsx` so the modal is importable into a browser test WITHOUT
+// this page's `getServerSideProps` tRPC-server graph.
 import {
   OnsiteReviewModal,
-  formatBytes,
-  formatDate,
   type AnyRequest,
-  type ApprovedRequest,
-  type FileSummary,
-  type ManifestDiffSummary,
-  type PendingRequest,
-  type RejectedRequest,
+  type OnsiteReviewMode,
 } from '~/components/Apps/OnsiteReviewModal';
+import { UnifiedReviewList } from '~/components/Apps/UnifiedReviewList';
+import type {
+  OffsiteReviewRequest,
+  OnsiteReviewRequest,
+} from '~/components/Apps/unifiedReviewRow';
 import { Meta } from '~/components/Meta/Meta';
 import { AppsPageLayout } from '~/components/Apps/AppsPageLayout';
 import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
@@ -54,21 +41,29 @@ import { getLoginLink } from '~/utils/login-helpers';
 import { trpc } from '~/utils/trpc';
 
 /**
- * /apps/review — Moderator review queue + history for App Blocks publish
- * requests.
+ * /apps/review — Moderator review queue + history for Apps (on-site App Blocks AND
+ * off-site external listings), UNIFIED into one list per tab.
  *
- * Three tabs:
- *  - Pending  — oldest-first FIFO queue; click into a row to approve/reject.
- *  - Approved — newest-first history with the mod's optional approval notes
- *               and the "View code in Forgejo" link. Read-only modal.
- *  - Rejected — newest-first history with the required rejection reason
- *               surfaced inline. Read-only modal.
+ * Five tabs:
+ *  - Pending  — ONE oldest-first FIFO list interleaving on-site publish requests
+ *               (`blocks.listPendingRequests`) + off-site requests
+ *               (`appListings.listPendingRequests`). Each row carries a kind badge
+ *               (App / External) and a Review action that opens the CORRECT modal.
+ *  - Approved — unified newest-first history (on-site + off-site approved requests).
+ *  - Rejected — unified newest-first history (on-site + off-site rejected requests).
+ *  - Reports  — off-site listing report queue + mod takedown actions (unchanged).
+ *  - Manage listings — the full all-status lifecycle table (reset/relist/claim/purge).
  *
- * Active tab is mirrored to `?tab=approved|rejected` so a mod can deep-link
- * to a specific history view (e.g. when pasting into a Discord thread).
+ * Both review modals are PAGE-OWNED (lifted here): the on-site `OnsiteReviewModal`
+ * and the off-site `OffsiteReviewModal`. The unified list + the management table
+ * both call the page's `openOnsiteReview` / `openOffsiteReview` — so there is exactly
+ * ONE instance of each modal and the kinds never cross. This is presentation +
+ * modal-state lifting only: no server proc, modal internal, or approve/reject/
+ * lifecycle logic changes.
  *
- * v0 gate: requires `isModerator`. v1 (W11 audit) opens to reviewers
- * outside the civitai team behind RBAC.
+ * Active tab is mirrored to `?tab=` so a mod can deep-link a specific view.
+ *
+ * v0 gate: requires `isAppReviewer`. Dark + mod-only.
  */
 export const getServerSideProps = createServerSideProps({
   useSession: true,
@@ -89,28 +84,36 @@ export const getServerSideProps = createServerSideProps({
   },
 });
 
-// The request types (PendingRequest / ApprovedRequest / RejectedRequest /
-// AnyRequest, FileSummary, ManifestDiffSummary) moved to `OnsiteReviewModal.tsx`
-// alongside the modal and are imported above.
-
-type TabValue = 'pending' | 'approved' | 'rejected' | 'reports';
+type TabValue = 'pending' | 'approved' | 'rejected' | 'reports' | 'manage';
 
 function isTabValue(v: unknown): v is TabValue {
-  return v === 'pending' || v === 'approved' || v === 'rejected' || v === 'reports';
+  return (
+    v === 'pending' ||
+    v === 'approved' ||
+    v === 'rejected' ||
+    v === 'reports' ||
+    v === 'manage'
+  );
 }
 
-// `formatBytes` + `formatDate` moved to `OnsiteReviewModal.tsx` (imported above).
-// The global active-previews panel + its `formatAge` helper moved to
-// `~/components/Apps/ActivePreviewsPanel` (mirrors the OnsiteReviewModal
-// extraction) so the panel is mountable in a browser test without this page's
-// `getServerSideProps` server graph. It's imported above and rendered identically.
+/** Rows fetched per source per page (bounded by each proc's schema at ≤100). Mod
+ *  queues are low/moderate volume, so one bounded page per source + Load-more is
+ *  simple and correct. */
+const PAGE_LIMIT = 50;
+
+/** Append `page` onto `accumulated`, dropping ids already present (defensive dedup
+ *  in case Load-more double-fires before a fetch settles). */
+function mergeById<T extends { id: string }>(accumulated: T[], page: T[]): T[] {
+  const seen = new Set(accumulated.map((r) => r.id));
+  return [...accumulated, ...page.filter((r) => !seen.has(r.id))];
+}
 
 export default function ReviewQueuePage() {
   const features = useFeatureFlags();
   const router = useRouter();
 
-  // Sync active tab with `?tab=` so deep-links land on the right view. Use
-  // shallow routing so the page query doesn't re-trigger getServerSideProps.
+  // Sync active tab with `?tab=` so deep-links land on the right view. Shallow
+  // routing so the page query doesn't re-trigger getServerSideProps.
   const tab: TabValue = useMemo(() => {
     const qt = router.query.tab;
     if (typeof qt === 'string' && isTabValue(qt)) return qt;
@@ -125,24 +128,40 @@ export default function ReviewQueuePage() {
     );
   };
 
-  const [selected, setSelected] = useState<{
-    request: AnyRequest;
-    mode: TabValue;
+  // On-site review modal selection (page-owned; unchanged behaviour).
+  const [selected, setSelected] = useState<{ request: AnyRequest; mode: OnsiteReviewMode } | null>(
+    null
+  );
+  // Off-site review modal — LIFTED to the page so one instance is shared by the
+  // unified Pending list and the management table. `onActioned` lets whichever
+  // surface opened it refresh its own paginated query after an approve/reject.
+  const [offsiteReview, setOffsiteReview] = useState<{
+    row: OffsitePendingRow;
+    onActioned?: () => void | Promise<void>;
   } | null>(null);
 
-  // DUAL-PATH row selection (Phase 1 of the review modal → page migration).
-  // Under the `appReviewPage` flag a row NAVIGATES to the deep-linkable detail
-  // page `/apps/review/<id>`; with the flag off it opens the modal exactly as
-  // before. Fully reversible: flip the flag off (or unset it) to restore the
-  // modal path with zero code change. The report/tabs redesign is Phase 2.
+  // DUAL-PATH on-site row selection: under the `appReviewPage` flag a row NAVIGATES
+  // to the deep-linkable detail page `/apps/review/<id>`; with the flag off it opens
+  // the modal exactly as before. Off-site has no detail page → always the modal.
   const linkToPage = !!features?.appReviewPage;
-  const openRequest = (request: AnyRequest, mode: TabValue) => {
-    if (linkToPage) {
-      void router.push(`/apps/review/${request.id}`);
-      return;
-    }
-    setSelected({ request, mode });
-  };
+
+  const openOnsiteReview = useCallback(
+    (request: AnyRequest, mode: OnsiteReviewMode) => {
+      if (linkToPage) {
+        void router.push(`/apps/review/${request.id}`);
+        return;
+      }
+      setSelected({ request, mode });
+    },
+    [linkToPage, router]
+  );
+
+  const openOffsiteReview = useCallback(
+    (row: OffsitePendingRow, onActioned?: () => void | Promise<void>) => {
+      setOffsiteReview({ row, onActioned });
+    },
+    []
+  );
 
   if (!features?.appBlocks) return <NotFound />;
 
@@ -152,7 +171,7 @@ export default function ReviewQueuePage() {
       <AppsPageLayout
         size="xl"
         title="App publish-request queue"
-        subtitle="Moderator review for Apps. Pending queue is oldest-first; history tabs are newest-first."
+        subtitle="Moderator review for Apps. On-site + external submissions share one queue per tab; Pending is oldest-first, history is newest-first."
       >
         <ActivePreviewsPanel />
 
@@ -176,385 +195,255 @@ export default function ReviewQueuePage() {
             <Tabs.Tab value="reports" leftSection={<IconFlag size={14} />}>
               Reports
             </Tabs.Tab>
+            <Tabs.Tab value="manage" leftSection={<IconClipboardList size={14} />}>
+              Manage listings
+            </Tabs.Tab>
           </Tabs.List>
 
           <Tabs.Panel value="pending" pt="md">
-            {/* On-site (App Block) queue — deep code review (byte-unchanged). The
-                onsite iframe/preview review lives here and is KEPT as-is. */}
-            <PendingTab onSelect={(r) => openRequest(r, 'pending')} />
-            {/* Unified moderator LISTINGS MANAGEMENT table (W13 post-approval mgmt,
-                P2) — all statuses across both kinds, with per-row lifecycle actions.
-                REPLACES the flat off-site pending list (`OffsiteReviewQueue`): a
-                pending off-site row's Review action opens that same review modal, so
-                the table now covers pending too while adding post-approval
-                management (reset/hide/relist/claim/purge) that had no home. */}
-            <AppListingsModerationTable />
+            {/* ONE unified oldest-first queue: on-site + off-site pending requests. */}
+            <UnifiedPendingTab
+              openOnsiteReview={openOnsiteReview}
+              openOffsiteReview={openOffsiteReview}
+            />
           </Tabs.Panel>
 
           <Tabs.Panel value="approved" pt="md">
-            <ApprovedTab onSelect={(r) => openRequest(r, 'approved')} />
+            <UnifiedHistoryTab
+              kind="approved"
+              openOnsiteReview={openOnsiteReview}
+              openOffsiteReview={openOffsiteReview}
+            />
           </Tabs.Panel>
 
           <Tabs.Panel value="rejected" pt="md">
-            <RejectedTab onSelect={(r) => openRequest(r, 'rejected')} />
+            <UnifiedHistoryTab
+              kind="rejected"
+              openOnsiteReview={openOnsiteReview}
+              openOffsiteReview={openOffsiteReview}
+            />
           </Tabs.Panel>
 
           <Tabs.Panel value="reports" pt="md">
-            {/* Off-site listing REPORT queue + mod takedown actions (W13 P3b PR3).
-                Dark + mod-only; read via appListings.listListingReports. */}
+            {/* Off-site listing REPORT queue + mod takedown actions. Unchanged. */}
             <OffsiteReportsQueue />
+          </Tabs.Panel>
+
+          <Tabs.Panel value="manage" pt="md">
+            {/* Full all-status listings MANAGEMENT table (reset/relist/claim/purge).
+                Its pending rows' Review action opens the same page-owned off-site
+                modal; its lifecycle-action modals stay local to it. */}
+            <AppListingsModerationTable openOffsiteReview={openOffsiteReview} />
           </Tabs.Panel>
         </Tabs>
       </AppsPageLayout>
 
-      <OnsiteReviewModal
-        selection={selected}
-        onClose={() => setSelected(null)}
+      <OnsiteReviewModal selection={selected} onClose={() => setSelected(null)} />
+      <OffsiteReviewModal
+        request={offsiteReview?.row ?? null}
+        onClose={() => setOffsiteReview(null)}
+        onActioned={offsiteReview?.onActioned}
       />
     </>
   );
 }
 
 // ---------------------------------------------------------------------------
-// Pending tab — original FIFO queue with approve/reject modal.
+// Unified PENDING tab — one oldest-first list merging the on-site + off-site
+// pending queues. Each source is independently keyset-paginated; Load-more
+// advances whichever source(s) still have a next page, and the pure merge
+// re-sorts the full accumulated set. (Global order across the two independently-
+// paginated sources is exact once both first pages are loaded — fine at mod-queue
+// volumes; we never build a server-side cross-table cursor.)
 // ---------------------------------------------------------------------------
 
-function PendingTab({ onSelect }: { onSelect: (r: PendingRequest) => void }) {
-  const features = useFeatureFlags();
-  const queue = trpc.blocks.listPendingRequests.useQuery(
-    { limit: 50 },
-    { enabled: !!features?.appBlocks }
-  );
-
-  const items = (queue.data?.items ?? []) as PendingRequest[];
-
-  // The modal invalidates listPendingRequests via trpc.useUtils() on
-  // approve/reject success, which forces this query to refetch
-  // automatically — no prop-drilled onActioned callback needed.
-
-  return (
-    <Stack gap="md">
-      <Text c="dimmed" size="sm">
-        {queue.isLoading ? 'Loading…' : `${items.length} pending.`}
-      </Text>
-
-      {queue.isError && (
-        <Alert color="red" icon={<IconAlertTriangle size={16} />}>
-          {queue.error.message}
-        </Alert>
-      )}
-
-      {!queue.isLoading && items.length === 0 && (
-        <Card withBorder p="lg">
-          <Group gap="xs">
-            <IconCheck color="var(--mantine-color-green-6)" size={20} />
-            <Text>Queue is empty. Nothing waiting for review.</Text>
-          </Group>
-        </Card>
-      )}
-
-      {items.length > 0 && (
-        <Card withBorder p={0}>
-          <Table verticalSpacing="md" horizontalSpacing="md">
-            <Table.Thead>
-              <Table.Tr>
-                <Table.Th>App</Table.Th>
-                <Table.Th>Version</Table.Th>
-                <Table.Th>Submitter</Table.Th>
-                <Table.Th>Submitted</Table.Th>
-                <Table.Th>Bundle</Table.Th>
-                <Table.Th>Changes</Table.Th>
-                <Table.Th />
-              </Table.Tr>
-            </Table.Thead>
-            <Table.Tbody>
-              {items.map((r) => {
-                const fs = (r.fileSummary ?? {}) as FileSummary;
-                const mds = (r.manifestDiffSummary ?? {}) as ManifestDiffSummary;
-                const isFirst = mds.kind === 'first-version';
-                return (
-                  <Table.Tr key={r.id} style={{ cursor: 'pointer' }}>
-                    <Table.Td onClick={() => onSelect(r)}>
-                      <Group gap={6}>
-                        <Code>{r.slug}</Code>
-                        {isFirst && (
-                          <Badge color="violet" size="xs">
-                            first version
-                          </Badge>
-                        )}
-                      </Group>
-                    </Table.Td>
-                    <Table.Td onClick={() => onSelect(r)}>
-                      <Code>{r.version}</Code>
-                    </Table.Td>
-                    <Table.Td onClick={() => onSelect(r)}>
-                      {r.submittedBy.username ?? `#${r.submittedBy.id}`}
-                    </Table.Td>
-                    <Table.Td onClick={() => onSelect(r)}>
-                      <Group gap={4}>
-                        <IconClock size={14} />
-                        <Text size="xs">{formatDate(r.submittedAt)}</Text>
-                      </Group>
-                    </Table.Td>
-                    <Table.Td onClick={() => onSelect(r)}>
-                      <Text size="xs" c="dimmed">
-                        {formatBytes(r.bundleSizeBytes)} ·{' '}
-                        {fs.files?.length ?? 0} files
-                      </Text>
-                    </Table.Td>
-                    <Table.Td onClick={() => onSelect(r)}>
-                      <Group gap={6}>
-                        {(fs.added?.length ?? 0) > 0 && (
-                          <Badge color="green" size="xs">
-                            +{fs.added.length}
-                          </Badge>
-                        )}
-                        {(fs.changed?.length ?? 0) > 0 && (
-                          <Badge color="yellow" size="xs">
-                            ~{fs.changed.length}
-                          </Badge>
-                        )}
-                        {(fs.removed?.length ?? 0) > 0 && (
-                          <Badge color="red" size="xs">
-                            −{fs.removed.length}
-                          </Badge>
-                        )}
-                      </Group>
-                    </Table.Td>
-                    <Table.Td>
-                      <Button
-                        size="xs"
-                        variant="default"
-                        onClick={() => onSelect(r)}
-                        rightSection={<IconExternalLink size={12} />}
-                      >
-                        Review
-                      </Button>
-                    </Table.Td>
-                  </Table.Tr>
-                );
-              })}
-            </Table.Tbody>
-          </Table>
-        </Card>
-      )}
-    </Stack>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Approved tab — cursor-paginated history with inline approval notes.
-// ---------------------------------------------------------------------------
-
-function ApprovedTab({ onSelect }: { onSelect: (r: ApprovedRequest) => void }) {
-  return (
-    <HistoryTab
-      kind="approved"
-      onSelect={(r) => onSelect(r as ApprovedRequest)}
-      emptyLabel="No approved publish requests yet."
-    />
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Rejected tab — cursor-paginated history with inline rejection reason.
-// ---------------------------------------------------------------------------
-
-function RejectedTab({ onSelect }: { onSelect: (r: RejectedRequest) => void }) {
-  return (
-    <HistoryTab
-      kind="rejected"
-      onSelect={(r) => onSelect(r as RejectedRequest)}
-      emptyLabel="No rejected publish requests yet."
-    />
-  );
-}
-
-// ---------------------------------------------------------------------------
-// Shared history tab — drives both approved + rejected. Differs only by the
-// tRPC proc it calls and the inline mod-note column it renders.
-// ---------------------------------------------------------------------------
-
-function HistoryTab({
-  kind,
-  onSelect,
-  emptyLabel,
+function UnifiedPendingTab({
+  openOnsiteReview,
+  openOffsiteReview,
 }: {
-  kind: 'approved' | 'rejected';
-  onSelect: (r: ApprovedRequest | RejectedRequest) => void;
-  emptyLabel: string;
+  openOnsiteReview: (req: AnyRequest, mode: OnsiteReviewMode) => void;
+  openOffsiteReview: (row: OffsitePendingRow, onActioned?: () => void | Promise<void>) => void;
 }) {
   const features = useFeatureFlags();
-  const [cursor, setCursor] = useState<string | undefined>(undefined);
-  const [accumulated, setAccumulated] = useState<Array<ApprovedRequest | RejectedRequest>>([]);
+  const enabled = !!features?.appBlocks;
 
-  // Reset accumulated state when switching between tabs (kind doesn't
-  // change in practice — each HistoryTab instance is per-kind — but if a
-  // mod reloads the page on a different tab we start fresh).
-  // Both procs share the listPendingRequestsSchema shape so the input
-  // types are interchangeable.
-  const approvedQuery = trpc.blocks.listApprovedRequests.useQuery(
-    { limit: 25, cursor },
-    { enabled: !!features?.appBlocks && kind === 'approved' }
+  const [onsiteCursor, setOnsiteCursor] = useState<string | undefined>(undefined);
+  const [offsiteCursor, setOffsiteCursor] = useState<string | undefined>(undefined);
+  const [onsiteAcc, setOnsiteAcc] = useState<OnsiteReviewRequest[]>([]);
+  const [offsiteAcc, setOffsiteAcc] = useState<OffsiteReviewRequest[]>([]);
+
+  const onsiteQuery = trpc.blocks.listPendingRequests.useQuery(
+    { limit: PAGE_LIMIT, cursor: onsiteCursor },
+    { enabled, retry: false }
   );
-  const rejectedQuery = trpc.blocks.listRejectedRequests.useQuery(
-    { limit: 25, cursor },
-    { enabled: !!features?.appBlocks && kind === 'rejected' }
+  const offsiteQuery = trpc.appListings.listPendingRequests.useQuery(
+    { limit: PAGE_LIMIT, cursor: offsiteCursor },
+    { enabled, retry: false }
   );
-  const query = kind === 'approved' ? approvedQuery : rejectedQuery;
 
-  const page = (query.data?.items ?? []) as Array<ApprovedRequest | RejectedRequest>;
+  const onsitePage = (onsiteQuery.data?.items ?? []) as OnsiteReviewRequest[];
+  const offsitePage = (offsiteQuery.data?.items ?? []) as OffsiteReviewRequest[];
 
-  // Merge each page result into the accumulated list. Dedupe by id in case
-  // the user clicks Load more multiple times before the previous fetch
-  // settled (defensive — react-query usually serializes these).
-  const merged = useMemo(() => {
-    if (!cursor) return page;
-    const seen = new Set(accumulated.map((r) => r.id));
-    return [...accumulated, ...page.filter((r) => !seen.has(r.id))];
-  }, [accumulated, page, cursor]);
+  const onsiteItems = useMemo(
+    () => (onsiteCursor ? mergeById(onsiteAcc, onsitePage) : onsitePage),
+    [onsiteAcc, onsitePage, onsiteCursor]
+  );
+  const offsiteItems = useMemo(
+    () => (offsiteCursor ? mergeById(offsiteAcc, offsitePage) : offsitePage),
+    [offsiteAcc, offsitePage, offsiteCursor]
+  );
+
+  const onsiteNext = onsiteQuery.data?.nextCursor ?? null;
+  const offsiteNext = offsiteQuery.data?.nextCursor ?? null;
+
+  const resetPaging = useCallback(() => {
+    setOnsiteAcc([]);
+    setOffsiteAcc([]);
+    setOnsiteCursor(undefined);
+    setOffsiteCursor(undefined);
+  }, []);
+
+  const boundOnsite = useCallback(
+    (req: OnsiteReviewRequest) => openOnsiteReview(req, 'pending'),
+    [openOnsiteReview]
+  );
+  const boundOffsite = useCallback(
+    (row: OffsitePendingRow) => openOffsiteReview(row, resetPaging),
+    [openOffsiteReview, resetPaging]
+  );
 
   const onLoadMore = () => {
-    // Snapshot the current page before advancing the cursor so the next
-    // useQuery call starts a new fetch.
-    setAccumulated(merged);
-    const next = query.data?.nextCursor ?? undefined;
-    if (next) setCursor(next);
+    if (onsiteNext != null) {
+      setOnsiteAcc(onsiteItems);
+      setOnsiteCursor(onsiteNext);
+    }
+    if (offsiteNext != null) {
+      setOffsiteAcc(offsiteItems);
+      setOffsiteCursor(offsiteNext);
+    }
   };
 
   return (
-    <Stack gap="md">
-      <Text c="dimmed" size="sm">
-        {query.isLoading ? 'Loading…' : `${merged.length} shown.`}
-      </Text>
-
-      {query.isError && (
-        <Alert color="red" icon={<IconAlertTriangle size={16} />}>
-          {query.error.message}
-        </Alert>
-      )}
-
-      {!query.isLoading && merged.length === 0 && (
-        <Card withBorder p="lg">
-          <Group gap="xs">
-            <IconCheck color="var(--mantine-color-gray-6)" size={20} />
-            <Text>{emptyLabel}</Text>
-          </Group>
-        </Card>
-      )}
-
-      {merged.length > 0 && (
-        <Card withBorder p={0}>
-          <Table verticalSpacing="md" horizontalSpacing="md">
-            <Table.Thead>
-              <Table.Tr>
-                <Table.Th>App</Table.Th>
-                <Table.Th>Version</Table.Th>
-                <Table.Th>Submitter</Table.Th>
-                <Table.Th>{kind === 'approved' ? 'Approved by' : 'Rejected by'}</Table.Th>
-                <Table.Th>Reviewed</Table.Th>
-                <Table.Th>{kind === 'approved' ? 'Notes' : 'Reason'}</Table.Th>
-                <Table.Th />
-              </Table.Tr>
-            </Table.Thead>
-            <Table.Tbody>
-              {merged.map((r) => {
-                const isApproved = kind === 'approved';
-                const approved = r as ApprovedRequest;
-                const rejected = r as RejectedRequest;
-                const note = isApproved ? approved.approvalNotes : rejected.rejectionReason;
-                return (
-                  <Table.Tr key={r.id} style={{ cursor: 'pointer' }}>
-                    <Table.Td onClick={() => onSelect(r)}>
-                      <Code>{r.slug}</Code>
-                    </Table.Td>
-                    <Table.Td onClick={() => onSelect(r)}>
-                      <Code>{r.version}</Code>
-                    </Table.Td>
-                    <Table.Td onClick={() => onSelect(r)}>
-                      {r.submittedBy.username ?? `#${r.submittedBy.id}`}
-                    </Table.Td>
-                    <Table.Td onClick={() => onSelect(r)}>
-                      {r.reviewedBy
-                        ? r.reviewedBy.username
-                          ? `@${r.reviewedBy.username}`
-                          : `#${r.reviewedBy.id}`
-                        : '—'}
-                    </Table.Td>
-                    <Table.Td onClick={() => onSelect(r)}>
-                      <Group gap={4}>
-                        <IconClock size={14} />
-                        <Text size="xs">{formatDate(r.reviewedAt)}</Text>
-                      </Group>
-                    </Table.Td>
-                    <Table.Td onClick={() => onSelect(r)}>
-                      <HistoryNoteCell note={note} />
-                    </Table.Td>
-                    <Table.Td>
-                      <Button
-                        size="xs"
-                        variant="default"
-                        onClick={() => onSelect(r)}
-                        rightSection={<IconExternalLink size={12} />}
-                      >
-                        View
-                      </Button>
-                    </Table.Td>
-                  </Table.Tr>
-                );
-              })}
-            </Table.Tbody>
-          </Table>
-        </Card>
-      )}
-
-      {query.data?.nextCursor && !query.isFetching && (
-        <Group justify="center">
-          <Button variant="default" onClick={onLoadMore}>
-            Load more
-          </Button>
-        </Group>
-      )}
-    </Stack>
+    <UnifiedReviewList
+      onsiteItems={onsiteItems}
+      offsiteItems={offsiteItems}
+      direction="asc"
+      openOnsiteReview={boundOnsite}
+      openOffsiteReview={boundOffsite}
+      isLoading={onsiteQuery.isLoading || offsiteQuery.isLoading}
+      errorMessage={onsiteQuery.error?.message ?? offsiteQuery.error?.message}
+      emptyLabel="Queue is empty. Nothing waiting for review."
+      dateLabel="Submitted"
+      actionLabel="Review"
+      hasMore={onsiteNext != null || offsiteNext != null}
+      isLoadingMore={onsiteQuery.isFetching || offsiteQuery.isFetching}
+      onLoadMore={onLoadMore}
+    />
   );
 }
 
-/**
- * Inline mod-note cell. Notes are usually one line; collapse anything
- * over ~120 chars behind a Show more toggle so the table rows don't
- * stretch unboundedly.
- */
-function HistoryNoteCell({ note }: { note: string | null | undefined }) {
-  const [expanded, setExpanded] = useState(false);
-  if (!note) {
-    return (
-      <Text size="xs" c="dimmed">
-        —
-      </Text>
-    );
-  }
-  const long = note.length > 120;
-  const shown = expanded || !long ? note : `${note.slice(0, 120).trimEnd()}…`;
+// ---------------------------------------------------------------------------
+// Unified HISTORY tab (drives both Approved + Rejected) — newest-first, merging
+// the on-site + off-site decided requests. Mirrors the pending tab's dual-source
+// keyset pagination. All four history queries are declared (rules of hooks); only
+// the active kind's pair is enabled.
+// ---------------------------------------------------------------------------
+
+function UnifiedHistoryTab({
+  kind,
+  openOnsiteReview,
+  openOffsiteReview,
+}: {
+  kind: 'approved' | 'rejected';
+  openOnsiteReview: (req: AnyRequest, mode: OnsiteReviewMode) => void;
+  openOffsiteReview: (row: OffsitePendingRow, onActioned?: () => void | Promise<void>) => void;
+}) {
+  const features = useFeatureFlags();
+  const enabled = !!features?.appBlocks;
+  const isApproved = kind === 'approved';
+
+  const [onsiteCursor, setOnsiteCursor] = useState<string | undefined>(undefined);
+  const [offsiteCursor, setOffsiteCursor] = useState<string | undefined>(undefined);
+  const [onsiteAcc, setOnsiteAcc] = useState<OnsiteReviewRequest[]>([]);
+  const [offsiteAcc, setOffsiteAcc] = useState<OffsiteReviewRequest[]>([]);
+
+  const onsiteApprovedQ = trpc.blocks.listApprovedRequests.useQuery(
+    { limit: PAGE_LIMIT, cursor: onsiteCursor },
+    { enabled: enabled && isApproved, retry: false }
+  );
+  const onsiteRejectedQ = trpc.blocks.listRejectedRequests.useQuery(
+    { limit: PAGE_LIMIT, cursor: onsiteCursor },
+    { enabled: enabled && !isApproved, retry: false }
+  );
+  const offsiteApprovedQ = trpc.appListings.listApprovedRequests.useQuery(
+    { limit: PAGE_LIMIT, cursor: offsiteCursor },
+    { enabled: enabled && isApproved, retry: false }
+  );
+  const offsiteRejectedQ = trpc.appListings.listRejectedRequests.useQuery(
+    { limit: PAGE_LIMIT, cursor: offsiteCursor },
+    { enabled: enabled && !isApproved, retry: false }
+  );
+
+  const onsiteQuery = isApproved ? onsiteApprovedQ : onsiteRejectedQ;
+  const offsiteQuery = isApproved ? offsiteApprovedQ : offsiteRejectedQ;
+
+  const onsitePage = (onsiteQuery.data?.items ?? []) as OnsiteReviewRequest[];
+  const offsitePage = (offsiteQuery.data?.items ?? []) as OffsiteReviewRequest[];
+
+  const onsiteItems = useMemo(
+    () => (onsiteCursor ? mergeById(onsiteAcc, onsitePage) : onsitePage),
+    [onsiteAcc, onsitePage, onsiteCursor]
+  );
+  const offsiteItems = useMemo(
+    () => (offsiteCursor ? mergeById(offsiteAcc, offsitePage) : offsitePage),
+    [offsiteAcc, offsitePage, offsiteCursor]
+  );
+
+  const onsiteNext = onsiteQuery.data?.nextCursor ?? null;
+  const offsiteNext = offsiteQuery.data?.nextCursor ?? null;
+
+  const resetPaging = useCallback(() => {
+    setOnsiteAcc([]);
+    setOffsiteAcc([]);
+    setOnsiteCursor(undefined);
+    setOffsiteCursor(undefined);
+  }, []);
+
+  const boundOnsite = useCallback(
+    (req: OnsiteReviewRequest) => openOnsiteReview(req, kind),
+    [openOnsiteReview, kind]
+  );
+  const boundOffsite = useCallback(
+    (row: OffsitePendingRow) => openOffsiteReview(row, resetPaging),
+    [openOffsiteReview, resetPaging]
+  );
+
+  const onLoadMore = () => {
+    if (onsiteNext != null) {
+      setOnsiteAcc(onsiteItems);
+      setOnsiteCursor(onsiteNext);
+    }
+    if (offsiteNext != null) {
+      setOffsiteAcc(offsiteItems);
+      setOffsiteCursor(offsiteNext);
+    }
+  };
+
   return (
-    <Stack gap={2} maw={360}>
-      <Text size="xs" style={{ whiteSpace: 'pre-wrap', wordBreak: 'break-word' }}>
-        {shown}
-      </Text>
-      {long && (
-        <Text
-          component="button"
-          type="button"
-          size="xs"
-          c="blue"
-          onClick={(e: MouseEvent<HTMLButtonElement>) => {
-            e.stopPropagation();
-            setExpanded((v) => !v);
-          }}
-          style={{ background: 'none', border: 'none', padding: 0, cursor: 'pointer' }}
-        >
-          {expanded ? 'Show less' : 'Show more'}
-        </Text>
-      )}
-    </Stack>
+    <UnifiedReviewList
+      onsiteItems={onsiteItems}
+      offsiteItems={offsiteItems}
+      direction="desc"
+      openOnsiteReview={boundOnsite}
+      openOffsiteReview={boundOffsite}
+      isLoading={onsiteQuery.isLoading || offsiteQuery.isLoading}
+      errorMessage={onsiteQuery.error?.message ?? offsiteQuery.error?.message}
+      emptyLabel={isApproved ? 'No approved requests yet.' : 'No rejected requests yet.'}
+      dateLabel="Reviewed"
+      actionLabel="View"
+      hasMore={onsiteNext != null || offsiteNext != null}
+      isLoadingMore={onsiteQuery.isFetching || offsiteQuery.isFetching}
+      onLoadMore={onLoadMore}
+    />
   );
 }

--- a/src/pages/apps/review.tsx
+++ b/src/pages/apps/review.tsx
@@ -128,16 +128,22 @@ export default function ReviewQueuePage() {
     );
   };
 
-  // On-site review modal selection (page-owned; unchanged behaviour).
-  const [selected, setSelected] = useState<{ request: AnyRequest; mode: OnsiteReviewMode } | null>(
-    null
-  );
+  // On-site review modal selection (page-owned). `onActioned` lets the opening tab
+  // refresh its own paginated query after an approve/reject (symmetric with off-site).
+  const [selected, setSelected] = useState<{
+    request: AnyRequest;
+    mode: OnsiteReviewMode;
+    onActioned?: () => void | Promise<void>;
+  } | null>(null);
   // Off-site review modal — LIFTED to the page so one instance is shared by the
   // unified Pending list and the management table. `onActioned` lets whichever
-  // surface opened it refresh its own paginated query after an approve/reject.
+  // surface opened it refresh its own paginated query after an approve/reject;
+  // `readOnly` makes a history-tab (Approved/Rejected) open a read-only detail view
+  // (no Approve/Reject buttons) — matching the on-site history posture.
   const [offsiteReview, setOffsiteReview] = useState<{
     row: OffsitePendingRow;
     onActioned?: () => void | Promise<void>;
+    readOnly?: boolean;
   } | null>(null);
 
   // DUAL-PATH on-site row selection: under the `appReviewPage` flag a row NAVIGATES
@@ -146,19 +152,19 @@ export default function ReviewQueuePage() {
   const linkToPage = !!features?.appReviewPage;
 
   const openOnsiteReview = useCallback(
-    (request: AnyRequest, mode: OnsiteReviewMode) => {
+    (request: AnyRequest, mode: OnsiteReviewMode, onActioned?: () => void | Promise<void>) => {
       if (linkToPage) {
         void router.push(`/apps/review/${request.id}`);
         return;
       }
-      setSelected({ request, mode });
+      setSelected({ request, mode, onActioned });
     },
     [linkToPage, router]
   );
 
   const openOffsiteReview = useCallback(
-    (row: OffsitePendingRow, onActioned?: () => void | Promise<void>) => {
-      setOffsiteReview({ row, onActioned });
+    (row: OffsitePendingRow, onActioned?: () => void | Promise<void>, readOnly = false) => {
+      setOffsiteReview({ row, onActioned, readOnly });
     },
     []
   );
@@ -238,11 +244,16 @@ export default function ReviewQueuePage() {
         </Tabs>
       </AppsPageLayout>
 
-      <OnsiteReviewModal selection={selected} onClose={() => setSelected(null)} />
+      <OnsiteReviewModal
+        selection={selected}
+        onClose={() => setSelected(null)}
+        onActioned={selected?.onActioned}
+      />
       <OffsiteReviewModal
         request={offsiteReview?.row ?? null}
         onClose={() => setOffsiteReview(null)}
         onActioned={offsiteReview?.onActioned}
+        readOnly={offsiteReview?.readOnly}
       />
     </>
   );
@@ -261,8 +272,16 @@ function UnifiedPendingTab({
   openOnsiteReview,
   openOffsiteReview,
 }: {
-  openOnsiteReview: (req: AnyRequest, mode: OnsiteReviewMode) => void;
-  openOffsiteReview: (row: OffsitePendingRow, onActioned?: () => void | Promise<void>) => void;
+  openOnsiteReview: (
+    req: AnyRequest,
+    mode: OnsiteReviewMode,
+    onActioned?: () => void | Promise<void>
+  ) => void;
+  openOffsiteReview: (
+    row: OffsitePendingRow,
+    onActioned?: () => void | Promise<void>,
+    readOnly?: boolean
+  ) => void;
 }) {
   const features = useFeatureFlags();
   const enabled = !!features?.appBlocks;
@@ -304,8 +323,11 @@ function UnifiedPendingTab({
   }, []);
 
   const boundOnsite = useCallback(
-    (req: OnsiteReviewRequest) => openOnsiteReview(req, 'pending'),
-    [openOnsiteReview]
+    // Register the tab's paging reset as the onsite modal's post-success callback so
+    // approving/rejecting an onsite item clears the accumulators + refetches page 1
+    // (mirrors the offsite path — kills the stale ghost-row after a decision).
+    (req: OnsiteReviewRequest) => openOnsiteReview(req, 'pending', resetPaging),
+    [openOnsiteReview, resetPaging]
   );
   const boundOffsite = useCallback(
     (row: OffsitePendingRow) => openOffsiteReview(row, resetPaging),
@@ -355,8 +377,16 @@ function UnifiedHistoryTab({
   openOffsiteReview,
 }: {
   kind: 'approved' | 'rejected';
-  openOnsiteReview: (req: AnyRequest, mode: OnsiteReviewMode) => void;
-  openOffsiteReview: (row: OffsitePendingRow, onActioned?: () => void | Promise<void>) => void;
+  openOnsiteReview: (
+    req: AnyRequest,
+    mode: OnsiteReviewMode,
+    onActioned?: () => void | Promise<void>
+  ) => void;
+  openOffsiteReview: (
+    row: OffsitePendingRow,
+    onActioned?: () => void | Promise<void>,
+    readOnly?: boolean
+  ) => void;
 }) {
   const features = useFeatureFlags();
   const enabled = !!features?.appBlocks;
@@ -410,11 +440,15 @@ function UnifiedHistoryTab({
   }, []);
 
   const boundOnsite = useCallback(
-    (req: OnsiteReviewRequest) => openOnsiteReview(req, kind),
-    [openOnsiteReview, kind]
+    // History rows open in read-only mode ('approved'/'rejected'), so the action bar
+    // self-suppresses and onActioned never fires — but wire resetPaging for symmetry.
+    (req: OnsiteReviewRequest) => openOnsiteReview(req, kind, resetPaging),
+    [openOnsiteReview, kind, resetPaging]
   );
   const boundOffsite = useCallback(
-    (row: OffsitePendingRow) => openOffsiteReview(row, resetPaging),
+    // Off-site history opens the modal READ-ONLY (no Approve/Reject buttons) — an
+    // already-decided request would only error NOT_PENDING; this matches on-site.
+    (row: OffsitePendingRow) => openOffsiteReview(row, resetPaging, true),
     [openOffsiteReview, resetPaging]
   );
 

--- a/src/tests/pages/apps/review/review-queue-nav.browser.test.tsx
+++ b/src/tests/pages/apps/review/review-queue-nav.browser.test.tsx
@@ -51,7 +51,12 @@ vi.mock('~/components/Apps/AppListingsModerationTable', () => ({
   AppListingsModerationTable: () => null,
 }));
 vi.mock('~/components/Apps/ActivePreviewsPanel', () => ({ ActivePreviewsPanel: () => null }));
-vi.mock('~/components/Apps/OffsiteReviewQueue', () => ({ OffsiteReportsQueue: () => null }));
+// The off-site review modal is now PAGE-OWNED (rendered by the page) — stub it + the
+// reports queue so this test isolates the on-site pending queue's selection path.
+vi.mock('~/components/Apps/OffsiteReviewQueue', () => ({
+  OffsiteReportsQueue: () => null,
+  OffsiteReviewModal: () => null,
+}));
 vi.mock('~/components/Meta/Meta', () => ({ Meta: () => null }));
 
 const PENDING = {
@@ -71,19 +76,38 @@ const PENDING = {
 };
 
 const inert = { invalidate: vi.fn() };
+const emptyQuery = () => ({
+  data: { items: [], nextCursor: null },
+  isLoading: false,
+  isFetching: false,
+  isError: false,
+  error: null,
+});
 vi.mock('~/utils/trpc', () => ({
   trpc: {
-    useUtils: () => ({ blocks: { listPendingRequests: inert, listApprovedRequests: inert, listRejectedRequests: inert } }),
+    useUtils: () => ({
+      blocks: { listPendingRequests: inert, listApprovedRequests: inert, listRejectedRequests: inert },
+      appListings: { listPendingRequests: inert, listApprovedRequests: inert, listRejectedRequests: inert },
+    }),
     blocks: {
       listPendingRequests: {
-        useQuery: () => ({ data: { items: [PENDING] }, isLoading: false, isError: false, error: null }),
+        useQuery: () => ({
+          data: { items: [PENDING], nextCursor: null },
+          isLoading: false,
+          isFetching: false,
+          isError: false,
+          error: null,
+        }),
       },
-      listApprovedRequests: {
-        useQuery: () => ({ data: { items: [] }, isLoading: false, isError: false, error: null }),
-      },
-      listRejectedRequests: {
-        useQuery: () => ({ data: { items: [] }, isLoading: false, isError: false, error: null }),
-      },
+      listApprovedRequests: { useQuery: emptyQuery },
+      listRejectedRequests: { useQuery: emptyQuery },
+    },
+    // The unified pending queue also reads the OFF-SITE pending source; return an
+    // empty page so this test isolates the single on-site row's selection path.
+    appListings: {
+      listPendingRequests: { useQuery: emptyQuery },
+      listApprovedRequests: { useQuery: emptyQuery },
+      listRejectedRequests: { useQuery: emptyQuery },
     },
   },
 }));


### PR DESCRIPTION
## Problem

`/apps/review` stacked TWO separate lists on the **Pending** tab — the on-site
(App Block) FIFO queue and the off-site (external listing) management table — so a
moderator had to scan two surfaces to see everything awaiting review. Off-site
approved/rejected history had no home on the queue at all (only inside the mgmt
table's status sections).

## New tab layout

**Pending | Approved | Rejected | Reports | Manage listings**

- **Pending** — ONE list interleaving on-site pending requests (`blocks.listPendingRequests`)
  + off-site pending requests (`appListings.listPendingRequests`), merge-sorted
  **oldest-first**. Each row shows a **kind badge (App / External)**, the app/listing
  name + slug, submitter, submitted date, and a Review action opening the CORRECT modal.
- **Approved** — unified `blocks.listApprovedRequests` + `appListings.listApprovedRequests`, **newest-first**.
- **Rejected** — unified `blocks.listRejectedRequests` + `appListings.listRejectedRequests`, **newest-first**.
- **Reports** — unchanged.
- **Manage listings** (NEW) — the full all-status lifecycle table
  (reset / relist / claim / purge) moved here unchanged. Left all-status (no default
  re-scope) to avoid changing its filter behaviour. Its lifecycle-action modals stay
  local to it.

## Architecture (presentation + modal-state lifting only)

- **Both review modals are page-lifted.** `OnsiteReviewModal` AND `OffsiteReviewModal`
  are now page-owned. The unified list AND the management table both call the page's
  `openOnsiteReview` / `openOffsiteReview`, so there is exactly **one instance of each
  modal** — no divergence. The management table's local `reviewRow` + `OffsiteReviewModal`
  were removed; its lifecycle-action modals stay local.
- **A shared pure module** (`unifiedReviewRow.ts`, server-graph-free):
  - kind-namespaced adapters `onsiteRequestToUnifiedRow` / `offsiteRequestToUnifiedRow`
    (`onsite:<id>` / `offsite:<id>` keys — cross-kind rows can never collide);
  - a pure `mergeReviewRows(onsite, offsite, direction)` — dedup by key, sort by the
    row timestamp (asc = oldest-first pending, desc = newest-first history), stable
    direction-independent tiebreak. **This is the correctness core — exhaustively unit-tested.**
- **`UnifiedReviewList`** normalizes both sources through the adapters, merges, and
  renders one table with kind badges, loading/error/empty states, a combined count,
  and per-source keyset **Load more** (advances whichever source(s) still have a next
  page, re-merges the accumulated set). Global order across the two independently-
  paginated sources is exact once both first pages are loaded — fine at mod-queue
  volumes; no server-side cross-table cursor.

## Invariants held

- **Correct modal routing:** an on-site row always opens `OnsiteReviewModal`; an
  off-site row always opens `OffsiteReviewModal`. Never cross (unit- + browser-tested).
- **No drop / no dup:** every source row appears exactly once (dedup only on the
  globally-unique key).
- **Zero behaviour change to review/approve/reject/lifecycle LOGIC** — no server proc,
  modal internal, or approve/reject flow touched. List presentation + modal-state
  lifting + the new tab only.
- Effective-pending in the management table preserved; SSR-safe (`keepMounted={false}`).

## Behaviour notes

- History tabs replace the old inline "approved by / notes" columns with the kind-unified
  row; that detail still lives in the modal a row opens.
- Off-site rows route to `OffsiteReviewModal` in every tab. On a decided (approved/rejected)
  history row the modal's approve/reject is a no-op — the server guards `NOT_PENDING` — so
  it cannot re-decide.

## Scope

Dark / mod-only, no migration.

## Gates

pr-preview + an adversarial `/audit-pr` + a **human click-through of the approve/reject
paths on the preview** are the gates: routing to the right modal and a real approve/reject
are NOT verifiable headless.

Tests: 18 blocking unit tests on the pure adapters/merge pass locally; browser render
tests authored per convention (report-only; run in CI). `tsc --noEmit` clean for all
edited files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
