### PR TITLE
fix(apps): show progress on the edit-view retry + cover the bounded-loader gaps

### DIFF
--- a/src/components/Apps/AppsSubmitEditView.browser.test.tsx
+++ b/src/components/Apps/AppsSubmitEditView.browser.test.tsx
@@ -18,6 +18,7 @@ const mocks = vi.hoisted(() => ({
   edit: {
     data: undefined as unknown,
     isLoading: true,
+    isFetching: true,
     isError: false,
     error: null as { message?: string } | null,
     refetch: vi.fn(),
@@ -46,7 +47,14 @@ vi.mock('~/components/Apps/ExternalSubmitForm', () => ({
 const { AppsSubmitEditView } = await import('./AppsSubmitEditView');
 
 beforeEach(() => {
-  mocks.edit = { data: undefined, isLoading: true, isError: false, error: null, refetch: vi.fn() };
+  mocks.edit = {
+    data: undefined,
+    isLoading: true,
+    isFetching: true,
+    isError: false,
+    error: null,
+    refetch: vi.fn(),
+  };
 });
 
 describe('AppsSubmitEditView — routing', () => {
@@ -59,6 +67,7 @@ describe('AppsSubmitEditView — routing', () => {
     mocks.edit = {
       data: { slug: 'vitrine', status: 'draft' },
       isLoading: false,
+      isFetching: false,
       isError: false,
       error: null,
       refetch: vi.fn(),
@@ -73,6 +82,7 @@ describe('AppsSubmitEditView — routing', () => {
     mocks.edit = {
       data: undefined,
       isLoading: false,
+      isFetching: false,
       isError: true,
       error: { message: 'listing apl_1 not found' },
       refetch: vi.fn(),
@@ -89,6 +99,7 @@ describe('AppsSubmitEditView — routing', () => {
     mocks.edit = {
       data: undefined,
       isLoading: false,
+      isFetching: false,
       isError: false,
       error: null,
       refetch: vi.fn(),
@@ -101,7 +112,14 @@ describe('AppsSubmitEditView — routing', () => {
 
   test('the "Try again" control refetches the query', async () => {
     const refetch = vi.fn();
-    mocks.edit = { data: undefined, isLoading: false, isError: true, error: null, refetch };
+    mocks.edit = {
+      data: undefined,
+      isLoading: false,
+      isFetching: false,
+      isError: true,
+      error: null,
+      refetch,
+    };
     renderWithProviders(<AppsSubmitEditView listingId="apl_1" />);
     const retry = page.getByTestId('apps-offsite-edit-retry');
     await expect.element(retry).toBeInTheDocument();
@@ -115,12 +133,123 @@ describe('AppsSubmitEditView — routing', () => {
     // alert — proving the spinner can never trap the user indefinitely. A pre-fix
     // build (loader gated on `isLoading` alone) leaves the loader up forever and
     // fails this test.
-    mocks.edit = { data: undefined, isLoading: true, isError: false, error: null, refetch: vi.fn() };
+    mocks.edit = {
+      data: undefined,
+      isLoading: true,
+      isFetching: true,
+      isError: false,
+      error: null,
+      refetch: vi.fn(),
+    };
     renderWithProviders(<AppsSubmitEditView listingId="apl_1" loaderCeilingMs={30} />);
     // Loader shows first…
     await expect.element(page.getByTestId('apps-offsite-edit-loading')).toBeInTheDocument();
     // …then the ceiling elapses and the recoverable alert takes over.
     await expect.element(page.getByTestId('apps-offsite-edit-not-found')).toBeInTheDocument();
     expect(page.getByTestId('apps-offsite-edit-loading').elements()).toHaveLength(0);
+  });
+
+  test('retry RE-ARMS a fresh ceiling: a never-settling query recovers the spinner then re-lands the alert', async () => {
+    // Covers the trickiest bit of the bounded loader: `retryNonce` re-arming the
+    // ceiling timer. The query NEVER settles (`isLoading` stays true across the
+    // refetch — the real prod symptom, NOT the error-state mock the retry test
+    // above uses). So clicking "Try again" cannot rely on `isLoading` toggling;
+    // the nonce bump is the ONLY thing that flips the loader back on. We prove:
+    //   1. ceiling elapses → alert,
+    //   2. click "Try again" → the SPINNER returns (only possible if the nonce
+    //      re-armed `loaderExpired=false` while the query is still loading),
+    //   3. a FRESH ceiling elapses → the alert returns again.
+    const refetch = vi.fn(); // never-settling: refetch does not change the query state
+    mocks.edit = {
+      data: undefined,
+      isLoading: true,
+      isFetching: true,
+      isError: false,
+      error: null,
+      refetch,
+    };
+    // A comfortable ceiling so the transient re-armed spinner is observable by the
+    // polling matcher (not a real 15s wait — the prod default is 15_000ms).
+    renderWithProviders(<AppsSubmitEditView listingId="apl_1" loaderCeilingMs={200} />);
+
+    // 1. First ceiling elapses → recoverable alert.
+    await expect.element(page.getByTestId('apps-offsite-edit-not-found')).toBeInTheDocument();
+
+    // 2. Retry re-arms the loader (proves nonce → fresh timer, since isLoading
+    //    never toggled) and re-issues the fetch.
+    await page.getByTestId('apps-offsite-edit-retry').click();
+    await expect.element(page.getByTestId('apps-offsite-edit-loading')).toBeInTheDocument();
+    expect(refetch).toHaveBeenCalledTimes(1);
+
+    // 3. The fresh ceiling elapses → the alert returns (still never settled).
+    await expect.element(page.getByTestId('apps-offsite-edit-not-found')).toBeInTheDocument();
+    expect(page.getByTestId('apps-offsite-edit-loading').elements()).toHaveLength(0);
+  });
+
+  test('slow load that eventually resolves recovers to the form automatically (no manual retry)', async () => {
+    // Load-bearing auto-recovery: the query is still pending when the ceiling
+    // elapses (alert shows), then the data arrives on a later render and the form
+    // renders itself — the user does NOT have to click "Try again".
+    mocks.edit = {
+      data: undefined,
+      isLoading: true,
+      isFetching: true,
+      isError: false,
+      error: null,
+      refetch: vi.fn(),
+    };
+    const { rerender } = await renderWithProviders(
+      <AppsSubmitEditView listingId="apl_1" loaderCeilingMs={30} />
+    );
+
+    // Ceiling elapses while still pending → recoverable alert.
+    await expect.element(page.getByTestId('apps-offsite-edit-not-found')).toBeInTheDocument();
+
+    // The slow query now resolves with data — flip the mock and re-render (the
+    // same component instance, so its ceiling state persists).
+    mocks.edit = {
+      data: { slug: 'vitrine', status: 'draft' },
+      isLoading: false,
+      isFetching: false,
+      isError: false,
+      error: null,
+      refetch: vi.fn(),
+    };
+    await rerender(<AppsSubmitEditView listingId="apl_1" loaderCeilingMs={30} />);
+
+    // Form appears with no manual retry; the alert is gone.
+    const stub = page.getByTestId('apps-offsite-edit-form-stub');
+    await expect.element(stub).toBeInTheDocument();
+    await expect.element(stub).toHaveTextContent('editing vitrine');
+    expect(page.getByTestId('apps-offsite-edit-not-found').elements()).toHaveLength(0);
+  });
+
+  test('error retry shows a disabled "Retrying…" state while the refetch is in flight (isFetching)', async () => {
+    // Fix for the inert-retry gap: after an *error*, `refetch()` keeps
+    // `status: 'error'` (so `isLoading` stays false) and only flips `isFetching`
+    // → true. The button must reflect that in-flight retry instead of sitting
+    // there looking dead. The mock's refetch flips `isFetching` on, mirroring
+    // React-Query; the `handleRetry` state bump re-renders and reads it.
+    const refetch = vi.fn(() => {
+      mocks.edit.isFetching = true;
+    });
+    mocks.edit = {
+      data: undefined,
+      isLoading: false,
+      isFetching: false,
+      isError: true,
+      error: { message: 'listing apl_1 not found' },
+      refetch,
+    };
+    renderWithProviders(<AppsSubmitEditView listingId="apl_1" />);
+
+    const retry = page.getByTestId('apps-offsite-edit-retry');
+    await expect.element(retry).toHaveTextContent('Try again');
+    await retry.click();
+
+    // In-flight retry: disabled + "Retrying…" (keyed off isFetching, not isLoading).
+    await expect.element(retry).toHaveTextContent('Retrying…');
+    await expect.element(retry).toBeDisabled();
+    expect(refetch).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/components/Apps/AppsSubmitEditView.tsx
+++ b/src/components/Apps/AppsSubmitEditView.tsx
@@ -33,7 +33,9 @@ export const EDIT_LOADER_CEILING_MS = 15_000;
  * state, never an infinite spinner: any settled outcome (thrown error, a settled
  * query with no data, or the loader ceiling elapsing) renders the "Can't edit this
  * listing" alert with a retry, so the user is never stuck. The spinner shows ONLY
- * while a first load is genuinely in flight AND under the ceiling.
+ * while a first load is genuinely in flight AND under the ceiling. The alert's
+ * "Try again" gives its own in-flight feedback (a disabled "Retrying…" state keyed
+ * off `isFetching`) so a retry after an error never looks inert.
  */
 export function AppsSubmitEditView({
   listingId,
@@ -67,6 +69,15 @@ export function AppsSubmitEditView({
   }, [editQuery.isLoading, loaderCeilingMs, retryNonce]);
 
   const showLoader = editQuery.isLoading && !loaderExpired;
+
+  // Progress feedback for the alert's "Try again". After a React-Query *error*,
+  // a `refetch()` leaves `status: 'error'` (so `isLoading` stays false) and only
+  // flips `fetchStatus` to `'fetching'` — `isFetching` is the signal that catches
+  // an in-flight retry, `isLoading` does NOT. We AND out `isLoading` so this only
+  // covers a background refetch (the settled-error retry), never the initial /
+  // never-settled first load — that path is owned by `showLoader` above and its
+  // button must stay clickable so a stuck query can still re-arm the ceiling.
+  const retryPending = editQuery.isFetching && !editQuery.isLoading;
 
   const handleRetry = () => {
     setLoaderExpired(false);
@@ -109,9 +120,11 @@ export function AppsSubmitEditView({
                 variant="light"
                 color="red"
                 data-testid="apps-offsite-edit-retry"
+                loading={retryPending}
+                disabled={retryPending}
                 onClick={handleRetry}
               >
-                Try again
+                {retryPending ? 'Retrying…' : 'Try again'}
               </Button>
             </Stack>
           </Alert>


### PR DESCRIPTION
Two small follow-ups to #3429 (bounded loader on `/apps/submit?edit=`), both in `AppsSubmitEditView.tsx` + its `.browser.test.tsx`.

### Fix 1 — retry now shows progress after an error
After a React-Query **error**, `refetch()` keeps `status: 'error'` — so `isLoading` stays `false` and only `fetchStatus` flips to `'fetching'`. Clicking **Try again** from the "Can't edit this listing" alert re-issued the fetch but showed no feedback: the button just sat there looking inert until it resolved.

Now the button reflects the in-flight retry with a disabled **Retrying…** state, keyed off `isFetching` (not `isLoading`):

```ts
const retryPending = editQuery.isFetching && !editQuery.isLoading;
```

`isLoading` is AND-ed out on purpose: the initial / never-settled first load is owned by the bounded spinner (`showLoader`), and its retry button must stay clickable so a genuinely stuck query can still re-arm the ceiling. `isFetching && !isLoading` is exactly "a background refetch of an already-settled (errored) query is in flight" — nothing else reaches the alert's button while fetching. No change to the success→form or settled→alert behavior.

### Fix 2 — cover the untested bounded-loader paths
- **retry re-arms a fresh ceiling** on a *never-settling* query (proves the `retryNonce` → timer re-arm, since `isLoading` never toggles — distinct from the error-state retry test).
- **slow load auto-recovers to the form**: pending past the ceiling → alert → data arrives → form renders with no manual retry.
- **error retry shows the "Retrying…"/disabled state** while `isFetching` (Fix 1).

### Notes
- `NODE_OPTIONS=--max_old_space_size=8192 npx tsc --noEmit`: **zero errors from this diff**. (Remaining errors are pre-existing worktree-env issues unrelated to this change — missing `kysely` / `event-engine-common` workspace packages.)
- The `.browser.test.tsx` suite is report-only in CI and the Playwright browser isn't available on the authoring host, so the new tests are authored-to-convention + type-checked but were **not executed locally** — CI's browser runner is the executing gate. Ceiling is driven with a tiny `loaderCeilingMs` (matching the existing bounded-loader test), never a real 15s wait.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
