### PR TITLE
feat(apps): auto-trigger external-listing autofill + inline data-URI icon support

### DIFF
--- a/src/components/Apps/ExternalListingEditForm.tsx
+++ b/src/components/Apps/ExternalListingEditForm.tsx
@@ -20,13 +20,12 @@ import {
 } from '@tabler/icons-react';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
-import { useEffect, useRef, useState, type KeyboardEvent as ReactKeyboardEvent } from 'react';
+import { useRef, useState, type KeyboardEvent as ReactKeyboardEvent } from 'react';
 import {
   OFFSITE_CATEGORY_OPTIONS,
   OFFSITE_CONTENT_RATING_OPTIONS,
   OFFSITE_SUBMIT_LIMITS,
   isUrlStepComplete,
-  normalizeLinkUrl,
   scopeJustificationError,
   validateOffsiteSubmitForm,
   type OffsiteSubmitFormErrors,
@@ -34,7 +33,9 @@ import {
 } from '~/components/Apps/offsiteSubmitFormConfig';
 import { DerivedScopesDisclosure } from '~/components/Apps/DerivedScopesDisclosure';
 import { FadeIn } from '~/components/Apps/wizardMotion';
-import { ListingAssetStep, type MetaSuggestions } from '~/components/Apps/ListingAssetStep';
+import { ListingAssetStep } from '~/components/Apps/ListingAssetStep';
+import { describeMissingChannels } from '~/components/Apps/listingAutofillStatus';
+import { useListingAutofill } from '~/components/Apps/useListingAutofill';
 import {
   buildScalarPatch,
   editContextToForm,
@@ -103,97 +104,23 @@ export function ExternalListingEditForm({ edit }: { edit: ListingEditContext }) 
   const shadowId = edit.shadowId;
   const effectiveId = approved ? shadowId : edit.parentId;
 
-  // OG metadata auto-pull (same SSRF-safe path as create) — re-fires on a URL
-  // change; NON-DESTRUCTIVE (fills only blank name/tagline; asset suggestions show
-  // only for an empty asset slot, so a prefilled asset is never clobbered).
-  const [metaUrl, setMetaUrl] = useState<string | null>(null);
-  const [suggestions, setSuggestions] = useState<MetaSuggestions>({});
-  const appliedMetaRef = useRef<string | null>(null);
-  // On-demand "Autofill from website" (edit-only): the OG pull otherwise fires only on
-  // a URL CHANGE, so a listing whose icon/cover ended up empty could never re-surface
-  // suggestions without editing the URL. `autofillActive` tracks a button-triggered
-  // pull (drives the loading/error/note feedback); `autofillTick` forces the apply
-  // effect to re-run on a re-click of the SAME url (unchanged `metaUrl` + a cached
-  // `metaQuery.data` reference otherwise skip it).
-  const [autofillActive, setAutofillActive] = useState(false);
-  const [autofillTick, setAutofillTick] = useState(0);
-  const [autofillNote, setAutofillNote] = useState<'applied' | 'empty' | 'error' | null>(null);
-  const metaQuery = trpc.appListings.fetchListingMetaFromUrl.useQuery(
-    { url: metaUrl ?? '' },
-    { enabled: !!metaUrl, retry: false, refetchOnWindowFocus: false, staleTime: Infinity }
-  );
-  useEffect(() => {
-    // Apply at most once per settled url. The `appliedMetaRef` short-circuit also covers
-    // the initial `metaUrl === null` state (null === null).
-    if (!metaUrl || appliedMetaRef.current === metaUrl) return;
-    // Settle on SUCCESS or ERROR for the CURRENT metaUrl (mirrors the create form). With a
-    // per-url cache key + retry:false, `metaQuery.data`/`isError` belong to `metaUrl`; wait
-    // out an in-flight (re)fetch so a stale cached error can't be applied before a button
-    // `refetch()` resolves — that guard is also what keeps the same-url refetch from looping.
-    if (metaQuery.isFetching) return;
-    const data = metaQuery.data;
-    const settled = !!data || metaQuery.isError;
-    if (!settled) return;
-    appliedMetaRef.current = metaUrl;
-
-    if (!data) {
-      // ERROR-settled: don't surface stale suggestions, and don't co-render an
-      // "applied"/"empty" note. The inline "Couldn't read that site's details." message
-      // renders from the `'error'` note (tied to THIS url) below. Resetting the active
-      // flag stops a later non-button URL advance from rendering a spurious note, and the
-      // same url stays retryable via `metaQuery.refetch()` in the button handler.
-      setSuggestions({});
-      if (autofillActive) {
-        setAutofillNote('error');
-        setAutofillActive(false);
-      }
-      return;
-    }
-
-    setValues((v) => ({
-      ...v,
-      name: v.name.trim().length === 0 && data.name ? data.name : v.name,
-      tagline: v.tagline.trim().length === 0 && data.tagline ? data.tagline : v.tagline,
-      // Description autofill: fill ONLY when empty, truncated to the field bound —
-      // never clobbers existing copy (non-destructive OG re-pull on a URL change).
-      description:
-        v.description.trim().length === 0 && data.description
-          ? data.description.slice(0, OFFSITE_SUBMIT_LIMITS.descriptionMax)
-          : v.description,
-    }));
-    setSuggestions({ coverImageUrl: data.coverImageUrl, iconImageUrl: data.iconImageUrl });
-    // When THIS apply was button-triggered, report whether the pull surfaced anything
-    // ACTIONABLE: copy for a still-empty text field, or an icon/cover suggestion for a
-    // slot that is currently EMPTY (imageId == null in the edit prefill — the only case
-    // where ListingAssetStep renders a "Use this"). A suggestion URL for an already-filled
-    // slot is NOT actionable, so it must not claim "applied". Emptiness is read from the
-    // ref snapshot — NOT the async `setValues` updater above, whose side effects haven't
-    // committed yet. (Slot-filled state is the edit prefill; if the author added/removed an
-    // asset THIS session ListingAssetStep owns that state, so the note is best-effort.)
-    if (autofillActive) {
-      const v = valuesRef.current;
-      const filledAny =
-        (v.name.trim().length === 0 && !!data.name) ||
-        (v.tagline.trim().length === 0 && !!data.tagline) ||
-        (v.description.trim().length === 0 && !!data.description);
-      const hasActionableSuggestion =
-        (!!data.iconImageUrl && edit.assets.icon.imageId == null) ||
-        (!!data.coverImageUrl && edit.assets.cover.imageId == null);
-      setAutofillNote(filledAny || hasActionableSuggestion ? 'applied' : 'empty');
-      setAutofillActive(false);
-    }
-    // `autofillTick` is a dep so a same-url re-click (which leaves `metaUrl` + the cached
-    // `metaQuery.data` reference unchanged) still re-runs this effect and re-applies from
-    // cache — the click also resets `appliedMetaRef`, so the guard above passes.
-  }, [
-    metaQuery.data,
-    metaQuery.isError,
-    metaQuery.isFetching,
-    metaUrl,
-    autofillTick,
-    autofillActive,
-    edit,
-  ]);
+  // OG metadata auto-pull via the shared `useListingAutofill` hook (same SSRF-safe path
+  // as create) — auto-fires on a URL CHANGE (blur/Enter/advance + a debounced pause);
+  // NON-DESTRUCTIVE (fills only blank name/tagline/description; an icon/cover suggestion
+  // is only ACTIONABLE for an EMPTY slot, so a prefilled asset is never clobbered).
+  // Seeded with the prefilled URL so it does NOT auto-fire on mount for an existing
+  // listing — only a change (or the assets-step "Re-pull from site" button) fires.
+  const autofill = useListingAutofill({
+    externalUrl: values.externalUrl,
+    setValues,
+    valuesRef,
+    onBeforeFire: (url) => setField('externalUrl', url),
+    initialUrl: edit.scalars.externalUrl ?? undefined,
+    // A suggestion is only actionable for a slot the prefill left EMPTY (imageId == null
+    // — the only case where ListingAssetStep renders a "Use this"), so the note never
+    // claims "applied" for an already-filled slot.
+    isSuggestionActionable: (kind) => edit.assets[kind].imageId == null,
+  });
 
   const updateListingMutation = trpc.appListings.updateListing.useMutation();
   const updateRevisionMutation = trpc.appListings.updateRevisionDraft.useMutation();
@@ -224,9 +151,9 @@ export function ExternalListingEditForm({ edit }: { edit: ListingEditContext }) 
       setErrors((prev) => ({ ...prev, externalUrl: undefined }));
       return;
     }
-    const result = normalizeLinkUrl(values.externalUrl);
-    if (result.error) return;
-    setField('externalUrl', result.url);
+    // Canonicalise + auto-fire the OG pull (once per distinct URL) via the hook.
+    const { error } = autofill.triggerFromUrl(values.externalUrl);
+    if (error) return; // a bad URL keeps whatever's typed (no hard error on blur here)
     setErrors((prev) => ({ ...prev, externalUrl: undefined }));
   }
 
@@ -239,14 +166,12 @@ export function ExternalListingEditForm({ edit }: { edit: ListingEditContext }) 
       setActive(STEP_DETAILS);
       return;
     }
-    const result = normalizeLinkUrl(values.externalUrl);
-    if (result.error) {
-      setErrors((prev) => ({ ...prev, externalUrl: result.error }));
+    const { error } = autofill.triggerFromUrl(values.externalUrl);
+    if (error) {
+      setErrors((prev) => ({ ...prev, externalUrl: error }));
       return;
     }
-    setField('externalUrl', result.url);
     setErrors((prev) => ({ ...prev, externalUrl: undefined }));
-    setMetaUrl(result.url); // re-fire the OG auto-pull for the (possibly new) URL
     setActive(STEP_DETAILS);
   }
 
@@ -254,35 +179,6 @@ export function ExternalListingEditForm({ edit }: { edit: ListingEditContext }) 
     if (e.key !== 'Enter' || e.nativeEvent.isComposing) return;
     e.preventDefault();
     handleAdvanceFromUrl();
-  }
-
-  // "Autofill from website" — on-demand OG re-pull without changing the URL. Reuses the
-  // existing `metaQuery` + fill-if-empty effect + ListingAssetStep suggestions, so it's
-  // non-destructive by construction (typed text and attached assets are never clobbered).
-  function handleAutofillFromWebsite() {
-    const result = normalizeLinkUrl(values.externalUrl);
-    if (result.error) {
-      // A bad/blank URL never fires a fetch (the button is also disabled in this state).
-      setErrors((prev) => ({ ...prev, externalUrl: result.error }));
-      return;
-    }
-    setField('externalUrl', result.url);
-    setErrors((prev) => ({ ...prev, externalUrl: undefined }));
-    setAutofillNote(null);
-    setAutofillActive(true);
-    appliedMetaRef.current = null; // force the idempotent apply effect to re-run
-    if (result.url === metaUrl) {
-      // SAME url: `setMetaUrl` is a no-op and (staleTime:Infinity + retry:false) the cached
-      // success/error won't re-fetch on its own — so a previously-ERRORED url could never be
-      // retried via the button. `refetch()` re-attempts the fetch; on a cached success it
-      // re-applies from data and the tick below re-runs the effect. No loop: `refetch()`
-      // synchronously flips `isFetching` true, so the tick-driven effect run bails on the
-      // isFetching guard and only applies once the (re)fetch settles.
-      void metaQuery.refetch();
-    } else {
-      setMetaUrl(result.url); // NEW url → the query fires for it
-    }
-    setAutofillTick((t) => t + 1); // bump a tick so the effect re-applies even when metaUrl is unchanged
   }
 
   async function finishSave() {
@@ -355,10 +251,6 @@ export function ExternalListingEditForm({ edit }: { edit: ListingEditContext }) 
     }
   }
 
-  // Gate the Autofill button on a valid, normalizable URL (empty/invalid → disabled, no
-  // wasted fetch). Cheap enough to derive per render.
-  const autofillUrl = normalizeLinkUrl(values.externalUrl);
-
   return (
     <Stack gap="md" data-testid="apps-offsite-edit-form">
       <Alert
@@ -429,7 +321,7 @@ export function ExternalListingEditForm({ edit }: { edit: ListingEditContext }) 
                 value={values.externalUrl}
                 onChange={(e) => {
                   setField('externalUrl', e.currentTarget.value);
-                  setAutofillNote(null);
+                  autofill.clearNote();
                 }}
                 onBlur={handleUrlBlur}
                 onKeyDown={handleUrlKeyDown}
@@ -451,36 +343,39 @@ export function ExternalListingEditForm({ edit }: { edit: ListingEditContext }) 
                   </Text>
                 </Alert>
               )}
-              {/* On-demand OG re-pull: fills only-empty name/tagline/description and re-surfaces
-                  icon/cover suggestions for empty slots on the Assets step. Non-destructive. */}
-              <Group gap="xs" align="center">
-                <Button
-                  variant="light"
-                  color="grape"
-                  leftSection={<IconSparkles size={16} />}
-                  onClick={handleAutofillFromWebsite}
-                  disabled={!!autofillUrl.error}
-                  loading={autofillActive && metaQuery.isFetching}
-                  data-testid="apps-offsite-edit-autofill"
-                >
-                  Autofill from website
-                </Button>
-                <Text size="xs" c="dimmed">
-                  Re-scan your link for a name, description, icon and cover — only empty fields and
-                  slots are filled.
-                </Text>
-              </Group>
-              {autofillNote === 'error' && (
+              {/* The OG pull auto-fires when the URL changes to a valid https URL (blur,
+                  Enter, Next, or a debounced pause) — no manual button. A subtle inline
+                  status reports loading / applied / partial / empty / error. The
+                  assets-step "Re-pull from site" button is the manual retry. */}
+              {autofill.loading && (
+                <Group gap={6} data-testid="apps-offsite-edit-meta-loading">
+                  <Loader size={12} />
+                  <Text size="xs" c="dimmed">
+                    Looking for a name, description and images from your link…
+                  </Text>
+                </Group>
+              )}
+              {!autofill.loading && autofill.result?.status === 'error' && (
                 <Text size="xs" c="red" data-testid="apps-offsite-edit-autofill-error">
                   Couldn’t read that site’s details.
                 </Text>
               )}
-              {autofillNote === 'empty' && (
+              {!autofill.loading && autofill.result?.status === 'empty' && (
                 <Text size="xs" c="dimmed" data-testid="apps-offsite-edit-autofill-empty">
-                  Nothing to autofill — your details and assets are already set.
+                  {autofill.result.siteExposedNothing
+                    ? 'Your site didn’t expose a name, description, icon or cover to pull — add them manually.'
+                    : 'Nothing to autofill — your details and assets are already set.'}
                 </Text>
               )}
-              {autofillNote === 'applied' && (
+              {!autofill.loading && autofill.result?.status === 'partial' && (
+                <Text size="xs" c="dimmed" data-testid="apps-offsite-edit-autofill-partial">
+                  Pulled what your link exposed — {describeMissingChannels(autofill.result.missing)}{' '}
+                  {(autofill.result.missing?.length ?? 0) > 1 ? 'were' : 'was'} not found; add{' '}
+                  {(autofill.result.missing?.length ?? 0) > 1 ? 'those' : 'that'} manually. Check the
+                  Details and Assets steps for what we found.
+                </Text>
+              )}
+              {!autofill.loading && autofill.result?.status === 'applied' && (
                 <Alert
                   color="grape"
                   variant="light"
@@ -609,7 +504,9 @@ export function ExternalListingEditForm({ edit }: { edit: ListingEditContext }) 
               <ListingAssetStep
                 listingId={effectiveId}
                 contentRating={values.contentRating}
-                suggestions={suggestions}
+                suggestions={autofill.suggestions}
+                onRepull={autofill.repull}
+                repullLoading={autofill.loading}
                 initial={edit.assets}
                 allowRemove
                 onAssetMutated={() => setAssetsDirty(true)}

--- a/src/components/Apps/ExternalSubmitForm.browser.test.tsx
+++ b/src/components/Apps/ExternalSubmitForm.browser.test.tsx
@@ -83,6 +83,7 @@ vi.mock('~/utils/trpc', () => {
         },
         persistAssetImage: { useMutation: mutation },
         ingestAssetFromUrl: { useMutation: mutation },
+        ingestAssetFromDataUri: { useMutation: mutation },
         setIcon: { useMutation: mutation },
         setCover: { useMutation: mutation },
         addScreenshot: { useMutation: mutation },
@@ -428,38 +429,33 @@ describe('ExternalSubmitForm — OAuth step: mod global-search + create deeplink
 });
 
 /**
- * "Pull from site" button (create wizard). The auto-pull fires ONCE per URL
- * (`appliedMetaRef` guard) and `staleTime:Infinity` + `retry:false` pin the result, so a
- * first-time empty / errored / not-ready pull (or a client-rendered SPA that exposes no
- * server-side OG tags — #3344) could never be retried without editing the URL. This
- * button re-runs the OG pull on demand for the CURRENT url, applies name/tagline/
- * description fill-if-empty, and re-surfaces the icon/cover suggestions on the Assets
- * step. Mirrors the edit wizard's "Autofill from website".
+ * Auto-trigger + inline status + assets-step "Re-pull from site" (create wizard).
+ * The manual "Pull from site" button was REMOVED: entering a valid https URL now
+ * auto-fires the OG pull (on blur / advance), a subtle inline status reports the
+ * four-state outcome (applied / partial / empty / error), and the assets step carries
+ * the sole manual retry. Also covers the inline data-URI icon suggestion (radio case).
  */
-describe('ExternalSubmitForm — create "Pull from site" button', () => {
-  /** Drive the wizard URL → App → Details → create draft → Assets. */
+describe('ExternalSubmitForm — auto-trigger, status, re-pull, data-URI icon', () => {
+  /** Fill a URL + advance to the App step (blur auto-fires the pull). */
+  async function fillUrlAndAdvance(url: string) {
+    await page.getByTestId('apps-offsite-submit-url').fill(url);
+    await page.getByTestId('apps-offsite-submit-url').element().blur();
+    await page.getByTestId('apps-offsite-wizard-next-url').click();
+  }
+  /** Drive URL → App → Details → create draft → Assets. */
   async function reachAssets() {
     await pickClient();
     await page.getByTestId('apps-offsite-wizard-next-app').click();
     await page.getByRole('button', { name: 'Create draft' }).click();
   }
 
-  test('renders on the URL step (create mode), enabled once a valid https URL is entered', async () => {
+  test('the manual "Pull from site" button is GONE (auto-trigger replaces it)', async () => {
     renderWithProviders(<ExternalSubmitForm />);
-    const btn = page.getByTestId('apps-offsite-submit-autofill');
-    // Blank URL → disabled (no wasted fetch).
-    await expect.element(btn).toBeDisabled();
     await page.getByTestId('apps-offsite-submit-url').fill('https://vitrine.civitai.com');
-    await expect.element(btn).toBeEnabled();
+    expect(page.getByTestId('apps-offsite-submit-autofill').elements()).toHaveLength(0);
   });
 
-  test('is DISABLED for a non-https URL', async () => {
-    renderWithProviders(<ExternalSubmitForm />);
-    await page.getByTestId('apps-offsite-submit-url').fill('http://insecure.example.com');
-    await expect.element(page.getByTestId('apps-offsite-submit-autofill')).toBeDisabled();
-  });
-
-  test('clicking it pulls meta, applies fill-if-empty name/description, and surfaces the "applied" note', async () => {
+  test('entering a valid URL auto-fires the pull (on blur): fills empty name/description + shows the applied note', async () => {
     mocks.meta = {
       data: {
         name: 'Civitai Cosmetic Studio',
@@ -473,11 +469,11 @@ describe('ExternalSubmitForm — create "Pull from site" button', () => {
     };
     renderWithProviders(<ExternalSubmitForm />);
     await page.getByTestId('apps-offsite-submit-url').fill('https://cosmetic-studio.civitai.com');
-    await page.getByTestId('apps-offsite-submit-autofill').click();
+    await page.getByTestId('apps-offsite-submit-url').element().blur();
+    // The applied note appears WITHOUT any button click — the pull auto-fired on blur.
     await expect
       .element(page.getByTestId('apps-offsite-submit-autofill-applied'))
       .toBeInTheDocument();
-    // Advance to Details — the pulled title + description filled the empty fields.
     await pickClient();
     await page.getByTestId('apps-offsite-wizard-next-app').click();
     await expect
@@ -488,75 +484,40 @@ describe('ExternalSubmitForm — create "Pull from site" button', () => {
       .toHaveValue('Pulled from the link.');
   });
 
-  test('the pulled icon/cover suggestions flow to the Assets step (Use this previews)', async () => {
+  test('a site exposing SOME channels shows the honest PARTIAL note (radio: title + icon, no cover/description)', async () => {
     mocks.meta = {
       data: {
-        name: 'Vitrine',
-        tagline: undefined,
-        description: undefined,
-        coverImageUrl: 'https://cdn/og-cover.png',
-        iconImageUrl: 'https://cdn/og-icon.png',
+        name: 'AI Radio',
+        iconDataUri: 'data:image/svg+xml,%3Csvg%2F%3E',
       },
       isFetching: false,
       isSuccess: true,
     };
     renderWithProviders(<ExternalSubmitForm />);
-    await page.getByTestId('apps-offsite-submit-url').fill('https://vitrine.civitai.com');
-    await page.getByTestId('apps-offsite-submit-autofill').click();
+    await page.getByTestId('apps-offsite-submit-url').fill('https://radio.example.com');
+    await page.getByTestId('apps-offsite-submit-url').element().blur();
     await expect
-      .element(page.getByTestId('apps-offsite-submit-autofill-applied'))
+      .element(page.getByTestId('apps-offsite-submit-autofill-partial'))
       .toBeInTheDocument();
-    await reachAssets();
-    // The empty icon + cover slots offer the pulled OG suggestion via "Use this".
-    await expect.element(page.getByTestId('apps-offsite-accept-icon')).toBeInTheDocument();
-    await expect.element(page.getByTestId('apps-offsite-accept-cover')).toBeInTheDocument();
-    await expect
-      .element(page.getByTestId('apps-offsite-suggested-icon-preview'))
-      .toBeInTheDocument();
+    // NOT a spurious applied/empty.
+    expect(page.getByTestId('apps-offsite-submit-autofill-applied').elements()).toHaveLength(0);
   });
 
-  test('does NOT clobber a name the user already typed', async () => {
-    // Reach Details with no meta applied, type a name, go back, then Pull from site.
-    mocks.meta = { data: undefined, isFetching: false, isSuccess: false };
-    renderWithProviders(<ExternalSubmitForm />);
-    await advanceFromUrl('https://vitrine.civitai.com');
-    await pickClient();
-    await page.getByTestId('apps-offsite-wizard-next-app').click();
-    await page.getByTestId('apps-offsite-submit-name').fill('User Typed Name');
-    // Back to the URL step and pull — the meta now carries a title.
-    await page.getByTestId('apps-offsite-wizard-back-details').click();
-    await page.getByTestId('apps-offsite-wizard-back-app').click();
-    mocks.meta = {
-      data: { name: 'OG Title', tagline: undefined, description: undefined, coverImageUrl: undefined, iconImageUrl: undefined },
-      isFetching: false,
-      isSuccess: true,
-    };
-    await page.getByTestId('apps-offsite-submit-autofill').click();
-    // The typed name is preserved (fill-if-empty).
-    await pickClient();
-    await page.getByTestId('apps-offsite-wizard-next-app').click();
-    await expect
-      .element(page.getByTestId('apps-offsite-submit-name'))
-      .toHaveValue('User Typed Name');
-  });
-
-  test('a site that exposed NOTHING (SPA #3344) shows the honest empty note', async () => {
-    // Empty data — the pull surfaces no icon/cover/description; the host-derived name
-    // fallback is not counted as "pulled from the site", so the note is the honest empty.
+  test('a site that exposed NOTHING (SPA #3344) shows the honest empty note — never "already filled"', async () => {
     mocks.meta = { data: {}, isFetching: false, isSuccess: true };
     renderWithProviders(<ExternalSubmitForm />);
     await page.getByTestId('apps-offsite-submit-url').fill('https://spa.example.com');
-    await page.getByTestId('apps-offsite-submit-autofill').click();
+    await page.getByTestId('apps-offsite-submit-url').element().blur();
     await expect
       .element(page.getByTestId('apps-offsite-submit-autofill-empty'))
       .toBeInTheDocument();
   });
 
-  test('an ERRORED pull shows the error note (no spurious applied/empty)', async () => {
+  test('an ERRORED pull shows the error note (no spurious applied/empty/partial)', async () => {
     mocks.meta = { data: undefined, isFetching: false, isSuccess: false, isError: true };
     renderWithProviders(<ExternalSubmitForm />);
     await page.getByTestId('apps-offsite-submit-url').fill('https://broken.example.com');
-    await page.getByTestId('apps-offsite-submit-autofill').click();
+    await page.getByTestId('apps-offsite-submit-url').element().blur();
     await expect
       .element(page.getByTestId('apps-offsite-submit-autofill-error'))
       .toBeInTheDocument();
@@ -564,27 +525,86 @@ describe('ExternalSubmitForm — create "Pull from site" button', () => {
     expect(page.getByTestId('apps-offsite-submit-autofill-empty').elements()).toHaveLength(0);
   });
 
-  test('re-clicking with the SAME url bypasses the once-per-url guard via refetch()', async () => {
+  test('the pulled https icon/cover suggestions flow to the Assets step (Use this previews)', async () => {
     mocks.meta = {
-      data: { name: 'Vitrine', tagline: undefined, description: undefined, coverImageUrl: 'https://cdn/og-cover.png', iconImageUrl: 'https://cdn/og-icon.png' },
+      data: {
+        name: 'Vitrine',
+        coverImageUrl: 'https://cdn/og-cover.png',
+        iconImageUrl: 'https://cdn/og-icon.png',
+      },
       isFetching: false,
       isSuccess: true,
     };
     renderWithProviders(<ExternalSubmitForm />);
-    await page.getByTestId('apps-offsite-submit-url').fill('https://vitrine.civitai.com');
-    await page.getByTestId('apps-offsite-submit-url').element().blur(); // sets metaUrl via the auto-pull path
-
-    // FIRST click: metaUrl already set by blur → same-url path → refetch().
-    await page.getByTestId('apps-offsite-submit-autofill').click();
+    await fillUrlAndAdvance('https://vitrine.civitai.com');
+    await reachAssets();
+    await expect.element(page.getByTestId('apps-offsite-accept-icon')).toBeInTheDocument();
+    await expect.element(page.getByTestId('apps-offsite-accept-cover')).toBeInTheDocument();
     await expect
-      .element(page.getByTestId('apps-offsite-submit-autofill-applied'))
+      .element(page.getByTestId('apps-offsite-suggested-icon-preview'))
       .toBeInTheDocument();
-    await vi.waitFor(() => expect(mocks.refetch).toHaveBeenCalled());
-    const firstCount = mocks.refetch.mock.calls.length;
+  });
 
-    // SECOND click, url UNCHANGED: the once-per-url guard would block a re-apply, so the
-    // retry MUST go through refetch() again — proving the guard is bypassed on a manual pull.
-    await page.getByTestId('apps-offsite-submit-autofill').click();
-    await vi.waitFor(() => expect(mocks.refetch.mock.calls.length).toBeGreaterThan(firstCount));
+  test('an inline data-URI icon (radio) surfaces as an icon "Use this" tile on the Assets step', async () => {
+    mocks.meta = {
+      data: {
+        name: 'AI Radio',
+        iconDataUri: 'data:image/svg+xml,%3Csvg%2F%3E',
+      },
+      isFetching: false,
+      isSuccess: true,
+    };
+    renderWithProviders(<ExternalSubmitForm />);
+    await fillUrlAndAdvance('https://radio.example.com');
+    await reachAssets();
+    // The inline data-URI icon offers an accept tile even though there's no https icon URL.
+    await expect.element(page.getByTestId('apps-offsite-accept-icon')).toBeInTheDocument();
+    await expect
+      .element(page.getByTestId('apps-offsite-suggested-icon-preview'))
+      .toBeInTheDocument();
+    // No cover suggestion (the site exposed none).
+    expect(page.getByTestId('apps-offsite-accept-cover').elements()).toHaveLength(0);
+  });
+
+  test('the assets-step "Re-pull from site" button invokes repull (refetch of the current url)', async () => {
+    mocks.meta = {
+      data: {
+        name: 'Vitrine',
+        coverImageUrl: 'https://cdn/og-cover.png',
+        iconImageUrl: 'https://cdn/og-icon.png',
+      },
+      isFetching: false,
+      isSuccess: true,
+    };
+    renderWithProviders(<ExternalSubmitForm />);
+    await fillUrlAndAdvance('https://vitrine.civitai.com');
+    await reachAssets();
+    const repull = page.getByTestId('apps-offsite-assets-repull');
+    await expect.element(repull).toBeInTheDocument();
+    // The URL was fired via setMetaUrl (new url), so a repull of the SAME url must
+    // refetch — proving the button re-runs the query.
+    mocks.refetch.mockClear();
+    await repull.click();
+    await vi.waitFor(() => expect(mocks.refetch).toHaveBeenCalled());
+  });
+
+  test('does NOT clobber a name the user already typed', async () => {
+    // Reach Details with no meta applied, type a name, then a later settled pull must not clobber.
+    mocks.meta = { data: undefined, isFetching: false, isSuccess: false };
+    renderWithProviders(<ExternalSubmitForm />);
+    await advanceFromUrl('https://vitrine.civitai.com');
+    await pickClient();
+    await page.getByTestId('apps-offsite-wizard-next-app').click();
+    await page.getByTestId('apps-offsite-submit-name').fill('User Typed Name');
+    // A later re-render with settled meta carrying a title must respect the typed name.
+    mocks.meta = {
+      data: { name: 'OG Title' },
+      isFetching: false,
+      isSuccess: true,
+    };
+    await page.getByRole('textbox', { name: /^Tagline/ }).fill('trigger a re-render');
+    await expect
+      .element(page.getByTestId('apps-offsite-submit-name'))
+      .toHaveValue('User Typed Name');
   });
 });

--- a/src/components/Apps/ExternalSubmitForm.edit.browser.test.tsx
+++ b/src/components/Apps/ExternalSubmitForm.edit.browser.test.tsx
@@ -65,6 +65,7 @@ vi.mock('~/utils/trpc', () => {
         // ListingAssetStep procs not otherwise exercised.
         persistAssetImage: { useMutation: noopMutation },
         ingestAssetFromUrl: { useMutation: noopMutation },
+        ingestAssetFromDataUri: { useMutation: noopMutation },
         setIcon: { useMutation: noopMutation },
         setCover: { useMutation: noopMutation },
         addScreenshot: { useMutation: noopMutation },
@@ -316,13 +317,13 @@ describe('ExternalSubmitForm — edit mode', () => {
   });
 });
 
+
 /**
- * "Autofill from website" button (edit-only). Closes the gap where the edit-mode OG
- * pull fired ONLY on a URL change, so a listing whose icon/cover ended up empty could
- * never re-surface suggestions without editing the URL. Clicking the button re-runs
- * the existing fetch → fill-if-empty effect → ListingAssetStep suggestions, WITHOUT
- * changing the URL. Non-destructive by construction (typed text + attached assets are
- * never clobbered — proven by the "empty" note when nothing is fillable).
+ * Auto-trigger + assets-step "Re-pull from site" (edit wizard). The manual "Autofill
+ * from website" button was REMOVED: a CHANGE of the App URL to a valid https URL now
+ * auto-fires the OG pull (the prefilled URL does NOT auto-fire on mount), a subtle
+ * inline status reports the four-state outcome, and the assets step carries the manual
+ * retry. Non-destructive: a suggestion is only actionable for an EMPTY slot.
  */
 function makeEmptyAssetsCtx(overrides: Partial<ListingEditContext> = {}): ListingEditContext {
   return makeCtx({
@@ -335,148 +336,72 @@ function makeEmptyAssetsCtx(overrides: Partial<ListingEditContext> = {}): Listin
   });
 }
 
-describe('ExternalSubmitForm — edit mode "Autofill from website" button', () => {
-  test('clicking it (URL unchanged) pulls meta and surfaces "Use this" icon/cover suggestions for EMPTY slots', async () => {
-    mocks.meta = {
-      data: {
-        name: undefined,
-        tagline: undefined,
-        description: undefined,
-        coverImageUrl: 'https://cdn/og-cover.png',
-        iconImageUrl: 'https://cdn/og-icon.png',
-      },
-      isFetching: false,
-      isSuccess: true,
-    };
-    // Assets start EMPTY (the gap this fixes) — the URL is already prefilled, unchanged.
+describe('ExternalSubmitForm — edit mode auto-trigger + re-pull', () => {
+  const fullMeta = {
+    data: {
+      description: 'Pulled description',
+      coverImageUrl: 'https://cdn/og-cover.png',
+      iconImageUrl: 'https://cdn/og-icon.png',
+    },
+    isFetching: false,
+    isSuccess: true,
+  };
+
+  test('the manual "Autofill from website" button is GONE (auto-trigger replaces it)', async () => {
     renderWithProviders(<ExternalSubmitForm edit={makeEmptyAssetsCtx()} />);
-    await page.getByTestId('apps-offsite-edit-autofill').click();
-    // The URL step shows the "applied" note; then navigate URL → Details → Assets.
-    await expect.element(page.getByTestId('apps-offsite-edit-autofill-applied')).toBeInTheDocument();
+    expect(page.getByTestId('apps-offsite-edit-autofill').elements()).toHaveLength(0);
+  });
+
+  test('CHANGING the URL to a new valid URL auto-fires and surfaces "Use this" icon/cover for EMPTY slots', async () => {
+    mocks.meta = fullMeta;
+    renderWithProviders(<ExternalSubmitForm edit={makeEmptyAssetsCtx()} />);
+    // Change the prefilled URL to a NEW one and blur → auto-fire.
+    await page.getByTestId('apps-offsite-edit-url').fill('https://new-url.example.com');
+    await page.getByTestId('apps-offsite-edit-url').element().blur();
+    await expect
+      .element(page.getByTestId('apps-offsite-edit-autofill-applied'))
+      .toBeInTheDocument();
+    // URL → Details → Assets.
     await page.getByRole('button', { name: 'Next' }).click();
     await page.getByRole('button', { name: 'Next' }).click();
-    // The empty icon + cover slots now offer the OG suggestion via "Use this".
     await expect.element(page.getByTestId('apps-offsite-accept-icon')).toBeInTheDocument();
     await expect.element(page.getByTestId('apps-offsite-accept-cover')).toBeInTheDocument();
+  });
+
+  test('a fully-populated listing + a URL change shows the honest empty (already-set) note, not "applied"', async () => {
+    // The listing already has an attached icon + cover; a suggestion for a filled slot
+    // is not actionable, so the note is the honest "already set", never "applied".
+    mocks.meta = fullMeta;
+    renderWithProviders(<ExternalSubmitForm edit={makeCtx()} />);
+    await page.getByTestId('apps-offsite-edit-url').fill('https://new-url.example.com');
+    await page.getByTestId('apps-offsite-edit-url').element().blur();
     await expect
-      .element(page.getByTestId('apps-offsite-suggested-icon-preview'))
+      .element(page.getByTestId('apps-offsite-edit-autofill-empty'))
       .toBeInTheDocument();
-  });
-
-  test('is DISABLED when the App URL is blank (no wasted fetch)', async () => {
-    const ctx = makeCtx({
-      scalars: {
-        name: 'Vitrine',
-        tagline: null,
-        description: null,
-        category: null,
-        contentRating: 'g',
-        externalUrl: '', // pre-existing blank URL
-      },
-    });
-    renderWithProviders(<ExternalSubmitForm edit={ctx} />);
-    await expect.element(page.getByTestId('apps-offsite-edit-autofill')).toBeDisabled();
-  });
-
-  test('is DISABLED when the App URL is invalid (non-https)', async () => {
-    const ctx = makeCtx({
-      scalars: {
-        name: 'Vitrine',
-        tagline: null,
-        description: null,
-        category: null,
-        contentRating: 'g',
-        externalUrl: 'http://insecure.example.com',
-      },
-    });
-    renderWithProviders(<ExternalSubmitForm edit={ctx} />);
-    await expect.element(page.getByTestId('apps-offsite-edit-autofill')).toBeDisabled();
-  });
-
-  test('shows a "Nothing to autofill" note when the pull yields nothing fillable', async () => {
-    // Fully-populated listing (name/tagline/description + attached icon/cover) and a
-    // meta pull with no suggestions and nothing to fill → the empty note, NOT a clobber.
-    mocks.meta = { data: {}, isFetching: false, isSuccess: true };
-    renderWithProviders(<ExternalSubmitForm edit={makeCtx()} />);
-    await page.getByTestId('apps-offsite-edit-autofill').click();
-    await expect.element(page.getByTestId('apps-offsite-edit-autofill-empty')).toBeInTheDocument();
-    // The prefilled name is untouched.
-    await page.getByRole('button', { name: 'Next' }).click();
-    await expect.element(page.getByRole('textbox', { name: /^Name/ })).toHaveValue('Vitrine');
-  });
-
-  test('does NOT claim "applied" when a suggestion targets an already-FILLED slot', async () => {
-    // A fully-populated listing (icon+cover attached in the prefill) + a meta pull that
-    // carries icon/cover URLs but nothing fillable. ListingAssetStep renders NO "Use this"
-    // for a filled slot, so the note must be the honest "Nothing to autofill", not "applied".
-    mocks.meta = {
-      data: {
-        name: undefined,
-        tagline: undefined,
-        description: undefined,
-        coverImageUrl: 'https://cdn/og-cover.png',
-        iconImageUrl: 'https://cdn/og-icon.png',
-      },
-      isFetching: false,
-      isSuccess: true,
-    };
-    renderWithProviders(<ExternalSubmitForm edit={makeCtx()} />);
-    await page.getByTestId('apps-offsite-edit-autofill').click();
-    await expect.element(page.getByTestId('apps-offsite-edit-autofill-empty')).toBeInTheDocument();
     expect(page.getByTestId('apps-offsite-edit-autofill-applied').elements()).toHaveLength(0);
   });
 
-  test('re-clicking with the SAME url re-surfaces the icon/cover suggestions (tick + refetch, from cache)', async () => {
-    // The PR's headline mechanism: the OG pull fires only on a URL CHANGE, so re-pulling
-    // the SAME url must go through the button's `autofillTick` + `appliedMetaRef` reset (and,
-    // once `metaUrl` is already set, a `metaQuery.refetch()`). Assets start EMPTY.
-    mocks.meta = {
-      data: {
-        name: undefined,
-        tagline: undefined,
-        description: undefined,
-        coverImageUrl: 'https://cdn/og-cover.png',
-        iconImageUrl: 'https://cdn/og-icon.png',
-      },
-      isFetching: false,
-      isSuccess: true,
-    };
+  test('the assets-step "Re-pull from site" button re-runs the pull and surfaces suggestions for empty slots', async () => {
+    mocks.meta = fullMeta;
     renderWithProviders(<ExternalSubmitForm edit={makeEmptyAssetsCtx()} />);
-
-    // FIRST click: `metaUrl` was null, so this SETS it (not a refetch) and applies.
-    await page.getByTestId('apps-offsite-edit-autofill').click();
-    await expect.element(page.getByTestId('apps-offsite-edit-autofill-applied')).toBeInTheDocument();
-    expect(mocks.refetch).not.toHaveBeenCalled();
-
-    // SECOND click, url UNCHANGED: `setMetaUrl(sameUrl)` is a no-op, so the retry MUST go
-    // through `refetch()` + the tick-driven re-apply — proving the same-url path works.
-    await page.getByTestId('apps-offsite-edit-autofill').click();
-    await vi.waitFor(() => expect(mocks.refetch).toHaveBeenCalledTimes(1));
-    await expect.element(page.getByTestId('apps-offsite-edit-autofill-applied')).toBeInTheDocument();
-
-    // The re-applied suggestions still surface "Use this" on the empty icon + cover slots.
+    // Navigate to Assets WITHOUT changing the URL — the prefilled URL does not auto-fire
+    // on mount, so no suggestions yet.
     await page.getByRole('button', { name: 'Next' }).click();
     await page.getByRole('button', { name: 'Next' }).click();
+    expect(page.getByTestId('apps-offsite-accept-icon').elements()).toHaveLength(0);
+    // Re-pull fires the query → suggestions surface as accept tiles.
+    await page.getByTestId('apps-offsite-assets-repull').click();
     await expect.element(page.getByTestId('apps-offsite-accept-icon')).toBeInTheDocument();
     await expect.element(page.getByTestId('apps-offsite-accept-cover')).toBeInTheDocument();
   });
 
-  test('an ERRORED OG fetch shows the error note, sets NO applied/empty note, and a re-click refetches', async () => {
-    // The 🟡 fix: on a failed fetch the effect must SETTLE (via isError), reset the active
-    // flag, and surface the error via the settled note (tied to this url) — never a spurious
-    // "applied"/"empty". And because staleTime:Infinity + retry:false pins the cached error,
-    // a re-click must `refetch()` so a transient failure is retryable without editing the URL.
+  test('an errored pull (via a URL change) shows the error note', async () => {
     mocks.meta = { data: undefined, isFetching: false, isError: true };
     renderWithProviders(<ExternalSubmitForm edit={makeEmptyAssetsCtx()} />);
-
-    await page.getByTestId('apps-offsite-edit-autofill').click();
-    await expect.element(page.getByTestId('apps-offsite-edit-autofill-error')).toBeInTheDocument();
-    // No spurious success/empty note co-renders with the error.
-    expect(page.getByTestId('apps-offsite-edit-autofill-applied').elements()).toHaveLength(0);
-    expect(page.getByTestId('apps-offsite-edit-autofill-empty').elements()).toHaveLength(0);
-
-    // Re-click the SAME (errored) url → a refetch fires so the user can retry.
-    await page.getByTestId('apps-offsite-edit-autofill').click();
-    await vi.waitFor(() => expect(mocks.refetch).toHaveBeenCalledTimes(1));
+    await page.getByTestId('apps-offsite-edit-url').fill('https://broken.example.com');
+    await page.getByTestId('apps-offsite-edit-url').element().blur();
+    await expect
+      .element(page.getByTestId('apps-offsite-edit-autofill-error'))
+      .toBeInTheDocument();
   });
 });

--- a/src/components/Apps/ExternalSubmitForm.tsx
+++ b/src/components/Apps/ExternalSubmitForm.tsx
@@ -24,13 +24,7 @@ import {
   IconWorld,
 } from '@tabler/icons-react';
 import Link from 'next/link';
-import {
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-  type KeyboardEvent as ReactKeyboardEvent,
-} from 'react';
+import { useMemo, useRef, useState, type KeyboardEvent as ReactKeyboardEvent } from 'react';
 import {
   OFFSITE_CATEGORY_OPTIONS,
   OFFSITE_CONTENT_RATING_OPTIONS,
@@ -41,14 +35,15 @@ import {
   isClientStepComplete,
   isCreateDetailsStepComplete,
   isCreateUrlStepComplete,
-  normalizeLinkUrl,
   toSubmitExternalInput,
   validateExternalCreateForm,
   type OffsiteSubmitFormErrors,
   type OffsiteSubmitFormValues,
 } from '~/components/Apps/offsiteSubmitFormConfig';
 import { DerivedScopesDisclosure } from '~/components/Apps/DerivedScopesDisclosure';
-import { ListingAssetStep, type MetaSuggestions } from '~/components/Apps/ListingAssetStep';
+import { ListingAssetStep } from '~/components/Apps/ListingAssetStep';
+import { describeMissingChannels } from '~/components/Apps/listingAutofillStatus';
+import { useListingAutofill } from '~/components/Apps/useListingAutofill';
 import { ExternalListingEditForm } from '~/components/Apps/ExternalListingEditForm';
 import { FadeIn } from '~/components/Apps/wizardMotion';
 import type { ListingEditContext } from '~/components/Apps/offsiteEditConfig';
@@ -126,32 +121,16 @@ function ExternalCreateForm() {
   // SENSITIVE justification surfaces its required error at once.
   const [showScopeErrors, setShowScopeErrors] = useState(false);
 
-  // App-URL metadata auto-pull: once a valid URL is entered, fetch the target page's
-  // OG metadata SERVER-side (SSRF-safe) and surface prefill + asset suggestions.
-  const [metaUrl, setMetaUrl] = useState<string | null>(null);
-  const [suggestions, setSuggestions] = useState<MetaSuggestions>({});
-  const [autofillApplied, setAutofillApplied] = useState(false);
-  const appliedMetaRef = useRef<string | null>(null);
-  // Host-derived name kept as a FALLBACK only — used to fill `name` when the OG-meta
-  // fetch settles with no usable `<title>`. The real page title is preferred (see the
-  // meta effect); we never seed this up front so the title can win.
+  // App-URL metadata auto-pull is owned by the shared `useListingAutofill` hook
+  // (declared below `applyNormalizedUrl`): once a valid https URL is entered — on blur,
+  // Enter, step-advance, OR a debounced pause in typing — it fetches the target page's
+  // OG metadata SERVER-side (SSRF-safe) and surfaces fill-if-empty prefill + asset
+  // suggestions. Host-derived name kept as a FALLBACK only — used to fill `name` when
+  // the OG-meta fetch settles with no usable `<title>` (the real page title is
+  // preferred); never seeded up front so the title can win.
   const hostNameFallbackRef = useRef<string>('');
-
-  // On-demand "Pull from site" (create parity with the edit wizard's "Autofill from
-  // website"): the auto-pull fires ONCE per URL (`appliedMetaRef` guard) and
-  // `staleTime:Infinity` + `retry:false` pin the result, so a first-time
-  // empty / errored / not-ready pull could NEVER be re-surfaced without editing the URL
-  // (and a client-rendered SPA that exposes no server-side OG tags legitimately returns
-  // nothing — #3344). `autofillActive` tracks a button-triggered pull (drives the
-  // loading/note feedback); `autofillTick` forces the apply effect to re-run on a
-  // re-click of the SAME url (unchanged `metaUrl` + a cached `metaQuery.data` reference
-  // otherwise skip it). `autofillNote` reports applied / empty / error near the URL input.
-  const [autofillActive, setAutofillActive] = useState(false);
-  const [autofillTick, setAutofillTick] = useState(0);
-  const [autofillNote, setAutofillNote] = useState<'applied' | 'empty' | 'error' | null>(null);
-  // Latest `values` for the button-note emptiness check — the effect must read current
-  // emptiness WITHOUT depending on `values` (its async `setValues` updater hasn't run
-  // yet when the note is computed), mirroring the edit wizard's `valuesRef`.
+  // Latest `values` for the hook's emptiness reads (its async `setValues` updater hasn't
+  // committed yet when the status note is computed).
   const valuesRef = useRef(values);
   valuesRef.current = values;
 
@@ -219,80 +198,18 @@ function ExternalCreateForm() {
     : ownSelectedClient;
   const allowedScopes = selectedClient?.allowedScopes ?? 0;
 
-  const metaQuery = trpc.appListings.fetchListingMetaFromUrl.useQuery(
-    { url: metaUrl ?? '' },
-    { enabled: !!metaUrl, retry: false, refetchOnWindowFocus: false, staleTime: Infinity }
-  );
-
-  // Apply the OG-meta prefill ONCE per settled URL. Runs only after the fetch settles
-  // (success OR error) for the current `metaUrl`, so the real page `<title>`
-  // (`data.name`) has a chance to arrive before we touch the `name` field — the Name
-  // input lives on the later Details step, so the fetch has time. NAME precedence:
-  // prefer the extracted `<title>`; if the fetch yields none (or errors), fall back to
-  // the host-derived name. Every field is fill-if-empty, so typed text is never
-  // clobbered.
-  useEffect(() => {
-    if (!metaUrl || appliedMetaRef.current === metaUrl) return;
-    // Wait until the fetch settles for THIS url. With a per-url cache key + retry:false,
-    // `metaQuery.data` (when present) belongs to `metaUrl`, and `isError` is its result.
-    if (metaQuery.isFetching) return;
-    const data = metaQuery.data;
-    const settled = !!data || metaQuery.isError;
-    if (!settled) return;
-    appliedMetaRef.current = metaUrl;
-
-    // Snapshot pre-apply emptiness for the button note (the async `setValues` below
-    // hasn't committed yet, so read what the fields were BEFORE this apply).
-    const before = valuesRef.current;
-
-    // Prefer the page <title> (data.name) over the host-derived fallback name.
-    const resolvedName = data?.name || hostNameFallbackRef.current;
-    setValues((v) => ({
-      ...v,
-      name: v.name.trim().length === 0 && resolvedName ? resolvedName : v.name,
-      tagline: v.tagline.trim().length === 0 && data?.tagline ? data.tagline : v.tagline,
-      // Description autofill: fill ONLY when empty, truncated to the field bound —
-      // a suggestion the author can freely edit or clear (never clobbers typed text).
-      description:
-        v.description.trim().length === 0 && data?.description
-          ? data.description.slice(0, OFFSITE_SUBMIT_LIMITS.descriptionMax)
-          : v.description,
-    }));
-    setSuggestions({ coverImageUrl: data?.coverImageUrl, iconImageUrl: data?.iconImageUrl });
-    // Reveal the "we found your details" note whenever the link yielded anything the
-    // author can accept (computed from `data` directly — NOT the async setValues
-    // updater, whose side effects haven't run yet at this point).
-    if (
-      data &&
-      (data.name || data.tagline || data.description || data.coverImageUrl || data.iconImageUrl)
-    ) {
-      setAutofillApplied(true);
-    }
-
-    // Button-triggered pull → report applied / empty / error near the URL input. Only
-    // what the SITE actually exposed counts as "applied": a fillable text field from
-    // `data.*` (NOT the host-derived name fallback, which is derived from the URL, not
-    // pulled from the site) or an icon/cover suggestion. In CREATE every asset slot
-    // starts empty, so any suggested icon/cover URL is actionable. An error-settled
-    // fetch (or a site that exposed nothing — the #3344 SPA case) reports honestly so
-    // the author knows to upload manually.
-    if (autofillActive) {
-      if (metaQuery.isError && !data) {
-        setAutofillNote('error');
-      } else {
-        const filledAny =
-          (before.name.trim().length === 0 && !!data?.name) ||
-          (before.tagline.trim().length === 0 && !!data?.tagline) ||
-          (before.description.trim().length === 0 && !!data?.description);
-        const hasSuggestion = !!data?.coverImageUrl || !!data?.iconImageUrl;
-        setAutofillNote(filledAny || hasSuggestion ? 'applied' : 'empty');
-      }
-      setAutofillActive(false);
-    }
-    // `autofillTick` is a dep so a same-url re-click (which leaves `metaUrl` + the cached
-    // `metaQuery.data` reference unchanged) still re-runs this effect — the click resets
-    // `appliedMetaRef` so the guard above passes.
-  }, [metaUrl, metaQuery.isFetching, metaQuery.data, metaQuery.isError, autofillTick, autofillActive]);
+  // Shared autofill core (auto-trigger + fill-if-empty apply + suggestions + status +
+  // repull). CREATE prefers the page <title>, falling back to the host-derived name;
+  // every asset slot starts empty so all suggestions are actionable (default). The
+  // Name input lives on the later Details step, so the fetch has time to settle before
+  // the author sees it.
+  const autofill = useListingAutofill({
+    externalUrl: values.externalUrl,
+    setValues,
+    valuesRef,
+    nameFallbackRef: hostNameFallbackRef,
+    onBeforeFire: applyNormalizedUrl,
+  });
 
   const submitMutation = trpc.appListings.submitExternalListing.useMutation({
     onSuccess: (res: Submitted) => {
@@ -359,49 +276,14 @@ function ExternalCreateForm() {
     }));
   }
 
-  // The App URL is REQUIRED. Blur tidies it into canonical https (no blocking); the
-  // required gate is enforced on advance.
+  // The App URL is REQUIRED. Blur tidies it into canonical https (no blocking) and
+  // auto-fires the OG pull via the hook (once per distinct URL); the required gate is
+  // enforced on advance. `onBeforeFire` (applyNormalizedUrl) canonicalises + derives
+  // the slug + stashes the host-name fallback when the pull fires.
   function handleUrlBlur() {
     if (values.externalUrl.trim().length === 0) return;
-    const result = normalizeLinkUrl(values.externalUrl);
-    if (result.error) {
-      setErrors((prev) => ({ ...prev, externalUrl: result.error }));
-      return;
-    }
-    applyNormalizedUrl(result.url);
-    setMetaUrl(result.url);
-    setErrors((prev) => ({ ...prev, externalUrl: undefined }));
-  }
-
-  // "Pull from site" — on-demand OG re-pull without leaving the URL step. Reuses the
-  // existing `metaQuery` + fill-if-empty apply effect + ListingAssetStep suggestions, so
-  // it's non-destructive by construction (typed text is never clobbered). This is the
-  // manual retry the auto-pull lacks: the once-per-url `appliedMetaRef` guard +
-  // `staleTime:Infinity` otherwise pin a first-time empty/errored/not-ready pull forever.
-  function handlePullFromSite() {
-    const result = normalizeLinkUrl(values.externalUrl);
-    if (result.error) {
-      // A bad/blank URL never fires a fetch (the button is also disabled in this state).
-      setErrors((prev) => ({ ...prev, externalUrl: result.error }));
-      return;
-    }
-    applyNormalizedUrl(result.url); // canonicalise URL + derive slug + stash host-name fallback
-    setErrors((prev) => ({ ...prev, externalUrl: undefined }));
-    setAutofillNote(null);
-    setAutofillActive(true);
-    appliedMetaRef.current = null; // force the idempotent apply effect to re-run
-    if (result.url === metaUrl) {
-      // SAME url: `setMetaUrl` is a no-op and (staleTime:Infinity + retry:false) the
-      // cached success/error won't re-fetch on its own — so a previously-empty/errored
-      // url could never be retried. `refetch()` re-attempts; on a cached success the
-      // tick below re-applies from data. No loop: `refetch()` synchronously flips
-      // `isFetching` true, so the tick-driven run bails on the isFetching guard and only
-      // applies once the (re)fetch settles.
-      void metaQuery.refetch();
-    } else {
-      setMetaUrl(result.url); // NEW url → the query fires for it
-    }
-    setAutofillTick((t) => t + 1); // re-run the effect even when metaUrl is unchanged
+    const { error } = autofill.triggerFromUrl(values.externalUrl);
+    setErrors((prev) => ({ ...prev, externalUrl: error }));
   }
 
   function handleAdvanceFromUrl() {
@@ -409,13 +291,11 @@ function ExternalCreateForm() {
       setErrors((prev) => ({ ...prev, externalUrl: 'Enter your app’s URL to continue.' }));
       return;
     }
-    const result = normalizeLinkUrl(values.externalUrl);
-    if (result.error) {
-      setErrors((prev) => ({ ...prev, externalUrl: result.error }));
+    const { error } = autofill.triggerFromUrl(values.externalUrl);
+    if (error) {
+      setErrors((prev) => ({ ...prev, externalUrl: error }));
       return;
     }
-    applyNormalizedUrl(result.url);
-    setMetaUrl(result.url);
     setErrors((prev) => ({ ...prev, externalUrl: undefined }));
     setActive(STEP_APP);
   }
@@ -475,9 +355,6 @@ function ExternalCreateForm() {
   }
 
   const busy = submitMutation.isPending;
-  // Gate the "Pull from site" button on a valid, normalizable URL (empty/invalid →
-  // disabled, no wasted fetch). Cheap enough to derive per render.
-  const pullUrl = normalizeLinkUrl(values.externalUrl);
   const clientOptions = clients.map((c) => ({ value: c.id, label: c.name }));
   const modClientOptions = modOptionClients.map((c) => ({
     value: c.id,
@@ -556,7 +433,10 @@ function ExternalCreateForm() {
                 data-testid="apps-offsite-submit-url"
               />
 
-              {metaQuery.isFetching && (
+              {/* The OG pull now auto-fires once a valid https URL is entered (blur,
+                  Enter, Next, or a debounced pause) — no manual button. A subtle inline
+                  status reports loading / applied / partial / empty / error. */}
+              {autofill.loading && (
                 <Group gap={6} data-testid="apps-offsite-meta-loading">
                   <Loader size={12} />
                   <Text size="xs" c="dimmed">
@@ -564,41 +444,34 @@ function ExternalCreateForm() {
                   </Text>
                 </Group>
               )}
-
-              {/* Manual "Pull from site" — an on-demand retry of the OG pull for the
-                  current URL. Fills only-empty name/tagline/description and re-surfaces
-                  the icon/cover suggestions on the Assets step. Non-destructive. */}
-              <Group gap="xs" align="center">
-                <Button
-                  variant="light"
-                  color="grape"
-                  leftSection={<IconSparkles size={16} />}
-                  onClick={handlePullFromSite}
-                  disabled={busy || !!pullUrl.error}
-                  loading={autofillActive && metaQuery.isFetching}
-                  data-testid="apps-offsite-submit-autofill"
-                >
-                  Pull from site
-                </Button>
-                <Text size="xs" c="dimmed">
-                  Pull a name, description, icon and cover from your link — only empty
-                  fields are filled; icon/cover appear on the Assets step.
-                </Text>
-              </Group>
-              {autofillNote === 'error' && (
+              {!autofill.loading && autofill.result?.status === 'error' && (
                 <Text size="xs" c="red" data-testid="apps-offsite-submit-autofill-error">
                   Couldn’t read that site’s details — check the URL, or add your images and
                   description manually.
                 </Text>
               )}
-              {autofillNote === 'empty' && (
+              {!autofill.loading && autofill.result?.status === 'empty' && (
                 <Text size="xs" c="dimmed" data-testid="apps-offsite-submit-autofill-empty">
-                  Your site didn’t expose an icon, cover or description to pull (or your
-                  fields are already filled). Add them to the page’s <Code>&lt;head&gt;</Code>,
-                  or upload images manually on the Assets step.
+                  {autofill.result.siteExposedNothing ? (
+                    <>
+                      Your site didn’t expose a name, description, icon or cover to pull. Add them
+                      to the page’s <Code>&lt;head&gt;</Code>, or add your details and images
+                      manually on the next steps.
+                    </>
+                  ) : (
+                    'Nothing new to pull — your details and assets are already set.'
+                  )}
                 </Text>
               )}
-              {autofillNote === 'applied' && (
+              {!autofill.loading && autofill.result?.status === 'partial' && (
+                <Text size="xs" c="dimmed" data-testid="apps-offsite-submit-autofill-partial">
+                  Pulled what your link exposed — {describeMissingChannels(autofill.result.missing)}{' '}
+                  {(autofill.result.missing?.length ?? 0) > 1 ? 'were' : 'was'} not found; add{' '}
+                  {(autofill.result.missing?.length ?? 0) > 1 ? 'those' : 'that'} manually. Check the
+                  Details and Assets steps for what we found.
+                </Text>
+              )}
+              {!autofill.loading && autofill.result?.status === 'applied' && (
                 <Alert
                   color="grape"
                   variant="light"
@@ -737,7 +610,7 @@ function ExternalCreateForm() {
         >
           <FadeIn>
             <Stack gap="md" mt="md">
-              {autofillApplied && (
+              {autofill.applied && (
                 <FadeIn>
                   <Alert
                     color="grape"
@@ -752,7 +625,7 @@ function ExternalCreateForm() {
                   </Alert>
                 </FadeIn>
               )}
-              {metaQuery.isFetching && (
+              {autofill.loading && (
                 <Group gap={6} data-testid="apps-offsite-meta-loading">
                   <Loader size={12} />
                   <Text size="xs" c="dimmed">
@@ -886,7 +759,9 @@ function ExternalCreateForm() {
               <ListingAssetStep
                 listingId={submitted.listingId}
                 contentRating={values.contentRating}
-                suggestions={suggestions}
+                suggestions={autofill.suggestions}
+                onRepull={autofill.repull}
+                repullLoading={autofill.loading}
                 header={
                   <Alert
                     color="green"

--- a/src/components/Apps/ListingAssetStep.tsx
+++ b/src/components/Apps/ListingAssetStep.tsx
@@ -5,6 +5,7 @@ import {
   IconInfoCircle,
   IconPhoto,
   IconRefresh,
+  IconSparkles,
   IconTrash,
   IconUpload,
   IconX,
@@ -45,8 +46,18 @@ import { trpc } from '~/utils/trpc';
  * thumbnail, replaceable — and screenshots removable when `allowRemove`).
  */
 
-/** Server-suggested image URLs from the URL's page metadata (cover = og:image, icon = favicon/apple-touch). */
-export type MetaSuggestions = { coverImageUrl?: string; iconImageUrl?: string };
+/**
+ * Server-suggested image URLs from the URL's page metadata (cover = og:image, icon =
+ * favicon/apple-touch). `iconDataUri` is a DISTINCT channel: an inline `data:image/...`
+ * favicon the https-only URL path can't fetch — accepted through a separate server
+ * ingest that rasterizes it to PNG (never stores raw SVG). Preferred order for the icon
+ * slot: an https `iconImageUrl` first, else the inline `iconDataUri`.
+ */
+export type MetaSuggestions = {
+  coverImageUrl?: string;
+  iconImageUrl?: string;
+  iconDataUri?: string;
+};
 
 type AssetKind = 'icon' | 'cover' | 'screenshot';
 
@@ -109,6 +120,8 @@ export function ListingAssetStep({
   allowRemove = false,
   onAssetMutated,
   onCompletenessChange,
+  onRepull,
+  repullLoading = false,
 }: {
   listingId: string;
   contentRating: OffsiteContentRating;
@@ -128,6 +141,13 @@ export function ListingAssetStep({
    *  submit button. `meetsFloor` = icon+cover attached (the publish floor);
    *  `complete` = also has ≥1 screenshot (advisory). */
   onCompletenessChange?: (state: { meetsFloor: boolean; complete: boolean }) => void;
+  /** Re-pull the OG metadata from the app's URL (the shared autofill hook's `repull`).
+   *  When provided, renders a step-level "Re-pull from site" button that refreshes the
+   *  icon/cover suggestion tiles — the manual retry that replaces the removed URL-step
+   *  button. Omit to hide it. */
+  onRepull?: () => void;
+  /** True while a `onRepull()` fetch is in flight (drives the button spinner). */
+  repullLoading?: boolean;
 }) {
   const { uploadToCF } = useCFImageUpload();
   const [icon, setIcon] = useState<AssetState>(() => assetFromInitial(initial?.icon));
@@ -154,6 +174,7 @@ export function ListingAssetStep({
   const utils = trpc.useUtils();
   const persistMutation = trpc.appListings.persistAssetImage.useMutation();
   const ingestMutation = trpc.appListings.ingestAssetFromUrl.useMutation();
+  const ingestDataUriMutation = trpc.appListings.ingestAssetFromDataUri.useMutation();
   const setIconMutation = trpc.appListings.setIcon.useMutation();
   const setCoverMutation = trpc.appListings.setCover.useMutation();
   const addScreenshotMutation = trpc.appListings.addScreenshot.useMutation();
@@ -425,6 +446,37 @@ export function ListingAssetStep({
     }
   }
 
+  /**
+   * Accept an inline `data:image/...` icon suggestion (radio.civitai.com's favicon).
+   * Distinct from `acceptSuggestion`: the server DECODES + RASTERIZES the data URI to
+   * PNG (never storing raw SVG) via `ingestAssetFromDataUri`, then it flows through the
+   * SAME attach + scan-poll path as any other icon. The data URI is itself a usable
+   * preview (a browser renders it in an `<img>` — no HTML injection), shown through the
+   * scan. Only ever an icon.
+   */
+  async function acceptDataUriSuggestion(
+    key: string,
+    dataUri: string,
+    apply: (s: AssetState) => void
+  ) {
+    clearTimer(key);
+    const epoch = bumpEpoch(key);
+    // The data URI renders as a preview in an <img>; it's NOT an object URL, so drop
+    // any prior blob for this key (never track it).
+    revokeObjectUrl(key);
+    apply({ status: 'working', imageId: null, message: null, previewUrl: dataUri });
+    try {
+      const { imageId } = await ingestDataUriMutation.mutateAsync({ dataUri, kind: 'icon' });
+      if (!isCurrentEpoch(key, epoch)) return;
+      await drive(key, 'icon', imageId, 0, epoch, apply);
+    } catch (err) {
+      if (!isCurrentEpoch(key, epoch)) return;
+      clearTimer(key);
+      apply({ status: 'error', imageId: null, message: (err as Error).message });
+      showErrorNotification({ title: 'Could not import icon', error: err as Error });
+    }
+  }
+
   async function retryAttach(
     key: string,
     kind: AssetKind,
@@ -525,6 +577,25 @@ export function ListingAssetStep({
     <Stack gap="md" data-testid="apps-offsite-submit-success">
       {header}
 
+      {onRepull && (
+        <Group gap="xs" align="center" data-testid="apps-offsite-assets-repull-row">
+          <Button
+            variant="light"
+            color="grape"
+            size="compact-sm"
+            leftSection={<IconSparkles size={16} />}
+            onClick={onRepull}
+            loading={repullLoading}
+            data-testid="apps-offsite-assets-repull"
+          >
+            Re-pull from site
+          </Button>
+          <Text size="xs" c="dimmed">
+            Re-scan your link for an icon and cover — only refreshes the suggestions below.
+          </Text>
+        </Group>
+      )}
+
       <AssetRow
         kind="icon"
         label="Icon"
@@ -535,10 +606,14 @@ export function ListingAssetStep({
           if (icon.imageId != null) void retryAttach('icon', 'icon', icon.imageId, applyIcon);
         }}
         onCancel={() => cancelAsset('icon', applyIcon)}
-        suggestionUrl={suggestions.iconImageUrl}
+        suggestionUrl={suggestions.iconImageUrl ?? suggestions.iconDataUri}
         onAcceptSuggestion={() => {
+          // Prefer an https URL (re-fetched SSRF-safe); else the inline data-URI icon
+          // (decoded + rasterized to PNG server-side — the radio.civitai.com case).
           if (suggestions.iconImageUrl)
             void acceptSuggestion('icon', 'icon', suggestions.iconImageUrl, applyIcon);
+          else if (suggestions.iconDataUri)
+            void acceptDataUriSuggestion('icon', suggestions.iconDataUri, applyIcon);
         }}
       />
       <AssetRow

--- a/src/components/Apps/__tests__/listingAutofillStatus.test.ts
+++ b/src/components/Apps/__tests__/listingAutofillStatus.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  computeAutofillStatus,
+  describeMissingChannels,
+  siteExposedChannels,
+} from '~/components/Apps/listingAutofillStatus';
+import type { ListingMetaSuggestion } from '~/server/utils/og-metadata';
+
+/**
+ * PURE four-state autofill status derivation. The headline requirement: never claim
+ * "already filled" when the pull genuinely found nothing (the misleading old copy).
+ * The state is a deterministic function of (a) what the SITE exposed and (b) what
+ * actually became ACTIONABLE given current form state.
+ */
+
+describe('siteExposedChannels', () => {
+  it('counts an icon whether it came as an https URL or an inline data URI', () => {
+    expect(siteExposedChannels({ iconImageUrl: 'https://x/i.png' }).icon).toBe(true);
+    expect(siteExposedChannels({ iconDataUri: 'data:image/svg+xml,%3Csvg%2F%3E' }).icon).toBe(true);
+    expect(siteExposedChannels({}).icon).toBe(false);
+  });
+
+  it('counts a description from either description or tagline', () => {
+    expect(siteExposedChannels({ description: 'x' }).description).toBe(true);
+    expect(siteExposedChannels({ tagline: 'x' }).description).toBe(true);
+    expect(siteExposedChannels({}).description).toBe(false);
+  });
+});
+
+describe('computeAutofillStatus', () => {
+  const actionedNone = { filledText: false, suggestedAsset: false };
+  const actionedText = { filledText: true, suggestedAsset: false };
+  const actionedAsset = { filledText: false, suggestedAsset: true };
+
+  it('error: a failed fetch → error (regardless of data)', () => {
+    expect(computeAutofillStatus({ errored: true, data: undefined, actioned: actionedNone })).toEqual(
+      { status: 'error' }
+    );
+  });
+
+  it('empty (site exposed nothing): {} → empty with siteExposedNothing=true (NOT "already filled")', () => {
+    expect(computeAutofillStatus({ errored: false, data: {}, actioned: actionedNone })).toEqual({
+      status: 'empty',
+      siteExposedNothing: true,
+    });
+    expect(
+      computeAutofillStatus({ errored: false, data: undefined, actioned: actionedNone })
+    ).toEqual({ status: 'empty', siteExposedNothing: true });
+  });
+
+  it('empty (already filled): site exposed things but nothing was actionable → empty, siteExposedNothing=false', () => {
+    const data: ListingMetaSuggestion = {
+      name: 'X',
+      description: 'd',
+      coverImageUrl: 'https://x/c.png',
+      iconImageUrl: 'https://x/i.png',
+    };
+    expect(computeAutofillStatus({ errored: false, data, actioned: actionedNone })).toEqual({
+      status: 'empty',
+      siteExposedNothing: false,
+    });
+  });
+
+  it('applied: exposed every expected channel (description + cover + icon) AND something actioned', () => {
+    const data: ListingMetaSuggestion = {
+      name: 'X',
+      description: 'd',
+      coverImageUrl: 'https://x/c.png',
+      iconImageUrl: 'https://x/i.png',
+    };
+    expect(computeAutofillStatus({ errored: false, data, actioned: actionedAsset })).toEqual({
+      status: 'applied',
+    });
+  });
+
+  it('partial (the radio case): title + inline icon actioned, but cover + description absent', () => {
+    const data: ListingMetaSuggestion = {
+      name: 'AI Radio',
+      iconDataUri: 'data:image/svg+xml,%3Csvg%2F%3E',
+    };
+    // Name already filled (not counted), the inline icon IS actionable.
+    const r = computeAutofillStatus({ errored: false, data, actioned: actionedAsset });
+    expect(r.status).toBe('partial');
+    expect(r.missing).toEqual(['description', 'cover']);
+  });
+
+  it('partial: filled description text but no cover/icon exposed', () => {
+    const data: ListingMetaSuggestion = { name: 'X', description: 'd' };
+    const r = computeAutofillStatus({ errored: false, data, actioned: actionedText });
+    expect(r.status).toBe('partial');
+    expect(r.missing).toEqual(['cover', 'icon']);
+  });
+});
+
+describe('describeMissingChannels', () => {
+  it('phrases one / two / three missing channels', () => {
+    expect(describeMissingChannels(['icon'])).toBe('an icon');
+    expect(describeMissingChannels(['cover', 'icon'])).toBe('a cover or an icon');
+    expect(describeMissingChannels(['description', 'cover', 'icon'])).toBe(
+      'a description, a cover, or an icon'
+    );
+    expect(describeMissingChannels([])).toBe('some details');
+    expect(describeMissingChannels(undefined)).toBe('some details');
+  });
+});

--- a/src/components/Apps/__tests__/useListingAutofill.test.ts
+++ b/src/components/Apps/__tests__/useListingAutofill.test.ts
@@ -1,0 +1,190 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as React from 'react';
+import type { act as actType } from 'react-dom/test-utils';
+import { createRoot, type Root } from 'react-dom/client';
+
+/**
+ * The SHARED external-listing autofill hook. Covers the behavioural contract the two
+ * wizards rely on: auto-fires once per valid URL, re-fires on a URL change, never fires
+ * for an invalid/empty URL, fill-if-empty never clobbers an edited field, and repull()
+ * re-runs the query. The debounce timing itself is a library concern — `useDebouncedValue`
+ * is mocked to identity so the auto-trigger fires synchronously; the query is mocked so we
+ * drive the settle deterministically.
+ */
+
+// React 18.3 exposes `act` on the `react` export; borrow the typed signature.
+const act = (React as unknown as { act: typeof actType }).act;
+
+vi.mock('@mantine/hooks', () => ({
+  useDebouncedValue: (v: unknown) => [v],
+}));
+
+const queryMock = vi.hoisted(() => ({
+  state: { data: undefined, isFetching: false, isError: false } as {
+    data?: unknown;
+    isFetching?: boolean;
+    isError?: boolean;
+  },
+  refetch: vi.fn(),
+  inputs: [] as Array<{ url: string }>,
+}));
+
+vi.mock('~/utils/trpc', () => ({
+  trpc: {
+    appListings: {
+      fetchListingMetaFromUrl: {
+        useQuery: (input: { url: string }) => {
+          queryMock.inputs.push(input);
+          return { ...queryMock.state, refetch: queryMock.refetch };
+        },
+      },
+    },
+  },
+}));
+
+import {
+  useListingAutofill,
+  type UseListingAutofillReturn,
+} from '~/components/Apps/useListingAutofill';
+import {
+  emptyOffsiteSubmitForm,
+  type OffsiteSubmitFormValues,
+} from '~/components/Apps/offsiteSubmitFormConfig';
+
+let api: UseListingAutofillReturn;
+let currentValues: OffsiteSubmitFormValues;
+let setUrl: (u: string) => void;
+let edit: (patch: Partial<OffsiteSubmitFormValues>) => void;
+let bump: () => void;
+
+function Harness({ initial }: { initial?: Partial<OffsiteSubmitFormValues> }) {
+  const [values, setValues] = React.useState<OffsiteSubmitFormValues>(() => ({
+    ...emptyOffsiteSubmitForm(),
+    ...initial,
+  }));
+  const [, setTick] = React.useState(0);
+  const valuesRef = React.useRef(values);
+  valuesRef.current = values;
+  const nameFallbackRef = React.useRef('');
+  api = useListingAutofill({
+    externalUrl: values.externalUrl,
+    setValues,
+    valuesRef,
+    nameFallbackRef,
+  });
+  currentValues = values;
+  setUrl = (u) => setValues((v) => ({ ...v, externalUrl: u }));
+  edit = (patch) => setValues((v) => ({ ...v, ...patch }));
+  bump = () => setTick((t) => t + 1);
+  return null;
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  queryMock.state = { data: undefined, isFetching: false, isError: false };
+  queryMock.refetch.mockReset();
+  queryMock.inputs.length = 0;
+  container = document.createElement('div');
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+function render(initial?: Partial<OffsiteSubmitFormValues>) {
+  act(() => root.render(React.createElement(Harness, { initial })));
+}
+function lastInputUrl(): string | undefined {
+  return queryMock.inputs[queryMock.inputs.length - 1]?.url;
+}
+function settle(data: unknown, extra: Partial<typeof queryMock.state> = {}) {
+  act(() => {
+    queryMock.state = { data, isFetching: false, isError: false, ...extra };
+    bump();
+  });
+}
+
+describe('useListingAutofill', () => {
+  it('does NOT fire for an empty or invalid (non-https) URL', () => {
+    render();
+    expect(lastInputUrl()).toBe(''); // metaUrl null → query disabled with empty url
+    act(() => setUrl('http://insecure.example.com')); // http rejected by normalizeLinkUrl
+    expect(lastInputUrl()).toBe('');
+    expect(queryMock.refetch).not.toHaveBeenCalled();
+  });
+
+  it('auto-fires ONCE per valid URL (a re-render with the same URL does not re-fire)', () => {
+    render();
+    act(() => setUrl('https://vitrine.civitai.com'));
+    // Fired with the NORMALIZED url.
+    expect(lastInputUrl()).toBe('https://vitrine.civitai.com/');
+    // A plain re-render (same URL) must not trigger a refetch (once-per-url guard).
+    act(() => bump());
+    expect(queryMock.refetch).not.toHaveBeenCalled();
+    expect(lastInputUrl()).toBe('https://vitrine.civitai.com/');
+  });
+
+  it('re-fires when the URL changes to a new valid URL', () => {
+    render();
+    act(() => setUrl('https://a.example.com'));
+    expect(lastInputUrl()).toBe('https://a.example.com/');
+    act(() => setUrl('https://b.example.com'));
+    expect(lastInputUrl()).toBe('https://b.example.com/');
+  });
+
+  it('fill-if-empty applies name + description on settle (full pull → applied)', () => {
+    render();
+    act(() => setUrl('https://vitrine.civitai.com'));
+    settle({
+      name: 'Vitrine',
+      description: 'A gallery',
+      coverImageUrl: 'https://cdn/c.png',
+      iconImageUrl: 'https://cdn/i.png',
+    });
+    expect(currentValues.name).toBe('Vitrine');
+    expect(currentValues.description).toBe('A gallery');
+    // Exposed name + description + cover + icon → nothing missing → applied.
+    expect(api.result?.status).toBe('applied');
+  });
+
+  it('never clobbers a field the author already edited', () => {
+    render();
+    act(() => setUrl('https://vitrine.civitai.com'));
+    act(() => edit({ name: 'My Own Name' }));
+    settle({ name: 'OG Title', description: 'desc' });
+    // Edited name preserved; empty description filled.
+    expect(currentValues.name).toBe('My Own Name');
+    expect(currentValues.description).toBe('desc');
+  });
+
+  it('surfaces the inline data-URI icon as a suggestion on settle', () => {
+    render();
+    act(() => setUrl('https://radio.example.com'));
+    settle({ name: 'AI Radio', iconDataUri: 'data:image/svg+xml,%3Csvg%2F%3E' });
+    expect(api.suggestions.iconDataUri).toBe('data:image/svg+xml,%3Csvg%2F%3E');
+    // Name already implicitly filled; description/cover absent → partial.
+    expect(api.result?.status).toBe('partial');
+  });
+
+  it('repull() re-runs the query for the current URL (refetch on the same url)', () => {
+    render();
+    act(() => setUrl('https://vitrine.civitai.com'));
+    settle({ name: 'Vitrine' });
+    queryMock.refetch.mockClear();
+    act(() => api.repull());
+    expect(queryMock.refetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('an error-settled fetch produces the error status', () => {
+    render();
+    act(() => setUrl('https://broken.example.com'));
+    settle(undefined, { isError: true });
+    expect(api.result?.status).toBe('error');
+  });
+});

--- a/src/components/Apps/listingAutofillStatus.ts
+++ b/src/components/Apps/listingAutofillStatus.ts
@@ -1,0 +1,101 @@
+import type { ListingMetaSuggestion } from '~/server/utils/og-metadata';
+
+/**
+ * App Store Listings (W13) — PURE status/note derivation for the external-listing
+ * autofill (shared by the create + edit wizards via `useListingAutofill`).
+ *
+ * The old copy conflated "the site exposed nothing" with "your fields are already
+ * filled" ("Your site didn't expose an icon, cover or description to pull (or your
+ * fields are already filled)") — misleading on a fresh CREATE where the fields were
+ * empty and the SITE simply had nothing (the radio.civitai.com case). This splits
+ * the outcome into four honest states + a reason, computed deterministically from
+ * (a) what the SITE exposed and (b) what actually became ACTIONABLE given the current
+ * form state (a suggestion for an already-filled slot is not actionable):
+ *
+ *   - `error`   — the fetch failed (no data).
+ *   - `empty`   — nothing was applied. `siteExposedNothing` disambiguates the copy:
+ *                 `true`  → the page's <head> genuinely exposed nothing;
+ *                 `false` → it exposed something, but it's already filled in.
+ *   - `partial` — something was applied/surfaced, but the page did NOT expose every
+ *                 expected channel (`missing` lists which of description/cover/icon).
+ *   - `applied` — something was applied AND the page exposed all expected channels.
+ */
+
+export type ListingAutofillStatus = 'applied' | 'partial' | 'empty' | 'error';
+
+export type ListingAutofillResult = {
+  status: ListingAutofillStatus;
+  /** For `empty` only: did the site expose nothing at all (vs everything already filled)? */
+  siteExposedNothing?: boolean;
+  /** For `partial` only: expected channels the page did NOT expose. */
+  missing?: Array<'description' | 'cover' | 'icon'>;
+};
+
+/** What a pull ACTUALLY changed, given current form state (computed by the caller). */
+export type ListingAutofillActioned = {
+  /** At least one empty text field (name/tagline/description) got filled by this pull. */
+  filledText: boolean;
+  /** At least one icon/cover suggestion is actionable (its slot is currently empty). */
+  suggestedAsset: boolean;
+};
+
+/**
+ * Which channels the SITE exposed (independent of form state) — an icon counts
+ * whether it came as an https URL or an inline data URI.
+ */
+export function siteExposedChannels(data: ListingMetaSuggestion | undefined): {
+  name: boolean;
+  description: boolean;
+  cover: boolean;
+  icon: boolean;
+} {
+  return {
+    name: !!data?.name,
+    description: !!data?.description || !!data?.tagline,
+    cover: !!data?.coverImageUrl,
+    icon: !!data?.iconImageUrl || !!data?.iconDataUri,
+  };
+}
+
+/**
+ * Derive the four-state autofill outcome. `errored` short-circuits to `error`.
+ * Otherwise: nothing exposed → `empty` (siteExposedNothing); exposed-but-nothing-
+ * actionable → `empty` (already filled); actionable + every expected channel present
+ * → `applied`; actionable but some expected channel absent → `partial` (+ `missing`).
+ */
+export function computeAutofillStatus(input: {
+  errored: boolean;
+  data: ListingMetaSuggestion | undefined;
+  actioned: ListingAutofillActioned;
+}): ListingAutofillResult {
+  if (input.errored) return { status: 'error' };
+  const site = siteExposedChannels(input.data);
+  const anyExposed = site.name || site.description || site.cover || site.icon;
+  if (!anyExposed) return { status: 'empty', siteExposedNothing: true };
+
+  const anyActioned = input.actioned.filledText || input.actioned.suggestedAsset;
+  if (!anyActioned) return { status: 'empty', siteExposedNothing: false };
+
+  const missing: Array<'description' | 'cover' | 'icon'> = [];
+  if (!site.description) missing.push('description');
+  if (!site.cover) missing.push('cover');
+  if (!site.icon) missing.push('icon');
+  if (missing.length === 0) return { status: 'applied' };
+  return { status: 'partial', missing };
+}
+
+/** Human phrase for the channels a `partial` pull did NOT expose (e.g. "a cover or an icon"). */
+export function describeMissingChannels(
+  missing: Array<'description' | 'cover' | 'icon'> | undefined
+): string {
+  const labels: Record<'description' | 'cover' | 'icon', string> = {
+    description: 'a description',
+    cover: 'a cover',
+    icon: 'an icon',
+  };
+  const parts = (missing ?? []).map((m) => labels[m]);
+  if (parts.length === 0) return 'some details';
+  if (parts.length === 1) return parts[0];
+  if (parts.length === 2) return `${parts[0]} or ${parts[1]}`;
+  return `${parts.slice(0, -1).join(', ')}, or ${parts[parts.length - 1]}`;
+}

--- a/src/components/Apps/useListingAutofill.ts
+++ b/src/components/Apps/useListingAutofill.ts
@@ -1,0 +1,282 @@
+import { useDebouncedValue } from '@mantine/hooks';
+import {
+  useEffect,
+  useRef,
+  useState,
+  type Dispatch,
+  type MutableRefObject,
+  type SetStateAction,
+} from 'react';
+
+import type { MetaSuggestions } from '~/components/Apps/ListingAssetStep';
+import {
+  computeAutofillStatus,
+  type ListingAutofillResult,
+} from '~/components/Apps/listingAutofillStatus';
+import {
+  OFFSITE_SUBMIT_LIMITS,
+  normalizeLinkUrl,
+  type OffsiteSubmitFormValues,
+} from '~/components/Apps/offsiteSubmitFormConfig';
+import type { ListingMetaSuggestion } from '~/server/utils/og-metadata';
+import { trpc } from '~/utils/trpc';
+
+/**
+ * App Store Listings (W13) — the SHARED external-listing autofill hook, consumed by
+ * both the CREATE (`ExternalSubmitForm`) and EDIT (`ExternalListingEditForm`) wizards.
+ * It replaces the duplicated auto-pull logic (and the removed manual "Pull from site"
+ * / "Autofill from website" buttons) with ONE auto-triggering core:
+ *
+ *   - AUTO-TRIGGER: fires the SSRF-safe `fetchListingMetaFromUrl` query when the
+ *     external-URL field holds a valid https URL — on blur/Enter/step-advance
+ *     (`triggerFromUrl`) AND on a debounced change (`debounceMs`). It fires at most
+ *     ONCE per distinct normalized URL (`firedUrlRef`) and re-fires when the URL
+ *     changes to a new valid URL. Invalid/empty URLs never fire.
+ *   - FILL-IF-EMPTY apply: name / tagline / description are filled ONLY when empty,
+ *     so a field the author has edited is never clobbered. CREATE prefers the page
+ *     `<title>` and falls back to a host-derived name (`nameFallbackRef`).
+ *   - SUGGESTIONS: the `{ coverImageUrl, iconImageUrl, iconDataUri }` object handed
+ *     to `ListingAssetStep` for its accept-suggestion tiles.
+ *   - STATUS: the four-state note (applied / partial / empty / error) via the pure
+ *     `computeAutofillStatus`, honest about what the SITE exposed vs. what was
+ *     actionable (never "already filled" when the pull genuinely found nothing).
+ *   - REPULL: `repull()` — the manual retry (the assets-step "Re-pull from site"
+ *     button), re-runs the query for the current URL even when unchanged.
+ *
+ * Form-specific field wiring (which setters to call, host-name fallback, whether an
+ * asset slot is empty, URL-side effects like slug derivation) is injected via params
+ * so both forms reuse the identical core.
+ */
+
+export type UseListingAutofillParams = {
+  /** The raw (unnormalized) external-URL form value — drives the debounced auto-trigger. */
+  externalUrl: string;
+  /** Form setter — the apply effect fills empty name/tagline/description through it. */
+  setValues: Dispatch<SetStateAction<OffsiteSubmitFormValues>>;
+  /**
+   * Ref to the latest form values. The apply effect reads pre-apply emptiness from
+   * here (its own `setValues` updater hasn't committed when the note is computed).
+   */
+  valuesRef: MutableRefObject<OffsiteSubmitFormValues>;
+  /**
+   * CREATE only: host-derived fallback name, used to fill an empty Name when the page
+   * exposes no `<title>`. Omit for EDIT (no fallback — an empty name stays empty).
+   */
+  nameFallbackRef?: MutableRefObject<string>;
+  /**
+   * Whether an icon/cover suggestion is ACTIONABLE right now — i.e. its asset slot is
+   * empty (a suggestion for an already-filled slot is not actionable, so it must not
+   * count toward an "applied"/"partial" note). CREATE → always true (every slot starts
+   * empty); EDIT → depends on the prefill/attached state. Default: always actionable.
+   */
+  isSuggestionActionable?: (kind: 'icon' | 'cover') => boolean;
+  /**
+   * Optional side effect run right before an actual fire, with the normalized URL —
+   * CREATE uses it to canonicalize the URL field + derive the slug + stash the
+   * host-name fallback; EDIT uses it to canonicalize the URL field.
+   */
+  onBeforeFire?: (normalizedUrl: string) => void;
+  /**
+   * A pre-existing URL (EDIT prefill) that should NOT auto-fire on mount — only a
+   * CHANGE to a new URL (or an explicit `repull`) fires. Seeds the once-per-url guard.
+   */
+  initialUrl?: string;
+  /** Debounced-change trigger delay (default 600ms). */
+  debounceMs?: number;
+};
+
+export type UseListingAutofillReturn = {
+  /** The `{ coverImageUrl, iconImageUrl, iconDataUri }` suggestions for ListingAssetStep. */
+  suggestions: MetaSuggestions;
+  /** True while the CURRENT pull's fetch is in flight (drives the loading note + button spinner). */
+  loading: boolean;
+  /** The settled four-state result of the last pull (null before any pull settles). */
+  result: ListingAutofillResult | null;
+  /** CREATE Details "we found these details" reveal — sticky once any pull applied something. */
+  applied: boolean;
+  /**
+   * Normalize `raw` and, if it's a valid https URL, fire an auto-pull (once per distinct
+   * URL). Returns the normalize error (if any) so the form can surface it. Used on blur,
+   * Enter, and step-advance.
+   */
+  triggerFromUrl: (raw: string) => { error?: string };
+  /** Manual re-pull of the CURRENT url — the assets-step "Re-pull from site" button + retries. */
+  repull: () => void;
+  /** Clear the transient status note (e.g. the user is editing the URL again). */
+  clearNote: () => void;
+};
+
+export function useListingAutofill(params: UseListingAutofillParams): UseListingAutofillReturn {
+  const {
+    externalUrl,
+    setValues,
+    valuesRef,
+    nameFallbackRef,
+    isSuggestionActionable,
+    onBeforeFire,
+    initialUrl,
+    debounceMs = 600,
+  } = params;
+
+  const [metaUrl, setMetaUrl] = useState<string | null>(null);
+  const [suggestions, setSuggestions] = useState<MetaSuggestions>({});
+  const [result, setResult] = useState<ListingAutofillResult | null>(null);
+  const [applied, setApplied] = useState(false);
+  const [pullActive, setPullActive] = useState(false);
+  const [autofillTick, setAutofillTick] = useState(0);
+
+  // Once-per-distinct-url guard. Seeded from an EDIT prefill so the existing URL does
+  // NOT auto-fire on mount (only a change / explicit repull does).
+  const firedUrlRef = useRef<string | null>(
+    initialUrl ? normalizeLinkUrl(initialUrl).url || null : null
+  );
+  // Apply-effect idempotency: reset to null on each fire so the effect re-applies.
+  const appliedMetaRef = useRef<string | null>(null);
+  // Latest raw URL for repull() (reads current, not the render-captured, value).
+  const externalUrlRef = useRef(externalUrl);
+  externalUrlRef.current = externalUrl;
+
+  const metaQuery = trpc.appListings.fetchListingMetaFromUrl.useQuery(
+    { url: metaUrl ?? '' },
+    { enabled: !!metaUrl, retry: false, refetchOnWindowFocus: false, staleTime: Infinity }
+  );
+
+  function fire(normalizedUrl: string, opts: { force: boolean }) {
+    if (!opts.force && firedUrlRef.current === normalizedUrl) return;
+    firedUrlRef.current = normalizedUrl;
+    onBeforeFire?.(normalizedUrl);
+    setResult(null);
+    setPullActive(true);
+    // Force the idempotent apply effect to re-run for this fire.
+    appliedMetaRef.current = null;
+    if (normalizedUrl === metaUrl) {
+      // Same url: `setMetaUrl` is a no-op and (staleTime:Infinity + retry:false) the
+      // cached success/error won't re-fetch on its own. `refetch()` re-attempts; the
+      // tick below re-runs the apply effect once it settles. No loop: `refetch()`
+      // flips `isFetching` true synchronously, so the tick-driven run bails on the
+      // isFetching guard and only applies once the (re)fetch settles.
+      void metaQuery.refetch();
+    } else {
+      setMetaUrl(normalizedUrl);
+    }
+    setAutofillTick((t) => t + 1);
+  }
+
+  function triggerFromUrl(raw: string): { error?: string } {
+    const r = normalizeLinkUrl(raw);
+    if (r.error) return { error: r.error };
+    fire(r.url, { force: false });
+    return {};
+  }
+
+  function repull() {
+    const r = normalizeLinkUrl(externalUrlRef.current);
+    if (r.error) return; // a bad/blank URL never fires (the button is also disabled)
+    fire(r.url, { force: true });
+  }
+
+  function clearNote() {
+    setResult(null);
+  }
+
+  // Debounced-change auto-trigger: once the user pauses typing on a valid https URL,
+  // fire the pull (once per distinct URL). Invalid/empty URLs never fire.
+  const [debouncedUrl] = useDebouncedValue(externalUrl, debounceMs);
+  useEffect(() => {
+    const r = normalizeLinkUrl(debouncedUrl);
+    if (r.error) return;
+    fire(r.url, { force: false });
+    // Intentionally keyed only on the debounced URL — `fire` is idempotent per URL via
+    // `firedUrlRef`, so re-running on unrelated renders is a no-op.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [debouncedUrl]);
+
+  // Apply the settled pull ONCE per url (fill-if-empty text + suggestions + note).
+  useEffect(() => {
+    if (!metaUrl || appliedMetaRef.current === metaUrl) return;
+    if (metaQuery.isFetching) return;
+    const data = metaQuery.data as ListingMetaSuggestion | undefined;
+    const settled = !!data || metaQuery.isError;
+    if (!settled) return;
+    appliedMetaRef.current = metaUrl;
+    const errored = metaQuery.isError && !data;
+
+    // Snapshot pre-apply emptiness for the note (the async setValues below hasn't
+    // committed yet). Fill-if-empty runs in BOTH the success AND error case: on error
+    // there is no `data`, so only the host-derived name fallback (CREATE) can fill an
+    // empty Name — so an errored pull never leaves Name blank on create.
+    const before = valuesRef.current;
+    const fallbackName = nameFallbackRef?.current ?? '';
+    const resolvedName = data?.name || fallbackName;
+
+    setValues((v) => ({
+      ...v,
+      name: v.name.trim().length === 0 && resolvedName ? resolvedName : v.name,
+      tagline: v.tagline.trim().length === 0 && data?.tagline ? data.tagline : v.tagline,
+      description:
+        v.description.trim().length === 0 && data?.description
+          ? data.description.slice(0, OFFSITE_SUBMIT_LIMITS.descriptionMax)
+          : v.description,
+    }));
+    // ERROR-settled: drop stale suggestions + surface the error note (after the name
+    // fallback fill above).
+    setSuggestions(
+      errored
+        ? {}
+        : {
+            coverImageUrl: data?.coverImageUrl,
+            iconImageUrl: data?.iconImageUrl,
+            iconDataUri: data?.iconDataUri,
+          }
+    );
+    if (errored) {
+      setResult({ status: 'error' });
+      setPullActive(false);
+      return;
+    }
+
+    // Sticky "we found details" reveal — only what the SITE exposed counts (NOT the
+    // host-derived name fallback, which is derived from the URL, not pulled).
+    if (
+      data &&
+      (data.name ||
+        data.tagline ||
+        data.description ||
+        data.coverImageUrl ||
+        data.iconImageUrl ||
+        data.iconDataUri)
+    ) {
+      setApplied(true);
+    }
+
+    // Four-state note. "filled a text field" counts ONLY the site-exposed value into an
+    // empty field; an actionable asset = a suggestion for a currently-empty slot.
+    const actionable = (kind: 'icon' | 'cover') => isSuggestionActionable?.(kind) ?? true;
+    const filledText =
+      (before.name.trim().length === 0 && !!data?.name) ||
+      (before.tagline.trim().length === 0 && !!data?.tagline) ||
+      (before.description.trim().length === 0 && !!data?.description);
+    const iconActionable = (!!data?.iconImageUrl || !!data?.iconDataUri) && actionable('icon');
+    const coverActionable = !!data?.coverImageUrl && actionable('cover');
+    setResult(
+      computeAutofillStatus({
+        errored: false,
+        data,
+        actioned: { filledText, suggestedAsset: iconActionable || coverActionable },
+      })
+    );
+    setPullActive(false);
+    // `autofillTick` is a dep so a same-url repull re-runs this effect from cache.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [metaUrl, metaQuery.data, metaQuery.isError, metaQuery.isFetching, autofillTick]);
+
+  return {
+    suggestions,
+    loading: pullActive && metaQuery.isFetching,
+    result,
+    applied,
+    triggerFromUrl,
+    repull,
+    clearNote,
+  };
+}

--- a/src/server/routers/app-listings.router.ts
+++ b/src/server/routers/app-listings.router.ts
@@ -38,6 +38,7 @@ import {
 } from '~/server/schema/blocks/offsite-listing.schema';
 import {
   fetchListingMetaSchema,
+  ingestListingAssetFromDataUriSchema,
   ingestListingAssetFromUrlSchema,
 } from '~/server/schema/blocks/listing-meta.schema';
 import {
@@ -646,6 +647,32 @@ export const appListingsRouter = router({
         '~/server/services/blocks/listing-meta.service'
       );
       return ingestListingAssetFromUrl({ input, userId: ctx.user.id });
+    }),
+
+  /**
+   * AUTHOR: ingest an ACCEPTED inline `data:image/...` icon (a favicon declared as a
+   * data URI — the https-only URL path drops these) into a scannable `Image` row.
+   * The bytes come from the data URI itself (no outbound fetch); the server decodes,
+   * REJECTS any non-image MIME, caps the decoded size, and RASTERIZES to PNG (raw SVG
+   * is never stored/served — XSS vector) before running the STANDARD scan pipeline.
+   * Returns the numeric `imageId` the client then attaches via `setIcon`. Same auth +
+   * rate-limit shape as the URL accept.
+   */
+  ingestAssetFromDataUri: appDeveloperProcedure
+    .use(
+      rateLimit({
+        limit: 30,
+        period: 3600,
+        errorMessage: 'Too many image imports — slow down.',
+      })
+    )
+    .input(ingestListingAssetFromDataUriSchema)
+    .mutation(async ({ ctx, input }) => {
+      if (!ctx.user) throw throwAuthorizationError('Not authenticated');
+      const { ingestListingAssetFromDataUri } = await import(
+        '~/server/services/blocks/listing-meta.service'
+      );
+      return ingestListingAssetFromDataUri({ input, userId: ctx.user.id });
     }),
 
   /** AUTHOR: the caller's OWN off-site submissions (my-submissions page, PR-c). */

--- a/src/server/schema/blocks/listing-meta.schema.ts
+++ b/src/server/schema/blocks/listing-meta.schema.ts
@@ -37,3 +37,26 @@ export const ingestListingAssetFromUrlSchema = z.object({
   kind: z.enum(['icon', 'cover']),
 });
 export type IngestListingAssetFromUrlInput = z.infer<typeof ingestListingAssetFromUrlSchema>;
+
+/**
+ * Max ENCODED (data-URI string) length accepted by the inline-icon ingest — a
+ * coarse first gate before decoding; the SERVICE independently re-caps the DECODED
+ * byte size ({@link INLINE_ICON_MAX_DECODED_BYTES}). base64 inflates ~4/3, so this
+ * comfortably admits a ~2MB decoded image while bounding the request body.
+ */
+export const INLINE_ICON_MAX_DATA_URI_LEN = 3_500_000;
+
+/**
+ * Ingest an accepted INLINE `data:image/...` icon (e.g. a favicon declared as a
+ * data URI) into a scannable Image row. Distinct from the URL path: the bytes are
+ * decoded from the data URI (no outbound fetch — never routed through safeFetch),
+ * RASTERIZED to PNG (SVG is never stored/served raw — XSS vector), then run through
+ * the standard scan pipeline. Only `icon` (the only asset a favicon feeds).
+ */
+export const ingestListingAssetFromDataUriSchema = z.object({
+  dataUri: z.string().min(1).max(INLINE_ICON_MAX_DATA_URI_LEN),
+  kind: z.literal('icon'),
+});
+export type IngestListingAssetFromDataUriInput = z.infer<
+  typeof ingestListingAssetFromDataUriSchema
+>;

--- a/src/server/services/blocks/__tests__/listing-meta.datauri-raster.integration.test.ts
+++ b/src/server/services/blocks/__tests__/listing-meta.datauri-raster.integration.test.ts
@@ -1,0 +1,96 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * UNMOCKED sharp integration test for the inline-icon rasterizer (the data-URI icon
+ * accept path). Unlike `listing-meta.service.test.ts` — which MOCKS sharp to unit-test
+ * the control flow — this runs REAL sharp / librsvg so the security invariants are
+ * CI-guarded against a sharp/libvips/librsvg bump:
+ *
+ *   (a) raw SVG is NEVER stored/served — the bytes that reach the store are always PNG;
+ *   (b) an external SVG resource ref (`file://` / `http://`) is NOT fetched/embedded;
+ *   (c) an over-`limitInputPixels` SVG (huge viewBox) is REJECTED cleanly (BAD_REQUEST,
+ *       nothing stored) via the EXPLICIT input-pixel cap — not a 500, not an OOM.
+ *
+ * Only the downstream store + DB are mocked; sharp/librsvg run for real. Fast + hermetic
+ * (no network, tiny inline SVGs).
+ */
+
+vi.mock('~/utils/s3-utils', () => ({ uploadImageBufferToStore: vi.fn() }));
+vi.mock('~/server/services/image.service', () => ({ createImage: vi.fn() }));
+
+import { uploadImageBufferToStore } from '~/utils/s3-utils';
+import { createImage } from '~/server/services/image.service';
+import { ingestListingAssetFromDataUri } from '~/server/services/blocks/listing-meta.service';
+
+const upload = vi.mocked(uploadImageBufferToStore);
+const create = vi.mocked(createImage);
+const PNG_MAGIC = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+
+function svgDataUri(inner: string): string {
+  return 'data:image/svg+xml,' + encodeURIComponent(inner);
+}
+
+beforeEach(() => {
+  upload.mockReset();
+  create.mockReset();
+  upload.mockResolvedValue({ key: 'store-key', backend: 'backblaze' } as never);
+  create.mockResolvedValue({ id: 42 } as never);
+});
+
+describe('ingestListingAssetFromDataUri — REAL sharp rasterization (integration)', () => {
+  it('(a) rasterizes a valid data:image/svg+xml to PNG and NEVER stores raw SVG bytes', async () => {
+    const svg = svgDataUri(
+      '<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64"><rect width="64" height="64" fill="red"/></svg>'
+    );
+    const res = await ingestListingAssetFromDataUri({ input: { dataUri: svg, kind: 'icon' }, userId: 1 });
+    expect(res).toEqual({ imageId: 42 });
+
+    expect(upload).toHaveBeenCalledTimes(1);
+    const stored = upload.mock.calls[0][0] as Buffer;
+    // Real PNG magic bytes; NO SVG markup anywhere in the stored bytes.
+    expect(stored.subarray(0, 8).equals(PNG_MAGIC)).toBe(true);
+    expect(stored.includes(Buffer.from('<svg'))).toBe(false);
+    expect(stored.includes(Buffer.from('rect'))).toBe(false);
+    expect(upload.mock.calls[0][1]).toMatchObject({ contentType: 'image/png' });
+    // Standard scan pipeline: the PNG store key + png mime, no bypass.
+    expect(create).toHaveBeenCalledWith(
+      expect.objectContaining({ url: 'store-key', mimeType: 'image/png' })
+    );
+  });
+
+  it('(b) does NOT fetch/embed an external SVG resource ref (file:// / http://)', async () => {
+    const svg = svgDataUri(
+      '<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="32" height="32">' +
+        '<image href="file:///etc/passwd" xlink:href="file:///etc/passwd" width="32" height="32"/>' +
+        '<image href="http://169.254.169.254/latest/meta-data/" width="32" height="32"/>' +
+        '</svg>'
+    );
+    let stored: Buffer | undefined;
+    try {
+      await ingestListingAssetFromDataUri({ input: { dataUri: svg, kind: 'icon' }, userId: 1 });
+      stored = upload.mock.calls[0]?.[0] as Buffer | undefined;
+    } catch (e) {
+      // Rejecting cleanly is equally acceptable — either outcome means NO leak/fetch.
+      expect((e as { code?: string }).code).toBe('BAD_REQUEST');
+    }
+    if (stored) {
+      // If it rasterized, the external resource's contents are NOT embedded, and it's PNG.
+      expect(stored.subarray(0, 8).equals(PNG_MAGIC)).toBe(true);
+      expect(stored.includes(Buffer.from('root:'))).toBe(false);
+      expect(stored.includes(Buffer.from('ami-'))).toBe(false);
+    }
+  });
+
+  it('(c) REJECTS an over-limitInputPixels SVG (huge viewBox) with BAD_REQUEST — nothing stored', async () => {
+    // 15000×15000 ≈ 225MP > the 16MP input cap. librsvg would render this at ~900MB at
+    // intrinsic size; the explicit limitInputPixels rejects it at decode instead.
+    const svg = svgDataUri(
+      '<svg xmlns="http://www.w3.org/2000/svg" width="15000" height="15000"><rect width="15000" height="15000" fill="blue"/></svg>'
+    );
+    await expect(
+      ingestListingAssetFromDataUri({ input: { dataUri: svg, kind: 'icon' }, userId: 1 })
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+    expect(upload).not.toHaveBeenCalled();
+    expect(create).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/services/blocks/__tests__/listing-meta.service.test.ts
+++ b/src/server/services/blocks/__tests__/listing-meta.service.test.ts
@@ -36,10 +36,19 @@ const { mockSafeFetch, SafeFetchError } = vi.hoisted(() => {
 });
 vi.mock('~/server/utils/safe-fetch', () => ({ safeFetch: mockSafeFetch, SafeFetchError }));
 
-const { mockMetadata, mockSharp } = vi.hoisted(() => {
+const { mockMetadata, mockToBuffer, mockSharp } = vi.hoisted(() => {
   const mockMetadata = vi.fn();
-  const mockSharp = vi.fn(() => ({ metadata: mockMetadata }));
-  return { mockMetadata, mockSharp };
+  const mockToBuffer = vi.fn();
+  // A single chainable instance backs both the URL path (`sharp(bytes).metadata()`) and
+  // the data-URI path (`sharp(bytes,{density}).resize(...).png().toBuffer()` then
+  // `sharp(png).metadata()`).
+  const instance: Record<string, unknown> = {};
+  instance.resize = () => instance;
+  instance.png = () => instance;
+  instance.toBuffer = mockToBuffer;
+  instance.metadata = mockMetadata;
+  const mockSharp = vi.fn(() => instance);
+  return { mockMetadata, mockToBuffer, mockSharp };
 });
 vi.mock('sharp', () => ({ default: mockSharp }));
 
@@ -55,12 +64,14 @@ vi.mock('~/server/services/image.service', () => ({ createImage: mockCreateImage
 
 import {
   fetchListingMeta,
+  ingestListingAssetFromDataUri,
   ingestListingAssetFromUrl,
 } from '~/server/services/blocks/listing-meta.service';
 
 beforeEach(() => {
   mockSafeFetch.mockReset();
   mockMetadata.mockReset();
+  mockToBuffer.mockReset();
   mockSharp.mockClear();
   mockUploadImageBufferToStore.mockReset();
   mockCreateImage.mockReset();
@@ -217,6 +228,109 @@ describe('ingestListingAssetFromUrl', () => {
     await expect(
       ingestListingAssetFromUrl({ input: { url: 'https://cdn.example.com/x', kind: 'icon' }, userId: 1 })
     ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+    expect(mockCreateImage).not.toHaveBeenCalled();
+  });
+});
+
+/**
+ * 🔴 SECURITY: the inline data-URI icon path (the radio.civitai.com favicon case). It
+ * NEVER routes through safeFetch (bytes come from the data URI itself), REJECTS any
+ * non-image MIME, caps the decoded size, and RASTERIZES to PNG so the bytes that reach
+ * the store are ALWAYS PNG — raw SVG is never persisted or served (XSS vector). All I/O
+ * (sharp, the store upload, createImage) is mocked; the rasterize chain returns a
+ * sentinel PNG buffer so the "never raw SVG" invariant is assertable.
+ */
+describe('ingestListingAssetFromDataUri', () => {
+  const pngBytes = Buffer.from('rasterized-png-bytes');
+
+  function primeRaster() {
+    mockToBuffer.mockResolvedValue(pngBytes);
+    mockMetadata.mockResolvedValue({ width: 128, height: 128, format: 'png' });
+    mockUploadImageBufferToStore.mockResolvedValue({ key: 'store-uuid-key', backend: 'backblaze' });
+    mockCreateImage.mockResolvedValue({ id: 555 });
+  }
+
+  it('decodes + RASTERIZES a data:image/svg+xml icon to PNG, stores the PNG (never raw SVG), and createImage runs the standard scan pipeline', async () => {
+    primeRaster();
+    const svg = 'data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%2F%3E';
+    const res = await ingestListingAssetFromDataUri({
+      input: { dataUri: svg, kind: 'icon' },
+      userId: 7,
+    });
+    expect(res).toEqual({ imageId: 555 });
+
+    // NEVER RAW SVG: the bytes uploaded are the RASTERIZED PNG (the sentinel from
+    // toBuffer), and the object Content-Type is image/png — not the source SVG.
+    expect(mockUploadImageBufferToStore).toHaveBeenCalledTimes(1);
+    expect(mockUploadImageBufferToStore).toHaveBeenCalledWith(
+      pngBytes,
+      expect.objectContaining({ contentType: 'image/png' })
+    );
+
+    // Standard scan pipeline (no bypass), PNG mime, data-URI provenance stamped.
+    expect(mockCreateImage).toHaveBeenCalledTimes(1);
+    const arg = mockCreateImage.mock.calls[0][0];
+    expect(arg).toMatchObject({
+      url: 'store-uuid-key',
+      type: 'image',
+      mimeType: 'image/png',
+      userId: 7,
+      metadata: { source: 'app-listing-og-pull-datauri', appListingAssetKind: 'icon' },
+    });
+    expect(arg.skipIngestion).toBeUndefined();
+  });
+
+  it('REJECTS a data:text/html icon (non-image) without rasterizing or ingesting', async () => {
+    await expect(
+      ingestListingAssetFromDataUri({
+        input: { dataUri: 'data:text/html,%3Cscript%3Ealert(1)%3C%2Fscript%3E', kind: 'icon' },
+        userId: 1,
+      })
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+    expect(mockToBuffer).not.toHaveBeenCalled();
+    expect(mockUploadImageBufferToStore).not.toHaveBeenCalled();
+    expect(mockCreateImage).not.toHaveBeenCalled();
+  });
+
+  it('REJECTS a data:application/javascript icon (non-image)', async () => {
+    await expect(
+      ingestListingAssetFromDataUri({
+        input: { dataUri: 'data:application/javascript,alert(1)', kind: 'icon' },
+        userId: 1,
+      })
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+    expect(mockUploadImageBufferToStore).not.toHaveBeenCalled();
+    expect(mockCreateImage).not.toHaveBeenCalled();
+  });
+
+  it('REJECTS an oversized decoded data URI (decompression-abuse bound) before rasterizing', async () => {
+    // URL-encoded all-ASCII payload → decoded byte length == payload length. >2MB.
+    const huge = 'data:image/png,' + 'A'.repeat(2 * 1024 * 1024 + 16);
+    await expect(
+      ingestListingAssetFromDataUri({ input: { dataUri: huge, kind: 'icon' }, userId: 1 })
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+    expect(mockToBuffer).not.toHaveBeenCalled();
+    expect(mockUploadImageBufferToStore).not.toHaveBeenCalled();
+    expect(mockCreateImage).not.toHaveBeenCalled();
+  });
+
+  it('REJECTS a malformed data URI (no payload separator)', async () => {
+    await expect(
+      ingestListingAssetFromDataUri({ input: { dataUri: 'data:image/png;base64', kind: 'icon' }, userId: 1 })
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+    expect(mockUploadImageBufferToStore).not.toHaveBeenCalled();
+    expect(mockCreateImage).not.toHaveBeenCalled();
+  });
+
+  it('REJECTS an image data URI whose bytes cannot be rasterized (sharp throws)', async () => {
+    mockToBuffer.mockRejectedValue(new Error('input buffer contains unsupported image format'));
+    await expect(
+      ingestListingAssetFromDataUri({
+        input: { dataUri: 'data:image/png;base64,QG5vdC1hLXBuZw==', kind: 'icon' },
+        userId: 1,
+      })
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+    expect(mockUploadImageBufferToStore).not.toHaveBeenCalled();
     expect(mockCreateImage).not.toHaveBeenCalled();
   });
 });

--- a/src/server/services/blocks/listing-meta.service.ts
+++ b/src/server/services/blocks/listing-meta.service.ts
@@ -4,6 +4,7 @@ import { LISTING_ASSET_MAX_DIMENSION_PX } from '~/server/schema/blocks/app-listi
 import { validateExternalUrl } from '~/server/schema/blocks/external-app.schema';
 import type {
   FetchListingMetaInput,
+  IngestListingAssetFromDataUriInput,
   IngestListingAssetFromUrlInput,
 } from '~/server/schema/blocks/listing-meta.schema';
 import { extractListingMeta, type ListingMetaSuggestion } from '~/server/utils/og-metadata';
@@ -48,6 +49,25 @@ const FORMAT_TO_MIME: Record<string, string> = {
   png: 'image/png',
   webp: 'image/webp',
 };
+
+/**
+ * Inline-icon (data-URI) ingest bounds. A favicon is small; cap the DECODED bytes
+ * hard (independent of the schema's encoded-length gate — a highly-compressed blob
+ * can still decode large) before handing anything to sharp. Also bound the
+ * rasterized PNG's dimensions so an SVG with a huge intrinsic viewBox can't produce
+ * an enormous canvas.
+ */
+export const INLINE_ICON_MAX_DECODED_BYTES = 2 * 1024 * 1024;
+const INLINE_ICON_RASTER_MAX_PX = 1024;
+/** MIME types accepted for an inline-icon data URI (mirrors the extractor allowlist). */
+const INLINE_ICON_ALLOWED_MIME = new Set([
+  'image/svg+xml',
+  'image/png',
+  'image/jpeg',
+  'image/jpg',
+  'image/webp',
+  'image/gif',
+]);
 
 /** Generic, non-leaky message for any safe-fetch-layer failure. */
 function friendlyFetchError(): TRPCError {
@@ -189,6 +209,140 @@ export async function ingestListingAssetFromUrl(opts: {
     metadata: {
       size: fetched.bytes.byteLength,
       source: 'app-listing-og-pull',
+      appListingAssetKind: input.kind,
+    },
+    userId,
+  });
+
+  return { imageId: image.id };
+}
+
+// ---------------------------------------------------------------------------
+// ingestListingAssetFromDataUri (author) — accepted INLINE icon → PNG → Image row.
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse a `data:[<mime>][;base64],<data>` URI into its declared MIME + decoded
+ * bytes. Returns `null` for anything that isn't a well-formed data URI. base64 and
+ * percent-encoded (URL-encoded) payloads are both supported (an SVG favicon is
+ * commonly URL-encoded). NEVER throws.
+ */
+function parseImageDataUri(dataUri: string): { mime: string; bytes: Buffer } | null {
+  const m = /^data:([^,;]*)?(;[^,]*)?,(.*)$/is.exec(dataUri.trim());
+  if (!m) return null;
+  const mime = (m[1] || 'text/plain').toLowerCase().trim();
+  const params = (m[2] || '').toLowerCase();
+  const payload = m[3] ?? '';
+  const isBase64 = /;base64/.test(params);
+  try {
+    const bytes = isBase64
+      ? Buffer.from(payload, 'base64')
+      : Buffer.from(decodeURIComponent(payload), 'utf8');
+    if (bytes.byteLength === 0) return null;
+    return { mime, bytes };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Ingest an ACCEPTED inline `data:image/...` icon (e.g. a favicon declared as a data
+ * URI — radio.civitai.com) into a scannable `Image` row. This is a SEPARATE ingest
+ * path from the URL fetch: the bytes come from the data URI itself (no outbound
+ * fetch — never routed through safeFetch, which is https-only by design).
+ *
+ * 🔴 SECURITY — never store or serve raw SVG (SVG is an XSS vector). The flow:
+ *   1. decode the data URI; REJECT any non-image MIME (`data:text/html`,
+ *      `data:application/*`, scripts) — only `image/(svg+xml|png|jpeg|webp|gif)`;
+ *   2. cap the DECODED byte size (decompression-abuse bound);
+ *   3. RASTERIZE to PNG via sharp (SVG rasterizes through librsvg; a raster source
+ *      is normalised too), bounding the output dimensions — so the bytes that ever
+ *      reach the store are PNG, never SVG markup;
+ *   4. upload the PNG into the SAME scannable image store the URL path uses →
+ *      `createImage` through the STANDARD scan pipeline (no bypass) → `{ imageId }`.
+ * The client then attaches via `setIcon` (polling until Scanned), exactly like an
+ * author upload. Ownership is bound to the caller.
+ */
+export async function ingestListingAssetFromDataUri(opts: {
+  input: IngestListingAssetFromDataUriInput;
+  userId: number;
+}): Promise<{ imageId: number }> {
+  const { input, userId } = opts;
+
+  const parsed = parseImageDataUri(input.dataUri);
+  if (!parsed) {
+    throw new TRPCError({
+      code: 'BAD_REQUEST',
+      message: "That icon couldn't be read. Try uploading it manually.",
+    });
+  }
+  // Reject a non-image data URI (data:text/html / scripts / application/*). Only an
+  // image MIME is ever rasterized + ingested.
+  if (!INLINE_ICON_ALLOWED_MIME.has(parsed.mime)) {
+    throw new TRPCError({
+      code: 'BAD_REQUEST',
+      message: 'Unsupported icon type — upload a PNG, JPEG or WebP manually.',
+    });
+  }
+  // Cap the DECODED size (the encoded-length schema gate is coarse; a compressed
+  // blob can still decode large). Bound before handing anything to sharp.
+  if (parsed.bytes.byteLength > INLINE_ICON_MAX_DECODED_BYTES) {
+    throw new TRPCError({
+      code: 'BAD_REQUEST',
+      message: 'That icon is too large. Try uploading a smaller one manually.',
+    });
+  }
+
+  // Rasterize to PNG. This is the load-bearing security step: whatever the source
+  // (SVG markup or a raster image), the bytes we STORE are always PNG — raw SVG is
+  // never persisted or served. sharp reads an SVG via librsvg; `resize(...inside)`
+  // bounds the output canvas so a huge intrinsic viewBox can't bomb the pipeline.
+  const { default: sharp } = await import('sharp');
+  let png: Buffer;
+  let width: number | undefined;
+  let height: number | undefined;
+  try {
+    png = await sharp(parsed.bytes, { density: 96 })
+      .resize({
+        width: INLINE_ICON_RASTER_MAX_PX,
+        height: INLINE_ICON_RASTER_MAX_PX,
+        fit: 'inside',
+        withoutEnlargement: true,
+      })
+      .png()
+      .toBuffer();
+    const meta = await sharp(png).metadata();
+    width = meta.width;
+    height = meta.height;
+  } catch {
+    throw new TRPCError({
+      code: 'BAD_REQUEST',
+      message: "That icon couldn't be read. Try uploading it manually.",
+    });
+  }
+  if (!width || !height || width <= 0 || height <= 0) {
+    throw new TRPCError({
+      code: 'BAD_REQUEST',
+      message: "That icon couldn't be read. Try uploading it manually.",
+    });
+  }
+
+  // Upload the RASTERIZED PNG into the SAME scannable store the URL path uses (B2
+  // image bucket + storage-resolver) — the edge URL + scanner resolve it.
+  const { uploadImageBufferToStore } = await import('~/utils/s3-utils');
+  const { key } = await uploadImageBufferToStore(png, { contentType: 'image/png' });
+
+  const { createImage } = await import('~/server/services/image.service');
+  const image = await createImage({
+    url: key,
+    name: `listing-${input.kind}`,
+    type: 'image',
+    width,
+    height,
+    mimeType: 'image/png',
+    metadata: {
+      size: png.byteLength,
+      source: 'app-listing-og-pull-datauri',
       appListingAssetKind: input.kind,
     },
     userId,

--- a/src/server/services/blocks/listing-meta.service.ts
+++ b/src/server/services/blocks/listing-meta.service.ts
@@ -59,6 +59,17 @@ const FORMAT_TO_MIME: Record<string, string> = {
  */
 export const INLINE_ICON_MAX_DECODED_BYTES = 2 * 1024 * 1024;
 const INLINE_ICON_RASTER_MAX_PX = 1024;
+/**
+ * 🔴 EXPLICIT input-pixel cap for the inline-icon rasterizer — do NOT rely on
+ * librsvg's implicit default policy (a sharp/libvips/librsvg bump could silently
+ * change it). The output is always clamped to ≤{@link INLINE_ICON_RASTER_MAX_PX}px
+ * (~1MP), so 16MP (4096×4096) is ample headroom while bounding librsvg allocation:
+ * a VALID sub-268MP SVG with a huge intrinsic viewBox (e.g. 15000×15000 ≈ 225MP,
+ * which librsvg would render at ~900MB BEFORE the downscale clamps it) is instead
+ * rejected at decode with a clean BAD_REQUEST — nothing is allocated at full size
+ * and nothing is stored. Applies to the raster (png/jpeg/webp/gif) path too.
+ */
+const INLINE_ICON_MAX_INPUT_PIXELS = 16 * 1024 * 1024; // 16,777,216 px = 4096×4096
 /** MIME types accepted for an inline-icon data URI (mirrors the extractor allowlist). */
 const INLINE_ICON_ALLOWED_MIME = new Set([
   'image/svg+xml',
@@ -302,7 +313,14 @@ export async function ingestListingAssetFromDataUri(opts: {
   let width: number | undefined;
   let height: number | undefined;
   try {
-    png = await sharp(parsed.bytes, { density: 96 })
+    png = await sharp(parsed.bytes, {
+      density: 96,
+      // 🔴 Explicit input-pixel cap (see INLINE_ICON_MAX_INPUT_PIXELS) — reject an
+      // oversized SVG viewBox / raster canvas at DECODE with a clean BAD_REQUEST,
+      // rather than trusting librsvg's implicit default. Bounds allocation before the
+      // downscale.
+      limitInputPixels: INLINE_ICON_MAX_INPUT_PIXELS,
+    })
       .resize({
         width: INLINE_ICON_RASTER_MAX_PX,
         height: INLINE_ICON_RASTER_MAX_PX,

--- a/src/server/utils/__tests__/og-metadata.test.ts
+++ b/src/server/utils/__tests__/og-metadata.test.ts
@@ -145,6 +145,55 @@ describe('extractListingMeta', () => {
     });
   });
 
+  describe('inline data-URI icon channel (iconDataUri)', () => {
+    it('surfaces a data:image/svg+xml favicon as iconDataUri (radio.civitai.com case) — name set, cover/description undefined', () => {
+      // radio.civitai.com's <head>: only a <title> + an inline SVG favicon. No og:image,
+      // no description. The https icon channel drops the data: URI; the inline channel
+      // surfaces it so the author still gets an accept-able icon.
+      const svg = 'data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%2F%3E';
+      const html = `<title>AI Radio</title><link rel="icon" type="image/svg+xml" href="${svg}">`;
+      const r = extractListingMeta(html, BASE);
+      expect(r.name).toBe('AI Radio');
+      expect(r.iconDataUri).toBe(svg);
+      // No usable https icon, no cover, no description — genuinely absent.
+      expect(r.iconImageUrl).toBeUndefined();
+      expect(r.coverImageUrl).toBeUndefined();
+      expect(r.description).toBeUndefined();
+      expect(r.tagline).toBeUndefined();
+    });
+
+    it('surfaces a base64 data:image/png apple-touch-icon as iconDataUri', () => {
+      const dataUri = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUg==';
+      const html = `<link rel="apple-touch-icon" href="${dataUri}">`;
+      expect(extractListingMeta(html, BASE).iconDataUri).toBe(dataUri);
+    });
+
+    it('does NOT surface a data:text/html icon as iconDataUri (non-image rejected)', () => {
+      const html = `<link rel="icon" href="data:text/html,%3Cscript%3Ealert(1)%3C%2Fscript%3E">`;
+      const r = extractListingMeta(html, BASE);
+      expect(r.iconDataUri).toBeUndefined();
+      expect(r.iconImageUrl).toBeUndefined();
+    });
+
+    it('prefers a real https favicon for iconImageUrl but STILL surfaces an inline data-URI icon separately', () => {
+      const dataUri = 'data:image/svg+xml,%3Csvg%2F%3E';
+      const html = `
+        <link rel="icon" href="/favicon.png">
+        <link rel="apple-touch-icon" href="${dataUri}">`;
+      const r = extractListingMeta(html, BASE);
+      // The https favicon is NOT shadowed by the data-URI apple-touch-icon.
+      expect(r.iconImageUrl).toBe('https://vendor.example.com/favicon.png');
+      expect(r.iconDataUri).toBe(dataUri);
+    });
+
+    it('a normal page with no data-URI icon leaves iconDataUri undefined (https icon still works)', () => {
+      const html = `<link rel="icon" href="/favicon.ico">`;
+      const r = extractListingMeta(html, BASE);
+      expect(r.iconImageUrl).toBe('https://vendor.example.com/favicon.ico');
+      expect(r.iconDataUri).toBeUndefined();
+    });
+  });
+
   describe('adversarial-input cost (event-loop-freeze / ReDoS guard)', () => {
     // Regression for the O(n^2) container-regex freeze: many unclosed <header>
     // open tags forced the lazy backreference match to rescan to EOF at every

--- a/src/server/utils/og-metadata.ts
+++ b/src/server/utils/og-metadata.ts
@@ -38,6 +38,19 @@ const META_HTML_PARSE_CAP = 256_000;
 // lazy inner capture stops the container regex from rescanning to EOF at every
 // unmatched open tag (the O(n^2) event-loop-freeze vector on hostile input).
 const HEADER_NAV_BLOCK_MAX = 8_000;
+/**
+ * Allowed inline-icon data-URI image MIME types (mirrors the server ingest
+ * allowlist). A `data:text/html` / `data:application/*` / script URI is NEVER
+ * surfaced as an `iconDataUri` — it is not an image and the accept path rejects it.
+ */
+const ICON_DATA_URI_RE = /^data:image\/(svg\+xml|png|jpeg|jpg|webp|gif)[;,]/i;
+/**
+ * Upper bound on the surfaced data-URI string length. The parse cap
+ * ({@link META_HTML_PARSE_CAP}) already bounds it, but a hard skip keeps an
+ * absurd inline blob out of the suggestion payload. The SERVER re-caps the
+ * DECODED byte size independently on accept.
+ */
+const MAX_ICON_DATA_URI_LEN = 2_000_000;
 
 export type ListingMetaSuggestion = {
   name?: string;
@@ -46,6 +59,18 @@ export type ListingMetaSuggestion = {
   description?: string;
   coverImageUrl?: string;
   iconImageUrl?: string;
+  /**
+   * An inline `data:image/...` icon (e.g. a favicon declared as
+   * `<link rel="icon" href="data:image/svg+xml,...">`) — a DISTINCT channel from
+   * `iconImageUrl`. The https-only `resolveUrl`/`safeFetch` path deliberately drops
+   * `data:` URIs (they can't be re-fetched), so a site whose ONLY icon is inline
+   * (radio.civitai.com) would otherwise surface no icon at all. This is NOT routed
+   * through `safeFetch`; on accept the server decodes + RASTERIZES it to PNG through
+   * a separate, size-capped, image-mime-allowlisted ingest path (never stores raw
+   * SVG — an XSS vector). Only a `data:image/(svg+xml|png|jpeg|webp|gif)` href is
+   * ever surfaced here (a `data:text/html` / script URI is not).
+   */
+  iconDataUri?: string;
 };
 
 /** Read one attribute value from a single tag string (double, single, or unquoted). */
@@ -145,6 +170,28 @@ function pickIconHref(candidates: IconCandidate[]): string | undefined {
     .filter((c) => c.rel.includes('icon'))
     .sort((a, b) => b.sizePx - a.sizePx);
   return icons[0]?.href;
+}
+
+/**
+ * Pick the best INLINE `data:` icon from the candidates (radio.civitai.com's only
+ * icon is `<link rel="icon" href="data:image/svg+xml,...">`). Prefer apple-touch,
+ * then the largest declared `rel=icon`; only an image-MIME data URI within the
+ * length bound is returned (a `data:text/html` / oversized blob is skipped). The
+ * raw href is returned; the server validates + rasterizes it on accept.
+ */
+function pickIconDataUri(candidates: IconCandidate[]): string | undefined {
+  const dataUris = candidates.filter((c) => /^data:/i.test(c.href.trim()));
+  if (dataUris.length === 0) return undefined;
+  const apple = dataUris
+    .filter((c) => c.rel.includes('apple-touch-icon'))
+    .sort((a, b) => b.sizePx - a.sizePx);
+  const rest = dataUris.filter((c) => c.rel.includes('icon')).sort((a, b) => b.sizePx - a.sizePx);
+  for (const c of [...apple, ...rest]) {
+    const href = c.href.trim();
+    if (href.length > MAX_ICON_DATA_URI_LEN) continue;
+    if (ICON_DATA_URI_RE.test(href)) return href;
+  }
+  return undefined;
 }
 
 /**
@@ -280,12 +327,20 @@ export function extractListingMeta(html: string, finalUrl: string): ListingMetaS
     meta.get('twitter:image:src');
   const coverImageUrl = resolveUrl(coverHref, finalUrl);
 
+  const iconCandidates = extractIconCandidates(html);
   // Favicon / apple-touch-icon first; a header/nav brand <img> is the LAST-RESORT
   // icon so a site with no declared icon still gets a suggestion (never
   // auto-committed — the author accepts it, then it re-fetches through safeFetch).
+  // For the https channel, IGNORE `data:` candidates so a data-URI apple-touch-icon
+  // can't shadow a real https favicon (the inline one is surfaced separately below).
+  const httpsIconCandidates = iconCandidates.filter((c) => !/^data:/i.test(c.href.trim()));
   const iconImageUrl =
-    resolveUrl(pickIconHref(extractIconCandidates(html)), finalUrl) ??
+    resolveUrl(pickIconHref(httpsIconCandidates), finalUrl) ??
     resolveUrl(extractHeaderNavImgHref(html), finalUrl);
+  // Inline data-URI icon — a DISTINCT channel (never routed through the https-only
+  // safeFetch path). Surfaced when present so a site whose only icon is inline
+  // (radio.civitai.com) still gets an accept-able suggestion.
+  const iconDataUri = pickIconDataUri(iconCandidates);
 
   const result: ListingMetaSuggestion = {};
   if (name) result.name = name;
@@ -293,5 +348,6 @@ export function extractListingMeta(html: string, finalUrl: string): ListingMetaS
   if (description) result.description = description;
   if (coverImageUrl) result.coverImageUrl = coverImageUrl;
   if (iconImageUrl) result.iconImageUrl = iconImageUrl;
+  if (iconDataUri) result.iconDataUri = iconDataUri;
   return result;
 }


### PR DESCRIPTION
Rework the App Blocks external-listing autofill (create + edit wizards):

1. Auto-trigger the OG pull on a valid https URL (blur/Enter/advance + a
   debounced ~600ms pause) and REMOVE the manual "Pull from site" /
   "Autofill from website" buttons. Fires at most once per distinct URL and
   re-fires on a new URL; never fires for invalid/empty. Preserves
   fill-if-empty (never clobbers an edited field).

2. Factor the duplicated autofill logic into one shared hook
   `useListingAutofill` (auto-trigger + fetchListingMetaFromUrl + fill-if-empty
   apply + MetaSuggestions + status/note + repull), consumed by both forms with
   form-specific wiring injected.

3. Add a step-level "Re-pull from site" button to ListingAssetStep (the manual
   retry that replaces the removed URL-step button), wired through both forms.

4. Support an inline data-URI icon (the radio.civitai.com case: only a
   `<link rel=icon href="data:image/svg+xml,...">`). og-metadata surfaces it as
   a distinct `iconDataUri` channel (data: URIs still never go through the
   https-only safeFetch/resolveUrl path). On accept, a new authed
   `ingestAssetFromDataUri` mutation decodes it, REJECTS non-image MIMEs
   (data:text/html/scripts/application/*), caps the decoded size (~2MB), and
   RASTERIZES to PNG via sharp — raw SVG is never stored or served (XSS vector) —
   then runs the standard scan pipeline.

Also fix the misleading autofill note: distinguish applied / partial / empty
(site-exposed-nothing vs already-filled) / error via a pure
`computeAutofillStatus` — never claims "already filled" when the pull genuinely
found nothing.

Tests: og-metadata iconDataUri (radio fixture, non-image rejected, https
preferred but inline still surfaced); data-URI ingest (svg->PNG, non-image /
oversized / malformed / unrasterizable rejected, never-raw-SVG asserted); the
status four-state logic; the useListingAutofill hook (once-per-url, re-fire,
no-fire-on-invalid, fill-if-empty, repull); and browser-mode coverage of the
auto-trigger, status notes, data-URI icon tile, and the "Re-pull from site"
button.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
