### PR TITLE
UX suggestion: pinned editor sidebar strands Tags/Attachments on long articles

### DIFF
--- a/src/components/Article/ArticleUpsertForm.module.scss
+++ b/src/components/Article/ArticleUpsertForm.module.scss
@@ -1,0 +1,19 @@
+.sidebar {
+  position: sticky;
+  top: calc(var(--header-height) + var(--mantine-spacing-md));
+}
+
+// Only from `md` up, where the form is actually two columns. Below that the
+// sidebar is stacked under the editor at full width and scrolls with the page.
+@media (min-width: theme('screens.md')) {
+  .sidebar {
+    // Pinning the top of a column taller than the viewport leaves its lower
+    // fields — Tags, Attachments — permanently below the fold, reachable only
+    // by scrolling to the very end of the article. Giving the pinned column its
+    // own scroll keeps every field reachable from any position in the document.
+    max-height: calc(100dvh - var(--header-height) - 2 * var(--mantine-spacing-md));
+    overflow-y: auto;
+    // Room for the scrollbar so it doesn't sit on top of the inputs.
+    padding-right: var(--mantine-spacing-xs);
+  }
+}

--- a/src/components/Article/ArticleUpsertForm.tsx
+++ b/src/components/Article/ArticleUpsertForm.tsx
@@ -54,6 +54,7 @@ import { showErrorNotification } from '~/utils/notifications';
 import { parseNumericString } from '~/utils/query-string-helpers';
 import { titleCase } from '~/utils/string-helpers';
 import { trpc } from '~/utils/trpc';
+import classes from './ArticleUpsertForm.module.scss';
 
 const schema = upsertArticleInput
   .omit({
@@ -349,13 +350,7 @@ export function ArticleUpsertForm({ article }: Props) {
           </Stack>
         </ContainerGrid2.Col>
         <ContainerGrid2.Col span={{ base: 12, md: 4 }}>
-          <Stack
-            style={{
-              position: 'sticky',
-              top: 'calc(var(--header-height) + var(--mantine-spacing-md))',
-            }}
-            gap="xl"
-          >
+          <Stack className={classes.sidebar} gap="xl">
             {article?.id && article.status === ArticleStatus.Processing && (
               <ArticleScanStatus
                 articleId={article.id}


### PR DESCRIPTION
> **This is a UX suggestion, not a merge request.** The diagnosis below I'm confident in; the fix is one of several reasonable answers and picking between them is a design call that belongs to you. Draft on purpose. Happy to implement whichever option you prefer, or to close this if you'd rather handle it yourselves.

## The problem

The editor's right-hand column is `position: sticky`, and the sticky works — but the column is **taller than the viewport**. Pinning its top means its lower fields, **Tags** and **Attachments**, sit permanently below the fold. On a long article the only way to reach them is to scroll to the very end of the document, then scroll back to carry on writing.

Reported by an author writing a ~700-line article, confirmed from screenshots at the top, middle and end of the document. Two details from those worth having:

- The RTE toolbar in the same form **stays pinned throughout**, so sticky is working fine here — it's specifically the column's height that defeats it.
- At the very bottom of the document the sidebar's lower fields finally appear, which is the tell for "pinned tall element" rather than "sticky not applying".

## What this branch does (option A)

Give the pinned column its own scroll, from `md` up, where the form is actually two columns:

```scss
max-height: calc(100dvh - var(--header-height) - 2 * var(--mantine-spacing-md));
overflow-y: auto;
```

The column stays pinned and every field in it becomes reachable from any position in the document. Below `md` the sidebar is stacked full-width under the editor and scrolls with the page, so the rule is scoped — an internal scroll box on a phone would be worse than today.

The `position: sticky` / `top` pair moved from an inline `style` into a CSS module only because the new rule needs a media query. Pinned position unchanged.

## Other options, if you'd rather

- **B — retune the pin offset.** The sidebar pins at `calc(var(--header-height) + var(--mantine-spacing-md))`, while the toolbar in the same form pins at `stickyOffset = 0` (its default) and lands correctly under the nav. If the `ScrollArea` viewport already starts below the header, the column is pinning about a header-height lower than it needs to, which costs vertical room and makes the overflow worse. Cheap, and complementary to A rather than an alternative.
- **C — compact sticky action bar.** Pin only Save/Publish (a short element, so sticky behaves) and let the fields scroll normally. Keeps the actions permanently in reach, which A does not fully solve, at the cost of restructuring the column.
- **D — leave it.** Authors mostly set tags once at the start, so the round trip may not be worth changing the layout for. Legitimate answer and I won't argue with it.

I'd lean **A + B**: A fixes the reported problem, B is a small correction in the same area that makes A work better.

## What I got wrong on the way here

My first attempt duplicated the Save/Publish buttons at the bottom of the sidebar, assuming the actions were the thing out of reach. Wrong twice: the sidebar's bottom is *also* off-screen mid-article, so the copy would have been just as unreachable; and the actions were never the main casualty — Tags and Attachments were. Reverted; not in this branch.

## Verification, and its limits

Typecheck 0 errors repo-wide. Prettier clean on both files. ESLint clean on the changed file — its one warning (`:127`, `as any` in `defaultValues`) is pre-existing.

**Not verified in a browser, and it should be before anything merges.** The change is entirely visual, and I can't run the app locally — it needs 28 required server env vars including a Postgres primary *and* replica. Specifically unverified: whether `100dvh` matches the `ScrollArea`'s actual viewport (it's an approximation, so the column may clip slightly or leave a gap), and whether the `padding-right` I added for the scrollbar looks right. If you pick a direction I'll validate it against a deployed preview and iterate on the numbers.
