### PR TITLE
fix(challenge): emit completion + prize-paid metrics from the scheduled job path

### DIFF
--- a/src/server/games/daily-challenge/challenge-helpers.ts
+++ b/src/server/games/daily-challenge/challenge-helpers.ts
@@ -788,22 +788,39 @@ export async function incrementOperationSpent(challengeId: number, amount: numbe
 /**
  * Atomically claim a challenge for completion processing.
  * Uses UPDATE ... WHERE status='Active' to prevent duplicate processing.
- * Returns true if this process owns the challenge, false if already claimed.
+ *
+ * Returns the claim stamp written to `metadata.completingClaimedAt` when this process owns the
+ * challenge, or `null` when the row was already claimed. The stamp is always a non-empty ISO
+ * string, so the historical `if (!claimed)` boolean reading is preserved exactly.
+ *
+ * Why the stamp is returned rather than a bare boolean: the claim is NOT held for the lifetime of
+ * the run. `resetStuckCompletingChallenges` below revokes a `Completing` claim purely on elapsed
+ * time — no liveness check, no ownership token — so a slow-but-alive run can have its claim taken
+ * over by a second run while it is still executing. A re-claim overwrites the stamp, so a run that
+ * re-reads the row and finds a DIFFERENT stamp knows it no longer owns the completion. That signal
+ * is used to suppress duplicate TELEMETRY only (see `claimStillHeld` in daily-challenge-processing);
+ * it does not gate any write, and the status writes remain unconditional as before.
  */
-export async function claimChallengeForCompletion(challengeId: number): Promise<boolean> {
+export async function claimChallengeForCompletion(challengeId: number): Promise<string | null> {
+  const claimedAt = new Date().toISOString();
   const result = await dbWrite.$executeRaw`
     UPDATE "Challenge"
     SET status = ${ChallengeStatus.Completing}::"ChallengeStatus",
-        metadata = COALESCE(metadata, '{}'::jsonb) || jsonb_build_object('completingClaimedAt', ${new Date().toISOString()})
+        metadata = COALESCE(metadata, '{}'::jsonb) || jsonb_build_object('completingClaimedAt', ${claimedAt})
     WHERE id = ${challengeId}
     AND status = ${ChallengeStatus.Active}::"ChallengeStatus"
   `;
-  return result > 0;
+  return result > 0 ? claimedAt : null;
 }
 
 /**
  * Reset challenges stuck in 'Completing' status back to 'Active' for retry.
  * A challenge is considered stuck if it has been in Completing for longer than timeoutMinutes.
+ *
+ * 🔴 This is purely TIME-BASED: there is no liveness check and no ownership token, so it can revoke
+ * the claim of a run that is still executing (a run slower than `timeoutMinutes` is assumed dead).
+ * Callers must therefore not treat "I claimed it" as "I still own it" — re-check the claim stamp
+ * (see `claimChallengeForCompletion`) before doing anything that must not happen twice.
  */
 export async function resetStuckCompletingChallenges(timeoutMinutes = 10): Promise<number> {
   const result = await dbWrite.$executeRaw`

--- a/src/server/jobs/__tests__/challenge-completion-metrics.test.ts
+++ b/src/server/jobs/__tests__/challenge-completion-metrics.test.ts
@@ -1,0 +1,499 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import client from 'prom-client';
+
+// Regression coverage for the SCHEDULED-JOB challenge completion telemetry.
+//
+// The bug this locks down: `challenge_completed_total` and `challenge_prize_paid_buzz_total` were
+// only emitted from `endChallengeAndPickWinners` (the manual/moderator tRPC path). The daily job's
+// own two completion sites in `pickWinnersForChallenge` — the zero-entries completion and the
+// winners completion — emitted nothing, so both counters stayed permanently empty in production
+// even while challenges completed and prizes were paid. Removing either emit must fail this file.
+//
+// The metrics module is spied THROUGH to the real implementation (not stubbed out), so every
+// assertion below is backed by both the spy call AND the real prom-client series — a missing emit
+// shows up as an ABSENT series, never as a helper's `?? 0` default.
+//
+// Mocking mirrors challenge-degenerate-winners.test.ts: `~/server/events` is stubbed to cut its
+// heavy transitive chain, everything touching DB/LLM/buzz is mocked at the module boundary.
+
+const {
+  mockDbReadQueryRaw,
+  mockDbReadChallengeFindUnique,
+  mockDbWriteQueryRaw,
+  mockDbWriteExecuteRaw,
+  mockDbWriteChallengeUpdate,
+  mockDbWriteChallengeFindUnique,
+  mockGetChallengeConfig,
+  mockGetJudgingConfig,
+  mockEndChallenge,
+  mockGetActiveChallenges,
+  mockGenerateWinners,
+  mockClaimChallengeForCompletion,
+  mockGetExistingWinnersForRetry,
+  mockResolveEventContext,
+  mockUpdateChallengeStatus,
+  mockRefundUserChallengeFunds,
+  mockCreateNotification,
+  mockCreateChallengeWinner,
+  mockGetChallengeById,
+  mockCreateBuzzTransactionMany,
+  mockGetChallengeBuzzType,
+  mockSendChallengeResultsNotification,
+} = vi.hoisted(() => ({
+  mockDbReadQueryRaw: vi.fn(),
+  mockDbReadChallengeFindUnique: vi.fn(),
+  mockDbWriteQueryRaw: vi.fn(),
+  mockDbWriteExecuteRaw: vi.fn().mockResolvedValue(1),
+  mockDbWriteChallengeUpdate: vi.fn().mockResolvedValue(undefined),
+  mockDbWriteChallengeFindUnique: vi.fn().mockResolvedValue({
+    prizePool: 0,
+    prizeDistribution: null,
+  }),
+  mockGetChallengeConfig: vi.fn(),
+  mockGetJudgingConfig: vi.fn(),
+  mockEndChallenge: vi.fn().mockResolvedValue(undefined),
+  mockGetActiveChallenges: vi.fn(),
+  mockGenerateWinners: vi.fn(),
+  mockClaimChallengeForCompletion: vi.fn().mockResolvedValue(true),
+  mockGetExistingWinnersForRetry: vi.fn().mockResolvedValue([]),
+  mockResolveEventContext: vi.fn().mockResolvedValue(undefined),
+  mockUpdateChallengeStatus: vi.fn().mockResolvedValue(undefined),
+  mockRefundUserChallengeFunds: vi.fn().mockResolvedValue({ refundedEntries: 0 }),
+  mockCreateNotification: vi.fn().mockResolvedValue(undefined),
+  mockCreateChallengeWinner: vi.fn().mockResolvedValue(1),
+  mockGetChallengeById: vi.fn().mockResolvedValue(null),
+  mockCreateBuzzTransactionMany: vi.fn().mockResolvedValue(undefined),
+  mockGetChallengeBuzzType: vi.fn().mockResolvedValue('yellow'),
+  mockSendChallengeResultsNotification: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('~/server/db/client', () => ({
+  dbRead: {
+    $queryRaw: mockDbReadQueryRaw,
+    challenge: { findUnique: mockDbReadChallengeFindUnique },
+  },
+  dbWrite: {
+    $queryRaw: mockDbWriteQueryRaw,
+    $executeRaw: mockDbWriteExecuteRaw,
+    challenge: { update: mockDbWriteChallengeUpdate, findUnique: mockDbWriteChallengeFindUnique },
+  },
+}));
+
+vi.mock('~/server/events', () => ({
+  eventEngine: { processEngagement: vi.fn().mockResolvedValue(undefined) },
+}));
+
+vi.mock('~/server/flipt/client', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('~/server/flipt/client')>();
+  return { ...actual, isFlipt: vi.fn().mockResolvedValue(false) };
+});
+
+// Spy THROUGH to the real record helpers so the assertions can read the real registry series.
+vi.mock('~/server/prom/challenge.metrics', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('~/server/prom/challenge.metrics')>();
+  return {
+    ...actual,
+    recordChallengeCompleted: vi.fn(actual.recordChallengeCompleted),
+    recordChallengePrizePaidBuzz: vi.fn(actual.recordChallengePrizePaidBuzz),
+  };
+});
+
+vi.mock('~/server/games/daily-challenge/daily-challenge.utils', async () => {
+  const real = await import('~/server/games/daily-challenge/daily-challenge-scoring');
+  return {
+    SCORE_WEIGHTS: real.SCORE_WEIGHTS,
+    calculateWeightedScore: real.calculateWeightedScore,
+    challengeToLegacyFormat: vi.fn(),
+    deriveChallengeNsfwLevel: vi.fn(() => 1),
+    endChallenge: mockEndChallenge,
+    getActiveChallenges: mockGetActiveChallenges,
+    getChallengeConfig: mockGetChallengeConfig,
+    getJudgingConfig: mockGetJudgingConfig,
+    getUpcomingSystemChallenge: vi.fn(),
+  };
+});
+
+vi.mock('~/server/games/daily-challenge/challenge-helpers', () => ({
+  claimChallengeForCompletion: mockClaimChallengeForCompletion,
+  computeDynamicPool: vi.fn(),
+  distributePrizes: vi.fn(),
+  createChallengeRecord: vi.fn(),
+  createChallengeWinner: mockCreateChallengeWinner,
+  getChallengeById: mockGetChallengeById,
+  getChallengeEntryCount: vi.fn().mockResolvedValue(0),
+  getExistingWinnersForRetry: mockGetExistingWinnersForRetry,
+  incrementOperationSpent: vi.fn().mockResolvedValue(undefined),
+  resolveEventContext: mockResolveEventContext,
+  setChallengeActive: vi.fn(),
+  updateChallengeStatus: mockUpdateChallengeStatus,
+}));
+
+vi.mock('~/server/games/daily-challenge/challenge-rewards', () => ({
+  distributeParticipationPrizes: vi.fn().mockResolvedValue([]),
+  promoteChallengeEntries: vi.fn().mockResolvedValue(0),
+}));
+
+vi.mock('~/server/games/daily-challenge/generative-content', () => ({
+  estimateBuzzCost: vi.fn().mockReturnValue(0),
+  generateArticle: vi.fn(),
+  generateCollectionDetails: vi.fn(),
+  generateReview: vi.fn(),
+  generateWinners: mockGenerateWinners,
+}));
+
+vi.mock('~/server/services/buzz.service', () => ({
+  createBuzzTransactionMany: mockCreateBuzzTransactionMany,
+  getTransactionByExternalId: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock('~/server/services/commentsv2.service', () => ({
+  upsertComment: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('~/server/services/notification.service', () => ({
+  createNotification: mockCreateNotification,
+}));
+
+vi.mock('~/server/services/challenge-engagement.service', () => ({
+  sendChallengeResultsNotification: mockSendChallengeResultsNotification,
+}));
+
+vi.mock('~/server/services/reaction.service', () => ({
+  toggleReaction: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('~/server/games/daily-challenge/challenge-funding', () => ({
+  refundUserChallengeFunds: mockRefundUserChallengeFunds,
+  buildWinnerPayoutTransactions: vi.fn().mockReturnValue([]),
+  getChallengeBuzzType: mockGetChallengeBuzzType,
+  reportPoolFundingShortfall: vi.fn(),
+}));
+
+vi.mock('~/utils/logging', () => ({
+  createLogger: vi.fn(() => vi.fn()),
+}));
+
+const { pickWinnersForChallenge } = await import('~/server/jobs/daily-challenge-processing');
+const { ChallengeSource } = await import('~/shared/utils/prisma/enums');
+const {
+  recordChallengeCompleted,
+  recordChallengePrizePaidBuzz,
+  __resetChallengeMetricsForTest,
+} = await import('~/server/prom/challenge.metrics');
+
+const COMPLETED_METRIC = 'civitai_app_challenge_completed_total';
+const PRIZE_PAID_METRIC = 'civitai_app_challenge_prize_paid_buzz_total';
+
+type Series = { value: number; labels: Record<string, string> };
+
+/**
+ * Read a single series off the REAL default registry. Deliberately returns `undefined` when the
+ * series is absent rather than defaulting to 0 — a missing emit must be distinguishable from an
+ * emit of zero, which is exactly the trap that let an earlier metrics test pass both with and
+ * without the fix.
+ */
+async function seriesFor(
+  name: string,
+  labels: Record<string, string>
+): Promise<Series | undefined> {
+  const metric = client.register.getSingleMetric(name) as unknown as {
+    get: () => Promise<{ values: Series[] }>;
+  };
+  const data = await metric.get();
+  return data.values.find((v) =>
+    Object.entries(labels).every(([key, val]) => v.labels[key] === val)
+  );
+}
+
+async function allSeries(name: string): Promise<Series[]> {
+  const metric = client.register.getSingleMetric(name) as unknown as {
+    get: () => Promise<{ values: Series[] }>;
+  };
+  return (await metric.get()).values;
+}
+
+const BASE_CONFIG = {
+  challengeType: 'world-morph',
+  challengeCollectionId: 1,
+  judgedTagId: 11,
+  reviewMeTagId: 12,
+  userCooldown: '14 day',
+  resourceCooldown: '90 day',
+  winnerCooldown: '7 day',
+  prizes: [],
+  entryPrizeRequirement: 10,
+  entryPrize: { buzz: 0, points: 0 },
+  reviewAmount: { min: 6, max: 12 },
+  maxScoredPerUser: 5,
+  finalReviewAmount: 10,
+  resourceCosmeticId: null,
+  articleTagId: 1,
+  defaultJudgeId: 1,
+  defaultJudge: null,
+} as never;
+
+const JUDGING_CONFIG = {
+  judgeId: 1,
+  userId: 999,
+  sourceCollectionId: null,
+  prompts: {},
+  reviewTemplate: null,
+} as never;
+
+// 3 prize places (500/250/100 = 850 configured) — only 2 are awarded below, so the emitted
+// prize total must be 750, not the 850 sitting in the prize table.
+const currentChallenge = {
+  challengeId: 1,
+  type: 'daily',
+  date: new Date(),
+  theme: 'test',
+  modelId: 1,
+  modelVersionIds: [1],
+  collectionId: 100,
+  title: 'Test',
+  invitation: '',
+  coverUrl: '',
+  prizes: [
+    { buzz: 500, points: 10 },
+    { buzz: 250, points: 5 },
+    { buzz: 100, points: 2 },
+  ],
+  entryPrizeRequirement: 10,
+  entryPrize: { buzz: 0, points: 0 },
+} as never;
+
+function challengeRecordWith(source: string) {
+  return {
+    id: 1,
+    collectionId: 100,
+    source,
+    entryFee: 0,
+    operationSpent: 0,
+    metadata: {},
+    prizes: [
+      { buzz: 500, points: 10 },
+      { buzz: 250, points: 5 },
+      { buzz: 100, points: 2 },
+    ],
+  };
+}
+
+function mockChallengeJudgeRow(source: string | undefined) {
+  mockDbReadQueryRaw.mockResolvedValueOnce([
+    source === undefined
+      ? undefined
+      : { judgeId: null, judgingPrompt: null, eventId: null, source, judgingCategories: null },
+  ]);
+}
+
+function mockJudgedEntryRows(rows: Array<{ imageId: number; userId: number; username: string }>) {
+  mockDbReadQueryRaw.mockResolvedValueOnce(
+    rows.map((row) => ({
+      ...row,
+      note: JSON.stringify({
+        score: { theme: 10, aesthetic: 8, humor: 8, wittiness: 8 },
+        summary: `entry by ${row.username}`,
+      }),
+    }))
+  );
+}
+
+/** Drive the fresh two-entrant LLM path to a winners completion with 2 of 3 places filled. */
+async function runTwoWinnerCompletion(source: string) {
+  mockGetChallengeById.mockResolvedValue(challengeRecordWith(source));
+  mockChallengeJudgeRow(source);
+  mockJudgedEntryRows([
+    { imageId: 1, userId: 100, username: 'alice' },
+    { imageId: 2, userId: 200, username: 'bob' },
+  ]);
+  mockDbWriteQueryRaw.mockResolvedValueOnce([]);
+  mockGenerateWinners.mockResolvedValue({
+    process: 'llm',
+    outcome: 'llm-picked',
+    model: 'test-model',
+    usage: {},
+    winners: [
+      { creator: 'alice', creatorId: 100, reason: 'best' },
+      { creator: 'bob', creatorId: 200, reason: 'second' },
+    ],
+  });
+
+  await pickWinnersForChallenge(currentChallenge, BASE_CONFIG);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  __resetChallengeMetricsForTest();
+  mockDbWriteExecuteRaw.mockResolvedValue(1);
+  // clearAllMocks clears calls but NOT implementations — restore explicitly so the
+  // rejecting-write test below cannot leak into the tests that follow it.
+  mockDbWriteChallengeUpdate.mockResolvedValue(undefined);
+  mockGetChallengeConfig.mockResolvedValue(BASE_CONFIG);
+  mockGetJudgingConfig.mockResolvedValue(JUDGING_CONFIG);
+  mockEndChallenge.mockResolvedValue(undefined);
+  mockClaimChallengeForCompletion.mockResolvedValue(true);
+  mockGetExistingWinnersForRetry.mockResolvedValue([]);
+  mockResolveEventContext.mockResolvedValue(undefined);
+  mockUpdateChallengeStatus.mockResolvedValue(undefined);
+  mockRefundUserChallengeFunds.mockResolvedValue({ refundedEntries: 0 });
+  mockDbWriteChallengeFindUnique.mockResolvedValue({ prizePool: 0, prizeDistribution: null });
+  mockCreateChallengeWinner.mockResolvedValue(1);
+  mockGetChallengeById.mockResolvedValue(null);
+  mockGetChallengeBuzzType.mockResolvedValue('yellow');
+});
+
+describe('pickWinnersForChallenge — zero-entries completion telemetry', () => {
+  it('emits challenge_completed_total exactly once with the challenge source', async () => {
+    mockChallengeJudgeRow(ChallengeSource.User);
+    // userBestEntries returns no rows -> getJudgedEntries short-circuits to [].
+    mockDbReadQueryRaw.mockResolvedValueOnce([]);
+
+    await pickWinnersForChallenge(currentChallenge, BASE_CONFIG);
+
+    // The completion actually happened...
+    expect(mockUpdateChallengeStatus).toHaveBeenCalledWith(1, 'Completed');
+    // ...and it was counted, once, with the right source.
+    expect(recordChallengeCompleted).toHaveBeenCalledTimes(1);
+    expect(recordChallengeCompleted).toHaveBeenCalledWith({ source: ChallengeSource.User });
+
+    const series = await seriesFor(COMPLETED_METRIC, { source: 'User' });
+    expect(series).toBeDefined();
+    expect(series?.value).toBe(1);
+  });
+
+  it('does not emit a prize payout for a zero-winner completion', async () => {
+    mockChallengeJudgeRow(ChallengeSource.User);
+    mockDbReadQueryRaw.mockResolvedValueOnce([]);
+
+    await pickWinnersForChallenge(currentChallenge, BASE_CONFIG);
+
+    expect(recordChallengePrizePaidBuzz).not.toHaveBeenCalled();
+    expect(await allSeries(PRIZE_PAID_METRIC)).toHaveLength(0);
+  });
+});
+
+describe('pickWinnersForChallenge — winners completion telemetry', () => {
+  it('emits challenge_completed_total once for a winners completion', async () => {
+    await runTwoWinnerCompletion(ChallengeSource.System);
+
+    expect(mockCreateChallengeWinner).toHaveBeenCalledTimes(2);
+    expect(recordChallengeCompleted).toHaveBeenCalledTimes(1);
+    expect(recordChallengeCompleted).toHaveBeenCalledWith({ source: ChallengeSource.System });
+
+    const series = await seriesFor(COMPLETED_METRIC, { source: 'System' });
+    expect(series).toBeDefined();
+    expect(series?.value).toBe(1);
+  });
+
+  it('emits the prize buzz ACTUALLY awarded to winners, not the configured prize table', async () => {
+    await runTwoWinnerCompletion(ChallengeSource.System);
+
+    // 2 of 3 places filled: 500 + 250. The prize table totals 850 — reporting that would
+    // overstate payouts on every partial-winner completion.
+    expect(recordChallengePrizePaidBuzz).toHaveBeenCalledTimes(1);
+    expect(recordChallengePrizePaidBuzz).toHaveBeenCalledWith({
+      source: ChallengeSource.System,
+      buzzType: 'yellow',
+      amount: 750,
+    });
+
+    const series = await seriesFor(PRIZE_PAID_METRIC, { source: 'System', buzzType: 'yellow' });
+    expect(series).toBeDefined();
+    expect(series?.value).toBe(750);
+  });
+
+  it('reports the buzz total from the retry path (existing winners) as recorded on ChallengeWinner', async () => {
+    mockGetChallengeById.mockResolvedValue(challengeRecordWith(ChallengeSource.User));
+    mockGetChallengeBuzzType.mockResolvedValue('green');
+    mockGetExistingWinnersForRetry.mockResolvedValue([
+      { userId: 100, imageId: 1, place: 1, buzzAwarded: 400, reason: 'best' },
+      { userId: 200, imageId: 2, place: 2, buzzAwarded: 200, reason: 'second' },
+    ]);
+
+    await pickWinnersForChallenge(currentChallenge, BASE_CONFIG);
+
+    // Retry reuses stored winners; no fresh judging, no fresh ChallengeWinner rows.
+    expect(mockGenerateWinners).not.toHaveBeenCalled();
+    expect(recordChallengeCompleted).toHaveBeenCalledTimes(1);
+    expect(recordChallengePrizePaidBuzz).toHaveBeenCalledWith({
+      source: ChallengeSource.User,
+      buzzType: 'green',
+      amount: 600,
+    });
+
+    const series = await seriesFor(PRIZE_PAID_METRIC, { source: 'User', buzzType: 'green' });
+    expect(series).toBeDefined();
+    expect(series?.value).toBe(600);
+  });
+});
+
+describe('pickWinnersForChallenge — emit placement is retry-safe', () => {
+  it('emits nothing when the atomic completion claim is lost (challenge not Active)', async () => {
+    mockClaimChallengeForCompletion.mockResolvedValue(false);
+
+    await pickWinnersForChallenge(currentChallenge, BASE_CONFIG);
+
+    expect(recordChallengeCompleted).not.toHaveBeenCalled();
+    expect(recordChallengePrizePaidBuzz).not.toHaveBeenCalled();
+    expect(await allSeries(COMPLETED_METRIC)).toHaveLength(0);
+    expect(await allSeries(PRIZE_PAID_METRIC)).toHaveLength(0);
+  });
+
+  it('emits only AFTER the Completed status write, never at the payout call', async () => {
+    await runTwoWinnerCompletion(ChallengeSource.System);
+
+    // Only one challenge.update runs for a System-source completion: the Completed write.
+    expect(mockDbWriteChallengeUpdate).toHaveBeenCalledTimes(1);
+    const completedWriteOrder = mockDbWriteChallengeUpdate.mock.invocationCallOrder[0];
+    const payoutOrder = mockCreateBuzzTransactionMany.mock.invocationCallOrder[0];
+    const completedEmitOrder = vi.mocked(recordChallengeCompleted).mock.invocationCallOrder[0];
+    const prizeEmitOrder = vi.mocked(recordChallengePrizePaidBuzz).mock.invocationCallOrder[0];
+
+    // The payout happens first, but the emits must not ride along with it: a crash between the
+    // payout and the Completed write leaves the challenge to be reset Active and retried, and the
+    // retry re-issues the (idempotent) payout. Counting at the payout would double-count Buzz that
+    // was only ever paid once; counting after the Completed write happens once per challenge.
+    expect(payoutOrder).toBeLessThan(completedWriteOrder);
+    expect(completedEmitOrder).toBeGreaterThan(completedWriteOrder);
+    expect(prizeEmitOrder).toBeGreaterThan(completedWriteOrder);
+  });
+
+  it('does not emit when the Completed status write throws', async () => {
+    mockDbWriteChallengeUpdate.mockRejectedValue(new Error('db down'));
+
+    await expect(runTwoWinnerCompletion(ChallengeSource.System)).rejects.toThrow('db down');
+
+    expect(recordChallengeCompleted).not.toHaveBeenCalled();
+    expect(recordChallengePrizePaidBuzz).not.toHaveBeenCalled();
+  });
+});
+
+describe('pickWinnersForChallenge — labels stay enum-bound', () => {
+  it('routes an unrecognized source through normSource to "unknown"', async () => {
+    mockGetChallengeById.mockResolvedValue(challengeRecordWith('Sneaky<script>'));
+    mockChallengeJudgeRow('Sneaky<script>');
+    mockJudgedEntryRows([
+      { imageId: 1, userId: 100, username: 'alice' },
+      { imageId: 2, userId: 200, username: 'bob' },
+    ]);
+    mockDbWriteQueryRaw.mockResolvedValueOnce([]);
+    mockGenerateWinners.mockResolvedValue({
+      process: 'llm',
+      outcome: 'llm-picked',
+      model: 'test-model',
+      usage: {},
+      winners: [
+        { creator: 'alice', creatorId: 100, reason: 'best' },
+        { creator: 'bob', creatorId: 200, reason: 'second' },
+      ],
+    });
+
+    await pickWinnersForChallenge(currentChallenge, BASE_CONFIG);
+
+    for (const name of [COMPLETED_METRIC, PRIZE_PAID_METRIC]) {
+      const values = await allSeries(name);
+      expect(values).toHaveLength(1);
+      expect(values[0].labels.source).toBe('unknown');
+    }
+  });
+});

--- a/src/server/jobs/__tests__/challenge-completion-metrics.test.ts
+++ b/src/server/jobs/__tests__/challenge-completion-metrics.test.ts
@@ -54,7 +54,7 @@ const {
   mockEndChallenge: vi.fn().mockResolvedValue(undefined),
   mockGetActiveChallenges: vi.fn(),
   mockGenerateWinners: vi.fn(),
-  mockClaimChallengeForCompletion: vi.fn().mockResolvedValue(true),
+  mockClaimChallengeForCompletion: vi.fn().mockResolvedValue('2026-07-29T12:00:00.000Z'),
   mockGetExistingWinnersForRetry: vi.fn().mockResolvedValue([]),
   mockResolveEventContext: vi.fn().mockResolvedValue(undefined),
   mockUpdateChallengeStatus: vi.fn().mockResolvedValue(undefined),
@@ -262,14 +262,22 @@ const currentChallenge = {
   entryPrize: { buzz: 0, points: 0 },
 } as never;
 
-function challengeRecordWith(source: string) {
+// The stamp `claimChallengeForCompletion` writes to metadata.completingClaimedAt for THIS run.
+const CLAIM_STAMP = '2026-07-29T12:00:00.000Z';
+// The stamp a SECOND run would write after resetStuckCompletingChallenges revoked our claim.
+const TAKEOVER_STAMP = '2026-07-29T12:11:00.000Z';
+
+function challengeRecordWith(
+  source: string,
+  rowMetadata: Record<string, unknown> = { completingClaimedAt: CLAIM_STAMP }
+) {
   return {
     id: 1,
     collectionId: 100,
     source,
     entryFee: 0,
     operationSpent: 0,
-    metadata: {},
+    metadata: rowMetadata,
     prizes: [
       { buzz: 500, points: 10 },
       { buzz: 250, points: 5 },
@@ -278,11 +286,21 @@ function challengeRecordWith(source: string) {
   };
 }
 
-function mockChallengeJudgeRow(source: string | undefined) {
+function mockChallengeJudgeRow(
+  source: string | undefined,
+  rowMetadata: Record<string, unknown> = { completingClaimedAt: CLAIM_STAMP }
+) {
   mockDbReadQueryRaw.mockResolvedValueOnce([
     source === undefined
       ? undefined
-      : { judgeId: null, judgingPrompt: null, eventId: null, source, judgingCategories: null },
+      : {
+          judgeId: null,
+          judgingPrompt: null,
+          eventId: null,
+          source,
+          judgingCategories: null,
+          metadata: rowMetadata,
+        },
   ]);
 }
 
@@ -298,10 +316,15 @@ function mockJudgedEntryRows(rows: Array<{ imageId: number; userId: number; user
   );
 }
 
-/** Drive the fresh two-entrant LLM path to a winners completion with 2 of 3 places filled. */
-async function runTwoWinnerCompletion(source: string) {
-  mockGetChallengeById.mockResolvedValue(challengeRecordWith(source));
-  mockChallengeJudgeRow(source);
+/**
+ * Drive the fresh two-entrant LLM path to a winners completion with 2 of 3 places filled.
+ * `rowStamp` is the claim stamp the challenge row carries when it is re-read at step 7 — pass
+ * TAKEOVER_STAMP to simulate this run's claim being revoked and re-taken mid-flight.
+ */
+async function runTwoWinnerCompletion(source: string, rowStamp: string | undefined = CLAIM_STAMP) {
+  const rowMetadata = rowStamp === undefined ? {} : { completingClaimedAt: rowStamp };
+  mockGetChallengeById.mockResolvedValue(challengeRecordWith(source, rowMetadata));
+  mockChallengeJudgeRow(source, rowMetadata);
   mockJudgedEntryRows([
     { imageId: 1, userId: 100, username: 'alice' },
     { imageId: 2, userId: 200, username: 'bob' },
@@ -331,7 +354,7 @@ beforeEach(() => {
   mockGetChallengeConfig.mockResolvedValue(BASE_CONFIG);
   mockGetJudgingConfig.mockResolvedValue(JUDGING_CONFIG);
   mockEndChallenge.mockResolvedValue(undefined);
-  mockClaimChallengeForCompletion.mockResolvedValue(true);
+  mockClaimChallengeForCompletion.mockResolvedValue(CLAIM_STAMP);
   mockGetExistingWinnersForRetry.mockResolvedValue([]);
   mockResolveEventContext.mockResolvedValue(undefined);
   mockUpdateChallengeStatus.mockResolvedValue(undefined);
@@ -429,7 +452,7 @@ describe('pickWinnersForChallenge — winners completion telemetry', () => {
 
 describe('pickWinnersForChallenge — emit placement is retry-safe', () => {
   it('emits nothing when the atomic completion claim is lost (challenge not Active)', async () => {
-    mockClaimChallengeForCompletion.mockResolvedValue(false);
+    mockClaimChallengeForCompletion.mockResolvedValue(null);
 
     await pickWinnersForChallenge(currentChallenge, BASE_CONFIG);
 
@@ -465,6 +488,55 @@ describe('pickWinnersForChallenge — emit placement is retry-safe', () => {
 
     expect(recordChallengeCompleted).not.toHaveBeenCalled();
     expect(recordChallengePrizePaidBuzz).not.toHaveBeenCalled();
+  });
+});
+
+// The ENTRY guard (claim never acquired) is covered above. This block covers the case that guard
+// cannot reach: the claim WAS acquired, then revoked mid-flight by resetStuckCompletingChallenges
+// (purely time-based — no liveness check, no ownership token) and re-taken by a second run, while
+// this run keeps executing. Both Completed writes are unconditional `UPDATE ... WHERE id = $1` with
+// no status predicate, so this run's write still lands; without a claim re-check it would also emit,
+// on top of the takeover run's emit. The re-checked claim stamp is what holds the counters to one
+// increment per completion.
+describe('pickWinnersForChallenge — claim REVOKED mid-flight (write still runs)', () => {
+  it('winners path: still performs the Completed write but does NOT emit', async () => {
+    await runTwoWinnerCompletion(ChallengeSource.System, TAKEOVER_STAMP);
+
+    // The unconditional write really did execute — this is the whole point of the case.
+    expect(mockDbWriteChallengeUpdate).toHaveBeenCalledTimes(1);
+    expect(mockDbWriteChallengeUpdate.mock.calls[0][0]).toMatchObject({
+      data: { status: 'Completed' },
+    });
+    // The payout ran too (it is retry-safe, so the takeover run re-issued the same one).
+    expect(mockCreateBuzzTransactionMany).toHaveBeenCalled();
+
+    // ...and neither counter moved, so the takeover run's own emits are the only ones.
+    expect(recordChallengeCompleted).not.toHaveBeenCalled();
+    expect(recordChallengePrizePaidBuzz).not.toHaveBeenCalled();
+    expect(await allSeries(COMPLETED_METRIC)).toHaveLength(0);
+    expect(await allSeries(PRIZE_PAID_METRIC)).toHaveLength(0);
+  });
+
+  it('zero-entries path: still marks Completed but does NOT emit', async () => {
+    mockChallengeJudgeRow(ChallengeSource.User, { completingClaimedAt: TAKEOVER_STAMP });
+    mockDbReadQueryRaw.mockResolvedValueOnce([]);
+
+    await pickWinnersForChallenge(currentChallenge, BASE_CONFIG);
+
+    expect(mockUpdateChallengeStatus).toHaveBeenCalledWith(1, 'Completed');
+    expect(recordChallengeCompleted).not.toHaveBeenCalled();
+    expect(await allSeries(COMPLETED_METRIC)).toHaveLength(0);
+  });
+
+  it('fails OPEN when the row carries no claim stamp at all (replica lag is not a takeover)', async () => {
+    // A missing stamp is indistinguishable from a replica that has not caught up with our own claim
+    // write, so the gate must NOT suppress here — it may only ever drop a duplicate.
+    await runTwoWinnerCompletion(ChallengeSource.System, undefined);
+
+    expect(recordChallengeCompleted).toHaveBeenCalledTimes(1);
+    const series = await seriesFor(COMPLETED_METRIC, { source: 'System' });
+    expect(series).toBeDefined();
+    expect(series?.value).toBe(1);
   });
 });
 

--- a/src/server/jobs/daily-challenge-processing.ts
+++ b/src/server/jobs/daily-challenge-processing.ts
@@ -64,6 +64,10 @@ import {
 } from '~/server/games/daily-challenge/generative-content';
 import { logToAxiom } from '~/server/logging/client';
 import {
+  recordChallengeCompleted,
+  recordChallengePrizePaidBuzz,
+} from '~/server/prom/challenge.metrics';
+import {
   challengeJudgingCategoriesSchema,
   parseChallengeMetadata,
   type ChallengeJudgingCategory,
@@ -1341,6 +1345,13 @@ export async function pickWinnersForChallenge(
         }
         await updateChallengeStatus(currentChallenge.challengeId, ChallengeStatus.Completed);
         log('Challenge marked as completed (no entries)');
+        // Telemetry: emit AFTER the Completed write, never before. `claimChallengeForCompletion`
+        // above only flips Active -> Completing, so a re-run over an already-Completed challenge
+        // fails the claim and returns early; a run that crashes before this write is reset
+        // Completing -> Active by resetStuckCompletingChallenges and retried, and it never got
+        // here to emit. Emitting post-write is therefore exactly-once per real completion.
+        // `source` reuses the already-fetched judge row — no extra (throwable) query.
+        recordChallengeCompleted({ source: challengeJudgeRow?.source });
         const freshChallenge = await getChallengeById(currentChallenge.challengeId);
         if (freshChallenge) await logChallengeSpendMetric(freshChallenge);
         return;
@@ -1514,6 +1525,25 @@ export async function pickWinnersForChallenge(
       },
     });
     log('Challenge status updated to Completed');
+
+    // Telemetry: emitted AFTER the Completed write, deliberately NOT next to the payout above.
+    // The payout is retry-safe by deterministic externalTransactionId, so a run that pays prizes
+    // and then crashes before this write is reset Completing -> Active and re-enters via the
+    // `existingWinners` branch, which re-issues the same (already-settled) payout. An emit at the
+    // payout site would count that Buzz twice; only this write happens exactly once per challenge
+    // (the claim above requires status=Active, which a Completed challenge can never satisfy).
+    // Amount mirrors endChallengeAndPickWinners: the sum of the prizes actually awarded to the
+    // winners paid on this completion (equal to each ChallengeWinner.buzzAwarded), not the
+    // configured prize table — a partial-winner completion pays less and must report less.
+    // `winnerBuzzType` is the currency buildWinnerPayoutTransactions actually paid in, and
+    // `challengeRecord` is already in scope — neither needs a new query.
+    recordChallengeCompleted({ source: challengeRecord?.source });
+    recordChallengePrizePaidBuzz({
+      source: challengeRecord?.source,
+      buzzType: winnerBuzzType,
+      amount: winningEntries.reduce((sum, e) => sum + (e.prize ?? 0), 0),
+    });
+
     if (challengeRecord) await logChallengeSpendMetric(challengeRecord);
 
     // 8. Send notifications to winners (non-critical, last)

--- a/src/server/jobs/daily-challenge-processing.ts
+++ b/src/server/jobs/daily-challenge-processing.ts
@@ -1199,6 +1199,27 @@ async function logChallengeSpendMetric(challenge: ChallengeDetails) {
 }
 
 /**
+ * True while `metadata.completingClaimedAt` still matches the stamp this run claimed with — i.e.
+ * nobody has revoked and re-taken this completion since. TELEMETRY GATE ONLY: it guards the two
+ * counter emits below and nothing else, so it can never change what is written or paid.
+ *
+ * Deliberately FAILS OPEN (returns true) when the row carries no stamp: `metadata` here is read
+ * through the replica pool, where "no stamp yet" is indistinguishable from "the replica has not
+ * caught up with our own claim write". Only a stamp that is present AND different is treated as
+ * proof of a takeover. Consequence, stated plainly: this can only ever suppress a duplicate emit,
+ * never manufacture one — and it does not make the emit exactly-once (see the emit sites).
+ */
+function claimStillHeld(
+  metadata: Record<string, unknown> | null | undefined,
+  claimedAt: string | null
+): boolean {
+  if (!claimedAt) return false;
+  const current = metadata?.completingClaimedAt;
+  if (typeof current !== 'string' || current.length === 0) return true;
+  return current === claimedAt;
+}
+
+/**
  * Pick winners for a single challenge.
  *
  * Operation order (race-condition safe):
@@ -1217,9 +1238,11 @@ export async function pickWinnersForChallenge(
 ) {
   log('Picking winners for challenge:', currentChallenge.challengeId);
 
-  // 1. Atomic claim — prevent duplicate processing
-  const claimed = await claimChallengeForCompletion(currentChallenge.challengeId);
-  if (!claimed) {
+  // 1. Atomic claim — prevent duplicate processing. `claimedAt` is the stamp written to
+  // metadata.completingClaimedAt; a later read showing a different stamp means this run's claim was
+  // revoked (resetStuckCompletingChallenges) and re-taken. Used to gate telemetry only.
+  const claimedAt = await claimChallengeForCompletion(currentChallenge.challengeId);
+  if (!claimedAt) {
     log('Challenge already claimed for completion, skipping:', currentChallenge.challengeId);
     return;
   }
@@ -1264,11 +1287,14 @@ export async function pickWinnersForChallenge(
               eventId: number | null;
               source: ChallengeSource;
               judgingCategories: unknown;
+              // Carried purely so the zero-entries emit below can re-check the claim stamp without
+              // a second round-trip — an extra COLUMN on a query that already runs, not a new read.
+              metadata: Record<string, unknown> | null;
             }
           | undefined
         ]
       >`
-        SELECT "judgeId", "judgingPrompt", "eventId", "source", "judgingCategories" FROM "Challenge"
+        SELECT "judgeId", "judgingPrompt", "eventId", "source", "judgingCategories", "metadata" FROM "Challenge"
         WHERE id = ${currentChallenge.challengeId}
         LIMIT 1
       `;
@@ -1345,13 +1371,24 @@ export async function pickWinnersForChallenge(
         }
         await updateChallengeStatus(currentChallenge.challengeId, ChallengeStatus.Completed);
         log('Challenge marked as completed (no entries)');
-        // Telemetry: emit AFTER the Completed write, never before. `claimChallengeForCompletion`
-        // above only flips Active -> Completing, so a re-run over an already-Completed challenge
-        // fails the claim and returns early; a run that crashes before this write is reset
-        // Completing -> Active by resetStuckCompletingChallenges and retried, and it never got
-        // here to emit. Emitting post-write is therefore exactly-once per real completion.
-        // `source` reuses the already-fetched judge row — no extra (throwable) query.
-        recordChallengeCompleted({ source: challengeJudgeRow?.source });
+        // Telemetry: emit AFTER the Completed write, never before, and only while this run still
+        // holds the claim it took at the top of the function.
+        //
+        // What that actually guarantees — stated precisely, because the write it follows does NOT
+        // provide exactly-once on its own: `updateChallengeStatus` is an unconditional
+        // `UPDATE ... WHERE id = $1` with no status predicate, and `resetStuckCompletingChallenges`
+        // is purely time-based, so a slow-but-alive run can be reset to Active, re-claimed by a
+        // second run, and STILL execute its own Completed write. The stamp check is what keeps that
+        // run from emitting a second time. Making the write itself conditional would be a real
+        // behaviour change and is deliberately out of scope.
+        //
+        // Residual window on THIS path: the freshest read of the row before the emit is the judge-row
+        // SELECT above, taken right after the claim — so a takeover during judging/refund is not
+        // observed here and would still double-count. The winners path below re-reads the row much
+        // later and is correspondingly tighter. Both fail open on a missing stamp (see claimStillHeld).
+        // `source`/`metadata` reuse the already-fetched judge row — no extra (throwable) query.
+        if (claimStillHeld(challengeJudgeRow?.metadata, claimedAt))
+          recordChallengeCompleted({ source: challengeJudgeRow?.source });
         const freshChallenge = await getChallengeById(currentChallenge.challengeId);
         if (freshChallenge) await logChallengeSpendMetric(freshChallenge);
         return;
@@ -1530,19 +1567,35 @@ export async function pickWinnersForChallenge(
     // The payout is retry-safe by deterministic externalTransactionId, so a run that pays prizes
     // and then crashes before this write is reset Completing -> Active and re-enters via the
     // `existingWinners` branch, which re-issues the same (already-settled) payout. An emit at the
-    // payout site would count that Buzz twice; only this write happens exactly once per challenge
-    // (the claim above requires status=Active, which a Completed challenge can never satisfy).
-    // Amount mirrors endChallengeAndPickWinners: the sum of the prizes actually awarded to the
-    // winners paid on this completion (equal to each ChallengeWinner.buzzAwarded), not the
-    // configured prize table — a partial-winner completion pays less and must report less.
-    // `winnerBuzzType` is the currency buildWinnerPayoutTransactions actually paid in, and
-    // `challengeRecord` is already in scope — neither needs a new query.
-    recordChallengeCompleted({ source: challengeRecord?.source });
-    recordChallengePrizePaidBuzz({
-      source: challengeRecord?.source,
-      buzzType: winnerBuzzType,
-      amount: winningEntries.reduce((sum, e) => sum + (e.prize ?? 0), 0),
-    });
+    // payout site would count that Buzz twice.
+    //
+    // Post-write placement alone is NOT exactly-once, and the code does not pretend otherwise: this
+    // Completed write is an unconditional `UPDATE ... WHERE id = $1` (no status predicate), and
+    // `resetStuckCompletingChallenges` revokes a Completing claim on elapsed time alone with no
+    // liveness check — so a slow-but-alive run can lose its claim to a second run and still run this
+    // write. The `claimStillHeld` gate is what stops that run from emitting a second time:
+    // `challengeRecord` was read at step 7, AFTER judging and both payout steps, so a takeover during
+    // the long part of the run is observed here. Residual window: a takeover between that read and
+    // this line is not covered — closing it would mean a conditional write, i.e. a real behaviour
+    // change, which is out of scope. The gate fails open on a missing stamp (see claimStillHeld), so
+    // it can only ever suppress a duplicate, never a first emit under normal operation.
+    //
+    // Amount mirrors endChallengeAndPickWinners: the sum of the prizes SUBMITTED for the winners
+    // paid on this completion (equal to each ChallengeWinner.buzzAwarded), not the configured prize
+    // table — a partial-winner completion pays less and must report less. Note this is prize Buzz
+    // ATTEMPTED, not confirmed-settled: `createBuzzTransactionMany` silently drops any non-success,
+    // non-conflict result (e.g. insufficientFunds) from both of its result arrays, so a leg that did
+    // not move money is invisible here and is still counted. `winnerBuzzType` is the currency
+    // buildWinnerPayoutTransactions actually paid in, and `challengeRecord` is already in scope —
+    // neither needs a new query.
+    if (claimStillHeld(challengeRecord?.metadata, claimedAt)) {
+      recordChallengeCompleted({ source: challengeRecord?.source });
+      recordChallengePrizePaidBuzz({
+        source: challengeRecord?.source,
+        buzzType: winnerBuzzType,
+        amount: winningEntries.reduce((sum, e) => sum + (e.prize ?? 0), 0),
+      });
+    }
 
     if (challengeRecord) await logChallengeSpendMetric(challengeRecord);
 

--- a/src/server/prom/challenge.metrics.ts
+++ b/src/server/prom/challenge.metrics.ts
@@ -104,9 +104,14 @@ const entryFeesBuzzCounter = registerCounterWithLabels({
   help: 'Buzz charged for challenge entry fees (house + pool legs, first-time charges only), by source and buzzType',
   labelNames: ['source', 'buzzType'] as const,
 });
+// ATTEMPTED, not settled — do not read this as "Buzz that reached winners". The emit sites sum the
+// winner prizes SUBMITTED to `createBuzzTransactionMany`, which silently drops any non-success,
+// non-conflict result (notably insufficientFunds) from both of its result arrays: the money did not
+// move and is otherwise invisible. There is no per-leg settlement signal to filter on, so the sum is
+// counted as submitted. Treat a gap vs the Buzz ledger as expected, not as an instrumentation bug.
 const prizePaidBuzzCounter = registerCounterWithLabels({
   name: 'challenge_prize_paid_buzz_total',
-  help: 'Buzz paid out to challenge winners (winner prizes), by source and buzzType',
+  help: 'Buzz submitted for challenge winner-prize payouts (ATTEMPTED, not confirmed-settled: non-success legs such as insufficientFunds are dropped upstream and still counted), by source and buzzType',
   labelNames: ['source', 'buzzType'] as const,
 });
 const operationSpentBuzzCounter = registerCounterWithLabels({

--- a/src/server/services/__tests__/challenge-completion-emit-boundary.service.test.ts
+++ b/src/server/services/__tests__/challenge-completion-emit-boundary.service.test.ts
@@ -1,0 +1,403 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import client from 'prom-client';
+
+// Regression coverage for the MOD -> JOB completion boundary.
+//
+// The bug this locks down: `endChallengeAndPickWinners` (the moderator/tRPC path) used to emit
+// `challenge_prize_paid_buzz_total` right next to the winner payout, BEFORE its Completed write.
+// Everything between those two points is awaited and throwable (the entry-prize
+// `createBuzzTransactionMany`, its `createNotification`, `logToAxiom`) and the catch re-throws, so
+// the challenge is left in `Completing`. `resetStuckCompletingChallenges` then flips it back to
+// `Active`, the scheduled job claims it, takes the `existingWinners` branch, re-issues the same
+// deterministic-id (already-settled) payout, writes Completed and emits. One payout of Buzz, two
+// increments of the counter.
+//
+// This file runs that exact interleaving end to end — real service path, then real job path, one
+// shared prom-client registry — and pins the counter to a SINGLE increment. Moving the service
+// emit back next to the payout must fail it.
+//
+// Both modules are imported for real; everything touching DB / LLM / buzz / notifications is mocked
+// at the module boundary, so the mock set below is the union of what each module needs.
+
+const {
+  mockDbReadQueryRaw,
+  mockDbWriteQueryRaw,
+  mockDbWriteExecuteRaw,
+  mockDbWriteChallengeUpdate,
+  mockDbWriteChallengeFindUnique,
+  mockClaimChallengeForCompletion,
+  mockGetChallengeById,
+  mockGetExistingWinnersForRetry,
+  mockCreateBuzzTransactionMany,
+  mockCreateNotification,
+  mockGetChallengeBuzzType,
+  mockEndChallenge,
+  mockUpdateChallengeStatus,
+  mockSendChallengeResultsNotification,
+} = vi.hoisted(() => ({
+  mockDbReadQueryRaw: vi.fn(),
+  mockDbWriteQueryRaw: vi.fn(),
+  mockDbWriteExecuteRaw: vi.fn().mockResolvedValue(1),
+  mockDbWriteChallengeUpdate: vi.fn().mockResolvedValue(undefined),
+  mockDbWriteChallengeFindUnique: vi.fn().mockResolvedValue({
+    prizePool: 0,
+    prizeDistribution: null,
+  }),
+  mockClaimChallengeForCompletion: vi.fn(),
+  mockGetChallengeById: vi.fn(),
+  mockGetExistingWinnersForRetry: vi.fn(),
+  mockCreateBuzzTransactionMany: vi.fn().mockResolvedValue(undefined),
+  mockCreateNotification: vi.fn().mockResolvedValue(undefined),
+  mockGetChallengeBuzzType: vi.fn().mockResolvedValue('green'),
+  mockEndChallenge: vi.fn().mockResolvedValue(undefined),
+  mockUpdateChallengeStatus: vi.fn().mockResolvedValue(undefined),
+  mockSendChallengeResultsNotification: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('~/server/db/client', () => ({
+  dbRead: {
+    $queryRaw: mockDbReadQueryRaw,
+    challenge: { findUnique: vi.fn() },
+  },
+  dbWrite: {
+    $queryRaw: mockDbWriteQueryRaw,
+    $executeRaw: mockDbWriteExecuteRaw,
+    challenge: { update: mockDbWriteChallengeUpdate, findUnique: mockDbWriteChallengeFindUnique },
+  },
+}));
+
+vi.mock('~/server/events', () => ({
+  eventEngine: { processEngagement: vi.fn().mockResolvedValue(undefined) },
+}));
+
+vi.mock('~/server/flipt/client', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('~/server/flipt/client')>();
+  return { ...actual, isFlipt: vi.fn().mockResolvedValue(false) };
+});
+
+// Spy THROUGH to the real record helpers so assertions read the real registry series.
+vi.mock('~/server/prom/challenge.metrics', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('~/server/prom/challenge.metrics')>();
+  return {
+    ...actual,
+    recordChallengeCompleted: vi.fn(actual.recordChallengeCompleted),
+    recordChallengePrizePaidBuzz: vi.fn(actual.recordChallengePrizePaidBuzz),
+  };
+});
+
+vi.mock('~/server/games/daily-challenge/daily-challenge.utils', async () => {
+  const real = await import('~/server/games/daily-challenge/daily-challenge-scoring');
+  return {
+    SCORE_WEIGHTS: real.SCORE_WEIGHTS,
+    calculateWeightedScore: real.calculateWeightedScore,
+    challengeToLegacyFormat: vi.fn(),
+    deriveChallengeNsfwLevel: vi.fn(() => 1),
+    endChallenge: mockEndChallenge,
+    getActiveChallenges: vi.fn(),
+    getChallengeConfig: vi.fn().mockResolvedValue({ defaultJudgeId: 1, defaultJudge: null }),
+    getJudgingConfig: vi.fn().mockResolvedValue({
+      judgeId: 1,
+      userId: 999,
+      sourceCollectionId: null,
+      prompts: {},
+      reviewTemplate: null,
+    }),
+    getUpcomingSystemChallenge: vi.fn(),
+    setChallengeConfig: vi.fn(),
+    refreshDefaultJudgeCache: vi.fn(),
+    parseJudgeScore: vi.fn(),
+  };
+});
+
+vi.mock('~/server/games/daily-challenge/challenge-helpers', () => ({
+  buildChallengeModerationText: vi.fn(),
+  claimChallengeForCompletion: mockClaimChallengeForCompletion,
+  closeChallengeCollection: vi.fn().mockResolvedValue(undefined),
+  computeDynamicPool: vi.fn(),
+  createChallengeRecord: vi.fn(),
+  createChallengeWinner: vi.fn().mockResolvedValue(1),
+  distributePrizes: vi.fn(),
+  getChallengeById: mockGetChallengeById,
+  getChallengeEntryCount: vi.fn().mockResolvedValue(0),
+  getChallengeWinners: vi.fn().mockResolvedValue([]),
+  getExistingWinnersForRetry: mockGetExistingWinnersForRetry,
+  incrementOperationSpent: vi.fn().mockResolvedValue(undefined),
+  resolveEventContext: vi.fn().mockResolvedValue(undefined),
+  setChallengeActive: vi.fn(),
+  updateChallengeStatus: mockUpdateChallengeStatus,
+}));
+
+vi.mock('~/server/games/daily-challenge/challenge-rewards', () => ({
+  distributeParticipationPrizes: vi.fn().mockResolvedValue([]),
+  promoteChallengeEntries: vi.fn().mockResolvedValue(0),
+}));
+
+vi.mock('~/server/games/daily-challenge/challenge-funding', () => ({
+  buildWinnerPayoutTransactions: vi.fn().mockReturnValue([]),
+  chargeInitialPrize: vi.fn(),
+  getChallengeBuzzType: mockGetChallengeBuzzType,
+  refundUserChallengeFunds: vi.fn().mockResolvedValue({ refundedEntries: 0 }),
+  reportPoolFundingShortfall: vi.fn(),
+}));
+
+vi.mock('~/server/games/daily-challenge/generative-content', () => ({
+  estimateBuzzCost: vi.fn().mockReturnValue(0),
+  generateArticle: vi.fn(),
+  generateCollectionDetails: vi.fn(),
+  generateReview: vi.fn(),
+  generateThemeElements: vi.fn(),
+  generateWinners: vi.fn(),
+}));
+
+vi.mock('~/server/services/buzz.service', () => ({
+  createBuzzTransaction: vi.fn(),
+  createBuzzTransactionMany: mockCreateBuzzTransactionMany,
+  getTransactionByExternalId: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock('~/server/services/notification.service', () => ({
+  createNotification: mockCreateNotification,
+}));
+
+vi.mock('~/server/services/challenge-engagement.service', () => ({
+  sendChallengeResultsNotification: mockSendChallengeResultsNotification,
+}));
+
+vi.mock('~/server/services/commentsv2.service', () => ({
+  upsertComment: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('~/server/services/reaction.service', () => ({
+  toggleReaction: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('~/server/services/image.service', () => ({
+  createImage: vi.fn(),
+  enqueueImageIngestion: vi.fn(),
+  imagesForModelVersionsCache: { bust: vi.fn() },
+}));
+
+vi.mock('~/server/services/user.service', () => ({
+  amIBlockedByUser: vi.fn().mockResolvedValue(false),
+  getCosmeticsForUsers: vi.fn(() => ({})),
+  getProfilePicturesForUsers: vi.fn(() => ({})),
+}));
+
+vi.mock('~/server/services/challenge-eligibility.service', () => ({
+  assertCanCreateUserChallenge: vi.fn(),
+  assertUserAccountInGoodStanding: vi.fn(),
+}));
+
+vi.mock('~/server/integrations/moderation', () => ({
+  extModeration: {},
+}));
+
+vi.mock('~/server/search-index', () => ({
+  collectionsSearchIndex: { queueUpdate: vi.fn() },
+}));
+
+vi.mock('~/utils/logging', () => ({
+  createLogger: vi.fn(() => vi.fn()),
+}));
+
+const { endChallengeAndPickWinners } = await import('~/server/services/challenge.service');
+const { pickWinnersForChallenge } = await import('~/server/jobs/daily-challenge-processing');
+const { ChallengeSource, ChallengeStatus } = await import('~/shared/utils/prisma/enums');
+const { recordChallengeCompleted, recordChallengePrizePaidBuzz, __resetChallengeMetricsForTest } =
+  await import('~/server/prom/challenge.metrics');
+
+const COMPLETED_METRIC = 'civitai_app_challenge_completed_total';
+const PRIZE_PAID_METRIC = 'civitai_app_challenge_prize_paid_buzz_total';
+
+type Series = { value: number; labels: Record<string, string> };
+
+/**
+ * Read a single series off the REAL default registry. Returns `undefined` for an absent series
+ * rather than defaulting to 0, so "never emitted" can never be mistaken for "emitted zero".
+ */
+async function seriesFor(
+  name: string,
+  labels: Record<string, string>
+): Promise<Series | undefined> {
+  const metric = client.register.getSingleMetric(name) as unknown as {
+    get: () => Promise<{ values: Series[] }>;
+  };
+  const data = await metric.get();
+  return data.values.find((v) =>
+    Object.entries(labels).every(([key, val]) => v.labels[key] === val)
+  );
+}
+
+// The stamp the JOB's claim writes to metadata.completingClaimedAt once the reset frees the row.
+const JOB_CLAIM_STAMP = '2026-07-29T12:20:00.000Z';
+
+// The single winner, worth 500 green Buzz. Both runs pay this same winner: the service run pays it
+// and dies, the job run re-issues the identical deterministic-id transaction. 500 Buzz moved ONCE,
+// so the counter must read 500 — 1000 is the double count this file exists to catch.
+const WINNER_PRIZE_BUZZ = 500;
+const EXISTING_WINNERS = [
+  { userId: 1, imageId: 10, place: 1, buzzAwarded: WINNER_PRIZE_BUZZ, reason: 'best' },
+];
+
+const challengeRow = {
+  id: 1,
+  title: 'Boundary Challenge',
+  status: ChallengeStatus.Active,
+  collectionId: 100,
+  source: ChallengeSource.System,
+  buzzType: 'green',
+  prizes: [{ buzz: WINNER_PRIZE_BUZZ, points: 0 }],
+  entryPrize: { buzz: 50, points: 0 },
+  entryPrizeRequirement: 1,
+  prizePool: 0,
+  prizeDistribution: null,
+  operationSpent: 0,
+  operationBudget: 0,
+  entryFee: 0,
+  judgeId: null,
+  judgingPrompt: null,
+  judgingCategories: null,
+  eventId: null,
+  createdById: 999,
+  metadata: { completingClaimedAt: JOB_CLAIM_STAMP },
+};
+
+// The shape the scheduled job is handed for the same challenge.
+const jobChallenge = {
+  challengeId: 1,
+  type: 'daily',
+  date: new Date(),
+  theme: 'test',
+  modelId: 1,
+  modelVersionIds: [1],
+  collectionId: 100,
+  title: 'Boundary Challenge',
+  invitation: '',
+  coverUrl: '',
+  prizes: [{ buzz: WINNER_PRIZE_BUZZ, points: 0 }],
+  entryPrizeRequirement: 1,
+  entryPrize: { buzz: 0, points: 0 },
+} as never;
+
+const JOB_CONFIG = {
+  challengeType: 'world-morph',
+  challengeCollectionId: 1,
+  judgedTagId: 11,
+  reviewMeTagId: 12,
+  prizes: [],
+  entryPrizeRequirement: 1,
+  entryPrize: { buzz: 0, points: 0 },
+  reviewAmount: { min: 6, max: 12 },
+  maxScoredPerUser: 5,
+  finalReviewAmount: 10,
+  resourceCosmeticId: null,
+  articleTagId: 1,
+  defaultJudgeId: 1,
+  defaultJudge: null,
+} as never;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  __resetChallengeMetricsForTest();
+  mockDbWriteExecuteRaw.mockResolvedValue(1);
+  mockDbWriteChallengeUpdate.mockResolvedValue(undefined);
+  mockDbWriteChallengeFindUnique.mockResolvedValue({ prizePool: 0, prizeDistribution: null });
+  mockGetChallengeById.mockResolvedValue(challengeRow);
+  mockGetExistingWinnersForRetry.mockResolvedValue(EXISTING_WINNERS);
+  mockCreateBuzzTransactionMany.mockResolvedValue(undefined);
+  mockCreateNotification.mockResolvedValue(undefined);
+  mockGetChallengeBuzzType.mockResolvedValue('green');
+  mockEndChallenge.mockResolvedValue(undefined);
+  mockUpdateChallengeStatus.mockResolvedValue(undefined);
+  mockSendChallengeResultsNotification.mockResolvedValue(undefined);
+  mockClaimChallengeForCompletion.mockResolvedValue(JOB_CLAIM_STAMP);
+});
+
+describe('mod -> job completion boundary — prize Buzz is counted exactly once', () => {
+  it('a moderator run that pays winners then throws before its Completed write emits nothing', async () => {
+    // The entry-participation prize block runs (user 2 earned it, user 1 is the winner) and its
+    // notification throws — i.e. a failure strictly BETWEEN the winner payout and the Completed
+    // write, which is the whole hazard window.
+    mockDbReadQueryRaw.mockResolvedValueOnce([{ userId: 1 }, { userId: 2 }]);
+    mockCreateNotification.mockRejectedValueOnce(new Error('notification service down'));
+
+    await expect(endChallengeAndPickWinners(1)).rejects.toThrow('notification service down');
+
+    // The winner payout DID happen...
+    expect(mockCreateBuzzTransactionMany).toHaveBeenCalled();
+    // ...the Completed write did NOT (challenge is left in Completing for recovery)...
+    expect(mockDbWriteChallengeUpdate).not.toHaveBeenCalled();
+    // ...so nothing may have been counted yet. This is the assertion the old emit placement broke.
+    expect(recordChallengePrizePaidBuzz).not.toHaveBeenCalled();
+    expect(recordChallengeCompleted).not.toHaveBeenCalled();
+    expect(
+      await seriesFor(PRIZE_PAID_METRIC, { source: 'System', buzzType: 'green' })
+    ).toBeUndefined();
+  });
+
+  it('the job retry after that failure yields exactly ONE prize-Buzz increment for one payout', async () => {
+    // --- Phase 1: the moderator run pays the winner, then dies before marking Completed.
+    mockDbReadQueryRaw.mockResolvedValueOnce([{ userId: 1 }, { userId: 2 }]);
+    mockCreateNotification.mockRejectedValueOnce(new Error('notification service down'));
+    await expect(endChallengeAndPickWinners(1)).rejects.toThrow('notification service down');
+
+    // --- Phase 2: resetStuckCompletingChallenges flips Completing -> Active, the scheduled job
+    // claims it, reuses the stored winners and re-issues the identical (already-settled) payout.
+    await pickWinnersForChallenge(jobChallenge, JOB_CONFIG);
+
+    // The payout call really was made twice across the two runs — one settlement, two attempts.
+    expect(mockCreateBuzzTransactionMany.mock.calls.length).toBeGreaterThanOrEqual(2);
+    // The job's Completed write landed.
+    expect(mockDbWriteChallengeUpdate).toHaveBeenCalledTimes(1);
+    expect(mockDbWriteChallengeUpdate.mock.calls[0][0]).toMatchObject({
+      data: { status: ChallengeStatus.Completed },
+    });
+
+    // ...and the Buzz was counted ONCE.
+    expect(recordChallengePrizePaidBuzz).toHaveBeenCalledTimes(1);
+    expect(recordChallengeCompleted).toHaveBeenCalledTimes(1);
+
+    const prizeSeries = await seriesFor(PRIZE_PAID_METRIC, { source: 'System', buzzType: 'green' });
+    expect(prizeSeries).toBeDefined();
+    expect(prizeSeries?.value).toBe(WINNER_PRIZE_BUZZ);
+
+    const completedSeries = await seriesFor(COMPLETED_METRIC, { source: 'System' });
+    expect(completedSeries).toBeDefined();
+    expect(completedSeries?.value).toBe(1);
+  });
+
+  it('a clean moderator completion still emits both counters exactly once', async () => {
+    // Guards the fix from the opposite direction: moving the emits after the Completed write must
+    // not have dropped them from the happy path.
+    mockDbReadQueryRaw.mockResolvedValueOnce([{ userId: 1 }]);
+
+    await expect(endChallengeAndPickWinners(1)).resolves.toMatchObject({ success: true });
+
+    expect(mockDbWriteChallengeUpdate).toHaveBeenCalledTimes(1);
+    expect(recordChallengeCompleted).toHaveBeenCalledTimes(1);
+    expect(recordChallengePrizePaidBuzz).toHaveBeenCalledTimes(1);
+
+    const prizeSeries = await seriesFor(PRIZE_PAID_METRIC, { source: 'System', buzzType: 'green' });
+    expect(prizeSeries).toBeDefined();
+    expect(prizeSeries?.value).toBe(WINNER_PRIZE_BUZZ);
+  });
+
+  it('a winner-notification failure no longer desyncs the two counters on the moderator path', async () => {
+    // Pre-fix the completed emit sat AFTER the winner-notification loop while the prize emit had
+    // already fired, so a throw there left prize_paid counted and completed NOT counted for a
+    // challenge that is permanently Completed (status is already written, so the time-based
+    // Completing reset can never retry it). Both emits now anchor to the same successful write.
+    mockDbReadQueryRaw.mockResolvedValueOnce([{ userId: 1 }]);
+    mockCreateNotification.mockRejectedValueOnce(new Error('winner notification failed'));
+
+    await expect(endChallengeAndPickWinners(1)).rejects.toThrow('winner notification failed');
+
+    expect(mockDbWriteChallengeUpdate).toHaveBeenCalledTimes(1);
+    expect(recordChallengeCompleted).toHaveBeenCalledTimes(1);
+    expect(recordChallengePrizePaidBuzz).toHaveBeenCalledTimes(1);
+
+    const completedSeries = await seriesFor(COMPLETED_METRIC, { source: 'System' });
+    expect(completedSeries).toBeDefined();
+    expect(completedSeries?.value).toBe(1);
+  });
+});

--- a/src/server/services/challenge.service.ts
+++ b/src/server/services/challenge.service.ts
@@ -2607,14 +2607,6 @@ export async function endChallengeAndPickWinners(challengeId: number) {
     );
     log('Prizes sent');
 
-    // Economy telemetry: total winner-prize Buzz paid this completion (paid in the challenge's
-    // stored currency). Entry-participation prizes below are a separate blue-Buzz reward, not counted.
-    recordChallengePrizePaidBuzz({
-      source: challenge.source,
-      buzzType: challenge.buzzType,
-      amount: winningEntries.reduce((sum, e) => sum + (e.prize ?? 0), 0),
-    });
-
     // Send entry participation prizes to all eligible users
     // Hoisted so it's still in scope for sendChallengeResultsNotification's excludeUserIds below,
     // even though it's only populated inside the conditional (participation prizes are optional).
@@ -2708,6 +2700,38 @@ export async function endChallengeAndPickWinners(challengeId: number) {
     });
     log('Challenge status updated to Completed');
 
+    // Economy + funnel telemetry, emitted TOGETHER immediately after the Completed write.
+    //
+    // Why not at the payout call above (where the prize emit used to live): everything between the
+    // payout and this write is awaited and throwable (entry-prize `createBuzzTransactionMany`,
+    // `createNotification`, `logToAxiom`) and the catch below re-throws, leaving the challenge in
+    // `Completing`. `resetStuckCompletingChallenges` then flips it back to `Active`, the scheduled
+    // job claims it, takes the `existingWinners` branch and re-issues the same (already-settled,
+    // deterministic-id) payout before writing Completed and emitting. An emit at the payout site
+    // would count that Buzz once here and again there — one payout, two increments.
+    //
+    // Why the completed emit moved up here too (it used to sit after the winner-notification loop):
+    // a throw in that loop suppressed the completed emit while the prize emit had already fired, so
+    // the two counters silently diverged on this path. The challenge IS completed once this write
+    // lands — the notification loop is explicitly the non-critical tail — so anchoring both emits to
+    // the same successful write is the placement that makes them consistent by construction, and it
+    // matches the scheduled-job path. Observable consequence, deliberately accepted:
+    // `challenge_completed_total` now also counts a completion whose winner notifications threw.
+    // That completion is real and permanent (status is already Completed, so the time-based
+    // Completing reset can never retry it and the count would otherwise be lost forever), and both
+    // helpers are never-throw no-ops for business logic, so nothing outside telemetry changes.
+    //
+    // Prize amount is Buzz ATTEMPTED for winner prizes, not confirmed-settled:
+    // `createBuzzTransactionMany` silently drops any non-success, non-conflict result (e.g.
+    // insufficientFunds) from both result arrays, so a leg that never moved money is invisible here
+    // and is still counted. Entry-participation prizes are a separate blue-Buzz reward, not counted.
+    recordChallengeCompleted({ source: challenge.source });
+    recordChallengePrizePaidBuzz({
+      source: challenge.source,
+      buzzType: challenge.buzzType,
+      amount: winningEntries.reduce((sum, e) => sum + (e.prize ?? 0), 0),
+    });
+
     // Notify winners (non-critical, last)
     for (const entry of winningEntries) {
       await createNotification({
@@ -2733,7 +2757,6 @@ export async function endChallengeAndPickWinners(challengeId: number) {
     });
     log('Winners notified');
 
-    recordChallengeCompleted({ source: challenge.source });
     return { success: true, winnersCount: winningEntries.length };
   } catch (error) {
     // On failure, challenge stays in 'Completing' for recovery to handle


### PR DESCRIPTION
## The gap

`challenge_completed_total` and `challenge_prize_paid_buzz_total` are defined and wired, but neither has ever emitted a single series — while challenges have been completing and prizes have been paid the whole time.

Both counters were only ever emitted from `endChallengeAndPickWinners` (`challenge.service.ts`), whose sole caller is the `challenge.router.ts` mutation — i.e. the manual/moderator path. The **scheduled daily-challenge job** completes challenges through `pickWinnersForChallenge` (`src/server/jobs/daily-challenge-processing.ts`), which contained zero `recordChallenge*` calls and never imported `~/server/prom/challenge.metrics`. That job has two completion sites:

- the zero-entries completion (`updateChallengeStatus(..., Completed)`)
- the winners completion (the direct `status: ChallengeStatus.Completed` update after payouts)

Neither was counted, so in practice the two counters measured only the rare manual path and read as permanently empty.

## The change

Additive emits at both job completion sites. **No behaviour change** — the job is *not* refactored to call `endChallengeAndPickWinners`; that would move prize payouts and refunds onto a different code path, which is out of scope here.

Fixing the placement then turned up a pre-existing double-count on the moderator path and a false invariant in the comments; both are addressed below.

## Why the emits sit where they do

`pickWinnersForChallenge` has the same atomic guard the service path has — `claimChallengeForCompletion` flips `Active -> Completing` and returns falsy otherwise, so a re-run over an already-`Completed` challenge returns before reaching any emit. But that is not the whole story: `resetStuckCompletingChallenges` deliberately resets a stalled `Completing` challenge back to `Active` after a timeout so it can be retried, and the retry re-enters through the `existingWinners` branch and **re-issues the same payout** (safe, because `buildWinnerPayoutTransactions` uses deterministic external transaction ids).

So a run that pays prizes and then dies before the `Completed` write will legitimately execute the payout call twice while only ever moving Buzz once. Emitting next to the payout would double-count that Buzz. Both emits are therefore placed **after** the `Completed` status write.

### Moderator path: the same trap, already live

`endChallengeAndPickWinners` emitted `challenge_prize_paid_buzz_total` **at the payout site**, before its own `Completed` write. Between the two are awaited, throwable steps (the entry-prize `createBuzzTransactionMany`, its `createNotification`, `logToAxiom`) and the catch re-throws, leaving the challenge in `Completing`. Interleaving: a moderator ends the challenge, winners are paid, the prize emit fires, a later step throws, the challenge is reset to `Active`, the job claims it, takes the `existingWinners` branch, re-issues the same already-settled payout, writes `Completed` and emits again. One payout, **two** increments. That emit has moved to after the `Completed` write.

`recordChallengeCompleted` moved with it. It used to sit *after* the winner-notification loop, so a throw in that loop suppressed the completed emit while the prize emit had already fired — the two counters silently diverged on this path. The challenge *is* completed once the write lands (the notification loop is explicitly the non-critical tail), so anchoring both emits to the same successful write makes them consistent by construction and matches the job path.

Observable consequence, deliberately accepted: `challenge_completed_total` now also counts a completion whose winner notifications threw. That completion is real and permanent — status is already `Completed`, so the time-based `Completing` reset can never retry it, and the count would otherwise be lost forever. Both record helpers are never-throw no-ops for business logic, so nothing outside telemetry changes.

## What "after the Completed write" does and does not guarantee

Post-write placement alone is **not** exactly-once, and the code no longer claims it is. Both `Completed` writes are unconditional `UPDATE ... WHERE id = $1` with no status predicate, and `resetStuckCompletingChallenges` is purely time-based — no liveness check, no ownership token — so it can revoke the claim of a run that is still executing. That run keeps going and its unconditional write still lands, on top of the takeover run's.

`claimChallengeForCompletion` already stamps `metadata.completingClaimedAt`. It now **returns** that stamp, and both job emits are gated on the row's current stamp still matching the one this run claimed with:

- **winners path** — reuses the challenge record already fetched at step 7, i.e. read *after* judging and both payout steps, so a takeover during the long part of the run is observed.
- **zero-entries path** — `metadata` was added as a **column** to the judge-row `SELECT` that already runs. No extra query, no extra `await`. This read happens right after the claim, so it covers a much narrower window than the winners path; that limit is stated in the comment rather than papered over.

The gate **fails open** when the row carries no stamp: `metadata` is read through the replica pool, where "no stamp yet" is indistinguishable from "the replica has not caught up with our own claim write". Only a stamp that is present *and* different is treated as a takeover, so the gate can only ever suppress a duplicate, never drop a first emit.

The `Completed` writes are deliberately left unconditional — making them conditional would be a real behaviour change, not a telemetry fix. The comments now state the guarantee the code actually provides, including the residual window on each path.

This is a latent defect, not an actively-firing one: the `challenge-completion` job's duration histogram currently sits entirely under 0.5s against a 5-minute lock self-release and a 10-minute reset threshold, so the concurrency window is not open today. Job duration is not a guarantee, hence the fix.

## Prize amount basis — this counter measures ATTEMPTED, not settled

`winningEntries.reduce((sum, e) => sum + (e.prize ?? 0), 0)` — the same expression both paths use. That is the Buzz **submitted** for the winners paid on this completion (equal to each `ChallengeWinner.buzzAwarded`), **not** the configured prize table: a partial-winner completion pays less than the table and must report less.

It is *not* confirmed-settled Buzz. `createBuzzTransactionMany` silently drops any non-success, non-conflict result (notably `insufficientFunds`) from **both** of its result arrays — its own comment notes the money did not move and it is otherwise invisible — and the emit sums the full winner set regardless. There is no per-leg settlement signal to filter on, so the metric's `help` text and both code comments have been corrected to say "attempted". A gap against the Buzz ledger is expected, not an instrumentation bug. The measurement itself is unchanged.

`buzzType` is the currency the payout was actually built in. `source` is taken from values already in scope (the judge row on the zero-entries path, the already-fetched challenge record on the winners path) so no new — throwable — read is introduced into a payout path, and every label goes through the existing enum-bound normalizers.

## Tests

`src/server/jobs/__tests__/challenge-completion-metrics.test.ts` (12 tests) and the new `src/server/services/__tests__/challenge-completion-emit-boundary.service.test.ts` (4 tests). Both spy **through** to the real record helpers, so each assertion is backed by the spy call *and* the real `prom-client` series — a missing emit surfaces as an *absent series*, never as a defaulted `0`.

Job suite covers: both completion sites; the retry/`existingWinners` path; a zero-winner completion emitting no payout; a lost claim emitting nothing; a failed `Completed` write emitting nothing; emit ordering after the `Completed` write; an unrecognized `source` normalizing to `unknown`; **a claim revoked mid-flight on each path, with the unconditional `Completed` write still executing, emitting nothing**; and the deliberate fail-open when the row carries no stamp.

The boundary suite runs the real moderator path and then the real job path over one shared registry: a payout followed by a throw before the `Completed` write emits nothing, and the job retry after it yields **exactly one** prize-Buzz increment for one settlement. It also pins the clean completion (both counters once) and the winner-notification failure that used to desync them.

Mutation-checked — each mutation applied to the source, the suite re-run, then restored:

| mutation | result |
|---|---|
| move the moderator prize emit back to the payout site | 2 failed / 2 passed — `recordChallengePrizePaidBuzz` "expected to be called 1 times, but got 2 times" |
| move the moderator completed emit back after the notification loop | 1 failed / 3 passed — completed "expected to be called 1 times, but got 0 times" while prize was 1 |
| remove the winners-path claim gate | 1 failed / 11 passed |
| remove the zero-entries claim gate | 1 failed / 11 passed |
| make the claim gate always suppress | 7 failed / 5 passed |

Restored: 16/16 pass. Surrounding suites (`jobs`, `services`, `games/daily-challenge`, `notifications`) 183 files / 2041 tests green; the 2 reported errors are the pre-existing local Prisma query-engine load failures in `dedupe-official-uploads.test.ts` and `bitdex-model3did.test.ts`, reproduced identically with these changes stashed. `NODE_OPTIONS=--max_old_space_size=8192 npx tsc --noEmit` exits 0.
