### PR TITLE
perf(db): set Prisma errorFormat 'minimal' in production

### DIFF
--- a/packages/civitai-db/src/client.errorFormat.test.ts
+++ b/packages/civitai-db/src/client.errorFormat.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { buildErrorFormatOption } from './client';
+
+// Prisma's non-'minimal' errorFormat makes the client capture a stack trace (`new Error`) on every
+// model-method call, just to annotate errors with a source location. In production that annotation
+// is never rendered (the renderer early-returns on NODE_ENV === 'production'), so the capture is
+// pure waste — it was the largest single allocation source in a production SSR allocation profile.
+describe('buildErrorFormatOption', () => {
+  it("uses 'minimal' in production so Prisma skips the per-call callsite capture", () => {
+    expect(buildErrorFormatOption(true)).toEqual({ errorFormat: 'minimal' });
+  });
+
+  it('leaves errorFormat at the Prisma default outside production for readable local errors', () => {
+    // Must be an ABSENT key, not `errorFormat: undefined` — spreading an explicit `undefined`
+    // into the client options would override Prisma's own default.
+    const opts = buildErrorFormatOption(false);
+    expect(opts).toEqual({});
+    expect('errorFormat' in opts).toBe(false);
+  });
+});

--- a/packages/civitai-db/src/client.ts
+++ b/packages/civitai-db/src/client.ts
@@ -12,6 +12,26 @@ export type CreatePrismaClientsOptions = Partial<DbConfig> & {
 };
 
 /**
+ * Prisma's default `errorFormat` ('colorless') makes the client construct a `new Error`
+ * on EVERY model-method invocation (`prisma.x.findMany(...)`) purely to capture a callsite
+ * for pretty error rendering. Capturing that stack is not free: it was the single largest
+ * allocation source in a production V8 allocation-sampling profile of our SSR tier
+ * (~15% of all bytes allocated) and ~2.3% of on-CPU JS time.
+ *
+ * That work is entirely wasted in production: the client's error renderer early-returns
+ * before ever reading the callsite when `process.env.NODE_ENV === 'production'`, so the
+ * captured stack is allocated and immediately discarded. `errorFormat: 'minimal'` swaps the
+ * stack-capturing callsite for a no-op one. Error `code`, `meta` and `message` are unchanged;
+ * only the (already-unused-in-prod) source-location decoration is dropped.
+ *
+ * Kept as the rich default outside production so local/dev error output still shows the
+ * offending source line.
+ */
+export function buildErrorFormatOption(isProd: boolean): { errorFormat?: 'minimal' } {
+  return isProd ? { errorFormat: 'minimal' } : {};
+}
+
+/**
  * Build the Prisma read/write clients. Connection config defaults come from the
  * package env schema (./env, overridable via options); app behavior (logger, slow-query
  * sink) is injected. HMR/global caching and the Next build guard live in the app shim
@@ -53,6 +73,7 @@ export function createPrismaClients(options: CreatePrismaClientsOptions = {}): P
     const dbUrl = readonly ? config.replicaUrl : config.databaseUrl;
     const clientOptions = {
       log: logDef,
+      ...buildErrorFormatOption(config.isProd),
       datasources: { db: { url: dbUrl } },
     } as Prisma.PrismaClientOptions;
     const prisma = new PrismaClient(clientOptions);


### PR DESCRIPTION
Prisma’s default `errorFormat` (`colorless`) makes the client construct a **`new Error` on every model-method invocation** (`prisma.x.findMany(...)`) purely to capture a callsite for source-annotated error rendering.

That capture is **wasted work in production**. The client’s error renderer early-returns before ever calling `callsite.getLocation()`:

```js
if (!e || typeof window < "u" || process.env.NODE_ENV === "production") return s;
let a = e.getLocation();   // unreachable in prod
```

so the stack is captured and then unconditionally discarded.

### Why it is worth changing

Measured on a production SSR process with a V8 **allocation-sampling** profile (`HeapProfiler.startSampling` with `includeObjectsCollectedByMinorGC`, so short-lived garbage is counted):

| | |
|---|---|
| Prisma runtime frame doing the capture | **~15% of ALL bytes allocated** — the single largest allocation source |
| Same frame in a CPU profile of that tier | ~2.3% of on-CPU JS time |
| Reproduced | yes — two independent processes, ranking stable within ~1pp |

Allocation volume matters here because the SSR tier’s GC is **scavenge-dominated** (~93% of GC time is young-generation), so bytes allocated convert almost directly into GC CPU.

### Behaviour change

`errorFormat: minimal` swaps the stack-capturing callsite for a no-op one.

- `code`, `meta` and `message` on `PrismaClientKnownRequestError` are **unchanged**.
- Only the source-location decoration is dropped — and it is already unreachable in production.
- The rich default is preserved **outside** production, so local/dev error output still points at the offending source line.

### Test

`packages/civitai-db/src/client.errorFormat.test.ts` covers both branches, including that the non-prod branch returns an **absent** key rather than `errorFormat: undefined` (spreading an explicit `undefined` would override Prisma’s own default).

🤖 Generated with [Claude Code](https://claude.com/claude-code)