### PR TITLE
feat(app-blocks): SAVE_IMAGE download bridge, viewerVoted, SHARED_REPORT, shared get(key)

### DIFF
--- a/src/components/AppBlocks/IframeHost.browser.test.tsx
+++ b/src/components/AppBlocks/IframeHost.browser.test.tsx
@@ -48,6 +48,7 @@ vi.mock('~/utils/trpc', () => ({
         vote: { useMutation: () => ({ mutateAsync: vi.fn() }) },
         unvote: { useMutation: () => ({ mutateAsync: vi.fn() }) },
         withdraw: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        report: { useMutation: () => ({ mutateAsync: vi.fn() }) },
       },
       storage: {
         set: { useMutation: () => ({ mutateAsync: vi.fn() }) },
@@ -60,6 +61,7 @@ vi.mock('~/utils/trpc', () => ({
           list: { fetch: vi.fn() },
           getCount: { fetch: vi.fn() },
           getCounts: { fetch: vi.fn() },
+          get: { fetch: vi.fn() },
         },
         storage: {
           get: { fetch: vi.fn() },

--- a/src/components/AppBlocks/IframeHost.tsx
+++ b/src/components/AppBlocks/IframeHost.tsx
@@ -1492,6 +1492,7 @@ export function IframeHost({
   const sharedVoteMutation = trpc.apps.shared.vote.useMutation();
   const sharedUnvoteMutation = trpc.apps.shared.unvote.useMutation();
   const sharedWithdrawMutation = trpc.apps.shared.withdraw.useMutation();
+  const sharedReportMutation = trpc.apps.shared.report.useMutation();
 
   useEffect(() => {
     const off = onMessage<
@@ -1529,6 +1530,8 @@ export function IframeHost({
               it.createdAt instanceof Date ? it.createdAt.toISOString() : String(it.createdAt),
             updatedAt:
               it.updatedAt instanceof Date ? it.updatedAt.toISOString() : String(it.updatedAt),
+            // item 3: pass the per-viewer vote flag straight through (no logic).
+            viewerVoted: it.viewerVoted,
           })),
           nextCursor: result.nextCursor,
         });
@@ -1691,6 +1694,64 @@ export function IframeHost({
     );
     return off;
   }, [onMessage, send, token, sharedWithdrawMutation]);
+
+  // SHARED_GET → apps.shared.get → SHARED_GET_RESULT (single-row deep-link fetch).
+  // Mirrors SHARED_LIST's item mapping (createdAt/updatedAt → ISO; additive
+  // viewerVoted passes through); a missing/hidden row comes back `item: null`.
+  useEffect(() => {
+    const off = onMessage<{ requestId?: unknown; key?: unknown } | undefined>(
+      'SHARED_GET',
+      async (raw) => {
+        if (!raw || typeof raw.requestId !== 'string' || typeof raw.key !== 'string') return;
+        const requestId = raw.requestId;
+        try {
+          const result = await trpcUtils.apps.shared.get.fetch({ blockToken: token, key: raw.key });
+          const it = result.item;
+          send('SHARED_GET_RESULT', {
+            requestId,
+            item: it
+              ? {
+                  key: it.key,
+                  authorUserId: it.authorUserId,
+                  value: it.value,
+                  count: it.count,
+                  createdAt:
+                    it.createdAt instanceof Date ? it.createdAt.toISOString() : String(it.createdAt),
+                  updatedAt:
+                    it.updatedAt instanceof Date ? it.updatedAt.toISOString() : String(it.updatedAt),
+                  viewerVoted: it.viewerVoted,
+                }
+              : null,
+          });
+        } catch (err) {
+          send('SHARED_GET_RESULT', { requestId, item: null, error: storageErrorMessage(err) });
+        }
+      }
+    );
+    return off;
+  }, [onMessage, send, token, trpcUtils]);
+
+  // SHARED_REPORT → apps.shared.report → SHARED_REPORT_RESULT. User reports a
+  // posted row for mod review (server trust-gates + rate-limits + files it).
+  // Reply is SHARED_WITHDRAW-style `{ ok, error? }` — the error path MUST carry
+  // ok:false or the SDK drops it (→ hang).
+  useEffect(() => {
+    const off = onMessage<{ requestId?: unknown; key?: unknown; reason?: unknown } | undefined>(
+      'SHARED_REPORT',
+      async (raw) => {
+        if (!raw || typeof raw.requestId !== 'string' || typeof raw.key !== 'string') return;
+        const requestId = raw.requestId;
+        const reason = typeof raw.reason === 'string' ? raw.reason : undefined;
+        try {
+          await sharedReportMutation.mutateAsync({ blockToken: token, key: raw.key, reason });
+          send('SHARED_REPORT_RESULT', { requestId, ok: true });
+        } catch (err) {
+          send('SHARED_REPORT_RESULT', { requestId, ok: false, error: storageErrorMessage(err) });
+        }
+      }
+    );
+    return off;
+  }, [onMessage, send, token, sharedReportMutation]);
 
   useEffect(() => {
     if (status !== 'ready') return;

--- a/src/components/AppBlocks/PageBlockHost.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHost.browser.test.tsx
@@ -57,6 +57,7 @@ vi.mock('~/utils/trpc', () => ({
         vote: { useMutation: () => ({ mutateAsync: vi.fn() }) },
         unvote: { useMutation: () => ({ mutateAsync: vi.fn() }) },
         withdraw: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        report: { useMutation: () => ({ mutateAsync: vi.fn() }) },
       },
       storage: {
         set: { useMutation: () => ({ mutateAsync: vi.fn() }) },
@@ -69,6 +70,7 @@ vi.mock('~/utils/trpc', () => ({
           list: { fetch: vi.fn() },
           getCount: { fetch: vi.fn() },
           getCounts: { fetch: vi.fn() },
+          get: { fetch: vi.fn() },
         },
         storage: {
           get: { fetch: vi.fn() },

--- a/src/components/AppBlocks/PageBlockHost.tsx
+++ b/src/components/AppBlocks/PageBlockHost.tsx
@@ -39,6 +39,7 @@ import {
   isAllowedSaveImageUrl,
   resolveSaveImageRequest,
   sanitizeDownloadFilename,
+  SAVE_IMAGE_MAX_CONCURRENT,
 } from './saveImageDownload';
 import { env } from '~/env/client';
 import { effectiveSandboxIsOpaque, intersectSandbox } from './sandbox';
@@ -1962,6 +1963,12 @@ export function PageBlockHost({
     return off;
   }, [onMessage, send, token, sharedReportMutation, reviewMode]);
 
+  // F2 concurrency-cap counter for SAVE_IMAGE (see the handler below). A ref (not
+  // state) so increment/decrement never re-renders and the count is read
+  // synchronously in the message handler (single-threaded ⇒ check→increment before
+  // the first await is atomic per message), mirroring wildcardInFlightRef.
+  const saveImageInFlightRef = useRef<number>(0);
+
   // SAVE_IMAGE → SAVE_IMAGE_RESULT (Batch-D item 1). The host downloads an image
   // the block already displays, in its UNSANDBOXED top frame (the block's sandbox
   // has no allow-downloads). TWO variants, each with its own security gate:
@@ -1984,6 +1991,16 @@ export function PageBlockHost({
         send('SAVE_IMAGE_RESULT', { requestId, ok: false, error: 'invalid save-image request' });
         return;
       }
+      // F2 concurrency cap (host-side backpressure): bound concurrent host-side
+      // image downloads so a hostile block can't download-bomb the viewer's tab
+      // (memory/bandwidth). check→increment runs synchronously before the first
+      // await (single-threaded), so N concurrent SAVE_IMAGEs can't all pass the
+      // gate; excess replies `busy` (the block retries) rather than fetching.
+      if (saveImageInFlightRef.current >= SAVE_IMAGE_MAX_CONCURRENT) {
+        send('SAVE_IMAGE_RESULT', { requestId, ok: false, error: 'busy' });
+        return;
+      }
+      saveImageInFlightRef.current += 1;
       try {
         if (req.kind === 'url') {
           if (!isAllowedSaveImageUrl(req.url, env.NEXT_PUBLIC_IMAGE_LOCATION)) {
@@ -2014,6 +2031,10 @@ export function PageBlockHost({
         send('SAVE_IMAGE_RESULT', { requestId, ok: true });
       } catch (err) {
         send('SAVE_IMAGE_RESULT', { requestId, ok: false, error: storageErrorMessage(err) });
+      } finally {
+        // Release the slot on EVERY exit that acquired one (success / refusal /
+        // error) so the gate can't leak slots and wedge shut.
+        saveImageInFlightRef.current -= 1;
       }
     });
     return off;

--- a/src/components/AppBlocks/PageBlockHost.tsx
+++ b/src/components/AppBlocks/PageBlockHost.tsx
@@ -34,6 +34,13 @@ import {
 } from './wildcardPackParse';
 import { resolveRequestConsent } from './requestConsentGate';
 import { resolveRequestSignIn } from './requestSignInGate';
+import {
+  downloadUrlAsBlob,
+  isAllowedSaveImageUrl,
+  resolveSaveImageRequest,
+  sanitizeDownloadFilename,
+} from './saveImageDownload';
+import { env } from '~/env/client';
 import { effectiveSandboxIsOpaque, intersectSandbox } from './sandbox';
 import { PAGE_SLOT_ID } from '~/shared/constants/slot-registry';
 import { usePostMessage } from './usePostMessage';
@@ -1610,6 +1617,7 @@ export function PageBlockHost({
   const sharedVoteMutation = trpc.apps.shared.vote.useMutation();
   const sharedUnvoteMutation = trpc.apps.shared.unvote.useMutation();
   const sharedWithdrawMutation = trpc.apps.shared.withdraw.useMutation();
+  const sharedReportMutation = trpc.apps.shared.report.useMutation();
 
   // SHARED_LIST → apps.shared.list → SHARED_LIST_RESULT (query).
   useEffect(() => {
@@ -1650,6 +1658,8 @@ export function PageBlockHost({
               it.createdAt instanceof Date ? it.createdAt.toISOString() : String(it.createdAt),
             updatedAt:
               it.updatedAt instanceof Date ? it.updatedAt.toISOString() : String(it.updatedAt),
+            // item 3: pass the per-viewer vote flag straight through (no logic).
+            viewerVoted: it.viewerVoted,
           })),
           nextCursor: result.nextCursor,
         });
@@ -1874,6 +1884,140 @@ export function PageBlockHost({
     );
     return off;
   }, [onMessage, send, token, sharedWithdrawMutation, reviewMode]);
+
+  // SHARED_GET → apps.shared.get → SHARED_GET_RESULT (query). Single-row deep-link
+  // fetch-by-key. READ (anon-allowed server-side; no reviewMode NACK — reads stay
+  // live). Maps the item exactly like SHARED_LIST (createdAt/updatedAt → ISO, and
+  // the additive viewerVoted flows straight through). A missing/hidden row comes
+  // back as `item: null` (the server applies the same hidden_at gate as list).
+  useEffect(() => {
+    const off = onMessage<{ requestId?: unknown; key?: unknown } | undefined>(
+      'SHARED_GET',
+      async (raw) => {
+        if (!raw || typeof raw.requestId !== 'string' || typeof raw.key !== 'string' || !token)
+          return;
+        const requestId = raw.requestId;
+        try {
+          const result = await trpcUtils.apps.shared.get.fetch({
+            blockToken: token,
+            key: raw.key,
+          });
+          const it = result.item;
+          send('SHARED_GET_RESULT', {
+            requestId,
+            item: it
+              ? {
+                  key: it.key,
+                  authorUserId: it.authorUserId,
+                  value: it.value,
+                  count: it.count,
+                  createdAt:
+                    it.createdAt instanceof Date ? it.createdAt.toISOString() : String(it.createdAt),
+                  updatedAt:
+                    it.updatedAt instanceof Date ? it.updatedAt.toISOString() : String(it.updatedAt),
+                  viewerVoted: it.viewerVoted,
+                }
+              : null,
+          });
+        } catch (err) {
+          send('SHARED_GET_RESULT', { requestId, item: null, error: storageErrorMessage(err) });
+        }
+      }
+    );
+    return off;
+  }, [onMessage, send, token, trpcUtils]);
+
+  // SHARED_REPORT → apps.shared.report → SHARED_REPORT_RESULT (mutation). A user
+  // reports a posted row for mod review; the server already trust-gates + rate-
+  // limits + files the report (endpoint pre-exists). Reply is SHARED_WITHDRAW-
+  // style `{ ok, error? }` — the error path MUST carry ok:false or the SDK drops
+  // it (→ hang). reviewMode NACK: report is a shared:write-trust op, never granted
+  // in run-for-real (mirrors the other shared writes).
+  useEffect(() => {
+    const off = onMessage<{ requestId?: unknown; key?: unknown; reason?: unknown } | undefined>(
+      'SHARED_REPORT',
+      async (raw) => {
+        if (reviewMode) {
+          if (raw && typeof raw.requestId === 'string') {
+            send('SHARED_REPORT_RESULT', {
+              requestId: raw.requestId,
+              ok: false,
+              error: REVIEW_NACK_MESSAGE,
+            });
+          }
+          return;
+        }
+        if (!raw || typeof raw.requestId !== 'string' || typeof raw.key !== 'string' || !token)
+          return;
+        const requestId = raw.requestId;
+        const reason = typeof raw.reason === 'string' ? raw.reason : undefined;
+        try {
+          await sharedReportMutation.mutateAsync({ blockToken: token, key: raw.key, reason });
+          send('SHARED_REPORT_RESULT', { requestId, ok: true });
+        } catch (err) {
+          send('SHARED_REPORT_RESULT', { requestId, ok: false, error: storageErrorMessage(err) });
+        }
+      }
+    );
+    return off;
+  }, [onMessage, send, token, sharedReportMutation, reviewMode]);
+
+  // SAVE_IMAGE → SAVE_IMAGE_RESULT (Batch-D item 1). The host downloads an image
+  // the block already displays, in its UNSANDBOXED top frame (the block's sandbox
+  // has no allow-downloads). TWO variants, each with its own security gate:
+  //   • url  — the block's OWN output. MUST pass the civitai image/blob origin
+  //            allowlist (isAllowedSaveImageUrl) — never a host-side fetch of an
+  //            attacker origin (an opaque-origin block's url/data is untrusted).
+  //   • id   — a cross-user grid image. Resolved through the SAME per-viewer
+  //            gated read (blocks.getImagesByIds) that GET_IMAGES_BY_IDS uses, so
+  //            a withheld/above-ceiling image (status !== 'visible', or omitted)
+  //            can NEVER be saved.
+  // A NON-download UI affordance, so NO reviewMode NACK (it saves what the viewer
+  // already sees). REQUEST-style ⇒ every path replies (ok:false on any refusal)
+  // so the block never hangs.
+  useEffect(() => {
+    const off = onMessage<unknown>('SAVE_IMAGE', async (raw) => {
+      const req = resolveSaveImageRequest(raw);
+      if (!req) return; // missing/invalid requestId — can't correlate, drop
+      const { requestId } = req;
+      if (req.kind === 'invalid') {
+        send('SAVE_IMAGE_RESULT', { requestId, ok: false, error: 'invalid save-image request' });
+        return;
+      }
+      try {
+        if (req.kind === 'url') {
+          if (!isAllowedSaveImageUrl(req.url, env.NEXT_PUBLIC_IMAGE_LOCATION)) {
+            send('SAVE_IMAGE_RESULT', { requestId, ok: false, error: 'image url is not allowed' });
+            return;
+          }
+          await downloadUrlAsBlob(req.url, sanitizeDownloadFilename(req.filename, req.url));
+          send('SAVE_IMAGE_RESULT', { requestId, ok: true });
+          return;
+        }
+        // id variant — route through the gated per-viewer read.
+        if (!token) {
+          send('SAVE_IMAGE_RESULT', { requestId, ok: false, error: 'no block token' });
+          return;
+        }
+        const result = await getImagesByIdsMutation.mutateAsync({
+          blockToken: token,
+          imageIds: [req.imageId],
+        });
+        const image = result.images.find((i) => i.imageId === req.imageId);
+        if (!image || image.status !== 'visible') {
+          // Withheld (hidden / above-ceiling / unscanned / flagged) or unresolvable
+          // → never saveable. Do NOT leak which reason.
+          send('SAVE_IMAGE_RESULT', { requestId, ok: false, error: 'image is not available' });
+          return;
+        }
+        await downloadUrlAsBlob(image.url, sanitizeDownloadFilename(req.filename, image.url));
+        send('SAVE_IMAGE_RESULT', { requestId, ok: true });
+      } catch (err) {
+        send('SAVE_IMAGE_RESULT', { requestId, ok: false, error: storageErrorMessage(err) });
+      }
+    });
+    return off;
+  }, [onMessage, send, token, getImagesByIdsMutation]);
 
   // ── OPEN_RESOURCE_PICKER → RESOURCE_PICKER_RESULT (Design 1 host-chrome) ────
   //

--- a/src/components/AppBlocks/PageBlockHostBenchmarkGrid.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostBenchmarkGrid.browser.test.tsx
@@ -49,6 +49,7 @@ vi.mock('~/utils/trpc', () => ({
         vote: { useMutation: () => ({ mutateAsync: vi.fn() }) },
         unvote: { useMutation: () => ({ mutateAsync: vi.fn() }) },
         withdraw: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        report: { useMutation: () => ({ mutateAsync: vi.fn() }) },
       },
       storage: {
         set: { useMutation: () => ({ mutateAsync: vi.fn() }) },
@@ -61,6 +62,7 @@ vi.mock('~/utils/trpc', () => ({
           list: { fetch: vi.fn() },
           getCount: { fetch: vi.fn() },
           getCounts: { fetch: vi.fn() },
+          get: { fetch: vi.fn() },
         },
         storage: { get: { fetch: vi.fn() }, list: { fetch: vi.fn() }, getQuota: { fetch: vi.fn() } },
       },

--- a/src/components/AppBlocks/PageBlockHostCheckpointPicker.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostCheckpointPicker.browser.test.tsx
@@ -73,6 +73,7 @@ vi.mock('~/utils/trpc', () => ({
         vote: { useMutation: () => ({ mutateAsync: vi.fn() }) },
         unvote: { useMutation: () => ({ mutateAsync: vi.fn() }) },
         withdraw: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        report: { useMutation: () => ({ mutateAsync: vi.fn() }) },
       },
       storage: {
         set: { useMutation: () => ({ mutateAsync: vi.fn() }) },
@@ -85,6 +86,7 @@ vi.mock('~/utils/trpc', () => ({
           list: { fetch: vi.fn() },
           getCount: { fetch: vi.fn() },
           getCounts: { fetch: vi.fn() },
+          get: { fetch: vi.fn() },
         },
         storage: {
           get: { fetch: vi.fn() },

--- a/src/components/AppBlocks/PageBlockHostImageUpload.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostImageUpload.browser.test.tsx
@@ -61,6 +61,7 @@ vi.mock('~/utils/trpc', () => ({
         vote: { useMutation: () => ({ mutateAsync: vi.fn() }) },
         unvote: { useMutation: () => ({ mutateAsync: vi.fn() }) },
         withdraw: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        report: { useMutation: () => ({ mutateAsync: vi.fn() }) },
       },
       storage: {
         set: { useMutation: () => ({ mutateAsync: vi.fn() }) },
@@ -73,6 +74,7 @@ vi.mock('~/utils/trpc', () => ({
           list: { fetch: vi.fn() },
           getCount: { fetch: vi.fn() },
           getCounts: { fetch: vi.fn() },
+          get: { fetch: vi.fn() },
         },
         storage: {
           get: { fetch: vi.fn() },

--- a/src/components/AppBlocks/PageBlockHostImageUploadAsync.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostImageUploadAsync.browser.test.tsx
@@ -59,6 +59,7 @@ vi.mock('~/utils/trpc', () => ({
         vote: { useMutation: () => ({ mutateAsync: vi.fn() }) },
         unvote: { useMutation: () => ({ mutateAsync: vi.fn() }) },
         withdraw: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        report: { useMutation: () => ({ mutateAsync: vi.fn() }) },
       },
       storage: {
         set: { useMutation: () => ({ mutateAsync: vi.fn() }) },
@@ -71,6 +72,7 @@ vi.mock('~/utils/trpc', () => ({
           list: { fetch: vi.fn() },
           getCount: { fetch: vi.fn() },
           getCounts: { fetch: vi.fn() },
+          get: { fetch: vi.fn() },
         },
         storage: {
           get: { fetch: vi.fn() },

--- a/src/components/AppBlocks/PageBlockHostResourcePicker.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostResourcePicker.browser.test.tsx
@@ -74,6 +74,7 @@ vi.mock('~/utils/trpc', () => ({
         vote: { useMutation: () => ({ mutateAsync: vi.fn() }) },
         unvote: { useMutation: () => ({ mutateAsync: vi.fn() }) },
         withdraw: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        report: { useMutation: () => ({ mutateAsync: vi.fn() }) },
       },
       storage: {
         set: { useMutation: () => ({ mutateAsync: vi.fn() }) },
@@ -86,6 +87,7 @@ vi.mock('~/utils/trpc', () => ({
           list: { fetch: vi.fn() },
           getCount: { fetch: vi.fn() },
           getCounts: { fetch: vi.fn() },
+          get: { fetch: vi.fn() },
         },
         storage: {
           get: { fetch: vi.fn() },

--- a/src/components/AppBlocks/PageBlockHostReviewMode.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostReviewMode.browser.test.tsx
@@ -65,6 +65,7 @@ vi.mock('~/utils/trpc', () => ({
         vote: { useMutation: () => ({ mutateAsync: vi.fn() }) },
         unvote: { useMutation: () => ({ mutateAsync: vi.fn() }) },
         withdraw: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        report: { useMutation: () => ({ mutateAsync: vi.fn() }) },
       },
       storage: {
         set: { useMutation: () => ({ mutateAsync: mocks.storageSet }) },
@@ -77,6 +78,7 @@ vi.mock('~/utils/trpc', () => ({
           list: { fetch: vi.fn() },
           getCount: { fetch: vi.fn() },
           getCounts: { fetch: vi.fn() },
+          get: { fetch: vi.fn() },
         },
         storage: {
           get: { fetch: vi.fn() },

--- a/src/components/AppBlocks/PageBlockHostSetUserCheckpoint.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostSetUserCheckpoint.browser.test.tsx
@@ -71,6 +71,7 @@ vi.mock('~/utils/trpc', () => ({
         vote: { useMutation: () => ({ mutateAsync: vi.fn() }) },
         unvote: { useMutation: () => ({ mutateAsync: vi.fn() }) },
         withdraw: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        report: { useMutation: () => ({ mutateAsync: vi.fn() }) },
       },
       storage: {
         set: { useMutation: () => ({ mutateAsync: vi.fn() }) },
@@ -83,6 +84,7 @@ vi.mock('~/utils/trpc', () => ({
           list: { fetch: vi.fn() },
           getCount: { fetch: vi.fn() },
           getCounts: { fetch: vi.fn() },
+          get: { fetch: vi.fn() },
         },
         storage: {
           get: { fetch: vi.fn() },

--- a/src/components/AppBlocks/PageBlockHostSharedStorage.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostSharedStorage.browser.test.tsx
@@ -38,6 +38,7 @@ import { renderWithProviders } from '../../../test/component-setup';
 const mocks = vi.hoisted(() => ({
   // shared reads
   list: vi.fn(),
+  get: vi.fn(),
   getCount: vi.fn(),
   getCounts: vi.fn(),
   // shared writes
@@ -46,6 +47,12 @@ const mocks = vi.hoisted(() => ({
   vote: vi.fn(),
   unvote: vi.fn(),
   withdraw: vi.fn(),
+  report: vi.fn(),
+  // gated cross-user image read (backs the SAVE_IMAGE id variant)
+  getImagesByIds: vi.fn(),
+  // the top-frame blob download (stubbed so no real network fetch in the test);
+  // the origin allowlist + request parse stay REAL (see the partial mock below).
+  saveDownload: vi.fn(),
   // per-user storage reads/writes (also wired at render; inert here)
   storageGet: vi.fn(),
   storageSet: vi.fn(),
@@ -57,6 +64,14 @@ const mocks = vi.hoisted(() => ({
 // AppBlockChrome (in the host frame) calls useCurrentUser() for the platform-nav
 // moderator gate; these suites render the real host without a CivitaiSessionProvider.
 vi.mock('~/hooks/useCurrentUser', () => ({ useCurrentUser: () => null }));
+
+// Partial mock: keep the REAL origin allowlist + filename sanitizer + request
+// parser (the security-critical pure logic), stub ONLY the top-frame blob
+// download so the SAVE_IMAGE tests never hit the network.
+vi.mock('~/components/AppBlocks/saveImageDownload', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('./saveImageDownload')>();
+  return { ...actual, downloadUrlAsBlob: mocks.saveDownload };
+});
 
 vi.mock('~/utils/trpc', () => ({
   // FeatureFlagsProvider (in PageBlockHost's real render graph) statically imports
@@ -81,7 +96,7 @@ vi.mock('~/utils/trpc', () => ({
       queryAppWorkflows: { useMutation: () => ({ mutateAsync: vi.fn() }) },
       cancelAppWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
       publishGenerationOutputs: { useMutation: () => ({ mutateAsync: vi.fn() }) },
-      getImagesByIds: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      getImagesByIds: { useMutation: () => ({ mutateAsync: mocks.getImagesByIds }) },
     },
     apps: {
       storage: {
@@ -94,6 +109,7 @@ vi.mock('~/utils/trpc', () => ({
         vote: { useMutation: () => ({ mutateAsync: mocks.vote }) },
         unvote: { useMutation: () => ({ mutateAsync: mocks.unvote }) },
         withdraw: { useMutation: () => ({ mutateAsync: mocks.withdraw }) },
+        report: { useMutation: () => ({ mutateAsync: mocks.report }) },
       },
     },
     useUtils: () => ({
@@ -105,6 +121,7 @@ vi.mock('~/utils/trpc', () => ({
         },
         shared: {
           list: { fetch: mocks.list },
+          get: { fetch: mocks.get },
           getCount: { fetch: mocks.getCount },
           getCounts: { fetch: mocks.getCounts },
         },
@@ -187,6 +204,7 @@ async function driveToReady() {
 describe('PageBlockHost SHARED storage bridge (Phase 2b cross-user datastore)', () => {
   beforeEach(() => {
     mocks.list.mockReset();
+    mocks.get.mockReset();
     mocks.getCount.mockReset();
     mocks.getCounts.mockReset();
     mocks.append.mockReset();
@@ -194,6 +212,9 @@ describe('PageBlockHost SHARED storage bridge (Phase 2b cross-user datastore)', 
     mocks.vote.mockReset();
     mocks.unvote.mockReset();
     mocks.withdraw.mockReset();
+    mocks.report.mockReset();
+    mocks.getImagesByIds.mockReset();
+    mocks.saveDownload.mockReset();
     useDialogStore.getState().closeAll();
   });
 
@@ -566,6 +587,296 @@ describe('PageBlockHost SHARED storage bridge (Phase 2b cross-user datastore)', 
       if (!r) throw new Error('no reply yet');
       expect(r.payload).toEqual({ requestId: 'rq_wd_err', error: 'storage unavailable' });
     });
+    replies.stop();
+  });
+
+  // ── item 3: viewerVoted passes through SHARED_LIST ───────────────────────────
+  test('SHARED_LIST passes the per-viewer viewerVoted flag through to the block', async () => {
+    mocks.list.mockResolvedValue({
+      items: [
+        {
+          key: '01ABC',
+          authorUserId: 7,
+          value: { title: 'voted' },
+          count: 3,
+          createdAt: new Date('2026-06-17T00:00:00.000Z'),
+          updatedAt: new Date('2026-06-17T00:00:00.000Z'),
+          viewerVoted: true,
+        },
+      ],
+    });
+    renderWithProviders(<PageBlockHost {...baseProps} />);
+    await driveToReady();
+    const replies = listenForReply();
+
+    postFromBlock('SHARED_LIST', { requestId: 'rq_vv' });
+
+    await vi.waitFor(() => {
+      const r = replies.last('SHARED_LIST_RESULT');
+      if (!r) throw new Error('no reply yet');
+      const payload = r.payload as { items: Array<{ viewerVoted?: boolean }> };
+      expect(payload.items[0].viewerVoted).toBe(true);
+    });
+    replies.stop();
+  });
+
+  // ── item 6: SHARED_GET (single-row fetch-by-key) ─────────────────────────────
+  test('SHARED_GET forwards key + host token and posts SHARED_GET_RESULT (item incl. viewerVoted)', async () => {
+    mocks.get.mockResolvedValue({
+      item: {
+        key: '01ABC',
+        authorUserId: 7,
+        value: { title: 'Add dark mode' },
+        count: 5,
+        createdAt: new Date('2026-06-17T00:00:00.000Z'),
+        updatedAt: new Date('2026-06-18T00:00:00.000Z'),
+        viewerVoted: true,
+      },
+    });
+    renderWithProviders(<PageBlockHost {...baseProps} />);
+    await driveToReady();
+    const replies = listenForReply();
+
+    postFromBlock('SHARED_GET', { requestId: 'rq_get', key: '01ABC', blockToken: 'SPOOFED' });
+
+    await vi.waitFor(() => {
+      expect(mocks.get).toHaveBeenCalledWith({ blockToken: 'tok_abc', key: '01ABC' });
+    });
+    await vi.waitFor(() => {
+      const r = replies.last('SHARED_GET_RESULT');
+      if (!r) throw new Error('no reply yet');
+      expect(r.payload).toEqual({
+        requestId: 'rq_get',
+        item: {
+          key: '01ABC',
+          authorUserId: 7,
+          value: { title: 'Add dark mode' },
+          count: 5,
+          createdAt: '2026-06-17T00:00:00.000Z',
+          updatedAt: '2026-06-18T00:00:00.000Z',
+          viewerVoted: true,
+        },
+      });
+    });
+    replies.stop();
+  });
+
+  test('SHARED_GET returns item:null for a missing/hidden key', async () => {
+    mocks.get.mockResolvedValue({ item: null });
+    renderWithProviders(<PageBlockHost {...baseProps} />);
+    await driveToReady();
+    const replies = listenForReply();
+
+    postFromBlock('SHARED_GET', { requestId: 'rq_get_null', key: 'gone' });
+
+    await vi.waitFor(() => {
+      const r = replies.last('SHARED_GET_RESULT');
+      if (!r) throw new Error('no reply yet');
+      expect(r.payload).toEqual({ requestId: 'rq_get_null', item: null });
+    });
+    replies.stop();
+  });
+
+  test('SHARED_GET error path posts { requestId, item:null, error } (no hang)', async () => {
+    mocks.get.mockRejectedValue(new Error('shared storage is not enabled'));
+    renderWithProviders(<PageBlockHost {...baseProps} />);
+    await driveToReady();
+    const replies = listenForReply();
+
+    postFromBlock('SHARED_GET', { requestId: 'rq_get_err', key: 'k' });
+
+    await vi.waitFor(() => {
+      const r = replies.last('SHARED_GET_RESULT');
+      if (!r) throw new Error('no reply yet');
+      expect(r.payload).toEqual({
+        requestId: 'rq_get_err',
+        item: null,
+        error: 'shared storage is not enabled',
+      });
+    });
+    replies.stop();
+  });
+
+  // ── item 5: SHARED_REPORT ────────────────────────────────────────────────────
+  test('SHARED_REPORT forwards key + reason + host token and posts SHARED_REPORT_RESULT {ok:true}', async () => {
+    mocks.report.mockResolvedValue({ ok: true });
+    renderWithProviders(<PageBlockHost {...baseProps} />);
+    await driveToReady();
+    const replies = listenForReply();
+
+    postFromBlock('SHARED_REPORT', {
+      requestId: 'rq_rep',
+      key: '01ABC',
+      reason: 'harassment',
+      blockToken: 'SPOOFED',
+    });
+
+    await vi.waitFor(() => {
+      expect(mocks.report).toHaveBeenCalledWith({
+        blockToken: 'tok_abc',
+        key: '01ABC',
+        reason: 'harassment',
+      });
+    });
+    await vi.waitFor(() => {
+      const r = replies.last('SHARED_REPORT_RESULT');
+      if (!r) throw new Error('no reply yet');
+      expect(r.payload).toEqual({ requestId: 'rq_rep', ok: true });
+    });
+    replies.stop();
+  });
+
+  test('SHARED_REPORT error path posts { requestId, ok:false, error } (no hang)', async () => {
+    mocks.report.mockRejectedValue(new Error('request not found'));
+    renderWithProviders(<PageBlockHost {...baseProps} />);
+    await driveToReady();
+    const replies = listenForReply();
+
+    postFromBlock('SHARED_REPORT', { requestId: 'rq_rep_err', key: 'missing' });
+
+    await vi.waitFor(() => {
+      const r = replies.last('SHARED_REPORT_RESULT');
+      if (!r) throw new Error('no reply yet');
+      // ok:false REQUIRED (the SDK validator drops a reply without a boolean ok).
+      expect(r.payload).toEqual({ requestId: 'rq_rep_err', ok: false, error: 'request not found' });
+    });
+    replies.stop();
+  });
+
+  // ── item 1: SAVE_IMAGE (host download bridge) ────────────────────────────────
+  test('SAVE_IMAGE url variant: an ALLOWLISTED civitai origin downloads + replies ok', async () => {
+    mocks.saveDownload.mockResolvedValue(undefined);
+    renderWithProviders(<PageBlockHost {...baseProps} />);
+    await driveToReady();
+    const replies = listenForReply();
+
+    postFromBlock('SAVE_IMAGE', {
+      requestId: 'rq_save_url',
+      url: 'https://image.civitai.com/xG/77/original.jpeg',
+      filename: 'render.png',
+    });
+
+    await vi.waitFor(() => {
+      expect(mocks.saveDownload).toHaveBeenCalledWith(
+        'https://image.civitai.com/xG/77/original.jpeg',
+        'render.png'
+      );
+    });
+    await vi.waitFor(() => {
+      const r = replies.last('SAVE_IMAGE_RESULT');
+      if (!r) throw new Error('no reply yet');
+      expect(r.payload).toEqual({ requestId: 'rq_save_url', ok: true });
+    });
+    replies.stop();
+  });
+
+  test('SAVE_IMAGE url variant: an ARBITRARY origin is REFUSED (ok:false, NO download)', async () => {
+    renderWithProviders(<PageBlockHost {...baseProps} />);
+    await driveToReady();
+    const replies = listenForReply();
+
+    postFromBlock('SAVE_IMAGE', { requestId: 'rq_save_evil', url: 'https://evil.example/x.png' });
+
+    await vi.waitFor(() => {
+      const r = replies.last('SAVE_IMAGE_RESULT');
+      if (!r) throw new Error('no reply yet');
+      expect(r.payload).toEqual({ requestId: 'rq_save_evil', ok: false, error: 'image url is not allowed' });
+    });
+    // The disallowed URL was NEVER fetched host-side.
+    expect(mocks.saveDownload).not.toHaveBeenCalled();
+    replies.stop();
+  });
+
+  test('SAVE_IMAGE id variant: a VISIBLE image routes through the gated read + downloads', async () => {
+    mocks.getImagesByIds.mockResolvedValue({
+      images: [
+        {
+          imageId: 55,
+          status: 'visible',
+          nsfwLevel: 1,
+          contentRating: 'g',
+          url: 'https://image.civitai.com/edge/55.jpeg',
+          width: 512,
+          height: 512,
+        },
+      ],
+    });
+    mocks.saveDownload.mockResolvedValue(undefined);
+    renderWithProviders(<PageBlockHost {...baseProps} />);
+    await driveToReady();
+    const replies = listenForReply();
+
+    postFromBlock('SAVE_IMAGE', { requestId: 'rq_save_id', imageId: 55 });
+
+    await vi.waitFor(() => {
+      // Routed through the SAME gated per-viewer read (host token bound).
+      expect(mocks.getImagesByIds).toHaveBeenCalledWith({ blockToken: 'tok_abc', imageIds: [55] });
+    });
+    await vi.waitFor(() => {
+      expect(mocks.saveDownload).toHaveBeenCalledWith('https://image.civitai.com/edge/55.jpeg', '55.jpeg');
+    });
+    await vi.waitFor(() => {
+      const r = replies.last('SAVE_IMAGE_RESULT');
+      if (!r) throw new Error('no reply yet');
+      expect(r.payload).toEqual({ requestId: 'rq_save_id', ok: true });
+    });
+    replies.stop();
+  });
+
+  test('SAVE_IMAGE id variant: a WITHHELD (hidden) image is NEVER downloaded (ok:false)', async () => {
+    mocks.getImagesByIds.mockResolvedValue({ images: [{ imageId: 55, status: 'hidden' }] });
+    renderWithProviders(<PageBlockHost {...baseProps} />);
+    await driveToReady();
+    const replies = listenForReply();
+
+    postFromBlock('SAVE_IMAGE', { requestId: 'rq_save_hidden', imageId: 55 });
+
+    await vi.waitFor(() => {
+      const r = replies.last('SAVE_IMAGE_RESULT');
+      if (!r) throw new Error('no reply yet');
+      expect(r.payload).toEqual({ requestId: 'rq_save_hidden', ok: false, error: 'image is not available' });
+    });
+    // The gated read ran, but a hidden image is never handed to the downloader.
+    expect(mocks.getImagesByIds).toHaveBeenCalled();
+    expect(mocks.saveDownload).not.toHaveBeenCalled();
+    replies.stop();
+  });
+
+  test('SAVE_IMAGE id variant: an UNRESOLVABLE id (omitted from the gated read) is refused', async () => {
+    mocks.getImagesByIds.mockResolvedValue({ images: [] });
+    renderWithProviders(<PageBlockHost {...baseProps} />);
+    await driveToReady();
+    const replies = listenForReply();
+
+    postFromBlock('SAVE_IMAGE', { requestId: 'rq_save_gone', imageId: 999 });
+
+    await vi.waitFor(() => {
+      const r = replies.last('SAVE_IMAGE_RESULT');
+      if (!r) throw new Error('no reply yet');
+      expect(r.payload).toEqual({ requestId: 'rq_save_gone', ok: false, error: 'image is not available' });
+    });
+    expect(mocks.saveDownload).not.toHaveBeenCalled();
+    replies.stop();
+  });
+
+  test('SAVE_IMAGE with BOTH url and imageId is an invalid request (ok:false, no download)', async () => {
+    renderWithProviders(<PageBlockHost {...baseProps} />);
+    await driveToReady();
+    const replies = listenForReply();
+
+    postFromBlock('SAVE_IMAGE', {
+      requestId: 'rq_save_both',
+      url: 'https://image.civitai.com/x.jpeg',
+      imageId: 5,
+    });
+
+    await vi.waitFor(() => {
+      const r = replies.last('SAVE_IMAGE_RESULT');
+      if (!r) throw new Error('no reply yet');
+      expect(r.payload).toEqual({ requestId: 'rq_save_both', ok: false, error: 'invalid save-image request' });
+    });
+    expect(mocks.saveDownload).not.toHaveBeenCalled();
+    expect(mocks.getImagesByIds).not.toHaveBeenCalled();
     replies.stop();
   });
 

--- a/src/components/AppBlocks/PageBlockHostSharedStorage.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostSharedStorage.browser.test.tsx
@@ -3,6 +3,7 @@ import { page } from 'vitest/browser';
 import { useDialogStore } from '~/components/Dialog/dialogStore';
 // `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
 import { renderWithProviders } from '../../../test/component-setup';
+import { SAVE_IMAGE_MAX_CONCURRENT } from '~/components/AppBlocks/saveImageDownload';
 
 /**
  * App Blocks SHARED (cross-user / app-global) storage bridge — host side (Phase 2b).
@@ -877,6 +878,37 @@ describe('PageBlockHost SHARED storage bridge (Phase 2b cross-user datastore)', 
     });
     expect(mocks.saveDownload).not.toHaveBeenCalled();
     expect(mocks.getImagesByIds).not.toHaveBeenCalled();
+    replies.stop();
+  });
+
+  test(`F2: caps concurrent SAVE_IMAGE downloads — the (N+1)th gets busy (N=${SAVE_IMAGE_MAX_CONCURRENT})`, async () => {
+    // Make the host-side download hang so the first N requests each hold an
+    // in-flight slot; the (N+1)th must be refused `busy` BEFORE it fetches (so a
+    // hostile block can't download-bomb the tab).
+    mocks.saveDownload.mockReturnValue(new Promise(() => {}));
+    renderWithProviders(<PageBlockHost {...baseProps} />);
+    await driveToReady();
+    const replies = listenForReply();
+
+    for (let i = 0; i < SAVE_IMAGE_MAX_CONCURRENT; i++) {
+      postFromBlock('SAVE_IMAGE', {
+        requestId: `rq_c${i}`,
+        url: 'https://image.civitai.com/xG/77/original.jpeg',
+      });
+    }
+    postFromBlock('SAVE_IMAGE', {
+      requestId: 'rq_overflow',
+      url: 'https://image.civitai.com/xG/77/original.jpeg',
+    });
+
+    await vi.waitFor(() => {
+      const r = replies.last('SAVE_IMAGE_RESULT');
+      if (!r) throw new Error('no reply yet');
+      expect(r.payload).toEqual({ requestId: 'rq_overflow', ok: false, error: 'busy' });
+    });
+    // Only the N that acquired a slot reached the downloader; the overflow
+    // short-circuited to busy BEFORE fetching a byte.
+    expect(mocks.saveDownload).toHaveBeenCalledTimes(SAVE_IMAGE_MAX_CONCURRENT);
     replies.stop();
   });
 

--- a/src/components/AppBlocks/PageBlockHostSignIn.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostSignIn.browser.test.tsx
@@ -60,6 +60,7 @@ vi.mock('~/utils/trpc', () => ({
         vote: { useMutation: () => ({ mutateAsync: vi.fn() }) },
         unvote: { useMutation: () => ({ mutateAsync: vi.fn() }) },
         withdraw: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        report: { useMutation: () => ({ mutateAsync: vi.fn() }) },
       },
       storage: {
         set: { useMutation: () => ({ mutateAsync: vi.fn() }) },
@@ -72,6 +73,7 @@ vi.mock('~/utils/trpc', () => ({
           list: { fetch: vi.fn() },
           getCount: { fetch: vi.fn() },
           getCounts: { fetch: vi.fn() },
+          get: { fetch: vi.fn() },
         },
         storage: {
           get: { fetch: vi.fn() },

--- a/src/components/AppBlocks/PageBlockHostStorage.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostStorage.browser.test.tsx
@@ -79,6 +79,7 @@ vi.mock('~/utils/trpc', () => ({
         vote: { useMutation: () => ({ mutateAsync: vi.fn() }) },
         unvote: { useMutation: () => ({ mutateAsync: vi.fn() }) },
         withdraw: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        report: { useMutation: () => ({ mutateAsync: vi.fn() }) },
       },
       storage: {
         set: { useMutation: () => ({ mutateAsync: mocks.set }) },
@@ -91,6 +92,7 @@ vi.mock('~/utils/trpc', () => ({
           list: { fetch: vi.fn() },
           getCount: { fetch: vi.fn() },
           getCounts: { fetch: vi.fn() },
+          get: { fetch: vi.fn() },
         },
         storage: {
           get: { fetch: mocks.get },

--- a/src/components/AppBlocks/PageBlockHostWildcardPack.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostWildcardPack.browser.test.tsx
@@ -62,6 +62,7 @@ vi.mock('~/utils/trpc', () => ({
         vote: { useMutation: () => ({ mutateAsync: vi.fn() }) },
         unvote: { useMutation: () => ({ mutateAsync: vi.fn() }) },
         withdraw: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        report: { useMutation: () => ({ mutateAsync: vi.fn() }) },
       },
       storage: {
         set: { useMutation: () => ({ mutateAsync: vi.fn() }) },
@@ -74,6 +75,7 @@ vi.mock('~/utils/trpc', () => ({
           list: { fetch: vi.fn() },
           getCount: { fetch: vi.fn() },
           getCounts: { fetch: vi.fn() },
+          get: { fetch: vi.fn() },
         },
         storage: { get: { fetch: vi.fn() }, list: { fetch: vi.fn() }, getQuota: { fetch: vi.fn() } },
       },

--- a/src/components/AppBlocks/PageBlockHostWorkflow.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostWorkflow.browser.test.tsx
@@ -83,6 +83,7 @@ vi.mock('~/utils/trpc', () => ({
         vote: { useMutation: () => ({ mutateAsync: vi.fn() }) },
         unvote: { useMutation: () => ({ mutateAsync: vi.fn() }) },
         withdraw: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        report: { useMutation: () => ({ mutateAsync: vi.fn() }) },
       },
       storage: {
         set: { useMutation: () => ({ mutateAsync: vi.fn() }) },
@@ -95,6 +96,7 @@ vi.mock('~/utils/trpc', () => ({
           list: { fetch: vi.fn() },
           getCount: { fetch: vi.fn() },
           getCounts: { fetch: vi.fn() },
+          get: { fetch: vi.fn() },
         },
         storage: {
           get: { fetch: vi.fn() },

--- a/src/components/AppBlocks/hostHandlerParity.ts
+++ b/src/components/AppBlocks/hostHandlerParity.ts
@@ -459,6 +459,47 @@ export const INVENTORY = {
     PageBlockHost: 'required',
     InlineHost: INLINE_STUB,
   },
+  // Single-row fetch-by-key (Batch-D item 6) — the deep-link companion to
+  // SHARED_LIST's paged read. Same REQUEST-style hang class + same both-host
+  // placement as its SHARED_* siblings (the shared datastore is a per-APP surface
+  // a model-slot block can also read). Ahead of the published SDK dist union
+  // (forward-looking coverage, like the SHARED_* siblings were) — the one-
+  // directional compile-time gate allows the extra key.
+  SHARED_GET: {
+    request: true,
+    reply: 'SHARED_GET_RESULT',
+    IframeHost: 'required',
+    PageBlockHost: 'required',
+    InlineHost: INLINE_STUB,
+  },
+  // User report of a posted shared row (Batch-D item 5) — the server procedure
+  // `apps.shared.report` already exists; this is the postMessage seam. Same both-
+  // host placement as SHARED_WITHDRAW (its reply is the SHARED_WITHDRAW-style
+  // `{ ok, error? }`: the error path MUST carry `ok: false` or the SDK drops it →
+  // hang). Ahead of the published SDK dist union — forward-looking coverage.
+  SHARED_REPORT: {
+    request: true,
+    reply: 'SHARED_REPORT_RESULT',
+    IframeHost: 'required',
+    PageBlockHost: 'required',
+    InlineHost: INLINE_STUB,
+  },
+  // Host download bridge (Batch-D item 1) — the host fetches an image in its
+  // UNSANDBOXED top frame + triggers the browser download (a sandboxed block has
+  // no `allow-downloads`). Two variants: an origin-allowlisted OWN-output `url`,
+  // or a cross-user `imageId` routed through the gated per-viewer read. PAGE-ONLY
+  // affordance today (the paid-output apps — gen-matrix / custom-generators /
+  // model-benchmarking — are all page apps), so N/A for the model host, mirroring
+  // the GET_IMAGES_BY_IDS / PUBLISH_GENERATION_OUTPUTS page-only exemption.
+  // Ahead of the published SDK dist union — forward-looking coverage.
+  SAVE_IMAGE: {
+    request: true,
+    reply: 'SAVE_IMAGE_RESULT',
+    IframeHost:
+      'download bridge is a page-only affordance today; the paid-output apps are page apps, the model slot has no such surface',
+    PageBlockHost: 'required',
+    InlineHost: INLINE_STUB,
+  },
   // ── Wildcard-pack import (W13, page-host bridge) ───────────────────────────
   // A page block asks the HOST to resolve + fetch + unzip + parse a wildcard
   // pack's list files, as the logged-in user (the host holds the real session).

--- a/src/components/AppBlocks/saveImageDownload.dom.test.ts
+++ b/src/components/AppBlocks/saveImageDownload.dom.test.ts
@@ -1,0 +1,197 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { downloadUrlAsBlob, SAVE_IMAGE_MAX_BYTES } from './saveImageDownload';
+
+/**
+ * F4 — executed coverage for `downloadUrlAsBlob` (the browser-side XHR→blob→
+ * `<a download>` core the SAVE_IMAGE host bridge calls). The pure allowlist /
+ * filename / parse helpers are covered in saveImageDownload.test.ts; the browser
+ * `.browser.test.tsx` suite MOCKS this function, so this path had ZERO executed
+ * coverage. Here we drive a FAKE XMLHttpRequest under happy-dom to exercise the
+ * real function: the size cap actually aborts an over-size transfer, a normal
+ * transfer resolves + triggers the `<a download>` DOM path (with the F2 safe
+ * extension applied), and the abort/error/non-200 paths reject cleanly.
+ */
+
+// A controllable XMLHttpRequest double: the test constructs the download, grabs
+// the instance, and drives its events. `abort()` mimics the browser (the 'abort'
+// event is dispatched as a queued task, AFTER the caller's synchronous reject).
+class FakeXHR {
+  static instances: FakeXHR[] = [];
+  static last(): FakeXHR {
+    const x = FakeXHR.instances[FakeXHR.instances.length - 1];
+    if (!x) throw new Error('no FakeXHR constructed');
+    return x;
+  }
+
+  responseType = '';
+  response: unknown = null;
+  readyState = 0;
+  status = 0;
+  aborted = false;
+  opened: { method: string; url: string } | null = null;
+  sent = false;
+  private listeners: Record<string, Array<(ev?: unknown) => void>> = {};
+
+  constructor() {
+    FakeXHR.instances.push(this);
+  }
+  addEventListener(type: string, cb: (ev?: unknown) => void) {
+    (this.listeners[type] ||= []).push(cb);
+  }
+  emit(type: string, ev?: unknown) {
+    (this.listeners[type] || []).forEach((cb) => cb(ev));
+  }
+  open(method: string, url: string) {
+    this.opened = { method, url };
+  }
+  send() {
+    this.sent = true;
+  }
+  abort() {
+    this.aborted = true;
+    // Real XHR.abort() queues the 'abort' dispatch — it must NOT pre-empt the
+    // synchronous reject that runs on the next line of the progress handler.
+    Promise.resolve().then(() => this.emit('abort'));
+  }
+}
+
+const realXHR = globalThis.XMLHttpRequest;
+let createObjectURL: ReturnType<typeof vi.fn>;
+let revokeObjectURL: ReturnType<typeof vi.fn>;
+let clickSpy: ReturnType<typeof vi.spyOn>;
+let clickedAnchor: HTMLAnchorElement | null;
+
+beforeEach(() => {
+  FakeXHR.instances = [];
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (globalThis as any).XMLHttpRequest = FakeXHR;
+  createObjectURL = vi.fn(() => 'blob:mock-url');
+  revokeObjectURL = vi.fn();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (URL as any).createObjectURL = createObjectURL;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (URL as any).revokeObjectURL = revokeObjectURL;
+  clickedAnchor = null;
+  clickSpy = vi
+    .spyOn(HTMLAnchorElement.prototype, 'click')
+    .mockImplementation(function (this: HTMLAnchorElement) {
+      clickedAnchor = this;
+    });
+});
+
+afterEach(() => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (globalThis as any).XMLHttpRequest = realXHR;
+  clickSpy.mockRestore();
+  vi.clearAllMocks();
+});
+
+describe('downloadUrlAsBlob (F4 executed coverage)', () => {
+  it('a normal transfer resolves and triggers the <a download> DOM path', async () => {
+    const p = downloadUrlAsBlob('https://image.civitai.com/x/original', 'evil.html');
+    const xhr = FakeXHR.last();
+    // it opened a GET and set responseType=blob (the real transfer setup)
+    expect(xhr.opened).toEqual({ method: 'GET', url: 'https://image.civitai.com/x/original' });
+    expect(xhr.responseType).toBe('blob');
+    expect(xhr.sent).toBe(true);
+
+    const blob = new Blob(['abc'], { type: 'image/png' });
+    xhr.readyState = 4;
+    xhr.status = 200;
+    xhr.response = blob;
+    xhr.emit('loadend');
+
+    await expect(p).resolves.toBeUndefined();
+    // object URL created for the blob, anchor clicked, URL revoked (no leak)
+    expect(createObjectURL).toHaveBeenCalledWith(blob);
+    expect(clickSpy).toHaveBeenCalledTimes(1);
+    expect(revokeObjectURL).toHaveBeenCalledTimes(1);
+    // F2: the hostile .html name was coerced to the content type's safe extension
+    expect(clickedAnchor).not.toBeNull();
+    expect(clickedAnchor?.download).toBe('evil.png');
+  });
+
+  it('a benign progress event does NOT abort a normal transfer', async () => {
+    const p = downloadUrlAsBlob('https://image.civitai.com/x', 'a.jpg');
+    const xhr = FakeXHR.last();
+    xhr.emit('progress', { loaded: 10, total: 20 }); // well under the cap
+    expect(xhr.aborted).toBe(false);
+    xhr.readyState = 4;
+    xhr.status = 200;
+    xhr.response = new Blob(['x'], { type: 'image/jpeg' });
+    xhr.emit('loadend');
+    await expect(p).resolves.toBeUndefined();
+  });
+
+  it('the size cap ABORTS an over-size transfer via the progress handler → rejects', async () => {
+    const p = downloadUrlAsBlob('https://image.civitai.com/big.mp4', 'v.mp4', { maxBytes: 100 });
+    const xhr = FakeXHR.last();
+    // a declared total over the cap trips the guard: the handler aborts + rejects
+    xhr.emit('progress', { loaded: 0, total: 500 });
+    await expect(p).rejects.toThrow(/maximum download size/i);
+    expect(xhr.aborted).toBe(true);
+    // no download was triggered
+    expect(clickSpy).not.toHaveBeenCalled();
+  });
+
+  it('the cap also trips on streamed bytes exceeding it (no declared total)', async () => {
+    const p = downloadUrlAsBlob('https://image.civitai.com/big', 'v.mp4', { maxBytes: 100 });
+    const xhr = FakeXHR.last();
+    xhr.emit('progress', { loaded: 250, total: 0 });
+    await expect(p).rejects.toThrow(/maximum download size/i);
+    expect(xhr.aborted).toBe(true);
+  });
+
+  it('rejects when the loaded blob exceeds the cap (belt for a missed progress)', async () => {
+    const p = downloadUrlAsBlob('https://image.civitai.com/x', 'a.png', { maxBytes: 100 });
+    const xhr = FakeXHR.last();
+    xhr.readyState = 4;
+    xhr.status = 200;
+    // a blob bigger than the cap that slipped past progress
+    xhr.response = { size: 999, type: 'image/png' } as Blob;
+    xhr.emit('loadend');
+    await expect(p).rejects.toThrow(/maximum download size/i);
+    expect(clickSpy).not.toHaveBeenCalled();
+  });
+
+  it('rejects cleanly on a non-200 response', async () => {
+    const p = downloadUrlAsBlob('https://image.civitai.com/gone', 'a.png');
+    const xhr = FakeXHR.last();
+    xhr.readyState = 4;
+    xhr.status = 404;
+    xhr.emit('loadend');
+    await expect(p).rejects.toThrow(/download failed \(404\)/i);
+    expect(clickSpy).not.toHaveBeenCalled();
+  });
+
+  it('rejects cleanly on a network error', async () => {
+    const p = downloadUrlAsBlob('https://image.civitai.com/x', 'a.png');
+    const xhr = FakeXHR.last();
+    xhr.emit('error');
+    await expect(p).rejects.toThrow(/download failed/i);
+    expect(clickSpy).not.toHaveBeenCalled();
+  });
+
+  it('rejects cleanly on an abort event', async () => {
+    const p = downloadUrlAsBlob('https://image.civitai.com/x', 'a.png');
+    const xhr = FakeXHR.last();
+    xhr.emit('abort');
+    await expect(p).rejects.toThrow(/download aborted/i);
+    expect(clickSpy).not.toHaveBeenCalled();
+  });
+
+  it('defaults the cap to SAVE_IMAGE_MAX_BYTES (200 MB) when unspecified', async () => {
+    expect(SAVE_IMAGE_MAX_BYTES).toBe(200 * 1024 * 1024);
+    const p = downloadUrlAsBlob('https://image.civitai.com/x', 'a.png');
+    const xhr = FakeXHR.last();
+    // just under the default cap streams fine
+    xhr.emit('progress', { loaded: 199 * 1024 * 1024, total: 199 * 1024 * 1024 });
+    expect(xhr.aborted).toBe(false);
+    xhr.readyState = 4;
+    xhr.status = 200;
+    xhr.response = new Blob(['x'], { type: 'image/png' });
+    xhr.emit('loadend');
+    await expect(p).resolves.toBeUndefined();
+  });
+});

--- a/src/components/AppBlocks/saveImageDownload.test.ts
+++ b/src/components/AppBlocks/saveImageDownload.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   CIVITAI_IMAGE_HOSTS,
+  enforceImageExtension,
   isAllowedSaveImageUrl,
   resolveSaveImageRequest,
   sanitizeDownloadFilename,
@@ -79,6 +80,55 @@ describe('sanitizeDownloadFilename', () => {
     );
     expect(sanitizeDownloadFilename(null, 'https://image.civitai.com/')).toBe('download');
     expect(sanitizeDownloadFilename('   ', 'https://image.civitai.com/')).toBe('download');
+  });
+});
+
+// F2 — the saved download name is constrained to a SAFE MEDIA extension derived
+// from the RESOLVED content type of the fetched bytes, so a block can't save an
+// (allowlisted) orchestration blob under render.html / x.exe / .svg.
+describe('enforceImageExtension (F2 safe-extension gate)', () => {
+  it('forces the canonical extension for a KNOWN content type (replaces a hostile ext)', () => {
+    expect(enforceImageExtension('render.html', 'image/png')).toBe('render.png');
+    expect(enforceImageExtension('x.exe', 'image/jpeg')).toBe('x.jpg');
+    expect(enforceImageExtension('clip.txt', 'video/mp4')).toBe('clip.mp4');
+    // content type may carry parameters — only the media type is read
+    expect(enforceImageExtension('a.sh', 'image/webp; charset=binary')).toBe('a.webp');
+  });
+
+  it('appends the canonical extension when the name has NONE', () => {
+    expect(enforceImageExtension('render', 'image/png')).toBe('render.png');
+    expect(enforceImageExtension('download', 'video/webm')).toBe('download.webm');
+  });
+
+  it('keeps a name that already carries the matching / alias extension', () => {
+    expect(enforceImageExtension('photo.png', 'image/png')).toBe('photo.png');
+    // jpeg ≡ jpg — do not churn the name
+    expect(enforceImageExtension('photo.jpeg', 'image/jpeg')).toBe('photo.jpeg');
+    expect(enforceImageExtension('photo.jpg', 'image/jpeg')).toBe('photo.jpg');
+  });
+
+  it('preserves internal dots when replacing the extension', () => {
+    expect(enforceImageExtension('my.render.v2.html', 'image/png')).toBe('my.render.v2.png');
+  });
+
+  it('NEVER yields an .svg name even for an svg content type (svg is scriptable)', () => {
+    // image/svg+xml is intentionally not mapped → unknown branch → default .jpg
+    expect(enforceImageExtension('x.svg', 'image/svg+xml')).toBe('x.jpg');
+    expect(enforceImageExtension('x.html', 'image/svg+xml')).toBe('x.jpg');
+  });
+
+  it('unknown content type: keeps an already-safe media extension', () => {
+    expect(enforceImageExtension('a.png', undefined)).toBe('a.png');
+    expect(enforceImageExtension('a.mp4', '')).toBe('a.mp4');
+    expect(enforceImageExtension('a.jpeg', null)).toBe('a.jpeg');
+  });
+
+  it('unknown content type + unsafe/absent extension: coerces to the safe default', () => {
+    expect(enforceImageExtension('a.html', undefined)).toBe('a.jpg');
+    expect(enforceImageExtension('a.exe', '')).toBe('a.jpg');
+    expect(enforceImageExtension('noext', undefined)).toBe('noext.jpg');
+    // empty name falls back to a safe default too
+    expect(enforceImageExtension('', 'application/octet-stream')).toBe('download.jpg');
   });
 });
 

--- a/src/components/AppBlocks/saveImageDownload.test.ts
+++ b/src/components/AppBlocks/saveImageDownload.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from 'vitest';
+import {
+  CIVITAI_IMAGE_HOSTS,
+  isAllowedSaveImageUrl,
+  resolveSaveImageRequest,
+  sanitizeDownloadFilename,
+} from './saveImageDownload';
+
+const CDN = 'https://image.civitai.com';
+
+describe('isAllowedSaveImageUrl (SAVE_IMAGE origin allowlist)', () => {
+  it('ALLOWS the civitai image CDN + orchestration blob hosts (https)', () => {
+    expect(isAllowedSaveImageUrl('https://image.civitai.com/xG/77/original.jpeg', CDN)).toBe(true);
+    expect(
+      isAllowedSaveImageUrl(
+        'https://orchestration.civitai.com/v2/consumer/blobs/ABC123.jpeg?sig=x',
+        CDN
+      )
+    ).toBe(true);
+    // sanity: the static list is exactly the two known product hosts
+    expect([...CIVITAI_IMAGE_HOSTS].sort()).toEqual(['image.civitai.com', 'orchestration.civitai.com']);
+  });
+
+  it('ALLOWS the configured CDN origin even when not in the static list', () => {
+    // A self-hosted / non-prod NEXT_PUBLIC_IMAGE_LOCATION is covered without editing the list.
+    expect(isAllowedSaveImageUrl('https://cdn.example.net/a/b.jpeg', 'https://cdn.example.net')).toBe(true);
+    // …but only that exact host — a different host is still refused.
+    expect(isAllowedSaveImageUrl('https://other.example.net/a.jpeg', 'https://cdn.example.net')).toBe(false);
+  });
+
+  it('REJECTS an arbitrary attacker origin', () => {
+    expect(isAllowedSaveImageUrl('https://evil.example/x.png', CDN)).toBe(false);
+    expect(isAllowedSaveImageUrl('https://image.civitai.com.evil.example/x.png', CDN)).toBe(false);
+    // no subdomain wildcarding
+    expect(isAllowedSaveImageUrl('https://sub.image.civitai.com/x.png', CDN)).toBe(false);
+  });
+
+  it('REJECTS non-https schemes: data:, blob:, file:, http:', () => {
+    expect(isAllowedSaveImageUrl('data:image/png;base64,AAAA', CDN)).toBe(false);
+    expect(isAllowedSaveImageUrl('blob:https://image.civitai.com/uuid', CDN)).toBe(false);
+    expect(isAllowedSaveImageUrl('file:///etc/passwd', CDN)).toBe(false);
+    // plain http (downgrade/MITM) is refused even for an allowlisted host
+    expect(isAllowedSaveImageUrl('http://image.civitai.com/x.png', CDN)).toBe(false);
+  });
+
+  it('REJECTS non-string / empty / unparseable input', () => {
+    expect(isAllowedSaveImageUrl(undefined, CDN)).toBe(false);
+    expect(isAllowedSaveImageUrl('', CDN)).toBe(false);
+    expect(isAllowedSaveImageUrl('not a url', CDN)).toBe(false);
+    expect(isAllowedSaveImageUrl(42, CDN)).toBe(false);
+  });
+
+  it('tolerates an empty / relative NEXT_PUBLIC_IMAGE_LOCATION (falls back to the static list)', () => {
+    expect(isAllowedSaveImageUrl('https://image.civitai.com/x.png', '')).toBe(true);
+    expect(isAllowedSaveImageUrl('https://evil.example/x.png', '')).toBe(false);
+    expect(isAllowedSaveImageUrl('https://image.civitai.com/x.png', '/relative')).toBe(true);
+  });
+});
+
+describe('sanitizeDownloadFilename', () => {
+  it('strips query params and fragments', () => {
+    expect(sanitizeDownloadFilename('a.jpeg?token=x#frag', 'https://x/y')).toBe('a.jpeg');
+  });
+
+  it('collapses a duplicated trailing extension, preserving base dots', () => {
+    expect(sanitizeDownloadFilename('file.mp4.mp4', 'https://x/y')).toBe('file.mp4');
+    expect(sanitizeDownloadFilename('video-ttget.com.mp4', 'https://x/y')).toBe('video-ttget.com.mp4');
+  });
+
+  it('drops path separators / traversal (untrusted block-supplied name)', () => {
+    expect(sanitizeDownloadFilename('../../etc/passwd', 'https://x/y')).toBe('passwd');
+    expect(sanitizeDownloadFilename('a/b/c.png', 'https://x/y')).toBe('c.png');
+    expect(sanitizeDownloadFilename('..\\..\\win.png', 'https://x/y')).toBe('win.png');
+  });
+
+  it('falls back to the url last segment, then a generic name', () => {
+    expect(sanitizeDownloadFilename(undefined, 'https://image.civitai.com/xG/77/original.jpeg')).toBe(
+      'original.jpeg'
+    );
+    expect(sanitizeDownloadFilename(null, 'https://image.civitai.com/')).toBe('download');
+    expect(sanitizeDownloadFilename('   ', 'https://image.civitai.com/')).toBe('download');
+  });
+});
+
+describe('resolveSaveImageRequest', () => {
+  it('parses a url-variant request', () => {
+    expect(
+      resolveSaveImageRequest({ requestId: 'r', url: 'https://image.civitai.com/x.jpeg', filename: 'a.png' })
+    ).toEqual({ requestId: 'r', kind: 'url', url: 'https://image.civitai.com/x.jpeg', filename: 'a.png' });
+  });
+
+  it('parses an id-variant request', () => {
+    expect(resolveSaveImageRequest({ requestId: 'r', imageId: 55 })).toEqual({
+      requestId: 'r',
+      kind: 'id',
+      imageId: 55,
+      filename: undefined,
+    });
+  });
+
+  it('returns kind:invalid when BOTH url and imageId are present', () => {
+    expect(
+      resolveSaveImageRequest({ requestId: 'r', url: 'https://image.civitai.com/x.jpeg', imageId: 5 })
+    ).toEqual({ requestId: 'r', kind: 'invalid' });
+  });
+
+  it('returns kind:invalid when NEITHER url nor imageId is present', () => {
+    expect(resolveSaveImageRequest({ requestId: 'r' })).toEqual({ requestId: 'r', kind: 'invalid' });
+  });
+
+  it('rejects a non-positive / non-integer imageId (treated as absent → invalid)', () => {
+    expect(resolveSaveImageRequest({ requestId: 'r', imageId: 0 })).toEqual({ requestId: 'r', kind: 'invalid' });
+    expect(resolveSaveImageRequest({ requestId: 'r', imageId: -3 })).toEqual({ requestId: 'r', kind: 'invalid' });
+    expect(resolveSaveImageRequest({ requestId: 'r', imageId: 1.5 })).toEqual({ requestId: 'r', kind: 'invalid' });
+  });
+
+  it('returns null (drop, uncorrelatable) for a missing/invalid requestId', () => {
+    expect(resolveSaveImageRequest({ url: 'https://image.civitai.com/x.jpeg' })).toBeNull();
+    expect(resolveSaveImageRequest({ requestId: '', url: 'https://image.civitai.com/x.jpeg' })).toBeNull();
+    expect(resolveSaveImageRequest(null)).toBeNull();
+    expect(resolveSaveImageRequest('nope')).toBeNull();
+  });
+});

--- a/src/components/AppBlocks/saveImageDownload.ts
+++ b/src/components/AppBlocks/saveImageDownload.ts
@@ -1,0 +1,180 @@
+/**
+ * App Blocks `SAVE_IMAGE` download bridge — the PURE, unit-testable core.
+ *
+ * A block rendered in the unverified sandbox (`allow-scripts allow-forms`, NO
+ * `allow-downloads`, opaque origin) cannot trigger a browser "Save As" of an
+ * image it displays — only copy-URL works. This module backs the host handler
+ * that does the download in the UNSANDBOXED top frame on the block's behalf.
+ *
+ * SECURITY: the block never gets to name an arbitrary host to fetch. There are
+ * two request variants and each has its own gate (see PageBlockHost's handler):
+ *   - `url`     — the block's OWN output (an orchestration blob it has no image
+ *                 id for). MUST pass {@link isAllowedSaveImageUrl} — an origin
+ *                 allowlist over the civitai image/blob CDN. An arbitrary host,
+ *                 a `data:` / `blob:` / `file:` URL, or plain `http:` is
+ *                 REFUSED — never a host-side fetch of an attacker origin (the
+ *                 same lesson as "raw block `data` URLs are untrusted").
+ *   - `imageId` — a cross-user grid image. Resolved host-side through the SAME
+ *                 gated per-viewer read that backs `GET_IMAGES_BY_IDS`, so a
+ *                 withheld image can never be coerced into a download. The url it
+ *                 yields is a civitai edge url — which ALSO satisfies the
+ *                 allowlist, so the download step is uniform.
+ */
+
+/**
+ * Civitai-owned image / orchestration-blob hostnames the download bridge may
+ * fetch. These are PUBLIC product domains (they already appear throughout the
+ * open-source civitai app + its config), not infra internals. The configured
+ * image CDN origin (`NEXT_PUBLIC_IMAGE_LOCATION`) is added on top at call time,
+ * so a non-prod/self-hosted deployment's CDN is covered without editing this.
+ */
+export const CIVITAI_IMAGE_HOSTS: readonly string[] = [
+  'image.civitai.com',
+  'orchestration.civitai.com',
+];
+
+/** Bound the host-side blob fetch so a hostile block can't pull an unbounded video. */
+export const SAVE_IMAGE_MAX_BYTES = 200 * 1024 * 1024; // 200 MB
+
+/**
+ * True iff `rawUrl` is a civitai-served image/blob URL the host may fetch+download.
+ *
+ * Rules (fail-closed): must PARSE as a URL, must be `https:` (rejects
+ * `data:`/`blob:`/`file:`/`http:` — an opaque-origin block's own `data` URL is
+ * untrusted, and http would allow a downgrade/MITM download), and its hostname
+ * must be an EXACT match in the allowlist — {@link CIVITAI_IMAGE_HOSTS} plus the
+ * hostname of `imageCdnLocation` (the deployment's configured image CDN origin,
+ * e.g. `NEXT_PUBLIC_IMAGE_LOCATION`). No subdomain/suffix wildcarding.
+ *
+ * @param rawUrl            the URL the block asked to save (its own output)
+ * @param imageCdnLocation  the configured image CDN base (absolute URL) or ''
+ */
+export function isAllowedSaveImageUrl(rawUrl: unknown, imageCdnLocation: string): boolean {
+  if (typeof rawUrl !== 'string' || rawUrl.length === 0) return false;
+  let u: URL;
+  try {
+    u = new URL(rawUrl);
+  } catch {
+    return false;
+  }
+  // https only — drops data:/blob:/file: and plain http:.
+  if (u.protocol !== 'https:') return false;
+  const allowed = new Set<string>(CIVITAI_IMAGE_HOSTS);
+  if (imageCdnLocation) {
+    try {
+      allowed.add(new URL(imageCdnLocation).hostname);
+    } catch {
+      /* an unset / relative NEXT_PUBLIC_IMAGE_LOCATION contributes nothing */
+    }
+  }
+  return allowed.has(u.hostname);
+}
+
+/**
+ * Sanitize a download filename — LIFTED from `~/components/Image/DownloadImage`
+ * (kept behavior-identical) so the bridge and the on-site component share ONE
+ * cleaner. Strips a query/fragment, collapses a duplicate trailing extension
+ * (`file.mp4.mp4` → `file.mp4`) while preserving dots in the base name, and —
+ * the bridge-specific hardening — drops any path separators / traversal so a
+ * block-supplied `filename` can never write outside the download name (`a/../b`
+ * → `b`). Falls back to the URL's last path segment, then a generic name.
+ */
+export function sanitizeDownloadFilename(name: string | undefined | null, url: string): string {
+  let cleanFilename = (name ?? url.split('/').pop() ?? 'download').toString();
+  // Drop any directory component / traversal (block-supplied names are untrusted).
+  cleanFilename = cleanFilename.split(/[\\/]/).pop() ?? cleanFilename;
+  // Strip query params and fragments.
+  cleanFilename = cleanFilename.split('?')[0].split('#')[0];
+  // Collapse a duplicated trailing extension (token-appended), preserving base dots.
+  const extMatch = cleanFilename.match(/\.([a-zA-Z0-9]{2,5})$/);
+  if (extMatch) {
+    const ext = extMatch[1];
+    const dupePattern = new RegExp(`(\\.${ext})+$`);
+    cleanFilename = cleanFilename.replace(dupePattern, `.${ext}`);
+  }
+  cleanFilename = cleanFilename.trim();
+  return cleanFilename.length > 0 ? cleanFilename : 'download';
+}
+
+/** Parsed, validated SAVE_IMAGE request. Exactly one of url / imageId is set. */
+export type SaveImageRequest =
+  | { requestId: string; kind: 'url'; url: string; filename?: string }
+  | { requestId: string; kind: 'id'; imageId: number; filename?: string };
+
+/**
+ * Parse a raw inbound SAVE_IMAGE payload into a discriminated request, or `null`
+ * when it's unusable (missing/invalid requestId, or NOT exactly one of
+ * url/imageId). Pure — no allowlist / no DOM — so the message-shape contract is
+ * unit-testable independently of the origin gate + the download. A `null` return
+ * means "drop, no reply" (a missing requestId can't be correlated); a shape that
+ * HAS a requestId but is otherwise invalid returns a request the caller NACKs.
+ */
+export function resolveSaveImageRequest(raw: unknown): SaveImageRequest | { requestId: string; kind: 'invalid' } | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const r = raw as { requestId?: unknown; url?: unknown; imageId?: unknown; filename?: unknown };
+  if (typeof r.requestId !== 'string' || r.requestId.length === 0) return null;
+  const filename = typeof r.filename === 'string' ? r.filename : undefined;
+  const hasUrl = typeof r.url === 'string' && r.url.length > 0;
+  const hasId = typeof r.imageId === 'number' && Number.isInteger(r.imageId) && r.imageId > 0;
+  // Exactly one variant. Both-or-neither is an invalid (NACK-able) request.
+  if (hasUrl === hasId) return { requestId: r.requestId, kind: 'invalid' };
+  if (hasUrl) return { requestId: r.requestId, kind: 'url', url: r.url as string, filename };
+  return { requestId: r.requestId, kind: 'id', imageId: r.imageId as number, filename };
+}
+
+/**
+ * Fetch `url` as a blob in the TOP frame (host document — not the sandboxed
+ * iframe) and trigger a browser download. Runs the same XHR→blob→`<a download>`
+ * path as `~/components/Image/DownloadImage`, with a byte cap
+ * ({@link SAVE_IMAGE_MAX_BYTES}) that aborts an over-size transfer. Resolves on
+ * success, throws on failure (non-200, over-size, network). The CALLER is
+ * responsible for having validated the origin ({@link isAllowedSaveImageUrl}) or
+ * resolved it via the gated read BEFORE calling this.
+ */
+export async function downloadUrlAsBlob(
+  url: string,
+  filename: string,
+  opts: { maxBytes?: number } = {}
+): Promise<void> {
+  const maxBytes = opts.maxBytes ?? SAVE_IMAGE_MAX_BYTES;
+  const blob = await new Promise<Blob>((resolve, reject) => {
+    const xhr = new XMLHttpRequest();
+    xhr.responseType = 'blob';
+    xhr.addEventListener('progress', ({ loaded, total }) => {
+      // Abort as soon as a declared or streamed size blows the cap.
+      if ((total && total > maxBytes) || loaded > maxBytes) {
+        xhr.abort();
+        reject(new Error('image exceeds the maximum download size'));
+      }
+    });
+    xhr.addEventListener('loadend', () => {
+      if (xhr.readyState === 4 && xhr.status === 200) {
+        const b = xhr.response as Blob;
+        if (b && b.size > maxBytes) {
+          reject(new Error('image exceeds the maximum download size'));
+          return;
+        }
+        resolve(b);
+      } else if (xhr.readyState === 4) {
+        reject(new Error(`download failed (${xhr.status})`));
+      }
+    });
+    xhr.addEventListener('error', () => reject(new Error('download failed')));
+    xhr.addEventListener('abort', () => reject(new Error('download aborted')));
+    xhr.open('GET', url);
+    xhr.send();
+  });
+
+  const href = URL.createObjectURL(blob);
+  try {
+    const a = document.createElement('a');
+    a.href = href;
+    a.download = filename;
+    a.target = '_blank';
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+  } finally {
+    URL.revokeObjectURL(href);
+  }
+}

--- a/src/components/AppBlocks/saveImageDownload.ts
+++ b/src/components/AppBlocks/saveImageDownload.ts
@@ -37,6 +37,43 @@ export const CIVITAI_IMAGE_HOSTS: readonly string[] = [
 export const SAVE_IMAGE_MAX_BYTES = 200 * 1024 * 1024; // 200 MB
 
 /**
+ * F2 — max concurrent host-side SAVE_IMAGE downloads per host frame. The host
+ * fetches on the block's behalf in the unsandboxed top frame; without a cap a
+ * hostile block could fire a burst of SAVE_IMAGEs and download-bomb the viewer's
+ * tab (memory / bandwidth). The host gates on this and replies `busy` past it.
+ */
+export const SAVE_IMAGE_MAX_CONCURRENT = 3;
+
+/**
+ * F2 — canonical download extension per resolved content type. Bytes fetched
+ * host-side are constrained to a SAFE MEDIA extension (see
+ * {@link enforceImageExtension}) so a block can't save an orchestration blob under
+ * an arbitrary/executable name (`render.html`, `x.exe`). Deliberately EXCLUDES
+ * `image/svg+xml` — an SVG is scriptable, so it never gets an `.svg` download name.
+ */
+const CONTENT_TYPE_TO_EXT: Readonly<Record<string, string>> = {
+  'image/jpeg': 'jpg',
+  'image/jpg': 'jpg',
+  'image/png': 'png',
+  'image/webp': 'webp',
+  'image/gif': 'gif',
+  'image/avif': 'avif',
+  'image/apng': 'apng',
+  'image/bmp': 'bmp',
+  'video/mp4': 'mp4',
+  'video/webm': 'webm',
+  'video/quicktime': 'mov',
+};
+
+/** Extensions we allow a supplied filename to KEEP when the content type is unknown. */
+const SAFE_MEDIA_EXTENSIONS: ReadonlySet<string> = new Set(
+  Object.values(CONTENT_TYPE_TO_EXT).concat('jpeg')
+);
+
+/** Fallback download extension when the content type is unknown and the name has no safe one. */
+const DEFAULT_SAFE_EXTENSION = 'jpg';
+
+/**
  * True iff `rawUrl` is a civitai-served image/blob URL the host may fetch+download.
  *
  * Rules (fail-closed): must PARSE as a URL, must be `https:` (rejects
@@ -96,6 +133,41 @@ export function sanitizeDownloadFilename(name: string | undefined | null, url: s
   return cleanFilename.length > 0 ? cleanFilename : 'download';
 }
 
+/**
+ * F2 — constrain a (already-sanitized) download filename to a SAFE MEDIA extension
+ * derived from the RESOLVED content type of the fetched bytes. This is the
+ * download-name analogue of the origin allowlist: the origin gate stops the host
+ * fetching an attacker URL; this stops a block naming allowlisted image/blob bytes
+ * `render.html` / `x.exe` so a "Save image" can never write an executable/markup
+ * extension the OS or a later open would treat as such.
+ *
+ * Rules:
+ *   • Known content type → force its canonical extension (`image/png` → `.png`),
+ *     unless the name already carries that exact/alias extension (jpeg≡jpg), in
+ *     which case the name is kept verbatim. Internal dots are preserved.
+ *   • Unknown content type → keep the name IFF its current extension is already a
+ *     safe media extension; otherwise coerce to {@link DEFAULT_SAFE_EXTENSION}.
+ * `sanitizeDownloadFilename` (traversal/query strip) runs FIRST; this only touches
+ * the extension.
+ */
+export function enforceImageExtension(filename: string, contentType?: string | null): string {
+  const name = filename && filename.trim().length > 0 ? filename.trim() : 'download';
+  const m = name.match(/^(.*)\.([a-zA-Z0-9]{1,5})$/);
+  const base = m ? m[1] : name;
+  const currentExt = m ? m[2].toLowerCase() : '';
+
+  const normalizedType = (contentType ?? '').split(';')[0].trim().toLowerCase();
+  const canonical = CONTENT_TYPE_TO_EXT[normalizedType];
+
+  if (canonical) {
+    const aliasOk = currentExt === canonical || (canonical === 'jpg' && currentExt === 'jpeg');
+    return aliasOk ? name : `${base}.${canonical}`;
+  }
+  // Unknown content type: keep an already-safe extension, else force the default.
+  if (currentExt && SAFE_MEDIA_EXTENSIONS.has(currentExt)) return name;
+  return `${base}.${DEFAULT_SAFE_EXTENSION}`;
+}
+
 /** Parsed, validated SAVE_IMAGE request. Exactly one of url / imageId is set. */
 export type SaveImageRequest =
   | { requestId: string; kind: 'url'; url: string; filename?: string }
@@ -130,6 +202,14 @@ export function resolveSaveImageRequest(raw: unknown): SaveImageRequest | { requ
  * success, throws on failure (non-200, over-size, network). The CALLER is
  * responsible for having validated the origin ({@link isAllowedSaveImageUrl}) or
  * resolved it via the gated read BEFORE calling this.
+ *
+ * F3 (documented client-side limitation): XHR transparently FOLLOWS HTTP
+ * redirects, and {@link isAllowedSaveImageUrl} only gates the INITIAL url — a
+ * first-party (allowlisted) host that itself issues an open redirect could land
+ * the fetch on another origin. This is accepted for v1: the allowlist is the
+ * civitai image/blob CDN, which does not open-redirect; a stricter check would
+ * need a HEAD/redirect-manual pre-flight (not worth it for the same-origin CDN).
+ * The bytes are additionally bounded by the size cap + the safe-extension gate.
  */
 export async function downloadUrlAsBlob(
   url: string,
@@ -165,11 +245,14 @@ export async function downloadUrlAsBlob(
     xhr.send();
   });
 
+  // F2: constrain the saved name to a safe media extension keyed on the RESOLVED
+  // content type of the fetched bytes (a block can't save a blob as render.html).
+  const safeFilename = enforceImageExtension(filename, blob?.type);
   const href = URL.createObjectURL(blob);
   try {
     const a = document.createElement('a');
     a.href = href;
-    a.download = filename;
+    a.download = safeFilename;
     a.target = '_blank';
     document.body.appendChild(a);
     a.click();

--- a/src/server/routers/__tests__/apps-shared.router.test.ts
+++ b/src/server/routers/__tests__/apps-shared.router.test.ts
@@ -21,6 +21,7 @@ const {
   mockGetSessionUser,
   mockCheckAppendRl,
   mockCheckVoteRl,
+  mockCheckReportRl,
   mockThrowOnBlockedLinkDomain,
   mockAuditPromptServer,
   mockIsRevoked,
@@ -44,6 +45,7 @@ const {
     mockGetSessionUser: vi.fn(),
     mockCheckAppendRl: vi.fn(async () => ({ allowed: true })),
     mockCheckVoteRl: vi.fn(async () => ({ allowed: true })),
+    mockCheckReportRl: vi.fn(async () => ({ allowed: true })),
     mockThrowOnBlockedLinkDomain: vi.fn(async () => undefined),
     mockAuditPromptServer: vi.fn(async () => undefined),
     mockIsRevoked: vi.fn(async () => false),
@@ -66,6 +68,7 @@ vi.mock('~/server/db/appsDb', () => ({ requireAppsDb: () => mockPool }));
 vi.mock('~/server/utils/shared-storage-rate-limit', () => ({
   checkSharedAppendRateLimit: (...a: unknown[]) => mockCheckAppendRl(...a),
   checkSharedVoteRateLimit: (...a: unknown[]) => mockCheckVoteRl(...a),
+  checkSharedReportRateLimit: (...a: unknown[]) => mockCheckReportRl(...a),
 }));
 // Keep the content-safety belt REAL; mock only its redis-backed deps.
 vi.mock('~/server/services/blocklist.service', () => ({
@@ -155,6 +158,7 @@ beforeEach(() => {
   mockClient.query.mockResolvedValue({ rows: [], rowCount: 0 });
   mockCheckAppendRl.mockResolvedValue({ allowed: true });
   mockCheckVoteRl.mockResolvedValue({ allowed: true });
+  mockCheckReportRl.mockResolvedValue({ allowed: true });
   mockThrowOnBlockedLinkDomain.mockResolvedValue(undefined);
   mockAuditPromptServer.mockResolvedValue(undefined);
   mockLogToAxiom.mockResolvedValue(undefined);
@@ -757,6 +761,76 @@ describe('H4 rate limits', () => {
     await expect(caller().vote({ blockToken: 't', key: 'k' })).rejects.toMatchObject({
       code: 'TOO_MANY_REQUESTS',
     });
+  });
+});
+
+// F1 (pre-GA): `report` is now block-reachable and each report files a row + fires
+// a mod-channel webhook, so — like every other shared write op — it MUST be
+// rate-limited, AND a repeat report of the same row by the same reporter must be a
+// no-op (no 2nd row, no 2nd alert, no 2nd webhook). The Discord webhook is
+// co-gated with the Axiom report emit in the SAME `if (!filed) return` branch, so
+// the emit count is the faithful observable for "was the mod-notify fired".
+describe('F1 report rate-limit + per-(reporter,key) dedup', () => {
+  function auditEmits(name: string) {
+    return (mockLogToAxiom.mock.calls as Array<[Record<string, unknown>, string?]>)
+      .filter((c) => c[1] === 'block-audit' && c[0]?.name === name)
+      .map((c) => c[0]);
+  }
+  // The row-exists SELECT (on shared_kv) resolves truthy; the dedup INSERT (on
+  // shared_kv_reports) resolves with the caller-supplied rowCount so we can pin
+  // "new" (1) vs "duplicate" (0) independently of the existence check.
+  function mockReportPath(insertRowCount: number) {
+    mockPool.query.mockImplementation(async (sql: string) => {
+      if (sql.includes('shared_kv_reports')) return { rows: [], rowCount: insertRowCount };
+      return { rows: [{ x: 1 }], rowCount: 1 }; // the row-exists pre-check
+    });
+  }
+
+  it('report over the daily cap → TOO_MANY_REQUESTS (before any DB write)', async () => {
+    mockVerifyBlockToken.mockResolvedValueOnce(validClaims());
+    mockCheckReportRl.mockResolvedValueOnce({ allowed: false, retryAfterSeconds: 3600 });
+    await expect(
+      caller().report({ blockToken: 't', key: 'req-1', reason: 'spam' })
+    ).rejects.toMatchObject({ code: 'TOO_MANY_REQUESTS' });
+    // Rate-limited before it touches the DB or emits.
+    expect(mockPool.query).not.toHaveBeenCalled();
+    expect(auditEmits('app-blocks-shared-storage-report')).toHaveLength(0);
+  });
+
+  it('a NEW (reporter,key) report files exactly one row + emits once', async () => {
+    mockVerifyBlockToken.mockResolvedValueOnce(validClaims());
+    mockReportPath(1); // insert affected a row → genuinely new
+    const out = await caller().report({ blockToken: 't', key: 'req-new', reason: 'harassment' });
+    expect(out).toEqual({ ok: true });
+    // exactly one dedup-INSERT against shared_kv_reports, and it is a WHERE NOT
+    // EXISTS conditional insert (the structural dedup) — not an unconditional VALUES.
+    const inserts = (mockPool.query.mock.calls as Array<[string, unknown[]?]>).filter((c) =>
+      c[0].includes('INSERT INTO') && c[0].includes('shared_kv_reports')
+    );
+    expect(inserts).toHaveLength(1);
+    expect(inserts[0][0]).toMatch(/WHERE NOT EXISTS/i);
+    // the alert (and its co-gated Discord notify) fired exactly once
+    expect(auditEmits('app-blocks-shared-storage-report')).toHaveLength(1);
+  });
+
+  it('a DUPLICATE (reporter,key) report is a no-op: no 2nd row, no 2nd webhook/emit', async () => {
+    mockVerifyBlockToken.mockResolvedValueOnce(validClaims());
+    mockReportPath(0); // WHERE NOT EXISTS matched an existing row → nothing inserted
+    const out = await caller().report({ blockToken: 't', key: 'req-dup', reason: 'again' });
+    // still succeeds (idempotent from the caller's view) …
+    expect(out).toEqual({ ok: true });
+    // … but the report alert + its co-gated mod-Discord notify are SKIPPED.
+    expect(auditEmits('app-blocks-shared-storage-report')).toHaveLength(0);
+  });
+
+  it('distinct keys from the same reporter each file + emit (dedup is per-key)', async () => {
+    // Two distinct keys → the WHERE NOT EXISTS admits both (rowCount 1 each).
+    mockVerifyBlockToken.mockResolvedValueOnce(validClaims());
+    mockReportPath(1);
+    await caller().report({ blockToken: 't', key: 'k1' });
+    mockVerifyBlockToken.mockResolvedValueOnce(validClaims());
+    await caller().report({ blockToken: 't', key: 'k2' });
+    expect(auditEmits('app-blocks-shared-storage-report')).toHaveLength(2);
   });
 });
 

--- a/src/server/routers/__tests__/apps-shared.router.test.ts
+++ b/src/server/routers/__tests__/apps-shared.router.test.ts
@@ -761,7 +761,7 @@ describe('H4 rate limits', () => {
 });
 
 describe('isolation + read invariants', () => {
-  it('list reads ONLY shared_kv/counters (never kv/votes), excludes hidden', async () => {
+  it('list reads shared_kv/counters + a viewer-scoped votes join (never the per-user kv), excludes hidden', async () => {
     mockVerifyBlockToken.mockResolvedValueOnce(validClaims());
     mockPool.query.mockResolvedValueOnce({ rows: [], rowCount: 0 });
     await caller().list({ blockToken: 't' });
@@ -769,8 +769,13 @@ describe('isolation + read invariants', () => {
     expect(sql).toContain('.shared_kv');
     expect(sql).toContain('.counters');
     expect(sql).toContain('hidden_at IS NULL');
+    // NEVER the per-user kv table.
     expect(sql).not.toMatch(/\.kv\b/);
-    expect(sql).not.toMatch(/\.votes\b/);
+    // item 3: votes IS joined now — but ONLY the viewer's own row (v.user_id = the
+    // resolved subject uid) to derive the boolean; the raw vote rows are never
+    // SELECTed/returned (only the derived `viewer_voted`).
+    expect(sql).toMatch(/LEFT JOIN\s+"app_app_voting"\.votes v ON v\.key = s\.key AND v\.user_id = \$4/);
+    expect(sql).toContain('(v.user_id IS NOT NULL) AS viewer_voted');
   });
 
   it('per-app isolation: schema derives from claims.blockId (app A ≠ app B)', async () => {
@@ -779,6 +784,189 @@ describe('isolation + read invariants', () => {
     const sql = (mockPool.query.mock.calls[0] as [string])[0];
     expect(sql).toContain('"app_app_beta".shared_kv');
     expect(sql).not.toContain('app_app_voting');
+  });
+});
+
+// Item 3 — per-viewer vote hydration on `list`. A LEFT JOIN on the viewer's OWN
+// vote row derives an additive `viewerVoted` boolean; anon → NULL uid → false.
+// The raw vote rows are never returned, only the derived boolean.
+describe('item 3 viewerVoted (per-viewer vote flag on list)', () => {
+  it('JOINs votes on the RESOLVED subject uid and maps viewer_voted → viewerVoted', async () => {
+    mockVerifyBlockToken.mockResolvedValueOnce(validClaims()); // sub user:42
+    mockPool.query.mockResolvedValueOnce({
+      rows: [
+        {
+          key: 'K1',
+          author_user_id: 7,
+          value: { title: 't' },
+          count: '2',
+          created_at: new Date(),
+          updated_at: new Date(),
+          viewer_voted: true,
+        },
+        {
+          key: 'K2',
+          author_user_id: 8,
+          value: { title: 'u' },
+          count: '0',
+          created_at: new Date(),
+          updated_at: new Date(),
+          viewer_voted: false,
+        },
+      ],
+      rowCount: 2,
+    });
+    const out = await caller().list({ blockToken: 't' });
+    expect(out.items[0].viewerVoted).toBe(true);
+    expect(out.items[1].viewerVoted).toBe(false);
+    const [sql, params] = mockPool.query.mock.calls[0] as [string, unknown[]];
+    // The vote join + derived boolean are present, keyed on the $4 uid param.
+    expect(sql).toContain('.votes v');
+    expect(sql).toContain('(v.user_id IS NOT NULL) AS viewer_voted');
+    expect(sql).toContain('v.user_id = $4::int');
+    // $4 is the RESOLVED subject uid (42) — never client input.
+    expect(params[3]).toBe(42);
+    // The ONLY reference to a vote row's user_id is the DERIVED boolean — the raw
+    // vote rows are never selected/returned.
+    expect(sql.match(/v\.user_id/g)?.length).toBe(2); // the JOIN predicate + the boolean
+    expect(sql).toContain('(v.user_id IS NOT NULL) AS viewer_voted');
+  });
+
+  it('anon viewer passes a NULL uid → the join never matches (viewerVoted false)', async () => {
+    mockVerifyBlockToken.mockResolvedValueOnce(validClaims({ sub: 'anon' }));
+    mockPool.query.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+    await caller().list({ blockToken: 't' });
+    const [, params] = mockPool.query.mock.calls[0] as [string, unknown[]];
+    expect(params[3]).toBeNull();
+  });
+
+  it('is PER-VIEWER: the join keys on the token subject, not a fixed user', async () => {
+    mockVerifyBlockToken.mockResolvedValueOnce(validClaims({ sub: 'user:99' }));
+    mockGetSessionUser.mockResolvedValueOnce(trustedUser({ id: 99 }));
+    mockPool.query.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+    await caller().list({ blockToken: 't' });
+    const [, params] = mockPool.query.mock.calls[0] as [string, unknown[]];
+    expect(params[3]).toBe(99);
+  });
+});
+
+// Item 6 — single-row fetch-by-key for `?g=` deep links. READ op (anon-allowed),
+// same per-viewer visibility gate (`hidden_at IS NULL`) as `list`.
+describe('item 6 apps.shared.get (single-row fetch-by-key)', () => {
+  it('returns the row (count + viewerVoted) mapped to the list item shape', async () => {
+    mockVerifyBlockToken.mockResolvedValueOnce(validClaims());
+    const created = new Date();
+    const updated = new Date();
+    mockPool.query.mockResolvedValueOnce({
+      rows: [
+        {
+          key: 'K',
+          author_user_id: 7,
+          value: { title: 't', data: { x: 1 } },
+          count: '5',
+          created_at: created,
+          updated_at: updated,
+          viewer_voted: true,
+        },
+      ],
+      rowCount: 1,
+    });
+    const out = await caller().get({ blockToken: 't', key: 'K' });
+    expect(out.item).toMatchObject({ key: 'K', authorUserId: 7, count: 5, viewerVoted: true });
+    expect((out.item as { value: unknown }).value).toEqual({ title: 't', data: { x: 1 } });
+    const [sql, params] = mockPool.query.mock.calls[0] as [string, unknown[]];
+    expect(sql).toContain('WHERE s.key = $1 AND s.hidden_at IS NULL');
+    expect(sql).toContain('.votes v');
+    expect(params[0]).toBe('K');
+    expect(params[1]).toBe(42); // resolved subject uid for viewerVoted
+  });
+
+  it('returns item:null for a missing key', async () => {
+    mockVerifyBlockToken.mockResolvedValueOnce(validClaims());
+    mockPool.query.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+    const out = await caller().get({ blockToken: 't', key: 'ghost' });
+    expect(out.item).toBeNull();
+  });
+
+  it('does NOT leak a hidden/moderated row — the query filters hidden_at IS NULL so a hidden row yields item:null', async () => {
+    mockVerifyBlockToken.mockResolvedValueOnce(validClaims());
+    // Assert the visibility gate is IN the SQL, and (as the DB would) a hidden row
+    // returns no rows → item:null. A get by key can't bypass the list's gate.
+    mockPool.query.mockImplementationOnce(async (sql: string) => {
+      expect(sql).toContain('hidden_at IS NULL');
+      return { rows: [], rowCount: 0 };
+    });
+    const out = await caller().get({ blockToken: 't', key: 'hidden-row' });
+    expect(out.item).toBeNull();
+  });
+
+  it('anon may READ a single row (get is a READ op) with a NULL viewer uid', async () => {
+    mockVerifyBlockToken.mockResolvedValueOnce(validClaims({ sub: 'anon' }));
+    mockPool.query.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+    const out = await caller().get({ blockToken: 't', key: 'K' });
+    expect(out.item).toBeNull();
+    const [, params] = mockPool.query.mock.calls[0] as [string, unknown[]];
+    expect(params[1]).toBeNull();
+  });
+
+  it('get requires the READ scope (a write-only token is FORBIDDEN, no DB access)', async () => {
+    mockVerifyBlockToken.mockResolvedValueOnce(validClaims({ scopes: [WRITE] }));
+    await expect(caller().get({ blockToken: 't', key: 'K' })).rejects.toMatchObject({
+      code: 'FORBIDDEN',
+    });
+    expect(mockPool.query).not.toHaveBeenCalled();
+  });
+
+  it('per-app isolation: the get query derives the schema from claims.blockId', async () => {
+    mockVerifyBlockToken.mockResolvedValueOnce(validClaims({ blockId: 'app-beta' }));
+    mockPool.query.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+    await caller().get({ blockToken: 't', key: 'K' });
+    const sql = (mockPool.query.mock.calls[0] as [string])[0];
+    expect(sql).toContain('"app_app_beta".shared_kv');
+    expect(sql).not.toContain('app_app_voting');
+  });
+});
+
+// Item 5 — the `report` procedure ALREADY existed (its emit/report-row behavior
+// is covered under "FIX 1 abuse observability"). These pin its AUTHZ: report is a
+// WRITE-trust op (not a read), so anon/untrusted/read-only-scope are all denied.
+describe('item 5 apps.shared.report authz (write-trust gated)', () => {
+  it('a read-only token is FORBIDDEN (report requires the write scope)', async () => {
+    mockVerifyBlockToken.mockResolvedValueOnce(validClaims({ scopes: [READ] }));
+    await expect(caller().report({ blockToken: 't', key: 'k' })).rejects.toMatchObject({
+      code: 'FORBIDDEN',
+    });
+    expect(mockPool.query).not.toHaveBeenCalled();
+  });
+
+  it('anon may NOT report (UNAUTHORIZED)', async () => {
+    mockVerifyBlockToken.mockResolvedValueOnce(validClaims({ sub: 'anon' }));
+    await expect(caller().report({ blockToken: 't', key: 'k' })).rejects.toMatchObject({
+      code: 'UNAUTHORIZED',
+    });
+    expect(mockPool.query).not.toHaveBeenCalled();
+  });
+
+  it('an untrusted (too-new) reporter is DENIED (FORBIDDEN)', async () => {
+    mockVerifyBlockToken.mockResolvedValueOnce(validClaims());
+    mockGetSessionUser.mockResolvedValueOnce(trustedUser({ createdAt: new Date() }));
+    await expect(caller().report({ blockToken: 't', key: 'k' })).rejects.toMatchObject({
+      code: 'FORBIDDEN',
+    });
+    expect(mockPool.query).not.toHaveBeenCalled();
+  });
+
+  it('a trusted reporter files the report row and returns { ok: true }', async () => {
+    mockVerifyBlockToken.mockResolvedValueOnce(validClaims());
+    mockPool.query.mockResolvedValue({ rows: [{ x: 1 }], rowCount: 1 }); // row exists + insert
+    const out = await caller().report({ blockToken: 't', key: 'req-1', reason: 'spam' });
+    expect(out).toEqual({ ok: true });
+    const report = (mockPool.query.mock.calls as Array<[string, unknown[]?]>).find((c) =>
+      c[0].includes('shared_kv_reports')
+    );
+    expect(report).toBeTruthy();
+    // the reporter uid is the RESOLVED subject (42), never client input
+    expect((report![1] as unknown[])[2]).toBe(42);
   });
 });
 

--- a/src/server/routers/apps-shared.router.ts
+++ b/src/server/routers/apps-shared.router.ts
@@ -71,6 +71,7 @@ const REQUIRE_PAID_TIER = false;
 
 type SharedOp =
   | 'list'
+  | 'get'
   | 'getCount'
   | 'append'
   // Author-scoped in-place edit of an OWN published row (write-gated exactly like
@@ -85,7 +86,7 @@ type SharedOp =
   //   - 'getTop' is a READ (anon-allowed like list/getCount)
   | 'increment'
   | 'getTop';
-const READ_OPS: ReadonlySet<SharedOp> = new Set<SharedOp>(['list', 'getCount', 'getTop']);
+const READ_OPS: ReadonlySet<SharedOp> = new Set<SharedOp>(['list', 'get', 'getCount', 'getTop']);
 
 const SHARED_READ_SCOPE = 'apps:storage:shared:read';
 const SHARED_WRITE_SCOPE = 'apps:storage:shared:write';
@@ -292,7 +293,9 @@ export const appsSharedRouter = router({
       })
     )
     .query(async ({ input }) => {
-      const { schema } = await resolveSharedContext(input.blockToken, 'list');
+      // `userId` is the RESOLVED token subject (null for anon) — used ONLY to
+      // hydrate the per-viewer `viewerVoted` flag below. It is never client input.
+      const { schema, userId } = await resolveSharedContext(input.blockToken, 'list');
       const pool = requireAppsDb();
 
       const afterKey = input.cursor
@@ -301,6 +304,12 @@ export const appsSharedRouter = router({
       const escapedPrefix = (input.prefix ?? '').replace(/([\\%_])/g, '\\$1');
       const prefixPattern = `${escapedPrefix}%`;
 
+      // Per-viewer vote hydration (item 3): LEFT JOIN the viewer's OWN vote row
+      // ($4 = resolved subject uid, or NULL for anon). `v.user_id = $4` is UNKNOWN
+      // (never true) for a NULL param, so an anonymous viewer always reads
+      // `viewer_voted = false`. The join keys on votes' PK `(key, user_id)`, so it
+      // is index-covered and adds no scan to the hot list path. The raw vote rows
+      // are NEVER returned — only the boolean derived from the viewer's own row.
       const rows = (
         await pool.query<{
           key: string;
@@ -309,17 +318,20 @@ export const appsSharedRouter = router({
           count: string;
           created_at: Date;
           updated_at: Date;
+          viewer_voted: boolean;
         }>(
           `SELECT s.key, s.author_user_id, s.value, COALESCE(c.count, 0)::text AS count,
-                  s.created_at, s.updated_at
+                  s.created_at, s.updated_at,
+                  (v.user_id IS NOT NULL) AS viewer_voted
              FROM ${schema}.shared_kv s
              LEFT JOIN ${schema}.counters c ON c.key = s.key
+             LEFT JOIN ${schema}.votes v ON v.key = s.key AND v.user_id = $4::int
             WHERE s.hidden_at IS NULL
               AND s.key LIKE $1 ESCAPE '\\'
               AND ($2::text IS NULL OR s.key < $2)
             ORDER BY s.key DESC
             LIMIT $3`,
-          [prefixPattern, afterKey, input.limit]
+          [prefixPattern, afterKey, input.limit, userId]
         )
       ).rows;
 
@@ -336,8 +348,59 @@ export const appsSharedRouter = router({
           count: Number(r.count),
           createdAt: r.created_at,
           updatedAt: r.updated_at,
+          viewerVoted: r.viewer_voted,
         })),
         nextCursor,
+      };
+    }),
+
+  /**
+   * Single-row fetch by key (item 6 — deep-link resolution). Returns the SAME
+   * item shape as `list` (incl. `count` + the per-viewer `viewerVoted`), or
+   * `null` when the key is missing OR hidden — applying the identical
+   * `hidden_at IS NULL` visibility gate as `list`, so a direct key fetch can
+   * NOT leak a withdrawn / moderator-hidden row that the paged list excludes.
+   * READ op (anon-allowed like `list`/`getCount`). Reuses `resolveSharedContext`
+   * so per-app isolation, the approved-block + revocation checks, the read scope,
+   * and the fail-closed kill-switch all hold verbatim. The `votes`/`kv` rows are
+   * never returned — only the aggregate count + the viewer's own vote boolean.
+   */
+  get: publicProcedure
+    .input(blockTokenInput.extend({ key: sharedKeyInput }))
+    .query(async ({ input }) => {
+      const { schema, userId } = await resolveSharedContext(input.blockToken, 'get');
+      const pool = requireAppsDb();
+      const row = (
+        await pool.query<{
+          key: string;
+          author_user_id: number;
+          value: unknown;
+          count: string;
+          created_at: Date;
+          updated_at: Date;
+          viewer_voted: boolean;
+        }>(
+          `SELECT s.key, s.author_user_id, s.value, COALESCE(c.count, 0)::text AS count,
+                  s.created_at, s.updated_at,
+                  (v.user_id IS NOT NULL) AS viewer_voted
+             FROM ${schema}.shared_kv s
+             LEFT JOIN ${schema}.counters c ON c.key = s.key
+             LEFT JOIN ${schema}.votes v ON v.key = s.key AND v.user_id = $2::int
+            WHERE s.key = $1 AND s.hidden_at IS NULL`,
+          [input.key, userId]
+        )
+      ).rows[0];
+      if (!row) return { item: null };
+      return {
+        item: {
+          key: row.key,
+          authorUserId: row.author_user_id,
+          value: row.value,
+          count: Number(row.count),
+          createdAt: row.created_at,
+          updatedAt: row.updated_at,
+          viewerVoted: row.viewer_voted,
+        },
       };
     }),
 

--- a/src/server/routers/apps-shared.router.ts
+++ b/src/server/routers/apps-shared.router.ts
@@ -43,6 +43,7 @@ import {
 import {
   checkSharedAppendRateLimit,
   checkSharedVoteRateLimit,
+  checkSharedReportRateLimit,
 } from '~/server/utils/shared-storage-rate-limit';
 import { moderatorProcedure, publicProcedure, router } from '~/server/trpc';
 
@@ -808,17 +809,39 @@ export const appsSharedRouter = router({
         'report'
       );
       const uid = userId as number;
+
+      // F1 (pre-GA): `report` is now block-reachable (PageBlockHost / IframeHost),
+      // and each report files a row AND fires a mod-channel Discord webhook. Every
+      // OTHER shared write op is rate-limited; this one was not — so a trusted user
+      // could loop it into report-table growth + mod-channel flooding. Bound the
+      // per-(user, app) report velocity on its own daily bucket (fail-open, like the
+      // other buckets — the containment is defence-in-depth, not the auth boundary).
+      const rl = await checkSharedReportRateLimit(uid, appBlockId);
+      if (!rl.allowed) {
+        throw new TRPCError({
+          code: 'TOO_MANY_REQUESTS',
+          message: `Too many reports — retry in ${rl.retryAfterSeconds}s`,
+        });
+      }
+
       const pool = requireAppsDb();
       const exists = (
         await pool.query(`SELECT 1 FROM ${schema}.shared_kv WHERE key = $1`, [input.key])
       ).rowCount;
       if (!exists) throw new TRPCError({ code: 'NOT_FOUND', message: 'request not found' });
       const reason = input.reason ?? 'user-report';
-      await insertSharedReport(schema, {
+
+      // F1 dedup: a repeat report of the SAME row by the SAME reporter is a no-op —
+      // no 2nd row, no 2nd webhook, no 2nd alert. `filed` is false when this
+      // (reporter, key) pair already has a report row, and the observability +
+      // mod-notify side effects below are skipped entirely. Only a genuinely-new
+      // report fires them (distinct keys / distinct reporters are unaffected).
+      const filed = await insertUserSharedReportDeduped(schema, {
         key: input.key,
         reporterUserId: uid,
         reason,
       });
+      if (!filed) return { ok: true as const };
 
       // FIX 1 (pre-GA gate 1 — make abuse OBSERVABLE): a user report previously
       // filed a `shared_kv_reports` row that NOTHING reads, so ordinary abuse
@@ -1153,6 +1176,38 @@ async function insertSharedReport(
      VALUES ($1, $2, $3, $4)`,
     [`skr_${newUlid()}`, args.key, args.reporterUserId, args.reason]
   );
+}
+
+/**
+ * F1 — file a USER report row with per-(reporter, key) dedup. A single
+ * conditional INSERT that no-ops when this reporter already has a report row for
+ * this key. Returns true iff a NEW row was filed — the caller then emits the
+ * abuse alert + fires the mod webhook; false on a duplicate (skip both, so a
+ * re-report can't grow the table or re-ping the mod channel).
+ *
+ * `reporter_user_id` and `key` are both non-null on the user-report path (the
+ * subject uid + a validated key), so `WHERE NOT EXISTS` is exact. It is scoped to
+ * the (reporter, key) pair, so it never collides with the auto-report rows
+ * (`key IS NULL`) or another user's report of the same key. NOTE (honest bound):
+ * under two TRULY-simultaneous identical reports READ COMMITTED can admit both —
+ * the per-(user, app) report rate limit is the hard ceiling; this collapses the
+ * common repeat-click / retry case, which is the actual webhook-spam vector.
+ */
+async function insertUserSharedReportDeduped(
+  schema: string,
+  args: { key: string; reporterUserId: number; reason: string }
+): Promise<boolean> {
+  const pool = requireAppsDb();
+  const res = await pool.query(
+    `INSERT INTO ${schema}.shared_kv_reports (id, key, reporter_user_id, reason)
+     SELECT $1, $2, $3, $4
+     WHERE NOT EXISTS (
+       SELECT 1 FROM ${schema}.shared_kv_reports
+       WHERE reporter_user_id = $3 AND key = $2
+     )`,
+    [`skr_${newUlid()}`, args.key, args.reporterUserId, args.reason]
+  );
+  return (res.rowCount ?? 0) > 0;
 }
 
 /**

--- a/src/server/services/apps/migrations/20260708120000_app_blocks_shared_storage.sql
+++ b/src/server/services/apps/migrations/20260708120000_app_blocks_shared_storage.sql
@@ -80,6 +80,11 @@ BEGIN
         created_at timestamptz DEFAULT now() NOT NULL
       )$ddl$, s);
 
+    -- Backfill the F1 dedup-lookup index (non-unique: auto/mod report rows share
+    -- the table). Idempotent; matches storage-provision.service.ts.
+    EXECUTE format(
+      'CREATE INDEX IF NOT EXISTS shared_kv_reports_reporter_key_idx ON %s.shared_kv_reports (reporter_user_id, key)', s);
+
     -- Reuse the existing per-schema kv_quota_trigger() on shared_kv so shared
     -- bytes/rows fold into the same app quota row (created with the schema).
     EXECUTE format('DROP TRIGGER IF EXISTS shared_kv_quota_trg ON %s.shared_kv', s);

--- a/src/server/services/apps/storage-provision.service.ts
+++ b/src/server/services/apps/storage-provision.service.ts
@@ -150,6 +150,13 @@ export const AppStorageProvisioner = {
           created_at timestamptz DEFAULT now() NOT NULL
         )
       `);
+      // Supports the F1 per-(reporter, key) dedup lookup on the USER-report path
+      // (the WHERE NOT EXISTS in insertUserSharedReportDeduped). Non-unique: the
+      // auto/mod report rows share the table and must not be constrained by it.
+      await client.query(
+        `CREATE INDEX IF NOT EXISTS shared_kv_reports_reporter_key_idx
+           ON ${schema}.shared_kv_reports (reporter_user_id, key)`
+      );
 
       // Trigger function — quota row is keyed on app_block_id pulled from
       // session-local `app.current_app_block_id`. tRPC procedures must

--- a/src/server/utils/shared-storage-rate-limit.ts
+++ b/src/server/utils/shared-storage-rate-limit.ts
@@ -39,6 +39,15 @@ export const SHARED_APPEND_RATE_LIMIT_WINDOW_SECONDS = 24 * 60 * 60;
 export const SHARED_VOTE_RATE_LIMIT_MAX = 30;
 export const SHARED_VOTE_RATE_LIMIT_WINDOW_SECONDS = 60;
 
+// REPORT: R reports/day/app/user. A report is a rare, moderator-facing action
+// that files a row AND fires a mod-channel webhook — so unlike votes it is the
+// abuse SURFACE (report-table growth + Discord flooding), not just noise. The
+// per-(reporter, key) dedup collapses re-reports of the SAME row; this daily
+// bucket bounds a flood of DISTINCT-key reports (the residual webhook-spam
+// vector) from a single user. Matches the append daily-window shape.
+export const SHARED_REPORT_RATE_LIMIT_MAX = 20;
+export const SHARED_REPORT_RATE_LIMIT_WINDOW_SECONDS = 24 * 60 * 60;
+
 export type SharedStorageRateLimitResult =
   | { allowed: true }
   | { allowed: false; retryAfterSeconds: number };
@@ -95,5 +104,19 @@ export async function checkSharedVoteRateLimit(
     key,
     SHARED_VOTE_RATE_LIMIT_MAX,
     SHARED_VOTE_RATE_LIMIT_WINDOW_SECONDS
+  );
+}
+
+/** One `report` against the (user, app) daily bucket (own sub-namespace). */
+export async function checkSharedReportRateLimit(
+  userId: number,
+  appBlockId: string
+): Promise<SharedStorageRateLimitResult> {
+  const key =
+    `${REDIS_KEYS.BLOCKS.TOKEN_RATE_LIMIT}:shared-report:${appBlockId}:${userId}` as const;
+  return checkFixedWindow(
+    key,
+    SHARED_REPORT_RATE_LIMIT_MAX,
+    SHARED_REPORT_RATE_LIMIT_WINDOW_SECONDS
   );
 }


### PR DESCRIPTION
Batch D, shared-storage/protocol slice. Four host-side primitives that let apps drop workarounds they only carry because the platform lacked the seam.

## What this does
- **`SAVE_IMAGE` download bridge.** Unverified blocks only get `allow-scripts`/`allow-forms` — no `allow-downloads`, no new-tab — so an in-app download is impossible and every app fell back to copy-URL. The host now brokers the save. Concurrency-capped (3) with a safe-extension guard.
- **`viewerVoted`** on shared-storage reads — kills the double-click-unvote in 3 apps, which currently can't tell whether the viewer already voted. The join rides the existing `votes(key, user_id)` PK (verified: `votes_pkey UNIQUE btree (key, user_id)` on all 15 provisioned `app_*` schemas in prod appsDb — no new index, no drift).
- **`SHARED_REPORT`** — a report path for shared rows. Rate-limited (20/day) + deduped, and the dedup **co-gates the Discord webhook** so a report storm can't fan out to mods.
- **`get(key)`** on shared storage — enables `?g=` deep-links (custom-generators today reconstructs this by listing).

## Security
Adversarial audit found no 🔴. 🟡 F1 (`SHARED_REPORT` unrate-limited) + F2/F4 fixed in `e9053189`; adds `shared_kv_reports_reporter_key_idx` in both the provisioner and the backfill migration. `SAVE_IMAGE` / `get` / `viewerVoted` all held under attack (cross-user isolation, traversal, and the jsdom XHR cap-abort case are covered).

## Testing
⚠️ The host-handler tests (`SAVE_IMAGE` / `SHARED_GET` / `SHARED_REPORT` + the F2 concurrency cap) **typecheck only** locally — NixOS can't run Playwright Chromium, so this PR's preview is the authoritative browser/component run.

Companion SDK PR in `civitai-app-starters` (`zach/batchd-contract-sdk`). Merge host-first, then publish the SDK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)