### PR TITLE
chore: fetch event-engine-common over HTTPS

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "event-engine-common"]
 	path = event-engine-common
-	url = git@github.com:civitai/event-engine-common.git
+	url = https://github.com/civitai/event-engine-common.git


### PR DESCRIPTION
`civitai/event-engine-common` is now public. This switches the submodule URL from SSH to HTTPS so it can actually be fetched by people who don't have repo SSH access — which is the whole point of publishing it.

```diff
-	url = git@github.com:civitai/event-engine-common.git
+	url = https://github.com/civitai/event-engine-common.git
```

Visibility alone doesn't fix cloning: `git@github.com:` requires a key regardless of whether the repo is public, so fork CI would still fail with an auth error rather than a permissions one. `civitai/metric-event-watcher` already references the same submodule over HTTPS, so this also makes the two consumers consistent.

## What this unblocks

External contributors currently get 16 `tsc` errors and 46 vitest files that fail to collect on unmodified `main`, purely because they can't fetch this submodule. That's also why `lint.yml`'s typecheck job is skipped on fork PRs:

```yaml
# Do not make this a required check without solving the fork case first.
if: github.event.pull_request.head.repo.full_name == github.repository
```

That condition can now be removed, and the `webfactory/ssh-agent` step with `SUBMODULE_SSH_KEY` along with it. **Not doing it in this PR** — worth confirming a fork PR actually goes green first, since the change is only safe once HTTPS fetching is proven in CI. Happy to follow up.

## Existing clones

Anyone with the repo already checked out needs one command to pick up the new URL:

```
git submodule sync --recursive
```

Without it, git keeps using the URL recorded in `.git/config` and will carry on using SSH. Nothing breaks for people who have working SSH access, so this is a convenience, not a required step.

## Note

The `Submodule Pin Guard` workflow is unaffected — this changes the URL only, not the pinned commit.
