### PR TITLE
fix(articles): don't 500 the `followed` feed when the user follows nobody

### DIFF
--- a/src/server/services/article.service.ts
+++ b/src/server/services/article.service.ts
@@ -332,7 +332,11 @@ export const getArticles = async ({
       const followedUsersIds =
         followedUsers?.engagingUsers?.map(({ targetUser }) => targetUser.id) ?? [];
 
-      AND.push(Prisma.sql`a."userId" IN (${Prisma.join(followedUsersIds, ',')})`);
+      // `Prisma.join([])` throws, so a caller who follows nobody got a 500
+      // instead of an empty feed. model.service.ts guards the same clause the
+      // same way.
+      if (!followedUsersIds.length) AND.push(Prisma.sql`1 = 0`);
+      else AND.push(Prisma.sql`a."userId" IN (${Prisma.join(followedUsersIds, ',')})`);
     }
 
     const publishedAtFilter: Prisma.Sql | undefined =

--- a/src/server/services/article.service.ts
+++ b/src/server/services/article.service.ts
@@ -327,7 +327,11 @@ export const getArticles = async ({
       const followedUsersIds =
         followedUsers?.engagingUsers?.map(({ targetUser }) => targetUser.id) ?? [];
 
-      AND.push(Prisma.sql`a."userId" IN (${Prisma.join(followedUsersIds, ',')})`);
+      // `Prisma.join([])` throws, so a caller who follows nobody got a 500
+      // instead of an empty feed. model.service.ts guards the same clause the
+      // same way.
+      if (!followedUsersIds.length) AND.push(Prisma.sql`1 = 0`);
+      else AND.push(Prisma.sql`a."userId" IN (${Prisma.join(followedUsersIds, ',')})`);
     }
 
     const publishedAtFilter: Prisma.Sql | undefined =


### PR DESCRIPTION
`getArticles` builds the `followed` clause with an unguarded `Prisma.join`, which throws on an empty array. So a logged-in user who follows **nobody** and turns on the "Followed" filter on `/articles` gets a 500 rather than an empty feed.

Verified by execution against the installed Prisma 6.13.0:

```
Prisma.join([], ',')
→ TypeError: Expected `join([])` to be called with an array of multiple elements, but got an empty array
```

`article.service.ts:335` was:

```ts
AND.push(Prisma.sql`a."userId" IN (${Prisma.join(followedUsersIds, ',')})`);
```

`followedUsersIds` comes from `?? []` two lines above, so the empty case is reachable by design. The throw is caught by the `try` at `:194` → `throwDbError` → tRPC 500.

## Articles is the only service missing this guard

- `model.service.ts:603-606` — `if (!followedUsersIds.length) AND.push(Prisma.sql`1 = 0`)`
- `post.service.ts:247-251` — ternary to `null`
- `image.service.ts:3258-3262` — early return

This matches `model.service.ts`, which reads clearest and gives the correct semantics (follow nobody → match nothing).

## Why you may not have seen it reported

`ArticlesInfinite.tsx:37-71` branches only on `isFetching` and `articles.length` — there's no `isError` case, and `src/utils/trpc.ts` sets no global query `onError`. So this 500 renders as *"No results found — try adjusting your search or filters"*, identical to a genuinely empty feed, with no toast. That's tracked separately in #3461; it's the reason this went unnoticed.

## Relationship to the other article PRs

Found while investigating #3461, but split out per CONTRIBUTING's "prefer a separate issue or PR over widening the one you're in". Independent of #3462 (a client-side filter fix on the profile tab) — **both are based directly on `main`, not stacked**, and they can merge in either order.

Worth noting the two are related in a way that matters for review: #3462 stops a stray `followed: true` reaching a profile query, and this stops `followed` erroring when the follow list is empty. Either one alone leaves a path to the same empty-looking screen.

## Verification

Typecheck **0 errors** repo-wide; unit suite **680 files / 9055 tests passed, 0 failed** (1 skipped); Prettier clean. ESLint reports two warnings on the changed file (`:1467` unused `userId`, `:2663` `any`) — both pre-existing, ~1,100 lines from the change.

I did not add a test. The clause isn't extracted into anything testable, and the surrounding `getArticles` needs a live `dbRead`; the existing `src/server/services/__tests__/article-*.test.ts` files all cover extracted pure helpers. Extracting this one for coverage felt like more churn than the one-line guard justifies, but say the word and I'll do it.
