### PR TITLE
fix(ingest-images): bound orchestrator submit + make send loop hang-proof

### DIFF
--- a/src/server/jobs/__tests__/ingest-images-send-resilience.test.ts
+++ b/src/server/jobs/__tests__/ingest-images-send-resilience.test.ts
@@ -42,7 +42,7 @@ const { mockDbRead, mockDbWrite, mockIngestImage, mockDeleteImages, mockLimitCon
       // Image id 2 hangs forever; all others succeed. A hung submit must not stall
       // or reject the run — the per-image timeout turns it into a failed send.
       mockIngestImage: vi.fn(({ image }: { image: { id: number } }) =>
-        image.id === 2 ? new Promise<boolean>(() => {}) : Promise.resolve(true)
+        image.id === 2 ? new Promise<boolean>(() => undefined) : Promise.resolve(true)
       ),
       mockDeleteImages: vi.fn(async () => undefined),
       mockLimitConcurrency: vi.fn(async (tasks: Array<() => Promise<unknown>>) => {
@@ -70,10 +70,8 @@ vi.mock('~/env/server', () => ({
 import { ingestImages } from '~/server/jobs/image-ingestion';
 
 const ctx = {} as Parameters<typeof ingestImages.run>[0];
-async function runJob<T extends { run: (ctx: any) => { result: Promise<unknown> } }>(
-  job: T
-): Promise<unknown> {
-  return await job.run(ctx).result;
+async function runJob(): Promise<unknown> {
+  return await ingestImages.run(ctx).result;
 }
 
 beforeEach(() => {
@@ -90,7 +88,7 @@ afterEach(() => {
 
 describe('ingest-images send resilience', () => {
   it('completes the run and submits the healthy images even when one ingestImage hangs', async () => {
-    const p = runJob(ingestImages) as Promise<{
+    const p = runJob() as Promise<{
       sent: number;
       sentUserPending: number;
       failedSends: number;

--- a/src/server/jobs/__tests__/ingest-images-send-resilience.test.ts
+++ b/src/server/jobs/__tests__/ingest-images-send-resilience.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// A single ingestImage whose orchestrator submit never resolves must NOT stall the
+// whole run. The sends run sequentially within a chunk, so an unbounded hang there
+// meant the run never completed, got killed, recorded no job metric, and re-loaded
+// the same stuck oldest rows forever (the backlog never drained). This drives the
+// real job with one image whose ingestImage never settles and asserts the run still
+// completes: the hung image is failed (bounded by the per-image timeout) while the
+// others are submitted.
+
+const { mockDbRead, mockDbWrite, mockIngestImage, mockDeleteImages, mockLimitConcurrency } =
+  vi.hoisted(() => {
+    const pulled: { ids: number[] } = { ids: [] };
+    return {
+      mockDbRead: {
+        jobQueue: {
+          findMany: vi.fn(async ({ take }: { take: number }) => {
+            pulled.ids = Array.from({ length: take }, (_, i) => i + 1);
+            return pulled.ids.map((entityId) => ({ entityId }));
+          }),
+        },
+      },
+      mockDbWrite: {
+        $queryRaw: vi.fn(async () =>
+          pulled.ids.map((id) => ({
+            id,
+            url: `img-${id}`,
+            type: 'image',
+            width: 100,
+            height: 100,
+            prompt: null,
+            scanRequestedAt: null,
+            createdAt: new Date(),
+            ingestion: 'Pending',
+            retryCount: 0,
+            failureClass: null,
+            isBackfill: false,
+          }))
+        ),
+        $executeRaw: vi.fn(async () => 0),
+      },
+      // Image id 2 hangs forever; all others succeed. A hung submit must not stall
+      // or reject the run — the per-image timeout turns it into a failed send.
+      mockIngestImage: vi.fn(({ image }: { image: { id: number } }) =>
+        image.id === 2 ? new Promise<boolean>(() => {}) : Promise.resolve(true)
+      ),
+      mockDeleteImages: vi.fn(async () => undefined),
+      mockLimitConcurrency: vi.fn(async (tasks: Array<() => Promise<unknown>>) => {
+        for (const t of tasks) await t();
+      }),
+    };
+  });
+
+vi.mock('~/server/db/client', () => ({ dbRead: mockDbRead, dbWrite: mockDbWrite }));
+vi.mock('~/server/services/image.service', () => ({
+  ingestImage: mockIngestImage,
+  deleteImages: mockDeleteImages,
+}));
+vi.mock('~/server/utils/concurrency-helpers', () => ({ limitConcurrency: mockLimitConcurrency }));
+vi.mock('~/env/other', () => ({ isProd: true }));
+vi.mock('~/env/server', () => ({
+  env: {
+    IMAGE_SCANNING_MAX_PER_RUN: 3,
+    IMAGE_SCANNING_RETRY_DELAY: 5,
+    IMAGE_SCANNING_PENDING_TIMEOUT: 60 * 24,
+    DATABASE_IS_PROD: true,
+  },
+}));
+
+import { ingestImages } from '~/server/jobs/image-ingestion';
+
+const ctx = {} as Parameters<typeof ingestImages.run>[0];
+async function runJob<T extends { run: (ctx: any) => { result: Promise<unknown> } }>(
+  job: T
+): Promise<unknown> {
+  return await job.run(ctx).result;
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  mockDbRead.jobQueue.findMany.mockClear();
+  mockDbWrite.$queryRaw.mockClear();
+  mockDbWrite.$executeRaw.mockClear();
+  mockIngestImage.mockClear();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('ingest-images send resilience', () => {
+  it('completes the run and submits the healthy images even when one ingestImage hangs', async () => {
+    const p = runJob(ingestImages) as Promise<{
+      sent: number;
+      sentUserPending: number;
+      failedSends: number;
+    }>;
+
+    // Advance past the per-image timeout for every in-batch retry of the hung image
+    // (3 retries * 60s) so the run drains to completion instead of hanging.
+    await vi.advanceTimersByTimeAsync(4 * 60 * 1000);
+
+    const result = await p;
+
+    // The two healthy images (ids 1 and 3) were submitted; the hung image (id 2) is
+    // counted as a failed send, not a run-stalling hang.
+    expect(result.sentUserPending).toBe(2);
+    expect(result.failedSends).toBe(1);
+    // The hung image was attempted and retried in-batch rather than aborting the loop.
+    const hungAttempts = mockIngestImage.mock.calls.filter((c) => c[0].image.id === 2).length;
+    expect(hungAttempts).toBeGreaterThan(1);
+  });
+});

--- a/src/server/jobs/image-ingestion.ts
+++ b/src/server/jobs/image-ingestion.ts
@@ -16,6 +16,35 @@ import { decreaseDate } from '~/utils/date-helpers';
 const IMAGE_SCANNING_ERROR_DELAY = 60 * 1; // 1 hour
 const IMAGE_SCANNING_RETRY_LIMIT = 9;
 
+// Hard per-image backstop for the send loop below. The sends run sequentially within
+// each 250-image chunk (concurrency 4), so a SINGLE ingestImage that never resolves
+// stalls its whole chunk and the run never completes — and because createJob only
+// records duration/errors once the run settles, a killed run records NOTHING (the
+// exact "absent from job metrics" signature) and re-loads the same stuck oldest-1000
+// rows every 5 min, so the backlog never drains. The orchestrator submit is already
+// bounded per-attempt (createImageIngestionRequest), but this also covers any other
+// external await inside ingestImage (Redis flag read, prompt lookup, the scanJobs
+// UPDATE). Set above the bounded submit worst case (~15s × 3 + backoff) so it never
+// pre-empts a legitimately-retrying submit; a fired timeout just fails that image →
+// it stays queued and is retried on a later run.
+const INGEST_IMAGE_TIMEOUT_MS = 60 * 1000;
+
+function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(`ingestImage timed out after ${ms}ms`)), ms);
+    promise.then(
+      (value) => {
+        clearTimeout(timer);
+        resolve(value);
+      },
+      (error) => {
+        clearTimeout(timer);
+        reject(error);
+      }
+    );
+  });
+}
+
 type IngestImageRow = IngestImageInput & {
   scanRequestedAt: Date | null;
   ingestion: string;
@@ -134,15 +163,10 @@ export const ingestImages = createJob('ingest-images', '*/5 * * * *', async () =
   // Pending image is flipped to Error (below, in the prod block), which routes it
   // into the EXISTING capped Error-retry machinery — it gets a bounded number of
   // real retries and then terminalizes, instead of being Pending forever.
-  const pendingTimeoutDate = decreaseDate(
-    now,
-    env.IMAGE_SCANNING_PENDING_TIMEOUT,
-    'minutes'
-  );
+  const pendingTimeoutDate = decreaseDate(now, env.IMAGE_SCANNING_PENDING_TIMEOUT, 'minutes');
   const agedOutPendingIds = images
     .filter(
-      (img) =>
-        img.ingestion === 'Pending' && !img.isBackfill && img.createdAt <= pendingTimeoutDate
+      (img) => img.ingestion === 'Pending' && !img.isBackfill && img.createdAt <= pendingTimeoutDate
     )
     .map((img) => img.id);
   const agedOutPendingSet = new Set(agedOutPendingIds);
@@ -397,7 +421,18 @@ async function sendImagesForScanBulk(
       const failedImages: IngestImageInput[] = [];
 
       for (const image of imagesToProcess) {
-        const imageSuccess = await ingestImage({ image, lowPriority: options?.lowPriority });
+        // Bound each submit AND catch throws so one hung/failing image can't stall or
+        // abort the batch — a timeout or error just marks this image failed (retried
+        // in-batch below, then on a later run), never rejects the whole run.
+        let imageSuccess = false;
+        try {
+          imageSuccess = await withTimeout(
+            ingestImage({ image, lowPriority: options?.lowPriority }),
+            INGEST_IMAGE_TIMEOUT_MS
+          );
+        } catch {
+          imageSuccess = false;
+        }
         if (!imageSuccess) {
           failedImages.push(image);
         }

--- a/src/server/services/orchestrator/orchestrator.service.ts
+++ b/src/server/services/orchestrator/orchestrator.service.ts
@@ -20,6 +20,21 @@ import { EntityModerationStatus, ModelHashType, ScanResultCode } from '~/shared/
 import { stringifyAIR } from '~/shared/utils/air';
 import { resolveDownloadUrl } from '~/utils/delivery-worker';
 
+// Per-attempt backstop for the image-ingestion orchestrator SUBMIT (enqueue only —
+// this returns a workflow id immediately, it does NOT wait for the scan to finish).
+// Left unbounded, a submit whose socket the orchestrator accepts but never answers
+// (the Siglip/wdTagging container-instability failure mode) hangs forever with no
+// caller-side timeout. In the ingest-images cron that single hang stalls its send
+// chunk and the whole run never completes — and because createJob only records
+// duration/errors when the run settles, the killed run records nothing and re-loads
+// the same stuck oldest-1000 rows every 5 min, so the backlog never drains. 15s sits
+// well above the ~4.7s submit P99, so it fires only on the genuine hang tail; a fired
+// AbortSignal.timeout throws a TimeoutError that submitWorkflowWithRetry treats as a
+// transient failure → backoff + retry (3 attempts) → surface. Mirrors the whatIf
+// per-attempt backstop. Only applied when NOT `wait`ing (a caller that passes `wait`
+// explicitly wants to block for the workflow, so we must not abort it early).
+const IMAGE_INGEST_SUBMIT_ATTEMPT_TIMEOUT_MS = 15_000;
+
 export async function createImageIngestionRequest({
   imageId,
   url,
@@ -178,11 +193,14 @@ export async function createImageIngestionRequest({
 
   // Re-submit transient infra failures (5xx / no-response), reusing the same
   // `externalId` so a 500 that actually created the workflow isn't duplicated.
-  const result = await submitWorkflowWithRetry({
-    client: internalOrchestratorClient,
-    query: wait ? { wait } : undefined,
-    body,
-  });
+  const result = await submitWorkflowWithRetry(
+    {
+      client: internalOrchestratorClient,
+      query: wait ? { wait } : undefined,
+      body,
+    },
+    wait ? undefined : { perAttemptTimeoutMs: IMAGE_INGEST_SUBMIT_ATTEMPT_TIMEOUT_MS }
+  );
   const { data, response, attempts } = result;
   // `error` isn't present on every member of the result union — narrow with `in`.
   const error = 'error' in result ? result.error : undefined;


### PR DESCRIPTION
## Problem: the `ingest-images` cron hangs every run

The cron is **completely absent** from `civitai_app_job_duration_seconds` and `civitai_app_job_errors_total` while **75 other jobs record normally** — so `createJob`'s instrumentation works; `ingest-images` specifically never reaches the completed path. Yet it **does** set `civitai_app_image_ingest_cron_queue_depth = 1000` (an early line, right after loading the queue) and emits **nothing** on `civitai_app_image_ingest_cron_total` (the send-accounting counters near the end). So it **starts every run, then hangs before completing, and gets killed** — submitting nothing. Because it loads the oldest-1000 first and re-loads the same stuck rows every 5 min, the backlog (**46k Error + ~8k ancient Pending, oldest 2023**) never drains. The downstream scanner is healthy (36,717 scans/6h, 0.4% errors) via the direct upload path — this is **not** scanner capacity.

Why the metric is absent: `createJob` records duration in `.finally()` and errors in `.catch()` (`job.ts:84-102`) — both only run once the returned promise **settles**. A run that hangs forever never settles, so it records neither. **No error series either** → it is not throwing-and-caught; it is hanging on an unbounded await.

## Hang point (confirmed): unbounded orchestrator submit

`sendImagesForScanBulk` → `ingestImage` (`image.service.ts:864`) → new-scanner path → `createImageIngestionRequest` (`orchestrator.service.ts`) → `submitWorkflowWithRetry(...)` called with **no `perAttemptTimeoutMs`** → `clientSubmitWorkflow` runs an **unbounded `fetch`** (`workflows.ts:494`). When the orchestrator accepts the socket but never answers — the Siglip/wdTagging container-instability failure mode — the submit hangs forever. The cron sends **sequentially within 250-image chunks at concurrency 4** (`image-ingestion.ts`), so **one** hung `ingestImage` stalls its chunk and the whole run never finishes. Classic "job hangs, gets killed, records nothing."

Corroborating:
- The **legacy** `IMAGE_SCANNING_ENDPOINT` path already has a 60s fetch timeout (`image.service.ts:960`); the **new** orchestrator path did not. It regressed when the orchestrator submit-backoff landed (`54a29a32bd`, 2026-06-02); the per-attempt timeout added later was scoped to whatIf only.
- Suspect (a), the `dbWrite.$queryRaw` isBackfill fetch, is **ruled out**: Postgres `statement_timeout` would make it **throw** → an error series we don't see. It runs on the primary and could be improved, but it is not the hang, so it's left unchanged to avoid replica-lag semantics changes to the send/prune logic.

## Fix

1. **Root cause** — bound each orchestrator ingestion submit attempt to **15s** in `createImageIngestionRequest` (passes `perAttemptTimeoutMs`). A hung socket now aborts via `AbortSignal.timeout` → `submitWorkflowWithRetry` retries (3 attempts) → surfaces, instead of hanging. Sized above the ~4.7s submit P99; mirrors the existing whatIf backstop. **Skipped when `wait` is set** (a caller that blocks for the workflow must not be aborted early).
2. **Resilience** — in the cron send loop, wrap each `ingestImage` in a **60s per-image timeout AND a try/catch**. A timeout or throw now fails just that one image (counted as a failed send → left in the queue → retried next run) instead of stalling or aborting the batch. The 60s cap also covers any other external await inside `ingestImage` (Redis flag read, prompt lookup, the scanJobs UPDATE).

## Invariants preserved

- #3370 terminal-delete + prune-before-send ordering
- retry / bucket / cooldown / cap logic and the reason-aware Error ceiling
- the `isProd` guard
- the pending / backfill / rescan / error lanes and their priorities

## Tests

Added `src/server/jobs/__tests__/ingest-images-send-resilience.test.ts` (fake timers): a never-resolving `ingestImage` no longer stalls the run — the healthy images still submit and the hung one is recorded as a failed send. All 4 ingest-images cron tests pass (8 tests). `typecheck` and `lint` clean (pre-existing unrelated `kysely` / `@civitai/client` mage-flow errors only).

This is what **unblocks draining the 46k Error + 8k Pending backlog**.

## For the reviewer

- Value choices: 15s per-attempt submit / 60s per-image cap. Both are backstops sized well above healthy latency; tighten later if the tail allows.
- The 60s per-image timeout does not cancel the underlying `ingestImage` promise — but fix #1 aborts the actual fetch, so the leaked promise settles shortly after. Only a non-fetch internal hang would leave a true leak, which we accept in exchange for the run always progressing.
- Left `dbWrite.$queryRaw` on the primary unchanged (see ruled-out reasoning above) — flag if you'd prefer moving it to `dbRead`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
