### PR TITLE
feat(apps): make `tagline` a manifest field + re-sync manifest-governed listing copy on approve

### DIFF
--- a/public/schemas/app-block/v1.json
+++ b/public/schemas/app-block/v1.json
@@ -30,9 +30,10 @@
     },
     "tagline": {
       "type": "string",
-      "description": "Optional one-line pitch shown under the app's name on its `/apps` store card + detail page. Manifest-governed: it flows to the store listing on moderator-approve and is re-synced from the manifest on every subsequent approved version. Omit it and the store simply shows no tagline. Trimmed and capped at 140 characters — the same bound off-site listings use (OFFSITE_TAGLINE_MAX), kept in lockstep with MANIFEST_TAGLINE_MAX_LENGTH in src/server/services/block-manifest-validator.service.ts (a drift-guard test enforces equality).",
+      "description": "Optional one-line pitch shown under the app's name on its `/apps` store card + detail page. Manifest-governed: it flows to the store listing on moderator-approve and is re-synced from the manifest on every subsequent approved version. Omit it and the store simply shows no tagline. Must contain a non-whitespace character and is capped at 140 characters — the same bound off-site listings use (OFFSITE_TAGLINE_MAX), kept in lockstep with MANIFEST_TAGLINE_MAX_LENGTH in src/server/services/block-manifest-validator.service.ts (a drift-guard test enforces equality). NOTE: the server measures the TRIMMED length, while this maxLength counts the raw string — so a value padded past 140 is rejected here but accepted server-side. That asymmetry is deliberate and one-directional: this schema is never more permissive than the server, so local validation can't green-light something submit would reject.",
       "minLength": 1,
-      "maxLength": 140
+      "maxLength": 140,
+      "pattern": "\\S"
     },
     "type": {
       "type": "string",

--- a/public/schemas/app-block/v1.json
+++ b/public/schemas/app-block/v1.json
@@ -28,6 +28,12 @@
       "description": "Human-readable display name. The server only requires a non-empty string (no length cap), so the CLI does not impose one either.",
       "minLength": 1
     },
+    "tagline": {
+      "type": "string",
+      "description": "Optional one-line pitch shown under the app's name on its `/apps` store card + detail page. Manifest-governed: it flows to the store listing on moderator-approve and is re-synced from the manifest on every subsequent approved version. Omit it and the store simply shows no tagline. Trimmed and capped at 140 characters — the same bound off-site listings use (OFFSITE_TAGLINE_MAX), kept in lockstep with MANIFEST_TAGLINE_MAX_LENGTH in src/server/services/block-manifest-validator.service.ts (a drift-guard test enforces equality).",
+      "minLength": 1,
+      "maxLength": 140
+    },
     "type": {
       "type": "string",
       "description": "Free-form descriptor used by some examples (e.g. \"block\"). Not validated by the platform.",

--- a/src/components/Apps/ManifestEditForm.browser.test.tsx
+++ b/src/components/Apps/ManifestEditForm.browser.test.tsx
@@ -164,6 +164,26 @@ describe('ManifestEditForm — per-scope justification authoring', () => {
     expect(arg.patch.targets).toBeUndefined();
   });
 
+  test('preserves the existing name / description / content-rating / version fields', async () => {
+    renderWithProviders(
+      <ManifestEditForm
+        appBlockId="app-1"
+        slug="my-block"
+        currentVersion="1.0.0"
+        manifest={{ ...BASE_MANIFEST, description: 'Does a thing.' }}
+      />
+    );
+    await expect.element(page.getByRole('textbox', { name: 'Name' })).toHaveValue('My Block');
+    await expect
+      .element(page.getByRole('textbox', { name: 'Description' }))
+      .toHaveValue('Does a thing.');
+    // New version defaults to a patch bump of the current version.
+    await expect.element(page.getByRole('textbox', { name: 'New version' })).toHaveValue('1.0.1');
+    await expect.element(page.getByRole('textbox', { name: 'Block ID (immutable)' })).toHaveValue(
+      'my-block'
+    );
+  });
+
   test('clearing all justification inputs submits an explicit empty object (not undefined) so stored rationale is overwritten', async () => {
     renderWithProviders(
       <ManifestEditForm
@@ -187,5 +207,139 @@ describe('ManifestEditForm — per-scope justification authoring', () => {
     // previously-stored justifications instead of retaining stale rationale.
     expect(arg.patch.scopeJustifications).toEqual({});
     expect(arg.patch.scopeJustifications).not.toBeUndefined();
+  });
+});
+
+/**
+ * Tagline + Category — the two MANIFEST-GOVERNED store fields the onsite author
+ * had no surface for at all. Without them an onsite listing was permanently
+ * `tagline = null` / `category = null`, which is exactly what made
+ * /apps/my-submissions warn "Missing tagline / category" for a field the
+ * developer could not set anywhere.
+ */
+describe('ManifestEditForm — tagline + category (manifest-governed store fields)', () => {
+  test('renders both controls, seeded from the stored manifest', async () => {
+    renderWithProviders(
+      <ManifestEditForm
+        appBlockId="app-1"
+        slug="my-block"
+        currentVersion="1.0.0"
+        manifest={{ ...BASE_MANIFEST, tagline: 'Does the thing', category: 'utility' }}
+      />
+    );
+    await expect.element(page.getByRole('textbox', { name: 'Tagline' })).toHaveValue(
+      'Does the thing'
+    );
+    // Mantine Select renders as a combobox whose display value is the LABEL.
+    await expect.element(page.getByRole('textbox', { name: 'Category' })).toHaveValue('Utility');
+  });
+
+  test('Save includes the trimmed tagline + selected category on the patch', async () => {
+    renderWithProviders(
+      <ManifestEditForm
+        appBlockId="app-1"
+        slug="my-block"
+        currentVersion="1.0.0"
+        manifest={{ ...BASE_MANIFEST, category: 'utility' }}
+      />
+    );
+    await userEvent.fill(page.getByRole('textbox', { name: 'Tagline' }), '  A crisp one-liner  ');
+    await userEvent.click(page.getByRole('button', { name: 'Save & submit for review' }));
+
+    expect(mocks.mutate).toHaveBeenCalledTimes(1);
+    const arg = mocks.mutate.mock.calls[0][0] as { patch: Record<string, unknown> };
+    expect(arg.patch.tagline).toBe('A crisp one-liner');
+    expect(arg.patch.category).toBe('utility');
+  });
+
+  test('an EMPTY tagline / unset category submit as explicit null (so the server clears the manifest key)', async () => {
+    renderWithProviders(
+      <ManifestEditForm
+        appBlockId="app-1"
+        slug="my-block"
+        currentVersion="1.0.0"
+        manifest={{ ...BASE_MANIFEST, tagline: 'Old pitch' }}
+      />
+    );
+    await userEvent.clear(page.getByRole('textbox', { name: 'Tagline' }));
+    await userEvent.click(page.getByRole('button', { name: 'Save & submit for review' }));
+
+    const arg = mocks.mutate.mock.calls[0][0] as { patch: Record<string, unknown> };
+    // NOT undefined — an undefined may be dropped in transit and the server's
+    // {...stored, ...patch} merge would then retain the stale value.
+    expect(arg.patch.tagline).toBeNull();
+    expect(arg.patch.category).toBeNull();
+  });
+
+  test('lets the author PICK a category from the marketplace taxonomy', async () => {
+    renderWithProviders(
+      <ManifestEditForm
+        appBlockId="app-1"
+        slug="my-block"
+        currentVersion="1.0.0"
+        manifest={BASE_MANIFEST}
+      />
+    );
+    await userEvent.click(page.getByRole('textbox', { name: 'Category' }));
+    await userEvent.click(page.getByRole('option', { name: 'Games' }));
+    await userEvent.click(page.getByRole('button', { name: 'Save & submit for review' }));
+
+    const arg = mocks.mutate.mock.calls[0][0] as { patch: Record<string, unknown> };
+    expect(arg.patch.category).toBe('games');
+  });
+
+  test('an over-length tagline shows an error and DISABLES Save (advisory client gate)', async () => {
+    renderWithProviders(
+      <ManifestEditForm
+        appBlockId="app-1"
+        slug="my-block"
+        currentVersion="1.0.0"
+        manifest={BASE_MANIFEST}
+      />
+    );
+    await userEvent.fill(page.getByRole('textbox', { name: 'Tagline' }), 'a'.repeat(141));
+
+    await expect
+      .element(page.getByText('Tagline must be at most 140 characters'))
+      .toBeInTheDocument();
+    await expect
+      .element(page.getByRole('button', { name: 'Save & submit for review' }))
+      .toBeDisabled();
+  });
+
+  test('an exactly-at-cap tagline is accepted (Save stays enabled)', async () => {
+    renderWithProviders(
+      <ManifestEditForm
+        appBlockId="app-1"
+        slug="my-block"
+        currentVersion="1.0.0"
+        manifest={BASE_MANIFEST}
+      />
+    );
+    await userEvent.fill(page.getByRole('textbox', { name: 'Tagline' }), 'a'.repeat(140));
+    await expect
+      .element(page.getByRole('button', { name: 'Save & submit for review' }))
+      .toBeEnabled();
+  });
+
+  test('still OMITS targets from the patch when tagline/category are present (no slot clobber)', async () => {
+    renderWithProviders(
+      <ManifestEditForm
+        appBlockId="app-1"
+        slug="my-block"
+        currentVersion="1.0.0"
+        manifest={{
+          ...BASE_MANIFEST,
+          targets: [{ slotId: 'model.sidebar_top' }],
+          tagline: 'Pitch',
+          category: 'games',
+        }}
+      />
+    );
+    await userEvent.click(page.getByRole('button', { name: 'Save & submit for review' }));
+    const arg = mocks.mutate.mock.calls[0][0] as { patch: Record<string, unknown> };
+    expect('targets' in arg.patch).toBe(false);
+    expect(arg.patch.tagline).toBe('Pitch');
+    expect(arg.patch.category).toBe('games');
   });
 });

--- a/src/components/Apps/ManifestEditForm.tsx
+++ b/src/components/Apps/ManifestEditForm.tsx
@@ -14,7 +14,15 @@ import Link from 'next/link';
 import { useState } from 'react';
 import { BlockScopeSelector } from '~/components/Apps/BlockScopeSelector';
 import { buildScopeJustifications } from '~/components/Apps/blockScopeSelection';
-import { ALLOWED_CONTENT_RATINGS } from '~/server/services/block-manifest-validator.service';
+import {
+  ALLOWED_CONTENT_RATINGS,
+  MANIFEST_TAGLINE_MAX_LENGTH,
+} from '~/server/services/block-manifest-validator.service';
+import {
+  MARKETPLACE_CATEGORIES,
+  MARKETPLACE_CATEGORY_LABELS,
+  isMarketplaceCategory,
+} from '~/server/services/blocks/marketplace-categories.constants';
 import { showErrorNotification, showSuccessNotification } from '~/utils/notifications';
 import { trpc } from '~/utils/trpc';
 
@@ -36,6 +44,8 @@ type StoredManifest = Record<string, unknown> & {
   version?: string;
   name?: string;
   description?: string;
+  tagline?: string;
+  category?: string;
   contentRating?: string;
   scopes?: string[];
   scopeJustifications?: Record<string, string>;
@@ -60,6 +70,15 @@ export function ManifestEditForm({
 
   const [name, setName] = useState<string>(manifest.name ?? '');
   const [description, setDescription] = useState<string>(manifest.description ?? '');
+  // One-line store pitch + marketplace category. Both are MANIFEST-GOVERNED for
+  // an onsite listing (the /apps/[appBlockId]/edit Listing tab is media-only), so
+  // this form is the ONLY place an author sets them. Empty tagline / null
+  // category = "not set" and is sent as an explicit `null` so the server CLEARS
+  // the manifest key (see the nullable patch fields in blocks.router).
+  const [tagline, setTagline] = useState<string>(manifest.tagline ?? '');
+  const [category, setCategory] = useState<string | null>(
+    isMarketplaceCategory(manifest.category) ? manifest.category : null
+  );
   const [contentRating, setContentRating] = useState<string>(manifest.contentRating ?? 'g');
   const [version, setVersion] = useState<string>(bumpPatch(currentVersion));
   // Declared scopes, seeded from the stored manifest. Driven by the
@@ -119,6 +138,10 @@ export function ManifestEditForm({
         version,
         name: name.trim() || undefined,
         description: description.trim() || undefined,
+        // Explicit `null` = clear the manifest key (an `undefined` may be dropped
+        // in transit and the server merge would then retain the stored value).
+        tagline: tagline.trim() || null,
+        category: category ?? null,
         contentRating,
         scopes,
         scopeJustifications: shouldSend ? scopeJustifications : undefined,
@@ -134,7 +157,11 @@ export function ManifestEditForm({
     });
   }
 
-  const canSave = versionValid && versionHigher && !mutation.isPending && name.trim().length > 0;
+  // Advisory client gate only — the server re-validates every field with
+  // BlockManifestValidator (which is what actually enforces the tagline cap).
+  const taglineTooLong = tagline.trim().length > MANIFEST_TAGLINE_MAX_LENGTH;
+  const canSave =
+    versionValid && versionHigher && !mutation.isPending && name.trim().length > 0 && !taglineTooLong;
 
   return (
     <Stack gap="md">
@@ -156,6 +183,16 @@ export function ManifestEditForm({
         error={name.trim().length === 0 ? 'Name is required' : undefined}
       />
 
+      <TextInput
+        label="Tagline"
+        description={`A one-line pitch shown under your app's name in the Apps store. Optional — leave it empty for no tagline. Max ${MANIFEST_TAGLINE_MAX_LENGTH} characters.`}
+        value={tagline}
+        onChange={(e) => setTagline(e.currentTarget.value)}
+        error={
+          taglineTooLong ? `Tagline must be at most ${MANIFEST_TAGLINE_MAX_LENGTH} characters` : undefined
+        }
+      />
+
       <Textarea
         label="Description"
         autosize
@@ -163,6 +200,19 @@ export function ManifestEditForm({
         maxRows={6}
         value={description}
         onChange={(e) => setDescription(e.currentTarget.value)}
+      />
+
+      <Select
+        label="Category"
+        description="Where your app is filed in the Apps store. Optional — a moderator can categorise it for you. A category a moderator has already set is not overwritten."
+        placeholder="No category"
+        clearable
+        data={[...MARKETPLACE_CATEGORIES].map((c) => ({
+          value: c,
+          label: MARKETPLACE_CATEGORY_LABELS[c],
+        }))}
+        value={category}
+        onChange={setCategory}
       />
 
       <Select

--- a/src/components/Apps/OnsiteReviewModal.browser.test.tsx
+++ b/src/components/Apps/OnsiteReviewModal.browser.test.tsx
@@ -240,6 +240,47 @@ describe('OnsiteReviewModal — onsite-specific contract', () => {
   });
 });
 
+describe('OnsiteReviewModal — store-visible copy is surfaced INLINE for the mod', () => {
+  // `tagline` + `category` are MANIFEST-GOVERNED and go live on the app's /apps
+  // listing the moment this request is approved. The mod is the ONLY gate on
+  // store-visible copy changing, so they must render beside name/description —
+  // not be buried in the collapsed "Other manifest fields" raw-JSON disclosure.
+  test('renders the manifest tagline + category in the identity card, not the raw-JSON fallback', async () => {
+    const withCopy = {
+      ...ONSITE_PENDING,
+      manifest: {
+        ...ONSITE_PENDING.manifest,
+        tagline: 'The fastest way to remix a model',
+        category: 'generation',
+      },
+    };
+    renderWithProviders(
+      <OnsiteReviewModal selection={{ request: withCopy, mode: 'pending' }} onClose={vi.fn()} />
+    );
+    // Both are visible WITHOUT expanding any disclosure.
+    await expect
+      .element(page.getByText('The fastest way to remix a model'))
+      .toBeInTheDocument();
+    await expect.element(page.getByText('generation')).toBeInTheDocument();
+    // They are HANDLED keys, so the "Other manifest fields" count is unchanged
+    // (still just the one novel key from the base fixture) — i.e. they did not
+    // fall through to the raw-JSON dump.
+    await expect
+      .element(page.getByRole('button', { name: 'Other manifest fields (1)' }))
+      .toBeInTheDocument();
+  });
+
+  test('omitting them renders no empty tagline/category chrome', async () => {
+    // The base fixture declares neither.
+    renderWithProviders(
+      <OnsiteReviewModal selection={{ request: ONSITE_PENDING, mode: 'pending' }} onClose={vi.fn()} />
+    );
+    await expect.element(page.getByText('My Onsite Block')).toBeInTheDocument();
+    expect(page.getByText('The fastest way to remix a model').elements()).toHaveLength(0);
+    expect(page.getByText('generation').elements()).toHaveLength(0);
+  });
+});
+
 describe('OnsiteReviewModal — per-scope justifications shown to the mod', () => {
   test('renders each declared permission with its dev-supplied justification, and a "No justification provided" fallback when absent', async () => {
     const withJustifications = {

--- a/src/components/Apps/OnsiteReviewModal.tsx
+++ b/src/components/Apps/OnsiteReviewModal.tsx
@@ -937,6 +937,12 @@ const HANDLED_MANIFEST_KEYS = new Set([
   'version',
   'name',
   'description',
+  // Store-visible copy: both are MANIFEST-GOVERNED and flow to the app's `/apps`
+  // listing on approve, so the reviewer must see them INLINE next to name +
+  // description — not buried in the "Other manifest fields" raw-JSON disclosure.
+  // The mod is the only gate on store-visible copy changing.
+  'tagline',
+  'category',
   'type',
   'minApiVersion',
   'contentRating',
@@ -1014,6 +1020,8 @@ function ManifestIdentity({ manifest }: { manifest: Record<string, unknown> }) {
   const name = typeof manifest.name === 'string' ? manifest.name : null;
   const description =
     typeof manifest.description === 'string' ? manifest.description : null;
+  const tagline = typeof manifest.tagline === 'string' ? manifest.tagline : null;
+  const category = typeof manifest.category === 'string' ? manifest.category : null;
   const blockId = typeof manifest.blockId === 'string' ? manifest.blockId : null;
   const version = typeof manifest.version === 'string' ? manifest.version : null;
   const contentRating =
@@ -1031,12 +1039,25 @@ function ManifestIdentity({ manifest }: { manifest: Record<string, unknown> }) {
                 {name}
               </Text>
             )}
+            {/* Store-visible one-liner (manifest-governed — goes live on approve). */}
+            {tagline && (
+              <Text size="sm" c="dimmed">
+                {tagline}
+              </Text>
+            )}
             <Group gap={6}>
               {blockId && <Code>{blockId}</Code>}
               {version && (
                 <Badge color="gray" variant="light">
                   v{version}
                 </Badge>
+              )}
+              {category && (
+                <Tooltip label="Marketplace category">
+                  <Badge color="gray" variant="light">
+                    {category}
+                  </Badge>
+                </Tooltip>
               )}
             </Group>
           </Stack>

--- a/src/server/routers/__tests__/blocks.router.updateManifest.test.ts
+++ b/src/server/routers/__tests__/blocks.router.updateManifest.test.ts
@@ -376,6 +376,82 @@ describe('blocks.updateManifest — Phase 1 web manifest editor', () => {
     expect(validated.trustTier).toBe('unverified');
   });
 
+  // The MANIFEST-GOVERNED store fields. An onsite listing has no other author
+  // surface for these (the /apps/[appBlockId]/edit Listing tab is media-only),
+  // so the editor must be able to both SET and CLEAR them here.
+  describe('tagline + category (manifest-governed store fields)', () => {
+    it('accepts + commits a tagline and category', async () => {
+      findUnique.mockResolvedValue(approvedBlock);
+      const caller = blocksRouter.createCaller(fakeCtx(ownerUser) as never);
+      await caller.updateManifest({
+        appBlockId: 'ab_1',
+        patch: { ...validPatch, tagline: 'A crisp one-liner', category: 'utility' },
+      });
+
+      const commitArg = mockCommitFiles.mock.calls[0][0];
+      const committed = JSON.parse(commitArg.files[0].content.toString('utf8'));
+      expect(committed.tagline).toBe('A crisp one-liner');
+      expect(committed.category).toBe('utility');
+      // The validator (the authoritative gate) saw them too.
+      const validated = mockValidate.mock.calls[0][0] as Record<string, unknown>;
+      expect(validated.tagline).toBe('A crisp one-liner');
+      expect(validated.category).toBe('utility');
+    });
+
+    it('an explicit null DELETES the key from the merged manifest (clear, not a null value)', async () => {
+      // The stored manifest already has both; the client clears them. `null` must
+      // REMOVE the key — the manifest fields are optional and the validator
+      // rejects a non-string value, so a literal null would fail validation and
+      // an `undefined` would be dropped by the {...stored, ...patch} merge (which
+      // would silently retain the stale value).
+      findUnique.mockResolvedValue({
+        ...approvedBlock,
+        manifest: { ...approvedBlock.manifest, tagline: 'Old pitch', category: 'games' },
+      });
+      const caller = blocksRouter.createCaller(fakeCtx(ownerUser) as never);
+      await caller.updateManifest({
+        appBlockId: 'ab_1',
+        patch: { ...validPatch, tagline: null, category: null },
+      });
+
+      const validated = mockValidate.mock.calls[0][0] as Record<string, unknown>;
+      expect('tagline' in validated).toBe(false);
+      expect('category' in validated).toBe(false);
+      const commitArg = mockCommitFiles.mock.calls[0][0];
+      const committed = JSON.parse(commitArg.files[0].content.toString('utf8'));
+      expect('tagline' in committed).toBe(false);
+      expect('category' in committed).toBe(false);
+      // And the stale values are genuinely gone from the committed bytes.
+      expect(commitArg.files[0].content.toString('utf8')).not.toContain('Old pitch');
+    });
+
+    it('OMITTING them preserves the stored values (sparse patch, unchanged merge semantics)', async () => {
+      findUnique.mockResolvedValue({
+        ...approvedBlock,
+        manifest: { ...approvedBlock.manifest, tagline: 'Kept pitch', category: 'games' },
+      });
+      const caller = blocksRouter.createCaller(fakeCtx(ownerUser) as never);
+      await caller.updateManifest({ appBlockId: 'ab_1', patch: validPatch });
+
+      const validated = mockValidate.mock.calls[0][0] as Record<string, unknown>;
+      expect(validated.tagline).toBe('Kept pitch');
+      expect(validated.category).toBe('games');
+    });
+
+    it('a validator-rejected tagline is a BAD_REQUEST — nothing committed', async () => {
+      findUnique.mockResolvedValue(approvedBlock);
+      mockValidate.mockReturnValue({ valid: false, errors: ['tagline must be ≤140 chars'] });
+      const caller = blocksRouter.createCaller(fakeCtx(ownerUser) as never);
+      await expect(
+        caller.updateManifest({
+          appBlockId: 'ab_1',
+          patch: { ...validPatch, tagline: 'a'.repeat(200) },
+        })
+      ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+      expect(mockCommitFiles).not.toHaveBeenCalled();
+    });
+  });
+
   it('server-owned trustTier: with no stored tier on the row it defaults to `unverified` (never the patched value)', async () => {
     // approvedBlock has no trustTier field at all (null/undefined on the row) —
     // the override must fall back to `unverified`, not honour the client patch.

--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -5104,6 +5104,19 @@ export const blocksRouter = router({
             renderMode: z.string().min(1).max(16).optional(),
             trustTier: z.string().min(1).max(16).optional(),
             description: z.string().max(5000).optional(),
+            // One-line store pitch + marketplace category. Both are
+            // MANIFEST-GOVERNED for an onsite listing (there is no other author
+            // surface — the /apps/[appBlockId]/edit Listing tab is media-only),
+            // so the editor writes them here and they flow to the store listing
+            // on approve. The BlockManifestValidator re-checks both below
+            // (tagline ≤140 trimmed, category ∈ MARKETPLACE_CATEGORIES); these
+            // bounds are just coarse request-size guards. `.nullable()` so the
+            // client can explicitly CLEAR a previously-set value (an `undefined`
+            // may be dropped in transit, and the server merge is
+            // `{...stored, ...patch}` — so a dropped key would retain the old
+            // value; see the same reasoning for scopeJustifications).
+            tagline: z.string().max(500).nullable().optional(),
+            category: z.string().max(64).nullable().optional(),
             scopes: z.array(z.string().min(1).max(128)).max(64).optional(),
             // Optional per-scope justification map (scope-id → rationale). The
             // BlockManifestValidator re-checks it below (keys must be declared
@@ -5207,6 +5220,16 @@ export const blocksRouter = router({
         blockId: slug,
         iframe: { ...storedIframe, ...(patch.iframe ?? {}) },
       };
+
+      // Explicit CLEAR for the nullable optional fields. The client sends `null`
+      // to REMOVE a previously-set `tagline`/`category`; a plain `undefined` may
+      // be dropped in transit, and the `{...stored, ...patch}` merge above would
+      // then retain the stored value. Both fields are OPTIONAL in the manifest,
+      // and the validator rejects a non-string/blank value, so "cleared" must
+      // mean the KEY IS ABSENT — not `null`.
+      for (const key of ['tagline', 'category'] as const) {
+        if (patch[key] === null) delete merged[key];
+      }
 
       // version must STRICTLY increase so each edit is a new, ordered version
       // (mirrors a ZIP submitVersion). Reject equal/lower to keep the version

--- a/src/server/services/__tests__/block-manifest-validator.service.test.ts
+++ b/src/server/services/__tests__/block-manifest-validator.service.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest';
-import { BlockManifestValidator } from '../block-manifest-validator.service';
+import {
+  BlockManifestValidator,
+  MANIFEST_TAGLINE_MAX_LENGTH,
+} from '../block-manifest-validator.service';
 import { TokenScope } from '~/shared/constants/token-scope.constants';
 import { MARKETPLACE_CATEGORIES } from '~/server/services/blocks/marketplace-categories.constants';
 
@@ -666,6 +669,85 @@ describe('BlockManifestValidator', () => {
       expect(result.valid).toBe(false);
       if (!result.valid) {
         expect(result.errors.some((e) => e.startsWith('category must be one of'))).toBe(true);
+      }
+    });
+  });
+
+  // The OPTIONAL one-line store `tagline`. Absent is fine (the store shows no
+  // tagline); present must be a string whose TRIMMED length is 1..140. This is
+  // the AUTHORITATIVE gate — the published JSON schema is a shape hint.
+  describe('tagline (optional store one-liner)', () => {
+    it('accepts a manifest with NO tagline (optional, backward-compatible)', () => {
+      // VALID_MANIFEST declares no tagline.
+      expect(BlockManifestValidator.validate(VALID_MANIFEST, APP_CTX)).toEqual({ valid: true });
+    });
+
+    it('accepts a normal tagline', () => {
+      const manifest = { ...VALID_MANIFEST, tagline: 'The fastest way to remix a model' };
+      expect(BlockManifestValidator.validate(manifest, APP_CTX)).toEqual({ valid: true });
+    });
+
+    it('accepts a tagline EXACTLY at the cap', () => {
+      const manifest = { ...VALID_MANIFEST, tagline: 'a'.repeat(MANIFEST_TAGLINE_MAX_LENGTH) };
+      expect(BlockManifestValidator.validate(manifest, APP_CTX)).toEqual({ valid: true });
+    });
+
+    it('accepts an over-cap tagline whose TRIMMED length fits (padding is not counted)', () => {
+      const manifest = {
+        ...VALID_MANIFEST,
+        tagline: `   ${'a'.repeat(MANIFEST_TAGLINE_MAX_LENGTH)}   `,
+      };
+      expect(BlockManifestValidator.validate(manifest, APP_CTX)).toEqual({ valid: true });
+    });
+
+    it('rejects a tagline one char OVER the cap', () => {
+      const manifest = { ...VALID_MANIFEST, tagline: 'a'.repeat(MANIFEST_TAGLINE_MAX_LENGTH + 1) };
+      const result = BlockManifestValidator.validate(manifest, APP_CTX);
+      expect(result.valid).toBe(false);
+      if (!result.valid) {
+        expect(
+          result.errors.some((e) => e === `tagline must be ≤${MANIFEST_TAGLINE_MAX_LENGTH} chars`)
+        ).toBe(true);
+      }
+    });
+
+    it.each([
+      [42, 'number'],
+      [null, 'null'],
+      [{ text: 'hi' }, 'object'],
+      [['hi'], 'array'],
+      [true, 'boolean'],
+    ])('rejects a non-string tagline %j (%s)', (tagline) => {
+      const manifest = { ...VALID_MANIFEST, tagline };
+      const result = BlockManifestValidator.validate(manifest, APP_CTX);
+      expect(result.valid).toBe(false);
+      if (!result.valid) {
+        expect(result.errors.some((e) => e === 'tagline must be a string')).toBe(true);
+      }
+    });
+
+    it.each([
+      ['', 'empty string'],
+      ['   ', 'spaces only'],
+      ['\n\t ', 'whitespace only'],
+    ])('rejects a blank tagline %j (%s) — omit it instead', (tagline) => {
+      const manifest = { ...VALID_MANIFEST, tagline };
+      const result = BlockManifestValidator.validate(manifest, APP_CTX);
+      expect(result.valid).toBe(false);
+      if (!result.valid) {
+        expect(
+          result.errors.some((e) => e === 'tagline must not be blank (omit it instead)')
+        ).toBe(true);
+      }
+    });
+
+    it('does not regress the other manifest rules (a bad blockId still fails alongside a good tagline)', () => {
+      const manifest = { ...VALID_MANIFEST, blockId: 'X', tagline: 'fine' };
+      const result = BlockManifestValidator.validate(manifest, APP_CTX);
+      expect(result.valid).toBe(false);
+      if (!result.valid) {
+        expect(result.errors.some((e) => e.startsWith('blockId must be'))).toBe(true);
+        expect(result.errors.some((e) => e.startsWith('tagline'))).toBe(false);
       }
     });
   });

--- a/src/server/services/block-manifest-validator.service.ts
+++ b/src/server/services/block-manifest-validator.service.ts
@@ -34,6 +34,16 @@ interface RawManifest {
    * hasn't already curated one — see `approveRequest`). Absent is fine.
    */
   category?: unknown;
+  /**
+   * OPTIONAL one-line pitch shown under the app's name on its `/apps` store card
+   * + detail page. Manifest-governed (the onsite store listing has NO other
+   * author surface for it — see the "ONSITE = ASSETS-ONLY" invariant in
+   * `offsite-listing.service`), so it flows to the listing on approve and is
+   * re-synced on every subsequent approved version. When present it must be a
+   * string whose TRIMMED length is 1..{@link MANIFEST_TAGLINE_MAX_LENGTH}; absent
+   * is fine (the store simply shows no tagline).
+   */
+  tagline?: unknown;
   iframe?: {
     src?: unknown;
     minHeight?: unknown;
@@ -126,6 +136,21 @@ const BLOCK_ID_MAX_LENGTH = 40;
 // CANONICAL version rule: semantic version `x.y.z` with an optional
 // `-prerelease` suffix. Single-sourced with the published schema + the CLI.
 const VERSION_RE = /^\d+\.\d+\.\d+(-[0-9A-Za-z.-]+)?$/;
+
+/**
+ * CANONICAL `tagline` length cap. Deliberately the SAME bound off-site listings
+ * use (`OFFSITE_TAGLINE_MAX` in `~/server/schema/blocks/offsite-listing.schema`)
+ * so the two store kinds render consistently in the same card/detail slots.
+ *
+ * It is re-declared here rather than imported because this module is
+ * CLIENT-BUNDLE-SAFE (see the `ssrf-hostname` note above — `ManifestEditForm.tsx`
+ * imports it), and `offsite-listing.schema` pulls in zod + the external-app
+ * schema graph. A drift-guard test
+ * (`manifest-tagline.schema-drift.test.ts`) asserts this const, the canonical
+ * published schema's `tagline.maxLength`, and `OFFSITE_TAGLINE_MAX` are all equal,
+ * so the duplication can never silently diverge.
+ */
+export const MANIFEST_TAGLINE_MAX_LENGTH = 140;
 
 // Config-as-code `buildCommand` shape allowlist (defense-in-depth — see the
 // field comment in RawManifest). The build sandbox is already isolated; this
@@ -341,6 +366,25 @@ export class BlockManifestValidator {
     // submission path validates its taxonomy category.
     if (m.category !== undefined && !isMarketplaceCategory(m.category)) {
       errors.push(`category must be one of ${MARKETPLACE_CATEGORIES.join(', ')}`);
+    }
+
+    // Optional `tagline` (the one-line store pitch). Absent is fine. When
+    // present it must be a STRING whose TRIMMED length is 1..140 — trimmed so a
+    // whitespace-only value is rejected here rather than silently landing as a
+    // blank tagline on the store card, and so the cap can't be evaded with
+    // padding. The cap mirrors off-site listings (see
+    // MANIFEST_TAGLINE_MAX_LENGTH) so both store kinds render the same slot.
+    if (m.tagline !== undefined) {
+      if (typeof m.tagline !== 'string') {
+        errors.push('tagline must be a string');
+      } else {
+        const trimmed = m.tagline.trim();
+        if (trimmed.length === 0) {
+          errors.push('tagline must not be blank (omit it instead)');
+        } else if (trimmed.length > MANIFEST_TAGLINE_MAX_LENGTH) {
+          errors.push(`tagline must be ≤${MANIFEST_TAGLINE_MAX_LENGTH} chars`);
+        }
+      }
     }
 
     if (!Array.isArray(m.scopes)) {

--- a/src/server/services/blocks/__tests__/app-listing-mapper.test.ts
+++ b/src/server/services/blocks/__tests__/app-listing-mapper.test.ts
@@ -31,7 +31,7 @@ type Ab = {
 const onsite: Ab = {
   id: 'ab_1',
   blockId: 'cool-app',
-  manifest: { name: 'Cool App', description: 'A cool app' },
+  manifest: { name: 'Cool App', description: 'A cool app', tagline: 'The coolest app' },
   contentRating: 'pg',
   category: 'utility',
   featured: true,
@@ -62,6 +62,7 @@ describe('mapAppBlockToListing (shared)', () => {
       slug: 'cool-app',
       name: 'Cool App',
       description: 'A cool app',
+      tagline: 'The coolest app',
       iconId: null,
       coverId: null,
       category: 'utility',
@@ -91,11 +92,40 @@ describe('mapAppBlockToListing (shared)', () => {
     expect(mapAppBlockToListing(offsite).status).toBe('approved');
   });
 
-  it('falls back to slug for name and null description when the manifest lacks them', async () => {
+  it('falls back to slug for name and null description/tagline when the manifest lacks them', async () => {
     const { mapAppBlockToListing } = await import('../app-listing-mapper');
     const data = mapAppBlockToListing({ ...onsite, manifest: {} });
     expect(data.name).toBe('cool-app');
     expect(data.description).toBeNull();
+    expect(data.tagline).toBeNull();
+  });
+
+  it('maps a whitespace-only manifest tagline to null (never a blank store tagline)', async () => {
+    const { mapAppBlockToListing } = await import('../app-listing-mapper');
+    const data = mapAppBlockToListing({
+      ...onsite,
+      manifest: { name: 'Cool App', tagline: '   \n ' },
+    });
+    expect(data.tagline).toBeNull();
+  });
+
+  it('trims a manifest tagline before it reaches the listing', async () => {
+    const { mapAppBlockToListing } = await import('../app-listing-mapper');
+    const data = mapAppBlockToListing({
+      ...onsite,
+      manifest: { name: 'Cool App', tagline: '  Padded pitch  ' },
+    });
+    expect(data.tagline).toBe('Padded pitch');
+  });
+
+  it('carries the tagline onto an off-site (external-link) listing too', async () => {
+    const { mapAppBlockToListing } = await import('../app-listing-mapper');
+    const data = mapAppBlockToListing({
+      ...offsite,
+      manifest: { name: 'Ext App', tagline: 'Elsewhere' },
+    });
+    expect(data.kind).toBe('offsite');
+    expect(data.tagline).toBe('Elsewhere');
   });
 
   it('throws on a null owner (misuse — the callers guard this)', async () => {
@@ -120,5 +150,69 @@ describe('resolveListingName / resolveListingDescription (shared)', () => {
     expect(resolveListingDescription({ description: '   ' })).toBeNull();
     expect(resolveListingDescription({})).toBeNull();
     expect(resolveListingDescription(null)).toBeNull();
+  });
+
+  it('resolveListingTagline returns the trimmed string or null (blank/absent/non-string => null)', async () => {
+    const { resolveListingTagline } = await import('../app-listing-mapper');
+    expect(resolveListingTagline({ tagline: '  one-liner  ' })).toBe('one-liner');
+    expect(resolveListingTagline({ tagline: '   ' })).toBeNull();
+    expect(resolveListingTagline({})).toBeNull();
+    expect(resolveListingTagline(null)).toBeNull();
+    expect(resolveListingTagline({ tagline: 123 })).toBeNull();
+  });
+});
+
+describe('buildListingScalarSync (approve-time copy re-sync)', () => {
+  it('returns EXACTLY the manifest-governed scalar set — nothing curated', async () => {
+    const { buildListingScalarSync } = await import('../app-listing-mapper');
+    const out = buildListingScalarSync({
+      manifest: { name: ' New Name ', description: ' New desc ', tagline: ' New pitch ' },
+      blockId: 'cool-app',
+      category: 'utility',
+    });
+    // The exact key set matters: anything extra here would be written by the
+    // approve re-sync and could clobber a curated/mod-owned column.
+    expect(Object.keys(out).sort()).toEqual(['category', 'description', 'name', 'tagline']);
+    expect(out).toEqual({
+      name: 'New Name',
+      description: 'New desc',
+      tagline: 'New pitch',
+      category: 'utility',
+    });
+  });
+
+  it('agrees with mapAppBlockToListing for the same manifest (create ⇄ re-sync cannot drift)', async () => {
+    const { buildListingScalarSync, mapAppBlockToListing } = await import('../app-listing-mapper');
+    const created = mapAppBlockToListing(onsite);
+    const synced = buildListingScalarSync({
+      manifest: onsite.manifest,
+      blockId: onsite.blockId,
+      category: onsite.category,
+    });
+    expect(synced).toEqual({
+      name: created.name,
+      description: created.description ?? null,
+      tagline: created.tagline ?? null,
+      category: created.category ?? null,
+    });
+  });
+
+  it('takes category from the caller (AppBlock.category), NOT the manifest — mod curation survives', async () => {
+    const { buildListingScalarSync } = await import('../app-listing-mapper');
+    const out = buildListingScalarSync({
+      // The manifest says "games"; a moderator curated "analytics" onto the
+      // AppBlock, and that is what the caller passes.
+      manifest: { name: 'Cool App', category: 'games' },
+      blockId: 'cool-app',
+      category: 'analytics',
+    });
+    expect(out.category).toBe('analytics');
+  });
+
+  it('nulls a cleared description/tagline and falls back to the slug for a missing name', async () => {
+    const { buildListingScalarSync } = await import('../app-listing-mapper');
+    expect(
+      buildListingScalarSync({ manifest: {}, blockId: 'cool-app', category: null })
+    ).toEqual({ name: 'cool-app', description: null, tagline: null, category: null });
   });
 });

--- a/src/server/services/blocks/__tests__/manifest-tagline.schema-drift.test.ts
+++ b/src/server/services/blocks/__tests__/manifest-tagline.schema-drift.test.ts
@@ -1,0 +1,49 @@
+import { readFileSync } from 'fs';
+import path from 'path';
+import { describe, expect, it } from 'vitest';
+
+import { MANIFEST_TAGLINE_MAX_LENGTH } from '~/server/services/block-manifest-validator.service';
+import { OFFSITE_TAGLINE_MAX } from '~/server/schema/blocks/offsite-listing.schema';
+
+/**
+ * Drift guard — manifest `tagline`.
+ *
+ * THREE places declare the tagline bound and they must never diverge:
+ *   1. the canonical published schema `public/schemas/app-block/v1.json` (what
+ *      the `civitai` CLI byte-mirrors + what editors validate against),
+ *   2. `MANIFEST_TAGLINE_MAX_LENGTH` — the IMPERATIVE validator's cap, which is
+ *      the authoritative gate at submit/approve (the JSON schema is a shape hint),
+ *   3. `OFFSITE_TAGLINE_MAX` — the off-site listing bound. Onsite + offsite
+ *      taglines render in the SAME store card/detail slot, so they share a cap.
+ *
+ * The validator deliberately re-declares the number rather than importing (2)
+ * from (3) — it is client-bundle-safe and `offsite-listing.schema` pulls in zod +
+ * the external-app schema graph. This test is what makes that duplication safe.
+ */
+const REPO_ROOT = path.resolve(__dirname, '../../../../..');
+const SCHEMA_PATH = path.join(REPO_ROOT, 'public/schemas/app-block/v1.json');
+
+describe('app-block v1 schema ⇄ tagline bound drift guard', () => {
+  const schema = JSON.parse(readFileSync(SCHEMA_PATH, 'utf8')) as {
+    required?: unknown;
+    properties?: { tagline?: { type?: unknown; minLength?: unknown; maxLength?: unknown } };
+  };
+
+  it('declares tagline as an OPTIONAL non-empty string', () => {
+    const tagline = schema.properties?.tagline;
+    expect(tagline).toBeDefined();
+    expect(tagline?.type).toBe('string');
+    expect(tagline?.minLength).toBe(1);
+    // Optional: must NOT be listed in the schema's top-level `required`.
+    const required = Array.isArray(schema.required) ? (schema.required as string[]) : [];
+    expect(required).not.toContain('tagline');
+  });
+
+  it('schema maxLength equals the validator cap MANIFEST_TAGLINE_MAX_LENGTH', () => {
+    expect(schema.properties?.tagline?.maxLength).toBe(MANIFEST_TAGLINE_MAX_LENGTH);
+  });
+
+  it('the validator cap equals the off-site listing cap (one bound per store slot)', () => {
+    expect(MANIFEST_TAGLINE_MAX_LENGTH).toBe(OFFSITE_TAGLINE_MAX);
+  });
+});

--- a/src/server/services/blocks/__tests__/manifest-tagline.schema-drift.test.ts
+++ b/src/server/services/blocks/__tests__/manifest-tagline.schema-drift.test.ts
@@ -26,7 +26,14 @@ const SCHEMA_PATH = path.join(REPO_ROOT, 'public/schemas/app-block/v1.json');
 describe('app-block v1 schema ⇄ tagline bound drift guard', () => {
   const schema = JSON.parse(readFileSync(SCHEMA_PATH, 'utf8')) as {
     required?: unknown;
-    properties?: { tagline?: { type?: unknown; minLength?: unknown; maxLength?: unknown } };
+    properties?: {
+      tagline?: {
+        type?: unknown;
+        minLength?: unknown;
+        maxLength?: unknown;
+        pattern?: unknown;
+      };
+    };
   };
 
   it('declares tagline as an OPTIONAL non-empty string', () => {
@@ -37,6 +44,26 @@ describe('app-block v1 schema ⇄ tagline bound drift guard', () => {
     // Optional: must NOT be listed in the schema's top-level `required`.
     const required = Array.isArray(schema.required) ? (schema.required as string[]) : [];
     expect(required).not.toContain('tagline');
+  });
+
+  it('rejects a whitespace-only tagline the same way the validator does', () => {
+    // The validator rejects a BLANK tagline (it trims first). JSON Schema's
+    // minLength counts characters, so `"   "` would slip through it — the
+    // `\S` pattern is what keeps the schema from being MORE PERMISSIVE than the
+    // server, which is the divergence direction that actually hurts (a dev
+    // green locally, rejected at submit).
+    const pattern = schema.properties?.tagline?.pattern;
+    expect(pattern).toBe('\\S');
+    const re = new RegExp(pattern as string);
+    expect(re.test('   ')).toBe(false);
+    expect(re.test('')).toBe(false);
+    expect(re.test('\n\t ')).toBe(false);
+    expect(re.test('A crisp one-liner')).toBe(true);
+    // Padding around real content still passes the schema — matching the server,
+    // which trims before measuring. (The validator's own blank/over-cap
+    // rejections are covered in block-manifest-validator.service.test.ts; this
+    // guard's job is only that the SCHEMA is never the more permissive of the two.)
+    expect(re.test('  padded  ')).toBe(true);
   });
 
   it('schema maxLength equals the validator cap MANIFEST_TAGLINE_MAX_LENGTH', () => {

--- a/src/server/services/blocks/__tests__/publish-request.listingSync.test.ts
+++ b/src/server/services/blocks/__tests__/publish-request.listingSync.test.ts
@@ -203,8 +203,9 @@ describe('approveRequest (3b) — FIRST approve creates the listing (path unchan
     await approveRequest({ publishRequestId: 'req_1', reviewerUserId: 9 });
 
     expect(db.write.appListing.create).toHaveBeenCalledTimes(1);
-    const created = (db.write.appListing.create.mock.calls[0][0] as { data: Record<string, unknown> })
-      .data;
+    const created = (
+      db.write.appListing.create.mock.calls[0][0] as { data: Record<string, unknown> }
+    ).data;
     // The full mapper payload — including the newly-mapped tagline (trimmed).
     expect(created).toEqual({
       id: 'apl_fixed',

--- a/src/server/services/blocks/__tests__/publish-request.listingSync.test.ts
+++ b/src/server/services/blocks/__tests__/publish-request.listingSync.test.ts
@@ -244,7 +244,7 @@ describe('approveRequest (3b) — FIRST approve creates the listing (path unchan
 describe('approveRequest (3b-sync) — SUBSEQUENT approve re-syncs manifest-governed copy', () => {
   beforeEach(() => {
     // A listing already exists for this app ⇒ the re-sync branch.
-    db.read.appListing.findUnique.mockResolvedValue({ id: 'apl_existing' });
+    db.read.appListing.findUnique.mockResolvedValue({ id: 'apl_existing', kind: 'onsite' });
   });
 
   it('updates name/description/tagline/category from the new manifest and never creates', async () => {
@@ -339,5 +339,61 @@ describe('approveRequest (3b-sync) — SUBSEQUENT approve re-syncs manifest-gove
 
     expect(scalarSyncCalls()).toHaveLength(0);
     expect(db.write.appListing.create).not.toHaveBeenCalled();
+  });
+
+  it('REFUSES to sync onto an off-site listing — and says so instead of failing silently', async () => {
+    // An off-site listing's name/tagline/description are AUTHOR-supplied through
+    // the submit wizard, NOT manifest-governed, so writing manifest copy onto one
+    // would clobber the author's edits. approveRequest only ever produces hosted
+    // blocks, so this is anomalous — which is exactly why it must be LOUD rather
+    // than a silent zero-row no-op that disables the feature unnoticed.
+    db.read.appListing.findUnique.mockResolvedValue({ id: 'apl_existing', kind: 'offsite' });
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    await approveRequest({ publishRequestId: 'req_1', reviewerUserId: 9 });
+
+    expect(scalarSyncCalls()).toHaveLength(0);
+    expect(db.write.appListing.create).not.toHaveBeenCalled();
+    expect(
+      warn.mock.calls.some(
+        (c) =>
+          typeof c[0] === 'string' &&
+          c[0].includes('skipping listing copy re-sync') &&
+          c[0].includes("kind='offsite'")
+      )
+    ).toBe(true);
+    warn.mockRestore();
+  });
+
+  it('WARNS when the re-sync matches zero rows (replica lag) instead of silently skipping', async () => {
+    // The replica said a listing exists but the PRIMARY matched none. Benign and
+    // self-converging, but invisible-by-default would mean the store quietly keeps
+    // serving the previously-approved copy — the exact bug this re-sync fixes.
+    db.write.appListing.updateMany.mockResolvedValue({ count: 0 });
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    await approveRequest({ publishRequestId: 'req_1', reviewerUserId: 9 });
+
+    expect(scalarSyncCalls()).toHaveLength(1);
+    expect(
+      warn.mock.calls.some(
+        (c) => typeof c[0] === 'string' && c[0].includes('re-sync matched 0 rows')
+      )
+    ).toBe(true);
+    warn.mockRestore();
+  });
+
+  it('does NOT warn when the re-sync matches its row', async () => {
+    db.write.appListing.updateMany.mockResolvedValue({ count: 1 });
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    await approveRequest({ publishRequestId: 'req_1', reviewerUserId: 9 });
+
+    expect(
+      warn.mock.calls.some(
+        (c) => typeof c[0] === 'string' && c[0].includes('re-sync matched 0 rows')
+      )
+    ).toBe(false);
+    warn.mockRestore();
   });
 });

--- a/src/server/services/blocks/__tests__/publish-request.listingSync.test.ts
+++ b/src/server/services/blocks/__tests__/publish-request.listingSync.test.ts
@@ -1,0 +1,342 @@
+import JSZip from 'jszip';
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * `approveRequest` (3b) — onsite AppListing CREATE vs manifest-governed COPY RE-SYNC.
+ *
+ * An onsite store listing's `name` / `tagline` / `description` / `category` have
+ * NO author surface other than the block manifest (the /apps/[appBlockId]/edit
+ * Listing tab is media-only, and `applyApprovedRevision`'s onsite branch copies
+ * ONLY assets). Before the re-sync those scalars were snapshotted ONCE at the
+ * FIRST approve and never refreshed, so a developer who added a description (or
+ * a tagline) in a later version kept seeing "Missing description / tagline" on
+ * /apps/my-submissions forever and the store kept serving the v1 copy.
+ *
+ * What these tests pin:
+ *   1. FIRST approve (no listing yet) → CREATE, byte-identical to before: the
+ *      mapper payload, and NO update write at all.
+ *   2. SUBSEQUENT approve (listing exists) → an `updateMany` scoped to
+ *      `{ appBlockId, kind: 'onsite' }` carrying EXACTLY the manifest-governed
+ *      scalars — and NEVER a create.
+ *   3. `category` comes from `AppBlock.category` (mod curation survives), not
+ *      straight from the manifest.
+ *   4. Curated / mod-owned columns (assets, featured, contentRating, status,
+ *      slug) are NOT in the update payload.
+ *   5. The re-sync is BEST-EFFORT: a failing write is swallowed and the
+ *      approve/deploy still succeeds.
+ *
+ * The mapper module is NOT mocked here — the point is that the real
+ * `mapAppBlockToListing` / `buildListingScalarSync` payloads reach the DB layer.
+ */
+
+const { db, s3, holder } = vi.hoisted(() => {
+  const holder: { zipBytes: Uint8Array } = { zipBytes: new Uint8Array() };
+  const makeDb = () => ({
+    appBlockPublishRequest: {
+      findUnique: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
+      update: vi.fn(async (a: { data?: unknown }) => a?.data ?? {}),
+      updateMany: vi.fn(async (..._a: unknown[]) => ({ count: 1 })),
+    },
+    appBlock: {
+      findFirst: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
+      findUnique: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
+      create: vi.fn(async (a: { data?: unknown }) => a?.data ?? {}),
+      update: vi.fn(async (a: { data?: unknown }) => a?.data ?? {}),
+      updateMany: vi.fn(async (..._a: unknown[]) => ({ count: 0 })),
+    },
+    oauthClient: {
+      findUnique: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
+      create: vi.fn(async (a: { data?: unknown }) => a?.data ?? {}),
+      update: vi.fn(async (a: { data?: unknown }) => a?.data ?? {}),
+    },
+    appListing: {
+      findUnique: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
+      findFirst: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
+      create: vi.fn(async (a: { data?: unknown }) => a?.data ?? { id: 'apl_created' }),
+      updateMany: vi.fn(async (..._a: unknown[]) => ({ count: 0 })),
+    },
+  });
+  const db = { read: makeDb(), write: makeDb() };
+  const s3 = {
+    send: vi.fn(async () => ({
+      Body: { transformToByteArray: async () => holder.zipBytes },
+    })),
+  };
+  return { db, s3, holder };
+});
+
+vi.mock('~/server/services/blocks/app-block-notify', () => ({
+  notifyAppBlockSubmitter: vi.fn(async () => undefined),
+}));
+vi.mock('~/server/db/client', () => ({ dbRead: db.read, dbWrite: db.write }));
+vi.mock('~/env/server', () => ({
+  env: {
+    FORGEJO_BASE_URL: 'https://forgejo.example',
+    FORGEJO_ADMIN_TOKEN: 'tok',
+    FORGEJO_WEBHOOK_SECRET: 'sec',
+    APPS_DOMAIN: 'apps.example',
+    NEXTAUTH_URL: 'https://civitai.example',
+  },
+}));
+vi.mock('~/server/utils/app-block-ids', async () => {
+  const actual = await vi.importActual<Record<string, unknown>>('~/server/utils/app-block-ids');
+  return { ...actual, newUlid: () => 'ULID000', newAppListingId: () => 'apl_fixed' };
+});
+vi.mock('~/server/services/block-manifest-validator.service', () => ({
+  BlockManifestValidator: {
+    validate: () => ({ valid: true, errors: [] }),
+    validateSubmission: async () => ({ valid: true, errors: [] }),
+  },
+}));
+vi.mock('~/server/services/blocks/forgejo.service', () => ({
+  commitFiles: vi.fn(async () => ({ sha: 'deadbeefsha' })),
+  setCommitStatus: vi.fn(async () => undefined),
+  createRepoFromTemplate: vi.fn(async () => ({ html_url: 'https://forgejo.example/x' })),
+  ensurePushWebhook: vi.fn(async () => undefined),
+  listRepoTreeAtRef: vi.fn(async () => new Map()),
+  getBlobContent: vi.fn(async () => Buffer.from('')),
+}));
+vi.mock('~/server/services/blocks/apps-pipeline.service', () => ({
+  triggerBuild: vi.fn(async () => undefined),
+}));
+vi.mock('~/utils/bundle-s3', () => ({
+  getBundleBucket: () => 'bundles',
+  getBundleS3Client: () => s3,
+}));
+
+const { approveRequest } = await import('~/server/services/blocks/publish-request.service');
+
+/** The manifest the NEW version being approved declares. */
+const NEW_MANIFEST = {
+  name: 'Cool App v2',
+  description: 'Now with more cool.',
+  tagline: '  The coolest app  ',
+  scopes: [],
+};
+
+/** A pending, SUBSEQUENT-version request row (an AppBlock already exists). */
+function pendingRow() {
+  return {
+    id: 'req_1',
+    status: 'pending',
+    slug: 'cool-app',
+    version: '1.2.0',
+    manifest: NEW_MANIFEST,
+    bundleKey: 'bundles/cool-app.zip',
+    forgejoCommitSha: '',
+    submittedByUserId: 4242,
+    appBlockId: 'apb_1',
+    deployState: null,
+  };
+}
+
+function existingAppBlock() {
+  return {
+    id: 'apb_1',
+    appId: 'app_1',
+    repoUrl: 'https://forgejo.example/cool-app',
+    trustTier: 'unverified',
+    app: { allowedScopes: 0, allowedOrigins: ['https://cool-app.apps.example'] },
+  };
+}
+
+/** The (3b) read of the freshly-approved AppBlock's own columns. */
+function appBlockRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'apb_1',
+    blockId: 'cool-app',
+    manifest: NEW_MANIFEST,
+    contentRating: 'pg',
+    category: 'utility',
+    featured: false,
+    featuredOrder: null,
+    externalUrl: null,
+    app: { userId: 42 },
+    ...overrides,
+  };
+}
+
+beforeAll(async () => {
+  const zip = new JSZip();
+  zip.file('block.manifest.json', JSON.stringify(NEW_MANIFEST));
+  zip.file('index.html', '<html></html>');
+  holder.zipBytes = await zip.generateAsync({ type: 'uint8array' });
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  db.write.appBlockPublishRequest.update.mockImplementation(
+    async (a: { data?: unknown }) => a?.data ?? {}
+  );
+  db.write.appBlockPublishRequest.updateMany.mockResolvedValue({ count: 1 });
+  db.write.appBlock.update.mockImplementation(async (a: { data?: unknown }) => a?.data ?? {});
+  db.write.appBlock.updateMany.mockResolvedValue({ count: 0 });
+  db.write.appBlock.findUnique.mockResolvedValue(appBlockRow());
+  db.write.oauthClient.update.mockResolvedValue({});
+  db.write.appListing.create.mockResolvedValue({ id: 'apl_created' });
+  db.write.appListing.updateMany.mockResolvedValue({ count: 0 });
+  db.write.appListing.findFirst.mockResolvedValue(null);
+  db.read.appBlockPublishRequest.findUnique.mockResolvedValue(pendingRow());
+  db.read.appBlock.findFirst.mockResolvedValue(existingAppBlock());
+  s3.send.mockImplementation(async () => ({
+    Body: { transformToByteArray: async () => holder.zipBytes },
+  }));
+});
+
+afterAll(() => {
+  vi.restoreAllMocks();
+});
+
+/** The (3b) listing write calls, ignoring the unrelated (3b-reset) restore flip. */
+function scalarSyncCalls() {
+  return db.write.appListing.updateMany.mock.calls.filter((c) => {
+    const arg = c[0] as { data?: Record<string, unknown> };
+    // The (3b-reset) restore writes ONLY `{ status: 'approved' }`.
+    return arg?.data != null && !('status' in arg.data);
+  });
+}
+
+describe('approveRequest (3b) — FIRST approve creates the listing (path unchanged)', () => {
+  it('CREATES via the mapper and performs NO manifest-governed update write', async () => {
+    db.read.appListing.findUnique.mockResolvedValue(null);
+
+    await approveRequest({ publishRequestId: 'req_1', reviewerUserId: 9 });
+
+    expect(db.write.appListing.create).toHaveBeenCalledTimes(1);
+    const created = (db.write.appListing.create.mock.calls[0][0] as { data: Record<string, unknown> })
+      .data;
+    // The full mapper payload — including the newly-mapped tagline (trimmed).
+    expect(created).toEqual({
+      id: 'apl_fixed',
+      kind: 'onsite',
+      slug: 'cool-app',
+      name: 'Cool App v2',
+      description: 'Now with more cool.',
+      tagline: 'The coolest app',
+      iconId: null,
+      coverId: null,
+      category: 'utility',
+      status: 'approved',
+      contentRating: 'pg',
+      externalUrl: null,
+      connectClientId: null,
+      appBlockId: 'apb_1',
+      featured: false,
+      featuredOrder: null,
+      userId: 42,
+    });
+    // The create path must not also run the re-sync.
+    expect(scalarSyncCalls()).toHaveLength(0);
+  });
+
+  it('still skips the create when the AppBlock has no resolvable owner (unchanged)', async () => {
+    db.read.appListing.findUnique.mockResolvedValue(null);
+    db.write.appBlock.findUnique.mockResolvedValue(appBlockRow({ app: null }));
+
+    await approveRequest({ publishRequestId: 'req_1', reviewerUserId: 9 });
+
+    expect(db.write.appListing.create).not.toHaveBeenCalled();
+    expect(scalarSyncCalls()).toHaveLength(0);
+  });
+});
+
+describe('approveRequest (3b-sync) — SUBSEQUENT approve re-syncs manifest-governed copy', () => {
+  beforeEach(() => {
+    // A listing already exists for this app ⇒ the re-sync branch.
+    db.read.appListing.findUnique.mockResolvedValue({ id: 'apl_existing' });
+  });
+
+  it('updates name/description/tagline/category from the new manifest and never creates', async () => {
+    await approveRequest({ publishRequestId: 'req_1', reviewerUserId: 9 });
+
+    expect(db.write.appListing.create).not.toHaveBeenCalled();
+    const calls = scalarSyncCalls();
+    expect(calls).toHaveLength(1);
+    const arg = calls[0][0] as { where: Record<string, unknown>; data: Record<string, unknown> };
+    expect(arg.where).toEqual({ appBlockId: 'apb_1', kind: 'onsite' });
+    expect(arg.data).toEqual({
+      name: 'Cool App v2',
+      description: 'Now with more cool.',
+      tagline: 'The coolest app',
+      category: 'utility',
+    });
+  });
+
+  it('writes EXACTLY the manifest-governed keys — no curated/mod-owned column is touched', async () => {
+    await approveRequest({ publishRequestId: 'req_1', reviewerUserId: 9 });
+
+    const arg = scalarSyncCalls()[0][0] as { data: Record<string, unknown> };
+    expect(Object.keys(arg.data).sort()).toEqual(['category', 'description', 'name', 'tagline']);
+    for (const curated of [
+      'iconId',
+      'coverId',
+      'featured',
+      'featuredOrder',
+      'contentRating',
+      'status',
+      'slug',
+      'externalUrl',
+      'userId',
+    ]) {
+      expect(arg.data).not.toHaveProperty(curated);
+    }
+  });
+
+  it('takes category from AppBlock.category (mod curation), NOT the manifest', async () => {
+    // The manifest asks for `games`; a moderator already curated `analytics`
+    // onto the AppBlock (step (3a) is null-gated so it does not overwrite it).
+    db.read.appBlockPublishRequest.findUnique.mockResolvedValue({
+      ...pendingRow(),
+      manifest: { ...NEW_MANIFEST, category: 'games' },
+    });
+    db.write.appBlock.findUnique.mockResolvedValue(
+      appBlockRow({
+        category: 'analytics',
+        manifest: { ...NEW_MANIFEST, category: 'games' },
+      })
+    );
+
+    await approveRequest({ publishRequestId: 'req_1', reviewerUserId: 9 });
+
+    const arg = scalarSyncCalls()[0][0] as { data: Record<string, unknown> };
+    expect(arg.data.category).toBe('analytics');
+  });
+
+  it('CLEARS a removed description/tagline (manifest-governed means the manifest wins)', async () => {
+    const stripped = { name: 'Cool App v2', scopes: [] };
+    db.read.appBlockPublishRequest.findUnique.mockResolvedValue({
+      ...pendingRow(),
+      manifest: stripped,
+    });
+    db.write.appBlock.findUnique.mockResolvedValue(
+      appBlockRow({ manifest: stripped, category: null })
+    );
+
+    await approveRequest({ publishRequestId: 'req_1', reviewerUserId: 9 });
+
+    const arg = scalarSyncCalls()[0][0] as { data: Record<string, unknown> };
+    expect(arg.data).toEqual({
+      name: 'Cool App v2',
+      description: null,
+      tagline: null,
+      category: null,
+    });
+  });
+
+  it('is BEST-EFFORT: a failing re-sync write does not fail the approve/deploy', async () => {
+    db.write.appListing.updateMany.mockRejectedValueOnce(new Error('db blip'));
+
+    await expect(
+      approveRequest({ publishRequestId: 'req_1', reviewerUserId: 9 })
+    ).resolves.toMatchObject({ publishRequestId: 'req_1', appBlockId: 'apb_1' });
+  });
+
+  it('skips the re-sync when the AppBlock row cannot be read (no blind write)', async () => {
+    db.write.appBlock.findUnique.mockResolvedValue(null);
+
+    await approveRequest({ publishRequestId: 'req_1', reviewerUserId: 9 });
+
+    expect(scalarSyncCalls()).toHaveLength(0);
+    expect(db.write.appListing.create).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/services/blocks/__tests__/publish-request.notify.service.test.ts
+++ b/src/server/services/blocks/__tests__/publish-request.notify.service.test.ts
@@ -87,6 +87,16 @@ vi.mock('~/server/services/blocks/apps-pipeline.service', () => ({
 }));
 vi.mock('~/server/services/blocks/app-listing-mapper', () => ({
   mapAppBlockToListing: () => ({ id: 'apl_mapped' }),
+  // The approve path also imports the manifest-governed copy re-sync builder
+  // (subsequent-version approve). Stubbed so this suite stays focused on the
+  // notification emission; the re-sync itself has its own suite
+  // (publish-request.listingSync.test.ts).
+  buildListingScalarSync: () => ({
+    name: 'Cool App',
+    description: null,
+    tagline: null,
+    category: null,
+  }),
 }));
 vi.mock('~/utils/bundle-s3', () => ({
   getBundleBucket: () => 'bundles',

--- a/src/server/services/blocks/__tests__/publish-request.notify.service.test.ts
+++ b/src/server/services/blocks/__tests__/publish-request.notify.service.test.ts
@@ -38,7 +38,9 @@ const { mockNotify, db, s3, holder } = vi.hoisted(() => {
       update: vi.fn(async (a: { data?: unknown }) => a?.data ?? {}),
     },
     appListing: {
-      findUnique: vi.fn(async (..._a: unknown[]): Promise<unknown> => ({ id: 'apl_existing' })),
+      findUnique: vi.fn(
+        async (..._a: unknown[]): Promise<unknown> => ({ id: 'apl_existing', kind: 'onsite' })
+      ),
       create: vi.fn(async (a: { data?: unknown }) => a?.data ?? {}),
       updateMany: vi.fn(async (..._a: unknown[]) => ({ count: 0 })),
     },
@@ -156,7 +158,7 @@ beforeEach(() => {
   db.write.appBlock.findUnique.mockResolvedValue({ id: 'apb_existing' });
   db.write.oauthClient.update.mockResolvedValue({});
   db.write.appListing.updateMany.mockResolvedValue({ count: 0 });
-  db.read.appListing.findUnique.mockResolvedValue({ id: 'apl_existing' });
+  db.read.appListing.findUnique.mockResolvedValue({ id: 'apl_existing', kind: 'onsite' });
   s3.send.mockImplementation(async () => ({
     Body: { transformToByteArray: async () => holder.zipBytes },
   }));

--- a/src/server/services/blocks/__tests__/publish-request.orchestration.test.ts
+++ b/src/server/services/blocks/__tests__/publish-request.orchestration.test.ts
@@ -2169,7 +2169,9 @@ describe('approveRequest', () => {
       // Idempotency guard: checked for an existing listing by appBlockId first.
       expect(mockDbRead.appListing.findUnique).toHaveBeenCalledWith({
         where: { appBlockId: result.appBlockId },
-        select: { id: true },
+        // `kind` is selected so the (3b-sync) re-sync can refuse to write
+        // manifest copy onto an off-site listing (whose copy is author-supplied).
+        select: { id: true, kind: true },
       });
       // Exactly one listing minted — onsite, approved, slug=blockId, appBlockId
       // set, name/contentRating derived from the manifest, owner = submitter.
@@ -2208,7 +2210,7 @@ describe('approveRequest', () => {
       expect(data.connectClientId).toBeNull();
     });
 
-    it('subsequent-version approve does NOT duplicate or clobber an existing listing', async () => {
+    it('subsequent-version approve does NOT duplicate the listing, and re-syncs ONLY the manifest-governed scalars', async () => {
       const { approveRequest } = await import('../publish-request.service');
       mockDbRead.appBlockPublishRequest.findUnique.mockResolvedValue(
         pendingRequest({ manifest: manifest({ version: '0.2.0' }) })
@@ -2220,8 +2222,12 @@ describe('approveRequest', () => {
         app: { allowedScopes: 33554431, allowedOrigins: ['https://hello.civit.ai'] },
       });
       // A listing already exists (minted on the first approve; a mod may since
-      // have set category/featured). The guard must SKIP, never update.
-      mockDbRead.appListing.findUnique.mockResolvedValue({ id: 'apl_existing' });
+      // have set category/featured). The guard must never CREATE a second one —
+      // and the (3b-sync) re-sync must touch ONLY the manifest-governed scalars.
+      mockDbRead.appListing.findUnique.mockResolvedValue({ id: 'apl_existing', kind: 'onsite' });
+      // The (3b-sync) re-sync runs FIRST and matches the row; the later
+      // (3b-reset) restore keeps the default 0 (no reset is in flight here).
+      mockDbWrite.appListing.updateMany.mockResolvedValueOnce({ count: 1 });
       mockBundleBuffer.current = await makeValidBundle({ version: '0.2.0' });
 
       const result = await approveRequest({ publishRequestId: 'pubreq_1', reviewerUserId: 999 });
@@ -2229,12 +2235,26 @@ describe('approveRequest', () => {
       expect(result.appBlockId).toBe('apb_existing');
       expect(mockDbRead.appListing.findUnique).toHaveBeenCalledWith({
         where: { appBlockId: 'apb_existing' },
-        select: { id: true },
+        select: { id: true, kind: true },
       });
-      // Skip-if-exists: no create. There is NO appListing.update path at all in
-      // the approve flow, so curated fields (category/featured/featuredOrder)
-      // cannot be clobbered on a re-approve.
+      // Never a second listing for the same app.
       expect(mockDbWrite.appListing.create).not.toHaveBeenCalled();
+      // The approve DOES update the existing listing — but ONLY the four
+      // manifest-governed scalars. Curated / mod-owned columns
+      // (iconId/coverId/featured/featuredOrder/contentRating/status/slug) must
+      // never appear in the payload; asserting the exact key set is what stops a
+      // future edit from widening this write into a clobber.
+      const syncCalls = mockDbWrite.appListing.updateMany.mock.calls.filter(
+        (c: [{ data?: Record<string, unknown> }]) =>
+          c[0]?.data != null && !('status' in c[0].data) // exclude the (3b-reset) status flip
+      );
+      expect(syncCalls).toHaveLength(1);
+      expect(Object.keys(syncCalls[0][0].data).sort()).toEqual([
+        'category',
+        'description',
+        'name',
+        'tagline',
+      ]);
       // The approve itself still completes (build triggered, request finalised).
       expect(mockForgejo.commitFiles).toHaveBeenCalledOnce();
       expect(mockTriggerBuild).toHaveBeenCalledOnce();

--- a/src/server/services/blocks/app-listing-mapper.ts
+++ b/src/server/services/blocks/app-listing-mapper.ts
@@ -54,6 +54,60 @@ export function resolveListingDescription(manifest: unknown): string | null {
 }
 
 /**
+ * Extract the optional one-line store tagline from the manifest (null when
+ * absent / blank / not a string). The manifest is the ONLY author surface for an
+ * onsite listing's tagline — see the "ONSITE = ASSETS-ONLY" invariant in
+ * `offsite-listing.service`, which keeps name/tagline/description/category
+ * manifest-governed. The submission validator already bounds the length
+ * (MANIFEST_TAGLINE_MAX_LENGTH); this resolver only normalises whitespace, so a
+ * legacy row that predates the validator can never crash the mapper.
+ */
+export function resolveListingTagline(manifest: unknown): string | null {
+  const m = (manifest ?? {}) as { tagline?: unknown };
+  const tagline = typeof m.tagline === 'string' ? m.tagline.trim() : '';
+  return tagline.length > 0 ? tagline : null;
+}
+
+/**
+ * The MANIFEST-GOVERNED scalar set of an onsite store listing, in the shape the
+ * approve path writes on a subsequent-version re-sync.
+ *
+ * SINGLE SOURCE with {@link mapAppBlockToListing} (which builds its own payload
+ * from the same resolvers), so the create path and the re-sync path can never
+ * drift into showing different copy for the same manifest.
+ *
+ * NOT included — these are curated/mod-owned and must never be clobbered by an
+ * approve: assets (icon/cover/screenshots), `featured`/`featuredOrder`,
+ * `contentRating` (mod override, floored at the derived rating), `status`,
+ * `slug`, `externalUrl`.
+ *
+ * `category` is passed in RATHER than read from the manifest on purpose: the
+ * approve path resolves it from `AppBlock.category`, which is the manifest value
+ * only when a moderator has NOT curated one (`setMarketplaceMeta` writes
+ * `AppBlock.category`). Reading the manifest directly here would silently undo
+ * mod curation on the next version bump.
+ */
+export type ListingScalarSync = {
+  name: string;
+  description: string | null;
+  tagline: string | null;
+  category: string | null;
+};
+
+export function buildListingScalarSync(args: {
+  manifest: unknown;
+  blockId: string;
+  category: string | null;
+}): ListingScalarSync {
+  return {
+    name: resolveListingName(args.manifest, args.blockId),
+    description: resolveListingDescription(args.manifest),
+    tagline: resolveListingTagline(args.manifest),
+    category: args.category,
+  };
+}
+
+/**
  * Pure mapping from an approved AppBlock to the AppListing create payload.
  * Requires a resolved owner (`app.userId`) — the callers guard the null-owner
  * case; a missing owner here is misuse, so throw loudly rather than silently
@@ -76,6 +130,9 @@ export function mapAppBlockToListing(ab: SourceAppBlock): Prisma.AppListingUnche
     slug: ab.blockId,
     name: resolveListingName(ab.manifest, ab.blockId),
     description: resolveListingDescription(ab.manifest),
+    // Manifest-governed one-liner for the store card/detail slot. Absent/blank in
+    // the manifest ⇒ NULL (the card renders no tagline) — same as description.
+    tagline: resolveListingTagline(ab.manifest),
     // Assets are P1 — left NULL here (no mandatory-asset enforcement in P0).
     iconId: null,
     coverId: null,

--- a/src/server/services/blocks/publish-request.service.ts
+++ b/src/server/services/blocks/publish-request.service.ts
@@ -2354,10 +2354,9 @@ export async function approveRequest(params: ApproveRequestParams): Promise<Appr
   // listing and the flow converges. The listing is never permanently orphaned.
   //
   // IDEMPOTENT on `appBlockId` (the 1:1 unique): first-version approve CREATES it;
-  // a subsequent-version approve finds it present and SKIPS — it must NEVER clobber
-  // curator edits (category/featured/featuredOrder) made after the first approve.
-  // A concurrent create (a racing approve or the backfill) is absorbed by the
-  // P2002 catch. We NEVER update an existing listing here.
+  // a subsequent-version approve finds it present and RE-SYNCS only the
+  // MANIFEST-GOVERNED scalars (see (3b-sync) below). A concurrent create (a racing
+  // approve or the backfill) is absorbed by the P2002 catch.
   //
   // ONSITE ONLY: approveRequest only ever produces hosted (external_url IS NULL)
   // AppBlocks, so `mapAppBlockToListing` yields kind='onsite'. The offsite
@@ -2372,7 +2371,7 @@ export async function approveRequest(params: ApproveRequestParams): Promise<Appr
   // OauthClient owner are mirrored faithfully — important for the transition case
   // where an app approved BEFORE this feature (possibly already curated) has its
   // first listing minted now on a subsequent-version approve.
-  const { mapAppBlockToListing } = await import('./app-listing-mapper');
+  const { mapAppBlockToListing, buildListingScalarSync } = await import('./app-listing-mapper');
   try {
     const existingListing = await dbRead.appListing.findUnique({
       where: { appBlockId },
@@ -2403,6 +2402,51 @@ export async function approveRequest(params: ApproveRequestParams): Promise<Appr
           select: { id: true },
         });
       }
+    } else {
+      // (3b-sync) MANIFEST-GOVERNED COPY RE-SYNC (subsequent-version approve).
+      //
+      // WHY: an onsite listing's name / tagline / description / category have NO
+      // author surface other than the manifest ("ONSITE = ASSETS-ONLY" — the
+      // `/apps/[appBlockId]/edit` Listing tab is media-only, and
+      // `applyApprovedRevision`'s onsite branch deliberately copies ONLY assets).
+      // Before this, those scalars were snapshotted ONCE at the FIRST approve and
+      // never refreshed, so a dev who added/edited a description (or the newly
+      // manifest-governed tagline) in a later version kept seeing "Missing
+      // description" forever and the store kept serving the v1 copy.
+      //
+      // WHEN: only on a MODERATOR APPROVE — never on a manifest save. A save
+      // parks a pending review; the mod is the gate, so store-visible copy never
+      // changes without re-review.
+      //
+      // WHAT WE DO NOT TOUCH (curated / mod-owned): assets (icon / cover /
+      // screenshots), `featured` / `featuredOrder`, `contentRating` (mod override,
+      // floored at the derived rating), `status`, `slug`, `externalUrl`.
+      //
+      // `category` comes from `AppBlock.category` — NOT the manifest — because
+      // step (3a) writes the manifest category onto that column ONLY when it is
+      // still null, so a moderator's curated category (via `setMarketplaceMeta`)
+      // survives. Reading the manifest here would silently undo mod curation on
+      // every version bump. When the column is null we still write null (the
+      // "Missing category" advisory stands, and a mod can curate later).
+      //
+      // Scoped `kind: 'onsite'` (belt-and-suspenders: approveRequest only ever
+      // produces hosted blocks) and keyed on `appBlockId`, which is `@unique` and
+      // NULL on shadow revision rows — so a live media revision in flight cannot
+      // be hit by this write.
+      const ab = await dbWrite.appBlock.findUnique({
+        where: { id: appBlockId },
+        select: { blockId: true, manifest: true, category: true },
+      });
+      if (ab) {
+        await dbWrite.appListing.updateMany({
+          where: { appBlockId, kind: 'onsite' },
+          data: buildListingScalarSync({
+            manifest: ab.manifest,
+            blockId: ab.blockId,
+            category: ab.category,
+          }),
+        });
+      }
     }
   } catch (err) {
     // The store listing is a CONVENIENCE — it must NEVER gate the approve/deploy.
@@ -2422,8 +2466,9 @@ export async function approveRequest(params: ApproveRequestParams): Promise<Appr
     if (code !== 'P2002') {
       // eslint-disable-next-line no-console
       console.warn(
-        `[approveRequest] onsite AppListing auto-create failed (slug=${request.slug}, appBlockId=${appBlockId}); ` +
-          `approve/deploy CONTINUES — the app will not appear on /apps until a blocks.backfillAppListings run: ${
+        `[approveRequest] onsite AppListing auto-create/copy-sync failed (slug=${request.slug}, appBlockId=${appBlockId}); ` +
+          `approve/deploy CONTINUES — the app will not appear on /apps until a blocks.backfillAppListings run, ` +
+          `or (for an existing listing) its store copy stays on the previously-approved version until the next approve: ${
             err instanceof Error ? err.message : String(err)
           }`
       );

--- a/src/server/services/blocks/publish-request.service.ts
+++ b/src/server/services/blocks/publish-request.service.ts
@@ -2311,8 +2311,11 @@ export async function approveRequest(params: ApproveRequestParams): Promise<Appr
   // listing-create reads the just-written category (read-your-writes). A first-
   // version approve whose manifest declares a category therefore mints a listing
   // already categorised; a manifest with no category leaves it null (mod-curated
-  // later). The "category added in a LATER version" case (listing already exists,
-  // so (3b) skips it) is an accepted non-goal — recoverable via mod curation.
+  // later). The "category added in a LATER version" case (the listing already
+  // exists) is now HANDLED — the (3b-sync) re-sync below propagates this column
+  // onto the existing listing on a subsequent-version approve. This null-gate is
+  // also what makes sourcing the re-sync's `category` from HERE safe: a curated
+  // value is never overwritten above, so propagating it can't undo curation.
   if (manifestCategory !== null) {
     try {
       await dbWrite.appBlock.updateMany({
@@ -2375,7 +2378,7 @@ export async function approveRequest(params: ApproveRequestParams): Promise<Appr
   try {
     const existingListing = await dbRead.appListing.findUnique({
       where: { appBlockId },
-      select: { id: true },
+      select: { id: true, kind: true },
     });
     if (!existingListing) {
       const ab = await dbWrite.appBlock.findUnique({
@@ -2429,23 +2432,49 @@ export async function approveRequest(params: ApproveRequestParams): Promise<Appr
       // every version bump. When the column is null we still write null (the
       // "Missing category" advisory stands, and a mod can curate later).
       //
-      // Scoped `kind: 'onsite'` (belt-and-suspenders: approveRequest only ever
-      // produces hosted blocks) and keyed on `appBlockId`, which is `@unique` and
-      // NULL on shadow revision rows — so a live media revision in flight cannot
-      // be hit by this write.
-      const ab = await dbWrite.appBlock.findUnique({
-        where: { id: appBlockId },
-        select: { blockId: true, manifest: true, category: true },
-      });
-      if (ab) {
-        await dbWrite.appListing.updateMany({
-          where: { appBlockId, kind: 'onsite' },
-          data: buildListingScalarSync({
-            manifest: ab.manifest,
-            blockId: ab.blockId,
-            category: ab.category,
-          }),
+      // Keyed on `appBlockId`, which is `@unique` and NULL on shadow revision
+      // rows — so a live media revision in flight cannot be hit by this write.
+      //
+      // 🔴 The `kind: 'onsite'` scope is LOAD-BEARING, not decorative: an
+      // OFF-SITE listing's name/tagline/description are AUTHOR-supplied through
+      // the submit wizard, NOT manifest-governed, so syncing manifest copy onto
+      // one would clobber the author's edits. approveRequest only ever produces
+      // hosted blocks, so a non-onsite row here is anomalous — but a filter that
+      // can silently disable the whole feature must never fail QUIETLY, so we
+      // log the skip and the zero-row outcome rather than no-op into the void.
+      if (existingListing.kind !== 'onsite') {
+        // eslint-disable-next-line no-console
+        console.warn(
+          `[approveRequest] skipping listing copy re-sync (slug=${request.slug}, appBlockId=${appBlockId}): ` +
+            `the backing listing is kind='${existingListing.kind}', whose copy is author-supplied, not manifest-governed`
+        );
+      } else {
+        const ab = await dbWrite.appBlock.findUnique({
+          where: { id: appBlockId },
+          select: { blockId: true, manifest: true, category: true },
         });
+        if (ab) {
+          const synced = await dbWrite.appListing.updateMany({
+            where: { appBlockId, kind: 'onsite' },
+            data: buildListingScalarSync({
+              manifest: ab.manifest,
+              blockId: ab.blockId,
+              category: ab.category,
+            }),
+          });
+          if (synced.count === 0) {
+            // The replica said a listing exists but the PRIMARY matched no row —
+            // replica lag, or the row changed kind between the two reads. Benign
+            // (the next approve converges) but it must be VISIBLE: otherwise the
+            // store silently keeps serving the previously-approved copy, which is
+            // the exact symptom this re-sync exists to fix.
+            // eslint-disable-next-line no-console
+            console.warn(
+              `[approveRequest] listing copy re-sync matched 0 rows (slug=${request.slug}, appBlockId=${appBlockId}); ` +
+                `the store copy stays on the previously-approved version until the next approve`
+            );
+          }
+        }
       }
     }
   } catch (err) {


### PR DESCRIPTION
## The report

An app developer editing an **onsite** (hosted, CLI-submitted) app told us:

> "it says I need a description and tagline... I have the former and the latter doesn't exist?"

They were right on both halves. Two distinct bugs.

## Root causes

**1. `AppListing.tagline` is permanently `NULL` for every onsite app.**
`computeListingProblems` flags an empty tagline (and an empty category) on `/apps/my-submissions`, but `mapAppBlockToListing` — the only thing that mints an onsite listing — never set `tagline`, and there was no author surface for it anywhere: not in the manifest schema/validator, not in the manifest editor, and not on the Listing tab (which is media-only by design). `category` had the same shape of gap: it *is* a manifest field, but the editor had no control for it. So today every onsite app's store card + detail page simply shows no tagline at all (both render sites are truthiness-guarded — `AppListingCard.tsx:233`, `AppListingDetailBody.tsx:338` — so nothing is *visually broken*; the copy is just permanently unavailable to onsite authors).

**2. Manifest-governed listing copy was snapshotted once, at the first approve, and never refreshed.**
The `(3b)` block in `approveRequest` creates the listing when absent and otherwise skips entirely. So a developer who *added* a description in a later version kept seeing "Missing description" forever, and the store kept serving the v1 copy. This is the "I have the former" half of the report.

## What changed

Everything below preserves the **"onsite = assets-only; name/tagline/description/category stay manifest-governed"** invariant (`offsite-listing.service`), and the mod stays the gate on anything store-visible.

- **`tagline` becomes a first-class optional manifest field.** Declared in the canonical published schema (`public/schemas/app-block/v1.json`) and enforced by the authoritative imperative validator: must be a string whose **trimmed** length is 1..140. 140 is deliberately `OFFSITE_TAGLINE_MAX` — onsite and off-site taglines render in the same card/detail slot, so they share a bound. A new drift-guard test ties the schema's `maxLength`, the validator const, and the off-site const together, which is what makes the (client-bundle-safety-motivated) duplication safe.
- **The mapper maps it** onto the listing at create time.
- **Subsequent-version approve re-syncs the manifest-governed scalars** (`name` / `description` / `tagline` / `category`) onto the existing listing, through a shared `buildListingScalarSync` builder so the create path and the re-sync path cannot drift.
  - Curated / mod-owned columns are **not** touched: assets, `featured`, `featuredOrder`, `contentRating`, `status`, `slug`, `externalUrl`. A test asserts the written key set is exactly the four.
  - `category` is read from **`AppBlock.category`**, not the manifest — step `(3a)` only writes the manifest category onto that column when it is still null, so a moderator's curated category survives a version bump. Reading the manifest directly here would silently undo curation.
  - Scoped `kind: 'onsite'` and keyed on `appBlockId`, which is `@unique` and NULL on shadow revision rows, so an in-flight media revision can't be hit.
  - Same best-effort posture as the existing create — it can never gate the approve/deploy.
  - **Timing:** only on a moderator **approve**, never on a manifest save. A save parks a pending review, so store-visible copy never changes without re-review.
- **The manifest editor gains Tagline + Category controls.** Both send an explicit `null` to clear, because an `undefined` may be dropped in transit and the server's `{...stored, ...patch}` merge would then retain the stale value (same reasoning already documented for `scopeJustifications`). `updateManifest` still **omits `targets`** from the patch — unchanged, so slot apps can't be clobbered.

**The first-approve create path is byte-identical** and locked with a test.

## No migration

`AppListing.tagline` already exists (off-site listings use it) — confirmed in `schema.full.prisma` and the `20260701120000_w13_p0_app_listing` migration. Nothing to apply.

## Tests

New/extended, all mutation-verified (each guard was deliberately broken and a *specific* test confirmed failing, then reverted):

- `app-listing-mapper.test.ts` — tagline mapped/trimmed/blank→null/absent→null; `buildListingScalarSync` writes exactly the four manifest-governed keys, agrees with the create payload, and takes category from the caller.
- `publish-request.listingSync.test.ts` *(new)* — first approve creates (full payload asserted) and performs no update; subsequent approve updates with exactly the manifest-governed keys, scoped `{ appBlockId, kind: 'onsite' }`; category comes from `AppBlock.category`; a removed description/tagline is cleared; the re-sync is best-effort.
- `block-manifest-validator.service.test.ts` — tagline absent/normal/at-cap/over-cap/whitespace-padded-but-fits/non-string/blank, plus an unregressed-rules case.
- `manifest-tagline.schema-drift.test.ts` *(new)* — schema ⇄ validator ⇄ off-site bound.
- `blocks.router.updateManifest.test.ts` — tagline/category commit, explicit-null clear, omission preserves stored, validator rejection is a `BAD_REQUEST` with nothing committed.
- `ManifestEditForm.browser.test.tsx` — both controls render + seed, Save sends trimmed tagline + category, empty → explicit null, category picker, over-cap error disables Save, at-cap stays enabled, `targets` still omitted.

## Follow-ups deliberately left out of scope

- Existing already-approved onsite listings keep `tagline = null` until their next approve. `blocks.backfillAppListings` is create-only, so backfilling them needs a new no-clobber update path — **not** implemented here.
- `description` in the editor still sends `undefined` (not `null`) when cleared, so clearing a description via the web form doesn't take effect. Pre-existing; same class as the null-clear handling added here for tagline/category, but it changes existing behaviour so it wants its own change + test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
