### PR TITLE
feat(app-listings): consolidate onsite listing-media revisions through review (server, dark)

### DIFF
--- a/src/server/services/blocks/__tests__/offsite-listing.edit.service.test.ts
+++ b/src/server/services/blocks/__tests__/offsite-listing.edit.service.test.ts
@@ -846,19 +846,30 @@ describe('listMySubmissions (shadow handling)', () => {
       string,
       unknown
     >;
-    expect(where).toMatchObject({ submittedByUserId: OWNER, kind: 'offsite' });
-    // Shadow-targeting requests are excluded (OR: appListingId null OR parent listing).
-    expect(where.OR).toEqual([{ appListingId: null }, { appListing: { revisionOfId: null } }]);
+    // Widened to include onsite media revisions (kind IN onsite|offsite).
+    expect(where).toMatchObject({
+      submittedByUserId: OWNER,
+      kind: { in: ['onsite', 'offsite'] },
+    });
+    // OFFSITE shadow-targeting requests are STILL excluded (surfaced as a parent
+    // badge): OR keeps `appListingId null` OR `parent listing`. ONSITE requests (which
+    // are always shadow revisions, and whose auto-created parent has no own request)
+    // are included directly via the `{ kind: 'onsite' }` branch.
+    expect(where.OR).toEqual([
+      { appListingId: null },
+      { appListing: { revisionOfId: null } },
+      { kind: 'onsite' },
+    ]);
 
     // The detection query filters on a PENDING request targeting a shadow — NOT on
-    // shadow existence (an abandoned shadow has no such request).
+    // shadow existence (an abandoned shadow has no such request). Widened to both kinds.
     const revWhere = mockRead.appListingPublishRequest.findMany.mock.calls[1][0].where as Record<
       string,
       unknown
     >;
     expect(revWhere).toMatchObject({
       status: 'pending',
-      kind: 'offsite',
+      kind: { in: ['onsite', 'offsite'] },
       appListing: { revisionOfId: { in: ['apl_parent'] } },
     });
 

--- a/src/server/services/blocks/__tests__/offsite-listing.onsite-revision.service.test.ts
+++ b/src/server/services/blocks/__tests__/offsite-listing.onsite-revision.service.test.ts
@@ -1,0 +1,445 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  approveExternalRequest,
+  rejectExternalRequest,
+  submitListingRevision,
+  listPendingOffsiteRequests,
+  listApprovedOffsiteRequests,
+  listRejectedOffsiteRequests,
+} from '~/server/services/blocks/offsite-listing.service';
+
+/**
+ * W13 — ONSITE listing-media revision CONSOLIDATION service tests.
+ *
+ * The onsite half of the shadow-draft revision flow: an onsite app's `AppListing`
+ * is auto-created (`kind:'onsite'`, `status:'approved'`); its media (icon/cover/
+ * screenshots) is edited via the SAME begin/upload/submit shadow flow, then the
+ * revision is CONSOLIDATED through the (now kind-widened) mod queue + approve/reject.
+ *
+ * These tests pin the genuinely-new onsite behavior + prove offsite is byte-identical:
+ *   1. approve of an onsite media revision is ASSETS-ONLY — it copies the shadow's
+ *      icon/cover/screenshots onto the live parent but PRESERVES the parent's
+ *      manifest-governed scalars (name/tagline/description/category/contentRating),
+ *      and does NOT derive/raise contentRating from the assets (cap-at-app-rating).
+ *   2. reject deletes ONLY the onsite draft shadow; the live parent stays approved.
+ *   3. the approve supersede scopes by the REQUEST's kind (offsite stays 'offsite';
+ *      generalizes to 'onsite' so an onsite sibling is never stranded).
+ *   4. the mod queue procs return onsite rows carrying `kind:'onsite'`; offsite rows
+ *      are unchanged and the where-clause widens to kind IN ('onsite','offsite').
+ *   5. REGRESSION GUARD: an offsite revision approve/reject is byte-identical (full
+ *      scalar copy + asset-derived rating on approve; shadow-only delete on reject).
+ *   6. INVARIANT: the only producer of a `kind='onsite'` AppListingPublishRequest is
+ *      `submitListingRevision` on an onsite shadow (a media revision targeting a
+ *      shadow, `revisionOfId != null`) — so widening the queue gates surfaces exactly
+ *      media revisions, nothing else.
+ *
+ * All DB deps mocked in the sibling service-test style (no real Prisma).
+ */
+
+const { mockRead, mockWrite, seq } = vi.hoisted(() => {
+  const makeClient = () => ({
+    appListing: {
+      findUnique: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
+      findFirst: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
+      create: vi.fn(async (args: { data: unknown }) => args.data),
+      update: vi.fn(async (args: { data: unknown }) => args.data),
+      updateMany: vi.fn(async (..._a: unknown[]) => ({ count: 1 })),
+      deleteMany: vi.fn(async (..._a: unknown[]) => ({ count: 1 })),
+    },
+    appListingScreenshot: {
+      count: vi.fn(async (..._a: unknown[]) => 1),
+      findMany: vi.fn(async (..._a: unknown[]): Promise<unknown[]> => []),
+      createMany: vi.fn(async (..._a: unknown[]) => ({ count: 0 })),
+      deleteMany: vi.fn(async (..._a: unknown[]) => ({ count: 0 })),
+      updateMany: vi.fn(async (..._a: unknown[]) => ({ count: 0 })),
+    },
+    appListingModerationEvent: {
+      create: vi.fn(async (args: { data: unknown }) => args.data),
+    },
+    image: { findMany: vi.fn(async (..._a: unknown[]): Promise<unknown[]> => []) },
+    appListingPublishRequest: {
+      findUnique: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
+      findFirst: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
+      findMany: vi.fn(async (..._a: unknown[]): Promise<unknown[]> => []),
+      create: vi.fn(async (args: { data: unknown }) => args.data),
+      updateMany: vi.fn(async (..._a: unknown[]) => ({ count: 1 })),
+    },
+  });
+  const mockRead = makeClient();
+  const mockWrite = makeClient() as ReturnType<typeof makeClient> & {
+    $transaction: ReturnType<typeof vi.fn>;
+  };
+  mockWrite.$transaction = vi.fn(async (cb: (tx: unknown) => Promise<unknown>) => cb(mockWrite));
+  return { mockRead, mockWrite, seq: { n: 0 } };
+});
+
+const { mockNotify } = vi.hoisted(() => ({ mockNotify: vi.fn(async () => undefined) }));
+
+vi.mock('~/server/db/client', () => ({ dbRead: mockRead, dbWrite: mockWrite }));
+vi.mock('~/server/services/blocks/app-listing-notify', () => ({
+  notifyAppListingOwner: mockNotify,
+}));
+vi.mock('~/server/utils/app-block-ids', () => ({
+  newAppListingId: () => `apl_new_${++seq.n}`,
+  newAppListingPublishRequestId: () => `alpr_new_${++seq.n}`,
+  newAppListingScreenshotId: () => `apls_new_${++seq.n}`,
+  newAppListingModerationEventId: () => `alme_new_${++seq.n}`,
+  newUlid: () => `ULID${++seq.n}`,
+}));
+
+const MOD = 7;
+const CALLER = 42;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  seq.n = 0;
+  for (const c of [mockRead, mockWrite]) {
+    c.appListing.findUnique.mockReset().mockResolvedValue(null);
+    c.appListing.findFirst.mockReset().mockResolvedValue(null);
+    c.appListing.create.mockReset().mockImplementation(async (a: { data: unknown }) => a.data);
+    c.appListing.update.mockReset().mockImplementation(async (a: { data: unknown }) => a.data);
+    c.appListing.updateMany.mockReset().mockResolvedValue({ count: 1 });
+    c.appListing.deleteMany.mockReset().mockResolvedValue({ count: 1 });
+    c.appListingScreenshot.count.mockReset().mockResolvedValue(1);
+    c.appListingScreenshot.findMany.mockReset().mockResolvedValue([]);
+    c.appListingScreenshot.createMany.mockReset().mockResolvedValue({ count: 0 });
+    c.appListingScreenshot.deleteMany.mockReset().mockResolvedValue({ count: 0 });
+    c.appListingScreenshot.updateMany.mockReset().mockResolvedValue({ count: 0 });
+    c.appListingModerationEvent.create.mockReset().mockImplementation(async (a: { data: unknown }) => a.data);
+    c.image.findMany.mockReset().mockResolvedValue([]);
+    c.appListingPublishRequest.findUnique.mockReset().mockResolvedValue(null);
+    c.appListingPublishRequest.findFirst.mockReset().mockResolvedValue(null);
+    c.appListingPublishRequest.findMany.mockReset().mockResolvedValue([]);
+    c.appListingPublishRequest.create.mockReset().mockImplementation(async (a: { data: unknown }) => a.data);
+    c.appListingPublishRequest.updateMany.mockReset().mockResolvedValue({ count: 1 });
+  }
+  mockWrite.$transaction
+    .mockReset()
+    .mockImplementation(async (cb: (tx: unknown) => Promise<unknown>) => cb(mockWrite));
+  mockNotify.mockReset().mockResolvedValue(undefined);
+});
+
+// ---------------------------------------------------------------------------
+// Stagers: an ONSITE and an OFFSITE media-revision approve (revisionOfId set →
+// applyApprovedRevision). The onsite parent's scalars MUST NOT be overwritten.
+// ---------------------------------------------------------------------------
+
+/** Stage a media-revision approve of the given kind. The shadow carries EDITED
+ *  scalars (name/description) to prove they are ignored on the onsite branch. */
+function stageRevisionApprove(kind: 'onsite' | 'offsite') {
+  mockRead.appListingPublishRequest.findUnique.mockResolvedValue({
+    id: 'alpr_r',
+    status: 'pending',
+    kind,
+    slug: 'my-app',
+    appListingId: 'apl_shadow',
+  });
+  // Replica reads: the SHADOW (revisionOfId set → routes to applyApprovedRevision),
+  // then the PARENT (still approved, carries `kind`).
+  mockRead.appListing.findUnique.mockImplementation(async (args: { where: { id: string } }) => {
+    if (args.where.id === 'apl_shadow') {
+      return {
+        id: 'apl_shadow',
+        status: 'draft',
+        externalUrl: kind === 'offsite' ? 'https://example.com/' : null,
+        iconId: 99,
+        coverId: 88,
+        revisionOfId: 'apl_parent',
+        connectClientId: null,
+        connectRequestedScopes: null,
+        connectScopeJustifications: null,
+        userId: CALLER,
+        name: 'Edited Name',
+        slug: 'my-app',
+      };
+    }
+    if (args.where.id === 'apl_parent') {
+      return { id: 'apl_parent', slug: 'my-app', status: 'approved', kind };
+    }
+    return null;
+  });
+  // In-tx (PRIMARY) shadow re-read: the edited scalars + the new assets.
+  mockWrite.appListing.findUnique.mockImplementation(async (args: { where: { id: string } }) => {
+    if (args.where.id === 'apl_shadow') {
+      return {
+        id: 'apl_shadow',
+        status: 'draft',
+        revisionOfId: 'apl_parent',
+        name: 'Edited Name',
+        tagline: 'Edited tagline',
+        description: 'Edited description',
+        category: 'games',
+        contentRating: 'x', // shadow declares a HIGH rating — must NOT flow onto an onsite parent
+        externalUrl: kind === 'offsite' ? 'https://example.com/' : null,
+        connectClientId: null,
+        connectRequestedScopes: null,
+        connectScopeJustifications: null,
+        connectClient: null,
+        iconId: 99,
+        coverId: 88,
+      };
+    }
+    return null;
+  });
+}
+
+describe('approveExternalRequest — ONSITE media revision is ASSETS-ONLY (cap-at-app-rating)', () => {
+  it('copies icon/cover onto the live parent but PRESERVES the parent scalars (no name/description/category/contentRating write)', async () => {
+    stageRevisionApprove('onsite');
+    const res = await approveExternalRequest({ publishRequestId: 'alpr_r', reviewerUserId: MOD });
+    expect(res).toEqual({ publishRequestId: 'alpr_r', listingId: 'apl_parent', slug: 'my-app' });
+
+    // The parent copy wrote ONLY the asset columns.
+    const copy = mockWrite.appListing.update.mock.calls[0][0] as {
+      where: { id: string };
+      data: Record<string, unknown>;
+    };
+    expect(copy.where).toEqual({ id: 'apl_parent' });
+    expect(copy.data).toEqual({ iconId: 99, coverId: 88 });
+    // 🔴 manifest-governed scalars are NOT touched.
+    expect(copy.data).not.toHaveProperty('name');
+    expect(copy.data).not.toHaveProperty('tagline');
+    expect(copy.data).not.toHaveProperty('description');
+    expect(copy.data).not.toHaveProperty('category');
+    expect(copy.data).not.toHaveProperty('contentRating');
+  });
+
+  it('does NOT derive/raise contentRating from the shadow assets (resolveApprovalContentRating skipped → no Image level read)', async () => {
+    stageRevisionApprove('onsite');
+    await approveExternalRequest({ publishRequestId: 'alpr_r', reviewerUserId: MOD });
+    // resolveApprovalContentRating (the asset-floor) is the ONLY reader of Image
+    // nsfwLevel here; the onsite branch must skip it entirely.
+    expect(mockWrite.image.findMany).not.toHaveBeenCalled();
+    // A mod contentRating override is also ignored for the onsite branch.
+  });
+
+  it('an onsite contentRating override is ignored (still assets-only)', async () => {
+    stageRevisionApprove('onsite');
+    await approveExternalRequest({
+      publishRequestId: 'alpr_r',
+      reviewerUserId: MOD,
+      contentRating: 'r',
+    });
+    const copy = mockWrite.appListing.update.mock.calls[0][0] as { data: Record<string, unknown> };
+    expect(copy.data).toEqual({ iconId: 99, coverId: 88 });
+    expect(copy.data).not.toHaveProperty('contentRating');
+  });
+
+  it('reparents the shadow screenshots onto the parent + retires the shadow (kind-agnostic reuse)', async () => {
+    stageRevisionApprove('onsite');
+    await approveExternalRequest({ publishRequestId: 'alpr_r', reviewerUserId: MOD });
+    // Parent's old rows dropped, shadow rows moved to the parent, shadow deleted.
+    expect(mockWrite.appListingScreenshot.deleteMany).toHaveBeenCalledWith({
+      where: { appListingId: 'apl_parent' },
+    });
+    expect(mockWrite.appListingScreenshot.updateMany).toHaveBeenCalledWith({
+      where: { appListingId: 'apl_shadow' },
+      data: { appListingId: 'apl_parent' },
+    });
+    expect(mockWrite.appListing.deleteMany).toHaveBeenCalledWith({
+      where: { id: 'apl_shadow', revisionOfId: { not: null } },
+    });
+    // A revision approve does NOT notify (the parent stayed live).
+    expect(mockNotify).not.toHaveBeenCalled();
+  });
+});
+
+describe('approveExternalRequest — OFFSITE revision approve is BYTE-IDENTICAL (regression guard)', () => {
+  it('copies the FULL scalar set onto the parent + DERIVES the rating from assets', async () => {
+    stageRevisionApprove('offsite');
+    const res = await approveExternalRequest({ publishRequestId: 'alpr_r', reviewerUserId: MOD });
+    expect(res).toEqual({ publishRequestId: 'alpr_r', listingId: 'apl_parent', slug: 'my-app' });
+
+    const copy = mockWrite.appListing.update.mock.calls[0][0] as { data: Record<string, unknown> };
+    // The offsite branch still copies name/tagline/description/category + assets.
+    expect(copy.data).toMatchObject({
+      name: 'Edited Name',
+      tagline: 'Edited tagline',
+      description: 'Edited description',
+      category: 'games',
+      externalUrl: 'https://example.com/',
+      iconId: 99,
+      coverId: 88,
+    });
+    // contentRating is present (asset-DERIVED, floored) — the offsite path stamps it.
+    expect(copy.data).toHaveProperty('contentRating');
+    // The asset-floor derivation DID read Image levels (proves resolveApprovalContentRating ran).
+    expect(mockWrite.image.findMany).toHaveBeenCalled();
+  });
+});
+
+describe('rejectExternalRequest — ONSITE revision deletes ONLY the shadow (parent stays live)', () => {
+  it('deletes the draft shadow, never flips the parent, writes no delist event, sends no owner notice', async () => {
+    mockRead.appListingPublishRequest.findUnique.mockResolvedValue({
+      id: 'alpr_r',
+      status: 'pending',
+      kind: 'onsite',
+      appListingId: 'apl_shadow',
+    });
+    // Snapshot read (owner/name/slug/revisionOfId) — revisionOfId set ⇒ a revision reject.
+    mockRead.appListing.findUnique.mockResolvedValue({
+      userId: CALLER,
+      name: 'My App',
+      slug: 'rev-abc',
+      revisionOfId: 'apl_parent',
+    });
+    // closeTerminalListing reads the listing status via the tx (write) client.
+    mockWrite.appListing.findUnique.mockResolvedValue({ status: 'draft', slug: 'rev-abc' });
+
+    await rejectExternalRequest({
+      publishRequestId: 'alpr_r',
+      reviewerUserId: MOD,
+      rejectionReason: 'blurry screenshots',
+    });
+
+    // The request flipped to rejected …
+    expect(mockWrite.appListingPublishRequest.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: 'alpr_r', status: 'pending' },
+        data: expect.objectContaining({ status: 'rejected' }),
+      })
+    );
+    // … and ONLY the draft shadow was deleted (status-guarded).
+    expect(mockWrite.appListing.deleteMany).toHaveBeenCalledWith({
+      where: { id: 'apl_shadow', status: 'draft' },
+    });
+    // The parent was never flipped (no pending→removed) and no delist event written
+    // (that's the reset-to-pending branch, not a draft shadow).
+    expect(mockWrite.appListing.updateMany).not.toHaveBeenCalled();
+    expect(mockWrite.appListingModerationEvent.create).not.toHaveBeenCalled();
+    // A revision reject sends NO "your app was not approved" notice (parent still live).
+    expect(mockNotify).not.toHaveBeenCalled();
+  });
+});
+
+describe('approveExternalRequest — supersede scopes by the REQUEST kind (no onsite sibling stranded)', () => {
+  /**
+   * Stage a FIRST-TIME (non-revision) approve of the given kind so the main-body
+   * supersede runs. Offsite is the real production path; the onsite case pins the
+   * generalization defensively — the invariant means onsite normally routes to the
+   * revision-apply path, but IF the main-body supersede is reached its kind filter
+   * must follow `request.kind`, never a hard-coded 'offsite' (else an onsite sibling
+   * on the same listing would be left pending / stranded).
+   */
+  function stageFirstTimeApprove(kind: 'onsite' | 'offsite') {
+    mockRead.appListingPublishRequest.findUnique.mockResolvedValue({
+      id: 'alpr_ft',
+      status: 'pending',
+      kind,
+      slug: 'app',
+      appListingId: 'apl_ft',
+    });
+    mockRead.appListing.findUnique.mockResolvedValue({
+      id: 'apl_ft',
+      status: 'draft',
+      externalUrl: kind === 'offsite' ? 'https://example.com/' : null,
+      iconId: 1,
+      coverId: 2,
+      revisionOfId: null, // NON-revision → main-body flip + supersede
+      connectClientId: null,
+      connectRequestedScopes: null,
+      connectScopeJustifications: null,
+      userId: CALLER,
+      name: 'App',
+      slug: 'app',
+    });
+    mockWrite.appListing.findUnique.mockResolvedValue({
+      externalUrl: kind === 'offsite' ? 'https://example.com/' : null,
+      iconId: 1,
+      coverId: 2,
+      connectClientId: null,
+      connectRequestedScopes: null,
+      connectScopeJustifications: null,
+      connectClient: null,
+    });
+  }
+
+  it('offsite first-time approve supersedes siblings scoped kind:offsite (byte-identical)', async () => {
+    stageFirstTimeApprove('offsite');
+    await approveExternalRequest({ publishRequestId: 'alpr_ft', reviewerUserId: MOD });
+    // Two publishRequest.updateMany calls: [0] the status flip, [1] the supersede.
+    const supersede = mockWrite.appListingPublishRequest.updateMany.mock.calls[1][0] as {
+      where: Record<string, unknown>;
+    };
+    expect(supersede.where).toMatchObject({
+      appListingId: 'apl_ft',
+      status: 'pending',
+      kind: 'offsite',
+      NOT: { id: 'alpr_ft' },
+    });
+  });
+
+  it('onsite (defensive main-body) approve supersedes siblings scoped kind:onsite — not hard-coded offsite', async () => {
+    stageFirstTimeApprove('onsite');
+    await approveExternalRequest({ publishRequestId: 'alpr_ft', reviewerUserId: MOD });
+    const supersede = mockWrite.appListingPublishRequest.updateMany.mock.calls[1][0] as {
+      where: Record<string, unknown>;
+    };
+    expect(supersede.where).toMatchObject({
+      appListingId: 'apl_ft',
+      status: 'pending',
+      kind: 'onsite',
+      NOT: { id: 'alpr_ft' },
+    });
+  });
+});
+
+describe('mod queue procs — widened to kind IN (onsite, offsite), each row carries kind', () => {
+  it('listPendingOffsiteRequests: where widens to both kinds, select carries kind, onsite rows surface with kind:onsite', async () => {
+    mockRead.appListingPublishRequest.findMany.mockResolvedValue([
+      { id: 'a', kind: 'onsite', slug: 'x', status: 'pending', appListingId: 'apl_s', appListing: {} },
+      { id: 'b', kind: 'offsite', slug: 'y', status: 'pending', appListingId: 'apl_o', appListing: {} },
+    ]);
+    const res = await listPendingOffsiteRequests({});
+    const call = mockRead.appListingPublishRequest.findMany.mock.calls[0][0] as {
+      where: Record<string, unknown>;
+      select: Record<string, unknown>;
+    };
+    expect(call.where).toMatchObject({ status: 'pending', kind: { in: ['onsite', 'offsite'] } });
+    // The request kind is selected so PR-2 can badge the row.
+    expect(call.select.kind).toBe(true);
+    expect(res.items.map((r: { kind: string }) => r.kind)).toEqual(['onsite', 'offsite']);
+  });
+
+  it('listApprovedOffsiteRequests + listRejectedOffsiteRequests both widen the kind filter', async () => {
+    await listApprovedOffsiteRequests({});
+    await listRejectedOffsiteRequests({});
+    const approvedWhere = (mockRead.appListingPublishRequest.findMany.mock.calls[0][0] as { where: Record<string, unknown> }).where;
+    const rejectedWhere = (mockRead.appListingPublishRequest.findMany.mock.calls[1][0] as { where: Record<string, unknown> }).where;
+    expect(approvedWhere).toMatchObject({ status: 'approved', kind: { in: ['onsite', 'offsite'] } });
+    expect(rejectedWhere).toMatchObject({ status: 'rejected', kind: { in: ['onsite', 'offsite'] } });
+  });
+});
+
+describe('INVARIANT — the only producer of a kind:onsite AppListingPublishRequest is submitListingRevision on an onsite shadow', () => {
+  it('submitListingRevision on an onsite shadow mints a kind:onsite request targeting the shadow (revisionOfId set)', async () => {
+    // The shadow: a draft revision of an approved onsite parent (revisionOfId set).
+    mockRead.appListing.findUnique.mockResolvedValue({
+      id: 'apl_shadow',
+      kind: 'onsite',
+      status: 'draft',
+      userId: CALLER,
+      revisionOfId: 'apl_parent', // ⇐ a SHADOW, never a top-level listing
+      externalUrl: null,
+      iconId: 99,
+      coverId: 88,
+      revisionOf: { slug: 'my-app', status: 'approved' },
+    });
+    // Asset-complete (dbWrite screenshot count) + no open request yet.
+    mockWrite.appListingScreenshot.count.mockResolvedValue(1);
+    mockRead.appListingPublishRequest.findFirst.mockResolvedValue(null);
+
+    const res = await submitListingRevision({ shadowId: 'apl_shadow', userId: CALLER });
+    expect(res).toMatchObject({ shadowId: 'apl_shadow', slug: 'my-app' });
+
+    const created = mockWrite.appListingPublishRequest.create.mock.calls[0][0].data as Record<string, unknown>;
+    // 🔴 the request is kind:onsite AND points at the SHADOW — so widening the queue
+    // gates to include onsite surfaces exactly media revisions, nothing else.
+    expect(created.kind).toBe('onsite');
+    expect(created.appListingId).toBe('apl_shadow');
+    // The public PARENT slug is denormalized so the queue reads the live slug.
+    expect(created.slug).toBe('my-app');
+    expect(created.status).toBe('pending');
+  });
+});

--- a/src/server/services/blocks/offsite-listing.service.ts
+++ b/src/server/services/blocks/offsite-listing.service.ts
@@ -1388,7 +1388,9 @@ export async function getMyListingForEdit(opts: {
     const pendingRevisionReq = await dbRead.appListingPublishRequest.findFirst({
       where: {
         status: 'pending',
-        kind: 'offsite',
+        // Onsite media revisions are kind:'onsite'; widen so the onsite "revision in
+        // review" badge resolves (the probe is already scoped to this parent's shadows).
+        kind: { in: [...REVIEWABLE_LISTING_KINDS] },
         appListing: { revisionOfId: listingId },
       },
       select: { id: true },
@@ -1468,6 +1470,18 @@ export async function updateRevisionDraft(opts: {
 }
 
 // ---------------------------------------------------------------------------
+// Listing-request kinds surfaced by the CONSOLIDATION half of the flow
+// (approve/reject + the mod review queue + my-submissions).
+//
+// 🔴 INVARIANT: the ONLY producer of a `kind='onsite'` `AppListingPublishRequest`
+// is `submitListingRevision` on an onsite SHADOW (i.e. an onsite media revision) —
+// the onsite CODE review runs over a DIFFERENT table (`AppBlockPublishRequest`).
+// So widening these gates from `'offsite'` to this set surfaces EXACTLY onsite
+// media revisions, nothing else. (Asserted in the service tests.)
+// ---------------------------------------------------------------------------
+const REVIEWABLE_LISTING_KINDS = ['onsite', 'offsite'] as const;
+
+// ---------------------------------------------------------------------------
 // approveExternalRequest / rejectExternalRequest (moderator) — PR-b.
 //
 // Mirror the on-site `publish-request.service` approve/reject state machine over
@@ -1476,6 +1490,14 @@ export async function updateRevisionDraft(opts: {
 // surfaces it in the store); reject DELETES the draft (releases the slug). Both
 // writes are status-guarded `updateMany`/`deleteMany` so a concurrent
 // approve/reject/withdraw can never double-act (TOCTOU).
+//
+// ONSITE (assets-only media revision): an onsite app's `AppListing` is auto-created
+// `approved`; its media (icon/cover/screenshots) is edited via the SAME shadow-draft
+// revision flow, so an onsite request is always a revision (its listing's
+// `revisionOfId != null`) and routes to `applyApprovedRevision`, which — for an
+// onsite parent — copies ONLY the asset columns and leaves the manifest-governed
+// scalars (name/tagline/description/category/contentRating) untouched. The offsite
+// path is unchanged.
 // ---------------------------------------------------------------------------
 
 export type ApproveExternalRequestResult = {
@@ -1617,10 +1639,11 @@ export async function approveExternalRequest(opts: {
   if (!request) {
     throw new OffsiteRequestError('NOT_FOUND', `publish request ${publishRequestId} not found`);
   }
-  if (request.kind !== 'offsite') {
+  // Accept onsite media revisions too (assets-only apply; see REVIEWABLE_LISTING_KINDS).
+  if (!(REVIEWABLE_LISTING_KINDS as readonly string[]).includes(request.kind)) {
     throw new OffsiteRequestError(
       'NOT_FOUND',
-      `publish request ${publishRequestId} is not an off-site request`
+      `publish request ${publishRequestId} is not a reviewable listing request`
     );
   }
   if (request.status !== 'pending') {
@@ -1854,7 +1877,11 @@ export async function approveExternalRequest(opts: {
       where: {
         appListingId,
         status: 'pending',
-        kind: 'offsite',
+        // Match THIS request's kind (a listing has exactly one kind, so all its
+        // requests share it) rather than hard-coding 'offsite' — otherwise an onsite
+        // sibling pending request on the same appListingId would be stranded. Byte-
+        // identical for offsite (request.kind === 'offsite' here).
+        kind: request.kind,
         NOT: { id: publishRequestId },
       },
       data: { status: 'withdrawn' },
@@ -1913,9 +1940,12 @@ async function applyApprovedRevision(opts: {
   const { request, shadowId, parentId, reviewerUserId, approvalNotes } = opts;
 
   // Parent must still exist (defense — its delete would CASCADE the shadow away).
+  // `kind` drives the assets-only branch below: an ONSITE parent's scalars mirror the
+  // manifest/AppBlock (single source), so an onsite media revision copies ONLY the
+  // asset columns and leaves name/tagline/description/category/contentRating untouched.
   const parent = await dbRead.appListing.findUnique({
     where: { id: parentId },
-    select: { id: true, slug: true, status: true },
+    select: { id: true, slug: true, status: true, kind: true },
   });
   if (!parent) {
     throw new OffsiteRequestError('NOT_FOUND', `parent listing ${parentId} not found`);
@@ -2024,37 +2054,58 @@ async function applyApprovedRevision(opts: {
       );
     }
 
-    // (3) Copy scalars onto the parent (id / slug / appBlockId / status untouched).
-    // The content rating is DERIVED from the shadow's assets' max nsfwLevel (+ the
-    // mod override, floored) rather than trusting the shadow's declared value — same
-    // never-under-rate safety as the first-time approve path.
-    const finalRating = await resolveApprovalContentRating(tx, {
-      appListingId: shadowId,
-      iconId: shadow.iconId,
-      coverId: shadow.coverId,
-      override: opts.contentRating,
-    });
-    await tx.appListing.update({
-      where: { id: parentId },
-      data: {
-        name: shadow.name,
-        tagline: shadow.tagline,
-        description: shadow.description,
-        category: shadow.category,
-        contentRating: finalRating,
-        externalUrl: shadow.externalUrl,
-        connectClientId: shadow.connectClientId,
-        // Apply the revision's disclosed OAuth scopes + justifications onto the live
-        // parent (a scope change is material, so the shadow carries the reviewed set).
-        connectRequestedScopes: shadow.connectRequestedScopes,
-        connectScopeJustifications:
-          shadow.connectScopeJustifications === null
-            ? Prisma.DbNull
-            : (shadow.connectScopeJustifications as Prisma.InputJsonValue),
+    // (3) Copy the shadow's contents onto the parent (id / slug / appBlockId / status
+    // untouched). KIND-AWARE:
+    if (parent.kind === 'onsite') {
+      // 🔴 ONSITE = ASSETS-ONLY. An onsite listing's name/tagline/description/category/
+      // contentRating MIRROR the manifest/AppBlock (single source — the listing must
+      // never override the runtime serving gate). An onsite media revision therefore
+      // copies ONLY the asset columns (icon/cover; screenshots are reparented in step 4)
+      // and leaves ALL manifest-governed scalars untouched. CAP-AT-APP-RATING:
+      // `resolveApprovalContentRating`'s asset-floor is deliberately NOT applied here —
+      // the listing rating stays the app's manifest rating; over-rated media is a
+      // mod-reject at review, never an auto-raise. The connect fields are also left
+      // untouched (an onsite listing has no OAuth-connect client — always null).
+      await tx.appListing.update({
+        where: { id: parentId },
+        data: {
+          iconId: shadow.iconId,
+          coverId: shadow.coverId,
+        },
+      });
+    } else {
+      // OFFSITE (byte-identical to the prior behavior). Copy the FULL scalar set. The
+      // content rating is DERIVED from the shadow's assets' max nsfwLevel (+ the mod
+      // override, floored) rather than trusting the shadow's declared value — same
+      // never-under-rate safety as the first-time approve path.
+      const finalRating = await resolveApprovalContentRating(tx, {
+        appListingId: shadowId,
         iconId: shadow.iconId,
         coverId: shadow.coverId,
-      },
-    });
+        override: opts.contentRating,
+      });
+      await tx.appListing.update({
+        where: { id: parentId },
+        data: {
+          name: shadow.name,
+          tagline: shadow.tagline,
+          description: shadow.description,
+          category: shadow.category,
+          contentRating: finalRating,
+          externalUrl: shadow.externalUrl,
+          connectClientId: shadow.connectClientId,
+          // Apply the revision's disclosed OAuth scopes + justifications onto the live
+          // parent (a scope change is material, so the shadow carries the reviewed set).
+          connectRequestedScopes: shadow.connectRequestedScopes,
+          connectScopeJustifications:
+            shadow.connectScopeJustifications === null
+              ? Prisma.DbNull
+              : (shadow.connectScopeJustifications as Prisma.InputJsonValue),
+          iconId: shadow.iconId,
+          coverId: shadow.coverId,
+        },
+      });
+    }
 
     // (4) Reparent screenshots BEFORE deleting the shadow (cascade-safe): drop the
     // parent's current rows, then move the shadow's rows onto the parent.
@@ -2122,10 +2173,13 @@ export async function rejectExternalRequest(opts: {
   if (!request) {
     throw new OffsiteRequestError('NOT_FOUND', `publish request ${publishRequestId} not found`);
   }
-  if (request.kind !== 'offsite') {
+  // Accept onsite media revisions too. The reject path (`closeTerminalListing`) is
+  // already kind-agnostic — an onsite revision points at a `draft` shadow, so only the
+  // shadow is deleted; the live onsite parent is untouched (see REVIEWABLE_LISTING_KINDS).
+  if (!(REVIEWABLE_LISTING_KINDS as readonly string[]).includes(request.kind)) {
     throw new OffsiteRequestError(
       'NOT_FOUND',
-      `publish request ${publishRequestId} is not an off-site request`
+      `publish request ${publishRequestId} is not a reviewable listing request`
     );
   }
   if (request.status !== 'pending') {
@@ -2240,6 +2294,10 @@ export async function persistListingAssetImage(opts: {
 const submissionSelect = {
   id: true,
   appListingId: true,
+  // The request KIND ('onsite' | 'offsite') — surfaced so the unified /apps/review
+  // queue (PR-2) can badge onsite media revisions vs offsite submissions. Additive:
+  // pre-existing consumers ignore it.
+  kind: true,
   slug: true,
   status: true,
   submittedAt: true,
@@ -2301,10 +2359,21 @@ export async function listMySubmissions(
   const rows = await dbRead.appListingPublishRequest.findMany({
     where: {
       submittedByUserId: opts.userId,
-      kind: 'offsite',
-      // Exclude requests targeting a SHADOW (revision) listing — surfaced as a
-      // flag on the parent, not as their own row. Keep requests with no listing.
-      OR: [{ appListingId: null }, { appListing: { revisionOfId: null } }],
+      kind: { in: [...REVIEWABLE_LISTING_KINDS] },
+      // OFFSITE: exclude requests targeting a SHADOW (revision) listing — those are
+      // surfaced as a `hasPendingRevision` flag on the PARENT's own submission row.
+      // Keep requests with no listing.
+      //
+      // ONSITE: an onsite listing is auto-created and has NO own publish request, so
+      // there is no parent row to badge — its ONLY representation IS the revision
+      // request (all onsite requests are shadow revisions, per the invariant). Include
+      // them directly via the `{ kind: 'onsite' }` OR branch so onsite media revisions
+      // appear on my-submissions (decision: yes).
+      OR: [
+        { appListingId: null },
+        { appListing: { revisionOfId: null } },
+        { kind: 'onsite' },
+      ],
     },
     orderBy: { submittedAt: 'desc' },
     take: limit + 1,
@@ -2328,7 +2397,7 @@ export async function listMySubmissions(
       ? await dbRead.appListingPublishRequest.findMany({
           where: {
             status: 'pending',
-            kind: 'offsite',
+            kind: { in: [...REVIEWABLE_LISTING_KINDS] },
             appListing: { revisionOfId: { in: parentIds } },
           },
           select: { appListing: { select: { revisionOfId: true } } },
@@ -2386,11 +2455,15 @@ export async function listMySubmissions(
   return { items, nextCursor: hasNext ? items[items.length - 1].id : null };
 }
 
-/** Mod queue: pending off-site requests, oldest-first (FIFO), keyset-paginated. */
+/**
+ * Mod queue: pending listing requests (offsite submissions + onsite media revisions),
+ * oldest-first (FIFO), keyset-paginated. Each row carries `kind` so the unified
+ * /apps/review queue (PR-2) can badge an onsite media revision vs an offsite submission.
+ */
 export async function listPendingOffsiteRequests(opts: ListOffsiteRequestsOptions = {}) {
   const limit = Math.min(opts.limit ?? 25, 100);
   const rows = await dbRead.appListingPublishRequest.findMany({
-    where: { status: 'pending', kind: 'offsite' },
+    where: { status: 'pending', kind: { in: [...REVIEWABLE_LISTING_KINDS] } },
     orderBy: { submittedAt: 'asc' },
     take: limit + 1,
     ...(opts.cursor ? { cursor: { id: opts.cursor }, skip: 1 } : {}),
@@ -2401,11 +2474,11 @@ export async function listPendingOffsiteRequests(opts: ListOffsiteRequestsOption
   return { items, nextCursor: hasNext ? items[items.length - 1].id : null };
 }
 
-/** Mod history: approved off-site requests, most-recently-reviewed first. */
+/** Mod history: approved listing requests (offsite + onsite media revisions), most-recently-reviewed first. */
 export async function listApprovedOffsiteRequests(opts: ListOffsiteRequestsOptions = {}) {
   const limit = Math.min(opts.limit ?? 25, 100);
   const rows = await dbRead.appListingPublishRequest.findMany({
-    where: { status: 'approved', kind: 'offsite' },
+    where: { status: 'approved', kind: { in: [...REVIEWABLE_LISTING_KINDS] } },
     orderBy: { reviewedAt: 'desc' },
     take: limit + 1,
     ...(opts.cursor ? { cursor: { id: opts.cursor }, skip: 1 } : {}),
@@ -2420,11 +2493,11 @@ export async function listApprovedOffsiteRequests(opts: ListOffsiteRequestsOptio
   return { items, nextCursor: hasNext ? items[items.length - 1].id : null };
 }
 
-/** Mod history: rejected off-site requests, most-recently-reviewed first. */
+/** Mod history: rejected listing requests (offsite + onsite media revisions), most-recently-reviewed first. */
 export async function listRejectedOffsiteRequests(opts: ListOffsiteRequestsOptions = {}) {
   const limit = Math.min(opts.limit ?? 25, 100);
   const rows = await dbRead.appListingPublishRequest.findMany({
-    where: { status: 'rejected', kind: 'offsite' },
+    where: { status: 'rejected', kind: { in: [...REVIEWABLE_LISTING_KINDS] } },
     orderBy: { reviewedAt: 'desc' },
     take: limit + 1,
     ...(opts.cursor ? { cursor: { id: opts.cursor }, skip: 1 } : {}),


### PR DESCRIPTION
## What

Consolidates **onsite** App-listing **media** revisions through the same mod
review path offsite listings already use — server-only, **dark** (no UI). An
onsite app's `AppListing` is auto-created (`kind:'onsite'`, `status:'approved'`,
null assets); the shadow-revision flow could already BEGIN/upload/submit an onsite
media revision (it is kind-correct), but the **consolidation** half
(approve/reject + the mod queue) was offsite-only, so an onsite media revision
**stranded**. This widens the consolidation to onsite, **assets-only**.

No migration — `AppListing.kind` / `AppListingPublishRequest.kind` are plain
`String` columns (with a DB CHECK) that already allow `'onsite'`.

## Kind-widening (gates widened to `kind IN ('onsite','offsite')`)

All in `src/server/services/blocks/offsite-listing.service.ts`:

- `approveExternalRequest` kind gate — accept onsite (core unblock).
- `rejectExternalRequest` kind gate — accept onsite (reject via `closeTerminalListing`
  is already kind-agnostic; only the gate blocked).
- approve main-body **supersede** — now scopes `kind: request.kind` instead of
  hard-coded `'offsite'` (already scoped by `appListingId`), so an onsite sibling
  is never stranded. **Byte-identical for offsite** (`request.kind === 'offsite'`).
- `getMyListingForEdit` pending-revision probe — widened so the onsite "revision
  in review" state resolves.
- `listMySubmissions` main filter + sub-query — widened; onsite media revisions
  **appear on my-submissions** (an onsite parent has no own request to badge, so
  the revision request surfaces directly via a `{ kind: 'onsite' }` OR branch;
  offsite shadow requests are still excluded and badged on the parent).
- Queue procs `listPendingOffsiteRequests` / `listApprovedOffsiteRequests` /
  `listRejectedOffsiteRequests` — widened, and each row's `kind` is added to the
  shared `submissionSelect` so the unified `/apps/review` queue (PR-2) can badge it.

**Left offsite-only (verified, untouched):** `submitExternalListing` + its
pending-count (onsite listings are auto-created, never submitted here); the
`externalUrl`/`connectClientId` validation gates (already conditional on non-null —
an onsite revision has both null and correctly no-ops them); all of
`offsite-moderation.service` (delist/relist/claim/purge/report) — out of scope.

## The one genuinely-new behavior — onsite assets-only apply

`approveExternalRequest` routes a revision to `applyApprovedRevision`, which for an
**offsite** parent copies the shadow's FULL scalar set (name/tagline/description/
category/**contentRating**/externalUrl/connect fields + assets). For a
`kind:'onsite'` parent those scalars mirror the manifest/`AppBlock` (single source),
so the apply now branches: **onsite copies ONLY the asset columns** (icon/cover +
reparents screenshots) and **leaves name/tagline/description/category/contentRating
untouched**.

**Cap-at-app-rating:** the onsite branch does NOT run `resolveApprovalContentRating`
(the asset-floor) — the listing rating stays the app's manifest rating; over-rated
media is a mod-reject at review, never an auto-raise. The screenshot-reparent +
shadow-retire logic is already kind-agnostic and is reused. **The offsite branch is
byte-identical to before.**

## Invariant (asserted in tests)

The ONLY producer of a `kind='onsite'` `AppListingPublishRequest` is
`submitListingRevision` on an onsite shadow (a media revision — `revisionOfId != null`).
The onsite CODE review uses a DIFFERENT table (`AppBlockPublishRequest`), and
`resetOnsiteListingToPending` clones an `AppBlockPublishRequest`, not a listing
request. So widening the listing-request procs surfaces **exactly onsite media
revisions, nothing else**.

## Queue-proc return shape (for PR-2)

Each queue row now carries a top-level `kind: 'onsite' | 'offsite'` (added to
`submissionSelect`), alongside the existing `id`, `appListingId`, `slug`, `status`,
`submittedAt`, `reviewedAt`, `rejectionReason`, `approvalNotes`, `changelog`, and
the `appListing { … revisionOfId, status, connect* }` projection. Pending adds
`submittedBy`; approved/rejected add `submittedBy` + `reviewedBy`. PR-2 badges an
onsite media revision vs an offsite submission off `kind` (and infers "revision"
from `appListing.revisionOfId != null`).

## Tests

New `src/server/services/blocks/__tests__/offsite-listing.onsite-revision.service.test.ts`
(11 tests, `dbRead`/`dbWrite` mocked in the existing service-test style):

- onsite revision approve copies icon/cover/screenshots onto the parent AND
  preserves name/description/category/contentRating (assets-only); contentRating is
  NOT raised from assets (no Image-level read); a mod override is ignored.
- onsite reject deletes only the draft shadow; the parent is never flipped, no
  delist event, no owner notice.
- the supersede scopes by the request's kind (offsite stays `'offsite'`; generalizes
  to `'onsite'`).
- the queue procs widen to `kind IN ('onsite','offsite')`, select `kind`, and return
  onsite rows with `kind:'onsite'`; offsite unchanged.
- **regression guard:** the offsite revision approve is byte-identical (full scalar
  copy + asset-derived rating).
- **invariant:** `submitListingRevision` on an onsite shadow mints a `kind:'onsite'`
  request targeting the shadow (`revisionOfId != null`).

One existing assertion in `offsite-listing.edit.service.test.ts` (`listMySubmissions`
where-clause) updated to the widened contract.

## Verification

- `npx vitest run --project unit` over the offsite-listing suite: **151 passed**
  (11 new). `tsc --noEmit`: 0 new errors in the edited files. (Pre-existing,
  unrelated failures in `manifest-schema-endpoint` / `app-listing.moderation` /
  `listing-meta` are a missing-`kysely`-package env issue in this checkout, not this
  change.)
- **Honest status:** dark/server-only. End-to-end (owner edits onsite media →
  submits → mod approves → live listing shows new media) needs **PR-2** (unified
  `/apps/review` queue UI) and **PR-3** (owner edit UI), plus a human review
  click-through. PR-2 & PR-3 build on this. pr-preview and `/audit-pr` gates apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
