### PR TITLE
fix(prom): emit explicit 0 for challenge state gauges so healthy-zero is distinguishable from no-data

### DIFF
--- a/src/server/prom/__tests__/challenge.metrics.test.ts
+++ b/src/server/prom/__tests__/challenge.metrics.test.ts
@@ -342,3 +342,87 @@ describe('state gauges — collect() emits series from injected (mocked) cache',
     ).toBe(7);
   });
 });
+
+describe('state gauges — zero-emit so a healthy 0 is distinguishable from dead instrumentation', () => {
+  // NOTE: these assert on the emitted SERIES LIST, never via valueFor() — valueFor returns
+  // `?? 0` for a missing series, so it cannot tell "emitted 0" from "emitted nothing", which is
+  // the entire bug under test.
+  const ZERO_EMIT_GAUGES = [
+    'civitai_app_challenge_ingestion_pending',
+    'civitai_app_challenge_completing_stuck',
+    'civitai_app_challenge_operation_budget_used_ratio',
+  ] as const;
+
+  async function sourcePairs(name: string): Promise<[string, number][]> {
+    const values = await readMetric(name);
+    return values
+      .map((v) => [v.labels.source, v.value] as [string, number])
+      // Codepoint sort (NOT localeCompare — that is locale-dependent and orders 'unknown'
+      // before 'User', which would make this assertion machine-dependent).
+      .sort((a, b) => (a[0] < b[0] ? -1 : a[0] > b[0] ? 1 : 0));
+  }
+
+  it('emits an explicit 0 for every known source when the query returns no rows', async () => {
+    // Exactly the production steady state: healthy system, every GROUP BY returns zero rows.
+    __setChallengeGaugeCacheForTest({});
+
+    for (const name of ZERO_EMIT_GAUGES) {
+      expect(await sourcePairs(name), `${name} must emit a real 0 per source, not nothing`).toEqual([
+        ['Mod', 0],
+        ['System', 0],
+        ['User', 0],
+      ]);
+    }
+  });
+
+  it('query rows overlay the zeros; sources missing from the rows still emit 0', async () => {
+    __setChallengeGaugeCacheForTest({
+      ingestionPending: [{ source: 'User', count: 3 }],
+      completingStuck: [{ source: 'System', count: 1 }],
+      budgetRatio: [{ source: 'System', ratio: 0.25 }],
+    });
+
+    expect(await sourcePairs('civitai_app_challenge_ingestion_pending')).toEqual([
+      ['Mod', 0],
+      ['System', 0],
+      ['User', 3],
+    ]);
+    expect(await sourcePairs('civitai_app_challenge_completing_stuck')).toEqual([
+      ['Mod', 0],
+      ['System', 1],
+      ['User', 0],
+    ]);
+    expect(await sourcePairs('civitai_app_challenge_operation_budget_used_ratio')).toEqual([
+      ['Mod', 0],
+      ['System', 0.25],
+      ['User', 0],
+    ]);
+  });
+
+  it('an out-of-enum source from the DB is added alongside the zeros, not instead of them', async () => {
+    __setChallengeGaugeCacheForTest({ ingestionPending: [{ source: 'GARBAGE', count: 5 }] });
+
+    expect(await sourcePairs('civitai_app_challenge_ingestion_pending')).toEqual([
+      ['Mod', 0],
+      ['System', 0],
+      ['User', 0],
+      ['unknown', 5],
+    ]);
+  });
+
+  it('challenge_by_status stays SPARSE — no source×status zero-fill (deliberate, cardinality)', async () => {
+    __setChallengeGaugeCacheForTest({
+      byStatus: [{ source: 'User', status: 'Active', count: 4 }],
+    });
+
+    // 1 series, not the 15-series 3×5 cross-product. See the ZERO-EMIT comment in the module.
+    expect(await readMetric('civitai_app_challenge_by_status')).toHaveLength(1);
+  });
+
+  it('gauge collect() never throws even if the injected cache holds junk', async () => {
+    __setChallengeGaugeCacheForTest({
+      ingestionPending: [{ source: null as unknown as string, count: NaN }],
+    });
+    await expect(readMetric('civitai_app_challenge_ingestion_pending')).resolves.toBeDefined();
+  });
+});

--- a/src/server/prom/challenge.metrics.ts
+++ b/src/server/prom/challenge.metrics.ts
@@ -23,7 +23,10 @@ import { registerCounterWithLabels } from '@civitai/telemetry/client';
 // ---------------------------------------------------------------------------
 // Label normalization (enum-bound — never emit raw/free-text)
 // ---------------------------------------------------------------------------
-const SOURCES = new Set(['System', 'Mod', 'User']);
+// The `ChallengeSource` DB enum, in full. Also the zero-emit key set for the single-label state
+// gauges below — keep it and `normSource` sharing one array so the two can never drift.
+export const SOURCE_VALUES = ['System', 'Mod', 'User'] as const;
+const SOURCES = new Set<string>(SOURCE_VALUES);
 const BUZZ_TYPES = new Set(['green', 'yellow']);
 const SCAN_RESULTS = new Set(['scanned', 'blocked', 'error']);
 const STATUSES = new Set(['Scheduled', 'Active', 'Completing', 'Completed', 'Cancelled']);
@@ -403,6 +406,37 @@ function maybeRefreshChallengeGauges() {
   if (Date.now() - challengeGaugeFetchedAt > CHALLENGE_GAUGE_TTL_MS) void refreshChallengeGauges();
 }
 
+/**
+ * ZERO-EMIT — why the single-label gauges pre-seed every known source with 0.
+ *
+ * A `GROUP BY` returns NO ROW for a count of zero, so a gauge that only `.set()`s the returned rows
+ * emits NO SERIES while everything is healthy. That is indistinguishable from "the instrumentation
+ * died": every alert on such a gauge fails open, and a dashboard reading it over different windows
+ * reports different answers (absent over 1h, `1` over 12h) purely because the series only exists for
+ * the ~1min the count was non-zero.
+ *
+ * So: seed `0` for every `ChallengeSource` FIRST, then overlay the query rows (a real row wins).
+ * Applied to the three single-label gauges — `ingestion_pending`, `completing_stuck`,
+ * `operation_budget_used_ratio` — which are precisely the "should be zero" health signals where
+ * healthy-zero vs no-data is the distinction that matters.
+ *
+ * DELIBERATELY NOT applied to `challenge_by_status`: it is a descriptive inventory gauge, not an
+ * alert source, and zero-filling it means the full source×status cross-product — 15 series/pod
+ * instead of the ~7 actually populated, on the one gauge that is ALREADY this module's cardinality
+ * problem (these gauges run on every web pod behind the 45s memo; see the GATING note above). A
+ * dashboard for it aggregates with `sum()`, which handles an absent zero-count bucket correctly.
+ * Cost of the choice made here: 3 sources × 3 gauges = 9 series/pod. The cross-product option would
+ * have added 15 more on top of that, per pod.
+ *
+ * `unknown` is not pre-seeded — it only exists if the DB hands back a value outside the enum, and a
+ * permanent `unknown=0` on every pod would be pure noise.
+ */
+function zeroFillKnownSources(gauge: {
+  set(labels: Record<string, string>, value: number): void;
+}): void {
+  for (const source of SOURCE_VALUES) gauge.set({ source }, 0);
+}
+
 declare global {
   // eslint-disable-next-line no-var
   var challengeGaugesInitialized: boolean | undefined;
@@ -427,6 +461,7 @@ if (!globalThis.challengeGaugesInitialized) {
     collect() {
       maybeRefreshChallengeGauges();
       this.reset();
+      zeroFillKnownSources(this);
       for (const row of challengeGaugeCache.ingestionPending)
         this.set({ source: normSource(row.source) }, row.count);
     },
@@ -438,17 +473,30 @@ if (!globalThis.challengeGaugesInitialized) {
     collect() {
       maybeRefreshChallengeGauges();
       this.reset();
+      zeroFillKnownSources(this);
       for (const row of challengeGaugeCache.completingStuck)
         this.set({ source: normSource(row.source) }, row.count);
     },
   });
+  // 🔴 READ BEFORE ALERTING ON THIS GAUGE. `operationBudget` is `Int @default(0)` and NOTHING in
+  // the product sets it today — every Challenge row carries budget 0, while `operationSpent` is
+  // genuinely non-zero. The query's `NULLIF(SUM("operationBudget"), 0)` therefore yields NULL, the
+  // row is dropped, and before the zero-emit below this gauge produced no series at all. That was
+  // never an emit bug — it is faithfully reporting "there is no budget to be a ratio of".
+  //
+  // Consequence: a `0` here means "no budget configured", NOT "budget healthy". A cost-control
+  // alert of the shape `ratio > 0.8` can never fire while budgets are unset, so it would fail open
+  // exactly like the missing series did. Gate any such alert on budgets actually being set (or
+  // alert on absolute `challenge_operation_spent_buzz_total` instead) until the product writes a
+  // non-zero `operationBudget`.
   new client.Gauge({
     name: 'civitai_app_challenge_operation_budget_used_ratio',
-    help: 'SUM(operationSpent)/SUM(operationBudget) over Active+Completing challenges, by source',
+    help: 'SUM(operationSpent)/SUM(operationBudget) over Active+Completing challenges, by source (0 also means "no operationBudget set" — see the note in challenge.metrics.ts)',
     labelNames: ['source'],
     collect() {
       maybeRefreshChallengeGauges();
       this.reset();
+      zeroFillKnownSources(this);
       for (const row of challengeGaugeCache.budgetRatio)
         this.set({ source: normSource(row.source) }, row.ratio);
     },


### PR DESCRIPTION
Follow-up to #3345. Fixes two instrumentation defects in the Challenge Prometheus metrics found while building dashboards/alerts on them.

## Defect 1 — the state gauges emitted no series at zero

The four state gauges are populated from an async `collect()` that runs a `GROUP BY` behind a 45s memo, and they only `.set()` the rows the query returns. **A count of zero produces no series at all.**

Over 3 days of production this made them unusable:

| gauge | observed |
|---|---|
| `challenge_ingestion_pending` | 19 samples total, every value `1`, each lasting ~1 min — nothing in between |
| `challenge_completing_stuck` | exactly 3 samples, one per day, value `1` |
| `challenge_operation_budget_used_ratio` | **zero samples, ever** (see Defect 2) |

Consequences:
- The same dashboard panel answers `0` over 1h, `0` over 6h and `1` over 12h — not because anything changed, but because the series only exists during the minute the count is non-zero.
- **Every alert on these fails open.** "Healthy zero" and "the instrumentation died" are byte-identical to Prometheus.

**Fix:** `collect()` now seeds an explicit `0` for every `ChallengeSource` *before* overlaying the query rows, so a real row still wins and the series is always present.

### Design decision: which gauges get zero-filled

**Zero-filled** — `challenge_ingestion_pending`, `challenge_completing_stuck`, `challenge_operation_budget_used_ratio`. These are the "should be zero" *health* signals; they are exactly the ones we want to alert on, and they are single-label (`source`), so the fill is 3 sources × 3 gauges = **9 series per pod**.

**Left sparse** — `challenge_by_status`. Zero-filling it means the full `source`×`status` cross-product: **15 series/pod instead of the ~7 actually populated today**, on the one gauge that is already this module's cardinality concern (these gauges run on every web pod behind the 45s memo — see the GATING note in the module). It is also a *descriptive inventory* gauge rather than an alert source: dashboards aggregate it with `sum()`, which handles an absent zero-count bucket correctly, and its populated buckets are stable rather than flapping in and out of existence the way the health gauges do.

The cross-product would be strictly more correct for alerting, so this is a real trade-off, not a free win — it is documented in a comment in the module so the next person can reverse it deliberately.

`unknown` is not pre-seeded: it only appears if the DB hands back a value outside the enum, and a permanent `unknown=0` on every pod is pure noise.

## Defect 2 — why `challenge_operation_budget_used_ratio` has never emitted a series

**Root cause: the data, not the code.** Investigated against production before touching anything.

`operationBudget` is `Int @default(0)` and **nothing in the product ever sets it to a non-zero value**. A live aggregate over the whole `Challenge` table:

```
total_rows | null_budget | nonzero_budget | max_budget | rows_with_spend
       237 |           0 |              0 |          0 |              29
```

Every row carries budget `0`, while `operationSpent` is genuinely non-zero (29 rows have spend; the Active/Completing rows the gauge covers sum to ~1.3k spent against 0 budget). So `NULLIF(SUM("operationBudget"), 0)` evaluates to `NULL`, the `.filter((r) => r.ratio != null)` drops the row, and no series is emitted.

**The query and the emit are correct.** This is hypothesis (a) — there is no bug to fix here, and the zero-emit from Defect 1 resolves the missing-series symptom.

🔴 **But it does not make the metric usable for cost control, and that is the important part.** A `0` on this gauge now means *"no budget is configured"*, not *"budget is healthy"*. An alert of the shape `ratio > 0.8` cannot fire while budgets are unset — it fails open in exactly the same way the missing series did. Until the product actually writes a non-zero `operationBudget`, a cost-control alert should either gate on budgets being set or watch absolute `challenge_operation_spent_buzz_total` instead. Called out inline in the module and in the metric's `help` string so it is visible at query time.

## Sanity check: `challenge_created_total` — correct as-is

Only 3 creations counted since the 07-24 deploy while the status gauge shows 22 `User` challenges. Verified this is expected, not a missed emit:

- `upsertUserChallenge` is genuinely the **only user-facing creation path** (`challenge.upsertUserChallenge`, `protectedProcedure`). The other two creators are the moderator `challenge.upsert` (`moderatorProcedure`) and the System daily-challenge job — neither is user-created, and the counter's help text scopes it to user-created challenges.
- The emit is not missing a branch: the edit branch returns before it, and the only other `return created` in the create branch is the inner `$transaction` callback's, not the function's. Every successful create reaches the emit.
- 3 post-deploy creations vs 22 all-history `User` rows is consistent — the counter starts at deploy, the gauge reflects all history.

Minor asymmetry worth knowing (not changed here, it would alter the metric's meaning): `source` is normalized to admit `System`/`Mod`, but only `User` is ever emitted, so grouping this counter by `source` will only ever show `User`.

## Known follow-up (not in this PR)

These gauges run on **every** web pod behind the 45s memo, so `challenge_by_status` accumulates series proportional to the size of the app fleet — to describe a ~237-row table. A leader/pod-role gate is the real fix; it was already flagged as a deferred follow-up on #3345 and there is still no clean pod-role signal to gate on. The conservative choice in Defect 1 is partly *because* of this: it adds 9 series/pod rather than 24.

## Tests

Extends `src/server/prom/__tests__/challenge.metrics.test.ts` (23 tests, all passing).

The new assertions read the **emitted series list**, never the suite's `valueFor()` helper — `valueFor` returns `?? 0` for a missing series and therefore cannot distinguish "emitted 0" from "emitted nothing", which is the entire bug under test.

**Mutation-checked.** With the three `zeroFillKnownSources(this)` calls removed, 3 of the new tests fail with `expected [] to deeply equal [ [ 'Mod', +0 ], … ]`; restored, all 23 pass.

`NODE_OPTIONS=--max_old_space_size=8192 npx tsc --noEmit` → **exit 0**.

The module's never-throw invariant is preserved: the zero-fill is synchronous, introduces no `await`, and a test asserts `collect()` still survives junk in the cache.
