### PR TITLE
feat(apps): public REST list/search/view for published App Blocks

### DIFF
--- a/packages/civitai-redis/src/client.ts
+++ b/packages/civitai-redis/src/client.ts
@@ -1675,6 +1675,16 @@ export const REDIS_SYS_KEYS = {
      */
     SUBMISSIONS_RATE_LIMIT: 'system:blocks:submissions-rate-limit',
     /**
+     * Per-user (fallback per-IP) rate-limit counter for the PUBLIC app-catalog
+     * read (`/api/v1/apps` list + `/api/v1/apps/{slug}` detail). Same
+     * `SET NX EX` + `INCR` MULTI shape as `SUBMISSIONS_RATE_LIMIT` (always
+     * created with its TTL), on `sysRedis`. Mirrors the 60/60 limit the tRPC
+     * marketplace procs carry, keyed on the authenticated user when a bearer is
+     * present and the client IP otherwise. Bounds a scripted crawler of the
+     * published-apps listing.
+     */
+    APPS_CATALOG_RATE_LIMIT: 'system:blocks:apps-catalog-rate-limit',
+    /**
      * Per-user (fallback per-IP) rate-limit counter for the token-auth
      * self-scoped submission WITHDRAW (`/api/v1/blocks/withdraw`). Same
      * `SET NX EX` + `INCR` MULTI shape as `SUBMISSIONS_RATE_LIMIT` (always

--- a/src/pages/api/v1/apps/[slug].ts
+++ b/src/pages/api/v1/apps/[slug].ts
@@ -1,0 +1,73 @@
+import * as z from 'zod';
+import { resolveStoreVisibilityScope } from '~/server/services/app-blocks-flag';
+import { getListingDetail } from '~/server/services/blocks/app-listing.service';
+import { MixedAuthEndpoint, handleEndpointError } from '~/server/utils/endpoint-helpers';
+import { enforceAppsCatalogRateLimit } from '~/server/utils/apps-catalog-rate-limit';
+import { isHostForColor } from '~/server/utils/server-domain';
+
+/**
+ * GET /api/v1/apps/{slug}
+ *
+ * PUBLIC, stable REST detail (card fields + gallery + manifest-derived action
+ * data) for ONE published App-Block listing, by slug — the REST front for the
+ * otherwise tRPC-only per-app store detail. Backs the CLI's app-view command.
+ *
+ * ## Auth — OPTIONAL bearer (anon-capable)
+ * `MixedAuthEndpoint` resolves the caller from an `Authorization: Bearer` token
+ * when present and otherwise proceeds anonymous; an absent / invalid / expired
+ * token is treated as anonymous, never a hard error.
+ *
+ * ## Visibility — per-user SCOPE, DEFAULT CLOSED
+ * Same gate as the list endpoint: `resolveStoreVisibilityScope({ user })` is
+ * computed and passed EXPLICITLY to the listing service. A `none` scope (anon /
+ * non-privileged, pre-launch default) yields 404 — a caller can never enumerate
+ * a listing outside their scope, and the boundary AUTO-WIDENS with the same
+ * marketplace flag the store UI keys on (no code change here).
+ *
+ * ## 404 posture
+ * A missing slug, a non-approved listing, an onsite listing under
+ * `public-external` scope, or a mature listing off a non-red host all resolve to
+ * the SAME 404 as a genuinely absent app — no existence oracle.
+ */
+
+/** Single query-param value (Next gives `string | string[] | undefined`); '' → undefined. */
+function firstQuery(v: string | string[] | undefined): string | undefined {
+  const first = Array.isArray(v) ? v[0] : v;
+  return first === '' ? undefined : first;
+}
+
+/** RED-capable host membership test — mirrors the store router's maturity gate. */
+function isRedCapableRequest(host: string | undefined): boolean {
+  return !!host && host !== '' && isHostForColor(host, 'red');
+}
+
+const slugSchema = z.object({ slug: z.string().min(1).max(64) });
+
+export default MixedAuthEndpoint(async function handler(req, res, user) {
+  const parsed = slugSchema.safeParse({ slug: firstQuery(req.query.slug) });
+  if (!parsed.success) {
+    return res.status(400).json({ error: parsed.error.flatten() });
+  }
+
+  const limited = await enforceAppsCatalogRateLimit({ req, res, user, log: req.log });
+  if (limited) return;
+
+  // DEFAULT-CLOSED scope gate — pass the resolved scope EXPLICITLY to the service.
+  const scope = await resolveStoreVisibilityScope({ user });
+  if (scope === 'none') {
+    return res.status(404).json({ error: 'App not found' });
+  }
+
+  try {
+    const detail = await getListingDetail(
+      { slug: parsed.data.slug },
+      { redCapable: isRedCapableRequest(req.headers.host), scope }
+    );
+    if (!detail) {
+      return res.status(404).json({ error: 'App not found' });
+    }
+    return res.status(200).json(detail);
+  } catch (e) {
+    return handleEndpointError(res, e);
+  }
+});

--- a/src/pages/api/v1/apps/index.ts
+++ b/src/pages/api/v1/apps/index.ts
@@ -1,0 +1,94 @@
+import * as z from 'zod';
+import { getAppListingsListQuery } from '~/server/schema/blocks/app-listing-read.schema';
+import { resolveStoreVisibilityScope } from '~/server/services/app-blocks-flag';
+import { listAvailableListings } from '~/server/services/blocks/app-listing.service';
+import { MixedAuthEndpoint, handleEndpointError } from '~/server/utils/endpoint-helpers';
+import { enforceAppsCatalogRateLimit } from '~/server/utils/apps-catalog-rate-limit';
+import { getNextPage } from '~/server/utils/pagination-helpers';
+import { isHostForColor } from '~/server/utils/server-domain';
+
+/**
+ * GET /api/v1/apps
+ *
+ * PUBLIC, stable REST list/search of PUBLISHED App-Block listings — the REST
+ * front for the unified `/apps` marketplace (which is otherwise tRPC-only). It
+ * backs a CLI app-discovery command: a client can enumerate + filter published
+ * apps over the same `/api/v1/*` contract the rest of the CLI already speaks.
+ *
+ * ## Auth — OPTIONAL bearer (anon-capable)
+ * `MixedAuthEndpoint` resolves the caller from an `Authorization: Bearer` token
+ * when one is present (via the same session path every `/api/v1/*` endpoint
+ * uses) and otherwise proceeds as anonymous. An absent / invalid / expired token
+ * is simply treated as anonymous — NEVER a hard error.
+ *
+ * ## Visibility — per-user SCOPE, DEFAULT CLOSED (the security crux)
+ * The catalog is gated by `resolveStoreVisibilityScope({ user })` — the SAME
+ * helper the store tRPC read middleware uses — and its result is passed
+ * EXPLICITLY to the listing service. The service is scope-parametric and
+ * defaults to `full`, so the scope MUST be threaded through: never let an
+ * unscoped caller fall through to the full catalog.
+ *   - `none`            → empty page (anon / non-privileged, pre-launch default).
+ *   - `full`            → the whole approved catalog (mods + app-dev-testers).
+ *   - `public-external` → offsite listings only (once the public flag opens).
+ * This AUTO-WIDENS for everyone the instant the marketplace Flipt segment opens,
+ * with no code change here — the endpoint defers to the same flag the store UI
+ * keys on.
+ *
+ * ## Response — the standard paginated `/api/v1` envelope
+ * `{ items: ListingCard[], metadata: { nextCursor, nextPage } }` — keyset cursor
+ * pagination (NOT page/offset), so the client's existing cursor machinery works
+ * unchanged.
+ *
+ * ## Filters (only what the store service actually supports)
+ * `kind` (all|onsite|offsite), `category`, `sort` (top-rated|popular|newest|
+ * name), `cursor`, `limit` (1..50). NOTE: the store service exposes no free-text
+ * search or slot filter, so this endpoint intentionally does not accept a
+ * `query`/`slot` param (they'd be inert).
+ */
+
+/** Single query-param value (Next gives `string | string[] | undefined`); '' → undefined. */
+function firstQuery(v: string | string[] | undefined): string | undefined {
+  const first = Array.isArray(v) ? v[0] : v;
+  return first === '' ? undefined : first;
+}
+
+/** RED-capable host membership test — mirrors the store router's maturity gate. */
+function isRedCapableRequest(host: string | undefined): boolean {
+  return !!host && host !== '' && isHostForColor(host, 'red');
+}
+
+const querySchema = getAppListingsListQuery();
+
+export default MixedAuthEndpoint(async function handler(req, res, user) {
+  const parsed = querySchema.safeParse({
+    kind: firstQuery(req.query.kind),
+    category: firstQuery(req.query.category),
+    sort: firstQuery(req.query.sort),
+    cursor: firstQuery(req.query.cursor),
+    limit: firstQuery(req.query.limit),
+  });
+  if (!parsed.success) {
+    return res.status(400).json({ error: parsed.error.flatten() });
+  }
+
+  const limited = await enforceAppsCatalogRateLimit({ req, res, user, log: req.log });
+  if (limited) return;
+
+  // DEFAULT-CLOSED scope gate — pass the resolved scope EXPLICITLY to the service.
+  const scope = await resolveStoreVisibilityScope({ user });
+  if (scope === 'none') {
+    // Anon / non-privileged pre-launch → empty page, NEVER the full catalog.
+    return res.status(200).json({ items: [], metadata: { nextCursor: undefined, nextPage: undefined } });
+  }
+
+  try {
+    const { items, nextCursor } = await listAvailableListings(parsed.data, {
+      redCapable: isRedCapableRequest(req.headers.host),
+      scope,
+    });
+    const { nextPage } = getNextPage({ req, nextCursor });
+    return res.status(200).json({ items, metadata: { nextCursor, nextPage } });
+  } catch (e) {
+    return handleEndpointError(res, e);
+  }
+});

--- a/src/server/schema/blocks/app-listing-read.schema.ts
+++ b/src/server/schema/blocks/app-listing-read.schema.ts
@@ -59,6 +59,31 @@ export const listAppListingsSchema = z.object({
 export type ListAppListingsInput = z.infer<typeof listAppListingsSchema>;
 
 /**
+ * REST-query variant of {@link listAppListingsSchema} for the public
+ * `GET /api/v1/apps` endpoint. Identical filter axes + bounds, but `limit`
+ * arrives as a STRING query param, so it is coerced (empty/absent → the default)
+ * and the parse output is exactly a {@link ListAppListingsInput} — the same
+ * object the listing service consumes. A factory (not a const) so the endpoint
+ * gets a fresh schema without pulling the whole read-schema module's eval graph
+ * at import time. NOTE: the store service supports no free-text search or slot
+ * filter, so neither is accepted here (they would be inert).
+ */
+export function getAppListingsListQuery() {
+  return z.object({
+    kind: listingKindFilterSchema.default('all'),
+    category: z.enum(MARKETPLACE_CATEGORIES).optional(),
+    sort: listingSortSchema.default('top-rated'),
+    cursor: z.string().max(128).optional(),
+    limit: z
+      .preprocess(
+        (v) => (v === undefined || v === null || v === '' ? undefined : Number(v)),
+        z.number().int().min(1).max(50)
+      )
+      .default(20),
+  });
+}
+
+/**
  * W13 POST-APPROVAL MOD MANAGEMENT — the moderator all-status listings read.
  *
  * Backs `appListings.listAllListingsForModeration` (moderatorProcedure): unlike

--- a/src/server/services/blocks/__tests__/app-listing.public-scope.test.ts
+++ b/src/server/services/blocks/__tests__/app-listing.public-scope.test.ts
@@ -221,4 +221,13 @@ describe('getListingDetail — STORE-SCOPE kind gate (app-layer)', () => {
     mockDbRead.appListing.findFirst.mockResolvedValueOnce({ ...onsiteRow(), status: 'approved' });
     expect(await getListingDetail({ slug: 'cool-app' })).not.toBeNull();
   });
+
+  it('none → HIDES (null) even an approved listing, and never touches the DB (default-closed guard)', async () => {
+    // Defense-in-depth symmetric with listingPublicVisibilityFilter('none') → FALSE:
+    // a caller with no store visibility gets nothing. The guard short-circuits before
+    // the hydration read, so an approved row mocked here must NOT leak.
+    mockDbRead.appListing.findFirst.mockResolvedValueOnce({ ...onsiteRow(), status: 'approved' });
+    expect(await getListingDetail({ slug: 'cool-app' }, { scope: 'none' })).toBeNull();
+    expect(mockDbRead.appListing.findFirst).not.toHaveBeenCalled();
+  });
 });

--- a/src/server/services/blocks/app-listing.service.ts
+++ b/src/server/services/blocks/app-listing.service.ts
@@ -556,6 +556,12 @@ export async function getListingDetail(
   const redCapable = opts.redCapable ?? false;
   // Default `full` for callers that don't pass a scope (see listAvailableListings).
   const scope = opts.scope ?? 'full';
+  // STORE-SCOPE `none` (default-closed): a caller with no store visibility gets
+  // nothing — symmetric with the list path's `listingPublicVisibilityFilter('none')`
+  // → FALSE. The v1 endpoints short-circuit `none` before calling this, but honor
+  // the gate here too so a future non-endpoint caller passing `none` can't reach a
+  // listing's detail.
+  if (scope === 'none') return null;
   // Assert exactly-one selector in the SERVICE (the zod `.refine` only guards the
   // tRPC boundary, but this fn is exported). Neither → `findFirst({ slug:
   // undefined })` would return an ARBITRARY approved row (enumeration footgun);

--- a/src/server/utils/apps-catalog-rate-limit.ts
+++ b/src/server/utils/apps-catalog-rate-limit.ts
@@ -1,0 +1,91 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import type { SessionUser } from '~/types/session';
+import { REDIS_SYS_KEYS, sysRedis } from '~/server/redis/client';
+
+/**
+ * Abuse-control rate limiter for the PUBLIC app-catalog read endpoints
+ * (`GET /api/v1/apps` + `GET /api/v1/apps/{slug}`).
+ *
+ * Mirrors the counter shape of the sibling `/api/v1/blocks/submissions` limiter
+ * (atomic `SET NX EX` + `INCR` MULTI on `sysRedis`) and the 60/60 window the
+ * tRPC marketplace procs carry — keyed on the authenticated user id when a
+ * bearer is present (`u:<id>`, the stable identity) and the client IP otherwise
+ * (`ip:<addr>`, the anon fallback).
+ *
+ * DELIBERATE DIVERGENCE from the submissions limiter: these are PUBLIC, edge-
+ * cacheable READ endpoints, so a Redis blip should NOT turn a catalog browse
+ * into a 503 wall — this limiter FAILS OPEN (serves the request) on a limiter
+ * error/malformed result, trading a transient loss of abuse-control for
+ * availability. The submissions read fails CLOSED because it is a private,
+ * un-cached, per-user surface. (The security gate for these endpoints is the
+ * visibility SCOPE, not the rate limit.)
+ *
+ * Returns `true` when the request was rate-limited and a `429` has already been
+ * written to `res` (the caller must stop); `false` when the caller should
+ * proceed.
+ */
+
+const RATE_LIMIT = { max: 60, windowSeconds: 60 } as const;
+
+function clientIp(req: NextApiRequest): string {
+  const xff = req.headers['x-forwarded-for'];
+  const first = Array.isArray(xff) ? xff[0] : xff?.split(',')[0];
+  return (first ?? req.socket?.remoteAddress ?? 'unknown').trim();
+}
+
+type LimiterLog = { warn?: (message: string, meta?: Record<string, unknown>) => void };
+
+export async function enforceAppsCatalogRateLimit({
+  req,
+  res,
+  user,
+  log,
+}: {
+  req: NextApiRequest;
+  res: NextApiResponse;
+  user: SessionUser | undefined;
+  log?: LimiterLog;
+}): Promise<boolean> {
+  const rateSubject = user?.id ? `u:${user.id}` : `ip:${clientIp(req)}`;
+  const rateKey = `${REDIS_SYS_KEYS.BLOCKS.APPS_CATALOG_RATE_LIMIT}:${rateSubject}` as const;
+
+  let count: number;
+  try {
+    const multiResult = await sysRedis
+      .multi()
+      .set(rateKey, '0', { NX: true, EX: RATE_LIMIT.windowSeconds })
+      .incr(rateKey)
+      .exec();
+    count = Number(multiResult?.[1]);
+  } catch (err) {
+    // PUBLIC read → fail OPEN (availability over abuse-control on a Redis incident).
+    log?.warn?.('apps-catalog: rate limiter threw; failing open', { rateSubject });
+    return false;
+  }
+
+  if (!Number.isFinite(count)) {
+    log?.warn?.('apps-catalog: rate-limit counter malformed; failing open', { rateSubject });
+    return false;
+  }
+
+  // Self-heal a TTL-less key (re-arm only when the TTL is actually missing, so an
+  // active window is never extended) — same footgun guard as the sibling limiters.
+  if (count > 1) {
+    const ttl = await sysRedis.ttl(rateKey).catch(() => -1);
+    if (ttl < 0) await sysRedis.expire(rateKey, RATE_LIMIT.windowSeconds).catch(() => {});
+  }
+
+  if (count > RATE_LIMIT.max) {
+    const retryAfter = await sysRedis.ttl(rateKey).catch(() => RATE_LIMIT.windowSeconds);
+    res.setHeader('Retry-After', String(Math.max(retryAfter, 1)));
+    res.status(429).json({
+      message: 'Rate limit exceeded',
+      retryAfterSeconds: retryAfter,
+      limit: RATE_LIMIT.max,
+      windowSeconds: RATE_LIMIT.windowSeconds,
+    });
+    return true;
+  }
+
+  return false;
+}

--- a/src/tests/api/v1/apps/apps.test.ts
+++ b/src/tests/api/v1/apps/apps.test.ts
@@ -1,0 +1,305 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * Handler-level coverage for the PUBLIC app-catalog REST endpoints:
+ *   - GET /api/v1/apps          (list + filter, keyset paginated)
+ *   - GET /api/v1/apps/{slug}   (single detail)
+ *
+ * The security crux is the DEFAULT-CLOSED per-user scope gate: an anonymous /
+ * non-privileged caller resolves scope `none` and MUST receive the empty page /
+ * 404 — NEVER the full catalog — even though the underlying listing service
+ * defaults to `full`. The load-bearing guards (`does NOT leak the catalog to
+ * anon`) mock the service to return NON-empty data and assert the handler still
+ * returns nothing for an unscoped caller, so deleting the scope wiring fails the
+ * test.
+ */
+
+const {
+  mockResolveScope,
+  mockList,
+  mockDetail,
+  mockRateLimit,
+  mockGetNextPage,
+  mockIsHostForColor,
+} = vi.hoisted(() => ({
+  mockResolveScope: vi.fn(),
+  mockList: vi.fn(),
+  mockDetail: vi.fn(),
+  mockRateLimit: vi.fn(),
+  mockGetNextPage: vi.fn(),
+  mockIsHostForColor: vi.fn(),
+}));
+
+vi.mock('~/server/utils/endpoint-helpers', () => ({
+  MixedAuthEndpoint: (handler: unknown) => handler,
+  handleEndpointError: (res: { status: (n: number) => { json: (b: unknown) => unknown } }, e: unknown) =>
+    res.status(500).json({ message: (e as Error)?.message ?? 'error' }),
+}));
+vi.mock('~/server/services/app-blocks-flag', () => ({
+  resolveStoreVisibilityScope: mockResolveScope,
+}));
+vi.mock('~/server/services/blocks/app-listing.service', () => ({
+  listAvailableListings: mockList,
+  getListingDetail: mockDetail,
+}));
+vi.mock('~/server/utils/apps-catalog-rate-limit', () => ({
+  enforceAppsCatalogRateLimit: mockRateLimit,
+}));
+vi.mock('~/server/utils/pagination-helpers', () => ({
+  getNextPage: mockGetNextPage,
+}));
+vi.mock('~/server/utils/server-domain', () => ({
+  isHostForColor: mockIsHostForColor,
+}));
+
+import listHandler from '~/pages/api/v1/apps/index';
+import detailHandler from '~/pages/api/v1/apps/[slug]';
+
+type Handler = (req: unknown, res: unknown, user: unknown) => Promise<unknown>;
+
+function createMocks({
+  query = {},
+  headers = {},
+}: { query?: Record<string, string>; headers?: Record<string, string> } = {}) {
+  const req = {
+    method: 'GET',
+    url: '/api/v1/apps',
+    query,
+    headers,
+    socket: { remoteAddress: '203.0.113.7' },
+    log: { warn: vi.fn(), info: vi.fn(), error: vi.fn() },
+  };
+  let statusCode = 200;
+  let payload: unknown;
+  const responseHeaders: Record<string, string> = {};
+  const res = {
+    status(c: number) {
+      statusCode = c;
+      return res;
+    },
+    json(b: unknown) {
+      payload = b;
+      return res;
+    },
+    setHeader(k: string, v: string) {
+      responseHeaders[k] = v;
+    },
+    end() {
+      return res;
+    },
+    _status: () => statusCode,
+    _json: () => payload,
+    _headers: () => responseHeaders,
+  };
+  return { req, res };
+}
+
+const MOD = { id: 7, isModerator: true };
+const NORMAL = { id: 8, isModerator: false };
+
+function card(slug: string) {
+  return { id: `al_${slug}`, slug, kind: 'onsite', name: slug, category: 'utility' };
+}
+function detail(slug: string) {
+  return { id: `al_${slug}`, serialId: 1, slug, kind: 'onsite', name: slug, screenshots: [] };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockRateLimit.mockResolvedValue(false); // not rate-limited by default
+  mockIsHostForColor.mockReturnValue(false); // non-red host by default
+  mockGetNextPage.mockImplementation(({ nextCursor }: { nextCursor?: string }) => ({
+    baseUrl: new URL('http://localhost/api/v1/apps'),
+    nextPage: nextCursor ? `http://localhost/api/v1/apps?cursor=${nextCursor}` : undefined,
+  }));
+  // Default identity scope: mods → full, everyone else → none (the pre-launch default).
+  mockResolveScope.mockImplementation(async ({ user }: { user?: { isModerator?: boolean } }) =>
+    user?.isModerator ? 'full' : 'none'
+  );
+  mockList.mockResolvedValue({ items: [card('a'), card('b')], nextCursor: undefined });
+  mockDetail.mockResolvedValue(detail('a'));
+});
+
+describe('GET /api/v1/apps (list)', () => {
+  it('SECURITY: anonymous caller gets the CLOSED scope — empty page, NOT the full catalog', async () => {
+    // The service is mocked to ALWAYS return items; the handler must still return
+    // empty for an unscoped (anon) caller. This fails if the scope gate is removed.
+    mockList.mockResolvedValue({ items: [card('leak-a'), card('leak-b')], nextCursor: 'x' });
+    const { req, res } = createMocks();
+    await (listHandler as unknown as Handler)(req, res, undefined);
+    expect(res._status()).toBe(200);
+    expect((res._json() as { items: unknown[] }).items).toEqual([]);
+    // The catalog service is never consulted for a `none` scope.
+    expect(mockList).not.toHaveBeenCalled();
+  });
+
+  it('SECURITY: a normal (non-privileged) authed user also gets the closed scope', async () => {
+    mockList.mockResolvedValue({ items: [card('leak')], nextCursor: undefined });
+    const { req, res } = createMocks();
+    await (listHandler as unknown as Handler)(req, res, NORMAL);
+    expect((res._json() as { items: unknown[] }).items).toEqual([]);
+    expect(mockList).not.toHaveBeenCalled();
+  });
+
+  it('a mod (full scope) gets the catalog — service called WITH the resolved scope', async () => {
+    const { req, res } = createMocks();
+    await (listHandler as unknown as Handler)(req, res, MOD);
+    expect(res._status()).toBe(200);
+    const body = res._json() as { items: unknown[]; metadata: { nextCursor?: string } };
+    expect(body.items).toHaveLength(2);
+    // The scope is threaded EXPLICITLY into the service (guards against a caller
+    // falling through to the service default of `full`).
+    expect(mockList).toHaveBeenCalledTimes(1);
+    const [, opts] = mockList.mock.calls[0];
+    expect(opts).toMatchObject({ scope: 'full' });
+  });
+
+  it('serves the public-external scope (offsite-only) to a widened caller', async () => {
+    mockResolveScope.mockResolvedValueOnce('public-external');
+    const { req, res } = createMocks();
+    await (listHandler as unknown as Handler)(req, res, undefined);
+    expect(res._status()).toBe(200);
+    const [, opts] = mockList.mock.calls[0];
+    expect(opts).toMatchObject({ scope: 'public-external' });
+  });
+
+  it('passes every filter param through to the service, coercing limit to a number', async () => {
+    const { req, res } = createMocks({
+      query: { kind: 'offsite', category: 'utility', sort: 'newest', cursor: 'c1', limit: '5' },
+    });
+    await (listHandler as unknown as Handler)(req, res, MOD);
+    const [input] = mockList.mock.calls[0];
+    expect(input).toEqual({
+      kind: 'offsite',
+      category: 'utility',
+      sort: 'newest',
+      cursor: 'c1',
+      limit: 5,
+    });
+  });
+
+  it('applies schema defaults when no filters are supplied', async () => {
+    const { req, res } = createMocks();
+    await (listHandler as unknown as Handler)(req, res, MOD);
+    const [input] = mockList.mock.calls[0];
+    expect(input).toEqual({ kind: 'all', sort: 'top-rated', limit: 20 });
+  });
+
+  it('cursor pagination round-trips: nextCursor surfaces in metadata + nextPage', async () => {
+    mockList.mockResolvedValueOnce({ items: [card('a')], nextCursor: 'c2' });
+    const { req, res } = createMocks();
+    await (listHandler as unknown as Handler)(req, res, MOD);
+    const md = (res._json() as { metadata: { nextCursor?: string; nextPage?: string } }).metadata;
+    expect(md.nextCursor).toBe('c2');
+    expect(md.nextPage).toContain('cursor=c2');
+
+    // Page 2: a cursor in, no cursor out → terminal page.
+    mockList.mockResolvedValueOnce({ items: [card('c')], nextCursor: undefined });
+    const { req: req2, res: res2 } = createMocks({ query: { cursor: 'c2' } });
+    await (listHandler as unknown as Handler)(req2, res2, MOD);
+    const md2 = (res2._json() as { metadata: { nextCursor?: string } }).metadata;
+    expect(md2.nextCursor).toBeUndefined();
+    expect(mockList.mock.calls[1][0]).toMatchObject({ cursor: 'c2' });
+  });
+
+  it('threads redCapable from a red-capable host into the service', async () => {
+    mockIsHostForColor.mockReturnValue(true);
+    const { req, res } = createMocks({ headers: { host: 'civitai.red' } });
+    await (listHandler as unknown as Handler)(req, res, MOD);
+    const [, opts] = mockList.mock.calls[0];
+    expect(opts).toMatchObject({ redCapable: true });
+  });
+
+  it('invalid/expired token → treated as anonymous (no 500): user undefined → empty page', async () => {
+    // MixedAuthEndpoint resolves an invalid bearer to `undefined`; the handler
+    // must treat that as anon (empty), never crash.
+    const { req, res } = createMocks({ headers: { authorization: 'Bearer garbage' } });
+    await (listHandler as unknown as Handler)(req, res, undefined);
+    expect(res._status()).toBe(200);
+    expect((res._json() as { items: unknown[] }).items).toEqual([]);
+  });
+
+  it('400 on an out-of-range limit', async () => {
+    const { req, res } = createMocks({ query: { limit: '0' } });
+    await (listHandler as unknown as Handler)(req, res, MOD);
+    expect(res._status()).toBe(400);
+    expect(mockList).not.toHaveBeenCalled();
+
+    const { req: r2, res: res2 } = createMocks({ query: { limit: '51' } });
+    await (listHandler as unknown as Handler)(r2, res2, MOD);
+    expect(res2._status()).toBe(400);
+  });
+
+  it('429 when rate-limited: the limiter short-circuits before any scope/service work', async () => {
+    mockRateLimit.mockImplementationOnce(async ({ res }: { res: { status: (n: number) => { json: (b: unknown) => unknown } } }) => {
+      res.status(429).json({ message: 'Rate limit exceeded' });
+      return true;
+    });
+    const { req, res } = createMocks();
+    await (listHandler as unknown as Handler)(req, res, MOD);
+    expect(res._status()).toBe(429);
+    expect(mockResolveScope).not.toHaveBeenCalled();
+    expect(mockList).not.toHaveBeenCalled();
+  });
+
+  it('maps a service throw to a 500 via handleEndpointError (not an unhandled crash)', async () => {
+    mockList.mockRejectedValueOnce(new Error('db exploded'));
+    const { req, res } = createMocks();
+    await (listHandler as unknown as Handler)(req, res, MOD);
+    expect(res._status()).toBe(500);
+  });
+});
+
+describe('GET /api/v1/apps/{slug} (detail)', () => {
+  it('SECURITY: an out-of-scope (anon) caller gets 404, and the service is never called', async () => {
+    // Service mocked to return a real listing; the scope gate must still 404.
+    mockDetail.mockResolvedValue(detail('secret-app'));
+    const { req, res } = createMocks({ query: { slug: 'secret-app' } });
+    await (detailHandler as unknown as Handler)(req, res, undefined);
+    expect(res._status()).toBe(404);
+    expect(mockDetail).not.toHaveBeenCalled();
+  });
+
+  it('found in scope → 200 with the detail + manifest-derived fields', async () => {
+    const { req, res } = createMocks({ query: { slug: 'my-app' } });
+    await (detailHandler as unknown as Handler)(req, res, MOD);
+    expect(res._status()).toBe(200);
+    expect((res._json() as { slug: string }).slug).toBe('a');
+    // Scope threaded explicitly into the service, keyed by slug.
+    expect(mockDetail).toHaveBeenCalledWith(
+      { slug: 'my-app' },
+      expect.objectContaining({ scope: 'full' })
+    );
+  });
+
+  it('absent listing (service returns null) → 404', async () => {
+    mockDetail.mockResolvedValueOnce(null);
+    const { req, res } = createMocks({ query: { slug: 'ghost' } });
+    await (detailHandler as unknown as Handler)(req, res, MOD);
+    expect(res._status()).toBe(404);
+  });
+
+  it('400 on a missing/empty slug', async () => {
+    const { req, res } = createMocks({ query: {} });
+    await (detailHandler as unknown as Handler)(req, res, MOD);
+    expect(res._status()).toBe(400);
+    expect(mockDetail).not.toHaveBeenCalled();
+  });
+
+  it('invalid/expired token → anonymous → 404 (not a 500)', async () => {
+    const { req, res } = createMocks({ query: { slug: 'my-app' }, headers: { authorization: 'Bearer garbage' } });
+    await (detailHandler as unknown as Handler)(req, res, undefined);
+    expect(res._status()).toBe(404);
+  });
+
+  it('429 when rate-limited: short-circuits before scope/service', async () => {
+    mockRateLimit.mockImplementationOnce(async ({ res }: { res: { status: (n: number) => { json: (b: unknown) => unknown } } }) => {
+      res.status(429).json({ message: 'Rate limit exceeded' });
+      return true;
+    });
+    const { req, res } = createMocks({ query: { slug: 'my-app' } });
+    await (detailHandler as unknown as Handler)(req, res, MOD);
+    expect(res._status()).toBe(429);
+    expect(mockDetail).not.toHaveBeenCalled();
+  });
+});

--- a/src/tests/server/utils/apps-catalog-rate-limit.test.ts
+++ b/src/tests/server/utils/apps-catalog-rate-limit.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+/**
+ * Unit coverage for the PUBLIC app-catalog rate limiter shared by
+ * `GET /api/v1/apps` + `GET /api/v1/apps/{slug}`.
+ *
+ * Asserts:
+ *   - per-user key (`u:<id>`) when a bearer resolved a user; client-IP fallback
+ *     (`ip:<addr>`) otherwise.
+ *   - under the 60/window limit → proceeds (returns false, no 429).
+ *   - over the limit → 429 + Retry-After (returns true).
+ *   - FAIL-OPEN (the deliberate divergence from the submissions limiter): a Redis
+ *     throw OR a malformed exec result → PROCEEDS (returns false), never a 503.
+ *   - self-heals a TTL-less counter key.
+ */
+
+const { mockSysRedis, mockMulti } = vi.hoisted(() => {
+  const mockMulti = {
+    value: 1 as number,
+    malformedExec: false as unknown[] | null | false,
+    throwExec: false,
+    setKey: undefined as string | undefined,
+  };
+  const multiFactory = () => ({
+    set: vi.fn((key: string) => {
+      mockMulti.setKey = key;
+      return multiChain;
+    }),
+    incr: vi.fn(() => multiChain),
+    exec: vi.fn(async () => {
+      if (mockMulti.throwExec) throw new Error('redis down');
+      return mockMulti.malformedExec !== false
+        ? mockMulti.malformedExec
+        : ['OK', mockMulti.value];
+    }),
+  });
+  let multiChain: ReturnType<typeof multiFactory>;
+  const mockSysRedis = {
+    multi: vi.fn(() => {
+      multiChain = multiFactory();
+      return multiChain;
+    }),
+    ttl: vi.fn().mockResolvedValue(60),
+    expire: vi.fn().mockResolvedValue(1),
+  };
+  return { mockSysRedis, mockMulti };
+});
+
+vi.mock('~/server/redis/client', () => ({
+  sysRedis: mockSysRedis,
+  REDIS_SYS_KEYS: { BLOCKS: { APPS_CATALOG_RATE_LIMIT: 'system:blocks:apps-catalog-rate-limit' } },
+}));
+
+import { enforceAppsCatalogRateLimit } from '~/server/utils/apps-catalog-rate-limit';
+
+function makeReqRes(remoteAddress = '203.0.113.9') {
+  const req = {
+    headers: {},
+    socket: { remoteAddress },
+  } as never;
+  let statusCode = 200;
+  const headers: Record<string, string> = {};
+  let payload: unknown;
+  const res = {
+    status(c: number) {
+      statusCode = c;
+      return res;
+    },
+    json(b: unknown) {
+      payload = b;
+      return res;
+    },
+    setHeader(k: string, v: string) {
+      headers[k] = v;
+    },
+    _status: () => statusCode,
+    _headers: () => headers,
+    _json: () => payload,
+  } as never;
+  return { req, res };
+}
+
+const MOD = { id: 7, isModerator: true } as never;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockMulti.value = 1;
+  mockMulti.malformedExec = false;
+  mockMulti.throwExec = false;
+  mockMulti.setKey = undefined;
+  mockSysRedis.ttl.mockResolvedValue(60);
+  mockSysRedis.expire.mockResolvedValue(1);
+});
+
+describe('enforceAppsCatalogRateLimit', () => {
+  it('uses a per-user key when a user is present and proceeds under the limit', async () => {
+    const { req, res } = makeReqRes();
+    const limited = await enforceAppsCatalogRateLimit({ req, res, user: MOD });
+    expect(limited).toBe(false);
+    expect(mockMulti.setKey).toBe('system:blocks:apps-catalog-rate-limit:u:7');
+    expect((res as { _status: () => number })._status()).toBe(200); // untouched
+  });
+
+  it('falls back to a client-IP key for an anonymous caller', async () => {
+    const { req, res } = makeReqRes('198.51.100.4');
+    const limited = await enforceAppsCatalogRateLimit({ req, res, user: undefined });
+    expect(limited).toBe(false);
+    expect(mockMulti.setKey).toBe('system:blocks:apps-catalog-rate-limit:ip:198.51.100.4');
+  });
+
+  it('429 + Retry-After when the window is exceeded', async () => {
+    mockMulti.value = 61; // > 60
+    const { req, res } = makeReqRes();
+    const limited = await enforceAppsCatalogRateLimit({ req, res, user: MOD });
+    expect(limited).toBe(true);
+    expect((res as { _status: () => number })._status()).toBe(429);
+    expect((res as { _headers: () => Record<string, string> })._headers()['Retry-After']).toBeDefined();
+  });
+
+  it('FAILS OPEN (proceeds, no 503) when the limiter exec throws — public-read divergence', async () => {
+    mockMulti.throwExec = true;
+    const warn = vi.fn();
+    const { req, res } = makeReqRes();
+    const limited = await enforceAppsCatalogRateLimit({ req, res, user: MOD, log: { warn } });
+    expect(limited).toBe(false);
+    expect((res as { _status: () => number })._status()).toBe(200); // never 503
+    expect(warn).toHaveBeenCalled();
+  });
+
+  it('FAILS OPEN when the exec result is malformed', async () => {
+    mockMulti.malformedExec = null;
+    const { req, res } = makeReqRes();
+    const limited = await enforceAppsCatalogRateLimit({ req, res, user: MOD });
+    expect(limited).toBe(false);
+    expect((res as { _status: () => number })._status()).toBe(200);
+  });
+
+  it('self-heals a TTL-less counter key (re-arms expiry when ttl < 0)', async () => {
+    mockMulti.value = 2; // not first hit → self-heal branch
+    mockSysRedis.ttl.mockResolvedValueOnce(-1);
+    const { req, res } = makeReqRes();
+    await enforceAppsCatalogRateLimit({ req, res, user: MOD });
+    expect(mockSysRedis.expire).toHaveBeenCalledWith(
+      'system:blocks:apps-catalog-rate-limit:u:7',
+      60
+    );
+  });
+});


### PR DESCRIPTION
## What

Adds two stable, public REST endpoints under the existing `/api/v1` surface so clients can **list, search/filter, and view published App Blocks** over plain REST. Today the `/apps` marketplace is reachable only via tRPC, which isn't a usable contract for non-web clients — this backs a **CLI app-discovery** feature (`list` / `search` / `view`).

```
GET /api/v1/apps          — list + filter published listings, keyset-paginated
GET /api/v1/apps/{slug}    — single listing detail (+ manifest-derived fields)
```

- **`GET /api/v1/apps`** returns the standard paginated envelope other v1 endpoints use:
  `{ items: ListingCard[], metadata: { nextCursor, nextPage } }`.
  Filters: `kind` (`all|onsite|offsite`), `category`, `sort` (`top-rated|popular|newest|name`), plus `cursor` + `limit` (1–50). Pagination is **keyset cursor**, not page/offset.
- **`GET /api/v1/apps/{slug}`** returns the public detail projection, or `404` when the app is absent or outside the caller's visibility.

## Design

- **Optional bearer (anon-capable).** The caller is resolved from an `Authorization: Bearer` token when one is present (the same session path every `/api/v1/*` endpoint uses) and otherwise proceeds anonymously. An absent / invalid / expired token is simply treated as anonymous — never a hard error.
- **Default-closed, per-user visibility scope (the security crux).** Visibility is computed with the **same `resolveStoreVisibilityScope({ user })` helper the store's tRPC read middleware uses**, and the resolved scope is passed **explicitly** to the listing service. The service is scope-parametric and defaults to the full catalog, so the resolved scope must be threaded through — an unscoped caller receives the **closed** page / `404`, never the full catalog. Behavior:
  - non-privileged / anonymous → closed (empty list / `404`)
  - privileged (moderators + app-dev-testers) → full catalog
  - **auto-widens for everyone** the moment the marketplace flag opens — no code change here, because the endpoint defers to the same flag the store UI already keys on.
- **Thin wrapper over the existing, already-tested listing service** (`listAvailableListings` / `getListingDetail`). No new query logic and only the existing public-allowlist projection is returned — no new field exposure.
- **Abuse-control rate limit.** Per-user key when a bearer is present, client-IP fallback otherwise, mirroring the 60/60 window the tRPC marketplace procs carry. Since these are public, edge-cacheable **reads**, the limiter **fails open** on a limiter incident (availability over abuse-control) — the visibility scope, not the limiter, is the security boundary.

### Note for reviewers

- The store listing service currently exposes **no free-text search or slot filter** (those axes live only on the moderator listing path), so this endpoint intentionally accepts neither — the supported filter axes are `kind`/`category`/`sort` + `cursor`/`limit`. If a public keyword search is desired, it needs a corresponding addition to the listing service in a follow-up.
- Pre-launch, an anonymous `GET /api/v1/apps` legitimately returns an **empty page** (closed scope) until the marketplace segment is widened — the endpoint is dark-safe by construction and needs no further change to go live.
- One deliberate divergence from the sibling `submissions` limiter: this one **fails open** rather than closed, which suits a public cacheable read (flagged above in case you'd prefer fail-closed).

## Tests

- Handler-level coverage of both endpoints: default-closed scope gate (anonymous **and** normal authed users get the closed scope; privileged users get the full catalog; the service is called **with** the resolved scope), filter/param pass-through, cursor round-trip across pages, optional-bearer (invalid token → anonymous, not a 500), rate-limit short-circuit, and the `404`/`400` posture. Includes a **load-bearing guard**: the service is mocked to return a non-empty catalog and the test asserts an unscoped caller still receives nothing — so removing the scope wiring fails the suite.
- A unit suite for the shared rate limiter (per-user vs IP keying, `429` over the window, fail-open on a limiter error/malformed result, TTL self-heal).

Full-project `tsc --noEmit` passes; new + related existing suites are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
