### PR TITLE
fix(tests): repair app-blocks unit+component baseline breaks on main

### DIFF
--- a/src/components/AppBlocks/PageBlockHostResourcePicker.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostResourcePicker.browser.test.tsx
@@ -248,8 +248,11 @@ describe('PageBlockHost resource picker (Design 1 host-chrome)', () => {
     await vi.waitFor(() => {
       const r = replies.last('RESOURCE_PICKER_RESULT');
       if (!r) throw new Error('no reply yet');
-      // EXACTLY the six-field allowlist — IDs + the public display names of the
-      // user-picked resource — nothing else.
+      // EXACTLY the projectSafeGenerationResource allowlist — IDs + public display
+      // names + the PUBLIC recommended generation settings (strength/min/max clamp,
+      // trainedWords, clipSkip; widened in PR-C so a block can seed a weight slider +
+      // trigger-word display). Defaults fill the unset settings on `fakeResource()`.
+      // Nothing outside the allowlist — no availability/access/early-access internals.
       expect(r.payload).toEqual({
         requestId: 'rq_pick',
         selected: {
@@ -259,25 +262,31 @@ describe('PageBlockHost resource picker (Design 1 host-chrome)', () => {
           versionName: 'v1.0',
           baseModel: 'Flux.1 D',
           modelType: 'Checkpoint',
+          strength: 1,
+          minStrength: -1,
+          maxStrength: 2,
+          trainedWords: [],
+          clipSkip: null,
         },
       });
     });
 
     // Adversarial leak check: the reply payload must NOT carry any of the
-    // sensitive fields present on the source GenerationResource. The two public
-    // display names (modelName/versionName) ARE allowed now — everything else
+    // sensitive fields present on the source GenerationResource. The public display
+    // names (modelName/versionName) and the PUBLIC recommended settings (strength/
+    // min/max clamp, trainedWords, clipSkip) ARE allowed — everything else
     // (availability/access/early-access/nsfw/poi/minor/cover-image/userId/the
-    // full model object) must STILL be dropped; the leak-prevention property
-    // holds, only the two name fields were added.
+    // full model object) must STILL be dropped; the leak-prevention property holds.
     const payload = replies.last('RESOURCE_PICKER_RESULT')!.payload as {
       selected: Record<string, unknown>;
     };
     const sel = payload.selected;
     const sensitiveAbsent = ['availability', 'hasAccess', 'canGenerate', 'image', 'name',
-      'nsfw', 'nsfwLevel', 'poi', 'minor', 'sfwOnly', 'userId', 'trainedWords', 'model'];
+      'nsfw', 'nsfwLevel', 'poi', 'minor', 'sfwOnly', 'userId', 'model'];
     for (const k of sensitiveAbsent) expect(sel).not.toHaveProperty(k);
     expect(Object.keys(sel).sort()).toEqual(
-      ['baseModel', 'modelId', 'modelName', 'modelType', 'versionId', 'versionName']
+      ['baseModel', 'clipSkip', 'maxStrength', 'minStrength', 'modelId', 'modelName',
+        'modelType', 'strength', 'trainedWords', 'versionId', 'versionName']
     );
     replies.stop();
   });

--- a/src/components/Apps/AppListingCard.browser.test.tsx
+++ b/src/components/Apps/AppListingCard.browser.test.tsx
@@ -200,8 +200,14 @@ describe('AppListingCard', () => {
 
   test('a long username reveals the full value in a tooltip on hover (clip fallback)', async () => {
     const longName = 'a-really-long-creator-username-that-will-definitely-overflow-the-card-column';
+    // The tooltip is overflow-GATED (TruncatedText disables it unless the label
+    // actually clips — a runtime scrollWidth/scrollHeight measurement). Constrain
+    // the card to a narrow column so the long username really overflows; without a
+    // width bound the label never clips and the tooltip stays disabled.
     renderWithProviders(
-      <AppListingCard card={base({ creator: { id: 5, username: longName, image: null } })} canOpenPage />
+      <div style={{ width: 200 }}>
+        <AppListingCard card={base({ creator: { id: 5, username: longName, image: null } })} canOpenPage />
+      </div>
     );
     const label = page.getByText(`by ${longName}`);
     await expect.element(label).toBeInTheDocument();

--- a/src/components/Apps/AppListingDetailBody.browser.test.tsx
+++ b/src/components/Apps/AppListingDetailBody.browser.test.tsx
@@ -115,8 +115,14 @@ describe('AppListingDetailBody', () => {
 
   test('a long username reveals the full value in a tooltip on hover (clip fallback)', async () => {
     const longName = 'a-really-long-creator-username-that-will-definitely-overflow-the-header-column';
+    // The tooltip is overflow-GATED (TruncatedText disables it unless the label
+    // actually clips — a runtime scrollWidth/scrollHeight measurement). Constrain
+    // the header to a narrow column so the long username really overflows; without a
+    // width bound the label never clips and the tooltip stays disabled.
     renderWithProviders(
-      <AppListingDetailBody detail={base({ creator: { id: 5, username: longName, image: null } })} />
+      <div style={{ width: 200 }}>
+        <AppListingDetailBody detail={base({ creator: { id: 5, username: longName, image: null } })} />
+      </div>
     );
     const label = page.getByText(`by ${longName}`);
     await expect.element(label).toBeInTheDocument();

--- a/src/components/Apps/AppListingTruncate.tsx
+++ b/src/components/Apps/AppListingTruncate.tsx
@@ -52,9 +52,10 @@ export function useIsOverflowing<T extends HTMLElement = HTMLElement>() {
 export function TruncatedText({
   children,
   tooltipLabel,
+  style,
   ...textProps
 }: { children: string; tooltipLabel?: string } & TextProps) {
-  const { ref, overflowing } = useIsOverflowing<HTMLParagraphElement>();
+  const { ref, overflowing } = useIsOverflowing<HTMLSpanElement>();
   return (
     <Tooltip
       label={tooltipLabel ?? children}
@@ -64,7 +65,27 @@ export function TruncatedText({
       maw={320}
       withArrow
     >
-      <Text ref={ref} span {...textProps}>
+      {/* `component="span"` (inline-VALID inside the chip's <a>) + an explicit
+          `inline-block` so the element HAS a client box. Mantine's `span` boolean
+          prop forces `display: inline`, whose clientWidth/scrollWidth are always 0
+          — the overflow measurement then never trips and the Tooltip is dead (and
+          the passed `lineClamp` never clips either). Clipping on a single line
+          below makes `scrollWidth > clientWidth` a true overflow signal; the inline
+          `display` overrides any `-webkit-box` a forwarded `lineClamp` would set. */}
+      <Text
+        ref={ref}
+        component="span"
+        {...textProps}
+        style={{
+          ...style,
+          display: 'inline-block',
+          maxWidth: '100%',
+          overflow: 'hidden',
+          textOverflow: 'ellipsis',
+          whiteSpace: 'nowrap',
+          verticalAlign: 'bottom',
+        }}
+      >
         {children}
       </Text>
     </Tooltip>

--- a/src/components/Apps/AppListingsMarketplaceBody.browser.test.tsx
+++ b/src/components/Apps/AppListingsMarketplaceBody.browser.test.tsx
@@ -37,6 +37,12 @@ const mocks = vi.hoisted(() => ({
   lastArgs: null as null | Record<string, unknown>,
 }));
 
+// The grid renders AppListingCard, which calls useCurrentUser() (owner "Edit"
+// deep-link gate, added in #3392). Without a mock it hits the real
+// CivitaiSessionContext — absent in the provider stack — and throws "missing
+// CivitaiSessionContext", crashing every card render. Mock a signed-out viewer.
+vi.mock('~/hooks/useCurrentUser', () => ({ useCurrentUser: () => null }));
+
 vi.mock('~/utils/trpc', () => ({
   trpc: {
     appListings: {

--- a/src/components/Apps/AppListingsModerationTable.browser.test.tsx
+++ b/src/components/Apps/AppListingsModerationTable.browser.test.tsx
@@ -320,8 +320,13 @@ describe('AppListingsModerationTable — effective status (draft-with-pending �
     await expect.element(draftSection).toBeInTheDocument();
 
     const draftPendingRow = page.getByTestId('apps-mod-listing-row-draft-pending-ext');
-    const orphanRow = page.getByTestId('apps-mod-listing-row-draft-orphan-ext');
     await expect.element(draftPendingRow).toBeInTheDocument();
+
+    // The Draft section is a quiet, default-COLLAPSED trailing section (collapsible:
+    // true in MOD_SECTION_META) — its rows aren't in the DOM until it's expanded. Open
+    // it so the orphan draft row renders.
+    await page.getByTestId('apps-mod-listings-section-draft-toggle').click();
+    const orphanRow = page.getByTestId('apps-mod-listing-row-draft-orphan-ext');
     await expect.element(orphanRow).toBeInTheDocument();
 
     // Bucketing: the draft-with-pending sits in the Pending section, the orphan in Draft.

--- a/src/components/Apps/OffsiteReviewQueue.browser.test.tsx
+++ b/src/components/Apps/OffsiteReviewQueue.browser.test.tsx
@@ -392,10 +392,12 @@ describe('OffsiteReviewModal — on-site listing-media revision (kind: onsite)',
   test('flags media rated higher than the app rating as a cap violation (reject reason)', async () => {
     // Assets derive 'r' (screenshot @ level 4) vs the app rating 'g' → cap exceeded.
     renderWithProviders(<OffsiteReviewModal request={ONSITE_MEDIA_ROW} onClose={vi.fn()} />);
-    await expect.element(page.getByTestId('apps-offsite-rating-mismatch')).toBeInTheDocument();
-    await expect
-      .element(page.getByText('must not exceed the app’s rating', { exact: false }))
-      .toBeInTheDocument();
+    const mismatch = page.getByTestId('apps-offsite-rating-mismatch');
+    await expect.element(mismatch).toBeInTheDocument();
+    // The cap-rule phrase now also appears in the on-site explainer note, so a bare
+    // getByText matches two elements (strict-mode violation). Scope the reject-reason
+    // assertion to the mismatch callout itself.
+    await expect.element(mismatch).toHaveTextContent('must not exceed the app’s rating');
   });
 });
 

--- a/src/components/Apps/UnifiedReviewList.browser.test.tsx
+++ b/src/components/Apps/UnifiedReviewList.browser.test.tsx
@@ -89,6 +89,11 @@ describe('UnifiedReviewList — renders both kinds with correct badges', () => {
 
   test('oldest-first order under direction="asc" (on-site row precedes off-site)', async () => {
     renderList();
+    // Wait for the async render to commit before the synchronous `.elements()`
+    // read — reading immediately after renderList() races the mount and returns 0.
+    await expect
+      .element(page.getByTestId('apps-unified-review-row-onsite:or1'))
+      .toBeInTheDocument();
     const rows = page.getByTestId(/^apps-unified-review-row-/).elements();
     expect(rows).toHaveLength(2);
     expect(rows[0].getAttribute('data-testid')).toBe('apps-unified-review-row-onsite:or1');

--- a/src/server/utils/__tests__/subscription.utils.test.ts
+++ b/src/server/utils/__tests__/subscription.utils.test.ts
@@ -18,6 +18,12 @@ vi.mock('~/server/services/orchestrator/civitai', () => ({
 vi.mock('~/server/services/vault.service', () => ({
   setVaultFromSubscription: vi.fn().mockResolvedValue(undefined),
 }));
+// Added by #3322: invalidateSubscriptionCaches now busts the read-time membership-
+// validity cache via redis.del. Without this mock the real redis client is called,
+// which hangs (~240s CI timeout) and rejects (breaking the "no log"/"exactly 2" asserts).
+vi.mock('~/server/services/creator-membership.service', () => ({
+  bustCreatorMembershipValidCache: vi.fn().mockResolvedValue(undefined),
+}));
 
 describe('getPrepaidTokens', () => {
   describe('null/empty metadata', () => {


### PR DESCRIPTION
## What

Repairs a **new multi-suite (unit + component) baseline break on `main`**. The App
Listings / App Blocks feature PRs land service + component changes while the
**UNIT and COMPONENT vitest suites run report-only** (no required CI gate), so
tests the source outgrew merged broken. These were confirmed failing in CI on the
merge-with-`main` of the unrelated PR #3406 — i.e. baseline breaks on `main`, not
that PR's diff.

Base: `origin/main` @ `44ebf38c0a`.

## Per-file root cause + test-vs-source verdict

### Unit (2 files fixed → 1)
- **`subscription.utils.test.ts`** — **TEST (mock gap).** #3322 added a
  `bustCreatorMembershipValidCache` step to `invalidateSubscriptionCaches`, which
  calls the real `redis` client. The test never mocked `creator-membership.service`,
  so that step **hung (~240 s CI timeout)** and rejected, breaking the
  "does-not-log" / "logs exactly N" assertions. Added the missing mock. **Source is
  correct** — `invalidateSubscriptionCaches` already uses `Promise.allSettled` +
  per-step error isolation and is properly bounded (this is **not** a hang
  regression; the source cannot hang the caller).
- **`og-metadata.test.ts`** — **no change (not a real regression).** The ReDoS
  guard runs in ~0.6 s locally against the 4 s bound; `extractListingMeta` already
  has the 256 KB parse cap + bounded lazy quantifier. Its CI failure was
  **collateral**: the `subscription.utils` hang was spinning a CI worker ~240 s in
  the *same* unit run, starving CPU and inflating this wall-clock bound. Fixing the
  hang removes the starvation — no ReDoS source fix needed.

### Component (8 files — AppBlocks/Apps browser tests)
- **`AppListingTruncate.tsx`** — 🔴 **SOURCE (real, cosmetic defect).**
  `TruncatedText` rendered `<Text span lineClamp>`, but Mantine's `span` boolean
  forces `display:inline`, whose `clientWidth`/`scrollWidth` are always **0** — so
  `useIsOverflowing` never trips and **both the overflow tooltip and the `lineClamp`
  were DEAD in production**: a long creator username neither clipped nor showed a
  tooltip. Now renders a measurable `inline-block` with a real single-line ellipsis.
  (The two tooltip tests also now render inside a width-constrained container so the
  clip actually triggers.) Fixed in source, not worked around.
- **`AppListingsMarketplaceBody.browser.test.tsx`** — **TEST (provider/mock gap).**
  The grid renders `AppListingCard`, which gained `useCurrentUser()` in #3392;
  unmocked it throws **"missing CivitaiSessionContext"** and crashes every card.
  Added the `useCurrentUser` mock (repo convention).
- **`AppListingsModerationTable.browser.test.tsx`** — **TEST (stale interaction).**
  The Draft section is a quiet **default-collapsed** trailing section
  (`collapsible:true`); its rows aren't in the DOM until expanded. Expand the
  section toggle before asserting the orphan-draft row. Source behavior is correct.
- **`OffsiteReviewQueue.browser.test.tsx`** — **TEST (ambiguous locator).** The
  cap-rule phrase legitimately appears in *both* the on-site explainer note and the
  reject-reason callout, so a bare `getByText` matched two elements (strict-mode
  violation). Scoped the assertion to the mismatch callout.
- **`UnifiedReviewList.browser.test.tsx`** — **TEST (sync-read race).** The order
  test read `.elements()` synchronously right after render (0 rows). Await the row
  mount first.
- **`PageBlockHostResourcePicker.browser.test.tsx`** — **TEST (stale allowlist).**
  The `RESOURCE_PICKER_RESULT` projection was deliberately **widened (PR-C)** via
  `projectSafeGenerationResource` to also carry PUBLIC recommended settings
  (`strength`/`min`/`max` clamp, `trainedWords`, `clipSkip`); the test still
  asserted the old 6-field shape. Updated the expected object + the adversarial
  leak-check key set (`trainedWords` is now a legit public field). **`projectSafe…`
  is a strict field-by-field allowlist** — no sensitive
  (availability/access/early-access/nsfw/poi/minor/userId/model) field leaks; the
  leak-prevention property is preserved.

## Source regressions flagged
- One real source fix: **`AppListingTruncate.tsx`** (overflow tooltip + lineClamp
  were non-functional due to inline display) — fixed in this PR, low-severity/cosmetic.
- **No** subscription.utils hang regression and **no** og-metadata ReDoS regression
  (both investigated with highest scrutiny and cleared — the source is bounded/safe;
  the failures were a test mock-gap and its CPU-starvation collateral).

## Verification
Local, vitest 4 browser mode (system chromium):
- **UNIT: 49/49 pass (2 files)** — `subscription.utils` now 117 ms (was hanging
  ~240 s → 90 s-timeout reproduced before the fix); `og-metadata` ReDoS guard 0.6 s.
- **COMPONENT: 102/102 pass (8 files)**, no unhandled errors.

## CI-gate note
A **required** unit + component gate on PRs would have blocked every one of these —
they merged only because both suites run report-only. Making the unit + component
projects a required check (at least on `src/components/Apps`, `src/components/AppBlocks`,
and the touched services) would prevent this recurring class.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
