### PR TITLE
fix(generation): send the MageFlow checkpoint AIR so generations get …

### DIFF
--- a/src/server/services/orchestrator/ecosystems/mage-flow.handler.ts
+++ b/src/server/services/orchestrator/ecosystems/mage-flow.handler.ts
@@ -38,47 +38,53 @@ const versionToModel = new Map<number, MageFlowModel>([
 
 const isTurbo = (model: MageFlowModel) => model === '4b-turbo' || model === '4b-edit-turbo';
 
-export const createMageFlowInput = defineHandler<MageFlowCtx, [ImageGenStepTemplate]>((data) => {
-  if (!data.aspectRatio) throw new Error('Aspect ratio is required for Mage Flow workflows');
+export const createMageFlowInput = defineHandler<MageFlowCtx, [ImageGenStepTemplate]>(
+  (data, ctx) => {
+    if (!data.aspectRatio) throw new Error('Aspect ratio is required for Mage Flow workflows');
 
-  const isTxt2Img = data.workflow.startsWith('txt');
-  const model = (data.model ? versionToModel.get(data.model.id) : undefined) ?? '4b';
-  if (isTxt2Img !== (model === '4b' || model === '4b-turbo'))
-    throw new Error(`Mage Flow model ${model} cannot be used for ${data.workflow}`);
+    const isTxt2Img = data.workflow.startsWith('txt');
+    const model = (data.model ? versionToModel.get(data.model.id) : undefined) ?? '4b';
+    if (isTxt2Img !== (model === '4b' || model === '4b-turbo'))
+      throw new Error(`Mage Flow model ${model} cannot be used for ${data.workflow}`);
 
-  const turbo = isTurbo(model);
-  const baseInput = {
-    engine: 'comfy',
-    ecosystem: 'mageflow',
-    prompt: data.prompt,
-    width: data.aspectRatio.width,
-    height: data.aspectRatio.height,
-    steps: ('steps' in data ? data.steps : undefined) ?? (turbo ? 4 : 30),
-    cfgScale: ('cfgScale' in data ? data.cfgScale : undefined) ?? (turbo ? 1 : 5),
-    quantity: data.quantity ?? 1,
-    seed: data.seed,
-  } as const;
+    const turbo = isTurbo(model);
+    const baseInput = {
+      engine: 'comfy',
+      ecosystem: 'mageflow',
+      prompt: data.prompt,
+      width: data.aspectRatio.width,
+      height: data.aspectRatio.height,
+      steps: ('steps' in data ? data.steps : undefined) ?? (turbo ? 4 : 30),
+      cfgScale: ('cfgScale' in data ? data.cfgScale : undefined) ?? (turbo ? 1 : 5),
+      quantity: data.quantity ?? 1,
+      seed: data.seed,
+      // Without an AIR reaching the orchestrator, the job's `resourcesUsed` stays
+      // empty and the version's generationCount can never accrue. The `model`
+      // string alone selects the checkpoint; this only carries attribution.
+      diffusionModel: data.model ? ctx.airs.getOrThrow(data.model.id) : undefined,
+    } as const;
 
-  if (isTxt2Img) {
+    if (isTxt2Img) {
+      return [
+        {
+          $type: 'imageGen',
+          input: removeEmpty({ ...baseInput, operation: 'createImage', model }) as
+            | ComfyMageFlow4bCreateImageGenInput
+            | ComfyMageFlow4bTurboCreateImageGenInput,
+        } as ImageGenStepTemplate,
+      ];
+    }
+
     return [
       {
         $type: 'imageGen',
-        input: removeEmpty({ ...baseInput, operation: 'createImage', model }) as
-          | ComfyMageFlow4bCreateImageGenInput
-          | ComfyMageFlow4bTurboCreateImageGenInput,
+        input: removeEmpty({
+          ...baseInput,
+          operation: 'editImage',
+          model,
+          images: data.images?.map((x) => x.url) ?? [],
+        }) as ComfyMageFlow4bEditImageInput | ComfyMageFlow4bEditTurboImageInput,
       } as ImageGenStepTemplate,
     ];
   }
-
-  return [
-    {
-      $type: 'imageGen',
-      input: removeEmpty({
-        ...baseInput,
-        operation: 'editImage',
-        model,
-        images: data.images?.map((x) => x.url) ?? [],
-      }) as ComfyMageFlow4bEditImageInput | ComfyMageFlow4bEditTurboImageInput,
-    } as ImageGenStepTemplate,
-  ];
-});
+);


### PR DESCRIPTION
…counted

The MageFlow handler translated the selected modelVersionId into an orchestrator model string ('4b' | '4b-turbo' | '4b-edit' | '4b-edit-turbo') and emitted no AIR — the only open-weight ecosystem handler that never calls ctx.airs.getOrThrow for its checkpoint.

The orchestrator derives orchestration.jobs.resourcesUsed from the AIRs in the step input, and that array is what feeds daily_resource_generation_counts -> ModelVersionMetric.generationCount. With no AIR, none of the four MageFlow versions can ever accrue a generation count.

Pass the AIR through the input contract's existing (previously unused) diffusionModel field, mirroring how z-image.handler.ts pairs a vendor model string with diffuserModel.