### PR TITLE
fix(mobile): stop pull-to-refresh firing where it makes no sense

### DIFF
--- a/src/components/Dialog/Templates/PageModal.tsx
+++ b/src/components/Dialog/Templates/PageModal.tsx
@@ -14,7 +14,10 @@ export function PageModal({ children, ...props }: ModalProps) {
       removeScrollProps={{ allowPinchZoom: true }}
       zIndex={250}
     >
-      <ScrollArea pb={0}>{children}</ScrollArea>
+      {/* a drag inside a modal should never reload the page underneath it */}
+      <ScrollArea pb={0} withPullToRefresh={false}>
+        {children}
+      </ScrollArea>
     </Modal>
   );
 }

--- a/src/components/ScrollArea/ScrollArea.tsx
+++ b/src/components/ScrollArea/ScrollArea.tsx
@@ -15,6 +15,7 @@ export function ScrollArea({
   className,
   scrollRestore,
   intersectionObserverOptions,
+  withPullToRefresh = true,
   ...props
 }: ScrollAreaProps & { children: React.ReactNode }) {
   const { ref: scrollRef, key } = useScrollRestore<HTMLDivElement>(scrollRestore);
@@ -31,7 +32,7 @@ export function ScrollArea({
           className={clsx('scroll-area flex-1 @container ', className)}
           {...props}
         >
-          {isMobile && <DragLoader />}
+          {isMobile && withPullToRefresh && <DragLoader />}
           {children}
         </Box>
       </IntersectionObserverProvider>
@@ -46,6 +47,12 @@ export type ScrollAreaProps = BoxProps & {
   scrollRestore?: UseScrollRestoreProps;
   id?: string;
   intersectionObserverOptions?: IntersectionObserverInit;
+  /**
+   * Pull-down-to-refresh on touch devices. Off for surfaces where reloading the
+   * page is not a sensible response to a downward drag — modals, and anything
+   * that handles its own gestures.
+   */
+  withPullToRefresh?: boolean;
 };
 
 function DragLoader() {
@@ -68,6 +75,10 @@ function DragLoader() {
     };
 
     const pullStart = (e: TouchEvent) => {
+      // A view with nothing to scroll has no top to pull from, so every downward
+      // drag would arm the refresh — including a drift off a horizontal swipe in
+      // a full-height view like image detail.
+      if (node.scrollHeight <= node.clientHeight) return;
       const { screenY } = e.targetTouches[0];
       if (node.scrollTop === 0) {
         startPointRef.current = screenY;


### PR DESCRIPTION
Pull-to-refresh fires in the image detail view, where a downward drag reloading the page makes no sense and collides with swipe navigation. Reported by Justin while testing #3422 on mobile.

Split out from #3422 because it's a general app-level issue, not specific to the carousel. Based directly on `main`, not stacked.

## Why it happens

`ScrollArea` mounts `DragLoader` on every touch device, unconditionally:

```tsx
{isMobile && <DragLoader />}
```

Both `AppLayout` and `PageModal` render a `ScrollArea`, so the image detail modal carries **two** of them — the layout's and the modal's.

The arming condition is `node.scrollTop === 0`. In a full-height view that never scrolls, scrollTop is *permanently* 0, so every downward drag reads as a pull from the top. A horizontal swipe with a little vertical drift is enough, and a pull past 220px calls `window.location.reload()`.

## Changes

- **Only arm when the container actually scrolls** (`scrollHeight > clientHeight`). A view with nothing to scroll has no top to pull from. This is the general fix — it takes pull-to-refresh off every non-scrolling surface, not just this one.
- **`withPullToRefresh` opt-out on `ScrollArea`, off for `PageModal`.** A drag inside a modal should never reload the page underneath it, scrollable or not. Covers image detail, post detail, and resource review — the three `PageModal` consumers.

## Verification

Typecheck and lint clean (the one remaining `exhaustive-deps` warning in `ScrollArea` is pre-existing). The behavior is touch-only, so it needs a device:

- [ ] Image detail on mobile: swipe horizontally — no refresh spinner, no reload
- [ ] Image detail on mobile: drag straight down — nothing happens
- [ ] Image feed / model list: pull down from the top still refreshes
- [ ] A short feed that doesn't fill the viewport no longer offers pull-to-refresh — this is the intended consequence of the scrollability guard, but worth a look in case that reads as a regression to you

The claim that the image detail view's layout `ScrollArea` is non-scrolling is from reading the markup (`size-full` + `overflow-hidden`), not from a device — so the scrollability guard doing the work there is expected rather than confirmed. The `PageModal` opt-out covers the modal path regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
