### PR TITLE
chore(basemodel): retire dead compat-layer exports

### DIFF
--- a/docs/adding-basemodel-ecosystem-guide.md
+++ b/docs/adding-basemodel-ecosystem-guide.md
@@ -715,7 +715,6 @@ After adding a new model, verify:
 - [ ] Model appears in `activeBaseModels` if not hidden
 - [ ] Ecosystem appears in `baseModelGroups` array export
 - [ ] `getBaseModelGenerationConfig()` includes new ecosystem (if has generation support)
-- [ ] `getGenerationBaseModelConfigs()` includes new ecosystem (if has generation support)
 
 ### Documentation
 - [ ] Updated this guide with new patterns (if introducing new pattern)

--- a/docs/adding-new-base-models-to-generation.md
+++ b/docs/adding-new-base-models-to-generation.md
@@ -17,7 +17,7 @@ Before a base model can be used for generation, it must first be defined in the 
 ### 1. Define Base Model in Constants
 
 #### Add to Base Model Configuration
-**File**: `src/shared/constants/base-model.constants.ts`
+**File**: `src/shared/constants/basemodel.constants.ts`
 
 Add a new entry to the `baseModelConfig` array. The structure determines the base model's basic properties:
 
@@ -92,7 +92,7 @@ Once the base model is defined in the system, you can enable it for generation w
 ### 4. Define Base Model Generation Support
 
 #### Add to Base Model Generation Configuration
-**File**: `src/shared/constants/base-model.constants.ts`
+**File**: `src/shared/constants/basemodel.constants.ts`
 
 Add a new configuration entry to the `baseModelGenerationConfig` array:
 
@@ -294,7 +294,7 @@ This commit implemented Part 1 of the process:
 - Added 'CHR' badge indicator for the UI
 
 **Files Changed:**
-- `src/shared/constants/base-model.constants.ts` - Added base model definition
+- `src/shared/constants/basemodel.constants.ts` - Added base model definition
 - `src/server/common/constants.ts` - Added license mapping
 - `src/components/Model/ModelTypeBadge/ModelTypeBadge.tsx` - Added badge
 
@@ -308,7 +308,7 @@ This commit implemented Part 2 of the process:
 - Configured generation-specific behaviors
 
 **Files Changed:**
-- `src/shared/constants/base-model.constants.ts` - Added generation config
+- `src/shared/constants/basemodel.constants.ts` - Added generation config
 - `src/shared/constants/generation.constants.ts` - Added helper functions
 - `src/server/common/constants.ts` - Added generation resource config
 - `src/server/services/orchestrator/common.ts` - Added parameter handling

--- a/docs/features/generator.md
+++ b/docs/features/generator.md
@@ -279,7 +279,7 @@ Located in `src/server/orchestrator/`:
 Would you like me to dive deeper into any specific area or add more details about particular integration methods?
 
 @dev: Please review the contents of these files to refine your understanding. These are critical files to the generation process and are typically updated when adding support for new base model types and generation engines:
-- src/shared/constants/base-model.constants.ts
+- src/shared/constants/basemodel.constants.ts
 - src/shared/constants/generation.constants.ts
 - src/server/common/constants.ts
 - src/components/ImageGeneration/GenerationForm/GenerationForm2.tsx

--- a/src/server/services/blocks/workflow.service.ts
+++ b/src/server/services/blocks/workflow.service.ts
@@ -317,7 +317,7 @@ export async function resolveBlockVersionContext(modelVersionId: number, expecte
 // Page-LoRA (Increment 1): the model types accepted as a page additional
 // resource. v1 is LoRA-only — the generator's LoRA family is LORA + LoCon +
 // DoRA (the same set the generation resource picker groups as "LoRA"; see
-// base-model.constants supportMap). VAE / embeddings / etc. also flow through
+// basemodel.constants supportMap). VAE / embeddings / etc. also flow through
 // the same `resources` array + belt but are deferred to a later increment.
 export const PAGE_LORA_MODEL_TYPES: ReadonlySet<string> = new Set([
   ModelType.LORA,

--- a/src/shared/constants/basemodel.constants.ts
+++ b/src/shared/constants/basemodel.constants.ts
@@ -4424,18 +4424,6 @@ export const DEPRECATED_BASE_MODELS: string[] = baseModelRecords
   .filter((x) => x.disabled)
   .map((x) => x.name);
 
-/**
- * Configuration for base model groups (ecosystems)
- * Maps ecosystem keys to display names and descriptions
- */
-export const baseModelGroupConfig: Record<string, { name: string; description?: string }> =
-  Object.fromEntries(
-    ecosystems.map((eco) => [
-      eco.key,
-      { name: eco.displayName ?? eco.key, description: eco.description },
-    ])
-  );
-
 // -----------------------------------------------------------------------------
 // Helper Functions
 // -----------------------------------------------------------------------------
@@ -4533,59 +4521,14 @@ export function getBaseModelEngine(baseModel: string): string | undefined {
 }
 
 /**
- * Get all base model configs for an ecosystem
- * @param group - Ecosystem key
- * @returns Array of base model records
- */
-export function getBaseModelConfigsByGroup(group: string): BaseModelRecord[] {
-  const ecosystem = ecosystemByKey.get(group);
-  if (!ecosystem) return [];
-  return getBaseModelsByEcosystemId(ecosystem.id, false);
-}
-
-/**
  * Get all base model names for an ecosystem
  * @param group - Ecosystem key
  * @returns Array of base model names
  */
 export function getBaseModelsByGroup(group: string): string[] {
-  return getBaseModelConfigsByGroup(group).map((x) => x.name);
-}
-
-/**
- * Get all base model configs for a media type
- * @param type - Media type ('image' or 'video')
- * @returns Array of base model records
- */
-export function getBaseModelConfigsByMediaType(type: MediaType): BaseModelRecord[] {
-  return baseModelRecords.filter((x) =>
-    Array.isArray(x.type) ? x.type.includes(type) : x.type === type
-  );
-}
-
-/**
- * Get all base model names for a media type
- * @param type - Media type ('image' or 'video')
- * @returns Array of base model names
- */
-export function getBaseModelByMediaType(type: MediaType): string[] {
-  return getBaseModelConfigsByMediaType(type).map((x) => x.name);
-}
-
-/**
- * Get all ecosystem keys for a media type
- * @param type - Media type ('image' or 'video')
- * @returns Array of ecosystem keys
- */
-export function getBaseModelGroupsByMediaType(type: MediaType): string[] {
-  return [
-    ...new Set(
-      getBaseModelConfigsByMediaType(type).map((x) => {
-        const ecosystem = ecosystemById.get(x.ecosystemId);
-        return ecosystem?.key ?? 'Other';
-      })
-    ),
-  ];
+  const ecosystem = ecosystemByKey.get(group);
+  if (!ecosystem) return [];
+  return getBaseModelsByEcosystemId(ecosystem.id, false).map((x) => x.name);
 }
 
 // -----------------------------------------------------------------------------
@@ -4656,58 +4599,6 @@ export const getBaseModelGenerationConfig = lazy(() =>
 );
 
 /**
- * Get ecosystem keys that have generation support
- * @param type - Optional media type filter
- * @returns Array of ecosystem keys with generation support
- */
-export function getGenerationBaseModelConfigs(type?: MediaType): string[] {
-  const result = ecosystems
-    .filter((ecosystem) => {
-      const genSupport = getEcosystemSupport(ecosystem.id, 'generation');
-      if (!genSupport || genSupport.disabled) return false;
-
-      if (type) {
-        const models = getBaseModelsByEcosystemId(ecosystem.id, false);
-        return models.some((m) => m.type === type);
-      }
-
-      return true;
-    })
-    .map((ecosystem) => ecosystem.key);
-
-  // Include ecosystem group IDs when any member ecosystem has generation support
-  for (const group of ecosystemGroups) {
-    if (!result.includes(group.id)) {
-      const hasGenSupport = group.ecosystemIds.some((id) => {
-        const support = getEcosystemSupport(id, 'generation');
-        if (!support || support.disabled) return false;
-        if (type) {
-          const models = getBaseModelsByEcosystemId(id, false);
-          return models.some((m) => m.type === type);
-        }
-        return true;
-      });
-      if (hasGenSupport) result.push(group.id);
-    }
-  }
-
-  return result;
-}
-
-/**
- * Get base model names that support generation for a media type
- * @param type - Media type ('image' or 'video')
- * @returns Array of base model names
- */
-export function getGenerationBaseModelsByMediaType(type: MediaType): string[] {
-  const allModels = getBaseModelByMediaType(type);
-  const generationModels = getBaseModelGenerationConfig().flatMap(({ supportMap }) =>
-    [...supportMap.values()].flatMap((entry) => entry.map((x) => x.baseModel))
-  );
-  return allModels.filter((baseModel) => generationModels.includes(baseModel));
-}
-
-/**
  * Get generation configuration for an ecosystem (by key or base model name)
  * @param baseModel - Ecosystem key or base model name
  * @param missedMatch - Internal flag for recursion
@@ -4770,18 +4661,6 @@ export function getGenerationBaseModels(group: string, modelType: ModelType): st
 }
 
 /**
- * Check if a base model supports generation for a model type
- * @param baseModel - Base model name
- * @param modelType - Model type (e.g., LORA, Checkpoint)
- * @returns True if generation is supported
- */
-export function getBaseModelGenerationSupported(baseModel: string, modelType: ModelType): boolean {
-  const record = baseModelByName.get(baseModel);
-  if (!record) return false;
-  return isModelSupported(record.id, 'generation', modelType);
-}
-
-/**
  * Get associated ecosystem keys for generation
  * @param group - Ecosystem key
  * @param modelType - Model type
@@ -4804,23 +4683,6 @@ export function getGenerationBaseModelAssociatedGroups(
         .filter(isDefined)
     ),
   ];
-}
-
-/**
- * Group base models by model type
- * @param args - Array of {modelType, baseModel} pairs
- * @returns Record mapping model type to base model names
- */
-export function getBaseModelsByModelType(
-  args: { modelType: ModelType; baseModel: string }[]
-): Record<ModelType, string[]> {
-  return args.reduce(
-    (acc, { modelType, baseModel }) => ({
-      ...acc,
-      [modelType]: [...(acc[modelType] ?? []), baseModel],
-    }),
-    {} as Record<ModelType, string[]>
-  );
 }
 
 /**


### PR DESCRIPTION
Cleanup split out of #3425. Independent of it — the file sets are disjoint, so these can merge in either order.

## Background

There were two base-model constants files. The legacy `src/shared/constants/base-model.constants.ts` had drifted — its list has `Flux.1 Krea` but not `Krea 2`, which is 11,972 `ModelVersion` rows in prod. That surfaced when the contest base-model picker read the stale list. **#3425 deletes that file**; this PR cleans up what it left behind.

`basemodel.constants.ts` carries a section headed *"Compatibility Layer for base-model.constants.ts Migration"* — string-keyed exports mirroring the old API while the module's real model is numeric IDs. Some of it never had a consumer.

## Change

Deletes 9 exports with zero consumers, **141 lines**:

| Export | Evidence |
|---|---|
| `getBaseModelGroupsByMediaType` | only self-definition |
| `getBaseModelConfigsByMediaType` | only self + internal refs |
| `getBaseModelConfigsByGroup` | only self + one in-file caller (inlined) |
| `getBaseModelByMediaType` | only self + internal ref |
| `baseModelGroupConfig` | only self + doc mentions of the *old* file |
| `getBaseModelGenerationSupported` | **zero hits anywhere** — dead on arrival |
| `getBaseModelsByModelType` | only self-definition |
| `getGenerationBaseModelsByMediaType` | only self-definition |
| `getGenerationBaseModelConfigs` | only self + doc mentions |

`getBaseModelConfigsByGroup` had one live in-file caller, `getBaseModelsByGroup` (26 call sites), so its two-line body was inlined rather than left as a wrapper. Behavior is identical — same `ecosystemByKey.get`, same `getBaseModelsByEcosystemId(id, false)` (the `false` matters: it controls which models are included), same ordering. The only difference is the miss path returning a `[]` literal instead of `[].map(...)`, both fresh empty arrays.

Also drops one checklist line from `docs/adding-basemodel-ecosystem-guide.md` that named `getGenerationBaseModelConfigs`. The line above it covers the same verification step via `getBaseModelGenerationConfig()`, the live non-compat function — so the checklist has no hole.

## Review

Adversarially reviewed, zero blocking findings. Verification covered the paths a naive `src/`-scoped grep misses:

- **`.claude/skills/**`** — `add-ecosystem`, `add-generation-support`, `add-training-support` and `ecosystem-seo-page` all edit this file for a living. None references any deleted function, so the ecosystem-onboarding workflow is intact.
- No namespace imports of the module exist, so string-keyed access (`constants['getFoo']`) is impossible
- No barrel re-export, no `export *`, no dynamic `import()`, no alias under another name
- Every identifier the deleted functions used is still live in-file; no orphaned imports or helpers

**Explicitly left alone:** `baseModels`, `activeBaseModels`, `baseModelGroups`, `defaultBaseModel`, the `BaseModel`/`BaseModelGroup` type aliases, and the seven compat functions that do have consumers (`getBaseModelsByGroup` 26, `getBaseModelGroup` 18, `DEPRECATED_BASE_MODELS` 11, `getBaseModelMediaType` 8, `getBaseModelEngine` 3, `getBaseModelSeoName` 2, `getBaseModelConfig` 2). Retiring those is a ~70-call-site migration tracked separately.

## Testing

`pnpm typecheck` — 8 errors, all pre-existing and environmental (missing `kysely` in two workspace packages, `@civitai/client` version drift in `mage-flow.handler.ts`), none attributable to this change.

`pnpm exec vitest run src/shared/` — 15 files, 176 tests, all pass. Worth stating plainly: **none of those tests cover `basemodel.constants.ts`**, so that run only shows nothing else regressed. The real evidence here is the typecheck plus the exhaustive reference sweep.

## Follow-up

Two docs cite names that disappear with #3425's file deletion, not with this change: `docs/base-model-constants-management.md:44` and `docs/plans/generator-filtering-options.md`. Being handled in #3425.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
