### PR TITLE
docs(articles): say why the profile feed disables store filters

### DIFF
--- a/src/pages/user/[username]/articles.tsx
+++ b/src/pages/user/[username]/articles.tsx
@@ -110,6 +110,11 @@ function UserArticlesPage() {
                   includeDrafts: !!currentUser?.isModerator,
                   pending: true,
                 }}
+                // Filters here are URL-driven, so merging the global feed's
+                // persisted store leaked its `followed: true` into a user-scoped
+                // query — and nobody follows themselves, which hid every one of
+                // the owner's own articles.
+                disableStoreFilters
                 showEmptyCta={selfView}
               />
             ) : (

--- a/src/pages/user/[username]/articles.tsx
+++ b/src/pages/user/[username]/articles.tsx
@@ -103,6 +103,10 @@ function UserArticlesPage() {
             </Group>
             {viewingPublished ? (
               <ArticlesInfinite
+                // Filters here are URL-driven. Merging the global feed's persisted
+                // store leaked its `followed: true` into this user-scoped query, and
+                // nobody follows themselves, so every one of the owner's own articles
+                // was hidden. Do not drop this as redundant.
                 disableStoreFilters
                 filters={{
                   ...query,


### PR DESCRIPTION
> ## Rebased onto current main — the fix already landed, this is now comment-only
>
> `main` moved 1,544 commits since this branch was cut, and **`disableStoreFilters` is already on `ArticlesInfinite` in `src/pages/user/[username]/articles.tsx`**. Someone fixed this independently.
>
> Worth flagging how that surfaced: the rebase was **textually clean**. `main` put the prop above `filters={{…}}` and this branch put it below, so git merged both and produced a duplicate JSX attribute. Nothing complained until a full-repo typecheck — `TS17001: JSX elements cannot have multiple attributes with the same name`. A clean rebase and a green PR are not the same thing.
>
> So this PR is reduced to the part `main` doesn't have: a comment recording *why* the prop is there. It passes the keep test in `CLAUDE.md` — the specific future edit that goes wrong without it is someone deleting `disableStoreFilters` as redundant, since it sits right next to an explicit `filters` object and reads like a no-op. The failure it causes is silent and total: profile filters are URL-driven, the global feed's persisted store leaks `followed: true` into a user-scoped query, and nobody follows themselves, so every one of the owner's articles disappears.
>
> Close it if a comment isn't worth a review cycle. Typecheck is green (0 errors).

---

Fixes #3461 — the profile Articles tab rendered "No results found" for the profile owner while the tab bar showed `Articles 80` and the same articles appeared in "Most popular articles" on the same page.

## What happened

The tab merged the **global** article feed's persisted filter store underneath its own filters. A `followed: true` left in that store from `/articles` survived into a user-scoped query, and since nobody follows themselves it excluded every one of the owner's articles.

The chain, all five links verified:

1. `articleFilterSchema` carries an optional `followed` boolean — `FiltersProvider.tsx:117-122` — persisted under the `article-filters` key (`:236`).
2. `user/[username]/articles.tsx:52-55` destructures `followed` **out** of the URL params, so it is deliberately absent from the `filters` prop it passes down.
3. `ArticlesInfinite.tsx:22-24` merges the store **underneath** those overrides — `removeEmpty({ ...articlesFilters, ...filterOverrides })`. `sort` and `period` are overridden and win; `followed` isn't in the overrides at all, so the stored `true` has nothing to override it. `removeEmpty` only drops nil and empty arrays (`object-helpers.ts:3-14`), so a boolean survives.
4. The tRPC input schema accepts `followed` — `article.schema.ts:73`.
5. `article.service.ts:322-336` applies `AND a."userId" IN (followedUserIds)`. The owner is not in their own follow list.

## Why this only hit Articles

All four feed stores carry a `followed` key — model (`FiltersProvider.tsx:50`), image (`:84`), post (`:112`), article (`:121`) — so every profile tab had the same trap armed. The other three defend against it, each differently:

| Profile tab | Handling | Leaks? |
|---|---|---|
| Models | **both** guards — `disableStoreFilters` (`models.tsx:135,161`) *and* forwards `followed ?? false` (`:55,123,148`) | no |
| Images / Videos | destructures `followed = undefined` (`UserMediaInfinite.tsx:37`) and passes it explicitly (`:161`) so the `undefined` shadows the store — same as its `hidden: undefined` at `:155` | no |
| Posts | destructures `followed = false` (`posts.tsx:45`) and passes it (`:108`) | no |
| **Articles** | destructures `followed = undefined` (`articles.tsx:54`) and never passes it | **yes** |

Articles is the only tab that strips the key without forwarding it. Worth noting for review: three tabs, three different guards, none of them obvious — which is why this reads as an article bug rather than a store-merge design problem.

## Why this fix

`disableStoreFilters` rather than `followed: !!followed`, because the page is already URL-driven and shouldn't be reading that store at all: its `ArticleFiltersDropdown` is passed an `onChange` (`:96-100`), which routes writes to `replace()` — the URL — instead of `setFilters` (`ArticleFiltersDropdown.tsx:26-31`). The store was only ever an accidental input here.

It also makes the tab consistent with its sibling: **`user/[username]/models.tsx:135,161` already passes `disableStoreFilters`**, and `Collection.tsx:464` already uses the flag on `ArticlesInfinite` itself. Articles was the outlier.

Patching `followed` alone would work but leaves the same trap armed for every other key the store gains later.

## No behaviour lost

Everything the store contributed here is either overridden by the page or irrelevant:

| store key | default | after this change |
|---|---|---|
| `sort` | `MostBookmarks` | page supplies it (URL, default `Newest`) |
| `period` | `Month` | page supplies it (URL, default `AllTime`) |
| `followed` | — | **gone, which is the fix** |
| `periodMode` | — | only read when `period !== AllTime` (`article.service.ts:341`); the page's default is `AllTime` |

The dropdown is unaffected: it renders from `query || filters` (`ArticleFiltersDropdown.tsx:24`) and the page passes `query`, so it was already displaying URL state, not store state.

## Not fixed here

Adjacent defects found while verifying this one, deliberately kept out. Full write-up in #3461:

- **`Prisma.join([])` throws** at `article.service.ts:335`, so `followed` with an empty follow list 500s instead of returning an empty feed. Articles is the only service missing that guard. Same code path as this bug, but a different failure mode and a server file — separate PR.
- `ArticlesInfinite` has no `isError` branch (`:37-71`), so any query failure renders this same empty state. That's why this presented as a filter problem rather than an error. Changes user-visible copy, so it wants its own PR.
- `article.utils.ts:33` uses `z.coerce.boolean()` for `followed`, so `?followed=false` parses as `true`. Inert here post-fix, live on `/articles`.
- `useZodRouteParams.ts:11-12` returns `{}` on any parse failure, dropping `username` with it — so one bad param renders the *global* feed inside a profile's Articles tab.

## What I'm not certain about

The mechanism above is verified end to end in code, but **I never confirmed against the wire that the reporting user's `localStorage['article-filters']` actually held `followed: true`.** The diagnosis is an elimination argument over the four input differences between this query and the working "Most popular" one, and it is consistent with all six observations — but a 200-with-zero-rows and a 500 render identically here (see the missing `isError` branch above), so I can't fully exclude that they hit the `Prisma.join` 500 instead, which the separate PR fixes. Both fixes are independently correct; I'd just rather flag that than imply I watched it happen.

## Verification

One file, one prop. Typecheck **0 errors** repo-wide; unit suite **680 files / 9055 tests passed, 0 failed** (1 skipped); Prettier and ESLint clean on the changed file.

Component tests weren't run: nothing under `src/**/*.browser.test.tsx` references `ArticlesInfinite`, `disableStoreFilters`, or this page, so they can't cover it either way.

The filter merge was confirmed against the repo's real `removeEmpty` rather than a reimplementation: with the store merged the object sent to tRPC is `{period: AllTime, sort: Newest, followed: true, includeDrafts: false, pending: true}`; with `disableStoreFilters` it is the same minus `followed`. `period` and `sort` are identical either way, which is the evidence that this removes exactly one input.

Also checked, since `disableStoreFilters` skips `removeEmpty`: zod `.partial()` omits absent keys rather than emitting `undefined`, so no `undefined` reaches the input here; and React Query's `hashKey` drops undefined-valued keys, so there is no cache-key split even where they do occur. `Collection.tsx:433-445,464` already ships `followed/favorites/hidden: undefined` through this same flag in production.

## One thing I deliberately did not add

A regression test. Nothing under `src/**/*.test.*` currently references `ArticlesInfinite`, `disableStoreFilters`, or this page, so nothing pins this fix. Doing it properly needs either extracting the filter-merge into a testable unit or new tRPC-input mocking for a component test — both larger than the fix itself. Happy to follow up if you'd like it, but I'd rather not bolt on fragile mocking to claim coverage.

I also considered forwarding `followed: false` explicitly on top of the flag, to match Models' belt-and-braces. I left it out: `article.service.ts:322` (`!!sessionUser && followed`) and `:202` (`!followed`) treat `undefined` and `false` identically, so it changes nothing today and would imply the flag alone is insufficient. A test is the right way to pin that, not a redundant prop.

