### PR TITLE
ci: run typecheck on forks and add a unit test job

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -133,24 +133,18 @@ jobs:
   typecheck:
     name: Typecheck
     runs-on: ubuntu-latest
-    # civitai/civitai is public, and a pull_request from a fork gets no secrets.
-    # Typecheck needs the private event-engine-common submodule, which a fork cannot
-    # fetch: ssh-agent would hard-fail on an empty key, and even skipping it just
-    # trades that for a wall of "Cannot find module" errors. Either way an external
-    # contributor gets a red check they have no way to fix, so skip the job entirely.
-    # Do not make this a required check without solving the fork case first.
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    # Runs on forks now. event-engine-common is public and fetched over HTTPS, so
+    # this needs no secret — which is why the ssh-agent step is gone rather than
+    # merely unused. Leaving it in would have kept the fork case broken AND masked
+    # the HTTPS path: webfactory/ssh-agent rewrites
+    # url."git@key-<sha>.github.com:<owner>/<repo>".insteadOf "https://github.com/<owner>/<repo>"
+    # for any loaded key whose comment names a github.com repo, silently sending
+    # the new HTTPS URL back over SSH.
     timeout-minutes: 25
     steps:
       - uses: actions/checkout@v4
-
-      - name: Setup SSH for submodule
-        uses: webfactory/ssh-agent@v0.9.0
         with:
-          ssh-private-key: ${{ secrets.SUBMODULE_SSH_KEY }}
-
-      - name: Init submodule
-        run: git submodule update --init event-engine-common
+          submodules: true
 
       - uses: pnpm/action-setup@v4
 
@@ -164,3 +158,29 @@ jobs:
 
       - name: Typecheck
         run: pnpm run typecheck
+
+  unit:
+    name: Unit tests
+    runs-on: ubuntu-latest
+    # ~8,000 tests that until now only ran on whoever remembered to run them.
+    # Node env, no browser — component tests (`*.browser.test.tsx`) are not here
+    # on purpose: they need Chromium and carry the cold-optimizeDeps flake
+    # documented at vitest.config.mts:98-124.
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: pnpm
+
+      - name: Install
+        run: pnpm install --frozen-lockfile
+
+      - name: Unit tests
+        run: pnpm run test:unit:run

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -166,7 +166,19 @@ jobs:
     # Node env, no browser — component tests (`*.browser.test.tsx`) are not here
     # on purpose: they need Chromium and carry the cold-optimizeDeps flake
     # documented at vitest.config.mts:98-124.
-    timeout-minutes: 20
+    #
+    # REPORT-ONLY to start, deliberately. A full local run passed 8,937/8,943 but
+    # timed out 5 tests under machine load; every one of them passed in isolation
+    # (that file runs in 138ms — the cost is the ~33s import/transform phase, not
+    # the assertions). The per-test timeout is 60s, so a 2-core runner could trip
+    # the same way. Blocking on that from day one would red unrelated PRs and the
+    # job would be switched off within a week — the same reasoning the ESLint and
+    # Prettier modified-file steps are built on.
+    #
+    # FLIP TO BLOCKING once a couple of weeks of runs show a clean pass rate.
+    # Remove `continue-on-error` and this comment together.
+    continue-on-error: true
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/submodule-pin-guard.yml
+++ b/.github/workflows/submodule-pin-guard.yml
@@ -55,12 +55,6 @@ jobs:
             echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Setup SSH for submodule
-        if: steps.pin.outputs.changed == 'true'
-        uses: webfactory/ssh-agent@v0.9.0
-        with:
-          ssh-private-key: ${{ secrets.SUBMODULE_SSH_KEY }}
-
       - name: Guard against backward pin move
         if: steps.pin.outputs.changed == 'true'
         env:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -202,7 +202,8 @@ Comments are not type-checked, so they rot silently and become misleading. Write
 
 ### Git Worktrees
 When you create a new worktree (`git worktree add …`), **always initialize the `event-engine-common` submodule
-in it**: `git submodule update --init event-engine-common`. Worktrees don't check out submodules automatically,
+in it**: `git submodule sync --recursive && git submodule update --init event-engine-common`.
+Worktrees don't check out submodules automatically,
 and without it `pnpm typecheck`/`build` fail with a wall of `Cannot find module '.../event-engine-common/...'`
 errors (and the missing types cascade into unrelated `implicitly has an 'any' type` errors) — noise that looks
 like your change broke something when it didn't.


### PR DESCRIPTION
Now that #3436 has landed and `event-engine-common` is public over HTTPS, this makes CI actually useful to outside contributors — and adds the test job the repo has never had.

## Typecheck now runs on forks

Removes the skip:

```yaml
if: github.event.pull_request.head.repo.full_name == github.repository
```

Its stated rationale ("Typecheck needs the **private** event-engine-common submodule, which a fork cannot fetch") is no longer true. Submodule init switches to `actions/checkout` with `submodules: true`, which needs no secret against a public repo.

## The ssh-agent step is removed, not left in place

This is the part worth reviewing carefully. It would have been tempting to leave `webfactory/ssh-agent` alone on the grounds that it's now merely redundant. It isn't redundant — it's actively harmful, and it would have hidden its own harm.

`webfactory/ssh-agent@v0.9.0` doesn't only start an agent. For each loaded key whose **public-key comment** matches a `github.com` repo path, it writes:

```
git config --global --replace-all \
  url."git@key-<sha>.github.com:<owner>/<repo>".insteadOf "https://github.com/<owner>/<repo>"
```

That rewrite is **HTTPS → SSH** — the opposite direction from the `insteadOf` in our Tekton build config. Setting the key comment to the repo path is exactly what webfactory's own docs recommend, so it's a live possibility rather than a hypothetical. If our `SUBMODULE_SSH_KEY` carries such a comment, the typecheck job would silently rewrite #3436's new HTTPS URL straight back to SSH — and a green check would prove nothing about whether HTTPS works.

I could not rule this out by inspection: the deploy key registered on `event-engine-common` (`github-actions-civitai-submodule`, read-only, last used 2026-07-23) has **no comment** on its public half, but ssh-agent matches the comment on the *private* key inside the secret, which isn't readable. Removing the step resolves it structurally instead of relying on that being safe.

The same step is dropped from `submodule-pin-guard.yml`, where it was gated on `steps.pin.outputs.changed` rather than on same-repo — so a fork PR that moved the pin hit the empty-key `core.setFailed`. Pre-existing, and this is the natural place to fix it.

`SUBMODULE_SSH_KEY` and the deploy key are now unused by CI. Revoking them is deliberately **not** in this PR — worth confirming nothing else consumes them first.

## New: unit test job

The repo has ~870 unit test files (~8,000 tests) and ~106 component test files, and **CI has never run any of them.** They execute only when someone remembers to locally. Adds `pnpm run test:unit:run` as a blocking job.

**It starts report-only (`continue-on-error: true`), and that's a considered choice, not timidity.** I ran the full suite locally before opening this: **8,937 passed / 5 failed / 1 skipped across 8,943 tests**, exit 1. All 5 failures were `Test timed out in 60000ms` under machine load — I had several other jobs running. Re-running the affected file in isolation: **5 passed in 138ms.** The assertions are not slow; the ~33s import/transform phase per file is, and the per-test timeout is 60s. A 2-core GitHub runner can plausibly trip the same way.

Blocking on that from day one would red unrelated PRs and the job would be switched off inside a week — which is precisely the reasoning already written into this file's header for the ESLint and Prettier modified-file steps. Report-only gets us the signal and the real pass rate; flipping to blocking is a one-line follow-up once a couple of weeks of runs justify it. `timeout-minutes` is 30 rather than 20 for the same reason — the local run took 403s on a loaded machine and a runner is slower.

Component tests (`*.browser.test.tsx`) are deliberately **not** included. They need real Chromium and carry the cold-`optimizeDeps` flake documented at `vitest.config.mts:98-124`, where adding any browser test perturbs `optimizeDeps.entries` and two unrelated files fail with `Vitest failed to find the runner`. That belongs on a nightly or a label, not on the merge path.

## Also

`CLAUDE.md`'s worktree instruction now runs `git submodule sync --recursive` before `--init`. `submodule.<name>.url` lives in the shared config, not per-worktree, so a clone created before #3436 hands every new worktree the old SSH URL indefinitely.

## Validation

This is the first thing to actually exercise the HTTPS submodule path — nothing did before, since the only job touching the submodule was the one skipped on forks. **The real test is the first fork PR after this merges.** If something's wrong, the failure is a loud submodule fetch error in Typecheck, not a subtle one.

## Known stale, not touched here

Four test files still justify their mocks with "private submodule" wording that's now false: `getAllImages-prioritized-guards.test.ts:26`, `image-feed-clickhouse-failsoft.test.ts:39`, `image-metrics-timeout.test.ts:30`, `unblock-image-nsfwlevel-reset.test.ts:79`. The mocks stay valid; only the stated reason rotted. Left out to keep this diff to CI config.
