### PR TITLE
perf(build): enable Turbopack server-side nested async chunking (-316.7 MiB of server chunk source)

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -192,6 +192,21 @@ export default defineNextConfig(
       serverSourceMaps: true,
       // instrumentationHook removed in Next 15 — instrumentation.ts is enabled by default now
       largePageDataBytes: 512 * 100000,
+      // Nested async chunking for the SERVER build. Next's own default table
+      // (node_modules/next/dist/docs/01-app/03-api-reference/08-turbopack.md) has
+      // `turbopackClientSideNestedAsyncChunking` defaulting to TRUE in build mode but
+      // `turbopackServerSideNestedAsyncChunking` defaulting to FALSE in *both* dev and
+      // build — so the server build never got the async-chunk dedup the client build has,
+      // and every async chunk group re-emits its whole module graph.
+      //
+      // Measured on the production server build: 21,247 emitted chunk files / 587 MB of
+      // chunk source across 7,844 distinct modules — ~150 copies per module, 96.7% of
+      // chunk bytes duplicated. Enabling this on the same commit: 5,830 files / 255 MB
+      // (-72.6% files, -316.7 MiB), page entries unchanged at 548.
+      //
+      // Cost: ~+37% build wall time. Keep build memory headroom in mind — the builder
+      // already peaks well above 8 GB.
+      turbopackServerSideNestedAsyncChunking: true,
       optimizePackageImports: [
         '@civitai/client',
         './src/libs/form',

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -192,20 +192,16 @@ export default defineNextConfig(
       serverSourceMaps: true,
       // instrumentationHook removed in Next 15 — instrumentation.ts is enabled by default now
       largePageDataBytes: 512 * 100000,
-      // Nested async chunking for the SERVER build. Next's own default table
+      // Nested async chunking for the SERVER build. Next's own defaults table
       // (node_modules/next/dist/docs/01-app/03-api-reference/08-turbopack.md) has
       // `turbopackClientSideNestedAsyncChunking` defaulting to TRUE in build mode but
       // `turbopackServerSideNestedAsyncChunking` defaulting to FALSE in *both* dev and
       // build — so the server build never got the async-chunk dedup the client build has,
       // and every async chunk group re-emits its whole module graph.
       //
-      // Measured on the production server build: 21,247 emitted chunk files / 587 MB of
-      // chunk source across 7,844 distinct modules — ~150 copies per module, 96.7% of
-      // chunk bytes duplicated. Enabling this on the same commit: 5,830 files / 255 MB
-      // (-72.6% files, -316.7 MiB), page entries unchanged at 548.
-      //
-      // Cost: ~+37% build wall time. Keep build memory headroom in mind — the builder
-      // already peaks well above 8 GB.
+      // Trade: ~72% fewer emitted server chunks and roughly half the server chunk bytes,
+      // in exchange for ~+8% CI build time and ~+33% peak builder RSS. Measurements live
+      // in the PR rather than here, so they don't rot when Next's chunker changes.
       turbopackServerSideNestedAsyncChunking: true,
       optimizePackageImports: [
         '@civitai/client',


### PR DESCRIPTION
Next ships the client build with async-chunk dedup and the server build without it.

From Next 16.2.7's own defaults table (`node_modules/next/dist/docs/01-app/03-api-reference/08-turbopack.md:269-270`, verified verbatim):

| flag | dev default | build default |
|---|---|---|
| `turbopackClientSideNestedAsyncChunking` | false | **true** |
| `turbopackServerSideNestedAsyncChunking` | false | **false** |

So every async chunk group in the server build re-emits its whole module graph.

## Measured — same-commit A/B

Two throwaway worktrees, identical env, cold `.next`. Both arms reached `✓ Compiled successfully` and both aborted at the same later stage (`Failed to collect page data` — no DB locally), so the emitted-output comparison is apples-to-apples:

| | flag OFF | flag ON | Δ |
|---|---|---|---|
| `.next/server/chunks/**/*.js` files | 21,341 | **5,787** | **−72.9%** |
| chunk `.js` bytes | 596,646,895 | **259,058,894** | **−321.9 MiB (−56.6%)** |
| chunk `.js.map` bytes | 1,406,897,393 | 870,028,268 | −512.0 MiB (−38.2%) |
| `.next/server` total | 2,481,104,905 | 1,606,913,643 | −833.7 MiB (−35.2%) |
| `.next/static` content md5 | `5e8c985b…` | `5e8c985b…` | **identical** |
| page entries | 548 | 548 | unchanged |

Confirmed on the **deployed preview image** for this commit: standalone `.next/server/chunks/*.js` 21,341 → **5,787**, chunk bytes 597,663,216 → **259,324,555**, `.next/server` 1,075.7 MB → 737.6 MB. Server source maps staged: 21,893 (1.4 G) → **6,339 (845.3 M)**.

Per-module copies for four heavily-shared modules: **490→15, 497→9, 312→9, 484→10**.

## Costs — measured, and lower than first stated

| | value |
|---|---|
| CI build step (this commit) | **312.8 s** vs ~290 s baseline median → **+7.9%** |
| cold local A/B wall | +13% (Turbopack compile +19%) |
| **peak builder RSS** | **16.96 GiB → 22.51 GiB (+5.55 GiB, +33%)** |

⚠️ An earlier revision of this PR said **+37% build wall time**. That was wrong — it compared against an anomalously fast local baseline. Real CI is **+7.9%**, which is 5.8% of the 1h30m task timeout.

🔴 **The genuine watch item is build memory, not build time.** Peak RSS rises 16.96 → 22.51 GiB against buildkit's 32Gi limit, so headroom falls from ~15 GiB to ~9.5 GiB on one observation. It fit, and CI built this commit successfully. The local box had 24 cores vs buildkit's 12, so 22.5 GiB is likely an upper bound. Bumping the buildkit limit 32Gi → 40Gi is cheap insurance and can land independently. (An earlier revision cited `NODE_BUILD_MEM=8192` — that is only the local default; CI already passes 16384.)

## Why this is low runtime risk — verified live

- `[turbopack]_runtime.js` is **md5-identical** across both arms (`8a704f70…`) and contains `if (!moduleFactories.has(id))`. Duplicate copies were already registered-then-discarded; this changes what is **emitted**, not module identity. No singleton / `instanceof` risk.
- **Eager load count and byte volume unchanged**: 27,210 `R.c(...)` calls in both arms, eager chunk bytes −0.03%, distinct eager chunks 1,401 → 1,399. (Chunk *filenames* are content hashes so they necessarily differ — an earlier revision wrongly said "byte-identical".)
- **Nothing dropped from the image**: staged map count equals chunks + 548 entries + 4 in both arms, and 0 of the 1,399 entry-referenced chunks are missing from the standalone image.
- Client output content is byte-identical, so no `optimizePackageImports` barrel-rewrite interaction.
- Preview pod Ready, 0 restarts. Smoke 59 pass / 2 fail — the same 2 failures appear on PRs 3452/3454/3455/3457 (pre-existing). Bundle-budget report byte-identical to baseline.

## Not verified

- **Process cold-start / warmup-gate duration on a production-shaped pod.** The eager-set equality above is a strong proxy, not a measurement; preview readiness timestamps are too coarse. Worth confirming post-merge.
- **Runtime memory saving is expected but NOT booked.** A server process retains ~223–240 MB of bundled chunk source (about two thirds of all string bytes in its heap). This flag leaves the eager set unchanged, so the saving comes from the lazy fraction — plausibly ~100 MB/process. To be measured after deploy with a heap snapshot, not claimed here.

## Reviewer gate

```
find .next/server/chunks -name "*.js" | wc -l     # ~21,341 -> ~5,787
find .next/server/chunks -name "*.js" -printf "%s\n" | awk "{s+=\$1} END{print s}"
```

## Not addressed here

A larger duplication axis remains on the **eager** side: first-party service modules bundled once per API entry group. Turbopack 16.2.7 exposes no knob for eager chunk-group sharing, and `serverExternalPackages` does not help (first-party modules). Needs an app-level refactor of route→service imports; scoped separately.

Related upstream: vercel/next.js#89192, vercel/next.js#95559.