### PR TITLE
fix(editor): size headings in the rich text editor

### DIFF
--- a/src/components/RichTextEditor/RichTextEditorComponent.module.scss
+++ b/src/components/RichTextEditor/RichTextEditorComponent.module.scss
@@ -42,6 +42,45 @@
       // color should be set inline via style prop if it depends on error
       font-size: var(--editor-font-size, 14px);
     }
+
+    // Tailwind preflight resets headings to inherit, and the editor content —
+    // unlike the published article — isn't wrapped in TypographyStylesWrapper.
+    // Without this an H1 and a paragraph look identical while writing and only
+    // diverge once published. Mirrors the same Mantine variables that wrapper
+    // uses so the two views agree. Only h1-h3 exist here (see CustomHeading).
+    h1,
+    h2,
+    h3 {
+      margin-bottom: var(--mantine-spacing-xs);
+      text-wrap: var(--mantine-heading-text-wrap);
+      font-family: var(--mantine-font-family-headings);
+    }
+
+    h1 {
+      margin-top: calc(1.5 * var(--mantine-spacing-xl));
+      font-size: var(--mantine-h1-font-size);
+      line-height: var(--mantine-h1-line-height);
+      font-weight: var(--mantine-h1-font-weight);
+    }
+
+    h2 {
+      margin-top: var(--mantine-spacing-xl);
+      font-size: var(--mantine-h2-font-size);
+      line-height: var(--mantine-h2-line-height);
+      font-weight: var(--mantine-h2-font-weight);
+    }
+
+    h3 {
+      margin-top: calc(0.8 * var(--mantine-spacing-xl));
+      font-size: var(--mantine-h3-font-size);
+      line-height: var(--mantine-h3-line-height);
+      font-weight: var(--mantine-h3-font-weight);
+    }
+
+    // The first block shouldn't be pushed away from the top of the editor.
+    > :first-child {
+      margin-top: 0;
+    }
   }
 
   iframe {

--- a/src/components/RichTextEditor/RichTextEditorComponent.module.scss
+++ b/src/components/RichTextEditor/RichTextEditorComponent.module.scss
@@ -77,6 +77,18 @@
       font-weight: var(--mantine-h3-font-weight);
     }
 
+    // Same gap for blockquote: StarterKit enables it wherever `formatting` is on,
+    // so `> ` produces one, but preflight zeroes its margins and it renders as a
+    // plain paragraph until published.
+    blockquote {
+      font-size: var(--mantine-font-size-lg);
+      line-height: var(--mantine-line-height);
+      margin: var(--mantine-spacing-md) 0;
+      border-radius: var(--mantine-radius-sm);
+      padding: var(--mantine-spacing-md) var(--mantine-spacing-lg);
+      background-color: light-dark(var(--mantine-color-gray-0), var(--mantine-color-dark-8));
+    }
+
     // The first block shouldn't be pushed away from the top of the editor.
     > :first-child {
       margin-top: 0;


### PR DESCRIPTION
Addresses item 4 of #3398.

Tailwind's preflight resets headings to `font-size: inherit`, and the editor's content — unlike the published article, which `RenderRichText` wraps in `TypographyStylesWrapper` — has no typography styles of its own. `RichTextEditorComponent.module.scss` only gave `h1/h2/h3` an anchor-offset pseudo-element under `.htmlRenderer`, nothing under `.richTextEditor`.

Result: an H1 and a paragraph looked identical while writing, and only diverged once published. That makes the H1/H2/H3 buttons hard to use and is disorienting when pasting or importing a long document.

This mirrors the same Mantine variables `TypographyStylesWrapper` uses, so the two views agree by construction rather than by copied numbers, and zeroes `margin-top` on the first block so content isn't pushed away from the top of the editor.

## Verified

Measured in a real browser after pasting `<h1>/<h2>/<h3>/<p>`:

| | font-size | weight | margin-top |
|---|---|---|---|
| h1 | 34px | 700 | 0 (first child) |
| h2 | 26px | 700 | 32px (`spacing-xl`) |
| h3 | 22px | 700 | 25.6px (`0.8 × xl`) |
| p | 16px | 400 | 0 |

Those match `TypographyStylesWrapper`'s values for the same elements.

## A cascade note for reviewers

While checking this I hit a trap worth recording: `@mantine/tiptap/styles.css` is **unlayered**, and unlayered CSS outranks every layered rule — including CSS modules, which Next wraps in `@layer modules` (see the comment at the top of `src/styles/globals.css`). Importing the plain build instead of `styles.layer.css` therefore lets Mantine silently override module styles it doesn't override in the real app. `_app.tsx:85` correctly imports `@mantine/tiptap/styles.layer.css`; my first preview attempt didn't, and these margins appeared not to apply as a result. Nothing to fix in the app — flagging it because it's an easy mistake in any new harness or embed.
