### PR TITLE
fix(blocks): enforce sensitive-scope justification AT SUBMIT (CLI + web-session)

### DIFF
--- a/src/server/services/block-manifest-validator.service.ts
+++ b/src/server/services/block-manifest-validator.service.ts
@@ -1,6 +1,7 @@
 import {
   isKnownBlockScope,
-  isSensitiveBlockScope,
+  sensitiveScopeJustificationError,
+  unjustifiedSensitiveScopes,
   validateBlockScopesAgainstOauthClient,
 } from '~/shared/constants/block-scope.constants';
 import { isKnownSlotId, isPageSlot } from '~/shared/constants/slot-registry';
@@ -502,30 +503,15 @@ export class BlockManifestValidator {
     // `enforceSensitiveScopeJustification:false` so a LEGACY pending request
     // (submitted before this shipped, no justification) stays approvable. Only
     // THIS rule is exempted on approve — every other check above still runs.
-    if (opts?.enforceSensitiveScopeJustification !== false && Array.isArray(m.scopes)) {
-      const justifications =
-        m.scopeJustifications &&
-        typeof m.scopeJustifications === 'object' &&
-        !Array.isArray(m.scopeJustifications)
-          ? (m.scopeJustifications as Record<string, unknown>)
-          : {};
-      const unjustifiedSensitive = [
-        ...new Set(
-          (m.scopes as unknown[])
-            .filter((s): s is string => typeof s === 'string')
-            .filter((scope) => isSensitiveBlockScope(scope))
-            .filter((scope) => {
-              const raw = justifications[scope];
-              return !(typeof raw === 'string' && raw.trim().length > 0);
-            })
-        ),
-      ];
+    if (opts?.enforceSensitiveScopeJustification !== false) {
+      // DRY: the rule (which sensitive scopes are unjustified + the message) is
+      // single-sourced in block-scope.constants so this validator and the
+      // submit-time gate in `submitVersion` can never drift. The `!== false`
+      // gate (approve exemption for legacy pending requests) stays HERE; the
+      // helper is the pure rule and always evaluates.
+      const unjustifiedSensitive = unjustifiedSensitiveScopes(m);
       if (unjustifiedSensitive.length > 0) {
-        errors.push(
-          `sensitive scopes require a justification — add a non-empty scopeJustifications entry for: ${unjustifiedSensitive.join(
-            ', '
-          )}`
-        );
+        errors.push(sensitiveScopeJustificationError(unjustifiedSensitive));
       }
     }
 

--- a/src/server/services/blocks/__tests__/publish-request.service.test.ts
+++ b/src/server/services/blocks/__tests__/publish-request.service.test.ts
@@ -1,10 +1,11 @@
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import JSZip from 'jszip';
 import {
   computeBundleLineDiff,
   computeFileDiff,
   computeManifestDiff,
   extractBundleMetadata,
+  submitVersion,
   type FileMeta,
 } from '../publish-request.service';
 import {
@@ -13,6 +14,44 @@ import {
   MAX_FILE_SIZE_BYTES,
   MAX_TOTAL_DECOMPRESSED_BYTES,
 } from '~/server/schema/blocks/publish-request.schema';
+
+// submitVersion dynamically imports these; mock them so the sensitive-scope
+// gate can be exercised end-to-end without a real DB / MinIO / Forgejo. The
+// gate itself runs BEFORE any of these are touched (fail-fast), so the
+// rejection test never reaches them; the "accepts" tests drive the full
+// happy-path insert through the mocks.
+const dbMocks = vi.hoisted(() => ({
+  createPublishRequest: vi.fn(),
+  pubReqFindFirst: vi.fn(),
+  appBlockFindFirst: vi.fn(),
+  userFindUnique: vi.fn(),
+}));
+
+vi.mock('~/server/db/client', () => ({
+  dbRead: {
+    appBlockPublishRequest: { findFirst: dbMocks.pubReqFindFirst },
+    appBlock: { findFirst: dbMocks.appBlockFindFirst },
+    user: { findUnique: dbMocks.userFindUnique },
+  },
+  dbWrite: {
+    appBlockPublishRequest: { create: dbMocks.createPublishRequest },
+  },
+}));
+
+vi.mock('~/env/server', () => ({
+  env: { APPS_DOMAIN: 'civit.ai', DISCORD_WEBHOOK_MOD_ALERTS: undefined },
+}));
+
+vi.mock('~/utils/bundle-s3', () => ({
+  bundleKey: (sha: string) => `bundles/${sha}.zip`,
+  getBundleBucket: () => 'test-bucket',
+  getBundleS3Client: () => ({ send: vi.fn().mockResolvedValue({}) }),
+}));
+
+vi.mock('~/server/services/blocks/forgejo.service', () => ({
+  ensureReviewRepo: vi.fn().mockResolvedValue(undefined),
+  commitFiles: vi.fn().mockResolvedValue(undefined),
+}));
 
 /**
  * Deterministic-input coverage for the W1 publish-request flow's diff
@@ -481,5 +520,63 @@ describe('computeBundleLineDiff', () => {
     const curr = [f('z.ts', 'z\n'), f('a.ts', 'a\n'), f('m.ts', 'm\n')];
     const result = computeBundleLineDiff(curr, null);
     expect(result.files.map((x) => x.path)).toEqual(['a.ts', 'm.ts', 'z.ts']);
+  });
+});
+
+describe('submitVersion — sensitive-scope justification gate (enforced AT SUBMIT)', () => {
+  async function makeBundle(manifest: Record<string, unknown>): Promise<Buffer> {
+    const zip = new JSZip();
+    zip.file('block.manifest.json', JSON.stringify(manifest));
+    zip.file('index.html', '<!doctype html><html><body>hi</body></html>');
+    return Buffer.from(await zip.generateAsync({ type: 'nodebuffer' }));
+  }
+
+  const baseManifest = { blockId: 'my-app', version: '0.1.0', name: 'My App' };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    dbMocks.pubReqFindFirst.mockResolvedValue(null);
+    dbMocks.appBlockFindFirst.mockResolvedValue(null);
+    dbMocks.userFindUnique.mockResolvedValue({ username: 'dev' });
+    dbMocks.createPublishRequest.mockResolvedValue({});
+  });
+
+  it('rejects a NEW sensitive-scope submit with NO scopeJustifications (was: accepted → pending)', async () => {
+    const buf = await makeBundle({ ...baseManifest, scopes: ['ai:write:budgeted'] });
+    await expect(submitVersion({ bundleBuffer: buf, submittedByUserId: 1 })).rejects.toThrow(
+      'sensitive scopes require a justification — add a non-empty scopeJustifications entry for: ai:write:budgeted'
+    );
+    // Fail-fast: rejected before any DB insert — it never enters the mod queue.
+    expect(dbMocks.createPublishRequest).not.toHaveBeenCalled();
+  });
+
+  it('names every unjustified sensitive scope in the rejection message', async () => {
+    const buf = await makeBundle({
+      ...baseManifest,
+      scopes: ['ai:write:budgeted', 'buzz:read:self', 'models:read:self'],
+    });
+    await expect(submitVersion({ bundleBuffer: buf, submittedByUserId: 1 })).rejects.toThrow(
+      'sensitive scopes require a justification — add a non-empty scopeJustifications entry for: ai:write:budgeted, buzz:read:self'
+    );
+    expect(dbMocks.createPublishRequest).not.toHaveBeenCalled();
+  });
+
+  it('accepts a sensitive-scope submit WITH a non-empty justification → pending pubreq', async () => {
+    const buf = await makeBundle({
+      ...baseManifest,
+      scopes: ['ai:write:budgeted'],
+      scopeJustifications: { 'ai:write:budgeted': 'runs the generation the user requested' },
+    });
+    const result = await submitVersion({ bundleBuffer: buf, submittedByUserId: 1 });
+    expect(result.slug).toBe('my-app');
+    expect(result.version).toBe('0.1.0');
+    expect(dbMocks.createPublishRequest).toHaveBeenCalledTimes(1);
+  });
+
+  it('accepts a NON-sensitive-scope submit with no justification → pending pubreq', async () => {
+    const buf = await makeBundle({ ...baseManifest, scopes: ['models:read:self'] });
+    const result = await submitVersion({ bundleBuffer: buf, submittedByUserId: 1 });
+    expect(result.slug).toBe('my-app');
+    expect(dbMocks.createPublishRequest).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/server/services/blocks/publish-request.service.ts
+++ b/src/server/services/blocks/publish-request.service.ts
@@ -17,7 +17,10 @@ import {
 } from '~/server/schema/blocks/publish-request.schema';
 // Pure shared module (only depends on token-scope.constants) — safe to import
 // statically without coupling to env/Prisma, so the pure-helper tests still run.
-import { deriveOauthBitmaskFromBlockScopes } from '~/shared/constants/block-scope.constants';
+import {
+  assertSensitiveScopesJustified,
+  deriveOauthBitmaskFromBlockScopes,
+} from '~/shared/constants/block-scope.constants';
 // Pure (no env/Prisma) — stamps the platform-owned iframe.src onto a manifest.
 import { stampCanonicalIframeSrc } from '~/server/services/blocks/manifest-normalize';
 // Zero-runtime-graph helper (its ONLY static import is a type; it DYNAMICALLY imports
@@ -1038,6 +1041,22 @@ export async function submitVersion(params: SubmitVersionParams): Promise<Submit
 
   const slug = manifest.blockId;
   const version = manifest.version;
+
+  // Sensitive-scope justification gate — enforced AT SUBMIT (fail-fast, before
+  // the MinIO upload + review-repo push). The primary submit path (CLI `app
+  // submit` + the web session-submit route) deliberately defers the deep
+  // BlockManifestValidator to APPROVE — and approve exempts THIS rule
+  // (`enforceSensitiveScopeJustification:false`, to grandfather legacy pending
+  // requests) — so without this call the sensitive-scope enforcement shipped in
+  // #3451 never fires for a CLI/web-session submit (a live dogfood submitted an
+  // `ai:write:budgeted` app with no scopeJustifications and it was accepted).
+  // The check needs only the manifest's `scopes` + `scopeJustifications`, both
+  // already present in the extracted manifest — no AppContext needed — so we run
+  // the targeted rule here via the SAME single-sourced helper the validator
+  // uses (DRY; identical message). `assertSensitiveScopesJustified` throws a
+  // plain Error, which the CLI route surfaces as a 400 and the web session
+  // route surfaces likewise. Deep validation stays deferred to approve.
+  assertSensitiveScopesJustified(manifest);
 
   // F-E E5 — validate publisher screenshots NOW (fail-fast) so a bundle with a
   // too-many / oversized / fake-image / odd-named screenshot is rejected inline

--- a/src/shared/constants/__tests__/block-scope.constants.test.ts
+++ b/src/shared/constants/__tests__/block-scope.constants.test.ts
@@ -1,13 +1,16 @@
 import { describe, expect, it } from 'vitest';
 import {
   APP_BLOCK_OAUTH_CLIENT_ID_PREFIX,
+  assertSensitiveScopesJustified,
   BLOCK_SCOPE_TO_OAUTH_BIT,
   deriveOauthBitmaskFromBlockScopes,
   isAppBlockOauthClientId,
   isKnownBlockScope,
   isSensitiveBlockScope,
   SENSITIVE_BLOCK_SCOPES,
+  sensitiveScopeJustificationError,
   SKIP_OAUTH_CHECK,
+  unjustifiedSensitiveScopes,
   validateBlockScopesAgainstOauthClient,
 } from '../block-scope.constants';
 import { TokenScope } from '../token-scope.constants';
@@ -89,6 +92,116 @@ describe('block-scope.constants', () => {
         expect(isKnownBlockScope(scope)).toBe(true);
         expect(scope in BLOCK_SCOPE_TO_OAUTH_BIT).toBe(true);
       }
+    });
+  });
+
+  describe('unjustifiedSensitiveScopes (single-sourced submit + validate rule)', () => {
+    it('flags a declared sensitive scope with NO scopeJustifications key at all', () => {
+      expect(unjustifiedSensitiveScopes({ scopes: ['ai:write:budgeted'] })).toEqual([
+        'ai:write:budgeted',
+      ]);
+    });
+
+    it('flags a sensitive scope missing from a present scopeJustifications object', () => {
+      expect(
+        unjustifiedSensitiveScopes({
+          scopes: ['ai:write:budgeted', 'buzz:read:self'],
+          scopeJustifications: { 'buzz:read:self': 'show the balance' },
+        })
+      ).toEqual(['ai:write:budgeted']);
+    });
+
+    it('flags a sensitive scope whose justification is empty / whitespace-only', () => {
+      expect(
+        unjustifiedSensitiveScopes({
+          scopes: ['ai:write:budgeted', 'social:tip:self'],
+          scopeJustifications: { 'ai:write:budgeted': '', 'social:tip:self': '   ' },
+        })
+      ).toEqual(['ai:write:budgeted', 'social:tip:self']);
+    });
+
+    it('flags a sensitive scope whose justification is a non-string value', () => {
+      expect(
+        unjustifiedSensitiveScopes({
+          scopes: ['ai:write:budgeted'],
+          scopeJustifications: { 'ai:write:budgeted': 42 },
+        })
+      ).toEqual(['ai:write:budgeted']);
+    });
+
+    it('returns [] when every sensitive scope has a non-empty justification', () => {
+      expect(
+        unjustifiedSensitiveScopes({
+          scopes: ['ai:write:budgeted', 'models:read:self'],
+          scopeJustifications: { 'ai:write:budgeted': 'runs a generation the user asked for' },
+        })
+      ).toEqual([]);
+    });
+
+    it('returns [] for a manifest declaring only non-sensitive scopes, even with no justifications', () => {
+      expect(
+        unjustifiedSensitiveScopes({ scopes: ['models:read:self', 'user:read:self'] })
+      ).toEqual([]);
+    });
+
+    it('returns [] when scopes is absent or not an array', () => {
+      expect(unjustifiedSensitiveScopes({})).toEqual([]);
+      expect(unjustifiedSensitiveScopes({ scopes: 'ai:write:budgeted' })).toEqual([]);
+      expect(unjustifiedSensitiveScopes({ scopes: null })).toEqual([]);
+    });
+
+    it('dedupes a sensitive scope declared more than once', () => {
+      expect(
+        unjustifiedSensitiveScopes({ scopes: ['ai:write:budgeted', 'ai:write:budgeted'] })
+      ).toEqual(['ai:write:budgeted']);
+    });
+
+    it('ignores a scopeJustifications that is not a plain object (array / null)', () => {
+      expect(
+        unjustifiedSensitiveScopes({ scopes: ['ai:write:budgeted'], scopeJustifications: [] })
+      ).toEqual(['ai:write:budgeted']);
+      expect(
+        unjustifiedSensitiveScopes({ scopes: ['ai:write:budgeted'], scopeJustifications: null })
+      ).toEqual(['ai:write:budgeted']);
+    });
+  });
+
+  describe('assertSensitiveScopesJustified + sensitiveScopeJustificationError', () => {
+    it('throws the scope-named message for an unjustified sensitive scope', () => {
+      expect(() =>
+        assertSensitiveScopesJustified({ scopes: ['ai:write:budgeted'] })
+      ).toThrow(
+        'sensitive scopes require a justification — add a non-empty scopeJustifications entry for: ai:write:budgeted'
+      );
+    });
+
+    it('lists every unjustified sensitive scope in the message (comma-joined)', () => {
+      expect(() =>
+        assertSensitiveScopesJustified({ scopes: ['ai:write:budgeted', 'buzz:read:self'] })
+      ).toThrow(
+        'sensitive scopes require a justification — add a non-empty scopeJustifications entry for: ai:write:budgeted, buzz:read:self'
+      );
+    });
+
+    it('does NOT throw when the sensitive scope is justified', () => {
+      expect(() =>
+        assertSensitiveScopesJustified({
+          scopes: ['ai:write:budgeted'],
+          scopeJustifications: { 'ai:write:budgeted': 'runs the generation' },
+        })
+      ).not.toThrow();
+    });
+
+    it('does NOT throw for non-sensitive-only scopes', () => {
+      expect(() =>
+        assertSensitiveScopesJustified({ scopes: ['models:read:self'] })
+      ).not.toThrow();
+    });
+
+    it('sensitiveScopeJustificationError formats the exact submit/validate message', () => {
+      expect(sensitiveScopeJustificationError(['ai:write:budgeted'])).toBe(
+        'sensitive scopes require a justification — add a non-empty scopeJustifications entry for: ai:write:budgeted'
+      );
     });
   });
 

--- a/src/shared/constants/block-scope.constants.ts
+++ b/src/shared/constants/block-scope.constants.ts
@@ -177,6 +177,77 @@ export function isSensitiveBlockScope(scope: string): boolean {
 }
 
 /**
+ * Manifest-shaped input for the sensitive-scope-justification gate. Only the two
+ * fields the rule actually reads are needed, and both are `unknown` because
+ * callers pass raw, not-yet-fully-validated manifests — the ZIP-extracted blob
+ * at submit (`submitVersion`) and the stored/deep-validated manifest at
+ * `validate`. Keeping the shape this loose is what lets ONE helper back both
+ * enforcement sites.
+ */
+export type SensitiveScopeManifestInput = {
+  scopes?: unknown;
+  scopeJustifications?: unknown;
+};
+
+/**
+ * Returns the DECLARED sensitive scopes that lack a non-empty
+ * `scopeJustifications` entry (deduped, in declaration order). Empty when the
+ * manifest is compliant, declares no sensitive scope, or has a non-array
+ * `scopes`. A justification "counts" only when it is a string with non-whitespace
+ * content — an empty/whitespace value, a non-string value, or a missing key all
+ * leave the sensitive scope unjustified.
+ *
+ * SINGLE SOURCE OF TRUTH for the "sensitive scopes must be justified" rule: the
+ * manifest validator (`validate`) and the submit path (`submitVersion`) both
+ * call this so the two enforcement sites can never drift. Pure + client-safe.
+ */
+export function unjustifiedSensitiveScopes(manifest: SensitiveScopeManifestInput): string[] {
+  if (!Array.isArray(manifest.scopes)) return [];
+  const justifications =
+    manifest.scopeJustifications &&
+    typeof manifest.scopeJustifications === 'object' &&
+    !Array.isArray(manifest.scopeJustifications)
+      ? (manifest.scopeJustifications as Record<string, unknown>)
+      : {};
+  return [
+    ...new Set(
+      (manifest.scopes as unknown[])
+        .filter((s): s is string => typeof s === 'string')
+        .filter((scope) => isSensitiveBlockScope(scope))
+        .filter((scope) => {
+          const raw = justifications[scope];
+          return !(typeof raw === 'string' && raw.trim().length > 0);
+        })
+    ),
+  ];
+}
+
+/**
+ * The exact operator-facing message both enforcement sites raise for an
+ * unjustified sensitive scope. Single-sourced so the validator's
+ * `errors.push(...)` string and `submitVersion`'s `throw` stay byte-identical.
+ */
+export function sensitiveScopeJustificationError(unjustifiedScopes: string[]): string {
+  return `sensitive scopes require a justification — add a non-empty scopeJustifications entry for: ${unjustifiedScopes.join(
+    ', '
+  )}`;
+}
+
+/**
+ * Throws (with `sensitiveScopeJustificationError`) when any declared sensitive
+ * scope lacks a justification; a no-op when the manifest is compliant. This is
+ * the imperative form used by `submitVersion` at submit time — the validator
+ * uses `unjustifiedSensitiveScopes` directly so it can accumulate the message
+ * into its `errors[]` alongside the other checks.
+ */
+export function assertSensitiveScopesJustified(manifest: SensitiveScopeManifestInput): void {
+  const unjustifiedScopes = unjustifiedSensitiveScopes(manifest);
+  if (unjustifiedScopes.length > 0) {
+    throw new Error(sensitiveScopeJustificationError(unjustifiedScopes));
+  }
+}
+
+/**
  * Validates that every requested block scope either declares no OAuth-bit
  * requirement (SKIP_OAUTH_CHECK) or has its OAuth bit set in the
  * OauthClient.allowedScopes bitmask.


### PR DESCRIPTION
## The gap

The sensitive-scope-justification enforcement shipped in #3451 **never fired for the primary submit path** — the CLI `app submit` and the web session-submit route.

Both of those hand off to `submitVersion` (`publish-request.service.ts`), which does only **lightweight** inline validation at submit (blockId/version/name shape, screenshots, iframe-src stamp) and **deliberately defers** the deep `BlockManifestValidator` to **approve**. The only `validateSubmission` call on this path is at approve — and #3451's follow-up correctly set `enforceSensitiveScopeJustification: false` there, to avoid retro-blocking legacy pending requests.

Net effect: for a CLI/web-session submit, the sensitive-scope rule ran **nowhere** — not at submit (no `validateSubmission` call), not at approve (exempted). A **new** app declaring a sensitive scope (e.g. `ai:write:budgeted`) with **no `scopeJustifications`** was accepted straight into the review queue. Caught by a live dogfood (submitted → `pending`).

The other entry points were fine — the git-push webhook, the dev-manifest API, and the web-editor `updateManifest` call `validateSubmission` directly with enforcement default-ON.

## The fix

Run the **targeted** sensitive-scope check **at submit**, inside `submitVersion`, where the CLI + web-session submit actually validate. The check needs only the manifest's `scopes` + `scopeJustifications` (both present in the extracted manifest), so it introduces **no** deep validation and no `AppContext` — the deliberate "defer deep validation to approve" architecture is preserved.

**DRY — single-sourced helper so the two enforcement sites can't drift.** The rule (from #3451) previously lived as an inline loop in `block-manifest-validator.service.ts`. It's now extracted into pure, client-safe helpers next to `SENSITIVE_BLOCK_SCOPES` in `shared/constants/block-scope.constants.ts`:

- `unjustifiedSensitiveScopes(manifest): string[]` — the pure rule
- `sensitiveScopeJustificationError(scopes): string` — the exact message
- `assertSensitiveScopesJustified(manifest): void` — imperative throw form

Both sites call them:
1. the validator's enforcement block replaces its inline loop with the helper (same message, same behavior — the `enforceSensitiveScopeJustification !== false` approve-exemption gate stays in the validator);
2. `submitVersion` calls `assertSensitiveScopesJustified(manifest)` after the manifest is extracted, before creating the publish request. It throws a plain `Error` with the **same** message, which the CLI route surfaces as a `400` and the web session route surfaces likewise.

## Behavior after

- CLI + web-session submit of a **new** sensitive-scope-no-justification app → **rejected at submit** (never enters the queue).
- Legacy pending requests already in the queue → **not** re-validated at submit → still approvable (approve exemption unchanged) → **grandfathered**.
- git-push / dev-API / `updateManifest` → unchanged (still enforce, default-ON).
- Approve stays exempt — untouched.

## Tests

- **`submitVersion`** (new): a bundle declaring `ai:write:budgeted` with no `scopeJustifications` → `submitVersion` throws with the scope-named message and **never reaches the DB insert** (previously it resolved to a pending request); with a non-empty justification → resolves to a pending request; a non-sensitive scope with no justification → resolves.
- **Shared helper** (new): `unjustifiedSensitiveScopes` / `assertSensitiveScopesJustified` / `sensitiveScopeJustificationError` across absent / empty / whitespace / non-string / compliant / non-array-scopes / dedupe cases.
- The existing validator + checklist + `updateManifest` enforcement suites pass unchanged (the validator now calls the helper but behavior is identical).

`tsc --noEmit`: 0 errors. Full relevant suite: 337 tests passing (validator 169, block-scope 35, publish-request 43, updateManifest 5+17, git-push 11, plus checklist + submit-version routes).

Refs #3451

🤖 Generated with [Claude Code](https://claude.com/claude-code)
