### PR TITLE
feat(app-listings): onsite listing-media upload page for app owners

### DIFF
--- a/src/components/Apps/MySubmissionsList.tsx
+++ b/src/components/Apps/MySubmissionsList.tsx
@@ -13,6 +13,7 @@ import {
   IconHistory,
   IconMessage,
   IconPencil,
+  IconPhoto,
   IconUsers,
   IconX,
 } from '@tabler/icons-react';
@@ -807,6 +808,18 @@ function SubmissionActions({
             data-testid={`apps-onsite-edit-${s.slug}`}
           >
             Edit
+          </Button>
+        )}
+        {showEdit && s.appBlockId && (
+          <Button
+            size="xs"
+            variant="default"
+            component={Link}
+            href={`/apps/${encodeURIComponent(s.appBlockId)}/listing`}
+            leftSection={<IconPhoto size={12} />}
+            data-testid={`apps-onsite-listing-media-${s.slug}`}
+          >
+            Listing images
           </Button>
         )}
         {canManage && s.appBlockId && (

--- a/src/pages/apps/[appBlockId]/listing.tsx
+++ b/src/pages/apps/[appBlockId]/listing.tsx
@@ -1,0 +1,197 @@
+import { Alert, Anchor, Button, Center, Container, Group, Loader, Stack, Text } from '@mantine/core';
+import { IconArrowLeft, IconInfoCircle, IconSend } from '@tabler/icons-react';
+import Link from 'next/link';
+import { useRouter } from 'next/router';
+import { useEffect, useState } from 'react';
+import { NotFound } from '~/components/AppLayout/NotFound';
+import { ListingAssetStep } from '~/components/Apps/ListingAssetStep';
+import { Meta } from '~/components/Meta/Meta';
+import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
+import type { OffsiteContentRating } from '~/server/schema/blocks/offsite-listing.schema';
+import { createServerSideProps } from '~/server/utils/server-side-helpers';
+import { getLoginLink } from '~/utils/login-helpers';
+import { showErrorNotification, showSuccessNotification } from '~/utils/notifications';
+import { trpc } from '~/utils/trpc';
+
+/**
+ * On-site listing media (owner) — the owner-facing icon / cover / screenshot editor
+ * for a LIVE on-site app at `/apps/<appBlockId>/listing`.
+ *
+ * Gating mirrors `edit-manifest.tsx`: the SSR resolver enforces the appBlocks flag
+ * + a logged-in session (anon → /login). The OWNER check is single-sourced at the
+ * tRPC layer — `appListings.getMyListingForApp` throws FORBIDDEN (non-owner) /
+ * NOT_FOUND (no listing) — so a non-owner / missing listing settles to NotFound.
+ *
+ * Flow (assets-only; name/description/URL/rating stay in the manifest editor):
+ *   1. Resolve `appBlockId` → `appListingId` via `getMyListingForApp`.
+ *   2. `beginListingRevision({ listingId })` (idempotent — resumes an in-flight
+ *      shadow) to get the editable SHADOW id. All asset edits target the shadow, so
+ *      the live listing keeps serving until a moderator re-approves.
+ *   3. Render `<ListingAssetStep listingId={shadowId} …/>` (reused verbatim — each
+ *      icon/cover/screenshot mutation hits the shadow eagerly through the standard
+ *      Image ingestion + NSFW scan).
+ *   4. "Submit for review" → `submitListingRevision({ shadowId })`.
+ *
+ * 🔴 HONEST FRAMING: the app is live, so image changes are staged as a revision and
+ * go live only after a moderator re-approves — surfaced up-front (+ a pending-review
+ * notice when a revision is already queued). Consolidation of an approved revision
+ * to live is handled server-side by the sibling onsite-consolidation change.
+ */
+export const getServerSideProps = createServerSideProps({
+  useSession: true,
+  resolver: async ({ features, session, ctx }) => {
+    if (!features?.appBlocks) return { notFound: true };
+    if (!session?.user) {
+      return {
+        redirect: { destination: getLoginLink({ returnUrl: ctx.resolvedUrl }), permanent: false },
+      };
+    }
+    return { props: {} };
+  },
+});
+
+export default function ListingMediaPage() {
+  const features = useFeatureFlags();
+  const router = useRouter();
+  const utils = trpc.useUtils();
+  const appBlockId = typeof router.query.appBlockId === 'string' ? router.query.appBlockId : '';
+
+  // 1) Owner-gated resolve of the backing listing id for this app block. A non-owner
+  //    (FORBIDDEN) or a missing listing (NOT_FOUND) both settle to NotFound (retry:false).
+  const {
+    data: listing,
+    isLoading: listingLoading,
+    error: listingError,
+  } = trpc.appListings.getMyListingForApp.useQuery(
+    { appBlockId },
+    { enabled: !!features.appBlocks && !!appBlockId, retry: false }
+  );
+
+  const listingId = listing?.appListingId;
+
+  // 2) Begin (or resume) the editable shadow revision — idempotent. Every asset
+  //    mutation the step performs targets the shadow, never the live parent.
+  const [shadowId, setShadowId] = useState<string | null>(null);
+  const [beginError, setBeginError] = useState<string | null>(null);
+  const beginRevision = trpc.appListings.beginListingRevision.useMutation();
+  useEffect(() => {
+    if (!listingId || shadowId || beginRevision.isPending) return;
+    beginRevision.mutate(
+      { listingId },
+      {
+        onSuccess: (res) => setShadowId(res.shadowId),
+        onError: (e) => setBeginError(e.message),
+      }
+    );
+    // Fire once per resolved listing id; the mutation object identity is stable enough
+    // and re-adding it would loop on each render.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [listingId]);
+
+  // 4) Submit the prepared shadow for moderator re-approval.
+  const submitRevision = trpc.appListings.submitListingRevision.useMutation();
+  async function handleSubmit() {
+    if (!shadowId) return;
+    try {
+      await submitRevision.mutateAsync({ shadowId });
+      await utils.appListings.getMyListingForApp.invalidate({ appBlockId });
+      showSuccessNotification({
+        title: 'Sent for review',
+        message: 'Your image changes go live once a moderator re-approves them.',
+      });
+      void router.push('/apps/my-submissions');
+    } catch (e) {
+      const message = (e as { message?: string }).message ?? 'Failed to submit for review.';
+      showErrorNotification({ title: 'Could not submit', error: new Error(message) });
+    }
+  }
+
+  if (!features.appBlocks) return <NotFound />;
+  // FORBIDDEN (non-owner) / NOT_FOUND (no listing) both settle to NotFound.
+  if (listingError) return <NotFound />;
+
+  return (
+    <>
+      <Meta title="Listing images — Civitai Apps" deIndex />
+      <Container size="sm" py="md">
+        <Stack gap="lg">
+          <Anchor component={Link} href={`/apps/${appBlockId}`} size="sm">
+            <Group gap={4}>
+              <IconArrowLeft size={14} />
+              Back to app
+            </Group>
+          </Anchor>
+
+          {/* 🔴 Honest, up-front framing — mirrors ExternalListingEditForm's live-app notice. */}
+          <Alert
+            icon={<IconInfoCircle size={16} />}
+            color="blue"
+            variant="light"
+            title="Listing images"
+            data-testid="apps-listing-media-live-notice"
+          >
+            <Text size="sm">
+              This app is <b>live</b> — your image changes are staged as a revision and go live only
+              after a moderator re-approves. Update the icon, cover and screenshots below, then
+              submit for review.
+            </Text>
+          </Alert>
+
+          {listing?.hasPendingRevision && (
+            <Alert
+              color="orange"
+              variant="light"
+              icon={<IconInfoCircle size={16} />}
+              data-testid="apps-listing-media-pending-revision-notice"
+            >
+              <Text size="sm">
+                A revision of this app is already under review. Submitting again updates that pending
+                revision.
+              </Text>
+            </Alert>
+          )}
+
+          {beginError && (
+            <Alert color="red" variant="light" data-testid="apps-listing-media-begin-error">
+              <Text size="sm">{beginError}</Text>
+            </Alert>
+          )}
+
+          {listingLoading || !listing ? (
+            <Center py="xl">
+              <Loader />
+            </Center>
+          ) : !shadowId ? (
+            <Group gap={8} data-testid="apps-listing-media-preparing">
+              <Loader size={16} />
+              <Text size="sm" c="dimmed">
+                Preparing your revision…
+              </Text>
+            </Group>
+          ) : (
+            <Stack gap="md">
+              <div data-testid="apps-listing-media-assets-panel">
+                <ListingAssetStep
+                  listingId={shadowId}
+                  contentRating={listing.contentRating as OffsiteContentRating}
+                  suggestions={{}}
+                  allowRemove
+                />
+              </div>
+              <Group justify="flex-end">
+                <Button
+                  onClick={() => void handleSubmit()}
+                  loading={submitRevision.isPending}
+                  leftSection={<IconSend size={16} />}
+                  data-testid="apps-listing-media-submit"
+                >
+                  Submit for review
+                </Button>
+              </Group>
+            </Stack>
+          )}
+        </Stack>
+      </Container>
+    </>
+  );
+}

--- a/src/server/routers/app-listings.router.ts
+++ b/src/server/routers/app-listings.router.ts
@@ -23,6 +23,7 @@ import {
 import {
   approveExternalRequestSchema,
   beginListingRevisionSchema,
+  getMyListingForAppSchema,
   getMyListingForEditSchema,
   listMySubmissionsSchema,
   listOffsiteRequestsSchema,
@@ -442,6 +443,28 @@ export const appListingsRouter = router({
           patch: input.patch,
           userId: ctx.user.id,
         });
+      } catch (err) {
+        throw mapOffsiteError(err);
+      }
+    }),
+
+  /**
+   * OWNER: resolve the caller's OWN listing by its backing `appBlockId` — the entry
+   * read for the owner-facing on-site listing-media page (`/apps/<appBlockId>/listing`).
+   * Returns the `AppListing.id` the page passes to `beginListingRevision` + the asset
+   * procs, plus the listing status / content rating / whether a revision is already
+   * under review. Owner-bound in the service; typed failures map via `mapOffsiteError`
+   * (NOT_OWNED→FORBIDDEN, NOT_FOUND when no listing row exists for the app).
+   */
+  getMyListingForApp: appDeveloperProcedure
+    .input(getMyListingForAppSchema)
+    .query(async ({ ctx, input }) => {
+      if (!ctx.user) throw throwAuthorizationError('Not authenticated');
+      const { getMyListingForApp } = await import(
+        '~/server/services/blocks/offsite-listing.service'
+      );
+      try {
+        return await getMyListingForApp({ appBlockId: input.appBlockId, userId: ctx.user.id });
       } catch (err) {
         throw mapOffsiteError(err);
       }

--- a/src/server/schema/blocks/offsite-listing.schema.ts
+++ b/src/server/schema/blocks/offsite-listing.schema.ts
@@ -213,6 +213,18 @@ export const beginListingRevisionSchema = z.object({
 export type BeginListingRevisionInput = z.infer<typeof beginListingRevisionSchema>;
 
 /**
+ * OWNER: resolve the caller's OWN listing by its backing `appBlockId`
+ * (`AppListing.appBlockId` is `@unique`) — the entry read for the owner-facing
+ * on-site listing-media page. Returns the `AppListing.id` (the target for
+ * `beginListingRevision` + the asset procs). Owner-bound in the service
+ * (NOT_OWNED→FORBIDDEN, NOT_FOUND when no listing row exists for the app).
+ */
+export const getMyListingForAppSchema = z.object({
+  appBlockId: z.string().min(1).max(64),
+});
+export type GetMyListingForAppInput = z.infer<typeof getMyListingForAppSchema>;
+
+/**
  * AUTHOR: owner-gated prefill read for the dual-mode edit wizard
  * (`/apps/submit?edit=<listingId>`). Returns the listing's scalars + current
  * assets + status + hasPendingRevision (resolving an approved parent's

--- a/src/server/services/blocks/__tests__/offsite-listing.get-my-listing-for-app.service.test.ts
+++ b/src/server/services/blocks/__tests__/offsite-listing.get-my-listing-for-app.service.test.ts
@@ -1,0 +1,109 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  OffsiteRequestError,
+  getMyListingForApp,
+} from '~/server/services/blocks/offsite-listing.service';
+
+/**
+ * `getMyListingForApp` — the owner-gated `appBlockId` → `AppListing.id` resolver
+ * for the on-site listing-media owner page. Covers the three contract branches:
+ *   - owner happy-path → `{ appListingId, status, contentRating, hasPendingRevision }`
+ *   - a listing owned by ANOTHER user → NOT_OWNED (router maps → FORBIDDEN)
+ *   - no listing row for the app → NOT_FOUND
+ * plus the pending-revision flag (a queued shadow-revision request flips it true).
+ *
+ * DB is fully mocked — no real Prisma. Only the two reads the function makes are
+ * stubbed (`appListing.findUnique`, `appListingPublishRequest.findFirst`).
+ */
+
+const { mockRead } = vi.hoisted(() => ({
+  mockRead: {
+    appListing: {
+      findUnique: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
+    },
+    appListingPublishRequest: {
+      findFirst: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
+    },
+  },
+}));
+
+vi.mock('~/server/db/client', () => ({ dbRead: mockRead, dbWrite: mockRead }));
+
+const OWNER = 42;
+const OTHER = 99;
+
+beforeEach(() => {
+  mockRead.appListing.findUnique.mockReset().mockResolvedValue(null);
+  mockRead.appListingPublishRequest.findFirst.mockReset().mockResolvedValue(null);
+});
+
+describe('getMyListingForApp', () => {
+  it('owner happy-path → returns the listing id + status + rating (no pending revision)', async () => {
+    mockRead.appListing.findUnique.mockResolvedValue({
+      id: 'apl_onsite',
+      userId: OWNER,
+      status: 'approved',
+      contentRating: 'pg13',
+    });
+
+    const res = await getMyListingForApp({ appBlockId: 'my-block', userId: OWNER });
+
+    expect(res).toEqual({
+      appListingId: 'apl_onsite',
+      status: 'approved',
+      contentRating: 'pg13',
+      hasPendingRevision: false,
+    });
+    // Resolved by the @unique appBlockId, not by id.
+    expect(mockRead.appListing.findUnique).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { appBlockId: 'my-block' } })
+    );
+  });
+
+  it('flags hasPendingRevision when a shadow-revision request is already queued', async () => {
+    mockRead.appListing.findUnique.mockResolvedValue({
+      id: 'apl_onsite',
+      userId: OWNER,
+      status: 'approved',
+      contentRating: 'g',
+    });
+    mockRead.appListingPublishRequest.findFirst.mockResolvedValue({ id: 'alpr_pending' });
+
+    const res = await getMyListingForApp({ appBlockId: 'my-block', userId: OWNER });
+
+    expect(res.hasPendingRevision).toBe(true);
+    // The pending check is scoped to a pending request whose listing is a shadow of ours.
+    expect(mockRead.appListingPublishRequest.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          status: 'pending',
+          appListing: { revisionOfId: 'apl_onsite' },
+        }),
+      })
+    );
+  });
+
+  it('a listing owned by another user → NOT_OWNED', async () => {
+    mockRead.appListing.findUnique.mockResolvedValue({
+      id: 'apl_onsite',
+      userId: OTHER,
+      status: 'approved',
+      contentRating: 'g',
+    });
+
+    await expect(getMyListingForApp({ appBlockId: 'my-block', userId: OWNER })).rejects.toMatchObject(
+      { name: 'OffsiteRequestError', code: 'NOT_OWNED' }
+    );
+    // Never probes the revision request once ownership fails.
+    expect(mockRead.appListingPublishRequest.findFirst).not.toHaveBeenCalled();
+  });
+
+  it('no listing row for the app → NOT_FOUND', async () => {
+    mockRead.appListing.findUnique.mockResolvedValue(null);
+
+    const err = await getMyListingForApp({ appBlockId: 'ghost', userId: OWNER }).catch((e) => e);
+    expect(err).toBeInstanceOf(OffsiteRequestError);
+    expect(err.code).toBe('NOT_FOUND');
+  });
+});

--- a/src/server/services/blocks/offsite-listing.service.ts
+++ b/src/server/services/blocks/offsite-listing.service.ts
@@ -1426,6 +1426,59 @@ export async function getMyListingForEdit(opts: {
   };
 }
 
+export type GetMyListingForAppResult = {
+  /** The backing `AppListing.id` — the target for `beginListingRevision` + the owner asset procs. */
+  appListingId: string;
+  /** The listing's TRUE lifecycle status (`draft|pending|approved|rejected|removed`). */
+  status: string;
+  /** The listing's stored content rating (drives the asset NSFW-scan threshold). */
+  contentRating: string;
+  /** Whether a shadow-revision publish request is already under review for this listing. */
+  hasPendingRevision: boolean;
+};
+
+/**
+ * OWNER: resolve the caller's OWN listing by its backing `appBlockId`
+ * (`AppListing.appBlockId` is `@unique`) — the entry read for the owner-facing
+ * on-site listing-media page. Returns the `AppListing.id` (the target the page
+ * then passes to `beginListingRevision` + the owner-gated asset procs), the
+ * listing's lifecycle status + content rating, and whether a revision is already
+ * under review. Owner-bound: a listing owned by another user → NOT_OWNED
+ * (→FORBIDDEN); no listing row for the app → NOT_FOUND. Kind-agnostic (works for
+ * both on-site and off-site listings — the on-site owner UI is the first caller).
+ */
+export async function getMyListingForApp(opts: {
+  appBlockId: string;
+  userId: number;
+}): Promise<GetMyListingForAppResult> {
+  const { appBlockId, userId } = opts;
+  const listing = await dbRead.appListing.findUnique({
+    where: { appBlockId },
+    select: { id: true, userId: true, status: true, contentRating: true },
+  });
+  if (!listing) {
+    throw new OffsiteRequestError('NOT_FOUND', `no listing found for app ${appBlockId}`);
+  }
+  if (listing.userId !== userId) {
+    throw new OffsiteRequestError('NOT_OWNED', 'you can only manage your own listings');
+  }
+  // A pending revision REQUEST (not mere shadow existence) drives the "already
+  // under review" notice — mirrors `getMyListingForEdit`. Kind-agnostic: a revision
+  // request carries the parent listing's kind, so match on the shadow relation only.
+  const pendingRevisionReq = await dbRead.appListingPublishRequest.findFirst({
+    where: { status: 'pending', appListing: { revisionOfId: listing.id } },
+    select: { id: true },
+  });
+  return {
+    appListingId: listing.id,
+    status: listing.status,
+    // Nullable column; fall back to the safest rating so the asset step's scan
+    // threshold is always defined.
+    contentRating: listing.contentRating ?? 'g',
+    hasPendingRevision: !!pendingRevisionReq,
+  };
+}
+
 /**
  * AUTHOR: write a scalar patch to an owned DRAFT shadow revision (the "direct once
  * shadow exists" scalar write for the approved edit flow). Symmetric with the

--- a/src/tests/pages/apps/listing-media-page.browser.test.tsx
+++ b/src/tests/pages/apps/listing-media-page.browser.test.tsx
@@ -1,0 +1,174 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { page, userEvent } from 'vitest/browser';
+// `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
+import { renderWithProviders } from '../../../../test/component-setup';
+import { useRouter } from 'next/router';
+
+/**
+ * On-site listing-media OWNER page (`/apps/<appBlockId>/listing`) — route-shell
+ * render test (browser mode, report-only in Tekton).
+ *
+ * Asserts the client wiring: it resolves `appBlockId` → `appListingId`
+ * (`getMyListingForApp`), begins the editable shadow revision
+ * (`beginListingRevision`), re-hosts the reused `ListingAssetStep` against the
+ * SHADOW id + the listing's content rating, surfaces the honest live-app framing
+ * copy (+ the pending-revision notice when applicable), and fires
+ * `submitListingRevision({ shadowId })` from the Submit-for-review button. The
+ * asset step itself is stubbed — its real behaviour is covered by
+ * `ListingAssetStep.browser.test.tsx`.
+ */
+
+const state = vi.hoisted(() => ({
+  // getMyListingForApp.useQuery control object.
+  query: {
+    data: undefined as unknown,
+    isLoading: false,
+    error: null as unknown,
+  },
+  // beginListingRevision — resolves to a shadow id via onSuccess.
+  begin: { shadowId: 'apl_shadow' as string | null, error: null as string | null, pending: false },
+  // submitListingRevision — captured args.
+  submit: { calls: [] as unknown[], pending: false },
+  // Props the stubbed ListingAssetStep received.
+  assetProps: { last: null as null | { listingId: string; contentRating: string } },
+  invalidate: vi.fn().mockResolvedValue(undefined),
+  flags: { appBlocks: true } as Record<string, boolean>,
+}));
+
+// The page's `getServerSideProps` calls createServerSideProps at module top — stub
+// it so importing the page in a browser test doesn't pull the server graph.
+vi.mock('~/server/utils/server-side-helpers', () => ({
+  createServerSideProps: () => async () => ({ props: {} }),
+}));
+
+vi.mock('~/providers/FeatureFlagsProvider', () => ({
+  useFeatureFlags: () => state.flags,
+}));
+
+vi.mock('~/components/AppLayout/NotFound', () => ({
+  NotFound: () => <div data-testid="not-found">Not found</div>,
+}));
+vi.mock('~/components/Meta/Meta', () => ({ Meta: () => null }));
+vi.mock('~/utils/notifications', () => ({
+  showSuccessNotification: vi.fn(),
+  showErrorNotification: vi.fn(),
+}));
+
+// Stub the reused asset step — capture the props to prove the shell threads the
+// SHADOW id + rating, without re-running its own (covered) upload behaviour.
+vi.mock('~/components/Apps/ListingAssetStep', () => ({
+  ListingAssetStep: (props: { listingId: string; contentRating: string }) => {
+    state.assetProps.last = props;
+    return (
+      <div data-testid="asset-step">
+        assets:{props.listingId}:{props.contentRating}
+      </div>
+    );
+  },
+}));
+
+vi.mock('~/utils/trpc', () => ({
+  trpc: {
+    useUtils: () => ({
+      appListings: { getMyListingForApp: { invalidate: state.invalidate } },
+    }),
+    appListings: {
+      getMyListingForApp: { useQuery: () => state.query },
+      beginListingRevision: {
+        useMutation: () => ({
+          mutate: (
+            _vars: unknown,
+            opts?: { onSuccess?: (r: { shadowId: string }) => void; onError?: (e: { message: string }) => void }
+          ) => {
+            if (state.begin.error) opts?.onError?.({ message: state.begin.error });
+            else if (state.begin.shadowId) opts?.onSuccess?.({ shadowId: state.begin.shadowId });
+          },
+          isPending: state.begin.pending,
+        }),
+      },
+      submitListingRevision: {
+        useMutation: () => ({
+          mutateAsync: async (vars: unknown) => {
+            state.submit.calls.push(vars);
+            return { publishRequestId: 'alpr_1', shadowId: state.begin.shadowId, slug: 'my-app' };
+          },
+          isPending: state.submit.pending,
+        }),
+      },
+    },
+  },
+}));
+
+const ListingMediaPage = (await import('~/pages/apps/[appBlockId]/listing')).default;
+
+function setRouterQuery(query: Record<string, string>) {
+  const router = (useRouter as unknown as () => { query: Record<string, string> })();
+  router.query = query;
+}
+
+beforeEach(() => {
+  state.query = {
+    data: { appListingId: 'apl_onsite', status: 'approved', contentRating: 'pg13', hasPendingRevision: false },
+    isLoading: false,
+    error: null,
+  };
+  state.begin = { shadowId: 'apl_shadow', error: null, pending: false };
+  state.submit = { calls: [], pending: false };
+  state.assetProps.last = null;
+  state.invalidate.mockClear();
+  state.flags = { appBlocks: true };
+  setRouterQuery({ appBlockId: 'my-block' });
+});
+
+describe('ListingMediaPage — owner listing-media route shell', () => {
+  test('resolves the listing, begins the shadow revision, and renders the asset step against the SHADOW id + rating', async () => {
+    renderWithProviders(<ListingMediaPage />);
+
+    // The reused asset step is hosted against the shadow id + the listing's rating.
+    await expect.element(page.getByTestId('asset-step')).toBeInTheDocument();
+    await expect.element(page.getByTestId('asset-step')).toHaveTextContent('assets:apl_shadow:pg13');
+    expect(state.assetProps.last).toMatchObject({ listingId: 'apl_shadow', contentRating: 'pg13' });
+    expect(page.getByTestId('not-found').elements()).toHaveLength(0);
+  });
+
+  test('surfaces the honest live-app framing copy', async () => {
+    renderWithProviders(<ListingMediaPage />);
+    const notice = page.getByTestId('apps-listing-media-live-notice');
+    await expect.element(notice).toBeInTheDocument();
+    await expect.element(notice).toHaveTextContent(/live/i);
+    await expect.element(notice).toHaveTextContent(/moderator re-approves/i);
+  });
+
+  test('Submit for review fires submitListingRevision with the shadow id', async () => {
+    renderWithProviders(<ListingMediaPage />);
+    await expect.element(page.getByTestId('apps-listing-media-submit')).toBeInTheDocument();
+    await userEvent.click(page.getByTestId('apps-listing-media-submit'));
+    await vi.waitFor(() => expect(state.submit.calls).toHaveLength(1));
+    expect(state.submit.calls[0]).toEqual({ shadowId: 'apl_shadow' });
+  });
+
+  test('shows the pending-revision notice when a revision is already under review', async () => {
+    state.query = {
+      data: { appListingId: 'apl_onsite', status: 'approved', contentRating: 'g', hasPendingRevision: true },
+      isLoading: false,
+      error: null,
+    };
+    renderWithProviders(<ListingMediaPage />);
+    await expect
+      .element(page.getByTestId('apps-listing-media-pending-revision-notice'))
+      .toBeInTheDocument();
+  });
+
+  test('does NOT show the pending-revision notice when none is queued', async () => {
+    renderWithProviders(<ListingMediaPage />);
+    await expect.element(page.getByTestId('asset-step')).toBeInTheDocument();
+    expect(page.getByTestId('apps-listing-media-pending-revision-notice').elements()).toHaveLength(0);
+  });
+
+  test('fails closed to NotFound when the owner resolve errors (non-owner / missing listing)', async () => {
+    state.query = { data: undefined, isLoading: false, error: { message: 'FORBIDDEN' } };
+    renderWithProviders(<ListingMediaPage />);
+    await expect.element(page.getByTestId('not-found')).toBeInTheDocument();
+    expect(page.getByTestId('asset-step').elements()).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## What

Onsite app owners had **no way** to add or update their listing's icon, cover, or screenshots. This PR adds the owner-facing media editor page + the read proc that backs it.

### New page — `src/pages/apps/[appBlockId]/listing.tsx`
Mirrors `edit-manifest.tsx`'s gating (appBlocks flag + login + owner). Flow:
1. Resolve `appBlockId` → `appListingId` via the new `appListings.getMyListingForApp`.
2. `beginListingRevision({ listingId })` (idempotent — gets/resumes the shadow) to get the editable **shadow** id.
3. Render the **reused** `<ListingAssetStep listingId={shadowId} …/>` — each icon/cover/screenshot mutation hits the shadow eagerly through the standard Image ingestion + NSFW scan.
4. **"Submit for review"** → `submitListingRevision({ shadowId })`.

**Assets-only** — no name/description/URL/category/rating fields (those stay in the manifest editor for onsite).

### New proc — `appListings.getMyListingForApp({ appBlockId })`
Owner-gated. Resolves `AppListing` by its `@unique` `appBlockId`, owner-checks it (non-owner → FORBIDDEN, no listing row → NOT_FOUND), and returns `{ appListingId, status, contentRating, hasPendingRevision }`. Typed failures map through the existing `mapOffsiteError`.

### Honest review framing
The app is **live**, so image changes are staged as a revision and go live **only after a moderator re-approves** — surfaced up-front, mirroring the external listing edit form's live-app notice. A pending-revision notice shows when a revision is already under review.

### Entry point
A **"Listing images"** action on the approved onsite row in `MySubmissionsList` (owner-gated; hidden on a mod-removed listing).

## Tests
- **Blocking unit test** for `getMyListingForApp` (owner happy-path → `{ appListingId }`; non-owner → FORBIDDEN; no listing → NOT_FOUND; pending-revision flag). DB mocked. `4 passed`.
- **Report-only browser test** for the page shell (resolves listing → begins shadow → renders `ListingAssetStep` against the shadow id/rating → submit fires `submitListingRevision`; live-app framing + pending-revision copy present; fails closed to NotFound on a non-owner resolve). Mocked procs.

## Dependency
Uploads + submit-for-review **work today** (the shadow-revision begin/upload/submit machinery is kind-correct for onsite). The final **approve → live consolidation** of an onsite listing-media revision depends on the sibling **`zach/onsite-listing-revision-server`** PR.

## Verification note
`tsc --noEmit` is clean on all edited files (pre-existing errors elsewhere untouched). The blocking unit test passes. The report-only browser test was authored following the existing page-shell test pattern but **not executed locally** (no runnable browser on this host) — it runs report-only in CI. The mod-gated page needs a **human preview click-through** to confirm the end-to-end upload → submit round-trip.

## Gates
- pr-preview
- /audit-pr

🤖 Generated with [Claude Code](https://claude.com/claude-code)
