### PR TITLE
feat(api/v1/apps): surface onsite liveUrl on list cards (no N+1)

### DIFF
--- a/src/components/Apps/AppListingCard.browser.test.tsx
+++ b/src/components/Apps/AppListingCard.browser.test.tsx
@@ -41,7 +41,7 @@ function base(over: Partial<ListingCard>): ListingCard {
     creator: { id: 5, username: 'alice', image: null },
     recommend: { recommendedCount: 0, notRecommendedCount: 0, recommendPct: null },
     reviewCount: 0,
-    kindData: { kind: 'onsite', appBlockId: 'blk-1', hasPage: true },
+    kindData: { kind: 'onsite', appBlockId: 'blk-1', hasPage: true, liveUrl: 'https://my-app.civit.ai' },
     ...over,
   };
 }

--- a/src/components/Apps/AppListingsMarketplaceBody.browser.test.tsx
+++ b/src/components/Apps/AppListingsMarketplaceBody.browser.test.tsx
@@ -27,7 +27,7 @@ function makeCard(id: string, name: string, kind: 'onsite' | 'offsite' = 'onsite
     reviewCount: 0,
     kindData:
       kind === 'onsite'
-        ? { kind: 'onsite', appBlockId: `blk-${id}`, hasPage: false }
+        ? { kind: 'onsite', appBlockId: `blk-${id}`, hasPage: false, liveUrl: `https://slug-${id}.civit.ai` }
         : { kind: 'offsite', subKind: 'external-link', externalUrl: 'https://x.app' },
   };
 }

--- a/src/server/schema/blocks/app-listing-read.schema.ts
+++ b/src/server/schema/blocks/app-listing-read.schema.ts
@@ -158,6 +158,14 @@ export type ListingCardKindData =
       appBlockId: string | null;
       /** True when the app declares a launch page (Open CTA) vs a model-slot install (Install CTA). */
       hasPage: boolean;
+      /**
+       * Already-public standalone block origin (no token/scope) — IDENTICAL in
+       * name + type to the detail projection's `liveUrl`, so a client can link an
+       * onsite app straight from the list card without an N+1 detail fetch. An
+       * onsite card only appears once its backing block has deployed (the same
+       * deploy-gate the detail read applies), so this origin is always live.
+       */
+      liveUrl: string;
     }
   | {
       kind: 'offsite';

--- a/src/server/services/blocks/__tests__/app-listing.service.test.ts
+++ b/src/server/services/blocks/__tests__/app-listing.service.test.ts
@@ -235,15 +235,43 @@ describe('projectListingCard — public allowlist (no internal leaks)', () => {
     expect(card.reviewCount).toBe(10);
   });
 
-  it('onsite kindData carries appBlockId + hasPage (Open) when the manifest declares a page', () => {
+  it('onsite kindData carries appBlockId + hasPage (Open) + the computed liveUrl when the manifest declares a page', () => {
     const card = projectListingCard(hydratedRow() as never);
-    expect(card.kindData).toEqual({ kind: 'onsite', appBlockId: 'ab_1', hasPage: true });
+    expect(card.kindData).toEqual({
+      kind: 'onsite',
+      appBlockId: 'ab_1',
+      hasPage: true,
+      liveUrl: 'https://cool-app.civit.ai',
+    });
   });
 
-  it('onsite hasPage=false (Install) when the manifest declares no page', () => {
+  it('onsite hasPage=false (Install) when the manifest declares no page (liveUrl still present)', () => {
     const row = hydratedRow({ appBlock: { manifest: { name: 'X', targets: [] } } });
     const card = projectListingCard(row as never);
-    expect(card.kindData).toEqual({ kind: 'onsite', appBlockId: 'ab_1', hasPage: false });
+    expect(card.kindData).toEqual({
+      kind: 'onsite',
+      appBlockId: 'ab_1',
+      hasPage: false,
+      liveUrl: 'https://cool-app.civit.ai',
+    });
+  });
+
+  it('onsite card liveUrl is `https://<slug>.<APPS_DOMAIN>` for the seeded slug', () => {
+    const row = hydratedRow({ slug: 'my-neat-app' });
+    const card = projectListingCard(row as never);
+    expect(card.kindData).toMatchObject({ kind: 'onsite', liveUrl: 'https://my-neat-app.civit.ai' });
+  });
+
+  it('PARITY GUARD: onsite card liveUrl === detail liveUrl for the same listing (anti-drift)', () => {
+    // Both projections must compose liveUrl the SAME way (shared helper). If a
+    // future change alters one derivation and not the other, this fails.
+    const row = hydratedRow({ slug: 'parity-app' });
+    const card = projectListingCard(row as never);
+    const detail = projectListingDetail(row as never);
+    const cardKind = card.kindData as { kind: 'onsite'; liveUrl: string };
+    const detailKind = detail.kindData as { kind: 'onsite'; liveUrl: string };
+    expect(cardKind.liveUrl).toBe('https://parity-app.civit.ai');
+    expect(cardKind.liveUrl).toBe(detailKind.liveUrl);
   });
 
   it('coverUrl falls back to the first screenshot when there is no cover', () => {

--- a/src/server/services/blocks/app-listing.service.ts
+++ b/src/server/services/blocks/app-listing.service.ts
@@ -190,6 +190,17 @@ function manifestHasPage(manifest: unknown): boolean {
 }
 
 /**
+ * The already-public standalone origin for an ONSITE listing (no token/scope) —
+ * the same `<slug>.<APPS_DOMAIN>` host the webhook validates the bundle's iframe
+ * against. Shared by the card AND detail projections so their `liveUrl` for a
+ * given slug can never drift. Both projections only compose this once the row
+ * has passed the deploy-gate (list SQL + detail read), so the origin is live.
+ */
+function onsiteLiveUrl(slug: string): string {
+  return `https://${slug}.${env.APPS_DOMAIN}`;
+}
+
+/**
  * The Prisma `select` for a hydrated listing row (shared by card + detail). Only
  * fields the public projection uses — the internal columns (status, ownership
  * beyond the chip, raw manifest internals) are never selected into a public DTO.
@@ -249,6 +260,9 @@ function cardKindData(row: HydratedListing): ListingCardKindData {
     kind: 'onsite',
     appBlockId: row.appBlockId ?? null,
     hasPage: manifestHasPage(row.appBlock?.manifest),
+    // Surfaced on the card so a client can link the onsite app without an N+1
+    // detail fetch. Same derivation as the detail projection (shared helper).
+    liveUrl: onsiteLiveUrl(row.slug),
   };
 }
 
@@ -289,8 +303,9 @@ function detailKindData(row: HydratedListing): ListingDetailKindData {
     appBlockId: row.appBlockId ?? null,
     hasPage: manifestHasPage(row.appBlock?.manifest),
     // Already-public standalone origin (no token/scope) — same host the webhook
-    // validates the bundle's iframe against. Built from slug + APPS_DOMAIN.
-    liveUrl: `https://${row.slug}.${env.APPS_DOMAIN}`,
+    // validates the bundle's iframe against. Shared derivation with the card
+    // projection (onsiteLiveUrl) so list + detail can never drift.
+    liveUrl: onsiteLiveUrl(row.slug),
   };
 }
 


### PR DESCRIPTION
## What

Adds `liveUrl` to **onsite** items in the `GET /api/v1/apps` **list** response, mirroring the field the `GET /api/v1/apps/{slug}` **detail** response already returns.

## Why

The list response's per-item `kindData` for an onsite app carried only `{ kind, appBlockId, hasPage }` — no live URL — while the detail response's `kindData` already includes `liveUrl`. A consumer building an app directory therefore had to N+1 the detail endpoint per onsite app (or hardcode the URL convention) just to link it. This surfaces the same field on the list card so a single list call is enough.

## How

- **Schema:** add `liveUrl: string` to the onsite variant of the list card kind-data type, identical in name + type to the detail type so consumers see one consistent field.
- **Service:** extract the URL derivation into a shared `onsiteLiveUrl(slug)` helper and use it in **both** the card and detail projections, so list and detail can never drift. A **parity test** asserts they compose byte-identically for the same slug.
- **Additive & safe:** an onsite card only appears once its backing block has deployed (the same deploy-gate the detail read applies), so the origin is always live. **Offsite items are unchanged** (still `externalUrl`).

## Tests

- Onsite list card now includes `liveUrl` = the composed origin for the seeded slug.
- Parity guard: list card `liveUrl` === detail `liveUrl` for the same listing (anti-drift).
- Offsite items unaffected (no spurious `liveUrl`).
- Updated the two `AppListingCard` / `AppListingsMarketplaceBody` component-test fixtures for the new field.

Touched-file typecheck + the `app-listing` unit projection suites pass (82 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)