### PR TITLE
fix(tests): repair 2 baseline unit-test breaks on main (AI_MODELS mock, article upsert hang)

### DIFF
--- a/src/server/services/__tests__/article-locked-properties.service.test.ts
+++ b/src/server/services/__tests__/article-locked-properties.service.test.ts
@@ -39,6 +39,25 @@ const { mockDbRead, mockDbWrite } = vi.hoisted(() => {
 vi.mock('~/server/db/client', () => ({ dbRead: mockDbRead, dbWrite: mockDbWrite }));
 vi.mock('~/server/services/blocklist.service', () => ({ throwOnBlockedLinkDomain: vi.fn() }));
 
+// upsertArticle's UPDATE path does post-commit work that reaches Redis: the
+// count-cache refresh and the replication-lag markers. With no live Redis these
+// awaits never settle and the tests hang. Stub the Redis-backed helpers so the
+// tests exercise the lockedProperties enforcement (which happens before commit)
+// instead of blocking on infra. `importOriginal` keeps every other export real
+// so the rest of the large import graph is untouched.
+vi.mock('~/server/db/db-lag-helpers', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('~/server/db/db-lag-helpers')>()),
+  preventReplicationLag: vi.fn(async () => {}),
+  getDbWithoutLag: vi.fn(async () => mockDbRead),
+}));
+vi.mock('~/server/redis/caches', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('~/server/redis/caches')>();
+  return {
+    ...actual,
+    userArticleCountCache: { ...actual.userArticleCountCache, refresh: vi.fn(async () => {}) },
+  };
+});
+
 import { upsertArticle } from '~/server/services/article.service';
 
 const ARTICLE_ID = 21;

--- a/src/server/services/blocks/__tests__/agent-review-chat.service.test.ts
+++ b/src/server/services/blocks/__tests__/agent-review-chat.service.test.ts
@@ -33,7 +33,13 @@ vi.mock('~/server/services/blocks/app-review-report.service', () => ({
   getAgentReport: mockGetAgentReport,
 }));
 // The OpenRouter client civitai now calls directly for the grounded reply.
-vi.mock('~/server/services/ai/openrouter', () => ({
+// Keep the real `AI_MODELS` export (drift-proof: agent-review.service reads
+// `AI_MODELS.CLAUDE_HAIKU` at module load for AGENT_REVIEW_CHAT_MODEL). Only the
+// live `openrouter` client is stubbed. `importOriginal` doesn't construct a real
+// client here — `~/env/server` is mocked with no OPENROUTER_API_KEY, so the
+// module-load `createOpenRouterClient()` guard is skipped.
+vi.mock('~/server/services/ai/openrouter', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('~/server/services/ai/openrouter')>()),
   openrouter: { getTextCompletion: mockGetTextCompletion },
 }));
 


### PR DESCRIPTION
Two unit tests were RED on `main` under the new report-only `unit` CI job (confirmed failing on multiple unrelated PRs → breaks on `main`, not branch-specific). Both fixes are **test-only**.

## FIX 1 — `agent-review-chat.service.test.ts`

**Root cause:** collection error — `No "AI_MODELS" export is defined on the "~/server/services/ai/openrouter" mock`. `agent-review.service.ts:618` runs `export const AGENT_REVIEW_CHAT_MODEL = AI_MODELS.CLAUDE_HAIKU;` at module load, but the test's `vi.mock('~/server/services/ai/openrouter', …)` only returned `openrouter`, so importing the service threw before any test ran (0 tests collected).

**Fix:** switched the mock to an `importOriginal` spread so the real `AI_MODELS` is preserved (drift-proof — no hand-copied string table) and only the live `openrouter` client is stubbed:

```ts
vi.mock('~/server/services/ai/openrouter', async (importOriginal) => ({
  ...(await importOriginal<typeof import('~/server/services/ai/openrouter')>()),
  openrouter: { getTextCompletion: mockGetTextCompletion },
}));
```

Verified `importOriginal` does **not** construct a real OpenRouter client here: `openrouter.ts` only calls `createOpenRouterClient()` at load when `env.OPENROUTER_API_KEY` is truthy, and the test already mocks `~/env/server` with no key — so the guard is skipped. The `AGENT_REVIEW_CHAT_MODEL` assertion (`call.model` toBe `AGENT_REVIEW_CHAT_MODEL`) stays meaningful.

- **Before:** `Failed Suites 1 … No "AI_MODELS" export`, 0 tests.
- **After:** 9 passed in ~35ms.

## FIX 2 — `article-locked-properties.service.test.ts`

**Root cause:** all 5 tests hung to the 60s timeout. Each hits the `upsertArticle` UPDATE path (existing article by id). After the (mocked) DB transaction commits, the service does post-commit work that reaches **Redis with no live connection**, so the awaits never settle:
- `userArticleCountCache.refresh(...)` — Redis-backed count cache (first to block, `article.service.ts:1143`).
- `preventReplicationLag('article'|'userArticles', id)` → `lagTracker.markFresh` → Redis (`db-lag-helpers.ts:55`).

`article.service.ts` is unchanged since the test was added (#3327); the new `unit` job merely surfaced the latent hang.

**Fix:** targeted `importOriginal` mocks for just the two Redis-backed modules so the post-commit awaits resolve, leaving the rest of the large import graph real:

```ts
vi.mock('~/server/db/db-lag-helpers', async (importOriginal) => ({
  ...(await importOriginal<…>()),
  preventReplicationLag: vi.fn(async () => {}),
  getDbWithoutLag: vi.fn(async () => mockDbRead),
}));
vi.mock('~/server/redis/caches', async (importOriginal) => {
  const actual = await importOriginal<…>();
  return { ...actual, userArticleCountCache: { ...actual.userArticleCountCache, refresh: vi.fn(async () => {}) } };
});
```

The lockedProperties enforcement (which happens **before** commit, reading locks from the stored row not the client payload) and all 5 assertions are unchanged.

- **Before:** 5 tests each `Test timed out in 60000ms`.
- **After:** 5 passed in ~130ms.

**Note on stderr:** the article test emits a few swallowed `[cause]: … reading 'coverId'` traces. These come from the service's own **fire-and-forget** `updateArticleImageScanStatus([id]).catch(handleLogError)` post-commit call (`article.service.ts:1249`) — non-blocking by design in source. It's deliberately left failing-fast-and-swallowed rather than mocked further: feeding it a valid row would push execution into `dispatchArticleIngestionPostCommit` → `articlesSearchIndex.queueUpdate` (unmocked search infra), which is exactly the kind of dependency that reintroduces hang risk. The traces do not affect the passing assertions.

## Combined evidence (both files, default 60s timeout)

```
 ✓ unit  src/server/services/blocks/__tests__/agent-review-chat.service.test.ts (9 tests) 33ms
 ✓ unit  src/server/services/__tests__/article-locked-properties.service.test.ts (5 tests) 123ms

 Test Files  2 passed (2)
      Tests  14 passed (14)
   Duration  13.22s (transform 7.05s, setup 548ms, import 13.45s, tests 156ms)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
