### PR TITLE
fix(challenge): key winner payouts to the persisted place to stop duplicate prizes

### DIFF
--- a/src/server/games/daily-challenge/__tests__/challenge-degenerate-winners.test.ts
+++ b/src/server/games/daily-challenge/__tests__/challenge-degenerate-winners.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { freshPersistedWinner } from './persisted-winner.fixture';
 
 // Verifies Task 10: pickWinnersForChallenge skips the LLM winner-pick (generateWinners) when
 // fewer than 2 distinct entrants were judged. generateWinners is asked to pick "exactly 3"
@@ -52,7 +53,7 @@ const {
   mockUpdateChallengeStatus: vi.fn().mockResolvedValue(undefined),
   mockRefundUserChallengeFunds: vi.fn().mockResolvedValue({ refundedEntries: 0 }),
   mockCreateNotification: vi.fn().mockResolvedValue(undefined),
-  mockCreateChallengeWinner: vi.fn().mockResolvedValue(1),
+  mockCreateChallengeWinner: vi.fn(),
   mockGetChallengeById: vi.fn().mockResolvedValue(null),
 }));
 
@@ -227,7 +228,12 @@ beforeEach(() => {
   mockUpdateChallengeStatus.mockResolvedValue(undefined);
   mockRefundUserChallengeFunds.mockResolvedValue({ refundedEntries: 0 });
   mockDbWriteChallengeFindUnique.mockResolvedValue({ prizePool: 0, prizeDistribution: null });
-  mockCreateChallengeWinner.mockResolvedValue(1);
+  // Resolve to the PERSISTED row (fresh insert), the real return shape. Resolving `1` here left the
+  // sole-entrant reconcile on its degrade path — see persisted-winner.fixture.
+  mockCreateChallengeWinner.mockImplementation(
+    async (input: { place: number; buzzAwarded: number; pointsAwarded?: number }) =>
+      freshPersistedWinner(input)
+  );
   mockGetChallengeById.mockResolvedValue(null);
 });
 

--- a/src/server/games/daily-challenge/__tests__/challenge-winner-mapping.test.ts
+++ b/src/server/games/daily-challenge/__tests__/challenge-winner-mapping.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { freshPersistedWinner } from './persisted-winner.fixture';
 
 // Task 19: hardens the LLM-winner -> judged-entry mapping in pickWinnersForChallenge against
 // creator-name spoofing. generateWinners (a TEXT-only LLM call) returns
@@ -57,7 +58,7 @@ const {
   mockUpdateChallengeStatus: vi.fn().mockResolvedValue(undefined),
   mockRefundUserChallengeFunds: vi.fn().mockResolvedValue({ refundedEntries: 0 }),
   mockCreateNotification: vi.fn().mockResolvedValue(undefined),
-  mockCreateChallengeWinner: vi.fn().mockResolvedValue(1),
+  mockCreateChallengeWinner: vi.fn(),
   mockGetChallengeById: vi.fn().mockResolvedValue(null),
 }));
 
@@ -239,7 +240,12 @@ beforeEach(() => {
   mockUpdateChallengeStatus.mockResolvedValue(undefined);
   mockRefundUserChallengeFunds.mockResolvedValue({ refundedEntries: 0 });
   mockDbWriteChallengeFindUnique.mockResolvedValue({ prizePool: 0, prizeDistribution: null });
-  mockCreateChallengeWinner.mockResolvedValue(1);
+  // Resolve to the PERSISTED row (fresh insert), the real return shape. Resolving `1` here left
+  // every caller's `reconcileWinnerToPersisted` on its degrade path — see persisted-winner.fixture.
+  mockCreateChallengeWinner.mockImplementation(
+    async (input: { place: number; buzzAwarded: number; pointsAwarded?: number }) =>
+      freshPersistedWinner(input)
+  );
   mockGetChallengeById.mockResolvedValue(null);
 });
 

--- a/src/server/games/daily-challenge/__tests__/challenge-winner-payout-dedupe.test.ts
+++ b/src/server/games/daily-challenge/__tests__/challenge-winner-payout-dedupe.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import client from 'prom-client';
+// Namespace type-imports (erased at compile time, so they are safe above the hoisted vi.mock calls)
+// — the repo forbids inline `typeof import(...)` annotations.
+import type * as FliptClient from '~/server/flipt/client';
+import type * as ChallengeFunding from '~/server/games/daily-challenge/challenge-funding';
 
 // Winner-prize payouts are deduped ONLY by their externalTransactionId, which embeds the winner's
 // PLACE (`challenge-winner-prize-{challengeId}-{userId}-place-{place}`) — `createBuzzTransactionMany`
@@ -84,7 +88,7 @@ vi.mock('~/server/logging/client', () => ({
 }));
 
 vi.mock('~/server/flipt/client', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('~/server/flipt/client')>();
+  const actual = await importOriginal<typeof FliptClient>();
   return { ...actual, isFlipt: vi.fn().mockResolvedValue(false) };
 });
 
@@ -153,9 +157,7 @@ vi.mock('~/server/services/reaction.service', () => ({
 // NOTE: `buildWinnerPayoutTransactions` is deliberately left REAL (it is a pure function) so the
 // assertions below run against the genuine externalTransactionId strings.
 vi.mock('~/server/games/daily-challenge/challenge-funding', async (importOriginal) => {
-  const actual = await importOriginal<
-    typeof import('~/server/games/daily-challenge/challenge-funding')
-  >();
+  const actual = await importOriginal<typeof ChallengeFunding>();
   return {
     ...actual,
     refundUserChallengeFunds: mockRefundUserChallengeFunds,

--- a/src/server/games/daily-challenge/__tests__/challenge-winner-payout-dedupe.test.ts
+++ b/src/server/games/daily-challenge/__tests__/challenge-winner-payout-dedupe.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import client from 'prom-client';
 
 // Winner-prize payouts are deduped ONLY by their externalTransactionId, which embeds the winner's
 // PLACE (`challenge-winner-prize-{challengeId}-{userId}-place-{place}`) — `createBuzzTransactionMany`
@@ -169,6 +170,27 @@ vi.mock('~/utils/logging', () => ({
 
 const { pickWinnersForChallenge } = await import('~/server/jobs/daily-challenge-processing');
 const { ChallengeSource } = await import('~/shared/utils/prisma/enums');
+const { __resetChallengeMetricsForTest } = await import('~/server/prom/challenge.metrics');
+
+const DUPLICATE_PICK_METRIC = 'civitai_app_challenge_winner_duplicate_pick_total';
+
+/**
+ * Read one series off the REAL prom registry. Returns `undefined` for an absent series rather than
+ * defaulting to 0, so "never emitted" can never be mistaken for "emitted zero".
+ */
+async function counterValue(
+  name: string,
+  labels: Record<string, string>
+): Promise<number | undefined> {
+  const metric = client.register.getSingleMetric(name) as unknown as {
+    get: () => Promise<{ values: Array<{ value: number; labels: Record<string, string> }> }>;
+  } | null;
+  if (!metric) return undefined;
+  const data = await metric.get();
+  return data.values.find((v) =>
+    Object.entries(labels).every(([key, val]) => v.labels[key] === val)
+  )?.value;
+}
 
 const BASE_CONFIG = {
   challengeType: 'world-morph',
@@ -260,8 +282,41 @@ function paidAmountsById(): Record<string, number> {
   );
 }
 
+/**
+ * A double that enforces the real (challengeId, userId) unique constraint.
+ *
+ * The FIRST create for a user inserts and comes back `created: true`; every later create for that
+ * same user conflicts and comes back as the STORED row with `created: false` — which is exactly
+ * what the production helper does when it catches P2002 and re-reads the row. Without this, a
+ * duplicate creator looks like two clean inserts and the whole failure mode disappears from the
+ * test.
+ */
+function stubUniqueWinnerTable() {
+  const stored = new Map<number, { id: number; place: number; buzzAwarded: number }>();
+  mockCreateChallengeWinner.mockImplementation(
+    async ({
+      userId,
+      place,
+      buzzAwarded,
+      pointsAwarded,
+    }: {
+      userId: number;
+      place: number;
+      buzzAwarded: number;
+      pointsAwarded?: number;
+    }) => {
+      const existing = stored.get(userId);
+      if (existing) return { ...existing, pointsAwarded: 0, created: false };
+      const row = { id: stored.size + 1, place, buzzAwarded };
+      stored.set(userId, row);
+      return { ...row, pointsAwarded: pointsAwarded ?? 0, created: true };
+    }
+  );
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
+  __resetChallengeMetricsForTest();
   mockDbWriteExecuteRaw.mockResolvedValue(1);
   mockGetChallengeConfig.mockResolvedValue(BASE_CONFIG);
   mockGetJudgingConfig.mockResolvedValue(JUDGING_CONFIG);
@@ -431,5 +486,162 @@ describe('winner payout keys on the PERSISTED placement (duplicate-payout guard)
       [`challenge-winner-prize-${CHALLENGE_ID}-100-place-1`]: 500,
       [`challenge-winner-prize-${CHALLENGE_ID}-200-place-2`]: 250,
     });
+  });
+
+  // The SOLE-ENTRANT branch — a completely separate `createChallengeWinner` +
+  // `reconcileWinnerToPersisted` call site from the LLM loop above, reached when a challenge has
+  // fewer than 2 distinct entrants and place 1 is awarded deterministically without the LLM.
+  // Nothing covered it: with the stale `mockResolvedValue(1)` doubles in place, its reconcile could
+  // be deleted outright and the whole suite stayed green.
+  it('sole-entrant award pays the RECORDED place, not the deterministic place 1', async () => {
+    mockChallengeJudgeRow(ChallengeSource.System);
+    // One distinct entrant -> the deterministic branch, no `generateWinners` call.
+    mockJudgedEntryRows([{ imageId: 1, userId: 100, username: 'alice' }]);
+    mockDbWriteQueryRaw.mockResolvedValueOnce([]); // winner-cooldown query: nobody excluded
+
+    // ...but alice is already recorded — and already PAID — at place 2 for this challenge, from an
+    // earlier run of the same completion. The branch always picks place 1 with prizes[0].buzz, so
+    // paying what it picked would settle a brand-new `-place-1` id on top of the `-place-2` id the
+    // ledger has already honoured: a second prize.
+    mockCreateChallengeWinner.mockResolvedValue({
+      id: 7,
+      place: 2,
+      buzzAwarded: 250,
+      pointsAwarded: 5,
+      created: false,
+    });
+
+    await pickWinnersForChallenge(currentChallenge, BASE_CONFIG);
+
+    expect(mockGenerateWinners).not.toHaveBeenCalled();
+    expect(paidExternalIds()).toEqual([`challenge-winner-prize-${CHALLENGE_ID}-100-place-2`]);
+    expect(paidAmountsById()).toEqual({
+      [`challenge-winner-prize-${CHALLENGE_ID}-100-place-2`]: 250,
+    });
+  });
+
+  it('sole-entrant fresh award still pays place 1 — the deterministic branch is not broken', async () => {
+    mockChallengeJudgeRow(ChallengeSource.System);
+    mockJudgedEntryRows([{ imageId: 1, userId: 100, username: 'alice' }]);
+    mockDbWriteQueryRaw.mockResolvedValueOnce([]);
+    stubUniqueWinnerTable();
+
+    await pickWinnersForChallenge(currentChallenge, BASE_CONFIG);
+
+    expect(paidExternalIds()).toEqual([`challenge-winner-prize-${CHALLENGE_ID}-100-place-1`]);
+    expect(paidAmountsById()).toEqual({
+      [`challenge-winner-prize-${CHALLENGE_ID}-100-place-1`]: 500,
+    });
+  });
+});
+
+describe('one creator named twice in a single pick is paid once (duplicate-pick guard)', () => {
+  // `generateWinners` returns raw LLM JSON. "Select exactly 3 different winners" is prompt text with
+  // no code-level enforcement, and the mapping loop resolves each winner with a `find()` by
+  // creatorId — so the same creator named in two slots produces two entries holding two places.
+  //
+  // Both outcomes of that are money bugs. Before the reconcile existed, the two entries paid under
+  // two DIFFERENT ids: a straight double mint. With the reconcile, the second entry is folded onto
+  // the stored row and the two collapse onto the SAME id inside one batch, which is then handed to
+  // an external Buzz service whose within-batch behaviour cannot be verified from this repo.
+  it('pays the duplicated creator exactly once, at their better place, with no repeated id', async () => {
+    mockChallengeJudgeRow(ChallengeSource.System);
+    mockJudgedEntryRows([
+      { imageId: 1, userId: 100, username: 'alice' },
+      { imageId: 2, userId: 200, username: 'bob' },
+      { imageId: 3, userId: 300, username: 'carol' },
+    ]);
+    mockDbWriteQueryRaw.mockResolvedValueOnce([]);
+
+    // The LLM names alice in BOTH the 1st- and 2nd-place slots.
+    mockGenerateWinners.mockResolvedValue({
+      process: 'llm',
+      outcome: 'llm-picked',
+      model: 'test-model',
+      usage: {},
+      winners: [
+        { creator: 'alice', creatorId: 100, reason: 'best' },
+        { creator: 'alice', creatorId: 100, reason: 'also best' },
+        { creator: 'bob', creatorId: 200, reason: 'third' },
+      ],
+    });
+    stubUniqueWinnerTable();
+
+    await pickWinnersForChallenge(currentChallenge, BASE_CONFIG);
+
+    const ids = paidExternalIds();
+    // No id may appear twice in one batch — the property the external Buzz service is not trusted
+    // to enforce for us.
+    expect(new Set(ids).size).toBe(ids.length);
+    // alice keeps place 1 (the better place, 500 Buzz), NOT the dropped place 2 at 250.
+    expect(ids.sort()).toEqual([
+      `challenge-winner-prize-${CHALLENGE_ID}-100-place-1`,
+      `challenge-winner-prize-${CHALLENGE_ID}-200-place-3`,
+    ]);
+    expect(paidAmountsById()).toEqual({
+      [`challenge-winner-prize-${CHALLENGE_ID}-100-place-1`]: 500,
+      [`challenge-winner-prize-${CHALLENGE_ID}-200-place-3`]: 100,
+    });
+
+    // Dropped BEFORE the create loop, so the duplicate never conflicts against the row its own twin
+    // just inserted — that conflict would otherwise fire the place-divergence warning + counter for
+    // something that is not a re-pick at all.
+    expect(mockCreateChallengeWinner).toHaveBeenCalledTimes(2);
+  });
+
+  it('records the dropped placement on challenge_winner_duplicate_pick_total', async () => {
+    mockChallengeJudgeRow(ChallengeSource.System);
+    mockJudgedEntryRows([
+      { imageId: 1, userId: 100, username: 'alice' },
+      { imageId: 2, userId: 200, username: 'bob' },
+    ]);
+    mockDbWriteQueryRaw.mockResolvedValueOnce([]);
+    mockGenerateWinners.mockResolvedValue({
+      process: 'llm',
+      outcome: 'llm-picked',
+      model: 'test-model',
+      usage: {},
+      winners: [
+        { creator: 'alice', creatorId: 100, reason: 'best' },
+        { creator: 'alice', creatorId: 100, reason: 'again' },
+      ],
+    });
+    stubUniqueWinnerTable();
+
+    await pickWinnersForChallenge(currentChallenge, BASE_CONFIG);
+
+    // An LLM handing back the same creator twice is a real judging anomaly, not something to
+    // swallow silently just because the payout is now safe.
+    expect(await counterValue(DUPLICATE_PICK_METRIC, { source: 'System' })).toBe(1);
+  });
+
+  it('leaves a clean pick alone — the guard does not over-trigger', async () => {
+    mockChallengeJudgeRow(ChallengeSource.System);
+    mockJudgedEntryRows([
+      { imageId: 1, userId: 100, username: 'alice' },
+      { imageId: 2, userId: 200, username: 'bob' },
+    ]);
+    mockDbWriteQueryRaw.mockResolvedValueOnce([]);
+    mockGenerateWinners.mockResolvedValue({
+      process: 'llm',
+      outcome: 'llm-picked',
+      model: 'test-model',
+      usage: {},
+      winners: [
+        { creator: 'alice', creatorId: 100, reason: 'best' },
+        { creator: 'bob', creatorId: 200, reason: 'second' },
+      ],
+    });
+    stubUniqueWinnerTable();
+
+    await pickWinnersForChallenge(currentChallenge, BASE_CONFIG);
+
+    expect(paidExternalIds()).toEqual([
+      `challenge-winner-prize-${CHALLENGE_ID}-100-place-1`,
+      `challenge-winner-prize-${CHALLENGE_ID}-200-place-2`,
+    ]);
+    expect(mockCreateChallengeWinner).toHaveBeenCalledTimes(2);
+    // Absent series, not zero — the counter must never have been touched.
+    expect(await counterValue(DUPLICATE_PICK_METRIC, { source: 'System' })).toBeUndefined();
   });
 });

--- a/src/server/games/daily-challenge/__tests__/challenge-winner-payout-dedupe.test.ts
+++ b/src/server/games/daily-challenge/__tests__/challenge-winner-payout-dedupe.test.ts
@@ -1,0 +1,435 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Winner-prize payouts are deduped ONLY by their externalTransactionId, which embeds the winner's
+// PLACE (`challenge-winner-prize-{challengeId}-{userId}-place-{place}`) — `createBuzzTransactionMany`
+// adds no dedupe of its own, and nothing downstream checks whether a challenge already paid. So if a
+// completion re-picks winners over an existing `ChallengeWinner` record and lands the same user on a
+// DIFFERENT place, the payout goes out under a brand-new key and mints a second prize.
+//
+// That re-pick is not exotic. `ChallengeWinner` is uniquely keyed on (challengeId, userId), NOT on
+// (challengeId, place), so the re-pick's insert conflicts and the stored row keeps its ORIGINAL
+// place — while the in-memory entry that actually gets paid carries the NEW place. Record and
+// payment diverge. And because the winner cooldown only excludes winners of COMPLETED challenges, a
+// challenge's own in-flight winners stay eligible, which is what makes the re-pick a PERMUTATION of
+// the same users rather than a fresh set.
+//
+// These tests assert on the real externalTransactionId strings handed to `createBuzzTransactionMany`
+// — the actual money keys — so the real `buildWinnerPayoutTransactions` is left unmocked.
+//
+// Mocking otherwise mirrors challenge-winner-mapping.test.ts.
+
+const {
+  mockDbReadQueryRaw,
+  mockDbReadChallengeFindUnique,
+  mockDbWriteQueryRaw,
+  mockDbWriteExecuteRaw,
+  mockDbWriteChallengeUpdate,
+  mockDbWriteChallengeFindUnique,
+  mockGetChallengeConfig,
+  mockGetJudgingConfig,
+  mockEndChallenge,
+  mockGenerateWinners,
+  mockClaimChallengeForCompletion,
+  mockGetExistingWinnersForRetry,
+  mockResolveEventContext,
+  mockUpdateChallengeStatus,
+  mockRefundUserChallengeFunds,
+  mockCreateChallengeWinner,
+  mockGetChallengeById,
+  mockCreateBuzzTransactionMany,
+} = vi.hoisted(() => ({
+  mockDbReadQueryRaw: vi.fn(),
+  mockDbReadChallengeFindUnique: vi.fn(),
+  mockDbWriteQueryRaw: vi.fn(),
+  mockDbWriteExecuteRaw: vi.fn().mockResolvedValue(1),
+  mockDbWriteChallengeUpdate: vi.fn().mockResolvedValue(undefined),
+  mockDbWriteChallengeFindUnique: vi.fn().mockResolvedValue({
+    prizePool: 0,
+    prizeDistribution: null,
+  }),
+  mockGetChallengeConfig: vi.fn(),
+  mockGetJudgingConfig: vi.fn(),
+  mockEndChallenge: vi.fn().mockResolvedValue(undefined),
+  mockGenerateWinners: vi.fn(),
+  mockClaimChallengeForCompletion: vi.fn().mockResolvedValue(true),
+  mockGetExistingWinnersForRetry: vi.fn().mockResolvedValue([]),
+  mockResolveEventContext: vi.fn().mockResolvedValue(undefined),
+  mockUpdateChallengeStatus: vi.fn().mockResolvedValue(undefined),
+  mockRefundUserChallengeFunds: vi.fn().mockResolvedValue({ refundedEntries: 0 }),
+  mockCreateChallengeWinner: vi.fn(),
+  mockGetChallengeById: vi.fn().mockResolvedValue(null),
+  mockCreateBuzzTransactionMany: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('~/server/db/client', () => ({
+  dbRead: {
+    $queryRaw: mockDbReadQueryRaw,
+    challenge: { findUnique: mockDbReadChallengeFindUnique },
+  },
+  dbWrite: {
+    $queryRaw: mockDbWriteQueryRaw,
+    $executeRaw: mockDbWriteExecuteRaw,
+    challenge: { update: mockDbWriteChallengeUpdate, findUnique: mockDbWriteChallengeFindUnique },
+  },
+}));
+
+vi.mock('~/server/events', () => ({
+  eventEngine: { processEngagement: vi.fn().mockResolvedValue(undefined) },
+}));
+
+vi.mock('~/server/logging/client', () => ({
+  logToAxiom: vi.fn().mockResolvedValue(undefined),
+  safeError: vi.fn((e: unknown) => e),
+}));
+
+vi.mock('~/server/flipt/client', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('~/server/flipt/client')>();
+  return { ...actual, isFlipt: vi.fn().mockResolvedValue(false) };
+});
+
+vi.mock('~/server/games/daily-challenge/daily-challenge.utils', async () => {
+  const real = await import('~/server/games/daily-challenge/daily-challenge-scoring');
+  return {
+    SCORE_WEIGHTS: real.SCORE_WEIGHTS,
+    calculateWeightedScore: real.calculateWeightedScore,
+    challengeToLegacyFormat: vi.fn(),
+    deriveChallengeNsfwLevel: vi.fn(() => 1),
+    endChallenge: mockEndChallenge,
+    getActiveChallenges: vi.fn(),
+    getChallengeConfig: mockGetChallengeConfig,
+    getJudgingConfig: mockGetJudgingConfig,
+    getUpcomingSystemChallenge: vi.fn(),
+  };
+});
+
+vi.mock('~/server/games/daily-challenge/challenge-helpers', () => ({
+  claimChallengeForCompletion: mockClaimChallengeForCompletion,
+  computeDynamicPool: vi.fn(),
+  distributePrizes: vi.fn(),
+  createChallengeRecord: vi.fn(),
+  createChallengeWinner: mockCreateChallengeWinner,
+  getChallengeById: mockGetChallengeById,
+  getChallengeEntryCount: vi.fn().mockResolvedValue(0),
+  getExistingWinnersForRetry: mockGetExistingWinnersForRetry,
+  incrementOperationSpent: vi.fn().mockResolvedValue(undefined),
+  resolveEventContext: mockResolveEventContext,
+  setChallengeActive: vi.fn(),
+  updateChallengeStatus: mockUpdateChallengeStatus,
+}));
+
+vi.mock('~/server/games/daily-challenge/challenge-rewards', () => ({
+  distributeParticipationPrizes: vi.fn().mockResolvedValue([]),
+  promoteChallengeEntries: vi.fn().mockResolvedValue(0),
+}));
+
+vi.mock('~/server/games/daily-challenge/generative-content', () => ({
+  estimateBuzzCost: vi.fn().mockReturnValue(0),
+  generateArticle: vi.fn(),
+  generateCollectionDetails: vi.fn(),
+  generateReview: vi.fn(),
+  generateWinners: mockGenerateWinners,
+}));
+
+vi.mock('~/server/services/buzz.service', () => ({
+  createBuzzTransaction: vi.fn().mockResolvedValue(undefined),
+  createBuzzTransactionMany: mockCreateBuzzTransactionMany,
+  getTransactionByExternalId: vi.fn().mockResolvedValue(null),
+  refundMultiAccountTransaction: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('~/server/services/commentsv2.service', () => ({
+  upsertComment: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('~/server/services/notification.service', () => ({
+  createNotification: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('~/server/services/reaction.service', () => ({
+  toggleReaction: vi.fn().mockResolvedValue(undefined),
+}));
+
+// NOTE: `buildWinnerPayoutTransactions` is deliberately left REAL (it is a pure function) so the
+// assertions below run against the genuine externalTransactionId strings.
+vi.mock('~/server/games/daily-challenge/challenge-funding', async (importOriginal) => {
+  const actual = await importOriginal<
+    typeof import('~/server/games/daily-challenge/challenge-funding')
+  >();
+  return {
+    ...actual,
+    refundUserChallengeFunds: mockRefundUserChallengeFunds,
+    getChallengeBuzzType: vi.fn().mockResolvedValue('yellow'),
+    reportPoolFundingShortfall: vi.fn().mockResolvedValue(undefined),
+  };
+});
+
+vi.mock('~/utils/logging', () => ({
+  createLogger: vi.fn(() => vi.fn()),
+}));
+
+const { pickWinnersForChallenge } = await import('~/server/jobs/daily-challenge-processing');
+const { ChallengeSource } = await import('~/shared/utils/prisma/enums');
+
+const BASE_CONFIG = {
+  challengeType: 'world-morph',
+  challengeCollectionId: 1,
+  judgedTagId: 11,
+  reviewMeTagId: 12,
+  userCooldown: '14 day',
+  resourceCooldown: '90 day',
+  winnerCooldown: '7 day',
+  prizes: [],
+  entryPrizeRequirement: 10,
+  entryPrize: { buzz: 0, points: 0 },
+  reviewAmount: { min: 6, max: 12 },
+  maxScoredPerUser: 5,
+  finalReviewAmount: 10,
+  resourceCosmeticId: null,
+  articleTagId: 1,
+  defaultJudgeId: 1,
+  defaultJudge: null,
+} as never;
+
+const JUDGING_CONFIG = {
+  judgeId: 1,
+  userId: 999,
+  sourceCollectionId: null,
+  prompts: {},
+  reviewTemplate: null,
+} as never;
+
+const CHALLENGE_ID = 69;
+
+const currentChallenge = {
+  challengeId: CHALLENGE_ID,
+  type: 'daily',
+  date: new Date(),
+  theme: 'test',
+  modelId: 1,
+  modelVersionIds: [1],
+  collectionId: 100,
+  title: 'Test',
+  invitation: '',
+  coverUrl: '',
+  prizes: [
+    { buzz: 500, points: 10 },
+    { buzz: 250, points: 5 },
+    { buzz: 100, points: 2 },
+  ],
+  entryPrizeRequirement: 10,
+  entryPrize: { buzz: 0, points: 0 },
+} as never;
+
+function mockChallengeJudgeRow(source: string) {
+  mockDbReadQueryRaw.mockResolvedValueOnce([
+    { judgeId: null, judgingPrompt: null, eventId: null, source, judgingCategories: null },
+  ]);
+}
+
+function mockJudgedEntryRows(rows: Array<{ imageId: number; userId: number; username: string }>) {
+  mockDbReadQueryRaw.mockResolvedValueOnce(
+    rows.map((row) => ({
+      imageId: row.imageId,
+      userId: row.userId,
+      username: row.username,
+      note: JSON.stringify({
+        score: { theme: 10, aesthetic: 8, humor: 8, wittiness: 8 },
+        summary: `entry by ${row.username}`,
+      }),
+    }))
+  );
+}
+
+/** The externalTransactionIds actually submitted to the buzz ledger, in submission order. */
+function paidExternalIds(): string[] {
+  expect(mockCreateBuzzTransactionMany).toHaveBeenCalledTimes(1);
+  const [transactions] = mockCreateBuzzTransactionMany.mock.calls[0];
+  return (transactions as Array<{ externalTransactionId: string }>).map(
+    (t) => t.externalTransactionId
+  );
+}
+
+/** externalTransactionId -> amount, so a reconciled place can be checked to pay its recorded prize. */
+function paidAmountsById(): Record<string, number> {
+  const [transactions] = mockCreateBuzzTransactionMany.mock.calls[0];
+  return Object.fromEntries(
+    (transactions as Array<{ externalTransactionId: string; amount: number }>).map((t) => [
+      t.externalTransactionId,
+      t.amount,
+    ])
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockDbWriteExecuteRaw.mockResolvedValue(1);
+  mockGetChallengeConfig.mockResolvedValue(BASE_CONFIG);
+  mockGetJudgingConfig.mockResolvedValue(JUDGING_CONFIG);
+  mockEndChallenge.mockResolvedValue(undefined);
+  mockClaimChallengeForCompletion.mockResolvedValue(true);
+  mockGetExistingWinnersForRetry.mockResolvedValue([]);
+  mockResolveEventContext.mockResolvedValue(undefined);
+  mockUpdateChallengeStatus.mockResolvedValue(undefined);
+  mockRefundUserChallengeFunds.mockResolvedValue({ refundedEntries: 0 });
+  mockDbWriteChallengeFindUnique.mockResolvedValue({ prizePool: 0, prizeDistribution: null });
+  mockGetChallengeById.mockResolvedValue(null);
+  mockCreateBuzzTransactionMany.mockResolvedValue(undefined);
+});
+
+describe('winner payout keys on the PERSISTED placement (duplicate-payout guard)', () => {
+  it('permuted re-pick over an existing record pays the recorded places — the original transaction ids, no new money', async () => {
+    // Reproduces the production signature on challenge 69: users 100 and 200 were already recorded
+    // and PAID as place 1 / place 2 respectively. A second completion run re-picks the very same two
+    // users with their places SWAPPED.
+    //
+    // The retry short-circuit does not save us here: this run's `getExistingWinnersForRetry` came
+    // back empty (the rows were written by a concurrent run after this run's read), so the run goes
+    // down the fresh LLM re-pick path.
+    mockChallengeJudgeRow(ChallengeSource.System);
+    mockJudgedEntryRows([
+      { imageId: 1, userId: 100, username: 'alice' },
+      { imageId: 2, userId: 200, username: 'bob' },
+    ]);
+    mockDbWriteQueryRaw.mockResolvedValueOnce([]); // winner-cooldown query: nobody excluded
+
+    mockGenerateWinners.mockResolvedValue({
+      process: 'llm',
+      outcome: 'llm-picked',
+      model: 'test-model',
+      usage: {},
+      winners: [
+        { creator: 'bob', creatorId: 200, reason: 'best' }, // recorded at place 2
+        { creator: 'alice', creatorId: 100, reason: 'second' }, // recorded at place 1
+      ],
+    });
+
+    // Both inserts conflict on (challengeId, userId); the stored rows keep their ORIGINAL places.
+    mockCreateChallengeWinner.mockImplementation(async ({ userId }: { userId: number }) =>
+      userId === 200
+        ? { id: 2, place: 2, buzzAwarded: 250, pointsAwarded: 5, created: false }
+        : { id: 1, place: 1, buzzAwarded: 500, pointsAwarded: 10, created: false }
+    );
+
+    await pickWinnersForChallenge(currentChallenge, BASE_CONFIG);
+
+    // The payout must key to the RECORDED places. `...-200-place-1` / `...-100-place-2` would be
+    // fresh, never-seen ids that the ledger's idempotency index cannot dedupe — a second prize for
+    // two users who were already paid.
+    expect(paidExternalIds().sort()).toEqual([
+      `challenge-winner-prize-${CHALLENGE_ID}-100-place-1`,
+      `challenge-winner-prize-${CHALLENGE_ID}-200-place-2`,
+    ]);
+
+    // And each pays the amount recorded against that place, so payment matches the record exactly.
+    expect(paidAmountsById()).toEqual({
+      [`challenge-winner-prize-${CHALLENGE_ID}-100-place-1`]: 500,
+      [`challenge-winner-prize-${CHALLENGE_ID}-200-place-2`]: 250,
+    });
+  });
+
+  it('a single winner re-picked at a different place pays the recorded place only', async () => {
+    mockChallengeJudgeRow(ChallengeSource.System);
+    mockJudgedEntryRows([
+      { imageId: 1, userId: 100, username: 'alice' },
+      { imageId: 2, userId: 200, username: 'bob' },
+    ]);
+    mockDbWriteQueryRaw.mockResolvedValueOnce([]);
+
+    mockGenerateWinners.mockResolvedValue({
+      process: 'llm',
+      outcome: 'llm-picked',
+      model: 'test-model',
+      usage: {},
+      winners: [{ creator: 'alice', creatorId: 100, reason: 'best' }], // picked place 1
+    });
+
+    // ...but alice is already recorded (and paid) at place 3.
+    mockCreateChallengeWinner.mockResolvedValue({
+      id: 7,
+      place: 3,
+      buzzAwarded: 100,
+      pointsAwarded: 2,
+      created: false,
+    });
+
+    await pickWinnersForChallenge(currentChallenge, BASE_CONFIG);
+
+    expect(paidExternalIds()).toEqual([`challenge-winner-prize-${CHALLENGE_ID}-100-place-3`]);
+    expect(paidAmountsById()).toEqual({
+      [`challenge-winner-prize-${CHALLENGE_ID}-100-place-3`]: 100,
+    });
+  });
+
+  it('fresh winners (no conflict) pay the freshly-picked places — happy path unchanged', async () => {
+    mockChallengeJudgeRow(ChallengeSource.System);
+    mockJudgedEntryRows([
+      { imageId: 1, userId: 100, username: 'alice' },
+      { imageId: 2, userId: 200, username: 'bob' },
+    ]);
+    mockDbWriteQueryRaw.mockResolvedValueOnce([]);
+
+    mockGenerateWinners.mockResolvedValue({
+      process: 'llm',
+      outcome: 'llm-picked',
+      model: 'test-model',
+      usage: {},
+      winners: [
+        { creator: 'bob', creatorId: 200, reason: 'best' },
+        { creator: 'alice', creatorId: 100, reason: 'second' },
+      ],
+    });
+
+    // Rows inserted for the first time — nothing to reconcile against.
+    mockCreateChallengeWinner.mockImplementation(
+      async ({
+        userId,
+        place,
+        buzzAwarded,
+      }: {
+        userId: number;
+        place: number;
+        buzzAwarded: number;
+      }) => ({
+        id: userId,
+        place,
+        buzzAwarded,
+        pointsAwarded: 0,
+        created: true,
+      })
+    );
+
+    await pickWinnersForChallenge(currentChallenge, BASE_CONFIG);
+
+    expect(paidExternalIds()).toEqual([
+      `challenge-winner-prize-${CHALLENGE_ID}-200-place-1`,
+      `challenge-winner-prize-${CHALLENGE_ID}-100-place-2`,
+    ]);
+    expect(paidAmountsById()).toEqual({
+      [`challenge-winner-prize-${CHALLENGE_ID}-200-place-1`]: 500,
+      [`challenge-winner-prize-${CHALLENGE_ID}-100-place-2`]: 250,
+    });
+  });
+
+  it('retry short-circuit still reuses the stored winners and re-issues the same transaction ids', async () => {
+    // The `getExistingWinnersForRetry` branch (now reading the primary). Behaviour must be
+    // unchanged: no LLM re-pick, no new ChallengeWinner writes, payout replays the stored
+    // placements so the ledger conflicts them away.
+    mockGetExistingWinnersForRetry.mockResolvedValue([
+      { userId: 100, imageId: 1, place: 1, buzzAwarded: 500, pointsAwarded: 10, reason: 'r1' },
+      { userId: 200, imageId: 2, place: 2, buzzAwarded: 250, pointsAwarded: 5, reason: 'r2' },
+    ]);
+
+    await pickWinnersForChallenge(currentChallenge, BASE_CONFIG);
+
+    expect(mockGenerateWinners).not.toHaveBeenCalled();
+    expect(mockCreateChallengeWinner).not.toHaveBeenCalled();
+    expect(paidExternalIds()).toEqual([
+      `challenge-winner-prize-${CHALLENGE_ID}-100-place-1`,
+      `challenge-winner-prize-${CHALLENGE_ID}-200-place-2`,
+    ]);
+    expect(paidAmountsById()).toEqual({
+      [`challenge-winner-prize-${CHALLENGE_ID}-100-place-1`]: 500,
+      [`challenge-winner-prize-${CHALLENGE_ID}-200-place-2`]: 250,
+    });
+  });
+});

--- a/src/server/games/daily-challenge/__tests__/challenge-winner-persistence.test.ts
+++ b/src/server/games/daily-challenge/__tests__/challenge-winner-persistence.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Covers the two DB-facing halves of the duplicate-payout guard:
+//
+//  P0-a  `getExistingWinnersForRetry` must read the PRIMARY. An empty result routes the completion
+//        into a fresh, non-deterministic LLM re-pick rather than aborting, so a replica that had not
+//        yet caught up would hand back "no winners" for a challenge that already has (already paid)
+//        winners.
+//
+//  P0-b  `createChallengeWinner` must RESOLVE a (challengeId, userId) conflict instead of swallowing
+//        it. The stored row keeps the original place; returning `null` let the caller pay the
+//        freshly-picked place under a brand-new externalTransactionId — a second prize.
+
+const {
+  mockDbReadQueryRaw,
+  mockDbWriteQueryRaw,
+  mockCreate,
+  mockFindUnique,
+  mockLogToAxiom,
+  mockRecordDivergence,
+} = vi.hoisted(() => ({
+  mockDbReadQueryRaw: vi.fn().mockResolvedValue([]),
+  mockDbWriteQueryRaw: vi.fn().mockResolvedValue([]),
+  mockCreate: vi.fn(),
+  mockFindUnique: vi.fn(),
+  mockLogToAxiom: vi.fn().mockResolvedValue(undefined),
+  mockRecordDivergence: vi.fn(),
+}));
+
+vi.mock('~/server/db/client', () => ({
+  dbRead: { $queryRaw: mockDbReadQueryRaw },
+  dbWrite: {
+    $queryRaw: mockDbWriteQueryRaw,
+    challengeWinner: { create: mockCreate, findUnique: mockFindUnique },
+  },
+}));
+vi.mock('~/server/redis/client', () => ({ redis: {}, REDIS_KEYS: {} }));
+vi.mock('~/server/logging/client', () => ({
+  logToAxiom: mockLogToAxiom,
+  safeError: vi.fn((e: unknown) => e),
+}));
+vi.mock('~/server/prom/challenge.metrics', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('~/server/prom/challenge.metrics')>();
+  return { ...actual, recordChallengeWinnerPlaceDivergence: mockRecordDivergence };
+});
+
+const { createChallengeWinner, getExistingWinnersForRetry } = await import(
+  '~/server/games/daily-challenge/challenge-helpers'
+);
+const { Prisma } = await import('@prisma/client');
+
+const p2002 = () =>
+  new Prisma.PrismaClientKnownRequestError('Unique constraint failed', {
+    code: 'P2002',
+    clientVersion: 'test',
+  });
+
+const INPUT = {
+  challengeId: 69,
+  userId: 100,
+  imageId: 1,
+  place: 1,
+  buzzAwarded: 500,
+  pointsAwarded: 10,
+  reason: 'best',
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockDbReadQueryRaw.mockResolvedValue([]);
+  mockDbWriteQueryRaw.mockResolvedValue([]);
+});
+
+describe('getExistingWinnersForRetry (P0-a)', () => {
+  it('reads the primary, not a replica', async () => {
+    const rows = [
+      { userId: 100, imageId: 1, place: 1, buzzAwarded: 500, pointsAwarded: 10, reason: 'r' },
+    ];
+    mockDbWriteQueryRaw.mockResolvedValue(rows);
+
+    await expect(getExistingWinnersForRetry(69)).resolves.toEqual(rows);
+
+    expect(mockDbWriteQueryRaw).toHaveBeenCalledTimes(1);
+    // A replica read here is the failure mode: stale "no winners" routes into a fresh re-pick.
+    expect(mockDbReadQueryRaw).not.toHaveBeenCalled();
+  });
+
+  it('passes the challengeId to the query', async () => {
+    await getExistingWinnersForRetry(1234);
+    // Tagged-template call: (strings, ...values) — the challengeId is the only interpolated value.
+    expect(mockDbWriteQueryRaw.mock.calls[0][1]).toBe(1234);
+  });
+});
+
+describe('createChallengeWinner (P0-b)', () => {
+  it('returns the inserted row as created on a fresh insert', async () => {
+    mockCreate.mockResolvedValue({ id: 5, place: 1, buzzAwarded: 500, pointsAwarded: 10 });
+
+    await expect(createChallengeWinner(INPUT)).resolves.toEqual({
+      id: 5,
+      place: 1,
+      buzzAwarded: 500,
+      pointsAwarded: 10,
+      created: true,
+    });
+    expect(mockFindUnique).not.toHaveBeenCalled();
+    expect(mockRecordDivergence).not.toHaveBeenCalled();
+  });
+
+  it('on a conflict re-reads the stored row from the primary and returns its place, not the attempted one', async () => {
+    mockCreate.mockRejectedValue(p2002());
+    mockFindUnique.mockResolvedValue({ id: 5, place: 3, buzzAwarded: 100, pointsAwarded: 2 });
+
+    await expect(createChallengeWinner(INPUT)).resolves.toEqual({
+      id: 5,
+      place: 3, // stored, NOT the attempted place 1
+      buzzAwarded: 100, // stored, NOT the attempted 500
+      pointsAwarded: 2,
+      created: false,
+    });
+
+    expect(mockFindUnique).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { challengeId_userId: { challengeId: 69, userId: 100 } },
+      })
+    );
+  });
+
+  it('logs a warning and increments the divergence metric when the stored place differs', async () => {
+    mockCreate.mockRejectedValue(p2002());
+    mockFindUnique.mockResolvedValue({ id: 5, place: 3, buzzAwarded: 100, pointsAwarded: 2 });
+
+    await createChallengeWinner(INPUT);
+
+    expect(mockRecordDivergence).toHaveBeenCalledWith({ field: 'both' });
+    expect(mockLogToAxiom).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'warning',
+        name: 'challenge-winner-place-divergence',
+        storedPlace: 3,
+        attemptedPlace: 1,
+      })
+    );
+  });
+
+  it('labels a place-only divergence as place', async () => {
+    mockCreate.mockRejectedValue(p2002());
+    mockFindUnique.mockResolvedValue({ id: 5, place: 2, buzzAwarded: 500, pointsAwarded: 10 });
+
+    await createChallengeWinner(INPUT);
+
+    expect(mockRecordDivergence).toHaveBeenCalledWith({ field: 'place' });
+  });
+
+  it('an identical duplicate stays info-level and does not touch the divergence metric', async () => {
+    mockCreate.mockRejectedValue(p2002());
+    mockFindUnique.mockResolvedValue({ id: 5, place: 1, buzzAwarded: 500, pointsAwarded: 10 });
+
+    await expect(createChallengeWinner(INPUT)).resolves.toEqual({
+      id: 5,
+      place: 1,
+      buzzAwarded: 500,
+      pointsAwarded: 10,
+      created: false,
+    });
+
+    expect(mockRecordDivergence).not.toHaveBeenCalled();
+    expect(mockLogToAxiom).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'info', name: 'challenge-winner-duplicate' })
+    );
+  });
+
+  it('returns null and warns when the conflict resolves to no readable row', async () => {
+    mockCreate.mockRejectedValue(p2002());
+    mockFindUnique.mockResolvedValue(null);
+
+    await expect(createChallengeWinner(INPUT)).resolves.toBeNull();
+    expect(mockLogToAxiom).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'warning',
+        name: 'challenge-winner-conflict-unresolved',
+      })
+    );
+  });
+
+  it('rethrows a non-P2002 error', async () => {
+    mockCreate.mockRejectedValue(new Error('connection reset'));
+    await expect(createChallengeWinner(INPUT)).rejects.toThrow('connection reset');
+    expect(mockFindUnique).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/games/daily-challenge/__tests__/challenge-winner-persistence.test.ts
+++ b/src/server/games/daily-challenge/__tests__/challenge-winner-persistence.test.ts
@@ -1,4 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+// Namespace type-import (erased at compile time, so it is safe above the hoisted vi.mock calls) —
+// the repo forbids inline `typeof import(...)` annotations.
+import type * as ChallengeMetrics from '~/server/prom/challenge.metrics';
 
 // Covers the two DB-facing halves of the duplicate-payout guard:
 //
@@ -40,7 +43,7 @@ vi.mock('~/server/logging/client', () => ({
   safeError: vi.fn((e: unknown) => e),
 }));
 vi.mock('~/server/prom/challenge.metrics', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('~/server/prom/challenge.metrics')>();
+  const actual = await importOriginal<typeof ChallengeMetrics>();
   return { ...actual, recordChallengeWinnerPlaceDivergence: mockRecordDivergence };
 });
 

--- a/src/server/games/daily-challenge/__tests__/challenge-winner-reconcile.test.ts
+++ b/src/server/games/daily-challenge/__tests__/challenge-winner-reconcile.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from 'vitest';
+import {
+  reconcileWinnerToPersisted,
+  type PersistedChallengeWinner,
+} from '~/server/games/daily-challenge/challenge-winner-reconcile';
+
+const entry = {
+  userId: 100,
+  imageId: 1,
+  position: 1,
+  prize: 500,
+  reason: 'best',
+};
+
+const persisted = (over: Partial<PersistedChallengeWinner> = {}): PersistedChallengeWinner => ({
+  id: 5,
+  place: 1,
+  buzzAwarded: 500,
+  pointsAwarded: 10,
+  created: false,
+  ...over,
+});
+
+describe('reconcileWinnerToPersisted', () => {
+  it('leaves a freshly inserted winner untouched', () => {
+    expect(reconcileWinnerToPersisted(entry, persisted({ place: 9, created: true }))).toEqual(
+      entry
+    );
+  });
+
+  it('leaves the entry untouched when there is no persisted row', () => {
+    expect(reconcileWinnerToPersisted(entry, null)).toEqual(entry);
+  });
+
+  it('leaves the entry untouched when the stored row already agrees', () => {
+    expect(reconcileWinnerToPersisted(entry, persisted())).toEqual(entry);
+  });
+
+  it('adopts the stored place when it differs from the picked one', () => {
+    expect(reconcileWinnerToPersisted(entry, persisted({ place: 2, buzzAwarded: 250 }))).toEqual({
+      ...entry,
+      position: 2,
+      prize: 250,
+    });
+  });
+
+  it('adopts the stored prize even when the place matches', () => {
+    expect(reconcileWinnerToPersisted(entry, persisted({ buzzAwarded: 400 }))).toEqual({
+      ...entry,
+      prize: 400,
+    });
+  });
+
+  it('does not mutate the input entry', () => {
+    const input = { ...entry };
+    reconcileWinnerToPersisted(input, persisted({ place: 3, buzzAwarded: 100 }));
+    expect(input).toEqual(entry);
+  });
+
+  it('keeps the picked entry when the stored place is not a real number', () => {
+    // Money path: an absent/garbled field must never propagate `undefined` into the payout amount
+    // or the place-bearing transaction id.
+    expect(
+      reconcileWinnerToPersisted(entry, {
+        place: undefined,
+        buzzAwarded: undefined,
+      } as unknown as PersistedChallengeWinner)
+    ).toEqual(entry);
+    expect(reconcileWinnerToPersisted(entry, persisted({ place: NaN, buzzAwarded: NaN }))).toEqual(
+      entry
+    );
+  });
+
+  it('keeps the picked entry when only the stored prize is unusable', () => {
+    expect(
+      reconcileWinnerToPersisted(
+        entry,
+        persisted({ place: 2, buzzAwarded: undefined as unknown as number })
+      )
+    ).toEqual(entry);
+  });
+
+  it('preserves extra fields on the entry', () => {
+    const extended = { ...entry, imageId: 42, reason: 'x' as string | null };
+    expect(reconcileWinnerToPersisted(extended, persisted({ place: 2, buzzAwarded: 250 }))).toEqual(
+      {
+        ...extended,
+        position: 2,
+        prize: 250,
+      }
+    );
+  });
+});

--- a/src/server/games/daily-challenge/__tests__/persisted-winner.fixture.ts
+++ b/src/server/games/daily-challenge/__tests__/persisted-winner.fixture.ts
@@ -1,0 +1,54 @@
+import type { PersistedChallengeWinner } from '~/server/games/daily-challenge/challenge-winner-reconcile';
+
+/**
+ * Shared test double for `createChallengeWinner`'s resolved value.
+ *
+ * WHY THIS IS SHARED RATHER THAN COPIED PER FILE — the copies are what broke.
+ *
+ * `createChallengeWinner` used to resolve to a bare row id (`number | null`) and now resolves to the
+ * PERSISTED row (`PersistedChallengeWinner | null`). Four suites kept doubling it as `1`, and that
+ * stale double does not fail loudly — it fails SILENTLY, in the one direction that hides the bug:
+ *
+ *   `1` is truthy, so `reconcileWinnerToPersisted` gets past its `!persisted` guard;
+ *   `(1).created` is `undefined` -> falsy, so it does not take the "fresh insert" early return;
+ *   `Number.isFinite((1).place)` is false, so it takes the malformed-row DEGRADE path
+ *   and returns the entry completely untouched.
+ *
+ * Every winner therefore flowed through the reconcile as a no-op. Deleting the reconcile call from
+ * a completion path left the whole 316-file suite green — which is exactly how two of the three
+ * changed call sites shipped with no coverage at all.
+ *
+ * Keeping one definition means the next shape change breaks in one place instead of silently
+ * degrading four suites back into the same blind spot. The return type annotation is the guard: a
+ * field added to `PersistedChallengeWinner` fails `tsc` here rather than quietly reintroducing the
+ * degrade path at runtime.
+ */
+export function freshPersistedWinner(input: {
+  place: number;
+  buzzAwarded: number;
+  pointsAwarded?: number;
+  id?: number;
+}): PersistedChallengeWinner {
+  return {
+    id: input.id ?? 1,
+    place: input.place,
+    buzzAwarded: input.buzzAwarded,
+    pointsAwarded: input.pointsAwarded ?? 0,
+    // The insert succeeded: this row IS what was just picked, so there is nothing to reconcile.
+    created: true,
+  };
+}
+
+/**
+ * The conflict case: the insert hit the (challengeId, userId) unique constraint and this is the
+ * STORED row that was already there — whose place/prize the payout must be keyed to, not the
+ * freshly-picked one.
+ */
+export function conflictedPersistedWinner(input: {
+  place: number;
+  buzzAwarded: number;
+  pointsAwarded?: number;
+  id?: number;
+}): PersistedChallengeWinner {
+  return { ...freshPersistedWinner(input), created: false };
+}

--- a/src/server/games/daily-challenge/challenge-funding.test.ts
+++ b/src/server/games/daily-challenge/challenge-funding.test.ts
@@ -329,6 +329,62 @@ describe('buildWinnerPayoutTransactions', () => {
     });
     expect(tx.toAccountType).toBe('yellow');
   });
+
+  // The choke point's own dedupe is a no-op while both callers dedupe first, so nothing else in the
+  // suite reaches it. Without these two it could be deleted with every test still green — and it
+  // guards a batch of duplicate transaction ids being handed to an external ledger whose
+  // within-batch behaviour we cannot observe.
+  it('never emits the same transaction id twice, even if a caller passes a duplicated creator', () => {
+    const txs = buildWinnerPayoutTransactions({
+      challengeId: 7,
+      title: 'Neon Cats',
+      buzzType: 'yellow',
+      // One creator named at two places — the shape an un-deduped caller would produce.
+      winners: [
+        { userId: 11, position: 1, prize: 5000 },
+        { userId: 11, position: 2, prize: 2500 },
+        { userId: 22, position: 3, prize: 1000 },
+      ],
+    });
+
+    const ids = txs.map((tx) => tx.externalTransactionId);
+    expect(new Set(ids).size).toBe(ids.length);
+    // The better place survives: dropping the first would silently under-pay.
+    expect(ids).toEqual([
+      'challenge-winner-prize-7-11-place-1',
+      'challenge-winner-prize-7-22-place-3',
+    ]);
+  });
+
+  it('records the drop, so money vanishing here can never be silent', async () => {
+    const client = (await import('prom-client')).default;
+    const metric = client.register.getSingleMetric(
+      'civitai_app_challenge_winner_duplicate_pick_total'
+    ) as unknown as {
+      get: () => Promise<{ values: Array<{ value: number; labels: Record<string, string> }> }>;
+    } | null;
+    const readUnknownSource = async () => {
+      if (!metric) return undefined;
+      const data = await metric.get();
+      // `source: unknown` is the signal that the choke point caught what a caller missed — the
+      // caller-level emits always carry a real source.
+      return data.values.find((v) => v.labels.source === 'unknown')?.value;
+    };
+
+    const before = (await readUnknownSource()) ?? 0;
+
+    buildWinnerPayoutTransactions({
+      challengeId: 7,
+      title: 'Neon Cats',
+      buzzType: 'yellow',
+      winners: [
+        { userId: 11, position: 1, prize: 5000 },
+        { userId: 11, position: 2, prize: 2500 },
+      ],
+    });
+
+    expect(await readUnknownSource()).toBe(before + 1);
+  });
 });
 
 describe('refundUserChallengeFunds — void refunds pool legs only', () => {

--- a/src/server/games/daily-challenge/challenge-funding.test.ts
+++ b/src/server/games/daily-challenge/challenge-funding.test.ts
@@ -356,22 +356,22 @@ describe('buildWinnerPayoutTransactions', () => {
     ]);
   });
 
-  it('records the drop, so money vanishing here can never be silent', async () => {
+  // `origin: chokepoint` rather than `source`: normSource folds enum drift AND a caller's own null
+  // source into `unknown`, so source alone cannot identify a choke-point drop.
+  const readChokepointDrops = async () => {
     const client = (await import('prom-client')).default;
     const metric = client.register.getSingleMetric(
       'civitai_app_challenge_winner_duplicate_pick_total'
     ) as unknown as {
       get: () => Promise<{ values: Array<{ value: number; labels: Record<string, string> }> }>;
     } | null;
-    const readUnknownSource = async () => {
-      if (!metric) return undefined;
-      const data = await metric.get();
-      // `source: unknown` is the signal that the choke point caught what a caller missed — the
-      // caller-level emits always carry a real source.
-      return data.values.find((v) => v.labels.source === 'unknown')?.value;
-    };
+    if (!metric) return undefined;
+    const data = await metric.get();
+    return data.values.find((v) => v.labels.origin === 'chokepoint')?.value;
+  };
 
-    const before = (await readUnknownSource()) ?? 0;
+  it('records the drop, so money vanishing here can never be silent', async () => {
+    const before = (await readChokepointDrops()) ?? 0;
 
     buildWinnerPayoutTransactions({
       challengeId: 7,
@@ -383,7 +383,46 @@ describe('buildWinnerPayoutTransactions', () => {
       ],
     });
 
-    expect(await readUnknownSource()).toBe(before + 1);
+    expect(await readChokepointDrops()).toBe(before + 1);
+  });
+
+  // The counter is documented as sitting flat at zero and is an alert trigger, so proving it fires
+  // is only half the contract — a version that increments on every payout would pass the test above
+  // and page continuously.
+  it('stays silent on a clean pick — the counter cannot drift up on normal payouts', async () => {
+    const before = (await readChokepointDrops()) ?? 0;
+
+    buildWinnerPayoutTransactions({
+      challengeId: 7,
+      title: 'Neon Cats',
+      buzzType: 'yellow',
+      winners: [
+        { userId: 11, position: 1, prize: 5000 },
+        { userId: 22, position: 2, prize: 2500 },
+        { userId: 33, position: 3, prize: 1000 },
+      ],
+    });
+
+    expect((await readChokepointDrops()) ?? 0).toBe(before);
+  });
+
+  // Records PLACEMENTS dropped, not "a duplicate happened". With a single-duplicate fixture only,
+  // a hardcoded 1 would pass — and this counter is the sole record of how much money vanished.
+  it('records how many placements were dropped, not merely that some were', async () => {
+    const before = (await readChokepointDrops()) ?? 0;
+
+    buildWinnerPayoutTransactions({
+      challengeId: 7,
+      title: 'Neon Cats',
+      buzzType: 'yellow',
+      winners: [
+        { userId: 11, position: 1, prize: 5000 },
+        { userId: 11, position: 2, prize: 2500 },
+        { userId: 11, position: 3, prize: 1000 },
+      ],
+    });
+
+    expect(await readChokepointDrops()).toBe(before + 2);
   });
 });
 

--- a/src/server/games/daily-challenge/challenge-funding.ts
+++ b/src/server/games/daily-challenge/challenge-funding.ts
@@ -410,13 +410,13 @@ export function buildWinnerPayoutTransactions({
   // removes the need to trust that a future caller remembers.
   //
   // If this branch ever fires, a caller reached the money path with duplicates and did NOT report
-  // it — the drop is real money not paid, and this counter is the only trace it leaves. It records
-  // `source: unknown` because the challenge's source is not in scope here; that is deliberate and
-  // diagnostic, since the caller-level emits always carry a real source. An `unknown` sample means
-  // "the choke point caught what a caller missed", which is a different and more alarming event
-  // than a duplicate the caller already handled.
+  // it — the drop is real money not paid, and this counter is the only trace it leaves. It is
+  // tagged `origin: 'chokepoint'` rather than being distinguished by an absent `source`: the
+  // challenge's source genuinely isn't in scope here, but `normSource` also folds enum drift and a
+  // caller's own null source into `unknown`, so `source` alone cannot tell those three apart.
   const { winners: payable, dropped } = dedupeWinnersForPayout(winners);
-  if (dropped.length) recordChallengeWinnerDuplicatePick({ count: dropped.length });
+  if (dropped.length)
+    recordChallengeWinnerDuplicatePick({ count: dropped.length, origin: 'chokepoint' });
   return payable.map((entry) => ({
     type: TransactionType.Reward,
     toAccountId: entry.userId,

--- a/src/server/games/daily-challenge/challenge-funding.ts
+++ b/src/server/games/daily-challenge/challenge-funding.ts
@@ -31,6 +31,7 @@
 import { TRPCError } from '@trpc/server';
 import { dbRead, dbWrite } from '~/server/db/client';
 import type { ChallengeBuzzType } from '~/server/games/daily-challenge/challenge-currency';
+import { dedupeWinnersForPayout } from '~/server/games/daily-challenge/challenge-winner-reconcile';
 import { logToAxiom } from '~/server/logging/client';
 import {
   createBuzzTransaction,
@@ -378,6 +379,11 @@ export async function reportPoolFundingShortfall({
   }).catch(() => {});
 }
 
+/** The idempotency key a winner-prize payout is settled under. */
+export function winnerPayoutExternalId(challengeId: number, userId: number, position: number) {
+  return `challenge-winner-prize-${challengeId}-${userId}-place-${position}`;
+}
+
 /** Build the winner-prize transactions for a challenge, paid in its stored currency. Pure. */
 export function buildWinnerPayoutTransactions({
   challengeId,
@@ -390,13 +396,20 @@ export function buildWinnerPayoutTransactions({
   buzzType: ChallengeBuzzType;
   winners: Array<{ userId: number; position: number; prize: number }>;
 }) {
-  return winners.map((entry) => ({
+  // Both callers dedupe before they get here (so they can report the anomaly with the challenge
+  // context they hold), which makes this a no-op on every current path. It is applied anyway
+  // because this function is the single choke point every winner payout passes through, and a
+  // duplicate id inside one batch is handed to an external Buzz service whose within-batch
+  // behaviour is not observable from this repo. Guaranteeing the invariant here costs one pass and
+  // removes the need to trust that a future caller remembers.
+  const { winners: payable } = dedupeWinnersForPayout(winners);
+  return payable.map((entry) => ({
     type: TransactionType.Reward,
     toAccountId: entry.userId,
     fromAccountId: 0,
     amount: entry.prize,
     description: `Challenge Winner Prize #${entry.position}: ${title}`,
-    externalTransactionId: `challenge-winner-prize-${challengeId}-${entry.userId}-place-${entry.position}`,
+    externalTransactionId: winnerPayoutExternalId(challengeId, entry.userId, entry.position),
     toAccountType: buzzType,
   }));
 }

--- a/src/server/games/daily-challenge/challenge-funding.ts
+++ b/src/server/games/daily-challenge/challenge-funding.ts
@@ -50,6 +50,7 @@ import {
   recordChallengeEntryFeesBuzz,
   recordChallengeRefundBuzz,
   recordChallengeRefundFailure,
+  recordChallengeWinnerDuplicatePick,
 } from '~/server/prom/challenge.metrics';
 
 const log = createLogger('challenge-funding', 'yellow');
@@ -384,7 +385,12 @@ export function winnerPayoutExternalId(challengeId: number, userId: number, posi
   return `challenge-winner-prize-${challengeId}-${userId}-place-${position}`;
 }
 
-/** Build the winner-prize transactions for a challenge, paid in its stored currency. Pure. */
+/**
+ * Build the winner-prize transactions for a challenge, paid in its stored currency.
+ *
+ * Pure apart from one never-throwing counter increment on the duplicate-drop branch — see below for
+ * why a silent drop here would be the worst possible failure.
+ */
 export function buildWinnerPayoutTransactions({
   challengeId,
   title,
@@ -402,7 +408,15 @@ export function buildWinnerPayoutTransactions({
   // duplicate id inside one batch is handed to an external Buzz service whose within-batch
   // behaviour is not observable from this repo. Guaranteeing the invariant here costs one pass and
   // removes the need to trust that a future caller remembers.
-  const { winners: payable } = dedupeWinnersForPayout(winners);
+  //
+  // If this branch ever fires, a caller reached the money path with duplicates and did NOT report
+  // it — the drop is real money not paid, and this counter is the only trace it leaves. It records
+  // `source: unknown` because the challenge's source is not in scope here; that is deliberate and
+  // diagnostic, since the caller-level emits always carry a real source. An `unknown` sample means
+  // "the choke point caught what a caller missed", which is a different and more alarming event
+  // than a duplicate the caller already handled.
+  const { winners: payable, dropped } = dedupeWinnersForPayout(winners);
+  if (dropped.length) recordChallengeWinnerDuplicatePick({ count: dropped.length });
   return payable.map((entry) => ({
     type: TransactionType.Reward,
     toAccountId: entry.userId,

--- a/src/server/games/daily-challenge/challenge-helpers.ts
+++ b/src/server/games/daily-challenge/challenge-helpers.ts
@@ -1,10 +1,14 @@
 import { Prisma } from '@prisma/client';
 import { dbRead, dbWrite } from '~/server/db/client';
 import { logToAxiom } from '~/server/logging/client';
-import { recordChallengeOperationSpentBuzz } from '~/server/prom/challenge.metrics';
+import {
+  recordChallengeOperationSpentBuzz,
+  recordChallengeWinnerPlaceDivergence,
+} from '~/server/prom/challenge.metrics';
 import { removeTags } from '~/utils/string-helpers';
 import type { ChallengeBuzzType } from '~/server/games/daily-challenge/challenge-currency';
 import { isImageHiddenFromGreenViewer } from '~/server/games/daily-challenge/challenge-visibility';
+import type { PersistedChallengeWinner } from '~/server/games/daily-challenge/challenge-winner-reconcile';
 import {
   challengeJudgingCategoriesSchema,
   type ChallengeJudgingCategory,
@@ -550,7 +554,31 @@ export type CreateWinnerInput = {
   reason?: string;
 };
 
-export async function createChallengeWinner(input: CreateWinnerInput): Promise<number | null> {
+/**
+ * Create the `ChallengeWinner` record for one winner and return the placement that is actually
+ * PERSISTED — which is not always the placement passed in.
+ *
+ * The table is uniquely keyed on (challengeId, userId), so a user who was already recorded as a
+ * winner of this challenge cannot get a second row: the insert conflicts (P2002) and the stored
+ * row keeps its ORIGINAL place. This used to return `null` on that conflict, which read as "record
+ * skipped, carry on" — and the caller then paid the freshly-picked place. Because the winner-prize
+ * externalTransactionId embeds the place, that paid under a brand-new key and MINTED A SECOND
+ * PRIZE for a user who had already been paid, with the stored row still showing the old place.
+ *
+ * So the conflict is now resolved rather than swallowed: the row is re-read from the primary and
+ * returned with `created: false`, and the caller reconciles the payout onto the stored place (see
+ * `reconcileWinnerToPersisted`). Record and payment can then never diverge.
+ */
+export async function createChallengeWinner(
+  input: CreateWinnerInput
+): Promise<PersistedChallengeWinner | null> {
+  const persistedFields = {
+    id: true,
+    place: true,
+    buzzAwarded: true,
+    pointsAwarded: true,
+  } as const;
+
   try {
     const winner = await dbWrite.challengeWinner.create({
       data: {
@@ -562,19 +590,67 @@ export async function createChallengeWinner(input: CreateWinnerInput): Promise<n
         pointsAwarded: input.pointsAwarded,
         reason: input.reason,
       },
-      select: { id: true },
+      select: persistedFields,
     });
-    return winner.id;
+    return { ...winner, created: true };
   } catch (error) {
-    // P2002 = unique constraint violation — record already exists (idempotent on recovery retry)
+    // P2002 = unique constraint violation on (challengeId, userId) — this user is already recorded
+    // as a winner of this challenge, from an earlier run of the same completion or from a
+    // concurrent run that re-picked winners.
     if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2002') {
-      logToAxiom({
-        type: 'info',
-        name: 'challenge-winner-duplicate',
-        message: `Duplicate winner skipped (recovery retry): challenge=${input.challengeId} user=${input.userId} place=${input.place}`,
-        challengeId: input.challengeId,
+      // Read from the PRIMARY: the row we are conflicting with may have been written moments ago,
+      // and a replica read that missed it would send us straight back down the mint path.
+      const persisted = await dbWrite.challengeWinner.findUnique({
+        where: { challengeId_userId: { challengeId: input.challengeId, userId: input.userId } },
+        select: persistedFields,
       });
-      return null;
+
+      if (!persisted) {
+        // Structurally unreachable — (challengeId, userId) is this table's only unique constraint,
+        // so a P2002 here means the row exists. Surfaced loudly rather than silently, and the
+        // caller is deliberately left on its in-memory placement: refusing to pay would introduce
+        // an UNDER-payment failure mode on a path where nobody has ever been underpaid.
+        logToAxiom({
+          type: 'warning',
+          name: 'challenge-winner-conflict-unresolved',
+          message: `Winner insert conflicted but no stored row could be read; payout left on the freshly-picked place: challenge=${input.challengeId} user=${input.userId} place=${input.place}`,
+          challengeId: input.challengeId,
+          userId: input.userId,
+          attemptedPlace: input.place,
+        });
+        return null;
+      }
+
+      const placeDiverged = persisted.place !== input.place;
+      const prizeDiverged = persisted.buzzAwarded !== input.buzzAwarded;
+
+      if (placeDiverged || prizeDiverged) {
+        // The anomaly that caused real duplicate payouts. Loud + alertable, never info-level: at
+        // this point a payout under the freshly-picked place would have been a second mint.
+        logToAxiom({
+          type: 'warning',
+          name: 'challenge-winner-place-divergence',
+          message: `Winner re-picked at a different placement than the one recorded; payout reconciled to the stored place: challenge=${input.challengeId} user=${input.userId} storedPlace=${persisted.place} attemptedPlace=${input.place}`,
+          challengeId: input.challengeId,
+          userId: input.userId,
+          storedPlace: persisted.place,
+          attemptedPlace: input.place,
+          storedBuzzAwarded: persisted.buzzAwarded,
+          attemptedBuzzAwarded: input.buzzAwarded,
+        });
+        recordChallengeWinnerPlaceDivergence({
+          field: placeDiverged && prizeDiverged ? 'both' : placeDiverged ? 'place' : 'prize',
+        });
+      } else {
+        logToAxiom({
+          type: 'info',
+          name: 'challenge-winner-duplicate',
+          message: `Duplicate winner skipped (recovery retry): challenge=${input.challengeId} user=${input.userId} place=${input.place}`,
+          challengeId: input.challengeId,
+        });
+      }
+
+      return { ...persisted, created: false };
     }
     throw error;
   }
@@ -655,6 +731,13 @@ export async function getChallengeWinners(
  * Check if ChallengeWinner records already exist for a challenge.
  * Used to short-circuit LLM winner generation on retry — if winners were already
  * picked in a previous (failed) run, reuse them instead of re-running the LLM.
+ *
+ * Reads the PRIMARY, deliberately. An empty result here does not abort — it routes straight into a
+ * fresh, non-deterministic LLM re-pick, and the challenge's own in-flight winners are still
+ * eligible to be picked again (the winner cooldown only excludes Completed challenges). A stale
+ * replica read that missed rows written moments earlier therefore ends in a re-pick of the same
+ * users at permuted places, i.e. a second payout under a new transaction id. This runs at most a
+ * few times a day (once per challenge completion), so there is no load argument for the replica.
  */
 export async function getExistingWinnersForRetry(challengeId: number): Promise<
   Array<{
@@ -666,7 +749,7 @@ export async function getExistingWinnersForRetry(challengeId: number): Promise<
     reason: string | null;
   }>
 > {
-  return dbRead.$queryRaw`
+  return dbWrite.$queryRaw`
     SELECT
       cw."userId",
       cw."imageId",

--- a/src/server/games/daily-challenge/challenge-winner-reconcile.ts
+++ b/src/server/games/daily-challenge/challenge-winner-reconcile.ts
@@ -1,0 +1,60 @@
+/**
+ * Winner payout reconciliation — pure, no DB/LLM imports.
+ *
+ * A challenge's winner-prize payout is made idempotent ONLY by its externalTransactionId, which
+ * embeds the winner's place (`challenge-winner-prize-{challengeId}-{userId}-place-{place}`). There
+ * is no dedupe of the payout anywhere downstream. So if a user is paid at place 1 and a later run
+ * re-picks that same user at place 2, the second payout carries a DIFFERENT key, does not conflict,
+ * and mints a second prize.
+ *
+ * The `ChallengeWinner` table is uniquely keyed on (challengeId, userId) — NOT on
+ * (challengeId, place) — so that re-pick cannot write a second row: the insert conflicts and the
+ * stored row keeps its ORIGINAL place. That makes the stored row the only durable record of what
+ * was actually paid, and therefore the authority the payout must key to.
+ *
+ * `reconcileWinnerToPersisted` is the point where a freshly-picked placement is folded back onto
+ * the persisted one, so record and payment can never diverge.
+ */
+
+/** The persisted state of a `ChallengeWinner` row after a create attempt. */
+export type PersistedChallengeWinner = {
+  id: number;
+  place: number;
+  buzzAwarded: number;
+  pointsAwarded: number;
+  /** true = this call inserted the row; false = the row already existed and this is its stored state. */
+  created: boolean;
+};
+
+/** The in-memory winner shape both completion paths build and then pay out. */
+export type WinnerPayoutEntry = {
+  userId: number;
+  imageId: number | null;
+  position: number;
+  prize: number;
+  reason: string | null;
+};
+
+/**
+ * Fold a freshly-picked winner entry onto the placement that is actually persisted.
+ *
+ * - Fresh insert (`created: true`) — nothing to reconcile, the row matches what we picked.
+ * - `null` — the create neither inserted nor resolved to a readable row (structurally unreachable:
+ *   (challengeId, userId) is the table's only unique constraint). Left untouched deliberately, so
+ *   this fix can never turn into an UNDER-payment; the create path logs it loudly instead.
+ * - Existing row — its place/prize win. Paying the freshly-picked place instead is exactly the
+ *   double-mint: the user was already paid under the recorded place's transaction id.
+ *
+ * A placement is only ever adopted when it is a real finite number. This is a money path: an
+ * absent/garbled field must degrade to "keep what we picked" rather than propagate `undefined`
+ * into the payout amount and the transaction id.
+ */
+export function reconcileWinnerToPersisted<T extends WinnerPayoutEntry>(
+  entry: T,
+  persisted: PersistedChallengeWinner | null
+): T {
+  if (!persisted || persisted.created) return entry;
+  if (!Number.isFinite(persisted.place) || !Number.isFinite(persisted.buzzAwarded)) return entry;
+  if (persisted.place === entry.position && persisted.buzzAwarded === entry.prize) return entry;
+  return { ...entry, position: persisted.place, prize: persisted.buzzAwarded };
+}

--- a/src/server/games/daily-challenge/challenge-winner-reconcile.ts
+++ b/src/server/games/daily-challenge/challenge-winner-reconcile.ts
@@ -80,8 +80,9 @@ export function reconcileWinnerToPersisted<T extends WinnerPayoutEntry>(
  * then. If reconciliation did not happen (`createChallengeWinner` returned `null`, its
  * unresolved-conflict branch) the entries keep their distinct places, produce two distinct
  * never-before-seen ids, and an id-keyed dedupe would pass both through to be minted twice. Keying
- * on the creator closes that case too, and cannot itself over-drop: the id embeds the creator, so
- * two ids that differ must have different creators.
+ * on the creator closes that case too, and cannot itself over-drop — for the reason given above:
+ * the unique key means a creator has at most one row per challenge, so a repeat of that creator is
+ * always a duplicate of the same award and never a second one they were owed.
  *
  * The FIRST occurrence wins. Entries are built in placement order, so the first holds the best
  * place and therefore the largest prize — keeping a later, worse placement instead would turn a

--- a/src/server/games/daily-challenge/challenge-winner-reconcile.ts
+++ b/src/server/games/daily-challenge/challenge-winner-reconcile.ts
@@ -58,3 +58,51 @@ export function reconcileWinnerToPersisted<T extends WinnerPayoutEntry>(
   if (persisted.place === entry.position && persisted.buzzAwarded === entry.prize) return entry;
   return { ...entry, position: persisted.place, prize: persisted.buzzAwarded };
 }
+
+/**
+ * Drop winner entries that would pay a creator already paid earlier in the SAME batch.
+ *
+ * Nothing upstream guarantees one placement per creator. `generateWinners` returns raw LLM JSON —
+ * "Select exactly 3 different winners" is prompt text, not a validated constraint — and both
+ * completion paths map winners to entries with a `find()` by creatorId, so one creator named in two
+ * slots yields two entries holding two different places. Before the reconcile above existed, those
+ * two entries paid under two distinct transaction ids: a genuine double mint with no re-pick
+ * involved. With it, they collapse onto the same stored place and hence the same id — a duplicate
+ * id inside a single batch, handed to an external Buzz service whose within-batch behaviour is not
+ * observable from this repo. Neither outcome is acceptable, so the duplicate is dropped here.
+ *
+ * That is safe by construction: `ChallengeWinner` is uniquely keyed on (challengeId, userId), so a
+ * creator has at most ONE row per challenge and therefore at most one thing to be paid for. A
+ * second placement for the same creator is a duplicate of the first, never a second prize.
+ *
+ * Keyed on the CREATOR, not on the full externalTransactionId, and that difference is load-bearing.
+ * Once reconciled the two entries share an id, so an id-keyed dedupe would catch them — but only
+ * then. If reconciliation did not happen (`createChallengeWinner` returned `null`, its
+ * unresolved-conflict branch) the entries keep their distinct places, produce two distinct
+ * never-before-seen ids, and an id-keyed dedupe would pass both through to be minted twice. Keying
+ * on the creator closes that case too, and cannot itself over-drop: the id embeds the creator, so
+ * two ids that differ must have different creators.
+ *
+ * The FIRST occurrence wins. Entries are built in placement order, so the first holds the best
+ * place and therefore the largest prize — keeping a later, worse placement instead would turn a
+ * duplicate pick into an under-payment.
+ *
+ * Lives in this module rather than beside `buildWinnerPayoutTransactions` for a mundane but real
+ * reason: `challenge-funding` is mocked with an explicit export list by 15 test files, so a new
+ * export there breaks all of them, while this pure module is imported for real everywhere.
+ */
+export function dedupeWinnersForPayout<T extends { userId: number }>(
+  winners: T[]
+): { winners: T[]; dropped: T[] } {
+  const seen = new Set<number>();
+  const kept: T[] = [];
+  const dropped: T[] = [];
+  for (const entry of winners) {
+    if (seen.has(entry.userId)) dropped.push(entry);
+    else {
+      seen.add(entry.userId);
+      kept.push(entry);
+    }
+  }
+  return { winners: kept, dropped };
+}

--- a/src/server/jobs/__tests__/challenge-completion-metrics.test.ts
+++ b/src/server/jobs/__tests__/challenge-completion-metrics.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import client from 'prom-client';
+import { freshPersistedWinner } from '~/server/games/daily-challenge/__tests__/persisted-winner.fixture';
 
 // Regression coverage for the SCHEDULED-JOB challenge completion telemetry.
 //
@@ -60,7 +61,7 @@ const {
   mockUpdateChallengeStatus: vi.fn().mockResolvedValue(undefined),
   mockRefundUserChallengeFunds: vi.fn().mockResolvedValue({ refundedEntries: 0 }),
   mockCreateNotification: vi.fn().mockResolvedValue(undefined),
-  mockCreateChallengeWinner: vi.fn().mockResolvedValue(1),
+  mockCreateChallengeWinner: vi.fn(),
   mockGetChallengeById: vi.fn().mockResolvedValue(null),
   mockCreateBuzzTransactionMany: vi.fn().mockResolvedValue(undefined),
   mockGetChallengeBuzzType: vi.fn().mockResolvedValue('yellow'),
@@ -360,7 +361,12 @@ beforeEach(() => {
   mockUpdateChallengeStatus.mockResolvedValue(undefined);
   mockRefundUserChallengeFunds.mockResolvedValue({ refundedEntries: 0 });
   mockDbWriteChallengeFindUnique.mockResolvedValue({ prizePool: 0, prizeDistribution: null });
-  mockCreateChallengeWinner.mockResolvedValue(1);
+  // Resolve to the PERSISTED row (fresh insert), the real return shape — see
+  // persisted-winner.fixture for why resolving `1` silently neutered the reconcile.
+  mockCreateChallengeWinner.mockImplementation(
+    async (input: { place: number; buzzAwarded: number; pointsAwarded?: number }) =>
+      freshPersistedWinner(input)
+  );
   mockGetChallengeById.mockResolvedValue(null);
   mockGetChallengeBuzzType.mockResolvedValue('yellow');
 });

--- a/src/server/jobs/daily-challenge-processing.ts
+++ b/src/server/jobs/daily-challenge-processing.ts
@@ -27,6 +27,7 @@ import {
   promoteChallengeEntries,
 } from '~/server/games/daily-challenge/challenge-rewards';
 import { filterRecentWinners } from '~/server/games/daily-challenge/winner-cooldown';
+import { reconcileWinnerToPersisted } from '~/server/games/daily-challenge/challenge-winner-reconcile';
 import {
   ChallengeReviewCostType,
   ChallengeSource,
@@ -1422,7 +1423,7 @@ export async function pickWinnersForChallenge(
         process = 'Deterministic award: fewer than 2 distinct entrants';
         outcome = 'Sole entrant awarded place 1 without LLM judging';
 
-        await createChallengeWinner({
+        const solePersisted = await createChallengeWinner({
           challengeId: currentChallenge.challengeId,
           userId: soleEntry.userId,
           imageId: soleEntry.imageId,
@@ -1431,6 +1432,11 @@ export async function pickWinnersForChallenge(
           pointsAwarded: currentChallenge.prizes[0]?.points ?? 0,
           reason: soleWinnerReason,
         });
+        // Pay the placement that is PERSISTED, not the one just picked — see the reconcile note on
+        // the LLM path below.
+        winningEntries = winningEntries.map((entry) =>
+          reconcileWinnerToPersisted(entry, solePersisted)
+        );
         log('ChallengeWinner record created (deterministic sole-entrant award)');
       } else {
         log('Sending entries for final judgment');
@@ -1471,9 +1477,17 @@ export async function pickWinnersForChallenge(
           })
           .filter(isDefined);
 
-        // 4. Create ChallengeWinner records (idempotent via P2002 handling)
+        // 4. Create ChallengeWinner records, then pay the placement that is PERSISTED rather than
+        // the one just picked. A user already recorded as a winner of this challenge cannot get a
+        // second row — (challengeId, userId) is unique, so the insert conflicts and the stored row
+        // keeps its original place. Paying the freshly-picked place would key the payout to a
+        // different externalTransactionId than the one already settled at the stored place and mint
+        // a second prize (this is the observed duplicate-payout mechanism, and re-picks tend to be
+        // permutations of the same users because the winner cooldown only excludes Completed
+        // challenges, leaving this challenge's own in-flight winners eligible).
+        const reconciledEntries: typeof winningEntries = [];
         for (const entry of winningEntries) {
-          await createChallengeWinner({
+          const persisted = await createChallengeWinner({
             challengeId: currentChallenge.challengeId,
             userId: entry.userId,
             imageId: entry.imageId!, // always non-null on fresh winner path
@@ -1482,7 +1496,9 @@ export async function pickWinnersForChallenge(
             pointsAwarded: currentChallenge.prizes[entry.position - 1]?.points ?? 0,
             reason: entry.reason ?? undefined,
           });
+          reconciledEntries.push(reconcileWinnerToPersisted(entry, persisted));
         }
+        winningEntries = reconciledEntries;
         log('ChallengeWinner records created');
       }
     }

--- a/src/server/jobs/daily-challenge-processing.ts
+++ b/src/server/jobs/daily-challenge-processing.ts
@@ -1501,8 +1501,12 @@ export async function pickWinnersForChallenge(
             droppedPlaces: droppedWinners.map((entry) => entry.position),
           }).catch(() => undefined);
           recordChallengeWinnerDuplicatePick({
-            source: challengeJudgeRow?.source,
+            // Defaulted the same way the judging call at ~:1365 defaults it: the judge row is typed
+            // `| undefined`, and letting it fall through to `unknown` would put a caller-side emit
+            // in a bucket that is meant to mean something else.
+            source: challengeJudgeRow?.source ?? ChallengeSource.System,
             count: droppedWinners.length,
+            origin: 'caller',
           });
         }
 
@@ -1536,16 +1540,17 @@ export async function pickWinnersForChallenge(
     // to the recorded ChallengeWinner.buzzAwarded) — indexing prizes[] by array position would
     // overpay when an unmatched LLM winner was filtered out above (place-2 entry at index 0
     // would get place-1 buzz), and on the retry path the array order isn't tied to place at all.
-    await withRetries(() =>
-      createBuzzTransactionMany(
-        buildWinnerPayoutTransactions({
-          challengeId: currentChallenge.challengeId,
-          title: currentChallenge.title,
-          buzzType: winnerBuzzType,
-          winners: winningEntries,
-        })
-      )
-    );
+    // Built OUTSIDE the retry closure. The output is deterministic so a rebuild would not move
+    // money, but the builder increments the duplicate-pick counter on its drop branch, and
+    // `withRetries` re-invokes up to 4 times — which would record 4x the placements actually
+    // dropped on exactly the flaky-payout run where the number matters most.
+    const winnerPayoutTransactions = buildWinnerPayoutTransactions({
+      challengeId: currentChallenge.challengeId,
+      title: currentChallenge.title,
+      buzzType: winnerBuzzType,
+      winners: winningEntries,
+    });
+    await withRetries(() => createBuzzTransactionMany(winnerPayoutTransactions));
     log('Prizes sent');
 
     // 6. Distribute entry participation prizes

--- a/src/server/jobs/daily-challenge-processing.ts
+++ b/src/server/jobs/daily-challenge-processing.ts
@@ -27,7 +27,10 @@ import {
   promoteChallengeEntries,
 } from '~/server/games/daily-challenge/challenge-rewards';
 import { filterRecentWinners } from '~/server/games/daily-challenge/winner-cooldown';
-import { reconcileWinnerToPersisted } from '~/server/games/daily-challenge/challenge-winner-reconcile';
+import {
+  dedupeWinnersForPayout,
+  reconcileWinnerToPersisted,
+} from '~/server/games/daily-challenge/challenge-winner-reconcile';
 import {
   ChallengeReviewCostType,
   ChallengeSource,
@@ -67,6 +70,7 @@ import { logToAxiom } from '~/server/logging/client';
 import {
   recordChallengeCompleted,
   recordChallengePrizePaidBuzz,
+  recordChallengeWinnerDuplicatePick,
 } from '~/server/prom/challenge.metrics';
 import {
   challengeJudgingCategoriesSchema,
@@ -1476,6 +1480,31 @@ export async function pickWinnersForChallenge(
             };
           })
           .filter(isDefined);
+
+        // Nothing above stops the LLM naming the same creator in two slots — "exactly 3 different
+        // winners" is prompt text, and `find()` happily matches the same entry twice — which would
+        // put one creator on two places. That creator has at most one `ChallengeWinner` row to be
+        // paid for, so the extra placement is a duplicate, not a second prize. Dropped HERE, before
+        // the create loop, rather than at the payout: it keeps the duplicate from conflicting
+        // against the row its own twin just inserted, which would otherwise fire the
+        // place-divergence warning and counter for an anomaly that is not a re-pick at all.
+        const { winners: dedupedWinners, dropped: droppedWinners } =
+          dedupeWinnersForPayout(winningEntries);
+        if (droppedWinners.length) {
+          winningEntries = dedupedWinners;
+          await logToAxiom({
+            type: 'warning',
+            name: 'challenge-winner-duplicate-pick',
+            message: `Winner pick named the same creator in more than one place; the extra placements were dropped before payout: challenge=${currentChallenge.challengeId}`,
+            challengeId: currentChallenge.challengeId,
+            droppedUserIds: droppedWinners.map((entry) => entry.userId),
+            droppedPlaces: droppedWinners.map((entry) => entry.position),
+          }).catch(() => undefined);
+          recordChallengeWinnerDuplicatePick({
+            source: challengeJudgeRow?.source,
+            count: droppedWinners.length,
+          });
+        }
 
         // 4. Create ChallengeWinner records, then pay the placement that is PERSISTED rather than
         // the one just picked. A user already recorded as a winner of this challenge cannot get a

--- a/src/server/prom/challenge.metrics.ts
+++ b/src/server/prom/challenge.metrics.ts
@@ -155,7 +155,12 @@ const winnerPlaceDivergenceCounter = registerCounterWithLabels({
 const winnerDuplicatePickCounter = registerCounterWithLabels({
   name: 'challenge_winner_duplicate_pick_total',
   help: 'Winner placements dropped before payout because the same creator held more than one place in a single pick (expected to stay at zero)',
-  labelNames: ['source'] as const,
+  // `origin` separates the two layers that can drop, and it exists because `source` cannot do the
+  // job: `normSource` routes both enum drift AND a null source (the caller reads its source off a
+  // row typed `| undefined`) into `unknown`, so `source: unknown` alone cannot distinguish "the
+  // choke point caught what a caller missed" from "a caller emitted without a readable source".
+  // Those want different responses, so they get different label values rather than a shared bucket.
+  labelNames: ['source', 'origin'] as const,
 });
 
 // ---------------------------------------------------------------------------
@@ -325,14 +330,25 @@ export function recordChallengeWinnerPlaceDivergence(args: { field: 'place' | 'p
   }
 }
 
-/** `count` = how many placements were dropped, not how many picks contained a duplicate. */
+/**
+ * `count` = how many placements were dropped, not how many picks contained a duplicate.
+ *
+ * An explicit `count: 0` records NOTHING. This counter is documented as sitting flat at zero and is
+ * an alert trigger, so "I dropped nothing" must never read as "I dropped one" — an omitted `count`
+ * still defaults to 1, which is the only case where 1 is the honest answer.
+ */
 export function recordChallengeWinnerDuplicatePick(args: {
   source?: string | null;
   count?: number;
+  origin: 'caller' | 'chokepoint';
 }) {
   try {
+    if (args.count === 0) return;
     const count = isPositiveFinite(args.count) ? args.count : 1;
-    winnerDuplicatePickCounter.inc({ source: normSource(args.source) }, count);
+    winnerDuplicatePickCounter.inc(
+      { source: normSource(args.source), origin: args.origin },
+      count
+    );
   } catch {
     /* never throw from telemetry */
   }

--- a/src/server/prom/challenge.metrics.ts
+++ b/src/server/prom/challenge.metrics.ts
@@ -32,6 +32,7 @@ const SCAN_RESULTS = new Set(['scanned', 'blocked', 'error']);
 const STATUSES = new Set(['Scheduled', 'Active', 'Completing', 'Completed', 'Cancelled']);
 const VOID_REASONS = new Set(['moderator', 'nsfw', 'activation']);
 const REFUND_REASONS = new Set(['void', 'delete']);
+const DIVERGENCE_FIELDS = new Set(['place', 'prize', 'both']);
 
 export function normSource(v: string | null | undefined): string {
   return v && SOURCES.has(v) ? v : 'unknown';
@@ -55,6 +56,9 @@ export function normVoidReason(v: string | null | undefined): string {
 }
 export function normRefundReason(v: string | null | undefined): string {
   return v && REFUND_REASONS.has(v) ? v : 'other';
+}
+export function normDivergenceField(v: string | null | undefined): string {
+  return v && DIVERGENCE_FIELDS.has(v) ? v : 'other';
 }
 
 // ---------------------------------------------------------------------------
@@ -128,6 +132,15 @@ const refundFailuresCounter = registerCounterWithLabels({
   name: 'challenge_refund_failures_total',
   help: 'Challenge refund attempts that threw (non NOT_FOUND), by source and reason',
   labelNames: ['source', 'reason'] as const,
+});
+// Money-path anomaly. A winner-prize payout is deduped only by its externalTransactionId, which
+// embeds the place — so a winner re-picked at a different place than the one already recorded would
+// pay twice. Any non-zero value means a completion re-picked winners over an existing record and
+// the payout had to be reconciled onto the stored placement. Expected to sit flat at zero.
+const winnerPlaceDivergenceCounter = registerCounterWithLabels({
+  name: 'challenge_winner_place_divergence_total',
+  help: 'ChallengeWinner inserts that conflicted with a stored row holding a different place/prize; the payout was reconciled to the stored placement (expected to stay at zero)',
+  labelNames: ['field'] as const,
 });
 
 // ---------------------------------------------------------------------------
@@ -284,6 +297,14 @@ export function recordChallengeRefundFailure(args: {
       source: normSource(args.source),
       reason: normRefundReason(args.reason),
     });
+  } catch {
+    /* never throw from telemetry */
+  }
+}
+
+export function recordChallengeWinnerPlaceDivergence(args: { field: 'place' | 'prize' | 'both' }) {
+  try {
+    winnerPlaceDivergenceCounter.inc({ field: normDivergenceField(args.field) });
   } catch {
     /* never throw from telemetry */
   }

--- a/src/server/prom/challenge.metrics.ts
+++ b/src/server/prom/challenge.metrics.ts
@@ -142,6 +142,21 @@ const winnerPlaceDivergenceCounter = registerCounterWithLabels({
   help: 'ChallengeWinner inserts that conflicted with a stored row holding a different place/prize; the payout was reconciled to the stored placement (expected to stay at zero)',
   labelNames: ['field'] as const,
 });
+// Money-path anomaly, and DELIBERATELY NOT folded into the divergence counter above. That one means
+// "a stored row disagreed with a re-pick" — a cross-run anomaly whose remediation is to work out why
+// a completion ran twice. This one means "one winner-pick named the same creator in more than one
+// slot", a judging-quality anomaly whose remediation is the prompt/model. Same metric, and an
+// operator reading a non-zero value could not tell which had happened, nor could an alert on one
+// avoid firing on the other.
+//
+// A creator can only ever hold ONE ChallengeWinner row per challenge — (challengeId, userId) is the
+// table's unique key — so a second placement for the same creator is never payable, and the extra
+// entries are dropped before the payout is built. Expected to sit flat at zero.
+const winnerDuplicatePickCounter = registerCounterWithLabels({
+  name: 'challenge_winner_duplicate_pick_total',
+  help: 'Winner placements dropped before payout because the same creator held more than one place in a single pick (expected to stay at zero)',
+  labelNames: ['source'] as const,
+});
 
 // ---------------------------------------------------------------------------
 // Never-throw record helpers — called from business logic emit sites
@@ -305,6 +320,19 @@ export function recordChallengeRefundFailure(args: {
 export function recordChallengeWinnerPlaceDivergence(args: { field: 'place' | 'prize' | 'both' }) {
   try {
     winnerPlaceDivergenceCounter.inc({ field: normDivergenceField(args.field) });
+  } catch {
+    /* never throw from telemetry */
+  }
+}
+
+/** `count` = how many placements were dropped, not how many picks contained a duplicate. */
+export function recordChallengeWinnerDuplicatePick(args: {
+  source?: string | null;
+  count?: number;
+}) {
+  try {
+    const count = isPositiveFinite(args.count) ? args.count : 1;
+    winnerDuplicatePickCounter.inc({ source: normSource(args.source) }, count);
   } catch {
     /* never throw from telemetry */
   }
@@ -547,6 +575,12 @@ export function __resetChallengeMetricsForTest(): void {
   operationSpentBuzzCounter.reset();
   refundBuzzCounter.reset();
   refundFailuresCounter.reset();
+  // Both money-path anomaly counters were missing here. Counters live on a process-global registry,
+  // so an un-reset one carries its value across every test in the file that touched it — a test
+  // asserting "this stayed at zero" would pass or fail on execution ORDER rather than on behaviour,
+  // which is precisely backwards for a metric whose whole contract is "expected to sit at zero".
+  winnerPlaceDivergenceCounter.reset();
+  winnerDuplicatePickCounter.reset();
 }
 
 /**

--- a/src/server/services/__tests__/challenge-completion-emit-boundary.service.test.ts
+++ b/src/server/services/__tests__/challenge-completion-emit-boundary.service.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import client from 'prom-client';
+import type { PersistedChallengeWinner } from '~/server/games/daily-challenge/challenge-winner-reconcile';
 
 // Regression coverage for the MOD -> JOB completion boundary.
 //
@@ -115,7 +116,18 @@ vi.mock('~/server/games/daily-challenge/challenge-helpers', () => ({
   closeChallengeCollection: vi.fn().mockResolvedValue(undefined),
   computeDynamicPool: vi.fn(),
   createChallengeRecord: vi.fn(),
-  createChallengeWinner: vi.fn().mockResolvedValue(1),
+  // Resolves to the PERSISTED row, matching the real signature. Inlined rather than built from
+  // `persisted-winner.fixture` / `WINNER_PRIZE_BUZZ` because a `vi.mock` factory is hoisted and
+  // cannot reference module-scope bindings. `1` used to sit here, which is truthy but has no
+  // `.created` / `.place`, so every caller's `reconcileWinnerToPersisted` degraded to a no-op —
+  // see persisted-winner.fixture. The `satisfies` is the guard that keeps this copy honest.
+  createChallengeWinner: vi.fn().mockResolvedValue({
+    id: 1,
+    place: 1,
+    buzzAwarded: 500, // = WINNER_PRIZE_BUZZ, declared below
+    pointsAwarded: 0,
+    created: true,
+  } satisfies PersistedChallengeWinner),
   distributePrizes: vi.fn(),
   getChallengeById: mockGetChallengeById,
   getChallengeEntryCount: vi.fn().mockResolvedValue(0),

--- a/src/server/services/__tests__/challenge-winner-payout-dedupe.service.test.ts
+++ b/src/server/services/__tests__/challenge-winner-payout-dedupe.service.test.ts
@@ -176,6 +176,27 @@ vi.mock('~/utils/logging', () => ({ createLogger: vi.fn(() => vi.fn()) }));
 const { endChallengeAndPickWinners } = await import('~/server/services/challenge.service');
 const { ChallengeSource, ChallengeStatus } = await import('~/shared/utils/prisma/enums');
 const { __resetChallengeMetricsForTest } = await import('~/server/prom/challenge.metrics');
+const client = (await import('prom-client')).default;
+
+const DUPLICATE_PICK_METRIC = 'civitai_app_challenge_winner_duplicate_pick_total';
+
+/**
+ * Read one series off the REAL prom registry. Returns `undefined` for an absent series rather than
+ * defaulting to 0, so "never emitted" can never be mistaken for "emitted zero".
+ */
+async function counterValue(
+  name: string,
+  labels: Record<string, string>
+): Promise<number | undefined> {
+  const metric = client.register.getSingleMetric(name) as unknown as {
+    get: () => Promise<{ values: Array<{ value: number; labels: Record<string, string> }> }>;
+  } | null;
+  if (!metric) return undefined;
+  const data = await metric.get();
+  return data.values.find((v) =>
+    Object.entries(labels).every(([key, val]) => v.labels[key] === val)
+  )?.value;
+}
 
 const CHALLENGE_ID = 42;
 
@@ -378,6 +399,10 @@ describe('endChallengeAndPickWinners — one creator named twice is paid once', 
     // just inserted — a conflict that would otherwise fire the place-divergence signal for
     // something that is not a re-pick at all.
     expect(mockCreateChallengeWinner).toHaveBeenCalledTimes(2);
+    // The anomaly must be visible on the mod path too. Without this the emit could be deleted with
+    // the suite still green — and this is the human-triggered path, so its signal is the one most
+    // likely to be wanted and, until now, the only one unprotected.
+    expect(await counterValue(DUPLICATE_PICK_METRIC, { source: ChallengeSource.System })).toBe(1);
   });
 
   it('leaves a clean pick alone — the guard does not over-trigger', async () => {

--- a/src/server/services/__tests__/challenge-winner-payout-dedupe.service.test.ts
+++ b/src/server/services/__tests__/challenge-winner-payout-dedupe.service.test.ts
@@ -1,0 +1,399 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// The MODERATOR completion path — `endChallengeAndPickWinners`, reached from the tRPC router when a
+// mod ends a challenge by hand. It has its own `createChallengeWinner` +
+// `reconcileWinnerToPersisted` loop, separate from the scheduled job's, and until this file existed
+// nothing covered it: every suite that touched it doubled `createChallengeWinner` as `1`, which is
+// truthy but has no `.created` / `.place`, so the reconcile degraded to a no-op and the call could
+// be deleted with the whole suite still green.
+//
+// Winner-prize payouts are deduped ONLY by their externalTransactionId, which embeds the PLACE
+// (`challenge-winner-prize-{challengeId}-{userId}-place-{place}`). `createBuzzTransactionMany` adds
+// no dedupe of its own, so these tests assert on the real transaction ids handed to the ledger and
+// deliberately leave the real (pure) `buildWinnerPayoutTransactions` unmocked.
+//
+// Mocking mirrors challenge-judging-categories-gate.service.test.ts, which is the leanest existing
+// harness that drives this function down its LLM re-pick branch.
+
+const {
+  mockDbWrite,
+  mockGetJudgedEntries,
+  mockGenerateWinners,
+  mockGetChallengeById,
+  mockCreateChallengeWinner,
+  mockCreateBuzzTransactionMany,
+  mockGetExistingWinnersForRetry,
+} = vi.hoisted(() => ({
+  mockDbWrite: {
+    $queryRaw: vi.fn().mockResolvedValue([]),
+    $executeRaw: vi.fn().mockResolvedValue(1),
+    challenge: {
+      update: vi.fn().mockResolvedValue(undefined),
+      findUnique: vi.fn().mockResolvedValue({ prizePool: 0, prizeDistribution: null }),
+    },
+  },
+  mockGetJudgedEntries: vi.fn(),
+  mockGenerateWinners: vi.fn(),
+  mockGetChallengeById: vi.fn(),
+  mockCreateChallengeWinner: vi.fn(),
+  mockCreateBuzzTransactionMany: vi.fn().mockResolvedValue(undefined),
+  mockGetExistingWinnersForRetry: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock('~/server/db/client', () => ({
+  dbRead: { $queryRaw: vi.fn().mockResolvedValue([]), challenge: { findUnique: vi.fn() } },
+  dbWrite: mockDbWrite,
+}));
+
+vi.mock('~/server/events', () => ({
+  eventEngine: { processEngagement: vi.fn().mockResolvedValue(undefined) },
+}));
+
+vi.mock('~/server/flipt/client', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('~/server/flipt/client')>();
+  return { ...actual, isFlipt: vi.fn().mockResolvedValue(false) };
+});
+
+vi.mock('~/server/logging/client', () => ({
+  logToAxiom: vi.fn().mockResolvedValue(undefined),
+  safeError: vi.fn((e: unknown) => e),
+}));
+
+vi.mock('~/server/games/daily-challenge/daily-challenge.utils', () => ({
+  getChallengeConfig: vi.fn().mockResolvedValue({
+    defaultJudgeId: 1,
+    defaultJudge: null,
+    judgedTagId: 1,
+    reviewMeTagId: 2,
+    winnerCooldown: '7 day',
+    finalReviewAmount: 10,
+    maxScoredPerUser: 5,
+    reviewAmount: { min: 6, max: 12 },
+  }),
+  setChallengeConfig: vi.fn(),
+  deriveChallengeNsfwLevel: vi.fn(() => 1),
+  getJudgingConfig: vi.fn().mockResolvedValue({
+    judgeId: 1,
+    userId: 999,
+    sourceCollectionId: null,
+    prompts: {},
+    reviewTemplate: null,
+  }),
+  endChallenge: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('~/server/games/daily-challenge/challenge-helpers', () => ({
+  claimChallengeForCompletion: vi.fn().mockResolvedValue(true),
+  closeChallengeCollection: vi.fn().mockResolvedValue(undefined),
+  createChallengeWinner: mockCreateChallengeWinner,
+  getChallengeById: mockGetChallengeById,
+  getChallengeWinners: vi.fn().mockResolvedValue([]),
+  getExistingWinnersForRetry: mockGetExistingWinnersForRetry,
+  incrementOperationSpent: vi.fn().mockResolvedValue(undefined),
+  resolveEventContext: vi.fn().mockResolvedValue(undefined),
+  updateChallengeStatus: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('~/server/games/daily-challenge/generative-content', () => ({
+  estimateBuzzCost: vi.fn().mockReturnValue(0),
+  generateArticle: vi.fn(),
+  generateReview: vi.fn(),
+  generateThemeElements: vi.fn(),
+  generateWinners: mockGenerateWinners,
+}));
+
+vi.mock('~/server/jobs/daily-challenge-processing', () => ({
+  getCoverOfModel: vi.fn(),
+  getJudgedEntries: mockGetJudgedEntries,
+}));
+
+// `buildWinnerPayoutTransactions` is deliberately left REAL (it is pure) so the assertions below run
+// against the genuine externalTransactionId strings — the actual money keys.
+vi.mock('~/server/games/daily-challenge/challenge-funding', async (importOriginal) => {
+  const actual = await importOriginal<
+    typeof import('~/server/games/daily-challenge/challenge-funding')
+  >();
+  return {
+    ...actual,
+    chargeInitialPrize: vi.fn(),
+    refundUserChallengeFunds: vi.fn().mockResolvedValue({ refundedEntries: 0 }),
+    reportPoolFundingShortfall: vi.fn().mockResolvedValue(undefined),
+  };
+});
+
+vi.mock('~/server/services/buzz.service', () => ({
+  createBuzzTransaction: vi.fn(),
+  createBuzzTransactionMany: mockCreateBuzzTransactionMany,
+  getTransactionByExternalId: vi.fn().mockResolvedValue(null),
+  refundMultiAccountTransaction: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('~/server/services/notification.service', () => ({
+  createNotification: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('~/server/services/challenge-engagement.service', () => ({
+  sendChallengeResultsNotification: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('~/server/services/commentsv2.service', () => ({
+  upsertComment: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('~/server/services/reaction.service', () => ({
+  toggleReaction: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('~/server/services/image.service', () => ({
+  createImage: vi.fn(),
+  enqueueImageIngestion: vi.fn(),
+  imagesForModelVersionsCache: { bust: vi.fn() },
+}));
+
+vi.mock('~/server/services/user.service', () => ({
+  amIBlockedByUser: vi.fn().mockResolvedValue(false),
+  getCosmeticsForUsers: vi.fn(() => ({})),
+  getProfilePicturesForUsers: vi.fn(() => ({})),
+}));
+
+vi.mock('~/server/services/challenge-eligibility.service', () => ({
+  assertCanCreateUserChallenge: vi.fn(),
+  assertUserAccountInGoodStanding: vi.fn(),
+}));
+
+vi.mock('~/server/integrations/moderation', () => ({ extModeration: {} }));
+
+vi.mock('~/server/search-index', () => ({
+  collectionsSearchIndex: { queueUpdate: vi.fn() },
+}));
+
+vi.mock('~/utils/errorHandling', () => ({
+  withRetries: vi.fn((fn: () => unknown) => fn()),
+}));
+
+vi.mock('~/utils/logging', () => ({ createLogger: vi.fn(() => vi.fn()) }));
+
+const { endChallengeAndPickWinners } = await import('~/server/services/challenge.service');
+const { ChallengeSource, ChallengeStatus } = await import('~/shared/utils/prisma/enums');
+const { __resetChallengeMetricsForTest } = await import('~/server/prom/challenge.metrics');
+
+const CHALLENGE_ID = 42;
+
+const challengeRow = {
+  id: CHALLENGE_ID,
+  title: 'Mod Ended Challenge',
+  status: ChallengeStatus.Active,
+  collectionId: 100,
+  source: ChallengeSource.System,
+  buzzType: 'yellow',
+  theme: 'test',
+  prizes: [
+    { buzz: 500, points: 10 },
+    { buzz: 250, points: 5 },
+    { buzz: 100, points: 2 },
+  ],
+  // Left null so the entry-participation prize block is skipped — it is a different payout with its
+  // own transaction ids and would only add noise to the winner-prize assertions here.
+  entryPrize: null,
+  entryPrizeRequirement: 10,
+  prizePool: 0,
+  prizeDistribution: null,
+  operationSpent: 0,
+  operationBudget: 0,
+  entryFee: 0,
+  judgeId: null,
+  judgingPrompt: null,
+  judgingCategories: null,
+  eventId: null,
+  createdById: 999,
+  modelVersionIds: [],
+  metadata: null,
+};
+
+const JUDGED_ENTRIES = [
+  { imageId: 1, userId: 100, username: 'alice', summary: 'a', score: 10 },
+  { imageId: 2, userId: 200, username: 'bob', summary: 'b', score: 9 },
+  { imageId: 3, userId: 300, username: 'carol', summary: 'c', score: 8 },
+];
+
+function llmWinners(winners: Array<{ creatorId: number; creator: string }>) {
+  mockGenerateWinners.mockResolvedValue({
+    process: 'llm',
+    outcome: 'llm-picked',
+    model: 'test-model',
+    usage: {},
+    winners: winners.map((w) => ({ ...w, reason: `because ${w.creator}` })),
+  });
+}
+
+/** See challenge-winner-payout-dedupe.test.ts — a double that enforces (challengeId, userId). */
+function stubUniqueWinnerTable() {
+  const stored = new Map<number, { id: number; place: number; buzzAwarded: number }>();
+  mockCreateChallengeWinner.mockImplementation(
+    async ({
+      userId,
+      place,
+      buzzAwarded,
+    }: {
+      userId: number;
+      place: number;
+      buzzAwarded: number;
+    }) => {
+      const existing = stored.get(userId);
+      if (existing) return { ...existing, pointsAwarded: 0, created: false };
+      const row = { id: stored.size + 1, place, buzzAwarded };
+      stored.set(userId, row);
+      return { ...row, pointsAwarded: 0, created: true };
+    }
+  );
+}
+
+/** The externalTransactionIds actually submitted to the buzz ledger, in submission order. */
+function paidExternalIds(): string[] {
+  expect(mockCreateBuzzTransactionMany).toHaveBeenCalledTimes(1);
+  const [transactions] = mockCreateBuzzTransactionMany.mock.calls[0];
+  return (transactions as Array<{ externalTransactionId: string }>).map(
+    (t) => t.externalTransactionId
+  );
+}
+
+/** externalTransactionId -> amount, so a reconciled place can be checked to pay its recorded prize. */
+function paidAmountsById(): Record<string, number> {
+  const [transactions] = mockCreateBuzzTransactionMany.mock.calls[0];
+  return Object.fromEntries(
+    (transactions as Array<{ externalTransactionId: string; amount: number }>).map((t) => [
+      t.externalTransactionId,
+      t.amount,
+    ])
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  __resetChallengeMetricsForTest();
+  mockDbWrite.$queryRaw.mockResolvedValue([]);
+  mockDbWrite.$executeRaw.mockResolvedValue(1);
+  mockDbWrite.challenge.update.mockResolvedValue(undefined);
+  mockDbWrite.challenge.findUnique.mockResolvedValue({ prizePool: 0, prizeDistribution: null });
+  mockGetChallengeById.mockResolvedValue(challengeRow);
+  mockGetExistingWinnersForRetry.mockResolvedValue([]);
+  mockGetJudgedEntries.mockResolvedValue(JUDGED_ENTRIES);
+  mockCreateBuzzTransactionMany.mockResolvedValue(undefined);
+  stubUniqueWinnerTable();
+});
+
+describe('endChallengeAndPickWinners — payout keys on the PERSISTED placement', () => {
+  it('a permuted re-pick over existing records pays the recorded places, not the new ones', async () => {
+    // Users 100 and 200 are already recorded — and already PAID — at places 1 and 2. This run's
+    // `getExistingWinnersForRetry` came back empty (rows written by a concurrent run after this
+    // run's read), so it goes down the fresh LLM re-pick path and picks the same two users with
+    // their places SWAPPED.
+    llmWinners([
+      { creatorId: 200, creator: 'bob' },
+      { creatorId: 100, creator: 'alice' },
+    ]);
+    mockCreateChallengeWinner.mockImplementation(async ({ userId }: { userId: number }) =>
+      userId === 200
+        ? { id: 2, place: 2, buzzAwarded: 250, pointsAwarded: 5, created: false }
+        : { id: 1, place: 1, buzzAwarded: 500, pointsAwarded: 10, created: false }
+    );
+
+    await endChallengeAndPickWinners(CHALLENGE_ID);
+
+    // `...-200-place-1` / `...-100-place-2` would be fresh, never-seen ids the ledger's idempotency
+    // index cannot dedupe — a second prize for two users who were already paid.
+    expect(paidExternalIds().sort()).toEqual([
+      `challenge-winner-prize-${CHALLENGE_ID}-100-place-1`,
+      `challenge-winner-prize-${CHALLENGE_ID}-200-place-2`,
+    ]);
+    expect(paidAmountsById()).toEqual({
+      [`challenge-winner-prize-${CHALLENGE_ID}-100-place-1`]: 500,
+      [`challenge-winner-prize-${CHALLENGE_ID}-200-place-2`]: 250,
+    });
+  });
+
+  it('a single winner re-picked at a different place pays the recorded place only', async () => {
+    llmWinners([{ creatorId: 100, creator: 'alice' }]); // picked place 1
+    // ...but alice is already recorded (and paid) at place 3.
+    mockCreateChallengeWinner.mockResolvedValue({
+      id: 7,
+      place: 3,
+      buzzAwarded: 100,
+      pointsAwarded: 2,
+      created: false,
+    });
+
+    await endChallengeAndPickWinners(CHALLENGE_ID);
+
+    expect(paidExternalIds()).toEqual([`challenge-winner-prize-${CHALLENGE_ID}-100-place-3`]);
+    expect(paidAmountsById()).toEqual({
+      [`challenge-winner-prize-${CHALLENGE_ID}-100-place-3`]: 100,
+    });
+  });
+
+  it('fresh winners (no conflict) pay the freshly-picked places — happy path unchanged', async () => {
+    llmWinners([
+      { creatorId: 200, creator: 'bob' },
+      { creatorId: 100, creator: 'alice' },
+    ]);
+
+    await endChallengeAndPickWinners(CHALLENGE_ID);
+
+    expect(paidExternalIds()).toEqual([
+      `challenge-winner-prize-${CHALLENGE_ID}-200-place-1`,
+      `challenge-winner-prize-${CHALLENGE_ID}-100-place-2`,
+    ]);
+    expect(paidAmountsById()).toEqual({
+      [`challenge-winner-prize-${CHALLENGE_ID}-200-place-1`]: 500,
+      [`challenge-winner-prize-${CHALLENGE_ID}-100-place-2`]: 250,
+    });
+  });
+});
+
+describe('endChallengeAndPickWinners — one creator named twice is paid once', () => {
+  it('pays the duplicated creator exactly once, at their better place, with no repeated id', async () => {
+    // `generateWinners` returns raw LLM JSON; "Select exactly 3 different winners" is prompt text
+    // with no code-level enforcement, and the mapping loop resolves each winner with a `find()` by
+    // creatorId — so one creator in two slots yields two entries holding two places.
+    llmWinners([
+      { creatorId: 100, creator: 'alice' },
+      { creatorId: 100, creator: 'alice' },
+      { creatorId: 200, creator: 'bob' },
+    ]);
+
+    await endChallengeAndPickWinners(CHALLENGE_ID);
+
+    const ids = paidExternalIds();
+    expect(new Set(ids).size).toBe(ids.length);
+    expect(ids.sort()).toEqual([
+      `challenge-winner-prize-${CHALLENGE_ID}-100-place-1`,
+      `challenge-winner-prize-${CHALLENGE_ID}-200-place-3`,
+    ]);
+    // alice keeps place 1 (500), not the dropped place 2 (250).
+    expect(paidAmountsById()).toEqual({
+      [`challenge-winner-prize-${CHALLENGE_ID}-100-place-1`]: 500,
+      [`challenge-winner-prize-${CHALLENGE_ID}-200-place-3`]: 100,
+    });
+    // Dropped BEFORE the create loop, so the duplicate never conflicts against the row its own twin
+    // just inserted — a conflict that would otherwise fire the place-divergence signal for
+    // something that is not a re-pick at all.
+    expect(mockCreateChallengeWinner).toHaveBeenCalledTimes(2);
+  });
+
+  it('leaves a clean pick alone — the guard does not over-trigger', async () => {
+    llmWinners([
+      { creatorId: 100, creator: 'alice' },
+      { creatorId: 200, creator: 'bob' },
+      { creatorId: 300, creator: 'carol' },
+    ]);
+
+    await endChallengeAndPickWinners(CHALLENGE_ID);
+
+    expect(paidExternalIds()).toEqual([
+      `challenge-winner-prize-${CHALLENGE_ID}-100-place-1`,
+      `challenge-winner-prize-${CHALLENGE_ID}-200-place-2`,
+      `challenge-winner-prize-${CHALLENGE_ID}-300-place-3`,
+    ]);
+    expect(mockCreateChallengeWinner).toHaveBeenCalledTimes(3);
+  });
+});

--- a/src/server/services/__tests__/challenge-winner-payout-dedupe.service.test.ts
+++ b/src/server/services/__tests__/challenge-winner-payout-dedupe.service.test.ts
@@ -1,4 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+// Namespace type-imports (erased at compile time, so they are safe above the hoisted vi.mock calls)
+// — the repo forbids inline `typeof import(...)` annotations.
+import type * as FliptClient from '~/server/flipt/client';
+import type * as ChallengeFunding from '~/server/games/daily-challenge/challenge-funding';
 
 // The MODERATOR completion path — `endChallengeAndPickWinners`, reached from the tRPC router when a
 // mod ends a challenge by hand. It has its own `createChallengeWinner` +
@@ -50,7 +54,7 @@ vi.mock('~/server/events', () => ({
 }));
 
 vi.mock('~/server/flipt/client', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('~/server/flipt/client')>();
+  const actual = await importOriginal<typeof FliptClient>();
   return { ...actual, isFlipt: vi.fn().mockResolvedValue(false) };
 });
 
@@ -110,9 +114,7 @@ vi.mock('~/server/jobs/daily-challenge-processing', () => ({
 // `buildWinnerPayoutTransactions` is deliberately left REAL (it is pure) so the assertions below run
 // against the genuine externalTransactionId strings — the actual money keys.
 vi.mock('~/server/games/daily-challenge/challenge-funding', async (importOriginal) => {
-  const actual = await importOriginal<
-    typeof import('~/server/games/daily-challenge/challenge-funding')
-  >();
+  const actual = await importOriginal<typeof ChallengeFunding>();
   return {
     ...actual,
     chargeInitialPrize: vi.fn(),

--- a/src/server/services/challenge.service.ts
+++ b/src/server/services/challenge.service.ts
@@ -2603,6 +2603,7 @@ export async function endChallengeAndPickWinners(challengeId: number) {
         recordChallengeWinnerDuplicatePick({
           source: challenge.source,
           count: droppedWinners.length,
+          origin: 'caller',
         });
       }
 
@@ -2633,16 +2634,15 @@ export async function endChallengeAndPickWinners(challengeId: number) {
     // the same builder as the cron completion path — hardcoding 'yellow' here minted yellow and
     // stranded the collected green pool for green challenges. Deterministic externalTransactionId
     // (challenge-winner-prize-{cid}-{uid}-place-{n}) keeps retries idempotent.
-    await withRetries(() =>
-      createBuzzTransactionMany(
-        buildWinnerPayoutTransactions({
-          challengeId,
-          title: challenge.title,
-          buzzType: challenge.buzzType,
-          winners: winningEntries,
-        })
-      )
-    );
+    // Built OUTSIDE the retry closure — see the matching note on the cron path. The builder emits
+    // the duplicate-pick counter on its drop branch, and `withRetries` re-invokes up to 4 times.
+    const winnerPayoutTransactions = buildWinnerPayoutTransactions({
+      challengeId,
+      title: challenge.title,
+      buzzType: challenge.buzzType,
+      winners: winningEntries,
+    });
+    await withRetries(() => createBuzzTransactionMany(winnerPayoutTransactions));
     log('Prizes sent');
 
     // Send entry participation prizes to all eligible users

--- a/src/server/services/challenge.service.ts
+++ b/src/server/services/challenge.service.ts
@@ -107,6 +107,7 @@ import {
   refundUserChallengeFunds,
   reportPoolFundingShortfall,
 } from '~/server/games/daily-challenge/challenge-funding';
+import { reconcileWinnerToPersisted } from '~/server/games/daily-challenge/challenge-winner-reconcile';
 import {
   deriveDomainCurrency,
   isChallengeHiddenByDomainCurrency,
@@ -2576,9 +2577,15 @@ export async function endChallengeAndPickWinners(challengeId: number) {
         })
         .filter(isDefined);
 
-      // Create ChallengeWinner records (idempotent via P2002 handling)
+      // Create ChallengeWinner records, then pay the placement that is PERSISTED rather than the
+      // one just picked. A user already recorded as a winner of this challenge cannot get a second
+      // row — (challengeId, userId) is unique, so the insert conflicts and the stored row keeps its
+      // original place. Paying the freshly-picked place would key the payout to a different
+      // externalTransactionId than the one already settled at the stored place and mint a second
+      // prize. (Parity with the cron completion path.)
+      const reconciledEntries: typeof winningEntries = [];
       for (const entry of winningEntries) {
-        await createChallengeWinner({
+        const persisted = await createChallengeWinner({
           challengeId,
           userId: entry.userId,
           imageId: entry.imageId!, // always non-null on fresh winner path
@@ -2587,7 +2594,9 @@ export async function endChallengeAndPickWinners(challengeId: number) {
           pointsAwarded: challenge.prizes[entry.position - 1]?.points ?? 0,
           reason: entry.reason ?? undefined,
         });
+        reconciledEntries.push(reconcileWinnerToPersisted(entry, persisted));
       }
+      winningEntries = reconciledEntries;
       log('ChallengeWinner records created');
     }
 

--- a/src/server/services/challenge.service.ts
+++ b/src/server/services/challenge.service.ts
@@ -26,6 +26,7 @@ import {
   recordChallengeVoided,
   recordChallengeDeleted,
   recordChallengePrizePaidBuzz,
+  recordChallengeWinnerDuplicatePick,
 } from '~/server/prom/challenge.metrics';
 import {
   ChallengeParticipation,
@@ -107,7 +108,10 @@ import {
   refundUserChallengeFunds,
   reportPoolFundingShortfall,
 } from '~/server/games/daily-challenge/challenge-funding';
-import { reconcileWinnerToPersisted } from '~/server/games/daily-challenge/challenge-winner-reconcile';
+import {
+  dedupeWinnersForPayout,
+  reconcileWinnerToPersisted,
+} from '~/server/games/daily-challenge/challenge-winner-reconcile';
 import {
   deriveDomainCurrency,
   isChallengeHiddenByDomainCurrency,
@@ -2576,6 +2580,31 @@ export async function endChallengeAndPickWinners(challengeId: number) {
           };
         })
         .filter(isDefined);
+
+      // Nothing above stops the LLM naming the same creator in two slots — "exactly 3 different
+      // winners" is prompt text, and `find()` happily matches the same entry twice — which would put
+      // one creator on two places. That creator has at most one `ChallengeWinner` row to be paid
+      // for, so the extra placement is a duplicate, not a second prize. Dropped HERE, before the
+      // create loop, rather than at the payout: it keeps the duplicate from conflicting against the
+      // row its own twin just inserted, which would otherwise fire the place-divergence warning and
+      // counter for an anomaly that is not a re-pick at all. (Parity with the cron path.)
+      const { winners: dedupedWinners, dropped: droppedWinners } =
+        dedupeWinnersForPayout(winningEntries);
+      if (droppedWinners.length) {
+        winningEntries = dedupedWinners;
+        await logToAxiom({
+          type: 'warning',
+          name: 'challenge-winner-duplicate-pick',
+          message: `Winner pick named the same creator in more than one place; the extra placements were dropped before payout: challenge=${challengeId}`,
+          challengeId,
+          droppedUserIds: droppedWinners.map((entry) => entry.userId),
+          droppedPlaces: droppedWinners.map((entry) => entry.position),
+        }).catch(() => undefined);
+        recordChallengeWinnerDuplicatePick({
+          source: challenge.source,
+          count: droppedWinners.length,
+        });
+      }
 
       // Create ChallengeWinner records, then pay the placement that is PERSISTED rather than the
       // one just picked. A user already recorded as a winner of this challenge cannot get a second


### PR DESCRIPTION
## Why

Duplicate challenge prize payouts have minted **~2.21M Buzz** in production — 2,196,695 across 11 challenges (2026-02-28) and 9,000 on challenge 130 (2026-05-06). Nobody was ever underpaid; this is pure mint from account 0.

Winner payouts are settled under `challenge-winner-prize-{challengeId}-{userId}-place-{position}`. `createBuzzTransactionMany` has **no dedupe of its own** — idempotency is entirely the ledger's unique index on that id. Change the position, change the key, money moves again.

`ChallengeWinner` is `@@unique([challengeId, userId])` — deliberately, so ties are allowed. That means a re-picked winner at a different place hits P2002, and `createChallengeWinner` previously returned `null`, leaving the stored row at the OLD place while the in-memory entry paid the NEW one.

## What changed

**1. The persisted place is authoritative.** `createChallengeWinner` now returns the stored row on conflict; entries adopt its `place` and `buzzAwarded`, so a re-pick re-issues the *original* transaction id and the ledger conflicts it away.

**2. The retry read goes to the primary.** `getExistingWinnersForRetry` used `dbRead`; under replica lag an empty result routed to a fresh LLM re-pick.

**3. Duplicate creator picks are dropped.** `generateWinners` returns raw LLM JSON — *"select exactly 3 different winners"* is prompt text, not a validated constraint — and both mapping loops `find()` by creatorId, so one creator could hold two places. Dropped at both callers and again inside `buildWinnerPayoutTransactions`, keyed on the **creator** rather than the id (if reconciliation did not happen the entries keep distinct ids, and an id-keyed dedupe would let both through).

## 🔴 New user-visible behaviour

**A prize place can now go unpaid to anyone.** If the LLM names alice at places 1 and 2 and bob at 3, alice keeps place 1 and bob keeps place 3 — bob is **not** promoted, and place 2's prize is paid to nobody. This is correct in the "no phantom second winner" sense, but it is a real product decision being made here; the alternative is to re-rank and compact places. `recordChallengePrizePaidBuzz` reports the reduced sum, so no metric overstates it.

## Corrections to earlier claims in this PR

- ~~"can never reduce a payout relative to current behaviour"~~ — **false.** A stored `buzzAwarded: 0` row (reachable when the LLM returns more winners than `prizes[]` has places) is adopted and then dropped entirely by `createBuzzTransactionMany`'s `amount > 0` filter. The accurate claim: *it can never pay below the recorded `ChallengeWinner.buzzAwarded`, which is already what the retry path pays.*
- ~~"the `dbWrite` change is nearly inert once the reconcile lands"~~ — **false.** The retry short-circuit is the only mechanism preventing a fresh re-pick from putting a *different* user on an already-paid place. It is load-bearing.

## Known residual (not closed here)

A re-pick placing a **different** user on an already-paid place still double-pays: that user's record and payment agree, but the challenge has paid two place-1 prizes. **This is the majority of the historical damage — 5 of the 11 incidents, ~658,500 Buzz.** Only a pre-payout ledger check closes it, which needs an abort-vs-reconcile decision and puts a network call on the money path. A daily reconciliation job now detects this class within a day.

## Fail-closed dependency

A throwing P2002 re-read now propagates, so completion fails before payout and the challenge stays `Completing` for recovery. Recovery latency is up to ~70 min, and the recovery job returns early when the `CHALLENGE_PLATFORM_ENABLED` flag is off — flag off means nothing recovers a stuck challenge. `claimChallengeForCompletion` is the only writer of `Completing` and stamps atomically, so this path cannot produce the never-reset stampless row.

## Verification

```
Test Files  317 passed (317)
     Tests  4245 passed (4245)
     Errors  4   (pre-existing NixOS Prisma linux-nixos engine failures, unrelated files)
tsc --noEmit  exit 0
```

Mutation-checked at full scope: each call site's reconcile, each dedupe, the choke-point dedupe and its metric, the service-path emit, and first-wins-vs-last-wins all fail a test when reverted.

## Not verified

No integration run against real Postgres or the live Buzz ledger. In particular, whether the external ledger dedupes two identical ids **within one batch** is unobservable from this repo — which is why the dedupe is deterministic rather than relying on it. The 2026-05-06 challenge-130 event's trigger remains unexplained and is not accounted for by either mechanism fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)