### PR TITLE
fix(model-files): keep file names readable in the file list

### DIFF
--- a/src/components/Auction/AuctionPlacementCard.tsx
+++ b/src/components/Auction/AuctionPlacementCard.tsx
@@ -229,7 +229,7 @@ const OverflowTooltip = ({
   searchText,
   ...highlightProps
 }: { label: string; searchText: string } & Omit<HighlightProps, 'highlight' | 'children'>) => {
-  const { ref, overflown } = useIsOverflown<HTMLDivElement>();
+  const { ref, overflown } = useIsOverflown<HTMLDivElement>([label]);
 
   return (
     <Tooltip label={label} disabled={!overflown} withinPortal multiline>

--- a/src/components/Auction/AuctionPlacementCard.tsx
+++ b/src/components/Auction/AuctionPlacementCard.tsx
@@ -48,6 +48,7 @@ import { useScrollAreaRef } from '~/components/ScrollArea/ScrollAreaContext';
 import { UserAvatar } from '~/components/UserAvatar/UserAvatar';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
 import { useIsMobile } from '~/hooks/useIsMobile';
+import { useIsOverflown } from '~/hooks/useIsOverflown';
 import { useBrowsingSettings } from '~/providers/BrowserSettingsProvider';
 import type {
   GetAuctionBySlugReturn,
@@ -228,22 +229,12 @@ const OverflowTooltip = ({
   searchText,
   ...highlightProps
 }: { label: string; searchText: string } & Omit<HighlightProps, 'highlight' | 'children'>) => {
-  const textElementRef = useRef<HTMLDivElement>(null);
-  const [isOverflown, setIsOverflown] = useState(false);
-
-  // TODO this doesnt appear to listen for changes when resizing
-  useEffect(() => {
-    const element = textElementRef.current;
-    const compare = element
-      ? element.offsetWidth < element.scrollWidth || element.offsetHeight < element.scrollHeight
-      : false;
-    setIsOverflown(compare);
-  }, []);
+  const { ref, overflown } = useIsOverflown<HTMLDivElement>();
 
   return (
-    <Tooltip label={label} disabled={!isOverflown} withinPortal multiline>
+    <Tooltip label={label} disabled={!overflown} withinPortal multiline>
       <Highlight
-        ref={textElementRef}
+        ref={ref}
         className="min-w-0 max-w-[min(400px,80vw)] truncate"
         highlight={searchText}
         {...highlightProps}

--- a/src/components/Resource/Files.tsx
+++ b/src/components/Resource/Files.tsx
@@ -294,7 +294,7 @@ export function Files({ showRenameOnPrimary }: { showRenameOnPrimary?: boolean }
             preferences.
           </Text>
         </Card.Section>
-        <Stack gap="sm" p="md">
+        <Stack gap="sm" pt="md">
           {modelFiles.length > 0 ? (
             <>
               {modelFiles.map((file) => (
@@ -369,7 +369,7 @@ export function Files({ showRenameOnPrimary }: { showRenameOnPrimary?: boolean }
             Components and files that accompany this model. Mark each as required or optional.
           </Text>
         </Card.Section>
-        <Stack gap="sm" p="md">
+        <Stack gap="sm" pt="md">
           {!hasAdditionalContent && (
             <Stack gap="xs" align="center" py="md">
               <IconLayersLinked
@@ -666,45 +666,47 @@ function FileCard({
       p="sm"
     >
       <Group gap="md">
-        <ThemeIcon size={40} radius="sm" color={iconConfig.color} variant="light">
-          <FileIcon size={20} />
-        </ThemeIcon>
-        <div style={{ flex: 1, minWidth: 220 }}>
-          <Tooltip label={displayName} openDelay={300}>
-            <Text size="sm" fw={500} c={failedUpload ? 'red' : 'white'} truncate>
-              {displayName}
-            </Text>
-          </Tooltip>
-          <Group gap={6} wrap="nowrap">
-            <Text size="xs" c="dimmed">
-              {[fileSizeStr, formatLabel].filter(Boolean).join(' \u2022 ')}
-            </Text>
-            {isMissingRequiredInfo(versionFile) && (
-              <Badge color="yellow" variant="light" size="xs">
-                Needs info
-              </Badge>
-            )}
-          </Group>
-          {versionFile.isCheckingOfficial && (
-            <Group gap={6} wrap="nowrap" mt={4}>
-              <Loader size="xs" />
-              <Text size="xs" c="dimmed">
-                Checking for an existing copy on Civitai&hellip;
+        <Group gap="md" wrap="nowrap" style={{ flex: 1, minWidth: 220 }}>
+          <ThemeIcon size={40} radius="sm" color={iconConfig.color} variant="light">
+            <FileIcon size={20} />
+          </ThemeIcon>
+          <div style={{ flex: 1, minWidth: 0 }}>
+            <Tooltip label={displayName} openDelay={300}>
+              <Text size="sm" fw={500} c={failedUpload ? 'red' : 'white'} truncate>
+                {displayName}
               </Text>
+            </Tooltip>
+            <Group gap={6} wrap="nowrap">
+              <Text size="xs" c="dimmed">
+                {[fileSizeStr, formatLabel].filter(Boolean).join(' \u2022 ')}
+              </Text>
+              {isMissingRequiredInfo(versionFile) && (
+                <Badge color="yellow" variant="light" size="xs">
+                  Needs info
+                </Badge>
+              )}
             </Group>
-          )}
-          {showRequiredToggle && !versionFile.isUploading && !versionFile.isCheckingOfficial && (
-            <Switch
-              size="xs"
-              label="Required"
-              checked={versionFile.isRequired ?? false}
-              onChange={(e) =>
-                updateFile(versionFile.uuid, { isRequired: e.currentTarget.checked })
-              }
-              mt={4}
-            />
-          )}
-        </div>
+            {versionFile.isCheckingOfficial && (
+              <Group gap={6} wrap="nowrap" mt={4}>
+                <Loader size="xs" />
+                <Text size="xs" c="dimmed">
+                  Checking for an existing copy on Civitai&hellip;
+                </Text>
+              </Group>
+            )}
+            {showRequiredToggle && !versionFile.isUploading && !versionFile.isCheckingOfficial && (
+              <Switch
+                size="xs"
+                label="Required"
+                checked={versionFile.isRequired ?? false}
+                onChange={(e) =>
+                  updateFile(versionFile.uuid, { isRequired: e.currentTarget.checked })
+                }
+                mt={4}
+              />
+            )}
+          </div>
+        </Group>
         {/* Selects render during upload too, so the user can set type/precision/
             size/quant while the bytes upload — the save reads the latest via
             filesRef. */}

--- a/src/components/Resource/Files.tsx
+++ b/src/components/Resource/Files.tsx
@@ -44,6 +44,7 @@ import { useFilesContext } from '~/components/Resource/FilesProvider';
 import type { ModelFileType, ZipModelFileType } from '~/server/common/constants';
 import { componentFileTypes, constants, zipModelFileTypes } from '~/server/common/constants';
 import { baseModelHasFileSize } from '~/shared/constants/basemodel.constants';
+import { useIsOverflown } from '~/hooks/useIsOverflown';
 import { useModelFileOptions } from '~/hooks/useModelFileOptions';
 import { useS3UploadStore } from '~/store/s3-upload.store';
 import { removeDuplicates } from '~/utils/array-helpers';
@@ -643,6 +644,7 @@ function FileCard({
   };
 
   const displayName = versionFile.overrideName ?? versionFile.name;
+  const { ref: nameRef, overflown: nameOverflown } = useIsOverflown<HTMLParagraphElement>();
   const iconConfig = getFileIconConfig(versionFile.name, {
     format: versionFile.format,
   });
@@ -666,13 +668,21 @@ function FileCard({
       p="sm"
     >
       <Group gap="md">
-        <Group gap="md" wrap="nowrap" style={{ flex: 1, minWidth: 220 }}>
+        <Group gap="md" wrap="nowrap" style={{ flex: '1 1 220px', minWidth: 0 }}>
           <ThemeIcon size={40} radius="sm" color={iconConfig.color} variant="light">
             <FileIcon size={20} />
           </ThemeIcon>
           <div style={{ flex: 1, minWidth: 0 }}>
-            <Tooltip label={displayName} openDelay={300}>
-              <Text size="sm" fw={500} c={failedUpload ? 'red' : 'white'} truncate>
+            <Tooltip
+              label={displayName}
+              disabled={!nameOverflown}
+              openDelay={300}
+              withinPortal
+              multiline
+              maw={420}
+              style={{ overflowWrap: 'anywhere' }}
+            >
+              <Text ref={nameRef} size="sm" fw={500} c={failedUpload ? 'red' : 'white'} truncate>
                 {displayName}
               </Text>
             </Tooltip>

--- a/src/components/Resource/Files.tsx
+++ b/src/components/Resource/Files.tsx
@@ -644,7 +644,9 @@ function FileCard({
   };
 
   const displayName = versionFile.overrideName ?? versionFile.name;
-  const { ref: nameRef, overflown: nameOverflown } = useIsOverflown<HTMLParagraphElement>();
+  const { ref: nameRef, overflown: nameOverflown } = useIsOverflown<HTMLParagraphElement>([
+    displayName,
+  ]);
   const iconConfig = getFileIconConfig(versionFile.name, {
     format: versionFile.format,
   });

--- a/src/components/Resource/Files.tsx
+++ b/src/components/Resource/Files.tsx
@@ -734,11 +734,7 @@ function FileCard({
               withinPortal
             >
               <Popover.Target>
-                <LegacyActionIcon
-                  onClick={handleRenameOpen}
-                  style={{ marginTop: 18 }}
-                  title="Rename download file"
-                >
+                <LegacyActionIcon onClick={handleRenameOpen} title="Rename download file">
                   <IconPencil size={16} />
                 </LegacyActionIcon>
               </Popover.Target>
@@ -773,7 +769,6 @@ function FileCard({
               color="red"
               onClick={() => handleRemoveFile(versionFile.uuid)}
               loading={deleteFileMutation.isPending}
-              style={{ marginTop: 18 }}
             >
               <IconTrash size={16} />
             </LegacyActionIcon>

--- a/src/components/Resource/Files.tsx
+++ b/src/components/Resource/Files.tsx
@@ -642,6 +642,7 @@ function FileCard({
     renameFileMutation.mutate({ id: versionFile.id, overrideName: next });
   };
 
+  const displayName = versionFile.overrideName ?? versionFile.name;
   const iconConfig = getFileIconConfig(versionFile.name, {
     format: versionFile.format,
   });
@@ -664,14 +665,19 @@ function FileCard({
       withBorder
       p="sm"
     >
-      <Group gap="md" wrap="nowrap">
+      <Group gap="md">
         <ThemeIcon size={40} radius="sm" color={iconConfig.color} variant="light">
           <FileIcon size={20} />
         </ThemeIcon>
-        <div style={{ flex: 1, minWidth: 0 }}>
-          <Group gap={6} wrap="nowrap">
+        <div style={{ flex: 1, minWidth: 220 }}>
+          <Tooltip label={displayName} openDelay={300}>
             <Text size="sm" fw={500} c={failedUpload ? 'red' : 'white'} truncate>
-              {versionFile.overrideName ?? versionFile.name}
+              {displayName}
+            </Text>
+          </Tooltip>
+          <Group gap={6} wrap="nowrap">
+            <Text size="xs" c="dimmed">
+              {[fileSizeStr, formatLabel].filter(Boolean).join(' \u2022 ')}
             </Text>
             {isMissingRequiredInfo(versionFile) && (
               <Badge color="yellow" variant="light" size="xs">
@@ -679,9 +685,6 @@ function FileCard({
               </Badge>
             )}
           </Group>
-          <Text size="xs" c="dimmed">
-            {[fileSizeStr, formatLabel].filter(Boolean).join(' \u2022 ')}
-          </Text>
           {versionFile.isCheckingOfficial && (
             <Group gap={6} wrap="nowrap" mt={4}>
               <Loader size="xs" />
@@ -705,7 +708,7 @@ function FileCard({
         {/* Selects render during upload too, so the user can set type/precision/
             size/quant while the bytes upload — the save reads the latest via
             filesRef. */}
-        <Group gap="xs" wrap="nowrap" align="flex-end">
+        <Group gap="xs" align="flex-end">
           <FileEditForm file={versionFile} fileTypes={fileTypes} index={index} />
           {!versionFile.isUploading && showRename && versionFile.id && !trackedFile && (
             <Popover
@@ -1014,7 +1017,7 @@ function FileEditForm({
   const showMetadataSelects = isCheckpoint || isComponentFile;
 
   return (
-    <Group gap="xs" align="flex-end" wrap="nowrap">
+    <Group gap="xs" align="flex-end">
       <div>
         <SelectLabel>Type</SelectLabel>
         <Select

--- a/src/components/Resource/FilesEditModal.tsx
+++ b/src/components/Resource/FilesEditModal.tsx
@@ -1,4 +1,15 @@
-import { Anchor, Button, Center, Group, Loader, Modal, Stack, Text, Title } from '@mantine/core';
+import {
+  Anchor,
+  Button,
+  Center,
+  Container,
+  Group,
+  Loader,
+  Modal,
+  Stack,
+  Text,
+  Title,
+} from '@mantine/core';
 import { IconArrowLeft } from '@tabler/icons-react';
 import { NextLink as Link } from '~/components/NextLink/NextLink';
 
@@ -43,44 +54,46 @@ export default function FilesEditModal({ modelVersionId }: { modelVersionId: num
 
   return (
     <Modal {...dialog} withCloseButton={false} closeOnEscape={false} fullScreen>
-      {isLoading ? (
-        <Center>
-          <Loader size="lg" />
-        </Center>
-      ) : modelVersion ? (
-        <FilesProvider model={modelVersion?.model} version={modelVersion}>
-          <Stack gap="xl">
-            <Group justify="space-between" align="flex-start" wrap="nowrap">
-              <Stack gap={8}>
-                <Link
-                  legacyBehavior
-                  href={getModelUrl({
-                    modelId: modelVersion.model.id,
-                    modelName: modelVersion.model.name,
-                  })}
-                  passHref
-                  shallow
-                >
-                  <Anchor size="xs">
-                    <Group gap={4}>
-                      <IconArrowLeft size={12} />
-                      <Text inherit>Back to {modelVersion?.model?.name} page</Text>
-                    </Group>
-                  </Anchor>
-                </Link>
-                <Title order={1}>Manage Files</Title>
-                <Text size="sm" c="dimmed">
-                  {modelVersion.model.name} &bull; {modelVersion.name}
-                </Text>
-              </Stack>
-              <SaveButton />
-            </Group>
-            <Files showRenameOnPrimary={isTrained} />
-          </Stack>
-        </FilesProvider>
-      ) : (
-        <NotFound />
-      )}
+      <Container size="xl">
+        {isLoading ? (
+          <Center>
+            <Loader size="lg" />
+          </Center>
+        ) : modelVersion ? (
+          <FilesProvider model={modelVersion?.model} version={modelVersion}>
+            <Stack gap="xl">
+              <Group justify="space-between" align="flex-start" wrap="nowrap">
+                <Stack gap={8}>
+                  <Link
+                    legacyBehavior
+                    href={getModelUrl({
+                      modelId: modelVersion.model.id,
+                      modelName: modelVersion.model.name,
+                    })}
+                    passHref
+                    shallow
+                  >
+                    <Anchor size="xs">
+                      <Group gap={4}>
+                        <IconArrowLeft size={12} />
+                        <Text inherit>Back to {modelVersion?.model?.name} page</Text>
+                      </Group>
+                    </Anchor>
+                  </Link>
+                  <Title order={1}>Manage Files</Title>
+                  <Text size="sm" c="dimmed">
+                    {modelVersion.model.name} &bull; {modelVersion.name}
+                  </Text>
+                </Stack>
+                <SaveButton />
+              </Group>
+              <Files showRenameOnPrimary={isTrained} />
+            </Stack>
+          </FilesProvider>
+        ) : (
+          <NotFound />
+        )}
+      </Container>
     </Modal>
   );
 }

--- a/src/components/Resource/FilesEditModal.tsx
+++ b/src/components/Resource/FilesEditModal.tsx
@@ -1,15 +1,4 @@
-import {
-  Anchor,
-  Button,
-  Center,
-  Container,
-  Group,
-  Loader,
-  Modal,
-  Stack,
-  Text,
-  Title,
-} from '@mantine/core';
+import { Anchor, Button, Center, Group, Loader, Modal, Stack, Text, Title } from '@mantine/core';
 import { IconArrowLeft } from '@tabler/icons-react';
 import { NextLink as Link } from '~/components/NextLink/NextLink';
 
@@ -52,49 +41,46 @@ export default function FilesEditModal({ modelVersionId }: { modelVersionId: num
 
   const isTrained = modelVersion?.model?.uploadType === ModelUploadType.Trained;
 
-
   return (
     <Modal {...dialog} withCloseButton={false} closeOnEscape={false} fullScreen>
-      <Container size="md">
-        {isLoading ? (
-          <Center>
-            <Loader size="lg" />
-          </Center>
-        ) : modelVersion ? (
-          <FilesProvider model={modelVersion?.model} version={modelVersion}>
-            <Stack gap="xl">
-              <Group justify="space-between" align="flex-start" wrap="nowrap">
-                <Stack gap={8}>
-                  <Link
-                    legacyBehavior
-                    href={getModelUrl({
-                      modelId: modelVersion.model.id,
-                      modelName: modelVersion.model.name,
-                    })}
-                    passHref
-                    shallow
-                  >
-                    <Anchor size="xs">
-                      <Group gap={4}>
-                        <IconArrowLeft size={12} />
-                        <Text inherit>Back to {modelVersion?.model?.name} page</Text>
-                      </Group>
-                    </Anchor>
-                  </Link>
-                  <Title order={1}>Manage Files</Title>
-                  <Text size="sm" c="dimmed">
-                    {modelVersion.model.name} &bull; {modelVersion.name}
-                  </Text>
-                </Stack>
-                <SaveButton />
-              </Group>
-              <Files showRenameOnPrimary={isTrained} />
-            </Stack>
-          </FilesProvider>
-        ) : (
-          <NotFound />
-        )}
-      </Container>
+      {isLoading ? (
+        <Center>
+          <Loader size="lg" />
+        </Center>
+      ) : modelVersion ? (
+        <FilesProvider model={modelVersion?.model} version={modelVersion}>
+          <Stack gap="xl">
+            <Group justify="space-between" align="flex-start" wrap="nowrap">
+              <Stack gap={8}>
+                <Link
+                  legacyBehavior
+                  href={getModelUrl({
+                    modelId: modelVersion.model.id,
+                    modelName: modelVersion.model.name,
+                  })}
+                  passHref
+                  shallow
+                >
+                  <Anchor size="xs">
+                    <Group gap={4}>
+                      <IconArrowLeft size={12} />
+                      <Text inherit>Back to {modelVersion?.model?.name} page</Text>
+                    </Group>
+                  </Anchor>
+                </Link>
+                <Title order={1}>Manage Files</Title>
+                <Text size="sm" c="dimmed">
+                  {modelVersion.model.name} &bull; {modelVersion.name}
+                </Text>
+              </Stack>
+              <SaveButton />
+            </Group>
+            <Files showRenameOnPrimary={isTrained} />
+          </Stack>
+        </FilesProvider>
+      ) : (
+        <NotFound />
+      )}
     </Modal>
   );
 }

--- a/src/hooks/useIsOverflown.ts
+++ b/src/hooks/useIsOverflown.ts
@@ -1,0 +1,23 @@
+import { useEffect, useRef, useState } from 'react';
+
+export function useIsOverflown<T extends HTMLElement = HTMLDivElement>() {
+  const ref = useRef<T>(null);
+  const [overflown, setOverflown] = useState(false);
+
+  useEffect(() => {
+    const element = ref.current;
+    if (!element) return;
+
+    const check = () =>
+      setOverflown(
+        element.offsetWidth < element.scrollWidth || element.offsetHeight < element.scrollHeight
+      );
+
+    check();
+    const observer = new ResizeObserver(check);
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, []);
+
+  return { ref, overflown };
+}

--- a/src/hooks/useIsOverflown.ts
+++ b/src/hooks/useIsOverflown.ts
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 
-export function useIsOverflown<T extends HTMLElement = HTMLDivElement>() {
+export function useIsOverflown<T extends HTMLElement = HTMLDivElement>(deps: unknown[] = []) {
   const ref = useRef<T>(null);
   const [overflown, setOverflown] = useState(false);
 
@@ -17,7 +17,9 @@ export function useIsOverflown<T extends HTMLElement = HTMLDivElement>() {
     const observer = new ResizeObserver(check);
     observer.observe(element);
     return () => observer.disconnect();
-  }, []);
+    // ResizeObserver only sees box changes, so text changes need an explicit re-measure.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, deps);
 
   return { ref, overflown };
 }


### PR DESCRIPTION
## The report

MNeMiC, with a screenshot:

> "[BUG] I can't see the full file-name, it's getting ...-cropped, with no tooltip for full name. Did this window get thinner? I have no idea which is which, so now I have to size-compare, which will not always work."

Follow-up: *"Yup, the 'Manage Files' (add more models) is wider."*

His workaround is comparing file **sizes** to tell variants apart, which is exactly the disambiguation problem we've been fixing elsewhere.

## What I found about the width difference

The original diagnosis had it backwards. The two surfaces do differ, but the **dialog was already the wider one**, which matches MNeMiC's own follow-up:

| Surface | Constraint | Content width |
|---|---|---|
| `?dialog=filesEdit` ("Manage Files") | was `<Container size="md">` in a `fullScreen` Modal | Mantine md 960px minus padding, about **928px** |
| Wizard upload step (`/wizard?step=2`) | `<div className="container flex max-w-sm ...">` | our Tailwind `sm` = 768px minus `container` padding, about **736px** |

Both wizards (`ModelVersionWizard.tsx:120`, `ModelWizard.tsx:193`) cap the upload step at `max-w-sm`; there is no unconstrained surface. Our Tailwind `screens`/`maxWidth` come from `src/utils/tailwind.ts`, where `sm = 768px`, narrower than Mantine's `md` container. So the surface MNeMiC was cropping on is the **wizard**, and "Manage Files is wider" is literally true.

## What changed

**`FilesEditModal.tsx`: the dialog's `Container` went `md` to `xl`.** A deliberate width change to a shared surface. Mantine's `--container-size-xl` is **1320px**, so content goes from ~928px to roughly **1288px**, a substantially bigger gain than the `md` cap allowed. Fully fluid was tried first and looked wrong on a wide display, so the container stays; `xl` is the compromise.

Padding also changed: the file-list `Stack` moved from `p="md"` to `pt="md"`. `Card.css` restores exactly `var(--card-padding)` (16px) via `Card.Section [data-inherit-padding]`, the `Stack` is not a `Card.Section` so the `:last-child` negative margin does not apply, and the Card's own bottom padding survives. So this removes doubled padding without letting any child touch an edge, including the empty states and dropzones.

**`Files.tsx`: reworked the `FileCard` row so the name isn't the first thing sacrificed.** Extra width helps at MNeMiC's monitor size but doesn't fix the underlying layout, so the row changes are the substantive part:

1. **Tooltip carrying the full name**, so truncation is never a dead end at any width. It is `multiline` with `maw={420}` and `overflow-wrap: anywhere`. Mantine tooltips are `white-space: nowrap` unless `multiline`, and an unbroken 120-char filename would otherwise render *outside* the tooltip's own background, as white text on the page. It is also `disabled` unless the name is actually cut off, since Mantine has no truncation awareness and would otherwise fire on every row.
2. **"Needs info" badge moved off the name line** down to the metadata line next to size and format. The badge held its width while the name collapsed; the metadata line is short, dimmed, and has room to spare.
3. **The row now wraps.** The outer `Group` and both metadata-select `Group`s dropped `wrap="nowrap"`, and the name column is `flex: '1 1 220px'` with `minWidth: 0`. Previously the name column could shrink to zero to keep the fixed-width Type/Precision/Quant/Size selects (up to ~525px of them) on one line. Flex line-breaking uses the hypothetical main size, so the `220px` basis makes the selects wrap at the same threshold a `min-width` floor would, but the column can still shrink below 220 when it's alone on a line rather than clipping silently inside the `overflow: hidden` Card on very narrow screens. The icon now sits in the same nested `Group` as the name so it travels with it. At wide widths the layout is unchanged.
4. **Dropped the `marginTop: 18` on the rename and delete icons.** Justin confirmed on mobile that they sat "extra spaced out down at the bottom" once the row wrapped. That offset approximated a Mantine input label's height to line the icons up with labeled selects on a single `nowrap` line, but their parent `Group` is already `align="flex-end"`, which bottom-aligns them against the selects on its own. So the offset was doing nothing on one line and only added dead space above the icons once they could wrap onto a line of their own. Removed rather than made conditional; no media query, which would be the wrong tool here since this component renders at ~1288px in the dialog and ~736px in the wizard at the same window size.

**`useIsOverflown` (new, `src/hooks/useIsOverflown.ts`), and a second surface, `AuctionPlacementCard.tsx`.** Flagging that file explicitly since it sits outside the model-files title and the change was deliberate. `AuctionPlacementCard`'s `OverflowTooltip` already measured `offsetWidth < scrollWidth` inline to gate a tooltip, carrying a `// TODO this doesnt appear to listen for changes when resizing`. Rather than copy that logic into `Files.tsx`, it is lifted into a shared hook that observes the element with a `ResizeObserver`, and both call sites use it. That **closes the TODO** as a side effect, at a net -9 lines in the auction file.

The hook also takes a deps passthrough, used as `useIsOverflown([displayName])` and `useIsOverflown([label])`. `ResizeObserver` fires on box changes, not content changes, so without it a rename through the Popover (a new `overrideName` gives a new `displayName` at the same column width) would leave the measurement stale: short to long would mean no tooltip on a name that now truncates. Same hazard for the auction card's `label` when data refetches into a mounted card.

## Visual checklist

- [ ] **~1288px (the dialog at `xl`)** with a long filename. Names should not truncate at all. This is the actual bug report and it has only been eyeballed at one window size.
- [ ] **~500-700px with a `.gguf` component file**, the fullest select set (Type + Quant + Precision) and the tightest wrap case.
- [ ] **The wizard at 768px** (`/models/[id]/model-versions/[versionId]/wizard?step=2`), including a **mid-upload row** (progress bar section) and a **failed-upload row** (red name).
- [ ] **The rename Popover open while the row is wrapped** (a Trained model, `showRenameOnPrimary`).
- [ ] **Rename a file short to long in Manage Files, then hover.** The stale-measurement case the deps passthrough fixes.
- [ ] **A row with a select validation error while wrapped**: red Card border plus the inline `Select` error text.
- [ ] **A row showing the "Needs info" badge**: a `.gguf` with no quant type, or a Checkpoint `Model` file with no precision. Badge should sit on the metadata line, not compete with the name.
- [ ] **Both empty states** ("No additional components yet", and the large primary dropzone) at the new 16px inset.
- [ ] **Hover one genuinely long name** and look at the wrapped tooltip at ~420px. Confirm it *looks* right, not merely that it doesn't overflow. **Hover a short name**: no tooltip.
- [ ] **Phone width, wrapped row.** Justin confirmed the stranded-icon state here before the fix, so this is a re-check rather than an unknown: the rename and delete icons should now sit tight against the selects above them with no gap.
- [ ] **One glance at `/auctions`.** Each card renders two `OverflowTooltip`s and that page can hold hundreds of unvirtualized cards, so ~800+ ResizeObservers where there were none. Expected to be fine: RO batches post-layout, nothing writes to the DOM between reads so there's no forced-reflow thrash, and React 18 batches the `setState`s. But it's a new per-card cost on a page with a known perf history (#3260), so worth seeing once rather than assuming.

## Verification

- `pnpm run typecheck`: clean, full unfiltered output.
- `pnpm exec eslint` on all changed files: no issues.
- `pnpm exec prettier --write` on all changed files.

## Known follow-ups, deliberately not in this PR

- **Metadata line at a ~180px name column.** The size/format `Text` wraps to two lines and the Badge ellipsises to "Needs...". `flexShrink: 0` on the Badge plus `whiteSpace: 'nowrap'` on the `Text` would fix it.
- **The wizard is still the narrowest surface** at 736px. Raising `max-w-sm` on the upload step in `ModelVersionWizard.tsx` and `ModelWizard.tsx` is a one-line change, left out because it desyncs that step from the rest of the stepper, which is uniformly `max-w-sm`.
- **Two measurement edge cases inherited from the old inline code**, judged not worth changing: `scrollWidth` is integer-rounded, so a sub-pixel clip can render an ellipsis with the tooltip disabled; and a webfont swapping in after mount changes text metrics without resizing the box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
