### PR TITLE
fix(security): gate three public procedures

### DIFF
--- a/src/components/NewsletterDialog/NewsletterDialog.tsx
+++ b/src/components/NewsletterDialog/NewsletterDialog.tsx
@@ -25,7 +25,7 @@ export function NewsletterDialog() {
 
   const form = useForm({
     schema: updateSubscriptionSchema,
-    defaultValues: { email: currentUser?.email ?? '', subscribed: true },
+    defaultValues: { subscribed: true },
   });
 
   const {
@@ -100,13 +100,6 @@ export function NewsletterDialog() {
 
         <Form form={form} onSubmit={handleSubscribe}>
           <Group gap={8} align="flex-start" justify="flex-end">
-            <InputText
-              placeholder="hello@civitai.com"
-              name="email"
-              type={currentUser ? 'hidden' : undefined}
-              hidden={!!currentUser}
-              style={{ flex: 1 }}
-            />
             <InputText name="subscribed" type="hidden" style={{ display: 'none' }} hidden />
             <Button type="submit" loading={updateNewsletterSubscriptionMutation.isPending}>
               Subscribe

--- a/src/server/controllers/api-key.controller.ts
+++ b/src/server/controllers/api-key.controller.ts
@@ -20,11 +20,19 @@ import { dbRead } from '~/server/db/client';
 import { getBuzzSpendForSubjects, type Subject } from '~/server/http/orchestrator/api-key-spend';
 import { generationServiceCookie } from '~/shared/constants/generation.constants';
 
-export async function getApiKeyHandler({ input }: { input: GetAPIKeyInput }) {
+export async function getApiKeyHandler({
+  input,
+  ctx,
+}: {
+  input: GetAPIKeyInput;
+  ctx: ProtectedContext;
+}) {
   const { id } = input;
 
   try {
-    const apiKey = await getApiKey({ id });
+    // Scoped to the caller: an id belonging to someone else must be indistinguishable from one
+    // that doesn't exist, or this enumerates the key table by owner and scope.
+    const apiKey = await getApiKey({ id, userId: ctx.user.id });
     if (!apiKey) throw throwNotFoundError(`No api key with id ${id}`);
 
     return { success: !!apiKey, data: apiKey };

--- a/src/server/routers/apiKey.router.ts
+++ b/src/server/routers/apiKey.router.ts
@@ -13,11 +13,11 @@ import {
   getUserApiKeysInputSchema,
   setBuzzLimitInputSchema,
 } from '~/server/schema/api-key.schema';
-import { protectedProcedure, publicProcedure, router, verifiedProcedure } from '~/server/trpc';
+import { protectedProcedure, router, verifiedProcedure } from '~/server/trpc';
 import { TokenScope } from '~/shared/constants/token-scope.constants';
 
 export const apiKeyRouter = router({
-  verifyKey: publicProcedure
+  verifyKey: protectedProcedure
     .meta({ requiredScope: TokenScope.Full })
     .input(getApiKeyInputSchema)
     .query(getApiKeyHandler),

--- a/src/server/routers/newsletter.router.ts
+++ b/src/server/routers/newsletter.router.ts
@@ -11,14 +11,17 @@ export const newsletterRouter = router({
   getSubscription: publicProcedure
     .meta({ requiredScope: TokenScope.UserRead })
     .query(({ ctx }) => getSubscription(ctx.user?.email)),
-  updateSubscription: publicProcedure
+  updateSubscription: protectedProcedure
     .meta({ requiredScope: TokenScope.UserWrite })
     .input(updateSubscriptionSchema)
     .mutation(({ input, ctx }) =>
+      // The email is taken from the session, never from input: a client-supplied address let an
+      // anonymous caller unsubscribe anyone whose address they knew, or sign a stranger up and
+      // have Beehiiv mail them under our sender identity.
       updateSubscription({
         ...input,
-        email: input.email ?? ctx.user?.email,
-        userId: ctx.user?.id,
+        email: ctx.user.email,
+        userId: ctx.user.id,
       })
     ),
   postpone: protectedProcedure

--- a/src/server/routers/system.router.ts
+++ b/src/server/routers/system.router.ts
@@ -11,6 +11,15 @@ import { CacheTTL } from '~/server/common/constants';
 import { dbKV } from '~/server/db/db-helpers';
 import { TokenScope } from '~/shared/constants/token-scope.constants';
 
+/**
+ * `KeyValue` is a general-purpose store: alongside job cursors it holds OAuth codes, scoring
+ * multipliers and other operational config. This procedure is unauthenticated, so it may only
+ * ever serve keys that are already public through a dedicated endpoint of their own —
+ * `modelFileOptions` via `modelFile.getOptions`, `training-announcement-2` via
+ * `training.getStatus`. Anything else needs its own procedure with its own gate.
+ */
+const PUBLIC_DB_KV_KEYS = ['modelFileOptions', 'training-announcement-2'] as const;
+
 export const systemRouter = router({
   getLiveNow: publicProcedure
     .meta({ requiredScope: TokenScope.Full })
@@ -28,7 +37,7 @@ export const systemRouter = router({
     .query(() => getCreationBlockedTags()),
   getDbKV: publicProcedure
     .meta({ requiredScope: TokenScope.Full })
-    .input(z.object({ key: z.string() }))
+    .input(z.object({ key: z.enum(PUBLIC_DB_KV_KEYS) }))
     .use(edgeCacheIt({ ttl: CacheTTL.sm }))
     .query(async ({ input }) => {
       return dbKV.get(input.key);

--- a/src/server/schema/newsletter.schema.ts
+++ b/src/server/schema/newsletter.schema.ts
@@ -1,7 +1,17 @@
 import * as z from 'zod';
 
 export type UpdateSubscriptionSchema = z.infer<typeof updateSubscriptionSchema>;
+/**
+ * No `email` field: the address comes from the session. Accepting one let an anonymous caller
+ * unsubscribe anybody whose address they knew, or sign a stranger up and have Beehiiv mail them
+ * under our sender identity.
+ *
+ * Reviving anonymous signup needs more than putting the field back. Unsubscribing must always
+ * require a session; subscribing may be anonymous, but only with proof the caller controls the
+ * address — double opt-in on the Beehiiv publication, or a signed token like the one
+ * `user.verifyEmailChange` uses — plus a rate limit. `beehiiv.setSubscription` posts
+ * `reactivate_existing: true` with no confirmation step of our own.
+ */
 export const updateSubscriptionSchema = z.object({
   subscribed: z.boolean(),
-  email: z.string().trim().email().optional(),
 });

--- a/src/server/services/api-key.service.ts
+++ b/src/server/services/api-key.service.ts
@@ -16,9 +16,9 @@ import { bustBuzzLimitCache, deleteAuthSubject } from '~/server/http/orchestrato
 import { invalidateCivitaiUser } from '~/server/services/orchestrator/civitai';
 import { logToAxiom, safeError } from '~/server/logging/client';
 
-export function getApiKey({ id }: GetAPIKeyInput) {
-  return dbRead.apiKey.findUnique({
-    where: { id },
+export function getApiKey({ id, userId }: GetAPIKeyInput & { userId: number }) {
+  return dbRead.apiKey.findFirst({
+    where: { id, userId },
     select: {
       tokenScope: true,
       user: { select: simpleUserSelect },


### PR DESCRIPTION
Three tRPC procedures relied on `meta({ requiredScope })` as though it were authentication. It is not: `ctx.tokenScope` defaults to Full when a request carries no bearer token, so the scope check is skipped entirely for anonymous callers.

- `system.getDbKV` takes an enum of the two keys already served publicly by dedicated endpoints of their own.
- `apiKey.verifyKey` is protected and scoped to the caller.
- `newsletter.updateSubscription` is protected and takes the address from the session; `email` is removed from the schema rather than accepted and ignored, so a caller that still sends one fails to compile.

The only mounted newsletter caller is already authenticated, and no caller of the other two exists in this repo or the sibling app repos. Typecheck, eslint and prettier clean.

Merging straight away by design — detail follows once prod confirms.