### PR TITLE
feat(apps): surface build-failure reasons to app authors + mod-only build re-trigger for stranded approvals

### DIFF
--- a/src/components/Apps/MySubmissionsList.buildFailure.browser.test.tsx
+++ b/src/components/Apps/MySubmissionsList.buildFailure.browser.test.tsx
@@ -117,9 +117,7 @@ describe('A — the real build-failure reason reaches the author', () => {
     // text, but the renderer must ALSO escape — pin that a script-ish payload
     // becomes visible characters and creates no element.
     const hostile = 'error at <script>alert(1)</script> in <b>index.ts</b>';
-    render(
-      makeSubmission({ deployState: 'failed', deployDetail: `Build Failed\n\n${hostile}` })
-    );
+    render(makeSubmission({ deployState: 'failed', deployDetail: `Build Failed\n\n${hostile}` }));
     const block = page.getByTestId('apps-submissions-failure-detail-my-app');
     await expect.element(block).toBeInTheDocument();
     const el = block.element();
@@ -144,7 +142,9 @@ describe('A — the real build-failure reason reaches the author', () => {
   });
 
   test('the excerpt block is height-capped and scrolls — it cannot blow out the row', async () => {
-    const huge = Array.from({ length: 400 }, (_, i) => `line ${i}: something went wrong`).join('\n');
+    const huge = Array.from({ length: 400 }, (_, i) => `line ${i}: something went wrong`).join(
+      '\n'
+    );
     render(makeSubmission({ deployState: 'failed', deployDetail: `Build Failed\n\n${huge}` }));
     const block = page.getByTestId('apps-submissions-failure-detail-my-app');
     await expect.element(block).toBeInTheDocument();
@@ -175,7 +175,9 @@ describe('B — the STRANDED row stops masquerading as healthy', () => {
   test('an approved row with a null deploy state, long past approval, reads as stranded', async () => {
     render(makeSubmission({ deployState: null, deployUpdatedAt: null, reviewedAt: LONG_AGO }));
     // The BADGE text is exactly this — the row no longer wears a green "approved".
-    await expect.element(page.getByText('build never started', { exact: true })).toBeInTheDocument();
+    await expect
+      .element(page.getByText('build never started', { exact: true }))
+      .toBeInTheDocument();
     await expect.element(page.getByTestId('apps-submissions-stranded-my-app')).toBeInTheDocument();
     // And the healthy green badge is gone.
     expect(page.getByText('approved', { exact: true }).elements()).toHaveLength(0);

--- a/src/components/Apps/MySubmissionsList.buildFailure.browser.test.tsx
+++ b/src/components/Apps/MySubmissionsList.buildFailure.browser.test.tsx
@@ -1,0 +1,216 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { page } from 'vitest/browser';
+// `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
+import { renderWithProviders } from '../../../test/component-setup';
+import { DEPLOY_STALE_AFTER_MS } from '~/shared/constants/app-block-deploy.constants';
+
+/**
+ * /apps/my-submissions — the OWNER-FACING half of the build-failure fix.
+ *
+ * Two production defects are covered here:
+ *
+ *   A. A failed build showed only "Build Failed". The line that actually tells the
+ *      author what to fix lived in a build log they cannot read. The excerpt now
+ *      renders in a scroll-capped block — and it must render as TEXT, escaped,
+ *      never as markup.
+ *
+ *   B. An approved request whose build never fired rendered a healthy green
+ *      "approved" forever (the badge's `default` branch). It must now read as
+ *      stranded — but ONLY past the stale threshold, so a freshly-approved row is
+ *      byte-for-byte what it always was.
+ */
+
+const mocks = vi.hoisted(() => ({
+  invalidate: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('~/utils/notifications', () => ({
+  showSuccessNotification: vi.fn(),
+  showErrorNotification: vi.fn(),
+}));
+
+vi.mock('~/utils/trpc', () => ({
+  trpc: {
+    useUtils: () => ({ blocks: { listMyPublishRequests: { invalidate: mocks.invalidate } } }),
+    blocks: {
+      getMyAppAnalytics: { useQuery: () => ({ data: undefined, isLoading: false }) },
+      getMyApps: { useQuery: () => ({ data: [], isLoading: false }) },
+      getMyAppRepo: { useQuery: () => ({ data: undefined, isLoading: false }) },
+    },
+    appListings: {
+      unpublishOwnListing: { useMutation: () => ({ mutate: vi.fn(), isPending: false }) },
+      republishOwnListing: { useMutation: () => ({ mutate: vi.fn(), isPending: false }) },
+      listMyListingModerationEvents: {
+        useQuery: () => ({ data: { items: [], nextCursor: null }, isLoading: false, error: null }),
+      },
+    },
+  },
+  setTrpcBatchingEnabled: vi.fn(),
+}));
+
+vi.mock('~/components/AppBlocks/AppAnalyticsPanel', () => ({
+  AppAnalyticsPanel: () => <div data-testid="analytics-panel" />,
+}));
+
+import type { Submission } from './MySubmissionsList';
+const { MySubmissionsList } = await import('./MySubmissionsList');
+
+const LONG_AGO = new Date(Date.now() - DEPLOY_STALE_AFTER_MS - 60_000);
+const JUST_NOW = new Date(Date.now() - 5_000);
+
+function makeSubmission(overrides: Partial<Submission> = {}): Submission {
+  return {
+    id: 's1',
+    appBlockId: 'block-1',
+    slug: 'my-app',
+    version: '1.0.0',
+    status: 'approved',
+    submittedAt: new Date('2026-01-01T00:00:00Z'),
+    reviewedAt: LONG_AGO,
+    rejectionReason: null,
+    approvalNotes: null,
+    deployState: 'live',
+    deployDetail: null,
+    deployUpdatedAt: LONG_AGO,
+    fileSummary: {},
+    manifestDiffSummary: {},
+    modelInstallCount: 0,
+    userSubscriptionCount: 0,
+    appListingId: 'listing-1',
+    listingStatus: 'approved',
+    lastModerationAction: null,
+    hasPage: true,
+    ...overrides,
+  };
+}
+
+function render(s: Submission) {
+  renderWithProviders(
+    <MySubmissionsList submissions={[s]} onWithdraw={vi.fn()} withdrawing={false} />
+  );
+}
+
+beforeEach(() => {
+  mocks.invalidate.mockClear();
+});
+
+describe('A — the real build-failure reason reaches the author', () => {
+  const EXCERPT = 'ERROR: no package-lock.json is committed. Commit your lockfile.';
+
+  test('renders the excerpt for a failed deploy', async () => {
+    render(
+      makeSubmission({
+        deployState: 'failed',
+        deployDetail: `Build Failed\n\n${EXCERPT}`,
+      })
+    );
+    await expect
+      .element(page.getByTestId('apps-submissions-failure-detail-my-app'))
+      .toBeInTheDocument();
+    await expect.element(page.getByText(EXCERPT, { exact: false })).toBeInTheDocument();
+    // The "Build Failed" headline is still shown alongside it.
+    await expect.element(page.getByText('Build Failed', { exact: false })).toBeInTheDocument();
+  });
+
+  test('renders the excerpt as ESCAPED TEXT, never as markup', async () => {
+    // The excerpt is tenant-influenced. It is sanitized server-side to printable
+    // text, but the renderer must ALSO escape — pin that a script-ish payload
+    // becomes visible characters and creates no element.
+    const hostile = 'error at <script>alert(1)</script> in <b>index.ts</b>';
+    render(
+      makeSubmission({ deployState: 'failed', deployDetail: `Build Failed\n\n${hostile}` })
+    );
+    const block = page.getByTestId('apps-submissions-failure-detail-my-app');
+    await expect.element(block).toBeInTheDocument();
+    const el = block.element();
+    // The literal characters are present as TEXT...
+    expect(el.textContent).toContain('<script>alert(1)</script>');
+    expect(el.textContent).toContain('<b>index.ts</b>');
+    // ...and no element was ever created from them.
+    expect(el.querySelector('script')).toBeNull();
+    expect(el.querySelector('b')).toBeNull();
+  });
+
+  test('preserves newlines in a multi-line excerpt', async () => {
+    const multi = 'ERROR: build failed\n  at Object.<anonymous> (index.ts:3:9)\n  exit code 1';
+    render(makeSubmission({ deployState: 'failed', deployDetail: `Build Failed\n\n${multi}` }));
+    const block = page.getByTestId('apps-submissions-failure-detail-my-app');
+    await expect.element(block).toBeInTheDocument();
+    const el = block.element();
+    expect(el.textContent).toContain('\n');
+    expect(el.textContent).toContain('exit code 1');
+    // pre-wrap is what makes those newlines visible rather than collapsed.
+    expect(getComputedStyle(el).whiteSpace).toBe('pre-wrap');
+  });
+
+  test('the excerpt block is height-capped and scrolls — it cannot blow out the row', async () => {
+    const huge = Array.from({ length: 400 }, (_, i) => `line ${i}: something went wrong`).join('\n');
+    render(makeSubmission({ deployState: 'failed', deployDetail: `Build Failed\n\n${huge}` }));
+    const block = page.getByTestId('apps-submissions-failure-detail-my-app');
+    await expect.element(block).toBeInTheDocument();
+    const el = block.element();
+    const style = getComputedStyle(el);
+    expect(style.overflow === 'auto' || style.overflowY === 'auto').toBe(true);
+    // Rendered height stays bounded even with 400 lines of content.
+    expect(el.getBoundingClientRect().height).toBeLessThan(400);
+    expect(el.scrollHeight).toBeGreaterThan(el.clientHeight);
+  });
+
+  test('a failed deploy with NO excerpt shows the generic guidance (unchanged)', async () => {
+    render(makeSubmission({ deployState: 'failed', deployDetail: null }));
+    await expect
+      .element(page.getByText(/fix the issue and resubmit a new version/i))
+      .toBeInTheDocument();
+    expect(page.getByTestId('apps-submissions-failure-detail-my-app').elements()).toHaveLength(0);
+  });
+
+  test('a deployDetail with no excerpt renders the headline only, no code block', async () => {
+    render(makeSubmission({ deployState: 'failed', deployDetail: 'Build Failed' }));
+    await expect.element(page.getByText('Build Failed', { exact: false })).toBeInTheDocument();
+    expect(page.getByTestId('apps-submissions-failure-detail-my-app').elements()).toHaveLength(0);
+  });
+});
+
+describe('B — the STRANDED row stops masquerading as healthy', () => {
+  test('an approved row with a null deploy state, long past approval, reads as stranded', async () => {
+    render(makeSubmission({ deployState: null, deployUpdatedAt: null, reviewedAt: LONG_AGO }));
+    // The BADGE text is exactly this — the row no longer wears a green "approved".
+    await expect.element(page.getByText('build never started', { exact: true })).toBeInTheDocument();
+    await expect.element(page.getByTestId('apps-submissions-stranded-my-app')).toBeInTheDocument();
+    // And the healthy green badge is gone.
+    expect(page.getByText('approved', { exact: true }).elements()).toHaveLength(0);
+  });
+
+  test('the stranded message tells the author to contact a moderator, NOT to resubmit', async () => {
+    render(makeSubmission({ deployState: null, deployUpdatedAt: null, reviewedAt: LONG_AGO }));
+    const banner = page.getByTestId('apps-submissions-stranded-my-app');
+    await expect.element(banner).toBeInTheDocument();
+    const alert = banner.element();
+    expect(alert.textContent).toMatch(/contact a moderator/i);
+    expect(alert.textContent).toMatch(/build never started/i);
+    // The author must NOT be told to resubmit — only a moderator can fix this.
+    expect(alert.textContent).not.toMatch(/resubmit/i);
+  });
+
+  test('DARK-SAFE: a FRESHLY-approved null-state row is unchanged (still plain "approved")', async () => {
+    render(makeSubmission({ deployState: null, deployUpdatedAt: null, reviewedAt: JUST_NOW }));
+    await expect.element(page.getByText('approved', { exact: true })).toBeInTheDocument();
+    expect(page.getByText('build never started', { exact: true }).elements()).toHaveLength(0);
+    expect(page.getByTestId('apps-submissions-stranded-my-app').elements()).toHaveLength(0);
+  });
+
+  test('DARK-SAFE: a LEGACY null-state row that once transitioned is unchanged', async () => {
+    // Pre-feature approved rows can have a null state; if they carry a transition
+    // timestamp the lifecycle DID run, so they must not be flagged.
+    render(makeSubmission({ deployState: null, deployUpdatedAt: LONG_AGO, reviewedAt: LONG_AGO }));
+    expect(page.getByText('build never started', { exact: true }).elements()).toHaveLength(0);
+    expect(page.getByTestId('apps-submissions-stranded-my-app').elements()).toHaveLength(0);
+  });
+
+  test('a LIVE row is untouched by any of this', async () => {
+    render(makeSubmission({ deployState: 'live' }));
+    await expect.element(page.getByText('live', { exact: true })).toBeInTheDocument();
+    expect(page.getByText('build never started', { exact: true }).elements()).toHaveLength(0);
+    expect(page.getByTestId('apps-submissions-failure-detail-my-app').elements()).toHaveLength(0);
+  });
+});

--- a/src/components/Apps/MySubmissionsList.tsx
+++ b/src/components/Apps/MySubmissionsList.tsx
@@ -25,7 +25,7 @@ import {
   type ListingProblem,
 } from '~/components/Apps/ListingProblemsIndicator';
 import { getDetailPrimaryAction } from '~/components/Apps/appListingDetailView';
-import { isStaleDeploy } from '~/components/Apps/deploy-status';
+import { isStaleDeploy, isStrandedDeploy } from '~/components/Apps/deploy-status';
 import {
   canOwnerRepublish,
   canOwnerUnpublish,
@@ -138,8 +138,16 @@ export function formatSubmissionDate(d: string | Date): string {
   return formatDate(d, 'MMMM D, YYYY');
 }
 
+/** Copy for the STRANDED state, shared by the badge tooltip and the row alert so
+ *  the two can never drift. The author cannot fix this themselves — the approval
+ *  is durable and only a moderator can re-fire the build — so the guidance is to
+ *  ask, NOT to resubmit at a new version. */
+export const STRANDED_DEPLOY_MESSAGE =
+  'This version was approved but its build never started, so the code was never deployed. ' +
+  'This is not something you can fix by editing your app — contact a moderator to re-run the build.';
+
 export function statusBadge(
-  submission: Pick<Submission, 'status' | 'deployState' | 'deployUpdatedAt'>,
+  submission: Pick<Submission, 'status' | 'deployState' | 'deployUpdatedAt' | 'reviewedAt'>,
   /** The "live" green badge is reserved for the CURRENTLY-PUBLISHED version (the
    *  newest approved one). A previous approved version — even one whose deploy is
    *  still marked 'live' — shows a plain "approved" badge instead. */
@@ -149,6 +157,23 @@ export function statusBadge(
   // For an approved request, show the real build/deploy lifecycle rather than a
   // flat "approved" — the dev cares whether their code is actually live.
   if (status === 'approved') {
+    // STRANDED — approved long ago, but the build never started so `deployState`
+    // was never written. Checked BEFORE the switch, whose `default` branch would
+    // otherwise render a healthy green "approved" for exactly this case.
+    // `isStrandedDeploy` only fires past DEPLOY_STALE_AFTER_MS with no recorded
+    // transition, so a freshly-approved row (and every pre-feature legacy row
+    // that ever transitioned) is untouched.
+    if (isStrandedDeploy(submission)) {
+      return (
+        <Badge
+          color="orange"
+          leftSection={<IconAlertTriangle size={12} />}
+          title={STRANDED_DEPLOY_MESSAGE}
+        >
+          build never started
+        </Badge>
+      );
+    }
     if (isStaleDeploy(submission)) {
       return (
         <Badge
@@ -421,15 +446,89 @@ function OnsiteRow({
               icon={<IconAlertTriangle size={16} />}
               title="Build / deploy failed"
             >
-              <Text size="sm" style={{ whiteSpace: 'pre-wrap' }}>
-                {s.deployDetail ??
-                  'The build or deploy failed. Fix the issue and resubmit a new version.'}
-              </Text>
+              <DeployFailureDetail detail={s.deployDetail} slug={s.slug} />
+            </Alert>
+          </Table.Td>
+        </Table.Tr>
+      )}
+      {s.status === 'approved' && isStrandedDeploy(s) && (
+        <Table.Tr>
+          <Table.Td colSpan={8} p={0}>
+            <Alert
+              color="orange"
+              variant="light"
+              radius={0}
+              icon={<IconAlertTriangle size={16} />}
+              title="Approved, but the build never started"
+              data-testid={`apps-submissions-stranded-${s.slug}`}
+            >
+              <Text size="sm">{STRANDED_DEPLOY_MESSAGE}</Text>
             </Alert>
           </Table.Td>
         </Table.Tr>
       )}
     </>
+  );
+}
+
+/**
+ * The build/deploy failure body shown to the APP AUTHOR.
+ *
+ * `deployDetail` is now `"Build <status>"` plus, when the pipeline sent one, a
+ * blank line and a sanitized excerpt of the real build log — the line that
+ * actually tells the author what to fix ("no package-lock.json is committed…").
+ * Before this, that line existed only in a build log they cannot read.
+ *
+ * RENDERING SAFETY — the excerpt originates from tenant-influenced build output.
+ * It is sanitized server-side to printable text + newlines
+ * (`sanitizeBuildFailureReason`) AND rendered here through ordinary React text
+ * interpolation, which escapes. There is deliberately no `dangerouslySetInnerHTML`
+ * anywhere on this path, so even a hostile excerpt renders as literal characters.
+ *
+ * LAYOUT — the excerpt is capped at ~14rem of scrollable height and scrolls on
+ * BOTH axes inside its own box, so a multi-KB stack trace or a very long line can
+ * never blow out the table row or push the page into horizontal scroll.
+ */
+function DeployFailureDetail({ detail, slug }: { detail: string | null; slug: string }) {
+  const fallback = 'The build or deploy failed. Fix the issue and resubmit a new version.';
+  if (!detail) {
+    return <Text size="sm">{fallback}</Text>;
+  }
+  // Split the "Build <status>" headline from the log excerpt (the server joins
+  // them with a blank line). No excerpt → the headline is the whole message and
+  // renders exactly as it did before this feature.
+  const separator = detail.indexOf('\n\n');
+  const headline = separator === -1 ? detail : detail.slice(0, separator);
+  const excerpt = separator === -1 ? null : detail.slice(separator + 2);
+  return (
+    <Stack gap={6}>
+      <Text size="sm" style={{ whiteSpace: 'pre-wrap' }}>
+        {headline}
+      </Text>
+      {excerpt && (
+        // A plain <pre> rather than Mantine's <Code block>: the excerpt needs
+        // `pre-wrap` + a hard height cap, and owning the styles outright keeps
+        // that guarantee independent of the component library's own CSS.
+        <pre
+          data-testid={`apps-submissions-failure-detail-${slug}`}
+          style={{
+            margin: 0,
+            padding: '0.5rem 0.65rem',
+            borderRadius: 4,
+            fontSize: '0.75rem',
+            lineHeight: 1.45,
+            fontFamily: 'var(--mantine-font-family-monospace, monospace)',
+            background: 'var(--mantine-color-default, rgba(0,0,0,0.06))',
+            whiteSpace: 'pre-wrap',
+            overflowWrap: 'anywhere',
+            maxHeight: '14rem',
+            overflow: 'auto',
+          }}
+        >
+          {excerpt}
+        </pre>
+      )}
+    </Stack>
   );
 }
 

--- a/src/components/Apps/OnsiteReviewModal.tsx
+++ b/src/components/Apps/OnsiteReviewModal.tsx
@@ -113,6 +113,13 @@ export type ApprovedRequest = ReviewedRequestCommon & {
   reviewedAt: string | Date | null;
   approvalNotes: string | null;
   reviewedBy: UserProfile | null;
+  /** Build/deploy lifecycle for the approved version — `null` means either a
+   *  legacy pre-feature row OR the STRANDED case (approved, but the build never
+   *  started). Selected by `listApprovedRequests`; optional so older callers /
+   *  fixtures that omit it still typecheck. */
+  deployState?: string | null;
+  deployDetail?: string | null;
+  deployUpdatedAt?: string | Date | null;
 };
 
 export type RejectedRequest = ReviewedRequestCommon & {

--- a/src/components/Apps/UnifiedReviewList.retrigger.browser.test.tsx
+++ b/src/components/Apps/UnifiedReviewList.retrigger.browser.test.tsx
@@ -97,7 +97,9 @@ describe('Approved tab — the Deploy column exposes a stranded approval', () =>
   test('the Deploy column and control are ABSENT when no handler is passed (Rejected tab)', async () => {
     renderApproved({ row: onsiteRow(), onRetrigger: undefined });
     // The row still renders...
-    await expect.element(page.getByTestId('apps-unified-review-row-onsite:req-1')).toBeInTheDocument();
+    await expect
+      .element(page.getByTestId('apps-unified-review-row-onsite:req-1'))
+      .toBeInTheDocument();
     // ...with no Deploy column and no retrigger control.
     expect(page.getByTestId(DEPLOY_CHIP).elements()).toHaveLength(0);
     expect(page.getByTestId(RETRIGGER).elements()).toHaveLength(0);

--- a/src/components/Apps/UnifiedReviewList.retrigger.browser.test.tsx
+++ b/src/components/Apps/UnifiedReviewList.retrigger.browser.test.tsx
@@ -1,0 +1,199 @@
+import { describe, expect, test, vi } from 'vitest';
+import { page } from 'vitest/browser';
+// `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
+import { renderWithProviders } from '../../../test/component-setup';
+import { DEPLOY_STALE_AFTER_MS } from '~/shared/constants/app-block-deploy.constants';
+import type { OffsitePendingRow } from './OffsiteReviewQueue';
+import type { OnsiteReviewRequest } from './unifiedReviewRow';
+
+/**
+ * /apps/review APPROVED tab — the MODERATOR half of the fix.
+ *
+ * A production approval whose build never fired left `deploy_state` NULL forever.
+ * In the mod queue that was indistinguishable from a healthy approval, and there
+ * was no way to re-run the build (`approveRequest` is not idempotent), so the only
+ * recovery was asking the developer to resubmit at a new version.
+ *
+ * These tests pin: the Deploy column surfaces the "never built" state; the
+ * "Retrigger build" control appears and is enabled exactly where the server would
+ * accept it; and a double-click cannot fire the mutation twice.
+ */
+
+const LONG_AGO = new Date(Date.now() - DEPLOY_STALE_AFTER_MS - 60_000);
+const JUST_NOW = new Date(Date.now() - 30_000);
+
+function onsiteRow(over: Partial<Record<string, unknown>> = {}): OnsiteReviewRequest {
+  return {
+    id: 'req-1',
+    appBlockId: 'apb_1',
+    slug: 'my-onsite',
+    version: '1.0.0',
+    submittedAt: '2026-01-01T00:00:00Z',
+    reviewedAt: LONG_AGO,
+    approvalNotes: null,
+    reviewedBy: null,
+    bundleSizeBytes: '10',
+    bundleSha256: 'sha',
+    manifest: { name: 'My Onsite App' },
+    fileSummary: {},
+    manifestDiffSummary: {},
+    reviewRepoUrl: 'https://example.invalid/repo',
+    submittedBy: { id: 7, username: 'onsite-dev', image: null },
+    // The lifecycle projection `listApprovedRequests` now selects.
+    deployState: null,
+    deployDetail: null,
+    deployUpdatedAt: null,
+    ...over,
+  } as unknown as OnsiteReviewRequest;
+}
+
+const { UnifiedReviewList } = await import('./UnifiedReviewList');
+
+function renderApproved(opts: {
+  row: OnsiteReviewRequest;
+  onRetrigger?: (id: string) => void;
+  retriggeringId?: string | null;
+}) {
+  renderWithProviders(
+    <UnifiedReviewList
+      onsiteItems={[opts.row]}
+      offsiteItems={[]}
+      direction="desc"
+      openOnsiteReview={vi.fn()}
+      openOffsiteReview={vi.fn() as unknown as (r: OffsitePendingRow) => void}
+      isLoading={false}
+      emptyLabel="empty"
+      dateLabel="Reviewed"
+      actionLabel="View"
+      hasMore={false}
+      onLoadMore={vi.fn()}
+      onRetriggerBuild={opts.onRetrigger}
+      retriggeringId={opts.retriggeringId ?? null}
+    />
+  );
+}
+
+const RETRIGGER = 'apps-unified-review-retrigger-onsite:req-1';
+const DEPLOY_CHIP = 'apps-unified-review-deploy-onsite:req-1';
+
+describe('Approved tab — the Deploy column exposes a stranded approval', () => {
+  test('a null deploy state renders as "never built", not as a healthy approval', async () => {
+    renderApproved({ row: onsiteRow(), onRetrigger: vi.fn() });
+    const chip = page.getByTestId(DEPLOY_CHIP);
+    await expect.element(chip).toBeInTheDocument();
+    expect(chip.element().textContent).toMatch(/never built/i);
+  });
+
+  test('a live deploy renders its real state', async () => {
+    renderApproved({
+      row: onsiteRow({ deployState: 'live', deployUpdatedAt: LONG_AGO }),
+      onRetrigger: vi.fn(),
+    });
+    const chip = page.getByTestId(DEPLOY_CHIP);
+    await expect.element(chip).toBeInTheDocument();
+    expect(chip.element().textContent).toMatch(/live/i);
+  });
+
+  test('the Deploy column and control are ABSENT when no handler is passed (Rejected tab)', async () => {
+    renderApproved({ row: onsiteRow(), onRetrigger: undefined });
+    // The row still renders...
+    await expect.element(page.getByTestId('apps-unified-review-row-onsite:req-1')).toBeInTheDocument();
+    // ...with no Deploy column and no retrigger control.
+    expect(page.getByTestId(DEPLOY_CHIP).elements()).toHaveLength(0);
+    expect(page.getByTestId(RETRIGGER).elements()).toHaveLength(0);
+    expect(page.getByText('Deploy', { exact: true }).elements()).toHaveLength(0);
+  });
+});
+
+describe('Approved tab — the Retrigger control follows the server gate', () => {
+  test('ENABLED for a stranded (null-state) approval', async () => {
+    renderApproved({ row: onsiteRow(), onRetrigger: vi.fn() });
+    const btn = page.getByTestId(RETRIGGER);
+    await expect.element(btn).toBeInTheDocument();
+    expect((btn.element() as HTMLButtonElement).disabled).toBe(false);
+  });
+
+  test('ENABLED for a failed build', async () => {
+    renderApproved({
+      row: onsiteRow({ deployState: 'failed', deployUpdatedAt: JUST_NOW }),
+      onRetrigger: vi.fn(),
+    });
+    const btn = page.getByTestId(RETRIGGER);
+    await expect.element(btn).toBeInTheDocument();
+    expect((btn.element() as HTMLButtonElement).disabled).toBe(false);
+  });
+
+  test('DISABLED for a live deploy — nothing to recover', async () => {
+    renderApproved({
+      row: onsiteRow({ deployState: 'live', deployUpdatedAt: LONG_AGO }),
+      onRetrigger: vi.fn(),
+    });
+    const btn = page.getByTestId(RETRIGGER);
+    await expect.element(btn).toBeInTheDocument();
+    expect((btn.element() as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  test('DISABLED for a build that is still genuinely in flight', async () => {
+    renderApproved({
+      row: onsiteRow({ deployState: 'building', deployUpdatedAt: JUST_NOW }),
+      onRetrigger: vi.fn(),
+    });
+    const btn = page.getByTestId(RETRIGGER);
+    await expect.element(btn).toBeInTheDocument();
+    expect((btn.element() as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  test('ENABLED once an in-flight build has stalled past the shared threshold', async () => {
+    renderApproved({
+      row: onsiteRow({ deployState: 'building', deployUpdatedAt: LONG_AGO }),
+      onRetrigger: vi.fn(),
+    });
+    const btn = page.getByTestId(RETRIGGER);
+    await expect.element(btn).toBeInTheDocument();
+    expect((btn.element() as HTMLButtonElement).disabled).toBe(false);
+  });
+});
+
+describe('Approved tab — the control cannot double-fire', () => {
+  test('requires a CONFIRM click, then fires ONCE with the publish-request id', async () => {
+    const onRetrigger = vi.fn();
+    renderApproved({ row: onsiteRow(), onRetrigger });
+    const btn = page.getByTestId(RETRIGGER);
+    await expect.element(btn).toBeInTheDocument();
+
+    // First click ARMS — it must not fire the mutation.
+    await btn.click();
+    expect(onRetrigger).not.toHaveBeenCalled();
+    expect(btn.element().textContent).toMatch(/confirm/i);
+
+    // Second click fires, exactly once, with only the request id.
+    await btn.click();
+    expect(onRetrigger).toHaveBeenCalledTimes(1);
+    expect(onRetrigger).toHaveBeenCalledWith('req-1');
+  });
+
+  test('a rapid DOUBLE-CLICK arms then fires ONCE — never twice', async () => {
+    const onRetrigger = vi.fn();
+    renderApproved({ row: onsiteRow(), onRetrigger });
+    const btn = page.getByTestId(RETRIGGER);
+    await expect.element(btn).toBeInTheDocument();
+    await btn.dblClick();
+    expect(onRetrigger).toHaveBeenCalledTimes(1);
+  });
+
+  test('is disabled while ITS OWN mutation is in flight', async () => {
+    const onRetrigger = vi.fn();
+    renderApproved({ row: onsiteRow(), onRetrigger, retriggeringId: 'req-1' });
+    const btn = page.getByTestId(RETRIGGER);
+    await expect.element(btn).toBeInTheDocument();
+    expect((btn.element() as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  test('another row in flight does NOT disable this row', async () => {
+    const onRetrigger = vi.fn();
+    renderApproved({ row: onsiteRow(), onRetrigger, retriggeringId: 'some-other-request' });
+    const btn = page.getByTestId(RETRIGGER);
+    await expect.element(btn).toBeInTheDocument();
+    expect((btn.element() as HTMLButtonElement).disabled).toBe(false);
+  });
+});

--- a/src/components/Apps/UnifiedReviewList.retrigger.browser.test.tsx
+++ b/src/components/Apps/UnifiedReviewList.retrigger.browser.test.tsx
@@ -115,6 +115,16 @@ describe('Approved tab — the Retrigger control follows the server gate', () =>
     expect((btn.element() as HTMLButtonElement).disabled).toBe(false);
   });
 
+  test('DISABLED for a JUST-approved null state — the first build may still be starting', async () => {
+    // Mirrors the server's grace bound: approveRequest awaits triggerBuild BEFORE
+    // writing 'building', so a null state moments after approval is not evidence
+    // of a stranded row and re-firing would race a second PipelineRun.
+    renderApproved({ row: onsiteRow({ reviewedAt: JUST_NOW }), onRetrigger: vi.fn() });
+    const btn = page.getByTestId(RETRIGGER);
+    await expect.element(btn).toBeInTheDocument();
+    expect((btn.element() as HTMLButtonElement).disabled).toBe(true);
+  });
+
   test('ENABLED for a failed build', async () => {
     renderApproved({
       row: onsiteRow({ deployState: 'failed', deployUpdatedAt: JUST_NOW }),

--- a/src/components/Apps/UnifiedReviewList.tsx
+++ b/src/components/Apps/UnifiedReviewList.tsx
@@ -1,7 +1,14 @@
 import { Alert, Badge, Button, Card, Code, Group, Stack, Table, Text } from '@mantine/core';
-import { IconAlertTriangle, IconCheck, IconClock, IconExternalLink } from '@tabler/icons-react';
-import { useMemo } from 'react';
+import {
+  IconAlertTriangle,
+  IconCheck,
+  IconClock,
+  IconExternalLink,
+  IconRefresh,
+} from '@tabler/icons-react';
+import { useMemo, useState } from 'react';
 import type { OffsitePendingRow } from '~/components/Apps/OffsiteReviewQueue';
+import { canRetriggerBuild } from '~/components/Apps/deploy-status';
 import {
   mergeReviewRows,
   offsiteRequestToUnifiedRow,
@@ -38,6 +45,8 @@ export function UnifiedReviewList({
   hasMore,
   isLoadingMore,
   onLoadMore,
+  onRetriggerBuild,
+  retriggeringId,
 }: {
   onsiteItems: OnsiteReviewRequest[];
   offsiteItems: OffsiteReviewRequest[];
@@ -64,12 +73,24 @@ export function UnifiedReviewList({
   hasMore: boolean;
   isLoadingMore?: boolean;
   onLoadMore: () => void;
+  /** APPROVED tab only. When provided, rows that carry a deploy projection render a
+   *  Deploy column (including the STRANDED "build never started" state) plus a
+   *  "Retrigger build" control wired to `blocks.retriggerBuild`. Omitted on the
+   *  Pending/Rejected tabs, where neither exists — so those tabs are unchanged. */
+  onRetriggerBuild?: (publishRequestId: string) => void;
+  /** The publish-request id currently being re-triggered — disables + spins ITS
+   *  button only, so a double-click cannot fire the mutation twice client-side. */
+  retriggeringId?: string | null;
 }) {
   const rows = useMemo(() => {
     const onsiteRows = onsiteItems.map((r) => onsiteRequestToUnifiedRow(r, openOnsiteReview));
     const offsiteRows = offsiteItems.map((r) => offsiteRequestToUnifiedRow(r, openOffsiteReview));
     return mergeReviewRows(onsiteRows, offsiteRows, direction, openCombinedReview);
   }, [onsiteItems, offsiteItems, direction, openOnsiteReview, openOffsiteReview, openCombinedReview]);
+
+  // The Deploy column exists only where a retrigger handler was supplied (the
+  // Approved tab). Pending/Rejected render exactly as before.
+  const showDeploy = !!onRetriggerBuild;
 
   return (
     <Stack gap="md">
@@ -103,12 +124,20 @@ export function UnifiedReviewList({
                 <Table.Th>App</Table.Th>
                 <Table.Th>Submitter</Table.Th>
                 <Table.Th>{dateLabel}</Table.Th>
+                {showDeploy && <Table.Th>Deploy</Table.Th>}
                 <Table.Th />
               </Table.Tr>
             </Table.Thead>
             <Table.Tbody>
               {rows.map((row) => (
-                <UnifiedReviewRowView key={row.key} row={row} actionLabel={actionLabel} />
+                <UnifiedReviewRowView
+                  key={row.key}
+                  row={row}
+                  actionLabel={actionLabel}
+                  showDeploy={showDeploy}
+                  onRetriggerBuild={onRetriggerBuild}
+                  retriggeringId={retriggeringId ?? null}
+                />
               ))}
             </Table.Tbody>
           </Table>
@@ -132,8 +161,114 @@ export function UnifiedReviewList({
   );
 }
 
-function UnifiedReviewRowView({ row, actionLabel }: { row: UnifiedReviewRow; actionLabel: string }) {
+/**
+ * Deploy-state chip for an on-site APPROVED row. The point of this column is the
+ * `null` case: an approval whose build never started looked, until now, exactly
+ * like a healthy one in the mod queue.
+ */
+function DeployStateChip({ state, rowKey }: { state: string | null; rowKey: string }) {
+  const testId = `apps-unified-review-deploy-${rowKey}`;
+  if (state === null || state === undefined) {
+    return (
+      <Badge
+        size="sm"
+        color="orange"
+        variant="light"
+        leftSection={<IconAlertTriangle size={11} />}
+        title="No build was ever recorded for this approval — the build most likely never started."
+        data-testid={testId}
+      >
+        never built
+      </Badge>
+    );
+  }
+  const color =
+    state === 'live'
+      ? 'green'
+      : state === 'failed'
+      ? 'red'
+      : state.startsWith('preview-')
+      ? 'grape'
+      : 'blue';
+  return (
+    <Badge size="sm" color={color} variant="light" data-testid={testId}>
+      {state}
+    </Badge>
+  );
+}
+
+/**
+ * "Retrigger build" — re-fires the Tekton build for an already-approved request
+ * using its STORED commit sha (the mutation takes only the request id).
+ *
+ * Two independent double-fire guards, because a duplicated PipelineRun is the
+ * failure mode here:
+ *   1. `armed` — the first click asks for confirmation, the second fires. A stray
+ *      double-click therefore arms-then-fires ONCE rather than firing twice.
+ *   2. `busy` — while the mutation for THIS row is in flight the button is both
+ *      `disabled` and `loading`.
+ * The server holds the authoritative guard anyway (a per-request redis NX lock).
+ */
+function RetriggerBuildButton({
+  publishRequestId,
+  disabled,
+  busy,
+  onRetrigger,
+  rowKey,
+}: {
+  publishRequestId: string;
+  disabled: boolean;
+  busy: boolean;
+  onRetrigger: (publishRequestId: string) => void;
+  rowKey: string;
+}) {
+  const [armed, setArmed] = useState(false);
+  return (
+    <Button
+      size="compact-xs"
+      variant={armed ? 'filled' : 'default'}
+      color={armed ? 'orange' : undefined}
+      leftSection={<IconRefresh size={12} />}
+      disabled={disabled || busy}
+      loading={busy}
+      title={
+        disabled
+          ? 'This version is deployed (or a build is still running) — nothing to re-trigger.'
+          : 'Re-run the build for the commit that was already approved.'
+      }
+      data-testid={`apps-unified-review-retrigger-${rowKey}`}
+      onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
+        // The row's other cells open the review modal on click; this control must
+        // not also do that.
+        e.stopPropagation();
+        if (!armed) {
+          setArmed(true);
+          return;
+        }
+        setArmed(false);
+        onRetrigger(publishRequestId);
+      }}
+    >
+      {armed ? 'Confirm rebuild' : 'Retrigger build'}
+    </Button>
+  );
+}
+
+function UnifiedReviewRowView({
+  row,
+  actionLabel,
+  showDeploy,
+  onRetriggerBuild,
+  retriggeringId,
+}: {
+  row: UnifiedReviewRow;
+  actionLabel: string;
+  showDeploy: boolean;
+  onRetriggerBuild?: (publishRequestId: string) => void;
+  retriggeringId: string | null;
+}) {
   const submitter = row.submitter;
+  const deploy = row.deploy;
   return (
     <Table.Tr style={{ cursor: 'pointer' }} data-testid={`apps-unified-review-row-${row.key}`}>
       <Table.Td onClick={row.onReview}>
@@ -167,6 +302,28 @@ function UnifiedReviewRowView({ row, actionLabel }: { row: UnifiedReviewRow; act
           <Text size="xs">{row.submittedAt.toLocaleString()}</Text>
         </Group>
       </Table.Td>
+      {showDeploy && (
+        <Table.Td>
+          {deploy ? (
+            <Stack gap={4} align="flex-start">
+              <DeployStateChip state={deploy.state} rowKey={row.key} />
+              {onRetriggerBuild && (
+                <RetriggerBuildButton
+                  publishRequestId={deploy.publishRequestId}
+                  rowKey={row.key}
+                  disabled={!canRetriggerBuild(deploy)}
+                  busy={retriggeringId === deploy.publishRequestId}
+                  onRetrigger={onRetriggerBuild}
+                />
+              )}
+            </Stack>
+          ) : (
+            <Text size="xs" c="dimmed">
+              —
+            </Text>
+          )}
+        </Table.Td>
+      )}
       <Table.Td>
         <Button
           size="xs"

--- a/src/components/Apps/__tests__/deploy-status.test.ts
+++ b/src/components/Apps/__tests__/deploy-status.test.ts
@@ -10,6 +10,11 @@ import {
   isStrandedDeploy,
   type DeployLifecycleRow,
 } from '../deploy-status';
+import {
+  DEPLOY_STATE_TRACKING_EPOCH_MS,
+  isApprovedAndServing,
+  isStrandedApprovedDeploy,
+} from '~/shared/constants/app-block-deploy.constants';
 
 const NOW = 1_700_000_000_000;
 const fresh = new Date(NOW - 60_000); // 1 min ago
@@ -204,7 +209,32 @@ describe('isAwaitingDeployState', () => {
  * refuse, so its truth table is pinned against the same shared threshold.
  */
 describe('canRetriggerBuild', () => {
-  it('allows the STRANDED case (null state)', () => {
+  it('allows the STRANDED case (null state) once past the approval grace window', () => {
+    expect(canRetriggerBuild({ state: null, updatedAt: null, reviewedAt: stale }, NOW)).toBe(true);
+  });
+
+  it('refuses a JUST-approved null state — its first build may still be starting', () => {
+    // Mirrors the server: approveRequest awaits triggerBuild BEFORE writing
+    // 'building', so a null state inside the grace window is not evidence of a
+    // stranded row — re-firing there races a second PipelineRun.
+    expect(
+      canRetriggerBuild({ state: null, updatedAt: null, reviewedAt: new Date(NOW - 1_000) }, NOW)
+    ).toBe(false);
+    expect(
+      canRetriggerBuild(
+        { state: null, updatedAt: null, reviewedAt: new Date(NOW - DEPLOY_PENDING_GRACE_MS) },
+        NOW
+      )
+    ).toBe(false);
+    expect(
+      canRetriggerBuild(
+        { state: null, updatedAt: null, reviewedAt: new Date(NOW - DEPLOY_PENDING_GRACE_MS - 1) },
+        NOW
+      )
+    ).toBe(true);
+  });
+
+  it('stays permissive with NO anchor — the server is the authority, not this hint', () => {
     expect(canRetriggerBuild({ state: null, updatedAt: null }, NOW)).toBe(true);
   });
 
@@ -242,5 +272,118 @@ describe('canRetriggerBuild', () => {
 
   it('refuses an unrecognized state rather than guessing', () => {
     expect(canRetriggerBuild({ state: 'something-new', updatedAt: stale }, NOW)).toBe(false);
+  });
+});
+
+/**
+ * `isApprovedAndServing` — the predicate behind `liveUrl` on the CLI-facing
+ * `/api/v1/blocks/submissions`.
+ *
+ * The whole difficulty is that `deployState === null` covers TWO opposite
+ * realities. Reporting a STRANDED approval as live re-creates the invisible
+ * failure this feature exists to remove; refusing a LEGACY pre-tracking row its
+ * URL regresses apps that genuinely deployed. Both directions are pinned below.
+ */
+describe('isApprovedAndServing', () => {
+  const AFTER_EPOCH = DEPLOY_STATE_TRACKING_EPOCH_MS + 30 * 24 * 60 * 60 * 1000;
+  const BEFORE_EPOCH = DEPLOY_STATE_TRACKING_EPOCH_MS - 30 * 24 * 60 * 60 * 1000;
+
+  const approved = (over: Record<string, unknown> = {}) => ({
+    status: 'approved',
+    deployState: null as string | null,
+    deployUpdatedAt: null as Date | null,
+    reviewedAt: new Date(AFTER_EPOCH),
+    ...over,
+  });
+
+  it("only 'live' is a positive deploy state", () => {
+    expect(isApprovedAndServing(approved({ deployState: 'live' }))).toBe(true);
+    for (const s of ['building', 'deploying', 'failed', 'preview-live']) {
+      expect(isApprovedAndServing(approved({ deployState: s }))).toBe(false);
+    }
+  });
+
+  it('false for any non-approved status, however it deployed', () => {
+    for (const st of ['pending', 'rejected', 'withdrawn']) {
+      expect(isApprovedAndServing(approved({ status: st, deployState: 'live' }))).toBe(
+        false
+      );
+    }
+  });
+
+  it('STRANDED null (tracked era, nothing ever transitioned) is NOT serving', () => {
+    expect(isApprovedAndServing(approved())).toBe(false);
+  });
+
+  it('LEGACY null (approved before tracking began) IS serving', () => {
+    expect(isApprovedAndServing(approved({ reviewedAt: new Date(BEFORE_EPOCH) }))).toBe(
+      true
+    );
+  });
+
+  it('is EXCLUSIVE at the epoch instant itself', () => {
+    // Approved exactly at the epoch counts as tracked (>= epoch → not legacy).
+    expect(
+      isApprovedAndServing(approved({ reviewedAt: new Date(DEPLOY_STATE_TRACKING_EPOCH_MS) }))
+    ).toBe(false);
+    expect(
+      isApprovedAndServing(approved({ reviewedAt: new Date(DEPLOY_STATE_TRACKING_EPOCH_MS - 1) }))
+    ).toBe(true);
+  });
+
+  it('a recorded transition means the lifecycle ran — serving, whatever the date', () => {
+    expect(
+      isApprovedAndServing(approved({ deployUpdatedAt: new Date(AFTER_EPOCH + 1000) }))
+    ).toBe(true);
+  });
+
+  it('fails toward SERVING when there is no anchor at all (never removes a right URL)', () => {
+    expect(isApprovedAndServing(approved({ reviewedAt: null }))).toBe(true);
+  });
+
+  it('accepts ISO strings as well as Dates (the REST/JSON path)', () => {
+    expect(
+      isApprovedAndServing(approved({ reviewedAt: new Date(BEFORE_EPOCH).toISOString() }))
+    ).toBe(true);
+    expect(
+      isApprovedAndServing(approved({ reviewedAt: new Date(AFTER_EPOCH).toISOString() }))
+    ).toBe(false);
+  });
+});
+
+describe('isStrandedApprovedDeploy', () => {
+  const AFTER_EPOCH = DEPLOY_STATE_TRACKING_EPOCH_MS + 30 * 24 * 60 * 60 * 1000;
+  const BEFORE_EPOCH = DEPLOY_STATE_TRACKING_EPOCH_MS - 30 * 24 * 60 * 60 * 1000;
+  const base = (over: Record<string, unknown> = {}) => ({
+    status: 'approved',
+    deployState: null as string | null,
+    deployUpdatedAt: null as Date | null,
+    reviewedAt: new Date(AFTER_EPOCH),
+    ...over,
+  });
+
+  it('true past the stale threshold in the tracked era', () => {
+    expect(isStrandedApprovedDeploy(base(), AFTER_EPOCH + DEPLOY_STALE_AFTER_MS + 1)).toBe(true);
+  });
+
+  it('false while still inside the stale window (may yet transition)', () => {
+    expect(isStrandedApprovedDeploy(base(), AFTER_EPOCH + DEPLOY_STALE_AFTER_MS)).toBe(false);
+  });
+
+  it('NEVER flags a LEGACY pre-tracking approval, however old', () => {
+    expect(
+      isStrandedApprovedDeploy(
+        base({ reviewedAt: new Date(BEFORE_EPOCH) }),
+        AFTER_EPOCH + DEPLOY_STALE_AFTER_MS * 100
+      )
+    ).toBe(false);
+  });
+
+  it('false once any deploy state exists', () => {
+    for (const s of ['building', 'live', 'failed']) {
+      expect(
+        isStrandedApprovedDeploy(base({ deployState: s }), AFTER_EPOCH + DEPLOY_STALE_AFTER_MS + 1)
+      ).toBe(false);
+    }
   });
 });

--- a/src/components/Apps/__tests__/deploy-status.test.ts
+++ b/src/components/Apps/__tests__/deploy-status.test.ts
@@ -1,9 +1,13 @@
 import { describe, expect, it } from 'vitest';
 import {
+  DEPLOY_PENDING_GRACE_MS,
   DEPLOY_STALE_AFTER_MS,
+  canRetriggerBuild,
   deployRefetchInterval,
+  isAwaitingDeployState,
   isInFlightDeploy,
   isStaleDeploy,
+  isStrandedDeploy,
   type DeployLifecycleRow,
 } from '../deploy-status';
 
@@ -15,6 +19,15 @@ const row = (over: Partial<DeployLifecycleRow> = {}): DeployLifecycleRow => ({
   status: 'approved',
   deployState: 'building',
   deployUpdatedAt: fresh,
+  ...over,
+});
+
+/** A row in the STRANDED shape: approved, no deploy state, no transition ever. */
+const strandedRow = (over: Partial<DeployLifecycleRow> = {}): DeployLifecycleRow => ({
+  status: 'approved',
+  deployState: null,
+  deployUpdatedAt: null,
+  reviewedAt: stale,
   ...over,
 });
 
@@ -81,5 +94,153 @@ describe('deployRefetchInterval', () => {
         NOW
       )
     ).toBe(30000);
+  });
+
+  it('polls a just-approved row awaiting its first deploy-state write', () => {
+    const justApproved = strandedRow({ reviewedAt: new Date(NOW - 5_000) });
+    expect(deployRefetchInterval([justApproved], NOW)).toBe(5000);
+  });
+
+  it('does NOT poll a STRANDED row forever — nothing will ever change it', () => {
+    expect(deployRefetchInterval([strandedRow()], NOW)).toBe(false);
+  });
+
+  it('does NOT poll a null-state row past the grace window but before stranding', () => {
+    const between = strandedRow({ reviewedAt: new Date(NOW - DEPLOY_PENDING_GRACE_MS - 1_000) });
+    expect(deployRefetchInterval([between], NOW)).toBe(false);
+  });
+});
+
+/**
+ * STRANDED — the defect-B signature: `approveRequest` made the approval durable
+ * (status='approved' + forgejo_commit_sha) and then threw inside `triggerBuild`,
+ * so `markRequestDeployState` was never reached and `deploy_state` stayed NULL.
+ * Before this predicate, the badge's `default` branch rendered these as a healthy
+ * green "approved" forever.
+ *
+ * The boundaries below are the DARK-SAFETY contract: a freshly approved row and a
+ * legacy row that ever transitioned must NOT be flagged.
+ */
+describe('isStrandedDeploy', () => {
+  it('true for an approved row with no state and no transition, past the threshold', () => {
+    expect(isStrandedDeploy(strandedRow(), NOW)).toBe(true);
+  });
+
+  it('false immediately after approval (the real approve → mark race window)', () => {
+    expect(isStrandedDeploy(strandedRow({ reviewedAt: new Date(NOW) }), NOW)).toBe(false);
+    expect(isStrandedDeploy(strandedRow({ reviewedAt: new Date(NOW - 1_000) }), NOW)).toBe(false);
+  });
+
+  it('is EXCLUSIVE at exactly the threshold, and true one ms past it', () => {
+    const atThreshold = new Date(NOW - DEPLOY_STALE_AFTER_MS);
+    const pastThreshold = new Date(NOW - DEPLOY_STALE_AFTER_MS - 1);
+    expect(isStrandedDeploy(strandedRow({ reviewedAt: atThreshold }), NOW)).toBe(false);
+    expect(isStrandedDeploy(strandedRow({ reviewedAt: pastThreshold }), NOW)).toBe(true);
+  });
+
+  it('false when ANY deploy state is set, however old', () => {
+    for (const s of ['building', 'deploying', 'live', 'failed'] as const) {
+      expect(isStrandedDeploy(strandedRow({ deployState: s }), NOW)).toBe(false);
+    }
+  });
+
+  it('false for a LEGACY row that ever transitioned (deployUpdatedAt present)', () => {
+    // A pre-feature approved row could have a null state; if it also carries a
+    // transition timestamp, the lifecycle DID run and it is not stranded.
+    expect(isStrandedDeploy(strandedRow({ deployUpdatedAt: stale }), NOW)).toBe(false);
+  });
+
+  it('false when there is no reviewedAt anchor to measure from', () => {
+    expect(isStrandedDeploy(strandedRow({ reviewedAt: null }), NOW)).toBe(false);
+    expect(isStrandedDeploy(strandedRow({ reviewedAt: undefined }), NOW)).toBe(false);
+  });
+
+  it('false for non-approved rows regardless of age', () => {
+    for (const st of ['pending', 'rejected', 'withdrawn']) {
+      expect(isStrandedDeploy(strandedRow({ status: st }), NOW)).toBe(false);
+    }
+  });
+
+  it('parses an ISO-string reviewedAt (defensive non-superjson path)', () => {
+    expect(isStrandedDeploy(strandedRow({ reviewedAt: stale.toISOString() }), NOW)).toBe(true);
+    expect(isStrandedDeploy(strandedRow({ reviewedAt: new Date(NOW).toISOString() }), NOW)).toBe(
+      false
+    );
+  });
+
+  it('is never simultaneously true with isStaleDeploy (disjoint states)', () => {
+    const s = strandedRow();
+    expect(isStrandedDeploy(s, NOW) && isStaleDeploy(s, NOW)).toBe(false);
+  });
+});
+
+describe('isAwaitingDeployState', () => {
+  it('true only inside the post-approval grace window', () => {
+    expect(isAwaitingDeployState(strandedRow({ reviewedAt: new Date(NOW - 1_000) }), NOW)).toBe(true);
+    expect(
+      isAwaitingDeployState(strandedRow({ reviewedAt: new Date(NOW - DEPLOY_PENDING_GRACE_MS) }), NOW)
+    ).toBe(true);
+    expect(
+      isAwaitingDeployState(
+        strandedRow({ reviewedAt: new Date(NOW - DEPLOY_PENDING_GRACE_MS - 1) }),
+        NOW
+      )
+    ).toBe(false);
+  });
+
+  it('false once a deploy state exists', () => {
+    expect(
+      isAwaitingDeployState(
+        strandedRow({ deployState: 'building', reviewedAt: new Date(NOW) }),
+        NOW
+      )
+    ).toBe(false);
+  });
+});
+
+/**
+ * The CLIENT MIRROR of the server's retrigger gate. Not a security boundary — the
+ * server re-checks everything — but it must not offer a button the server will
+ * refuse, so its truth table is pinned against the same shared threshold.
+ */
+describe('canRetriggerBuild', () => {
+  it('allows the STRANDED case (null state)', () => {
+    expect(canRetriggerBuild({ state: null, updatedAt: null }, NOW)).toBe(true);
+  });
+
+  it('allows a failed build/deploy', () => {
+    expect(canRetriggerBuild({ state: 'failed', updatedAt: fresh }, NOW)).toBe(true);
+  });
+
+  it('refuses a live deploy', () => {
+    expect(canRetriggerBuild({ state: 'live', updatedAt: fresh }, NOW)).toBe(false);
+  });
+
+  it('refuses every review-preview state', () => {
+    for (const s of ['preview-building', 'preview-deploying', 'preview-live', 'preview-failed']) {
+      expect(canRetriggerBuild({ state: s, updatedAt: stale }, NOW)).toBe(false);
+    }
+  });
+
+  it('refuses a FRESH in-flight build (never race two PipelineRuns)', () => {
+    expect(canRetriggerBuild({ state: 'building', updatedAt: fresh }, NOW)).toBe(false);
+    expect(canRetriggerBuild({ state: 'deploying', updatedAt: fresh }, NOW)).toBe(false);
+  });
+
+  it('allows an in-flight build only once STALLED past the shared threshold', () => {
+    expect(canRetriggerBuild({ state: 'building', updatedAt: stale }, NOW)).toBe(true);
+    expect(canRetriggerBuild({ state: 'deploying', updatedAt: stale }, NOW)).toBe(true);
+    // Exactly at the threshold is still "not stalled" — matches the server.
+    expect(
+      canRetriggerBuild({ state: 'building', updatedAt: new Date(NOW - DEPLOY_STALE_AFTER_MS) }, NOW)
+    ).toBe(false);
+  });
+
+  it('refuses an in-flight build with no timestamp to judge staleness by', () => {
+    expect(canRetriggerBuild({ state: 'building', updatedAt: null }, NOW)).toBe(false);
+  });
+
+  it('refuses an unrecognized state rather than guessing', () => {
+    expect(canRetriggerBuild({ state: 'something-new', updatedAt: stale }, NOW)).toBe(false);
   });
 });

--- a/src/components/Apps/deploy-status.ts
+++ b/src/components/Apps/deploy-status.ts
@@ -5,29 +5,39 @@
  * audit-fix passes — is unit-testable without React.
  */
 
+import {
+  DEPLOY_PENDING_GRACE_MS,
+  DEPLOY_STALE_AFTER_MS,
+} from '~/shared/constants/app-block-deploy.constants';
+
 export type DeployLifecycleState = 'building' | 'deploying' | 'live' | 'failed' | null;
 
 export type DeployLifecycleRow = {
   status: string;
   deployState: DeployLifecycleState;
   deployUpdatedAt?: string | Date | null;
+  /** When the moderator decision landed. The anchor for STRANDED detection: a
+   *  stranded row has no `deployUpdatedAt` at all (nothing ever transitioned), so
+   *  the approval time is the only clock available. */
+  reviewedAt?: string | Date | null;
 };
 
-// A build/deploy that hasn't advanced in this long is treated as STALLED: the
-// fire-and-forget apply watcher was likely lost to a civitai-web pod restart
-// (build-callback.ts documents this self-heal-on-next-build window). Sits
-// COMFORTABLY above the build pipeline's own ceiling — the Tekton pipeline
-// timeout is 20m EXECUTION plus queue time on the single slow build node — so a
-// legitimately slow/queued build is never mislabeled. A stalled row only BACKS
-// OFF polling (never stops), so a slow build that finishes past the threshold
-// still self-heals to live/failed without a page reload.
-export const DEPLOY_STALE_AFTER_MS = 45 * 60 * 1000;
+// Re-exported so every existing `~/components/Apps/deploy-status` importer keeps
+// working. The VALUE now lives in `~/shared/constants/app-block-deploy.constants`
+// because the SERVER's retrigger gate must use the identical threshold — two
+// hardcoded numbers would let the UI offer a retrigger the server rejects.
+export { DEPLOY_PENDING_GRACE_MS, DEPLOY_STALE_AFTER_MS };
+
+function toMs(d: string | Date | null | undefined): number | null {
+  if (!d) return null;
+  const date = typeof d === 'string' ? new Date(d) : d;
+  const ms = date.getTime();
+  return Number.isFinite(ms) ? ms : null;
+}
 
 /** An approved request whose code is still being built or deployed. */
 export function isInFlightDeploy(s: Pick<DeployLifecycleRow, 'status' | 'deployState'>): boolean {
-  return (
-    s.status === 'approved' && (s.deployState === 'building' || s.deployState === 'deploying')
-  );
+  return s.status === 'approved' && (s.deployState === 'building' || s.deployState === 'deploying');
 }
 
 /**
@@ -35,10 +45,89 @@ export function isInFlightDeploy(s: Pick<DeployLifecycleRow, 'status' | 'deployS
  * stuck (watcher lost to a pod restart). `now` is injectable for tests.
  */
 export function isStaleDeploy(s: DeployLifecycleRow, now: number = Date.now()): boolean {
-  if (!isInFlightDeploy(s) || !s.deployUpdatedAt) return false;
-  const updated =
-    typeof s.deployUpdatedAt === 'string' ? new Date(s.deployUpdatedAt) : s.deployUpdatedAt;
-  return now - updated.getTime() > DEPLOY_STALE_AFTER_MS;
+  if (!isInFlightDeploy(s)) return false;
+  const updated = toMs(s.deployUpdatedAt);
+  if (updated == null) return false;
+  return now - updated > DEPLOY_STALE_AFTER_MS;
+}
+
+/**
+ * STRANDED: an APPROVED request whose build never started, so its `deploy_state`
+ * is still NULL long after the approval landed.
+ *
+ * WHY THIS EXISTS — `approveRequest` writes `status='approved'` +
+ * `forgejo_commit_sha` and only THEN calls `markRequestDeployState(…,'building')`.
+ * If `triggerBuild` throws in between (a transient 502 from the build trigger —
+ * this happened in production), the approve is already durable but the deploy
+ * state is never written. The row then looks like a healthy green "approved"
+ * forever while nothing is building, nothing is deploying, and nothing ever will.
+ *
+ * DARK-SAFE BY CONSTRUCTION — this is deliberately NOT "deployState is null".
+ * A freshly-approved row legitimately has a null state for the sub-second window
+ * between the two writes, and every APPROVED ROW FROM BEFORE THE DEPLOY-STATE
+ * FEATURE SHIPPED has a permanently-null state. So a row only becomes stranded
+ * once it is older than `DEPLOY_STALE_AFTER_MS` **and** carries no
+ * `deployUpdatedAt` (any legacy row that has ever transitioned is excluded), and
+ * a row with no `reviewedAt` anchor at all is never flagged. Inside the window
+ * the row renders exactly as it does today.
+ */
+export function isStrandedDeploy(s: DeployLifecycleRow, now: number = Date.now()): boolean {
+  if (s.status !== 'approved') return false;
+  if (s.deployState !== null && s.deployState !== undefined) return false;
+  // Any recorded transition means the lifecycle DID run at some point; a null
+  // state alongside a transition timestamp is not the stranding signature.
+  if (toMs(s.deployUpdatedAt) != null) return false;
+  const reviewed = toMs(s.reviewedAt);
+  if (reviewed == null) return false;
+  return now - reviewed > DEPLOY_STALE_AFTER_MS;
+}
+
+/**
+ * An approved row whose deploy state has not been written YET but is still within
+ * the short post-approval grace window — the genuine race between the approve
+ * commit and `markRequestDeployState`. Worth polling briefly; NOT worth polling
+ * for the full stale threshold, because past the grace window nothing is going to
+ * write it (see {@link isStrandedDeploy}).
+ */
+export function isAwaitingDeployState(s: DeployLifecycleRow, now: number = Date.now()): boolean {
+  if (s.status !== 'approved') return false;
+  if (s.deployState !== null && s.deployState !== undefined) return false;
+  if (toMs(s.deployUpdatedAt) != null) return false;
+  const reviewed = toMs(s.reviewedAt);
+  if (reviewed == null) return false;
+  return now - reviewed <= DEPLOY_PENDING_GRACE_MS;
+}
+
+/** The deploy projection a moderator-queue row carries (see `unifiedReviewRow`). */
+export type ModDeployRow = { state: string | null; updatedAt: Date | string | null };
+
+/**
+ * CLIENT MIRROR of the server's "approved but not successfully built" gate — the
+ * predicate that decides whether the mod queue offers a "Retrigger build" button.
+ *
+ * 🔴 The AUTHORITY is `assertRetriggerableDeployState` in
+ * `~/server/services/blocks/publish-request.service`. This exists only to avoid
+ * offering a button the server will reject; it is NOT a security boundary (the
+ * server re-checks every condition, plus ownership/supersede/rate limits it
+ * cannot see from here). Both read `DEPLOY_STALE_AFTER_MS` from the same shared
+ * constant, so the "stalled" cut-off can never drift apart.
+ *
+ * Allowed: `null` (STRANDED — the build never started) and `'failed'`.
+ * Allowed only once stalled: `'building'` / `'deploying'` past
+ * `DEPLOY_STALE_AFTER_MS`. Refused: `'live'` and any `preview-*` value.
+ */
+export function canRetriggerBuild(deploy: ModDeployRow, now: number = Date.now()): boolean {
+  const state = deploy.state;
+  if (state === null || state === undefined) return true;
+  if (state === 'failed') return true;
+  if (state === 'live') return false;
+  if (state.startsWith('preview-')) return false;
+  if (state === 'building' || state === 'deploying') {
+    const updated = toMs(deploy.updatedAt);
+    if (updated == null) return false;
+    return now - updated > DEPLOY_STALE_AFTER_MS;
+  }
+  return false;
 }
 
 /**
@@ -46,12 +135,17 @@ export function isStaleDeploy(s: DeployLifecycleRow, now: number = Date.now()): 
  * 30s once every in-flight row looks stalled (back off but DON'T stop, so a
  * slow build still self-heals — the global query config is staleTime:Infinity
  * + refetchOnWindowFocus:false), and stop (`false`) when nothing is in flight.
+ *
+ * A just-approved row awaiting its first deploy-state write counts as fresh
+ * in-flight for the grace window only, so the badge flips to "building" without a
+ * reload. A STRANDED row is deliberately NOT polled — nothing will ever change
+ * it, and polling it forever is the bug this replaces.
  */
 export function deployRefetchInterval(
   rows: DeployLifecycleRow[],
   now: number = Date.now()
 ): number | false {
-  const inFlight = rows.filter(isInFlightDeploy);
+  const inFlight = rows.filter((s) => isInFlightDeploy(s) || isAwaitingDeployState(s, now));
   if (inFlight.length === 0) return false;
   return inFlight.some((s) => !isStaleDeploy(s, now)) ? 5000 : 30000;
 }

--- a/src/components/Apps/deploy-status.ts
+++ b/src/components/Apps/deploy-status.ts
@@ -99,7 +99,15 @@ export function isAwaitingDeployState(s: DeployLifecycleRow, now: number = Date.
 }
 
 /** The deploy projection a moderator-queue row carries (see `unifiedReviewRow`). */
-export type ModDeployRow = { state: string | null; updatedAt: Date | string | null };
+export type ModDeployRow = {
+  state: string | null;
+  updatedAt: Date | string | null;
+  /** Approval time — the anchor for the null-state grace window (a null state has
+   *  no transition of its own to measure from). Optional so older callers/fixtures
+   *  keep compiling; absent means "cannot measure", which stays permissive here
+   *  because the SERVER is the authority. */
+  reviewedAt?: Date | string | null;
+};
 
 /**
  * CLIENT MIRROR of the server's "approved but not successfully built" gate — the
@@ -112,13 +120,25 @@ export type ModDeployRow = { state: string | null; updatedAt: Date | string | nu
  * cannot see from here). Both read `DEPLOY_STALE_AFTER_MS` from the same shared
  * constant, so the "stalled" cut-off can never drift apart.
  *
- * Allowed: `null` (STRANDED — the build never started) and `'failed'`.
- * Allowed only once stalled: `'building'` / `'deploying'` past
- * `DEPLOY_STALE_AFTER_MS`. Refused: `'live'` and any `preview-*` value.
+ * Allowed: `null` (STRANDED — the build never started) once past
+ * `DEPLOY_PENDING_GRACE_MS`, and `'failed'`. Allowed only once stalled:
+ * `'building'` / `'deploying'` past `DEPLOY_STALE_AFTER_MS`. Refused: `'live'` and
+ * any `preview-*` value.
+ *
+ * The grace bound on the null branch mirrors the server's: inside the
+ * approve→`markRequestDeployState` window a build IS already being triggered, and
+ * re-firing would race a second PipelineRun. With no `reviewedAt` anchor to
+ * measure that window, this stays permissive (offer the button, let the server
+ * decide) — the asymmetry with the server's fail-closed branch is deliberate,
+ * since this side is a hint and that side is the guard.
  */
 export function canRetriggerBuild(deploy: ModDeployRow, now: number = Date.now()): boolean {
   const state = deploy.state;
-  if (state === null || state === undefined) return true;
+  if (state === null || state === undefined) {
+    const anchor = toMs(deploy.reviewedAt) ?? toMs(deploy.updatedAt);
+    if (anchor == null) return true;
+    return now - anchor > DEPLOY_PENDING_GRACE_MS;
+  }
   if (state === 'failed') return true;
   if (state === 'live') return false;
   if (state.startsWith('preview-')) return false;

--- a/src/components/Apps/unifiedReviewRow.ts
+++ b/src/components/Apps/unifiedReviewRow.ts
@@ -84,10 +84,30 @@ export type UnifiedReviewRow = {
   /** Present ONLY on a `kind: 'combined'` row: the two underlying request ids +
    *  payloads (code + listing-media) that the combined surface stacks. */
   combined?: CombinedReviewPayload;
+  /** On-site APPROVED rows only: the build/deploy lifecycle of the approved
+   *  version, so the Approved tab can show that an approval never actually
+   *  shipped (and offer a re-trigger). Undefined for every other row kind. */
+  deploy?: ReviewRowDeploy;
+};
+
+/** The deploy lifecycle projection carried on an on-site approved review row. */
+export type ReviewRowDeploy = {
+  /** `null` = never transitioned: a legacy pre-feature row, OR the STRANDED case. */
+  state: string | null;
+  detail: string | null;
+  updatedAt: Date | null;
+  /** The publish-request id — the ONLY argument `blocks.retriggerBuild` takes. */
+  publishRequestId: string;
 };
 
 function toDate(d: string | Date): Date {
   return typeof d === 'string' ? new Date(d) : d;
+}
+
+function toOptionalDate(d: string | Date | null | undefined): Date | null {
+  if (!d) return null;
+  const date = typeof d === 'string' ? new Date(d) : d;
+  return Number.isFinite(date.getTime()) ? date : null;
 }
 
 /** The on-site request shape consumed by the adapter (a superset of the pending
@@ -109,6 +129,18 @@ export function onsiteRequestToUnifiedRow(
       ? (req.manifest as Record<string, unknown>).name
       : undefined;
   const title = typeof manifestName === 'string' && manifestName.length > 0 ? manifestName : req.slug;
+  // Approved rows carry the deploy lifecycle (added to `listApprovedRequests`);
+  // pending/rejected rows do not, so `deploy` stays undefined and every existing
+  // caller/fixture is unaffected.
+  const deploy: ReviewRowDeploy | undefined =
+    'deployState' in req
+      ? {
+          state: (req as { deployState?: string | null }).deployState ?? null,
+          detail: (req as { deployDetail?: string | null }).deployDetail ?? null,
+          updatedAt: toOptionalDate((req as { deployUpdatedAt?: string | Date | null }).deployUpdatedAt),
+          publishRequestId: req.id,
+        }
+      : undefined;
   return {
     key: `onsite:${req.id}`,
     kind: 'onsite',
@@ -122,6 +154,7 @@ export function onsiteRequestToUnifiedRow(
     // Carried for code+media pairing + the combined surface.
     appBlockId: req.appBlockId,
     onsiteRequest: req,
+    deploy,
   };
 }
 

--- a/src/components/Apps/unifiedReviewRow.ts
+++ b/src/components/Apps/unifiedReviewRow.ts
@@ -94,11 +94,19 @@ export type UnifiedReviewRow = {
 export type ReviewRowDeploy = {
   /** `null` = never transitioned: a legacy pre-feature row, OR the STRANDED case. */
   state: string | null;
-  detail: string | null;
   updatedAt: Date | null;
+  /** Approval time — the anchor `canRetriggerBuild` measures the post-approval
+   *  grace window from (a null state has no transition of its own). */
+  reviewedAt: Date | null;
   /** The publish-request id — the ONLY argument `blocks.retriggerBuild` takes. */
   publishRequestId: string;
 };
+// NOTE: `deployDetail` is deliberately NOT projected here. It carries the
+// TENANT-INFLUENCED build-log excerpt (sanitized, but author-authored bytes) and
+// the moderator queue never renders it — carrying it into this payload would be
+// dead data on a surface where a future renderer would have to re-derive the
+// escaping guarantees. The owner-facing /apps/my-submissions row is where the
+// excerpt is shown, and it reads it straight from its own query.
 
 function toDate(d: string | Date): Date {
   return typeof d === 'string' ? new Date(d) : d;
@@ -136,8 +144,8 @@ export function onsiteRequestToUnifiedRow(
     'deployState' in req
       ? {
           state: (req as { deployState?: string | null }).deployState ?? null,
-          detail: (req as { deployDetail?: string | null }).deployDetail ?? null,
           updatedAt: toOptionalDate((req as { deployUpdatedAt?: string | Date | null }).deployUpdatedAt),
+          reviewedAt: toOptionalDate(reviewedAt),
           publishRequestId: req.id,
         }
       : undefined;

--- a/src/pages/api/internal/blocks/build-callback.ts
+++ b/src/pages/api/internal/blocks/build-callback.ts
@@ -9,6 +9,7 @@ import { isAppBlocksPipelineEnabled } from '~/server/services/app-blocks-flag';
 import { setCommitStatus } from '~/server/services/blocks/forgejo.service';
 import { triggerApply, waitForApplyJob } from '~/server/services/blocks/apps-pipeline.service';
 import { autogenerateScreenshotIfMissing } from '~/server/services/blocks/autogenerate-screenshot.service';
+import { buildFailureDeployDetail } from '~/server/services/blocks/build-failure-reason';
 import { markRequestDeployState } from '~/server/services/blocks/publish-request.service';
 
 /**
@@ -57,6 +58,17 @@ type CallbackBody = {
   // it is covered by the signature. Validated for skew below. ABSENT/non-finite
   // is ALLOWED (enforce-if-present rollout tolerance).
   ts?: unknown;
+  // OPTIONAL sanitized excerpt of WHY the build failed, emitted by the build
+  // pipeline ONLY on a non-success outcome and only when a non-empty excerpt
+  // exists. Absent on every success callback and on every callback from a
+  // pipeline that predates the field, in which case the stored deploy_detail is
+  // byte-identical to what shipped before (see `buildFailureDeployDetail`).
+  //
+  // Typed `unknown` ON PURPOSE: this is tenant-influenced build output. It is
+  // only READ when it is a string, and its content is ALWAYS re-sanitized
+  // server-side by `sanitizeBuildFailureReason` before being persisted — an HMAC
+  // proves WHO sent the bytes, never that the bytes are safe.
+  failureReason?: unknown;
 };
 
 // F5 — allowed clock skew between the callback signer and this receiver, in
@@ -292,12 +304,17 @@ export default withAxiom(async function handler(req: NextApiRequest, res: NextAp
       context: 'civitai/build',
       description: `Build ${body.status ?? 'failed'}`,
     });
+    // Surface the REAL reason to the app author. `buildFailureDeployDetail`
+    // returns exactly the previous `Build <status>` string when there is no
+    // usable excerpt (absent field, non-string, or empty after sanitization), so
+    // an OLD pipeline against this handler is byte-identical to today.
     await markRequestDeployState(
       body.slug,
       body.sha,
       'failed',
-      `Build ${String(body.status ?? 'failed').slice(0, 60)}`
+      buildFailureDeployDetail(body.status, body.failureReason)
     );
+    // Response body unchanged — Tekton consumes nothing beyond `ok`.
     res.status(200).json({ ok: true, applied: false, reason: 'build failed' });
     return;
   }

--- a/src/pages/api/v1/blocks/submissions.ts
+++ b/src/pages/api/v1/blocks/submissions.ts
@@ -7,6 +7,7 @@ import { getSessionFromBearerToken } from '~/server/auth/bearer-token';
 import { dbRead } from '~/server/db/client';
 import { sysRedis, REDIS_SYS_KEYS } from '~/server/redis/client';
 import { isAppBlocksAuthorEnabled, isAppBlocksEnabled } from '~/server/services/app-blocks-flag';
+import { isApprovedAndServing } from '~/shared/constants/app-block-deploy.constants';
 import { TokenScope } from '~/shared/constants/token-scope.constants';
 import { Flags } from '~/shared/utils/flags';
 
@@ -115,13 +116,20 @@ type SubmissionRow = {
  * columns (bundleKey/bundleSha256/forgejoCommitSha/manifest/file diffs/reviewer
  * id), and never another user's data (rows are self-scoped at the query).
  *
- * `liveUrl` is the `https://<slug>.civit.ai/` surface, surfaced ONLY once the
- * app is actually serving (deployState 'live', or a legacy null deployState on
- * an approved row — same "assume live" rule as the /apps/my-submissions UI).
+ * `liveUrl` is the `https://<slug>.civit.ai/` surface, surfaced ONLY once the app
+ * is actually serving — `isApprovedAndServing`, the SHARED predicate (and shared
+ * staleness/epoch constants) the owner-facing UI reasons with.
+ *
+ * 🔴 It is NOT "approved && deployState != 'failed'". A STRANDED approval (the
+ * build never fired, so deploy_state stayed null) would otherwise hand
+ * `civitai app status` a working-looking `liveUrl` for an app that 404s — the
+ * exact invisible failure this feature exists to remove, re-created on the CLI
+ * surface. The predicate still returns true for a LEGACY null state (approved
+ * before deploy-state tracking existed, or carrying a recorded transition), so
+ * pre-feature rows that genuinely deployed keep their URL.
  */
 function shapeRow(row: SubmissionRow, appsDomain: string) {
-  const isApproved = row.status === 'approved';
-  const isLive = isApproved && (row.deployState === 'live' || row.deployState == null);
+  const isLive = isApprovedAndServing(row);
   return {
     id: row.id,
     blockId: row.slug, // the app slug == `block_id` that builds <slug>.civit.ai

--- a/src/pages/apps/review.tsx
+++ b/src/pages/apps/review.tsx
@@ -43,6 +43,7 @@ import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
 import { isAppReviewer } from '~/shared/utils/app-blocks-access';
 import { createServerSideProps } from '~/server/utils/server-side-helpers';
 import { getLoginLink } from '~/utils/login-helpers';
+import { showErrorNotification, showSuccessNotification } from '~/utils/notifications';
 import { trpc } from '~/utils/trpc';
 
 /**
@@ -491,6 +492,33 @@ function UnifiedHistoryTab({
     }
   };
 
+  // APPROVED tab only — re-fire the build for an approved request whose build
+  // never started (deploy state null) or failed. The mutation takes ONLY the
+  // request id; the sha to rebuild is read server-side from the already-reviewed
+  // DB row. Tracks the in-flight id so only that row's button spins/disables.
+  const [retriggeringId, setRetriggeringId] = useState<string | null>(null);
+  const retriggerMutation = trpc.blocks.retriggerBuild.useMutation({
+    onSuccess: () => {
+      showSuccessNotification({
+        message: 'Build re-triggered — the deploy state will update as it progresses.',
+      });
+      resetPaging();
+      void onsiteApprovedQ.refetch();
+    },
+    onError: (e) =>
+      showErrorNotification({ title: 'Re-trigger failed', error: new Error(e.message) }),
+    onSettled: () => setRetriggeringId(null),
+  });
+  const onRetriggerBuild = useCallback(
+    (publishRequestId: string) => {
+      // Belt against a double-fire that slips past the button's own disabled state.
+      if (retriggerMutation.isPending) return;
+      setRetriggeringId(publishRequestId);
+      retriggerMutation.mutate({ publishRequestId });
+    },
+    [retriggerMutation]
+  );
+
   return (
     <UnifiedReviewList
       onsiteItems={onsiteItems}
@@ -506,6 +534,10 @@ function UnifiedHistoryTab({
       hasMore={onsiteNext != null || offsiteNext != null}
       isLoadingMore={onsiteQuery.isFetching || offsiteQuery.isFetching}
       onLoadMore={onLoadMore}
+      // Deploy column + retrigger control exist on the APPROVED tab only; the
+      // Rejected tab passes neither and renders exactly as before.
+      onRetriggerBuild={isApproved ? onRetriggerBuild : undefined}
+      retriggeringId={retriggeringId}
     />
   );
 }

--- a/src/server/routers/__tests__/blocks.router.listMyPublishRequests.test.ts
+++ b/src/server/routers/__tests__/blocks.router.listMyPublishRequests.test.ts
@@ -258,3 +258,83 @@ describe('listMyPublishRequests — P4 owner-control augmentation', () => {
     expect(mockDbRead.appListingModerationEvent.findMany).not.toHaveBeenCalled();
   });
 });
+
+/**
+ * OWNER-ONLY VISIBILITY — the security boundary for the build-failure excerpt.
+ *
+ * `deployDetail` now carries a sanitized slice of the app's BUILD LOG. That is
+ * the author's own material and must reach the author (and moderators, via the
+ * separate mod procs) and NOBODY ELSE. The guard is the `submittedByUserId`
+ * filter on this query — there is no post-filter and no per-row ownership check,
+ * so if that `where` clause were ever dropped or widened, every viewer would see
+ * every developer's build output.
+ *
+ * These tests pin the filter itself rather than the shape of the result, because
+ * the filter IS the guard.
+ */
+describe('listMyPublishRequests — OWNER-ONLY scoping (guards the build-failure excerpt)', () => {
+  const otherUser = { id: 999, isModerator: false, tier: 'free', username: 'someone-else' };
+
+  it('scopes the query to the CALLING user id — the only ownership guard there is', async () => {
+    mockDbRead.appBlockPublishRequest.findMany.mockResolvedValue([]);
+    const caller = blocksRouter.createCaller(fakeCtx(owner) as never);
+    await caller.listMyPublishRequests();
+
+    const args = mockDbRead.appBlockPublishRequest.findMany.mock.calls[0][0] as {
+      where: Record<string, unknown>;
+    };
+    expect(args.where).toEqual({ submittedByUserId: owner.id });
+  });
+
+  it('a DIFFERENT caller queries with THEIR id — never a shared/unscoped read', async () => {
+    mockDbRead.appBlockPublishRequest.findMany.mockResolvedValue([]);
+    const caller = blocksRouter.createCaller(fakeCtx(otherUser) as never);
+    await caller.listMyPublishRequests();
+
+    const args = mockDbRead.appBlockPublishRequest.findMany.mock.calls[0][0] as {
+      where: Record<string, unknown>;
+    };
+    expect(args.where).toEqual({ submittedByUserId: otherUser.id });
+    expect(args.where.submittedByUserId).not.toBe(owner.id);
+  });
+
+  it('an ANONYMOUS caller gets nothing and NO query is issued at all', async () => {
+    mockDbRead.appBlockPublishRequest.findMany.mockResolvedValue([]);
+    const caller = blocksRouter.createCaller(fakeCtx(undefined) as never);
+    await expect(caller.listMyPublishRequests()).rejects.toBeTruthy();
+    expect(mockDbRead.appBlockPublishRequest.findMany).not.toHaveBeenCalled();
+  });
+
+  it('selects the build-failure excerpt for the owner (deployDetail is returned)', async () => {
+    const EXCERPT = 'Build Failed\n\nERROR: no package-lock.json is committed';
+    mockDbRead.appBlockPublishRequest.findMany.mockResolvedValue([
+      {
+        id: 'req-f',
+        appBlockId: null,
+        slug: 'failed-app',
+        version: '1.0.0',
+        status: 'approved',
+        submittedAt: new Date('2026-01-01'),
+        reviewedAt: new Date('2026-01-02'),
+        rejectionReason: null,
+        approvalNotes: null,
+        deployState: 'failed',
+        deployDetail: EXCERPT,
+        deployUpdatedAt: new Date('2026-01-02'),
+        fileSummary: null,
+        manifestDiffSummary: null,
+        appBlock: null,
+      },
+    ]);
+    const caller = blocksRouter.createCaller(fakeCtx(owner) as never);
+    const rows = await caller.listMyPublishRequests();
+    expect(rows[0]).toMatchObject({ deployState: 'failed', deployDetail: EXCERPT });
+
+    // And the select explicitly asks for it (pins the projection, not just the row).
+    const args = mockDbRead.appBlockPublishRequest.findMany.mock.calls[0][0] as {
+      select: Record<string, unknown>;
+    };
+    expect(args.select.deployDetail).toBe(true);
+    expect(args.select.reviewedAt).toBe(true); // the STRANDED-detection anchor
+  });
+});

--- a/src/server/routers/__tests__/blocks.router.retriggerBuild.test.ts
+++ b/src/server/routers/__tests__/blocks.router.retriggerBuild.test.ts
@@ -1,5 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { TRPCError } from '@trpc/server';
+// Type-only imports (erased at runtime, so they are safe above the hoisted
+// `vi.mock` calls) — the lint rule forbids inline `import()` type annotations.
+import type * as FeatureFlagsService from '~/server/services/feature-flags.service';
+import type * as RedisClient from '@civitai/redis/client';
 
 /**
  * `blocks.retriggerBuild` — router AUTHZ + input surface + error mapping.
@@ -40,7 +44,7 @@ vi.mock('~/server/services/app-blocks-flag', () => ({
   isAppBlocksAuthorEnabled: vi.fn(async () => true),
 }));
 vi.mock('~/server/services/feature-flags.service', async (importOriginal) => ({
-  ...(await importOriginal<typeof import('~/server/services/feature-flags.service')>()),
+  ...(await importOriginal<typeof FeatureFlagsService>()),
   getFeatureFlags: () => ({ appBlocks: true, appBlocksAuthor: true, appBlocksPages: false }),
 }));
 // The router dynamically imports the whole publish-request service; stub just the
@@ -66,9 +70,7 @@ vi.mock('~/server/services/orchestrator/promptAuditing', () => ({ auditPromptSer
 vi.mock('~/server/services/user.service', () => ({ getUserById: vi.fn() }));
 vi.mock('~/server/db/client', () => ({ dbRead: mockDbRead, dbWrite: {} }));
 vi.mock('~/server/redis/client', async () => {
-  const actual = await vi.importActual<typeof import('@civitai/redis/client')>(
-    '@civitai/redis/client'
-  );
+  const actual = await vi.importActual<typeof RedisClient>('@civitai/redis/client');
   return {
     ...actual,
     redis: { get: vi.fn(), set: vi.fn() },

--- a/src/server/routers/__tests__/blocks.router.retriggerBuild.test.ts
+++ b/src/server/routers/__tests__/blocks.router.retriggerBuild.test.ts
@@ -1,0 +1,252 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { TRPCError } from '@trpc/server';
+
+/**
+ * `blocks.retriggerBuild` — router AUTHZ + input surface + error mapping.
+ *
+ * Drives the REAL `blocksRouter` through `createCaller` so the MIDDLEWARE WIRING
+ * is what decides, not a hand-rolled stand-in. Three things are pinned:
+ *
+ *   1. MODERATOR-ONLY. It is a `moderatorProcedure` with the same redundant inner
+ *      `ctx.user?.isModerator` belt `approveRequest` carries. A non-mod (and an
+ *      anonymous caller) is rejected and the SERVICE IS NEVER REACHED.
+ *   2. NO SHA ON THE WIRE. The zod input accepts ONLY `publishRequestId` — a
+ *      caller cannot name a commit to build. This makes "rebuild an arbitrary,
+ *      unreviewed sha" structurally impossible rather than merely guarded.
+ *   3. TYPED ERROR MAPPING. NOT_FOUND -> NOT_FOUND, RATE_LIMITED ->
+ *      TOO_MANY_REQUESTS, everything else -> BAD_REQUEST.
+ *
+ * Heavy-mock skeleton copied from `blocks.router.listMyPublishRequests.test.ts` so
+ * importing the router doesn't drag in the generated Prisma client.
+ */
+
+const { mockIsAppBlocksEnabled, mockRetrigger, mockDbRead } = vi.hoisted(() => ({
+  mockIsAppBlocksEnabled: vi.fn(),
+  mockRetrigger: vi.fn<(...a: any[]) => Promise<unknown>>(async () => ({
+    publishRequestId: 'pubreq_1',
+    appBlockId: 'apb_x',
+    forgejoCommitSha: 'a'.repeat(40),
+  })),
+  mockDbRead: {
+    appBlockPublishRequest: { findMany: vi.fn(), findUnique: vi.fn() },
+    appListing: { findMany: vi.fn() },
+    appListingModerationEvent: { findMany: vi.fn() },
+    blockUserSubscription: { groupBy: vi.fn() },
+  },
+}));
+
+vi.mock('~/server/services/app-blocks-flag', () => ({
+  isAppBlocksEnabled: mockIsAppBlocksEnabled,
+  isAppBlocksAuthorEnabled: vi.fn(async () => true),
+}));
+vi.mock('~/server/services/feature-flags.service', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('~/server/services/feature-flags.service')>()),
+  getFeatureFlags: () => ({ appBlocks: true, appBlocksAuthor: true, appBlocksPages: false }),
+}));
+// The router dynamically imports the whole publish-request service; stub just the
+// export under test plus the handful the module graph needs.
+vi.mock('~/server/services/blocks/publish-request.service', () => ({
+  retriggerBuild: mockRetrigger,
+}));
+vi.mock('~/server/middleware/block-scope.middleware', () => ({
+  verifyBlockToken: vi.fn(),
+  parseSubjectUserId: vi.fn(),
+}));
+vi.mock('~/server/orchestrator/get-orchestrator-token', () => ({ getOrchestratorToken: vi.fn() }));
+vi.mock('~/server/services/orchestrator/orchestration-new.service', () => ({
+  buildGenerationContext: vi.fn(),
+  createWorkflowStepsFromGraphInput: vi.fn(),
+}));
+vi.mock('~/server/services/orchestrator/workflows', () => ({
+  submitWorkflow: vi.fn(),
+  getWorkflow: vi.fn(),
+  cancelWorkflow: vi.fn(),
+}));
+vi.mock('~/server/services/orchestrator/promptAuditing', () => ({ auditPromptServer: vi.fn() }));
+vi.mock('~/server/services/user.service', () => ({ getUserById: vi.fn() }));
+vi.mock('~/server/db/client', () => ({ dbRead: mockDbRead, dbWrite: {} }));
+vi.mock('~/server/redis/client', async () => {
+  const actual = await vi.importActual<typeof import('@civitai/redis/client')>(
+    '@civitai/redis/client'
+  );
+  return {
+    ...actual,
+    redis: { get: vi.fn(), set: vi.fn() },
+    sysRedis: { get: vi.fn(), incrBy: vi.fn(), expire: vi.fn(), ttl: vi.fn() },
+  };
+});
+vi.mock('~/server/rewards/active/dailyBoost.reward', () => ({
+  dailyBoostReward: { apply: vi.fn(), getUserRewardDetails: vi.fn() },
+}));
+vi.mock('~/server/services/buzz.service', () => ({ getUserBuzzAccounts: vi.fn() }));
+vi.mock('~/server/logging/client', () => ({ logToAxiom: vi.fn(async () => undefined) }));
+vi.mock('~/server/services/block-registry.service', () => ({
+  BlockRegistry: {
+    listForModel: vi.fn(),
+    listAvailable: vi.fn(),
+    installOnModel: vi.fn(),
+    updateSettings: vi.fn(),
+    toggleEnabled: vi.fn(),
+    uninstallFromModel: vi.fn(),
+    resolveBlockInstance: vi.fn(),
+  },
+}));
+vi.mock('~/server/middleware.trpc', async () => {
+  const { middleware } = await import('~/server/trpc');
+  return { rateLimit: () => middleware(async ({ next }) => next()) };
+});
+
+import { blocksRouter } from '../blocks.router';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
+
+function fakeCtx(user: unknown) {
+  return {
+    acceptableOrigin: true,
+    user,
+    apiKeyId: null,
+    tokenScope: TokenScope.Full,
+    req: { headers: {} } as never,
+    res: { setHeader: () => undefined } as never,
+    cache: { edgeTTL: 0 },
+    features: { appBlocks: true, appBlocksAuthor: true } as never,
+    track: undefined,
+  };
+}
+
+const mod = { id: 1, isModerator: true, tier: 'free', username: 'mod', onboarding: 0x1f };
+const tester = { id: 2, isModerator: false, tier: 'free', username: 'tester', onboarding: 0x1f };
+const REQ_ID = 'pubreq_1';
+
+function retriggerErr(code: string, message: string): Error {
+  return Object.assign(new Error(message), { name: 'RetriggerBuildError', code });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockIsAppBlocksEnabled.mockResolvedValue(true);
+  mockRetrigger.mockResolvedValue({
+    publishRequestId: REQ_ID,
+    appBlockId: 'apb_x',
+    forgejoCommitSha: 'a'.repeat(40),
+  });
+});
+
+describe('blocks.retriggerBuild — moderator gate', () => {
+  it('a NON-MODERATOR is rejected; the service is never reached', async () => {
+    const caller = blocksRouter.createCaller(fakeCtx(tester) as never);
+    await expect(caller.retriggerBuild({ publishRequestId: REQ_ID })).rejects.toBeInstanceOf(
+      TRPCError
+    );
+    expect(mockRetrigger).not.toHaveBeenCalled();
+  });
+
+  it('an ANONYMOUS caller is rejected; the service is never reached', async () => {
+    const caller = blocksRouter.createCaller(fakeCtx(undefined) as never);
+    await expect(caller.retriggerBuild({ publishRequestId: REQ_ID })).rejects.toBeInstanceOf(
+      TRPCError
+    );
+    expect(mockRetrigger).not.toHaveBeenCalled();
+  });
+
+  it('a user who merely CLAIMS elevation in the payload is still rejected', async () => {
+    const caller = blocksRouter.createCaller(fakeCtx(tester) as never);
+    await expect(
+      caller.retriggerBuild({ publishRequestId: REQ_ID, isModerator: true } as never)
+    ).rejects.toBeInstanceOf(TRPCError);
+    expect(mockRetrigger).not.toHaveBeenCalled();
+  });
+
+  it('a MODERATOR passes and the service runs', async () => {
+    const caller = blocksRouter.createCaller(fakeCtx(mod) as never);
+    await expect(caller.retriggerBuild({ publishRequestId: REQ_ID })).resolves.toMatchObject({
+      publishRequestId: REQ_ID,
+    });
+    expect(mockRetrigger).toHaveBeenCalledTimes(1);
+  });
+
+  it('binds the reviewer to the SESSION user id — never anything client-supplied', async () => {
+    const caller = blocksRouter.createCaller(fakeCtx(mod) as never);
+    await caller.retriggerBuild({
+      publishRequestId: REQ_ID,
+      reviewerUserId: 9999,
+    } as never);
+    expect(mockRetrigger).toHaveBeenCalledWith({
+      publishRequestId: REQ_ID,
+      reviewerUserId: mod.id,
+    });
+  });
+});
+
+describe('blocks.retriggerBuild — input surface: NO sha on the wire', () => {
+  it('passes ONLY publishRequestId + the session reviewer to the service', async () => {
+    const caller = blocksRouter.createCaller(fakeCtx(mod) as never);
+    await caller.retriggerBuild({ publishRequestId: REQ_ID });
+    // Exact-equality: any additional forwarded field would fail this.
+    expect(mockRetrigger).toHaveBeenCalledWith({
+      publishRequestId: REQ_ID,
+      reviewerUserId: mod.id,
+    });
+  });
+
+  it('a caller-supplied sha is STRIPPED by the schema and never reaches the service', async () => {
+    const caller = blocksRouter.createCaller(fakeCtx(mod) as never);
+    await caller.retriggerBuild({
+      publishRequestId: REQ_ID,
+      sha: 'b'.repeat(40),
+      forgejoCommitSha: 'c'.repeat(40),
+      ref: 'refs/heads/attacker',
+    } as never);
+    const args = mockRetrigger.mock.calls[0][0] as Record<string, unknown>;
+    expect(Object.keys(args).sort()).toEqual(['publishRequestId', 'reviewerUserId']);
+    expect(JSON.stringify(args)).not.toContain('b'.repeat(40));
+    expect(JSON.stringify(args)).not.toContain('c'.repeat(40));
+    expect(JSON.stringify(args)).not.toContain('refs/heads/attacker');
+  });
+
+  it('rejects a missing / empty / oversized publishRequestId at the schema', async () => {
+    const caller = blocksRouter.createCaller(fakeCtx(mod) as never);
+    await expect(caller.retriggerBuild({} as never)).rejects.toBeInstanceOf(TRPCError);
+    await expect(caller.retriggerBuild({ publishRequestId: '' })).rejects.toBeInstanceOf(TRPCError);
+    await expect(
+      caller.retriggerBuild({ publishRequestId: 'x'.repeat(65) })
+    ).rejects.toBeInstanceOf(TRPCError);
+    expect(mockRetrigger).not.toHaveBeenCalled();
+  });
+});
+
+describe('blocks.retriggerBuild — typed error mapping', () => {
+  it('NOT_FOUND maps to a NOT_FOUND TRPCError', async () => {
+    mockRetrigger.mockRejectedValue(retriggerErr('NOT_FOUND', 'publish request nope not found'));
+    const caller = blocksRouter.createCaller(fakeCtx(mod) as never);
+    await expect(caller.retriggerBuild({ publishRequestId: REQ_ID })).rejects.toMatchObject({
+      code: 'NOT_FOUND',
+    });
+  });
+
+  it('RATE_LIMITED maps to TOO_MANY_REQUESTS', async () => {
+    mockRetrigger.mockRejectedValue(retriggerErr('RATE_LIMITED', 'Too many build re-triggers'));
+    const caller = blocksRouter.createCaller(fakeCtx(mod) as never);
+    await expect(caller.retriggerBuild({ publishRequestId: REQ_ID })).rejects.toMatchObject({
+      code: 'TOO_MANY_REQUESTS',
+    });
+  });
+
+  it('NOT_RETRIGGERABLE maps to BAD_REQUEST and surfaces the reason to the mod', async () => {
+    mockRetrigger.mockRejectedValue(
+      retriggerErr('NOT_RETRIGGERABLE', 'This version is already deployed.')
+    );
+    const caller = blocksRouter.createCaller(fakeCtx(mod) as never);
+    await expect(caller.retriggerBuild({ publishRequestId: REQ_ID })).rejects.toMatchObject({
+      code: 'BAD_REQUEST',
+      message: 'This version is already deployed.',
+    });
+  });
+
+  it('an untyped error still maps to BAD_REQUEST rather than escaping raw', async () => {
+    mockRetrigger.mockRejectedValue(new Error('kaboom'));
+    const caller = blocksRouter.createCaller(fakeCtx(mod) as never);
+    await expect(caller.retriggerBuild({ publishRequestId: REQ_ID })).rejects.toMatchObject({
+      code: 'BAD_REQUEST',
+    });
+  });
+});

--- a/src/server/routers/__tests__/blocks.router.retriggerBuild.test.ts
+++ b/src/server/routers/__tests__/blocks.router.retriggerBuild.test.ts
@@ -18,7 +18,9 @@ import type * as RedisClient from '@civitai/redis/client';
  *      caller cannot name a commit to build. This makes "rebuild an arbitrary,
  *      unreviewed sha" structurally impossible rather than merely guarded.
  *   3. TYPED ERROR MAPPING. NOT_FOUND -> NOT_FOUND, RATE_LIMITED ->
- *      TOO_MANY_REQUESTS, everything else -> BAD_REQUEST.
+ *      TOO_MANY_REQUESTS, TRIGGER_FAILED -> INTERNAL_SERVER_ERROR (a build-service
+ *      outage is a server fault, not a malformed request), everything else ->
+ *      BAD_REQUEST.
  *
  * Heavy-mock skeleton copied from `blocks.router.listMyPublishRequests.test.ts` so
  * importing the router doesn't drag in the generated Prisma client.
@@ -241,6 +243,29 @@ describe('blocks.retriggerBuild — typed error mapping', () => {
     await expect(caller.retriggerBuild({ publishRequestId: REQ_ID })).rejects.toMatchObject({
       code: 'BAD_REQUEST',
       message: 'This version is already deployed.',
+    });
+  });
+
+  it('TRIGGER_FAILED maps to INTERNAL_SERVER_ERROR, not a 400', async () => {
+    // A build-service outage is OUR fault. Reporting it as BAD_REQUEST told the
+    // moderator they had sent a malformed request and kept a real incident off
+    // the server-fault error board.
+    mockRetrigger.mockRejectedValue(
+      retriggerErr('TRIGGER_FAILED', 'The build re-trigger could not be sent to the build service.')
+    );
+    const caller = blocksRouter.createCaller(fakeCtx(mod) as never);
+    await expect(caller.retriggerBuild({ publishRequestId: REQ_ID })).rejects.toMatchObject({
+      code: 'INTERNAL_SERVER_ERROR',
+    });
+  });
+
+  it('INVALID_STORED_SHA maps to BAD_REQUEST', async () => {
+    mockRetrigger.mockRejectedValue(
+      retriggerErr('INVALID_STORED_SHA', 'Request has no valid committed sha to rebuild.')
+    );
+    const caller = blocksRouter.createCaller(fakeCtx(mod) as never);
+    await expect(caller.retriggerBuild({ publishRequestId: REQ_ID })).rejects.toMatchObject({
+      code: 'BAD_REQUEST',
     });
   });
 

--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -1952,11 +1952,17 @@ export const blocksRouter = router({
         });
       } catch (err) {
         if (err instanceof TRPCError) throw err;
+        const serviceCode = err instanceof Error ? (err as { code?: unknown }).code : undefined;
         const code =
-          err instanceof Error && (err as { code?: unknown }).code === 'NOT_FOUND'
+          serviceCode === 'NOT_FOUND'
             ? 'NOT_FOUND'
-            : err instanceof Error && (err as { code?: unknown }).code === 'RATE_LIMITED'
+            : serviceCode === 'RATE_LIMITED'
             ? 'TOO_MANY_REQUESTS'
+            : // A build-service outage is OUR fault, not a malformed request —
+              // reporting it as a 400 mislabels an incident as user error (and
+              // keeps it off the server-fault error board).
+            serviceCode === 'TRIGGER_FAILED'
+            ? 'INTERNAL_SERVER_ERROR'
             : 'BAD_REQUEST';
         throw new TRPCError({ code, message: (err as Error).message });
       }

--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -72,6 +72,7 @@ import {
   mintReviewBlockTokenSchema,
   previewRequestSchema,
   rejectRequestSchema,
+  retriggerBuildSchema,
   startAgentReviewSchema,
   teardownPreviewSchema,
   withdrawRequestSchema,
@@ -1917,6 +1918,48 @@ export const blocksRouter = router({
         });
       }
       return { ok: true };
+    }),
+
+  /**
+   * MOD-ONLY: re-fire the Tekton build for an ALREADY-APPROVED publish request
+   * whose build never started (the STRANDED case: `approveRequest` committed the
+   * approval and then threw inside `triggerBuild`, leaving `deploy_state` null
+   * forever) or whose build/deploy failed.
+   *
+   * 🔴 The commit sha is read from the DB row — the input carries NO sha, so a
+   * caller cannot name an arbitrary/unreviewed commit to build and deploy. See
+   * `retriggerBuildSchema` and the service's supersede guard.
+   *
+   * MOD-ONLY IS A DELIBERATE CHOICE, not an oversight: owner self-service would
+   * need its own abuse controls and a build-capacity budget. The owner instead
+   * gets the real build-failure reason on /apps/my-submissions plus a
+   * "contact a moderator" affordance.
+   */
+  retriggerBuild: moderatorProcedure
+    .use(enforceAppBlocksFlag)
+    .input(retriggerBuildSchema)
+    .mutation(async ({ ctx, input }) => {
+      const { retriggerBuild } = await import('~/server/services/blocks/publish-request.service');
+      if (!ctx.user?.isModerator) {
+        throw throwAuthorizationError('Re-triggering builds is restricted to civitai team');
+      }
+      try {
+        return await retriggerBuild({
+          publishRequestId: input.publishRequestId,
+          // Bound to the SESSION user — never client-supplied. Also the rate-limit
+          // subject, so a mod cannot spend another mod's quota.
+          reviewerUserId: ctx.user.id,
+        });
+      } catch (err) {
+        if (err instanceof TRPCError) throw err;
+        const code =
+          err instanceof Error && (err as { code?: unknown }).code === 'NOT_FOUND'
+            ? 'NOT_FOUND'
+            : err instanceof Error && (err as { code?: unknown }).code === 'RATE_LIMITED'
+            ? 'TOO_MANY_REQUESTS'
+            : 'BAD_REQUEST';
+        throw new TRPCError({ code, message: (err as Error).message });
+      }
     }),
 
   /**

--- a/src/server/schema/blocks/publish-request.schema.ts
+++ b/src/server/schema/blocks/publish-request.schema.ts
@@ -115,6 +115,22 @@ export const rejectRequestSchema = z.object({
 
 export type RejectRequestInput = z.infer<typeof rejectRequestSchema>;
 
+/**
+ * Input for the MOD-ONLY `blocks.retriggerBuild` — re-fire the Tekton build for
+ * an ALREADY-APPROVED request whose build never started (or failed).
+ *
+ * `publishRequestId` is the ONLY field, and that is load-bearing: the commit sha
+ * to rebuild is read from the DB row, NEVER supplied by the caller. Accepting a
+ * sha here would let a moderator rebuild + deploy an ARBITRARY commit that was
+ * never reviewed. Keeping the sha off the wire makes that structurally
+ * impossible rather than merely validated-against.
+ */
+export const retriggerBuildSchema = z.object({
+  publishRequestId: z.string().min(1).max(64),
+});
+
+export type RetriggerBuildInput = z.infer<typeof retriggerBuildSchema>;
+
 /** Input for the MOD-ONLY `blocks.getPublishRequestScreenshots` (F-E E5 review). */
 export const getPublishRequestScreenshotsSchema = z.object({
   publishRequestId: z.string().min(1).max(64),

--- a/src/server/services/blocks/__tests__/build-failure-reason.test.ts
+++ b/src/server/services/blocks/__tests__/build-failure-reason.test.ts
@@ -209,7 +209,7 @@ describe('sanitizeBuildFailureReason — adversarial fixture', () => {
     expect(out).not.toContain('[38;5;196m');
   });
 
-  it('PRESERVES HTML-ish and SQL-ish text verbatim — escaping is the renderer\'s job', () => {
+  it("PRESERVES HTML-ish and SQL-ish text verbatim — escaping is the renderer's job", () => {
     // These are legitimate build-log characters. They are safe because the value is
     // only ever rendered through escaping React text nodes / JSON, never HTML.
     const out = sanitizeBuildFailureReason(adversarial) as string;

--- a/src/server/services/blocks/__tests__/build-failure-reason.test.ts
+++ b/src/server/services/blocks/__tests__/build-failure-reason.test.ts
@@ -1,0 +1,256 @@
+import { describe, expect, it } from 'vitest';
+import {
+  BUILD_FAILURE_TRUNCATION_MARKER,
+  MAX_BUILD_FAILURE_REASON_CHARS,
+  buildFailureDeployDetail,
+  sanitizeBuildFailureReason,
+} from '../build-failure-reason';
+
+/**
+ * The build-failure excerpt is TENANT-INFLUENCED build output that reaches us over
+ * an authenticated channel. Authentication proves WHO sent it, never that the
+ * CONTENT is safe — so the sanitizer is the boundary and every one of its
+ * guarantees is pinned here.
+ *
+ * Control characters are built from `String.fromCharCode` so this test file, like
+ * the module it covers, contains no raw control bytes.
+ */
+
+const ESC = String.fromCharCode(0x1b);
+const BEL = String.fromCharCode(0x07);
+const NUL = String.fromCharCode(0x00);
+const DEL = String.fromCharCode(0x7f);
+const CSI8 = String.fromCharCode(0x9b);
+const C1 = String.fromCharCode(0x85);
+
+/** Every code point in `s` that is neither `\n` nor printable (0x20..0x7E, >=0xA0). */
+function disallowedChars(s: string): number[] {
+  const bad: number[] = [];
+  for (let i = 0; i < s.length; i += 1) {
+    const c = s.charCodeAt(i);
+    if (c === 0x0a) continue;
+    if (c < 0x20 || c === 0x7f || (c >= 0x80 && c <= 0x9f)) bad.push(c);
+  }
+  return bad;
+}
+
+describe('sanitizeBuildFailureReason — non-string / empty input', () => {
+  it('returns undefined for anything that is not a string', () => {
+    expect(sanitizeBuildFailureReason(undefined)).toBeUndefined();
+    expect(sanitizeBuildFailureReason(null)).toBeUndefined();
+    expect(sanitizeBuildFailureReason(42)).toBeUndefined();
+    expect(sanitizeBuildFailureReason(true)).toBeUndefined();
+    expect(sanitizeBuildFailureReason({ toString: () => 'boom' })).toBeUndefined();
+    expect(sanitizeBuildFailureReason(['boom'])).toBeUndefined();
+  });
+
+  it('returns undefined for empty / whitespace-only input', () => {
+    expect(sanitizeBuildFailureReason('')).toBeUndefined();
+    expect(sanitizeBuildFailureReason('   ')).toBeUndefined();
+    expect(sanitizeBuildFailureReason('\n\n\n')).toBeUndefined();
+    expect(sanitizeBuildFailureReason(' \t \r\n  \n ')).toBeUndefined();
+  });
+
+  it('returns undefined when the input is ONLY escape sequences / control chars', () => {
+    expect(sanitizeBuildFailureReason(`${ESC}[0m${ESC}[1;31m`)).toBeUndefined();
+    expect(sanitizeBuildFailureReason(`${NUL}${DEL}${C1}`)).toBeUndefined();
+  });
+});
+
+describe('sanitizeBuildFailureReason — the real-world happy path', () => {
+  it('passes an ordinary build error through verbatim', () => {
+    const msg =
+      'ERROR: no package-lock.json is committed. Commit your lockfile — `npm install` then commit.';
+    expect(sanitizeBuildFailureReason(msg)).toBe(msg);
+  });
+
+  it('preserves interior newlines and the shape of a multi-line log', () => {
+    const msg = 'ERROR: build failed\n  at Object.<anonymous> (index.ts:3:9)\n  exit code 1';
+    expect(sanitizeBuildFailureReason(msg)).toBe(msg);
+  });
+});
+
+describe('sanitizeBuildFailureReason — escape sequences', () => {
+  it('strips CSI/SGR colour codes but keeps the text they wrapped', () => {
+    const out = sanitizeBuildFailureReason(`${ESC}[1;31mERROR${ESC}[0m: missing lockfile`);
+    expect(out).toBe('ERROR: missing lockfile');
+    expect(out).not.toContain('[1;31m');
+    expect(out).not.toContain('[0m');
+  });
+
+  it('strips an OSC window-title sequence (BEL-terminated)', () => {
+    const out = sanitizeBuildFailureReason(`${ESC}]0;pwned${BEL}build failed`);
+    expect(out).toBe('build failed');
+    expect(out).not.toContain('pwned');
+  });
+
+  it('strips an OSC sequence terminated by ST (ESC backslash)', () => {
+    const out = sanitizeBuildFailureReason(`${ESC}]8;;https://evil.example${ESC}\\click`);
+    expect(out).toBe('click');
+    expect(out).not.toContain('evil.example');
+  });
+
+  it('strips an UNTERMINATED OSC sequence (nothing is left dangling)', () => {
+    expect(sanitizeBuildFailureReason(`before ${ESC}]0;never-closed`)).toBe('before');
+  });
+
+  it('strips an 8-bit CSI introducer', () => {
+    expect(sanitizeBuildFailureReason(`${CSI8}31mred text`)).toBe('red text');
+  });
+
+  it('strips two-character escapes and a lone trailing ESC', () => {
+    expect(sanitizeBuildFailureReason(`${ESC}(Bplain${ESC}`)).toBe('plain');
+  });
+
+  it('strips cursor-movement / erase sequences that would rewrite the terminal', () => {
+    expect(sanitizeBuildFailureReason(`line one${ESC}[2K${ESC}[1Aoverwrite`)).toBe(
+      'line oneoverwrite'
+    );
+  });
+});
+
+describe('sanitizeBuildFailureReason — control characters', () => {
+  it('drops NUL, DEL, VT/FF and C1 controls', () => {
+    const out = sanitizeBuildFailureReason(
+      `a${NUL}b${DEL}c${String.fromCharCode(0x0b)}d${String.fromCharCode(0x0c)}e${C1}f`
+    );
+    expect(out).toBe('abcdef');
+  });
+
+  it('converts CRLF to LF and DROPS a bare CR', () => {
+    expect(sanitizeBuildFailureReason('one\r\ntwo')).toBe('one\ntwo');
+    expect(sanitizeBuildFailureReason('one\rtwo')).toBe('onetwo');
+    expect(sanitizeBuildFailureReason('progress\rdone')).not.toContain('\r');
+  });
+
+  it('converts tabs to spaces (word separation preserved)', () => {
+    expect(sanitizeBuildFailureReason('key\tvalue')).toBe('key value');
+    expect(sanitizeBuildFailureReason('a\t\tb')).toBe('a  b');
+  });
+
+  it('keeps newline as the ONE surviving control character', () => {
+    const out = sanitizeBuildFailureReason('a\nb') as string;
+    expect(out).toBe('a\nb');
+    expect(disallowedChars(out)).toEqual([]);
+  });
+});
+
+describe('sanitizeBuildFailureReason — whitespace normalization', () => {
+  it('collapses runs of blank lines to a single blank line', () => {
+    expect(sanitizeBuildFailureReason('a\n\n\n\n\nb')).toBe('a\n\nb');
+  });
+
+  it('keeps a single blank line as-is', () => {
+    expect(sanitizeBuildFailureReason('a\n\nb')).toBe('a\n\nb');
+  });
+
+  it('strips trailing spaces on each line', () => {
+    expect(sanitizeBuildFailureReason('a   \nb  \nc')).toBe('a\nb\nc');
+  });
+
+  it('trims leading/trailing whitespace of the whole excerpt', () => {
+    expect(sanitizeBuildFailureReason('\n\n  real message  \n\n')).toBe('real message');
+  });
+});
+
+describe('sanitizeBuildFailureReason — truncation boundary', () => {
+  it('leaves an excerpt exactly AT the cap untouched (no marker)', () => {
+    const atCap = 'x'.repeat(MAX_BUILD_FAILURE_REASON_CHARS);
+    const out = sanitizeBuildFailureReason(atCap) as string;
+    expect(out).toBe(atCap);
+    expect(out.length).toBe(MAX_BUILD_FAILURE_REASON_CHARS);
+    expect(out.endsWith(BUILD_FAILURE_TRUNCATION_MARKER)).toBe(false);
+  });
+
+  it('truncates ONE char over the cap and marks it', () => {
+    const overCap = 'x'.repeat(MAX_BUILD_FAILURE_REASON_CHARS + 1);
+    const out = sanitizeBuildFailureReason(overCap) as string;
+    expect(out.length).toBe(MAX_BUILD_FAILURE_REASON_CHARS);
+    expect(out.endsWith(BUILD_FAILURE_TRUNCATION_MARKER)).toBe(true);
+  });
+
+  it('never exceeds the cap even for a hugely oversized input', () => {
+    const huge = 'abcdefghij'.repeat(5000); // 50k chars, well past the input ceiling
+    const out = sanitizeBuildFailureReason(huge) as string;
+    expect(out.length).toBeLessThanOrEqual(MAX_BUILD_FAILURE_REASON_CHARS);
+    expect(out.endsWith(BUILD_FAILURE_TRUNCATION_MARKER)).toBe(true);
+  });
+
+  it('the total stored deploy_detail stays under the 4000-char budget', () => {
+    const detail = buildFailureDeployDetail('F'.repeat(500), 'y'.repeat(50_000));
+    expect(detail.length).toBeLessThan(4000);
+  });
+});
+
+describe('sanitizeBuildFailureReason — adversarial fixture', () => {
+  // Everything a hostile author could plausibly put in their own build output.
+  const adversarial = [
+    `${ESC}]0;title-injection${BEL}`,
+    `${ESC}[38;5;196mSCARY${ESC}[0m`,
+    '</script><script>alert(1)</script>',
+    '"; DROP TABLE app_blocks; --',
+    'back\\slash and "quotes" and \'apostrophes\'',
+    `nul>${NUL}<del>${DEL}<c1>${C1}<`,
+    'carriage\rreturn\ttab',
+    `${CSI8}2J`,
+  ].join('\n');
+
+  it('produces printable text + newlines ONLY', () => {
+    const out = sanitizeBuildFailureReason(adversarial) as string;
+    expect(out).toBeDefined();
+    expect(disallowedChars(out)).toEqual([]);
+  });
+
+  it('removes every escape sequence and its payload', () => {
+    const out = sanitizeBuildFailureReason(adversarial) as string;
+    expect(out).not.toContain(ESC);
+    expect(out).not.toContain(CSI8);
+    expect(out).not.toContain('title-injection');
+    expect(out).not.toContain('[38;5;196m');
+  });
+
+  it('PRESERVES HTML-ish and SQL-ish text verbatim — escaping is the renderer\'s job', () => {
+    // These are legitimate build-log characters. They are safe because the value is
+    // only ever rendered through escaping React text nodes / JSON, never HTML.
+    const out = sanitizeBuildFailureReason(adversarial) as string;
+    expect(out).toContain('</script><script>alert(1)</script>');
+    expect(out).toContain('DROP TABLE app_blocks');
+    expect(out).toContain('back\\slash and "quotes"');
+  });
+
+  it('is idempotent — sanitizing twice changes nothing', () => {
+    const once = sanitizeBuildFailureReason(adversarial) as string;
+    expect(sanitizeBuildFailureReason(once)).toBe(once);
+  });
+});
+
+describe('buildFailureDeployDetail — the DARK-SAFE contract', () => {
+  it('with NO reason produces byte-identically what shipped before this feature', () => {
+    // The pre-feature expression was: `Build ${String(status ?? 'failed').slice(0, 60)}`.
+    expect(buildFailureDeployDetail('Failed', undefined)).toBe('Build Failed');
+    expect(buildFailureDeployDetail('Cancelled', undefined)).toBe('Build Cancelled');
+    expect(buildFailureDeployDetail(undefined, undefined)).toBe('Build failed');
+  });
+
+  it('a non-string reason is ignored — same string as no reason at all', () => {
+    expect(buildFailureDeployDetail('Failed', 12345)).toBe('Build Failed');
+    expect(buildFailureDeployDetail('Failed', { message: 'nope' })).toBe('Build Failed');
+    expect(buildFailureDeployDetail('Failed', ['nope'])).toBe('Build Failed');
+  });
+
+  it('a reason that sanitizes to nothing is ignored — same string as no reason', () => {
+    expect(buildFailureDeployDetail('Failed', '   \n\n  ')).toBe('Build Failed');
+    expect(buildFailureDeployDetail('Failed', `${ESC}[0m`)).toBe('Build Failed');
+  });
+
+  it('appends a surviving excerpt after a blank line, keeping the Build prefix', () => {
+    expect(buildFailureDeployDetail('Failed', 'ERROR: no package-lock.json is committed')).toBe(
+      'Build Failed\n\nERROR: no package-lock.json is committed'
+    );
+  });
+
+  it('keeps clamping the status prefix to 60 chars (unchanged behaviour)', () => {
+    const detail = buildFailureDeployDetail('S'.repeat(200), 'why');
+    expect(detail.startsWith(`Build ${'S'.repeat(60)}\n\n`)).toBe(true);
+  });
+});

--- a/src/server/services/blocks/__tests__/publish-request.retriggerBuild.test.ts
+++ b/src/server/services/blocks/__tests__/publish-request.retriggerBuild.test.ts
@@ -1,0 +1,391 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { DEPLOY_STALE_AFTER_MS } from '~/shared/constants/app-block-deploy.constants';
+
+/**
+ * `retriggerBuild` — the recovery path for an APPROVED publish request whose build
+ * never ran.
+ *
+ * WHY IT EXISTS: `approveRequest` writes `status='approved'` + `forgejo_commit_sha`
+ * and only THEN calls `markRequestDeployState(...,'building')`. When `triggerBuild`
+ * threw in between (a transient 502 from the build trigger, seen in production),
+ * the approve was durable but `deploy_state` stayed NULL forever. `approveRequest`
+ * is not idempotent, so the request was UNRECOVERABLE.
+ *
+ * Every guard below has a test for BOTH its passing and its failing branch. The
+ * load-bearing one is (3): the sha comes from the DB, never the caller.
+ */
+
+const { mockDbRead, mockUpdateMany, mockTriggerBuild, mockSetCommitStatus, mockRedis, limiter } =
+  vi.hoisted(() => {
+    const mockRedis = { nxResult: true, nxThrows: false, quotaAllowed: true };
+    return {
+      mockRedis,
+      mockDbRead: { appBlockPublishRequest: { findUnique: vi.fn() } },
+      // `markRequestDeployState` lives in the module UNDER TEST, so it cannot be
+      // mocked — assert on the DB write it performs instead. That is the stronger
+      // assertion anyway: it pins the actual persisted row, not a call to a spy.
+      mockUpdateMany: vi.fn(async () => ({ count: 1 })),
+      mockTriggerBuild: vi.fn<(...a: any[]) => Promise<{ name: string }>>(async () => ({
+        name: 'pipelinerun-1',
+      })),
+      mockSetCommitStatus: vi.fn(async () => undefined),
+      limiter: {
+        acquire: vi.fn(async () => mockRedis.nxResult),
+        release: vi.fn(async () => undefined),
+        quota: vi.fn(async () =>
+          mockRedis.quotaAllowed
+            ? ({ allowed: true } as const)
+            : ({ allowed: false, retryAfterSeconds: 1800 } as const)
+        ),
+      },
+    };
+  });
+
+vi.mock('~/server/db/client', () => ({
+  dbRead: mockDbRead,
+  dbWrite: { appBlockPublishRequest: { updateMany: mockUpdateMany } },
+}));
+vi.mock('~/env/server', () => ({
+  env: { FORGEJO_BASE_URL: 'https://forge.example', FORGEJO_ADMIN_TOKEN: 'tok' },
+}));
+vi.mock('~/server/services/blocks/apps-pipeline.service', () => ({
+  triggerBuild: mockTriggerBuild,
+}));
+vi.mock('~/server/services/blocks/forgejo.service', () => ({
+  setCommitStatus: mockSetCommitStatus,
+  reviewRepoUrl: vi.fn(() => ''),
+  repoCommitUrl: vi.fn(() => ''),
+  listRepoTreeAtRef: vi.fn(),
+  getBlobContent: vi.fn(),
+  commitFiles: vi.fn(),
+  createRepoFromTemplate: vi.fn(),
+  ensurePushWebhook: vi.fn(),
+}));
+vi.mock('~/server/utils/blocks-retrigger-rate-limit', () => ({
+  acquireRetriggerLock: limiter.acquire,
+  releaseRetriggerLock: limiter.release,
+  checkRetriggerModeratorQuota: limiter.quota,
+}));
+
+const SHA = 'a'.repeat(40);
+const OTHER_SHA = 'b'.repeat(40);
+const APB = 'apb_0123456789ABCDEFGHJKMNPQRS';
+const REQ_ID = 'pubreq_1';
+const MOD_ID = 7;
+
+/** An approved-but-STRANDED request: the exact production shape of defect B. */
+function strandedRow(over: Record<string, unknown> = {}) {
+  return {
+    id: REQ_ID,
+    status: 'approved',
+    slug: 'my-app',
+    appBlockId: APB,
+    forgejoCommitSha: SHA,
+    deployState: null,
+    deployUpdatedAt: null,
+    appBlock: { id: APB, currentVersionSha: SHA },
+    ...over,
+  };
+}
+
+async function callRetrigger(overrides: Record<string, unknown> = {}) {
+  mockDbRead.appBlockPublishRequest.findUnique.mockResolvedValue(strandedRow(overrides));
+  const { retriggerBuild } = await import('../publish-request.service');
+  return retriggerBuild({ publishRequestId: REQ_ID, reviewerUserId: MOD_ID });
+}
+
+/** Assert the call rejects with a RetriggerBuildError carrying `code`. */
+async function expectRejectCode(promise: Promise<unknown>, code: string) {
+  await expect(promise).rejects.toMatchObject({ name: 'RetriggerBuildError', code });
+}
+
+/** The deploy-lifecycle writes `markRequestDeployState` performed, flattened. */
+function deployWrites(): Array<{ slug: string; sha: string; state: string; detail: string | null }> {
+  return mockUpdateMany.mock.calls.map((call) => {
+    const arg = call[0] as {
+      where: { slug: string; forgejoCommitSha: string };
+      data: { deployState: string; deployDetail: string | null };
+    };
+    return {
+      slug: arg.where.slug,
+      sha: arg.where.forgejoCommitSha,
+      state: arg.data.deployState,
+      detail: arg.data.deployDetail,
+    };
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockRedis.nxResult = true;
+  mockRedis.quotaAllowed = true;
+  mockTriggerBuild.mockResolvedValue({ name: 'pipelinerun-1' });
+});
+
+describe('retriggerBuild — happy path', () => {
+  it('fires the build with the DB sha and marks the request building', async () => {
+    const result = await callRetrigger();
+
+    expect(mockTriggerBuild).toHaveBeenCalledTimes(1);
+    expect(mockTriggerBuild).toHaveBeenCalledWith(
+      expect.objectContaining({ slug: 'my-app', sha: SHA, appBlockId: APB })
+    );
+    expect(mockTriggerBuild.mock.calls[0][0].callbackUrl).toContain(
+      '/api/internal/blocks/build-callback'
+    );
+    expect(deployWrites()).toEqual([
+      {
+        slug: 'my-app',
+        sha: SHA,
+        state: 'building',
+        detail: expect.stringContaining(`moderator #${MOD_ID}`),
+      },
+    ]);
+    expect(result).toEqual({ publishRequestId: REQ_ID, appBlockId: APB, forgejoCommitSha: SHA });
+  });
+
+  it('sets a pending commit status before triggering', async () => {
+    await callRetrigger();
+    expect(mockSetCommitStatus).toHaveBeenCalledWith(
+      expect.objectContaining({ sha: SHA, state: 'pending', context: 'civitai/build' })
+    );
+  });
+
+  it('performs NONE of approveRequest side effects (no re-commit, no block mutation)', async () => {
+    const forgejo = await import('~/server/services/blocks/forgejo.service');
+    await callRetrigger();
+    expect(vi.mocked(forgejo.commitFiles)).not.toHaveBeenCalled();
+    expect(vi.mocked(forgejo.createRepoFromTemplate)).not.toHaveBeenCalled();
+    expect(vi.mocked(forgejo.ensurePushWebhook)).not.toHaveBeenCalled();
+  });
+
+  it('allows a previously FAILED build', async () => {
+    await expect(
+      callRetrigger({ deployState: 'failed', deployUpdatedAt: new Date() })
+    ).resolves.toMatchObject({ forgejoCommitSha: SHA });
+    expect(mockTriggerBuild).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('retriggerBuild — guard 1: request must exist', () => {
+  it('NOT_FOUND when the row does not exist', async () => {
+    mockDbRead.appBlockPublishRequest.findUnique.mockResolvedValue(null);
+    const { retriggerBuild } = await import('../publish-request.service');
+    await expectRejectCode(
+      retriggerBuild({ publishRequestId: 'nope', reviewerUserId: MOD_ID }),
+      'NOT_FOUND'
+    );
+    expect(mockTriggerBuild).not.toHaveBeenCalled();
+  });
+});
+
+describe('retriggerBuild — guard 2: status must be approved', () => {
+  it.each(['pending', 'rejected', 'withdrawn'])('refuses status=%s', async (status) => {
+    await expectRejectCode(callRetrigger({ status }), 'NOT_RETRIGGERABLE');
+    expect(mockTriggerBuild).not.toHaveBeenCalled();
+  });
+});
+
+describe('retriggerBuild — guard 3: the sha comes from the DB, never the caller', () => {
+  it('refuses a request with NO stored sha', async () => {
+    await expectRejectCode(callRetrigger({ forgejoCommitSha: null }), 'NOT_RETRIGGERABLE');
+    expect(mockTriggerBuild).not.toHaveBeenCalled();
+  });
+
+  it('refuses an empty stored sha', async () => {
+    await expectRejectCode(callRetrigger({ forgejoCommitSha: '' }), 'NOT_RETRIGGERABLE');
+    expect(mockTriggerBuild).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ['too short', 'abc123'],
+    ['too long', 'a'.repeat(41)],
+    ['uppercase hex', 'A'.repeat(40)],
+    ['non-hex', 'g'.repeat(40)],
+    ['a git ref instead of a sha', 'refs/heads/main'],
+    ['path traversal', '../'.repeat(13) + 'a'],
+  ])('refuses a malformed stored sha (%s)', async (_label, sha) => {
+    await expectRejectCode(callRetrigger({ forgejoCommitSha: sha }), 'NOT_RETRIGGERABLE');
+    expect(mockTriggerBuild).not.toHaveBeenCalled();
+  });
+
+  it('IGNORES any caller-supplied sha — only the DB value reaches triggerBuild', async () => {
+    // The tRPC input schema has no sha field, but pin the SERVICE too: even when a
+    // caller smuggles extra properties into the params object, the sha handed to
+    // triggerBuild is the one read from the row.
+    mockDbRead.appBlockPublishRequest.findUnique.mockResolvedValue(strandedRow());
+    const { retriggerBuild } = await import('../publish-request.service');
+    await retriggerBuild({
+      publishRequestId: REQ_ID,
+      reviewerUserId: MOD_ID,
+      // deliberately not part of RetriggerBuildParams
+      ...({ sha: OTHER_SHA, forgejoCommitSha: OTHER_SHA } as unknown as object),
+    } as never);
+    expect(mockTriggerBuild).toHaveBeenCalledWith(expect.objectContaining({ sha: SHA }));
+    expect(mockTriggerBuild).not.toHaveBeenCalledWith(expect.objectContaining({ sha: OTHER_SHA }));
+  });
+});
+
+describe('retriggerBuild — guard 4: appBlockId must be present', () => {
+  it('refuses a request with no backing app block', async () => {
+    await expectRejectCode(
+      callRetrigger({ appBlockId: null, appBlock: null }),
+      'NOT_RETRIGGERABLE'
+    );
+    expect(mockTriggerBuild).not.toHaveBeenCalled();
+  });
+});
+
+describe('retriggerBuild — guard 5: superseded by a newer approved version', () => {
+  it('refuses when the app has since moved to a DIFFERENT sha', async () => {
+    await expectRejectCode(
+      callRetrigger({ appBlock: { id: APB, currentVersionSha: OTHER_SHA } }),
+      'NOT_RETRIGGERABLE'
+    );
+    // Rebuilding here would deploy OLDER code over the current version.
+    expect(mockTriggerBuild).not.toHaveBeenCalled();
+  });
+
+  it('allows when the app current sha still matches this request', async () => {
+    await expect(
+      callRetrigger({ appBlock: { id: APB, currentVersionSha: SHA } })
+    ).resolves.toBeTruthy();
+  });
+
+  it('allows when the app has no current sha yet (first version never deployed)', async () => {
+    await expect(
+      callRetrigger({ appBlock: { id: APB, currentVersionSha: null } })
+    ).resolves.toBeTruthy();
+  });
+});
+
+describe('retriggerBuild — guard 6: deploy-state gate', () => {
+  const stale = () => new Date(Date.now() - DEPLOY_STALE_AFTER_MS - 60_000);
+  const freshTs = () => new Date(Date.now() - 30_000);
+
+  it('refuses an ALREADY-DEPLOYED (live) version', async () => {
+    await expectRejectCode(
+      callRetrigger({ deployState: 'live', deployUpdatedAt: freshTs() }),
+      'NOT_RETRIGGERABLE'
+    );
+    expect(mockTriggerBuild).not.toHaveBeenCalled();
+  });
+
+  it.each(['preview-building', 'preview-deploying', 'preview-live', 'preview-failed'])(
+    'refuses the review-preview lane state %s',
+    async (deployState) => {
+      await expectRejectCode(
+        callRetrigger({ deployState, deployUpdatedAt: stale() }),
+        'NOT_RETRIGGERABLE'
+      );
+      expect(mockTriggerBuild).not.toHaveBeenCalled();
+    }
+  );
+
+  it.each(['building', 'deploying'])(
+    'refuses a FRESH in-flight %s (never race two PipelineRuns)',
+    async (deployState) => {
+      await expectRejectCode(
+        callRetrigger({ deployState, deployUpdatedAt: freshTs() }),
+        'NOT_RETRIGGERABLE'
+      );
+      expect(mockTriggerBuild).not.toHaveBeenCalled();
+    }
+  );
+
+  it.each(['building', 'deploying'])(
+    'ALLOWS a %s that has stalled past the shared threshold',
+    async (deployState) => {
+      await expect(
+        callRetrigger({ deployState, deployUpdatedAt: stale() })
+      ).resolves.toBeTruthy();
+      expect(mockTriggerBuild).toHaveBeenCalledTimes(1);
+    }
+  );
+
+  it('refuses an in-flight state with no timestamp to judge staleness by', async () => {
+    await expectRejectCode(
+      callRetrigger({ deployState: 'building', deployUpdatedAt: null }),
+      'NOT_RETRIGGERABLE'
+    );
+  });
+
+  it('refuses an unrecognized deploy state rather than guessing', async () => {
+    await expectRejectCode(
+      callRetrigger({ deployState: 'quantum', deployUpdatedAt: stale() }),
+      'NOT_RETRIGGERABLE'
+    );
+  });
+});
+
+describe('retriggerBuild — guard 7: rate limit + double-click idempotency', () => {
+  it('refuses when the per-moderator quota is exhausted', async () => {
+    mockRedis.quotaAllowed = false;
+    await expectRejectCode(callRetrigger(), 'RATE_LIMITED');
+    expect(mockTriggerBuild).not.toHaveBeenCalled();
+  });
+
+  it('charges the quota to the SESSION moderator id', async () => {
+    await callRetrigger();
+    expect(limiter.quota).toHaveBeenCalledWith(MOD_ID);
+  });
+
+  it('a DOUBLE-FIRE within the lock window does not create a second build', async () => {
+    // First call takes the lock.
+    await callRetrigger();
+    expect(mockTriggerBuild).toHaveBeenCalledTimes(1);
+    // Second call: the NX lock is already held.
+    mockRedis.nxResult = false;
+    await expectRejectCode(callRetrigger(), 'RATE_LIMITED');
+    expect(mockTriggerBuild).toHaveBeenCalledTimes(1); // still ONE
+  });
+
+  it('takes the single-flight lock keyed on the publish request', async () => {
+    await callRetrigger();
+    expect(limiter.acquire).toHaveBeenCalledWith(REQ_ID);
+  });
+
+  it('checks the quota and the lock BEFORE triggering anything', async () => {
+    mockRedis.quotaAllowed = false;
+    await expectRejectCode(callRetrigger(), 'RATE_LIMITED');
+    expect(limiter.acquire).not.toHaveBeenCalled();
+    expect(mockSetCommitStatus).not.toHaveBeenCalled();
+  });
+});
+
+describe('retriggerBuild — guard 8: a failing trigger becomes VISIBLE', () => {
+  it("marks the request 'failed' with a reason when triggerBuild throws", async () => {
+    mockTriggerBuild.mockRejectedValue(new Error('trigger 502 Bad Gateway'));
+    await expectRejectCode(callRetrigger(), 'TRIGGER_FAILED');
+    // This is the crux: the stranded-invisible state becomes a VISIBLE failure
+    // even when the recovery itself fails.
+    expect(deployWrites()).toEqual([
+      {
+        slug: 'my-app',
+        sha: SHA,
+        state: 'failed',
+        detail: expect.stringContaining('Re-trigger failed'),
+      },
+    ]);
+  });
+
+  it('flips the commit status to failure when triggerBuild throws', async () => {
+    mockTriggerBuild.mockRejectedValue(new Error('boom'));
+    await expectRejectCode(callRetrigger(), 'TRIGGER_FAILED');
+    expect(mockSetCommitStatus).toHaveBeenCalledWith(
+      expect.objectContaining({ state: 'failure', context: 'civitai/build' })
+    );
+  });
+
+  it('frees the single-flight lock on failure so a retry is not wedged', async () => {
+    mockTriggerBuild.mockRejectedValue(new Error('boom'));
+    await expectRejectCode(callRetrigger(), 'TRIGGER_FAILED');
+    expect(limiter.release).toHaveBeenCalledWith(REQ_ID);
+  });
+
+  it('never marks building when the trigger failed', async () => {
+    mockTriggerBuild.mockRejectedValue(new Error('boom'));
+    await expectRejectCode(callRetrigger(), 'TRIGGER_FAILED');
+    expect(deployWrites().map((w) => w.state)).not.toContain('building');
+  });
+});

--- a/src/server/services/blocks/__tests__/publish-request.retriggerBuild.test.ts
+++ b/src/server/services/blocks/__tests__/publish-request.retriggerBuild.test.ts
@@ -1,5 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { DEPLOY_STALE_AFTER_MS } from '~/shared/constants/app-block-deploy.constants';
+import {
+  DEPLOY_PENDING_GRACE_MS,
+  DEPLOY_STALE_AFTER_MS,
+} from '~/shared/constants/app-block-deploy.constants';
 
 /**
  * `retriggerBuild` — the recovery path for an APPROVED publish request whose build
@@ -13,38 +16,60 @@ import { DEPLOY_STALE_AFTER_MS } from '~/shared/constants/app-block-deploy.const
  *
  * Every guard below has a test for BOTH its passing and its failing branch. The
  * load-bearing one is (3): the sha comes from the DB, never the caller.
+ *
+ * 🔴 GUARD TESTS MUST BE INDEPENDENTLY KILLING. An earlier revision of this suite
+ * asserted the sha guard with `NOT_RETRIGGERABLE` — the same code the SUPERSEDE
+ * guard throws — while the fixture pinned `appBlock.currentVersionSha = SHA`. A
+ * malformed `forgejoCommitSha` therefore tripped supersede too, and deleting the
+ * `/^[0-9a-f]{40}$/` check left all 41 tests green. The fix is BOTH halves: the sha
+ * guard has its own `INVALID_STORED_SHA` code, and the sha cases null out
+ * `currentVersionSha` so no other guard can stand in for it. Verified by mutation:
+ * deleting the sha check now fails these tests.
  */
 
-const { mockDbRead, mockUpdateMany, mockTriggerBuild, mockSetCommitStatus, mockRedis, limiter } =
-  vi.hoisted(() => {
-    const mockRedis = { nxResult: true, nxThrows: false, quotaAllowed: true };
-    return {
-      mockRedis,
-      mockDbRead: { appBlockPublishRequest: { findUnique: vi.fn() } },
-      // `markRequestDeployState` lives in the module UNDER TEST, so it cannot be
-      // mocked — assert on the DB write it performs instead. That is the stronger
-      // assertion anyway: it pins the actual persisted row, not a call to a spy.
-      mockUpdateMany: vi.fn(async () => ({ count: 1 })),
-      mockTriggerBuild: vi.fn<(...a: any[]) => Promise<{ name: string }>>(async () => ({
-        name: 'pipelinerun-1',
-      })),
-      mockSetCommitStatus: vi.fn(async () => undefined),
-      limiter: {
-        acquire: vi.fn(async () => mockRedis.nxResult),
-        release: vi.fn(async () => undefined),
-        quota: vi.fn(async () =>
-          mockRedis.quotaAllowed
-            ? ({ allowed: true } as const)
-            : ({ allowed: false, retryAfterSeconds: 1800 } as const)
-        ),
-      },
-    };
-  });
+const {
+  mockDbRead,
+  mockDbWriteFindUnique,
+  mockUpdateMany,
+  mockTriggerBuild,
+  mockSetCommitStatus,
+  mockRedis,
+  limiter,
+} = vi.hoisted(() => {
+  const mockRedis = { nxResult: true, nxThrows: false, quotaAllowed: true };
+  return {
+    mockRedis,
+    // The READ REPLICA. `retriggerBuild` must NOT consult it for any guard — it
+    // is wired here precisely so a regression back to `dbRead` is detectable.
+    mockDbRead: { appBlockPublishRequest: { findUnique: vi.fn() } },
+    mockDbWriteFindUnique: vi.fn(),
+    // `markRequestDeployState` lives in the module UNDER TEST, so it cannot be
+    // mocked — assert on the DB write it performs instead. That is the stronger
+    // assertion anyway: it pins the actual persisted row, not a call to a spy.
+    mockUpdateMany: vi.fn(async () => ({ count: 1 })),
+    mockTriggerBuild: vi.fn<(...a: any[]) => Promise<{ name: string }>>(async () => ({
+      name: 'pipelinerun-1',
+    })),
+    mockSetCommitStatus: vi.fn(async () => undefined),
+    limiter: {
+      acquire: vi.fn(async () => mockRedis.nxResult),
+      release: vi.fn(async () => undefined),
+      quota: vi.fn(async () =>
+        mockRedis.quotaAllowed
+          ? ({ allowed: true } as const)
+          : ({ allowed: false, retryAfterSeconds: 1800 } as const)
+      ),
+    },
+  };
+});
 
 vi.mock('~/server/db/client', () => ({
   dbRead: mockDbRead,
-  dbWrite: { appBlockPublishRequest: { updateMany: mockUpdateMany } },
+  dbWrite: {
+    appBlockPublishRequest: { findUnique: mockDbWriteFindUnique, updateMany: mockUpdateMany },
+  },
 }));
+vi.mock('~/server/logging/client', () => ({ logToAxiom: vi.fn(async () => undefined) }));
 vi.mock('~/env/server', () => ({
   env: { FORGEJO_BASE_URL: 'https://forge.example', FORGEJO_ADMIN_TOKEN: 'tok' },
 }));
@@ -73,6 +98,9 @@ const APB = 'apb_0123456789ABCDEFGHJKMNPQRS';
 const REQ_ID = 'pubreq_1';
 const MOD_ID = 7;
 
+/** Older than the post-approval grace window — a genuinely stranded approval. */
+const strandedReviewedAt = () => new Date(Date.now() - DEPLOY_STALE_AFTER_MS - 60_000);
+
 /** An approved-but-STRANDED request: the exact production shape of defect B. */
 function strandedRow(over: Record<string, unknown> = {}) {
   return {
@@ -83,13 +111,16 @@ function strandedRow(over: Record<string, unknown> = {}) {
     forgejoCommitSha: SHA,
     deployState: null,
     deployUpdatedAt: null,
+    // `approveRequest` always stamps this; it is the anchor for the null-state
+    // grace window, so the realistic fixture carries it.
+    reviewedAt: strandedReviewedAt(),
     appBlock: { id: APB, currentVersionSha: SHA },
     ...over,
   };
 }
 
 async function callRetrigger(overrides: Record<string, unknown> = {}) {
-  mockDbRead.appBlockPublishRequest.findUnique.mockResolvedValue(strandedRow(overrides));
+  mockDbWriteFindUnique.mockResolvedValue(strandedRow(overrides));
   const { retriggerBuild } = await import('../publish-request.service');
   return retriggerBuild({ publishRequestId: REQ_ID, reviewerUserId: MOD_ID });
 }
@@ -174,7 +205,7 @@ describe('retriggerBuild — happy path', () => {
 
 describe('retriggerBuild — guard 1: request must exist', () => {
   it('NOT_FOUND when the row does not exist', async () => {
-    mockDbRead.appBlockPublishRequest.findUnique.mockResolvedValue(null);
+    mockDbWriteFindUnique.mockResolvedValue(null);
     const { retriggerBuild } = await import('../publish-request.service');
     await expectRejectCode(
       retriggerBuild({ publishRequestId: 'nope', reviewerUserId: MOD_ID }),
@@ -192,13 +223,27 @@ describe('retriggerBuild — guard 2: status must be approved', () => {
 });
 
 describe('retriggerBuild — guard 3: the sha comes from the DB, never the caller', () => {
+  /**
+   * Every case here nulls out `appBlock.currentVersionSha` so the SUPERSEDE guard
+   * (5) — which a malformed sha would otherwise also trip — cannot be what rejects
+   * the call. Combined with the guard's own `INVALID_STORED_SHA` code, these
+   * assertions are killed by deleting the sha check and by nothing else.
+   */
+  const noBlockSha = { appBlock: { id: APB, currentVersionSha: null } };
+
   it('refuses a request with NO stored sha', async () => {
-    await expectRejectCode(callRetrigger({ forgejoCommitSha: null }), 'NOT_RETRIGGERABLE');
+    await expectRejectCode(
+      callRetrigger({ forgejoCommitSha: null, ...noBlockSha }),
+      'INVALID_STORED_SHA'
+    );
     expect(mockTriggerBuild).not.toHaveBeenCalled();
   });
 
   it('refuses an empty stored sha', async () => {
-    await expectRejectCode(callRetrigger({ forgejoCommitSha: '' }), 'NOT_RETRIGGERABLE');
+    await expectRejectCode(
+      callRetrigger({ forgejoCommitSha: '', ...noBlockSha }),
+      'INVALID_STORED_SHA'
+    );
     expect(mockTriggerBuild).not.toHaveBeenCalled();
   });
 
@@ -210,7 +255,10 @@ describe('retriggerBuild — guard 3: the sha comes from the DB, never the calle
     ['a git ref instead of a sha', 'refs/heads/main'],
     ['path traversal', '../'.repeat(13) + 'a'],
   ])('refuses a malformed stored sha (%s)', async (_label, sha) => {
-    await expectRejectCode(callRetrigger({ forgejoCommitSha: sha }), 'NOT_RETRIGGERABLE');
+    await expectRejectCode(
+      callRetrigger({ forgejoCommitSha: sha, ...noBlockSha }),
+      'INVALID_STORED_SHA'
+    );
     expect(mockTriggerBuild).not.toHaveBeenCalled();
   });
 
@@ -218,7 +266,7 @@ describe('retriggerBuild — guard 3: the sha comes from the DB, never the calle
     // The tRPC input schema has no sha field, but pin the SERVICE too: even when a
     // caller smuggles extra properties into the params object, the sha handed to
     // triggerBuild is the one read from the row.
-    mockDbRead.appBlockPublishRequest.findUnique.mockResolvedValue(strandedRow());
+    mockDbWriteFindUnique.mockResolvedValue(strandedRow());
     const { retriggerBuild } = await import('../publish-request.service');
     await retriggerBuild({
       publishRequestId: REQ_ID,
@@ -260,6 +308,113 @@ describe('retriggerBuild — guard 5: superseded by a newer approved version', (
   it('allows when the app has no current sha yet (first version never deployed)', async () => {
     await expect(
       callRetrigger({ appBlock: { id: APB, currentVersionSha: null } })
+    ).resolves.toBeTruthy();
+  });
+});
+
+/**
+ * TOCTOU — every guard value must come from the PRIMARY.
+ *
+ * `dbRead` is a SEPARATE readonly client that can lag behind `dbWrite`. Reading a
+ * guard off it means deciding on a stale world: within the lag window an approval
+ * that has already moved on still looks re-triggerable. Both races below are
+ * expressed the only way that actually proves the fix — the replica is stubbed
+ * with the PERMISSIVE (stale) row and the primary with the CURRENT one, so a
+ * regression to `dbRead` flips each assertion.
+ */
+describe('retriggerBuild — reads its guards from the PRIMARY, not the replica', () => {
+  it('never consults the read replica at all', async () => {
+    await callRetrigger();
+    expect(mockDbWriteFindUnique).toHaveBeenCalledTimes(1);
+    expect(mockDbRead.appBlockPublishRequest.findUnique).not.toHaveBeenCalled();
+  });
+
+  it('RACE 1 — a v2 approval that has not reached the replica still supersedes v1', async () => {
+    // Primary: the app has already moved to v2's sha (a mod approved it moments ago).
+    mockDbWriteFindUnique.mockResolvedValue(
+      strandedRow({
+        deployState: 'failed',
+        deployUpdatedAt: new Date(),
+        appBlock: { id: APB, currentVersionSha: OTHER_SHA },
+      })
+    );
+    // Replica: still serving the pre-approval world, where v1 IS the current sha.
+    mockDbRead.appBlockPublishRequest.findUnique.mockResolvedValue(
+      strandedRow({ deployState: 'failed', deployUpdatedAt: new Date() })
+    );
+    const { retriggerBuild } = await import('../publish-request.service');
+    await expectRejectCode(
+      retriggerBuild({ publishRequestId: REQ_ID, reviewerUserId: MOD_ID }),
+      'NOT_RETRIGGERABLE'
+    );
+    // The whole point: v1's OLDER reviewed sha must not be rebuilt over v2.
+    expect(mockTriggerBuild).not.toHaveBeenCalled();
+  });
+
+  it("RACE 2 — a fresh approval's 'building' write is seen even if the replica lags", async () => {
+    // Primary: approveRequest has already written 'building'.
+    mockDbWriteFindUnique.mockResolvedValue(
+      strandedRow({ deployState: 'building', deployUpdatedAt: new Date() })
+    );
+    // Replica: still null — the shape that used to look re-triggerable.
+    mockDbRead.appBlockPublishRequest.findUnique.mockResolvedValue(strandedRow());
+    const { retriggerBuild } = await import('../publish-request.service');
+    await expectRejectCode(
+      retriggerBuild({ publishRequestId: REQ_ID, reviewerUserId: MOD_ID }),
+      'NOT_RETRIGGERABLE'
+    );
+    expect(mockTriggerBuild).not.toHaveBeenCalled(); // no second PipelineRun
+  });
+});
+
+/**
+ * The remaining half of RACE 2, which no amount of primary-reading can fix:
+ * `approveRequest` writes the approval, then AWAITS `triggerBuild` (a 30s network
+ * timeout), and only THEN writes `deploy_state='building'`. During that WALL-CLOCK
+ * window the primary itself legitimately reads null while a PipelineRun is already
+ * being created. The null branch is therefore bounded by the shared
+ * DEPLOY_PENDING_GRACE_MS.
+ */
+describe('retriggerBuild — guard 6b: the null deploy state is time-bounded', () => {
+  it('refuses a JUST-approved request — its first build may still be starting', async () => {
+    await expectRejectCode(callRetrigger({ reviewedAt: new Date() }), 'NOT_RETRIGGERABLE');
+    expect(mockTriggerBuild).not.toHaveBeenCalled();
+  });
+
+  it('is EXCLUSIVE at exactly the grace boundary, and allows one ms past it', async () => {
+    // The service reads its own Date.now(), so pin the clock to make the boundary
+    // exact rather than "whatever elapsed between the two calls".
+    vi.useFakeTimers();
+    try {
+      const now = new Date('2026-07-01T00:00:00Z').getTime();
+      vi.setSystemTime(now);
+
+      await expectRejectCode(
+        callRetrigger({ reviewedAt: new Date(now - DEPLOY_PENDING_GRACE_MS) }),
+        'NOT_RETRIGGERABLE'
+      );
+      expect(mockTriggerBuild).not.toHaveBeenCalled();
+
+      await expect(
+        callRetrigger({ reviewedAt: new Date(now - DEPLOY_PENDING_GRACE_MS - 1) })
+      ).resolves.toBeTruthy();
+      expect(mockTriggerBuild).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('FAILS CLOSED when there is no anchor to measure the window from', async () => {
+    await expectRejectCode(
+      callRetrigger({ reviewedAt: null, deployUpdatedAt: null }),
+      'NOT_RETRIGGERABLE'
+    );
+    expect(mockTriggerBuild).not.toHaveBeenCalled();
+  });
+
+  it('falls back to deployUpdatedAt when reviewedAt is missing', async () => {
+    await expect(
+      callRetrigger({ reviewedAt: null, deployUpdatedAt: strandedReviewedAt() })
     ).resolves.toBeTruthy();
   });
 });
@@ -367,7 +522,7 @@ describe('retriggerBuild — guard 8: a failing trigger becomes VISIBLE', () => 
         slug: 'my-app',
         sha: SHA,
         state: 'failed',
-        detail: expect.stringContaining('Re-trigger failed'),
+        detail: expect.stringContaining('Build re-trigger failed'),
       },
     ]);
   });
@@ -390,5 +545,118 @@ describe('retriggerBuild — guard 8: a failing trigger becomes VISIBLE', () => 
     mockTriggerBuild.mockRejectedValue(new Error('boom'));
     await expectRejectCode(callRetrigger(), 'TRIGGER_FAILED');
     expect(deployWrites().map((w) => w.state)).not.toContain('building');
+  });
+});
+
+/**
+ * 🔴 …AND VISIBLE IS NOT THE SAME AS VERBATIM.
+ *
+ * `deploy_detail` is OWNER-visible: both `blocks.listMyPublishRequests` and
+ * `GET /api/v1/blocks/submissions` hand it to the app's THIRD-PARTY author. The
+ * errors `triggerBuild` throws are internal — `trigger <status> <statusText>:
+ * <first 240 bytes of the trigger receiver's response body>`, or a message naming
+ * the trigger env vars. Storing them verbatim published our build infrastructure
+ * to an app developer.
+ *
+ * These are the exact two thrown shapes, asserted against the STORED value.
+ */
+describe('retriggerBuild — the trigger failure must not leak internals to the author', () => {
+  // A SYNTHETIC stand-in for whatever the trigger receiver returns on a bad day:
+  // a stack trace plus deployment-internal identifiers. The point of the assertions
+  // is that NONE of it survives into the author-visible column, so the exact bytes
+  // are irrelevant — only that they are distinctive enough to detect.
+  const RECEIVER_BODY =
+    'SENTINEL-TRACE-A1: SENTINEL-INTERNAL-B2 rejected the request ' +
+    '(SENTINEL-IDENTIFIER-C3 / SENTINEL-CREDENTIAL-D4 expired)';
+
+  it('stores NO part of the trigger receiver response body', async () => {
+    mockTriggerBuild.mockRejectedValue(
+      new Error(`trigger 500 Internal Server Error: ${RECEIVER_BODY}`)
+    );
+    await expectRejectCode(callRetrigger(), 'TRIGGER_FAILED');
+
+    const detail = deployWrites()[0].detail ?? '';
+    expect(detail).not.toContain(RECEIVER_BODY);
+    // Per-token, so a partially-copied body is caught too — not just the whole string.
+    for (const fragment of [
+      'SENTINEL-TRACE-A1',
+      'SENTINEL-INTERNAL-B2',
+      'SENTINEL-IDENTIFIER-C3',
+      'SENTINEL-CREDENTIAL-D4',
+      'Internal Server Error',
+      'trigger 500',
+    ]) {
+      expect(detail).not.toContain(fragment);
+    }
+  });
+
+  it('stores NO env-var name when the trigger is unconfigured', async () => {
+    mockTriggerBuild.mockRejectedValue(
+      new Error('APPS_TEKTON_TRIGGER_URL / APPS_TEKTON_TRIGGER_SECRET not configured')
+    );
+    await expectRejectCode(callRetrigger(), 'TRIGGER_FAILED');
+
+    const detail = deployWrites()[0].detail ?? '';
+    expect(detail).not.toContain('APPS_TEKTON_TRIGGER_URL');
+    expect(detail).not.toContain('APPS_TEKTON_TRIGGER_SECRET');
+    expect(detail).not.toContain('TEKTON');
+  });
+
+  it('stores the FIXED author-facing message — identical whatever was thrown', async () => {
+    const { RETRIGGER_FAILED_AUTHOR_DETAIL } = await import('../publish-request.service');
+
+    mockTriggerBuild.mockRejectedValue(new Error(`trigger 502 Bad Gateway: ${RECEIVER_BODY}`));
+    await expectRejectCode(callRetrigger(), 'TRIGGER_FAILED');
+    const first = deployWrites()[0].detail;
+
+    vi.clearAllMocks();
+    mockTriggerBuild.mockRejectedValue(new Error('SENTINEL-CONNECT-E5 refused'));
+    await expectRejectCode(callRetrigger(), 'TRIGGER_FAILED');
+    const second = deployWrites()[0].detail;
+
+    expect(first).toBe(RETRIGGER_FAILED_AUTHOR_DETAIL);
+    expect(second).toBe(RETRIGGER_FAILED_AUTHOR_DETAIL);
+  });
+
+  it('the stored detail survives sanitizeBuildFailureReason unchanged (the invariant)', async () => {
+    const { RETRIGGER_FAILED_AUTHOR_DETAIL } = await import('../publish-request.service');
+    const { sanitizeBuildFailureReason } = await import('../build-failure-reason');
+    // The value is written THROUGH the sanitizer, so the stored bytes are
+    // guaranteed printable + bounded like every other deploy_detail write.
+    expect(sanitizeBuildFailureReason(RETRIGGER_FAILED_AUTHOR_DETAIL)).toBe(
+      RETRIGGER_FAILED_AUTHOR_DETAIL
+    );
+  });
+
+  it('does not leak the receiver body through the Forgejo commit status either', async () => {
+    mockTriggerBuild.mockRejectedValue(
+      new Error(`trigger 500 Internal Server Error: ${RECEIVER_BODY}`)
+    );
+    await expectRejectCode(callRetrigger(), 'TRIGGER_FAILED');
+    const failure = mockSetCommitStatus.mock.calls
+      .map((c) => c[0] as { state: string; description: string })
+      .find((c) => c.state === 'failure');
+    expect(failure?.description ?? '').not.toContain('SENTINEL-TRACE-A1');
+    expect(failure?.description ?? '').not.toContain('SENTINEL-INTERNAL-B2');
+  });
+
+  it('logs the INTERNAL detail server-side so the failure is still diagnosable', async () => {
+    const { logToAxiom } = await import('~/server/logging/client');
+    mockTriggerBuild.mockRejectedValue(
+      new Error(`trigger 500 Internal Server Error: ${RECEIVER_BODY}`)
+    );
+    await expectRejectCode(callRetrigger(), 'TRIGGER_FAILED');
+    // The dynamic import + `.then` chain resolves on a later microtask tick.
+    await new Promise((r) => setTimeout(r, 0));
+    expect(vi.mocked(logToAxiom)).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'app-block-retrigger-failed',
+        details: expect.objectContaining({
+          publishRequestId: REQ_ID,
+          error: expect.stringContaining(RECEIVER_BODY),
+        }),
+      }),
+      'app-blocks'
+    );
   });
 });

--- a/src/server/services/blocks/__tests__/publish-request.retriggerBuild.test.ts
+++ b/src/server/services/blocks/__tests__/publish-request.retriggerBuild.test.ts
@@ -100,7 +100,12 @@ async function expectRejectCode(promise: Promise<unknown>, code: string) {
 }
 
 /** The deploy-lifecycle writes `markRequestDeployState` performed, flattened. */
-function deployWrites(): Array<{ slug: string; sha: string; state: string; detail: string | null }> {
+function deployWrites(): Array<{
+  slug: string;
+  sha: string;
+  state: string;
+  detail: string | null;
+}> {
   return mockUpdateMany.mock.calls.map((call) => {
     const arg = call[0] as {
       where: { slug: string; forgejoCommitSha: string };
@@ -296,9 +301,7 @@ describe('retriggerBuild — guard 6: deploy-state gate', () => {
   it.each(['building', 'deploying'])(
     'ALLOWS a %s that has stalled past the shared threshold',
     async (deployState) => {
-      await expect(
-        callRetrigger({ deployState, deployUpdatedAt: stale() })
-      ).resolves.toBeTruthy();
+      await expect(callRetrigger({ deployState, deployUpdatedAt: stale() })).resolves.toBeTruthy();
       expect(mockTriggerBuild).toHaveBeenCalledTimes(1);
     }
   );

--- a/src/server/services/blocks/build-failure-reason.ts
+++ b/src/server/services/blocks/build-failure-reason.ts
@@ -1,0 +1,186 @@
+/**
+ * Sanitizer for the App Blocks build-failure excerpt.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * When an app's Tekton build fails, the only actionable information ("no
+ * package-lock.json is committed", "tsc: Cannot find module ...") lives in a
+ * build log the third-party author has no access to. The build callback now
+ * carries an OPTIONAL `failureReason` excerpt so we can show the author WHY their
+ * build failed instead of a bare "Build Failed".
+ *
+ * THAT EXCERPT IS TENANT-INFLUENCED CONTENT. It is a slice of the build log of
+ * code the app author wrote -- an author who controls its bytes can put anything
+ * in it (ANSI escapes, terminal control sequences, NUL, `</script>`, a 4 KB
+ * blob). It arrives over an HMAC-authenticated channel, but authentication only
+ * proves WHO sent it, never that the CONTENT is safe. So we re-sanitize
+ * server-side, unconditionally, before it is ever persisted to
+ * `app_block_publish_requests.deploy_detail`.
+ *
+ * The rendering path (React text nodes, never `dangerouslySetInnerHTML`) already
+ * escapes, and the sibling `/api/v1/blocks/submissions` JSON path escapes on
+ * serialization -- this is defence-in-depth so the STORED value is guaranteed
+ * printable text + newlines regardless of who consumes it later (a log line, a
+ * terminal `psql` session, a future non-React surface).
+ *
+ * IMPLEMENTATION NOTE: every escape/control character below is built from an
+ * explicit `String.fromCharCode` constant rather than a `\xNN` literal, so this
+ * source file contains no raw control bytes and the intent of each pattern stays
+ * readable in a diff.
+ */
+
+/**
+ * Hard ceiling on the sanitized excerpt. The pipeline contract caps
+ * `failureReason` at 2000 chars; this is the independent server-side enforcement
+ * (never trust the sender's cap).
+ *
+ * Budget for the STORED `deploy_detail`, which is `"Build <status>" + "\n\n" +
+ * <excerpt>`: the status prefix is itself sliced to 60 chars, so the worst case is
+ * 6 + 60 + 2 + 3000 = 3068 chars -- comfortably under the 4000-char total cap this
+ * feature commits to. (`deploy_detail` is unbounded TEXT in Postgres, so the cap
+ * is a product / DoS decision, not a schema limit.)
+ */
+export const MAX_BUILD_FAILURE_REASON_CHARS = 3000;
+
+/** Appended when the excerpt is cut, so a reader knows they are not seeing it all. */
+export const BUILD_FAILURE_TRUNCATION_MARKER = '\n... [truncated]';
+
+/**
+ * Defensive input ceiling applied BEFORE any regex work. The transport already
+ * bounds this (MAX_BODY_BYTES = 8 KiB on the callback), but slicing first means
+ * the sanitizer's cost is bounded by a constant no matter how it is called -- no
+ * pathological-input CPU spike on the request path.
+ */
+const MAX_RAW_INPUT_CHARS = 8000;
+
+const ESC = String.fromCharCode(0x1b); // ESC
+const BEL = String.fromCharCode(0x07); // BEL (OSC terminator)
+const CSI8 = String.fromCharCode(0x9b); // 8-bit CSI introducer
+
+/**
+ * Terminal escape sequences, stripped BEFORE the generic control-character pass.
+ * Order matters: removing the bare ESC first would leave the human-visible
+ * garbage tail (`[0m`, `]0;title`) behind as ordinary text.
+ *
+ * Every pattern is linear-time -- no nested quantifiers and no alternation inside
+ * a repetition -- so this is not a ReDoS surface. (The OSC body class excludes
+ * both terminators AND ESC, which is what removes the backtracking ambiguity.)
+ */
+const ESCAPE_SEQUENCE_PATTERNS: RegExp[] = [
+  // OSC: ESC ] ... terminated by BEL or ST (ESC \), or unterminated at end of input.
+  new RegExp(`${ESC}\\][^${BEL}${ESC}]*(?:${BEL}|${ESC}\\\\)?`, 'g'),
+  // CSI: ESC [ params intermediates final -- SGR colours, cursor moves, erases.
+  new RegExp(`${ESC}\\[[0-?]*[ -/]*[@-~]`, 'g'),
+  // 8-bit CSI (0x9B): same grammar, single-byte introducer.
+  new RegExp(`${CSI8}[0-?]*[ -/]*[@-~]`, 'g'),
+  // Any OTHER escape sequence, per the ECMA-48 grammar: ESC, zero or more
+  // intermediate bytes (0x20-0x2F), one final byte (0x30-0x7E). Covers charset
+  // selects (ESC ( B), ESC =, ESC >, ESC 7/8, and the two-character Fe escapes.
+  // Runs AFTER the CSI/OSC patterns above, so it only sees what they left.
+  // The two character classes are disjoint, so this is unambiguous + linear.
+  new RegExp(`${ESC}[ -/]*[0-~]`, 'g'),
+  // A lone/trailing ESC with nothing usable after it.
+  new RegExp(ESC, 'g'),
+];
+
+/**
+ * Is this code point allowed in the sanitized output?
+ *
+ * Allowed: `\n` (0x0A) and every printable character from 0x20 up, EXCEPT DEL
+ * (0x7F) and the C1 control block (0x80-0x9F). `\t` and `\r` are rewritten before
+ * this predicate runs, so they are correctly rejected here as leftovers.
+ */
+function isAllowedChar(code: number): boolean {
+  if (code === 0x0a) return true; // newline -- the one control character we keep
+  if (code < 0x20) return false; // C0 controls (NUL, BEL, VT, FF, ESC, ...)
+  if (code === 0x7f) return false; // DEL
+  if (code >= 0x80 && code <= 0x9f) return false; // C1 controls
+  return true;
+}
+
+/** Drop every disallowed control character in one linear pass. */
+function stripControlChars(text: string): string {
+  let out = '';
+  for (let i = 0; i < text.length; i += 1) {
+    if (isAllowedChar(text.charCodeAt(i))) out += text[i];
+  }
+  return out;
+}
+
+/**
+ * Normalize an untrusted build-failure excerpt into printable text + `\n` only.
+ *
+ * Pure and total -- never throws, never touches I/O, and returns `undefined` for
+ * anything that is not a non-empty string after sanitization, so callers can use
+ * a plain truthiness check to decide whether there is an excerpt to show.
+ *
+ * Guarantees on the returned value:
+ *   1. contains no ANSI/CSI/OSC escape sequence;
+ *   2. contains no control character other than `\n` -- no `\r`, no `\t`, no NUL,
+ *      no DEL, no C1;
+ *   3. has no run of more than one blank line, and no trailing spaces per line;
+ *   4. is at most {@link MAX_BUILD_FAILURE_REASON_CHARS} characters, ending in
+ *      {@link BUILD_FAILURE_TRUNCATION_MARKER} when it was cut;
+ *   5. is trimmed (no leading/trailing whitespace).
+ *
+ * NOT done, deliberately: HTML escaping. `<`, `>`, `&`, `"` are legitimate
+ * build-log characters (`Cannot find module "foo"`, `a < b`) and are preserved
+ * verbatim -- escaping belongs to the renderer, and every current consumer (React
+ * text nodes, JSON) escapes correctly. A raw `</script>` in the excerpt is
+ * therefore preserved AS TEXT, and is safe precisely because it is never
+ * interpolated into an HTML or script context.
+ */
+export function sanitizeBuildFailureReason(raw: unknown): string | undefined {
+  if (typeof raw !== 'string') return undefined;
+  if (raw.length === 0) return undefined;
+
+  // Bound the work before any regex touches it.
+  let text = raw.length > MAX_RAW_INPUT_CHARS ? raw.slice(0, MAX_RAW_INPUT_CHARS) : raw;
+
+  // 1. Terminal escape sequences (must precede the control-character sweep).
+  for (const pattern of ESCAPE_SEQUENCE_PATTERNS) text = text.replace(pattern, '');
+
+  // 2. Line endings: CRLF -> LF, then drop any stray CR (a bare CR would otherwise
+  //    overwrite the line in a terminal / render as an invisible artifact).
+  text = text.replace(/\r\n/g, '\n').replace(/\r/g, '');
+
+  // 3. Tabs -> a single space (preserves word separation without terminal-width
+  //    surprises); then remove every remaining disallowed control character.
+  text = stripControlChars(text.replace(/\t/g, ' '));
+
+  // 4. Trim trailing whitespace per line, then collapse blank-line runs to one.
+  text = text
+    .split('\n')
+    .map((line) => line.replace(/ +$/, ''))
+    .join('\n')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+
+  if (text.length === 0) return undefined;
+
+  // 5. Hard truncate. The marker REPLACES the tail so the total never exceeds the
+  //    cap (a marker appended past the cap would defeat the point).
+  if (text.length > MAX_BUILD_FAILURE_REASON_CHARS) {
+    const keep = MAX_BUILD_FAILURE_REASON_CHARS - BUILD_FAILURE_TRUNCATION_MARKER.length;
+    text = text.slice(0, keep).trimEnd() + BUILD_FAILURE_TRUNCATION_MARKER;
+  }
+
+  return text;
+}
+
+/**
+ * The exact `deploy_detail` string stored for a NON-successful build callback.
+ *
+ * DARK-SAFE CONTRACT: with no excerpt this returns `Build <status>` -- BYTE-
+ * IDENTICAL to what shipped before `failureReason` existed -- so an old pipeline
+ * (which never sends the field) against new civitai-web produces exactly today's
+ * value. The excerpt is appended after a blank line only when one survives
+ * sanitization.
+ *
+ * Pure + exported so both the handler and its tests derive the string the same way.
+ */
+export function buildFailureDeployDetail(status: string | undefined, reason: unknown): string {
+  const prefix = `Build ${String(status ?? 'failed').slice(0, 60)}`;
+  const excerpt = sanitizeBuildFailureReason(reason);
+  return excerpt ? `${prefix}\n\n${excerpt}` : prefix;
+}

--- a/src/server/services/blocks/publish-request.service.ts
+++ b/src/server/services/blocks/publish-request.service.ts
@@ -40,7 +40,15 @@ import { sanitizeAppSlug } from '~/server/utils/apps-slug';
 // Pure const (no env/Prisma). THE SAME threshold the owner-facing UI uses to call
 // a deploy "stalled" — shared so the mod retrigger gate and the badge can never
 // disagree about whether a build is stuck.
-import { DEPLOY_STALE_AFTER_MS } from '~/shared/constants/app-block-deploy.constants';
+import {
+  DEPLOY_PENDING_GRACE_MS,
+  DEPLOY_STALE_AFTER_MS,
+} from '~/shared/constants/app-block-deploy.constants';
+// Pure, dependency-free sanitizer. Applied to EVERY value written to the
+// owner-visible `deploy_detail`, so the "guaranteed printable, bounded text"
+// invariant that module documents holds on all write paths — not just the
+// build-callback's.
+import { sanitizeBuildFailureReason } from './build-failure-reason';
 
 // dbRead/dbWrite/newUlid/bundle-s3 are dynamically imported inside the
 // functions that need them so the pure helpers (extract/diff) can be
@@ -2814,6 +2822,24 @@ export async function markRequestDeployState(
 // MOD-ONLY BUILD RE-TRIGGER — recover an APPROVED request whose build never ran.
 // ---------------------------------------------------------------------------
 
+/**
+ * The EXACT `deploy_detail` an app author sees when the moderator's re-trigger
+ * could not be handed to the build service.
+ *
+ * 🔴 FIXED STRING, never derived from the thrown error. `deploy_detail` is
+ * owner-visible on both `blocks.listMyPublishRequests` and
+ * `GET /api/v1/blocks/submissions`, and the errors `triggerBuild` throws carry
+ * infrastructure detail (the trigger receiver's raw response body, the names of
+ * the trigger env vars). Those go to the server log instead.
+ *
+ * It says what the author actually needs: this is our failure, not their code, and
+ * they should not resubmit.
+ */
+export const RETRIGGER_FAILED_AUTHOR_DETAIL =
+  'Build re-trigger failed: Civitai could not reach the build service. ' +
+  'This is a problem on our side, not with your app — a moderator has to retry it. ' +
+  'No new version submission is needed.';
+
 /** Typed failure from {@link retriggerBuild}; `code` drives the tRPC mapping. */
 export class RetriggerBuildError extends Error {
   code: string;
@@ -2844,7 +2870,9 @@ export type RetriggerBuildResult = {
  *                                   forgejo_commit_sha) and then threw inside
  *                                   `triggerBuild`, so `markRequestDeployState`
  *                                   was never reached. Nothing is building and
- *                                   nothing ever will.
+ *                                   nothing ever will. 🔴 Allowed ONLY once the
+ *                                   approval is older than
+ *                                   DEPLOY_PENDING_GRACE_MS — see below.
  *   - `deployState === 'failed'`  → the build or the apply ended badly. Re-firing
  *                                   is exactly the intended recovery (e.g. a
  *                                   transient registry/cluster failure).
@@ -2857,13 +2885,43 @@ export type RetriggerBuildResult = {
  * Everything else is refused: `'live'` (already deployed — a rebuild would churn
  * a serving app for no reason) and any `preview-*` value (the mod review-sandbox
  * lane, which has its own build/teardown path and must not be driven from here).
+ *
+ * 🔴 WHY THE NULL BRANCH IS TIME-BOUNDED. `approveRequest` writes the approval,
+ * then `await`s `triggerBuild` (up to a 30s network timeout), and only THEN writes
+ * `deploy_state='building'`. In that window the row legitimately reads null on the
+ * PRIMARY while a PipelineRun is already being created — reading the primary
+ * (which this function's caller now does) cannot close it, because the gap is in
+ * WALL TIME, not replica lag. An unbounded null branch therefore let a second
+ * moderator race a second PipelineRun onto the same sha. The bound is
+ * DEPLOY_PENDING_GRACE_MS — the SHARED constant the owner UI already uses for
+ * exactly this approve→mark window, and comfortably above triggerBuild's own
+ * timeout. It is deliberately NOT DEPLOY_STALE_AFTER_MS: making a moderator wait
+ * 45 minutes to recover a request that is already provably stranded would defeat
+ * the recovery this whole procedure exists to provide.
+ *
+ * With NO anchor at all (`reviewedAt` and `deployUpdatedAt` both null) the window
+ * cannot be measured, so the null branch FAILS CLOSED — matching the in-flight
+ * branch's "no timestamp → refuse". `approveRequest` always stamps `reviewedAt`,
+ * so a real approved row always has an anchor.
  */
 function assertRetriggerableDeployState(
   deployState: string | null,
   deployUpdatedAt: Date | null,
+  reviewedAt: Date | null,
   now: number
 ): void {
-  if (deployState === null) return; // stranded — the whole point
+  if (deployState === null) {
+    // Anchor: the approval time (the null case has no transition by definition;
+    // deployUpdatedAt is only a fallback for an odd null-state-with-transition row).
+    const anchor = reviewedAt?.getTime() ?? deployUpdatedAt?.getTime() ?? null;
+    if (anchor == null || now - anchor <= DEPLOY_PENDING_GRACE_MS) {
+      throw new RetriggerBuildError(
+        'NOT_RETRIGGERABLE',
+        'This request was just approved — its first build may still be starting. Wait a moment and retry.'
+      );
+    }
+    return; // stranded — the whole point
+  }
   if (deployState === 'failed') return;
   if (deployState === 'live') {
     throw new RetriggerBuildError(
@@ -2916,13 +2974,24 @@ function assertRetriggerableDeployState(
 export async function retriggerBuild(
   params: RetriggerBuildParams
 ): Promise<RetriggerBuildResult> {
-  const [{ dbRead }, { env }] = await Promise.all([
+  const [{ dbWrite }, { env }] = await Promise.all([
     import('~/server/db/client'),
     import('~/env/server'),
   ]);
 
   // (1) The request must exist.
-  const request = await dbRead.appBlockPublishRequest.findUnique({
+  //
+  // 🔴 READ THE PRIMARY (`dbWrite`), NOT the replica. Every value below is a
+  // GUARD, and `dbRead` is a separate readonly client that can lag. Concretely:
+  // a moderator approves v2 (primary now has AppBlock.currentVersionSha = B) and
+  // within the lag window another moderator hits "Retrigger" on v1 — a replica
+  // still serving currentVersionSha = A lets the supersede guard (5) pass, and
+  // v1's older reviewed sha gets rebuilt and deployed OVER the newer approval.
+  // The same lag re-opens the deploy-state gate (6): a fresh `deploy_state =
+  // 'building'` can read back as null, so a second PipelineRun races the first.
+  // The redis NX lock does not help — `approveRequest` never takes it. This is a
+  // once-per-click moderator action, so the primary read costs nothing.
+  const request = await dbWrite.appBlockPublishRequest.findUnique({
     where: { id: params.publishRequestId },
     select: {
       id: true,
@@ -2932,6 +3001,9 @@ export async function retriggerBuild(
       forgejoCommitSha: true,
       deployState: true,
       deployUpdatedAt: true,
+      // Anchor for the null-deploy-state grace window (see
+      // assertRetriggerableDeployState).
+      reviewedAt: true,
       appBlock: { select: { id: true, currentVersionSha: true } },
     },
   });
@@ -2953,10 +3025,16 @@ export async function retriggerBuild(
   // (3) The sha comes from the DB and must look like a real commit. The procedure
   //     input carries no sha at all, so there is nothing to smuggle in here — this
   //     is the integrity check on our OWN stored value, not input validation.
+  //
+  //     🔴 DISTINCT ERROR CODE, deliberately. Sharing NOT_RETRIGGERABLE with the
+  //     supersede guard (5) made this guard untestable: the stranded fixture also
+  //     trips (5), so a test asserting "malformed sha is refused" passed even with
+  //     this check deleted. A code only this guard can produce makes the assertion
+  //     load-bearing (see the mutation note in the retriggerBuild test suite).
   const sha = request.forgejoCommitSha;
   if (!sha || !/^[0-9a-f]{40}$/.test(sha)) {
     throw new RetriggerBuildError(
-      'NOT_RETRIGGERABLE',
+      'INVALID_STORED_SHA',
       'Request has no valid committed sha to rebuild.'
     );
   }
@@ -2980,7 +3058,12 @@ export async function retriggerBuild(
   }
 
   // (6) Deploy-state gate (see assertRetriggerableDeployState for the definition).
-  assertRetriggerableDeployState(request.deployState, request.deployUpdatedAt, Date.now());
+  assertRetriggerableDeployState(
+    request.deployState,
+    request.deployUpdatedAt,
+    request.reviewedAt,
+    Date.now()
+  );
 
   if (!env.FORGEJO_BASE_URL || !env.FORGEJO_ADMIN_TOKEN) {
     throw new RetriggerBuildError('NOT_RETRIGGERABLE', 'Forgejo not configured');
@@ -3028,26 +3111,62 @@ export async function retriggerBuild(
     // Free the single-flight slot so the moderator can retry immediately rather
     // than waiting out the TTL after a visible failure.
     await releaseRetriggerLock(request.id);
+    const internalDetail = err instanceof Error ? err.message : String(err);
+    // 🔴 The INTERNAL detail goes to the server log ONLY. `triggerBuild` throws
+    // `trigger <status> <statusText>: <first 240 bytes of the receiver's response
+    // body>`, or a message naming the trigger env vars — infrastructure detail
+    // that must never reach a third-party app author.
+    void import('~/server/logging/client')
+      .then(({ logToAxiom }) =>
+        logToAxiom(
+          {
+            type: 'error',
+            name: 'app-block-retrigger-failed',
+            message: 'retriggerBuild: the build trigger call failed',
+            details: {
+              publishRequestId: request.id,
+              slug: request.slug,
+              appBlockId,
+              reviewerUserId: params.reviewerUserId,
+              error: internalDetail,
+            },
+          },
+          'app-blocks'
+        )
+      )
+      .catch(() => undefined);
     await setCommitStatus({
       slug: request.slug,
       sha,
       state: 'failure',
       context: 'civitai/build',
-      description: `Re-trigger failed: ${String(err).slice(0, 80)}`,
+      // The author can see their own repo's commit statuses, so this stays
+      // generic too — the detail is in the server log above.
+      description: 'Build re-trigger failed; see Civitai for details',
     }).catch(() => undefined);
-    // 🔴 Make the failure VISIBLE. This is the half of the fix that matters most:
+    // 🔴 Make the failure VISIBLE — this is the half of the fix that matters most:
     // a stranded request's whole problem is that it looks healthy while nothing is
     // happening. Even when the retrigger ITSELF fails, the row now carries a
     // 'failed' state + a reason instead of reverting to a silent null.
+    //
+    // 🔴 …but the reason stored here is OWNER-VISIBLE (`deploy_detail` is returned
+    // by BOTH `blocks.listMyPublishRequests` and GET /api/v1/blocks/submissions),
+    // so it is a FIXED, GENERIC, author-actionable string — never the thrown
+    // error. It still goes through `sanitizeBuildFailureReason` so the stored
+    // value keeps that module's "guaranteed printable, bounded text" invariant on
+    // every write path, not just the build-callback one.
     await markRequestDeployState(
       request.slug,
       sha,
       'failed',
-      `Re-trigger failed: ${(err as Error).message ?? String(err)}`.slice(0, 500)
+      sanitizeBuildFailureReason(RETRIGGER_FAILED_AUTHOR_DETAIL) ?? null
     );
     throw new RetriggerBuildError(
       'TRIGGER_FAILED',
-      `The build re-trigger failed: ${(err as Error).message}. The request is now marked failed; try again once the build service is reachable.`
+      // Moderator-facing (a `moderatorProcedure` response), and deliberately also
+      // generic: the actionable internal detail is in the server log, keyed by the
+      // publish-request id above.
+      'The build re-trigger could not be sent to the build service. The request is now marked failed; try again once the build service is reachable.'
     );
   }
 

--- a/src/server/services/blocks/publish-request.service.ts
+++ b/src/server/services/blocks/publish-request.service.ts
@@ -37,6 +37,10 @@ import type { SourceAppBlock } from '~/server/services/blocks/app-listing-mapper
 // derivation exactly. The provisioner VALUE is dynamically imported at use so
 // appsDb/pg stay out of this module's static graph (mirrors the (3b) mapper).
 import { sanitizeAppSlug } from '~/server/utils/apps-slug';
+// Pure const (no env/Prisma). THE SAME threshold the owner-facing UI uses to call
+// a deploy "stalled" — shared so the mod retrigger gate and the badge can never
+// disagree about whether a build is stuck.
+import { DEPLOY_STALE_AFTER_MS } from '~/shared/constants/app-block-deploy.constants';
 
 // dbRead/dbWrite/newUlid/bundle-s3 are dynamically imported inside the
 // functions that need them so the pure helpers (extract/diff) can be
@@ -1836,6 +1840,13 @@ export async function listApprovedRequests(opts: ListPendingRequestsOptions = {}
       fileSummary: true,
       manifestDiffSummary: true,
       forgejoCommitSha: true,
+      // Build/deploy lifecycle — additive. The Approved tab is where a moderator
+      // sees that an approved app never actually built (deployState null =
+      // STRANDED) and can re-trigger it; without these three the queue shows a
+      // uniformly-healthy list of approvals regardless of what actually shipped.
+      deployState: true,
+      deployDetail: true,
+      deployUpdatedAt: true,
       submittedBy: { select: { id: true, username: true, image: true } },
       reviewedBy: { select: { id: true, username: true, image: true } },
     },
@@ -2797,6 +2808,259 @@ export async function markRequestDeployState(
       }`
     );
   }
+}
+
+// ---------------------------------------------------------------------------
+// MOD-ONLY BUILD RE-TRIGGER — recover an APPROVED request whose build never ran.
+// ---------------------------------------------------------------------------
+
+/** Typed failure from {@link retriggerBuild}; `code` drives the tRPC mapping. */
+export class RetriggerBuildError extends Error {
+  code: string;
+  constructor(code: string, message: string) {
+    super(message);
+    this.name = 'RetriggerBuildError';
+    this.code = code;
+  }
+}
+
+export type RetriggerBuildParams = {
+  publishRequestId: string;
+  reviewerUserId: number;
+};
+
+export type RetriggerBuildResult = {
+  publishRequestId: string;
+  appBlockId: string;
+  forgejoCommitSha: string;
+};
+
+/**
+ * "APPROVED BUT NOT SUCCESSFULLY BUILT" — the precise, documented definition of a
+ * request this function will re-fire a build for:
+ *
+ *   - `deployState === null`      → the STRANDED case. `approveRequest` made the
+ *                                   approval durable (status='approved' +
+ *                                   forgejo_commit_sha) and then threw inside
+ *                                   `triggerBuild`, so `markRequestDeployState`
+ *                                   was never reached. Nothing is building and
+ *                                   nothing ever will.
+ *   - `deployState === 'failed'`  → the build or the apply ended badly. Re-firing
+ *                                   is exactly the intended recovery (e.g. a
+ *                                   transient registry/cluster failure).
+ *   - `'building' | 'deploying'`  → allowed ONLY once `deployUpdatedAt` is older
+ *                                   than DEPLOY_STALE_AFTER_MS, i.e. the same
+ *                                   "stalled" threshold the owner-facing UI uses.
+ *                                   A genuinely in-flight build is NEVER
+ *                                   re-fired — that would race two PipelineRuns.
+ *
+ * Everything else is refused: `'live'` (already deployed — a rebuild would churn
+ * a serving app for no reason) and any `preview-*` value (the mod review-sandbox
+ * lane, which has its own build/teardown path and must not be driven from here).
+ */
+function assertRetriggerableDeployState(
+  deployState: string | null,
+  deployUpdatedAt: Date | null,
+  now: number
+): void {
+  if (deployState === null) return; // stranded — the whole point
+  if (deployState === 'failed') return;
+  if (deployState === 'live') {
+    throw new RetriggerBuildError(
+      'NOT_RETRIGGERABLE',
+      'This version is already deployed. Submit a new version instead of rebuilding a live one.'
+    );
+  }
+  if (deployState.startsWith('preview-')) {
+    throw new RetriggerBuildError(
+      'NOT_RETRIGGERABLE',
+      `Request is in the review-preview lane (${deployState}); use the review preview controls.`
+    );
+  }
+  if (deployState === 'building' || deployState === 'deploying') {
+    const updated = deployUpdatedAt ? deployUpdatedAt.getTime() : null;
+    if (updated == null || now - updated <= DEPLOY_STALE_AFTER_MS) {
+      throw new RetriggerBuildError(
+        'NOT_RETRIGGERABLE',
+        `A build is already ${deployState}. Wait for it to finish or stall before re-triggering.`
+      );
+    }
+    return; // stalled past the shared threshold → recovery is legitimate
+  }
+  throw new RetriggerBuildError(
+    'NOT_RETRIGGERABLE',
+    `Unexpected deploy state "${deployState}"; not re-triggering.`
+  );
+}
+
+/**
+ * Re-fire the Tekton build for an ALREADY-APPROVED publish request, using the sha
+ * that was already committed and reviewed.
+ *
+ * WHY THIS EXISTS — `approveRequest` is not idempotent (`cannot approve a request
+ * in status approved`) and there was no other way to re-run a build, so an
+ * approved request whose `triggerBuild` threw was UNRECOVERABLE: the only fix was
+ * for the developer to resubmit at a brand-new version number. This is that
+ * missing recovery, and nothing more.
+ *
+ * DELIBERATELY NONE OF `approveRequest`'S SIDE EFFECTS: no Forgejo commit, no
+ * AppBlock / OauthClient mutation, no listing / category / storage provisioning,
+ * no approval notification, no supersede-others sweep. It re-runs step (7) of the
+ * approve flow and only step (7).
+ *
+ * MODERATION IS NOT BYPASSED. The sha comes from the DB row a moderator already
+ * approved; the caller cannot name a sha (see `retriggerBuildSchema`), and the
+ * supersede guard below refuses even the stored sha once a NEWER version has been
+ * approved for the app.
+ */
+export async function retriggerBuild(
+  params: RetriggerBuildParams
+): Promise<RetriggerBuildResult> {
+  const [{ dbRead }, { env }] = await Promise.all([
+    import('~/server/db/client'),
+    import('~/env/server'),
+  ]);
+
+  // (1) The request must exist.
+  const request = await dbRead.appBlockPublishRequest.findUnique({
+    where: { id: params.publishRequestId },
+    select: {
+      id: true,
+      status: true,
+      slug: true,
+      appBlockId: true,
+      forgejoCommitSha: true,
+      deployState: true,
+      deployUpdatedAt: true,
+      appBlock: { select: { id: true, currentVersionSha: true } },
+    },
+  });
+  if (!request) {
+    throw new RetriggerBuildError(
+      'NOT_FOUND',
+      `publish request ${params.publishRequestId} not found`
+    );
+  }
+
+  // (2) Only an APPROVED request has a reviewed, committed sha to rebuild.
+  if (request.status !== 'approved') {
+    throw new RetriggerBuildError(
+      'NOT_RETRIGGERABLE',
+      `cannot re-trigger a build for a request in status ${request.status}`
+    );
+  }
+
+  // (3) The sha comes from the DB and must look like a real commit. The procedure
+  //     input carries no sha at all, so there is nothing to smuggle in here — this
+  //     is the integrity check on our OWN stored value, not input validation.
+  const sha = request.forgejoCommitSha;
+  if (!sha || !/^[0-9a-f]{40}$/.test(sha)) {
+    throw new RetriggerBuildError(
+      'NOT_RETRIGGERABLE',
+      'Request has no valid committed sha to rebuild.'
+    );
+  }
+
+  // (4) An approved request always has a backing block; without it there is
+  //     nothing to build an image for.
+  const appBlockId = request.appBlockId;
+  if (!appBlockId) {
+    throw new RetriggerBuildError('NOT_RETRIGGERABLE', 'Request has no backing app block.');
+  }
+
+  // (5) SUPERSEDED — a newer version has been approved for this app since. The
+  //     app's current sha is what should be serving; rebuilding + deploying this
+  //     OLDER sha would roll the live app backwards. Refuse.
+  const currentSha = request.appBlock?.currentVersionSha ?? null;
+  if (currentSha && currentSha !== sha) {
+    throw new RetriggerBuildError(
+      'NOT_RETRIGGERABLE',
+      'A newer version has since been approved for this app — re-triggering this older version would deploy stale code.'
+    );
+  }
+
+  // (6) Deploy-state gate (see assertRetriggerableDeployState for the definition).
+  assertRetriggerableDeployState(request.deployState, request.deployUpdatedAt, Date.now());
+
+  if (!env.FORGEJO_BASE_URL || !env.FORGEJO_ADMIN_TOKEN) {
+    throw new RetriggerBuildError('NOT_RETRIGGERABLE', 'Forgejo not configured');
+  }
+
+  // (7) Abuse controls — redis-backed, because the tRPC `rateLimit` middleware
+  //     short-circuits for moderators and would be a no-op here.
+  const { acquireRetriggerLock, releaseRetriggerLock, checkRetriggerModeratorQuota } = await import(
+    '~/server/utils/blocks-retrigger-rate-limit'
+  );
+  const quota = await checkRetriggerModeratorQuota(params.reviewerUserId);
+  if (!quota.allowed) {
+    throw new RetriggerBuildError(
+      'RATE_LIMITED',
+      `Too many build re-triggers — try again in ${quota.retryAfterSeconds}s.`
+    );
+  }
+  // Single-flight: a double-click must not create two PipelineRuns.
+  if (!(await acquireRetriggerLock(request.id))) {
+    throw new RetriggerBuildError(
+      'RATE_LIMITED',
+      'A re-trigger for this request is already in flight.'
+    );
+  }
+
+  // (8) Fire it — the same step (7) `approveRequest` runs, nothing else.
+  const { triggerBuild } = await import('./apps-pipeline.service');
+  const { setCommitStatus } = await import('./forgejo.service');
+  const callbackUrl = `${(process.env.NEXTAUTH_URL ?? '').replace(
+    /\/$/,
+    ''
+  )}/api/internal/blocks/build-callback`;
+
+  await setCommitStatus({
+    slug: request.slug,
+    sha,
+    state: 'pending',
+    context: 'civitai/build',
+    description: 'Build re-queued by a moderator',
+  }).catch(() => undefined);
+
+  try {
+    await triggerBuild({ slug: request.slug, sha, appBlockId, callbackUrl });
+  } catch (err) {
+    // Free the single-flight slot so the moderator can retry immediately rather
+    // than waiting out the TTL after a visible failure.
+    await releaseRetriggerLock(request.id);
+    await setCommitStatus({
+      slug: request.slug,
+      sha,
+      state: 'failure',
+      context: 'civitai/build',
+      description: `Re-trigger failed: ${String(err).slice(0, 80)}`,
+    }).catch(() => undefined);
+    // 🔴 Make the failure VISIBLE. This is the half of the fix that matters most:
+    // a stranded request's whole problem is that it looks healthy while nothing is
+    // happening. Even when the retrigger ITSELF fails, the row now carries a
+    // 'failed' state + a reason instead of reverting to a silent null.
+    await markRequestDeployState(
+      request.slug,
+      sha,
+      'failed',
+      `Re-trigger failed: ${(err as Error).message ?? String(err)}`.slice(0, 500)
+    );
+    throw new RetriggerBuildError(
+      'TRIGGER_FAILED',
+      `The build re-trigger failed: ${(err as Error).message}. The request is now marked failed; try again once the build service is reachable.`
+    );
+  }
+
+  // Build is queued — advance the lifecycle exactly as approveRequest does, with
+  // an attributable detail so the mod queue shows who re-fired it and when.
+  await markRequestDeployState(
+    request.slug,
+    sha,
+    'building',
+    `Build re-triggered by moderator #${params.reviewerUserId} at ${new Date().toISOString()}`
+  );
+
+  return { publishRequestId: request.id, appBlockId, forgejoCommitSha: sha };
 }
 
 // ---------------------------------------------------------------------------

--- a/src/server/utils/blocks-retrigger-rate-limit.ts
+++ b/src/server/utils/blocks-retrigger-rate-limit.ts
@@ -81,7 +81,9 @@ export async function releaseRetriggerLock(publishRequestId: string): Promise<vo
   }
 }
 
-export type RetriggerQuotaResult = { allowed: true } | { allowed: false; retryAfterSeconds: number };
+export type RetriggerQuotaResult =
+  | { allowed: true }
+  | { allowed: false; retryAfterSeconds: number };
 
 /**
  * Record one retrigger attempt against this moderator's fixed window and report

--- a/src/server/utils/blocks-retrigger-rate-limit.ts
+++ b/src/server/utils/blocks-retrigger-rate-limit.ts
@@ -1,0 +1,116 @@
+import { redis, REDIS_KEYS } from '~/server/redis/client';
+
+/**
+ * Redis-backed abuse controls for the moderator-only `blocks.retriggerBuild`
+ * mutation.
+ *
+ * WHY NOT THE tRPC `rateLimit` MIDDLEWARE — `rateLimit` from
+ * `~/server/middleware.trpc` SHORT-CIRCUITS for moderators:
+ *
+ *     if (ctx.user?.isModerator || isDev || isTest || isPreview) return await next();
+ *
+ * so on a `moderatorProcedure` it is a guaranteed NO-OP. A mod-only build
+ * re-trigger therefore needs its own limiter or it has none at all. These helpers
+ * follow the established blocks limiter shapes instead: the atomic
+ * `setNxKeepTtlWithEx` typed-boolean NX lock used by the build callback's apply
+ * dedup, and the `INCR` + `EXPIRE` fixed window used by the tip / catalog
+ * limiters. Both live under the existing `BLOCKS.TOKEN_RATE_LIMIT` key family in
+ * their own sub-namespaces so they never contend with the mint / apply buckets.
+ *
+ * FAIL DIRECTION — both helpers FAIL OPEN on a Redis error, matching
+ * `markApplyTriggered` in `build-callback.ts` (the closest sibling on this exact
+ * path). Rationale: this procedure exists to RECOVER from a stuck deploy, and it
+ * is reachable only by a moderator who has already passed `moderatorProcedure` +
+ * the inner `isModerator` recheck. Letting a Redis incident block an incident
+ * recovery is strictly worse than letting a trusted operator briefly exceed a
+ * courtesy cap. (Contrast `block-tip-rate-limit`, which fails CLOSED because it
+ * guards a money path reachable by any user.)
+ */
+
+/**
+ * Single-flight lock TTL for one publish request. Long enough that a double-click
+ * / duplicated tab cannot create two Tekton PipelineRuns, short enough that a
+ * genuine second attempt after a visible failure is not wedged for long.
+ */
+export const RETRIGGER_LOCK_TTL_SECONDS = 60;
+
+/** Per-moderator ceiling: how many retriggers one mod may fire per window. */
+export const RETRIGGER_MAX_PER_WINDOW = 10;
+/** Window for {@link RETRIGGER_MAX_PER_WINDOW}. */
+export const RETRIGGER_WINDOW_SECONDS = 60 * 60; // 1 hour
+
+function lockKey(publishRequestId: string): string {
+  return `${REDIS_KEYS.BLOCKS.TOKEN_RATE_LIMIT}:retrigger:${publishRequestId}`;
+}
+
+function moderatorQuotaKey(reviewerUserId: number): string {
+  return `${REDIS_KEYS.BLOCKS.TOKEN_RATE_LIMIT}:retrigger-mod:${reviewerUserId}`;
+}
+
+/**
+ * Claim the single-flight slot for `publishRequestId`.
+ *
+ * @returns `true` when the caller OWNS the slot and may proceed; `false` when a
+ *   retrigger for this request is already in flight within the TTL window (the
+ *   double-click case) and the caller must stop.
+ */
+export async function acquireRetriggerLock(publishRequestId: string): Promise<boolean> {
+  try {
+    // true = newly set (we own it); false = key already present (in flight).
+    return await redis.setNxKeepTtlWithEx(
+      lockKey(publishRequestId) as never,
+      '1',
+      RETRIGGER_LOCK_TTL_SECONDS
+    );
+  } catch {
+    // FAIL OPEN — see the module doc. A Redis incident must not block a recovery.
+    return true;
+  }
+}
+
+/**
+ * Release the single-flight slot early, so a moderator who saw the retrigger fail
+ * can immediately try again instead of waiting out the TTL. Best-effort; the TTL
+ * is the backstop. Never throws.
+ */
+export async function releaseRetriggerLock(publishRequestId: string): Promise<void> {
+  try {
+    await redis.del(lockKey(publishRequestId) as never);
+  } catch {
+    // swallow — the TTL releases the slot regardless.
+  }
+}
+
+export type RetriggerQuotaResult = { allowed: true } | { allowed: false; retryAfterSeconds: number };
+
+/**
+ * Record one retrigger attempt against this moderator's fixed window and report
+ * whether it is within {@link RETRIGGER_MAX_PER_WINDOW}. Bounds how hard the
+ * procedure can hammer the shared build cluster even in the hands of a trusted
+ * operator (or a runaway client).
+ */
+export async function checkRetriggerModeratorQuota(
+  reviewerUserId: number
+): Promise<RetriggerQuotaResult> {
+  const key = moderatorQuotaKey(reviewerUserId);
+  try {
+    const count = await redis.incrBy(key as never, 1);
+    if (count === 1) {
+      await redis.expire(key as never, RETRIGGER_WINDOW_SECONDS);
+    } else {
+      // Self-heal a TTL-less key (re-arm ONLY when the TTL is actually missing, so
+      // an active window is never extended) — same footgun guard as the siblings.
+      const ttl = await redis.ttl(key as never);
+      if (ttl < 0) await redis.expire(key as never, RETRIGGER_WINDOW_SECONDS);
+    }
+
+    if (count <= RETRIGGER_MAX_PER_WINDOW) return { allowed: true };
+
+    let retryAfter = await redis.ttl(key as never);
+    if (!Number.isFinite(retryAfter) || retryAfter < 1) retryAfter = RETRIGGER_WINDOW_SECONDS;
+    return { allowed: false, retryAfterSeconds: retryAfter };
+  } catch {
+    // FAIL OPEN — see the module doc.
+    return { allowed: true };
+  }
+}

--- a/src/shared/constants/app-block-deploy.constants.ts
+++ b/src/shared/constants/app-block-deploy.constants.ts
@@ -1,15 +1,19 @@
 /**
- * Shared App Blocks build/deploy-lifecycle timing constants.
+ * Shared App Blocks build/deploy-lifecycle timing constants + the pure predicates
+ * derived from them.
  *
  * Lives in `shared/` because BOTH sides need the SAME number:
  *   - the owner-facing UI (`~/components/Apps/deploy-status`) decides when a
- *     build/deploy is "stalled" or "stranded", and
+ *     build/deploy is "stalled" or "stranded",
  *   - the server (`retriggerBuild` in `publish-request.service`) decides when an
  *     apparently in-flight deploy is stale enough that a moderator may re-fire
- *     the build.
+ *     the build, and
+ *   - the CLI-facing REST surface (`/api/v1/blocks/submissions`) decides whether
+ *     an approved submission is actually SERVING (`liveUrl`).
  *
- * A second hardcoded number on either side would silently let the UI offer a
- * retrigger the server rejects (or vice-versa), so this is the single source.
+ * A second hardcoded number on any side would silently let the UI offer a
+ * retrigger the server rejects (or hand a CLI a `liveUrl` for an app that never
+ * built), so this is the single source.
  */
 
 /**
@@ -37,3 +41,100 @@ export const DEPLOY_STALE_AFTER_MS = 45 * 60 * 1000;
  * the state minutes later, so polling past this is pure waste.
  */
 export const DEPLOY_PENDING_GRACE_MS = 2 * 60 * 1000;
+
+/**
+ * When `deploy_state` tracking began — the moment after which a NULL deploy state
+ * on an APPROVED row stopped being normal.
+ *
+ * The column was added by the `20260615130000_app_blocks_deploy_state` migration
+ * and `approveRequest` has written `'building'` ever since. So:
+ *   - approved BEFORE this instant + null state  → LEGACY. The lifecycle simply
+ *     wasn't recorded; the app genuinely deployed and is serving.
+ *   - approved AFTER this instant + null state   → the build never started (the
+ *     STRANDED signature) or has not been confirmed yet. NOT serving.
+ *
+ * That distinction is the ONLY thing separating the two null cases — they are
+ * byte-identical in the row otherwise — so it has to be an explicit epoch rather
+ * than something derived. Deliberately the migration's own date (UTC midnight),
+ * i.e. slightly EARLIER than the deploy, so the classification errs toward
+ * "legacy / serving" and can never regress a real pre-feature row.
+ */
+export const DEPLOY_STATE_TRACKING_EPOCH_MS = Date.UTC(2026, 5, 15); // 2026-06-15T00:00:00Z
+
+/** Row shape the shared deploy predicates read. Dates or ISO strings both work. */
+export type ApprovedDeployProjection = {
+  status: string;
+  deployState: string | null | undefined;
+  deployUpdatedAt?: Date | string | null;
+  reviewedAt?: Date | string | null;
+};
+
+/** Milliseconds for a Date | ISO string, or `null` when absent/unparseable. */
+export function deployTimestampMs(d: Date | string | null | undefined): number | null {
+  if (!d) return null;
+  const date = typeof d === 'string' ? new Date(d) : d;
+  const ms = date.getTime();
+  return Number.isFinite(ms) ? ms : null;
+}
+
+/**
+ * Is this publish request's version ACTUALLY SERVING at `https://<slug>.civit.ai/`?
+ *
+ * 🔴 The predicate behind `liveUrl` on `/api/v1/blocks/submissions` — the surface
+ * `civitai app status` reads. Reporting a version as live when it never built
+ * re-creates exactly the invisible-failure this whole feature exists to remove:
+ * the CLI would print a working-looking URL for an app that 404s.
+ *
+ * `'live'` is the only positive deploy state. The subtlety is `null`, which covers
+ * TWO opposite realities:
+ *   - LEGACY — approved before {@link DEPLOY_STATE_TRACKING_EPOCH_MS}, or carrying
+ *     a `deployUpdatedAt` that proves the lifecycle did run at some point. These
+ *     genuinely deployed and MUST keep their `liveUrl`.
+ *   - NEVER BUILT — approved in the tracked era with no transition ever recorded:
+ *     either still inside the approve→build window or STRANDED past
+ *     {@link DEPLOY_STALE_AFTER_MS}. Not serving, so no `liveUrl`.
+ *
+ * Fails toward "serving" whenever it cannot prove otherwise (no `reviewedAt`
+ * anchor at all), so the change can only ever REMOVE a URL that was wrong, never
+ * remove one that was right.
+ *
+ * Takes no `now`: BOTH tracked-era null cases — still inside the approve→build
+ * window, and stranded long past it — are equally "not serving", so the answer
+ * does not depend on the clock. Only {@link isStrandedApprovedDeploy}, which
+ * separates those two, needs one.
+ */
+export function isApprovedAndServing(row: ApprovedDeployProjection): boolean {
+  if (row.status !== 'approved') return false;
+  if (row.deployState === 'live') return true;
+  // Any other non-null state — building / deploying / failed / preview-* — is by
+  // definition not a serving production version.
+  if (row.deployState !== null && row.deployState !== undefined) return false;
+
+  // --- null deploy state: legacy vs never-built ---
+  // A recorded transition means the lifecycle DID run (pre-feature rows that ever
+  // moved), so treat it as the legacy serving case.
+  if (deployTimestampMs(row.deployUpdatedAt) != null) return true;
+  const reviewed = deployTimestampMs(row.reviewedAt);
+  if (reviewed == null) return true; // no anchor to judge by — keep the old assumption
+  if (reviewed < DEPLOY_STATE_TRACKING_EPOCH_MS) return true; // LEGACY pre-tracking approval
+  return false; // tracked era, nothing ever started: in-flight-unconfirmed or STRANDED
+}
+
+/**
+ * The STRANDED signature specifically: a tracked-era approval whose build never
+ * started and is now past {@link DEPLOY_STALE_AFTER_MS} — nothing is running and
+ * nothing ever will without a moderator re-trigger. A strict subset of
+ * `!isApprovedAndServing` (which also covers the still-fresh approve→build
+ * window), and it deliberately excludes the LEGACY null case.
+ */
+export function isStrandedApprovedDeploy(
+  row: ApprovedDeployProjection,
+  now: number = Date.now()
+): boolean {
+  if (isApprovedAndServing(row)) return false;
+  if (row.status !== 'approved') return false;
+  if (row.deployState !== null && row.deployState !== undefined) return false;
+  const reviewed = deployTimestampMs(row.reviewedAt);
+  if (reviewed == null) return false;
+  return now - reviewed > DEPLOY_STALE_AFTER_MS;
+}

--- a/src/shared/constants/app-block-deploy.constants.ts
+++ b/src/shared/constants/app-block-deploy.constants.ts
@@ -1,0 +1,39 @@
+/**
+ * Shared App Blocks build/deploy-lifecycle timing constants.
+ *
+ * Lives in `shared/` because BOTH sides need the SAME number:
+ *   - the owner-facing UI (`~/components/Apps/deploy-status`) decides when a
+ *     build/deploy is "stalled" or "stranded", and
+ *   - the server (`retriggerBuild` in `publish-request.service`) decides when an
+ *     apparently in-flight deploy is stale enough that a moderator may re-fire
+ *     the build.
+ *
+ * A second hardcoded number on either side would silently let the UI offer a
+ * retrigger the server rejects (or vice-versa), so this is the single source.
+ */
+
+/**
+ * A build/deploy that hasn't advanced in this long is treated as STALLED: the
+ * fire-and-forget apply watcher was likely lost to a civitai-web pod restart
+ * (build-callback.ts documents this self-heal-on-next-build window). Sits
+ * COMFORTABLY above the build pipeline's own ceiling — the Tekton pipeline
+ * timeout is 20m EXECUTION plus queue time on the build node — so a legitimately
+ * slow/queued build is never mislabeled.
+ */
+export const DEPLOY_STALE_AFTER_MS = 45 * 60 * 1000;
+
+/**
+ * Grace window for an APPROVED request whose `deploy_state` is still NULL.
+ *
+ * `approveRequest` writes `status='approved'` (+ `forgejo_commit_sha`) and only
+ * THEN calls `markRequestDeployState(..., 'building')`, so there is a genuine —
+ * but sub-second — window where an approved row legitimately has a null deploy
+ * state. Within this grace window the UI keeps polling and renders exactly as it
+ * always has; past {@link DEPLOY_STALE_AFTER_MS} with a still-null state the row
+ * is STRANDED (the build never fired — e.g. `triggerBuild` threw after the
+ * approve was already durable) and is surfaced as such.
+ *
+ * Deliberately much smaller than the stale threshold: nothing is going to write
+ * the state minutes later, so polling past this is pure waste.
+ */
+export const DEPLOY_PENDING_GRACE_MS = 2 * 60 * 1000;

--- a/src/tests/api/internal/blocks/build-callback.test.ts
+++ b/src/tests/api/internal/blocks/build-callback.test.ts
@@ -463,3 +463,171 @@ describe('build-callback handler — flag gate + replay guard', () => {
     expect(mockTriggerApply).not.toHaveBeenCalled();
   });
 });
+
+// ---- OPTIONAL `failureReason` excerpt ---------------------------------------
+//
+// The pipeline may append ONE optional trailing string field, `failureReason`, to
+// a NON-SUCCESS callback. These tests pin BOTH deploy orderings of that
+// independently-shipped contract:
+//
+//   new pipeline + OLD web  — the field is unknown; the handler has no strict
+//     schema (it JSON.parses and validates named fields only) and the HMAC is
+//     computed over the RAW BYTES before parsing, so an added field can neither
+//     break the signature nor the parse. Proven by the "old-web" simulation below,
+//     which verifies a body CONTAINING failureReason against `verifySignature`.
+//
+//   OLD pipeline + new web  — the field is absent; `deploy_detail` must be
+//     BYTE-IDENTICAL to what shipped before. Pinned as an exact-string assertion.
+
+describe('build-callback handler — failureReason excerpt (A1/A2)', () => {
+  const failBody = (over: Record<string, unknown> = {}) => ({
+    ...validSuccessBody(),
+    status: 'Failed',
+    ...over,
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFlag.enabled = true;
+    mockRedis.nxResult = true;
+    mockRedis.nxThrows = false;
+  });
+  afterEach(async () => {
+    await flush();
+  });
+
+  it('ABSENT failureReason → the EXACT pre-feature deploy_detail (dark-safe)', async () => {
+    const res = makeRes();
+    await invoke(signedReq(failBody()), res);
+    expect(res._status).toBe(200);
+    // Byte-identical to the previous `Build ${status.slice(0,60)}` expression.
+    expect(mockMarkDeploy).toHaveBeenCalledWith(SLUG, SHA, 'failed', 'Build Failed');
+  });
+
+  it('PRESENT failureReason → the Build prefix, a blank line, then the excerpt', async () => {
+    const res = makeRes();
+    await invoke(
+      signedReq(failBody({ failureReason: 'ERROR: no package-lock.json is committed' })),
+      res
+    );
+    expect(res._status).toBe(200);
+    expect(mockMarkDeploy).toHaveBeenCalledWith(
+      SLUG,
+      SHA,
+      'failed',
+      'Build Failed\n\nERROR: no package-lock.json is committed'
+    );
+  });
+
+  it('NON-STRING failureReason is ignored (same detail as absent)', async () => {
+    for (const bogus of [42, true, { message: 'x' }, ['x'], null]) {
+      vi.clearAllMocks();
+      const res = makeRes();
+      await invoke(signedReq(failBody({ failureReason: bogus })), res);
+      expect(res._status).toBe(200);
+      expect(mockMarkDeploy).toHaveBeenCalledWith(SLUG, SHA, 'failed', 'Build Failed');
+    }
+  });
+
+  it('re-sanitizes server-side — escapes/control chars never reach the DB', async () => {
+    const ESC = String.fromCharCode(0x1b);
+    const NUL = String.fromCharCode(0x00);
+    const res = makeRes();
+    await invoke(
+      signedReq(failBody({ failureReason: `${ESC}[1;31mERROR${ESC}[0m${NUL}: bad lockfile\r\nline2` })),
+      res
+    );
+    const detail = mockMarkDeploy.mock.calls.at(-1)?.[3] as string;
+    expect(detail).toBe('Build Failed\n\nERROR: bad lockfile\nline2');
+    expect(detail).not.toContain(ESC);
+    expect(detail).not.toContain(NUL);
+    expect(detail).not.toContain('\r');
+  });
+
+  it('OVERSIZED failureReason is truncated with an explicit marker', async () => {
+    const res = makeRes();
+    await invoke(signedReq(failBody({ failureReason: 'z'.repeat(7000) })), res);
+    const detail = mockMarkDeploy.mock.calls.at(-1)?.[3] as string;
+    expect(detail.length).toBeLessThan(4000);
+    expect(detail.endsWith('... [truncated]')).toBe(true);
+  });
+
+  it('a SUCCESS callback ignores failureReason entirely (apply path unchanged)', async () => {
+    const res = makeRes();
+    await invoke(signedReq({ ...validSuccessBody(), failureReason: 'should be ignored' }), res);
+    expect(res._status).toBe(200);
+    expect(res._body).toMatchObject({ ok: true, applied: true });
+    expect(mockTriggerApply).toHaveBeenCalledTimes(1);
+    // No 'failed' transition, and no excerpt anywhere in the states written.
+    for (const call of mockMarkDeploy.mock.calls) expect(call[2]).not.toBe('failed');
+  });
+
+  it('the RESPONSE body is unchanged by the new field (Tekton contract intact)', async () => {
+    const res = makeRes();
+    await invoke(signedReq(failBody({ failureReason: 'boom' })), res);
+    expect(res._body).toEqual({ ok: true, applied: false, reason: 'build failed' });
+  });
+
+  // ---- HMAC is unaffected by the added field --------------------------------
+
+  it('a body CONTAINING failureReason verifies — the signature is over raw bytes', () => {
+    const raw = Buffer.from(JSON.stringify(failBody({ failureReason: 'why it broke' })), 'utf8');
+    const sig = createHmac('sha256', SECRET).update(raw).digest('hex');
+    expect(verifySignature(raw, sig)).toBe(true);
+    expect(verifySignature(raw, `sha256=${sig}`)).toBe(true);
+  });
+
+  it('flipping ONE byte of a failureReason body breaks the signature', () => {
+    const raw = Buffer.from(JSON.stringify(failBody({ failureReason: 'why it broke' })), 'utf8');
+    const sig = createHmac('sha256', SECRET).update(raw).digest('hex');
+    const tampered = Buffer.from(raw);
+    tampered[tampered.length - 5] ^= 0x01;
+    expect(verifySignature(tampered, sig)).toBe(false);
+  });
+
+  it('OLD-WEB SIMULATION: an old handler ignores the unknown field and still verifies', () => {
+    // The pre-feature handler had NO `failureReason` in its CallbackBody type and no
+    // strict schema — it JSON.parsed and read named fields only. Reproduce that:
+    // signature over the raw bytes passes, and the parsed object still exposes every
+    // field the old handler cared about, so `new pipeline + old web` is a no-op.
+    const body = failBody({ failureReason: 'unknown to the old handler' });
+    const raw = Buffer.from(JSON.stringify(body), 'utf8');
+    expect(verifySignature(raw, createHmac('sha256', SECRET).update(raw).digest('hex'))).toBe(true);
+    const parsed = JSON.parse(raw.toString('utf8')) as Record<string, unknown>;
+    expect(parsed.slug).toBe(SLUG);
+    expect(parsed.sha).toBe(SHA);
+    expect(parsed.appBlockId).toBe(APB);
+    expect(parsed.status).toBe('Failed');
+  });
+
+  it('a REALISTIC 2000-char excerpt stays well inside MAX_BODY_BYTES', () => {
+    // Contract: excerpt <= 2000 chars; base body ~250 B; MAX_BODY_BYTES = 8 KiB.
+    // A real build-log excerpt is printable text plus newlines/quotes, each of
+    // which costs 1-2 bytes once JSON-escaped.
+    const printable = ('ERROR: cannot find module "foo"\n' as string).repeat(65).slice(0, 2000);
+    const body = JSON.stringify(failBody({ failureReason: printable }));
+    expect(Buffer.byteLength(body, 'utf8')).toBeLessThan(8 * 1024);
+  });
+
+  it('DOCUMENTED CEILING: an all-control-character excerpt WOULD exceed 8 KiB', () => {
+    //  JSON-escapes to six bytes, so a pathological 2000-char excerpt of
+    // pure control characters serializes to ~12 KB and `readRawBody` would 413 it
+    // BEFORE the handler ever parses.
+    //
+    // Not a security issue and not a regression — the pre-existing 8 KiB ceiling
+    // still holds and rejects it. The consequence is a DEGRADATION: that callback
+    // is dropped, so the request keeps its previous state (it looks stalled)
+    // instead of flipping to 'failed'. The emitting pipeline is contractually
+    // required to send a SANITIZED excerpt, which by construction contains no
+    // control characters, so this is unreachable in practice. Pinned so the
+    // arithmetic is on the record rather than assumed.
+    const pathological = JSON.stringify(
+      failBody({ failureReason: String.fromCharCode(0x01).repeat(2000) })
+    );
+    expect(Buffer.byteLength(pathological, 'utf8')).toBeGreaterThan(8 * 1024);
+    // The safe budget for a control-character-free excerpt: even fully quote/
+    // newline-escaped at 2 bytes each, 2000 chars fits.
+    const escapeHeavy = JSON.stringify(failBody({ failureReason: '"\n'.repeat(1000) }));
+    expect(Buffer.byteLength(escapeHeavy, 'utf8')).toBeLessThan(8 * 1024);
+  });
+});

--- a/src/tests/api/v1/blocks/submissions.test.ts
+++ b/src/tests/api/v1/blocks/submissions.test.ts
@@ -354,6 +354,78 @@ describe('GET /api/v1/blocks/submissions', () => {
     expect(out.submissions[0].liveUrl).toBeNull();
   });
 
+  /**
+   * 🔴 `liveUrl` and the TWO opposite meanings of a null deployState.
+   *
+   * This is the surface `civitai app status` reads. Handing it a working-looking
+   * URL for a STRANDED approval (the build never fired, so deploy_state stayed
+   * null) re-creates on the CLI exactly the invisible failure this feature exists
+   * to remove. But a LEGACY row — approved before deploy-state tracking existed —
+   * has the same null and genuinely IS serving, so it must keep its URL.
+   */
+  it('liveUrl is null for a STRANDED approval (tracked era, build never fired)', async () => {
+    mockGetSession.mockResolvedValueOnce(MOD_SESSION);
+    mockFindMany.mockResolvedValueOnce([
+      dbRow({
+        status: 'approved',
+        deployState: null,
+        // Approved AFTER deploy-state tracking began, and nothing ever transitioned.
+        reviewedAt: new Date('2026-06-21T00:00:00Z'),
+        deployUpdatedAt: null,
+      }),
+    ]);
+    const { req, res } = authGet();
+    await handler(req as never, res as never);
+    expect(res._getStatusCode()).toBe(200);
+    const out = res._getJSONData() as { submissions: Array<{ liveUrl: string | null }> };
+    expect(out.submissions[0].liveUrl).toBeNull();
+  });
+
+  it('liveUrl is PRESERVED for a LEGACY approval predating deploy-state tracking', async () => {
+    mockGetSession.mockResolvedValueOnce(MOD_SESSION);
+    mockFindMany.mockResolvedValueOnce([
+      dbRow({
+        status: 'approved',
+        deployState: null,
+        // Approved before the deploy_state column existed: null is expected here
+        // and says nothing about whether the app deployed. It did.
+        reviewedAt: new Date('2026-05-01T00:00:00Z'),
+        deployUpdatedAt: null,
+      }),
+    ]);
+    const { req, res } = authGet();
+    await handler(req as never, res as never);
+    const out = res._getJSONData() as { submissions: Array<{ liveUrl: string | null }> };
+    expect(out.submissions[0].liveUrl).toBe('https://my-page-app.civit.ai/');
+  });
+
+  it('liveUrl is PRESERVED for a null-state row that DID record a transition', async () => {
+    // A recorded deployUpdatedAt proves the lifecycle ran at some point, so this
+    // is not the stranded signature whatever the approval date.
+    mockGetSession.mockResolvedValueOnce(MOD_SESSION);
+    mockFindMany.mockResolvedValueOnce([
+      dbRow({
+        status: 'approved',
+        deployState: null,
+        reviewedAt: new Date('2026-06-21T00:00:00Z'),
+        deployUpdatedAt: new Date('2026-06-22T00:00:00Z'),
+      }),
+    ]);
+    const { req, res } = authGet();
+    await handler(req as never, res as never);
+    const out = res._getJSONData() as { submissions: Array<{ liveUrl: string | null }> };
+    expect(out.submissions[0].liveUrl).toBe('https://my-page-app.civit.ai/');
+  });
+
+  it('liveUrl is null for a FAILED build', async () => {
+    mockGetSession.mockResolvedValueOnce(MOD_SESSION);
+    mockFindMany.mockResolvedValueOnce([dbRow({ status: 'approved', deployState: 'failed' })]);
+    const { req, res } = authGet();
+    await handler(req as never, res as never);
+    const out = res._getJSONData() as { submissions: Array<{ liveUrl: string | null }> };
+    expect(out.submissions[0].liveUrl).toBeNull();
+  });
+
   it('liveUrl is null for a pending (not-approved) submission', async () => {
     mockGetSession.mockResolvedValueOnce(MOD_SESSION);
     mockFindMany.mockResolvedValueOnce([


### PR DESCRIPTION
Two coupled defects, both hit in production today.

**A. Build failures were invisible to the app author.** A failed build stored `deployDetail = "Build Failed"`. The line that actually tells the author what to fix (`ERROR: no package-lock.json is committed. Commit your lockfile — …`) lived only in a build log a third-party author cannot read.

**B. An approved request whose build never fired was stranded.** `approveRequest` writes `status='approved'` + `forgejoCommitSha` and only *then* calls `markRequestDeployState(…,'building')`. When `triggerBuild` threw in between (a transient 502 from the trigger), the approve was already durable but `deploy_state` stayed `NULL` forever. `approveRequest` is not idempotent (`cannot approve a request in status approved`) and there was no re-trigger — so the only recovery was asking the developer to resubmit at a brand-new version. In the UI that row rendered a healthy green **approved** the whole time.

**No schema migration.** `app_block_publish_requests.deploy_detail` is already `String?` → unbounded `TEXT` (`20260615130000_app_blocks_deploy_state`). This PR only populates it.

---

## A — the callback contract

The build callback body gains **one optional trailing string field**:

```json
{"slug":"…","sha":"…","appBlockId":"…","imageRef":"…","status":"…","ts":123,"failureReason":"<sanitized excerpt>"}
```

Emitted by the pipeline **only** when the build did not succeed **and** a non-empty excerpt exists; otherwise entirely absent and the body is byte-identical to today. ≤ 2000 characters. The `review` callback lane is untouched.

### Backward compatibility — proven in both directions

The pipeline (GitOps) and civitai-web (release train) deploy independently, so both orderings matter.

**new pipeline + old web — safe.** The handler has no strict schema: it `JSON.parse`s and validates only named fields (`build-callback.ts` — `slug`/`sha`/`appBlockId`/`imageRef`/`ts`), so an unknown key is ignored. And the signature is computed over the **raw request bytes before parsing** — `verifySignature(rawBody, …)` runs at the top of the handler, with `config.api.bodyParser = false` precisely so the bytes Tekton hashed are the bytes we hash. An added body field therefore cannot break the HMAC. Pinned by `OLD-WEB SIMULATION: an old handler ignores the unknown field and still verifies`, plus a sign/verify pair over a body containing `failureReason` and a byte-flip negative.

**old pipeline + new web — byte-identical to today.** With the field absent, `buildFailureDeployDetail(status, undefined)` returns `Build ${String(status ?? 'failed').slice(0, 60)}` — exactly the previous inline expression. Pinned by exact-string assertions (`'Build Failed'`, `'Build Cancelled'`, `'Build failed'`).

### Sanitization — never trust the field's content

The excerpt is **tenant-influenced build output**. It arrives over an authenticated channel, but an HMAC proves *who* sent the bytes, never that the bytes are safe — so it is re-sanitized server-side, unconditionally, before it is persisted.

`sanitizeBuildFailureReason(raw: unknown): string | undefined` — pure, exported, in `src/server/services/blocks/build-failure-reason.ts` (**not** under `src/pages/**`):

1. non-string → `undefined`;
2. input hard-sliced to 8000 chars **before any regex** (bounds cost regardless of caller);
3. ANSI/CSI/OSC escape sequences stripped **first** — removing the bare `ESC` first would leave `[0m` / `]0;title` behind as visible garbage. Covers OSC (BEL-, ST- and unterminated forms), CSI, 8-bit CSI `0x9B`, and the general ECMA-48 `ESC [ -/]* [0-~]` form;
4. `\r\n` → `\n`, stray `\r` dropped, `\t` → space;
5. every remaining control character removed — output is `\n` plus printable only (no NUL, DEL, C0, C1);
6. trailing spaces per line trimmed, blank-line runs collapsed to one, whole string trimmed;
7. hard-truncated to **3000 chars**, the marker `\n... [truncated]` *replacing* the tail so the cap is never exceeded;
8. empty/whitespace-only result → `undefined`.

**Caps.** Excerpt ≤ 3000. Stored `deploy_detail` = `"Build <status≤60>" + "\n\n" + excerpt` ⇒ worst case 3068, comfortably under the **4000-char** budget this feature commits to.

Deliberately **not** HTML-escaped: `<`, `>`, `&`, `"` are legitimate build-log characters (`Cannot find module "foo"`). Escaping belongs to the renderer, and every consumer escapes (React text nodes; JSON on the v1 route). A literal `</script>` is preserved as text and is safe because it is never interpolated into an HTML/script context — pinned by a browser test asserting the characters appear in `textContent` while `querySelector('script')` is `null`.

### Owner-facing surfacing

`listMyPublishRequests` is scoped by `submittedByUserId` — **that scoping is the guard**, and it is not widened here. The excerpt renders in a `<pre>` with `white-space: pre-wrap`, `max-height: 14rem`, `overflow: auto`, through normal React escaping. (A plain `<pre>` rather than Mantine's `<Code block>` so the wrap + height cap are owned outright.)

**Stranded badge, dark-safe by construction.** `isStrandedDeploy` (pure, exported, unit-tested) fires only when the row is `approved` **and** `deployState === null` **and** there is **no** `deployUpdatedAt` (any legacy row that ever transitioned is excluded) **and** `now - reviewedAt > DEPLOY_STALE_AFTER_MS`. The millisecond window between the approve write and `markRequestDeployState` therefore looks exactly as it does today. `reviewedAt` was already in the select; it is now also carried on the row type.

Polling: a null-state row is polled during a short `DEPLOY_PENDING_GRACE_MS` (2 min) window — the real race — and then **not** polled, because nothing will ever write it. The previous behaviour (`null` never in-flight) would never have shown the transition; polling a permanently stranded row forever would be the opposite bug.

---

## B — mod-only `blocks.retriggerBuild`

`moderatorProcedure.use(enforceAppBlocksFlag)` + the redundant inner `ctx.user?.isModerator` belt, matching `approveRequest` exactly. Input schema carries **only** `publishRequestId`.

`retriggerBuild({ publishRequestId, reviewerUserId })` re-runs step (7) of the approve flow and nothing else: **no** Forgejo re-commit, **no** `AppBlock`/`OauthClient` mutation, **no** listing/category/storage provisioning, **no** approval notification, **no** supersede sweep.

### Guards

1. **Exists** → `NOT_FOUND`.
2. **`status === 'approved'`** — `pending` / `rejected` / `withdrawn` refused.
3. **The sha comes from the DB, never the client.** The procedure input has no sha field at all, so this is structurally impossible rather than merely validated. The stored value is additionally asserted against `/^[0-9a-f]{40}$/`.
4. **`appBlockId` present.**
5. **Not superseded** — if `AppBlock.currentVersionSha !== request.forgejoCommitSha`, a newer version has since been approved and rebuilding this one would deploy older code over the current one. Refused.
6. **Deploy-state gate** — the precise definition of *approved-but-not-successfully-built*:
   - allow `null` (the stranding case) and `'failed'`;
   - allow `'building'` / `'deploying'` **only** when `deployUpdatedAt` is older than the stale threshold;
   - refuse `'live'` and any `preview-*` value (the review-sandbox lane).

   The threshold is the **shared** `DEPLOY_STALE_AFTER_MS`, moved to `~/shared/constants/app-block-deploy.constants` and re-exported from `deploy-status.ts` so every existing importer is unaffected — the UI and the server gate cannot drift.
7. **Rate limit + double-click idempotency, both redis-backed.** `rateLimit` from `~/server/middleware.trpc` short-circuits for moderators (`middleware.trpc.ts:153`), so on a mod-only procedure it is a guaranteed no-op — hence a dedicated limiter: a per-`publishRequestId` NX lock (60 s) and a per-moderator cap (10/hour, charged to the **session** user id).

   **Fail direction: OPEN**, on both, matching `markApplyTriggered` in `build-callback.ts` — the closest sibling on this exact path. This procedure exists to *recover* from a stuck deploy and is reachable only by a moderator, so letting a Redis incident block an incident recovery is strictly worse than a trusted operator briefly exceeding a courtesy cap. (Contrast `block-tip-rate-limit`, which fails closed because it guards a money path open to any user.)
8. **A failing re-trigger becomes visible.** On `triggerBuild` throwing: free the lock, flip the Forgejo commit status to failure, and `markRequestDeployState(… 'failed', 'Re-trigger failed: …')` before throwing. This alone converts defect B's silent `null` into a visible failure.
9. **Moderation is not bypassed** — the sha is the already-reviewed one, straight from the DB.

**Judgement call — mod-only, deliberately.** Owner self-service would need its own abuse controls and a build-capacity budget. The owner instead gets the real failure reason (deliverable A) plus a "contact a moderator to re-run it" affordance. Worth revisiting if mods become the bottleneck.

### Mod UI

`listApprovedRequests` now selects `deployState` / `deployDetail` / `deployUpdatedAt` (additive). The `/apps/review` **Approved** tab gains a Deploy column — a null state renders **never built** rather than silently looking healthy — plus a **Retrigger build** control that is confirm-gated (first click arms, second fires), disabled wherever the server gate would reject via the pure `canRetriggerBuild` mirror, and disabled+spinning while its own mutation is in flight. The **Rejected** tab passes no handler and renders exactly as before.

---

## Tests

| File | Covers |
|---|---|
| `services/blocks/__tests__/build-failure-reason.test.ts` (33) | sanitizer: non-string/empty, ANSI/CSI/OSC (incl. unterminated + 8-bit), control chars, `\r`/CRLF/tabs, blank-line collapsing, truncation boundary (at cap / +1 / huge), adversarial fixture (`"`, `\`, `</script>`, `]0;…`, NUL) proving printable+`\n` output, idempotence, and the dark-safe `buildFailureDeployDetail` contract |
| `tests/api/internal/blocks/build-callback.test.ts` (+10 → 43) | absent → exact pre-feature string; present → prefixed detail; non-string ignored; server-side re-sanitization; oversized → truncated with marker; success path ignores it; response body unchanged; HMAC verifies with the field and fails on a byte flip; old-web simulation; body-size ceiling |
| `services/blocks/__tests__/publish-request.retriggerBuild.test.ts` (54) | every guard branch, pass **and** fail: each wrong status, missing/empty/malformed stored sha (8 shapes, asserted on the guard's OWN `INVALID_STORED_SHA` code — see the sha-guard note below), caller-supplied sha ignored, missing appBlockId, superseded, `live`, each `preview-*`, fresh in-flight, stalled in-flight (allowed), no timestamp, unknown state, the null-state grace bound (just-approved refused / boundary / no-anchor fail-closed / `deployUpdatedAt` fallback), both replica-lag races, quota exhausted, double-fire within the lock, trigger-throws → `failed` written + lock freed + never `building` + **no internal detail in the stored reason**, happy path with the DB sha |
| `routers/__tests__/blocks.router.retriggerBuild.test.ts` (12) | non-mod / anonymous / payload-claimed elevation rejected with the service never reached; mod passes; reviewer bound to the session id; schema strips a caller sha/ref; input validation; typed error mapping (NOT_FOUND / TOO_MANY_REQUESTS / BAD_REQUEST) |
| `routers/__tests__/blocks.router.listMyPublishRequests.test.ts` (+4) | owner-only scoping — the `where` clause pinned per caller, anonymous issues no query, and `deployDetail`/`reviewedAt` present in the select |
| `components/Apps/__tests__/deploy-status.test.ts` (+22 → 34) | `isStrandedDeploy` boundaries (exclusive at the threshold, fresh approval, legacy transitioned row, no anchor, non-approved, ISO strings, disjoint from stale), `isAwaitingDeployState`, poll cadence for stranded/awaiting, and the full `canRetriggerBuild` truth table |
| `components/Apps/MySubmissionsList.buildFailure.browser.test.tsx` (11) | excerpt renders; renders as escaped **text** with no `<script>`/`<b>` element created; newlines preserved with `pre-wrap`; height-capped + scrollable with 400 lines; no-excerpt paths unchanged; stranded badge + banner past the threshold; fresh-approved and legacy rows unchanged; live row untouched |
| `components/Apps/UnifiedReviewList.retrigger.browser.test.tsx` (12) | Deploy column shows "never built"; column+control absent without a handler; enabled/disabled across null/failed/live/fresh-in-flight/stalled; confirm-then-fire; `dblClick` fires once; own-row-in-flight disables, other-row does not |

**Run output.** Unit: **1888 passed (1888)** across **100** files (all of `src/server/services/blocks/__tests__/`, both router tests, `src/tests/api/internal/blocks/`, `deploy-status`, `unifiedReviewRow`). Component: `MySubmissionsList.buildFailure` 11/11, `UnifiedReviewList.retrigger` 12/12, and the pre-existing `MySubmissionsList` 38/38 and `UnifiedReviewList` 4/4 still green.

### Mutation testing

Each security-critical guard was broken on purpose, the suite re-run, and reverted.

1. **Owner-only visibility** — `where: { submittedByUserId: ctx.user.id }` → `where: {}`. **2 tests failed** (`expected {} to deeply equal { submittedByUserId: 7 }` / `{ submittedByUserId: 999 }`). Reverted → 7/7 green.
2. **Moderator gate** — `moderatorProcedure` → `protectedProcedure`, `isModerator` belt removed. **2 tests failed** (`promise resolved … instead of rejecting`, for the non-mod and payload-claimed-elevation cases). Reverted → 12/12 green.
3. **Sha from the DB, not the client** — service changed to `params.sha ?? request.forgejoCommitSha`. **1 test failed** (`IGNORES any caller-supplied sha`). Reverted. The router layer of the same guard was mutated separately (schema accepts `sha`, router forwards `input.sha`) → **1 test failed** (`a caller-supplied sha is STRIPPED by the schema`). Reverted → 60/60 green.

### Typecheck

`NODE_OPTIONS=--max_old_space_size=8192 npx tsc --noEmit` — **clean**. (One genuine error was caught and fixed along the way: an implicitly-`any` click-handler param.)

---

## Notes and things worth a reviewer's eye

- **Body-size ceiling — documented rather than assumed.** The estimate of a ≈4 KB worst case for an escaped 2000-char excerpt holds for realistic content (~1–2 bytes/char escaped) but **not** for a pathological all-control-character excerpt, which JSON-escapes to six bytes each ≈ 12 KB and would be rejected by the pre-existing 8 KiB `MAX_BODY_BYTES` with a 413. Not a security issue and not a regression — the consequence is a *degradation*: that callback is dropped, so the row keeps its previous state (looks stalled) instead of flipping to `failed`. Unreachable in practice because the pipeline is contractually required to send a sanitized excerpt, which by construction has no control characters. Both the safe bound and the pathological ceiling are pinned as tests so the arithmetic is on the record.
- **`src/pages/api/v1/blocks/submissions.ts`** is a second consumer of the excerpt (it serializes as JSON, which escapes). Its access posture is unchanged and was already safe: self-scoped at the query (`{ submittedByUserId: user.id }` is always the first clause) plus a personal API key or an Apps-submit-scoped OAuth token. Its `liveUrl` predicate **was** changed — see audit fix 3.
- **Still not changed:** `SubmissionActions` (the owner UI button) treats `deployState == null` as "live enough" to offer *Open live* on a stranded row. For a stranded **subsequent** version that is correct (the previous version is still serving); for a stranded **first** version it points at an origin that never deployed. The equivalent hole on the **CLI-facing REST** surface *was* closed (audit fix 3) because that one is machine-read by `civitai app status`; the UI button now has a shared predicate available (`isApprovedAndServing`) if a follow-up wants it.
- `ApprovedRequest` gained three optional deploy fields, so existing fixtures that omit them still typecheck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Audit fixes (commit `e5151fa`)

An adversarial audit of this PR returned *safe to merge, no 🔴* with four findings. All four are fixed here, each mutation-verified.

### 1. 🔴 The retrigger's OWN failure text was shown to the third-party author

`triggerBuild` throws `` `trigger ${status} ${statusText}: ${text.slice(0,240)}` `` — **240 raw bytes of the internal trigger receiver's response body** — or a message naming the trigger env vars. The failure path wrote that string straight into `deploy_detail`, which **both** `blocks.listMyPublishRequests` **and** `GET /api/v1/blocks/submissions` hand to the app **owner**. It also bypassed `sanitizeBuildFailureReason`, contradicting that module's stated invariant that the *stored* value is guaranteed printable, bounded text.

The owner-visible column now receives a fixed, generic, author-actionable string, written **through** the sanitizer so the invariant holds on every write path — not just the build-callback's. Verbatim, what an author now sees on a trigger failure:

```
Build re-trigger failed: Civitai could not reach the build service. This is a problem on our side, not with your app — a moderator has to retry it. No new version submission is needed.
```

The internal detail goes to a structured `logToAxiom` record (`app-block-retrigger-failed`, dataset `app-blocks`) carrying the publish-request id, slug, appBlockId, reviewer id and the raw error, so the failure is still fully diagnosable server-side. The Forgejo commit-status description — readable by the author on their own repo — and the moderator-facing tRPC message are generic for the same reason.

### 2. Guards read from the read replica; TOCTOU under lag

Every guard read via `dbRead`, a **separate readonly client** that can lag. Two concrete races:

- a mod approves v2 (primary now has `AppBlock.currentVersionSha = B`); within the lag window another mod clicks **Retrigger** on v1 — the replica still returns `A`, the supersede guard passes, and v1's older reviewed sha is rebuilt and applied **over the newer approval**;
- a fresh approval's `deploy_state='building'` reads back as `null`, so a second PipelineRun races the first.

The redis NX lock does not help: `approveRequest` never takes it.

The guard row is now read from **`dbWrite`** (the primary) — a once-per-click moderator action, so the primary read costs nothing. That closes the lag half. The other half is **wall-clock and unfixable by reading the primary**: `approveRequest` writes the approval, then `await`s `triggerBuild` (a 30 s network timeout), and only *then* writes `'building'` — during that window the primary itself legitimately reads `null` while a PipelineRun is already being created. So the `null` branch is now bounded by the **shared `DEPLOY_PENDING_GRACE_MS`** (not a second hardcoded number, and deliberately not `DEPLOY_STALE_AFTER_MS` — making a mod wait 45 minutes to recover a provably-stranded request would defeat the procedure). With no anchor at all it **fails closed**, matching the in-flight branch. `canRetriggerBuild` (the client mirror) gains the same bound, staying permissive with no anchor since the server is the authority.

### 3. The CLI-facing REST surface reported a STRANDED row as live

`isLive = isApproved && (deployState === 'live' || deployState == null)` — so a stranded **first** version returned a working-looking `liveUrl`. That is the surface `civitai app status` reads, which re-creates the exact invisible failure this PR exists to eliminate.

`deployState == null` also covers a **legacy** pre-`deploy_state` row that genuinely *was* live, so the two are separated rather than lumped. The new shared `isApprovedAndServing` predicate returns **true** for: `'live'`; a null state with a recorded `deployUpdatedAt` (the lifecycle ran at some point); a null state approved **before** `DEPLOY_STATE_TRACKING_EPOCH_MS` (the `20260615130000_app_blocks_deploy_state` migration date — the only thing that distinguishes the two nulls, since the rows are otherwise byte-identical); and a null state with no `reviewedAt` anchor at all. It returns **false** for a null state in the tracked era. It therefore fails *toward* serving and can only ever remove a URL that was already wrong. Both directions are pinned — the stranded case and the legacy case — and both are killed by mutation.

### 4. A test-coverage claim in this body was false; now it is true

The table above previously claimed the stored-sha guard's "missing/empty/malformed sha (6 shapes)" was pinned. It was not: the auditor deleted the `/^[0-9a-f]{40}$/` assertion and **all 41 tests still passed**. The `strandedRow()` fixture set `appBlock.currentVersionSha = SHA`, so a malformed `forgejoCommitSha` also tripped the **supersede** guard, which threw the same `NOT_RETRIGGERABLE` code the assertion checked — one guard's test masquerading as another's.

Fixed on both axes: the sha guard now throws its own **`INVALID_STORED_SHA`** code, and the sha cases null out `currentVersionSha` so no other guard can stand in for it. The claim is now backed by the mutation below.

### Also

- **`TRIGGER_FAILED` → `INTERNAL_SERVER_ERROR`** instead of `BAD_REQUEST`. A build-service outage is a server fault; reporting it to a mod as a 400 mislabelled an incident as user error and kept it off the server-fault error board. (`INVALID_STORED_SHA` maps to `BAD_REQUEST`.)
- **`deployDetail` dropped from the moderator-queue row projection** (`unifiedReviewRow.ts`). It shipped the tenant-influenced excerpt into a payload the mod queue never renders. `ReviewRowDeploy` gains `reviewedAt` instead — the anchor the client-mirror grace bound needs.

### Mutation verification

Each guard touched or added was broken on purpose, the suite re-run, and reverted.

| Mutation | Result |
|---|---|
| Delete the sha guard's `/^[0-9a-f]{40}$/` check | **8 tests failed** (`refuses a request with NO stored sha`, `refuses an empty stored sha`, and the 6 malformed shapes). Reverted → green. *This is the mutation that used to pass.* |
| `dbWrite.findUnique` → `dbRead.findUnique` in the guard path | **3 targeted tests failed** (`never consults the read replica at all`, `RACE 1 — a v2 approval that has not reached the replica still supersedes v1`, `RACE 2 — a fresh approval's 'building' write is seen even if the replica lags`; the whole file fails, since the fixture stubs the primary). Reverted → green. |
| Remove the `null`-branch grace bound | **3 tests failed** (`refuses a JUST-approved request`, the grace-boundary exclusivity pair, `FAILS CLOSED when there is no anchor`). Reverted → green. |
| Restore the raw thrown error as `deployDetail` + commit-status description | **5 tests failed** (`stores NO part of the trigger receiver response body`, `stores NO env-var name when the trigger is unconfigured`, `stores the FIXED author-facing message`, `does not leak the receiver body through the Forgejo commit status either`, plus the guard-8 detail assertion). Reverted → green. |
| Restore `isLive = approved && (state === 'live' \|\| state == null)` | **1 test failed** (`liveUrl is null for a STRANDED approval`) — while both legacy tests stayed green, which is the proof the legacy case is not regressed. Reverted → green. |
| Reverse direction: make `isApprovedAndServing` treat **every** null as never-built | **8 tests failed**, including `liveUrl is PRESERVED for a LEGACY approval predating deploy-state tracking` and `liveUrl is PRESERVED for a null-state row that DID record a transition` — so the legacy-null assertions are themselves killing, not decorative. Reverted → green. |

### Test + typecheck run

- Targeted: **2150 passed / 117 files** (`services/blocks/__tests__/`, both retrigger router tests, `tests/api/v1/blocks/submissions.test.ts`, `components/Apps/__tests__/`).
- Full unit project: **8851 passed, 12 failed, 1 skipped (8864)**. The 12 failures are in `components/AppBlocks/__tests__/hiddenBlocks.test.ts` (undefined `localStorage`) and `server/services/__tests__/article-locked-properties.service.test.ts` (Prisma query-engine binary not found) — **confirmed pre-existing**: they reproduce identically with this branch's working tree reverted to `HEAD`, and neither file imports anything this change touches.
- `NODE_OPTIONS=--max_old_space_size=8192 npx tsc --noEmit` — **clean**.
- All *added* files pass `prettier --check` and `eslint` (no errors). No test or helper file was placed under `src/pages/**`.
