### PR TITLE
feat(apps): reduce card/detail text truncation + owner Edit deep-link

### DIFF
--- a/src/components/Apps/AppListingCard.browser.test.tsx
+++ b/src/components/Apps/AppListingCard.browser.test.tsx
@@ -1,16 +1,31 @@
-import { describe, expect, test } from 'vitest';
+import { describe, expect, test, vi, beforeEach } from 'vitest';
 import { page } from 'vitest/browser';
 // `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
 import { renderWithProviders } from '../../../test/component-setup';
-import { AppListingCard } from '~/components/Apps/AppListingCard';
 import type { ListingCard } from '~/server/schema/blocks/app-listing-read.schema';
 
 /**
  * P2b AppListingCard component tests (REPORT-ONLY — the browser project is
  * non-blocking; the blocking gate is appListingCardView.test.ts). These pin the
  * rendered kind badge, recommend label, and kind-aware CTA affordance for a few
- * representative cards.
+ * representative cards, PLUS the owner "Edit" deep-link gating (Item 2) and the
+ * long-username tooltip fallback (Item 1).
  */
+
+const mocks = vi.hoisted(() => ({
+  currentUser: null as null | { id: number; username: string },
+}));
+
+vi.mock('~/hooks/useCurrentUser', () => ({
+  useCurrentUser: () => mocks.currentUser,
+}));
+
+// Import AFTER the mock is declared (vi.mock is hoisted, imports are not).
+const { AppListingCard } = await import('./AppListingCard');
+
+beforeEach(() => {
+  mocks.currentUser = null;
+});
 
 function base(over: Partial<ListingCard>): ListingCard {
   return {
@@ -103,5 +118,51 @@ describe('AppListingCard', () => {
     renderWithProviders(<AppListingCard card={base({})} canOpenPage={false} />);
     const details = page.getByRole('link', { name: 'View details' });
     await expect.element(details).toHaveAttribute('href', '/apps/store-preview/my-app');
+  });
+
+  test('owner sees the Edit deep-link → on-site manifest editor', async () => {
+    mocks.currentUser = { id: 5, username: 'alice' }; // matches base().creator.id
+    renderWithProviders(<AppListingCard card={base({})} canOpenPage />);
+    const edit = page.getByTestId('apps-listing-owner-edit');
+    await expect.element(edit).toBeInTheDocument();
+    await expect.element(edit).toHaveAttribute('href', '/apps/blk-1/edit-manifest');
+  });
+
+  test('owner of an off-site listing → Edit routes to the submit editor by listing id', async () => {
+    mocks.currentUser = { id: 5, username: 'alice' };
+    renderWithProviders(
+      <AppListingCard
+        card={base({
+          kind: 'offsite',
+          kindData: { kind: 'offsite', subKind: 'external-link', externalUrl: 'https://ext.app' },
+        })}
+      />
+    );
+    const edit = page.getByTestId('apps-listing-owner-edit');
+    await expect.element(edit).toHaveAttribute('href', '/apps/submit?edit=l1');
+  });
+
+  test('non-owner does NOT see the Edit deep-link', async () => {
+    mocks.currentUser = { id: 999, username: 'bob' };
+    renderWithProviders(<AppListingCard card={base({})} canOpenPage />);
+    await expect.element(page.getByTestId('apps-listing-owner-edit')).not.toBeInTheDocument();
+  });
+
+  test('signed-out viewer does NOT see the Edit deep-link', async () => {
+    mocks.currentUser = null;
+    renderWithProviders(<AppListingCard card={base({})} canOpenPage />);
+    await expect.element(page.getByTestId('apps-listing-owner-edit')).not.toBeInTheDocument();
+  });
+
+  test('a long username reveals the full value in a tooltip on hover (clip fallback)', async () => {
+    const longName = 'a-really-long-creator-username-that-will-definitely-overflow-the-card-column';
+    renderWithProviders(
+      <AppListingCard card={base({ creator: { id: 5, username: longName, image: null } })} canOpenPage />
+    );
+    const label = page.getByText(`by ${longName}`);
+    await expect.element(label).toBeInTheDocument();
+    await label.hover();
+    // The Tooltip renders the full username (portal) once the label overflows.
+    await expect.element(page.getByText(longName, { exact: true })).toBeInTheDocument();
   });
 });

--- a/src/components/Apps/AppListingCard.tsx
+++ b/src/components/Apps/AppListingCard.tsx
@@ -2,6 +2,7 @@ import { Anchor, Avatar, Badge, Box, Button, Card, Group, Image, Stack, Text, Ti
 import {
   IconApps,
   IconExternalLink,
+  IconPencil,
   IconPlugConnected,
   IconThumbUp,
 } from '@tabler/icons-react';
@@ -14,12 +15,16 @@ import {
   FALLBACK_CATEGORY_ICON,
 } from '~/components/Apps/marketplaceCategoryIcons';
 import {
+  canOwnerEditListing,
   getListingBadge,
   getListingCta,
   getListingDetailHref,
+  getOwnerEditHref,
   getRecommendLabel,
   type ListingBadgeKind,
 } from '~/components/Apps/appListingCardView';
+import { TruncatedBadge, TruncatedText } from '~/components/Apps/AppListingTruncate';
+import { useCurrentUser } from '~/hooks/useCurrentUser';
 import {
   isMarketplaceCategory,
   MARKETPLACE_CATEGORY_LABELS,
@@ -35,8 +40,11 @@ import type { ListingCard } from '~/server/schema/blocks/app-listing-read.schema
  * Visit ↗ / Connect). Mirrors the visual language of the live `AppBlockCard`
  * (Mantine Card + category-glyph cover placeholder) so listings feel native.
  *
- * DARK / parallel-run: used only by the mod-only `/apps/store-preview` surface —
- * the default `/apps` render (MarketplaceBody → AppBlockCard) is untouched.
+ * LIVE (P2d cut over): this is the DEFAULT `/apps` store card
+ * (`AppListingsMarketplaceBody` → `AppListingCard`) over BOTH kinds. The page is
+ * still flag-gated (the App Blocks Flipt segment + `deIndex`) — no longer
+ * "store-preview only". The unified DETAIL still lives at
+ * `/apps/store-preview/<slug>`.
  *
  * Reuse note: the plan (§6.1) suggests rendering through `AspectRatioImageCard`
  * for cosmetic frames + per-image maturity blur. That component's image slot
@@ -138,13 +146,21 @@ function CreatorChip({ creator }: { creator: ListingCard['creator'] }) {
       c="dimmed"
       onClick={(e: MouseEvent) => e.stopPropagation()}
     >
-      <Group gap={6} wrap="nowrap">
-        <Avatar src={avatarSrc} alt="" radius="xl" size={20}>
+      <Group gap={6} wrap="nowrap" style={{ minWidth: 0 }}>
+        <Avatar src={avatarSrc} alt="" radius="xl" size={20} style={{ flexShrink: 0 }}>
           {creator.username.charAt(0).toUpperCase()}
         </Avatar>
-        <Text size="xs" c="dimmed" lineClamp={1}>
-          by {creator.username}
-        </Text>
+        {/* Tuned to fit in the common case; the Tooltip reveals a long username
+            only when it would still clip. */}
+        <TruncatedText
+          size="xs"
+          c="dimmed"
+          lineClamp={1}
+          tooltipLabel={creator.username}
+          style={{ minWidth: 0 }}
+        >
+          {`by ${creator.username}`}
+        </TruncatedText>
       </Group>
     </Anchor>
   );
@@ -161,22 +177,39 @@ export interface AppListingCardProps {
 }
 
 export function AppListingCard({ card, canOpenPage = false }: AppListingCardProps) {
+  const currentUser = useCurrentUser();
   const badge = getListingBadge(card);
   const cta = getListingCta(card, { canOpenPage });
   const detailHref = getListingDetailHref(card.slug);
   const recommendLabel = getRecommendLabel(card.recommend, card.reviewCount);
   const BadgeIcon = KIND_BADGE_ICON[badge.kind];
 
+  // Owner "Edit" deep-link (Item 2). The public store DTO is approved-only + has
+  // no status field, so gating is owner + editable-status (status omitted →
+  // editable); the href builder returns null when there's no editable target
+  // (an on-site listing with no backing appBlockId) → the button is hidden.
+  const isOwner = !!currentUser?.id && currentUser.id === card.creator?.id;
+  const editHref = getOwnerEditHref(card.kindData, card.id);
+  const showEdit = canOwnerEditListing({ isOwner }) && !!editHref;
+
   return (
     <Card shadow="sm" padding="md" radius="md" withBorder className="h-full">
       <ListingCover coverUrl={card.coverUrl} category={card.category} name={card.name} />
       <Stack gap="sm" h="100%" pt="sm">
-        <Group justify="space-between" align="flex-start" wrap="nowrap">
-          <Group gap="xs" wrap="nowrap" align="flex-start" style={{ minWidth: 0 }}>
+        <Group justify="space-between" align="flex-start" wrap="nowrap" gap="xs">
+          {/* flex:1 + minWidth:0 lets the text column take the row's slack and
+              shrink gracefully instead of being over-squeezed by the badges. */}
+          <Group gap="xs" wrap="nowrap" align="flex-start" style={{ minWidth: 0, flex: 1 }}>
             {/* App icon (square, publisher-supplied). Decorative — the title
                 carries the accessible name; a missing icon falls back to the
                 app's initial. */}
-            <Avatar src={card.iconUrl ?? undefined} alt="" radius="md" size={40}>
+            <Avatar
+              src={card.iconUrl ?? undefined}
+              alt=""
+              radius="md"
+              size={40}
+              style={{ flexShrink: 0 }}
+            >
               {card.name.charAt(0).toUpperCase()}
             </Avatar>
             <Stack gap={2} style={{ minWidth: 0 }}>
@@ -197,8 +230,12 @@ export function AppListingCard({ card, canOpenPage = false }: AppListingCardProp
               <CreatorChip creator={card.creator} />
             </Stack>
           </Group>
-          <Stack gap={4} align="flex-end">
-            {/* Kind badge — App (on-site) vs Connect app / Off-site (off-site). */}
+          {/* Badge column — capped width + flex-shrink:0 so it never over-squeezes
+              the text column; a long category label ellipsizes with a Tooltip
+              fallback instead of pushing the title/creator out. */}
+          <Stack gap={4} align="flex-end" style={{ flexShrink: 0, maxWidth: 150 }}>
+            {/* Kind badge — App (on-site) vs Connect app / Off-site (off-site).
+                Kind labels are short + fixed, so no truncation needed. */}
             <Badge
               variant="light"
               color={KIND_BADGE_COLOR[badge.kind]}
@@ -210,14 +247,14 @@ export function AppListingCard({ card, canOpenPage = false }: AppListingCardProp
             {card.category && (() => {
               const CategoryIcon = categoryIcon(card.category);
               return (
-                <Badge
+                <TruncatedBadge
                   variant="light"
                   color="grape"
                   size="sm"
+                  maw={150}
                   leftSection={<CategoryIcon size={12} />}
-                >
-                  {categoryLabel(card.category)}
-                </Badge>
+                  label={categoryLabel(card.category)}
+                />
               );
             })()}
           </Stack>
@@ -241,31 +278,50 @@ export function AppListingCard({ card, canOpenPage = false }: AppListingCardProp
             </Text>
           </Group>
 
-          {/* Kind-aware CTA — always has a working target (a direct Open / Visit,
-              or the unified detail). External Visit → new-tab anchor; everything
-              else → an internal Link. */}
-          {cta.external ? (
-            <Button
-              component="a"
-              href={cta.href}
-              target="_blank"
-              rel="noopener noreferrer"
-              size="xs"
-              variant="light"
-              rightSection={<IconExternalLink size={14} />}
-            >
-              {cta.label}
-            </Button>
-          ) : (
-            <Button
-              component={Link}
-              href={cta.href}
-              size="xs"
-              variant={cta.action === 'open' ? 'filled' : 'light'}
-            >
-              {cta.label}
-            </Button>
-          )}
+          <Group gap={6} wrap="nowrap">
+            {/* Owner-only "Edit" deep-link — subtle secondary action, gated by
+                owner + editable status (mod-removed listings hide it). Routes by
+                kind (manifest editor for on-site, submit editor for off-site). */}
+            {showEdit && editHref && (
+              <Button
+                component={Link}
+                href={editHref}
+                size="xs"
+                variant="default"
+                leftSection={<IconPencil size={14} />}
+                data-testid="apps-listing-owner-edit"
+                onClick={(e: MouseEvent) => e.stopPropagation()}
+              >
+                Edit
+              </Button>
+            )}
+
+            {/* Kind-aware CTA — always has a working target (a direct Open / Visit,
+                or the unified detail). External Visit → new-tab anchor; everything
+                else → an internal Link. */}
+            {cta.external ? (
+              <Button
+                component="a"
+                href={cta.href}
+                target="_blank"
+                rel="noopener noreferrer"
+                size="xs"
+                variant="light"
+                rightSection={<IconExternalLink size={14} />}
+              >
+                {cta.label}
+              </Button>
+            ) : (
+              <Button
+                component={Link}
+                href={cta.href}
+                size="xs"
+                variant={cta.action === 'open' ? 'filled' : 'light'}
+              >
+                {cta.label}
+              </Button>
+            )}
+          </Group>
         </Group>
       </Stack>
     </Card>

--- a/src/components/Apps/AppListingDetailBody.browser.test.tsx
+++ b/src/components/Apps/AppListingDetailBody.browser.test.tsx
@@ -1,0 +1,110 @@
+import { describe, expect, test, vi, beforeEach } from 'vitest';
+import { page } from 'vitest/browser';
+// `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
+import { renderWithProviders } from '../../../test/component-setup';
+import type { ListingDetail } from '~/server/schema/blocks/app-listing-read.schema';
+
+/**
+ * P2c AppListingDetailBody component tests (REPORT-ONLY — the browser project is
+ * non-blocking; the blocking gate is appListingDetailView.test.ts). These pin the
+ * owner "Edit" deep-link gating (Item 2) + the long-username tooltip fallback
+ * (Item 1) on the detail surface. The trpc-consuming children (reviews / report /
+ * comments) are mocked to null so this stays network-free and header-focused.
+ */
+
+const mocks = vi.hoisted(() => ({
+  currentUser: null as null | { id: number; username: string },
+}));
+
+vi.mock('~/hooks/useCurrentUser', () => ({
+  useCurrentUser: () => mocks.currentUser,
+}));
+
+// Header-focused: stub the trpc-backed children (reviews/report/comments) so the
+// test needs no tRPC wiring.
+vi.mock('~/components/Apps/ReviewListingButton', () => ({ ReviewListingButton: () => null }));
+vi.mock('~/components/Apps/ReportListingButton', () => ({ ReportListingButton: () => null }));
+vi.mock('~/components/Apps/AppListingReviews', () => ({ AppListingReviews: () => null }));
+vi.mock('~/components/Apps/AppListingComments', () => ({ AppListingComments: () => null }));
+
+// Import AFTER the mocks are declared (vi.mock is hoisted, imports are not).
+const { AppListingDetailBody } = await import('./AppListingDetailBody');
+
+beforeEach(() => {
+  mocks.currentUser = null;
+});
+
+function base(over: Partial<ListingDetail>): ListingDetail {
+  return {
+    id: 'l1',
+    serialId: 1,
+    slug: 'my-app',
+    kind: 'onsite',
+    name: 'My App',
+    tagline: 'A handy app',
+    description: null,
+    category: 'utility',
+    contentRating: null,
+    iconUrl: null,
+    coverUrl: null,
+    creator: { id: 5, username: 'alice', image: null },
+    recommend: { recommendedCount: 0, notRecommendedCount: 0, recommendPct: null },
+    reviewCount: 0,
+    screenshots: [],
+    kindData: { kind: 'onsite', appBlockId: 'blk-1', hasPage: true, liveUrl: 'https://my-app.civit.ai' },
+    ...over,
+  };
+}
+
+describe('AppListingDetailBody', () => {
+  test('owner sees the Edit deep-link → on-site manifest editor', async () => {
+    mocks.currentUser = { id: 5, username: 'alice' }; // matches base().creator.id
+    renderWithProviders(<AppListingDetailBody detail={base({})} />);
+    const edit = page.getByTestId('apps-listing-owner-edit');
+    await expect.element(edit).toBeInTheDocument();
+    await expect.element(edit).toHaveAttribute('href', '/apps/blk-1/edit-manifest');
+  });
+
+  test('owner of an off-site listing → Edit routes to the submit editor by listing id', async () => {
+    mocks.currentUser = { id: 5, username: 'alice' };
+    renderWithProviders(
+      <AppListingDetailBody
+        detail={base({
+          kind: 'offsite',
+          kindData: {
+            kind: 'offsite',
+            subKind: 'external-link',
+            externalUrl: 'https://ext.app',
+            connectClientId: null,
+          },
+        })}
+      />
+    );
+    await expect
+      .element(page.getByTestId('apps-listing-owner-edit'))
+      .toHaveAttribute('href', '/apps/submit?edit=l1');
+  });
+
+  test('non-owner does NOT see the Edit deep-link', async () => {
+    mocks.currentUser = { id: 999, username: 'bob' };
+    renderWithProviders(<AppListingDetailBody detail={base({})} />);
+    await expect.element(page.getByTestId('apps-listing-owner-edit')).not.toBeInTheDocument();
+  });
+
+  test('signed-out viewer does NOT see the Edit deep-link', async () => {
+    mocks.currentUser = null;
+    renderWithProviders(<AppListingDetailBody detail={base({})} />);
+    await expect.element(page.getByTestId('apps-listing-owner-edit')).not.toBeInTheDocument();
+  });
+
+  test('a long username reveals the full value in a tooltip on hover (clip fallback)', async () => {
+    const longName = 'a-really-long-creator-username-that-will-definitely-overflow-the-header-column';
+    renderWithProviders(
+      <AppListingDetailBody detail={base({ creator: { id: 5, username: longName, image: null } })} />
+    );
+    const label = page.getByText(`by ${longName}`);
+    await expect.element(label).toBeInTheDocument();
+    await label.hover();
+    await expect.element(page.getByText(longName, { exact: true })).toBeInTheDocument();
+  });
+});

--- a/src/components/Apps/AppListingDetailBody.tsx
+++ b/src/components/Apps/AppListingDetailBody.tsx
@@ -20,6 +20,7 @@ import {
   IconArrowLeft,
   IconExternalLink,
   IconInfoCircle,
+  IconPencil,
   IconPlugConnected,
   IconThumbUp,
 } from '@tabler/icons-react';
@@ -32,7 +33,13 @@ import {
   getRecommendLabel,
   type ListingBadgeKind,
 } from '~/components/Apps/appListingCardView';
-import { getDetailPrimaryAction } from '~/components/Apps/appListingDetailView';
+import {
+  canOwnerEditListing,
+  getDetailPrimaryAction,
+  getOwnerEditHref,
+} from '~/components/Apps/appListingDetailView';
+import { TruncatedBadge, TruncatedText } from '~/components/Apps/AppListingTruncate';
+import { useCurrentUser } from '~/hooks/useCurrentUser';
 import { AppListingComments } from '~/components/Apps/AppListingComments';
 import { ReportListingButton } from '~/components/Apps/ReportListingButton';
 import { ReviewListingButton } from '~/components/Apps/ReviewListingButton';
@@ -161,13 +168,20 @@ function CreatorChip({ creator }: { creator: ListingDetail['creator'] }) {
       underline="hover"
       c="dimmed"
     >
-      <Group gap={6} wrap="nowrap">
-        <Avatar src={avatarSrc} alt="" radius="xl" size={24}>
+      <Group gap={6} wrap="nowrap" style={{ minWidth: 0 }}>
+        <Avatar src={avatarSrc} alt="" radius="xl" size={24} style={{ flexShrink: 0 }}>
           {creator.username.charAt(0).toUpperCase()}
         </Avatar>
-        <Text size="sm" c="dimmed" lineClamp={1}>
-          by {creator.username}
-        </Text>
+        {/* Tuned to fit; Tooltip reveals a long username only when it still clips. */}
+        <TruncatedText
+          size="sm"
+          c="dimmed"
+          lineClamp={1}
+          tooltipLabel={creator.username}
+          style={{ minWidth: 0 }}
+        >
+          {`by ${creator.username}`}
+        </TruncatedText>
       </Group>
     </Anchor>
   );
@@ -292,10 +306,18 @@ export interface AppListingDetailBodyProps {
 }
 
 export function AppListingDetailBody({ detail, canOpenPage = false }: AppListingDetailBodyProps) {
+  const currentUser = useCurrentUser();
   const badge = getListingBadge(detail);
   const BadgeIcon = KIND_BADGE_ICON[badge.kind];
   const recommendLabel = getRecommendLabel(detail.recommend, detail.reviewCount);
   const hasRecommend = detail.recommend.recommendPct != null;
+
+  // Owner "Edit" deep-link (Item 2) — owner + editable status (approved-only read
+  // path carries no status → editable); the href builder returns null when there
+  // is no editable target (on-site listing with no backing appBlockId).
+  const isOwner = !!currentUser?.id && currentUser.id === detail.creator?.id;
+  const editHref = getOwnerEditHref(detail.kindData, detail.id);
+  const showEdit = canOwnerEditListing({ isOwner }) && !!editHref;
 
   return (
     <Stack gap="lg">
@@ -336,9 +358,14 @@ export function AppListingDetailBody({ detail, canOpenPage = false }: AppListing
               {detail.category && (() => {
                 const CategoryIcon = categoryIcon(detail.category);
                 return (
-                  <Badge variant="light" color="grape" size="sm" leftSection={<CategoryIcon size={12} />}>
-                    {categoryLabel(detail.category)}
-                  </Badge>
+                  <TruncatedBadge
+                    variant="light"
+                    color="grape"
+                    size="sm"
+                    maw={220}
+                    leftSection={<CategoryIcon size={12} />}
+                    label={categoryLabel(detail.category)}
+                  />
                 );
               })()}
               {detail.contentRating && (
@@ -352,6 +379,20 @@ export function AppListingDetailBody({ detail, canOpenPage = false }: AppListing
         <Box style={{ flexShrink: 0 }}>
           <Stack gap="xs" align="flex-end">
             <PrimaryAction detail={detail} canOpenPage={canOpenPage} />
+            {/* Owner-only "Edit" deep-link — subtle secondary action, gated by
+                owner + editable status (mod-removed listings hide it). Routes by
+                kind (manifest editor for on-site, submit editor for off-site). */}
+            {showEdit && editHref && (
+              <Button
+                component={Link}
+                href={editHref}
+                variant="default"
+                leftSection={<IconPencil size={16} />}
+                data-testid="apps-listing-owner-edit"
+              >
+                Edit
+              </Button>
+            )}
             {/* Review affordance (thumbs/recommend) — hidden for the owner + signed-out
                 viewers; the write proc is protected + flag-gated + self-review-blocked
                 server-side. Feeds the recommend metric below SYNCHRONOUSLY. */}

--- a/src/components/Apps/AppListingTruncate.tsx
+++ b/src/components/Apps/AppListingTruncate.tsx
@@ -33,7 +33,9 @@ export function useIsOverflowing<T extends HTMLElement = HTMLElement>() {
     measure();
     // ResizeObserver covers card reflow / responsive breakpoints without a
     // window resize listener (the AuctionPlacementCard OverflowTooltip missed
-    // resize — this fixes that gap).
+    // resize — this fixes that gap). Guard for environments without RO
+    // (defense-in-depth) — the one-shot measure() above still runs.
+    if (typeof ResizeObserver === 'undefined') return;
     const ro = new ResizeObserver(measure);
     ro.observe(el);
     return () => ro.disconnect();

--- a/src/components/Apps/AppListingTruncate.tsx
+++ b/src/components/Apps/AppListingTruncate.tsx
@@ -1,0 +1,108 @@
+import { Badge, Text, Tooltip } from '@mantine/core';
+import type { BadgeProps, TextProps } from '@mantine/core';
+import { useEffect, useRef, useState } from 'react';
+
+/**
+ * App Store Listings (W13) — shared truncation helpers for the store card +
+ * detail (Item 1: "tune to fit, tooltip fallback").
+ *
+ * The store header lays a creator username + kind/category badges into a
+ * `wrap="nowrap"` row; the design is tuned so those fit WITHOUT truncation in the
+ * common case (adequate `maw`/flex on the columns). These helpers add the last-
+ * resort fallback: a Mantine `Tooltip` that reveals the full value on hover ONLY
+ * when the text would actually still clip. Whether it clips is a runtime DOM
+ * measurement (`scrollWidth`/`scrollHeight` vs the client box) — not a pure
+ * decision — so it lives here in a measuring hook rather than the pure view-model.
+ */
+
+/**
+ * Measure whether the referenced element's content overflows its box (horizontal
+ * ellipsis OR vertical line-clamp). Re-measures on element resize so the verdict
+ * stays correct as the grid reflows. Returns a ref to attach to the clipping
+ * element + the current overflow verdict.
+ */
+export function useIsOverflowing<T extends HTMLElement = HTMLElement>() {
+  const ref = useRef<T>(null);
+  const [overflowing, setOverflowing] = useState(false);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    const measure = () =>
+      setOverflowing(el.scrollWidth > el.clientWidth || el.scrollHeight > el.clientHeight);
+    measure();
+    // ResizeObserver covers card reflow / responsive breakpoints without a
+    // window resize listener (the AuctionPlacementCard OverflowTooltip missed
+    // resize — this fixes that gap).
+    const ro = new ResizeObserver(measure);
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
+
+  return { ref, overflowing };
+}
+
+/**
+ * A `Text` that clips (via `lineClamp`/`truncate` passed through) and reveals its
+ * full value in a Tooltip ONLY when it actually clips. Rendered inline (`span`)
+ * so it composes inside the creator chip's Group.
+ */
+export function TruncatedText({
+  children,
+  tooltipLabel,
+  ...textProps
+}: { children: string; tooltipLabel?: string } & TextProps) {
+  const { ref, overflowing } = useIsOverflowing<HTMLParagraphElement>();
+  return (
+    <Tooltip
+      label={tooltipLabel ?? children}
+      disabled={!overflowing}
+      withinPortal
+      multiline
+      maw={320}
+      withArrow
+    >
+      <Text ref={ref} span {...textProps}>
+        {children}
+      </Text>
+    </Tooltip>
+  );
+}
+
+/**
+ * A `Badge` whose label clips to `maw` with an ellipsis and reveals the full label
+ * in a Tooltip ONLY when it clips. The inner `<span>` (not Mantine's label
+ * wrapper) does the clipping so the overflow is measurable; `leftSection` (the
+ * category glyph) is passed through and sits outside the measured span.
+ */
+export function TruncatedBadge({
+  label,
+  tooltipLabel,
+  ...badgeProps
+}: { label: string; tooltipLabel?: string } & Omit<BadgeProps, 'children'>) {
+  const { ref, overflowing } = useIsOverflowing<HTMLSpanElement>();
+  return (
+    <Tooltip
+      label={tooltipLabel ?? label}
+      disabled={!overflowing}
+      withinPortal
+      multiline
+      maw={320}
+      withArrow
+    >
+      <Badge {...badgeProps} styles={{ label: { overflow: 'visible' }, ...badgeProps.styles }}>
+        <span
+          ref={ref}
+          style={{
+            display: 'block',
+            overflow: 'hidden',
+            textOverflow: 'ellipsis',
+            whiteSpace: 'nowrap',
+          }}
+        >
+          {label}
+        </span>
+      </Badge>
+    </Tooltip>
+  );
+}

--- a/src/components/Apps/AppListingsMarketplaceBody.tsx
+++ b/src/components/Apps/AppListingsMarketplaceBody.tsx
@@ -22,9 +22,11 @@ import { trpc } from '~/utils/trpc';
  * empty/loading states. Mirrors the structure of the live `MarketplaceBody` so
  * the two feel identical.
  *
- * DARK / parallel-run: mounted only by the mod-only `/apps/store-preview`
- * surface. The default `/apps` render (MarketplaceBody → AppBlockCard) is
- * untouched; the cutover is a later PR (P2d).
+ * LIVE (P2d cut over): this is now the DEFAULT `/apps` store grid (see
+ * `src/pages/apps/index.tsx`), replacing the legacy `MarketplaceBody` →
+ * `AppBlockCard` path (retained in the tree as a one-line rollback). The page is
+ * still flag-gated (the App Blocks Flipt segment + `deIndex`) — no longer
+ * "store-preview only".
  *
  * ⚠️ Search gap: the P2a `listAvailable` input has NO `query` field (kind /
  * category / sort / cursor / limit only). Server-side search would need a P2a

--- a/src/components/Apps/__tests__/appListingCardView.test.ts
+++ b/src/components/Apps/__tests__/appListingCardView.test.ts
@@ -1,9 +1,12 @@
 import { describe, expect, it } from 'vitest';
 import {
+  canOwnerEditListing,
   getListingBadge,
   getListingCta,
   getListingDetailHref,
+  getOwnerEditHref,
   getRecommendLabel,
+  isEditableListingStatus,
   safeExternalHref,
 } from '~/components/Apps/appListingCardView';
 import type {
@@ -193,5 +196,63 @@ describe('getListingCta — off-site (P2c: View details → unified detail)', ()
       href: '/apps/store-preview/ext-app',
       external: false,
     });
+  });
+});
+
+describe('getOwnerEditHref (owner Edit deep-link)', () => {
+  it('on-site → the manifest editor keyed on appBlockId', () => {
+    expect(getOwnerEditHref({ kind: 'onsite', appBlockId: 'blk-1' }, 'l1')).toBe(
+      '/apps/blk-1/edit-manifest'
+    );
+  });
+  it('on-site with no backing appBlockId → null (no editable target → hide)', () => {
+    expect(getOwnerEditHref({ kind: 'onsite', appBlockId: null }, 'l1')).toBeNull();
+  });
+  it('off-site → the submit editor keyed on the listing id', () => {
+    expect(getOwnerEditHref({ kind: 'offsite' }, 'l2')).toBe('/apps/submit?edit=l2');
+  });
+  it('accepts the full card kindData (extra fields are ignored)', () => {
+    expect(getOwnerEditHref(onsiteCard({ hasPage: true, appBlockId: 'blk-9' }).kindData, 'l1')).toBe(
+      '/apps/blk-9/edit-manifest'
+    );
+    expect(getOwnerEditHref(offsiteCard('connect', null).kindData, 'l2')).toBe(
+      '/apps/submit?edit=l2'
+    );
+  });
+  it('encodes odd ids (defense in depth)', () => {
+    expect(getOwnerEditHref({ kind: 'onsite', appBlockId: 'a b/c' }, 'l1')).toBe(
+      '/apps/a%20b%2Fc/edit-manifest'
+    );
+    expect(getOwnerEditHref({ kind: 'offsite' }, 'a b/c')).toBe('/apps/submit?edit=a%20b%2Fc');
+  });
+});
+
+describe('isEditableListingStatus / canOwnerEditListing (owner Edit gating)', () => {
+  it('no status (approved-only store DTO) → editable', () => {
+    expect(isEditableListingStatus(null)).toBe(true);
+    expect(isEditableListingStatus(undefined)).toBe(true);
+  });
+  it('editable lifecycle statuses → editable', () => {
+    expect(isEditableListingStatus('draft')).toBe(true);
+    expect(isEditableListingStatus('pending')).toBe(true);
+    expect(isEditableListingStatus('approved')).toBe(true);
+  });
+  it('mod-removed / rejected → NOT editable', () => {
+    expect(isEditableListingStatus('removed')).toBe(false);
+    expect(isEditableListingStatus('rejected')).toBe(false);
+  });
+
+  it('owner + editable → show', () => {
+    expect(canOwnerEditListing({ isOwner: true })).toBe(true);
+    expect(canOwnerEditListing({ isOwner: true, status: 'approved' })).toBe(true);
+    expect(canOwnerEditListing({ isOwner: true, status: 'pending' })).toBe(true);
+  });
+  it('non-owner → hide (even for an editable status)', () => {
+    expect(canOwnerEditListing({ isOwner: false })).toBe(false);
+    expect(canOwnerEditListing({ isOwner: false, status: 'approved' })).toBe(false);
+  });
+  it('owner but mod-removed / rejected → hide', () => {
+    expect(canOwnerEditListing({ isOwner: true, status: 'removed' })).toBe(false);
+    expect(canOwnerEditListing({ isOwner: true, status: 'rejected' })).toBe(false);
   });
 });

--- a/src/components/Apps/__tests__/appListingDetailView.test.ts
+++ b/src/components/Apps/__tests__/appListingDetailView.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { getDetailPrimaryAction } from '~/components/Apps/appListingDetailView';
+import {
+  canOwnerEditListing,
+  getDetailPrimaryAction,
+  getOwnerEditHref,
+  isEditableListingStatus,
+} from '~/components/Apps/appListingDetailView';
 import type { ListingDetail } from '~/server/schema/blocks/app-listing-read.schema';
 
 /**
@@ -139,5 +144,30 @@ describe('getDetailPrimaryAction — off-site', () => {
     expect(action.href).toBeUndefined();
     expect(action.external).toBe(false);
     expect(action.note).toBeTruthy();
+  });
+});
+
+describe('owner Edit deep-link + gating (on the detail view-model)', () => {
+  it('on-site detail kindData → the manifest editor (extra fields ignored)', () => {
+    expect(
+      getOwnerEditHref(onsiteDetail({ hasPage: true, appBlockId: 'blk-7' }).kindData, 'l1')
+    ).toBe('/apps/blk-7/edit-manifest');
+  });
+  it('on-site with no appBlockId → null (no editable target → hide)', () => {
+    expect(getOwnerEditHref(onsiteDetail({ hasPage: false, appBlockId: null }).kindData, 'l1')).toBeNull();
+  });
+  it('off-site detail kindData → the submit editor keyed on the listing id', () => {
+    expect(getOwnerEditHref(offsiteDetail('external-link', { externalUrl: 'https://x' }).kindData, 'l2')).toBe(
+      '/apps/submit?edit=l2'
+    );
+    expect(getOwnerEditHref(offsiteDetail('connect').kindData, 'l2')).toBe('/apps/submit?edit=l2');
+  });
+
+  it('owner + editable → show; non-owner → hide; mod-removed → hide', () => {
+    expect(canOwnerEditListing({ isOwner: true })).toBe(true);
+    expect(canOwnerEditListing({ isOwner: false })).toBe(false);
+    expect(canOwnerEditListing({ isOwner: true, status: 'removed' })).toBe(false);
+    expect(isEditableListingStatus('approved')).toBe(true);
+    expect(isEditableListingStatus('removed')).toBe(false);
   });
 });

--- a/src/components/Apps/appListingCardView.ts
+++ b/src/components/Apps/appListingCardView.ts
@@ -6,9 +6,12 @@
  * project (the civitai browser-mode component suites are REPORT-ONLY / non-
  * blocking — so the real, blocking test coverage for this behaviour is here).
  *
- * DARK / parallel-run: consumed only by the mod-only `/apps/store-preview`
- * preview surface. The default `/apps` render (MarketplaceBody → AppBlockCard)
- * is untouched; the cutover is a later PR (P2d).
+ * LIVE (P2d cut over): this view-model now backs the DEFAULT `/apps` store grid
+ * (`AppListingsMarketplaceBody` → `AppListingCard`), reading the unified
+ * `AppListing` record over BOTH kinds. The page remains flag-gated (the App
+ * Blocks Flipt segment + `deIndex`) — not "store-preview only" any more. The
+ * unified DETAIL still lives at `/apps/store-preview/<slug>`
+ * (`getListingDetailHref`).
  *
  * CTA target policy (P2c — the unified dark listing detail now exists at
  * `/apps/store-preview/<slug>`, so every card can reach a real detail surface and
@@ -34,6 +37,7 @@ import type {
   ListingCard,
   ListingRecommendRollup,
 } from '~/server/schema/blocks/app-listing-read.schema';
+import type { AppListingStatus } from '~/server/services/blocks/app-listing-status.constants';
 
 /** Kind badge shown on the card face. */
 export type ListingBadgeKind = 'onsite' | 'connect' | 'external-link';
@@ -136,4 +140,61 @@ export function getListingCta(
 
   // Off-site connect (OAuth) — the Connect affordance lives on the detail page.
   return { label: 'View details', action: 'detail', href: detailHref, external: false };
+}
+
+// ---------------------------------------------------------------------------
+// Owner "Edit" deep-link (Item 2) — pure gating + href builders, shared by the
+// store card + detail. Mirrors the my-submissions edit gating
+// (`MySubmissionsList` `showEdit` / `OffsiteSubmissionsList` `canEdit`): the
+// owner can edit an app that is still editable (NOT mod-removed / rejected).
+// ---------------------------------------------------------------------------
+
+/** Statuses whose backing listing an owner can still edit (mirrors the my-
+ *  submissions gating: a `removed`/`rejected` listing is NOT editable). */
+const EDITABLE_LISTING_STATUSES: readonly AppListingStatus[] = ['draft', 'pending', 'approved'];
+
+/**
+ * Is a listing in an owner-editable status? The public store read path is
+ * approved-only and its allowlist DTO deliberately carries NO status field, so
+ * the card/detail call this with `null`/`undefined` → treated as editable (an
+ * approved, live listing). A `removed` (mod takedown) / `rejected` status is
+ * never editable — so if a status is ever threaded in, the gate stays correct.
+ */
+export function isEditableListingStatus(status?: AppListingStatus | null): boolean {
+  if (status == null) return true;
+  return EDITABLE_LISTING_STATUSES.includes(status);
+}
+
+/**
+ * Show the owner "Edit" affordance? True only for the listing owner AND an
+ * editable status. Non-owners never see it; a mod-removed / rejected listing is
+ * not editable even for the owner (mirrors `showEdit` / `canEdit`).
+ */
+export function canOwnerEditListing(opts: {
+  isOwner: boolean;
+  status?: AppListingStatus | null;
+}): boolean {
+  return opts.isOwner && isEditableListingStatus(opts.status);
+}
+
+/**
+ * The owner "Edit" deep-link target, by kind:
+ *   - on-site  → `/apps/<appBlockId>/edit-manifest` (the manifest editor). Null
+ *     when the on-site listing has no backing `appBlockId` (nothing to edit) —
+ *     the caller then hides the button rather than routing to a dead link.
+ *   - off-site → `/apps/submit?edit=<listingId>` (the off-site submit editor,
+ *     keyed on the AppListing id).
+ * Structurally accepts both the card + detail `kindData` (only `kind` +
+ * `appBlockId` are read). `null` = no editable target → don't render Edit.
+ */
+export function getOwnerEditHref(
+  kindData: { kind: 'onsite'; appBlockId: string | null } | { kind: 'offsite' },
+  listingId: string
+): string | null {
+  if (kindData.kind === 'onsite') {
+    return kindData.appBlockId
+      ? `/apps/${encodeURIComponent(kindData.appBlockId)}/edit-manifest`
+      : null;
+  }
+  return `/apps/submit?edit=${encodeURIComponent(listingId)}`;
 }

--- a/src/components/Apps/appListingDetailView.ts
+++ b/src/components/Apps/appListingDetailView.ts
@@ -33,6 +33,17 @@ import { safeExternalHref } from '~/components/Apps/appListingCardView';
 import type { ListingDetail } from '~/server/schema/blocks/app-listing-read.schema';
 
 /**
+ * Owner "Edit" deep-link gating + href builders are shared with the store card,
+ * so they live in the base card view-model. Re-exported here so the detail body
+ * (and its unit test) import the owner-edit logic from the DETAIL view-model.
+ */
+export {
+  canOwnerEditListing,
+  getOwnerEditHref,
+  isEditableListingStatus,
+} from '~/components/Apps/appListingCardView';
+
+/**
  * Primary-action mode:
  *   - `open`    → internal nav to the in-host page runner.
  *   - `visit`   → external new-tab anchor (Visit / Open live).


### PR DESCRIPTION
## What

Two App-marketplace UX fixes on the store card (`AppListingCard`) + listing detail (`AppListingDetailBody`).

### Item 1 — text truncation (tune to fit, tooltip fallback)
- **Tuned the header layout to fit without truncation in the common case:** the text column now takes the row's slack (`flex: 1` + `minWidth: 0`) and the badge column is width-capped + `flex-shrink: 0`, so a long category label can no longer over-squeeze the title/creator username.
- **Added a Tooltip fallback for the rare clip:** a new reusable `AppListingTruncate` module (`useIsOverflowing` ResizeObserver hook + `TruncatedText` / `TruncatedBadge`) reveals the full username / category label on hover **only when it would still clip**. Applied to both card + detail.

### Item 2 — owner "Edit" deep-link (card + detail)
- Owner-only, **editable-status-gated** (mirrors the my-submissions `showEdit` / `canEdit` gating — a mod-removed / rejected listing hides it).
- Routes by kind: **on-site** → `/apps/<appBlockId>/edit-manifest`; **off-site** → `/apps/submit?edit=<listingId>`. Subtle secondary `Button` + `IconPencil`, `data-testid="apps-listing-owner-edit"`.

### Reuse + purity
- Pure logic (owner-edit **href builder** + **owner/editable gating predicate**) lives in the view-model modules (`appListingCardView.ts`, re-exported from `appListingDetailView.ts`) — unit-testable, not buried in JSX.
- Fixed **stale docstrings** (`AppListingCard.tsx`, `appListingCardView.ts`, `AppListingsMarketplaceBody.tsx`) that still claimed "DARK / store-preview only" — the store-card grid is the live `/apps` grid post-P2d (still flag-gated).

## Notes / gating
- This surface is **dark / flag-gated** (the App Blocks Flipt segment + `deIndex`); the owner Edit is additionally **owner + editable-status gated**. The public store read path is approved-only and its allowlist DTO carries **no status field** — so the predicate models the mod-removed exclusion for correctness/future, while server-side the removed listings never reach this read at all.
- **pr-preview** and **/audit-pr** are the verification gates. The mod-gated UI still needs a **human preview click-through** — the owner Edit visibility + tooltip-on-clip weren't reproduced in a real browser here.

## Tests
- **Blocking pure suites** (node `unit`): extended `appListingCardView.test.ts` + `appListingDetailView.test.ts` for the owner-edit href (on-site vs off-site, missing appBlockId → null) + the owner/editable gating (owner+editable → show, non-owner → hide, mod-removed/rejected → hide). **44 tests pass** across the two files.
- **Report-only browser** (`AppListingCard.browser.test.tsx` extended + new `AppListingDetailBody.browser.test.tsx`): Edit visible + routes for owner, hidden for non-owner/signed-out, and the clipped-username tooltip — `useCurrentUser` mocked. Not run locally (no headless Chromium); CI runs it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)