### PR TITLE
fix(db): create empty migrations next to the schema

### DIFF
--- a/scripts/create-empty-migration.mjs
+++ b/scripts/create-empty-migration.mjs
@@ -1,5 +1,19 @@
-import { mkdir, writeFile } from 'fs/promises';
-import { join } from 'path';
+import { mkdir, readFile, writeFile } from 'fs/promises';
+import { dirname, join, relative, resolve } from 'path';
+import { fileURLToPath } from 'url';
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+
+// Migrations live next to the schema, which moved into packages/ with the
+// monorepo. Deriving the directory from package.json's `prisma.schema` keeps it
+// correct if the schema moves again, and anchoring on the script's own location
+// means the result doesn't depend on the cwd it was invoked from.
+const migrationsDir = async () => {
+  const pkg = JSON.parse(await readFile(join(repoRoot, 'package.json'), 'utf8'));
+  const schema = pkg.prisma?.schema;
+  if (!schema) throw new Error('package.json is missing a `prisma.schema` path');
+  return join(repoRoot, dirname(schema), 'migrations');
+};
 
 // Get migration name from command line args
 const migrationName = process.argv[2];
@@ -35,9 +49,10 @@ const getTimestamp = () => {
 const timestamp = getTimestamp();
 const snakeCaseName = toSnakeCase(migrationName);
 const folderName = `${timestamp}_${snakeCaseName}`;
-const migrationPath = join('prisma', 'migrations', folderName);
 
 try {
+  const migrationPath = join(await migrationsDir(), folderName);
+
   // Create migration folder
   await mkdir(migrationPath, { recursive: true });
 
@@ -45,7 +60,7 @@ try {
   await writeFile(join(migrationPath, 'migration.sql'), '-- Add migration here\n');
 
   console.log(`✓ Created empty migration: ${folderName}`);
-  console.log(`  Location: ${migrationPath}/migration.sql`);
+  console.log(`  Location: ${relative(repoRoot, migrationPath)}/migration.sql`);
 } catch (error) {
   console.error('Error creating migration:', error.message);
   process.exit(1);


### PR DESCRIPTION
Fixes #3397.

`scripts/create-empty-migration.mjs` built the target path as a **cwd-relative** `prisma/migrations`, which is the pre-monorepo location. The schema and the canonical migrations directory (the only one with `migration_lock.toml`) now live in `packages/civitai-db-schema/prisma/`, so `pnpm run db:migrate:empty` was dropping new migrations into a directory Prisma no longer reads — about a third of everything added since 2026-05-22.

Now derived from `package.json`'s `prisma.schema` and anchored on the script's own location, so it follows the schema if that moves again and no longer depends on where it was invoked from.

Verified from two working directories:

```
$ node scripts/create-empty-migration.mjs "probe from root"
  Location: packages/civitai-db-schema/prisma/migrations/2026…_probe_from_root/migration.sql

$ cd src && node ../scripts/create-empty-migration.mjs "probe from subdir"
  Location: packages/civitai-db-schema/prisma/migrations/2026…_probe_from_subdir/migration.sql
```

(Both probe directories removed before committing.)

It also fails loudly now if `prisma.schema` is ever missing from `package.json`, rather than silently writing somewhere unexpected.

The ~67 migrations already sitting in the root `prisma/migrations/` are untouched — whether to consolidate them or keep them as history felt like a separate call.
