### PR TITLE
fix(model-files): component-linking feedback from koen

### DIFF
--- a/src/components/Apps/AppSettingsModal.tsx
+++ b/src/components/Apps/AppSettingsModal.tsx
@@ -561,7 +561,7 @@ function ManifestField(props: {
                 title: `Pick ${def.label}`,
                 onSelect: (resource) => onChange(resource.id),
                 options: { resources: [{ type: resourceType }] },
-                selectSource: 'modelVersion',
+                selectSource: 'generation',
               })
             }
           >

--- a/src/components/Challenge/ModelVersionMultiSelect.tsx
+++ b/src/components/Challenge/ModelVersionMultiSelect.tsx
@@ -94,7 +94,7 @@ export function ModelVersionMultiSelect({
         ],
         excludeIds: value,
       },
-      selectSource: 'modelVersion',
+      selectSource: 'generation',
     });
   };
 

--- a/src/components/ImageGeneration/GenerationForm/ResourceSelectProvider.tsx
+++ b/src/components/ImageGeneration/GenerationForm/ResourceSelectProvider.tsx
@@ -51,9 +51,9 @@ export function ResourceSelectProvider({
   const { generation } = useCurrentUserSettings();
   const selectSource = props.selectSource ?? 'generation';
 
-  // For modelVersion linking, always start on the 'all' tab (and don't persist)
-  // since 'recent' depends on recommended models that are often empty for new
-  // uploads.
+  // For modelVersion linking, start on the 'official' tab (and don't persist):
+  // linking a canonical component is the intended path, and the persisted tab
+  // ('recent'/'liked') depends on data that's often empty for new uploads.
   const persistTab = selectSource !== 'modelVersion';
   const [storedTab, setStoredTab] = useStorage<Tabs>({
     type: 'localStorage',
@@ -61,7 +61,9 @@ export function ResourceSelectProvider({
     defaultValue: defaultTab,
     getInitialValueInEffect: false,
   });
-  const [localTab, setLocalTab] = useState<Tabs>(defaultTab);
+  const [localTab, setLocalTab] = useState<Tabs>(
+    selectSource === 'modelVersion' ? 'official' : defaultTab
+  );
   // useStorage's value widens to `Tabs | undefined`; fall back to the default so
   // the context always exposes a concrete tab.
   const tab = (persistTab ? storedTab : localTab) ?? defaultTab;

--- a/src/components/Model/ModelVersions/RequiredComponentsSection.tsx
+++ b/src/components/Model/ModelVersions/RequiredComponentsSection.tsx
@@ -1,6 +1,7 @@
 import {
   Accordion,
   ActionIcon,
+  Anchor,
   Badge,
   Box,
   Button,
@@ -251,24 +252,23 @@ export function RequiredComponentsSection({
                     </ThemeIcon>
                     <Box>
                       <Group gap={6}>
-                        <Text
+                        <Anchor
                           component={Link}
-                          href={getModelUrl({ modelId: lc.modelId, modelName: lc.modelName })}
+                          href={getModelUrl({
+                            modelId: lc.modelId,
+                            modelName: lc.modelName,
+                            modelVersionId: lc.versionId,
+                          })}
                           size="sm"
                           fw={500}
-                          td="underline"
-                          style={{ textDecorationStyle: 'dotted' }}
                         >
-                          {lc.modelName}
-                        </Text>
+                          <Group gap={4} wrap="nowrap">
+                            {lc.modelName}
+                            <IconExternalLink size={12} />
+                          </Group>
+                        </Anchor>
                         <Badge size="xs" variant="light" color="gray">
                           {config?.name ?? lc.componentType}
-                        </Badge>
-                        <Badge size="xs" variant="outline" color="blue">
-                          <Group gap={4}>
-                            <IconExternalLink size={10} />
-                            External
-                          </Group>
                         </Badge>
                       </Group>
                       <Text size="xs" c="dimmed">

--- a/src/components/Resource/Files.tsx
+++ b/src/components/Resource/Files.tsx
@@ -631,6 +631,22 @@ function FileCard({
     },
   });
 
+  // Persisted on change rather than through the file's inline Save: the page-level
+  // "Save Changes" button only starts uploads, so a deferred flag silently gets lost.
+  const requiredMutation = trpc.modelFile.update.useMutation({
+    onError(_error, variables) {
+      updateFile(versionFile.uuid, { isRequired: !variables.metadata?.isRequired });
+      showErrorNotification({
+        error: new Error('Could not update the required flag, please try again'),
+      });
+    },
+  });
+
+  const handleToggleRequired = (isRequired: boolean) => {
+    updateFile(versionFile.uuid, { isRequired });
+    if (versionFile.id) requiredMutation.mutate({ id: versionFile.id, metadata: { isRequired } });
+  };
+
   const handleRenameOpen = () => {
     setRenameValue(versionFile.overrideName ?? versionFile.name);
     setRenameOpen(true);
@@ -711,9 +727,7 @@ function FileCard({
                 size="xs"
                 label="Required"
                 checked={versionFile.isRequired ?? false}
-                onChange={(e) =>
-                  updateFile(versionFile.uuid, { isRequired: e.currentTarget.checked })
-                }
+                onChange={(e) => handleToggleRequired(e.currentTarget.checked)}
                 mt={4}
               />
             )}
@@ -1003,15 +1017,16 @@ function FileEditForm({
       size: initialFile.size,
       fp: initialFile.fp,
       quantType: initialFile.quantType,
-      isRequired: initialFile.isRequired,
     });
   };
 
+  // isRequired is excluded because its toggle persists on change — comparing it
+  // would leave Save/Reset showing for a value that's already saved.
   const canManualSave =
     !!versionFile.id &&
     !isEqual(
-      { ...versionFile, overrideName: undefined },
-      { ...initialFile, overrideName: undefined }
+      { ...versionFile, overrideName: undefined, isRequired: undefined },
+      { ...initialFile, overrideName: undefined, isRequired: undefined }
     );
 
   const isCheckpoint = versionFile.type === 'Model' && versionFile.modelType === 'Checkpoint';

--- a/src/components/Resource/FilesProvider.tsx
+++ b/src/components/Resource/FilesProvider.tsx
@@ -329,6 +329,98 @@ export function FilesProvider({ model, version, children }: FilesProviderProps) 
     }
   };
 
+  // Called once the finished file has been cleared from the upload tracker, so the
+  // toast can't announce a completed upload while the row still renders a progress bar.
+  const showUploadFinishedNotification = (result: {
+    id: number;
+    name: string;
+    modelVersion: { id: number; status: ModelStatus; _count: { posts: number } };
+  }) => {
+    const hasPublishedPosts = result.modelVersion._count.posts > 0;
+    const isVersionPublished = result.modelVersion.status === ModelStatus.Published;
+    const { uploading } = useS3UploadStore
+      .getState()
+      .getStatus((item) => item.meta?.versionId === result.modelVersion.id);
+    const stillUploading = uploading > 0;
+
+    const notificationId = `upload-finished-${result.id}`;
+    showNotification({
+      id: notificationId,
+      autoClose: stillUploading,
+      color: 'green',
+      title: `Finished uploading ${result.name}`,
+      styles: { root: { alignItems: 'flex-start' } },
+      message: !stillUploading ? (
+        <Stack gap={4}>
+          {isVersionPublished ? (
+            <>
+              <Text size="sm" c="dimmed">
+                All files finished uploading.
+              </Text>
+              <Link
+                href={getModelUrl({
+                  modelId: model?.id ?? 0,
+                  modelName: model?.name,
+                  modelVersionId: result.modelVersion.id,
+                })}
+                passHref
+                legacyBehavior
+              >
+                <Anchor size="sm" onClick={() => hideNotification(notificationId)}>
+                  Go to model
+                </Anchor>
+              </Link>
+            </>
+          ) : hasPublishedPosts ? (
+            <>
+              <Text size="sm" c="dimmed">
+                {`Your files have finished uploading, let's publish this version.`}
+              </Text>
+              <Text
+                c="blue.4"
+                size="sm"
+                style={{ cursor: 'pointer' }}
+                onClick={() => {
+                  hideNotification(notificationId);
+
+                  showNotification({
+                    id: 'publishing-version',
+                    message: 'Publishing...',
+                    loading: true,
+                  });
+
+                  if (model?.status !== ModelStatus.Published)
+                    publishModelMutation.mutate({
+                      id: model?.id as number,
+                      versionIds: [result.modelVersion.id],
+                    });
+                  else publishVersionMutation.mutate({ id: result.modelVersion.id });
+                }}
+              >
+                Publish it
+              </Text>
+            </>
+          ) : (
+            <>
+              <Text size="sm" c="dimmed">
+                Your files have finished uploading, but you still need to add a post.
+              </Text>
+              <Link
+                href={`/models/${model?.id}/model-versions/${result.modelVersion.id}/wizard?step=3`}
+                passHref
+                legacyBehavior
+              >
+                <Anchor size="sm" onClick={() => hideNotification(notificationId)}>
+                  Finish setup
+                </Anchor>
+              </Link>
+            </>
+          )}
+        </Stack>
+      ) : undefined,
+    });
+  };
+
   // Passing a uuid validates only that file — editing one file's settings shouldn't
   // fail because another file in the version is still missing metadata.
   const checkValidation = (uuid?: string) => {
@@ -422,90 +514,6 @@ export function FilesProvider({ model, version, children }: FilesProviderProps) 
 
   const createFileMutation = trpc.modelFile.create.useMutation({
     async onSuccess(result) {
-      const hasPublishedPosts = result.modelVersion._count.posts > 0;
-      const isVersionPublished = result.modelVersion.status === ModelStatus.Published;
-      const { uploading } = useS3UploadStore
-        .getState()
-        .getStatus((item) => item.meta?.versionId === result.modelVersion.id);
-      const stillUploading = uploading > 0;
-
-      const notificationId = `upload-finished-${result.id}`;
-      showNotification({
-        id: notificationId,
-        autoClose: stillUploading,
-        color: 'green',
-        title: `Finished uploading ${result.name}`,
-        styles: { root: { alignItems: 'flex-start' } },
-        message: !stillUploading ? (
-          <Stack gap={4}>
-            {isVersionPublished ? (
-              <>
-                <Text size="sm" c="dimmed">
-                  All files finished uploading.
-                </Text>
-                <Link
-                  href={getModelUrl({
-                    modelId: model?.id ?? 0,
-                    modelName: model?.name,
-                    modelVersionId: result.modelVersion.id,
-                  })}
-                  passHref
-                  legacyBehavior
-                >
-                  <Anchor size="sm" onClick={() => hideNotification(notificationId)}>
-                    Go to model
-                  </Anchor>
-                </Link>
-              </>
-            ) : hasPublishedPosts ? (
-              <>
-                <Text size="sm" c="dimmed">
-                  {`Your files have finished uploading, let's publish this version.`}
-                </Text>
-                <Text
-                  c="blue.4"
-                  size="sm"
-                  style={{ cursor: 'pointer' }}
-                  onClick={() => {
-                    hideNotification(notificationId);
-
-                    showNotification({
-                      id: 'publishing-version',
-                      message: 'Publishing...',
-                      loading: true,
-                    });
-
-                    if (model?.status !== ModelStatus.Published)
-                      publishModelMutation.mutate({
-                        id: model?.id as number,
-                        versionIds: [result.modelVersion.id],
-                      });
-                    else publishVersionMutation.mutate({ id: result.modelVersion.id });
-                  }}
-                >
-                  Publish it
-                </Text>
-              </>
-            ) : (
-              <>
-                <Text size="sm" c="dimmed">
-                  Your files have finished uploading, but you still need to add a post.
-                </Text>
-                <Link
-                  href={`/models/${model?.id}/model-versions/${result.modelVersion.id}/wizard?step=3`}
-                  passHref
-                  legacyBehavior
-                >
-                  <Anchor size="sm" onClick={() => hideNotification(notificationId)}>
-                    Finish setup
-                  </Anchor>
-                </Link>
-              </>
-            )}
-          </Stack>
-        ) : undefined,
-      });
-
       await queryUtils.modelVersion.getById.invalidate({
         id: result.modelVersion.id,
         withFiles: true,
@@ -688,6 +696,7 @@ export function FilesProvider({ model, version, children }: FilesProviderProps) 
             setFiles((state) =>
               state.map((x) => (x.uuid === uuid ? { ...x, id: saved.id, isUploading: false } : x))
             );
+            showUploadFinishedNotification(saved);
           } catch (e: unknown) {
             showErrorNotification({
               title: 'Failed to save file',

--- a/src/pages/models/[id]/[[...slug]].tsx
+++ b/src/pages/models/[id]/[[...slug]].tsx
@@ -48,7 +48,7 @@ import {
 import { truncate } from 'lodash-es';
 import type { InferGetServerSidePropsType } from 'next';
 import { useRouter } from 'next/router';
-import { useEffect, useState, useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
 import { getEdgeUrl } from '~/client-utils/cf-images-utils';
 import { RenderAdUnitOutstream } from '~/components/Ads/AdUnitOutstream';
 import { AlertWithIcon } from '~/components/AlertWithIcon/AlertWithIcon';
@@ -132,7 +132,6 @@ import {
 } from '~/shared/constants/browsingLevel.constants';
 import { ModelModifier } from '~/shared/utils/prisma/enums';
 import { Availability, CollectionType, ModelStatus, ModelType } from '~/shared/utils/prisma/enums';
-import type { ModelById } from '~/types/router';
 import { formatDate, isFutureDate } from '~/utils/date-helpers';
 import {
   showErrorNotification,
@@ -386,8 +385,6 @@ export const getServerSideProps = createServerSideProps({
   },
 });
 
-type ModelVersionDetail = ModelById['modelVersions'][number];
-
 export default function ModelDetailsV2({
   id,
 }: InferGetServerSidePropsType<typeof getServerSideProps>) {
@@ -410,10 +407,6 @@ export default function ModelDetailsV2({
     id,
     excludeTrainingData: true,
   });
-  // NOTE: the removed v4 `onSuccess` set selectedVersion to modelVersions[0] on each fetch.
-  // That is already covered (URL-aware) by the `selectedVersion` useState initializer below
-  // and the querystring-sync effect further down — replicating it via useEffect([model]) would
-  // also fire on cached/SSR mounts (where onSuccess did not) and clobber deep-linked versions.
   const browsingSettingsAddons = useBrowsingSettingsAddons();
 
   const rawVersionId = router.query.modelVersionId;
@@ -435,11 +428,13 @@ export default function ModelDetailsV2({
       ? model?.modelVersions.filter((v) => v.status === ModelStatus.Published) ?? []
       : model?.modelVersions ?? [];
   }, [isOwner, model?.modelVersions]);
-  const latestVersion =
+  // The querystring is the source of truth for which version is shown. Deriving it
+  // (rather than mirroring it into state) is what keeps an in-page link to a sibling
+  // version from being snapped back by a sync effect.
+  const selectedVersion =
     publishedVersions.find((version) => version.id === modelVersionId) ??
     publishedVersions[0] ??
     null;
-  const [selectedVersion, setSelectedVersion] = useState<ModelVersionDetail | null>(latestVersion);
   const selectedEcosystemName = getBaseModelSeoName(selectedVersion?.baseModel);
   const tippedAmount = useBuzzTippingStore({ entityType: 'Model', entityId: model?.id ?? -1 });
   const buzzEarned =
@@ -458,7 +453,7 @@ export default function ModelDetailsV2({
   // TODO change this to just grab one image, since that's all it's used for
   const { images: versionImages, isLoading: loadingImages } = useQueryImages(
     {
-      modelVersionId: latestVersion?.id,
+      modelVersionId: selectedVersion?.id,
       prioritizedUserIds: model ? [model.user.id] : undefined,
       period: 'AllTime',
       sort: ImageSort.MostReactions,
@@ -467,7 +462,7 @@ export default function ModelDetailsV2({
       include: [],
       withMeta: false,
     },
-    { enabled: !!latestVersion }
+    { enabled: !!selectedVersion }
   );
 
   const deleteMutation = trpc.model.delete.useMutation({
@@ -691,33 +686,16 @@ export default function ModelDetailsV2({
   const basicView = view === 'basic' && isModerator;
   const canLoadBelowTheFold = isClient && !loadingModel && !loadingImages && !basicView;
 
+  // Pin the resolved version into the url so shares/refreshes land on what's displayed.
+  // One-way (state never drives this back): the url already decides the selection.
   useEffect(() => {
-    // Change the selected modelVersion based on querystring param
-    if (loadingModel) return;
-    const queryVersion = publishedVersions.find((v) => v.id === modelVersionId);
-    const current = publishedVersions.find((v) => v.id === selectedVersion?.id);
-    if (!current) {
-      // Selected version is no longer present (deep-link / removed version): fall back.
-      setSelectedVersion(queryVersion ?? publishedVersions[0] ?? null);
-    } else if (current !== selectedVersion) {
-      // Re-sync the held reference to the freshly-fetched object after a refetch. This
-      // replaces the query `onSuccess` removed in the RQ v5 migration; without it, the
-      // id-based effect below would compare a stale object ref and (with `router` in deps)
-      // loop on router.replace whenever a mod action invalidates model.getById.
-      setSelectedVersion(current);
-    }
-    if (selectedVersion && queryVersion?.id !== selectedVersion.id) {
-      router.replace(
-        getModelUrl({
-          modelId: id,
-          modelName: model?.name,
-          modelVersionId: selectedVersion.id,
-        }),
-        undefined,
-        { shallow: true }
-      );
-    }
-  }, [id, publishedVersions, selectedVersion, modelVersionId, loadingModel, router]);
+    if (loadingModel || !selectedVersion || selectedVersion.id === modelVersionId) return;
+    router.replace(
+      getModelUrl({ modelId: id, modelName: model?.name, modelVersionId: selectedVersion.id }),
+      undefined,
+      { shallow: true }
+    );
+  }, [id, model?.name, selectedVersion, modelVersionId, loadingModel, router]);
 
   useEffect(() => {
     if (!canLoadBelowTheFold) return;
@@ -1460,10 +1438,15 @@ export default function ModelDetailsV2({
                 selected={selectedVersion?.id}
                 onVersionClick={(version) => {
                   if (version.id !== selectedVersion?.id) {
-                    setSelectedVersion(version);
-                    // router.replace(`/models/${model.id}?modelVersionId=${version.id}`, undefined, {
-                    //   shallow: true,
-                    // });
+                    router.replace(
+                      getModelUrl({
+                        modelId: model.id,
+                        modelName: model.name,
+                        modelVersionId: version.id,
+                      }),
+                      undefined,
+                      { shallow: true }
+                    );
                   }
                 }}
                 showExtraIcons={isOwner || isModerator}

--- a/src/store/s3-upload.store.ts
+++ b/src/store/s3-upload.store.ts
@@ -448,7 +448,16 @@ export const useS3UploadStore = create<StoreProps>()(
           });
           if (!completeResult.ok) return;
 
-          updateFile(pendingItem.uuid, { status: 'success' });
+          // The final part's bytes land on 'loadend', which doesn't schedule a
+          // progress frame — without this the row would settle on the last
+          // rendered percentage (e.g. 87%) instead of a finished bar.
+          updateFile(pendingItem.uuid, {
+            status: 'success',
+            progress: 100,
+            uploaded: size,
+            speed: 0,
+            timeRemaining: 0,
+          });
 
           const url = urls[0].url.split('?')[0];
           const payload = preparePayload(pendingItem.uuid, { url, bucket, key, backend });


### PR DESCRIPTION
Feedback round from Koen on the model file upload / component linking flow.

### 1. Official tab by default when linking a component
`openResourceSelectModal` with `selectSource: 'modelVersion'` now opens on the **Official** tab instead of `all` — linking a canonical component is the point of that picker. The two callers using that select source for other reasons (`AppSettingsModal` manifest field, `ModelVersionMultiSelect`) were moved to `'generation'`.

### 2. Required flag now sticks
Toggling **Required** on an uploaded component file only updated local state. The page-level **Save Changes** button just calls `startUpload()` — and hides entirely once nothing is pending — so unless you found the small inline per-file Save, the flag never reached the DB.

It now persists on change via `modelFile.update` (server merges `metadata`, so nothing else is clobbered) and reverts locally on error. `isRequired` is excluded from the inline form's dirty comparison so Save/Reset don't appear for an already-saved value.

Note: linked components were already persisting correctly — every `RecommendedResource` row on the model in the report has `isRequired: true`.

### 3. Upload toast no longer fires early
Two causes:
- The toast lived in `createFileMutation.onSuccess`, which showed it **before** awaiting three query invalidations. The tracker row was only cleared after `mutateAsync` resolved — seconds later. It now fires after that cleanup.
- The final part's bytes land on `xhr.upload`'s `loadend`, which doesn't schedule a progress frame, so the bar parked at whatever percentage was last rendered (87% in Koen's screenshot). Success now writes `progress: 100, uploaded: size, speed: 0, timeRemaining: 0`.

### 4. "EXTERNAL" badge replaced with a real link
The badge read as clickable but wasn't. The component name is now an `Anchor` with an external-link icon, deep-linking to the **version** hosting the file — so a VAE deduped from another version of the same model lands on that version, and something like Qwen3-VL goes to its own model page.

### 5. Model page: querystring is the source of truth for the selected version

Clicking the link from #4 navigated and then snapped straight back. Captured trace:

```
[vsync] mv=3172043 ref=3172039 sel=3172039  → adopt: setSelectedVersion(3172043)
[vsync] mv=3172043 ref=3172043 sel=3172039  → effect re-ran BEFORE the setState landed
                                              → rewrote the url back to 3172039
```

`router` is in that effect's dep array and Next swaps its identity mid-navigation, so it fires twice per query change.

Rather than add another guard, `selectedVersion` is now **derived** from the querystring instead of mirrored into state. This is the same mirroring that caused the infinite `router.replace` loop fixed in 1fb7d928cb (RQ v5 structural sharing handed the version a new object ref; the by-reference compare was permanently true) and the deep-link clobbering that commit references. Deriving removes object identity from the comparison entirely.

- `useState` / `setSelectedVersion` deleted; the 27-line sync effect replaced by a 9-line one-way effect that only pins the param when it's missing.
- Version-tab clicks write the url — the shallow `router.replace` that was already sitting commented out at that call site.
- `latestVersion` → `selectedVersion` is an identity substitution (same expression), so the image carousel reads what it read before.

Net −22 lines on that page.

## Verification

No automated coverage exists for this page, so this was checked by hand against a local dev server:

| Case | Result |
|---|---|
| Deep link `?modelVersionId=…` | correct version, no rewrite |
| Component link → sibling version | url + title switch and stay |
| Version tab click | shallow replace, url + title update |
| Bare `/models/2812690/mage-flow` | unchanged from before |
| Browser back / forward | now switches versions correctly (previously the effect fought it) |

`pnpm vitest run` on the two touched Resource suites passes (7 tests).

## Behavior changes worth knowing

- Back/forward now moves between versions. Improvement, but it is a change.
- Tab switching routes through the router instead of `setState` — one extra shallow tick, no server fetch. `getServerSideProps` still doesn't re-run on tab clicks, same as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
