### PR TITLE
feat(announcements): targeted announcements with optional user notifi…

### DIFF
--- a/packages/civitai-db-schema/prisma/migrations/20260729190000_targeted_announcements/migration.sql
+++ b/packages/civitai-db-schema/prisma/migrations/20260729190000_targeted_announcements/migration.sql
@@ -1,0 +1,24 @@
+-- Targeted announcements: per-announcement allowlist of user ids.
+-- An announcement with rows here is only shown to those users; announcements
+-- without rows keep the current show-everyone behavior.
+CREATE TABLE "AnnouncementUser" (
+    "announcementId" INTEGER NOT NULL,
+    "userId" INTEGER NOT NULL,
+
+    CONSTRAINT "AnnouncementUser_pkey" PRIMARY KEY ("userId", "announcementId")
+);
+
+-- PK ("userId", "announcementId") serves the hot read path: membership lookup for
+-- one user against the small set of currently-live targeted announcements.
+-- This index serves the write path: replacing/deleting an announcement's target set.
+CREATE INDEX "AnnouncementUser_announcementId_idx" ON "AnnouncementUser"("announcementId");
+
+ALTER TABLE "AnnouncementUser"
+    ADD CONSTRAINT "AnnouncementUser_announcementId_fkey"
+    FOREIGN KEY ("announcementId") REFERENCES "Announcement"("id")
+    ON DELETE CASCADE ON UPDATE CASCADE;
+
+ALTER TABLE "AnnouncementUser"
+    ADD CONSTRAINT "AnnouncementUser_userId_fkey"
+    FOREIGN KEY ("userId") REFERENCES "User"("id")
+    ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/civitai-db-schema/prisma/schema.full.prisma
+++ b/packages/civitai-db-schema/prisma/schema.full.prisma
@@ -589,6 +589,7 @@ model User {
   appListingReportsReported          AppListingReport[]         @relation("AppListingReportReporter")
   appListingReportsResolved          AppListingReport[]         @relation("AppListingReportResolver")
   appListingModerationEvents         AppListingModerationEvent[] @relation("AppListingModEventActor")
+  targetedAnnouncements              AnnouncementUser[]
 
   @@index([deletedAt])
 }
@@ -3751,18 +3752,30 @@ enum DomainColor {
 }
 
 model Announcement {
-  id        Int           @id @default(autoincrement())
-  title     String
-  content   String
-  emoji     String?
-  color     String        @default("blue")
-  domain    DomainColor[] @default([all])
-  createdAt DateTime      @default(now())
-  updatedAt DateTime      @updatedAt
-  startsAt  DateTime?
-  endsAt    DateTime?
-  metadata  Json?
-  disabled  Boolean       @default(false)
+  id          Int                @id @default(autoincrement())
+  title       String
+  content     String
+  emoji       String?
+  color       String             @default("blue")
+  domain      DomainColor[]      @default([all])
+  createdAt   DateTime           @default(now())
+  updatedAt   DateTime           @updatedAt
+  startsAt    DateTime?
+  endsAt      DateTime?
+  metadata    Json?
+  disabled    Boolean            @default(false)
+  targetUsers AnnouncementUser[]
+}
+
+/// Allowlist of users an announcement targets. No rows = shown to everyone.
+model AnnouncementUser {
+  announcementId Int
+  userId         Int
+  announcement   Announcement @relation(fields: [announcementId], references: [id], onDelete: Cascade)
+  user           User         @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@id([userId, announcementId])
+  @@index([announcementId])
 }
 
 model RewardsBonusEvent {

--- a/packages/civitai-db-schema/src/kysely/types.ts
+++ b/packages/civitai-db-schema/src/kysely/types.ts
@@ -163,6 +163,10 @@ export type Announcement = {
   metadata: unknown | null;
   disabled: Generated<boolean>;
 };
+export type AnnouncementUser = {
+  announcementId: number;
+  userId: number;
+};
 export type Answer = {
   id: Generated<number>;
   questionId: number;
@@ -3884,6 +3888,7 @@ export type DB = {
   Account: Account;
   AdToken: AdToken;
   Announcement: Announcement;
+  AnnouncementUser: AnnouncementUser;
   Answer: Answer;
   AnswerMetric: AnswerMetric;
   AnswerRank: AnswerRank;

--- a/packages/civitai-db-schema/src/models.ts
+++ b/packages/civitai-db-schema/src/models.ts
@@ -649,6 +649,7 @@ export interface User {
   appListingReportsReported?: AppListingReport[];
   appListingReportsResolved?: AppListingReport[];
   appListingModerationEvents?: AppListingModerationEvent[];
+  targetedAnnouncements?: AnnouncementUser[];
 }
 
 export interface CustomerSubscription {
@@ -2534,6 +2535,14 @@ export interface Announcement {
   endsAt: Date | null;
   metadata: JsonValue | null;
   disabled: boolean;
+  targetUsers?: AnnouncementUser[];
+}
+
+export interface AnnouncementUser {
+  announcementId: number;
+  userId: number;
+  announcement?: Announcement;
+  user?: User;
 }
 
 export interface RewardsBonusEvent {

--- a/src/components/Announcements/AnnouncementEditModal.browser.test.tsx
+++ b/src/components/Announcements/AnnouncementEditModal.browser.test.tsx
@@ -59,6 +59,9 @@ vi.mock('~/utils/trpc', async (importOriginal) => ({
       upsertAnnouncement: {
         useMutation: () => ({ mutate: mocks.mutate, isPending: false }),
       },
+      getAnnouncementTargets: {
+        useQuery: () => ({ data: [], isSuccess: true }),
+      },
     },
   },
 }));

--- a/src/components/Announcements/AnnouncementEditModal.tsx
+++ b/src/components/Announcements/AnnouncementEditModal.tsx
@@ -1,7 +1,7 @@
 import type { SelectProps } from '@mantine/core';
 import { Button, ColorSwatch, Modal, useMantineTheme } from '@mantine/core';
 import dayjs from '~/shared/utils/dayjs';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import * as z from 'zod';
 import { useDialogContext } from '~/components/Dialog/DialogProvider';
 import {
@@ -23,8 +23,10 @@ import {
   toAnnouncementImageKey,
 } from '~/components/Announcements/announcement-image';
 import type { UpsertAnnouncementSchema } from '~/server/schema/announcement.schema';
+import { MAX_ANNOUNCEMENT_TARGET_USERS } from '~/server/schema/announcement.schema';
 import { DomainColor } from '~/shared/utils/prisma/enums';
 import { dateWithoutTimezone, endOfDay, startOfDay } from '~/utils/date-helpers';
+import { showErrorNotification } from '~/utils/notifications';
 import { capitalize } from '~/utils/string-helpers';
 import { trpc } from '~/utils/trpc';
 
@@ -39,9 +41,23 @@ const schema = z.object({
   disabled: z.boolean().optional(),
   linkText: z.string().optional(),
   linkUrl: z.string().optional(),
+  targetUserIds: z.string().optional(),
+  notifyTargetedUsers: z.boolean().optional(),
 });
 
 export const UPLOAD_IN_FLIGHT_MESSAGE = 'Wait for the banner image to finish uploading.';
+
+export function parseTargetUserIds(value?: string) {
+  const tokens = (value ?? '').split(/[\s,;]+/).filter(Boolean);
+  const ids = new Set<number>();
+  const invalid: string[] = [];
+  for (const token of tokens) {
+    const id = Number(token);
+    if (Number.isInteger(id) && id > 0) ids.add(id);
+    else invalid.push(token);
+  }
+  return { ids: [...ids], invalid };
+}
 
 const domainColorOptions = Object.values(DomainColor).map((domain) => ({
   value: domain,
@@ -86,6 +102,24 @@ export function AnnouncementEditModal({
   const theme = useMantineTheme();
   const colors = Object.keys(theme.colors);
 
+  // Existing target set, loaded lazily when editing. Until it resolves the textarea is
+  // disabled and `targetUserIds` is sent as undefined (leave targeting unchanged), so a
+  // quick save can never silently wipe an announcement's targeting.
+  const targetsQuery = trpc.announcement.getAnnouncementTargets.useQuery(
+    { id: announcement?.id as number },
+    { enabled: !!announcement?.id }
+  );
+  const targetsReady = !announcement?.id || targetsQuery.isSuccess;
+  useEffect(() => {
+    if (targetsQuery.data) form.setValue('targetUserIds', targetsQuery.data.join(', '));
+  }, [targetsQuery.data]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const watchedTargets = form.watch('targetUserIds');
+  const targetCount = useMemo(
+    () => parseTargetUserIds(watchedTargets).ids.length,
+    [watchedTargets]
+  );
+
   // Last banner key the form actually held. Replacing a banner is a two-step gesture —
   // remove (which clears form state) then drop — so at the moment an upload fails the
   // form no longer remembers what it is about to overwrite. Keeping the last non-empty
@@ -111,9 +145,38 @@ export function AnnouncementEditModal({
       dialog.onClose();
       queryUtils.announcement.getAnnouncementsPaged.invalidate();
     },
+    onError: (error) => {
+      // A bad target list rejects the whole save server-side; pin that message to the
+      // field the moderator has to fix.
+      if (error.message.includes('target user id'))
+        form.setError('targetUserIds', { type: 'manual', message: error.message });
+      showErrorNotification({ title: 'Failed to save announcement', error });
+    },
   });
 
-  function handleSubmit({ image, ...data }: z.infer<typeof schema>) {
+  function handleSubmit({
+    image,
+    targetUserIds: targetUserIdsRaw,
+    ...data
+  }: z.infer<typeof schema>) {
+    const { ids: targetUserIds, invalid } = parseTargetUserIds(targetUserIdsRaw);
+    if (invalid.length) {
+      form.setError('targetUserIds', {
+        type: 'manual',
+        message: `Not valid user ids: ${invalid.slice(0, 5).join(', ')}${
+          invalid.length > 5 ? ` (+${invalid.length - 5} more)` : ''
+        }`,
+      });
+      return;
+    }
+    if (targetUserIds.length > MAX_ANNOUNCEMENT_TARGET_USERS) {
+      form.setError('targetUserIds', {
+        type: 'manual',
+        message: `Too many target users (${targetUserIds.length.toLocaleString()}). Max is ${MAX_ANNOUNCEMENT_TARGET_USERS.toLocaleString()}.`,
+      });
+      return;
+    }
+
     // 🔴 A submit must not land while a banner upload is in flight. The upload widget
     // only writes the new key into form state once the upload reaches `success`, and
     // replacing a banner means removing the old one first — so a save mid-upload
@@ -134,6 +197,8 @@ export function AnnouncementEditModal({
     mutate({
       ...announcement,
       ...data,
+      targetUserIds: targetsReady ? targetUserIds : undefined,
+      notifyTargetedUsers: targetsReady && targetUserIds.length > 0 && data.notifyTargetedUsers,
       title: data.title.trim(),
       content: data.content.trim(),
       startsAt: isToday
@@ -178,6 +243,28 @@ export function AnnouncementEditModal({
           searchable
           clearable
         />
+
+        <InputTextArea
+          name="targetUserIds"
+          label="Target User IDs"
+          description={
+            targetCount > 0
+              ? `Targeting ${targetCount.toLocaleString()} user${targetCount === 1 ? '' : 's'}`
+              : 'Optional. Comma, space, or newline separated user ids. Leave empty to show the announcement to everyone.'
+          }
+          placeholder={targetsReady ? 'e.g. 123, 456, 789' : 'Loading current targets...'}
+          disabled={!targetsReady}
+          autosize
+          maxRows={6}
+        />
+
+        {targetCount > 0 && (
+          <InputCheckbox
+            name="notifyTargetedUsers"
+            label="Send a notification to targeted users"
+            description="On save, each targeted user also gets a system notification linking to the first announcement action (if any). Saving again with this checked sends it again."
+          />
+        )}
 
         {/*
           Banner upload — deliberately does NOT create an `Image` row.

--- a/src/components/Announcements/AnnouncementEditModal.tsx
+++ b/src/components/Announcements/AnnouncementEditModal.tsx
@@ -87,6 +87,10 @@ export function AnnouncementEditModal({
     schema,
     defaultValues: {
       ...announcement,
+      // The form field is a text blob, not the server's number[] — the current target
+      // set streams in via getAnnouncementTargets and form.setValue below.
+      targetUserIds: undefined,
+      notifyTargetedUsers: false,
       domain: announcement?.domain ?? [DomainColor.all],
       startsAt: announcement?.startsAt
         ? isToday

--- a/src/pages/moderator/announcements.tsx
+++ b/src/pages/moderator/announcements.tsx
@@ -59,6 +59,11 @@ export function AnnouncementsPage() {
               dismissible={false}
               moderatorActions={
                 <div className="flex items-center gap-1">
+                  {announcement.targetUserCount > 0 && (
+                    <Badge color="violet">
+                      Targeted · {announcement.targetUserCount.toLocaleString()}
+                    </Badge>
+                  )}
                   {announcement.disabled ? (
                     <Badge color="red">Disabled</Badge>
                   ) : active ? (

--- a/src/server/routers/announcement.router.ts
+++ b/src/server/routers/announcement.router.ts
@@ -7,6 +7,7 @@ import {
 import {
   deleteAnnouncement,
   getAnnouncementsPaged,
+  getAnnouncementTargetUserIds,
   getCurrentAnnouncements,
   upsertAnnouncement,
 } from '~/server/services/announcement.service';
@@ -29,4 +30,7 @@ export const announcementRouter = router({
   getAnnouncementsPaged: moderatorProcedure
     .input(getAnnouncementsPagedSchema)
     .query(({ input }) => getAnnouncementsPaged(input)),
+  getAnnouncementTargets: moderatorProcedure
+    .input(getByIdSchema)
+    .query(({ input }) => getAnnouncementTargetUserIds(input.id)),
 });

--- a/src/server/schema/announcement.schema.ts
+++ b/src/server/schema/announcement.schema.ts
@@ -42,6 +42,8 @@ export const announcementMetaSchema = z
   })
   .partial();
 
+export const MAX_ANNOUNCEMENT_TARGET_USERS = 50_000;
+
 export type UpsertAnnouncementSchema = z.infer<typeof upsertAnnouncementSchema>;
 export const upsertAnnouncementSchema = z.object({
   id: z.number().optional(),
@@ -53,6 +55,13 @@ export const upsertAnnouncementSchema = z.object({
   endsAt: z.date().nullish(),
   disabled: z.boolean().optional(),
   metadata: announcementMetaSchema,
+  // Replace-set semantics: undefined leaves targeting unchanged, [] clears it
+  // (announcement shows to everyone), a non-empty array restricts the
+  // announcement to exactly those users.
+  targetUserIds: z.array(z.number().int().positive()).max(MAX_ANNOUNCEMENT_TARGET_USERS).optional(),
+  // Only acted on when targetUserIds resolves to a non-empty set: sends a
+  // system-announcement notification to each targeted user on this save.
+  notifyTargetedUsers: z.boolean().optional(),
 });
 
 export type GetAnnouncementsPagedSchema = z.infer<typeof getAnnouncementsPagedSchema>;

--- a/src/server/services/__tests__/announcement-targeting.test.ts
+++ b/src/server/services/__tests__/announcement-targeting.test.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Targeted announcements ride the same global per-domain cache flagged with
+// `targeted: true`; getCurrentAnnouncements resolves per-user visibility with a
+// single AnnouncementUser membership lookup — and only when a targeted
+// announcement is actually live. These tests prove: non-members (and anon) never
+// see a targeted announcement, members do, the internal `targeted` flag never
+// leaks into the returned DTOs, and the membership query is skipped entirely
+// when nothing is targeted.
+const { redisGet, membershipFindMany, announcementCreate, userFindMany, createNotificationMock } =
+  vi.hoisted(() => ({
+    redisGet: vi.fn(),
+    membershipFindMany: vi.fn(),
+    announcementCreate: vi.fn(),
+    userFindMany: vi.fn(),
+    createNotificationMock: vi.fn(),
+  }));
+
+vi.mock('~/server/common/constants', () => ({ CacheTTL: { day: 86400 } }));
+vi.mock('~/server/services/notification.service', () => ({
+  createNotification: createNotificationMock,
+}));
+vi.mock('~/server/db/client', () => ({
+  dbRead: {
+    announcement: { findMany: vi.fn(), count: vi.fn() },
+    announcementUser: { findMany: membershipFindMany },
+    $transaction: vi.fn(),
+  },
+  dbWrite: {
+    announcement: { findMany: vi.fn(), create: announcementCreate, update: vi.fn() },
+    announcementUser: { deleteMany: vi.fn(), createMany: vi.fn() },
+    user: { findMany: userFindMany },
+    $transaction: vi.fn(),
+  },
+}));
+vi.mock('~/server/redis/client', () => ({
+  redis: { get: redisGet, set: vi.fn(), del: vi.fn() },
+  REDIS_KEYS: { CACHES: { ANNOUNCEMENTS: 'packed:caches:announcements' } },
+}));
+vi.mock('~/server/utils/pagination-helpers', () => ({
+  DEFAULT_PAGE_SIZE: 20,
+  getPagination: vi.fn(),
+  getPagingData: vi.fn(),
+}));
+vi.mock('~/shared/utils/prisma/enums', () => ({
+  DomainColor: { all: 'all', green: 'green', red: 'red' },
+}));
+
+async function loadService() {
+  vi.resetModules();
+  return import('../announcement.service');
+}
+
+function cachedAnnouncements() {
+  const base = {
+    title: 't',
+    content: 'c',
+    color: 'blue',
+    emoji: null,
+    createdAt: new Date('2000-01-01').toISOString(),
+    startsAt: new Date('2000-01-01').toISOString(),
+    endsAt: new Date('2100-01-01').toISOString(),
+    metadata: {},
+  };
+  return [
+    { ...base, id: 1, targeted: false },
+    { ...base, id: 2, targeted: true },
+  ];
+}
+
+describe('getCurrentAnnouncements targeting', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('hides targeted announcements from anonymous users without a membership query', async () => {
+    const { getCurrentAnnouncements } = await loadService();
+    redisGet.mockResolvedValue(JSON.stringify(cachedAnnouncements()));
+
+    const result = await getCurrentAnnouncements({});
+
+    expect(result.map((x) => x.id)).toEqual([1]);
+    expect(membershipFindMany).not.toHaveBeenCalled();
+  });
+
+  it('hides targeted announcements from non-members', async () => {
+    const { getCurrentAnnouncements } = await loadService();
+    redisGet.mockResolvedValue(JSON.stringify(cachedAnnouncements()));
+    membershipFindMany.mockResolvedValue([]);
+
+    const result = await getCurrentAnnouncements({ userId: 42 });
+
+    expect(result.map((x) => x.id)).toEqual([1]);
+    expect(membershipFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { userId: 42, announcementId: { in: [2] } } })
+    );
+  });
+
+  it('shows targeted announcements to members and strips the targeted flag', async () => {
+    const { getCurrentAnnouncements } = await loadService();
+    redisGet.mockResolvedValue(JSON.stringify(cachedAnnouncements()));
+    membershipFindMany.mockResolvedValue([{ announcementId: 2 }]);
+
+    const result = await getCurrentAnnouncements({ userId: 42 });
+
+    expect(result.map((x) => x.id)).toEqual([1, 2]);
+    for (const announcement of result) {
+      expect(announcement).not.toHaveProperty('targeted');
+    }
+  });
+
+  it('skips the membership query when no live announcement is targeted', async () => {
+    const { getCurrentAnnouncements } = await loadService();
+    redisGet.mockResolvedValue(JSON.stringify(cachedAnnouncements().filter((x) => !x.targeted)));
+
+    const result = await getCurrentAnnouncements({ userId: 42 });
+
+    expect(result.map((x) => x.id)).toEqual([1]);
+    expect(membershipFindMany).not.toHaveBeenCalled();
+  });
+
+  it('treats pre-migration cache entries (no targeted field) as visible to everyone', async () => {
+    const { getCurrentAnnouncements } = await loadService();
+    const legacy = cachedAnnouncements().map(({ targeted, ...x }) => x);
+    redisGet.mockResolvedValue(JSON.stringify(legacy));
+
+    const result = await getCurrentAnnouncements({ userId: 42 });
+
+    expect(result.map((x) => x.id)).toEqual([1, 2]);
+    expect(membershipFindMany).not.toHaveBeenCalled();
+  });
+});
+
+describe('upsertAnnouncement target notifications', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    announcementCreate.mockResolvedValue({
+      id: 7,
+      title: 'Hello',
+      metadata: { actions: [{ type: 'button', link: '/faq', linkText: 'FAQ' }] },
+    });
+  });
+
+  it('notifies the target users with the announcement title and action url', async () => {
+    const { upsertAnnouncement } = await loadService();
+    userFindMany.mockResolvedValue([{ id: 1 }, { id: 2 }]);
+
+    await upsertAnnouncement({
+      title: 'Hello',
+      content: 'c',
+      targetUserIds: [1, 2, 2],
+      notifyTargetedUsers: true,
+    } as never);
+
+    expect(createNotificationMock).toHaveBeenCalledTimes(1);
+    const arg = createNotificationMock.mock.calls[0][0];
+    expect(arg.userIds).toEqual([1, 2]);
+    expect(arg.type).toBe('system-announcement');
+    expect(arg.details).toEqual({ message: 'Hello', url: '/faq' });
+    expect(arg.key).toMatch(/^system-announcement:targeted:7:/);
+  });
+
+  it('does not notify without the flag', async () => {
+    const { upsertAnnouncement } = await loadService();
+    userFindMany.mockResolvedValue([{ id: 1 }]);
+
+    await upsertAnnouncement({ title: 'Hello', content: 'c', targetUserIds: [1] } as never);
+
+    expect(createNotificationMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects the whole save when target ids do not exist, naming them', async () => {
+    const { upsertAnnouncement } = await loadService();
+    userFindMany.mockResolvedValue([{ id: 1 }]);
+
+    await expect(
+      upsertAnnouncement({
+        title: 'Hello',
+        content: 'c',
+        targetUserIds: [1, 999, 1000],
+        notifyTargetedUsers: true,
+      } as never)
+    ).rejects.toThrow(/2 target user ids do not exist: 999, 1000/);
+
+    expect(announcementCreate).not.toHaveBeenCalled();
+    expect(createNotificationMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/services/__tests__/announcement-targeting.test.ts
+++ b/src/server/services/__tests__/announcement-targeting.test.ts
@@ -7,14 +7,23 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 // see a targeted announcement, members do, the internal `targeted` flag never
 // leaks into the returned DTOs, and the membership query is skipped entirely
 // when nothing is targeted.
-const { redisGet, membershipFindMany, announcementCreate, userFindMany, createNotificationMock } =
-  vi.hoisted(() => ({
-    redisGet: vi.fn(),
-    membershipFindMany: vi.fn(),
-    announcementCreate: vi.fn(),
-    userFindMany: vi.fn(),
-    createNotificationMock: vi.fn(),
-  }));
+const {
+  redisGet,
+  membershipFindMany,
+  announcementCreate,
+  userFindMany,
+  createNotificationMock,
+  targetDeleteMany,
+  targetCreateMany,
+} = vi.hoisted(() => ({
+  redisGet: vi.fn(),
+  membershipFindMany: vi.fn(),
+  announcementCreate: vi.fn(),
+  userFindMany: vi.fn(),
+  createNotificationMock: vi.fn(),
+  targetDeleteMany: vi.fn(),
+  targetCreateMany: vi.fn(),
+}));
 
 vi.mock('~/server/common/constants', () => ({ CacheTTL: { day: 86400 } }));
 vi.mock('~/server/services/notification.service', () => ({
@@ -28,7 +37,7 @@ vi.mock('~/server/db/client', () => ({
   },
   dbWrite: {
     announcement: { findMany: vi.fn(), create: announcementCreate, update: vi.fn() },
-    announcementUser: { deleteMany: vi.fn(), createMany: vi.fn() },
+    announcementUser: { deleteMany: targetDeleteMany, createMany: targetCreateMany },
     user: { findMany: userFindMany },
     $transaction: vi.fn(),
   },
@@ -167,6 +176,20 @@ describe('upsertAnnouncement target notifications', () => {
     await upsertAnnouncement({ title: 'Hello', content: 'c', targetUserIds: [1] } as never);
 
     expect(createNotificationMock).not.toHaveBeenCalled();
+  });
+
+  it('clears the target set when [] is passed, and leaves it untouched when omitted', async () => {
+    const { upsertAnnouncement } = await loadService();
+
+    await upsertAnnouncement({ title: 'Hello', content: 'c', targetUserIds: [] } as never);
+    expect(targetDeleteMany).toHaveBeenCalledWith({ where: { announcementId: 7 } });
+    expect(targetCreateMany).not.toHaveBeenCalled();
+
+    vi.clearAllMocks();
+    announcementCreate.mockResolvedValue({ id: 7, title: 'Hello', metadata: {} });
+    await upsertAnnouncement({ title: 'Hello', content: 'c' } as never);
+    expect(targetDeleteMany).not.toHaveBeenCalled();
+    expect(targetCreateMany).not.toHaveBeenCalled();
   });
 
   it('rejects the whole save when target ids do not exist, naming them', async () => {

--- a/src/server/services/announcement.service.ts
+++ b/src/server/services/announcement.service.ts
@@ -28,14 +28,16 @@ export async function upsertAnnouncement({
 }: UpsertAnnouncementSchema) {
   // Validated BEFORE the announcement is written: a bad target list must reject the
   // whole save, not persist an announcement whose targeting silently differs from
-  // what the moderator submitted.
-  const targets = targetUserIds ? await validateTargetUserIds(targetUserIds) : undefined;
+  // what the moderator submitted. Explicitly undefined-checked: [] is a meaningful
+  // value here (clear targeting), only an omitted field means "leave unchanged".
+  const targets =
+    targetUserIds !== undefined ? await validateTargetUserIds(targetUserIds) : undefined;
 
   const result = data.id
     ? await dbWrite.announcement.update({ where: { id: data.id }, data })
     : await dbWrite.announcement.create({ data });
 
-  if (targets) {
+  if (targets !== undefined) {
     await setAnnouncementTargets(result.id, targets);
     if (notifyTargetedUsers && targets.length) {
       await notifyAnnouncementTargets(result, targets);

--- a/src/server/services/announcement.service.ts
+++ b/src/server/services/announcement.service.ts
@@ -1,5 +1,8 @@
 import type { Prisma } from '@prisma/client';
+import { chunk } from 'lodash-es';
+import { v4 as uuid } from 'uuid';
 import { CacheTTL } from '~/server/common/constants';
+import { NotificationCategory } from '~/server/common/enums';
 import { dbRead, dbWrite } from '~/server/db/client';
 import type { RedisKeyTemplateCache } from '~/server/redis/client';
 import { REDIS_KEYS, redis } from '~/server/redis/client';
@@ -8,6 +11,7 @@ import type {
   GetAnnouncementsPagedSchema,
   UpsertAnnouncementSchema,
 } from '~/server/schema/announcement.schema';
+import { throwBadRequestError } from '~/server/utils/errorHandling';
 import { DEFAULT_PAGE_SIZE, getPagination, getPagingData } from '~/server/utils/pagination-helpers';
 import { DomainColor } from '~/shared/utils/prisma/enums';
 import { createKeyedTtlMemo } from '~/server/utils/ttl-memoize';
@@ -17,15 +21,112 @@ const announcementRedisKeys = ['', ...domainColors].map((domain) =>
   domain ? `${REDIS_KEYS.CACHES.ANNOUNCEMENTS}:${domain}` : REDIS_KEYS.CACHES.ANNOUNCEMENTS
 ) as RedisKeyTemplateCache[];
 
-export async function upsertAnnouncement(data: UpsertAnnouncementSchema) {
+export async function upsertAnnouncement({
+  targetUserIds,
+  notifyTargetedUsers,
+  ...data
+}: UpsertAnnouncementSchema) {
+  // Validated BEFORE the announcement is written: a bad target list must reject the
+  // whole save, not persist an announcement whose targeting silently differs from
+  // what the moderator submitted.
+  const targets = targetUserIds ? await validateTargetUserIds(targetUserIds) : undefined;
+
   const result = data.id
     ? await dbWrite.announcement.update({ where: { id: data.id }, data })
     : await dbWrite.announcement.create({ data });
+
+  if (targets) {
+    await setAnnouncementTargets(result.id, targets);
+    if (notifyTargetedUsers && targets.length) {
+      await notifyAnnouncementTargets(result, targets);
+    }
+  }
 
   // Clear all announcement caches when upserting
   await redis.del(announcementRedisKeys);
 
   return result;
+}
+
+// Matches the transport's own bulk chunking so no single request carries an
+// oversized recipient list.
+const NOTIFY_TARGETS_CHUNK_SIZE = 1000;
+
+async function notifyAnnouncementTargets(
+  announcement: { id: number; title: string; metadata: Prisma.JsonValue },
+  userIds: number[]
+) {
+  // Lazy: notification.service's import chain (detail-fetchers → buzz/currency) is far
+  // heavier than this service and only needed on this mod-only write path.
+  const { createNotification } = await import('~/server/services/notification.service');
+  const metadata = (announcement.metadata ?? {}) as AnnouncementMetaSchema;
+  const url = metadata.actions?.[0]?.link;
+  for (const batch of chunk(userIds, NOTIFY_TARGETS_CHUNK_SIZE)) {
+    // uuid keeps each send unique: reusing a key would merge recipients into a
+    // previously-processed PendingNotification row and they'd never be delivered.
+    await createNotification({
+      userIds: batch,
+      category: NotificationCategory.System,
+      type: 'system-announcement',
+      key: `system-announcement:targeted:${announcement.id}:${uuid()}`,
+      details: { message: announcement.title, url },
+    });
+  }
+}
+
+// Keeps each INSERT comfortably under the postgres bind-parameter limit.
+const TARGET_USERS_CHUNK_SIZE = 5000;
+
+/**
+ * Dedupes `userIds` and throws BAD_REQUEST naming the ids that have no `User` row,
+ * so the moderator can fix their pasted list instead of silently targeting fewer
+ * users than they submitted.
+ */
+async function validateTargetUserIds(userIds: number[]) {
+  const uniqueIds = [...new Set(userIds)];
+
+  const foundIds = new Set<number>();
+  for (const batch of chunk(uniqueIds, TARGET_USERS_CHUNK_SIZE)) {
+    const users = await dbWrite.user.findMany({
+      where: { id: { in: batch } },
+      select: { id: true },
+    });
+    for (const user of users) foundIds.add(user.id);
+  }
+
+  const missingIds = uniqueIds.filter((id) => !foundIds.has(id));
+  if (missingIds.length) {
+    throw throwBadRequestError(
+      `${missingIds.length} target user id${
+        missingIds.length === 1 ? ' does' : 's do'
+      } not exist: ${missingIds.slice(0, 20).join(', ')}${
+        missingIds.length > 20 ? `, … (+${missingIds.length - 20} more)` : ''
+      }`
+    );
+  }
+
+  return uniqueIds;
+}
+
+/** Replaces an announcement's target set (empty = untargeted, shown to everyone). */
+async function setAnnouncementTargets(announcementId: number, userIds: number[]) {
+  await dbWrite.$transaction([
+    dbWrite.announcementUser.deleteMany({ where: { announcementId } }),
+    ...chunk(userIds, TARGET_USERS_CHUNK_SIZE).map((batch) =>
+      dbWrite.announcementUser.createMany({
+        data: batch.map((userId) => ({ announcementId, userId })),
+      })
+    ),
+  ]);
+}
+
+export async function getAnnouncementTargetUserIds(announcementId: number) {
+  const rows = await dbRead.announcementUser.findMany({
+    where: { announcementId },
+    select: { userId: true },
+    orderBy: { userId: 'asc' },
+  });
+  return rows.map((x) => x.userId);
 }
 
 export async function deleteAnnouncement(id: number) {
@@ -55,6 +156,7 @@ export async function getAnnouncementsPaged(data: GetAnnouncementsPagedSchema) {
         disabled: true,
         metadata: true,
         emoji: true,
+        _count: { select: { targetUsers: true } },
       },
       orderBy: { startsAt: { sort: 'desc', nulls: 'last' } },
     }),
@@ -63,10 +165,11 @@ export async function getAnnouncementsPaged(data: GetAnnouncementsPagedSchema) {
 
   return getPagingData(
     {
-      items: items.map((item) => ({
+      items: items.map(({ _count, ...item }) => ({
         ...item,
         startsAt: item.startsAt ?? new Date(),
         metadata: (item.metadata ?? {}) as AnnouncementMetaSchema,
+        targetUserCount: _count.targetUsers,
       })),
       count,
     },
@@ -81,11 +184,11 @@ export async function getCurrentAnnouncements({
 }: {
   userId?: number;
   domain?: DomainColor;
-}) {
+}): Promise<AnnouncementDTO[]> {
   const announcements = await getAnnouncementsCached(domain);
   const now = Date.now();
 
-  return announcements.filter((announcement) => {
+  const active = announcements.filter((announcement) => {
     if (!userId && announcement.metadata.targetAudience === 'authenticated') return false;
     if (!!userId && announcement.metadata.targetAudience === 'unauthenticated') return false;
     const startsAt = new Date(announcement.startsAt ?? now).getTime();
@@ -93,6 +196,23 @@ export async function getCurrentAnnouncements({
     if (startsAt <= now && now <= endsAt) return true;
     return false;
   });
+
+  // Targeted announcements ride the same global per-domain cache (flagged at cache
+  // fill), so membership costs one indexed lookup per request — and only while a
+  // targeted announcement is actually live; the common no-targeting case adds nothing.
+  const targetedIds = active.filter((x) => x.targeted).map((x) => x.id);
+  let visibleTargetedIds: Set<number> | undefined;
+  if (targetedIds.length && userId) {
+    const memberships = await dbRead.announcementUser.findMany({
+      where: { userId, announcementId: { in: targetedIds } },
+      select: { announcementId: true },
+    });
+    visibleTargetedIds = new Set(memberships.map((x) => x.announcementId));
+  }
+
+  return active
+    .filter((x) => !x.targeted || visibleTargetedIds?.has(x.id))
+    .map(({ targeted, ...announcement }) => announcement);
 }
 
 // This redis read is GLOBAL per domain — the per-user (targetAudience) + active
@@ -108,7 +228,7 @@ export async function getCurrentAnnouncements({
 // shared per-domain array.
 const ANNOUNCEMENTS_INPROC_TTL_MS = 30_000;
 
-const getAnnouncementsCachedMemo = createKeyedTtlMemo<AnnouncementDTO[]>(
+const getAnnouncementsCachedMemo = createKeyedTtlMemo<CachedAnnouncement[]>(
   async (domainKey) => {
     const domain = (domainKey || undefined) as DomainColor | undefined;
     const cacheKey: RedisKeyTemplateCache = domain
@@ -116,7 +236,7 @@ const getAnnouncementsCachedMemo = createKeyedTtlMemo<AnnouncementDTO[]>(
       : REDIS_KEYS.CACHES.ANNOUNCEMENTS;
 
     const cached = await redis.get(cacheKey);
-    if (cached) return JSON.parse(cached) as AnnouncementDTO[];
+    if (cached) return JSON.parse(cached) as CachedAnnouncement[];
 
     const announcements = await getAnnouncements(domain);
 
@@ -203,7 +323,11 @@ export async function getMonitoredAnnouncementImageRefs(
     .filter((x): x is { id: number; key: string } => !!x.key);
 }
 
-export type AnnouncementDTO = Awaited<ReturnType<typeof getAnnouncements>>[number];
+// The cached shape carries the internal `targeted` flag; `getCurrentAnnouncements`
+// strips it after the membership check, so the public DTO never exposes it.
+type CachedAnnouncement = Awaited<ReturnType<typeof getAnnouncements>>[number];
+export type AnnouncementDTO = Omit<CachedAnnouncement, 'targeted'>;
+
 async function getAnnouncements(domain?: DomainColor) {
   const now = new Date();
   const announcements = await dbWrite.announcement.findMany({
@@ -221,14 +345,16 @@ async function getAnnouncements(domain?: DomainColor) {
       color: true,
       emoji: true,
       metadata: true,
+      targetUsers: { select: { userId: true }, take: 1 },
     },
     orderBy: { startsAt: { sort: 'desc', nulls: 'last' } },
   });
 
-  return announcements.map(({ createdAt, metadata, startsAt, ...x }) => ({
+  return announcements.map(({ createdAt, metadata, startsAt, targetUsers, ...x }) => ({
     ...x,
     createdAt,
     startsAt: startsAt ?? createdAt,
     metadata: (metadata ?? {}) as AnnouncementMetaSchema,
+    targeted: targetUsers.length > 0,
   }));
 }


### PR DESCRIPTION
…cation

Adds an AnnouncementUser allowlist table: announcements with target rows are only visible to those users (feed banner, drawer, badge, SSR seed all funnel through getCurrentAnnouncements); announcements without rows behave as before. Targeted announcements ride the existing global per-domain cache via a boolean flag, resolved per-user with one indexed membership lookup only while a targeted announcement is live. Target ids never leave the server.

Upsert validates the pasted id list before writing anything — unknown ids reject the whole save naming the offenders — and can optionally send each targeted user a system-announcement notification (chunked, uuid-keyed). Mod UI gets a target-ids textarea + notify checkbox and a Targeted badge.

Migration 20260729190000_targeted_announcements must be applied manually.