### PR TITLE
style: satisfy the lint gate on the SAVE_IMAGE files landed by #3474

### DIFF
--- a/src/components/AppBlocks/saveImageDownload.dom.test.ts
+++ b/src/components/AppBlocks/saveImageDownload.dom.test.ts
@@ -76,6 +76,11 @@ beforeEach(() => {
   clickSpy = vi
     .spyOn(HTMLAnchorElement.prototype, 'click')
     .mockImplementation(function (this: HTMLAnchorElement) {
+      // Capturing the spy's RECEIVER is the whole point here — we assert which
+      // <a download> element the bridge actually clicked. `this` is the anchor,
+      // so the alias is intentional, not the accidental closure-capture the rule
+      // guards against.
+      // eslint-disable-next-line @typescript-eslint/no-this-alias
       clickedAnchor = this;
     });
 });

--- a/src/components/AppBlocks/saveImageDownload.test.ts
+++ b/src/components/AppBlocks/saveImageDownload.test.ts
@@ -19,14 +19,21 @@ describe('isAllowedSaveImageUrl (SAVE_IMAGE origin allowlist)', () => {
       )
     ).toBe(true);
     // sanity: the static list is exactly the two known product hosts
-    expect([...CIVITAI_IMAGE_HOSTS].sort()).toEqual(['image.civitai.com', 'orchestration.civitai.com']);
+    expect([...CIVITAI_IMAGE_HOSTS].sort()).toEqual([
+      'image.civitai.com',
+      'orchestration.civitai.com',
+    ]);
   });
 
   it('ALLOWS the configured CDN origin even when not in the static list', () => {
     // A self-hosted / non-prod NEXT_PUBLIC_IMAGE_LOCATION is covered without editing the list.
-    expect(isAllowedSaveImageUrl('https://cdn.example.net/a/b.jpeg', 'https://cdn.example.net')).toBe(true);
+    expect(
+      isAllowedSaveImageUrl('https://cdn.example.net/a/b.jpeg', 'https://cdn.example.net')
+    ).toBe(true);
     // …but only that exact host — a different host is still refused.
-    expect(isAllowedSaveImageUrl('https://other.example.net/a.jpeg', 'https://cdn.example.net')).toBe(false);
+    expect(
+      isAllowedSaveImageUrl('https://other.example.net/a.jpeg', 'https://cdn.example.net')
+    ).toBe(false);
   });
 
   it('REJECTS an arbitrary attacker origin', () => {
@@ -65,7 +72,9 @@ describe('sanitizeDownloadFilename', () => {
 
   it('collapses a duplicated trailing extension, preserving base dots', () => {
     expect(sanitizeDownloadFilename('file.mp4.mp4', 'https://x/y')).toBe('file.mp4');
-    expect(sanitizeDownloadFilename('video-ttget.com.mp4', 'https://x/y')).toBe('video-ttget.com.mp4');
+    expect(sanitizeDownloadFilename('video-ttget.com.mp4', 'https://x/y')).toBe(
+      'video-ttget.com.mp4'
+    );
   });
 
   it('drops path separators / traversal (untrusted block-supplied name)', () => {
@@ -75,9 +84,9 @@ describe('sanitizeDownloadFilename', () => {
   });
 
   it('falls back to the url last segment, then a generic name', () => {
-    expect(sanitizeDownloadFilename(undefined, 'https://image.civitai.com/xG/77/original.jpeg')).toBe(
-      'original.jpeg'
-    );
+    expect(
+      sanitizeDownloadFilename(undefined, 'https://image.civitai.com/xG/77/original.jpeg')
+    ).toBe('original.jpeg');
     expect(sanitizeDownloadFilename(null, 'https://image.civitai.com/')).toBe('download');
     expect(sanitizeDownloadFilename('   ', 'https://image.civitai.com/')).toBe('download');
   });
@@ -135,8 +144,17 @@ describe('enforceImageExtension (F2 safe-extension gate)', () => {
 describe('resolveSaveImageRequest', () => {
   it('parses a url-variant request', () => {
     expect(
-      resolveSaveImageRequest({ requestId: 'r', url: 'https://image.civitai.com/x.jpeg', filename: 'a.png' })
-    ).toEqual({ requestId: 'r', kind: 'url', url: 'https://image.civitai.com/x.jpeg', filename: 'a.png' });
+      resolveSaveImageRequest({
+        requestId: 'r',
+        url: 'https://image.civitai.com/x.jpeg',
+        filename: 'a.png',
+      })
+    ).toEqual({
+      requestId: 'r',
+      kind: 'url',
+      url: 'https://image.civitai.com/x.jpeg',
+      filename: 'a.png',
+    });
   });
 
   it('parses an id-variant request', () => {
@@ -150,23 +168,41 @@ describe('resolveSaveImageRequest', () => {
 
   it('returns kind:invalid when BOTH url and imageId are present', () => {
     expect(
-      resolveSaveImageRequest({ requestId: 'r', url: 'https://image.civitai.com/x.jpeg', imageId: 5 })
+      resolveSaveImageRequest({
+        requestId: 'r',
+        url: 'https://image.civitai.com/x.jpeg',
+        imageId: 5,
+      })
     ).toEqual({ requestId: 'r', kind: 'invalid' });
   });
 
   it('returns kind:invalid when NEITHER url nor imageId is present', () => {
-    expect(resolveSaveImageRequest({ requestId: 'r' })).toEqual({ requestId: 'r', kind: 'invalid' });
+    expect(resolveSaveImageRequest({ requestId: 'r' })).toEqual({
+      requestId: 'r',
+      kind: 'invalid',
+    });
   });
 
   it('rejects a non-positive / non-integer imageId (treated as absent → invalid)', () => {
-    expect(resolveSaveImageRequest({ requestId: 'r', imageId: 0 })).toEqual({ requestId: 'r', kind: 'invalid' });
-    expect(resolveSaveImageRequest({ requestId: 'r', imageId: -3 })).toEqual({ requestId: 'r', kind: 'invalid' });
-    expect(resolveSaveImageRequest({ requestId: 'r', imageId: 1.5 })).toEqual({ requestId: 'r', kind: 'invalid' });
+    expect(resolveSaveImageRequest({ requestId: 'r', imageId: 0 })).toEqual({
+      requestId: 'r',
+      kind: 'invalid',
+    });
+    expect(resolveSaveImageRequest({ requestId: 'r', imageId: -3 })).toEqual({
+      requestId: 'r',
+      kind: 'invalid',
+    });
+    expect(resolveSaveImageRequest({ requestId: 'r', imageId: 1.5 })).toEqual({
+      requestId: 'r',
+      kind: 'invalid',
+    });
   });
 
   it('returns null (drop, uncorrelatable) for a missing/invalid requestId', () => {
     expect(resolveSaveImageRequest({ url: 'https://image.civitai.com/x.jpeg' })).toBeNull();
-    expect(resolveSaveImageRequest({ requestId: '', url: 'https://image.civitai.com/x.jpeg' })).toBeNull();
+    expect(
+      resolveSaveImageRequest({ requestId: '', url: 'https://image.civitai.com/x.jpeg' })
+    ).toBeNull();
     expect(resolveSaveImageRequest(null)).toBeNull();
     expect(resolveSaveImageRequest('nope')).toBeNull();
   });

--- a/src/components/AppBlocks/saveImageDownload.ts
+++ b/src/components/AppBlocks/saveImageDownload.ts
@@ -181,7 +181,9 @@ export type SaveImageRequest =
  * means "drop, no reply" (a missing requestId can't be correlated); a shape that
  * HAS a requestId but is otherwise invalid returns a request the caller NACKs.
  */
-export function resolveSaveImageRequest(raw: unknown): SaveImageRequest | { requestId: string; kind: 'invalid' } | null {
+export function resolveSaveImageRequest(
+  raw: unknown
+): SaveImageRequest | { requestId: string; kind: 'invalid' } | null {
   if (!raw || typeof raw !== 'object') return null;
   const r = raw as { requestId?: unknown; url?: unknown; imageId?: unknown; filename?: unknown };
   if (typeof r.requestId !== 'string' || r.requestId.length === 0) return null;


### PR DESCRIPTION
Follow-up to #3474 (merged). That PR merged with its `ESLint + Prettier (changed files)` check red, so `main` currently carries a lint error and two unformatted files in the code it added. This is the fix, rebased onto post-merge `main`.

- **`no-this-alias`** at `src/components/AppBlocks/saveImageDownload.dom.test.ts:79`. The spy's **receiver** is exactly what the test asserts on (which `<a download>` element the bridge actually clicked), so the alias is intentional, not the accidental closure-capture the rule guards against. Narrowly disabled with a rationale rather than reworked — reworking it would mean changing what the test observes.
- **Prettier** formatting on `saveImageDownload.ts` + `saveImageDownload.test.ts`.

Lint and formatting only — no logic change. `eslint` clean, `prettier --list-different` clean, 23/23 `saveImageDownload` unit tests green.

Context: this fix existed before #3474 merged but didn't make it in — #3474 was merged (and its head ref auto-deleted) while the fix was being pushed, so the commit landed on a recreated branch no longer attached to any PR. Recovered here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)