### PR TITLE
fix(event-engine): bound + retry signals fetch to fix undici ECONNRESET

### DIFF
--- a/apps/event-engine/src/common/services/signals.test.ts
+++ b/apps/event-engine/src/common/services/signals.test.ts
@@ -1,0 +1,92 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { SignalsService } from './signals';
+
+/**
+ * These tests use Node's built-in test runner (`node:test`) so they need no
+ * extra dev dependency / jest-transform wiring. Run with the repo's `tsx`:
+ *   pnpm --filter @civitai/event-engine exec tsx --test src/common/services/signals.test.ts
+ */
+
+const originalFetch = globalThis.fetch;
+
+function okResponse(): Response {
+  return new Response('{}', { status: 200, headers: { 'Content-Type': 'application/json' } });
+}
+
+function econnreset(): Error {
+  // Mirrors how undici surfaces a keep-alive stale-socket reset: the thrown
+  // error carries `cause.code === 'ECONNRESET'`.
+  const err = new Error('read ECONNRESET');
+  (err as Error & { cause?: unknown }).cause = { code: 'ECONNRESET' };
+  return err;
+}
+
+function withMockFetch(impl: typeof fetch, run: () => Promise<void>): Promise<void> {
+  globalThis.fetch = impl;
+  return run().finally(() => {
+    globalThis.fetch = originalFetch;
+  });
+}
+
+test('retries once on ECONNRESET and succeeds on the second attempt (never throws)', async () => {
+  let calls = 0;
+  await withMockFetch(
+    (async () => {
+      calls++;
+      if (calls === 1) throw econnreset();
+      return okResponse();
+    }) as typeof fetch,
+    async () => {
+      const svc = new SignalsService('http://signals.local', true);
+      // Must resolve without throwing.
+      await assert.doesNotReject(svc.sendSignal('topic-1', 'metric:update', { a: 1 }));
+    }
+  );
+  assert.equal(calls, 2, 'fetch should be attempted twice (initial + one retry)');
+});
+
+test('does NOT retry a non-transient error and rethrows it', async () => {
+  let calls = 0;
+  await withMockFetch(
+    (async () => {
+      calls++;
+      throw new Error('boom'); // no cause.code -> not transient
+    }) as typeof fetch,
+    async () => {
+      const svc = new SignalsService('http://signals.local', true);
+      await assert.rejects(svc.sendSignal('topic-2', 'metric:update', { a: 1 }), /boom/);
+    }
+  );
+  assert.equal(calls, 1, 'non-transient error should not be retried');
+});
+
+test('retries at most once, then rethrows on a second consecutive ECONNRESET', async () => {
+  let calls = 0;
+  await withMockFetch(
+    (async () => {
+      calls++;
+      throw econnreset();
+    }) as typeof fetch,
+    async () => {
+      const svc = new SignalsService('http://signals.local', true);
+      await assert.rejects(svc.sendSignal('topic-3', 'metric:update', { a: 1 }), /ECONNRESET/);
+    }
+  );
+  assert.equal(calls, 2, 'should attempt exactly twice, then give up');
+});
+
+test('is a no-op (never throws) when disabled / no URL configured', async () => {
+  let calls = 0;
+  await withMockFetch(
+    (async () => {
+      calls++;
+      return okResponse();
+    }) as typeof fetch,
+    async () => {
+      const svc = new SignalsService('', true); // disabled: no URL
+      await assert.doesNotReject(svc.sendSignal('topic-4', 'metric:update', { a: 1 }));
+    }
+  );
+  assert.equal(calls, 0, 'disabled service should not call fetch');
+});

--- a/apps/event-engine/src/common/services/signals.ts
+++ b/apps/event-engine/src/common/services/signals.ts
@@ -1,3 +1,17 @@
+// Bound every send so a hung/slow signals endpoint can never stall the
+// (best-effort) caller — this also caps the awaited hot-path `sendDelta`.
+const REQUEST_TIMEOUT_MS = 2000;
+
+// Connection-level failure codes we retry once (on a fresh connection). The
+// dominant one here is the undici keep-alive race: a pooled idle socket the
+// server has already closed gets reused, surfacing as `read ECONNRESET`.
+const TRANSIENT_CONNECTION_CODES = new Set(['ECONNRESET', 'ECONNREFUSED', 'UND_ERR_SOCKET']);
+
+function isTransientConnectionError(error: unknown): boolean {
+  const code = (error as { cause?: { code?: unknown } } | null | undefined)?.cause?.code;
+  return typeof code === 'string' && TRANSIENT_CONNECTION_CODES.has(code);
+}
+
 export class SignalsService {
   private signalsApiUrl: string;
   private enabled: boolean;
@@ -12,7 +26,14 @@ export class SignalsService {
   }
 
   /**
-   * Send a signal to a specific topic
+   * Send a signal to a specific topic.
+   *
+   * Best-effort telemetry: bounded by a short timeout and retried once on a
+   * transient connection-level error (see the undici keep-alive race above).
+   * On final failure it logs and rethrows so the caller
+   * (`MetricSignals.sendDelta`) records the failure metric and swallows it —
+   * the fire-and-forget contract is unchanged.
+   *
    * @param topic The topic to send the signal to
    * @param signalName The name of the signal event
    * @param payload The payload to send
@@ -25,24 +46,40 @@ export class SignalsService {
     if (!this.enabled) return;
 
     const url = `${this.signalsApiUrl}/topics/${topic}/signals/${signalName}`;
+    const body = JSON.stringify(payload);
 
-    try {
-      const response = await fetch(url, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'Accept': 'application/json'
-        },
-        body: JSON.stringify(payload)
-      });
+    // One retry on a transient connection reset: a fresh connection avoids the
+    // stale pooled socket that caused the reset.
+    let lastError: unknown;
+    for (let attempt = 0; attempt < 2; attempt++) {
+      try {
+        const response = await fetch(url, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'Accept': 'application/json'
+          },
+          body,
+          signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS)
+        });
 
-      if (!response.ok) {
-        throw new Error(`Signal API returned ${response.status}: ${response.statusText}`);
+        if (!response.ok) {
+          throw new Error(`Signal API returned ${response.status}: ${response.statusText}`);
+        }
+        return;
+      } catch (error) {
+        lastError = error;
+        if (attempt === 0 && isTransientConnectionError(error)) {
+          continue; // retry once on a fresh connection
+        }
+        break;
       }
-    } catch (error) {
-      console.error(`[SignalsService] Failed to send signal to topic ${topic}:`, error);
-      throw error;
     }
+
+    // Best-effort telemetry — warn (not error) to reduce log noise, then
+    // rethrow so the caller's failure metric + swallow still apply.
+    console.warn(`[SignalsService] Failed to send signal to topic ${topic}:`, lastError);
+    throw lastError;
   }
 
   isEnabled(): boolean {


### PR DESCRIPTION
## Root cause

`apps/event-engine`'s `SignalsService.sendSignal()` POSTs metric signals with a **bare global `fetch()`** (Node 22 undici) — no timeout, no retry. About **0.13% of sends fail with `read ECONNRESET`**: the classic undici keep-alive race where a pooled idle socket the server has already closed gets reused for the next request.

These signal sends are **best-effort, fire-and-forget telemetry** — failures are already logged and swallowed by the caller (`MetricSignals.sendDelta`) and never break event processing. So this is low severity, but it (a) floods the error log, and (b) leaves a secondary risk: one call site awaits `sendDelta` on the hot path with no bound, so a truly-hanging send could prolong graceful shutdown.

## Fix (confined to the `sendSignal` path)

- **Bound every request** with `AbortSignal.timeout(2000)` — prevents a hang and caps the awaited hot-path send.
- **Retry once on a transient connection-level error** (`ECONNRESET` / `ECONNREFUSED` / `UND_ERR_SOCKET`). The retry runs on a **fresh connection**, sidestepping the stale pooled socket that caused the reset. Non-connection failures (e.g. a non-2xx response) are **not** retried.
- **Downgrade the final-failure log** from `error` to `warn` to cut noise; still **rethrow** so the caller's failure metric + swallow are unchanged (the fire-and-forget contract and call sites are untouched).

### Why no custom undici `Agent` / `Connection: close`
The retry-on-reset already resolves the stale-socket race directly, and at the client's low volume (~22 req/s) keep-alive is beneficial — forcing `Connection: close` or a low `keepAliveTimeout` would trade the race for more reconnects with no clear win. Timeout + retry is the minimal, sufficient fix.

## Tests

Adds a **dependency-free** unit test (`node:test`, run via the app's existing `tsx` — the app has no wired jest TS-transform, so this avoids a disproportionate lockfile-touching harness):

- retries once on an `ECONNRESET`-cause error and **succeeds on the 2nd attempt** (never throws)
- does **not** retry a non-transient error, and rethrows it
- retries **at most once**, then rethrows on a 2nd consecutive `ECONNRESET`
- is a no-op (never throws, never calls `fetch`) when disabled / no URL

Run: `pnpm --filter @civitai/event-engine exec tsx --test src/common/services/signals.test.ts` — 4/4 pass. `pnpm --filter @civitai/event-engine typecheck` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)