### PR TITLE
fix(gallery): re-measure virtualizer scrollMargin when content above resizes

### DIFF
--- a/src/components/Auction/VirtualRowList.tsx
+++ b/src/components/Auction/VirtualRowList.tsx
@@ -2,8 +2,9 @@ import { Center, Divider, Stack, Title } from '@mantine/core';
 import { Skeleton } from '@mantine/core';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import type { ReactNode } from 'react';
-import { useCallback, useLayoutEffect, useRef, useState } from 'react';
+import { useCallback, useRef } from 'react';
 import { useScrollAreaRef } from '~/components/ScrollArea/ScrollAreaContext';
+import { useScrollMargin } from '~/hooks/useScrollMargin';
 
 const ROW_GAP = 8;
 const SKELETON_HEIGHT = 78;
@@ -62,33 +63,11 @@ export function VirtualRowList<T extends { kind: string }>({
 }) {
   const scrollAreaRef = useScrollAreaRef();
   const listRef = useRef<HTMLDivElement>(null);
-  const [scrollMargin, setScrollMargin] = useState(0);
 
   // Rows are absolutely positioned against the scroll container, so a stale offset
   // shifts every one of them. Anything above the list can resize without touching the
-  // row count — placing a bid expands the panel above it by a couple of rows' worth —
-  // so this watches the scrolled content, not just the (fixed-size) scroll box.
-  useLayoutEffect(() => {
-    const list = listRef.current;
-    const scrollArea = scrollAreaRef?.current;
-    if (!list || !scrollArea) return;
-
-    const measure = () => {
-      let offset = 0;
-      let current: HTMLElement | null = list;
-      while (current && current !== scrollArea) {
-        offset += current.offsetTop;
-        current = current.offsetParent as HTMLElement;
-      }
-      setScrollMargin(offset);
-    };
-
-    measure();
-    const observer = new ResizeObserver(measure);
-    observer.observe(scrollArea);
-    for (const child of Array.from(scrollArea.children)) observer.observe(child);
-    return () => observer.disconnect();
-  }, [scrollAreaRef, rows.length]);
+  // row count — placing a bid expands the panel above it by a couple of rows' worth.
+  const scrollMargin = useScrollMargin(listRef);
 
   const virtualizer = useVirtualizer({
     count: rows.length,

--- a/src/components/MasonryColumns/MasonryColumnsVirtual.browser.test.tsx
+++ b/src/components/MasonryColumns/MasonryColumnsVirtual.browser.test.tsx
@@ -1,0 +1,148 @@
+import React, { useRef } from 'react';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { MasonryColumnsVirtual } from '~/components/MasonryColumns/MasonryColumnsVirtual';
+import { MasonryProvider } from '~/components/MasonryColumns/MasonryProvider';
+import { ScrollAreaContext } from '~/components/ScrollArea/ScrollAreaContext';
+import { renderWithProviders } from '../../../test/component-setup';
+
+// Model-page gallery blanking (CU 868kgxjv7).
+//
+// Repro: scroll to the gallery, scroll back up, expand a long description via "Show More",
+// scroll back down. The description pushes the gallery ~5000px further down the scroll
+// container; the virtualizer keeps mapping `scrollTop` through the offset it captured when
+// the gallery mounted, so it renders a window ~5000px deeper into the list and the rows
+// actually on screen are gone.
+//
+// Asserted as the user-visible symptom — no vertical hole at the top of the gallery once
+// it's scrolled to — rather than the offset value, which is `useScrollMargin`'s own test.
+
+// Ads/browsing-level are ambient app context this component reads but the bug
+// doesn't involve; stub the hooks and keep each module's other exports intact.
+vi.mock('~/components/Ads/AdsProvider', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('~/components/Ads/AdsProvider')>()),
+  useAdsContext: () => ({ adsEnabled: false, useDirectAds: false }),
+}));
+vi.mock('~/components/BrowsingLevel/BrowsingLevelProvider', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('~/components/BrowsingLevel/BrowsingLevelProvider')>()),
+  useBrowsingLevelDebounced: () => 1,
+}));
+vi.mock('~/components/Ads/ads.utils', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('~/components/Ads/ads.utils')>()),
+  useCreateAdFeed: () => (args: { data: unknown[] }) =>
+    args.data.map((item) => ({ type: 'data' as const, data: item })),
+}));
+
+const SCROLL_AREA_HEIGHT = 400;
+const INITIAL_SPACER = 300;
+const ITEM_HEIGHT = 200;
+
+type Item = { id: number };
+const items: Item[] = Array.from({ length: 60 }, (_, i) => ({ id: i }));
+
+function Card({ data }: { data: Item }) {
+  return <div data-testid="card" data-id={data.id} style={{ height: ITEM_HEIGHT }} />;
+}
+
+function Gallery() {
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  return (
+    <ScrollAreaContext.Provider value={{ ref: scrollRef as React.RefObject<HTMLDivElement> }}>
+      <div
+        ref={scrollRef}
+        data-testid="scroll-area"
+        style={{
+          height: SCROLL_AREA_HEIGHT,
+          width: 700,
+          overflowY: 'auto',
+          position: 'relative',
+        }}
+      >
+        {/* Both sections sit under one page wrapper, as they do on the model page. */}
+        <div>
+          {/* Stands in for the model description above the gallery. */}
+          <div data-testid="description" style={{ height: INITIAL_SPACER }} />
+          <MasonryProvider columnWidth={320} maxColumnCount={6} style={{ width: 700 }}>
+            <MasonryColumnsVirtual
+              data={items}
+              render={Card}
+              imageDimensions={() => ({ width: 320, height: ITEM_HEIGHT })}
+              itemId={(data) => data.id}
+            />
+          </MasonryProvider>
+        </div>
+      </div>
+    </ScrollAreaContext.Provider>
+  );
+}
+
+const el = (testId: string) => document.querySelector(`[data-testid="${testId}"]`) as HTMLElement;
+const columns = () =>
+  Array.from(document.querySelectorAll('div.mx-auto.flex.justify-center.gap-4 > div'));
+
+/** Largest blank strip between the top of a column and its first rendered card. */
+function holeAtTopOfGallery() {
+  return Math.max(
+    ...columns().map((column) => {
+      const cards = Array.from(column.querySelectorAll('[data-testid="card"]'));
+      if (!cards.length) return Infinity;
+      const columnTop = column.getBoundingClientRect().top;
+      const viewportTop = el('scroll-area').getBoundingClientRect().top;
+      const firstCardTop = Math.min(...cards.map((card) => card.getBoundingClientRect().top));
+      return firstCardTop - Math.max(columnTop, viewportTop);
+    })
+  );
+}
+
+const renderedIds = () =>
+  Array.from(document.querySelectorAll('[data-testid="card"]')).map((card) =>
+    Number(card.getAttribute('data-id'))
+  );
+
+function scrollBy(delta: number) {
+  el('scroll-area').scrollTop += delta;
+}
+
+/** Put the top of the gallery at the top of the viewport. */
+function scrollToGallery() {
+  const scrollArea = el('scroll-area');
+  scrollBy(columns()[0].getBoundingClientRect().top - scrollArea.getBoundingClientRect().top);
+}
+
+/** The first row is rendered and sits flush against the top of the viewport. */
+async function expectGalleryTopOnScreen() {
+  await vi.waitFor(() => {
+    expect(renderedIds()).toContain(0);
+    expect(holeAtTopOfGallery()).toBeLessThan(20);
+  });
+}
+
+describe('MasonryColumnsVirtual', () => {
+  beforeEach(async () => {
+    renderWithProviders(<Gallery />);
+    await vi.waitFor(() => expect(columns().length).toBe(2));
+    await vi.waitFor(() => expect(renderedIds().length).toBeGreaterThan(0));
+  });
+
+  test('fills the viewport when scrolled to the gallery', async () => {
+    scrollToGallery();
+
+    await expectGalleryTopOnScreen();
+  });
+
+  test('keeps rendering the rows on screen after content above it expands', async () => {
+    scrollToGallery();
+    await expectGalleryTopOnScreen();
+
+    // Scroll deep enough that the first row is windowed out, so the assertion at the
+    // end can only pass if the virtualizer re-renders rather than leaving stale DOM.
+    scrollBy(4000);
+    await vi.waitFor(() => expect(renderedIds()).not.toContain(0));
+
+    // "Show More": the description grows while the gallery is mounted and untouched.
+    el('description').style.height = `${INITIAL_SPACER + 3000}px`;
+    scrollToGallery();
+
+    await expectGalleryTopOnScreen();
+  });
+});

--- a/src/components/MasonryColumns/MasonryColumnsVirtual.browser.test.tsx
+++ b/src/components/MasonryColumns/MasonryColumnsVirtual.browser.test.tsx
@@ -4,6 +4,9 @@ import { MasonryColumnsVirtual } from '~/components/MasonryColumns/MasonryColumn
 import { MasonryProvider } from '~/components/MasonryColumns/MasonryProvider';
 import { ScrollAreaContext } from '~/components/ScrollArea/ScrollAreaContext';
 import { renderWithProviders } from '../../../test/component-setup';
+import type * as AdsProvider from '~/components/Ads/AdsProvider';
+import type * as AdsUtils from '~/components/Ads/ads.utils';
+import type * as BrowsingLevelProvider from '~/components/BrowsingLevel/BrowsingLevelProvider';
 
 // Model-page gallery blanking (CU 868kgxjv7).
 //
@@ -19,15 +22,15 @@ import { renderWithProviders } from '../../../test/component-setup';
 // Ads/browsing-level are ambient app context this component reads but the bug
 // doesn't involve; stub the hooks and keep each module's other exports intact.
 vi.mock('~/components/Ads/AdsProvider', async (importOriginal) => ({
-  ...(await importOriginal<typeof import('~/components/Ads/AdsProvider')>()),
+  ...(await importOriginal<typeof AdsProvider>()),
   useAdsContext: () => ({ adsEnabled: false, useDirectAds: false }),
 }));
 vi.mock('~/components/BrowsingLevel/BrowsingLevelProvider', async (importOriginal) => ({
-  ...(await importOriginal<typeof import('~/components/BrowsingLevel/BrowsingLevelProvider')>()),
+  ...(await importOriginal<typeof BrowsingLevelProvider>()),
   useBrowsingLevelDebounced: () => 1,
 }));
 vi.mock('~/components/Ads/ads.utils', async (importOriginal) => ({
-  ...(await importOriginal<typeof import('~/components/Ads/ads.utils')>()),
+  ...(await importOriginal<typeof AdsUtils>()),
   useCreateAdFeed: () => (args: { data: unknown[] }) =>
     args.data.map((item) => ({ type: 'data' as const, data: item })),
 }));

--- a/src/components/MasonryColumns/MasonryColumnsVirtual.tsx
+++ b/src/components/MasonryColumns/MasonryColumnsVirtual.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useLayoutEffect, useRef, useState } from 'react';
+import React, { useCallback, useRef } from 'react';
 import type { ColumnItem } from '~/components/MasonryColumns/masonry.utils';
 import { useMasonryColumns } from '~/components/MasonryColumns/masonry.utils';
 import { useMasonryContext } from '~/components/MasonryColumns/MasonryProvider';
@@ -12,6 +12,7 @@ import { TwCard } from '~/components/TwCard/TwCard';
 import clsx from 'clsx';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import { useScrollAreaRef } from '~/components/ScrollArea/ScrollAreaContext';
+import { useScrollMargin } from '~/hooks/useScrollMargin';
 import type { AdFeedItem } from '~/components/Ads/ads.utils';
 
 type Props<TData> = {
@@ -48,8 +49,13 @@ export function MasonryColumnsVirtual<TData>({
     withAds
   );
 
+  // Measured here rather than per column: the columns are flush with this wrapper, and
+  // this component doesn't re-render on scroll the way each column does.
+  const ref = useRef<HTMLDivElement>(null);
+  const scrollMargin = useScrollMargin(ref);
+
   return (
-    <div className="mx-auto flex justify-center gap-4">
+    <div ref={ref} className="mx-auto flex justify-center gap-4">
       {columns.map((items, colIndex) => (
         <VirtualColumn
           key={colIndex}
@@ -57,6 +63,7 @@ export function MasonryColumnsVirtual<TData>({
           render={render}
           itemId={itemId}
           columnWidth={columnWidth}
+          scrollMargin={scrollMargin}
           className={clsx(
             'flex max-w-[450px] flex-col gap-4',
             columnCount === 1 ? 'w-full' : 'w-[320px]'
@@ -75,6 +82,7 @@ function VirtualColumn<TData>({
   style,
   itemId,
   overscan = 5,
+  scrollMargin,
   ...rest
 }: {
   items: ColumnItem<AdFeedItem<TData>>[];
@@ -84,8 +92,8 @@ function VirtualColumn<TData>({
   itemId?: (data: TData) => string | number;
   columnWidth: number;
   overscan?: number;
+  scrollMargin: number;
 }) {
-  const ref = useRef<HTMLDivElement | null>(null);
   const scrollAreaRef = useScrollAreaRef();
 
   const getItemKey = useCallback(
@@ -96,13 +104,6 @@ function VirtualColumn<TData>({
     },
     [items]
   );
-
-  const [scrollMargin, setScrollMargin] = useState(0);
-  useLayoutEffect(() => {
-    if (ref.current && scrollAreaRef?.current) {
-      setScrollMargin(getOffsetTopRelativeToAncestor(ref.current, scrollAreaRef.current));
-    }
-  }, []);
 
   const rowVirtualizer = useVirtualizer({
     count: items.length,
@@ -120,7 +121,6 @@ function VirtualColumn<TData>({
 
   return (
     <div
-      ref={ref}
       className={className}
       style={{
         width: '100%',
@@ -186,20 +186,4 @@ function VirtualItem<TData>({
     default:
       return null;
   }
-}
-
-function getOffsetTopRelativeToAncestor(descendant: HTMLElement, ancestor: HTMLElement): number {
-  let offset = 0;
-  let current: HTMLElement | null = descendant;
-
-  while (current && current !== ancestor) {
-    offset += current.offsetTop;
-    current = current.offsetParent as HTMLElement;
-  }
-
-  if (current !== ancestor) {
-    throw new Error('Ancestor is not an offsetParent of the descendant');
-  }
-
-  return offset;
 }

--- a/src/components/MasonryColumns/MasonryGridVirtual.tsx
+++ b/src/components/MasonryColumns/MasonryGridVirtual.tsx
@@ -2,7 +2,7 @@ import { Button, Text, useComputedColorScheme } from '@mantine/core';
 import { IconCaretRightFilled } from '@tabler/icons-react';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import Image from 'next/image';
-import React, { useCallback, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useMemo, useRef } from 'react';
 import { AdUnitIncontent_1 } from '~/components/Ads/AdUnit';
 import { AdUnitRenderable } from '~/components/Ads/AdUnitRenderable';
 import { useAdsContext } from '~/components/Ads/AdsProvider';
@@ -11,6 +11,7 @@ import type { MasonryRenderItemProps } from '~/components/MasonryColumns/masonry
 import { useMasonryContext } from '~/components/MasonryColumns/MasonryProvider';
 import { NextLink as Link } from '~/components/NextLink/NextLink';
 import { useScrollAreaRef } from '~/components/ScrollArea/ScrollAreaContext';
+import { useScrollMargin } from '~/hooks/useScrollMargin';
 import { TwCard } from '~/components/TwCard/TwCard';
 import { useBrowsingLevelDebounced } from '~/components/BrowsingLevel/BrowsingLevelProvider';
 import { getIsSafeBrowsingLevel } from '~/shared/constants/browsingLevel.constants';
@@ -91,13 +92,7 @@ export function MasonryGridVirtual<TData>({
   const ref = useRef<HTMLDivElement | null>(null);
   const scrollAreaRef = useScrollAreaRef();
 
-  const [scrollMargin, setScrollMargin] = useState(0);
-  useLayoutEffect(() => {
-    if (ref.current && scrollAreaRef?.current) {
-      setScrollMargin(getOffsetTopRelativeToAncestor(ref.current, scrollAreaRef.current));
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  const scrollMargin = useScrollMargin(ref);
 
   const getRowKey = useCallback(
     (rowIndex: number) => {
@@ -214,20 +209,4 @@ export function MasonryGridVirtual<TData>({
       })}
     </div>
   );
-}
-
-function getOffsetTopRelativeToAncestor(descendant: HTMLElement, ancestor: HTMLElement): number {
-  let offset = 0;
-  let current: HTMLElement | null = descendant;
-
-  while (current && current !== ancestor) {
-    offset += current.offsetTop;
-    current = current.offsetParent as HTMLElement;
-  }
-
-  if (current !== ancestor) {
-    throw new Error('Ancestor is not an offsetParent of the descendant');
-  }
-
-  return offset;
 }

--- a/src/hooks/useScrollMargin.browser.test.tsx
+++ b/src/hooks/useScrollMargin.browser.test.tsx
@@ -1,0 +1,175 @@
+import React, { useRef, useState } from 'react';
+import { describe, expect, test, vi } from 'vitest';
+import { page, userEvent } from 'vitest/browser';
+import { ScrollAreaContext } from '~/components/ScrollArea/ScrollAreaContext';
+import { useScrollMargin } from '~/hooks/useScrollMargin';
+import { renderWithProviders } from '../../test/component-setup';
+
+// `useScrollMargin` — the offset a virtualizer maps `scrollTop` through.
+//
+// The offset changes without the list itself changing: a description above it expands, an
+// ad loads, a panel opens. Measuring once on mount is what blanked the model-page gallery
+// (CU 868kgxjv7) — the virtualizer kept windowing against the pre-expansion offset and
+// unmounted rows that were on screen.
+//
+// The hook re-measures on every commit, so the tests that assert it STOPS (no scroll
+// container, element never attached) matter as much as the ones that assert it measures.
+//
+// Browser mode because every assertion is real layout: `offsetTop` chains, `offsetParent`
+// resolution and `ResizeObserver` delivery.
+
+const SPACER = 'spacer';
+const TARGET = 'target';
+
+function Target() {
+  const ref = useRef<HTMLDivElement>(null);
+  const scrollMargin = useScrollMargin(ref);
+
+  return <div ref={ref} data-testid={TARGET} data-margin={scrollMargin} style={{ height: 400 }} />;
+}
+
+/** A scroll container with resizable content above the measured element. */
+function Harness({
+  spacerHeight = 300,
+  withTarget = true,
+  nested = false,
+}: {
+  spacerHeight?: number;
+  withTarget?: boolean;
+  /** Wrap the target so the offset has to be summed across an ancestor chain. */
+  nested?: boolean;
+}) {
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const content = (
+    <>
+      <div data-testid={SPACER} style={{ height: spacerHeight }} />
+      {withTarget ? <Target /> : null}
+      <div style={{ height: 2000 }} />
+    </>
+  );
+
+  return (
+    <ScrollAreaContext.Provider value={{ ref: scrollRef as React.RefObject<HTMLDivElement> }}>
+      <div
+        ref={scrollRef}
+        data-testid="scroll-area"
+        style={{ height: 200, overflowY: 'auto', position: 'relative' }}
+      >
+        {nested ? <div style={{ paddingTop: 50 }}>{content}</div> : content}
+      </div>
+    </ScrollAreaContext.Provider>
+  );
+}
+
+const margin = () =>
+  Number(document.querySelector(`[data-testid="${TARGET}"]`)?.getAttribute('data-margin'));
+
+let renders = 0;
+
+/** Counts its own renders; `attach` false leaves the measured ref empty forever. */
+function CountingTarget({ attach }: { attach: boolean }) {
+  const ref = useRef<HTMLDivElement>(null);
+  useScrollMargin(ref);
+  renders++;
+
+  return <div ref={attach ? ref : undefined} data-testid={TARGET} style={{ height: 400 }} />;
+}
+
+/** ~18 frames — long enough for a per-frame retry loop to be obvious. */
+const settle = () => new Promise((resolve) => setTimeout(resolve, 300));
+
+/** Resize outside React so only the ResizeObserver can notice. */
+function setSpacerHeight(height: number) {
+  const spacer = document.querySelector(`[data-testid="${SPACER}"]`) as HTMLElement;
+  spacer.style.height = `${height}px`;
+}
+
+describe('useScrollMargin', () => {
+  test('measures the offset from the scroll container on mount', async () => {
+    renderWithProviders(<Harness spacerHeight={300} />);
+
+    await vi.waitFor(() => expect(margin()).toBe(300));
+  });
+
+  test('sums the offset across the ancestor chain', async () => {
+    renderWithProviders(<Harness spacerHeight={300} nested />);
+
+    await vi.waitFor(() => expect(margin()).toBe(350));
+  });
+
+  test('re-measures when content above it grows without a re-render', async () => {
+    renderWithProviders(<Harness spacerHeight={300} />);
+    await vi.waitFor(() => expect(margin()).toBe(300));
+
+    setSpacerHeight(2000);
+
+    await vi.waitFor(() => expect(margin()).toBe(2000));
+  });
+
+  test('re-measures when the growth is nested below the scroll container', async () => {
+    // The app's case: the description that expands is buried several levels under the
+    // scroll container, so only the child it grows is observable.
+    renderWithProviders(<Harness spacerHeight={300} nested />);
+    await vi.waitFor(() => expect(margin()).toBe(350));
+
+    setSpacerHeight(2000);
+
+    await vi.waitFor(() => expect(margin()).toBe(2050));
+  });
+
+  test('re-measures when content above it shrinks back', async () => {
+    renderWithProviders(<Harness spacerHeight={2000} />);
+    await vi.waitFor(() => expect(margin()).toBe(2000));
+
+    setSpacerHeight(300);
+
+    await vi.waitFor(() => expect(margin()).toBe(300));
+  });
+
+  test('measures an element that mounts after the hook', async () => {
+    // Lists commonly render behind a loading state, so the ref is empty on the
+    // hook's first commit. A mount-only effect would leave the margin at 0 forever.
+    function LateMount() {
+      const [ready, setReady] = useState(false);
+      return (
+        <>
+          <button onClick={() => setReady(true)}>load</button>
+          <Harness spacerHeight={300} withTarget={ready} />
+        </>
+      );
+    }
+
+    renderWithProviders(<LateMount />);
+    expect(document.querySelector(`[data-testid="${TARGET}"]`)).toBeNull();
+
+    await userEvent.click(page.getByRole('button', { name: 'load' }));
+
+    await vi.waitFor(() => expect(margin()).toBe(300));
+  });
+
+  test('settles when the measured element never attaches', async () => {
+    // `MasonryGridVirtual`'s empty state and `downloads.tsx`'s "no results" both call the
+    // hook while never rendering the ref, so re-measuring per commit must not self-feed.
+    renders = 0;
+    renderWithProviders(
+      <ScrollAreaContext.Provider
+        value={{ ref: { current: document.body as unknown as HTMLDivElement } }}
+      >
+        <CountingTarget attach={false} />
+      </ScrollAreaContext.Provider>
+    );
+
+    await settle();
+
+    expect(renders).toBeLessThan(5);
+  });
+
+  test('settles when there is no scroll container in the tree', async () => {
+    renders = 0;
+    renderWithProviders(<CountingTarget attach />);
+
+    await settle();
+
+    expect(renders).toBeLessThan(6);
+  });
+});

--- a/src/hooks/useScrollMargin.ts
+++ b/src/hooks/useScrollMargin.ts
@@ -1,0 +1,97 @@
+import type { MutableRefObject, RefObject } from 'react';
+import { useEffect, useRef, useState } from 'react';
+import { useScrollAreaRef } from '~/components/ScrollArea/ScrollAreaContext';
+import { useIsomorphicLayoutEffect } from '~/hooks/useIsomorphicLayoutEffect';
+
+type Observed = { element: HTMLElement; root: HTMLElement; observer: ResizeObserver };
+
+/** A scroll container that mounts in the same commit attaches its ref after this hook's
+ * effect. More frames than that means there is no ScrollArea above us — stop looking. */
+const ROOT_ATTACH_RETRIES = 3;
+
+/**
+ * Distance between the top of the scroll container and the top of `ref`, kept in
+ * sync while content above it grows or shrinks (expanding descriptions, ads that
+ * load late). `useVirtualizer` turns `scrollTop - scrollMargin` into the window of
+ * items it renders, so a stale value blanks rows that are on screen.
+ */
+export function useScrollMargin(ref: RefObject<HTMLElement | null>) {
+  const scrollAreaRef = useScrollAreaRef();
+  const [scrollMargin, setScrollMargin] = useState(0);
+  const [, retry] = useState(0);
+  const retriesRef = useRef(0);
+  const warnedRef = useRef(false);
+  const observedRef = useRef<Observed | null>(null);
+
+  // No dependency array: the measured element commonly mounts later than the hook (lists
+  // rendered behind a loading state), and a commit is the cheapest place to catch layout
+  // changes the observer below can't see.
+  useIsomorphicLayoutEffect(() => {
+    const element = ref.current;
+    if (!element) {
+      disconnect(observedRef);
+      return;
+    }
+
+    const root = scrollAreaRef?.current;
+    if (!root) {
+      if (retriesRef.current >= ROOT_ATTACH_RETRIES) return;
+      retriesRef.current++;
+      const frame = requestAnimationFrame(() => retry((count) => count + 1));
+      return () => cancelAnimationFrame(frame);
+    }
+    retriesRef.current = 0;
+
+    const update = () => {
+      const offset = getOffsetTopRelativeToAncestor(element, root);
+      if (offset === null) {
+        if (process.env.NODE_ENV !== 'production' && !warnedRef.current) {
+          warnedRef.current = true;
+          console.warn(
+            'useScrollMargin: the scroll container is not an offsetParent of the measured element — is it positioned?'
+          );
+        }
+        return;
+      }
+      setScrollMargin((prev) => (prev !== offset ? offset : prev));
+    };
+
+    update();
+
+    if (observedRef.current?.element === element && observedRef.current.root === root) return;
+    disconnect(observedRef);
+
+    // Whatever grows above the list lives inside one of the scroll container's children,
+    // and grows that child's own box. Observing the list's ancestors instead would also
+    // fire on the list growing downward, which can never move its own top.
+    const observer = new ResizeObserver(update);
+    observer.observe(root);
+    for (const child of Array.from(root.children)) observer.observe(child);
+
+    observedRef.current = { element, root, observer };
+  });
+
+  useEffect(() => () => disconnect(observedRef), []);
+
+  return scrollMargin;
+}
+
+function disconnect(ref: MutableRefObject<Observed | null>) {
+  ref.current?.observer.disconnect();
+  ref.current = null;
+}
+
+function getOffsetTopRelativeToAncestor(
+  descendant: HTMLElement,
+  ancestor: HTMLElement
+): number | null {
+  let offset = 0;
+  let current: HTMLElement | null = descendant;
+
+  while (current && current !== ancestor) {
+    offset += current.offsetTop;
+    current = current.offsetParent as HTMLElement;
+  }
+
+  return current === ancestor ? offset : null;
+}

--- a/src/pages/user/downloads.tsx
+++ b/src/pages/user/downloads.tsx
@@ -1,7 +1,7 @@
 import { Center, Container, Group, Loader, Stack, Text, ThemeIcon, Title } from '@mantine/core';
 import { IconCloudOff } from '@tabler/icons-react';
 import { useVirtualizer } from '@tanstack/react-virtual';
-import { useCallback, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useMemo, useRef } from 'react';
 import { DownloadCard } from '~/components/Downloads/DownloadCard';
 import {
   DownloadActiveFilters,
@@ -14,6 +14,7 @@ import {
 } from '~/components/Downloads/download.utils';
 import { useScrollAreaRef } from '~/components/ScrollArea/ScrollAreaContext';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
+import { useScrollMargin } from '~/hooks/useScrollMargin';
 import type { DownloadHistoryItem } from '~/server/services/download.service';
 import { trpc } from '~/utils/trpc';
 
@@ -25,7 +26,7 @@ export default function Downloads() {
   const queryUtils = trpc.useUtils();
   const scrollAreaRef = useScrollAreaRef();
   const listRef = useRef<HTMLDivElement>(null);
-  const [scrollMargin, setScrollMargin] = useState(0);
+  const scrollMargin = useScrollMargin(listRef);
 
   const { filters, setFilters, clearFilters, hasActiveFilters } = useDownloadFilters();
 
@@ -43,19 +44,6 @@ export default function Downloads() {
     () => filterDownloads(downloads, filters),
     [downloads, filters]
   );
-
-  // Calculate scroll margin (offset from top of scroll container to our list)
-  useLayoutEffect(() => {
-    if (listRef.current && scrollAreaRef?.current) {
-      let offset = 0;
-      let current: HTMLElement | null = listRef.current;
-      while (current && current !== scrollAreaRef.current) {
-        offset += current.offsetTop;
-        current = current.offsetParent as HTMLElement;
-      }
-      setScrollMargin(offset);
-    }
-  }, [scrollAreaRef, isLoading]);
 
   // Set up virtualizer for efficient rendering using the main scroll area
   const virtualizer = useVirtualizer({


### PR DESCRIPTION
Fixes the model-page gallery blanking reported in [CU 868kgxjv7](https://app.clickup.com/t/8459928/868kgxjv7) (Freshdesk #67830).

## The bug

Open a model with a long description, scroll down to the gallery, scroll back up, click **Show More**, scroll back down — the first row(s) of images vanish while still inside the viewport. Order matters: expanding *before* the gallery has mounted doesn't reproduce it.

## Root cause

The gallery mounts lazily when scrolled to, so `VirtualColumn` measured its offset within the scroll container with the description still collapsed. That offset feeds `useVirtualizer({ scrollMargin })`, which windows on `scrollTop - scrollMargin` — and it was measured once, in a `useLayoutEffect(…, [])`. Expanding the description moved the gallery down without anything re-measuring, so the virtualizer rendered a window that far deeper into the list and unmounted the rows on screen.

Measured on `/models/2458426` in a real browser:

| | |
|---|---|
| gallery offset when it mounted | 2725px |
| offset after "Show More" | 7843px |
| stale by | **5118px** |
| resulting blank strip, per column | 1985 / 2526 / 2900 / 2665 px |

## The fix

New `useScrollMargin(ref)` hook that re-measures on commit and via a `ResizeObserver` on the scroll container and its direct children (whatever grows above the list grows one of those). Adopted at all four call sites that had this pattern — `MasonryColumnsVirtual` (model gallery), `MasonryGridVirtual` (main feeds), `VirtualRowList` (auctions), `user/downloads`. The latter two had partial variants of the same logic; the hook is a superset of both, and four copies of `getOffsetTopRelativeToAncestor` collapse into one.

Two things fall out of consolidating:

- **The element can mount after the hook.** `downloads.tsx` renders its list behind a loading state, so the ref is empty on the first commit. The effect runs per commit and wires observers once, keyed on element identity.
- **The measurement is hoisted out of the per-column loop** on the gallery. Columns are flush with their wrapper, and the wrapper doesn't re-render on scroll the way each column does — so instead of 6 hook instances doing 6 forced layout reads per scroll re-render, there's one, off the scroll path.

## Tests

`pnpm vitest run --project component src/hooks/useScrollMargin.browser.test.tsx src/components/MasonryColumns/MasonryColumnsVirtual.browser.test.tsx` — 10 tests, browser mode (real layout, real `ResizeObserver`).

The gallery test drives the ticket's repro against the real component: scroll to the gallery → scroll deep enough that row 0 is windowed out → grow the description 3000px → scroll back → assert row 0 renders flush at the top. Verified it catches the old behavior rather than passing vacuously:

```
× keeps rendering the rows on screen after content above it expands
    AssertionError: expected [ 16, 18, 20, 22, 24, 26, 28, …(19) ] to include +0
× re-measures when content above it grows without a re-render — expected 300 to be 2000
× re-measures when the growth is nested below the scroll container — expected 350 to be 2050
× re-measures when content above it shrinks back — expected 2000 to be 300
```

Two further tests pin that the per-commit measurement **settles** — an element that never attaches, and no `ScrollAreaContext` in the tree. Without a bounded retry those states re-render forever (37 renders in 300ms), which `MasonryGridVirtual`'s `empty` state and an empty downloads list both reach.

## Verification

- Reproduced and re-checked the fix in the running app on `/models/2458426` as a moderator: blank strip 1985–2900px → **0px**, first row fills the viewport.
- Feeds re-checked after deep scroll on `/models` — rows continuous, no gaps, no `ResizeObserver` console errors.
- Full component suite: 857 passed. The 16 failures are all in `Apps/*` / `AppBlocks/*`, import nothing this PR touches, and vary run to run on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
