### PR TITLE
fix(virtualizer): stop useScrollMargin from chasing an element its own margin moves

### DIFF
--- a/src/hooks/useScrollMargin.browser.test.tsx
+++ b/src/hooks/useScrollMargin.browser.test.tsx
@@ -1,4 +1,5 @@
-import React, { useRef, useState } from 'react';
+import React, { Component, useRef, useState } from 'react';
+import type { ReactNode } from 'react';
 import { describe, expect, test, vi } from 'vitest';
 import { page, userEvent } from 'vitest/browser';
 import { ScrollAreaContext } from '~/components/ScrollArea/ScrollAreaContext';
@@ -171,5 +172,136 @@ describe('useScrollMargin', () => {
     await settle();
 
     expect(renders).toBeLessThan(6);
+  });
+
+  describe('when the layout reacts to the margin the hook publishes', () => {
+    // The margin is fed to `useVirtualizer`, which decides what renders inside the scroll
+    // container. If any of that lands above the measured element — directly, or through a
+    // container the virtualizer sizes — measuring on every commit re-measures a position
+    // that the last measurement moved, and there is no offset that holds still.
+    //
+    // Re-measuring per commit with no bound turns that into an unbroken chain of
+    // synchronous re-renders: React counts 50 nested updates and throws "Maximum update
+    // depth exceeded", which is not recoverable — the nearest error boundary replaces the
+    // page. So the hook has to give up on a moving target rather than chase it.
+
+    /** Offset flips between two values, so no published margin is ever the measured one. */
+    function TwoCycle({ onRender }: { onRender?: () => void }) {
+      const ref = useRef<HTMLDivElement>(null);
+      const scrollMargin = useScrollMargin(ref);
+      onRender?.();
+
+      return (
+        <>
+          <div data-testid="feedback-spacer" style={{ height: scrollMargin > 200 ? 100 : 400 }} />
+          <div ref={ref} data-testid={TARGET} data-margin={scrollMargin} style={{ height: 100 }} />
+        </>
+      );
+    }
+
+    function CoupledHarness({ children }: { children: ReactNode }) {
+      const scrollRef = useRef<HTMLDivElement>(null);
+
+      return (
+        <ScrollAreaContext.Provider value={{ ref: scrollRef as React.RefObject<HTMLDivElement> }}>
+          <div
+            ref={scrollRef}
+            data-testid="scroll-area"
+            style={{ height: 200, overflowY: 'auto', position: 'relative' }}
+          >
+            {children}
+          </div>
+        </ScrollAreaContext.Provider>
+      );
+    }
+
+    class Boundary extends Component<{ children: ReactNode }, { error: Error | null }> {
+      state = { error: null as Error | null };
+      static getDerivedStateFromError(error: Error) {
+        return { error };
+      }
+      render() {
+        return this.state.error ? (
+          <div data-testid="crashed">{this.state.error.message}</div>
+        ) : (
+          this.props.children
+        );
+      }
+    }
+
+    const crashed = () => document.querySelector('[data-testid="crashed"]')?.textContent ?? null;
+
+    test('gives up instead of exceeding the update depth', async () => {
+      renderWithProviders(
+        <Boundary>
+          <CoupledHarness>
+            <TwoCycle />
+          </CoupledHarness>
+        </Boundary>
+      );
+
+      await settle();
+
+      expect(crashed()).toBeNull();
+    });
+
+    test('stops re-rendering once it has given up', async () => {
+      let renderCount = 0;
+      renderWithProviders(
+        <Boundary>
+          <CoupledHarness>
+            <TwoCycle onRender={() => renderCount++} />
+          </CoupledHarness>
+        </Boundary>
+      );
+
+      await settle();
+      const afterSettle = renderCount;
+      await settle();
+
+      expect(crashed()).toBeNull();
+      expect(renderCount).toBe(afterSettle);
+    });
+
+    test('a real resize above it still re-measures after it has given up', async () => {
+      // Giving up must not deafen the hook to the case #3426 exists for: the budget is
+      // spent on chasing our own output, and a resize above the list is not that.
+      function Coupled() {
+        const ref = useRef<HTMLDivElement>(null);
+        const scrollMargin = useScrollMargin(ref);
+
+        return (
+          <>
+            <div data-testid={SPACER} style={{ height: 0 }} />
+            <div
+              data-testid="feedback-spacer"
+              style={{ height: scrollMargin % 2 === 0 ? 401 : 100 }}
+            />
+            <div
+              ref={ref}
+              data-testid={TARGET}
+              data-margin={scrollMargin}
+              style={{ height: 100 }}
+            />
+          </>
+        );
+      }
+
+      renderWithProviders(
+        <Boundary>
+          <CoupledHarness>
+            <Coupled />
+          </CoupledHarness>
+        </Boundary>
+      );
+      await settle();
+      expect(crashed()).toBeNull();
+      const givenUpAt = margin();
+
+      setSpacerHeight(1000);
+
+      await vi.waitFor(() => expect(margin()).not.toBe(givenUpAt));
+      expect(crashed()).toBeNull();
+    });
   });
 });

--- a/src/hooks/useScrollMargin.ts
+++ b/src/hooks/useScrollMargin.ts
@@ -10,6 +10,24 @@ type Observed = { element: HTMLElement; root: HTMLElement; observer: ResizeObser
 const ROOT_ATTACH_RETRIES = 3;
 
 /**
+ * How many margins we will publish before the element has to hold still at one of them.
+ *
+ * The margin is fed to `useVirtualizer`, which decides what renders inside the scroll
+ * container. Where any of that ends up above the measured element, publishing a margin
+ * moves the thing the next commit measures, and no offset is a fixed point. Measuring on
+ * every commit then feeds itself: each layout effect sets state, the state schedules a
+ * synchronous re-render, and the re-render runs the layout effect again. React counts 50
+ * of those and throws "Maximum update depth exceeded" — an error no boundary can recover
+ * from, so the page it happens on goes blank.
+ *
+ * A layout that settles spends one of these and gets it back (see `publishedRef`); only
+ * one that answers a new margin with a new offset burns through them. Giving up leaves a
+ * margin that is at most one layout stale, which costs a mispositioned row — and the
+ * ResizeObserver hands the budget back the moment anything above the list really resizes.
+ */
+const UNSETTLED_PUBLISHES = 3;
+
+/**
  * Distance between the top of the scroll container and the top of `ref`, kept in
  * sync while content above it grows or shrinks (expanding descriptions, ads that
  * load late). `useVirtualizer` turns `scrollTop - scrollMargin` into the window of
@@ -21,7 +39,14 @@ export function useScrollMargin(ref: RefObject<HTMLElement | null>) {
   const [, retry] = useState(0);
   const retriesRef = useRef(0);
   const warnedRef = useRef(false);
+  const warnedChaseRef = useRef(false);
   const observedRef = useRef<Observed | null>(null);
+  /** The margin the element is currently positioned against — a ref, not the state, because
+   * the observer below keeps the closure it was created with. Seeded to the initial state. */
+  const publishedRef = useRef(0);
+  /** Margins published since the element last measured at one of them: `count` is what the
+   * budget spends, `offsets` is how a resize we caused is told from one we didn't. */
+  const chaseRef = useRef({ count: 0, offsets: new Set<number>() });
 
   // No dependency array: the measured element commonly mounts later than the hook (lists
   // rendered behind a loading state), and a commit is the cheapest place to catch layout
@@ -42,7 +67,18 @@ export function useScrollMargin(ref: RefObject<HTMLElement | null>) {
     }
     retriesRef.current = 0;
 
-    const update = () => {
+    // A different element, or the same one under a different scroll container, is a
+    // different measurement — nothing about the last one's chase applies to it.
+    const observed = observedRef.current;
+    const reattached = observed?.element !== element || observed.root !== root;
+    if (reattached) {
+      chaseRef.current.count = 0;
+      chaseRef.current.offsets.clear();
+    }
+
+    /** `resized` distinguishes the observer — content above really moved — from the
+     * per-commit read, which cannot tell our own last margin from anything else. */
+    const update = (resized: boolean) => {
       const offset = getOffsetTopRelativeToAncestor(element, root);
       if (offset === null) {
         if (process.env.NODE_ENV !== 'production' && !warnedRef.current) {
@@ -53,18 +89,51 @@ export function useScrollMargin(ref: RefObject<HTMLElement | null>) {
         }
         return;
       }
-      setScrollMargin((prev) => (prev !== offset ? offset : prev));
+
+      const chase = chaseRef.current;
+
+      // The element measured where the margin we published puts it: this margin is the
+      // fixed point, and whatever chase got us here is over.
+      if (offset === publishedRef.current) {
+        chase.count = 0;
+        chase.offsets.clear();
+        return;
+      }
+
+      // A resize above the list is the case this hook exists for, so it refills the
+      // budget — but only when it lands somewhere the chase has not already been. A
+      // layout that answers our margin by resizing content above it fires this observer
+      // too, and refilling on that is how a bounded chase becomes an endless one.
+      if (resized && !chase.offsets.has(offset)) {
+        chase.count = 0;
+        chase.offsets.clear();
+      }
+
+      if (chase.count >= UNSETTLED_PUBLISHES) {
+        if (process.env.NODE_ENV !== 'production' && !warnedChaseRef.current) {
+          warnedChaseRef.current = true;
+          console.warn(
+            `useScrollMargin: the measured element moves every time the margin changes (${publishedRef.current} → ${offset}) — something the virtualizer sizes is rendering above it. Keeping ${publishedRef.current}.`
+          );
+        }
+        return;
+      }
+
+      chase.count++;
+      chase.offsets.add(offset);
+      publishedRef.current = offset;
+      setScrollMargin(offset);
     };
 
-    update();
+    update(false);
 
-    if (observedRef.current?.element === element && observedRef.current.root === root) return;
+    if (!reattached) return;
     disconnect(observedRef);
 
     // Whatever grows above the list lives inside one of the scroll container's children,
     // and grows that child's own box. Observing the list's ancestors instead would also
     // fire on the list growing downward, which can never move its own top.
-    const observer = new ResizeObserver(update);
+    const observer = new ResizeObserver(() => update(true));
     observer.observe(root);
     for (const child of Array.from(root.children)) observer.observe(child);
 


### PR DESCRIPTION
`useScrollMargin` re-measures in a layout effect with no dependency array, so it
runs on every commit, and every run can `setScrollMargin`. That is only safe if
the measured offset is a fixed point.

It isn't guaranteed to be one. The margin is handed to `useVirtualizer`, which
decides what renders inside the scroll container; wherever any of that lands
above the measured element, publishing a margin moves the thing the next commit
measures. The layout effect then feeds itself — set state, synchronous
re-render, layout effect, set state — and React throws "Maximum update depth
exceeded" (minified #185) after 50 of them. That error is not recoverable: the
nearest error boundary replaces the page, which is what a user hit while
scrolling.

The measurement itself is not new; the unbounded re-measure is. The call sites
this hook replaced each bounded it — `useLayoutEffect(…, [])` on the galleries,
`[scrollAreaRef, rows.length]` on the auction list — and lifting them into one
hook dropped the dependency array without putting anything in its place.

So put something in its place: a margin may be published, but the element then
has to measure at it. Three publishes without the element holding still and the
hook stops, keeping the last margin rather than chasing a target that has no
fixed point. Every settled measurement hands the budget straight back, so an
element in a layout that behaves never touches the limit, and a genuine resize
above the list refills it — the ResizeObserver still drives the case #3426 was
about (expanding descriptions, ads landing late), and its notifications are
only ignored when they land on an offset the current chase has already
published, which is the hook hearing its own echo.

Tests: three additions to the hook's browser suite, all of which fail on the
current hook with "Maximum update depth exceeded" — it does not crash under a
layout with no fixed point, it stops re-rendering once it gives up, and a real
resize above it still re-measures afterwards. `MasonryColumnsVirtual`'s gallery
regression test (the #3426 symptom) is unchanged and still passes.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
