### PR TITLE
feat(collections): community-pick scoring for contest collections

### DIFF
--- a/packages/civitai-redis/src/client.ts
+++ b/packages/civitai-redis/src/client.ts
@@ -2185,6 +2185,7 @@ export const REDIS_KEYS = {
     // `setUserSetting`; `CacheTTL.md` backstops any other writer. See
     // `getUserMetricPrivacyDefaultsMap` in creator-membership.service.
     USER_METRIC_PRIVACY_DEFAULTS: 'packed:caches:user-metric-privacy-defaults',
+    CONTEST_COMMUNITY_SCORE: 'packed:caches:contest-community-score',
   },
   RESEARCH: {
     RATINGS_COUNT: 'research:ratings-count',

--- a/packages/civitai-redis/src/client.ts
+++ b/packages/civitai-redis/src/client.ts
@@ -2186,6 +2186,10 @@ export const REDIS_KEYS = {
     // `getUserMetricPrivacyDefaultsMap` in creator-membership.service.
     USER_METRIC_PRIVACY_DEFAULTS: 'packed:caches:user-metric-privacy-defaults',
     CONTEST_COMMUNITY_SCORE: 'packed:caches:contest-community-score',
+    // Async contest-scoring runs: per-run state, the per-collection pointer to the
+    // most recent run, and the scored result each run produces. Every key carries a
+    // TTL, so the whole namespace self-cleans and no table backs it.
+    CONTEST_SCORE_RUN: 'packed:caches:contest-score-run',
   },
   RESEARCH: {
     RATINGS_COUNT: 'research:ratings-count',

--- a/src/components/Collections/components/ContestCollections/ContestCommunityScore.tsx
+++ b/src/components/Collections/components/ContestCollections/ContestCommunityScore.tsx
@@ -166,6 +166,14 @@ function CategoryTable({
             No qualified engagement in this category — every entry is tied, so no ranking is shown.
           </Alert>
         )}
+        {category.truncated && (
+          <Alert color="red" title="This category is incomplete — ranks withheld">
+            {category.missingCount} {category.missingCount === 1 ? 'entry is' : 'entries are'}{' '}
+            missing from this run because the contest exceeded the per-run entry ceiling. Scores are
+            normalized against the entries that survived, so every score here is wrong by an unknown
+            amount. Narrow the window and run again before using this category.
+          </Alert>
+        )}
         <Table.ScrollContainer minWidth={900}>
           <Table striped highlightOnHover verticalSpacing="xs">
             <Table.Thead>
@@ -197,7 +205,21 @@ function CategoryTable({
             <Table.Tbody>
               {entries.map((entry) => (
                 <Table.Tr key={entry.collectionItemId} opacity={entry.eligible ? 1 : 0.55}>
-                  <Table.Td>{entry.rank ?? '—'}</Table.Td>
+                  <Table.Td>
+                    <Group gap={4} wrap="nowrap">
+                      <Text size="sm">{entry.rank ?? '—'}</Text>
+                      {entry.sharedRank && (
+                        <Tooltip
+                          label="Tied on score with another entry — they share this rank"
+                          withArrow
+                        >
+                          <Badge color="yellow" variant="light" size="xs">
+                            tie
+                          </Badge>
+                        </Tooltip>
+                      )}
+                    </Group>
+                  </Table.Td>
                   <Table.Td>
                     <Group gap="xs" wrap="nowrap">
                       {entry.image && (
@@ -257,7 +279,19 @@ function CategoryTable({
                     </Tooltip>
                   </Table.Td>
                   <Table.Td>
-                    <Text fw={600}>{entry.eligible ? entry.score.toFixed(3) : '—'}</Text>
+                    <Group gap={4} wrap="nowrap">
+                      <Text fw={600}>{entry.eligible ? entry.score.toFixed(3) : '—'}</Text>
+                      {entry.belowDisplayPrecision && (
+                        <Tooltip
+                          label="An adjacent entry's score differs only below the precision shown here. Do not separate them on this number alone."
+                          withArrow
+                        >
+                          <Badge color="orange" variant="light" size="xs">
+                            ~
+                          </Badge>
+                        </Tooltip>
+                      )}
+                    </Group>
                   </Table.Td>
                 </Table.Tr>
               ))}
@@ -272,10 +306,19 @@ function CategoryTable({
 function ScoreBody({ score }: { score: ContestCommunityScoreResult }) {
   return (
     <Stack gap="lg">
+      {/* Driven by the score itself, not by the live query, so a snapshot taken
+          mid-contest carries the same warning as the live view it came from. */}
+      {score.partial && (
+        <Alert color="orange" title="Preview — the contest was still open">
+          Scored up to {formatDate(score.window.effectiveEnd, 'MMM D, YYYY h:mm A')}. These
+          standings are not a final result.
+        </Alert>
+      )}
       {score.truncated.entries && (
-        <Alert color="yellow">
-          Showing the first {score.entryCount} entries only. Narrow the category or status filter to
-          score the rest.
+        <Alert color="red" title="Entries were dropped from this run">
+          This contest has more entries than a single run scores, so the {score.entryCount} oldest
+          were kept and the newest dropped. Affected categories have their ranks withheld. Narrow
+          the window and run again.
         </Alert>
       )}
       {score.truncated.images && (
@@ -316,6 +359,7 @@ export function ContestCommunityScore({ collectionId }: { collectionId: number }
   const [start, setStart] = useState<Date | null>(null);
   const [end, setEnd] = useState<Date | null>(null);
   const [snapshotKey, setSnapshotKey] = useState<string | null>(null);
+  const [configOpen, setConfigOpen] = useState<string | null>(null);
 
   const filters = useMemo(
     () => ({
@@ -382,9 +426,10 @@ export function ContestCommunityScore({ collectionId }: { collectionId: number }
     <Stack gap="lg">
       <Stack gap="xs">
         <Text c="dimmed" size="sm">
-          Entries ranked by distinct qualified users per signal, normalized within each category.
-          Raw counts include engagement that failed qualification; a large gap is a prompt for human
-          review, never an automatic disqualification.
+          Accepted entries only, ranked by distinct qualified users per signal and normalized within
+          each category. Entries still in review and rejected entries are not scored. Raw counts
+          include engagement that failed qualification; a large gap is a prompt for human review,
+          never an automatic disqualification.
         </Text>
         <Group gap="sm" align="flex-end">
           <DatePickerInput
@@ -445,13 +490,6 @@ export function ContestCommunityScore({ collectionId }: { collectionId: number }
         </Alert>
       )}
 
-      {result?.partial && (
-        <Alert color="orange" title="Preview — the contest is still open">
-          Scored up to {formatDate(result.window.effectiveEnd, 'MMM D, YYYY h:mm A')}. These
-          standings are not a final result.
-        </Alert>
-      )}
-
       {isLoading ? (
         <Center py="xl">
           <Loader size="xl" />
@@ -468,11 +506,14 @@ export function ContestCommunityScore({ collectionId }: { collectionId: number }
         </Stack>
       )}
 
-      <Accordion variant="contained">
+      {/* Controlled, and the editor is mounted only while open: an always-mounted
+          panel would fetch the config and put its values in every moderator's browser
+          on tab open, whether or not anyone asked to see them. */}
+      <Accordion variant="contained" value={configOpen} onChange={setConfigOpen}>
         <Accordion.Item value="config">
           <Accordion.Control>Scoring configuration</Accordion.Control>
           <Accordion.Panel>
-            <ContestScoringConfigEditor collectionId={collectionId} />
+            {configOpen === 'config' && <ContestScoringConfigEditor collectionId={collectionId} />}
           </Accordion.Panel>
         </Accordion.Item>
       </Accordion>
@@ -493,6 +534,13 @@ export function ContestCommunityScore({ collectionId }: { collectionId: number }
                       {formatDate(ref.takenAt, 'MMM D, YYYY h:mm A')}
                     </Text>
                   </UnstyledButton>
+                  {ref.partial && (
+                    <Tooltip label="Taken while the contest was still open" withArrow>
+                      <Badge color="orange" variant="light" size="xs">
+                        Partial
+                      </Badge>
+                    </Tooltip>
+                  )}
                   {ref.source && (
                     <Badge color="grape" variant="light" size="xs">
                       {ref.source}

--- a/src/components/Collections/components/ContestCollections/ContestCommunityScore.tsx
+++ b/src/components/Collections/components/ContestCollections/ContestCommunityScore.tsx
@@ -42,6 +42,7 @@ import type {
   ContestScoreCategory,
   ContestScoreEntry,
 } from '~/server/services/contest-score.service';
+import { CONTEST_SCORE_CODE_VERSION } from '~/server/services/contest-score.service';
 import type { MediaType } from '~/shared/utils/prisma/enums';
 import { formatDate } from '~/utils/date-helpers';
 import { showErrorNotification, showSuccessNotification } from '~/utils/notifications';
@@ -55,6 +56,27 @@ const signalLabels: Record<ContestScoreSignal, string> = {
   collectors: 'Collects',
 };
 
+/**
+ * A stored snapshot is whatever the code that took it wrote. Nothing parses, migrates
+ * or backfills it on read, so every field added since the first snapshot is genuinely
+ * absent on older ones — and the types below say so, because the payload types do not.
+ *
+ * Treating them as present is how a display bug becomes a dead panel: dereferencing one
+ * missing field above the tables takes down the whole artifact we keep to settle a
+ * disputed placement. Render what is missing as missing, never as zero.
+ */
+type StoredEntry = Omit<ContestScoreEntry, 'qualifyingVersionCount'> & {
+  qualifyingVersionCount?: number;
+};
+type StoredCategory = Omit<ContestScoreCategory, 'entries'> & { entries: StoredEntry[] };
+type StoredScore = Omit<ContestCommunityScoreResult, 'eligibility' | 'categories'> & {
+  eligibility?: ContestCommunityScoreResult['eligibility'];
+  categories: StoredCategory[];
+};
+
+/** Version scoping landed here; anything older counted every version of the model. */
+const VERSION_SCOPING_CODE_VERSION = 3;
+
 // Display-only banding for the qualification gap. Purely how loudly a row asks for
 // staff eyes — it is not a scoring input and nothing is disqualified automatically.
 function disqualifiedColor(share: number) {
@@ -66,7 +88,7 @@ function disqualifiedColor(share: number) {
 type SortColumn = 'rank' | 'entry' | 'total' | 'gap' | 'score' | ContestScoreSignal;
 type Sort = { column: SortColumn; desc: boolean };
 
-const sortValue = (entry: ContestScoreEntry, column: SortColumn) => {
+const sortValue = (entry: StoredEntry, column: SortColumn) => {
   switch (column) {
     case 'rank':
       return entry.rank ?? Number.MAX_SAFE_INTEGER;
@@ -88,7 +110,7 @@ const sortValue = (entry: ContestScoreEntry, column: SortColumn) => {
  * client-side reorder — no refetch, and the server never learns which column a
  * moderator is looking at.
  */
-function sortEntries(entries: ContestScoreEntry[], sort: Sort) {
+function sortEntries(entries: StoredEntry[], sort: Sort) {
   return [...entries].sort((a, b) => {
     const left = sortValue(a, sort.column);
     const right = sortValue(b, sort.column);
@@ -130,7 +152,7 @@ function CategoryTable({
   category,
   signalSources,
 }: {
-  category: ContestScoreCategory;
+  category: StoredCategory;
   signalSources: Record<ContestScoreSignal, string>;
 }) {
   const [sort, setSort] = useState<Sort>({ column: 'rank', desc: false });
@@ -243,17 +265,30 @@ function CategoryTable({
                             by {entry.creatorUsername}
                           </Text>
                         )}
-                        <Tooltip
-                          label="Versions created during the contest window on a qualifying base model. Only these are counted."
-                          withArrow
-                          multiline
-                          w={260}
-                        >
-                          <Text size="xs" c="dimmed" w="fit-content">
-                            {entry.qualifyingVersionCount}{' '}
-                            {entry.qualifyingVersionCount === 1 ? 'version' : 'versions'}
-                          </Text>
-                        </Tooltip>
+                        {entry.qualifyingVersionCount === undefined ? (
+                          <Tooltip
+                            label="This run predates version scoping, so it counted every version of the model."
+                            withArrow
+                            multiline
+                            w={260}
+                          >
+                            <Text size="xs" c="dimmed" fs="italic" w="fit-content">
+                              versions not recorded
+                            </Text>
+                          </Tooltip>
+                        ) : (
+                          <Tooltip
+                            label="Versions created during the contest window on a qualifying base model. Only these are counted."
+                            withArrow
+                            multiline
+                            w={260}
+                          >
+                            <Text size="xs" c="dimmed" w="fit-content">
+                              {entry.qualifyingVersionCount}{' '}
+                              {entry.qualifyingVersionCount === 1 ? 'version' : 'versions'}
+                            </Text>
+                          </Tooltip>
+                        )}
                         {entry.ineligibleReason && (
                           <Badge
                             color="red"
@@ -334,20 +369,34 @@ const boundSourceLabels: Record<ContestCommunityScoreResult['eligibility']['star
  * the pickers — narrowing them changes only what was counted — so the header says it
  * outright rather than leaving a moderator to assume the one they set is both.
  */
-function WindowSummary({ score }: { score: ContestCommunityScoreResult }) {
+function WindowSummary({ score }: { score: StoredScore }) {
+  const eligibility = score.eligibility;
   return (
     <Group gap="xl">
       <Stack gap={0}>
         <Text size="xs" c="dimmed" tt="uppercase" fw={600}>
           Eligibility window
         </Text>
-        <Text size="sm">
-          {formatDate(score.eligibility.start)} – {formatDate(score.eligibility.end)}
-        </Text>
-        <Text size="xs" c="dimmed">
-          Versions created here qualify · from {boundSourceLabels[score.eligibility.startSource]} to{' '}
-          {boundSourceLabels[score.eligibility.endSource]}
-        </Text>
+        {eligibility ? (
+          <>
+            <Text size="sm">
+              {formatDate(eligibility.start)} – {formatDate(eligibility.end)}
+            </Text>
+            <Text size="xs" c="dimmed">
+              Versions created here qualify · from {boundSourceLabels[eligibility.startSource]} to{' '}
+              {boundSourceLabels[eligibility.endSource]}
+            </Text>
+          </>
+        ) : (
+          <>
+            <Text size="sm" fs="italic" c="dimmed">
+              Not recorded
+            </Text>
+            <Text size="xs" c="dimmed">
+              This run predates the eligibility window being tracked
+            </Text>
+          </>
+        )}
       </Stack>
       <Stack gap={0}>
         <Text size="xs" c="dimmed" tt="uppercase" fw={600}>
@@ -364,9 +413,33 @@ function WindowSummary({ score }: { score: ContestCommunityScoreResult }) {
   );
 }
 
-function ScoreBody({ score }: { score: ContestCommunityScoreResult }) {
+/**
+ * `codeVersion` is only passed for a STORED snapshot — a live result is current by
+ * definition. It is the one thing that distinguishes a snapshot which counted every
+ * version of a model from one that did not, and until now it was stored and shown
+ * nowhere.
+ */
+function ScoreBody({ score, codeVersion }: { score: StoredScore; codeVersion?: number }) {
+  const stale = codeVersion !== undefined && codeVersion < CONTEST_SCORE_CODE_VERSION;
+  const preVersionScoping = codeVersion !== undefined && codeVersion < VERSION_SCOPING_CODE_VERSION;
+
   return (
     <Stack gap="lg">
+      {stale && (
+        <Alert
+          color={preVersionScoping ? 'red' : 'yellow'}
+          title={
+            preVersionScoping
+              ? 'Taken before the version-scoping fix'
+              : 'Taken by an older version of the scorer'
+          }
+        >
+          {preVersionScoping
+            ? 'Counts here include every version of each model, not only versions created during the contest on a qualifying base model. Entries carrying an older, unrelated version are overstated. Do not compare these standings to a current run.'
+            : 'Scoring has changed since this snapshot was taken, so its standings are not directly comparable to a current run.'}{' '}
+          (scorer v{codeVersion}, current v{CONTEST_SCORE_CODE_VERSION})
+        </Alert>
+      )}
       <WindowSummary score={score} />
       {/* Driven by the score itself, not by the live query, so a snapshot taken
           mid-contest carries the same warning as the live view it came from. */}
@@ -643,9 +716,16 @@ export function ContestCommunityScore({ collectionId }: { collectionId: number }
                       Partial
                     </Badge>
                   )}
+                  {snapshot.codeVersion < CONTEST_SCORE_CODE_VERSION && (
+                    <Tooltip label="Scoring has changed since this snapshot was taken" withArrow>
+                      <Badge color="red" variant="light" size="xs">
+                        Scorer v{snapshot.codeVersion}
+                      </Badge>
+                    </Tooltip>
+                  )}
                   {snapshot.note && <Badge variant="light">{snapshot.note}</Badge>}
                 </Group>
-                <ScoreBody score={snapshot.score} />
+                <ScoreBody score={snapshot.score} codeVersion={snapshot.codeVersion} />
               </>
             )}
           </Stack>

--- a/src/components/Collections/components/ContestCollections/ContestCommunityScore.tsx
+++ b/src/components/Collections/components/ContestCollections/ContestCommunityScore.tsx
@@ -31,6 +31,14 @@ import { NextLink as Link } from '~/components/NextLink/NextLink';
 import { NoContent } from '~/components/NoContent/NoContent';
 import { ContestScoringConfigEditor } from '~/components/Collections/components/ContestCollections/ContestScoringConfigEditor';
 import { useSignalConnection, useSignalTopic } from '~/components/Signals/SignalsProvider';
+// Value imports here must never reach `~/server/services/contest-score.service`: it pulls
+// `~/server/db/client` and `~/env/server`, neither of which can be tree-shaken (both run
+// side effects at import), and the resulting client bundle only fails at `next build`.
+// Every other import from that module in this file is `import type` and erases.
+import {
+  CONTEST_SCORE_CODE_VERSION,
+  CONTEST_VERSION_SCOPING_CODE_VERSION,
+} from '~/server/common/constants';
 import { SignalMessages, SignalTopic } from '~/server/common/enums';
 import type {
   ContestScoreRunState,
@@ -42,7 +50,6 @@ import type {
   ContestScoreCategory,
   ContestScoreEntry,
 } from '~/server/services/contest-score.service';
-import { CONTEST_SCORE_CODE_VERSION } from '~/server/services/contest-score.service';
 import type { MediaType } from '~/shared/utils/prisma/enums';
 import { formatDate } from '~/utils/date-helpers';
 import { showErrorNotification, showSuccessNotification } from '~/utils/notifications';
@@ -73,9 +80,6 @@ type StoredScore = Omit<ContestCommunityScoreResult, 'eligibility' | 'categories
   eligibility?: ContestCommunityScoreResult['eligibility'];
   categories: StoredCategory[];
 };
-
-/** Version scoping landed here; anything older counted every version of the model. */
-const VERSION_SCOPING_CODE_VERSION = 3;
 
 // Display-only banding for the qualification gap. Purely how loudly a row asks for
 // staff eyes — it is not a scoring input and nothing is disqualified automatically.
@@ -414,14 +418,21 @@ function WindowSummary({ score }: { score: StoredScore }) {
 }
 
 /**
- * `codeVersion` is only passed for a STORED snapshot — a live result is current by
- * definition. It is the one thing that distinguishes a snapshot which counted every
- * version of a model from one that did not, and until now it was stored and shown
- * nowhere.
+ * `snapshot` is passed only for a STORED result — a live one is current by definition.
+ * Its `codeVersion` is what distinguishes a snapshot that counted every version of a
+ * model from one that did not, and an absent version is treated as the oldest case
+ * rather than the newest: a row too old to record it is certainly older than the fix.
  */
-function ScoreBody({ score, codeVersion }: { score: StoredScore; codeVersion?: number }) {
-  const stale = codeVersion !== undefined && codeVersion < CONTEST_SCORE_CODE_VERSION;
-  const preVersionScoping = codeVersion !== undefined && codeVersion < VERSION_SCOPING_CODE_VERSION;
+function ScoreBody({
+  score,
+  snapshot,
+}: {
+  score: StoredScore;
+  snapshot?: { codeVersion?: number };
+}) {
+  const codeVersion = snapshot?.codeVersion;
+  const stale = !!snapshot && (codeVersion ?? 0) < CONTEST_SCORE_CODE_VERSION;
+  const preVersionScoping = !!snapshot && (codeVersion ?? 0) < CONTEST_VERSION_SCOPING_CODE_VERSION;
 
   return (
     <Stack gap="lg">
@@ -437,7 +448,8 @@ function ScoreBody({ score, codeVersion }: { score: StoredScore; codeVersion?: n
           {preVersionScoping
             ? 'Counts here include every version of each model, not only versions created during the contest on a qualifying base model. Entries carrying an older, unrelated version are overstated. Do not compare these standings to a current run.'
             : 'Scoring has changed since this snapshot was taken, so its standings are not directly comparable to a current run.'}{' '}
-          (scorer v{codeVersion}, current v{CONTEST_SCORE_CODE_VERSION})
+          (scorer {codeVersion === undefined ? 'version not recorded' : `v${codeVersion}`}, current
+          v{CONTEST_SCORE_CODE_VERSION})
         </Alert>
       )}
       <WindowSummary score={score} />
@@ -716,16 +728,18 @@ export function ContestCommunityScore({ collectionId }: { collectionId: number }
                       Partial
                     </Badge>
                   )}
-                  {snapshot.codeVersion < CONTEST_SCORE_CODE_VERSION && (
+                  {(snapshot.codeVersion ?? 0) < CONTEST_SCORE_CODE_VERSION && (
                     <Tooltip label="Scoring has changed since this snapshot was taken" withArrow>
                       <Badge color="red" variant="light" size="xs">
-                        Scorer v{snapshot.codeVersion}
+                        {snapshot.codeVersion === undefined
+                          ? 'Scorer version unknown'
+                          : `Scorer v${snapshot.codeVersion}`}
                       </Badge>
                     </Tooltip>
                   )}
                   {snapshot.note && <Badge variant="light">{snapshot.note}</Badge>}
                 </Group>
-                <ScoreBody score={snapshot.score} codeVersion={snapshot.codeVersion} />
+                <ScoreBody score={snapshot.score} snapshot={snapshot} />
               </>
             )}
           </Stack>

--- a/src/components/Collections/components/ContestCollections/ContestCommunityScore.tsx
+++ b/src/components/Collections/components/ContestCollections/ContestCommunityScore.tsx
@@ -306,7 +306,12 @@ export function ContestCommunityScore({ collectionId }: { collectionId: number }
                   </Text>
                   {snapshot.partial && (
                     <Badge color="orange" variant="light" size="xs">
-                      Preview
+                      Partial
+                    </Badge>
+                  )}
+                  {snapshot.source && (
+                    <Badge color="grape" variant="light" size="xs">
+                      {snapshot.source}
                     </Badge>
                   )}
                 </Group>

--- a/src/components/Collections/components/ContestCollections/ContestCommunityScore.tsx
+++ b/src/components/Collections/components/ContestCollections/ContestCommunityScore.tsx
@@ -143,10 +143,25 @@ export function ContestCommunityScore({ collectionId }: { collectionId: number }
         </Alert>
       )}
 
-      {data?.truncated && (
+      {data?.truncated.entries && (
         <Alert color="yellow">
           Showing the first {data.entryCount} entries only. Narrow the category or status filter to
           score the rest.
+        </Alert>
+      )}
+
+      {data?.truncated.images && (
+        <Alert color="yellow" title="Image set truncated">
+          This contest published more images in the window than a single run counts, so reaction
+          counts are incomplete. Narrow the window.
+        </Alert>
+      )}
+
+      {data?.degraded.bannedRefinementSkipped && (
+        <Alert color="red" title="Banned-account filtering was skipped">
+          Too many distinct engagers to resolve account status for this run. Counts still exclude
+          new, excluded and contest-banned accounts, but not banned or deleted ones. Do not decide a
+          prize on this run.
         </Alert>
       )}
 

--- a/src/components/Collections/components/ContestCollections/ContestCommunityScore.tsx
+++ b/src/components/Collections/components/ContestCollections/ContestCommunityScore.tsx
@@ -321,9 +321,53 @@ function CategoryTable({
   );
 }
 
+const boundSourceLabels: Record<ContestCommunityScoreResult['eligibility']['startSource'], string> =
+  {
+    submissionStartDate: 'contest submission start',
+    submissionEndDate: 'contest submission end',
+    endsAt: 'contest end date',
+    collectionCreatedAt: 'collection creation date (no submission start is set)',
+  };
+
+/**
+ * The two windows, side by side. Which dates decided ELIGIBILITY is not inferable from
+ * the pickers — narrowing them changes only what was counted — so the header says it
+ * outright rather than leaving a moderator to assume the one they set is both.
+ */
+function WindowSummary({ score }: { score: ContestCommunityScoreResult }) {
+  return (
+    <Group gap="xl">
+      <Stack gap={0}>
+        <Text size="xs" c="dimmed" tt="uppercase" fw={600}>
+          Eligibility window
+        </Text>
+        <Text size="sm">
+          {formatDate(score.eligibility.start)} – {formatDate(score.eligibility.end)}
+        </Text>
+        <Text size="xs" c="dimmed">
+          Versions created here qualify · from {boundSourceLabels[score.eligibility.startSource]} to{' '}
+          {boundSourceLabels[score.eligibility.endSource]}
+        </Text>
+      </Stack>
+      <Stack gap={0}>
+        <Text size="xs" c="dimmed" tt="uppercase" fw={600}>
+          Counted window
+        </Text>
+        <Text size="sm">
+          {formatDate(score.window.start)} – {formatDate(score.window.effectiveEnd)}
+        </Text>
+        <Text size="xs" c="dimmed">
+          Traffic counted · narrowing this never changes eligibility
+        </Text>
+      </Stack>
+    </Group>
+  );
+}
+
 function ScoreBody({ score }: { score: ContestCommunityScoreResult }) {
   return (
     <Stack gap="lg">
+      <WindowSummary score={score} />
       {/* Driven by the score itself, not by the live query, so a snapshot taken
           mid-contest carries the same warning as the live view it came from. */}
       {score.partial && (

--- a/src/components/Collections/components/ContestCollections/ContestCommunityScore.tsx
+++ b/src/components/Collections/components/ContestCollections/ContestCommunityScore.tsx
@@ -1,4 +1,6 @@
 import {
+  Accordion,
+  ActionIcon,
   Alert,
   Badge,
   Button,
@@ -11,17 +13,35 @@ import {
   Text,
   Title,
   Tooltip,
+  UnstyledButton,
 } from '@mantine/core';
 import { DatePickerInput } from '@mantine/dates';
-import { IconCamera, IconReload } from '@tabler/icons-react';
+import {
+  IconCamera,
+  IconChevronDown,
+  IconChevronUp,
+  IconPlayerPlay,
+  IconX,
+} from '@tabler/icons-react';
 import { keepPreviousData } from '@tanstack/react-query';
-import { useMemo, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 
 import { EdgeMedia } from '~/components/EdgeMedia/EdgeMedia';
 import { NextLink as Link } from '~/components/NextLink/NextLink';
 import { NoContent } from '~/components/NoContent/NoContent';
-import type { ContestScoreSignal } from '~/server/schema/contest-score.schema';
+import { ContestScoringConfigEditor } from '~/components/Collections/components/ContestCollections/ContestScoringConfigEditor';
+import { useSignalConnection, useSignalTopic } from '~/components/Signals/SignalsProvider';
+import { SignalMessages, SignalTopic } from '~/server/common/enums';
+import type {
+  ContestScoreRunState,
+  ContestScoreSignal,
+} from '~/server/schema/contest-score.schema';
 import { contestScoreSignals } from '~/server/schema/contest-score.schema';
+import type {
+  ContestCommunityScore as ContestCommunityScoreResult,
+  ContestScoreCategory,
+  ContestScoreEntry,
+} from '~/server/services/contest-score.service';
 import type { MediaType } from '~/shared/utils/prisma/enums';
 import { formatDate } from '~/utils/date-helpers';
 import { showErrorNotification, showSuccessNotification } from '~/utils/notifications';
@@ -43,10 +63,259 @@ function disqualifiedColor(share: number) {
   return 'gray';
 }
 
+type SortColumn = 'rank' | 'entry' | 'total' | 'gap' | 'score' | ContestScoreSignal;
+type Sort = { column: SortColumn; desc: boolean };
+
+const sortValue = (entry: ContestScoreEntry, column: SortColumn) => {
+  switch (column) {
+    case 'rank':
+      return entry.rank ?? Number.MAX_SAFE_INTEGER;
+    case 'entry':
+      return entry.modelName.toLowerCase();
+    case 'total':
+      return entry.qualifiedTotal;
+    case 'gap':
+      return entry.disqualifiedShare;
+    case 'score':
+      return entry.score;
+    default:
+      return entry.signals[column].qualified;
+  }
+};
+
+/**
+ * Every run returns its category ranked in full, so re-sorting a column is a pure
+ * client-side reorder — no refetch, and the server never learns which column a
+ * moderator is looking at.
+ */
+function sortEntries(entries: ContestScoreEntry[], sort: Sort) {
+  return [...entries].sort((a, b) => {
+    const left = sortValue(a, sort.column);
+    const right = sortValue(b, sort.column);
+    const cmp =
+      typeof left === 'string' && typeof right === 'string'
+        ? left.localeCompare(right)
+        : Number(left) - Number(right);
+    return sort.desc ? -cmp : cmp;
+  });
+}
+
+function SortableTh({
+  column,
+  sort,
+  onSort,
+  children,
+}: {
+  column: SortColumn;
+  sort: Sort;
+  onSort: (column: SortColumn) => void;
+  children: React.ReactNode;
+}) {
+  const active = sort.column === column;
+  return (
+    <Table.Th>
+      <UnstyledButton onClick={() => onSort(column)} className="w-full">
+        <Group gap={4} wrap="nowrap">
+          <Text size="sm" fw={active ? 700 : 500}>
+            {children}
+          </Text>
+          {active && (sort.desc ? <IconChevronDown size={14} /> : <IconChevronUp size={14} />)}
+        </Group>
+      </UnstyledButton>
+    </Table.Th>
+  );
+}
+
+function CategoryTable({
+  category,
+  signalSources,
+}: {
+  category: ContestScoreCategory;
+  signalSources: Record<ContestScoreSignal, string>;
+}) {
+  const [sort, setSort] = useState<Sort>({ column: 'rank', desc: false });
+  const entries = useMemo(() => sortEntries(category.entries, sort), [category.entries, sort]);
+
+  const onSort = useCallback(
+    (column: SortColumn) =>
+      setSort((current) =>
+        current.column === column
+          ? { column, desc: !current.desc }
+          : { column, desc: column !== 'rank' && column !== 'entry' }
+      ),
+    []
+  );
+
+  return (
+    <Paper withBorder p="md" radius="md">
+      <Stack gap="sm">
+        <Group justify="space-between">
+          <Title order={4}>{category.tagName ?? 'Uncategorized'}</Title>
+          <Text size="sm" c="dimmed">
+            {category.eligibleCount} eligible of {category.entryCount}
+          </Text>
+        </Group>
+        {category.soloEntry && (
+          <Alert color="yellow">
+            Only one eligible entry in this category. A lone entrant tops every signal by
+            definition, so its score is not comparable to any other category.
+          </Alert>
+        )}
+        {category.tied && (
+          <Alert color="gray">
+            No qualified engagement in this category — every entry is tied, so no ranking is shown.
+          </Alert>
+        )}
+        <Table.ScrollContainer minWidth={900}>
+          <Table striped highlightOnHover verticalSpacing="xs">
+            <Table.Thead>
+              <Table.Tr>
+                <SortableTh column="rank" sort={sort} onSort={onSort}>
+                  #
+                </SortableTh>
+                <SortableTh column="entry" sort={sort} onSort={onSort}>
+                  Entry
+                </SortableTh>
+                {contestScoreSignals.map((signal) => (
+                  <SortableTh key={signal} column={signal} sort={sort} onSort={onSort}>
+                    <Tooltip label={signalSources[signal]} withArrow>
+                      <span>{signalLabels[signal]}</span>
+                    </Tooltip>
+                  </SortableTh>
+                ))}
+                <SortableTh column="total" sort={sort} onSort={onSort}>
+                  Total
+                </SortableTh>
+                <SortableTh column="gap" sort={sort} onSort={onSort}>
+                  Gap
+                </SortableTh>
+                <SortableTh column="score" sort={sort} onSort={onSort}>
+                  Score
+                </SortableTh>
+              </Table.Tr>
+            </Table.Thead>
+            <Table.Tbody>
+              {entries.map((entry) => (
+                <Table.Tr key={entry.collectionItemId} opacity={entry.eligible ? 1 : 0.55}>
+                  <Table.Td>{entry.rank ?? '—'}</Table.Td>
+                  <Table.Td>
+                    <Group gap="xs" wrap="nowrap">
+                      {entry.image && (
+                        <EdgeMedia
+                          src={entry.image.url}
+                          type={entry.image.type as MediaType}
+                          width={64}
+                          className="size-10 rounded object-cover"
+                        />
+                      )}
+                      <Stack gap={0}>
+                        <Link
+                          href={`/models/${entry.modelId}`}
+                          target="_blank"
+                          className="font-medium"
+                        >
+                          {entry.modelName}
+                        </Link>
+                        {entry.creatorUsername && (
+                          <Text size="xs" c="dimmed">
+                            by {entry.creatorUsername}
+                          </Text>
+                        )}
+                        {entry.ineligibleReason && (
+                          <Badge color="red" variant="light" size="xs">
+                            {entry.ineligibleReason}
+                          </Badge>
+                        )}
+                      </Stack>
+                    </Group>
+                  </Table.Td>
+                  {contestScoreSignals.map((signal) => (
+                    <Table.Td key={signal}>
+                      <Text size="sm">
+                        {entry.signals[signal].qualified}
+                        <Text span size="xs" c="dimmed">
+                          {' '}
+                          / {entry.signals[signal].raw}
+                        </Text>
+                      </Text>
+                    </Table.Td>
+                  ))}
+                  <Table.Td>
+                    <Text size="sm">
+                      {entry.qualifiedTotal}
+                      <Text span size="xs" c="dimmed">
+                        {' '}
+                        / {entry.rawTotal}
+                      </Text>
+                    </Text>
+                  </Table.Td>
+                  <Table.Td>
+                    <Tooltip label="Share of engagement that failed qualification" withArrow>
+                      <Badge color={disqualifiedColor(entry.disqualifiedShare)} variant="light">
+                        {Math.round(entry.disqualifiedShare * 100)}%
+                      </Badge>
+                    </Tooltip>
+                  </Table.Td>
+                  <Table.Td>
+                    <Text fw={600}>{entry.eligible ? entry.score.toFixed(3) : '—'}</Text>
+                  </Table.Td>
+                </Table.Tr>
+              ))}
+            </Table.Tbody>
+          </Table>
+        </Table.ScrollContainer>
+      </Stack>
+    </Paper>
+  );
+}
+
+function ScoreBody({ score }: { score: ContestCommunityScoreResult }) {
+  return (
+    <Stack gap="lg">
+      {score.truncated.entries && (
+        <Alert color="yellow">
+          Showing the first {score.entryCount} entries only. Narrow the category or status filter to
+          score the rest.
+        </Alert>
+      )}
+      {score.truncated.images && (
+        <Alert color="yellow" title="Image set truncated">
+          This contest published more images in the window than a single run counts, so reaction
+          counts are incomplete. Narrow the window.
+        </Alert>
+      )}
+      {score.degraded.bannedRefinementSkipped && (
+        <Alert color="red" title="Banned-account filtering was skipped">
+          Too many distinct engagers to resolve account status for this run. Counts still exclude
+          new, excluded and contest-banned accounts, but not banned or deleted ones. Do not decide a
+          prize on this run.
+        </Alert>
+      )}
+      {!score.categories.length ? (
+        <NoContent message="No entries matched this window" />
+      ) : (
+        score.categories.map((category) => (
+          <CategoryTable
+            key={category.tagId ?? 'uncategorized'}
+            category={category}
+            signalSources={score.signalSources}
+          />
+        ))
+      )}
+    </Stack>
+  );
+}
+
+function runLabel(run: ContestScoreRunState) {
+  if (run.status === 'queued') return 'Run queued…';
+  if (run.status === 'running') return 'Scoring run in progress…';
+  return null;
+}
+
 export function ContestCommunityScore({ collectionId }: { collectionId: number }) {
   const [start, setStart] = useState<Date | null>(null);
   const [end, setEnd] = useState<Date | null>(null);
-  const [refreshing, setRefreshing] = useState(false);
+  const [snapshotKey, setSnapshotKey] = useState<string | null>(null);
 
   const filters = useMemo(
     () => ({
@@ -58,11 +327,36 @@ export function ContestCommunityScore({ collectionId }: { collectionId: number }
   );
 
   const queryUtils = trpc.useUtils();
-  const { data, isLoading, isFetching, error } = trpc.contestScore.getCommunityScore.useQuery(
-    filters,
-    { placeholderData: keepPreviousData }
-  );
+  const { data, isLoading, error } = trpc.contestScore.getCommunityScore.useQuery(filters, {
+    placeholderData: keepPreviousData,
+  });
   const { data: snapshots } = trpc.contestScore.listSnapshots.useQuery({ collectionId });
+  const { data: snapshot, isLoading: loadingSnapshot } = trpc.contestScore.getSnapshot.useQuery(
+    { collectionId, key: snapshotKey ?? '' },
+    { enabled: !!snapshotKey }
+  );
+
+  useSignalTopic(`${SignalTopic.ContestScore}:${collectionId}`);
+  useSignalConnection(
+    SignalMessages.ContestScoreRunUpdate,
+    useCallback(
+      (state: ContestScoreRunState) => {
+        if (state.collectionId !== collectionId) return;
+        // The signal carries run bookkeeping only, so a finished run is a prompt to
+        // refetch the moderator-gated result rather than a result in itself.
+        queryUtils.contestScore.getCommunityScore.invalidate({ collectionId }).catch(() => null);
+      },
+      [collectionId, queryUtils]
+    )
+  );
+
+  const runMutation = trpc.contestScore.runCommunityScore.useMutation({
+    onSuccess: async () => {
+      await queryUtils.contestScore.getCommunityScore.invalidate({ collectionId });
+    },
+    onError: (error) =>
+      showErrorNotification({ title: 'Failed to start run', error: new Error(error.message) }),
+  });
 
   const snapshotMutation = trpc.contestScore.snapshot.useMutation({
     onSuccess: async () => {
@@ -73,24 +367,16 @@ export function ContestCommunityScore({ collectionId }: { collectionId: number }
       showErrorNotification({ title: 'Failed to snapshot', error: new Error(error.message) }),
   });
 
-  const handleRefresh = async () => {
-    setRefreshing(true);
-    try {
-      await queryUtils.contestScore.getCommunityScore.fetch({ ...filters, refresh: true });
-      await queryUtils.contestScore.getCommunityScore.invalidate(filters);
-    } catch (e) {
-      showErrorNotification({ title: 'Failed to refresh', error: e as Error });
-    } finally {
-      setRefreshing(false);
-    }
-  };
-
   if (error)
     return (
       <Alert color="red" title="Community scoring unavailable">
         {error.message}
       </Alert>
     );
+
+  const run = data?.run ?? null;
+  const result = data?.result ?? null;
+  const inFlight = runMutation.isPending || run?.status === 'queued' || run?.status === 'running';
 
   return (
     <Stack gap="lg">
@@ -119,11 +405,11 @@ export function ContestCommunityScore({ collectionId }: { collectionId: number }
           />
           <Button
             variant="light"
-            leftSection={<IconReload size={16} />}
-            loading={refreshing}
-            onClick={handleRefresh}
+            leftSection={<IconPlayerPlay size={16} />}
+            loading={inFlight}
+            onClick={() => runMutation.mutate(filters)}
           >
-            Refresh
+            Run scoring
           </Button>
           <Button
             variant="light"
@@ -136,158 +422,60 @@ export function ContestCommunityScore({ collectionId }: { collectionId: number }
         </Group>
       </Stack>
 
-      {data?.partial && (
+      {run && runLabel(run) && (
+        <Alert color="blue">
+          <Group gap="xs">
+            <Loader size="xs" />
+            <Text size="sm">
+              {runLabel(run)}
+              {result
+                ? ` Showing the run from ${formatDate(
+                    result.generatedAt,
+                    'MMM D, YYYY h:mm A'
+                  )} until it finishes.`
+                : ''}
+            </Text>
+          </Group>
+        </Alert>
+      )}
+
+      {run?.status === 'failed' && (
+        <Alert color="red" title="The last run failed">
+          {run.error}
+        </Alert>
+      )}
+
+      {result?.partial && (
         <Alert color="orange" title="Preview — the contest is still open">
-          Scored up to {formatDate(data.window.effectiveEnd, 'MMM D, YYYY h:mm A')}. These standings
-          are not a final result.
+          Scored up to {formatDate(result.window.effectiveEnd, 'MMM D, YYYY h:mm A')}. These
+          standings are not a final result.
         </Alert>
       )}
 
-      {data?.truncated.entries && (
-        <Alert color="yellow">
-          Showing the first {data.entryCount} entries only. Narrow the category or status filter to
-          score the rest.
-        </Alert>
-      )}
-
-      {data?.truncated.images && (
-        <Alert color="yellow" title="Image set truncated">
-          This contest published more images in the window than a single run counts, so reaction
-          counts are incomplete. Narrow the window.
-        </Alert>
-      )}
-
-      {data?.degraded.bannedRefinementSkipped && (
-        <Alert color="red" title="Banned-account filtering was skipped">
-          Too many distinct engagers to resolve account status for this run. Counts still exclude
-          new, excluded and contest-banned accounts, but not banned or deleted ones. Do not decide a
-          prize on this run.
-        </Alert>
-      )}
-
-      {isLoading || isFetching ? (
+      {isLoading ? (
         <Center py="xl">
           <Loader size="xl" />
         </Center>
-      ) : !data?.categories.length ? (
-        <NoContent message="No entries matched this window" />
+      ) : !result ? (
+        <NoContent message="No scoring run for this window yet. Run scoring to produce one." />
       ) : (
-        data.categories.map((category) => (
-          <Paper key={category.tagId ?? 'uncategorized'} withBorder p="md" radius="md">
-            <Stack gap="sm">
-              <Group justify="space-between">
-                <Title order={4}>{category.tagName ?? 'Uncategorized'}</Title>
-                <Text size="sm" c="dimmed">
-                  {category.eligibleCount} eligible of {category.entryCount}
-                </Text>
-              </Group>
-              {category.soloEntry && (
-                <Alert color="yellow">
-                  Only one eligible entry in this category. A lone entrant tops every signal by
-                  definition, so its score is not comparable to any other category.
-                </Alert>
-              )}
-              {category.tied && (
-                <Alert color="gray">
-                  No qualified engagement in this category — every entry is tied, so no ranking is
-                  shown.
-                </Alert>
-              )}
-              <Table.ScrollContainer minWidth={900}>
-                <Table striped highlightOnHover verticalSpacing="xs">
-                  <Table.Thead>
-                    <Table.Tr>
-                      <Table.Th>#</Table.Th>
-                      <Table.Th>Entry</Table.Th>
-                      {contestScoreSignals.map((signal) => (
-                        <Table.Th key={signal}>
-                          <Tooltip label={data.signalSources[signal]} withArrow>
-                            <span>{signalLabels[signal]}</span>
-                          </Tooltip>
-                        </Table.Th>
-                      ))}
-                      <Table.Th>Total</Table.Th>
-                      <Table.Th>Gap</Table.Th>
-                      <Table.Th>Score</Table.Th>
-                    </Table.Tr>
-                  </Table.Thead>
-                  <Table.Tbody>
-                    {category.entries.map((entry) => (
-                      <Table.Tr key={entry.collectionItemId} opacity={entry.eligible ? 1 : 0.55}>
-                        <Table.Td>{entry.rank ?? '—'}</Table.Td>
-                        <Table.Td>
-                          <Group gap="xs" wrap="nowrap">
-                            {entry.image && (
-                              <EdgeMedia
-                                src={entry.image.url}
-                                type={entry.image.type as MediaType}
-                                width={64}
-                                className="size-10 rounded object-cover"
-                              />
-                            )}
-                            <Stack gap={0}>
-                              <Link
-                                href={`/models/${entry.modelId}`}
-                                target="_blank"
-                                className="font-medium"
-                              >
-                                {entry.modelName}
-                              </Link>
-                              {entry.creatorUsername && (
-                                <Text size="xs" c="dimmed">
-                                  by {entry.creatorUsername}
-                                </Text>
-                              )}
-                              {entry.ineligibleReason && (
-                                <Badge color="red" variant="light" size="xs">
-                                  {entry.ineligibleReason}
-                                </Badge>
-                              )}
-                            </Stack>
-                          </Group>
-                        </Table.Td>
-                        {contestScoreSignals.map((signal) => (
-                          <Table.Td key={signal}>
-                            <Text size="sm">
-                              {entry.signals[signal].qualified}
-                              <Text span size="xs" c="dimmed">
-                                {' '}
-                                / {entry.signals[signal].raw}
-                              </Text>
-                            </Text>
-                          </Table.Td>
-                        ))}
-                        <Table.Td>
-                          <Text size="sm">
-                            {entry.qualifiedTotal}
-                            <Text span size="xs" c="dimmed">
-                              {' '}
-                              / {entry.rawTotal}
-                            </Text>
-                          </Text>
-                        </Table.Td>
-                        <Table.Td>
-                          <Tooltip label="Share of engagement that failed qualification" withArrow>
-                            <Badge
-                              color={disqualifiedColor(entry.disqualifiedShare)}
-                              variant="light"
-                            >
-                              {Math.round(entry.disqualifiedShare * 100)}%
-                            </Badge>
-                          </Tooltip>
-                        </Table.Td>
-                        <Table.Td>
-                          <Text fw={600}>{entry.eligible ? entry.score.toFixed(3) : '—'}</Text>
-                        </Table.Td>
-                      </Table.Tr>
-                    ))}
-                  </Table.Tbody>
-                </Table>
-              </Table.ScrollContainer>
-            </Stack>
-          </Paper>
-        ))
+        <Stack gap="lg">
+          <Text size="xs" c="dimmed">
+            Scored {formatDate(result.generatedAt, 'MMM D, YYYY h:mm A')} &middot;{' '}
+            {result.entryCount} entries
+          </Text>
+          <ScoreBody score={result} />
+        </Stack>
       )}
+
+      <Accordion variant="contained">
+        <Accordion.Item value="config">
+          <Accordion.Control>Scoring configuration</Accordion.Control>
+          <Accordion.Panel>
+            <ContestScoringConfigEditor collectionId={collectionId} />
+          </Accordion.Panel>
+        </Accordion.Item>
+      </Accordion>
 
       <Paper withBorder p="md" radius="md">
         <Stack gap="xs">
@@ -297,33 +485,62 @@ export function ContestCommunityScore({ collectionId }: { collectionId: number }
               No snapshots taken yet.
             </Text>
           ) : (
-            snapshots.map((snapshot) => (
-              <Group key={snapshot.key} gap="xs" justify="space-between">
+            snapshots.map((ref) => (
+              <Group key={ref.key} gap="xs" justify="space-between">
                 <Group gap="xs">
-                  <Text size="sm">
-                    {formatDate(snapshot.takenAt, 'MMM D, YYYY h:mm A')} &middot;{' '}
-                    {snapshot.takenByUsername ?? `user ${snapshot.takenById}`}
+                  <UnstyledButton onClick={() => setSnapshotKey(ref.key)}>
+                    <Text size="sm" td={snapshotKey === ref.key ? 'underline' : undefined}>
+                      {formatDate(ref.takenAt, 'MMM D, YYYY h:mm A')}
+                    </Text>
+                  </UnstyledButton>
+                  {ref.source && (
+                    <Badge color="grape" variant="light" size="xs">
+                      {ref.source}
+                    </Badge>
+                  )}
+                </Group>
+              </Group>
+            ))
+          )}
+        </Stack>
+      </Paper>
+
+      {snapshotKey && (
+        <Paper withBorder p="md" radius="md">
+          <Stack gap="sm">
+            <Group justify="space-between">
+              <Title order={5}>
+                Snapshot {formatDate(snapshot?.takenAt ?? snapshotKey, 'MMM D, YYYY h:mm A')}
+              </Title>
+              <ActionIcon variant="subtle" onClick={() => setSnapshotKey(null)}>
+                <IconX size={16} />
+              </ActionIcon>
+            </Group>
+            {loadingSnapshot || !snapshot ? (
+              <Center py="lg">
+                <Loader />
+              </Center>
+            ) : (
+              <>
+                <Group gap="xs">
+                  <Text size="sm" c="dimmed">
+                    Taken by {snapshot.takenByUsername ?? `user ${snapshot.takenById}`} &middot;{' '}
+                    {snapshot.entryCount} entries &middot; {formatDate(snapshot.window.start)} –{' '}
+                    {formatDate(snapshot.window.effectiveEnd)}
                   </Text>
                   {snapshot.partial && (
                     <Badge color="orange" variant="light" size="xs">
                       Partial
                     </Badge>
                   )}
-                  {snapshot.source && (
-                    <Badge color="grape" variant="light" size="xs">
-                      {snapshot.source}
-                    </Badge>
-                  )}
+                  {snapshot.note && <Badge variant="light">{snapshot.note}</Badge>}
                 </Group>
-                <Text size="xs" c="dimmed">
-                  {snapshot.entryCount} entries &middot; {formatDate(snapshot.window.start)} –{' '}
-                  {formatDate(snapshot.window.effectiveEnd)}
-                </Text>
-              </Group>
-            ))
-          )}
-        </Stack>
-      </Paper>
+                <ScoreBody score={snapshot.score} />
+              </>
+            )}
+          </Stack>
+        </Paper>
+      )}
     </Stack>
   );
 }

--- a/src/components/Collections/components/ContestCollections/ContestCommunityScore.tsx
+++ b/src/components/Collections/components/ContestCollections/ContestCommunityScore.tsx
@@ -1,0 +1,278 @@
+import {
+  Alert,
+  Badge,
+  Button,
+  Center,
+  Group,
+  Loader,
+  Paper,
+  Stack,
+  Table,
+  Text,
+  Title,
+  Tooltip,
+} from '@mantine/core';
+import { DatePickerInput } from '@mantine/dates';
+import { IconCamera, IconReload } from '@tabler/icons-react';
+import { keepPreviousData } from '@tanstack/react-query';
+import { useMemo, useState } from 'react';
+
+import { EdgeMedia } from '~/components/EdgeMedia/EdgeMedia';
+import { NextLink as Link } from '~/components/NextLink/NextLink';
+import { NoContent } from '~/components/NoContent/NoContent';
+import type { ContestScoreSignal } from '~/server/schema/contest-score.schema';
+import { contestScoreSignals } from '~/server/schema/contest-score.schema';
+import type { MediaType } from '~/shared/utils/prisma/enums';
+import { formatDate } from '~/utils/date-helpers';
+import { showErrorNotification, showSuccessNotification } from '~/utils/notifications';
+import { trpc } from '~/utils/trpc';
+
+const signalLabels: Record<ContestScoreSignal, string> = {
+  imageAuthors: 'Creators',
+  reactors: 'Reactions',
+  downloaders: 'Downloads',
+  generators: 'Generations',
+  collectors: 'Collects',
+};
+
+// Display-only banding for the qualification gap. Purely how loudly a row asks for
+// staff eyes — it is not a scoring input and nothing is disqualified automatically.
+function disqualifiedColor(share: number) {
+  if (share >= 0.5) return 'red';
+  if (share >= 0.25) return 'yellow';
+  return 'gray';
+}
+
+export function ContestCommunityScore({ collectionId }: { collectionId: number }) {
+  const [start, setStart] = useState<Date | null>(null);
+  const [end, setEnd] = useState<Date | null>(null);
+  const [refreshing, setRefreshing] = useState(false);
+
+  const filters = useMemo(
+    () => ({
+      collectionId,
+      start: start ?? undefined,
+      end: end ?? undefined,
+    }),
+    [collectionId, start, end]
+  );
+
+  const queryUtils = trpc.useUtils();
+  const { data, isLoading, isFetching, error } = trpc.contestScore.getCommunityScore.useQuery(
+    filters,
+    { placeholderData: keepPreviousData }
+  );
+  const { data: snapshots } = trpc.contestScore.listSnapshots.useQuery({ collectionId });
+
+  const snapshotMutation = trpc.contestScore.snapshot.useMutation({
+    onSuccess: async () => {
+      showSuccessNotification({ message: 'Snapshot saved' });
+      await queryUtils.contestScore.listSnapshots.invalidate({ collectionId });
+    },
+    onError: (error) =>
+      showErrorNotification({ title: 'Failed to snapshot', error: new Error(error.message) }),
+  });
+
+  const handleRefresh = async () => {
+    setRefreshing(true);
+    try {
+      await queryUtils.contestScore.getCommunityScore.fetch({ ...filters, refresh: true });
+      await queryUtils.contestScore.getCommunityScore.invalidate(filters);
+    } catch (e) {
+      showErrorNotification({ title: 'Failed to refresh', error: e as Error });
+    } finally {
+      setRefreshing(false);
+    }
+  };
+
+  if (error)
+    return (
+      <Alert color="red" title="Community scoring unavailable">
+        {error.message}
+      </Alert>
+    );
+
+  return (
+    <Stack gap="lg">
+      <Stack gap="xs">
+        <Text c="dimmed" size="sm">
+          Entries ranked by distinct qualified users per signal, normalized within each category.
+          Raw counts include engagement that failed qualification; a large gap is a prompt for human
+          review, never an automatic disqualification.
+        </Text>
+        <Group gap="sm" align="flex-end">
+          <DatePickerInput
+            label="Window start"
+            placeholder="Collection start"
+            value={start}
+            onChange={setStart}
+            clearable
+            maxDate={end ?? undefined}
+          />
+          <DatePickerInput
+            label="Window end"
+            placeholder="Now"
+            value={end}
+            onChange={setEnd}
+            clearable
+            minDate={start ?? undefined}
+          />
+          <Button
+            variant="light"
+            leftSection={<IconReload size={16} />}
+            loading={refreshing}
+            onClick={handleRefresh}
+          >
+            Refresh
+          </Button>
+          <Button
+            variant="light"
+            leftSection={<IconCamera size={16} />}
+            loading={snapshotMutation.isPending}
+            onClick={() => snapshotMutation.mutate(filters)}
+          >
+            Snapshot
+          </Button>
+        </Group>
+      </Stack>
+
+      {data?.truncated && (
+        <Alert color="yellow">
+          Showing the first {data.entryCount} entries only. Narrow the category or status filter to
+          score the rest.
+        </Alert>
+      )}
+
+      {isLoading || isFetching ? (
+        <Center py="xl">
+          <Loader size="xl" />
+        </Center>
+      ) : !data?.categories.length ? (
+        <NoContent message="No entries matched this window" />
+      ) : (
+        data.categories.map((category) => (
+          <Paper key={category.tagId ?? 'uncategorized'} withBorder p="md" radius="md">
+            <Stack gap="sm">
+              <Group justify="space-between">
+                <Title order={4}>{category.tagName ?? 'Uncategorized'}</Title>
+                <Text size="sm" c="dimmed">
+                  {category.entryCount} entries
+                </Text>
+              </Group>
+              <Table.ScrollContainer minWidth={900}>
+                <Table striped highlightOnHover verticalSpacing="xs">
+                  <Table.Thead>
+                    <Table.Tr>
+                      <Table.Th>#</Table.Th>
+                      <Table.Th>Entry</Table.Th>
+                      {contestScoreSignals.map((signal) => (
+                        <Table.Th key={signal}>
+                          <Tooltip label={data.signalSources[signal]} withArrow>
+                            <span>{signalLabels[signal]}</span>
+                          </Tooltip>
+                        </Table.Th>
+                      ))}
+                      <Table.Th>Total</Table.Th>
+                      <Table.Th>Gap</Table.Th>
+                      <Table.Th>Score</Table.Th>
+                    </Table.Tr>
+                  </Table.Thead>
+                  <Table.Tbody>
+                    {category.entries.map((entry) => (
+                      <Table.Tr key={entry.collectionItemId}>
+                        <Table.Td>{entry.rank}</Table.Td>
+                        <Table.Td>
+                          <Group gap="xs" wrap="nowrap">
+                            {entry.image && (
+                              <EdgeMedia
+                                src={entry.image.url}
+                                type={entry.image.type as MediaType}
+                                width={64}
+                                className="size-10 rounded object-cover"
+                              />
+                            )}
+                            <Stack gap={0}>
+                              <Link
+                                href={`/models/${entry.modelId}`}
+                                target="_blank"
+                                className="font-medium"
+                              >
+                                {entry.modelName}
+                              </Link>
+                              {entry.creatorUsername && (
+                                <Text size="xs" c="dimmed">
+                                  by {entry.creatorUsername}
+                                </Text>
+                              )}
+                            </Stack>
+                          </Group>
+                        </Table.Td>
+                        {contestScoreSignals.map((signal) => (
+                          <Table.Td key={signal}>
+                            <Text size="sm">
+                              {entry.signals[signal].qualified}
+                              <Text span size="xs" c="dimmed">
+                                {' '}
+                                / {entry.signals[signal].raw}
+                              </Text>
+                            </Text>
+                          </Table.Td>
+                        ))}
+                        <Table.Td>
+                          <Text size="sm">
+                            {entry.qualifiedTotal}
+                            <Text span size="xs" c="dimmed">
+                              {' '}
+                              / {entry.rawTotal}
+                            </Text>
+                          </Text>
+                        </Table.Td>
+                        <Table.Td>
+                          <Tooltip label="Share of engagement that failed qualification" withArrow>
+                            <Badge
+                              color={disqualifiedColor(entry.disqualifiedShare)}
+                              variant="light"
+                            >
+                              {Math.round(entry.disqualifiedShare * 100)}%
+                            </Badge>
+                          </Tooltip>
+                        </Table.Td>
+                        <Table.Td>
+                          <Text fw={600}>{entry.score.toFixed(3)}</Text>
+                        </Table.Td>
+                      </Table.Tr>
+                    ))}
+                  </Table.Tbody>
+                </Table>
+              </Table.ScrollContainer>
+            </Stack>
+          </Paper>
+        ))
+      )}
+
+      <Paper withBorder p="md" radius="md">
+        <Stack gap="xs">
+          <Title order={5}>Snapshots</Title>
+          {!snapshots?.length ? (
+            <Text size="sm" c="dimmed">
+              No snapshots taken yet.
+            </Text>
+          ) : (
+            snapshots.map((snapshot) => (
+              <Group key={snapshot.key} gap="xs" justify="space-between">
+                <Text size="sm">
+                  {formatDate(snapshot.takenAt, 'MMM D, YYYY h:mm A')} &middot;{' '}
+                  {snapshot.takenByUsername ?? `user ${snapshot.takenById}`}
+                </Text>
+                <Text size="xs" c="dimmed">
+                  {snapshot.entryCount} entries &middot; {formatDate(snapshot.window.start)} –{' '}
+                  {formatDate(snapshot.window.end)}
+                </Text>
+              </Group>
+            ))
+          )}
+        </Stack>
+      </Paper>
+    </Stack>
+  );
+}

--- a/src/components/Collections/components/ContestCollections/ContestCommunityScore.tsx
+++ b/src/components/Collections/components/ContestCollections/ContestCommunityScore.tsx
@@ -243,8 +243,26 @@ function CategoryTable({
                             by {entry.creatorUsername}
                           </Text>
                         )}
+                        <Tooltip
+                          label="Versions created during the contest window on a qualifying base model. Only these are counted."
+                          withArrow
+                          multiline
+                          w={260}
+                        >
+                          <Text size="xs" c="dimmed" w="fit-content">
+                            {entry.qualifyingVersionCount}{' '}
+                            {entry.qualifyingVersionCount === 1 ? 'version' : 'versions'}
+                          </Text>
+                        </Tooltip>
                         {entry.ineligibleReason && (
-                          <Badge color="red" variant="light" size="xs">
+                          <Badge
+                            color="red"
+                            variant="light"
+                            size="xs"
+                            h="auto"
+                            classNames={{ label: 'whitespace-normal' }}
+                            className="py-0.5"
+                          >
                             {entry.ineligibleReason}
                           </Badge>
                         )}

--- a/src/components/Collections/components/ContestCollections/ContestCommunityScore.tsx
+++ b/src/components/Collections/components/ContestCollections/ContestCommunityScore.tsx
@@ -136,6 +136,13 @@ export function ContestCommunityScore({ collectionId }: { collectionId: number }
         </Group>
       </Stack>
 
+      {data?.partial && (
+        <Alert color="orange" title="Preview — the contest is still open">
+          Scored up to {formatDate(data.window.effectiveEnd, 'MMM D, YYYY h:mm A')}. These standings
+          are not a final result.
+        </Alert>
+      )}
+
       {data?.truncated && (
         <Alert color="yellow">
           Showing the first {data.entryCount} entries only. Narrow the category or status filter to
@@ -156,9 +163,21 @@ export function ContestCommunityScore({ collectionId }: { collectionId: number }
               <Group justify="space-between">
                 <Title order={4}>{category.tagName ?? 'Uncategorized'}</Title>
                 <Text size="sm" c="dimmed">
-                  {category.entryCount} entries
+                  {category.eligibleCount} eligible of {category.entryCount}
                 </Text>
               </Group>
+              {category.soloEntry && (
+                <Alert color="yellow">
+                  Only one eligible entry in this category. A lone entrant tops every signal by
+                  definition, so its score is not comparable to any other category.
+                </Alert>
+              )}
+              {category.tied && (
+                <Alert color="gray">
+                  No qualified engagement in this category — every entry is tied, so no ranking is
+                  shown.
+                </Alert>
+              )}
               <Table.ScrollContainer minWidth={900}>
                 <Table striped highlightOnHover verticalSpacing="xs">
                   <Table.Thead>
@@ -179,8 +198,8 @@ export function ContestCommunityScore({ collectionId }: { collectionId: number }
                   </Table.Thead>
                   <Table.Tbody>
                     {category.entries.map((entry) => (
-                      <Table.Tr key={entry.collectionItemId}>
-                        <Table.Td>{entry.rank}</Table.Td>
+                      <Table.Tr key={entry.collectionItemId} opacity={entry.eligible ? 1 : 0.55}>
+                        <Table.Td>{entry.rank ?? '—'}</Table.Td>
                         <Table.Td>
                           <Group gap="xs" wrap="nowrap">
                             {entry.image && (
@@ -203,6 +222,11 @@ export function ContestCommunityScore({ collectionId }: { collectionId: number }
                                 <Text size="xs" c="dimmed">
                                   by {entry.creatorUsername}
                                 </Text>
+                              )}
+                              {entry.ineligibleReason && (
+                                <Badge color="red" variant="light" size="xs">
+                                  {entry.ineligibleReason}
+                                </Badge>
                               )}
                             </Stack>
                           </Group>
@@ -238,7 +262,7 @@ export function ContestCommunityScore({ collectionId }: { collectionId: number }
                           </Tooltip>
                         </Table.Td>
                         <Table.Td>
-                          <Text fw={600}>{entry.score.toFixed(3)}</Text>
+                          <Text fw={600}>{entry.eligible ? entry.score.toFixed(3) : '—'}</Text>
                         </Table.Td>
                       </Table.Tr>
                     ))}
@@ -260,13 +284,20 @@ export function ContestCommunityScore({ collectionId }: { collectionId: number }
           ) : (
             snapshots.map((snapshot) => (
               <Group key={snapshot.key} gap="xs" justify="space-between">
-                <Text size="sm">
-                  {formatDate(snapshot.takenAt, 'MMM D, YYYY h:mm A')} &middot;{' '}
-                  {snapshot.takenByUsername ?? `user ${snapshot.takenById}`}
-                </Text>
+                <Group gap="xs">
+                  <Text size="sm">
+                    {formatDate(snapshot.takenAt, 'MMM D, YYYY h:mm A')} &middot;{' '}
+                    {snapshot.takenByUsername ?? `user ${snapshot.takenById}`}
+                  </Text>
+                  {snapshot.partial && (
+                    <Badge color="orange" variant="light" size="xs">
+                      Preview
+                    </Badge>
+                  )}
+                </Group>
                 <Text size="xs" c="dimmed">
                   {snapshot.entryCount} entries &middot; {formatDate(snapshot.window.start)} –{' '}
-                  {formatDate(snapshot.window.end)}
+                  {formatDate(snapshot.window.effectiveEnd)}
                 </Text>
               </Group>
             ))

--- a/src/components/Collections/components/ContestCollections/ContestScoringConfigEditor.tsx
+++ b/src/components/Collections/components/ContestCollections/ContestScoringConfigEditor.tsx
@@ -1,0 +1,242 @@
+import {
+  Alert,
+  Button,
+  Checkbox,
+  Divider,
+  Group,
+  Loader,
+  NumberInput,
+  Paper,
+  Radio,
+  SimpleGrid,
+  Stack,
+  Text,
+  TextInput,
+} from '@mantine/core';
+import { IconAlertTriangle } from '@tabler/icons-react';
+import { useEffect, useState } from 'react';
+
+import type {
+  ContestScoreSignal,
+  ContestScoringConfigValues,
+  ContestScoringScope,
+} from '~/server/schema/contest-score.schema';
+import { contestScoreSignals } from '~/server/schema/contest-score.schema';
+import { formatDate } from '~/utils/date-helpers';
+import { showErrorNotification, showSuccessNotification } from '~/utils/notifications';
+import { trpc } from '~/utils/trpc';
+
+const signalLabels: Record<ContestScoreSignal, string> = {
+  imageAuthors: 'Creators',
+  reactors: 'Reactions',
+  downloaders: 'Downloads',
+  generators: 'Generations',
+  collectors: 'Collects',
+};
+
+const toNumber = (value: string | number) =>
+  typeof value === 'number' ? value : Number(value) || 0;
+
+export function ContestScoringConfigEditor({ collectionId }: { collectionId: number }) {
+  const queryUtils = trpc.useUtils();
+  const { data, isLoading, error } = trpc.contestScore.getConfig.useQuery({ collectionId });
+
+  const [scope, setScope] = useState<ContestScoringScope>('collection');
+  const [acknowledged, setAcknowledged] = useState(false);
+  const [reason, setReason] = useState('');
+  const [values, setValues] = useState<ContestScoringConfigValues | null>(null);
+
+  // Seeded from whichever row is live for this contest, so an edit starts from what
+  // the last run actually used rather than from an empty form.
+  useEffect(() => {
+    if (!data || values) return;
+    const source = data.collection ?? data.global;
+    if (!source) return;
+    const { version, updatedById, updatedByUsername, updatedAt, ...rest } = source;
+    setValues(rest);
+  }, [data, values]);
+
+  const setConfig = trpc.contestScore.setConfig.useMutation({
+    onSuccess: async () => {
+      showSuccessNotification({ message: 'Scoring config saved' });
+      setAcknowledged(false);
+      await Promise.all([
+        queryUtils.contestScore.getConfig.invalidate({ collectionId }),
+        queryUtils.contestScore.getCommunityScore.invalidate({ collectionId }),
+      ]);
+    },
+    onError: (error) =>
+      showErrorNotification({ title: 'Failed to save', error: new Error(error.message) }),
+  });
+
+  if (error)
+    return (
+      <Alert color="red" title="Scoring config unavailable">
+        {error.message}
+      </Alert>
+    );
+
+  if (isLoading || !values)
+    return (
+      <Group justify="center" py="md">
+        <Loader />
+      </Group>
+    );
+
+  const live = data?.collection ?? data?.global;
+  const global = scope === 'global';
+  const canSave = !global || acknowledged;
+
+  const update = (patch: Partial<ContestScoringConfigValues>) =>
+    setValues((current) => (current ? { ...current, ...patch } : current));
+
+  return (
+    <Stack gap="md">
+      <Stack gap={4}>
+        <Text size="sm" c="dimmed">
+          {data?.effectiveScope === 'collection'
+            ? 'This contest has its own scoring config.'
+            : 'This contest currently uses the global config.'}
+        </Text>
+        {live?.updatedAt && (
+          <Text size="xs" c="dimmed">
+            Last changed by {live.updatedByUsername ?? `user ${live.updatedById}`} on{' '}
+            {formatDate(live.updatedAt, 'MMM D, YYYY h:mm A')} (version {live.version})
+          </Text>
+        )}
+      </Stack>
+
+      <Radio.Group
+        label="Save to"
+        value={scope}
+        onChange={(value) => {
+          setScope(value as ContestScoringScope);
+          setAcknowledged(false);
+        }}
+      >
+        <Stack gap="xs" mt="xs">
+          <Radio
+            value="collection"
+            label="This contest only"
+            description="Creates or updates this collection's own config. Nothing else changes."
+          />
+          <Radio
+            value="global"
+            label="All contests"
+            description="Rewrites the global fallback every contest without its own config reads — including contests that do not exist yet."
+          />
+        </Stack>
+      </Radio.Group>
+
+      {global && (
+        <Alert color="red" icon={<IconAlertTriangle size={18} />} title="This is the global config">
+          Saving here changes scoring for every current and future contest that has no config of its
+          own. If you only meant to tune this contest, choose &ldquo;This contest only&rdquo;.
+          <Checkbox
+            mt="sm"
+            color="red"
+            checked={acknowledged}
+            onChange={(event) => setAcknowledged(event.currentTarget.checked)}
+            label="I understand this affects every contest"
+          />
+        </Alert>
+      )}
+
+      <Divider label="Weights" labelPosition="left" />
+      <SimpleGrid cols={{ base: 2, md: 5 }}>
+        {contestScoreSignals.map((signal) => (
+          <NumberInput
+            key={signal}
+            label={signalLabels[signal]}
+            value={values.weights[signal]}
+            onChange={(value) =>
+              update({ weights: { ...values.weights, [signal]: toNumber(value) } })
+            }
+            decimalScale={4}
+            step={0.05}
+          />
+        ))}
+      </SimpleGrid>
+
+      <Divider label="Minimum normalization denominator" labelPosition="left" />
+      <SimpleGrid cols={{ base: 2, md: 5 }}>
+        {contestScoreSignals.map((signal) => (
+          <NumberInput
+            key={signal}
+            label={signalLabels[signal]}
+            value={values.minDenominator[signal]}
+            onChange={(value) =>
+              update({ minDenominator: { ...values.minDenominator, [signal]: toNumber(value) } })
+            }
+            min={0}
+          />
+        ))}
+      </SimpleGrid>
+
+      <Divider label="Gates" labelPosition="left" />
+      <SimpleGrid cols={{ base: 2, md: 4 }}>
+        <NumberInput
+          label="Age gate (days)"
+          description="Accounts registered inside this many days before the contest opened are disqualified."
+          value={values.ageGateDays}
+          onChange={(value) => update({ ageGateDays: toNumber(value) })}
+          min={0}
+        />
+        <NumberInput
+          label="Max engagers"
+          description="Above this, the banned/deleted refinement is skipped and the run is flagged degraded."
+          value={values.maxEngagers}
+          onChange={(value) => update({ maxEngagers: toNumber(value) })}
+          min={1}
+        />
+        <NumberInput
+          label="Farm IP — min peers"
+          description="Distinct contest engagers sharing an IP before it is treated as a farm."
+          value={values.farmIp.minPeers}
+          onChange={(value) => update({ farmIp: { ...values.farmIp, minPeers: toNumber(value) } })}
+          min={1}
+        />
+        <NumberInput
+          label="Farm IP — min entries"
+          description="Entries a single-creator engager must touch to be surfaced as a candidate."
+          value={values.farmIp.minEntries}
+          onChange={(value) =>
+            update({ farmIp: { ...values.farmIp, minEntries: toNumber(value) } })
+          }
+          min={1}
+        />
+      </SimpleGrid>
+
+      <TextInput
+        label="Reason"
+        placeholder="Why is this changing? (recorded in the audit log)"
+        value={reason}
+        onChange={(event) => setReason(event.currentTarget.value)}
+        maxLength={500}
+      />
+
+      <Paper withBorder p="sm" radius="md">
+        <Group justify="space-between">
+          <Text size="sm" c="dimmed">
+            Saving bumps the config version, which invalidates every cached run for this contest.
+          </Text>
+          <Button
+            color={global ? 'red' : undefined}
+            loading={setConfig.isPending}
+            disabled={!canSave}
+            onClick={() =>
+              setConfig.mutate({
+                collectionId,
+                scope,
+                config: values,
+                reason: reason.trim() || undefined,
+              })
+            }
+          >
+            {global ? 'Save for ALL contests' : 'Save for this contest'}
+          </Button>
+        </Group>
+      </Paper>
+    </Stack>
+  );
+}

--- a/src/pages/collections/[collectionId]/review.tsx
+++ b/src/pages/collections/[collectionId]/review.tsx
@@ -113,6 +113,7 @@ const ReviewCollection = () => {
   const { collectionId: collectionIdString } = router.query;
   const collectionId = Number(collectionIdString);
 
+  const user = useCurrentUser();
   const deselectAll = useStore((state) => state.deselectAll);
   const [statuses, setStatuses] = useState<CollectionItemStatus[]>([CollectionItemStatus.REVIEW]);
   const [sort, setSort] = useState<CollectionReviewSort>(CollectionReviewSort.Newest);
@@ -164,6 +165,9 @@ const ReviewCollection = () => {
   if ((!loadingCollection && !collection) || (permissions && !permissions.manage))
     return <NotFound />;
 
+  // Moderators only — the scoring procedures are moderator-gated server-side, and a
+  // collection owner holds `manage` on their own collection.
+  const showCommunityTab = collection?.mode === CollectionMode.Contest && !!user?.isModerator;
   const isContestCollection = collection?.mode === CollectionMode.Contest;
 
   const reviewPanel = (
@@ -268,7 +272,7 @@ const ReviewCollection = () => {
               <BackButton url={`/collections/${collectionId}`} />
               <Title order={1}>Collection items that need review</Title>
             </Group>
-            {!isContestCollection ? (
+            {!showCommunityTab ? (
               reviewPanel
             ) : (
               // keepMounted={false} so the community score is only requested once the

--- a/src/pages/collections/[collectionId]/review.tsx
+++ b/src/pages/collections/[collectionId]/review.tsx
@@ -7,6 +7,7 @@ import {
   Loader,
   Paper,
   Stack,
+  Tabs,
   Text,
   Title,
   UnstyledButton,
@@ -53,6 +54,7 @@ import type { GetAllCollectionItemsSchema } from '~/server/schema/collection.sch
 import { allBrowsingLevelsFlag } from '~/shared/constants/browsingLevel.constants';
 import { CollectionItemNSFWLevelSelector } from '~/components/Collections/components/ContestCollections/CollectionItemNSFWLevelSelector';
 import { ContestCollectionItemScorer } from '~/components/Collections/components/ContestCollections/ContestCollectionItemScorer';
+import { ContestCommunityScore } from '~/components/Collections/components/ContestCollections/ContestCommunityScore';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
 import { AspectRatioImageCard } from '~/components/CardTemplates/AspectRatioImageCard';
 import { MasonryGrid } from '~/components/MasonryColumns/MasonryGrid';
@@ -116,6 +118,7 @@ const ReviewCollection = () => {
   const [sort, setSort] = useState<CollectionReviewSort>(CollectionReviewSort.Newest);
   const [collectionTagId, setCollectionTagId] = useState<number | undefined>(undefined);
   const [awaitingHumanReview, setAwaitingHumanReview] = useState(false);
+  const [tab, setTab] = useState<'review' | 'community'>('review');
 
   const filters = useMemo(
     () => ({
@@ -163,104 +166,129 @@ const ReviewCollection = () => {
 
   const isContestCollection = collection?.mode === CollectionMode.Contest;
 
+  const reviewPanel = (
+    <>
+      <Paper
+        withBorder
+        shadow="lg"
+        p="xs"
+        style={{
+          display: 'inline-flex',
+          float: 'right',
+          alignSelf: 'flex-end',
+          marginRight: 6,
+          position: 'sticky',
+          top: 'var(--header-height,0)',
+          marginBottom: -60,
+          zIndex: 1000,
+        }}
+      >
+        <ModerationControls collectionItems={collectionItems} filters={filters} />
+      </Paper>
+
+      <Stack gap="sm" mb="lg">
+        <Text c="dimmed">
+          You are reviewing items on the collection that are either pending review or have been
+          rejected. You can change the status of these to be accepted or rejected.
+        </Text>
+        {isContestCollection && collection.tags.length > 0 && (
+          <CollectionCategorySelect
+            collectionId={collection.id}
+            value={collectionTagId?.toString() ?? 'all'}
+            onChange={(x) => setCollectionTagId(x && x !== 'all' ? parseInt(x, 10) : undefined)}
+          />
+        )}
+        <Group justify="space-between">
+          <Chip.Group value={statuses} onChange={handleStatusToggle} multiple>
+            <Group gap="xs">
+              <Chip value={CollectionItemStatus.REVIEW}>
+                <span>Review</span>
+              </Chip>
+              <Chip value={CollectionItemStatus.REJECTED}>
+                <span>Rejected</span>
+              </Chip>
+              <Chip value={CollectionItemStatus.ACCEPTED}>
+                <span>Accepted</span>
+              </Chip>
+            </Group>
+          </Chip.Group>
+          <Chip
+            checked={awaitingHumanReview}
+            onChange={() => {
+              setAwaitingHumanReview((v) => !v);
+              deselectAll();
+            }}
+          >
+            <span>Needs human review</span>
+          </Chip>
+
+          <SelectMenuV2
+            label="Sort by"
+            options={Object.values(CollectionReviewSort).map((v) => ({ label: v, value: v }))}
+            value={sort}
+            onClick={(x) => setSort(x as CollectionReviewSort)}
+          />
+        </Group>
+      </Stack>
+      {isLoading ? (
+        <Center py="xl">
+          <Loader size="xl" />
+        </Center>
+      ) : (
+        <div className="relative">
+          <MasonryGrid
+            data={collectionItems}
+            empty={<NoContent mt="lg" message="There are no images that need review" />}
+            render={CollectionItemGridItem}
+            withAds={false}
+          />
+          {hasNextPage && (
+            <InViewLoader
+              loadFn={fetchNextPage}
+              loadCondition={!isFetching}
+              style={{ gridColumn: '1/-1' }}
+            >
+              <Center p="xl" style={{ height: 36 }} mt="md">
+                <Loader />
+              </Center>
+            </InViewLoader>
+          )}
+          {!hasNextPage && collectionItems.length > 0 && <EndOfFeed />}
+        </div>
+      )}
+    </>
+  );
+
   return (
     <ReviewCollectionContext.Provider value={filters}>
       <MasonryProvider maxColumnCount={4}>
         <MasonryContainer>
           <Stack>
-            <Paper
-              withBorder
-              shadow="lg"
-              p="xs"
-              style={{
-                display: 'inline-flex',
-                float: 'right',
-                alignSelf: 'flex-end',
-                marginRight: 6,
-                position: 'sticky',
-                top: 'var(--header-height,0)',
-                marginBottom: -60,
-                zIndex: 1000,
-              }}
-            >
-              <ModerationControls collectionItems={collectionItems} filters={filters} />
-            </Paper>
-
-            <Stack gap="sm" mb="lg">
-              <Group gap="xs">
-                <BackButton url={`/collections/${collectionId}`} />
-                <Title order={1}>Collection items that need review</Title>
-              </Group>
-              <Text c="dimmed">
-                You are reviewing items on the collection that are either pending review or have
-                been rejected. You can change the status of these to be accepted or rejected.
-              </Text>
-              {isContestCollection && collection.tags.length > 0 && (
-                <CollectionCategorySelect
-                  collectionId={collection.id}
-                  value={collectionTagId?.toString() ?? 'all'}
-                  onChange={(x) =>
-                    setCollectionTagId(x && x !== 'all' ? parseInt(x, 10) : undefined)
-                  }
-                />
-              )}
-              <Group justify="space-between">
-                <Chip.Group value={statuses} onChange={handleStatusToggle} multiple>
-                  <Group gap="xs">
-                    <Chip value={CollectionItemStatus.REVIEW}>
-                      <span>Review</span>
-                    </Chip>
-                    <Chip value={CollectionItemStatus.REJECTED}>
-                      <span>Rejected</span>
-                    </Chip>
-                    <Chip value={CollectionItemStatus.ACCEPTED}>
-                      <span>Accepted</span>
-                    </Chip>
-                  </Group>
-                </Chip.Group>
-                <Chip
-                  checked={awaitingHumanReview}
-                  onChange={() => {
-                    setAwaitingHumanReview((v) => !v);
-                    deselectAll();
-                  }}
-                >
-                  <span>Needs human review</span>
-                </Chip>
-
-                <SelectMenuV2
-                  label="Sort by"
-                  options={Object.values(CollectionReviewSort).map((v) => ({ label: v, value: v }))}
-                  value={sort}
-                  onClick={(x) => setSort(x as CollectionReviewSort)}
-                />
-              </Group>
-            </Stack>
-            {isLoading ? (
-              <Center py="xl">
-                <Loader size="xl" />
-              </Center>
+            <Group gap="xs">
+              <BackButton url={`/collections/${collectionId}`} />
+              <Title order={1}>Collection items that need review</Title>
+            </Group>
+            {!isContestCollection ? (
+              reviewPanel
             ) : (
-              <div className="relative">
-                <MasonryGrid
-                  data={collectionItems}
-                  empty={<NoContent mt="lg" message="There are no images that need review" />}
-                  render={CollectionItemGridItem}
-                  withAds={false}
-                />
-                {hasNextPage && (
-                  <InViewLoader
-                    loadFn={fetchNextPage}
-                    loadCondition={!isFetching}
-                    style={{ gridColumn: '1/-1' }}
-                  >
-                    <Center p="xl" style={{ height: 36 }} mt="md">
-                      <Loader />
-                    </Center>
-                  </InViewLoader>
-                )}
-                {!hasNextPage && collectionItems.length > 0 && <EndOfFeed />}
-              </div>
+              // keepMounted={false} so the community score is only requested once the
+              // tab is opened — it is an expensive cross-store aggregation.
+              <Tabs
+                value={tab}
+                onChange={(value) => setTab(value === 'community' ? 'community' : 'review')}
+                keepMounted={false}
+              >
+                <Tabs.List mb="md">
+                  <Tabs.Tab value="review">Review</Tabs.Tab>
+                  <Tabs.Tab value="community">Community</Tabs.Tab>
+                </Tabs.List>
+                <Tabs.Panel value="review">
+                  <Stack>{reviewPanel}</Stack>
+                </Tabs.Panel>
+                <Tabs.Panel value="community">
+                  <ContestCommunityScore collectionId={collectionId} />
+                </Tabs.Panel>
+              </Tabs>
             )}
           </Stack>
         </MasonryContainer>

--- a/src/server/common/constants.ts
+++ b/src/server/common/constants.ts
@@ -1754,4 +1754,8 @@ export const EARLY_ACCESS_CONFIG: {
 export const KEY_VALUE_KEYS = {
   REDEEM_CODE_GIFT_NOTICES: 'redeemCodeGiftNotices',
   MODEL_FILE_OPTIONS: 'modelFileOptions',
+  CONTEST_SCORING: 'contestScoring',
 } as const;
+
+// Snapshot rows are one KeyValue per run: `contestSnapshot:<collectionId>:<takenAt ISO>`.
+export const CONTEST_SNAPSHOT_KEY_PREFIX = 'contestSnapshot';

--- a/src/server/common/constants.ts
+++ b/src/server/common/constants.ts
@@ -1759,3 +1759,18 @@ export const KEY_VALUE_KEYS = {
 
 // Snapshot rows are one KeyValue per run: `contestSnapshot:<collectionId>:<takenAt ISO>`.
 export const CONTEST_SNAPSHOT_KEY_PREFIX = 'contestSnapshot';
+
+/**
+ * Bumped whenever a change to contest scoring could move a ranking. Recorded in every
+ * snapshot so a disputed result can be traced to the code that produced it, and read
+ * by the results UI to mark a snapshot taken by an older scorer.
+ *
+ * It lives HERE rather than beside the scorer because the client reads it: a value
+ * import from `contest-score.service` would pull `~/server/db/client` and `~/env/server`
+ * into the browser bundle, and neither module can be tree-shaken away (both run side
+ * effects at import). That failure only surfaces at `next build`.
+ */
+export const CONTEST_SCORE_CODE_VERSION = 5;
+
+/** Scoring counted every version of a model before this. */
+export const CONTEST_VERSION_SCOPING_CODE_VERSION = 3;

--- a/src/server/common/enums.ts
+++ b/src/server/common/enums.ts
@@ -153,6 +153,7 @@ export enum SignalMessages {
   ReferralClawback = 'referral:clawback',
   ReferralTokenExpiringSoon = 'referral:token-expiring-soon',
   ScannerPolicyTestProgress = 'scanner-policy:test-progress',
+  ContestScoreRunUpdate = 'contest-score:run-update',
 }
 
 export enum BountySort {
@@ -384,6 +385,7 @@ export enum SignalTopic {
   NewOrderPlayer = 'new-order-player', // with :playerId
   NewOrderQueue = 'new-order-queue', // with :queueId
   Metric = 'metrics', // with :entityType:entityId
+  ContestScore = 'contest-score', // with :collectionId
 }
 
 export enum NewOrderImageRatingStatus {

--- a/src/server/routers/_probe.router.ts
+++ b/src/server/routers/_probe.router.ts
@@ -1,0 +1,9 @@
+import * as z from 'zod';
+import { moderatorProcedure, router } from '~/server/trpc';
+
+// Temporary diagnostic: perturbs the server module graph without touching contest
+// scoring, to test whether the production build failure is a chunk-name collision
+// rather than a defect in this branch.
+export const probeRouter = router({
+  ping: moderatorProcedure.input(z.object({ n: z.number() })).query(({ input }) => input.n),
+});

--- a/src/server/routers/_probe.router.ts
+++ b/src/server/routers/_probe.router.ts
@@ -1,9 +1,0 @@
-import * as z from 'zod';
-import { moderatorProcedure, router } from '~/server/trpc';
-
-// Temporary diagnostic: perturbs the server module graph without touching contest
-// scoring, to test whether the production build failure is a chunk-name collision
-// rather than a defect in this branch.
-export const probeRouter = router({
-  ping: moderatorProcedure.input(z.object({ n: z.number() })).query(({ input }) => input.n),
-});

--- a/src/server/routers/contest-score.router.ts
+++ b/src/server/routers/contest-score.router.ts
@@ -2,13 +2,21 @@ import {
   createContestSnapshotSchema,
   getCommunityScoreSchema,
   getContestCandidatesSchema,
+  getContestScoringConfigSchema,
+  getContestSnapshotSchema,
   listContestSnapshotsSchema,
+  runCommunityScoreSchema,
+  setContestScoringConfigSchema,
 } from '~/server/schema/contest-score.schema';
 import {
   createContestSnapshot,
   getCommunityScore,
   getContestCandidates,
+  getContestScoringConfigForEditor,
+  getContestSnapshot,
   listContestSnapshots,
+  runCommunityScore,
+  setContestScoringConfig,
 } from '~/server/services/contest-score.service';
 import { moderatorProcedure, router } from '~/server/trpc';
 
@@ -16,10 +24,17 @@ import { moderatorProcedure, router } from '~/server/trpc';
 // OWNER holds it, so honouring it would let any user point the scorer at any
 // collection — a weight oracle and an unbounded load path in one. The service
 // additionally refuses any collection that is not `mode = Contest`.
+//
+// The config procedures are separate from the scoring ones and carry a separate
+// payload. Scores never include weights, denominators or thresholds, so relaxing the
+// gate on one of these cannot expose the other.
 export const contestScoreRouter = router({
   getCommunityScore: moderatorProcedure
     .input(getCommunityScoreSchema)
     .query(({ input }) => getCommunityScore(input)),
+  runCommunityScore: moderatorProcedure
+    .input(runCommunityScoreSchema)
+    .mutation(({ input, ctx }) => runCommunityScore({ input, userId: ctx.user.id })),
   getCandidates: moderatorProcedure
     .input(getContestCandidatesSchema)
     .query(({ input }) => getContestCandidates(input)),
@@ -31,4 +46,15 @@ export const contestScoreRouter = router({
   listSnapshots: moderatorProcedure
     .input(listContestSnapshotsSchema)
     .query(({ input }) => listContestSnapshots(input)),
+  getSnapshot: moderatorProcedure
+    .input(getContestSnapshotSchema)
+    .query(({ input }) => getContestSnapshot(input)),
+  getConfig: moderatorProcedure
+    .input(getContestScoringConfigSchema)
+    .query(({ input }) => getContestScoringConfigForEditor(input.collectionId)),
+  setConfig: moderatorProcedure
+    .input(setContestScoringConfigSchema)
+    .mutation(({ input, ctx }) =>
+      setContestScoringConfig({ input, userId: ctx.user.id, username: ctx.user.username })
+    ),
 });

--- a/src/server/routers/contest-score.router.ts
+++ b/src/server/routers/contest-score.router.ts
@@ -1,0 +1,46 @@
+import {
+  createContestSnapshotSchema,
+  getCommunityScoreSchema,
+  getContestCandidatesSchema,
+  listContestSnapshotsSchema,
+} from '~/server/schema/contest-score.schema';
+import {
+  assertCanScoreContest,
+  createContestSnapshot,
+  getCommunityScore,
+  getContestCandidates,
+  listContestSnapshots,
+} from '~/server/services/contest-score.service';
+import { protectedProcedure, router } from '~/server/trpc';
+import { throwBadRequestError } from '~/server/utils/errorHandling';
+
+// Runs ahead of input validation, so the collectionId is still raw here.
+const isCollectionManager = protectedProcedure.use(async ({ ctx, next, getRawInput }) => {
+  const { collectionId } = ((await getRawInput()) ?? {}) as { collectionId?: unknown };
+  if (typeof collectionId !== 'number' || !Number.isInteger(collectionId) || collectionId <= 0)
+    throw throwBadRequestError('A valid collectionId is required');
+
+  await assertCanScoreContest({
+    collectionId,
+    userId: ctx.user.id,
+    isModerator: ctx.user.isModerator,
+  });
+  return next();
+});
+
+export const contestScoreRouter = router({
+  getCommunityScore: isCollectionManager
+    .input(getCommunityScoreSchema)
+    .query(({ input }) => getCommunityScore(input)),
+  getCandidates: isCollectionManager
+    .input(getContestCandidatesSchema)
+    .query(({ input }) => getContestCandidates(input)),
+  snapshot: isCollectionManager
+    .input(createContestSnapshotSchema)
+    .mutation(({ input, ctx }) =>
+      createContestSnapshot({ input, userId: ctx.user.id, username: ctx.user.username })
+    ),
+  listSnapshots: isCollectionManager
+    .input(listContestSnapshotsSchema)
+    .query(({ input }) => listContestSnapshots(input)),
+});

--- a/src/server/routers/contest-score.router.ts
+++ b/src/server/routers/contest-score.router.ts
@@ -5,42 +5,30 @@ import {
   listContestSnapshotsSchema,
 } from '~/server/schema/contest-score.schema';
 import {
-  assertCanScoreContest,
   createContestSnapshot,
   getCommunityScore,
   getContestCandidates,
   listContestSnapshots,
 } from '~/server/services/contest-score.service';
-import { protectedProcedure, router } from '~/server/trpc';
-import { throwBadRequestError } from '~/server/utils/errorHandling';
+import { moderatorProcedure, router } from '~/server/trpc';
 
-// Runs ahead of input validation, so the collectionId is still raw here.
-const isCollectionManager = protectedProcedure.use(async ({ ctx, next, getRawInput }) => {
-  const { collectionId } = ((await getRawInput()) ?? {}) as { collectionId?: unknown };
-  if (typeof collectionId !== 'number' || !Number.isInteger(collectionId) || collectionId <= 0)
-    throw throwBadRequestError('A valid collectionId is required');
-
-  await assertCanScoreContest({
-    collectionId,
-    userId: ctx.user.id,
-    isModerator: ctx.user.isModerator,
-  });
-  return next();
-});
-
+// Moderators only. Collection MANAGE is deliberately NOT accepted: every collection
+// OWNER holds it, so honouring it would let any user point the scorer at any
+// collection — a weight oracle and an unbounded load path in one. The service
+// additionally refuses any collection that is not `mode = Contest`.
 export const contestScoreRouter = router({
-  getCommunityScore: isCollectionManager
+  getCommunityScore: moderatorProcedure
     .input(getCommunityScoreSchema)
     .query(({ input }) => getCommunityScore(input)),
-  getCandidates: isCollectionManager
+  getCandidates: moderatorProcedure
     .input(getContestCandidatesSchema)
     .query(({ input }) => getContestCandidates(input)),
-  snapshot: isCollectionManager
+  snapshot: moderatorProcedure
     .input(createContestSnapshotSchema)
     .mutation(({ input, ctx }) =>
       createContestSnapshot({ input, userId: ctx.user.id, username: ctx.user.username })
     ),
-  listSnapshots: isCollectionManager
+  listSnapshots: moderatorProcedure
     .input(listContestSnapshotsSchema)
     .query(({ input }) => listContestSnapshots(input)),
 });

--- a/src/server/routers/index.ts
+++ b/src/server/routers/index.ts
@@ -26,6 +26,7 @@ export const appRouter = router({
   collection: lazy(() => import('./collection.router').then((m) => m.collectionRouter)),
   comment: lazy(() => import('./comment.router').then((m) => m.commentRouter)),
   contestScore: lazy(() => import('./contest-score.router').then((m) => m.contestScoreRouter)),
+  probe: lazy(() => import('./_probe.router').then((m) => m.probeRouter)),
   commentv2: lazy(() => import('./commentv2.router').then((m) => m.commentv2Router)),
   common: lazy(() => import('~/server/routers/common.router').then((m) => m.commonRouter)),
   content: lazy(() => import('./content.router').then((m) => m.contentRouter)),

--- a/src/server/routers/index.ts
+++ b/src/server/routers/index.ts
@@ -25,6 +25,7 @@ export const appRouter = router({
   chat: lazy(() => import('./chat.router').then((m) => m.chatRouter)),
   collection: lazy(() => import('./collection.router').then((m) => m.collectionRouter)),
   comment: lazy(() => import('./comment.router').then((m) => m.commentRouter)),
+  contestScore: lazy(() => import('./contest-score.router').then((m) => m.contestScoreRouter)),
   commentv2: lazy(() => import('./commentv2.router').then((m) => m.commentv2Router)),
   common: lazy(() => import('~/server/routers/common.router').then((m) => m.commonRouter)),
   content: lazy(() => import('./content.router').then((m) => m.contentRouter)),
@@ -98,9 +99,15 @@ export const appRouter = router({
     import('~/server/routers/membership-gift.router').then((m) => m.membershipGiftRouter)
   ),
   tool: lazy(() => import('~/server/routers/tool.router').then((m) => m.toolRouter)),
-  cosmeticShop: lazy(() => import('~/server/routers/cosmetic-shop.router').then((m) => m.cosmeticShopRouter)),
-  creatorShop: lazy(() => import('~/server/routers/creator-shop.router').then((m) => m.creatorShopRouter)),
-  productBadge: lazy(() => import('~/server/routers/product-badge.router').then((m) => m.productBadgeRouter)),
+  cosmeticShop: lazy(() =>
+    import('~/server/routers/cosmetic-shop.router').then((m) => m.cosmeticShopRouter)
+  ),
+  creatorShop: lazy(() =>
+    import('~/server/routers/creator-shop.router').then((m) => m.creatorShopRouter)
+  ),
+  productBadge: lazy(() =>
+    import('~/server/routers/product-badge.router').then((m) => m.productBadgeRouter)
+  ),
   technique: lazy(() => import('~/server/routers/technique.router').then((m) => m.techniqueRouter)),
   donationGoal: lazy(() =>
     import('~/server/routers/donation-goal.router').then((m) => m.donationGoalRouter)

--- a/src/server/routers/index.ts
+++ b/src/server/routers/index.ts
@@ -26,7 +26,6 @@ export const appRouter = router({
   collection: lazy(() => import('./collection.router').then((m) => m.collectionRouter)),
   comment: lazy(() => import('./comment.router').then((m) => m.commentRouter)),
   contestScore: lazy(() => import('./contest-score.router').then((m) => m.contestScoreRouter)),
-  probe: lazy(() => import('./_probe.router').then((m) => m.probeRouter)),
   commentv2: lazy(() => import('./commentv2.router').then((m) => m.commentv2Router)),
   common: lazy(() => import('~/server/routers/common.router').then((m) => m.commonRouter)),
   content: lazy(() => import('./content.router').then((m) => m.contentRouter)),

--- a/src/server/routers/index.ts
+++ b/src/server/routers/index.ts
@@ -99,15 +99,9 @@ export const appRouter = router({
     import('~/server/routers/membership-gift.router').then((m) => m.membershipGiftRouter)
   ),
   tool: lazy(() => import('~/server/routers/tool.router').then((m) => m.toolRouter)),
-  cosmeticShop: lazy(() =>
-    import('~/server/routers/cosmetic-shop.router').then((m) => m.cosmeticShopRouter)
-  ),
-  creatorShop: lazy(() =>
-    import('~/server/routers/creator-shop.router').then((m) => m.creatorShopRouter)
-  ),
-  productBadge: lazy(() =>
-    import('~/server/routers/product-badge.router').then((m) => m.productBadgeRouter)
-  ),
+  cosmeticShop: lazy(() => import('~/server/routers/cosmetic-shop.router').then((m) => m.cosmeticShopRouter)),
+  creatorShop: lazy(() => import('~/server/routers/creator-shop.router').then((m) => m.creatorShopRouter)),
+  productBadge: lazy(() => import('~/server/routers/product-badge.router').then((m) => m.productBadgeRouter)),
   technique: lazy(() => import('~/server/routers/technique.router').then((m) => m.techniqueRouter)),
   donationGoal: lazy(() =>
     import('~/server/routers/donation-goal.router').then((m) => m.donationGoalRouter)

--- a/src/server/schema/contest-score.schema.ts
+++ b/src/server/schema/contest-score.schema.ts
@@ -56,12 +56,18 @@ export const getContestSnapshotSchema = z.object({
 // ---------------------------------------------------------------------------
 
 /**
- * Structural validation only, and deliberately so: a min/max on a weight or a
- * threshold would publish that value's range to anyone who can read this file, and
- * this repo mirrors publicly. Magnitudes are constrained by review, not by zod.
+ * Bounded at zero and nowhere else. A min/max carrying a magnitude would publish that
+ * value's range to anyone reading this file, and the repo mirrors publicly — but zero
+ * is a sign, not a magnitude, and it discloses nothing.
+ *
+ * It is worth having: a negative `ageGateDays` puts the cutoff in the FUTURE, the
+ * `min(id) WHERE createdAt > cutoff` lookup comes back empty, `COALESCE` falls to
+ * `max(id)`, and the threshold admits every account on the site. The age gate switches
+ * itself off with no warning and no `degraded` flag, and the run looks entirely
+ * normal. Negative weights are the same class of silent inversion.
  */
 const weightsSchema = z.object(
-  Object.fromEntries(contestScoreSignals.map((s) => [s, z.number()])) as Record<
+  Object.fromEntries(contestScoreSignals.map((s) => [s, z.number().nonnegative()])) as Record<
     ContestScoreSignal,
     z.ZodNumber
   >
@@ -71,15 +77,15 @@ const weightsSchema = z.object(
 export type ContestScoringConfigValues = z.infer<typeof contestScoringConfigValuesSchema>;
 export const contestScoringConfigValuesSchema = z.object({
   weights: weightsSchema,
-  ageGateDays: z.number(),
+  ageGateDays: z.number().nonnegative(),
   // Floor on each signal's normalization denominator. Where a category's leading
   // qualified count is tiny, plain max-normalization lets one or two users swing a
   // signal from 0 to 0.5 and decide a placement on noise.
   minDenominator: weightsSchema,
   // Ceiling on the engager set resolved against Postgres. Past it the banned/deleted
   // refinement is skipped and the run is flagged degraded rather than run anyway.
-  maxEngagers: z.number(),
-  farmIp: z.object({ minPeers: z.number(), minEntries: z.number() }),
+  maxEngagers: z.number().positive(),
+  farmIp: z.object({ minPeers: z.number().positive(), minEntries: z.number().positive() }),
 });
 
 export type ContestScoringConfig = z.infer<typeof contestScoringConfigSchema>;
@@ -132,6 +138,8 @@ export type ContestScoreRunState = {
   requestedAt: string;
   startedAt: string | null;
   finishedAt: string | null;
+  /** Refreshed while the run is alive; a state that stops beating is treated as dead. */
+  heartbeatAt?: string | null;
   error: string | null;
   /** `generatedAt` of the result this run produced; the client uses it to tell runs apart. */
   generatedAt: string | null;

--- a/src/server/schema/contest-score.schema.ts
+++ b/src/server/schema/contest-score.schema.ts
@@ -1,0 +1,43 @@
+import * as z from 'zod';
+import { CollectionItemStatus } from '~/shared/utils/prisma/enums';
+
+export const contestScoreSignals = [
+  'imageAuthors',
+  'reactors',
+  'downloaders',
+  'generators',
+  'collectors',
+] as const;
+export type ContestScoreSignal = (typeof contestScoreSignals)[number];
+
+const windowShape = {
+  collectionId: z.number().int().positive(),
+  start: z.coerce.date().optional(),
+  end: z.coerce.date().optional(),
+  tagIds: z.array(z.number().int().positive()).max(50).optional(),
+  statuses: z.array(z.enum(CollectionItemStatus)).min(1).max(3).optional(),
+};
+
+const orderedWindow = (data: { start?: Date; end?: Date }) =>
+  !data.start || !data.end || data.start < data.end;
+const orderedWindowError = { message: 'start must precede end', path: ['end'] };
+
+export type GetCommunityScoreInput = z.infer<typeof getCommunityScoreSchema>;
+export const getCommunityScoreSchema = z
+  .object({ ...windowShape, refresh: z.boolean().optional() })
+  .refine(orderedWindow, orderedWindowError);
+
+export type GetContestCandidatesInput = z.infer<typeof getContestCandidatesSchema>;
+export const getContestCandidatesSchema = z
+  .object({ ...windowShape, limit: z.number().int().positive().max(1000).optional() })
+  .refine(orderedWindow, orderedWindowError);
+
+export type CreateContestSnapshotInput = z.infer<typeof createContestSnapshotSchema>;
+export const createContestSnapshotSchema = z
+  .object({ ...windowShape, note: z.string().max(500).optional() })
+  .refine(orderedWindow, orderedWindowError);
+
+export type ListContestSnapshotsInput = z.infer<typeof listContestSnapshotsSchema>;
+export const listContestSnapshotsSchema = z.object({
+  collectionId: z.number().int().positive(),
+});

--- a/src/server/schema/contest-score.schema.ts
+++ b/src/server/schema/contest-score.schema.ts
@@ -24,8 +24,11 @@ const orderedWindowError = { message: 'start must precede end', path: ['end'] };
 
 export type GetCommunityScoreInput = z.infer<typeof getCommunityScoreSchema>;
 export const getCommunityScoreSchema = z
-  .object({ ...windowShape, refresh: z.boolean().optional() })
+  .object(windowShape)
   .refine(orderedWindow, orderedWindowError);
+
+export type RunCommunityScoreInput = z.infer<typeof runCommunityScoreSchema>;
+export const runCommunityScoreSchema = getCommunityScoreSchema;
 
 export type GetContestCandidatesInput = z.infer<typeof getContestCandidatesSchema>;
 export const getContestCandidatesSchema = z
@@ -41,3 +44,95 @@ export type ListContestSnapshotsInput = z.infer<typeof listContestSnapshotsSchem
 export const listContestSnapshotsSchema = z.object({
   collectionId: z.number().int().positive(),
 });
+
+export type GetContestSnapshotInput = z.infer<typeof getContestSnapshotSchema>;
+export const getContestSnapshotSchema = z.object({
+  collectionId: z.number().int().positive(),
+  key: z.string().min(1).max(200),
+});
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+/**
+ * Structural validation only, and deliberately so: a min/max on a weight or a
+ * threshold would publish that value's range to anyone who can read this file, and
+ * this repo mirrors publicly. Magnitudes are constrained by review, not by zod.
+ */
+const weightsSchema = z.object(
+  Object.fromEntries(contestScoreSignals.map((s) => [s, z.number()])) as Record<
+    ContestScoreSignal,
+    z.ZodNumber
+  >
+);
+
+/** The editable surface. `version` and provenance are set by the server, never by a client. */
+export type ContestScoringConfigValues = z.infer<typeof contestScoringConfigValuesSchema>;
+export const contestScoringConfigValuesSchema = z.object({
+  weights: weightsSchema,
+  ageGateDays: z.number(),
+  // Floor on each signal's normalization denominator. Where a category's leading
+  // qualified count is tiny, plain max-normalization lets one or two users swing a
+  // signal from 0 to 0.5 and decide a placement on noise.
+  minDenominator: weightsSchema,
+  // Ceiling on the engager set resolved against Postgres. Past it the banned/deleted
+  // refinement is skipped and the run is flagged degraded rather than run anyway.
+  maxEngagers: z.number(),
+  farmIp: z.object({ minPeers: z.number(), minEntries: z.number() }),
+});
+
+export type ContestScoringConfig = z.infer<typeof contestScoringConfigSchema>;
+export const contestScoringConfigSchema = contestScoringConfigValuesSchema.extend({
+  version: z.number(),
+  updatedById: z.number().optional(),
+  updatedByUsername: z.string().nullish(),
+  updatedAt: z.string().optional(),
+});
+
+/**
+ * Which KeyValue row an edit lands on. `global` rewrites the fallback every future
+ * contest reads, so the client must choose it explicitly — there is no default that
+ * quietly means "all contests".
+ */
+export const contestScoringScopes = ['collection', 'global'] as const;
+export type ContestScoringScope = (typeof contestScoringScopes)[number];
+
+export type GetContestScoringConfigInput = z.infer<typeof getContestScoringConfigSchema>;
+export const getContestScoringConfigSchema = z.object({
+  collectionId: z.number().int().positive(),
+});
+
+export type SetContestScoringConfigInput = z.infer<typeof setContestScoringConfigSchema>;
+export const setContestScoringConfigSchema = z.object({
+  collectionId: z.number().int().positive(),
+  scope: z.enum(contestScoringScopes),
+  config: contestScoringConfigValuesSchema,
+  reason: z.string().max(500).optional(),
+});
+
+// ---------------------------------------------------------------------------
+// Runs
+// ---------------------------------------------------------------------------
+
+export const contestScoreRunStatuses = ['queued', 'running', 'done', 'failed'] as const;
+export type ContestScoreRunStatus = (typeof contestScoreRunStatuses)[number];
+
+/**
+ * Pushed to `SignalTopic.ContestScore:<collectionId>` on every state change and also
+ * returned by the read query. It carries run bookkeeping ONLY — no scores, no config.
+ * A topic is joinable by any connected client, so nothing on this payload may be
+ * something the moderator gate exists to protect.
+ */
+export type ContestScoreRunState = {
+  runId: string;
+  collectionId: number;
+  status: ContestScoreRunStatus;
+  requestedBy: number;
+  requestedAt: string;
+  startedAt: string | null;
+  finishedAt: string | null;
+  error: string | null;
+  /** `generatedAt` of the result this run produced; the client uses it to tell runs apart. */
+  generatedAt: string | null;
+};

--- a/src/server/schema/contest-score.schema.ts
+++ b/src/server/schema/contest-score.schema.ts
@@ -85,6 +85,9 @@ export const contestScoringConfigValuesSchema = z.object({
   // Ceiling on the engager set resolved against Postgres. Past it the banned/deleted
   // refinement is skipped and the run is flagged degraded rather than run anyway.
   maxEngagers: z.number().positive(),
+  // Base models a version must be built on to represent its entry. Absent or empty
+  // applies no base-model filter — the contest-window filter still applies on its own.
+  baseModels: z.array(z.string().min(1).max(100)).max(50).optional(),
   farmIp: z.object({ minPeers: z.number().positive(), minEntries: z.number().positive() }),
 });
 

--- a/src/server/services/contest-score.queries.ts
+++ b/src/server/services/contest-score.queries.ts
@@ -1,0 +1,923 @@
+/**
+ * Data access for contest scoring: every Postgres and ClickHouse query the scorer
+ * runs, plus the gate and id-list helpers that sit against them.
+ *
+ * Split out of `contest-score.service.ts`, which had grown past 2,300 lines. The seam
+ * is deliberate rather than an arbitrary halving: this module knows how to ASK the two
+ * stores things, and nothing about weights, normalization, ranking or snapshots. The
+ * service keeps all of that and never writes SQL.
+ *
+ * The dependency runs one way — service imports queries, never the reverse — so the
+ * shared types and the error class live here, at the bottom of the graph.
+ *
+ * Server-only. Nothing the client imports may reach this module: it pulls
+ * `~/server/db/client` and the ClickHouse client, both of which run side effects at
+ * import and drag `~/env/server` in behind them.
+ */
+
+import { Prisma } from '@prisma/client';
+import pLimit from 'p-limit';
+import { CacheTTL } from '~/server/common/constants';
+import { clickhouse } from '~/server/clickhouse/client';
+import { dbRead } from '~/server/db/client';
+import { REDIS_KEYS } from '~/server/redis/client';
+import type { RedisKeyTemplateCache } from '~/server/redis/client';
+import { fetchThroughCache } from '~/server/utils/cache-helpers';
+import { withSpan } from '~/server/utils/otel-helpers';
+import { CollectionItemStatus, ModelStatus } from '~/shared/utils/prisma/enums';
+
+/**
+ * An error whose message is safe to show the caller — a misconfiguration or a bad
+ * request, never a query failure. Everything else is logged and replaced with a
+ * generic message, because the ClickHouse `$query` wrapper appends the generated
+ * SQL (id lists included) to the errors it throws.
+ */
+export class ContestScoringError extends Error {}
+
+/**
+ * Every timestamp column this service compares against — `User.createdAt`,
+ * `Post.publishedAt`, `CollectionItem.createdAt`, `bannedAt`, `deletedAt` — is
+ * `timestamp WITHOUT time zone` holding UTC. A bound `Date` arrives as `timestamptz`
+ * and Postgres coerces it using the SESSION timezone, so the comparison is only
+ * correct while that session happens to be UTC. Converting explicitly makes it
+ * correct under any session timezone.
+ */
+const utc = (d: Date) => Prisma.sql`(${d}::timestamptz AT TIME ZONE 'UTC')`;
+const nowUtc = Prisma.raw(`(NOW() AT TIME ZONE 'UTC')`);
+
+/**
+ * Two windows, and the difference decides prizes.
+ *
+ * `start`/`end` are the DISPLAY window a moderator drives from the date pickers — a
+ * lens over the traffic being counted, freely narrowed to look at a single day.
+ *
+ * `contestStart`/`contestEnd` are the contest itself, off the collection's metadata.
+ * Anything that decides ELIGIBILITY reads these: the age gate, and which versions
+ * qualify. Narrowing the view must never make an entry ineligible, only quieter.
+ */
+export type ResolvedWindow = {
+  start: Date;
+  end: Date;
+  /** `end` clamped to now. A contest still running is scored up to this instant. */
+  effectiveEnd: Date;
+  /** True while the contest is still open — the run is a preview, not a result. */
+  partial: boolean;
+  ageCutoff: Date;
+  contestStart: Date;
+  contestEnd: Date;
+  contestStartSource: ContestBoundSource;
+  contestEndSource: ContestBoundSource;
+  /** `Collection.metadata.baseModels` — the rule entrants were actually told. */
+  declaredBaseModels: string[];
+};
+
+/** Which field an eligibility bound came from, so a run can say so rather than imply it. */
+export type ContestBoundSource =
+  | 'submissionStartDate'
+  | 'submissionEndDate'
+  | 'endsAt'
+  | 'collectionCreatedAt';
+
+// Raised from 1000 after a past contest (collection 3991102) came in at 1138 accepted
+// items — the old ceiling was already reachable, and a category that loses entries has
+// to have its ranks withheld because the normalization maxima come from survivors.
+const MAX_ENTRIES = 5000;
+
+// Entities per ClickHouse call. Chunks are cut along ENTRY boundaries, never entity
+// ones: uniqExact cannot be summed across chunks, so every entity belonging to an
+// entry has to be counted in the same call.
+//
+// The ceiling is the query TEXT, not the row count: `chPairTable` inlines every pair
+// as a tuple literal, and the cluster caps a query at 262,144 bytes / 50,000 AST
+// elements. The measured limit is ~8,000 four-element tuples; 5,000 leaves headroom.
+const CH_ENTITY_CHUNK = 5000;
+
+const CH_CONCURRENCY = 4;
+
+export const DEFAULT_STATUSES: CollectionItemStatus[] = [CollectionItemStatus.ACCEPTED];
+
+// ---------------------------------------------------------------------------
+// Gates
+// ---------------------------------------------------------------------------
+
+type BaseGates = {
+  userIdThreshold: number;
+  ageGateBandUsers: number;
+  baseDisqualifiedIds: number[];
+};
+
+export type Gates = BaseGates & {
+  /** Base list plus the banned/deleted engagers resolved for THIS contest. */
+  disqualifiedIds: number[];
+  /** Set when the engager set blew the cap and the ban refinement was skipped. */
+  bannedRefinementSkipped: boolean;
+  engagerCount: number;
+};
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+// Progressively widened until a registration is found. Civitai takes thousands of
+// signups a day, so the first bound effectively always hits; the rest exist so the
+// answer is correct rather than convenient.
+const AGE_THRESHOLD_WINDOW_DAYS = [1, 7, 30];
+
+/**
+ * The lowest `User.id` registered after `cutoff`, optionally within a bounded window.
+ *
+ * `MATERIALIZED` is doing the work. `User` carries a PARTIAL index —
+ * `User_createdAt_idx ON "User"("createdAt") WHERE "deletedAt" IS NULL` — which a
+ * query omitting the `deletedAt` predicate cannot use at all; and even with the
+ * predicate, `min(id)` tempts the planner into an ascending primary-key walk that
+ * discards ~12.7M rows before its first match. Forcing the candidate set to
+ * materialize off the index first turns that walk into a range scan.
+ *
+ * `deletedAt IS NULL` is safe here and the reasoning is not obvious. Skipping
+ * soft-deleted rows can only RAISE `min(id)`, so the threshold can only get more
+ * permissive — but every id in the resulting gap belongs, by definition, to a deleted
+ * account, and deleted accounts are already disqualified by the ban/delete rule. The
+ * gate is unchanged in effect.
+ *
+ * The one exception worth knowing: when the engager set blows `maxEngagers` that
+ * ban/delete refinement is SKIPPED, and in that degraded path a soft-deleted account
+ * in the gap would be admitted where the unfiltered query would have caught it via
+ * the age gate. Such a run is already flagged `bannedRefinementSkipped` and told not
+ * to decide a prize. The Postgres-side signals join `User` and check the ban columns
+ * inline, so they are unaffected either way.
+ */
+async function lowestUserIdAfter(cutoff: Date, windowDays: number | null) {
+  const upperBound =
+    windowDays === null
+      ? Prisma.empty
+      : Prisma.sql`AND u."createdAt" < ${utc(new Date(cutoff.getTime() + windowDays * DAY_MS))}`;
+
+  const [row] = await dbRead.$queryRaw<{ minId: number | null }[]>`
+    WITH candidates AS MATERIALIZED (
+      SELECT u.id
+      FROM "User" u
+      WHERE u."createdAt" > ${utc(cutoff)}
+        ${upperBound}
+        AND u."deletedAt" IS NULL
+    )
+    SELECT min(id)::int AS "minId" FROM candidates
+  `;
+
+  return row?.minId ?? null;
+}
+
+/**
+ * `User.id` is autoincrement but NOT strictly monotonic with `createdAt` — at least
+ * one backdated system account exists. `max(id) WHERE createdAt <= cutoff` would let
+ * that single row drag the threshold up and wave through every account registered
+ * since. `min(id) WHERE createdAt > cutoff` minus one can only ever be too strict,
+ * which is the safe direction for an anti-cheat gate.
+ *
+ * The answer is a pure function of the cutoff and effectively immutable (a later
+ * registration always has both a higher id and a later `createdAt`), so it stays
+ * cached for a week — that is now a cheap miss rather than a painful one.
+ */
+async function loadAgeThreshold(ageCutoff: Date) {
+  const key = `${
+    REDIS_KEYS.CACHES.CONTEST_COMMUNITY_SCORE
+  }:age-threshold:${ageCutoff.toISOString()}` as RedisKeyTemplateCache;
+
+  return fetchThroughCache(
+    key,
+    () =>
+      withSpan('contest-score.age-threshold', async () => {
+        let threshold: number | null = null;
+        for (const windowDays of AGE_THRESHOLD_WINDOW_DAYS) {
+          const minId = await lowestUserIdAfter(ageCutoff, windowDays);
+          if (minId !== null) {
+            threshold = minId - 1;
+            break;
+          }
+        }
+
+        if (threshold === null) {
+          // Only an UNBOUNDED miss means nobody registered after the cutoff. Treating
+          // an empty bounded window as "nobody" would COALESCE to max(id) and admit
+          // every account on the site — the same silent fail-open the age-gate bound
+          // exists to prevent.
+          const unbounded = await lowestUserIdAfter(ageCutoff, null);
+          if (unbounded !== null) threshold = unbounded - 1;
+          else {
+            const [{ maxId }] = await dbRead.$queryRaw<{ maxId: number }[]>`
+              SELECT max(id)::int AS "maxId" FROM "User"
+            `;
+            threshold = maxId;
+          }
+        }
+
+        const [{ bandUsers }] = await dbRead.$queryRaw<{ bandUsers: number }[]>`
+          SELECT count(*)::int AS "bandUsers"
+          FROM "User" u
+          WHERE u."createdAt" <= ${utc(ageCutoff)} AND u.id > ${threshold}
+        `;
+        return { threshold, bandUsers };
+      }),
+    { ttl: CacheTTL.week, lockTTL: 60 }
+  );
+}
+
+/** The always-on gates: cheap, bounded, and enough to bound the engager set. */
+export async function loadBaseGates(ageCutoff: Date) {
+  const threshold = await loadAgeThreshold(ageCutoff);
+
+  if (threshold.bandUsers)
+    console.warn(
+      `[contest-score] age gate band holds ${threshold.bandUsers} user(s) registered before the cutoff but carrying an id above the threshold; they are disqualified.`
+    );
+
+  const [excluded, contestBanned] = await Promise.all([
+    withSpan('contest-score.excluded-users', () =>
+      clickhouse!.$query<{ userId: number }>(`
+        SELECT userId FROM metricExcludedUsers FINAL WHERE active = 1
+      `)
+    ),
+    withSpan(
+      'contest-score.contest-banned',
+      () =>
+        dbRead.$queryRaw<{ id: number }[]>`
+        SELECT u.id FROM "User" u WHERE u.meta ->> 'contestBanDetails' IS NOT NULL
+      `
+    ),
+  ]);
+
+  return {
+    userIdThreshold: threshold.threshold,
+    ageGateBandUsers: threshold.bandUsers,
+    baseDisqualifiedIds: [
+      ...new Set([...excluded.map((e) => Number(e.userId)), ...contestBanned.map((u) => u.id)]),
+    ].sort((a, b) => a - b),
+  };
+}
+
+// Postgres caps a statement at 65,535 bind parameters. Chunked well under it so this
+// is a bounded loop rather than a cliff a big contest walks off.
+const PG_ID_CHUNK = 10000;
+
+/**
+ * Resolves banned / deleted / vanished accounts against the ENGAGER set rather than
+ * the other way round. The banned-or-deleted population is ~1.35M rows and must
+ * never be pushed into ClickHouse; the engagers on a contest number in the
+ * thousands, so the small side is the one that travels.
+ *
+ * An id with no `User` row at all is a hard-deleted account and never counts.
+ */
+export async function resolveBannedEngagers(engagerIds: number[]) {
+  if (!engagerIds.length) return [] as number[];
+
+  const disqualified: number[] = [];
+  for (let i = 0; i < engagerIds.length; i += PG_ID_CHUNK) {
+    const chunk = engagerIds.slice(i, i + PG_ID_CHUNK);
+    const rows = await dbRead.$queryRaw<{ id: number; gone: boolean }[]>`
+      SELECT ids.id, (u.id IS NULL OR u."bannedAt" IS NOT NULL OR u."deletedAt" IS NOT NULL) AS "gone"
+      FROM unnest(ARRAY[${Prisma.join(chunk)}]::int[]) AS ids(id)
+      LEFT JOIN "User" u ON u.id = ids.id
+    `;
+    for (const row of rows) if (row.gone) disqualified.push(row.id);
+  }
+
+  return disqualified;
+}
+
+/**
+ * Distinct users who engaged through a ClickHouse signal, already narrowed by the
+ * age gate and the base exclusions. Postgres signals do not need this — they join
+ * `User` inline — so only the three ClickHouse signals pay the round trip.
+ */
+export async function collectChEngagers(
+  sources: string[],
+  base: { userIdThreshold: number; baseDisqualifiedIds: number[] }
+) {
+  const disqualified = base.baseDisqualifiedIds.length ? intList(base.baseDisqualifiedIds) : '0';
+
+  const results = await withSpan('contest-score.engagers', () => {
+    const limit = pLimit(CH_CONCURRENCY);
+    return Promise.all(
+      sources.map((source) =>
+        limit(() =>
+          clickhouse!.$query<{ userId: number }>(`
+            SELECT DISTINCT userId
+            FROM (${source}) AS s
+            WHERE userId <= ${base.userIdThreshold} AND userId NOT IN (${disqualified})
+          `)
+        )
+      )
+    );
+  });
+
+  return [...new Set(results.flat().map((r) => Number(r.userId)))];
+}
+
+// ---------------------------------------------------------------------------
+// Entries
+// ---------------------------------------------------------------------------
+
+export type EntryRow = {
+  collectionItemId: number;
+  modelId: number;
+  modelName: string;
+  creatorId: number;
+  creatorUsername: string | null;
+  addedById: number | null;
+  tagId: number | null;
+  tagName: string | null;
+  status: string;
+  modelStatus: string;
+  modelDeleted: boolean;
+  modelAvailability: string;
+};
+
+export type EntryImage = {
+  id: number;
+  url: string;
+  nsfwLevel: number;
+  type: string;
+  width: number | null;
+  height: number | null;
+};
+
+/** Every id reaching raw SQL passes through here, so nothing downstream has to trust a caller. */
+export function intList(values: number[]) {
+  for (const value of values)
+    if (!Number.isInteger(value)) throw new ContestScoringError('Expected integer identifiers');
+  return values.join(',');
+}
+
+export type WindowInput = {
+  collectionId: number;
+  start?: Date;
+  end?: Date;
+  tagIds?: number[];
+  statuses?: CollectionItemStatus[];
+};
+
+export async function loadEntries(input: WindowInput) {
+  const { collectionId, tagIds } = input;
+  const statuses = input.statuses ?? DEFAULT_STATUSES;
+
+  const items = await withSpan(
+    'contest-score.entries',
+    () =>
+      dbRead.$queryRaw<EntryRow[]>`
+      SELECT
+        ci.id                     AS "collectionItemId",
+        ci."modelId"              AS "modelId",
+        m.name                    AS "modelName",
+        m."userId"                AS "creatorId",
+        u.username                AS "creatorUsername",
+        ci."addedById"            AS "addedById",
+        ci."tagId"                AS "tagId",
+        t.name                    AS "tagName",
+        ci.status::text           AS "status",
+        m.status::text            AS "modelStatus",
+        m."deletedAt" IS NOT NULL AS "modelDeleted",
+        m.availability::text      AS "modelAvailability"
+      FROM "CollectionItem" ci
+      JOIN "Model" m ON m.id = ci."modelId"
+      LEFT JOIN "User" u ON u.id = m."userId"
+      LEFT JOIN "Tag" t ON t.id = ci."tagId"
+      WHERE ci."collectionId" = ${collectionId}
+        AND ci."modelId" IS NOT NULL
+        AND ci.status = ANY(ARRAY[${Prisma.join(statuses)}]::"CollectionItemStatus"[])
+        ${tagIds?.length ? Prisma.sql`AND ci."tagId" IN (${Prisma.join(tagIds)})` : Prisma.empty}
+      ORDER BY ci.id
+      LIMIT ${MAX_ENTRIES + 1}
+    `
+  );
+
+  return { entries: items.slice(0, MAX_ENTRIES), truncated: items.length > MAX_ENTRIES };
+}
+
+/**
+ * True per-category entry counts, unaffected by the cap. `loadEntries` cuts on
+ * `ci.id`, so truncation drops the NEWEST entries and does so unevenly across
+ * categories; without this the surviving rows would render a complete-looking 1..N
+ * ranking whose normalization maxima came from survivors alone. Predicates are kept
+ * in step with `loadEntries` — a divergence here would understate what was lost.
+ */
+export async function loadCategoryTotals(input: WindowInput) {
+  const { collectionId, tagIds } = input;
+  const statuses = input.statuses ?? DEFAULT_STATUSES;
+
+  const rows = await withSpan(
+    'contest-score.category-totals',
+    () =>
+      dbRead.$queryRaw<{ tagId: number | null; total: number }[]>`
+      SELECT ci."tagId" AS "tagId", count(*)::int AS "total"
+      FROM "CollectionItem" ci
+      JOIN "Model" m ON m.id = ci."modelId"
+      WHERE ci."collectionId" = ${collectionId}
+        AND ci."modelId" IS NOT NULL
+        AND ci.status = ANY(ARRAY[${Prisma.join(statuses)}]::"CollectionItemStatus"[])
+        ${tagIds?.length ? Prisma.sql`AND ci."tagId" IN (${Prisma.join(tagIds)})` : Prisma.empty}
+      GROUP BY ci."tagId"
+    `
+  );
+
+  return new Map(rows.map((row) => [row.tagId, Number(row.total)]));
+}
+
+/** One representative image per model — the creator's own showcase post, in their order. */
+export async function loadEntryImages(modelIds: number[]) {
+  const images = new Map<number, EntryImage>();
+  if (!modelIds.length) return images;
+
+  const rows = await withSpan(
+    'contest-score.entry-images',
+    () =>
+      dbRead.$queryRaw<({ modelId: number } & EntryImage)[]>`
+      SELECT DISTINCT ON (mv."modelId")
+        mv."modelId"  AS "modelId",
+        i.id          AS "id",
+        i.url         AS "url",
+        i."nsfwLevel" AS "nsfwLevel",
+        i.type::text  AS "type",
+        i.width       AS "width",
+        i.height      AS "height"
+      FROM "ModelVersion" mv
+      JOIN "Model" m ON m.id = mv."modelId"
+      JOIN "Post" p ON p."modelVersionId" = mv.id AND p."userId" = m."userId"
+      JOIN "Image" i ON i."postId" = p.id
+      WHERE mv."modelId" IN (${Prisma.join(modelIds)})
+        AND p."publishedAt" IS NOT NULL
+        AND p."publishedAt" <= ${nowUtc}
+        AND i.ingestion <> 'Blocked'::"ImageIngestionStatus"
+      ORDER BY mv."modelId", mv."index", p.id, i."index"
+    `
+  );
+  for (const { modelId, ...image } of rows) images.set(modelId, image);
+
+  return images;
+}
+
+// ---------------------------------------------------------------------------
+// Signals
+// ---------------------------------------------------------------------------
+
+export type SignalCount = { collectionItemId: number; rawUsers: number; qualifiedUsers: number };
+
+/**
+ * (entity, entry) pairs for the ClickHouse joins. Deliberately many-to-many in both
+ * directions: one image can credit several entered models (stacked LoRAs), and one
+ * model can be entered more than once (two categories, a resubmission,
+ * maxItemsPerUser > 1). Collapsing either direction silently zeroes an entry.
+ */
+type EntryPair = { entityId: number; entryId: number; creatorId: number; addedById: number };
+
+/**
+ * A ClickHouse-side lookup table built from a tuple literal. `values()` would read
+ * better but is not available on every deployment; arrayJoin over a tuple array is.
+ */
+function chPairTable(pairs: EntryPair[]) {
+  const tuples = pairs
+    .map((p) => `(${intList([p.entityId, p.entryId, p.creatorId, p.addedById])})`)
+    .join(',');
+  return `
+    SELECT
+      toInt64(p.1) AS entityId,
+      toInt64(p.2) AS entryId,
+      toInt64(p.3) AS creatorId,
+      toInt64(p.4) AS addedById
+    FROM (SELECT arrayJoin([${tuples}]) AS p)
+  `;
+}
+
+/**
+ * Seconds since the epoch, never a formatted string. `toDateTime('2026-07-24
+ * 00:00:00')` is parsed in the ClickHouse SERVER timezone, so a literal silently
+ * shifts the window; an integer is an absolute instant.
+ */
+const chDateTime = (d: Date) => `toDateTime(${Math.floor(d.getTime() / 1000)})`;
+
+/**
+ * Counts distinct users per ENTRY inside ClickHouse. `source` projects `userId` and
+ * `entityId`; the qualification gates are applied there too, so only two integers
+ * per entry come back.
+ */
+function chCountQuery({
+  source,
+  pairs,
+  gates,
+}: {
+  source: (entityIds: string) => string;
+  pairs: EntryPair[];
+  gates: Gates;
+}) {
+  const disqualified = gates.disqualifiedIds.length ? intList(gates.disqualifiedIds) : '0';
+  const entityIds = intList([...new Set(pairs.map((p) => p.entityId))]);
+
+  return `
+    SELECT
+      p.entryId AS entryId,
+      uniqExact(s.userId) AS rawUsers,
+      uniqExactIf(
+        s.userId,
+        s.userId <= ${gates.userIdThreshold}
+          AND s.userId != p.creatorId
+          AND (p.addedById = 0 OR s.userId != p.addedById)
+          AND s.userId NOT IN (${disqualified})
+      ) AS qualifiedUsers
+    FROM (${source(entityIds)}) AS s
+    INNER JOIN (${chPairTable(pairs)}) AS p ON s.entityId = p.entityId
+    GROUP BY entryId
+  `;
+}
+
+/**
+ * Splits pairs into calls, cutting only between ENTRIES. An entry's entities must all
+ * land in one call because uniqExact cannot be summed across chunks.
+ */
+function chunkPairsByEntry(pairs: EntryPair[]) {
+  const byEntry = new Map<number, EntryPair[]>();
+  for (const pair of pairs) {
+    const existing = byEntry.get(pair.entryId);
+    if (existing) existing.push(pair);
+    else byEntry.set(pair.entryId, [pair]);
+  }
+
+  const chunks: EntryPair[][] = [];
+  let current: EntryPair[] = [];
+  for (const group of byEntry.values()) {
+    if (current.length && current.length + group.length > CH_ENTITY_CHUNK) {
+      chunks.push(current);
+      current = [];
+    }
+    current.push(...group);
+  }
+  if (current.length) chunks.push(current);
+
+  return chunks;
+}
+
+/** Runs the chunks with bounded concurrency so a big contest cannot fan out unboundedly. */
+export async function runChCounts(
+  name: string,
+  pairs: EntryPair[],
+  gates: Gates,
+  source: (entityIds: string) => string
+): Promise<SignalCount[]> {
+  if (!pairs.length) return [];
+
+  const chunks = chunkPairsByEntry(pairs);
+
+  return withSpan(
+    `contest-score.${name}`,
+    { pairs: pairs.length, chunks: chunks.length },
+    async () => {
+      const limit = pLimit(CH_CONCURRENCY);
+      const results = await Promise.all(
+        chunks.map((chunk) =>
+          limit(() =>
+            clickhouse!.$query<{ entryId: number; rawUsers: number; qualifiedUsers: number }>(
+              chCountQuery({ source, pairs: chunk, gates })
+            )
+          )
+        )
+      );
+      return results.flat().map((row) => ({
+        collectionItemId: Number(row.entryId),
+        rawUsers: Number(row.rawUsers),
+        qualifiedUsers: Number(row.qualifiedUsers),
+      }));
+    }
+  );
+}
+
+/** The entries as a Postgres lookup table, keyed by collectionItemId. */
+function pgEntryTable(entries: EntryRow[]) {
+  const values = entries
+    .map(
+      (e) =>
+        `(${intList([e.collectionItemId, e.modelId, e.creatorId])},${
+          e.addedById === null ? 'NULL' : intList([e.addedById])
+        })`
+    )
+    .join(',');
+  return Prisma.raw(`(VALUES ${values}) AS e("entryId", "modelId", "creatorId", "addedById")`);
+}
+
+/** The qualification gate, identical across every signal. */
+function pgQualified(userColumn: string, userAlias: string, gates: BaseGates) {
+  const disqualified = gates.baseDisqualifiedIds.length ? intList(gates.baseDisqualifiedIds) : '-1';
+  // Postgres can see the ban columns directly, so the engager round trip the
+  // ClickHouse signals need is unnecessary here — the predicate is the same one.
+  return Prisma.raw(`
+    ${userColumn} <> e."creatorId"
+    AND (e."addedById" IS NULL OR ${userColumn} <> e."addedById")
+    AND ${userColumn} <= ${gates.userIdThreshold}
+    AND NOT (${userColumn} = ANY(ARRAY[${disqualified}]::int[]))
+    AND ${userAlias}.id IS NOT NULL
+    AND ${userAlias}."bannedAt" IS NULL
+    AND ${userAlias}."deletedAt" IS NULL
+  `);
+}
+
+/**
+ * The entries' on-site images, windowed on PUBLICATION. Publication is the
+ * contest-meaningful event — an already-existing model can be entered, so filtering
+ * on image creation would credit or drop the wrong work. Scheduled posts carry a
+ * future `publishedAt` and are visible to nobody, hence the `<= NOW()`.
+ */
+export async function loadImagePairs(
+  entries: EntryRow[],
+  versionPairs: EntryPair[],
+  window: ResolvedWindow
+) {
+  return withSpan(
+    'contest-score.image-pairs',
+    () =>
+      dbRead.$queryRaw<{ entryId: number; imageId: number }[]>`
+      SELECT DISTINCT e."entryId" AS "entryId", i.id AS "imageId"
+      FROM ${pgEntryTable(entries)}
+      JOIN ${pgVersionTable(versionPairs)} ON v."entryId" = e."entryId"
+      JOIN "ImageResourceNew" ir ON ir."modelVersionId" = v."versionId"
+      JOIN "Image" i ON i.id = ir."imageId"
+      JOIN "Post" p ON p.id = i."postId"
+      WHERE p."publishedAt" IS NOT NULL
+        AND p."publishedAt" <= ${nowUtc}
+        AND p."publishedAt" >= ${utc(window.start)}
+        AND p."publishedAt" < ${utc(window.effectiveEnd)}
+        AND i.ingestion <> 'Blocked'::"ImageIngestionStatus"
+      ORDER BY "entryId", "imageId"
+    `
+  );
+}
+
+export async function countImageAuthors(
+  entries: EntryRow[],
+  versionPairs: EntryPair[],
+  window: ResolvedWindow,
+  gates: BaseGates
+) {
+  return withSpan(
+    'contest-score.image-authors',
+    () =>
+      dbRead.$queryRaw<SignalCount[]>`
+      SELECT
+        e."entryId"                     AS "collectionItemId",
+        count(DISTINCT i."userId")::int AS "rawUsers",
+        count(DISTINCT i."userId") FILTER (WHERE ${pgQualified('i."userId"', 'au', gates)})::int
+                                        AS "qualifiedUsers"
+      FROM ${pgEntryTable(entries)}
+      JOIN ${pgVersionTable(versionPairs)} ON v."entryId" = e."entryId"
+      JOIN "ImageResourceNew" ir ON ir."modelVersionId" = v."versionId"
+      JOIN "Image" i ON i.id = ir."imageId"
+      JOIN "Post" p ON p.id = i."postId"
+      LEFT JOIN "User" au ON au.id = i."userId"
+      WHERE p."publishedAt" IS NOT NULL
+        AND p."publishedAt" <= ${nowUtc}
+        AND p."publishedAt" >= ${utc(window.start)}
+        AND p."publishedAt" < ${utc(window.effectiveEnd)}
+        AND i.ingestion <> 'Blocked'::"ImageIngestionStatus"
+      GROUP BY e."entryId"
+    `
+  );
+}
+
+/**
+ * The only signal that stays MODEL-level. A collect targets the model, never a
+ * version, so there is nothing to scope it to; the window filter is all it gets.
+ */
+export async function countCollectors(
+  entries: EntryRow[],
+  window: ResolvedWindow,
+  gates: BaseGates,
+  collectionId: number
+) {
+  return withSpan(
+    'contest-score.collectors',
+    () =>
+      dbRead.$queryRaw<SignalCount[]>`
+      SELECT
+        e."entryId"                         AS "collectionItemId",
+        count(DISTINCT ci."addedById")::int AS "rawUsers",
+        count(DISTINCT ci."addedById") FILTER (WHERE ${pgQualified(
+          'ci."addedById"',
+          'cu',
+          gates
+        )})::int
+                                            AS "qualifiedUsers"
+      FROM ${pgEntryTable(entries)}
+      JOIN "CollectionItem" ci ON ci."modelId" = e."modelId"
+      LEFT JOIN "User" cu ON cu.id = ci."addedById"
+      WHERE ci."collectionId" <> ${collectionId}
+        AND ci."addedById" IS NOT NULL
+        AND ci."createdAt" >= ${utc(window.start)}
+        AND ci."createdAt" < ${utc(window.effectiveEnd)}
+      GROUP BY e."entryId"
+    `
+  );
+}
+
+/**
+ * The versions that actually represent an entry: created inside the CONTEST window,
+ * publicly published, and — where the contest names any — built on one of its base
+ * models.
+ *
+ * Contest rules let an already-existing model enter with a new version, so counting
+ * every version of the model credits an entry with traffic its contest work never
+ * earned — a fifteen-month-old sibling version can carry an entry to first place.
+ *
+ * Deliberately NOT "the latest version": a creator who iterates during the contest
+ * has every in-window version count toward the same entry.
+ *
+ * `contestStart`/`contestEnd`, never the display window: a moderator narrowing the
+ * date pickers to inspect one day must not thereby strip every entry of its
+ * qualifying version and declare the whole contest ineligible.
+ */
+export async function loadQualifyingVersions(
+  entries: EntryRow[],
+  window: ResolvedWindow,
+  baseModels: string[]
+) {
+  const versions = await withSpan(
+    'contest-score.qualifying-versions',
+    () =>
+      dbRead.$queryRaw<{ id: number; modelId: number }[]>`
+      SELECT mv.id AS "id", mv."modelId" AS "modelId"
+      FROM "ModelVersion" mv
+      WHERE mv."modelId" IN (${Prisma.join(entries.map((e) => e.modelId))})
+        AND mv."createdAt" >= ${utc(window.contestStart)}
+        AND mv."createdAt" < ${utc(window.contestEnd)}
+        AND mv.status = ${ModelStatus.Published}::"ModelStatus"
+        ${
+          baseModels.length
+            ? Prisma.sql`AND mv."baseModel" IN (${Prisma.join(baseModels)})`
+            : Prisma.empty
+        }
+    `
+  );
+
+  const byModel = new Map<number, EntryRow[]>();
+  for (const entry of entries) {
+    const existing = byModel.get(entry.modelId);
+    if (existing) existing.push(entry);
+    else byModel.set(entry.modelId, [entry]);
+  }
+
+  const pairs: EntryPair[] = [];
+  const countByEntry = new Map<number, number>(entries.map((e) => [e.collectionItemId, 0]));
+  for (const version of versions)
+    for (const entry of byModel.get(version.modelId) ?? []) {
+      pairs.push({
+        entityId: version.id,
+        entryId: entry.collectionItemId,
+        creatorId: entry.creatorId,
+        addedById: entry.addedById ?? 0,
+      });
+      countByEntry.set(entry.collectionItemId, (countByEntry.get(entry.collectionItemId) ?? 0) + 1);
+    }
+
+  return { pairs, countByEntry };
+}
+
+/**
+ * The qualifying versions as a Postgres lookup table, so the image-derived signals
+ * resolve their images through exactly the version set the ClickHouse signals count.
+ *
+ * An empty set renders as a well-typed table of no rows rather than an empty `VALUES`
+ * list, which is a syntax error. The guard belongs here: every call site joins against
+ * this, so relying on each of them to remember is one edit away from a 500 on a
+ * contest where nothing qualifies.
+ */
+function pgVersionTable(pairs: EntryPair[]) {
+  if (!pairs.length)
+    return Prisma.raw(`(SELECT NULL::int AS "entryId", NULL::int AS "versionId" WHERE false) AS v`);
+
+  const values = pairs.map((p) => `(${intList([p.entryId, p.entityId])})`).join(',');
+  return Prisma.raw(`(VALUES ${values}) AS v("entryId", "versionId")`);
+}
+
+export function toImagePairs(rows: { entryId: number; imageId: number }[], entries: EntryRow[]) {
+  const byEntry = new Map(entries.map((e) => [e.collectionItemId, e]));
+  const pairs: EntryPair[] = [];
+  for (const row of rows) {
+    const entry = byEntry.get(Number(row.entryId));
+    if (!entry) continue;
+    pairs.push({
+      entityId: Number(row.imageId),
+      entryId: entry.collectionItemId,
+      creatorId: entry.creatorId,
+      addedById: entry.addedById ?? 0,
+    });
+  }
+  return pairs;
+}
+
+export function requireClickhouse() {
+  if (!clickhouse)
+    throw new ContestScoringError('ClickHouse is not configured in this environment');
+  return clickhouse;
+}
+
+type PerCreatorRow = {
+  userId: number;
+  creatorId: number;
+  events: number;
+  entries: number;
+  ips: string[];
+};
+
+/** Same entry-boundary chunking as the scoring path — the query-text ceiling is identical. */
+export async function runChPerCreator(
+  name: string,
+  pairs: EntryPair[],
+  source: (entityIds: string) => string
+): Promise<PerCreatorRow[]> {
+  if (!pairs.length) return [];
+
+  return withSpan(`contest-score.${name}`, { pairs: pairs.length }, async () => {
+    const limit = pLimit(CH_CONCURRENCY);
+    const results = await Promise.all(
+      chunkPairsByEntry(pairs).map((chunk) =>
+        limit(() => {
+          const entityIds = intList([...new Set(chunk.map((p) => p.entityId))]);
+          return clickhouse!.$query<PerCreatorRow>(`
+            SELECT
+              s.userId AS userId,
+              p.creatorId AS creatorId,
+              count() AS events,
+              uniqExact(p.entryId) AS entries,
+              groupUniqArray(s.ip) AS ips
+            FROM (${source(entityIds)}) AS s
+            INNER JOIN (${chPairTable(chunk)}) AS p ON s.entityId = p.entityId
+            GROUP BY userId, creatorId
+          `);
+        })
+      )
+    );
+    return results.flat().map((row) => ({
+      userId: Number(row.userId),
+      creatorId: Number(row.creatorId),
+      events: Number(row.events),
+      entries: Number(row.entries),
+      ips: row.ips ?? [],
+    }));
+  });
+}
+
+/**
+ * The three ClickHouse signal sources, bound to a window. Each takes the entity id
+ * list and returns a projection of `userId` + `entityId`; the qualification gates are
+ * applied by `chCountQuery` around them.
+ */
+export function chSignalSources(window: ResolvedWindow) {
+  return {
+    reactors: (ids: string) => `
+        SELECT toInt64(userId) AS userId, toInt64(entityId) AS entityId
+        FROM reactions
+        WHERE type = 'Image_Create'
+          AND entityId IN (${ids})
+          AND time >= ${chDateTime(window.start)} AND time < ${chDateTime(window.effectiveEnd)}
+          AND userId != 0
+      `,
+    downloaders: (ids: string) => `
+        SELECT toInt64(userId) AS userId, toInt64(modelVersionId) AS entityId
+        FROM modelVersionEvents
+        WHERE type = 'Download'
+          AND modelVersionId IN (${ids})
+          AND time >= ${chDateTime(window.start)} AND time < ${chDateTime(window.effectiveEnd)}
+          AND userId != 0
+      `,
+    // Straight off orchestration.jobs, NOT default.daily_user_resource: that view
+    // only ingests jobType IN ('TextToImage','TextToImageV2','Comfy'), so every
+    // newer engine (ComfyImageGen, AnimaComfy, StableDiffusionCpp, …) is missing
+    // from it and whole ecosystems read as zero generations.
+    generators: (ids: string) => `
+        SELECT toInt64(userId) AS userId, toInt64(resource) AS entityId
+        FROM orchestration.jobs
+        ARRAY JOIN resourcesUsed AS resource
+        WHERE resource IN (${ids})
+          AND createdAt >= ${chDateTime(window.start)}
+          AND createdAt < ${chDateTime(window.effectiveEnd)}
+          AND userId != 0
+      `,
+  };
+}
+
+/**
+ * The candidate-report sources. Same events as the download and reaction signals but
+ * carrying `ip`, which the scoring path deliberately never selects — this is the one
+ * surface that legitimately reports user ids.
+ */
+export function chCandidateSources(window: ResolvedWindow) {
+  return {
+    downloads: (ids: string) => `
+      SELECT toInt64(userId) AS userId, toInt64(modelVersionId) AS entityId, ip
+      FROM modelVersionEvents
+      WHERE type = 'Download'
+        AND modelVersionId IN (${ids})
+        AND time >= ${chDateTime(window.start)} AND time < ${chDateTime(window.effectiveEnd)}
+        AND userId != 0
+    `,
+    reactions: (ids: string) => `
+      SELECT toInt64(userId) AS userId, toInt64(entityId) AS entityId, ip
+      FROM reactions
+      WHERE type = 'Image_Create'
+        AND entityId IN (${ids})
+        AND time >= ${chDateTime(window.start)} AND time < ${chDateTime(window.effectiveEnd)}
+        AND userId != 0
+    `,
+  };
+}

--- a/src/server/services/contest-score.service.ts
+++ b/src/server/services/contest-score.service.ts
@@ -80,7 +80,11 @@ const SCORE_CACHE_TTL = 60 * 15;
 // Entities per ClickHouse call. Chunks are cut along ENTRY boundaries, never entity
 // ones: uniqExact cannot be summed across chunks, so every entity belonging to an
 // entry has to be counted in the same call.
-const CH_ENTITY_CHUNK = 20000;
+//
+// The ceiling is the query TEXT, not the row count: `chPairTable` inlines every pair
+// as a tuple literal, and the cluster caps a query at 262,144 bytes / 50,000 AST
+// elements. The measured limit is ~8,000 four-element tuples; 5,000 leaves headroom.
+const CH_ENTITY_CHUNK = 5000;
 // Ceiling on the reactor lookup table, which scales with images published in the
 // window rather than with entry count. Past it the run is flagged truncated.
 const MAX_IMAGE_PAIRS = 200000;
@@ -561,17 +565,10 @@ function chCountQuery({
 }
 
 /**
- * Splits pairs into calls, cutting only between entries, and runs them with bounded
- * concurrency so a large contest cannot open an unbounded fan of CH queries.
+ * Splits pairs into calls, cutting only between ENTRIES. An entry's entities must all
+ * land in one call because uniqExact cannot be summed across chunks.
  */
-async function runChCounts(
-  name: string,
-  pairs: EntryPair[],
-  gates: Gates,
-  source: (entityIds: string) => string
-): Promise<SignalCount[]> {
-  if (!pairs.length) return [];
-
+function chunkPairsByEntry(pairs: EntryPair[]) {
   const byEntry = new Map<number, EntryPair[]>();
   for (const pair of pairs) {
     const existing = byEntry.get(pair.entryId);
@@ -589,6 +586,20 @@ async function runChCounts(
     current.push(...group);
   }
   if (current.length) chunks.push(current);
+
+  return chunks;
+}
+
+/** Runs the chunks with bounded concurrency so a big contest cannot fan out unboundedly. */
+async function runChCounts(
+  name: string,
+  pairs: EntryPair[],
+  gates: Gates,
+  source: (entityIds: string) => string
+): Promise<SignalCount[]> {
+  if (!pairs.length) return [];
+
+  const chunks = chunkPairsByEntry(pairs);
 
   return withSpan(
     `contest-score.${name}`,
@@ -794,6 +805,12 @@ export type ContestScoreEntry = {
   image: EntryImage | null;
   // No `normalized` here: alongside `score`, five normalized values and five scores
   // solve for the five weights. The UI never rendered it.
+  //
+  // ⚠️ Dropping it does NOT make this payload weight-safe. Normalization is
+  // max-within-category, so a caller holding every entry in a category can
+  // reconstruct each maximum from `qualified` and solve for the weights from
+  // `score`. `moderatorProcedure` on every procedure is what actually closes the
+  // oracle. Do not relax that gate on the belief that the payload is safe alone.
   signals: Record<Signal, { raw: number; qualified: number }>;
   rawTotal: number;
   qualifiedTotal: number;
@@ -1120,6 +1137,12 @@ export async function getCommunityScore(input: GetCommunityScoreInput) {
  * Engagers on this contest worth a look: accounts acting from IPs shared by many
  * contest engagers, or whose contest engagement concentrates on a single creator.
  * Evidence only — never an automatic disqualification.
+ *
+ * Unlike the scoring path this legitimately returns user ids — that IS the report —
+ * so it aggregates per (user, creator) in ClickHouse and merges in Node. The
+ * intermediate is bounded by the engager ceiling, and the response by `limit`.
+ * Farm-IP peer counts have to be global, so they are built from the merged set
+ * rather than per chunk, where they would undercount.
  */
 export async function getContestCandidates(input: GetContestCandidatesInput) {
   try {
@@ -1135,102 +1158,155 @@ export async function getContestCandidates(input: GetContestCandidatesInput) {
     const imagePairs = toImagePairs(await loadImagePairs(entries, window), entries);
 
     // Reactions and downloads are the engagement events that carry an IP — the same
-    // farm-IP signal `reaction-abuse` uses, scoped to this contest. Everything below
-    // is aggregated in ClickHouse; only the capped candidate rows come back.
-    const imageIds = intList([...new Set(imagePairs.map((p) => p.entityId))]);
-    const modelIds = intList([...new Set(entries.map((e) => e.modelId))]);
+    // farm-IP signal `reaction-abuse` uses, scoped to this contest.
+    const perCreator = (
+      await Promise.all([
+        runChPerCreator(
+          'candidates.downloads',
+          modelPairs(entries),
+          (ids) => `
+          SELECT toInt64(userId) AS userId, toInt64(modelId) AS entityId, ip
+          FROM modelVersionEvents
+          WHERE type = 'Download'
+            AND modelId IN (${ids})
+            AND time >= ${chDateTime(window.start)} AND time < ${chDateTime(window.effectiveEnd)}
+            AND userId != 0
+        `
+        ),
+        runChPerCreator(
+          'candidates.reactions',
+          imagePairs,
+          (ids) => `
+          SELECT toInt64(userId) AS userId, toInt64(entityId) AS entityId, ip
+          FROM reactions
+          WHERE type = 'Image_Create'
+            AND entityId IN (${ids})
+            AND time >= ${chDateTime(window.start)} AND time < ${chDateTime(window.effectiveEnd)}
+            AND userId != 0
+        `
+        ),
+      ])
+    ).flat();
 
-    const downloadEvents = `
-      SELECT s.userId AS userId, p.entryId AS entryId, p.creatorId AS creatorId, s.ip AS ip
-      FROM (
-        SELECT toInt64(userId) AS userId, toInt64(modelId) AS entityId, ip
-        FROM modelVersionEvents
-        WHERE type = 'Download'
-          AND modelId IN (${modelIds || '0'})
-          AND time >= ${chDateTime(window.start)} AND time < ${chDateTime(window.effectiveEnd)}
-          AND userId != 0
-      ) AS s
-      INNER JOIN (${chPairTable(modelPairs(entries))}) AS p ON s.entityId = p.entityId
-    `;
-    const reactionEvents = imagePairs.length
-      ? `
-      SELECT s.userId AS userId, p.entryId AS entryId, p.creatorId AS creatorId, s.ip AS ip
-      FROM (
-        SELECT toInt64(userId) AS userId, toInt64(entityId) AS entityId, ip
-        FROM reactions
-        WHERE type = 'Image_Create'
-          AND entityId IN (${imageIds})
-          AND time >= ${chDateTime(window.start)} AND time < ${chDateTime(window.effectiveEnd)}
-          AND userId != 0
-      ) AS s
-      INNER JOIN (${chPairTable(imagePairs)}) AS p ON s.entityId = p.entityId
-    `
-      : null;
-
-    const events = [downloadEvents, reactionEvents].filter(Boolean).join('\nUNION ALL\n');
-
-    const rows = await withSpan('contest-score.candidates', () =>
-      clickhouse!.$query<{
-        userId: number;
-        events: number;
-        entriesTouched: number;
-        distinctCreators: number;
-        topCreator: number;
-        toTopCreator: number;
-        farmIpsUsed: number;
-      }>(`
-        WITH ev AS (${events}),
-             farm AS (
-               SELECT ip FROM ev WHERE ip != '' GROUP BY ip
-               HAVING uniqExact(userId) >= ${Number(config.farmIp.minPeers)}
-             ),
-             perCreator AS (
-               SELECT
-                 userId,
-                 creatorId,
-                 count() AS creatorEvents,
-                 uniqExact(entryId) AS creatorEntries,
-                 groupUniqArrayIf(ip, ip IN (SELECT ip FROM farm)) AS creatorFarmIps
-               FROM ev
-               GROUP BY userId, creatorId
-             )
-        SELECT
-          userId,
-          sum(creatorEvents) AS events,
-          sum(creatorEntries) AS entriesTouched,
-          count() AS distinctCreators,
-          argMax(creatorId, creatorEvents) AS topCreator,
-          max(creatorEvents) AS toTopCreator,
-          length(arrayDistinct(arrayFlatten(groupArray(creatorFarmIps)))) AS farmIpsUsed
-        FROM perCreator
-        GROUP BY userId
-        HAVING farmIpsUsed > 0
-            OR (entriesTouched >= ${Number(config.farmIp.minEntries)} AND distinctCreators = 1)
-        ORDER BY toTopCreator / events DESC, farmIpsUsed DESC, events DESC
-        LIMIT ${Number(limit)}
-      `)
+    const usersPerIp = new Map<string, Set<number>>();
+    for (const row of perCreator)
+      for (const ip of row.ips) {
+        if (!ip) continue;
+        if (!usersPerIp.has(ip)) usersPerIp.set(ip, new Set());
+        usersPerIp.get(ip)!.add(row.userId);
+      }
+    const farmIps = new Set(
+      [...usersPerIp.entries()]
+        .filter(([, users]) => users.size >= config.farmIp.minPeers)
+        .map(([ip]) => ip)
     );
 
-    return {
-      collectionId: input.collectionId,
-      count: rows.length,
-      candidates: rows.map((row) => ({
-        userId: Number(row.userId),
-        events: Number(row.events),
-        entriesTouched: Number(row.entriesTouched),
-        distinctCreators: Number(row.distinctCreators),
-        topCreator: Number(row.topCreator),
-        toTopCreator: Number(row.toTopCreator),
-        topCreatorConcentration: +(Number(row.toTopCreator) / Number(row.events)).toFixed(2),
-        farmIpsUsed: Number(row.farmIpsUsed),
-        // Reported so a reviewer can tell a too-young account from an excluded one
-        // without re-deriving the threshold themselves.
-        newAccount: Number(row.userId) > baseGates.userIdThreshold,
-      })),
+    type Candidate = {
+      events: number;
+      entriesTouched: number;
+      creators: Map<number, number>;
+      farmIps: Set<string>;
     };
+    const byUser = new Map<number, Candidate>();
+    for (const row of perCreator) {
+      let candidate = byUser.get(row.userId);
+      if (!candidate) {
+        candidate = { events: 0, entriesTouched: 0, creators: new Map(), farmIps: new Set() };
+        byUser.set(row.userId, candidate);
+      }
+      candidate.events += row.events;
+      candidate.entriesTouched += row.entries;
+      candidate.creators.set(
+        row.creatorId,
+        (candidate.creators.get(row.creatorId) ?? 0) + row.events
+      );
+      for (const ip of row.ips) if (farmIps.has(ip)) candidate.farmIps.add(ip);
+    }
+
+    const rows = [...byUser.entries()]
+      .map(([userId, candidate]) => {
+        const [topCreator, toTopCreator] = [...candidate.creators.entries()].sort(
+          (a, b) => b[1] - a[1]
+        )[0] ?? [0, 0];
+        return {
+          userId,
+          events: candidate.events,
+          entriesTouched: candidate.entriesTouched,
+          distinctCreators: candidate.creators.size,
+          topCreator,
+          toTopCreator,
+          topCreatorConcentration: +(toTopCreator / candidate.events).toFixed(2),
+          farmIpsUsed: candidate.farmIps.size,
+          // Reported so a reviewer can tell a too-young account from an excluded one
+          // without re-deriving the threshold themselves.
+          newAccount: userId > baseGates.userIdThreshold,
+        };
+      })
+      .filter(
+        (row) =>
+          row.farmIpsUsed > 0 ||
+          (row.entriesTouched >= config.farmIp.minEntries && row.distinctCreators === 1)
+      )
+      // Concentration on one creator is the discriminating signal; farm IPs alone
+      // catch shared/CGNAT addresses too, so they only break ties.
+      .sort(
+        (a, b) =>
+          b.topCreatorConcentration - a.topCreatorConcentration ||
+          b.farmIpsUsed - a.farmIpsUsed ||
+          b.events - a.events
+      )
+      .slice(0, limit);
+
+    return { collectionId: input.collectionId, count: rows.length, candidates: rows };
   } catch (e) {
     return sanitizeError(input.collectionId, e);
   }
+}
+
+type PerCreatorRow = {
+  userId: number;
+  creatorId: number;
+  events: number;
+  entries: number;
+  ips: string[];
+};
+
+/** Same entry-boundary chunking as the scoring path — the query-text ceiling is identical. */
+async function runChPerCreator(
+  name: string,
+  pairs: EntryPair[],
+  source: (entityIds: string) => string
+): Promise<PerCreatorRow[]> {
+  if (!pairs.length) return [];
+
+  return withSpan(`contest-score.${name}`, { pairs: pairs.length }, async () => {
+    const limit = pLimit(CH_CONCURRENCY);
+    const results = await Promise.all(
+      chunkPairsByEntry(pairs).map((chunk) =>
+        limit(() => {
+          const entityIds = intList([...new Set(chunk.map((p) => p.entityId))]);
+          return clickhouse!.$query<PerCreatorRow>(`
+            SELECT
+              s.userId AS userId,
+              p.creatorId AS creatorId,
+              count() AS events,
+              uniqExact(p.entryId) AS entries,
+              groupUniqArray(s.ip) AS ips
+            FROM (${source(entityIds)}) AS s
+            INNER JOIN (${chPairTable(chunk)}) AS p ON s.entityId = p.entityId
+            GROUP BY userId, creatorId
+          `);
+        })
+      )
+    );
+    return results.flat().map((row) => ({
+      userId: Number(row.userId),
+      creatorId: Number(row.creatorId),
+      events: Number(row.events),
+      entries: Number(row.entries),
+      ips: row.ips ?? [],
+    }));
+  });
 }
 
 // ---------------------------------------------------------------------------
@@ -1238,9 +1314,26 @@ export async function getContestCandidates(input: GetContestCandidatesInput) {
 // ---------------------------------------------------------------------------
 
 /**
+ * Which deployment produced a snapshot, derived from the ENVIRONMENT and never from
+ * mutation input — an operator cannot forget it and a client cannot spoof it.
+ * Preview namespaces carry these vars; production carries none of them.
+ */
+function snapshotSource() {
+  if (process.env.IS_PREVIEW !== 'true' && process.env.NEXT_PUBLIC_IS_PR_PREVIEW !== 'true')
+    return null;
+  const pr = process.env.NEXT_PUBLIC_PR_NUMBER;
+  return pr ? `preview-${pr}` : 'preview';
+}
+
+/**
  * The artifact that defends a disputed prize, so it stores the RESOLVED config —
  * weights included — alongside the window, the age cutoff and the code version.
  * Weights are stripped on the wire, never in storage. No userIds are ever stored.
+ *
+ * The source marker is in the KEY as well as the value so preview rows are a prefix
+ * delete rather than a deserialize-and-filter:
+ *   contestSnapshot:<collectionId>:preview-<pr>:<ISO>
+ *   contestSnapshot:<collectionId>:<ISO>
  *
  * KeyValue keeps this migration-free for v1. A dedicated table (indexed by
  * collection, payload out of a jsonb column) is the follow-up once the shape
@@ -1251,10 +1344,15 @@ export type ContestSnapshot = {
   takenAt: string;
   takenById: number;
   takenByUsername: string | null;
+  source: string | null;
   note?: string;
   codeVersion: number;
   config: ContestScoringConfig;
   ageCutoff: string;
+  /**
+   * Diagnostic only. The threshold is cached for a week, so this can be up to that
+   * stale — it is NOT a measurement taken at snapshot time.
+   */
   ageGateBandUsers: number;
   engagerCount: number;
   partial: boolean;
@@ -1267,8 +1365,8 @@ export type ContestSnapshotSummary = Omit<ContestSnapshot, 'config' | 'score'> &
   entryCount: number;
 };
 
-const snapshotKey = (collectionId: number, takenAt: string) =>
-  `${CONTEST_SNAPSHOT_KEY_PREFIX}:${collectionId}:${takenAt}`;
+const snapshotKey = (collectionId: number, takenAt: string, source: string | null) =>
+  [CONTEST_SNAPSHOT_KEY_PREFIX, collectionId, ...(source ? [source] : []), takenAt].join(':');
 
 function toSnapshotSummary(key: string, snapshot: ContestSnapshot): ContestSnapshotSummary {
   // `config` — and therefore the weights — is dropped here. It is stored for audit,
@@ -1291,15 +1389,28 @@ export async function createContestSnapshot({
     const config = await getContestScoringConfig(window.collectionId);
     const resolved = await resolveWindow(window.collectionId, window, config);
     const audit: RunAudit = { engagerCount: 0, ageGateBandUsers: 0 };
-    const score = await computeCommunityScore(window, audit);
+
+    // Through the same lock the scoring path uses. Snapshotting is a full run, so two
+    // mods clicking the button would otherwise stack exactly what the lock exists to
+    // prevent.
+    const score = await withDistributedLock(
+      { key: `contest-score:${window.collectionId}`, ttl: 120, maxRetries: 60 },
+      () => computeCommunityScore(window, audit)
+    );
+    if (!score)
+      throw new ContestScoringError(
+        'A scoring run for this collection is already in progress. Try again shortly.'
+      );
 
     const takenAt = new Date().toISOString();
-    const key = snapshotKey(window.collectionId, takenAt);
+    const source = snapshotSource();
+    const key = snapshotKey(window.collectionId, takenAt, source);
     const snapshot: ContestSnapshot = {
       collectionId: window.collectionId,
       takenAt,
       takenById: userId,
       takenByUsername: username ?? null,
+      source,
       ...(note ? { note } : {}),
       codeVersion: CONTEST_SCORE_CODE_VERSION,
       config,
@@ -1310,9 +1421,17 @@ export async function createContestSnapshot({
       score,
     };
 
-    await dbWrite.keyValue.create({
-      data: { key, value: snapshot as unknown as Prisma.InputJsonValue },
-    });
+    try {
+      await dbWrite.keyValue.create({
+        data: { key, value: snapshot as unknown as Prisma.InputJsonValue },
+      });
+    } catch (e) {
+      // Never an upsert: overwriting a judging artifact silently is worse than
+      // failing. Only the message is softened.
+      if ((e as { code?: string }).code === 'P2002')
+        throw new ContestScoringError('A snapshot for this instant already exists.');
+      throw e;
+    }
 
     return toSnapshotSummary(key, snapshot);
   } catch (e) {
@@ -1321,12 +1440,16 @@ export async function createContestSnapshot({
 }
 
 export async function listContestSnapshots({ collectionId }: { collectionId: number }) {
-  const rows = await dbRead.keyValue.findMany({
-    where: { key: { startsWith: `${CONTEST_SNAPSHOT_KEY_PREFIX}:${collectionId}:` } },
-    select: { key: true, value: true },
-  });
+  try {
+    const rows = await dbRead.keyValue.findMany({
+      where: { key: { startsWith: `${CONTEST_SNAPSHOT_KEY_PREFIX}:${collectionId}:` } },
+      select: { key: true, value: true },
+    });
 
-  return rows
-    .map(({ key, value }) => toSnapshotSummary(key, value as unknown as ContestSnapshot))
-    .sort((a, b) => b.takenAt.localeCompare(a.takenAt));
+    return rows
+      .map(({ key, value }) => toSnapshotSummary(key, value as unknown as ContestSnapshot))
+      .sort((a, b) => b.takenAt.localeCompare(a.takenAt));
+  } catch (e) {
+    return sanitizeError(collectionId, e);
+  }
 }

--- a/src/server/services/contest-score.service.ts
+++ b/src/server/services/contest-score.service.ts
@@ -239,13 +239,16 @@ export async function setContestScoringConfig({
     // previous run already used.
     const version = Math.max(existing?.version ?? 0, globalConfig?.version ?? 0) + 1;
     const updatedAt = new Date().toISOString();
-    const next: ContestScoringConfig = {
+    // Through the READER's schema, not just the mutation input's. The input covers
+    // the editable fields; this is the row a run will actually parse, so a write that
+    // the reader would reject must fail here rather than at the next run.
+    const next = parseConfig(collectionId, {
       ...config,
       version,
       updatedById: userId,
       updatedByUsername: username ?? null,
       updatedAt,
-    };
+    });
 
     await dbWrite.$transaction([
       dbWrite.keyValue.upsert({

--- a/src/server/services/contest-score.service.ts
+++ b/src/server/services/contest-score.service.ts
@@ -22,7 +22,7 @@
 import { Prisma } from '@prisma/client';
 import pLimit from 'p-limit';
 import * as z from 'zod';
-import { CONTEST_SNAPSHOT_KEY_PREFIX, KEY_VALUE_KEYS } from '~/server/common/constants';
+import { CacheTTL, CONTEST_SNAPSHOT_KEY_PREFIX, KEY_VALUE_KEYS } from '~/server/common/constants';
 import { clickhouse } from '~/server/clickhouse/client';
 import { dbRead, dbWrite } from '~/server/db/client';
 import { dbKV } from '~/server/db/db-helpers';
@@ -211,33 +211,51 @@ type Gates = {
   disqualifiedIds: number[];
 };
 
-async function loadGates(window: ResolvedWindow): Promise<Gates> {
-  // `User.id` is autoincrement but NOT strictly monotonic with `createdAt` — at
-  // least one backdated system account exists. `max(id) WHERE createdAt <= cutoff`
-  // would let that single row drag the threshold up and wave through every account
-  // registered since. `min(id) WHERE createdAt > cutoff` minus one can only ever be
-  // too strict, which is the safe direction for an anti-cheat gate.
-  const [threshold] = await withSpan(
-    'contest-score.age-threshold',
-    () =>
-      dbRead.$queryRaw<{ threshold: number; bandUsers: number }[]>`
-      WITH t AS (
-        SELECT COALESCE(
-          (SELECT min(id) FROM "User" WHERE "createdAt" > ${window.ageCutoff}) - 1,
-          (SELECT max(id) FROM "User")
-        ) AS threshold
-      )
-      SELECT
-        t.threshold::int AS "threshold",
-        (
-          SELECT count(*)::int FROM "User" u
-          WHERE u."createdAt" <= ${window.ageCutoff} AND u.id > t.threshold
-        ) AS "bandUsers"
-      FROM t
-    `
-  );
+/**
+ * `User.id` is autoincrement but NOT strictly monotonic with `createdAt` — at least
+ * one backdated system account exists. `max(id) WHERE createdAt <= cutoff` would let
+ * that single row drag the threshold up and wave through every account registered
+ * since. `min(id) WHERE createdAt > cutoff` minus one can only ever be too strict,
+ * which is the safe direction for an anti-cheat gate.
+ *
+ * `User` has no index on `createdAt`, so the planner walks the primary key from id 1
+ * discarding ~12.7M rows: ~12s, and the single largest cost in a run. The answer is
+ * a pure function of the cutoff and effectively immutable (a later registration
+ * always has both a higher id and a later `createdAt`), so it is cached hard. An
+ * index on `User."createdAt"` would make this instant and let the cache go.
+ */
+async function loadAgeThreshold(ageCutoff: Date) {
+  const key = `${
+    REDIS_KEYS.CACHES.CONTEST_COMMUNITY_SCORE
+  }:age-threshold:${ageCutoff.toISOString()}` as RedisKeyTemplateCache;
 
-  if (threshold?.bandUsers)
+  return fetchThroughCache(
+    key,
+    () =>
+      withSpan('contest-score.age-threshold', async () => {
+        // Two statements, not one: as a single CTE the planner materializes the band
+        // count against an unknown threshold and the query takes ~50s instead of ~12s.
+        const [{ threshold }] = await dbRead.$queryRaw<{ threshold: number }[]>`
+          SELECT COALESCE(
+            (SELECT min(id) FROM "User" WHERE "createdAt" > ${ageCutoff}) - 1,
+            (SELECT max(id) FROM "User")
+          )::int AS "threshold"
+        `;
+        const [{ bandUsers }] = await dbRead.$queryRaw<{ bandUsers: number }[]>`
+          SELECT count(*)::int AS "bandUsers"
+          FROM "User" u
+          WHERE u."createdAt" <= ${ageCutoff} AND u.id > ${threshold}
+        `;
+        return { threshold, bandUsers };
+      }),
+    { ttl: CacheTTL.week, lockTTL: 60 }
+  );
+}
+
+async function loadGates(window: ResolvedWindow): Promise<Gates> {
+  const threshold = await loadAgeThreshold(window.ageCutoff);
+
+  if (threshold.bandUsers)
     console.warn(
       `[contest-score] age gate band holds ${threshold.bandUsers} user(s) registered before the cutoff but carrying an id above the threshold; they are disqualified.`
     );
@@ -423,10 +441,10 @@ function chPairTable(pairs: EntryPair[]) {
     .join(',');
   return `
     SELECT
-      toUInt64(p.1) AS entityId,
-      toUInt64(p.2) AS entryId,
-      toUInt64(p.3) AS creatorId,
-      toUInt64(p.4) AS addedById
+      toInt64(p.1) AS entityId,
+      toInt64(p.2) AS entryId,
+      toInt64(p.3) AS creatorId,
+      toInt64(p.4) AS addedById
     FROM (SELECT arrayJoin([${tuples}]) AS p)
   `;
 }
@@ -771,7 +789,7 @@ async function computeCommunityScore(input: WindowInput): Promise<ContestCommuni
       toImagePairs(imageRows, entries),
       gates,
       (ids) => `
-        SELECT userId, entityId
+        SELECT toInt64(userId) AS userId, toInt64(entityId) AS entityId
         FROM reactions
         WHERE type = 'Image_Create'
           AND entityId IN (${ids})
@@ -784,7 +802,7 @@ async function computeCommunityScore(input: WindowInput): Promise<ContestCommuni
       modelPairs(entries),
       gates,
       (ids) => `
-        SELECT userId, modelId AS entityId
+        SELECT toInt64(userId) AS userId, toInt64(modelId) AS entityId
         FROM modelVersionEvents
         WHERE type = 'Download'
           AND modelId IN (${ids})
@@ -801,7 +819,7 @@ async function computeCommunityScore(input: WindowInput): Promise<ContestCommuni
       versionPairs,
       gates,
       (ids) => `
-        SELECT userId, resource AS entityId
+        SELECT toInt64(userId) AS userId, toInt64(resource) AS entityId
         FROM orchestration.jobs
         ARRAY JOIN resourcesUsed AS resource
         WHERE resource IN (${ids})
@@ -975,7 +993,7 @@ export async function getContestCandidates(input: GetContestCandidatesInput) {
     const downloadEvents = `
       SELECT s.userId AS userId, p.entryId AS entryId, p.creatorId AS creatorId, s.ip AS ip
       FROM (
-        SELECT userId, modelId AS entityId, ip
+        SELECT toInt64(userId) AS userId, toInt64(modelId) AS entityId, ip
         FROM modelVersionEvents
         WHERE type = 'Download'
           AND modelId IN (${modelIds || '0'})
@@ -988,7 +1006,7 @@ export async function getContestCandidates(input: GetContestCandidatesInput) {
       ? `
       SELECT s.userId AS userId, p.entryId AS entryId, p.creatorId AS creatorId, s.ip AS ip
       FROM (
-        SELECT userId, entityId, ip
+        SELECT toInt64(userId) AS userId, toInt64(entityId) AS entityId, ip
         FROM reactions
         WHERE type = 'Image_Create'
           AND entityId IN (${imageIds})

--- a/src/server/services/contest-score.service.ts
+++ b/src/server/services/contest-score.service.ts
@@ -24,8 +24,7 @@
  * snapshot and stripped from every response.
  */
 
-import { Prisma } from '@prisma/client';
-import pLimit from 'p-limit';
+import type { Prisma } from '@prisma/client';
 import { v4 as uuid } from 'uuid';
 import {
   CacheTTL,
@@ -34,7 +33,6 @@ import {
   KEY_VALUE_KEYS,
 } from '~/server/common/constants';
 import { SignalMessages, SignalTopic } from '~/server/common/enums';
-import { clickhouse } from '~/server/clickhouse/client';
 import { dbRead, dbWrite } from '~/server/db/client';
 import { dbKV } from '~/server/db/db-helpers';
 import { logToAxiom } from '~/server/logging/client';
@@ -56,31 +54,50 @@ import {
   contestScoreSignals,
   contestScoringConfigSchema,
 } from '~/server/schema/contest-score.schema';
-import { fetchThroughCache } from '~/server/utils/cache-helpers';
+// Every query this service runs lives next door. The dependency is one-way: nothing in
+// `contest-score.queries` imports from here, so the shared types and the error class
+// live there rather than being passed back and forth.
+import {
+  chCandidateSources,
+  chSignalSources,
+  collectChEngagers,
+  ContestScoringError,
+  countCollectors,
+  countImageAuthors,
+  DEFAULT_STATUSES,
+  intList,
+  loadBaseGates,
+  loadCategoryTotals,
+  loadEntries,
+  loadEntryImages,
+  loadImagePairs,
+  loadQualifyingVersions,
+  requireClickhouse,
+  resolveBannedEngagers,
+  runChCounts,
+  runChPerCreator,
+  toImagePairs,
+  type ContestBoundSource,
+  type EntryImage,
+  type EntryRow,
+  type Gates,
+  type ResolvedWindow,
+  type SignalCount,
+  type WindowInput,
+} from '~/server/services/contest-score.queries';
 import { withDistributedLock } from '~/server/utils/distributed-lock';
 import { throwBadRequestError } from '~/server/utils/errorHandling';
-import { withSpan } from '~/server/utils/otel-helpers';
-import {
-  Availability,
-  CollectionItemStatus,
-  CollectionMode,
-  ModelStatus,
-} from '~/shared/utils/prisma/enums';
+import { Availability, CollectionMode } from '~/shared/utils/prisma/enums';
+import type { CollectionItemStatus } from '~/shared/utils/prisma/enums';
 import { signalClient } from '~/utils/signal-client';
 import { hashifyObject } from '~/utils/string-helpers';
 
-type Signal = ContestScoreSignal;
+// Re-exported so callers that already import these from the service keep working; the
+// definitions live next door with the queries that use them.
+export type { ResolvedWindow, ContestBoundSource } from '~/server/services/contest-score.queries';
+export { ContestScoringError } from '~/server/services/contest-score.queries';
 
-/**
- * Every timestamp column this service compares against — `User.createdAt`,
- * `Post.publishedAt`, `CollectionItem.createdAt`, `bannedAt`, `deletedAt` — is
- * `timestamp WITHOUT time zone` holding UTC. A bound `Date` arrives as `timestamptz`
- * and Postgres coerces it using the SESSION timezone, so the comparison is only
- * correct while that session happens to be UTC. Converting explicitly makes it
- * correct under any session timezone.
- */
-const utc = (d: Date) => Prisma.sql`(${d}::timestamptz AT TIME ZONE 'UTC')`;
-const nowUtc = Prisma.raw(`(NOW() AT TIME ZONE 'UTC')`);
+type Signal = ContestScoreSignal;
 
 /**
  * Comments and tips are deliberately unweighted: both are trivially launderable
@@ -94,10 +111,6 @@ export const CONTEST_SIGNAL_SOURCES: Record<Signal, string> = {
   collectors: 'Distinct users adding the model to another collection',
 };
 
-// Raised from 1000 after a past contest (collection 3991102) came in at 1138 accepted
-// items — the old ceiling was already reachable, and a category that loses entries has
-// to have its ranks withheld because the normalization maxima come from survivors.
-const MAX_ENTRIES = 5000;
 // Decimal places the UI renders a score to. Scores are carried at 4, so two rows can
 // read identically on screen while holding different ranks; entries that straddle that
 // boundary are flagged rather than silently rounded together.
@@ -112,27 +125,9 @@ const RUN_STATE_TTL = CacheTTL.hour;
 const RUN_LOCK_TTL = 600;
 const RUN_HEARTBEAT_INTERVAL = 15;
 const RUN_STALE_AFTER = 60;
-// Entities per ClickHouse call. Chunks are cut along ENTRY boundaries, never entity
-// ones: uniqExact cannot be summed across chunks, so every entity belonging to an
-// entry has to be counted in the same call.
-//
-// The ceiling is the query TEXT, not the row count: `chPairTable` inlines every pair
-// as a tuple literal, and the cluster caps a query at 262,144 bytes / 50,000 AST
-// elements. The measured limit is ~8,000 four-element tuples; 5,000 leaves headroom.
-const CH_ENTITY_CHUNK = 5000;
 // Ceiling on the reactor lookup table, which scales with images published in the
 // window rather than with entry count. Past it the run is flagged truncated.
 const MAX_IMAGE_PAIRS = 200000;
-const CH_CONCURRENCY = 4;
-const DEFAULT_STATUSES: CollectionItemStatus[] = [CollectionItemStatus.ACCEPTED];
-
-/**
- * An error whose message is safe to show the caller — a misconfiguration or a bad
- * request, never a query failure. Everything else is logged and replaced with a
- * generic message, because the ClickHouse `$query` wrapper appends the generated
- * SQL (id lists included) to the errors it throws.
- */
-export class ContestScoringError extends Error {}
 
 function safeErrorMessage(collectionId: number, e: unknown) {
   if (e instanceof ContestScoringError) return e.message;
@@ -319,39 +314,6 @@ export async function setContestScoringConfig({
 // ---------------------------------------------------------------------------
 
 /**
- * Two windows, and the difference decides prizes.
- *
- * `start`/`end` are the DISPLAY window a moderator drives from the date pickers — a
- * lens over the traffic being counted, freely narrowed to look at a single day.
- *
- * `contestStart`/`contestEnd` are the contest itself, off the collection's metadata.
- * Anything that decides ELIGIBILITY reads these: the age gate, and which versions
- * qualify. Narrowing the view must never make an entry ineligible, only quieter.
- */
-export type ResolvedWindow = {
-  start: Date;
-  end: Date;
-  /** `end` clamped to now. A contest still running is scored up to this instant. */
-  effectiveEnd: Date;
-  /** True while the contest is still open — the run is a preview, not a result. */
-  partial: boolean;
-  ageCutoff: Date;
-  contestStart: Date;
-  contestEnd: Date;
-  contestStartSource: ContestBoundSource;
-  contestEndSource: ContestBoundSource;
-  /** `Collection.metadata.baseModels` — the rule entrants were actually told. */
-  declaredBaseModels: string[];
-};
-
-/** Which field an eligibility bound came from, so a run can say so rather than imply it. */
-export type ContestBoundSource =
-  | 'submissionStartDate'
-  | 'submissionEndDate'
-  | 'endsAt'
-  | 'collectionCreatedAt';
-
-/**
  * Derived from the collection's own contest metadata, never defaulted. An absent
  * window silently becoming "all time" would switch the age gate off, which is the
  * worst way for this to fail.
@@ -467,254 +429,6 @@ function resolveBaseModels(
     : { baseModels: [], source: 'none' };
 }
 
-// ---------------------------------------------------------------------------
-// Gates
-// ---------------------------------------------------------------------------
-
-type BaseGates = {
-  userIdThreshold: number;
-  ageGateBandUsers: number;
-  baseDisqualifiedIds: number[];
-};
-
-type Gates = BaseGates & {
-  /** Base list plus the banned/deleted engagers resolved for THIS contest. */
-  disqualifiedIds: number[];
-  /** Set when the engager set blew the cap and the ban refinement was skipped. */
-  bannedRefinementSkipped: boolean;
-  engagerCount: number;
-};
-
-const DAY_MS = 24 * 60 * 60 * 1000;
-// Progressively widened until a registration is found. Civitai takes thousands of
-// signups a day, so the first bound effectively always hits; the rest exist so the
-// answer is correct rather than convenient.
-const AGE_THRESHOLD_WINDOW_DAYS = [1, 7, 30];
-
-/**
- * The lowest `User.id` registered after `cutoff`, optionally within a bounded window.
- *
- * `MATERIALIZED` is doing the work. `User` carries a PARTIAL index —
- * `User_createdAt_idx ON "User"("createdAt") WHERE "deletedAt" IS NULL` — which a
- * query omitting the `deletedAt` predicate cannot use at all; and even with the
- * predicate, `min(id)` tempts the planner into an ascending primary-key walk that
- * discards ~12.7M rows before its first match. Forcing the candidate set to
- * materialize off the index first turns that walk into a range scan.
- *
- * `deletedAt IS NULL` is safe here and the reasoning is not obvious. Skipping
- * soft-deleted rows can only RAISE `min(id)`, so the threshold can only get more
- * permissive — but every id in the resulting gap belongs, by definition, to a deleted
- * account, and deleted accounts are already disqualified by the ban/delete rule. The
- * gate is unchanged in effect.
- *
- * The one exception worth knowing: when the engager set blows `maxEngagers` that
- * ban/delete refinement is SKIPPED, and in that degraded path a soft-deleted account
- * in the gap would be admitted where the unfiltered query would have caught it via
- * the age gate. Such a run is already flagged `bannedRefinementSkipped` and told not
- * to decide a prize. The Postgres-side signals join `User` and check the ban columns
- * inline, so they are unaffected either way.
- */
-async function lowestUserIdAfter(cutoff: Date, windowDays: number | null) {
-  const upperBound =
-    windowDays === null
-      ? Prisma.empty
-      : Prisma.sql`AND u."createdAt" < ${utc(new Date(cutoff.getTime() + windowDays * DAY_MS))}`;
-
-  const [row] = await dbRead.$queryRaw<{ minId: number | null }[]>`
-    WITH candidates AS MATERIALIZED (
-      SELECT u.id
-      FROM "User" u
-      WHERE u."createdAt" > ${utc(cutoff)}
-        ${upperBound}
-        AND u."deletedAt" IS NULL
-    )
-    SELECT min(id)::int AS "minId" FROM candidates
-  `;
-
-  return row?.minId ?? null;
-}
-
-/**
- * `User.id` is autoincrement but NOT strictly monotonic with `createdAt` — at least
- * one backdated system account exists. `max(id) WHERE createdAt <= cutoff` would let
- * that single row drag the threshold up and wave through every account registered
- * since. `min(id) WHERE createdAt > cutoff` minus one can only ever be too strict,
- * which is the safe direction for an anti-cheat gate.
- *
- * The answer is a pure function of the cutoff and effectively immutable (a later
- * registration always has both a higher id and a later `createdAt`), so it stays
- * cached for a week — that is now a cheap miss rather than a painful one.
- */
-async function loadAgeThreshold(ageCutoff: Date) {
-  const key = `${
-    REDIS_KEYS.CACHES.CONTEST_COMMUNITY_SCORE
-  }:age-threshold:${ageCutoff.toISOString()}` as RedisKeyTemplateCache;
-
-  return fetchThroughCache(
-    key,
-    () =>
-      withSpan('contest-score.age-threshold', async () => {
-        let threshold: number | null = null;
-        for (const windowDays of AGE_THRESHOLD_WINDOW_DAYS) {
-          const minId = await lowestUserIdAfter(ageCutoff, windowDays);
-          if (minId !== null) {
-            threshold = minId - 1;
-            break;
-          }
-        }
-
-        if (threshold === null) {
-          // Only an UNBOUNDED miss means nobody registered after the cutoff. Treating
-          // an empty bounded window as "nobody" would COALESCE to max(id) and admit
-          // every account on the site — the same silent fail-open the age-gate bound
-          // exists to prevent.
-          const unbounded = await lowestUserIdAfter(ageCutoff, null);
-          if (unbounded !== null) threshold = unbounded - 1;
-          else {
-            const [{ maxId }] = await dbRead.$queryRaw<{ maxId: number }[]>`
-              SELECT max(id)::int AS "maxId" FROM "User"
-            `;
-            threshold = maxId;
-          }
-        }
-
-        const [{ bandUsers }] = await dbRead.$queryRaw<{ bandUsers: number }[]>`
-          SELECT count(*)::int AS "bandUsers"
-          FROM "User" u
-          WHERE u."createdAt" <= ${utc(ageCutoff)} AND u.id > ${threshold}
-        `;
-        return { threshold, bandUsers };
-      }),
-    { ttl: CacheTTL.week, lockTTL: 60 }
-  );
-}
-
-/** The always-on gates: cheap, bounded, and enough to bound the engager set. */
-async function loadBaseGates(ageCutoff: Date) {
-  const threshold = await loadAgeThreshold(ageCutoff);
-
-  if (threshold.bandUsers)
-    console.warn(
-      `[contest-score] age gate band holds ${threshold.bandUsers} user(s) registered before the cutoff but carrying an id above the threshold; they are disqualified.`
-    );
-
-  const [excluded, contestBanned] = await Promise.all([
-    withSpan('contest-score.excluded-users', () =>
-      clickhouse!.$query<{ userId: number }>(`
-        SELECT userId FROM metricExcludedUsers FINAL WHERE active = 1
-      `)
-    ),
-    withSpan(
-      'contest-score.contest-banned',
-      () =>
-        dbRead.$queryRaw<{ id: number }[]>`
-        SELECT u.id FROM "User" u WHERE u.meta ->> 'contestBanDetails' IS NOT NULL
-      `
-    ),
-  ]);
-
-  return {
-    userIdThreshold: threshold.threshold,
-    ageGateBandUsers: threshold.bandUsers,
-    baseDisqualifiedIds: [
-      ...new Set([...excluded.map((e) => Number(e.userId)), ...contestBanned.map((u) => u.id)]),
-    ].sort((a, b) => a - b),
-  };
-}
-
-// Postgres caps a statement at 65,535 bind parameters. Chunked well under it so this
-// is a bounded loop rather than a cliff a big contest walks off.
-const PG_ID_CHUNK = 10000;
-
-/**
- * Resolves banned / deleted / vanished accounts against the ENGAGER set rather than
- * the other way round. The banned-or-deleted population is ~1.35M rows and must
- * never be pushed into ClickHouse; the engagers on a contest number in the
- * thousands, so the small side is the one that travels.
- *
- * An id with no `User` row at all is a hard-deleted account and never counts.
- */
-async function resolveBannedEngagers(engagerIds: number[]) {
-  if (!engagerIds.length) return [] as number[];
-
-  const disqualified: number[] = [];
-  for (let i = 0; i < engagerIds.length; i += PG_ID_CHUNK) {
-    const chunk = engagerIds.slice(i, i + PG_ID_CHUNK);
-    const rows = await dbRead.$queryRaw<{ id: number; gone: boolean }[]>`
-      SELECT ids.id, (u.id IS NULL OR u."bannedAt" IS NOT NULL OR u."deletedAt" IS NOT NULL) AS "gone"
-      FROM unnest(ARRAY[${Prisma.join(chunk)}]::int[]) AS ids(id)
-      LEFT JOIN "User" u ON u.id = ids.id
-    `;
-    for (const row of rows) if (row.gone) disqualified.push(row.id);
-  }
-
-  return disqualified;
-}
-
-/**
- * Distinct users who engaged through a ClickHouse signal, already narrowed by the
- * age gate and the base exclusions. Postgres signals do not need this — they join
- * `User` inline — so only the three ClickHouse signals pay the round trip.
- */
-async function collectChEngagers(
-  sources: string[],
-  base: { userIdThreshold: number; baseDisqualifiedIds: number[] }
-) {
-  const disqualified = base.baseDisqualifiedIds.length ? intList(base.baseDisqualifiedIds) : '0';
-
-  const results = await withSpan('contest-score.engagers', () => {
-    const limit = pLimit(CH_CONCURRENCY);
-    return Promise.all(
-      sources.map((source) =>
-        limit(() =>
-          clickhouse!.$query<{ userId: number }>(`
-            SELECT DISTINCT userId
-            FROM (${source}) AS s
-            WHERE userId <= ${base.userIdThreshold} AND userId NOT IN (${disqualified})
-          `)
-        )
-      )
-    );
-  });
-
-  return [...new Set(results.flat().map((r) => Number(r.userId)))];
-}
-
-// ---------------------------------------------------------------------------
-// Entries
-// ---------------------------------------------------------------------------
-
-type EntryRow = {
-  collectionItemId: number;
-  modelId: number;
-  modelName: string;
-  creatorId: number;
-  creatorUsername: string | null;
-  addedById: number | null;
-  tagId: number | null;
-  tagName: string | null;
-  status: string;
-  modelStatus: string;
-  modelDeleted: boolean;
-  modelAvailability: string;
-};
-
-type EntryImage = {
-  id: number;
-  url: string;
-  nsfwLevel: number;
-  type: string;
-  width: number | null;
-  height: number | null;
-};
-
-/** Every id reaching raw SQL passes through here, so nothing downstream has to trust a caller. */
-function intList(values: number[]) {
-  for (const value of values)
-    if (!Number.isInteger(value)) throw new ContestScoringError('Expected integer identifiers');
-  return values.join(',');
-}
-
 function ineligibilityReason(
   entry: EntryRow,
   qualifyingVersions: number,
@@ -730,467 +444,6 @@ function ineligibilityReason(
       ? 'No published version was created during the contest on a qualifying base model'
       : 'No published version was created during the contest';
   return null;
-}
-
-type WindowInput = {
-  collectionId: number;
-  start?: Date;
-  end?: Date;
-  tagIds?: number[];
-  statuses?: CollectionItemStatus[];
-};
-
-async function loadEntries(input: WindowInput) {
-  const { collectionId, tagIds } = input;
-  const statuses = input.statuses ?? DEFAULT_STATUSES;
-
-  const items = await withSpan(
-    'contest-score.entries',
-    () =>
-      dbRead.$queryRaw<EntryRow[]>`
-      SELECT
-        ci.id                     AS "collectionItemId",
-        ci."modelId"              AS "modelId",
-        m.name                    AS "modelName",
-        m."userId"                AS "creatorId",
-        u.username                AS "creatorUsername",
-        ci."addedById"            AS "addedById",
-        ci."tagId"                AS "tagId",
-        t.name                    AS "tagName",
-        ci.status::text           AS "status",
-        m.status::text            AS "modelStatus",
-        m."deletedAt" IS NOT NULL AS "modelDeleted",
-        m.availability::text      AS "modelAvailability"
-      FROM "CollectionItem" ci
-      JOIN "Model" m ON m.id = ci."modelId"
-      LEFT JOIN "User" u ON u.id = m."userId"
-      LEFT JOIN "Tag" t ON t.id = ci."tagId"
-      WHERE ci."collectionId" = ${collectionId}
-        AND ci."modelId" IS NOT NULL
-        AND ci.status = ANY(ARRAY[${Prisma.join(statuses)}]::"CollectionItemStatus"[])
-        ${tagIds?.length ? Prisma.sql`AND ci."tagId" IN (${Prisma.join(tagIds)})` : Prisma.empty}
-      ORDER BY ci.id
-      LIMIT ${MAX_ENTRIES + 1}
-    `
-  );
-
-  return { entries: items.slice(0, MAX_ENTRIES), truncated: items.length > MAX_ENTRIES };
-}
-
-/**
- * True per-category entry counts, unaffected by the cap. `loadEntries` cuts on
- * `ci.id`, so truncation drops the NEWEST entries and does so unevenly across
- * categories; without this the surviving rows would render a complete-looking 1..N
- * ranking whose normalization maxima came from survivors alone. Predicates are kept
- * in step with `loadEntries` — a divergence here would understate what was lost.
- */
-async function loadCategoryTotals(input: WindowInput) {
-  const { collectionId, tagIds } = input;
-  const statuses = input.statuses ?? DEFAULT_STATUSES;
-
-  const rows = await withSpan(
-    'contest-score.category-totals',
-    () =>
-      dbRead.$queryRaw<{ tagId: number | null; total: number }[]>`
-      SELECT ci."tagId" AS "tagId", count(*)::int AS "total"
-      FROM "CollectionItem" ci
-      JOIN "Model" m ON m.id = ci."modelId"
-      WHERE ci."collectionId" = ${collectionId}
-        AND ci."modelId" IS NOT NULL
-        AND ci.status = ANY(ARRAY[${Prisma.join(statuses)}]::"CollectionItemStatus"[])
-        ${tagIds?.length ? Prisma.sql`AND ci."tagId" IN (${Prisma.join(tagIds)})` : Prisma.empty}
-      GROUP BY ci."tagId"
-    `
-  );
-
-  return new Map(rows.map((row) => [row.tagId, Number(row.total)]));
-}
-
-/** One representative image per model — the creator's own showcase post, in their order. */
-async function loadEntryImages(modelIds: number[]) {
-  const images = new Map<number, EntryImage>();
-  if (!modelIds.length) return images;
-
-  const rows = await withSpan(
-    'contest-score.entry-images',
-    () =>
-      dbRead.$queryRaw<({ modelId: number } & EntryImage)[]>`
-      SELECT DISTINCT ON (mv."modelId")
-        mv."modelId"  AS "modelId",
-        i.id          AS "id",
-        i.url         AS "url",
-        i."nsfwLevel" AS "nsfwLevel",
-        i.type::text  AS "type",
-        i.width       AS "width",
-        i.height      AS "height"
-      FROM "ModelVersion" mv
-      JOIN "Model" m ON m.id = mv."modelId"
-      JOIN "Post" p ON p."modelVersionId" = mv.id AND p."userId" = m."userId"
-      JOIN "Image" i ON i."postId" = p.id
-      WHERE mv."modelId" IN (${Prisma.join(modelIds)})
-        AND p."publishedAt" IS NOT NULL
-        AND p."publishedAt" <= ${nowUtc}
-        AND i.ingestion <> 'Blocked'::"ImageIngestionStatus"
-      ORDER BY mv."modelId", mv."index", p.id, i."index"
-    `
-  );
-  for (const { modelId, ...image } of rows) images.set(modelId, image);
-
-  return images;
-}
-
-// ---------------------------------------------------------------------------
-// Signals
-// ---------------------------------------------------------------------------
-
-type SignalCount = { collectionItemId: number; rawUsers: number; qualifiedUsers: number };
-
-/**
- * (entity, entry) pairs for the ClickHouse joins. Deliberately many-to-many in both
- * directions: one image can credit several entered models (stacked LoRAs), and one
- * model can be entered more than once (two categories, a resubmission,
- * maxItemsPerUser > 1). Collapsing either direction silently zeroes an entry.
- */
-type EntryPair = { entityId: number; entryId: number; creatorId: number; addedById: number };
-
-/**
- * A ClickHouse-side lookup table built from a tuple literal. `values()` would read
- * better but is not available on every deployment; arrayJoin over a tuple array is.
- */
-function chPairTable(pairs: EntryPair[]) {
-  const tuples = pairs
-    .map((p) => `(${intList([p.entityId, p.entryId, p.creatorId, p.addedById])})`)
-    .join(',');
-  return `
-    SELECT
-      toInt64(p.1) AS entityId,
-      toInt64(p.2) AS entryId,
-      toInt64(p.3) AS creatorId,
-      toInt64(p.4) AS addedById
-    FROM (SELECT arrayJoin([${tuples}]) AS p)
-  `;
-}
-
-/**
- * Seconds since the epoch, never a formatted string. `toDateTime('2026-07-24
- * 00:00:00')` is parsed in the ClickHouse SERVER timezone, so a literal silently
- * shifts the window; an integer is an absolute instant.
- */
-const chDateTime = (d: Date) => `toDateTime(${Math.floor(d.getTime() / 1000)})`;
-
-/**
- * Counts distinct users per ENTRY inside ClickHouse. `source` projects `userId` and
- * `entityId`; the qualification gates are applied there too, so only two integers
- * per entry come back.
- */
-function chCountQuery({
-  source,
-  pairs,
-  gates,
-}: {
-  source: (entityIds: string) => string;
-  pairs: EntryPair[];
-  gates: Gates;
-}) {
-  const disqualified = gates.disqualifiedIds.length ? intList(gates.disqualifiedIds) : '0';
-  const entityIds = intList([...new Set(pairs.map((p) => p.entityId))]);
-
-  return `
-    SELECT
-      p.entryId AS entryId,
-      uniqExact(s.userId) AS rawUsers,
-      uniqExactIf(
-        s.userId,
-        s.userId <= ${gates.userIdThreshold}
-          AND s.userId != p.creatorId
-          AND (p.addedById = 0 OR s.userId != p.addedById)
-          AND s.userId NOT IN (${disqualified})
-      ) AS qualifiedUsers
-    FROM (${source(entityIds)}) AS s
-    INNER JOIN (${chPairTable(pairs)}) AS p ON s.entityId = p.entityId
-    GROUP BY entryId
-  `;
-}
-
-/**
- * Splits pairs into calls, cutting only between ENTRIES. An entry's entities must all
- * land in one call because uniqExact cannot be summed across chunks.
- */
-function chunkPairsByEntry(pairs: EntryPair[]) {
-  const byEntry = new Map<number, EntryPair[]>();
-  for (const pair of pairs) {
-    const existing = byEntry.get(pair.entryId);
-    if (existing) existing.push(pair);
-    else byEntry.set(pair.entryId, [pair]);
-  }
-
-  const chunks: EntryPair[][] = [];
-  let current: EntryPair[] = [];
-  for (const group of byEntry.values()) {
-    if (current.length && current.length + group.length > CH_ENTITY_CHUNK) {
-      chunks.push(current);
-      current = [];
-    }
-    current.push(...group);
-  }
-  if (current.length) chunks.push(current);
-
-  return chunks;
-}
-
-/** Runs the chunks with bounded concurrency so a big contest cannot fan out unboundedly. */
-async function runChCounts(
-  name: string,
-  pairs: EntryPair[],
-  gates: Gates,
-  source: (entityIds: string) => string
-): Promise<SignalCount[]> {
-  if (!pairs.length) return [];
-
-  const chunks = chunkPairsByEntry(pairs);
-
-  return withSpan(
-    `contest-score.${name}`,
-    { pairs: pairs.length, chunks: chunks.length },
-    async () => {
-      const limit = pLimit(CH_CONCURRENCY);
-      const results = await Promise.all(
-        chunks.map((chunk) =>
-          limit(() =>
-            clickhouse!.$query<{ entryId: number; rawUsers: number; qualifiedUsers: number }>(
-              chCountQuery({ source, pairs: chunk, gates })
-            )
-          )
-        )
-      );
-      return results.flat().map((row) => ({
-        collectionItemId: Number(row.entryId),
-        rawUsers: Number(row.rawUsers),
-        qualifiedUsers: Number(row.qualifiedUsers),
-      }));
-    }
-  );
-}
-
-/** The entries as a Postgres lookup table, keyed by collectionItemId. */
-function pgEntryTable(entries: EntryRow[]) {
-  const values = entries
-    .map(
-      (e) =>
-        `(${intList([e.collectionItemId, e.modelId, e.creatorId])},${
-          e.addedById === null ? 'NULL' : intList([e.addedById])
-        })`
-    )
-    .join(',');
-  return Prisma.raw(`(VALUES ${values}) AS e("entryId", "modelId", "creatorId", "addedById")`);
-}
-
-/** The qualification gate, identical across every signal. */
-function pgQualified(userColumn: string, userAlias: string, gates: BaseGates) {
-  const disqualified = gates.baseDisqualifiedIds.length ? intList(gates.baseDisqualifiedIds) : '-1';
-  // Postgres can see the ban columns directly, so the engager round trip the
-  // ClickHouse signals need is unnecessary here — the predicate is the same one.
-  return Prisma.raw(`
-    ${userColumn} <> e."creatorId"
-    AND (e."addedById" IS NULL OR ${userColumn} <> e."addedById")
-    AND ${userColumn} <= ${gates.userIdThreshold}
-    AND NOT (${userColumn} = ANY(ARRAY[${disqualified}]::int[]))
-    AND ${userAlias}.id IS NOT NULL
-    AND ${userAlias}."bannedAt" IS NULL
-    AND ${userAlias}."deletedAt" IS NULL
-  `);
-}
-
-/**
- * The entries' on-site images, windowed on PUBLICATION. Publication is the
- * contest-meaningful event — an already-existing model can be entered, so filtering
- * on image creation would credit or drop the wrong work. Scheduled posts carry a
- * future `publishedAt` and are visible to nobody, hence the `<= NOW()`.
- */
-async function loadImagePairs(
-  entries: EntryRow[],
-  versionPairs: EntryPair[],
-  window: ResolvedWindow
-) {
-  return withSpan(
-    'contest-score.image-pairs',
-    () =>
-      dbRead.$queryRaw<{ entryId: number; imageId: number }[]>`
-      SELECT DISTINCT e."entryId" AS "entryId", i.id AS "imageId"
-      FROM ${pgEntryTable(entries)}
-      JOIN ${pgVersionTable(versionPairs)} ON v."entryId" = e."entryId"
-      JOIN "ImageResourceNew" ir ON ir."modelVersionId" = v."versionId"
-      JOIN "Image" i ON i.id = ir."imageId"
-      JOIN "Post" p ON p.id = i."postId"
-      WHERE p."publishedAt" IS NOT NULL
-        AND p."publishedAt" <= ${nowUtc}
-        AND p."publishedAt" >= ${utc(window.start)}
-        AND p."publishedAt" < ${utc(window.effectiveEnd)}
-        AND i.ingestion <> 'Blocked'::"ImageIngestionStatus"
-      ORDER BY "entryId", "imageId"
-    `
-  );
-}
-
-async function countImageAuthors(
-  entries: EntryRow[],
-  versionPairs: EntryPair[],
-  window: ResolvedWindow,
-  gates: BaseGates
-) {
-  return withSpan(
-    'contest-score.image-authors',
-    () =>
-      dbRead.$queryRaw<SignalCount[]>`
-      SELECT
-        e."entryId"                     AS "collectionItemId",
-        count(DISTINCT i."userId")::int AS "rawUsers",
-        count(DISTINCT i."userId") FILTER (WHERE ${pgQualified('i."userId"', 'au', gates)})::int
-                                        AS "qualifiedUsers"
-      FROM ${pgEntryTable(entries)}
-      JOIN ${pgVersionTable(versionPairs)} ON v."entryId" = e."entryId"
-      JOIN "ImageResourceNew" ir ON ir."modelVersionId" = v."versionId"
-      JOIN "Image" i ON i.id = ir."imageId"
-      JOIN "Post" p ON p.id = i."postId"
-      LEFT JOIN "User" au ON au.id = i."userId"
-      WHERE p."publishedAt" IS NOT NULL
-        AND p."publishedAt" <= ${nowUtc}
-        AND p."publishedAt" >= ${utc(window.start)}
-        AND p."publishedAt" < ${utc(window.effectiveEnd)}
-        AND i.ingestion <> 'Blocked'::"ImageIngestionStatus"
-      GROUP BY e."entryId"
-    `
-  );
-}
-
-/**
- * The only signal that stays MODEL-level. A collect targets the model, never a
- * version, so there is nothing to scope it to; the window filter is all it gets.
- */
-async function countCollectors(
-  entries: EntryRow[],
-  window: ResolvedWindow,
-  gates: BaseGates,
-  collectionId: number
-) {
-  return withSpan(
-    'contest-score.collectors',
-    () =>
-      dbRead.$queryRaw<SignalCount[]>`
-      SELECT
-        e."entryId"                         AS "collectionItemId",
-        count(DISTINCT ci."addedById")::int AS "rawUsers",
-        count(DISTINCT ci."addedById") FILTER (WHERE ${pgQualified(
-          'ci."addedById"',
-          'cu',
-          gates
-        )})::int
-                                            AS "qualifiedUsers"
-      FROM ${pgEntryTable(entries)}
-      JOIN "CollectionItem" ci ON ci."modelId" = e."modelId"
-      LEFT JOIN "User" cu ON cu.id = ci."addedById"
-      WHERE ci."collectionId" <> ${collectionId}
-        AND ci."addedById" IS NOT NULL
-        AND ci."createdAt" >= ${utc(window.start)}
-        AND ci."createdAt" < ${utc(window.effectiveEnd)}
-      GROUP BY e."entryId"
-    `
-  );
-}
-
-/**
- * The versions that actually represent an entry: created inside the CONTEST window,
- * publicly published, and — where the contest names any — built on one of its base
- * models.
- *
- * Contest rules let an already-existing model enter with a new version, so counting
- * every version of the model credits an entry with traffic its contest work never
- * earned — a fifteen-month-old sibling version can carry an entry to first place.
- *
- * Deliberately NOT "the latest version": a creator who iterates during the contest
- * has every in-window version count toward the same entry.
- *
- * `contestStart`/`contestEnd`, never the display window: a moderator narrowing the
- * date pickers to inspect one day must not thereby strip every entry of its
- * qualifying version and declare the whole contest ineligible.
- */
-async function loadQualifyingVersions(
-  entries: EntryRow[],
-  window: ResolvedWindow,
-  baseModels: string[]
-) {
-  const versions = await withSpan(
-    'contest-score.qualifying-versions',
-    () =>
-      dbRead.$queryRaw<{ id: number; modelId: number }[]>`
-      SELECT mv.id AS "id", mv."modelId" AS "modelId"
-      FROM "ModelVersion" mv
-      WHERE mv."modelId" IN (${Prisma.join(entries.map((e) => e.modelId))})
-        AND mv."createdAt" >= ${utc(window.contestStart)}
-        AND mv."createdAt" < ${utc(window.contestEnd)}
-        AND mv.status = ${ModelStatus.Published}::"ModelStatus"
-        ${
-          baseModels.length
-            ? Prisma.sql`AND mv."baseModel" IN (${Prisma.join(baseModels)})`
-            : Prisma.empty
-        }
-    `
-  );
-
-  const byModel = new Map<number, EntryRow[]>();
-  for (const entry of entries) {
-    const existing = byModel.get(entry.modelId);
-    if (existing) existing.push(entry);
-    else byModel.set(entry.modelId, [entry]);
-  }
-
-  const pairs: EntryPair[] = [];
-  const countByEntry = new Map<number, number>(entries.map((e) => [e.collectionItemId, 0]));
-  for (const version of versions)
-    for (const entry of byModel.get(version.modelId) ?? []) {
-      pairs.push({
-        entityId: version.id,
-        entryId: entry.collectionItemId,
-        creatorId: entry.creatorId,
-        addedById: entry.addedById ?? 0,
-      });
-      countByEntry.set(entry.collectionItemId, (countByEntry.get(entry.collectionItemId) ?? 0) + 1);
-    }
-
-  return { pairs, countByEntry };
-}
-
-/**
- * The qualifying versions as a Postgres lookup table, so the image-derived signals
- * resolve their images through exactly the version set the ClickHouse signals count.
- *
- * An empty set renders as a well-typed table of no rows rather than an empty `VALUES`
- * list, which is a syntax error. The guard belongs here: every call site joins against
- * this, so relying on each of them to remember is one edit away from a 500 on a
- * contest where nothing qualifies.
- */
-function pgVersionTable(pairs: EntryPair[]) {
-  if (!pairs.length)
-    return Prisma.raw(`(SELECT NULL::int AS "entryId", NULL::int AS "versionId" WHERE false) AS v`);
-
-  const values = pairs.map((p) => `(${intList([p.entryId, p.entityId])})`).join(',');
-  return Prisma.raw(`(VALUES ${values}) AS v("entryId", "versionId")`);
-}
-
-function toImagePairs(rows: { entryId: number; imageId: number }[], entries: EntryRow[]) {
-  const byEntry = new Map(entries.map((e) => [e.collectionItemId, e]));
-  const pairs: EntryPair[] = [];
-  for (const row of rows) {
-    const entry = byEntry.get(Number(row.entryId));
-    if (!entry) continue;
-    pairs.push({
-      entityId: Number(row.imageId),
-      entryId: entry.collectionItemId,
-      creatorId: entry.creatorId,
-      addedById: entry.addedById ?? 0,
-    });
-  }
-  return pairs;
 }
 
 // ---------------------------------------------------------------------------
@@ -1277,12 +530,6 @@ export type ContestCommunityScore = {
   signalSources: Record<Signal, string>;
   categories: ContestScoreCategory[];
 };
-
-function requireClickhouse() {
-  if (!clickhouse)
-    throw new ContestScoringError('ClickHouse is not configured in this environment');
-  return clickhouse;
-}
 
 function emptySignals() {
   return Object.fromEntries(
@@ -1384,37 +631,7 @@ async function computeCommunityScore(input: WindowInput): Promise<RunOutcome> {
   const imageRows = truncatedImages ? imageRowsRaw.slice(0, MAX_IMAGE_PAIRS) : imageRowsRaw;
   const imagePairs = toImagePairs(imageRows, entries);
 
-  const chSources = {
-    reactors: (ids: string) => `
-      SELECT toInt64(userId) AS userId, toInt64(entityId) AS entityId
-      FROM reactions
-      WHERE type = 'Image_Create'
-        AND entityId IN (${ids})
-        AND time >= ${chDateTime(window.start)} AND time < ${chDateTime(window.effectiveEnd)}
-        AND userId != 0
-    `,
-    downloaders: (ids: string) => `
-      SELECT toInt64(userId) AS userId, toInt64(modelVersionId) AS entityId
-      FROM modelVersionEvents
-      WHERE type = 'Download'
-        AND modelVersionId IN (${ids})
-        AND time >= ${chDateTime(window.start)} AND time < ${chDateTime(window.effectiveEnd)}
-        AND userId != 0
-    `,
-    // Straight off orchestration.jobs, NOT default.daily_user_resource: that view
-    // only ingests jobType IN ('TextToImage','TextToImageV2','Comfy'), so every
-    // newer engine (ComfyImageGen, AnimaComfy, StableDiffusionCpp, …) is missing
-    // from it and whole ecosystems read as zero generations.
-    generators: (ids: string) => `
-      SELECT toInt64(userId) AS userId, toInt64(resource) AS entityId
-      FROM orchestration.jobs
-      ARRAY JOIN resourcesUsed AS resource
-      WHERE resource IN (${ids})
-        AND createdAt >= ${chDateTime(window.start)}
-        AND createdAt < ${chDateTime(window.effectiveEnd)}
-        AND userId != 0
-    `,
-  };
+  const chSources = chSignalSources(window);
 
   const imageIds = intList([...new Set(imagePairs.map((p) => p.entityId))]) || '0';
   const versionIds = intList([...new Set(versionPairs.map((p) => p.entityId))]) || '0';
@@ -1863,32 +1080,11 @@ export async function getContestCandidates(input: GetContestCandidatesInput) {
 
     // Reactions and downloads are the engagement events that carry an IP — the same
     // farm-IP signal `reaction-abuse` uses, scoped to this contest.
+    const candidateSources = chCandidateSources(window);
     const perCreator = (
       await Promise.all([
-        runChPerCreator(
-          'candidates.downloads',
-          versionPairs,
-          (ids) => `
-          SELECT toInt64(userId) AS userId, toInt64(modelVersionId) AS entityId, ip
-          FROM modelVersionEvents
-          WHERE type = 'Download'
-            AND modelVersionId IN (${ids})
-            AND time >= ${chDateTime(window.start)} AND time < ${chDateTime(window.effectiveEnd)}
-            AND userId != 0
-        `
-        ),
-        runChPerCreator(
-          'candidates.reactions',
-          imagePairs,
-          (ids) => `
-          SELECT toInt64(userId) AS userId, toInt64(entityId) AS entityId, ip
-          FROM reactions
-          WHERE type = 'Image_Create'
-            AND entityId IN (${ids})
-            AND time >= ${chDateTime(window.start)} AND time < ${chDateTime(window.effectiveEnd)}
-            AND userId != 0
-        `
-        ),
+        runChPerCreator('candidates.downloads', versionPairs, candidateSources.downloads),
+        runChPerCreator('candidates.reactions', imagePairs, candidateSources.reactions),
       ])
     ).flat();
 
@@ -1965,52 +1161,6 @@ export async function getContestCandidates(input: GetContestCandidatesInput) {
   } catch (e) {
     return sanitizeError(input.collectionId, e);
   }
-}
-
-type PerCreatorRow = {
-  userId: number;
-  creatorId: number;
-  events: number;
-  entries: number;
-  ips: string[];
-};
-
-/** Same entry-boundary chunking as the scoring path — the query-text ceiling is identical. */
-async function runChPerCreator(
-  name: string,
-  pairs: EntryPair[],
-  source: (entityIds: string) => string
-): Promise<PerCreatorRow[]> {
-  if (!pairs.length) return [];
-
-  return withSpan(`contest-score.${name}`, { pairs: pairs.length }, async () => {
-    const limit = pLimit(CH_CONCURRENCY);
-    const results = await Promise.all(
-      chunkPairsByEntry(pairs).map((chunk) =>
-        limit(() => {
-          const entityIds = intList([...new Set(chunk.map((p) => p.entityId))]);
-          return clickhouse!.$query<PerCreatorRow>(`
-            SELECT
-              s.userId AS userId,
-              p.creatorId AS creatorId,
-              count() AS events,
-              uniqExact(p.entryId) AS entries,
-              groupUniqArray(s.ip) AS ips
-            FROM (${source(entityIds)}) AS s
-            INNER JOIN (${chPairTable(chunk)}) AS p ON s.entityId = p.entityId
-            GROUP BY userId, creatorId
-          `);
-        })
-      )
-    );
-    return results.flat().map((row) => ({
-      userId: Number(row.userId),
-      creatorId: Number(row.creatorId),
-      events: Number(row.events),
-      entries: Number(row.entries),
-      ips: row.ips ?? [],
-    }));
-  });
 }
 
 // ---------------------------------------------------------------------------

--- a/src/server/services/contest-score.service.ts
+++ b/src/server/services/contest-score.service.ts
@@ -55,7 +55,12 @@ import { fetchThroughCache } from '~/server/utils/cache-helpers';
 import { withDistributedLock } from '~/server/utils/distributed-lock';
 import { throwBadRequestError } from '~/server/utils/errorHandling';
 import { withSpan } from '~/server/utils/otel-helpers';
-import { Availability, CollectionItemStatus, CollectionMode } from '~/shared/utils/prisma/enums';
+import {
+  Availability,
+  CollectionItemStatus,
+  CollectionMode,
+  ModelStatus,
+} from '~/shared/utils/prisma/enums';
 import { signalClient } from '~/utils/signal-client';
 import { hashifyObject } from '~/utils/string-helpers';
 
@@ -76,7 +81,7 @@ const nowUtc = Prisma.raw(`(NOW() AT TIME ZONE 'UTC')`);
  * Bumped whenever a change here could move a ranking. Recorded in every snapshot so
  * a disputed result can be traced to the code that produced it.
  */
-export const CONTEST_SCORE_CODE_VERSION = 3;
+export const CONTEST_SCORE_CODE_VERSION = 4;
 
 /**
  * Comments and tips are deliberately unweighted: both are trivially launderable
@@ -242,6 +247,15 @@ export async function setContestScoringConfig({
 }) {
   const { collectionId, scope, config, reason } = input;
   try {
+    // A base-model list is a single contest's rule. On the global row it would apply to
+    // every contest that has no config of its own, and any whose entries are built on
+    // anything else would go wholly ineligible behind a reason that reads like a
+    // finding rather than a misconfiguration.
+    if (scope === 'global' && config.baseModels?.length)
+      throw new ContestScoringError(
+        'Base models cannot be set on the global config — they are specific to one contest. Save them to this contest only, or set them on the collection itself.'
+      );
+
     const suffix = scopeSuffix(scope, collectionId);
     const key = configKey(suffix);
 
@@ -305,6 +319,16 @@ export async function setContestScoringConfig({
 // Window
 // ---------------------------------------------------------------------------
 
+/**
+ * Two windows, and the difference decides prizes.
+ *
+ * `start`/`end` are the DISPLAY window a moderator drives from the date pickers — a
+ * lens over the traffic being counted, freely narrowed to look at a single day.
+ *
+ * `contestStart`/`contestEnd` are the contest itself, off the collection's metadata.
+ * Anything that decides ELIGIBILITY reads these: the age gate, and which versions
+ * qualify. Narrowing the view must never make an entry ineligible, only quieter.
+ */
 export type ResolvedWindow = {
   start: Date;
   end: Date;
@@ -313,6 +337,10 @@ export type ResolvedWindow = {
   /** True while the contest is still open — the run is a preview, not a result. */
   partial: boolean;
   ageCutoff: Date;
+  contestStart: Date;
+  contestEnd: Date;
+  /** `Collection.metadata.baseModels` — the rule entrants were actually told. */
+  declaredBaseModels: string[];
 };
 
 /**
@@ -347,9 +375,12 @@ async function resolveWindow(
       `Collection ${collectionId} has neither submissionEndDate nor endsAt, and no explicit window end was given.`
     );
 
-  // Always the contest's own start, never a narrowed display window — otherwise
-  // zooming the view would drag the age gate along with it.
+  // Always the contest's own bounds, never a narrowed display window — otherwise
+  // zooming the view would drag the age gate and version eligibility along with it.
+  // They fall back to the resolved window only for a contest carrying no submission
+  // dates at all, where the caller's dates are the only definition available.
   const contestStart = metadata.submissionStartDate ?? start;
+  const contestEnd = metadata.submissionEndDate ?? metadata.endsAt ?? end;
   const ageCutoff = new Date(contestStart.getTime() - config.ageGateDays * 24 * 60 * 60 * 1000);
 
   // Belt and braces behind the schema's `nonnegative()`: a row written before that
@@ -363,7 +394,41 @@ async function resolveWindow(
   const now = new Date();
   const partial = end > now;
 
-  return { start, end, effectiveEnd: partial ? now : end, partial, ageCutoff };
+  return {
+    start,
+    end,
+    effectiveEnd: partial ? now : end,
+    partial,
+    ageCutoff,
+    contestStart,
+    contestEnd,
+    declaredBaseModels: metadata.baseModels?.filter(Boolean) ?? [],
+  };
+}
+
+export type ResolvedBaseModels = {
+  baseModels: string[];
+  source: 'collection' | 'config' | 'none';
+};
+
+/**
+ * The collection's metadata wins over the scoring config, because it is the rule the
+ * submission validator rejected entrants against and the one the contest settings UI
+ * publishes. The config field is the fallback for a contest whose metadata declares
+ * none. The two CAN disagree, so the winning source travels with the answer and is
+ * recorded in the snapshot rather than left to be re-derived.
+ */
+function resolveBaseModels(
+  window: ResolvedWindow,
+  config: ContestScoringConfig
+): ResolvedBaseModels {
+  if (window.declaredBaseModels.length)
+    return { baseModels: window.declaredBaseModels, source: 'collection' };
+
+  const configured = config.baseModels?.filter(Boolean) ?? [];
+  return configured.length
+    ? { baseModels: configured, source: 'config' }
+    : { baseModels: [], source: 'none' };
 }
 
 // ---------------------------------------------------------------------------
@@ -614,12 +679,20 @@ function intList(values: number[]) {
   return values.join(',');
 }
 
-function ineligibilityReason(entry: EntryRow, qualifyingVersions: number) {
+function ineligibilityReason(
+  entry: EntryRow,
+  qualifyingVersions: number,
+  baseModelFilterApplied: boolean
+) {
   if (entry.modelDeleted) return 'Model deleted';
   if (entry.modelStatus !== 'Published') return `Model ${entry.modelStatus.toLowerCase()}`;
   if (entry.modelAvailability === Availability.Private) return 'Model is private';
+  // Only claims a base-model rule when one actually ran, so the reason never asserts a
+  // requirement the contest never had.
   if (!qualifyingVersions)
-    return 'No version was created during the contest window on a qualifying base model';
+    return baseModelFilterApplied
+      ? 'No published version was created during the contest on a qualifying base model'
+      : 'No published version was created during the contest';
   return null;
 }
 
@@ -903,8 +976,6 @@ async function loadImagePairs(
   versionPairs: EntryPair[],
   window: ResolvedWindow
 ) {
-  if (!versionPairs.length) return [];
-
   return withSpan(
     'contest-score.image-pairs',
     () =>
@@ -931,8 +1002,6 @@ async function countImageAuthors(
   window: ResolvedWindow,
   gates: BaseGates
 ) {
-  if (!versionPairs.length) return [];
-
   return withSpan(
     'contest-score.image-authors',
     () =>
@@ -994,8 +1063,9 @@ async function countCollectors(
 }
 
 /**
- * The versions that actually represent an entry: created inside the contest window
- * and, where the config names any, built on one of its base models.
+ * The versions that actually represent an entry: created inside the CONTEST window,
+ * publicly published, and — where the contest names any — built on one of its base
+ * models.
  *
  * Contest rules let an already-existing model enter with a new version, so counting
  * every version of the model credits an entry with traffic its contest work never
@@ -1003,6 +1073,10 @@ async function countCollectors(
  *
  * Deliberately NOT "the latest version": a creator who iterates during the contest
  * has every in-window version count toward the same entry.
+ *
+ * `contestStart`/`contestEnd`, never the display window: a moderator narrowing the
+ * date pickers to inspect one day must not thereby strip every entry of its
+ * qualifying version and declare the whole contest ineligible.
  */
 async function loadQualifyingVersions(
   entries: EntryRow[],
@@ -1016,8 +1090,9 @@ async function loadQualifyingVersions(
       SELECT mv.id AS "id", mv."modelId" AS "modelId"
       FROM "ModelVersion" mv
       WHERE mv."modelId" IN (${Prisma.join(entries.map((e) => e.modelId))})
-        AND mv."createdAt" >= ${utc(window.start)}
-        AND mv."createdAt" < ${utc(window.effectiveEnd)}
+        AND mv."createdAt" >= ${utc(window.contestStart)}
+        AND mv."createdAt" < ${utc(window.contestEnd)}
+        AND mv.status = ${ModelStatus.Published}::"ModelStatus"
         ${
           baseModels.length
             ? Prisma.sql`AND mv."baseModel" IN (${Prisma.join(baseModels)})`
@@ -1052,8 +1127,16 @@ async function loadQualifyingVersions(
 /**
  * The qualifying versions as a Postgres lookup table, so the image-derived signals
  * resolve their images through exactly the version set the ClickHouse signals count.
+ *
+ * An empty set renders as a well-typed table of no rows rather than an empty `VALUES`
+ * list, which is a syntax error. The guard belongs here: every call site joins against
+ * this, so relying on each of them to remember is one edit away from a 500 on a
+ * contest where nothing qualifies.
  */
 function pgVersionTable(pairs: EntryPair[]) {
+  if (!pairs.length)
+    return Prisma.raw(`(SELECT NULL::int AS "entryId", NULL::int AS "versionId" WHERE false) AS v`);
+
   const values = pairs.map((p) => `(${intList([p.entryId, p.entityId])})`).join(',');
   return Prisma.raw(`(VALUES ${values}) AS v("entryId", "versionId")`);
 }
@@ -1165,6 +1248,8 @@ type RunAudit = {
   ageGateBandUsers: number;
   /** Resolved rather than read back off the config, which may not carry the field. */
   baseModels: string[];
+  /** Which of the two rule sources won — they can disagree. */
+  baseModelSource: ResolvedBaseModels['source'];
 };
 
 /**
@@ -1189,8 +1274,13 @@ async function computeCommunityScore(input: WindowInput): Promise<RunOutcome> {
   const { config, scope } = await resolveContestScoringConfig(input.collectionId);
   const window = await resolveWindow(input.collectionId, input, config);
   const statuses = input.statuses ?? DEFAULT_STATUSES;
-  const baseModels = config.baseModels ?? [];
-  const audit: RunAudit = { engagerCount: 0, ageGateBandUsers: 0, baseModels };
+  const { baseModels, source: baseModelSource } = resolveBaseModels(window, config);
+  const audit: RunAudit = {
+    engagerCount: 0,
+    ageGateBandUsers: 0,
+    baseModels,
+    baseModelSource,
+  };
 
   const base = {
     collectionId: input.collectionId,
@@ -1336,7 +1426,7 @@ async function computeCommunityScore(input: WindowInput): Promise<RunOutcome> {
     const rawTotal = contestScoreSignals.reduce((sum, s) => sum + signals[s].raw, 0);
     const qualifiedTotal = contestScoreSignals.reduce((sum, s) => sum + signals[s].qualified, 0);
     const qualifyingVersionCount = qualifyingVersions.get(entry.collectionItemId) ?? 0;
-    const reason = ineligibilityReason(entry, qualifyingVersionCount);
+    const reason = ineligibilityReason(entry, qualifyingVersionCount, baseModels.length > 0);
 
     return {
       collectionItemId: entry.collectionItemId,
@@ -1713,7 +1803,7 @@ export async function getContestCandidates(input: GetContestCandidatesInput) {
     const { pairs: versionPairs } = await loadQualifyingVersions(
       entries,
       window,
-      config.baseModels ?? []
+      resolveBaseModels(window, config).baseModels
     );
     const imagePairs = toImagePairs(await loadImagePairs(entries, versionPairs, window), entries);
 
@@ -1919,6 +2009,8 @@ export type ContestSnapshot = {
   engagerCount: number;
   /** Empty means no base-model filter was applied, not that the field was forgotten. */
   baseModels: string[];
+  /** `collection` metadata, the scoring `config` row, or `none`. */
+  baseModelSource: ResolvedBaseModels['source'];
   partial: boolean;
   score: ContestCommunityScore;
 };
@@ -1989,6 +2081,7 @@ export async function createContestSnapshot({
       ageGateBandUsers: outcome.audit.ageGateBandUsers,
       engagerCount: outcome.audit.engagerCount,
       baseModels: outcome.audit.baseModels,
+      baseModelSource: outcome.audit.baseModelSource,
       partial: outcome.window.partial,
       score: outcome.score,
     };

--- a/src/server/services/contest-score.service.ts
+++ b/src/server/services/contest-score.service.ts
@@ -85,11 +85,24 @@ export const CONTEST_SIGNAL_SOURCES: Record<Signal, string> = {
   collectors: 'Distinct users adding the model to another collection',
 };
 
-const MAX_ENTRIES = 1000;
+// Raised from 1000 after a past contest (collection 3991102) came in at 1138 accepted
+// items — the old ceiling was already reachable, and a category that loses entries has
+// to have its ranks withheld because the normalization maxima come from survivors.
+const MAX_ENTRIES = 5000;
+// Decimal places the UI renders a score to. Scores are carried at 4, so two rows can
+// read identically on screen while holding different ranks; entries that straddle that
+// boundary are flagged rather than silently rounded together.
+const SCORE_DISPLAY_PRECISION = 3;
 // A finished run stays readable for a day so the tab opens on the last result rather
 // than on an empty table waiting for a fresh run.
 const RESULT_TTL = CacheTTL.day;
 const RUN_STATE_TTL = CacheTTL.hour;
+// The lock has to outlast the work it guards: the age-threshold query alone is ~12s
+// and a full run can run for minutes. It is renewed on a timer as well, so this is a
+// backstop for a dead holder rather than a deadline for a live one.
+const RUN_LOCK_TTL = 600;
+const RUN_HEARTBEAT_INTERVAL = 15;
+const RUN_STALE_AFTER = 60;
 // Entities per ClickHouse call. Chunks are cut along ENTRY boundaries, never entity
 // ones: uniqExact cannot be summed across chunks, so every entity belonging to an
 // entry has to be counted in the same call.
@@ -334,6 +347,14 @@ async function resolveWindow(
   const contestStart = metadata.submissionStartDate ?? start;
   const ageCutoff = new Date(contestStart.getTime() - config.ageGateDays * 24 * 60 * 60 * 1000);
 
+  // Belt and braces behind the schema's `nonnegative()`: a row written before that
+  // existed would push the cutoff past the contest start, and the age gate would
+  // admit every account on the site while the run still looked normal.
+  if (ageCutoff > contestStart)
+    throw new ContestScoringError(
+      'The configured age gate resolves to a cutoff after the contest start, which would disable the gate entirely. Fix the scoring config before running.'
+    );
+
   const now = new Date();
   const partial = end > now;
 
@@ -577,6 +598,35 @@ async function loadEntries(input: WindowInput) {
   return { entries: items.slice(0, MAX_ENTRIES), truncated: items.length > MAX_ENTRIES };
 }
 
+/**
+ * True per-category entry counts, unaffected by the cap. `loadEntries` cuts on
+ * `ci.id`, so truncation drops the NEWEST entries and does so unevenly across
+ * categories; without this the surviving rows would render a complete-looking 1..N
+ * ranking whose normalization maxima came from survivors alone. Predicates are kept
+ * in step with `loadEntries` — a divergence here would understate what was lost.
+ */
+async function loadCategoryTotals(input: WindowInput) {
+  const { collectionId, tagIds } = input;
+  const statuses = input.statuses ?? DEFAULT_STATUSES;
+
+  const rows = await withSpan(
+    'contest-score.category-totals',
+    () =>
+      dbRead.$queryRaw<{ tagId: number | null; total: number }[]>`
+      SELECT ci."tagId" AS "tagId", count(*)::int AS "total"
+      FROM "CollectionItem" ci
+      JOIN "Model" m ON m.id = ci."modelId"
+      WHERE ci."collectionId" = ${collectionId}
+        AND ci."modelId" IS NOT NULL
+        AND ci.status = ANY(ARRAY[${Prisma.join(statuses)}]::"CollectionItemStatus"[])
+        ${tagIds?.length ? Prisma.sql`AND ci."tagId" IN (${Prisma.join(tagIds)})` : Prisma.empty}
+      GROUP BY ci."tagId"
+    `
+  );
+
+  return new Map(rows.map((row) => [row.tagId, Number(row.total)]));
+}
+
 /** One representative image per model — the creator's own showcase post, in their order. */
 async function loadEntryImages(modelIds: number[]) {
   const images = new Map<number, EntryImage>();
@@ -794,6 +844,7 @@ async function loadImagePairs(entries: EntryRow[], window: ResolvedWindow) {
         AND p."publishedAt" >= ${utc(window.start)}
         AND p."publishedAt" < ${utc(window.effectiveEnd)}
         AND i.ingestion <> 'Blocked'::"ImageIngestionStatus"
+      ORDER BY "entryId", "imageId"
     `
   );
 }
@@ -935,6 +986,10 @@ export type ContestScoreEntry = {
   qualifiedTotal: number;
   disqualifiedShare: number;
   score: number;
+  /** Another eligible entry holds this exact score and therefore this exact rank. */
+  sharedRank: boolean;
+  /** An adjacent entry's score differs only below the precision the UI renders. */
+  belowDisplayPrecision: boolean;
 };
 
 export type ContestScoreCategory = {
@@ -946,6 +1001,9 @@ export type ContestScoreCategory = {
   soloEntry: boolean;
   /** Nothing in this category scored: ranks are withheld rather than invented. */
   tied: boolean;
+  /** Entries in this category were lost to the entry cap, so its ranks are withheld. */
+  truncated: boolean;
+  missingCount: number;
   entries: ContestScoreEntry[];
 };
 
@@ -982,14 +1040,29 @@ function emptySignals() {
 /** Filled in during a run for the snapshot's audit trail; never sent to a client. */
 type RunAudit = { engagerCount: number; ageGateBandUsers: number };
 
-async function computeCommunityScore(
-  input: WindowInput,
-  audit?: RunAudit
-): Promise<ContestCommunityScore> {
+/**
+ * What a run actually used, returned rather than re-derived by the caller.
+ *
+ * Callers used to resolve the config themselves and pair it with a score computed
+ * against a SECOND, independent resolution. A config saved while a run waited on the
+ * lock produced a snapshot attesting to weights that never produced its ranking — in
+ * the one row that would defend a disputed prize — and stranded a run's result under
+ * a cache key derived from the wrong version.
+ */
+type RunOutcome = {
+  score: ContestCommunityScore;
+  config: ContestScoringConfig;
+  scope: ContestScoringScope;
+  window: ResolvedWindow;
+  audit: RunAudit;
+};
+
+async function computeCommunityScore(input: WindowInput): Promise<RunOutcome> {
   requireClickhouse();
-  const config = await getContestScoringConfig(input.collectionId);
+  const { config, scope } = await resolveContestScoringConfig(input.collectionId);
   const window = await resolveWindow(input.collectionId, input, config);
   const statuses = input.statuses ?? DEFAULT_STATUSES;
+  const audit: RunAudit = { engagerCount: 0, ageGateBandUsers: 0 };
 
   const base = {
     collectionId: input.collectionId,
@@ -1004,14 +1077,23 @@ async function computeCommunityScore(
     signalSources: CONTEST_SIGNAL_SOURCES,
   };
 
-  const { entries, truncated } = await loadEntries(input);
+  const [{ entries, truncated }, categoryTotals] = await Promise.all([
+    loadEntries(input),
+    loadCategoryTotals(input),
+  ]);
   if (!entries.length)
     return {
-      ...base,
-      entryCount: 0,
-      truncated: { entries: truncated, images: false },
-      degraded: { bannedRefinementSkipped: false },
-      categories: [],
+      score: {
+        ...base,
+        entryCount: 0,
+        truncated: { entries: truncated, images: false },
+        degraded: { bannedRefinementSkipped: false },
+        categories: [],
+      },
+      config,
+      scope,
+      window,
+      audit,
     };
 
   const baseGates = await loadBaseGates(window.ageCutoff);
@@ -1095,10 +1177,8 @@ async function computeCommunityScore(
     engagerCount: engagers.length,
   };
 
-  if (audit) {
-    audit.engagerCount = gates.engagerCount;
-    audit.ageGateBandUsers = gates.ageGateBandUsers;
-  }
+  audit.engagerCount = gates.engagerCount;
+  audit.ageGateBandUsers = gates.ageGateBandUsers;
 
   const [reactors, downloaders, generators] = await Promise.all([
     runChCounts('reactors', imagePairs, gates, chSources.reactors),
@@ -1152,6 +1232,7 @@ async function computeCommunityScore(
       const tagName = entries.find((e) => e.tagId === tagId)?.tagName ?? null;
       const items = scored.filter((e) => e.tagId === tagId);
       const eligible = items.filter((i) => i.eligible);
+      const missingCount = Math.max((categoryTotals.get(tagId) ?? items.length) - items.length, 0);
 
       // Normalized against the leading ELIGIBLE entry per signal, so an entry pulled
       // after accruing engagement cannot set the bar for everyone else.
@@ -1176,15 +1257,54 @@ async function computeCommunityScore(
       });
 
       const tied = withScores.every((item) => item.score === 0);
-      const entriesRanked = withScores
-        .sort(
-          (a, b) =>
-            Number(b.eligible) - Number(a.eligible) ||
-            b.score - a.score ||
-            b.qualifiedTotal - a.qualifiedTotal ||
-            a.modelId - b.modelId
-        )
-        .map((item, index) => ({ ...item, rank: !item.eligible || tied ? null : index + 1 }));
+
+      // Ranks are withheld wholesale when the category lost entries to the cap: the
+      // maxima above are computed from SURVIVORS only, so every score in the category
+      // is wrong by an unknown amount and a 1..N ranking over them would look
+      // complete while being unsound.
+      const rankable = !tied && !missingCount;
+
+      const ordered = withScores.sort(
+        (a, b) =>
+          Number(b.eligible) - Number(a.eligible) ||
+          b.score - a.score ||
+          b.qualifiedTotal - a.qualifiedTotal ||
+          a.modelId - b.modelId
+      );
+
+      // Competition ranking: equal scores take the SAME rank and consume the numbers
+      // after it (1, 2, 2, 4). The secondary sort keys above order the rows for
+      // display, but they must never break a tie into distinct prizes — deciding a
+      // placement by lower model id is arbitrary, and nothing on screen would have
+      // said so.
+      let lastScore: number | null = null;
+      let lastRank = 0;
+      const entriesRanked = ordered.map((item, index) => {
+        if (!item.eligible || !rankable)
+          return { ...item, rank: null, sharedRank: false, belowDisplayPrecision: false };
+        const rank = lastScore !== null && item.score === lastScore ? lastRank : index + 1;
+        lastScore = item.score;
+        lastRank = rank;
+
+        const neighbours = [ordered[index - 1], ordered[index + 1]].filter(
+          (n) => n?.eligible && n.score !== item.score
+        );
+        return {
+          ...item,
+          rank,
+          sharedRank: ordered.some(
+            (other) => other !== item && other.eligible && other.score === item.score
+          ),
+          // Scores are carried at 4dp and rendered at 3dp, so two rows can read
+          // identically on screen and still hold different ranks. Flagged rather than
+          // hidden: the fix is a judgement call, not a rounding one.
+          belowDisplayPrecision: neighbours.some(
+            (n) =>
+              n!.score.toFixed(SCORE_DISPLAY_PRECISION) ===
+              item.score.toFixed(SCORE_DISPLAY_PRECISION)
+          ),
+        };
+      });
 
       return {
         tagId,
@@ -1193,17 +1313,25 @@ async function computeCommunityScore(
         eligibleCount: eligible.length,
         soloEntry: eligible.length === 1,
         tied,
+        truncated: missingCount > 0,
+        missingCount,
         entries: entriesRanked,
       };
     }
   );
 
   return {
-    ...base,
-    entryCount: entries.length,
-    truncated: { entries: truncated, images: truncatedImages },
-    degraded: { bannedRefinementSkipped },
-    categories,
+    score: {
+      ...base,
+      entryCount: entries.length,
+      truncated: { entries: truncated, images: truncatedImages },
+      degraded: { bannedRefinementSkipped },
+      categories,
+    },
+    config,
+    scope,
+    window,
+    audit,
   };
 }
 
@@ -1250,11 +1378,27 @@ async function clearLatestRun(collectionId: number) {
  * state in Redis is the truth, and the read query returns it, so a dropped push
  * costs a refresh rather than a stuck UI.
  */
-async function publishRunState(state: ContestScoreRunState) {
+async function writeRunState(state: ContestScoreRunState) {
+  const current = await redis.packed
+    .get<ContestScoreRunState>(latestRunKey(state.collectionId))
+    .catch(() => null);
+
+  // The pointer is last-write-wins, and two runs can be in flight across pods (the
+  // lock serializes the COMPUTE, not the enqueue). Without this an older run's
+  // terminal write lands after a newer run's `running` and walks the banner backwards.
+  const stale =
+    !!current && current.runId !== state.runId && current.requestedAt > state.requestedAt;
+
   await Promise.all([
     redis.packed.set(runStateKey(state.collectionId, state.runId), state, { EX: RUN_STATE_TTL }),
-    redis.packed.set(latestRunKey(state.collectionId), state, { EX: RUN_STATE_TTL }),
+    stale
+      ? Promise.resolve()
+      : redis.packed.set(latestRunKey(state.collectionId), state, { EX: RUN_STATE_TTL }),
   ]);
+}
+
+async function publishRunState(state: ContestScoreRunState) {
+  await writeRunState(state);
 
   signalClient
     .topicSend({
@@ -1269,44 +1413,86 @@ async function publishRunState(state: ContestScoreRunState) {
     );
 }
 
+/**
+ * A run whose pod died mid-compute leaves `running` behind with nothing to clear it,
+ * and the UI disables its Run button for as long as the state survives. The heartbeat
+ * is what distinguishes a long run from a dead one; a state that stopped beating is
+ * reported as failed so a moderator can start another.
+ */
+function reconcileStaleRun(state: ContestScoreRunState | null) {
+  if (!state || (state.status !== 'running' && state.status !== 'queued')) return state;
+
+  const beat = new Date(state.heartbeatAt ?? state.startedAt ?? state.requestedAt).getTime();
+  if (Date.now() - beat < RUN_STALE_AFTER * 1000) return state;
+
+  return {
+    ...state,
+    status: 'failed' as const,
+    finishedAt: new Date().toISOString(),
+    error: 'The run stopped reporting progress and was abandoned. Start another.',
+  };
+}
+
 async function readRunState(collectionId: number) {
-  return (await redis.packed.get<ContestScoreRunState>(latestRunKey(collectionId))) ?? null;
+  const stored = await redis.packed.get<ContestScoreRunState>(latestRunKey(collectionId));
+  return reconcileStaleRun(stored ?? null);
 }
 
 async function executeRun(input: WindowInput, state: ContestScoreRunState) {
   const startedAt = new Date().toISOString();
-  await publishRunState({ ...state, status: 'running', startedAt });
+  let running: ContestScoreRunState = {
+    ...state,
+    status: 'running',
+    startedAt,
+    heartbeatAt: startedAt,
+  };
+  await publishRunState(running);
+
+  // Redis-only, and deliberately not signalled: the beat is liveness, not news.
+  const heartbeat = setInterval(() => {
+    running = { ...running, heartbeatAt: new Date().toISOString() };
+    writeRunState(running).catch(() => null);
+  }, RUN_HEARTBEAT_INTERVAL * 1000);
 
   try {
-    const { config, scope } = await resolveContestScoringConfig(input.collectionId);
-
     // One run per collection at a time. Nothing is waiting on the response now, so
     // the loser of the race waits for the lock rather than failing the caller.
-    const result = await withDistributedLock(
-      { key: `contest-score:${input.collectionId}`, ttl: 600, retryDelay: 500, maxRetries: 240 },
+    const outcome = await withDistributedLock(
+      {
+        key: `contest-score:${input.collectionId}`,
+        ttl: RUN_LOCK_TTL,
+        retryDelay: 500,
+        maxRetries: 240,
+        autoRenew: true,
+      },
       () => computeCommunityScore(input)
     );
-    if (!result)
+    if (!outcome)
       throw new ContestScoringError(
         'A scoring run for this collection is already in progress. Try again shortly.'
       );
 
-    await redis.packed.set(resultKeyFor(input, config, scope), result, { EX: RESULT_TTL });
+    // Keyed off the config the run ACTUALLY used, not a second resolution taken
+    // before the lock — a config saved while this waited would otherwise strand the
+    // result under a key no reader will look at.
+    await redis.packed.set(resultKeyFor(input, outcome.config, outcome.scope), outcome.score, {
+      EX: RESULT_TTL,
+    });
     await publishRunState({
-      ...state,
+      ...running,
       status: 'done',
-      startedAt,
       finishedAt: new Date().toISOString(),
-      generatedAt: result.generatedAt,
+      generatedAt: outcome.score.generatedAt,
     });
   } catch (e) {
     await publishRunState({
-      ...state,
+      ...running,
       status: 'failed',
-      startedAt,
       finishedAt: new Date().toISOString(),
       error: safeErrorMessage(input.collectionId, e),
     });
+  } finally {
+    clearInterval(heartbeat);
   }
 }
 
@@ -1586,6 +1772,8 @@ export type ContestSnapshot = {
   note?: string;
   codeVersion: number;
   config: ContestScoringConfig;
+  /** Which row the config came from, so a later reader need not guess. */
+  configScope: ContestScoringScope;
   ageCutoff: string;
   /**
    * Diagnostic only. The threshold is cached for a week, so this can be up to that
@@ -1624,18 +1812,20 @@ export async function createContestSnapshot({
 }): Promise<ContestSnapshotSummary> {
   const { note, ...window } = input;
   try {
-    const config = await getContestScoringConfig(window.collectionId);
-    const resolved = await resolveWindow(window.collectionId, window, config);
-    const audit: RunAudit = { engagerCount: 0, ageGateBandUsers: 0 };
-
-    // Through the same lock the scoring path uses. Snapshotting is a full run, so two
-    // mods clicking the button would otherwise stack exactly what the lock exists to
-    // prevent.
-    const score = await withDistributedLock(
-      { key: `contest-score:${window.collectionId}`, ttl: 120, maxRetries: 60 },
-      () => computeCommunityScore(window, audit)
+    // Through the same lock the scoring path uses, and with the same TTL: at 120s a
+    // snapshot silently lost the lock partway through its own run and a concurrent
+    // run stacked the second aggregation this exists to prevent.
+    const outcome = await withDistributedLock(
+      {
+        key: `contest-score:${window.collectionId}`,
+        ttl: RUN_LOCK_TTL,
+        retryDelay: 500,
+        maxRetries: 240,
+        autoRenew: true,
+      },
+      () => computeCommunityScore(window)
     );
-    if (!score)
+    if (!outcome)
       throw new ContestScoringError(
         'A scoring run for this collection is already in progress. Try again shortly.'
       );
@@ -1643,6 +1833,10 @@ export async function createContestSnapshot({
     const takenAt = new Date().toISOString();
     const source = snapshotSource();
     const key = snapshotKey(window.collectionId, takenAt, source);
+    // Every field here comes from the run that produced `score`, never from a second
+    // resolution taken around it. A config saved while this waited on the lock would
+    // otherwise leave a permanent record attesting to weights that never produced its
+    // ranking — in the one row we would use to defend a disputed prize.
     const snapshot: ContestSnapshot = {
       collectionId: window.collectionId,
       takenAt,
@@ -1651,12 +1845,13 @@ export async function createContestSnapshot({
       source,
       ...(note ? { note } : {}),
       codeVersion: CONTEST_SCORE_CODE_VERSION,
-      config,
-      ageCutoff: resolved.ageCutoff.toISOString(),
-      ageGateBandUsers: audit.ageGateBandUsers,
-      engagerCount: audit.engagerCount,
-      partial: resolved.partial,
-      score,
+      config: outcome.config,
+      configScope: outcome.scope,
+      ageCutoff: outcome.window.ageCutoff.toISOString(),
+      ageGateBandUsers: outcome.audit.ageGateBandUsers,
+      engagerCount: outcome.audit.engagerCount,
+      partial: outcome.window.partial,
+      score: outcome.score,
     };
 
     try {
@@ -1677,14 +1872,22 @@ export async function createContestSnapshot({
   }
 }
 
-export type ContestSnapshotRef = { key: string; source: string | null; takenAt: string };
+export type ContestSnapshotRef = {
+  key: string;
+  source: string | null;
+  takenAt: string;
+  partial: boolean;
+};
 
 /**
  * The key carries everything the list needs, so `takenAt` and the source marker are
  * read back off it: `<prefix>:<collectionId>:[source:]<ISO>`. The ISO timestamp
  * contains colons of its own, hence the leading-year test rather than a field count.
  */
-function parseSnapshotKey(collectionId: number, key: string): ContestSnapshotRef | null {
+function parseSnapshotKey(
+  collectionId: number,
+  key: string
+): Omit<ContestSnapshotRef, 'partial'> | null {
   const prefix = `${CONTEST_SNAPSHOT_KEY_PREFIX}:${collectionId}:`;
   if (!key.startsWith(prefix)) return null;
 
@@ -1697,19 +1900,28 @@ function parseSnapshotKey(collectionId: number, key: string): ContestSnapshotRef
 }
 
 /**
- * Keys only. Every snapshot embeds a full scored payload, so deserializing the set
- * just to render a list of dates would grow with entries × snapshots for a list that
- * shows neither. The value is fetched for ONE snapshot, on click.
+ * The key plus one jsonb field. `takenAt` and the source marker come off the key;
+ * `partial` is extracted IN Postgres rather than by shipping the row — a snapshot
+ * embeds a full scored payload, and deserializing the set to render a list of dates
+ * would grow with entries × snapshots for a list that shows neither.
+ *
+ * `partial` earns the exception: without it a mid-contest snapshot is
+ * indistinguishable from a final one in the list, which is the most damaging thing
+ * this screen can get wrong.
  */
 export async function listContestSnapshots({ collectionId }: { collectionId: number }) {
   try {
-    const rows = await dbRead.keyValue.findMany({
-      where: { key: { startsWith: `${CONTEST_SNAPSHOT_KEY_PREFIX}:${collectionId}:` } },
-      select: { key: true },
-    });
+    const rows = await dbRead.$queryRaw<{ key: string; partial: boolean | null }[]>`
+      SELECT kv."key" AS "key", (kv."value" ->> 'partial')::boolean AS "partial"
+      FROM "KeyValue" kv
+      WHERE kv."key" LIKE ${`${CONTEST_SNAPSHOT_KEY_PREFIX}:${collectionId}:%`}
+    `;
 
     return rows
-      .map(({ key }) => parseSnapshotKey(collectionId, key))
+      .map((row) => {
+        const ref = parseSnapshotKey(collectionId, row.key);
+        return ref ? { ...ref, partial: row.partial ?? false } : null;
+      })
       .filter((ref): ref is ContestSnapshotRef => !!ref)
       .sort((a, b) => b.takenAt.localeCompare(a.takenAt));
   } catch (e) {

--- a/src/server/services/contest-score.service.ts
+++ b/src/server/services/contest-score.service.ts
@@ -21,27 +21,37 @@
 
 import { Prisma } from '@prisma/client';
 import pLimit from 'p-limit';
-import * as z from 'zod';
+import { v4 as uuid } from 'uuid';
 import { CacheTTL, CONTEST_SNAPSHOT_KEY_PREFIX, KEY_VALUE_KEYS } from '~/server/common/constants';
+import { SignalMessages, SignalTopic } from '~/server/common/enums';
 import { clickhouse } from '~/server/clickhouse/client';
 import { dbRead, dbWrite } from '~/server/db/client';
 import { dbKV } from '~/server/db/db-helpers';
 import { logToAxiom } from '~/server/logging/client';
-import { REDIS_KEYS } from '~/server/redis/client';
+import { redis, REDIS_KEYS } from '~/server/redis/client';
 import type { RedisKeyTemplateCache } from '~/server/redis/client';
 import { collectionMetadataSchema } from '~/server/schema/collection.schema';
 import type {
+  ContestScoreRunState,
+  ContestScoringConfig,
+  ContestScoringScope,
   CreateContestSnapshotInput,
   GetCommunityScoreInput,
   GetContestCandidatesInput,
   ContestScoreSignal,
+  RunCommunityScoreInput,
+  SetContestScoringConfigInput,
 } from '~/server/schema/contest-score.schema';
-import { contestScoreSignals } from '~/server/schema/contest-score.schema';
-import { bustFetchThroughCache, fetchThroughCache } from '~/server/utils/cache-helpers';
+import {
+  contestScoreSignals,
+  contestScoringConfigSchema,
+} from '~/server/schema/contest-score.schema';
+import { fetchThroughCache } from '~/server/utils/cache-helpers';
 import { withDistributedLock } from '~/server/utils/distributed-lock';
 import { throwBadRequestError } from '~/server/utils/errorHandling';
 import { withSpan } from '~/server/utils/otel-helpers';
 import { Availability, CollectionItemStatus, CollectionMode } from '~/shared/utils/prisma/enums';
+import { signalClient } from '~/utils/signal-client';
 import { hashifyObject } from '~/utils/string-helpers';
 
 type Signal = ContestScoreSignal;
@@ -76,7 +86,10 @@ export const CONTEST_SIGNAL_SOURCES: Record<Signal, string> = {
 };
 
 const MAX_ENTRIES = 1000;
-const SCORE_CACHE_TTL = 60 * 15;
+// A finished run stays readable for a day so the tab opens on the last result rather
+// than on an empty table waiting for a fresh run.
+const RESULT_TTL = CacheTTL.day;
+const RUN_STATE_TTL = CacheTTL.hour;
 // Entities per ClickHouse call. Chunks are cut along ENTRY boundaries, never entity
 // ones: uniqExact cannot be summed across chunks, so every entity belonging to an
 // entry has to be counted in the same call.
@@ -99,69 +112,172 @@ const DEFAULT_STATUSES: CollectionItemStatus[] = [CollectionItemStatus.ACCEPTED]
  */
 export class ContestScoringError extends Error {}
 
-function sanitizeError(collectionId: number, e: unknown): never {
-  if (e instanceof ContestScoringError) throw throwBadRequestError(e.message);
+function safeErrorMessage(collectionId: number, e: unknown) {
+  if (e instanceof ContestScoringError) return e.message;
   const error = e as Error;
   logToAxiom(
     { name: 'contest-score', type: 'error', collectionId, message: error?.message },
     'civitai-prod'
   ).catch(() => null);
   console.error('[contest-score] failed', collectionId, error?.message);
-  throw new Error('Contest scoring failed. See server logs.');
+  return 'Contest scoring failed. See server logs.';
+}
+
+function sanitizeError(collectionId: number, e: unknown): never {
+  if (e instanceof ContestScoringError) throw throwBadRequestError(e.message);
+  throw new Error(safeErrorMessage(collectionId, e));
 }
 
 // ---------------------------------------------------------------------------
 // Config
 // ---------------------------------------------------------------------------
 
-// Structural validation only. A bound on a weight or a threshold discloses that
-// value's range, so nothing here constrains magnitude.
-const weightsSchema = z.object(
-  Object.fromEntries(contestScoreSignals.map((s) => [s, z.number()])) as Record<Signal, z.ZodNumber>
-);
-const storedConfigSchema = z.object({
-  version: z.number(),
-  weights: weightsSchema,
-  ageGateDays: z.number(),
-  // Floor on each signal's normalization denominator. Where a category's leading
-  // qualified count is tiny, plain max-normalization lets one or two users swing a
-  // signal from 0 to 0.5 and decide a placement on noise.
-  minDenominator: weightsSchema,
-  // Ceiling on the engager set resolved against Postgres. Past it the banned/deleted
-  // refinement is skipped and the run is flagged degraded rather than run anyway.
-  maxEngagers: z.number(),
-  farmIp: z.object({ minPeers: z.number(), minEntries: z.number() }),
-});
-
-export type ContestScoringConfig = z.infer<typeof storedConfigSchema>;
-
 const configKey = (suffix: number | 'default') => `${KEY_VALUE_KEYS.CONTEST_SCORING}:${suffix}`;
+const scopeSuffix = (scope: ContestScoringScope, collectionId: number) =>
+  scope === 'global' ? ('default' as const) : collectionId;
+
+type ResolvedConfig = { config: ContestScoringConfig; scope: ContestScoringScope };
+
+function parseConfig(collectionId: number, stored: unknown): ContestScoringConfig {
+  const parsed = contestScoringConfigSchema.safeParse(stored);
+  if (!parsed.success)
+    throw new ContestScoringError(
+      `The contest scoring config for collection ${collectionId} is malformed: ${parsed.error.message}`
+    );
+  return parsed.data;
+}
 
 /**
  * Per-collection config with a global fallback. One shared row would let a later
  * edit retroactively change a finished contest's ranking.
+ *
+ * The winning SCOPE travels with the config because it is part of the run's cache
+ * identity: a fresh per-collection row can carry a lower `version` than the global
+ * one it overrides, so version alone would let the collection-scoped run collide with
+ * a stale globally-scoped one.
  */
-export async function getContestScoringConfig(collectionId: number): Promise<ContestScoringConfig> {
+async function resolveContestScoringConfig(collectionId: number): Promise<ResolvedConfig> {
   const [specific, fallback] = await Promise.all([
     dbKV.get<unknown>(configKey(collectionId)),
     dbKV.get<unknown>(configKey('default')),
   ]);
 
-  const stored = specific ?? fallback;
-  if (!stored)
+  if (!specific && !fallback)
     throw new ContestScoringError(
       `Contest scoring is not configured: neither "${configKey(collectionId)}" nor "${configKey(
         'default'
       )}" exists in KeyValue. Weights and thresholds live only in the database — there is no code fallback.`
     );
 
-  const parsed = storedConfigSchema.safeParse(stored);
-  if (!parsed.success)
-    throw new ContestScoringError(
-      `The contest scoring config for collection ${collectionId} is malformed: ${parsed.error.message}`
-    );
+  return specific
+    ? { config: parseConfig(collectionId, specific), scope: 'collection' }
+    : { config: parseConfig(collectionId, fallback), scope: 'global' };
+}
 
-  return parsed.data;
+export async function getContestScoringConfig(collectionId: number): Promise<ContestScoringConfig> {
+  return (await resolveContestScoringConfig(collectionId)).config;
+}
+
+/**
+ * The moderator-facing read. Deliberately a SEPARATE procedure from the scoring
+ * query: the score payload carries no weights, denominators or thresholds, so
+ * relaxing the gate on one endpoint cannot expose the other.
+ */
+export async function getContestScoringConfigForEditor(collectionId: number) {
+  try {
+    const [specific, fallback] = await Promise.all([
+      dbKV.get<unknown>(configKey(collectionId)),
+      dbKV.get<unknown>(configKey('default')),
+    ]);
+
+    return {
+      collectionId,
+      effectiveScope: (specific ? 'collection' : 'global') as ContestScoringScope,
+      collection: specific ? parseConfig(collectionId, specific) : null,
+      global: fallback ? parseConfig(collectionId, fallback) : null,
+    };
+  } catch (e) {
+    return sanitizeError(collectionId, e);
+  }
+}
+
+/**
+ * Append-only audit rows, one per edit:
+ *   contestScoring:audit:<collectionId|default>:<ISO>
+ *
+ * Written with `create` inside the same transaction as the config write, so a
+ * config change that is not accompanied by an audit row cannot exist. `create` and
+ * not `upsert`: colliding on an existing row must fail loudly rather than silently
+ * rewrite history.
+ */
+const auditKey = (suffix: number | 'default', at: string) =>
+  `${KEY_VALUE_KEYS.CONTEST_SCORING}:audit:${suffix}:${at}`;
+
+export async function setContestScoringConfig({
+  input,
+  userId,
+  username,
+}: {
+  input: SetContestScoringConfigInput;
+  userId: number;
+  username?: string | null;
+}) {
+  const { collectionId, scope, config, reason } = input;
+  try {
+    const suffix = scopeSuffix(scope, collectionId);
+    const key = configKey(suffix);
+
+    const [existingRaw, defaultRaw] = await Promise.all([
+      dbKV.get<unknown>(key),
+      dbKV.get<unknown>(configKey('default')),
+    ]);
+    const existing = existingRaw ? parseConfig(collectionId, existingRaw) : null;
+    const globalConfig = defaultRaw ? parseConfig(collectionId, defaultRaw) : null;
+
+    // Above BOTH rows, never just the one being written. A per-collection row that
+    // started below the global version could otherwise mint a cache identity a
+    // previous run already used.
+    const version = Math.max(existing?.version ?? 0, globalConfig?.version ?? 0) + 1;
+    const updatedAt = new Date().toISOString();
+    const next: ContestScoringConfig = {
+      ...config,
+      version,
+      updatedById: userId,
+      updatedByUsername: username ?? null,
+      updatedAt,
+    };
+
+    await dbWrite.$transaction([
+      dbWrite.keyValue.upsert({
+        where: { key },
+        create: { key, value: next as unknown as Prisma.InputJsonValue },
+        update: { value: next as unknown as Prisma.InputJsonValue },
+      }),
+      dbWrite.keyValue.create({
+        data: {
+          key: auditKey(suffix, updatedAt),
+          value: {
+            userId,
+            username: username ?? null,
+            scope,
+            collectionId,
+            ...(reason ? { reason } : {}),
+            before: existing,
+            after: next,
+          } as unknown as Prisma.InputJsonValue,
+        },
+      }),
+    ]);
+
+    // The version bump already orphans every result key this collection had cached
+    // (version is part of the key), so the stale result is unreachable and TTLs out.
+    // Dropping the run pointer is what stops the UI from presenting it as current.
+    await clearLatestRun(collectionId);
+
+    return { scope, version, updatedAt };
+  } catch (e) {
+    return sanitizeError(collectionId, e);
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -1092,44 +1208,163 @@ async function computeCommunityScore(
 // Public API
 // ---------------------------------------------------------------------------
 
-function cacheKeyFor(input: WindowInput, configVersion: number) {
-  return `${REDIS_KEYS.CACHES.CONTEST_COMMUNITY_SCORE}:${input.collectionId}:${hashifyObject({
+const runNamespace = (collectionId: number) =>
+  `${REDIS_KEYS.CACHES.CONTEST_SCORE_RUN}:${collectionId}`;
+const runStateKey = (collectionId: number, runId: string) =>
+  `${runNamespace(collectionId)}:run:${runId}` as RedisKeyTemplateCache;
+const latestRunKey = (collectionId: number) =>
+  `${runNamespace(collectionId)}:latest` as RedisKeyTemplateCache;
+
+/**
+ * A run's identity: the window, the filters, and the exact config and code that
+ * produced it. A config edit bumps `version`, so the previous result becomes
+ * unreachable at its old key and expires on its own rather than being served as if
+ * the new weights had produced it.
+ */
+function resultKeyFor(
+  input: WindowInput,
+  config: ContestScoringConfig,
+  scope: ContestScoringScope
+) {
+  return `${runNamespace(input.collectionId)}:result:${hashifyObject({
     start: input.start?.toISOString(),
     end: input.end?.toISOString(),
     tagIds: input.tagIds,
     statuses: input.statuses,
-    configVersion,
+    configScope: scope,
+    configVersion: config.version,
     codeVersion: CONTEST_SCORE_CODE_VERSION,
   })}` as RedisKeyTemplateCache;
 }
 
-export async function getCommunityScore(input: GetCommunityScoreInput) {
-  const { refresh, ...window } = input;
-  try {
-    const config = await getContestScoringConfig(window.collectionId);
-    const cacheKey = cacheKeyFor(window, config.version);
+async function clearLatestRun(collectionId: number) {
+  await redis.del(latestRunKey(collectionId)).catch(() => null);
+}
 
-    if (refresh) await bustFetchThroughCache(cacheKey);
+/**
+ * Run state is Redis-only and every key carries a TTL, so the namespace self-cleans
+ * and an abandoned run cannot outlive its usefulness. The signal is best-effort: the
+ * state in Redis is the truth, and the read query returns it, so a dropped push
+ * costs a refresh rather than a stuck UI.
+ */
+async function publishRunState(state: ContestScoreRunState) {
+  await Promise.all([
+    redis.packed.set(runStateKey(state.collectionId, state.runId), state, { EX: RUN_STATE_TTL }),
+    redis.packed.set(latestRunKey(state.collectionId), state, { EX: RUN_STATE_TTL }),
+  ]);
 
-    return await fetchThroughCache(
-      cacheKey,
-      async () => {
-        // One run per collection at a time. A refresh storm would otherwise stack
-        // full cross-store aggregations on top of one another.
-        const result = await withDistributedLock(
-          { key: `contest-score:${window.collectionId}`, ttl: 120, maxRetries: 60 },
-          () => computeCommunityScore(window)
-        );
-        if (!result)
-          throw new ContestScoringError(
-            'A scoring run for this collection is already in progress. Try again shortly.'
-          );
-        return result;
-      },
-      { ttl: SCORE_CACHE_TTL }
+  signalClient
+    .topicSend({
+      topic: `${SignalTopic.ContestScore}:${state.collectionId}`,
+      target: SignalMessages.ContestScoreRunUpdate,
+      // Run bookkeeping only. A topic is joinable by any connected client, so no
+      // score and no config value may ride on this payload.
+      data: state,
+    })
+    .catch((error: Error) =>
+      console.error('[contest-score] failed to signal run state', state.runId, error?.message)
     );
+}
+
+async function readRunState(collectionId: number) {
+  return (await redis.packed.get<ContestScoreRunState>(latestRunKey(collectionId))) ?? null;
+}
+
+async function executeRun(input: WindowInput, state: ContestScoreRunState) {
+  const startedAt = new Date().toISOString();
+  await publishRunState({ ...state, status: 'running', startedAt });
+
+  try {
+    const { config, scope } = await resolveContestScoringConfig(input.collectionId);
+
+    // One run per collection at a time. Nothing is waiting on the response now, so
+    // the loser of the race waits for the lock rather than failing the caller.
+    const result = await withDistributedLock(
+      { key: `contest-score:${input.collectionId}`, ttl: 600, retryDelay: 500, maxRetries: 240 },
+      () => computeCommunityScore(input)
+    );
+    if (!result)
+      throw new ContestScoringError(
+        'A scoring run for this collection is already in progress. Try again shortly.'
+      );
+
+    await redis.packed.set(resultKeyFor(input, config, scope), result, { EX: RESULT_TTL });
+    await publishRunState({
+      ...state,
+      status: 'done',
+      startedAt,
+      finishedAt: new Date().toISOString(),
+      generatedAt: result.generatedAt,
+    });
   } catch (e) {
-    return sanitizeError(window.collectionId, e);
+    await publishRunState({
+      ...state,
+      status: 'failed',
+      startedAt,
+      finishedAt: new Date().toISOString(),
+      error: safeErrorMessage(input.collectionId, e),
+    });
+  }
+}
+
+/**
+ * Enqueues a run and returns immediately. The compute is detached on purpose: a full
+ * cross-store aggregation outlives a request timeout on a large contest, and the run
+ * state in Redis — not the HTTP response — is what the UI follows.
+ */
+export async function runCommunityScore({
+  input,
+  userId,
+}: {
+  input: RunCommunityScoreInput;
+  userId: number;
+}): Promise<ContestScoreRunState> {
+  try {
+    // Resolved before enqueueing so a misconfiguration or a non-contest collection
+    // fails the mutation rather than surfacing minutes later as a failed run.
+    requireClickhouse();
+    const { config } = await resolveContestScoringConfig(input.collectionId);
+    await resolveWindow(input.collectionId, input, config);
+
+    const state: ContestScoreRunState = {
+      runId: uuid(),
+      collectionId: input.collectionId,
+      status: 'queued',
+      requestedBy: userId,
+      requestedAt: new Date().toISOString(),
+      startedAt: null,
+      finishedAt: null,
+      error: null,
+      generatedAt: null,
+    };
+    await publishRunState(state);
+
+    void executeRun(input, state).catch((error: Error) =>
+      console.error('[contest-score] run crashed', state.runId, error?.message)
+    );
+
+    return state;
+  } catch (e) {
+    return sanitizeError(input.collectionId, e);
+  }
+}
+
+/**
+ * Read-only. Returns whatever the last completed run produced for this window plus
+ * the current run state; it never computes. The client keeps the previous result on
+ * screen while a run is in flight, so a run starting must not blank the table.
+ */
+export async function getCommunityScore(input: GetCommunityScoreInput) {
+  try {
+    const { config, scope } = await resolveContestScoringConfig(input.collectionId);
+    const [result, run] = await Promise.all([
+      redis.packed.get<ContestCommunityScore>(resultKeyFor(input, config, scope)),
+      readRunState(input.collectionId),
+    ]);
+
+    return { result: result ?? null, run };
+  } catch (e) {
+    return sanitizeError(input.collectionId, e);
   }
 }
 
@@ -1439,16 +1674,67 @@ export async function createContestSnapshot({
   }
 }
 
+export type ContestSnapshotRef = { key: string; source: string | null; takenAt: string };
+
+/**
+ * The key carries everything the list needs, so `takenAt` and the source marker are
+ * read back off it: `<prefix>:<collectionId>:[source:]<ISO>`. The ISO timestamp
+ * contains colons of its own, hence the leading-year test rather than a field count.
+ */
+function parseSnapshotKey(collectionId: number, key: string): ContestSnapshotRef | null {
+  const prefix = `${CONTEST_SNAPSHOT_KEY_PREFIX}:${collectionId}:`;
+  if (!key.startsWith(prefix)) return null;
+
+  const rest = key.slice(prefix.length);
+  if (/^\d{4}-/.test(rest)) return { key, source: null, takenAt: rest };
+
+  const split = rest.indexOf(':');
+  if (split < 0) return null;
+  return { key, source: rest.slice(0, split), takenAt: rest.slice(split + 1) };
+}
+
+/**
+ * Keys only. Every snapshot embeds a full scored payload, so deserializing the set
+ * just to render a list of dates would grow with entries × snapshots for a list that
+ * shows neither. The value is fetched for ONE snapshot, on click.
+ */
 export async function listContestSnapshots({ collectionId }: { collectionId: number }) {
   try {
     const rows = await dbRead.keyValue.findMany({
       where: { key: { startsWith: `${CONTEST_SNAPSHOT_KEY_PREFIX}:${collectionId}:` } },
-      select: { key: true, value: true },
+      select: { key: true },
     });
 
     return rows
-      .map(({ key, value }) => toSnapshotSummary(key, value as unknown as ContestSnapshot))
+      .map(({ key }) => parseSnapshotKey(collectionId, key))
+      .filter((ref): ref is ContestSnapshotRef => !!ref)
       .sort((a, b) => b.takenAt.localeCompare(a.takenAt));
+  } catch (e) {
+    return sanitizeError(collectionId, e);
+  }
+}
+
+export async function getContestSnapshot({
+  collectionId,
+  key,
+}: {
+  collectionId: number;
+  key: string;
+}) {
+  try {
+    // The key is client-supplied, so it is re-derived against this collection's
+    // prefix before it reaches the query — a KeyValue lookup by arbitrary key would
+    // read any row in the table, config and audit rows included.
+    if (!parseSnapshotKey(collectionId, key))
+      throw new ContestScoringError('That snapshot does not belong to this collection.');
+
+    const row = await dbRead.keyValue.findUnique({ where: { key }, select: { value: true } });
+    if (!row) throw new ContestScoringError('Snapshot not found.');
+
+    const snapshot = row.value as unknown as ContestSnapshot;
+    // `config` — and therefore the weights — is dropped by toSnapshotSummary. It is
+    // stored for audit, never served.
+    return { ...toSnapshotSummary(key, snapshot), score: snapshot.score };
   } catch (e) {
     return sanitizeError(collectionId, e);
   }

--- a/src/server/services/contest-score.service.ts
+++ b/src/server/services/contest-score.service.ts
@@ -383,17 +383,6 @@ async function resolveWindow(
     );
   const metadata = parsed.data;
 
-  const start = input.start ?? metadata.submissionStartDate;
-  const end = input.end ?? metadata.submissionEndDate ?? metadata.endsAt;
-  if (!start)
-    throw new ContestScoringError(
-      `Collection ${collectionId} has no submissionStartDate and no explicit window start was given.`
-    );
-  if (!end)
-    throw new ContestScoringError(
-      `Collection ${collectionId} has neither submissionEndDate nor endsAt, and no explicit window end was given.`
-    );
-
   // The contest's own bounds, and NEVER the display window: these decide the age gate
   // and which versions qualify, so letting them fall back to the date pickers would
   // hand eligibility to whoever is looking at the screen. The two bounds resolve
@@ -419,6 +408,14 @@ async function resolveWindow(
     throw new ContestScoringError(
       `Collection ${collectionId} has neither submissionEndDate nor endsAt, so there is no trustworthy end for deciding which versions qualify. An explicit window end only narrows the view; it cannot define the contest.`
     );
+
+  // The display window defaults to the whole contest. Resolved AFTER the bounds above
+  // and from them, so a contest carrying only an `endsAt` scores without a moderator
+  // having to invent a start date — one that no longer affects eligibility and so would
+  // be asking them to supply a number that changes nothing.
+  const start = input.start ?? contestStart;
+  const end = input.end ?? contestEnd;
+
   const ageCutoff = new Date(contestStart.getTime() - config.ageGateDays * 24 * 60 * 60 * 1000);
 
   // Belt and braces behind the schema's `nonnegative()`: a row written before that

--- a/src/server/services/contest-score.service.ts
+++ b/src/server/services/contest-score.service.ts
@@ -27,7 +27,12 @@
 import { Prisma } from '@prisma/client';
 import pLimit from 'p-limit';
 import { v4 as uuid } from 'uuid';
-import { CacheTTL, CONTEST_SNAPSHOT_KEY_PREFIX, KEY_VALUE_KEYS } from '~/server/common/constants';
+import {
+  CacheTTL,
+  CONTEST_SCORE_CODE_VERSION,
+  CONTEST_SNAPSHOT_KEY_PREFIX,
+  KEY_VALUE_KEYS,
+} from '~/server/common/constants';
 import { SignalMessages, SignalTopic } from '~/server/common/enums';
 import { clickhouse } from '~/server/clickhouse/client';
 import { dbRead, dbWrite } from '~/server/db/client';
@@ -76,12 +81,6 @@ type Signal = ContestScoreSignal;
  */
 const utc = (d: Date) => Prisma.sql`(${d}::timestamptz AT TIME ZONE 'UTC')`;
 const nowUtc = Prisma.raw(`(NOW() AT TIME ZONE 'UTC')`);
-
-/**
- * Bumped whenever a change here could move a ranking. Recorded in every snapshot so
- * a disputed result can be traced to the code that produced it.
- */
-export const CONTEST_SCORE_CODE_VERSION = 5;
 
 /**
  * Comments and tips are deliberately unweighted: both are trivially launderable
@@ -2070,7 +2069,26 @@ export type ContestSnapshot = {
   score: ContestCommunityScore;
 };
 
-export type ContestSnapshotSummary = Omit<ContestSnapshot, 'config' | 'score'> & {
+/**
+ * The READ shape, and deliberately weaker than the write shape above. A stored row is
+ * whatever the code that wrote it produced, and it is cast through unvalidated — so
+ * every field added after the first snapshot is optional here.
+ *
+ * `ContestSnapshot` describes what we WRITE today; this describes what we may FIND.
+ * Conflating the two is what let a missing field be dereferenced and take down the
+ * whole results panel. A field added later must not typecheck as present on a row
+ * written before it existed.
+ */
+export type StoredContestSnapshot = Omit<
+  ContestSnapshot,
+  'codeVersion' | 'baseModels' | 'baseModelSource'
+> & {
+  codeVersion?: number;
+  baseModels?: string[];
+  baseModelSource?: ResolvedBaseModels['source'];
+};
+
+export type ContestSnapshotSummary = Omit<StoredContestSnapshot, 'config' | 'score'> & {
   key: string;
   window: ContestCommunityScore['window'];
   entryCount: number;
@@ -2079,7 +2097,7 @@ export type ContestSnapshotSummary = Omit<ContestSnapshot, 'config' | 'score'> &
 const snapshotKey = (collectionId: number, takenAt: string, source: string | null) =>
   [CONTEST_SNAPSHOT_KEY_PREFIX, collectionId, ...(source ? [source] : []), takenAt].join(':');
 
-function toSnapshotSummary(key: string, snapshot: ContestSnapshot): ContestSnapshotSummary {
+function toSnapshotSummary(key: string, snapshot: StoredContestSnapshot): ContestSnapshotSummary {
   // `config` — and therefore the weights — is dropped here. It is stored for audit,
   // never served.
   const { config: _config, score, ...rest } = snapshot;
@@ -2233,7 +2251,7 @@ export async function getContestSnapshot({
     const row = await dbRead.keyValue.findUnique({ where: { key }, select: { value: true } });
     if (!row) throw new ContestScoringError('Snapshot not found.');
 
-    const snapshot = row.value as unknown as ContestSnapshot;
+    const snapshot = row.value as unknown as StoredContestSnapshot;
     // `config` — and therefore the weights — is dropped by toSnapshotSummary. It is
     // stored for audit, never served.
     return { ...toSnapshotSummary(key, snapshot), score: snapshot.score };

--- a/src/server/services/contest-score.service.ts
+++ b/src/server/services/contest-score.service.ts
@@ -9,19 +9,27 @@
  * Categories are separate contests — normalization and ranking never cross a
  * category boundary, so raw volume is never compared across them.
  *
- * Weights and anti-cheat thresholds are NOT in this file and have no code default.
- * They live in the `contestScoring` KeyValue row; this module fails loudly when it
- * is missing. Nothing derived from them is ever returned to the client.
+ * Every count is computed IN the database. No user-id array ever crosses into
+ * Node: the age gate becomes a `userId <= threshold` pushdown, and the (small)
+ * disqualified set is pushed into each query as a literal id list.
+ *
+ * Weights and thresholds are NOT in this file and have no code default. They live
+ * in `contestScoring:<collectionId>` (falling back to `contestScoring:default`);
+ * this module fails loudly when neither row exists. They are recorded in every
+ * snapshot and stripped from every response.
  */
 
 import { Prisma } from '@prisma/client';
+import pLimit from 'p-limit';
 import * as z from 'zod';
 import { CONTEST_SNAPSHOT_KEY_PREFIX, KEY_VALUE_KEYS } from '~/server/common/constants';
 import { clickhouse } from '~/server/clickhouse/client';
 import { dbRead, dbWrite } from '~/server/db/client';
 import { dbKV } from '~/server/db/db-helpers';
+import { logToAxiom } from '~/server/logging/client';
 import { REDIS_KEYS } from '~/server/redis/client';
 import type { RedisKeyTemplateCache } from '~/server/redis/client';
+import { collectionMetadataSchema } from '~/server/schema/collection.schema';
 import type {
   CreateContestSnapshotInput,
   GetCommunityScoreInput,
@@ -29,14 +37,20 @@ import type {
   ContestScoreSignal,
 } from '~/server/schema/contest-score.schema';
 import { contestScoreSignals } from '~/server/schema/contest-score.schema';
-import { getUserCollectionPermissionsById } from '~/server/services/collection.service';
 import { bustFetchThroughCache, fetchThroughCache } from '~/server/utils/cache-helpers';
-import { throwAuthorizationError, throwBadRequestError } from '~/server/utils/errorHandling';
+import { withDistributedLock } from '~/server/utils/distributed-lock';
+import { throwBadRequestError } from '~/server/utils/errorHandling';
 import { withSpan } from '~/server/utils/otel-helpers';
-import { CollectionItemStatus } from '~/shared/utils/prisma/enums';
+import { Availability, CollectionItemStatus, CollectionMode } from '~/shared/utils/prisma/enums';
 import { hashifyObject } from '~/utils/string-helpers';
 
 type Signal = ContestScoreSignal;
+
+/**
+ * Bumped whenever a change here could move a ranking. Recorded in every snapshot so
+ * a disputed result can be traced to the code that produced it.
+ */
+export const CONTEST_SCORE_CODE_VERSION = 2;
 
 /**
  * Comments and tips are deliberately unweighted: both are trivially launderable
@@ -50,84 +64,226 @@ export const CONTEST_SIGNAL_SOURCES: Record<Signal, string> = {
   collectors: 'Distinct users adding the model to another collection',
 };
 
-// A ClickHouse `IN` list is materialized in the query string; chunk to keep it sane.
-const CH_IN_CHUNK = 25000;
 const MAX_ENTRIES = 1000;
 const SCORE_CACHE_TTL = 60 * 15;
+// Entities per ClickHouse call. Chunks are cut along ENTRY boundaries, never entity
+// ones: uniqExact cannot be summed across chunks, so every entity belonging to an
+// entry has to be counted in the same call.
+const CH_ENTITY_CHUNK = 20000;
+const CH_CONCURRENCY = 4;
 const DEFAULT_STATUSES: CollectionItemStatus[] = [CollectionItemStatus.ACCEPTED];
 
+/**
+ * An error whose message is safe to show the caller — a misconfiguration or a bad
+ * request, never a query failure. Everything else is logged and replaced with a
+ * generic message, because the ClickHouse `$query` wrapper appends the generated
+ * SQL (id lists included) to the errors it throws.
+ */
+export class ContestScoringError extends Error {}
+
+function sanitizeError(collectionId: number, e: unknown): never {
+  if (e instanceof ContestScoringError) throw throwBadRequestError(e.message);
+  const error = e as Error;
+  logToAxiom(
+    { name: 'contest-score', type: 'error', collectionId, message: error?.message },
+    'civitai-prod'
+  ).catch(() => null);
+  console.error('[contest-score] failed', collectionId, error?.message);
+  throw new Error('Contest scoring failed. See server logs.');
+}
+
+// ---------------------------------------------------------------------------
+// Config
+// ---------------------------------------------------------------------------
+
+// Structural validation only. A bound on a weight or a threshold discloses that
+// value's range, so nothing here constrains magnitude.
 const weightsSchema = z.object(
-  Object.fromEntries(contestScoreSignals.map((s) => [s, z.number().min(0)])) as Record<
-    Signal,
-    z.ZodNumber
-  >
+  Object.fromEntries(contestScoreSignals.map((s) => [s, z.number()])) as Record<Signal, z.ZodNumber>
 );
-const settingsSchema = z.object({
-  weights: weightsSchema,
-  ageGateDays: z.number().min(0),
-  farmIp: z.object({ minPeers: z.number().int().min(1), minEntries: z.number().int().min(1) }),
-});
-const settingsOverrideSchema = z.object({
-  weights: weightsSchema.partial().optional(),
-  ageGateDays: z.number().min(0).optional(),
-  farmIp: z
-    .object({ minPeers: z.number().int().min(1), minEntries: z.number().int().min(1) })
-    .partial()
-    .optional(),
-});
 const storedConfigSchema = z.object({
-  version: z.number().int().min(1),
-  default: settingsSchema,
-  collections: z.record(z.string(), settingsOverrideSchema).optional(),
+  version: z.number(),
+  weights: weightsSchema,
+  ageGateDays: z.number(),
+  farmIp: z.object({ minPeers: z.number(), minEntries: z.number() }),
 });
 
-type ContestScoringSettings = z.infer<typeof settingsSchema>;
-type ContestScoringConfig = ContestScoringSettings & { version: number };
+export type ContestScoringConfig = z.infer<typeof storedConfigSchema>;
 
+const configKey = (suffix: number | 'default') => `${KEY_VALUE_KEYS.CONTEST_SCORING}:${suffix}`;
+
+/**
+ * Per-collection config with a global fallback. One shared row would let a later
+ * edit retroactively change a finished contest's ranking.
+ */
 export async function getContestScoringConfig(collectionId: number): Promise<ContestScoringConfig> {
-  const stored = await dbKV.get<unknown>(KEY_VALUE_KEYS.CONTEST_SCORING);
+  const [specific, fallback] = await Promise.all([
+    dbKV.get<unknown>(configKey(collectionId)),
+    dbKV.get<unknown>(configKey('default')),
+  ]);
+
+  const stored = specific ?? fallback;
   if (!stored)
-    throw new Error(
-      `Contest scoring is not configured: the "${KEY_VALUE_KEYS.CONTEST_SCORING}" KeyValue row is missing. Weights and thresholds live only in the database — there is no code fallback.`
+    throw new ContestScoringError(
+      `Contest scoring is not configured: neither "${configKey(collectionId)}" nor "${configKey(
+        'default'
+      )}" exists in KeyValue. Weights and thresholds live only in the database — there is no code fallback.`
     );
 
   const parsed = storedConfigSchema.safeParse(stored);
   if (!parsed.success)
-    throw new Error(
-      `The "${KEY_VALUE_KEYS.CONTEST_SCORING}" KeyValue row is malformed: ${parsed.error.message}`
+    throw new ContestScoringError(
+      `The contest scoring config for collection ${collectionId} is malformed: ${parsed.error.message}`
     );
 
-  const { version, default: base, collections } = parsed.data;
-  const override = collections?.[String(collectionId)];
+  return parsed.data;
+}
+
+// ---------------------------------------------------------------------------
+// Window
+// ---------------------------------------------------------------------------
+
+export type ResolvedWindow = {
+  start: Date;
+  end: Date;
+  /** `end` clamped to now. A contest still running is scored up to this instant. */
+  effectiveEnd: Date;
+  /** True while the contest is still open — the run is a preview, not a result. */
+  partial: boolean;
+  ageCutoff: Date;
+};
+
+/**
+ * Derived from the collection's own contest metadata, never defaulted. An absent
+ * window silently becoming "all time" would switch the age gate off, which is the
+ * worst way for this to fail.
+ */
+async function resolveWindow(
+  collectionId: number,
+  input: { start?: Date; end?: Date },
+  config: ContestScoringConfig
+): Promise<ResolvedWindow> {
+  const collection = await dbRead.collection.findUnique({
+    where: { id: collectionId },
+    select: { id: true, mode: true, metadata: true },
+  });
+  if (!collection) throw new ContestScoringError(`Collection ${collectionId} not found`);
+  if (collection.mode !== CollectionMode.Contest)
+    throw new ContestScoringError(`Collection ${collectionId} is not a contest collection`);
+
+  const parsed = collectionMetadataSchema.safeParse(collection.metadata ?? {});
+  const metadata = parsed.success ? parsed.data : {};
+
+  const start = input.start ?? metadata.submissionStartDate;
+  const end = input.end ?? metadata.submissionEndDate ?? metadata.endsAt;
+  if (!start)
+    throw new ContestScoringError(
+      `Collection ${collectionId} has no submissionStartDate and no explicit window start was given.`
+    );
+  if (!end)
+    throw new ContestScoringError(
+      `Collection ${collectionId} has neither submissionEndDate nor endsAt, and no explicit window end was given.`
+    );
+
+  // Always the contest's own start, never a narrowed display window — otherwise
+  // zooming the view would drag the age gate along with it.
+  const contestStart = metadata.submissionStartDate ?? start;
+  const ageCutoff = new Date(contestStart.getTime() - config.ageGateDays * 24 * 60 * 60 * 1000);
+
+  const now = new Date();
+  const partial = end > now;
+
+  return { start, end, effectiveEnd: partial ? now : end, partial, ageCutoff };
+}
+
+// ---------------------------------------------------------------------------
+// Gates
+// ---------------------------------------------------------------------------
+
+type Gates = {
+  /** An account with an id above this registered after the cutoff. */
+  userIdThreshold: number;
+  /**
+   * Users wrongly caught by the id threshold: registered before the cutoff but
+   * holding an id above it. Recorded so a snapshot can be audited.
+   */
+  ageGateBandUsers: number;
+  disqualifiedIds: number[];
+};
+
+async function loadGates(window: ResolvedWindow): Promise<Gates> {
+  // `User.id` is autoincrement but NOT strictly monotonic with `createdAt` — at
+  // least one backdated system account exists. `max(id) WHERE createdAt <= cutoff`
+  // would let that single row drag the threshold up and wave through every account
+  // registered since. `min(id) WHERE createdAt > cutoff` minus one can only ever be
+  // too strict, which is the safe direction for an anti-cheat gate.
+  const [threshold] = await withSpan(
+    'contest-score.age-threshold',
+    () =>
+      dbRead.$queryRaw<{ threshold: number; bandUsers: number }[]>`
+      WITH t AS (
+        SELECT COALESCE(
+          (SELECT min(id) FROM "User" WHERE "createdAt" > ${window.ageCutoff}) - 1,
+          (SELECT max(id) FROM "User")
+        ) AS threshold
+      )
+      SELECT
+        t.threshold::int AS "threshold",
+        (
+          SELECT count(*)::int FROM "User" u
+          WHERE u."createdAt" <= ${window.ageCutoff} AND u.id > t.threshold
+        ) AS "bandUsers"
+      FROM t
+    `
+  );
+
+  if (threshold?.bandUsers)
+    console.warn(
+      `[contest-score] age gate band holds ${threshold.bandUsers} user(s) registered before the cutoff but carrying an id above the threshold; they are disqualified.`
+    );
+
+  // Only accounts banned or deleted ON OR AFTER the window start can have engaged
+  // during it — every signal here requires an authenticated action and a banned or
+  // deleted account cannot perform one. That turns a 1.35M-row set into a few
+  // thousand, small enough to push into ClickHouse. Contest bans are unconditional
+  // (a scoring sanction, not an access one) and number in the dozens.
+  const banned = await withSpan(
+    'contest-score.banned',
+    () =>
+      dbRead.$queryRaw<{ id: number }[]>`
+      SELECT u.id
+      FROM "User" u
+      WHERE u.id <= ${threshold.threshold}
+        AND (
+          u."bannedAt" >= ${window.start}
+          OR u."deletedAt" >= ${window.start}
+          OR u.meta ->> 'contestBanDetails' IS NOT NULL
+        )
+    `
+  );
+
+  const excluded = await withSpan('contest-score.excluded-users', () =>
+    clickhouse!.$query<{ userId: number }>(`
+      SELECT userId FROM metricExcludedUsers FINAL WHERE active = 1
+    `)
+  );
+
+  const disqualifiedIds = [
+    ...new Set([...banned.map((b) => b.id), ...excluded.map((e) => Number(e.userId))]),
+  ].sort((a, b) => a - b);
 
   return {
-    version,
-    weights: { ...base.weights, ...override?.weights },
-    ageGateDays: override?.ageGateDays ?? base.ageGateDays,
-    farmIp: { ...base.farmIp, ...override?.farmIp },
+    userIdThreshold: threshold.threshold,
+    ageGateBandUsers: threshold.bandUsers,
+    disqualifiedIds,
   };
 }
 
-export async function assertCanScoreContest({
-  collectionId,
-  userId,
-  isModerator,
-}: {
-  collectionId: number;
-  userId: number;
-  isModerator?: boolean;
-}) {
-  const permissions = await getUserCollectionPermissionsById({
-    id: collectionId,
-    userId,
-    isModerator,
-  });
-  if (!permissions.manage)
-    throw throwAuthorizationError('You do not have permission to score this collection');
-  return permissions;
-}
+// ---------------------------------------------------------------------------
+// Entries
+// ---------------------------------------------------------------------------
 
-type Entry = {
+type EntryRow = {
   collectionItemId: number;
   modelId: number;
   modelName: string;
@@ -137,8 +293,9 @@ type Entry = {
   tagId: number | null;
   tagName: string | null;
   status: string;
-  versionIds: number[];
-  signals: Record<Signal, Set<number>>;
+  modelStatus: string;
+  modelDeleted: boolean;
+  modelAvailability: string;
 };
 
 type EntryImage = {
@@ -150,29 +307,18 @@ type EntryImage = {
   height: number | null;
 };
 
-const chDateTime = (d: Date) => `toDateTime('${d.toISOString().slice(0, 19).replace('T', ' ')}')`;
-
-function chunk<T>(items: T[], size: number) {
-  const out: T[][] = [];
-  for (let i = 0; i < items.length; i += size) out.push(items.slice(i, i + size));
-  return out;
+/** Every id reaching raw SQL passes through here, so nothing downstream has to trust a caller. */
+function intList(values: number[]) {
+  for (const value of values)
+    if (!Number.isInteger(value)) throw new ContestScoringError('Expected integer identifiers');
+  return values.join(',');
 }
 
-/** Runs `build` once per chunk of ids and concatenates the rows. */
-async function chQueryChunked<T extends object>(
-  name: string,
-  ids: number[],
-  build: (idList: string) => string
-) {
-  if (!ids.length) return [] as T[];
-  return withSpan(`contest-score.${name}`, { ids: ids.length }, async () => {
-    const results: T[] = [];
-    for (const part of chunk(ids, CH_IN_CHUNK)) {
-      const rows = await clickhouse!.$query<T>(build(part.join(',')));
-      results.push(...rows);
-    }
-    return results;
-  });
+function ineligibilityReason(entry: EntryRow) {
+  if (entry.modelDeleted) return 'Model deleted';
+  if (entry.modelStatus !== 'Published') return `Model ${entry.modelStatus.toLowerCase()}`;
+  if (entry.modelAvailability === Availability.Private) return 'Model is private';
+  return null;
 }
 
 type WindowInput = {
@@ -190,17 +336,20 @@ async function loadEntries(input: WindowInput) {
   const items = await withSpan(
     'contest-score.entries',
     () =>
-      dbRead.$queryRaw<Omit<Entry, 'versionIds' | 'signals'>[]>`
+      dbRead.$queryRaw<EntryRow[]>`
       SELECT
-        ci.id           AS "collectionItemId",
-        ci."modelId"    AS "modelId",
-        m.name          AS "modelName",
-        m."userId"      AS "creatorId",
-        u.username      AS "creatorUsername",
-        ci."addedById"  AS "addedById",
-        ci."tagId"      AS "tagId",
-        t.name          AS "tagName",
-        ci.status::text AS "status"
+        ci.id                     AS "collectionItemId",
+        ci."modelId"              AS "modelId",
+        m.name                    AS "modelName",
+        m."userId"                AS "creatorId",
+        u.username                AS "creatorUsername",
+        ci."addedById"            AS "addedById",
+        ci."tagId"                AS "tagId",
+        t.name                    AS "tagName",
+        ci.status::text           AS "status",
+        m.status::text            AS "modelStatus",
+        m."deletedAt" IS NOT NULL AS "modelDeleted",
+        m.availability::text      AS "modelAvailability"
       FROM "CollectionItem" ci
       JOIN "Model" m ON m.id = ci."modelId"
       LEFT JOIN "User" u ON u.id = m."userId"
@@ -214,27 +363,7 @@ async function loadEntries(input: WindowInput) {
     `
   );
 
-  const truncated = items.length > MAX_ENTRIES;
-  const entries: Entry[] = items.slice(0, MAX_ENTRIES).map((item) => ({
-    ...item,
-    versionIds: [],
-    signals: Object.fromEntries(contestScoreSignals.map((s) => [s, new Set<number>()])) as Record<
-      Signal,
-      Set<number>
-    >,
-  }));
-
-  if (entries.length) {
-    const modelIds = entries.map((e) => e.modelId);
-    const versions = await dbRead.$queryRaw<{ id: number; modelId: number }[]>`
-      SELECT id, "modelId" FROM "ModelVersion"
-      WHERE "modelId" IN (${Prisma.join(modelIds)})
-    `;
-    const byModel = new Map(entries.map((e) => [e.modelId, e]));
-    for (const v of versions) byModel.get(v.modelId)?.versionIds.push(v.id);
-  }
-
-  return { entries, truncated };
+  return { entries: items.slice(0, MAX_ENTRIES), truncated: items.length > MAX_ENTRIES };
 }
 
 /** One representative image per model — the creator's own showcase post, in their order. */
@@ -242,214 +371,326 @@ async function loadEntryImages(modelIds: number[]) {
   const images = new Map<number, EntryImage>();
   if (!modelIds.length) return images;
 
-  const rows = await dbRead.$queryRaw<({ modelId: number } & EntryImage)[]>`
-    SELECT DISTINCT ON (mv."modelId")
-      mv."modelId"  AS "modelId",
-      i.id          AS "id",
-      i.url         AS "url",
-      i."nsfwLevel" AS "nsfwLevel",
-      i.type::text  AS "type",
-      i.width       AS "width",
-      i.height      AS "height"
-    FROM "ModelVersion" mv
-    JOIN "Model" m ON m.id = mv."modelId"
-    JOIN "Post" p ON p."modelVersionId" = mv.id AND p."userId" = m."userId"
-    JOIN "Image" i ON i."postId" = p.id
-    WHERE mv."modelId" IN (${Prisma.join(modelIds)})
-      AND p."publishedAt" IS NOT NULL
-      AND i.ingestion <> 'Blocked'::"ImageIngestionStatus"
-    ORDER BY mv."modelId", mv."index", p.id, i."index"
-  `;
+  const rows = await withSpan(
+    'contest-score.entry-images',
+    () =>
+      dbRead.$queryRaw<({ modelId: number } & EntryImage)[]>`
+      SELECT DISTINCT ON (mv."modelId")
+        mv."modelId"  AS "modelId",
+        i.id          AS "id",
+        i.url         AS "url",
+        i."nsfwLevel" AS "nsfwLevel",
+        i.type::text  AS "type",
+        i.width       AS "width",
+        i.height      AS "height"
+      FROM "ModelVersion" mv
+      JOIN "Model" m ON m.id = mv."modelId"
+      JOIN "Post" p ON p."modelVersionId" = mv.id AND p."userId" = m."userId"
+      JOIN "Image" i ON i."postId" = p.id
+      WHERE mv."modelId" IN (${Prisma.join(modelIds)})
+        AND p."publishedAt" IS NOT NULL
+        AND p."publishedAt" <= NOW()
+        AND i.ingestion <> 'Blocked'::"ImageIngestionStatus"
+      ORDER BY mv."modelId", mv."index", p.id, i."index"
+    `
+  );
   for (const { modelId, ...image } of rows) images.set(modelId, image);
 
   return images;
 }
 
+// ---------------------------------------------------------------------------
+// Signals
+// ---------------------------------------------------------------------------
+
+type SignalCount = { collectionItemId: number; rawUsers: number; qualifiedUsers: number };
+
 /**
- * Fills each entry's per-signal distinct-user sets and returns the imageId ->
- * modelId map (the reactor signal is keyed off the entry's on-site images).
+ * (entity, entry) pairs for the ClickHouse joins. Deliberately many-to-many in both
+ * directions: one image can credit several entered models (stacked LoRAs), and one
+ * model can be entered more than once (two categories, a resubmission,
+ * maxItemsPerUser > 1). Collapsing either direction silently zeroes an entry.
  */
-async function collectSignals(entries: Entry[], start: Date, end: Date) {
-  const byModel = new Map(entries.map((e) => [e.modelId, e]));
-  const byVersion = new Map<number, Entry>();
-  for (const entry of entries) for (const id of entry.versionIds) byVersion.set(id, entry);
+type EntryPair = { entityId: number; entryId: number; creatorId: number; addedById: number };
 
-  const modelIds = [...byModel.keys()];
-  const versionIds = [...byVersion.keys()];
-  const imageToModel = new Map<number, number>();
-
-  // Reactors are keyed off the entries' on-site images, so that pair runs as one
-  // chain; the other three are independent.
-  const imagesThenReactors = async () => {
-    const images = await withSpan(
-      'contest-score.images',
-      () =>
-        dbRead.$queryRaw<{ modelId: number; imageId: number; userId: number }[]>`
-        SELECT DISTINCT mv."modelId" AS "modelId", i.id AS "imageId", i."userId" AS "userId"
-        FROM "ImageResourceNew" ir
-        JOIN "ModelVersion" mv ON mv.id = ir."modelVersionId"
-        JOIN "Image" i ON i.id = ir."imageId"
-        JOIN "Post" p ON p.id = i."postId"
-        WHERE mv."modelId" IN (${Prisma.join(modelIds)})
-          AND i."createdAt" >= ${start}
-          AND i."createdAt" < ${end}
-          AND p."publishedAt" IS NOT NULL
-          AND i.ingestion <> 'Blocked'::"ImageIngestionStatus"
-      `
-    );
-    for (const row of images) {
-      imageToModel.set(row.imageId, row.modelId);
-      byModel.get(row.modelId)?.signals.imageAuthors.add(row.userId);
-    }
-
-    const reactions = await chQueryChunked<{ entityId: number; userId: number }>(
-      'reactors',
-      [...imageToModel.keys()],
-      (ids) => `
-        SELECT entityId, userId
-        FROM reactions
-        WHERE type = 'Image_Create'
-          AND entityId IN (${ids})
-          AND time >= ${chDateTime(start)} AND time < ${chDateTime(end)}
-          AND userId != 0
-        GROUP BY entityId, userId
-      `
-    );
-    for (const row of reactions) {
-      const modelId = imageToModel.get(row.entityId);
-      if (modelId) byModel.get(modelId)?.signals.reactors.add(row.userId);
-    }
-  };
-
-  const loadCollectors = async () => {
-    const collectors = await withSpan(
-      'contest-score.collectors',
-      () =>
-        dbRead.$queryRaw<{ modelId: number; userId: number }[]>`
-        SELECT DISTINCT ci."modelId" AS "modelId", ci."addedById" AS "userId"
-        FROM "CollectionItem" ci
-        WHERE ci."modelId" IN (${Prisma.join(modelIds)})
-          AND ci."addedById" IS NOT NULL
-          AND ci."createdAt" >= ${start}
-          AND ci."createdAt" < ${end}
-      `
-    );
-    for (const row of collectors) byModel.get(row.modelId)?.signals.collectors.add(row.userId);
-  };
-
-  const loadDownloaders = async () => {
-    const downloads = await chQueryChunked<{ modelId: number; userId: number }>(
-      'downloaders',
-      modelIds,
-      (ids) => `
-        SELECT modelId, userId
-        FROM modelVersionEvents
-        WHERE type = 'Download'
-          AND modelId IN (${ids})
-          AND time >= ${chDateTime(start)} AND time < ${chDateTime(end)}
-          AND userId != 0
-        GROUP BY modelId, userId
-      `
-    );
-    for (const row of downloads) byModel.get(row.modelId)?.signals.downloaders.add(row.userId);
-  };
-
-  // Straight off orchestration.jobs, NOT default.daily_user_resource: that view
-  // only ingests jobType IN ('TextToImage','TextToImageV2','Comfy'), so every
-  // newer engine (ComfyImageGen, AnimaComfy, StableDiffusionCpp, …) is missing
-  // from it and whole ecosystems read as zero generations.
-  const loadGenerators = async () => {
-    const generations = await chQueryChunked<{ modelVersionId: number; userId: number }>(
-      'generators',
-      versionIds,
-      (ids) => `
-        SELECT resource AS modelVersionId, userId
-        FROM orchestration.jobs
-        ARRAY JOIN resourcesUsed AS resource
-        WHERE resource IN (${ids})
-          AND createdAt >= ${chDateTime(start)} AND createdAt < ${chDateTime(end)}
-          AND userId != 0
-        GROUP BY resource, userId
-      `
-    );
-    for (const row of generations)
-      byVersion.get(row.modelVersionId)?.signals.generators.add(row.userId);
-  };
-
-  await Promise.all([imagesThenReactors(), loadCollectors(), loadDownloaders(), loadGenerators()]);
-
-  return { imageToModel };
+/**
+ * A ClickHouse-side lookup table built from a tuple literal. `values()` would read
+ * better but is not available on every deployment; arrayJoin over a tuple array is.
+ */
+function chPairTable(pairs: EntryPair[]) {
+  const tuples = pairs
+    .map((p) => `(${intList([p.entityId, p.entryId, p.creatorId, p.addedById])})`)
+    .join(',');
+  return `
+    SELECT
+      toUInt64(p.1) AS entityId,
+      toUInt64(p.2) AS entryId,
+      toUInt64(p.3) AS creatorId,
+      toUInt64(p.4) AS addedById
+    FROM (SELECT arrayJoin([${tuples}]) AS p)
+  `;
 }
 
-type Disqualification = {
-  excluded: boolean;
-  contestBanned: boolean;
-  banned: boolean;
-  tooNew: boolean;
-};
+const chDateTime = (d: Date) => `toDateTime('${d.toISOString().slice(0, 19).replace('T', ' ')}')`;
 
-async function loadDisqualifications(userIds: number[], ageCutoff: Date) {
-  const disqualified = new Map<number, Disqualification>();
-  if (!userIds.length) return disqualified;
+/**
+ * Counts distinct users per ENTRY inside ClickHouse. `source` projects `userId` and
+ * `entityId`; the qualification gates are applied there too, so only two integers
+ * per entry come back.
+ */
+function chCountQuery({
+  source,
+  pairs,
+  gates,
+}: {
+  source: (entityIds: string) => string;
+  pairs: EntryPair[];
+  gates: Gates;
+}) {
+  const disqualified = gates.disqualifiedIds.length ? intList(gates.disqualifiedIds) : '0';
+  const entityIds = intList([...new Set(pairs.map((p) => p.entityId))]);
 
-  const users = await withSpan(
-    'contest-score.disqualifications',
+  return `
+    SELECT
+      p.entryId AS entryId,
+      uniqExact(s.userId) AS rawUsers,
+      uniqExactIf(
+        s.userId,
+        s.userId <= ${gates.userIdThreshold}
+          AND s.userId != p.creatorId
+          AND (p.addedById = 0 OR s.userId != p.addedById)
+          AND s.userId NOT IN (${disqualified})
+      ) AS qualifiedUsers
+    FROM (${source(entityIds)}) AS s
+    INNER JOIN (${chPairTable(pairs)}) AS p ON s.entityId = p.entityId
+    GROUP BY entryId
+  `;
+}
+
+/**
+ * Splits pairs into calls, cutting only between entries, and runs them with bounded
+ * concurrency so a large contest cannot open an unbounded fan of CH queries.
+ */
+async function runChCounts(
+  name: string,
+  pairs: EntryPair[],
+  gates: Gates,
+  source: (entityIds: string) => string
+): Promise<SignalCount[]> {
+  if (!pairs.length) return [];
+
+  const byEntry = new Map<number, EntryPair[]>();
+  for (const pair of pairs) {
+    const existing = byEntry.get(pair.entryId);
+    if (existing) existing.push(pair);
+    else byEntry.set(pair.entryId, [pair]);
+  }
+
+  const chunks: EntryPair[][] = [];
+  let current: EntryPair[] = [];
+  for (const group of byEntry.values()) {
+    if (current.length && current.length + group.length > CH_ENTITY_CHUNK) {
+      chunks.push(current);
+      current = [];
+    }
+    current.push(...group);
+  }
+  if (current.length) chunks.push(current);
+
+  return withSpan(
+    `contest-score.${name}`,
+    { pairs: pairs.length, chunks: chunks.length },
+    async () => {
+      const limit = pLimit(CH_CONCURRENCY);
+      const results = await Promise.all(
+        chunks.map((chunk) =>
+          limit(() =>
+            clickhouse!.$query<{ entryId: number; rawUsers: number; qualifiedUsers: number }>(
+              chCountQuery({ source, pairs: chunk, gates })
+            )
+          )
+        )
+      );
+      return results.flat().map((row) => ({
+        collectionItemId: Number(row.entryId),
+        rawUsers: Number(row.rawUsers),
+        qualifiedUsers: Number(row.qualifiedUsers),
+      }));
+    }
+  );
+}
+
+/** The entries as a Postgres lookup table, keyed by collectionItemId. */
+function pgEntryTable(entries: EntryRow[]) {
+  const values = entries
+    .map(
+      (e) =>
+        `(${intList([e.collectionItemId, e.modelId, e.creatorId])},${
+          e.addedById === null ? 'NULL' : intList([e.addedById])
+        })`
+    )
+    .join(',');
+  return Prisma.raw(`(VALUES ${values}) AS e("entryId", "modelId", "creatorId", "addedById")`);
+}
+
+/** The qualification gate, identical across every signal. */
+function pgQualified(userColumn: string, gates: Gates) {
+  const disqualified = gates.disqualifiedIds.length ? intList(gates.disqualifiedIds) : '-1';
+  return Prisma.raw(`
+    ${userColumn} <> e."creatorId"
+    AND (e."addedById" IS NULL OR ${userColumn} <> e."addedById")
+    AND ${userColumn} <= ${gates.userIdThreshold}
+    AND NOT (${userColumn} = ANY(ARRAY[${disqualified}]::int[]))
+  `);
+}
+
+/**
+ * The entries' on-site images, windowed on PUBLICATION. Publication is the
+ * contest-meaningful event — an already-existing model can be entered, so filtering
+ * on image creation would credit or drop the wrong work. Scheduled posts carry a
+ * future `publishedAt` and are visible to nobody, hence the `<= NOW()`.
+ */
+async function loadImagePairs(entries: EntryRow[], window: ResolvedWindow) {
+  return withSpan(
+    'contest-score.image-pairs',
     () =>
-      dbRead.$queryRaw<{ id: number; contestBanned: boolean; banned: boolean; tooNew: boolean }[]>`
-      SELECT
-        u.id,
-        (u.meta -> 'contestBanDetails') IS NOT NULL             AS "contestBanned",
-        (u."bannedAt" IS NOT NULL OR u."deletedAt" IS NOT NULL) AS "banned",
-        u."createdAt" > ${ageCutoff}                            AS "tooNew"
-      FROM "User" u
-      WHERE u.id IN (${Prisma.join(userIds)})
+      dbRead.$queryRaw<{ entryId: number; imageId: number }[]>`
+      SELECT DISTINCT e."entryId" AS "entryId", i.id AS "imageId"
+      FROM ${pgEntryTable(entries)}
+      JOIN "ModelVersion" mv ON mv."modelId" = e."modelId"
+      JOIN "ImageResourceNew" ir ON ir."modelVersionId" = mv.id
+      JOIN "Image" i ON i.id = ir."imageId"
+      JOIN "Post" p ON p.id = i."postId"
+      WHERE p."publishedAt" IS NOT NULL
+        AND p."publishedAt" <= NOW()
+        AND p."publishedAt" >= ${window.start}
+        AND p."publishedAt" < ${window.effectiveEnd}
+        AND i.ingestion <> 'Blocked'::"ImageIngestionStatus"
     `
   );
-  const known = new Set(users.map((u) => u.id));
-  for (const user of users) {
-    if (!user.contestBanned && !user.banned && !user.tooNew) continue;
-    disqualified.set(user.id, { excluded: false, ...user });
-  }
-
-  const excludedRows = await chQueryChunked<{ userId: number }>(
-    'excluded-users',
-    userIds,
-    (ids) => `
-      SELECT userId FROM metricExcludedUsers FINAL
-      WHERE active = 1 AND userId IN (${ids})
-    `
-  );
-  for (const row of excludedRows) {
-    const existing = disqualified.get(row.userId);
-    if (existing) existing.excluded = true;
-    else
-      disqualified.set(row.userId, {
-        excluded: true,
-        contestBanned: false,
-        banned: false,
-        tooNew: false,
-      });
-  }
-
-  // A userId with no User row is a deleted account: never counts.
-  for (const id of userIds) {
-    if (known.has(id) || disqualified.has(id)) continue;
-    disqualified.set(id, { excluded: false, contestBanned: false, banned: true, tooNew: false });
-  }
-
-  return disqualified;
 }
+
+async function countImageAuthors(entries: EntryRow[], window: ResolvedWindow, gates: Gates) {
+  return withSpan(
+    'contest-score.image-authors',
+    () =>
+      dbRead.$queryRaw<SignalCount[]>`
+      SELECT
+        e."entryId"                     AS "collectionItemId",
+        count(DISTINCT i."userId")::int AS "rawUsers",
+        count(DISTINCT i."userId") FILTER (WHERE ${pgQualified('i."userId"', gates)})::int
+                                        AS "qualifiedUsers"
+      FROM ${pgEntryTable(entries)}
+      JOIN "ModelVersion" mv ON mv."modelId" = e."modelId"
+      JOIN "ImageResourceNew" ir ON ir."modelVersionId" = mv.id
+      JOIN "Image" i ON i.id = ir."imageId"
+      JOIN "Post" p ON p.id = i."postId"
+      WHERE p."publishedAt" IS NOT NULL
+        AND p."publishedAt" <= NOW()
+        AND p."publishedAt" >= ${window.start}
+        AND p."publishedAt" < ${window.effectiveEnd}
+        AND i.ingestion <> 'Blocked'::"ImageIngestionStatus"
+      GROUP BY e."entryId"
+    `
+  );
+}
+
+async function countCollectors(
+  entries: EntryRow[],
+  window: ResolvedWindow,
+  gates: Gates,
+  collectionId: number
+) {
+  return withSpan(
+    'contest-score.collectors',
+    () =>
+      dbRead.$queryRaw<SignalCount[]>`
+      SELECT
+        e."entryId"                         AS "collectionItemId",
+        count(DISTINCT ci."addedById")::int AS "rawUsers",
+        count(DISTINCT ci."addedById") FILTER (WHERE ${pgQualified('ci."addedById"', gates)})::int
+                                            AS "qualifiedUsers"
+      FROM ${pgEntryTable(entries)}
+      JOIN "CollectionItem" ci ON ci."modelId" = e."modelId"
+      WHERE ci."collectionId" <> ${collectionId}
+        AND ci."addedById" IS NOT NULL
+        AND ci."createdAt" >= ${window.start}
+        AND ci."createdAt" < ${window.effectiveEnd}
+      GROUP BY e."entryId"
+    `
+  );
+}
+
+async function loadVersionPairs(entries: EntryRow[]) {
+  const versions = await dbRead.$queryRaw<{ id: number; modelId: number }[]>`
+    SELECT id, "modelId" FROM "ModelVersion"
+    WHERE "modelId" IN (${Prisma.join(entries.map((e) => e.modelId))})
+  `;
+
+  const byModel = new Map<number, EntryRow[]>();
+  for (const entry of entries) {
+    const existing = byModel.get(entry.modelId);
+    if (existing) existing.push(entry);
+    else byModel.set(entry.modelId, [entry]);
+  }
+
+  const pairs: EntryPair[] = [];
+  for (const version of versions)
+    for (const entry of byModel.get(version.modelId) ?? [])
+      pairs.push({
+        entityId: version.id,
+        entryId: entry.collectionItemId,
+        creatorId: entry.creatorId,
+        addedById: entry.addedById ?? 0,
+      });
+
+  return pairs;
+}
+
+function modelPairs(entries: EntryRow[]): EntryPair[] {
+  return entries.map((entry) => ({
+    entityId: entry.modelId,
+    entryId: entry.collectionItemId,
+    creatorId: entry.creatorId,
+    addedById: entry.addedById ?? 0,
+  }));
+}
+
+function toImagePairs(rows: { entryId: number; imageId: number }[], entries: EntryRow[]) {
+  const byEntry = new Map(entries.map((e) => [e.collectionItemId, e]));
+  const pairs: EntryPair[] = [];
+  for (const row of rows) {
+    const entry = byEntry.get(Number(row.entryId));
+    if (!entry) continue;
+    pairs.push({
+      entityId: Number(row.imageId),
+      entryId: entry.collectionItemId,
+      creatorId: entry.creatorId,
+      addedById: entry.addedById ?? 0,
+    });
+  }
+  return pairs;
+}
+
+// ---------------------------------------------------------------------------
+// Scoring
+// ---------------------------------------------------------------------------
 
 export type ContestScoreEntry = {
-  rank: number;
+  /** Null when the entry is ineligible, or when its whole category is tied at zero. */
+  rank: number | null;
   collectionItemId: number;
   modelId: number;
   modelName: string;
   creatorId: number;
   creatorUsername: string | null;
   status: string;
+  eligible: boolean;
+  ineligibleReason: string | null;
   image: EntryImage | null;
-  signals: Record<Signal, { raw: number; qualified: number; normalized: number }>;
+  // No `normalized` here: alongside `score`, five normalized values and five scores
+  // solve for the five weights. The UI never rendered it.
+  signals: Record<Signal, { raw: number; qualified: number }>;
   rawTotal: number;
   qualifiedTotal: number;
   disqualifiedShare: number;
@@ -460,75 +701,138 @@ export type ContestScoreCategory = {
   tagId: number | null;
   tagName: string | null;
   entryCount: number;
+  eligibleCount: number;
+  /** A lone entrant normalizes to 1.0 on every non-zero signal — not a comparable score. */
+  soloEntry: boolean;
+  /** Nothing in this category scored: ranks are withheld rather than invented. */
+  tied: boolean;
   entries: ContestScoreEntry[];
 };
 
 export type ContestCommunityScore = {
   collectionId: number;
   generatedAt: string;
-  window: { start: string; end: string };
+  window: { start: string; end: string; effectiveEnd: string };
+  partial: boolean;
   statuses: CollectionItemStatus[];
   entryCount: number;
   truncated: boolean;
   signalSources: Record<Signal, string>;
-  engagers: { total: number; disqualified: number };
   categories: ContestScoreCategory[];
 };
 
-function resolveWindow(input: WindowInput) {
-  return { start: input.start ?? new Date(0), end: input.end ?? new Date() };
+function requireClickhouse() {
+  if (!clickhouse)
+    throw new ContestScoringError('ClickHouse is not configured in this environment');
+  return clickhouse;
 }
 
-function requireClickhouse() {
-  if (!clickhouse) throw throwBadRequestError('ClickHouse is not configured in this environment');
-  return clickhouse;
+function emptySignals() {
+  return Object.fromEntries(
+    contestScoreSignals.map((s) => [s, { raw: 0, qualified: 0 }])
+  ) as ContestScoreEntry['signals'];
 }
 
 async function computeCommunityScore(input: WindowInput): Promise<ContestCommunityScore> {
   requireClickhouse();
   const config = await getContestScoringConfig(input.collectionId);
-  const { start, end } = resolveWindow(input);
+  const window = await resolveWindow(input.collectionId, input, config);
   const statuses = input.statuses ?? DEFAULT_STATUSES;
 
+  const base = {
+    collectionId: input.collectionId,
+    generatedAt: new Date().toISOString(),
+    window: {
+      start: window.start.toISOString(),
+      end: window.end.toISOString(),
+      effectiveEnd: window.effectiveEnd.toISOString(),
+    },
+    partial: window.partial,
+    statuses,
+    signalSources: CONTEST_SIGNAL_SOURCES,
+  };
+
   const { entries, truncated } = await loadEntries(input);
-  if (!entries.length)
-    return {
-      collectionId: input.collectionId,
-      generatedAt: new Date().toISOString(),
-      window: { start: start.toISOString(), end: end.toISOString() },
-      statuses,
-      entryCount: 0,
-      truncated,
-      signalSources: CONTEST_SIGNAL_SOURCES,
-      engagers: { total: 0, disqualified: 0 },
-      categories: [],
-    };
+  if (!entries.length) return { ...base, entryCount: 0, truncated, categories: [] };
 
-  const ageCutoff = new Date(start.getTime() - config.ageGateDays * 24 * 60 * 60 * 1000);
+  const gates = await loadGates(window);
 
-  const [, images] = await Promise.all([
-    collectSignals(entries, start, end),
+  const [imageAuthors, collectors, imageRows, versionPairs, images] = await Promise.all([
+    countImageAuthors(entries, window, gates),
+    countCollectors(entries, window, gates, input.collectionId),
+    loadImagePairs(entries, window),
+    loadVersionPairs(entries),
     loadEntryImages(entries.map((e) => e.modelId)),
   ]);
 
-  const engagers = new Set<number>();
-  for (const entry of entries)
-    for (const signal of contestScoreSignals)
-      for (const id of entry.signals[signal]) engagers.add(id);
-  const disqualified = await loadDisqualifications([...engagers], ageCutoff);
+  const [reactors, downloaders, generators] = await Promise.all([
+    runChCounts(
+      'reactors',
+      toImagePairs(imageRows, entries),
+      gates,
+      (ids) => `
+        SELECT userId, entityId
+        FROM reactions
+        WHERE type = 'Image_Create'
+          AND entityId IN (${ids})
+          AND time >= ${chDateTime(window.start)} AND time < ${chDateTime(window.effectiveEnd)}
+          AND userId != 0
+      `
+    ),
+    runChCounts(
+      'downloaders',
+      modelPairs(entries),
+      gates,
+      (ids) => `
+        SELECT userId, modelId AS entityId
+        FROM modelVersionEvents
+        WHERE type = 'Download'
+          AND modelId IN (${ids})
+          AND time >= ${chDateTime(window.start)} AND time < ${chDateTime(window.effectiveEnd)}
+          AND userId != 0
+      `
+    ),
+    // Straight off orchestration.jobs, NOT default.daily_user_resource: that view
+    // only ingests jobType IN ('TextToImage','TextToImageV2','Comfy'), so every
+    // newer engine (ComfyImageGen, AnimaComfy, StableDiffusionCpp, …) is missing
+    // from it and whole ecosystems read as zero generations.
+    runChCounts(
+      'generators',
+      versionPairs,
+      gates,
+      (ids) => `
+        SELECT userId, resource AS entityId
+        FROM orchestration.jobs
+        ARRAY JOIN resourcesUsed AS resource
+        WHERE resource IN (${ids})
+          AND createdAt >= ${chDateTime(window.start)}
+          AND createdAt < ${chDateTime(window.effectiveEnd)}
+          AND userId != 0
+      `
+    ),
+  ]);
+
+  const counts = new Map<number, ContestScoreEntry['signals']>(
+    entries.map((e) => [e.collectionItemId, emptySignals()])
+  );
+  const apply = (signal: Signal, rows: SignalCount[]) => {
+    for (const row of rows) {
+      const bucket = counts.get(Number(row.collectionItemId));
+      if (!bucket) continue;
+      bucket[signal] = { raw: Number(row.rawUsers), qualified: Number(row.qualifiedUsers) };
+    }
+  };
+  apply('imageAuthors', imageAuthors);
+  apply('collectors', collectors);
+  apply('reactors', reactors);
+  apply('downloaders', downloaders);
+  apply('generators', generators);
 
   const scored = entries.map((entry) => {
-    const isQualified = (userId: number) =>
-      userId !== entry.creatorId && userId !== entry.addedById && !disqualified.has(userId);
-
-    const signals = {} as Record<Signal, { raw: number; qualified: number }>;
-    for (const signal of contestScoreSignals) {
-      const users = [...entry.signals[signal]];
-      signals[signal] = { raw: users.length, qualified: users.filter(isQualified).length };
-    }
-
+    const signals = counts.get(entry.collectionItemId) ?? emptySignals();
     const rawTotal = contestScoreSignals.reduce((sum, s) => sum + signals[s].raw, 0);
     const qualifiedTotal = contestScoreSignals.reduce((sum, s) => sum + signals[s].qualified, 0);
+    const reason = ineligibilityReason(entry);
 
     return {
       collectionItemId: entry.collectionItemId,
@@ -537,6 +841,8 @@ async function computeCommunityScore(input: WindowInput): Promise<ContestCommuni
       creatorId: entry.creatorId,
       creatorUsername: entry.creatorUsername,
       status: entry.status,
+      eligible: !reason,
+      ineligibleReason: reason,
       tagId: entry.tagId,
       image: images.get(entry.modelId) ?? null,
       signals,
@@ -547,66 +853,99 @@ async function computeCommunityScore(input: WindowInput): Promise<ContestCommuni
     };
   });
 
-  const categories = [...new Set(entries.map((e) => e.tagId))].map((tagId) => {
-    const tagName = entries.find((e) => e.tagId === tagId)?.tagName ?? null;
-    const items = scored.filter((e) => e.tagId === tagId);
+  const categories = [...new Set(entries.map((e) => e.tagId))].map(
+    (tagId): ContestScoreCategory => {
+      const tagName = entries.find((e) => e.tagId === tagId)?.tagName ?? null;
+      const items = scored.filter((e) => e.tagId === tagId);
+      const eligible = items.filter((i) => i.eligible);
 
-    // Normalize within category against that category's leader per signal, so a
-    // category with fewer entrants can't be compared against a busier one.
-    const maxima = Object.fromEntries(
-      contestScoreSignals.map((s) => [s, Math.max(...items.map((i) => i.signals[s].qualified), 0)])
-    ) as Record<Signal, number>;
+      // Normalized against the leading ELIGIBLE entry per signal, so an entry pulled
+      // after accruing engagement cannot set the bar for everyone else.
+      const maxima = Object.fromEntries(
+        contestScoreSignals.map((s) => [
+          s,
+          Math.max(...eligible.map((i) => i.signals[s].qualified), 0),
+        ])
+      ) as Record<Signal, number>;
 
-    const ranked = items
-      .map(({ tagId: _tagId, signals, ...item }) => {
-        const withNormalized = {} as ContestScoreEntry['signals'];
+      const withScores = items.map(({ tagId: _tagId, ...item }) => {
         let total = 0;
-        for (const s of contestScoreSignals) {
-          const normalized = maxima[s] > 0 ? +(signals[s].qualified / maxima[s]).toFixed(4) : 0;
-          withNormalized[s] = { ...signals[s], normalized };
-          total += normalized * config.weights[s];
+        for (const signal of contestScoreSignals) {
+          const max = maxima[signal];
+          if (max > 0) total += (item.signals[signal].qualified / max) * config.weights[signal];
         }
-        return { ...item, signals: withNormalized, score: +total.toFixed(4) };
-      })
-      .sort(
-        (a, b) => b.score - a.score || b.qualifiedTotal - a.qualifiedTotal || a.modelId - b.modelId
-      )
-      .map((item, index): ContestScoreEntry => ({ rank: index + 1, ...item }));
+        return { ...item, score: item.eligible ? +total.toFixed(4) : 0 };
+      });
 
-    return { tagId, tagName, entryCount: ranked.length, entries: ranked };
-  });
+      const tied = withScores.every((item) => item.score === 0);
+      const entriesRanked = withScores
+        .sort(
+          (a, b) =>
+            Number(b.eligible) - Number(a.eligible) ||
+            b.score - a.score ||
+            b.qualifiedTotal - a.qualifiedTotal ||
+            a.modelId - b.modelId
+        )
+        .map((item, index) => ({ ...item, rank: !item.eligible || tied ? null : index + 1 }));
 
-  return {
-    collectionId: input.collectionId,
-    generatedAt: new Date().toISOString(),
-    window: { start: start.toISOString(), end: end.toISOString() },
-    statuses,
-    entryCount: entries.length,
-    truncated,
-    signalSources: CONTEST_SIGNAL_SOURCES,
-    engagers: { total: engagers.size, disqualified: disqualified.size },
-    categories,
-  };
+      return {
+        tagId,
+        tagName,
+        entryCount: items.length,
+        eligibleCount: eligible.length,
+        soloEntry: eligible.length === 1,
+        tied,
+        entries: entriesRanked,
+      };
+    }
+  );
+
+  return { ...base, entryCount: entries.length, truncated, categories };
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+function cacheKeyFor(input: WindowInput, configVersion: number) {
+  return `${REDIS_KEYS.CACHES.CONTEST_COMMUNITY_SCORE}:${input.collectionId}:${hashifyObject({
+    start: input.start?.toISOString(),
+    end: input.end?.toISOString(),
+    tagIds: input.tagIds,
+    statuses: input.statuses,
+    configVersion,
+    codeVersion: CONTEST_SCORE_CODE_VERSION,
+  })}` as RedisKeyTemplateCache;
 }
 
 export async function getCommunityScore(input: GetCommunityScoreInput) {
   const { refresh, ...window } = input;
-  const config = await getContestScoringConfig(window.collectionId);
-  const cacheKey = `${REDIS_KEYS.CACHES.CONTEST_COMMUNITY_SCORE}:${
-    window.collectionId
-  }:${hashifyObject({
-    start: window.start?.toISOString(),
-    end: window.end?.toISOString(),
-    tagIds: window.tagIds,
-    statuses: window.statuses,
-    configVersion: config.version,
-  })}` as RedisKeyTemplateCache;
+  try {
+    const config = await getContestScoringConfig(window.collectionId);
+    const cacheKey = cacheKeyFor(window, config.version);
 
-  if (refresh) await bustFetchThroughCache(cacheKey);
+    if (refresh) await bustFetchThroughCache(cacheKey);
 
-  return fetchThroughCache(cacheKey, () => computeCommunityScore(window), {
-    ttl: SCORE_CACHE_TTL,
-  });
+    return await fetchThroughCache(
+      cacheKey,
+      async () => {
+        // One run per collection at a time. A refresh storm would otherwise stack
+        // full cross-store aggregations on top of one another.
+        const result = await withDistributedLock(
+          { key: `contest-score:${window.collectionId}`, ttl: 120, maxRetries: 60 },
+          () => computeCommunityScore(window)
+        );
+        if (!result)
+          throw new ContestScoringError(
+            'A scoring run for this collection is already in progress. Try again shortly.'
+          );
+        return result;
+      },
+      { ttl: SCORE_CACHE_TTL }
+    );
+  } catch (e) {
+    return sanitizeError(window.collectionId, e);
+  }
 }
 
 /**
@@ -615,146 +954,159 @@ export async function getCommunityScore(input: GetCommunityScoreInput) {
  * Evidence only — never an automatic disqualification.
  */
 export async function getContestCandidates(input: GetContestCandidatesInput) {
-  requireClickhouse();
-  const config = await getContestScoringConfig(input.collectionId);
-  const { start, end } = resolveWindow(input);
-  const limit = input.limit ?? 200;
+  try {
+    requireClickhouse();
+    const config = await getContestScoringConfig(input.collectionId);
+    const window = await resolveWindow(input.collectionId, input, config);
+    const limit = input.limit ?? 200;
 
-  const { entries } = await loadEntries(input);
-  if (!entries.length) return { collectionId: input.collectionId, count: 0, candidates: [] };
+    const { entries } = await loadEntries(input);
+    if (!entries.length) return { collectionId: input.collectionId, count: 0, candidates: [] };
 
-  const { imageToModel } = await collectSignals(entries, start, end);
-  const creatorByModel = new Map(entries.map((e) => [e.modelId, e.creatorId]));
+    const gates = await loadGates(window);
+    const imagePairs = toImagePairs(await loadImagePairs(entries, window), entries);
 
-  // Engagement events carrying an IP: reactions on the entries' images and
-  // downloads of the entries' models — the same farm-IP signal `reaction-abuse`
-  // uses, scoped to this contest.
-  const [reactionRows, downloadRows] = await Promise.all([
-    chQueryChunked<{ userId: number; entityId: number; ip: string }>(
-      'candidates.reactions',
-      [...imageToModel.keys()],
-      (ids) => `
+    // Reactions and downloads are the engagement events that carry an IP — the same
+    // farm-IP signal `reaction-abuse` uses, scoped to this contest. Everything below
+    // is aggregated in ClickHouse; only the capped candidate rows come back.
+    const imageIds = intList([...new Set(imagePairs.map((p) => p.entityId))]);
+    const modelIds = intList([...new Set(entries.map((e) => e.modelId))]);
+
+    const downloadEvents = `
+      SELECT s.userId AS userId, p.entryId AS entryId, p.creatorId AS creatorId, s.ip AS ip
+      FROM (
+        SELECT userId, modelId AS entityId, ip
+        FROM modelVersionEvents
+        WHERE type = 'Download'
+          AND modelId IN (${modelIds || '0'})
+          AND time >= ${chDateTime(window.start)} AND time < ${chDateTime(window.effectiveEnd)}
+          AND userId != 0
+      ) AS s
+      INNER JOIN (${chPairTable(modelPairs(entries))}) AS p ON s.entityId = p.entityId
+    `;
+    const reactionEvents = imagePairs.length
+      ? `
+      SELECT s.userId AS userId, p.entryId AS entryId, p.creatorId AS creatorId, s.ip AS ip
+      FROM (
         SELECT userId, entityId, ip
         FROM reactions
         WHERE type = 'Image_Create'
-          AND entityId IN (${ids})
-          AND time >= ${chDateTime(start)} AND time < ${chDateTime(end)}
+          AND entityId IN (${imageIds})
+          AND time >= ${chDateTime(window.start)} AND time < ${chDateTime(window.effectiveEnd)}
           AND userId != 0
-        GROUP BY userId, entityId, ip
-      `
-    ),
-    chQueryChunked<{ userId: number; modelId: number; ip: string }>(
-      'candidates.downloads',
-      entries.map((e) => e.modelId),
-      (ids) => `
-        SELECT userId, modelId, ip
-        FROM modelVersionEvents
-        WHERE type = 'Download'
-          AND modelId IN (${ids})
-          AND time >= ${chDateTime(start)} AND time < ${chDateTime(end)}
-          AND userId != 0
-        GROUP BY userId, modelId, ip
-      `
-    ),
-  ]);
+      ) AS s
+      INNER JOIN (${chPairTable(imagePairs)}) AS p ON s.entityId = p.entityId
+    `
+      : null;
 
-  const events = [
-    ...reactionRows.map((r) => ({
-      userId: r.userId,
-      modelId: imageToModel.get(r.entityId),
-      ip: r.ip,
-    })),
-    ...downloadRows.map((r) => ({ userId: r.userId, modelId: r.modelId, ip: r.ip })),
-  ].filter((e): e is { userId: number; modelId: number; ip: string } => !!e.modelId);
+    const events = [downloadEvents, reactionEvents].filter(Boolean).join('\nUNION ALL\n');
 
-  const usersPerIp = new Map<string, Set<number>>();
-  for (const event of events) {
-    if (!event.ip) continue;
-    if (!usersPerIp.has(event.ip)) usersPerIp.set(event.ip, new Set());
-    usersPerIp.get(event.ip)!.add(event.userId);
+    const rows = await withSpan('contest-score.candidates', () =>
+      clickhouse!.$query<{
+        userId: number;
+        events: number;
+        entriesTouched: number;
+        distinctCreators: number;
+        topCreator: number;
+        toTopCreator: number;
+        farmIpsUsed: number;
+      }>(`
+        WITH ev AS (${events}),
+             farm AS (
+               SELECT ip FROM ev WHERE ip != '' GROUP BY ip
+               HAVING uniqExact(userId) >= ${Number(config.farmIp.minPeers)}
+             ),
+             perCreator AS (
+               SELECT
+                 userId,
+                 creatorId,
+                 count() AS creatorEvents,
+                 uniqExact(entryId) AS creatorEntries,
+                 groupUniqArrayIf(ip, ip IN (SELECT ip FROM farm)) AS creatorFarmIps
+               FROM ev
+               GROUP BY userId, creatorId
+             )
+        SELECT
+          userId,
+          sum(creatorEvents) AS events,
+          sum(creatorEntries) AS entriesTouched,
+          count() AS distinctCreators,
+          argMax(creatorId, creatorEvents) AS topCreator,
+          max(creatorEvents) AS toTopCreator,
+          length(arrayDistinct(arrayFlatten(groupArray(creatorFarmIps)))) AS farmIpsUsed
+        FROM perCreator
+        GROUP BY userId
+        HAVING farmIpsUsed > 0
+            OR (entriesTouched >= ${Number(config.farmIp.minEntries)} AND distinctCreators = 1)
+        ORDER BY toTopCreator / events DESC, farmIpsUsed DESC, events DESC
+        LIMIT ${Number(limit)}
+      `)
+    );
+
+    return {
+      collectionId: input.collectionId,
+      count: rows.length,
+      candidates: rows.map((row) => ({
+        userId: Number(row.userId),
+        events: Number(row.events),
+        entriesTouched: Number(row.entriesTouched),
+        distinctCreators: Number(row.distinctCreators),
+        topCreator: Number(row.topCreator),
+        toTopCreator: Number(row.toTopCreator),
+        topCreatorConcentration: +(Number(row.toTopCreator) / Number(row.events)).toFixed(2),
+        farmIpsUsed: Number(row.farmIpsUsed),
+        // Reported so a reviewer can tell a too-young account from an excluded one
+        // without re-deriving the threshold themselves.
+        newAccount: Number(row.userId) > gates.userIdThreshold,
+      })),
+    };
+  } catch (e) {
+    return sanitizeError(input.collectionId, e);
   }
-  const farmIps = new Set(
-    [...usersPerIp.entries()]
-      .filter(([, users]) => users.size >= config.farmIp.minPeers)
-      .map(([ip]) => ip)
-  );
-
-  type Candidate = {
-    userId: number;
-    entriesTouched: Set<number>;
-    creators: Map<number, number>;
-    farmIps: Set<string>;
-    maxIpPeers: number;
-    events: number;
-  };
-  const byUser = new Map<number, Candidate>();
-  for (const event of events) {
-    let candidate = byUser.get(event.userId);
-    if (!candidate) {
-      candidate = {
-        userId: event.userId,
-        entriesTouched: new Set(),
-        creators: new Map(),
-        farmIps: new Set(),
-        maxIpPeers: 0,
-        events: 0,
-      };
-      byUser.set(event.userId, candidate);
-    }
-    candidate.events++;
-    candidate.entriesTouched.add(event.modelId);
-    const creatorId = creatorByModel.get(event.modelId);
-    if (creatorId) candidate.creators.set(creatorId, (candidate.creators.get(creatorId) ?? 0) + 1);
-    if (farmIps.has(event.ip)) candidate.farmIps.add(event.ip);
-    candidate.maxIpPeers = Math.max(candidate.maxIpPeers, usersPerIp.get(event.ip)?.size ?? 0);
-  }
-
-  const rows = [...byUser.values()]
-    .map((candidate) => {
-      const [topCreator, toTopCreator] = [...candidate.creators.entries()].sort(
-        (a, b) => b[1] - a[1]
-      )[0] ?? [0, 0];
-      return {
-        userId: candidate.userId,
-        events: candidate.events,
-        entriesTouched: candidate.entriesTouched.size,
-        distinctCreators: candidate.creators.size,
-        topCreator,
-        toTopCreator,
-        topCreatorConcentration: +(toTopCreator / candidate.events).toFixed(2),
-        farmIpsUsed: candidate.farmIps.size,
-        maxIpPeers: candidate.maxIpPeers,
-      };
-    })
-    .filter(
-      (row) =>
-        row.farmIpsUsed > 0 ||
-        (row.entriesTouched >= config.farmIp.minEntries && row.distinctCreators === 1)
-    )
-    // Concentration on one creator is the discriminating signal; farm IPs alone
-    // catch shared/CGNAT addresses too, so they only break ties.
-    .sort(
-      (a, b) =>
-        b.topCreatorConcentration - a.topCreatorConcentration ||
-        b.farmIpsUsed - a.farmIpsUsed ||
-        b.events - a.events
-    )
-    .slice(0, limit);
-
-  return { collectionId: input.collectionId, count: rows.length, candidates: rows };
 }
 
+// ---------------------------------------------------------------------------
+// Snapshots
+// ---------------------------------------------------------------------------
+
+/**
+ * The artifact that defends a disputed prize, so it stores the RESOLVED config —
+ * weights included — alongside the window, the age cutoff and the code version.
+ * Weights are stripped on the wire, never in storage. No userIds are ever stored.
+ *
+ * KeyValue keeps this migration-free for v1. A dedicated table (indexed by
+ * collection, payload out of a jsonb column) is the follow-up once the shape
+ * settles.
+ */
 export type ContestSnapshot = {
   collectionId: number;
   takenAt: string;
   takenById: number;
   takenByUsername: string | null;
   note?: string;
+  codeVersion: number;
+  config: ContestScoringConfig;
+  ageCutoff: string;
+  ageGateBandUsers: number;
+  partial: boolean;
   score: ContestCommunityScore;
+};
+
+export type ContestSnapshotSummary = Omit<ContestSnapshot, 'config' | 'score'> & {
+  key: string;
+  window: ContestCommunityScore['window'];
+  entryCount: number;
 };
 
 const snapshotKey = (collectionId: number, takenAt: string) =>
   `${CONTEST_SNAPSHOT_KEY_PREFIX}:${collectionId}:${takenAt}`;
+
+function toSnapshotSummary(key: string, snapshot: ContestSnapshot): ContestSnapshotSummary {
+  // `config` — and therefore the weights — is dropped here. It is stored for audit,
+  // never served.
+  const { config: _config, score, ...rest } = snapshot;
+  return { key, ...rest, window: score.window, entryCount: score.entryCount };
+}
 
 export async function createContestSnapshot({
   input,
@@ -764,27 +1116,38 @@ export async function createContestSnapshot({
   input: CreateContestSnapshotInput;
   userId: number;
   username?: string | null;
-}) {
+}): Promise<ContestSnapshotSummary> {
   const { note, ...window } = input;
-  const score = await computeCommunityScore(window);
-  const takenAt = new Date().toISOString();
-  const snapshot: ContestSnapshot = {
-    collectionId: window.collectionId,
-    takenAt,
-    takenById: userId,
-    takenByUsername: username ?? null,
-    ...(note ? { note } : {}),
-    score,
-  };
+  try {
+    const config = await getContestScoringConfig(window.collectionId);
+    const resolved = await resolveWindow(window.collectionId, window, config);
+    const gates = await loadGates(resolved);
+    const score = await computeCommunityScore(window);
 
-  await dbWrite.keyValue.create({
-    data: {
-      key: snapshotKey(window.collectionId, takenAt),
-      value: snapshot as unknown as Prisma.InputJsonValue,
-    },
-  });
+    const takenAt = new Date().toISOString();
+    const key = snapshotKey(window.collectionId, takenAt);
+    const snapshot: ContestSnapshot = {
+      collectionId: window.collectionId,
+      takenAt,
+      takenById: userId,
+      takenByUsername: username ?? null,
+      ...(note ? { note } : {}),
+      codeVersion: CONTEST_SCORE_CODE_VERSION,
+      config,
+      ageCutoff: resolved.ageCutoff.toISOString(),
+      ageGateBandUsers: gates.ageGateBandUsers,
+      partial: resolved.partial,
+      score,
+    };
 
-  return snapshot;
+    await dbWrite.keyValue.create({
+      data: { key, value: snapshot as unknown as Prisma.InputJsonValue },
+    });
+
+    return toSnapshotSummary(key, snapshot);
+  } catch (e) {
+    return sanitizeError(window.collectionId, e);
+  }
 }
 
 export async function listContestSnapshots({ collectionId }: { collectionId: number }) {
@@ -794,23 +1157,6 @@ export async function listContestSnapshots({ collectionId }: { collectionId: num
   });
 
   return rows
-    .map(({ key, value }) => {
-      const snapshot = value as unknown as ContestSnapshot;
-      return {
-        key,
-        takenAt: snapshot.takenAt,
-        takenById: snapshot.takenById,
-        takenByUsername: snapshot.takenByUsername,
-        note: snapshot.note,
-        window: snapshot.score.window,
-        entryCount: snapshot.score.entryCount,
-      };
-    })
+    .map(({ key, value }) => toSnapshotSummary(key, value as unknown as ContestSnapshot))
     .sort((a, b) => b.takenAt.localeCompare(a.takenAt));
-}
-
-export async function getContestSnapshot({ key }: { key: string }) {
-  const row = await dbRead.keyValue.findUnique({ where: { key } });
-  if (!row) throw throwBadRequestError('Snapshot not found');
-  return row.value as unknown as ContestSnapshot;
 }

--- a/src/server/services/contest-score.service.ts
+++ b/src/server/services/contest-score.service.ts
@@ -9,6 +9,11 @@
  * Categories are separate contests — normalization and ranking never cross a
  * category boundary, so raw volume is never compared across them.
  *
+ * Every version-scoped signal counts only QUALIFYING versions: created inside the
+ * contest window, on a configured base model. An already-existing model may enter with
+ * a new version, so crediting the whole model hands an entry its own back catalogue.
+ * Collects are the one exception and stay model-level — see `countCollectors`.
+ *
  * Every count is computed IN the database. No user-id array ever crosses into
  * Node: the age gate becomes a `userId <= threshold` pushdown, and the (small)
  * disqualified set is pushed into each query as a literal id list.
@@ -71,17 +76,17 @@ const nowUtc = Prisma.raw(`(NOW() AT TIME ZONE 'UTC')`);
  * Bumped whenever a change here could move a ranking. Recorded in every snapshot so
  * a disputed result can be traced to the code that produced it.
  */
-export const CONTEST_SCORE_CODE_VERSION = 2;
+export const CONTEST_SCORE_CODE_VERSION = 3;
 
 /**
  * Comments and tips are deliberately unweighted: both are trivially launderable
  * (a tip can be sent back out of band).
  */
 export const CONTEST_SIGNAL_SOURCES: Record<Signal, string> = {
-  imageAuthors: 'Distinct authors of on-site images made with the model',
+  imageAuthors: "Distinct authors of on-site images made with the entry's versions",
   reactors: 'Distinct users reacting to those images',
-  downloaders: 'Distinct users downloading the model',
-  generators: 'Distinct users generating with the model',
+  downloaders: "Distinct users downloading the entry's versions",
+  generators: "Distinct users generating with the entry's versions",
   collectors: 'Distinct users adding the model to another collection',
 };
 
@@ -609,10 +614,12 @@ function intList(values: number[]) {
   return values.join(',');
 }
 
-function ineligibilityReason(entry: EntryRow) {
+function ineligibilityReason(entry: EntryRow, qualifyingVersions: number) {
   if (entry.modelDeleted) return 'Model deleted';
   if (entry.modelStatus !== 'Published') return `Model ${entry.modelStatus.toLowerCase()}`;
   if (entry.modelAvailability === Availability.Private) return 'Model is private';
+  if (!qualifyingVersions)
+    return 'No version was created during the contest window on a qualifying base model';
   return null;
 }
 
@@ -891,15 +898,21 @@ function pgQualified(userColumn: string, userAlias: string, gates: BaseGates) {
  * on image creation would credit or drop the wrong work. Scheduled posts carry a
  * future `publishedAt` and are visible to nobody, hence the `<= NOW()`.
  */
-async function loadImagePairs(entries: EntryRow[], window: ResolvedWindow) {
+async function loadImagePairs(
+  entries: EntryRow[],
+  versionPairs: EntryPair[],
+  window: ResolvedWindow
+) {
+  if (!versionPairs.length) return [];
+
   return withSpan(
     'contest-score.image-pairs',
     () =>
       dbRead.$queryRaw<{ entryId: number; imageId: number }[]>`
       SELECT DISTINCT e."entryId" AS "entryId", i.id AS "imageId"
       FROM ${pgEntryTable(entries)}
-      JOIN "ModelVersion" mv ON mv."modelId" = e."modelId"
-      JOIN "ImageResourceNew" ir ON ir."modelVersionId" = mv.id
+      JOIN ${pgVersionTable(versionPairs)} ON v."entryId" = e."entryId"
+      JOIN "ImageResourceNew" ir ON ir."modelVersionId" = v."versionId"
       JOIN "Image" i ON i.id = ir."imageId"
       JOIN "Post" p ON p.id = i."postId"
       WHERE p."publishedAt" IS NOT NULL
@@ -912,7 +925,14 @@ async function loadImagePairs(entries: EntryRow[], window: ResolvedWindow) {
   );
 }
 
-async function countImageAuthors(entries: EntryRow[], window: ResolvedWindow, gates: BaseGates) {
+async function countImageAuthors(
+  entries: EntryRow[],
+  versionPairs: EntryPair[],
+  window: ResolvedWindow,
+  gates: BaseGates
+) {
+  if (!versionPairs.length) return [];
+
   return withSpan(
     'contest-score.image-authors',
     () =>
@@ -923,8 +943,8 @@ async function countImageAuthors(entries: EntryRow[], window: ResolvedWindow, ga
         count(DISTINCT i."userId") FILTER (WHERE ${pgQualified('i."userId"', 'au', gates)})::int
                                         AS "qualifiedUsers"
       FROM ${pgEntryTable(entries)}
-      JOIN "ModelVersion" mv ON mv."modelId" = e."modelId"
-      JOIN "ImageResourceNew" ir ON ir."modelVersionId" = mv.id
+      JOIN ${pgVersionTable(versionPairs)} ON v."entryId" = e."entryId"
+      JOIN "ImageResourceNew" ir ON ir."modelVersionId" = v."versionId"
       JOIN "Image" i ON i.id = ir."imageId"
       JOIN "Post" p ON p.id = i."postId"
       LEFT JOIN "User" au ON au.id = i."userId"
@@ -938,6 +958,10 @@ async function countImageAuthors(entries: EntryRow[], window: ResolvedWindow, ga
   );
 }
 
+/**
+ * The only signal that stays MODEL-level. A collect targets the model, never a
+ * version, so there is nothing to scope it to; the window filter is all it gets.
+ */
 async function countCollectors(
   entries: EntryRow[],
   window: ResolvedWindow,
@@ -969,11 +993,38 @@ async function countCollectors(
   );
 }
 
-async function loadVersionPairs(entries: EntryRow[]) {
-  const versions = await dbRead.$queryRaw<{ id: number; modelId: number }[]>`
-    SELECT id, "modelId" FROM "ModelVersion"
-    WHERE "modelId" IN (${Prisma.join(entries.map((e) => e.modelId))})
-  `;
+/**
+ * The versions that actually represent an entry: created inside the contest window
+ * and, where the config names any, built on one of its base models.
+ *
+ * Contest rules let an already-existing model enter with a new version, so counting
+ * every version of the model credits an entry with traffic its contest work never
+ * earned — a fifteen-month-old sibling version can carry an entry to first place.
+ *
+ * Deliberately NOT "the latest version": a creator who iterates during the contest
+ * has every in-window version count toward the same entry.
+ */
+async function loadQualifyingVersions(
+  entries: EntryRow[],
+  window: ResolvedWindow,
+  baseModels: string[]
+) {
+  const versions = await withSpan(
+    'contest-score.qualifying-versions',
+    () =>
+      dbRead.$queryRaw<{ id: number; modelId: number }[]>`
+      SELECT mv.id AS "id", mv."modelId" AS "modelId"
+      FROM "ModelVersion" mv
+      WHERE mv."modelId" IN (${Prisma.join(entries.map((e) => e.modelId))})
+        AND mv."createdAt" >= ${utc(window.start)}
+        AND mv."createdAt" < ${utc(window.effectiveEnd)}
+        ${
+          baseModels.length
+            ? Prisma.sql`AND mv."baseModel" IN (${Prisma.join(baseModels)})`
+            : Prisma.empty
+        }
+    `
+  );
 
   const byModel = new Map<number, EntryRow[]>();
   for (const entry of entries) {
@@ -983,25 +1034,28 @@ async function loadVersionPairs(entries: EntryRow[]) {
   }
 
   const pairs: EntryPair[] = [];
+  const countByEntry = new Map<number, number>(entries.map((e) => [e.collectionItemId, 0]));
   for (const version of versions)
-    for (const entry of byModel.get(version.modelId) ?? [])
+    for (const entry of byModel.get(version.modelId) ?? []) {
       pairs.push({
         entityId: version.id,
         entryId: entry.collectionItemId,
         creatorId: entry.creatorId,
         addedById: entry.addedById ?? 0,
       });
+      countByEntry.set(entry.collectionItemId, (countByEntry.get(entry.collectionItemId) ?? 0) + 1);
+    }
 
-  return pairs;
+  return { pairs, countByEntry };
 }
 
-function modelPairs(entries: EntryRow[]): EntryPair[] {
-  return entries.map((entry) => ({
-    entityId: entry.modelId,
-    entryId: entry.collectionItemId,
-    creatorId: entry.creatorId,
-    addedById: entry.addedById ?? 0,
-  }));
+/**
+ * The qualifying versions as a Postgres lookup table, so the image-derived signals
+ * resolve their images through exactly the version set the ClickHouse signals count.
+ */
+function pgVersionTable(pairs: EntryPair[]) {
+  const values = pairs.map((p) => `(${intList([p.entryId, p.entityId])})`).join(',');
+  return Prisma.raw(`(VALUES ${values}) AS v("entryId", "versionId")`);
 }
 
 function toImagePairs(rows: { entryId: number; imageId: number }[], entries: EntryRow[]) {
@@ -1035,6 +1089,11 @@ export type ContestScoreEntry = {
   status: string;
   eligible: boolean;
   ineligibleReason: string | null;
+  /**
+   * Versions of the model that represent this entry. Recorded so a disputed placement
+   * can be explained without re-deriving which versions the run counted.
+   */
+  qualifyingVersionCount: number;
   image: EntryImage | null;
   // No `normalized` here: alongside `score`, five normalized values and five scores
   // solve for the five weights. The UI never rendered it.
@@ -1101,7 +1160,12 @@ function emptySignals() {
 }
 
 /** Filled in during a run for the snapshot's audit trail; never sent to a client. */
-type RunAudit = { engagerCount: number; ageGateBandUsers: number };
+type RunAudit = {
+  engagerCount: number;
+  ageGateBandUsers: number;
+  /** Resolved rather than read back off the config, which may not carry the field. */
+  baseModels: string[];
+};
 
 /**
  * What a run actually used, returned rather than re-derived by the caller.
@@ -1125,7 +1189,8 @@ async function computeCommunityScore(input: WindowInput): Promise<RunOutcome> {
   const { config, scope } = await resolveContestScoringConfig(input.collectionId);
   const window = await resolveWindow(input.collectionId, input, config);
   const statuses = input.statuses ?? DEFAULT_STATUSES;
-  const audit: RunAudit = { engagerCount: 0, ageGateBandUsers: 0 };
+  const baseModels = config.baseModels ?? [];
+  const audit: RunAudit = { engagerCount: 0, ageGateBandUsers: 0, baseModels };
 
   const base = {
     collectionId: input.collectionId,
@@ -1159,13 +1224,15 @@ async function computeCommunityScore(input: WindowInput): Promise<RunOutcome> {
       audit,
     };
 
-  const baseGates = await loadBaseGates(window.ageCutoff);
+  const [baseGates, { pairs: versionPairs, countByEntry: qualifyingVersions }] = await Promise.all([
+    loadBaseGates(window.ageCutoff),
+    loadQualifyingVersions(entries, window, baseModels),
+  ]);
 
-  const [imageAuthors, collectors, imageRowsRaw, versionPairs, images] = await Promise.all([
-    countImageAuthors(entries, window, baseGates),
+  const [imageAuthors, collectors, imageRowsRaw, images] = await Promise.all([
+    countImageAuthors(entries, versionPairs, window, baseGates),
     countCollectors(entries, window, baseGates, input.collectionId),
-    loadImagePairs(entries, window),
-    loadVersionPairs(entries),
+    loadImagePairs(entries, versionPairs, window),
     loadEntryImages(entries.map((e) => e.modelId)),
   ]);
 
@@ -1183,10 +1250,10 @@ async function computeCommunityScore(input: WindowInput): Promise<RunOutcome> {
         AND userId != 0
     `,
     downloaders: (ids: string) => `
-      SELECT toInt64(userId) AS userId, toInt64(modelId) AS entityId
+      SELECT toInt64(userId) AS userId, toInt64(modelVersionId) AS entityId
       FROM modelVersionEvents
       WHERE type = 'Download'
-        AND modelId IN (${ids})
+        AND modelVersionId IN (${ids})
         AND time >= ${chDateTime(window.start)} AND time < ${chDateTime(window.effectiveEnd)}
         AND userId != 0
     `,
@@ -1206,7 +1273,6 @@ async function computeCommunityScore(input: WindowInput): Promise<RunOutcome> {
   };
 
   const imageIds = intList([...new Set(imagePairs.map((p) => p.entityId))]) || '0';
-  const modelIds = intList([...new Set(entries.map((e) => e.modelId))]) || '0';
   const versionIds = intList([...new Set(versionPairs.map((p) => p.entityId))]) || '0';
 
   // Resolve banned/deleted against the ENGAGERS, not the other way round: the
@@ -1214,7 +1280,7 @@ async function computeCommunityScore(input: WindowInput): Promise<RunOutcome> {
   const engagers = await collectChEngagers(
     [
       chSources.reactors(imageIds),
-      chSources.downloaders(modelIds),
+      chSources.downloaders(versionIds),
       chSources.generators(versionIds),
     ],
     baseGates
@@ -1245,7 +1311,7 @@ async function computeCommunityScore(input: WindowInput): Promise<RunOutcome> {
 
   const [reactors, downloaders, generators] = await Promise.all([
     runChCounts('reactors', imagePairs, gates, chSources.reactors),
-    runChCounts('downloaders', modelPairs(entries), gates, chSources.downloaders),
+    runChCounts('downloaders', versionPairs, gates, chSources.downloaders),
     runChCounts('generators', versionPairs, gates, chSources.generators),
   ]);
 
@@ -1269,10 +1335,12 @@ async function computeCommunityScore(input: WindowInput): Promise<RunOutcome> {
     const signals = counts.get(entry.collectionItemId) ?? emptySignals();
     const rawTotal = contestScoreSignals.reduce((sum, s) => sum + signals[s].raw, 0);
     const qualifiedTotal = contestScoreSignals.reduce((sum, s) => sum + signals[s].qualified, 0);
-    const reason = ineligibilityReason(entry);
+    const qualifyingVersionCount = qualifyingVersions.get(entry.collectionItemId) ?? 0;
+    const reason = ineligibilityReason(entry, qualifyingVersionCount);
 
     return {
       collectionItemId: entry.collectionItemId,
+      qualifyingVersionCount,
       modelId: entry.modelId,
       modelName: entry.modelName,
       creatorId: entry.creatorId,
@@ -1642,7 +1710,12 @@ export async function getContestCandidates(input: GetContestCandidatesInput) {
     if (!entries.length) return { collectionId: input.collectionId, count: 0, candidates: [] };
 
     const baseGates = await loadBaseGates(window.ageCutoff);
-    const imagePairs = toImagePairs(await loadImagePairs(entries, window), entries);
+    const { pairs: versionPairs } = await loadQualifyingVersions(
+      entries,
+      window,
+      config.baseModels ?? []
+    );
+    const imagePairs = toImagePairs(await loadImagePairs(entries, versionPairs, window), entries);
 
     // Reactions and downloads are the engagement events that carry an IP — the same
     // farm-IP signal `reaction-abuse` uses, scoped to this contest.
@@ -1650,12 +1723,12 @@ export async function getContestCandidates(input: GetContestCandidatesInput) {
       await Promise.all([
         runChPerCreator(
           'candidates.downloads',
-          modelPairs(entries),
+          versionPairs,
           (ids) => `
-          SELECT toInt64(userId) AS userId, toInt64(modelId) AS entityId, ip
+          SELECT toInt64(userId) AS userId, toInt64(modelVersionId) AS entityId, ip
           FROM modelVersionEvents
           WHERE type = 'Download'
-            AND modelId IN (${ids})
+            AND modelVersionId IN (${ids})
             AND time >= ${chDateTime(window.start)} AND time < ${chDateTime(window.effectiveEnd)}
             AND userId != 0
         `
@@ -1844,6 +1917,8 @@ export type ContestSnapshot = {
    */
   ageGateBandUsers: number;
   engagerCount: number;
+  /** Empty means no base-model filter was applied, not that the field was forgotten. */
+  baseModels: string[];
   partial: boolean;
   score: ContestCommunityScore;
 };
@@ -1913,6 +1988,7 @@ export async function createContestSnapshot({
       ageCutoff: outcome.window.ageCutoff.toISOString(),
       ageGateBandUsers: outcome.audit.ageGateBandUsers,
       engagerCount: outcome.audit.engagerCount,
+      baseModels: outcome.audit.baseModels,
       partial: outcome.window.partial,
       score: outcome.score,
     };

--- a/src/server/services/contest-score.service.ts
+++ b/src/server/services/contest-score.service.ts
@@ -81,7 +81,7 @@ const nowUtc = Prisma.raw(`(NOW() AT TIME ZONE 'UTC')`);
  * Bumped whenever a change here could move a ranking. Recorded in every snapshot so
  * a disputed result can be traced to the code that produced it.
  */
-export const CONTEST_SCORE_CODE_VERSION = 4;
+export const CONTEST_SCORE_CODE_VERSION = 5;
 
 /**
  * Comments and tips are deliberately unweighted: both are trivially launderable
@@ -339,9 +339,18 @@ export type ResolvedWindow = {
   ageCutoff: Date;
   contestStart: Date;
   contestEnd: Date;
+  contestStartSource: ContestBoundSource;
+  contestEndSource: ContestBoundSource;
   /** `Collection.metadata.baseModels` — the rule entrants were actually told. */
   declaredBaseModels: string[];
 };
+
+/** Which field an eligibility bound came from, so a run can say so rather than imply it. */
+export type ContestBoundSource =
+  | 'submissionStartDate'
+  | 'submissionEndDate'
+  | 'endsAt'
+  | 'collectionCreatedAt';
 
 /**
  * Derived from the collection's own contest metadata, never defaulted. An absent
@@ -355,14 +364,24 @@ async function resolveWindow(
 ): Promise<ResolvedWindow> {
   const collection = await dbRead.collection.findUnique({
     where: { id: collectionId },
-    select: { id: true, mode: true, metadata: true },
+    select: { id: true, mode: true, metadata: true, createdAt: true },
   });
   if (!collection) throw new ContestScoringError(`Collection ${collectionId} not found`);
   if (collection.mode !== CollectionMode.Contest)
     throw new ContestScoringError(`Collection ${collectionId} is not a contest collection`);
 
+  // A hard failure, never a silent `{}`. Eligibility reads two metadata fields, and a
+  // fallback shape would drop the contest start to the display window AND empty the
+  // declared base models — handing the rule back to the config row — with nothing on
+  // screen to say so. This is reachable: the schema refines `baseModels` against
+  // `basemodel.constants.ts`, so retiring a base model stops every contest naming it
+  // from parsing.
   const parsed = collectionMetadataSchema.safeParse(collection.metadata ?? {});
-  const metadata = parsed.success ? parsed.data : {};
+  if (!parsed.success)
+    throw new ContestScoringError(
+      `Collection ${collectionId} has contest metadata that no longer parses, so its contest window and base models cannot be trusted: ${parsed.error.message}`
+    );
+  const metadata = parsed.data;
 
   const start = input.start ?? metadata.submissionStartDate;
   const end = input.end ?? metadata.submissionEndDate ?? metadata.endsAt;
@@ -375,12 +394,31 @@ async function resolveWindow(
       `Collection ${collectionId} has neither submissionEndDate nor endsAt, and no explicit window end was given.`
     );
 
-  // Always the contest's own bounds, never a narrowed display window — otherwise
-  // zooming the view would drag the age gate and version eligibility along with it.
-  // They fall back to the resolved window only for a contest carrying no submission
-  // dates at all, where the caller's dates are the only definition available.
-  const contestStart = metadata.submissionStartDate ?? start;
-  const contestEnd = metadata.submissionEndDate ?? metadata.endsAt ?? end;
+  // The contest's own bounds, and NEVER the display window: these decide the age gate
+  // and which versions qualify, so letting them fall back to the date pickers would
+  // hand eligibility to whoever is looking at the screen. The two bounds resolve
+  // independently — the common `endsAt`-only shape satisfies the end while leaving the
+  // start with no submission date at all — so each carries its own fallback.
+  //
+  // `Collection.createdAt` is the backstop because it is structural and cannot be
+  // nudged: a contest's entries cannot predate the collection holding them. Where even
+  // that is unavailable the run refuses rather than scoring against an arbitrary line.
+  const contestStart = metadata.submissionStartDate ?? collection.createdAt;
+  const contestStartSource: ContestBoundSource = metadata.submissionStartDate
+    ? 'submissionStartDate'
+    : 'collectionCreatedAt';
+  const contestEnd = metadata.submissionEndDate ?? metadata.endsAt;
+  const contestEndSource: ContestBoundSource = metadata.submissionEndDate
+    ? 'submissionEndDate'
+    : 'endsAt';
+  if (!contestStart)
+    throw new ContestScoringError(
+      `Collection ${collectionId} has no submissionStartDate and no creation date, so there is no trustworthy start for deciding which versions qualify.`
+    );
+  if (!contestEnd)
+    throw new ContestScoringError(
+      `Collection ${collectionId} has neither submissionEndDate nor endsAt, so there is no trustworthy end for deciding which versions qualify. An explicit window end only narrows the view; it cannot define the contest.`
+    );
   const ageCutoff = new Date(contestStart.getTime() - config.ageGateDays * 24 * 60 * 60 * 1000);
 
   // Belt and braces behind the schema's `nonnegative()`: a row written before that
@@ -402,6 +440,8 @@ async function resolveWindow(
     ageCutoff,
     contestStart,
     contestEnd,
+    contestStartSource,
+    contestEndSource,
     declaredBaseModels: metadata.baseModels?.filter(Boolean) ?? [],
   };
 }
@@ -1215,7 +1255,19 @@ export type ContestScoreCategory = {
 export type ContestCommunityScore = {
   collectionId: number;
   generatedAt: string;
+  /** The DISPLAY window — which traffic was counted. */
   window: { start: string; end: string; effectiveEnd: string };
+  /**
+   * The contest itself — which versions qualified, and therefore who was eligible.
+   * Distinct from `window` on purpose: a moderator narrowing the pickers changes the
+   * former and must never change the latter, and the header says which is which.
+   */
+  eligibility: {
+    start: string;
+    end: string;
+    startSource: ContestBoundSource;
+    endSource: ContestBoundSource;
+  };
   partial: boolean;
   statuses: CollectionItemStatus[];
   entryCount: number;
@@ -1289,6 +1341,12 @@ async function computeCommunityScore(input: WindowInput): Promise<RunOutcome> {
       start: window.start.toISOString(),
       end: window.end.toISOString(),
       effectiveEnd: window.effectiveEnd.toISOString(),
+    },
+    eligibility: {
+      start: window.contestStart.toISOString(),
+      end: window.contestEnd.toISOString(),
+      startSource: window.contestStartSource,
+      endSource: window.contestEndSource,
     },
     partial: window.partial,
     statuses,

--- a/src/server/services/contest-score.service.ts
+++ b/src/server/services/contest-score.service.ts
@@ -47,6 +47,17 @@ import { hashifyObject } from '~/utils/string-helpers';
 type Signal = ContestScoreSignal;
 
 /**
+ * Every timestamp column this service compares against — `User.createdAt`,
+ * `Post.publishedAt`, `CollectionItem.createdAt`, `bannedAt`, `deletedAt` — is
+ * `timestamp WITHOUT time zone` holding UTC. A bound `Date` arrives as `timestamptz`
+ * and Postgres coerces it using the SESSION timezone, so the comparison is only
+ * correct while that session happens to be UTC. Converting explicitly makes it
+ * correct under any session timezone.
+ */
+const utc = (d: Date) => Prisma.sql`(${d}::timestamptz AT TIME ZONE 'UTC')`;
+const nowUtc = Prisma.raw(`(NOW() AT TIME ZONE 'UTC')`);
+
+/**
  * Bumped whenever a change here could move a ranking. Recorded in every snapshot so
  * a disputed result can be traced to the code that produced it.
  */
@@ -70,6 +81,9 @@ const SCORE_CACHE_TTL = 60 * 15;
 // ones: uniqExact cannot be summed across chunks, so every entity belonging to an
 // entry has to be counted in the same call.
 const CH_ENTITY_CHUNK = 20000;
+// Ceiling on the reactor lookup table, which scales with images published in the
+// window rather than with entry count. Past it the run is flagged truncated.
+const MAX_IMAGE_PAIRS = 200000;
 const CH_CONCURRENCY = 4;
 const DEFAULT_STATUSES: CollectionItemStatus[] = [CollectionItemStatus.ACCEPTED];
 
@@ -105,6 +119,13 @@ const storedConfigSchema = z.object({
   version: z.number(),
   weights: weightsSchema,
   ageGateDays: z.number(),
+  // Floor on each signal's normalization denominator. Where a category's leading
+  // qualified count is tiny, plain max-normalization lets one or two users swing a
+  // signal from 0 to 0.5 and decide a placement on noise.
+  minDenominator: weightsSchema,
+  // Ceiling on the engager set resolved against Postgres. Past it the banned/deleted
+  // refinement is skipped and the run is flagged degraded rather than run anyway.
+  maxEngagers: z.number(),
   farmIp: z.object({ minPeers: z.number(), minEntries: z.number() }),
 });
 
@@ -200,15 +221,18 @@ async function resolveWindow(
 // Gates
 // ---------------------------------------------------------------------------
 
-type Gates = {
-  /** An account with an id above this registered after the cutoff. */
+type BaseGates = {
   userIdThreshold: number;
-  /**
-   * Users wrongly caught by the id threshold: registered before the cutoff but
-   * holding an id above it. Recorded so a snapshot can be audited.
-   */
   ageGateBandUsers: number;
+  baseDisqualifiedIds: number[];
+};
+
+type Gates = BaseGates & {
+  /** Base list plus the banned/deleted engagers resolved for THIS contest. */
   disqualifiedIds: number[];
+  /** Set when the engager set blew the cap and the ban refinement was skipped. */
+  bannedRefinementSkipped: boolean;
+  engagerCount: number;
 };
 
 /**
@@ -237,14 +261,14 @@ async function loadAgeThreshold(ageCutoff: Date) {
         // count against an unknown threshold and the query takes ~50s instead of ~12s.
         const [{ threshold }] = await dbRead.$queryRaw<{ threshold: number }[]>`
           SELECT COALESCE(
-            (SELECT min(id) FROM "User" WHERE "createdAt" > ${ageCutoff}) - 1,
+            (SELECT min(id) FROM "User" WHERE "createdAt" > ${utc(ageCutoff)}) - 1,
             (SELECT max(id) FROM "User")
           )::int AS "threshold"
         `;
         const [{ bandUsers }] = await dbRead.$queryRaw<{ bandUsers: number }[]>`
           SELECT count(*)::int AS "bandUsers"
           FROM "User" u
-          WHERE u."createdAt" <= ${ageCutoff} AND u.id > ${threshold}
+          WHERE u."createdAt" <= ${utc(ageCutoff)} AND u.id > ${threshold}
         `;
         return { threshold, bandUsers };
       }),
@@ -252,49 +276,95 @@ async function loadAgeThreshold(ageCutoff: Date) {
   );
 }
 
-async function loadGates(window: ResolvedWindow): Promise<Gates> {
-  const threshold = await loadAgeThreshold(window.ageCutoff);
+/** The always-on gates: cheap, bounded, and enough to bound the engager set. */
+async function loadBaseGates(ageCutoff: Date) {
+  const threshold = await loadAgeThreshold(ageCutoff);
 
   if (threshold.bandUsers)
     console.warn(
       `[contest-score] age gate band holds ${threshold.bandUsers} user(s) registered before the cutoff but carrying an id above the threshold; they are disqualified.`
     );
 
-  // Only accounts banned or deleted ON OR AFTER the window start can have engaged
-  // during it — every signal here requires an authenticated action and a banned or
-  // deleted account cannot perform one. That turns a 1.35M-row set into a few
-  // thousand, small enough to push into ClickHouse. Contest bans are unconditional
-  // (a scoring sanction, not an access one) and number in the dozens.
-  const banned = await withSpan(
-    'contest-score.banned',
-    () =>
-      dbRead.$queryRaw<{ id: number }[]>`
-      SELECT u.id
-      FROM "User" u
-      WHERE u.id <= ${threshold.threshold}
-        AND (
-          u."bannedAt" >= ${window.start}
-          OR u."deletedAt" >= ${window.start}
-          OR u.meta ->> 'contestBanDetails' IS NOT NULL
-        )
-    `
-  );
-
-  const excluded = await withSpan('contest-score.excluded-users', () =>
-    clickhouse!.$query<{ userId: number }>(`
-      SELECT userId FROM metricExcludedUsers FINAL WHERE active = 1
-    `)
-  );
-
-  const disqualifiedIds = [
-    ...new Set([...banned.map((b) => b.id), ...excluded.map((e) => Number(e.userId))]),
-  ].sort((a, b) => a - b);
+  const [excluded, contestBanned] = await Promise.all([
+    withSpan('contest-score.excluded-users', () =>
+      clickhouse!.$query<{ userId: number }>(`
+        SELECT userId FROM metricExcludedUsers FINAL WHERE active = 1
+      `)
+    ),
+    withSpan(
+      'contest-score.contest-banned',
+      () =>
+        dbRead.$queryRaw<{ id: number }[]>`
+        SELECT u.id FROM "User" u WHERE u.meta ->> 'contestBanDetails' IS NOT NULL
+      `
+    ),
+  ]);
 
   return {
     userIdThreshold: threshold.threshold,
     ageGateBandUsers: threshold.bandUsers,
-    disqualifiedIds,
+    baseDisqualifiedIds: [
+      ...new Set([...excluded.map((e) => Number(e.userId)), ...contestBanned.map((u) => u.id)]),
+    ].sort((a, b) => a - b),
   };
+}
+
+// Postgres caps a statement at 65,535 bind parameters. Chunked well under it so this
+// is a bounded loop rather than a cliff a big contest walks off.
+const PG_ID_CHUNK = 10000;
+
+/**
+ * Resolves banned / deleted / vanished accounts against the ENGAGER set rather than
+ * the other way round. The banned-or-deleted population is ~1.35M rows and must
+ * never be pushed into ClickHouse; the engagers on a contest number in the
+ * thousands, so the small side is the one that travels.
+ *
+ * An id with no `User` row at all is a hard-deleted account and never counts.
+ */
+async function resolveBannedEngagers(engagerIds: number[]) {
+  if (!engagerIds.length) return [] as number[];
+
+  const disqualified: number[] = [];
+  for (let i = 0; i < engagerIds.length; i += PG_ID_CHUNK) {
+    const chunk = engagerIds.slice(i, i + PG_ID_CHUNK);
+    const rows = await dbRead.$queryRaw<{ id: number; gone: boolean }[]>`
+      SELECT ids.id, (u.id IS NULL OR u."bannedAt" IS NOT NULL OR u."deletedAt" IS NOT NULL) AS "gone"
+      FROM unnest(ARRAY[${Prisma.join(chunk)}]::int[]) AS ids(id)
+      LEFT JOIN "User" u ON u.id = ids.id
+    `;
+    for (const row of rows) if (row.gone) disqualified.push(row.id);
+  }
+
+  return disqualified;
+}
+
+/**
+ * Distinct users who engaged through a ClickHouse signal, already narrowed by the
+ * age gate and the base exclusions. Postgres signals do not need this — they join
+ * `User` inline — so only the three ClickHouse signals pay the round trip.
+ */
+async function collectChEngagers(
+  sources: string[],
+  base: { userIdThreshold: number; baseDisqualifiedIds: number[] }
+) {
+  const disqualified = base.baseDisqualifiedIds.length ? intList(base.baseDisqualifiedIds) : '0';
+
+  const results = await withSpan('contest-score.engagers', () => {
+    const limit = pLimit(CH_CONCURRENCY);
+    return Promise.all(
+      sources.map((source) =>
+        limit(() =>
+          clickhouse!.$query<{ userId: number }>(`
+            SELECT DISTINCT userId
+            FROM (${source}) AS s
+            WHERE userId <= ${base.userIdThreshold} AND userId NOT IN (${disqualified})
+          `)
+        )
+      )
+    );
+  });
+
+  return [...new Set(results.flat().map((r) => Number(r.userId)))];
 }
 
 // ---------------------------------------------------------------------------
@@ -407,7 +477,7 @@ async function loadEntryImages(modelIds: number[]) {
       JOIN "Image" i ON i."postId" = p.id
       WHERE mv."modelId" IN (${Prisma.join(modelIds)})
         AND p."publishedAt" IS NOT NULL
-        AND p."publishedAt" <= NOW()
+        AND p."publishedAt" <= ${nowUtc}
         AND i.ingestion <> 'Blocked'::"ImageIngestionStatus"
       ORDER BY mv."modelId", mv."index", p.id, i."index"
     `
@@ -449,7 +519,12 @@ function chPairTable(pairs: EntryPair[]) {
   `;
 }
 
-const chDateTime = (d: Date) => `toDateTime('${d.toISOString().slice(0, 19).replace('T', ' ')}')`;
+/**
+ * Seconds since the epoch, never a formatted string. `toDateTime('2026-07-24
+ * 00:00:00')` is parsed in the ClickHouse SERVER timezone, so a literal silently
+ * shifts the window; an integer is an absolute instant.
+ */
+const chDateTime = (d: Date) => `toDateTime(${Math.floor(d.getTime() / 1000)})`;
 
 /**
  * Counts distinct users per ENTRY inside ClickHouse. `source` projects `userId` and
@@ -552,13 +627,18 @@ function pgEntryTable(entries: EntryRow[]) {
 }
 
 /** The qualification gate, identical across every signal. */
-function pgQualified(userColumn: string, gates: Gates) {
-  const disqualified = gates.disqualifiedIds.length ? intList(gates.disqualifiedIds) : '-1';
+function pgQualified(userColumn: string, userAlias: string, gates: BaseGates) {
+  const disqualified = gates.baseDisqualifiedIds.length ? intList(gates.baseDisqualifiedIds) : '-1';
+  // Postgres can see the ban columns directly, so the engager round trip the
+  // ClickHouse signals need is unnecessary here — the predicate is the same one.
   return Prisma.raw(`
     ${userColumn} <> e."creatorId"
     AND (e."addedById" IS NULL OR ${userColumn} <> e."addedById")
     AND ${userColumn} <= ${gates.userIdThreshold}
     AND NOT (${userColumn} = ANY(ARRAY[${disqualified}]::int[]))
+    AND ${userAlias}.id IS NOT NULL
+    AND ${userAlias}."bannedAt" IS NULL
+    AND ${userAlias}."deletedAt" IS NULL
   `);
 }
 
@@ -580,15 +660,15 @@ async function loadImagePairs(entries: EntryRow[], window: ResolvedWindow) {
       JOIN "Image" i ON i.id = ir."imageId"
       JOIN "Post" p ON p.id = i."postId"
       WHERE p."publishedAt" IS NOT NULL
-        AND p."publishedAt" <= NOW()
-        AND p."publishedAt" >= ${window.start}
-        AND p."publishedAt" < ${window.effectiveEnd}
+        AND p."publishedAt" <= ${nowUtc}
+        AND p."publishedAt" >= ${utc(window.start)}
+        AND p."publishedAt" < ${utc(window.effectiveEnd)}
         AND i.ingestion <> 'Blocked'::"ImageIngestionStatus"
     `
   );
 }
 
-async function countImageAuthors(entries: EntryRow[], window: ResolvedWindow, gates: Gates) {
+async function countImageAuthors(entries: EntryRow[], window: ResolvedWindow, gates: BaseGates) {
   return withSpan(
     'contest-score.image-authors',
     () =>
@@ -596,17 +676,18 @@ async function countImageAuthors(entries: EntryRow[], window: ResolvedWindow, ga
       SELECT
         e."entryId"                     AS "collectionItemId",
         count(DISTINCT i."userId")::int AS "rawUsers",
-        count(DISTINCT i."userId") FILTER (WHERE ${pgQualified('i."userId"', gates)})::int
+        count(DISTINCT i."userId") FILTER (WHERE ${pgQualified('i."userId"', 'au', gates)})::int
                                         AS "qualifiedUsers"
       FROM ${pgEntryTable(entries)}
       JOIN "ModelVersion" mv ON mv."modelId" = e."modelId"
       JOIN "ImageResourceNew" ir ON ir."modelVersionId" = mv.id
       JOIN "Image" i ON i.id = ir."imageId"
       JOIN "Post" p ON p.id = i."postId"
+      LEFT JOIN "User" au ON au.id = i."userId"
       WHERE p."publishedAt" IS NOT NULL
-        AND p."publishedAt" <= NOW()
-        AND p."publishedAt" >= ${window.start}
-        AND p."publishedAt" < ${window.effectiveEnd}
+        AND p."publishedAt" <= ${nowUtc}
+        AND p."publishedAt" >= ${utc(window.start)}
+        AND p."publishedAt" < ${utc(window.effectiveEnd)}
         AND i.ingestion <> 'Blocked'::"ImageIngestionStatus"
       GROUP BY e."entryId"
     `
@@ -616,7 +697,7 @@ async function countImageAuthors(entries: EntryRow[], window: ResolvedWindow, ga
 async function countCollectors(
   entries: EntryRow[],
   window: ResolvedWindow,
-  gates: Gates,
+  gates: BaseGates,
   collectionId: number
 ) {
   return withSpan(
@@ -626,14 +707,19 @@ async function countCollectors(
       SELECT
         e."entryId"                         AS "collectionItemId",
         count(DISTINCT ci."addedById")::int AS "rawUsers",
-        count(DISTINCT ci."addedById") FILTER (WHERE ${pgQualified('ci."addedById"', gates)})::int
+        count(DISTINCT ci."addedById") FILTER (WHERE ${pgQualified(
+          'ci."addedById"',
+          'cu',
+          gates
+        )})::int
                                             AS "qualifiedUsers"
       FROM ${pgEntryTable(entries)}
       JOIN "CollectionItem" ci ON ci."modelId" = e."modelId"
+      LEFT JOIN "User" cu ON cu.id = ci."addedById"
       WHERE ci."collectionId" <> ${collectionId}
         AND ci."addedById" IS NOT NULL
-        AND ci."createdAt" >= ${window.start}
-        AND ci."createdAt" < ${window.effectiveEnd}
+        AND ci."createdAt" >= ${utc(window.start)}
+        AND ci."createdAt" < ${utc(window.effectiveEnd)}
       GROUP BY e."entryId"
     `
   );
@@ -734,7 +820,13 @@ export type ContestCommunityScore = {
   partial: boolean;
   statuses: CollectionItemStatus[];
   entryCount: number;
-  truncated: boolean;
+  truncated: { entries: boolean; images: boolean };
+  /**
+   * Set when a bound was hit and part of the qualification was skipped. Degrading
+   * loudly matters more than degrading gracefully for an artifact that decides a
+   * prize.
+   */
+  degraded: { bannedRefinementSkipped: boolean };
   signalSources: Record<Signal, string>;
   categories: ContestScoreCategory[];
 };
@@ -751,7 +843,13 @@ function emptySignals() {
   ) as ContestScoreEntry['signals'];
 }
 
-async function computeCommunityScore(input: WindowInput): Promise<ContestCommunityScore> {
+/** Filled in during a run for the snapshot's audit trail; never sent to a client. */
+type RunAudit = { engagerCount: number; ageGateBandUsers: number };
+
+async function computeCommunityScore(
+  input: WindowInput,
+  audit?: RunAudit
+): Promise<ContestCommunityScore> {
   requireClickhouse();
   const config = await getContestScoringConfig(input.collectionId);
   const window = await resolveWindow(input.collectionId, input, config);
@@ -771,63 +869,105 @@ async function computeCommunityScore(input: WindowInput): Promise<ContestCommuni
   };
 
   const { entries, truncated } = await loadEntries(input);
-  if (!entries.length) return { ...base, entryCount: 0, truncated, categories: [] };
+  if (!entries.length)
+    return {
+      ...base,
+      entryCount: 0,
+      truncated: { entries: truncated, images: false },
+      degraded: { bannedRefinementSkipped: false },
+      categories: [],
+    };
 
-  const gates = await loadGates(window);
+  const baseGates = await loadBaseGates(window.ageCutoff);
 
-  const [imageAuthors, collectors, imageRows, versionPairs, images] = await Promise.all([
-    countImageAuthors(entries, window, gates),
-    countCollectors(entries, window, gates, input.collectionId),
+  const [imageAuthors, collectors, imageRowsRaw, versionPairs, images] = await Promise.all([
+    countImageAuthors(entries, window, baseGates),
+    countCollectors(entries, window, baseGates, input.collectionId),
     loadImagePairs(entries, window),
     loadVersionPairs(entries),
     loadEntryImages(entries.map((e) => e.modelId)),
   ]);
 
-  const [reactors, downloaders, generators] = await Promise.all([
-    runChCounts(
-      'reactors',
-      toImagePairs(imageRows, entries),
-      gates,
-      (ids) => `
-        SELECT toInt64(userId) AS userId, toInt64(entityId) AS entityId
-        FROM reactions
-        WHERE type = 'Image_Create'
-          AND entityId IN (${ids})
-          AND time >= ${chDateTime(window.start)} AND time < ${chDateTime(window.effectiveEnd)}
-          AND userId != 0
-      `
-    ),
-    runChCounts(
-      'downloaders',
-      modelPairs(entries),
-      gates,
-      (ids) => `
-        SELECT toInt64(userId) AS userId, toInt64(modelId) AS entityId
-        FROM modelVersionEvents
-        WHERE type = 'Download'
-          AND modelId IN (${ids})
-          AND time >= ${chDateTime(window.start)} AND time < ${chDateTime(window.effectiveEnd)}
-          AND userId != 0
-      `
-    ),
+  const truncatedImages = imageRowsRaw.length > MAX_IMAGE_PAIRS;
+  const imageRows = truncatedImages ? imageRowsRaw.slice(0, MAX_IMAGE_PAIRS) : imageRowsRaw;
+  const imagePairs = toImagePairs(imageRows, entries);
+
+  const chSources = {
+    reactors: (ids: string) => `
+      SELECT toInt64(userId) AS userId, toInt64(entityId) AS entityId
+      FROM reactions
+      WHERE type = 'Image_Create'
+        AND entityId IN (${ids})
+        AND time >= ${chDateTime(window.start)} AND time < ${chDateTime(window.effectiveEnd)}
+        AND userId != 0
+    `,
+    downloaders: (ids: string) => `
+      SELECT toInt64(userId) AS userId, toInt64(modelId) AS entityId
+      FROM modelVersionEvents
+      WHERE type = 'Download'
+        AND modelId IN (${ids})
+        AND time >= ${chDateTime(window.start)} AND time < ${chDateTime(window.effectiveEnd)}
+        AND userId != 0
+    `,
     // Straight off orchestration.jobs, NOT default.daily_user_resource: that view
     // only ingests jobType IN ('TextToImage','TextToImageV2','Comfy'), so every
     // newer engine (ComfyImageGen, AnimaComfy, StableDiffusionCpp, …) is missing
     // from it and whole ecosystems read as zero generations.
-    runChCounts(
-      'generators',
-      versionPairs,
-      gates,
-      (ids) => `
-        SELECT toInt64(userId) AS userId, toInt64(resource) AS entityId
-        FROM orchestration.jobs
-        ARRAY JOIN resourcesUsed AS resource
-        WHERE resource IN (${ids})
-          AND createdAt >= ${chDateTime(window.start)}
-          AND createdAt < ${chDateTime(window.effectiveEnd)}
-          AND userId != 0
-      `
-    ),
+    generators: (ids: string) => `
+      SELECT toInt64(userId) AS userId, toInt64(resource) AS entityId
+      FROM orchestration.jobs
+      ARRAY JOIN resourcesUsed AS resource
+      WHERE resource IN (${ids})
+        AND createdAt >= ${chDateTime(window.start)}
+        AND createdAt < ${chDateTime(window.effectiveEnd)}
+        AND userId != 0
+    `,
+  };
+
+  const imageIds = intList([...new Set(imagePairs.map((p) => p.entityId))]) || '0';
+  const modelIds = intList([...new Set(entries.map((e) => e.modelId))]) || '0';
+  const versionIds = intList([...new Set(versionPairs.map((p) => p.entityId))]) || '0';
+
+  // Resolve banned/deleted against the ENGAGERS, not the other way round: the
+  // banned-or-deleted population is ~1.35M rows and must never reach ClickHouse.
+  const engagers = await collectChEngagers(
+    [
+      chSources.reactors(imageIds),
+      chSources.downloaders(modelIds),
+      chSources.generators(versionIds),
+    ],
+    baseGates
+  );
+
+  const bannedRefinementSkipped = engagers.length > config.maxEngagers;
+  if (bannedRefinementSkipped)
+    console.warn(
+      `[contest-score] collection ${input.collectionId} has ${engagers.length} engagers, above the configured ceiling; the banned/deleted refinement was skipped and the run is flagged degraded.`
+    );
+
+  const gates: Gates = {
+    ...baseGates,
+    disqualifiedIds: bannedRefinementSkipped
+      ? baseGates.baseDisqualifiedIds
+      : [
+          ...new Set([
+            ...baseGates.baseDisqualifiedIds,
+            ...(await resolveBannedEngagers(engagers)),
+          ]),
+        ].sort((a, b) => a - b),
+    bannedRefinementSkipped,
+    engagerCount: engagers.length,
+  };
+
+  if (audit) {
+    audit.engagerCount = gates.engagerCount;
+    audit.ageGateBandUsers = gates.ageGateBandUsers;
+  }
+
+  const [reactors, downloaders, generators] = await Promise.all([
+    runChCounts('reactors', imagePairs, gates, chSources.reactors),
+    runChCounts('downloaders', modelPairs(entries), gates, chSources.downloaders),
+    runChCounts('generators', versionPairs, gates, chSources.generators),
   ]);
 
   const counts = new Map<number, ContestScoreEntry['signals']>(
@@ -879,10 +1019,14 @@ async function computeCommunityScore(input: WindowInput): Promise<ContestCommuni
 
       // Normalized against the leading ELIGIBLE entry per signal, so an entry pulled
       // after accruing engagement cannot set the bar for everyone else.
+      //
+      // Floored at the configured minDenominator: where a category's leading count is
+      // tiny, a bare maximum lets one or two users swing a signal from 0 to 0.5 and
+      // decide a placement on noise.
       const maxima = Object.fromEntries(
         contestScoreSignals.map((s) => [
           s,
-          Math.max(...eligible.map((i) => i.signals[s].qualified), 0),
+          Math.max(...eligible.map((i) => i.signals[s].qualified), 0, config.minDenominator[s]),
         ])
       ) as Record<Signal, number>;
 
@@ -918,7 +1062,13 @@ async function computeCommunityScore(input: WindowInput): Promise<ContestCommuni
     }
   );
 
-  return { ...base, entryCount: entries.length, truncated, categories };
+  return {
+    ...base,
+    entryCount: entries.length,
+    truncated: { entries: truncated, images: truncatedImages },
+    degraded: { bannedRefinementSkipped },
+    categories,
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -981,7 +1131,7 @@ export async function getContestCandidates(input: GetContestCandidatesInput) {
     const { entries } = await loadEntries(input);
     if (!entries.length) return { collectionId: input.collectionId, count: 0, candidates: [] };
 
-    const gates = await loadGates(window);
+    const baseGates = await loadBaseGates(window.ageCutoff);
     const imagePairs = toImagePairs(await loadImagePairs(entries, window), entries);
 
     // Reactions and downloads are the engagement events that carry an IP — the same
@@ -1075,7 +1225,7 @@ export async function getContestCandidates(input: GetContestCandidatesInput) {
         farmIpsUsed: Number(row.farmIpsUsed),
         // Reported so a reviewer can tell a too-young account from an excluded one
         // without re-deriving the threshold themselves.
-        newAccount: Number(row.userId) > gates.userIdThreshold,
+        newAccount: Number(row.userId) > baseGates.userIdThreshold,
       })),
     };
   } catch (e) {
@@ -1106,6 +1256,7 @@ export type ContestSnapshot = {
   config: ContestScoringConfig;
   ageCutoff: string;
   ageGateBandUsers: number;
+  engagerCount: number;
   partial: boolean;
   score: ContestCommunityScore;
 };
@@ -1139,8 +1290,8 @@ export async function createContestSnapshot({
   try {
     const config = await getContestScoringConfig(window.collectionId);
     const resolved = await resolveWindow(window.collectionId, window, config);
-    const gates = await loadGates(resolved);
-    const score = await computeCommunityScore(window);
+    const audit: RunAudit = { engagerCount: 0, ageGateBandUsers: 0 };
+    const score = await computeCommunityScore(window, audit);
 
     const takenAt = new Date().toISOString();
     const key = snapshotKey(window.collectionId, takenAt);
@@ -1153,7 +1304,8 @@ export async function createContestSnapshot({
       codeVersion: CONTEST_SCORE_CODE_VERSION,
       config,
       ageCutoff: resolved.ageCutoff.toISOString(),
-      ageGateBandUsers: gates.ageGateBandUsers,
+      ageGateBandUsers: audit.ageGateBandUsers,
+      engagerCount: audit.engagerCount,
       partial: resolved.partial,
       score,
     };

--- a/src/server/services/contest-score.service.ts
+++ b/src/server/services/contest-score.service.ts
@@ -1,0 +1,816 @@
+/**
+ * Community-pick scoring for contest collections.
+ *
+ * Each entry (a CollectionItem carrying a modelId) is scored by counting DISTINCT
+ * QUALIFIED USERS per signal inside the contest window, normalized within its
+ * category, then weighted. Distinct-user counting IS the anti-cheat: one account
+ * contributes at most 1 to any signal, so volume farming collapses to 1.
+ *
+ * Categories are separate contests — normalization and ranking never cross a
+ * category boundary, so raw volume is never compared across them.
+ *
+ * Weights and anti-cheat thresholds are NOT in this file and have no code default.
+ * They live in the `contestScoring` KeyValue row; this module fails loudly when it
+ * is missing. Nothing derived from them is ever returned to the client.
+ */
+
+import { Prisma } from '@prisma/client';
+import * as z from 'zod';
+import { CONTEST_SNAPSHOT_KEY_PREFIX, KEY_VALUE_KEYS } from '~/server/common/constants';
+import { clickhouse } from '~/server/clickhouse/client';
+import { dbRead, dbWrite } from '~/server/db/client';
+import { dbKV } from '~/server/db/db-helpers';
+import { REDIS_KEYS } from '~/server/redis/client';
+import type { RedisKeyTemplateCache } from '~/server/redis/client';
+import type {
+  CreateContestSnapshotInput,
+  GetCommunityScoreInput,
+  GetContestCandidatesInput,
+  ContestScoreSignal,
+} from '~/server/schema/contest-score.schema';
+import { contestScoreSignals } from '~/server/schema/contest-score.schema';
+import { getUserCollectionPermissionsById } from '~/server/services/collection.service';
+import { bustFetchThroughCache, fetchThroughCache } from '~/server/utils/cache-helpers';
+import { throwAuthorizationError, throwBadRequestError } from '~/server/utils/errorHandling';
+import { withSpan } from '~/server/utils/otel-helpers';
+import { CollectionItemStatus } from '~/shared/utils/prisma/enums';
+import { hashifyObject } from '~/utils/string-helpers';
+
+type Signal = ContestScoreSignal;
+
+/**
+ * Comments and tips are deliberately unweighted: both are trivially launderable
+ * (a tip can be sent back out of band).
+ */
+export const CONTEST_SIGNAL_SOURCES: Record<Signal, string> = {
+  imageAuthors: 'Distinct authors of on-site images made with the model',
+  reactors: 'Distinct users reacting to those images',
+  downloaders: 'Distinct users downloading the model',
+  generators: 'Distinct users generating with the model',
+  collectors: 'Distinct users adding the model to another collection',
+};
+
+// A ClickHouse `IN` list is materialized in the query string; chunk to keep it sane.
+const CH_IN_CHUNK = 25000;
+const MAX_ENTRIES = 1000;
+const SCORE_CACHE_TTL = 60 * 15;
+const DEFAULT_STATUSES: CollectionItemStatus[] = [CollectionItemStatus.ACCEPTED];
+
+const weightsSchema = z.object(
+  Object.fromEntries(contestScoreSignals.map((s) => [s, z.number().min(0)])) as Record<
+    Signal,
+    z.ZodNumber
+  >
+);
+const settingsSchema = z.object({
+  weights: weightsSchema,
+  ageGateDays: z.number().min(0),
+  farmIp: z.object({ minPeers: z.number().int().min(1), minEntries: z.number().int().min(1) }),
+});
+const settingsOverrideSchema = z.object({
+  weights: weightsSchema.partial().optional(),
+  ageGateDays: z.number().min(0).optional(),
+  farmIp: z
+    .object({ minPeers: z.number().int().min(1), minEntries: z.number().int().min(1) })
+    .partial()
+    .optional(),
+});
+const storedConfigSchema = z.object({
+  version: z.number().int().min(1),
+  default: settingsSchema,
+  collections: z.record(z.string(), settingsOverrideSchema).optional(),
+});
+
+type ContestScoringSettings = z.infer<typeof settingsSchema>;
+type ContestScoringConfig = ContestScoringSettings & { version: number };
+
+export async function getContestScoringConfig(collectionId: number): Promise<ContestScoringConfig> {
+  const stored = await dbKV.get<unknown>(KEY_VALUE_KEYS.CONTEST_SCORING);
+  if (!stored)
+    throw new Error(
+      `Contest scoring is not configured: the "${KEY_VALUE_KEYS.CONTEST_SCORING}" KeyValue row is missing. Weights and thresholds live only in the database — there is no code fallback.`
+    );
+
+  const parsed = storedConfigSchema.safeParse(stored);
+  if (!parsed.success)
+    throw new Error(
+      `The "${KEY_VALUE_KEYS.CONTEST_SCORING}" KeyValue row is malformed: ${parsed.error.message}`
+    );
+
+  const { version, default: base, collections } = parsed.data;
+  const override = collections?.[String(collectionId)];
+
+  return {
+    version,
+    weights: { ...base.weights, ...override?.weights },
+    ageGateDays: override?.ageGateDays ?? base.ageGateDays,
+    farmIp: { ...base.farmIp, ...override?.farmIp },
+  };
+}
+
+export async function assertCanScoreContest({
+  collectionId,
+  userId,
+  isModerator,
+}: {
+  collectionId: number;
+  userId: number;
+  isModerator?: boolean;
+}) {
+  const permissions = await getUserCollectionPermissionsById({
+    id: collectionId,
+    userId,
+    isModerator,
+  });
+  if (!permissions.manage)
+    throw throwAuthorizationError('You do not have permission to score this collection');
+  return permissions;
+}
+
+type Entry = {
+  collectionItemId: number;
+  modelId: number;
+  modelName: string;
+  creatorId: number;
+  creatorUsername: string | null;
+  addedById: number | null;
+  tagId: number | null;
+  tagName: string | null;
+  status: string;
+  versionIds: number[];
+  signals: Record<Signal, Set<number>>;
+};
+
+type EntryImage = {
+  id: number;
+  url: string;
+  nsfwLevel: number;
+  type: string;
+  width: number | null;
+  height: number | null;
+};
+
+const chDateTime = (d: Date) => `toDateTime('${d.toISOString().slice(0, 19).replace('T', ' ')}')`;
+
+function chunk<T>(items: T[], size: number) {
+  const out: T[][] = [];
+  for (let i = 0; i < items.length; i += size) out.push(items.slice(i, i + size));
+  return out;
+}
+
+/** Runs `build` once per chunk of ids and concatenates the rows. */
+async function chQueryChunked<T extends object>(
+  name: string,
+  ids: number[],
+  build: (idList: string) => string
+) {
+  if (!ids.length) return [] as T[];
+  return withSpan(`contest-score.${name}`, { ids: ids.length }, async () => {
+    const results: T[] = [];
+    for (const part of chunk(ids, CH_IN_CHUNK)) {
+      const rows = await clickhouse!.$query<T>(build(part.join(',')));
+      results.push(...rows);
+    }
+    return results;
+  });
+}
+
+type WindowInput = {
+  collectionId: number;
+  start?: Date;
+  end?: Date;
+  tagIds?: number[];
+  statuses?: CollectionItemStatus[];
+};
+
+async function loadEntries(input: WindowInput) {
+  const { collectionId, tagIds } = input;
+  const statuses = input.statuses ?? DEFAULT_STATUSES;
+
+  const items = await withSpan(
+    'contest-score.entries',
+    () =>
+      dbRead.$queryRaw<Omit<Entry, 'versionIds' | 'signals'>[]>`
+      SELECT
+        ci.id           AS "collectionItemId",
+        ci."modelId"    AS "modelId",
+        m.name          AS "modelName",
+        m."userId"      AS "creatorId",
+        u.username      AS "creatorUsername",
+        ci."addedById"  AS "addedById",
+        ci."tagId"      AS "tagId",
+        t.name          AS "tagName",
+        ci.status::text AS "status"
+      FROM "CollectionItem" ci
+      JOIN "Model" m ON m.id = ci."modelId"
+      LEFT JOIN "User" u ON u.id = m."userId"
+      LEFT JOIN "Tag" t ON t.id = ci."tagId"
+      WHERE ci."collectionId" = ${collectionId}
+        AND ci."modelId" IS NOT NULL
+        AND ci.status = ANY(ARRAY[${Prisma.join(statuses)}]::"CollectionItemStatus"[])
+        ${tagIds?.length ? Prisma.sql`AND ci."tagId" IN (${Prisma.join(tagIds)})` : Prisma.empty}
+      ORDER BY ci.id
+      LIMIT ${MAX_ENTRIES + 1}
+    `
+  );
+
+  const truncated = items.length > MAX_ENTRIES;
+  const entries: Entry[] = items.slice(0, MAX_ENTRIES).map((item) => ({
+    ...item,
+    versionIds: [],
+    signals: Object.fromEntries(contestScoreSignals.map((s) => [s, new Set<number>()])) as Record<
+      Signal,
+      Set<number>
+    >,
+  }));
+
+  if (entries.length) {
+    const modelIds = entries.map((e) => e.modelId);
+    const versions = await dbRead.$queryRaw<{ id: number; modelId: number }[]>`
+      SELECT id, "modelId" FROM "ModelVersion"
+      WHERE "modelId" IN (${Prisma.join(modelIds)})
+    `;
+    const byModel = new Map(entries.map((e) => [e.modelId, e]));
+    for (const v of versions) byModel.get(v.modelId)?.versionIds.push(v.id);
+  }
+
+  return { entries, truncated };
+}
+
+/** One representative image per model — the creator's own showcase post, in their order. */
+async function loadEntryImages(modelIds: number[]) {
+  const images = new Map<number, EntryImage>();
+  if (!modelIds.length) return images;
+
+  const rows = await dbRead.$queryRaw<({ modelId: number } & EntryImage)[]>`
+    SELECT DISTINCT ON (mv."modelId")
+      mv."modelId"  AS "modelId",
+      i.id          AS "id",
+      i.url         AS "url",
+      i."nsfwLevel" AS "nsfwLevel",
+      i.type::text  AS "type",
+      i.width       AS "width",
+      i.height      AS "height"
+    FROM "ModelVersion" mv
+    JOIN "Model" m ON m.id = mv."modelId"
+    JOIN "Post" p ON p."modelVersionId" = mv.id AND p."userId" = m."userId"
+    JOIN "Image" i ON i."postId" = p.id
+    WHERE mv."modelId" IN (${Prisma.join(modelIds)})
+      AND p."publishedAt" IS NOT NULL
+      AND i.ingestion <> 'Blocked'::"ImageIngestionStatus"
+    ORDER BY mv."modelId", mv."index", p.id, i."index"
+  `;
+  for (const { modelId, ...image } of rows) images.set(modelId, image);
+
+  return images;
+}
+
+/**
+ * Fills each entry's per-signal distinct-user sets and returns the imageId ->
+ * modelId map (the reactor signal is keyed off the entry's on-site images).
+ */
+async function collectSignals(entries: Entry[], start: Date, end: Date) {
+  const byModel = new Map(entries.map((e) => [e.modelId, e]));
+  const byVersion = new Map<number, Entry>();
+  for (const entry of entries) for (const id of entry.versionIds) byVersion.set(id, entry);
+
+  const modelIds = [...byModel.keys()];
+  const versionIds = [...byVersion.keys()];
+  const imageToModel = new Map<number, number>();
+
+  // Reactors are keyed off the entries' on-site images, so that pair runs as one
+  // chain; the other three are independent.
+  const imagesThenReactors = async () => {
+    const images = await withSpan(
+      'contest-score.images',
+      () =>
+        dbRead.$queryRaw<{ modelId: number; imageId: number; userId: number }[]>`
+        SELECT DISTINCT mv."modelId" AS "modelId", i.id AS "imageId", i."userId" AS "userId"
+        FROM "ImageResourceNew" ir
+        JOIN "ModelVersion" mv ON mv.id = ir."modelVersionId"
+        JOIN "Image" i ON i.id = ir."imageId"
+        JOIN "Post" p ON p.id = i."postId"
+        WHERE mv."modelId" IN (${Prisma.join(modelIds)})
+          AND i."createdAt" >= ${start}
+          AND i."createdAt" < ${end}
+          AND p."publishedAt" IS NOT NULL
+          AND i.ingestion <> 'Blocked'::"ImageIngestionStatus"
+      `
+    );
+    for (const row of images) {
+      imageToModel.set(row.imageId, row.modelId);
+      byModel.get(row.modelId)?.signals.imageAuthors.add(row.userId);
+    }
+
+    const reactions = await chQueryChunked<{ entityId: number; userId: number }>(
+      'reactors',
+      [...imageToModel.keys()],
+      (ids) => `
+        SELECT entityId, userId
+        FROM reactions
+        WHERE type = 'Image_Create'
+          AND entityId IN (${ids})
+          AND time >= ${chDateTime(start)} AND time < ${chDateTime(end)}
+          AND userId != 0
+        GROUP BY entityId, userId
+      `
+    );
+    for (const row of reactions) {
+      const modelId = imageToModel.get(row.entityId);
+      if (modelId) byModel.get(modelId)?.signals.reactors.add(row.userId);
+    }
+  };
+
+  const loadCollectors = async () => {
+    const collectors = await withSpan(
+      'contest-score.collectors',
+      () =>
+        dbRead.$queryRaw<{ modelId: number; userId: number }[]>`
+        SELECT DISTINCT ci."modelId" AS "modelId", ci."addedById" AS "userId"
+        FROM "CollectionItem" ci
+        WHERE ci."modelId" IN (${Prisma.join(modelIds)})
+          AND ci."addedById" IS NOT NULL
+          AND ci."createdAt" >= ${start}
+          AND ci."createdAt" < ${end}
+      `
+    );
+    for (const row of collectors) byModel.get(row.modelId)?.signals.collectors.add(row.userId);
+  };
+
+  const loadDownloaders = async () => {
+    const downloads = await chQueryChunked<{ modelId: number; userId: number }>(
+      'downloaders',
+      modelIds,
+      (ids) => `
+        SELECT modelId, userId
+        FROM modelVersionEvents
+        WHERE type = 'Download'
+          AND modelId IN (${ids})
+          AND time >= ${chDateTime(start)} AND time < ${chDateTime(end)}
+          AND userId != 0
+        GROUP BY modelId, userId
+      `
+    );
+    for (const row of downloads) byModel.get(row.modelId)?.signals.downloaders.add(row.userId);
+  };
+
+  // Straight off orchestration.jobs, NOT default.daily_user_resource: that view
+  // only ingests jobType IN ('TextToImage','TextToImageV2','Comfy'), so every
+  // newer engine (ComfyImageGen, AnimaComfy, StableDiffusionCpp, …) is missing
+  // from it and whole ecosystems read as zero generations.
+  const loadGenerators = async () => {
+    const generations = await chQueryChunked<{ modelVersionId: number; userId: number }>(
+      'generators',
+      versionIds,
+      (ids) => `
+        SELECT resource AS modelVersionId, userId
+        FROM orchestration.jobs
+        ARRAY JOIN resourcesUsed AS resource
+        WHERE resource IN (${ids})
+          AND createdAt >= ${chDateTime(start)} AND createdAt < ${chDateTime(end)}
+          AND userId != 0
+        GROUP BY resource, userId
+      `
+    );
+    for (const row of generations)
+      byVersion.get(row.modelVersionId)?.signals.generators.add(row.userId);
+  };
+
+  await Promise.all([imagesThenReactors(), loadCollectors(), loadDownloaders(), loadGenerators()]);
+
+  return { imageToModel };
+}
+
+type Disqualification = {
+  excluded: boolean;
+  contestBanned: boolean;
+  banned: boolean;
+  tooNew: boolean;
+};
+
+async function loadDisqualifications(userIds: number[], ageCutoff: Date) {
+  const disqualified = new Map<number, Disqualification>();
+  if (!userIds.length) return disqualified;
+
+  const users = await withSpan(
+    'contest-score.disqualifications',
+    () =>
+      dbRead.$queryRaw<{ id: number; contestBanned: boolean; banned: boolean; tooNew: boolean }[]>`
+      SELECT
+        u.id,
+        (u.meta -> 'contestBanDetails') IS NOT NULL             AS "contestBanned",
+        (u."bannedAt" IS NOT NULL OR u."deletedAt" IS NOT NULL) AS "banned",
+        u."createdAt" > ${ageCutoff}                            AS "tooNew"
+      FROM "User" u
+      WHERE u.id IN (${Prisma.join(userIds)})
+    `
+  );
+  const known = new Set(users.map((u) => u.id));
+  for (const user of users) {
+    if (!user.contestBanned && !user.banned && !user.tooNew) continue;
+    disqualified.set(user.id, { excluded: false, ...user });
+  }
+
+  const excludedRows = await chQueryChunked<{ userId: number }>(
+    'excluded-users',
+    userIds,
+    (ids) => `
+      SELECT userId FROM metricExcludedUsers FINAL
+      WHERE active = 1 AND userId IN (${ids})
+    `
+  );
+  for (const row of excludedRows) {
+    const existing = disqualified.get(row.userId);
+    if (existing) existing.excluded = true;
+    else
+      disqualified.set(row.userId, {
+        excluded: true,
+        contestBanned: false,
+        banned: false,
+        tooNew: false,
+      });
+  }
+
+  // A userId with no User row is a deleted account: never counts.
+  for (const id of userIds) {
+    if (known.has(id) || disqualified.has(id)) continue;
+    disqualified.set(id, { excluded: false, contestBanned: false, banned: true, tooNew: false });
+  }
+
+  return disqualified;
+}
+
+export type ContestScoreEntry = {
+  rank: number;
+  collectionItemId: number;
+  modelId: number;
+  modelName: string;
+  creatorId: number;
+  creatorUsername: string | null;
+  status: string;
+  image: EntryImage | null;
+  signals: Record<Signal, { raw: number; qualified: number; normalized: number }>;
+  rawTotal: number;
+  qualifiedTotal: number;
+  disqualifiedShare: number;
+  score: number;
+};
+
+export type ContestScoreCategory = {
+  tagId: number | null;
+  tagName: string | null;
+  entryCount: number;
+  entries: ContestScoreEntry[];
+};
+
+export type ContestCommunityScore = {
+  collectionId: number;
+  generatedAt: string;
+  window: { start: string; end: string };
+  statuses: CollectionItemStatus[];
+  entryCount: number;
+  truncated: boolean;
+  signalSources: Record<Signal, string>;
+  engagers: { total: number; disqualified: number };
+  categories: ContestScoreCategory[];
+};
+
+function resolveWindow(input: WindowInput) {
+  return { start: input.start ?? new Date(0), end: input.end ?? new Date() };
+}
+
+function requireClickhouse() {
+  if (!clickhouse) throw throwBadRequestError('ClickHouse is not configured in this environment');
+  return clickhouse;
+}
+
+async function computeCommunityScore(input: WindowInput): Promise<ContestCommunityScore> {
+  requireClickhouse();
+  const config = await getContestScoringConfig(input.collectionId);
+  const { start, end } = resolveWindow(input);
+  const statuses = input.statuses ?? DEFAULT_STATUSES;
+
+  const { entries, truncated } = await loadEntries(input);
+  if (!entries.length)
+    return {
+      collectionId: input.collectionId,
+      generatedAt: new Date().toISOString(),
+      window: { start: start.toISOString(), end: end.toISOString() },
+      statuses,
+      entryCount: 0,
+      truncated,
+      signalSources: CONTEST_SIGNAL_SOURCES,
+      engagers: { total: 0, disqualified: 0 },
+      categories: [],
+    };
+
+  const ageCutoff = new Date(start.getTime() - config.ageGateDays * 24 * 60 * 60 * 1000);
+
+  const [, images] = await Promise.all([
+    collectSignals(entries, start, end),
+    loadEntryImages(entries.map((e) => e.modelId)),
+  ]);
+
+  const engagers = new Set<number>();
+  for (const entry of entries)
+    for (const signal of contestScoreSignals)
+      for (const id of entry.signals[signal]) engagers.add(id);
+  const disqualified = await loadDisqualifications([...engagers], ageCutoff);
+
+  const scored = entries.map((entry) => {
+    const isQualified = (userId: number) =>
+      userId !== entry.creatorId && userId !== entry.addedById && !disqualified.has(userId);
+
+    const signals = {} as Record<Signal, { raw: number; qualified: number }>;
+    for (const signal of contestScoreSignals) {
+      const users = [...entry.signals[signal]];
+      signals[signal] = { raw: users.length, qualified: users.filter(isQualified).length };
+    }
+
+    const rawTotal = contestScoreSignals.reduce((sum, s) => sum + signals[s].raw, 0);
+    const qualifiedTotal = contestScoreSignals.reduce((sum, s) => sum + signals[s].qualified, 0);
+
+    return {
+      collectionItemId: entry.collectionItemId,
+      modelId: entry.modelId,
+      modelName: entry.modelName,
+      creatorId: entry.creatorId,
+      creatorUsername: entry.creatorUsername,
+      status: entry.status,
+      tagId: entry.tagId,
+      image: images.get(entry.modelId) ?? null,
+      signals,
+      rawTotal,
+      qualifiedTotal,
+      // Share of engagement that failed qualification. High = worth staff eyes.
+      disqualifiedShare: rawTotal ? +((rawTotal - qualifiedTotal) / rawTotal).toFixed(3) : 0,
+    };
+  });
+
+  const categories = [...new Set(entries.map((e) => e.tagId))].map((tagId) => {
+    const tagName = entries.find((e) => e.tagId === tagId)?.tagName ?? null;
+    const items = scored.filter((e) => e.tagId === tagId);
+
+    // Normalize within category against that category's leader per signal, so a
+    // category with fewer entrants can't be compared against a busier one.
+    const maxima = Object.fromEntries(
+      contestScoreSignals.map((s) => [s, Math.max(...items.map((i) => i.signals[s].qualified), 0)])
+    ) as Record<Signal, number>;
+
+    const ranked = items
+      .map(({ tagId: _tagId, signals, ...item }) => {
+        const withNormalized = {} as ContestScoreEntry['signals'];
+        let total = 0;
+        for (const s of contestScoreSignals) {
+          const normalized = maxima[s] > 0 ? +(signals[s].qualified / maxima[s]).toFixed(4) : 0;
+          withNormalized[s] = { ...signals[s], normalized };
+          total += normalized * config.weights[s];
+        }
+        return { ...item, signals: withNormalized, score: +total.toFixed(4) };
+      })
+      .sort(
+        (a, b) => b.score - a.score || b.qualifiedTotal - a.qualifiedTotal || a.modelId - b.modelId
+      )
+      .map((item, index): ContestScoreEntry => ({ rank: index + 1, ...item }));
+
+    return { tagId, tagName, entryCount: ranked.length, entries: ranked };
+  });
+
+  return {
+    collectionId: input.collectionId,
+    generatedAt: new Date().toISOString(),
+    window: { start: start.toISOString(), end: end.toISOString() },
+    statuses,
+    entryCount: entries.length,
+    truncated,
+    signalSources: CONTEST_SIGNAL_SOURCES,
+    engagers: { total: engagers.size, disqualified: disqualified.size },
+    categories,
+  };
+}
+
+export async function getCommunityScore(input: GetCommunityScoreInput) {
+  const { refresh, ...window } = input;
+  const config = await getContestScoringConfig(window.collectionId);
+  const cacheKey = `${REDIS_KEYS.CACHES.CONTEST_COMMUNITY_SCORE}:${
+    window.collectionId
+  }:${hashifyObject({
+    start: window.start?.toISOString(),
+    end: window.end?.toISOString(),
+    tagIds: window.tagIds,
+    statuses: window.statuses,
+    configVersion: config.version,
+  })}` as RedisKeyTemplateCache;
+
+  if (refresh) await bustFetchThroughCache(cacheKey);
+
+  return fetchThroughCache(cacheKey, () => computeCommunityScore(window), {
+    ttl: SCORE_CACHE_TTL,
+  });
+}
+
+/**
+ * Engagers on this contest worth a look: accounts acting from IPs shared by many
+ * contest engagers, or whose contest engagement concentrates on a single creator.
+ * Evidence only — never an automatic disqualification.
+ */
+export async function getContestCandidates(input: GetContestCandidatesInput) {
+  requireClickhouse();
+  const config = await getContestScoringConfig(input.collectionId);
+  const { start, end } = resolveWindow(input);
+  const limit = input.limit ?? 200;
+
+  const { entries } = await loadEntries(input);
+  if (!entries.length) return { collectionId: input.collectionId, count: 0, candidates: [] };
+
+  const { imageToModel } = await collectSignals(entries, start, end);
+  const creatorByModel = new Map(entries.map((e) => [e.modelId, e.creatorId]));
+
+  // Engagement events carrying an IP: reactions on the entries' images and
+  // downloads of the entries' models — the same farm-IP signal `reaction-abuse`
+  // uses, scoped to this contest.
+  const [reactionRows, downloadRows] = await Promise.all([
+    chQueryChunked<{ userId: number; entityId: number; ip: string }>(
+      'candidates.reactions',
+      [...imageToModel.keys()],
+      (ids) => `
+        SELECT userId, entityId, ip
+        FROM reactions
+        WHERE type = 'Image_Create'
+          AND entityId IN (${ids})
+          AND time >= ${chDateTime(start)} AND time < ${chDateTime(end)}
+          AND userId != 0
+        GROUP BY userId, entityId, ip
+      `
+    ),
+    chQueryChunked<{ userId: number; modelId: number; ip: string }>(
+      'candidates.downloads',
+      entries.map((e) => e.modelId),
+      (ids) => `
+        SELECT userId, modelId, ip
+        FROM modelVersionEvents
+        WHERE type = 'Download'
+          AND modelId IN (${ids})
+          AND time >= ${chDateTime(start)} AND time < ${chDateTime(end)}
+          AND userId != 0
+        GROUP BY userId, modelId, ip
+      `
+    ),
+  ]);
+
+  const events = [
+    ...reactionRows.map((r) => ({
+      userId: r.userId,
+      modelId: imageToModel.get(r.entityId),
+      ip: r.ip,
+    })),
+    ...downloadRows.map((r) => ({ userId: r.userId, modelId: r.modelId, ip: r.ip })),
+  ].filter((e): e is { userId: number; modelId: number; ip: string } => !!e.modelId);
+
+  const usersPerIp = new Map<string, Set<number>>();
+  for (const event of events) {
+    if (!event.ip) continue;
+    if (!usersPerIp.has(event.ip)) usersPerIp.set(event.ip, new Set());
+    usersPerIp.get(event.ip)!.add(event.userId);
+  }
+  const farmIps = new Set(
+    [...usersPerIp.entries()]
+      .filter(([, users]) => users.size >= config.farmIp.minPeers)
+      .map(([ip]) => ip)
+  );
+
+  type Candidate = {
+    userId: number;
+    entriesTouched: Set<number>;
+    creators: Map<number, number>;
+    farmIps: Set<string>;
+    maxIpPeers: number;
+    events: number;
+  };
+  const byUser = new Map<number, Candidate>();
+  for (const event of events) {
+    let candidate = byUser.get(event.userId);
+    if (!candidate) {
+      candidate = {
+        userId: event.userId,
+        entriesTouched: new Set(),
+        creators: new Map(),
+        farmIps: new Set(),
+        maxIpPeers: 0,
+        events: 0,
+      };
+      byUser.set(event.userId, candidate);
+    }
+    candidate.events++;
+    candidate.entriesTouched.add(event.modelId);
+    const creatorId = creatorByModel.get(event.modelId);
+    if (creatorId) candidate.creators.set(creatorId, (candidate.creators.get(creatorId) ?? 0) + 1);
+    if (farmIps.has(event.ip)) candidate.farmIps.add(event.ip);
+    candidate.maxIpPeers = Math.max(candidate.maxIpPeers, usersPerIp.get(event.ip)?.size ?? 0);
+  }
+
+  const rows = [...byUser.values()]
+    .map((candidate) => {
+      const [topCreator, toTopCreator] = [...candidate.creators.entries()].sort(
+        (a, b) => b[1] - a[1]
+      )[0] ?? [0, 0];
+      return {
+        userId: candidate.userId,
+        events: candidate.events,
+        entriesTouched: candidate.entriesTouched.size,
+        distinctCreators: candidate.creators.size,
+        topCreator,
+        toTopCreator,
+        topCreatorConcentration: +(toTopCreator / candidate.events).toFixed(2),
+        farmIpsUsed: candidate.farmIps.size,
+        maxIpPeers: candidate.maxIpPeers,
+      };
+    })
+    .filter(
+      (row) =>
+        row.farmIpsUsed > 0 ||
+        (row.entriesTouched >= config.farmIp.minEntries && row.distinctCreators === 1)
+    )
+    // Concentration on one creator is the discriminating signal; farm IPs alone
+    // catch shared/CGNAT addresses too, so they only break ties.
+    .sort(
+      (a, b) =>
+        b.topCreatorConcentration - a.topCreatorConcentration ||
+        b.farmIpsUsed - a.farmIpsUsed ||
+        b.events - a.events
+    )
+    .slice(0, limit);
+
+  return { collectionId: input.collectionId, count: rows.length, candidates: rows };
+}
+
+export type ContestSnapshot = {
+  collectionId: number;
+  takenAt: string;
+  takenById: number;
+  takenByUsername: string | null;
+  note?: string;
+  score: ContestCommunityScore;
+};
+
+const snapshotKey = (collectionId: number, takenAt: string) =>
+  `${CONTEST_SNAPSHOT_KEY_PREFIX}:${collectionId}:${takenAt}`;
+
+export async function createContestSnapshot({
+  input,
+  userId,
+  username,
+}: {
+  input: CreateContestSnapshotInput;
+  userId: number;
+  username?: string | null;
+}) {
+  const { note, ...window } = input;
+  const score = await computeCommunityScore(window);
+  const takenAt = new Date().toISOString();
+  const snapshot: ContestSnapshot = {
+    collectionId: window.collectionId,
+    takenAt,
+    takenById: userId,
+    takenByUsername: username ?? null,
+    ...(note ? { note } : {}),
+    score,
+  };
+
+  await dbWrite.keyValue.create({
+    data: {
+      key: snapshotKey(window.collectionId, takenAt),
+      value: snapshot as unknown as Prisma.InputJsonValue,
+    },
+  });
+
+  return snapshot;
+}
+
+export async function listContestSnapshots({ collectionId }: { collectionId: number }) {
+  const rows = await dbRead.keyValue.findMany({
+    where: { key: { startsWith: `${CONTEST_SNAPSHOT_KEY_PREFIX}:${collectionId}:` } },
+    select: { key: true, value: true },
+  });
+
+  return rows
+    .map(({ key, value }) => {
+      const snapshot = value as unknown as ContestSnapshot;
+      return {
+        key,
+        takenAt: snapshot.takenAt,
+        takenById: snapshot.takenById,
+        takenByUsername: snapshot.takenByUsername,
+        note: snapshot.note,
+        window: snapshot.score.window,
+        entryCount: snapshot.score.entryCount,
+      };
+    })
+    .sort((a, b) => b.takenAt.localeCompare(a.takenAt));
+}
+
+export async function getContestSnapshot({ key }: { key: string }) {
+  const row = await dbRead.keyValue.findUnique({ where: { key } });
+  if (!row) throw throwBadRequestError('Snapshot not found');
+  return row.value as unknown as ContestSnapshot;
+}

--- a/src/server/services/contest-score.service.ts
+++ b/src/server/services/contest-score.service.ts
@@ -379,6 +379,55 @@ type Gates = BaseGates & {
   engagerCount: number;
 };
 
+const DAY_MS = 24 * 60 * 60 * 1000;
+// Progressively widened until a registration is found. Civitai takes thousands of
+// signups a day, so the first bound effectively always hits; the rest exist so the
+// answer is correct rather than convenient.
+const AGE_THRESHOLD_WINDOW_DAYS = [1, 7, 30];
+
+/**
+ * The lowest `User.id` registered after `cutoff`, optionally within a bounded window.
+ *
+ * `MATERIALIZED` is doing the work. `User` carries a PARTIAL index —
+ * `User_createdAt_idx ON "User"("createdAt") WHERE "deletedAt" IS NULL` — which a
+ * query omitting the `deletedAt` predicate cannot use at all; and even with the
+ * predicate, `min(id)` tempts the planner into an ascending primary-key walk that
+ * discards ~12.7M rows before its first match. Forcing the candidate set to
+ * materialize off the index first turns that walk into a range scan.
+ *
+ * `deletedAt IS NULL` is safe here and the reasoning is not obvious. Skipping
+ * soft-deleted rows can only RAISE `min(id)`, so the threshold can only get more
+ * permissive — but every id in the resulting gap belongs, by definition, to a deleted
+ * account, and deleted accounts are already disqualified by the ban/delete rule. The
+ * gate is unchanged in effect.
+ *
+ * The one exception worth knowing: when the engager set blows `maxEngagers` that
+ * ban/delete refinement is SKIPPED, and in that degraded path a soft-deleted account
+ * in the gap would be admitted where the unfiltered query would have caught it via
+ * the age gate. Such a run is already flagged `bannedRefinementSkipped` and told not
+ * to decide a prize. The Postgres-side signals join `User` and check the ban columns
+ * inline, so they are unaffected either way.
+ */
+async function lowestUserIdAfter(cutoff: Date, windowDays: number | null) {
+  const upperBound =
+    windowDays === null
+      ? Prisma.empty
+      : Prisma.sql`AND u."createdAt" < ${utc(new Date(cutoff.getTime() + windowDays * DAY_MS))}`;
+
+  const [row] = await dbRead.$queryRaw<{ minId: number | null }[]>`
+    WITH candidates AS MATERIALIZED (
+      SELECT u.id
+      FROM "User" u
+      WHERE u."createdAt" > ${utc(cutoff)}
+        ${upperBound}
+        AND u."deletedAt" IS NULL
+    )
+    SELECT min(id)::int AS "minId" FROM candidates
+  `;
+
+  return row?.minId ?? null;
+}
+
 /**
  * `User.id` is autoincrement but NOT strictly monotonic with `createdAt` — at least
  * one backdated system account exists. `max(id) WHERE createdAt <= cutoff` would let
@@ -386,11 +435,9 @@ type Gates = BaseGates & {
  * since. `min(id) WHERE createdAt > cutoff` minus one can only ever be too strict,
  * which is the safe direction for an anti-cheat gate.
  *
- * `User` has no index on `createdAt`, so the planner walks the primary key from id 1
- * discarding ~12.7M rows: ~12s, and the single largest cost in a run. The answer is
- * a pure function of the cutoff and effectively immutable (a later registration
- * always has both a higher id and a later `createdAt`), so it is cached hard. An
- * index on `User."createdAt"` would make this instant and let the cache go.
+ * The answer is a pure function of the cutoff and effectively immutable (a later
+ * registration always has both a higher id and a later `createdAt`), so it stays
+ * cached for a week — that is now a cheap miss rather than a painful one.
  */
 async function loadAgeThreshold(ageCutoff: Date) {
   const key = `${
@@ -401,14 +448,30 @@ async function loadAgeThreshold(ageCutoff: Date) {
     key,
     () =>
       withSpan('contest-score.age-threshold', async () => {
-        // Two statements, not one: as a single CTE the planner materializes the band
-        // count against an unknown threshold and the query takes ~50s instead of ~12s.
-        const [{ threshold }] = await dbRead.$queryRaw<{ threshold: number }[]>`
-          SELECT COALESCE(
-            (SELECT min(id) FROM "User" WHERE "createdAt" > ${utc(ageCutoff)}) - 1,
-            (SELECT max(id) FROM "User")
-          )::int AS "threshold"
-        `;
+        let threshold: number | null = null;
+        for (const windowDays of AGE_THRESHOLD_WINDOW_DAYS) {
+          const minId = await lowestUserIdAfter(ageCutoff, windowDays);
+          if (minId !== null) {
+            threshold = minId - 1;
+            break;
+          }
+        }
+
+        if (threshold === null) {
+          // Only an UNBOUNDED miss means nobody registered after the cutoff. Treating
+          // an empty bounded window as "nobody" would COALESCE to max(id) and admit
+          // every account on the site — the same silent fail-open the age-gate bound
+          // exists to prevent.
+          const unbounded = await lowestUserIdAfter(ageCutoff, null);
+          if (unbounded !== null) threshold = unbounded - 1;
+          else {
+            const [{ maxId }] = await dbRead.$queryRaw<{ maxId: number }[]>`
+              SELECT max(id)::int AS "maxId" FROM "User"
+            `;
+            threshold = maxId;
+          }
+        }
+
         const [{ bandUsers }] = await dbRead.$queryRaw<{ bandUsers: number }[]>`
           SELECT count(*)::int AS "bandUsers"
           FROM "User" u

--- a/src/server/utils/distributed-lock.ts
+++ b/src/server/utils/distributed-lock.ts
@@ -8,6 +8,13 @@ export interface DistributedLockOptions {
   ttl?: number; // TTL in seconds, default 5 on DP / 30 on DOKS
   retryDelay?: number; // Retry delay in ms, default 100
   maxRetries?: number; // Max retries, default 10
+  /**
+   * Extend the lock on a timer for as long as the holder is alive. Opt-in: without
+   * it the TTL is a hard deadline, so an operation that outruns its TTL keeps
+   * running while a second holder acquires the same lock and does the work twice.
+   * A dead holder stops renewing and the TTL still reclaims the lock.
+   */
+  autoRenew?: boolean;
 }
 
 export class DistributedLock {
@@ -15,6 +22,8 @@ export class DistributedLock {
   private readonly ttl: number;
   private readonly retryDelay: number;
   private readonly maxRetries: number;
+  private readonly autoRenew: boolean;
+  private renewTimer: NodeJS.Timeout | null = null;
   private lockValue: string | null = null;
 
   constructor(options: DistributedLockOptions) {
@@ -22,6 +31,43 @@ export class DistributedLock {
     this.ttl = options.ttl ?? (env.IS_DATAPACKET ? 5 : 30);
     this.retryDelay = options.retryDelay ?? 100;
     this.maxRetries = options.maxRetries ?? 10;
+    this.autoRenew = options.autoRenew ?? false;
+  }
+
+  /**
+   * Compare-and-extend: only the holder whose value still matches may push the
+   * expiry out, so a lock already reclaimed and retaken is never extended by its
+   * previous owner.
+   */
+  private startRenewal(): void {
+    if (!this.autoRenew || !redis) return;
+
+    const script = `
+      if redis.call("get", KEYS[1]) == ARGV[1] then
+        return redis.call("pexpire", KEYS[1], ARGV[2])
+      else
+        return 0
+      end
+    `;
+
+    this.renewTimer = setInterval(() => {
+      if (!this.lockValue) return;
+      redis
+        .eval(script, {
+          keys: [this.lockKey],
+          arguments: [this.lockValue, String(this.ttl * 1000)],
+        })
+        .catch((error) => handleLogError(error as Error, `Failed to renew lock: ${this.lockKey}`));
+    }, Math.max((this.ttl * 1000) / 3, 1000));
+
+    // Renewal must never be the reason a process stays alive.
+    this.renewTimer.unref?.();
+  }
+
+  private stopRenewal(): void {
+    if (!this.renewTimer) return;
+    clearInterval(this.renewTimer);
+    this.renewTimer = null;
   }
 
   async acquire(): Promise<boolean> {
@@ -37,6 +83,7 @@ export class DistributedLock {
         });
 
         if (result === 'OK') {
+          this.startRenewal();
           return true;
         }
 
@@ -53,6 +100,7 @@ export class DistributedLock {
   }
 
   async release(): Promise<void> {
+    this.stopRenewal();
     if (!redis || !this.lockValue) return;
 
     try {


### PR DESCRIPTION
Adds a **Community** tab to the contest collection review page so moderators can rank entries by community engagement alongside the existing staff-pick scorer.

## How it scores

Each entry is scored by counting **distinct qualified users per signal** inside the contest window, normalized within its category tag, then weighted. Distinct-user counting is the structural anti-cheat: one account contributes at most 1 to any signal, so volume farming collapses to 1.

Signals: on-site image authors (`ImageResourceNew` ⋈ `Image`), reactors on those images (ClickHouse `reactions`), downloaders (`modelVersionEvents`), generating users (`orchestration.jobs`), and collectors (`CollectionItem`). Comments and tips are deliberately unweighted — both launder trivially.

A user is disqualified for an entry when they are the model's creator or the submitter, are in `metricExcludedUsers`, are contest-banned, are banned or deleted, or registered after the account-age cutoff. Every entry reports raw vs qualified per signal so a farmed entry surfaces for human review rather than being auto-disqualified.

Categories are separate contests — normalization and ranking never cross a category boundary.

## Notable details

- **All tuning values live in a `KeyValue` row**, not in source. Weights, thresholds and denominators are read at runtime, scoped per collection with a global fallback, and edited through a moderator-only procedure that is separate from the scoring payload.
- **Counting happens in the database.** No user-id arrays cross into Node; the age gate is pushed down as a monotonic id predicate rather than enumerating accounts.
- **Runs are async.** A run is enqueued, its state lives in Redis with a TTL, and a signal tells the UI to refetch. The signal payload carries run bookkeeping only.
- **Snapshots** freeze a ranking with its resolved config as the auditable artifact; re-running the same window reproduces the same result.
- Config edits are recorded append-only in the same transaction as the write.

## Testing

Validated against production data on a live contest (105 accepted entries, 4 categories, ~7.5k engagers): per-entry counts reconciled against an independently-built oracle, including a fan-out case where one image references two entered models. Typecheck, eslint and prettier clean.

No migration. No schema change.
