### PR TITLE
test: repair unit baseline broken by app-listings/blocks feature merges

### DIFF
--- a/src/server/routers/__tests__/blocks.router.listMyPublishRequests.test.ts
+++ b/src/server/routers/__tests__/blocks.router.listMyPublishRequests.test.ts
@@ -136,7 +136,7 @@ describe('listMyPublishRequests — P4 owner-control augmentation', () => {
       },
     ]);
     mockDbRead.appListing.findMany.mockResolvedValue([
-      { id: 'l-a', appBlockId: 'block-a', status: 'approved' },
+      { id: 'l-a', appBlockId: 'block-a', status: 'approved', _count: { screenshots: 3 } },
     ]);
 
     const caller = blocksRouter.createCaller(fakeCtx(owner) as never);
@@ -191,8 +191,8 @@ describe('listMyPublishRequests — P4 owner-control augmentation', () => {
       },
     ]);
     mockDbRead.appListing.findMany.mockResolvedValue([
-      { id: 'l-h', appBlockId: 'block-h', status: 'removed' },
-      { id: 'l-m', appBlockId: 'block-m', status: 'removed' },
+      { id: 'l-h', appBlockId: 'block-h', status: 'removed', _count: { screenshots: 3 } },
+      { id: 'l-m', appBlockId: 'block-m', status: 'removed', _count: { screenshots: 3 } },
     ]);
     mockDbRead.appListingModerationEvent.findMany.mockResolvedValue([
       { appListingId: 'l-h', action: 'owner-unpublish' },

--- a/src/server/services/__tests__/model-version.deregister.service.test.ts
+++ b/src/server/services/__tests__/model-version.deregister.service.test.ts
@@ -95,7 +95,10 @@ function wireTransaction() {
 const VERSION_ID = 4242;
 
 function stubVersionRows(fileUrls: string[]) {
-  mockDbWrite.modelFile.findMany.mockResolvedValue(fileUrls.map((url) => ({ url })));
+  // The tx snapshot selects `{ url, hashes: { hash } }` (hashes added by #3323 for
+  // by-hash edge-cache purge) — mock rows must carry `hashes` or `files.flatMap`
+  // dereferences undefined.
+  mockDbWrite.modelFile.findMany.mockResolvedValue(fileUrls.map((url) => ({ url, hashes: [] })));
   mockDbWrite.modelVersion.findFirstOrThrow.mockResolvedValue({
     id: VERSION_ID,
     modelId: 7,

--- a/src/server/services/__tests__/referral.service.test.ts
+++ b/src/server/services/__tests__/referral.service.test.ts
@@ -69,6 +69,15 @@ vi.mock('~/server/services/cosmetic.service', () => ({
 vi.mock('~/server/services/creator-membership.service', () => ({
   bustCreatorMembershipValidCache: vi.fn().mockResolvedValue(undefined),
 }));
+// redeemTokens now routes cache invalidation through the shared
+// `invalidateSubscriptionCaches` helper (#3324) — which itself busts the
+// creator-membership-validity cache alongside session/multiplier/vault/cap/civitai
+// caches, matching how stripe/paddle activation invalidates them. Mock it at that
+// seam (the function redeemTokens actually calls) so the assertion isn't coupled to
+// its transitive internals (and doesn't drag in its heavy real dep graph).
+vi.mock('~/server/utils/subscription.utils', () => ({
+  invalidateSubscriptionCaches: vi.fn().mockResolvedValue(undefined),
+}));
 
 import { Prisma } from '@prisma/client';
 import {
@@ -82,6 +91,7 @@ import {
 } from '../referral.service';
 import { createBuzzTransaction } from '~/server/services/buzz.service';
 import { bustCreatorMembershipValidCache } from '~/server/services/creator-membership.service';
+import { invalidateSubscriptionCaches } from '~/server/utils/subscription.utils';
 import { ReferralRewardKind, ReferralRewardStatus } from '~/shared/utils/prisma/enums';
 import { TransactionType } from '~/shared/constants/buzz.constants';
 
@@ -118,6 +128,8 @@ const resetAllMocks = () => {
   (createBuzzTransaction as any).mockResolvedValue({ transactionId: 't1' });
   (bustCreatorMembershipValidCache as any).mockClear();
   (bustCreatorMembershipValidCache as any).mockResolvedValue(undefined);
+  (invalidateSubscriptionCaches as any).mockClear();
+  (invalidateSubscriptionCaches as any).mockResolvedValue(undefined);
 };
 
 beforeEach(resetAllMocks);
@@ -1030,11 +1042,12 @@ describe('redeemTokens — creator-membership cache invalidation', () => {
     const result = await redeemTokens({ userId: 42, offerIndex: 0 });
 
     expect(result.id).toBe(99);
-    // The grant committed (create ran); the cache was busted for exactly the
-    // granted user, exactly once.
+    // The grant committed (create ran); subscription caches (incl. the
+    // membership-validity cache) were invalidated for exactly the granted user,
+    // exactly once, after the tx commit.
     expect(mockDbWrite.customerSubscription.create).toHaveBeenCalledTimes(1);
-    expect(bustCreatorMembershipValidCache).toHaveBeenCalledTimes(1);
-    expect(bustCreatorMembershipValidCache).toHaveBeenCalledWith(42);
+    expect(invalidateSubscriptionCaches).toHaveBeenCalledTimes(1);
+    expect(invalidateSubscriptionCaches).toHaveBeenCalledWith(42);
   });
 
   it('does not bust the cache when the redemption transaction fails', async () => {
@@ -1047,6 +1060,6 @@ describe('redeemTokens — creator-membership cache invalidation', () => {
     await expect(redeemTokens({ userId: 42, offerIndex: 0 })).rejects.toThrow(
       /Insufficient tokens/
     );
-    expect(bustCreatorMembershipValidCache).not.toHaveBeenCalled();
+    expect(invalidateSubscriptionCaches).not.toHaveBeenCalled();
   });
 });

--- a/src/server/services/blocks/__tests__/app-listing.moderation.service.test.ts
+++ b/src/server/services/blocks/__tests__/app-listing.moderation.service.test.ts
@@ -129,14 +129,20 @@ describe('listAllListingsForModeration — filters, keyset + pagination', () => 
   it('excludes shadow revision drafts (revisionOfId: null) and applies no filter by default', async () => {
     await listAllListingsForModeration({ limit: 25 });
     const { where, orderBy, take } = lastFindMany();
-    expect(where).toEqual({ revisionOfId: null });
+    // Status + search clauses (each possibly an `OR`) are composed under `AND` so
+    // neither overwrites the other's `OR` key; with no filters the AND is empty.
+    expect(where).toEqual({ revisionOfId: null, AND: [] });
     expect(orderBy).toEqual({ id: 'desc' });
     expect(take).toBe(26); // limit + 1
   });
 
   it('binds the status filter when provided', async () => {
     await listAllListingsForModeration({ status: 'removed', limit: 25 });
-    expect(lastFindMany().where).toMatchObject({ status: 'removed', revisionOfId: null });
+    // A concrete status is bound as an AND member (a plain `{ status }` clause).
+    expect(lastFindMany().where).toMatchObject({
+      revisionOfId: null,
+      AND: [{ status: 'removed' }],
+    });
   });
 
   it('binds the kind filter when provided', async () => {
@@ -146,10 +152,15 @@ describe('listAllListingsForModeration — filters, keyset + pagination', () => 
 
   it('builds a case-insensitive name/slug OR for search (trimmed)', async () => {
     await listAllListingsForModeration({ search: '  Cool  ', limit: 25 });
+    // The search OR is an AND member (so it can't collide with a status OR).
     expect(lastFindMany().where).toMatchObject({
-      OR: [
-        { name: { contains: 'Cool', mode: 'insensitive' } },
-        { slug: { contains: 'Cool', mode: 'insensitive' } },
+      AND: [
+        {
+          OR: [
+            { name: { contains: 'Cool', mode: 'insensitive' } },
+            { slug: { contains: 'Cool', mode: 'insensitive' } },
+          ],
+        },
       ],
     });
   });

--- a/src/server/services/blocks/__tests__/listing-meta.service.test.ts
+++ b/src/server/services/blocks/__tests__/listing-meta.service.test.ts
@@ -78,9 +78,12 @@ describe('fetchListingMeta', () => {
       ),
     });
     const r = await fetchListingMeta({ url: 'https://vendor.example.com/app' });
+    // og:description now feeds BOTH the short tagline AND the longer description
+    // field (richer autofill, #3332) — same source, two clamps.
     expect(r).toEqual({
       name: 'Cool App',
       tagline: 'Neat',
+      description: 'Neat',
       coverImageUrl: 'https://cdn.example.com/og.png',
     });
   });

--- a/src/server/services/blocks/__tests__/offsite-listing.edit.service.test.ts
+++ b/src/server/services/blocks/__tests__/offsite-listing.edit.service.test.ts
@@ -829,7 +829,7 @@ describe('listMySubmissions (shadow handling)', () => {
     appListingId: 'apl_parent',
     slug: 'cool-app',
     status: 'approved',
-    appListing: { name: 'Cool App', revisionOfId: null },
+    appListing: { name: 'Cool App', revisionOfId: null, _count: { screenshots: 3 } },
   };
 
   it('excludes shadow-targeting requests from the main query and flags a parent with a PENDING revision request', async () => {
@@ -908,14 +908,14 @@ describe('listMySubmissions (lastModerationAction for removed listings)', () => 
     appListingId: 'apl_removed',
     slug: 'gone-app',
     status: 'approved',
-    appListing: { name: 'Gone App', revisionOfId: null, status: 'removed' },
+    appListing: { name: 'Gone App', revisionOfId: null, status: 'removed', _count: { screenshots: 3 } },
   };
   const liveRequestRow = {
     id: 'alpr_live',
     appListingId: 'apl_live',
     slug: 'live-app',
     status: 'approved',
-    appListing: { name: 'Live App', revisionOfId: null, status: 'approved' },
+    appListing: { name: 'Live App', revisionOfId: null, status: 'approved', _count: { screenshots: 3 } },
   };
 
   it('attaches the latest moderation-event action for a REMOVED listing (owner-unpublish → eligible)', async () => {


### PR DESCRIPTION
## What

Repairs a **new unit-test baseline break** on `main` (confirmed failing on HEAD `216f7cb078`, not a stale base). Six unit test files across the app-listings/blocks + referral/model-version areas went red because feature PRs merged 07-24/25 changed service/router code **without updating their existing unit tests**. There is no PR-level unit CI, so the breaks landed on `main` unnoticed.

**All six fixes are test-only.** Every source change was git-blamed to its PR and verified correct — no source regression, including the highest-scrutiny referral cache-bust (see below).

## Per-file root cause + verdict

| File | Fail | Cause (PR) | Verdict | Fix |
|---|---|---|---|---|
| `offsite-listing.edit.service.test.ts` | 6 | #3379 `problems` calc reads `appListing._count.screenshots` (query selects `_count`) | **mock-gap** | add `_count: { screenshots }` to mocked appListing rows |
| `blocks.router.listMyPublishRequests.test.ts` | 2 | same #3379 change in router (`l._count.screenshots`) | **mock-gap** | add `_count` to mock listing rows |
| `model-version.deregister.service.test.ts` | 3 | #3323 added a `hashes` snapshot (`files.flatMap(f => f.hashes…)`) to the in-tx `modelFile.findMany` select | **mock-gap** | mock rows return `{ url, hashes: [] }` |
| `app-listing.moderation.service.test.ts` | 3 | #3368 composes status + search clauses under `AND: [...]` (each may be an `OR`; AND-wrapping stops one OR key overwriting the other) | **stale test — source is a correct bug fix** | update expectations to the AND-wrapped shape |
| `listing-meta.service.test.ts` | 1 | #3332 richer autofill: `og:description` now feeds both `tagline` and a new `description` field (documented on `ListingMetaSuggestion`) | **stale test — intended new field** | add `description` to expected shape |
| `referral.service.test.ts` | 1 | #3324 routed `redeemTokens`' post-commit bust through `invalidateSubscriptionCaches(userId)` | **stale test — NOT a regression** | assert on the new seam |

## The high-scrutiny one: referral cache-bust — verified NOT a regression

The failing test expected `bustCreatorMembershipValidCache` to be called once after `redeemTokens` and it was called 0 times. Investigation:

- `redeemTokens` still busts the membership cache after commit — PR #3324 refactored the direct `bustCreatorMembershipValidCache(userId)` call into the shared `invalidateSubscriptionCaches(userId)` helper, which internally calls `bustCreatorMembershipValidCache(userId)` **plus** session/multiplier/vault/cap/civitai invalidation (matching how stripe/paddle activation invalidates them). Membership validity **is** still re-derived after redemption — no stale-membership bug.
- The assertion read 0 only because the test left `invalidateSubscriptionCaches` **unmocked**, so the real helper ran through unmocked heavy deps and threw in an earlier step before reaching the transitive bust.

Fix asserts on the actual seam `redeemTokens` calls (`invalidateSubscriptionCaches`), which is the correct unit boundary and decoupled from the helper's internals. **No source change.**

## Before / after evidence

Each file reproduced red on `216f7cb078`, then green after the fix:

| File | Before | After |
|---|---|---|
| offsite-listing.edit | 6 failed / 34 passed | 40 passed |
| blocks.router.listMyPublishRequests | 2 failed / 1 passed | 3 passed |
| model-version.deregister | 3 failed / 1 passed | 4 passed |
| app-listing.moderation | 3 failed / 11 passed | 14 passed |
| listing-meta | 1 failed / 8 passed | 9 passed |
| referral | 1 failed / 41 passed | 42 passed |

All six together: **112 passed**.

## Left for a human
Nothing — no file was judged a source regression.

## Systemic note
These all broke because feature PRs merge service/router changes with **no required unit-CI gate** on PRs (unit runs report-only). A required unit gate on PRs would have caught every one of these before merge. Out of scope for this PR (test/source fixes only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)