### PR TITLE
feat(app-listings): OAuth step — mod client search + create-client deeplink

### DIFF
--- a/src/components/Apps/ExternalSubmitForm.browser.test.tsx
+++ b/src/components/Apps/ExternalSubmitForm.browser.test.tsx
@@ -33,6 +33,13 @@ const mocks = vi.hoisted(() => ({
     data: [{ id: 'oauth-client-1', name: 'My OAuth App', allowedScopes: 4 | 32 }] as unknown,
     isLoading: false,
   },
+  // Mod-only global-search result (App-Blocks mod picker). Empty by default; the mod
+  // tests set foreign clients here. `useCurrentUser` drives which picker renders.
+  search: { data: { items: [] as unknown[], nextCursor: undefined }, isFetching: false } as {
+    data: { items: unknown[]; nextCursor?: string };
+    isFetching: boolean;
+  },
+  currentUser: null as null | { id: number; username: string; isModerator?: boolean },
 }));
 
 vi.mock('~/utils/trpc', () => {
@@ -57,10 +64,18 @@ vi.mock('~/utils/trpc', () => {
       },
       oauthClient: {
         getAll: { useQuery: () => mocks.clients },
+        searchForModerator: { useQuery: () => mocks.search },
       },
     },
   };
 });
+
+// The OAuth picker is role-aware: mods get the async global-search control, non-mods
+// the own-clients dropdown. Drive the role via a mocked `useCurrentUser` (the harness
+// provides no session context, so this hook must be mocked here).
+vi.mock('~/hooks/useCurrentUser', () => ({
+  useCurrentUser: () => mocks.currentUser,
+}));
 
 vi.mock('~/hooks/useCFImageUpload', () => ({
   useCFImageUpload: () => ({
@@ -86,6 +101,9 @@ beforeEach(() => {
     data: [{ id: 'oauth-client-1', name: 'My OAuth App', allowedScopes: READONLY_SCOPES }],
     isLoading: false,
   };
+  mocks.search = { data: { items: [], nextCursor: undefined }, isFetching: false };
+  // Default caller: NOT a moderator → own-clients dropdown (existing tests unchanged).
+  mocks.currentUser = null;
 });
 
 /** Fill a valid App URL on step 0 and advance to the App & scopes step. */
@@ -312,5 +330,72 @@ describe('ExternalSubmitForm — redesigned wizard', () => {
     await page.getByTestId('apps-offsite-wizard-next-app').click();
     await page.getByRole('button', { name: 'Create draft' }).click();
     expect(mocks.mutate).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('ExternalSubmitForm — OAuth step: mod global-search + create deeplink', () => {
+  test('a NON-moderator sees the own-clients dropdown (unchanged), not the search control', async () => {
+    mocks.currentUser = { id: 5, username: 'dev' }; // no isModerator
+    renderWithProviders(<ExternalSubmitForm />);
+    await advanceFromUrl();
+    await expect.element(page.getByTestId('apps-offsite-client-select')).toBeInTheDocument();
+    expect(page.getByTestId('apps-offsite-client-search').elements()).toHaveLength(0);
+  });
+
+  test('a MODERATOR sees the async global-search control, not the own-clients dropdown', async () => {
+    mocks.currentUser = { id: 1, username: 'mod', isModerator: true };
+    mocks.search = {
+      data: { items: [], nextCursor: undefined },
+      isFetching: false,
+    };
+    renderWithProviders(<ExternalSubmitForm />);
+    await advanceFromUrl();
+    await expect.element(page.getByTestId('apps-offsite-client-search')).toBeInTheDocument();
+    expect(page.getByTestId('apps-offsite-client-select').elements()).toHaveLength(0);
+  });
+
+  test('a mod selecting a searched FOREIGN client derives the requested scopes from THAT client', async () => {
+    // The foreign client is NOT in the caller's own list; its allowedScopes must still
+    // flow into deriveScopesFromClient. UserRead=1 is SENSITIVE → its justification
+    // input appearing proves the derived requestedScopes came from the foreign client.
+    mocks.currentUser = { id: 1, username: 'mod', isModerator: true };
+    mocks.search = {
+      data: {
+        items: [
+          { id: 'foreign-1', name: 'Bobs App', allowedScopes: 1, user: { id: 9, username: 'bob' } },
+        ],
+        nextCursor: undefined,
+      },
+      isFetching: false,
+    };
+    renderWithProviders(<ExternalSubmitForm />);
+    await advanceFromUrl();
+    await page.getByTestId('apps-offsite-client-search').click();
+    await page.getByRole('option', { name: /Bobs App/ }).click();
+    // Derived from allowedScopes=1 (UserRead, sensitive) → required justification input.
+    await expect.element(page.getByTestId('apps-offsite-justification-1')).toBeInTheDocument();
+    await expect.element(page.getByTestId('apps-offsite-scope-readonly')).toBeInTheDocument();
+  });
+
+  test('the "Create an OAuth client" deeplink renders for a NON-mod → /user/account in a new tab', async () => {
+    mocks.currentUser = { id: 5, username: 'dev' };
+    renderWithProviders(<ExternalSubmitForm />);
+    await advanceFromUrl();
+    const link = page.getByTestId('apps-offsite-create-client-link');
+    await expect.element(link).toBeInTheDocument();
+    await expect.element(link).toHaveAttribute('href', '/user/account');
+    await expect.element(link).toHaveAttribute('target', '_blank');
+    await expect.element(link).toHaveAttribute('rel', expect.stringContaining('noopener'));
+  });
+
+  test('the "Create an OAuth client" deeplink renders for a MODERATOR → /user/account in a new tab', async () => {
+    mocks.currentUser = { id: 1, username: 'mod', isModerator: true };
+    renderWithProviders(<ExternalSubmitForm />);
+    await advanceFromUrl();
+    const link = page.getByTestId('apps-offsite-create-client-link');
+    await expect.element(link).toBeInTheDocument();
+    await expect.element(link).toHaveAttribute('href', '/user/account');
+    await expect.element(link).toHaveAttribute('target', '_blank');
+    await expect.element(link).toHaveAttribute('rel', expect.stringContaining('noopener'));
   });
 });

--- a/src/components/Apps/ExternalSubmitForm.tsx
+++ b/src/components/Apps/ExternalSubmitForm.tsx
@@ -1,5 +1,6 @@
 import {
   Alert,
+  Anchor,
   Badge,
   Button,
   Code,
@@ -7,11 +8,13 @@ import {
   Loader,
   Select,
   Stack,
-  Stepper,
   Text,
   TextInput,
   Textarea,
+  Stepper,
 } from '@mantine/core';
+import { useDebouncedValue } from '@mantine/hooks';
+import { keepPreviousData } from '@tanstack/react-query';
 import {
   IconAlertTriangle,
   IconCheck,
@@ -52,8 +55,22 @@ import type { ListingEditContext } from '~/components/Apps/offsiteEditConfig';
 import type { MarketplaceCategory } from '~/server/services/blocks/marketplace-categories.constants';
 import type { OffsiteContentRating } from '~/server/schema/blocks/offsite-listing.schema';
 import { isAppBlockOauthClientId } from '~/shared/constants/block-scope.constants';
+import { useCurrentUser } from '~/hooks/useCurrentUser';
 import { showErrorNotification, showSuccessNotification } from '~/utils/notifications';
 import { trpc } from '~/utils/trpc';
+
+/**
+ * A moderator's global-search OAuth-client option — the SECRET-FREE projection
+ * returned by `oauthClient.searchForModerator` (plus what we pin for the selected
+ * FOREIGN client). Kept minimal so a searched client not in the caller's own list
+ * still resolves its `allowedScopes` for `deriveScopesFromClient`.
+ */
+type ModClientOption = {
+  id: string;
+  name: string;
+  allowedScopes: number;
+  user: { id: number; username: string | null } | null;
+};
 
 /**
  * /apps/submit — "External app" mode body (W13 P3a, MERGED external+connect model).
@@ -120,6 +137,9 @@ function ExternalCreateForm() {
   // meta effect); we never seed this up front so the title can win.
   const hostNameFallbackRef = useRef<string>('');
 
+  const currentUser = useCurrentUser();
+  const isModerator = !!currentUser?.isModerator;
+
   const clientsQuery = trpc.oauthClient.getAll.useQuery(undefined, {
     retry: false,
     refetchOnWindowFocus: false,
@@ -133,10 +153,52 @@ function ExternalCreateForm() {
     [clientsQuery.data]
   );
 
-  const selectedClient = useMemo(
+  // MODERATOR picker: a debounced async global search over ALL non-App-Block clients.
+  // An empty search returns the mod's own clients (server default), so mods get the
+  // same starting point as regular devs before typing. Non-mods never fire this.
+  const [clientSearch, setClientSearch] = useState('');
+  const [debouncedClientSearch] = useDebouncedValue(clientSearch.trim(), 300);
+  const modSearchQuery = trpc.oauthClient.searchForModerator.useQuery(
+    { query: debouncedClientSearch || undefined },
+    {
+      enabled: isModerator,
+      retry: false,
+      refetchOnWindowFocus: false,
+      placeholderData: keepPreviousData,
+    }
+  );
+  const modResults = useMemo<ModClientOption[]>(
+    () => modSearchQuery.data?.items ?? [],
+    [modSearchQuery.data]
+  );
+
+  // The full selected-client object — the ONLY source of `allowedScopes` for mods,
+  // because a searched FOREIGN client is not in the caller's own `clients` list. Also
+  // pinned into the Select's `data` so Mantine can render its label across searches.
+  const [selectedClientData, setSelectedClientData] = useState<ModClientOption | null>(null);
+
+  // Options the mod Select can render/select from: the current search results, PLUS
+  // the pinned selected client (so its label survives when a later search drops it).
+  const modOptionClients = useMemo<ModClientOption[]>(() => {
+    const map = new Map<string, ModClientOption>();
+    for (const c of modResults) map.set(c.id, c);
+    if (selectedClientData && !map.has(selectedClientData.id)) {
+      map.set(selectedClientData.id, selectedClientData);
+    }
+    return [...map.values()];
+  }, [modResults, selectedClientData]);
+
+  // Role-aware resolution of the selected client + its scope ceiling. Mods resolve from
+  // the pinned/search object (FOREIGN-client safe); non-mods from their own list.
+  const ownSelectedClient = useMemo(
     () => clients.find((c) => c.id === values.connectClientId) ?? null,
     [clients, values.connectClientId]
   );
+  const selectedClient = isModerator
+    ? values.connectClientId === selectedClientData?.id
+      ? selectedClientData
+      : null
+    : ownSelectedClient;
   const allowedScopes = selectedClient?.allowedScopes ?? 0;
 
   const metaQuery = trpc.appListings.fetchListingMetaFromUrl.useQuery(
@@ -210,8 +272,20 @@ function ExternalCreateForm() {
     // Changing the client RE-DERIVES the requested scopes from the new client's
     // `allowedScopes` (the listing requests exactly the client's set — no picker) and
     // re-keys the justifications, dropping any whose scope the new client doesn't have.
-    const nextClient = clientId ? clients.find((c) => c.id === clientId) ?? null : null;
-    const nextAllowed = nextClient?.allowedScopes ?? 0;
+    // Mods resolve the picked client from the global-search options (which may be a
+    // FOREIGN client) and PIN it so its scopes + label survive later searches; non-mods
+    // resolve from their own client list, unchanged.
+    let nextAllowed = 0;
+    if (isModerator) {
+      const nextClient = clientId
+        ? modOptionClients.find((c) => c.id === clientId) ?? null
+        : null;
+      setSelectedClientData(nextClient);
+      nextAllowed = nextClient?.allowedScopes ?? 0;
+    } else {
+      const nextClient = clientId ? clients.find((c) => c.id === clientId) ?? null : null;
+      nextAllowed = nextClient?.allowedScopes ?? 0;
+    }
     setValues((v) => deriveScopesFromClient({ ...v, connectClientId: clientId }, nextAllowed));
     setShowScopeErrors(false);
     setErrors((prev) => ({ ...prev, connectClientId: undefined, requestedScopes: undefined }));
@@ -325,6 +399,27 @@ function ExternalCreateForm() {
 
   const busy = submitMutation.isPending;
   const clientOptions = clients.map((c) => ({ value: c.id, label: c.name }));
+  const modClientOptions = modOptionClients.map((c) => ({
+    value: c.id,
+    label: `${c.name} — by @${c.user?.username ?? 'unknown'}`,
+  }));
+
+  // Create-client deeplink for EVERYONE (mods + regular devs) — opens the OAuth-apps
+  // card on /user/account in a NEW TAB so the in-progress wizard isn't lost. Rendered
+  // persistently below the picker AND reused as the Select's `nothingFoundMessage`.
+  const createClientLink = (
+    <Anchor
+      href="/user/account"
+      target="_blank"
+      rel="noopener noreferrer"
+      size="xs"
+      style={{ display: 'inline-flex', alignItems: 'center', gap: 4 }}
+      data-testid="apps-offsite-create-client-link"
+    >
+      Don’t see your app? Create an OAuth client
+      <IconExternalLink size={12} />
+    </Anchor>
+  );
 
   return (
     <Stack gap="md" data-testid="apps-offsite-submit-form">
@@ -419,7 +514,30 @@ function ExternalCreateForm() {
         >
           <FadeIn>
             <Stack gap="md" mt="md">
-              {clientsQuery.isLoading ? (
+              {isModerator ? (
+                // MOD: async global search over ALL non-App-Block clients. Empty search
+                // returns the mod's own clients (server default). Server does the
+                // matching, so client-side Select filtering is disabled (`filter`
+                // passthrough) — otherwise it would re-filter the label locally.
+                <Select
+                  label="OAuth app"
+                  description="Search any developer’s OAuth client by app name, author username, or author ID. Leave empty to see your own."
+                  placeholder="Search apps…"
+                  searchable
+                  searchValue={clientSearch}
+                  onSearchChange={setClientSearch}
+                  filter={({ options }) => options}
+                  data={modClientOptions}
+                  value={values.connectClientId}
+                  onChange={handleSelectClient}
+                  error={errors.connectClientId}
+                  disabled={busy}
+                  required
+                  nothingFoundMessage={createClientLink}
+                  rightSection={modSearchQuery.isFetching ? <Loader size={14} /> : undefined}
+                  data-testid="apps-offsite-client-search"
+                />
+              ) : clientsQuery.isLoading ? (
                 <Group gap={8} data-testid="apps-offsite-clients-loading">
                   <Loader size={16} />
                   <Text size="sm" c="dimmed">
@@ -434,30 +552,31 @@ function ExternalCreateForm() {
                   </Text>
                 </Alert>
               ) : (
-                <>
-                  <Select
-                    label="OAuth app"
-                    description="One of your registered OAuth clients. Users will grant this app access."
-                    placeholder="Choose an app"
-                    data={clientOptions}
-                    value={values.connectClientId}
-                    onChange={handleSelectClient}
-                    error={errors.connectClientId}
-                    disabled={busy}
-                    required
-                    data-testid="apps-offsite-client-select"
-                  />
+                <Select
+                  label="OAuth app"
+                  description="One of your registered OAuth clients. Users will grant this app access."
+                  placeholder="Choose an app"
+                  data={clientOptions}
+                  value={values.connectClientId}
+                  onChange={handleSelectClient}
+                  error={errors.connectClientId}
+                  disabled={busy}
+                  required
+                  data-testid="apps-offsite-client-select"
+                />
+              )}
 
-                  {selectedClient && (
-                    <DerivedScopesDisclosure
-                      requestedScopes={values.requestedScopes}
-                      justifications={values.scopeJustifications}
-                      onJustificationChange={handleJustificationChange}
-                      disabled={busy}
-                      forceShowErrors={showScopeErrors}
-                    />
-                  )}
-                </>
+              {/* Persistent create-client deeplink — both roles, every picker state. */}
+              {createClientLink}
+
+              {selectedClient && (
+                <DerivedScopesDisclosure
+                  requestedScopes={values.requestedScopes}
+                  justifications={values.scopeJustifications}
+                  onJustificationChange={handleJustificationChange}
+                  disabled={busy}
+                  forceShowErrors={showScopeErrors}
+                />
               )}
 
               <Group justify="space-between">

--- a/src/components/Apps/__tests__/offsiteSubmitFormConfig.oauth-fields.test.ts
+++ b/src/components/Apps/__tests__/offsiteSubmitFormConfig.oauth-fields.test.ts
@@ -64,6 +64,19 @@ describe('deriveScopesFromClient', () => {
     expect(v.requestedScopes).toBe(0);
     expect(v.scopeJustifications).toEqual({});
   });
+
+  it('derives from a FOREIGN client’s allowedScopes (mod global-search picker) — source-agnostic', () => {
+    // The mod picker can select a client the caller does NOT own; deriveScopesFromClient
+    // is pure over the passed mask, so a foreign client's allowedScopes derive identically.
+    const foreignAllowed = TokenScope.MediaRead | TokenScope.MediaWrite;
+    const v = deriveScopesFromClient(
+      { ...emptyOffsiteSubmitForm(), scopeJustifications: { ModelsRead: 'stale-own-scope' } },
+      foreignAllowed
+    );
+    expect(v.requestedScopes).toBe(foreignAllowed);
+    // The justification for a scope the foreign client lacks (ModelsRead) is pruned.
+    expect(v.scopeJustifications).toEqual({});
+  });
 });
 
 describe('pruneJustificationsToMask / shapeScopeJustifications', () => {

--- a/src/server/routers/__tests__/oauth-client.router.searchForModerator.test.ts
+++ b/src/server/routers/__tests__/oauth-client.router.searchForModerator.test.ts
@@ -1,0 +1,207 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { TRPCError } from '@trpc/server';
+
+/**
+ * `oauthClient.searchForModerator` — the moderator-only global OAuth-client search
+ * that backs the App-Blocks external-submit mod picker.
+ *
+ * Drives the REAL `oauthClientRouter` via `createCaller` so the `moderatorProcedure`
+ * middleware (the mod gate) is exercised, not mocked. `dbRead`/`dbWrite` are mocked so
+ * importing the router never drags in the generated Prisma client; the `findMany` mock
+ * both RECORDS the `where`/`select`/`orderBy`/`take`/`cursor` the router builds (so we
+ * can assert the query shape a mocked DB can't otherwise prove) AND serves a fixed,
+ * pre-sorted dataset honoring keyset pagination for the two-page test.
+ */
+
+const APP_BLOCK_EXCLUDE = { NOT: { id: { startsWith: 'appblk-' } } };
+
+type Row = {
+  id: string;
+  name: string;
+  allowedScopes: number;
+  logoUrl: string | null;
+  isConfidential: boolean;
+  isVerified: boolean;
+  createdAt: Date;
+  user: { id: number; username: string | null } | null;
+};
+
+const mocks = vi.hoisted(() => ({
+  // Pre-sorted (createdAt desc, id asc) dataset the findMany mock slices by take+cursor.
+  dataset: [] as Row[],
+  findMany: vi.fn(),
+}));
+
+vi.mock('~/server/db/client', () => ({
+  dbRead: { oauthClient: { findMany: mocks.findMany } },
+  dbWrite: { oauthClient: {}, apiKey: {} },
+}));
+// The router imports this at module load for the (unrelated) delete path — stub it so
+// importing the router doesn't reach the orchestrator client.
+vi.mock('~/server/services/orchestrator/civitai', () => ({
+  invalidateCivitaiUser: vi.fn(async () => undefined),
+}));
+
+import { oauthClientRouter } from '../oauth-client.router';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
+
+function fakeCtx(user: unknown) {
+  return {
+    acceptableOrigin: true,
+    user,
+    apiKeyId: null,
+    tokenScope: TokenScope.Full,
+    req: { headers: {} } as never,
+    res: { setHeader: () => undefined } as never,
+    cache: { edgeTTL: 0 },
+    features: {} as never,
+    track: undefined,
+  };
+}
+
+const mod = { id: 1, isModerator: true, tier: 'free', username: 'mod', onboarding: 0x1f };
+const nonMod = { id: 3, isModerator: false, tier: 'free', username: 'user', onboarding: 0x1f };
+
+function row(over: Partial<Row> & { id: string }): Row {
+  return {
+    name: 'Client',
+    allowedScopes: 1,
+    logoUrl: null,
+    isConfidential: true,
+    isVerified: false,
+    createdAt: new Date('2026-01-01T00:00:00Z'),
+    user: { id: 1, username: 'mod' },
+    ...over,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.dataset = [];
+  // Default: slice the dataset honoring Prisma's INCLUSIVE cursor + `take`, so the
+  // pagination test gets a faithful two-page seek. Arg-assertion tests ignore the
+  // return value.
+  mocks.findMany.mockImplementation(async (args: any) => {
+    const all = mocks.dataset;
+    const take: number = args?.take ?? all.length;
+    const startId: string | undefined = args?.cursor?.id;
+    const idx = startId ? all.findIndex((r) => r.id === startId) : 0;
+    const from = idx < 0 ? 0 : idx;
+    return all.slice(from, from + take);
+  });
+});
+
+describe('oauthClient.searchForModerator — mod gate', () => {
+  it('non-moderator caller → FORBIDDEN, DB never queried', async () => {
+    const caller = oauthClientRouter.createCaller(fakeCtx(nonMod) as never);
+    await expect(caller.searchForModerator({})).rejects.toBeInstanceOf(TRPCError);
+    expect(mocks.findMany).not.toHaveBeenCalled();
+  });
+
+  it('anonymous caller → UNAUTHORIZED/FORBIDDEN, DB never queried', async () => {
+    const caller = oauthClientRouter.createCaller(fakeCtx(undefined) as never);
+    await expect(caller.searchForModerator({})).rejects.toBeInstanceOf(TRPCError);
+    expect(mocks.findMany).not.toHaveBeenCalled();
+  });
+});
+
+describe('oauthClient.searchForModerator — where construction', () => {
+  it('empty query → the CALLER’s own clients only (userId + app-block exclude, no OR)', async () => {
+    const caller = oauthClientRouter.createCaller(fakeCtx(mod) as never);
+    await caller.searchForModerator({});
+    const where = mocks.findMany.mock.calls[0][0].where;
+    expect(where).toEqual({ AND: [{ userId: mod.id }, APP_BLOCK_EXCLUDE] });
+  });
+
+  it('non-empty query → matches client name (case-insensitive ILIKE)', async () => {
+    const caller = oauthClientRouter.createCaller(fakeCtx(mod) as never);
+    await caller.searchForModerator({ query: 'Cool' });
+    const where = mocks.findMany.mock.calls[0][0].where;
+    expect(where.AND[1]).toEqual(APP_BLOCK_EXCLUDE);
+    expect(where.AND[0].OR).toContainEqual({ name: { contains: 'Cool', mode: 'insensitive' } });
+  });
+
+  it('non-empty query → matches owner username (case-insensitive ILIKE)', async () => {
+    const caller = oauthClientRouter.createCaller(fakeCtx(mod) as never);
+    await caller.searchForModerator({ query: 'alice' });
+    const or = mocks.findMany.mock.calls[0][0].where.AND[0].OR;
+    expect(or).toContainEqual({ user: { username: { contains: 'alice', mode: 'insensitive' } } });
+  });
+
+  it('numeric query → matches owner id exactly (in addition to the ILIKE clauses)', async () => {
+    const caller = oauthClientRouter.createCaller(fakeCtx(mod) as never);
+    await caller.searchForModerator({ query: '42' });
+    const or = mocks.findMany.mock.calls[0][0].where.AND[0].OR;
+    expect(or).toContainEqual({ userId: 42 });
+    // still an ILIKE name/username match too
+    expect(or).toContainEqual({ name: { contains: '42', mode: 'insensitive' } });
+  });
+
+  it('non-numeric query → NO owner-id clause', async () => {
+    const caller = oauthClientRouter.createCaller(fakeCtx(mod) as never);
+    await caller.searchForModerator({ query: 'alice' });
+    const or: any[] = mocks.findMany.mock.calls[0][0].where.AND[0].OR;
+    expect(or.some((c) => 'userId' in c)).toBe(false);
+  });
+
+  it('ALWAYS excludes App-Block (appblk-*) clients at the DB level, even with a query', async () => {
+    const caller = oauthClientRouter.createCaller(fakeCtx(mod) as never);
+    await caller.searchForModerator({ query: 'appblk' });
+    const where = mocks.findMany.mock.calls[0][0].where;
+    expect(where.AND).toContainEqual(APP_BLOCK_EXCLUDE);
+  });
+});
+
+describe('oauthClient.searchForModerator — projection & ordering', () => {
+  it('selects ONLY safe fields (user:{id,username}) and NEVER the secret', async () => {
+    const caller = oauthClientRouter.createCaller(fakeCtx(mod) as never);
+    await caller.searchForModerator({ query: 'x' });
+    const args = mocks.findMany.mock.calls[0][0];
+    expect(args.select).toEqual({
+      id: true,
+      name: true,
+      allowedScopes: true,
+      logoUrl: true,
+      isConfidential: true,
+      isVerified: true,
+      createdAt: true,
+      user: { select: { id: true, username: true } },
+    });
+    // Belt-and-suspenders: no credential field is ever requested.
+    expect(args.select).not.toHaveProperty('secret');
+    expect(args.select.user.select).not.toHaveProperty('secret');
+    expect(args.orderBy).toEqual([{ createdAt: 'desc' }, { id: 'asc' }]);
+  });
+});
+
+describe('oauthClient.searchForModerator — keyset pagination', () => {
+  it('second page via nextCursor returns the next batch with NO overlap', async () => {
+    // 5 clients, page size 2. Page 1 → [c0,c1] + nextCursor; page 2 → [c2,c3].
+    mocks.dataset = [0, 1, 2, 3, 4].map((i) =>
+      row({ id: `c${i}`, name: `App ${i}`, createdAt: new Date(2026, 0, 5 - i) })
+    );
+    const caller = oauthClientRouter.createCaller(fakeCtx(mod) as never);
+
+    const page1 = await caller.searchForModerator({ query: 'App', limit: 2 });
+    expect(page1.items.map((r) => r.id)).toEqual(['c0', 'c1']);
+    expect(page1.nextCursor).toBe('c2');
+
+    const page2 = await caller.searchForModerator({
+      query: 'App',
+      limit: 2,
+      cursor: page1.nextCursor,
+    });
+    expect(page2.items.map((r) => r.id)).toEqual(['c2', 'c3']);
+
+    const page1Ids = new Set(page1.items.map((r) => r.id));
+    for (const r of page2.items) expect(page1Ids.has(r.id)).toBe(false);
+  });
+
+  it('a final short page returns no nextCursor', async () => {
+    mocks.dataset = [row({ id: 'only', name: 'App only' })];
+    const caller = oauthClientRouter.createCaller(fakeCtx(mod) as never);
+    const res = await caller.searchForModerator({ query: 'App', limit: 20 });
+    expect(res.items.map((r) => r.id)).toEqual(['only']);
+    expect(res.nextCursor).toBeUndefined();
+  });
+});

--- a/src/server/routers/__tests__/oauth-client.router.searchForModerator.test.ts
+++ b/src/server/routers/__tests__/oauth-client.router.searchForModerator.test.ts
@@ -144,6 +144,15 @@ describe('oauthClient.searchForModerator — where construction', () => {
     expect(or.some((c) => 'userId' in c)).toBe(false);
   });
 
+  it('all-digits query beyond int32 → NO owner-id clause (avoids Postgres int4 overflow 500)', async () => {
+    const caller = oauthClientRouter.createCaller(fakeCtx(mod) as never);
+    await caller.searchForModerator({ query: '9999999999' });
+    const or: any[] = mocks.findMany.mock.calls[0][0].where.AND[0].OR;
+    // out-of-range int → only the ILIKE name/username clauses, no `userId` (which would overflow int4)
+    expect(or.some((c) => 'userId' in c)).toBe(false);
+    expect(or).toContainEqual({ name: { contains: '9999999999', mode: 'insensitive' } });
+  });
+
   it('ALWAYS excludes App-Block (appblk-*) clients at the DB level, even with a query', async () => {
     const caller = oauthClientRouter.createCaller(fakeCtx(mod) as never);
     await caller.searchForModerator({ query: 'appblk' });

--- a/src/server/routers/oauth-client.router.ts
+++ b/src/server/routers/oauth-client.router.ts
@@ -112,10 +112,15 @@ export const oauthClientRouter = router({
         // Global search: app name OR author username (both case-insensitive ILIKE) OR,
         // when the query is an integer, the author's exact user id.
         const numeric = Number(query);
+        // Only treat the query as an author id when it's a valid positive
+        // Postgres int4 — an all-digits query beyond int32 (e.g. a pasted long
+        // number) passes Number.isInteger but would 500 on int4 overflow.
+        const numericIsUserId =
+          Number.isInteger(numeric) && numeric >= 1 && numeric <= 2147483647;
         const or: Prisma.OauthClientWhereInput[] = [
           { name: { contains: query, mode: 'insensitive' } },
           { user: { username: { contains: query, mode: 'insensitive' } } },
-          ...(Number.isInteger(numeric) ? [{ userId: numeric }] : []),
+          ...(numericIsUserId ? [{ userId: numeric }] : []),
         ];
         where = { AND: [{ OR: or }, excludeAppBlocks] };
       }

--- a/src/server/routers/oauth-client.router.ts
+++ b/src/server/routers/oauth-client.router.ts
@@ -1,6 +1,6 @@
 import { TRPCError } from '@trpc/server';
 import { v4 as uuidv4 } from 'uuid';
-import { protectedProcedure, publicProcedure, router } from '~/server/trpc';
+import { moderatorProcedure, protectedProcedure, publicProcedure, router } from '~/server/trpc';
 import { dbRead, dbWrite } from '~/server/db/client';
 import { generateKey, generateSecretHash } from '~/server/utils/key-generator';
 import { logOAuthEvent } from '~/server/oauth/audit-log';
@@ -11,10 +11,15 @@ import {
   deriveAllowedOriginsFromRedirectUris,
   getOauthClientByIdSchema,
   rotateOauthClientSecretSchema,
+  searchOauthClientsForModeratorSchema,
   updateOauthClientSchema,
 } from '~/server/schema/oauth-client.schema';
 import { TokenScope } from '~/shared/constants/token-scope.constants';
-import { isAppBlockOauthClientId } from '~/shared/constants/block-scope.constants';
+import {
+  APP_BLOCK_OAUTH_CLIENT_ID_PREFIX,
+  isAppBlockOauthClientId,
+} from '~/shared/constants/block-scope.constants';
+import type { Prisma } from '@prisma/client';
 
 /**
  * SECURITY (audit A1/A2): App-Blocks-provisioned OauthClients (`appblk-<slug>`)
@@ -78,6 +83,70 @@ export const oauthClientRouter = router({
       orderBy: { createdAt: 'desc' },
     });
   }),
+
+  // MODERATOR-ONLY global OAuth-client search (App-Blocks external-submit mod picker).
+  // An empty/absent query returns the CALLER's own clients (mirrors the non-mod
+  // `getAll` default); a non-empty query searches ALL clients by app name / author
+  // username / (numeric) author id. App-Block (`appblk-*`) clients are ALWAYS excluded
+  // at the DB level (never a hand-authored external-app target, and post-filtering
+  // would corrupt keyset pagination). The projection is SECRET-FREE — the client
+  // secret / hashed secret is NEVER selected.
+  searchForModerator: moderatorProcedure
+    .meta({ requiredScope: TokenScope.UserRead })
+    .input(searchOauthClientsForModeratorSchema)
+    .query(async ({ ctx, input }) => {
+      const query = input.query?.trim() ?? '';
+      const limit = input.limit;
+
+      // Always exclude App-Block-provisioned clients (clean `appblk-` prefix →
+      // `startsWith`; mirrors `isAppBlockOauthClientId`).
+      const excludeAppBlocks: Prisma.OauthClientWhereInput = {
+        NOT: { id: { startsWith: APP_BLOCK_OAUTH_CLIENT_ID_PREFIX } },
+      };
+
+      let where: Prisma.OauthClientWhereInput;
+      if (query.length === 0) {
+        // Default (empty search): the mod's OWN clients, same as the non-mod picker.
+        where = { AND: [{ userId: ctx.user.id }, excludeAppBlocks] };
+      } else {
+        // Global search: app name OR author username (both case-insensitive ILIKE) OR,
+        // when the query is an integer, the author's exact user id.
+        const numeric = Number(query);
+        const or: Prisma.OauthClientWhereInput[] = [
+          { name: { contains: query, mode: 'insensitive' } },
+          { user: { username: { contains: query, mode: 'insensitive' } } },
+          ...(Number.isInteger(numeric) ? [{ userId: numeric }] : []),
+        ];
+        where = { AND: [{ OR: or }, excludeAppBlocks] };
+      }
+
+      const rows = await dbRead.oauthClient.findMany({
+        where,
+        select: {
+          id: true,
+          name: true,
+          allowedScopes: true,
+          logoUrl: true,
+          isConfidential: true,
+          isVerified: true,
+          createdAt: true,
+          user: { select: { id: true, username: true } },
+        },
+        orderBy: [{ createdAt: 'desc' }, { id: 'asc' }],
+        // Fetch one extra to detect a further page (Prisma cursor is INCLUSIVE, so the
+        // popped extra becomes the first row of the next page — no overlap, no skip).
+        take: limit + 1,
+        ...(input.cursor ? { cursor: { id: input.cursor } } : {}),
+      });
+
+      let nextCursor: string | undefined;
+      if (rows.length > limit) {
+        const nextItem = rows.pop();
+        nextCursor = nextItem?.id;
+      }
+
+      return { items: rows, nextCursor };
+    }),
 
   // Register a new OAuth client
   create: protectedProcedure

--- a/src/server/schema/oauth-client.schema.ts
+++ b/src/server/schema/oauth-client.schema.ts
@@ -113,5 +113,20 @@ export function redirectUriMatches(registeredUris: string[], provided: string): 
 export const deleteOauthClientSchema = z.object({ id: z.string() });
 export type DeleteOauthClientInput = z.infer<typeof deleteOauthClientSchema>;
 
+/**
+ * Moderator-only global OAuth-client search (App-Blocks external-submit flow — mod
+ * client picker). An EMPTY/absent `query` returns the CALLER's own clients (matching
+ * the non-mod default); a non-empty `query` searches ALL non-App-Block clients by app
+ * name / author username / (numeric) author id. Keyset paginated by `createdAt desc`.
+ */
+export const searchOauthClientsForModeratorSchema = z.object({
+  query: z.string().trim().max(100).optional(),
+  limit: z.number().int().min(1).max(50).default(20),
+  cursor: z.string().optional(),
+});
+export type SearchOauthClientsForModeratorInput = z.infer<
+  typeof searchOauthClientsForModeratorSchema
+>;
+
 export const rotateOauthClientSecretSchema = z.object({ id: z.string() });
 export type RotateOauthClientSecretInput = z.infer<typeof rotateOauthClientSecretSchema>;


### PR DESCRIPTION
## Summary

External-app submit flow — OAuth step. Two changes:

1. **Mod-only global client search.** New `oauthClient.searchForModerator` (`moderatorProcedure` — non-mods forbidden): an **empty query returns the caller's own clients** (the fast default), a non-empty query matches **client name OR owner username** (case-insensitive `contains`) **OR exact numeric owner id** — one search box covers "find by app name" and "find by which dev owns it". App-Block (`appblk-*`) clients are **always excluded at the DB level** (`NOT: { id: { startsWith: <appblk prefix> } }`, mirroring `isAppBlockOauthClientId`). The projection is **secret-free** (`id, name, logoUrl, allowedScopes, isConfidential, isVerified, createdAt, user:{id, username}`), keyset-paginated. `oauthClient.getAll` (own-only) is unchanged.

2. **OAuth-step UI + create-client deeplink.** In `ExternalSubmitForm` (the external-app OAuth step):
   - **Moderators** get an async, debounced global-search picker backed by `searchForModerator`; empty search shows their own clients. A selected **foreign** client's `allowedScopes` flows into the existing `deriveScopesFromClient` (the selected client is pinned into the Select data so its label + scopes resolve even when it drops out of the current search results). Non-moderators keep the current own-clients dropdown, unchanged.
   - A **"Create an OAuth client" deeplink for everyone** (mods + regular devs): a persistent link below the input **and** a dropdown affordance, both → `/user/account` (the OAuth Apps section), opened in a **new tab** so the in-progress submission isn't lost.

Listing ownership stays with the submitter; scopes still derive from the picked client's `allowedScopes`. No schema/migration.

## Files changed
- `src/server/routers/oauth-client.router.ts` — `searchForModerator` proc
- `src/server/schema/oauth-client.schema.ts` — its input schema
- `src/server/routers/__tests__/oauth-client.router.searchForModerator.test.ts` — server tests (new)
- `src/components/Apps/ExternalSubmitForm.tsx` — mod search picker + foreign-client scope derivation + create deeplink
- `src/components/Apps/ExternalSubmitForm.browser.test.tsx` — component tests
- `src/components/Apps/__tests__/offsiteSubmitFormConfig.oauth-fields.test.ts` — config tests

## Test plan
- [x] `tsc --noEmit` — clean on all changed files (pre-existing unrelated `image.service.ts` implicit-any noise is a worktree Prisma-resolution artifact, not from this diff / not in a touched file).
- [x] `eslint` on changed source — no new errors.
- [x] Server unit tests (node project) — **39 passed** (`searchForModerator`: mod-gate/non-mod forbidden, empty-query→own-clients, match by name / owner-username / numeric owner-id, `appblk-*` exclusion, pagination, secret-free projection; + the offsite oauth-fields config tests).
- [ ] Browser/component tests (`ExternalSubmitForm.browser.test.tsx`) — **written but not executed** locally (the authoring sandbox couldn't provision Playwright's chromium); these are the report-only browser suite. CI pr-preview is authoritative. Coverage: mod sees search vs non-mod sees own-clients dropdown, foreign-client selection derives scopes, create deeplink present for both roles with `target="_blank"` → `/user/account`.

⚠️ Touches `src/components/Apps/ExternalSubmitForm.tsx`, which a concurrent PR (#3393) also edits in a different region (the asset step) — expect at most a trivial rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
