### PR TITLE
fix(apps): make the model-slot BLOCK_READY transition batching-safe

### DIFF
--- a/src/components/AppBlocks/IframeHost.browser.test.tsx
+++ b/src/components/AppBlocks/IframeHost.browser.test.tsx
@@ -264,8 +264,10 @@ describe('IframeHost block render/impression (Analytics Phase 2, model.sidebar_t
     await vi.waitFor(() => expect(beaconCalls()).toHaveLength(1));
 
     // A second/third BLOCK_READY (block re-ack, or a re-render re-running
-    // listeners) finds status === 'ready', so `appliedReady` stays false AND
-    // the emit-once ref is already set → no re-emit.
+    // listeners) can't re-emit: the beacon now fires from the COMMITTED
+    // loading→ready effect, which is already past its once-per-mount guard, and
+    // the shared emit-once ref is set. (See IframeHostReadyTransition.browser
+    // .test.tsx for the batching-immunity + H-11 coverage of that effect.)
     postFromBlock('BLOCK_READY', {});
     postFromBlock('BLOCK_READY', {});
     await new Promise((r) => setTimeout(r, 150));

--- a/src/components/AppBlocks/IframeHost.tsx
+++ b/src/components/AppBlocks/IframeHost.tsx
@@ -853,11 +853,17 @@ export function IframeHost({
       const payload =
         raw && typeof raw === 'object' && 'height' in raw ? (raw as { height?: unknown }) : {};
       // Record the offered height for the ready-transition effect below to apply
-      // once React has COMMITTED 'ready'. Deliberately ungated: H-11 is enforced
-      // by that effect's `status === 'ready'` guard, not here (see the ref's
-      // comment). When several acks land in one batch the LAST one wins, which is
-      // the block's most recent statement of its own handshake height.
-      pendingReadyHeightRef.current = payload.height;
+      // once React has COMMITTED 'ready'. NOT gated on the current status: H-11 is
+      // enforced by that effect's `status === 'ready'` guard, not here (see the
+      // ref's comment).
+      //
+      // When several acks land in one batch the LAST one that CARRIES a height
+      // wins — the block's most recent statement of its own handshake height. The
+      // `!== undefined` check matters: without it a `BLOCK_READY {height: 640}`
+      // followed in the same batch by a bare `BLOCK_READY {}` (or one whose height
+      // fails the shape guard) would reset the ref to `undefined` and LOSE a height
+      // the old code applied, turning this fix into a regression in that direction.
+      if (payload.height !== undefined) pendingReadyHeightRef.current = payload.height;
       setStatus((current) => (current === 'loading' ? 'ready' : current));
       // Block acked — stop re-posting BLOCK_INIT and cancel the readiness
       // timeout. Called UNCONDITIONALLY, not behind a "did this ack win the

--- a/src/components/AppBlocks/IframeHost.tsx
+++ b/src/components/AppBlocks/IframeHost.tsx
@@ -529,15 +529,32 @@ export function IframeHost({
   // the controller started — the next tick picks up the new payload) without
   // re-creating the controller and resetting its timers.
   const buildInitPayloadRef = useRef<() => BlockInitPayload>();
-  // Analytics Phase 2: emit-once guard for the block-render beacon (see the
-  // BLOCK_READY effect). The 'loading' → 'ready' transition is the primary
-  // dedup; this ref makes the per-mount emit deterministic even if duplicate
-  // BLOCK_READY acks land before React commits the 'ready' state.
+  // Analytics Phase 2: emit-once guard for the block-render beacon, SHARED with
+  // the render-FAILURE beacon below so `ok` and `error` are mutually exclusive
+  // per mount. The committed-`status` effects are the primary dedup; this ref
+  // makes the per-mount emit deterministic even if duplicate BLOCK_READY acks
+  // land before React commits the 'ready' state.
   const blockRenderEmittedRef = useRef<boolean>(false);
+  // The height the block offered in its BLOCK_READY ack, stashed for the
+  // ready-transition effect to apply once React has COMMITTED 'ready'.
+  //
+  // 🔴 A ref, not state, and read ONLY from the `status === 'ready'` effect. That
+  // makes H-11 STRUCTURAL rather than a timing observation: a late ack that
+  // arrives after the host already landed on 'timeout' / 'fatal' / 'no_token'
+  // still writes here, but `status` can never become 'ready' again from a
+  // terminal state (BLOCK_READY only transitions FROM 'loading'), so the stashed
+  // value is simply never read and the height is never applied.
+  const pendingReadyHeightRef = useRef<unknown>(undefined);
+  // Run the loading→ready side effects (height + `ok` beacon) exactly once per
+  // mount. Without this, an identity change of the `applyHeight` callback (its
+  // deps are manifest min/max height) would re-run the effect while `status` is
+  // still 'ready' and re-apply the handshake height, clobbering a height the
+  // block had since negotiated via RESIZE_IFRAME.
+  const readyTransitionAppliedRef = useRef<boolean>(false);
 
   // App Blocks Analytics Phase 2 — fire-and-forget block render/impression,
-  // emitted exactly once per mount at the BLOCK_READY transition (see the
-  // BLOCK_READY effect below) via the lightweight /api/track/block-render beacon
+  // emitted exactly once per mount on the COMMITTED loading→ready transition
+  // (see the ready-transition effect below) via the /api/track/block-render beacon
   // (NOT a tRPC mutation — this fires per model-page-with-a-block view, so at GA
   // it must skip the full tRPC middleware chain; mirrors the #2680 addView ->
   // beacon move). The client passes only the three identifiers; `isAnon`/`userId`
@@ -831,48 +848,86 @@ export function IframeHost({
     const off = onMessage<unknown>('BLOCK_READY', (raw) => {
       // Validate the shape — payload comes from cross-origin iframe code and
       // is functionally untyped. Reject anything that isn't {height?:number}.
+      // (`applyHeight` is the value guard: it drops anything non-finite/≤0 and
+      // clamps to manifest min/max + HARD_HEIGHT_CEILING.)
       const payload =
         raw && typeof raw === 'object' && 'height' in raw ? (raw as { height?: unknown }) : {};
-      // H-11: only honor the height when the transition actually lands on
-      // 'ready'. setStatus's updater returns the *prior* status — we use
-      // the next status (which the updater computed) to gate the height
-      // application. Late BLOCK_READY arriving after timeout/fatal/no_token
-      // must not nudge the iframe height.
-      let appliedReady = false;
-      setStatus((current) => {
-        if (current === 'loading') {
-          appliedReady = true;
-          return 'ready';
-        }
-        return current;
-      });
-      if (appliedReady) {
-        // Block acked — stop re-posting BLOCK_INIT and cancel the readiness
-        // timeout. One extra in-flight retry tick before this lands is fine
-        // (the block dedupes init), but we must not keep spamming.
-        controllerRef.current?.notifyReady();
-        applyHeight(payload.height);
-        // Analytics Phase 2: one render/impression per mount. `appliedReady`
-        // flips on the loading→ready transition; the emit-once ref makes it
-        // deterministic even if duplicate acks land before React commits 'ready'
-        // (so it fires exactly once per mount and never on re-render).
-        // Fire-and-forget beacon — failures are a no-op (and a harmless no-op
-        // until the `blockRenders` ClickHouse table exists; see PR body).
-        if (!blockRenderEmittedRef.current) {
-          blockRenderEmittedRef.current = true;
-          sendBlockRender({
-            appBlockId: install.appBlockId,
-            blockInstanceId: install.blockInstanceId,
-            slotId,
-          });
-        }
-      }
+      // Record the offered height for the ready-transition effect below to apply
+      // once React has COMMITTED 'ready'. Deliberately ungated: H-11 is enforced
+      // by that effect's `status === 'ready'` guard, not here (see the ref's
+      // comment). When several acks land in one batch the LAST one wins, which is
+      // the block's most recent statement of its own handshake height.
+      pendingReadyHeightRef.current = payload.height;
+      setStatus((current) => (current === 'loading' ? 'ready' : current));
+      // Block acked — stop re-posting BLOCK_INIT and cancel the readiness
+      // timeout. Called UNCONDITIONALLY, not behind a "did this ack win the
+      // transition" flag, because that flag is exactly what could not be read
+      // reliably (see the effect below). Safe in every state:
+      //   - `notifyReady()` is documented-idempotent (→ `stop()`, a no-op once
+      //     stopped), so repeat/duplicate acks cost nothing;
+      //   - after 'timeout' the controller already stopped itself — no-op;
+      //   - after 'no_token' the controller was never created (`shouldStartInit`
+      //     requires a token) — the optional chain no-ops;
+      //   - after 'fatal' it cancels the retry interval and the readiness
+      //     timeout, which is what we WANT while terminal, and it cannot revive
+      //     `status`: the only writer here is the guarded updater above, and
+      //     `onReadyTimeout` is itself `current === 'loading'`-guarded.
+      // So this cannot weaken H-11: the observable content of "don't notify
+      // ready" (no height, no `ok` beacon, no status change) is still enforced,
+      // and is regression-tested per terminal state.
+      //
+      // NB this is the FAST path, not the only one: `status` is in the init
+      // effect's dep array, so the loading→ready commit re-runs that effect and
+      // its cleanup `dispose()`s the controller regardless. Calling notifyReady
+      // here just stops the retry loop one render earlier.
+      controllerRef.current?.notifyReady();
     });
     return off;
-  }, [onMessage, applyHeight, install.appBlockId, install.blockInstanceId, slotId]);
+  }, [onMessage]);
+
+  // Analytics Phase 2 + the acked iframe height — the loading→ready COMMIT.
+  // Fires once per mount; the `ok` beacon is mutually exclusive with the
+  // render-FAILURE beacon below (shared `blockRenderEmittedRef`).
+  //
+  // 🔴 WHY THIS IS AN EFFECT AND NOT A SIDE EFFECT INSIDE THE BLOCK_READY
+  // HANDLER (a real bug this fixes, not a refactor): it used to live inside the
+  // handler behind an `appliedReady` flag that the `setStatus` UPDATER set —
+  //     let appliedReady = false;
+  //     setStatus((current) => { if (current === 'loading') { appliedReady = true; … } });
+  //     if (appliedReady) { …notifyReady + applyHeight + sendBlockRender… }
+  // — and the in-code comment claimed it could read the transition out of the
+  // updater. It cannot. That only works because React *eagerly* evaluates an
+  // updater when the fiber has no other pending update (the bail-out
+  // optimisation in `dispatchSetState`). As soon as ANY unrelated state update is
+  // already queued on THIS component when BLOCK_READY lands, React skips the
+  // eager path, the updater runs later during render, `appliedReady` is still
+  // false at the `if`, and the WHOLE branch is skipped: the acked height is never
+  // applied (the iframe stays pinned at `minHeight` → clipped content or a dead
+  // gap) and the impression beacon is silently dropped. This host has such
+  // updates in flight in the real world (the `getEffectiveCheckpoint` /
+  // `getShowcaseImages` react-query subscriptions resolving, `iframeHeight`
+  // itself). Keying off the COMMITTED `status` is immune to batching. Mirrors
+  // both the failure-beacon effect below and PR #3457's fix to the sibling
+  // PageBlockHost — one problem, one solution, in both hosts.
+  useEffect(() => {
+    if (status !== 'ready') return;
+    if (readyTransitionAppliedRef.current) return;
+    readyTransitionAppliedRef.current = true;
+    applyHeight(pendingReadyHeightRef.current);
+    if (blockRenderEmittedRef.current) return;
+    blockRenderEmittedRef.current = true;
+    // Fire-and-forget beacon — failures are a no-op (and a harmless no-op until
+    // the `blockRenders` ClickHouse table exists).
+    sendBlockRender({
+      appBlockId: install.appBlockId,
+      blockInstanceId: install.blockInstanceId,
+      slotId,
+    });
+  }, [status, applyHeight, install.appBlockId, install.blockInstanceId, slotId]);
 
   // App Blocks runtime observability — render-FAILURE beacon. The success
-  // beacon fires at BLOCK_READY above (guarded by `blockRenderEmittedRef`). Here
+  // beacon fires from the loading→ready commit effect above (both guarded by the
+  // shared `blockRenderEmittedRef`). Here
   // we fire the mutually-exclusive `error` beacon when the host lands on a
   // terminal-failure state — the iframe never reached BLOCK_READY in time
   // ('timeout'), the block reported a fatal error ('fatal'), or its token never

--- a/src/components/AppBlocks/IframeHostReadyTransition.browser.test.tsx
+++ b/src/components/AppBlocks/IframeHostReadyTransition.browser.test.tsx
@@ -47,9 +47,12 @@ import { renderWithProviders } from '../../../test/component-setup';
  * React internals. Every other test here runs the un-batched path too, so both
  * scheduling shapes are pinned.
  *
- * Also covered: H-11 in both directions (a late ack after `fatal` / `timeout` /
- * `no_token` must apply nothing and emit no `ok` beacon), emit-once semantics,
- * and untrusted-payload height validation.
+ * Also covered: H-11 — a BLOCK_READY that loses the race to a terminal state must
+ * apply nothing and emit no `ok` beacon. Read the note on the H-11 describe block
+ * for which of those tests exercise the guard DIRECTLY (the batched
+ * `BLOCK_ERROR{fatal}` pair) versus which pin only the terminal outcome
+ * (`timeout` / `no_token`, where a late ack is undeliverable). Plus emit-once
+ * semantics and untrusted-payload height validation.
  */
 
 // `vi.mock` is hoisted, so the per-test levers must live in a hoisted block the
@@ -227,10 +230,11 @@ const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 // ── beacon plumbing ──────────────────────────────────────────────────────────
 let fetchSpy: ReturnType<typeof vi.spyOn>;
 // Direct observation of side effect #2. Counting BLOCK_INIT postMessages instead
-// would be VACUOUS: the same-origin iframe REPLACES its `contentWindow` when its
-// document loads, so a listener attached to the window we can reach from the test
-// never sees the host's posts (verified — it captured 0, so the assertion could
-// never fail). Spying the controller method the handler calls is the honest
+// would be VACUOUS: when the same-origin iframe's document loads, the inner global
+// is swapped out (the `WindowProxy` object identity is preserved, but the listener
+// registered on the pre-load global is not), so a listener the test attaches never
+// sees the host's posts — verified, it captured 0, meaning the assertion could
+// never have failed. Spying the controller method the handler calls is the honest
 // observable, and it IS the guard under test.
 let notifyReadySpy: ReturnType<typeof vi.spyOn>;
 
@@ -334,8 +338,10 @@ describe('IframeHost ready transition — emit-once / apply-once semantics', () 
 
   test('a later ack WITHOUT a usable height does not erase the height an earlier ack in the same batch supplied', async () => {
     // The regression direction of "last ack wins": a block that acks with a height
-    // and then re-acks bare (or with a height the shape/value guards reject) must
-    // keep the height it actually stated. Without the `!== undefined` stash guard
+    // and then re-acks bare (or with a payload the shape guard reduces to `{}`)
+    // must keep the height it actually stated. Both re-acks below land on
+    // `payload.height === undefined`, so they exercise the same single branch —
+    // they're belt-and-braces, not two separately-pinned routes. Without the `!== undefined` stash guard
     // the ref resets and the frame stays pinned at minHeight — a case the OLD code
     // got right (its eager path applied the FIRST ack), so this would have turned
     // the fix into a regression.
@@ -499,22 +505,28 @@ describe('IframeHost ready transition — H-11: a late BLOCK_READY after a termi
   // rendering a framed BlockFallback, so `block-iframe` is gone — which is how
   // FRAME-1 is satisfied here (nothing rendered ⇒ nothing to masquerade as).
   //
-  // 🔴 CONSEQUENCE FOR HOW THESE TESTS ARE WRITTEN — read before adding one.
-  // Because the host collapses, a BLOCK_READY dispatched AFTER a terminal state
-  // is UNDELIVERABLE, not merely ignored: `usePostMessage` pins
+  // CONSEQUENCE FOR HOW THESE TESTS ARE WRITTEN — read before adding one.
+  // Because the host collapses, a BLOCK_READY dispatched AFTER a terminal state is
+  // UNDELIVERABLE, not merely ignored: `usePostMessage` pins
   // `event.source === iframeRef.current?.contentWindow`, and once the iframe
-  // unmounts `iframeRef.current` is null, so every inbound message is dropped
-  // before the BLOCK_READY handler runs. There is therefore NO way to exercise the
-  // effect's `status !== 'ready'` guard via a post-terminal ack, and a test that
-  // dispatches one and asserts "nothing happened" is VACUOUS — it would pass with
-  // the guard entirely removed. (An earlier draft of this file had exactly that;
-  // it was caught in review.)
-  // So the coverage is split deliberately:
-  //   - the guard itself is exercised by the BATCHED `BLOCK_ERROR{fatal}` case
-  //     below, where both messages arrive while the iframe is still mounted;
-  //   - the `timeout` / `no_token` tests assert the TERMINAL OUTCOME (error beacon
-  //     only, host collapsed, still no `ok` beacon) plus the drop itself, and say
-  //     so rather than claiming to test the guard.
+  // unmounts that comparand is `undefined` while `MessageEvent.source` is never
+  // `undefined` (absent → `null`) — so NO source value can pass and the message is
+  // dropped before the BLOCK_READY handler runs. Two things follow:
+  //   - The late `dispatchEvent` in the `timeout` / `no_token` tests below is a
+  //     NO-OP that asserts nothing on its own — nothing there distinguishes
+  //     "dropped at the transport" from "delivered and correctly ignored". Treat it
+  //     as documentation of the scenario, not as coverage.
+  //   - Those tests still have real teeth, just from a different line: their
+  //     terminal-OUTCOME assertions (exactly one `error` beacon of the right class,
+  //     no `ok` beacon, host collapsed). Removing the ready effect's
+  //     `status !== 'ready'` guard fails BOTH of them, because the ready effect then
+  //     fires at mount, claims the shared `blockRenderEmittedRef`, and the failure
+  //     beacon never gets to fire. (Verified: that mutation fails 10 of the 25 tests
+  //     in this file, these two included.)
+  // The guard is *directly* exercised — ack genuinely delivered, status genuinely
+  // terminal — only by the two BATCHED `BLOCK_ERROR{fatal}` cases, where both
+  // messages arrive while the iframe is still mounted. Prefer that shape when
+  //   adding H-11 coverage.
 
   test('BLOCK_ERROR{fatal} batched with a BLOCK_READY in the same task stays fatal: no height, no ok beacon, only the error beacon', async () => {
     // The DELIVERABLE H-11 case — both messages are dispatched while the iframe
@@ -549,9 +561,6 @@ describe('IframeHost ready transition — H-11: a late BLOCK_READY after a termi
     // emit-once ref, so the error beacon never gets to fire).
     renderWithProviders(<IframeHost {...baseProps} />);
     await waitForMount();
-    // Capture the live contentWindow BEFORE the collapse so the late dispatch
-    // carries the most permissive `source` a real block could ever have.
-    const preCollapseWindow = iframeEl().contentWindow;
     // Never ack → the controller's ~10s readiness timeout fires → 'timeout'.
     await vi.waitFor(
       () => {
@@ -562,13 +571,13 @@ describe('IframeHost ready transition — H-11: a late BLOCK_READY after a termi
     await vi.waitFor(() => expect(errorBeacons()).toHaveLength(1));
     expect(errorBeacons()[0]).toMatchObject({ errorClass: 'timeout' });
 
-    // A late ack (the block finally woke up) changes nothing — it is dropped by the
-    // transport's source pin, because there is no longer an iframe to pin to.
+    // A late ack (the block finally woke up). Documentation only — see the
+    // describe-block note: post-collapse there is no iframe to pin to, so no
+    // `source` value can pass the transport and this asserts nothing by itself.
     window.dispatchEvent(
       new MessageEvent('message', {
         data: { type: 'BLOCK_READY', payload: { height: 640 } },
         origin: window.location.origin,
-        source: preCollapseWindow,
       })
     );
     await sleep(200);
@@ -583,7 +592,6 @@ describe('IframeHost ready transition — H-11: a late BLOCK_READY after a termi
     // the timeout case above — outcome, not guard.
     renderWithProviders(<IframeHost {...baseProps} token="" />);
     await waitForMount();
-    const preCollapseWindow = iframeEl().contentWindow;
     await vi.waitFor(
       () => {
         expect(iframeQuery()).toBeNull();
@@ -597,7 +605,6 @@ describe('IframeHost ready transition — H-11: a late BLOCK_READY after a termi
       new MessageEvent('message', {
         data: { type: 'BLOCK_READY', payload: { height: 640 } },
         origin: window.location.origin,
-        source: preCollapseWindow,
       })
     );
     await sleep(200);

--- a/src/components/AppBlocks/IframeHostReadyTransition.browser.test.tsx
+++ b/src/components/AppBlocks/IframeHostReadyTransition.browser.test.tsx
@@ -332,6 +332,30 @@ describe('IframeHost ready transition — emit-once / apply-once semantics', () 
     expect(errorBeacons()).toHaveLength(0);
   });
 
+  test('a later ack WITHOUT a usable height does not erase the height an earlier ack in the same batch supplied', async () => {
+    // The regression direction of "last ack wins": a block that acks with a height
+    // and then re-acks bare (or with a height the shape/value guards reject) must
+    // keep the height it actually stated. Without the `!== undefined` stash guard
+    // the ref resets and the frame stays pinned at minHeight — a case the OLD code
+    // got right (its eager path applied the FIRST ack), so this would have turned
+    // the fix into a regression.
+    renderWithProviders(<IframeHost {...baseProps} />);
+    await waitForMount();
+
+    postFromBlock('BLOCK_READY', { height: 640 });
+    postFromBlock('BLOCK_READY', {});
+    postFromBlock('BLOCK_READY', { width: 100 });
+
+    await vi.waitFor(() => {
+      expect(iframeEl().getAttribute('data-block-ready')).toBe('true');
+    });
+    await vi.waitFor(() => {
+      expect(appliedHeight()).toBe(640);
+    });
+    await sleep(120);
+    expect(okBeacons()).toHaveLength(1);
+  });
+
   test('a duplicate ack AFTER the ready commit does not re-emit and does not clobber a negotiated RESIZE_IFRAME height', async () => {
     renderWithProviders(<IframeHost {...baseProps} />);
     await driveToReady({ height: 300 });
@@ -474,6 +498,23 @@ describe('IframeHost ready transition — H-11: a late BLOCK_READY after a termi
   // terminal state COLLAPSES the host to null (hostRenderDecision) rather than
   // rendering a framed BlockFallback, so `block-iframe` is gone — which is how
   // FRAME-1 is satisfied here (nothing rendered ⇒ nothing to masquerade as).
+  //
+  // 🔴 CONSEQUENCE FOR HOW THESE TESTS ARE WRITTEN — read before adding one.
+  // Because the host collapses, a BLOCK_READY dispatched AFTER a terminal state
+  // is UNDELIVERABLE, not merely ignored: `usePostMessage` pins
+  // `event.source === iframeRef.current?.contentWindow`, and once the iframe
+  // unmounts `iframeRef.current` is null, so every inbound message is dropped
+  // before the BLOCK_READY handler runs. There is therefore NO way to exercise the
+  // effect's `status !== 'ready'` guard via a post-terminal ack, and a test that
+  // dispatches one and asserts "nothing happened" is VACUOUS — it would pass with
+  // the guard entirely removed. (An earlier draft of this file had exactly that;
+  // it was caught in review.)
+  // So the coverage is split deliberately:
+  //   - the guard itself is exercised by the BATCHED `BLOCK_ERROR{fatal}` case
+  //     below, where both messages arrive while the iframe is still mounted;
+  //   - the `timeout` / `no_token` tests assert the TERMINAL OUTCOME (error beacon
+  //     only, host collapsed, still no `ok` beacon) plus the drop itself, and say
+  //     so rather than claiming to test the guard.
 
   test('BLOCK_ERROR{fatal} batched with a BLOCK_READY in the same task stays fatal: no height, no ok beacon, only the error beacon', async () => {
     // The DELIVERABLE H-11 case — both messages are dispatched while the iframe
@@ -499,9 +540,18 @@ describe('IframeHost ready transition — H-11: a late BLOCK_READY after a termi
     expect(okBeacons()).toHaveLength(0);
   });
 
-  test('a late BLOCK_READY after the readiness TIMEOUT applies nothing and emits no ok beacon', async () => {
+  test('the readiness TIMEOUT is terminal: error beacon only, host collapsed, and a late ack is not even deliverable', async () => {
+    // NOT a test of the effect's status guard — see the describe-block note: once
+    // the host collapses the ack cannot reach a handler at all. What this pins is
+    // the terminal OUTCOME (exactly one `error` beacon, classed 'timeout', never an
+    // `ok` one) and that a late ack leaves it that way. Killed by M3 (removing the
+    // status guard makes the ready effect fire at mount and claim the shared
+    // emit-once ref, so the error beacon never gets to fire).
     renderWithProviders(<IframeHost {...baseProps} />);
     await waitForMount();
+    // Capture the live contentWindow BEFORE the collapse so the late dispatch
+    // carries the most permissive `source` a real block could ever have.
+    const preCollapseWindow = iframeEl().contentWindow;
     // Never ack → the controller's ~10s readiness timeout fires → 'timeout'.
     await vi.waitFor(
       () => {
@@ -512,11 +562,13 @@ describe('IframeHost ready transition — H-11: a late BLOCK_READY after a termi
     await vi.waitFor(() => expect(errorBeacons()).toHaveLength(1));
     expect(errorBeacons()[0]).toMatchObject({ errorClass: 'timeout' });
 
-    // A late ack (the block finally woke up) must change nothing.
+    // A late ack (the block finally woke up) changes nothing — it is dropped by the
+    // transport's source pin, because there is no longer an iframe to pin to.
     window.dispatchEvent(
       new MessageEvent('message', {
         data: { type: 'BLOCK_READY', payload: { height: 640 } },
         origin: window.location.origin,
+        source: preCollapseWindow,
       })
     );
     await sleep(200);
@@ -525,11 +577,13 @@ describe('IframeHost ready transition — H-11: a late BLOCK_READY after a termi
     expect(iframeQuery()).toBeNull();
   }, 22_000);
 
-  test('a late BLOCK_READY after NO_TOKEN applies nothing and emits no ok beacon', async () => {
+  test('NO_TOKEN is terminal: error beacon only, and a late ack is not even deliverable', async () => {
     // An empty token never satisfies `shouldStartInit`, so the independent
-    // token-wait timer (~15s) is what goes terminal here.
+    // token-wait timer (~15s) is what goes terminal here. Same coverage note as
+    // the timeout case above — outcome, not guard.
     renderWithProviders(<IframeHost {...baseProps} token="" />);
     await waitForMount();
+    const preCollapseWindow = iframeEl().contentWindow;
     await vi.waitFor(
       () => {
         expect(iframeQuery()).toBeNull();
@@ -543,12 +597,36 @@ describe('IframeHost ready transition — H-11: a late BLOCK_READY after a termi
       new MessageEvent('message', {
         data: { type: 'BLOCK_READY', payload: { height: 640 } },
         origin: window.location.origin,
+        source: preCollapseWindow,
       })
     );
     await sleep(200);
     expect(okBeacons()).toHaveLength(0);
     expect(errorBeacons()).toHaveLength(1);
   }, 28_000);
+
+  test('BLOCK_READY then BLOCK_ERROR{fatal} in the same batch resolves to fatal — the error beacon, not the ok beacon', async () => {
+    // The REVERSE order of the case above, and a genuine behaviour change vs
+    // `main`: there the handler emitted `ok` synchronously before the fatal was
+    // processed, so `error` was suppressed by the shared emit-once ref. Now both
+    // updaters run in one render, the committed status is 'fatal', and the ready
+    // effect early-returns — so the mount is reported as a FAILED render. Pinned
+    // because it moves BlockRenderFailureRate, and declared in the PR body.
+    renderWithProviders(<IframeHost {...baseProps} />);
+    await waitForMount();
+
+    postFromBlock('BLOCK_READY', { height: 640 });
+    postFromBlock('BLOCK_ERROR', { fatal: true });
+
+    await vi.waitFor(() => {
+      expect(iframeQuery()).toBeNull();
+    });
+    await vi.waitFor(() => {
+      expect(errorBeacons()).toHaveLength(1);
+    });
+    expect(errorBeacons()[0]).toMatchObject({ status: 'error', errorClass: 'fatal' });
+    expect(okBeacons()).toHaveLength(0);
+  });
 });
 
 describe('IframeHost ready transition — a ready block must never go terminal', () => {

--- a/src/components/AppBlocks/IframeHostReadyTransition.browser.test.tsx
+++ b/src/components/AppBlocks/IframeHostReadyTransition.browser.test.tsx
@@ -1,0 +1,589 @@
+import { describe, expect, test, vi, beforeEach } from 'vitest';
+import { page } from 'vitest/browser';
+// Used INSIDE the hoisted `vi.mock` factory below. Safe: the factory is invoked
+// lazily (on first import of the mocked module), long after this binding is
+// initialised — an `await import('react')` inside the factory instead trips the
+// browser mocker.
+import { useState } from 'react';
+// `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
+import { renderWithProviders } from '../../../test/component-setup';
+
+/**
+ * IframeHost — the COMMITTED loading→ready transition (model.sidebar_top).
+ *
+ * 🔴 THE BUG THIS FILE EXISTS FOR. The BLOCK_READY handler used to read the
+ * transition out of the `setStatus` UPDATER:
+ *
+ *     let appliedReady = false;
+ *     setStatus((current) => { if (current === 'loading') { appliedReady = true; … } });
+ *     if (appliedReady) { notifyReady(); applyHeight(payload.height); …sendBlockRender… }
+ *
+ * React does NOT guarantee the updater runs before the next statement. It only
+ * evaluates it eagerly as a bail-out optimisation, and ONLY when the fiber has no
+ * other pending update. The moment any unrelated state update is already queued on
+ * THIS component when BLOCK_READY lands, the eager path is skipped, the updater
+ * runs later during render, `appliedReady` is still `false` at the `if`, and the
+ * ENTIRE branch is skipped — three side effects lost at once:
+ *   1. `applyHeight(payload.height)` — the iframe stays pinned at manifest
+ *      `minHeight` (clipped block content, or a dead gap under a short block).
+ *   2. `controllerRef.current?.notifyReady()` — the init controller is not told
+ *      the block acked, so it keeps re-posting BLOCK_INIT until something else
+ *      tears it down. (Impact is BOUNDED: `status` is in the init effect's dep
+ *      array, so committing 'ready' re-runs that effect and its cleanup
+ *      `dispose()`s the controller anyway — see the "never goes terminal" suite.)
+ *   3. the `/api/track/block-render` impression beacon — silently dropped.
+ * The fix moves 1+3 into an effect keyed on the COMMITTED `status`, and makes 2
+ * unconditional (it is idempotent). PR #3457 applied the same shape to the
+ * sibling PageBlockHost.
+ *
+ * 🔴 WHY THE EXISTING SUITE COULD NOT CATCH IT. IframeHost.browser.test.tsx
+ * stubs every tRPC hook as a CONSTANT-returning function, which removes the very
+ * batching condition the bug needs: the fiber is quiescent when BLOCK_READY
+ * arrives, React takes the eager path, and the buggy code passes. So this file
+ * mocks `useBrowsingLevelDebounced` (called directly by IframeHost, so its hooks
+ * live on the IframeHost FIBER) with a REAL `useState` and exposes its setter.
+ * That lets a test queue a genuine React update on the host and then deliver
+ * BLOCK_READY in the SAME synchronous task — the real batched path, no faking of
+ * React internals. Every other test here runs the un-batched path too, so both
+ * scheduling shapes are pinned.
+ *
+ * Also covered: H-11 in both directions (a late ack after `fatal` / `timeout` /
+ * `no_token` must apply nothing and emit no `ok` beacon), emit-once semantics,
+ * and untrusted-payload height validation.
+ */
+
+// `vi.mock` is hoisted, so the per-test levers must live in a hoisted block the
+// factory can close over.
+const mocks = vi.hoisted(() => ({
+  /** Queue a real, IframeHost-fiber-local React update (the batching lever). */
+  bump: null as null | (() => void),
+}));
+
+// The batching lever. IframeHost calls useBrowsingLevelDebounced() directly, so
+// the useState below belongs to the IframeHost fiber and its setter schedules an
+// update on exactly the fiber whose `setStatus` we care about. The RETURNED value
+// stays constant (1) — it only feeds the mocked showcase query, so bumping is
+// behaviourally inert and purely a scheduling lever.
+vi.mock('~/components/BrowsingLevel/BrowsingLevelProvider', () => ({
+  useBrowsingLevelDebounced: () => {
+    const [, setTick] = useState(0);
+    mocks.bump = () => setTick((n) => n + 1);
+    return 1;
+  },
+}));
+
+// AppBlockChrome calls useCurrentUser() for the platform-nav moderator gate;
+// this suite renders the real host without a CivitaiSessionProvider.
+vi.mock('~/hooks/useCurrentUser', () => ({ useCurrentUser: () => null }));
+
+// IframeHost drives two tRPC queries at render plus the SDK bridges. Stub them so
+// the host mounts network-free AND the init handshake is ALLOWED to start
+// immediately (getEffectiveCheckpoint must report isLoading:false so
+// `shouldStartInit` fires and the controller arms its readiness timeout).
+vi.mock('~/utils/trpc', () => ({
+  trpc: {
+    blocks: {
+      getEffectiveCheckpoint: {
+        useQuery: () => ({ data: { checkpoint: null }, isLoading: false }),
+      },
+      getShowcaseImages: {
+        useQuery: () => ({ data: [], isLoading: false }),
+      },
+      submitWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      estimateWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      pollWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      cancelWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      updateUserSettings: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      getMyBuzzBalance: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+    },
+    apps: {
+      shared: {
+        append: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        update: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        vote: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        unvote: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        withdraw: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      },
+      storage: {
+        set: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        delete: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      },
+    },
+    useUtils: () => ({
+      apps: {
+        shared: {
+          list: { fetch: vi.fn() },
+          getCount: { fetch: vi.fn() },
+          getCounts: { fetch: vi.fn() },
+        },
+        storage: {
+          get: { fetch: vi.fn() },
+          list: { fetch: vi.fn() },
+          getQuota: { fetch: vi.fn() },
+        },
+      },
+    }),
+  },
+}));
+
+// eslint-disable-next-line import/first
+import { IframeHost } from '~/components/AppBlocks/IframeHost';
+// eslint-disable-next-line import/first
+import { IframeInitController } from '~/components/AppBlocks/iframeInitController';
+// eslint-disable-next-line import/first
+import type { BlockInstall, ModelSlotContext } from '~/components/AppBlocks/types';
+
+// Same-origin so trustTier='internal' yields a pinned (non-opaque) transport
+// whose expectedOrigin equals this frame's origin, exactly like a verified/
+// internal block. We post FROM the iframe's contentWindow so the
+// `event.source === iframe.contentWindow` authenticating pin holds.
+const SAME_ORIGIN_SRC = `${window.location.origin}/`;
+
+const MIN_HEIGHT = 200;
+const MAX_HEIGHT = 800;
+
+const install: BlockInstall = {
+  blockInstanceId: 'inst_test',
+  blockId: 'my-model-app',
+  appId: 'app_test',
+  appBlockId: 'apb_test',
+  manifest: {
+    name: 'Background Remover',
+    scopes: ['ai:write:budgeted'],
+    iframe: {
+      src: SAME_ORIGIN_SRC,
+      minHeight: MIN_HEIGHT,
+      maxHeight: MAX_HEIGHT,
+      resizable: true,
+      sandbox: 'allow-scripts',
+    },
+  },
+  publisherSettings: {},
+  enabled: true,
+  renderMode: 'iframe',
+  trustTier: 'internal',
+};
+
+const context: ModelSlotContext = {
+  slotId: 'model.sidebar_top',
+  entityType: 'model',
+  modelId: 123,
+  modelVersionId: 456,
+  modelName: 'Some Model',
+  modelType: 'Checkpoint',
+  modelNsfwLevel: 1,
+  creatorUserId: 7,
+  viewerUserId: 42,
+  viewerNsfwEnabled: false,
+  viewerUsername: 'tester',
+  theme: 'light',
+};
+
+const baseProps = {
+  install,
+  context,
+  token: 'tok_abc',
+  expiresAt: new Date(Date.now() + 15 * 60_000).toISOString(),
+};
+
+const iframeEl = () => page.getByTestId('block-iframe').element() as HTMLIFrameElement;
+const iframeQuery = () => page.getByTestId('block-iframe').query() as HTMLIFrameElement | null;
+
+/** The height the host has actually applied to the iframe element. */
+function appliedHeight(): number {
+  return Number.parseFloat(iframeEl().style.height);
+}
+
+function postFromBlock(type: string, payload?: unknown) {
+  const cw = iframeEl().contentWindow;
+  if (!cw) throw new Error('iframe contentWindow missing');
+  window.dispatchEvent(
+    new MessageEvent('message', {
+      data: { type, payload },
+      origin: window.location.origin,
+      source: cw,
+    })
+  );
+}
+
+async function waitForMount() {
+  await vi.waitFor(() => {
+    const el = iframeQuery();
+    if (!el?.contentWindow) throw new Error('not mounted yet');
+  });
+}
+
+/** Un-batched drive to ready (the eager-updater path). */
+async function driveToReady(payload: unknown = {}) {
+  await waitForMount();
+  await vi.waitFor(() => {
+    postFromBlock('BLOCK_READY', payload);
+    if (iframeEl().getAttribute('data-block-ready') !== 'true') throw new Error('not ready yet');
+  });
+}
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+// ── beacon plumbing ──────────────────────────────────────────────────────────
+let fetchSpy: ReturnType<typeof vi.spyOn>;
+// Direct observation of side effect #2. Counting BLOCK_INIT postMessages instead
+// would be VACUOUS: the same-origin iframe REPLACES its `contentWindow` when its
+// document loads, so a listener attached to the window we can reach from the test
+// never sees the host's posts (verified — it captured 0, so the assertion could
+// never fail). Spying the controller method the handler calls is the honest
+// observable, and it IS the guard under test.
+let notifyReadySpy: ReturnType<typeof vi.spyOn>;
+
+function beaconBodies(): Array<Record<string, unknown>> {
+  return (fetchSpy.mock.calls as unknown[][])
+    .filter((c) => typeof c[0] === 'string' && (c[0] as string).includes('/api/track/block-render'))
+    .map((c) => JSON.parse(String((c[1] as RequestInit).body)) as Record<string, unknown>);
+}
+const okBeacons = () => beaconBodies().filter((b) => b.status === undefined);
+const errorBeacons = () => beaconBodies().filter((b) => b.status === 'error');
+
+beforeEach(() => {
+  mocks.bump = null;
+  // vi.spyOn dedupes to the same mock when fetch is already spied, so its
+  // .mock.calls would accumulate across tests — clear it each time.
+  fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(null, { status: 200 }));
+  fetchSpy.mockClear();
+  // spyOn calls through to the real implementation by default, so the controller
+  // still genuinely stops its retry loop + readiness timeout.
+  notifyReadySpy = vi.spyOn(IframeInitController.prototype, 'notifyReady');
+  notifyReadySpy.mockClear();
+});
+
+describe('IframeHost ready transition — batched updates (the regression)', () => {
+  test('a BLOCK_READY that lands with an unrelated update already queued STILL applies the height, stops the init retries, and emits exactly one ok beacon', async () => {
+    renderWithProviders(<IframeHost {...baseProps} />);
+    await waitForMount();
+    expect(appliedHeight()).toBe(MIN_HEIGHT);
+    expect(notifyReadySpy).not.toHaveBeenCalled();
+
+    // 🔴 THE REPRO. Queue a real update on the IframeHost fiber, then deliver
+    // BLOCK_READY in the SAME synchronous task — no await in between. React now
+    // has pending work on this fiber, so it CANNOT take the eager-updater path,
+    // which is exactly the condition under which the old
+    // `let appliedReady = …; setStatus(u); if (appliedReady)` code silently
+    // skipped all three side effects.
+    if (!mocks.bump) throw new Error('batching lever not wired');
+    mocks.bump();
+    postFromBlock('BLOCK_READY', { height: 640 });
+
+    // The status transition itself was never the broken part — it is the SIDE
+    // EFFECTS that were lost, so assert each one.
+    await vi.waitFor(() => {
+      expect(iframeEl().getAttribute('data-block-ready')).toBe('true');
+    });
+    // 1. height applied (was: stuck at minHeight).
+    await vi.waitFor(() => {
+      expect(appliedHeight()).toBe(640);
+    });
+    // 3. exactly one impression beacon (was: silently dropped).
+    await vi.waitFor(() => {
+      expect(okBeacons()).toHaveLength(1);
+    });
+    expect(okBeacons()[0]).toEqual({
+      appBlockId: 'apb_test',
+      blockInstanceId: 'inst_test',
+      slotId: 'model.sidebar_top',
+    });
+    expect(errorBeacons()).toHaveLength(0);
+
+    // 2. the init controller was told the block acked, so it stops re-posting
+    // BLOCK_INIT and cancels its readiness timeout (was: the ~400ms loop kept
+    // firing until the 10s timeout stopped it).
+    expect(notifyReadySpy).toHaveBeenCalledTimes(1);
+  });
+
+  test('the un-batched ack (eager-updater path) applies the height and emits one ok beacon too', async () => {
+    // The scheduling shape that ALWAYS worked — pinned so the fix cannot regress
+    // the common path while fixing the batched one.
+    renderWithProviders(<IframeHost {...baseProps} />);
+    await driveToReady({ height: 512 });
+    await vi.waitFor(() => {
+      expect(appliedHeight()).toBe(512);
+    });
+    await vi.waitFor(() => expect(okBeacons()).toHaveLength(1));
+  });
+});
+
+describe('IframeHost ready transition — emit-once / apply-once semantics', () => {
+  test('duplicate BLOCK_READY acks in ONE batch yield exactly one beacon and one height application (last ack wins)', async () => {
+    renderWithProviders(<IframeHost {...baseProps} />);
+    await waitForMount();
+
+    // Three acks, same task. The first takes the eager path; the 2nd/3rd land
+    // with the first's updates pending — the exact shape that used to drop them.
+    postFromBlock('BLOCK_READY', { height: 300 });
+    postFromBlock('BLOCK_READY', { height: 450 });
+    postFromBlock('BLOCK_READY', { height: 610 });
+
+    await vi.waitFor(() => {
+      expect(iframeEl().getAttribute('data-block-ready')).toBe('true');
+    });
+    await vi.waitFor(() => {
+      // The block's most recent statement of its own handshake height.
+      expect(appliedHeight()).toBe(610);
+    });
+    await sleep(120);
+    expect(okBeacons()).toHaveLength(1);
+    expect(errorBeacons()).toHaveLength(0);
+  });
+
+  test('a duplicate ack AFTER the ready commit does not re-emit and does not clobber a negotiated RESIZE_IFRAME height', async () => {
+    renderWithProviders(<IframeHost {...baseProps} />);
+    await driveToReady({ height: 300 });
+    await vi.waitFor(() => expect(okBeacons()).toHaveLength(1));
+
+    // The block has since grown via the post-ready channel.
+    postFromBlock('RESIZE_IFRAME', { height: 700 });
+    await vi.waitFor(() => {
+      expect(appliedHeight()).toBe(700);
+    });
+
+    // A late re-ack must not rewind the height to its handshake value, and must
+    // not emit a second impression.
+    postFromBlock('BLOCK_READY', { height: 300 });
+    await sleep(150);
+    expect(appliedHeight()).toBe(700);
+    expect(okBeacons()).toHaveLength(1);
+  });
+
+  test('a manifest height change after ready does NOT re-run the ready commit and rewind a negotiated height', async () => {
+    // The scenario `readyTransitionAppliedRef` exists for. `applyHeight` is a
+    // useCallback over manifest min/maxHeight, so those values changing mid-mount
+    // (a new approved version landing under an unpinned install) gives the
+    // ready-commit effect a NEW dependency identity. Without the run-once guard
+    // it re-runs while `status` is still 'ready' and re-applies the stale
+    // HANDSHAKE height, silently rewinding a height the block had since
+    // negotiated via RESIZE_IFRAME.
+    const { rerender } = await renderWithProviders(<IframeHost {...baseProps} />);
+    await driveToReady({ height: 260 });
+    await vi.waitFor(() => expect(okBeacons()).toHaveLength(1));
+
+    postFromBlock('RESIZE_IFRAME', { height: 700 });
+    await vi.waitFor(() => {
+      expect(appliedHeight()).toBe(700);
+    });
+
+    await rerender(
+      <IframeHost
+        {...baseProps}
+        install={{
+          ...install,
+          manifest: {
+            ...install.manifest,
+            // Rebuilt (not spread) because `manifest.iframe` is optional, so
+            // spreading it widens every field to `| undefined`.
+            iframe: {
+              src: SAME_ORIGIN_SRC,
+              minHeight: MIN_HEIGHT,
+              maxHeight: 900,
+              resizable: true,
+              sandbox: 'allow-scripts',
+            },
+          },
+        }}
+      />
+    );
+    await sleep(200);
+
+    expect(appliedHeight()).toBe(700);
+    expect(okBeacons()).toHaveLength(1);
+  });
+
+  test('ok and error beacons are mutually exclusive: a fatal AFTER ready emits no second beacon', async () => {
+    // Pins the SHARED `blockRenderEmittedRef`. The ready-transition effect must
+    // claim it, so the terminal-failure effect below it can never add a second
+    // impression for the same mount.
+    renderWithProviders(<IframeHost {...baseProps} />);
+    await driveToReady({ height: 320 });
+    await vi.waitFor(() => expect(okBeacons()).toHaveLength(1));
+
+    postFromBlock('BLOCK_ERROR', { fatal: true });
+    await vi.waitFor(() => {
+      expect(iframeQuery()).toBeNull();
+    });
+    await sleep(150);
+    expect(okBeacons()).toHaveLength(1);
+    expect(errorBeacons()).toHaveLength(0);
+    expect(beaconBodies()).toHaveLength(1);
+  });
+});
+
+describe('IframeHost ready transition — untrusted height payload', () => {
+  test('an ack with NO height leaves the iframe at the manifest minHeight and still completes the handshake', async () => {
+    renderWithProviders(<IframeHost {...baseProps} />);
+    await driveToReady({});
+    await vi.waitFor(() => expect(okBeacons()).toHaveLength(1));
+    expect(appliedHeight()).toBe(MIN_HEIGHT);
+  });
+
+  // The payload crosses an iframe boundary and is functionally untyped: the shape
+  // guard reduces anything without a `height` key to `{}`, and `applyHeight`
+  // rejects every non-finite / non-positive value. Either way the handshake must
+  // still complete (a bad height is not a fatal error).
+  test.each([
+    ['a non-object payload', 'nope' as unknown],
+    ['a null payload', null as unknown],
+    ['no height key', { width: 400 } as unknown],
+    ['a string height', { height: '640' } as unknown],
+    ['NaN', { height: Number.NaN } as unknown],
+    ['Infinity', { height: Number.POSITIVE_INFINITY } as unknown],
+    ['zero', { height: 0 } as unknown],
+    ['a negative height', { height: -900 } as unknown],
+    ['a null height', { height: null } as unknown],
+    ['an object height', { height: { valueOf: () => 640 } } as unknown],
+  ])(
+    '%s is rejected but the block still reaches ready with one beacon',
+    async (_label, payload) => {
+      renderWithProviders(<IframeHost {...baseProps} />);
+      await driveToReady(payload);
+      await vi.waitFor(() => expect(okBeacons()).toHaveLength(1));
+      expect(appliedHeight()).toBe(MIN_HEIGHT);
+    }
+  );
+
+  test('an over-ceiling height is clamped to the manifest maxHeight', async () => {
+    renderWithProviders(<IframeHost {...baseProps} />);
+    await driveToReady({ height: 999_999 });
+    await vi.waitFor(() => {
+      expect(appliedHeight()).toBe(MAX_HEIGHT);
+    });
+  });
+
+  test('a height below the manifest minHeight is floored to minHeight', async () => {
+    renderWithProviders(<IframeHost {...baseProps} />);
+    await driveToReady({ height: 12 });
+    await vi.waitFor(() => expect(okBeacons()).toHaveLength(1));
+    expect(appliedHeight()).toBe(MIN_HEIGHT);
+  });
+});
+
+describe('IframeHost ready transition — H-11: a late BLOCK_READY after a terminal state', () => {
+  // 🔴 THE INVARIANT the buggy code was (correctly) trying to protect, and which
+  // the fix must not trade away: once the host has landed on `timeout` / `fatal` /
+  // `no_token`, a BLOCK_READY that arrives afterwards must apply NO height, emit
+  // NO `ok` beacon, and never revive `ready`. It is now STRUCTURAL rather than a
+  // timing observation — the ready-transition effect early-returns on
+  // `status !== 'ready'`, and `status` can only become 'ready' from 'loading'.
+  //
+  // Note on IframeHost's terminal shape (it diverges from PageBlockHost): every
+  // terminal state COLLAPSES the host to null (hostRenderDecision) rather than
+  // rendering a framed BlockFallback, so `block-iframe` is gone — which is how
+  // FRAME-1 is satisfied here (nothing rendered ⇒ nothing to masquerade as).
+
+  test('BLOCK_ERROR{fatal} batched with a BLOCK_READY in the same task stays fatal: no height, no ok beacon, only the error beacon', async () => {
+    // The DELIVERABLE H-11 case — both messages are dispatched while the iframe
+    // is still mounted, so both really reach the host's handlers, and the
+    // BLOCK_READY lands with the fatal transition already queued (no eager path).
+    renderWithProviders(<IframeHost {...baseProps} />);
+    await waitForMount();
+
+    postFromBlock('BLOCK_ERROR', { fatal: true });
+    postFromBlock('BLOCK_READY', { height: 640 });
+
+    // Collapsed → the whole host renders null.
+    await vi.waitFor(() => {
+      expect(iframeQuery()).toBeNull();
+    });
+    // The mutually-exclusive FAILURE beacon fired; the ok beacon never did. (If a
+    // regression re-ran the ready side effects unconditionally, the ok beacon
+    // would claim the shared emit-once ref and this would flip.)
+    await vi.waitFor(() => {
+      expect(errorBeacons()).toHaveLength(1);
+    });
+    expect(errorBeacons()[0]).toMatchObject({ status: 'error', errorClass: 'fatal' });
+    expect(okBeacons()).toHaveLength(0);
+  });
+
+  test('a late BLOCK_READY after the readiness TIMEOUT applies nothing and emits no ok beacon', async () => {
+    renderWithProviders(<IframeHost {...baseProps} />);
+    await waitForMount();
+    // Never ack → the controller's ~10s readiness timeout fires → 'timeout'.
+    await vi.waitFor(
+      () => {
+        expect(iframeQuery()).toBeNull();
+      },
+      { timeout: 14_000, interval: 250 }
+    );
+    await vi.waitFor(() => expect(errorBeacons()).toHaveLength(1));
+    expect(errorBeacons()[0]).toMatchObject({ errorClass: 'timeout' });
+
+    // A late ack (the block finally woke up) must change nothing.
+    window.dispatchEvent(
+      new MessageEvent('message', {
+        data: { type: 'BLOCK_READY', payload: { height: 640 } },
+        origin: window.location.origin,
+      })
+    );
+    await sleep(200);
+    expect(okBeacons()).toHaveLength(0);
+    expect(errorBeacons()).toHaveLength(1);
+    expect(iframeQuery()).toBeNull();
+  }, 22_000);
+
+  test('a late BLOCK_READY after NO_TOKEN applies nothing and emits no ok beacon', async () => {
+    // An empty token never satisfies `shouldStartInit`, so the independent
+    // token-wait timer (~15s) is what goes terminal here.
+    renderWithProviders(<IframeHost {...baseProps} token="" />);
+    await waitForMount();
+    await vi.waitFor(
+      () => {
+        expect(iframeQuery()).toBeNull();
+      },
+      { timeout: 19_000, interval: 250 }
+    );
+    await vi.waitFor(() => expect(errorBeacons()).toHaveLength(1));
+    expect(errorBeacons()[0]).toMatchObject({ errorClass: 'no_token' });
+
+    window.dispatchEvent(
+      new MessageEvent('message', {
+        data: { type: 'BLOCK_READY', payload: { height: 640 } },
+        origin: window.location.origin,
+      })
+    );
+    await sleep(200);
+    expect(okBeacons()).toHaveLength(0);
+    expect(errorBeacons()).toHaveLength(1);
+  }, 28_000);
+});
+
+describe('IframeHost ready transition — a ready block must never go terminal', () => {
+  test('a block that acked BLOCK_READY (under batching) still shows no timeout past the readiness window', async () => {
+    // The consequence chain worth pinning. Skipping `notifyReady()` leaves the
+    // controller's readiness timeout armed — but a ready block still cannot be
+    // flipped to 'timeout', because THREE independent guards each prevent it:
+    //   1. `notifyReady()` → `stop()` clears the timeout (the direct path);
+    //   2. `status` is in the init effect's dep array, so committing 'ready'
+    //      re-runs it → the cleanup `dispose()`s the controller and
+    //      `shouldStartInit` then refuses to make a new one. This one fires even
+    //      if (1) is skipped, and is the reason the impact of the reported bug
+    //      stops at "wasted BLOCK_INIT re-posts in the commit window";
+    //   3. `onReadyTimeout` is itself `current === 'loading'`-guarded.
+    // Assert the CONTRACT rather than any one mechanism: a ready block stays
+    // rendered, keeps its height, and emits no error beacon well past
+    // BLOCK_READY_TIMEOUT_MS. (Mutation-verified: breaking all three — see M11 in
+    // the PR body — fails this test; breaking any two still passes.)
+    renderWithProviders(<IframeHost {...baseProps} />);
+    await waitForMount();
+    if (!mocks.bump) throw new Error('batching lever not wired');
+    mocks.bump();
+    postFromBlock('BLOCK_READY', { height: 420 });
+
+    await vi.waitFor(() => {
+      expect(iframeEl().getAttribute('data-block-ready')).toBe('true');
+    });
+    await vi.waitFor(() => expect(okBeacons()).toHaveLength(1));
+
+    await sleep(12_000);
+
+    expect(iframeQuery()).not.toBeNull();
+    expect(iframeEl().getAttribute('data-block-ready')).toBe('true');
+    expect(appliedHeight()).toBe(420);
+    expect(errorBeacons()).toHaveLength(0);
+    expect(okBeacons()).toHaveLength(1);
+  }, 22_000);
+});


### PR DESCRIPTION
## The bug

`IframeHost`'s `BLOCK_READY` handler read the `loading → ready` transition out of the `setStatus` **updater**:

```js
let appliedReady = false;
setStatus((current) => {
  if (current === 'loading') { appliedReady = true; return 'ready'; }
  return current;
});
if (appliedReady) {
  controllerRef.current?.notifyReady();
  applyHeight(payload.height);
  if (!blockRenderEmittedRef.current) { blockRenderEmittedRef.current = true; sendBlockRender({...}); }
}
```

The in-code comment claimed this could read the transition out of the updater. It cannot. React only evaluates an updater eagerly as a **bail-out optimisation**, and only while the fiber has no other pending update. As soon as any unrelated state update is already queued on this component when `BLOCK_READY` lands, the eager path is skipped, the updater runs later during render, `appliedReady` is still `false` at the `if`, and the **entire branch is dropped**.

## Consequence set (all three side effects, not just the height)

| # | Side effect skipped | Real-world consequence |
|---|---|---|
| 1 | `applyHeight(payload.height)` | The iframe stays pinned at manifest `minHeight` — clipped block content, or a dead gap under a short block. This is the reported symptom. |
| 2 | `controllerRef.current?.notifyReady()` | The init controller is not told the block acked, so it keeps re-posting `BLOCK_INIT` on its ~400 ms loop. **Bounded, and it does NOT cause a false timeout** — see below. |
| 3 | `sendBlockRender({...})` | The render/impression beacon is silently dropped → `civitai_app_block_renders_total{result="ok"}` undercounts and ClickHouse `blockRenders` misses the row. |

### #2 answered from the code: can a ready block still flip to `timeout`?

**No.** Three independent guards each prevent it, and I mutation-tested the layering:

1. `notifyReady()` → `stop()` clears the retry interval **and** the readiness timeout (the direct path — the one that was being skipped).
2. **`status` is in the init effect's dependency array** (`IframeHost.tsx:818`), so committing `'ready'` re-runs that effect; its cleanup calls `controller.dispose()` and `shouldStartInit({status:'ready'})` then refuses to create a new one. **This fires even when (1) is skipped**, which is what bounds the blast radius of the bug: the extra `BLOCK_INIT` re-posts only span the ack → commit window (realistically 0–1 posts), not the full 10 s.
3. `onReadyTimeout` is itself `current === 'loading'`-guarded, so even a surviving timer is a no-op once ready.

Mutation-verified: breaking (1)+(3) together (**M10**) still passes; breaking all three (**M11**) fails. So the `notifyReady` miss is **wasted work + a redundant armed timer, not a user-visible "Block took too long to load"** — materially *less* bad than the height bug, contrary to the hypothesis in the brief.

## The fix

Reuses PR #3457's approach on the sibling `PageBlockHost` so the two hosts don't diverge into two solutions for one problem:

- plain guarded `setStatus` transition — no side effect read out of the updater;
- `notifyReady()` called **unconditionally** (documented-idempotent → `stop()`);
- the acked height is stashed in `pendingReadyHeightRef` and applied — together with the `ok` beacon — from a **new effect keyed on the COMMITTED `status`**, mirroring the render-FAILURE effect right below it.

`PageBlockHost` has no `applyHeight` (it's full-bleed), so the height ref is the one addition beyond #3457's shape.

### Invariants preserved

- **H-11** is now **structural** rather than a timing observation: the commit effect early-returns unless `status === 'ready'`, and `status` can only reach `'ready'` from `'loading'`. A late ack after `timeout` / `fatal` / `no_token` still writes the ref, but it is never read.
  - ⚠️ One deliberate, narrow deviation from H-11's literal wording ("must not … notify ready"): `notifyReady()` **is** called after a terminal state. It is provably inert there — after `timeout` the controller already stopped itself; after `no_token` it was never created (`shouldStartInit` requires a token); after `fatal` it cancels timers we *want* cancelled and cannot revive `status` (the only writer is the guarded updater, and `onReadyTimeout` is status-guarded). The **observable** content of the invariant (no height, no `ok` beacon, no status change) is enforced and regression-tested per terminal state. Making it unconditional is what removes the last dependence on observing the updater — same call #3457 made.
- **Emit-once**: `ok`/`error` still share `blockRenderEmittedRef`, so they stay mutually exclusive per mount. A new `readyTransitionAppliedRef` keeps the commit effect to one run per mount.
- **Untrusted payload**: the `{height?: unknown}` shape guard is unchanged, and `applyHeight` still drops non-finite/≤0 and clamps to `minHeight`/`maxHeight`/`HARD_HEIGHT_CEILING`.
- **FRAME-1**: untouched. Note `IframeHost` satisfies it by **collapsing to `null`** on every terminal state (`hostRenderDecision`) — nothing rendered ⇒ nothing to masquerade as — which differs from `PageBlockHost`'s framed-fallback shape.

## Declared behaviour changes

Beyond the fix itself, three observable changes — all surfaced or sharpened by the adversarial audit, all now pinned by tests:

1. **Duplicate acks in one batch: the last ack that *carries a height* wins.** Previously the eager path applied the first ack's height and dropped later ones. A later ack with no usable height no longer erases an earlier one (that direction would have been a regression — fixed in the second commit).
2. **`BLOCK_READY` then `BLOCK_ERROR{fatal}` in the same batch now reports `result=error`, not `result=ok`.** The old synchronous handler had already emitted `ok` before the fatal was processed, and the shared emit-once ref then suppressed the `error` beacon. Now both updaters run in one render, committed `status` is `fatal`, the ready effect early-returns, and the mount is honestly reported as a failed render. This moves the render-failure ratio in the **opposite** direction from the beacon fix below — i.e. *more* sensitive, not less.
3. **Ack-immediately-followed-by-unmount now emits no `ok` beacon.** The beacon moved from the synchronous handler to a passive effect, so if the host unmounts between the ack and the effect flush the update is discarded and the beacon is never issued — meaning `sendBlockRender`'s `keepalive: true` (which exists precisely for the navigate-away-on-ready case) no longer covers that window. Accepted: emitting synchronously is what the bug was.

**Scope correction on "H-11 is structural":** the claim holds for the `BLOCK_READY` path, which is what this PR touches. Separately and unchanged by this PR, `RESIZE_IFRAME` / `REQUEST_SIGN_IN` / `OPEN_BUZZ_PURCHASE` capture `status` in a closure that re-subscribes only on the effect flush, so each has a pre-existing stale-closure window after a terminal commit. For `RESIZE_IFRAME` it is unobservable (the host renders `null`, so nothing consumes `iframeHeight`).

## Test coverage

New `IframeHostReadyTransition.browser.test.tsx` — **25 cases**, extending (not replacing) the existing suite. All **223** `src/components/AppBlocks/**` component tests pass.

🔴 **Why the existing suite could not catch this**: `IframeHost.browser.test.tsx` stubs every tRPC hook as a constant-returning function, which **removes the very batching condition the bug needs** — the fiber is quiescent when `BLOCK_READY` arrives, React takes the eager path, and the buggy code passes. (This is the trap the sibling PR hit.) The new file therefore mocks `useBrowsingLevelDebounced` — called directly by `IframeHost`, so its hooks live on the **host fiber** — with a real `useState` and exposes the setter, so a test can queue a genuine React update and then deliver `BLOCK_READY` in the **same synchronous task**. The mock *adds* the batching condition rather than papering over it.

Covered: batched **and** un-batched ready paths · `notifyReady` observed · exactly one `ok` beacon with the model-slot identifiers · duplicate acks in one batch · a late ack after the ready commit not clobbering a negotiated `RESIZE_IFRAME` height · a manifest height change not rewinding it · `ok`/`error` mutual exclusion · 10 malformed/absent height payloads · min-floor and max-clamp · H-11 for all three terminal states (including the *deliverable* batched `BLOCK_ERROR{fatal}` + `BLOCK_READY` case) · a ready block never going terminal.

## Mutation table

Every guard was broken, the *specific* failing test recorded, then reverted.

| # | Mutation | Result |
|---|---|---|
| **M1** | Revert wholesale to the original `appliedReady` code | ✅ **FAIL** — batched-ack test: `expected 200 to be 640` (the exact reported symptom) |
| **M2** | Drop `applyHeight(pendingReadyHeightRef.current)` | ✅ **FAIL** — batched-ack test: `expected 200 to be 640` |
| **M3** | Remove the `status !== 'ready'` guard (H-11's structural gate) | ✅ **FAIL** — H-11 `fatal` test *and* H-11 `timeout` test: `expected [] to have a length of 1` (the `ok` beacon claimed the shared ref, suppressing the `error` beacon) |
| **M4** | Remove the `readyTransitionAppliedRef` run-once guard | ✅ **FAIL** — manifest-height-change test: `expected 700, received 260` (rewound to the stale handshake height) |
| **M5** | Stop claiming the shared `blockRenderEmittedRef` | ✅ **FAIL** — mutual-exclusion test: 2 beacons instead of 1 |
| **M6** | Remove `controllerRef.current?.notifyReady()` | ✅ **FAIL** — batched-ack test: `expected "notifyReady" to be called 1 times, but got 0` |
| **M7** | Remove the untrusted-payload shape guard | ✅ **FAIL** — null-payload test: `TypeError: Cannot read properties of null (reading 'height')` |
| **M9** | Drop only `sendBlockRender(...)` | ✅ **FAIL** — batched-ack test: `expected [] to have a length of 1` |
| **M10** | No `notifyReady` **+** unguarded `onReadyTimeout` | ⚪ **PASSES** — correctly: the init effect's `status`-keyed cleanup is a third, independent guard |
| **M11** | M10 **+** drop `status` from the init effect deps (all three guards) | ✅ **FAIL** — never-goes-terminal test: `expected null not to be null` |
| **M8** | Stash the height from *inside* the `setStatus` updater | ⚪ **PASSES** — **equivalent mutant**, not a coverage gap: the updater runs during render, before the commit effect reads the ref, so behaviour is identical |

One assertion was found **vacuous during this process and replaced**: counting `BLOCK_INIT` postMessages to observe `notifyReady` captured **0** messages (the same-origin iframe replaces its `contentWindow` on load, so a test-side listener never sees the host's posts) — it could never have failed. It now spies `IframeInitController.prototype.notifyReady` (call-through), which M6 does flip. Separately, the late-ack `dispatchEvent` in the `timeout` / `no_token` tests asserts nothing on its own (post-collapse no message can be delivered) — those tests are killed by **M3** via their terminal-outcome assertions instead, and now say so.

## Real-world exposure

**No user-visible impact expected today** — this is a latent correctness bug, not a live one.

- Model-slot apps are outside the launch allowlist (`LAUNCH_SLOT_IDS = ['app.page']`, `src/shared/constants/slot-registry.ts:250`) and the whole surface sits behind the mod-only `appBlocks` Flipt flag.
- `IframeHost` has exactly **one** production mount chain — `ModelVersionDetails` → `BlockSlot` → `BlockSlotClient` → `BlockHost` → `IframeHost`. Verified by grep; nothing else imports it (`PageBlockHost` takes only `AppBlockChrome` from the module, and the mod-review sandbox mounts `PageBlockHost`).
- Every `listForModel` resolve branch gates `AND ab.status = 'approved'` (`src/server/services/block-registry.service.ts:792`, `:853`, `:931`, `:1005`) plus the deploy gate, so a non-approved app structurally cannot mount the host. (Caveat found in review: the 60s anon cache path at `:718-735` filters only on kill-list + host maturity, so a status change is visible for up to a minute on that branch — pre-existing, self-healing, unrelated to this PR.)

I checked the current install census against the database separately; the specifics live in the private infra repo rather than here. Net: this is **not urgent**, but it stops being latent the moment a model-slot app is approved — at which point the height half is immediately visible (clipped content / dead gap) and the beacon half is silent.

## Metrics / alerting note

Fixing the dropped beacon will **step `civitai_app_block_renders_total{result="ok"}` up on deploy** for model-slot blocks. Not a regression — the old rate was an undercount. Two consequences to expect:

- graphs baselined on the old rate shift;
- the infra-side render-failure alert is a **ratio** of `error` to total, so a larger `ok` denominator makes it **less sensitive** (a fixed number of failures dilutes toward its threshold).

Given the exposure above the step is effectively **0 → 0** right now, so the practical impact lands whenever model-slot blocks actually serve.

## Verification

- `vitest --project component src/components/AppBlocks/` → **223/223 pass** (20 files), including the 5 pre-existing `IframeHost.browser.test.tsx` cases. Also re-ran the batching / reverse-order / height-loss cases 16× to check for scheduling flakiness — all deterministic.
- `tsc --noEmit -p tsconfig.json` → **28 errors, byte-identical to the `main` baseline** (uninitialised `event-engine-common` submodule + stale Prisma client + `@civitai/buzz` workspace resolution — all local-env artifacts in files this PR doesn't touch). Zero added.
- `eslint` on the changed files → **0 errors**, 1 warning that is pre-existing on `main`.
- `prettier --check` clean on the new file; the two pre-existing files are already prettier-dirty on `main`, so they were left unformatted to avoid unrelated churn.

`preview / deploy` (`next build`) is the authoritative typecheck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
