### PR TITLE
fix(apps): deterministic per-app placeholder for listings missing icon/cover

### DIFF
--- a/src/components/Apps/AppListingCard.tsx
+++ b/src/components/Apps/AppListingCard.tsx
@@ -56,10 +56,13 @@ function categoryIcon(category: string): Icon {
 
 /**
  * Card cover — the listing's cover image (`coverUrl`, already a CDN URL, with the
- * first screenshot as a server-side fallback). When absent, a tasteful
- * category-glyph placeholder over a neutral gradient (mirrors AppBlockCard) so a
- * card is never a broken/empty `<img>`. Decorative (aria-hidden) — the placeholder
- * carries no info the title/category chip don't.
+ * first screenshot as a server-side fallback). When absent, a category-glyph
+ * placeholder over the listing's DETERMINISTIC PER-APP seeded gradient (shared
+ * with the server-generated cover SVG — see
+ * `~/shared/constants/app-listing-placeholder.constants`), so a card is never a
+ * broken/empty `<img>` and two coverless listings never look identical.
+ * Decorative (aria-hidden) — the placeholder carries no info the title/category
+ * chip don't.
  */
 function ListingCover({
   coverUrl,
@@ -100,7 +103,7 @@ function ListingCover({
         aria-hidden
         h={140}
         className="flex items-center justify-center"
-        data-listing-cover-placeholder
+        data-listing-cover-placeholder=""
         style={{ background: listingPlaceholderGradient({ slug, category, surface: 'cover' }) }}
       >
         <PlaceholderIcon size={44} className="opacity-60" />

--- a/src/components/Apps/AppListingCard.tsx
+++ b/src/components/Apps/AppListingCard.tsx
@@ -18,6 +18,10 @@ import {
 import { TruncatedText } from '~/components/Apps/AppListingTruncate';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
 import { isMarketplaceCategory } from '~/server/services/blocks/marketplace-categories.constants';
+import {
+  appInitial,
+  listingPlaceholderGradient,
+} from '~/shared/constants/app-listing-placeholder.constants';
 import type { ListingCard } from '~/server/schema/blocks/app-listing-read.schema';
 
 /**
@@ -61,10 +65,12 @@ function ListingCover({
   coverUrl,
   category,
   name,
+  slug,
 }: {
   coverUrl: string | null;
   category: string | null;
   name: string;
+  slug: string;
 }) {
   // A non-null coverUrl can still 404 (the server derives it from a first-
   // screenshot fallback, whose Image can dangle) — fall back to the category
@@ -84,18 +90,20 @@ function ListingCover({
     );
   }
   const PlaceholderIcon = category ? categoryIcon(category) : IconApps;
+  // Per-app SEEDED gradient (not one uniform grey for every coverless listing) —
+  // same seed + stops the generated cover SVG uses, so a listing that later gets
+  // a real generated asset keeps its colour identity. See
+  // `~/shared/constants/app-listing-placeholder.constants`.
   return (
     <Card.Section>
       <Box
         aria-hidden
         h={140}
         className="flex items-center justify-center"
-        style={{
-          background:
-            'linear-gradient(135deg, var(--mantine-color-dark-5) 0%, var(--mantine-color-dark-7) 100%)',
-        }}
+        data-listing-cover-placeholder
+        style={{ background: listingPlaceholderGradient({ slug, category, surface: 'cover' }) }}
       >
-        <PlaceholderIcon size={44} className="opacity-40" />
+        <PlaceholderIcon size={44} className="opacity-60" />
       </Box>
     </Card.Section>
   );
@@ -176,7 +184,12 @@ export function AppListingCard({ card, canOpenPage = false }: AppListingCardProp
 
   return (
     <Card shadow="sm" padding="md" radius="md" withBorder className="h-full">
-      <ListingCover coverUrl={card.coverUrl} category={card.category} name={card.name} />
+      <ListingCover
+        coverUrl={card.coverUrl}
+        category={card.category}
+        name={card.name}
+        slug={card.slug}
+      />
       <Stack gap="sm" h="100%" pt="sm">
         <Group gap="xs" wrap="nowrap" align="flex-start" style={{ minWidth: 0 }}>
           {/* App icon (square, publisher-supplied). Decorative — the title
@@ -188,8 +201,23 @@ export function AppListingCard({ card, canOpenPage = false }: AppListingCardProp
             radius="md"
             size={40}
             style={{ flexShrink: 0 }}
+            data-listing-icon-placeholder={card.iconUrl == null ? '' : undefined}
+            styles={{
+              // Missing icon → the SAME seeded monogram the generated icon SVG
+              // renders (per-app hue + first-alphanumeric initial), instead of
+              // Mantine's default flat grey placeholder.
+              placeholder: {
+                background: listingPlaceholderGradient({
+                  slug: card.slug,
+                  category: card.category,
+                  surface: 'icon',
+                }),
+                color: 'var(--mantine-color-white)',
+                fontWeight: 700,
+              },
+            }}
           >
-            {card.name.charAt(0).toUpperCase()}
+            {appInitial(card.name, card.slug)}
           </Avatar>
           <Stack gap={2} style={{ minWidth: 0 }}>
             {/* Title links to the unified detail so the detail is reachable

--- a/src/components/Apps/AppListingDetailBody.tsx
+++ b/src/components/Apps/AppListingDetailBody.tsx
@@ -93,9 +93,11 @@ function categoryIcon(category: string): Icon {
 
 /**
  * Hero cover — the listing cover (`coverUrl`, already a CDN URL). Falls back to a
- * category-glyph placeholder over a neutral gradient when absent OR the image
- * 404s (a coverUrl derived from a first-screenshot fallback can dangle) — never
- * a broken `<img>`. Decorative (aria-hidden placeholder).
+ * category-glyph placeholder over the listing's DETERMINISTIC PER-APP seeded
+ * gradient (shared with the server-generated cover SVG — see
+ * `~/shared/constants/app-listing-placeholder.constants`) when absent OR the
+ * image 404s (a coverUrl derived from a first-screenshot fallback can dangle) —
+ * never a broken `<img>`. Decorative (aria-hidden placeholder).
  */
 function HeroCover({
   coverUrl,
@@ -129,7 +131,7 @@ function HeroCover({
       aria-hidden
       h={260}
       className="flex items-center justify-center"
-      data-listing-cover-placeholder
+      data-listing-cover-placeholder=""
       style={{
         borderRadius: 'var(--mantine-radius-md)',
         background: listingPlaceholderGradient({ slug, category, surface: 'cover' }),

--- a/src/components/Apps/AppListingDetailBody.tsx
+++ b/src/components/Apps/AppListingDetailBody.tsx
@@ -28,6 +28,10 @@ import type { Icon } from '@tabler/icons-react';
 import Link from 'next/link';
 import { useState } from 'react';
 import { getEdgeUrl } from '~/client-utils/cf-images-utils';
+import {
+  appInitial,
+  listingPlaceholderGradient,
+} from '~/shared/constants/app-listing-placeholder.constants';
 import { getRecommendLabel } from '~/components/Apps/appListingCardView';
 import {
   canOwnerEditListing,
@@ -97,10 +101,12 @@ function HeroCover({
   coverUrl,
   category,
   name,
+  slug,
 }: {
   coverUrl: string | null;
   category: string | null;
   name: string;
+  slug: string;
 }) {
   const [broken, setBroken] = useState(false);
   if (coverUrl && !broken) {
@@ -116,18 +122,20 @@ function HeroCover({
     );
   }
   const PlaceholderIcon = category ? categoryIcon(category) : IconApps;
+  // Per-app SEEDED gradient — same seed/stops as the generated cover SVG and the
+  // store card, so one listing reads as one identity across every surface.
   return (
     <Box
       aria-hidden
       h={260}
       className="flex items-center justify-center"
+      data-listing-cover-placeholder
       style={{
         borderRadius: 'var(--mantine-radius-md)',
-        background:
-          'linear-gradient(135deg, var(--mantine-color-dark-5) 0%, var(--mantine-color-dark-7) 100%)',
+        background: listingPlaceholderGradient({ slug, category, surface: 'cover' }),
       }}
     >
-      <PlaceholderIcon size={72} className="opacity-40" />
+      <PlaceholderIcon size={72} className="opacity-60" />
     </Box>
   );
 }
@@ -323,13 +331,35 @@ export function AppListingDetailBody({
         </Anchor>
       )}
 
-      <HeroCover coverUrl={detail.coverUrl} category={detail.category} name={detail.name} />
+      <HeroCover
+        coverUrl={detail.coverUrl}
+        category={detail.category}
+        name={detail.name}
+        slug={detail.slug}
+      />
 
       {/* Header: icon + name + tagline + creator + content-rating badge + action. */}
       <Group justify="space-between" align="flex-start" wrap="nowrap">
         <Group gap="md" wrap="nowrap" align="flex-start" style={{ minWidth: 0 }}>
-          <Avatar src={detail.iconUrl ?? undefined} alt="" radius="md" size={64}>
-            {detail.name.charAt(0).toUpperCase()}
+          <Avatar
+            src={detail.iconUrl ?? undefined}
+            alt=""
+            radius="md"
+            size={64}
+            data-listing-icon-placeholder={detail.iconUrl == null ? '' : undefined}
+            styles={{
+              placeholder: {
+                background: listingPlaceholderGradient({
+                  slug: detail.slug,
+                  category: detail.category,
+                  surface: 'icon',
+                }),
+                color: 'var(--mantine-color-white)',
+                fontWeight: 700,
+              },
+            }}
+          >
+            {appInitial(detail.name, detail.slug)}
           </Avatar>
           <Stack gap={6} style={{ minWidth: 0 }}>
             <Title order={2} className="line-clamp-2">

--- a/src/server/services/blocks/__tests__/app-listing-assets.service.test.ts
+++ b/src/server/services/blocks/__tests__/app-listing-assets.service.test.ts
@@ -311,18 +311,36 @@ describe('pure helpers', () => {
     const category = 'games';
     const { hue, hue2 } = placeholderHues(listingPlaceholderSeed(slug, category));
 
+    // 🔴 Assert the stop + its OFFSET as ONE string. A pair of order-agnostic
+    // `toContain(stop)` checks passes even if the two stops are SWAPPED — an
+    // inverted gradient on every generated icon, which is a real visual
+    // regression. Binding offset→colour is what actually pins the direction.
     const icon = buildPlaceholderIconSvg({ slug, category, name: 'Cool App' });
-    expect(icon).toContain(placeholderStop('icon', 'from', hue));
-    expect(icon).toContain(placeholderStop('icon', 'to', hue2));
+    expect(icon).toContain(`offset="0%" stop-color="${placeholderStop('icon', 'from', hue)}"`);
+    expect(icon).toContain(`offset="100%" stop-color="${placeholderStop('icon', 'to', hue2)}"`);
 
     const cover = buildPlaceholderCoverSvg({ slug, category, name: 'Cool App' });
-    expect(cover).toContain(placeholderStop('cover', 'from', hue));
-    expect(cover).toContain(placeholderStop('cover', 'to', hue2));
+    expect(cover).toContain(`offset="0%" stop-color="${placeholderStop('cover', 'from', hue)}"`);
+    expect(cover).toContain(`offset="100%" stop-color="${placeholderStop('cover', 'to', hue2)}"`);
 
-    // …and the CSS the client renders uses those very same stop strings.
-    const css = listingPlaceholderGradient({ slug, category, surface: 'cover' });
-    expect(css).toContain(placeholderStop('cover', 'from', hue));
-    expect(css).toContain(placeholderStop('cover', 'to', hue2));
+    // …and the CSS the client renders uses those very same stops, in the same
+    // order. BOTH surfaces are cross-checked: `icon` backs the Avatar monogram
+    // and `cover` backs the card/hero, so checking only one leaves the other
+    // free to drift.
+    expect(listingPlaceholderGradient({ slug, category, surface: 'cover' })).toBe(
+      `linear-gradient(135deg, ${placeholderStop('cover', 'from', hue)} 0%, ${placeholderStop(
+        'cover',
+        'to',
+        hue2
+      )} 100%)`
+    );
+    expect(listingPlaceholderGradient({ slug, category, surface: 'icon' })).toBe(
+      `linear-gradient(135deg, ${placeholderStop('icon', 'from', hue)} 0%, ${placeholderStop(
+        'icon',
+        'to',
+        hue2
+      )} 100%)`
+    );
   });
 
   it('chooseScreenshotSource: existing → migrate(real only) → none', async () => {

--- a/src/server/services/blocks/__tests__/app-listing-assets.service.test.ts
+++ b/src/server/services/blocks/__tests__/app-listing-assets.service.test.ts
@@ -294,6 +294,37 @@ describe('pure helpers', () => {
     expect(cover).not.toContain('<x>');
   });
 
+  // DRIFT GUARD (cross-surface): the GENERATED asset SVGs and the CLIENT
+  // render-time fallback (AppListingCard / AppListingDetailBody, via
+  // `listingPlaceholderGradient`) must derive from the SAME seed + stops. They
+  // used to be two hand-rolled designs that silently diverged — a generated
+  // seeded-hue icon next to a uniform grey cover placeholder. If someone
+  // recolours one side only, this fails.
+  it('generated SVG stops match the client placeholder gradient stops', async () => {
+    const { buildPlaceholderIconSvg, buildPlaceholderCoverSvg } = await import(
+      '../app-listing-assets.service'
+    );
+    const { listingPlaceholderGradient, listingPlaceholderSeed, placeholderHues, placeholderStop } =
+      await import('~/shared/constants/app-listing-placeholder.constants');
+
+    const slug = 'cool-app';
+    const category = 'games';
+    const { hue, hue2 } = placeholderHues(listingPlaceholderSeed(slug, category));
+
+    const icon = buildPlaceholderIconSvg({ slug, category, name: 'Cool App' });
+    expect(icon).toContain(placeholderStop('icon', 'from', hue));
+    expect(icon).toContain(placeholderStop('icon', 'to', hue2));
+
+    const cover = buildPlaceholderCoverSvg({ slug, category, name: 'Cool App' });
+    expect(cover).toContain(placeholderStop('cover', 'from', hue));
+    expect(cover).toContain(placeholderStop('cover', 'to', hue2));
+
+    // …and the CSS the client renders uses those very same stop strings.
+    const css = listingPlaceholderGradient({ slug, category, surface: 'cover' });
+    expect(css).toContain(placeholderStop('cover', 'from', hue));
+    expect(css).toContain(placeholderStop('cover', 'to', hue2));
+  });
+
   it('chooseScreenshotSource: existing → migrate(real only) → none', async () => {
     const { chooseScreenshotSource } = await import('../app-listing-assets.service');
     const base = {

--- a/src/server/services/blocks/app-listing-assets.service.ts
+++ b/src/server/services/blocks/app-listing-assets.service.ts
@@ -16,6 +16,14 @@ import {
   type ListingAssetKind,
 } from '~/server/schema/blocks/app-listing.schema';
 import type { SessionUser } from '~/types/session';
+import {
+  appInitial,
+  categoryGlyph,
+  listingPlaceholderSeed,
+  placeholderHues,
+  placeholderStop,
+  seededHue,
+} from '~/shared/constants/app-listing-placeholder.constants';
 
 /**
  * App Store Listings (W13) — P1 asset pipeline service.
@@ -171,39 +179,15 @@ export function pickLogoPrefillUrl(logoUrl: string | null | undefined): string |
 // by the impure default deps below via sharp).
 // ---------------------------------------------------------------------------
 
-/** Category → glyph letter/emoji-free monogram seed (kept ASCII for the SVG). */
-const CATEGORY_GLYPH: Record<string, string> = {
-  generation: '✦',
-  games: '◆',
-  utility: '⚙',
-  discovery: '◈',
-  moderation: '⛨',
-  analytics: '▤',
-  other: '●',
-};
-
-/** FNV-1a → a stable 0..359 hue from a seed string (deterministic per slug). */
-export function seededHue(seed: string): number {
-  let h = 0x811c9dc5;
-  for (let i = 0; i < seed.length; i++) {
-    h ^= seed.charCodeAt(i);
-    h = Math.imul(h, 0x01000193);
-  }
-  return Math.abs(h) % 360;
-}
-
-/** The app's display initial (first alphanumeric of name, else slug), uppercased. */
-export function appInitial(name: string, slug: string): string {
-  // A whitespace-only name must fall through to the slug (not resolve to '?').
-  const src = (name?.trim() || slug?.trim() || '?').trim();
-  const m = src.match(/[A-Za-z0-9]/);
-  return (m ? m[0] : '?').toUpperCase();
-}
+// The placeholder PRIMITIVES (glyphs / seeded hue / initial / gradient stops)
+// now live in `~/shared/constants/app-listing-placeholder.constants` so the
+// CLIENT render-time fallback (AppListingCard / AppListingDetailBody) can derive
+// its colours from the SAME seed as these generated assets. They are re-exported
+// below to keep this module's public API (and its existing tests) unchanged.
+export { seededHue, appInitial };
 
 function gradientDefs(seed: string): { hue: number; hue2: number } {
-  const hue = seededHue(seed);
-  const hue2 = (hue + 40) % 360;
-  return { hue, hue2 };
+  return placeholderHues(seed);
 }
 
 /** Escape the few chars that are unsafe inside SVG text content. */
@@ -228,14 +212,14 @@ export function buildPlaceholderIconSvg(args: {
   size?: number;
 }): string {
   const size = args.size ?? 512;
-  const seed = `${args.category ?? 'other'}:${args.slug}`;
+  const seed = listingPlaceholderSeed(args.slug, args.category);
   const { hue, hue2 } = gradientDefs(seed);
   const initial = svgEscape(appInitial(args.name, args.slug));
   return [
     `<svg xmlns="http://www.w3.org/2000/svg" width="${size}" height="${size}" viewBox="0 0 ${size} ${size}">`,
     `<defs><linearGradient id="g" x1="0" y1="0" x2="1" y2="1">`,
-    `<stop offset="0%" stop-color="hsl(${hue} 55% 42%)"/>`,
-    `<stop offset="100%" stop-color="hsl(${hue2} 60% 22%)"/>`,
+    `<stop offset="0%" stop-color="${placeholderStop('icon', 'from', hue)}"/>`,
+    `<stop offset="100%" stop-color="${placeholderStop('icon', 'to', hue2)}"/>`,
     `</linearGradient></defs>`,
     `<rect width="${size}" height="${size}" rx="${Math.round(size * 0.18)}" fill="url(#g)"/>`,
     `<text x="50%" y="50%" dy="0.35em" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-weight="700" font-size="${Math.round(size * 0.5)}" fill="#ffffff" fill-opacity="0.92">${initial}</text>`,
@@ -257,15 +241,15 @@ export function buildPlaceholderCoverSvg(args: {
 }): string {
   const width = args.width ?? 1280;
   const height = args.height ?? 720;
-  const seed = `${args.category ?? 'other'}:${args.slug}`;
+  const seed = listingPlaceholderSeed(args.slug, args.category);
   const { hue, hue2 } = gradientDefs(seed);
-  const glyph = svgEscape(CATEGORY_GLYPH[args.category ?? 'other'] ?? CATEGORY_GLYPH.other);
+  const glyph = svgEscape(categoryGlyph(args.category));
   const name = svgEscape((args.name || args.slug).slice(0, 48));
   return [
     `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}">`,
     `<defs><linearGradient id="g" x1="0" y1="0" x2="1" y2="1">`,
-    `<stop offset="0%" stop-color="hsl(${hue} 45% 32%)"/>`,
-    `<stop offset="100%" stop-color="hsl(${hue2} 50% 16%)"/>`,
+    `<stop offset="0%" stop-color="${placeholderStop('cover', 'from', hue)}"/>`,
+    `<stop offset="100%" stop-color="${placeholderStop('cover', 'to', hue2)}"/>`,
     `</linearGradient></defs>`,
     `<rect width="${width}" height="${height}" fill="url(#g)"/>`,
     `<text x="50%" y="44%" text-anchor="middle" font-family="Inter, Arial, sans-serif" font-size="${Math.round(height * 0.22)}" fill="#ffffff" fill-opacity="0.85">${glyph}</text>`,

--- a/src/shared/constants/__tests__/app-listing-placeholder.constants.test.ts
+++ b/src/shared/constants/__tests__/app-listing-placeholder.constants.test.ts
@@ -123,7 +123,9 @@ describe('listingPlaceholderGradient', () => {
     const a = listingPlaceholderGradient({ slug: 'buzz', category: 'analytics', surface: 'cover' });
     const b = listingPlaceholderGradient({ slug: 'buzz', category: 'analytics', surface: 'cover' });
     expect(a).toBe(b);
-    expect(a).toMatch(/^linear-gradient\(135deg, hsl\(\d+ \d+% \d+%\) 0%, hsl\(\d+ \d+% \d+%\) 100%\)$/);
+    expect(a).toMatch(
+      /^linear-gradient\(135deg, hsl\(\d+ \d+% \d+%\) 0%, hsl\(\d+ \d+% \d+%\) 100%\)$/
+    );
   });
 
   it('differs per app', () => {
@@ -147,9 +149,9 @@ describe('listingPlaceholderGradient', () => {
     expect(listingPlaceholderGradient({ slug: 'buzz', category: null, surface: 'icon' })).toContain(
       `hsl(${hue} `
     );
-    expect(listingPlaceholderGradient({ slug: 'buzz', category: null, surface: 'cover' })).toContain(
-      `hsl(${hue} `
-    );
+    expect(
+      listingPlaceholderGradient({ slug: 'buzz', category: null, surface: 'cover' })
+    ).toContain(`hsl(${hue} `);
   });
 
   it('null and "other" category resolve identically (same seed)', () => {

--- a/src/shared/constants/__tests__/app-listing-placeholder.constants.test.ts
+++ b/src/shared/constants/__tests__/app-listing-placeholder.constants.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from 'fs';
+import path from 'path';
 import { describe, expect, it } from 'vitest';
 
 import {
@@ -44,10 +46,38 @@ describe('seededHue', () => {
 });
 
 describe('appInitial', () => {
-  it('takes the first alphanumeric of the name, uppercased', () => {
+  it('takes the first letter/digit of the name, uppercased', () => {
     expect(appInitial('Cool App', 'slug')).toBe('C');
     expect(appInitial('123abc', 'x')).toBe('1');
     expect(appInitial('  spaced', 'x')).toBe('S');
+  });
+
+  // 🔴 REGRESSION GUARD. An ASCII-only [A-Za-z0-9] class renders a literal '?'
+  // for every non-Latin app name — the exact "looks broken" outcome these
+  // placeholders exist to prevent. App names are unrestricted free text, so
+  // these are reachable inputs, not hypotheticals.
+  it('handles non-Latin scripts instead of collapsing them to ?', () => {
+    expect(appInitial('日本語アプリ', 'jp-app')).toBe('日');
+    expect(appInitial('Привет', 'ru-app')).toBe('П');
+    expect(appInitial('العربية', 'ar-app')).toBe('ا');
+  });
+
+  it('preserves accented Latin rather than skipping to the next ASCII letter', () => {
+    expect(appInitial('Émile', 'e-app')).toBe('É');
+    expect(appInitial('Ünicode App', 'u-app')).toBe('Ü');
+  });
+
+  it('skips a leading emoji / punctuation to the first real letter', () => {
+    // Must be the WHOLE code point, never a lone broken surrogate half.
+    expect(appInitial('🎨 Canvas', 'c-app')).toBe('C');
+    expect(appInitial('-dash', 'd-app')).toBe('D');
+  });
+
+  it('returns a single whole code point for an astral-plane first letter', () => {
+    // 𝐀 (U+1D400) is \p{L} and is a surrogate PAIR in UTF-16.
+    const out = appInitial('𝐀pp', 'x');
+    expect([...out]).toHaveLength(1);
+    expect(out).toBe('𝐀'.toUpperCase());
   });
 
   it('falls through to the slug for a blank/whitespace-only name', () => {
@@ -55,7 +85,12 @@ describe('appInitial', () => {
     expect(appInitial('', 'df-qwen-canvas')).toBe('D');
   });
 
-  it("resolves to '?' only when neither name nor slug has an alphanumeric", () => {
+  it('falls through to the slug when the NAME yields no letter/digit', () => {
+    expect(appInitial('—', 'cool-app')).toBe('C');
+    expect(appInitial('🎨', 'panorama-360')).toBe('P');
+  });
+
+  it("resolves to '?' only when neither name nor slug has a letter/digit", () => {
     expect(appInitial('', '')).toBe('?');
     expect(appInitial('—', '—')).toBe('?');
   });
@@ -159,4 +194,48 @@ describe('listingPlaceholderGradient', () => {
       listingPlaceholderGradient({ slug: 'x', category: 'other', surface: 'icon' })
     );
   });
+});
+
+/**
+ * 🔴 COMPONENT RE-COUPLING GUARD (source-level, mirrors the
+ * `block-scope.schema-drift` readFileSync convention).
+ *
+ * A value-equality test can only prove the numbers agree — it CANNOT see a
+ * component going back to its own hardcoded gradient, because a re-hardcoded
+ * literal that happens to match still passes every value assertion. That is the
+ * precise regression this whole module exists to prevent, and the store card /
+ * detail hero have NO blocking test coverage of their own (their `.browser.test.tsx`
+ * suites are report-only and assert nothing about the placeholder).
+ *
+ * So assert it structurally: these two components must derive their placeholder
+ * from the shared helper and must NOT carry the old uniform `--mantine-color-dark-*`
+ * gradient that made every below-floor listing look identical.
+ */
+const REPO_ROOT = path.resolve(__dirname, '../../../..');
+const COMPONENTS = [
+  'src/components/Apps/AppListingCard.tsx',
+  'src/components/Apps/AppListingDetailBody.tsx',
+];
+
+describe('listing placeholder ⇄ component re-coupling guard', () => {
+  for (const rel of COMPONENTS) {
+    describe(rel, () => {
+      const src = readFileSync(path.join(REPO_ROOT, rel), 'utf8');
+
+      it('imports the shared placeholder helper', () => {
+        expect(src).toContain('~/shared/constants/app-listing-placeholder.constants');
+        expect(src).toContain('listingPlaceholderGradient');
+      });
+
+      it('does not re-hardcode the old uniform dark gradient', () => {
+        expect(src).not.toMatch(/linear-gradient\([^)]*--mantine-color-dark-/);
+      });
+
+      it('does not hand-roll an initial via charAt for the APP name', () => {
+        // `creator.username.charAt(0)` is a DIFFERENT, legitimate use (usernames
+        // are not app names), so scope the ban to the app-name/detail-name forms.
+        expect(src).not.toMatch(/\b(card|detail)\.name\.charAt\(/);
+      });
+    });
+  }
 });

--- a/src/shared/constants/__tests__/app-listing-placeholder.constants.test.ts
+++ b/src/shared/constants/__tests__/app-listing-placeholder.constants.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  CATEGORY_GLYPH,
+  appInitial,
+  categoryGlyph,
+  listingPlaceholderGradient,
+  listingPlaceholderSeed,
+  placeholderHues,
+  placeholderStop,
+  seededHue,
+} from '../app-listing-placeholder.constants';
+
+/**
+ * These primitives back BOTH the server-generated placeholder assets and the
+ * CLIENT render-time fallback for a listing with no icon/cover. The whole point
+ * of the shared module is that the two can't drift, so the properties that must
+ * hold are: determinism (no SSR/hydration flicker), per-app variation (below-
+ * floor listings must not all look identical), and stable stop values (a change
+ * here changes generated assets too — so it should break a test, loudly).
+ */
+
+describe('seededHue', () => {
+  it('is deterministic and within [0,360)', () => {
+    expect(seededHue('cool-app')).toBe(seededHue('cool-app'));
+    expect(seededHue('cool-app')).toBeGreaterThanOrEqual(0);
+    expect(seededHue('cool-app')).toBeLessThan(360);
+  });
+
+  it('varies across seeds (below-floor listings must not all look alike)', () => {
+    const hues = new Set(
+      ['buzz', 'df-qwen-canvas', 'gen-matrix', 'prompt-vault', 'panorama-360'].map(seededHue)
+    );
+    // Not a strict guarantee of the hash, but a collapse to 1 bucket would mean
+    // the per-app identity this module exists to provide is gone.
+    expect(hues.size).toBeGreaterThan(1);
+  });
+
+  it('handles the empty seed without throwing', () => {
+    expect(() => seededHue('')).not.toThrow();
+    expect(seededHue('')).toBeGreaterThanOrEqual(0);
+    expect(seededHue('')).toBeLessThan(360);
+  });
+});
+
+describe('appInitial', () => {
+  it('takes the first alphanumeric of the name, uppercased', () => {
+    expect(appInitial('Cool App', 'slug')).toBe('C');
+    expect(appInitial('123abc', 'x')).toBe('1');
+    expect(appInitial('  spaced', 'x')).toBe('S');
+  });
+
+  it('falls through to the slug for a blank/whitespace-only name', () => {
+    expect(appInitial('  ', 'slug')).toBe('S');
+    expect(appInitial('', 'df-qwen-canvas')).toBe('D');
+  });
+
+  it("resolves to '?' only when neither name nor slug has an alphanumeric", () => {
+    expect(appInitial('', '')).toBe('?');
+    expect(appInitial('—', '—')).toBe('?');
+  });
+});
+
+describe('categoryGlyph', () => {
+  it('maps a known category', () => {
+    expect(categoryGlyph('generation')).toBe(CATEGORY_GLYPH.generation);
+    expect(categoryGlyph('analytics')).toBe(CATEGORY_GLYPH.analytics);
+  });
+
+  it('falls back to the `other` glyph for null / unknown (never undefined)', () => {
+    // df-qwen-canvas is live with a NULL category — this path is real.
+    expect(categoryGlyph(null)).toBe(CATEGORY_GLYPH.other);
+    expect(categoryGlyph(undefined)).toBe(CATEGORY_GLYPH.other);
+    expect(categoryGlyph('not-a-category')).toBe(CATEGORY_GLYPH.other);
+  });
+});
+
+describe('listingPlaceholderSeed', () => {
+  it('is `<category>:<slug>` and treats null category as `other`', () => {
+    expect(listingPlaceholderSeed('buzz', 'analytics')).toBe('analytics:buzz');
+    expect(listingPlaceholderSeed('df-qwen-canvas', null)).toBe('other:df-qwen-canvas');
+    expect(listingPlaceholderSeed('x', undefined)).toBe('other:x');
+  });
+
+  it('distinguishes two apps that share a category', () => {
+    expect(listingPlaceholderSeed('a', 'utility')).not.toBe(listingPlaceholderSeed('b', 'utility'));
+  });
+});
+
+describe('placeholderHues', () => {
+  it('offsets the second hue by 40°, wrapping at 360', () => {
+    const { hue, hue2 } = placeholderHues('some-seed');
+    expect(hue2).toBe((hue + 40) % 360);
+    expect(hue2).toBeGreaterThanOrEqual(0);
+    expect(hue2).toBeLessThan(360);
+  });
+});
+
+describe('placeholderStop', () => {
+  // Locks the exact saturation/lightness pairs. These are ALSO baked into the
+  // generated icon/cover SVGs, so an unintended change here would silently
+  // recolour previously-generated assets relative to live placeholders.
+  it('emits the icon surface stops', () => {
+    expect(placeholderStop('icon', 'from', 10)).toBe('hsl(10 55% 42%)');
+    expect(placeholderStop('icon', 'to', 50)).toBe('hsl(50 60% 22%)');
+  });
+
+  it('emits the (dimmer) cover surface stops', () => {
+    expect(placeholderStop('cover', 'from', 10)).toBe('hsl(10 45% 32%)');
+    expect(placeholderStop('cover', 'to', 50)).toBe('hsl(50 50% 16%)');
+  });
+
+  it('keeps the cover darker than the icon so foreground glyph/text stays legible', () => {
+    const lightness = (s: string) => Number(/\s(\d+)%\)$/.exec(s)?.[1]);
+    expect(lightness(placeholderStop('cover', 'from', 0))).toBeLessThan(
+      lightness(placeholderStop('icon', 'from', 0))
+    );
+  });
+});
+
+describe('listingPlaceholderGradient', () => {
+  it('is a deterministic 135deg CSS gradient', () => {
+    const a = listingPlaceholderGradient({ slug: 'buzz', category: 'analytics', surface: 'cover' });
+    const b = listingPlaceholderGradient({ slug: 'buzz', category: 'analytics', surface: 'cover' });
+    expect(a).toBe(b);
+    expect(a).toMatch(/^linear-gradient\(135deg, hsl\(\d+ \d+% \d+%\) 0%, hsl\(\d+ \d+% \d+%\) 100%\)$/);
+  });
+
+  it('differs per app', () => {
+    const buzz = listingPlaceholderGradient({ slug: 'buzz', category: null, surface: 'cover' });
+    const qwen = listingPlaceholderGradient({
+      slug: 'df-qwen-canvas',
+      category: null,
+      surface: 'cover',
+    });
+    expect(buzz).not.toBe(qwen);
+  });
+
+  it('differs per surface for the same app (icon is brighter than cover)', () => {
+    const icon = listingPlaceholderGradient({ slug: 'buzz', category: null, surface: 'icon' });
+    const cover = listingPlaceholderGradient({ slug: 'buzz', category: null, surface: 'cover' });
+    expect(icon).not.toBe(cover);
+  });
+
+  it('uses the same hue for icon and cover of one app (one colour identity)', () => {
+    const hue = seededHue(listingPlaceholderSeed('buzz', null));
+    expect(listingPlaceholderGradient({ slug: 'buzz', category: null, surface: 'icon' })).toContain(
+      `hsl(${hue} `
+    );
+    expect(listingPlaceholderGradient({ slug: 'buzz', category: null, surface: 'cover' })).toContain(
+      `hsl(${hue} `
+    );
+  });
+
+  it('null and "other" category resolve identically (same seed)', () => {
+    expect(listingPlaceholderGradient({ slug: 'x', category: null, surface: 'icon' })).toBe(
+      listingPlaceholderGradient({ slug: 'x', category: 'other', surface: 'icon' })
+    );
+  });
+});

--- a/src/shared/constants/app-listing-placeholder.constants.ts
+++ b/src/shared/constants/app-listing-placeholder.constants.ts
@@ -125,9 +125,9 @@ export function listingPlaceholderGradient(args: {
   surface: PlaceholderSurface;
 }): string {
   const { hue, hue2 } = placeholderHues(listingPlaceholderSeed(args.slug, args.category));
-  return `linear-gradient(135deg, ${placeholderStop(args.surface, 'from', hue)} 0%, ${placeholderStop(
+  return `linear-gradient(135deg, ${placeholderStop(
     args.surface,
-    'to',
-    hue2
-  )} 100%)`;
+    'from',
+    hue
+  )} 0%, ${placeholderStop(args.surface, 'to', hue2)} 100%)`;
 }

--- a/src/shared/constants/app-listing-placeholder.constants.ts
+++ b/src/shared/constants/app-listing-placeholder.constants.ts
@@ -65,13 +65,31 @@ export function seededHue(seed: string): number {
 }
 
 /**
- * The app's display initial (first alphanumeric of name, else slug), uppercased.
- * A whitespace-only name must fall through to the slug (not resolve to '?').
+ * The app's display initial — the first LETTER-or-DIGIT of the name, else of the
+ * slug, uppercased; `'?'` only when neither yields one.
+ *
+ * 🔴 The class is Unicode `\p{L}\p{N}`, NOT `[A-Za-z0-9]`. An ASCII-only class
+ * silently renders a literal `?` for every non-Latin app name (日本語アプリ,
+ * Привет, العربية) and strips the accent off `Émile` → `M` — i.e. exactly the
+ * "this listing looks broken" outcome these placeholders exist to prevent. App
+ * names are unrestricted free text (`offsite-listing.schema` bounds only length),
+ * so non-Latin names are reachable, not hypothetical.
+ *
+ * The `u` flag is load-bearing: it makes the match code-point-based, so an
+ * astral-plane first character returns a WHOLE code point rather than a lone
+ * broken surrogate half.
+ *
+ * A name that is blank OR yields no letter/digit (e.g. "—", "🎨") falls through
+ * to the slug before giving up — the slug is DNS-label-shaped, so it almost
+ * always yields one.
  */
+const INITIAL_CHAR = /[\p{L}\p{N}]/u;
+
 export function appInitial(name: string, slug: string): string {
-  const src = (name?.trim() || slug?.trim() || '?').trim();
-  const m = src.match(/[A-Za-z0-9]/);
-  return (m ? m[0] : '?').toUpperCase();
+  const m = name?.trim().match(INITIAL_CHAR) ?? null;
+  if (m) return m[0].toUpperCase();
+  const s = slug?.trim().match(INITIAL_CHAR) ?? null;
+  return (s ? s[0] : '?').toUpperCase();
 }
 
 /**

--- a/src/shared/constants/app-listing-placeholder.constants.ts
+++ b/src/shared/constants/app-listing-placeholder.constants.ts
@@ -1,0 +1,133 @@
+/**
+ * App Store Listings (W13) — deterministic listing PLACEHOLDER primitives.
+ *
+ * Shared by BOTH:
+ *   - the server-side generated placeholder assets
+ *     (`app-listing-assets.service` → `buildPlaceholderIconSvg` /
+ *     `buildPlaceholderCoverSvg`, rasterised to real `Image` rows), and
+ *   - the CLIENT render-time fallback for a listing that has NO icon / cover
+ *     (`AppListingCard`, `AppListingDetailBody`).
+ *
+ * WHY THIS MODULE EXISTS (the extraction): these are pure functions, but they
+ * used to live only inside `app-listing-assets.service.ts`, which imports
+ * `dbRead`/`dbWrite`/`sharp`. A client component therefore could NOT reuse them,
+ * so the card/detail hand-rolled a DIFFERENT, weaker placeholder (one flat dark
+ * gradient for every app + a generic icon). The two designs drifted: a listing
+ * whose generated icon was a seeded-hue monogram sat on a card whose cover
+ * placeholder was uniform grey. Pulling the primitives into `src/shared` lets the
+ * live fallback and the generated asset derive from the SAME seed, so a
+ * below-floor listing looks intentional and per-app rather than broken.
+ *
+ * Pure + framework-free ON PURPOSE — no React, no Prisma, no `sharp`. Keep it
+ * that way so both sides can import it (a server-only import here would put the
+ * client back where it started).
+ *
+ * The mandatory-asset FLOOR (icon + cover, `checkListingMeetsFloor`) is
+ * unaffected: these placeholders are a RENDER-time fallback, never a stored
+ * asset, so they can't satisfy — or be mistaken for — a real uploaded asset.
+ */
+
+/**
+ * Category → a compact ASCII-safe glyph. Used verbatim in the generated SVG
+ * placeholders. The CLIENT prefers a real tabler icon for the same category and
+ * falls back to this glyph only for a category with no icon mapping, so the two
+ * surfaces stay visually aligned without the client shipping the SVG text.
+ */
+export const CATEGORY_GLYPH: Record<string, string> = {
+  generation: '✦',
+  games: '◆',
+  utility: '⚙',
+  discovery: '◈',
+  moderation: '⛨',
+  analytics: '▤',
+  other: '●',
+};
+
+/** The glyph for a (possibly null / unknown) category, never undefined. */
+export function categoryGlyph(category: string | null | undefined): string {
+  return CATEGORY_GLYPH[category ?? 'other'] ?? CATEGORY_GLYPH.other;
+}
+
+/**
+ * FNV-1a → a stable 0..359 hue from a seed string (deterministic per slug).
+ *
+ * Deterministic is the whole point: the same listing must get the same colour on
+ * every render, on every device, and in the generated asset — otherwise the
+ * placeholder flickers between SSR and hydration.
+ */
+export function seededHue(seed: string): number {
+  let h = 0x811c9dc5;
+  for (let i = 0; i < seed.length; i++) {
+    h ^= seed.charCodeAt(i);
+    h = Math.imul(h, 0x01000193);
+  }
+  return Math.abs(h) % 360;
+}
+
+/**
+ * The app's display initial (first alphanumeric of name, else slug), uppercased.
+ * A whitespace-only name must fall through to the slug (not resolve to '?').
+ */
+export function appInitial(name: string, slug: string): string {
+  const src = (name?.trim() || slug?.trim() || '?').trim();
+  const m = src.match(/[A-Za-z0-9]/);
+  return (m ? m[0] : '?').toUpperCase();
+}
+
+/**
+ * The seed a listing's placeholder colour derives from. SINGLE SOURCE so the
+ * server-generated asset and the client fallback can never disagree — changing
+ * the seed shape here changes both at once (that is deliberate).
+ */
+export function listingPlaceholderSeed(slug: string, category: string | null | undefined): string {
+  return `${category ?? 'other'}:${slug}`;
+}
+
+/** The two hues of a listing's diagonal placeholder gradient. */
+export function placeholderHues(seed: string): { hue: number; hue2: number } {
+  const hue = seededHue(seed);
+  return { hue, hue2: (hue + 40) % 360 };
+}
+
+/**
+ * Saturation/lightness pairs per surface. Kept as data (not inlined) so the SVG
+ * builders and the CSS builder below provably use the SAME values — this is what
+ * makes a generated icon and a live cover placeholder read as one system.
+ */
+const SURFACE_STOPS = {
+  /** Square app icon — brighter, it sits small against the card surface. */
+  icon: { from: { s: 55, l: 42 }, to: { s: 60, l: 22 } },
+  /** Landscape cover — dimmer, it sits behind foreground text/glyph. */
+  cover: { from: { s: 45, l: 32 }, to: { s: 50, l: 16 } },
+} as const;
+
+export type PlaceholderSurface = keyof typeof SURFACE_STOPS;
+
+/** One `hsl()` stop for a surface, as a CSS/SVG-safe colour string. */
+export function placeholderStop(
+  surface: PlaceholderSurface,
+  which: 'from' | 'to',
+  hue: number
+): string {
+  const { s, l } = SURFACE_STOPS[surface][which];
+  return `hsl(${hue} ${s}% ${l}%)`;
+}
+
+/**
+ * The CSS `linear-gradient(...)` for a listing's placeholder on a given surface.
+ * 135deg matches the SVG builders' x1,y1 → x2,y2 diagonal.
+ *
+ * Client-side render fallback ONLY — this never becomes a stored asset.
+ */
+export function listingPlaceholderGradient(args: {
+  slug: string;
+  category: string | null | undefined;
+  surface: PlaceholderSurface;
+}): string {
+  const { hue, hue2 } = placeholderHues(listingPlaceholderSeed(args.slug, args.category));
+  return `linear-gradient(135deg, ${placeholderStop(args.surface, 'from', hue)} 0%, ${placeholderStop(
+    args.surface,
+    'to',
+    hue2
+  )} 100%)`;
+}


### PR DESCRIPTION
## Problem

A listing with no icon and/or no cover already fell back rather than rendering a broken `<img>` — but **every** such listing got the same flat dark gradient + a generic icon, so they were indistinguishable and read as *broken* rather than *no art yet*.

Two live examples right now, both grandfathered in below the #3392 icon+cover floor:

| slug | icon | cover | category |
|---|---|---|---|
| `buzz` | – | – | analytics |
| `df-qwen-canvas` | – | – | **null** → generic `IconApps` |

Meanwhile the **server** already had a much better deterministic design for the *generated* placeholder assets: a slug-seeded hue + the app's initial (`buildPlaceholderIconSvg`), and a seeded gradient + category glyph (`buildPlaceholderCoverSvg`). The client couldn't reuse any of it — those pure helpers lived inside `app-listing-assets.service.ts`, which imports `dbRead`/`dbWrite`/`sharp`. So the two designs were hand-rolled separately and drifted.

## Change

Extract the primitives into **`~/shared/constants/app-listing-placeholder.constants`** — pure, no React, no Prisma, no `sharp` — and have both sides derive from it:

- **`AppListingCard` + `AppListingDetailBody`** — cover placeholder uses the seeded per-app gradient; a missing icon renders the seeded monogram via `appInitial()` (which correctly handles a whitespace-only or non-alphanumeric name) instead of Mantine's flat grey `name.charAt(0)`.
- **The SVG builders** consume the same shared seed + stops, so a generated asset and the live fallback are provably one colour identity.

## Scope / safety

- **No behaviour change** for a listing that has both assets.
- **No change to the mandatory-asset floor.** These are render-time fallbacks that never become stored assets, so they can't satisfy — or be mistaken for — a real uploaded asset. `checkListingMeetsFloor` / the owner "Incomplete" badge / the my-submissions warning are all untouched, and `buzz` + `df-qwen-canvas` remain below the floor.
- The server service re-exports `seededHue` / `appInitial`, so its public API and existing tests are unchanged.

## Tests

- 19 new unit tests on the shared module (determinism, per-app variation, the null-category path, exact stop values) — in the **blocking** `unit` project.
- A **cross-surface drift guard** in the service suite asserting the generated SVG stops equal the client gradient stops.
- Both guards **mutation-verified**: re-inlining a literal stop in the SVG builder, and nudging a shared stop's lightness, each fail the intended test (then reverted).

```
unit  src/shared/constants/__tests__/app-listing-placeholder.constants.test.ts  19 passed
unit  src/server/services/blocks/__tests__/app-listing-assets.service.test.ts   78 passed
```

`tsc --noEmit` reports **zero** errors in the changed files (the 32 remaining are pre-existing environmental — missing `event-engine-common` submodule, stale Prisma client, `@civitai/buzz` workspace). The authoritative typecheck is the pr-preview build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)