### PR TITLE
fix(editor): keep blockquotes through sanitizeHtml

### DIFF
--- a/src/utils/__tests__/html-sanitize-helpers.test.ts
+++ b/src/utils/__tests__/html-sanitize-helpers.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { sanitizeHtml } from '~/utils/html-sanitize-helpers';
+
+describe('sanitizeHtml', () => {
+  // StarterKit's Blockquote is enabled whenever the `formatting` control is, so
+  // `> ` in any article editor produces one — but the tag was never allowlisted,
+  // so it was unwrapped on save while the CSS for it already shipped.
+  it('keeps blockquotes', () => {
+    expect(sanitizeHtml('<blockquote><p>quoted</p></blockquote>')).toBe(
+      '<blockquote><p>quoted</p></blockquote>'
+    );
+  });
+
+  it('still drops tags outside the allowlist', () => {
+    expect(sanitizeHtml('<table><tr><td>x</td></tr></table>')).toBe('x');
+    expect(sanitizeHtml('<script>alert(1)</script>')).toBe('');
+  });
+
+  it('forces rel="ugc" on links', () => {
+    expect(sanitizeHtml('<a href="https://example.com">x</a>')).toContain('rel="ugc"');
+  });
+});

--- a/src/utils/html-sanitize-helpers.ts
+++ b/src/utils/html-sanitize-helpers.ts
@@ -16,6 +16,7 @@ const DEFAULT_ALLOWED_TAGS = [
   'img',
   'iframe',
   'div',
+  'blockquote',
   'code',
   'pre',
   'span',


### PR DESCRIPTION
Split out of #3394, where this one line was buried among 15 files. It stands alone and has nothing to do with markdown import.

## The bug

`blockquote` is absent from `DEFAULT_ALLOWED_TAGS`, so `sanitizeHtml` unwraps it — verified against sanitize-html 2.12.1:

```
input : <blockquote><p>quoted</p></blockquote>
output: <p>quoted</p>
```

StarterKit enables Blockquote whenever the `formatting` control is on (`blockquote: !addFormatting ? false : undefined`), which is every rich text editor in the app. So typing `> ` — or Mod+Shift+B — produces a quote that renders correctly while editing and silently becomes a plain paragraph once saved.

The tell that this is an oversight rather than a policy: **the styling already ships.** `TypographyStylesWrapper.module.scss:234` gives blockquote padding and a background, and `globals.css` styles `.markdown-content blockquote`. Someone styled a tag the sanitizer was eating.

## Scope

This is the shared allowlist, so it applies to every `sanitizeHtml` caller that doesn't pass its own `allowedTags` — articles, model descriptions, bounties, cosmetic shop, questions. Low risk: `blockquote` takes no attributes here (only `id`, via the existing `'*'` rule), and it was already in the Tiptap schema on all those surfaces, so this restores content that was being discarded rather than admitting anything new.

Comments, resource reviews and model-version descriptions pass their own narrower `allowedTags` and still unwrap it. Making that uniform is a product question — whether blockquotes belong in a comment — so it's not here.

## Testing

`sanitizeHtml` had no tests; this adds the first three (blockquote kept, non-allowlisted tags still dropped, `rel="ugc"` still forced).

`article-extraction-parity.test.ts` — 48 tests over the same content pipeline — still passes unchanged.
