### PR TITLE
fix(app-listings): let moderators list a foreign OAuth client on external submit/edit (mirror mod-only client search)

### DIFF
--- a/src/server/routers/app-listings.router.ts
+++ b/src/server/routers/app-listings.router.ts
@@ -353,7 +353,14 @@ export const appListingsRouter = router({
       const { submitExternalListing } = await import(
         '~/server/services/blocks/offsite-listing.service'
       );
-      return submitExternalListing({ input, userId: ctx.user.id });
+      // `isModerator` lets a mod link ANY (non-App-Block) OAuth client on submit —
+      // mirroring the mod-only global client search (`oauthClient.searchForModerator`).
+      // A non-mod stays restricted to their own clients (default `false`).
+      return submitExternalListing({
+        input,
+        userId: ctx.user.id,
+        isModerator: ctx.user.isModerator,
+      });
     }),
 
   /**
@@ -405,6 +412,9 @@ export const appListingsRouter = router({
           listingId: input.listingId,
           patch: input.patch,
           userId: ctx.user.id,
+          // Mirror the mod-only client search: a mod editing a listing that links a
+          // foreign OAuth client isn't blocked by the owner re-assertion.
+          isModerator: ctx.user.isModerator,
         });
       } catch (err) {
         throw mapOffsiteError(err);
@@ -459,6 +469,8 @@ export const appListingsRouter = router({
           shadowId: input.shadowId,
           patch: input.patch,
           userId: ctx.user.id,
+          // Mirror the mod-only client search (same rationale as `updateListing`).
+          isModerator: ctx.user.isModerator,
         });
       } catch (err) {
         throw mapOffsiteError(err);

--- a/src/server/services/blocks/__tests__/offsite-listing.edit-consolidate.service.test.ts
+++ b/src/server/services/blocks/__tests__/offsite-listing.edit-consolidate.service.test.ts
@@ -321,4 +321,49 @@ describe('updateRevisionDraft', () => {
       updateRevisionDraft({ shadowId: 'apl_shadow', userId: 7, patch: { name: 'x' } })
     ).rejects.toMatchObject({ code: 'NOT_OWNED' });
   });
+
+  // #3399 completion: a MOD may edit scopes on a shadow whose linked OAuth client is
+  // owned by someone else (the client owner ≠ the listing/shadow owner). The owner
+  // re-assertion in deriveScopePatch is bypassed for mods only.
+  it('mod scope edit on a shadow linking a FOREIGN client → OK (derived, no FORBIDDEN)', async () => {
+    mockRead.appListing.findUnique.mockResolvedValue(
+      ownedRow({
+        id: 'apl_shadow',
+        status: 'draft',
+        revisionOfId: 'apl_parent',
+        connectClientId: 'oauth-1',
+      })
+    );
+    // Client owned by someone else (999); the shadow/listing is owned by the mod (7).
+    mockRead.oauthClient.findUnique.mockResolvedValue({ userId: 999, allowedScopes: 13 });
+    await updateRevisionDraft({
+      shadowId: 'apl_shadow',
+      userId: 7,
+      isModerator: true,
+      patch: { requestedScopes: 4, scopeJustifications: { ModelsRead: 'reason' } },
+    });
+    const data = mockWrite.appListing.update.mock.calls[0][0].data as Record<string, unknown>;
+    expect(data.connectRequestedScopes).toBe(13);
+  });
+
+  it('non-mod scope edit on a shadow linking a FOREIGN client → FORBIDDEN, no write', async () => {
+    mockRead.appListing.findUnique.mockResolvedValue(
+      ownedRow({
+        id: 'apl_shadow',
+        status: 'draft',
+        revisionOfId: 'apl_parent',
+        connectClientId: 'oauth-1',
+      })
+    );
+    mockRead.oauthClient.findUnique.mockResolvedValue({ userId: 999, allowedScopes: 13 });
+    await expect(
+      updateRevisionDraft({
+        shadowId: 'apl_shadow',
+        userId: 7,
+        isModerator: false,
+        patch: { requestedScopes: 4, scopeJustifications: { ModelsRead: 'reason' } },
+      })
+    ).rejects.toMatchObject({ code: 'FORBIDDEN' });
+    expect(mockWrite.appListing.update).not.toHaveBeenCalled();
+  });
 });

--- a/src/server/services/blocks/__tests__/offsite-listing.oauth-fields.service.test.ts
+++ b/src/server/services/blocks/__tests__/offsite-listing.oauth-fields.service.test.ts
@@ -2,6 +2,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
   buildListingPatchData,
+  deriveScopePatch,
+  loadConnectClientForListing,
   submitExternalListing,
   updateListing,
 } from '~/server/services/blocks/offsite-listing.service';
@@ -376,5 +378,187 @@ describe('updateListing (connect scope edit re-validation)', () => {
     });
     expect(res.requiresReview).toBe(true);
     expect(res.shadowId).toBeTruthy();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// MODERATOR foreign-client support (#3399 completion): the mod-only global client
+// search lets a mod SELECT any (non-App-Block) OAuth client, so the submit/edit
+// ownership check must be relaxed for mods ONLY. The App-Block exclusion + existence
+// checks + the non-mod restriction stay intact.
+// ---------------------------------------------------------------------------
+
+describe('loadConnectClientForListing (moderator ownership relaxation)', () => {
+  it('non-mod + FOREIGN client → FORBIDDEN (regression: owner-only for non-mods)', async () => {
+    mockRead.oauthClient.findUnique.mockResolvedValue(ownedClient({ userId: OTHER }));
+    await expect(loadConnectClientForListing(CLIENT_ID, CALLER)).rejects.toMatchObject({
+      code: 'FORBIDDEN',
+    });
+    // Default (undefined) isModerator behaves as non-mod.
+    await expect(loadConnectClientForListing(CLIENT_ID, CALLER, false)).rejects.toMatchObject({
+      code: 'FORBIDDEN',
+    });
+  });
+
+  it('mod + FOREIGN client → OK (returns the client allowedScopes ceiling)', async () => {
+    mockRead.oauthClient.findUnique.mockResolvedValue(ownedClient({ userId: OTHER }));
+    const client = await loadConnectClientForListing(CLIENT_ID, CALLER, true);
+    expect(client).toMatchObject({ id: CLIENT_ID, allowedScopes: CEILING });
+  });
+
+  it('mod + OWN client → OK', async () => {
+    mockRead.oauthClient.findUnique.mockResolvedValue(ownedClient()); // userId = CALLER
+    const client = await loadConnectClientForListing(CLIENT_ID, CALLER, true);
+    expect(client).toMatchObject({ id: CLIENT_ID, allowedScopes: CEILING });
+  });
+
+  it('mod + App-Block client → still BAD_REQUEST (exclusion holds for mods, no DB lookup)', async () => {
+    await expect(
+      loadConnectClientForListing('appblk-abc123', CALLER, true)
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST', message: expect.stringContaining('App Block') });
+    expect(mockRead.oauthClient.findUnique).not.toHaveBeenCalled();
+  });
+
+  it('client not found → NOT_FOUND for BOTH roles', async () => {
+    mockRead.oauthClient.findUnique.mockResolvedValue(null);
+    await expect(loadConnectClientForListing(CLIENT_ID, CALLER, false)).rejects.toMatchObject({
+      code: 'NOT_FOUND',
+    });
+    await expect(loadConnectClientForListing(CLIENT_ID, CALLER, true)).rejects.toMatchObject({
+      code: 'NOT_FOUND',
+    });
+  });
+});
+
+describe('submitExternalListing (moderator foreign client)', () => {
+  it('a MOD submitting with a FOREIGN client → SUCCEEDS (draft + pending request created)', async () => {
+    mockRead.oauthClient.findUnique.mockResolvedValue(ownedClient({ userId: OTHER }));
+    const res = await submitExternalListing({
+      input: baseInput,
+      userId: CALLER,
+      isModerator: true,
+    });
+    expect(res.slug).toBe('connect-app');
+    expect(mockWrite.$transaction).toHaveBeenCalledTimes(1);
+    // The mod flag threads through: the ownership error is NOT thrown, and the created
+    // listing OWNER is still the submitting caller (not the client's owner).
+    const listingData = mockWrite.appListing.create.mock.calls[0][0].data as {
+      userId: number;
+      connectClientId: string;
+      connectRequestedScopes: number;
+    };
+    expect(listingData.userId).toBe(CALLER);
+    expect(listingData.connectClientId).toBe(CLIENT_ID);
+    expect(listingData.connectRequestedScopes).toBe(CEILING);
+  });
+
+  it('a NON-MOD with a FOREIGN client → FORBIDDEN, no write (restriction preserved)', async () => {
+    mockRead.oauthClient.findUnique.mockResolvedValue(ownedClient({ userId: OTHER }));
+    await expect(
+      submitExternalListing({ input: baseInput, userId: CALLER, isModerator: false })
+    ).rejects.toMatchObject({ code: 'FORBIDDEN' });
+    expect(mockWrite.$transaction).not.toHaveBeenCalled();
+  });
+
+  it('a MOD with an App-Block client → still BAD_REQUEST (exclusion holds)', async () => {
+    await expect(
+      submitExternalListing({
+        input: { ...baseInput, connectClientId: 'appblk-abc123' },
+        userId: CALLER,
+        isModerator: true,
+      })
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST', message: expect.stringContaining('App Block') });
+    expect(mockWrite.$transaction).not.toHaveBeenCalled();
+  });
+});
+
+describe('deriveScopePatch (moderator ownership relaxation)', () => {
+  it('a non-scope patch is passed through unchanged, no client lookup (both roles)', async () => {
+    const patch = { name: 'New name' };
+    const res = await deriveScopePatch({ connectClientId: CLIENT_ID, patch, userId: CALLER });
+    expect(res).toEqual({ effectivePatch: patch, connectAllowedScopes: null });
+    expect(mockRead.oauthClient.findUnique).not.toHaveBeenCalled();
+  });
+
+  it('non-mod editing a FOREIGN-client listing scopes → FORBIDDEN', async () => {
+    mockRead.oauthClient.findUnique.mockResolvedValue(ownedClient({ userId: OTHER }));
+    await expect(
+      deriveScopePatch({
+        connectClientId: CLIENT_ID,
+        patch: { requestedScopes: TokenScope.ModelsRead, scopeJustifications: {} },
+        userId: CALLER,
+        isModerator: false,
+      })
+    ).rejects.toMatchObject({ code: 'FORBIDDEN' });
+  });
+
+  it('mod editing a FOREIGN-client listing scopes → OK (derives from the client current allowedScopes)', async () => {
+    mockRead.oauthClient.findUnique.mockResolvedValue(ownedClient({ userId: OTHER }));
+    const res = await deriveScopePatch({
+      connectClientId: CLIENT_ID,
+      // A bogus form mask; the derived snapshot must equal the client's CEILING.
+      patch: { requestedScopes: TokenScope.ModelsRead, scopeJustifications: { ModelsRead: 'r' } },
+      userId: CALLER,
+      isModerator: true,
+    });
+    expect(res.connectAllowedScopes).toBe(CEILING);
+    expect(res.effectivePatch.requestedScopes).toBe(CEILING);
+  });
+});
+
+describe('updateListing (moderator foreign client scope edit)', () => {
+  const approvedForeignListing = {
+    id: 'apl_live',
+    kind: 'offsite',
+    slug: 'connect-app',
+    status: 'approved',
+    // The LISTING is owned by the mod caller (owner-of-listing is unchanged); only the
+    // linked OAuth CLIENT is foreign — exactly the mod-picks-any-client case.
+    userId: CALLER,
+    revisionOfId: null,
+    name: 'Connect App',
+    tagline: null,
+    description: null,
+    category: null,
+    contentRating: 'g',
+    externalUrl: null,
+    connectClientId: CLIENT_ID,
+    connectRequestedScopes: TokenScope.ModelsRead,
+    connectScopeJustifications: { ModelsRead: 'reason' },
+    iconId: 1,
+    coverId: 2,
+  };
+
+  it('mod editing a foreign-client listing scopes → OK (stages a shadow, no FORBIDDEN)', async () => {
+    mockRead.appListing.findUnique.mockResolvedValue(approvedForeignListing);
+    mockRead.oauthClient.findUnique.mockResolvedValue(ownedClient({ userId: OTHER }));
+    mockRead.appListing.findFirst.mockResolvedValue(null); // no existing shadow
+    mockWrite.appListing.findFirst.mockResolvedValue({ id: 'apl_shadow' }); // winner re-read
+
+    const res = await updateListing({
+      listingId: 'apl_live',
+      userId: CALLER,
+      isModerator: true,
+      patch: {
+        requestedScopes: TokenScope.UserRead | TokenScope.ModelsRead,
+        scopeJustifications: { UserRead: 'profile', ModelsRead: 'reason' },
+      },
+    });
+    expect(res.requiresReview).toBe(true);
+    expect(res.shadowId).toBeTruthy();
+  });
+
+  it('non-mod editing a foreign-client listing scopes → FORBIDDEN, no shadow write', async () => {
+    mockRead.appListing.findUnique.mockResolvedValue(approvedForeignListing);
+    mockRead.oauthClient.findUnique.mockResolvedValue(ownedClient({ userId: OTHER }));
+    await expect(
+      updateListing({
+        listingId: 'apl_live',
+        userId: CALLER,
+        isModerator: false,
+        patch: { requestedScopes: TokenScope.ModelsRead, scopeJustifications: {} },
+      })
+    ).rejects.toMatchObject({ code: 'FORBIDDEN' });
+    expect(mockWrite.appListing.update).not.toHaveBeenCalled();
   });
 });

--- a/src/server/services/blocks/offsite-listing.service.ts
+++ b/src/server/services/blocks/offsite-listing.service.ts
@@ -127,8 +127,10 @@ export type SubmitExternalListingResult = {
  * Owner-binding (IDOR): both the `AppListing.userId` and the
  * `AppListingPublishRequest.submittedByUserId` are set from the AUTHENTICATED
  * caller (`userId`) — the input carries NO owner field, so a caller can never
- * submit on another user's behalf. The linked OAuth client is ALSO ownership-checked
- * (`loadConnectClientForListing`: exists / owned-by-caller / not an App-Block client).
+ * submit on another user's behalf. The linked OAuth client is ALSO gated
+ * (`loadConnectClientForListing`: exists / not an App-Block client / owned-by-caller —
+ * the owner check is relaxed for a MODERATOR, who may link any non-App-Block client,
+ * mirroring the mod-only global client search).
  *
  * REQUIRES a `connectClientId` (the caller's own OAuth client) + a DISCLOSED
  * `requestedScopes` subset (⊆ the client's `allowedScopes` ceiling) + per-scope
@@ -153,8 +155,15 @@ export type SubmitExternalListingResult = {
 export async function submitExternalListing(opts: {
   input: SubmitExternalListingInput;
   userId: number;
+  /**
+   * The caller's moderator status. When true, `loadConnectClientForListing` skips the
+   * owner-only check so a mod may link ANY (non-App-Block) OAuth client — mirroring the
+   * mod-only global client search that feeds the submit picker. A non-mod stays
+   * restricted to their own clients. The listing OWNER is still the caller (`userId`).
+   */
+  isModerator?: boolean;
 }): Promise<SubmitExternalListingResult> {
-  const { input, userId } = opts;
+  const { input, userId, isModerator = false } = opts;
 
   // Defense-in-depth: re-run the shared URL validator — but ONLY when a URL is
   // provided (externalUrl is now optional; a connect-only listing omits it). This fn
@@ -192,7 +201,7 @@ export async function submitExternalListing(opts: {
   // edit re-enters review). The subset check is trivially satisfied now (the set
   // equals its own ceiling) but kept as a defensive assertion; the per-scope
   // justifications are validated against the derived set.
-  const client = await loadConnectClientForListing(input.connectClientId, userId);
+  const client = await loadConnectClientForListing(input.connectClientId, userId, isModerator);
   const requestedScopes = client.allowedScopes;
   assertConnectScopesValid({
     requestedScopes,
@@ -296,19 +305,26 @@ export async function submitExternalListing(opts: {
 // ---------------------------------------------------------------------------
 
 /**
- * Load the caller's OWN OAuth client and assert it is eligible to back an external
- * listing: it must EXIST, be OWNED by `userId` (IDOR), and NOT be an App-Block
- * client (`isAppBlockOauthClientId` — those are managed by the App Blocks flow, not
- * hand-listed). Returns the client's `allowedScopes` ceiling. An external listing does
- * NOT require the client to be `isVerified` (decision Q4). All failures are friendly
- * TRPCErrors (parity with `submitExternalListing`'s validation style).
+ * Load an OAuth client and assert it is eligible to back an external listing: it must
+ * EXIST and NOT be an App-Block client (`isAppBlockOauthClientId` — those are managed
+ * by the App Blocks flow, not hand-listed). By default it must also be OWNED by
+ * `userId` (IDOR). Returns the client's `allowedScopes` ceiling. An external listing
+ * does NOT require the client to be `isVerified` (decision Q4). All failures are
+ * friendly TRPCErrors (parity with `submitExternalListing`'s validation style).
+ *
+ * `isModerator`: when true, the owner-only check is BYPASSED — a moderator may link
+ * ANY (non-App-Block) OAuth client, mirroring the mod-only GLOBAL client search that
+ * feeds the external-submit picker (`oauthClient.searchForModerator`). This ONLY
+ * relaxes ownership: the App-Block exclusion (for everyone) and the existence check
+ * still hold. A non-moderator stays restricted to their own clients.
  */
-async function loadConnectClientForListing(
+export async function loadConnectClientForListing(
   connectClientId: string,
-  userId: number
+  userId: number,
+  isModerator = false
 ): Promise<{ id: string; allowedScopes: number }> {
   // App-block clients are excluded up-front (cheap, no DB) — they are never a
-  // hand-authored connect target.
+  // hand-authored connect target. This exclusion holds for EVERYONE, mods included.
   if (isAppBlockOauthClientId(connectClientId)) {
     throw new TRPCError({
       code: 'BAD_REQUEST',
@@ -322,7 +338,9 @@ async function loadConnectClientForListing(
   if (!client) {
     throw new TRPCError({ code: 'NOT_FOUND', message: 'OAuth client not found' });
   }
-  if (client.userId !== userId) {
+  // Owner-only — BYPASSED for a moderator (who can pick any client via the mod-only
+  // global search). A non-mod picking a client they don't own is still FORBIDDEN.
+  if (!isModerator && client.userId !== userId) {
     throw new TRPCError({
       code: 'FORBIDDEN',
       message: 'you can only list an OAuth client you own',
@@ -371,13 +389,20 @@ function assertConnectScopesValid(opts: {
  * the new owner's ceiling. Validates the justifications against the derived set.
  * Shared by `updateListing` (in-place / material-shadow) and `updateRevisionDraft`
  * (approved shadow scalar write) so both snapshot scopes identically.
+ *
+ * `isModerator`: when true, that owner re-assertion is intentionally BYPASSED — a mod
+ * may edit a listing that links a client they don't own (mirroring the mod-only
+ * client search on submit). The existence check + scope-subset / justification
+ * validation (server-authoritative snapshot from the client's CURRENT allowedScopes)
+ * are UNCHANGED. A non-mod is still refused a foreign client.
  */
-async function deriveScopePatch(opts: {
+export async function deriveScopePatch(opts: {
   connectClientId: string | null;
   patch: UpdateListingPatch;
   userId: number;
+  isModerator?: boolean;
 }): Promise<{ effectivePatch: UpdateListingPatch; connectAllowedScopes: number | null }> {
-  const { connectClientId, patch, userId } = opts;
+  const { connectClientId, patch, userId, isModerator = false } = opts;
   const editsScopes =
     patch.requestedScopes !== undefined || patch.scopeJustifications !== undefined;
   if (!editsScopes) return { effectivePatch: patch, connectAllowedScopes: null };
@@ -395,7 +420,9 @@ async function deriveScopePatch(opts: {
   if (!client) {
     throw new TRPCError({ code: 'NOT_FOUND', message: 'OAuth client not found' });
   }
-  if (client.userId !== userId) {
+  // Owner re-assertion — BYPASSED for a moderator (the post-submit transfer guard is
+  // intentionally skipped for mods, who may link any client). Non-mods still refused.
+  if (!isModerator && client.userId !== userId) {
     throw new TRPCError({
       code: 'FORBIDDEN',
       message: 'you can only list an OAuth client you own',
@@ -833,8 +860,15 @@ export async function updateListing(opts: {
   listingId: string;
   patch: UpdateListingPatch;
   userId: number;
+  /**
+   * The caller's moderator status — threaded into `deriveScopePatch` so a mod editing
+   * a listing that links a foreign OAuth client isn't blocked by the owner re-assertion
+   * (mirrors the mod-only client search on submit). Listing OWNERSHIP is unaffected —
+   * `loadOwnedEditableListing` still requires the caller to own the LISTING itself.
+   */
+  isModerator?: boolean;
 }): Promise<UpdateListingResult> {
-  const { listingId, patch, userId } = opts;
+  const { listingId, patch, userId, isModerator = false } = opts;
   const listing = await loadOwnedEditableListing(listingId, userId);
 
   // A shadow is an internal draft — never editable via this top-level path (its
@@ -855,6 +889,7 @@ export async function updateListing(opts: {
     connectClientId: listing.connectClientId,
     patch,
     userId,
+    isModerator,
   });
   const patchOpts = { connectAllowedScopes };
 
@@ -1499,8 +1534,14 @@ export async function updateRevisionDraft(opts: {
   shadowId: string;
   patch: UpdateListingPatch;
   userId: number;
+  /**
+   * The caller's moderator status — threaded into `deriveScopePatch` (same rationale
+   * as `updateListing`): a mod editing a shadow whose parent links a foreign OAuth
+   * client isn't blocked by the owner re-assertion. Listing OWNERSHIP unaffected.
+   */
+  isModerator?: boolean;
 }): Promise<{ shadowId: string }> {
-  const { shadowId, patch, userId } = opts;
+  const { shadowId, patch, userId, isModerator = false } = opts;
   const shadow = await loadOwnedEditableListing(shadowId, userId);
   if (shadow.revisionOfId == null) {
     throw new OffsiteRequestError(
@@ -1522,6 +1563,7 @@ export async function updateRevisionDraft(opts: {
     connectClientId: shadow.connectClientId,
     patch,
     userId,
+    isModerator,
   });
   const data = buildListingPatchData(effectivePatch, { connectAllowedScopes });
   await dbWrite.appListing.update({ where: { id: shadowId }, data });


### PR DESCRIPTION
## Bug

PR #3399 added a mod-only **global** OAuth-client search to the external-app submit flow, so a moderator can now select ANY (non-App-Block) OAuth client — not just their own. But the server-side submit/edit validation still enforced owner-only, so a mod picking another user's client got:

> Submission problem — you can only list an OAuth client you own

The search feature was half-wired: the picker offers foreign clients, but the write path rejects them.

## Fix

Relax the client-**ownership** check for **moderators only** — exactly mirroring who the mod-only search serves (`oauthClient.searchForModerator` is `moderatorProcedure`-gated). Two ownership checks in `offsite-listing.service.ts` now take an `isModerator` flag and skip the `client.userId !== userId` `FORBIDDEN` throw when it is set:

- `loadConnectClientForListing(connectClientId, userId, isModerator=false)` — the submit path (`submitExternalListing`).
- `deriveScopePatch({ connectClientId, patch, userId, isModerator })` — the edit path (shared by `updateListing` + `updateRevisionDraft`).

`isModerator` is threaded from each router proc's `ctx.user.isModerator` (the repo's canonical mod check, already used across this router). The three procs (`submitExternalListing`, `updateListing`, `updateRevisionDraft`) all pass it down.

**Unchanged / preserved:**
- The App-Block-client exclusion (`isAppBlockOauthClientId` → `BAD_REQUEST`) still holds for **everyone**, mods included.
- The client **existence** check (`NOT_FOUND`) is unchanged for both roles.
- A **non-moderator** is still restricted to their own clients (still `FORBIDDEN` on a foreign client).
- Scope-subset / justification validation and the server-authoritative scope snapshot (from the client's current `allowedScopes`) are untouched.
- Listing **ownership** is unaffected — this only changes which OAuth *client* can be linked; the listing owner is still the submitting caller, and `loadOwnedEditableListing` still requires the caller to own the listing on edit.

Behavior-only — **no migration**, no schema change.

## Test coverage

Added to the existing service unit tests (`offsite-listing.oauth-fields.service.test.ts`, `offsite-listing.edit-consolidate.service.test.ts`):

- `loadConnectClientForListing`: non-mod + foreign → still `FORBIDDEN` (regression); mod + foreign → OK (returns `allowedScopes`); mod + own → OK; mod + App-Block → still `BAD_REQUEST`; not-found → `NOT_FOUND` (both roles).
- `deriveScopePatch`: mod + foreign scope edit → OK (derives current `allowedScopes`); non-mod + foreign → `FORBIDDEN`; non-scope patch → passthrough.
- `submitExternalListing`: mod + foreign client → succeeds (draft + pending request created, owner still the caller); non-mod + foreign → `FORBIDDEN`, no write; mod + App-Block → `BAD_REQUEST`.
- `updateListing` / `updateRevisionDraft`: mod editing a foreign-client listing's scopes → OK; non-mod → `FORBIDDEN`, no write.

**Verification** (fresh worktree, sibling `node_modules` symlinked):
- `npm run test:unit:run` — the two edited files: **50 passed**; full offsite-listing + moderation suite: **268 passed**.
- `npx eslint` on all four changed files — **0 errors** (only pre-existing `_a` unused-arg warnings in the mock boilerplate).
- `npx tsc --noEmit` — **no errors in any changed file**; remaining output is pre-existing `event-engine-common` module-resolution + `@civitai/client` mage-flow noise in untouched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
