### PR TITLE
feat(app-blocks): mod-opt-in 'run for real' review preview (#2831)

### DIFF
--- a/packages/civitai-redis/src/client.ts
+++ b/packages/civitai-redis/src/client.ts
@@ -1728,6 +1728,20 @@ export const REDIS_SYS_KEYS = {
      * absent for them (synthetic appBlockId), matching the txt2img caps.
      */
     CUSTOM_COMFY_SETTLE: 'system:blocks:custom-comfy-settle',
+    /**
+     * MOD REVIEW SANDBOX "run for real" (#2831) — AGGREGATE Buzz-spend ceiling
+     * for a moderator opting IN to run an UNAPPROVED review app for real against
+     * their OWN account. Keyed `${REVIEW_RUN_FOR_REAL_BUZZ_CAP}:<modUserId>:<publishRequestId>`
+     * so ALL run-for-real generations by one mod against one pending request
+     * accumulate against a SINGLE tight session ceiling (REVIEW_RUN_FOR_REAL_BUZZ_CAP)
+     * — a per-call budget alone can't bound a hostile app looping sub-budget calls
+     * (blocks.router.ts §aggregate-cap). The key intentionally binds to
+     * (mod, publishRequestId) NOT the token jti, so re-minting/re-confirming the
+     * consent CANNOT reset the ceiling within the window. Same atomic INCRBY
+     * reserve-and-refund + hard-TTL EX shape as the sibling BLOCKS caps, on
+     * `sysRedis`.
+     */
+    REVIEW_RUN_FOR_REAL_BUZZ_CAP: 'system:blocks:review-run-for-real-buzz-cap',
   },
   DOWNLOAD: {
     LIMITS: 'download:limits',

--- a/src/components/AppBlocks/PageBlockHost.tsx
+++ b/src/components/AppBlocks/PageBlockHost.tsx
@@ -196,6 +196,19 @@ export interface PageBlockHostProps {
    * mis-scoped — no single layer is load-bearing.
    */
   reviewMode?: boolean;
+  /**
+   * MOD REVIEW SANDBOX "run for real" (#2831). Meaningful ONLY when `reviewMode`
+   * is also true. Default false → the render-only sandbox (every side-effect
+   * NACKs, unchanged). When true, the mod has EXPLICITLY opted in (consent-gated)
+   * to run the unapproved app FOR REAL against their OWN account: the SELF-BOUND /
+   * money-IN / own-Buzz side-effect handlers (submit / estimate / poll / cancel /
+   * app-workflows / buzz balance+transactions+accounts+comp / per-user storage /
+   * buy-buzz) run the REAL mutation because the token now carries the scopes +
+   * budget. CROSS-USER shared-datastore WRITES and money-OUT stay NACKed even in
+   * run-for-real (they are never granted). The persistent banner is rendered by
+   * the preview surface, not here.
+   */
+  reviewRunForReal?: boolean;
 }
 
 export function PageBlockHost({
@@ -221,8 +234,16 @@ export function PageBlockHost({
   onConsentGranted,
   onRetryToken,
   reviewMode = false,
+  reviewRunForReal = false,
 }: PageBlockHostProps) {
   const router = useRouter();
+  // MOD REVIEW SANDBOX (#2831): the side-effect NACK gate. Side-effecting handlers
+  // NACK when in review mode UNLESS the mod opted in to run-for-real (in which case
+  // the token carries the scopes + budget and the REAL mutation runs). Handlers
+  // that must ALWAYS refuse in review (cross-user shared WRITES, money-OUT) keep
+  // gating on `reviewMode` directly, NOT this. Default (`reviewMode:false`) →
+  // reviewNack is false → prod path is byte-identical.
+  const reviewNack = reviewMode && !reviewRunForReal;
   const iframeRef = useRef<HTMLIFrameElement | null>(null);
   const [status, setStatus] = useState<Status>('loading');
   // Mirror of `status` for the Retry handler to read the prior terminal state
@@ -705,7 +726,7 @@ export function PageBlockHost({
     const off = onMessage<{ requestId?: unknown; body?: unknown } | undefined>(
       'SUBMIT_WORKFLOW',
       async (raw) => {
-        if (reviewMode) {
+        if (reviewNack) {
           // Real Buzz spend — NACK with the failure snapshot the block awaits so
           // it fails fast (never a hang) and never reaches submitWorkflowMutation.
           if (raw && typeof raw.requestId === 'string') {
@@ -731,14 +752,14 @@ export function PageBlockHost({
       }
     );
     return off;
-  }, [onMessage, send, token, submitWorkflowMutation, reviewMode]);
+  }, [onMessage, send, token, submitWorkflowMutation, reviewNack]);
 
   // ESTIMATE_WORKFLOW → blocks.estimateWorkflow → ESTIMATE_RESULT.
   useEffect(() => {
     const off = onMessage<{ requestId?: unknown; body?: unknown } | undefined>(
       'ESTIMATE_WORKFLOW',
       async (raw) => {
-        if (reviewMode) {
+        if (reviewNack) {
           if (raw && typeof raw.requestId === 'string') {
             send('ESTIMATE_RESULT', {
               requestId: raw.requestId,
@@ -761,14 +782,14 @@ export function PageBlockHost({
       }
     );
     return off;
-  }, [onMessage, send, token, estimateWorkflowMutation, reviewMode]);
+  }, [onMessage, send, token, estimateWorkflowMutation, reviewNack]);
 
   // POLL_WORKFLOW → blocks.pollWorkflow → WORKFLOW_STATUS.
   useEffect(() => {
     const off = onMessage<{ requestId?: unknown; workflowId?: unknown } | undefined>(
       'POLL_WORKFLOW',
       async (raw) => {
-        if (reviewMode) {
+        if (reviewNack) {
           if (raw && typeof raw.requestId === 'string') {
             send('WORKFLOW_STATUS', {
               requestId: raw.requestId,
@@ -799,7 +820,7 @@ export function PageBlockHost({
       }
     );
     return off;
-  }, [onMessage, send, token, pollWorkflowMutation, reviewMode]);
+  }, [onMessage, send, token, pollWorkflowMutation, reviewNack]);
 
   // CANCEL_WORKFLOW → blocks.cancelWorkflow → WORKFLOW_CANCELED. Ownership is
   // enforced server-side by the viewer's orchestrator token.
@@ -807,7 +828,7 @@ export function PageBlockHost({
     const off = onMessage<{ requestId?: unknown; workflowId?: unknown } | undefined>(
       'CANCEL_WORKFLOW',
       async (raw) => {
-        if (reviewMode) {
+        if (reviewNack) {
           if (raw && typeof raw.requestId === 'string') {
             send('WORKFLOW_CANCELED', {
               requestId: raw.requestId,
@@ -838,7 +859,7 @@ export function PageBlockHost({
       }
     );
     return off;
-  }, [onMessage, send, token, cancelWorkflowMutation, reviewMode]);
+  }, [onMessage, send, token, cancelWorkflowMutation, reviewNack]);
 
   // QUERY_APP_WORKFLOWS → blocks.queryAppWorkflows → APP_WORKFLOWS_RESULT. The
   // app's OWN tag-scoped generation subqueue (host page token + SERVER-forced
@@ -853,7 +874,7 @@ export function PageBlockHost({
       async (raw) => {
         if (!raw || typeof raw.requestId !== 'string') return;
         const requestId = raw.requestId;
-        if (reviewMode) {
+        if (reviewNack) {
           // The app's generation subqueue read — NACK (workflow family, and the
           // synthetic review appId has no queue anyway). Error-shape reply, no hang.
           send('APP_WORKFLOWS_RESULT', { requestId, error: REVIEW_NACK_MESSAGE });
@@ -880,7 +901,7 @@ export function PageBlockHost({
       }
     );
     return off;
-  }, [onMessage, send, token, queryAppWorkflowsMutation, reviewMode]);
+  }, [onMessage, send, token, queryAppWorkflowsMutation, reviewNack]);
 
   // CANCEL_APP_WORKFLOW → blocks.cancelAppWorkflow → CANCEL_APP_WORKFLOW_RESULT.
   // FAIL-CLOSED server-side (ownership + app-tag guard — the orchestrator by-id
@@ -902,7 +923,7 @@ export function PageBlockHost({
           return;
         }
         const requestId = raw.requestId;
-        if (reviewMode) {
+        if (reviewNack) {
           send('CANCEL_APP_WORKFLOW_RESULT', { requestId, error: REVIEW_NACK_MESSAGE });
           return;
         }
@@ -925,7 +946,7 @@ export function PageBlockHost({
       }
     );
     return off;
-  }, [onMessage, send, token, cancelAppWorkflowMutation, reviewMode]);
+  }, [onMessage, send, token, cancelAppWorkflowMutation, reviewNack]);
 
   // PUBLISH_GENERATION_OUTPUTS → blocks.publishGenerationOutputs → PUBLISH_RESULT.
   // Turn the app's OWN workflow outputs into bare, real-scanned public images.
@@ -1041,7 +1062,7 @@ export function PageBlockHost({
       async (raw) => {
         if (!raw || typeof raw.requestId !== 'string') return;
         const requestId = raw.requestId;
-        if (reviewMode) {
+        if (reviewNack) {
           // Private financial read — NACK (the review token has no buzz:read:self).
           send('BUZZ_BALANCE_RESULT', { requestId, error: REVIEW_NACK_MESSAGE });
           return;
@@ -1062,7 +1083,7 @@ export function PageBlockHost({
       }
     );
     return off;
-  }, [onMessage, send, token, getMyBuzzBalanceMutation, reviewMode]);
+  }, [onMessage, send, token, getMyBuzzBalanceMutation, reviewNack]);
 
   // GET_BUZZ_TRANSACTIONS → blocks.getMyBuzzTransactions → BUZZ_TRANSACTIONS_RESULT.
   // The Buzz-dashboard ledger read. Host-MEDIATED (the iframe never holds the
@@ -1076,7 +1097,7 @@ export function PageBlockHost({
       async (raw) => {
         if (!raw || typeof raw.requestId !== 'string') return;
         const requestId = raw.requestId;
-        if (reviewMode) {
+        if (reviewNack) {
           send('BUZZ_TRANSACTIONS_RESULT', { requestId, error: REVIEW_NACK_MESSAGE });
           return;
         }
@@ -1104,7 +1125,7 @@ export function PageBlockHost({
       }
     );
     return off;
-  }, [onMessage, send, token, getMyBuzzTransactionsMutation, reviewMode]);
+  }, [onMessage, send, token, getMyBuzzTransactionsMutation, reviewNack]);
 
   // GET_BUZZ_ACCOUNTS → blocks.getMyBuzzAccounts → BUZZ_ACCOUNTS_RESULT. All-pool
   // balances (spendable + creator payout pools). Same host-mediated + consent +
@@ -1115,7 +1136,7 @@ export function PageBlockHost({
       async (raw) => {
         if (!raw || typeof raw.requestId !== 'string') return;
         const requestId = raw.requestId;
-        if (reviewMode) {
+        if (reviewNack) {
           send('BUZZ_ACCOUNTS_RESULT', { requestId, error: REVIEW_NACK_MESSAGE });
           return;
         }
@@ -1135,7 +1156,7 @@ export function PageBlockHost({
       }
     );
     return off;
-  }, [onMessage, send, token, getMyBuzzAccountsMutation, reviewMode]);
+  }, [onMessage, send, token, getMyBuzzAccountsMutation, reviewNack]);
 
   // GET_DAILY_COMPENSATION → blocks.getMyDailyCompensation → DAILY_COMPENSATION_RESULT.
   // Per-modelVersion generation earnings for the month of `date`. Same contract.
@@ -1145,7 +1166,7 @@ export function PageBlockHost({
       async (raw) => {
         if (!raw || typeof raw.requestId !== 'string') return;
         const requestId = raw.requestId;
-        if (reviewMode) {
+        if (reviewNack) {
           // Private per-model earnings — NACK (buzz-read family; no scope granted).
           send('DAILY_COMPENSATION_RESULT', { requestId, error: REVIEW_NACK_MESSAGE });
           return;
@@ -1171,7 +1192,7 @@ export function PageBlockHost({
       }
     );
     return off;
-  }, [onMessage, send, token, getMyDailyCompensationMutation, reviewMode]);
+  }, [onMessage, send, token, getMyDailyCompensationMutation, reviewNack]);
 
   // GET_VIEWER → blocks.getMyViewer → VIEWER_RESULT. The block's "who am I" read
   // that backs the SDK `useViewer()` hook — the host-mediated successor to the
@@ -1228,7 +1249,7 @@ export function PageBlockHost({
     const off = onMessage<{ requestId?: unknown; suggestedAmount?: unknown } | undefined>(
       'OPEN_BUZZ_PURCHASE',
       (raw) => {
-        if (reviewMode) {
+        if (reviewNack) {
           // Real-money top-up — never summon the Buy-Buzz modal at the mod. Reply
           // the not-purchased result the block awaits (fail-fast, no hang).
           if (raw && typeof raw.requestId === 'string') {
@@ -1286,7 +1307,7 @@ export function PageBlockHost({
       }
     );
     return off;
-  }, [onMessage, send, status, appId, appBlockId, blockInstanceId, reviewMode]);
+  }, [onMessage, send, status, appId, appBlockId, blockInstanceId, reviewNack]);
 
   // ── Sign-in bridge: REQUEST_SIGN_IN (anonymous conversion) ─────────────────
   //
@@ -1347,7 +1368,7 @@ export function PageBlockHost({
     const off = onMessage<{ requestId?: unknown; key?: unknown } | undefined>(
       'APP_STORAGE_GET',
       async (raw) => {
-        if (reviewMode) {
+        if (reviewNack) {
           // Per-user App Storage — NACK (the synthetic review appId has no storage
           // namespace, and the token carries no apps:storage scope). Error-shape.
           if (raw && typeof raw.requestId === 'string') {
@@ -1378,14 +1399,14 @@ export function PageBlockHost({
       }
     );
     return off;
-  }, [onMessage, send, token, trpcUtils, reviewMode]);
+  }, [onMessage, send, token, trpcUtils, reviewNack]);
 
   // APP_STORAGE_SET → apps.storage.set → APP_STORAGE_SET_RESULT.
   useEffect(() => {
     const off = onMessage<{ requestId?: unknown; key?: unknown; value?: unknown } | undefined>(
       'APP_STORAGE_SET',
       async (raw) => {
-        if (reviewMode) {
+        if (reviewNack) {
           if (raw && typeof raw.requestId === 'string') {
             send('APP_STORAGE_SET_RESULT', {
               requestId: raw.requestId,
@@ -1419,14 +1440,14 @@ export function PageBlockHost({
       }
     );
     return off;
-  }, [onMessage, send, token, storageSetMutation, reviewMode]);
+  }, [onMessage, send, token, storageSetMutation, reviewNack]);
 
   // APP_STORAGE_DELETE → apps.storage.delete → APP_STORAGE_DELETE_RESULT.
   useEffect(() => {
     const off = onMessage<{ requestId?: unknown; key?: unknown } | undefined>(
       'APP_STORAGE_DELETE',
       async (raw) => {
-        if (reviewMode) {
+        if (reviewNack) {
           if (raw && typeof raw.requestId === 'string') {
             send('APP_STORAGE_DELETE_RESULT', {
               requestId: raw.requestId,
@@ -1461,7 +1482,7 @@ export function PageBlockHost({
       }
     );
     return off;
-  }, [onMessage, send, token, storageDeleteMutation, reviewMode]);
+  }, [onMessage, send, token, storageDeleteMutation, reviewNack]);
 
   // APP_STORAGE_LIST → apps.storage.list → APP_STORAGE_LIST_RESULT.
   useEffect(() => {
@@ -1474,7 +1495,7 @@ export function PageBlockHost({
         }
       | undefined
     >('APP_STORAGE_LIST', async (raw) => {
-      if (reviewMode) {
+      if (reviewNack) {
         if (raw && typeof raw.requestId === 'string') {
           send('APP_STORAGE_LIST_RESULT', {
             requestId: raw.requestId,
@@ -1516,14 +1537,14 @@ export function PageBlockHost({
       }
     });
     return off;
-  }, [onMessage, send, token, trpcUtils, reviewMode]);
+  }, [onMessage, send, token, trpcUtils, reviewNack]);
 
   // APP_STORAGE_QUOTA → apps.storage.getQuota → APP_STORAGE_QUOTA_RESULT.
   useEffect(() => {
     const off = onMessage<{ requestId?: unknown } | undefined>(
       'APP_STORAGE_QUOTA',
       async (raw) => {
-        if (reviewMode) {
+        if (reviewNack) {
           if (raw && typeof raw.requestId === 'string') {
             send('APP_STORAGE_QUOTA_RESULT', {
               requestId: raw.requestId,
@@ -1560,7 +1581,7 @@ export function PageBlockHost({
       }
     );
     return off;
-  }, [onMessage, send, token, trpcUtils, reviewMode]);
+  }, [onMessage, send, token, trpcUtils, reviewNack]);
 
   // ── App Blocks SHARED (cross-user / app-global) storage bridge (Phase 2b) ──
   //
@@ -1687,7 +1708,10 @@ export function PageBlockHost({
       'SHARED_APPEND',
       async (raw) => {
         if (reviewMode) {
-          // Cross-user shared datastore WRITE — NACK (shared reads stay live below).
+          // Cross-user shared datastore WRITE — NACK even in run-for-real: cross-user
+          // writes are NEVER granted (the run-for-real allowlist withholds
+          // apps:storage:shared:write), and this host NACK is defense-in-depth on top
+          // of the server resolveSharedContext 403. Shared READS stay live below.
           if (raw && typeof raw.requestId === 'string') {
             send('SHARED_APPEND_RESULT', { requestId: raw.requestId, error: REVIEW_NACK_MESSAGE });
           }
@@ -1730,7 +1754,9 @@ export function PageBlockHost({
       'SHARED_UPDATE',
       async (raw) => {
         if (reviewMode) {
-          // Reply MUST carry ok:false or the SDK drops it (→ hang). See handler doc.
+          // Cross-user shared datastore WRITE (author-scoped edit) — NACK even in
+          // run-for-real (never a cross-user write). Reply MUST carry ok:false or the
+          // SDK drops it (→ hang). See handler doc.
           if (raw && typeof raw.requestId === 'string') {
             send('SHARED_UPDATE_RESULT', {
               requestId: raw.requestId,
@@ -1773,6 +1799,7 @@ export function PageBlockHost({
       'SHARED_VOTE',
       async (raw) => {
         if (reviewMode) {
+          // Cross-user shared datastore WRITE (vote) — NACK even in run-for-real.
           if (raw && typeof raw.requestId === 'string') {
             send('SHARED_VOTE_RESULT', { requestId: raw.requestId, error: REVIEW_NACK_MESSAGE });
           }
@@ -1798,6 +1825,7 @@ export function PageBlockHost({
       'SHARED_UNVOTE',
       async (raw) => {
         if (reviewMode) {
+          // Cross-user shared datastore WRITE (unvote) — NACK even in run-for-real.
           if (raw && typeof raw.requestId === 'string') {
             send('SHARED_UNVOTE_RESULT', { requestId: raw.requestId, error: REVIEW_NACK_MESSAGE });
           }
@@ -1823,6 +1851,7 @@ export function PageBlockHost({
       'SHARED_WITHDRAW',
       async (raw) => {
         if (reviewMode) {
+          // Cross-user shared datastore WRITE (withdraw) — NACK even in run-for-real.
           if (raw && typeof raw.requestId === 'string') {
             send('SHARED_WITHDRAW_RESULT', { requestId: raw.requestId, error: REVIEW_NACK_MESSAGE });
           }

--- a/src/components/AppBlocks/PageBlockHost.tsx
+++ b/src/components/AppBlocks/PageBlockHost.tsx
@@ -1369,8 +1369,9 @@ export function PageBlockHost({
       'APP_STORAGE_GET',
       async (raw) => {
         if (reviewNack) {
-          // Per-user App Storage — NACK (the synthetic review appId has no storage
-          // namespace, and the token carries no apps:storage scope). Error-shape.
+          // Per-user App Storage — NACK in render-only review. Under run-for-real
+          // this runs the REAL op (the token carries apps:storage:* and the server
+          // resolves a disposable per-preview namespace). Error-shape.
           if (raw && typeof raw.requestId === 'string') {
             send('APP_STORAGE_GET_RESULT', {
               requestId: raw.requestId,

--- a/src/components/AppBlocks/PageBlockHostReviewMode.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostReviewMode.browser.test.tsx
@@ -283,6 +283,72 @@ describe('PageBlockHost reviewMode — side-effecting handlers fail-fast NACK, n
   });
 });
 
+describe('PageBlockHost reviewMode + reviewRunForReal — side-effects run the REAL mutation', () => {
+  // The mod opted in (consent-gated) to run the unapproved app for real against
+  // their OWN account. The self-bound / money-in / own-Buzz / per-user-storage
+  // handlers now reach the mutation (the token carries the scopes + budget) —
+  // proving reviewRunForReal flips the NACK. CROSS-USER writes stay NACKed below.
+  test('SUBMIT_WORKFLOW reaches submitWorkflow (no NACK)', async () => {
+    renderWithProviders(
+      <PageBlockHost {...baseProps} reviewMode reviewRunForReal onConsentGranted={vi.fn()} />
+    );
+    await driveToReady();
+
+    postFromBlock('SUBMIT_WORKFLOW', { requestId: 'rfr1', body: { ok: true } });
+
+    await vi.waitFor(() => expect(mocks.submit).toHaveBeenCalledTimes(1));
+  });
+
+  test('GET_BUZZ_BALANCE reaches getMyBuzzBalance (own, self-bound)', async () => {
+    renderWithProviders(
+      <PageBlockHost {...baseProps} reviewMode reviewRunForReal onConsentGranted={vi.fn()} />
+    );
+    await driveToReady();
+
+    postFromBlock('GET_BUZZ_BALANCE', { requestId: 'rfrb1' });
+
+    await vi.waitFor(() => expect(mocks.buzzBalance).toHaveBeenCalledTimes(1));
+  });
+
+  test('APP_STORAGE_SET reaches storage.set (per-user, own)', async () => {
+    renderWithProviders(
+      <PageBlockHost {...baseProps} reviewMode reviewRunForReal onConsentGranted={vi.fn()} />
+    );
+    await driveToReady();
+
+    postFromBlock('APP_STORAGE_SET', { requestId: 'rfrs1', key: 'k', value: 'v' });
+
+    await vi.waitFor(() => expect(mocks.storageSet).toHaveBeenCalledTimes(1));
+  });
+
+  test('SHARED_APPEND (cross-user write) STILL NACKs even in run-for-real, shared.append NOT called', async () => {
+    renderWithProviders(
+      <PageBlockHost {...baseProps} reviewMode reviewRunForReal onConsentGranted={vi.fn()} />
+    );
+    await driveToReady();
+    const l = listenForReply();
+
+    postFromBlock('SHARED_APPEND', { requestId: 'rfrsa1', value: { title: 'x' } });
+
+    await vi.waitFor(() => expect(l.last('SHARED_APPEND_RESULT')).toBeTruthy());
+    const reply = l.last('SHARED_APPEND_RESULT')!.payload as { requestId: string; error: string };
+    expect(reply.error).toBe('not available in review preview');
+    expect(mocks.sharedAppend).not.toHaveBeenCalled();
+    l.stop();
+  });
+
+  test('render-safe GET_VIEWER still works in run-for-real (read stays live in BOTH sub-modes)', async () => {
+    renderWithProviders(
+      <PageBlockHost {...baseProps} reviewMode reviewRunForReal onConsentGranted={vi.fn()} />
+    );
+    await driveToReady();
+
+    postFromBlock('GET_VIEWER', { requestId: 'rfrv1' });
+
+    await vi.waitFor(() => expect(mocks.viewer).toHaveBeenCalledTimes(1));
+  });
+});
+
 describe('PageBlockHost reviewMode — the NON-reviewMode (prod) path is unchanged', () => {
   test('without reviewMode, SUBMIT_WORKFLOW reaches submitWorkflow', async () => {
     renderWithProviders(<PageBlockHost {...baseProps} onConsentGranted={vi.fn()} />);

--- a/src/components/AppBlocks/PageBlockHostReviewMode.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostReviewMode.browser.test.tsx
@@ -52,6 +52,11 @@ vi.mock('~/utils/trpc', () => ({
       cancelWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
       queryAppWorkflows: { useMutation: () => ({ mutateAsync: vi.fn() }) },
       cancelAppWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      // PageBlockHost also wires these at render (image-scan republish path);
+      // stub so the mount succeeds. Missing → `trpc.blocks.<x>` is undefined →
+      // `.useMutation()` throws at render, crashing the whole file's setup.
+      publishGenerationOutputs: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      getImagesByIds: { useMutation: () => ({ mutateAsync: vi.fn() }) },
     },
     apps: {
       shared: {

--- a/src/components/Apps/ReviewBlockPreviewHost.browser.test.tsx
+++ b/src/components/Apps/ReviewBlockPreviewHost.browser.test.tsx
@@ -1,0 +1,170 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { page } from 'vitest/browser';
+// `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
+import { renderWithProviders } from '../../../test/component-setup';
+import { REVIEW_RUN_FOR_REAL_BUZZ_CAP } from '~/shared/constants/block-scope.constants';
+
+/**
+ * MOD REVIEW SANDBOX "run for real" (#2831) — `ReviewBlockPreviewHost` opt-in UI.
+ *
+ * Proves the mod-facing control surface of the run-for-real opt-in WITHOUT mounting
+ * the heavy real PageBlockHost (stubbed to report its `reviewRunForReal` prop):
+ *   - DEFAULT is render-only — no banner, the opt-in ("Run for real…") is off;
+ *   - arming shows the LOUD consent copy incl. the exact Buzz cap + "SFW enforced";
+ *   - CONFIRM re-mints with runForReal:true → the persistent banner shows and the
+ *     host is handed reviewRunForReal=true (server-authoritative: driven off the
+ *     minted token, not the UI flag);
+ *   - EXIT re-mints render-only → banner clears, host back to reviewRunForReal=false.
+ */
+
+// Stub the real host so the test targets the control surface only. It surfaces the
+// security-relevant prop so we can assert what the host is actually told to do.
+vi.mock('~/components/AppBlocks/PageBlockHost', () => ({
+  PageBlockHost: ({ reviewRunForReal }: { reviewRunForReal?: boolean }) => (
+    <div data-testid="page-host" data-rfr={String(!!reviewRunForReal)} />
+  ),
+}));
+
+vi.mock('~/hooks/useCurrentUser', () => ({
+  useCurrentUser: () => ({ id: 1, username: 'mod' }),
+}));
+
+const RENDER_ONLY_MINT = {
+  token: 'review.render-only.jwt',
+  expiresAt: '2099-01-01T00:00:00Z',
+  scopes: ['models:read:self', 'user:read:self'],
+  domain: null,
+  maxBrowsingLevel: 1,
+  blockId: 'my-app',
+  appId: 'pending-pubreq_X',
+  appBlockId: 'pubreq_X',
+  blockInstanceId: 'page_pubreq_X',
+  appName: 'My App',
+  sandbox: 'allow-scripts',
+  runForReal: false,
+  buzzCap: null,
+};
+
+const RUN_FOR_REAL_MINT = {
+  ...RENDER_ONLY_MINT,
+  token: 'review.run-for-real.jwt',
+  scopes: ['ai:write:budgeted', 'apps:storage:read', 'apps:storage:write', 'user:read:self'],
+  runForReal: true,
+  buzzCap: REVIEW_RUN_FOR_REAL_BUZZ_CAP,
+};
+
+// A REAL stateful useMutation stub: `mutate({ runForReal })` synchronously swaps
+// `data` between the two fixtures (mirrors a resolved re-mint), so the component
+// re-renders exactly as it would against the server.
+const mintCalls = vi.hoisted(() => ({ inputs: [] as Array<{ runForReal: boolean }> }));
+vi.mock('~/utils/trpc', async () => {
+  const React = await import('react');
+  return {
+    trpc: {
+      blocks: {
+        mintReviewBlockToken: {
+          useMutation: () => {
+            const [data, setData] = React.useState<typeof RENDER_ONLY_MINT | undefined>(undefined);
+            return {
+              data,
+              isPending: false,
+              isError: false,
+              mutate: (input: { publishRequestId: string; runForReal: boolean }) => {
+                mintCalls.inputs.push({ runForReal: input.runForReal });
+                setData(input.runForReal ? RUN_FOR_REAL_MINT : RENDER_ONLY_MINT);
+              },
+            };
+          },
+        },
+      },
+    },
+  };
+});
+
+// eslint-disable-next-line import/first
+import { ReviewBlockPreviewHost } from '~/components/Apps/ReviewBlockPreviewHost';
+
+beforeEach(() => {
+  mintCalls.inputs = [];
+});
+
+function mount() {
+  renderWithProviders(
+    <ReviewBlockPreviewHost
+      publishRequestId="pubreq_X"
+      slug="my-app"
+      iframeSrc="https://my-app.example/?mr=entry"
+    />
+  );
+}
+
+describe('ReviewBlockPreviewHost — run-for-real opt-in', () => {
+  test('DEFAULT is render-only: host gets reviewRunForReal=false, no banner, opt-in offered', async () => {
+    mount();
+    // The mount effect mints render-only.
+    await expect.element(page.getByTestId('page-host')).toBeInTheDocument();
+    expect(page.getByTestId('page-host').element().getAttribute('data-rfr')).toBe('false');
+    // No active banner; the opt-in control is present.
+    expect(page.getByTestId('review-run-for-real-banner').elements()).toHaveLength(0);
+    await expect.element(page.getByTestId('review-run-for-real-arm')).toBeInTheDocument();
+    // First mint was render-only (runForReal:false).
+    expect(mintCalls.inputs[0]).toEqual({ runForReal: false });
+  });
+
+  test('arming shows the LOUD consent copy with the exact Buzz cap + "SFW enforced"', async () => {
+    mount();
+    await page.getByTestId('review-run-for-real-arm').click();
+
+    const consent = page.getByTestId('review-run-for-real-consent');
+    await expect.element(consent).toBeInTheDocument();
+    const text = consent.element().textContent ?? '';
+    expect(text).toContain('UNAPPROVED');
+    expect(text).toContain('YOUR account');
+    expect(text).toContain(String(REVIEW_RUN_FOR_REAL_BUZZ_CAP));
+    expect(text).toContain('SFW enforced');
+    // Arming does NOT mint run-for-real yet — only the initial render-only mint ran.
+    expect(mintCalls.inputs).toEqual([{ runForReal: false }]);
+  });
+
+  test('CONFIRM re-mints runForReal:true → banner shows + host gets reviewRunForReal=true', async () => {
+    mount();
+    await page.getByTestId('review-run-for-real-arm').click();
+    await page.getByTestId('review-run-for-real-confirm').click();
+
+    await expect.element(page.getByTestId('review-run-for-real-banner')).toBeInTheDocument();
+    await vi.waitFor(() =>
+      expect(page.getByTestId('page-host').element().getAttribute('data-rfr')).toBe('true')
+    );
+    // The re-mint requested run-for-real.
+    expect(mintCalls.inputs.at(-1)).toEqual({ runForReal: true });
+  });
+
+  test('EXIT tears down run-for-real → banner clears, host back to render-only', async () => {
+    mount();
+    await page.getByTestId('review-run-for-real-arm').click();
+    await page.getByTestId('review-run-for-real-confirm').click();
+    await expect.element(page.getByTestId('review-run-for-real-banner')).toBeInTheDocument();
+
+    await page.getByTestId('review-run-for-real-exit').click();
+
+    await vi.waitFor(() =>
+      expect(page.getByTestId('review-run-for-real-banner').elements()).toHaveLength(0)
+    );
+    await vi.waitFor(() =>
+      expect(page.getByTestId('page-host').element().getAttribute('data-rfr')).toBe('false')
+    );
+    // Exit re-minted render-only.
+    expect(mintCalls.inputs.at(-1)).toEqual({ runForReal: false });
+  });
+
+  test('CANCEL on the consent gate returns to the opt-in without minting run-for-real', async () => {
+    mount();
+    await page.getByTestId('review-run-for-real-arm').click();
+    await page.getByTestId('review-run-for-real-cancel').click();
+
+    await expect.element(page.getByTestId('review-run-for-real-arm')).toBeInTheDocument();
+    expect(page.getByTestId('review-run-for-real-consent').elements()).toHaveLength(0);
+    // No run-for-real mint ever happened.
+    expect(mintCalls.inputs.every((i) => i.runForReal === false)).toBe(true);
+  });
+});

--- a/src/components/Apps/ReviewBlockPreviewHost.browser.test.tsx
+++ b/src/components/Apps/ReviewBlockPreviewHost.browser.test.tsx
@@ -3,6 +3,7 @@ import { page } from 'vitest/browser';
 // `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
 import { renderWithProviders } from '../../../test/component-setup';
 import { REVIEW_RUN_FOR_REAL_BUZZ_CAP } from '~/shared/constants/block-scope.constants';
+import type { MintReviewBlockTokenResult } from '~/server/services/blocks/publish-request.service';
 
 /**
  * MOD REVIEW SANDBOX "run for real" (#2831) — `ReviewBlockPreviewHost` opt-in UI.
@@ -29,7 +30,10 @@ vi.mock('~/hooks/useCurrentUser', () => ({
   useCurrentUser: () => ({ id: 1, username: 'mod' }),
 }));
 
-const RENDER_ONLY_MINT = {
+// Typed to the PRODUCTION mint-result shape (`buzzCap: number | null`,
+// `runForReal: boolean`) so the run-for-real variant type-checks AND the mock
+// exercises a well-typed state — not the narrowed literal `typeof` inference.
+const RENDER_ONLY_MINT: MintReviewBlockTokenResult = {
   token: 'review.render-only.jwt',
   expiresAt: '2099-01-01T00:00:00Z',
   scopes: ['models:read:self', 'user:read:self'],
@@ -45,7 +49,7 @@ const RENDER_ONLY_MINT = {
   buzzCap: null,
 };
 
-const RUN_FOR_REAL_MINT = {
+const RUN_FOR_REAL_MINT: MintReviewBlockTokenResult = {
   ...RENDER_ONLY_MINT,
   token: 'review.run-for-real.jwt',
   scopes: ['ai:write:budgeted', 'apps:storage:read', 'apps:storage:write', 'user:read:self'],
@@ -64,7 +68,9 @@ vi.mock('~/utils/trpc', async () => {
       blocks: {
         mintReviewBlockToken: {
           useMutation: () => {
-            const [data, setData] = React.useState<typeof RENDER_ONLY_MINT | undefined>(undefined);
+            const [data, setData] = React.useState<MintReviewBlockTokenResult | undefined>(
+              undefined
+            );
             return {
               data,
               isPending: false,

--- a/src/components/Apps/ReviewBlockPreviewHost.tsx
+++ b/src/components/Apps/ReviewBlockPreviewHost.tsx
@@ -1,8 +1,10 @@
-import { Alert, Loader, Stack, Text, useComputedColorScheme } from '@mantine/core';
-import { useEffect } from 'react';
+import { Alert, Button, Group, Loader, Stack, Text, useComputedColorScheme } from '@mantine/core';
+import { IconAlertTriangle, IconPlayerPlay, IconShieldLock } from '@tabler/icons-react';
+import { useCallback, useEffect, useState } from 'react';
 import { PageBlockHost } from '~/components/AppBlocks/PageBlockHost';
 import { clampReviewSandbox } from '~/components/AppBlocks/sandbox';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
+import { REVIEW_RUN_FOR_REAL_BUZZ_CAP } from '~/shared/constants/block-scope.constants';
 import { trpc } from '~/utils/trpc';
 
 /**
@@ -31,6 +33,19 @@ import { trpc } from '~/utils/trpc';
  *   3. HOST — `reviewMode` makes every side-effecting / money / private / cross-user
  *      host handler reply with a fail-fast NACK instead of doing the work.
  *
+ * RUN FOR REAL (opt-in): a moderator may EXPLICITLY opt in, per-preview, to run the
+ * app FOR REAL against THEIR OWN account (generation / own-Buzz / per-user storage)
+ * so they can fully evaluate it before approving. It is:
+ *   - LOUD-CONSENT-GATED (default OFF; the mod must confirm a clear warning);
+ *   - RE-MINTED server-side with `runForReal:true` — the token stays SELF-BOUND,
+ *     forced-SFW, clamped to (declared ∩ run-for-real allowlist); money-OUT and
+ *     cross-user are NEVER granted; spend is bounded by a per-call budget AND a
+ *     tight aggregate session Buzz cap (`REVIEW_RUN_FOR_REAL_BUZZ_CAP`);
+ *   - SERVER-AUTHORITATIVE — the host only un-NACKs when the MINTED token actually
+ *     came back `runForReal:true` (`mintData.runForReal`), never off local UI state;
+ *   - REVERSIBLE — "Exit run-for-real" re-mints the render-only token; the whole
+ *     preview is torn down on the approve/reject decision.
+ *
  * The mount is isolated in its OWN component (rendered only when the preview is
  * live) so `ReviewPreviewPanel`'s render path — and the OnsiteReviewModal browser
  * test that never reaches a live preview — never evaluates these hooks.
@@ -52,18 +67,27 @@ export function ReviewBlockPreviewHost({
   const theme: 'light' | 'dark' = colorScheme === 'dark' ? 'dark' : 'light';
 
   // Mint the SELF-BOUND, scope-stripped block token (mod-gated mutation). Minted
-  // once when the preview goes live; re-mintable on demand via onRetryToken (the
-  // 4h dev-lifetime token comfortably outlives a review session).
+  // once render-only when the preview goes live; RE-mintable on demand to flip
+  // between render-only and run-for-real, and on an auth-failure retry.
   const mintMut = trpc.blocks.mintReviewBlockToken.useMutation();
   const { mutate: mint, data: mintData, isError: mintError, isPending } = mintMut;
 
+  // Consent gate state — the mod arms (shows the loud warning) then confirms. The
+  // ACTIVE run-for-real state is read from the MINTED token (`mintData.runForReal`,
+  // server truth), never from this UI flag alone — that is what gates the host.
+  const [consentArmed, setConsentArmed] = useState(false);
+
+  const doMint = useCallback(
+    (runForReal: boolean) => mint({ publishRequestId, runForReal }),
+    [mint, publishRequestId]
+  );
+
   useEffect(() => {
-    // Fire once on mount for this live preview. React 18 StrictMode double-invokes
-    // effects in dev; `isPending`/`mintData` guards keep it to a single in-flight
-    // mint, and a duplicate mint is harmless (idempotent, audited).
-    if (!mintData && !isPending && !mintError) {
-      mint({ publishRequestId });
-    }
+    // Fire once on mount for this live preview — ALWAYS render-only first (the
+    // default sandbox). React 18 StrictMode double-invokes effects in dev; a
+    // duplicate mint is harmless (idempotent, audited, rate-limited only for the
+    // run-for-real path).
+    doMint(false);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [publishRequestId]);
 
@@ -90,37 +114,144 @@ export function ReviewBlockPreviewHost({
     ? { id: currentUser.id, username: currentUser.username ?? null }
     : null;
 
+  // SERVER TRUTH: only treat run-for-real as active when the MINTED token came back
+  // runForReal:true (the token is what actually carries the wider scopes + budget).
+  const runForRealActive = mintData.runForReal === true;
+  const buzzCap = mintData.buzzCap ?? REVIEW_RUN_FOR_REAL_BUZZ_CAP;
+
   return (
-    <PageBlockHost
-      appBlockId={mintData.appBlockId}
-      blockId={mintData.blockId}
-      appId={mintData.appId}
-      blockInstanceId={mintData.blockInstanceId}
-      appName={mintData.appName}
-      iframeSrc={iframeSrc}
-      // Clamp the manifest sandbox to the review render-only set: drop
-      // allow-popups / allow-downloads / allow-modals / allow-pointer-lock (+ the
-      // top-nav / escape tokens intersectSandbox already strips) so an untrusted
-      // review block can't open a popup or trigger a download aimed at the mod's
-      // tab. Keeps allow-scripts (+ allow-forms if declared).
-      sandbox={clampReviewSandbox(mintData.sandbox)}
-      // FORCED unverified → opaque origin (drops allow-same-origin). C1 defense.
-      trustTier="unverified"
-      slug={slug}
-      token={mintData.token}
-      expiresAt={mintData.expiresAt}
-      declaredScopes={mintData.scopes}
-      missingScopes={[]}
-      needsConsent={false}
-      tokenError={false}
-      domain={mintData.domain}
-      maxBrowsingLevel={mintData.maxBrowsingLevel}
-      viewer={viewer}
-      theme={theme}
-      // Read-only host: every side-effecting/money/private handler NACKs.
-      reviewMode
-      // Re-mint the block token on an auth-failure Retry.
-      onRetryToken={() => mint({ publishRequestId })}
-    />
+    <Stack gap="xs">
+      {runForRealActive ? (
+        // PERSISTENT banner while run-for-real is active. Stays visible for the
+        // whole run-for-real session so the mod is never unaware their OWN account
+        // is being spent against by an unapproved app.
+        <Alert
+          color="red"
+          variant="filled"
+          icon={<IconAlertTriangle size={18} />}
+          data-testid="review-run-for-real-banner"
+        >
+          <Group justify="space-between" wrap="nowrap" gap="sm">
+            <Text size="sm" fw={600}>
+              RUN FOR REAL is active — this UNAPPROVED app is running for real against YOUR
+              account and spending YOUR Buzz (capped at {buzzCap}). SFW enforced.
+            </Text>
+            <Button
+              size="xs"
+              color="gray"
+              variant="white"
+              onClick={() => {
+                setConsentArmed(false);
+                doMint(false);
+              }}
+              loading={isPending}
+              data-testid="review-run-for-real-exit"
+            >
+              Exit run-for-real
+            </Button>
+          </Group>
+        </Alert>
+      ) : consentArmed ? (
+        // LOUD consent gate — shown after the mod arms the toggle, BEFORE any
+        // run-for-real token is minted. Copy states exactly what will happen +
+        // the enforced cap + SFW.
+        <Alert
+          color="orange"
+          variant="light"
+          icon={<IconAlertTriangle size={18} />}
+          title="Run this UNAPPROVED app for real?"
+          data-testid="review-run-for-real-consent"
+        >
+          <Stack gap="xs">
+            <Text size="sm">
+              This runs an UNAPPROVED app for real against YOUR account and spends YOUR Buzz,
+              capped at {buzzCap}. SFW enforced. Generation, your own Buzz balance, and per-user
+              storage will use your real account; cross-user actions and money-out stay disabled.
+            </Text>
+            <Group gap="xs">
+              <Button
+                size="xs"
+                color="red"
+                leftSection={<IconPlayerPlay size={14} />}
+                onClick={() => {
+                  setConsentArmed(false);
+                  doMint(true);
+                }}
+                loading={isPending}
+                data-testid="review-run-for-real-confirm"
+              >
+                Yes, run for real (cap {buzzCap} Buzz)
+              </Button>
+              <Button
+                size="xs"
+                variant="default"
+                onClick={() => setConsentArmed(false)}
+                data-testid="review-run-for-real-cancel"
+              >
+                Cancel
+              </Button>
+            </Group>
+          </Stack>
+        </Alert>
+      ) : (
+        // DEFAULT: render-only. Offer the opt-in (off by default).
+        <Group justify="space-between" wrap="nowrap" gap="sm">
+          <Group gap={6} wrap="nowrap">
+            <IconShieldLock size={16} />
+            <Text size="xs" c="dimmed">
+              Read-only preview — side effects are disabled.
+            </Text>
+          </Group>
+          <Button
+            size="xs"
+            variant="light"
+            color="orange"
+            leftSection={<IconPlayerPlay size={14} />}
+            onClick={() => setConsentArmed(true)}
+            data-testid="review-run-for-real-arm"
+          >
+            Run for real…
+          </Button>
+        </Group>
+      )}
+
+      <PageBlockHost
+        // Remount on a mode flip so the new (render-only ↔ run-for-real) token
+        // re-handshakes the iframe cleanly instead of swapping a token mid-session.
+        key={runForRealActive ? 'run-for-real' : 'render-only'}
+        appBlockId={mintData.appBlockId}
+        blockId={mintData.blockId}
+        appId={mintData.appId}
+        blockInstanceId={mintData.blockInstanceId}
+        appName={mintData.appName}
+        iframeSrc={iframeSrc}
+        // Clamp the manifest sandbox to the review render-only set: drop
+        // allow-popups / allow-downloads / allow-modals / allow-pointer-lock (+ the
+        // top-nav / escape tokens intersectSandbox already strips) so an untrusted
+        // review block can't open a popup or trigger a download aimed at the mod's
+        // tab. Keeps allow-scripts (+ allow-forms if declared).
+        sandbox={clampReviewSandbox(mintData.sandbox)}
+        // FORCED unverified → opaque origin (drops allow-same-origin). C1 defense.
+        trustTier="unverified"
+        slug={slug}
+        token={mintData.token}
+        expiresAt={mintData.expiresAt}
+        declaredScopes={mintData.scopes}
+        missingScopes={[]}
+        needsConsent={false}
+        tokenError={false}
+        domain={mintData.domain}
+        maxBrowsingLevel={mintData.maxBrowsingLevel}
+        viewer={viewer}
+        theme={theme}
+        // Read-only host by default: every side-effecting/money/private handler
+        // NACKs. When (and only when) the SERVER minted a run-for-real token, the
+        // self-bound / money-in / own-Buzz / per-user-storage handlers run for real.
+        reviewMode
+        reviewRunForReal={runForRealActive}
+        // Re-mint the block token on an auth-failure Retry, preserving the mode.
+        onRetryToken={() => doMint(runForRealActive)}
+      />
+    </Stack>
   );
 }

--- a/src/server/middleware/__tests__/block-scope.middleware.test.ts
+++ b/src/server/middleware/__tests__/block-scope.middleware.test.ts
@@ -287,6 +287,22 @@ describe('verifyBlockToken fail-closed shapes (L-VERIFY / L-M6)', () => {
     expect(await verifyBlockToken(await signRaw({ domain: 123 }))).toBeNull();
   });
 
+  it('accepts + round-trips a boolean reviewRunForReal claim (#2831); absent is fine', async () => {
+    const withTrue = await verifyBlockToken(await signRaw({ reviewRunForReal: true, dev: true }));
+    expect(withTrue).not.toBeNull();
+    expect(withTrue?.reviewRunForReal).toBe(true);
+    const absent = await verifyBlockToken(await signRaw({}));
+    expect(absent).not.toBeNull();
+    expect(absent?.reviewRunForReal).toBeUndefined();
+  });
+
+  it('rejects a token whose reviewRunForReal claim is non-boolean (forged)', async () => {
+    // A forged run-for-real marker must be rejected outright so the runtime
+    // aggregate-cap selector can trust the boolean.
+    expect(await verifyBlockToken(await signRaw({ reviewRunForReal: 'true' }))).toBeNull();
+    expect(await verifyBlockToken(await signRaw({ reviewRunForReal: 1 }))).toBeNull();
+  });
+
   // ---- Maturity claim shape guard (from #2670, redundant cross-check) -----
   // The maxBrowsingLevel claim is optional (absent on legacy tokens), but if
   // PRESENT it must be a finite number — a forged non-numeric value is rejected

--- a/src/server/middleware/block-scope.middleware.ts
+++ b/src/server/middleware/block-scope.middleware.ts
@@ -75,6 +75,16 @@ export interface BlockTokenClaims {
    * the SHORTER 15min cap (and a non-boolean is rejected outright).
    */
   dev?: boolean;
+  /**
+   * MOD REVIEW SANDBOX "run for real" marker (#2831) — present (true) ONLY on a
+   * token minted by `mintReviewBlockToken({ runForReal: true })` (a moderator's
+   * consent-gated opt-in). The runtime spend paths (submitWorkflow / customComfy)
+   * read it to enforce the TIGHT per-(mod, publishRequestId) AGGREGATE Buzz
+   * ceiling instead of the ordinary per-user daily cap. Trustworthy ONLY because
+   * the RS256 signature is verified before it is read. Optional; MUST be a boolean
+   * if present (a non-boolean is rejected outright; absent → treated as false).
+   */
+  reviewRunForReal?: boolean;
 }
 
 export type BlockScopedNextApiRequest = NextApiRequest & {
@@ -518,6 +528,14 @@ export async function verifyBlockToken(token: string): Promise<BlockTokenClaims 
       // our own signer (jwtVerify already checked the RS256 signature against
       // our keys above), so the flag is trustworthy at this point.
       if (claims.dev !== undefined && typeof claims.dev !== 'boolean') {
+        return null;
+      }
+      // RUN-FOR-REAL marker shape guard. Optional (absent on every non-review
+      // token); if PRESENT it MUST be a boolean — a forged/garbage value is
+      // rejected outright so the runtime aggregate-cap selector can trust it. A
+      // signature-valid `reviewRunForReal:true` is only producible by our own
+      // signer (the RS256 signature was already verified above).
+      if (claims.reviewRunForReal !== undefined && typeof claims.reviewRunForReal !== 'boolean') {
         return null;
       }
       // Per-token-type max-age belt (replaces the global maxTokenAge). `exp`

--- a/src/server/routers/__tests__/apps.router.storage.test.ts
+++ b/src/server/routers/__tests__/apps.router.storage.test.ts
@@ -15,6 +15,7 @@ const {
   mockPool,
   mockClient,
   mockGetQuota,
+  mockProvisionReviewPreview,
   mockLogToAxiom,
   mockGetUserById,
   mockGetSessionUser,
@@ -39,6 +40,12 @@ const {
     mockPool,
     mockClient,
     mockGetQuota: vi.fn(),
+    // Mirrors the real AppStorageProvisioner.provisionReviewPreview: derives the
+    // disposable `apprev_<norm>` schema from the publishRequestId (so isolation
+    // tests can assert distinct schemas) without touching a real DB.
+    mockProvisionReviewPreview: vi.fn(async ({ publishRequestId }: { publishRequestId: string }) => ({
+      schema: `"apprev_${publishRequestId.toLowerCase().replace(/[^a-z0-9]+/g, '').slice(0, 48)}"`,
+    })),
     mockLogToAxiom: vi.fn(async () => undefined),
     mockGetUserById: vi.fn(),
     mockGetSessionUser: vi.fn(),
@@ -75,6 +82,7 @@ vi.mock('~/server/db/appsDb', () => ({
 vi.mock('~/server/services/apps/storage-provision.service', () => ({
   AppStorageProvisioner: {
     getQuota: (...args: unknown[]) => mockGetQuota(...args),
+    provisionReviewPreview: (...args: unknown[]) => mockProvisionReviewPreview(...args),
   },
 }));
 vi.mock('~/server/logging/client', () => ({
@@ -137,6 +145,9 @@ beforeEach(() => {
   mockIsAppBlocksAuthorEnabled.mockReset();
   mockRecordScopeInvocation.mockReset();
   mockRecordScopeInvocation.mockResolvedValue(undefined);
+  // mockClear (NOT mockReset) — preserve the derive-schema implementation set in
+  // the hoisted factory while clearing call history between tests.
+  mockProvisionReviewPreview.mockClear();
 
   // Sane defaults the happy-path tests inherit.
   mockIsAppBlocksEnabled.mockImplementation(async () => true);
@@ -551,5 +562,122 @@ describe('apps.storage.getQuota', () => {
     const out = await caller.storage.getQuota({ blockToken: 't' });
     expect(out.usedBytes).toBe(0);
     expect(out.rowCount).toBe(0);
+  });
+});
+
+// ── MOD REVIEW SANDBOX "run for real" preview storage (#2831) ────────────────
+// A run-for-real review token (signed `reviewRunForReal`) makes per-user storage
+// WORK for a PENDING app via a disposable, per-publishRequest, ISOLATED preview
+// schema — self-bound to the mod, never touching the approved app's namespace.
+describe('apps.storage — run-for-real preview namespace', () => {
+  // A review run-for-real token: synthetic pending ids + the signed claim.
+  function reviewClaims(over: Record<string, unknown> = {}) {
+    return validClaims({
+      reviewRunForReal: true,
+      appId: 'pending-pubreq_aaa',
+      appBlockId: 'pubreq_aaa',
+      blockInstanceId: 'page_pubreq_aaa',
+      blockId: 'generate-from-model',
+      ...over,
+    });
+  }
+
+  it('GET succeeds for a PENDING app: resolves the apprev_ preview schema, never the AppBlock lookup', async () => {
+    mockVerifyBlockToken.mockResolvedValueOnce(reviewClaims());
+    mockPool.query.mockResolvedValueOnce({ rows: [{ value: { hello: 'world' } }], rowCount: 1 });
+    const caller = appsRouter.createCaller(fakeCtx() as never);
+    const out = await caller.storage.get({ blockToken: 't', key: 'k' });
+    expect(out.value).toEqual({ hello: 'world' });
+    // The preview schema was provisioned on demand for THIS publish request.
+    expect(mockProvisionReviewPreview).toHaveBeenCalledWith({ publishRequestId: 'pubreq_aaa' });
+    // The read hit the DISPOSABLE preview schema — NOT the approved app schema.
+    const sql = String(mockPool.query.mock.calls.at(-1)?.[0]);
+    expect(sql).toContain('"apprev_pubreqaaa".kv');
+    expect(sql).not.toContain('app_generate_from_model');
+    // The run-for-real path NEVER consults the AppBlock row (the app is unapproved).
+    expect(mockDbRead.appBlock.findUnique).not.toHaveBeenCalled();
+  });
+
+  it('SET succeeds for a PENDING app: writes to the preview schema, self-bound to the mod', async () => {
+    mockVerifyBlockToken.mockResolvedValueOnce(reviewClaims());
+    // quota pre-read + existing-size read → both empty (fresh key, under quota).
+    mockPool.query.mockResolvedValue({ rows: [], rowCount: 0 });
+    const caller = appsRouter.createCaller(fakeCtx() as never);
+    const res = await caller.storage.set({ blockToken: 't', key: 'note', value: { a: 1 } });
+    expect(res.ok).toBe(true);
+    expect(mockProvisionReviewPreview).toHaveBeenCalledWith({ publishRequestId: 'pubreq_aaa' });
+    // The INSERT (client.query) targeted the preview schema, self-bound to user 42.
+    const insertCall = mockClient.query.mock.calls.find((c) =>
+      String(c[0]).includes('INSERT INTO')
+    );
+    expect(insertCall).toBeTruthy();
+    expect(String(insertCall?.[0])).toContain('"apprev_pubreqaaa".kv');
+    expect(String(insertCall?.[0])).not.toContain('app_generate_from_model');
+    // The quota GUC is set to the publishRequestId (preview quota row key).
+    const setLocalCall = mockClient.query.mock.calls.find((c) =>
+      String(c[0]).includes('SET LOCAL app.current_app_block_id')
+    );
+    expect(String(setLocalCall?.[0])).toContain('pubreq_aaa');
+    expect(insertCall?.[1]).toEqual(['page_pubreq_aaa', 42, 'note', JSON.stringify({ a: 1 })]);
+  });
+
+  it('ISOLATION: two pending apps resolve DISTINCT preview schemas; neither aliases the approved app schema', async () => {
+    // App A.
+    mockVerifyBlockToken.mockResolvedValueOnce(reviewClaims({ appBlockId: 'pubreq_aaa' }));
+    mockPool.query.mockResolvedValueOnce({ rows: [{ value: 1 }], rowCount: 1 });
+    let caller = appsRouter.createCaller(fakeCtx() as never);
+    await caller.storage.get({ blockToken: 't', key: 'k' });
+    const sqlA = String(mockPool.query.mock.calls.at(-1)?.[0]);
+
+    // App B — different publish request, SAME slug.
+    mockVerifyBlockToken.mockResolvedValueOnce(reviewClaims({ appBlockId: 'pubreq_bbb' }));
+    mockPool.query.mockResolvedValueOnce({ rows: [{ value: 2 }], rowCount: 1 });
+    caller = appsRouter.createCaller(fakeCtx() as never);
+    await caller.storage.get({ blockToken: 't', key: 'k' });
+    const sqlB = String(mockPool.query.mock.calls.at(-1)?.[0]);
+
+    expect(sqlA).toContain('"apprev_pubreqaaa".kv');
+    expect(sqlB).toContain('"apprev_pubreqbbb".kv');
+    // A cannot resolve B's namespace, and neither is the approved app schema —
+    // preview writes never pollute the eventual approved `app_<slug>` store.
+    expect(sqlA).not.toContain('apprev_pubreqbbb');
+    expect(sqlB).not.toContain('apprev_pubreqaaa');
+    expect(sqlA).not.toContain('app_generate_from_model');
+    expect(sqlB).not.toContain('app_generate_from_model');
+  });
+
+  it('REGRESSION: WITHOUT the run-for-real claim, a pending app still FAILS CLOSED (no preview schema)', async () => {
+    // Same synthetic pending token but NO reviewRunForReal → the approved-status
+    // gate runs and rejects; the preview namespace is never provisioned.
+    mockVerifyBlockToken.mockResolvedValueOnce(
+      validClaims({ appId: 'pending-pubreq_aaa', appBlockId: 'pubreq_aaa', blockId: 'generate-from-model' })
+    );
+    mockDbRead.appBlock.findUnique.mockResolvedValueOnce({ id: 'apb_x', status: 'pending' });
+    const caller = appsRouter.createCaller(fakeCtx() as never);
+    await expect(
+      caller.storage.set({ blockToken: 't', key: 'k', value: { a: 1 } })
+    ).rejects.toMatchObject({ code: 'FORBIDDEN' });
+    expect(mockProvisionReviewPreview).not.toHaveBeenCalled();
+    expect(mockClient.query).not.toHaveBeenCalled();
+  });
+
+  it('the storage SCOPE gate still applies under run-for-real (write needs apps:storage:write)', async () => {
+    mockVerifyBlockToken.mockResolvedValueOnce(
+      reviewClaims({ scopes: ['apps:storage:read'] }) // read-only → set must reject
+    );
+    const caller = appsRouter.createCaller(fakeCtx() as never);
+    await expect(
+      caller.storage.set({ blockToken: 't', key: 'k', value: { a: 1 } })
+    ).rejects.toMatchObject({ code: 'FORBIDDEN' });
+    // Rejected at the scope gate BEFORE provisioning any preview schema.
+    expect(mockProvisionReviewPreview).not.toHaveBeenCalled();
+  });
+
+  it('run-for-real is SELF-BOUND: an anon subject cannot write preview storage', async () => {
+    mockVerifyBlockToken.mockResolvedValueOnce(reviewClaims({ sub: 'anon' }));
+    const caller = appsRouter.createCaller(fakeCtx() as never);
+    await expect(
+      caller.storage.set({ blockToken: 't', key: 'k', value: { a: 1 } })
+    ).rejects.toMatchObject({ code: 'UNAUTHORIZED' });
   });
 });

--- a/src/server/routers/__tests__/apps.router.storage.test.ts
+++ b/src/server/routers/__tests__/apps.router.storage.test.ts
@@ -35,6 +35,9 @@ const {
     mockParseSubjectUserId: vi.fn(),
     mockDbRead: {
       appBlock: { findUnique: vi.fn() },
+      // Run-for-real storage reads the pubreq status (orphan guard) from the
+      // PRIMARY (dbWrite, mapped to this mock below).
+      appBlockPublishRequest: { findUnique: vi.fn() },
     },
     mockIsAppBlocksEnabled: vi.fn(async () => true),
     mockPool,
@@ -165,6 +168,10 @@ beforeEach(() => {
     id: 'apb_test',
     status: 'approved',
   });
+  // Default the pubreq to PENDING so run-for-real happy paths resolve; the orphan
+  // guard tests override with a non-pending / missing status.
+  mockDbRead.appBlockPublishRequest.findUnique.mockReset();
+  mockDbRead.appBlockPublishRequest.findUnique.mockResolvedValue({ status: 'pending' });
   mockPool.query.mockResolvedValue({ rows: [], rowCount: 0 });
   mockClient.query.mockResolvedValue({ rows: [], rowCount: 0 });
   mockLogToAxiom.mockResolvedValue(undefined);
@@ -679,5 +686,28 @@ describe('apps.storage — run-for-real preview namespace', () => {
     await expect(
       caller.storage.set({ blockToken: 't', key: 'k', value: { a: 1 } })
     ).rejects.toMatchObject({ code: 'UNAUTHORIZED' });
+  });
+
+  it('ORPHAN GUARD: a valid run-for-real token used AFTER approve/reject does NOT re-provision', async () => {
+    // The 4h token is still valid, but the request has left pending → the preview
+    // is gone; refuse and NEVER re-provision a schema nothing would tear down.
+    mockVerifyBlockToken.mockResolvedValueOnce(reviewClaims());
+    mockDbRead.appBlockPublishRequest.findUnique.mockResolvedValueOnce({ status: 'approved' });
+    const caller = appsRouter.createCaller(fakeCtx() as never);
+    await expect(
+      caller.storage.set({ blockToken: 't', key: 'k', value: { a: 1 } })
+    ).rejects.toMatchObject({ code: 'FORBIDDEN' });
+    expect(mockProvisionReviewPreview).not.toHaveBeenCalled();
+    expect(mockClient.query).not.toHaveBeenCalled();
+  });
+
+  it('ORPHAN GUARD: a run-for-real token for a VANISHED request refuses (no re-provision)', async () => {
+    mockVerifyBlockToken.mockResolvedValueOnce(reviewClaims());
+    mockDbRead.appBlockPublishRequest.findUnique.mockResolvedValueOnce(null);
+    const caller = appsRouter.createCaller(fakeCtx() as never);
+    await expect(
+      caller.storage.get({ blockToken: 't', key: 'k' })
+    ).rejects.toMatchObject({ code: 'FORBIDDEN' });
+    expect(mockProvisionReviewPreview).not.toHaveBeenCalled();
   });
 });

--- a/src/server/routers/__tests__/blocks.router.reviewSandbox.test.ts
+++ b/src/server/routers/__tests__/blocks.router.reviewSandbox.test.ts
@@ -174,9 +174,19 @@ beforeEach(() => {
   mockTeardownPreview.mockResolvedValue({ publishRequestId: PUBREQ, tornDown: true });
   mockListActivePreviews.mockReset();
   mockListActivePreviews.mockResolvedValue({ cap: 5, active: [] });
+  // sysRedis powers the run-for-real mint rate limiter — reset call history + a
+  // benign default so per-test call-count assertions are deterministic.
+  mockSysRedis.incrBy.mockReset();
+  mockSysRedis.incrBy.mockResolvedValue(1);
+  mockSysRedis.expire.mockReset();
+  mockSysRedis.expire.mockResolvedValue(true);
+  mockSysRedis.ttl.mockReset();
+  mockSysRedis.ttl.mockResolvedValue(-1);
   mockMintReviewBlockToken.mockReset();
   mockMintReviewBlockToken.mockResolvedValue({
     token: 'review.jwt',
+    runForReal: false,
+    buzzCap: null,
     expiresAt: '2099-01-01T00:00:00Z',
     scopes: ['models:read:self', 'user:read:self'],
     domain: null,
@@ -259,7 +269,7 @@ describe('blocks.getReviewStatus', () => {
 });
 
 describe('blocks.mintReviewBlockToken', () => {
-  it('moderator + flags on: mints with the SERVER-derived mod id (self-bound)', async () => {
+  it('moderator + flags on: mints render-only (runForReal defaults false) with the SERVER-derived mod id (self-bound)', async () => {
     const caller = blocksRouter.createCaller(fakeCtx(modUser) as never);
     const res = await caller.mintReviewBlockToken({ publishRequestId: PUBREQ });
     expect(res.token).toBe('review.jwt');
@@ -267,7 +277,58 @@ describe('blocks.mintReviewBlockToken', () => {
     expect(mockMintReviewBlockToken).toHaveBeenCalledWith({
       publishRequestId: PUBREQ,
       modUserId: 1, // SERVER-derived, never client-supplied
+      runForReal: false, // schema default — render-only
     });
+    // The render-only mint is NOT rate-limited (only the run-for-real opt-in is).
+    expect(mockSysRedis.incrBy).not.toHaveBeenCalled();
+  });
+
+  it('runForReal:true passes the flag through + rate-limit ALLOWS under the window', async () => {
+    mockSysRedis.incrBy.mockResolvedValue(1); // first mint in the window
+    mockMintReviewBlockToken.mockResolvedValue({
+      token: 'review.rfr.jwt',
+      expiresAt: '2099-01-01T00:00:00Z',
+      scopes: ['ai:write:budgeted', 'user:read:self'],
+      domain: null,
+      maxBrowsingLevel: 1,
+      blockId: 'my-app',
+      appId: `pending-${PUBREQ}`,
+      appBlockId: PUBREQ,
+      blockInstanceId: `page_${PUBREQ}`,
+      appName: 'My App',
+      sandbox: 'allow-scripts',
+      runForReal: true,
+      buzzCap: 5000,
+    });
+    const caller = blocksRouter.createCaller(fakeCtx(modUser) as never);
+    const res = await caller.mintReviewBlockToken({ publishRequestId: PUBREQ, runForReal: true });
+    expect(res.token).toBe('review.rfr.jwt');
+    expect(res.runForReal).toBe(true);
+    expect(res.buzzCap).toBe(5000);
+    expect(mockMintReviewBlockToken).toHaveBeenCalledWith({
+      publishRequestId: PUBREQ,
+      modUserId: 1,
+      runForReal: true,
+    });
+    // The run-for-real opt-in IS rate-limited (one reservation counted).
+    expect(mockSysRedis.incrBy).toHaveBeenCalledTimes(1);
+  });
+
+  it('runForReal:true is REJECTED (TOO_MANY_REQUESTS) once the mint rate limit is exceeded — service NOT reached', async () => {
+    mockSysRedis.incrBy.mockResolvedValue(999); // over the per-mod window cap
+    const caller = blocksRouter.createCaller(fakeCtx(modUser) as never);
+    await expect(
+      caller.mintReviewBlockToken({ publishRequestId: PUBREQ, runForReal: true })
+    ).rejects.toMatchObject({ code: 'TOO_MANY_REQUESTS' });
+    expect(mockMintReviewBlockToken).not.toHaveBeenCalled();
+  });
+
+  it('non-moderator with runForReal:true: UNAUTHORIZED, never rate-limited, service NOT reached', async () => {
+    const caller = blocksRouter.createCaller(fakeCtx(normalUser) as never);
+    await expect(
+      caller.mintReviewBlockToken({ publishRequestId: PUBREQ, runForReal: true })
+    ).rejects.toBeInstanceOf(TRPCError);
+    expect(mockMintReviewBlockToken).not.toHaveBeenCalled();
   });
 
   it('non-moderator: UNAUTHORIZED, service NOT reached', async () => {

--- a/src/server/routers/__tests__/blocks.router.workflow.test.ts
+++ b/src/server/routers/__tests__/blocks.router.workflow.test.ts
@@ -1498,6 +1498,83 @@ describe('blocks.submitWorkflow', () => {
     expect(mockSysRedis.decrBy).not.toHaveBeenCalled();
   });
 
+  // ---- MOD REVIEW SANDBOX "run for real" AGGREGATE cap (#2831) -------------
+  // A run-for-real review token (signed reviewRunForReal:true) reserves against a
+  // TIGHT per-(mod, publishRequestId) session ceiling (REVIEW_RUN_FOR_REAL_BUZZ_CAP
+  // = 5000) INSTEAD OF the ordinary 50k/day cap. This is invariant #6: a low
+  // per-call budget alone cannot bound a hostile app looping sub-budget calls.
+  describe('run-for-real aggregate Buzz cap (#2831)', () => {
+    // Run-for-real tokens are dev:true (signDevScopedPageToken) + carry the pubreq
+    // id as appBlockId. dev:true also skips the G8 per-app reserve (synthetic id).
+    const runForRealClaims = () =>
+      validClaims({
+        reviewRunForReal: true,
+        dev: true,
+        buzzBudget: 1000,
+        appBlockId: 'pubreq_ABC',
+      });
+
+    it('reserves against the per-(mod, publishRequestId) session key, NOT the daily key', async () => {
+      mockVerifyBlockToken.mockResolvedValue(runForRealClaims());
+      happyVersionLookup();
+      happyUser();
+      mockSysRedis.incrBy.mockResolvedValue(125); // under the 5000 session cap
+      mockSubmitWorkflow
+        .mockResolvedValueOnce({ id: '', status: 'succeeded', cost: { total: 25 }, steps: [] })
+        .mockResolvedValueOnce({ id: 'wf_real', status: 'unassigned', cost: { total: 25 }, steps: [] });
+      const caller = blocksRouter.createCaller(fakeCtx() as never);
+      const result = await caller.submitWorkflow({ blockToken: 'tok', body: validBody() });
+      expect(result.snapshot.workflowId).toBe('wf_real');
+      const incrKey = String(mockSysRedis.incrBy.mock.calls[0][0]);
+      // The review-session key (auto-vivified REDIS_SYS_KEYS placeholder) — bound to
+      // the pubreq id and NOT the ordinary daily buzz-cap key.
+      expect(incrKey).toContain('REVIEW_RUN_FOR_REAL_BUZZ_CAP');
+      expect(incrKey).toContain('pubreq_ABC');
+      expect(incrKey).not.toContain('system:blocks:buzz-cap');
+    });
+
+    it('REJECTS a run-for-real submit that tops the 5000 session cap even FAR under the 50k daily cap', async () => {
+      mockVerifyBlockToken.mockResolvedValue(runForRealClaims());
+      happyVersionLookup();
+      happyUser();
+      // 5001 > REVIEW_RUN_FOR_REAL_BUZZ_CAP(5000) but ~10× under the 50k daily cap:
+      // the tighter aggregate ceiling MUST bind (looping-app defense, invariant #6).
+      mockSysRedis.incrBy.mockResolvedValue(5001);
+      mockSubmitWorkflow.mockResolvedValueOnce({
+        id: '',
+        status: 'succeeded',
+        cost: { total: 1 },
+        steps: [],
+      });
+      const caller = blocksRouter.createCaller(fakeCtx() as never);
+      const result = await caller.submitWorkflow({ blockToken: 'tok', body: validBody() });
+      expect(result.snapshot.status).toBe('failed');
+      expect(result.snapshot.error).toMatch(/review run-for-real Buzz cap/i);
+      // Real submit never fired; the over-cap reservation was refunded.
+      expect(mockSubmitWorkflow).toHaveBeenCalledTimes(1);
+      expect(mockSysRedis.decrBy).toHaveBeenCalledTimes(1);
+      // Refund targets the EXACT reserved session key.
+      expect(String(mockSysRedis.decrBy.mock.calls[0][0])).toBe(
+        String(mockSysRedis.incrBy.mock.calls[0][0])
+      );
+    });
+
+    it('a NON-run-for-real token with the SAME total stays on the 50k daily cap (proves the tight cap is run-for-real ONLY)', async () => {
+      mockVerifyBlockToken.mockResolvedValue(validClaims({ buzzBudget: 1000 }));
+      happyVersionLookup();
+      happyUser();
+      // 5001 is UNDER the 50k daily cap → a normal token proceeds.
+      mockSysRedis.incrBy.mockResolvedValue(5001);
+      mockSubmitWorkflow
+        .mockResolvedValueOnce({ id: '', status: 'succeeded', cost: { total: 25 }, steps: [] })
+        .mockResolvedValueOnce({ id: 'wf_real', status: 'unassigned', cost: { total: 25 }, steps: [] });
+      const caller = blocksRouter.createCaller(fakeCtx() as never);
+      const result = await caller.submitWorkflow({ blockToken: 'tok', body: validBody() });
+      expect(result.snapshot.workflowId).toBe('wf_real');
+      expect(String(mockSysRedis.incrBy.mock.calls[0][0])).toContain('system:blocks:buzz-cap');
+    });
+  });
+
   it('rejects when the token has no buzzBudget claim', async () => {
     mockVerifyBlockToken.mockResolvedValue(validClaims({ buzzBudget: undefined }));
     const caller = blocksRouter.createCaller(fakeCtx() as never);

--- a/src/server/routers/apps.router.ts
+++ b/src/server/routers/apps.router.ts
@@ -13,7 +13,7 @@
 
 import { TRPCError } from '@trpc/server';
 import * as z from 'zod';
-import { dbRead } from '~/server/db/client';
+import { dbRead, dbWrite } from '~/server/db/client';
 import { parseSubjectUserId, verifyBlockToken } from '~/server/middleware/block-scope.middleware';
 import { isAppBlocksAuthorEnabled, isAppBlocksEnabled } from '~/server/services/app-blocks-flag';
 import { sessionClient } from '~/server/auth/session-client';
@@ -151,9 +151,27 @@ async function resolveStorageContext(blockToken: string, op: StorageOp): Promise
     }
     // The preview namespace is keyed on the publishRequestId (the token's
     // `appBlockId` claim = `pubreq_<ULID>`), so it is isolated per pending app AND
-    // never aliases the eventual approved `app_<slug>` schema. Provision on demand
-    // (idempotent; fast-paths once the schema exists).
+    // never aliases the eventual approved `app_<slug>` schema.
     const publishRequestId = claims.appBlockId;
+    // ORPHAN GUARD: a run-for-real token lives 4h, but the review preview only
+    // exists while the request is PENDING (teardown drops the preview schema on
+    // approve/reject). A still-valid token used AFTER the decision must NOT
+    // re-provision a fresh `apprev_` schema that nothing would ever tear down
+    // again. Mirror the mint's pending-only gate: refuse (and do NOT provision)
+    // once the request has left the pending state. Read from the PRIMARY so a
+    // just-landed approve/reject isn't missed to replication lag.
+    const pr = await dbWrite.appBlockPublishRequest.findUnique({
+      where: { id: publishRequestId },
+      select: { status: true },
+    });
+    if (!pr || pr.status !== 'pending') {
+      appStorageOpsCounter.inc({ op, outcome: 'unauthorized' });
+      throw new TRPCError({
+        code: 'FORBIDDEN',
+        message: 'review preview is no longer active for this request',
+      });
+    }
+    // Provision on demand (idempotent; fast-paths once the schema exists).
     const { schema } = await AppStorageProvisioner.provisionReviewPreview({ publishRequestId });
     return {
       userId,

--- a/src/server/routers/apps.router.ts
+++ b/src/server/routers/apps.router.ts
@@ -94,8 +94,14 @@ const enforceAppBlocksFlag = middleware(async ({ ctx, next, type }) => {
 async function resolveStorageContext(blockToken: string, op: StorageOp): Promise<{
   userId: number | null;
   slug: string;
+  /** The resolved, quoted Postgres schema the op MUST read/write — either the
+   *  approved app's `app_<slug>` schema OR (run-for-real) the disposable,
+   *  per-publishRequest `apprev_<pubreq>` preview schema. */
+  schema: string;
   appBlockId: string;
   blockInstanceId: string;
+  /** True when this resolved to the run-for-real preview namespace. */
+  reviewPreview: boolean;
 }> {
   const claims = await verifyBlockToken(blockToken);
   if (!claims) {
@@ -110,6 +116,55 @@ async function resolveStorageContext(blockToken: string, op: StorageOp): Promise
       message: 'block id is not a valid storage slug',
     });
   }
+
+  // The DECLARED-scope gate (A5 / design-gaps H4). Reads need apps:storage:read;
+  // mutations need apps:storage:write. This runs for BOTH the approved and the
+  // run-for-real paths — a review token only carries the scope if the PENDING
+  // manifest declared it AND it survived the run-for-real allowlist clamp.
+  const requiredScope: string = op === 'set' || op === 'delete'
+    ? 'apps:storage:write'
+    : 'apps:storage:read';
+
+  // ── MOD REVIEW SANDBOX "run for real" (#2831) ──────────────────────────────
+  // ONLY when the verified token carries the signed `reviewRunForReal` claim: a
+  // moderator opted in to run an UNAPPROVED app for real against their OWN
+  // account. Resolve a DISPOSABLE, per-publishRequest, ISOLATED preview schema
+  // instead of the approved `app_<slug>` schema (which may not exist yet). This
+  // branch is GATED entirely on the signed claim — a normal (render-only) review
+  // token, or any prod token, never reaches it and keeps failing closed on the
+  // approved-status check below, byte-identical to before. Cross-user shared
+  // storage is untouched (apps:storage:shared:* lives in a different resolver and
+  // is never granted in run-for-real).
+  if (claims.reviewRunForReal === true) {
+    if (!Array.isArray(claims.scopes) || !claims.scopes.includes(requiredScope)) {
+      appStorageOpsCounter.inc({ op, outcome: 'unauthorized' });
+      throw new TRPCError({
+        code: 'FORBIDDEN',
+        message: `storage ${op} requires the ${requiredScope} scope`,
+      });
+    }
+    const userId = parseSubjectUserId(claims.sub);
+    // Self-bound: reads/writes land in the reviewing MOD's own rows. A non-mod
+    // subject can't hold a review token (mint is mod-gated); assert developer.
+    if (userId != null) {
+      await assertViewerIsAppDeveloper(userId);
+    }
+    // The preview namespace is keyed on the publishRequestId (the token's
+    // `appBlockId` claim = `pubreq_<ULID>`), so it is isolated per pending app AND
+    // never aliases the eventual approved `app_<slug>` schema. Provision on demand
+    // (idempotent; fast-paths once the schema exists).
+    const publishRequestId = claims.appBlockId;
+    const { schema } = await AppStorageProvisioner.provisionReviewPreview({ publishRequestId });
+    return {
+      userId,
+      slug,
+      schema,
+      appBlockId: publishRequestId,
+      blockInstanceId: claims.blockInstanceId,
+      reviewPreview: true,
+    };
+  }
+
   const block = await dbRead.appBlock.findUnique({
     where: { appId_blockId: { appId: claims.appId, blockId: claims.blockId } },
     select: { id: true, status: true },
@@ -127,13 +182,9 @@ async function resolveStorageContext(blockToken: string, op: StorageOp): Promise
   // carries the storage scope appropriate to the op. The scope only reaches
   // the token if it was in the manifest AND in the block's approvedScopes
   // snapshot (block-tokens/index.ts), so this re-checks the issuance contract
-  // at the point of use. Reads need apps:storage:read; mutations need
-  // apps:storage:write. (Previously resolveStorageContext never inspected
+  // at the point of use. (Previously resolveStorageContext never inspected
   // claims.scopes, so a block approved for e.g. only models:read:self could
   // still read/write 50MB of per-user KV it never disclosed.)
-  const requiredScope: string = op === 'set' || op === 'delete'
-    ? 'apps:storage:write'
-    : 'apps:storage:read';
   if (!Array.isArray(claims.scopes) || !claims.scopes.includes(requiredScope)) {
     appStorageOpsCounter.inc({ op, outcome: 'unauthorized' });
     throw new TRPCError({
@@ -153,8 +204,10 @@ async function resolveStorageContext(blockToken: string, op: StorageOp): Promise
   return {
     userId,
     slug,
+    schema: appSchemaIdent(slug),
     appBlockId: block.id,
     blockInstanceId: claims.blockInstanceId,
+    reviewPreview: false,
   };
 }
 
@@ -177,7 +230,7 @@ export const appsStorageRouter = router({
     .query(async ({ input }) => {
       const stopTimer = appStorageLatencyHistogram.startTimer({ op: 'get' });
       try {
-        const { userId, slug, blockInstanceId } = await resolveStorageContext(
+        const { userId, schema, blockInstanceId } = await resolveStorageContext(
           input.blockToken,
           'get'
         );
@@ -188,7 +241,7 @@ export const appsStorageRouter = router({
         const pool = requireAppsDb();
         const rows = (
           await pool.query<{ value: unknown }>(
-            `SELECT value FROM ${appSchemaIdent(slug)}.kv
+            `SELECT value FROM ${schema}.kv
                WHERE block_instance_id = $1 AND user_id = $2 AND key = $3`,
             [blockInstanceId, userId, input.key]
           )
@@ -221,7 +274,7 @@ export const appsStorageRouter = router({
     .mutation(async ({ input }) => {
       const stopTimer = appStorageLatencyHistogram.startTimer({ op: 'set' });
       try {
-      const { userId, slug, appBlockId, blockInstanceId } = await resolveStorageContext(
+      const { userId, schema, appBlockId, blockInstanceId } = await resolveStorageContext(
         input.blockToken,
         'set'
       );
@@ -244,7 +297,6 @@ export const appsStorageRouter = router({
       }
 
       const pool = requireAppsDb();
-      const schema = appSchemaIdent(slug);
 
       // Pre-flight quota read. used_bytes already reflects all previous
       // writes through the trigger. Worst case the gate is one write
@@ -370,7 +422,7 @@ export const appsStorageRouter = router({
     .mutation(async ({ input }) => {
       const stopTimer = appStorageLatencyHistogram.startTimer({ op: 'delete' });
       try {
-        const { userId, slug, appBlockId, blockInstanceId } = await resolveStorageContext(
+        const { userId, schema, appBlockId, blockInstanceId } = await resolveStorageContext(
           input.blockToken,
           'delete'
         );
@@ -382,7 +434,6 @@ export const appsStorageRouter = router({
           });
         }
         const pool = requireAppsDb();
-        const schema = appSchemaIdent(slug);
         const client = await pool.connect();
         try {
           await client.query('BEGIN');
@@ -455,7 +506,7 @@ export const appsStorageRouter = router({
     .query(async ({ input }) => {
       const stopTimer = appStorageLatencyHistogram.startTimer({ op: 'list' });
       try {
-        const { userId, slug, blockInstanceId } = await resolveStorageContext(
+        const { userId, schema, blockInstanceId } = await resolveStorageContext(
           input.blockToken,
           'list'
         );
@@ -474,7 +525,7 @@ export const appsStorageRouter = router({
 
         const rows = (
           await pool.query<{ key: string; updated_at: Date }>(
-            `SELECT key, updated_at FROM ${appSchemaIdent(slug)}.kv
+            `SELECT key, updated_at FROM ${schema}.kv
                WHERE block_instance_id = $1 AND user_id = $2
                  AND key LIKE $3 ESCAPE '\\'
                  AND key > $4
@@ -510,8 +561,28 @@ export const appsStorageRouter = router({
     .query(async ({ input }) => {
       const stopTimer = appStorageLatencyHistogram.startTimer({ op: 'getQuota' });
       try {
-        const { slug, appBlockId } = await resolveStorageContext(input.blockToken, 'getQuota');
-        const quota = await AppStorageProvisioner.getQuota({ slug, appBlockId });
+        const { slug, schema, appBlockId, reviewPreview } = await resolveStorageContext(
+          input.blockToken,
+          'getQuota'
+        );
+        let quota: { usedBytes: number; rowCount: number } | null;
+        if (reviewPreview) {
+          // Read the preview schema's own quota row directly (the schema is
+          // provisioned by resolveStorageContext, so it always exists here).
+          const pool = requireAppsDb();
+          const rows = (
+            await pool.query<{ used_bytes: string; row_count: string }>(
+              `SELECT used_bytes::text, row_count::text FROM ${schema}.quota WHERE app_block_id = $1`,
+              [appBlockId]
+            )
+          ).rows;
+          quota = {
+            usedBytes: Number(rows[0]?.used_bytes ?? '0'),
+            rowCount: Number(rows[0]?.row_count ?? '0'),
+          };
+        } else {
+          quota = await AppStorageProvisioner.getQuota({ slug, appBlockId });
+        }
         appStorageOpsCounter.inc({ op: 'getQuota', outcome: 'ok' });
         return {
           usedBytes: quota?.usedBytes ?? 0,

--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -10,7 +10,12 @@ import { dbRead, dbWrite } from '~/server/db/client';
 import { FORGEJO_ORG } from '~/server/services/blocks/forgejo.service';
 import { logToAxiom } from '~/server/logging/client';
 import { getOrchestratorToken } from '~/server/orchestrator/get-orchestrator-token';
-import { parseSubjectUserId, verifyBlockToken } from '~/server/middleware/block-scope.middleware';
+import {
+  parseSubjectUserId,
+  verifyBlockToken,
+  type BlockTokenClaims,
+} from '~/server/middleware/block-scope.middleware';
+import { REVIEW_RUN_FOR_REAL_BUZZ_CAP } from '~/shared/constants/block-scope.constants';
 import { REDIS_SYS_KEYS, sysRedis } from '~/server/redis/client';
 import { dailyBoostReward } from '~/server/rewards/active/dailyBoost.reward';
 import {
@@ -679,13 +684,100 @@ async function reserveBlockBuzzSpend(
  * value and handing the user a window of extra cap headroom. Pinning the key
  * eliminates that race.
  */
-async function refundBlockBuzzSpend(
-  key: ReturnType<typeof buzzCapRedisKey>,
-  cost: number
-): Promise<void> {
+async function refundBlockBuzzSpend(key: string, cost: number): Promise<void> {
   await sysRedis.decrBy(key, Math.ceil(cost)).catch(() => {
     /* best-effort — see note above; a lost refund over-counts (stricter cap) */
   });
+}
+
+// ---- MOD REVIEW SANDBOX "run for real" AGGREGATE Buzz cap (#2831) ----------
+//
+// When a moderator opts IN (consent-gated) to run an UNAPPROVED review app FOR
+// REAL against their OWN account, the token's per-call `buzzBudget` bounds ONE
+// submit — but a hostile app can loop many ≤budget submits (the exact hole the
+// per-user daily cap comment above describes). This is the run-for-real analog:
+// a per-(mod, publishRequestId) CUMULATIVE ceiling (REVIEW_RUN_FOR_REAL_BUZZ_CAP),
+// swapped IN PLACE OF the ordinary per-user daily cap for a run-for-real token so
+// there is still exactly ONE reserve/refund path per submit (the whole refund
+// choreography below keys off the returned `key`, so it works unchanged).
+//
+// The key binds to (mod, publishRequestId) — NOT the token jti — so re-minting /
+// re-confirming the consent CANNOT reset the ceiling within the window. It is
+// STRICTLY TIGHTER than the 50k/day cap, so it is the binding constraint; the
+// mod's OWN non-review block usage still counts against the daily key separately.
+const REVIEW_RUN_FOR_REAL_BUZZ_CAP_TTL_SECONDS = 25 * 60 * 60;
+
+function reviewRunForRealBuzzCapKey(
+  userId: number,
+  publishRequestId: string
+): `${typeof REDIS_SYS_KEYS.BLOCKS.REVIEW_RUN_FOR_REAL_BUZZ_CAP}:${string}` {
+  return `${REDIS_SYS_KEYS.BLOCKS.REVIEW_RUN_FOR_REAL_BUZZ_CAP}:${userId}:${publishRequestId}`;
+}
+
+/**
+ * Atomically reserves `cost` against the (mod, publishRequestId) run-for-real
+ * cumulative counter. Identical atomic INCRBY + first-write-EX (+ ttl<0 re-arm)
+ * shape as `reserveBlockBuzzSpend`; fails CLOSED on a Redis error (throws).
+ */
+async function reserveReviewRunForRealBuzzSpend(
+  userId: number,
+  publishRequestId: string,
+  cost: number
+): Promise<{ total: number; key: ReturnType<typeof reviewRunForRealBuzzCapKey> }> {
+  const key = reviewRunForRealBuzzCapKey(userId, publishRequestId);
+  const total = await sysRedis.incrBy(key, Math.ceil(cost));
+  if (total <= Math.ceil(cost)) {
+    await sysRedis.expire(key, REVIEW_RUN_FOR_REAL_BUZZ_CAP_TTL_SECONDS);
+  } else {
+    const ttl = await sysRedis.ttl(key);
+    if (ttl < 0) await sysRedis.expire(key, REVIEW_RUN_FOR_REAL_BUZZ_CAP_TTL_SECONDS);
+  }
+  return { total, key };
+}
+
+/**
+ * Picks the correct cumulative Buzz reservation for a submit given its verified
+ * token claims: a RUN-FOR-REAL token (signed `reviewRunForReal:true`) reserves
+ * against the tight per-(mod, publishRequestId) session ceiling; every other
+ * token keeps the ordinary per-user daily cap — BYTE-IDENTICAL to before. Returns
+ * the reserved `key` (all refund sites key off it) plus the `cap` to compare the
+ * running `total` against. The run-for-real session id is the token's
+ * `appBlockId` claim (the `pubreq_<ULID>` request id the mint stamps).
+ */
+async function reserveBlockBuzzSpendForClaims(
+  claims: BlockTokenClaims,
+  userId: number,
+  cost: number
+): Promise<{ total: number; key: string; cap: number }> {
+  if (claims.reviewRunForReal === true) {
+    const { total, key } = await reserveReviewRunForRealBuzzSpend(userId, claims.appBlockId, cost);
+    return { total, key, cap: REVIEW_RUN_FOR_REAL_BUZZ_CAP };
+  }
+  const { total, key } = await reserveBlockBuzzSpend(userId, cost);
+  return { total, key, cap: BLOCK_BUZZ_CAP_PER_DAY };
+}
+
+// RUN-FOR-REAL mint rate limit — per-mod fixed window. A privileged,
+// money-touching opt-in (each accept re-mints a spend-capable token), so bound
+// the mint rate to blunt an account-compromise / runaway-client storm. Same
+// INCR + first-hit EX (+ ttl<0 self-heal) shape as the other BLOCKS limiters;
+// fails CLOSED (returns false) on a Redis error.
+const REVIEW_RUN_FOR_REAL_MINT_RATE_LIMIT = { max: 30, windowSeconds: 3600 } as const;
+
+async function checkReviewRunForRealMintRateLimit(userId: number): Promise<boolean> {
+  const key = `${REDIS_SYS_KEYS.BLOCKS.REVIEW_RUN_FOR_REAL_BUZZ_CAP}:mint-rate:${userId}` as const;
+  try {
+    const count = await sysRedis.incrBy(key, 1);
+    if (count === 1) {
+      await sysRedis.expire(key, REVIEW_RUN_FOR_REAL_MINT_RATE_LIMIT.windowSeconds);
+    } else {
+      const ttl = await sysRedis.ttl(key);
+      if (ttl < 0) await sysRedis.expire(key, REVIEW_RUN_FOR_REAL_MINT_RATE_LIMIT.windowSeconds);
+    }
+    return count <= REVIEW_RUN_FOR_REAL_MINT_RATE_LIMIT.max;
+  } catch {
+    return false;
+  }
 }
 
 // EPHEMERAL DEV-TUNNEL rate limit (Phase 1 pre-submit). Per-user fixed window,
@@ -1478,15 +1570,30 @@ export const blocksRouter = router({
       if (!(await isAppBlocksReviewSandboxEnabled({ user: ctx.user }))) {
         throw throwAuthorizationError('The review sandbox is not enabled');
       }
+      // RUN-FOR-REAL rate limit — a privileged, money-touching opt-in. Bound how
+      // many run-for-real re-mints one mod can trigger per window (blunts an
+      // account-compromise / runaway-client mint storm). Only the run-for-real
+      // path is limited; the ordinary render-only mint is unaffected.
+      if (input.runForReal) {
+        const allowed = await checkReviewRunForRealMintRateLimit(ctx.user.id);
+        if (!allowed) {
+          throw new TRPCError({
+            code: 'TOO_MANY_REQUESTS',
+            message: 'run-for-real mint rate limit reached — please wait a moment and retry',
+          });
+        }
+      }
       const { mintReviewBlockToken } = await import(
         '~/server/services/blocks/publish-request.service'
       );
       try {
         // The mod id is SERVER-derived (never client-supplied) so the token can
-        // only ever be self-bound to the calling moderator.
+        // only ever be self-bound to the calling moderator. `runForReal` is the
+        // mod's explicit, consent-gated opt-in (default false → render-only).
         return await mintReviewBlockToken({
           publishRequestId: input.publishRequestId,
           modUserId: ctx.user.id,
+          runForReal: input.runForReal,
         });
       } catch (err) {
         throw new TRPCError({ code: 'BAD_REQUEST', message: (err as Error).message });
@@ -3714,18 +3821,29 @@ export const blocksRouter = router({
       // record (no separate fire-and-forget incr that could silently drop and
       // under-count). A Redis error on the reserve throws → fails CLOSED,
       // matching the old read path.
-      const { total, key: buzzCapKey } = await reserveBlockBuzzSpend(userId, cost);
-      if (total > BLOCK_BUZZ_CAP_PER_DAY) {
+      // A RUN-FOR-REAL review token reserves against the tight per-(mod,
+      // publishRequestId) session ceiling instead of the per-user daily cap
+      // (reserveBlockBuzzSpendForClaims picks the right one; every refund site
+      // below keys off the returned `buzzCapKey`, so they work unchanged).
+      const {
+        total,
+        key: buzzCapKey,
+        cap: buzzCap,
+      } = await reserveBlockBuzzSpendForClaims(claims, userId, cost);
+      if (total > buzzCap) {
         await refundBlockBuzzSpend(buzzCapKey, cost);
         return {
           snapshot: {
             workflowId: 'failed',
             status: 'failed' as const,
             cost: { total: cost },
-            error:
-              `daily Buzz cap reached: ${total - Math.ceil(cost)} already spent today ` +
-              `across your installed apps, this generation costs ${cost}, ` +
-              `daily cap is ${BLOCK_BUZZ_CAP_PER_DAY}`,
+            error: claims.reviewRunForReal === true
+              ? `review run-for-real Buzz cap reached: ${total - Math.ceil(cost)} already ` +
+                `spent this review session, this generation costs ${cost}, ` +
+                `session cap is ${buzzCap}`
+              : `daily Buzz cap reached: ${total - Math.ceil(cost)} already spent today ` +
+                `across your installed apps, this generation costs ${cost}, ` +
+                `daily cap is ${buzzCap}`,
           },
         };
       }
@@ -5505,20 +5623,29 @@ async function submitCustomComfyWorkflow(opts: {
     };
   }
 
-  // (2) Reserve the CEILING (not the 0 estimate) against the per-user daily cap so
-  // post-paid spend can't slip past the 50k/day ceiling counted at ~0.
-  const { total, key: buzzCapKey } = await reserveBlockBuzzSpend(userId, ceiling);
-  if (total > BLOCK_BUZZ_CAP_PER_DAY) {
+  // (2) Reserve the CEILING (not the 0 estimate) against the cumulative cap so
+  // post-paid spend can't slip past it counted at ~0. A RUN-FOR-REAL review token
+  // reserves against the tight per-(mod, publishRequestId) session ceiling; every
+  // other token keeps the per-user 50k/day cap (byte-identical).
+  const {
+    total,
+    key: buzzCapKey,
+    cap: buzzCap,
+  } = await reserveBlockBuzzSpendForClaims(claims, userId, ceiling);
+  if (total > buzzCap) {
     await refundBlockBuzzSpend(buzzCapKey, ceiling);
     return {
       snapshot: {
         workflowId: 'failed',
         status: 'failed' as const,
         cost: { total: ceiling },
-        error:
-          `daily Buzz cap reached: ${total - Math.ceil(ceiling)} already spent today ` +
-          `across your installed apps, this generation may cost up to ${ceiling}, ` +
-          `daily cap is ${BLOCK_BUZZ_CAP_PER_DAY}`,
+        error: claims.reviewRunForReal === true
+          ? `review run-for-real Buzz cap reached: ${total - Math.ceil(ceiling)} already ` +
+            `spent this review session, this generation may cost up to ${ceiling}, ` +
+            `session cap is ${buzzCap}`
+          : `daily Buzz cap reached: ${total - Math.ceil(ceiling)} already spent today ` +
+            `across your installed apps, this generation may cost up to ${ceiling}, ` +
+            `daily cap is ${buzzCap}`,
       },
     };
   }

--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -702,9 +702,11 @@ async function refundBlockBuzzSpend(key: string, cost: number): Promise<void> {
 // choreography below keys off the returned `key`, so it works unchanged).
 //
 // The key binds to (mod, publishRequestId) — NOT the token jti — so re-minting /
-// re-confirming the consent CANNOT reset the ceiling within the window. It is
-// STRICTLY TIGHTER than the 50k/day cap, so it is the binding constraint; the
-// mod's OWN non-review block usage still counts against the daily key separately.
+// re-confirming the consent CANNOT reset the ceiling within the window. Window =
+// the key's 25h TTL (re-armed on first write): the ceiling is cumulative per
+// (mod, publishRequestId) over a rolling ~25h, NOT reset per submit or per mint.
+// It is STRICTLY TIGHTER than the 50k/day cap, so it is the binding constraint;
+// the mod's OWN non-review block usage still counts against the daily key separately.
 const REVIEW_RUN_FOR_REAL_BUZZ_CAP_TTL_SECONDS = 25 * 60 * 60;
 
 function reviewRunForRealBuzzCapKey(
@@ -738,11 +740,12 @@ async function reserveReviewRunForRealBuzzSpend(
 /**
  * Picks the correct cumulative Buzz reservation for a submit given its verified
  * token claims: a RUN-FOR-REAL token (signed `reviewRunForReal:true`) reserves
- * against the tight per-(mod, publishRequestId) session ceiling; every other
- * token keeps the ordinary per-user daily cap — BYTE-IDENTICAL to before. Returns
- * the reserved `key` (all refund sites key off it) plus the `cap` to compare the
- * running `total` against. The run-for-real session id is the token's
- * `appBlockId` claim (the `pubreq_<ULID>` request id the mint stamps).
+ * against the tight per-(mod, publishRequestId) cumulative ceiling (rolling ~25h
+ * window); every other token keeps the ordinary per-user daily cap —
+ * BYTE-IDENTICAL to before. Returns the reserved `key` (all refund sites key off
+ * it) plus the `cap` to compare the running `total` against. The run-for-real
+ * reservation id is the token's `appBlockId` claim (the `pubreq_<ULID>` request id
+ * the mint stamps).
  */
 async function reserveBlockBuzzSpendForClaims(
   claims: BlockTokenClaims,
@@ -3822,9 +3825,9 @@ export const blocksRouter = router({
       // under-count). A Redis error on the reserve throws → fails CLOSED,
       // matching the old read path.
       // A RUN-FOR-REAL review token reserves against the tight per-(mod,
-      // publishRequestId) session ceiling instead of the per-user daily cap
-      // (reserveBlockBuzzSpendForClaims picks the right one; every refund site
-      // below keys off the returned `buzzCapKey`, so they work unchanged).
+      // publishRequestId) cumulative ceiling (rolling ~25h window) instead of the
+      // per-user daily cap (reserveBlockBuzzSpendForClaims picks the right one;
+      // every refund site below keys off the returned `buzzCapKey`, unchanged).
       const {
         total,
         key: buzzCapKey,

--- a/src/server/schema/blocks/publish-request.schema.ts
+++ b/src/server/schema/blocks/publish-request.schema.ts
@@ -158,6 +158,15 @@ export type GetReviewStatusInput = z.infer<typeof getReviewStatusSchema>;
  *  host handshakes with. Same shape as previewRequest (the pending request id). */
 export const mintReviewBlockTokenSchema = z.object({
   publishRequestId: z.string().min(1).max(64),
+  /**
+   * MOD REVIEW SANDBOX "run for real" (#2831). Default false → the render-only
+   * sandbox (byte-identical to today). When true, the mod has EXPLICITLY opted in
+   * (behind a loud client consent gate) to run the unapproved app for real against
+   * their OWN account; the server re-mints a wider, still-clamped, still-self-bound,
+   * still-forced-SFW token with a per-call budget + an aggregate session Buzz cap.
+   * The opt-in is authorized + rate-limited server-side regardless of this flag.
+   */
+  runForReal: z.boolean().optional().default(false),
 });
 
 export type MintReviewBlockTokenInput = z.infer<typeof mintReviewBlockTokenSchema>;

--- a/src/server/services/__tests__/block-token.service.test.ts
+++ b/src/server/services/__tests__/block-token.service.test.ts
@@ -72,6 +72,43 @@ describe('BlockTokenService.sign — JWT round-trip', () => {
     expect(payload.buzzBudget).toBe(200);
   });
 
+  it('stamps reviewRunForReal:true ONLY when supplied (absent otherwise)', async () => {
+    const { BlockTokenService } = await import('../block-token.service');
+    const withFlag = await BlockTokenService.sign({
+      userId: 1,
+      blockId: 'b',
+      appId: 'a',
+      appBlockId: 'apb_a',
+      blockInstanceId: 'bki',
+      scopes: ['ai:write:budgeted'],
+      ctx: {},
+      buzzBudget: 50,
+      dev: true,
+      reviewRunForReal: true,
+    });
+    const withoutFlag = await BlockTokenService.sign({
+      userId: 1,
+      blockId: 'b',
+      appId: 'a',
+      appBlockId: 'apb_a',
+      blockInstanceId: 'bki',
+      scopes: ['user:read:self'],
+      ctx: {},
+    });
+    const { payload: withPayload } = await jwtVerify(withFlag.token, publicKey, {
+      issuer: 'civitai',
+      audience: 'civitai-app-block',
+      algorithms: ['RS256'],
+    });
+    const { payload: withoutPayload } = await jwtVerify(withoutFlag.token, publicKey, {
+      issuer: 'civitai',
+      audience: 'civitai-app-block',
+      algorithms: ['RS256'],
+    });
+    expect(withPayload.reviewRunForReal).toBe(true);
+    expect(withoutPayload.reviewRunForReal).toBeUndefined();
+  });
+
   it('stamps maxBrowsingLevel + domain claims when supplied (SFW domain)', async () => {
     const { BlockTokenService } = await import('../block-token.service');
     const r = await BlockTokenService.sign({

--- a/src/server/services/apps/__tests__/storage-provision.service.test.ts
+++ b/src/server/services/apps/__tests__/storage-provision.service.test.ts
@@ -165,6 +165,73 @@ describe('AppStorageProvisioner.deprovision', () => {
   });
 });
 
+describe('AppStorageProvisioner.provisionReviewPreview (#2831)', () => {
+  it('rejects an invalid publishRequestId before touching the pool', async () => {
+    await expect(
+      AppStorageProvisioner.provisionReviewPreview({ publishRequestId: '!!' })
+    ).rejects.toThrow(/invalid publishRequestId/);
+    expect(mockPool.connect).not.toHaveBeenCalled();
+  });
+
+  it('provisions the DISPOSABLE apprev_ schema (per-user KV only) keyed on the publishRequestId', async () => {
+    // Default mockPool.query → schema does not exist → the DDL runs.
+    const { schema } = await AppStorageProvisioner.provisionReviewPreview({
+      publishRequestId: 'pubreq_abc',
+    });
+    expect(schema).toBe('"apprev_pubreqabc"');
+    const sqls = capturedQueries.map((q) => q.sql);
+    expect(sqls.some((s) => s.startsWith('BEGIN'))).toBe(true);
+    expect(sqls.some((s) => s.startsWith('COMMIT'))).toBe(true);
+    expect(sqls.some((s) => s.includes('CREATE SCHEMA IF NOT EXISTS "apprev_pubreqabc"'))).toBe(true);
+    expect(sqls.some((s) => s.includes('CREATE TABLE IF NOT EXISTS "apprev_pubreqabc".kv'))).toBe(true);
+    expect(sqls.some((s) => s.includes('"apprev_pubreqabc".quota'))).toBe(true);
+    expect(sqls.some((s) => s.includes('kv_quota_trigger'))).toBe(true);
+    // The quota seed row is keyed on the publishRequestId. Read the args from
+    // mock.calls (records the real 2nd arg regardless of any leaked impl).
+    const seedCall = mockClient.query.mock.calls.find(
+      (c) => String(c[0]).includes('INSERT INTO') && String(c[0]).includes('.quota')
+    );
+    expect(String(seedCall?.[0])).toContain('"apprev_pubreqabc".quota');
+    expect(seedCall?.[1]).toEqual(['pubreq_abc']);
+    // NEVER the approved app schema, and NEVER the cross-user / role surfaces.
+    expect(sqls.some((s) => s.includes('"app_'))).toBe(false);
+    expect(sqls.some((s) => s.includes('shared_kv'))).toBe(false);
+    expect(sqls.some((s) => s.includes('votes'))).toBe(false);
+    expect(sqls.some((s) => s.includes('CREATE ROLE'))).toBe(false);
+    expect(mockClient.release).toHaveBeenCalledOnce();
+  });
+
+  it('FAST-PATHs (no DDL) when the preview schema already exists', async () => {
+    mockPool.query.mockResolvedValueOnce({ rows: [{ exists: true }], rowCount: 1 });
+    const { schema } = await AppStorageProvisioner.provisionReviewPreview({
+      publishRequestId: 'pubreq_abc',
+    });
+    expect(schema).toBe('"apprev_pubreqabc"');
+    // Existing schema → the DDL transaction is skipped entirely.
+    expect(mockPool.connect).not.toHaveBeenCalled();
+    expect(capturedQueries).toHaveLength(0);
+  });
+});
+
+describe('AppStorageProvisioner.deprovisionReviewPreview (#2831)', () => {
+  it('rejects an invalid publishRequestId', async () => {
+    await expect(
+      AppStorageProvisioner.deprovisionReviewPreview({ publishRequestId: '!!' })
+    ).rejects.toThrow(/invalid publishRequestId/);
+    expect(mockPool.query).not.toHaveBeenCalled();
+  });
+
+  it('DROPs the disposable preview schema CASCADE (no role to reclaim)', async () => {
+    await AppStorageProvisioner.deprovisionReviewPreview({ publishRequestId: 'pubreq_abc' });
+    const poolSqls = mockPool.query.mock.calls.map((c) => String(c[0]));
+    expect(poolSqls.some((s) => s.includes('DROP SCHEMA IF EXISTS "apprev_pubreqabc" CASCADE'))).toBe(
+      true
+    );
+    // A preview schema has no per-app role.
+    expect(poolSqls.some((s) => s.includes('DROP ROLE'))).toBe(false);
+  });
+});
+
 describe('AppStorageProvisioner.getQuota', () => {
   it('returns null when the schema has not been provisioned', async () => {
     mockPool.query.mockResolvedValueOnce({ rows: [{ exists: false }], rowCount: 1 });

--- a/src/server/services/apps/storage-provision.service.ts
+++ b/src/server/services/apps/storage-provision.service.ts
@@ -22,6 +22,8 @@ import {
   appRoleIdent,
   appSchemaIdent,
   isValidAppSlug,
+  normalizeReviewPreviewId,
+  reviewPreviewSchemaIdent,
 } from '~/server/utils/apps-slug';
 
 export type ProvisionOpts = {
@@ -247,6 +249,154 @@ export const AppStorageProvisioner = {
     } finally {
       client.release();
     }
+  },
+
+  /**
+   * MOD REVIEW SANDBOX "run for real" (#2831) — provision the DISPOSABLE,
+   * per-publishRequest PREVIEW storage schema so a moderator can exercise a
+   * PENDING app's per-user storage for real without an approved AppBlock row.
+   *
+   * ISOLATION (the whole point):
+   *   - keyed on the publishRequestId → per-pending-app isolated (app A's
+   *     `apprev_<A>` schema is unreachable from app B's `apprev_<B>`);
+   *   - the `apprev_` prefix can NEVER alias a production `app_<slug>` schema, so
+   *     preview writes NEVER pollute the eventual approved app's namespace;
+   *   - DISPOSABLE — dropped by `deprovisionReviewPreview` on approve/reject teardown.
+   *
+   * Deliberately a MINIMAL subset of `provision()`: only the PER-USER `kv` path
+   * (schema + kv + indexes + quota + trigger + seed). It creates NO shared_kv /
+   * votes / counters (cross-user surfaces are never granted in run-for-real) and
+   * NO per-app role (kv ops run via the pool user, same as the approved path).
+   * Fast-paths on an already-existing schema so repeated ops in one review
+   * session skip the DDL. The quota row is keyed on the publishRequestId (matches
+   * the token's `appBlockId` claim, which the storage ops use as the GUC).
+   */
+  async provisionReviewPreview({
+    publishRequestId,
+  }: {
+    publishRequestId: string;
+  }): Promise<{ schema: string }> {
+    const norm = normalizeReviewPreviewId(publishRequestId);
+    if (norm === null) {
+      throw new Error(
+        `AppStorageProvisioner.provisionReviewPreview: invalid publishRequestId ${JSON.stringify(
+          publishRequestId
+        )}`
+      );
+    }
+    const schema = reviewPreviewSchemaIdent(publishRequestId); // "apprev_<norm>"
+    const pool = requireAppsDb();
+
+    // Fast path — skip the DDL transaction entirely once the preview schema
+    // exists (a review session issues many storage ops against the same schema).
+    const existing = await pool.query<{ exists: boolean }>(
+      `SELECT EXISTS (SELECT 1 FROM information_schema.schemata WHERE schema_name = $1) AS exists`,
+      [`apprev_${norm}`]
+    );
+    if (existing.rows[0]?.exists) return { schema };
+
+    const client = await pool.connect();
+    try {
+      await client.query('BEGIN');
+      await client.query(`CREATE SCHEMA IF NOT EXISTS ${schema}`);
+      // Mirrors ${schema}.kv in provision() (per-user store only).
+      await client.query(`
+        CREATE TABLE IF NOT EXISTS ${schema}.kv (
+          block_instance_id text NOT NULL,
+          user_id integer NOT NULL,
+          key text NOT NULL,
+          value jsonb NOT NULL,
+          size_bytes integer GENERATED ALWAYS AS (octet_length(value::text)) STORED,
+          created_at timestamptz DEFAULT now() NOT NULL,
+          updated_at timestamptz DEFAULT now() NOT NULL,
+          PRIMARY KEY (block_instance_id, user_id, key)
+        )
+      `);
+      await client.query(
+        `CREATE INDEX IF NOT EXISTS kv_user_idx ON ${schema}.kv (user_id, block_instance_id)`
+      );
+      await client.query(
+        `CREATE INDEX IF NOT EXISTS kv_updated_idx ON ${schema}.kv (updated_at)`
+      );
+      await client.query(`
+        CREATE TABLE IF NOT EXISTS ${schema}.quota (
+          app_block_id text PRIMARY KEY,
+          used_bytes bigint NOT NULL DEFAULT 0,
+          row_count bigint NOT NULL DEFAULT 0,
+          updated_at timestamptz DEFAULT now() NOT NULL
+        )
+      `);
+      // Same quota trigger as provision() — folds preview bytes/rows into the
+      // preview schema's own quota row (keyed on the publishRequestId GUC).
+      await client.query(`
+        CREATE OR REPLACE FUNCTION ${schema}.kv_quota_trigger() RETURNS trigger AS $fn$
+        DECLARE
+          v_app_block_id text := current_setting('app.current_app_block_id', true);
+        BEGIN
+          IF v_app_block_id IS NULL OR v_app_block_id = '' THEN
+            RETURN NULL;
+          END IF;
+          IF TG_OP = 'INSERT' THEN
+            UPDATE ${schema}.quota
+               SET used_bytes = used_bytes + NEW.size_bytes,
+                   row_count  = row_count + 1,
+                   updated_at = now()
+             WHERE app_block_id = v_app_block_id;
+          ELSIF TG_OP = 'UPDATE' THEN
+            UPDATE ${schema}.quota
+               SET used_bytes = used_bytes + (NEW.size_bytes - OLD.size_bytes),
+                   updated_at = now()
+             WHERE app_block_id = v_app_block_id;
+          ELSIF TG_OP = 'DELETE' THEN
+            UPDATE ${schema}.quota
+               SET used_bytes = used_bytes - OLD.size_bytes,
+                   row_count  = row_count - 1,
+                   updated_at = now()
+             WHERE app_block_id = v_app_block_id;
+          END IF;
+          RETURN NULL;
+        END $fn$ LANGUAGE plpgsql
+      `);
+      await client.query(`DROP TRIGGER IF EXISTS kv_quota_trg ON ${schema}.kv`);
+      await client.query(`
+        CREATE TRIGGER kv_quota_trg
+        AFTER INSERT OR UPDATE OR DELETE ON ${schema}.kv
+        FOR EACH ROW EXECUTE FUNCTION ${schema}.kv_quota_trigger()
+      `);
+      await client.query(
+        `INSERT INTO ${schema}.quota (app_block_id) VALUES ($1) ON CONFLICT (app_block_id) DO NOTHING`,
+        [publishRequestId]
+      );
+      await client.query('COMMIT');
+    } catch (err) {
+      await client.query('ROLLBACK').catch(() => {});
+      throw err;
+    } finally {
+      client.release();
+    }
+    return { schema };
+  },
+
+  /**
+   * Drop a DISPOSABLE preview schema (run-for-real teardown, #2831). Best-effort;
+   * safe to call for a request that never used preview storage (IF EXISTS). No
+   * role is created for a preview schema, so there is nothing else to reclaim.
+   */
+  async deprovisionReviewPreview({
+    publishRequestId,
+  }: {
+    publishRequestId: string;
+  }): Promise<void> {
+    if (normalizeReviewPreviewId(publishRequestId) === null) {
+      throw new Error(
+        `AppStorageProvisioner.deprovisionReviewPreview: invalid publishRequestId ${JSON.stringify(
+          publishRequestId
+        )}`
+      );
+    }
+    const schema = reviewPreviewSchemaIdent(publishRequestId);
+    const pool = requireAppsDb();
+    await pool.query(`DROP SCHEMA IF EXISTS ${schema} CASCADE`);
   },
 
   /**

--- a/src/server/services/block-token.service.ts
+++ b/src/server/services/block-token.service.ts
@@ -188,6 +188,20 @@ export interface SignBlockTokenInput {
    * (900s, or 300s for settings scopes).
    */
   dev?: boolean;
+  /**
+   * MOD REVIEW SANDBOX "run for real" marker (#2831). Set ONLY by
+   * `mintReviewBlockToken({ runForReal: true })` — a moderator's explicit,
+   * consent-gated opt-in to run an UNAPPROVED review app FOR REAL against their
+   * OWN account. When true a `reviewRunForReal: true` claim is stamped so the
+   * runtime spend paths (submitWorkflow / customComfy) enforce the TIGHT
+   * per-(mod, publishRequestId) AGGREGATE Buzz ceiling
+   * (`REVIEW_RUN_FOR_REAL_BUZZ_CAP`) rather than the ordinary per-user daily cap.
+   * Only trustworthy because the RS256 signature is verified before the claim is
+   * read (a forged `reviewRunForReal:true` can't pass the signature gate). Does
+   * NOT change the token lifetime (run-for-real tokens are also `dev:true`).
+   * Absent/false → byte-identical to a normal token (no claim stamped).
+   */
+  reviewRunForReal?: boolean;
 }
 
 export interface SignBlockTokenResult {
@@ -265,6 +279,13 @@ export class BlockTokenService {
     // true so a non-dev token never carries the claim (absent → 15min cap).
     if (input.dev === true) {
       claims.dev = true;
+    }
+    // RUN-FOR-REAL marker — stamped ONLY for a mod's consent-gated review
+    // run-for-real token. Read (after signature validation) by the runtime spend
+    // paths to select the tight per-(mod, publishRequestId) aggregate Buzz cap.
+    // Stamped only when explicitly true so a normal token never carries it.
+    if (input.reviewRunForReal === true) {
+      claims.reviewRunForReal = true;
     }
 
     const token = await new SignJWT(claims)

--- a/src/server/services/blocks/__tests__/dev-scoped-mint.service.test.ts
+++ b/src/server/services/blocks/__tests__/dev-scoped-mint.service.test.ts
@@ -39,6 +39,7 @@ import {
   parseManifestBuzzBudget,
   resolveDevBuzzBudget,
   REVIEW_MINT_SCOPE_ALLOWLIST,
+  REVIEW_RUN_FOR_REAL_MINT_SCOPE_ALLOWLIST,
   signDevScopedPageToken,
   TUNNEL_HOST_MINT_SCOPE_ALLOWLIST,
 } from '~/server/services/blocks/dev-scoped-mint.service';
@@ -270,6 +271,112 @@ describe('clampDevScopes — REVIEW_MINT_SCOPE_ALLOWLIST (mod review sandbox #28
       allowlist: REVIEW_MINT_SCOPE_ALLOWLIST,
     });
     expect(granted).toEqual(['user:read:self']);
+  });
+});
+
+describe('clampDevScopes — REVIEW_RUN_FOR_REAL_MINT_SCOPE_ALLOWLIST (mod opt-in #2831)', () => {
+  // The SAME malicious manifest — now clamped through the WIDER run-for-real belt.
+  const MALICIOUS_MANIFEST_SCOPES = [
+    'models:read:self',
+    'media:read:owned', // removed decorative scope — unknown → stripped
+    'collections:read:self',
+    'ai:write:budgeted',
+    'apps:storage:read',
+    'apps:storage:write',
+    'apps:storage:shared:read',
+    'apps:storage:shared:write',
+    'collections:read:private',
+    'collections:write:self',
+    'social:tip:self',
+    'buzz:read:self',
+  ];
+
+  it('grants ONLY declared ∩ allowlist — spend + own storage + own buzz survive, cross-user/private/money-out do NOT', () => {
+    const granted = clampDevScopes({
+      scopeSource: MALICIOUS_MANIFEST_SCOPES,
+      oauthAllowed: null, // pending app — no OauthClient
+      keyCanSpend: true, // run-for-real spends the mod's OWN Buzz
+      allowlist: REVIEW_RUN_FOR_REAL_MINT_SCOPE_ALLOWLIST,
+    });
+    expect(granted).toEqual([
+      'ai:write:budgeted',
+      'apps:storage:read',
+      'apps:storage:write',
+      'buzz:read:self',
+      'collections:read:self',
+      'models:read:self',
+      'user:read:self',
+    ]);
+    // Clamp holds against a malicious manifest — none of these can EVER survive.
+    for (const withheld of [
+      'apps:storage:shared:read', // cross-user
+      'apps:storage:shared:write', // cross-user write
+      'collections:read:private', // private
+      'collections:write:self', // write surface
+      'social:tip:self', // money OUT (also PAGE_FORBIDDEN)
+      'media:read:owned', // unknown
+    ]) {
+      expect(granted).not.toContain(withheld);
+    }
+  });
+
+  it('NEVER grants social:tip:self even with keyCanSpend:true (money-OUT excluded by allowlist AND PAGE_FORBIDDEN)', () => {
+    expect(REVIEW_RUN_FOR_REAL_MINT_SCOPE_ALLOWLIST.has('social:tip:self')).toBe(false);
+    const granted = clampDevScopes({
+      scopeSource: ['social:tip:self', 'ai:write:budgeted'],
+      oauthAllowed: null,
+      keyCanSpend: true,
+      allowlist: REVIEW_RUN_FOR_REAL_MINT_SCOPE_ALLOWLIST,
+    });
+    expect(granted).not.toContain('social:tip:self');
+    expect(granted).toContain('ai:write:budgeted');
+  });
+
+  it('keyCanSpend:false STILL strips the spend scope (belt-and-suspenders) even under the wider allowlist', () => {
+    const granted = clampDevScopes({
+      scopeSource: ['ai:write:budgeted', 'models:read:self'],
+      oauthAllowed: null,
+      keyCanSpend: false,
+      allowlist: REVIEW_RUN_FOR_REAL_MINT_SCOPE_ALLOWLIST,
+    });
+    expect(granted).not.toContain('ai:write:budgeted');
+  });
+
+  it('withholds cross-user shared storage the run-for-real allowlist never lists', () => {
+    expect(REVIEW_RUN_FOR_REAL_MINT_SCOPE_ALLOWLIST.has('apps:storage:shared:read')).toBe(false);
+    expect(REVIEW_RUN_FOR_REAL_MINT_SCOPE_ALLOWLIST.has('apps:storage:shared:write')).toBe(false);
+    expect(REVIEW_RUN_FOR_REAL_MINT_SCOPE_ALLOWLIST.has('collections:read:private')).toBe(false);
+  });
+});
+
+describe('signDevScopedPageToken — reviewRunForReal claim (#2831)', () => {
+  it('stamps reviewRunForReal:true ONLY when the flag is set (absent otherwise)', async () => {
+    const withFlag = (await signDevScopedPageToken({
+      userId: 7,
+      signBlockId: 'b',
+      signAppId: 'pending-x',
+      signAppBlockId: 'pubreq_x',
+      blockInstanceId: 'page_x',
+      granted: ['ai:write:budgeted', 'user:read:self'],
+      buzzBudget: 50,
+      reviewRunForReal: true,
+    })) as unknown as { _input: Record<string, unknown> };
+    expect(withFlag._input.reviewRunForReal).toBe(true);
+    // Still self-bound, forced-SFW, dev lifetime.
+    expect(withFlag._input.userId).toBe(7);
+    expect(withFlag._input.maxBrowsingLevel).toBe(FORCED_SFW_CEILING);
+    expect(withFlag._input.dev).toBe(true);
+
+    const withoutFlag = (await signDevScopedPageToken({
+      userId: 7,
+      signBlockId: 'b',
+      signAppId: 'pending-x',
+      signAppBlockId: 'pubreq_x',
+      blockInstanceId: 'page_x',
+      granted: ['user:read:self'],
+      buzzBudget: undefined,
+    })) as unknown as { _input: Record<string, unknown> };
+    expect(withoutFlag._input.reviewRunForReal).toBeUndefined();
   });
 });
 

--- a/src/server/services/blocks/__tests__/dev-scoped-mint.service.test.ts
+++ b/src/server/services/blocks/__tests__/dev-scoped-mint.service.test.ts
@@ -313,14 +313,18 @@ describe('clampDevScopes — REVIEW_RUN_FOR_REAL_MINT_SCOPE_ALLOWLIST (mod opt-i
       'apps:storage:shared:write', // cross-user write
       'collections:read:private', // private
       'collections:write:self', // write surface
-      'social:tip:self', // money OUT (also PAGE_FORBIDDEN)
+      'social:tip:self', // money OUT — excluded by the allowlist (NOT PAGE_FORBIDDEN)
       'media:read:owned', // unknown
     ]) {
       expect(granted).not.toContain(withheld);
     }
   });
 
-  it('NEVER grants social:tip:self even with keyCanSpend:true (money-OUT excluded by allowlist AND PAGE_FORBIDDEN)', () => {
+  it('NEVER grants social:tip:self even with keyCanSpend:true — the ALLOWLIST is the sole money-out gate (PAGE_FORBIDDEN is empty)', () => {
+    // PAGE_FORBIDDEN_SCOPES is intentionally empty (a PROD page token legitimately
+    // carries a bounded social:tip:self tip button), so the review-sandbox exclusion
+    // is the allowlist ALONE — assert both the allowlist omits it AND a manifest
+    // declaring it gets it stripped by the clamp.
     expect(REVIEW_RUN_FOR_REAL_MINT_SCOPE_ALLOWLIST.has('social:tip:self')).toBe(false);
     const granted = clampDevScopes({
       scopeSource: ['social:tip:self', 'ai:write:budgeted'],

--- a/src/server/services/blocks/__tests__/publish-request.mintReviewToken.test.ts
+++ b/src/server/services/blocks/__tests__/publish-request.mintReviewToken.test.ts
@@ -35,7 +35,12 @@ vi.mock('~/server/logging/client', () => ({
 }));
 
 import { mintReviewBlockToken } from '~/server/services/blocks/publish-request.service';
-import { FORCED_SFW_CEILING } from '~/server/services/blocks/dev-scoped-mint.service';
+import {
+  DEV_BUZZ_BUDGET_CAP,
+  DEV_BUZZ_BUDGET_DEFAULT,
+  FORCED_SFW_CEILING,
+} from '~/server/services/blocks/dev-scoped-mint.service';
+import { REVIEW_RUN_FOR_REAL_BUZZ_CAP } from '~/shared/constants/block-scope.constants';
 
 const PUBREQ = 'pubreq_0123456789ABCDEFGHJKMNPQRS';
 const MOD_ID = 4242;
@@ -171,5 +176,136 @@ describe('mintReviewBlockToken', () => {
       mintReviewBlockToken({ publishRequestId: PUBREQ, modUserId: MOD_ID })
     ).rejects.toThrow(/not pending/);
     expect(mockSign).not.toHaveBeenCalled();
+  });
+
+  it('runForReal:false is BYTE-IDENTICAL to omitting it (render-only, no budget, no claim)', async () => {
+    mockFindUnique.mockResolvedValue(pendingRow());
+    const res = await mintReviewBlockToken({
+      publishRequestId: PUBREQ,
+      modUserId: MOD_ID,
+      runForReal: false,
+    });
+    const arg = mockSign.mock.calls[0][0] as Record<string, unknown>;
+    // No spend scope, no budget, no run-for-real claim.
+    expect(arg.scopes).toEqual(['collections:read:self', 'models:read:self', 'user:read:self']);
+    expect(arg.buzzBudget).toBeUndefined();
+    expect(arg.reviewRunForReal).toBeUndefined();
+    // Result flags reflect render-only.
+    expect(res.runForReal).toBe(false);
+    expect(res.buzzCap).toBeNull();
+  });
+
+  describe('runForReal:true (mod opt-in)', () => {
+    it('mints a SELF-BOUND, forced-SFW, SPEND-capable token clamped to declared ∩ allowlist', async () => {
+      mockFindUnique.mockResolvedValue(pendingRow());
+
+      const res = await mintReviewBlockToken({
+        publishRequestId: PUBREQ,
+        modUserId: MOD_ID,
+        runForReal: true,
+      });
+
+      const arg = mockSign.mock.calls[0][0] as Record<string, unknown>;
+      // Still SELF-BOUND to the mod + forced-SFW + synthetic ids + dev lifetime.
+      expect(arg.userId).toBe(MOD_ID);
+      expect(arg.maxBrowsingLevel).toBe(FORCED_SFW_CEILING);
+      expect(arg.domain).toBeNull();
+      expect(arg.appBlockId).toBe(PUBREQ);
+      expect(arg.appId).toBe(`pending-${PUBREQ}`);
+      expect(arg.dev).toBe(true);
+      // The signed run-for-real MARKER (selects the aggregate cap at runtime).
+      expect(arg.reviewRunForReal).toBe(true);
+
+      // Granted == (manifest DECLARED) ∩ (run-for-real allowlist) + forced user:read:self.
+      // A malicious manifest declaring extra scopes gets ONLY the intersection.
+      const scopes = arg.scopes as string[];
+      expect(scopes).toEqual([
+        'ai:write:budgeted',
+        'apps:storage:read',
+        'apps:storage:write',
+        'buzz:read:self',
+        'collections:read:self',
+        'models:read:self',
+        'user:read:self',
+      ]);
+      // Spend-IN survived (keyCanSpend:true) — but every money-OUT / cross-user /
+      // private scope the manifest declared is ABSENT.
+      expect(scopes).toContain('ai:write:budgeted');
+      for (const withheld of [
+        'social:tip:self', // money OUT — never (also PAGE_FORBIDDEN)
+        'apps:storage:shared:write', // cross-user write — never
+        'collections:read:private', // private — never
+        'media:read:owned', // unknown — stripped
+      ]) {
+        expect(scopes).not.toContain(withheld);
+      }
+
+      // A per-call budget is attached (spend scope survived) — the platform default,
+      // clamped to the dev per-call cap.
+      expect(arg.buzzBudget).toBe(DEV_BUZZ_BUDGET_DEFAULT);
+
+      // The result advertises run-for-real + the AGGREGATE session cap surfaced to the UI.
+      expect(res.runForReal).toBe(true);
+      expect(res.buzzCap).toBe(REVIEW_RUN_FOR_REAL_BUZZ_CAP);
+      expect(res.scopes).toEqual(scopes);
+
+      // Audit records the privileged opt-in + enforced budgets (never the token).
+      const [auditArg] = mockLogToAxiom.mock.calls[0] as [Record<string, unknown>];
+      expect(auditArg).toMatchObject({
+        name: 'app-blocks.review.mint',
+        runForReal: true,
+        buzzBudget: DEV_BUZZ_BUDGET_DEFAULT,
+        buzzCap: REVIEW_RUN_FOR_REAL_BUZZ_CAP,
+      });
+    });
+
+    it('NEVER grants social:tip:self even if the manifest ONLY declares money-out scopes', async () => {
+      mockFindUnique.mockResolvedValue({
+        id: PUBREQ,
+        status: 'pending',
+        slug: 'tip-app',
+        manifest: { scopes: ['social:tip:self', 'apps:storage:shared:write'] },
+      });
+      const res = await mintReviewBlockToken({
+        publishRequestId: PUBREQ,
+        modUserId: MOD_ID,
+        runForReal: true,
+      });
+      // Only the force-granted self-read survives; no money-out, no cross-user, no spend.
+      expect(res.scopes).toEqual(['user:read:self']);
+      expect(res.scopes).not.toContain('social:tip:self');
+      expect(res.scopes).not.toContain('apps:storage:shared:write');
+      // No spend scope survived → no budget.
+      const arg = mockSign.mock.calls[0][0] as Record<string, unknown>;
+      expect(arg.buzzBudget).toBeUndefined();
+    });
+
+    it('FLOORS the per-call buzz budget to the dev cap when the manifest asks for more', async () => {
+      mockFindUnique.mockResolvedValue({
+        id: PUBREQ,
+        status: 'pending',
+        slug: 'greedy-app',
+        manifest: {
+          scopes: ['ai:write:budgeted'],
+          // Manifest asks for a huge per-gen budget — must be clamped to DEV_BUZZ_BUDGET_CAP.
+          page: { buzzBudgetPerGen: 999999 },
+        },
+      });
+      await mintReviewBlockToken({
+        publishRequestId: PUBREQ,
+        modUserId: MOD_ID,
+        runForReal: true,
+      });
+      const arg = mockSign.mock.calls[0][0] as Record<string, unknown>;
+      expect(arg.buzzBudget).toBe(DEV_BUZZ_BUDGET_CAP);
+    });
+
+    it('THROWS for a non-pending request even with runForReal (fail-closed, no sign)', async () => {
+      mockFindUnique.mockResolvedValue({ ...pendingRow(), status: 'rejected' });
+      await expect(
+        mintReviewBlockToken({ publishRequestId: PUBREQ, modUserId: MOD_ID, runForReal: true })
+      ).rejects.toThrow(/not pending/);
+      expect(mockSign).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/server/services/blocks/__tests__/publish-request.reviewSandbox.test.ts
+++ b/src/server/services/blocks/__tests__/publish-request.reviewSandbox.test.ts
@@ -22,6 +22,7 @@ const {
   mockDeleteReviewResources,
   mockDeleteAgentReviewResources,
   mockDeleteStagedBundle,
+  mockDeprovisionReviewPreview,
 } = vi.hoisted(() => ({
   mockDbRead: {
     appBlockPublishRequest: { findUnique: vi.fn(), findMany: vi.fn(async () => []) },
@@ -51,6 +52,9 @@ const {
   mockDeleteReviewResources: vi.fn(async () => undefined),
   mockDeleteAgentReviewResources: vi.fn(async () => undefined),
   mockDeleteStagedBundle: vi.fn(async () => undefined),
+  // #2831 — teardownReviewForRequest dynamically imports this to drop the
+  // disposable run-for-real preview storage schema.
+  mockDeprovisionReviewPreview: vi.fn(async () => undefined),
 }));
 
 vi.mock('~/server/db/client', () => ({ dbRead: mockDbRead, dbWrite: mockDbWrite }));
@@ -71,6 +75,11 @@ vi.mock('~/server/services/blocks/agent-review.service', () => ({
 }));
 vi.mock('~/utils/bundle-s3', () => ({
   deleteStagedBundle: mockDeleteStagedBundle,
+}));
+vi.mock('~/server/services/apps/storage-provision.service', () => ({
+  AppStorageProvisioner: {
+    deprovisionReviewPreview: mockDeprovisionReviewPreview,
+  },
 }));
 
 import {
@@ -272,6 +281,8 @@ describe('teardownReviewForRequest', () => {
   beforeEach(() => {
     mockDbRead.appBlockPublishRequest.findUnique.mockReset();
     mockDeleteReviewResources.mockClear();
+    mockDeprovisionReviewPreview.mockReset();
+    mockDeprovisionReviewPreview.mockResolvedValue(undefined);
   });
 
   it('deletes review resources by publish request (label selector is the boundary)', async () => {
@@ -286,6 +297,8 @@ describe('teardownReviewForRequest', () => {
       sha: SHA,
       publishRequestId: PUBREQ,
     });
+    // The disposable preview storage schema is dropped too (#2831).
+    expect(mockDeprovisionReviewPreview).toHaveBeenCalledWith({ publishRequestId: PUBREQ });
   });
 
   it('never throws even if the delete fails', async () => {
@@ -296,6 +309,40 @@ describe('teardownReviewForRequest', () => {
     });
     mockDeleteReviewResources.mockRejectedValue(new Error('k8s down'));
     await expect(teardownReviewForRequest(PUBREQ)).resolves.toBeUndefined();
+  });
+
+  it('#2831 — a k8s teardown FAILURE still DROPs the preview schema (drop runs first, independently)', async () => {
+    mockDbRead.appBlockPublishRequest.findUnique.mockResolvedValue({
+      slug: 'my-app',
+      deployState: 'preview-live',
+      deployDetail: JSON.stringify({ sha: SHA }),
+    });
+    // The k8s delete throws — must NOT skip the schema drop.
+    mockDeleteReviewResources.mockRejectedValue(new Error('k8s down'));
+    await expect(teardownReviewForRequest(PUBREQ)).resolves.toBeUndefined();
+    // The DROP ran regardless of the k8s failure (it runs FIRST, in its own try).
+    expect(mockDeprovisionReviewPreview).toHaveBeenCalledWith({ publishRequestId: PUBREQ });
+  });
+
+  it('#2831 — drops the preview schema even when the request row has VANISHED (early return path)', async () => {
+    // The row lookup returns null → the k8s teardown early-returns, but the schema
+    // drop already ran before the lookup, so it is not skipped.
+    mockDbRead.appBlockPublishRequest.findUnique.mockResolvedValue(null);
+    await teardownReviewForRequest(PUBREQ);
+    expect(mockDeprovisionReviewPreview).toHaveBeenCalledWith({ publishRequestId: PUBREQ });
+    expect(mockDeleteReviewResources).not.toHaveBeenCalled();
+  });
+
+  it('#2831 — a preview-drop FAILURE never throws and does not block the k8s teardown', async () => {
+    mockDbRead.appBlockPublishRequest.findUnique.mockResolvedValue({
+      slug: 'my-app',
+      deployState: 'preview-live',
+      deployDetail: JSON.stringify({ sha: SHA }),
+    });
+    mockDeprovisionReviewPreview.mockRejectedValue(new Error('appsdb down'));
+    await expect(teardownReviewForRequest(PUBREQ)).resolves.toBeUndefined();
+    // The k8s teardown still ran despite the preview-drop failure.
+    expect(mockDeleteReviewResources).toHaveBeenCalled();
   });
 });
 

--- a/src/server/services/blocks/custom-comfy-settle.service.ts
+++ b/src/server/services/blocks/custom-comfy-settle.service.ts
@@ -214,9 +214,12 @@ export async function settleCustomComfySpend(input: {
   const refund = Math.max(0, ceiling - actual);
   if (refund <= 0) return; // nothing to give back (job spent the full ceiling)
 
-  // Per-user daily cap: DECRBY the over-reservation on the EXACT key reserved
-  // (mirrors refundBlockBuzzSpend — pin the key so a midnight-UTC settle can't
-  // decrement the next day's window).
+  // Cumulative buzz cap: DECRBY the over-reservation on the EXACT key reserved.
+  // `buzzCapKey` is whichever cumulative key the submit reserved against — the
+  // per-user daily cap for a normal token, OR the per-(mod, publishRequestId)
+  // run-for-real session key for a review run-for-real submit (#2831). Pinning the
+  // stored key (not re-deriving) settles the right window either way and avoids a
+  // midnight-UTC / re-derivation race (mirrors refundBlockBuzzSpend).
   if (record.buzzCapKey) {
     await sysRedis.decrBy(record.buzzCapKey as BuzzCapKey, refund).catch(() => {
       /* best-effort — a lost refund over-counts (stricter cap) */

--- a/src/server/services/blocks/dev-scoped-mint.service.ts
+++ b/src/server/services/blocks/dev-scoped-mint.service.ts
@@ -184,15 +184,14 @@ export const REVIEW_MINT_SCOPE_ALLOWLIST: ReadonlySet<string> = new Set<string>(
  *   - `collections:read:private`      third-party-reachable private data
  *   - `collections:write:self`        write surface not needed to evaluate a page app
  *
- * (*) CAVEAT — App Storage may still fail CLOSED downstream: `resolveStorageContext`
- * (apps.router) requires an APPROVED `AppBlock` row keyed on the token's appId, but
- * a review token's appId is the synthetic non-resolving `pending-<id>` and the app
- * is un-approved. So even with the scope granted, a storage op returns NOT_FOUND /
- * FORBIDDEN until the app is approved. Granting the scope here is faithful to the
- * declared∩allowlist contract and lets the host surface the REAL server response to
- * the mod (rather than a synthetic NACK); it is NOT a claim that storage is fully
- * exercisable pre-approval. Generation + own-Buzz-read DO work (self-bound; they do
- * not require an approved AppBlock row).
+ * (*) App Storage WORKS under run-for-real via a dedicated preview namespace:
+ * `resolveStorageContext` (apps.router), when the token carries the signed
+ * `reviewRunForReal` claim, resolves a DISPOSABLE, per-publishRequest, ISOLATED
+ * `apprev_<pubreq>` schema (provisioned on demand) instead of the un-approved
+ * `app_<slug>` schema. Reads/writes are self-bound to the mod, cannot reach another
+ * pending app's namespace, and never pollute the eventual approved app's schema; the
+ * preview schema is dropped on the approve/reject teardown. Generation + own-Buzz-read
+ * likewise work (self-bound; no approved AppBlock row required).
  *
  * Money-OUT (`social:tip:self`) is additionally excluded by PAGE_FORBIDDEN_SCOPES
  * inside the clamp, so it can NEVER survive on ANY page token regardless of allowlist.

--- a/src/server/services/blocks/dev-scoped-mint.service.ts
+++ b/src/server/services/blocks/dev-scoped-mint.service.ts
@@ -193,8 +193,14 @@ export const REVIEW_MINT_SCOPE_ALLOWLIST: ReadonlySet<string> = new Set<string>(
  * preview schema is dropped on the approve/reject teardown. Generation + own-Buzz-read
  * likewise work (self-bound; no approved AppBlock row required).
  *
- * Money-OUT (`social:tip:self`) is additionally excluded by PAGE_FORBIDDEN_SCOPES
- * inside the clamp, so it can NEVER survive on ANY page token regardless of allowlist.
+ * Money-OUT (`social:tip:self`) is excluded SOLELY by its ABSENCE from this
+ * allowlist: the clamp keeps only scopes in the allowlist (step b), so a manifest
+ * declaring `social:tip:self` gets it dropped for a review mint. NOTE this is NOT
+ * a page-wide rule — `PAGE_FORBIDDEN_SCOPES` is intentionally EMPTY because a
+ * PROD page token legitimately CAN carry a bounded, consent-gated `social:tip:self`
+ * (a page tip button, capped per-tip + per-day in /api/v1/blocks/tip). The
+ * review-sandbox exclusion is therefore this allowlist ALONE — verified by a
+ * regression test (a run-for-real mint never yields `social:tip:self`).
  */
 export const REVIEW_RUN_FOR_REAL_MINT_SCOPE_ALLOWLIST: ReadonlySet<string> = new Set<string>([
   'models:read:self',
@@ -216,7 +222,10 @@ export const REVIEW_RUN_FOR_REAL_MINT_SCOPE_ALLOWLIST: ReadonlySet<string> = new
  *   c) keep only scopes within the app's OAuth ceiling (approved path only —
  *      `oauthAllowed !== null`); OMITTED for a pending / no-row / ephemeral app
  *      (no OauthClient — passing 0 would WRONGLY strip every non-skip scope),
- *   d) drop the PAGE_FORBIDDEN money/spend scopes (the page hard rule),
+ *   d) drop any PAGE_FORBIDDEN scopes — currently a NO-OP (PAGE_FORBIDDEN_SCOPES
+ *      is intentionally EMPTY: every page-requestable money scope is now bounded).
+ *      Retained as the deterministic re-forbid hook; it is NOT the money-out gate
+ *      for the review sandbox — that is the allowlist (b), which omits social:tip:self,
  *   e) if the body narrowed, intersect with the requested subset,
  *   f) BEARER-credential spend ceiling — strip `ai:write:budgeted` unless
  *      `keyCanSpend` (dev-token: the bearer's AIServicesWrite bit; host-mint:

--- a/src/server/services/blocks/dev-scoped-mint.service.ts
+++ b/src/server/services/blocks/dev-scoped-mint.service.ts
@@ -160,6 +160,54 @@ export const REVIEW_MINT_SCOPE_ALLOWLIST: ReadonlySet<string> = new Set<string>(
 ]);
 
 /**
+ * The MOD-REVIEW-SANDBOX "RUN FOR REAL" host-mint allowlist (#2831). Used ONLY
+ * when a moderator EXPLICITLY opts in (per-preview, behind a loud consent gate)
+ * to run an UNAPPROVED review app FOR REAL against THEIR OWN account, so they can
+ * fully evaluate generation / storage / buzz before approving.
+ *
+ * It is the render-only `REVIEW_MINT_SCOPE_ALLOWLIST` PLUS the SELF-BOUND
+ * capabilities needed to exercise a page app end-to-end — and NOTHING that could
+ * move money OUT or touch another user:
+ *
+ * ADDED over render-only (all SELF-BOUND to the reviewing mod):
+ *   - `ai:write:budgeted`   real Buzz SPEND-IN for generation (also gated by the
+ *                           per-call budget AND the aggregate session cap below)
+ *   - `apps:storage:read`   the mod's OWN per-app KV (see caveat *)
+ *   - `apps:storage:write`  the mod's OWN per-app KV (see caveat *)
+ *   - `buzz:read:self`      the mod's OWN balance/ledger (self-bound read)
+ *
+ * DELIBERATELY WITHHELD (clamped out regardless of what the pending manifest
+ * declares — the clamp keeps only scopes IN this set, so a malicious manifest
+ * declaring extra scopes gets NONE of these):
+ *   - `social:tip:self`               real money OUT — NEVER granted (invariant #4)
+ *   - `apps:storage:shared:read|write` cross-user shared datastore — NEVER (invariant #2)
+ *   - `collections:read:private`      third-party-reachable private data
+ *   - `collections:write:self`        write surface not needed to evaluate a page app
+ *
+ * (*) CAVEAT — App Storage may still fail CLOSED downstream: `resolveStorageContext`
+ * (apps.router) requires an APPROVED `AppBlock` row keyed on the token's appId, but
+ * a review token's appId is the synthetic non-resolving `pending-<id>` and the app
+ * is un-approved. So even with the scope granted, a storage op returns NOT_FOUND /
+ * FORBIDDEN until the app is approved. Granting the scope here is faithful to the
+ * declared∩allowlist contract and lets the host surface the REAL server response to
+ * the mod (rather than a synthetic NACK); it is NOT a claim that storage is fully
+ * exercisable pre-approval. Generation + own-Buzz-read DO work (self-bound; they do
+ * not require an approved AppBlock row).
+ *
+ * Money-OUT (`social:tip:self`) is additionally excluded by PAGE_FORBIDDEN_SCOPES
+ * inside the clamp, so it can NEVER survive on ANY page token regardless of allowlist.
+ */
+export const REVIEW_RUN_FOR_REAL_MINT_SCOPE_ALLOWLIST: ReadonlySet<string> = new Set<string>([
+  'models:read:self',
+  'user:read:self',
+  'collections:read:self',
+  'ai:write:budgeted',
+  'apps:storage:read',
+  'apps:storage:write',
+  'buzz:read:self',
+]);
+
+/**
  * The AUDITED scope clamp belt (dev-token.ts steps 7a–7g), extracted verbatim.
  * Start from `scopeSource` (the app's approved snapshot, an owned pending request's
  * un-reviewed `manifest.scopes`, or the caller's self-declared body scopes) and:
@@ -314,6 +362,15 @@ export async function signDevScopedPageToken(opts: {
   blockInstanceId: string;
   granted: string[];
   buzzBudget: number | undefined;
+  /**
+   * MOD REVIEW SANDBOX "run for real" (#2831) marker. When true, stamps a
+   * signed `reviewRunForReal: true` claim so the runtime spend paths
+   * (submitWorkflow / customComfy) enforce the TIGHT per-(mod, publishRequestId)
+   * aggregate Buzz ceiling instead of the ordinary per-user daily cap. The flag
+   * is only trustworthy because it is inside the RS256-signed payload. Absent
+   * (default) → byte-identical to a normal dev-scoped page token.
+   */
+  reviewRunForReal?: boolean;
 }): Promise<Awaited<ReturnType<typeof BlockTokenService.sign>>> {
   const ctx: Record<string, unknown> = {
     slotId: PAGE_SLOT_ID,
@@ -334,5 +391,6 @@ export async function signDevScopedPageToken(opts: {
     domain: null,
     maxBrowsingLevel: FORCED_SFW_CEILING,
     dev: true,
+    ...(opts.reviewRunForReal === true ? { reviewRunForReal: true } : {}),
   });
 }

--- a/src/server/services/blocks/publish-request.service.ts
+++ b/src/server/services/blocks/publish-request.service.ts
@@ -3355,6 +3355,20 @@ export type MintReviewBlockTokenResult = {
   /** The pending manifest's declared iframe sandbox (render fidelity). trustTier is
    *  forced 'unverified' at the host → allow-same-origin is dropped regardless. */
   sandbox: string;
+  /**
+   * MOD REVIEW SANDBOX "run for real" (#2831) — true iff this token was minted
+   * with `runForReal:true` (a mod's consent-gated opt-in to run the unapproved app
+   * for real against their OWN account). The host uses it to run the REAL
+   * side-effect handlers instead of NACKing; default false → render-only sandbox.
+   */
+  runForReal: boolean;
+  /**
+   * The AGGREGATE (session) Buzz ceiling the mod's OWN account can spend across
+   * all run-for-real generations of THIS request (`REVIEW_RUN_FOR_REAL_BUZZ_CAP`),
+   * surfaced so the consent copy + active banner show the exact enforced number.
+   * null on a render-only (runForReal:false) mint.
+   */
+  buzzCap: number | null;
 };
 
 /**
@@ -3391,7 +3405,20 @@ export async function mintReviewBlockToken(opts: {
   publishRequestId: string;
   /** The calling moderator's id — the token `sub` is bound to it (self-bound). */
   modUserId: number;
+  /**
+   * MOD REVIEW SANDBOX "run for real" (#2831). Default false → the render-only
+   * sandbox, BYTE-IDENTICAL to the pre-existing behaviour (render-only allowlist,
+   * keyCanSpend:false, no budget, no run-for-real claim). When true (a mod's
+   * EXPLICIT, consent-gated opt-in), the SAME audited clamp belt runs with the
+   * wider `REVIEW_RUN_FOR_REAL_MINT_SCOPE_ALLOWLIST` and `keyCanSpend:true`, a
+   * per-call Buzz budget is attached, and a signed `reviewRunForReal` claim
+   * selects the tight aggregate session Buzz cap at runtime. STILL: self-bound to
+   * the mod, forced-SFW, money-OUT (`social:tip:self`) excluded, and clamped to
+   * (declared ∩ allowlist) — a malicious manifest can never exceed either.
+   */
+  runForReal?: boolean;
 }): Promise<MintReviewBlockTokenResult> {
+  const runForReal = opts.runForReal === true;
   const { dbRead } = await import('~/server/db/client');
   const row = await dbRead.appBlockPublishRequest.findUnique({
     where: { id: opts.publishRequestId },
@@ -3412,6 +3439,7 @@ export async function mintReviewBlockToken(opts: {
     scopes?: unknown;
     name?: unknown;
     iframe?: { sandbox?: unknown } | null;
+    page?: unknown;
   };
   const manifestScopes: string[] = Array.isArray(manifest.scopes)
     ? manifest.scopes.filter((s): s is string => typeof s === 'string')
@@ -3426,17 +3454,41 @@ export async function mintReviewBlockToken(opts: {
     clampDevScopes,
     signDevScopedPageToken,
     REVIEW_MINT_SCOPE_ALLOWLIST,
+    REVIEW_RUN_FOR_REAL_MINT_SCOPE_ALLOWLIST,
+    resolveDevBuzzBudget,
+    parseManifestBuzzBudget,
     FORCED_SFW_CEILING,
   } = await import('./dev-scoped-mint.service');
+  const { REVIEW_RUN_FOR_REAL_BUZZ_CAP } = await import(
+    '~/shared/constants/block-scope.constants'
+  );
 
-  // The AUDITED clamp belt — render-only allowlist + NO OAuth ceiling (a pending
-  // app has no OauthClient) + keyCanSpend:false (belt-and-suspenders spend strip).
+  // The AUDITED clamp belt (SAME function both modes — never fork the clamp).
+  //   - render-only (default): render-only allowlist + keyCanSpend:false → the
+  //     spend scope is stripped even if the manifest declares it. BYTE-IDENTICAL
+  //     to the pre-existing sandbox.
+  //   - run-for-real (mod opt-in): the WIDER run-for-real allowlist + keyCanSpend:true.
+  //     Granted = (manifest DECLARED scopes) ∩ allowlist ∩ (page money-out forbid),
+  //     so a malicious manifest declaring extra scopes still gets ONLY declared∩allowlist.
+  // NO OAuth ceiling in either mode (a pending app has no OauthClient; passing 0
+  // would wrongly strip every non-skip scope — see clampDevScopes doc).
   const granted = clampDevScopes({
     scopeSource: manifestScopes,
     oauthAllowed: null,
-    keyCanSpend: false,
-    allowlist: REVIEW_MINT_SCOPE_ALLOWLIST,
+    keyCanSpend: runForReal,
+    allowlist: runForReal
+      ? REVIEW_RUN_FOR_REAL_MINT_SCOPE_ALLOWLIST
+      : REVIEW_MINT_SCOPE_ALLOWLIST,
   });
+
+  // Per-call Buzz budget — ONLY for run-for-real AND only if the spend scope
+  // survived the clamp. Resolved from the manifest page's declared per-gen budget,
+  // hard-clamped to the dev per-call cap (DEV_BUZZ_BUDGET_CAP inside resolveDevBuzzBudget).
+  // The AGGREGATE session ceiling (REVIEW_RUN_FOR_REAL_BUZZ_CAP) is enforced
+  // separately at runtime — a per-call budget alone can't bound a looping app.
+  const buzzBudget = runForReal
+    ? resolveDevBuzzBudget(granted, undefined, parseManifestBuzzBudget(manifest.page))
+    : undefined;
 
   // SIGN — self-bound to the MOD, forced-SFW, domain:null, synthetic non-resolving
   // ids (see the fn doc). `signAppBlockId` = the `pubreq_<ULID>` request id (already
@@ -3452,7 +3504,8 @@ export async function mintReviewBlockToken(opts: {
     signAppBlockId: row.id,
     blockInstanceId: `page_${row.id}`,
     granted,
-    buzzBudget: undefined,
+    buzzBudget,
+    reviewRunForReal: runForReal,
   });
 
   // MINT-TIME AUDIT (mirror the `app-blocks.dev-tunnel.mint` structured event):
@@ -3467,6 +3520,12 @@ export async function mintReviewBlockToken(opts: {
       publishRequestId: row.id,
       slug: row.slug,
       scopes: granted,
+      // Run-for-real is a PRIVILEGED, money-touching action — record the opt-in
+      // (and the enforced budgets) distinctly so the forensic trail shows WHEN a
+      // mod ran an unapproved app for real against their own account.
+      runForReal,
+      buzzBudget: buzzBudget ?? null,
+      buzzCap: runForReal ? REVIEW_RUN_FOR_REAL_BUZZ_CAP : null,
     },
     'webhooks'
   ).catch(() => null);
@@ -3483,6 +3542,8 @@ export async function mintReviewBlockToken(opts: {
     blockInstanceId: `page_${row.id}`,
     appName: manifestName,
     sandbox: manifestSandbox,
+    runForReal,
+    buzzCap: runForReal ? REVIEW_RUN_FOR_REAL_BUZZ_CAP : null,
   };
 }
 

--- a/src/server/services/blocks/publish-request.service.ts
+++ b/src/server/services/blocks/publish-request.service.ts
@@ -3577,6 +3577,24 @@ export async function teardownReviewForRequest(publishRequestId: string): Promis
       sha: detail.sha ?? '',
       publishRequestId,
     });
+    // MOD REVIEW SANDBOX "run for real" (#2831) — drop the DISPOSABLE preview
+    // storage schema (`apprev_<pubreq>`) a mod may have created by running the app
+    // for real. Best-effort + idempotent (IF EXISTS): a request that never used
+    // preview storage has no schema to drop, and this NEVER touches the approved
+    // app's `app_<slug>` schema. Runs on the same approve/reject teardown path.
+    try {
+      const { AppStorageProvisioner } = await import(
+        '~/server/services/apps/storage-provision.service'
+      );
+      await AppStorageProvisioner.deprovisionReviewPreview({ publishRequestId });
+    } catch (previewErr) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        `[teardownReviewForRequest] preview-storage teardown failed (id=${publishRequestId}): ${
+          previewErr instanceof Error ? previewErr.message : String(previewErr)
+        }`
+      );
+    }
   } catch (err) {
     // eslint-disable-next-line no-console
     console.warn(

--- a/src/server/services/blocks/publish-request.service.ts
+++ b/src/server/services/blocks/publish-request.service.ts
@@ -3554,6 +3554,27 @@ export async function mintReviewBlockToken(opts: {
  * review k8s resources by label selector, swallowing every error.
  */
 export async function teardownReviewForRequest(publishRequestId: string): Promise<void> {
+  // MOD REVIEW SANDBOX "run for real" (#2831) — drop the DISPOSABLE preview
+  // storage schema (`apprev_<pubreq>`) a mod may have created by running the app
+  // for real. Runs FIRST, in its OWN try/catch, so a downstream failure (the
+  // fallible k8s `deleteReviewResources`, or a missing row) can NEVER skip the
+  // DROP and leak the mod's preview data in appsDb. Best-effort + idempotent (IF
+  // EXISTS): a request that never used preview storage has no schema to drop, and
+  // this NEVER touches the approved app's `app_<slug>` schema. Only needs the
+  // publishRequestId (not the row), so it's safe to run before the row lookup.
+  try {
+    const { AppStorageProvisioner } = await import(
+      '~/server/services/apps/storage-provision.service'
+    );
+    await AppStorageProvisioner.deprovisionReviewPreview({ publishRequestId });
+  } catch (previewErr) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      `[teardownReviewForRequest] preview-storage teardown failed (id=${publishRequestId}): ${
+        previewErr instanceof Error ? previewErr.message : String(previewErr)
+      }`
+    );
+  }
   try {
     const { dbRead } = await import('~/server/db/client');
     const row = await dbRead.appBlockPublishRequest.findUnique({
@@ -3577,24 +3598,6 @@ export async function teardownReviewForRequest(publishRequestId: string): Promis
       sha: detail.sha ?? '',
       publishRequestId,
     });
-    // MOD REVIEW SANDBOX "run for real" (#2831) — drop the DISPOSABLE preview
-    // storage schema (`apprev_<pubreq>`) a mod may have created by running the app
-    // for real. Best-effort + idempotent (IF EXISTS): a request that never used
-    // preview storage has no schema to drop, and this NEVER touches the approved
-    // app's `app_<slug>` schema. Runs on the same approve/reject teardown path.
-    try {
-      const { AppStorageProvisioner } = await import(
-        '~/server/services/apps/storage-provision.service'
-      );
-      await AppStorageProvisioner.deprovisionReviewPreview({ publishRequestId });
-    } catch (previewErr) {
-      // eslint-disable-next-line no-console
-      console.warn(
-        `[teardownReviewForRequest] preview-storage teardown failed (id=${publishRequestId}): ${
-          previewErr instanceof Error ? previewErr.message : String(previewErr)
-        }`
-      );
-    }
   } catch (err) {
     // eslint-disable-next-line no-console
     console.warn(

--- a/src/server/utils/__tests__/apps-slug.test.ts
+++ b/src/server/utils/__tests__/apps-slug.test.ts
@@ -3,6 +3,8 @@ import {
   appRoleIdent,
   appSchemaIdent,
   isValidAppSlug,
+  normalizeReviewPreviewId,
+  reviewPreviewSchemaIdent,
   sanitizeAppSlug,
 } from '~/server/utils/apps-slug';
 
@@ -108,6 +110,40 @@ describe('apps-slug', () => {
       expect(() => appSchemaIdent('invalid-slug')).toThrow(/invalid app slug/);
       expect(() => appRoleIdent('')).toThrow(/invalid app slug/);
       expect(() => appSchemaIdent('1bad')).toThrow(/invalid app slug/);
+    });
+  });
+
+  describe('review preview schema ident (#2831)', () => {
+    it('normalises a pubreq_<ULID> id to a lowercase alnum component', () => {
+      expect(normalizeReviewPreviewId('pubreq_01ARZ3NDEKTSV4RRFFQ69G5FAV')).toBe(
+        'pubreq01arz3ndektsv4rrffq69g5fav'
+      );
+    });
+
+    it('produces the quoted apprev_ schema for a publish request id', () => {
+      expect(reviewPreviewSchemaIdent('pubreq_01ARZ3NDEKTSV4RRFFQ69G5FAV')).toBe(
+        '"apprev_pubreq01arz3ndektsv4rrffq69g5fav"'
+      );
+    });
+
+    it('ISOLATION: the preview schema can NEVER alias a production app_<slug> schema', () => {
+      // Production schemas are `app_` + slug (index-3 char is `_`); preview schemas
+      // are `apprev_` + id (index-3 char is `r`) — so no slug can ever collide.
+      const preview = reviewPreviewSchemaIdent('pubreq_abc');
+      // Try to construct a matching production slug — impossible: `apprev_...`
+      // cannot equal `app_<slug>` for any valid slug.
+      expect(preview).toBe('"apprev_pubreqabc"');
+      expect(preview.startsWith('"app_')).toBe(false);
+      expect(preview.startsWith('"apprev_')).toBe(true);
+      // A different publish request → a different schema (per-app isolation).
+      expect(reviewPreviewSchemaIdent('pubreq_xyz')).not.toBe(preview);
+    });
+
+    it('throws (fail-shut) on an id that normalises to something unusable', () => {
+      expect(() => reviewPreviewSchemaIdent('!!')).toThrow(/invalid review preview id/);
+      expect(() => reviewPreviewSchemaIdent('')).toThrow(/invalid review preview id/);
+      expect(normalizeReviewPreviewId(null)).toBe(null);
+      expect(normalizeReviewPreviewId(42 as unknown as string)).toBe(null);
     });
   });
 });

--- a/src/server/utils/apps-slug.ts
+++ b/src/server/utils/apps-slug.ts
@@ -56,3 +56,39 @@ export function appRoleIdent(slug: string): string {
   }
   return `"app_${slug}_role"`;
 }
+
+// ── MOD REVIEW SANDBOX "run for real" preview storage namespace (#2831) ──────
+//
+// A moderator running an UNAPPROVED app for real gets a DISPOSABLE, per-publish-
+// request storage schema so preview scribbles (a) can't read another pending
+// app's data and (b) never pollute the eventual APPROVED app's production
+// `app_<slug>` schema. Keyed on the publishRequestId (`pubreq_<ULID>`), NOT the
+// slug — two pending apps, or a pending app and its later-approved self, get
+// DIFFERENT schemas.
+//
+// SAFETY: the prefix is `apprev_` (NO underscore after `app`), which by
+// construction can NEVER collide with a production `app_<slug>` schema — those
+// always have `_` at string index 3 (`a p p _`), while `apprev_…` has `r`. So no
+// approved app schema and no preview schema can ever alias, regardless of slug.
+// The id is normalised to `[a-z0-9]` (identifiers can't be parameterized in DDL);
+// the strict regex is the load-bearing boundary, exactly like `isValidAppSlug`.
+
+const REVIEW_PREVIEW_ID_RE = /^[a-z0-9]{3,48}$/;
+
+/** Normalise a publishRequestId to the identifier-safe component of its preview
+ *  schema. Lowercases + strips non-alnum; returns null if the result is unusable. */
+export function normalizeReviewPreviewId(publishRequestId: unknown): string | null {
+  if (typeof publishRequestId !== 'string') return null;
+  const norm = publishRequestId.toLowerCase().replace(/[^a-z0-9]+/g, '').slice(0, 48);
+  return REVIEW_PREVIEW_ID_RE.test(norm) ? norm : null;
+}
+
+/** Quote-and-return the DISPOSABLE per-publish-request preview schema identifier.
+ *  Throws (fail-shut) if the id can't be normalised — mirrors `appSchemaIdent`. */
+export function reviewPreviewSchemaIdent(publishRequestId: string): string {
+  const norm = normalizeReviewPreviewId(publishRequestId);
+  if (norm === null) {
+    throw new Error(`invalid review preview id: ${JSON.stringify(publishRequestId)}`);
+  }
+  return `"apprev_${norm}"`;
+}

--- a/src/shared/constants/block-scope.constants.ts
+++ b/src/shared/constants/block-scope.constants.ts
@@ -117,6 +117,22 @@ export const BLOCK_SCOPE_TO_OAUTH_BIT: Record<string, ScopeBitmaskRequirement> =
 
 export type BlockScopeString = keyof typeof BLOCK_SCOPE_TO_OAUTH_BIT;
 
+/**
+ * MOD REVIEW SANDBOX "run for real" (#2831) — the AGGREGATE (session) Buzz
+ * ceiling a moderator's OWN account can spend across ALL run-for-real
+ * generations of ONE pending publish request. This is the number surfaced in
+ * the loud consent copy ("…spends YOUR Buzz, capped at N…") AND the number the
+ * server enforces as a per-(mod, publishRequestId) cumulative Redis reservation
+ * in `blocks.router.ts` (see `reserveReviewRunForRealBuzzSpend`).
+ *
+ * SINGLE SOURCE OF TRUTH: defined HERE (a client-safe shared constants module)
+ * so the server enforcement, the mint service, and the client consent dialog all
+ * read the identical value — a low per-call `buzzBudget` alone is NOT sufficient
+ * (a hostile app loops sub-budget calls; see `blocks.router.ts:594`), so this
+ * cumulative ceiling is what actually bounds a run-for-real session.
+ */
+export const REVIEW_RUN_FOR_REAL_BUZZ_CAP = 5000;
+
 export function isKnownBlockScope(scope: string): scope is BlockScopeString {
   return scope in BLOCK_SCOPE_TO_OAUTH_BIT;
 }


### PR DESCRIPTION
## Mod-opt-in "Run for real" for the App Blocks review preview (#2831)

The App Blocks **mod review preview** deliberately blocks all side effects (the render-only sandbox): the review JWT is scope-stripped and `PageBlockHost` NACKs every side-effecting handler with `"not available in review preview"`. That's correct for normal review, but it means a moderator can't actually evaluate generation / storage / buzz before approving.

This PR adds an **explicit, per-preview, consent-gated opt-in** for a moderator to run a **pending, unapproved** app **for real against their OWN account** — without weakening the default render-only sandbox.

### Default OFF is byte-identical to today
`runForReal` defaults to `false` everywhere (schema, service, host prop). When it's off, the render-only token, the `reviewMode` NACKs, and every existing test path are unchanged.

### How each security invariant is enforced + tested

| Invariant | Enforcement | Test |
|---|---|---|
| **1. Default OFF = identical** | `runForReal` defaults false; nothing changes unless a mod opts in | existing suites stay green + `runForReal:false is BYTE-IDENTICAL` |
| **2. Self-bound** | token `sub` stays the reviewing mod's `userId` (server-derived, never client input) | mint test asserts `userId === modUserId` |
| **3. SFW forced** | `FORCED_SFW_CEILING` kept in both modes; `domain:null` | mint test asserts `maxBrowsingLevel` unchanged |
| **4. Money-OUT never** | `social:tip:self` excluded by its **absence from the run-for-real allowlist** — the clamp keeps only allowlisted scopes. Note `PAGE_FORBIDDEN_SCOPES` is intentionally EMPTY (a prod page token legitimately carries a bounded, consent-gated `social:tip:self` tip button), so the allowlist is the **sole** money-out gate for the review sandbox. | clamp + mint regression tests ("NEVER grants social:tip:self even when the manifest declares it") |
| **5. Clamp to declared ∩ allowlist** | reuses the existing `clampDevScopes` belt with a **new** `REVIEW_RUN_FOR_REAL_MINT_SCOPE_ALLOWLIST` (added alongside the render-only + dev allowlists — the clamp logic is not forked) | "grants ONLY declared ∩ allowlist" against a malicious manifest |
| **6. Bounded Buzz — AGGREGATE cap** | see below | router aggregate-cap suite |
| **7. Authz + binding** | mint stays `moderatorProcedure` + review-sandbox flag + pending-only; the run-for-real opt-in is additionally **rate-limited** per mod | router suite (non-mod / flag-off / rate-limit) |
| **8. Loud consent + banner** | `ReviewBlockPreviewHost` shows a consent gate stating the exact cap + "SFW enforced" before any run-for-real token is minted; a persistent banner shows while active; default is render-only | UI browser suite |
| **9. Audit** | the mint logs `runForReal`, `buzzBudget`, `buzzCap` (never the token) | mint test asserts the audit event |
| **10. Teardown** | "Exit run-for-real" re-mints render-only; the whole preview tears down on approve/reject | UI browser suite ("EXIT tears down…") |

### Invariant #6 — a TRUE aggregate cap (not just per-call)

The token's per-call `buzzBudget` alone cannot bound a hostile app looping sub-budget calls. A run-for-real token is signed with a `reviewRunForReal` claim; at spend time (`submitWorkflow` **and** the `customComfy` path) it reserves against a **tight per-(mod, publishRequestId) cumulative ceiling** (`REVIEW_RUN_FOR_REAL_BUZZ_CAP = 5000`) using the same atomic reserve-and-refund machinery as the existing per-user daily cap — **in place of** the ordinary daily cap, so there's exactly one reserve/refund path and the whole refund choreography is untouched. The key binds to (mod, publishRequestId), not the token id, so re-minting/re-confirming the consent cannot reset the ceiling. Tested: a submit at 5001 (≈10× under the 50k daily cap) is **rejected** for a run-for-real token but proceeds for a normal token.

### Run-for-real preview storage (isolated + disposable) — closes "Couldn't save vault item"

Per-app storage read/write now **actually works** for a pending app under run-for-real (the third original symptom), via a dedicated preview namespace — **not** by relaxing the approved-status gate:

- **Only under run-for-real.** `resolveStorageContext` branches on the signed `reviewRunForReal` claim. A render-only review token, or any prod token, never enters the branch and keeps failing closed on the approved-status check — **byte-identical** to before (regression-tested).
- **Isolated, per-publishRequest namespace.** It resolves a disposable schema `apprev_<pubreq>` (keyed on the publishRequestId, i.e. the token's `appBlockId`) provisioned on demand. By construction the `apprev_` prefix can **never** alias a production `app_<slug>` schema (position-3 char is `r` vs `_`), and two pending apps get **different** schemas — so app A can't read app B, and preview scribbles **never pollute** the eventual approved app's namespace. Unit-tested at the ident level + the resolver level.
- **Self-bound.** Rows are partitioned by `user_id` = the reviewing mod; an anon subject can't write. The storage-scope gate (`apps:storage:read/write`) still applies.
- **No cross-user widening.** `apps:storage:shared:*` is a different resolver and remains excluded from the run-for-real allowlist — untouched.
- **Disposable + leak-safe teardown.** The preview schema is dropped (`DROP SCHEMA … CASCADE`) on the existing approve/reject teardown (`teardownReviewForRequest`). The drop runs **FIRST, in its own try/catch**, so a fallible k8s `deleteReviewResources` (or a vanished row) can never skip it. Best-effort + idempotent, never touching `app_<slug>`.
- **Orphan guard.** A run-for-real token lives 4h but the preview only exists while the request is pending. `resolveStorageContext` re-checks the pubreq status (from the primary) and **refuses to (re)provision** once the request leaves `pending` — so a still-valid token used after approve/reject can't recreate a schema nothing would tear down again. Mirrors the mint's pending-only gate.
- **Minimal surface.** The preview provisioner creates only the per-user `kv` + `quota` + trigger — no shared tables, no per-app role.

Generation and own-Buzz-read also work (self-bound; no approved AppBlock row required). Money-out and cross-user remain excluded.

### Test status (honest)
Ran locally and **green** — 199 tests across 8 suites the environment could resolve: `apps-slug` (23, incl. preview-schema isolation), `storage-provision.service` (17, incl. `provisionReviewPreview`/`deprovisionReviewPreview`), `apps.router.storage` (37, incl. run-for-real read/write/isolation/regression/scope/self-bound), `dev-scoped-mint.service` (39), `publish-request.mintReviewToken` (9), `block-token.service` (19), `block-scope.middleware` (34), `block-scope.constants` (21) — covering all new clamp/allowlist/budget-floor/money-out/self-bound/forced-SFW/claim-stamp/claim-validation **and** preview-storage cases.

CI-gated (couldn't load locally — stale local dep tree missing workspace deps like `kysely`): the router aggregate-cap + reviewSandbox suites and the two browser-mode suites (`PageBlockHostReviewMode` incl. the storage-write-runs-real matrix, `ReviewBlockPreviewHost`). Written to match existing passing patterns; the pr-preview / typecheck is the authority — **not** claimed as executed green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
