### PR TITLE
obs(eventloop): extend long-task histogram buckets to 20s/30s

### DIFF
--- a/src/server/__tests__/eventloop-longtask-metrics.test.ts
+++ b/src/server/__tests__/eventloop-longtask-metrics.test.ts
@@ -58,6 +58,8 @@ import {
   recordDrift,
   classifyDrift,
   __initEventLoopDelayGaugesForTests,
+  LONGTASK_DURATION_BUCKETS,
+  LONGTASK_MAX_SUPPORTED_SUSPEND_CAP_MS,
   type DriftClassification,
 } from '~/server/eventloop-longtask';
 
@@ -157,6 +159,57 @@ describe('eventloop-longtask metrics: emission reaches the REGISTERED metric', (
     recordDrift(classified, recordOpts);
     expect(await counterValue(COUNTER)).toBe(cBefore + 1);
     expect(await histogramCount(HISTOGRAM, 'unlabeled')).toBe(hBefore + 1);
+  });
+});
+
+describe('eventloop-longtask metrics: duration buckets cover the suspension cap', () => {
+  const topFinite = LONGTASK_DURATION_BUCKETS[LONGTASK_DURATION_BUCKETS.length - 1];
+  const capSeconds = LONGTASK_MAX_SUPPORTED_SUSPEND_CAP_MS / 1000;
+
+  it('the top finite bucket reaches the highest supported suspension cap', () => {
+    expect(
+      topFinite,
+      `Top finite histogram bucket is ${topFinite}s but the highest supported ` +
+        `EVENTLOOP_LONGTASK_SUSPEND_MS is ${LONGTASK_MAX_SUPPORTED_SUSPEND_CAP_MS}ms (${capSeconds}s). ` +
+        'Blocks between the top bucket and the cap ARE recorded, but they all land in the ' +
+        '+Inf bucket, so histogram_quantile() reports exactly the top bound and cannot ' +
+        'distinguish them. If the deployed cap was raised, add the matching buckets to ' +
+        'LONGTASK_DURATION_BUCKETS in the same change.'
+    ).toBeGreaterThanOrEqual(capSeconds);
+  });
+
+  it('no bucket exceeds the cap (such a bucket could never be observed)', () => {
+    expect(
+      topFinite,
+      `Bucket ${topFinite}s is above the suspension cap ${capSeconds}s. classifyDrift ` +
+        'reclassifies any gap at or above the cap as `suspension` and skips the histogram, ' +
+        'so a bucket above the cap is a permanently-empty series — pure cardinality cost. ' +
+        'Either lower the bucket or raise LONGTASK_MAX_SUPPORTED_SUSPEND_CAP_MS to match ' +
+        'the deployed cap.'
+    ).toBeLessThanOrEqual(capSeconds);
+  });
+
+  it('buckets are strictly ascending (prom-client requires ordered bounds)', () => {
+    for (let i = 1; i < LONGTASK_DURATION_BUCKETS.length; i++) {
+      expect(
+        LONGTASK_DURATION_BUCKETS[i],
+        `Bucket bounds must be strictly ascending; index ${i} (${LONGTASK_DURATION_BUCKETS[i]}) ` +
+          `is not greater than index ${i - 1} (${LONGTASK_DURATION_BUCKETS[i - 1]}).`
+      ).toBeGreaterThan(LONGTASK_DURATION_BUCKETS[i - 1]);
+    }
+  });
+
+  it('a block in the newly-covered band is observed below +Inf, not swallowed by it', async () => {
+    // 15s block: under the 30s cap so classifyDrift keeps it as a block, and with
+    // the extended buckets it lands in le="20" rather than only +Inf.
+    const classified = classifyDrift(15_020, 0, 20, 50, LONGTASK_MAX_SUPPORTED_SUSPEND_CAP_MS);
+    expect(classified).toEqual({ kind: 'block', blockedMs: 15_000 });
+    recordDrift(classified, { logMinMs: 50, threshold: 50, logPerMin: 30 });
+
+    const scraped = await testRegistry.getSingleMetricAsString(HISTOGRAM);
+    const le20 = /le="20"[^\n]*?\s(\d+)$/m.exec(scraped);
+    expect(le20, `expected an le="20" bucket series in:\n${scraped}`).not.toBeNull();
+    expect(Number(le20?.[1])).toBeGreaterThanOrEqual(1);
   });
 });
 

--- a/src/server/eventloop-longtask.ts
+++ b/src/server/eventloop-longtask.ts
@@ -141,6 +141,11 @@ function resolveStackSample(): number {
  * block — so a descheduled pod doesn't emit a fake multi-second "block". The
  * authoritative lag signal remains the monitorEventLoopDelay histogram. Tunable
  * via EVENTLOOP_LONGTASK_SUSPEND_MS; <=0 disables the cap.
+ *
+ * COUPLED TO THE HISTOGRAM BUCKETS: the cap is the largest value the duration
+ * histogram can ever observe, so raising it past
+ * LONGTASK_MAX_SUPPORTED_SUSPEND_CAP_MS without adding buckets pushes the newly
+ * admitted band into `+Inf`, where histogram_quantile() cannot resolve it.
  */
 function resolveSuspendCapMs(): number {
   const parsed = Number.parseInt(process.env.EVENTLOOP_LONGTASK_SUSPEND_MS ?? '', 10);
@@ -437,11 +442,56 @@ function installStackHook(sampleEvery: number, mapCap: number): void {
 // Prometheus metrics (registered via the existing prom/client helpers)
 // ---------------------------------------------------------------------------
 
+/**
+ * Highest EVENTLOOP_LONGTASK_SUSPEND_MS value the duration buckets below are sized
+ * for, in milliseconds.
+ *
+ * The cap and the top bucket are COUPLED and must move together:
+ *   - A gap whose excess is >= the suspension cap is classified as `suspension`
+ *     (see classifyDrift) and never reaches the histogram at all. So a bucket
+ *     ABOVE the cap can never be observed — it would be a permanently-empty series.
+ *   - Conversely, everything between the top finite bucket and the cap collapses
+ *     into `+Inf`. histogram_quantile() then reports exactly the top bound and
+ *     cannot tell an 11s block from a 29s one.
+ *
+ * Therefore: top finite bucket == the highest cap we intend to run.
+ * If the deployed cap is ever raised past this, raise this constant AND add the
+ * matching buckets in the same change. Both directions are guarded by the
+ * "duration buckets cover the suspension cap" suite in
+ * src/server/__tests__/eventloop-longtask-metrics.test.ts.
+ *
+ * Applies to BOTH histograms: installLabelHook receives the same resolved
+ * suspendCapMs as the drift timer (see armEventLoopLongTaskDetector).
+ */
+export const LONGTASK_MAX_SUPPORTED_SUSPEND_CAP_MS = 30_000;
+
+/**
+ * Shared duration buckets (seconds) for BOTH long-task histograms.
+ *
+ * The low end (50ms..2s) is where routine pins live. The 5/10/20/30 tail exists
+ * because the deployed suspension cap was raised from the 5s default to 30s,
+ * which admits a real multi-second freeze class that used to be discarded as
+ * "suspension" before it ever reached a histogram. With the old ceiling of 10 the
+ * entire 10-30s band landed in `+Inf` and had no duration resolution.
+ *
+ * COST: each bucket is one extra time series per label combination per process.
+ * The drift histogram's `label` is the constant 'unlabeled' (see recordDrift), so
+ * this is +1 series per added bucket per process on that family.
+ *
+ * NOT RETROACTIVE: changing this does not rewrite existing series. Pods started
+ * before the change keep emitting the old `le` set, so histogram_quantile() over a
+ * window spanning the rollout mixes two bucket layouts and is not meaningful until
+ * every process has restarted. `_sum` and `_count` are unaffected either way.
+ */
+export const LONGTASK_DURATION_BUCKETS: readonly number[] = [
+  0.05, 0.1, 0.25, 0.5, 1, 2, 5, 10, 20, 30,
+];
+
 // Long-task duration histogram, labeled by attributed operation. Cardinality is
 // bounded: in base-armed mode every block is 'unlabeled' (one series); with the
 // labels tier on, `label` is the same fixed tRPC-procedure / route enum that
-// trpc_procedure_duration already uses. Buckets target the 50ms..several-seconds
-// range that matters for pins.
+// trpc_procedure_duration already uses. Buckets target the 50ms..suspension-cap
+// range that matters for pins — see LONGTASK_DURATION_BUCKETS.
 const longTaskHistogram = registerInstrumentationMetric(
   PROM_PREFIX + 'eventloop_longtask_duration_seconds',
   () =>
@@ -449,7 +499,7 @@ const longTaskHistogram = registerInstrumentationMetric(
       name: PROM_PREFIX + 'eventloop_longtask_duration_seconds',
       help: 'Synchronous event-loop blocks over threshold, by attributed operation label. NOTE: drift-timer based — counts include GC pauses and (below the suspension cap) brief CPU-steal, not only JS blocks. The authoritative lag signal is civitai_app_eventloop_delay_ms.',
       labelNames: ['label'] as const,
-      buckets: [0.05, 0.1, 0.25, 0.5, 1, 2, 5, 10],
+      buckets: [...LONGTASK_DURATION_BUCKETS],
       // Register into the shared cross-graph registry instead of the default
       // (per-graph) globalRegistry, so the request-graph /metrics scrape sees the
       // observes made from the instrumentation-graph detector loop.
@@ -506,7 +556,7 @@ const labeledHistogram = registerInstrumentationMetric(
       name: PROM_PREFIX + 'eventloop_longtask_labeled_duration_seconds',
       help: 'Per-resource (async_hooks-attributed) synchronous event-loop blocks over threshold, by tRPC-procedure/route label. SEPARATE attribution view — only present when EVENTLOOP_LONGTASK_LABELS is armed. Does NOT sum to eventloop_longtask_duration_seconds (the loop-level drift total); it is "which routes contributed long single-callback blocks", not total blocked time.',
       labelNames: ['label'] as const,
-      buckets: [0.05, 0.1, 0.25, 0.5, 1, 2, 5, 10],
+      buckets: [...LONGTASK_DURATION_BUCKETS],
       registers: [instrumentationRegistry],
     })
 );


### PR DESCRIPTION
## What

Extend the shared duration buckets on the event-loop long-task histograms.

| | buckets (seconds) |
|---|---|
| **before** | `[0.05, 0.1, 0.25, 0.5, 1, 2, 5, 10]` |
| **after** | `[0.05, 0.1, 0.25, 0.5, 1, 2, 5, 10, 20, 30]` |

Applies to both `civitai_app_eventloop_longtask_duration_seconds` (the drift / unlabelled family — the one that emits in production) and `civitai_app_eventloop_longtask_labeled_duration_seconds` (the opt-in async_hooks attribution family, currently off). They already shared an identical literal; this hoists it into one exported constant, `LONGTASK_DURATION_BUCKETS`.

## Why

A companion infrastructure change raised the suspension cap (`EVENTLOOP_LONGTASK_SUSPEND_MS`) from its 5 s default to 30 s across the production deployment. `classifyDrift` reclassifies any gap at or above the cap as `suspension` and skips the histogram entirely, so under the old 5 s cap every block over 5 s was discarded into a bare counter and never reached a duration histogram at all. Raising the cap un-censors that class.

But with the top finite bucket at 10 s, everything in the newly-admitted 10–30 s band lands in `+Inf`. `histogram_quantile()` then returns exactly the second-highest bound — it reports `10` and cannot tell an 11 s stall from a 29 s one.

Measured over a 7-day window on the production deployment (`nodejs_eventloop_lag_max_seconds`, per pod-instance):

- **1,428** pod-instances peaked in the 5–10 s band → land in `le=10`, resolvable today
- **98** pod-instances peaked in the 10–30 s band → land in `+Inf`, unresolvable — **this is what the change fixes**
- **8** pod-instances peaked **≥30 s** → classified as *suspension* and never reach the histogram at all — **still unresolvable after this change**
- observed 7 d maxima per group: 14.97 s, 18.15 s, 44.90 s, 59.73 s

⚠️ Note the last two group maxima (44.90 s, 59.73 s) sit **above** the 30 s suspension cap, so those samples never enter the histogram. This change buys resolution up to just under 30 s — **not** to ~60 s.

🔴 **Units.** These count **pod-instances by their 7 d peak**, not events. A pod with one 12 s freeze and fifty 6 s freezes counts once, in the 10–30 s band. The **event-level** split across bands is unmeasured, and was unmeasurable before the cap was raised: the previous 5 s default routed every >5 s block to a bare counter carrying no duration, so the duration histogram holds **zero** observations above 5 s for any window predating that change. Re-derive the event split from the histogram after a few days of post-cap data rather than reading ~6.4 % as an event fraction.

So ~6.4 % of pod-instances — and specifically the most severe tail — has no duration resolution. This is a resolution gap, not a total blind spot: `_sum` and `_count` are exact regardless of bucket layout, and the structured log line already carries an exact `durationMs`.

## Why the ceiling is exactly 30, not higher

The cap and the top bucket are **coupled in both directions**, and this PR makes that explicit rather than implicit:

- **Top bucket below the cap** → the tail between them collapses into `+Inf` (the bug being fixed).
- **Top bucket above the cap** → it can *never* be observed. Anything at or above the cap is classified `suspension` and never reaches `.observe()`, so a `60` bucket would be a permanently-empty series — pure cardinality cost for zero information.

Hence: **top finite bucket == the highest cap we intend to run.** A new exported `LONGTASK_MAX_SUPPORTED_SUSPEND_CAP_MS = 30_000` records that intent and the doc comment on `resolveSuspendCapMs` points at it.

🔴 **Correction — an earlier revision of this body overstated the guard.** It claimed "raising the deployed cap again without adding buckets fails CI". That is only true for someone editing the constant *in this repo*. The realistic path is different and this repo cannot see it:

- `LONGTASK_MAX_SUPPORTED_SUSPEND_CAP_MS` has **zero runtime references** — `resolveSuspendCapMs()` never consults it, so it clamps nothing. The in-repo test compares two in-source constants to each other.
- The cap is actually set by an env var in the infrastructure repo, and **this repo's CI does not run when that env changes**.

The real gate therefore lives on the infrastructure side, where a companion change pins its own ceiling to this file's top finite bucket (previously 120 s, which would have permitted a cap no bucket could cover). Treat the constant here as **recorded intent**, not an enforced guard.

## Cardinality

Each added bucket is one extra time series per label combination per process. Two buckets added:

| family | label combos in prod | series added per process | processes | total |
|---|---|---|---|---|
| `..._duration_seconds` (drift) | **1** — `label` is the constant `'unlabeled'`; the drift timer runs outside any request's ALS scope, so `recordDrift` hardcodes it | +2 | ~165 | **+330** |
| `..._labeled_duration_seconds` | n/a — requires `EVENTLOOP_LONGTASK_LABELS=true`, off in production | +2 × (procedure/route enum) | 0 emitting | **0 today** |

**~330 new active series.** Small in absolute terms — but stating the real number rather than hand-waving: if the labels tier is ever armed for a measurement window, the second row is the one to watch, since it multiplies by the tRPC-procedure/route enum, not by 1.

## ⚠️ Bucket changes are not retroactive — do not read the discontinuity as a regression

Prometheus does not rewrite existing series. Processes started before this deploys keep emitting the **old** `le` set; new ones emit the new set. During the rollout the two layouts coexist, and:

- `histogram_quantile()` over a window that spans the deploy mixes bucket layouts and **is not valid** — expect it to look unstable until every process has restarted.
- The `le="20"` and `le="30"` series simply do not exist for older processes; that is absence, not zero.
- `_sum` and `_count` are unaffected in both directions and remain the safe cross-boundary comparison.

Any dashboard panel or alert doing quantile math on this histogram should be treated as untrustworthy for the duration of the rollout window.

## Tests

Existing coverage lives in `src/server/__tests__/eventloop-longtask-metrics.test.ts` (plus `-arm`, `-labels`, and the base file). **Nothing previously asserted the bucket array**, so nothing needed updating — this adds a new `describe` block with four guards:

1. top finite bucket ≥ the highest supported cap (the actual bug this PR fixes)
2. top finite bucket ≤ the cap (no permanently-empty bucket)
3. bounds are strictly ascending
4. end-to-end: a 15 s block is classified as a block under the 30 s cap and lands in a real `le="20"` bucket rather than only `+Inf`

Each failure message carries the rationale, so a future cap change reads as an instruction rather than a puzzle.

All four are **mutation-verified** — deliberately broken, observed failing, reverted. Real output:

Reverting the buckets to the old `[…, 5, 10]` (guards 1 and 4):

```
AssertionError: Top finite histogram bucket is 10s but the highest supported
EVENTLOOP_LONGTASK_SUSPEND_MS is 30000ms (30s). Blocks between the top bucket and
the cap ARE recorded, but they all land in the +Inf bucket, so histogram_quantile()
reports exactly the top bound and cannot distinguish them. If the deployed cap was
raised, add the matching buckets to LONGTASK_DURATION_BUCKETS in the same change.:
expected 10 to be greater than or equal to 30

AssertionError: expected an le="20" bucket series in:
… civitai_app_eventloop_longtask_duration_seconds_bucket{le="10",label="unlabeled"} 6
  civitai_app_eventloop_longtask_duration_seconds_bucket{le="+Inf",label="unlabeled"} 7
: expected null not to be null

Tests  2 failed | 11 passed (13)
```

Adding a `60` bucket above the cap (guard 2):

```
AssertionError: Bucket 60s is above the suspension cap 30s. classifyDrift
reclassifies any gap at or above the cap as `suspension` and skips the histogram,
so a bucket above the cap is a permanently-empty series — pure cardinality cost.
Either lower the bucket or raise LONGTASK_MAX_SUPPORTED_SUSPEND_CAP_MS to match
the deployed cap.: expected 60 to be less than or equal to 30

Tests  1 failed | 12 passed (13)
```

Swapping two bounds out of order (guard 3):

```
AssertionError: Bucket bounds must be strictly ascending; index 8 (20) is not
greater than index 7 (30).: expected 20 to be greater than 30

Tests  1 failed | 12 passed (13)
```

Restored, the whole eventloop-longtask suite is green:

```
$ npx vitest run --project unit src/server/__tests__/eventloop-longtask*.test.ts
 ✓ src/server/__tests__/eventloop-longtask.test.ts (12 tests)
 ✓ src/server/__tests__/eventloop-longtask-arm.test.ts (7 tests)
 ✓ src/server/__tests__/eventloop-longtask-metrics.test.ts (13 tests)
 ✓ src/server/__tests__/eventloop-longtask-labels.test.ts (15 tests)

 Test Files  4 passed (4)
      Tests  47 passed (47)
```

`prettier --check` is clean on both changed files. (`eslint` crashes with a `@typescript-eslint/consistent-type-imports` internal `TypeError` on *any* file in `src/server/__tests__/` — reproduced on untouched sibling test files at `origin/main`, so it is pre-existing and unrelated.)

### Typecheck — partial, stated honestly

`NODE_OPTIONS=--max_old_space_size=8192 npx tsc --noEmit` reports **16 errors, none in the changed files**. All 16 are pre-existing environment artifacts of the throwaway worktree used here, not regressions: 4 × `Cannot find module 'kysely'` (workspace sub-package `node_modules` not installed in the worktree) and 12 in `image.service.ts` / `bitdex-stats.ts` from an absent sibling `event-engine-common` directory. Neither `eventloop-longtask.ts` nor its test file produces a diagnostic.

**I did not run a full `next build`** — it is slow and I did not complete one, so I am not claiming build-level type confidence beyond the `tsc --noEmit` above.

## Risk

Instrumentation-only. No behaviour change to request handling and no new code on the hot path — the change is two extra numbers in a histogram bucket array, plus doc comments and tests. Fully reversible by reverting the constant. The one operational caveat to carry forward is the non-retroactivity note above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

