### PR TITLE
fix(image-detail): restore keyboard and swipe navigation

### DIFF
--- a/src/components/EmblaCarousel/EmblaCarouselProvider.tsx
+++ b/src/components/EmblaCarousel/EmblaCarouselProvider.tsx
@@ -140,8 +140,14 @@ export function EmblaCarouselProvider({
     );
 
   const setSlidesInView = storeRef.current.getState().setSlidesInView;
+
+  // `onSelect` is registered with embla once, so read the callback through a ref
+  // rather than capturing the first render's closure.
+  const onSlideChangeRef = useRef(onSlideChange);
+  onSlideChangeRef.current = onSlideChange;
+
   const onSelect = useCallback((emblaApi: EmblaCarouselType) => {
-    onSlideChange?.(emblaApi.selectedScrollSnap());
+    onSlideChangeRef.current?.(emblaApi.selectedScrollSnap());
     if (storeRef.current) {
       storeRef.current.setState({
         canScrollNext: emblaApi.canScrollNext(),

--- a/src/components/Image/Detail/ImageDetailProvider.tsx
+++ b/src/components/Image/Detail/ImageDetailProvider.tsx
@@ -31,6 +31,8 @@ type ImageDetailState = {
   toggleInfo: () => void;
   close: () => void;
   navigate: (id: number) => void;
+  loadMore: () => void;
+  hasMore: boolean;
   updateImage: (id: number, data: Partial<ImagesInfiniteModel>) => void;
   collection?: CollectionByIdModel;
   hideReactions?: boolean;
@@ -82,13 +84,27 @@ export function ImageDetailProvider({
   // #region [data fetching]
   const shouldFetchMany = !initialImages?.length && (Object.keys(filters).length > 0 || !!postId);
   const browsingLevel = useBrowsingLevelDebounced();
-  const { images: queryImages = [], isInitialLoading: imagesLoading } = useQueryImages(
+  const {
+    images: queryImages = [],
+    isInitialLoading: imagesLoading,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+  } = useQueryImages(
     // TODO: Hacky way to prevent sending the userId when filtering by reactions
     { ...filters, userId: !!reactions?.length ? undefined : userId, postId, browsingLevel },
     { enabled: shouldFetchMany }
   );
 
-  const images = initialImages.length > 0 ? initialImages : queryImages;
+  const usingQueryImages = initialImages.length === 0;
+  const images = usingQueryImages ? queryImages : initialImages;
+
+  // Seeded from a feed card, `images` is a fixed window the feed handed us — only
+  // the query we own here can grow.
+  const hasMore = usingQueryImages && shouldFetchMany && !!hasNextPage;
+  const loadMore = () => {
+    if (hasMore && !isFetchingNextPage) fetchNextPage();
+  };
 
   const shouldFetchImage =
     !imagesLoading && (images.length === 0 || !images.find((x) => x.id === imageId));
@@ -217,6 +233,8 @@ export function ImageDetailProvider({
         isMod,
         shareUrl,
         navigate,
+        loadMore,
+        hasMore,
         index,
         updateImage,
         collection,

--- a/src/components/Image/DetailV2/ImageDetail2.tsx
+++ b/src/components/Image/DetailV2/ImageDetail2.tsx
@@ -142,16 +142,19 @@ export function ImageDetail2() {
   const videoRef = useRef<EdgeVideoRef | null>(null);
   const adContainerRef = useRef<HTMLDivElement | null>(null);
 
-  const carouselNavigation = useCarouselNavigation({
-    items: images,
-    initialIndex: index,
-    onChange: (image, newIndex) => {
-      navigate(image.id);
-      // keep a runway ahead of the viewer so arrow/swipe navigation doesn't
-      // dead-end (and loop back) at the edge of the loaded page
-      if (hasMore && newIndex >= images.length - PREFETCH_THRESHOLD) loadMore();
-    },
-  });
+  const carouselNavigation = useCarouselNavigation({ items: images, initialIndex: index });
+
+  // Deferred to the carousel settling rather than run per slide change: the URL
+  // replace pushes a global store update that re-renders every useBrowserRouter
+  // consumer, which is too much to do inside an animating frame.
+  const handleSettle = (settledIndex: number) => {
+    const settled = images[settledIndex];
+    if (!settled) return;
+    navigate(settled.id);
+    // keep a runway ahead of the viewer so arrow/swipe navigation doesn't
+    // dead-end (and loop back) at the edge of the loaded page
+    if (hasMore && settledIndex >= images.length - PREFETCH_THRESHOLD) loadMore();
+  };
 
   const image = images[carouselNavigation.index];
 
@@ -436,6 +439,7 @@ export function ImageDetail2() {
                         images={images}
                         videoRef={videoRef}
                         connect={connect}
+                        onSettle={handleSettle}
                         {...carouselNavigation}
                       />
                       {/* FOOTER */}

--- a/src/components/Image/DetailV2/ImageDetail2.tsx
+++ b/src/components/Image/DetailV2/ImageDetail2.tsx
@@ -86,6 +86,8 @@ import { generationGraphPanel } from '~/store/generation-graph.store';
 import { LegacyActionIcon } from '~/components/LegacyActionIcon/LegacyActionIcon';
 import { AdUnitOutstream } from '~/components/Ads/AdUnitOutstream';
 
+const PREFETCH_THRESHOLD = 5;
+
 const sharedBadgeProps: Partial<Omit<BadgeProps, 'children'>> = {
   variant: 'filled',
   color: 'gray',
@@ -125,6 +127,8 @@ export function ImageDetail2() {
     shareUrl,
     connect,
     navigate,
+    loadMore,
+    hasMore,
     index,
     collection,
     hideReactions,
@@ -141,7 +145,12 @@ export function ImageDetail2() {
   const carouselNavigation = useCarouselNavigation({
     items: images,
     initialIndex: index,
-    onChange: (image) => navigate(image.id),
+    onChange: (image, newIndex) => {
+      navigate(image.id);
+      // keep a runway ahead of the viewer so arrow/swipe navigation doesn't
+      // dead-end (and loop back) at the edge of the loaded page
+      if (hasMore && newIndex >= images.length - PREFETCH_THRESHOLD) loadMore();
+    },
   });
 
   const image = images[carouselNavigation.index];

--- a/src/components/Image/DetailV2/ImageDetail2.tsx
+++ b/src/components/Image/DetailV2/ImageDetail2.tsx
@@ -32,7 +32,7 @@ import {
   IconPhoto,
   IconShare3,
 } from '@tabler/icons-react';
-import { useRef } from 'react';
+import { useMemo, useRef } from 'react';
 import clsx from 'clsx';
 import { getEdgeUrl } from '~/client-utils/cf-images-utils';
 import { env } from '~/env/client';
@@ -147,9 +147,12 @@ export function ImageDetail2() {
   // Deferred to the carousel settling rather than run per slide change: the URL
   // replace pushes a global store update that re-renders every useBrowserRouter
   // consumer, which is too much to do inside an animating frame.
+  const lastSettledIdRef = useRef(images[index]?.id);
   const handleSettle = (settledIndex: number) => {
     const settled = images[settledIndex];
-    if (!settled) return;
+    // a drag that springs back settles on the slide it started from
+    if (!settled || lastSettledIdRef.current === settled.id) return;
+    lastSettledIdRef.current = settled.id;
     navigate(settled.id);
     // keep a runway ahead of the viewer so arrow/swipe navigation doesn't
     // dead-end (and loop back) at the edge of the loaded page
@@ -157,6 +160,14 @@ export function ImageDetail2() {
   };
 
   const image = images[carouselNavigation.index];
+
+  // The address bar trails the carousel until it settles, so share the image
+  // that's actually on screen rather than whatever the URL still says.
+  const imageShareUrl = useMemo(() => {
+    if (!image || images[index]?.id === image.id) return shareUrl;
+    const [, queryString] = shareUrl.split('?');
+    return queryString ? `/images/${image.id}?${queryString}` : `/images/${image.id}`;
+  }, [shareUrl, image, images, index]);
 
   const { collectionItems, post } = useImageContestCollectionDetails(
     { id: image?.id as number },
@@ -401,7 +412,7 @@ export function ImageDetail2() {
                               )}
                             </DownloadImage>
                             <ShareButton
-                              url={shareUrl}
+                              url={imageShareUrl}
                               title={title}
                               collect={{ type: CollectionType.Image, imageId: image.id }}
                             >

--- a/src/components/Image/DetailV2/ImageDetailCarousel.tsx
+++ b/src/components/Image/DetailV2/ImageDetailCarousel.tsx
@@ -1,5 +1,5 @@
-import { useHotkeys, useLocalStorage, useOs } from '@mantine/hooks';
-import { useState, useEffect, createContext, useContext } from 'react';
+import { useLocalStorage } from '@mantine/hooks';
+import { useState, useEffect, useRef, createContext, useContext } from 'react';
 import { EdgeMedia } from '~/components/EdgeMedia/EdgeMedia';
 import { shouldDisplayHtmlControls } from '~/components/EdgeMedia/EdgeMedia.util';
 import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
@@ -8,7 +8,6 @@ import { ImageGuardContent } from '~/components/ImageGuard/ImageGuard2';
 import { MediaHash } from '~/components/ImageHash/ImageHash';
 import { useAspectRatioFit } from '~/hooks/useAspectRatioFit';
 import { useResizeObserver } from '~/hooks/useResizeObserver';
-import useIsClient from '~/hooks/useIsClient';
 import type { EdgeVideoRef } from '~/components/EdgeMedia/EdgeVideo';
 import { useCarouselNavigation } from '~/hooks/useCarouselNavigation';
 import { UnstyledButton } from '@mantine/core';
@@ -55,6 +54,32 @@ export function ImageDetailCarouselProvider<T extends ImageProps>({
   );
 }
 
+const IGNORED_HOTKEY_TAGS = ['INPUT', 'TEXTAREA', 'SELECT'];
+
+function shouldHandleHotkey(event: KeyboardEvent) {
+  if (event.defaultPrevented || event.altKey || event.ctrlKey || event.metaKey || event.shiftKey)
+    return false;
+  const target = event.target;
+  if (!(target instanceof HTMLElement)) return true;
+  if (target.isContentEditable) return false;
+  if (IGNORED_HOTKEY_TAGS.includes(target.tagName)) return false;
+  // an open popover/menu/modal above the detail view owns its own arrow handling
+  return !target.closest('[role="menu"],[role="listbox"],[role="dialog"][data-nested]');
+}
+
+// Touch and pen drags navigate; mouse drags don't, so click-dragging an image on
+// desktop still does nothing. Declared at module scope because embla compares
+// function options by source, and a new body every render would reInit the engine.
+function watchTouchDrag(
+  _emblaApi: EmblaCarouselType,
+  event: TouchEvent | MouseEvent | PointerEvent
+) {
+  // embla binds touchstart/mousedown today; the pointerType branch keeps this
+  // correct if it ever moves to pointer events
+  if ('pointerType' in event) return event.pointerType !== 'mouse';
+  return event.type.startsWith('touch');
+}
+
 export function ImageDetailCarousel({
   images,
   videoRef,
@@ -62,66 +87,82 @@ export function ImageDetailCarousel({
   index,
   canNavigate,
   navigate,
+  next,
+  previous,
 }: ImageDetailCarouselProps & {
   images: ImageProps[];
   index: number;
   navigate?: (index: number) => void;
+  next: () => void;
+  previous: () => void;
   canNavigate: boolean;
 }) {
   const [embla, setEmbla] = useState<EmblaCarouselType | null>(null);
 
-  // const [slidesInView, setSlidesInView] = useState<number[]>([index]);
+  // Embla owns the slide animation, but `index` is the source of truth. Feeding
+  // it back in as `startIndex` would reInit the engine on every navigation,
+  // which tears down the pointer handlers mid-swipe.
+  const startIndexRef = useRef(index);
 
-  // useEffect(() => {
-  //   if (!embla) return;
-  //   const onSelect = () => {
-  //     setSlidesInView([...embla.slidesInView(true)]);
-  //   };
+  const navigationRef = useRef({ next, previous, canNavigate });
+  navigationRef.current = { next, previous, canNavigate };
 
-  //   embla.on('select', onSelect);
-  //   return () => {
-  //     embla.off('select', onSelect);
-  //   };
-  // }, [embla]);
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== 'ArrowLeft' && event.key !== 'ArrowRight') return;
+      const { next, previous, canNavigate } = navigationRef.current;
+      if (!canNavigate || !shouldHandleHotkey(event)) return;
+      event.preventDefault();
+      if (event.key === 'ArrowLeft') previous();
+      else next();
+    };
 
-  useHotkeys([
-    ['ArrowLeft', () => embla?.scrollPrev()],
-    ['ArrowRight', () => embla?.scrollNext()],
-  ]);
+    // capture phase so the keypress reaches us regardless of what currently has
+    // focus (reaction buttons, controls) or what stops propagation on the way up
+    document.addEventListener('keydown', handleKeyDown, true);
+    return () => document.removeEventListener('keydown', handleKeyDown, true);
+  }, []);
+
+  useEffect(() => {
+    if (!embla) return;
+    if (embla.selectedScrollSnap() !== index) embla.scrollTo(index);
+  }, [embla, index]);
 
   const ref = useResizeObserver<HTMLDivElement>(() => {
     embla?.reInit();
   });
-
-  const os = useOs();
-  const isDesktop = os === 'windows' || os === 'linux' || os === 'macos';
-
-  // useEffect(() => {
-  //   if (!slidesInView.includes(index)) {
-  //     embla?.scrollTo(index, true);
-  //   }
-  // }, [index, slidesInView]); // eslint-disable-line
 
   if (!images.length) return null;
 
   return (
     <div ref={ref} className="flex min-h-0 flex-1 items-stretch justify-stretch">
       <Embla
-        key={images.length}
         withControls={canNavigate}
         className="flex-1"
         onSlideChange={navigate}
         setEmbla={setEmbla}
-        startIndex={index}
+        startIndex={startIndexRef.current}
         loop
-        watchDrag={!isDesktop && canNavigate}
+        watchDrag={canNavigate && watchTouchDrag}
         withKeyboardEvents={false}
       >
-        <Embla.Viewport className="h-full">
+        {/* pan-y keeps vertical page scrolling native while horizontal drags go to embla */}
+        <Embla.Viewport className="h-full touch-pan-y">
           <Embla.Container className="flex h-full">
             {images.map((image, i) => (
               <Embla.Slide key={image.id} index={i} className="flex-[0_0_100%]">
-                {index === i && <ImageContent image={image} {...connect} videoRef={videoRef} />}
+                {/* function child opts out of Embla's own in-view gating — adjacency
+                    is the gate here, so a neighbor is painted before the drag reveals it */}
+                {() =>
+                  isAdjacent(i, index, images.length) && (
+                    <ImageContent
+                      image={image}
+                      active={index === i}
+                      {...connect}
+                      videoRef={index === i ? videoRef : undefined}
+                    />
+                  )
+                }
               </Embla.Slide>
             ))}
           </Embla.Container>
@@ -131,11 +172,19 @@ export function ImageDetailCarousel({
   );
 }
 
+// the carousel loops, so the neighbors of the first/last slide wrap around
+function isAdjacent(i: number, index: number, length: number) {
+  if (length < 2) return i === index;
+  const distance = Math.abs(i - index);
+  return Math.min(distance, length - distance) <= 1;
+}
+
 function ImageContent({
   image,
   videoRef,
+  active = true,
   ...connect
-}: { image: ImageProps } & ConnectProps & ImageDetailCarouselProps) {
+}: { image: ImageProps; active?: boolean } & ConnectProps & ImageDetailCarouselProps) {
   const [defaultMuted, setDefaultMuted] = useLocalStorage({
     getInitialValueInEffect: false,
     key: 'detailView_defaultMuted',
@@ -185,10 +234,12 @@ function ImageContent({
                 },
               }}
               // width={!isVideo ? undefined : 450} // Leave as undefined to get original size
-              anim
+              anim={active}
               quality={90}
-              original={isVideo ? true : undefined}
-              html5Controls={features.nativeVideoControls || shouldDisplayHtmlControls(image)}
+              original={isVideo && active ? true : undefined}
+              html5Controls={
+                active && (features.nativeVideoControls || shouldDisplayHtmlControls(image))
+              }
               muted={defaultMuted}
               onMutedChange={(isMuted) => {
                 setDefaultMuted(isMuted);
@@ -204,9 +255,9 @@ function ImageContent({
                   ? (image.metadata as VideoMetadata)?.vimeoVideoId
                   : undefined
               }
-              controls
+              controls={active}
               videoProps={{
-                autoPlay: true,
+                autoPlay: active,
               }}
             />
           )}

--- a/src/components/Image/DetailV2/ImageDetailCarousel.tsx
+++ b/src/components/Image/DetailV2/ImageDetailCarousel.tsx
@@ -94,12 +94,14 @@ export function ImageDetailCarousel({
   navigate,
   next,
   previous,
+  onSettle,
 }: ImageDetailCarouselProps & {
   images: ImageProps[];
   index: number;
   navigate?: (index: number) => void;
   next: () => void;
   previous: () => void;
+  onSettle?: (index: number) => void;
   canNavigate: boolean;
 }) {
   const [embla, setEmbla] = useState<EmblaCarouselType | null>(null);
@@ -151,6 +153,27 @@ export function ImageDetailCarousel({
     syncingRef.current = false;
   }, [embla, index]);
 
+  // Everything expensive hangs off the settled index rather than the live one:
+  // a URL replace, a signal resubscribe and a fresh full-size neighbor decode
+  // all landing mid-transform is what makes the swipe stutter on mobile. Embla
+  // emits 'settle' once the animation is done AND the finger is up.
+  const [settledIndex, setSettledIndex] = useState(index);
+  const onSettleRef = useRef(onSettle);
+  onSettleRef.current = onSettle;
+
+  useEffect(() => {
+    if (!embla) return;
+    const handleSettle = () => {
+      const current = embla.selectedScrollSnap();
+      setSettledIndex(current);
+      onSettleRef.current?.(current);
+    };
+    embla.on('settle', handleSettle);
+    return () => {
+      embla.off('settle', handleSettle);
+    };
+  }, [embla]);
+
   const ref = useResizeObserver<HTMLDivElement>(() => {
     embla?.reInit();
   });
@@ -175,9 +198,12 @@ export function ImageDetailCarousel({
             {images.map((image, i) => (
               <Embla.Slide key={image.id} index={i} className="flex-[0_0_100%]">
                 {/* function child opts out of Embla's own in-view gating — adjacency
-                    is the gate here, so a neighbor is painted before the drag reveals it */}
+                    is the gate here, so a neighbor is painted before the drag reveals it.
+                    Neighbors are keyed off the settled index so a new full-size decode
+                    never starts mid-swipe; the live slide always renders regardless, so
+                    a missed 'settle' costs preloading rather than a blank frame. */}
                 {() =>
-                  isAdjacent(i, index, images.length) && (
+                  (i === index || isAdjacent(i, settledIndex, images.length)) && (
                     <ImageContent
                       image={image}
                       active={index === i}

--- a/src/components/Image/DetailV2/ImageDetailCarousel.tsx
+++ b/src/components/Image/DetailV2/ImageDetailCarousel.tsx
@@ -72,6 +72,10 @@ function shouldHandleHotkey(event: KeyboardEvent, carouselRoot: HTMLElement | nu
   return !dialog || (!!carouselRoot && dialog.contains(carouselRoot));
 }
 
+// Comfortably longer than embla's scroll animation (duration 25), so it only
+// ever fires for a 'settle' that was genuinely dropped.
+const SETTLE_FALLBACK_MS = 800;
+
 // Touch and pen drags navigate; mouse drags don't, so click-dragging an image on
 // desktop still does nothing. At module scope so the body is identical every
 // render — embla compares function options by source string.
@@ -153,24 +157,41 @@ export function ImageDetailCarousel({
     syncingRef.current = false;
   }, [embla, index]);
 
-  // Everything expensive hangs off the settled index rather than the live one:
-  // a URL replace, a signal resubscribe and a fresh full-size neighbor decode
-  // all landing mid-transform is what makes the swipe stutter on mobile. Embla
-  // emits 'settle' once the animation is done AND the finger is up.
+  // The URL replace and the incoming neighbor's full-size decode hang off the
+  // settled index rather than the live one — landing either mid-transform is
+  // what makes the swipe stutter on mobile. Embla emits 'settle' once the
+  // animation is done AND the finger is up.
   const [settledIndex, setSettledIndex] = useState(index);
   const onSettleRef = useRef(onSettle);
   onSettleRef.current = onSettle;
 
   useEffect(() => {
     if (!embla) return;
-    const handleSettle = () => {
+    let fallback: ReturnType<typeof setTimeout> | undefined;
+
+    const commit = () => {
+      if (fallback) {
+        clearTimeout(fallback);
+        fallback = undefined;
+      }
       const current = embla.selectedScrollSnap();
       setSettledIndex(current);
       onSettleRef.current?.(current);
     };
-    embla.on('settle', handleSettle);
+
+    // 'settle' only fires from the animation loop, so anything that destroys the
+    // engine mid-flight swallows it — including `loadMore` appending slides,
+    // which trips embla's own container MutationObserver into a reInit. Without
+    // a fallback the URL would just silently stop tracking the visible image.
+    const armFallback = () => {
+      if (fallback) clearTimeout(fallback);
+      fallback = setTimeout(commit, SETTLE_FALLBACK_MS);
+    };
+
+    embla.on('settle', commit).on('reInit', commit).on('select', armFallback);
     return () => {
-      embla.off('settle', handleSettle);
+      if (fallback) clearTimeout(fallback);
+      embla.off('settle', commit).off('reInit', commit).off('select', armFallback);
     };
   }, [embla]);
 
@@ -199,9 +220,10 @@ export function ImageDetailCarousel({
               <Embla.Slide key={image.id} index={i} className="flex-[0_0_100%]">
                 {/* function child opts out of Embla's own in-view gating — adjacency
                     is the gate here, so a neighbor is painted before the drag reveals it.
-                    Neighbors are keyed off the settled index so a new full-size decode
-                    never starts mid-swipe; the live slide always renders regardless, so
-                    a missed 'settle' costs preloading rather than a blank frame. */}
+                    Neighbors key off the settled index so a new full-size decode never
+                    starts mid-swipe. While a settle is outstanding the next slide along
+                    isn't mounted yet, so a drag started in that window reveals it late;
+                    the fallback timer above bounds how long that can last. */}
                 {() =>
                   (i === index || isAdjacent(i, settledIndex, images.length)) && (
                     <ImageContent

--- a/src/components/Image/DetailV2/ImageDetailCarousel.tsx
+++ b/src/components/Image/DetailV2/ImageDetailCarousel.tsx
@@ -54,22 +54,27 @@ export function ImageDetailCarouselProvider<T extends ImageProps>({
   );
 }
 
-const IGNORED_HOTKEY_TAGS = ['INPUT', 'TEXTAREA', 'SELECT'];
+// VIDEO is here so arrow keys still seek a focused player with native controls
+const IGNORED_HOTKEY_TAGS = ['INPUT', 'TEXTAREA', 'SELECT', 'VIDEO'];
 
-function shouldHandleHotkey(event: KeyboardEvent) {
+function shouldHandleHotkey(event: KeyboardEvent, carouselRoot: HTMLElement | null) {
   if (event.defaultPrevented || event.altKey || event.ctrlKey || event.metaKey || event.shiftKey)
     return false;
   const target = event.target;
   if (!(target instanceof HTMLElement)) return true;
   if (target.isContentEditable) return false;
   if (IGNORED_HOTKEY_TAGS.includes(target.tagName)) return false;
-  // an open popover/menu/modal above the detail view owns its own arrow handling
-  return !target.closest('[role="menu"],[role="listbox"],[role="dialog"][data-nested]');
+  if (target.closest('[role="menu"],[role="listbox"]')) return false;
+  // A dialog stacked on top of the detail view (report, add-to-collection) owns
+  // its own arrow handling. The detail view's own modal shell is also a dialog,
+  // but it contains the carousel, which is what tells the two apart.
+  const dialog = target.closest('[role="dialog"]');
+  return !dialog || (!!carouselRoot && dialog.contains(carouselRoot));
 }
 
 // Touch and pen drags navigate; mouse drags don't, so click-dragging an image on
-// desktop still does nothing. Declared at module scope because embla compares
-// function options by source, and a new body every render would reInit the engine.
+// desktop still does nothing. At module scope so the body is identical every
+// render — embla compares function options by source string.
 function watchTouchDrag(
   _emblaApi: EmblaCarouselType,
   event: TouchEvent | MouseEvent | PointerEvent
@@ -98,10 +103,19 @@ export function ImageDetailCarousel({
   canNavigate: boolean;
 }) {
   const [embla, setEmbla] = useState<EmblaCarouselType | null>(null);
+  const emblaRef = useRef<EmblaCarouselType | null>(null);
+  const handleSetEmbla = (api: EmblaCarouselType) => {
+    emblaRef.current = api;
+    setEmbla(api);
+  };
 
   // Embla owns the slide animation, but `index` is the source of truth. Feeding
   // it back in as `startIndex` would reInit the engine on every navigation,
   // which tears down the pointer handlers mid-swipe.
+  //
+  // Keep every other option static too: embla's `reActivate` merges the options
+  // it is handed OVER the index it just preserved, so a changing option would
+  // snap the carousel back to whichever image was open at mount.
   const startIndexRef = useRef(index);
 
   const navigationRef = useRef({ next, previous, canNavigate });
@@ -111,7 +125,7 @@ export function ImageDetailCarousel({
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key !== 'ArrowLeft' && event.key !== 'ArrowRight') return;
       const { next, previous, canNavigate } = navigationRef.current;
-      if (!canNavigate || !shouldHandleHotkey(event)) return;
+      if (!canNavigate || !shouldHandleHotkey(event, emblaRef.current?.rootNode() ?? null)) return;
       event.preventDefault();
       if (event.key === 'ArrowLeft') previous();
       else next();
@@ -123,9 +137,18 @@ export function ImageDetailCarousel({
     return () => document.removeEventListener('keydown', handleKeyDown, true);
   }, []);
 
+  // `scrollTo` emits 'select' synchronously, which would echo straight back into
+  // `navigate` and run the whole onChange side-effect chain a second time.
+  const syncingRef = useRef(false);
+  const handleSlideChange = (slideIndex: number) => {
+    if (!syncingRef.current) navigate?.(slideIndex);
+  };
+
   useEffect(() => {
-    if (!embla) return;
-    if (embla.selectedScrollSnap() !== index) embla.scrollTo(index);
+    if (!embla || embla.selectedScrollSnap() === index) return;
+    syncingRef.current = true;
+    embla.scrollTo(index);
+    syncingRef.current = false;
   }, [embla, index]);
 
   const ref = useResizeObserver<HTMLDivElement>(() => {
@@ -139,8 +162,8 @@ export function ImageDetailCarousel({
       <Embla
         withControls={canNavigate}
         className="flex-1"
-        onSlideChange={navigate}
-        setEmbla={setEmbla}
+        onSlideChange={handleSlideChange}
+        setEmbla={handleSetEmbla}
         startIndex={startIndexRef.current}
         loop
         watchDrag={canNavigate && watchTouchDrag}
@@ -234,9 +257,11 @@ function ImageContent({
                 },
               }}
               // width={!isVideo ? undefined : 450} // Leave as undefined to get original size
-              anim={active}
+              // `anim` and `original` feed the CDN URL — an inactive slide has to
+              // request the same URL the active one will, or it warms nothing
+              anim
               quality={90}
-              original={isVideo && active ? true : undefined}
+              original={isVideo ? true : undefined}
               html5Controls={
                 active && (features.nativeVideoControls || shouldDisplayHtmlControls(image))
               }

--- a/src/components/Metrics/AnimatedCount.tsx
+++ b/src/components/Metrics/AnimatedCount.tsx
@@ -22,6 +22,14 @@ interface AnimatedCountProps {
    * Default: true (back-compat).
    */
   animate?: boolean;
+  /**
+   * Identifies which entity `value` belongs to. When it changes the new value
+   * is a different thing's count, not a delta, so the number snaps instead of
+   * rolling and no "+N" is shown. Without it, swapping entities in a persistent
+   * instance (paging through the image detail carousel) fires a spurious
+   * increase animation and a forced reflow on every change.
+   */
+  resetKey?: string | number;
 }
 
 /**
@@ -36,13 +44,21 @@ export function AnimatedCount({
   abbreviate = true,
   className,
   animate = true,
+  resetKey,
 }: AnimatedCountProps) {
   const spanRef = useRef<HTMLSpanElement>(null);
   const prevRef = useRef(value);
+  const resetKeyRef = useRef(resetKey);
   const [floatingDelta, setFloatingDelta] = useState<{ key: number; amount: number } | null>(null);
   const deltaKeyRef = useRef(0);
 
   useEffect(() => {
+    if (resetKeyRef.current !== resetKey) {
+      resetKeyRef.current = resetKey;
+      prevRef.current = value;
+      setFloatingDelta(null);
+      return;
+    }
     if (!animate) {
       prevRef.current = value;
       return;
@@ -60,7 +76,7 @@ export function AnimatedCount({
       setFloatingDelta({ key: deltaKeyRef.current, amount: delta });
     }
     prevRef.current = value;
-  }, [value, animate]);
+  }, [value, animate, resetKey]);
 
   if (!animate) {
     const formatter = abbreviate ? compactFormatter : fullFormatter;
@@ -70,6 +86,9 @@ export function AnimatedCount({
   return (
     <span ref={spanRef} className={`${classes.wrapper} ${className ?? ''}`}>
       <CustomNumberFlow
+        // remounting on entity change starts the digit columns at their new
+        // position instead of rolling there from another entity's count
+        key={resetKey}
         respectMotionPreference={false}
         value={value}
         format={abbreviate ? compactFormat : undefined}

--- a/src/components/Metrics/LiveMetric.tsx
+++ b/src/components/Metrics/LiveMetric.tsx
@@ -44,7 +44,11 @@ export function LiveMetric({
 
   return (
     <Text {...textProps}>
-      <AnimatedCount value={liveValue} abbreviate={abbreviate} />
+      <AnimatedCount
+        value={liveValue}
+        abbreviate={abbreviate}
+        resetKey={`${entityType}:${entityId}:${metricType}`}
+      />
     </Text>
   );
 }

--- a/src/components/Model/ModelVersions/ModelVersionDetails.tsx
+++ b/src/components/Model/ModelVersions/ModelVersionDetails.tsx
@@ -1370,7 +1370,11 @@ function ModelVersionDetailsContent({ model, version, image, onFavoriteClick }: 
                             {version.hiddenMetrics?.downloads ? (
                               <HiddenMetricNotice size={16} />
                             ) : (
-                              <AnimatedCount value={liveMetrics.downloadCount} abbreviate={false} />
+                              <AnimatedCount
+                                value={liveMetrics.downloadCount}
+                                abbreviate={false}
+                                resetKey={version.id}
+                              />
                             )}
                           </Text>
                         </Group>
@@ -1382,7 +1386,10 @@ function ModelVersionDetailsContent({ model, version, image, onFavoriteClick }: 
                             {version.hiddenMetrics?.generations ? (
                               <HiddenMetricNotice size={16} />
                             ) : (
-                              <AnimatedCount value={liveMetrics.generationCount} />
+                              <AnimatedCount
+                                value={liveMetrics.generationCount}
+                                resetKey={version.id}
+                              />
                             )}
                           </Text>
                         </Group>
@@ -1394,7 +1401,10 @@ function ModelVersionDetailsContent({ model, version, image, onFavoriteClick }: 
                             {version.hiddenMetrics?.buzz ? (
                               <HiddenMetricNotice size={16} />
                             ) : (
-                              <AnimatedCount value={liveMetrics.earnedAmount} />
+                              <AnimatedCount
+                                value={liveMetrics.earnedAmount}
+                                resetKey={version.id}
+                              />
                             )}
                           </Text>
                         </Group>

--- a/src/components/Reaction/Reactions.tsx
+++ b/src/components/Reaction/Reactions.tsx
@@ -253,7 +253,7 @@ function ReactionsList({
               noEmpty={noEmpty}
               invisibleEmpty={invisibleEmpty}
             >
-              {(props) => <ReactionBadge {...props} abbreviate={abbreviate} />}
+              {(props) => <ReactionBadge {...props} abbreviate={abbreviate} resetKey={entityId} />}
             </ReactionButton>
           );
         })}
@@ -267,6 +267,7 @@ function ReactionBadge({
   reaction,
   canClick,
   abbreviate,
+  resetKey,
   ...buttonProps
 }: {
   hasReacted: boolean;
@@ -274,6 +275,7 @@ function ReactionBadge({
   reaction: ReviewReactions;
   canClick: boolean;
   abbreviate?: boolean;
+  resetKey?: string | number;
 } & Omit<ButtonProps, 'children'> &
   React.ComponentPropsWithoutRef<'button'>) {
   const color = hasReacted ? 'blue' : 'gray';
@@ -298,7 +300,7 @@ function ReactionBadge({
       </Text>{' '}
       {!hideReactionCount && (
         <Text inherit lh={1}>
-          <AnimatedCount value={count} abbreviate={abbreviate ?? false} />
+          <AnimatedCount value={count} abbreviate={abbreviate ?? false} resetKey={resetKey} />
         </Text>
       )}
     </Button>
@@ -345,7 +347,7 @@ function BuzzTippingBadge({
     >
       <IconBolt color="yellow.7" style={{ fill: theme.colors.yellow[7] }} size={16} />
       <Text inherit lh={1}>
-        <AnimatedCount value={tippedAmountCount + tippedAmount} />
+        <AnimatedCount value={tippedAmountCount + tippedAmount} resetKey={entityId} />
       </Text>
     </Badge>
   );


### PR DESCRIPTION
Restores keyboard and swipe navigation in the image detail view. Reported today in the Creator Studio Review group:

> **SubtleShader:** 1-2 year ago it was possible to swipe images in the gallery in Chrome on Android. Then suddenly it was not possible anymore & you have to hit the tiny arrow buttons, which is hard. It is still possible to swipe the showcase images though.

> **MNeMiC:** If you added a reaction, you were able to use arrow keys to move left/right immediately after. Now you cant. [...] Now the input is consumed and image doesn't swap to next/prev.

ClickUp: https://app.clickup.com/t/868kh5d91

## Root cause

`ImageDetailCarousel` fed its own `index` straight back into embla as `startIndex`:

```tsx
onSlideChange={navigate}     // embla select -> setIndex
startIndex={index}           // ...which comes right back in as an option
```

`embla-carousel-react` deep-compares its options each render and calls `emblaApi.reInit(options)` on any change. `reInit` runs `deActivate()` — which includes `engine.dragHandler.destroy()` — and rebuilds the engine from scratch. So **every navigation tore down the pointer handlers that had just produced it**, during the settle animation.

Two details make it worse:

- `reActivate` does `mergeOptions({ startIndex: selectedScrollSnap() }, withOptions)`, so the passed options *override* the position embla tried to preserve.
- `key={images.length}` remounted the whole carousel whenever the array length changed.

Buttons survived this because a click completes before the re-render lands. A touch drag does not.

**Caveat on attribution, after review:** `activate()` re-inits the drag handler, so this churn explains *glitchy and aborted* swipes and killed settle animations rather than permanently dead ones. The likelier primary cause of "swipe does nothing on Android" is the missing `touch-action` on the viewport: embla's `DragHandler.move` bails via `up(evt)` once `!evt.cancelable`, which is exactly what happens after mobile Chrome/Safari claims the gesture for native scrolling. This PR adds `touch-pan-y`, which was absent before. Both are fixed here; I'm flagging which line is doing the heavy lifting so the preview test targets the right thing.

## Changes

**`ImageDetailCarousel`**

- `startIndex` is frozen at mount (`startIndexRef`); `index` changes now drive `embla.scrollTo()` instead of an option change, so the engine is never rebuilt mid-gesture. The `key={images.length}` remount is gone too — embla's `watchSlides` reinits on slide-count changes and preserves position.
- Arrow keys bind to the navigation model (`next`/`previous`) rather than to embla's scroll API, on `document` in the **capture** phase. That makes them independent of what holds focus and of anything that stops propagation on the way up — reacting to an image leaves focus on the reaction button, which is when MNeMiC sees the keypress go nowhere. Skips `INPUT`/`TEXTAREA`/`SELECT`, contenteditable, already-defaultPrevented events, modified keys, and open `role="menu"`/`role="listbox"` surfaces.
- `watchDrag` is now a predicate that allows touch/pen and rejects mouse, replacing `useOs()`-based desktop detection that misreads tablets and touch laptops. Declared at module scope because embla compares function options **by source string** — a fresh closure per render would reInit the engine, which is the bug we're fixing. Viewport gets `touch-pan-y` so vertical page scrolling stays native.
- Neighbor slides render, so a drag reveals the next image instead of a blank slide. Uses `Embla.Slide`'s function-child form to opt out of embla's own in-view gating (that bookkeeping detaches its listener once every slide has been seen, which would leave slides added by pagination permanently blank). Inactive slides don't autoplay, don't request video originals, and don't take the video ref.

**`EmblaCarouselProvider`** — `onSelect` is registered with embla once but read `onSlideChange` from the first render's closure. Now read through a ref. Affects every `Embla` consumer that passes a closure over changing state.

**`ImageDetailProvider` / `ImageDetail2`** — navigating within 5 slides of the end fetches the next page, so keyboard/swipe don't dead-end (and loop back) at a page boundary. Only applies where the provider owns the query; a modal seeded with `images` from a feed card still gets the fixed ±50 window that card handed it (see below).

## Review pass

A second commit fixes findings from an adversarial review:

- **`scrollTo` emits `select` synchronously**, so the index-sync effect echoed back into `navigate` and ran the whole `onChange` chain twice per arrow keypress — two `browserRouter.replace` calls and two `fetchNextPage()` calls (React Query sets `isFetchingNextPage` asynchronously, so the guard didn't catch the second). Guarded with a syncing ref.
- **Neighbor preload was fetching the wrong URL.** `anim` and `original` resolve into the CDN URL, so gating them on `active` made the neighbor download a *different* URL than the active slide would request — double bandwidth, cold cache, no benefit. Both now match; only playback (`controls`, `autoPlay`, `videoRef`) is gated.
- **`[role="dialog"][data-nested]` matched nothing** — no such attribute exists in this repo or in Mantine — so arrow keys navigated the carousel underneath an open report/add-to-collection modal. Now any `[role="dialog"]` blocks, except the detail view's own modal shell, identified by it containing the carousel root.
- **`VIDEO` added to the ignored tags** so arrow keys still seek a focused native-controls player instead of skipping images.

### Honest note on the keyboard fix

I could not statically identify what swallows the keypress after reacting. Mantine's `useHotkeys` binds on `document.documentElement` in the bubble phase, and nothing between a reaction button and `<html>` stops keydown propagation — I checked `Reactions`/`ReactionButton` (click handlers only), `ModalBaseContent`, `ScrollArea`, and `LoginPopover`. The new guard is a strict superset of Mantine's, so anything Mantine suppressed is still suppressed; the only class of failure capture phase can fix is a bubble-phase `stopPropagation()` that I couldn't find. If the real cause is focus landing in an `<input>` (the buzz-tip flow has an amount input), **this will still reproduce.** Worth logging `document.activeElement` after reacting in the preview env before we call that half done.

What is unambiguously better: the old handler drove `embla.scrollPrev()/scrollNext()` directly; the new one drives React state and lets embla follow, which is the right direction now that `index` is the source of truth.

## Verification

Typecheck and lint clean. Behavior is DOM-interaction level, so the meaningful checks are manual:

- [ ] Desktop: arrow keys page through images; still work immediately after clicking a reaction, tipping, and toggling the sidebar
- [ ] Desktop: click-dragging an image does *not* move the carousel
- [ ] Android/iOS: swipe left/right moves between images; vertical scroll still works
- [ ] Videos: only the visible slide plays; neighbors don't autoplay or pull originals
- [ ] Arrow keys do nothing while typing in a tag input or with a menu open
- [ ] Paging to the end of a loaded page pulls the next one instead of wrapping

## Known gap

The detail modal opened from a feed card is seeded with a fixed ±50 window (`getDialogState` in `ImagesCard`) and can't grow — `loadMore` only applies when this provider owns the query. Extending that means handing the feed's query down into the modal; left out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
