### PR TITLE
App Blocks mod-review UX: drop report Summary tab, listing preview, combined code+media review

### DIFF
--- a/src/components/Apps/AgentReviewPanel.browser.test.tsx
+++ b/src/components/Apps/AgentReviewPanel.browser.test.tsx
@@ -68,11 +68,10 @@ vi.mock('~/utils/notifications', () => ({
   showErrorNotification: (...a: unknown[]) => showError(...a),
 }));
 
-// The Summary tab renders `summaryMd` through `CustomMarkdown`, which reads
-// `useCurrentUser()` (→ CivitaiSessionContext) for its link-rewrite. The
-// network-free scaffold has no session provider, so boundary-stub the hook (the
-// standard pattern in the sibling AgentReviewChat test). Null user is fine —
-// CustomMarkdown only uses `user?.id` (optional-chained).
+// The AgentReviewChat sub-panel reads `useCurrentUser()` (→ CivitaiSessionContext)
+// for its markdown link-rewrite. The network-free scaffold has no session provider,
+// so boundary-stub the hook (the standard pattern in the sibling AgentReviewChat
+// test). Null user is fine — the consumers only use `user?.id` (optional-chained).
 vi.mock('~/hooks/useCurrentUser', () => ({
   useCurrentUser: () => null,
 }));
@@ -594,7 +593,7 @@ describe('AgentReviewPanel — defensive / empty', () => {
 // ---------------------------------------------------------------------------
 
 describe('AgentReviewPanel — sanitization', () => {
-  test('adversarial HTML/script in finding text + summary renders as inert TEXT (no live DOM)', async () => {
+  test('adversarial HTML/script in finding text renders as inert TEXT (no live DOM)', async () => {
     const imgPayload = '<img src=x onerror="window.__xssFired=true">';
     const scriptPayload = '<script>window.__xssScript=true</script>';
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -602,11 +601,14 @@ describe('AgentReviewPanel — sanitization', () => {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (window as any).__xssScript = undefined;
 
+    // The former markdown summary surface was removed, so both payloads now live
+    // in structured finding fields (code detail + security detail) — every value
+    // there is rendered as inert React text (keepMounted, so present in the DOM
+    // regardless of the active tab).
     mocks.agentReport = {
       status: 'complete',
-      summaryMd: scriptPayload,
       codeReview: { findings: [{ title: 'XSS attempt', description: imgPayload }] },
-      securityAudit: {},
+      securityAudit: { findings: [{ title: 'Script attempt', detail: scriptPayload }] },
       scopeVerdicts: {},
     };
     renderWithProviders(<AgentReviewPanel publishRequestId="onsite-req-1" slug="my-onsite-block" />);
@@ -632,40 +634,36 @@ describe('AgentReviewPanel — sanitization', () => {
 // ---------------------------------------------------------------------------
 
 describe('AgentReviewPanel — tabbed report', () => {
-  test('renders the four tabs with finding counts in the labels', async () => {
+  test('renders the three tabs (Scopes, Security, Code review) with finding counts, no Summary tab', async () => {
     mocks.agentReport = MULTI_REPORT;
     renderWithProviders(<AgentReviewPanel publishRequestId="onsite-req-1" slug="my-onsite-block" />);
 
     // Tab labels carry the counts (3 code findings, 2 security, 2 scopes).
-    await expect.element(page.getByRole('tab', { name: /Summary/ })).toBeInTheDocument();
-    await expect.element(page.getByRole('tab', { name: /Code review.*3/ })).toBeInTheDocument();
-    await expect.element(page.getByRole('tab', { name: /Security audit.*2/ })).toBeInTheDocument();
     await expect.element(page.getByRole('tab', { name: /Scopes.*2/ })).toBeInTheDocument();
+    await expect.element(page.getByRole('tab', { name: /Security audit.*2/ })).toBeInTheDocument();
+    await expect.element(page.getByRole('tab', { name: /Code review.*3/ })).toBeInTheDocument();
 
-    // Summary roll-up shows the severity breakdown for security (1 critical, 1 high).
-    const rollup = page.getByTestId('report-rollup');
-    await expect.element(rollup).toBeVisible();
-    await expect.element(rollup.getByText(/Code 3/)).toBeInTheDocument();
-    await expect.element(rollup.getByText(/Security 2 \(1 critical, 1 high\)/)).toBeInTheDocument();
-    await expect.element(rollup.getByText(/2 scopes/)).toBeInTheDocument();
+    // The former Summary tab + its counts-first roll-up are gone.
+    expect(page.getByRole('tab', { name: /Summary/ }).elements().length).toBe(0);
+    expect(page.getByTestId('report-rollup').elements().length).toBe(0);
   });
 
-  test('switching tabs reveals the right section (one visible at a time)', async () => {
+  test('switching tabs reveals the right section (one visible at a time); Scopes is the default', async () => {
     mocks.agentReport = FULL_REPORT;
     renderWithProviders(<AgentReviewPanel publishRequestId="onsite-req-1" slug="my-onsite-block" />);
 
-    // Summary is the default active tab; its markdown panel is visible.
-    await expect.element(page.getByTestId('report-summary-md')).toBeVisible();
+    // Scopes is now the default active tab; its verdicts table is visible.
+    await expect.element(page.getByTestId('scope-verdicts-table')).toBeVisible();
     // Code-review-only content exists (keepMounted) but is NOT visible yet.
     await expect.element(page.getByText('Prior-version reconciliation')).not.toBeVisible();
 
-    // Activate the Code review tab → its content becomes visible, Summary hides.
+    // Activate the Code review tab → its content becomes visible, Scopes hides.
     await page.getByRole('tab', { name: /Code review/ }).click();
     await expect.element(page.getByText('Prior-version reconciliation')).toBeVisible();
     await expect.element(page.getByText('Hardcoded secret')).toBeVisible();
-    await expect.element(page.getByTestId('report-summary-md')).not.toBeVisible();
+    await expect.element(page.getByTestId('scope-verdicts-table')).not.toBeVisible();
 
-    // Activate the Scopes tab → the verdicts table becomes visible.
+    // Back to the Scopes tab → the verdicts table becomes visible again.
     await page.getByRole('tab', { name: /Scopes/ }).click();
     await expect.element(page.getByTestId('scope-verdicts-table')).toBeVisible();
     await expect.element(page.getByText('Prior-version reconciliation')).not.toBeVisible();
@@ -689,21 +687,6 @@ describe('AgentReviewPanel — tabbed report', () => {
     expect(texts[0]).toContain('Critical finding');
     expect(texts[1]).toContain('Medium finding');
     expect(texts[2]).toContain('Low finding');
-  });
-
-  test('summaryMd renders as markdown, and a markdown image is dropped (no <img>)', async () => {
-    mocks.agentReport = {
-      ...FULL_REPORT,
-      summaryMd: '# Heading one\n\n**bolded** text with an ![alt](https://evil.example/pixel.png)',
-    };
-    renderWithProviders(<AgentReviewPanel publishRequestId="onsite-req-1" slug="my-onsite-block" />);
-
-    // Markdown formatting is applied (heading + strong become real elements).
-    await expect.element(page.getByRole('heading', { name: 'Heading one' })).toBeInTheDocument();
-    expect(document.querySelector('.markdown-content strong')?.textContent).toBe('bolded');
-    // 🔴 img-guard (mirrors the Phase-0 chat guard): the markdown image produces
-    // NO <img> — an <img> would fire an external fetch from the moderator's browser.
-    expect(document.querySelectorAll('img').length).toBe(0);
   });
 
   test('an errored analysis section shows the failure state, not a crash', async () => {
@@ -743,7 +726,5 @@ describe('AgentReviewPanel — tabbed report', () => {
     await expect.element(page.getByText('No code-review findings.')).toBeInTheDocument();
     await expect.element(page.getByText('No security-audit findings.')).toBeInTheDocument();
     await expect.element(page.getByText('No scopes assessed.')).toBeInTheDocument();
-    // Summary tab with no summaryMd shows its own empty state.
-    await expect.element(page.getByText('No summary was provided.')).toBeInTheDocument();
   });
 });

--- a/src/components/Apps/AppListingDetailBody.browser.test.tsx
+++ b/src/components/Apps/AppListingDetailBody.browser.test.tsx
@@ -21,11 +21,21 @@ vi.mock('~/hooks/useCurrentUser', () => ({
 }));
 
 // Header-focused: stub the trpc-backed children (reviews/report/comments) so the
-// test needs no tRPC wiring.
-vi.mock('~/components/Apps/ReviewListingButton', () => ({ ReviewListingButton: () => null }));
-vi.mock('~/components/Apps/ReportListingButton', () => ({ ReportListingButton: () => null }));
-vi.mock('~/components/Apps/AppListingReviews', () => ({ AppListingReviews: () => null }));
-vi.mock('~/components/Apps/AppListingComments', () => ({ AppListingComments: () => null }));
+// test needs no tRPC wiring. They render identifiable markers (not null) so the
+// preview-mode tests below can assert they are OMITTED in preview + PRESENT in the
+// live (non-preview) render.
+vi.mock('~/components/Apps/ReviewListingButton', () => ({
+  ReviewListingButton: () => <div data-testid="mock-review-button" />,
+}));
+vi.mock('~/components/Apps/ReportListingButton', () => ({
+  ReportListingButton: () => <div data-testid="mock-report-button" />,
+}));
+vi.mock('~/components/Apps/AppListingReviews', () => ({
+  AppListingReviews: () => <div data-testid="mock-reviews" />,
+}));
+vi.mock('~/components/Apps/AppListingComments', () => ({
+  AppListingComments: () => <div data-testid="mock-comments" />,
+}));
 
 // Import AFTER the mocks are declared (vi.mock is hoisted, imports are not).
 const { AppListingDetailBody } = await import('./AppListingDetailBody');
@@ -111,6 +121,48 @@ describe('AppListingDetailBody', () => {
     mocks.currentUser = null;
     renderWithProviders(<AppListingDetailBody detail={base({})} />);
     await expect.element(page.getByTestId('apps-listing-owner-edit')).not.toBeInTheDocument();
+  });
+
+  test('preview mode renders presentational parts and OMITS comments/reviews/report/review-button/primary-action', async () => {
+    // Owner viewing — so even the owner Edit affordance must be absent in preview.
+    mocks.currentUser = { id: 5, username: 'alice' };
+    renderWithProviders(
+      <AppListingDetailBody
+        detail={base({
+          description: 'About **this** app.',
+          screenshots: [{ url: 'https://cdn.example/shot-1.png', caption: 'a shot' }],
+        })}
+        preview
+      />
+    );
+
+    // Presentational parts still render: name, content-rating, screenshot gallery,
+    // description body.
+    await expect.element(page.getByText('My App')).toBeInTheDocument();
+    await expect.element(page.getByText('Screenshots')).toBeInTheDocument();
+    await expect.element(page.getByText('About', { exact: true })).toBeInTheDocument();
+
+    // Interactive / review surfaces are all OMITTED.
+    expect(page.getByTestId('mock-comments').elements().length).toBe(0);
+    expect(page.getByTestId('mock-reviews').elements().length).toBe(0);
+    expect(page.getByTestId('mock-report-button').elements().length).toBe(0);
+    expect(page.getByTestId('mock-review-button').elements().length).toBe(0);
+    expect(page.getByTestId('apps-listing-owner-edit').elements().length).toBe(0);
+    // The primary action (base() = on-site page app → "Open live") is gone too.
+    expect(page.getByText('Open live', { exact: true }).elements().length).toBe(0);
+    // Back-to-store nav is gone.
+    expect(page.getByText('Back to store').elements().length).toBe(0);
+  });
+
+  test('non-preview (live) still renders comments/reviews/report/review-button + primary action (regression)', async () => {
+    renderWithProviders(<AppListingDetailBody detail={base({})} />);
+    // The live surfaces are all present.
+    await expect.element(page.getByTestId('mock-comments')).toBeInTheDocument();
+    await expect.element(page.getByTestId('mock-reviews')).toBeInTheDocument();
+    await expect.element(page.getByTestId('mock-report-button')).toBeInTheDocument();
+    await expect.element(page.getByTestId('mock-review-button')).toBeInTheDocument();
+    // Primary action present (on-site page app, viewer can't open page → "Open live").
+    await expect.element(page.getByText('Open live', { exact: true })).toBeInTheDocument();
   });
 
   test('a long username reveals the full value in a tooltip on hover (clip fallback)', async () => {

--- a/src/components/Apps/AppListingDetailBody.tsx
+++ b/src/components/Apps/AppListingDetailBody.tsx
@@ -62,9 +62,11 @@ import type {
  * — same screenshot-grid + description + external-link discipline — so listings
  * feel native.
  *
- * DARK / parallel-run: rendered only by the mod-only `/apps/store-preview/<slug>`
- * surface. The live `/apps/[appBlockId]` detail + `AppDetailsModal` + default
- * `/apps` are byte-unchanged; the canonical `/apps/[slug]` cutover is P2d.
+ * DARK / parallel-run: rendered by the mod-only `/apps/store-preview/<slug>`
+ * surface AND, in read-only `preview` mode (see props), by the moderator
+ * listing-media review as a store preview of an unapproved shadow listing. The
+ * live `/apps/[appBlockId]` detail + `AppDetailsModal` + default `/apps` are
+ * byte-unchanged; the canonical `/apps/[slug]` cutover is P2d.
  *
  * XSS / encoding discipline (mirrors P2b): external hrefs are https-guarded in
  * the pure view-model (`safeExternalHref`) + rendered with rel="noopener
@@ -280,9 +282,24 @@ export interface AppListingDetailBodyProps {
   detail: ListingDetail;
   /** Whether the viewer can launch an in-host page app (the `appBlocksPages` flag). */
   canOpenPage?: boolean;
+  /**
+   * READ-ONLY preview posture. When set, render ONLY the presentational parts —
+   * hero cover, icon, name, tagline, creator chip, content-rating badge, screenshot
+   * gallery, description markdown — and OMIT every LIVE/interactive surface: the
+   * comments + recommend reviews, the report / review / primary-action / owner-edit
+   * buttons, and the recommend roll-up. Used by the moderator listing-media review
+   * to render an unapproved SHADOW listing as a store preview WITHOUT loading its
+   * comments/reviews (which don't exist yet) or exposing user actions on an
+   * un-approved listing. When NOT set, behaviour is byte-identical to before.
+   */
+  preview?: boolean;
 }
 
-export function AppListingDetailBody({ detail, canOpenPage = false }: AppListingDetailBodyProps) {
+export function AppListingDetailBody({
+  detail,
+  canOpenPage = false,
+  preview = false,
+}: AppListingDetailBodyProps) {
   const currentUser = useCurrentUser();
   const recommendLabel = getRecommendLabel(detail.recommend, detail.reviewCount);
   const hasRecommend = detail.recommend.recommendPct != null;
@@ -296,12 +313,15 @@ export function AppListingDetailBody({ detail, canOpenPage = false }: AppListing
 
   return (
     <Stack gap="lg">
-      <Anchor component={Link} href="/apps/store-preview" size="sm">
-        <Group gap={4}>
-          <IconArrowLeft size={14} />
-          Back to store
-        </Group>
-      </Anchor>
+      {/* Back-to-store nav is a live-surface affordance — omitted in preview. */}
+      {!preview && (
+        <Anchor component={Link} href="/apps/store-preview" size="sm">
+          <Group gap={4}>
+            <IconArrowLeft size={14} />
+            Back to store
+          </Group>
+        </Anchor>
+      )}
 
       <HeroCover coverUrl={detail.coverUrl} category={detail.category} name={detail.name} />
 
@@ -330,6 +350,10 @@ export function AppListingDetailBody({ detail, canOpenPage = false }: AppListing
             )}
           </Stack>
         </Group>
+        {/* Action column (primary action + owner edit + review/report) — every
+            item here is a LIVE interactive affordance, so the whole column is
+            omitted in read-only preview. */}
+        {!preview && (
         <Box style={{ flexShrink: 0 }}>
           <Stack gap="xs" align="flex-end">
             <PrimaryAction detail={detail} canOpenPage={canOpenPage} />
@@ -356,26 +380,33 @@ export function AppListingDetailBody({ detail, canOpenPage = false }: AppListing
             <ReportListingButton appListingId={detail.id} />
           </Stack>
         </Box>
-      </Group>
-
-      {/* Recommend rollup — Steam-style "N% recommend (M)" or "No reviews yet". */}
-      <Group gap="md" wrap="wrap">
-        <Group gap={6} wrap="nowrap">
-          <IconThumbUp size={16} className={hasRecommend ? 'text-green-500' : 'text-gray-500'} />
-          <Text size="sm" fw={500}>
-            {recommendLabel}
-          </Text>
-        </Group>
-        {hasRecommend && (
-          <Text size="xs" c="dimmed">
-            {detail.recommend.recommendedCount.toLocaleString()} recommend ·{' '}
-            {detail.recommend.notRecommendedCount.toLocaleString()} don&apos;t
-          </Text>
         )}
       </Group>
 
-      {/* Recent reviews — thumbs/recommend list (mod-filtered, escaped plain text). */}
-      <AppListingReviews appListingId={detail.id} />
+      {/* Recommend rollup + recent reviews are review AGGREGATES — omitted in
+          preview (a shadow listing has none, and we must not query them). */}
+      {!preview && (
+        <>
+          {/* Recommend rollup — Steam-style "N% recommend (M)" or "No reviews yet". */}
+          <Group gap="md" wrap="wrap">
+            <Group gap={6} wrap="nowrap">
+              <IconThumbUp size={16} className={hasRecommend ? 'text-green-500' : 'text-gray-500'} />
+              <Text size="sm" fw={500}>
+                {recommendLabel}
+              </Text>
+            </Group>
+            {hasRecommend && (
+              <Text size="xs" c="dimmed">
+                {detail.recommend.recommendedCount.toLocaleString()} recommend ·{' '}
+                {detail.recommend.notRecommendedCount.toLocaleString()} don&apos;t
+              </Text>
+            )}
+          </Group>
+
+          {/* Recent reviews — thumbs/recommend list (mod-filtered, escaped plain text). */}
+          <AppListingReviews appListingId={detail.id} />
+        </>
+      )}
 
       <ScreenshotGallery screenshots={detail.screenshots} name={detail.name} />
 
@@ -405,8 +436,11 @@ export function AppListingDetailBody({ detail, canOpenPage = false }: AppListing
       {/* CommentsV2 discussion — reuses the shared comment + moderation stack keyed
           on the listing's Thread (`entityType="appListing"`, integer surrogate).
           Additive + separate from the recommend-style reviews above. Only reached
-          for an APPROVED listing (getListingDetail is approved-only). */}
-      <AppListingComments serialId={detail.serialId} ownerUserId={detail.creator?.id ?? null} />
+          for an APPROVED listing (getListingDetail is approved-only) — omitted in
+          preview (a shadow listing has no thread; loading it would 404/N+1). */}
+      {!preview && (
+        <AppListingComments serialId={detail.serialId} ownerUserId={detail.creator?.id ?? null} />
+      )}
     </Stack>
   );
 }

--- a/src/components/Apps/CombinedReviewModal.browser.test.tsx
+++ b/src/components/Apps/CombinedReviewModal.browser.test.tsx
@@ -88,6 +88,44 @@ const ASSETS = {
   hasPendingScan: false,
 };
 
+// The mod-only listing-preview projection result: the shadow's REAL media + scalars,
+// projected into the store card + detail shapes (the section renders these directly).
+const LISTING_PREVIEW = {
+  card: {
+    id: 'apl_1',
+    slug: 'combo-app',
+    kind: 'onsite' as const,
+    name: 'Combo App',
+    tagline: 'a handy combo',
+    category: 'utility',
+    contentRating: 'PG',
+    iconUrl: 'https://cdn.example/icon.png',
+    coverUrl: 'https://cdn.example/cover.png',
+    creator: { id: 7, username: 'dev-user', image: null },
+    recommend: { recommendedCount: 0, notRecommendedCount: 0, recommendPct: null },
+    reviewCount: 0,
+    kindData: { kind: 'onsite' as const, appBlockId: 'blk_1', hasPage: false, liveUrl: '' },
+  },
+  detail: {
+    id: 'apl_1',
+    serialId: 1,
+    slug: 'combo-app',
+    kind: 'onsite' as const,
+    name: 'Combo App',
+    tagline: 'a handy combo',
+    description: 'About the combo app.',
+    category: 'utility',
+    contentRating: 'PG',
+    iconUrl: 'https://cdn.example/icon.png',
+    coverUrl: 'https://cdn.example/cover.png',
+    creator: { id: 7, username: 'dev-user', image: null },
+    recommend: { recommendedCount: 0, notRecommendedCount: 0, recommendPct: null },
+    reviewCount: 0,
+    screenshots: [{ url: 'https://cdn.example/shot-1.png', caption: 'shot one' }],
+    kindData: { kind: 'onsite' as const, appBlockId: 'blk_1', hasPage: false, liveUrl: '' },
+  },
+};
+
 const mocks = vi.hoisted(() => ({
   invalidate: vi.fn().mockResolvedValue(undefined),
   mutate: vi.fn(),
@@ -172,6 +210,11 @@ vi.mock('~/utils/trpc', () => {
         getAssets: { useQuery: () => ({ data: ASSETS, isLoading: false, error: null }) },
         approveExternalRequest: { useMutation: mutation('appListings.approve') },
         rejectExternalRequest: { useMutation: mutation('appListings.reject') },
+        // The mod-only listing-preview projection — returns the shadow's REAL media
+        // + scalars so the media section renders the actual card + detail preview.
+        getListingPreviewForReview: {
+          useQuery: () => ({ data: LISTING_PREVIEW, isLoading: false, error: null }),
+        },
       },
     },
   };
@@ -203,6 +246,12 @@ describe('CombinedReviewModal', () => {
     await expect.element(page.getByTestId('apps-listing-preview-card')).toBeInTheDocument();
     await expect.element(page.getByTestId('apps-listing-preview-detail')).toBeInTheDocument();
     await expect.element(page.getByText('Content review checklist')).toBeInTheDocument();
+    // The REAL projected data renders — the tagline + description come ONLY from the
+    // proc projection (the placeholder-fallback builder yields null for both), so their
+    // presence proves the preview is showing the real shadow projection, not a fallback.
+    const detailScope = page.getByTestId('apps-listing-preview-detail');
+    await expect.element(detailScope.getByText('a handy combo')).toBeInTheDocument();
+    await expect.element(detailScope.getByText('About the combo app.')).toBeInTheDocument();
   });
 
   test('approving the CODE section fires ONLY blocks.approveRequest with the code request id', async () => {

--- a/src/components/Apps/CombinedReviewModal.browser.test.tsx
+++ b/src/components/Apps/CombinedReviewModal.browser.test.tsx
@@ -1,0 +1,231 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { page } from 'vitest/browser';
+// `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
+import { renderWithProviders } from '../../../test/component-setup';
+
+/**
+ * The COMBINED code + listing-media review surface (Item 4) — browser-mode render
+ * test (report-only in Tekton; the blocking gate for the pairing logic is the
+ * `unifiedReviewRow` unit suite). Asserts:
+ *  - BOTH stacked section headers render (App code review + Listing media);
+ *  - the CODE section shows the agent ReportTabs (Scopes/Security/Code review);
+ *  - the MEDIA section shows the listing PREVIEW (card + detail) + the assets/
+ *    content-review surface;
+ *  - the two approve buttons call DISTINCT procs with DISTINCT request ids —
+ *    approving the code section fires ONLY `blocks.approveRequest`; approving the
+ *    media section fires ONLY `appListings.approveExternalRequest`.
+ *
+ * Everything network-touching (both bodies' many trpc queries/mutations) is mocked;
+ * `mocks.mutate(name, vars)` records every mutation so the distinct-handler
+ * assertion can prove approving one section never triggers the other's proc.
+ */
+
+const CODE_REQUEST = {
+  id: 'code-req-1',
+  appBlockId: 'blk_1',
+  slug: 'combo-app',
+  version: '1.2.0',
+  submittedAt: new Date('2026-01-01T00:00:00Z'),
+  bundleSizeBytes: '2048',
+  bundleSha256: 'abcdef0123456789abcdef0123456789',
+  manifest: {
+    name: 'Combo App',
+    blockId: 'blk_1',
+    version: '1.2.0',
+    scopes: ['user:read'],
+    targets: [{ slotId: 'model.sidebar_top', priority: 10 }],
+  },
+  fileSummary: { files: [{ path: 'index.js', sha256: 'x', sizeBytes: 10 }], added: ['index.js'], removed: [], changed: [] },
+  manifestDiffSummary: { kind: 'first-version', fields: ['name'] },
+  reviewRepoUrl: 'https://forgejo.example/repo',
+  pushCommitUrl: null as string | null,
+  submittedBy: { id: 7, username: 'dev-user', image: null },
+};
+
+const LISTING_ROW = {
+  id: 'media-req-1',
+  kind: 'onsite' as const,
+  appListingId: 'apl_1',
+  slug: 'combo-app',
+  status: 'pending',
+  submittedAt: '2026-01-02T00:00:00Z',
+  changelog: null,
+  appListing: {
+    name: 'Combo App',
+    externalUrl: null,
+    category: 'utility',
+    contentRating: 'PG',
+  },
+  submittedBy: { id: 7, username: 'dev-user', image: null },
+};
+
+const SELECTION = {
+  onsiteRequestId: CODE_REQUEST.id,
+  listingRequestId: LISTING_ROW.id,
+  onsiteRequest: CODE_REQUEST,
+  listingRow: LISTING_ROW,
+};
+
+const AGENT_REPORT = {
+  status: 'complete',
+  codeReview: { findings: [{ severity: 'medium', title: 'A code finding', detail: 'code detail' }] },
+  securityAudit: { findings: [] },
+  scopeVerdicts: { scopes: [] },
+};
+
+// Clean, fully-scanned assets so the media Approve… is enabled (not scan-gated).
+const ASSETS = {
+  listingId: 'apl_1',
+  iconId: 1,
+  coverId: 2,
+  iconNsfwLevel: 1,
+  coverNsfwLevel: 1,
+  iconScanStatus: 'scanned',
+  coverScanStatus: 'scanned',
+  screenshots: [{ id: 's1', imageId: 3, order: 0, caption: null, nsfwLevel: 1, scanStatus: 'scanned' }],
+  completeness: { complete: true, missing: [] },
+  hasBlockedAsset: false,
+  hasPendingScan: false,
+};
+
+const mocks = vi.hoisted(() => ({
+  invalidate: vi.fn().mockResolvedValue(undefined),
+  mutate: vi.fn(),
+}));
+
+vi.mock('~/providers/FeatureFlagsProvider', () => ({
+  useFeatureFlags: () => ({ appBlocks: true, appBlocksAgenticReview: true }),
+}));
+vi.mock('~/hooks/useCurrentUser', () => ({ useCurrentUser: () => null }));
+
+// Keep the code section's heavy sub-graphs light (their own behaviour is covered
+// elsewhere): the review host bridge + the agent chat.
+vi.mock('~/components/Apps/ReviewBlockPreviewHost', () => ({
+  ReviewBlockPreviewHost: () => <div data-testid="review-host-stub" />,
+}));
+vi.mock('~/components/Apps/AgentReviewChat', () => ({ AgentReviewChat: () => null }));
+
+vi.mock('~/utils/notifications', () => ({
+  showSuccessNotification: vi.fn(),
+  showErrorNotification: vi.fn(),
+}));
+
+vi.mock('~/utils/trpc', () => {
+  const mutation =
+    (name: string) =>
+    (opts?: { onSuccess?: () => void; onError?: (e: { message: string }) => void }) => ({
+      mutate: (vars: unknown) => {
+        mocks.mutate(name, vars);
+        void opts?.onSuccess?.();
+      },
+      mutateAsync: vi.fn(),
+      isPending: false,
+    });
+  const inert = { invalidate: mocks.invalidate };
+  const utils = {
+    blocks: {
+      listPendingRequests: inert,
+      listApprovedRequests: inert,
+      listRejectedRequests: inert,
+      getReviewStatus: inert,
+      listActivePreviews: inert,
+      getAgentReview: inert,
+      getMarketplaceMeta: inert,
+      getFeaturedBlocks: inert,
+      listAvailable: inert,
+    },
+    appListings: {
+      listPendingRequests: inert,
+      listApprovedRequests: inert,
+      listRejectedRequests: inert,
+    },
+  };
+  return {
+    trpc: {
+      useUtils: () => utils,
+      blocks: {
+        approveRequest: { useMutation: mutation('blocks.approve') },
+        rejectRequest: { useMutation: mutation('blocks.reject') },
+        getReviewStatus: { useQuery: () => ({ data: null, isLoading: false, error: null }) },
+        previewRequest: { useMutation: mutation('blocks.preview') },
+        teardownPreview: { useMutation: mutation('blocks.teardown') },
+        getPublishRequestScreenshots: {
+          useQuery: () => ({ data: { items: [] }, isLoading: false, error: null }),
+        },
+        getPublishRequestDiff: { useQuery: () => ({ data: undefined, isLoading: false, error: null }) },
+        getAgentReview: {
+          useQuery: () => ({
+            data: AGENT_REPORT,
+            isLoading: false,
+            error: null,
+            failureCount: 0,
+            refetch: vi.fn(),
+          }),
+        },
+        startAgentReview: { useMutation: mutation('blocks.startAgentReview') },
+        getMarketplaceMeta: {
+          useQuery: () => ({ data: undefined, isLoading: false, isError: false, error: null }),
+        },
+        setMarketplaceMeta: { useMutation: mutation('blocks.setMeta') },
+      },
+      appListings: {
+        getAssets: { useQuery: () => ({ data: ASSETS, isLoading: false, error: null }) },
+        approveExternalRequest: { useMutation: mutation('appListings.approve') },
+        rejectExternalRequest: { useMutation: mutation('appListings.reject') },
+      },
+    },
+  };
+});
+
+const { CombinedReviewModal } = await import('./CombinedReviewModal');
+
+beforeEach(() => {
+  mocks.invalidate.mockClear();
+  mocks.mutate.mockClear();
+});
+
+describe('CombinedReviewModal', () => {
+  test('renders BOTH section headers, the code ReportTabs, and the media preview + assets', async () => {
+    renderWithProviders(<CombinedReviewModal selection={SELECTION} onClose={vi.fn()} />);
+
+    // Both stacked section headers.
+    await expect.element(page.getByText('App code review')).toBeInTheDocument();
+    await expect.element(page.getByText('Listing media')).toBeInTheDocument();
+
+    // Code section: the agent ReportTabs (its tabs) render.
+    await expect.element(page.getByRole('tab', { name: /Scopes/ })).toBeInTheDocument();
+    await expect.element(page.getByRole('tab', { name: /Code review/ })).toBeInTheDocument();
+    // Code section: the on-site bundle affordance.
+    await expect.element(page.getByText('View full source')).toBeInTheDocument();
+
+    // Media section: the listing PREVIEW (card + detail) + the content-review surface.
+    await expect.element(page.getByTestId('apps-listing-preview')).toBeInTheDocument();
+    await expect.element(page.getByTestId('apps-listing-preview-card')).toBeInTheDocument();
+    await expect.element(page.getByTestId('apps-listing-preview-detail')).toBeInTheDocument();
+    await expect.element(page.getByText('Content review checklist')).toBeInTheDocument();
+  });
+
+  test('approving the CODE section fires ONLY blocks.approveRequest with the code request id', async () => {
+    renderWithProviders(<CombinedReviewModal selection={SELECTION} onClose={vi.fn()} />);
+    await page.getByRole('button', { name: 'Approve + build' }).click();
+
+    const names = mocks.mutate.mock.calls.map((c) => c[0]);
+    expect(names).toContain('blocks.approve');
+    expect(names).not.toContain('appListings.approve');
+    const approveCall = mocks.mutate.mock.calls.find((c) => c[0] === 'blocks.approve');
+    expect(approveCall?.[1]).toMatchObject({ publishRequestId: 'code-req-1' });
+  });
+
+  test('approving the MEDIA section fires ONLY appListings.approveExternalRequest with the media request id', async () => {
+    renderWithProviders(<CombinedReviewModal selection={SELECTION} onClose={vi.fn()} />);
+    // Two-step: open the approve sub-form, then confirm.
+    await page.getByTestId('apps-offsite-approve-open').click();
+    await page.getByTestId('apps-offsite-approve-confirm').click();
+
+    const names = mocks.mutate.mock.calls.map((c) => c[0]);
+    expect(names).toContain('appListings.approve');
+    expect(names).not.toContain('blocks.approve');
+    const approveCall = mocks.mutate.mock.calls.find((c) => c[0] === 'appListings.approve');
+    expect(approveCall?.[1]).toMatchObject({ publishRequestId: 'media-req-1' });
+  });
+});

--- a/src/components/Apps/CombinedReviewModal.tsx
+++ b/src/components/Apps/CombinedReviewModal.tsx
@@ -1,0 +1,110 @@
+import { Badge, Divider, Group, Modal, Stack, Text, ThemeIcon } from '@mantine/core';
+import { IconCode, IconPhoto } from '@tabler/icons-react';
+import { useRef } from 'react';
+import { OnsiteReviewModalBody, type AnyRequest } from '~/components/Apps/OnsiteReviewModal';
+import { OffsiteReviewModalBody, type OffsitePendingRow } from '~/components/Apps/OffsiteReviewQueue';
+import type { CombinedReviewPayload } from '~/components/Apps/unifiedReviewRow';
+
+/**
+ * App Blocks mod review — the COMBINED code + listing-media review surface. When an
+ * app has BOTH a pending on-site CODE request AND a pending on-site listing-MEDIA
+ * revision, the unified queue collapses them into one row (`mergeReviewRows`) that
+ * opens THIS surface: ONE modal, two STACKED sections —
+ *   A) App code review — reuses `OnsiteReviewModalBody` (the ReportTabs report +
+ *      bundle/diff + its OWN approve/reject via the `blocks.*` procs);
+ *   B) Listing media — reuses `OffsiteReviewModalBody` (the listing preview +
+ *      assets + scan status + its OWN approve/reject via the `appListings.*` procs).
+ *
+ * 🔴 INDEPENDENT approve/reject (locked): each section keeps its own approve/reject
+ * wired to its own existing request/proc — there is NO joint approve and NO server
+ * coordination. A mod can approve the media while holding the code, or vice-versa;
+ * approving one NEVER triggers the other's mutation. (Deciding either section closes
+ * the modal + refreshes the queue; the still-pending side reappears as its own single
+ * row for a follow-up decision.)
+ *
+ * Front-end only: this is presentation/composition — it reuses the two existing
+ * bodies + their existing procs unchanged.
+ */
+
+export type CombinedReviewSelection =
+  | (CombinedReviewPayload & { onActioned?: () => void | Promise<void> })
+  | null;
+
+function SectionHeader({ icon, title }: { icon: React.ReactNode; title: string }) {
+  return (
+    <Group gap={8}>
+      <ThemeIcon size="sm" variant="light" color="indigo" radius="sm">
+        {icon}
+      </ThemeIcon>
+      <Text fw={700} size="sm">
+        {title}
+      </Text>
+    </Group>
+  );
+}
+
+export function CombinedReviewModal({
+  selection,
+  onClose,
+}: {
+  selection: CombinedReviewSelection;
+  onClose: () => void;
+}) {
+  // Each section publishes its in-flight state; the shell refuses to close while
+  // EITHER mutation is running.
+  const busyCode = useRef(false);
+  const busyMedia = useRef(false);
+
+  const onsiteRequest: AnyRequest | undefined = selection?.onsiteRequest;
+  const listingRow: OffsitePendingRow | undefined = selection?.listingRow;
+
+  return (
+    <Modal
+      opened={!!selection}
+      onClose={() => {
+        if (busyCode.current || busyMedia.current) return;
+        onClose();
+      }}
+      title={
+        selection ? (
+          <Group gap={6}>
+            <Text fw={600}>{selection.onsiteRequest.slug}</Text>
+            <Badge color="indigo" size="sm" variant="light" data-testid="combined-review-kind-badge">
+              App + media
+            </Badge>
+          </Group>
+        ) : null
+      }
+      size="xl"
+      centered
+    >
+      {selection && onsiteRequest && listingRow && (
+        <Stack gap="xl">
+          <Stack gap="sm" data-testid="combined-review-code-section">
+            <SectionHeader icon={<IconCode size={14} />} title="App code review" />
+            <OnsiteReviewModalBody
+              key={`code-${onsiteRequest.id}`}
+              selection={{ request: onsiteRequest, mode: 'pending' }}
+              onClose={onClose}
+              onActioned={selection.onActioned}
+              busyRef={busyCode}
+            />
+          </Stack>
+
+          <Divider />
+
+          <Stack gap="sm" data-testid="combined-review-media-section">
+            <SectionHeader icon={<IconPhoto size={14} />} title="Listing media" />
+            <OffsiteReviewModalBody
+              key={`media-${listingRow.id}`}
+              request={listingRow}
+              onClose={onClose}
+              onActioned={selection.onActioned}
+              busyRef={busyMedia}
+            />
+          </Stack>
+        </Stack>
+      )}
+    </Modal>
+  );
+}

--- a/src/components/Apps/ConnectScopesPanel.browser.test.tsx
+++ b/src/components/Apps/ConnectScopesPanel.browser.test.tsx
@@ -18,6 +18,9 @@ import { TokenScope } from '~/shared/constants/token-scope.constants';
 vi.mock('~/providers/FeatureFlagsProvider', () => ({
   useFeatureFlags: () => ({ appBlocks: true }),
 }));
+// The modal body renders the listing preview (AppListingCard + AppListingDetailBody),
+// which reads useCurrentUser — boundary-stub it (null user is fine).
+vi.mock('~/hooks/useCurrentUser', () => ({ useCurrentUser: () => null }));
 vi.mock('~/utils/notifications', () => ({
   showSuccessNotification: vi.fn(),
   showErrorNotification: vi.fn(),
@@ -50,6 +53,11 @@ vi.mock('~/utils/trpc', () => {
         },
         approveExternalRequest: { useMutation: mutation },
         rejectExternalRequest: { useMutation: mutation },
+        // Listing-preview projection — undefined data → the section falls back to
+        // the placeholder-art layout preview (fine for these connect-panel tests).
+        getListingPreviewForReview: {
+          useQuery: () => ({ data: undefined, isLoading: false, error: null }),
+        },
       },
     },
   };

--- a/src/components/Apps/OffsiteReviewQueue.browser.test.tsx
+++ b/src/components/Apps/OffsiteReviewQueue.browser.test.tsx
@@ -52,6 +52,9 @@ const mocks = vi.hoisted(() => ({
 vi.mock('~/providers/FeatureFlagsProvider', () => ({
   useFeatureFlags: () => ({ appBlocks: true }),
 }));
+// The modal body renders the listing preview (AppListingCard + AppListingDetailBody),
+// which reads useCurrentUser — boundary-stub it (null user is fine).
+vi.mock('~/hooks/useCurrentUser', () => ({ useCurrentUser: () => null }));
 
 vi.mock('~/utils/notifications', () => ({
   showSuccessNotification: vi.fn(),
@@ -100,6 +103,11 @@ vi.mock('~/utils/trpc', () => {
             mutateAsync: vi.fn(),
             isPending: false,
           }),
+        },
+        // Listing-preview projection — undefined data → the section falls back to the
+        // placeholder-art layout preview (these tests assert checklist/scan behaviour).
+        getListingPreviewForReview: {
+          useQuery: () => ({ data: undefined, isLoading: false, error: null }),
         },
       },
     },

--- a/src/components/Apps/OffsiteReviewQueue.tsx
+++ b/src/components/Apps/OffsiteReviewQueue.tsx
@@ -870,20 +870,30 @@ export function OffsiteReviewModalBody({
 
 /**
  * Store PREVIEW of the pending listing — the grid CARD + the store DETAIL as a
- * shopper would see them once approved, built from the review row via the pure
- * `reviewListingPreview` builders. `AppListingDetailBody` runs in read-only
- * `preview` mode (no comments / reviews / report / primary-action / owner-edit).
+ * shopper would see them once approved, showing the app's REAL media. It reads the
+ * mod-only `appListings.getListingPreviewForReview` projection (the SHADOW listing's
+ * icon / cover / ordered screenshots + name / tagline / description / category /
+ * content-rating / creator, projected with the SAME image→CDN-URL derivation as the
+ * public store detail). `AppListingDetailBody` runs in read-only `preview` mode (no
+ * comments / reviews / report / primary-action / owner-edit).
  *
- * NOTE (front-end-only scope): the uploaded ART (icon / cover / screenshots) is
- * reviewed via the assets + scan-status panels above. The mod-review data carries
- * image IDs, not CDN `url` keys, so this preview renders the LAYOUT with the store
- * components' built-in placeholder art. A pixel-accurate media preview would need
- * the review query to project image URLs — a server change, deliberately not made
- * here.
+ * GRACEFUL FALLBACK: while the projection query is loading, errors, or the row has
+ * no backing listing id, it renders a placeholder-art LAYOUT preview built from the
+ * row via the pure `reviewListingPreview` builders — so the review surface never
+ * crashes or blanks.
  */
 function ListingPreviewSection({ request }: { request: OffsitePendingRow }) {
-  const card = buildListingCardPreview(request);
-  const detail = buildListingDetailPreview(request);
+  const features = useFeatureFlags();
+  // Mod-only projection of the SHADOW listing's real media + scalars. Enabled only
+  // once a row with a backing listing id is open.
+  const previewQuery = trpc.appListings.getListingPreviewForReview.useQuery(
+    { listingId: request.appListingId ?? '' },
+    { enabled: !!features?.appBlocks && !!request.appListingId, retry: false }
+  );
+  // Prefer the real projected media; fall back to the placeholder-art layout preview
+  // from the row while loading / on error / when there's no listing id.
+  const card = previewQuery.data?.card ?? buildListingCardPreview(request);
+  const detail = previewQuery.data?.detail ?? buildListingDetailPreview(request);
   return (
     <Stack gap="xs" data-testid="apps-listing-preview">
       <Divider
@@ -898,9 +908,7 @@ function ListingPreviewSection({ request }: { request: OffsitePendingRow }) {
         labelPosition="left"
       />
       <Text size="xs" c="dimmed">
-        Listing preview — how it will appear once approved. Uploaded art is reviewed
-        via the assets + scan status above; this preview uses placeholder art where an
-        image isn’t resolvable on this surface.
+        Listing preview — how it will appear in the store once approved.
       </Text>
       <div style={{ maxWidth: 340 }} data-testid="apps-listing-preview-card">
         <AppListingCard card={card} />

--- a/src/components/Apps/OffsiteReviewQueue.tsx
+++ b/src/components/Apps/OffsiteReviewQueue.tsx
@@ -31,7 +31,13 @@ import {
   IconQuestionMark,
   IconX,
 } from '@tabler/icons-react';
-import { useState } from 'react';
+import { useRef, useState } from 'react';
+import { AppListingCard } from '~/components/Apps/AppListingCard';
+import { AppListingDetailBody } from '~/components/Apps/AppListingDetailBody';
+import {
+  buildListingCardPreview,
+  buildListingDetailPreview,
+} from '~/components/Apps/reviewListingPreview';
 import { ModQueryError, isModAuthzError } from '~/components/Apps/ModQuerySurface';
 import {
   ReasonGatedActionModal,
@@ -248,6 +254,15 @@ export function OffsiteReviewQueue() {
   );
 }
 
+/**
+ * Thin outer shell — owns the Mantine `<Modal>` (kept mounted + `opened`-toggled so
+ * open/close animates) + the static per-request title, and derives the in-flight
+ * close-guard from a `busyRef` the body writes. The interactive body is a SEPARATE
+ * component keyed on `request.id` so it REMOUNTS per request (deterministically
+ * resetting its approve/reject UI state — mirrors `OnsiteReviewModal`). The body is
+ * exported so the combined code+media review surface can re-host it WITHOUT this
+ * `<Modal>` shell.
+ */
 export function OffsiteReviewModal({
   request,
   onClose,
@@ -256,16 +271,81 @@ export function OffsiteReviewModal({
 }: {
   request: OffsitePendingRow | null;
   onClose: () => void;
+  onActioned?: () => void | Promise<void>;
+  readOnly?: boolean;
+}) {
+  const busyRef = useRef(false);
+  const isOnsite = request?.kind === 'onsite';
+  return (
+    <Modal
+      opened={!!request}
+      onClose={() => {
+        if (busyRef.current) return;
+        onClose();
+      }}
+      title={
+        request ? (
+          <Group gap={6}>
+            <Text fw={600}>{request.slug}</Text>
+            <Badge
+              color={isOnsite ? 'teal' : 'grape'}
+              size="sm"
+              variant="light"
+              data-testid="apps-offsite-kind-badge"
+            >
+              {isOnsite ? 'listing media' : 'external'}
+            </Badge>
+          </Group>
+        ) : null
+      }
+      size="lg"
+      centered
+    >
+      {request && (
+        <OffsiteReviewModalBody
+          key={request.id}
+          request={request}
+          onClose={onClose}
+          onActioned={onActioned}
+          readOnly={readOnly}
+          busyRef={busyRef}
+        />
+      )}
+    </Modal>
+  );
+}
+
+/**
+ * Interactive off-site / listing-media review BODY (icon/cover/screenshot assets +
+ * scan status + content review + the listing PREVIEW + approve/reject). Extracted
+ * from the modal shell so BOTH the standalone modal and the combined code+media
+ * review surface render the exact same controls + mutations from one source. Keyed
+ * by its callers on `request.id` so its transient state resets per request.
+ *
+ * `busyRef` (optional) is written each render so a hosting modal shell can refuse an
+ * in-flight close (the pre-split close-guard); the combined surface uses it too.
+ */
+export function OffsiteReviewModalBody({
+  request,
+  onClose,
+  onActioned,
+  readOnly = false,
+  busyRef,
+}: {
+  request: OffsitePendingRow | null;
+  onClose: () => void;
   /** Fired after a successful approve/reject — lets a host (e.g. the mod
    *  management table) invalidate its own query in addition to the review queues. */
   onActioned?: () => void | Promise<void>;
   /** History-tab (Approved/Rejected) posture: HIDE the Approve.../Reject... action
-   *  buttons so the modal is a read-only detail view (an already-decided request
+   *  buttons so the body is a read-only detail view (an already-decided request
    *  errors `NOT_PENDING` server-side — the buttons are misleading). Matches the
    *  on-site history read-only view. Purely presentational: it only conditionally
    *  RENDERS the buttons; the approve/reject handlers are unchanged. Default false so
    *  the Pending tab + the mgmt table's pending Review keep full actions. */
   readOnly?: boolean;
+  /** Modal-shell close-guard ref, written each render with the in-flight state. */
+  busyRef?: { current: boolean };
 }) {
   const utils = trpc.useUtils();
   const features = useFeatureFlags();
@@ -429,30 +509,12 @@ export function OffsiteReviewModal({
   const hasBlockedAsset = !assetsQuery.isLoading && (assetsData?.hasBlockedAsset ?? false);
   const hasPendingScan = !assetsQuery.isLoading && (assetsData?.hasPendingScan ?? false);
 
+  // Publish the in-flight state to a hosting modal shell so its onClose can guard
+  // on it (written during render so it is current by the time a close fires).
+  if (busyRef) busyRef.current = busy;
+
   return (
-    <Modal
-      opened={!!request}
-      onClose={() => {
-        if (busy) return;
-        close();
-      }}
-      title={
-        <Group gap={6}>
-          <Text fw={600}>{request.slug}</Text>
-          <Badge
-            color={isOnsite ? 'teal' : 'grape'}
-            size="sm"
-            variant="light"
-            data-testid="apps-offsite-kind-badge"
-          >
-            {isOnsite ? 'listing media' : 'external'}
-          </Badge>
-        </Group>
-      }
-      size="lg"
-      centered
-    >
-      <Stack gap="md">
+    <Stack gap="md">
         {isOnsite && (
           <Text size="xs" c="dimmed" data-testid="apps-offsite-onsite-note">
             Listing media update — the on-site app’s media (icon / cover / screenshots)
@@ -554,6 +616,8 @@ export function OffsiteReviewModal({
             )}
           </Stack>
         </Card>
+
+        <ListingPreviewSection request={request} />
 
         {isConnect && (
           <ConnectScopesPanel
@@ -801,7 +865,50 @@ export function OffsiteReviewModal({
           </Group>
           ))}
       </Stack>
-    </Modal>
+  );
+}
+
+/**
+ * Store PREVIEW of the pending listing — the grid CARD + the store DETAIL as a
+ * shopper would see them once approved, built from the review row via the pure
+ * `reviewListingPreview` builders. `AppListingDetailBody` runs in read-only
+ * `preview` mode (no comments / reviews / report / primary-action / owner-edit).
+ *
+ * NOTE (front-end-only scope): the uploaded ART (icon / cover / screenshots) is
+ * reviewed via the assets + scan-status panels above. The mod-review data carries
+ * image IDs, not CDN `url` keys, so this preview renders the LAYOUT with the store
+ * components' built-in placeholder art. A pixel-accurate media preview would need
+ * the review query to project image URLs — a server change, deliberately not made
+ * here.
+ */
+function ListingPreviewSection({ request }: { request: OffsitePendingRow }) {
+  const card = buildListingCardPreview(request);
+  const detail = buildListingDetailPreview(request);
+  return (
+    <Stack gap="xs" data-testid="apps-listing-preview">
+      <Divider
+        label={
+          <Group gap={6}>
+            <IconInfoCircle size={14} />
+            <Text size="sm" fw={600}>
+              Listing preview
+            </Text>
+          </Group>
+        }
+        labelPosition="left"
+      />
+      <Text size="xs" c="dimmed">
+        Listing preview — how it will appear once approved. Uploaded art is reviewed
+        via the assets + scan status above; this preview uses placeholder art where an
+        image isn’t resolvable on this surface.
+      </Text>
+      <div style={{ maxWidth: 340 }} data-testid="apps-listing-preview-card">
+        <AppListingCard card={card} />
+      </div>
+      <Card withBorder p="md" data-testid="apps-listing-preview-detail">
+        <AppListingDetailBody detail={detail} preview />
+      </Card>
+    </Stack>
   );
 }
 

--- a/src/components/Apps/ReportTabs.browser.test.tsx
+++ b/src/components/Apps/ReportTabs.browser.test.tsx
@@ -15,16 +15,19 @@ import { renderWithProviders } from '../../../test/component-setup';
  * each finding card carries a subtle "copy link" affordance.
  *
  * Covers:
+ *  - the tab IA (Item 1/2): tabs render in the order Scopes → Security → Code
+ *    review, there is NO Summary tab, the default selected tab is Scopes, the
+ *    count badges are present, and `summaryMd` is NOT rendered even when provided;
  *  - on the page route, landing on `#finding-security-1` activates the Security
  *    audit tab, the card carries `id="finding-security-1"`, `scrollIntoView`
  *    fires (deterministic post-commit scroll), and a copy-link renders;
  *  - a bare tab hash (`#code`) activates that tab with no finding target;
  *  - on the modal route there is NO deep-linking (no copy-link, no anchor id).
  *
- * The Summary tab renders `summaryMd` through CustomMarkdown, which reads
- * `useCurrentUser()`. We keep `summaryMd` null here so that surface is never hit,
- * and boundary-stub the hook anyway (null user is fine — the standard pattern in
- * the sibling AgentReview tests).
+ * The report renderer no longer has a markdown surface (Summary removed), so no
+ * `CustomMarkdown` / `useCurrentUser` path is hit — we boundary-stub the hook
+ * anyway (null user is fine — the standard pattern in the sibling AgentReview
+ * tests) so nothing reaches for a session provider the scaffold doesn't have.
  */
 
 vi.mock('~/hooks/useCurrentUser', () => ({
@@ -65,16 +68,62 @@ afterEach(() => {
   window.history.replaceState(null, '', '/');
 });
 
+describe('ReportTabs — tab IA (Item 1/2: drop Summary, reorder, default Scopes)', () => {
+  // Neutral (non-page) route so deep-linking is inert and the DEFAULT tab is what
+  // renders — the tab-order/default assertions don't depend on the hash.
+  beforeEach(() => {
+    window.history.replaceState(null, '', '/apps/review');
+  });
+
+  test('renders exactly three tabs in order Scopes → Security → Code review, no Summary', async () => {
+    renderWithProviders(<ReportTabs report={REPORT} costCapped={false} />);
+
+    const tabs = page.getByRole('tab').elements();
+    expect(tabs).toHaveLength(3);
+    const labels = tabs.map((t) => t.textContent ?? '');
+    expect(labels[0]).toMatch(/Scopes/);
+    expect(labels[1]).toMatch(/Security audit/);
+    expect(labels[2]).toMatch(/Code review/);
+    // No Summary tab remains.
+    expect(page.getByRole('tab', { name: /Summary/ }).elements().length).toBe(0);
+  });
+
+  test('the default selected tab is Scopes', async () => {
+    renderWithProviders(<ReportTabs report={REPORT} costCapped={false} />);
+    await expect
+      .element(page.getByRole('tab', { name: /Scopes/ }))
+      .toHaveAttribute('aria-selected', 'true');
+  });
+
+  test('count badges are present in the tab labels', async () => {
+    renderWithProviders(<ReportTabs report={REPORT} costCapped={false} />);
+    // REPORT has 1 code finding + 2 security findings + 0 scopes.
+    await expect.element(page.getByRole('tab', { name: /Code review.*1/ })).toBeInTheDocument();
+    await expect.element(page.getByRole('tab', { name: /Security audit.*2/ })).toBeInTheDocument();
+    await expect.element(page.getByRole('tab', { name: /Scopes.*0/ })).toBeInTheDocument();
+  });
+
+  test('summaryMd is NOT rendered even when the report carries one', async () => {
+    const withSummary = { ...REPORT, summaryMd: 'SENTINEL_SUMMARY_PROSE_XYZ' };
+    renderWithProviders(<ReportTabs report={withSummary} costCapped={false} />);
+    // The report renders (advisory banner present) …
+    await expect.element(page.getByText(/Advisory only/)).toBeInTheDocument();
+    // … but the prose overview is nowhere in the DOM (all tabs are keepMounted, so
+    // this is a true "never rendered" assertion, not just "not on the active tab").
+    expect(document.body.textContent).not.toContain('SENTINEL_SUMMARY_PROSE_XYZ');
+  });
+});
+
 describe('ReportTabs — deep-link to a finding (page route)', () => {
   test('landing on #finding-security-1 activates the Security audit tab', async () => {
     renderWithProviders(<ReportTabs report={REPORT} costCapped={false} />);
 
-    // The Security audit tab is selected (not the default Summary).
+    // The Security audit tab is selected (not the default Scopes).
     await expect
       .element(page.getByRole('tab', { name: /Security audit/ }))
       .toHaveAttribute('aria-selected', 'true');
     await expect
-      .element(page.getByRole('tab', { name: /Summary/ }))
+      .element(page.getByRole('tab', { name: /Scopes/ }))
       .toHaveAttribute('aria-selected', 'false');
 
     // The targeted finding is visible in the now-active tab.
@@ -138,9 +187,9 @@ describe('ReportTabs — modal route (deep-linking inert)', () => {
     window.history.replaceState(null, '', '/apps/review#finding-security-1');
     renderWithProviders(<ReportTabs report={REPORT} costCapped={false} />);
 
-    // Default Summary tab stays active — the finding hash is NOT honored.
+    // Default Scopes tab stays active — the finding hash is NOT honored.
     await expect
-      .element(page.getByRole('tab', { name: /Summary/ }))
+      .element(page.getByRole('tab', { name: /Scopes/ }))
       .toHaveAttribute('aria-selected', 'true');
 
     // No copy-link affordances and no per-finding anchor id anywhere (pre-feature

--- a/src/components/Apps/ReportTabs.tsx
+++ b/src/components/Apps/ReportTabs.tsx
@@ -10,7 +10,6 @@ import {
   IconLink,
   IconShieldLock,
 } from '@tabler/icons-react';
-import { CustomMarkdown } from '~/components/Markdown/CustomMarkdown';
 import {
   fileLineLabel,
   findingAnchorId,
@@ -19,7 +18,6 @@ import {
   parseAgentReport,
   parseReportHash,
   sectionAnalysisError,
-  severityBreakdown,
   sortFindingsBySeverity,
   type AgentFinding,
   type CodeReviewView,
@@ -33,21 +31,21 @@ import {
  * App Blocks — AGENTIC MOD CODE-REVIEW report renderer (P2, Phase-2 redesign).
  *
  * The report was a single scrolling "wall of text". This restructures it into
- * TABBED, scannable, per-finding sections — Summary | Code review (N) | Security
- * audit (N) | Scopes (N) — with counts in the tab labels and one section visible
- * at a time. It is a REUSABLE, prop-only renderer (no tRPC, no onsite-only
- * assumptions) so the offsite listing review (`OffsiteReviewModal`) can adopt it
- * later. It renders in BOTH the queue modal and the new review page — one shared
- * component, no divergence.
+ * TABBED, scannable, per-finding sections — Scopes (N) | Security audit (N) |
+ * Code review (N) — with counts in the tab labels and one section visible at a
+ * time. (The former free-text "Summary" tab was dropped; the agent prose overview
+ * is no longer surfaced here.) It is a REUSABLE, prop-only renderer (no tRPC, no
+ * onsite-only assumptions) so the offsite listing review (`OffsiteReviewModal`)
+ * can adopt it later. It renders in BOTH the queue modal and the new review page —
+ * one shared component, no divergence.
  *
  * 🔴 SANITIZATION — every value here is ADVERSARIAL. The report is generated from
  * an untrusted, prompt-injectable bundle. All free text (finding titles, details,
  * evidence, scope notes) is rendered through React (auto-escaped) — never
- * `dangerouslySetInnerHTML`, never raw HTML. ONLY `summaryMd` is rendered through
- * `CustomMarkdown` (react-markdown, NO `rehype-raw`, `disallowedElements={['img']}`)
- * so raw HTML is escaped to inert text and no `<img>` fires an external fetch from
- * the moderator's browser (tracking-pixel / IP+UA leak). This closes the
- * stored-XSS-at-render concern for the report surface.
+ * `dangerouslySetInnerHTML`, never raw HTML. With the markdown summary removed,
+ * there is no `CustomMarkdown` / raw-HTML surface at all here — every value is
+ * inert React text. This keeps the stored-XSS-at-render concern closed for the
+ * report surface.
  */
 
 function severityColor(severity?: string): string {
@@ -304,55 +302,6 @@ function TabLabel({ label, count }: { label: string; count?: number }) {
 }
 
 // --- Tab bodies (exported for offsite reuse) -------------------------------
-
-export function SummaryTab({
-  summaryMd,
-  codeReview,
-  securityAudit,
-  scopeCount,
-}: {
-  summaryMd?: string | null;
-  codeReview: CodeReviewView;
-  securityAudit: SecurityAuditView;
-  scopeCount: number;
-}) {
-  const sec = severityBreakdown(securityAudit.findings);
-  const secBreak: string[] = [];
-  if (sec.critical) secBreak.push(`${sec.critical} critical`);
-  if (sec.high) secBreak.push(`${sec.high} high`);
-  const secSuffix = secBreak.length ? ` (${secBreak.join(', ')})` : '';
-
-  return (
-    <Stack gap="sm">
-      {/* Counts-first roll-up. */}
-      <Group gap="xs" data-testid="report-rollup">
-        <Badge variant="light" color="gray" leftSection={<IconCode size={12} />}>
-          Code {codeReview.findings.length}
-        </Badge>
-        <Badge
-          variant="light"
-          color={sec.critical || sec.high ? 'red' : 'gray'}
-          leftSection={<IconShieldLock size={12} />}
-        >
-          Security {securityAudit.findings.length}
-          {secSuffix}
-        </Badge>
-        <Badge variant="light" color="gray" leftSection={<IconKey size={12} />}>
-          {scopeCount} {scopeCount === 1 ? 'scope' : 'scopes'}
-        </Badge>
-      </Group>
-
-      {summaryMd ? (
-        // ONLY markdown surface — CustomMarkdown (no rehype-raw, img-guarded).
-        <div className="markdown-content" data-testid="report-summary-md">
-          <CustomMarkdown disallowedElements={['img']}>{summaryMd}</CustomMarkdown>
-        </div>
-      ) : (
-        <EmptyState label="No summary was provided." />
-      )}
-    </Stack>
-  );
-}
 
 export function CodeReviewTab({
   codeReview,
@@ -720,7 +669,9 @@ export function ReportTabs({
     costUsd?: unknown;
     startedAt?: unknown;
     completedAt?: unknown;
-    summaryMd?: string | null;
+    // NOTE: `summaryMd` may still be present on the underlying report row (shared
+    // type), but it is intentionally NOT rendered here — the Summary tab was
+    // dropped. Callers pass the whole report object; the excess field is ignored.
     codeReview?: unknown;
     securityAudit?: unknown;
     scopeVerdicts?: unknown;
@@ -747,7 +698,8 @@ export function ReportTabs({
   // so the guard never fires. All window/document/history access lives inside
   // effects and event handlers (SSR-safe).
   const [deepLinkable, setDeepLinkable] = useState(false);
-  const [activeTab, setActiveTab] = useState<ReportTabValue>('summary');
+  // Default to the first tab (Scopes) now that Summary is gone.
+  const [activeTab, setActiveTab] = useState<ReportTabValue>('scopes');
   const [highlightedId, setHighlightedId] = useState<string | null>(null);
   // The finding to scroll to once its tab has COMMITTED. keepMounted panels are
   // display:none until active, so we defer the scroll to the [activeTab] effect
@@ -860,35 +812,19 @@ export function ReportTabs({
       <Tabs value={activeTab} onChange={handleTabChange} keepMounted>
         {/* Scrollable on narrow — the list scrolls within itself, never overflowing the page. */}
         <Tabs.List style={{ flexWrap: 'nowrap', overflowX: 'auto', overflowY: 'hidden' }}>
-          <Tabs.Tab value="summary" leftSection={<IconInfoCircle size={14} />}>
-            Summary
-          </Tabs.Tab>
-          <Tabs.Tab value="code" leftSection={<IconCode size={14} />}>
-            <TabLabel label="Code review" count={codeReview.findings.length} />
+          <Tabs.Tab value="scopes" leftSection={<IconKey size={14} />}>
+            <TabLabel label="Scopes" count={scopeVerdicts.scopes.length} />
           </Tabs.Tab>
           <Tabs.Tab value="security" leftSection={<IconShieldLock size={14} />}>
             <TabLabel label="Security audit" count={securityAudit.findings.length} />
           </Tabs.Tab>
-          <Tabs.Tab value="scopes" leftSection={<IconKey size={14} />}>
-            <TabLabel label="Scopes" count={scopeVerdicts.scopes.length} />
+          <Tabs.Tab value="code" leftSection={<IconCode size={14} />}>
+            <TabLabel label="Code review" count={codeReview.findings.length} />
           </Tabs.Tab>
         </Tabs.List>
 
-        <Tabs.Panel value="summary" pt="sm">
-          <SummaryTab
-            summaryMd={report.summaryMd}
-            codeReview={codeReview}
-            securityAudit={securityAudit}
-            scopeCount={scopeVerdicts.scopes.length}
-          />
-        </Tabs.Panel>
-        <Tabs.Panel value="code" pt="sm">
-          <CodeReviewTab
-            codeReview={codeReview}
-            error={codeError}
-            deepLinkable={deepLinkable}
-            highlightedId={highlightedId}
-          />
+        <Tabs.Panel value="scopes" pt="sm">
+          <ScopesTab scopeVerdicts={scopeVerdicts} error={scopeError} />
         </Tabs.Panel>
         <Tabs.Panel value="security" pt="sm">
           <SecurityAuditTab
@@ -898,8 +834,13 @@ export function ReportTabs({
             highlightedId={highlightedId}
           />
         </Tabs.Panel>
-        <Tabs.Panel value="scopes" pt="sm">
-          <ScopesTab scopeVerdicts={scopeVerdicts} error={scopeError} />
+        <Tabs.Panel value="code" pt="sm">
+          <CodeReviewTab
+            codeReview={codeReview}
+            error={codeError}
+            deepLinkable={deepLinkable}
+            highlightedId={highlightedId}
+          />
         </Tabs.Panel>
       </Tabs>
 

--- a/src/components/Apps/UnifiedReviewList.tsx
+++ b/src/components/Apps/UnifiedReviewList.tsx
@@ -6,6 +6,7 @@ import {
   mergeReviewRows,
   offsiteRequestToUnifiedRow,
   onsiteRequestToUnifiedRow,
+  type CombinedReviewPayload,
   type OffsiteReviewRequest,
   type OnsiteReviewRequest,
   type UnifiedReviewRow,
@@ -28,6 +29,7 @@ export function UnifiedReviewList({
   direction,
   openOnsiteReview,
   openOffsiteReview,
+  openCombinedReview,
   isLoading,
   errorMessage,
   emptyLabel,
@@ -45,6 +47,10 @@ export function UnifiedReviewList({
   openOnsiteReview: (req: OnsiteReviewRequest) => void;
   /** Opens the OFF-SITE modal for an off-site row (page-owned). */
   openOffsiteReview: (row: OffsitePendingRow) => void;
+  /** Opens the COMBINED code+media surface (page-owned). When provided, an app with
+   *  BOTH a pending code request AND a pending listing-media revision collapses into
+   *  ONE combined row (PENDING tab only). Omitted on history tabs → no combining. */
+  openCombinedReview?: (payload: CombinedReviewPayload) => void;
   isLoading: boolean;
   /** Non-empty when EITHER source query errored transiently — surfaced as an Alert
    *  rather than silently blanking the list. */
@@ -62,8 +68,8 @@ export function UnifiedReviewList({
   const rows = useMemo(() => {
     const onsiteRows = onsiteItems.map((r) => onsiteRequestToUnifiedRow(r, openOnsiteReview));
     const offsiteRows = offsiteItems.map((r) => offsiteRequestToUnifiedRow(r, openOffsiteReview));
-    return mergeReviewRows(onsiteRows, offsiteRows, direction);
-  }, [onsiteItems, offsiteItems, direction, openOnsiteReview, openOffsiteReview]);
+    return mergeReviewRows(onsiteRows, offsiteRows, direction, openCombinedReview);
+  }, [onsiteItems, offsiteItems, direction, openOnsiteReview, openOffsiteReview, openCombinedReview]);
 
   return (
     <Stack gap="md">

--- a/src/components/Apps/__tests__/agentReviewReport.test.ts
+++ b/src/components/Apps/__tests__/agentReviewReport.test.ts
@@ -261,7 +261,6 @@ describe('parseReportHash', () => {
   });
 
   it('parses a bare tab hash', () => {
-    expect(parseReportHash('#summary')).toEqual({ tab: 'summary' });
     expect(parseReportHash('#code')).toEqual({ tab: 'code' });
     expect(parseReportHash('#security')).toEqual({ tab: 'security' });
     expect(parseReportHash('#scopes')).toEqual({ tab: 'scopes' });
@@ -271,6 +270,8 @@ describe('parseReportHash', () => {
     expect(parseReportHash('')).toEqual({});
     expect(parseReportHash('#')).toEqual({});
     expect(parseReportHash('#unknown')).toEqual({});
+    // `summary` is no longer a tab (the Summary tab was dropped) → not recognized.
+    expect(parseReportHash('#summary')).toEqual({});
     // A tab value outside the union is ignored (not a finding tab, not a bare tab).
     expect(parseReportHash('#finding-scopes-2')).toEqual({});
     expect(parseReportHash('#finding-summary-0')).toEqual({});

--- a/src/components/Apps/__tests__/reviewListingPreview.test.ts
+++ b/src/components/Apps/__tests__/reviewListingPreview.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildListingCardPreview,
+  buildListingDetailPreview,
+} from '~/components/Apps/reviewListingPreview';
+import type { OffsitePendingRow } from '~/components/Apps/OffsiteReviewQueue';
+
+/**
+ * Pure mapping gate for the mod-review listing PREVIEW builders (Item 3): review row
+ * → `ListingCard` / `ListingDetail` store shapes. The browser component test for the
+ * preview surface is report-only, so this is the blocking coverage for the mapping.
+ * Pins: kind derivation, the name→slug fallback, submitter→creator chip, empty
+ * recommend rollup, placeholder-nulled image URLs (not resolvable on this surface),
+ * the omitted-in-preview scalars (tagline/description/serialId), kind-aware
+ * `kindData`, and the optional resolved-images passthrough.
+ */
+
+function row(over: Partial<OffsitePendingRow> & { id: string }): OffsitePendingRow {
+  return {
+    id: over.id,
+    appListingId: 'apl_1',
+    slug: 'my-app',
+    status: 'pending',
+    submittedAt: '2026-01-01T00:00:00Z',
+    changelog: null,
+    appListing: {
+      name: 'My App',
+      externalUrl: null,
+      category: 'utility',
+      contentRating: 'PG',
+    },
+    submittedBy: { id: 7, username: 'alice', image: 'img-key' },
+    ...over,
+  };
+}
+
+describe('buildListingCardPreview', () => {
+  it('maps an on-site listing-media row into an on-site card with placeholder art', () => {
+    const card = buildListingCardPreview(row({ id: 'r1', kind: 'onsite' }));
+    expect(card.kind).toBe('onsite');
+    expect(card.name).toBe('My App');
+    expect(card.category).toBe('utility');
+    expect(card.contentRating).toBe('PG');
+    expect(card.creator).toEqual({ id: 7, username: 'alice', image: 'img-key' });
+    // Image URLs aren't resolvable on the mod-review surface → null (placeholder art).
+    expect(card.iconUrl).toBeNull();
+    expect(card.coverUrl).toBeNull();
+    // No reviews on an unapproved listing.
+    expect(card.recommend.recommendPct).toBeNull();
+    expect(card.reviewCount).toBe(0);
+    expect(card.kindData).toEqual({ kind: 'onsite', appBlockId: null, hasPage: false, liveUrl: '' });
+  });
+
+  it('an external (offsite) row → offsite kindData with the external url + sub-kind', () => {
+    const card = buildListingCardPreview(
+      row({
+        id: 'r2',
+        appListing: {
+          name: 'Ext',
+          externalUrl: 'https://ext.app',
+          category: null,
+          contentRating: null,
+        },
+      })
+    );
+    expect(card.kind).toBe('offsite');
+    expect(card.kindData).toEqual({
+      kind: 'offsite',
+      subKind: 'external-link',
+      externalUrl: 'https://ext.app',
+    });
+  });
+
+  it('a connect (offsite) row → connect sub-kind', () => {
+    const card = buildListingCardPreview(
+      row({
+        id: 'r3',
+        appListing: {
+          name: 'Conn',
+          externalUrl: null,
+          category: null,
+          contentRating: null,
+          connectClientId: 'cc_1',
+        },
+      })
+    );
+    expect(card.kind).toBe('offsite');
+    expect(card.kindData.kind === 'offsite' && card.kindData.subKind).toBe('connect');
+  });
+
+  it('falls back to the slug when the listing (or its name) is absent', () => {
+    expect(buildListingCardPreview(row({ id: 'r4', appListing: null, slug: 'sx' })).name).toBe('sx');
+  });
+
+  it('passes resolved image URLs straight through when provided', () => {
+    const card = buildListingCardPreview(row({ id: 'r5' }), {
+      iconUrl: 'https://cdn/icon.png',
+      coverUrl: 'https://cdn/cover.png',
+    });
+    expect(card.iconUrl).toBe('https://cdn/icon.png');
+    expect(card.coverUrl).toBe('https://cdn/cover.png');
+  });
+});
+
+describe('buildListingDetailPreview', () => {
+  it('maps an on-site row into a detail with omitted scalars + empty gallery', () => {
+    const detail = buildListingDetailPreview(row({ id: 'r1', kind: 'onsite' }));
+    expect(detail.kind).toBe('onsite');
+    expect(detail.name).toBe('My App');
+    // Tagline/description aren't carried by the review data → null (omitted in preview).
+    expect(detail.tagline).toBeNull();
+    expect(detail.description).toBeNull();
+    // serialId only feeds the comments thread, which preview omits.
+    expect(detail.serialId).toBe(0);
+    expect(detail.screenshots).toEqual([]);
+    expect(detail.kindData).toEqual({ kind: 'onsite', appBlockId: null, hasPage: false, liveUrl: '' });
+  });
+
+  it('an external row carries the connectClientId (null) + externalUrl on kindData', () => {
+    const detail = buildListingDetailPreview(
+      row({
+        id: 'r2',
+        appListing: {
+          name: 'Ext',
+          externalUrl: 'https://ext.app',
+          category: null,
+          contentRating: null,
+        },
+      })
+    );
+    expect(detail.kindData).toEqual({
+      kind: 'offsite',
+      subKind: 'external-link',
+      externalUrl: 'https://ext.app',
+      connectClientId: null,
+    });
+  });
+
+  it('passes resolved screenshots + cover through when provided', () => {
+    const detail = buildListingDetailPreview(row({ id: 'r5' }), {
+      coverUrl: 'https://cdn/cover.png',
+      screenshots: [{ url: 'https://cdn/s1.png', caption: 'one' }],
+    });
+    expect(detail.coverUrl).toBe('https://cdn/cover.png');
+    expect(detail.screenshots).toEqual([{ url: 'https://cdn/s1.png', caption: 'one' }]);
+  });
+});

--- a/src/components/Apps/__tests__/unifiedReviewRow.test.ts
+++ b/src/components/Apps/__tests__/unifiedReviewRow.test.ts
@@ -387,3 +387,111 @@ describe('mergeReviewRows', () => {
     expect(on.map((r) => r.key)).toEqual(snapshot);
   });
 });
+
+// ---------------------------------------------------------------------------
+// mergeReviewRows — COMBINED code + listing-media collapse (Item 4).
+//
+// When `openCombined` is provided (the PENDING queue) an app with BOTH a pending
+// on-site CODE row AND a pending on-site listing-MEDIA row collapses into ONE
+// combined row carrying both ids + payloads. ONLY these two kinds combine; external
+// listings + apps with just one of the two are untouched. Without the opener (the
+// HISTORY tabs) nothing combines. Rows are built through the real adapters so they
+// carry the payloads (onsiteRequest / offsiteRow) the collapse needs.
+// ---------------------------------------------------------------------------
+
+describe('mergeReviewRows — combined code + listing-media', () => {
+  /** A code row + a listing-media row for the same app (paired by slug). */
+  function pairFor(app: string, opts?: { codeAt?: string; mediaAt?: string }) {
+    const code = onsiteRequestToUnifiedRow(
+      onsite({ id: `code-${app}`, slug: app, appBlockId: `blk-${app}`, submittedAt: opts?.codeAt ?? '2026-01-01T00:00:00Z' }),
+      vi.fn()
+    );
+    const media = offsiteRequestToUnifiedRow(
+      offsite({ id: `media-${app}`, slug: app, kind: 'onsite', submittedAt: opts?.mediaAt ?? '2026-01-02T00:00:00Z' }),
+      vi.fn()
+    );
+    return { code, media };
+  }
+
+  it('collapses a code + listing-media pair (same slug) into ONE combined row carrying both ids', () => {
+    const { code, media } = pairFor('app-x');
+    const merged = mergeReviewRows([code], [media], 'asc', vi.fn());
+    expect(merged).toHaveLength(1);
+    const combined = merged[0];
+    expect(combined.kind).toBe('combined');
+    expect(combined.combined?.onsiteRequestId).toBe('code-app-x');
+    expect(combined.combined?.listingRequestId).toBe('media-app-x');
+    // Both raw payloads are carried so the combined surface can open both sections.
+    expect(combined.combined?.onsiteRequest.id).toBe('code-app-x');
+    expect(combined.combined?.listingRow.id).toBe('media-app-x');
+    expect(combined.badge).toBe('App + media');
+  });
+
+  it('onReview opens the combined surface with the pair payload', () => {
+    const openCombined = vi.fn();
+    const { code, media } = pairFor('app-x');
+    const merged = mergeReviewRows([code], [media], 'asc', openCombined);
+    merged[0].onReview();
+    expect(openCombined).toHaveBeenCalledTimes(1);
+    const payload = openCombined.mock.calls[0][0];
+    expect(payload.onsiteRequestId).toBe('code-app-x');
+    expect(payload.listingRequestId).toBe('media-app-x');
+  });
+
+  it('an app with ONLY a code row stays a single on-site row (unchanged)', () => {
+    const code = onsiteRequestToUnifiedRow(onsite({ id: 'c1', slug: 'only-code' }), vi.fn());
+    const merged = mergeReviewRows([code], [], 'asc', vi.fn());
+    expect(merged).toHaveLength(1);
+    expect(merged[0].kind).toBe('onsite');
+    expect(merged[0].key).toBe('onsite:c1');
+  });
+
+  it('an app with ONLY a listing-media row stays a single row (unchanged)', () => {
+    const media = offsiteRequestToUnifiedRow(offsite({ id: 'm1', slug: 'only-media', kind: 'onsite' }), vi.fn());
+    const merged = mergeReviewRows([], [media], 'asc', vi.fn());
+    expect(merged).toHaveLength(1);
+    expect(merged[0].kind).toBe('offsite');
+    expect(merged[0].key).toBe('onsite-listing:m1');
+  });
+
+  it('an EXTERNAL off-site listing never combines (no code request)', () => {
+    const code = onsiteRequestToUnifiedRow(onsite({ id: 'c1', slug: 'app-x', appBlockId: 'blk-x' }), vi.fn());
+    const external = offsiteRequestToUnifiedRow(offsite({ id: 'e1', slug: 'app-x' }), vi.fn()); // kind absent → external
+    const merged = mergeReviewRows([code], [external], 'asc', vi.fn());
+    // No listing-MEDIA row → the external listing + the code row stay separate.
+    expect(merged).toHaveLength(2);
+    expect(merged.map((r) => r.kind).sort()).toEqual(['offsite', 'onsite']);
+    expect(merged.some((r) => r.kind === 'combined')).toBe(false);
+  });
+
+  it('two apps each with both → TWO combined rows', () => {
+    const a = pairFor('app-a', { codeAt: '2026-01-01T00:00:00Z' });
+    const b = pairFor('app-b', { codeAt: '2026-01-03T00:00:00Z' });
+    const merged = mergeReviewRows([a.code, b.code], [a.media, b.media], 'asc', vi.fn());
+    expect(merged).toHaveLength(2);
+    expect(merged.every((r) => r.kind === 'combined')).toBe(true);
+    // Sort preserved: app-a (earlier) before app-b.
+    expect(merged.map((r) => r.slug)).toEqual(['app-a', 'app-b']);
+  });
+
+  it('WITHOUT an opener (history tabs) nothing combines — the pair stays two rows', () => {
+    const { code, media } = pairFor('app-x');
+    const merged = mergeReviewRows([code], [media], 'desc');
+    expect(merged).toHaveLength(2);
+    expect(merged.some((r) => r.kind === 'combined')).toBe(false);
+  });
+
+  it('sorts the combined row by the EARLIER of the pair; interleaves with a single row', () => {
+    const { code, media } = pairFor('app-x', {
+      codeAt: '2026-01-05T00:00:00Z',
+      mediaAt: '2026-01-02T00:00:00Z', // earlier → combined sorts at 01-02
+    });
+    const external = offsiteRequestToUnifiedRow(
+      offsite({ id: 'e1', slug: 'ext', submittedAt: '2026-01-03T00:00:00Z' }),
+      vi.fn()
+    );
+    const merged = mergeReviewRows([code], [media, external], 'asc', vi.fn());
+    // combined@01-02, external@01-03.
+    expect(merged.map((r) => r.kind)).toEqual(['combined', 'offsite']);
+  });
+});

--- a/src/components/Apps/agentReviewReport.ts
+++ b/src/components/Apps/agentReviewReport.ts
@@ -250,12 +250,16 @@ export function severityBreakdown(findings: AgentFinding[]): SeverityBreakdown {
 
 // --- Deep-link to a finding (pure, unit-testable) --------------------------
 
-/** The report renderer's tab identifiers (in display order). */
-export type ReportTabValue = 'summary' | 'code' | 'security' | 'scopes';
+/**
+ * The report renderer's tab identifiers (in display order: Scopes → Security →
+ * Code review). The former `summary` tab was dropped — the agent prose overview
+ * is no longer surfaced in this renderer.
+ */
+export type ReportTabValue = 'scopes' | 'security' | 'code';
 
-const REPORT_TAB_VALUES: readonly ReportTabValue[] = ['summary', 'code', 'security', 'scopes'];
+const REPORT_TAB_VALUES: readonly ReportTabValue[] = ['scopes', 'security', 'code'];
 
-/** The two tabs that carry per-finding anchors (summary/scopes do not). */
+/** The two tabs that carry per-finding anchors (scopes does not). */
 export type FindingTab = 'code' | 'security';
 
 /**

--- a/src/components/Apps/reviewListingPreview.ts
+++ b/src/components/Apps/reviewListingPreview.ts
@@ -1,0 +1,133 @@
+/**
+ * App Blocks mod review — build a store-preview view-model (`ListingCard` +
+ * `ListingDetail`) for an UNAPPROVED listing from the data the moderator review
+ * surface already has client-side. Pure + React-free so the mapping is unit-tested
+ * in the node project (the browser suites are report-only), mirroring
+ * `appListingCardView` / `appListingDetailView`.
+ *
+ * WHY a builder (and its LIMITS): the mod review surface loads an `OffsitePendingRow`
+ * (name / category / contentRating / externalUrl / submitter) + the listing's assets
+ * via `appListings.getAssets`. But `getAssets` returns image *IDs* + scan status —
+ * NOT the CDN image `url` keys, and the row carries no tagline/description. A CDN URL
+ * can't be derived from a numeric image id on the client, so a pixel-accurate media
+ * preview (icon / cover / screenshots) would need the review query to project image
+ * URLs — a SERVER change, out of scope for this front-end-only work. This builder is
+ * therefore fed only what's available: it renders a LAYOUT preview (name, category,
+ * content-rating, creator chip, kind-aware framing) with the store components'
+ * built-in graceful placeholders for the art. If a caller CAN resolve image URLs, it
+ * may pass them via `images` and they flow straight through — so the builder is ready
+ * for that projection without a rewrite.
+ */
+
+import type { OffsitePendingRow } from '~/components/Apps/OffsiteReviewQueue';
+import type {
+  ListingCard,
+  ListingCardKindData,
+  ListingCreatorChip,
+  ListingDetail,
+  ListingDetailKindData,
+  ListingGalleryScreenshot,
+  ListingKind,
+  ListingRecommendRollup,
+} from '~/server/schema/blocks/app-listing-read.schema';
+
+/**
+ * Optionally-resolved image URLs + gallery for the preview. All fields optional so
+ * the mod surface (which has no resolved URLs) can omit them → placeholder art. If a
+ * future server projection supplies real CDN URLs, pass them here and they render.
+ */
+export type ReviewListingPreviewImages = {
+  iconUrl?: string | null;
+  coverUrl?: string | null;
+  screenshots?: ListingGalleryScreenshot[];
+};
+
+/** No-reviews-yet rollup — a shadow/unapproved listing has no reviews. */
+const EMPTY_RECOMMEND: ListingRecommendRollup = {
+  recommendedCount: 0,
+  notRecommendedCount: 0,
+  recommendPct: null,
+};
+
+/** The listing's store KIND: an on-site media revision is an on-site listing; an
+ *  external-link/connect revision is off-site. Absent row kind → off-site (the
+ *  backward-compatible default the review adapters already use). */
+function listingKind(row: OffsitePendingRow): ListingKind {
+  return row.kind === 'onsite' ? 'onsite' : 'offsite';
+}
+
+/** Submitter chip → the public creator chip shape (id/username/image only). */
+function creatorChip(row: OffsitePendingRow): ListingCreatorChip | null {
+  const s = row.submittedBy;
+  return s ? { id: s.id, username: s.username, image: s.image } : null;
+}
+
+/** Shared scalar fields common to the card + detail preview shapes. */
+function commonFields(row: OffsitePendingRow, images?: ReviewListingPreviewImages) {
+  return {
+    id: row.appListingId ?? row.id,
+    slug: row.slug,
+    kind: listingKind(row),
+    name: row.appListing?.name ?? row.slug,
+    category: row.appListing?.category ?? null,
+    contentRating: row.appListing?.contentRating ?? null,
+    iconUrl: images?.iconUrl ?? null,
+    coverUrl: images?.coverUrl ?? null,
+    creator: creatorChip(row),
+    recommend: EMPTY_RECOMMEND,
+    reviewCount: 0,
+  };
+}
+
+function cardKindData(row: OffsitePendingRow): ListingCardKindData {
+  if (listingKind(row) === 'onsite') {
+    // Backing appBlockId isn't carried on the review row; hasPage/liveUrl are
+    // unknown here (unused by the preview CTA, which is omitted). Safe placeholders.
+    return { kind: 'onsite', appBlockId: null, hasPage: false, liveUrl: '' };
+  }
+  return {
+    kind: 'offsite',
+    subKind: row.appListing?.connectClientId != null ? 'connect' : 'external-link',
+    externalUrl: row.appListing?.externalUrl ?? null,
+  };
+}
+
+function detailKindData(row: OffsitePendingRow): ListingDetailKindData {
+  if (listingKind(row) === 'onsite') {
+    return { kind: 'onsite', appBlockId: null, hasPage: false, liveUrl: '' };
+  }
+  return {
+    kind: 'offsite',
+    subKind: row.appListing?.connectClientId != null ? 'connect' : 'external-link',
+    externalUrl: row.appListing?.externalUrl ?? null,
+    connectClientId: row.appListing?.connectClientId ?? null,
+  };
+}
+
+/** Build the grid-CARD preview from the review row (+ optional resolved images). */
+export function buildListingCardPreview(
+  row: OffsitePendingRow,
+  images?: ReviewListingPreviewImages
+): ListingCard {
+  return {
+    ...commonFields(row, images),
+    tagline: null,
+    kindData: cardKindData(row),
+  };
+}
+
+/** Build the store-DETAIL preview from the review row (+ optional resolved images). */
+export function buildListingDetailPreview(
+  row: OffsitePendingRow,
+  images?: ReviewListingPreviewImages
+): ListingDetail {
+  return {
+    ...commonFields(row, images),
+    // serialId only feeds the comments thread, which the preview omits → 0.
+    serialId: 0,
+    tagline: null,
+    description: null,
+    screenshots: images?.screenshots ?? [],
+    kindData: detailKindData(row),
+  };
+}

--- a/src/components/Apps/reviewListingPreview.ts
+++ b/src/components/Apps/reviewListingPreview.ts
@@ -5,18 +5,16 @@
  * in the node project (the browser suites are report-only), mirroring
  * `appListingCardView` / `appListingDetailView`.
  *
- * WHY a builder (and its LIMITS): the mod review surface loads an `OffsitePendingRow`
- * (name / category / contentRating / externalUrl / submitter) + the listing's assets
- * via `appListings.getAssets`. But `getAssets` returns image *IDs* + scan status —
- * NOT the CDN image `url` keys, and the row carries no tagline/description. A CDN URL
- * can't be derived from a numeric image id on the client, so a pixel-accurate media
- * preview (icon / cover / screenshots) would need the review query to project image
- * URLs — a SERVER change, out of scope for this front-end-only work. This builder is
- * therefore fed only what's available: it renders a LAYOUT preview (name, category,
- * content-rating, creator chip, kind-aware framing) with the store components'
- * built-in graceful placeholders for the art. If a caller CAN resolve image URLs, it
- * may pass them via `images` and they flow straight through — so the builder is ready
- * for that projection without a rewrite.
+ * ROLE — the graceful FALLBACK. The real preview media now comes from the mod-only
+ * `appListings.getListingPreviewForReview` projection (the SHADOW listing's icon /
+ * cover / screenshots + scalars, projected with the SAME image→CDN-URL derivation as
+ * the public store detail). This builder is what the review section renders WHILE
+ * that query is loading, if it errors, or when the row has no backing listing id: a
+ * placeholder-art LAYOUT preview from the row's already-loaded fields (name, category,
+ * content-rating, creator chip, kind-aware framing) — so the surface never blanks or
+ * crashes. The row carries no CDN image `url` / tagline / description, so those fall
+ * to the store components' built-in placeholders. A caller that already HAS resolved
+ * image URLs may still pass them via `images` and they flow straight through.
  */
 
 import type { OffsitePendingRow } from '~/components/Apps/OffsiteReviewQueue';

--- a/src/components/Apps/unifiedReviewRow.ts
+++ b/src/components/Apps/unifiedReviewRow.ts
@@ -18,7 +18,23 @@ import type { OffsitePendingRow } from '~/components/Apps/OffsiteReviewQueue';
  * `OffsiteReviewModal`) — the kinds never cross.
  */
 
-export type UnifiedReviewKind = 'onsite' | 'offsite';
+export type UnifiedReviewKind = 'onsite' | 'offsite' | 'combined';
+
+/**
+ * The two underlying pending requests carried by a COMBINED row — an app that has
+ * BOTH a pending on-site CODE request AND a pending on-site listing-MEDIA revision.
+ * The combined review surface opens both sections from these payloads + ids.
+ */
+export type CombinedReviewPayload = {
+  /** The on-site CODE publish-request id (`onsite:<id>` source). */
+  onsiteRequestId: string;
+  /** The on-site listing-MEDIA revision publish-request id (`onsite-listing:<id>`). */
+  listingRequestId: string;
+  /** The raw code request (opens the code-review section). */
+  onsiteRequest: OnsiteReviewRequest;
+  /** The raw listing-media row (opens the media-review section + preview). */
+  listingRow: OffsitePendingRow;
+};
 
 /** Minimal user chip carried on a unified row (rendered by the list). */
 export type ReviewSubmitterChip = {
@@ -55,6 +71,19 @@ export type UnifiedReviewRow = {
   submittedAt: Date;
   /** Opens the correct review modal for this row's kind. */
   onReview: () => void;
+  /** Backing AppBlock id, when known (on-site CODE rows carry it) — the PRIMARY key
+   *  for pairing a code row with its listing-media row; pairing falls back to `slug`
+   *  when either side lacks it. Undefined for rows with no backing block. */
+  appBlockId?: string | null;
+  /** Raw on-site CODE request payload (set by the on-site adapter) — carried so a
+   *  COMBINED row can open the code-review section from it. */
+  onsiteRequest?: OnsiteReviewRequest;
+  /** Raw listing row payload (set by the listing adapter) — carried so a COMBINED
+   *  row can open the media-review section from it. */
+  offsiteRow?: OffsitePendingRow;
+  /** Present ONLY on a `kind: 'combined'` row: the two underlying request ids +
+   *  payloads (code + listing-media) that the combined surface stacks. */
+  combined?: CombinedReviewPayload;
 };
 
 function toDate(d: string | Date): Date {
@@ -90,6 +119,9 @@ export function onsiteRequestToUnifiedRow(
     submitter: req.submittedBy,
     submittedAt: toDate(reviewedAt ?? req.submittedAt),
     onReview: () => openOnsiteReview(req),
+    // Carried for code+media pairing + the combined surface.
+    appBlockId: req.appBlockId,
+    onsiteRequest: req,
   };
 }
 
@@ -179,7 +211,81 @@ export function offsiteRequestToUnifiedRow(
     submitter: req.submittedBy,
     submittedAt: toDate(reviewedAt ?? req.submittedAt),
     onReview: () => openOffsiteReview(row),
+    // Carried so a COMBINED row can open the media-review section from this payload.
+    // (The listing queue row has no backing appBlockId; pairing falls back to slug.)
+    offsiteRow: row,
   };
+}
+
+/** Do two rows belong to the SAME app? Prefer a backing-block match; fall back to
+ *  slug (a listing-media row carries no appBlockId, so code+media pairs match on
+ *  slug — the same app slug on both sides). */
+function sameApp(a: UnifiedReviewRow, b: UnifiedReviewRow): boolean {
+  if (a.appBlockId && b.appBlockId) return a.appBlockId === b.appBlockId;
+  return !!a.slug && a.slug === b.slug;
+}
+
+/**
+ * Collapse an on-site CODE row + an on-site listing-MEDIA row for the SAME app into
+ * ONE combined row carrying both request ids + payloads. ONLY these two kinds
+ * combine — an external/offsite listing (no separate code request) and an app with
+ * just one of the two are left untouched. Pure: given the deduped rows + a combined
+ * opener, returns a new row list with each matched pair replaced by a combined row
+ * (order of first appearance preserved for the pre-sort list).
+ */
+function combineCodeAndMediaRows(
+  rows: UnifiedReviewRow[],
+  openCombined: (payload: CombinedReviewPayload) => void
+): UnifiedReviewRow[] {
+  const codeRows = rows.filter((r) => r.kind === 'onsite' && r.onsiteRequest);
+  const mediaRows = rows.filter((r) => r.key.startsWith('onsite-listing:') && r.offsiteRow);
+  const consumedMedia = new Set<string>();
+  const combinedByCodeKey = new Map<string, UnifiedReviewRow>();
+
+  for (const code of codeRows) {
+    const media = mediaRows.find((m) => !consumedMedia.has(m.key) && sameApp(code, m));
+    if (!media || !code.onsiteRequest || !media.offsiteRow) continue;
+    consumedMedia.add(media.key);
+    const payload: CombinedReviewPayload = {
+      onsiteRequestId: code.onsiteRequest.id,
+      listingRequestId: media.offsiteRow.id,
+      onsiteRequest: code.onsiteRequest,
+      listingRow: media.offsiteRow,
+    };
+    combinedByCodeKey.set(code.key, {
+      // Deterministic, unique key from BOTH child keys.
+      key: `combined:${code.key}+${media.key}`,
+      kind: 'combined',
+      badge: 'App + media',
+      badgeColor: 'indigo',
+      title: code.title,
+      slug: code.slug,
+      submitter: code.submitter,
+      // Sort by the EARLIER of the two so the pair surfaces by when the app first
+      // needed review (oldest-first pending); tiebreak by key stays stable.
+      submittedAt: new Date(
+        Math.min(code.submittedAt.getTime(), media.submittedAt.getTime())
+      ),
+      appBlockId: code.appBlockId ?? media.appBlockId,
+      onReview: () => openCombined(payload),
+      combined: payload,
+    });
+  }
+
+  if (combinedByCodeKey.size === 0) return rows;
+
+  // Rebuild: replace each matched code row with its combined row (in place, so
+  // ordering is stable) and drop the consumed media rows.
+  const out: UnifiedReviewRow[] = [];
+  for (const r of rows) {
+    if (r.kind === 'onsite' && combinedByCodeKey.has(r.key)) {
+      out.push(combinedByCodeKey.get(r.key)!);
+      continue;
+    }
+    if (r.key.startsWith('onsite-listing:') && consumedMedia.has(r.key)) continue;
+    out.push(r);
+  }
+  return out;
 }
 
 /**
@@ -187,24 +293,31 @@ export function offsiteRequestToUnifiedRow(
  * date-sorted list.
  *   - dedup by `key` (first occurrence wins; on-site keys and off-site keys are
  *     namespaced so cross-kind rows never collide — dedup is a within-kind guard);
+ *   - when `openCombined` is provided (the PENDING queue), collapse an on-site CODE
+ *     row + an on-site listing-MEDIA row for the SAME app into ONE combined row
+ *     carrying both ids/payloads (see `combineCodeAndMediaRows`). History tabs omit
+ *     the opener, so decided rows are never combined;
  *   - sort by `submittedAt` — `asc` = oldest-first (pending FIFO), `desc` =
  *     newest-first (history);
  *   - STABLE, direction-independent tiebreak by `key` so equal timestamps always
  *     order identically (no render churn).
  *
- * Pure — no drops, no side effects. Every input row appears in the output exactly
- * once.
+ * Pure — no side effects. Every input row appears in the output exactly once, EXCEPT
+ * a combined code+media pair, which appears as its single combined row.
  */
 export function mergeReviewRows(
   onsite: UnifiedReviewRow[],
   offsite: UnifiedReviewRow[],
-  direction: 'asc' | 'desc'
+  direction: 'asc' | 'desc',
+  openCombined?: (payload: CombinedReviewPayload) => void
 ): UnifiedReviewRow[] {
   const byKey = new Map<string, UnifiedReviewRow>();
   for (const row of onsite) if (!byKey.has(row.key)) byKey.set(row.key, row);
   for (const row of offsite) if (!byKey.has(row.key)) byKey.set(row.key, row);
 
-  const rows = Array.from(byKey.values());
+  let rows = Array.from(byKey.values());
+  if (openCombined) rows = combineCodeAndMediaRows(rows, openCombined);
+
   rows.sort((a, b) => {
     const ta = a.submittedAt.getTime();
     const tb = b.submittedAt.getTime();

--- a/src/pages/apps/review.tsx
+++ b/src/pages/apps/review.tsx
@@ -27,8 +27,13 @@ import {
   type AnyRequest,
   type OnsiteReviewMode,
 } from '~/components/Apps/OnsiteReviewModal';
+import {
+  CombinedReviewModal,
+  type CombinedReviewSelection,
+} from '~/components/Apps/CombinedReviewModal';
 import { UnifiedReviewList } from '~/components/Apps/UnifiedReviewList';
 import type {
+  CombinedReviewPayload,
   OffsiteReviewRequest,
   OnsiteReviewRequest,
 } from '~/components/Apps/unifiedReviewRow';
@@ -145,6 +150,10 @@ export default function ReviewQueuePage() {
     onActioned?: () => void | Promise<void>;
     readOnly?: boolean;
   } | null>(null);
+  // Combined code+media review surface — opened when a PENDING row is an app that has
+  // BOTH a pending code request AND a pending listing-media revision (page-owned, one
+  // instance). Each stacked section keeps its own independent approve/reject.
+  const [combinedReview, setCombinedReview] = useState<CombinedReviewSelection>(null);
 
   // DUAL-PATH on-site row selection: under the `appReviewPage` flag a row NAVIGATES
   // to the deep-linkable detail page `/apps/review/<id>`; with the flag off it opens
@@ -165,6 +174,13 @@ export default function ReviewQueuePage() {
   const openOffsiteReview = useCallback(
     (row: OffsitePendingRow, onActioned?: () => void | Promise<void>, readOnly = false) => {
       setOffsiteReview({ row, onActioned, readOnly });
+    },
+    []
+  );
+
+  const openCombinedReview = useCallback(
+    (payload: CombinedReviewPayload, onActioned?: () => void | Promise<void>) => {
+      setCombinedReview({ ...payload, onActioned });
     },
     []
   );
@@ -211,6 +227,7 @@ export default function ReviewQueuePage() {
             <UnifiedPendingTab
               openOnsiteReview={openOnsiteReview}
               openOffsiteReview={openOffsiteReview}
+              openCombinedReview={openCombinedReview}
             />
           </Tabs.Panel>
 
@@ -255,6 +272,7 @@ export default function ReviewQueuePage() {
         onActioned={offsiteReview?.onActioned}
         readOnly={offsiteReview?.readOnly}
       />
+      <CombinedReviewModal selection={combinedReview} onClose={() => setCombinedReview(null)} />
     </>
   );
 }
@@ -271,6 +289,7 @@ export default function ReviewQueuePage() {
 function UnifiedPendingTab({
   openOnsiteReview,
   openOffsiteReview,
+  openCombinedReview,
 }: {
   openOnsiteReview: (
     req: AnyRequest,
@@ -281,6 +300,10 @@ function UnifiedPendingTab({
     row: OffsitePendingRow,
     onActioned?: () => void | Promise<void>,
     readOnly?: boolean
+  ) => void;
+  openCombinedReview: (
+    payload: CombinedReviewPayload,
+    onActioned?: () => void | Promise<void>
   ) => void;
 }) {
   const features = useFeatureFlags();
@@ -333,6 +356,10 @@ function UnifiedPendingTab({
     (row: OffsitePendingRow) => openOffsiteReview(row, resetPaging),
     [openOffsiteReview, resetPaging]
   );
+  const boundCombined = useCallback(
+    (payload: CombinedReviewPayload) => openCombinedReview(payload, resetPaging),
+    [openCombinedReview, resetPaging]
+  );
 
   const onLoadMore = () => {
     if (onsiteNext != null) {
@@ -352,6 +379,7 @@ function UnifiedPendingTab({
       direction="asc"
       openOnsiteReview={boundOnsite}
       openOffsiteReview={boundOffsite}
+      openCombinedReview={boundCombined}
       isLoading={onsiteQuery.isLoading || offsiteQuery.isLoading}
       errorMessage={onsiteQuery.error?.message ?? offsiteQuery.error?.message}
       emptyLabel="Queue is empty. Nothing waiting for review."

--- a/src/server/routers/__tests__/app-listings.router.mod-actions-authz.test.ts
+++ b/src/server/routers/__tests__/app-listings.router.mod-actions-authz.test.ts
@@ -26,6 +26,7 @@ const {
   mockReport,
   mockListReports,
   mockResetOnsite,
+  mockPreviewForReview,
   mockIsAppBlocksEnabled,
   mockIsAppBlocksAuthorEnabled,
 } = vi.hoisted(() => ({
@@ -43,6 +44,7 @@ const {
   mockListEvents: vi.fn(async () => ({ items: [], nextCursor: null })),
   mockReport: vi.fn(async () => ({ reportId: 'alrp_1' })),
   mockListReports: vi.fn(async () => ({ items: [], nextCursor: null })),
+  mockPreviewForReview: vi.fn(async () => ({ card: {}, detail: {} })),
   mockIsAppBlocksEnabled: vi.fn(),
   mockIsAppBlocksAuthorEnabled: vi.fn(),
 }));
@@ -58,6 +60,11 @@ vi.mock('~/server/services/blocks/offsite-moderation.service', () => ({
   dismissReport: mockDismiss,
   listModerationEvents: mockListEvents,
   resetOnsiteListingToPending: mockResetOnsite,
+}));
+// The listing-preview projection is dynamically imported by getListingPreviewForReview;
+// mock just that export so the mod-gate authz can be exercised without a DB.
+vi.mock('~/server/services/blocks/app-listing.service', () => ({
+  getListingPreviewForReview: mockPreviewForReview,
 }));
 vi.mock('~/server/services/app-blocks-flag', () => ({
   isAppBlocksEnabled: mockIsAppBlocksEnabled,
@@ -284,6 +291,38 @@ describe('mod actions — error mapping via mapOffsiteError', () => {
       caller.claimListing({ appListingId: 'apl_1', targetUserId: -5, reason: REASON })
     ).rejects.toBeInstanceOf(TRPCError);
     expect(mockClaim).not.toHaveBeenCalled();
+  });
+});
+
+describe('getListingPreviewForReview — moderator-only read', () => {
+  it('a tester is FORBIDDEN; the projection service is NOT called', async () => {
+    const caller = appListingsRouter.createCaller(fakeCtx(tester) as never);
+    await expect(caller.getListingPreviewForReview({ listingId: 'apl_1' })).rejects.toBeInstanceOf(
+      TRPCError
+    );
+    expect(mockPreviewForReview).not.toHaveBeenCalled();
+  });
+
+  it('anonymous is rejected; the projection service is NOT called', async () => {
+    const caller = appListingsRouter.createCaller(fakeCtx(undefined) as never);
+    await expect(caller.getListingPreviewForReview({ listingId: 'apl_1' })).rejects.toBeInstanceOf(
+      TRPCError
+    );
+    expect(mockPreviewForReview).not.toHaveBeenCalled();
+  });
+
+  it('a moderator passes the gate and the projection runs with the listing id', async () => {
+    const caller = appListingsRouter.createCaller(fakeCtx(mod) as never);
+    await expect(caller.getListingPreviewForReview({ listingId: 'apl_9' })).resolves.toBeDefined();
+    expect(mockPreviewForReview).toHaveBeenCalledWith({ listingId: 'apl_9' });
+  });
+
+  it('the router exposes getListingPreviewForReview', () => {
+    const procs = Object.keys(
+      (appListingsRouter as unknown as { _def: { procedures: Record<string, unknown> } })._def
+        .procedures
+    );
+    expect(procs).toContain('getListingPreviewForReview');
   });
 });
 

--- a/src/server/routers/app-listings.router.ts
+++ b/src/server/routers/app-listings.router.ts
@@ -226,6 +226,27 @@ export const appListingsRouter = router({
     }),
 
   /**
+   * MOD-ONLY: project a SHADOW / pending listing (by its `appListingId` — carried on
+   * the review row) into the SAME `ListingCard` + `ListingDetail` store shapes the
+   * public `getAppDetail` serves, so the moderator review surface can render the app's
+   * REAL media (icon / cover / screenshots) + scalars in store layout BEFORE approval.
+   * Read-only, `moderatorProcedure`-gated (the whole review surface is mod-only), NOT
+   * status-filtered (unlike the public approved-only read). Returns `null` for an
+   * unknown id → the client falls back to a placeholder-art layout preview.
+   */
+  getListingPreviewForReview: moderatorProcedure
+    .input(listingAssetsQuerySchema)
+    .query(async ({ ctx, input }) => {
+      if (!ctx.user?.isModerator) {
+        throw throwAuthorizationError('Listing review preview is restricted to civitai team');
+      }
+      const { getListingPreviewForReview } = await import(
+        '~/server/services/blocks/app-listing.service'
+      );
+      return getListingPreviewForReview({ listingId: input.listingId });
+    }),
+
+  /**
    * Poll the scan status of freshly-attached asset images. The listing-media step
    * attaches an in-flight image IMMEDIATELY (the server stores the pending id), then
    * polls THIS to flip a per-asset "Scanning…" badge to "Scanned" / "Blocked". Owner-

--- a/src/server/services/blocks/__tests__/app-listing.service.test.ts
+++ b/src/server/services/blocks/__tests__/app-listing.service.test.ts
@@ -18,6 +18,7 @@ const { mockDbRead } = vi.hoisted(() => ({
     appListing: {
       findMany: vi.fn(async (..._a: unknown[]): Promise<unknown[]> => []),
       findFirst: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
+      findUnique: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
     },
   },
 }));
@@ -39,6 +40,7 @@ import {
   decodeListingCursor,
   encodeListingCursor,
   getListingDetail,
+  getListingPreviewForReview,
   listAvailableListings,
   moderationStatusWhere,
   projectListingCard,
@@ -794,5 +796,49 @@ describe('moderationStatusWhere', () => {
 
   it('removed → an exact status match', () => {
     expect(moderationStatusWhere('removed')).toEqual({ status: 'removed' });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getListingPreviewForReview — mod-only shadow-listing preview projection.
+// Reuses listingHydrateSelect + projectListingCard/Detail (the SAME image→URL
+// derivation as the public read); NOT status-filtered (a mod previews a draft/
+// shadow). getEdgeUrl is mocked to identity, so URL fields echo the stored key.
+// ---------------------------------------------------------------------------
+
+describe('getListingPreviewForReview', () => {
+  beforeEach(() => {
+    mockDbRead.appListing.findUnique.mockReset();
+  });
+
+  it('projects the shadow listing into REAL card + detail (icon/cover/screenshots + scalars)', async () => {
+    mockDbRead.appListing.findUnique.mockResolvedValueOnce(hydratedRow());
+    const res = await getListingPreviewForReview({ listingId: 'apl_1' });
+    expect(res).not.toBeNull();
+    // Looked the row up by id (not a status-filtered read).
+    const arg = mockDbRead.appListing.findUnique.mock.calls[0][0] as { where: { id: string } };
+    expect(arg.where).toEqual({ id: 'apl_1' });
+    // Card + detail carry the REAL derived image URLs (getEdgeUrl mocked to identity).
+    expect(res!.card.iconUrl).toBe('icon-key');
+    expect(res!.card.coverUrl).toBe('cover-key');
+    expect(res!.card.name).toBe('Cool App');
+    expect(res!.detail.iconUrl).toBe('icon-key');
+    expect(res!.detail.coverUrl).toBe('cover-key');
+    expect(res!.detail.description).toBe('# Cool app\n\nbody');
+    expect(res!.detail.screenshots).toEqual([{ url: 'shot-0', caption: 'first shot' }]);
+    expect(res!.detail.creator).toEqual({ id: 7, username: 'dev', image: 'avatar-key' });
+  });
+
+  it('returns null when no listing row exists for the id', async () => {
+    mockDbRead.appListing.findUnique.mockResolvedValueOnce(null);
+    expect(await getListingPreviewForReview({ listingId: 'missing' })).toBeNull();
+  });
+
+  it('projects partial media correctly (icon+cover, no screenshots → empty gallery, cover from cover)', async () => {
+    mockDbRead.appListing.findUnique.mockResolvedValueOnce(hydratedRow({ screenshots: [] }));
+    const res = await getListingPreviewForReview({ listingId: 'apl_1' });
+    expect(res!.detail.screenshots).toEqual([]);
+    // Cover still resolves from the cover image (not the absent first screenshot).
+    expect(res!.detail.coverUrl).toBe('cover-key');
   });
 });

--- a/src/server/services/blocks/app-listing.service.ts
+++ b/src/server/services/blocks/app-listing.service.ts
@@ -322,6 +322,33 @@ function galleryScreenshots(row: HydratedListing): ListingGalleryScreenshot[] {
   return out;
 }
 
+/**
+ * MOD-ONLY review preview: project a SHADOW / pending listing (by its own id — the
+ * review row's `appListingId`) into the SAME `ListingCard` + `ListingDetail` store
+ * shapes the public `getAppDetail` read serves, so the moderator sees the app's
+ * REAL media (icon / cover / ordered screenshots) + scalars (name / tagline /
+ * description / category / contentRating / creator) laid out as the store card +
+ * detail — before approval.
+ *
+ * Reuses `listingHydrateSelect` + `projectListingCard` / `projectListingDetail`
+ * verbatim (the SAME image→CDN-URL derivation as the approved-listing read), so the
+ * preview can never drift from the live store projection and there is NO second
+ * image-URL builder. UNLIKE the public read it is NOT status-filtered (a mod may
+ * preview a draft / pending / shadow listing); the caller (`moderatorProcedure`) is
+ * the authz gate. Read-only — no listing mutation. Returns `null` when the id has no
+ * listing row (the client then falls back to a placeholder-art layout preview).
+ */
+export async function getListingPreviewForReview(args: {
+  listingId: string;
+}): Promise<{ card: ListingCard; detail: ListingDetail } | null> {
+  const row = await dbRead.appListing.findUnique({
+    where: { id: args.listingId },
+    select: listingHydrateSelect,
+  });
+  if (!row) return null;
+  return { card: projectListingCard(row), detail: projectListingDetail(row) };
+}
+
 /** Project a hydrated listing row → the PUBLIC detail DTO (allowlist). */
 export function projectListingDetail(row: HydratedListing): ListingDetail {
   const recommend = recommendRollup(row.metric);


### PR DESCRIPTION
Four front-end + one mod-only-read change to the flag-gated + mod-gated App Blocks review surfaces. Dark to public; no migration. The only server addition is a single read-only, moderator-gated projection proc for the listing preview (item 3).

## 1 + 2 — Agent-review report tabs: drop Summary, reorder
`ReportTabs` no longer has the free-text **Summary** tab. The tab is removed, `summaryMd` is no longer rendered/threaded through this renderer, the remaining tabs are reordered to **Scopes → Security audit → Code review**, and the default tab is now Scopes. `ReportTabValue` drops `'summary'`; `parseReportHash` no longer recognizes `#summary`. Count badges, per-finding deep-link anchors (`finding-<tab>-<i>`), copy-link, `keepMounted`, and the XSS-safe rendering are all preserved — with the markdown summary gone, there is no raw-HTML/markdown surface left in the report at all.

## 3 — Real listing media preview in the media review (card + detail)
The listing-media review renders both the grid **card** (`AppListingCard`) and the store **detail** (`AppListingDetailBody preview`) showing the app's **REAL media** — icon, cover, ordered screenshots — plus name / tagline / description / category / content-rating / creator, in store layout, as a "how it will appear once approved" preview.

- **New mod-only projection proc** `appListings.getListingPreviewForReview` (**`moderatorProcedure`**, read-only, **no migration**): given the review row's `appListingId` (the shadow / pending listing), it loads that listing and projects it into the SAME `ListingCard` / `ListingDetail` shapes the public `getAppDetail` serves — **reusing `listingHydrateSelect` + `projectListingCard` / `projectListingDetail`** (the same `image.url → getEdgeUrl` CDN derivation as the approved-listing read; **no second image-URL builder**). Unlike the public read it is **not** status-filtered (a mod may preview a draft/shadow); the `moderatorProcedure` gate is the authz boundary.
- `AppListingDetailBody` gains a read-only **`preview`** mode: renders only the presentational parts (hero cover, icon, name, tagline, creator chip, content-rating badge, screenshot gallery, description markdown) and OMITS the live surfaces — comments, recommend reviews/rollup, and the report / review / primary-action / owner-edit buttons. Non-preview behaviour is byte-identical.
- **Graceful fallback:** while the projection query is loading, errors, or the row has no backing listing id, the section renders a placeholder-art layout preview from the row via the pure `reviewListingPreview` builders — so the review surface never blanks or crashes.

## 4 — Combine an app's code + listing-media review into one surface
When the SAME app has BOTH a pending on-site **code** request AND a pending on-site **listing-media** revision, the unified `/apps/review` queue collapses them into ONE combined row (detected in the pure `mergeReviewRows`: match on `appBlockId`, falling back to `slug`). The row opens a `CombinedReviewModal` with two STACKED sections — **App code review** (reuses `OnsiteReviewModalBody`: the ReportTabs report + bundle/diff) and **Listing media** (reuses the extracted `OffsiteReviewModalBody`: the real-media preview + assets + scan status). Each section keeps its **own independent** approve/reject wired to its **own existing proc** (`blocks.*` vs `appListings.*`) — no joint approve, no server coordination; approving one never fires the other's mutation. Only onsite-code + onsite-listing-media combine; external listings and single-sided apps are unchanged, and combining is scoped to the PENDING queue (history tabs pass no opener). The deep-link page `review/[publishRequestId].tsx` was **not** extended to combined (optional per scope; the queue modal is the primary target).

**Known minor follow-up (left as-is):** the combined modal **closes on either section's decision** (then the queue refreshes and the still-pending side reappears as its own single row). Independent-approve semantics hold; a mod just can't approve both in one open session.

## Tests (honest run-vs-written)
- **Ran (blocking unit gate, green — 146 tests):** `app-listing.service` incl. `getListingPreviewForReview` (real projected card+detail URLs/scalars, null when absent, partial-media gallery); `app-listings.router.mod-actions-authz` incl. the new proc (non-mod / anonymous → FORBIDDEN + service not called, mod passes with the listing id, proc exposed); `unifiedReviewRow` (combine collapse — both ids, singles/external unchanged, two-apps, no-opener→no-combine, sort); `reviewListingPreview` (fallback-builder mapping); `agentReviewReport` (updated for dropped `#summary`).
- **Written but NOT executed locally (report-only browser suites; CI authoritative):** the Playwright chromium headless-shell would not provision in the sandbox (the unsupported-OS fallback build extracts incompletely), so the browser-mode component tests were not run locally. They cover: ReportTabs tab-IA (order / no Summary / default Scopes / count badges / summaryMd never rendered / deep-link still resolves); AppListingDetailBody preview-omits vs live-renders; the combined surface (both section headers, the code ReportTabs, the media preview with the REAL projected tagline/description, and distinct approve handlers). AgentReviewPanel / OffsiteReviewQueue / ConnectScopesPanel browser mocks were updated for the dropped summary surface + the new proc + `useCurrentUser`.
- **Verified:** `tsc --noEmit` clean on all changed files (the only remaining project errors are pre-existing drift in untouched files — `image.service.ts` implicit-any, `mage-flow.handler.ts` `@civitai/client`); `eslint` reports 0 errors on the changed source (pre-existing warnings only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
