### PR TITLE
fix(downloads): stop reporting an access denial as "you need to log in"

### DIFF
--- a/src/pages/api/download/models/[modelVersionId].ts
+++ b/src/pages/api/download/models/[modelVersionId].ts
@@ -133,6 +133,17 @@ export default PublicEndpoint(
           });
         else return res.redirect(`/model-versions/${modelVersionId}`);
       }
+      if (fileResult.status === 'no-access') {
+        if (!isBrowser)
+          return res.status(403).json({
+            error: 'Forbidden',
+            message: 'You do not have access to download this file',
+          });
+        else return res.redirect(`/model-versions/${modelVersionId}`);
+      }
+      // Only reachable without a session — `getFileForModelVersion` reports a signed-in user's
+      // missing grant as `no-access`, so sending someone to /login here can no longer loop them
+      // back to the page they started on.
       if (fileResult.status === 'unauthorized') {
         if (!isBrowser)
           return res.status(401).json({

--- a/src/pages/api/download/models/[modelVersionId].ts
+++ b/src/pages/api/download/models/[modelVersionId].ts
@@ -133,14 +133,12 @@ export default PublicEndpoint(
           });
         else return res.redirect(`/model-versions/${modelVersionId}`);
       }
-      if (fileResult.status === 'no-access') {
-        if (!isBrowser)
-          return res.status(403).json({
-            error: 'Forbidden',
-            message: 'You do not have access to download this file',
-          });
-        else return res.redirect(`/model-versions/${modelVersionId}`);
-      }
+      // Answer in place rather than redirecting. `early-access` can bounce to the version page
+      // because that page renders a purchase CTA, but a plain missing grant has nothing actionable
+      // there — the redirect just lands the user back where they clicked, which is the exact
+      // "download button does nothing" symptom this status exists to eliminate.
+      if (fileResult.status === 'no-access')
+        return errorResponse(403, 'You do not have access to download this file');
       // Only reachable without a session — `getFileForModelVersion` reports a signed-in user's
       // missing grant as `no-access`, so sending someone to /login here can no longer loop them
       // back to the page they started on.

--- a/src/pages/api/v1/model-files/[id]/tensor-metadata.ts
+++ b/src/pages/api/v1/model-files/[id]/tensor-metadata.ts
@@ -143,6 +143,7 @@ function getStatusCode(
 ) {
   switch (status) {
     case 'unauthorized':
+    case 'no-access':
     case 'downloads-disabled':
     case 'early-access':
       return 403;
@@ -162,6 +163,8 @@ function getErrorMessage(
   switch (status) {
     case 'unauthorized':
       return 'Unauthorized';
+    case 'no-access':
+      return 'You do not have access to this file';
     case 'downloads-disabled':
       return 'Downloads are disabled for this file';
     case 'early-access':

--- a/src/server/jobs/process-ending-early-access.ts
+++ b/src/server/jobs/process-ending-early-access.ts
@@ -33,9 +33,33 @@ export const processingEngingEarlyAccess = createJob(
       RETURNING mv.id, mv."modelId"
     `;
 
-    if (republished.length > 0) {
-      const updatedIds = republished.map((v) => v.id);
-      const modelIds = uniq(republished.map((v) => v.modelId));
+    // Reconciliation pass. The republish above is a ONE-SHOT: its `mv.publishedAt < pa.endsAt`
+    // guard stops matching the moment publishedAt is bumped, so anything that resets availability
+    // afterwards strands the version at 'EarlyAccess' forever and the version silently stops being
+    // downloadable for everyone but moderators. Sweep for expired gates that are still flagged,
+    // regardless of the lastRun window, so a single lost update self-corrects on the next tick.
+    //
+    // Deliberately does NOT touch publishedAt — these versions were already republished, and
+    // re-bumping it would resurface them as "New" and re-fire anything keyed on publishedAt.
+    // Driven off PaidAccess (small, indexed on (entityType, endsAt)) rather than a scan of
+    // ModelVersion for availability.
+    const reconciled = await dbWrite.$queryRaw<{ id: number; modelId: number }[]>`
+      UPDATE "ModelVersion" mv
+      SET "availability" = 'Public'
+      FROM "PaidAccess" pa
+      WHERE pa."entityType" = 'ModelVersion'
+        AND pa."entityId" = mv.id
+        AND pa."endsAt" IS NOT NULL
+        AND pa."endsAt" <= NOW()
+        AND mv."availability" = 'EarlyAccess'
+        AND mv.status = 'Published'
+      RETURNING mv.id, mv."modelId"
+    `;
+
+    const updated = [...republished, ...reconciled];
+    if (updated.length > 0) {
+      const updatedIds = uniq(updated.map((v) => v.id));
+      const modelIds = uniq(updated.map((v) => v.modelId));
       await bustMvCache(updatedIds, modelIds);
       await dataForModelsCache.refresh(modelIds);
       await modelsSearchIndex.queueUpdate(

--- a/src/server/services/__tests__/file-download-lookup.test.ts
+++ b/src/server/services/__tests__/file-download-lookup.test.ts
@@ -76,10 +76,11 @@ vi.mock('~/server/services/bountyEntry.service', () => ({
   getBountyEntryFilteredFiles: vi.fn(),
 }));
 
-// getFileForModelVersion sources the EA gate from getPaidAccess; return no gate
-// so the lookup runs unblocked (matches the pre-cutover column defaults here).
+// getFileForModelVersion sources the EA gate from getPaidAccess. Defaults to no gate so the lookup
+// runs unblocked; the access-denial tests below drive an active gate through it.
+const getPaidAccessMock = vi.fn();
 vi.mock('~/server/services/paid-access.service', () => ({
-  getPaidAccess: vi.fn(async () => ({})),
+  getPaidAccess: getPaidAccessMock,
 }));
 
 // Control whether the delivery URL resolves. A throw here is the
@@ -151,8 +152,10 @@ describe('getFileForModelVersion — orphan model relation + unresolvable URL', 
     recommendedResourceFindFirst.mockReset();
     hasEntityAccessMock.mockReset();
     resolveDownloadUrlMock.mockReset();
+    getPaidAccessMock.mockReset();
 
     hasEntityAccessMock.mockResolvedValue([{ hasAccess: true, permissions: 0 }]);
+    getPaidAccessMock.mockResolvedValue({});
     modelFileFindMany.mockResolvedValue([aFile]);
   });
 
@@ -217,5 +220,48 @@ describe('getFileForModelVersion — orphan model relation + unresolvable URL', 
 
     expect(result.status).toBe('success');
     if (result.status === 'success') expect(result.url).toBe('https://cdn.example.com/signed');
+  });
+
+  // --- Access denial must not masquerade as "you need to log in" ----------
+  // A signed-in user who lacks a grant used to get `unauthorized`, which the download endpoint
+  // answers with a redirect to /login. Already having a session, they were bounced straight back to
+  // the page they came from — the download button appeared to do nothing at all.
+  it('returns no-access (→403), NOT unauthorized (→/login), for a signed-in user without a grant', async () => {
+    modelVersionFindFirst.mockResolvedValue(publishedModelVersion());
+    hasEntityAccessMock.mockResolvedValue([{ hasAccess: false, permissions: -1 }]);
+
+    const result = await getFileForModelVersion({
+      modelVersionId: 1,
+      user: { id: 1234, isModerator: false },
+    });
+
+    expect(result.status).toBe('no-access');
+    expect(result.status).not.toBe('unauthorized');
+  });
+
+  it('still returns unauthorized (→/login) when there is no session at all', async () => {
+    modelVersionFindFirst.mockResolvedValue(publishedModelVersion());
+    hasEntityAccessMock.mockResolvedValue([{ hasAccess: false, permissions: -1 }]);
+
+    const result = await getFileForModelVersion({ modelVersionId: 1 });
+
+    // No session → a login redirect is the correct answer; the split must not swallow it.
+    expect(result.status).toBe('unauthorized');
+  });
+
+  it('routes an active paid gate to early-access (→purchase) rather than a bare denial', async () => {
+    modelVersionFindFirst.mockResolvedValue(publishedModelVersion());
+    const endsAt = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000);
+    getPaidAccessMock.mockResolvedValue({ 1: { endsAt, terms: { download: { price: 100 } } } });
+    // Has an access record, but not the EarlyAccessDownload bit (e.g. paid for generation only).
+    hasEntityAccessMock.mockResolvedValue([{ hasAccess: true, permissions: 0 }]);
+
+    const result = await getFileForModelVersion({
+      modelVersionId: 1,
+      user: { id: 1234, isModerator: false },
+    });
+
+    expect(result.status).toBe('early-access');
+    if (result.status === 'early-access') expect(result.details.deadline).toEqual(endsAt);
   });
 });

--- a/src/server/services/file.service.ts
+++ b/src/server/services/file.service.ts
@@ -262,18 +262,22 @@ export const getFileForModelVersion = async ({
   const requireAuth = modelVersion.requireAuth || !env.UNAUTHENTICATED_DOWNLOAD;
   if (requireAuth && !userId) return { status: 'unauthorized' };
 
-  if (!(versionAccess?.hasAccess ?? true)) {
-    return { status: 'unauthorized' };
-  }
-
-  // Check the early access scenario:
+  // The paid gate is checked BEFORE the generic access check so a gated version routes the user to
+  // the purchase flow; the other order collapses it into a bare denial and loses the reason.
   if (
     inEarlyAccess &&
-    (versionAccess.permissions & EntityAccessPermission.EarlyAccessDownload) == 0 &&
+    ((versionAccess?.permissions ?? 0) & EntityAccessPermission.EarlyAccessDownload) == 0 &&
     !isMod &&
     !isOwner
   ) {
     return { status: 'early-access', details: { deadline } };
+  }
+
+  // `unauthorized` means "no session" and callers answer it with a login redirect. A signed-in user
+  // who lacks a grant must NOT get that — they bounce off /login straight back to the page they came
+  // from, which reads as the download button doing nothing at all.
+  if (!(versionAccess?.hasAccess ?? true)) {
+    return { status: userId ? 'no-access' : 'unauthorized' };
   }
 
   // Get the correct file
@@ -442,6 +446,7 @@ type ModelVersionFileResult =
         | 'not-found'
         | 'resolve-failed'
         | 'unauthorized'
+        | 'no-access'
         | 'archived'
         | 'downloads-disabled'
         | 'error';


### PR DESCRIPTION
Steps 3-4 of [CU-868khn0hq](https://app.clickup.com/t/8459928/868khn0hq). Steps 1-2 (the trigger drop + backfill) are already live in prod.

**Access denial no longer masquerades as a login prompt.** A signed-in user without a grant was answered with `unauthorized`, which the download endpoint redirects to `/login` — already having a session, they bounced right back to the page they came from and the download button looked dead. `unauthorized` now means "no session"; a new `no-access` covers "signed in, no grant" and answers 403 / routes to the version page. The paid gate is checked before the generic access check so gated versions keep routing to purchase.

**`process-ending-early-access` is now self-healing.** Its republish is a one-shot guarded by `publishedAt < endsAt`, so anything that resets availability afterwards strands a version at `EarlyAccess` permanently. A reconciliation pass sweeps expired gates that are still flagged, independent of the lastRun window.

No migration. Tests added for the denial split; typecheck clean.