### PR TITLE
fix(apps): stop AppsSubNav from bailing hydration of every /apps page (dead submit/edit)

### DIFF
--- a/src/components/Apps/AppsSubNav.hydration.browser.test.tsx
+++ b/src/components/Apps/AppsSubNav.hydration.browser.test.tsx
@@ -1,0 +1,120 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { page } from 'vitest/browser';
+// `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
+import { renderWithProviders } from '../../../test/component-setup';
+
+/**
+ * Regression: `AppsSubNav` HYDRATION SAFETY (prod incident — every /apps page inert).
+ *
+ * The conditional sub-nav tabs (Installed / My submissions / Revenue / Review) are
+ * driven by the client-only `blocks.getNavSummary` query. tRPC runs with `ssr:false`,
+ * so the SERVER always renders the always-on set (`EMPTY_SUMMARY` → Marketplace +
+ * Create), while the query's data is present in the CLIENT's FIRST render. For a user
+ * with installs/submissions/approved-apps/reviewer status the first client paint
+ * rendered 6 tabs against the server's 2 — a React hydration mismatch (#418/#425)
+ * that bailed hydration of the ENTIRE /apps page ROOT, leaving every /apps page
+ * un-hydrated and inert (dead buttons; the `/apps/submit?edit=` query never fired →
+ * a permanent "Loading your listing…").
+ *
+ * The fix gates the conditional tabs on `useIsClient()` (false on the server AND the
+ * first client paint, true only AFTER mount) so the server render and the first
+ * client render are IDENTICAL — the conditional tabs reveal only post-hydration.
+ *
+ * These tests drive the `AppsSubNav` CONTAINER (not the pure `AppsSubNavView`) so the
+ * `useIsClient` gate is exercised. A summary with EVERY flag true is supplied via the
+ * mocked query; the assertion is that the pre-mount render still shows ONLY the
+ * always-on tabs. Reverting the fix (using `data ?? EMPTY_SUMMARY` unconditionally)
+ * renders all 6 tabs pre-mount and fails the first test — the exact divergence that
+ * broke hydration in prod.
+ */
+
+const ALL_TRUE_SUMMARY = {
+  hasInstalls: true,
+  hasSubmissions: true,
+  hasApprovedApps: true,
+  isReviewer: true,
+};
+
+const mocks = vi.hoisted(() => ({
+  // Controls `useIsClient()` — false simulates the server + the first client paint
+  // (pre-mount), true simulates a post-mount render.
+  isClient: false,
+  // The resolved `getNavSummary` data available to the CLIENT render.
+  navSummary: undefined as undefined | typeof ALL_TRUE_SUMMARY,
+}));
+
+vi.mock('~/providers/IsClientProvider', () => ({
+  useIsClient: () => mocks.isClient,
+}));
+
+vi.mock('~/providers/FeatureFlagsProvider', () => ({
+  useFeatureFlags: () => ({ appBlocks: true }),
+}));
+
+vi.mock('~/hooks/useCurrentUser', () => ({
+  useCurrentUser: () => ({ id: 1, username: 'dev' }),
+}));
+
+vi.mock('~/utils/trpc', () => ({
+  trpc: {
+    blocks: {
+      getNavSummary: {
+        useQuery: () => ({ data: mocks.navSummary }),
+      },
+    },
+  },
+}));
+
+const { AppsSubNav } = await import('./AppsSubNav');
+
+function tab(name: string) {
+  return page.getByRole('tab', { name });
+}
+
+const CONDITIONAL = ['Installed', 'My submissions', 'Revenue', 'Review'] as const;
+
+beforeEach(() => {
+  mocks.isClient = false;
+  // Simulate the query data being present on the client (the prod condition): a mod
+  // user whose summary is fully populated.
+  mocks.navSummary = { ...ALL_TRUE_SUMMARY };
+});
+
+describe('AppsSubNav container — hydration-safe conditional tabs', () => {
+  test('pre-mount (server + first client paint) renders ONLY the always-on tabs, even when the query already has a full summary', async () => {
+    mocks.isClient = false; // server / first client paint
+    renderWithProviders(<AppsSubNav />);
+
+    // The always-on tabs render.
+    await expect.element(tab('Marketplace')).toBeInTheDocument();
+    await expect.element(tab('Create')).toBeInTheDocument();
+
+    // The conditional tabs MUST NOT render pre-mount — this is what keeps the first
+    // client paint identical to the SSR HTML (the fix). Before the fix, the query
+    // data leaked into the first render and produced these tabs → hydration mismatch.
+    for (const name of CONDITIONAL) {
+      expect(tab(name).elements()).toHaveLength(0);
+    }
+  });
+
+  test('post-mount (isClient=true) reveals the conditional tabs from the summary', async () => {
+    mocks.isClient = true; // after mount / hydration has matched
+    renderWithProviders(<AppsSubNav />);
+
+    for (const name of ['Marketplace', 'Create', ...CONDITIONAL]) {
+      await expect.element(tab(name)).toBeInTheDocument();
+    }
+  });
+
+  test('pre-mount with NO summary data also shows only the always-on tabs (server parity)', async () => {
+    mocks.isClient = false;
+    mocks.navSummary = undefined; // server: query never resolved
+    renderWithProviders(<AppsSubNav />);
+
+    await expect.element(tab('Marketplace')).toBeInTheDocument();
+    await expect.element(tab('Create')).toBeInTheDocument();
+    for (const name of CONDITIONAL) {
+      expect(tab(name).elements()).toHaveLength(0);
+    }
+  });
+});

--- a/src/components/Apps/AppsSubNav.tsx
+++ b/src/components/Apps/AppsSubNav.tsx
@@ -12,6 +12,7 @@ import { useRouter } from 'next/router';
 import { trpc } from '~/utils/trpc';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
 import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
+import { useIsClient } from '~/providers/IsClientProvider';
 
 /**
  * The conditions that drive which sub-nav tabs are visible. Sourced from the
@@ -175,6 +176,19 @@ export function AppsSubNav() {
   const router = useRouter();
   const features = useFeatureFlags();
   const currentUser = useCurrentUser();
+  // 🔴 HYDRATION-SAFE tab set. The CONDITIONAL tabs are driven by the client-only
+  // `getNavSummary` query, whose data is present in the CLIENT's very first render
+  // but ABSENT during SSR (tRPC runs with `ssr: false`, so the server always
+  // renders `EMPTY_SUMMARY` = the two always-on tabs). Rendering the resolved
+  // summary on the first client paint therefore produced a DIFFERENT tab set than
+  // the server HTML (e.g. 2 tabs SSR vs 6 tabs client for a user with
+  // installs/submissions/approved-apps/reviewer status) — a React hydration
+  // mismatch (#418/#425) that bails hydration of the ENTIRE /apps page root,
+  // leaving every /apps page un-hydrated and inert (dead buttons, queries that
+  // never fire). Gate on `useIsClient()` so the server AND the first client paint
+  // both render the deterministic always-on set; the conditional tabs reveal only
+  // AFTER mount, once hydration has already matched.
+  const isClient = useIsClient();
 
   const { data } = trpc.blocks.getNavSummary.useQuery(undefined, {
     enabled: !!features.appBlocks && !!currentUser,
@@ -183,5 +197,7 @@ export function AppsSubNav() {
 
   if (!features.appBlocks) return null;
 
-  return <AppsSubNavView summary={data ?? EMPTY_SUMMARY} currentPath={router.pathname} />;
+  const summary = isClient ? data ?? EMPTY_SUMMARY : EMPTY_SUMMARY;
+
+  return <AppsSubNavView summary={summary} currentPath={router.pathname} />;
 }


### PR DESCRIPTION
The `/apps/submit` and `/apps/submit?edit=<id>` pages were completely inert in
production: the mode-selector cards did nothing when clicked, and the edit page
hung forever on "Loading your listing…" because the `getMyListingForEdit` query
never fired. Root cause was a React hydration mismatch (#425 text-content →
#418 → #423) that bailed hydration of the ENTIRE `/apps` page root, so no
component on the page ever became interactive.

The divergence is in `AppsSubNav`. Its conditional tabs (Installed / My
submissions / Revenue / Review) are driven by the client-only
`blocks.getNavSummary` query. tRPC runs with `ssr: false`, so the SERVER always
renders `EMPTY_SUMMARY` (the two always-on tabs, Marketplace + Create), while the
query's data is already present in the CLIENT's first render. For a user who
qualifies for the conditional tabs the first client paint rendered 6 tabs against
the server's 2 — a hydration mismatch. Because the sub-nav sits at the top of the
shared `AppsPageLayout` used by every `/apps` surface, the mismatch bailed the
whole page root, leaving it un-hydrated (this is why the mode-selector clicks were
dead and the edit query never mounted). It stayed latent until a user accumulated
installs/submissions/approved-apps/reviewer status (an empty-state user gets 2
tabs on both sides and no mismatch).

Fix: gate the conditional tabs on `useIsClient()` (the existing app-wide
hydration-safe hook — false on the server AND the first client paint, true only
after mount). The server and first client render now both produce the
deterministic always-on set, so hydration matches; the conditional tabs reveal
after mount, exactly as they already did once the query resolved. No behaviour
change beyond eliminating the mismatch.

Adds a browser-mode regression test driving the `AppsSubNav` container: it
asserts the pre-mount render shows ONLY the always-on tabs even when the query
already holds a full summary (fails on the pre-fix `data ?? EMPTY_SUMMARY`), and
reveals the conditional tabs post-mount.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
