### PR TITLE
fix(image-scan): age out never-returning Pending scans to Error (timeout safety net)

### DIFF
--- a/src/env/server-schema.ts
+++ b/src/env/server-schema.ts
@@ -370,6 +370,21 @@ export const serverSchema = z
     TEXT_MODERATION_CALLBACK: z.string().optional(),
     IMAGE_SCANNING_MODEL: z.string().optional(),
     IMAGE_SCANNING_RETRY_DELAY: z.coerce.number().default(5),
+    // Age-out threshold (minutes) for never-returning image scans. A scan verdict
+    // arrives via the fire-and-forget /image-scan-result webhook; a fraction never
+    // call back (dropped callback, or a stuck/unassigned workflow), and neither
+    // civitai nor the orchestrator times that out — so those images stay
+    // ingestion='Pending' forever and the retry cron re-drives them with no
+    // ceiling. The `ingest-images` cron flips a NON-backfill image whose
+    // `createdAt` (immutable first-upload time ~= first scan request; NOT
+    // `scanRequestedAt`, which every re-send resets) is older than this to Error,
+    // routing it into the existing capped Error-retry path. Conservative default:
+    // must exceed the wall-time of any legitimately in-flight scan so a healthy
+    // scan is never terminalized — well beyond a normal scan (seconds–minutes),
+    // while the never-returning cases are hours-to-days old. Positive to avoid a
+    // zero/negative threshold aging out every fresh Pending image. Tune via env
+    // without a redeploy; takes effect on the next pod restart (read at boot).
+    IMAGE_SCANNING_PENDING_TIMEOUT: z.coerce.number().int().positive().default(60),
     // Upper bound on how many queued images the `ingest-images` retry/backfill cron
     // pulls (and therefore can submit) per run. Sized to the scanner's sustainable
     // throughput so a large backlog drains gradually across runs instead of in one

--- a/src/server/jobs/__tests__/ingest-images-pending-ageout.test.ts
+++ b/src/server/jobs/__tests__/ingest-images-pending-ageout.test.ts
@@ -1,0 +1,218 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// A scan verdict returns via the fire-and-forget /image-scan-result webhook, which
+// flips ingestion Pending -> Scanned/Blocked/Error. A fraction of scans never call
+// back (dropped callback, or a stuck/unassigned workflow) and neither civitai nor
+// the orchestrator times that out, so those images stay ingestion='Pending' forever
+// and the retry cron re-drives them with no ceiling. The `ingest-images` cron now
+// ages out a too-long-Pending NON-backfill image to Error, routing it into the
+// existing capped Error-retry path so it can't be Pending forever.
+//
+// The age-out clock MUST be `createdAt`, not `scanRequestedAt`: `ingestImage` resets
+// `scanRequestedAt = now` on every re-send, so an age test keyed on it never fires.
+// These tests drive the real job with a controlled row set and assert:
+//   1. an old (past-threshold) non-backfill Pending image is flipped to Error;
+//   2. a fresh (under-threshold) Pending image is NOT flipped, and is still sent;
+//   3. an old BACKFILL Pending image is NOT prematurely terminalized;
+//   4. an aged-out image is NOT re-sent as Pending and stays in the JobQueue so it
+//      enters the capped Error-retry, while an at-cap Error image is pruned
+//      (terminal) — i.e. the loop is bounded, not infinite.
+
+const HOUR = 60 * 60 * 1000;
+// IMAGE_SCANNING_PENDING_TIMEOUT (minutes) under test. Inlined in the vi.mock env
+// factory below (mock factories are hoisted above module consts, so they can't
+// close over this) — OLD/FRESH are chosen relative to it: OLD (2h) is past it,
+// FRESH (now) is under it.
+const PENDING_TIMEOUT_MIN = 30;
+
+// Fixture rows returned by the image SELECT. Fields mirror IngestImageRow.
+const OLD = new Date(Date.now() - 2 * HOUR); // past the 30-min age-out threshold
+const FRESH = new Date(); // well under the threshold
+const OLD_SCAN = new Date(Date.now() - 2 * HOUR); // past the 60-min Error retry delay
+
+const ROWS = [
+  // 1: old, non-backfill, Pending  -> AGED OUT to Error (not sent, kept in queue)
+  mkRow({ id: 1, ingestion: 'Pending', createdAt: OLD, isBackfill: false, scanRequestedAt: null }),
+  // 2: fresh, non-backfill, Pending -> NOT aged out; sent this run
+  mkRow({ id: 2, ingestion: 'Pending', createdAt: FRESH, isBackfill: false, scanRequestedAt: null }),
+  // 3: old, BACKFILL, Pending       -> NOT aged out (backfill excluded); sent low-pri
+  mkRow({ id: 3, ingestion: 'Pending', createdAt: OLD, isBackfill: true, scanRequestedAt: null }),
+  // 4: Error, under the cap, cooled  -> re-tried via the Error lane (proves the
+  //    aged-out target lands in a working, capped retry path)
+  mkRow({
+    id: 4,
+    ingestion: 'Error',
+    createdAt: OLD,
+    isBackfill: false,
+    scanRequestedAt: OLD_SCAN,
+    retryCount: 0,
+  }),
+  // 5: Error, at the historical 9-cap -> NOT retried; becomes stale + pruned
+  //    (terminal) — the retry loop is bounded.
+  mkRow({
+    id: 5,
+    ingestion: 'Error',
+    createdAt: OLD,
+    isBackfill: false,
+    scanRequestedAt: OLD_SCAN,
+    retryCount: 9,
+  }),
+];
+
+function mkRow(overrides: {
+  id: number;
+  ingestion: string;
+  createdAt: Date;
+  isBackfill: boolean;
+  scanRequestedAt: Date | null;
+  retryCount?: number;
+  failureClass?: string | null;
+}) {
+  return {
+    url: `img-${overrides.id}`,
+    type: 'image',
+    width: 100,
+    height: 100,
+    prompt: null,
+    retryCount: 0,
+    failureClass: null,
+    ...overrides,
+  };
+}
+
+const { execLog, mockDbRead, mockDbWrite, mockIngestImage, mockDeleteImages, mockLimitConcurrency } =
+  vi.hoisted(() => {
+    const execLog: { sql: string; values: unknown[] }[] = [];
+    return {
+      execLog,
+      mockDbRead: {
+        jobQueue: {
+          // Return one queue row per fixture id, oldest-first.
+          findMany: vi.fn(async () => [1, 2, 3, 4, 5].map((entityId) => ({ entityId }))),
+        },
+      },
+      mockDbWrite: {
+        // Image SELECT -> the fixture rows.
+        $queryRaw: vi.fn(async () => ROWS),
+        // Record every write so the test can distinguish the age-out UPDATE
+        // (contains 'Pending'), the exhaustedRescan UPDATE ('Rescan'), and the
+        // JobQueue prune DELETE, plus inspect the id array each targets.
+        $executeRaw: vi.fn(async (strings: TemplateStringsArray, ...values: unknown[]) => {
+          execLog.push({ sql: strings.join('?'), values });
+          return 0;
+        }),
+      },
+      mockIngestImage: vi.fn(async () => true),
+      mockDeleteImages: vi.fn(async () => undefined),
+      // Sequential for deterministic assertions.
+      mockLimitConcurrency: vi.fn(async (tasks: Array<() => Promise<unknown>>) => {
+        for (const t of tasks) await t();
+      }),
+    };
+  });
+
+vi.mock('~/server/db/client', () => ({ dbRead: mockDbRead, dbWrite: mockDbWrite }));
+vi.mock('~/server/services/image.service', () => ({
+  ingestImage: mockIngestImage,
+  deleteImages: mockDeleteImages,
+}));
+vi.mock('~/server/utils/concurrency-helpers', () => ({ limitConcurrency: mockLimitConcurrency }));
+vi.mock('~/env/other', () => ({ isProd: true }));
+vi.mock('~/env/server', () => ({
+  env: {
+    IMAGE_SCANNING_MAX_PER_RUN: 100,
+    IMAGE_SCANNING_RETRY_DELAY: 5,
+    IMAGE_SCANNING_PENDING_TIMEOUT: 30, // must equal PENDING_TIMEOUT_MIN above
+    DATABASE_IS_PROD: true,
+  },
+}));
+
+import { ingestImages } from '~/server/jobs/image-ingestion';
+
+const ctx = {} as Parameters<typeof ingestImages.run>[0];
+async function runJob<T extends { run: (ctx: any) => { result: Promise<unknown> } }>(
+  job: T
+): Promise<unknown> {
+  return await job.run(ctx).result;
+}
+
+// Ids passed to ingestImage this run (the images actually (re-)sent for scanning).
+function sentIds() {
+  return mockIngestImage.mock.calls.map((c) => (c[0] as { image: { id: number } }).image.id);
+}
+// The id array targeted by a raw write is the sole array among its interpolated
+// values (the UPDATE interpolates only the ids; the DELETE also interpolates the
+// enum type/entityType strings first).
+function targetIds(call?: { values: unknown[] }): number[] {
+  return (call?.values.find(Array.isArray) as number[] | undefined) ?? [];
+}
+// The age-out UPDATE: flips Pending -> Error. Distinguished from the exhaustedRescan
+// UPDATE by the guarded status literal in the SQL text.
+function ageOutUpdate() {
+  return execLog.find((c) => c.sql.includes('UPDATE "Image"') && c.sql.includes("'Pending'"));
+}
+function pruneDelete() {
+  return execLog.find((c) => c.sql.includes('DELETE FROM "JobQueue"'));
+}
+
+beforeEach(() => {
+  execLog.length = 0;
+  mockDbRead.jobQueue.findMany.mockClear();
+  mockDbWrite.$queryRaw.mockClear();
+  mockDbWrite.$executeRaw.mockClear();
+  mockIngestImage.mockClear();
+});
+
+describe('ingest-images pending age-out', () => {
+  it('flips an old, non-backfill Pending image to Error (guarded on ingestion=Pending)', async () => {
+    const result = (await runJob(ingestImages)) as { agedOutPending: number };
+
+    const update = ageOutUpdate();
+    expect(update).toBeDefined();
+    // Bound UPDATE targeting exactly the aged-out id, guarded on the current status
+    // so a concurrent verdict is never clobbered.
+    expect(targetIds(update)).toEqual([1]);
+    expect(update!.sql).toContain("ingestion = 'Pending'::\"ImageIngestionStatus\"");
+    expect(result.agedOutPending).toBe(1);
+  });
+
+  it('does NOT flip a fresh (under-threshold) Pending image, and still sends it', async () => {
+    await runJob(ingestImages);
+
+    const update = ageOutUpdate();
+    expect(targetIds(update)).not.toContain(2);
+    // The fresh Pending image is still submitted for scanning this run.
+    expect(sentIds()).toContain(2);
+  });
+
+  it('does NOT terminalize an old BACKFILL Pending image', async () => {
+    const result = (await runJob(ingestImages)) as { agedOutPending: number };
+
+    const update = ageOutUpdate();
+    // Only id 1 aged out; the old backfill id 3 is excluded.
+    expect(targetIds(update)).toEqual([1]);
+    expect(targetIds(update)).not.toContain(3);
+    expect(result.agedOutPending).toBe(1);
+    // Backfill still scans via its (low-priority) lane rather than being dropped.
+    expect(sentIds()).toContain(3);
+  });
+
+  it('aged-out image enters the capped Error-retry (not re-sent, kept in queue); at-cap Error is terminal', async () => {
+    await runJob(ingestImages);
+
+    // Aged-out id 1 is flipped, NOT re-driven as Pending this run.
+    expect(sentIds()).not.toContain(1);
+    // ...and it is NOT pruned from the JobQueue — it stays so next run it is
+    // re-pulled as Error and retried through the existing capped Error path.
+    const del = pruneDelete();
+    expect(del).toBeDefined();
+    expect(targetIds(del)).not.toContain(1);
+
+    // An Error image under the cap IS retried (bounded retry path is live)...
+    expect(sentIds()).toContain(4);
+    // ...and an Error image at the 9-cap is NOT retried and IS pruned — terminal,
+    // so the retry loop is bounded, never infinite.
+    expect(sentIds()).not.toContain(5);
+    expect(targetIds(del)).toContain(5);
+  });
+});

--- a/src/server/jobs/image-ingestion.ts
+++ b/src/server/jobs/image-ingestion.ts
@@ -33,6 +33,13 @@ type IngestImageRow = IngestImageInput & {
    * orchestrator lane so they don't starve live user uploads.
    */
   isBackfill: boolean;
+  /**
+   * First-upload timestamp. Used ONLY as the age-out clock for never-returning
+   * Pending scans: unlike `scanRequestedAt` (reset to `now` on every re-send by
+   * `ingestImage`), `createdAt` is immutable, so it's the one signal a re-drive
+   * loop can't keep pushing into the future. See the Pending age-out below.
+   */
+  createdAt: Date;
 };
 
 export const ingestImages = createJob('ingest-images', '*/5 * * * *', async () => {
@@ -78,7 +85,7 @@ export const ingestImages = createJob('ingest-images', '*/5 * * * *', async () =
   const images =
     (await dbWrite.$queryRaw<IngestImageRow[]>`
     SELECT i.id, i.url, i.type, i.width, i.height, i.meta->>'prompt' as prompt,
-           i."scanRequestedAt", i.ingestion,
+           i."scanRequestedAt", i."createdAt", i.ingestion,
            (i."scanJobs"->>'retryCount')::int as "retryCount",
            i."scanJobs"->'error'->>'failureClass' as "failureClass",
            EXISTS (
@@ -101,12 +108,57 @@ export const ingestImages = createJob('ingest-images', '*/5 * * * *', async () =
       img.ingestion === 'Pending' && (!img.scanRequestedAt || img.scanRequestedAt <= rescanDate)
   );
 
+  // Age-out safety net for never-returning Pending scans.
+  //
+  // A scan verdict arrives via the fire-and-forget /image-scan-result webhook,
+  // which flips ingestion Pending -> Scanned/Blocked/Error. A fraction of scans
+  // never call back — a dropped callback (workflow succeeded, POST lost) or a
+  // stuck/unassigned workflow that never finishes — and NEITHER civitai nor the
+  // orchestrator has any timeout on that path. Those images stay ingestion
+  // 'Pending' forever and this cron re-drives them every cooldown with no ceiling.
+  //
+  // The age-out clock MUST be `createdAt`, NOT `scanRequestedAt`: `ingestImage`
+  // stamps `scanRequestedAt = now` on every (re-)send, so a "Pending too long by
+  // scanRequestedAt" test resets each run and can never fire. `createdAt` is the
+  // first-upload time (~first scan request, since user uploads scan directly via
+  // ingestImage on creation) and is never rewritten, so it's the one signal the
+  // re-drive loop can't push forward.
+  //
+  // Scope: user uploads only (`!isBackfill`). Article-content backfill images are
+  // legitimately old (createdAt months back) and drain slowly through the
+  // low-priority lane — an age-out keyed on createdAt would wrongly terminalize
+  // the entire backfill on its first pass, so it is excluded outright.
+  //
+  // Threshold is env-tuned and conservative: it must exceed the wall-time of any
+  // legitimately in-flight scan so a healthy scan is never cut off. A too-long
+  // Pending image is flipped to Error (below, in the prod block), which routes it
+  // into the EXISTING capped Error-retry machinery — it gets a bounded number of
+  // real retries and then terminalizes, instead of being Pending forever.
+  const pendingTimeoutDate = decreaseDate(
+    now,
+    env.IMAGE_SCANNING_PENDING_TIMEOUT,
+    'minutes'
+  );
+  const agedOutPendingIds = images
+    .filter(
+      (img) =>
+        img.ingestion === 'Pending' && !img.isBackfill && img.createdAt <= pendingTimeoutDate
+    )
+    .map((img) => img.id);
+  const agedOutPendingSet = new Set(agedOutPendingIds);
+
   // Split pending into backfill (article-connected, low-priority) and user
   // uploads (default high-priority). Backfill work shouldn't starve live
   // uploads. Published-article connection is determined by the isBackfill
-  // flag populated in the image SELECT above.
+  // flag populated in the image SELECT above. Aged-out user uploads are excluded
+  // from the send fan-out: they are terminalized to Error this run, so re-sending
+  // them as Pending would be wasted work (and re-stamp scanRequestedAt). They
+  // still stay in the JobQueue via `processedIds` below (they remain in
+  // `pendingImages`), so next run they are picked up through the Error path.
   const pendingBackfill = pendingImages.filter((img) => img.isBackfill);
-  const pendingUserUploads = pendingImages.filter((img) => !img.isBackfill);
+  const pendingUserUploads = pendingImages.filter(
+    (img) => !img.isBackfill && !agedOutPendingSet.has(img.id)
+  );
 
   // Rescan mirrors Pending/Error: only re-send once the retry delay has elapsed
   // (cooldown via scanRequestedAt) and while still under the retry cap. Without
@@ -191,6 +243,7 @@ export const ingestImages = createJob('ingest-images', '*/5 * * * *', async () =
     pendingImages: pendingImages.length,
     pendingUserUploads: pendingUserUploads.length,
     pendingBackfill: pendingBackfill.length,
+    agedOutPending: agedOutPendingIds.length,
     rescanImages: rescanImages.length,
     errorImages: errorImages.length,
     waitingForRetry: waitingForRetryIds.size,
@@ -234,6 +287,25 @@ export const ingestImages = createJob('ingest-images', '*/5 * * * *', async () =
     `;
   }
 
+  // Terminalize never-returning Pending scans (see the age-out rationale above).
+  // Flip the too-long-Pending user uploads to Error so they leave the Pending
+  // bucket and enter the capped Error-retry path. The id set is derived purely
+  // from the already-loaded rows and this runs before the send fan-out (mirrors
+  // the prune-before-send and exhaustedRescan ordering). The `AND ingestion =
+  // 'Pending'` guard makes the flip a no-op if a real verdict landed between the
+  // SELECT and here — a concurrent callback always wins, we never clobber a
+  // Scanned/Blocked result. These ids stay in the JobQueue (they're in
+  // `pendingImages` -> `processedIds`, so not pruned), so next run they are
+  // re-pulled and handled as Error.
+  if (agedOutPendingIds.length > 0) {
+    await dbWrite.$executeRaw`
+      UPDATE "Image"
+      SET ingestion = 'Error'::"ImageIngestionStatus"
+      WHERE id = ANY(${agedOutPendingIds})
+        AND ingestion = 'Pending'::"ImageIngestionStatus"
+    `;
+  }
+
   const sentUserPendingIds = await sendImagesForScanBulk(pendingUserUploads);
   const sentBackfillIds = await sendImagesForScanBulk(pendingBackfill, { lowPriority: true });
   const sentRescanIds = await sendImagesForScanBulk(rescanImages, { lowPriority: true });
@@ -248,6 +320,7 @@ export const ingestImages = createJob('ingest-images', '*/5 * * * *', async () =
   imageIngestCronCounter.inc({ bucket: 'sentError' }, sentErrorIds.length);
   imageIngestCronCounter.inc({ bucket: 'waitingForRetry' }, waitingForRetryIds.size);
   imageIngestCronCounter.inc({ bucket: 'staleRemoved' }, staleIds.length);
+  imageIngestCronCounter.inc({ bucket: 'agedOutPending' }, agedOutPendingIds.length);
 
   // Failed sends = attempted minus successfully-dispatched, across every lane.
   // sendImagesForScanBulk returns only the ids it managed to send, so the
@@ -271,6 +344,7 @@ export const ingestImages = createJob('ingest-images', '*/5 * * * *', async () =
       pending: pendingImages.length,
       rescan: rescanImages.length,
       error: errorImages.length,
+      agedOutPending: agedOutPendingIds.length,
       waitingForRetry: waitingForRetryIds.size,
       staleRemoved: staleIds.length,
       failedSends,
@@ -297,6 +371,7 @@ export const ingestImages = createJob('ingest-images', '*/5 * * * *', async () =
     sentBackfill: sentBackfillIds.length,
     sentRescan: sentRescanIds.length,
     sentError: sentErrorIds.length,
+    agedOutPending: agedOutPendingIds.length,
     waitingForRetry: waitingForRetryIds.size,
     staleRemoved: staleIds.length,
     failedSends,


### PR DESCRIPTION
## Root cause

Image scans are dispatched as orchestrator workflows. A verdict returns via the **fire-and-forget** `/api/webhooks/image-scan-result` callback, which sets `Image.ingestion` → `Scanned`/`Blocked`/`Error`. A fraction of scans **never get a callback** and stay `ingestion='Pending'` forever, in two modes:

- **lost callback** — the workflow succeeded but the fire-and-forget callback POST dropped;
- **stuck workflow** — the workflow never finishes / stays unassigned, so no callback is ever sent.

**Neither civitai nor the orchestrator has any timeout/expiry on that path.** The `ingest-images` retry cron (`*/5`) re-drives `Pending` images every cooldown but has **no cap and never terminalizes Pending → Error**, so these images re-drive indefinitely and never settle.

## Fix

A civitai-side **age-out**: a too-long-`Pending` image is flipped to `Error`, which routes it into the **existing capped Error-retry machinery** (`getImageScanRetryLimit`, reason-aware ceiling / historical 9-cap). After the flip it gets a bounded number of real retries and then terminalizes — it can no longer be `Pending` forever.

## The signal used, and why the reset pitfall doesn't fool it

The age-out keys off **`createdAt`**, **not** `scanRequestedAt`.

`ingestImage` stamps `scanRequestedAt = now` on **every (re-)send**, so a naive "Pending & `scanRequestedAt` older than N" test never fires — the clock resets each run. It also does **not** increment `scanJobs.retryCount` on a `Pending` re-send (retryCount is only bumped on a real Error callback, in `markImageScanError`), so a retryCount-cap couldn't fire either without changing the dispatch. `createdAt` is the immutable first-upload timestamp (≈ first scan request, since user uploads scan directly via `ingestImage` on creation) — the one signal the re-drive loop can't push forward.

## Backfill handling

Article-content **backfill** images (connected to an already-`Published` Article) are legitimately old (`createdAt` months back) and drain slowly through the low-priority orchestrator lane. A `createdAt` age-out would wrongly terminalize the entire backfill on its first pass, so backfill (`isBackfill`) images are **excluded** from the age-out outright.

## Threshold / env

`IMAGE_SCANNING_PENDING_TIMEOUT` (minutes), **default `60`**, positive-int guarded, consistent with the existing `IMAGE_SCANNING_*` envs. Conservative on purpose — it must exceed the wall-time of any legitimately in-flight scan (seconds–minutes) so a healthy scan is never cut off, while the never-returning cases are hours-to-days old. (Chose 60 over ~30 for conservatism; tune via env without a redeploy.)

## Mechanics / safety

- Bounded `UPDATE "Image" SET ingestion='Error' WHERE id = ANY(...) AND ingestion='Pending'`, id set derived **purely from the already-loaded rows**, run **before the send fan-out** (mirrors the existing `exhaustedRescan` terminalization + the prune-before-send ordering).
- The `AND ingestion='Pending'` guard means a **concurrent verdict always wins** — if a real callback landed between SELECT and UPDATE, the flip is a no-op and we never clobber a `Scanned`/`Blocked` result.
- Aged-out ids are excluded from the send lane (not re-sent as Pending) but **stay in the JobQueue** (they remain in `pendingImages` → `processedIds`), so next run they're re-pulled and handled through the **Error** path; an Error image that hits the retry cap becomes stale and is pruned — the loop stays bounded, never infinite.

## Additive / no dispatch change

No change to the dispatch (`ingestImage`), the callback handler, the Rescan/Error logic, the JobQueue prune semantics, or the `!isProd` guard.

## Tests

New `src/server/jobs/__tests__/ingest-images-pending-ageout.test.ts` (4 cases, mirrors the existing job-test harness): (1) old non-backfill Pending → flipped to Error (guarded on `Pending`); (2) fresh under-threshold Pending → not flipped, still sent; (3) old **backfill** Pending → not terminalized; (4) aged-out image not re-sent + kept in queue → enters the capped Error-retry, while an at-cap Error is pruned (terminal → bounded, not infinite). Run alongside the existing `ingest-images-cap` / `ingest-images-prune-order` suites: **7/7 pass**. `tsc --noEmit`: 0 new errors in edited files.

## Gates

pr-preview + an adversarial `/audit-pr` are the gates; this is a core, fleet-wide scheduled job so it wants a careful review before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
