### PR TITLE
feat(apps): reduce marketplace card truncation — widen grid, 5th column, drop kind/category badges

### DIFF
--- a/src/components/Apps/AppListingCard.browser.test.tsx
+++ b/src/components/Apps/AppListingCard.browser.test.tsx
@@ -50,13 +50,21 @@ describe('AppListingCard', () => {
   test('on-site page app + canOpenPage → Open link to the run route', async () => {
     renderWithProviders(<AppListingCard card={base({})} canOpenPage />);
     await expect.element(page.getByText('My App')).toBeInTheDocument();
-    // exact: the "App" kind badge, else the substring also matches the title
-    // ("My App") and description ("A handy app") — strict-mode violation.
-    await expect.element(page.getByText('App', { exact: true })).toBeInTheDocument();
     await expect.element(page.getByText('by alice')).toBeInTheDocument();
     const open = page.getByRole('link', { name: 'Open' });
     await expect.element(open).toBeInTheDocument();
     await expect.element(open).toHaveAttribute('href', '/apps/run/my-app');
+  });
+
+  test('kind + category badges are NOT rendered on the card (round-2 truncation fix)', async () => {
+    // "App" was formerly the on-site kind badge's exact-match text; "utility" is
+    // base()'s category. Neither should render now that the badge column is gone
+    // — the kind signal instead lives in the CTA (Open/View details vs Visit ↗)
+    // and, for off-site, the detail-page disclosure Alert.
+    renderWithProviders(<AppListingCard card={base({})} canOpenPage />);
+    await expect.element(page.getByText('My App')).toBeInTheDocument();
+    await expect.element(page.getByText('App', { exact: true })).not.toBeInTheDocument();
+    await expect.element(page.getByText('Utility', { exact: true })).not.toBeInTheDocument();
   });
 
   test('no reviews → "No reviews yet"', async () => {
@@ -87,17 +95,21 @@ describe('AppListingCard', () => {
         })}
       />
     );
-    await expect.element(page.getByText('Off-site')).toBeInTheDocument();
+    // The kind signal ("Off-site") is no longer a badge — it's conveyed by the
+    // CTA below (an external "Visit" anchor vs. an internal Open/View details
+    // link) plus the off-site disclosure Alert on the detail page.
+    await expect.element(page.getByText('Off-site', { exact: true })).not.toBeInTheDocument();
     const visit = page.getByRole('link', { name: 'Visit' });
     await expect.element(visit).toHaveAttribute('href', 'https://ext.app');
     await expect.element(visit).toHaveAttribute('target', '_blank');
     await expect.element(visit).toHaveAttribute('rel', 'noopener noreferrer');
   });
 
-  test('off-site connect → Connect badge + View details → unified detail (P2c)', async () => {
+  test('off-site connect → View details → unified detail (P2c)', async () => {
     // P2c: cards route to the unified detail; the Connect action itself lives on
     // the detail page (the connect flow needs a P2a authorize-URL DTO addition),
-    // so the card's CTA is "View details", not an inert Connect button.
+    // so the card's CTA is "View details", not an inert Connect button. The
+    // former "Connect app" kind badge is gone — no longer asserted here.
     renderWithProviders(
       <AppListingCard
         card={base({
@@ -107,9 +119,6 @@ describe('AppListingCard', () => {
         })}
       />
     );
-    // exact: the "Connect app" badge, else the substring also matches the title
-    // ("Connect App", case-insensitive) — strict-mode violation.
-    await expect.element(page.getByText('Connect app', { exact: true })).toBeInTheDocument();
     const details = page.getByRole('link', { name: 'View details' });
     await expect.element(details).toHaveAttribute('href', '/apps/store-preview/my-app');
   });

--- a/src/components/Apps/AppListingCard.tsx
+++ b/src/components/Apps/AppListingCard.tsx
@@ -1,11 +1,5 @@
-import { Anchor, Avatar, Badge, Box, Button, Card, Group, Image, Stack, Text, Title } from '@mantine/core';
-import {
-  IconApps,
-  IconExternalLink,
-  IconPencil,
-  IconPlugConnected,
-  IconThumbUp,
-} from '@tabler/icons-react';
+import { Anchor, Avatar, Box, Button, Card, Group, Image, Stack, Text, Title } from '@mantine/core';
+import { IconApps, IconExternalLink, IconPencil, IconThumbUp } from '@tabler/icons-react';
 import type { Icon } from '@tabler/icons-react';
 import Link from 'next/link';
 import { type MouseEvent, useState } from 'react';
@@ -16,19 +10,14 @@ import {
 } from '~/components/Apps/marketplaceCategoryIcons';
 import {
   canOwnerEditListing,
-  getListingBadge,
   getListingCta,
   getListingDetailHref,
   getOwnerEditHref,
   getRecommendLabel,
-  type ListingBadgeKind,
 } from '~/components/Apps/appListingCardView';
-import { TruncatedBadge, TruncatedText } from '~/components/Apps/AppListingTruncate';
+import { TruncatedText } from '~/components/Apps/AppListingTruncate';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
-import {
-  isMarketplaceCategory,
-  MARKETPLACE_CATEGORY_LABELS,
-} from '~/server/services/blocks/marketplace-categories.constants';
+import { isMarketplaceCategory } from '~/server/services/blocks/marketplace-categories.constants';
 import type { ListingCard } from '~/server/schema/blocks/app-listing-read.schema';
 
 /**
@@ -56,22 +45,6 @@ import type { ListingCard } from '~/server/schema/blocks/app-listing-read.schema
  * AspectRatioImageCard (cosmetic frames) would need the DTO to carry the Image
  * object — a P2a schema addition, out of scope for P2b (flagged in the PR).
  */
-
-const KIND_BADGE_ICON: Record<ListingBadgeKind, Icon> = {
-  onsite: IconApps,
-  connect: IconPlugConnected,
-  'external-link': IconExternalLink,
-};
-
-const KIND_BADGE_COLOR: Record<ListingBadgeKind, string> = {
-  onsite: 'blue',
-  connect: 'teal',
-  'external-link': 'blue',
-};
-
-function categoryLabel(category: string): string {
-  return isMarketplaceCategory(category) ? MARKETPLACE_CATEGORY_LABELS[category] : category;
-}
 
 function categoryIcon(category: string): Icon {
   return isMarketplaceCategory(category) ? CATEGORY_ICONS[category] : FALLBACK_CATEGORY_ICON;
@@ -178,11 +151,9 @@ export interface AppListingCardProps {
 
 export function AppListingCard({ card, canOpenPage = false }: AppListingCardProps) {
   const currentUser = useCurrentUser();
-  const badge = getListingBadge(card);
   const cta = getListingCta(card, { canOpenPage });
   const detailHref = getListingDetailHref(card.slug);
   const recommendLabel = getRecommendLabel(card.recommend, card.reviewCount);
-  const BadgeIcon = KIND_BADGE_ICON[badge.kind];
 
   // Owner "Edit" deep-link (Item 2). The public store DTO is approved-only + has
   // no status field, so gating is owner + editable-status (status omitted →
@@ -196,67 +167,35 @@ export function AppListingCard({ card, canOpenPage = false }: AppListingCardProp
     <Card shadow="sm" padding="md" radius="md" withBorder className="h-full">
       <ListingCover coverUrl={card.coverUrl} category={card.category} name={card.name} />
       <Stack gap="sm" h="100%" pt="sm">
-        <Group justify="space-between" align="flex-start" wrap="nowrap" gap="xs">
-          {/* flex:1 + minWidth:0 lets the text column take the row's slack and
-              shrink gracefully instead of being over-squeezed by the badges. */}
-          <Group gap="xs" wrap="nowrap" align="flex-start" style={{ minWidth: 0, flex: 1 }}>
-            {/* App icon (square, publisher-supplied). Decorative — the title
-                carries the accessible name; a missing icon falls back to the
-                app's initial. */}
-            <Avatar
-              src={card.iconUrl ?? undefined}
-              alt=""
-              radius="md"
-              size={40}
-              style={{ flexShrink: 0 }}
+        <Group gap="xs" wrap="nowrap" align="flex-start" style={{ minWidth: 0 }}>
+          {/* App icon (square, publisher-supplied). Decorative — the title
+              carries the accessible name; a missing icon falls back to the
+              app's initial. */}
+          <Avatar
+            src={card.iconUrl ?? undefined}
+            alt=""
+            radius="md"
+            size={40}
+            style={{ flexShrink: 0 }}
+          >
+            {card.name.charAt(0).toUpperCase()}
+          </Avatar>
+          <Stack gap={2} style={{ minWidth: 0 }}>
+            {/* Title links to the unified detail so the detail is reachable
+                from every card even when the primary CTA is a direct Open /
+                Visit. underline:hover keeps it visibly a link. */}
+            <Anchor
+              component={Link}
+              href={detailHref}
+              underline="hover"
+              c="inherit"
+              style={{ minWidth: 0 }}
             >
-              {card.name.charAt(0).toUpperCase()}
-            </Avatar>
-            <Stack gap={2} style={{ minWidth: 0 }}>
-              {/* Title links to the unified detail so the detail is reachable
-                  from every card even when the primary CTA is a direct Open /
-                  Visit. underline:hover keeps it visibly a link. */}
-              <Anchor
-                component={Link}
-                href={detailHref}
-                underline="hover"
-                c="inherit"
-                style={{ minWidth: 0 }}
-              >
-                <Title order={4} className="line-clamp-2">
-                  {card.name}
-                </Title>
-              </Anchor>
-              <CreatorChip creator={card.creator} />
-            </Stack>
-          </Group>
-          {/* Badge column — capped width + flex-shrink:0 so it never over-squeezes
-              the text column; a long category label ellipsizes with a Tooltip
-              fallback instead of pushing the title/creator out. */}
-          <Stack gap={4} align="flex-end" style={{ flexShrink: 0, maxWidth: 150 }}>
-            {/* Kind badge — App (on-site) vs Connect app / Off-site (off-site).
-                Kind labels are short + fixed, so no truncation needed. */}
-            <Badge
-              variant="light"
-              color={KIND_BADGE_COLOR[badge.kind]}
-              size="sm"
-              leftSection={<BadgeIcon size={12} />}
-            >
-              {badge.label}
-            </Badge>
-            {card.category && (() => {
-              const CategoryIcon = categoryIcon(card.category);
-              return (
-                <TruncatedBadge
-                  variant="light"
-                  color="grape"
-                  size="sm"
-                  maw={150}
-                  leftSection={<CategoryIcon size={12} />}
-                  label={categoryLabel(card.category)}
-                />
-              );
-            })()}
+              <Title order={4} className="line-clamp-2">
+                {card.name}
+              </Title>
+            </Anchor>
+            <CreatorChip creator={card.creator} />
           </Stack>
         </Group>
 

--- a/src/components/Apps/AppListingDetailBody.browser.test.tsx
+++ b/src/components/Apps/AppListingDetailBody.browser.test.tsx
@@ -57,6 +57,22 @@ function base(over: Partial<ListingDetail>): ListingDetail {
 }
 
 describe('AppListingDetailBody', () => {
+  test('kind + category badges are NOT rendered on the detail header (round-2 truncation fix)', async () => {
+    // "App" was formerly the on-site kind badge's exact-match text; "utility" is
+    // base()'s category → labeled "Utility". Neither should render now — the
+    // kind signal instead lives in the primary-action CTA + the off-site
+    // disclosure Alert.
+    renderWithProviders(<AppListingDetailBody detail={base({})} />);
+    await expect.element(page.getByText('My App')).toBeInTheDocument();
+    await expect.element(page.getByText('App', { exact: true })).not.toBeInTheDocument();
+    await expect.element(page.getByText('Utility', { exact: true })).not.toBeInTheDocument();
+  });
+
+  test('contentRating badge STILL renders (not removed — it is not a kind/category badge)', async () => {
+    renderWithProviders(<AppListingDetailBody detail={base({ contentRating: 'PG' })} />);
+    await expect.element(page.getByText('PG', { exact: true })).toBeInTheDocument();
+  });
+
   test('owner sees the Edit deep-link → on-site manifest editor', async () => {
     mocks.currentUser = { id: 5, username: 'alice' }; // matches base().creator.id
     renderWithProviders(<AppListingDetailBody detail={base({})} />);

--- a/src/components/Apps/AppListingDetailBody.tsx
+++ b/src/components/Apps/AppListingDetailBody.tsx
@@ -28,17 +28,13 @@ import type { Icon } from '@tabler/icons-react';
 import Link from 'next/link';
 import { useState } from 'react';
 import { getEdgeUrl } from '~/client-utils/cf-images-utils';
-import {
-  getListingBadge,
-  getRecommendLabel,
-  type ListingBadgeKind,
-} from '~/components/Apps/appListingCardView';
+import { getRecommendLabel } from '~/components/Apps/appListingCardView';
 import {
   canOwnerEditListing,
   getDetailPrimaryAction,
   getOwnerEditHref,
 } from '~/components/Apps/appListingDetailView';
-import { TruncatedBadge, TruncatedText } from '~/components/Apps/AppListingTruncate';
+import { TruncatedText } from '~/components/Apps/AppListingTruncate';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
 import { AppListingComments } from '~/components/Apps/AppListingComments';
 import { ReportListingButton } from '~/components/Apps/ReportListingButton';
@@ -49,10 +45,7 @@ import {
   FALLBACK_CATEGORY_ICON,
 } from '~/components/Apps/marketplaceCategoryIcons';
 import { CustomMarkdown } from '~/components/Markdown/CustomMarkdown';
-import {
-  isMarketplaceCategory,
-  MARKETPLACE_CATEGORY_LABELS,
-} from '~/server/services/blocks/marketplace-categories.constants';
+import { isMarketplaceCategory } from '~/server/services/blocks/marketplace-categories.constants';
 import type {
   ListingDetail,
   ListingGalleryScreenshot,
@@ -87,22 +80,6 @@ import type {
  *     so we render a plain cover with the category-glyph placeholder fallback
  *     (same as the card). Feeding those would be a P2a schema addition.
  */
-
-const KIND_BADGE_ICON: Record<ListingBadgeKind, Icon> = {
-  onsite: IconApps,
-  connect: IconPlugConnected,
-  'external-link': IconExternalLink,
-};
-
-const KIND_BADGE_COLOR: Record<ListingBadgeKind, string> = {
-  onsite: 'blue',
-  connect: 'teal',
-  'external-link': 'blue',
-};
-
-function categoryLabel(category: string): string {
-  return isMarketplaceCategory(category) ? MARKETPLACE_CATEGORY_LABELS[category] : category;
-}
 
 function categoryIcon(category: string): Icon {
   return isMarketplaceCategory(category) ? CATEGORY_ICONS[category] : FALLBACK_CATEGORY_ICON;
@@ -307,8 +284,6 @@ export interface AppListingDetailBodyProps {
 
 export function AppListingDetailBody({ detail, canOpenPage = false }: AppListingDetailBodyProps) {
   const currentUser = useCurrentUser();
-  const badge = getListingBadge(detail);
-  const BadgeIcon = KIND_BADGE_ICON[badge.kind];
   const recommendLabel = getRecommendLabel(detail.recommend, detail.reviewCount);
   const hasRecommend = detail.recommend.recommendPct != null;
 
@@ -330,7 +305,7 @@ export function AppListingDetailBody({ detail, canOpenPage = false }: AppListing
 
       <HeroCover coverUrl={detail.coverUrl} category={detail.category} name={detail.name} />
 
-      {/* Header: icon + name + tagline + creator + kind/category badges + action. */}
+      {/* Header: icon + name + tagline + creator + content-rating badge + action. */}
       <Group justify="space-between" align="flex-start" wrap="nowrap">
         <Group gap="md" wrap="nowrap" align="flex-start" style={{ minWidth: 0 }}>
           <Avatar src={detail.iconUrl ?? undefined} alt="" radius="md" size={64}>
@@ -346,34 +321,13 @@ export function AppListingDetailBody({ detail, canOpenPage = false }: AppListing
               </Text>
             )}
             <CreatorChip creator={detail.creator} />
-            <Group gap="xs" mt={2}>
-              <Badge
-                variant="light"
-                color={KIND_BADGE_COLOR[badge.kind]}
-                size="sm"
-                leftSection={<BadgeIcon size={12} />}
-              >
-                {badge.label}
-              </Badge>
-              {detail.category && (() => {
-                const CategoryIcon = categoryIcon(detail.category);
-                return (
-                  <TruncatedBadge
-                    variant="light"
-                    color="grape"
-                    size="sm"
-                    maw={220}
-                    leftSection={<CategoryIcon size={12} />}
-                    label={categoryLabel(detail.category)}
-                  />
-                );
-              })()}
-              {detail.contentRating && (
+            {detail.contentRating && (
+              <Group gap="xs" mt={2}>
                 <Badge variant="light" color="gray" size="sm">
                   {detail.contentRating}
                 </Badge>
-              )}
-            </Group>
+              </Group>
+            )}
           </Stack>
         </Group>
         <Box style={{ flexShrink: 0 }}>

--- a/src/components/Apps/AppListingsMarketplaceBody.tsx
+++ b/src/components/Apps/AppListingsMarketplaceBody.tsx
@@ -211,7 +211,7 @@ export function AppListingsMarketplaceBody() {
         <>
           <Grid gutter="md">
             {filteredItems.map((card) => (
-              <Grid.Col key={card.id} span={{ base: 12, sm: 6, md: 4, lg: 3 }}>
+              <Grid.Col key={card.id} span={{ base: 12, sm: 6, md: 4, lg: 3, xl: 2.4 }}>
                 <AppListingCard card={card} canOpenPage={!!features.appBlocksPages} />
               </Grid.Col>
             ))}

--- a/src/components/Apps/AppsPageLayout.tsx
+++ b/src/components/Apps/AppsPageLayout.tsx
@@ -39,8 +39,12 @@ export function AppsPageLayout({
   subtitle?: ReactNode;
   /** Right-aligned header controls (e.g. a "Submit a new app" button). */
   actions?: ReactNode;
-  /** Container width — pages keep their prior size (`sm` for Submit, etc.). */
-  size?: MantineSize;
+  /**
+   * Container width — pages keep their prior size (`sm` for Submit, etc.).
+   * Also accepts a raw number (px) — Mantine's `Container` supports it, used by
+   * the store index to widen past the `xl` (1320px) token.
+   */
+  size?: MantineSize | number;
   children: ReactNode;
 }) {
   const hasHeader = Boolean(title || subtitle || actions);

--- a/src/pages/apps/index.tsx
+++ b/src/pages/apps/index.tsx
@@ -47,7 +47,10 @@ export default function AppsPage() {
           (`blocks.backfillAppListings` → `appListings.backfillListingAssets`,
           a separate post-deploy op step) — the empty state renders sanely
           ("No apps yet"); expected + fine while dark. */}
-      <AppsPageLayout size="xl">
+      <AppsPageLayout size={1600}>
+        {/* Widened past the default `xl` (1320px) token — a 5-across grid at this
+            container width needs the extra room to keep card text from
+            truncating (see AppListingsMarketplaceBody's `xl` column span). */}
         <AppListingsMarketplaceBody />
       </AppsPageLayout>
     </>


### PR DESCRIPTION
## Summary

Round 2 of fixing text truncation in the `/apps` store grid cards (round 1, #3380, added tooltip fallbacks — not enough on its own). Three changes:

1. **Widen the container.** `AppsPageLayout`'s `size` prop now also accepts a raw number (Mantine `Container` supports px sizes), and the store index page (`src/pages/apps/index.tsx`) now uses `size={1600}` instead of the default `xl` (1320px) token. No other `/apps/*` page's width changed (Submit stays `sm`, store-preview detail stays `lg`).
2. **Add a responsive 5th column.** `AppListingsMarketplaceBody`'s grid now has an `xl` breakpoint (`2.4/12` = 5 columns): 1 col mobile → 2 (sm) → 3 (md) → 4 (lg) → 5 (xl), so the extra container width is put to use instead of just stretching 4 cards.
3. **Remove the kind + category badge column** from both `AppListingCard` (grid card) and `AppListingDetailBody` (detail page header) — it was eating horizontal room and forcing the truncation in the first place.

**On the kind signal (accuracy note):** removing the badge *does* reduce per-card kind disclosure — it's only *partially* covered elsewhere, not fully:
- **External-link** off-site apps stay distinguishable on the card via their CTA (external "Visit ↗" anchor) + the off-site disclosure `Alert` on the detail page.
- **Connect (OAuth)** off-site apps and **on-site** apps now share the same card CTA ("View details" / "Open") — that distinction is no longer on the card (it's still visible on the detail page's primary action).
- The dimension stays discoverable via the store's **kind filter** (All / On-site / Off-site) in `AppListingsMarketplaceBody`, which is unchanged.

If per-card connect-vs-on-site distinction turns out to be wanted, a small non-badge indicator can be added in a follow-up. `contentRating` badge on the detail page is unaffected (kept — it's not a kind/category badge).

## Files changed
- `src/components/Apps/AppsPageLayout.tsx` — widen `size` prop type to `MantineSize | number`
- `src/pages/apps/index.tsx` — store index uses `size={1600}`
- `src/components/Apps/AppListingsMarketplaceBody.tsx` — add `xl: 2.4` grid breakpoint
- `src/components/Apps/AppListingCard.tsx` — remove kind+category badge column, prune now-unused imports/consts
- `src/components/Apps/AppListingDetailBody.tsx` — remove kind+category badges from the header, keep `contentRating`, prune now-unused imports/consts
- `src/components/Apps/AppListingCard.browser.test.tsx` — update assertions (badge text no longer present) + add explicit not-rendered assertions
- `src/components/Apps/AppListingDetailBody.browser.test.tsx` — add not-rendered assertions for kind/category + a `contentRating`-still-renders test

The pure view-model unit tests (`appListingCardView.test.ts` / `appListingDetailView.test.ts`) and the `getListingBadge` function itself are untouched — the badge computation still exists, it's just no longer rendered in these two components. (Note: `TruncatedBadge` in `AppListingTruncate.tsx` is now unused by these two files — a safe follow-up prune if no other consumer appears.)

## Test plan
- [x] `tsc --noEmit` — clean (no errors)
- [x] `eslint` on the 5 changed non-test files — clean (0 errors; 1 pre-existing unrelated warning on `AppListingDetailBody.tsx` for an already-unused `ThemeIcon` import that predates this PR, confirmed present on `main` too)
- [ ] Vitest browser-mode component tests (`AppListingCard.browser.test.tsx`, `AppListingDetailBody.browser.test.tsx`, `AppListingsMarketplaceBody.browser.test.tsx`) — **written but not executed**: the sandbox this PR was authored in could not provision the Playwright `chromium-headless-shell` binary (download succeeded but the binary didn't materialize; `--with-deps` requires root/apt, unavailable in this sandbox). These are the existing "REPORT-ONLY" browser test suite per the file docstrings (not the blocking CI gate — the blocking pure-function tests are untouched and unaffected by this change). Please have CI or a human run `pnpm test:component` on this branch to confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
