### PR TITLE
test(apps): fix it.each tuple/callback type errors in the manifest-validator suite

### DIFF
--- a/src/server/services/__tests__/block-manifest-validator.service.test.ts
+++ b/src/server/services/__tests__/block-manifest-validator.service.test.ts
@@ -657,7 +657,10 @@ describe('BlockManifestValidator', () => {
       }
     );
 
-    it.each([
+    // `[unknown, string]` keeps the table's mixed-type cases in ONE tuple shape;
+    // otherwise each row infers its own tuple and the union is not assignable to
+    // a single callback signature.
+    it.each<[unknown, string]>([
       ['productivity', 'not in the taxonomy'],
       ['Generation', 'wrong case'],
       ['', 'empty string'],
@@ -711,7 +714,7 @@ describe('BlockManifestValidator', () => {
       }
     });
 
-    it.each([
+    it.each<[unknown, string]>([
       [42, 'number'],
       [null, 'null'],
       [{ text: 'hi' }, 'object'],
@@ -808,7 +811,7 @@ describe('BlockManifestValidator', () => {
       }
     });
 
-    it.each([
+    it.each<[unknown, string]>([
       ['', 'empty string'],
       [42, 'non-string'],
       [null, 'null'],
@@ -824,7 +827,7 @@ describe('BlockManifestValidator', () => {
       }
     });
 
-    it.each([
+    it.each<[unknown, string]>([
       [['models:read:self'], 'an array'],
       [null, 'null'],
       ['reason', 'a string'],


### PR DESCRIPTION
Follow-up to #3441. Tests-only type hygiene — no behaviour change.

## The bug

Four `it.each` tables in `block-manifest-validator.service.test.ts` mix value types across rows:

```ts
it.each([
  ['productivity', 'not in the taxonomy'],
  ['', 'empty string'],
  [42, 'non-string'],
  [null, 'null'],
])('rejects category %j (%s) with a clear error', (category) => { … });
```

TypeScript infers a **separate tuple type per row**, so the callback parameter type is a *union of tuple signatures* — `(...args: [number, string] | [string, string] | [null, string])` — and no single callback is assignable to it. That is a genuine `TS2345` in each of the four blocks:

| block | rows |
|---|---|
| `category` rejection | 5 |
| non-string `tagline` rejection | 5 |
| `scopeJustifications` value rejection | 3 |
| `scopeJustifications` non-object rejection | 3 |

(Homogeneous tables — every row the same tuple shape — are fine, because a callback with *fewer* parameters is assignable. Only the mixed-type tables break.)

## The fix

Annotate the table as `it.each<[unknown, string]>`, collapsing the rows to one tuple shape. The callback keeps its single parameter, the second element is still consumed by the `%s` in the test title, and **the rendered test names are byte-identical** (title formatting happens at runtime off the values, not the types).

## Why CI didn't catch it

`tsconfig.json` has `"exclude": [… "src/**/__tests__/**"]`, so `pnpm run typecheck` never type-checks any test under `__tests__`. The errors only show up in an editor. Verified by re-running `tsc --noEmit` with that exclusion lifted: **4 errors in this file before, 0 after.**

Lifting the exclusion repo-wide is *not* in scope here — there are ~500 pre-existing errors across the `__tests__` tree, which is presumably why it's excluded.

## Verification

- `vitest run --project unit src/server/services/__tests__/block-manifest-validator.service.test.ts` → **155 passed** before and after; the sorted test-name lists diff clean.
- `tsc --noEmit` with `src/**/__tests__/**` un-excluded: 4 → 0 errors in this file.
- **Mutation-verified** — restructuring an `it.each` is only safe if the assertions still bite. Each guard in `block-manifest-validator.service.ts` was broken in turn and the suite re-run:

| mutation | result |
|---|---|
| disable the `category` taxonomy check | **5 failed** (all 5 refactored category rows) |
| silently accept a non-string `tagline` | **5 failed** (all 5 refactored tagline rows) |
| disable the `scopeJustifications[…]` non-empty-string check | **3 failed** |
| disable the `scopeJustifications` object-shape check | **3 failed** |

All mutations reverted; the only file changed in this PR is the test file.

## Deliberately not changed

- Prettier still reports this file as unformatted — that is pre-existing on `main`, and the lines added here are themselves Prettier-clean. Reformatting the whole file would bury a 4-line diff.
- `it.each(MARKETPLACE_CATEGORIES.map((c) => [c] as const))` gets flagged in an editor as an implicit `any` on `c`. It is **not** an error in a correctly-configured program — it's a symptom of the file falling out of the tsconfig project (same reason the `~/…` imports show as unresolved there). Left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
