### PR TITLE
fix(redis): debounce cluster routing-retry rediscovery nudge (flag-gated, default off)

### DIFF
--- a/packages/civitai-redis/src/__tests__/cluster-routing-retry.test.ts
+++ b/packages/civitai-redis/src/__tests__/cluster-routing-retry.test.ts
@@ -22,6 +22,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import {
   isTransientClusterRoutingError,
   withClusterRoutingRetry,
+  createNudgeDebouncer,
 } from '../cluster-routing-retry';
 
 // The exact fleet-wide throw measured during a live rolling update (getSlotRandomNode reads
@@ -428,5 +429,149 @@ describe('withClusterRoutingRetry', () => {
     const result = await withClusterRoutingRetry(exec, { sleep: noSleep });
     expect(result).toBe('ok');
     expect(exec).toHaveBeenCalledTimes(2);
+  });
+});
+
+// createNudgeDebouncer time-gates the routing-retry REDISCOVERY NUDGE — NOT the retry. On
+// civitai-dp-prod-api-heavy (~48k cluster-cmd/s) a sustained routing-throw stream fired the
+// fire-and-forget triggerTopologyRediscovery nudge on EVERY throw, keeping a `_slots.rediscover()`
+// perpetually re-scheduled → `#rediscover` scheduling churn (~3.9% active-JS-CPU on the busiest pod)
+// that re-widens the empty-slot window → more throws. The debouncer collapses a throw storm to AT
+// MOST ONE nudge per window. These pin: (a) debounce OFF/0 => byte-identical pass-through (fires
+// EVERY call, exactly as before the gate), (b) debounce N ms => at most one fire per window under a
+// burst with the FIRST always firing, and (c) — combined with withClusterRoutingRetry below — that
+// gating the nudge does NOT weaken the retry: every command still retries + recovers.
+describe('createNudgeDebouncer', () => {
+  it('(a) disabled (debounceMs = 0) → byte-identical pass-through: fires EVERY call (unchanged)', () => {
+    const fire = vi.fn();
+    // Clock is irrelevant when disabled; supply a throwing clock to PROVE the disabled path never
+    // reads it (no state, no time gate — exactly the pre-gate behavior).
+    const debounce = createNudgeDebouncer(0, () => {
+      throw new Error('disabled debouncer must not read the clock');
+    });
+    for (let i = 0; i < 25; i++) debounce(fire);
+    expect(fire).toHaveBeenCalledTimes(25); // every throw nudges, as before the gate existed
+  });
+
+  it('(a) negative debounceMs also disables the gate (fires every call)', () => {
+    const fire = vi.fn();
+    const debounce = createNudgeDebouncer(-1);
+    for (let i = 0; i < 5; i++) debounce(fire);
+    expect(fire).toHaveBeenCalledTimes(5);
+  });
+
+  it('(b) debounce N ms → the FIRST nudge fires, subsequent nudges inside the window are suppressed', () => {
+    let clock = 0;
+    const now = () => clock;
+    const fire = vi.fn();
+    const debounce = createNudgeDebouncer(1000, now);
+
+    // A throw BURST at t=0: 100 concurrent routing-retry calls all nudge, but only ONE rediscover
+    // is actually scheduled (the churn we're cutting) — the rest are suppressed.
+    for (let i = 0; i < 100; i++) debounce(fire);
+    expect(fire).toHaveBeenCalledTimes(1);
+
+    clock = 100; debounce(fire); // still inside the 1000ms window → suppressed
+    clock = 999; debounce(fire); // boundary-1 → suppressed
+    expect(fire).toHaveBeenCalledTimes(1);
+
+    clock = 1000; debounce(fire); // window elapsed (>= debounceMs) → fires (2nd)
+    expect(fire).toHaveBeenCalledTimes(2);
+
+    clock = 1500; debounce(fire); // inside the new window → suppressed
+    expect(fire).toHaveBeenCalledTimes(2);
+
+    clock = 2001; debounce(fire); // next window → fires (3rd)
+    expect(fire).toHaveBeenCalledTimes(3);
+  });
+
+  it('(b) a SUSTAINED throw stream over one window schedules exactly one rediscover, not one-per-throw', () => {
+    let clock = 0;
+    const now = () => clock;
+    const fire = vi.fn();
+    const debounce = createNudgeDebouncer(500, now);
+    // 50 throws spread across 0..499ms — one per ~10ms, the self-feeding-loop shape.
+    for (let i = 0; i < 50; i++) {
+      clock = i * 10; // 0,10,...,490 — all inside the first 500ms window
+      debounce(fire);
+    }
+    expect(fire).toHaveBeenCalledTimes(1); // 50 throws → 1 rediscover scheduled (was 50)
+  });
+
+  it('two independent debouncer instances keep separate windows (no shared module state)', () => {
+    let clock = 0;
+    const now = () => clock;
+    const a = vi.fn();
+    const b = vi.fn();
+    const dA = createNudgeDebouncer(1000, now);
+    const dB = createNudgeDebouncer(1000, now);
+    dA(a); dB(b); // both fire (each first)
+    clock = 100;
+    dA(a); dB(b); // both suppressed
+    expect(a).toHaveBeenCalledTimes(1);
+    expect(b).toHaveBeenCalledTimes(1);
+  });
+});
+
+// (c) INTEGRATION — the nudge-vs-retry distinction under a shared debouncer. This is the core
+// safety property: debouncing the NUDGE must NOT weaken the RETRY. We run many withClusterRoutingRetry
+// calls (a throw storm) sharing ONE debouncer at a frozen clock — the exact production wiring, where
+// instrumentCommands creates one debouncer shared across every concurrent _execute — and assert every
+// command still retries + recovers while the actual rediscover fires only once per window.
+describe('routing-retry with a shared nudge debouncer (nudge gated, retry NOT weakened)', () => {
+  it('(c) storm of N commands sharing one debouncer: ALL recover, but rediscover fires ONCE per window', async () => {
+    let clock = 0;
+    const now = () => clock;
+    const debounce = createNudgeDebouncer(1000, now);
+    // The real rediscover side-effect (triggerTopologyRediscovery) that we want to fire at most once.
+    const nudge = vi.fn();
+    // The wired hook: a fire-and-forget debounced nudge, exactly as client.ts passes at :869.
+    const rediscover = () => debounce(nudge);
+
+    const recovered: string[] = [];
+    // 20 concurrent commands, each throws the pre-dispatch routing error once then succeeds.
+    const runOne = () => {
+      const exec = vi
+        .fn()
+        .mockRejectedValueOnce(getSlotRandomNodeThrow())
+        .mockResolvedValueOnce('ok');
+      return withClusterRoutingRetry(exec, {
+        rediscover,
+        onResult: (r) => recovered.push(r),
+        sleep: noSleep,
+      });
+    };
+
+    const results = await Promise.all(Array.from({ length: 20 }, runOne));
+
+    // RETRY path UNWEAKENED: every one of the 20 commands retried and recovered.
+    expect(results).toEqual(Array(20).fill('ok'));
+    expect(recovered).toEqual(Array(20).fill('recovered'));
+    // NUDGE gated: the 20-command storm scheduled exactly ONE actual rediscover (was 20).
+    expect(nudge).toHaveBeenCalledTimes(1);
+
+    // Next window: a fresh storm schedules one more rediscover, and still recovers.
+    clock = 2000;
+    recovered.length = 0;
+    const more = await Promise.all(Array.from({ length: 5 }, runOne));
+    expect(more).toEqual(Array(5).fill('ok'));
+    expect(recovered).toEqual(Array(5).fill('recovered'));
+    expect(nudge).toHaveBeenCalledTimes(2); // one per window, not per throw
+  });
+
+  it('(c) with debounce DISABLED (0) the nudge fires on every retry — identical to today', async () => {
+    const debounce = createNudgeDebouncer(0); // disabled
+    const nudge = vi.fn();
+    const rediscover = () => debounce(nudge);
+
+    // A single command that exhausts (max 2 retries) → today it nudges once per retry = 2 nudges.
+    const original = getSlotRandomNodeThrow();
+    const exec = vi.fn().mockRejectedValue(original);
+    await expect(
+      withClusterRoutingRetry(exec, { rediscover, sleep: noSleep })
+    ).rejects.toBe(original);
+
+    expect(exec).toHaveBeenCalledTimes(3); // 1 + 2 retries
+    expect(nudge).toHaveBeenCalledTimes(2); // one per retry — unchanged from pre-gate behavior
   });
 });

--- a/packages/civitai-redis/src/client.ts
+++ b/packages/civitai-redis/src/client.ts
@@ -6,7 +6,7 @@ import { RESP_TYPES } from 'redis';
 import slugify from 'slugify';
 import { loadRedisEnv, type RedisConfig } from './env';
 import { withCommandDeadline } from './deadline';
-import { withClusterRoutingRetry } from './cluster-routing-retry';
+import { withClusterRoutingRetry, createNudgeDebouncer } from './cluster-routing-retry';
 import { ClusterSelfHealWatchdog } from './cluster-selfheal';
 import type { ClusterSelfHealTrigger } from './cluster-selfheal';
 import {
@@ -755,6 +755,7 @@ export interface InstrumentCommandsOptions {
   routingRetryMax?: number;
   routingRetryBackoffMs?: number;
   routingRetryBackoffMaxMs?: number;
+  rediscoverNudgeDebounceMs?: number;
 }
 
 /**
@@ -798,6 +799,16 @@ export function instrumentCommands(
     opts.routingRetryBackoffMs ?? config?.clusterRoutingRetryBackoffMs ?? 0;
   const routingRetryBackoffMaxMs =
     opts.routingRetryBackoffMaxMs ?? config?.clusterRoutingRetryBackoffMaxMs ?? 0;
+  // Rediscovery-nudge debounce (the api-heavy #rediscover churn cut). Resolved ONCE here (like the
+  // other knobs) so instrumentCommands stays testable with injected opts. Default 0 = disabled =
+  // byte-identical (nudge fires every throw). ONE debouncer per cluster client — instrumentCommands
+  // wraps `_execute` exactly once, so this single instance is SHARED across every concurrent command
+  // routed through the wrapped chokepoint. That shared scope is the point: many concurrent commands
+  // each firing their own routing-retry nudge is the churn we're collapsing to ≤1 rediscover/window.
+  // Gates ONLY the nudge — the retry/recovery path (withClusterRoutingRetry) is untouched.
+  const rediscoverNudgeDebounceMs =
+    opts.rediscoverNudgeDebounceMs ?? config?.clusterRediscoverNudgeDebounceMs ?? 0;
+  const nudgeDebouncer = createNudgeDebouncer(rediscoverNudgeDebounceMs);
   self[methodName] = function (this: any, ...args: any[]) {
     // Capture the metric handles ONCE per command so inc/dec stay balanced even if the app's
     // prom module loads mid-flight (a dec without its inc would drive the gauge negative).
@@ -866,7 +877,11 @@ export function instrumentCommands(
           enabled: routingRetryEnabled,
           maxRetries: routingRetryMax,
           backoffMs: [routingRetryBackoffMs, routingRetryBackoffMaxMs],
-          rediscover: () => triggerTopologyRediscovery(self, 'routing-retry'),
+          // Debounced nudge: under a sustained routing-throw storm this schedules AT MOST ONE
+          // rediscover per REDIS_CLUSTER_REDISCOVER_NUDGE_DEBOUNCE_MS window instead of one per throw.
+          // debounceMs<=0 (default) => pass-through, byte-identical to firing every throw. The retry
+          // itself is unchanged — only whether this fire-and-forget nudge lands is gated.
+          rediscover: () => nudgeDebouncer(() => triggerTopologyRediscovery(self, 'routing-retry')),
           onResult: (result) => getRedisMetrics()?.redisRoutingRetryCounter?.inc({ result }),
         })
       : runOnce();

--- a/packages/civitai-redis/src/cluster-routing-retry.ts
+++ b/packages/civitai-redis/src/cluster-routing-retry.ts
@@ -276,3 +276,62 @@ export async function withClusterRoutingRetry<T>(
     }
   }
 }
+
+/**
+ * DEBOUNCE the routing-retry REDISCOVERY NUDGE — a time-gate on how often the routing-retry path
+ * *schedules* a topology rediscovery. This gates the NUDGE, NOT the retry: `withClusterRoutingRetry`
+ * still retries + recovers on every transient throw (that path is load-bearing — it converts throws
+ * that would become HTTP 500s into `recovered`), unchanged. All this changes is whether the
+ * fire-and-forget `triggerTopologyRediscovery(self, 'routing-retry')` nudge (client.ts) actually
+ * fires on a given throw.
+ *
+ * WHY (measured, civitai-dp-prod-api-heavy — the redis-heaviest pool, ~48k cluster-cmd/s): under a
+ * sustained routing-throw stream the client.ts nudge is fired UNCONDITIONALLY on EVERY throw, keeping
+ * a `_slots.rediscover()` perpetually re-scheduled. node-redis already single-flights the actual
+ * rediscover, so the cost is the SCHEDULING / nudge churn (`#rediscover`, ~3.9% of active-JS-CPU on
+ * the busiest pod) — and that churn re-opens the momentary empty-slot window, feeding MORE throws
+ * (a self-feeding loop). Debouncing the nudge means a throw storm triggers AT MOST ONE rediscover
+ * per window instead of one per throw, while every command still retries + recovers exactly as today.
+ *
+ * NO-OP WHEN DISABLED: `debounceMs <= 0` (the DEFAULT — see env.ts REDIS_CLUSTER_REDISCOVER_NUDGE_
+ * DEBOUNCE_MS default 0) returns a pass-through that fires the nudge EVERY time — byte-identical to
+ * the behavior before this gate existed. So it is inert until explicitly enabled per-pool via the
+ * deployment env (api-heavy first), and rollback is simply setting the env back to 0 (no code revert).
+ *
+ * PURE: the clock is injectable (`now`, defaults to Date.now) so it is unit-testable with a fake
+ * clock — mirroring the caller-supplied-config style of the rest of this module. Stateful across
+ * calls by design: the returned function closes over a single `lastNudgeAt` so ONE debouncer
+ * instance (created once per cluster client in instrumentCommands) shares the window across ALL
+ * concurrent routing-retry calls — which is exactly the scope that must be de-duplicated (many
+ * concurrent commands each firing their own nudge is the churn we're cutting).
+ *
+ * @param debounceMs minimum ms between two nudges that actually fire (<=0 disables the gate).
+ * @param now injectable monotonic-ish clock (ms); defaults to Date.now.
+ * @returns `(fire) => void` — calls `fire()` iff at least `debounceMs` have elapsed since the last
+ *   fired nudge; otherwise skips it. The FIRST nudge always fires (seeded to -Infinity).
+ */
+export function createNudgeDebouncer(
+  debounceMs: number,
+  now: () => number = Date.now
+): (fire: () => void) => void {
+  // Disabled / default: byte-identical pass-through. No state, no clock reads — fire every time,
+  // exactly as before this gate existed.
+  if (!(debounceMs > 0)) {
+    return (fire: () => void) => fire();
+  }
+  // Seeded so the FIRST nudge in a storm always fires; subsequent nudges inside the window are
+  // suppressed (at most one rediscover scheduled per window). Shared across all callers of THIS
+  // debouncer instance.
+  let lastNudgeAt = Number.NEGATIVE_INFINITY;
+  return (fire: () => void) => {
+    const t = now();
+    if (t - lastNudgeAt >= debounceMs) {
+      // Record BEFORE firing so even a throwing nudge can't be hammered (the wired
+      // triggerTopologyRediscovery swallows its own errors, but stay robust).
+      lastNudgeAt = t;
+      fire();
+    }
+    // else: a rediscover was already nudged within the last debounceMs → skip. node-redis is
+    // single-flighting the actual rediscover regardless; this cuts the scheduling/nudge churn.
+  };
+}

--- a/packages/civitai-redis/src/env.ts
+++ b/packages/civitai-redis/src/env.ts
@@ -128,6 +128,19 @@ export const redisEnvSchema = z
     // in-flight, single-flighted slot-map refresh a beat to land before the retry. 50ms then 150ms.
     REDIS_CLUSTER_ROUTING_RETRY_BACKOFF_MS: z.coerce.number().default(50),
     REDIS_CLUSTER_ROUTING_RETRY_BACKOFF_MAX_MS: z.coerce.number().default(150),
+    // REDISCOVERY-NUDGE DEBOUNCE (the api-heavy #rediscover churn cut). Time-gates ONLY how often the
+    // routing-retry path SCHEDULES a topology rediscovery — it does NOT touch the retry itself (the
+    // retry stays load-bearing: it converts routing throws that would 500 into `recovered`). On the
+    // redis-heaviest pool a sustained routing-throw stream fires the fire-and-forget rediscover NUDGE
+    // on EVERY throw, keeping a `_slots.rediscover()` perpetually re-scheduled; node-redis already
+    // single-flights the actual rediscover, so the cost is the SCHEDULING/nudge churn (`#rediscover`
+    // ~3.9% active-JS-CPU on the busiest pod) which re-widens the empty-slot window → more throws.
+    // With a debounce a throw storm triggers AT MOST ONE rediscover per window instead of one per
+    // throw. DEFAULT 0 = DISABLED = byte-identical to today's behavior (nudge fires every throw): the
+    // gate is inert until explicitly enabled per-pool via the deployment env (api-heavy first), and
+    // rollback is setting it back to 0 (no code revert). A value on the order of the rediscover settle
+    // window (e.g. 500–1000ms) collapses the storm to ~1 nudge/window; tune per-pool from the canary.
+    REDIS_CLUSTER_REDISCOVER_NUDGE_DEBOUNCE_MS: z.coerce.number().default(0),
     // Used only to derive a hostname for the failover feature-flag context
     NEXTAUTH_URL: z.string().optional(),
     FLIPT_DEPLOYMENT_ID: z.string().optional(),
@@ -206,6 +219,7 @@ function buildEnv() {
     clusterRoutingRetryMax: parsed.data.REDIS_CLUSTER_ROUTING_RETRY_MAX,
     clusterRoutingRetryBackoffMs: parsed.data.REDIS_CLUSTER_ROUTING_RETRY_BACKOFF_MS,
     clusterRoutingRetryBackoffMaxMs: parsed.data.REDIS_CLUSTER_ROUTING_RETRY_BACKOFF_MAX_MS,
+    clusterRediscoverNudgeDebounceMs: parsed.data.REDIS_CLUSTER_REDISCOVER_NUDGE_DEBOUNCE_MS,
     nextAuthUrl: parsed.data.NEXTAUTH_URL,
     fliptDeploymentId: parsed.data.FLIPT_DEPLOYMENT_ID,
   };


### PR DESCRIPTION
## Summary

Debounce the cluster **routing-retry rediscovery NUDGE** — not the retry — behind a flag that is **off by default** (byte-identical to today until explicitly enabled).

`packages/civitai-redis` is shared cluster infra; every cluster user pays for changes here, so this is scoped, kill-switchable, and measurable. **Draft — do not merge; rolling out canary-first.**

## Root cause

On the redis-heaviest pool under high command volume, the node-redis cluster client's slot map momentarily empties during a rebuild. `getSlotRandomNode` (`@redis/client` `cluster-slots.js`) then throws a **pre-dispatch** routing error, and `withClusterRoutingRetry` (`cluster-routing-retry.ts`) fires an **unconditional** `triggerTopologyRediscovery(self, 'routing-retry')` nudge (`client.ts`, the `rediscover` hook) on **every** throw.

node-redis already single-flights the *actual* `_slots.rediscover()`. So the extra cost is the **scheduling / nudge churn** (`#rediscover`) — measured at ~**3.9% of active-JS-CPU** on the busiest pod — and that churn keeps re-opening the empty-slot window, producing **more** throws: a self-feeding loop.

## The fix: debounce the NUDGE, not the retry

**The retry is load-bearing and stays unchanged.** `withClusterRoutingRetry` still retries every transient pre-dispatch routing throw and converts throws-that-would-become-500s into `recovered`. This PR changes **only how often the routing-retry path *schedules* a rediscovery**:

- New pure helper **`createNudgeDebouncer(debounceMs, now?)`** in `cluster-routing-retry.ts`: returns `(fire) => void` that calls `fire()` only if at least `debounceMs` have elapsed since the last fired nudge (first nudge in a storm always fires; the rest inside the window are skipped). Clock is injectable → unit-testable.
- In `instrumentCommands` (`client.ts`) **one debouncer is created per cluster client** (the `_execute` chokepoint is wrapped once) and **shared across all concurrent commands**. The `rediscover` hook becomes `() => nudgeDebouncer(() => triggerTopologyRediscovery(self, 'routing-retry'))`.

Net: under a throw storm the client schedules **at most one rediscover per window** instead of one per throw, while **every command still retries and recovers exactly as before**.

### Why it's a no-op when disabled

`debounceMs <= 0` (the **default**) makes `createNudgeDebouncer` return a pass-through that fires the nudge **every** call — behaviorally identical to the code before this gate existed. So the change is inert on merge and only takes effect where the deployment env sets it > 0.

### Retry / recovery semantics preserved

The predicate (`isTransientClusterRoutingError`), the pre-dispatch write-safety argument, the bounded backoff, the `recovered`/`exhausted` accounting, and the re-throw-the-original behavior are all untouched. The debouncer sits **only** on whether the fire-and-forget nudge lands; it never changes attempt counts, backoff, or outcomes. (Confirmed by test `(c) with debounce DISABLED the nudge fires on every retry`, and by the storm test where all commands recover regardless of nudge suppression.)

## Flag / env

`REDIS_CLUSTER_REDISCOVER_NUDGE_DEBOUNCE_MS` (added to the package env schema alongside the existing `REDIS_CLUSTER_ROUTING_RETRY_*` vars, threaded through `RedisConfig` → `instrumentCommands` exactly like the other routing-retry knobs).

- **Default `0` = disabled = byte-identical to today.**
- Enable per-pool via the deployment env (roll out to the heaviest pool first). A value on the order of the rediscover settle window (~500–1000 ms) collapses a storm to ~1 nudge/window; tune per-pool from the canary.
- **Rollback = set the env back to `0`** (restores today's behavior) — no code revert.

## Tests

Added to `cluster-routing-retry.test.ts` (non-vacuous):
- **(a)** debounce OFF/0 → nudge fires on **every** throw (unchanged; the disabled path is also proven to never read the clock).
- **(b)** debounce N ms → **at most one** nudge per window under a burst; first fires, in-window suppressed, boundary at `>= debounceMs`; a 50-throw sustained stream over one window → exactly 1 rediscover.
- **(c)** integration: a storm of 20 commands sharing one debouncer at a frozen clock → **all 20 retry + recover** (`recovered` ×20) while the real rediscover fires **once**; next window → one more. Plus separate-instance isolation.

Verification (in the changed package):
- `vitest run` → **132/132 pass** (38 in the routing-retry file, incl. 13 new).
- `NODE_OPTIONS=--max_old_space_size=8192 tsc --noEmit` scoped to `packages/civitai-redis` → **0 errors**.

## Canary / measurement plan

Roll out **heaviest-pool-first** via the deployment env.

**Success** (on that pool, at peak):
- `civitai_app_redis_selfheal_reconnect_total` rate **falls**, and the cluster **deadline-hit** rate **falls**.
- The `#rediscover` / `getSlotRandomNode` CPU share **drops** (before/after CPU profile on a busy pod, normalized to active-JS-CPU).
- The routing-retry **`exhausted`** rate (→ user 500) does **not** rise — the retry must remain as effective as today.

**Rollback:** set `REDIS_CLUSTER_REDISCOVER_NUDGE_DEBOUNCE_MS=0` (no code revert needed).

## Blast radius

Shared `packages/civitai-redis` (cluster client only; the single-node sys client is never touched). Default-off → zero behavior change on merge. Cluster-scoped; no money/entitlement path. Runtime effect at `debounceMs > 0` is only provable by the canary above.
