### PR TITLE
feat(apps): flag incomplete listings (missing assets/fields) on my-submissions

### DIFF
--- a/src/components/Apps/ListingProblemsIndicator.tsx
+++ b/src/components/Apps/ListingProblemsIndicator.tsx
@@ -1,0 +1,44 @@
+import { HoverCard, List, Text, ThemeIcon } from '@mantine/core';
+import { IconAlertTriangle } from '@tabler/icons-react';
+
+/** One advisory problem on a submission row (from the server's `computeListingProblems`). */
+export type ListingProblem = { code: string; label: string };
+
+/**
+ * Advisory "listing incomplete" warning shown next to a submission's status. When
+ * the row has one or more problems (missing assets / empty key fields) it renders
+ * an orange warning triangle; hovering (or focusing) opens a card that enumerates
+ * each problem's label. Renders NOTHING when `problems` is empty — a clean row shows
+ * no icon. Heads-up only; it is NOT a hard gate.
+ */
+export function ListingProblemsIndicator({ problems }: { problems: ListingProblem[] }) {
+  if (!problems || problems.length === 0) return null;
+  return (
+    <HoverCard width={260} position="top" withArrow shadow="md" withinPortal openDelay={100}>
+      <HoverCard.Target>
+        <ThemeIcon
+          color="yellow"
+          variant="light"
+          size="sm"
+          radius="xl"
+          data-testid="apps-submission-problems"
+          style={{ cursor: 'help' }}
+          aria-label="This listing has problems"
+          tabIndex={0}
+        >
+          <IconAlertTriangle size={14} />
+        </ThemeIcon>
+      </HoverCard.Target>
+      <HoverCard.Dropdown>
+        <Text size="xs" fw={600} mb={4}>
+          Listing needs attention
+        </Text>
+        <List size="xs" spacing={2}>
+          {problems.map((p) => (
+            <List.Item key={p.code}>{p.label}</List.Item>
+          ))}
+        </List>
+      </HoverCard.Dropdown>
+    </HoverCard>
+  );
+}

--- a/src/components/Apps/MySubmissionsList.browser.test.tsx
+++ b/src/components/Apps/MySubmissionsList.browser.test.tsx
@@ -952,6 +952,43 @@ describe('MySubmissionsList — P4 surfaced manage links', () => {
   });
 });
 
+describe('MySubmissionsList — advisory listing-problems warning', () => {
+  test('a row WITH problems renders the warning icon; hovering lists each problem label', async () => {
+    renderWithProviders(
+      <MySubmissionsList
+        submissions={[
+          makeSubmission({
+            problems: [
+              { code: 'missing-icon', label: 'Missing icon' },
+              { code: 'empty-tagline', label: 'Missing tagline' },
+            ],
+          }),
+        ]}
+        onWithdraw={vi.fn()}
+        withdrawing={false}
+      />
+    );
+    const warn = page.getByTestId('apps-submission-problems');
+    await expect.element(warn).toBeInTheDocument();
+    // The HoverCard dropdown mounts on hover and enumerates each problem label.
+    await warn.hover();
+    await expect.element(page.getByText('Missing icon', { exact: false })).toBeInTheDocument();
+    await expect.element(page.getByText('Missing tagline', { exact: false })).toBeInTheDocument();
+  });
+
+  test('a clean row (no problems) shows NO warning icon', async () => {
+    renderWithProviders(
+      <MySubmissionsList
+        submissions={[makeSubmission({ problems: [] })]}
+        onWithdraw={vi.fn()}
+        withdrawing={false}
+      />
+    );
+    await expect.element(page.getByText('my-app', { exact: false })).toBeInTheDocument();
+    expect(page.getByTestId('apps-submission-problems').elements()).toHaveLength(0);
+  });
+});
+
 describe('MySubmissionsList — P4 Open-live run-page branching (graceful, no dead link)', () => {
   test('a page app the viewer CAN open → /apps/run/<slug> (internal)', async () => {
     renderWithProviders(

--- a/src/components/Apps/MySubmissionsList.tsx
+++ b/src/components/Apps/MySubmissionsList.tsx
@@ -19,6 +19,10 @@ import {
 import Link from 'next/link';
 import { Fragment, useMemo, useState, type ReactNode } from 'react';
 import { AppAnalyticsInline } from '~/components/Apps/AppAnalyticsInline';
+import {
+  ListingProblemsIndicator,
+  type ListingProblem,
+} from '~/components/Apps/ListingProblemsIndicator';
 import { getDetailPrimaryAction } from '~/components/Apps/appListingDetailView';
 import { isStaleDeploy } from '~/components/Apps/deploy-status';
 import {
@@ -104,6 +108,9 @@ export type Submission = {
   /** Whether the backing block's manifest declares a launchable page — drives the
    *  Open-live → `/apps/run/<slug>` vs standalone-origin vs model-slot branching. */
   hasPage?: boolean | null;
+  /** Advisory listing-completeness problems (missing assets + empty key fields),
+   *  from the server's `computeListingProblems`. Empty ⇒ no warning icon. */
+  problems?: ListingProblem[];
 };
 
 /** Owner-control handlers threaded from the list down to each latest row. */
@@ -286,7 +293,10 @@ function StatusCell({
   );
   return (
     <Stack gap={6} align="flex-start">
-      {chip}
+      <Group gap={6} wrap="nowrap">
+        {chip}
+        <ListingProblemsIndicator problems={submission.problems ?? []} />
+      </Group>
       {notes && <ReviewerNotesButton notes={notes} variant={variant} />}
     </Stack>
   );

--- a/src/components/Apps/OffsiteSubmissionsList.browser.test.tsx
+++ b/src/components/Apps/OffsiteSubmissionsList.browser.test.tsx
@@ -401,3 +401,43 @@ describe('OffsiteSubmissionsList — moderation history modal', () => {
     await expect.element(page.getByTestId('apps-offsite-history-empty')).toBeInTheDocument();
   });
 });
+
+describe('OffsiteSubmissionsList — advisory listing-problems warning', () => {
+  test('a row WITH problems renders the warning icon; hovering lists each problem label', async () => {
+    renderWithProviders(
+      <OffsiteSubmissionsList
+        submissions={[
+          live({
+            problems: [
+              { code: 'missing-cover', label: 'Missing cover image' },
+              { code: 'empty-description', label: 'Missing description' },
+            ],
+          }),
+        ]}
+        onWithdraw={vi.fn()}
+        withdrawing={false}
+      />
+    );
+    const warn = page.getByTestId('apps-submission-problems');
+    await expect.element(warn).toBeInTheDocument();
+    await warn.hover();
+    await expect
+      .element(page.getByText('Missing cover image', { exact: false }))
+      .toBeInTheDocument();
+    await expect
+      .element(page.getByText('Missing description', { exact: false }))
+      .toBeInTheDocument();
+  });
+
+  test('a clean row (no problems) shows NO warning icon', async () => {
+    renderWithProviders(
+      <OffsiteSubmissionsList
+        submissions={[live({ problems: [] })]}
+        onWithdraw={vi.fn()}
+        withdrawing={false}
+      />
+    );
+    await expect.element(page.getByText('live-off', { exact: false })).toBeInTheDocument();
+    expect(page.getByTestId('apps-submission-problems').elements()).toHaveLength(0);
+  });
+});

--- a/src/components/Apps/OffsiteSubmissionsList.tsx
+++ b/src/components/Apps/OffsiteSubmissionsList.tsx
@@ -38,6 +38,10 @@ import {
 import { validateExternalUrl } from '~/server/schema/blocks/external-app.schema';
 import { ReviewerNotesButton } from '~/components/Apps/MySubmissionsList';
 import {
+  ListingProblemsIndicator,
+  type ListingProblem,
+} from '~/components/Apps/ListingProblemsIndicator';
+import {
   bucketGroupsByStatus,
   filterGroups,
   groupSubmissionsByApp,
@@ -107,6 +111,9 @@ export type OffsiteSubmission = {
    *  listing) — `owner-unpublish` ⇒ owner-hidden (republish-eligible), anything else
    *  (a moderator `delist`) ⇒ mod-removed (republish forbidden). */
   lastModerationAction?: string | null;
+  /** Advisory listing-completeness problems (missing assets + empty key fields),
+   *  from the server's `computeListingProblems`. Empty ⇒ no warning icon. */
+  problems?: ListingProblem[];
 };
 
 /** Field adapters for the shared filter/sort/group helpers. Collapse identity =
@@ -155,7 +162,10 @@ function StatusCell({
       : null;
   return (
     <Stack gap={6} align="flex-start">
-      <Badge color={chip.color}>{chip.label}</Badge>
+      <Group gap={6} wrap="nowrap">
+        <Badge color={chip.color}>{chip.label}</Badge>
+        <ListingProblemsIndicator problems={submission.problems ?? []} />
+      </Group>
       {notes && (
         <ReviewerNotesButton
           notes={notes}

--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -1913,7 +1913,13 @@ export const blocksRouter = router({
             description: true,
             tagline: true,
             category: true,
-            _count: { select: { screenshots: true } },
+            // Filtered COUNT — only screenshots whose Image is still live. A row
+            // whose Image was deleted (imageId → null via onDelete: SetNull) has
+            // no displayable asset, so it must not inflate the count, else the
+            // `no-screenshots` warning is a false-negative. Matches the
+            // authoritative asset gate: `screenshots.filter(s => s.imageId != null)`
+            // in app-listing-assets.service.ts (buildAssetStatus).
+            _count: { select: { screenshots: { where: { imageId: { not: null } } } } },
           },
         });
         for (const l of listings) {

--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -97,6 +97,7 @@ import {
   validateBlockCheckpoint,
 } from '~/server/services/blocks/checkpoint.service';
 import { getModelShowcaseImages } from '~/server/services/blocks/showcase.service';
+import { computeListingProblems } from '~/server/services/blocks/listing-problems';
 import { getRequestDomainColor, isHostForColor } from '~/server/utils/server-domain';
 // Type-only: the runtime `resolveCanGenerateForVersions` is loaded via a
 // dynamic import() inside assertViewerCanGeneratePageResources so the heavy
@@ -1883,14 +1884,50 @@ export const blocksRouter = router({
       // live/removed listing state. A publish request stays `approved` after an owner
       // unpublish, so the request status alone can't tell live from owner-hidden. One
       // batched findMany (NOT per-row) keyed by appBlockId.
-      const listingByBlockId = new Map<string, { id: string; status: string }>();
+      // Additive projection (advisory listing-completeness warning on
+      // /apps/my-submissions): the asset ids + key text fields + a screenshot
+      // COUNT (via `_count`, not the rows) feed the pure `computeListingProblems`
+      // helper below. Purely additive — the owner-controls fields are unchanged.
+      const listingByBlockId = new Map<
+        string,
+        {
+          id: string;
+          status: string;
+          iconId: number | null;
+          coverId: number | null;
+          description: string | null;
+          tagline: string | null;
+          category: string | null;
+          screenshotCount: number;
+        }
+      >();
       if (appBlockIds.length) {
         const listings = await dbRead.appListing.findMany({
           where: { appBlockId: { in: appBlockIds }, kind: 'onsite' },
-          select: { id: true, appBlockId: true, status: true },
+          select: {
+            id: true,
+            appBlockId: true,
+            status: true,
+            iconId: true,
+            coverId: true,
+            description: true,
+            tagline: true,
+            category: true,
+            _count: { select: { screenshots: true } },
+          },
         });
         for (const l of listings) {
-          if (l.appBlockId) listingByBlockId.set(l.appBlockId, { id: l.id, status: l.status });
+          if (l.appBlockId)
+            listingByBlockId.set(l.appBlockId, {
+              id: l.id,
+              status: l.status,
+              iconId: l.iconId,
+              coverId: l.coverId,
+              description: l.description,
+              tagline: l.tagline,
+              category: l.category,
+              screenshotCount: l._count.screenshots,
+            });
         }
       }
 
@@ -1941,6 +1978,19 @@ export const blocksRouter = router({
           appListingId: listing?.id ?? null,
           listingStatus: listing?.status ?? null,
           lastModerationAction: listing ? lastActionByListingId.get(listing.id) ?? null : null,
+          // Advisory listing-completeness problems (missing assets + empty key
+          // fields). Empty when there's no backing listing yet (a pending first
+          // version) — nothing to flag until a listing row exists.
+          problems: listing
+            ? computeListingProblems({
+                iconId: listing.iconId,
+                coverId: listing.coverId,
+                screenshotCount: listing.screenshotCount,
+                description: listing.description,
+                tagline: listing.tagline,
+                category: listing.category,
+              }).problems
+            : [],
           // Whether the manifest declares a launchable page (drives the Open-live →
           // /apps/run/<slug> vs standalone-origin vs model-slot branching). PUBLIC
           // subset only.

--- a/src/server/services/blocks/__tests__/listing-problems.test.ts
+++ b/src/server/services/blocks/__tests__/listing-problems.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  computeListingProblems,
+  type ListingProblemCode,
+  type ListingProblemInput,
+} from '~/server/services/blocks/listing-problems';
+
+/**
+ * Advisory listing-completeness helper tests. `computeListingProblems` is the
+ * AUTHORITATIVE gate for the /apps/my-submissions warning icon — it enumerates a
+ * listing's problems (missing assets via the shared `checkListingAssetsComplete`
+ * gate + empty key text fields). Pure; no DB/network. The db client is mocked
+ * only because the reused assets-service module imports it at load time.
+ */
+
+vi.mock('~/server/db/client', () => ({ dbRead: {}, dbWrite: {} }));
+
+/** A fully-complete listing (no problems). Spread + override per case. */
+const complete: ListingProblemInput = {
+  iconId: 10,
+  coverId: 20,
+  screenshotCount: 3,
+  description: 'A useful app that does a thing.',
+  tagline: 'Does the thing',
+  category: 'utility',
+};
+
+const codes = (input: ListingProblemInput): ListingProblemCode[] =>
+  computeListingProblems(input).problems.map((p) => p.code);
+
+describe('computeListingProblems', () => {
+  it('returns NO problems for an all-complete listing', () => {
+    const result = computeListingProblems(complete);
+    expect(result.problems).toEqual([]);
+  });
+
+  it('flags a missing icon', () => {
+    expect(codes({ ...complete, iconId: null })).toEqual(['missing-icon']);
+  });
+
+  it('flags a missing cover', () => {
+    expect(codes({ ...complete, coverId: null })).toEqual(['missing-cover']);
+  });
+
+  it('flags zero screenshots', () => {
+    expect(codes({ ...complete, screenshotCount: 0 })).toEqual(['no-screenshots']);
+  });
+
+  it('does NOT flag screenshots when count is positive', () => {
+    expect(codes({ ...complete, screenshotCount: 1 })).toEqual([]);
+  });
+
+  describe('empty description', () => {
+    it('flags null', () => {
+      expect(codes({ ...complete, description: null })).toEqual(['empty-description']);
+    });
+    it('flags whitespace-only', () => {
+      expect(codes({ ...complete, description: '   \n\t ' })).toEqual(['empty-description']);
+    });
+    it('does NOT flag a non-empty value', () => {
+      expect(codes({ ...complete, description: 'hi' })).toEqual([]);
+    });
+  });
+
+  describe('empty tagline', () => {
+    it('flags null', () => {
+      expect(codes({ ...complete, tagline: null })).toEqual(['empty-tagline']);
+    });
+    it('flags whitespace-only', () => {
+      expect(codes({ ...complete, tagline: '  ' })).toEqual(['empty-tagline']);
+    });
+    it('does NOT flag a non-empty value', () => {
+      expect(codes({ ...complete, tagline: 'ok' })).toEqual([]);
+    });
+  });
+
+  describe('empty category', () => {
+    it('flags null', () => {
+      expect(codes({ ...complete, category: null })).toEqual(['empty-category']);
+    });
+    it('flags whitespace-only', () => {
+      expect(codes({ ...complete, category: '\t' })).toEqual(['empty-category']);
+    });
+    it('does NOT flag a non-empty value', () => {
+      expect(codes({ ...complete, category: 'games' })).toEqual([]);
+    });
+  });
+
+  it('flags EVERY problem for a fully-empty listing, in a stable order', () => {
+    const result = computeListingProblems({
+      iconId: null,
+      coverId: null,
+      screenshotCount: 0,
+      description: null,
+      tagline: '   ',
+      category: null,
+    });
+    expect(result.problems.map((p) => p.code)).toEqual([
+      'missing-icon',
+      'missing-cover',
+      'no-screenshots',
+      'empty-description',
+      'empty-tagline',
+      'empty-category',
+    ]);
+    // Every problem carries a human-readable, non-empty label.
+    for (const p of result.problems) {
+      expect(p.label).toBeTypeOf('string');
+      expect(p.label.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('combines a missing asset with an empty field', () => {
+    expect(codes({ ...complete, coverId: null, tagline: '' })).toEqual([
+      'missing-cover',
+      'empty-tagline',
+    ]);
+  });
+});

--- a/src/server/services/blocks/listing-problems.ts
+++ b/src/server/services/blocks/listing-problems.ts
@@ -1,0 +1,87 @@
+import {
+  checkListingAssetsComplete,
+  type MissingAsset,
+} from '~/server/services/blocks/app-listing-assets.service';
+
+/**
+ * Advisory "listing completeness" surface for /apps/my-submissions.
+ *
+ * PURE + unit-tested. Given the subset of an `AppListing`'s asset ids + key text
+ * fields, it enumerates the row's PROBLEMS — missing assets (icon / cover /
+ * screenshots, delegated to the shared {@link checkListingAssetsComplete} gate)
+ * PLUS empty key fields (description / tagline / category). `name` is always
+ * filled from the manifest so it is intentionally NOT checked.
+ *
+ * This is a heads-up for the developer, NOT a hard gate — nothing here blocks
+ * publish/approve; it only drives the warning icon + popover on the submissions
+ * list. Both the on-site (`listMyPublishRequests`) and off-site
+ * (`listMySubmissions`) procs project the needed fields and call this per row.
+ */
+
+export type ListingProblemInput = {
+  /** Image FK for the listing icon (null ⇒ missing). */
+  iconId: number | null;
+  /** Image FK for the listing cover (null ⇒ missing). */
+  coverId: number | null;
+  /** Number of screenshot rows (0 ⇒ a problem). */
+  screenshotCount: number;
+  /** Free-text description (null / whitespace-only ⇒ a problem). */
+  description: string | null;
+  /** Short tagline (null / whitespace-only ⇒ a problem). */
+  tagline: string | null;
+  /** Marketplace category (null / whitespace-only ⇒ a problem). */
+  category: string | null;
+};
+
+export type ListingProblemCode =
+  | 'missing-icon'
+  | 'missing-cover'
+  | 'no-screenshots'
+  | 'empty-description'
+  | 'empty-tagline'
+  | 'empty-category';
+
+export type ListingProblem = { code: ListingProblemCode; label: string };
+
+export type ListingProblemsResult = { problems: ListingProblem[] };
+
+/** Map the shared asset-gate `missing` codes → this surface's codes + labels. */
+const ASSET_PROBLEM: Record<MissingAsset, ListingProblem> = {
+  icon: { code: 'missing-icon', label: 'Missing icon' },
+  cover: { code: 'missing-cover', label: 'Missing cover image' },
+  screenshots: { code: 'no-screenshots', label: 'No screenshots' },
+};
+
+/** A value is "empty" when it's null/undefined or trims to the empty string. */
+function isEmpty(value: string | null | undefined): boolean {
+  return value == null || value.trim().length === 0;
+}
+
+/**
+ * Enumerate a listing's advisory problems. Never throws. Order is stable:
+ * assets first (icon → cover → screenshots, from the shared gate), then the
+ * empty text fields (description → tagline → category). An all-complete listing
+ * returns `{ problems: [] }`.
+ */
+export function computeListingProblems(listing: ListingProblemInput): ListingProblemsResult {
+  const problems: ListingProblem[] = [];
+
+  // Reuse the authoritative asset-completeness gate for icon/cover/screenshots.
+  const assets = checkListingAssetsComplete({
+    iconId: listing.iconId,
+    coverId: listing.coverId,
+    screenshotCount: listing.screenshotCount,
+  });
+  if (!assets.complete) {
+    for (const missing of assets.missing) problems.push(ASSET_PROBLEM[missing]);
+  }
+
+  if (isEmpty(listing.description))
+    problems.push({ code: 'empty-description', label: 'Missing description' });
+  if (isEmpty(listing.tagline))
+    problems.push({ code: 'empty-tagline', label: 'Missing tagline' });
+  if (isEmpty(listing.category))
+    problems.push({ code: 'empty-category', label: 'Missing category' });
+
+  return { problems };
+}

--- a/src/server/services/blocks/offsite-listing.service.ts
+++ b/src/server/services/blocks/offsite-listing.service.ts
@@ -2295,7 +2295,13 @@ const mySubmissionSelect = {
       coverId: true,
       description: true,
       tagline: true,
-      _count: { select: { screenshots: true } },
+      // Filtered COUNT — only screenshots whose Image is still live. A row whose
+      // Image was deleted (imageId → null via onDelete: SetNull) has no
+      // displayable asset, so it must not inflate the count, else the
+      // `no-screenshots` warning is a false-negative. Matches the authoritative
+      // asset gate: `appListingScreenshot.count({ where: { imageId: { not: null } } })`
+      // (see assertListingAssetsComplete callsite ~L1103 in this file).
+      _count: { select: { screenshots: { where: { imageId: { not: null } } } } },
     },
   },
 } as const;

--- a/src/server/services/blocks/offsite-listing.service.ts
+++ b/src/server/services/blocks/offsite-listing.service.ts
@@ -25,6 +25,7 @@ import {
   tokenScopeMaskToList,
 } from '~/shared/constants/token-scope.constants';
 import { assertListingAssetsComplete } from '~/server/services/blocks/app-listing-assets.service';
+import { computeListingProblems } from '~/server/services/blocks/listing-problems';
 import { notifyAppListingOwner } from '~/server/services/blocks/app-listing-notify';
 import {
   deriveContentRatingFromAssets,
@@ -2278,6 +2279,27 @@ const submissionSelect = {
   },
 } as const;
 
+/**
+ * `submissionSelect` PLUS the advisory listing-completeness projection used ONLY
+ * by the author-facing `listMySubmissions` (NOT the mod queues — they don't render
+ * the warning). Adds the asset ids + key text fields + a screenshot COUNT (via
+ * `_count`, not the rows) so the pure `computeListingProblems` helper can flag a
+ * row. Purely additive; `category` is already in `submissionSelect`.
+ */
+const mySubmissionSelect = {
+  ...submissionSelect,
+  appListing: {
+    select: {
+      ...submissionSelect.appListing.select,
+      iconId: true,
+      coverId: true,
+      description: true,
+      tagline: true,
+      _count: { select: { screenshots: true } },
+    },
+  },
+} as const;
+
 const submitterChip = { select: { id: true, username: true, image: true } } as const;
 
 export type ListOffsiteRequestsOptions = { limit?: number; cursor?: string };
@@ -2309,7 +2331,7 @@ export async function listMySubmissions(
     orderBy: { submittedAt: 'desc' },
     take: limit + 1,
     ...(opts.cursor ? { cursor: { id: opts.cursor }, skip: 1 } : {}),
-    select: submissionSelect,
+    select: mySubmissionSelect,
   });
   const hasNext = rows.length > limit;
   const page = hasNext ? rows.slice(0, limit) : rows;
@@ -2381,6 +2403,19 @@ export async function listMySubmissions(
     // when `appListing.status === 'removed'` to gate the Republish affordance.
     lastModerationAction:
       r.appListingId != null ? lastActionByListing.get(r.appListingId) ?? null : null,
+    // Advisory listing-completeness problems (missing assets + empty key fields).
+    // Empty when there's no backing listing (a rejected/withdrawn row whose listing
+    // was deleted) — nothing to flag.
+    problems: r.appListing
+      ? computeListingProblems({
+          iconId: r.appListing.iconId,
+          coverId: r.appListing.coverId,
+          screenshotCount: r.appListing._count.screenshots,
+          description: r.appListing.description,
+          tagline: r.appListing.tagline,
+          category: r.appListing.category,
+        }).problems
+      : [],
   }));
 
   return { items, nextCursor: hasNext ? items[items.length - 1].id : null };


### PR DESCRIPTION
## What

On `/apps/my-submissions`, each listing row that is **incomplete** now shows an advisory warning icon (orange/yellow `IconAlertTriangle`) next to its status, wrapped in a hover card that enumerates each problem. This lands on **both** lists — the on-site (`MySubmissionsList`) and off-site (`OffsiteSubmissionsList`). A clean row shows no icon.

### Problems set (per row)
Missing assets (reusing the existing pure `checkListingAssetsComplete` gate):
- `missing-icon` — Missing icon
- `missing-cover` — Missing cover image
- `no-screenshots` — No screenshots

Plus empty key text fields (empty = null or whitespace-only):
- `empty-description` — Missing description
- `empty-tagline` — Missing tagline
- `empty-category` — Missing category

`name` is always populated from the manifest, so it is intentionally **not** checked.

## Server projection

New pure, unit-tested helper `computeListingProblems(listing)` in `src/server/services/blocks/listing-problems.ts` takes `{ iconId, coverId, screenshotCount, description, tagline, category }` and returns a structured `{ problems: Array<{ code, label }> }`. It delegates the asset checks to `checkListingAssetsComplete` and adds the empty-field checks.

Wired into both procs, additively (no existing returned field changed):
- **On-site** `blocks.listMyPublishRequests`: the backing `AppListing` batch-fetch now also selects `iconId`, `coverId`, `description`, `tagline`, `category`, and `_count: { screenshots }` (a **count**, not the rows), and each row returns a `problems` array.
- **Off-site** `appListings.listMySubmissions`: a dedicated `mySubmissionSelect` extends the shared `submissionSelect`'s `appListing` select with the same fields + `_count.screenshots`. The shared select the mod queues use is **left untouched**, so those don't over-fetch. Each item returns a `problems` array.

The screenshot count uses the Prisma `_count` relation aggregate (`appListing._count.screenshots`) — no screenshot rows are fetched.

## Client

A small shared `ListingProblemsIndicator` component (Mantine `HoverCard` + `ThemeIcon`, `data-testid="apps-submission-problems"`) renders the icon + the problem list; it renders nothing when `problems` is empty. Both lists drop it next to the status badge.

## Tests

- **Blocking pure tests** (`listing-problems.test.ts`, unit project): every combination — all-complete → none; each missing asset → its code; each empty field (null + whitespace) → its code; a fully-empty listing → all six codes in stable order; combined cases. **16/16 pass** locally.
- **Report-only browser tests** extend `MySubmissionsList.browser.test.tsx` + `OffsiteSubmissionsList.browser.test.tsx`: a row with problems renders the icon and the hover card lists the labels; a clean row shows no icon. (Not runnable locally — Playwright chromium isn't installed here; CI runs them.)

## Safety

Advisory only — **not** a hard gate; nothing here blocks publish/approve. Ships dark behind the existing app-blocks author gate. pr-preview + `/audit-pr` are the gates; the mod-gated UI still needs a human preview check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
