### PR TITLE
feat(apps): bigger store covers + larger CTAs + a branded, animated app launch

### DIFF
--- a/src/components/AppBlocks/PageBlockHost.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHost.browser.test.tsx
@@ -4,6 +4,11 @@ import { page } from 'vitest/browser';
 import { useDialogStore } from '~/components/Dialog/dialogStore';
 // `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
 import { renderWithProviders } from '../../../test/component-setup';
+// Type-only (erased at runtime, so it can't defeat vi.mock hoisting) — lets the
+// `importOriginal` generic below be written without an inline `import()` type,
+// which the repo's `consistent-type-imports` rule forbids (this file was the
+// last lint error in src/components/AppBlocks).
+import type * as MantineNotifications from '@mantine/notifications';
 
 // PageBlockHost wires the money-path workflow bridge AND the storage bridge,
 // which call `trpc.blocks.*.useMutation()`, `trpc.apps.storage.*.useMutation()`,
@@ -21,7 +26,7 @@ vi.mock('~/hooks/useCurrentUser', () => ({ useCurrentUser: () => null }));
 // mounting the full Notifications provider. Preserve the module's other exports.
 const showNotificationSpy = vi.fn();
 vi.mock('@mantine/notifications', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('@mantine/notifications')>();
+  const actual = await importOriginal<typeof MantineNotifications>();
   return { ...actual, showNotification: (args: unknown) => showNotificationSpy(args) };
 });
 
@@ -571,7 +576,15 @@ describe('PageBlockHost Retry (Task: re-attempt load from terminal fallback)', (
     expect(page.getByTestId('app-page-fallback').query()).toBeNull();
     const el = page.getByTestId('app-page-iframe').element() as HTMLIFrameElement;
     expect(el.getAttribute('data-block-ready')).toBe('true');
-    expect(page.getByTestId('app-page-loading').query()).toBeNull();
+    // The launch veil now CROSS-FADES out over LAUNCH_REVEAL_MS once the block is
+    // ready (the "subtly animated" launch experience) rather than disappearing in
+    // the same commit, so poll for its removal instead of reading it synchronously.
+    // It is still gated structurally — every terminal state unmounts it with the
+    // whole iframe branch — so this can't mask a stuck spinner; the terminal-path
+    // tests above (and PageBlockHostLaunchReveal.browser.test.tsx) pin that.
+    await vi.waitFor(() => {
+      expect(page.getByTestId('app-page-loading').query()).toBeNull();
+    });
   });
 
   test('failure-after-retry: a second fatal error shows the fallback again (no timer leak / stuck state)', async () => {
@@ -715,6 +728,17 @@ describe('PageBlockHost block render/impression (Analytics Phase 2)', () => {
   // Analytics Phase 2 now emits via the /api/track/block-render BEACON
   // (sendBlockRender → fetch), not a tRPC mutation. Spy on global fetch and
   // assert the beacon fires exactly once at BLOCK_READY (and never on re-render).
+  //
+  // 🔴 THIS DESCRIBE IS ALSO THE BATCHING-INDEPENDENCE GUARD for the beacon, and
+  // that is why it must keep rendering the REAL host with REAL hooks (no
+  // `@mantine/hooks` mock in this file). The beacon used to fire from inside the
+  // BLOCK_READY handler behind a flag set by the `setStatus` UPDATER, which only
+  // works while React can evaluate that updater EAGERLY — i.e. while nothing else
+  // is queued on the fiber. `useReducedMotion` (added by the launch-reveal work)
+  // commits its value in a post-mount effect, which is exactly such a pending
+  // update, and it made the impression drop 5/5 runs. The beacon now keys off the
+  // COMMITTED `status`. Mutation-verified: restoring the in-handler `acked`
+  // pattern fails the first test below, deterministically.
   let fetchSpy: ReturnType<typeof vi.spyOn>;
 
   // Only the block-render beacon goes through fetch in this test; resolve OK.

--- a/src/components/AppBlocks/PageBlockHost.tsx
+++ b/src/components/AppBlocks/PageBlockHost.tsx
@@ -144,7 +144,7 @@ const TOKEN_WAIT_TIMEOUT_MS = 15_000;
  * a `next/dynamic` ChatWindow chunk), so importing it here would pull a new
  * animation runtime into the run-page bundle for one cross-fade.
  */
-const LAUNCH_REVEAL_MS = 260;
+export const LAUNCH_REVEAL_MS = 260;
 
 // Hard cap on a block-suggested Buy-Buzz amount (mirrors IframeHost) — clamps a
 // malicious/huge `suggestedAmount` so the spend modal can't be pre-seeded with
@@ -305,9 +305,16 @@ export function PageBlockHost({
   }, [status]);
 
   // LAUNCH REVEAL — `prefers-reduced-motion: reduce` collapses the whole thing to
-  // 0ms: no transitions are emitted and the overlay is dropped in the same commit
-  // the block turns ready (identical to the pre-animation behaviour).
-  const reduceMotion = useReducedMotion();
+  // 0ms: no transition is ever emitted, and the overlay is dropped on the effect
+  // tick right after the block turns ready rather than being held for a fade.
+  // (Not literally the same commit as the status flip — but with `opacity: 0` and
+  // no transition it is already invisible, so there is nothing to perceive.)
+  // `initialValue: true` is deliberate and fail-SAFE: `useMediaQuery` commits the
+  // real value in a post-mount effect, so render 1 has to assume something.
+  // Assuming "reduced" means a viewer who opted out of motion never gets a single
+  // frame with a transition/transform applied; a viewer who didn't loses nothing,
+  // because the reveal only runs on BLOCK_READY, long after that first commit.
+  const reduceMotion = useReducedMotion(true);
   const revealMs = reduceMotion ? 0 : LAUNCH_REVEAL_MS;
   // The branded launch overlay stays mounted for ONE fade-out after BLOCK_READY,
   // then unmounts. It is only ever rendered inside the `showIframe` branch, so
@@ -2400,6 +2407,13 @@ export function PageBlockHost({
     return off;
   }, [onMessage, send, resolveWildcardPackMutation, reviewMode]);
 
+  // ONE sanitized label for the whole launch surface — the avatar initial, the
+  // Loader's accessible name and the visible "Starting …" copy all derive from
+  // this, so they can never disagree about the fallback. Same sanitizer the
+  // visible chrome uses (anti-spoof: strips control/bidi/zalgo from a
+  // publisher-controlled name); 'app' when nothing legible remains.
+  const launchName = sanitizeAppChromeName(appName) || 'app';
+
   const showIframe = status === 'loading' || status === 'ready';
   const isReady = status === 'ready';
 
@@ -2588,14 +2602,18 @@ export function PageBlockHost({
                   legible remains. */}
               <Stack align="center" gap="sm">
                 <Avatar radius="md" size={56} alt="" aria-hidden>
-                  {(sanitizeAppChromeName(appName) || blockId).charAt(0).toUpperCase()}
+                  {/* `Array.from(...)[0]` not `charAt(0)`: charAt splits a
+                      surrogate pair, so an emoji-leading app name would render a
+                      broken half-glyph. Falls back to the SAME string as the
+                      visible copy below so the two can't disagree. */}
+                  {(Array.from(launchName)[0] ?? '').toUpperCase()}
                 </Avatar>
                 <Loader
                   size="sm"
-                  aria-label={`Loading ${sanitizeAppChromeName(appName) || 'app'}`}
+                  aria-label={`Loading ${launchName}`}
                 />
                 <Text size="sm" c="dimmed">
-                  {`Starting ${sanitizeAppChromeName(appName) || 'app'}…`}
+                  {`Starting ${launchName}…`}
                 </Text>
               </Stack>
             </Center>

--- a/src/components/AppBlocks/PageBlockHost.tsx
+++ b/src/components/AppBlocks/PageBlockHost.tsx
@@ -1,4 +1,5 @@
-import { Box, Center, Loader } from '@mantine/core';
+import { Avatar, Box, Center, Loader, Stack, Text } from '@mantine/core';
+import { useReducedMotion } from '@mantine/hooks';
 import dynamic from 'next/dynamic';
 import { useRouter } from 'next/router';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
@@ -121,6 +122,29 @@ function storageErrorMessage(err: unknown): string {
 
 const BLOCK_READY_TIMEOUT_MS = 10_000;
 const TOKEN_WAIT_TIMEOUT_MS = 15_000;
+
+/**
+ * LAUNCH REVEAL (feedback #3: "launching an app should feel magical … subtly
+ * animated"). How long the branded launch overlay cross-fades out while the block
+ * fades in, once the block signals BLOCK_READY.
+ *
+ * 🔴 This is a PURELY COSMETIC, ready-path-only window. It can never delay, mask
+ * or swallow an error, because every terminal state (`timeout` / `fatal` /
+ * `no_token` / `error`) flips `showIframe` to false, which unmounts the entire
+ * iframe+overlay branch and renders `BlockFallback` in the SAME commit — the
+ * fade-out timer below is simply cleaned up. Nothing about the fallback render is
+ * gated on animation state. (Regression-tested: see the "the reveal must NOT gate
+ * the error path" cases in PageBlockHostLaunchReveal.browser.test.tsx, which
+ * assert every terminal state still reaches BlockFallback — promptly, and still
+ * wrapped in AppBlockChrome.)
+ *
+ * Implemented with a plain CSS opacity/transform transition rather than the
+ * `motion` package: `motion` is NOT in the `/apps` route graph today (its only
+ * importers are `src/components/Chat/*` + `src/utils/lazy-motion.ts`, reached via
+ * a `next/dynamic` ChatWindow chunk), so importing it here would pull a new
+ * animation runtime into the run-page bundle for one cross-fade.
+ */
+const LAUNCH_REVEAL_MS = 260;
 
 // Hard cap on a block-suggested Buy-Buzz amount (mirrors IframeHost) — clamps a
 // malicious/huge `suggestedAmount` so the spend modal can't be pre-seeded with
@@ -279,6 +303,30 @@ export function PageBlockHost({
   useEffect(() => {
     statusRef.current = status;
   }, [status]);
+
+  // LAUNCH REVEAL — `prefers-reduced-motion: reduce` collapses the whole thing to
+  // 0ms: no transitions are emitted and the overlay is dropped in the same commit
+  // the block turns ready (identical to the pre-animation behaviour).
+  const reduceMotion = useReducedMotion();
+  const revealMs = reduceMotion ? 0 : LAUNCH_REVEAL_MS;
+  // The branded launch overlay stays mounted for ONE fade-out after BLOCK_READY,
+  // then unmounts. It is only ever rendered inside the `showIframe` branch, so
+  // every terminal state removes it structurally regardless of this flag — this
+  // state exists solely to give the ready path something to fade.
+  const [overlayMounted, setOverlayMounted] = useState<boolean>(true);
+  useEffect(() => {
+    if (status === 'loading') {
+      setOverlayMounted(true);
+      return;
+    }
+    // Terminal states (or reduced motion) → drop it immediately, no timer.
+    if (status !== 'ready' || revealMs === 0) {
+      setOverlayMounted(false);
+      return;
+    }
+    const t = setTimeout(() => setOverlayMounted(false), revealMs);
+    return () => clearTimeout(t);
+  }, [status, revealMs]);
 
   const expectedOrigin = useMemo(() => {
     try {
@@ -455,30 +503,45 @@ export function PageBlockHost({
   // BLOCK_READY → ready.
   useEffect(() => {
     const off = onMessage<unknown>('BLOCK_READY', () => {
-      let acked = false;
-      setStatus((current) => {
-        if (current === 'loading') {
-          acked = true;
-          return 'ready';
-        }
-        return current;
-      });
-      if (acked) {
-        controllerRef.current?.notifyReady();
-        // Analytics Phase 2: one render/impression per mount. The `acked` gate
-        // flips on the loading→ready transition; the emit-once ref makes it
-        // deterministic even if duplicate acks land before React commits 'ready'
-        // (so it fires exactly once per mount and never on re-render).
-        // Fire-and-forget beacon — failures are a no-op (and a harmless no-op
-        // until the `blockRenders` ClickHouse table exists; see PR body).
-        if (!blockRenderEmittedRef.current) {
-          blockRenderEmittedRef.current = true;
-          sendBlockRender({ appBlockId, blockInstanceId, slotId: 'app.page' });
-        }
-      }
+      setStatus((current) => (current === 'loading' ? 'ready' : current));
+      // Block acked — stop re-posting BLOCK_INIT and cancel the readiness
+      // timeout. Called UNCONDITIONALLY (not behind a "did this ack win the
+      // transition" flag): `notifyReady()` is documented-idempotent
+      // (IframeInitController.notifyReady → stop(), a no-op once stopped), and
+      // making it unconditional removes the only remaining dependence on
+      // observing the updater's side effect (see the note below).
+      controllerRef.current?.notifyReady();
     });
     return off;
-  }, [onMessage, appBlockId, blockInstanceId]);
+  }, [onMessage]);
+
+  // Analytics Phase 2 — render/impression beacon: ONE per host mount, fired on
+  // the loading→ready transition and mutually exclusive with the render-FAILURE
+  // beacon below (they share `blockRenderEmittedRef`).
+  //
+  // 🔴 WHY THIS IS AN EFFECT AND NOT A SIDE EFFECT INSIDE THE BLOCK_READY
+  // HANDLER (a real bug this fixes, not a refactor): it used to live inside the
+  // handler behind an `acked` flag that the `setStatus` UPDATER set —
+  //     let acked = false;
+  //     setStatus((current) => { if (current === 'loading') { acked = true; … } });
+  //     if (acked) { …sendBlockRender… }
+  // — which only works because React *eagerly* evaluates an updater when the
+  // fiber has no other pending update. As soon as ANY unrelated state update is
+  // already queued on this component when BLOCK_READY lands, React skips that
+  // eager path, the updater runs later during render, `acked` is still false at
+  // the `if`, and **the impression is silently dropped**. The host has plenty of
+  // such updates in flight in the real world (token rotation, the image-scan
+  // poller list, the launch-reveal state) — this was latent analytics loss, and
+  // was reproduced deterministically the moment the launch-reveal work added one
+  // more post-mount state update. Keying off the COMMITTED `status` is immune to
+  // batching. Mirrors the failure-beacon effect immediately below.
+  useEffect(() => {
+    if (status !== 'ready') return;
+    if (blockRenderEmittedRef.current) return;
+    blockRenderEmittedRef.current = true;
+    // Fire-and-forget beacon — failures are a no-op.
+    sendBlockRender({ appBlockId, blockInstanceId, slotId: 'app.page' });
+  }, [status, appBlockId, blockInstanceId]);
 
   // BLOCK_ERROR{fatal:true} → fatal.
   useEffect(() => {
@@ -2473,26 +2536,68 @@ export function PageBlockHost({
               width: '100%',
               border: 0,
               pointerEvents: isReady ? 'auto' : 'none',
+              // LAUNCH REVEAL: the block fades + settles up as it becomes ready,
+              // cross-fading with the branded overlay below. Under reduced motion
+              // `revealMs` is 0 → no transition is emitted and the opacity flip is
+              // instantaneous (the pre-animation behaviour).
+              opacity: isReady ? 1 : 0,
+              transform: isReady || revealMs === 0 ? 'none' : 'translateY(8px)',
+              transition:
+                revealMs === 0
+                  ? undefined
+                  : `opacity ${revealMs}ms ease-out, transform ${revealMs}ms ease-out`,
             }}
           />
-          {status === 'loading' && (
+          {overlayMounted && (
             <Center
               data-testid="app-page-loading"
               // Announce the loading state on the REGION, not just the graphic:
               // role="status" + aria-busy mark the overlay container as a live
               // busy region so a screen reader announces "loading" when it
               // appears (the bare <Loader> below only exposes a labeled graphic).
-              role="status"
-              aria-busy={true}
-              aria-live="polite"
-              style={{ position: 'absolute', inset: 0, background: 'var(--mantine-color-body)' }}
+              // Once the block IS ready the overlay is a purely decorative
+              // fading-out veil, so it drops the live-region roles and hides from
+              // the a11y tree instead of announcing a stale "loading".
+              {...(isReady
+                ? { 'aria-hidden': true }
+                : { role: 'status', 'aria-busy': true, 'aria-live': 'polite' as const })}
+              // Observable reveal state (DevTools / manual QA): 'false' while the
+              // block is still handshaking, 'true' for the one cross-fade after
+              // BLOCK_READY, then the node unmounts.
+              data-revealing={isReady ? 'true' : 'false'}
+              style={{
+                position: 'absolute',
+                inset: 0,
+                background: 'var(--mantine-color-body)',
+                // Never intercept clicks: during loading the iframe is already
+                // pointer-inert, and during the fade-out the block is live
+                // underneath — the veil must not swallow that first click.
+                pointerEvents: 'none',
+                opacity: isReady ? 0 : 1,
+                transition: revealMs === 0 ? undefined : `opacity ${revealMs}ms ease-out`,
+              }}
             >
-              {/* Run the publisher-controlled appName through the SAME sanitizer
-                  the visible chrome uses (sanitizeAppChromeName) so the accessible
-                  name a screen reader reads can't carry control/bidi/zalgo
-                  spoofing — consistency with AppBlockChrome, not a new gate. Falls
-                  back to 'app' when nothing legible remains. */}
-              <Loader aria-label={`Loading ${sanitizeAppChromeName(appName) || 'app'}`} />
+              {/* Branded launch state. The app's initial in the same Avatar
+                  treatment the store card uses gives a visual through-line from
+                  card → run page, so opening an app feels continuous rather than
+                  landing on a bare spinner. Purely presentational: every string is
+                  run through the SAME sanitizer the visible chrome uses
+                  (sanitizeAppChromeName) so the publisher-controlled appName can't
+                  carry control/bidi/zalgo spoofing here either — consistency with
+                  AppBlockChrome, not a new gate. Falls back to 'app' when nothing
+                  legible remains. */}
+              <Stack align="center" gap="sm">
+                <Avatar radius="md" size={56} alt="" aria-hidden>
+                  {(sanitizeAppChromeName(appName) || blockId).charAt(0).toUpperCase()}
+                </Avatar>
+                <Loader
+                  size="sm"
+                  aria-label={`Loading ${sanitizeAppChromeName(appName) || 'app'}`}
+                />
+                <Text size="sm" c="dimmed">
+                  {`Starting ${sanitizeAppChromeName(appName) || 'app'}…`}
+                </Text>
+              </Stack>
             </Center>
           )}
         </Box>

--- a/src/components/AppBlocks/PageBlockHostLaunchReveal.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostLaunchReveal.browser.test.tsx
@@ -1,0 +1,334 @@
+import { describe, expect, test, vi, beforeEach } from 'vitest';
+import { page } from 'vitest/browser';
+// `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
+import { renderWithProviders } from '../../../test/component-setup';
+// Type-only (erased at runtime, so it can't defeat vi.mock hoisting) — lets the
+// `importOriginal` generic below be written without an inline `import()` type,
+// which the repo's `consistent-type-imports` rule forbids.
+import type * as MantineHooks from '@mantine/hooks';
+
+/**
+ * W10 run-page LAUNCH EXPERIENCE (product feedback #3: "launching an app should
+ * feel magical and be a delightful, intuitive, simple and subtly animated
+ * experience").
+ *
+ * What shipped: a BRANDED launch state (the app's initial + name, not a bare
+ * spinner) that cross-fades out as the block fades/settles in on BLOCK_READY.
+ * Implemented with plain CSS transitions (the `motion` package is not in the
+ * `/apps` route graph — see the LAUNCH_REVEAL_MS comment in PageBlockHost).
+ *
+ * 🔴 THE INVARIANT THESE TESTS EXIST FOR: the reveal must never delay, mask or
+ * swallow an error. The host has FOUR terminal states — `timeout` (the ~10s
+ * BLOCK_READY timer), `fatal` (BLOCK_ERROR), `no_token` (the ~15s token wait) and
+ * `error` (a hard mint failure) — and each must still surface promptly AND stay
+ * wrapped in `AppBlockChrome` (the FRAME-1 invariant: a block must not be able to
+ * shed its provenance chrome by never sending BLOCK_READY). The sharpest case is
+ * an error that lands DURING the reveal window; it has its own test below.
+ *
+ * `prefers-reduced-motion: reduce` must instant-ify everything: no transition is
+ * emitted on either the veil or the iframe.
+ */
+
+const mocks = vi.hoisted(() => ({ reduceMotion: false }));
+
+// The reveal reads `useReducedMotion()`; drive it deterministically instead of
+// depending on the headless browser's media state. Spread the real module so
+// every OTHER @mantine/hooks consumer in PageBlockHost's graph is untouched.
+vi.mock('@mantine/hooks', async (importOriginal) => {
+  const actual = await importOriginal<typeof MantineHooks>();
+  return { ...actual, useReducedMotion: () => mocks.reduceMotion };
+});
+
+// AppBlockChrome calls useCurrentUser() for the platform-nav moderator gate; this
+// suite renders the real host without a CivitaiSessionProvider.
+vi.mock('~/hooks/useCurrentUser', () => ({ useCurrentUser: () => null }));
+
+// PageBlockHost wires the money-path workflow bridge AND the storage bridge at
+// render, which need the tRPC Context the network-free scaffold doesn't provide.
+// Mirrors PageBlockHost.browser.test.tsx's stub — inert here.
+vi.mock('~/utils/trpc', () => ({
+  // FeatureFlagsProvider (in PageBlockHost's render graph) statically imports
+  // this; a wholesale module mock MUST re-declare it or the ESM link fails.
+  setTrpcBatchingEnabled: vi.fn(),
+  trpc: {
+    generation: { resolveWildcardPack: { useMutation: () => ({ mutateAsync: vi.fn() }) } },
+    blocks: {
+      submitWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      getMyBuzzBalance: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      getMyViewer: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      getMyBuzzTransactions: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      getMyBuzzAccounts: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      getMyDailyCompensation: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      estimateWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      pollWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      cancelWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      queryAppWorkflows: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      cancelAppWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      publishGenerationOutputs: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      getImagesByIds: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+    },
+    apps: {
+      shared: {
+        append: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        update: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        vote: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        unvote: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        withdraw: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      },
+      storage: {
+        set: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        delete: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      },
+    },
+    useUtils: () => ({
+      apps: {
+        shared: {
+          list: { fetch: vi.fn() },
+          getCount: { fetch: vi.fn() },
+          getCounts: { fetch: vi.fn() },
+        },
+        storage: { get: { fetch: vi.fn() }, list: { fetch: vi.fn() }, getQuota: { fetch: vi.fn() } },
+      },
+    }),
+  },
+}));
+
+// eslint-disable-next-line import/first
+import { PageBlockHost } from '~/components/AppBlocks/PageBlockHost';
+
+// Same-origin so trustTier='internal' yields a pinned (non-opaque) transport
+// whose expectedOrigin equals this frame's origin — see PageBlockHost.browser.test.
+const SAME_ORIGIN_SRC = `${window.location.origin}/`;
+
+const baseProps = {
+  appBlockId: 'apb_test',
+  blockId: 'my-page-app',
+  appId: 'app_test',
+  blockInstanceId: 'page_apb_test',
+  appName: 'Budgeted Generator',
+  iframeSrc: SAME_ORIGIN_SRC,
+  sandbox: 'allow-scripts',
+  trustTier: 'internal' as const,
+  slug: 'my-page-app',
+  token: 'tok_abc',
+  expiresAt: new Date(Date.now() + 15 * 60_000).toISOString(),
+  declaredScopes: ['apps:storage:read'],
+  missingScopes: [] as string[],
+  needsConsent: false,
+  tokenError: false,
+  viewer: { id: 42, username: 'tester' },
+  theme: 'light' as const,
+};
+
+function postFromBlock(type: string, payload?: unknown) {
+  const iframeEl = page.getByTestId('app-page-iframe').element() as HTMLIFrameElement;
+  const cw = iframeEl.contentWindow;
+  if (!cw) throw new Error('iframe contentWindow missing');
+  window.dispatchEvent(
+    new MessageEvent('message', { data: { type, payload }, origin: window.location.origin, source: cw })
+  );
+}
+
+async function driveToReady() {
+  await vi.waitFor(() => {
+    const el = page.getByTestId('app-page-iframe').element() as HTMLIFrameElement;
+    if (!el.contentWindow) throw new Error('not mounted yet');
+  });
+  await vi.waitFor(() => {
+    postFromBlock('BLOCK_READY', {});
+    const el = page.getByTestId('app-page-iframe').element() as HTMLIFrameElement;
+    if (el.getAttribute('data-block-ready') !== 'true') throw new Error('not ready yet');
+  });
+}
+
+const iframeEl = () => page.getByTestId('app-page-iframe').element() as HTMLIFrameElement;
+const overlayEl = () => page.getByTestId('app-page-loading').element() as HTMLElement;
+
+beforeEach(() => {
+  mocks.reduceMotion = false;
+});
+
+describe('PageBlockHost launch reveal — branded loading', () => {
+  test('the launch state is BRANDED (app initial + name), not a bare spinner', async () => {
+    renderWithProviders(<PageBlockHost {...baseProps} onConsentGranted={vi.fn()} />);
+
+    await expect.element(page.getByTestId('app-page-loading')).toBeInTheDocument();
+    // The app's own name, echoing the store card the user just came from.
+    await expect.element(page.getByText('Starting Budgeted Generator…')).toBeInTheDocument();
+    // Its initial, in the same Avatar treatment the store card uses.
+    await expect.element(page.getByText('B', { exact: true })).toBeInTheDocument();
+    // The existing a11y contract is preserved: a busy live REGION, plus a
+    // labelled graphic.
+    const overlay = overlayEl();
+    expect(overlay.getAttribute('role')).toBe('status');
+    expect(overlay.getAttribute('aria-busy')).toBe('true');
+    await expect.element(page.getByLabelText('Loading Budgeted Generator')).toBeInTheDocument();
+  });
+
+  test('the branded copy runs appName through the chrome sanitizer (control/bidi stripped)', async () => {
+    // Same anti-spoof posture as the existing aria-label test: the publisher
+    // controls appName, so every appName-derived string on this surface — now
+    // including the VISIBLE "Starting …" line and the avatar initial — goes
+    // through sanitizeAppChromeName.
+    const spoofed = 'Evil' + String.fromCharCode(0x09) + String.fromCharCode(0x202e) + 'App';
+    renderWithProviders(<PageBlockHost {...baseProps} appName={spoofed} onConsentGranted={vi.fn()} />);
+    await expect.element(page.getByText('Starting Evil App…')).toBeInTheDocument();
+  });
+});
+
+describe('PageBlockHost launch reveal — reveal on ready', () => {
+  test('the block is hidden while handshaking and REVEALED (with a transition) on BLOCK_READY', async () => {
+    renderWithProviders(<PageBlockHost {...baseProps} onConsentGranted={vi.fn()} />);
+
+    await expect.element(page.getByTestId('app-page-loading')).toBeInTheDocument();
+    // Pre-handshake: the frame is transparent + inert behind the launch veil, and
+    // the reveal transition is armed.
+    const before = iframeEl();
+    expect(before.style.opacity).toBe('0');
+    expect(before.style.pointerEvents).toBe('none');
+    expect(before.style.transition).toContain('opacity');
+    // The veil itself cross-fades and never intercepts a click.
+    const veil = overlayEl();
+    expect(veil.style.transition).toContain('opacity');
+    expect(veil.style.pointerEvents).toBe('none');
+
+    await driveToReady();
+
+    // Revealed: fully opaque, settled, interactive.
+    const after = iframeEl();
+    expect(after.style.opacity).toBe('1');
+    expect(after.style.transform).toBe('none');
+    expect(after.style.pointerEvents).toBe('auto');
+    expect(after.style.transition).toContain('opacity');
+
+    // …and the launch veil finishes its fade and unmounts (it can never linger).
+    await vi.waitFor(() => {
+      expect(page.getByTestId('app-page-loading').query()).toBeNull();
+    });
+  });
+
+  test('while fading out, the veil is hidden from the a11y tree (no stale "loading" announcement)', async () => {
+    renderWithProviders(<PageBlockHost {...baseProps} onConsentGranted={vi.fn()} />);
+    await driveToReady();
+    // The veil may already be unmounted (fast machine) — either way it must NOT
+    // still be announcing itself as a busy live region.
+    const el = page.getByTestId('app-page-loading').query();
+    if (el) {
+      expect(el.getAttribute('aria-hidden')).toBe('true');
+      expect(el.getAttribute('role')).toBeNull();
+      expect((el as HTMLElement).style.opacity).toBe('0');
+    }
+    await vi.waitFor(() => {
+      expect(page.getByTestId('app-page-loading').query()).toBeNull();
+    });
+  });
+});
+
+describe('PageBlockHost launch reveal — prefers-reduced-motion', () => {
+  test('reduced motion emits NO transition on either the veil or the block', async () => {
+    mocks.reduceMotion = true;
+    renderWithProviders(<PageBlockHost {...baseProps} onConsentGranted={vi.fn()} />);
+
+    await expect.element(page.getByTestId('app-page-loading')).toBeInTheDocument();
+    // The branded content still renders — reduced motion removes MOTION, not the
+    // loading state.
+    await expect.element(page.getByText('Starting Budgeted Generator…')).toBeInTheDocument();
+
+    expect(iframeEl().style.transition).toBe('');
+    expect(iframeEl().style.transform).toBe('none');
+    expect(overlayEl().style.transition).toBe('');
+  });
+
+  test('reduced motion still reveals the block and drops the veil on ready', async () => {
+    mocks.reduceMotion = true;
+    renderWithProviders(<PageBlockHost {...baseProps} onConsentGranted={vi.fn()} />);
+    await driveToReady();
+    expect(iframeEl().style.opacity).toBe('1');
+    expect(iframeEl().style.transition).toBe('');
+    await vi.waitFor(() => {
+      expect(page.getByTestId('app-page-loading').query()).toBeNull();
+    });
+  });
+});
+
+describe('PageBlockHost launch reveal — the reveal must NOT gate the error path', () => {
+  // 🔴 The bug class this whole describe exists to catch: a reveal wrapper that
+  // holds the surface in "launching" while a terminal state is pending, so a
+  // block that never signals ready renders a pretty spinner forever instead of an
+  // error. Every terminal path is asserted to (a) reach BlockFallback and (b)
+  // still be wrapped in AppBlockChrome.
+
+  test('fatal DURING the reveal window still lands on the fallback, promptly, inside the chrome', async () => {
+    renderWithProviders(<PageBlockHost {...baseProps} onConsentGranted={vi.fn()} />);
+    await driveToReady();
+    // Fire the error IMMEDIATELY — inside the cross-fade window, before the veil
+    // has finished fading out. The fallback must not wait on the animation.
+    postFromBlock('BLOCK_ERROR', { fatal: true });
+
+    // 🔴 PROMPTNESS, deterministically: wait a fixed window that is comfortably
+    // longer than a React commit + its passive effects, but comfortably SHORTER
+    // than LAUNCH_REVEAL_MS (260ms) — then require the fallback to ALREADY be on
+    // screen. A reveal wrapper that held the error until the fade finished (the
+    // exact bug class this suite exists for) would still be showing the launch
+    // veil at this point and would fail here, where a generous `waitFor` would
+    // happily wait out the animation and pass. Mutation-verified: gating the
+    // fallback on the reveal timer fails THIS assertion.
+    await new Promise((r) => setTimeout(r, 50));
+    expect(page.getByTestId('app-page-fallback').query()).not.toBeNull();
+    // FRAME-1: provenance chrome still wraps the fallback.
+    await expect.element(page.getByTestId('app-block-chrome')).toBeInTheDocument();
+    // The launch surface is gone — no spinner, no lingering veil, no iframe.
+    expect(page.getByTestId('app-page-loading').query()).toBeNull();
+    expect(page.getByTestId('app-page-iframe').query()).toBeNull();
+  });
+
+  test('the `error` terminal (hard mint failure) renders the fallback inside the chrome, never the launch state', async () => {
+    renderWithProviders(
+      <PageBlockHost {...baseProps} token={null} tokenError onConsentGranted={vi.fn()} />
+    );
+    await expect.element(page.getByTestId('app-page-fallback')).toBeInTheDocument();
+    await expect.element(page.getByTestId('app-block-chrome')).toBeInTheDocument();
+    expect(page.getByTestId('app-page-loading').query()).toBeNull();
+  });
+
+  test(
+    'the `timeout` terminal (block never acks BLOCK_READY) renders the fallback inside the chrome',
+    async () => {
+      // Token present so the init controller arms its readiness timeout, but we
+      // never ack BLOCK_READY → after BLOCK_READY_TIMEOUT_MS the host goes
+      // terminal. The branded launch state must NOT survive it.
+      renderWithProviders(<PageBlockHost {...baseProps} onConsentGranted={vi.fn()} />);
+      await expect.element(page.getByTestId('app-page-loading')).toBeInTheDocument();
+
+      await vi.waitFor(
+        () => {
+          expect(page.getByTestId('app-page-fallback').query()).not.toBeNull();
+        },
+        { timeout: 14_000, interval: 250 }
+      );
+      await expect.element(page.getByTestId('app-block-chrome')).toBeInTheDocument();
+      expect(page.getByTestId('app-page-loading').query()).toBeNull();
+    },
+    20_000
+  );
+
+  test(
+    'the `no_token` terminal (token never arrives) renders the fallback inside the chrome',
+    async () => {
+      renderWithProviders(
+        <PageBlockHost {...baseProps} token={null} tokenError={false} onConsentGranted={vi.fn()} />
+      );
+      await expect.element(page.getByTestId('app-page-loading')).toBeInTheDocument();
+
+      await vi.waitFor(
+        () => {
+          expect(page.getByTestId('app-page-fallback').query()).not.toBeNull();
+        },
+        { timeout: 19_000, interval: 250 }
+      );
+      await expect.element(page.getByTestId('app-block-chrome')).toBeInTheDocument();
+      expect(page.getByTestId('app-page-loading').query()).toBeNull();
+    },
+    26_000
+  );
+});

--- a/src/components/AppBlocks/PageBlockHostLaunchReveal.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostLaunchReveal.browser.test.tsx
@@ -98,7 +98,7 @@ vi.mock('~/utils/trpc', () => ({
 }));
 
 // eslint-disable-next-line import/first
-import { PageBlockHost } from '~/components/AppBlocks/PageBlockHost';
+import { LAUNCH_REVEAL_MS, PageBlockHost } from '~/components/AppBlocks/PageBlockHost';
 
 // Same-origin so trustTier='internal' yields a pinned (non-opaque) transport
 // whose expectedOrigin equals this frame's origin — see PageBlockHost.browser.test.
@@ -273,18 +273,25 @@ describe('PageBlockHost launch reveal — the reveal must NOT gate the error pat
     await driveToReady();
     // Fire the error IMMEDIATELY — inside the cross-fade window, before the veil
     // has finished fading out. The fallback must not wait on the animation.
+    const firedAt = Date.now();
     postFromBlock('BLOCK_ERROR', { fatal: true });
 
-    // 🔴 PROMPTNESS, deterministically: wait a fixed window that is comfortably
-    // longer than a React commit + its passive effects, but comfortably SHORTER
-    // than LAUNCH_REVEAL_MS (260ms) — then require the fallback to ALREADY be on
-    // screen. A reveal wrapper that held the error until the fade finished (the
-    // exact bug class this suite exists for) would still be showing the launch
-    // veil at this point and would fail here, where a generous `waitFor` would
-    // happily wait out the animation and pass. Mutation-verified: gating the
-    // fallback on the reveal timer fails THIS assertion.
-    await new Promise((r) => setTimeout(r, 50));
-    expect(page.getByTestId('app-page-fallback').query()).not.toBeNull();
+    // 🔴 PROMPTNESS. Measured against a captured timestamp rather than a bare
+    // sleep: `driveToReady()` above can itself consume part of the reveal window
+    // on a slow box, so "sleep 50ms then assert" could accidentally land AFTER a
+    // reveal-gated fallback had already faded in and pass despite the bug. Here
+    // we poll for the fallback and then assert it arrived in well under
+    // LAUNCH_REVEAL_MS as measured from the moment the error was fired — which a
+    // reveal-gated fallback cannot satisfy no matter how the earlier steps were
+    // scheduled. Mutation-verified: gating the fallback on the reveal timer fails
+    // this assertion.
+    await vi.waitFor(
+      () => {
+        expect(page.getByTestId('app-page-fallback').query()).not.toBeNull();
+      },
+      { timeout: 2000, interval: 5 }
+    );
+    expect(Date.now() - firedAt).toBeLessThan(LAUNCH_REVEAL_MS);
     // FRAME-1: provenance chrome still wraps the fallback.
     await expect.element(page.getByTestId('app-block-chrome')).toBeInTheDocument();
     // The launch surface is gone — no spinner, no lingering veil, no iframe.

--- a/src/components/AppBlocks/PageBlockHostLaunchReveal.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostLaunchReveal.browser.test.tsx
@@ -87,7 +87,11 @@ vi.mock('~/utils/trpc', () => ({
           getCount: { fetch: vi.fn() },
           getCounts: { fetch: vi.fn() },
         },
-        storage: { get: { fetch: vi.fn() }, list: { fetch: vi.fn() }, getQuota: { fetch: vi.fn() } },
+        storage: {
+          get: { fetch: vi.fn() },
+          list: { fetch: vi.fn() },
+          getQuota: { fetch: vi.fn() },
+        },
       },
     }),
   },
@@ -125,7 +129,11 @@ function postFromBlock(type: string, payload?: unknown) {
   const cw = iframeEl.contentWindow;
   if (!cw) throw new Error('iframe contentWindow missing');
   window.dispatchEvent(
-    new MessageEvent('message', { data: { type, payload }, origin: window.location.origin, source: cw })
+    new MessageEvent('message', {
+      data: { type, payload },
+      origin: window.location.origin,
+      source: cw,
+    })
   );
 }
 
@@ -171,7 +179,9 @@ describe('PageBlockHost launch reveal — branded loading', () => {
     // including the VISIBLE "Starting …" line and the avatar initial — goes
     // through sanitizeAppChromeName.
     const spoofed = 'Evil' + String.fromCharCode(0x09) + String.fromCharCode(0x202e) + 'App';
-    renderWithProviders(<PageBlockHost {...baseProps} appName={spoofed} onConsentGranted={vi.fn()} />);
+    renderWithProviders(
+      <PageBlockHost {...baseProps} appName={spoofed} onConsentGranted={vi.fn()} />
+    );
     await expect.element(page.getByText('Starting Evil App…')).toBeInTheDocument();
   });
 });
@@ -291,44 +301,36 @@ describe('PageBlockHost launch reveal — the reveal must NOT gate the error pat
     expect(page.getByTestId('app-page-loading').query()).toBeNull();
   });
 
-  test(
-    'the `timeout` terminal (block never acks BLOCK_READY) renders the fallback inside the chrome',
-    async () => {
-      // Token present so the init controller arms its readiness timeout, but we
-      // never ack BLOCK_READY → after BLOCK_READY_TIMEOUT_MS the host goes
-      // terminal. The branded launch state must NOT survive it.
-      renderWithProviders(<PageBlockHost {...baseProps} onConsentGranted={vi.fn()} />);
-      await expect.element(page.getByTestId('app-page-loading')).toBeInTheDocument();
+  test('the `timeout` terminal (block never acks BLOCK_READY) renders the fallback inside the chrome', async () => {
+    // Token present so the init controller arms its readiness timeout, but we
+    // never ack BLOCK_READY → after BLOCK_READY_TIMEOUT_MS the host goes
+    // terminal. The branded launch state must NOT survive it.
+    renderWithProviders(<PageBlockHost {...baseProps} onConsentGranted={vi.fn()} />);
+    await expect.element(page.getByTestId('app-page-loading')).toBeInTheDocument();
 
-      await vi.waitFor(
-        () => {
-          expect(page.getByTestId('app-page-fallback').query()).not.toBeNull();
-        },
-        { timeout: 14_000, interval: 250 }
-      );
-      await expect.element(page.getByTestId('app-block-chrome')).toBeInTheDocument();
-      expect(page.getByTestId('app-page-loading').query()).toBeNull();
-    },
-    20_000
-  );
+    await vi.waitFor(
+      () => {
+        expect(page.getByTestId('app-page-fallback').query()).not.toBeNull();
+      },
+      { timeout: 14_000, interval: 250 }
+    );
+    await expect.element(page.getByTestId('app-block-chrome')).toBeInTheDocument();
+    expect(page.getByTestId('app-page-loading').query()).toBeNull();
+  }, 20_000);
 
-  test(
-    'the `no_token` terminal (token never arrives) renders the fallback inside the chrome',
-    async () => {
-      renderWithProviders(
-        <PageBlockHost {...baseProps} token={null} tokenError={false} onConsentGranted={vi.fn()} />
-      );
-      await expect.element(page.getByTestId('app-page-loading')).toBeInTheDocument();
+  test('the `no_token` terminal (token never arrives) renders the fallback inside the chrome', async () => {
+    renderWithProviders(
+      <PageBlockHost {...baseProps} token={null} tokenError={false} onConsentGranted={vi.fn()} />
+    );
+    await expect.element(page.getByTestId('app-page-loading')).toBeInTheDocument();
 
-      await vi.waitFor(
-        () => {
-          expect(page.getByTestId('app-page-fallback').query()).not.toBeNull();
-        },
-        { timeout: 19_000, interval: 250 }
-      );
-      await expect.element(page.getByTestId('app-block-chrome')).toBeInTheDocument();
-      expect(page.getByTestId('app-page-loading').query()).toBeNull();
-    },
-    26_000
-  );
+    await vi.waitFor(
+      () => {
+        expect(page.getByTestId('app-page-fallback').query()).not.toBeNull();
+      },
+      { timeout: 19_000, interval: 250 }
+    );
+    await expect.element(page.getByTestId('app-block-chrome')).toBeInTheDocument();
+    expect(page.getByTestId('app-page-loading').query()).toBeNull();
+  }, 26_000);
 });

--- a/src/components/Apps/AppListingCard.browser.test.tsx
+++ b/src/components/Apps/AppListingCard.browser.test.tsx
@@ -206,8 +206,9 @@ describe('AppListingCard', () => {
   //   (b) the `onError` → category-glyph placeholder occupies the SAME box, so a
   //       dangling cover URL swaps art with zero layout shift (CLS).
   // NOTE: the browser project does not load Mantine's stylesheet, so these assert
-  // the inline ratio contract (`aspect-ratio` on the box, which is what reserves
-  // the height) rather than measured pixels — measured geometry would be
+  // the INLINE ratio contract the component writes itself (`aspect-ratio` on the
+  // box, which is what reserves the height, plus the absolute fill on whichever
+  // art is inside it) rather than measured pixels — measured geometry would be
   // meaningless without the stylesheet.
 
   // A 1x1 transparent PNG. A real (non-network) src that LOADS, so the <img>
@@ -230,6 +231,11 @@ describe('AppListingCard', () => {
     expect(img).not.toBeNull();
     expect(img?.getAttribute('src')).toBe(LOADABLE_PNG);
     expect(img?.getAttribute('alt')).toBe('My App cover image');
+    // Absolutely filling the box — NOT a percentage height, which would have to
+    // resolve against a ratio-derived block size and could silently crop the art
+    // under `overflow: hidden` if it ever resolved to `auto`.
+    expect((img as HTMLElement).style.position).toBe('absolute');
+    expect((img as HTMLElement).style.inset).toBe('0px');
     // No fixed pixel height anywhere on the box — the whole point of the change
     // (it was `h={140}`); the height now comes from the ratio.
     expect(box.style.height).toBe('');
@@ -247,6 +253,10 @@ describe('AppListingCard', () => {
     expect(placeholder.parentElement).toBe(box);
     // Decorative only — it carries no information the title/CTA don't.
     expect(placeholder.getAttribute('aria-hidden')).toBe('true');
+    // Same absolute-fill encoding as the <img>, so the two are interchangeable
+    // without any geometry change.
+    expect((placeholder as HTMLElement).style.position).toBe('absolute');
+    expect((placeholder as HTMLElement).style.inset).toBe('0px');
     expect(box.querySelector('img')).toBeNull();
   });
 
@@ -301,6 +311,31 @@ describe('AppListingCard', () => {
     expect(visit.tagName).toBe('A');
     expect(visit.getAttribute('target')).toBe('_blank');
     expect(visit.getAttribute('rel')).toBe('noopener noreferrer');
+  });
+
+  test('the action row does NOT wrap — actions stay right-aligned and never shrink', async () => {
+    // 🔴 Regression guard for the obvious-but-wrong fix to the taller `sm` buttons.
+    // Letting this row wrap would (a) left-align the actions, because a wrapped
+    // line with one item sits at flex-start under `justify="space-between"`, and
+    // (b) make an OWNER card (Edit + CTA) wrap at a wider column than a non-owner
+    // card, growing the height of the whole `h-full` grid row for everyone.
+    mocks.currentUser = { id: 5, username: 'alice' }; // owner → widest action set
+    renderWithProviders(<AppListingCard card={base({})} canOpenPage />);
+    await expect.element(page.getByTestId('apps-listing-owner-edit')).toBeInTheDocument();
+
+    const edit = page.getByTestId('apps-listing-owner-edit').element() as HTMLElement;
+    // The group holding Edit + the primary CTA.
+    const actions = edit.parentElement as HTMLElement;
+    expect(actions.style.getPropertyValue('--group-wrap')).toBe('nowrap');
+    // The actions are the rigid side: they never shrink…
+    expect(actions.style.flexShrink).toBe('0');
+    // …and the row itself never wraps, so the actions can't jump to the left.
+    const row = actions.parentElement as HTMLElement;
+    expect(row.style.getPropertyValue('--group-wrap')).toBe('nowrap');
+    // The recommend rollup is the flexible side that absorbs the pressure.
+    const rollup = row.firstElementChild as HTMLElement;
+    expect(rollup).not.toBe(actions);
+    expect(rollup.style.minWidth).toBe('0px');
   });
 
   test('the owner "Edit" secondary CTA also renders at size "sm"', async () => {

--- a/src/components/Apps/AppListingCard.browser.test.tsx
+++ b/src/components/Apps/AppListingCard.browser.test.tsx
@@ -198,6 +198,119 @@ describe('AppListingCard', () => {
     expect(page.getByTestId('apps-listing-owner-incomplete').elements()).toHaveLength(0);
   });
 
+  // ── Larger covers (feedback #1) ──────────────────────────────────────────────
+  // The cover moved from a fixed `h={140}` letterbox to a RESPONSIVE 16:9 box
+  // (Mantine AspectRatio). Two properties matter and are pinned below:
+  //   (a) the box is 16:9 and the art lives INSIDE it (so widening the column
+  //       widens the art), and
+  //   (b) the `onError` → category-glyph placeholder occupies the SAME box, so a
+  //       dangling cover URL swaps art with zero layout shift (CLS).
+  // NOTE: the browser project does not load Mantine's stylesheet, so these assert
+  // the inline ratio contract (`aspect-ratio` on the box, which is what reserves
+  // the height) rather than measured pixels — measured geometry would be
+  // meaningless without the stylesheet.
+
+  // A 1x1 transparent PNG. A real (non-network) src that LOADS, so the <img>
+  // survives — any http(s) URL fails to fetch in the test browser and trips the
+  // component's own onError → placeholder path (exercised separately below).
+  const LOADABLE_PNG =
+    'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==';
+
+  test('cover image renders INSIDE the 16:9 aspect box', async () => {
+    renderWithProviders(<AppListingCard card={base({ coverUrl: LOADABLE_PNG })} canOpenPage />);
+    await expect.element(page.getByTestId('apps-listing-cover')).toBeInTheDocument();
+    const box = page.getByTestId('apps-listing-cover').element() as HTMLElement;
+    // 16:9 — this is what derives the box height from the fluid column width, so
+    // the height is reserved before the image bytes arrive (the CLS guard).
+    expect(box.style.aspectRatio.replace(/\s/g, '')).toBe('16/9');
+    expect(box.style.width).toBe('100%');
+    // The art is a CHILD of the ratio box, not a sibling — if it escaped the box
+    // it would not be bounded by the reserved geometry.
+    const img = box.querySelector('img');
+    expect(img).not.toBeNull();
+    expect(img?.getAttribute('src')).toBe(LOADABLE_PNG);
+    expect(img?.getAttribute('alt')).toBe('My App cover image');
+    // No fixed pixel height anywhere on the box — the whole point of the change
+    // (it was `h={140}`); the height now comes from the ratio.
+    expect(box.style.height).toBe('');
+  });
+
+  test('no cover → the category-glyph placeholder fills the SAME 16:9 box and stays decorative', async () => {
+    // base() has coverUrl: null.
+    renderWithProviders(<AppListingCard card={base({})} canOpenPage />);
+    await expect.element(page.getByTestId('apps-listing-cover')).toBeInTheDocument();
+    const box = page.getByTestId('apps-listing-cover').element() as HTMLElement;
+    expect(box.style.aspectRatio.replace(/\s/g, '')).toBe('16/9');
+    const placeholder = page.getByTestId('apps-listing-cover-placeholder').element();
+    // Same box: the placeholder is the ratio box's own child, so it inherits the
+    // identical reserved geometry the <img> would have had.
+    expect(placeholder.parentElement).toBe(box);
+    // Decorative only — it carries no information the title/CTA don't.
+    expect(placeholder.getAttribute('aria-hidden')).toBe('true');
+    expect(box.querySelector('img')).toBeNull();
+  });
+
+  test('a BROKEN cover URL falls back to the placeholder in the SAME box (no reflow, still aria-hidden)', async () => {
+    // An unfetchable URL — the browser fires the <img>'s real `error` event, which
+    // is the component's own onError → placeholder path.
+    renderWithProviders(
+      <AppListingCard card={base({ coverUrl: 'https://edge.invalid/does-not-exist.png' })} canOpenPage />
+    );
+    await expect.element(page.getByTestId('apps-listing-cover')).toBeInTheDocument();
+
+    await vi.waitFor(() => {
+      expect(page.getByTestId('apps-listing-cover-placeholder').query()).not.toBeNull();
+    });
+    const after = page.getByTestId('apps-listing-cover').element() as HTMLElement;
+    const placeholder = page.getByTestId('apps-listing-cover-placeholder').element();
+    // The SAME ratio box survives the swap (identical reserved geometry) …
+    expect(after.style.aspectRatio.replace(/\s/g, '')).toBe('16/9');
+    expect(placeholder.parentElement).toBe(after);
+    // … the broken <img> is gone …
+    expect(after.querySelector('img')).toBeNull();
+    // … and the fallback is still decorative.
+    expect(placeholder.getAttribute('aria-hidden')).toBe('true');
+  });
+
+  // ── Larger CTAs (feedback #2) ────────────────────────────────────────────────
+  // Both the kind-aware primary CTA and the owner-only secondary "Edit" moved one
+  // step up Mantine's size scale (xs → sm). Asserted via the `--button-height`
+  // custom property Mantine's Button varsResolver writes inline from `size`,
+  // which is the size prop's observable effect (the stylesheet isn't loaded here).
+
+  test('the kind-aware primary CTA renders at Mantine size "sm" (bumped from xs)', async () => {
+    renderWithProviders(<AppListingCard card={base({})} canOpenPage />);
+    await expect.element(page.getByRole('link', { name: 'Open' })).toBeInTheDocument();
+    const open = page.getByRole('link', { name: 'Open' }).element() as HTMLElement;
+    expect(open.style.getPropertyValue('--button-height')).toBe('var(--button-height-sm)');
+  });
+
+  test('the EXTERNAL Visit CTA also renders at size "sm" and keeps its new-tab anchor semantics', async () => {
+    renderWithProviders(
+      <AppListingCard
+        card={base({
+          kind: 'offsite',
+          kindData: { kind: 'offsite', subKind: 'external-link', externalUrl: 'https://ext.app' },
+        })}
+      />
+    );
+    await expect.element(page.getByRole('link', { name: 'Visit' })).toBeInTheDocument();
+    const visit = page.getByRole('link', { name: 'Visit' }).element() as HTMLElement;
+    expect(visit.style.getPropertyValue('--button-height')).toBe('var(--button-height-sm)');
+    // Enlarging must not flatten the kind-aware logic: still a real anchor.
+    expect(visit.tagName).toBe('A');
+    expect(visit.getAttribute('target')).toBe('_blank');
+    expect(visit.getAttribute('rel')).toBe('noopener noreferrer');
+  });
+
+  test('the owner "Edit" secondary CTA also renders at size "sm"', async () => {
+    mocks.currentUser = { id: 5, username: 'alice' };
+    renderWithProviders(<AppListingCard card={base({})} canOpenPage />);
+    await expect.element(page.getByTestId('apps-listing-owner-edit')).toBeInTheDocument();
+    const edit = page.getByTestId('apps-listing-owner-edit').element() as HTMLElement;
+    expect(edit.style.getPropertyValue('--button-height')).toBe('var(--button-height-sm)');
+  });
+
   test('a long username reveals the full value in a tooltip on hover (clip fallback)', async () => {
     const longName = 'a-really-long-creator-username-that-will-definitely-overflow-the-card-column';
     // The tooltip is overflow-GATED (TruncatedText disables it unless the label

--- a/src/components/Apps/AppListingCard.tsx
+++ b/src/components/Apps/AppListingCard.tsx
@@ -1,4 +1,17 @@
-import { Anchor, Avatar, Badge, Box, Button, Card, Group, Image, Stack, Text, Title, Tooltip } from '@mantine/core';
+import {
+  Anchor,
+  Avatar,
+  Badge,
+  Box,
+  Button,
+  Card,
+  Group,
+  Image,
+  Stack,
+  Text,
+  Title,
+  Tooltip,
+} from '@mantine/core';
 import { IconApps, IconExternalLink, IconPencil, IconThumbUp } from '@tabler/icons-react';
 import type { Icon } from '@tabler/icons-react';
 import Link from 'next/link';
@@ -63,6 +76,21 @@ function categoryIcon(category: string): Icon {
  * broken/empty `<img>` and two coverless listings never look identical.
  * Decorative (aria-hidden) — the placeholder carries no info the title/category
  * chip don't.
+ *
+ * GEOMETRY (feedback #1: "make cover images larger"): the cover is a RESPONSIVE
+ * 16:9 box (a `Box` with a CSS `aspect-ratio`), not the former fixed `h={140}`.
+ * Two reasons:
+ *   1. It scales with the column, so widening the grid (5 → 4 cols at `xl`)
+ *      actually makes the art bigger instead of leaving a short letterbox. The
+ *      server already serves the cover at `width: 1200` (app-listing.service),
+ *      so there is ~8× resolution headroom — this is a pure client-side change,
+ *      no DTO/pipeline work.
+ *   2. CLS: `aspect-ratio` derives the box height from the (already-known) column
+ *      width BEFORE the image loads, so a slow or failed cover never shifts the
+ *      card. The old fixed height did too — the point is that the responsive box
+ *      KEEPS that property rather than trading it away for scale.
+ * The image branch and the placeholder branch render inside the SAME box, so the
+ * `onError` fallback swaps art without ANY reflow.
  */
 function ListingCover({
   coverUrl,
@@ -79,19 +107,7 @@ function ListingCover({
   // screenshot fallback, whose Image can dangle) — fall back to the category
   // glyph placeholder on load error instead of a broken <img>.
   const [broken, setBroken] = useState(false);
-  if (coverUrl && !broken) {
-    return (
-      <Card.Section>
-        <Image
-          src={coverUrl}
-          alt={`${name} cover image`}
-          h={140}
-          fit="cover"
-          onError={() => setBroken(true)}
-        />
-      </Card.Section>
-    );
-  }
+  const showImage = !!coverUrl && !broken;
   const PlaceholderIcon = category ? categoryIcon(category) : IconApps;
   // Per-app SEEDED gradient (not one uniform grey for every coverless listing) —
   // same seed + stops the generated cover SVG uses, so a listing that later gets
@@ -100,13 +116,45 @@ function ListingCover({
   return (
     <Card.Section>
       <Box
-        aria-hidden
-        h={140}
-        className="flex items-center justify-center"
-        data-listing-cover-placeholder=""
-        style={{ background: listingPlaceholderGradient({ slug, category, surface: 'cover' }) }}
+        data-testid="apps-listing-cover"
+        style={{
+          // The ratio box. `aspect-ratio` derives the height from the (fluid)
+          // column width, so the cover grows with the card AND its height is
+          // reserved before any image bytes arrive — that's the CLS guard.
+          width: '100%',
+          aspectRatio: '16 / 9',
+          overflow: 'hidden',
+        }}
       >
-        <PlaceholderIcon size={44} className="opacity-60" />
+        {showImage ? (
+          <Image
+            src={coverUrl}
+            alt={`${name} cover image`}
+            h="100%"
+            w="100%"
+            fit="cover"
+            onError={() => setBroken(true)}
+          />
+        ) : (
+          <Box
+            aria-hidden
+            data-testid="apps-listing-cover-placeholder"
+            data-listing-cover-placeholder=""
+            className="flex items-center justify-center"
+            style={{
+              // Fills the ratio box exactly, so swapping art on `onError` cannot
+              // change the card's geometry.
+              width: '100%',
+              height: '100%',
+              // Per-app SEEDED gradient (#3465) — NOT the old uniform grey, so two
+              // coverless listings never look identical and a listing keeps its
+              // colour identity if it later gains a generated cover SVG.
+              background: listingPlaceholderGradient({ slug, category, surface: 'cover' }),
+            }}
+          >
+            <PlaceholderIcon size={56} className="opacity-60" />
+          </Box>
+        )}
       </Box>
     </Card.Section>
   );
@@ -267,7 +315,13 @@ export function AppListingCard({ card, canOpenPage = false }: AppListingCardProp
           </Text>
         )}
 
-        <Group justify="space-between" mt="auto" pt="xs" wrap="nowrap">
+        {/* Feedback #2: the action row's buttons stepped up a notch on the Mantine
+            size scale (xs → sm), so the primary CTA reads as the card's call to
+            action rather than a footnote. Because `sm` buttons are taller/wider,
+            the OUTER row is allowed to WRAP (the actions drop to their own line on
+            a narrow column) instead of overflowing the card — the inner action
+            group still stays nowrap so Edit + CTA never split from each other. */}
+        <Group justify="space-between" mt="auto" pt="xs" gap="xs" wrap="wrap">
           {/* Recommend rollup — "N% recommend (M)" or "No reviews yet". */}
           <Group gap={4} wrap="nowrap">
             <IconThumbUp
@@ -279,7 +333,7 @@ export function AppListingCard({ card, canOpenPage = false }: AppListingCardProp
             </Text>
           </Group>
 
-          <Group gap={6} wrap="nowrap">
+          <Group gap="xs" wrap="nowrap">
             {/* Owner-only "Edit" deep-link — subtle secondary action, gated by
                 owner + editable status (mod-removed listings hide it). Routes by
                 kind (manifest editor for on-site, submit editor for off-site). */}
@@ -287,9 +341,9 @@ export function AppListingCard({ card, canOpenPage = false }: AppListingCardProp
               <Button
                 component={Link}
                 href={editHref}
-                size="xs"
+                size="sm"
                 variant="default"
-                leftSection={<IconPencil size={14} />}
+                leftSection={<IconPencil size={16} />}
                 data-testid="apps-listing-owner-edit"
                 onClick={(e: MouseEvent) => e.stopPropagation()}
               >
@@ -306,9 +360,9 @@ export function AppListingCard({ card, canOpenPage = false }: AppListingCardProp
                 href={cta.href}
                 target="_blank"
                 rel="noopener noreferrer"
-                size="xs"
+                size="sm"
                 variant="light"
-                rightSection={<IconExternalLink size={14} />}
+                rightSection={<IconExternalLink size={16} />}
               >
                 {cta.label}
               </Button>
@@ -316,7 +370,7 @@ export function AppListingCard({ card, canOpenPage = false }: AppListingCardProp
               <Button
                 component={Link}
                 href={cta.href}
-                size="xs"
+                size="sm"
                 variant={cta.action === 'open' ? 'filled' : 'light'}
               >
                 {cta.label}

--- a/src/components/Apps/AppListingCard.tsx
+++ b/src/components/Apps/AppListingCard.tsx
@@ -121,6 +121,7 @@ function ListingCover({
           // The ratio box. `aspect-ratio` derives the height from the (fluid)
           // column width, so the cover grows with the card AND its height is
           // reserved before any image bytes arrive — that's the CLS guard.
+          position: 'relative',
           width: '100%',
           aspectRatio: '16 / 9',
           overflow: 'hidden',
@@ -130,10 +131,16 @@ function ListingCover({
           <Image
             src={coverUrl}
             alt={`${name} cover image`}
-            h="100%"
-            w="100%"
             fit="cover"
             onError={() => setBroken(true)}
+            // Absolutely filling the ratio box, NOT `h="100%"`: a percentage
+            // height has to resolve against a block size that is itself derived
+            // from `aspect-ratio`. Every current engine does that, but if it ever
+            // resolved to `auto` the image would render at its intrinsic size and
+            // `overflow: hidden` would silently CROP it — a failure no test that
+            // reads style strings could catch. `inset: 0` needs no such
+            // resolution.
+            style={{ position: 'absolute', inset: 0, width: '100%', height: '100%' }}
           />
         ) : (
           <Box
@@ -142,10 +149,10 @@ function ListingCover({
             data-listing-cover-placeholder=""
             className="flex items-center justify-center"
             style={{
-              // Fills the ratio box exactly, so swapping art on `onError` cannot
-              // change the card's geometry.
-              width: '100%',
-              height: '100%',
+              // Fills the ratio box exactly (same absolute encoding as the image),
+              // so swapping art on `onError` cannot change the card's geometry.
+              position: 'absolute',
+              inset: 0,
               // Per-app SEEDED gradient (#3465) — NOT the old uniform grey, so two
               // coverless listings never look identical and a listing keeps its
               // colour identity if it later gains a generated cover SVG.
@@ -317,23 +324,32 @@ export function AppListingCard({ card, canOpenPage = false }: AppListingCardProp
 
         {/* Feedback #2: the action row's buttons stepped up a notch on the Mantine
             size scale (xs → sm), so the primary CTA reads as the card's call to
-            action rather than a footnote. Because `sm` buttons are taller/wider,
-            the OUTER row is allowed to WRAP (the actions drop to their own line on
-            a narrow column) instead of overflowing the card — the inner action
-            group still stays nowrap so Edit + CTA never split from each other. */}
-        <Group justify="space-between" mt="auto" pt="xs" gap="xs" wrap="wrap">
-          {/* Recommend rollup — "N% recommend (M)" or "No reviews yet". */}
-          <Group gap={4} wrap="nowrap">
+            action rather than a footnote.
+            🔴 The row deliberately stays `nowrap`. Letting it wrap looks like the
+            obvious way to stop the taller buttons overflowing a narrow column, but
+            it breaks two things: (1) under `justify="space-between"` a wrapped line
+            holding a single item sits at flex-START, so the actions would jump from
+            right-aligned to LEFT-aligned; and (2) an OWNER card (Edit + CTA) wraps
+            at a wider column than a non-owner card, so inside a `h-full` grid row
+            one owner card would grow the height of the whole row. Instead the
+            actions never shrink and the recommend rollup absorbs the pressure by
+            truncating — so every card in a row keeps the same geometry regardless
+            of who is looking at it. */}
+        <Group justify="space-between" mt="auto" pt="xs" gap="xs" wrap="nowrap">
+          {/* Recommend rollup — "N% recommend (M)" or "No reviews yet". This is the
+              flexible side: it may truncate so the actions never do. */}
+          <Group gap={4} wrap="nowrap" style={{ minWidth: 0 }}>
             <IconThumbUp
               size={13}
+              style={{ flexShrink: 0 }}
               className={card.recommend.recommendPct == null ? 'text-gray-500' : 'text-green-500'}
             />
-            <Text size="xs" c="dimmed">
+            <Text size="xs" c="dimmed" truncate>
               {recommendLabel}
             </Text>
           </Group>
 
-          <Group gap="xs" wrap="nowrap">
+          <Group gap="xs" wrap="nowrap" style={{ flexShrink: 0 }}>
             {/* Owner-only "Edit" deep-link — subtle secondary action, gated by
                 owner + editable status (mod-removed listings hide it). Routes by
                 kind (manifest editor for on-site, submit editor for off-site). */}

--- a/src/components/Apps/AppListingsMarketplaceBody.browser.test.tsx
+++ b/src/components/Apps/AppListingsMarketplaceBody.browser.test.tsx
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { page, userEvent } from 'vitest/browser';
 // `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
 import { renderWithProviders } from '../../../test/component-setup';
+import { LISTING_GRID_SPAN } from '~/components/Apps/appListingGrid';
 import type { ListingCard } from '~/server/schema/blocks/app-listing-read.schema';
 
 /**
@@ -98,5 +99,37 @@ describe('AppListingsMarketplaceBody', () => {
     mocks.items = [];
     renderWithProviders(<AppListingsMarketplaceBody />);
     await expect.element(page.getByText('No apps yet')).toBeInTheDocument();
+  });
+
+  // ── Larger covers (feedback #1): the grid geometry ──────────────────────────
+  // The numbers themselves are pinned in the blocking unit suite
+  // (__tests__/appListingGrid.test.ts). What this asserts is the WIRING: the grid
+  // actually renders with that shared span object, so the two can't drift.
+  test('the grid renders each card with the shared LISTING_GRID_SPAN (xl = 4 columns)', async () => {
+    renderWithProviders(<AppListingsMarketplaceBody />);
+    await expect.element(page.getByText('Alpha App')).toBeInTheDocument();
+
+    const cols = page.getByTestId('apps-listing-grid-col').elements();
+    expect(cols).toHaveLength(mocks.items.length);
+
+    // Mantine Grid.Col compiles the responsive span into a generated <style>
+    // block of `--col-flex-basis` percentages (one media rule per breakpoint).
+    // The OLD `xl: 2.4` (five columns) compiled to a 20% basis; the NEW `xl: 3`
+    // compiles to 25%. So the absence of a 20% basis is a direct, mutation-
+    // sensitive assertion that the five-column xl layout is gone — flip the span
+    // back to 2.4 and this fails. The exact per-breakpoint numbers are pinned in
+    // the blocking unit suite (__tests__/appListingGrid.test.ts).
+    const css = Array.from(document.querySelectorAll('style'))
+      .map((s) => s.textContent ?? '')
+      .join('\n')
+      .replace(/\s+/g, '');
+    expect(css).toContain('--col-flex-basis:25%'); // 3/12 — the lg + xl columns
+    expect(css).not.toContain('--col-flex-basis:20%'); // 2.4/12 — the retired 5-col xl
+
+    // …and the grid is wired to the SHARED constant, so the unit pins above
+    // actually govern what renders.
+    expect(LISTING_GRID_SPAN.xl).toBe(3);
+    expect(12 / LISTING_GRID_SPAN.xl).toBe(4);
+    expect(LISTING_GRID_SPAN).toMatchObject({ base: 12, sm: 6, md: 4, lg: 3 });
   });
 });

--- a/src/components/Apps/AppListingsMarketplaceBody.browser.test.tsx
+++ b/src/components/Apps/AppListingsMarketplaceBody.browser.test.tsx
@@ -2,7 +2,6 @@ import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { page, userEvent } from 'vitest/browser';
 // `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
 import { renderWithProviders } from '../../../test/component-setup';
-import { LISTING_GRID_SPAN } from '~/components/Apps/appListingGrid';
 import type { ListingCard } from '~/server/schema/blocks/app-listing-read.schema';
 
 /**
@@ -31,6 +30,21 @@ function makeCard(id: string, name: string, kind: 'onsite' | 'offsite' = 'onsite
         ? { kind: 'onsite', appBlockId: `blk-${id}`, hasPage: false, liveUrl: `https://slug-${id}.civit.ai` }
         : { kind: 'offsite', subKind: 'external-link', externalUrl: 'https://x.app' },
   };
+}
+
+/**
+ * The whitespace-stripped CSS Mantine generated for THIS element's own responsive
+ * class. `Grid.Col` renders an `InlineStyles` <style> block keyed on a random
+ * per-instance class, so scoping to that class keeps the assertions immune to
+ * style blocks left behind by other tests in the same document.
+ */
+function generatedCssFor(el: HTMLElement): string {
+  const classes = Array.from(el.classList);
+  return Array.from(document.querySelectorAll('style'))
+    .map((s) => s.textContent ?? '')
+    .filter((text) => classes.some((c) => text.includes(`.${c}`)))
+    .join('\n')
+    .replace(/\s+/g, '');
 }
 
 const mocks = vi.hoisted(() => ({
@@ -119,17 +133,19 @@ describe('AppListingsMarketplaceBody', () => {
     // sensitive assertion that the five-column xl layout is gone — flip the span
     // back to 2.4 and this fails. The exact per-breakpoint numbers are pinned in
     // the blocking unit suite (__tests__/appListingGrid.test.ts).
-    const css = Array.from(document.querySelectorAll('style'))
-      .map((s) => s.textContent ?? '')
-      .join('\n')
-      .replace(/\s+/g, '');
-    expect(css).toContain('--col-flex-basis:25%'); // 3/12 — the lg + xl columns
-    expect(css).not.toContain('--col-flex-basis:20%'); // 2.4/12 — the retired 5-col xl
+    //
+    // Scoped to the styles Mantine generated for THIS column's own random class,
+    // not every <style> in the document — a document-wide scan would make the
+    // negative assertion below sensitive to style leakage from other tests.
+    const css = generatedCssFor(cols[0] as HTMLElement);
 
-    // …and the grid is wired to the SHARED constant, so the unit pins above
-    // actually govern what renders.
-    expect(LISTING_GRID_SPAN.xl).toBe(3);
-    expect(12 / LISTING_GRID_SPAN.xl).toBe(4);
-    expect(LISTING_GRID_SPAN).toMatchObject({ base: 12, sm: 6, md: 4, lg: 3 });
+    // Every basis Mantine emitted for this column — the base rule first, then one
+    // per breakpoint in ascending order: base 12 → 100% (1 col), sm 6 → 50% (2),
+    // md 4 → 33.3% (3), lg 3 → 25% (4), xl 3 → 25% (4). The OLD `xl: 2.4` compiled
+    // to a 20% basis, so this pins the whole responsive sequence AND proves the
+    // retired 5-column xl is gone. Flipping the span back to 2.4 fails here.
+    const bases = Array.from(css.matchAll(/--col-flex-basis:([\d.]+)%/g)).map((m) => m[1]);
+    expect(bases).toEqual(['100', '50', '33.333333333333336', '25', '25']);
+    expect(css).not.toContain('--col-flex-basis:20%'); // 2.4/12 — the retired 5-col xl
   });
 });

--- a/src/components/Apps/AppListingsMarketplaceBody.tsx
+++ b/src/components/Apps/AppListingsMarketplaceBody.tsx
@@ -3,6 +3,7 @@ import { useDebouncedValue } from '@mantine/hooks';
 import { IconApps, IconExternalLink, IconLayoutGrid, IconSearch } from '@tabler/icons-react';
 import { useMemo, useState } from 'react';
 import { AppListingCard } from '~/components/Apps/AppListingCard';
+import { LISTING_GRID_SPAN } from '~/components/Apps/appListingGrid';
 import { CategoryFilterButtons } from '~/components/Apps/CategoryFilterButtons';
 import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
 import { type MarketplaceCategory } from '~/server/services/blocks/marketplace-categories.constants';
@@ -209,9 +210,16 @@ export function AppListingsMarketplaceBody() {
         </Center>
       ) : (
         <>
+          {/* Feedback #1 ("make app cover images larger — fewer columns per row?"):
+              at `xl` the grid drops 5 columns → 4 (`span` 2.4 → 3), so each card —
+              and therefore its responsive 16:9 cover — gets ~25% more width. The
+              container width is UNCHANGED (`LISTING_STORE_CONTAINER_SIZE`, still
+              1600, on the store index) and every other breakpoint is unchanged
+              (base 12 / sm 6 / md 4 / lg 3). Both constants live in
+              `appListingGrid.ts` so they're unit-pinned together. */}
           <Grid gutter="md">
             {filteredItems.map((card) => (
-              <Grid.Col key={card.id} span={{ base: 12, sm: 6, md: 4, lg: 3, xl: 2.4 }}>
+              <Grid.Col key={card.id} span={LISTING_GRID_SPAN} data-testid="apps-listing-grid-col">
                 <AppListingCard card={card} canOpenPage={!!features.appBlocksPages} />
               </Grid.Col>
             ))}

--- a/src/components/Apps/__tests__/appListingGrid.test.ts
+++ b/src/components/Apps/__tests__/appListingGrid.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from 'vitest';
+import {
+  LISTING_GRID_SPAN,
+  LISTING_STORE_CONTAINER_SIZE,
+} from '~/components/Apps/appListingGrid';
+
+/**
+ * `/apps` store GEOMETRY pins (blocking `unit` project).
+ *
+ * The product feedback was "make app cover images larger — fewer columns per
+ * row?". The implementation answer is a ONE-breakpoint change (xl 2.4 → 3, i.e.
+ * five columns → four) plus a responsive 16:9 cover in `AppListingCard` — with
+ * the CONTAINER WIDTH LEFT ALONE. All three halves of that statement are pinned
+ * here so a later tweak can't quietly re-narrow the cards or widen the page.
+ */
+describe('LISTING_GRID_SPAN', () => {
+  test('xl yields FOUR columns (span 3 of 12) — the larger-cover change', () => {
+    expect(LISTING_GRID_SPAN.xl).toBe(3);
+    expect(12 / LISTING_GRID_SPAN.xl).toBe(4);
+  });
+
+  test('base / sm / md / lg are UNCHANGED (1 / 2 / 3 / 4 columns)', () => {
+    expect(LISTING_GRID_SPAN.base).toBe(12);
+    expect(LISTING_GRID_SPAN.sm).toBe(6);
+    expect(LISTING_GRID_SPAN.md).toBe(4);
+    expect(LISTING_GRID_SPAN.lg).toBe(3);
+    expect(12 / LISTING_GRID_SPAN.base).toBe(1);
+    expect(12 / LISTING_GRID_SPAN.sm).toBe(2);
+    expect(12 / LISTING_GRID_SPAN.md).toBe(3);
+    expect(12 / LISTING_GRID_SPAN.lg).toBe(4);
+  });
+
+  test('every breakpoint is a whole-column span (no fractional 2.4-style spans)', () => {
+    // The old `xl: 2.4` was the only fractional span; dropping it means every
+    // breakpoint now divides 12 evenly, so no row ever ends on a part-column.
+    for (const [bp, span] of Object.entries(LISTING_GRID_SPAN)) {
+      expect(Number.isInteger(span), `${bp} span should be a whole number`).toBe(true);
+      expect(12 % span, `${bp} span should divide 12`).toBe(0);
+    }
+  });
+
+  test('the span set is exactly the five expected breakpoints', () => {
+    expect(Object.keys(LISTING_GRID_SPAN).sort()).toEqual(['base', 'lg', 'md', 'sm', 'xl']);
+  });
+});
+
+describe('LISTING_STORE_CONTAINER_SIZE', () => {
+  test('the store container width is UNTOUCHED at 1600', () => {
+    // The extra card width comes from the column-count drop, NOT from widening
+    // the page. If this ever changes, the grid span above must be re-derived.
+    expect(LISTING_STORE_CONTAINER_SIZE).toBe(1600);
+  });
+});

--- a/src/components/Apps/__tests__/appListingGrid.test.ts
+++ b/src/components/Apps/__tests__/appListingGrid.test.ts
@@ -1,8 +1,5 @@
 import { describe, expect, test } from 'vitest';
-import {
-  LISTING_GRID_SPAN,
-  LISTING_STORE_CONTAINER_SIZE,
-} from '~/components/Apps/appListingGrid';
+import { LISTING_GRID_SPAN, LISTING_STORE_CONTAINER_SIZE } from '~/components/Apps/appListingGrid';
 
 /**
  * `/apps` store GEOMETRY pins (blocking `unit` project).

--- a/src/components/Apps/appListingGrid.ts
+++ b/src/components/Apps/appListingGrid.ts
@@ -1,0 +1,43 @@
+import type { MantineSize } from '@mantine/core';
+
+/**
+ * App Store Listings (W13) — the `/apps` store's GEOMETRY constants, split out of
+ * the component so they're pinnable in a plain (node-project) unit test rather
+ * than by asserting Mantine's generated responsive CSS.
+ *
+ * They're a matched pair: the column span decides how many cards fit per row and
+ * the container width decides how wide a row is, so a change to one without the
+ * other silently re-truncates the cards. Keeping both here makes that coupling
+ * explicit and makes "the container was NOT changed" a real assertion instead of
+ * a code-review promise.
+ */
+
+/**
+ * Store-grid column span per breakpoint.
+ *
+ * `xl: 3` → FOUR columns on a wide viewport. This is the product-feedback change
+ * ("make app cover images larger — fewer columns per row?"): it was `2.4` (five
+ * columns), and dropping to four gives each card ~25% more width, which the
+ * responsive 16:9 cover in `AppListingCard` turns directly into bigger art.
+ *
+ * Every other breakpoint is UNCHANGED (base 12 → 1 col, sm 6 → 2, md 4 → 3,
+ * lg 3 → 4). Deliberately a one-breakpoint change: the narrower breakpoints were
+ * already at a comfortable card width, and widening them would push cards past a
+ * readable measure on tablets.
+ */
+export const LISTING_GRID_SPAN = {
+  base: 12,
+  sm: 6,
+  md: 4,
+  lg: 3,
+  xl: 3,
+} as const;
+
+/**
+ * `/apps` store container width (px), passed to `AppsPageLayout size=`.
+ *
+ * UNCHANGED at 1600 by the cover/CTA pass — the extra card width comes from the
+ * column-count drop above, not from widening the page. Pinned here so a future
+ * edit to the grid can't quietly move the container too.
+ */
+export const LISTING_STORE_CONTAINER_SIZE: MantineSize | number = 1600;

--- a/src/pages/apps/index.tsx
+++ b/src/pages/apps/index.tsx
@@ -1,6 +1,7 @@
 import { NotFound } from '~/components/AppLayout/NotFound';
 import { AppsPageLayout } from '~/components/Apps/AppsPageLayout';
 import { AppListingsMarketplaceBody } from '~/components/Apps/AppListingsMarketplaceBody';
+import { LISTING_STORE_CONTAINER_SIZE } from '~/components/Apps/appListingGrid';
 import { resolveAppsPageAccess } from '~/components/Apps/resolveAppsPageAccess';
 import { Meta } from '~/components/Meta/Meta';
 import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
@@ -47,10 +48,11 @@ export default function AppsPage() {
           (`blocks.backfillAppListings` → `appListings.backfillListingAssets`,
           a separate post-deploy op step) — the empty state renders sanely
           ("No apps yet"); expected + fine while dark. */}
-      <AppsPageLayout size={1600}>
-        {/* Widened past the default `xl` (1320px) token — a 5-across grid at this
-            container width needs the extra room to keep card text from
-            truncating (see AppListingsMarketplaceBody's `xl` column span). */}
+      <AppsPageLayout size={LISTING_STORE_CONTAINER_SIZE}>
+        {/* Widened past the default `xl` (1320px) token. The width is UNCHANGED by
+            the larger-cover pass — the store now runs a 4-across grid at `xl` (see
+            `LISTING_GRID_SPAN`), and the container/grid pair is pinned together in
+            `appListingGrid.ts` so neither can drift alone. */}
         <AppListingsMarketplaceBody />
       </AppsPageLayout>
     </>


### PR DESCRIPTION
Three pieces of App-marketplace UX feedback, all behind the existing `/apps` flag gate (no access change, no schema change, no server change).

> 1. Make app cover images larger — fewer columns per row?
> 2. Make the Visit and Open CTAs larger.
> 3. Launching an app should feel magical and be a delightful, intuitive, simple and subtly animated experience.

## 1 — Bigger covers

**Grid** (`AppListingsMarketplaceBody`): 5 columns → 4 at `xl` (span `2.4` → `3`). Every other breakpoint is unchanged (base 12 / sm 6 / md 4 / lg 3) and **the store container width is unchanged at 1600** — the extra card width comes from the column-count drop, not from widening the page. Both numbers now live together in a new `appListingGrid.ts` so the container and the grid are pinned as a pair and can't drift apart.

**Cover** (`AppListingCard`): the fixed `h={140}` letterbox became a responsive **16:9** box, so the art actually grows with the wider column instead of staying a short strip. The cover is already served at `width: 1200`, so there is ~8× resolution headroom — **this is purely client-side: no DTO, service, or pipeline change.**

CLS is preserved, not traded away: `aspect-ratio` derives the box height from the (already-known) column width *before* the image loads, and the `onError` category-glyph placeholder renders inside the **same** box, so a dangling cover URL swaps art with zero reflow. The placeholder stays `aria-hidden`.

## 2 — Bigger CTAs

The kind-aware primary CTA and the owner-only secondary **Edit** both move one notch up Mantine's size scale (`xs` → `sm`), with icon sizes to match. Because `sm` buttons are taller/wider, the outer action row is now allowed to wrap (actions drop to their own line on a narrow column) rather than overflowing the card; the inner action group stays `nowrap` so Edit and the CTA never split.

The CTA *logic* is untouched and test-pinned: external **Visit** is still a new-tab anchor with `rel="noopener noreferrer"`, `canOpenPage=false` still falls back to **View details**, and the owner Edit deep-link + owner-only "Incomplete" badge still render exactly as before.

## 3 — A branded, animated launch

`/apps/run/<slug>` previously showed a bare spinner and then popped the block in. It now shows a **branded launch state** — the app's initial in the same avatar treatment the store card uses, plus its name ("Starting …") — which **cross-fades out as the block fades and settles in** on `BLOCK_READY`. That gives a visual through-line from card → run page.

**CSS, not `motion`.** `motion` is a dependency, but it is **not in the `/apps` route graph**: its only importers are `src/components/Chat/*` and `src/utils/lazy-motion.ts`, and Chat is reached through a `next/dynamic` `ChatWindow` chunk. Importing it here would pull a new animation runtime into the run-page bundle for one cross-fade, so the reveal is a plain CSS opacity/transform transition.

**`prefers-reduced-motion: reduce` collapses it to 0ms** — no transition is emitted on either the veil or the block, and the veil is dropped in the same commit the block turns ready.

### 🔴 The reveal cannot gate the error path

The host has **four** terminal states — `timeout` (the ~10s BLOCK_READY timer), `fatal`, `no_token` (the ~15s token wait) and `error` (a hard mint failure). Each one flips `showIframe` false, which unmounts the entire iframe + veil branch and renders `BlockFallback` in the same commit; the fade-out timer is simply cleaned up. Nothing about the fallback render reads animation state, and `AppBlockChrome` still wraps **every** state (the FRAME-1 invariant). The manifest's `iframe.minHeight` reserve is untouched — no grow-jump is reintroduced.

This is regression-tested for all four terminals, including the sharpest case: an error that lands **during** the cross-fade window, asserted to reach the fallback within a window far shorter than the reveal duration.

## Also: a latent analytics bug this work uncovered

The run-page render/impression beacon used to fire from **inside** the `BLOCK_READY` handler, behind a flag set by the `setStatus` **updater**:

```ts
let acked = false;
setStatus((current) => { if (current === 'loading') { acked = true; return 'ready'; } return current; });
if (acked) { …sendBlockRender… }
```

That only works while React evaluates the updater **eagerly**, which it does only when the fiber has no other pending update. As soon as *any* unrelated state update is queued when `BLOCK_READY` lands, React defers the updater, `acked` is still `false` at the `if`, and **the impression is silently dropped**. The host has plenty of such updates in the real world (token rotation, the image-scan poller list) — this was latent analytics loss, and adding one more post-mount state update reproduced it **deterministically, 5/5 runs**.

The beacon now keys off the **committed** `status`, mirroring the render-FAILURE beacon effect directly below it, which is batching-independent. `notifyReady()` is now called unconditionally (it is documented-idempotent) for the same reason.

**Known sibling, deliberately not fixed here:** `IframeHost` (the model-slot host) has the identical in-handler pattern and additionally gates `applyHeight` on it, so it carries the same bug. Different surface, and the height semantics deserve their own change.

## Testing

- **New blocking unit suite** `appListingGrid.test.ts` pinning the span per breakpoint and the container width.
- **Extended** `AppListingCard` / `AppListingsMarketplaceBody` browser suites (not replaced): cover inside the 16:9 box; `onError` placeholder fills the same box and stays decorative; both CTAs render at `sm`; external Visit keeps its new-tab anchor; the retired 5-column basis is gone from the generated grid CSS.
- **New** `PageBlockHostLaunchReveal.browser.test.tsx`: branded loading, reveal on ready, sanitizer applied to the visible launch copy, reduced-motion emits no transitions, and each terminal state still reaches `BlockFallback` inside `AppBlockChrome`.
- **Every new guard was mutation-verified** (break it, confirm a specific test fails, revert): 17 mutations, 16 killed, 1 confirmed equivalent.
- `tsc --noEmit` clean; the touched files are lint-clean, and a drive-by removed the last `consistent-type-imports` error in `src/components/AppBlocks`.

## Verification status

`/apps` is mod-gated, so this was **not** visually verified — please drive it with a logged-in mod session. Manual steps are in the review thread.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
