### PR TITLE
feat(app-blocks): idempotent block generation + tip (Batch D money slice)

### DIFF
--- a/packages/civitai-redis/src/client.ts
+++ b/packages/civitai-redis/src/client.ts
@@ -1624,6 +1624,21 @@ export const REDIS_SYS_KEYS = {
     // each tip amount pre-transaction (reserve-and-refund), TTL set on first write.
     TIP_CAP: 'system:blocks:tip-cap',
     /**
+     * Idempotency record for the block TIP endpoint (`POST /api/v1/blocks/tip`),
+     * keyed `system:blocks:tip-idem:${userId}:${clientIdempotencyKey}`. A tip
+     * moves REAL Buzz to a third party and is IRREVERSIBLE, so a timeout /
+     * lost-response retry that re-POSTs the same logical tip must NOT move money
+     * twice. The endpoint claims this key with `SET NX` before it reserves/charges;
+     * a replay that finds it set either (a) replays the cached TERMINAL result
+     * (200/4xx/5xx) verbatim — no second reserve, no second charge — or (b) gets a
+     * 409 while the first attempt is still in flight. DISTINCT from TIP_CAP (the
+     * daily-aggregate cap): this dedupes a SINGLE logical tip across retries;
+     * TIP_CAP bounds the day's total. Short TTL (covers realistic retry windows);
+     * a genuinely-new tip uses a fresh client key. On `sysRedis`, like the sibling
+     * BLOCKS caps/limiters; fail-CLOSED on a redis error at claim time (money path).
+     */
+    TIP_IDEM: 'system:blocks:tip-idem',
+    /**
      * Per-APP cumulative spend-BOUNTY accrual cap counter (audit 🟡-2 / the
      * App-Blocks Sybil-economics review). DISTINCT from BUZZ_CAP: that one
      * bounds a single USER's daily Buzz SPEND; this one bounds the daily

--- a/packages/civitai-redis/src/client.ts
+++ b/packages/civitai-redis/src/client.ts
@@ -1639,6 +1639,25 @@ export const REDIS_SYS_KEYS = {
      */
     TIP_IDEM: 'system:blocks:tip-idem',
     /**
+     * Idempotency record for the block GENERATION submit (`blocks.submitWorkflow`
+     * — both the txt2img and customComfy branches), keyed
+     * `system:blocks:gen-idem:${userId}:${appBlockId}:${clientIdempotencyKey}`. A
+     * generation submit RESERVES the viewer's daily/per-app Buzz cap and SUBMITS to
+     * the orchestrator (a real charge), so two CONCURRENT same-key submits (a
+     * double-click / SDK auto-retry racing before the orchestrator's own
+     * `(userId, externalId)` dedupe engages) could otherwise BOTH reserve and BOTH
+     * charge. The handler `SET NX`-claims this key BEFORE the cap reservation; a
+     * concurrent submit that finds it in-progress gets a 409 (no 2nd reservation,
+     * no 2nd orchestrator submit), and a lost-response retry AFTER success replays
+     * the cached snapshot (no re-submit). DISTINCT from BUZZ_CAP (the daily-spend
+     * counter) and from TIP_IDEM (the tip endpoint's dedupe): this dedupes ONE
+     * logical generation across retries. Per-(user, app, key) so a key can never
+     * collide across apps or users. Short TTL (covers realistic retry windows); a
+     * genuinely-new generation uses a fresh client key. On `sysRedis`, like the
+     * sibling BLOCKS caps; fail-CLOSED on a redis error at claim time (money path).
+     */
+    GEN_IDEM: 'system:blocks:gen-idem',
+    /**
      * Per-APP cumulative spend-BOUNTY accrual cap counter (audit 🟡-2 / the
      * App-Blocks Sybil-economics review). DISTINCT from BUZZ_CAP: that one
      * bounds a single USER's daily Buzz SPEND; this one bounds the daily

--- a/src/components/AppBlocks/IframeHost.tsx
+++ b/src/components/AppBlocks/IframeHost.tsx
@@ -983,16 +983,26 @@ export function IframeHost({
   const getMyBuzzBalanceMutation = trpc.blocks.getMyBuzzBalance.useMutation();
 
   useEffect(() => {
-    const off = onMessage<{ requestId?: unknown; body?: unknown } | undefined>(
+    const off = onMessage<
+      { requestId?: unknown; body?: unknown; idempotencyKey?: unknown } | undefined
+    >(
       'SUBMIT_WORKFLOW',
       async (raw) => {
         if (!raw || typeof raw.requestId !== 'string') return;
         const requestId = raw.requestId;
+        // Idempotency (item 2, gen half): forward the OPTIONAL client key so a
+        // lost-response retry collapses to one Buzz charge. Host-first: accept it
+        // defensively (only a non-empty string) — older SDKs never send it.
+        const idempotencyKey =
+          typeof raw.idempotencyKey === 'string' && raw.idempotencyKey.length > 0
+            ? raw.idempotencyKey
+            : undefined;
         try {
           const { snapshot } = await submitWorkflowMutation.mutateAsync({
             blockToken: token,
             // Schema-validated server-side; the host never trusts this shape.
             body: raw.body as never,
+            ...(idempotencyKey ? { idempotencyKey } : {}),
           });
           send('WORKFLOW_SUBMITTED', { requestId, snapshot });
         } catch (err) {

--- a/src/components/AppBlocks/PageBlockHost.tsx
+++ b/src/components/AppBlocks/PageBlockHost.tsx
@@ -723,7 +723,9 @@ export function PageBlockHost({
 
   // SUBMIT_WORKFLOW → blocks.submitWorkflow → WORKFLOW_SUBMITTED.
   useEffect(() => {
-    const off = onMessage<{ requestId?: unknown; body?: unknown } | undefined>(
+    const off = onMessage<
+      { requestId?: unknown; body?: unknown; idempotencyKey?: unknown } | undefined
+    >(
       'SUBMIT_WORKFLOW',
       async (raw) => {
         if (reviewNack) {
@@ -739,11 +741,20 @@ export function PageBlockHost({
         }
         if (!raw || typeof raw.requestId !== 'string' || !token) return;
         const requestId = raw.requestId;
+        // Idempotency (item 2, gen half): forward the OPTIONAL client key to the
+        // server so a lost-response retry collapses to one Buzz charge. Host-first:
+        // accept it defensively (only when a non-empty string) so older SDKs that
+        // never send it are unaffected and a garbage value is ignored.
+        const idempotencyKey =
+          typeof raw.idempotencyKey === 'string' && raw.idempotencyKey.length > 0
+            ? raw.idempotencyKey
+            : undefined;
         try {
           const { snapshot } = await submitWorkflowMutation.mutateAsync({
             blockToken: token,
             // Schema-validated server-side; the host never trusts this shape.
             body: raw.body as never,
+            ...(idempotencyKey ? { idempotencyKey } : {}),
           });
           send('WORKFLOW_SUBMITTED', { requestId, snapshot });
         } catch (err) {

--- a/src/pages/api/v1/blocks/tip-allowance.ts
+++ b/src/pages/api/v1/blocks/tip-allowance.ts
@@ -7,6 +7,7 @@ import {
   type BlockScopedNextApiRequest,
 } from '~/server/middleware/block-scope.middleware';
 import { readBlockTipAllowance } from '~/server/utils/block-tip-rate-limit';
+import { checkBlockCatalogRateLimit } from '~/server/utils/block-catalog-rate-limit';
 
 /**
  * GET /api/v1/blocks/tip-allowance — scope `social:tip:self`.
@@ -30,6 +31,9 @@ import { readBlockTipAllowance } from '~/server/utils/block-tip-rate-limit';
  *
  * CORS: withBlockScope + allowOpaqueOrigin (an unverified block direct-fetches
  * this from `Origin: null`; the Bearer block-JWT is the sole authz gate).
+ *
+ * RATE LIMITED per blockInstanceId, consistent with the sibling blocks REST reads
+ * (`models.ts` / `images.ts`) — see the call site below.
  */
 const baseHandler = withAxiom(async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'GET') {
@@ -55,6 +59,21 @@ const baseHandler = withAxiom(async function handler(req: NextApiRequest, res: N
   }
   if (subjectUserId == null) {
     res.status(403).json({ error: 'Anonymous block tokens have no tip allowance' });
+    return;
+  }
+
+  // Per-instance rate limit (audit 🟡-4). Every sibling blocks REST read limits
+  // itself (`models.ts`, `images.ts`) and this one did not — yet it is DESIGNED to
+  // be live-polled (a block refreshing its remaining allowance), and each call is a
+  // `sysRedis` GET on the same instance that backs the money caps. Uses the SAME
+  // `checkBlockCatalogRateLimit` bucket + posture as the siblings (120/10s per
+  // blockInstanceId, fail-OPEN) rather than inventing a bucket: the ceiling is far
+  // above any legitimate poll rate, and a 429 here is benign (the block falls back
+  // to a stale allowance; the ENFORCING reserve on the tip path is unaffected).
+  const rateLimit = await checkBlockCatalogRateLimit(claims.blockInstanceId);
+  if (!rateLimit.allowed) {
+    res.setHeader('Retry-After', String(rateLimit.retryAfterSeconds));
+    res.status(429).json({ error: 'Rate limit exceeded, please retry shortly.' });
     return;
   }
 

--- a/src/pages/api/v1/blocks/tip-allowance.ts
+++ b/src/pages/api/v1/blocks/tip-allowance.ts
@@ -1,0 +1,77 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { withAxiom } from '@civitai/next-axiom';
+
+import {
+  parseSubjectUserId,
+  withBlockScope,
+  type BlockScopedNextApiRequest,
+} from '~/server/middleware/block-scope.middleware';
+import { readBlockTipAllowance } from '~/server/utils/block-tip-rate-limit';
+
+/**
+ * GET /api/v1/blocks/tip-allowance — scope `social:tip:self`.
+ *
+ * Returns the viewer's CURRENT daily tip allowance `{ cap, spent, remaining }`
+ * from the SAME authoritative `tip-cap` Redis counter the tip endpoint's
+ * reserve/refund path mutates (BLOCK_TIP_CAP_PER_DAY). This lets a block show a
+ * genuinely-tracked remaining allowance and disable the tip button at the true
+ * ceiling — instead of the dead client-side full-cap guess (`localStorage` is
+ * inert in the opaque-origin sandbox).
+ *
+ * Reuses the `social:tip:self` scope the app already holds to tip (no new scope /
+ * manifest change). Self-bound: the subject is the verified token subject; anon
+ * tokens are rejected (there is no "self" allowance to read). `spent` is
+ * reservation-based (net-committed-today) so it can briefly over-count between a
+ * reserve and its refund — the SAFE direction (under-reports `remaining`).
+ *
+ * FAIL-CLOSED on a redis error (503) — consistent with the reserve path; a
+ * fabricated full allowance on a blip would invite tipping past a ceiling the
+ * enforcing reserve then rejects.
+ *
+ * CORS: withBlockScope + allowOpaqueOrigin (an unverified block direct-fetches
+ * this from `Origin: null`; the Bearer block-JWT is the sole authz gate).
+ */
+const baseHandler = withAxiom(async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  if (req.method !== 'GET') {
+    res.setHeader('Allow', 'GET');
+    res.status(405).json({ error: 'Method not allowed' });
+    return;
+  }
+
+  const claims = (req as BlockScopedNextApiRequest).blockClaims;
+  if (!claims) {
+    // withBlockScope only invokes this handler with a valid block JWT; defense
+    // in depth.
+    res.status(401).json({ error: 'Block token required' });
+    return;
+  }
+
+  let subjectUserId: number | null;
+  try {
+    subjectUserId = parseSubjectUserId(claims.sub);
+  } catch {
+    res.status(403).json({ error: 'Invalid subject claim' });
+    return;
+  }
+  if (subjectUserId == null) {
+    res.status(403).json({ error: 'Anonymous block tokens have no tip allowance' });
+    return;
+  }
+
+  try {
+    const allowance = await readBlockTipAllowance(subjectUserId);
+    res.status(200).json(allowance);
+  } catch {
+    // Fail-CLOSED (redis error) → retryable 503, mirroring the reserve path.
+    res.status(503).json({ error: 'Tip allowance unavailable; please retry' });
+  }
+});
+
+export default withBlockScope(baseHandler, {
+  endpoint: 'tip_allowance',
+  requiredScope: 'social:tip:self',
+  allowOpaqueOrigin: true,
+});

--- a/src/pages/api/v1/blocks/tip-allowance.ts
+++ b/src/pages/api/v1/blocks/tip-allowance.ts
@@ -31,10 +31,7 @@ import { readBlockTipAllowance } from '~/server/utils/block-tip-rate-limit';
  * CORS: withBlockScope + allowOpaqueOrigin (an unverified block direct-fetches
  * this from `Origin: null`; the Bearer block-JWT is the sole authz gate).
  */
-const baseHandler = withAxiom(async function handler(
-  req: NextApiRequest,
-  res: NextApiResponse
-) {
+const baseHandler = withAxiom(async function handler(req: NextApiRequest, res: NextApiResponse) {
   if (req.method !== 'GET') {
     res.setHeader('Allow', 'GET');
     res.status(405).json({ error: 'Method not allowed' });

--- a/src/pages/api/v1/blocks/tip.ts
+++ b/src/pages/api/v1/blocks/tip.ts
@@ -25,6 +25,7 @@ import {
   releaseTipIdempotency,
   reserveBlockTipSpend,
 } from '~/server/utils/block-tip-rate-limit';
+import { BLOCK_IDEMPOTENCY_KEY_REGEX } from '~/server/utils/block-gen-idempotency';
 
 /**
  * POST /api/v1/blocks/tip
@@ -66,9 +67,12 @@ const bodySchema = z.object({
   entityType: z.enum(['Image', 'Collection', 'User']).optional(),
   entityId: z.number().int().positive().optional(),
   // OPTIONAL client idempotency key — a stable id the block reuses across its own
-  // retry of the SAME logical tip. Absent → no dedupe (today's behavior). Bounded
-  // so it can't bloat the redis key; the block SDK generates a `crypto.randomUUID`.
-  idempotencyKey: z.string().min(1).max(200).optional(),
+  // retry of the SAME logical tip. Absent → no dedupe (today's behavior). Charset-
+  // restricted to a UUID-ish alphabet (audit 🟢) so no control chars / newlines /
+  // colons flow into the ledger `externalTransactionId` derived from it, and length
+  // bounded so it can't bloat the redis key; the block SDK generates a
+  // `crypto.randomUUID` (or `idem-<base36>` fallback), both of which match.
+  idempotencyKey: z.string().regex(BLOCK_IDEMPOTENCY_KEY_REGEX).optional(),
 });
 
 /** A terminal HTTP outcome from the tip attempt. `transient` outcomes (429/503) are
@@ -210,6 +214,12 @@ export const baseHandler = withAxiom(async function handler(
           entityId,
         },
         ctx,
+        // Ledger-backed idempotency (audit 🟡-1): derive the tip's
+        // `externalTransactionId` from the client key so a retry after the Redis
+        // sentinel expired (a crash between charge and finalize) collides on the
+        // Buzz ledger's unique constraint = money moves once. The Redis sentinel
+        // above stays the fast-path; this is the authoritative second layer.
+        idempotencyKey,
       });
 
       // W13 richer audit detail — stash a structured ref so the middleware

--- a/src/pages/api/v1/blocks/tip.ts
+++ b/src/pages/api/v1/blocks/tip.ts
@@ -19,13 +19,17 @@ import {
   BLOCK_TIP_CAP_PER_DAY,
   BLOCK_TIP_MAX_PER_TIP,
   checkBlockTipRateLimit,
+  claimTipIdempotency,
+  finalizeTipIdempotency,
   refundBlockTipSpend,
+  releaseTipIdempotency,
   reserveBlockTipSpend,
 } from '~/server/utils/block-tip-rate-limit';
 
 /**
  * POST /api/v1/blocks/tip
- * Body `{ toUserId, amount, entityType?, entityId? }` — scope `social:tip:self`.
+ * Body `{ toUserId, amount, entityType?, entityId?, idempotencyKey? }` — scope
+ * `social:tip:self`.
  *
  * Sends a Buzz TIP from the token SUBJECT to `toUserId`. Reuses the real
  * money-moving flow `createBuzzTipTransactionHandler` (NOT the low-level
@@ -45,6 +49,12 @@ import {
  * `buzzBudget` + `BLOCK_BUZZ_CAP_PER_DAY` pair. Those caps are what let
  * `social:tip:self` come off PAGE_FORBIDDEN_SCOPES (a page tip is now bounded, no
  * longer effectively-unbounded spend). Over either cap → clean 4xx (never a 500).
+ *
+ * IDEMPOTENCY (item 2, tip half): a tip is IRREVERSIBLE, so an OPTIONAL
+ * client-generated `idempotencyKey` (stable across a lost-response / timeout
+ * retry) collapses a replay to the FIRST terminal result — no second reserve, no
+ * second charge. Absent key → today's behavior (no dedupe). The claim is fail-
+ * CLOSED (a redis error at claim time → 503), consistent with the tip-cap posture.
  */
 
 export const config = { api: { bodyParser: { sizeLimit: '4kb' } } };
@@ -55,7 +65,15 @@ const bodySchema = z.object({
   amount: z.number().int().positive().max(BLOCK_TIP_MAX_PER_TIP),
   entityType: z.enum(['Image', 'Collection', 'User']).optional(),
   entityId: z.number().int().positive().optional(),
+  // OPTIONAL client idempotency key — a stable id the block reuses across its own
+  // retry of the SAME logical tip. Absent → no dedupe (today's behavior). Bounded
+  // so it can't bloat the redis key; the block SDK generates a `crypto.randomUUID`.
+  idempotencyKey: z.string().min(1).max(200).optional(),
 });
+
+/** A terminal HTTP outcome from the tip attempt. `transient` outcomes (429/503) are
+ *  NOT cached under the idempotency key — a genuine retry may re-execute them. */
+type TipOutcome = { status: number; body: unknown; transient?: boolean };
 
 // Exported for unit testing (the default export is wrapped in withBlockScope,
 // whose JWT gate would otherwise have to be satisfied to reach this handler).
@@ -92,7 +110,7 @@ export const baseHandler = withAxiom(async function handler(
     res.status(400).json({ error: 'Invalid request body', details: parsed.error.flatten() });
     return;
   }
-  const { toUserId, amount, entityType, entityId } = parsed.data;
+  const { toUserId, amount, entityType, entityId, idempotencyKey } = parsed.data;
 
   // entityType/entityId must be supplied together (both or neither).
   if ((entityType && !entityId) || (!entityType && entityId)) {
@@ -121,126 +139,181 @@ export const baseHandler = withAxiom(async function handler(
     return;
   }
 
-  // Per-instance rate limit (fail-CLOSED on redis error — money path).
-  const rateLimit = await checkBlockTipRateLimit(claims.blockInstanceId);
-  if (!rateLimit.allowed) {
-    res.setHeader('Retry-After', String(rateLimit.retryAfterSeconds));
-    res.status(429).json({ error: 'Too many tips — please retry shortly.' });
-    return;
-  }
+  // ── The money attempt (rate-limit → reserve → charge). Returns a terminal
+  //    outcome instead of writing `res` directly, so the idempotency wrapper can
+  //    CACHE it (replay a lost-response retry) or RELEASE it (a transient 429/503
+  //    may be retried). `subjectUserId` is non-null here (guarded above).
+  const subjectId = subjectUserId;
+  const attemptTip = async (): Promise<TipOutcome> => {
+    // Per-instance rate limit (fail-CLOSED on redis error — money path).
+    const rateLimit = await checkBlockTipRateLimit(claims.blockInstanceId);
+    if (!rateLimit.allowed) {
+      // TRANSIENT: a rate-limited attempt moved no money — a retry once the window
+      // clears must be allowed to execute, so this is NOT cached under the idem key.
+      res.setHeader('Retry-After', String(rateLimit.retryAfterSeconds));
+      return { status: 429, body: { error: 'Too many tips — please retry shortly.' }, transient: true };
+    }
 
-  const subjectUser = await hydrateBlockSubject(subjectUserId);
-  if (!subjectUser) {
-    res.status(404).json({ error: 'User not found' });
-    return;
-  }
-  if (subjectUser.bannedAt) {
-    res.status(403).json({ error: 'banned' });
-    return;
-  }
-  if (subjectUser.muted) {
-    res.status(403).json({ error: 'Your account is restricted' });
-    return;
-  }
+    const subjectUser = await hydrateBlockSubject(subjectId);
+    if (!subjectUser) {
+      return { status: 404, body: { error: 'User not found' } };
+    }
+    if (subjectUser.bannedAt) {
+      return { status: 403, body: { error: 'banned' } };
+    }
+    if (subjectUser.muted) {
+      return { status: 403, body: { error: 'Your account is restricted' } };
+    }
 
-  // PER-USER DAILY CAP — atomically RESERVE this tip against the user's UTC-day
-  // aggregate BEFORE the money moves. Fail-CLOSED on a redis error (503). Over the
-  // daily cap → refund the reservation + clean 400. The reservation stands only if
-  // the tip transaction below resolves; any throw refunds it.
-  let capKey: Awaited<ReturnType<typeof reserveBlockTipSpend>>['key'];
-  try {
-    const reserved = await reserveBlockTipSpend(subjectUserId, amount);
-    capKey = reserved.key;
-    if (reserved.total > BLOCK_TIP_CAP_PER_DAY) {
-      await refundBlockTipSpend(capKey, amount);
-      res.status(400).json({
-        error: `Daily tip limit reached (${BLOCK_TIP_CAP_PER_DAY} Buzz). Try again tomorrow.`,
+    // PER-USER DAILY CAP — atomically RESERVE this tip against the user's UTC-day
+    // aggregate BEFORE the money moves. Fail-CLOSED on a redis error (503). Over the
+    // daily cap → refund the reservation + clean 400. The reservation stands only if
+    // the tip transaction below resolves; any throw refunds it.
+    let capKey: Awaited<ReturnType<typeof reserveBlockTipSpend>>['key'];
+    try {
+      const reserved = await reserveBlockTipSpend(subjectId, amount);
+      capKey = reserved.key;
+      if (reserved.total > BLOCK_TIP_CAP_PER_DAY) {
+        await refundBlockTipSpend(capKey, amount);
+        return {
+          status: 400,
+          body: {
+            error: `Daily tip limit reached (${BLOCK_TIP_CAP_PER_DAY} Buzz). Try again tomorrow.`,
+          },
+        };
+      }
+    } catch {
+      // TRANSIENT: the limiter is unavailable — a retry once redis recovers must be
+      // allowed to execute, so this 503 is NOT cached under the idem key.
+      return { status: 503, body: { error: 'Tip limiter unavailable; please retry' }, transient: true };
+    }
+
+    // Build a minimal ProtectedContext for the controller (it reads ctx.user +
+    // ctx.track). The sender is ALWAYS the verified subject — never body input.
+    const ctx = {
+      user: subjectUser,
+      track: new Tracker(req, res),
+      ip: '',
+      cache: null,
+      req,
+      res,
+    } as unknown as ProtectedContext;
+
+    try {
+      await createBuzzTipTransactionHandler({
+        input: {
+          toAccountId: toUserId,
+          amount,
+          fromAccountType: 'yellow',
+          toAccountType: 'yellow',
+          entityType,
+          entityId,
+        },
+        ctx,
       });
+
+      // W13 richer audit detail — stash a structured ref so the middleware
+      // finish-writer records "Tipped N Buzz to @recipient" (the view resolves
+      // toUserId → @username). Best-effort: `amount` is positive here (a credit TO
+      // the recipient).
+      //
+      // 🔴 The ENTIRE enrichment (detail construction AND the stash call) is wrapped
+      // in a swallow-everything try/catch so it can NEVER change this endpoint's
+      // outcome. A successful tip ALWAYS returns its real 200 even if enrichment
+      // throws — a missing/undefined stash export, a null-deref building the detail,
+      // or a non-writable `res` all no-op the audit row, they do not 500 a tip whose
+      // money already moved. (Regression: #3161's stash sat inside the money-path try
+      // and a throw at the call site surfaced as a 500 on the happy path.)
+      try {
+        stashBlockActionDetail(res, {
+          action: 'tip',
+          amount,
+          toUserId,
+          ...(entityType ? { entityType } : {}),
+          ...(entityId ? { entityId } : {}),
+          outcome: 'ok',
+        });
+      } catch {
+        /* audit enrichment is best-effort — it must never perturb the money path */
+      }
+
+      return {
+        status: 200,
+        body: {
+          ok: true,
+          tip: { toUserId, amount, entityType: entityType ?? null, entityId: entityId ?? null },
+        },
+      };
+    } catch (error) {
+      const trpcError = error as TRPCError;
+      const statusCode =
+        typeof trpcError?.code === 'string' ? getHTTPStatusCodeFromError(trpcError) : 500;
+
+      // REFUND ONLY ON A KNOWN-PRE-MONEY FAILURE. In createBuzzTipTransactionHandler
+      // the money moves at `createBuzzTransactionMany`; EVERY guard that runs before
+      // it (self-tip, banned/blocked target, 24h age, and the balance pre-check →
+      // insufficient funds) throws BAD_REQUEST — i.e. a 4xx GUARANTEES no Buzz left
+      // the sender, so the reservation must be refunded. A 5xx (or a non-TRPC throw)
+      // may originate AFTER the money moved (upsertBuzzTip / notification / metric),
+      // so we must NOT refund it — keeping the reservation only makes the daily cap
+      // STRICTER (the safe direction), never lets a real spend escape the ceiling.
+      // (Fixes the latent cap-bypass where a post-money throw refunded the cap and
+      // let the daily total under-count past the ceiling.)
+      if (statusCode >= 400 && statusCode < 500) {
+        await refundBlockTipSpend(capKey, amount);
+      }
+
+      // A 5xx is TERMINAL for idempotency (it may be a post-money failure) — caching
+      // it means a lost-response retry replays the 5xx rather than re-attempting a
+      // charge whose first pass may already have moved money.
+      return {
+        status: statusCode,
+        body: { ok: false, error: trpcError?.message ?? 'Failed to send tip' },
+      };
+    }
+  };
+
+  // ── IDEMPOTENCY WRAPPER (item 2, tip half). Absent key → run once, today's
+  //    behavior. Present key → claim-or-replay; finalize a terminal outcome so a
+  //    lost-response retry replays it, release a transient one so it can re-run.
+  if (idempotencyKey) {
+    let claim: Awaited<ReturnType<typeof claimTipIdempotency>>;
+    try {
+      claim = await claimTipIdempotency(subjectId, idempotencyKey);
+    } catch {
+      // Fail-CLOSED: a redis error at claim time → 503 (money endpoint must not
+      // dedupe blind), consistent with the reserve path.
+      res.status(503).json({ error: 'Tip idempotency unavailable; please retry' });
       return;
     }
-  } catch {
-    res.status(503).json({ error: 'Tip limiter unavailable; please retry' });
+
+    if (claim.state === 'replay') {
+      // A prior attempt already produced a terminal result — replay it VERBATIM.
+      // No second reserve, no second charge.
+      res.status(claim.status).json(claim.body);
+      return;
+    }
+    if (claim.state === 'in_progress') {
+      // The first attempt is still in flight (or a lost/garbage record) — never
+      // race a live first attempt into a double charge; ask the client to retry.
+      res.setHeader('Retry-After', '2');
+      res.status(409).json({ error: 'A tip with this idempotency key is already in progress' });
+      return;
+    }
+
+    // state === 'acquired' — we own the first attempt.
+    const outcome = await attemptTip();
+    if (outcome.transient) {
+      await releaseTipIdempotency(claim.key);
+    } else {
+      await finalizeTipIdempotency(claim.key, outcome.status, outcome.body);
+    }
+    res.status(outcome.status).json(outcome.body);
     return;
   }
 
-  // Build a minimal ProtectedContext for the controller (it reads ctx.user +
-  // ctx.track). The sender is ALWAYS the verified subject — never body input.
-  const ctx = {
-    user: subjectUser,
-    track: new Tracker(req, res),
-    ip: '',
-    cache: null,
-    req,
-    res,
-  } as unknown as ProtectedContext;
-
-  try {
-    await createBuzzTipTransactionHandler({
-      input: {
-        toAccountId: toUserId,
-        amount,
-        fromAccountType: 'yellow',
-        toAccountType: 'yellow',
-        entityType,
-        entityId,
-      },
-      ctx,
-    });
-
-    // W13 richer audit detail — stash a structured ref so the middleware
-    // finish-writer records "Tipped N Buzz to @recipient" (the view resolves
-    // toUserId → @username). Best-effort: `amount` is positive here (a credit TO
-    // the recipient).
-    //
-    // 🔴 The ENTIRE enrichment (detail construction AND the stash call) is wrapped
-    // in a swallow-everything try/catch so it can NEVER change this endpoint's
-    // outcome. A successful tip ALWAYS returns its real 200 even if enrichment
-    // throws — a missing/undefined stash export, a null-deref building the detail,
-    // or a non-writable `res` all no-op the audit row, they do not 500 a tip whose
-    // money already moved. (Regression: #3161's stash sat inside the money-path try
-    // and a throw at the call site surfaced as a 500 on the happy path.)
-    try {
-      stashBlockActionDetail(res, {
-        action: 'tip',
-        amount,
-        toUserId,
-        ...(entityType ? { entityType } : {}),
-        ...(entityId ? { entityId } : {}),
-        outcome: 'ok',
-      });
-    } catch {
-      /* audit enrichment is best-effort — it must never perturb the money path */
-    }
-
-    res.status(200).json({
-      ok: true,
-      tip: { toUserId, amount, entityType: entityType ?? null, entityId: entityId ?? null },
-    });
-    return;
-  } catch (error) {
-    const trpcError = error as TRPCError;
-    const statusCode =
-      typeof trpcError?.code === 'string' ? getHTTPStatusCodeFromError(trpcError) : 500;
-
-    // REFUND ONLY ON A KNOWN-PRE-MONEY FAILURE. In createBuzzTipTransactionHandler
-    // the money moves at `createBuzzTransactionMany`; EVERY guard that runs before
-    // it (self-tip, banned/blocked target, 24h age, and the balance pre-check →
-    // insufficient funds) throws BAD_REQUEST — i.e. a 4xx GUARANTEES no Buzz left
-    // the sender, so the reservation must be refunded. A 5xx (or a non-TRPC throw)
-    // may originate AFTER the money moved (upsertBuzzTip / notification / metric),
-    // so we must NOT refund it — keeping the reservation only makes the daily cap
-    // STRICTER (the safe direction), never lets a real spend escape the ceiling.
-    // (Fixes the latent cap-bypass where a post-money throw refunded the cap and
-    // let the daily total under-count past the ceiling.)
-    if (statusCode >= 400 && statusCode < 500) {
-      await refundBlockTipSpend(capKey, amount);
-    }
-
-    res
-      .status(statusCode)
-      .json({ ok: false, error: trpcError?.message ?? 'Failed to send tip' });
-    return;
-  }
+  const outcome = await attemptTip();
+  res.status(outcome.status).json(outcome.body);
 });
 
 // allowOpaqueOrigin: an UNVERIFIED block direct-fetches this from an opaque

--- a/src/pages/api/v1/blocks/tip.ts
+++ b/src/pages/api/v1/blocks/tip.ts
@@ -20,6 +20,7 @@ import {
   BLOCK_TIP_MAX_PER_TIP,
   checkBlockTipRateLimit,
   claimTipIdempotency,
+  computeTipFingerprint,
   finalizeTipIdempotency,
   refundBlockTipSpend,
   releaseTipIdempotency,
@@ -56,6 +57,18 @@ import { BLOCK_IDEMPOTENCY_KEY_REGEX } from '~/server/utils/block-gen-idempotenc
  * retry) collapses a replay to the FIRST terminal result — no second reserve, no
  * second charge. Absent key → today's behavior (no dedupe). The claim is fail-
  * CLOSED (a redis error at claim time → 503), consistent with the tip-cap posture.
+ * The claim is scoped per (user, APP, key) and pinned to a PAYLOAD FINGERPRINT:
+ *   - same key, same payload, first attempt live  → 409 (retry shortly)
+ *   - same key, same payload, terminal result     → replay it verbatim
+ *   - same key, DIFFERENT payload                 → 422 (mint a fresh key)
+ * and a throw that escapes the money attempt RELEASES the claim rather than
+ * stranding a 10-minute "already in progress" sentinel over nothing.
+ *
+ * Two layers back the dedupe. (1) The Redis sentinel above — fast path, 10-min TTL.
+ * (2) The LEDGER: the key derives the tip's `externalTransactionId`, so a retry
+ * after the sentinel expires collides on the Buzz ledger's unique constraint. That
+ * second layer reports a CONFLICT, which this endpoint uses to refund the daily-cap
+ * reservation it burned for Buzz that never moved (see `dedupedAmount` below).
  */
 
 export const config = { api: { bodyParser: { sizeLimit: '4kb' } } };
@@ -204,7 +217,7 @@ export const baseHandler = withAxiom(async function handler(
     } as unknown as ProtectedContext;
 
     try {
-      await createBuzzTipTransactionHandler({
+      const result = await createBuzzTipTransactionHandler({
         input: {
           toAccountId: toUserId,
           amount,
@@ -221,6 +234,23 @@ export const baseHandler = withAxiom(async function handler(
         // above stays the fast-path; this is the authoritative second layer.
         idempotencyKey,
       });
+
+      // ── LEDGER-DEDUPED TIP → REFUND THE CAP RESERVATION (audit 🔴-2) ──────────
+      // `dedupedAmount` is the Buzz the ledger REFUSED to move because the
+      // deterministic `externalTransactionId` already existed — i.e. this call
+      // debited that much less than we reserved above. Keeping the reservation would
+      // charge the viewer's daily tip ALLOWANCE a second time for a transfer that
+      // happened exactly once, which is not the "stricter is safer" case the refund
+      // policy in the catch below is about: there we don't know whether money moved,
+      // here the ledger has affirmatively told us it did not. Refund exactly the
+      // deduped amount (0 on every normal tip → byte-identical to today).
+      //
+      // Replay ABUSE is not what the money cap holds: a replay is already bounded by
+      // the per-instance 10-tips/60s limiter and the Redis idempotency sentinel, and
+      // it moves no Buzz.
+      if (result.dedupedAmount > 0) {
+        await refundBlockTipSpend(capKey, result.dedupedAmount);
+      }
 
       // W13 richer audit detail — stash a structured ref so the middleware
       // finish-writer records "Tipped N Buzz to @recipient" (the view resolves
@@ -287,9 +317,16 @@ export const baseHandler = withAxiom(async function handler(
   //    behavior. Present key → claim-or-replay; finalize a terminal outcome so a
   //    lost-response retry replays it, release a transient one so it can re-run.
   if (idempotencyKey) {
+    // Payload fingerprint (audit 🟡-1 residual) — pins the key to THIS request's
+    // (recipient, amount, entity) so the same key reused for a DIFFERENT tip is
+    // rejected rather than silently replaying the first tip's result.
+    const fingerprint = computeTipFingerprint({ toUserId, amount, entityType, entityId });
     let claim: Awaited<ReturnType<typeof claimTipIdempotency>>;
     try {
-      claim = await claimTipIdempotency(subjectId, idempotencyKey);
+      // Keyed per (user, APP, key) — audit 🟡-2. Without `claims.appBlockId`, two
+      // apps the same user installed that pick the same literal key value share one
+      // slot, and app B replays app A's body (learning A's recipient + amount).
+      claim = await claimTipIdempotency(subjectId, claims.appBlockId, idempotencyKey, fingerprint);
     } catch {
       // Fail-CLOSED: a redis error at claim time → 503 (money endpoint must not
       // dedupe blind), consistent with the reserve path.
@@ -297,6 +334,15 @@ export const baseHandler = withAxiom(async function handler(
       return;
     }
 
+    if (claim.state === 'mismatch') {
+      // Same key, DIFFERENT payload. Replaying the first result would tell the app a
+      // tip it never made succeeded; executing it would break the key's one-request
+      // contract. Reject (non-retryable) — the client must mint a fresh key.
+      res.status(422).json({
+        error: 'This idempotency key was already used for a different tip',
+      });
+      return;
+    }
     if (claim.state === 'replay') {
       // A prior attempt already produced a terminal result — replay it VERBATIM.
       // No second reserve, no second charge.
@@ -312,11 +358,27 @@ export const baseHandler = withAxiom(async function handler(
     }
 
     // state === 'acquired' — we own the first attempt.
-    const outcome = await attemptTip();
+    //
+    // 🔴 RELEASE ON A THROW (audit 🟡-3). `attemptTip` returns a terminal outcome for
+    // every failure it OWNS, but `hydrateBlockSubject(subjectId)` and
+    // `new Tracker(req, res)` sit outside its inner try — a throw there ESCAPES past
+    // both finalize and release. The sentinel would then survive its full 10-minute
+    // TTL and 409 every retry with "already in progress" when NOTHING is in progress,
+    // making the tip unlandable after a transient DB blip — precisely when retrying
+    // with the same key is the entire point. No money moved (the throw is upstream of
+    // the charge), so releasing is safe. The gen path already does this on its submit
+    // catch; this makes the tip path consistent.
+    let outcome: TipOutcome;
+    try {
+      outcome = await attemptTip();
+    } catch (e) {
+      await releaseTipIdempotency(claim.key);
+      throw e;
+    }
     if (outcome.transient) {
       await releaseTipIdempotency(claim.key);
     } else {
-      await finalizeTipIdempotency(claim.key, outcome.status, outcome.body);
+      await finalizeTipIdempotency(claim.key, outcome.status, outcome.body, fingerprint);
     }
     res.status(outcome.status).json(outcome.body);
     return;

--- a/src/server/controllers/__tests__/buzz.controller.tip.test.ts
+++ b/src/server/controllers/__tests__/buzz.controller.tip.test.ts
@@ -54,9 +54,15 @@ vi.mock('~/server/services/entity-collaborator.service', () => ({
   getEntityCollaborators: vi.fn(async () => []),
 }));
 vi.mock('~/server/services/image.service', () => ({ getImageById: vi.fn(async () => null) }));
-vi.mock('~/server/services/notification.service', () => ({ createNotification: vi.fn(async () => undefined) }));
-vi.mock('~/server/utils/metric-helpers', () => ({ updateEntityMetric: vi.fn(async () => undefined) }));
-vi.mock('~/server/rewards/active/dailyBoost.reward', () => ({ dailyBoostReward: { apply: vi.fn() } }));
+vi.mock('~/server/services/notification.service', () => ({
+  createNotification: vi.fn(async () => undefined),
+}));
+vi.mock('~/server/utils/metric-helpers', () => ({
+  updateEntityMetric: vi.fn(async () => undefined),
+}));
+vi.mock('~/server/rewards/active/dailyBoost.reward', () => ({
+  dailyBoostReward: { apply: vi.fn() },
+}));
 
 import { createBuzzTipTransactionHandler } from '../buzz.controller';
 
@@ -66,21 +72,19 @@ import { createBuzzTipTransactionHandler } from '../buzz.controller';
 function installLedger() {
   const moved = new Set<string>();
   let debits = 0;
-  mockCreateMany.mockImplementation(
-    async (txns: Array<{ externalTransactionId: string }>) => {
-      const transactions: string[] = [];
-      const conflicts: string[] = [];
-      for (const t of txns) {
-        if (moved.has(t.externalTransactionId)) conflicts.push(t.externalTransactionId);
-        else {
-          moved.add(t.externalTransactionId);
-          debits += 1;
-          transactions.push(`tx_${debits}`);
-        }
+  mockCreateMany.mockImplementation(async (txns: Array<{ externalTransactionId: string }>) => {
+    const transactions: string[] = [];
+    const conflicts: string[] = [];
+    for (const t of txns) {
+      if (moved.has(t.externalTransactionId)) conflicts.push(t.externalTransactionId);
+      else {
+        moved.add(t.externalTransactionId);
+        debits += 1;
+        transactions.push(`tx_${debits}`);
       }
-      return { transactions, conflicts };
     }
-  );
+    return { transactions, conflicts };
+  });
   return { debits: () => debits };
 }
 
@@ -106,10 +110,18 @@ beforeEach(() => {
 describe('createBuzzTipTransactionHandler — ledger-backed idempotency (audit 🟡-1)', () => {
   it('with a key: a same-key retry presents a DETERMINISTIC externalTransactionId → money moves ONCE', async () => {
     const ledger = installLedger();
-    await createBuzzTipTransactionHandler({ input: baseInput, ctx: ctxUser(), idempotencyKey: 'idem-abc' });
+    await createBuzzTipTransactionHandler({
+      input: baseInput,
+      ctx: ctxUser(),
+      idempotencyKey: 'idem-abc',
+    });
     // Simulate the crash window: the Redis sentinel has expired, so the endpoint
     // re-runs the handler with the SAME client key.
-    await createBuzzTipTransactionHandler({ input: baseInput, ctx: ctxUser(), idempotencyKey: 'idem-abc' });
+    await createBuzzTipTransactionHandler({
+      input: baseInput,
+      ctx: ctxUser(),
+      idempotencyKey: 'idem-abc',
+    });
 
     // 🔴 The load-bearing assertion: exactly ONE debit across the two calls — the 2nd
     // collided on the ledger's unique externalTransactionId.
@@ -121,7 +133,7 @@ describe('createBuzzTipTransactionHandler — ledger-backed idempotency (audit �
     expect(ext2).toBe(ext1);
   });
 
-  it('WITHOUT a key: each call mints a fresh uuid externalTransactionId (no ledger dedup — today\'s behavior)', async () => {
+  it("WITHOUT a key: each call mints a fresh uuid externalTransactionId (no ledger dedup — today's behavior)", async () => {
     const ledger = installLedger();
     await createBuzzTipTransactionHandler({ input: baseInput, ctx: ctxUser() });
     await createBuzzTipTransactionHandler({ input: baseInput, ctx: ctxUser() });
@@ -145,6 +157,8 @@ describe('createBuzzTipTransactionHandler — ledger-backed idempotency (audit �
     });
     // The key-derived id ignores entityType/entityId (the client key already uniquely
     // identifies the logical tip), so a retry with the same key collides regardless.
-    expect(mockCreateMany.mock.calls[0][0][0].externalTransactionId).toBe('block-tip:42:idem-xyz-5');
+    expect(mockCreateMany.mock.calls[0][0][0].externalTransactionId).toBe(
+      'block-tip:42:idem-xyz-5'
+    );
   });
 });

--- a/src/server/controllers/__tests__/buzz.controller.tip.test.ts
+++ b/src/server/controllers/__tests__/buzz.controller.tip.test.ts
@@ -54,11 +54,18 @@ vi.mock('~/server/services/entity-collaborator.service', () => ({
   getEntityCollaborators: vi.fn(async () => []),
 }));
 vi.mock('~/server/services/image.service', () => ({ getImageById: vi.fn(async () => null) }));
+
+// Hoisted so the 🔴-2 tests can assert these NON-idempotent side effects do not fire
+// for a transaction the ledger deduped.
+const { mockCreateNotification, mockUpdateEntityMetric } = vi.hoisted(() => ({
+  mockCreateNotification: vi.fn(),
+  mockUpdateEntityMetric: vi.fn(),
+}));
 vi.mock('~/server/services/notification.service', () => ({
-  createNotification: vi.fn(async () => undefined),
+  createNotification: (...a: unknown[]) => mockCreateNotification(...(a as [])),
 }));
 vi.mock('~/server/utils/metric-helpers', () => ({
-  updateEntityMetric: vi.fn(async () => undefined),
+  updateEntityMetric: (...a: unknown[]) => mockUpdateEntityMetric(...(a as [])),
 }));
 vi.mock('~/server/rewards/active/dailyBoost.reward', () => ({
   dailyBoostReward: { apply: vi.fn() },
@@ -105,6 +112,8 @@ beforeEach(() => {
   mockUserFindMany.mockResolvedValue([]); // no banned targets
   mockUserFindUnique.mockResolvedValue({ username: 'sender' });
   mockUpsertBuzzTip.mockResolvedValue(undefined);
+  mockCreateNotification.mockResolvedValue(undefined);
+  mockUpdateEntityMetric.mockResolvedValue(undefined);
 });
 
 describe('createBuzzTipTransactionHandler — ledger-backed idempotency (audit 🟡-1)', () => {
@@ -160,5 +169,109 @@ describe('createBuzzTipTransactionHandler — ledger-backed idempotency (audit �
     expect(mockCreateMany.mock.calls[0][0][0].externalTransactionId).toBe(
       'block-tip:42:idem-xyz-5'
     );
+  });
+});
+
+/**
+ * 🔴-2 — a ledger CONFLICT means the money already moved on an EARLIER call, so this
+ * call debited NOTHING. The three side effects (`upsertBuzzTip`, the `tip-received`
+ * notification, the Image Buzz metric) are all NON-idempotent, so firing them anyway
+ * credits a SECOND tip for money that moved once: a phantom tip.
+ *
+ * This state is ONLY reachable because of the deterministic `externalTransactionId`
+ * this PR introduced — with the legacy per-call `uuid()` id `conflicts` was always
+ * empty here. The prior test suite only asserted `debits() === 1`, which is exactly
+ * why the phantom side effects slipped through.
+ */
+describe('createBuzzTipTransactionHandler — ledger CONFLICT side effects (audit 🔴-2)', () => {
+  it('🔴 a deduped tip produces ZERO additional side effects (no BuzzTip row, no notification, no metric)', async () => {
+    const ledger = installLedger();
+    const input = { ...baseInput, entityType: 'Image' as const, entityId: 99 };
+
+    // First tip: money moves, side effects fire.
+    await createBuzzTipTransactionHandler({
+      input,
+      ctx: ctxUser(),
+      idempotencyKey: 'idem-dup',
+    });
+    expect(ledger.debits()).toBe(1);
+    expect(mockUpsertBuzzTip).toHaveBeenCalledTimes(1);
+    expect(mockUpdateEntityMetric).toHaveBeenCalledTimes(1);
+
+    vi.clearAllMocks();
+    mockUserFindMany.mockResolvedValue([]);
+    mockUserFindUnique.mockResolvedValue({ username: 'sender' });
+
+    // The reachable scenario from the audit: same key, same recipient, a DIFFERENT
+    // entityId (the derivation deliberately ignores the entity — see the test above),
+    // after the 10-min Redis sentinel expired. The ledger id is byte-identical → a
+    // conflict → ZERO Buzz moves. Without the fix, image 100 gets +100 Buzz, a
+    // BuzzTip row, and a 200.
+    const result = await createBuzzTipTransactionHandler({
+      input: { ...input, entityId: 100 },
+      ctx: ctxUser(),
+      idempotencyKey: 'idem-dup',
+    });
+
+    // 🔴 The load-bearing assertions: still exactly ONE debit, and NOTHING else fired.
+    expect(ledger.debits()).toBe(1);
+    expect(mockUpsertBuzzTip).not.toHaveBeenCalled();
+    expect(mockCreateNotification).not.toHaveBeenCalled();
+    expect(mockUpdateEntityMetric).not.toHaveBeenCalled();
+    // Reported up so the App Blocks tip endpoint can refund the daily-cap
+    // reservation it burned for Buzz that never moved.
+    expect(result.deduped).toBe(true);
+    expect(result.dedupedAmount).toBe(100);
+  });
+
+  it('🔴 a deduped ENTITY-LESS tip fires no `tip-received` notification (uuid key gives it no dedup)', async () => {
+    const ledger = installLedger();
+    // No entityType/entityId → the notification branch.
+    await createBuzzTipTransactionHandler({
+      input: baseInput,
+      ctx: ctxUser(),
+      idempotencyKey: 'idem-note',
+    });
+    expect(mockCreateNotification).toHaveBeenCalledTimes(1);
+
+    vi.clearAllMocks();
+    mockUserFindMany.mockResolvedValue([]);
+    mockUserFindUnique.mockResolvedValue({ username: 'sender' });
+
+    await createBuzzTipTransactionHandler({
+      input: baseInput,
+      ctx: ctxUser(),
+      idempotencyKey: 'idem-note',
+    });
+    expect(ledger.debits()).toBe(1);
+    // The notification key is `tip-received:${uuid()}` — it has NO dedup of its own,
+    // so nothing else would have stopped a second "you received a tip".
+    expect(mockCreateNotification).not.toHaveBeenCalled();
+  });
+
+  it('CONTROL: a normally-settled tip still fires every side effect and reports no dedupe', async () => {
+    installLedger();
+    const result = await createBuzzTipTransactionHandler({
+      input: { ...baseInput, entityType: 'Image' as const, entityId: 99 },
+      ctx: ctxUser(),
+      idempotencyKey: 'idem-fresh',
+    });
+    expect(mockUpsertBuzzTip).toHaveBeenCalledTimes(1);
+    expect(mockUpdateEntityMetric).toHaveBeenCalledTimes(1);
+    expect(result.deduped).toBe(false);
+    expect(result.dedupedAmount).toBe(0);
+  });
+
+  it('the metric + BuzzTip amount tracks only what SETTLED, not what was attempted', async () => {
+    installLedger();
+    await createBuzzTipTransactionHandler({
+      input: { ...baseInput, entityType: 'Image' as const, entityId: 99 },
+      ctx: ctxUser(),
+      idempotencyKey: 'idem-amt',
+    });
+    expect(mockUpdateEntityMetric).toHaveBeenCalledWith(
+      expect.objectContaining({ metricType: 'Buzz', amount: 100 })
+    );
+    expect(mockUpsertBuzzTip).toHaveBeenCalledWith(expect.objectContaining({ amount: 100 }));
   });
 });

--- a/src/server/controllers/__tests__/buzz.controller.tip.test.ts
+++ b/src/server/controllers/__tests__/buzz.controller.tip.test.ts
@@ -1,0 +1,150 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Ledger-backed idempotency for the App Blocks tip (audit 🟡-1).
+ *
+ * `createBuzzTipTransactionHandler` normally mints a fresh `uuid()` per call for the
+ * tip's `externalTransactionId`, bypassing the Buzz ledger's native idempotency (a
+ * duplicate `externalTransactionId` is a benign "money already moved" conflict). When
+ * the App Blocks tip endpoint threads a client `idempotencyKey`, the handler DERIVES
+ * the id deterministically (`block-tip:${fromUserId}:${key}-${toAccountId}`), so a
+ * retry AFTER the Redis sentinel has expired (a crash between charge and finalize)
+ * collides on the Postgres unique constraint = money moves ONCE.
+ *
+ * These tests exercise the REAL handler with a mocked `createBuzzTransactionMany`
+ * (the ledger boundary) that models the unique-constraint dedup, so the derivation +
+ * the money-moves-once property are verified for real.
+ */
+
+const { mockCreateMany, mockGetUserBuzzAccount, mockUpsertBuzzTip } = vi.hoisted(() => ({
+  mockCreateMany: vi.fn(),
+  mockGetUserBuzzAccount: vi.fn(),
+  mockUpsertBuzzTip: vi.fn(),
+}));
+
+vi.mock('~/server/services/buzz.service', () => ({
+  createBuzzTransactionMany: (...a: unknown[]) => mockCreateMany(...(a as [])),
+  getUserBuzzAccount: (...a: unknown[]) => mockGetUserBuzzAccount(...(a as [])),
+  upsertBuzzTip: (...a: unknown[]) => mockUpsertBuzzTip(...(a as [])),
+  // Unused by the tip path but imported by the controller module — stub so the
+  // module resolves without pulling the real buzz client (which connects on import).
+  completeStripeBuzzTransaction: vi.fn(),
+  getDailyCompensationRewardByUser: vi.fn(),
+  getMultipliersForUser: vi.fn(),
+  getTransactionsReport: vi.fn(),
+  getUserBuzzTransactions: vi.fn(),
+  getUserBuzzTransactionsMulti: vi.fn(),
+  previewMultiAccountTransaction: vi.fn(),
+}));
+
+const { mockUserFindMany, mockUserFindUnique } = vi.hoisted(() => ({
+  mockUserFindMany: vi.fn(),
+  mockUserFindUnique: vi.fn(),
+}));
+vi.mock('~/server/db/client', () => ({
+  dbWrite: {
+    user: {
+      findMany: (...a: unknown[]) => mockUserFindMany(...(a as [])),
+      findUnique: (...a: unknown[]) => mockUserFindUnique(...(a as [])),
+    },
+  },
+}));
+vi.mock('~/server/services/user.service', () => ({ amIBlockedByUser: vi.fn(async () => false) }));
+vi.mock('~/server/services/entity-collaborator.service', () => ({
+  getEntityCollaborators: vi.fn(async () => []),
+}));
+vi.mock('~/server/services/image.service', () => ({ getImageById: vi.fn(async () => null) }));
+vi.mock('~/server/services/notification.service', () => ({ createNotification: vi.fn(async () => undefined) }));
+vi.mock('~/server/utils/metric-helpers', () => ({ updateEntityMetric: vi.fn(async () => undefined) }));
+vi.mock('~/server/rewards/active/dailyBoost.reward', () => ({ dailyBoostReward: { apply: vi.fn() } }));
+
+import { createBuzzTipTransactionHandler } from '../buzz.controller';
+
+// A ledger mock that dedupes on externalTransactionId — a duplicate id is a benign
+// conflict (money already moved), NOT a new debit. Returns the {transactions, conflicts}
+// shape the real batch endpoint returns.
+function installLedger() {
+  const moved = new Set<string>();
+  let debits = 0;
+  mockCreateMany.mockImplementation(
+    async (txns: Array<{ externalTransactionId: string }>) => {
+      const transactions: string[] = [];
+      const conflicts: string[] = [];
+      for (const t of txns) {
+        if (moved.has(t.externalTransactionId)) conflicts.push(t.externalTransactionId);
+        else {
+          moved.add(t.externalTransactionId);
+          debits += 1;
+          transactions.push(`tx_${debits}`);
+        }
+      }
+      return { transactions, conflicts };
+    }
+  );
+  return { debits: () => debits };
+}
+
+function ctxUser() {
+  // createdAt well past the 24h membership gate.
+  return { user: { id: 42, createdAt: new Date('2020-01-01T00:00:00Z') } } as never;
+}
+const baseInput = {
+  toAccountId: 5,
+  amount: 100,
+  fromAccountType: 'yellow' as const,
+  toAccountType: 'yellow' as const,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGetUserBuzzAccount.mockResolvedValue([{ balance: 1_000_000 }]);
+  mockUserFindMany.mockResolvedValue([]); // no banned targets
+  mockUserFindUnique.mockResolvedValue({ username: 'sender' });
+  mockUpsertBuzzTip.mockResolvedValue(undefined);
+});
+
+describe('createBuzzTipTransactionHandler — ledger-backed idempotency (audit 🟡-1)', () => {
+  it('with a key: a same-key retry presents a DETERMINISTIC externalTransactionId → money moves ONCE', async () => {
+    const ledger = installLedger();
+    await createBuzzTipTransactionHandler({ input: baseInput, ctx: ctxUser(), idempotencyKey: 'idem-abc' });
+    // Simulate the crash window: the Redis sentinel has expired, so the endpoint
+    // re-runs the handler with the SAME client key.
+    await createBuzzTipTransactionHandler({ input: baseInput, ctx: ctxUser(), idempotencyKey: 'idem-abc' });
+
+    // 🔴 The load-bearing assertion: exactly ONE debit across the two calls — the 2nd
+    // collided on the ledger's unique externalTransactionId.
+    expect(ledger.debits()).toBe(1);
+    const ext1 = mockCreateMany.mock.calls[0][0][0].externalTransactionId;
+    const ext2 = mockCreateMany.mock.calls[1][0][0].externalTransactionId;
+    // Deterministic + delimiter-injective (block-tip:<fromUserId>:<key>-<toAccountId>).
+    expect(ext1).toBe('block-tip:42:idem-abc-5');
+    expect(ext2).toBe(ext1);
+  });
+
+  it('WITHOUT a key: each call mints a fresh uuid externalTransactionId (no ledger dedup — today\'s behavior)', async () => {
+    const ledger = installLedger();
+    await createBuzzTipTransactionHandler({ input: baseInput, ctx: ctxUser() });
+    await createBuzzTipTransactionHandler({ input: baseInput, ctx: ctxUser() });
+
+    const ext1 = mockCreateMany.mock.calls[0][0][0].externalTransactionId;
+    const ext2 = mockCreateMany.mock.calls[1][0][0].externalTransactionId;
+    // Non-deterministic uuid form (`tip-<uuid>---by-<fromUserId>-<toAccountId>`),
+    // DIFFERENT per call → two distinct debits (no ledger dedup).
+    expect(ext1).toMatch(/^tip-.+-by-42-5$/);
+    expect(ext1).not.toContain('block-tip');
+    expect(ext2).not.toBe(ext1);
+    expect(ledger.debits()).toBe(2);
+  });
+
+  it('with a key: the derived externalTransactionId carries the entity context via the sharedId key (still deterministic)', async () => {
+    installLedger();
+    await createBuzzTipTransactionHandler({
+      input: { ...baseInput, entityType: 'Image', entityId: 99 },
+      ctx: ctxUser(),
+      idempotencyKey: 'idem-xyz',
+    });
+    // The key-derived id ignores entityType/entityId (the client key already uniquely
+    // identifies the logical tip), so a retry with the same key collides regardless.
+    expect(mockCreateMany.mock.calls[0][0][0].externalTransactionId).toBe('block-tip:42:idem-xyz-5');
+  });
+});

--- a/src/server/controllers/buzz.controller.ts
+++ b/src/server/controllers/buzz.controller.ts
@@ -235,7 +235,7 @@ export async function createBuzzTipTransactionHandler({
     // The base of every transaction's `externalTransactionId` (`${sharedId}-${toAccountId}`).
     // With a client idempotency key, DERIVE it deterministically so a retry collides
     // on the ledger's unique constraint (money moves once — see the param doc). The
-    // key is charset-restricted (`^[A-Za-z0-9_-]{1,200}$`) at the endpoint, and both
+    // key is charset-restricted (`^[A-Za-z0-9_-]{1,64}$`) at the endpoint, and both
     // `fromUserId` and `toAccountId` are numeric, so `block-tip:${fromUserId}:${key}`
     // is delimiter-injective — no two distinct (user, key, target) triples collide.
     // Absent key → the original per-call `uuid()` (no dedup), byte-identical to today.
@@ -262,50 +262,92 @@ export async function createBuzzTipTransactionHandler({
     // Now, create all transactions
     const data = await createBuzzTransactionMany(transactions); // Now store these in the DB:
 
-    if (entityType && entityId) {
-      // TODO: We might wanna notify contributors, but hardly a priority right now imho.
-      await upsertBuzzTip({
-        ...transactions[0],
-        amount: finalAmount, // This is a total amount that was sent to all users.
-        entityType: entityType as string,
-        entityId: entityId as number,
-      });
-    } else {
-      const toAccountId = transactions[0].toAccountId;
-      const description = transactions[0].description;
-      if (toAccountId !== 0) {
-        const fromUser = await dbWrite.user.findUnique({
-          where: { id: fromAccountId },
-          select: { username: true },
-        });
+    // ── LEDGER CONFLICT = MONEY ALREADY MOVED (audit 🔴-2) ───────────────────────
+    // `createBuzzTransactionMany` returns `{ transactions, conflicts }`, and a
+    // `conflict` is the ledger REJECTING a duplicate `externalTransactionId`: that
+    // transaction debited NOTHING on this call because an earlier call already moved
+    // the money. The three side effects below (`upsertBuzzTip`, the `tip-received`
+    // notification — keyed by a fresh uuid so it has no dedup of its own — and the
+    // Image Buzz metric) are all NON-idempotent, so firing them for a conflicted
+    // transaction credits a SECOND tip for money that moved ONCE: a phantom tip.
+    //
+    // 🔴 This state is only REACHABLE because of the deterministic
+    // `externalTransactionId` introduced alongside `idempotencyKey` — with the
+    // legacy per-call `uuid()` id `conflicts` was always empty here, which is why
+    // ignoring it was previously (accidentally) safe. Concretely: tip N to X on
+    // image A with key K → wait past the 10-min Redis sentinel → same K, same
+    // recipient, DIFFERENT entityId (the derivation deliberately ignores the entity)
+    // → byte-identical ledger id → conflict, zero Buzz moves, yet image B would get
+    // +N Buzz, a BuzzTip row, and a 200.
+    //
+    // Matching is by `externalTransactionId` (what the batch endpoint reports as a
+    // conflict), with a COUNT belt: if the ledger reported ZERO successes then
+    // nothing moved on this call regardless of how the conflict identifiers are
+    // shaped on the wire. Both signals agree on the full-replay case above; the belt
+    // is what keeps the fail direction safe (never fire a side effect for money that
+    // did not move) if the identifier shape ever changes.
+    const conflictedIds = new Set(data.conflicts);
+    const settled =
+      data.transactions.length === 0
+        ? []
+        : transactions.filter((t) => !conflictedIds.has(t.externalTransactionId));
+    // Buzz that did NOT move on this call because the ledger deduped it. 0 on every
+    // non-conflicting tip → this whole block is inert for today's traffic.
+    const dedupedAmount = (transactions.length - settled.length) * amount;
+    const deduped = settled.length === 0 && dedupedAmount > 0;
 
-        await createNotification({
-          type: 'tip-received',
-          userId: toAccountId,
-          category: NotificationCategory.Buzz,
-          key: `tip-received:${uuid()}`,
-          details: {
-            amount: amount,
-            user: fromUser?.username,
-            fromUserId: fromAccountId,
-            message: description,
-            toAccountType: input.toAccountType,
-          },
+    if (settled.length > 0) {
+      if (entityType && entityId) {
+        // TODO: We might wanna notify contributors, but hardly a priority right now imho.
+        await upsertBuzzTip({
+          ...settled[0],
+          // The total that ACTUALLY moved on this call (a partially-deduped batch
+          // must not record the conflicted legs again).
+          amount: settled.length * amount,
+          entityType: entityType as string,
+          entityId: entityId as number,
+        });
+      } else {
+        const toAccountId = settled[0].toAccountId;
+        const description = settled[0].description;
+        if (toAccountId !== 0) {
+          const fromUser = await dbWrite.user.findUnique({
+            where: { id: fromAccountId },
+            select: { username: true },
+          });
+
+          await createNotification({
+            type: 'tip-received',
+            userId: toAccountId,
+            category: NotificationCategory.Buzz,
+            key: `tip-received:${uuid()}`,
+            details: {
+              amount: amount,
+              user: fromUser?.username,
+              fromUserId: fromAccountId,
+              message: description,
+              toAccountType: input.toAccountType,
+            },
+          });
+        }
+      }
+
+      if (entityType === 'Image' && !!entityId) {
+        await updateEntityMetric({
+          ctx,
+          entityType: 'Image',
+          entityId,
+          metricType: 'Buzz',
+          // Only the Buzz that actually moved on this call.
+          amount: settled.length * amount,
         });
       }
     }
 
-    if (entityType === 'Image' && !!entityId) {
-      await updateEntityMetric({
-        ctx,
-        entityType: 'Image',
-        entityId,
-        metricType: 'Buzz',
-        amount: finalAmount,
-      });
-    }
-
-    return data;
+    // `deduped` / `dedupedAmount` are ADDITIVE (the on-site tRPC caller ignores
+    // them). The App Blocks tip endpoint reads `dedupedAmount` to refund the daily
+    // tip-cap reservation it burned for Buzz that never moved — see tip.ts.
+    return { ...data, deduped, dedupedAmount };
   } catch (error) {
     throw getTRPCErrorFromUnknown(error);
   }

--- a/src/server/controllers/buzz.controller.ts
+++ b/src/server/controllers/buzz.controller.ts
@@ -121,9 +121,22 @@ export function completeStripeBuzzPurchaseHandler({
 export async function createBuzzTipTransactionHandler({
   input,
   ctx,
+  idempotencyKey,
 }: {
   input: UserBuzzTransactionInputSchema;
   ctx: ProtectedContext;
+  /**
+   * OPTIONAL client idempotency key (App Blocks tip endpoint, audit 🟡-1). When
+   * present, the tip's `externalTransactionId` is DERIVED from it deterministically
+   * (`block-tip:${fromUserId}:${idempotencyKey}-${toAccountId}`) instead of a fresh
+   * `uuid()`, so the Buzz ledger's own idempotency (a duplicate
+   * `externalTransactionId` is a benign "money already moved" conflict) becomes the
+   * AUTHORITATIVE dedup: a retry after the Redis sentinel has expired (a crash
+   * between charge and `finalizeTipIdempotency`) collides on the ledger = money
+   * moves once. Absent → today's per-call `uuid()` behavior (no ledger dedup),
+   * byte-identical for the on-site tip path which never passes this.
+   */
+  idempotencyKey?: string;
 }) {
   try {
     const { id: fromAccountId } = ctx.user;
@@ -219,7 +232,16 @@ export async function createBuzzTipTransactionHandler({
       throw throwInsufficientFundsError();
     }
 
-    const sharedId = `tip-${uuid()}-${entityType ?? ''}-${entityId ?? ''}-by-${ctx.user.id}`;
+    // The base of every transaction's `externalTransactionId` (`${sharedId}-${toAccountId}`).
+    // With a client idempotency key, DERIVE it deterministically so a retry collides
+    // on the ledger's unique constraint (money moves once — see the param doc). The
+    // key is charset-restricted (`^[A-Za-z0-9_-]{1,200}$`) at the endpoint, and both
+    // `fromUserId` and `toAccountId` are numeric, so `block-tip:${fromUserId}:${key}`
+    // is delimiter-injective — no two distinct (user, key, target) triples collide.
+    // Absent key → the original per-call `uuid()` (no dedup), byte-identical to today.
+    const sharedId = idempotencyKey
+      ? `block-tip:${ctx.user.id}:${idempotencyKey}`
+      : `tip-${uuid()}-${entityType ?? ''}-${entityId ?? ''}-by-${ctx.user.id}`;
     const transactions = targetUserIds.map((toAccountId) => ({
       ...input,
       fromAccountId: ctx.user.id,

--- a/src/server/metrics/app-block-runtime.metrics.ts
+++ b/src/server/metrics/app-block-runtime.metrics.ts
@@ -36,6 +36,7 @@ import client, { type Counter, type Histogram, type Registry } from 'prom-client
  */
 export type AppBlockEndpoint =
   | 'tip'
+  | 'tip_allowance'
   | 'images'
   | 'models'
   | 'model_detail'

--- a/src/server/routers/__tests__/blocks.router.workflow.test.ts
+++ b/src/server/routers/__tests__/blocks.router.workflow.test.ts
@@ -1057,7 +1057,17 @@ describe('blocks.submitWorkflow', () => {
       expect(bodies[1].externalId).toBe('blk08apb_gatekey-B');
     });
 
-    it('BACKWARD COMPAT: no idempotencyKey → real submit carries NO externalId (today\'s behavior)', async () => {
+    // ── audit 🔴-1: the UNKEYED path is where the live double-charge lived ──────
+    //
+    // Threading `externalId` only when the CLIENT sends `idempotencyKey` closed
+    // NOTHING on real traffic: no shipped client sends one (the SDK has zero
+    // occurrences; the live tipping block hand-rolls its POST). Meanwhile the actual
+    // double-charge is server-side and unconditional — `submitWorkflow` calls
+    // `submitWorkflowWithRetry` with maxAttempts=3 and no per-attempt timeout on the
+    // real submit, and that wrapper's own doc says it adds NO idempotency key: "the
+    // CALLER must set `body.externalId`". So the server now MINTS one when the client
+    // sends none.
+    it('🔴 UNKEYED submit MINTS a server-side externalId (a client key is NOT the gate)', async () => {
       mockVerifyBlockToken.mockResolvedValue(validClaims({ buzzBudget: 100, appBlockId: 'apb_gate' }));
       happyVersionLookup();
       happyUser();
@@ -1068,9 +1078,96 @@ describe('blocks.submitWorkflow', () => {
 
       const bodies = orch.realSubmitBodies();
       expect(bodies).toHaveLength(1);
-      expect(bodies[0]).not.toHaveProperty('externalId');
-      // Absent key → the civitai gen claim is NEVER taken (byte-identical to today).
+      // 🔴 The load-bearing assertion: an externalId IS present without a client key.
+      const extId: string = bodies[0].externalId;
+      expect(typeof extId).toBe('string');
+      // SERVER namespace (`bls`), structurally DISJOINT from the client `blk`
+      // namespace — a minted id can never collide with a client-supplied one.
+      expect(extId.startsWith('bls')).toBe(true);
+      expect(extId.startsWith('blk')).toBe(false);
+      // Satisfies the orchestrator contract (`^[A-Za-z0-9_-]+$`, <=128, enforced by
+      // [ApiController] as a hard 400 — not a truncation).
+      expect(extId).toMatch(/^[A-Za-z0-9_-]+$/);
+      expect(extId.length).toBeLessThanOrEqual(128);
+      // Absent key -> the civitai redis claim is still NEVER taken (a minted id is
+      // unique per request, so claiming on it could not dedupe anything). Keyed
+      // clients are therefore byte-identical to before.
       expect(mockClaimGen).not.toHaveBeenCalled();
+    });
+
+    it('🔴 UNKEYED: two DISTINCT submits get DISTINCT minted ids -> two charges (no over-dedupe)', async () => {
+      mockVerifyBlockToken.mockResolvedValue(validClaims({ buzzBudget: 100, appBlockId: 'apb_gate' }));
+      happyVersionLookup();
+      happyUser();
+      const orch = installDedupingOrchestrator();
+
+      const caller = blocksRouter.createCaller(fakeCtx() as never);
+      await caller.submitWorkflow({ blockToken: 'tok', body: validBody() });
+      happyVersionLookup();
+      happyUser();
+      await caller.submitWorkflow({ blockToken: 'tok', body: validBody() });
+
+      const bodies = orch.realSubmitBodies();
+      expect(bodies).toHaveLength(2);
+      // Unique per LOGICAL request — a minted id must never fuse two genuinely
+      // different generations onto one orchestrator dedupe slot.
+      expect(bodies[0].externalId).not.toBe(bodies[1].externalId);
+      expect(orch.chargeCount()).toBe(2);
+    });
+
+    // A backend that CREATES + CHARGES the workflow and only THEN loses the response
+    // (502/504/dropped socket) — exactly the window `submitWorkflowWithRetry` retries
+    // into. All 3 attempts present the SAME body object (the wrapper reuses it), so an
+    // externalId minted ONCE before the loop collapses them; no externalId means a
+    // fresh workflow + a fresh charge on every attempt.
+    function installLossyRetryingOrchestrator({ lostResponses = 2 } = {}) {
+      let chargeCount = 0;
+      let lost = 0;
+      const byExternalId = new Map<string, any>();
+      mockSubmitWorkflow.mockImplementation(async (arg: any) => {
+        if (arg?.query?.whatif === true)
+          return { id: '', status: 'succeeded', cost: { total: 25 }, steps: [] };
+        for (let attempt = 1; attempt <= 3; attempt++) {
+          const extId: string | undefined = arg?.body?.externalId;
+          let wf: any;
+          if (extId && byExternalId.has(extId)) {
+            wf = byExternalId.get(extId); // deduped — original workflow, NO new charge
+          } else {
+            chargeCount += 1;
+            wf = {
+              id: `wf_${chargeCount}`,
+              status: 'unassigned',
+              cost: { total: 25 },
+              steps: [],
+              transactions: [{ id: `txn_${chargeCount}`, type: 'debit', amount: -25 }],
+            };
+            if (extId) byExternalId.set(extId, wf);
+          }
+          if (lost < lostResponses) {
+            lost += 1;
+            continue; // the charge happened; the RESPONSE was lost -> the wrapper retries
+          }
+          return wf;
+        }
+        throw new Error('orchestrator unavailable after 3 attempts');
+      });
+      return { chargeCount: () => chargeCount };
+    }
+
+    it('🔴 UNKEYED + 2 LOST RESPONSES: ONE charge, not three (the double-spend this closes)', async () => {
+      mockVerifyBlockToken.mockResolvedValue(validClaims({ buzzBudget: 100, appBlockId: 'apb_gate' }));
+      happyVersionLookup();
+      happyUser();
+      const orch = installLossyRetryingOrchestrator({ lostResponses: 2 });
+
+      const caller = blocksRouter.createCaller(fakeCtx() as never);
+      const result = await caller.submitWorkflow({ blockToken: 'tok', body: validBody() });
+
+      // 🔴 THE assertion the PR previously claimed but did not deliver: one user
+      // action, one workflow, one Buzz charge — with NO client idempotency key.
+      // Without the server-side mint this is 3.
+      expect(orch.chargeCount()).toBe(1);
+      expect(result.snapshot.workflowId).toBe('wf_1');
     });
 
     // ---- audit 🔴-1: civitai-side in-flight / replay guard ----
@@ -1125,6 +1222,48 @@ describe('blocks.submitWorkflow', () => {
       releaseFirst();
       const firstResult = await firstPromise;
       expect(firstResult.snapshot.workflowId).toBe('wf_1');
+    });
+
+    it('🔴 RELEASE on the submit-THROW catch: a genuine retry with the same key can RE-RUN', async () => {
+      // The MOST important release site — this IS the retry scenario. A real submit
+      // that THROWS moved no money and left no reservation standing, so the claim
+      // must be dropped; otherwise the sentinel 409s every retry with the same key
+      // for its full 10-minute TTL and the generation becomes unlandable.
+      mockVerifyBlockToken.mockResolvedValue(validClaims({ buzzBudget: 100, appBlockId: 'apb_gate' }));
+      happyVersionLookup();
+      happyUser();
+      mockSubmitWorkflow.mockImplementation(async (arg: any) => {
+        if (arg?.query?.whatif === true)
+          return { id: '', status: 'succeeded', cost: { total: 25 }, steps: [] };
+        throw new Error('orchestrator exploded');
+      });
+
+      const caller = blocksRouter.createCaller(fakeCtx() as never);
+      await expect(
+        caller.submitWorkflow({ blockToken: 'tok', body: validBody(), idempotencyKey: 'throw-key' })
+      ).rejects.toThrow('orchestrator exploded');
+
+      // \U0001f534 The load-bearing assertion: the claim was RELEASED (not finalized).
+      expect(mockReleaseGen).toHaveBeenCalledTimes(1);
+      expect(mockFinalizeGen).not.toHaveBeenCalled();
+
+      // ...and prove it end-to-end: the SAME key now ACQUIRES again and succeeds,
+      // rather than 409-ing on a stranded sentinel.
+      happyVersionLookup();
+      happyUser();
+      let charge = 0;
+      mockSubmitWorkflow.mockImplementation(async (arg: any) => {
+        if (arg?.query?.whatif === true)
+          return { id: '', status: 'succeeded', cost: { total: 25 }, steps: [] };
+        charge += 1;
+        return { id: `wf_retry_${charge}`, status: 'unassigned', cost: { total: 25 }, steps: [] };
+      });
+      const retry = await caller.submitWorkflow({
+        blockToken: 'tok',
+        body: validBody(),
+        idempotencyKey: 'throw-key',
+      });
+      expect(retry.snapshot.workflowId).toBe('wf_retry_1');
     });
 
     it('CHARSET (audit 🟢): an idempotencyKey with a space/control char is REJECTED at the input (no claim, no submit)', async () => {
@@ -5006,6 +5145,35 @@ describe('customComfy bridge (submit/estimate/settle)', () => {
       expect(mockFinalizeGen).toHaveBeenCalledTimes(1);
       // The (single) real submit carried the namespaced externalId (2nd defense layer).
       expect(mockSubmitWorkflow.mock.calls[0][0].body.externalId).toBe('blk08apb_testcc-key');
+    });
+
+    it('🔴 a client key whose composed externalId the ORCHESTRATOR would reject FAILS CLOSED (no reserve, no submit)', async () => {
+      // composeBlockExternalId throws BEFORE any cap reservation, so a violation can
+      // never be silently truncated into a BROKEN (userId, externalId) dedupe — and
+      // no money moves. The orchestrator validates `^[A-Za-z0-9_-]+$` behind
+      // [ApiController]: an out-of-charset id is a hard 400, not a truncation.
+      // (The txt2img branch composes at the same point; this covers the customComfy
+      // branch's own call site, which had no coverage.)
+      mockVerifyBlockToken.mockResolvedValue(ccPageClaims({ appBlockId: 'apb:bad' }));
+      happyCcResources();
+      happySubmit();
+      await expect(
+        caller().submitWorkflow({ blockToken: 'tok', body: ccBody(), idempotencyKey: 'cc-key' })
+      ).rejects.toThrow(/characters the orchestrator/);
+      expect(mockClaimGen).not.toHaveBeenCalled();
+      expect(mockReserveAppSpend).not.toHaveBeenCalled();
+      expect(mockSubmitWorkflow).not.toHaveBeenCalled();
+    });
+
+    it('an appBlockId too long to length-encode also FAILS CLOSED', async () => {
+      mockVerifyBlockToken.mockResolvedValue(ccPageClaims({ appBlockId: 'a'.repeat(100) }));
+      happyCcResources();
+      happySubmit();
+      await expect(
+        caller().submitWorkflow({ blockToken: 'tok', body: ccBody(), idempotencyKey: 'cc-key' })
+      ).rejects.toThrow(/outside 1\.\.99/);
+      expect(mockReserveAppSpend).not.toHaveBeenCalled();
+      expect(mockSubmitWorkflow).not.toHaveBeenCalled();
     });
 
     it('IDEMPOTENCY (audit 🔴-1): a concurrent claim in-progress → 409 CONFLICT, NO reserve, NO submit', async () => {

--- a/src/server/routers/__tests__/blocks.router.workflow.test.ts
+++ b/src/server/routers/__tests__/blocks.router.workflow.test.ts
@@ -898,6 +898,119 @@ describe('blocks.submitWorkflow', () => {
     });
   });
 
+  // ---- Item 2 (gen half): idempotency key → orchestrator externalId dedupe ----
+  //
+  // STEP-1 GATE TEST. Verifies the load-bearing property: a same-key RETRY collapses
+  // to ONE Buzz charge. The orchestrator dedupes on `(userId, externalId)` (see the
+  // `submitWorkflowWithRetry` docstring in `~/server/services/orchestrator/workflows`)
+  // and, on a replay, returns the EXISTING workflow with its ORIGINAL transactions
+  // (no second debit). Here the orchestrator submit is mocked to model that dedupe,
+  // and we assert the client key threads to `body.externalId` and that a replay mints
+  // NO second charge.
+  describe('idempotency key → externalId dedupe (item 2, gen half)', () => {
+    // A stateful orchestrator mock: whatIf calls return a cost preview; a REAL submit
+    // dedupes on `body.externalId` — a cache HIT returns the original workflow +
+    // original transactions and mints NO new charge (mirrors the orchestrator).
+    function installDedupingOrchestrator() {
+      let chargeCount = 0;
+      const byExternalId = new Map<string, unknown>();
+      mockSubmitWorkflow.mockImplementation(async (arg: any) => {
+        const isWhatif = arg?.query?.whatif === true;
+        if (isWhatif) return { id: '', status: 'succeeded', cost: { total: 25 }, steps: [] };
+        // REAL submit.
+        const extId: string | undefined = arg?.body?.externalId;
+        if (extId && byExternalId.has(extId)) {
+          return byExternalId.get(extId); // replay → original workflow, NO new charge
+        }
+        chargeCount += 1;
+        const wf = {
+          id: `wf_${chargeCount}`,
+          status: 'unassigned',
+          cost: { total: 25 },
+          steps: [],
+          // The realized per-account Buzz DEBIT — one set per distinct charge.
+          transactions: [{ id: `txn_${chargeCount}`, type: 'debit', amount: -25 }],
+        };
+        if (extId) byExternalId.set(extId, wf);
+        return wf;
+      });
+      // Real-submit calls only (drop the interleaved whatIf calls).
+      const realSubmitBodies = () =>
+        mockSubmitWorkflow.mock.calls
+          .map((c: any[]) => c[0])
+          .filter((a: any) => a?.query?.whatif !== true)
+          .map((a: any) => a.body);
+      return { chargeCount: () => chargeCount, realSubmitBodies };
+    }
+
+    it('FORCED RETRY: two submits with the SAME key → ONE charge, same externalId, same workflow', async () => {
+      mockVerifyBlockToken.mockResolvedValue(validClaims({ buzzBudget: 100, appBlockId: 'apb_gate' }));
+      happyVersionLookup();
+      happyUser();
+      const orch = installDedupingOrchestrator();
+
+      const caller = blocksRouter.createCaller(fakeCtx() as never);
+      const first = await caller.submitWorkflow({
+        blockToken: 'tok',
+        body: validBody(),
+        idempotencyKey: 'gate-key',
+      });
+      // happyVersionLookup/happyUser are consumed per-call in some setups; re-arm so
+      // the SECOND submit resolves the same checkpoint/user as the first.
+      happyVersionLookup();
+      happyUser();
+      const second = await caller.submitWorkflow({
+        blockToken: 'tok',
+        body: validBody(),
+        idempotencyKey: 'gate-key',
+      });
+
+      // 🔴 THE load-bearing assertion: exactly ONE Buzz charge across both submits.
+      expect(orch.chargeCount()).toBe(1);
+      // Both real submits carried the SAME namespaced externalId (userId is added
+      // orchestrator-side; the namespace is per-app + per-key).
+      const bodies = orch.realSubmitBodies();
+      expect(bodies).toHaveLength(2);
+      expect(bodies[0].externalId).toBe('block:apb_gate:gate-key');
+      expect(bodies[1].externalId).toBe('block:apb_gate:gate-key');
+      // The replay returned the SAME workflow the first submit created.
+      expect(first.snapshot.workflowId).toBe('wf_1');
+      expect(second.snapshot.workflowId).toBe('wf_1');
+    });
+
+    it('CONTROL: two DIFFERENT keys → two externalIds → TWO charges (distinct gens are not deduped)', async () => {
+      mockVerifyBlockToken.mockResolvedValue(validClaims({ buzzBudget: 100, appBlockId: 'apb_gate' }));
+      happyVersionLookup();
+      happyUser();
+      const orch = installDedupingOrchestrator();
+
+      const caller = blocksRouter.createCaller(fakeCtx() as never);
+      await caller.submitWorkflow({ blockToken: 'tok', body: validBody(), idempotencyKey: 'key-A' });
+      happyVersionLookup();
+      happyUser();
+      await caller.submitWorkflow({ blockToken: 'tok', body: validBody(), idempotencyKey: 'key-B' });
+
+      expect(orch.chargeCount()).toBe(2);
+      const bodies = orch.realSubmitBodies();
+      expect(bodies[0].externalId).toBe('block:apb_gate:key-A');
+      expect(bodies[1].externalId).toBe('block:apb_gate:key-B');
+    });
+
+    it('BACKWARD COMPAT: no idempotencyKey → real submit carries NO externalId (today\'s behavior)', async () => {
+      mockVerifyBlockToken.mockResolvedValue(validClaims({ buzzBudget: 100, appBlockId: 'apb_gate' }));
+      happyVersionLookup();
+      happyUser();
+      const orch = installDedupingOrchestrator();
+
+      const caller = blocksRouter.createCaller(fakeCtx() as never);
+      await caller.submitWorkflow({ blockToken: 'tok', body: validBody() });
+
+      const bodies = orch.realSubmitBodies();
+      expect(bodies).toHaveLength(1);
+      expect(bodies[0]).not.toHaveProperty('externalId');
+    });
+  });
+
   // ---- G8: per-app aggregate spend + velocity cap -------------------------
   describe('per-app aggregate spend/velocity cap (G8)', () => {
     function setupSubmit(workflowId = 'wf_real') {

--- a/src/server/routers/__tests__/blocks.router.workflow.test.ts
+++ b/src/server/routers/__tests__/blocks.router.workflow.test.ts
@@ -190,6 +190,28 @@ vi.mock('~/server/services/blocks/custom-comfy-settle.service', () => ({
   persistCustomComfySettle: (...a: unknown[]) => mockPersistCustomComfySettle(...(a as [])),
   settleCustomComfySpend: (...a: unknown[]) => mockSettleCustomComfySpend(...(a as [])),
 }));
+// audit 🔴-1 — submitWorkflow (both the txt2img + customComfy branches) now claims a
+// civitai-side GEN idempotency guard BEFORE reserving/submitting. Mock claim/finalize/
+// release with a STATEFUL in-memory store so the router's USE of the guard (in-flight
+// 409, replay cached snapshot, release-on-reject, finalize-on-success, no double
+// cap-INCR) is tested end-to-end; the helper's OWN redis logic is unit-tested in
+// block-gen-idempotency.test.ts. `composeBlockExternalId` + BLOCK_IDEMPOTENCY_KEY_REGEX
+// stay REAL (importActual) so the externalId namespacing + zod charset still apply.
+const { mockClaimGen, mockFinalizeGen, mockReleaseGen, genIdemStore } = vi.hoisted(() => ({
+  genIdemStore: new Map<string, unknown>(),
+  mockClaimGen: vi.fn(),
+  mockFinalizeGen: vi.fn(),
+  mockReleaseGen: vi.fn(),
+}));
+vi.mock('~/server/utils/block-gen-idempotency', async (importActual) => {
+  const actual = await importActual<typeof import('~/server/utils/block-gen-idempotency')>();
+  return {
+    ...actual,
+    claimGenIdempotency: (...a: unknown[]) => mockClaimGen(...(a as [])),
+    finalizeGenIdempotency: (...a: unknown[]) => mockFinalizeGen(...(a as [])),
+    releaseGenIdempotency: (...a: unknown[]) => mockReleaseGen(...(a as [])),
+  };
+});
 // submitWorkflow fires recordScopeInvocation (detached) which dynamic-imports the
 // REAL, heavy user-app-surface.service. That first-time real import serializes the
 // module runner and starves the sibling detached fire-and-forget writes (G6 queue),
@@ -496,6 +518,32 @@ beforeEach(() => {
   mockPersistCustomComfySettle.mockResolvedValue(undefined);
   mockSettleCustomComfySpend.mockReset();
   mockSettleCustomComfySpend.mockResolvedValue(undefined);
+  // GEN idempotency (audit 🔴-1): a STATEFUL in-memory model of the SET-NX claim so
+  // the router integration tests exercise acquire → in_progress/replay end-to-end.
+  // `key` here is the composed `${userId}:${appBlockId}:${idempotencyKey}` — the
+  // helper's real redis-key prefix is irrelevant to the router's use of the guard.
+  genIdemStore.clear();
+  mockClaimGen.mockReset();
+  mockFinalizeGen.mockReset();
+  mockReleaseGen.mockReset();
+  mockClaimGen.mockImplementation(async (userId: number, appBlockId: string, key: string) => {
+    const k = `${userId}:${appBlockId}:${key}`;
+    const existing = genIdemStore.get(k);
+    if (existing === undefined) {
+      genIdemStore.set(k, '__in_progress__'); // sentinel — not yet finalized
+      return { state: 'acquired', key: k };
+    }
+    if (existing && typeof existing === 'object' && 'result' in (existing as object)) {
+      return { state: 'replay', result: (existing as { result: unknown }).result };
+    }
+    return { state: 'in_progress' };
+  });
+  mockFinalizeGen.mockImplementation(async (key: string, result: unknown) => {
+    genIdemStore.set(key, { result });
+  });
+  mockReleaseGen.mockImplementation(async (key: string) => {
+    genIdemStore.delete(key);
+  });
   // F4 defaults: no active dev tunnel (getActiveDevTunnel → null) so the dev
   // spend backstop is inert for every non-dev test. The F4 tests override these.
   mockGetActiveDevTunnel.mockResolvedValue(null);
@@ -943,7 +991,13 @@ describe('blocks.submitWorkflow', () => {
       return { chargeCount: () => chargeCount, realSubmitBodies };
     }
 
-    it('FORCED RETRY: two submits with the SAME key → ONE charge, same externalId, same workflow', async () => {
+    it('FORCED RETRY: two submits with the SAME key → ONE charge; the 2nd REPLAYS the cached snapshot (audit 🔴-1)', async () => {
+      // UPDATED for the civitai-side gen idempotency claim (audit 🔴-1). Previously
+      // both submits reached the orchestrator and its (userId, externalId) dedupe
+      // collapsed the 2nd. NOW the civitai-side claim is the PRIMARY guard: the 2nd
+      // same-key submit REPLAYS the first's cached snapshot and NEVER reserves or
+      // re-submits (no 2nd cap-INCR, no 2nd orchestrator round-trip). The externalId
+      // dedupe remains threaded on the (single) real submit as the 2nd defense layer.
       mockVerifyBlockToken.mockResolvedValue(validClaims({ buzzBudget: 100, appBlockId: 'apb_gate' }));
       happyVersionLookup();
       happyUser();
@@ -956,7 +1010,7 @@ describe('blocks.submitWorkflow', () => {
         idempotencyKey: 'gate-key',
       });
       // happyVersionLookup/happyUser are consumed per-call in some setups; re-arm so
-      // the SECOND submit resolves the same checkpoint/user as the first.
+      // a hypothetical SECOND real submit would resolve — it must NOT be reached.
       happyVersionLookup();
       happyUser();
       const second = await caller.submitWorkflow({
@@ -967,15 +1021,20 @@ describe('blocks.submitWorkflow', () => {
 
       // 🔴 THE load-bearing assertion: exactly ONE Buzz charge across both submits.
       expect(orch.chargeCount()).toBe(1);
-      // Both real submits carried the SAME namespaced externalId (userId is added
-      // orchestrator-side; the namespace is per-app + per-key).
+      // The civitai claim short-circuited the 2nd BEFORE the orchestrator — only ONE
+      // real submit ever happened, carrying the namespaced externalId.
       const bodies = orch.realSubmitBodies();
-      expect(bodies).toHaveLength(2);
+      expect(bodies).toHaveLength(1);
       expect(bodies[0].externalId).toBe('block:apb_gate:gate-key');
-      expect(bodies[1].externalId).toBe('block:apb_gate:gate-key');
-      // The replay returned the SAME workflow the first submit created.
+      // The first submit's snapshot was cached (finalize) and REPLAYED verbatim.
       expect(first.snapshot.workflowId).toBe('wf_1');
       expect(second.snapshot.workflowId).toBe('wf_1');
+      expect(mockFinalizeGen).toHaveBeenCalledTimes(1);
+      // 🟡-2: NO second cap reservation on the replay (the per-app + per-user cap
+      // counters can't double-INCR because the claim short-circuits before reserve).
+      expect(mockReserveAppSpend).toHaveBeenCalledTimes(1);
+      // buzz-cap reserve (reserveBlockBuzzSpend → sysRedis.incrBy) ran exactly once.
+      expect(mockSysRedis.incrBy).toHaveBeenCalledTimes(1);
     });
 
     it('CONTROL: two DIFFERENT keys → two externalIds → TWO charges (distinct gens are not deduped)', async () => {
@@ -1008,6 +1067,112 @@ describe('blocks.submitWorkflow', () => {
       const bodies = orch.realSubmitBodies();
       expect(bodies).toHaveLength(1);
       expect(bodies[0]).not.toHaveProperty('externalId');
+      // Absent key → the civitai gen claim is NEVER taken (byte-identical to today).
+      expect(mockClaimGen).not.toHaveBeenCalled();
+    });
+
+    // ---- audit 🔴-1: civitai-side in-flight / replay guard ----
+    it('CONCURRENT same-key: a 2nd submit while the 1st is IN-FLIGHT → 409, NO 2nd reserve/submit', async () => {
+      mockVerifyBlockToken.mockResolvedValue(validClaims({ buzzBudget: 100, appBlockId: 'apb_gate' }));
+      happyVersionLookup();
+      happyUser();
+
+      // Gate the FIRST real orchestrator submit so it stays in-flight (claim acquired,
+      // NOT finalized) while the second same-key submit races in.
+      let releaseFirst!: () => void;
+      const firstGate = new Promise<void>((r) => (releaseFirst = r));
+      let real = 0;
+      mockSubmitWorkflow.mockImplementation(async (arg: any) => {
+        if (arg?.query?.whatif === true)
+          return { id: '', status: 'succeeded', cost: { total: 25 }, steps: [] };
+        real += 1;
+        await firstGate; // hang the first real submit
+        return {
+          id: 'wf_1',
+          status: 'unassigned',
+          cost: { total: 25 },
+          steps: [],
+          transactions: [{ id: 'txn_1', type: 'debit', amount: -25 }],
+        };
+      });
+
+      const caller = blocksRouter.createCaller(fakeCtx() as never);
+      const firstPromise = caller.submitWorkflow({
+        blockToken: 'tok',
+        body: validBody(),
+        idempotencyKey: 'race-key',
+      });
+      // Wait until the first has CLAIMED + RESERVED and is parked at the orchestrator.
+      await vi.waitFor(() => {
+        expect(mockReserveAppSpend).toHaveBeenCalledTimes(1);
+        expect(real).toBe(1);
+      });
+
+      happyVersionLookup();
+      happyUser();
+      // The second same-key submit finds the in-progress sentinel → 409 CONFLICT.
+      await expect(
+        caller.submitWorkflow({ blockToken: 'tok', body: validBody(), idempotencyKey: 'race-key' })
+      ).rejects.toMatchObject({ code: 'CONFLICT' });
+
+      // 🔴 The second did NOT reserve again and did NOT submit again — exactly ONE of
+      // each across the race (no double cap-INCR, no double orchestrator submit).
+      expect(mockReserveAppSpend).toHaveBeenCalledTimes(1);
+      expect(real).toBe(1);
+
+      releaseFirst();
+      const firstResult = await firstPromise;
+      expect(firstResult.snapshot.workflowId).toBe('wf_1');
+    });
+
+    it('CHARSET (audit 🟢): an idempotencyKey with a space/control char is REJECTED at the input (no claim, no submit)', async () => {
+      mockVerifyBlockToken.mockResolvedValue(validClaims({ buzzBudget: 100, appBlockId: 'apb_gate' }));
+      happyVersionLookup();
+      happyUser();
+      const caller = blocksRouter.createCaller(fakeCtx() as never);
+      await expect(
+        caller.submitWorkflow({ blockToken: 'tok', body: validBody(), idempotencyKey: 'bad key\n' })
+      ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+      // Rejected by zod before any handler work — no claim, no orchestrator call.
+      expect(mockClaimGen).not.toHaveBeenCalled();
+      expect(mockSubmitWorkflow).not.toHaveBeenCalled();
+    });
+
+    it('FAIL-CLOSED: a redis error at claim time → INTERNAL_SERVER_ERROR, NO reserve, NO real submit', async () => {
+      mockVerifyBlockToken.mockResolvedValue(validClaims({ buzzBudget: 100, appBlockId: 'apb_gate' }));
+      happyVersionLookup();
+      happyUser();
+      installDedupingOrchestrator();
+      mockClaimGen.mockRejectedValueOnce(new Error('redis down'));
+
+      const caller = blocksRouter.createCaller(fakeCtx() as never);
+      await expect(
+        caller.submitWorkflow({ blockToken: 'tok', body: validBody(), idempotencyKey: 'k' })
+      ).rejects.toMatchObject({ code: 'INTERNAL_SERVER_ERROR' });
+      // Claim failed closed BEFORE the reservation + real submit.
+      expect(mockReserveAppSpend).not.toHaveBeenCalled();
+    });
+
+    it('RELEASE on a pre-money cap reject → a genuine retry can re-run (claim not stranded)', async () => {
+      mockVerifyBlockToken.mockResolvedValue(validClaims({ buzzBudget: 100, appBlockId: 'apb_gate' }));
+      happyVersionLookup();
+      happyUser();
+      installDedupingOrchestrator();
+      // Per-user daily cap RESERVE pushes over the ceiling (incrBy returns > cap) so
+      // the submit is rejected pre-money with a failed snapshot.
+      mockSysRedis.incrBy.mockResolvedValue(1_000_000);
+
+      const caller = blocksRouter.createCaller(fakeCtx() as never);
+      const result = await caller.submitWorkflow({
+        blockToken: 'tok',
+        body: validBody(),
+        idempotencyKey: 'cap-key',
+      });
+      expect(result.snapshot.status).toBe('failed');
+      // No money moved → the claim was RELEASED (so a genuine retry can re-run), and
+      // it was NOT finalized (a cap-reject is not a cached terminal success).
+      expect(mockReleaseGen).toHaveBeenCalledTimes(1);
+      expect(mockFinalizeGen).not.toHaveBeenCalled();
     });
   });
 
@@ -4813,6 +4978,44 @@ describe('customComfy bridge (submit/estimate/settle)', () => {
         recipe: 'seamless-pano-360',
         submittedAt: expect.any(Number),
       });
+    });
+
+    it('IDEMPOTENCY (audit 🔴-1): a same-key retry REPLAYS the cached snapshot — NO 2nd reserve/submit', async () => {
+      mockVerifyBlockToken.mockResolvedValue(ccPageClaims());
+      happyCcResources();
+      happySubmit();
+      const first = await caller().submitWorkflow({
+        blockToken: 'tok',
+        body: ccBody(),
+        idempotencyKey: 'cc-key',
+      });
+      expect(first.snapshot.workflowId).toBe('wf_cc_1');
+      happyCcResources();
+      const second = await caller().submitWorkflow({
+        blockToken: 'tok',
+        body: ccBody(),
+        idempotencyKey: 'cc-key',
+      });
+      expect(second.snapshot.workflowId).toBe('wf_cc_1');
+      // customComfy has NO whatIf — exactly ONE orchestrator submit + ONE reservation
+      // across both calls (the 2nd replayed the cached snapshot before reserving).
+      expect(mockSubmitWorkflow).toHaveBeenCalledTimes(1);
+      expect(mockReserveAppSpend).toHaveBeenCalledTimes(1);
+      expect(mockFinalizeGen).toHaveBeenCalledTimes(1);
+      // The (single) real submit carried the namespaced externalId (2nd defense layer).
+      expect(mockSubmitWorkflow.mock.calls[0][0].body.externalId).toBe('block:apb_test:cc-key');
+    });
+
+    it('IDEMPOTENCY (audit 🔴-1): a concurrent claim in-progress → 409 CONFLICT, NO reserve, NO submit', async () => {
+      mockVerifyBlockToken.mockResolvedValue(ccPageClaims());
+      happyCcResources();
+      happySubmit();
+      mockClaimGen.mockResolvedValue({ state: 'in_progress' });
+      await expect(
+        caller().submitWorkflow({ blockToken: 'tok', body: ccBody(), idempotencyKey: 'cc-key' })
+      ).rejects.toMatchObject({ code: 'CONFLICT' });
+      expect(mockReserveAppSpend).not.toHaveBeenCalled();
+      expect(mockSubmitWorkflow).not.toHaveBeenCalled();
     });
 
     it('tags reflect the recipe id + customComfy (never txt2img), preserving app-block provenance', async () => {

--- a/src/server/routers/__tests__/blocks.router.workflow.test.ts
+++ b/src/server/routers/__tests__/blocks.router.workflow.test.ts
@@ -1025,7 +1025,9 @@ describe('blocks.submitWorkflow', () => {
       // real submit ever happened, carrying the namespaced externalId.
       const bodies = orch.realSubmitBodies();
       expect(bodies).toHaveLength(1);
-      expect(bodies[0].externalId).toBe('block:apb_gate:gate-key');
+      // Shape is `blk<NN><appBlockId><key>` — NO colon. The orchestrator validates
+      // `^[A-Za-z0-9_-]+$` behind [ApiController], so a colon-delimited id is a 400.
+      expect(bodies[0].externalId).toBe('blk08apb_gategate-key');
       // The first submit's snapshot was cached (finalize) and REPLAYED verbatim.
       expect(first.snapshot.workflowId).toBe('wf_1');
       expect(second.snapshot.workflowId).toBe('wf_1');
@@ -1051,8 +1053,8 @@ describe('blocks.submitWorkflow', () => {
 
       expect(orch.chargeCount()).toBe(2);
       const bodies = orch.realSubmitBodies();
-      expect(bodies[0].externalId).toBe('block:apb_gate:key-A');
-      expect(bodies[1].externalId).toBe('block:apb_gate:key-B');
+      expect(bodies[0].externalId).toBe('blk08apb_gatekey-A');
+      expect(bodies[1].externalId).toBe('blk08apb_gatekey-B');
     });
 
     it('BACKWARD COMPAT: no idempotencyKey → real submit carries NO externalId (today\'s behavior)', async () => {
@@ -5003,7 +5005,7 @@ describe('customComfy bridge (submit/estimate/settle)', () => {
       expect(mockReserveAppSpend).toHaveBeenCalledTimes(1);
       expect(mockFinalizeGen).toHaveBeenCalledTimes(1);
       // The (single) real submit carried the namespaced externalId (2nd defense layer).
-      expect(mockSubmitWorkflow.mock.calls[0][0].body.externalId).toBe('block:apb_test:cc-key');
+      expect(mockSubmitWorkflow.mock.calls[0][0].body.externalId).toBe('blk08apb_testcc-key');
     });
 
     it('IDEMPOTENCY (audit 🔴-1): a concurrent claim in-progress → 409 CONFLICT, NO reserve, NO submit', async () => {

--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -30,6 +30,14 @@ import {
   checkBlockPublishRateLimit,
 } from '~/server/utils/block-catalog-rate-limit';
 import {
+  BLOCK_IDEMPOTENCY_KEY_REGEX,
+  claimGenIdempotency,
+  composeBlockExternalId,
+  finalizeGenIdempotency,
+  releaseGenIdempotency,
+  type BlockGenIdempotencyClaim,
+} from '~/server/utils/block-gen-idempotency';
+import {
   blockBuzzAccountTypes,
   getMyBuzzAccountsInput,
   getMyBuzzTransactionsInput,
@@ -3671,7 +3679,9 @@ export const blocksRouter = router({
         // spend-CAP counters (per-user daily / per-app) still INCR on a replay —
         // they are keyed on `(userId, day)`, not externalId — which over-counts the
         // ABUSE cap (stricter direction), never a real double-debit.
-        idempotencyKey: z.string().min(1).max(200).optional(),
+        // Charset-restricted (audit 🟢): a UUID-ish alphabet so no control chars /
+        // newlines / colons flow into the orchestrator `externalId`.
+        idempotencyKey: z.string().regex(BLOCK_IDEMPOTENCY_KEY_REGEX).optional(),
       })
     )
     .mutation(async ({ ctx, input }) => {
@@ -3701,7 +3711,7 @@ export const blocksRouter = router({
       // `userId-`), so a key can never collide across apps or users. Undefined when
       // the block sends no key → no externalId → today's non-deduped behavior.
       const blockExternalId = input.idempotencyKey
-        ? `block:${claims.appBlockId}:${input.idempotencyKey}`
+        ? composeBlockExternalId(claims.appBlockId, input.idempotencyKey)
         : undefined;
       // `input.body` is now the textToImage member. Capture it so the narrowing
       // survives into the fire-and-forget spend-attribution CLOSURE below (TS
@@ -3905,13 +3915,64 @@ export const blocksRouter = router({
       // publishRequestId) cumulative ceiling (rolling ~25h window) instead of the
       // per-user daily cap (reserveBlockBuzzSpendForClaims picks the right one;
       // every refund site below keys off the returned `buzzCapKey`, unchanged).
-      const {
-        total,
-        key: buzzCapKey,
-        cap: buzzCap,
-      } = await reserveBlockBuzzSpendForClaims(claims, userId, cost);
+      //
+      // ── GEN IDEMPOTENCY CLAIM (audit 🔴-1). Taken BEFORE the cap reservation +
+      //    orchestrator submit, so two CONCURRENT same-key submits (a double-click /
+      //    SDK auto-retry) can't BOTH reserve + BOTH charge before the orchestrator's
+      //    own (userId, externalId) dedupe engages. Placing it before the reservation
+      //    ALSO stops a replay from double-INCRing the daily/per-app cap counters
+      //    (audit 🟡-2 — they key on (userId|app, day), not externalId). Absent key →
+      //    no claim → byte-identical to today. Fail-CLOSED on a redis error (matches
+      //    the fail-closed reservation it fronts). A resolved submit FINALIZEs the
+      //    cached snapshot; every non-committed exit (cap reject / throw) RELEASEs so
+      //    a genuine retry can re-run. The orchestrator externalId dedupe stays as a
+      //    SECOND defense layer for the cross-process / post-TTL case this can't cover.
+      let genClaimKey: string | null = null;
+      if (input.idempotencyKey) {
+        let claim: BlockGenIdempotencyClaim<{ snapshot: ReturnType<typeof snapshotFromWorkflow> }>;
+        try {
+          claim = await claimGenIdempotency<{ snapshot: ReturnType<typeof snapshotFromWorkflow> }>(
+            userId,
+            claims.appBlockId,
+            input.idempotencyKey
+          );
+        } catch {
+          // Fail-CLOSED — a money path must not dedupe blind; surface a retryable
+          // error (mirrors the fail-closed cap reservation below).
+          throw new TRPCError({
+            code: 'INTERNAL_SERVER_ERROR',
+            message: 'generation idempotency unavailable; please retry',
+          });
+        }
+        if (claim.state === 'replay') {
+          // A prior attempt already resolved — replay its cached snapshot VERBATIM.
+          // No second reservation, no second orchestrator submit.
+          return claim.result;
+        }
+        if (claim.state === 'in_progress') {
+          // The first attempt is still in flight (or a lost/garbage record) — never
+          // race a live first attempt into a 2nd reservation + charge.
+          throw new TRPCError({
+            code: 'CONFLICT',
+            message: 'a generation with this idempotency key is already in progress',
+          });
+        }
+        genClaimKey = claim.key; // state === 'acquired' — we own the first attempt.
+      }
+
+      // The reservation THROWS fail-closed on a redis error; release the claim first
+      // (no money moved → a genuine retry must be allowed to re-run) then re-throw.
+      let reservation: Awaited<ReturnType<typeof reserveBlockBuzzSpendForClaims>>;
+      try {
+        reservation = await reserveBlockBuzzSpendForClaims(claims, userId, cost);
+      } catch (e) {
+        if (genClaimKey) await releaseGenIdempotency(genClaimKey);
+        throw e;
+      }
+      const { total, key: buzzCapKey, cap: buzzCap } = reservation;
       if (total > buzzCap) {
         await refundBlockBuzzSpend(buzzCapKey, cost);
+        if (genClaimKey) await releaseGenIdempotency(genClaimKey);
         return {
           snapshot: {
             workflowId: 'failed',
@@ -3959,6 +4020,9 @@ export const blocksRouter = router({
           // doesn't burn the viewer's own daily ceiling for a spend that never
           // happened.
           await refundBlockBuzzSpend(buzzCapKey, cost);
+          // No money moved → release the idempotency claim so a genuine retry can
+          // re-run (the app cap may clear; the "retry shortly" messages are transient).
+          if (genClaimKey) await releaseGenIdempotency(genClaimKey);
           return {
             snapshot: {
               workflowId: 'failed',
@@ -4022,6 +4086,8 @@ export const blocksRouter = router({
               );
               await refundAppSpend(appSpendReserve.key, appSpendReserve.cost);
             }
+            // No money moved → release the idempotency claim so a genuine retry runs.
+            if (genClaimKey) await releaseGenIdempotency(genClaimKey);
             return {
               snapshot: {
                 workflowId: 'failed',
@@ -4121,8 +4187,22 @@ export const blocksRouter = router({
           );
           await refundDevSessionBuzz(devSessionReserve.sessionId, devSessionReserve.cost);
         }
+        // No resolved submit → NO money moved and NO reservation stands; release the
+        // idempotency claim so a genuine retry with the same key can re-run (the
+        // orchestrator externalId dedupe still protects a retry that DID create a
+        // workflow server-side despite a lost response).
+        if (genClaimKey) await releaseGenIdempotency(genClaimKey);
         throw e;
       }
+
+      // A resolved submit is money-COMMITTED (the reservation is kept regardless of
+      // snapshot status). Cache the terminal result under the idempotency key so a
+      // lost-response retry replays it WITHOUT re-reserving or re-submitting. Done
+      // immediately (before the best-effort attribution closures below) so even a
+      // later throw on this path leaves a correct cached success. Best-effort — a
+      // failed finalize just falls back to the orchestrator externalId dedupe.
+      const genResult = { snapshot: autoClaim ? { ...snapshot, autoClaim } : snapshot };
+      if (genClaimKey) await finalizeGenIdempotency(genClaimKey, genResult);
 
       // Log the workflow submission to the per-user activity feed so
       // /apps/installed → Activity shows "this app ran a workflow on
@@ -4334,7 +4414,8 @@ export const blocksRouter = router({
         });
       }
 
-      return { snapshot: autoClaim ? { ...snapshot, autoClaim } : snapshot };
+      // Same object already cached under the idempotency key (see genResult above).
+      return genResult;
     }),
 
   /**
@@ -5631,7 +5712,7 @@ async function submitCustomComfyWorkflow(opts: {
   // Namespaced idempotency externalId (item 2, gen half) — same shape as the
   // txt2img branch. Undefined when no key is sent → today's non-deduped behavior.
   const blockExternalId = idempotencyKey
-    ? `block:${claims.appBlockId}:${idempotencyKey}`
+    ? composeBlockExternalId(claims.appBlockId, idempotencyKey)
     : undefined;
 
   // ── Page-only guard (mirror the model-token sourceImage rejection ~:3294).
@@ -5738,17 +5819,53 @@ async function submitCustomComfyWorkflow(opts: {
     };
   }
 
+  // ── GEN IDEMPOTENCY CLAIM (audit 🔴-1) — same guard as the txt2img path. Taken
+  //    BEFORE the cap reservation + orchestrator submit so two CONCURRENT same-key
+  //    submits can't BOTH reserve + BOTH charge, and a replay can't double-INCR the
+  //    cap counters (🟡-2). Absent key → no claim → byte-identical to today. Fail-
+  //    CLOSED on a redis error; a resolved submit FINALIZEs, every non-committed
+  //    exit RELEASEs. The orchestrator externalId dedupe stays as a 2nd layer.
+  let genClaimKey: string | null = null;
+  if (idempotencyKey) {
+    let claim: BlockGenIdempotencyClaim<{ snapshot: ReturnType<typeof snapshotFromWorkflow> }>;
+    try {
+      claim = await claimGenIdempotency<{ snapshot: ReturnType<typeof snapshotFromWorkflow> }>(
+        userId,
+        claims.appBlockId,
+        idempotencyKey
+      );
+    } catch {
+      throw new TRPCError({
+        code: 'INTERNAL_SERVER_ERROR',
+        message: 'generation idempotency unavailable; please retry',
+      });
+    }
+    if (claim.state === 'replay') return claim.result;
+    if (claim.state === 'in_progress') {
+      throw new TRPCError({
+        code: 'CONFLICT',
+        message: 'a generation with this idempotency key is already in progress',
+      });
+    }
+    genClaimKey = claim.key;
+  }
+
   // (2) Reserve the CEILING (not the 0 estimate) against the cumulative cap so
   // post-paid spend can't slip past it counted at ~0. A RUN-FOR-REAL review token
   // reserves against the tight per-(mod, publishRequestId) session ceiling; every
   // other token keeps the per-user 50k/day cap (byte-identical).
-  const {
-    total,
-    key: buzzCapKey,
-    cap: buzzCap,
-  } = await reserveBlockBuzzSpendForClaims(claims, userId, ceiling);
+  // The reservation THROWS fail-closed on a redis error; release the claim first.
+  let reservation: Awaited<ReturnType<typeof reserveBlockBuzzSpendForClaims>>;
+  try {
+    reservation = await reserveBlockBuzzSpendForClaims(claims, userId, ceiling);
+  } catch (e) {
+    if (genClaimKey) await releaseGenIdempotency(genClaimKey);
+    throw e;
+  }
+  const { total, key: buzzCapKey, cap: buzzCap } = reservation;
   if (total > buzzCap) {
     await refundBlockBuzzSpend(buzzCapKey, ceiling);
+    if (genClaimKey) await releaseGenIdempotency(genClaimKey);
     return {
       snapshot: {
         workflowId: 'failed',
@@ -5775,6 +5892,8 @@ async function submitCustomComfyWorkflow(opts: {
       // Roll back the per-user reservation so a rejected submit doesn't burn the
       // viewer's own daily ceiling for a spend that never happened.
       await refundBlockBuzzSpend(buzzCapKey, ceiling);
+      // No money moved → release the idempotency claim so a genuine retry runs.
+      if (genClaimKey) await releaseGenIdempotency(genClaimKey);
       return {
         snapshot: {
           workflowId: 'failed',
@@ -5831,6 +5950,8 @@ async function submitCustomComfyWorkflow(opts: {
           );
           await refundAppSpend(appSpendReserve.key, appSpendReserve.cost);
         }
+        // No money moved → release the idempotency claim so a genuine retry runs.
+        if (genClaimKey) await releaseGenIdempotency(genClaimKey);
         return {
           snapshot: {
             workflowId: 'failed',
@@ -5899,8 +6020,18 @@ async function submitCustomComfyWorkflow(opts: {
       );
       await refundDevSessionBuzz(devSessionReserve.sessionId, devSessionReserve.cost);
     }
+    // No resolved submit → no money moved; release the idempotency claim so a
+    // genuine retry can re-run (orchestrator externalId dedupe still covers a retry
+    // that DID create a workflow server-side despite a lost response).
+    if (genClaimKey) await releaseGenIdempotency(genClaimKey);
     throw e;
   }
+
+  // A resolved submit is money-COMMITTED. Cache the terminal result under the
+  // idempotency key BEFORE the (awaited) settle-record persist below, so a lost-
+  // response retry replays it even if that persist throws. Best-effort.
+  const genResult = { snapshot };
+  if (genClaimKey) await finalizeGenIdempotency(genClaimKey, genResult);
 
   // ── Persist the settle record (AWAITED — see custom-comfy-settle.service). The
   // terminal poll/cancel hook reads it and refunds `ceiling - actual` on the
@@ -6038,7 +6169,8 @@ async function submitCustomComfyWorkflow(opts: {
     });
   }
 
-  return { snapshot };
+  // Same object already cached under the idempotency key (see genResult above).
+  return genResult;
 }
 
 /**

--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -34,6 +34,7 @@ import {
   claimGenIdempotency,
   composeBlockExternalId,
   finalizeGenIdempotency,
+  mintServerBlockExternalId,
   releaseGenIdempotency,
   type BlockGenIdempotencyClaim,
 } from '~/server/utils/block-gen-idempotency';
@@ -3674,8 +3675,11 @@ export const blocksRouter = router({
         // lost-response / timeout RETRY that re-submits with the SAME key collapses
         // to the existing workflow instead of a second orchestrator submit — the
         // orchestrator dedupes on `(userId, externalId)` and returns the ORIGINAL
-        // transactions (no second Buzz charge). Absent → no externalId → today's
-        // behavior (additive/backward-compatible). NOTE: the civitai-side Redis
+        // transactions (no second Buzz charge). Absent → the server MINTS a
+        // per-request `bls<uuid>` externalId instead (audit 🔴-1), which dedupes
+        // `submitWorkflow`'s own 3× internal retry of THIS call but — being unique
+        // per request — does NOT dedupe a CLIENT-level retry; that still needs a
+        // client key. NOTE: the civitai-side Redis
         // spend-CAP counters (per-user daily / per-app) still INCR on a replay —
         // they are keyed on `(userId, day)`, not externalId — which over-counts the
         // ABUSE cap (stricter direction), never a real double-debit.
@@ -3708,11 +3712,27 @@ export const blocksRouter = router({
       }
       // Namespaced idempotency externalId for the orchestrator dedupe (item 2, gen
       // half). Per-app + per-user-scoped (the orchestrator additionally prefixes
-      // `userId-`), so a key can never collide across apps or users. Undefined when
-      // the block sends no key → no externalId → today's non-deduped behavior.
+      // `userId-`), so a key can never collide across apps or users.
+      //
+      // 🔴 ALWAYS SET (audit 🔴-1). When the block sends no key we MINT one
+      // server-side instead of leaving `externalId` undefined. The double-charge
+      // this closes is server-side and unconditional: `submitWorkflow` retries the
+      // real submit up to 3× with no per-attempt timeout, and a 502/504 AFTER the
+      // orchestrator created + charged the workflow makes each retry create another
+      // one. Gating `externalId` on a client key closed nothing in practice — NO
+      // shipped client sends one. Minted ONCE here (not per attempt): the body built
+      // below is the same object `submitWorkflowWithRetry` reuses on every attempt,
+      // so all attempts of THIS request present the same id while a genuinely
+      // different submit gets a different UUID. The `bls` origin tag keeps the
+      // minted namespace disjoint from the client-key `blk` namespace.
+      //
+      // NOTE the civitai-side redis SET-NX claim below stays gated on the CLIENT key
+      // — a server-minted id is unique per request, so claiming on it could never
+      // dedupe anything (it would only add two redis round-trips and a stuck-sentinel
+      // failure mode). Keyed clients therefore behave EXACTLY as before.
       const blockExternalId = input.idempotencyKey
         ? composeBlockExternalId(claims.appBlockId, input.idempotencyKey)
-        : undefined;
+        : mintServerBlockExternalId();
       // `input.body` is now the textToImage member. Capture it so the narrowing
       // survives into the fire-and-forget spend-attribution CLOSURE below (TS
       // drops discriminated-union property narrowing at nested-function
@@ -4156,11 +4176,13 @@ export const blocksRouter = router({
             // Authoritative maturity clamp on the REAL submit — the orchestrator
             // rejects mature output when this is false. Token-claim derived.
             ...(allowMatureContent === false ? { allowMatureContent: false } : {}),
-            // Idempotency (item 2, gen half): a same-key retry collapses to the
-            // existing workflow on the orchestrator (dedupe on (userId, externalId))
-            // → no second Buzz charge. Only set on the REAL submit — the whatIf
-            // preflight stays keyless (it never creates a workflow).
-            ...(blockExternalId ? { externalId: blockExternalId } : {}),
+            // Idempotency: a retry — the CLIENT's (same key) or `submitWorkflow`'s
+            // OWN internal 3× retry of THIS call — collapses to the existing
+            // workflow on the orchestrator (dedupe on (userId, externalId)) → no
+            // second Buzz charge. Always present (client-keyed or server-minted).
+            // Only set on the REAL submit — the whatIf preflight stays keyless (it
+            // never creates a workflow, and must never occupy a dedupe slot).
+            externalId: blockExternalId,
           },
         });
         snapshot = snapshotFromWorkflow(submitted);
@@ -5709,11 +5731,15 @@ async function submitCustomComfyWorkflow(opts: {
   idempotencyKey?: string;
 }) {
   const { ctx, claims, body, idempotencyKey } = opts;
-  // Namespaced idempotency externalId (item 2, gen half) — same shape as the
-  // txt2img branch. Undefined when no key is sent → today's non-deduped behavior.
+  // Namespaced idempotency externalId — same shape as the txt2img branch, and like
+  // it ALWAYS SET (audit 🔴-1): a server-minted `bls<uuid>` when the block sends no
+  // key, so `submitWorkflow`'s own 3× retry of the real submit can never create (and
+  // charge for) a second workflow after a 502/504. Minted ONCE here — the body built
+  // below is the object the retry wrapper reuses across attempts. See the txt2img
+  // branch for the full rationale + the client-vs-server namespace split.
   const blockExternalId = idempotencyKey
     ? composeBlockExternalId(claims.appBlockId, idempotencyKey)
-    : undefined;
+    : mintServerBlockExternalId();
 
   // ── Page-only guard (mirror the model-token sourceImage rejection ~:3294).
   if (!isPageToken(claims)) {
@@ -5998,9 +6024,10 @@ async function submitCustomComfyWorkflow(opts: {
         currencies,
         // Authoritative maturity clamp on the real submit — token-claim derived.
         ...(allowMatureContent === false ? { allowMatureContent: false } : {}),
-        // Idempotency (item 2, gen half): a same-key retry collapses to the
-        // existing workflow on the orchestrator → no second Buzz charge.
-        ...(blockExternalId ? { externalId: blockExternalId } : {}),
+        // Idempotency: a retry — the CLIENT's (same key) or `submitWorkflow`'s OWN
+        // internal 3× retry of THIS call — collapses to the existing workflow on the
+        // orchestrator → no second Buzz charge. Always present.
+        externalId: blockExternalId,
       },
     });
     snapshot = snapshotFromWorkflow(submitted);

--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -3657,7 +3657,23 @@ export const blocksRouter = router({
   submitWorkflow: publicProcedure
     // Block-JWT-authed (no session for dev:live) — flag evaluated against the
     // TOKEN subject below, not the `enforceAppBlocksFlag` middleware's ctx.user.
-    .input(z.object({ blockToken: z.string().min(1), body: blockWorkflowBodySchema }))
+    .input(
+      z.object({
+        blockToken: z.string().min(1),
+        body: blockWorkflowBodySchema,
+        // OPTIONAL client idempotency key (item 2, gen half). Threaded to
+        // `body.externalId` (namespaced `block:<appBlockId>:<key>`) so a
+        // lost-response / timeout RETRY that re-submits with the SAME key collapses
+        // to the existing workflow instead of a second orchestrator submit — the
+        // orchestrator dedupes on `(userId, externalId)` and returns the ORIGINAL
+        // transactions (no second Buzz charge). Absent → no externalId → today's
+        // behavior (additive/backward-compatible). NOTE: the civitai-side Redis
+        // spend-CAP counters (per-user daily / per-app) still INCR on a replay —
+        // they are keyed on `(userId, day)`, not externalId — which over-counts the
+        // ABUSE cap (stricter direction), never a real double-debit.
+        idempotencyKey: z.string().min(1).max(200).optional(),
+      })
+    )
     .mutation(async ({ ctx, input }) => {
       const claims = await verifyBlockToken(input.blockToken);
       if (!claims) throw new TRPCError({ code: 'UNAUTHORIZED', message: 'invalid block token' });
@@ -3673,8 +3689,20 @@ export const blocksRouter = router({
       // below stays byte-identical (we only ADD a branch); after this early
       // return `input.body` narrows to the textToImage member for the rest.
       if (input.body.kind === 'customComfy') {
-        return await submitCustomComfyWorkflow({ ctx, claims, body: input.body });
+        return await submitCustomComfyWorkflow({
+          ctx,
+          claims,
+          body: input.body,
+          idempotencyKey: input.idempotencyKey,
+        });
       }
+      // Namespaced idempotency externalId for the orchestrator dedupe (item 2, gen
+      // half). Per-app + per-user-scoped (the orchestrator additionally prefixes
+      // `userId-`), so a key can never collide across apps or users. Undefined when
+      // the block sends no key → no externalId → today's non-deduped behavior.
+      const blockExternalId = input.idempotencyKey
+        ? `block:${claims.appBlockId}:${input.idempotencyKey}`
+        : undefined;
       // `input.body` is now the textToImage member. Capture it so the narrowing
       // survives into the fire-and-forget spend-attribution CLOSURE below (TS
       // drops discriminated-union property narrowing at nested-function
@@ -4062,6 +4090,11 @@ export const blocksRouter = router({
             // Authoritative maturity clamp on the REAL submit — the orchestrator
             // rejects mature output when this is false. Token-claim derived.
             ...(allowMatureContent === false ? { allowMatureContent: false } : {}),
+            // Idempotency (item 2, gen half): a same-key retry collapses to the
+            // existing workflow on the orchestrator (dedupe on (userId, externalId))
+            // → no second Buzz charge. Only set on the REAL submit — the whatIf
+            // preflight stays keyless (it never creates a workflow).
+            ...(blockExternalId ? { externalId: blockExternalId } : {}),
           },
         });
         snapshot = snapshotFromWorkflow(submitted);
@@ -5591,8 +5624,15 @@ async function submitCustomComfyWorkflow(opts: {
   ctx: Context;
   claims: BlockClaims;
   body: CustomComfyBody;
+  /** OPTIONAL client idempotency key (item 2, gen half) → orchestrator externalId. */
+  idempotencyKey?: string;
 }) {
-  const { ctx, claims, body } = opts;
+  const { ctx, claims, body, idempotencyKey } = opts;
+  // Namespaced idempotency externalId (item 2, gen half) — same shape as the
+  // txt2img branch. Undefined when no key is sent → today's non-deduped behavior.
+  const blockExternalId = idempotencyKey
+    ? `block:${claims.appBlockId}:${idempotencyKey}`
+    : undefined;
 
   // ── Page-only guard (mirror the model-token sourceImage rejection ~:3294).
   if (!isPageToken(claims)) {
@@ -5837,6 +5877,9 @@ async function submitCustomComfyWorkflow(opts: {
         currencies,
         // Authoritative maturity clamp on the real submit — token-claim derived.
         ...(allowMatureContent === false ? { allowMatureContent: false } : {}),
+        // Idempotency (item 2, gen half): a same-key retry collapses to the
+        // existing workflow on the orchestrator → no second Buzz charge.
+        ...(blockExternalId ? { externalId: blockExternalId } : {}),
       },
     });
     snapshot = snapshotFromWorkflow(submitted);

--- a/src/server/services/blocks/__tests__/tip.detail.test.ts
+++ b/src/server/services/blocks/__tests__/tip.detail.test.ts
@@ -18,7 +18,15 @@ const {
   mockReserve,
   mockRefund,
 } = vi.hoisted(() => ({
-  mockCreateTip: vi.fn(async () => undefined),
+  // Models the REAL return shape: the ledger result plus the audit-🔴-2 dedupe
+  // report the endpoint reads to refund a burned cap reservation. (`undefined` here
+  // was a stale model — the handler always returns this object or throws.)
+  mockCreateTip: vi.fn(async () => ({
+    transactions: ['t1'],
+    conflicts: [] as string[],
+    deduped: false,
+    dedupedAmount: 0,
+  })),
   mockUserFindUnique: vi.fn(async () => ({ id: 7, deletedAt: null })),
   mockHydrateSubject: vi.fn(async () => ({ id: 42, bannedAt: null, muted: false })),
   mockCheckRateLimit: vi.fn(async () => ({ allowed: true })),

--- a/src/server/services/orchestrator/__tests__/submitWorkflow.timeout.test.ts
+++ b/src/server/services/orchestrator/__tests__/submitWorkflow.timeout.test.ts
@@ -204,3 +204,36 @@ describe('submitWorkflow — whatIf per-attempt timeout → 503, generate untouc
     expect(mockSubmitWorkflow).toHaveBeenCalledTimes(3);
   });
 });
+
+/**
+ * The contract the App Blocks server-minted `externalId` rests on (audit 🔴-1).
+ *
+ * `submitWorkflowWithRetry`'s own doc says it adds NO idempotency key and that "the
+ * same body — and thus the same key — is reused across every retry here". The blocks
+ * router mints ONE `externalId` before building the body precisely because of that.
+ * Nothing asserted it, so pin it: if a future refactor ever cloned/rebuilt the body
+ * per attempt, a lost-response retry would silently start double-charging again.
+ */
+describe('submitWorkflowWithRetry — externalId stability across attempts', () => {
+  it('presents the SAME body.externalId on every attempt of one logical submit', async () => {
+    // Attempt 1 + 2 are retryable 5xx; attempt 3 succeeds.
+    mockSubmitWorkflow
+      .mockResolvedValueOnce({ data: undefined, response: { status: 502 } })
+      .mockResolvedValueOnce({ data: undefined, response: { status: 503 } })
+      .mockResolvedValueOnce(okResult('wf-1'));
+
+    const body = { steps: [], externalId: 'bls11111111-2222-3333-4444-555555555555' };
+    const result = await submitWorkflowWithRetry(
+      { client: {} as never, body: body as never },
+      { baseDelayMs: 0 }
+    );
+
+    expect(result.attempts).toBe(3);
+    const seen = mockSubmitWorkflow.mock.calls.map((c: any[]) => c[0].body.externalId);
+    expect(seen).toHaveLength(3);
+    // 🔴 The load-bearing assertion: one id across all attempts, so the orchestrator's
+    // `(userId, externalId)` dedupe collapses them to ONE workflow + ONE charge.
+    expect(new Set(seen).size).toBe(1);
+    expect(seen[0]).toBe('bls11111111-2222-3333-4444-555555555555');
+  });
+});

--- a/src/server/utils/__tests__/block-gen-idempotency.test.ts
+++ b/src/server/utils/__tests__/block-gen-idempotency.test.ts
@@ -43,6 +43,7 @@ import {
   claimGenIdempotency,
   composeBlockExternalId,
   finalizeGenIdempotency,
+  mintServerBlockExternalId,
   releaseGenIdempotency,
 } from '../block-gen-idempotency';
 
@@ -172,10 +173,22 @@ describe('charset + externalId guards (audit 🟢)', () => {
     expect(ORCHESTRATOR_EXTERNAL_ID_REGEX.test(realistic)).toBe(true);
     expect(realistic.length).toBeLessThanOrEqual(ORCHESTRATOR_EXTERNAL_ID_MAX);
 
-    // Worst realistic case: an `ephemeral-<40-char slug>` dev id + a max-length key.
-    const worst = composeBlockExternalId(`ephemeral-${'s'.repeat(40)}`, 'k'.repeat(64));
+    // 🔴 TRUE worst case (audit 🟢). The LONGEST appBlockId shape is
+    // `page_local_<slug>` = 11 + a slug bounded at 40 by dev-token.ts's
+    // `z.string().min(3).max(40)` = 51 chars — NOT `ephemeral-<slug>` (50), which is
+    // what this test used to exercise. With a max-length 64-char key that is
+    // 3 + 2 + 51 + 64 = 120, headroom 8 (the doc previously claimed 119).
+    const worstAppBlockId = `page_local_${'s'.repeat(40)}`;
+    expect(worstAppBlockId).toHaveLength(51);
+    const worst = composeBlockExternalId(worstAppBlockId, 'k'.repeat(64));
+    expect(worst).toHaveLength(120);
     expect(ORCHESTRATOR_EXTERNAL_ID_REGEX.test(worst)).toBe(true);
     expect(worst.length).toBeLessThanOrEqual(ORCHESTRATOR_EXTERNAL_ID_MAX);
+    // The other two synthetic shapes are strictly shorter, so they cannot beat it.
+    expect(composeBlockExternalId(`ephemeral-${'s'.repeat(40)}`, 'k'.repeat(64))).toHaveLength(
+      119
+    );
+    expect(composeBlockExternalId(`pubreq_${'0'.repeat(26)}`, 'k'.repeat(64))).toHaveLength(102);
   });
 
   it('composeBlockExternalId is INJECTIVE across (app, key) even when both contain - and _', () => {
@@ -206,5 +219,47 @@ describe('charset + externalId guards (audit 🟢)', () => {
     expect(() => composeBlockExternalId('a'.repeat(99), 'k'.repeat(64))).toThrow(/too long/);
     // An appBlockId straying outside the orchestrator alphabet is caught too.
     expect(() => composeBlockExternalId('apb:bad', 'k')).toThrow(/characters the orchestrator/);
+  });
+
+  it('composeBlockExternalId is typeof-SAFE (audit 🟢) — a non-string can never slip past', () => {
+    // 🔴 Without the typeof guard, `undefined.length` makes BOTH `undefined < 1` and
+    // `undefined > 99` false, so the length check passes and
+    // `String(undefined).padStart(2,'0')` emits a NINE-char pseudo-`NN`
+    // (`undefined`), silently destroying the length-prefix injectivity the whole
+    // scheme rests on. Assert it THROWS rather than emitting such an id.
+    expect(() => composeBlockExternalId(undefined as never, 'k')).toThrow(/must be strings/);
+    expect(() => composeBlockExternalId(null as never, 'k')).toThrow(/must be strings/);
+    expect(() => composeBlockExternalId(123 as never, 'k')).toThrow(/must be strings/);
+    expect(() => composeBlockExternalId('apb_x', undefined as never)).toThrow(/must be strings/);
+  });
+});
+
+describe('mintServerBlockExternalId (audit 🔴-1)', () => {
+  it('emits an id the ORCHESTRATOR accepts, in the SERVER namespace', () => {
+    const id = mintServerBlockExternalId();
+    // `bls` (server) vs `blk` (client) — the two namespaces differ at index 2, so
+    // they are DISJOINT by construction and a minted id can never collide with a
+    // client-supplied one.
+    expect(id.startsWith('bls')).toBe(true);
+    expect(id.startsWith('blk')).toBe(false);
+    expect(ORCHESTRATOR_EXTERNAL_ID_REGEX.test(id)).toBe(true);
+    expect(id.length).toBeLessThanOrEqual(ORCHESTRATOR_EXTERNAL_ID_MAX);
+    // Fixed shape: 3-char tag + a 36-char UUID. Nothing caller-supplied contributes
+    // to the length, so the guard can never trip on this UNCONDITIONAL path.
+    expect(id).toHaveLength(39);
+  });
+
+  it('is UNIQUE per call (a minted id must never fuse two distinct submits)', () => {
+    const ids = new Set(Array.from({ length: 200 }, () => mintServerBlockExternalId()));
+    expect(ids.size).toBe(200);
+  });
+
+  it('can never collide with a CLIENT-composed id, even for a hostile key', () => {
+    // A block cannot craft an idempotencyKey that makes composeBlockExternalId emit
+    // something in the `bls` namespace — the `blk` tag is fixed and comes first.
+    const client = composeBlockExternalId('apb_x', 'bls00000000-0000-0000-0000-000000000000');
+    expect(client.startsWith('blk')).toBe(true);
+    const minted = new Set(Array.from({ length: 50 }, () => mintServerBlockExternalId()));
+    expect(minted.has(client)).toBe(false);
   });
 });

--- a/src/server/utils/__tests__/block-gen-idempotency.test.ts
+++ b/src/server/utils/__tests__/block-gen-idempotency.test.ts
@@ -125,7 +125,9 @@ describe('releaseGenIdempotency', () => {
 
   it('is best-effort — never throws on a redis error', async () => {
     mockSys.del.mockRejectedValueOnce(new Error('redis down'));
-    await expect(releaseGenIdempotency('system:blocks:gen-idem:42:apb_x:key-1')).resolves.toBeUndefined();
+    await expect(
+      releaseGenIdempotency('system:blocks:gen-idem:42:apb_x:key-1')
+    ).resolves.toBeUndefined();
   });
 });
 

--- a/src/server/utils/__tests__/block-gen-idempotency.test.ts
+++ b/src/server/utils/__tests__/block-gen-idempotency.test.ts
@@ -1,0 +1,168 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Direct unit coverage for the GEN idempotency REDIS PRIMITIVES
+ * (`claimGenIdempotency` / `finalizeGenIdempotency` / `releaseGenIdempotency`),
+ * exercised against an in-memory redis mock so the SET-NX acquire/replay/
+ * in-progress state machine, the finalize→replay round-trip, release, and the
+ * fail-closed posture are tested for real (the router tests mock these away).
+ *
+ * Mirrors block-tip-rate-limit.test.ts (the sibling tip idempotency layer).
+ */
+
+const { sysStore, sysTtls, mockSys } = vi.hoisted(() => {
+  const sysStore = new Map<string, string>();
+  const sysTtls = new Map<string, number>();
+  const mockSys = {
+    set: vi.fn(async (k: string, val: string, opts?: { NX?: boolean; EX?: number }) => {
+      if (opts?.NX && sysStore.has(k)) return null; // NX: only set when absent
+      sysStore.set(k, val);
+      if (opts?.EX != null) sysTtls.set(k, opts.EX);
+      return 'OK';
+    }),
+    get: vi.fn(async (k: string) => sysStore.get(k) ?? null),
+    del: vi.fn(async (k: string) => {
+      const had = sysStore.has(k);
+      sysStore.delete(k);
+      sysTtls.delete(k);
+      return had ? 1 : 0;
+    }),
+  };
+  return { sysStore, sysTtls, mockSys };
+});
+
+vi.mock('~/server/redis/client', () => ({
+  sysRedis: mockSys,
+  REDIS_SYS_KEYS: { BLOCKS: { GEN_IDEM: 'system:blocks:gen-idem' } },
+}));
+
+import {
+  BLOCK_IDEMPOTENCY_KEY_REGEX,
+  ORCHESTRATOR_EXTERNAL_ID_MAX,
+  claimGenIdempotency,
+  composeBlockExternalId,
+  finalizeGenIdempotency,
+  releaseGenIdempotency,
+} from '../block-gen-idempotency';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  sysStore.clear();
+  sysTtls.clear();
+});
+
+describe('claimGenIdempotency', () => {
+  it('ACQUIRES on the first claim (SET NX) with a per-(user, app, key) key + TTL', async () => {
+    const claim = await claimGenIdempotency(42, 'apb_x', 'key-1');
+    expect(claim).toEqual({ state: 'acquired', key: 'system:blocks:gen-idem:42:apb_x:key-1' });
+    // In-progress sentinel written with an EX TTL (10 min).
+    expect(mockSys.set).toHaveBeenCalledWith(
+      'system:blocks:gen-idem:42:apb_x:key-1',
+      ' in-progress',
+      { NX: true, EX: 10 * 60 }
+    );
+    expect(sysTtls.get('system:blocks:gen-idem:42:apb_x:key-1')).toBe(10 * 60);
+  });
+
+  it('returns IN_PROGRESS for a concurrent same-key claim while the first is unfinalized', async () => {
+    const first = await claimGenIdempotency(42, 'apb_x', 'key-1');
+    expect(first.state).toBe('acquired');
+    // Second claim before the first finalizes → the sentinel is present, not a
+    // terminal result → in_progress (the router 409s; never a 2nd reservation).
+    const second = await claimGenIdempotency(42, 'apb_x', 'key-1');
+    expect(second).toEqual({ state: 'in_progress' });
+  });
+
+  it('REPLAYS the cached terminal result after finalize (no re-run)', async () => {
+    const first = await claimGenIdempotency<{ snapshot: { workflowId: string } }>(
+      42,
+      'apb_x',
+      'key-1'
+    );
+    if (first.state !== 'acquired') throw new Error('expected acquired');
+    await finalizeGenIdempotency(first.key, { snapshot: { workflowId: 'wf_1' } });
+
+    const replay = await claimGenIdempotency<{ snapshot: { workflowId: string } }>(
+      42,
+      'apb_x',
+      'key-1'
+    );
+    expect(replay).toEqual({ state: 'replay', result: { snapshot: { workflowId: 'wf_1' } } });
+  });
+
+  it('a malformed stored value is treated as IN_PROGRESS (never re-run a money path)', async () => {
+    // Simulate a corrupt / partially-written record under the key.
+    sysStore.set('system:blocks:gen-idem:42:apb_x:key-1', 'not json');
+    const claim = await claimGenIdempotency(42, 'apb_x', 'key-1');
+    expect(claim).toEqual({ state: 'in_progress' });
+  });
+
+  it('FAILS CLOSED — throws on a redis error at claim time (money path must not dedupe blind)', async () => {
+    mockSys.set.mockRejectedValueOnce(new Error('redis down'));
+    await expect(claimGenIdempotency(42, 'apb_x', 'key-1')).rejects.toThrow('redis down');
+  });
+
+  it('key is INJECTIVE across (user, app, key) — no cross-app / cross-user collision', async () => {
+    const a = await claimGenIdempotency(42, 'apb_x', 'k');
+    const b = await claimGenIdempotency(42, 'apb_y', 'k'); // different app
+    const c = await claimGenIdempotency(99, 'apb_x', 'k'); // different user
+    const keys = [a, b, c].map((x) => (x.state === 'acquired' ? x.key : ''));
+    expect(new Set(keys).size).toBe(3);
+  });
+});
+
+describe('releaseGenIdempotency', () => {
+  it('deletes the claim so a genuine retry with the same key ACQUIRES fresh', async () => {
+    const first = await claimGenIdempotency(42, 'apb_x', 'key-1');
+    if (first.state !== 'acquired') throw new Error('expected acquired');
+    await releaseGenIdempotency(first.key);
+    expect(sysStore.has(first.key)).toBe(false);
+    // A subsequent claim wins the sentinel again (transient-reject retry path).
+    const again = await claimGenIdempotency(42, 'apb_x', 'key-1');
+    expect(again.state).toBe('acquired');
+  });
+
+  it('is best-effort — never throws on a redis error', async () => {
+    mockSys.del.mockRejectedValueOnce(new Error('redis down'));
+    await expect(releaseGenIdempotency('system:blocks:gen-idem:42:apb_x:key-1')).resolves.toBeUndefined();
+  });
+});
+
+describe('finalizeGenIdempotency', () => {
+  it('is best-effort — a failed write never throws (falls back to orchestrator dedupe)', async () => {
+    mockSys.set.mockRejectedValueOnce(new Error('redis down'));
+    await expect(
+      finalizeGenIdempotency('system:blocks:gen-idem:42:apb_x:key-1', { snapshot: {} })
+    ).resolves.toBeUndefined();
+  });
+});
+
+describe('charset + externalId guards (audit 🟢)', () => {
+  it('accepts UUID-ish keys (crypto.randomUUID + the SDK idem-<base36> fallback)', () => {
+    expect(BLOCK_IDEMPOTENCY_KEY_REGEX.test('3f1a9c2e-5b6d-4e7f-8a90-1b2c3d4e5f60')).toBe(true);
+    expect(BLOCK_IDEMPOTENCY_KEY_REGEX.test('idem-abc123-def456')).toBe(true);
+    expect(BLOCK_IDEMPOTENCY_KEY_REGEX.test('A_z-0')).toBe(true);
+  });
+
+  it('rejects control chars, whitespace, colons, and over-length keys', () => {
+    expect(BLOCK_IDEMPOTENCY_KEY_REGEX.test('has space')).toBe(false);
+    expect(BLOCK_IDEMPOTENCY_KEY_REGEX.test('new\nline')).toBe(false);
+    expect(BLOCK_IDEMPOTENCY_KEY_REGEX.test('has:colon')).toBe(false);
+    expect(BLOCK_IDEMPOTENCY_KEY_REGEX.test('')).toBe(false);
+    expect(BLOCK_IDEMPOTENCY_KEY_REGEX.test('a'.repeat(201))).toBe(false);
+  });
+
+  it('composeBlockExternalId namespaces per-(app, key) and stays within the assumed ceiling', () => {
+    expect(composeBlockExternalId('apb_x', 'key-1')).toBe('block:apb_x:key-1');
+    // A max-length key on a real appBlockId is comfortably under the ceiling.
+    const composed = composeBlockExternalId('apb_0123456789abcdefghijklmnop', 'k'.repeat(200));
+    expect(composed.length).toBeLessThanOrEqual(ORCHESTRATOR_EXTERNAL_ID_MAX);
+  });
+
+  it('composeBlockExternalId throws (fail-closed) if the composed id would exceed the ceiling', () => {
+    // Defense-in-depth guard: a pathological over-long appBlockId trips it before
+    // any reservation (no money moves). Real ids can never reach this.
+    const hugeApp = 'a'.repeat(ORCHESTRATOR_EXTERNAL_ID_MAX);
+    expect(() => composeBlockExternalId(hugeApp, 'k')).toThrow(/too long/);
+  });
+});

--- a/src/server/utils/__tests__/block-gen-idempotency.test.ts
+++ b/src/server/utils/__tests__/block-gen-idempotency.test.ts
@@ -39,6 +39,7 @@ vi.mock('~/server/redis/client', () => ({
 import {
   BLOCK_IDEMPOTENCY_KEY_REGEX,
   ORCHESTRATOR_EXTERNAL_ID_MAX,
+  ORCHESTRATOR_EXTERNAL_ID_REGEX,
   claimGenIdempotency,
   composeBlockExternalId,
   finalizeGenIdempotency,
@@ -149,20 +150,59 @@ describe('charset + externalId guards (audit 🟢)', () => {
     expect(BLOCK_IDEMPOTENCY_KEY_REGEX.test('new\nline')).toBe(false);
     expect(BLOCK_IDEMPOTENCY_KEY_REGEX.test('has:colon')).toBe(false);
     expect(BLOCK_IDEMPOTENCY_KEY_REGEX.test('')).toBe(false);
-    expect(BLOCK_IDEMPOTENCY_KEY_REGEX.test('a'.repeat(201))).toBe(false);
+    expect(BLOCK_IDEMPOTENCY_KEY_REGEX.test('a'.repeat(65))).toBe(false);
+    // The bound is 64 so the composed externalId can never approach the REAL
+    // orchestrator ceiling of 128.
+    expect(BLOCK_IDEMPOTENCY_KEY_REGEX.test('a'.repeat(64))).toBe(true);
   });
 
-  it('composeBlockExternalId namespaces per-(app, key) and stays within the assumed ceiling', () => {
-    expect(composeBlockExternalId('apb_x', 'key-1')).toBe('block:apb_x:key-1');
-    // A max-length key on a real appBlockId is comfortably under the ceiling.
-    const composed = composeBlockExternalId('apb_0123456789abcdefghijklmnop', 'k'.repeat(200));
-    expect(composed.length).toBeLessThanOrEqual(ORCHESTRATOR_EXTERNAL_ID_MAX);
+  it('composeBlockExternalId emits an id the ORCHESTRATOR accepts (charset + length)', () => {
+    // 🔴 The orchestrator validates `^[A-Za-z0-9_-]+$` (max 128) behind
+    // [ApiController] → an out-of-charset id is a 400, not a truncation. A
+    // colon-delimited shape (the pre-fix behavior) would 400 every keyed submit.
+    expect(composeBlockExternalId('apb_x', 'key-1')).toBe('blk05apb_xkey-1');
+    expect(composeBlockExternalId('apb_x', 'key-1')).not.toContain(':');
+
+    const realistic = composeBlockExternalId(
+      'apb_0123456789abcdefghijklmnop',
+      '3f1a9c2e-5b6d-4e7f-8a90-1b2c3d4e5f60'
+    );
+    expect(ORCHESTRATOR_EXTERNAL_ID_REGEX.test(realistic)).toBe(true);
+    expect(realistic.length).toBeLessThanOrEqual(ORCHESTRATOR_EXTERNAL_ID_MAX);
+
+    // Worst realistic case: an `ephemeral-<40-char slug>` dev id + a max-length key.
+    const worst = composeBlockExternalId(`ephemeral-${'s'.repeat(40)}`, 'k'.repeat(64));
+    expect(ORCHESTRATOR_EXTERNAL_ID_REGEX.test(worst)).toBe(true);
+    expect(worst.length).toBeLessThanOrEqual(ORCHESTRATOR_EXTERNAL_ID_MAX);
   });
 
-  it('composeBlockExternalId throws (fail-closed) if the composed id would exceed the ceiling', () => {
-    // Defense-in-depth guard: a pathological over-long appBlockId trips it before
-    // any reservation (no money moves). Real ids can never reach this.
-    const hugeApp = 'a'.repeat(ORCHESTRATOR_EXTERNAL_ID_MAX);
-    expect(() => composeBlockExternalId(hugeApp, 'k')).toThrow(/too long/);
+  it('composeBlockExternalId is INJECTIVE across (app, key) even when both contain - and _', () => {
+    // No delimiter is safe (both components may contain `-`/`_`), so the 2-digit
+    // length prefix is what pins the split. These pairs concatenate to the same
+    // raw string and MUST still produce distinct externalIds.
+    const a = composeBlockExternalId('ephemeral-my', 'app-key');
+    const b = composeBlockExternalId('ephemeral-my-app', 'key');
+    expect(a).not.toBe(b);
+
+    const seen = new Set(
+      (
+        [
+          ['apb_a', 'b-c'],
+          ['apb_a-b', 'c'],
+          ['apb_a_b', 'c'],
+          ['apb_a', 'b_c'],
+        ] as const
+      ).map(([app, key]) => composeBlockExternalId(app, key))
+    );
+    expect(seen.size).toBe(4);
+  });
+
+  it('composeBlockExternalId throws (fail-closed) rather than emit an id the orchestrator rejects', () => {
+    // Each guard trips BEFORE any cap reservation → no money moves.
+    expect(() => composeBlockExternalId('a'.repeat(100), 'k')).toThrow(/outside 1\.\.99/);
+    expect(() => composeBlockExternalId('', 'k')).toThrow(/outside 1\.\.99/);
+    expect(() => composeBlockExternalId('a'.repeat(99), 'k'.repeat(64))).toThrow(/too long/);
+    // An appBlockId straying outside the orchestrator alphabet is caught too.
+    expect(() => composeBlockExternalId('apb:bad', 'k')).toThrow(/characters the orchestrator/);
   });
 });

--- a/src/server/utils/__tests__/block-tip-rate-limit.test.ts
+++ b/src/server/utils/__tests__/block-tip-rate-limit.test.ts
@@ -8,18 +8,20 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
  */
 
 const { sysStore, sysTtls, mockSys, cacheStore, cacheTtls, mockCache } = vi.hoisted(() => {
-  const sysStore = new Map<string, number>();
+  // Holds numbers (counters via incrBy/decrBy) AND strings (idempotency records via
+  // set/get) — `get` coerces to string, `incrBy` coerces to number, mirroring redis.
+  const sysStore = new Map<string, string | number>();
   const sysTtls = new Map<string, number>();
   const cacheStore = new Map<string, number>();
   const cacheTtls = new Map<string, number>();
   const mockSys = {
     incrBy: vi.fn(async (k: string, n: number) => {
-      const v = (sysStore.get(k) ?? 0) + n;
+      const v = Number(sysStore.get(k) ?? 0) + n;
       sysStore.set(k, v);
       return v;
     }),
     decrBy: vi.fn(async (k: string, n: number) => {
-      const v = (sysStore.get(k) ?? 0) - n;
+      const v = Number(sysStore.get(k) ?? 0) - n;
       sysStore.set(k, v);
       return v;
     }),
@@ -28,6 +30,24 @@ const { sysStore, sysTtls, mockSys, cacheStore, cacheTtls, mockCache } = vi.hois
       return true;
     }),
     ttl: vi.fn(async (k: string) => sysTtls.get(k) ?? -1),
+    get: vi.fn(async (k: string) => {
+      const v = sysStore.get(k);
+      return v == null ? null : String(v);
+    }),
+    set: vi.fn(
+      async (k: string, val: string, opts?: { NX?: boolean; EX?: number }) => {
+        if (opts?.NX && sysStore.has(k)) return null; // NX: only set when absent
+        sysStore.set(k, val);
+        if (opts?.EX != null) sysTtls.set(k, opts.EX);
+        return 'OK';
+      }
+    ),
+    del: vi.fn(async (k: string) => {
+      const had = sysStore.has(k);
+      sysStore.delete(k);
+      sysTtls.delete(k);
+      return had ? 1 : 0;
+    }),
   };
   const mockCache = {
     incrBy: vi.fn(async (k: string, n: number) => {
@@ -47,14 +67,21 @@ const { sysStore, sysTtls, mockSys, cacheStore, cacheTtls, mockCache } = vi.hois
 vi.mock('~/server/redis/client', () => ({
   sysRedis: mockSys,
   redis: mockCache,
-  REDIS_SYS_KEYS: { BLOCKS: { TIP_CAP: 'system:blocks:tip-cap' } },
+  REDIS_SYS_KEYS: {
+    BLOCKS: { TIP_CAP: 'system:blocks:tip-cap', TIP_IDEM: 'system:blocks:tip-idem' },
+  },
   REDIS_KEYS: { BLOCKS: { TOKEN_RATE_LIMIT: 'rl' } },
 }));
 
 import {
+  BLOCK_TIP_CAP_PER_DAY,
   BLOCK_TIP_RATE_LIMIT_MAX,
   checkBlockTipRateLimit,
+  claimTipIdempotency,
+  finalizeTipIdempotency,
+  readBlockTipAllowance,
   refundBlockTipSpend,
+  releaseTipIdempotency,
   reserveBlockTipSpend,
 } from '../block-tip-rate-limit';
 
@@ -147,5 +174,121 @@ describe('checkBlockTipRateLimit', () => {
     mockCache.incrBy.mockRejectedValueOnce(new Error('redis down'));
     const r = await checkBlockTipRateLimit('bki_3');
     expect(r).toMatchObject({ allowed: false });
+  });
+});
+
+describe('readBlockTipAllowance (item 4)', () => {
+  it('returns full cap + remaining when nothing has been tipped today', async () => {
+    const a = await readBlockTipAllowance(42);
+    expect(a).toEqual({ cap: BLOCK_TIP_CAP_PER_DAY, spent: 0, remaining: BLOCK_TIP_CAP_PER_DAY });
+  });
+
+  it('reflects a reservation: spent tracks the counter, remaining = cap - spent', async () => {
+    await reserveBlockTipSpend(42, 4_000);
+    const a = await readBlockTipAllowance(42);
+    expect(a.cap).toBe(BLOCK_TIP_CAP_PER_DAY);
+    expect(a.spent).toBe(4_000);
+    expect(a.remaining).toBe(BLOCK_TIP_CAP_PER_DAY - 4_000);
+  });
+
+  it('reads the CURRENT-day key (same key the reserve path mutates)', async () => {
+    await reserveBlockTipSpend(7, 100);
+    await readBlockTipAllowance(7);
+    expect(mockSys.get).toHaveBeenCalledWith(`system:blocks:tip-cap:7:${TODAY}`);
+  });
+
+  it('CLAMPS remaining at 0 when a straddling over-cap reservation pushed spent past the cap', async () => {
+    await reserveBlockTipSpend(42, BLOCK_TIP_CAP_PER_DAY + 500); // momentarily over-cap
+    const a = await readBlockTipAllowance(42);
+    expect(a.spent).toBe(BLOCK_TIP_CAP_PER_DAY + 500);
+    expect(a.remaining).toBe(0); // never negative (safe direction: under-reports)
+  });
+
+  it('FAILS-CLOSED (throws) on a redis error — the endpoint maps it to a 503', async () => {
+    mockSys.get.mockRejectedValueOnce(new Error('redis down'));
+    await expect(readBlockTipAllowance(42)).rejects.toThrow();
+  });
+});
+
+describe('tip idempotency (item 2, tip half)', () => {
+  it('first claim ACQUIRES the key with an in-progress sentinel + short TTL', async () => {
+    const r = await claimTipIdempotency(42, 'key-1');
+    expect(r.state).toBe('acquired');
+    if (r.state !== 'acquired') throw new Error('unreachable');
+    expect(r.key).toBe('system:blocks:tip-idem:42:key-1');
+    // Sentinel set NX with a TTL (bounded so a lost finalize can't wedge forever).
+    expect(mockSys.set).toHaveBeenCalledWith(
+      'system:blocks:tip-idem:42:key-1',
+      expect.any(String),
+      expect.objectContaining({ NX: true, EX: expect.any(Number) })
+    );
+  });
+
+  it('a concurrent claim while the first is IN PROGRESS returns in_progress (never a 2nd run)', async () => {
+    await claimTipIdempotency(42, 'key-2'); // acquires, leaves the sentinel
+    const second = await claimTipIdempotency(42, 'key-2');
+    expect(second.state).toBe('in_progress');
+  });
+
+  it('after finalize, a replay returns the cached TERMINAL result verbatim (no 2nd charge)', async () => {
+    const first = await claimTipIdempotency(42, 'key-3');
+    if (first.state !== 'acquired') throw new Error('expected acquired');
+    await finalizeTipIdempotency(first.key, 200, {
+      ok: true,
+      tip: { toUserId: 5, amount: 25, entityType: null, entityId: null },
+    });
+
+    const replay = await claimTipIdempotency(42, 'key-3');
+    expect(replay.state).toBe('replay');
+    if (replay.state !== 'replay') throw new Error('unreachable');
+    expect(replay.status).toBe(200);
+    expect(replay.body).toEqual({
+      ok: true,
+      tip: { toUserId: 5, amount: 25, entityType: null, entityId: null },
+    });
+  });
+
+  it('a terminal 4xx is cached + replayed too (deterministic replay of the first outcome)', async () => {
+    const first = await claimTipIdempotency(42, 'key-4');
+    if (first.state !== 'acquired') throw new Error('expected acquired');
+    await finalizeTipIdempotency(first.key, 400, { ok: false, error: 'insufficient funds' });
+
+    const replay = await claimTipIdempotency(42, 'key-4');
+    expect(replay).toMatchObject({ state: 'replay', status: 400 });
+  });
+
+  it('release DELETES the sentinel so a genuine retry (after a transient 429/503) can re-run', async () => {
+    const first = await claimTipIdempotency(42, 'key-5');
+    if (first.state !== 'acquired') throw new Error('expected acquired');
+    await releaseTipIdempotency(first.key);
+    // The key is gone → a retry ACQUIRES fresh (re-executes), not 409-in-progress.
+    const retry = await claimTipIdempotency(42, 'key-5');
+    expect(retry.state).toBe('acquired');
+  });
+
+  it('a MALFORMED stored value is treated as in_progress (never re-run — fail safe)', async () => {
+    // Simulate a corrupt record (not the sentinel, not valid JSON with a status).
+    await mockSys.set('system:blocks:tip-idem:42:key-6', '{not-json');
+    const r = await claimTipIdempotency(42, 'key-6');
+    expect(r.state).toBe('in_progress');
+  });
+
+  it('claim FAILS-CLOSED (throws) on a redis error at claim time (money path → 503)', async () => {
+    mockSys.set.mockRejectedValueOnce(new Error('redis down'));
+    await expect(claimTipIdempotency(42, 'key-7')).rejects.toThrow();
+  });
+
+  it('finalize is best-effort — a redis error never throws (must not perturb a shipped response)', async () => {
+    mockSys.set.mockRejectedValueOnce(new Error('redis blip'));
+    await expect(
+      finalizeTipIdempotency('system:blocks:tip-idem:42:k' as never, 200, { ok: true })
+    ).resolves.toBeUndefined();
+  });
+
+  it('two DIFFERENT keys claim independently (a distinct logical tip is not deduped)', async () => {
+    const a = await claimTipIdempotency(42, 'key-8a');
+    const b = await claimTipIdempotency(42, 'key-8b');
+    expect(a.state).toBe('acquired');
+    expect(b.state).toBe('acquired');
   });
 });

--- a/src/server/utils/__tests__/block-tip-rate-limit.test.ts
+++ b/src/server/utils/__tests__/block-tip-rate-limit.test.ts
@@ -78,6 +78,7 @@ import {
   BLOCK_TIP_RATE_LIMIT_MAX,
   checkBlockTipRateLimit,
   claimTipIdempotency,
+  computeTipFingerprint,
   finalizeTipIdempotency,
   readBlockTipAllowance,
   refundBlockTipSpend,
@@ -211,34 +212,43 @@ describe('readBlockTipAllowance (item 4)', () => {
 });
 
 describe('tip idempotency (item 2, tip half)', () => {
-  it('first claim ACQUIRES the key with an in-progress sentinel + short TTL', async () => {
-    const r = await claimTipIdempotency(42, 'key-1');
+  // A stable fingerprint for the "same logical tip" across a retry, and a DIFFERENT
+  // one for a same-key-different-payload replay (audit 🟡-1 residual).
+  const FP = computeTipFingerprint({ toUserId: 5, amount: 25 });
+  const FP_OTHER = computeTipFingerprint({ toUserId: 9, amount: 25 });
+
+  it('first claim ACQUIRES the key with an in-progress record + short TTL', async () => {
+    const r = await claimTipIdempotency(42, 'apb_x', 'key-1', FP);
     expect(r.state).toBe('acquired');
     if (r.state !== 'acquired') throw new Error('unreachable');
-    expect(r.key).toBe('system:blocks:tip-idem:42:key-1');
-    // Sentinel set NX with a TTL (bounded so a lost finalize can't wedge forever).
+    // audit 🟡-2: the key carries the APP segment so two apps can't share a slot.
+    expect(r.key).toBe('system:blocks:tip-idem:42:apb_x:key-1');
+    // In-progress record set NX with a TTL (bounded so a lost finalize can't wedge
+    // forever), carrying the fingerprint but NO terminal status.
     expect(mockSys.set).toHaveBeenCalledWith(
-      'system:blocks:tip-idem:42:key-1',
-      expect.any(String),
+      'system:blocks:tip-idem:42:apb_x:key-1',
+      JSON.stringify({ fp: FP }),
       expect.objectContaining({ NX: true, EX: expect.any(Number) })
     );
   });
 
   it('a concurrent claim while the first is IN PROGRESS returns in_progress (never a 2nd run)', async () => {
-    await claimTipIdempotency(42, 'key-2'); // acquires, leaves the sentinel
-    const second = await claimTipIdempotency(42, 'key-2');
+    await claimTipIdempotency(42, 'apb_x', 'key-2', FP); // acquires, leaves the record
+    const second = await claimTipIdempotency(42, 'apb_x', 'key-2', FP);
     expect(second.state).toBe('in_progress');
   });
 
   it('after finalize, a replay returns the cached TERMINAL result verbatim (no 2nd charge)', async () => {
-    const first = await claimTipIdempotency(42, 'key-3');
+    const first = await claimTipIdempotency(42, 'apb_x', 'key-3', FP);
     if (first.state !== 'acquired') throw new Error('expected acquired');
-    await finalizeTipIdempotency(first.key, 200, {
-      ok: true,
-      tip: { toUserId: 5, amount: 25, entityType: null, entityId: null },
-    });
+    await finalizeTipIdempotency(
+      first.key,
+      200,
+      { ok: true, tip: { toUserId: 5, amount: 25, entityType: null, entityId: null } },
+      FP
+    );
 
-    const replay = await claimTipIdempotency(42, 'key-3');
+    const replay = await claimTipIdempotency(42, 'apb_x', 'key-3', FP);
     expect(replay.state).toBe('replay');
     if (replay.state !== 'replay') throw new Error('unreachable');
     expect(replay.status).toBe(200);
@@ -249,46 +259,111 @@ describe('tip idempotency (item 2, tip half)', () => {
   });
 
   it('a terminal 4xx is cached + replayed too (deterministic replay of the first outcome)', async () => {
-    const first = await claimTipIdempotency(42, 'key-4');
+    const first = await claimTipIdempotency(42, 'apb_x', 'key-4', FP);
     if (first.state !== 'acquired') throw new Error('expected acquired');
-    await finalizeTipIdempotency(first.key, 400, { ok: false, error: 'insufficient funds' });
+    await finalizeTipIdempotency(first.key, 400, { ok: false, error: 'insufficient funds' }, FP);
 
-    const replay = await claimTipIdempotency(42, 'key-4');
+    const replay = await claimTipIdempotency(42, 'apb_x', 'key-4', FP);
     expect(replay).toMatchObject({ state: 'replay', status: 400 });
   });
 
-  it('release DELETES the sentinel so a genuine retry (after a transient 429/503) can re-run', async () => {
-    const first = await claimTipIdempotency(42, 'key-5');
+  it('release DELETES the record so a genuine retry (after a transient 429/503) can re-run', async () => {
+    const first = await claimTipIdempotency(42, 'apb_x', 'key-5', FP);
     if (first.state !== 'acquired') throw new Error('expected acquired');
     await releaseTipIdempotency(first.key);
-    // The key is gone → a retry ACQUIRES fresh (re-executes), not 409-in-progress.
-    const retry = await claimTipIdempotency(42, 'key-5');
+    // The key is gone -> a retry ACQUIRES fresh (re-executes), not 409-in-progress.
+    const retry = await claimTipIdempotency(42, 'apb_x', 'key-5', FP);
     expect(retry.state).toBe('acquired');
   });
 
   it('a MALFORMED stored value is treated as in_progress (never re-run — fail safe)', async () => {
-    // Simulate a corrupt record (not the sentinel, not valid JSON with a status).
-    await mockSys.set('system:blocks:tip-idem:42:key-6', '{not-json');
-    const r = await claimTipIdempotency(42, 'key-6');
+    // Simulate a corrupt record (not valid JSON).
+    await mockSys.set('system:blocks:tip-idem:42:apb_x:key-6', '{not-json');
+    const r = await claimTipIdempotency(42, 'apb_x', 'key-6', FP);
     expect(r.state).toBe('in_progress');
   });
 
   it('claim FAILS-CLOSED (throws) on a redis error at claim time (money path → 503)', async () => {
     mockSys.set.mockRejectedValueOnce(new Error('redis down'));
-    await expect(claimTipIdempotency(42, 'key-7')).rejects.toThrow();
+    await expect(claimTipIdempotency(42, 'apb_x', 'key-7', FP)).rejects.toThrow();
   });
 
   it('finalize is best-effort — a redis error never throws (must not perturb a shipped response)', async () => {
     mockSys.set.mockRejectedValueOnce(new Error('redis blip'));
     await expect(
-      finalizeTipIdempotency('system:blocks:tip-idem:42:k' as never, 200, { ok: true })
+      finalizeTipIdempotency('system:blocks:tip-idem:42:apb_x:k' as never, 200, { ok: true }, FP)
     ).resolves.toBeUndefined();
   });
 
   it('two DIFFERENT keys claim independently (a distinct logical tip is not deduped)', async () => {
-    const a = await claimTipIdempotency(42, 'key-8a');
-    const b = await claimTipIdempotency(42, 'key-8b');
+    const a = await claimTipIdempotency(42, 'apb_x', 'key-8a', FP);
+    const b = await claimTipIdempotency(42, 'apb_x', 'key-8b', FP);
     expect(a.state).toBe('acquired');
     expect(b.state).toBe('acquired');
+  });
+
+  // ── audit 🟡-2: cross-app replay leak ────────────────────────────────────────
+  describe('per-APP scoping (audit 🟡-2)', () => {
+    it('the SAME key value in a DIFFERENT app claims independently — no cross-app replay', async () => {
+      const a = await claimTipIdempotency(42, 'apb_appA', 'tip1', FP);
+      expect(a.state).toBe('acquired');
+      if (a.state !== 'acquired') throw new Error('unreachable');
+      await finalizeTipIdempotency(
+        a.key,
+        200,
+        { ok: true, tip: { toUserId: 5, amount: 25 } },
+        FP
+      );
+
+      // App B hardcodes the SAME literal key. It must NOT receive app A's cached
+      // body (which would leak A's recipient + amount) and its own tip must run.
+      const b = await claimTipIdempotency(42, 'apb_appB', 'tip1', FP);
+      expect(b.state).toBe('acquired');
+      if (b.state !== 'acquired') throw new Error('unreachable');
+      expect(b.key).not.toBe(a.key);
+    });
+
+    it('keys are injective across (user, app, key)', async () => {
+      const claims = await Promise.all([
+        claimTipIdempotency(42, 'apb_x', 'k', FP),
+        claimTipIdempotency(42, 'apb_y', 'k', FP), // different app
+        claimTipIdempotency(99, 'apb_x', 'k', FP), // different user
+      ]);
+      const keys = claims.map((c) => (c.state === 'acquired' ? c.key : ''));
+      expect(new Set(keys).size).toBe(3);
+    });
+  });
+
+  // ── audit 🟡-1 residual: same key, different payload ──────────────────────────
+  describe('payload fingerprint (audit 🟡-1 residual)', () => {
+    it('MISMATCH: the same key with a DIFFERENT payload is rejected, not replayed', async () => {
+      const first = await claimTipIdempotency(42, 'apb_x', 'reused', FP);
+      if (first.state !== 'acquired') throw new Error('expected acquired');
+      await finalizeTipIdempotency(first.key, 200, { ok: true, tip: { toUserId: 5 } }, FP);
+
+      // Same key, DIFFERENT recipient. Replaying would tell the app a tip to user 9
+      // succeeded when the money actually went to user 5.
+      const reused = await claimTipIdempotency(42, 'apb_x', 'reused', FP_OTHER);
+      expect(reused.state).toBe('mismatch');
+    });
+
+    it('MISMATCH is detected while the first attempt is still IN PROGRESS too', async () => {
+      await claimTipIdempotency(42, 'apb_x', 'reused2', FP);
+      const reused = await claimTipIdempotency(42, 'apb_x', 'reused2', FP_OTHER);
+      expect(reused.state).toBe('mismatch');
+    });
+
+    it('the fingerprint distinguishes amount and entity, not just recipient', () => {
+      const base = computeTipFingerprint({ toUserId: 5, amount: 25 });
+      expect(computeTipFingerprint({ toUserId: 5, amount: 26 })).not.toBe(base);
+      expect(computeTipFingerprint({ toUserId: 5, amount: 25, entityType: 'Image' })).not.toBe(
+        base
+      );
+      expect(
+        computeTipFingerprint({ toUserId: 5, amount: 25, entityType: 'Image', entityId: 1 })
+      ).not.toBe(computeTipFingerprint({ toUserId: 5, amount: 25, entityType: 'Image', entityId: 2 }));
+      // Stable for the SAME payload (a retry must replay, not 422).
+      expect(computeTipFingerprint({ toUserId: 5, amount: 25 })).toBe(base);
+    });
   });
 });

--- a/src/server/utils/block-gen-idempotency.ts
+++ b/src/server/utils/block-gen-idempotency.ts
@@ -121,7 +121,10 @@ export function composeBlockExternalId(appBlockId: string, idempotencyKey: strin
       `block externalId: appBlockId length ${appBlockId.length} outside 1..${APP_BLOCK_ID_MAX_FOR_ENCODING}`
     );
   }
-  const externalId = `blk${String(appBlockId.length).padStart(2, '0')}${appBlockId}${idempotencyKey}`;
+  const externalId = `blk${String(appBlockId.length).padStart(
+    2,
+    '0'
+  )}${appBlockId}${idempotencyKey}`;
   if (externalId.length > ORCHESTRATOR_EXTERNAL_ID_MAX) {
     throw new Error(
       `block externalId too long (${externalId.length} > ${ORCHESTRATOR_EXTERNAL_ID_MAX})`

--- a/src/server/utils/block-gen-idempotency.ts
+++ b/src/server/utils/block-gen-idempotency.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'crypto';
 import { REDIS_SYS_KEYS, sysRedis } from '~/server/redis/client';
 
 /**
@@ -52,8 +53,9 @@ const GEN_IDEM_IN_PROGRESS = ' in-progress';
 
 /**
  * Compose the per-(user, app, key) redis key. INJECTIVE because: `userId` is
- * numeric (colon-free), `appBlockId` is a real `apb_<ULID>` or a synthetic
- * `ephemeral-<slug>` dev id (both colon-free), and `idempotencyKey` is charset-
+ * numeric (colon-free), `appBlockId` is a real `apb_<ULID>` or one of the three
+ * synthetic pre-approval ids `ephemeral-<slug>` / `page_local_<slug>` /
+ * `pubreq_<ULID>` (all colon-free), and `idempotencyKey` is charset-
  * restricted to `^[A-Za-z0-9_-]{1,64}$` at the zod input (colon-free). So no two
  * distinct (user, app, key) triples can ever collide on the delimiter. (A colon
  * IS a safe delimiter here — this is an internal redis key, not the orchestrator
@@ -98,33 +100,24 @@ export const ORCHESTRATOR_EXTERNAL_ID_REGEX = /^[A-Za-z0-9_-]+$/;
 const APP_BLOCK_ID_MAX_FOR_ENCODING = 99;
 
 /**
- * Compose the namespaced orchestrator `externalId` for a block generation submit.
- *
- * Shape: `blk<NN><appBlockId><key>`, where `NN` is the zero-padded 2-digit length
- * of `appBlockId`. A DELIMITER cannot be used — the orchestrator charset is
- * `[A-Za-z0-9_-]` and BOTH components may legitimately contain `_` and `-`
- * (`apb_<ULID>`, `ephemeral-<slug>`, `local-<slug>`, `pending-<pubreq>`; keys are
- * UUIDs). The length prefix pins the split point instead, which is INJECTIVE: two
- * inputs colliding would need the same `NN` (⇒ same appBlockId length ⇒ same
- * appBlockId prefix ⇒ same key).
- *
- * Worst case is well inside the ceiling: 3 + 2 + 50 (`ephemeral-<40-slug>`) + 64
- * = 119 ≤ 128. Typical is 3 + 2 + 30 (`apb_<26-ULID>`) + 36 (UUID) = 71.
- *
- * Fails CLOSED (throws before any cap reservation → no money moves) on anything
- * the orchestrator would reject, so a violation can never be silently truncated
- * into a BROKEN `(userId, externalId)` dedupe.
+ * ORIGIN NAMESPACE PREFIXES. Every block externalId starts with exactly one of
+ * these 3-char tags, and they differ at index 2 — so the CLIENT-key namespace and
+ * the SERVER-MINTED namespace are DISJOINT BY CONSTRUCTION. That is what makes it
+ * impossible for a server-minted id to collide with a client-supplied one (which
+ * would otherwise silently fuse two logically-distinct generations onto one
+ * orchestrator `(userId, externalId)` dedupe slot).
  */
-export function composeBlockExternalId(appBlockId: string, idempotencyKey: string): string {
-  if (appBlockId.length < 1 || appBlockId.length > APP_BLOCK_ID_MAX_FOR_ENCODING) {
-    throw new Error(
-      `block externalId: appBlockId length ${appBlockId.length} outside 1..${APP_BLOCK_ID_MAX_FOR_ENCODING}`
-    );
-  }
-  const externalId = `blk${String(appBlockId.length).padStart(
-    2,
-    '0'
-  )}${appBlockId}${idempotencyKey}`;
+const BLOCK_EXTERNAL_ID_PREFIX_CLIENT = 'blk';
+const BLOCK_EXTERNAL_ID_PREFIX_SERVER = 'bls';
+
+/**
+ * The SINGLE gate every emitted externalId passes. Shared by the client-key
+ * composer and the server minter so neither can drift from the orchestrator
+ * contract (`^[A-Za-z0-9_-]+$`, ≤128, enforced by `[ApiController]` as a hard 400
+ * BEFORE the action body runs — a violation is a rejected submit, not a
+ * truncation).
+ */
+function assertOrchestratorExternalId(externalId: string): string {
   if (externalId.length > ORCHESTRATOR_EXTERNAL_ID_MAX) {
     throw new Error(
       `block externalId too long (${externalId.length} > ${ORCHESTRATOR_EXTERNAL_ID_MAX})`
@@ -136,6 +129,89 @@ export function composeBlockExternalId(appBlockId: string, idempotencyKey: strin
     throw new Error('block externalId contains characters the orchestrator rejects');
   }
   return externalId;
+}
+
+/**
+ * Compose the namespaced orchestrator `externalId` for a block generation submit
+ * from a CLIENT-supplied idempotency key.
+ *
+ * Shape: `blk<NN><appBlockId><key>`, where `NN` is the zero-padded 2-digit length
+ * of `appBlockId`. A DELIMITER cannot be used — the orchestrator charset is
+ * `[A-Za-z0-9_-]` and BOTH components may legitimately contain `_` and `-`
+ * (`apb_<26-ULID>`, and the three SYNTHETIC pre-approval shapes
+ * `ephemeral-<slug>`, `page_local_<slug>`, `pubreq_<ULID>` — see
+ * SYNTHETIC_APP_BLOCK_ID_PREFIXES in user-app-surface.service; keys are UUIDs).
+ * The length prefix pins the split point instead, which is INJECTIVE: two inputs
+ * colliding would need the same `NN` (⇒ same appBlockId length ⇒ same appBlockId
+ * prefix ⇒ same key).
+ *
+ * LENGTH. The longest appBlockId shape is `page_local_<slug>` — 11 + a slug bounded
+ * at 40 by dev-token.ts's `z.string().min(3).max(40)` = 51 chars (NOT
+ * `ephemeral-<slug>`, which is 50). So the true worst case is
+ * 3 + 2 + 51 + 64 (max key) = **120** ≤ 128 — headroom 8, not the 119 an earlier
+ * revision of this comment claimed. Typical is 3 + 2 + 30 (`apb_<26-ULID>`) + 36
+ * (UUID) = 71.
+ *
+ * Fails CLOSED (throws before any cap reservation → no money moves) on anything
+ * the orchestrator would reject, so a violation can never be silently truncated
+ * into a BROKEN `(userId, externalId)` dedupe.
+ */
+export function composeBlockExternalId(appBlockId: string, idempotencyKey: string): string {
+  // 🔴 `typeof` FIRST. Without it a non-string (an absent claim typed as `string`
+  // by an upstream cast) reaches `undefined.length` → `undefined < 1` and
+  // `undefined > 99` are BOTH false, so the guard passes and `padStart` on
+  // `String(undefined)` yields a 9-char pseudo-`NN` (`undefined`) — silently
+  // breaking the length-prefix injectivity this whole scheme rests on.
+  if (typeof appBlockId !== 'string' || typeof idempotencyKey !== 'string') {
+    throw new Error('block externalId: appBlockId and idempotencyKey must be strings');
+  }
+  if (appBlockId.length < 1 || appBlockId.length > APP_BLOCK_ID_MAX_FOR_ENCODING) {
+    throw new Error(
+      `block externalId: appBlockId length ${appBlockId.length} outside 1..${APP_BLOCK_ID_MAX_FOR_ENCODING}`
+    );
+  }
+  return assertOrchestratorExternalId(
+    `${BLOCK_EXTERNAL_ID_PREFIX_CLIENT}${String(appBlockId.length).padStart(
+      2,
+      '0'
+    )}${appBlockId}${idempotencyKey}`
+  );
+}
+
+/**
+ * Mint a SERVER-SIDE orchestrator `externalId` for a block generation submit that
+ * carries NO client idempotency key (audit 🔴-1).
+ *
+ * WHY THIS EXISTS. `submitWorkflow` (services/orchestrator/workflows.ts) calls
+ * `submitWorkflowWithRetry` with `maxAttempts = 3` and NO per-attempt timeout on
+ * the real submit, and that wrapper's own doc is explicit that it adds no
+ * idempotency key — "the CALLER must set `body.externalId`". So a 502/504 or a
+ * dropped socket AFTER the orchestrator already created the workflow and charged
+ * makes attempts 2 and 3 create a SECOND and THIRD workflow: up to 3 charges for
+ * one user action. Threading `externalId` only when the CLIENT sends a key left
+ * that wide open, because no shipped client sends one (the SDK has zero
+ * occurrences; the live tipping block hand-rolls its POST). Minting one
+ * server-side closes it for ALL block traffic regardless of client version.
+ *
+ * STABLE-ACROSS-ATTEMPTS / UNIQUE-PER-REQUEST. This is called ONCE per logical
+ * submit, in the router, before the body is built — and `submitWorkflowWithRetry`
+ * reuses that same body object on every attempt. So all 3 attempts present the
+ * SAME id (⇒ the orchestrator's `(userId, externalId)` dedupe collapses them to
+ * one workflow + one charge), while two genuinely different submits get different
+ * UUIDs. NEVER call this per attempt — that reintroduces the exact bug.
+ *
+ * SHAPE: `bls<uuid>` — a FIXED 3 + 36 = 39 chars, entirely inside `[A-Za-z0-9_-]`.
+ * Deliberately carries NO appBlockId: uniqueness comes wholly from the UUID, so
+ * there is nothing to length-encode and the guard below can never trip (unlike the
+ * client-key path, whose length depends on caller-supplied components). That
+ * matters because this path is UNCONDITIONAL — a throw here would reject a
+ * generation that works today.
+ *
+ * The `bls` tag makes this namespace disjoint from the client `blk` namespace, so
+ * a server-minted id can never collide with a client-supplied one.
+ */
+export function mintServerBlockExternalId(): string {
+  return assertOrchestratorExternalId(`${BLOCK_EXTERNAL_ID_PREFIX_SERVER}${randomUUID()}`);
 }
 
 export type BlockGenIdempotencyClaim<T> =

--- a/src/server/utils/block-gen-idempotency.ts
+++ b/src/server/utils/block-gen-idempotency.ts
@@ -1,0 +1,184 @@
+import { REDIS_SYS_KEYS, sysRedis } from '~/server/redis/client';
+
+/**
+ * In-flight / replay idempotency guard for the App Blocks GENERATION submit
+ * (`blocks.submitWorkflow` — both the txt2img and customComfy branches).
+ *
+ * WHY (audit 🔴-1): a generation submit RESERVES the viewer's per-user daily +
+ * per-app Buzz cap and then SUBMITS to the orchestrator (a real Buzz charge). The
+ * base slice threads a client `idempotencyKey → orchestrator externalId` and
+ * relies on the orchestrator's own `(userId, externalId)` dedupe — but with NO
+ * civitai-side guard, two CONCURRENT same-key submits (a double-click, or an SDK
+ * auto-retry racing before the first submit reaches the orchestrator) can BOTH
+ * miss that dedupe → TWO cap-reservations + TWO pipeline runs + TWO charges. This
+ * adds the civitai-side `SET NX` claim that mirrors the tip idempotency layer:
+ *
+ *   claim  — SET NX an in-progress sentinel BEFORE the cap reservation.
+ *            first caller wins → { state: 'acquired' }.
+ *            key already holds a TERMINAL result → { state: 'replay', result }
+ *            (the handler returns the CACHED snapshot verbatim — no re-reservation,
+ *            no re-submit).
+ *            key still in-progress (or a lost/garbage value) → { state: 'in_progress' }
+ *            (the handler 409s so a live first attempt is never raced into a 2nd
+ *            reservation + charge).
+ *   finalize — overwrite the sentinel with the TERMINAL result (the returned
+ *              `{ snapshot }`) so a later lost-response retry replays it. Called
+ *              ONLY on a resolved orchestrator submit (the money-committed path).
+ *              Best-effort (never perturbs an already-produced response).
+ *   release  — delete the sentinel for a NON-committed outcome (a pre-reservation
+ *              rejection, a cap/velocity reject that refunded, or a throw before a
+ *              resolved submit) so a genuine retry with the same key can execute —
+ *              NO money moved, so re-running is safe.
+ *
+ * FAIL-CLOSED: `claim` THROWS on a redis error (the caller maps it to a retryable
+ * 503) — a money endpoint must not run its dedupe blind. Mirrors the fail-closed
+ * cap reservation the guard sits in front of.
+ *
+ * PLACEMENT: the claim is taken BEFORE `reserveBlockBuzzSpend`/`reserveAppSpend`,
+ * so a replay ALSO can't double-INCR the daily/per-app cap counters (which are
+ * keyed on `(userId, day)` / `(appBlockId, day)`, not on the externalId) — closing
+ * audit 🟡-2's "the Redis spend-CAP counters still INCR on a replay" gap. The
+ * orchestrator `externalId` dedupe remains a SECOND defense layer for the cross-
+ * process / post-TTL case this in-process claim can't cover.
+ */
+
+// Covers realistic lost-response / double-click / SDK-auto-retry windows without
+// pinning a stuck in-progress marker for long if `finalize` is ever lost on a
+// redis blip. Matches BLOCK_TIP_IDEM_TTL_SECONDS.
+const BLOCK_GEN_IDEM_TTL_SECONDS = 10 * 60;
+// Leading-space sentinel: never a valid JSON document, so a claim that reads it
+// back is unambiguously "still in progress" (JSON.parse throws → in_progress).
+const GEN_IDEM_IN_PROGRESS = ' in-progress';
+
+/**
+ * Compose the per-(user, app, key) redis key. INJECTIVE because: `userId` is
+ * numeric (colon-free), `appBlockId` is a real `apb_<ULID>` or a synthetic
+ * `ephemeral-<slug>` dev id (both colon-free), and `idempotencyKey` is charset-
+ * restricted to `^[A-Za-z0-9_-]{1,200}$` at the zod input (colon-free). So no two
+ * distinct (user, app, key) triples can ever collide on the delimiter.
+ */
+function genIdemRedisKey(userId: number, appBlockId: string, idempotencyKey: string): string {
+  return `${REDIS_SYS_KEYS.BLOCKS.GEN_IDEM}:${userId}:${appBlockId}:${idempotencyKey}`;
+}
+
+/**
+ * Charset for a client idempotency key (BOTH the gen submit and the tip endpoint,
+ * audit 🟢). Restricting to a UUID-ish alphabet at the zod input keeps control
+ * chars / newlines / colons out of the orchestrator `externalId` and the tip
+ * `externalTransactionId` derived from the key. The SDK mints `crypto.randomUUID()`
+ * (`[0-9a-f-]`) or an `idem-<base36>-<base36>` fallback — both match. The `{1,200}`
+ * bound stops a key from bloating the redis key or pushing the composed externalId
+ * past the orchestrator's accepted length (see ORCHESTRATOR_EXTERNAL_ID_MAX).
+ */
+export const BLOCK_IDEMPOTENCY_KEY_REGEX = /^[A-Za-z0-9_-]{1,200}$/;
+
+/**
+ * Conservative assumed ceiling for the orchestrator `externalId` (audit 🟢). The
+ * orchestrator dedupes on `(userId, externalId)` and PREFIXES `${userId}-` server-
+ * side; this repo does not carry the orchestrator's exact column/index limit, so we
+ * assume a typical indexed-varchar ceiling of 512. With a charset+length-bounded
+ * key (≤200) and an `apb_<26-ULID>` appBlockId (~30 chars), the composed
+ * `block:<appBlockId>:<key>` maxes ~237 chars + a ≤~12-char `userId-` prefix —
+ * comfortably under. The guard documents the assumption and fails CLOSED (throws,
+ * before any reservation → no money moves) if a future longer id/key approaches it.
+ */
+export const ORCHESTRATOR_EXTERNAL_ID_MAX = 512;
+
+/**
+ * Compose the namespaced orchestrator `externalId` for a block generation submit.
+ * INJECTIVE under the input contract (colon-free numeric prefix boundary is the
+ * orchestrator's `userId-`; `appBlockId` and the charset-restricted key are both
+ * colon-free), so `block:<appBlockId>:<key>` can never self-collide across apps or
+ * keys. Throws if the composed id would exceed the assumed orchestrator ceiling.
+ */
+export function composeBlockExternalId(appBlockId: string, idempotencyKey: string): string {
+  const externalId = `block:${appBlockId}:${idempotencyKey}`;
+  if (externalId.length > ORCHESTRATOR_EXTERNAL_ID_MAX) {
+    // Defense-in-depth: unreachable given the zod length/charset bounds, but a
+    // fail-closed assert beats silently sending an over-long id the orchestrator
+    // might truncate (which would BREAK the `(userId, externalId)` dedupe).
+    throw new Error(
+      `block externalId too long (${externalId.length} > ${ORCHESTRATOR_EXTERNAL_ID_MAX})`
+    );
+  }
+  return externalId;
+}
+
+export type BlockGenIdempotencyClaim<T> =
+  | { state: 'acquired'; key: string }
+  | { state: 'replay'; result: T }
+  | { state: 'in_progress' };
+
+/**
+ * Atomically CLAIM the idempotency key for a generation submit. Fail-CLOSED
+ * (throws) on a redis error so the caller returns a retryable 503 — a money
+ * endpoint must not dedupe blind. See the module doc-comment for the state machine.
+ *
+ * @typeParam T the caller's terminal result shape (the `{ snapshot }` it returns);
+ *   on `replay` the cached value is returned typed as `T` (the caller owns the
+ *   contract that `finalize` only ever stored a `T`).
+ */
+export async function claimGenIdempotency<T = unknown>(
+  userId: number,
+  appBlockId: string,
+  idempotencyKey: string
+): Promise<BlockGenIdempotencyClaim<T>> {
+  const key = genIdemRedisKey(userId, appBlockId, idempotencyKey);
+  // SET NX EX — first writer wins the in-progress sentinel. node-redis returns
+  // 'OK' on set, null when the key already exists. (`key as never`: the composed
+  // key is a valid runtime redis key; the sysRedis client's typed-key union doesn't
+  // model the dynamic `${user}:${app}:${key}` suffix — same cast the sibling
+  // block-tip-rate-limit helper uses on the cache client.)
+  const claimed = await sysRedis.set(key as never, GEN_IDEM_IN_PROGRESS, {
+    NX: true,
+    EX: BLOCK_GEN_IDEM_TTL_SECONDS,
+  });
+  if (claimed) return { state: 'acquired', key };
+
+  // Key already exists — read it to decide replay vs still-in-progress.
+  const existing = await sysRedis.get(key as never);
+  if (existing == null || existing === GEN_IDEM_IN_PROGRESS) {
+    // Still running (or a set→get race where the winner hasn't finalized yet).
+    // 409 rather than proceed — never race a live first attempt into a 2nd
+    // reservation + charge.
+    return { state: 'in_progress' };
+  }
+  try {
+    const parsed = JSON.parse(existing) as { result?: unknown };
+    if (parsed && typeof parsed === 'object' && 'result' in parsed) {
+      return { state: 'replay', result: parsed.result as T };
+    }
+  } catch {
+    /* fall through — a malformed value is treated as in-progress (do NOT re-run) */
+  }
+  return { state: 'in_progress' };
+}
+
+/**
+ * Persist the TERMINAL result (the returned `{ snapshot }`) of the FIRST resolved
+ * submit so a later lost-response retry replays it. Best-effort: if the record
+ * can't be written, the in-progress sentinel simply expires and a post-TTL retry
+ * may re-run — where the orchestrator `externalId` dedupe is the second defense.
+ * Never throws into an already-produced response.
+ */
+export async function finalizeGenIdempotency(key: string, result: unknown): Promise<void> {
+  try {
+    await sysRedis.set(key as never, JSON.stringify({ result }), {
+      EX: BLOCK_GEN_IDEM_TTL_SECONDS,
+    });
+  } catch {
+    /* best-effort — see doc comment */
+  }
+}
+
+/**
+ * Release the idempotency claim for a NON-committed outcome (a pre-reservation
+ * rejection, a cap/velocity reject that already refunded, or a throw before a
+ * resolved submit) so a genuine retry with the same key can execute. Safe because
+ * NO money moved and NO reservation stands. Best-effort; never throws.
+ */
+export async function releaseGenIdempotency(key: string): Promise<void> {
+  await sysRedis.del(key as never).catch(() => {
+    /* best-effort — a stuck sentinel just 409s a retry until its short TTL */
+  });
+}

--- a/src/server/utils/block-gen-idempotency.ts
+++ b/src/server/utils/block-gen-idempotency.ts
@@ -54,8 +54,10 @@ const GEN_IDEM_IN_PROGRESS = ' in-progress';
  * Compose the per-(user, app, key) redis key. INJECTIVE because: `userId` is
  * numeric (colon-free), `appBlockId` is a real `apb_<ULID>` or a synthetic
  * `ephemeral-<slug>` dev id (both colon-free), and `idempotencyKey` is charset-
- * restricted to `^[A-Za-z0-9_-]{1,200}$` at the zod input (colon-free). So no two
- * distinct (user, app, key) triples can ever collide on the delimiter.
+ * restricted to `^[A-Za-z0-9_-]{1,64}$` at the zod input (colon-free). So no two
+ * distinct (user, app, key) triples can ever collide on the delimiter. (A colon
+ * IS a safe delimiter here — this is an internal redis key, not the orchestrator
+ * `externalId`, whose charset excludes it. See composeBlockExternalId.)
  */
 function genIdemRedisKey(userId: number, appBlockId: string, idempotencyKey: string): string {
   return `${REDIS_SYS_KEYS.BLOCKS.GEN_IDEM}:${userId}:${appBlockId}:${idempotencyKey}`;
@@ -66,40 +68,69 @@ function genIdemRedisKey(userId: number, appBlockId: string, idempotencyKey: str
  * audit 🟢). Restricting to a UUID-ish alphabet at the zod input keeps control
  * chars / newlines / colons out of the orchestrator `externalId` and the tip
  * `externalTransactionId` derived from the key. The SDK mints `crypto.randomUUID()`
- * (`[0-9a-f-]`) or an `idem-<base36>-<base36>` fallback — both match. The `{1,200}`
- * bound stops a key from bloating the redis key or pushing the composed externalId
- * past the orchestrator's accepted length (see ORCHESTRATOR_EXTERNAL_ID_MAX).
+ * (36 chars, `[0-9a-f-]`) or an `idem-<base36>-<base36>-<base36>` fallback (~35) —
+ * both match comfortably. The `{1,64}` bound keeps the composed externalId under
+ * the orchestrator's REAL 128-char ceiling (see ORCHESTRATOR_EXTERNAL_ID_MAX).
  */
-export const BLOCK_IDEMPOTENCY_KEY_REGEX = /^[A-Za-z0-9_-]{1,200}$/;
+export const BLOCK_IDEMPOTENCY_KEY_REGEX = /^[A-Za-z0-9_-]{1,64}$/;
 
 /**
- * Conservative assumed ceiling for the orchestrator `externalId` (audit 🟢). The
- * orchestrator dedupes on `(userId, externalId)` and PREFIXES `${userId}-` server-
- * side; this repo does not carry the orchestrator's exact column/index limit, so we
- * assume a typical indexed-varchar ceiling of 512. With a charset+length-bounded
- * key (≤200) and an `apb_<26-ULID>` appBlockId (~30 chars), the composed
- * `block:<appBlockId>:<key>` maxes ~237 chars + a ≤~12-char `userId-` prefix —
- * comfortably under. The guard documents the assumption and fails CLOSED (throws,
- * before any reservation → no money moves) if a future longer id/key approaches it.
+ * The orchestrator's ACTUAL `externalId` contract, read from the source of truth
+ * `civitai-orchestration:src/Civitai.Orchestration.Grains.Abstractions/Workflows/
+ * WorkflowTemplate.cs` (`[StringLength(128, MinimumLength = 1)]` +
+ * `[RegularExpression("^[A-Za-z0-9_-]+$")]`). `ConsumerControllerBase` carries
+ * `[ApiController]`, so a violation is an automatic **400 before the action body
+ * runs** — not a truncation. Verified present in the deployed
+ * `orchestration-api:v2.26.11` (added by orchestration `c023ed9dd`).
+ *
+ * 🔴 An earlier revision ASSUMED a 512 ceiling and a colon-delimited id; both were
+ * wrong (colons are outside the charset), which would have 400'd every keyed block
+ * generation submit. Do not reintroduce a delimiter outside `[A-Za-z0-9_-]`.
+ *
+ * NOTE the orchestrator additionally PREFIXES `${userId}-` server-side when it
+ * stores the value, but validation runs on the RAW client field — so this ceiling
+ * applies to what we send, pre-prefix.
  */
-export const ORCHESTRATOR_EXTERNAL_ID_MAX = 512;
+export const ORCHESTRATOR_EXTERNAL_ID_MAX = 128;
+export const ORCHESTRATOR_EXTERNAL_ID_REGEX = /^[A-Za-z0-9_-]+$/;
+
+/** 2 fixed digits encode the appBlockId length, so it must be 1..99 chars. */
+const APP_BLOCK_ID_MAX_FOR_ENCODING = 99;
 
 /**
  * Compose the namespaced orchestrator `externalId` for a block generation submit.
- * INJECTIVE under the input contract (colon-free numeric prefix boundary is the
- * orchestrator's `userId-`; `appBlockId` and the charset-restricted key are both
- * colon-free), so `block:<appBlockId>:<key>` can never self-collide across apps or
- * keys. Throws if the composed id would exceed the assumed orchestrator ceiling.
+ *
+ * Shape: `blk<NN><appBlockId><key>`, where `NN` is the zero-padded 2-digit length
+ * of `appBlockId`. A DELIMITER cannot be used — the orchestrator charset is
+ * `[A-Za-z0-9_-]` and BOTH components may legitimately contain `_` and `-`
+ * (`apb_<ULID>`, `ephemeral-<slug>`, `local-<slug>`, `pending-<pubreq>`; keys are
+ * UUIDs). The length prefix pins the split point instead, which is INJECTIVE: two
+ * inputs colliding would need the same `NN` (⇒ same appBlockId length ⇒ same
+ * appBlockId prefix ⇒ same key).
+ *
+ * Worst case is well inside the ceiling: 3 + 2 + 50 (`ephemeral-<40-slug>`) + 64
+ * = 119 ≤ 128. Typical is 3 + 2 + 30 (`apb_<26-ULID>`) + 36 (UUID) = 71.
+ *
+ * Fails CLOSED (throws before any cap reservation → no money moves) on anything
+ * the orchestrator would reject, so a violation can never be silently truncated
+ * into a BROKEN `(userId, externalId)` dedupe.
  */
 export function composeBlockExternalId(appBlockId: string, idempotencyKey: string): string {
-  const externalId = `block:${appBlockId}:${idempotencyKey}`;
+  if (appBlockId.length < 1 || appBlockId.length > APP_BLOCK_ID_MAX_FOR_ENCODING) {
+    throw new Error(
+      `block externalId: appBlockId length ${appBlockId.length} outside 1..${APP_BLOCK_ID_MAX_FOR_ENCODING}`
+    );
+  }
+  const externalId = `blk${String(appBlockId.length).padStart(2, '0')}${appBlockId}${idempotencyKey}`;
   if (externalId.length > ORCHESTRATOR_EXTERNAL_ID_MAX) {
-    // Defense-in-depth: unreachable given the zod length/charset bounds, but a
-    // fail-closed assert beats silently sending an over-long id the orchestrator
-    // might truncate (which would BREAK the `(userId, externalId)` dedupe).
     throw new Error(
       `block externalId too long (${externalId.length} > ${ORCHESTRATOR_EXTERNAL_ID_MAX})`
     );
+  }
+  if (!ORCHESTRATOR_EXTERNAL_ID_REGEX.test(externalId)) {
+    // The key is charset-bounded at the zod input; this catches an appBlockId
+    // shape that ever strays outside the orchestrator alphabet.
+    throw new Error('block externalId contains characters the orchestrator rejects');
   }
   return externalId;
 }

--- a/src/server/utils/block-tip-rate-limit.ts
+++ b/src/server/utils/block-tip-rate-limit.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'crypto';
 import { redis, REDIS_KEYS, REDIS_SYS_KEYS, sysRedis } from '~/server/redis/client';
 
 /**
@@ -206,53 +207,118 @@ export async function readBlockTipAllowance(userId: number): Promise<BlockTipAll
 // Covers realistic lost-response / user-reload retry windows without pinning a
 // stuck in-progress marker for long if `finalize` is ever lost on a redis blip.
 const BLOCK_TIP_IDEM_TTL_SECONDS = 10 * 60;
-const TIP_IDEM_IN_PROGRESS = ' in-progress';
 
+/**
+ * Per-(user, APP, key) redis key (audit 🟡-2).
+ *
+ * 🔴 `appBlockId` is load-bearing, not decoration. Without it the key is
+ * `<userId>:<key>`, and the REST endpoint accepts ANY `[A-Za-z0-9_-]{1,64}` value
+ * — so two apps the SAME user has installed that happen to pick the same literal
+ * key (an app hardcoding `"tip1"`) share ONE idempotency slot. App B would then
+ * REPLAY app A's cached response body verbatim, LEARNING A's tip recipient and
+ * amount, while B's own tip silently never happens. Mirrors the gen key shape in
+ * `block-gen-idempotency.ts`, which already carried the app segment.
+ *
+ * INJECTIVE on `:` because `userId` is numeric, `appBlockId` is an `apb_<ULID>` or
+ * a synthetic `ephemeral-` / `page_local_` / `pubreq_` id, and `idempotencyKey` is
+ * charset-restricted to `^[A-Za-z0-9_-]{1,64}$` at the endpoint — none can contain
+ * a colon, so no two distinct triples collide.
+ */
 function tipIdemRedisKey(
   userId: number,
+  appBlockId: string,
   idempotencyKey: string
-): `${typeof REDIS_SYS_KEYS.BLOCKS.TIP_IDEM}:${number}:${string}` {
-  return `${REDIS_SYS_KEYS.BLOCKS.TIP_IDEM}:${userId}:${idempotencyKey}`;
+): `${typeof REDIS_SYS_KEYS.BLOCKS.TIP_IDEM}:${number}:${string}:${string}` {
+  return `${REDIS_SYS_KEYS.BLOCKS.TIP_IDEM}:${userId}:${appBlockId}:${idempotencyKey}`;
+}
+
+/**
+ * REQUEST FINGERPRINT (audit 🟡-1 residual). An idempotency key identifies ONE
+ * logical request; reusing it for a DIFFERENT payload is a client bug, and
+ * replaying the first result for it is actively misleading — the app is told "your
+ * tip of B Buzz to Y succeeded" when what actually happened was a tip of A Buzz to
+ * X. Stripe rejects that rather than replaying; so do we (the caller 422s).
+ *
+ * Covers exactly the fields that define the tip. `userId` + `appBlockId` are
+ * already pinned by the redis key, so they are deliberately not repeated here.
+ * Truncated to 32 hex chars — collision-irrelevant at this cardinality, and it
+ * keeps the stored record small.
+ */
+export function computeTipFingerprint(input: {
+  toUserId: number;
+  amount: number;
+  entityType?: string;
+  entityId?: number;
+}): string {
+  return createHash('sha256')
+    .update(
+      JSON.stringify([
+        input.toUserId,
+        input.amount,
+        input.entityType ?? null,
+        input.entityId ?? null,
+      ])
+    )
+    .digest('hex')
+    .slice(0, 32);
 }
 
 export type BlockTipIdempotencyClaim =
   | { state: 'acquired'; key: ReturnType<typeof tipIdemRedisKey> }
   | { state: 'replay'; status: number; body: unknown }
-  | { state: 'in_progress' };
+  | { state: 'in_progress' }
+  | { state: 'mismatch' };
 
 /**
  * Atomically CLAIM the idempotency key for a tip attempt. Fail-CLOSED (throws) on
  * a redis error so the caller returns a retryable 503 — a money endpoint must not
  * dedupe blind. See the block comment above for the state machine.
+ *
+ * The stored record is ALWAYS JSON: `{ fp }` while in progress, `{ fp, status, body }`
+ * once terminal (a numeric `status` is what distinguishes them). A record whose `fp`
+ * differs from THIS request's → `mismatch` (the caller 422s): the same key is being
+ * reused for a different payload, so neither replaying the old result nor executing
+ * the new tip is correct.
  */
 export async function claimTipIdempotency(
   userId: number,
-  idempotencyKey: string
+  appBlockId: string,
+  idempotencyKey: string,
+  fingerprint: string
 ): Promise<BlockTipIdempotencyClaim> {
-  const key = tipIdemRedisKey(userId, idempotencyKey);
+  const key = tipIdemRedisKey(userId, appBlockId, idempotencyKey);
   // SET NX EX — first writer wins the in-progress sentinel. node-redis returns
   // 'OK' on set, null when the key already exists.
-  const claimed = await sysRedis.set(key, TIP_IDEM_IN_PROGRESS, {
+  const claimed = await sysRedis.set(key, JSON.stringify({ fp: fingerprint }), {
     NX: true,
     EX: BLOCK_TIP_IDEM_TTL_SECONDS,
   });
   if (claimed) return { state: 'acquired', key };
 
-  // Key already exists — read it to decide replay vs still-in-progress.
+  // Key already exists — read it to decide mismatch vs replay vs still-in-progress.
   const existing = await sysRedis.get(key);
-  if (existing == null || existing === TIP_IDEM_IN_PROGRESS) {
-    // Still running (or a set→get race where the winner hasn't finalized yet).
-    // 409 rather than proceed — never race a live first attempt into a 2nd charge.
+  if (existing == null) {
+    // SET→GET race (the winner released or expired the key in between). Treat as
+    // in-progress: 409 rather than risk racing a live first attempt into a 2nd charge.
     return { state: 'in_progress' };
   }
+  let parsed: { fp?: unknown; status?: unknown; body?: unknown };
   try {
-    const parsed = JSON.parse(existing) as { status?: unknown; body?: unknown };
-    if (typeof parsed.status === 'number') {
-      return { state: 'replay', status: parsed.status, body: parsed.body };
-    }
+    parsed = JSON.parse(existing) as typeof parsed;
   } catch {
-    /* fall through — a malformed value is treated as in-progress (do NOT re-run) */
+    // A malformed / partially-written record is treated as in-progress — never
+    // re-run a money path on a value we cannot read.
+    return { state: 'in_progress' };
   }
+  if (parsed?.fp !== fingerprint) {
+    // Same key, DIFFERENT request. Never replay someone else's outcome, and never
+    // execute a second charge under a key that is already spoken for.
+    return { state: 'mismatch' };
+  }
+  if (typeof parsed.status === 'number') {
+    return { state: 'replay', status: parsed.status, body: parsed.body };
+  }
+  // Fingerprint matches but there is no terminal result yet — the first attempt is live.
   return { state: 'in_progress' };
 }
 
@@ -261,14 +327,19 @@ export async function claimTipIdempotency(
  * lost-response retry replays it. Best-effort: if the record can't be written,
  * the in-progress sentinel simply expires and a post-TTL retry may re-run
  * (a redis-down edge) — it never throws into an already-successful response.
+ *
+ * Carries the `fingerprint` forward so the mismatch check still applies to the
+ * TERMINAL record (a replay under the same key with a DIFFERENT payload must 422,
+ * not receive the old body).
  */
 export async function finalizeTipIdempotency(
   key: ReturnType<typeof tipIdemRedisKey>,
   status: number,
-  body: unknown
+  body: unknown,
+  fingerprint: string
 ): Promise<void> {
   try {
-    await sysRedis.set(key, JSON.stringify({ status, body }), {
+    await sysRedis.set(key, JSON.stringify({ fp: fingerprint, status, body }), {
       EX: BLOCK_TIP_IDEM_TTL_SECONDS,
     });
   } catch {

--- a/src/server/utils/block-tip-rate-limit.ts
+++ b/src/server/utils/block-tip-rate-limit.ts
@@ -145,3 +145,146 @@ export async function refundBlockTipSpend(
     /* best-effort — a lost refund over-counts (stricter cap) */
   });
 }
+
+// ── Tip allowance READ (item 4) ──────────────────────────────────────────────
+
+/** The daily tip allowance for a user: cap, net-reserved-today, and remaining. */
+export type BlockTipAllowance = { cap: number; spent: number; remaining: number };
+
+/**
+ * Reads the viewer's CURRENT daily tip allowance from the SAME authoritative
+ * `tip-cap` counter the reserve/refund path mutates — so a block can show a
+ * genuinely-tracked remaining allowance instead of a dead client-side full-cap
+ * guess (the opaque-origin sandbox has no working `localStorage`).
+ *
+ * `spent` is the RESERVATION-based net total (INCRBY on reserve, DECRBY on
+ * refund), so it reflects net-committed-today and can briefly OVER-count between
+ * a reserve and its refund — the SAFE direction (under-reports `remaining`,
+ * never over-reports). `remaining` is clamped at 0 (a straddling over-cap
+ * reservation could push the raw counter above the cap for an instant).
+ *
+ * FAIL-CLOSED on a redis error (throws) — the caller surfaces a retryable 503,
+ * consistent with the reserve path. A read is not money-moving, but reporting a
+ * fabricated full allowance on a redis blip would invite a block to let the user
+ * tip past a ceiling the enforcing reserve would then reject; failing closed
+ * keeps the read honest.
+ */
+export async function readBlockTipAllowance(userId: number): Promise<BlockTipAllowance> {
+  const key = tipCapRedisKey(userId);
+  const raw = await sysRedis.get(key);
+  const parsed = raw == null ? 0 : Number.parseInt(raw, 10);
+  const spent = Number.isFinite(parsed) && parsed > 0 ? parsed : 0;
+  const remaining = Math.max(0, BLOCK_TIP_CAP_PER_DAY - spent);
+  return { cap: BLOCK_TIP_CAP_PER_DAY, spent, remaining };
+}
+
+// ── Tip IDEMPOTENCY (item 2, tip half) ────────────────────────────────────────
+//
+// A tip moves REAL Buzz to a third party and is IRREVERSIBLE. `requestId` on the
+// postMessage/HTTP layer is a fresh per-attempt correlation id, so a timeout /
+// lost-response retry that re-POSTs the same logical tip would reserve AND charge
+// twice. A CLIENT-generated `idempotencyKey` that is stable across the retry lets
+// the endpoint collapse the replay to the FIRST terminal result.
+//
+// PATTERN (money-safe, not merely "block the second call"):
+//   claim  — SET NX the idem key to an in-progress sentinel BEFORE reserve/charge.
+//            first caller wins → { state: 'acquired' }.
+//            key already holds a TERMINAL result → { state: 'replay', … } (the
+//            endpoint returns it VERBATIM — no second reserve, no second charge).
+//            key still in-progress (or a lost/garbage value) → { state: 'in_progress' }
+//            → the endpoint 409s so a still-running first attempt is never raced
+//            into a double charge.
+//   finalize — overwrite the sentinel with the TERMINAL {status, body} so a later
+//              lost-response retry replays it. Best-effort (never perturbs an
+//              already-shipped response).
+//   release  — delete the sentinel for a TRANSIENT outcome (429/503) so a genuine
+//              retry can actually execute (no money moved → safe to re-attempt).
+//
+// FAIL-CLOSED: `claim` THROWS on a redis error (the caller maps it to a 503),
+// mirroring the reserve path — a money endpoint must not run its dedupe blind.
+
+// Covers realistic lost-response / user-reload retry windows without pinning a
+// stuck in-progress marker for long if `finalize` is ever lost on a redis blip.
+const BLOCK_TIP_IDEM_TTL_SECONDS = 10 * 60;
+const TIP_IDEM_IN_PROGRESS = ' in-progress';
+
+function tipIdemRedisKey(
+  userId: number,
+  idempotencyKey: string
+): `${typeof REDIS_SYS_KEYS.BLOCKS.TIP_IDEM}:${number}:${string}` {
+  return `${REDIS_SYS_KEYS.BLOCKS.TIP_IDEM}:${userId}:${idempotencyKey}`;
+}
+
+export type BlockTipIdempotencyClaim =
+  | { state: 'acquired'; key: ReturnType<typeof tipIdemRedisKey> }
+  | { state: 'replay'; status: number; body: unknown }
+  | { state: 'in_progress' };
+
+/**
+ * Atomically CLAIM the idempotency key for a tip attempt. Fail-CLOSED (throws) on
+ * a redis error so the caller returns a retryable 503 — a money endpoint must not
+ * dedupe blind. See the block comment above for the state machine.
+ */
+export async function claimTipIdempotency(
+  userId: number,
+  idempotencyKey: string
+): Promise<BlockTipIdempotencyClaim> {
+  const key = tipIdemRedisKey(userId, idempotencyKey);
+  // SET NX EX — first writer wins the in-progress sentinel. node-redis returns
+  // 'OK' on set, null when the key already exists.
+  const claimed = await sysRedis.set(key, TIP_IDEM_IN_PROGRESS, {
+    NX: true,
+    EX: BLOCK_TIP_IDEM_TTL_SECONDS,
+  });
+  if (claimed) return { state: 'acquired', key };
+
+  // Key already exists — read it to decide replay vs still-in-progress.
+  const existing = await sysRedis.get(key);
+  if (existing == null || existing === TIP_IDEM_IN_PROGRESS) {
+    // Still running (or a set→get race where the winner hasn't finalized yet).
+    // 409 rather than proceed — never race a live first attempt into a 2nd charge.
+    return { state: 'in_progress' };
+  }
+  try {
+    const parsed = JSON.parse(existing) as { status?: unknown; body?: unknown };
+    if (typeof parsed.status === 'number') {
+      return { state: 'replay', status: parsed.status, body: parsed.body };
+    }
+  } catch {
+    /* fall through — a malformed value is treated as in-progress (do NOT re-run) */
+  }
+  return { state: 'in_progress' };
+}
+
+/**
+ * Persist the TERMINAL {status, body} of the FIRST attempt so a later
+ * lost-response retry replays it. Best-effort: if the record can't be written,
+ * the in-progress sentinel simply expires and a post-TTL retry may re-run
+ * (a redis-down edge) — it never throws into an already-successful response.
+ */
+export async function finalizeTipIdempotency(
+  key: ReturnType<typeof tipIdemRedisKey>,
+  status: number,
+  body: unknown
+): Promise<void> {
+  try {
+    await sysRedis.set(key, JSON.stringify({ status, body }), {
+      EX: BLOCK_TIP_IDEM_TTL_SECONDS,
+    });
+  } catch {
+    /* best-effort — see doc comment */
+  }
+}
+
+/**
+ * Release the idempotency claim for a TRANSIENT outcome (429/503) so a genuine
+ * retry with the same key can execute. Safe because a transient rejection means
+ * NO money moved and NO reservation stands. Best-effort; never throws.
+ */
+export async function releaseTipIdempotency(
+  key: ReturnType<typeof tipIdemRedisKey>
+): Promise<void> {
+  await sysRedis.del(key).catch(() => {
+    /* best-effort — a stuck sentinel just 409s a retry until its short TTL */
+  });
+}

--- a/src/tests/api/v1/blocks/tip-allowance-endpoint.test.ts
+++ b/src/tests/api/v1/blocks/tip-allowance-endpoint.test.ts
@@ -67,9 +67,17 @@ vi.mock('~/server/middleware/block-scope.middleware', () => ({
 }));
 vi.mock('@civitai/next-axiom', () => ({ withAxiom: (h: any) => h }));
 
-const { mockReadAllowance } = vi.hoisted(() => ({ mockReadAllowance: vi.fn() }));
+const { mockReadAllowance, mockRateLimit } = vi.hoisted(() => ({
+  mockReadAllowance: vi.fn(),
+  mockRateLimit: vi.fn(),
+}));
 vi.mock('~/server/utils/block-tip-rate-limit', () => ({
   readBlockTipAllowance: mockReadAllowance,
+}));
+// audit 🟡-4 — this endpoint now rate-limits like its siblings (models.ts /
+// images.ts). Mocked here; the limiter's own logic is unit-tested separately.
+vi.mock('~/server/utils/block-catalog-rate-limit', () => ({
+  checkBlockCatalogRateLimit: mockRateLimit,
 }));
 
 import handlerDefault from '~/pages/api/v1/blocks/tip-allowance';
@@ -96,6 +104,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   claimsBox.claims = fakeClaims();
   mockReadAllowance.mockResolvedValue({ cap: 25_000, spent: 4_000, remaining: 21_000 });
+  mockRateLimit.mockResolvedValue({ allowed: true });
 });
 
 describe('GET /api/v1/blocks/tip-allowance', () => {
@@ -142,5 +151,26 @@ describe('GET /api/v1/blocks/tip-allowance', () => {
     const { req, res } = createMocks();
     await handlerDefault(req as never, res as never);
     expect(res._status()).toBe(503);
+  });
+
+  // ── audit 🟡-4: rate limited like every sibling blocks REST read ──────────────
+  describe('rate limit (audit 🟡-4)', () => {
+    it('limits per blockInstanceId, consistent with models.ts / images.ts', async () => {
+      const { req, res } = createMocks();
+      await handlerDefault(req as never, res as never);
+      expect(res._status()).toBe(200);
+      expect(mockRateLimit).toHaveBeenCalledWith('bki');
+    });
+
+    it('429 + Retry-After once the ceiling trips — and the redis read is NOT issued', async () => {
+      mockRateLimit.mockResolvedValueOnce({ allowed: false, retryAfterSeconds: 7 });
+      const { req, res } = createMocks();
+      await handlerDefault(req as never, res as never);
+      expect(res._status()).toBe(429);
+      expect(res._headers()['Retry-After']).toBe('7');
+      // 🔴 The point of the limit: a hammering poll never reaches the sysRedis GET
+      // on the instance that backs the money caps.
+      expect(mockReadAllowance).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/tests/api/v1/blocks/tip-allowance-endpoint.test.ts
+++ b/src/tests/api/v1/blocks/tip-allowance-endpoint.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { BlockTokenClaims } from '~/server/middleware/block-scope.middleware';
+
+/**
+ * Handler-level coverage for GET /api/v1/blocks/tip-allowance (item 4). Exercises
+ * the method guard, subject/anon gates, the read of the authoritative tip-cap
+ * counter (cap/spent/remaining), and fail-closed-on-redis-error. Scope enforcement
+ * (social:tip:self) is asserted by the withBlockScope wiring in the default export.
+ */
+
+function createMocks({ method = 'GET' }: { method?: string } = {}) {
+  const req = { method, query: {}, headers: {}, socket: { remoteAddress: '203.0.113.7' } } as unknown as Record<
+    string,
+    unknown
+  >;
+  let statusCode = 200;
+  let payload: unknown;
+  const headers: Record<string, string> = {};
+  const res = {
+    status(c: number) {
+      statusCode = c;
+      return res;
+    },
+    json(b: unknown) {
+      payload = b;
+      return res;
+    },
+    setHeader(k: string, v: string) {
+      headers[k] = v;
+    },
+    end() {
+      return res;
+    },
+    _status: () => statusCode,
+    _json: () => payload,
+    _headers: () => headers,
+  };
+  return { req, res };
+}
+
+const claimsBox: { claims: BlockTokenClaims | undefined } = { claims: undefined };
+class ForbiddenError extends Error {
+  readonly status = 403 as const;
+}
+
+// Capture the withBlockScope opts so we can assert the endpoint declares the
+// correct scope + endpoint label (the real authz gate at runtime). Hoisted so it
+// is initialized before the (hoisted) vi.mock factory runs at import time — the
+// endpoint's `export default withBlockScope(...)` touches it during module load.
+const { capturedOpts } = vi.hoisted(() => ({ capturedOpts: { opts: undefined as unknown } }));
+
+vi.mock('~/server/middleware/block-scope.middleware', () => ({
+  withBlockScope: (handler: any, opts: unknown) => {
+    capturedOpts.opts = opts;
+    return (req: any, res: any) => {
+      req.blockClaims = claimsBox.claims;
+      return handler(req, res);
+    };
+  },
+  parseSubjectUserId: (sub: string): number | null => {
+    if (sub === 'anon') return null;
+    if (!/^user:\d+$/.test(sub)) throw new ForbiddenError('bad');
+    return Number.parseInt(sub.slice('user:'.length), 10);
+  },
+}));
+vi.mock('@civitai/next-axiom', () => ({ withAxiom: (h: any) => h }));
+
+const { mockReadAllowance } = vi.hoisted(() => ({ mockReadAllowance: vi.fn() }));
+vi.mock('~/server/utils/block-tip-rate-limit', () => ({
+  readBlockTipAllowance: mockReadAllowance,
+}));
+
+import handlerDefault from '~/pages/api/v1/blocks/tip-allowance';
+
+function fakeClaims(over: Partial<BlockTokenClaims> = {}): BlockTokenClaims {
+  return {
+    iss: 'civitai',
+    aud: 'civitai-app-block',
+    sub: 'user:42',
+    iat: 0,
+    exp: 0,
+    jti: 'j',
+    blockId: 'b',
+    appId: 'a',
+    appBlockId: 'apb',
+    blockInstanceId: 'bki',
+    ctx: {},
+    scopes: ['social:tip:self'],
+    ...over,
+  } as BlockTokenClaims;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  claimsBox.claims = fakeClaims();
+  mockReadAllowance.mockResolvedValue({ cap: 25_000, spent: 4_000, remaining: 21_000 });
+});
+
+describe('GET /api/v1/blocks/tip-allowance', () => {
+  it('declares the social:tip:self scope + tip_allowance endpoint label', () => {
+    expect(capturedOpts.opts).toMatchObject({
+      endpoint: 'tip_allowance',
+      requiredScope: 'social:tip:self',
+      allowOpaqueOrigin: true,
+    });
+  });
+
+  it('405 for a non-GET method', async () => {
+    const { req, res } = createMocks({ method: 'POST' });
+    await handlerDefault(req as never, res as never);
+    expect(res._status()).toBe(405);
+  });
+
+  it('401 when blockClaims is absent', async () => {
+    claimsBox.claims = undefined;
+    const { req, res } = createMocks();
+    await handlerDefault(req as never, res as never);
+    expect(res._status()).toBe(401);
+  });
+
+  it('403 for an anonymous token (no "self" allowance to read)', async () => {
+    claimsBox.claims = fakeClaims({ sub: 'anon' as never });
+    const { req, res } = createMocks();
+    await handlerDefault(req as never, res as never);
+    expect(res._status()).toBe(403);
+    expect(mockReadAllowance).not.toHaveBeenCalled();
+  });
+
+  it('200: returns {cap, spent, remaining} read for the verified subject', async () => {
+    const { req, res } = createMocks();
+    await handlerDefault(req as never, res as never);
+    expect(res._status()).toBe(200);
+    expect(res._json()).toEqual({ cap: 25_000, spent: 4_000, remaining: 21_000 });
+    // Self-bound: the read is for the TOKEN subject (42), never a client-supplied id.
+    expect(mockReadAllowance).toHaveBeenCalledWith(42);
+  });
+
+  it('503 (fail-closed) when the allowance read throws (redis error)', async () => {
+    mockReadAllowance.mockRejectedValueOnce(new Error('redis down'));
+    const { req, res } = createMocks();
+    await handlerDefault(req as never, res as never);
+    expect(res._status()).toBe(503);
+  });
+});

--- a/src/tests/api/v1/blocks/tip-allowance-endpoint.test.ts
+++ b/src/tests/api/v1/blocks/tip-allowance-endpoint.test.ts
@@ -9,10 +9,12 @@ import type { BlockTokenClaims } from '~/server/middleware/block-scope.middlewar
  */
 
 function createMocks({ method = 'GET' }: { method?: string } = {}) {
-  const req = { method, query: {}, headers: {}, socket: { remoteAddress: '203.0.113.7' } } as unknown as Record<
-    string,
-    unknown
-  >;
+  const req = {
+    method,
+    query: {},
+    headers: {},
+    socket: { remoteAddress: '203.0.113.7' },
+  } as unknown as Record<string, unknown>;
   let statusCode = 200;
   let payload: unknown;
   const headers: Record<string, string> = {};

--- a/src/tests/api/v1/blocks/tip-endpoint.test.ts
+++ b/src/tests/api/v1/blocks/tip-endpoint.test.ts
@@ -453,5 +453,29 @@ describe('POST /api/v1/blocks/tip', () => {
       );
       expect(mockRelease).not.toHaveBeenCalled();
     });
+
+    it('THREADS the client key into createBuzzTipTransactionHandler (ledger-backed dedup, audit 🟡-1)', async () => {
+      const { req, res } = createMocks({
+        body: { toUserId: 5, amount: 25, idempotencyKey: 'idem-abc' },
+      });
+      await handler(req as never, res as never);
+      expect(res._status()).toBe(200);
+      // The handler DERIVES the tip's externalTransactionId from this key so a
+      // crash-window retry (Redis sentinel expired) collides on the Buzz ledger's
+      // unique constraint → money moves once. The Redis sentinel stays the fast-path.
+      expect(mockTip).toHaveBeenCalledWith(
+        expect.objectContaining({ idempotencyKey: 'idem-abc' })
+      );
+    });
+
+    it('CHARSET (audit 🟢): a key with a space/control char is REJECTED (400), no claim, no charge', async () => {
+      const { req, res } = createMocks({
+        body: { toUserId: 5, amount: 25, idempotencyKey: 'bad key\n' },
+      });
+      await handler(req as never, res as never);
+      expect(res._status()).toBe(400);
+      expect(mockClaim).not.toHaveBeenCalled();
+      expect(mockTip).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/tests/api/v1/blocks/tip-endpoint.test.ts
+++ b/src/tests/api/v1/blocks/tip-endpoint.test.ts
@@ -67,16 +67,29 @@ vi.mock('~/server/middleware/block-scope.middleware', () => ({
 }));
 vi.mock('@civitai/next-axiom', () => ({ withAxiom: (h: any) => h }));
 
-const { mockTip, mockHydrate, mockRate, mockReserve, mockRefund, mockUserFind, mockStash } =
-  vi.hoisted(() => ({
-    mockTip: vi.fn(),
-    mockHydrate: vi.fn(),
-    mockRate: vi.fn(),
-    mockReserve: vi.fn(),
-    mockRefund: vi.fn(),
-    mockUserFind: vi.fn(),
-    mockStash: vi.fn(),
-  }));
+const {
+  mockTip,
+  mockHydrate,
+  mockRate,
+  mockReserve,
+  mockRefund,
+  mockUserFind,
+  mockStash,
+  mockClaim,
+  mockFinalize,
+  mockRelease,
+} = vi.hoisted(() => ({
+  mockTip: vi.fn(),
+  mockHydrate: vi.fn(),
+  mockRate: vi.fn(),
+  mockReserve: vi.fn(),
+  mockRefund: vi.fn(),
+  mockUserFind: vi.fn(),
+  mockStash: vi.fn(),
+  mockClaim: vi.fn(),
+  mockFinalize: vi.fn(),
+  mockRelease: vi.fn(),
+}));
 
 vi.mock('~/server/controllers/buzz.controller', () => ({
   createBuzzTipTransactionHandler: mockTip,
@@ -91,6 +104,9 @@ vi.mock('~/server/utils/block-tip-rate-limit', () => ({
   checkBlockTipRateLimit: mockRate,
   reserveBlockTipSpend: mockReserve,
   refundBlockTipSpend: mockRefund,
+  claimTipIdempotency: mockClaim,
+  finalizeTipIdempotency: mockFinalize,
+  releaseTipIdempotency: mockRelease,
   BLOCK_TIP_MAX_PER_TIP: 5_000,
   BLOCK_TIP_CAP_PER_DAY: 25_000,
 }));
@@ -126,6 +142,10 @@ beforeEach(() => {
   mockRefund.mockResolvedValue(undefined);
   // Default: the recipient exists and is not deleted.
   mockUserFind.mockResolvedValue({ id: 5, deletedAt: null });
+  // Idempotency defaults: first attempt acquires the claim; finalize/release no-op.
+  mockClaim.mockResolvedValue({ state: 'acquired', key: 'system:blocks:tip-idem:42:k1' });
+  mockFinalize.mockResolvedValue(undefined);
+  mockRelease.mockResolvedValue(undefined);
 });
 
 describe('POST /api/v1/blocks/tip', () => {
@@ -324,5 +344,114 @@ describe('POST /api/v1/blocks/tip', () => {
     const { req, res } = createMocks({ body: { toUserId: 5, amount: 10 } });
     await handler(req as never, res as never);
     expect(res._status()).toBe(500);
+  });
+
+  // ── Idempotency (item 2, tip half) ──────────────────────────────────────────
+  describe('idempotencyKey', () => {
+    it('absent key → today\'s behavior: the idempotency claim is NEVER consulted', async () => {
+      const { req, res } = createMocks({ body: { toUserId: 5, amount: 25 } });
+      await handler(req as never, res as never);
+      expect(res._status()).toBe(200);
+      expect(mockClaim).not.toHaveBeenCalled();
+      expect(mockFinalize).not.toHaveBeenCalled();
+    });
+
+    it('present key, first attempt: claims, tips ONCE, and FINALIZES the 200 for replay', async () => {
+      const { req, res } = createMocks({
+        body: { toUserId: 5, amount: 25, idempotencyKey: 'idem-abc' },
+      });
+      await handler(req as never, res as never);
+      expect(res._status()).toBe(200);
+      expect(mockClaim).toHaveBeenCalledWith(42, 'idem-abc');
+      expect(mockTip).toHaveBeenCalledTimes(1);
+      // The terminal 200 (status+body) is cached under the key so a replay repeats it.
+      expect(mockFinalize).toHaveBeenCalledWith(
+        'system:blocks:tip-idem:42:k1',
+        200,
+        expect.objectContaining({ ok: true })
+      );
+      expect(mockRelease).not.toHaveBeenCalled();
+    });
+
+    it('REPLAY (lost-response retry): returns the cached result WITHOUT a 2nd charge', async () => {
+      mockClaim.mockResolvedValueOnce({
+        state: 'replay',
+        status: 200,
+        body: { ok: true, tip: { toUserId: 5, amount: 25, entityType: null, entityId: null } },
+      });
+      const { req, res } = createMocks({
+        body: { toUserId: 5, amount: 25, idempotencyKey: 'idem-abc' },
+      });
+      await handler(req as never, res as never);
+      expect(res._status()).toBe(200);
+      expect(res._json()).toEqual({
+        ok: true,
+        tip: { toUserId: 5, amount: 25, entityType: null, entityId: null },
+      });
+      // 🔴 The load-bearing assertion: NO second reserve, NO second charge.
+      expect(mockTip).not.toHaveBeenCalled();
+      expect(mockReserve).not.toHaveBeenCalled();
+      expect(mockFinalize).not.toHaveBeenCalled();
+    });
+
+    it('IN PROGRESS (concurrent duplicate): 409, never races into a 2nd charge', async () => {
+      mockClaim.mockResolvedValueOnce({ state: 'in_progress' });
+      const { req, res } = createMocks({
+        body: { toUserId: 5, amount: 25, idempotencyKey: 'idem-abc' },
+      });
+      await handler(req as never, res as never);
+      expect(res._status()).toBe(409);
+      expect(mockTip).not.toHaveBeenCalled();
+      expect(mockReserve).not.toHaveBeenCalled();
+    });
+
+    it('FAIL-CLOSED: a redis error at claim time → 503, no charge', async () => {
+      mockClaim.mockRejectedValueOnce(new Error('redis down'));
+      const { req, res } = createMocks({
+        body: { toUserId: 5, amount: 25, idempotencyKey: 'idem-abc' },
+      });
+      await handler(req as never, res as never);
+      expect(res._status()).toBe(503);
+      expect(mockTip).not.toHaveBeenCalled();
+    });
+
+    it('a TRANSIENT 429 (rate limit) RELEASES the claim (a retry may re-run) — not finalized', async () => {
+      mockRate.mockResolvedValueOnce({ allowed: false, retryAfterSeconds: 30 });
+      const { req, res } = createMocks({
+        body: { toUserId: 5, amount: 25, idempotencyKey: 'idem-abc' },
+      });
+      await handler(req as never, res as never);
+      expect(res._status()).toBe(429);
+      expect(mockRelease).toHaveBeenCalledWith('system:blocks:tip-idem:42:k1');
+      expect(mockFinalize).not.toHaveBeenCalled();
+    });
+
+    it('a TRANSIENT 503 (limiter reserve threw) RELEASES the claim — not finalized', async () => {
+      mockReserve.mockRejectedValueOnce(new Error('redis down'));
+      const { req, res } = createMocks({
+        body: { toUserId: 5, amount: 25, idempotencyKey: 'idem-abc' },
+      });
+      await handler(req as never, res as never);
+      expect(res._status()).toBe(503);
+      expect(mockRelease).toHaveBeenCalledWith('system:blocks:tip-idem:42:k1');
+      expect(mockFinalize).not.toHaveBeenCalled();
+    });
+
+    it('a terminal 400 (insufficient funds) is FINALIZED (cached) so a replay repeats it', async () => {
+      mockTip.mockRejectedValueOnce(
+        new TRPCError({ code: 'BAD_REQUEST', message: "you don't have enough funds" })
+      );
+      const { req, res } = createMocks({
+        body: { toUserId: 5, amount: 999, idempotencyKey: 'idem-abc' },
+      });
+      await handler(req as never, res as never);
+      expect(res._status()).toBe(400);
+      expect(mockFinalize).toHaveBeenCalledWith(
+        'system:blocks:tip-idem:42:k1',
+        400,
+        expect.objectContaining({ ok: false })
+      );
+      expect(mockRelease).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/tests/api/v1/blocks/tip-endpoint.test.ts
+++ b/src/tests/api/v1/blocks/tip-endpoint.test.ts
@@ -78,6 +78,7 @@ const {
   mockClaim,
   mockFinalize,
   mockRelease,
+  mockFingerprint,
 } = vi.hoisted(() => ({
   mockTip: vi.fn(),
   mockHydrate: vi.fn(),
@@ -89,6 +90,7 @@ const {
   mockClaim: vi.fn(),
   mockFinalize: vi.fn(),
   mockRelease: vi.fn(),
+  mockFingerprint: vi.fn(),
 }));
 
 vi.mock('~/server/controllers/buzz.controller', () => ({
@@ -107,6 +109,10 @@ vi.mock('~/server/utils/block-tip-rate-limit', () => ({
   claimTipIdempotency: mockClaim,
   finalizeTipIdempotency: mockFinalize,
   releaseTipIdempotency: mockRelease,
+  // Deterministic stub — the REAL fingerprint derivation is unit-tested in
+  // block-tip-rate-limit.test.ts; here we only need a stable value to assert the
+  // endpoint THREADS it into claim + finalize.
+  computeTipFingerprint: (...a: unknown[]) => mockFingerprint(...(a as [])),
   BLOCK_TIP_MAX_PER_TIP: 5_000,
   BLOCK_TIP_CAP_PER_DAY: 25_000,
 }));
@@ -131,12 +137,22 @@ function fakeClaims(over: Partial<BlockTokenClaims> = {}): BlockTokenClaims {
   } as BlockTokenClaims;
 }
 
+/** Stable stub fingerprint (see the module mock). */
+const FP = 'fp-deadbeef';
+
 beforeEach(() => {
   vi.clearAllMocks();
   claimsBox.claims = fakeClaims();
   mockRate.mockResolvedValue({ allowed: true });
   mockHydrate.mockResolvedValue({ id: 42, username: 'mod', bannedAt: null, muted: false });
-  mockTip.mockResolvedValue([{ transactionId: 't1' }]);
+  // The controller returns the ledger result plus the audit-🔴-2 dedupe report.
+  // `dedupedAmount: 0` = every transaction actually moved (the normal case).
+  mockTip.mockResolvedValue({
+    transactions: ['t1'],
+    conflicts: [],
+    deduped: false,
+    dedupedAmount: 0,
+  });
   // Default: reservation well under the daily cap.
   mockReserve.mockResolvedValue({ total: 25, key: 'system:blocks:tip-cap:42:2026-07-13' });
   mockRefund.mockResolvedValue(undefined);
@@ -146,6 +162,7 @@ beforeEach(() => {
   mockClaim.mockResolvedValue({ state: 'acquired', key: 'system:blocks:tip-idem:42:k1' });
   mockFinalize.mockResolvedValue(undefined);
   mockRelease.mockResolvedValue(undefined);
+  mockFingerprint.mockReturnValue(FP);
 });
 
 describe('POST /api/v1/blocks/tip', () => {
@@ -362,13 +379,16 @@ describe('POST /api/v1/blocks/tip', () => {
       });
       await handler(req as never, res as never);
       expect(res._status()).toBe(200);
-      expect(mockClaim).toHaveBeenCalledWith(42, 'idem-abc');
+      // (userId, appBlockId, key, fingerprint) — the app segment is audit 🟡-2,
+      // the fingerprint is the 🟡-1 residual.
+      expect(mockClaim).toHaveBeenCalledWith(42, 'apb', 'idem-abc', FP);
       expect(mockTip).toHaveBeenCalledTimes(1);
       // The terminal 200 (status+body) is cached under the key so a replay repeats it.
       expect(mockFinalize).toHaveBeenCalledWith(
         'system:blocks:tip-idem:42:k1',
         200,
-        expect.objectContaining({ ok: true })
+        expect.objectContaining({ ok: true }),
+        FP
       );
       expect(mockRelease).not.toHaveBeenCalled();
     });
@@ -449,7 +469,8 @@ describe('POST /api/v1/blocks/tip', () => {
       expect(mockFinalize).toHaveBeenCalledWith(
         'system:blocks:tip-idem:42:k1',
         400,
-        expect.objectContaining({ ok: false })
+        expect.objectContaining({ ok: false }),
+        FP
       );
       expect(mockRelease).not.toHaveBeenCalled();
     });
@@ -466,6 +487,71 @@ describe('POST /api/v1/blocks/tip', () => {
       expect(mockTip).toHaveBeenCalledWith(
         expect.objectContaining({ idempotencyKey: 'idem-abc' })
       );
+    });
+
+    it('MISMATCH (audit 🟡-1 residual): the same key with a DIFFERENT payload → 422, no charge', async () => {
+      // The claim layer reports that this key is already bound to a different
+      // request. Replaying the first tip's result would tell the app a tip it never
+      // made succeeded; executing would break the key's one-request contract.
+      mockClaim.mockResolvedValueOnce({ state: 'mismatch' });
+      const { req, res } = createMocks({
+        body: { toUserId: 9, amount: 25, idempotencyKey: 'idem-abc' },
+      });
+      await handler(req as never, res as never);
+      expect(res._status()).toBe(422);
+      expect(mockTip).not.toHaveBeenCalled();
+      expect(mockReserve).not.toHaveBeenCalled();
+      expect(mockFinalize).not.toHaveBeenCalled();
+    });
+
+    it('🔴 STRANDED CLAIM (audit 🟡-3): a throw that ESCAPES the money attempt RELEASES the claim', async () => {
+      // `hydrateBlockSubject` sits OUTSIDE attemptTip's inner try, so a transient DB
+      // blip there escapes past both finalize and release. Without the fix the
+      // sentinel survives its full 10-minute TTL and 409s every same-key retry with
+      // "already in progress" when NOTHING is in progress — making the tip
+      // unlandable exactly when retrying with the same key is the entire point.
+      mockHydrate.mockRejectedValueOnce(new Error('db blip'));
+      const { req, res } = createMocks({
+        body: { toUserId: 5, amount: 25, idempotencyKey: 'idem-abc' },
+      });
+      await expect(handler(req as never, res as never)).rejects.toThrow('db blip');
+      // 🔴 The load-bearing assertion: the claim is released, so a retry re-runs.
+      expect(mockRelease).toHaveBeenCalledWith('system:blocks:tip-idem:42:k1');
+      // No terminal result exists — nothing may be cached for replay.
+      expect(mockFinalize).not.toHaveBeenCalled();
+      // No money moved.
+      expect(mockTip).not.toHaveBeenCalled();
+    });
+
+    it('🔴 LEDGER-DEDUPED TIP (audit 🔴-2): the burned cap reservation is REFUNDED', async () => {
+      // The Redis sentinel expired, so the attempt runs and reserves against the
+      // daily tip cap — but the ledger rejects the deterministic
+      // externalTransactionId as a duplicate: ZERO Buzz moves on this call. Keeping
+      // the reservation would debit the viewer's daily ALLOWANCE twice for a
+      // transfer that happened once.
+      mockTip.mockResolvedValueOnce({
+        transactions: [],
+        conflicts: ['block-tip:42:idem-abc-5'],
+        deduped: true,
+        dedupedAmount: 25,
+      });
+      const { req, res } = createMocks({
+        body: { toUserId: 5, amount: 25, idempotencyKey: 'idem-abc' },
+      });
+      await handler(req as never, res as never);
+      // The tip still SUCCEEDED from the caller's perspective — money moved once.
+      expect(res._status()).toBe(200);
+      // 🔴 The load-bearing assertion: exactly the deduped amount is refunded.
+      expect(mockRefund).toHaveBeenCalledWith('system:blocks:tip-cap:42:2026-07-13', 25);
+    });
+
+    it('a normally-settled tip does NOT refund the cap (dedupedAmount 0 → inert)', async () => {
+      const { req, res } = createMocks({
+        body: { toUserId: 5, amount: 25, idempotencyKey: 'idem-abc' },
+      });
+      await handler(req as never, res as never);
+      expect(res._status()).toBe(200);
+      expect(mockRefund).not.toHaveBeenCalled();
     });
 
     it('CHARSET (audit 🟢): a key with a space/control char is REJECTED (400), no claim, no charge', async () => {


### PR DESCRIPTION
Batch D, money slice. Closes a **live double-spend exposure** on block generation, and a **phantom-tip** state this PR's own deterministic ledger id made reachable.

> **Correction to the original description.** It claimed to close a live double-spend. As first written it did **not**: `externalId` was emitted only when the client sent `idempotencyKey`, and **no shipped client sends one** (the SDK's `main` has zero occurrences, the companion SDK PR is unmerged/unpublished, and the live tipping block hand-rolls its POST). On all live traffic `externalId` was `undefined` and nothing was deduped. The latest commit makes the claim true.

## 🔴-1 — the double-spend is server-side and unconditional

`submitWorkflow` calls `submitWorkflowWithRetry` with the default `maxAttempts = 3` and **no per-attempt timeout on the real submit**. That wrapper's own doc is explicit that it adds no idempotency key — *"the CALLER must set `body.externalId`"*. So a 502/504 (or a dropped socket) **after** the orchestrator already created and charged the workflow makes attempts 2 and 3 create another one: up to **3 workflows and 3 charges for one user action**, with no client involvement at all.

**Fix:** the server now **mints an `externalId` when the client sends none**, on both `submitWorkflow` branches (txt2img + customComfy). A client-supplied key remains an override.

- **Stable across the attempts of one request, unique per request.** Minted **once** in the router before the body is built — `submitWorkflowWithRetry` reuses that same body object on every attempt, so all 3 present the same id (the orchestrator's `(userId, externalId)` dedupe collapses them to one workflow + one charge) while two genuinely different submits get different UUIDs. A new test pins that wrapper contract, since the mint rests on it.
- **Namespace-disjoint by construction.** Shape is `bls<uuid>`; client-keyed ids are `blk<NN><appBlockId><key>`. They differ at index 2, so a minted id can **never** collide with a client-supplied one. Both go through the same orchestrator-contract guard (`^[A-Za-z0-9_-]+$`, ≤128).
- **Cannot fail-closed on the new unconditional path.** `bls<uuid>` is a fixed 39 chars with nothing caller-supplied contributing to the length, so the guard can never trip and reject a generation that works today. (The client-key path keeps its fail-closed throw — there the caller *asked* for dedupe, so rejecting beats silently not deduping.)

**Behaviour, explicitly:**

| | before | after |
|---|---|---|
| **no client key** (all live traffic) | no `externalId`, no redis claim → a lost response double-charges | server-minted `externalId` → the wrapper's own 3× retry collapses to **one** charge. Redis claim still **not** taken (a per-request-unique id can't dedupe anything; taking it would only add two round-trips and a stuck-sentinel failure mode). A **client-level** retry is still not deduped — that still needs a client key. |
| **client key present** | `blk…` externalId + redis `SET NX` claim | **byte-identical** — same composed id, same claim, same replay/409/release semantics |

## 🔴-2 — deterministic `externalTransactionId` made a ledger conflict reachable, and the controller ignored it

`createBuzzTransactionMany` returns `{ transactions, conflicts }`, and a `conflict` means **the money already moved**. `buzz.controller.ts` never inspected it and unconditionally fired `upsertBuzzTip`, a `tip-received` notification (keyed by a fresh `uuid()`, so nothing else dedups it) and the Image Buzz metric, then returned `200 {ok:true}`.

Before this PR the id was `tip-${uuid()}-…`, so `conflicts` was always empty here — **this PR is what made the state reachable.** Reachable path: tip 5,000 to X on image A with key K → wait past the 10-min Redis sentinel → same K, same recipient, **different `entityId`** (the derivation deliberately ignores the entity) → byte-identical ledger id → conflict, **zero Buzz moves** — yet image B got +5,000 Buzz, a `BuzzTip` row and a 200.

**Fix:** `conflicts[]` is now inspected (matched on `externalTransactionId`, with a zero-successes count belt so the fail direction stays safe if the wire shape ever changes) and all three side effects are skipped for conflicted transactions. The controller reports `{ deduped, dedupedAmount }` upward.

**Cap refund: yes.** The tip endpoint refunds `dedupedAmount` against its daily tip-cap reservation. The "keeping the reservation only makes the cap stricter, which is safe" rule in the catch block applies to *uncertainty* about whether money moved; here the ledger has affirmatively told us it did **not**, so keeping it debits the viewer's daily allowance a second time for a transfer that happened once. Replay abuse is not what the money cap holds — a replay is already bounded by the per-instance 10-tips/60s limiter and the redis sentinel, and it moves no Buzz.

## 🟡 folded into the same pass

- **🟡-3 stranded claim.** `hydrateBlockSubject(subjectId)` and `new Tracker(req, res)` sit outside the money attempt's try, so a throw escaped past both finalize and release. The sentinel then survived its full 10-minute TTL and 409'd every retry with *"already in progress"* when nothing was — making a tip unlandable after a transient DB blip, precisely when retrying with the same key is the point. Now released on throw, matching the gen path.
- **🟡-2 cross-app replay leak.** The tip idem key gains `appBlockId` (`system:blocks:tip-idem:<userId>:<appBlockId>:<key>`), mirroring the gen key. Two apps the same user installed that collide on a key value (an app hardcoding `"tip1"`) no longer share a slot — app B can no longer replay app A's cached body and learn A's tip recipient and amount while its own tip silently doesn't happen.
- **🟡-1 residual.** The claim is now pinned to a **payload fingerprint** (recipient, amount, entity). Same key + different payload → **422**, instead of silently replaying someone else's outcome. Same key + same payload keeps replay/409 semantics.
- **🟡-4.** `/api/v1/blocks/tip-allowance` is rate-limited like its siblings (`models.ts`, `images.ts` both call `checkBlockCatalogRateLimit`) — same bucket, same fail-open posture. It is designed to be live-polled and each call is a `sysRedis` GET on the instance backing the money caps.

## 🟢

- `composeBlockExternalId` is now **`typeof`-safe**: a non-string previously slipped past `undefined < 1 || undefined > 99` and produced a 9-char pseudo-`NN`, breaking the length-prefix injectivity the whole scheme rests on.
- Corrected the synthetic-`appBlockId` shapes in the docs — the real ones are `page_local_<slug>` and `pubreq_<ULID>` (`local-`/`pending-` are **appId** shapes) — and the worst case: **120**, not 119 (`page_local_` + a 40-char slug + a 64-char key = headroom 8). The worst-case test now exercises that longest shape instead of `ephemeral-` (51 vs 50).
- Stale `^[A-Za-z0-9_-]{1,200}$` comment corrected to `{1,64}`.
- Removed a literal **NUL byte** (`0x00`) this branch had introduced as the documented "leading-space" in-progress sentinel; the tip record is now always JSON.

## 🔴 Orchestrator contract — verified against source, not assumed

An earlier revision assumed a 512-char ceiling and a colon-delimited id. The real contract (`civitai-orchestration:.../WorkflowTemplate.cs`) is:

```csharp
[StringLength(128, MinimumLength = 1)]
[RegularExpression("^[A-Za-z0-9_-]+$")]
public string? ExternalId { get; init; }
```

Colons are outside that charset, and `ConsumerControllerBase` carries `[ApiController]` — so it is an automatic **400 before the action body runs**, not a truncation. Confirmed present in the deployed `orchestration-api:v2.26.11` (orchestration `c023ed9dd`). Dedup is **userId-scoped** (`FindWorkflowByExternalIdAsync(userId, …)` + a server-side `{userId}-` prefix backing a partial unique index), a hit **returns the original `Workflow`**, and the create race is handled (`DuplicateExternalId` → re-fetch → return existing).

## Testing

- **341/341** money slice green (`block-gen-idempotency` 18, `block-tip-rate-limit` 29, `buzz.controller.tip` 7, `tip-endpoint` 34, `tip-allowance-endpoint` 8, `blocks.router.workflow` 237, `submitWorkflow.timeout` 8). Was 309 before this pass.
- **Whole `unit` project: 9386 passed / 697 files**, with one pre-existing failure (`hiddenBlocks.test.ts`, 7) that is untouched by this PR and fails identically before it — a local happy-dom/localStorage issue.
- **Browser suite: `PageBlockHost.browser.test.tsx` 25/25** (run with `PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH` pointed at a Nix chromium).
- `npx tsc --noEmit` clean in every touched file; eslint clean.
- **Both 🔴 fixes are mutation-checked.** Reverting the mint to `undefined` turns the unkeyed lost-response test red at **`expected 3 to be 1`** — three charges for one user action, the exact exposure. Re-ignoring `conflicts[]` turns the deduped-tip test red on the `BuzzTip` row and the notification firing. Dropping the cap refund and dropping the release-on-throw each turn their own test red.
- Added the tests the audit named as missing: `releaseGenIdempotency` on the submit-**throw** catch (the retry scenario, and the most important release site), and the customComfy `composeBlockExternalId` fail-closed throws.

Companion SDK PR in `civitai-app-starters` (same branch name) — no longer load-bearing for the double-spend fix, since the server now mints its own id.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
