### PR TITLE
fix(app-listings): add manual "pull from site" autofill button to external-submit + fix icon/cover pull

### DIFF
--- a/src/components/Apps/ExternalSubmitForm.browser.test.tsx
+++ b/src/components/Apps/ExternalSubmitForm.browser.test.tsx
@@ -29,6 +29,10 @@ const mocks = vi.hoisted(() => ({
     isSuccess: boolean;
     isError?: boolean;
   },
+  // The meta query's `refetch` — a same-url "Pull from site" re-click calls it
+  // (staleTime:Infinity + retry:false makes `setMetaUrl(sameUrl)` a no-op), so we assert
+  // it fired on re-click to prove the once-per-url guard is bypassed on a manual retry.
+  refetch: vi.fn(),
   clients: {
     data: [{ id: 'oauth-client-1', name: 'My OAuth App', allowedScopes: 4 | 32 }] as unknown,
     isLoading: false,
@@ -46,21 +50,43 @@ vi.mock('~/utils/trpc', () => {
   const mutation = () => ({ mutate: vi.fn(), mutateAsync: vi.fn(), isPending: false });
   return {
     trpc: {
+      // ListingAssetStep (reached on the Assets step) calls `trpc.useUtils()` and
+      // `utils.appListings.getAssetScanStatuses.fetch` on an accept — stub both.
+      useUtils: () => ({
+        appListings: {
+          getAssetScanStatuses: { fetch: vi.fn().mockResolvedValue([]) },
+        },
+      }),
       appListings: {
         submitExternalListing: {
-          useMutation: (opts?: unknown) => {
+          useMutation: (opts?: { onSuccess?: (r: unknown) => void }) => {
             mocks.submit(opts);
-            return { mutate: mocks.mutate, mutateAsync: vi.fn(), isPending: false };
+            return {
+              // On mutate, fire the caller's onSuccess so the wizard transitions to the
+              // Assets step (setSubmitted + STEP_ASSETS) — the only place the captured
+              // `suggestions` render. Existing tests assert the call count, unaffected.
+              mutate: (vars: unknown) => {
+                mocks.mutate(vars);
+                opts?.onSuccess?.({
+                  listingId: 'apl_new',
+                  publishRequestId: 'apr_new',
+                  slug: 'vitrine',
+                });
+              },
+              mutateAsync: vi.fn(),
+              isPending: false,
+            };
           },
         },
         fetchListingMetaFromUrl: {
-          useQuery: () => mocks.meta,
+          useQuery: () => ({ ...mocks.meta, refetch: mocks.refetch }),
         },
         persistAssetImage: { useMutation: mutation },
         ingestAssetFromUrl: { useMutation: mutation },
         setIcon: { useMutation: mutation },
         setCover: { useMutation: mutation },
         addScreenshot: { useMutation: mutation },
+        removeScreenshot: { useMutation: mutation },
       },
       oauthClient: {
         getAll: { useQuery: () => mocks.clients },
@@ -96,6 +122,7 @@ const { ExternalSubmitForm } = await import('./ExternalSubmitForm');
 beforeEach(() => {
   mocks.submit.mockClear();
   mocks.mutate.mockClear();
+  mocks.refetch.mockClear();
   mocks.meta = { data: undefined, isFetching: false, isSuccess: false };
   mocks.clients = {
     data: [{ id: 'oauth-client-1', name: 'My OAuth App', allowedScopes: READONLY_SCOPES }],
@@ -397,5 +424,167 @@ describe('ExternalSubmitForm — OAuth step: mod global-search + create deeplink
     await expect.element(link).toHaveAttribute('href', '/user/account');
     await expect.element(link).toHaveAttribute('target', '_blank');
     await expect.element(link).toHaveAttribute('rel', expect.stringContaining('noopener'));
+  });
+});
+
+/**
+ * "Pull from site" button (create wizard). The auto-pull fires ONCE per URL
+ * (`appliedMetaRef` guard) and `staleTime:Infinity` + `retry:false` pin the result, so a
+ * first-time empty / errored / not-ready pull (or a client-rendered SPA that exposes no
+ * server-side OG tags — #3344) could never be retried without editing the URL. This
+ * button re-runs the OG pull on demand for the CURRENT url, applies name/tagline/
+ * description fill-if-empty, and re-surfaces the icon/cover suggestions on the Assets
+ * step. Mirrors the edit wizard's "Autofill from website".
+ */
+describe('ExternalSubmitForm — create "Pull from site" button', () => {
+  /** Drive the wizard URL → App → Details → create draft → Assets. */
+  async function reachAssets() {
+    await pickClient();
+    await page.getByTestId('apps-offsite-wizard-next-app').click();
+    await page.getByRole('button', { name: 'Create draft' }).click();
+  }
+
+  test('renders on the URL step (create mode), enabled once a valid https URL is entered', async () => {
+    renderWithProviders(<ExternalSubmitForm />);
+    const btn = page.getByTestId('apps-offsite-submit-autofill');
+    // Blank URL → disabled (no wasted fetch).
+    await expect.element(btn).toBeDisabled();
+    await page.getByTestId('apps-offsite-submit-url').fill('https://vitrine.civitai.com');
+    await expect.element(btn).toBeEnabled();
+  });
+
+  test('is DISABLED for a non-https URL', async () => {
+    renderWithProviders(<ExternalSubmitForm />);
+    await page.getByTestId('apps-offsite-submit-url').fill('http://insecure.example.com');
+    await expect.element(page.getByTestId('apps-offsite-submit-autofill')).toBeDisabled();
+  });
+
+  test('clicking it pulls meta, applies fill-if-empty name/description, and surfaces the "applied" note', async () => {
+    mocks.meta = {
+      data: {
+        name: 'Civitai Cosmetic Studio',
+        tagline: 'short',
+        description: 'Pulled from the link.',
+        coverImageUrl: 'https://cdn/og-cover.png',
+        iconImageUrl: 'https://cdn/og-icon.png',
+      },
+      isFetching: false,
+      isSuccess: true,
+    };
+    renderWithProviders(<ExternalSubmitForm />);
+    await page.getByTestId('apps-offsite-submit-url').fill('https://cosmetic-studio.civitai.com');
+    await page.getByTestId('apps-offsite-submit-autofill').click();
+    await expect
+      .element(page.getByTestId('apps-offsite-submit-autofill-applied'))
+      .toBeInTheDocument();
+    // Advance to Details — the pulled title + description filled the empty fields.
+    await pickClient();
+    await page.getByTestId('apps-offsite-wizard-next-app').click();
+    await expect
+      .element(page.getByTestId('apps-offsite-submit-name'))
+      .toHaveValue('Civitai Cosmetic Studio');
+    await expect
+      .element(page.getByTestId('apps-offsite-submit-description'))
+      .toHaveValue('Pulled from the link.');
+  });
+
+  test('the pulled icon/cover suggestions flow to the Assets step (Use this previews)', async () => {
+    mocks.meta = {
+      data: {
+        name: 'Vitrine',
+        tagline: undefined,
+        description: undefined,
+        coverImageUrl: 'https://cdn/og-cover.png',
+        iconImageUrl: 'https://cdn/og-icon.png',
+      },
+      isFetching: false,
+      isSuccess: true,
+    };
+    renderWithProviders(<ExternalSubmitForm />);
+    await page.getByTestId('apps-offsite-submit-url').fill('https://vitrine.civitai.com');
+    await page.getByTestId('apps-offsite-submit-autofill').click();
+    await expect
+      .element(page.getByTestId('apps-offsite-submit-autofill-applied'))
+      .toBeInTheDocument();
+    await reachAssets();
+    // The empty icon + cover slots offer the pulled OG suggestion via "Use this".
+    await expect.element(page.getByTestId('apps-offsite-accept-icon')).toBeInTheDocument();
+    await expect.element(page.getByTestId('apps-offsite-accept-cover')).toBeInTheDocument();
+    await expect
+      .element(page.getByTestId('apps-offsite-suggested-icon-preview'))
+      .toBeInTheDocument();
+  });
+
+  test('does NOT clobber a name the user already typed', async () => {
+    // Reach Details with no meta applied, type a name, go back, then Pull from site.
+    mocks.meta = { data: undefined, isFetching: false, isSuccess: false };
+    renderWithProviders(<ExternalSubmitForm />);
+    await advanceFromUrl('https://vitrine.civitai.com');
+    await pickClient();
+    await page.getByTestId('apps-offsite-wizard-next-app').click();
+    await page.getByTestId('apps-offsite-submit-name').fill('User Typed Name');
+    // Back to the URL step and pull — the meta now carries a title.
+    await page.getByTestId('apps-offsite-wizard-back-details').click();
+    await page.getByTestId('apps-offsite-wizard-back-app').click();
+    mocks.meta = {
+      data: { name: 'OG Title', tagline: undefined, description: undefined, coverImageUrl: undefined, iconImageUrl: undefined },
+      isFetching: false,
+      isSuccess: true,
+    };
+    await page.getByTestId('apps-offsite-submit-autofill').click();
+    // The typed name is preserved (fill-if-empty).
+    await pickClient();
+    await page.getByTestId('apps-offsite-wizard-next-app').click();
+    await expect
+      .element(page.getByTestId('apps-offsite-submit-name'))
+      .toHaveValue('User Typed Name');
+  });
+
+  test('a site that exposed NOTHING (SPA #3344) shows the honest empty note', async () => {
+    // Empty data — the pull surfaces no icon/cover/description; the host-derived name
+    // fallback is not counted as "pulled from the site", so the note is the honest empty.
+    mocks.meta = { data: {}, isFetching: false, isSuccess: true };
+    renderWithProviders(<ExternalSubmitForm />);
+    await page.getByTestId('apps-offsite-submit-url').fill('https://spa.example.com');
+    await page.getByTestId('apps-offsite-submit-autofill').click();
+    await expect
+      .element(page.getByTestId('apps-offsite-submit-autofill-empty'))
+      .toBeInTheDocument();
+  });
+
+  test('an ERRORED pull shows the error note (no spurious applied/empty)', async () => {
+    mocks.meta = { data: undefined, isFetching: false, isSuccess: false, isError: true };
+    renderWithProviders(<ExternalSubmitForm />);
+    await page.getByTestId('apps-offsite-submit-url').fill('https://broken.example.com');
+    await page.getByTestId('apps-offsite-submit-autofill').click();
+    await expect
+      .element(page.getByTestId('apps-offsite-submit-autofill-error'))
+      .toBeInTheDocument();
+    expect(page.getByTestId('apps-offsite-submit-autofill-applied').elements()).toHaveLength(0);
+    expect(page.getByTestId('apps-offsite-submit-autofill-empty').elements()).toHaveLength(0);
+  });
+
+  test('re-clicking with the SAME url bypasses the once-per-url guard via refetch()', async () => {
+    mocks.meta = {
+      data: { name: 'Vitrine', tagline: undefined, description: undefined, coverImageUrl: 'https://cdn/og-cover.png', iconImageUrl: 'https://cdn/og-icon.png' },
+      isFetching: false,
+      isSuccess: true,
+    };
+    renderWithProviders(<ExternalSubmitForm />);
+    await page.getByTestId('apps-offsite-submit-url').fill('https://vitrine.civitai.com');
+    await page.getByTestId('apps-offsite-submit-url').element().blur(); // sets metaUrl via the auto-pull path
+
+    // FIRST click: metaUrl already set by blur → same-url path → refetch().
+    await page.getByTestId('apps-offsite-submit-autofill').click();
+    await expect
+      .element(page.getByTestId('apps-offsite-submit-autofill-applied'))
+      .toBeInTheDocument();
+    await vi.waitFor(() => expect(mocks.refetch).toHaveBeenCalled());
+    const firstCount = mocks.refetch.mock.calls.length;
+
+    // SECOND click, url UNCHANGED: the once-per-url guard would block a re-apply, so the
+    // retry MUST go through refetch() again — proving the guard is bypassed on a manual pull.
+    await page.getByTestId('apps-offsite-submit-autofill').click();
+    await vi.waitFor(() => expect(mocks.refetch.mock.calls.length).toBeGreaterThan(firstCount));
   });
 });

--- a/src/components/Apps/ExternalSubmitForm.tsx
+++ b/src/components/Apps/ExternalSubmitForm.tsx
@@ -137,6 +137,24 @@ function ExternalCreateForm() {
   // meta effect); we never seed this up front so the title can win.
   const hostNameFallbackRef = useRef<string>('');
 
+  // On-demand "Pull from site" (create parity with the edit wizard's "Autofill from
+  // website"): the auto-pull fires ONCE per URL (`appliedMetaRef` guard) and
+  // `staleTime:Infinity` + `retry:false` pin the result, so a first-time
+  // empty / errored / not-ready pull could NEVER be re-surfaced without editing the URL
+  // (and a client-rendered SPA that exposes no server-side OG tags legitimately returns
+  // nothing — #3344). `autofillActive` tracks a button-triggered pull (drives the
+  // loading/note feedback); `autofillTick` forces the apply effect to re-run on a
+  // re-click of the SAME url (unchanged `metaUrl` + a cached `metaQuery.data` reference
+  // otherwise skip it). `autofillNote` reports applied / empty / error near the URL input.
+  const [autofillActive, setAutofillActive] = useState(false);
+  const [autofillTick, setAutofillTick] = useState(0);
+  const [autofillNote, setAutofillNote] = useState<'applied' | 'empty' | 'error' | null>(null);
+  // Latest `values` for the button-note emptiness check — the effect must read current
+  // emptiness WITHOUT depending on `values` (its async `setValues` updater hasn't run
+  // yet when the note is computed), mirroring the edit wizard's `valuesRef`.
+  const valuesRef = useRef(values);
+  valuesRef.current = values;
+
   const currentUser = useCurrentUser();
   const isModerator = !!currentUser?.isModerator;
 
@@ -223,6 +241,10 @@ function ExternalCreateForm() {
     if (!settled) return;
     appliedMetaRef.current = metaUrl;
 
+    // Snapshot pre-apply emptiness for the button note (the async `setValues` below
+    // hasn't committed yet, so read what the fields were BEFORE this apply).
+    const before = valuesRef.current;
+
     // Prefer the page <title> (data.name) over the host-derived fallback name.
     const resolvedName = data?.name || hostNameFallbackRef.current;
     setValues((v) => ({
@@ -246,7 +268,31 @@ function ExternalCreateForm() {
     ) {
       setAutofillApplied(true);
     }
-  }, [metaUrl, metaQuery.isFetching, metaQuery.data, metaQuery.isError]);
+
+    // Button-triggered pull → report applied / empty / error near the URL input. Only
+    // what the SITE actually exposed counts as "applied": a fillable text field from
+    // `data.*` (NOT the host-derived name fallback, which is derived from the URL, not
+    // pulled from the site) or an icon/cover suggestion. In CREATE every asset slot
+    // starts empty, so any suggested icon/cover URL is actionable. An error-settled
+    // fetch (or a site that exposed nothing — the #3344 SPA case) reports honestly so
+    // the author knows to upload manually.
+    if (autofillActive) {
+      if (metaQuery.isError && !data) {
+        setAutofillNote('error');
+      } else {
+        const filledAny =
+          (before.name.trim().length === 0 && !!data?.name) ||
+          (before.tagline.trim().length === 0 && !!data?.tagline) ||
+          (before.description.trim().length === 0 && !!data?.description);
+        const hasSuggestion = !!data?.coverImageUrl || !!data?.iconImageUrl;
+        setAutofillNote(filledAny || hasSuggestion ? 'applied' : 'empty');
+      }
+      setAutofillActive(false);
+    }
+    // `autofillTick` is a dep so a same-url re-click (which leaves `metaUrl` + the cached
+    // `metaQuery.data` reference unchanged) still re-runs this effect — the click resets
+    // `appliedMetaRef` so the guard above passes.
+  }, [metaUrl, metaQuery.isFetching, metaQuery.data, metaQuery.isError, autofillTick, autofillActive]);
 
   const submitMutation = trpc.appListings.submitExternalListing.useMutation({
     onSuccess: (res: Submitted) => {
@@ -327,6 +373,37 @@ function ExternalCreateForm() {
     setErrors((prev) => ({ ...prev, externalUrl: undefined }));
   }
 
+  // "Pull from site" — on-demand OG re-pull without leaving the URL step. Reuses the
+  // existing `metaQuery` + fill-if-empty apply effect + ListingAssetStep suggestions, so
+  // it's non-destructive by construction (typed text is never clobbered). This is the
+  // manual retry the auto-pull lacks: the once-per-url `appliedMetaRef` guard +
+  // `staleTime:Infinity` otherwise pin a first-time empty/errored/not-ready pull forever.
+  function handlePullFromSite() {
+    const result = normalizeLinkUrl(values.externalUrl);
+    if (result.error) {
+      // A bad/blank URL never fires a fetch (the button is also disabled in this state).
+      setErrors((prev) => ({ ...prev, externalUrl: result.error }));
+      return;
+    }
+    applyNormalizedUrl(result.url); // canonicalise URL + derive slug + stash host-name fallback
+    setErrors((prev) => ({ ...prev, externalUrl: undefined }));
+    setAutofillNote(null);
+    setAutofillActive(true);
+    appliedMetaRef.current = null; // force the idempotent apply effect to re-run
+    if (result.url === metaUrl) {
+      // SAME url: `setMetaUrl` is a no-op and (staleTime:Infinity + retry:false) the
+      // cached success/error won't re-fetch on its own — so a previously-empty/errored
+      // url could never be retried. `refetch()` re-attempts; on a cached success the
+      // tick below re-applies from data. No loop: `refetch()` synchronously flips
+      // `isFetching` true, so the tick-driven run bails on the isFetching guard and only
+      // applies once the (re)fetch settles.
+      void metaQuery.refetch();
+    } else {
+      setMetaUrl(result.url); // NEW url → the query fires for it
+    }
+    setAutofillTick((t) => t + 1); // re-run the effect even when metaUrl is unchanged
+  }
+
   function handleAdvanceFromUrl() {
     if (values.externalUrl.trim().length === 0) {
       setErrors((prev) => ({ ...prev, externalUrl: 'Enter your app’s URL to continue.' }));
@@ -398,6 +475,9 @@ function ExternalCreateForm() {
   }
 
   const busy = submitMutation.isPending;
+  // Gate the "Pull from site" button on a valid, normalizable URL (empty/invalid →
+  // disabled, no wasted fetch). Cheap enough to derive per render.
+  const pullUrl = normalizeLinkUrl(values.externalUrl);
   const clientOptions = clients.map((c) => ({ value: c.id, label: c.name }));
   const modClientOptions = modOptionClients.map((c) => ({
     value: c.id,
@@ -483,6 +563,53 @@ function ExternalCreateForm() {
                     Looking for a name, description and images from your link…
                   </Text>
                 </Group>
+              )}
+
+              {/* Manual "Pull from site" — an on-demand retry of the OG pull for the
+                  current URL. Fills only-empty name/tagline/description and re-surfaces
+                  the icon/cover suggestions on the Assets step. Non-destructive. */}
+              <Group gap="xs" align="center">
+                <Button
+                  variant="light"
+                  color="grape"
+                  leftSection={<IconSparkles size={16} />}
+                  onClick={handlePullFromSite}
+                  disabled={busy || !!pullUrl.error}
+                  loading={autofillActive && metaQuery.isFetching}
+                  data-testid="apps-offsite-submit-autofill"
+                >
+                  Pull from site
+                </Button>
+                <Text size="xs" c="dimmed">
+                  Pull a name, description, icon and cover from your link — only empty
+                  fields are filled; icon/cover appear on the Assets step.
+                </Text>
+              </Group>
+              {autofillNote === 'error' && (
+                <Text size="xs" c="red" data-testid="apps-offsite-submit-autofill-error">
+                  Couldn’t read that site’s details — check the URL, or add your images and
+                  description manually.
+                </Text>
+              )}
+              {autofillNote === 'empty' && (
+                <Text size="xs" c="dimmed" data-testid="apps-offsite-submit-autofill-empty">
+                  Your site didn’t expose an icon, cover or description to pull (or your
+                  fields are already filled). Add them to the page’s <Code>&lt;head&gt;</Code>,
+                  or upload images manually on the Assets step.
+                </Text>
+              )}
+              {autofillNote === 'applied' && (
+                <Alert
+                  color="grape"
+                  variant="light"
+                  icon={<IconSparkles size={16} />}
+                  data-testid="apps-offsite-submit-autofill-applied"
+                >
+                  <Text size="sm">
+                    Pulled the latest details from your link — check the Details step for the
+                    name and description, and the Assets step for the suggested icon/cover.
+                  </Text>
+                </Alert>
               )}
 
               <Group justify="space-between">


### PR DESCRIPTION
## What & why

On the **external app** create wizard (`/apps/submit` → `ExternalSubmitForm`), the icon/cover auto-pull could not be retried and there was no manual trigger. This adds a **"Pull from site"** button on the URL step and closes the retry gap — mirroring the edit-wizard's "Autofill from website" button (#3374).

## Diagnosis — real form/wiring bug or app-side no-OG-tags?

**Neither an extraction nor a wiring bug.** I traced the full path:

- The server meta service already extracts **both** assets correctly: `extractListingMeta` returns `coverImageUrl` (`og:image` / `og:image:url` / `og:image:secure_url` / `twitter:image` variants) and `iconImageUrl` (`apple-touch-icon` → `rel=icon` → header/nav `<img>` last-resort), resolving relative URLs against the final URL. Covered by existing unit tests (`og-metadata.test.ts`), including the no-tags → `{}` case.
- The create wizard already wires the result through: the settle effect calls `setSuggestions({ coverImageUrl, iconImageUrl })`, and `ListingAssetStep` receives `suggestions` and renders click-to-accept icon/cover previews on the Assets step. So when the auto-pull **succeeds**, icon/cover DO surface.

The real gap: the auto-pull fires **once per URL** (`appliedMetaRef` guard) and is pinned by `staleTime: Infinity` + `retry: false`. So a first-time **empty / errored / not-ready** pull — or a client-rendered SPA that exposes **no server-side OG tags** (the honest #3344 case) — could never be re-surfaced without editing the URL, and there was no manual button to retry. Edit mode already had the fix; create did not.

## The change (create wizard only)

- **"Pull from site"** button on the URL step, next to the App-URL input. Clicking it re-runs the OG pull for the current URL **on demand, even for the same URL** — it resets `appliedMetaRef`, bumps a tick, and calls `metaQuery.refetch()` (bypassing the once-per-url + `staleTime:Infinity` guard). Loading state while fetching; disabled for a blank/invalid URL.
- Applies **name/tagline/description fill-if-empty** (same precedence as the auto path — never clobbers typed text) and `setSuggestions({ coverImageUrl, iconImageUrl })` so the icon/cover previews appear on the Assets step.
- **Honest applied / empty / error notes** (mirror edit's `autofillNote`): "applied" only when the **site** exposed something fillable or an icon/cover (the host-derived name fallback is *not* counted as "pulled from the site", so a no-OG-tag SPA honestly reports the #3344 "add them to the page's `<head>`, or upload manually" empty state); "error" on a failed fetch, retryable via re-click.
- The existing **auto-pull-on-URL** behavior is unchanged; the button is an additional manual trigger/retry. Accepting a suggestion still routes through the normal ingest → scan → attach path (no scan bypass).

## No migration

Behavior/UI only. No server/service change — the extraction is already correct and unit-tested.

## Tests — run vs written (honest)

- **Server extraction** (`og-metadata.test.ts`, `offsiteSubmitFormConfig.oauth-fields.test.ts`): **RUN green** locally (`test:unit:run`, 48 tests). No new server test needed — no extraction bug; icon/cover + empty-case coverage already exists.
- **Client component** (`ExternalSubmitForm.browser.test.tsx`): **WRITTEN, not run locally.** The Playwright browser fails to provision in the dev sandbox (OS-unsupported fallback build; extraction stalls), so the browser-mode suite could not execute here — **CI is authoritative**. Coverage mirrors the edit-mode button's suite: the button renders in create mode + is enabled only for a valid https URL (disabled blank/non-https); a click triggers a mocked `fetchListingMetaFromUrl` and applies name/description fill-if-empty; the pulled icon/cover suggestions flow to the Assets step ("Use this" previews); typed fields are not clobbered; the SPA/no-OG-tags empty note and the error note render; and a same-url re-click bypasses the once-per-url guard via `refetch()`.
- **tsc**: clean on the changed files (`tsc --noEmit`; the only errors are the pre-existing `event-engine-common` submodule module-resolution noise in untouched `image.service.ts` / `bitdex-stats.ts`).
- **eslint**: clean on both changed files (0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
