### PR TITLE
fix(announcements): upload banner images without minting an Image row, and monitor for broken/at-risk banners

### DIFF
--- a/src/client-utils/cf-images-utils.ts
+++ b/src/client-utils/cf-images-utils.ts
@@ -1,145 +1,25 @@
-import { MediaType } from '~/shared/utils/prisma/enums';
 import { useMemo } from 'react';
-import { env } from '~/env/client';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
 import { useBrowsingSettings } from '~/providers/BrowserSettingsProvider';
-import { isDefined } from '~/utils/type-guards';
+import {
+  getEdgeUrl,
+  getInferredMediaType,
+  shouldForceOptimized,
+  type EdgeUrlProps,
+} from '~/client-utils/edge-url';
 
-// from options available in CF Flexible variants:
-// https://developers.cloudflare.com/images/cloudflare-images/transform/flexible-variants/
-export type EdgeUrlProps = {
-  src: string;
-  name?: string | null;
-  width?: number | null;
-  height?: number | null;
-  fit?: 'scale-down' | 'contain' | 'cover' | 'crop' | 'pad';
-  anim?: boolean;
-  blur?: number; // 0-250
-  quality?: number; // 0-100
-  gravity?: 'auto' | 'side' | 'left' | 'right' | 'top' | 'bottom';
-  metadata?: 'keep' | 'copyright' | 'none';
-  background?: string;
-  gamma?: number;
-  optimized?: boolean;
-  transcode?: boolean;
-  type?: MediaType;
-  original?: boolean;
-  skip?: number;
-};
-
-const typeExtensions: Record<MediaType, string> = {
-  image: '.jpeg',
-  video: '.mp4',
-  audio: '.mp3',
-};
-
-// Discrete width ladder mirroring civitai-image-cacher's `ImageCacherOptions.CommonSizes`
-// (see appsettings.json in civitai-image-cacher). The cacher already snaps requested
-// widths up to the next ladder value server-side, but only AFTER admitting the unique
-// URL into its cache — costing one B2 Class C HEAD per unique width. By snapping
-// client-side to the same ladder we collapse cache cardinality before emission.
-//
-// Must stay in sync with the deployed cacher's CommonSizes. If the values diverge,
-// the snap simply becomes less effective (no correctness impact) — the cacher's
-// server-side snap remains the source of truth.
-export const COMMON_IMAGE_WIDTHS = [96, 320, 450, 512, 800, 1200, 1600, 2200] as const;
-
-/**
- * Snap a requested width up to the next value in `COMMON_IMAGE_WIDTHS`.
- *
- * Behavior matches `ServeImageMiddleware.cs` in civitai-image-cacher:
- *  - If the width is already in the ladder, leave it alone.
- *  - Otherwise, return the first ladder value strictly greater than `width`.
- *  - If no ladder value is greater (i.e. the request exceeds the ladder top),
- *    return the original width unchanged so callers that explicitly oversized
- *    aren't capped here. The existing 1800 cap in `getEdgeUrl` still applies.
- */
-export function snapWidthToCommonSize(width: number): number {
-  for (const size of COMMON_IMAGE_WIDTHS) {
-    if (size === width) return width;
-    if (size > width) return size;
-  }
-  return width;
-}
-
-export function getEdgeUrl(
-  src: string,
-  {
-    name,
-    type,
-    anim,
-    transcode,
-    width,
-    height,
-    original,
-    fit,
-    blur,
-    quality,
-    gravity,
-    metadata,
-    background,
-    gamma,
-    optimized,
-    skip,
-  }: Omit<EdgeUrlProps, 'src'> = {}
-) {
-  if (!src || src.startsWith('http') || src.startsWith('blob')) return src;
-
-  if (!width && !height && original === undefined) original = true;
-  if (original) {
-    width = undefined;
-    height = undefined;
-  }
-  // if(width && height) // TODO
-  // Snap width to the cacher's CommonSizes ladder *before* the 1800 cap so the cap
-  // remains the final word for over-ladder values. Height is not snapped — the
-  // cacher only snaps width.
-  if (width) width = snapWidthToCommonSize(width);
-  if (width && width > 1800) width = 1800;
-  if (height && height > 1000) height = 1000;
-
-  const modifiedParams = {
-    anim: anim ? undefined : anim,
-    transcode: transcode ? true : undefined,
-    width: width ?? undefined,
-    height: height ?? undefined,
-    original,
-    fit,
-    blur,
-    quality,
-    gravity,
-    metadata,
-    background,
-    gamma,
-    optimized,
-    skip,
-  };
-  const params = Object.entries(modifiedParams)
-    .map(([key, value]) => (value !== undefined ? `${key}=${value}` : undefined))
-    .filter(isDefined)
-    .join(',');
-
-  const extension = typeExtensions[type ?? MediaType.image];
-
-  // application-error logs indicate that `src` is sometimes undefined
-  name = (name ?? src ?? '').replaceAll('%', ''); // % symbol is escape character for url encoding
-  if (name.includes('.')) name = name.split('.').slice(0, -1).join('.') + extension;
-  else name = name + extension;
-
-  return [env.NEXT_PUBLIC_IMAGE_LOCATION, src, params.toString(), name].filter(Boolean).join('/');
-}
-
-const videoTypeExtensions = ['.gif', '.mp4', '.webm'];
-
-export function getInferredMediaType(
-  src: string,
-  options?: { name?: string | null; type?: MediaType | undefined }
-) {
-  return (
-    options?.type ??
-    (videoTypeExtensions.some((ext) => (options?.name || src)?.endsWith(ext)) ? 'video' : 'image')
-  );
-}
+// The pure URL builder now lives in `~/client-utils/edge-url` (React-free, so server
+// modules can resolve a delivery URL without pulling hooks/providers into their import
+// graph). Re-exported here so every existing consumer of this module is unaffected.
+export {
+  COMMON_IMAGE_WIDTHS,
+  OPTIMIZED_WIDTH_THRESHOLD,
+  getEdgeUrl,
+  getInferredMediaType,
+  shouldForceOptimized,
+  snapWidthToCommonSize,
+} from '~/client-utils/edge-url';
+export type { EdgeUrlProps } from '~/client-utils/edge-url';
 
 export function useEdgeUrl(src: string, options: Omit<EdgeUrlProps, 'src'> | undefined) {
   const currentUser = useCurrentUser();
@@ -160,7 +40,9 @@ export function useEdgeUrl(src: string, options: Omit<EdgeUrlProps, 'src'> | und
   }
 
   if (!anim) type = 'image';
-  const shouldOptimize = options?.width && options.width <= 450;
+  // Threshold lives in `edge-url` so anything that has to reproduce this decision
+  // outside React (the announcement banner health monitor) cannot drift from it.
+  const shouldOptimize = shouldForceOptimized(options?.width);
   const optimized =
     options?.optimized ||
     shouldOptimize ||

--- a/src/client-utils/edge-url.ts
+++ b/src/client-utils/edge-url.ts
@@ -1,0 +1,166 @@
+import { MediaType } from '~/shared/utils/prisma/enums';
+import { env } from '~/env/client';
+import { isDefined } from '~/utils/type-guards';
+
+/**
+ * Pure, React-free edge-URL construction.
+ *
+ * Split out of `cf-images-utils.ts` so a **server** module can resolve a delivery URL
+ * without dragging React client modules (`useCurrentUser`, `BrowserSettingsProvider`)
+ * into its import graph. `cf-images-utils` re-exports everything here, so every existing
+ * consumer is unaffected; the React hooks (`useEdgeUrl`, `useGetEdgeUrl`) stay there.
+ *
+ * Nothing in this file may import React, a hook, or a provider.
+ */
+
+// from options available in CF Flexible variants:
+// https://developers.cloudflare.com/images/cloudflare-images/transform/flexible-variants/
+export type EdgeUrlProps = {
+  src: string;
+  name?: string | null;
+  width?: number | null;
+  height?: number | null;
+  fit?: 'scale-down' | 'contain' | 'cover' | 'crop' | 'pad';
+  anim?: boolean;
+  blur?: number; // 0-250
+  quality?: number; // 0-100
+  gravity?: 'auto' | 'side' | 'left' | 'right' | 'top' | 'bottom';
+  metadata?: 'keep' | 'copyright' | 'none';
+  background?: string;
+  gamma?: number;
+  optimized?: boolean;
+  transcode?: boolean;
+  type?: MediaType;
+  original?: boolean;
+  skip?: number;
+};
+
+const typeExtensions: Record<MediaType, string> = {
+  image: '.jpeg',
+  video: '.mp4',
+  audio: '.mp3',
+};
+
+// Discrete width ladder mirroring civitai-image-cacher's `ImageCacherOptions.CommonSizes`
+// (see appsettings.json in civitai-image-cacher). The cacher already snaps requested
+// widths up to the next ladder value server-side, but only AFTER admitting the unique
+// URL into its cache — costing one B2 Class C HEAD per unique width. By snapping
+// client-side to the same ladder we collapse cache cardinality before emission.
+//
+// Must stay in sync with the deployed cacher's CommonSizes. If the values diverge,
+// the snap simply becomes less effective (no correctness impact) — the cacher's
+// server-side snap remains the source of truth.
+export const COMMON_IMAGE_WIDTHS = [96, 320, 450, 512, 800, 1200, 1600, 2200] as const;
+
+/**
+ * Below (and at) this requested width the render path forces `optimized=true`.
+ *
+ * 🔴 Load-bearing and deliberately shared: `useEdgeUrl` decides the `optimized` flag
+ * from this number, so anything that has to reproduce a URL the browser actually
+ * requests (e.g. `~/components/Announcements/announcement-image`, whose health monitor
+ * would otherwise probe a variant nobody loads and report a false failure) must read
+ * this constant rather than hardcoding the threshold.
+ */
+export const OPTIMIZED_WIDTH_THRESHOLD = 450;
+
+/** Whether the render path forces `optimized=true` for a given requested width. */
+export function shouldForceOptimized(width?: number | null) {
+  return !!width && width <= OPTIMIZED_WIDTH_THRESHOLD;
+}
+
+/**
+ * Snap a requested width up to the next value in `COMMON_IMAGE_WIDTHS`.
+ *
+ * Behavior matches `ServeImageMiddleware.cs` in civitai-image-cacher:
+ *  - If the width is already in the ladder, leave it alone.
+ *  - Otherwise, return the first ladder value strictly greater than `width`.
+ *  - If no ladder value is greater (i.e. the request exceeds the ladder top),
+ *    return the original width unchanged so callers that explicitly oversized
+ *    aren't capped here. The existing 1800 cap in `getEdgeUrl` still applies.
+ */
+export function snapWidthToCommonSize(width: number): number {
+  for (const size of COMMON_IMAGE_WIDTHS) {
+    if (size === width) return width;
+    if (size > width) return size;
+  }
+  return width;
+}
+
+export function getEdgeUrl(
+  src: string,
+  {
+    name,
+    type,
+    anim,
+    transcode,
+    width,
+    height,
+    original,
+    fit,
+    blur,
+    quality,
+    gravity,
+    metadata,
+    background,
+    gamma,
+    optimized,
+    skip,
+  }: Omit<EdgeUrlProps, 'src'> = {}
+) {
+  if (!src || src.startsWith('http') || src.startsWith('blob')) return src;
+
+  if (!width && !height && original === undefined) original = true;
+  if (original) {
+    width = undefined;
+    height = undefined;
+  }
+  // if(width && height) // TODO
+  // Snap width to the cacher's CommonSizes ladder *before* the 1800 cap so the cap
+  // remains the final word for over-ladder values. Height is not snapped — the
+  // cacher only snaps width.
+  if (width) width = snapWidthToCommonSize(width);
+  if (width && width > 1800) width = 1800;
+  if (height && height > 1000) height = 1000;
+
+  const modifiedParams = {
+    anim: anim ? undefined : anim,
+    transcode: transcode ? true : undefined,
+    width: width ?? undefined,
+    height: height ?? undefined,
+    original,
+    fit,
+    blur,
+    quality,
+    gravity,
+    metadata,
+    background,
+    gamma,
+    optimized,
+    skip,
+  };
+  const params = Object.entries(modifiedParams)
+    .map(([key, value]) => (value !== undefined ? `${key}=${value}` : undefined))
+    .filter(isDefined)
+    .join(',');
+
+  const extension = typeExtensions[type ?? MediaType.image];
+
+  // application-error logs indicate that `src` is sometimes undefined
+  name = (name ?? src ?? '').replaceAll('%', ''); // % symbol is escape character for url encoding
+  if (name.includes('.')) name = name.split('.').slice(0, -1).join('.') + extension;
+  else name = name + extension;
+
+  return [env.NEXT_PUBLIC_IMAGE_LOCATION, src, params.toString(), name].filter(Boolean).join('/');
+}
+
+const videoTypeExtensions = ['.gif', '.mp4', '.webm'];
+
+export function getInferredMediaType(
+  src: string,
+  options?: { name?: string | null; type?: MediaType | undefined }
+) {
+  return (
+    options?.type ??
+    (videoTypeExtensions.some((ext) => (options?.name || src)?.endsWith(ext)) ? 'video' : 'image')
+  );
+}

--- a/src/components/Announcements/Announcement.tsx
+++ b/src/components/Announcements/Announcement.tsx
@@ -9,6 +9,7 @@ import {
   dismissAnnouncements,
   useAnnouncementsStore,
 } from '~/components/Announcements/announcements.utils';
+import { ANNOUNCEMENT_IMAGE_WIDTH } from '~/components/Announcements/announcement-image';
 import clsx from 'clsx';
 import { TwCard } from '~/components/TwCard/TwCard';
 import { LegacyActionIcon } from '~/components/LegacyActionIcon/LegacyActionIcon';
@@ -61,7 +62,9 @@ export function Announcement({
         <div className="relative min-h-40 w-40 @max-md:hidden">
           <EdgeMedia
             src={image}
-            width={200}
+            // Shared with `announcement-media-check` so the monitored variant stays the
+            // variant users actually load. See announcement-image.ts.
+            width={ANNOUNCEMENT_IMAGE_WIDTH}
             alt="Announcement banner image"
             className="absolute inset-0 size-full object-cover"
           />

--- a/src/components/Announcements/AnnouncementEditModal.browser.test.tsx
+++ b/src/components/Announcements/AnnouncementEditModal.browser.test.tsx
@@ -1,0 +1,236 @@
+import { describe, expect, test, vi, beforeEach } from 'vitest';
+// `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
+import { renderWithProviders } from '../../../test/component-setup';
+
+/**
+ * The announcement banner cannot be destroyed by an interrupted or failed upload.
+ *
+ * `metadata.image` is a bare object key with no foreign key and no refcount, and losing
+ * it takes the sitewide banner down for everyone. Replacing a banner is a two-step
+ * gesture — remove, then drop — and the upload widget only writes the new key into form
+ * state once the upload succeeds. So the window between "removed" and "uploaded" is a
+ * window in which Save persists *no image*.
+ *
+ * These tests drive the real modal (real form, real upload widget, mocked network) and
+ * pin both halves of the guard: Save cannot land mid-upload, and a FAILED upload puts
+ * the previous key back rather than leaving the cleared value for the next Save.
+ */
+
+const mocks = vi.hoisted(() => ({
+  behavior: 'success' as 'success' | 'fail' | 'hang',
+  uploaded: { url: 'new-banner-key', objectUrl: 'blob:new', id: 'new-banner-key', type: 'image' },
+  mutate: vi.fn(),
+}));
+
+vi.mock('~/hooks/useCFImageUpload', async () => {
+  const { useState } = await import('react');
+  return {
+    useCFImageUpload: () => {
+      const [files, setFiles] = useState<Record<string, unknown>[]>([]);
+      return {
+        files,
+        removeImage: () => undefined,
+        resetFiles: () => setFiles([]),
+        uploadToCF: async () => {
+          if (mocks.behavior === 'hang') return new Promise(() => undefined);
+          setFiles([{ ...mocks.uploaded, status: 'uploading', progress: 0 }]);
+          await new Promise((r) => setTimeout(r, 0));
+          if (mocks.behavior === 'fail') {
+            setFiles([{ ...mocks.uploaded, status: 'error', progress: 0 }]);
+            throw new Error('Upload failed (status 500)');
+          }
+          setFiles([{ ...mocks.uploaded, status: 'success', progress: 100 }]);
+          return mocks.uploaded;
+        },
+      };
+    },
+  };
+});
+
+// Partial mock: other modules in the graph import unrelated named exports from here
+// (`setTrpcBatchingEnabled`), and replacing the module wholesale breaks their import.
+vi.mock('~/utils/trpc', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  trpc: {
+    useUtils: () => ({
+      announcement: { getAnnouncementsPaged: { invalidate: vi.fn() } },
+    }),
+    announcement: {
+      upsertAnnouncement: {
+        useMutation: () => ({ mutate: mocks.mutate, isPending: false }),
+      },
+    },
+  },
+}));
+
+vi.mock('~/components/Dialog/DialogProvider', () => ({
+  useDialogContext: () => ({ opened: true, onClose: vi.fn(), zIndex: 200 }),
+}));
+
+vi.mock('~/components/EdgeMedia/EdgeMedia', () => ({
+  EdgeMedia: ({ src }: { src: string }) => <img alt="preview" data-testid="preview" src={src} />,
+}));
+vi.mock('~/utils/application-error', () => ({ reportApplicationError: vi.fn() }));
+
+import { AnnouncementEditModal } from '~/components/Announcements/AnnouncementEditModal';
+
+const EXISTING_KEY = 'existing-banner-key';
+
+const existingAnnouncement = {
+  id: 42,
+  title: 'Scheduled maintenance',
+  content: 'Back shortly.',
+  color: 'blue',
+  domain: [],
+  startsAt: new Date('2026-07-27T00:00:00.000Z'),
+  endsAt: null,
+  metadata: { image: EXISTING_KEY },
+} as never;
+
+async function findByText<T extends HTMLElement>(selector: string, text: string) {
+  await expect
+    .poll(
+      () =>
+        [...document.querySelectorAll(selector)].find((el) => el.textContent?.trim() === text) ??
+        null,
+      { message: `expected a ${selector} labelled "${text}"` }
+    )
+    .not.toBeNull();
+  return [...document.querySelectorAll(selector)].find(
+    (el) => el.textContent?.trim() === text
+  ) as T;
+}
+
+/**
+ * The upload widget's remove control. Selected by its overlay positioning classes — the
+ * modal's own close button is also icon-only, so "the button with no text" is ambiguous.
+ */
+const REMOVE_CONTROL = 'button[class*="right-1"][class*="top-1"]';
+
+async function removeBanner() {
+  await expect
+    .poll(() => document.querySelector('[data-testid="preview"]'), {
+      message: 'the existing banner preview should render',
+    })
+    .not.toBeNull();
+  await expect
+    .poll(() => document.querySelector(REMOVE_CONTROL), {
+      message: 'expected the remove-image control',
+    })
+    .not.toBeNull();
+  (document.querySelector(REMOVE_CONTROL) as HTMLElement).click();
+}
+
+async function dropBanner() {
+  await expect
+    .poll(() => document.querySelector('input[type="file"]'), {
+      message: 'the dropzone should be available after removing the banner',
+    })
+    .not.toBeNull();
+  const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+  const transfer = new DataTransfer();
+  transfer.items.add(new File(['x'], 'banner.png', { type: 'image/png' }));
+  input.files = transfer.files;
+  input.dispatchEvent(new Event('change', { bubbles: true }));
+}
+
+/**
+ * Wait for the banner preview to settle on a given source.
+ *
+ * Load-bearing: a drop is processed asynchronously, so clicking Save straight after
+ * `dropBanner()` races the re-render and would pass for the wrong reason. The preview
+ * src is the observable end state of the upload — the new object URL on success, the
+ * restored key on failure.
+ */
+async function waitForPreviewSrc(fragment: string) {
+  await expect
+    .poll(() => document.querySelector('[data-testid="preview"]')?.getAttribute('src') ?? null, {
+      message: `expected the banner preview to settle on "${fragment}"`,
+    })
+    .toContain(fragment);
+}
+
+const savedImage = () => mocks.mutate.mock.calls.at(-1)?.[0]?.metadata?.image;
+
+describe('AnnouncementEditModal banner safety', () => {
+  beforeEach(() => {
+    mocks.behavior = 'success';
+    mocks.mutate.mockClear();
+  });
+
+  test('saving an untouched announcement round-trips the stored key byte-identically', async () => {
+    renderWithProviders(<AnnouncementEditModal announcement={existingAnnouncement} />);
+
+    (await findByText<HTMLButtonElement>('button', 'Save')).click();
+
+    await vi.waitFor(() => expect(mocks.mutate).toHaveBeenCalled());
+    expect(savedImage()).toBe(EXISTING_KEY);
+  });
+
+  test('Save is blocked while a replacement upload is in flight', async () => {
+    mocks.behavior = 'hang';
+    renderWithProviders(<AnnouncementEditModal announcement={existingAnnouncement} />);
+
+    await removeBanner();
+    await dropBanner();
+
+    // 🔴 The window in which a save used to persist `image: undefined` and kill the
+    // live sitewide banner.
+    const save = await findByText<HTMLButtonElement>('button', 'Uploading image…');
+    expect(save.disabled).toBe(true);
+
+    save.click();
+    // Belt-and-braces: the submit handler refuses even if the click gets through
+    // (a disabled button does not stop an Enter-key submit).
+    await new Promise((r) => setTimeout(r, 50));
+    expect(mocks.mutate).not.toHaveBeenCalled();
+  });
+
+  test('a failed replacement restores the previous key instead of saving no banner', async () => {
+    mocks.behavior = 'fail';
+    renderWithProviders(<AnnouncementEditModal announcement={existingAnnouncement} />);
+
+    await removeBanner();
+    await dropBanner();
+
+    // 🔴 The previous banner is put back rather than left cleared — visible to the
+    // moderator, not just recovered silently in form state.
+    await waitForPreviewSrc(EXISTING_KEY);
+
+    // And the button is usable again — a failed upload must not trap the moderator.
+    const save = await findByText<HTMLButtonElement>('button', 'Save');
+    expect(save.disabled).toBe(false);
+    save.click();
+
+    await vi.waitFor(() => expect(mocks.mutate).toHaveBeenCalled());
+    expect(savedImage()).toBe(EXISTING_KEY);
+  });
+
+  test('a successful replacement saves the NEW key', async () => {
+    mocks.behavior = 'success';
+    renderWithProviders(<AnnouncementEditModal announcement={existingAnnouncement} />);
+
+    await removeBanner();
+    await dropBanner();
+    await waitForPreviewSrc('blob:new');
+
+    const save = await findByText<HTMLButtonElement>('button', 'Save');
+    expect(save.disabled).toBe(false);
+    save.click();
+
+    await vi.waitFor(() => expect(mocks.mutate).toHaveBeenCalled());
+    expect(savedImage()).toBe('new-banner-key');
+  });
+
+  test('an explicit remove with no replacement drops the key entirely', async () => {
+    renderWithProviders(<AnnouncementEditModal announcement={existingAnnouncement} />);
+
+    await removeBanner();
+    (await findByText<HTMLButtonElement>('button', 'Save')).click();
+
+    await vi.waitFor(() => expect(mocks.mutate).toHaveBeenCalled());
+    // `announcementMetaSchema.image` is `z.string().optional()` — undefined, never null
+    // and never an empty string.
+    expect(savedImage()).toBeUndefined();
+  });
+});

--- a/src/components/Announcements/AnnouncementEditModal.tsx
+++ b/src/components/Announcements/AnnouncementEditModal.tsx
@@ -10,10 +10,16 @@ import {
   InputDatePicker,
   InputMultiSelect,
   InputSelect,
+  InputSimpleImageUpload,
   InputText,
   InputTextArea,
   useForm,
 } from '~/libs/form';
+import {
+  ANNOUNCEMENT_IMAGE_WIDTH,
+  announcementImageFormSchema,
+  toAnnouncementImageKey,
+} from '~/components/Announcements/announcement-image';
 import type { UpsertAnnouncementSchema } from '~/server/schema/announcement.schema';
 import { DomainColor } from '~/shared/utils/prisma/enums';
 import { dateWithoutTimezone, endOfDay, startOfDay } from '~/utils/date-helpers';
@@ -27,7 +33,7 @@ const schema = z.object({
   domain: z.enum(DomainColor).array().default([DomainColor.all]),
   startsAt: z.date(),
   endsAt: z.date().nullish(),
-  image: z.string().optional(),
+  image: announcementImageFormSchema,
   disabled: z.boolean().optional(),
   linkText: z.string().optional(),
   linkUrl: z.string().optional(),
@@ -80,7 +86,7 @@ export function AnnouncementEditModal({
     },
   });
 
-  function handleSubmit(data: z.infer<typeof schema>) {
+  function handleSubmit({ image, ...data }: z.infer<typeof schema>) {
     const startsAtUtc = dayjs.utc(data.startsAt).toDate();
     const isToday = startsAtUtc.toDateString() === new Date().toDateString();
     const { domain } = data;
@@ -99,7 +105,8 @@ export function AnnouncementEditModal({
           data.linkText && data.linkUrl
             ? [{ type: 'button', link: data.linkUrl, linkText: data.linkText }]
             : undefined,
-        image: data.image,
+        // Wire format is unchanged: a bare object key string (or undefined).
+        image: toAnnouncementImageKey(image),
       },
       domain: domain.length ? domain : [DomainColor.all],
     });
@@ -132,8 +139,38 @@ export function AnnouncementEditModal({
           clearable
         />
 
+        {/*
+          Banner upload — deliberately does NOT create an `Image` row.
+
+          `SimpleImageUpload` uploads via `/api/v1/image-upload`, which mints an object
+          key and a presigned PUT and nothing else. That is the point: `deleteImageFromS3`
+          is row-scoped, not bucket-scoped — every one of its call sites hands it an
+          `Image` row's id and url. A key that is not any `Image.url` therefore cannot be
+          reached by any deletion path in the app, so the banner cannot be deleted out
+          from under a live announcement. That is exactly the failure that broke a
+          sitewide announcement banner for every user. Membership badges already use this
+          same no-row pattern.
+
+          🔴 DO NOT "fix" this by adding a `createImage` / `dbWrite.image` call here.
+          Creating the row is what makes the object deletable, which reintroduces the bug.
+
+          🔴 Accepted, documented cost: these keys are intentionally UNREGISTERED — no
+          `Image` row, so no garbage collector will ever reclaim them. Any future
+          orphan-cleanup job over the uploads bucket keyed on "object has no `Image` row"
+          MUST exclude keys referenced by `Announcement.metadata->>'image'` (and the other
+          bare-key media pointers: `Cosmetic.data.url`, `Tool.icon`/`metadata.header`,
+          `Partner.logo`, `User.image`), or it will reproduce this outage from a new
+          direction. `~/server/jobs/announcement-media-check` monitors for exactly that.
+        */}
+        <InputSimpleImageUpload
+          name="image"
+          label="Banner Image"
+          description="Shown alongside the announcement. Uploads are stored as a bare object key."
+          previewWidth={ANNOUNCEMENT_IMAGE_WIDTH}
+          withNsfwLevel={false}
+        />
+
         <div className="grid grid-cols-1 gap-3 @sm:grid-cols-2">
-          <InputText name="image" label="Image ID" />
           <InputSelect
             name="color"
             label="Color"

--- a/src/components/Announcements/AnnouncementEditModal.tsx
+++ b/src/components/Announcements/AnnouncementEditModal.tsx
@@ -1,7 +1,7 @@
 import type { SelectProps } from '@mantine/core';
 import { Button, ColorSwatch, Modal, useMantineTheme } from '@mantine/core';
 import dayjs from '~/shared/utils/dayjs';
-import { useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import * as z from 'zod';
 import { useDialogContext } from '~/components/Dialog/DialogProvider';
 import {
@@ -15,9 +15,11 @@ import {
   InputTextArea,
   useForm,
 } from '~/libs/form';
+import type { SimpleImageUploadState } from '~/libs/form/components/SimpleImageUpload';
 import {
   ANNOUNCEMENT_IMAGE_WIDTH,
   announcementImageFormSchema,
+  toAnnouncementImageFormValue,
   toAnnouncementImageKey,
 } from '~/components/Announcements/announcement-image';
 import type { UpsertAnnouncementSchema } from '~/server/schema/announcement.schema';
@@ -39,6 +41,8 @@ const schema = z.object({
   linkUrl: z.string().optional(),
 });
 
+export const UPLOAD_IN_FLIGHT_MESSAGE = 'Wait for the banner image to finish uploading.';
+
 const domainColorOptions = Object.values(DomainColor).map((domain) => ({
   value: domain,
   label: `${capitalize(domain)} ${domain === DomainColor.all ? 'Servers' : 'Server'}`,
@@ -59,6 +63,9 @@ export function AnnouncementEditModal({
   const queryUtils = trpc.useUtils();
   const startsAtRef = useRef<Date | null>(null);
   const isToday = announcement?.startsAt?.toDateString() === new Date().toDateString();
+  // A banner upload in flight has NOT yet reached form state — see the guard in
+  // `handleSubmit` and `UPLOAD_IN_FLIGHT_MESSAGE`.
+  const [imageUploading, setImageUploading] = useState(false);
 
   const form = useForm({
     schema,
@@ -71,13 +78,33 @@ export function AnnouncementEditModal({
           : startOfDay(dateWithoutTimezone(announcement.startsAt))
         : new Date(),
       endsAt: endsAt ? startOfDay(dateWithoutTimezone(endsAt)) : null,
-      image: announcement?.metadata?.image,
+      image: toAnnouncementImageFormValue(announcement?.metadata),
       linkText: action?.linkText,
       linkUrl: action?.link,
     },
   });
   const theme = useMantineTheme();
   const colors = Object.keys(theme.colors);
+
+  // Last banner key the form actually held. Replacing a banner is a two-step gesture —
+  // remove (which clears form state) then drop — so at the moment an upload fails the
+  // form no longer remembers what it is about to overwrite. Keeping the last non-empty
+  // value lets a failed replacement be undone instead of silently saved as "no banner".
+  const watchedImage = form.watch('image');
+  const lastImageRef = useRef(toAnnouncementImageFormValue(announcement?.metadata));
+  useEffect(() => {
+    if (watchedImage) lastImageRef.current = watchedImage;
+  }, [watchedImage]);
+
+  function handleUploadStateChange(state: SimpleImageUploadState) {
+    setImageUploading(state === 'uploading');
+    if (state === 'uploading') form.clearErrors('image');
+    // 🔴 A failed upload must not degrade into "the moderator removed the banner".
+    // Restore what was there so a save cannot land the empty value the failed replace
+    // left behind; the upload widget keeps its own error visible, and the restored
+    // preview can be removed again if removal really was the intent.
+    if (state === 'error' && lastImageRef.current) form.setValue('image', lastImageRef.current);
+  }
 
   const { mutate, isPending: isLoading } = trpc.announcement.upsertAnnouncement.useMutation({
     onSuccess: () => {
@@ -87,6 +114,19 @@ export function AnnouncementEditModal({
   });
 
   function handleSubmit({ image, ...data }: z.infer<typeof schema>) {
+    // 🔴 A submit must not land while a banner upload is in flight. The upload widget
+    // only writes the new key into form state once the upload reaches `success`, and
+    // replacing a banner means removing the old one first — so a save mid-upload
+    // persists the CLEARED value and the sitewide banner disappears. That is not
+    // hypothetical: a lost `metadata.image` is what this whole change exists for.
+    //
+    // The Save button is disabled meanwhile; this guard additionally covers an
+    // Enter-key submit, which a disabled button does not prevent.
+    if (imageUploading) {
+      form.setError('image', { type: 'manual', message: UPLOAD_IN_FLIGHT_MESSAGE });
+      return;
+    }
+
     const startsAtUtc = dayjs.utc(data.startsAt).toDate();
     const isToday = startsAtUtc.toDateString() === new Date().toDateString();
     const { domain } = data;
@@ -168,18 +208,17 @@ export function AnnouncementEditModal({
           description="Shown alongside the announcement. Uploads are stored as a bare object key."
           previewWidth={ANNOUNCEMENT_IMAGE_WIDTH}
           withNsfwLevel={false}
+          onUploadStateChange={handleUploadStateChange}
         />
 
-        <div className="grid grid-cols-1 gap-3 @sm:grid-cols-2">
-          <InputSelect
-            name="color"
-            label="Color"
-            data={colors.map((color) => ({ value: color, label: color }))}
-            renderOption={renderSelectOption}
-            searchable
-            clearable
-          />
-        </div>
+        <InputSelect
+          name="color"
+          label="Color"
+          data={colors.map((color) => ({ value: color, label: color }))}
+          renderOption={renderSelectOption}
+          searchable
+          clearable
+        />
 
         <div className="grid grid-cols-1 gap-3 @sm:grid-cols-2">
           <InputDatePicker
@@ -198,8 +237,8 @@ export function AnnouncementEditModal({
         </div>
 
         <InputCheckbox name="disabled" label="Disabled" />
-        <Button type="submit" loading={isLoading}>
-          Save
+        <Button type="submit" loading={isLoading} disabled={imageUploading}>
+          {imageUploading ? 'Uploading image…' : 'Save'}
         </Button>
       </Form>
     </Modal>

--- a/src/components/Announcements/__tests__/announcement-image.test.ts
+++ b/src/components/Announcements/__tests__/announcement-image.test.ts
@@ -9,11 +9,24 @@ vi.mock('~/env/client', () => ({
   },
 }));
 
-import { getEdgeUrl } from '~/client-utils/cf-images-utils';
+// `useEdgeUrl` is the REAL render path and the thing the monitor must agree with. It is
+// a hook only in the sense that it calls `useCurrentUser()`; with that stubbed it is a
+// pure function, so it can be exercised directly from the node suite. Stub it to a
+// signed-out viewer — the default, and the one whose `filePreferences` cannot mask a
+// threshold change by forcing `optimized` on independently.
+vi.mock('~/hooks/useCurrentUser', () => ({ useCurrentUser: () => null }));
+vi.mock('~/providers/BrowserSettingsProvider', () => ({ useBrowsingSettings: () => false }));
+
+// Imported under a non-`use` alias on purpose: it is a hook only by naming convention
+// (its single hook call, `useCurrentUser`, is stubbed above), and the rules-of-hooks
+// lint would otherwise reject calling it inside the width-ladder loop below.
+import { getEdgeUrl, useEdgeUrl as resolveRenderedUrl } from '~/client-utils/cf-images-utils';
+import { OPTIMIZED_WIDTH_THRESHOLD, shouldForceOptimized } from '~/client-utils/edge-url';
 import {
   ANNOUNCEMENT_IMAGE_WIDTH,
   announcementImageFormSchema,
   getAnnouncementImageUrl,
+  toAnnouncementImageFormValue,
   toAnnouncementImageKey,
 } from '~/components/Announcements/announcement-image';
 
@@ -47,9 +60,44 @@ describe('getAnnouncementImageUrl', () => {
   });
 
   it('keeps the render width inside the range that forces optimized', () => {
-    // useEdgeUrl forces optimized for widths <= 450; if the banner width ever grows past
-    // that, this helper's hardcoded `optimized: true` would stop matching the render.
-    expect(ANNOUNCEMENT_IMAGE_WIDTH).toBeLessThanOrEqual(450);
+    // The helper derives `optimized` from the same predicate the render path uses, so a
+    // threshold change can no longer desync them — but a width above the threshold would
+    // still change which variant users load, so pin the relationship explicitly.
+    expect(ANNOUNCEMENT_IMAGE_WIDTH).toBeLessThanOrEqual(OPTIMIZED_WIDTH_THRESHOLD);
+    expect(shouldForceOptimized(ANNOUNCEMENT_IMAGE_WIDTH)).toBe(true);
+  });
+
+  it('equals the URL the render path actually produces, not a hand-rolled mirror', () => {
+    // 🔴 The binding test. `Announcement.tsx` renders
+    // `<EdgeMedia src={key} width={ANNOUNCEMENT_IMAGE_WIDTH} />`, and EdgeMedia resolves
+    // its src through `useEdgeUrl`. Compare against that function's real output rather
+    // than against `getEdgeUrl(..., { optimized: true })`, which would re-assert the
+    // helper's own assumption. Fails if the optimized threshold, the width ladder, the
+    // 1800 cap, the type/extension inference or the param order ever change under it —
+    // any of which would make the monitor probe a variant nobody loads and then emit a
+    // false `announcement-image-render-failed` on a healthy banner.
+    const rendered = resolveRenderedUrl(KEY, { width: ANNOUNCEMENT_IMAGE_WIDTH });
+    expect(getAnnouncementImageUrl(KEY)).toBe(rendered.url);
+  });
+
+  it('tracks the render path across the whole width ladder, not just the current width', () => {
+    // Generalises the binding: for any width the banner could plausibly be given, the
+    // helper's construction and the render path agree. Guards a future edit to
+    // ANNOUNCEMENT_IMAGE_WIDTH as well as to the ladder/threshold.
+    for (const width of [96, 200, 320, 450, 451, 512, 800, 2400]) {
+      const expected = resolveRenderedUrl(KEY, { width }).url;
+      const actual = getEdgeUrl(KEY, {
+        width,
+        optimized: shouldForceOptimized(width) ? true : undefined,
+      });
+      expect(actual, `width=${width}`).toBe(expected);
+    }
+  });
+
+  it('drops the optimized flag entirely above the threshold (never optimized=false)', () => {
+    const wide = OPTIMIZED_WIDTH_THRESHOLD + 1;
+    expect(shouldForceOptimized(wide)).toBe(false);
+    expect(resolveRenderedUrl(KEY, { width: wide }).url).not.toContain('optimized');
   });
 });
 
@@ -77,6 +125,54 @@ describe('announcement image form value <-> wire format', () => {
     expect(announcementImageFormSchema.parse({ url: KEY })).toMatchObject({ url: KEY });
     expect(announcementImageFormSchema.parse(null)).toBeNull();
     expect(announcementImageFormSchema.parse(undefined)).toBeUndefined();
+  });
+
+  describe('wire-format round-trip through the modal form', () => {
+    // The highest-stakes behaviour: editing a live announcement and saving it unchanged
+    // must not rewrite `metadata.image`. Mirrors what the modal does — read the stored
+    // metadata into `defaultValues.image`, let the form schema validate it, normalise on
+    // submit — without booting the modal itself.
+    const submit = (formValue: unknown) =>
+      toAnnouncementImageKey(announcementImageFormSchema.parse(formValue));
+
+    it('load -> save unchanged is byte-identical for a stored bare key', () => {
+      const stored = { image: KEY, colSpan: 6 };
+      const loaded = toAnnouncementImageFormValue(stored);
+      expect(loaded).toBe(KEY);
+      expect(submit(loaded)).toBe(KEY);
+      // Byte-identical, not merely equal: same string, no re-encoding or trimming.
+      expect(submit(loaded)).toStrictEqual(stored.image);
+    });
+
+    it('a fresh upload persists the uploaded key, not the widget object', () => {
+      // The widget hands the form a DataFromFile-shaped object on success.
+      const uploaded = { url: KEY, objectUrl: 'blob:http://localhost/abc', id: KEY, type: 'image' };
+      expect(submit(uploaded)).toBe(KEY);
+    });
+
+    it('replacing an existing banner persists the NEW key', () => {
+      const replacement = 'ffffffff-1111-2222-3333-444444444444';
+      const loaded = toAnnouncementImageFormValue({ image: KEY });
+      expect(submit(loaded)).toBe(KEY);
+      expect(submit({ url: replacement })).toBe(replacement);
+    });
+
+    it('clearing drops the key entirely rather than persisting null or an empty string', () => {
+      // `announcementMetaSchema.image` is `z.string().optional()`. `null` fails that
+      // schema outright, and `""` would persist a key that resolves to a broken URL —
+      // the metadata field must simply be absent.
+      expect(submit(null)).toBeUndefined();
+      expect(submit(undefined)).toBeUndefined();
+      expect(Object.prototype.hasOwnProperty.call({ image: submit(null) }, 'image')).toBe(true);
+      expect(JSON.stringify({ image: submit(null) })).toBe('{}');
+    });
+
+    it('loads no value from an announcement that never had a banner', () => {
+      expect(toAnnouncementImageFormValue(undefined)).toBeUndefined();
+      expect(toAnnouncementImageFormValue(null)).toBeUndefined();
+      expect(toAnnouncementImageFormValue({})).toBeUndefined();
+      expect(submit(toAnnouncementImageFormValue({}))).toBeUndefined();
+    });
   });
 
   it('round-trips form state back to the exact wire format the renderer reads', () => {

--- a/src/components/Announcements/__tests__/announcement-image.test.ts
+++ b/src/components/Announcements/__tests__/announcement-image.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi } from 'vitest';
+
+// `cf-images-utils` reads `env.NEXT_PUBLIC_IMAGE_LOCATION` at call time. Stub the
+// client env module before importing the unit under test so we don't trip the
+// zod schema check in `~/env/client`.
+vi.mock('~/env/client', () => ({
+  env: {
+    NEXT_PUBLIC_IMAGE_LOCATION: 'https://image.test',
+  },
+}));
+
+import { getEdgeUrl } from '~/client-utils/cf-images-utils';
+import {
+  ANNOUNCEMENT_IMAGE_WIDTH,
+  announcementImageFormSchema,
+  getAnnouncementImageUrl,
+  toAnnouncementImageKey,
+} from '~/components/Announcements/announcement-image';
+
+const KEY = '7171bdc6-8007-492c-84ad-f607e4dbd320';
+
+describe('getAnnouncementImageUrl', () => {
+  it('reproduces the variant the banner actually renders', () => {
+    // 200 snaps up the common-size ladder to 320, and widths <= 450 force optimized.
+    expect(getAnnouncementImageUrl(KEY)).toBe(
+      `https://image.test/${KEY}/width=320,optimized=true/${KEY}.jpeg`
+    );
+  });
+
+  it('matches what getEdgeUrl produces for the rendered width', () => {
+    expect(getAnnouncementImageUrl(KEY)).toBe(
+      getEdgeUrl(KEY, { width: ANNOUNCEMENT_IMAGE_WIDTH, optimized: true })
+    );
+  });
+
+  it('snaps the render width up to 320 rather than emitting it verbatim', () => {
+    const url = getAnnouncementImageUrl(KEY);
+    expect(url).toContain('width=320');
+    expect(url).not.toContain(`width=${ANNOUNCEMENT_IMAGE_WIDTH}`);
+  });
+
+  it('is NOT the original variant', () => {
+    // The original object and the derived variant are different derivation paths —
+    // checking `original=true` is what let a broken banner go unnoticed.
+    expect(getAnnouncementImageUrl(KEY)).not.toContain('original=true');
+    expect(getAnnouncementImageUrl(KEY)).not.toBe(getEdgeUrl(KEY, { original: true }));
+  });
+
+  it('keeps the render width inside the range that forces optimized', () => {
+    // useEdgeUrl forces optimized for widths <= 450; if the banner width ever grows past
+    // that, this helper's hardcoded `optimized: true` would stop matching the render.
+    expect(ANNOUNCEMENT_IMAGE_WIDTH).toBeLessThanOrEqual(450);
+  });
+});
+
+describe('announcement image form value <-> wire format', () => {
+  it('passes a stored bare key through byte-identically', () => {
+    expect(toAnnouncementImageKey(KEY)).toBe(KEY);
+  });
+
+  it('reduces an upload-widget object to its bare key', () => {
+    expect(toAnnouncementImageKey({ url: KEY, id: 5, nsfwLevel: 1 } as never)).toBe(KEY);
+  });
+
+  it('emits undefined (never null) when the image is cleared', () => {
+    // `announcementMetaSchema.image` is `z.string().optional()` — null would not validate.
+    expect(toAnnouncementImageKey(null)).toBeUndefined();
+    expect(toAnnouncementImageKey(undefined)).toBeUndefined();
+  });
+
+  it('preserves the empty string rather than silently changing the stored shape', () => {
+    expect(toAnnouncementImageKey('')).toBe('');
+  });
+
+  it('accepts both the stored string and the upload object in form state', () => {
+    expect(announcementImageFormSchema.parse(KEY)).toBe(KEY);
+    expect(announcementImageFormSchema.parse({ url: KEY })).toMatchObject({ url: KEY });
+    expect(announcementImageFormSchema.parse(null)).toBeNull();
+    expect(announcementImageFormSchema.parse(undefined)).toBeUndefined();
+  });
+
+  it('round-trips form state back to the exact wire format the renderer reads', () => {
+    const fromUpload = announcementImageFormSchema.parse({ url: KEY, extra: true });
+    const fromEdit = announcementImageFormSchema.parse(KEY);
+    expect(toAnnouncementImageKey(fromUpload)).toBe(KEY);
+    expect(toAnnouncementImageKey(fromEdit)).toBe(KEY);
+    // Both paths persist an identical bare key — no announcement's metadata changes shape.
+    expect(toAnnouncementImageKey(fromUpload)).toBe(toAnnouncementImageKey(fromEdit));
+  });
+});

--- a/src/components/Announcements/announcement-image.ts
+++ b/src/components/Announcements/announcement-image.ts
@@ -1,0 +1,61 @@
+import * as z from 'zod';
+import { getEdgeUrl } from '~/client-utils/cf-images-utils';
+
+/**
+ * Shared, isomorphic helpers for the announcement banner image.
+ *
+ * `Announcement.metadata.image` is a **bare object key** (not an `Image` row id and
+ * not a full URL). Both the renderer (`Announcement.tsx`) and the health monitor
+ * (`~/server/jobs/announcement-media-check`) resolve it through this module so the
+ * two cannot drift apart — a monitor that checks a variant nobody loads is a monitor
+ * that lies.
+ */
+
+/**
+ * The width `Announcement.tsx` renders the banner at. Load-bearing: the edge URL
+ * that users actually request is derived from this number, so the monitor must use
+ * the same value.
+ */
+export const ANNOUNCEMENT_IMAGE_WIDTH = 200;
+
+/**
+ * The exact variant URL a browser requests for an announcement banner.
+ *
+ * Mirrors what `useEdgeUrl` computes for `<EdgeMedia src={key} width={ANNOUNCEMENT_IMAGE_WIDTH} />`:
+ *  - `useEdgeUrl` forces `optimized=true` for any width <= 450, and
+ *  - `getEdgeUrl` snaps the width up the common-size ladder (200 -> 320).
+ *
+ * Do NOT substitute `{ original: true }` here. The original object and the derived
+ * variant are different cache/derivation paths — the original can serve 200 while
+ * the variant users load 404s, which is precisely how the outage this monitors for
+ * went unnoticed.
+ */
+export function getAnnouncementImageUrl(key: string) {
+  return getEdgeUrl(key, { width: ANNOUNCEMENT_IMAGE_WIDTH, optimized: true });
+}
+
+/**
+ * Form-state shape for the announcement banner field.
+ *
+ * The upload widget (`SimpleImageUpload`) emits an object (`{ url, ... }`) on
+ * success and `null` on remove, while an announcement being edited loads the stored
+ * **bare key string**. Accept all three here and normalise on submit — the persisted
+ * `metadata.image` must stay a bare key string.
+ */
+export const announcementImageFormSchema = z
+  .union([z.string(), z.object({ url: z.string() }).passthrough()])
+  .nullish();
+
+export type AnnouncementImageFormValue = z.infer<typeof announcementImageFormSchema>;
+
+/**
+ * Normalise the form value back to the persisted wire format: a bare object key, or
+ * `undefined` when there is no image. Never emits `null` — `announcementMetaSchema`
+ * types `image` as `z.string().optional()`.
+ */
+export function toAnnouncementImageKey(
+  value: AnnouncementImageFormValue
+): string | undefined {
+  if (typeof value === 'string') return value;
+  return value?.url;
+}

--- a/src/components/Announcements/announcement-image.ts
+++ b/src/components/Announcements/announcement-image.ts
@@ -1,5 +1,5 @@
 import * as z from 'zod';
-import { getEdgeUrl } from '~/client-utils/cf-images-utils';
+import { getEdgeUrl, shouldForceOptimized } from '~/client-utils/edge-url';
 
 /**
  * Shared, isomorphic helpers for the announcement banner image.
@@ -9,6 +9,12 @@ import { getEdgeUrl } from '~/client-utils/cf-images-utils';
  * (`~/server/jobs/announcement-media-check`) resolve it through this module so the
  * two cannot drift apart — a monitor that checks a variant nobody loads is a monitor
  * that lies.
+ *
+ * Imports the **React-free** `~/client-utils/edge-url` rather than `cf-images-utils`,
+ * so the server job that pulls this module in does not transitively import
+ * `useCurrentUser` / `BrowserSettingsProvider`. A module-scope `window` access
+ * anywhere in that chain would crash the import of the run-jobs endpoint and take
+ * down every job, not just this one.
  */
 
 /**
@@ -22,8 +28,14 @@ export const ANNOUNCEMENT_IMAGE_WIDTH = 200;
  * The exact variant URL a browser requests for an announcement banner.
  *
  * Mirrors what `useEdgeUrl` computes for `<EdgeMedia src={key} width={ANNOUNCEMENT_IMAGE_WIDTH} />`:
- *  - `useEdgeUrl` forces `optimized=true` for any width <= 450, and
+ *  - the render path forces `optimized=true` at or below `OPTIMIZED_WIDTH_THRESHOLD`,
+ *    read here through the SAME `shouldForceOptimized` predicate `useEdgeUrl` uses
+ *    (hardcoding `optimized: true` would let a threshold change silently make the
+ *    monitor probe a variant nobody loads, and then alert on a healthy banner); and
  *  - `getEdgeUrl` snaps the width up the common-size ladder (200 -> 320).
+ *
+ * `useEdgeUrl` emits `optimized: undefined` rather than `false` when it does not
+ * apply, so the flag is dropped from the URL entirely — matched here.
  *
  * Do NOT substitute `{ original: true }` here. The original object and the derived
  * variant are different cache/derivation paths — the original can serve 200 while
@@ -31,7 +43,10 @@ export const ANNOUNCEMENT_IMAGE_WIDTH = 200;
  * went unnoticed.
  */
 export function getAnnouncementImageUrl(key: string) {
-  return getEdgeUrl(key, { width: ANNOUNCEMENT_IMAGE_WIDTH, optimized: true });
+  return getEdgeUrl(key, {
+    width: ANNOUNCEMENT_IMAGE_WIDTH,
+    optimized: shouldForceOptimized(ANNOUNCEMENT_IMAGE_WIDTH) ? true : undefined,
+  });
 }
 
 /**
@@ -49,13 +64,25 @@ export const announcementImageFormSchema = z
 export type AnnouncementImageFormValue = z.infer<typeof announcementImageFormSchema>;
 
 /**
+ * The form's initial value for the banner field, read off a loaded announcement.
+ *
+ * Explicit (rather than an inline `announcement?.metadata?.image`) so the load leg of
+ * the round-trip is testable: `toAnnouncementImageKey(parse(toAnnouncementImageFormValue(m)))`
+ * must return the stored key byte-identically, or editing an existing announcement and
+ * saving it unchanged would silently rewrite `metadata.image`.
+ */
+export function toAnnouncementImageFormValue(
+  metadata?: { image?: string } | null
+): AnnouncementImageFormValue {
+  return metadata?.image;
+}
+
+/**
  * Normalise the form value back to the persisted wire format: a bare object key, or
  * `undefined` when there is no image. Never emits `null` — `announcementMetaSchema`
  * types `image` as `z.string().optional()`.
  */
-export function toAnnouncementImageKey(
-  value: AnnouncementImageFormValue
-): string | undefined {
+export function toAnnouncementImageKey(value: AnnouncementImageFormValue): string | undefined {
   if (typeof value === 'string') return value;
   return value?.url;
 }

--- a/src/libs/form/components/SimpleImageUpload.browser.test.tsx
+++ b/src/libs/form/components/SimpleImageUpload.browser.test.tsx
@@ -1,0 +1,208 @@
+import { describe, expect, test, vi, beforeEach } from 'vitest';
+// `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
+import { renderWithProviders } from '../../../../test/component-setup';
+
+/**
+ * `SimpleImageUpload`'s value-preservation contract.
+ *
+ * The widget used to call `handleRemove()` — which fires `onChange(null)` — the instant
+ * a file was dropped, while `onChange` only fires again once the upload reaches
+ * `status === 'success'`. Any form saved in that window, or after a failed upload,
+ * persisted "no image" and destroyed whatever was there. For the announcement banner
+ * that means the sitewide banner disappears; the same shape applies to every consumer
+ * that keeps the dropzone mounted alongside a value (`previewDisabled`).
+ *
+ * These tests pin: a drop never clears the value, a FAILED upload never clears the value
+ * and leaves the widget usable again, a SUCCESSFUL upload emits the new key, and an
+ * explicit remove still clears (the one case that legitimately should).
+ */
+
+const mocks = vi.hoisted(() => ({
+  behavior: 'success' as 'success' | 'fail' | 'hang',
+  uploaded: { url: 'new-key', objectUrl: 'blob:new', id: 'new-key', type: 'image' },
+}));
+
+// Real hook shape, driven per-test. `files` is genuine React state so the component's
+// `useDidUpdate([imageFile])` fires exactly as it does against the real hook.
+vi.mock('~/hooks/useCFImageUpload', async () => {
+  const { useState } = await import('react');
+  return {
+    useCFImageUpload: () => {
+      const [files, setFiles] = useState<Record<string, unknown>[]>([]);
+      return {
+        files,
+        removeImage: () => undefined,
+        resetFiles: () => setFiles([]),
+        uploadToCF: async () => {
+          if (mocks.behavior === 'hang') return new Promise(() => undefined);
+          setFiles([{ ...mocks.uploaded, status: 'uploading', progress: 0 }]);
+          await new Promise((r) => setTimeout(r, 0));
+          if (mocks.behavior === 'fail') {
+            // Mirrors the real hook: the tracked file is left below 100% progress.
+            setFiles([{ ...mocks.uploaded, status: 'error', progress: 0 }]);
+            throw new Error('Upload failed (status 500)');
+          }
+          setFiles([{ ...mocks.uploaded, status: 'success', progress: 100 }]);
+          return mocks.uploaded;
+        },
+      };
+    },
+  };
+});
+
+// Not under test, and the real one resolves a delivery URL through client-only hooks.
+vi.mock('~/components/EdgeMedia/EdgeMedia', () => ({
+  EdgeMedia: ({ src }: { src: string }) => <img alt="preview" data-testid="preview" src={src} />,
+}));
+vi.mock('~/utils/application-error', () => ({ reportApplicationError: vi.fn() }));
+
+import { SimpleImageUpload } from '~/libs/form/components/SimpleImageUpload';
+
+const EXISTING_KEY = 'existing-banner-key';
+
+/**
+ * Drop a file on the mounted dropzone.
+ *
+ * React commits asynchronously, so the input has to be polled for. The file is then set
+ * on the input directly rather than through `userEvent.upload`: the dropzone's input is
+ * visually hidden, and the userEvent helper resolves elements through a visible-role
+ * locator that cannot address it. Assigning `files` + dispatching `change` is exactly
+ * what the browser does on a real pick/drop, and is what react-dropzone listens for.
+ */
+async function dropFile() {
+  await expect
+    .poll(() => document.querySelector('input[type="file"]'), {
+      message: 'the dropzone file input should mount',
+    })
+    .not.toBeNull();
+
+  const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+  const transfer = new DataTransfer();
+  transfer.items.add(new File(['x'], 'banner.png', { type: 'image/png' }));
+  input.files = transfer.files;
+  input.dispatchEvent(new Event('change', { bubbles: true }));
+}
+
+describe('SimpleImageUpload value preservation', () => {
+  beforeEach(() => {
+    mocks.behavior = 'success';
+  });
+
+  test('an in-flight upload never clears the existing value', async () => {
+    mocks.behavior = 'hang';
+    const onChange = vi.fn();
+    const onUploadStateChange = vi.fn();
+
+    renderWithProviders(
+      <SimpleImageUpload
+        label="Banner"
+        value={EXISTING_KEY}
+        previewDisabled
+        withNsfwLevel={false}
+        onChange={onChange}
+        onUploadStateChange={onUploadStateChange}
+      />
+    );
+
+    await dropFile();
+    await vi.waitFor(() => expect(onUploadStateChange).toHaveBeenCalledWith('uploading'));
+
+    // 🔴 The regression: `onChange(null)` here is what a mid-upload save persisted.
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  test('a failed upload never clears the existing value and leaves the widget usable', async () => {
+    mocks.behavior = 'fail';
+    const onChange = vi.fn();
+    const onUploadStateChange = vi.fn();
+
+    renderWithProviders(
+      <SimpleImageUpload
+        label="Banner"
+        value={EXISTING_KEY}
+        previewDisabled
+        withNsfwLevel={false}
+        onChange={onChange}
+        onUploadStateChange={onUploadStateChange}
+      />
+    );
+
+    await dropFile();
+    await vi.waitFor(() => expect(onUploadStateChange).toHaveBeenCalledWith('error'));
+
+    expect(onChange).not.toHaveBeenCalled();
+    // The loading overlay used to be driven by `progress < 100`, which a failed upload
+    // never reaches — pinning the overlay on forever with no way to retry.
+    expect(document.querySelector('input[type="file"]')).not.toBeNull();
+  });
+
+  test('uploading and failing are reported as distinct states, in order', async () => {
+    mocks.behavior = 'fail';
+    const onUploadStateChange = vi.fn();
+
+    renderWithProviders(
+      <SimpleImageUpload
+        label="Banner"
+        previewDisabled
+        withNsfwLevel={false}
+        onUploadStateChange={onUploadStateChange}
+      />
+    );
+
+    await dropFile();
+    await vi.waitFor(() => expect(onUploadStateChange).toHaveBeenCalledWith('error'));
+
+    const states = onUploadStateChange.mock.calls.map(([s]) => s);
+    expect(states.indexOf('uploading')).toBeGreaterThanOrEqual(0);
+    expect(states.indexOf('error')).toBeGreaterThan(states.indexOf('uploading'));
+  });
+
+  test('a successful upload replaces the value with the new key and settles to idle', async () => {
+    mocks.behavior = 'success';
+    const onChange = vi.fn();
+    const onUploadStateChange = vi.fn();
+
+    renderWithProviders(
+      <SimpleImageUpload
+        label="Banner"
+        value={EXISTING_KEY}
+        previewDisabled
+        withNsfwLevel={false}
+        onChange={onChange}
+        onUploadStateChange={onUploadStateChange}
+      />
+    );
+
+    await dropFile();
+    await vi.waitFor(() => expect(onChange).toHaveBeenCalled());
+
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ url: 'new-key' }));
+    // Never a null in between — the parent form only ever sees old key -> new key.
+    expect(onChange.mock.calls.every(([v]) => v !== null)).toBe(true);
+    await vi.waitFor(() => expect(onUploadStateChange.mock.calls.at(-1)?.[0]).toBe('idle'));
+  });
+
+  test('an explicit remove still clears the value', async () => {
+    // The one path that SHOULD emit null. Without a preview there is no remove control,
+    // so this renders the default (preview-enabled) variant.
+    const onChange = vi.fn();
+
+    renderWithProviders(
+      <SimpleImageUpload
+        label="Banner"
+        value={EXISTING_KEY}
+        withNsfwLevel={false}
+        onChange={onChange}
+      />
+    );
+
+    await expect
+      .poll(() => document.querySelector('button'), {
+        message: 'the remove control should render next to the preview',
+      })
+      .not.toBeNull();
+    (document.querySelector('button') as HTMLElement).click();
+
+    expect(onChange).toHaveBeenCalledWith(null);
+  });
+});

--- a/src/libs/form/components/SimpleImageUpload.tsx
+++ b/src/libs/form/components/SimpleImageUpload.tsx
@@ -6,7 +6,7 @@ import { useDidUpdate } from '@mantine/hooks';
 import { IconPhoto, IconTrash, IconUpload, IconX } from '@tabler/icons-react';
 import { isEqual } from 'lodash-es';
 import type { DragEvent } from 'react';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import classes from './SimpleImageUpload.module.scss';
 
@@ -23,11 +23,23 @@ import { reportApplicationError } from '~/utils/application-error';
 import { LegacyActionIcon } from '~/components/LegacyActionIcon/LegacyActionIcon';
 import { isAndroidDevice } from '~/utils/device-helpers';
 
+/**
+ * `idle`   — nothing in flight; the current value is settled.
+ * `uploading` — a drop is being processed/uploaded; the value has NOT changed yet.
+ * `error`  — the last upload attempt failed; the previous value is still intact.
+ */
+export type SimpleImageUploadState = 'idle' | 'uploading' | 'error';
+
 type SimpleImageUploadProps = Omit<InputWrapperProps, 'children' | 'onChange'> & {
   value?:
     | string
     | { id?: number; nsfwLevel?: number; userId?: number; user?: { id: number }; url: string };
   onChange?: (value: DataFromFile | null) => void;
+  /**
+   * Opt-in upload-lifecycle signal for forms that must not submit mid-upload.
+   * Purely additive — consumers that don't pass it behave exactly as before.
+   */
+  onUploadStateChange?: (state: SimpleImageUploadState) => void;
   previewWidth?: number;
   maxSize?: number;
   aspectRatio?: number;
@@ -41,6 +53,7 @@ type SimpleImageUploadProps = Omit<InputWrapperProps, 'children' | 'onChange'> &
 export function SimpleImageUpload({
   value,
   onChange,
+  onUploadStateChange,
   maxSize = constants.mediaUpload.maxImageFileSize,
   previewWidth = 450,
   aspectRatio,
@@ -57,24 +70,42 @@ export function SimpleImageUpload({
   const [image, setImage] = useState<{ url: string; objectUrl?: string } | undefined>();
 
   const [error, setError] = useState('');
+  const [uploading, setUploading] = useState(false);
 
   const handleDrop = async (droppedFiles: FileWithPath[]) => {
     const hasLargeFile = droppedFiles.some((file) => file.size > maxSize);
     if (hasLargeFile) return setError(`Files should not exceed ${formatBytes(maxSize)}`);
 
-    handleRemove();
+    // 🔴 Deliberately does NOT call `handleRemove()` here.
+    //
+    // `handleRemove` fires `onChange(null)`, which cleared the parent form's value the
+    // instant a replacement was dropped — while `onChange` only fires again once the
+    // new upload reaches `status === 'success'`. A form saved mid-upload, or after a
+    // failed upload, therefore persisted "no image" and destroyed the previous one.
+    //
+    // Only `resetFiles()` is needed to free the tracked-file slot for the new upload;
+    // holding the old value until a replacement actually succeeds costs nothing and is
+    // strictly safer. This path is reachable with a value present wherever the dropzone
+    // stays mounted alongside one — `previewDisabled` consumers (e.g.
+    // PurchasableRewardUpsertForm) and the drag-from-generator `onDropCapture`.
+    resetFiles();
     setError('');
+    setUploading(true);
     const [file] = droppedFiles;
 
     try {
       await uploadToCF(file);
     } catch (e) {
       const reason = e instanceof Error && e.message ? e.message : '';
-      setError(reason ? `Image upload failed: ${reason}` : 'Image upload failed. Please try again.');
+      setError(
+        reason ? `Image upload failed: ${reason}` : 'Image upload failed. Please try again.'
+      );
       reportApplicationError(e, {
         name: 'SimpleImageUpload',
         message: `upload failed | file: ${file.name} (${file.type || 'unknown'}, ${file.size}b)`,
       });
+    } finally {
+      setUploading(false);
     }
   };
 
@@ -97,7 +128,10 @@ export function SimpleImageUpload({
     } catch (e) {
       console.error('Failed to load dropped image', e);
       setError("Couldn't load that image. Try saving it and uploading the file instead.");
-      reportApplicationError(e, { name: 'SimpleImageUpload', message: `drag-from-url failed | ${url}` });
+      reportApplicationError(e, {
+        name: 'SimpleImageUpload',
+        message: `drag-from-url failed | ${url}`,
+      });
     }
   };
 
@@ -125,8 +159,17 @@ export function SimpleImageUpload({
     // don't disable the eslint-disable
   }, [imageFile]); // eslint-disable-line
 
-  const [match] = imageFiles;
-  const showLoading = match && match.progress < 100;
+  // Driven by the drop lifecycle rather than upload progress: a failed upload leaves
+  // `progress` below 100 forever, which used to pin the overlay on permanently —
+  // no preview to remove and no dropzone to retry with.
+  const showLoading = uploading;
+
+  const uploadState: SimpleImageUploadState = uploading ? 'uploading' : error ? 'error' : 'idle';
+  const onUploadStateChangeRef = useRef(onUploadStateChange);
+  onUploadStateChangeRef.current = onUploadStateChange;
+  useEffect(() => {
+    onUploadStateChangeRef.current?.(uploadState);
+  }, [uploadState]);
 
   return (
     <Input.Wrapper {...props} error={props.error ?? error}>

--- a/src/pages/api/webhooks/run-jobs/[[...run]].ts
+++ b/src/pages/api/webhooks/run-jobs/[[...run]].ts
@@ -2,6 +2,7 @@ import * as z from 'zod';
 import { isProd } from '~/env/other';
 import { env } from '~/env/server';
 import { addOnDemandRunStrategiesJob } from '~/server/jobs/add-on-demand-run-strategies';
+import { announcementMediaCheckJob } from '~/server/jobs/announcement-media-check';
 import { auditRemixSourcesJob } from '~/server/jobs/audit-remix-sources';
 import { dedupeOfficialUploadsJob } from '~/server/jobs/dedupe-official-uploads';
 import { applyContestTags } from '~/server/jobs/apply-contest-tags';
@@ -204,6 +205,7 @@ export const jobs: Job[] = [
   processEnqueuedComicPanelsJob,
   auditRemixSourcesJob,
   dedupeOfficialUploadsJob,
+  announcementMediaCheckJob,
 ];
 
 const log = createLogger('jobs', 'green');

--- a/src/server/jobs/__tests__/announcement-media-check.test.ts
+++ b/src/server/jobs/__tests__/announcement-media-check.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('~/env/client', () => ({
+  env: { NEXT_PUBLIC_IMAGE_LOCATION: 'https://image.test' },
+}));
+
+// The unit under test is pure, but importing the job module pulls in the db client.
+// Stub it so the suite never instantiates a real Prisma client.
+vi.mock('~/server/db/client', () => ({
+  dbRead: { image: { findMany: vi.fn(async () => []) } },
+  dbWrite: { image: { findMany: vi.fn(async () => []) } },
+}));
+
+import {
+  classifyAnnouncementMedia,
+  evaluateAnnouncementMedia,
+} from '~/server/jobs/announcement-media-check';
+
+const KEY_A = 'aaaaaaaa-0000-0000-0000-000000000001';
+const KEY_B = 'bbbbbbbb-0000-0000-0000-000000000002';
+
+describe('classifyAnnouncementMedia', () => {
+  it('flags a missing object as BROKEN', () => {
+    expect(classifyAnnouncementMedia({ objectExists: false, hasImageRow: false })).toBe('broken');
+  });
+
+  it('flags a key backed by an Image row as AT RISK', () => {
+    expect(classifyAnnouncementMedia({ objectExists: true, hasImageRow: true })).toBe('at-risk');
+  });
+
+  it('reports OK when the object exists and no Image row references it', () => {
+    expect(classifyAnnouncementMedia({ objectExists: true, hasImageRow: false })).toBe('ok');
+  });
+
+  it('lets BROKEN outrank AT RISK', () => {
+    expect(classifyAnnouncementMedia({ objectExists: false, hasImageRow: true })).toBe('broken');
+  });
+
+  it('never manufactures BROKEN from an unknown bucket answer', () => {
+    // null = couldn't consult the bucket. An infra hiccup must not page.
+    expect(classifyAnnouncementMedia({ objectExists: null, hasImageRow: false })).toBe('ok');
+    expect(classifyAnnouncementMedia({ objectExists: null, hasImageRow: true })).toBe('at-risk');
+  });
+});
+
+describe('evaluateAnnouncementMedia', () => {
+  const deps = (over: Partial<Parameters<typeof evaluateAnnouncementMedia>[1]> = {}) => ({
+    objectExists: vi.fn(async () => true as boolean | null),
+    findKeysWithImageRow: vi.fn(async () => [] as string[]),
+    ...over,
+  });
+
+  it('classifies a missing object as broken and attributes the announcement', async () => {
+    const d = deps({ objectExists: vi.fn(async () => false) });
+    const findings = await evaluateAnnouncementMedia([{ id: 746, key: KEY_A }], d);
+
+    expect(findings).toHaveLength(1);
+    expect(findings[0]).toMatchObject({
+      key: KEY_A,
+      status: 'broken',
+      announcementIds: [746],
+      objectExists: false,
+    });
+  });
+
+  it('classifies a key that is also an Image url as at risk', async () => {
+    const d = deps({ findKeysWithImageRow: vi.fn(async () => [KEY_A]) });
+    const findings = await evaluateAnnouncementMedia([{ id: 748, key: KEY_A }], d);
+
+    expect(findings[0]).toMatchObject({ status: 'at-risk', hasImageRow: true });
+  });
+
+  it('reports ok when neither condition holds', async () => {
+    const findings = await evaluateAnnouncementMedia([{ id: 744, key: KEY_A }], deps());
+    expect(findings[0]).toMatchObject({ status: 'ok', hasImageRow: false, objectExists: true });
+  });
+
+  it('checks a shared key once and attributes every announcement that references it', async () => {
+    const d = deps({ objectExists: vi.fn(async () => false) });
+    const findings = await evaluateAnnouncementMedia(
+      [
+        { id: 747, key: KEY_A },
+        { id: 745, key: KEY_A },
+        { id: 737, key: KEY_A },
+        { id: 703, key: KEY_A },
+        { id: 738, key: KEY_B },
+      ],
+      d
+    );
+
+    expect(d.objectExists).toHaveBeenCalledTimes(2);
+    expect(d.findKeysWithImageRow).toHaveBeenCalledWith([KEY_A, KEY_B]);
+
+    const shared = findings.find((f) => f.key === KEY_A);
+    expect(shared?.announcementIds).toEqual([747, 745, 737, 703]);
+  });
+
+  it('does no lookups when nothing is referenced', async () => {
+    const d = deps();
+    expect(await evaluateAnnouncementMedia([], d)).toEqual([]);
+    expect(d.findKeysWithImageRow).not.toHaveBeenCalled();
+    expect(d.objectExists).not.toHaveBeenCalled();
+  });
+
+  it('runs the rendered-variant probe only when the cheap signals are clean', async () => {
+    const probeRenderedVariant = vi.fn(async () => 200 as number | null);
+    const d = deps({
+      objectExists: vi.fn(async (key: string) => key !== KEY_A),
+      probeRenderedVariant,
+    });
+
+    const findings = await evaluateAnnouncementMedia(
+      [
+        { id: 1, key: KEY_A },
+        { id: 2, key: KEY_B },
+      ],
+      d
+    );
+
+    expect(probeRenderedVariant).toHaveBeenCalledTimes(1);
+    expect(probeRenderedVariant).toHaveBeenCalledWith(KEY_B);
+    expect(findings.find((f) => f.key === KEY_A)?.renderedStatus).toBeUndefined();
+    expect(findings.find((f) => f.key === KEY_B)?.renderedStatus).toBe(200);
+  });
+
+  it('surfaces a failed rendered-variant probe without downgrading the cheap signals', async () => {
+    const d = deps({ probeRenderedVariant: vi.fn(async () => 404) });
+    const findings = await evaluateAnnouncementMedia([{ id: 9, key: KEY_A }], d);
+
+    expect(findings[0]).toMatchObject({ status: 'ok', renderedStatus: 404 });
+  });
+});

--- a/src/server/jobs/__tests__/announcement-media-check.test.ts
+++ b/src/server/jobs/__tests__/announcement-media-check.test.ts
@@ -11,9 +11,11 @@ vi.mock('~/server/db/client', () => ({
   dbWrite: { image: { findMany: vi.fn(async () => []) } },
 }));
 
+import type { AnnouncementMediaFinding } from '~/server/jobs/announcement-media-check';
 import {
   classifyAnnouncementMedia,
   evaluateAnnouncementMedia,
+  summarizeAnnouncementMediaFindings,
 } from '~/server/jobs/announcement-media-check';
 
 const KEY_A = 'aaaaaaaa-0000-0000-0000-000000000001';
@@ -40,6 +42,97 @@ describe('classifyAnnouncementMedia', () => {
     // null = couldn't consult the bucket. An infra hiccup must not page.
     expect(classifyAnnouncementMedia({ objectExists: null, hasImageRow: false })).toBe('ok');
     expect(classifyAnnouncementMedia({ objectExists: null, hasImageRow: true })).toBe('at-risk');
+  });
+
+  it('covers the full signal matrix with the intended precedence', () => {
+    // Exhaustive over (objectExists x hasImageRow). Pinned as a table so a change to the
+    // precedence rule is a deliberate edit here, not a silent behaviour change.
+    const matrix: [boolean | null, boolean, string][] = [
+      [false, false, 'broken'], // object gone -> BROKEN
+      [false, true, 'broken'], // both -> BROKEN wins (already failed beats will-fail)
+      [true, true, 'at-risk'], // Image row exists -> AT RISK
+      [true, false, 'ok'], // neither -> OK
+      [null, false, 'ok'], // can't tell -> fail open
+      [null, true, 'at-risk'], // can't tell, but the row is a real risk on its own
+    ];
+    for (const [objectExists, hasImageRow, expected] of matrix) {
+      expect(
+        classifyAnnouncementMedia({ objectExists, hasImageRow }),
+        `objectExists=${objectExists} hasImageRow=${hasImageRow}`
+      ).toBe(expected);
+    }
+  });
+});
+
+describe('summarizeAnnouncementMediaFindings', () => {
+  const finding = (over: Partial<AnnouncementMediaFinding> = {}): AnnouncementMediaFinding => ({
+    key: KEY_A,
+    announcementIds: [1],
+    status: 'ok',
+    objectExists: true,
+    hasImageRow: false,
+    ...over,
+  });
+
+  it('counts an unknown bucket answer as unknown, not as broken or ok-and-forgotten', () => {
+    // 🔴 The regression this exists for: `null` folds into `ok` by design, so without a
+    // separate count a fully fail-open run is indistinguishable from a healthy one.
+    const summary = summarizeAnnouncementMediaFindings([
+      finding({ objectExists: null, status: 'ok' }),
+      finding({ key: KEY_B, objectExists: true, status: 'ok' }),
+    ]);
+
+    expect(summary).toMatchObject({ checked: 2, broken: 0, atRisk: 0, unknown: 1, blind: false });
+  });
+
+  it('an infrastructure error never produces a BROKEN count', () => {
+    const summary = summarizeAnnouncementMediaFindings([
+      finding({ objectExists: null }),
+      finding({ key: KEY_B, objectExists: null }),
+    ]);
+    expect(summary.broken).toBe(0);
+  });
+
+  it('reports BLIND when the bucket could not be consulted for a single key', () => {
+    // Rotated / re-scoped credentials: every answer is unknown. "The monitor cannot see"
+    // must be its own alertable condition, separate from "a banner is broken".
+    const summary = summarizeAnnouncementMediaFindings([
+      finding({ objectExists: null }),
+      finding({ key: KEY_B, objectExists: null }),
+    ]);
+    expect(summary).toMatchObject({ checked: 2, unknown: 2, broken: 0, blind: true });
+  });
+
+  it('is NOT blind when even one key got a definite answer', () => {
+    const summary = summarizeAnnouncementMediaFindings([
+      finding({ objectExists: null }),
+      finding({ key: KEY_B, objectExists: false, status: 'broken' }),
+    ]);
+    expect(summary).toMatchObject({ unknown: 1, broken: 1, blind: false });
+  });
+
+  it('is NOT blind when there was nothing to check', () => {
+    // An empty active-announcement list must not masquerade as a credential failure.
+    expect(summarizeAnnouncementMediaFindings([])).toEqual({
+      checked: 0,
+      broken: 0,
+      atRisk: 0,
+      unknown: 0,
+      renderFailures: 0,
+      blind: false,
+    });
+  });
+
+  it('counts render failures only where the cheap signals were clean', () => {
+    const summary = summarizeAnnouncementMediaFindings([
+      finding({ status: 'ok', renderedStatus: 404 }),
+      finding({ key: KEY_B, status: 'at-risk', hasImageRow: true, renderedStatus: 503 }),
+      finding({ key: 'c', status: 'broken', objectExists: false, renderedStatus: 404 }),
+      finding({ key: 'd', status: 'ok', renderedStatus: 200 }),
+      finding({ key: 'e', status: 'ok', renderedStatus: null }),
+    ]);
+    // The broken one is excluded — it is already alerted on the primary signal.
+    expect(summary).toMatchObject({ checked: 5, broken: 1, atRisk: 1, renderFailures: 2 });
   });
 });
 
@@ -128,5 +221,35 @@ describe('evaluateAnnouncementMedia', () => {
     const findings = await evaluateAnnouncementMedia([{ id: 9, key: KEY_A }], d);
 
     expect(findings[0]).toMatchObject({ status: 'ok', renderedStatus: 404 });
+  });
+
+  it('still probes an AT RISK key — its object is present and should be serving', async () => {
+    const probeRenderedVariant = vi.fn(async () => 200 as number | null);
+    const d = deps({ findKeysWithImageRow: vi.fn(async () => [KEY_A]), probeRenderedVariant });
+    const findings = await evaluateAnnouncementMedia([{ id: 3, key: KEY_A }], d);
+
+    expect(probeRenderedVariant).toHaveBeenCalledWith(KEY_A);
+    expect(findings[0]).toMatchObject({ status: 'at-risk', renderedStatus: 200 });
+  });
+
+  it('carries an unknown bucket answer through to the finding', async () => {
+    const d = deps({ objectExists: vi.fn(async () => null) });
+    const findings = await evaluateAnnouncementMedia([{ id: 4, key: KEY_A }], d);
+
+    expect(findings[0]).toMatchObject({ status: 'ok', objectExists: null });
+    expect(summarizeAnnouncementMediaFindings(findings)).toMatchObject({
+      unknown: 1,
+      broken: 0,
+      blind: true,
+    });
+  });
+
+  it('ignores announcements with an empty key rather than checking ""', async () => {
+    const d = deps();
+    const findings = await evaluateAnnouncementMedia([{ id: 5, key: '' }], d);
+
+    expect(findings).toEqual([]);
+    expect(d.objectExists).not.toHaveBeenCalled();
+    expect(summarizeAnnouncementMediaFindings(findings).blind).toBe(false);
   });
 });

--- a/src/server/jobs/announcement-media-check.ts
+++ b/src/server/jobs/announcement-media-check.ts
@@ -1,0 +1,259 @@
+import { HeadObjectCommand } from '@aws-sdk/client-s3';
+import { getAnnouncementImageUrl } from '~/components/Announcements/announcement-image';
+import { env } from '~/env/server';
+import { dbRead } from '~/server/db/client';
+import { logToAxiom } from '~/server/logging/client';
+import { getActiveAnnouncementImageRefs } from '~/server/services/announcement.service';
+import { getB2ImageS3Client } from '~/utils/s3-utils';
+import { createLogger } from '~/utils/logging';
+import { createJob } from './job';
+
+const log = createLogger('announcement-media-check', 'yellow');
+
+const jobName = 'announcement-media-check';
+
+/**
+ * Health check for announcement banner images.
+ *
+ * `Announcement.metadata.image` is a bare object key with no foreign key and no
+ * refcount (see `announcement.schema.ts`). Two cheap conditions predict breakage,
+ * both determinable before a single user sees a broken banner:
+ *
+ *  - BROKEN  — the key is absent from the uploads bucket. The banner is dead (or will
+ *              be as soon as the derived variant ages out of the delivery cache).
+ *  - AT RISK — an `Image` row exists whose `url` equals the key. That row is
+ *              deletable through ordinary product paths, and deleting it deletes the
+ *              underlying object. This is the exact chain that broke a live sitewide
+ *              announcement.
+ *
+ * 🔴 Deliberately NOT primarily a "fetch the rendered URL" check. That signal is both
+ * lagging and maskable:
+ *  - the image service can keep serving an already-materialised variant from its own
+ *    cache long after the original object is gone, so the fetch stays green through
+ *    the entire window in which we could still have fixed it; and
+ *  - the delivery URL is edge-cached for a day, so a poller reads back its own cached
+ *    answer. The optional secondary fetch below therefore always cache-busts.
+ */
+
+export type AnnouncementMediaStatus = 'ok' | 'at-risk' | 'broken';
+
+export type AnnouncementMediaFinding = {
+  key: string;
+  announcementIds: number[];
+  status: AnnouncementMediaStatus;
+  /** `null` when the uploads bucket could not be consulted (no creds / transient error). */
+  objectExists: boolean | null;
+  hasImageRow: boolean;
+  /** HTTP status of the cache-busted rendered-variant probe, when one was performed. */
+  renderedStatus?: number | null;
+};
+
+export type AnnouncementMediaDeps = {
+  /** `true` present, `false` definitively absent, `null` unknown — unknown never alerts. */
+  objectExists: (key: string) => Promise<boolean | null>;
+  /** Subset of `keys` for which an `Image` row shares the url. */
+  findKeysWithImageRow: (keys: string[]) => Promise<string[]>;
+  /** Optional secondary user-visible probe. Must be cache-busted by the implementation. */
+  probeRenderedVariant?: (key: string) => Promise<number | null>;
+};
+
+/**
+ * Classify one key. BROKEN outranks AT RISK: a missing object is already a failure,
+ * not a risk. An unknown bucket answer (`null`) never manufactures a BROKEN.
+ */
+export function classifyAnnouncementMedia({
+  objectExists,
+  hasImageRow,
+}: {
+  objectExists: boolean | null;
+  hasImageRow: boolean;
+}): AnnouncementMediaStatus {
+  if (objectExists === false) return 'broken';
+  if (hasImageRow) return 'at-risk';
+  return 'ok';
+}
+
+/**
+ * Evaluate a set of announcement -> key references. Keys are de-duplicated before any
+ * lookup (the same object is legitimately shared by several announcements), and each
+ * finding carries every announcement id that references it.
+ */
+export async function evaluateAnnouncementMedia(
+  refs: { id: number; key: string }[],
+  deps: AnnouncementMediaDeps
+): Promise<AnnouncementMediaFinding[]> {
+  const byKey = new Map<string, number[]>();
+  for (const { id, key } of refs) {
+    if (!key) continue;
+    const ids = byKey.get(key);
+    if (ids) ids.push(id);
+    else byKey.set(key, [id]);
+  }
+
+  const keys = [...byKey.keys()];
+  if (!keys.length) return [];
+
+  const keysWithImageRow = new Set(await deps.findKeysWithImageRow(keys));
+
+  const findings: AnnouncementMediaFinding[] = [];
+  for (const key of keys) {
+    const objectExists = await deps.objectExists(key);
+    const hasImageRow = keysWithImageRow.has(key);
+    const status = classifyAnnouncementMedia({ objectExists, hasImageRow });
+
+    // Only worth the extra request when the cheap signals say we're fine — it exists to
+    // catch delivery-side failures those two can't see.
+    const renderedStatus =
+      status === 'broken' || !deps.probeRenderedVariant
+        ? undefined
+        : await deps.probeRenderedVariant(key);
+
+    findings.push({
+      key,
+      announcementIds: byKey.get(key) ?? [],
+      status,
+      objectExists,
+      hasImageRow,
+      renderedStatus,
+    });
+  }
+
+  return findings;
+}
+
+const UPLOADS_BUCKET = () => env.S3_IMAGE_B2_BUCKET ?? 'civitai-media-uploads';
+
+function isNotFound(e: unknown) {
+  const err = e as { name?: string; $metadata?: { httpStatusCode?: number } };
+  return err?.name === 'NotFound' || err?.name === 'NoSuchKey' || err?.$metadata?.httpStatusCode === 404;
+}
+
+/**
+ * Existence check against the uploads bucket the app actually writes to and deletes
+ * from. Note the legacy DigitalOcean image client cannot be used for this — it points
+ * at a decommissioned read proxy.
+ */
+async function objectExistsInUploads(key: string): Promise<boolean | null> {
+  if (!env.S3_IMAGE_B2_ACCESS_KEY || !env.S3_IMAGE_B2_SECRET_KEY || !env.S3_IMAGE_B2_ENDPOINT)
+    return null;
+
+  try {
+    await getB2ImageS3Client().send(
+      new HeadObjectCommand({ Bucket: UPLOADS_BUCKET(), Key: key })
+    );
+    return true;
+  } catch (e) {
+    if (isNotFound(e)) return false;
+    // Permission/transient/network — do not turn an infrastructure hiccup into a page.
+    return null;
+  }
+}
+
+async function findKeysWithImageRow(keys: string[]) {
+  const rows = await dbRead.image.findMany({
+    where: { url: { in: keys } },
+    select: { url: true },
+    distinct: ['url'],
+  });
+  return rows.map((r) => r.url);
+}
+
+const RENDER_PROBE_TIMEOUT_MS = 10_000;
+
+/**
+ * Secondary, user-visible probe of the exact variant the banner renders.
+ *
+ * 🔴 Cache-busted on purpose: the delivery URL is edge-cached for a day, so a plain
+ * request reads back the poller's own cached answer and would stay green through a
+ * real outage.
+ */
+async function probeRenderedVariant(key: string): Promise<number | null> {
+  const url = `${getAnnouncementImageUrl(key)}?cb=${Date.now()}`;
+  try {
+    const res = await fetch(url, {
+      method: 'GET',
+      headers: { range: 'bytes=0-0', 'cache-control': 'no-cache' },
+      signal: AbortSignal.timeout(RENDER_PROBE_TIMEOUT_MS),
+    });
+    return res.status;
+  } catch {
+    return null;
+  }
+}
+
+export const announcementMediaCheckJob = createJob(
+  jobName,
+  '0 * * * *',
+  async () => {
+    const refs = await getActiveAnnouncementImageRefs();
+    if (!refs.length) {
+      log('no active announcements with a banner image');
+      return { checked: 0, broken: 0, atRisk: 0 };
+    }
+
+    const findings = await evaluateAnnouncementMedia(refs, {
+      objectExists: objectExistsInUploads,
+      findKeysWithImageRow,
+      probeRenderedVariant,
+    });
+
+    const broken = findings.filter((f) => f.status === 'broken');
+    const atRisk = findings.filter((f) => f.status === 'at-risk');
+    // Cheap signals are clean but the variant users load isn't served.
+    const renderFailures = findings.filter(
+      (f) => f.status !== 'broken' && f.renderedStatus != null && f.renderedStatus >= 400
+    );
+
+    for (const finding of broken) {
+      logToAxiom({
+        type: 'error',
+        name: 'announcement-image-broken',
+        message: 'Announcement banner object is missing from the uploads bucket',
+        details: {
+          announcementIds: finding.announcementIds,
+          imageKey: finding.key,
+          url: getAnnouncementImageUrl(finding.key),
+        },
+      }).catch();
+    }
+
+    for (const finding of atRisk) {
+      logToAxiom({
+        type: 'warning',
+        name: 'announcement-image-at-risk',
+        message:
+          'Announcement banner key is also an Image url — deleting that image would break the banner',
+        details: {
+          announcementIds: finding.announcementIds,
+          imageKey: finding.key,
+        },
+      }).catch();
+    }
+
+    for (const finding of renderFailures) {
+      logToAxiom({
+        type: 'error',
+        name: 'announcement-image-render-failed',
+        message: 'Announcement banner variant did not serve',
+        details: {
+          announcementIds: finding.announcementIds,
+          imageKey: finding.key,
+          url: getAnnouncementImageUrl(finding.key),
+          status: finding.renderedStatus,
+        },
+      }).catch();
+    }
+
+    log(
+      `checked ${findings.length} keys: ${broken.length} broken, ${atRisk.length} at risk, ${renderFailures.length} render failures`
+    );
+
+    return {
+      checked: findings.length,
+      broken: broken.length,
+      atRisk: atRisk.length,
+      renderFailures: renderFailures.length,
+    };
+  },
+  { lockExpiration: 5 * 60 }
+);

--- a/src/server/jobs/announcement-media-check.ts
+++ b/src/server/jobs/announcement-media-check.ts
@@ -3,7 +3,7 @@ import { getAnnouncementImageUrl } from '~/components/Announcements/announcement
 import { env } from '~/env/server';
 import { dbRead } from '~/server/db/client';
 import { logToAxiom } from '~/server/logging/client';
-import { getActiveAnnouncementImageRefs } from '~/server/services/announcement.service';
+import { getMonitoredAnnouncementImageRefs } from '~/server/services/announcement.service';
 import { getB2ImageS3Client } from '~/utils/s3-utils';
 import { createLogger } from '~/utils/logging';
 import { createJob } from './job';
@@ -25,6 +25,13 @@ const jobName = 'announcement-media-check';
  *              deletable through ordinary product paths, and deleting it deletes the
  *              underlying object. This is the exact chain that broke a live sitewide
  *              announcement.
+ *
+ * A third outcome is reported but never alerts as a banner failure: UNKNOWN, when the
+ * bucket could not be consulted (missing credentials, a 403 from a rotated key, a
+ * network blip). Failing open there is deliberate — an infrastructure hiccup must not
+ * page — but silent fail-open is how a monitor lies, so unknowns are counted separately
+ * and a run in which EVERY key was unknown emits its own `announcement-media-check-blind`
+ * warning. "The monitor cannot see" is a different alert from "a banner is broken".
  *
  * 🔴 Deliberately NOT primarily a "fetch the rendered URL" check. That signal is both
  * lagging and maskable:
@@ -56,6 +63,50 @@ export type AnnouncementMediaDeps = {
   /** Optional secondary user-visible probe. Must be cache-busted by the implementation. */
   probeRenderedVariant?: (key: string) => Promise<number | null>;
 };
+
+export type AnnouncementMediaSummary = {
+  checked: number;
+  broken: number;
+  atRisk: number;
+  /**
+   * Keys whose existence could not be determined at all (`objectExists === null`):
+   * missing credentials, a 403 from a rotated/re-scoped key, a network blip.
+   */
+  unknown: number;
+  renderFailures: number;
+  /**
+   * True when the bucket could not be consulted for a SINGLE key it was asked about.
+   * This is the monitor reporting on itself: with `unknown` folded into `ok` (correct —
+   * an infrastructure hiccup must not page), a fully-blind run is indistinguishable
+   * from a clean one in `broken: 0`. Alert on this separately from a broken banner.
+   */
+  blind: boolean;
+};
+
+/**
+ * Roll findings up into the job's return value.
+ *
+ * 🔴 `unknown` is counted separately and never folded into `broken`. The fail-open
+ * choice is deliberate, but silent fail-open is how a monitor lies for months: if the
+ * B2 credentials are rotated, every hourly run would otherwise report `broken: 0`
+ * forever while a banner is dead.
+ */
+export function summarizeAnnouncementMediaFindings(
+  findings: AnnouncementMediaFinding[]
+): AnnouncementMediaSummary {
+  const unknown = findings.filter((f) => f.objectExists === null).length;
+  return {
+    checked: findings.length,
+    broken: findings.filter((f) => f.status === 'broken').length,
+    atRisk: findings.filter((f) => f.status === 'at-risk').length,
+    unknown,
+    // Cheap signals are clean but the variant users load isn't served.
+    renderFailures: findings.filter(
+      (f) => f.status !== 'broken' && f.renderedStatus != null && f.renderedStatus >= 400
+    ).length,
+    blind: findings.length > 0 && unknown === findings.length,
+  };
+}
 
 /**
  * Classify one key. BROKEN outranks AT RISK: a missing object is already a failure,
@@ -101,8 +152,10 @@ export async function evaluateAnnouncementMedia(
     const hasImageRow = keysWithImageRow.has(key);
     const status = classifyAnnouncementMedia({ objectExists, hasImageRow });
 
-    // Only worth the extra request when the cheap signals say we're fine — it exists to
-    // catch delivery-side failures those two can't see.
+    // Skipped only for an already-BROKEN key: the object is gone, so a failing probe
+    // adds nothing and a passing one is just a stale cached variant. AT RISK keys ARE
+    // probed — their object is present and should be serving — as are OK ones. This is
+    // the delivery-side signal the two cheap checks cannot see.
     const renderedStatus =
       status === 'broken' || !deps.probeRenderedVariant
         ? undefined
@@ -125,7 +178,9 @@ const UPLOADS_BUCKET = () => env.S3_IMAGE_B2_BUCKET ?? 'civitai-media-uploads';
 
 function isNotFound(e: unknown) {
   const err = e as { name?: string; $metadata?: { httpStatusCode?: number } };
-  return err?.name === 'NotFound' || err?.name === 'NoSuchKey' || err?.$metadata?.httpStatusCode === 404;
+  return (
+    err?.name === 'NotFound' || err?.name === 'NoSuchKey' || err?.$metadata?.httpStatusCode === 404
+  );
 }
 
 /**
@@ -138,9 +193,7 @@ async function objectExistsInUploads(key: string): Promise<boolean | null> {
     return null;
 
   try {
-    await getB2ImageS3Client().send(
-      new HeadObjectCommand({ Bucket: UPLOADS_BUCKET(), Key: key })
-    );
+    await getB2ImageS3Client().send(new HeadObjectCommand({ Bucket: UPLOADS_BUCKET(), Key: key }));
     return true;
   } catch (e) {
     if (isNotFound(e)) return false;
@@ -175,6 +228,10 @@ async function probeRenderedVariant(key: string): Promise<number | null> {
       headers: { range: 'bytes=0-0', 'cache-control': 'no-cache' },
       signal: AbortSignal.timeout(RENDER_PROBE_TIMEOUT_MS),
     });
+    // A `Range` request is a hint, not a contract — an origin is free to answer 200
+    // with the whole body. Release it rather than leaving the stream (and its socket)
+    // pinned until GC.
+    await res.body?.cancel().catch(() => undefined);
     return res.status;
   } catch {
     return null;
@@ -185,10 +242,10 @@ export const announcementMediaCheckJob = createJob(
   jobName,
   '0 * * * *',
   async () => {
-    const refs = await getActiveAnnouncementImageRefs();
+    const refs = await getMonitoredAnnouncementImageRefs();
     if (!refs.length) {
-      log('no active announcements with a banner image');
-      return { checked: 0, broken: 0, atRisk: 0 };
+      log('no monitored announcements with a banner image');
+      return { checked: 0, broken: 0, atRisk: 0, unknown: 0, renderFailures: 0, blind: false };
     }
 
     const findings = await evaluateAnnouncementMedia(refs, {
@@ -197,12 +254,35 @@ export const announcementMediaCheckJob = createJob(
       probeRenderedVariant,
     });
 
+    const summary = summarizeAnnouncementMediaFindings(findings);
     const broken = findings.filter((f) => f.status === 'broken');
     const atRisk = findings.filter((f) => f.status === 'at-risk');
-    // Cheap signals are clean but the variant users load isn't served.
     const renderFailures = findings.filter(
       (f) => f.status !== 'broken' && f.renderedStatus != null && f.renderedStatus >= 400
     );
+
+    // 🔴 "The monitor cannot see" is its own alertable condition, distinct from "a banner
+    // is broken". Unknown answers fail open into `ok` on purpose, so without this a
+    // rotated/re-scoped B2 key would leave every run reporting `broken: 0` indefinitely
+    // while a banner is dead.
+    if (summary.blind) {
+      logToAxiom({
+        type: 'warning',
+        name: 'announcement-media-check-blind',
+        message:
+          'Announcement media check could not consult the uploads bucket for any key — results are not trustworthy',
+        details: {
+          checked: summary.checked,
+          unknown: summary.unknown,
+          hasCredentials: !!(
+            env.S3_IMAGE_B2_ACCESS_KEY &&
+            env.S3_IMAGE_B2_SECRET_KEY &&
+            env.S3_IMAGE_B2_ENDPOINT
+          ),
+          bucket: UPLOADS_BUCKET(),
+        },
+      }).catch();
+    }
 
     for (const finding of broken) {
       logToAxiom({
@@ -245,15 +325,12 @@ export const announcementMediaCheckJob = createJob(
     }
 
     log(
-      `checked ${findings.length} keys: ${broken.length} broken, ${atRisk.length} at risk, ${renderFailures.length} render failures`
+      `checked ${summary.checked} keys: ${summary.broken} broken, ${summary.atRisk} at risk, ` +
+        `${summary.unknown} unknown, ${summary.renderFailures} render failures` +
+        (summary.blind ? ' — BLIND: bucket unreachable for every key' : '')
     );
 
-    return {
-      checked: findings.length,
-      broken: broken.length,
-      atRisk: atRisk.length,
-      renderFailures: renderFailures.length,
-    };
+    return summary;
   },
   { lockExpiration: 5 * 60 }
 );

--- a/src/server/schema/announcement.schema.ts
+++ b/src/server/schema/announcement.schema.ts
@@ -29,6 +29,14 @@ export const announcementMetaSchema = z
     targetAudience: z.enum(['all', 'unauthenticated', 'authenticated']).default('all'),
     dismissible: z.boolean().default(true),
     colSpan: z.number().default(6),
+    // A bare media object key — NOT an `Image` row id and NOT a URL.
+    //
+    // 🔴 These keys are intentionally not registered as `Image` rows. `deleteImageFromS3`
+    // is row-scoped (every call site passes an `Image` row's id + url), so a key with no
+    // row cannot be deleted by any app path — which is the whole point, after a deleted
+    // `Image` row took a live sitewide banner's object with it. Do not "normalise" this
+    // into an `Image` FK, and any future orphan sweeper over the uploads bucket must
+    // exclude the keys held here. Monitored by `~/server/jobs/announcement-media-check`.
     image: z.string().optional(),
     index: z.number().optional(),
   })

--- a/src/server/services/__tests__/announcement-media-window.test.ts
+++ b/src/server/services/__tests__/announcement-media-window.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// The window predicate the announcement media health check reads. The read path and the
+// monitor MUST agree about which announcements are showing, so both are built from one
+// `announcementWindowOverlapsWhere`; the monitor only widens the upper bound so a broken
+// banner is caught before it goes live rather than up to an hour after.
+//
+// Mock surface mirrors `announcement.memoize.test.ts` — the service's module-scope redis
+// key construction is what forces the redis mock, nothing here touches the cache.
+const { findMany } = vi.hoisted(() => ({ findMany: vi.fn() }));
+
+vi.mock('~/server/common/constants', () => ({ CacheTTL: { day: 86400 } }));
+vi.mock('~/server/db/client', () => ({
+  dbRead: { announcement: { findMany, count: vi.fn() }, $transaction: vi.fn() },
+  dbWrite: { announcement: { findMany: vi.fn() } },
+}));
+vi.mock('~/server/redis/client', () => ({
+  redis: { get: vi.fn(), set: vi.fn(), del: vi.fn() },
+  REDIS_KEYS: { CACHES: { ANNOUNCEMENTS: 'packed:caches:announcements' } },
+}));
+vi.mock('~/server/utils/pagination-helpers', () => ({
+  DEFAULT_PAGE_SIZE: 20,
+  getPagination: vi.fn(),
+  getPagingData: vi.fn(),
+}));
+vi.mock('~/shared/utils/prisma/enums', () => ({
+  DomainColor: { all: 'all', green: 'green', red: 'red' },
+}));
+
+import {
+  ANNOUNCEMENT_MEDIA_LOOKAHEAD_MS,
+  activeAnnouncementWhere,
+  announcementWindowOverlapsWhere,
+  getMonitoredAnnouncementImageRefs,
+} from '../announcement.service';
+
+const NOW = new Date('2026-07-27T12:00:00.000Z');
+
+/** Pull the `startsAt <= to` / `endsAt >= from` bounds out of the prisma where clause. */
+function bounds(where: ReturnType<typeof announcementWindowOverlapsWhere>) {
+  const and = where.AND as { OR: Record<string, { lte?: Date; gte?: Date }>[] }[];
+  return {
+    disabled: where.disabled,
+    startsAtLte: and[0].OR[0].startsAt.lte,
+    startsAtNullable: 'startsAt' in and[0].OR[1],
+    endsAtGte: and[1].OR[0].endsAt.gte,
+    endsAtNullable: 'endsAt' in and[1].OR[1],
+  };
+}
+
+describe('announcement window predicate', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    findMany.mockReset();
+    findMany.mockResolvedValue([]);
+  });
+
+  it('activeAnnouncementWhere is the degenerate from === to === now case', () => {
+    // Structural equality, so the read path provably keeps its exact previous behaviour
+    // after being refactored onto the shared builder.
+    expect(activeAnnouncementWhere(NOW)).toEqual(announcementWindowOverlapsWhere(NOW, NOW));
+  });
+
+  it('only ever matches enabled announcements, and treats null dates as open-ended', () => {
+    const b = bounds(activeAnnouncementWhere(NOW));
+    expect(b.disabled).toBe(false);
+    expect(b.startsAtNullable).toBe(true);
+    expect(b.endsAtNullable).toBe(true);
+  });
+
+  it('widens only the upper bound — a banner ending today is still monitored', () => {
+    // 🔴 The trap this pins: shifting the whole window forward (activeWhere(now + 24h))
+    // would drop announcements that END within the next day, i.e. banners live RIGHT NOW.
+    const to = new Date(NOW.getTime() + ANNOUNCEMENT_MEDIA_LOOKAHEAD_MS);
+    const b = bounds(announcementWindowOverlapsWhere(NOW, to));
+
+    expect(b.startsAtLte).toEqual(to);
+    expect(b.endsAtGte).toEqual(NOW);
+  });
+});
+
+describe('getMonitoredAnnouncementImageRefs', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+    findMany.mockReset();
+    findMany.mockResolvedValue([]);
+  });
+
+  it('queries live-now plus the look-ahead window', async () => {
+    await getMonitoredAnnouncementImageRefs();
+
+    const b = bounds(findMany.mock.calls[0][0].where);
+    expect(b.endsAtGte).toEqual(NOW);
+    expect(b.startsAtLte).toEqual(new Date(NOW.getTime() + ANNOUNCEMENT_MEDIA_LOOKAHEAD_MS));
+  });
+
+  it('defaults the look-ahead to a day and honours an explicit override', async () => {
+    expect(ANNOUNCEMENT_MEDIA_LOOKAHEAD_MS).toBe(24 * 60 * 60 * 1000);
+
+    await getMonitoredAnnouncementImageRefs(0);
+    // A zero look-ahead collapses back to exactly the read path's "live now".
+    expect(findMany.mock.calls[0][0].where).toEqual(activeAnnouncementWhere(NOW));
+  });
+
+  it('returns one ref per announcement carrying a banner key', async () => {
+    findMany.mockResolvedValue([
+      { id: 1, metadata: { image: 'key-a', colSpan: 6 } },
+      { id: 2, metadata: { image: 'key-a' } },
+      { id: 3, metadata: { image: 'key-b' } },
+    ]);
+
+    expect(await getMonitoredAnnouncementImageRefs()).toEqual([
+      { id: 1, key: 'key-a' },
+      { id: 2, key: 'key-a' },
+      { id: 3, key: 'key-b' },
+    ]);
+  });
+
+  it('drops announcements with no banner, null metadata or an empty key', async () => {
+    findMany.mockResolvedValue([
+      { id: 1, metadata: null },
+      { id: 2, metadata: {} },
+      { id: 3, metadata: { image: '' } },
+      { id: 4, metadata: { image: 'key-a' } },
+    ]);
+
+    expect(await getMonitoredAnnouncementImageRefs()).toEqual([{ id: 4, key: 'key-a' }]);
+  });
+
+  it('returns an empty list rather than throwing when nothing is scheduled', async () => {
+    findMany.mockResolvedValue([]);
+    expect(await getMonitoredAnnouncementImageRefs()).toEqual([]);
+  });
+});

--- a/src/server/services/announcement.service.ts
+++ b/src/server/services/announcement.service.ts
@@ -136,32 +136,62 @@ async function getAnnouncementsCached(domain?: DomainColor) {
 }
 
 /**
- * The "currently live" predicate: enabled, and now is inside the (open-ended)
- * start/end window. Shared with the announcement media health check so a monitor
- * can never disagree with the read path about which announcements are live.
+ * Enabled announcements whose (open-ended) start/end window overlaps `[from, to]`.
+ *
+ * The single source of truth for "is this announcement showing". `activeAnnouncementWhere`
+ * is the degenerate `from === to === now` case used by the read path; the media health
+ * check widens only the upper bound so it can see a banner before it goes live.
  */
-export function activeAnnouncementWhere(now: Date): Prisma.AnnouncementWhereInput {
+export function announcementWindowOverlapsWhere(
+  from: Date,
+  to: Date
+): Prisma.AnnouncementWhereInput {
   return {
     disabled: false,
     AND: [
       {
-        OR: [{ startsAt: { lte: now } }, { startsAt: { equals: null } }],
+        OR: [{ startsAt: { lte: to } }, { startsAt: { equals: null } }],
       },
       {
-        OR: [{ endsAt: { gte: now } }, { endsAt: { equals: null } }],
+        OR: [{ endsAt: { gte: from } }, { endsAt: { equals: null } }],
       },
     ],
   };
 }
 
 /**
- * Every currently-active announcement that carries a banner image key, across all
- * domains. Used by the media health check — deliberately NOT domain-filtered, since
- * a broken banner on a single-domain announcement is just as broken.
+ * The "currently live" predicate: enabled, and now is inside the (open-ended)
+ * start/end window. Shared with the announcement media health check so a monitor
+ * can never disagree with the read path about which announcements are live.
  */
-export async function getActiveAnnouncementImageRefs() {
+export function activeAnnouncementWhere(now: Date): Prisma.AnnouncementWhereInput {
+  return announcementWindowOverlapsWhere(now, now);
+}
+
+/**
+ * How far ahead of "now" the media health check looks.
+ *
+ * The check runs hourly, so a monitor limited to *currently-live* announcements would
+ * find a broken banner up to an hour after it went live — i.e. users see it first. One
+ * day of look-ahead means a scheduled announcement's banner is verified well before it
+ * is shown, and costs nothing: the extra rows are few and their keys de-duplicate
+ * against the live ones. A finding on a not-yet-live announcement is just as actionable,
+ * and cheaper to fix.
+ */
+export const ANNOUNCEMENT_MEDIA_LOOKAHEAD_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Every announcement that carries a banner image key and is either live now or goes
+ * live within `lookaheadMs`, across all domains. Used by the media health check —
+ * deliberately NOT domain-filtered, since a broken banner on a single-domain
+ * announcement is just as broken.
+ */
+export async function getMonitoredAnnouncementImageRefs(
+  lookaheadMs: number = ANNOUNCEMENT_MEDIA_LOOKAHEAD_MS
+) {
+  const now = new Date();
   const announcements = await dbRead.announcement.findMany({
-    where: activeAnnouncementWhere(new Date()),
+    where: announcementWindowOverlapsWhere(now, new Date(now.getTime() + lookaheadMs)),
     select: { id: true, metadata: true },
   });
 

--- a/src/server/services/announcement.service.ts
+++ b/src/server/services/announcement.service.ts
@@ -1,3 +1,4 @@
+import type { Prisma } from '@prisma/client';
 import { CacheTTL } from '~/server/common/constants';
 import { dbRead, dbWrite } from '~/server/db/client';
 import type { RedisKeyTemplateCache } from '~/server/redis/client';
@@ -134,21 +135,51 @@ async function getAnnouncementsCached(domain?: DomainColor) {
   return getAnnouncementsCachedMemo(domain ?? '');
 }
 
+/**
+ * The "currently live" predicate: enabled, and now is inside the (open-ended)
+ * start/end window. Shared with the announcement media health check so a monitor
+ * can never disagree with the read path about which announcements are live.
+ */
+export function activeAnnouncementWhere(now: Date): Prisma.AnnouncementWhereInput {
+  return {
+    disabled: false,
+    AND: [
+      {
+        OR: [{ startsAt: { lte: now } }, { startsAt: { equals: null } }],
+      },
+      {
+        OR: [{ endsAt: { gte: now } }, { endsAt: { equals: null } }],
+      },
+    ],
+  };
+}
+
+/**
+ * Every currently-active announcement that carries a banner image key, across all
+ * domains. Used by the media health check — deliberately NOT domain-filtered, since
+ * a broken banner on a single-domain announcement is just as broken.
+ */
+export async function getActiveAnnouncementImageRefs() {
+  const announcements = await dbRead.announcement.findMany({
+    where: activeAnnouncementWhere(new Date()),
+    select: { id: true, metadata: true },
+  });
+
+  return announcements
+    .map(({ id, metadata }) => ({
+      id,
+      key: ((metadata ?? {}) as AnnouncementMetaSchema).image,
+    }))
+    .filter((x): x is { id: number; key: string } => !!x.key);
+}
+
 export type AnnouncementDTO = Awaited<ReturnType<typeof getAnnouncements>>[number];
 async function getAnnouncements(domain?: DomainColor) {
   const now = new Date();
   const announcements = await dbWrite.announcement.findMany({
     where: {
-      disabled: false,
+      ...activeAnnouncementWhere(now),
       domain: { hasSome: domain ? [DomainColor.all, domain] : [DomainColor.all] },
-      AND: [
-        {
-          OR: [{ startsAt: { lte: now } }, { startsAt: { equals: null } }],
-        },
-        {
-          OR: [{ endsAt: { gte: now } }, { endsAt: { equals: null } }],
-        },
-      ],
     },
     select: {
       createdAt: true,


### PR DESCRIPTION
## Problem

`Announcement.metadata.image` holds a bare media object key in a JSON blob — no foreign key, no refcount, and nothing that knows an announcement points at that object.

The admin UI was a free-text field (`<InputText name="image" label="Image ID" />`), and there is no announcement upload path. So a moderator has to paste a key sourced from some other surface — and every such surface mints an `Image` row. That makes the announcement's key *also* an `Image.url`.

When that `Image` row is later deleted through any ordinary path, `deleteImageFromS3` (`src/server/services/image.service.ts`) deletes the underlying object. Its refcount guard only looks for **other `Image` rows** sharing the same url, so a metadata-held reference is completely invisible to it. The announcement then renders a broken image for everyone.

This is not hypothetical — it took out the only active announcement (`targetAudience: all`) for all users until it was manually recovered.

## Fix — upload, but deliberately create no `Image` row

Replace the text field with `<InputSimpleImageUpload>`. That uploads via `useCFImageUpload` → `POST /api/v1/image-upload`, which mints a key and a presigned PUT and **nothing else** — no `image.create`.

The key insight is that `deleteImageFromS3` is **row-scoped, not bucket-scoped**: all three of its call sites pass an `Image` row's `id` and `url`. So "the announcement's key is not any `Image.url`" is precisely the safe state, and uploading without minting a row puts every future announcement in it *structurally* — there is no guard to get wrong and no enforcement surface to miss a path in.

This is not a new pattern here: membership badges — sitewide and revenue-facing — already store a raw uploaded key with no `Image` row.

**Explicitly not doing:** minting an `Image` row, protected or otherwise. Creating the row is exactly what makes the object deletable, and there is no "system/protected image" primitive to lean on — the moderator-delete path and the owner-cascade would both remain wide open. That would convert "someone deleted the source image" into "someone deleted the banner's own image row" for no net safety gain.

### Wire format is unchanged

`metadata.image` stays a bare key string. `SimpleImageUpload` emits an object on success and `null` on remove, while an announcement being edited loads the stored string — all three are accepted in form state and normalised back to a bare key (or `undefined`, never `null`, since the metadata schema types it `z.string().optional()`) on submit. The read path, the cache, and the renderer are untouched.

### Accepted, documented cost

This intentionally creates objects with **no `Image` row that no garbage collector will ever reclaim**. Cost is negligible (order a dozen small objects), but the landmine is real: if someone later builds an orphan sweeper on the obvious predicate — *"delete uploads-bucket objects with no `Image` row"* — it will delete every announcement banner and reproduce this outage from a new direction.

That obligation is recorded in comments at the upload site and on the schema field, along with the other bare-key media pointers that share the hazard (`Cosmetic.data.url`, `Tool.icon`/`metadata.header`, `Partner.logo`, `User.image`).

Also accepted, and flagged as a decision rather than an oversight: announcement banners are not scanned. They are moderator-only, moderator-uploaded, behind `moderatorProcedure` — consistent with how badges are treated.

## Monitor — `announcement-media-check`

An hourly job over currently-active announcements with two **cheap primary signals**, both determinable before a single user sees anything wrong:

- **BROKEN (error)** — the key is absent from the uploads bucket. Direct failure.
- **AT RISK (warning)** — an `Image` row exists whose `url` equals the key. That row is deletable through ordinary product paths, and deleting it triggers exactly this outage.

### Why the rendered URL is not the primary signal

Two independent reasons, both of which would have made a naive checker lie:

1. **It lags.** The image service can keep serving an already-materialised variant from its own cache long after the original object is deleted. The banner renders fine right up until that cached variant expires — i.e. through the entire window in which we could still have fixed it. A rendered-URL check would only have caught the real incident by luck, because that particular variant happened never to have been materialised.
2. **It is cache-maskable.** The delivery URL is edge-cached for a day, so a poller reads back its own cached answer and stays green through a real outage.

So the rendered-variant fetch is included only as a **secondary** signal, and it always cache-busts.

### Anti-drift on the checked URL

The variant users actually load is `.../<key>/width=320,optimized=true/<key>.jpeg`: the renderer asks for `width=200`, widths ≤ 450 force `optimized=true`, and the width snaps up the common-size ladder to 320. A hand-written URL — or one using `original=true` — would check something nobody loads.

`announcement-image.ts` therefore owns the render width as a shared constant used by both `Announcement.tsx` and the monitor, plus a pure `getAnnouncementImageUrl()` the monitor calls. Tests pin the exact URL, the 200→320 snap, and that it is **not** the original variant.

### Judgment calls in the monitor

- An unknown answer from the bucket (missing credentials, permission error, transient failure) is `null` and **never** produces a BROKEN — an infrastructure hiccup must not page.
- A failed *secondary* variant probe logs at error, but a probe timeout/network error does not — that signal is supplementary and would otherwise page on ordinary flakiness. The two primary signals are the ones that carry the alert.
- The active-window predicate is extracted into `activeAnnouncementWhere()` and shared with the existing read path, so the monitor can't disagree with the app about which announcements are live. Unlike the read path it is deliberately *not* domain-filtered — a broken banner on a single-domain announcement is just as broken.
- Keys are de-duplicated before any lookup (announcements legitimately share an object), and each finding carries every announcement id that references it.

## Not covered here

- **Backfill.** Announcements whose key currently has an `Image` row stay at risk until they are re-keyed; the new AT RISK signal makes that set visible and self-reporting. Left out to keep this PR to one reviewable change.
- **Scheduling.** Registering the job exposes it on the run-jobs webhook; the cron cadence itself is picked up by the external job scheduler, which needs to refresh before the job actually runs periodically. Flagging so nobody assumes it's live on merge — until then it can be invoked by name on the webhook.

## Tests

- `announcement-image.test.ts` — the helper reproduces the real rendered URL (incl. the 200→320 snap and `optimized=true`), is not the original variant, and matches `getEdgeUrl` for the shared width; and the form value round-trips to a **byte-identical** bare key from both the stored-string and upload-object shapes, emitting `undefined` (never `null`) when cleared.
- `announcement-media-check.test.ts` — classification (missing object → BROKEN, `Image` row → AT RISK, neither → OK, BROKEN outranks AT RISK, unknown never fabricates BROKEN); a shared key is checked once and attributed to all four referencing announcements; the secondary probe runs only when the cheap signals are clean.

### Verification

```
$ NODE_OPTIONS=--max_old_space_size=8192 npx tsc --noEmit
EXIT=0        # clean

$ npx vitest run --project unit
 Test Files  2 failed | 648 passed (650)
      Tests  11 failed | 8444 passed | 1 skipped (8456)
```

The 2 failing files (`src/components/AppBlocks/__tests__/hiddenBlocks.test.ts`, `src/server/utils/__tests__/subscription.utils.test.ts`) are **pre-existing on `main`** — verified by re-running both files with this branch's changes stashed: identical 11 failures. Neither touches announcements.

The 23 new tests pass:

```
 ✓  unit  src/components/Announcements/__tests__/announcement-image.test.ts (11 tests) 5ms
 ✓  unit  src/server/jobs/__tests__/announcement-media-check.test.ts (12 tests) 5ms
 Test Files  2 passed (2)
      Tests  23 passed (23)
```

## Blast radius

- **UI swap** — one moderator-only modal. Wire format unchanged, so read path/cache/render are untouched. Worst case: mods can't set a banner until reverted. Fully reversible.
- **Monitor** — read-only, single-digit HEAD requests per hour. Cannot affect serving.


---

## Follow-up commit — review fixes

Three findings from review, plus cleanups. Supersedes the test counts above.

### 1. A save could still wipe a live banner

The first commit assumed the wire format was the only hazard. It isn't. Replacing a banner is a **two-step gesture** — remove (which clears form state immediately) then drop — and `SimpleImageUpload` only writes the new key back on `status === 'success'`. Save was gated on the mutation alone, so a moderator who hit Save mid-upload, or whose upload failed, persisted `metadata.image: undefined` and took the sitewide banner down. Exactly the outage this PR exists to prevent, from a different direction.

Fixed in the modal:

- Save is **disabled while an upload is in flight**, with a submit-handler guard as well — a disabled button does not stop an Enter-key submit.
- A **failed upload restores the previous key** rather than leaving the cleared value for the next Save. The widget keeps its error visible and the restored preview can be removed again, so removal is still reachable and the moderator is never trapped.

Two supporting changes in the shared upload widget, both **additive** (no consumer behaviour changes unless it opts in):

- A new optional `onUploadStateChange` callback — the only way a parent form can know an upload is in flight, since `onChange` is silent until success.
- A drop no longer fires `onChange(null)` before the replacement exists. That transient clear is reachable with a value present wherever the dropzone stays mounted alongside one (`previewDisabled` consumers, and the drag-from-generator path), where it has the same destructive shape.
- The loading overlay is driven by the drop lifecycle instead of upload progress. A failed upload never reaches 100%, which pinned the overlay on permanently — no preview to remove, no dropzone to retry with, i.e. a failed upload was previously unrecoverable without reopening the modal.

### 2. The monitor could be blind while reporting healthy

`objectExists` returns `null` both for missing credentials and for any non-404 error (a 403 from a rotated key), and `null` folds into `ok`. That fail-open is deliberate and stays — an infrastructure hiccup must not page — but it was **silent**: every hourly run would report `broken: 0` forever while a banner was dead.

Unknowns are now counted separately in the job's return value and its summary log, and a run in which **every** key was unknown emits its own `announcement-media-check-blind` warning. "The monitor cannot see" is now a distinct alertable condition from "a banner is broken".

### 3. The `optimized` threshold is bound structurally

The helper hardcoded `optimized: true`, mirroring a `width <= 450` rule in the render path. Lowering that threshold would have changed the URL users actually load while the monitor kept probing the old variant — and then emitted a **false** `announcement-image-render-failed` on a healthy banner. No test would have caught it.

The threshold is now a shared exported constant read by both the render path and the helper, so they cannot diverge; a test additionally asserts the helper's output **equals what `useEdgeUrl` actually produces**, across the width ladder rather than only at the current width.

The pure URL builder moved into a **React-free** `client-utils/edge-url` (re-exported from `cf-images-utils`, so all existing consumers are untouched). That also removes the server job's transitive import of `useCurrentUser` / `BrowserSettingsProvider` — a module-scope `window` access anywhere in that chain would crash the import of the run-jobs endpoint and take down **every** job, not just this one.

### Cleanups

- The monitor now looks **a day ahead** instead of only at currently-live announcements. It runs hourly, so a broken banner on a scheduled announcement was previously found up to an hour *after* it went live — users first. Both windows are built from one `announcementWindowOverlapsWhere`, and the read path's predicate is the degenerate `from === to === now` case, asserted structurally so its behaviour is provably unchanged. (Shifting the whole window forward would have dropped announcements ending within the day — i.e. banners live right now — so only the upper bound moves.)
- The probe response body is released (`Range` is a hint; an origin may answer 200 with the whole body).
- Corrected the comment claiming the probe runs "only when the cheap signals say we're fine" — it runs for AT RISK too, deliberately, since those objects are present and should be serving.
- The early-return path now returns the same shape as the main one.
- Dropped the two-column grid wrapper that contained a single select.

### Tests — 49 unit (was 23) + 10 browser-mode component

Unit:

- **Wire-format round-trip through the form**: load a stored bare key → save unchanged → byte-identical; fresh upload; replace-existing; and clear, which must drop the key entirely (`undefined`, never `null` or `""`, so it matches `z.string().optional()` — asserted via `JSON.stringify`).
- **Render-URL binding**: the helper equals `useEdgeUrl`'s real output at the banner width and across the ladder, and the flag is dropped rather than emitted as `optimized=false` above the threshold.
- **Classification matrix**: exhaustive over `(objectExists × hasImageRow)` with BROKEN-outranks-AT-RISK pinned as a table; unknown-vs-broken; an infrastructure error never produces a BROKEN; the blind condition and its two negative cases (one definite answer → not blind, nothing to check → not blind); AT RISK is still probed; an empty key is skipped.
- **Window predicate**: `activeAnnouncementWhere` equals the degenerate overlap case; the look-ahead widens only the upper bound; refs filter null/empty metadata; an empty list does not throw.

Browser-mode component tests drive the **real modal and the real upload widget** (network mocked) through the paths that matter:

- Save is blocked mid-upload; a failed replacement restores and then saves the **previous** key; a successful replacement saves the **new** key; an untouched announcement round-trips byte-identically; an explicit remove still drops the key.
- At the widget level: an in-flight and a failed upload each leave the existing value untouched, the widget stays usable after a failure, and an explicit remove still emits `null`.

```
$ NODE_OPTIONS=--max_old_space_size=8192 npx tsc --noEmit
EXIT=0

$ npx vitest run --project unit <the three announcement suites>
 Test Files  3 passed (3)
      Tests  49 passed (49)

$ npx vitest run --project component <the two new suites + the Announcements suites>
 Test Files  4 passed (4)
      Tests  24 passed (24)
```

### On `preview / smoke-tests`

The 3 failures are **ambient, not caused by this PR** — the identical three appear on unrelated PRs #3399, #3393 and #3392:

- `whatIfFromGraph fires on /generate…` (`preview-generation`) and `direct upload -> attach -> publish…` (`preview-post-upload`) fail on every recent preview, back through #3373.
- `APPROVE-GATE: submit with NO assets…` (`preview-apps-external-approve`) first appears on **#3392's own preview** and on every PR built after it merged. #3392 changed `assertListingAssetsComplete` / `listing-problems` — the exact behaviour that spec asserts — without updating the spec.

None touch announcements, and nothing in this PR is on their code paths.
