### PR TITLE
perf(redis L1): enable L1 on basic-tags + enlarge tag-ids-for-images L1

### DIFF
--- a/src/server/redis/__tests__/l1-cache-budget.test.ts
+++ b/src/server/redis/__tests__/l1-cache-budget.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { L1_CACHE_BYTE_BUDGETS, L1_TOTAL_BYTE_CEILING } from '../l1-cache-budget';
+
+/**
+ * Heap-safety invariant for the per-pod L1 (in-process LRU) caches in caches.ts.
+ *
+ * Each L1 cache is individually byte-bounded via `localMaxBytes`, sourced from
+ * L1_CACHE_BYTE_BUDGETS (single source of truth). The SUM of those budgets is the
+ * pod's total worst-case L1 footprint and MUST stay under the hard ceiling — this is
+ * the regression guard that stops someone adding/enlarging an L1 cache from silently
+ * blowing the dp-prod pod heap (4096MB old-space, >3200MB heap-headroom alert).
+ */
+describe('L1 cache byte budget', () => {
+  const sum = Object.values(L1_CACHE_BYTE_BUDGETS).reduce((a, b) => a + b, 0);
+
+  it('sum of all per-pod L1 byte budgets stays under the hard ceiling', () => {
+    expect(sum).toBeLessThanOrEqual(L1_TOTAL_BYTE_CEILING);
+  });
+
+  it('ceiling is a small fraction of the 4096MB pod old-space limit (heap safety)', () => {
+    const OLD_SPACE_LIMIT = 4096 * 1024 * 1024;
+    // Keep the total L1 footprint well under 5% of old-space so it can never be a
+    // meaningful contributor to a heap-headroom breach.
+    expect(L1_TOTAL_BYTE_CEILING).toBeLessThan(OLD_SPACE_LIMIT * 0.05);
+  });
+
+  it('every budget is a positive integer number of bytes', () => {
+    for (const [name, bytes] of Object.entries(L1_CACHE_BYTE_BUDGETS)) {
+      expect(bytes, name).toBeGreaterThan(0);
+      expect(Number.isInteger(bytes), name).toBe(true);
+    }
+  });
+});

--- a/src/server/redis/caches.ts
+++ b/src/server/redis/caches.ts
@@ -27,6 +27,7 @@ import type { EntityAccessDataType } from '~/server/services/common.service';
 import { getModelClient } from '~/server/services/orchestrator/models';
 import type { CachedObject } from '~/server/utils/cache-helpers';
 import { createCachedObject } from '~/server/utils/cache-helpers';
+import { L1_CACHE_BYTE_BUDGETS } from '~/server/redis/l1-cache-budget';
 import { getPrimaryFile } from '~/server/utils/model-helpers';
 import type { BaseModel } from '~/shared/constants/basemodel.constants';
 import { stringifyAIR } from '~/shared/utils/air';
@@ -60,11 +61,17 @@ export const tagIdsForImagesCache = createCachedObject<{
   ttl: CacheTTL.hour * 8,
   staleWhileRevalidateTtl: CacheTTL.hour,
   // L1: image tag-ids are near-static display metadata (busted on scan/tag edits);
-  // an 8h Redis TTL dwarfs a 15s per-pod L1, which only delays a cross-pod tag
-  // edit by ≤15s. Not a visibility gate (feed SQL enforces that). Hot-image set.
-  localTtl: 15,
-  localMax: 10000,
-  localMaxBytes: 6 * 1024 * 1024, // hard heap cap ~6MB (tag-id arrays are small)
+  // an 8h Redis TTL dwarfs the per-pod L1, which only delays a cross-pod tag edit by
+  // ≤localTtl. Not a visibility gate (feed SQL enforces that). This is the single
+  // largest driver of api-heavy's per-id Redis GET volume (feed streams distinct
+  // imageIds), so the L1 was starved at localTtl=15s/localMax=10k. Enlarged to a
+  // ~3min window + 50k hot entries so cross-user popular-image overlap + scroll-back
+  // land as L1 hits. Strictly byte-bounded (see l1-cache-budget) — the byte cap, not
+  // the entry cap, is the binding heap guard. The longer localTtl is safe here BECAUSE
+  // this value gates nothing (only delays a busted tag-list edit by ≤localTtl).
+  localTtl: 180,
+  localMax: 50000,
+  localMaxBytes: L1_CACHE_BYTE_BUDGETS.tagIdsForImages,
   async lookupFn(imageId, fromWrite) {
     const imageIds = Array.isArray(imageId) ? imageId : [imageId];
     const db = fromWrite ? dbWrite : dbRead;
@@ -357,7 +364,7 @@ export const userBasicCache = createCachedObject<UserBasicLookup>({
   // cross-pod delay on a rename/avatar/soft-delete propagating — imperceptible.
   localTtl: 30,
   localMax: 10000,
-  localMaxBytes: 4 * 1024 * 1024, // hard heap cap ~4MB (tiny records)
+  localMaxBytes: L1_CACHE_BYTE_BUDGETS.userBasic, // ~4MB (tiny records)
 });
 
 type ModelVersionAccessCache = EntityAccessDataType & { publishedAt: Date; status: ModelStatus };
@@ -433,6 +440,24 @@ export const tagCache = createCachedObject<TagLookup>({
     );
   },
   ttl: CacheTTL.day,
+  // L1: the tag catalog is a small, near-static, SHARED universe keyed by tag id, so a
+  // per-pod L1 sized to hold the hot catalog reaches a near-100% feed hit ratio and
+  // removes tagCache's per-id Redis GET fan-out. The 1d Redis TTL dwarfs a 30s L1.
+  // BEHAVIOR-AUDIT (2026-07): the value carries nsfwLevel + unlisted. Every reader was
+  // grepped — neither field feeds a HARD content-visibility gate on the feed. Readers
+  // use tag NAMES for display (getTagNamesForImages, search-index tagNames), tag id/name
+  // for category filtering (model.service), and `unlisted` ONLY in stripUnlistedTags —
+  // a non-moderator filter on the model VOTABLE-TAGS panel (a tag-label surface, not
+  // image/content visibility; the ImageTag SQL view already drops unlisted at the DB
+  // layer, and moderators bypass it). Image/model visibility is gated by the entity's
+  // OWN nsfwLevel, never the tag's. So a ≤30s L1 delay on a busted tag-level/unlisted
+  // edit is a cosmetic tag-label lag, not a moderation-visibility bug. localTtl kept
+  // conservative (30s) given that (minor) mod-adjacent surface; hit ratio is driven by
+  // catalog coverage (localMax), not localTtl. Busted per-id on mod tag-level changes
+  // (adjust-tag-level.ts) — dropped from THIS pod's L1, ≤30s cross-pod lag accepted.
+  localTtl: 30,
+  localMax: 100000,
+  localMaxBytes: L1_CACHE_BYTE_BUDGETS.basicTags,
 });
 
 export const tagCacheByName = {
@@ -1518,7 +1543,7 @@ export const imageTagsCache = createCachedObject<ImageTagsCacheItem>({
   // hidden-tag filtering, not a hard visibility gate. max 5000: ~4.2KB/key, heavy.
   localTtl: 15,
   localMax: 5000,
-  localMaxBytes: 16 * 1024 * 1024, // hard heap cap ~16MB (heaviest remaining value)
+  localMaxBytes: L1_CACHE_BYTE_BUDGETS.imageTags, // ~16MB (heaviest remaining value)
   lookupFn: async (ids, fromWrite) => {
     const db = fromWrite ? dbWrite : dbRead;
 
@@ -1687,13 +1712,14 @@ export const imageResourcesCache = createCachedObject<ImageResourcesCacheItem>({
   // edits, 8h Redis TTL. A 30s per-pod L1 only delays a cross-pod resource edit by
   // ≤30s. Not sensitive / not a visibility gate.
   //
-  // Per-pod L1 total HARD heap ceiling across the 4 enabled caches (localMaxBytes):
-  //   userBasic 4MB + imageResources 12MB + tagIdsForImages 6MB + imageTags 16MB
-  //   = 38MB/pod — well under the heap-headroom alert; byte-bounded so a per-value
-  //   size spike can never blow the cap (deterministic, deploy fleet-wide safely).
+  // Per-pod L1 byte budgets are centralized + ceiling-enforced in l1-cache-budget.ts
+  //   (userBasic 4 + imageResources 12 + imageTags 16 + tagIdsForImages 30 + basicTags 20
+  //   = 82MB/pod, under the 96MB ceiling; well below the >3200MB heap-headroom alert and
+  //   the 4096MB old-space limit). Byte-bounded so a per-value size spike can never blow
+  //   the cap (deterministic, deploy fleet-wide safely).
   localTtl: 30,
   localMax: 10000,
-  localMaxBytes: 12 * 1024 * 1024, // hard heap cap ~12MB
+  localMaxBytes: L1_CACHE_BYTE_BUDGETS.imageResources, // ~12MB
   lookupFn: async (ids, fromWrite) => {
     const imageIds = Array.isArray(ids) ? ids : [ids];
     if (imageIds.length === 0) return {};

--- a/src/server/redis/l1-cache-budget.ts
+++ b/src/server/redis/l1-cache-budget.ts
@@ -1,0 +1,40 @@
+/**
+ * Per-pod L1 (in-process LRU) heap byte budget — the single source of truth for the
+ * `localMaxBytes` cap of every L1-enabled cache in `caches.ts`.
+ *
+ * Each L1 cache is byte-bounded (deterministic `roughSizeOf` estimator, see
+ * `cache-helpers.ts` / `lru-cache.ts`) so a per-value size spike can never blow the
+ * cap. The SUM of these per-cache budgets is the pod's total L1 footprint; it MUST
+ * stay under `L1_TOTAL_BYTE_CEILING`. `l1-cache-budget.test.ts` enforces this
+ * invariant so adding/enlarging an L1 cache cannot silently exceed the ceiling.
+ *
+ * Heap safety: the dp-prod pods run with a 4096MB V8 old-space limit and a
+ * >3200MB heap-headroom alert. The ceiling below (96MB) is <2.5% of old-space and
+ * far under the alert threshold; `roughSizeOf` over-estimates retained bytes
+ * (2× UTF-16 JSON length + fixed overhead, while ASCII strings cost ≤1 byte/char
+ * internally and V8 dedupes), so the true resident footprint is lower still.
+ */
+const MB = 1024 * 1024;
+
+export const L1_CACHE_BYTE_BUDGETS = {
+  // userBasicCache — tiny per-user records (id/username/etc.).
+  userBasic: 4 * MB,
+  // imageResourcesCache — which model versions an image used (attribution metadata).
+  imageResources: 12 * MB,
+  // imageTagsCache — the heaviest remaining L1 value (composite image-tag rows).
+  imageTags: 16 * MB,
+  // tagIdsForImagesCache — { imageId, tags: number[] }; tag-id arrays are small but
+  // this holds a large hot working set of feed imageIds (enlarged 2026-07 to recover
+  // its Redis command volume — feed streams distinct imageIds).
+  tagIdsForImages: 30 * MB,
+  // tagCache (basic-tags) — { id, name, type, nsfwLevel, unlisted? }; tiny values,
+  // sized to hold the hot tag catalog for a near-100% feed hit ratio.
+  basicTags: 20 * MB,
+} as const;
+
+/**
+ * Hard per-pod ceiling for the SUM of all L1 byte budgets. Enforced by
+ * `l1-cache-budget.test.ts`. Raise ONLY with proven heap headroom vs the 4096MB
+ * old-space limit / >3200MB heap-headroom alert.
+ */
+export const L1_TOTAL_BYTE_CEILING = 96 * MB;


### PR DESCRIPTION
## What

Two per-pod L1 (in-process LRU) tuning changes on the API pool that carries the most Redis command volume, both mirroring the existing L1 pattern from #3296. Both are **imperceptible behaviour changes** (Bucket A) — they only add a small, bounded per-pod staleness window in front of near-static, non-visibility-gating feed-hydration caches. They buy capacity on a pool that is capacity- (not cost-) bound at peak, and relieve the cluster-routing-retry / cache-read-deadline pressure that per-id Redis GET fan-out drives.

### Change 1 — enable L1 on `basic-tags` (`tagCache`)
`tagCache` is keyed by **tag id** — a small, near-static, shared universe — so an L1 sized to hold the hot tag catalog reaches a near-100% hit ratio and removes tagCache's per-id Redis GET fan-out.

- **Removes ~8.4k cmd/s** at peak.
- Config: `localTtl: 30`, `localMax: 100000`, `localMaxBytes: 20MB`.
- Its Redis (L2) TTL is already 1 day, so it tolerates a 30s L1 staleness comfortably. Hit ratio is driven by catalog coverage (`localMax`), not by `localTtl`, so `localTtl` is kept conservative.

### Change 2 — tune the existing `tag-ids-for-images` L1 (`tagIdsForImagesCache`)
This cache already had an L1 but it was **starved** (`localTtl: 15s`, `localMax: 10k`) versus a feed that streams distinct imageIds — it's the single largest driver of per-id Redis GET volume. Enlarge it, strictly bounded by a byte cap.

- **Recovers ~40-60% of its ~15.4k cmd/s** — working-set-bound (cross-user popular-image overlap + scroll-back), not the full amount.
- Config: `localTtl: 180` (was 15), `localMax: 50000` (was 10k), `localMaxBytes: 30MB` (was 6MB).
- The longer `localTtl` is safe here because the value gates nothing — it only delays a busted tag-list display edit by ≤`localTtl` (the feed SQL enforces visibility).

## Heap-safety byte budget

Every L1 cache is individually byte-bounded via `localMaxBytes` (deterministic `roughSizeOf` estimator — a per-value size spike can never blow the cap). This PR centralizes those caps into a new single source of truth, `l1-cache-budget.ts`, with a hard total ceiling enforced by a new unit test.

| L1 cache | before | after |
|---|---|---|
| userBasic | 4 MB | 4 MB |
| imageResources | 12 MB | 12 MB |
| imageTags | 16 MB | 16 MB |
| tagIdsForImages | 6 MB | **30 MB** |
| basicTags (tagCache) | — | **20 MB** |
| **total / pod** | **38 MB** | **82 MB** |
| **hard ceiling** | | **96 MB** |

- New worst-case total **82 MB/pod** — **< 2.5% of the 4096 MB V8 old-space limit** and well below the heap-headroom alert threshold. Net increase is +44 MB.
- `roughSizeOf` **over-estimates** retained bytes (2× UTF-16 JSON length + fixed overhead, while ASCII strings cost ≤1 byte/char internally and V8 dedupes), so the true resident footprint is lower than the caps.
- Entry-size sanity: `tagIdsForImages` prior 6 MB / 10k ⇒ ~600 B/entry, so 30 MB ⇒ ~50k entries = `localMax`. `basicTags` `TagLookup` JSON ~55-100 chars ⇒ ~170-260 B/entry, so 20 MB ⇒ ~80-120k entries, covering `localMax` 100k. In both caches the byte cap and entry cap bind at roughly the same point.
- Existing L1 caches keep **byte-identical** caps, now sourced from the map (no behaviour change for them).

## Behaviour audit — `basic-tags` (the gate for Change 1)

The cached `TagLookup` carries `nsfwLevel` and `unlisted`. Every reader of `tagCache` / basic-tags was grepped to confirm neither field feeds a **hard content-visibility gate**:

- `getTagNamesForImages`, image search-index `tagNames`: use tag **names** for display only.
- `model.service` category filtering: uses tag **id/name** only.
- `stripUnlistedTags`: uses `unlisted` to filter which tags appear in the **model votable-tags panel** for non-moderators — a tag-label surface, not image/content visibility. The `ImageTag` SQL view already drops unlisted tags at the DB layer, and moderators bypass the filter.
- No reader gates image/model visibility on the **tag's** `nsfwLevel` — entity visibility is gated by the entity's **own** nsfwLevel.

Conclusion: a ≤30s per-pod L1 delay on a busted tag-level/unlisted edit is cosmetic tag-label staleness, **not** a moderation-visibility bug. Per-id busts (mod tag-level changes) already drop the entry from the acting pod's L1; cross-pod lag ≤ `localTtl` is accepted (same contract as the existing L1 caches).

## Tests

- New `l1-cache-budget.test.ts` — enforces `sum(localMaxBytes) ≤ ceiling` and that the ceiling stays a small fraction of old-space. This converts the previous prose "38 MB total" comment into an enforced regression guard so a future L1 addition can't silently blow the pod heap.
- The L1 **mechanism** (hit-skips-Redis, byte-bounded eviction, TTL expiry, isolation, positive-only, bust/refresh drop) is already exhaustively covered by `cache-helpers-l1.test.ts`; these changes are pure per-cache config, so no new mechanism test is added (would be vacuous).
- `tsc --noEmit`: 0 errors in `src/`.
