### PR TITLE
feat(collections): notify submitters when their contest item is accepted or rejected

### DIFF
--- a/prisma/migrations/20260727120000_collection_item_review_notification_settings/migration.sql
+++ b/prisma/migrations/20260727120000_collection_item_review_notification_settings/migration.sql
@@ -1,0 +1,10 @@
+-- Preserve opt-out state when splitting `contest-collection-item-status-change` into the
+-- `collection-item-accepted` / `collection-item-rejected` notification types. Every user who had
+-- disabled the old combined notification gets equivalent disabled rows for the two new types so
+-- they are not silently re-subscribed by the key change.
+INSERT INTO "UserNotificationSettings" ("userId", "type", "disabledAt")
+SELECT s."userId", t."type", s."disabledAt"
+FROM "UserNotificationSettings" s
+CROSS JOIN (VALUES ('collection-item-accepted'), ('collection-item-rejected')) AS t("type")
+WHERE s."type" = 'contest-collection-item-status-change'
+ON CONFLICT ("userId", "type") DO NOTHING;

--- a/src/server/notifications/collection.notifications.ts
+++ b/src/server/notifications/collection.notifications.ts
@@ -18,6 +18,30 @@ export const collectionNotifications = createNotificationProcessor({
         : `/collections/${details.collectionId}`,
     }),
   },
+  'collection-item-accepted': {
+    displayName: 'Your submission was accepted',
+    category: NotificationCategory.Update,
+    prepareMessage: ({ details }) => ({
+      message: `Your submission to ${details.collectionName} was accepted.`,
+      url: details.imageId
+        ? `/images/${details.imageId}`
+        : details.modelId
+        ? `/models/${details.modelId}`
+        : details.articleId
+        ? `/articles/${details.articleId}`
+        : details.postId
+        ? `/posts/${details.postId}`
+        : `/collections/${details.collectionId}`,
+    }),
+  },
+  'collection-item-rejected': {
+    displayName: "Your submission wasn't accepted",
+    category: NotificationCategory.Update,
+    prepareMessage: ({ details }) => ({
+      message: `Your submission to ${details.collectionName} wasn't accepted.`,
+      url: `/collections/${details.collectionId}`,
+    }),
+  },
   'beggars-board-rejected': {
     displayName: 'Beggars board entry declined',
     category: NotificationCategory.Buzz,

--- a/src/server/notifications/collection.notifications.ts
+++ b/src/server/notifications/collection.notifications.ts
@@ -5,6 +5,7 @@ export const collectionNotifications = createNotificationProcessor({
   'contest-collection-item-status-change': {
     displayName: 'Your item has been reviewed',
     category: NotificationCategory.Update,
+    toggleable: false,
     prepareMessage: ({ details }) => ({
       message: `The item you submitted to the contest "${details.collectionName}" has been ${details.status}.`,
       url: details.imageId
@@ -39,7 +40,15 @@ export const collectionNotifications = createNotificationProcessor({
     category: NotificationCategory.Update,
     prepareMessage: ({ details }) => ({
       message: `Your submission to ${details.collectionName} wasn't accepted.`,
-      url: `/collections/${details.collectionId}`,
+      url: details.imageId
+        ? `/images/${details.imageId}`
+        : details.modelId
+        ? `/models/${details.modelId}`
+        : details.articleId
+        ? `/articles/${details.articleId}`
+        : details.postId
+        ? `/posts/${details.postId}`
+        : `/collections/${details.collectionId}`,
     }),
   },
   'beggars-board-rejected': {

--- a/src/server/services/collection.service.ts
+++ b/src/server/services/collection.service.ts
@@ -1934,31 +1934,21 @@ export const updateCollectionItemsStatus = async ({
         // Skip missing submitter, self-review, and no-op status changes.
         if (!item.addedById || item.addedById === userId || item.status === status) return;
 
-        try {
-          await createNotification({
-            type: notificationType,
-            userId: item.addedById,
-            category: NotificationCategory.Update,
-            key: `${notificationType}:${item.id}:${uuid()}`,
-            details: {
-              status,
-              collectionId: collection.id,
-              collectionName: collection.name,
-              imageId: item.imageId,
-              articleId: item.articleId,
-              modelId: item.modelId,
-              postId: item.postId,
-            },
-          });
-        } catch (error) {
-          await logToAxiom({
-            type: 'error',
-            name: 'collection-item-review-notification-failed',
-            message: error instanceof Error ? error.message : String(error),
+        await createNotification({
+          type: notificationType,
+          userId: item.addedById,
+          category: NotificationCategory.Update,
+          key: `${notificationType}:${item.id}:${uuid()}`,
+          details: {
+            status,
             collectionId: collection.id,
-            collectionItemId: item.id,
-          }).catch(() => undefined);
-        }
+            collectionName: collection.name,
+            imageId: item.imageId,
+            articleId: item.articleId,
+            modelId: item.modelId,
+            postId: item.postId,
+          },
+        });
       })
     );
   }

--- a/src/server/services/collection.service.ts
+++ b/src/server/services/collection.service.ts
@@ -1892,6 +1892,26 @@ export const updateCollectionItemsStatus = async ({
     }
   }
 
+  const isReviewOutcome =
+    status === CollectionItemStatus.ACCEPTED || status === CollectionItemStatus.REJECTED;
+
+  // Capture prior state before the status write so we only notify on real transitions.
+  const priorItems =
+    collection.mode === CollectionMode.Contest && isReviewOutcome && collectionItemIds.length > 0
+      ? await dbWrite.collectionItem.findMany({
+          where: { id: { in: collectionItemIds }, collectionId },
+          select: {
+            id: true,
+            addedById: true,
+            status: true,
+            imageId: true,
+            articleId: true,
+            modelId: true,
+            postId: true,
+          },
+        })
+      : [];
+
   if (collectionItemIds.length > 0) {
     await dbWrite.$executeRaw`
       UPDATE "CollectionItem"
@@ -1903,32 +1923,42 @@ export const updateCollectionItemsStatus = async ({
     `;
   }
 
-  if (collection.mode === CollectionMode.Contest) {
-    const updatedItems = await dbWrite.collectionItem.findMany({
-      where: { id: { in: collectionItemIds }, collectionId },
-    });
+  if (priorItems.length > 0) {
+    const notificationType =
+      status === CollectionItemStatus.ACCEPTED
+        ? 'collection-item-accepted'
+        : 'collection-item-rejected';
 
     await Promise.all(
-      updatedItems.map(async (item) => {
-        if (!item.addedById) {
-          return;
-        }
+      priorItems.map(async (item) => {
+        // Skip missing submitter, self-review, and no-op status changes.
+        if (!item.addedById || item.addedById === userId || item.status === status) return;
 
-        await createNotification({
-          type: 'contest-collection-item-status-change',
-          userId: item.addedById,
-          category: NotificationCategory.Update,
-          key: `contest-collection-item-status-change:${uuid()}`,
-          details: {
-            status,
+        try {
+          await createNotification({
+            type: notificationType,
+            userId: item.addedById,
+            category: NotificationCategory.Update,
+            key: `${notificationType}:${item.id}:${uuid()}`,
+            details: {
+              status,
+              collectionId: collection.id,
+              collectionName: collection.name,
+              imageId: item.imageId,
+              articleId: item.articleId,
+              modelId: item.modelId,
+              postId: item.postId,
+            },
+          });
+        } catch (error) {
+          await logToAxiom({
+            type: 'error',
+            name: 'collection-item-review-notification-failed',
+            message: error instanceof Error ? error.message : String(error),
             collectionId: collection.id,
-            collectionName: collection.name,
-            imageId: item.imageId,
-            articleId: item.articleId,
-            modelId: item.modelId,
-            postId: item.postId,
-          },
-        });
+            collectionItemId: item.id,
+          }).catch(() => undefined);
+        }
       })
     );
   }


### PR DESCRIPTION
## What & why

Entrants to Contest-mode collections (specifically the Krea 2 training contest) had no reliable signal about the outcome of their submission. This adds a notification when a moderator reviews their `CollectionItem`.

## Trigger

Fires from `updateCollectionItemsStatus` in `src/server/services/collection.service.ts` — the single code path (via the `collection.updateCollectionItemsStatus` tRPC mutation) that a moderator uses to set a `CollectionItem`'s status. A notification is sent to the item's submitter (`addedById`) when:

- the collection is `Contest` mode, **and**
- the new status is `ACCEPTED` or `REJECTED`, **and**
- the item's prior status actually differs from the new status (no-op transitions are skipped), **and**
- the submitter is not the moderator performing the review.

## Accept vs reject

Two new notification definitions in `src/server/notifications/collection.notifications.ts` (both `NotificationCategory.Update`):

- `collection-item-accepted` → "Your submission to {collectionName} was accepted."
- `collection-item-rejected` → "Your submission to {collectionName} wasn't accepted."

**Both** now link via the same entity-link ladder (imageId → modelId → articleId → postId → fallback collection). Rejected deliberately does **not** fall back to only the collection page: `getCollectionItemPermissions` exposes ACCEPTED items (plus the viewer's own REVIEW items), so a REJECTED item is invisible to its submitter on the collection page and a bare collection link dead-ends (blank page / 403-404). Linking to the submitted entity, which the submitter owns, always resolves.

## Behavior change (wider than Krea 2 — read this)

This **replaces** the previous `contest-collection-item-status-change` firing, which notified on *every* status change — including `REVIEW` and no-op re-saves — with a generic all-caps message (`has been REJECTED`). That means **for ALL Contest collections, not just Krea 2**, submitters no longer get a notification when their item is moved to `REVIEW` or re-saved at the same status; they now only get one on a real ACCEPTED/REJECTED transition. The old processor definition is retained (marked `toggleable: false` so it stops rendering as a dead toggle in notification settings) so historical notifications of that type still render.

**Coverage is not 100%.** Auto-judged flows that set item status via raw SQL rather than this service function bypass the notification entirely — notably daily-challenge reward judging (`challenge-rewards.ts`) and post-entry paths (`post.service.ts`). Those would need separate wiring if outcome notifications are wanted there.

## Batch behavior

Moderators review many items at once. Each submitter notification is created independently inside a `Promise.all` map; `createNotification` is best-effort and swallows its own failures internally, so one bad recipient can't fail the review batch. Prior item state is read once before the status write so transition detection is accurate.

## Migration (manual apply required)

`prisma/migrations/20260727120000_collection_item_review_notification_settings/migration.sql` — **targets the main app DB** (where `UserNotificationSettings` lives; the notifications app reads it via `mainDbRead`). Changing the notification type key would otherwise orphan existing opt-out rows and silently re-subscribe users who had muted the old `contest-collection-item-status-change` notification. The migration copies each such user's disabled row (preserving `disabledAt`) to `collection-item-accepted` and `collection-item-rejected`, idempotent via `ON CONFLICT DO NOTHING`.

Per repo convention we do **not** run `prisma migrate deploy` — apply this SQL manually to preview / staging / prod.

## Follow-ups (not addressed here, by request)

- Concurrent-click dedup: two near-simultaneous review clicks could each generate a notification (keys use a uuid, so no dedup). Low impact.
- `collectionItemIds` is unbounded in the input schema; the prior-state `findMany` and notification fan-out inherit that. Worth a cap.

## Reviewer notes / assumptions

- Scope is intentionally kept to `Contest`-mode collections, matching where the old notification fired, to avoid spamming Bookmark/standard/moderation-collection reviews.
- Notifications are per-item, so a submitter with multiple reviewed entries receives one per entry (each links to its own submission) — consistent with prior behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
