### PR TITLE
chore: keep migrations in the schema package

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -73,6 +73,24 @@ jobs:
           echo "added ($(wc -l < added.txt)):"; cat added.txt
           echo "modified ($(wc -l < modified.txt)):"; cat modified.txt
 
+      # BLOCKING. Migrations live next to the schema in packages/civitai-db-schema.
+      # The root prisma/migrations directory predates the monorepo and has no
+      # migration_lock.toml, so Prisma never reads it — 68 migrations were written
+      # there by hand and silently ignored. `pnpm db:migrate:empty` now targets the
+      # right path; this catches the hand-authored case it can't.
+      - name: Migrations are in the schema package
+        run: |
+          set -euo pipefail
+          STRAYS=$(git diff --name-only --diff-filter=A FETCH_HEAD...HEAD -- 'prisma/migrations/**' || true)
+          if [ -n "$STRAYS" ]; then
+            while IFS= read -r f; do
+              [ -n "$f" ] || continue
+              echo "::error file=$f::Migrations belong in packages/civitai-db-schema/prisma/migrations/. Prisma does not read prisma/migrations/ at the repo root. Use: pnpm run db:migrate:empty \"description\""
+            done <<< "$STRAYS"
+            exit 1
+          fi
+          echo "no migrations added outside the schema package"
+
       - name: Register ESLint problem matcher
         run: echo "::add-matcher::.github/problem-matchers/eslint-unix.json"
 

--- a/README.md
+++ b/README.md
@@ -148,13 +148,16 @@ see [Calling All Developers: Join Civitai's Community Development Team](https://
 
 Over the course of development, you may need to change the structure of the database. To do this:
 
-1. Make your changes to the `schema.prisma` file
-2. Create a folder in the `prisma/migrations folder` named with the convention `YYYYMMDDHHmmss_brief_description_here`
-3. In this folder, create a file called `migration.sql`
-4. In that file, put your sql changes
+1. Make your changes to the `packages/civitai-db-schema/prisma/schema.prisma` file
+2. Run `pnpm run db:migrate:empty "brief description here"`. This creates
+   `packages/civitai-db-schema/prisma/migrations/YYYYMMDDHHmmss_brief_description_here/migration.sql`
+   for you, in the one directory Prisma reads.
+   To create it by hand instead, use that same path — **not** the `prisma/migrations`
+   directory at the repo root, which predates the monorepo layout and is no longer read.
+3. Put your sql changes in the generated `migration.sql`
     - These are usually simple sql commands like `ALTER TABLE ...`
-5. Run `make run-migrations` and `make gen-prisma`
-6. If you are adding/changing a column or table, please try to keep the `gen_seed.ts` file up to date with these changes.
+4. Run `make run-migrations` and `make gen-prisma`
+5. If you are adding/changing a column or table, please try to keep the `gen_seed.ts` file up to date with these changes.
 
 ## Sponsors
 


### PR DESCRIPTION
Follow-up to #3401, which fixed the *script* but not the reason most of the drift happened.

## The problem #3401 didn't solve

Migrations live in `packages/civitai-db-schema/prisma/migrations/` — the only directory with a `migration_lock.toml`, and the one `package.json`'s `prisma.schema` points at. The `prisma/migrations/` directory at the repo root predates the monorepo layout and Prisma no longer reads it. It currently holds 68 orphaned migrations.

#3401 fixed `pnpm db:migrate:empty` so it writes to the right place. But only **5 of those 68** came from that script — `getTimestamp()` uses real `getSeconds()` and essentially cannot emit `:00`, yet 62 of them have `:00` seconds. They were hand-authored straight into the stale path.

They were hand-authored because **`README.md` told people to**: *"Create a folder in the `prisma/migrations folder`"*. So the script fix alone doesn't stop it recurring.

## Two changes

**`README.md`** — the Data Migrations section now points at `packages/civitai-db-schema/prisma/`, leads with `pnpm run db:migrate:empty`, and explicitly names the root directory as the wrong one so anyone who lands there from an old branch or an old habit gets corrected. Also fixes the stale `schema.prisma` path and the list numbering.

**`lint.yml`** — a blocking step that fails the job if a PR *adds* any file under root `prisma/migrations/`, with an inline annotation pointing at the correct path and command. It reuses the `FETCH_HEAD...HEAD` diff the job already computes, so it costs nothing.

It's `--diff-filter=A` only, so the 68 existing files don't trip it and nobody gets blocked for touching history.

## Deliberately not included

**The 68 orphans are untouched.** Consolidating or deleting them is a judgement call that deserves its own PR — since migrations here are applied by hand, the risk they represent isn't unapplied SQL, it's that someone writes SQL into a directory nobody reads. This PR closes that door; what to do with what's already behind it is a separate decision.
