### PR TITLE
fix(event-engine): raise signals fetch timeout 2s -> 10s

### DIFF
--- a/apps/event-engine/src/common/services/signals.ts
+++ b/apps/event-engine/src/common/services/signals.ts
@@ -1,6 +1,10 @@
-// Bound every send so a hung/slow signals endpoint can never stall the
+// Bound every send so a truly hung signals endpoint can never stall the
 // (best-effort) caller — this also caps the awaited hot-path `sendDelta`.
-const REQUEST_TIMEOUT_MS = 2000;
+// NOTE: set generously (10s) — the signals endpoint's normal response time
+// routinely exceeds 2s, and those sends succeed. A tighter timeout aborts
+// normal-but-slow sends and turns them into failures (a 2s value regressed
+// the failure rate 0.13% -> ~1%); 10s only catches a genuine hang.
+const REQUEST_TIMEOUT_MS = 10000;
 
 // Connection-level failure codes we retry once (on a fresh connection). The
 // dominant one here is the undici keep-alive race: a pooled idle socket the


### PR DESCRIPTION
The 2s `AbortSignal.timeout` from #3375 was too tight — the signals endpoint's normal response routinely exceeds 2s (those sends succeed), so 2s aborted normal-but-slow sends and *raised* the failure rate (0.13% → ~1%, now dominated by `TimeoutError` rather than ECONNRESET). Bump to 10s: still bounds a genuine hang, stops aborting normal slow sends. Keeps the ECONNRESET retry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)