### PR TITLE
fix(prom): key challenge_completing_stuck off the claim stamp, not updatedAt

### DIFF
--- a/src/server/prom/__tests__/challenge.metrics.completing-stuck.behavior.test.ts
+++ b/src/server/prom/__tests__/challenge.metrics.completing-stuck.behavior.test.ts
@@ -1,0 +1,236 @@
+import { PGlite } from '@electric-sql/pglite';
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Behavioral tests for the `civitai_app_challenge_completing_stuck` PREDICATE.
+ *
+ * Why this file exists separately from challenge.metrics.test.ts: that file is, by its own header,
+ * a pure unit test that never boots the DB, and it drives the gauges through
+ * `__setChallengeGaugeCacheForTest` — which injects the rows a query WOULD have returned. That mocks
+ * at the wrong layer to defend a `WHERE` clause: it cannot distinguish a correct predicate from a
+ * broken one, which is exactly how the `updatedAt` defect shipped and survived a test suite.
+ *
+ * So this file runs the REAL, unmodified gauge SQL against an in-process Postgres (PGlite, the same
+ * WASM Postgres the listForModel behavior suite uses), seeds real `Challenge` rows, and asserts on
+ * the Prometheus series the gauge actually emits.
+ *
+ * The defect being pinned: `Challenge.updatedAt` is a Prisma-side `@updatedAt`, but the ONLY writer
+ * of `status = 'Completing'` is the raw-SQL `claimChallengeForCompletion`, so entering `Completing`
+ * never bumps `updatedAt`. The old predicate therefore fired the instant a day-old challenge was
+ * claimed (false positive) and went quiet whenever an unrelated Prisma write touched a genuinely
+ * stalled one (false negative). Both directions are asserted below; reverting the predicate to
+ * `"updatedAt" < now() - interval '30 minutes'` fails these tests.
+ */
+
+// Booting PGlite (WASM Postgres) can exceed the default 10s hook timeout on a slow/contended CI
+// node. Generous, env-agnostic timeouts — relaxing a timeout can only help a slow runner, never mask
+// a real failure. Mirrors listForModel.behavior.test.ts.
+vi.setConfig({ hookTimeout: 60_000, testTimeout: 60_000 });
+
+// A single mutable holder created during hoisting lets the (also-hoisted) vi.mock factory reference
+// a PGlite instance that is only assigned in beforeAll — the factory closes over `holder`.
+const holder = vi.hoisted(() => ({ db: null as unknown as import('@electric-sql/pglite').PGlite }));
+
+// The gauge query does `await import('~/server/db/pgDb')` then `pgDbRead.connect()`, and uses only
+// `.query(sql)` / `.release()`. Bridge those onto PGlite so the production SQL runs unmodified.
+vi.mock('~/server/db/pgDb', () => ({
+  pgDbRead: {
+    connect: async () => ({
+      query: (sql: string) => holder.db.query(sql),
+      release: () => undefined,
+    }),
+  },
+}));
+
+import {
+  __refreshChallengeGaugesFromDbForTest,
+  __setChallengeGaugeCacheForTest,
+} from '~/server/prom/challenge.metrics';
+import client from 'prom-client';
+
+const GAUGE = 'civitai_app_challenge_completing_stuck';
+
+type MetricJSON = { values: { value: number; labels: Record<string, string> }[] };
+
+/**
+ * The emitted series list for the gauge, as sorted [source, value] pairs.
+ *
+ * Asserted as a WHOLE LIST, never via a `find(...) ?? 0` lookup: that helper defaults a missing
+ * series to 0, so it cannot tell "the query correctly excluded this row" from "the query blew up and
+ * emitted nothing" — the two outcomes this file has to keep apart.
+ */
+async function sourcePairs(): Promise<[string, number][]> {
+  const metric = client.register.getSingleMetric(GAUGE) as unknown as {
+    get: () => Promise<MetricJSON>;
+  };
+  const { values } = await metric.get();
+  return values
+    .map((v) => [v.labels.source, v.value] as [string, number])
+    // Codepoint sort (NOT localeCompare — locale-dependent ordering would make this assertion
+    // machine-dependent).
+    .sort((a, b) => (a[0] < b[0] ? -1 : a[0] > b[0] ? 1 : 0));
+}
+
+/** ISO-8601 UTC stamp `minutesAgo` in the past, in the exact shape the claim writes. */
+function claimStamp(minutesAgo: number): string {
+  return new Date(Date.now() - minutesAgo * 60_000).toISOString();
+}
+
+type SeedRow = {
+  source: 'System' | 'Mod' | 'User';
+  status?: 'Active' | 'Completing' | 'Completed';
+  /** Raw text stored at metadata.completingClaimedAt; `null` = key absent entirely. */
+  claimedAt: string | null;
+  /** How long ago the Prisma-side `@updatedAt` column was last written. */
+  updatedAtMinutesAgo: number;
+};
+
+async function seed(rows: SeedRow[]): Promise<void> {
+  for (const r of rows) {
+    const metadata =
+      r.claimedAt === null
+        ? `'{}'::jsonb`
+        : `jsonb_build_object('completingClaimedAt', '${r.claimedAt}'::text)`;
+    await holder.db.query(
+      `INSERT INTO "Challenge" (source, status, metadata, "updatedAt")
+       VALUES ('${r.source}', '${r.status ?? 'Completing'}', ${metadata},
+               now() - interval '${r.updatedAtMinutesAgo} minutes')`
+    );
+  }
+}
+
+beforeAll(async () => {
+  holder.db = new PGlite();
+  // Only the enums/columns the four gauge queries actually read.
+  await holder.db.exec(`
+    CREATE TYPE "ChallengeSource" AS ENUM ('System','Mod','User');
+    CREATE TYPE "ChallengeStatus" AS ENUM ('Scheduled','Active','Completing','Completed','Cancelled');
+    CREATE TYPE "ChallengeIngestionStatus" AS ENUM ('Pending','Scanned','Blocked','Error');
+    CREATE TABLE "Challenge" (
+      id                serial PRIMARY KEY,
+      source            "ChallengeSource" NOT NULL DEFAULT 'System',
+      status            "ChallengeStatus" NOT NULL DEFAULT 'Scheduled',
+      ingestion         "ChallengeIngestionStatus" NOT NULL DEFAULT 'Scanned',
+      metadata          jsonb,
+      "operationBudget" integer NOT NULL DEFAULT 0,
+      "operationSpent"  integer NOT NULL DEFAULT 0,
+      "updatedAt"       timestamptz NOT NULL DEFAULT now()
+    );
+  `);
+});
+
+beforeEach(async () => {
+  await holder.db.query(`TRUNCATE "Challenge"`);
+  // Clear any series left by a previous case so an assertion can never read a stale emit.
+  __setChallengeGaugeCacheForTest({});
+});
+
+describe('completing_stuck predicate — real SQL against real Postgres', () => {
+  it('does NOT count a freshly claimed challenge whose updatedAt is a day old (the shipped false positive)', async () => {
+    // Exactly the production shape: a daily challenge last written by Prisma ~24h ago, claimed into
+    // Completing seconds ago by the raw-SQL claim (which does not bump updatedAt). This is healthy —
+    // the normal completion window is ~25-30s. The `updatedAt` predicate counted it immediately,
+    // which is the 00:00-00:01 UTC blip observed on 5 consecutive days.
+    await seed([{ source: 'System', claimedAt: claimStamp(1), updatedAtMinutesAgo: 24 * 60 }]);
+    await __refreshChallengeGaugesFromDbForTest();
+
+    expect(await sourcePairs()).toEqual([
+      ['Mod', 0],
+      ['System', 0],
+      ['User', 0],
+    ]);
+  });
+
+  it('counts a challenge claimed longer ago than the threshold, even if updatedAt was just bumped', async () => {
+    // The other direction the old predicate got wrong: a genuinely deadlocked run whose row was
+    // touched by an unrelated Prisma write (e.g. the prizes recompute, which runs while the row is
+    // Completing) had its `updatedAt` clock reset and went invisible.
+    await seed([{ source: 'Mod', claimedAt: claimStamp(45), updatedAtMinutesAgo: 0 }]);
+    await __refreshChallengeGaugesFromDbForTest();
+
+    expect(await sourcePairs()).toEqual([
+      ['Mod', 1],
+      ['System', 0],
+      ['User', 0],
+    ]);
+  });
+
+  it('counts a Completing challenge with NO claim stamp as stuck', async () => {
+    // A stampless Completing row is the least recoverable state in the system:
+    // resetStuckCompletingChallenges compares `(metadata->>'completingClaimedAt')::timestamptz`,
+    // which is NULL-propagating, so it never selects — the row stays Completing forever. Counting it
+    // is the deliberate choice; treating it as healthy would make the gauge blind to the one state
+    // that provably cannot self-heal.
+    await seed([{ source: 'User', claimedAt: null, updatedAtMinutesAgo: 0 }]);
+    await __refreshChallengeGaugesFromDbForTest();
+
+    expect(await sourcePairs()).toEqual([
+      ['Mod', 0],
+      ['System', 0],
+      ['User', 1],
+    ]);
+  });
+
+  it('counts a malformed claim stamp as stuck WITHOUT the query raising', async () => {
+    // `('not-a-timestamp')::timestamptz` raises in Postgres. Had the predicate cast, this row would
+    // fail the whole gauge read, the never-throw catch would swallow it, and all four gauges would
+    // silently freeze on last-good values. `__refreshChallengeGaugesFromDbForTest` deliberately does
+    // not swallow, so a regression to a casting predicate surfaces here as a thrown error rather
+    // than as a wrong number.
+    await seed([{ source: 'User', claimedAt: 'not-a-timestamp', updatedAtMinutesAgo: 0 }]);
+    await expect(__refreshChallengeGaugesFromDbForTest()).resolves.toBeUndefined();
+
+    expect(await sourcePairs()).toEqual([
+      ['Mod', 0],
+      ['System', 0],
+      ['User', 1],
+    ]);
+  });
+
+  it('a well-formed stamp in a different ISO shape is treated as unusable, not mis-ordered', async () => {
+    // Second-precision ISO ('...T00:00:00Z') is chronologically ancient but sorts AFTER the
+    // millisecond-precision threshold ('Z' > '.'), so a naive text comparison would call it fresh.
+    // The shape regex catches it first and it lands in the "no usable stamp" branch instead.
+    await seed([{ source: 'User', claimedAt: '2020-01-01T00:00:00Z', updatedAtMinutesAgo: 0 }]);
+    await __refreshChallengeGaugesFromDbForTest();
+
+    expect(await sourcePairs()).toEqual([
+      ['Mod', 0],
+      ['System', 0],
+      ['User', 1],
+    ]);
+  });
+
+  it('only Completing rows are considered, and counts split by source', async () => {
+    await seed([
+      // Stuck, counted.
+      { source: 'System', claimedAt: claimStamp(90), updatedAtMinutesAgo: 0 },
+      { source: 'User', claimedAt: claimStamp(31), updatedAtMinutesAgo: 0 },
+      { source: 'User', claimedAt: null, updatedAtMinutesAgo: 0 },
+      // Claimed inside the window — healthy.
+      { source: 'Mod', claimedAt: claimStamp(5), updatedAtMinutesAgo: 24 * 60 },
+      // Not Completing at all: an ancient stamp left behind on a finished/never-claimed row must not
+      // leak into the count.
+      { source: 'Mod', status: 'Completed', claimedAt: claimStamp(600), updatedAtMinutesAgo: 24 * 60 },
+      { source: 'Mod', status: 'Active', claimedAt: null, updatedAtMinutesAgo: 24 * 60 },
+    ]);
+    await __refreshChallengeGaugesFromDbForTest();
+
+    expect(await sourcePairs()).toEqual([
+      ['Mod', 0],
+      ['System', 1],
+      ['User', 2],
+    ]);
+  });
+
+  it('emits an explicit 0 per source when nothing is Completing (zero-emit survives the fix)', async () => {
+    await seed([{ source: 'System', status: 'Active', claimedAt: null, updatedAtMinutesAgo: 0 }]);
+    await __refreshChallengeGaugesFromDbForTest();
+
+    expect(await sourcePairs()).toEqual([
+      ['Mod', 0],
+      ['System', 0],
+      ['User', 0],
+    ]);
+  });
+});

--- a/src/server/prom/challenge.metrics.ts
+++ b/src/server/prom/challenge.metrics.ts
@@ -309,6 +309,52 @@ const CHALLENGE_GAUGE_TTL_MS = 45_000;
 const CHALLENGE_GAUGE_STATEMENT_TIMEOUT_MS = 5_000;
 const COMPLETING_STUCK_MINUTES = 30;
 
+/**
+ * COMPLETING-STUCK — why this keys off the claim stamp and not `updatedAt`.
+ *
+ * `completing_stuck` is meant to answer "has a challenge been sitting in `Completing` — i.e. mid
+ * winner-pick — long enough that it is deadlocked?". It originally asked that as
+ * `status = 'Completing' AND "updatedAt" < now() - 30 minutes`, which measured the wrong column and
+ * made the gauge (and its alert) meaningless:
+ *
+ *   `Challenge.updatedAt` is a PRISMA-side `@updatedAt` — the client writes it, there is no DB
+ *   trigger. But the only thing that ever puts a row into `Completing` is
+ *   `claimChallengeForCompletion`, which is RAW SQL (`$executeRaw`), so entering `Completing` never
+ *   bumps `updatedAt`. A daily challenge whose last Prisma write was ~24h earlier therefore already
+ *   satisfies `updatedAt < now() - 30 minutes` at the INSTANT it is claimed. Observed in prod as the
+ *   gauge blipping to exactly 1 for ~1 minute at 00:00–00:01 UTC on 5 consecutive days,
+ *   `source=System` only — that is the NORMAL ~25–30s completion window, not a stall. It also failed
+ *   in the other direction: any Prisma write during a live completion run (e.g. the prizes
+ *   recompute) resets `updatedAt` and hides a genuine stall.
+ *
+ * So the predicate now uses `metadata->>'completingClaimedAt'` — the stamp the claim itself writes,
+ * and the same field `resetStuckCompletingChallenges` already uses to decide a run is dead. That
+ * makes this gauge measure real claim age, and keeps it consistent with the recovery job.
+ *
+ * MISSING / MALFORMED STAMP COUNTS AS STUCK. A `Completing` row without a usable stamp is the most
+ * broken state there is, and the one thing nothing can recover: `resetStuckCompletingChallenges`
+ * compares `(metadata->>'completingClaimedAt')::timestamptz`, which is NULL-propagating, so a
+ * stampless row is never selected and never reset — it stays `Completing` forever. It is reachable:
+ * a metadata write that rebuilds the object from `parseChallengeMetadata` drops the stamp (the zod
+ * object strips unknown keys and `completingClaimedAt` is not in the schema), and at least one such
+ * write is neither status-predicated nor status-setting. Treating those rows as "not stuck" would
+ * make the gauge silently blind to the only permanently-wedged state — the same fail-open the
+ * zero-emit note below exists to prevent. The competing worry, legacy rows predating the stamp
+ * pinning the gauge high, does not apply: there are no `Completing` rows in prod today.
+ *
+ * TEXT COMPARISON, NOT `::timestamptz`. The cast is not an option here: `('garbage')::timestamptz`
+ * RAISES, which would fail the whole gauge query, get swallowed by the never-throw catch, and freeze
+ * ALL FOUR gauges on last-good values — a silent failure far worse than the bug being fixed. The
+ * stamp is only ever written as `new Date().toISOString()`, so the regex below pins it to exactly
+ * that fixed-width UTC shape; strings of that shape sort lexicographically iff they sort
+ * chronologically, so the plain `<` against a `to_char`-formatted threshold is an exact
+ * chronological comparison that cannot raise on any input. A stamp NOT of that shape is not
+ * silently mis-ordered — it falls into the "no usable stamp" branch above and counts as stuck.
+ */
+const CLAIM_STAMP_ISO_RE = String.raw`^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$`;
+/** `to_char` mask producing byte-identical output to JS `Date#toISOString()`. */
+const CLAIM_STAMP_PG_FORMAT = `YYYY-MM-DD"T"HH24:MI:SS.MS"Z"`;
+
 type SourceCount = { source: string; count: number };
 type SourceStatusCount = { source: string; status: string; count: number };
 type SourceRatio = { source: string; ratio: number };
@@ -346,11 +392,20 @@ async function queryChallengeGauges(): Promise<ChallengeGaugeData> {
       `SELECT source::text AS source, count(*)::text AS count
          FROM "Challenge" WHERE ingestion = 'Pending' GROUP BY source`
     );
+    // Claim age, NOT `updatedAt` — see the COMPLETING-STUCK note above for why `updatedAt` made this
+    // gauge fire on every healthy completion, and why the two "no usable stamp" branches count as
+    // stuck rather than being cast to a timestamp.
     const completingStuck = await dbClient.query<{ source: string; count: string }>(
       `SELECT source::text AS source, count(*)::text AS count
          FROM "Challenge"
         WHERE status = 'Completing'
-          AND "updatedAt" < now() - interval '${COMPLETING_STUCK_MINUTES} minutes'
+          AND (
+            metadata->>'completingClaimedAt' IS NULL
+            OR metadata->>'completingClaimedAt' !~ '${CLAIM_STAMP_ISO_RE}'
+            OR metadata->>'completingClaimedAt' < to_char(
+                 (now() AT TIME ZONE 'UTC') - interval '${COMPLETING_STUCK_MINUTES} minutes',
+                 '${CLAIM_STAMP_PG_FORMAT}')
+          )
         GROUP BY source`
     );
     // Budget utilisation over challenges currently consuming their AI-review budget (Active or
@@ -540,5 +595,23 @@ export function __setChallengeGaugeCacheForTest(data: Partial<ChallengeGaugeData
     completingStuck: data.completingStuck ?? [],
     budgetRatio: data.budgetRatio ?? [],
   };
+  challengeGaugeFetchedAt = Date.now();
+}
+
+/**
+ * Run the REAL gauge SQL (against whatever `~/server/db/pgDb` resolves to — a test mocks it onto an
+ * in-process Postgres) and await the cache update, bypassing the TTL and any in-flight refresh.
+ *
+ * `__setChallengeGaugeCacheForTest` mocks at the WRONG layer to defend a query predicate: it injects
+ * the rows a query would have returned, so it cannot tell a correct `WHERE` from a broken one. This
+ * hook is what lets a test seed real rows and assert the emitted series — the only way the
+ * `updatedAt` → `completingClaimedAt` fix is actually pinned.
+ *
+ * Deliberately does NOT swallow: `refreshChallengeGauges` catches everything to protect the scrape,
+ * so a test driving it would silently see an empty cache on a broken query. Here the error surfaces.
+ */
+export async function __refreshChallengeGaugesFromDbForTest(): Promise<void> {
+  challengeGaugeInflight = null;
+  challengeGaugeCache = await queryChallengeGauges();
   challengeGaugeFetchedAt = Date.now();
 }


### PR DESCRIPTION
## The defect

`civitai_app_challenge_completing_stuck` is meant to count challenges wedged mid winner-pick — a deadlock signal. It asked that as:

```sql
WHERE status = 'Completing' AND "updatedAt" < now() - interval '30 minutes'
```

`Challenge.updatedAt` is a Prisma-side `@updatedAt` (`packages/civitai-db-schema/prisma/schema.full.prisma:5484`) with no DB trigger behind it. But the only writer of `status = 'Completing'` is `claimChallengeForCompletion` (`src/server/games/daily-challenge/challenge-helpers.ts:805-813`), which is **raw SQL** — so entering `Completing` never bumps `updatedAt`.

A daily challenge whose last Prisma write was ~24h earlier therefore satisfied the predicate **the instant it was claimed**. The gauge and the alert on it have been meaningless since they shipped.

**Production evidence:** the gauge blipped to exactly 1 for ~1 minute at 00:00–00:01 UTC on 5 consecutive days, `source=System` only, never Mod/User — matching the normal ~25–30 second completion window, not a stall. There is no trigger on `Challenge` that bumps `updatedAt`, and the current `Completing` count is 0.

It also failed in the **other direction**: any Prisma write during a live completion run (e.g. the prizes recompute at `src/server/jobs/daily-challenge-processing.ts:1338`, which runs while the row is `Completing`) resets `updatedAt` and hides a genuine stall.

## The fix

Key the predicate off `metadata->>'completingClaimedAt'` — the stamp the claim itself writes, and the same field `resetStuckCompletingChallenges` (`challenge-helpers.ts:825-832`) already uses to decide a run is dead. The gauge now measures real claim age and is consistent with the recovery job.

### Missing or malformed stamp counts as STUCK

Deliberate, and the riskier-looking of the two options — the reasoning:

- A stampless `Completing` row is the one state **nothing can recover**. `resetStuckCompletingChallenges` compares `(metadata->>'completingClaimedAt')::timestamptz`, which is NULL-propagating, so such a row is never selected and never reset — it stays `Completing` forever. The owning run is blind too: `claimStillHeld` (`daily-challenge-processing.ts:1212-1219`) fails open on a missing stamp.
- It is **reachable**, not merely defensive — see the scope note below.
- Treating it as healthy would make the gauge silently blind to the only permanently-wedged state. That is the same fail-open the module's existing zero-emit note exists to prevent.
- The competing worry — legacy rows predating the stamp pinning the gauge high forever — does not apply: there are no `Completing` rows in production today.

### Text comparison, not `::timestamptz`

The cast is not an option here. `('garbage')::timestamptz` **raises** (verified against real Postgres: `invalid input syntax for type timestamp with time zone`). That would fail the whole gauge read, get swallowed by the never-throw catch, and freeze **all four** gauges on last-good values — a silent failure worse than the bug being fixed.

The stamp is only ever written as `new Date().toISOString()`, so a shape regex pins it to fixed-width UTC, where lexicographic order *is* chronological order, and the `<` against a `to_char`-formatted threshold cannot raise on any input. A stamp not of that shape is not silently mis-ordered — it falls into the "no usable stamp" branch and counts as stuck. (`to_char(…, 'YYYY-MM-DD"T"HH24:MI:SS.MS"Z"')` was verified byte-identical to `toISOString()`.)

### Unchanged

`source` label, `max`-not-`sum` per-pod semantics, the never-throw async `collect()` contract, the 45s memo, and the read-replica pool with statement timeout + last-good degradation are all untouched.

## Expected outcome: the gauge sits at 0

After this change the gauge will likely read 0 permanently, because no real stalls have been observed. **That is the correct outcome**, not a regression to "fix" back into firing. The zero-emit behaviour is retained, so a healthy 0 stays distinguishable from dead instrumentation.

## Heads-up for whoever owns the consuming alert

A Grafana alert fires on `max(...) > 0` with `for: 1h`, defined outside this repo. **Its expression stays valid and needs no change** — but its behaviour will change: it should stop seeing the daily 00:00 UTC blip. (The blip never actually paged, since it lasted ~1 minute against a `for: 1h`; the alert was simply incapable of ever firing on the real signal.) Flagging so the new permanent-0 is not mistaken for a broken exporter.

## Scope note — NOT fixed here, flagging instead

`parseChallengeMetadata` uses a plain `z.object(...)` (zod default-strip) and `completingClaimedAt` is not in `challengeMetadataSchema` (`src/server/schema/challenge.schema.ts:118-140`), so any write that rebuilds metadata from it **erases the stamp**.

For the two completion writes this is harmless — they set `status: Completed` in the same UPDATE, so the row leaves `Completing` anyway.

But one path can leave a **stampless row still in `Completing`**: `src/pages/api/mod/daily-challenge/backfill-theme-elements.ts:96-104`. It selects `WHERE status IN ('Active','Scheduled')` from the read replica, does a per-challenge LLM round-trip, then writes `SET metadata = <json>::jsonb` — a **wholesale replacement** (despite the comment saying "Merge into existing metadata") from `parseChallengeMetadata`, with **no status predicate and no status write**. A row claimed into `Completing` during that gap loses its stamp and is then unrecoverable.

That is what makes the missing-stamp decision above load-bearing rather than theoretical. It is a mod-only endpoint and a narrow race, and fixing it is a behaviour change beyond this observability fix, so it is **not** touched here. Two candidate follow-ups, for a maintainer to pick:

1. Add `completingClaimedAt` (and `reviewedAt`, stripped the same way but read back by an `ORDER BY cast(metadata->>'reviewedAt' as bigint)` at `challenge-helpers.ts:261`) to `challengeMetadataSchema`.
2. Make that endpoint a `||` jsonb merge, matching its own comment.

Happy to open either separately.

## Tests

New `src/server/prom/__tests__/challenge.metrics.completing-stuck.behavior.test.ts` runs the **real, unmodified gauge SQL** against an in-process Postgres (PGlite), following the existing `listForModel.behavior.test.ts` precedent, and asserts on the emitted Prometheus series (whole series list — never a `find(...) ?? 0` lookup, which cannot tell "correctly excluded" from "query blew up").

It is a separate file rather than an addition to `challenge.metrics.test.ts` because that file is by its own header a pure unit test that never boots a DB, and it drives the gauges via `__setChallengeGaugeCacheForTest` — which injects the rows a query *would* have returned. That mocks at the wrong layer to defend a `WHERE` clause, and is precisely how this defect shipped past a green suite.

Cases: fresh claim + stale `updatedAt` is not stuck (the shipped false positive); claim past the threshold is stuck even with `updatedAt` just bumped; missing stamp is stuck; malformed stamp is stuck *without the query raising*; an off-shape ISO stamp is treated as unusable rather than mis-ordered; only `Completing` rows count; zero-emit survives.

**Mutation check** — reverting the predicate to `updatedAt` fails **6 of 7**, including the headline case:

```
FAIL  challenge.metrics.completing-stuck.behavior.test.ts > does NOT count a freshly
      claimed challenge whose updatedAt is a day old (the shipped false positive)
AssertionError: expected [ Array(3) ] to deeply equal [ [ 'Mod', +0 ], …(2) ]

- Expected
+ Received

     "System",
-    0,
+    1,
```

Restored → `4 passed (4) / 51 passed (51)` across `src/server/prom/__tests__/`.

`NODE_OPTIONS=--max_old_space_size=8192 npx tsc --noEmit` → **exit code 0**, no output.
