### PR TITLE
feat(app-listings): add "Autofill from website" button to the external-listing edit form

### DIFF
--- a/src/components/Apps/ExternalListingEditForm.tsx
+++ b/src/components/Apps/ExternalListingEditForm.tsx
@@ -16,6 +16,7 @@ import {
   IconExternalLink,
   IconInfoCircle,
   IconLock,
+  IconSparkles,
 } from '@tabler/icons-react';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
@@ -79,6 +80,12 @@ export function ExternalListingEditForm({ edit }: { edit: ListingEditContext }) 
 
   const [active, setActive] = useState<number>(STEP_URL);
   const [values, setValues] = useState<OffsiteSubmitFormValues>(() => editContextToForm(edit));
+  // Latest `values` for the OG-apply effect's emptiness check (the effect must read
+  // current emptiness WITHOUT depending on `values`, and the async `setValues` updater
+  // hasn't run yet when we compute the button's feedback — same reason the create
+  // wizard computes off `data`).
+  const valuesRef = useRef(values);
+  valuesRef.current = values;
   const [errors, setErrors] = useState<OffsiteSubmitFormErrors>({});
   const [serverError, setServerError] = useState<string | null>(null);
   const [assetsDirty, setAssetsDirty] = useState(false);
@@ -102,6 +109,15 @@ export function ExternalListingEditForm({ edit }: { edit: ListingEditContext }) 
   const [metaUrl, setMetaUrl] = useState<string | null>(null);
   const [suggestions, setSuggestions] = useState<MetaSuggestions>({});
   const appliedMetaRef = useRef<string | null>(null);
+  // On-demand "Autofill from website" (edit-only): the OG pull otherwise fires only on
+  // a URL CHANGE, so a listing whose icon/cover ended up empty could never re-surface
+  // suggestions without editing the URL. `autofillActive` tracks a button-triggered
+  // pull (drives the loading/error/note feedback); `autofillTick` forces the apply
+  // effect to re-run on a re-click of the SAME url (unchanged `metaUrl` + a cached
+  // `metaQuery.data` reference otherwise skip it).
+  const [autofillActive, setAutofillActive] = useState(false);
+  const [autofillTick, setAutofillTick] = useState(0);
+  const [autofillNote, setAutofillNote] = useState<'applied' | 'empty' | null>(null);
   const metaQuery = trpc.appListings.fetchListingMetaFromUrl.useQuery(
     { url: metaUrl ?? '' },
     { enabled: !!metaUrl, retry: false, refetchOnWindowFocus: false, staleTime: Infinity }
@@ -122,7 +138,24 @@ export function ExternalListingEditForm({ edit }: { edit: ListingEditContext }) 
           : v.description,
     }));
     setSuggestions({ coverImageUrl: data.coverImageUrl, iconImageUrl: data.iconImageUrl });
-  }, [metaQuery.data, metaUrl]);
+    // When THIS apply was triggered by the button, report whether the pull surfaced
+    // anything actionable: a cover/icon suggestion, or copy for a still-empty field.
+    // Emptiness is read from the ref snapshot — NOT the async `setValues` updater above,
+    // whose side effects haven't committed yet.
+    if (autofillActive) {
+      const v = valuesRef.current;
+      const filledAny =
+        (v.name.trim().length === 0 && !!data.name) ||
+        (v.tagline.trim().length === 0 && !!data.tagline) ||
+        (v.description.trim().length === 0 && !!data.description);
+      const hasSuggestions = !!(data.coverImageUrl || data.iconImageUrl);
+      setAutofillNote(filledAny || hasSuggestions ? 'applied' : 'empty');
+      setAutofillActive(false);
+    }
+    // `autofillTick` is a dep so a same-url re-click (which leaves `metaUrl` + the cached
+    // `metaQuery.data` reference unchanged) still re-runs this effect and re-applies from
+    // cache — the click also resets `appliedMetaRef`, so the guard above passes.
+  }, [metaQuery.data, metaUrl, autofillTick, autofillActive]);
 
   const updateListingMutation = trpc.appListings.updateListing.useMutation();
   const updateRevisionMutation = trpc.appListings.updateRevisionDraft.useMutation();
@@ -183,6 +216,25 @@ export function ExternalListingEditForm({ edit }: { edit: ListingEditContext }) 
     if (e.key !== 'Enter' || e.nativeEvent.isComposing) return;
     e.preventDefault();
     handleAdvanceFromUrl();
+  }
+
+  // "Autofill from website" — on-demand OG re-pull without changing the URL. Reuses the
+  // existing `metaQuery` + fill-if-empty effect + ListingAssetStep suggestions, so it's
+  // non-destructive by construction (typed text and attached assets are never clobbered).
+  function handleAutofillFromWebsite() {
+    const result = normalizeLinkUrl(values.externalUrl);
+    if (result.error) {
+      // A bad/blank URL never fires a fetch (the button is also disabled in this state).
+      setErrors((prev) => ({ ...prev, externalUrl: result.error }));
+      return;
+    }
+    setField('externalUrl', result.url);
+    setErrors((prev) => ({ ...prev, externalUrl: undefined }));
+    setAutofillNote(null);
+    setAutofillActive(true);
+    appliedMetaRef.current = null; // force the idempotent apply effect to re-run
+    setMetaUrl(result.url); // (re)trigger the OG pull — a no-op value if unchanged…
+    setAutofillTick((t) => t + 1); // …so bump a tick to make the effect re-apply from cache
   }
 
   async function finishSave() {
@@ -255,6 +307,10 @@ export function ExternalListingEditForm({ edit }: { edit: ListingEditContext }) 
     }
   }
 
+  // Gate the Autofill button on a valid, normalizable URL (empty/invalid → disabled, no
+  // wasted fetch). Cheap enough to derive per render.
+  const autofillUrl = normalizeLinkUrl(values.externalUrl);
+
   return (
     <Stack gap="md" data-testid="apps-offsite-edit-form">
       <Alert
@@ -323,7 +379,10 @@ export function ExternalListingEditForm({ edit }: { edit: ListingEditContext }) 
                 description="Your app’s public https link — users open it from the listing."
                 placeholder="example.com/app"
                 value={values.externalUrl}
-                onChange={(e) => setField('externalUrl', e.currentTarget.value)}
+                onChange={(e) => {
+                  setField('externalUrl', e.currentTarget.value);
+                  setAutofillNote(null);
+                }}
                 onBlur={handleUrlBlur}
                 onKeyDown={handleUrlKeyDown}
                 error={errors.externalUrl}
@@ -341,6 +400,48 @@ export function ExternalListingEditForm({ edit }: { edit: ListingEditContext }) 
                   <Text size="sm">
                     This listing has no App URL. Adding one lets users open your app (and lets us
                     suggest a name, description and images) — but it’s optional here.
+                  </Text>
+                </Alert>
+              )}
+              {/* On-demand OG re-pull: fills only-empty name/tagline/description and re-surfaces
+                  icon/cover suggestions for empty slots on the Assets step. Non-destructive. */}
+              <Group gap="xs" align="center">
+                <Button
+                  variant="light"
+                  color="grape"
+                  leftSection={<IconSparkles size={16} />}
+                  onClick={handleAutofillFromWebsite}
+                  disabled={!!autofillUrl.error}
+                  loading={autofillActive && metaQuery.isFetching}
+                  data-testid="apps-offsite-edit-autofill"
+                >
+                  Autofill from website
+                </Button>
+                <Text size="xs" c="dimmed">
+                  Re-scan your link for a name, description, icon and cover — only empty fields and
+                  slots are filled.
+                </Text>
+              </Group>
+              {autofillActive && metaQuery.isError && !metaQuery.isFetching && (
+                <Text size="xs" c="red" data-testid="apps-offsite-edit-autofill-error">
+                  Couldn’t read that site’s details.
+                </Text>
+              )}
+              {autofillNote === 'empty' && (
+                <Text size="xs" c="dimmed" data-testid="apps-offsite-edit-autofill-empty">
+                  Nothing to autofill — your details and assets are already set.
+                </Text>
+              )}
+              {autofillNote === 'applied' && (
+                <Alert
+                  color="grape"
+                  variant="light"
+                  icon={<IconSparkles size={16} />}
+                  data-testid="apps-offsite-edit-autofill-applied"
+                >
+                  <Text size="sm">
+                    Pulled the latest details from your link — check the Details and Assets steps to
+                    review the name, description and the suggested icon/cover.
                   </Text>
                 </Alert>
               )}

--- a/src/components/Apps/ExternalListingEditForm.tsx
+++ b/src/components/Apps/ExternalListingEditForm.tsx
@@ -117,15 +117,39 @@ export function ExternalListingEditForm({ edit }: { edit: ListingEditContext }) 
   // `metaQuery.data` reference otherwise skip it).
   const [autofillActive, setAutofillActive] = useState(false);
   const [autofillTick, setAutofillTick] = useState(0);
-  const [autofillNote, setAutofillNote] = useState<'applied' | 'empty' | null>(null);
+  const [autofillNote, setAutofillNote] = useState<'applied' | 'empty' | 'error' | null>(null);
   const metaQuery = trpc.appListings.fetchListingMetaFromUrl.useQuery(
     { url: metaUrl ?? '' },
     { enabled: !!metaUrl, retry: false, refetchOnWindowFocus: false, staleTime: Infinity }
   );
   useEffect(() => {
-    if (!metaQuery.data || appliedMetaRef.current === metaUrl) return;
-    appliedMetaRef.current = metaUrl;
+    // Apply at most once per settled url. The `appliedMetaRef` short-circuit also covers
+    // the initial `metaUrl === null` state (null === null).
+    if (!metaUrl || appliedMetaRef.current === metaUrl) return;
+    // Settle on SUCCESS or ERROR for the CURRENT metaUrl (mirrors the create form). With a
+    // per-url cache key + retry:false, `metaQuery.data`/`isError` belong to `metaUrl`; wait
+    // out an in-flight (re)fetch so a stale cached error can't be applied before a button
+    // `refetch()` resolves — that guard is also what keeps the same-url refetch from looping.
+    if (metaQuery.isFetching) return;
     const data = metaQuery.data;
+    const settled = !!data || metaQuery.isError;
+    if (!settled) return;
+    appliedMetaRef.current = metaUrl;
+
+    if (!data) {
+      // ERROR-settled: don't surface stale suggestions, and don't co-render an
+      // "applied"/"empty" note. The inline "Couldn't read that site's details." message
+      // renders from the `'error'` note (tied to THIS url) below. Resetting the active
+      // flag stops a later non-button URL advance from rendering a spurious note, and the
+      // same url stays retryable via `metaQuery.refetch()` in the button handler.
+      setSuggestions({});
+      if (autofillActive) {
+        setAutofillNote('error');
+        setAutofillActive(false);
+      }
+      return;
+    }
+
     setValues((v) => ({
       ...v,
       name: v.name.trim().length === 0 && data.name ? data.name : v.name,
@@ -138,24 +162,38 @@ export function ExternalListingEditForm({ edit }: { edit: ListingEditContext }) 
           : v.description,
     }));
     setSuggestions({ coverImageUrl: data.coverImageUrl, iconImageUrl: data.iconImageUrl });
-    // When THIS apply was triggered by the button, report whether the pull surfaced
-    // anything actionable: a cover/icon suggestion, or copy for a still-empty field.
-    // Emptiness is read from the ref snapshot — NOT the async `setValues` updater above,
-    // whose side effects haven't committed yet.
+    // When THIS apply was button-triggered, report whether the pull surfaced anything
+    // ACTIONABLE: copy for a still-empty text field, or an icon/cover suggestion for a
+    // slot that is currently EMPTY (imageId == null in the edit prefill — the only case
+    // where ListingAssetStep renders a "Use this"). A suggestion URL for an already-filled
+    // slot is NOT actionable, so it must not claim "applied". Emptiness is read from the
+    // ref snapshot — NOT the async `setValues` updater above, whose side effects haven't
+    // committed yet. (Slot-filled state is the edit prefill; if the author added/removed an
+    // asset THIS session ListingAssetStep owns that state, so the note is best-effort.)
     if (autofillActive) {
       const v = valuesRef.current;
       const filledAny =
         (v.name.trim().length === 0 && !!data.name) ||
         (v.tagline.trim().length === 0 && !!data.tagline) ||
         (v.description.trim().length === 0 && !!data.description);
-      const hasSuggestions = !!(data.coverImageUrl || data.iconImageUrl);
-      setAutofillNote(filledAny || hasSuggestions ? 'applied' : 'empty');
+      const hasActionableSuggestion =
+        (!!data.iconImageUrl && edit.assets.icon.imageId == null) ||
+        (!!data.coverImageUrl && edit.assets.cover.imageId == null);
+      setAutofillNote(filledAny || hasActionableSuggestion ? 'applied' : 'empty');
       setAutofillActive(false);
     }
     // `autofillTick` is a dep so a same-url re-click (which leaves `metaUrl` + the cached
     // `metaQuery.data` reference unchanged) still re-runs this effect and re-applies from
     // cache — the click also resets `appliedMetaRef`, so the guard above passes.
-  }, [metaQuery.data, metaUrl, autofillTick, autofillActive]);
+  }, [
+    metaQuery.data,
+    metaQuery.isError,
+    metaQuery.isFetching,
+    metaUrl,
+    autofillTick,
+    autofillActive,
+    edit,
+  ]);
 
   const updateListingMutation = trpc.appListings.updateListing.useMutation();
   const updateRevisionMutation = trpc.appListings.updateRevisionDraft.useMutation();
@@ -233,8 +271,18 @@ export function ExternalListingEditForm({ edit }: { edit: ListingEditContext }) 
     setAutofillNote(null);
     setAutofillActive(true);
     appliedMetaRef.current = null; // force the idempotent apply effect to re-run
-    setMetaUrl(result.url); // (re)trigger the OG pull — a no-op value if unchanged…
-    setAutofillTick((t) => t + 1); // …so bump a tick to make the effect re-apply from cache
+    if (result.url === metaUrl) {
+      // SAME url: `setMetaUrl` is a no-op and (staleTime:Infinity + retry:false) the cached
+      // success/error won't re-fetch on its own — so a previously-ERRORED url could never be
+      // retried via the button. `refetch()` re-attempts the fetch; on a cached success it
+      // re-applies from data and the tick below re-runs the effect. No loop: `refetch()`
+      // synchronously flips `isFetching` true, so the tick-driven effect run bails on the
+      // isFetching guard and only applies once the (re)fetch settles.
+      void metaQuery.refetch();
+    } else {
+      setMetaUrl(result.url); // NEW url → the query fires for it
+    }
+    setAutofillTick((t) => t + 1); // bump a tick so the effect re-applies even when metaUrl is unchanged
   }
 
   async function finishSave() {
@@ -422,7 +470,7 @@ export function ExternalListingEditForm({ edit }: { edit: ListingEditContext }) 
                   slots are filled.
                 </Text>
               </Group>
-              {autofillActive && metaQuery.isError && !metaQuery.isFetching && (
+              {autofillNote === 'error' && (
                 <Text size="xs" c="red" data-testid="apps-offsite-edit-autofill-error">
                   Couldn’t read that site’s details.
                 </Text>

--- a/src/components/Apps/ExternalSubmitForm.edit.browser.test.tsx
+++ b/src/components/Apps/ExternalSubmitForm.edit.browser.test.tsx
@@ -21,7 +21,15 @@ import type { ListingEditContext } from './offsiteEditConfig';
  */
 
 const mocks = vi.hoisted(() => ({
-  meta: { data: undefined as unknown, isFetching: false, isSuccess: false },
+  meta: { data: undefined, isFetching: false, isError: false, isSuccess: false } as {
+    data?: unknown;
+    isFetching?: boolean;
+    isError?: boolean;
+    isSuccess?: boolean;
+  },
+  // The query's `refetch` — a same-url Autofill re-click calls it (staleTime:Infinity +
+  // retry:false makes `setMetaUrl(sameUrl)` a no-op), so we assert it fired on re-click.
+  refetch: vi.fn(),
   updateListing: vi.fn(),
   updateRevision: vi.fn(),
   submitRevision: vi.fn(),
@@ -49,7 +57,7 @@ vi.mock('~/utils/trpc', () => {
         },
       }),
       appListings: {
-        fetchListingMetaFromUrl: { useQuery: () => mocks.meta },
+        fetchListingMetaFromUrl: { useQuery: () => ({ ...mocks.meta, refetch: mocks.refetch }) },
         updateListing: { useMutation: recording(mocks.updateListing) },
         updateRevisionDraft: { useMutation: recording(mocks.updateRevision) },
         submitListingRevision: { useMutation: recording(mocks.submitRevision) },
@@ -121,7 +129,8 @@ function makeApprovedCtx(overrides: Partial<ListingEditContext> = {}): ListingEd
 }
 
 beforeEach(() => {
-  mocks.meta = { data: undefined, isFetching: false, isSuccess: false };
+  mocks.meta = { data: undefined, isFetching: false, isError: false, isSuccess: false };
+  mocks.refetch.mockClear();
   mocks.updateListing.mockClear();
   mocks.updateRevision.mockClear();
   mocks.submitRevision.mockClear();
@@ -394,5 +403,80 @@ describe('ExternalSubmitForm — edit mode "Autofill from website" button', () =
     // The prefilled name is untouched.
     await page.getByRole('button', { name: 'Next' }).click();
     await expect.element(page.getByRole('textbox', { name: /^Name/ })).toHaveValue('Vitrine');
+  });
+
+  test('does NOT claim "applied" when a suggestion targets an already-FILLED slot', async () => {
+    // A fully-populated listing (icon+cover attached in the prefill) + a meta pull that
+    // carries icon/cover URLs but nothing fillable. ListingAssetStep renders NO "Use this"
+    // for a filled slot, so the note must be the honest "Nothing to autofill", not "applied".
+    mocks.meta = {
+      data: {
+        name: undefined,
+        tagline: undefined,
+        description: undefined,
+        coverImageUrl: 'https://cdn/og-cover.png',
+        iconImageUrl: 'https://cdn/og-icon.png',
+      },
+      isFetching: false,
+      isSuccess: true,
+    };
+    renderWithProviders(<ExternalSubmitForm edit={makeCtx()} />);
+    await page.getByTestId('apps-offsite-edit-autofill').click();
+    await expect.element(page.getByTestId('apps-offsite-edit-autofill-empty')).toBeInTheDocument();
+    expect(page.getByTestId('apps-offsite-edit-autofill-applied').elements()).toHaveLength(0);
+  });
+
+  test('re-clicking with the SAME url re-surfaces the icon/cover suggestions (tick + refetch, from cache)', async () => {
+    // The PR's headline mechanism: the OG pull fires only on a URL CHANGE, so re-pulling
+    // the SAME url must go through the button's `autofillTick` + `appliedMetaRef` reset (and,
+    // once `metaUrl` is already set, a `metaQuery.refetch()`). Assets start EMPTY.
+    mocks.meta = {
+      data: {
+        name: undefined,
+        tagline: undefined,
+        description: undefined,
+        coverImageUrl: 'https://cdn/og-cover.png',
+        iconImageUrl: 'https://cdn/og-icon.png',
+      },
+      isFetching: false,
+      isSuccess: true,
+    };
+    renderWithProviders(<ExternalSubmitForm edit={makeEmptyAssetsCtx()} />);
+
+    // FIRST click: `metaUrl` was null, so this SETS it (not a refetch) and applies.
+    await page.getByTestId('apps-offsite-edit-autofill').click();
+    await expect.element(page.getByTestId('apps-offsite-edit-autofill-applied')).toBeInTheDocument();
+    expect(mocks.refetch).not.toHaveBeenCalled();
+
+    // SECOND click, url UNCHANGED: `setMetaUrl(sameUrl)` is a no-op, so the retry MUST go
+    // through `refetch()` + the tick-driven re-apply — proving the same-url path works.
+    await page.getByTestId('apps-offsite-edit-autofill').click();
+    await vi.waitFor(() => expect(mocks.refetch).toHaveBeenCalledTimes(1));
+    await expect.element(page.getByTestId('apps-offsite-edit-autofill-applied')).toBeInTheDocument();
+
+    // The re-applied suggestions still surface "Use this" on the empty icon + cover slots.
+    await page.getByRole('button', { name: 'Next' }).click();
+    await page.getByRole('button', { name: 'Next' }).click();
+    await expect.element(page.getByTestId('apps-offsite-accept-icon')).toBeInTheDocument();
+    await expect.element(page.getByTestId('apps-offsite-accept-cover')).toBeInTheDocument();
+  });
+
+  test('an ERRORED OG fetch shows the error note, sets NO applied/empty note, and a re-click refetches', async () => {
+    // The 🟡 fix: on a failed fetch the effect must SETTLE (via isError), reset the active
+    // flag, and surface the error via the settled note (tied to this url) — never a spurious
+    // "applied"/"empty". And because staleTime:Infinity + retry:false pins the cached error,
+    // a re-click must `refetch()` so a transient failure is retryable without editing the URL.
+    mocks.meta = { data: undefined, isFetching: false, isError: true };
+    renderWithProviders(<ExternalSubmitForm edit={makeEmptyAssetsCtx()} />);
+
+    await page.getByTestId('apps-offsite-edit-autofill').click();
+    await expect.element(page.getByTestId('apps-offsite-edit-autofill-error')).toBeInTheDocument();
+    // No spurious success/empty note co-renders with the error.
+    expect(page.getByTestId('apps-offsite-edit-autofill-applied').elements()).toHaveLength(0);
+    expect(page.getByTestId('apps-offsite-edit-autofill-empty').elements()).toHaveLength(0);
+
+    // Re-click the SAME (errored) url → a refetch fires so the user can retry.
+    await page.getByTestId('apps-offsite-edit-autofill').click();
+    await vi.waitFor(() => expect(mocks.refetch).toHaveBeenCalledTimes(1));
   });
 });

--- a/src/components/Apps/ExternalSubmitForm.edit.browser.test.tsx
+++ b/src/components/Apps/ExternalSubmitForm.edit.browser.test.tsx
@@ -306,3 +306,93 @@ describe('ExternalSubmitForm — edit mode', () => {
     await expect.element(page.getByRole('textbox', { name: /^Name/ })).toHaveValue('Vitrine');
   });
 });
+
+/**
+ * "Autofill from website" button (edit-only). Closes the gap where the edit-mode OG
+ * pull fired ONLY on a URL change, so a listing whose icon/cover ended up empty could
+ * never re-surface suggestions without editing the URL. Clicking the button re-runs
+ * the existing fetch → fill-if-empty effect → ListingAssetStep suggestions, WITHOUT
+ * changing the URL. Non-destructive by construction (typed text + attached assets are
+ * never clobbered — proven by the "empty" note when nothing is fillable).
+ */
+function makeEmptyAssetsCtx(overrides: Partial<ListingEditContext> = {}): ListingEditContext {
+  return makeCtx({
+    assets: {
+      icon: { imageId: null, url: null },
+      cover: { imageId: null, url: null },
+      screenshots: [],
+    },
+    ...overrides,
+  });
+}
+
+describe('ExternalSubmitForm — edit mode "Autofill from website" button', () => {
+  test('clicking it (URL unchanged) pulls meta and surfaces "Use this" icon/cover suggestions for EMPTY slots', async () => {
+    mocks.meta = {
+      data: {
+        name: undefined,
+        tagline: undefined,
+        description: undefined,
+        coverImageUrl: 'https://cdn/og-cover.png',
+        iconImageUrl: 'https://cdn/og-icon.png',
+      },
+      isFetching: false,
+      isSuccess: true,
+    };
+    // Assets start EMPTY (the gap this fixes) — the URL is already prefilled, unchanged.
+    renderWithProviders(<ExternalSubmitForm edit={makeEmptyAssetsCtx()} />);
+    await page.getByTestId('apps-offsite-edit-autofill').click();
+    // The URL step shows the "applied" note; then navigate URL → Details → Assets.
+    await expect.element(page.getByTestId('apps-offsite-edit-autofill-applied')).toBeInTheDocument();
+    await page.getByRole('button', { name: 'Next' }).click();
+    await page.getByRole('button', { name: 'Next' }).click();
+    // The empty icon + cover slots now offer the OG suggestion via "Use this".
+    await expect.element(page.getByTestId('apps-offsite-accept-icon')).toBeInTheDocument();
+    await expect.element(page.getByTestId('apps-offsite-accept-cover')).toBeInTheDocument();
+    await expect
+      .element(page.getByTestId('apps-offsite-suggested-icon-preview'))
+      .toBeInTheDocument();
+  });
+
+  test('is DISABLED when the App URL is blank (no wasted fetch)', async () => {
+    const ctx = makeCtx({
+      scalars: {
+        name: 'Vitrine',
+        tagline: null,
+        description: null,
+        category: null,
+        contentRating: 'g',
+        externalUrl: '', // pre-existing blank URL
+      },
+    });
+    renderWithProviders(<ExternalSubmitForm edit={ctx} />);
+    await expect.element(page.getByTestId('apps-offsite-edit-autofill')).toBeDisabled();
+  });
+
+  test('is DISABLED when the App URL is invalid (non-https)', async () => {
+    const ctx = makeCtx({
+      scalars: {
+        name: 'Vitrine',
+        tagline: null,
+        description: null,
+        category: null,
+        contentRating: 'g',
+        externalUrl: 'http://insecure.example.com',
+      },
+    });
+    renderWithProviders(<ExternalSubmitForm edit={ctx} />);
+    await expect.element(page.getByTestId('apps-offsite-edit-autofill')).toBeDisabled();
+  });
+
+  test('shows a "Nothing to autofill" note when the pull yields nothing fillable', async () => {
+    // Fully-populated listing (name/tagline/description + attached icon/cover) and a
+    // meta pull with no suggestions and nothing to fill → the empty note, NOT a clobber.
+    mocks.meta = { data: {}, isFetching: false, isSuccess: true };
+    renderWithProviders(<ExternalSubmitForm edit={makeCtx()} />);
+    await page.getByTestId('apps-offsite-edit-autofill').click();
+    await expect.element(page.getByTestId('apps-offsite-edit-autofill-empty')).toBeInTheDocument();
+    // The prefilled name is untouched.
+    await page.getByRole('button', { name: 'Next' }).click();
+    await expect.element(page.getByRole('textbox', { name: /^Name/ })).toHaveValue('Vitrine');
+  });
+});


### PR DESCRIPTION
## The gap

On the external-listing **edit** form (`/apps/submit?edit=<listingId>`), the OG metadata pull only fired on a URL **change**. If a mod/dev opened an existing listing without editing the URL, autofill never ran — so a listing whose icon/cover slots ended up empty could never get suggestions re-surfaced, blocking re-population of empty assets.

## The fix

Add an on-demand **"Autofill from website"** button on the edit form's URL step. On click it re-triggers the **existing** `fetchListingMetaFromUrl` query → the existing fill-if-empty effect → the existing `ListingAssetStep` "Use this" icon/cover suggestions — **without changing the URL**. It reuses the same `normalizeLinkUrl` helper the create wizard uses.

- **Non-destructive / only-empty** — by construction: the effect fills only blank name/tagline/description, and asset suggestions render only for idle/empty slots, so typed copy and already-attached assets are never clobbered. No new "clobber" path is introduced.
- **Feedback** — the button is disabled for a blank/invalid URL (no wasted fetch), shows a loading state while fetching, and reports "Nothing to autofill" when the pull yields nothing new.
- **Same-URL re-apply** — a re-click resets the applied ref and bumps a tick the apply effect depends on, so a cached result reliably re-surfaces even when the normalized URL is unchanged.

## Scope

- **Additive** and **dark** — the whole flow is `app-blocks-author` / mod-gated.
- **No server change**, **no create-form change**, **no `ListingAssetStep` change** — edit-form-only.

## Tests

Added browser-mode surface tests (report-only in CI — no local headless Chromium here) to the existing `ExternalSubmitForm.edit.browser.test.tsx`: clicking the button with a URL present pulls meta and surfaces the "Use this" icon/cover affordances for empty slots; the button is disabled for a blank and for a non-https URL; and a pull with nothing fillable shows the "Nothing to autofill" note without clobbering a prefilled name. `tsc --noEmit` clean for the edited files.

## Gates

pr-preview and an adversarial `/audit-pr` are the gates. The mod-gated edit-form interaction still needs a human click-through on the preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
