### PR TITLE
fix(tests): repair stale approve-gate assertion after the icon+cover floor (#3392)

### DIFF
--- a/tests/preview-apps-external-approve.spec.ts
+++ b/tests/preview-apps-external-approve.spec.ts
@@ -12,8 +12,8 @@ import { trpcMutation, trpcQuery } from './preview-trpc';
  *       (reject is terminal + releases the slug → self-cleaning, no leftover row).
  *
  *   (2) APPROVE-GATE: submit (mod, NO assets — no icon/cover/screenshot) →
- *       `approveExternalRequest` → asserts a BAD_REQUEST (the dark P1
- *       `assertListingAssetsComplete` gate fires: "missing required assets"),
+ *       `approveExternalRequest` → asserts a BAD_REQUEST (the publish-FLOOR gate
+ *       `assertListingMeetsFloor` fires, naming the missing `icon` + `cover`),
  *       proving approve is BLOCKED without assets. Then `withdrawExternalRequest`
  *       cleans the still-pending draft.
  *
@@ -207,9 +207,10 @@ test.describe('App Blocks P3a PR-b: off-site approve/reject (mod, self-cleaning)
       );
       publishRequestId = result.publishRequestId;
 
-      // APPROVE with NO icon/cover/screenshot attached → the assertListingAssetsComplete
-      // gate MUST fire (the router maps it to a BAD_REQUEST / HTTP 400 whose message
-      // names the missing assets). trpcMutation throws on a non-2xx response.
+      // APPROVE with NO icon/cover/screenshot attached → the publish-FLOOR gate
+      // `assertListingMeetsFloor` MUST fire (the router maps it to a BAD_REQUEST /
+      // HTTP 400 whose message names the missing floor assets). trpcMutation throws
+      // on a non-2xx response.
       let approveError: Error | null = null;
       try {
         await trpcMutation(request, 'appListings.approveExternalRequest', {
@@ -220,10 +221,14 @@ test.describe('App Blocks P3a PR-b: off-site approve/reject (mod, self-cleaning)
         approveError = err as Error;
       }
       expect(approveError, 'approve without assets must be rejected by the gate').not.toBeNull();
-      expect(
-        approveError?.message ?? '',
-        'the gate error names the missing required assets'
-      ).toMatch(/missing required assets/i);
+      // Assert the gate's INTENT — the error names each missing FLOOR asset — rather
+      // than pinning the sentence verbatim. The exact wording has already churned
+      // once (#3392 swapped the live approve gate from `assertListingAssetsComplete`
+      // → `assertListingMeetsFloor`, silently breaking a verbatim match here), and the
+      // wording is not the contract under test; naming what's missing is.
+      const approveMessage = approveError?.message ?? '';
+      expect(approveMessage, 'the gate error names the missing icon').toMatch(/icon/i);
+      expect(approveMessage, 'the gate error names the missing cover').toMatch(/cover/i);
 
       // The gate fired BEFORE any mutation → the request is still pending.
       const stillPending = await findPendingBySlug(request, SLUG);

--- a/tests/preview-apps-external-delist.spec.ts
+++ b/tests/preview-apps-external-delist.spec.ts
@@ -11,13 +11,14 @@ import { trpcMutation, trpcQuery } from './preview-trpc';
  * approve-success → store-render → delist/claim round-trip:
  *
  *   The full "approve an off-site listing, see it in the store, delist/claim it,
- *   purge to self-clean" round-trip requires a SUCCESSFUL approve, which the dark P1
- *   asset gate (`assertListingAssetsComplete`) blocks unless the draft has an
- *   icon+cover+≥1 screenshot whose backing Image is `ingestion = Scanned`. In a PR
- *   preview the external image scanner is UNREACHABLE, so uploaded images stay
+ *   purge to self-clean" round-trip requires a SUCCESSFUL approve, which two approve
+ *   gates block: the publish FLOOR (`assertListingMeetsFloor` — icon+cover required,
+ *   screenshots optional since #3392) and the go-live SCAN-CLEAN gate, which requires
+ *   every attached asset's backing Image to be `ingestion = Scanned`. In a PR preview
+ *   the external image scanner is UNREACHABLE, so uploaded images stay
  *   `Pending` forever (see `tests/preview-post-images.spec.ts`: "image ingestion …
- *   is unreachable in preview so the row stays Pending"). An attach of a Pending
- *   image is rejected ("scan is not complete"), so an off-site listing can NOT reach
+ *   is unreachable in preview so the row stays Pending"). A Pending asset therefore
+ *   never clears the scan-clean gate, so an off-site listing can NOT reach
  *   `approved`/`removed` in preview — i.e. a CLAIMABLE-state listing is not
  *   constructible here. So the claim HAPPY-PATH (approved/removed → reassigned +
  *   audit event) is covered EXHAUSTIVELY in the unit tests instead


### PR DESCRIPTION
## The bug

The `preview / smoke-tests` check has been **red on every open PR for days** on a **stale test assertion**, not a real regression. A permanently-red report-only signal trains people to ignore it, so it's worth repairing even though the failure itself is cosmetic.

## Root cause + timeline

| When | What |
|---|---|
| 2026-07-06 | `ab1c907f77` (#2954) wires the approve gate as `assertListingAssetsComplete` → message `Listing is missing required assets: <...>` |
| **2026-07-23** | `76706c367d` (#3317) — **last touch of the spec**; the verbatim `/missing required assets/i` match is still correct here |
| **2026-07-26** | **`81fe8f7c90` (#3392)** — "allow partial media submission (icon+cover floor, screenshots optional)" swaps the live approve gate to **`assertListingMeetsFloor`**, whose message is `Listing needs at least an icon and cover before it can be published (missing: icon, cover).` |

The spec was never updated, so its verbatim assertion has failed ever since. **The gate is working correctly — the test was wrong.**

Verified directly rather than taken on faith:
- `assertListingMeetsFloor` (`src/server/services/blocks/app-listing-assets.service.ts` ~L148) emits the new sentence; `assertListingAssetsComplete` (~L101) still emits the old one but is now **advisory-only** (its own docblock says no live path calls it).
- `approveExternalRequest` (`src/server/services/blocks/offsite-listing.service.ts` L1726) calls **`assertListingMeetsFloor`** at both the fail-fast (L1824) and the in-tx re-assert (L1897).

## What changed (test-only — no production code)

**`tests/preview-apps-external-approve.spec.ts`**
- The assertion now tests the gate's **intent** — that the error **names each missing FLOOR asset** — rather than pinning the sentence verbatim:
  ```js
  const approveMessage = approveError?.message ?? '';
  expect(approveMessage, 'the gate error names the missing icon').toMatch(/icon/i);
  expect(approveMessage, 'the gate error names the missing cover').toMatch(/cover/i);
  ```
  **Why this shape:** the contract worth pinning is "approve is blocked and the error tells the mod *what is missing*", not the copy. The wording has already churned once and silently broke CI; two narrow semantic matchers survive a reword while still failing on any wrong-gate/wrong-error outcome. Requiring **both** tokens keeps it from passing on a generic error (negative controls `FORBIDDEN` / `UNAUTHORIZED` / `request is not pending` / `Internal server error` all fail it), and the pre-existing `expect(approveError).not.toBeNull()` still catches an approve that wrongly *succeeds*.
- Fixed the two now-wrong comments naming `assertListingAssetsComplete` as the live gate (spec header + the inline comment above the assertion).

**`tests/preview-apps-external-delist.spec.ts`** (sibling sweep)
- Its header made the same stale claim — naming `assertListingAssetsComplete` and "icon+cover+≥1 screenshot" as what blocks approve. Corrected to the **floor** gate (icon+cover, screenshots optional since #3392) plus the **scan-clean** gate, which is what actually makes approve unreachable in a preview. Its conclusion is unchanged and still holds.

**Deliberately NOT changed:** `src/server/routers/__tests__/app-listings.router.offsite-authz.test.ts` (~L308/L314) also contains `missing required assets`, but that is a **unit** test asserting against its **own mocked** error string — self-consistent, not stale, and "fixing" it would break it.

## Verified

- Re-confirmed the diagnosis by reading both gate helpers and the approve path (not from the failure message alone).
- Reproduced the failure at the string level and checked the replacement: old regex → `false` against the real message (i.e. exactly the CI failure); new matchers → `true`, and `false` on four negative-control messages.
- `npx eslint` on both changed files → **0 errors, 0 warnings**.
- `npx tsc --noEmit` → **0 errors in the two touched files** (the ~32 pre-existing environmental errors elsewhere are unrelated).
- `npx prettier --list-different`: both files were **already** unformatted on `origin/main`, so their formatting is left alone to avoid unrelated churn. Confirmed every prettier deviation sits in pre-existing code and **none** touch the lines added here — no new unformatted content.

## NOT verified

**I did not run the preview smoke suite.** It is Playwright driving a deployed preview environment (the spec's own header says Tekton `pr-smoke-test` is authoritative and to not run browser-mode locally on NixOS), so I could not exercise the real approve call end-to-end. The evidence here is source-level (the gate the approve path calls + the string it emits) plus the regex check — **the Tekton `preview / smoke-tests` run on this PR is the real confirmation.**

## Found, not fixed

No product bugs found while sweeping. One nit worth noting but out of scope: `checkListingAssetsComplete`'s docblock still describes the P3 gate as the one "P3 will enforce at approve", which reads slightly dated next to the (accurate) `assertListingAssetsComplete` docblock right below it — production code, so untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
