### PR TITLE
feat(app-listings): review surface for onsite listing-media revisions

### DIFF
--- a/src/components/Apps/OffsiteReviewQueue.browser.test.tsx
+++ b/src/components/Apps/OffsiteReviewQueue.browser.test.tsx
@@ -261,6 +261,61 @@ describe('OffsiteReviewModal — readOnly (history) posture hides the action but
   });
 });
 
+// On-site listing-MEDIA revision (kind: 'onsite') — the same listing modal reviews
+// it, but it renders kind-aware: a "listing media" header (NOT "external app"), NO
+// external URL, NO connect panel, the shadow-asset content checklist, and a
+// cap-at-app-rating review (media must not exceed the app's rating). Report-only.
+describe('OffsiteReviewModal — on-site listing-media revision (kind: onsite)', () => {
+  const ONSITE_MEDIA_ROW = {
+    id: 'lmr-1',
+    kind: 'onsite' as const,
+    appListingId: 'listing-1',
+    slug: 'onsite-media-app',
+    status: 'pending',
+    submittedAt: new Date('2026-02-01T00:00:00Z'),
+    changelog: 'refreshed the screenshots',
+    appListing: {
+      name: 'On-site Media App',
+      // An on-site listing-media revision has NO external URL and NO connect client.
+      externalUrl: null,
+      category: 'utility',
+      contentRating: 'g',
+      connectClientId: null,
+    },
+    submittedBy: { id: 42, username: 'author-dev', image: null },
+  };
+
+  test('renders the listing-media header, the asset checklist, and NO URL / connect panel', async () => {
+    renderWithProviders(<OffsiteReviewModal request={ONSITE_MEDIA_ROW} onClose={vi.fn()} />);
+    // Kind-aware header — the "listing media" badge, not "external".
+    await expect.element(page.getByTestId('apps-offsite-kind-badge')).toHaveTextContent(
+      'listing media'
+    );
+    expect(page.getByText('external', { exact: true }).elements()).toHaveLength(0);
+    // The on-site explainer note renders.
+    await expect.element(page.getByTestId('apps-offsite-onsite-note')).toBeInTheDocument();
+    // The shadow-asset content checklist is present (asset-presence items).
+    await expect.element(page.getByText('Icon present')).toBeInTheDocument();
+    await expect.element(page.getByText('Cover present')).toBeInTheDocument();
+    // No external URL row is rendered (null externalUrl degrades gracefully).
+    expect(page.getByText('URL is https and opens externally').elements()).toHaveLength(0);
+    // No code-review items and no connect scopes panel.
+    expect(page.getByText('Code diff reviewed').elements()).toHaveLength(0);
+    expect(page.getByTestId('connect-scopes-panel').elements()).toHaveLength(0);
+    // The app-rating cap label surfaces (vs "declared" for offsite).
+    await expect.element(page.getByText('app rating (cap)', { exact: true })).toBeInTheDocument();
+  });
+
+  test('flags media rated higher than the app rating as a cap violation (reject reason)', async () => {
+    // Assets derive 'r' (screenshot @ level 4) vs the app rating 'g' → cap exceeded.
+    renderWithProviders(<OffsiteReviewModal request={ONSITE_MEDIA_ROW} onClose={vi.fn()} />);
+    await expect.element(page.getByTestId('apps-offsite-rating-mismatch')).toBeInTheDocument();
+    await expect
+      .element(page.getByText('must not exceed the app’s rating', { exact: false }))
+      .toBeInTheDocument();
+  });
+});
+
 describe('OffsiteReviewModal — content-rating derive + mod override', () => {
   test('surfaces the DERIVED rating and FLAGS it as higher than the declared rating', async () => {
     renderWithProviders(<OffsiteReviewQueue />);

--- a/src/components/Apps/OffsiteReviewQueue.tsx
+++ b/src/components/Apps/OffsiteReviewQueue.tsx
@@ -78,6 +78,12 @@ type OffsiteUser = { id: number; username: string | null; image: string | null }
 
 export type OffsitePendingRow = {
   id: string;
+  /** Listing-revision SOURCE kind. `'offsite'` (default) = an external-link/connect
+   *  listing revision; `'onsite'` = an on-site listing-MEDIA revision (shadow assets
+   *  changed on a first-class on-site app). The modal renders kind-aware: an on-site
+   *  row shows a "listing media" header + a cap-at-app-rating content review (media
+   *  must NOT exceed the app's rating) instead of the offsite auto-derive floor. */
+  kind?: 'onsite' | 'offsite';
   appListingId: string | null;
   slug: string;
   status: string;
@@ -336,11 +342,31 @@ export function OffsiteReviewModal({
   const derivedRating = deriveContentRatingFromAssets(
     assetLevels.map((nsfwLevel) => ({ nsfwLevel: nsfwLevel ?? null }))
   );
+  // On-site listing-MEDIA revision: reviewed by this same shadow-asset + content
+  // modal, but the rating discipline INVERTS. For an offsite listing the declared
+  // rating is a FLOOR the assets must meet (rate UP; the server floors an under-
+  // rating to the derived value). For an on-site revision the app's rating is a CAP
+  // the media must NOT EXCEED — assets more mature than the app's rating are a
+  // mod-REJECT reason, not an auto-derive. Both surface the same `ratingExceeds`
+  // comparison; only the copy + the approve default differ.
+  const isOnsite = request.kind === 'onsite';
   const declaredRating = request.appListing?.contentRating ?? null;
-  const ratingMismatch =
+  // The app's rating (the CAP for an on-site media revision), narrowed to a valid
+  // enum value; null when unknown/invalid.
+  const appRating: OffsiteContentRating | null =
+    declaredRating != null &&
+    (OFFSITE_CONTENT_RATINGS as readonly string[]).includes(declaredRating)
+      ? (declaredRating as OffsiteContentRating)
+      : null;
+  const ratingExceeds =
     !assetsQuery.isLoading &&
     nsfwLevelFromContentRating(derivedRating) > nsfwLevelFromContentRating(declaredRating);
-  const selectedRating: OffsiteContentRating = ratingOverride ?? derivedRating;
+  // Keep the offsite name for the unchanged offsite paths below.
+  const ratingMismatch = ratingExceeds;
+  // Onsite approve defaults to the app's rating (the cap — media inherits it); the
+  // offsite approve defaults to the derived floor. Either way the mod may override.
+  const defaultRating: OffsiteContentRating = isOnsite ? appRating ?? derivedRating : derivedRating;
+  const selectedRating: OffsiteContentRating = ratingOverride ?? defaultRating;
 
   // OAuth-CONNECT sub-kind (PR3): render the requested-scope panel + the sensitive-
   // justification checklist item only when the listing is a connect listing.
@@ -372,8 +398,13 @@ export function OffsiteReviewModal({
       title={
         <Group gap={6}>
           <Text fw={600}>{request.slug}</Text>
-          <Badge color="grape" size="sm" variant="light">
-            external
+          <Badge
+            color={isOnsite ? 'teal' : 'grape'}
+            size="sm"
+            variant="light"
+            data-testid="apps-offsite-kind-badge"
+          >
+            {isOnsite ? 'listing media' : 'external'}
           </Badge>
         </Group>
       }
@@ -381,6 +412,12 @@ export function OffsiteReviewModal({
       centered
     >
       <Stack gap="md">
+        {isOnsite && (
+          <Text size="xs" c="dimmed" data-testid="apps-offsite-onsite-note">
+            Listing media update — the on-site app’s media (icon / cover / screenshots)
+            changed. Content-only review; the media must not exceed the app’s rating.
+          </Text>
+        )}
         <Group gap="xs">
           <Text size="xs" c="dimmed">
             Submitter:
@@ -444,7 +481,7 @@ export function OffsiteReviewModal({
                     {request.appListing.contentRating}
                   </Badge>
                   <Text size="xs" c="dimmed">
-                    declared
+                    {isOnsite ? 'app rating (cap)' : 'declared'}
                   </Text>
                 </Group>
               )}
@@ -535,11 +572,19 @@ export function OffsiteReviewModal({
             icon={<IconAlertTriangle size={16} />}
             data-testid="apps-offsite-rating-mismatch"
           >
-            <Text size="sm">
-              Assets contain higher-maturity content ({derivedRating}) than the declared rating (
-              {declaredRating ?? '—'}). The final rating defaults to the detected value; rate it at
-              least that high.
-            </Text>
+            {isOnsite ? (
+              <Text size="sm">
+                Media assets are rated higher ({derivedRating}) than the app’s rating (
+                {declaredRating ?? '—'}). Listing media must not exceed the app’s rating — reject
+                this revision or ask the author to trim the over-rated assets.
+              </Text>
+            ) : (
+              <Text size="sm">
+                Assets contain higher-maturity content ({derivedRating}) than the declared rating (
+                {declaredRating ?? '—'}). The final rating defaults to the detected value; rate it at
+                least that high.
+              </Text>
+            )}
           </Alert>
         )}
 
@@ -580,7 +625,11 @@ export function OffsiteReviewModal({
           <Stack gap="xs">
             <Select
               label="Final content rating"
-              description="Defaults to the rating detected from the assets. You may rate up; an under-rating is floored to the detected value on save."
+              description={
+                isOnsite
+                  ? 'Defaults to the app’s rating (the cap). Listing media must not exceed the app’s rating; assets rated higher are a reject reason.'
+                  : 'Defaults to the rating detected from the assets. You may rate up; an under-rating is floored to the detected value on save.'
+              }
               data={OFFSITE_CONTENT_RATINGS.map((r) => ({ value: r, label: r }))}
               value={selectedRating}
               onChange={(v) => setRatingOverride((v as OffsiteContentRating) ?? null)}

--- a/src/components/Apps/OffsiteReviewQueue.tsx
+++ b/src/components/Apps/OffsiteReviewQueue.tsx
@@ -375,6 +375,9 @@ export function OffsiteReviewModal({
 
   const checklist = getOffsiteReviewChecklist({
     name: request.appListing?.name,
+    // On-site listing-media revisions have no external URL by design — thread the
+    // row's kind so the checklist omits the `url-https` item (no false warn).
+    kind: request.kind,
     externalUrl: request.appListing?.externalUrl,
     hasIcon,
     hasCover,

--- a/src/components/Apps/UnifiedReviewList.tsx
+++ b/src/components/Apps/UnifiedReviewList.tsx
@@ -127,7 +127,6 @@ export function UnifiedReviewList({
 }
 
 function UnifiedReviewRowView({ row, actionLabel }: { row: UnifiedReviewRow; actionLabel: string }) {
-  const isOnsite = row.kind === 'onsite';
   const submitter = row.submitter;
   return (
     <Table.Tr style={{ cursor: 'pointer' }} data-testid={`apps-unified-review-row-${row.key}`}>
@@ -135,10 +134,10 @@ function UnifiedReviewRowView({ row, actionLabel }: { row: UnifiedReviewRow; act
         <Badge
           size="sm"
           variant="light"
-          color={isOnsite ? 'blue' : 'grape'}
+          color={row.badgeColor}
           data-testid={`apps-unified-review-kind-${row.key}`}
         >
-          {isOnsite ? 'App' : 'External'}
+          {row.badge}
         </Badge>
       </Table.Td>
       <Table.Td onClick={row.onReview}>

--- a/src/components/Apps/__tests__/offsiteReviewChecklist.test.ts
+++ b/src/components/Apps/__tests__/offsiteReviewChecklist.test.ts
@@ -107,6 +107,49 @@ describe('getOffsiteReviewChecklist — auto-derived statuses', () => {
   });
 });
 
+describe('getOffsiteReviewChecklist — kind-aware url item (onsite media revision)', () => {
+  it("kind='onsite' (URL-less media revision) OMITS the url-https item entirely", () => {
+    const ids = getOffsiteReviewChecklist({
+      ...complete,
+      kind: 'onsite',
+      externalUrl: null,
+    }).map((i) => i.id);
+    expect(ids).not.toContain('url-https');
+    // The rest of the content checklist is unchanged.
+    expect(ids).toContain('name');
+    expect(ids).toContain('icon');
+    expect(ids).toContain('cover');
+    expect(ids).toContain('screenshots');
+    expect(ids).toContain('description');
+    expect(ids).toContain('category');
+  });
+
+  it("offsite (kind omitted) with a bad/http URL STILL warns on url-https", () => {
+    const item = getOffsiteReviewChecklist({
+      ...complete,
+      externalUrl: 'http://insecure.example.com',
+    }).find((i) => i.id === 'url-https');
+    expect(item?.status).toBe('warn');
+  });
+
+  it("kind='offsite' with a bad/http URL STILL warns on url-https (explicit)", () => {
+    const item = getOffsiteReviewChecklist({
+      ...complete,
+      kind: 'offsite',
+      externalUrl: 'http://insecure.example.com',
+    }).find((i) => i.id === 'url-https');
+    expect(item?.status).toBe('warn');
+  });
+
+  it("kind='offsite' with a valid https URL keeps the item ok (behaviour unchanged)", () => {
+    const item = getOffsiteReviewChecklist({
+      ...complete,
+      kind: 'offsite',
+    }).find((i) => i.id === 'url-https');
+    expect(item?.status).toBe('ok');
+  });
+});
+
 describe('getOffsiteReviewChecklist — connect sensitive-scope item (PR3)', () => {
   const connectBase: OffsiteChecklistData = {
     ...complete,

--- a/src/components/Apps/__tests__/unifiedReviewRow.test.ts
+++ b/src/components/Apps/__tests__/unifiedReviewRow.test.ts
@@ -74,6 +74,8 @@ describe('onsiteRequestToUnifiedRow', () => {
     const row = onsiteRequestToUnifiedRow(req, vi.fn());
     expect(row.key).toBe('onsite:r1');
     expect(row.kind).toBe('onsite');
+    expect(row.badge).toBe('App');
+    expect(row.badgeColor).toBe('blue');
     expect(row.title).toBe('My Block');
     expect(row.slug).toBe('my-block');
     expect(row.submitter).toEqual({ id: 7, username: 'onsite-dev', image: null });
@@ -128,6 +130,8 @@ describe('offsiteRequestToUnifiedRow', () => {
     const row = offsiteRequestToUnifiedRow(req, vi.fn());
     expect(row.key).toBe('offsite:o1');
     expect(row.kind).toBe('offsite');
+    expect(row.badge).toBe('External');
+    expect(row.badgeColor).toBe('grape');
     expect(row.title).toBe('External App');
     expect(row.slug).toBe('ext-app');
     expect(row.submitter).toEqual({ id: 9, username: 'offsite-dev', image: null });
@@ -212,6 +216,52 @@ describe('offsiteRequestToUnifiedRow', () => {
 });
 
 // ---------------------------------------------------------------------------
+// On-site listing-MEDIA revision (`kind: 'onsite'`) — reviewed by the SAME listing
+// adapter/modal as an external listing, but with a distinct badge + key namespace.
+// This is the review-surface half of onsite listing-media revisions: the queue proc
+// (widened separately) tags such a row `kind: 'onsite'`; the adapter must badge it
+// "Listing media", route it to the LISTING opener (NOT the code modal), and namespace
+// its key so it can never collide/dedup with an external listing or a code request.
+// ---------------------------------------------------------------------------
+
+describe('offsiteRequestToUnifiedRow — on-site listing-media revision (kind: onsite)', () => {
+  it('badges it "Listing media", namespaces the key, and keeps the LISTING routing kind', () => {
+    const req = offsite({ id: 'lm1', slug: 'onsite-app', kind: 'onsite' });
+    const row = offsiteRequestToUnifiedRow(req, vi.fn());
+    expect(row.key).toBe('onsite-listing:lm1');
+    // Routing kind stays `offsite` (opens the listing modal, NOT the code modal).
+    expect(row.kind).toBe('offsite');
+    expect(row.badge).toBe('Listing media');
+    expect(row.badgeColor).toBe('teal');
+    expect(row.title).toBe('External App');
+  });
+
+  it('opens the LISTING (off-site) opener with an OffsitePendingRow carrying kind=onsite', () => {
+    const open = vi.fn();
+    const req = offsite({
+      id: 'lm2',
+      appListingId: 'apl_onsite',
+      slug: 'onsite-app',
+      kind: 'onsite',
+    });
+    offsiteRequestToUnifiedRow(req, open).onReview();
+    expect(open).toHaveBeenCalledTimes(1);
+    const passed = open.mock.calls[0][0];
+    expect(passed.id).toBe('lm2');
+    expect(passed.appListingId).toBe('apl_onsite');
+    // The row the modal receives must carry the onsite kind so it renders the
+    // "listing media" header + cap-at-app-rating review.
+    expect(passed.kind).toBe('onsite');
+  });
+
+  it('an absent kind (older payload) still behaves as an external listing', () => {
+    const row = offsiteRequestToUnifiedRow(offsite({ id: 'o9', slug: 's' }), vi.fn());
+    expect(row.key).toBe('offsite:o9');
+    expect(row.badge).toBe('External');
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Cross-kind key uniqueness
 // ---------------------------------------------------------------------------
 
@@ -223,6 +273,15 @@ describe('key namespacing', () => {
     expect(offsiteRow.key).toBe('offsite:shared');
     expect(onsiteRow.key).not.toBe(offsiteRow.key);
   });
+
+  it('a code request, an external listing, and an on-site listing-media row sharing a raw id get 3 DISTINCT keys', () => {
+    const code = onsiteRequestToUnifiedRow(onsite({ id: 'dup' }), vi.fn());
+    const external = offsiteRequestToUnifiedRow(offsite({ id: 'dup' }), vi.fn());
+    const listingMedia = offsiteRequestToUnifiedRow(offsite({ id: 'dup', kind: 'onsite' }), vi.fn());
+    const keys = [code.key, external.key, listingMedia.key];
+    expect(keys).toEqual(['onsite:dup', 'offsite:dup', 'onsite-listing:dup']);
+    expect(new Set(keys).size).toBe(3);
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -230,9 +289,13 @@ describe('key namespacing', () => {
 // ---------------------------------------------------------------------------
 
 function row(key: string, iso: string): UnifiedReviewRow {
+  const isOnsiteCode = key.startsWith('onsite:');
   return {
     key,
-    kind: key.startsWith('onsite') ? 'onsite' : 'offsite',
+    // `onsite:` = code review; everything else routes to the listing modal.
+    kind: isOnsiteCode ? 'onsite' : 'offsite',
+    badge: isOnsiteCode ? 'App' : key.startsWith('onsite-listing:') ? 'Listing media' : 'External',
+    badgeColor: isOnsiteCode ? 'blue' : key.startsWith('onsite-listing:') ? 'teal' : 'grape',
     title: key,
     submitter: null,
     submittedAt: new Date(iso),
@@ -301,6 +364,20 @@ describe('mergeReviewRows', () => {
       'onsite:b',
       'onsite:c',
     ]);
+  });
+
+  it('interleaves all three row kinds (code + external + on-site listing-media) by date with no drop/dedup collision', () => {
+    // Code rows arrive via the on-site arg; BOTH listing sub-kinds (external +
+    // on-site listing-media) arrive via the off-site arg (the appListings query).
+    const code = [row('onsite:c', '2026-01-01T00:00:00Z')];
+    const listing = [
+      row('offsite:e', '2026-01-02T00:00:00Z'),
+      row('onsite-listing:m', '2026-01-03T00:00:00Z'),
+    ];
+    const merged = mergeReviewRows(code, listing, 'asc');
+    expect(merged.map((r) => r.key)).toEqual(['onsite:c', 'offsite:e', 'onsite-listing:m']);
+    // The on-site listing-media row carries its own badge through the merge.
+    expect(merged.find((r) => r.key === 'onsite-listing:m')?.badge).toBe('Listing media');
   });
 
   it('does not mutate the input arrays', () => {

--- a/src/components/Apps/offsiteReviewChecklist.ts
+++ b/src/components/Apps/offsiteReviewChecklist.ts
@@ -37,6 +37,12 @@ export type ReviewChecklistItem = {
 /** The off-site listing facts the content checklist derives its auto-checks from. */
 export type OffsiteChecklistData = {
   name: string | null | undefined;
+  // An on-site listing-MEDIA revision (`kind: 'onsite'`) is reviewed by this same
+  // content checklist but has NO external URL by design — pass `kind: 'onsite'` so
+  // the `url-https` item is OMITTED (a URL-less onsite row must not show a false
+  // "URL is https" warn). Omitted / `'offsite'` keeps the item (a real off-site
+  // listing with a missing / http URL still warns — unchanged).
+  kind?: ReviewChecklistKind;
   externalUrl: string | null | undefined;
   hasIcon: boolean;
   hasCover: boolean;
@@ -124,6 +130,11 @@ export function getOffsiteReviewChecklist(data: OffsiteChecklistData): ReviewChe
   const screenshotOk = data.screenshotCount >= 1;
   const isConnect = data.connectClientId != null;
   const unjustifiedSensitive = isConnect ? unjustifiedSensitiveScopeKeys(data) : [];
+  // An on-site listing-media revision has no external URL by design — omit the
+  // `url-https` item entirely so the mod doesn't see a false red-X. Any off-site
+  // listing (kind omitted or 'offsite') keeps the item and still warns on a
+  // missing / non-https URL — behaviour unchanged.
+  const includeUrlItem = data.kind !== 'onsite';
   return [
     {
       id: 'name',
@@ -131,12 +142,16 @@ export function getOffsiteReviewChecklist(data: OffsiteChecklistData): ReviewChe
       hint: 'The listing has a non-empty display name.',
       status: namePresent ? 'ok' : 'warn',
     },
-    {
-      id: 'url-https',
-      label: 'URL is https and opens externally',
-      hint: 'The target is a valid https:// URL rendered with target="_blank" rel="noopener".',
-      status: urlValid ? 'ok' : 'warn',
-    },
+    ...(includeUrlItem
+      ? [
+          {
+            id: 'url-https',
+            label: 'URL is https and opens externally',
+            hint: 'The target is a valid https:// URL rendered with target="_blank" rel="noopener".',
+            status: (urlValid ? 'ok' : 'warn') as ReviewChecklistItemStatus,
+          },
+        ]
+      : []),
     {
       id: 'icon',
       label: 'Icon present',

--- a/src/components/Apps/unifiedReviewRow.ts
+++ b/src/components/Apps/unifiedReviewRow.ts
@@ -28,11 +28,22 @@ export type ReviewSubmitterChip = {
 } | null;
 
 export type UnifiedReviewRow = {
-  /** GLOBALLY-unique dedup key across kinds — `onsite:<id>` / `offsite:<id>`.
-   *  The kind prefix guarantees an on-site and an off-site request that happen to
+  /** GLOBALLY-unique dedup key, namespaced by SOURCE — `onsite:<id>` (App Block
+   *  code review), `offsite:<id>` (external listing review), `onsite-listing:<id>`
+   *  (on-site listing-MEDIA revision). The prefix guarantees rows that happen to
    *  share a raw id can never collide (and so can never dedup each other away). */
   key: string;
+  /** ROUTING kind: which review modal the row opens — `onsite` → the App Block
+   *  CODE-review modal (`OnsiteReviewModal`); `offsite` → the LISTING-review modal
+   *  (`OffsiteReviewModal`). An on-site listing-media revision is reviewed like the
+   *  offsite listing (shadow assets + content), so it ALSO routes `offsite` — its
+   *  distinct display badge is carried separately in `badge`/`badgeColor` below. */
   kind: UnifiedReviewKind;
+  /** Kind-column display badge — DECOUPLED from the routing `kind` so an on-site
+   *  listing-media revision (routing `offsite`) can show a "Listing media" badge
+   *  distinct from an external listing's "External" badge. Adapter-controlled. */
+  badge: string;
+  badgeColor: string;
   /** App / listing display name (falls back to the slug). */
   title: string;
   slug?: string;
@@ -72,6 +83,8 @@ export function onsiteRequestToUnifiedRow(
   return {
     key: `onsite:${req.id}`,
     kind: 'onsite',
+    badge: 'App',
+    badgeColor: 'blue',
     title,
     slug: req.slug,
     submitter: req.submittedBy,
@@ -85,6 +98,13 @@ export function onsiteRequestToUnifiedRow(
  *  A superset of `OffsitePendingRow`: history rows also carry `reviewedAt`. */
 export type OffsiteReviewRequest = {
   id: string;
+  /** The listing-revision SOURCE kind carried by each row (widened in the
+   *  server queue procs): `'offsite'` = an external-link/connect listing revision;
+   *  `'onsite'` = an on-site listing-MEDIA revision (shadow assets changed on a
+   *  first-class on-site app). BOTH are reviewed by the same listing modal, but an
+   *  on-site row gets a distinct "Listing media" badge + a cap-at-app-rating review.
+   *  Absent (older payloads / pre-widening) → treated as `'offsite'`. */
+  kind?: 'onsite' | 'offsite';
   appListingId: string | null;
   slug: string;
   status: string;
@@ -107,17 +127,26 @@ export type OffsiteReviewRequest = {
 };
 
 /**
- * Map an off-site request → a unified row whose `onReview` opens the OFF-SITE
- * modal. Builds the exact `OffsitePendingRow` the modal expects so the modal's
- * internals stay untouched. `title` prefers the listing name, else the slug.
+ * Map a LISTING-review request → a unified row whose `onReview` opens the LISTING
+ * modal (`OffsiteReviewModal`). Handles BOTH listing sub-kinds — an external-link/
+ * connect listing (`kind: 'offsite'`) and an on-site listing-MEDIA revision
+ * (`kind: 'onsite'`) — because both are reviewed by the same shadow-asset + content
+ * modal. Only the DISPLAY badge and the dedup KEY namespace differ by sub-kind
+ * (routing is identical); the modal itself renders kind-aware from `row.kind`.
+ * Builds the exact `OffsitePendingRow` the modal expects so its internals stay
+ * untouched. `title` prefers the listing name, else the slug.
  */
 export function offsiteRequestToUnifiedRow(
   req: OffsiteReviewRequest,
   openOffsiteReview: (row: OffsitePendingRow) => void
 ): UnifiedReviewRow {
   const reviewedAt = req.reviewedAt != null ? req.reviewedAt : null;
+  // Row is an on-site listing-media revision when the proc tags it `kind: 'onsite'`;
+  // absent/`'offsite'` is the external-link/connect listing (backward-compatible).
+  const isOnsiteListing = req.kind === 'onsite';
   const row: OffsitePendingRow = {
     id: req.id,
+    kind: req.kind ?? 'offsite',
     appListingId: req.appListingId,
     slug: req.slug,
     status: req.status,
@@ -138,8 +167,13 @@ export function offsiteRequestToUnifiedRow(
     submittedBy: req.submittedBy,
   };
   return {
-    key: `offsite:${req.id}`,
+    // Distinct key namespace per sub-kind so an on-site listing-media row and an
+    // external listing row can never dedup each other away.
+    key: isOnsiteListing ? `onsite-listing:${req.id}` : `offsite:${req.id}`,
+    // Routing kind is `offsite` for BOTH (they open the same listing modal).
     kind: 'offsite',
+    badge: isOnsiteListing ? 'Listing media' : 'External',
+    badgeColor: isOnsiteListing ? 'teal' : 'grape',
     title: req.appListing?.name ?? req.slug,
     slug: req.slug,
     submitter: req.submittedBy,


### PR DESCRIPTION
## What

The **review-surface** half of on-site App-listing **media** revisions. A mod-facing UI to review an on-site listing-**media** revision inside the unified `/apps/review` queue.

An on-site listing-media revision is a NEW artifact: an `AppListingPublishRequest(kind='onsite')` reviewed like the offsite listing revision (shadow assets + content review), and COMPLETELY DISTINCT from the App Block **code** review (`OnsiteReviewModal`).

## Changes

- **Kind-aware listing adapter** (`unifiedReviewRow.ts`): the listing adapter reads the row's `kind` and sets the Kind-column badge — **"Listing media"** (teal) for onsite, **"External"** (grape) for offsite. **Both route to the LISTING modal** (`OffsiteReviewModal`), never the code-review `OnsiteReviewModal`. The badge is decoupled from the routing `kind` via new `badge`/`badgeColor` row fields (routing kind stays `offsite` for both listing sub-kinds). Distinct dedup-key namespace — `onsite-listing:<id>` vs `offsite:<id>` — so an onsite and an offsite listing row can never dedup-collide. Since `review.tsx` already calls `appListings.list*Requests`, onsite rows flow through with just this adapter + badge change — **no new query wiring**.
- **`OffsiteReviewModal` kind-aware** (`OffsiteReviewQueue.tsx`): for an onsite media revision the header reads **"listing media update"** (teal badge) with a short onsite explainer, and the rating discipline **inverts to cap-at-app-rating** — the media must NOT exceed the app's rating (a mod-reject reason), rather than the offsite auto-derive floor. Reuses the existing graceful degradation on null `externalUrl` (no URL row) and null `connectClientId` (no `ConnectScopesPanel`), and the `getAssets(appListingId)` shadow-asset content checklist.
- **Deferred**: the optional before/after asset diff panel (`reviewDiffPanels.tsx` is code-diff oriented; an asset diff would materially grow the change).

## Badge / routing logic

| Source | routing `kind` | badge | key namespace | modal |
|---|---|---|---|---|
| App Block code request | `onsite` | App (blue) | `onsite:<id>` | `OnsiteReviewModal` (code) |
| External / connect listing | `offsite` | External (grape) | `offsite:<id>` | `OffsiteReviewModal` (listing) |
| **On-site listing-media revision** | `offsite` | **Listing media (teal)** | `onsite-listing:<id>` | `OffsiteReviewModal` (listing) |

## Tests

- **Blocking pure suite** (`unifiedReviewRow.test.ts`, extended): **23 pass**. An onsite listing-media row gets the "Listing media" badge, opens the LISTING opener (not the code modal) with an `OffsitePendingRow` carrying `kind='onsite'`, and merges/sorts/dedups alongside offsite + onsite-code rows with 3 distinct key namespaces.
- **Report-only browser test** (`OffsiteReviewQueue.browser.test.tsx`): the modal renders an onsite media revision with the listing-media header, the asset checklist, no URL/connect panels, and flags a media rating exceeding the app rating as a cap violation.
- `tsc --noEmit`: 0 new errors in the edited files.

## Depends on

The sibling server PR **`zach/onsite-listing-revision-server`** which widens the queue procs (`appListings.list{Pending,Approved,Rejected}Requests`) to return BOTH onsite + offsite listing-revision requests — each row carrying its `kind` — and makes `approveExternalRequest`/`rejectExternalRequest` accept onsite. **Until that lands the queue returns no onsite rows, so this surface is inert.** End-to-end review still needs a **human mod click-through**.

Mod-gated / dark (`appBlocks` flag + `isAppReviewer`). Gated on the `pr-preview` build and `/audit-pr` review gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
