### PR TITLE
fix(app-listings): surface shadow-revision assets so onsite listing media can be submitted

### DIFF
--- a/src/components/Apps/ListingMediaEditor.tsx
+++ b/src/components/Apps/ListingMediaEditor.tsx
@@ -62,6 +62,22 @@ export function ListingMediaEditor({ appBlockId }: { appBlockId: string }) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [listingId]);
 
+  // 3) Re-pull the projected assets after EVERY successful asset mutation.
+  //
+  // 🔴 The step seeds icon/cover/screenshots in `useState` INITIALISERS only, and the
+  // owning /edit page mounts its tabs with `keepMounted={false}` — so media→manifest→
+  // media UNMOUNTS and REMOUNTS this editor. The query is `staleTime: Infinity` +
+  // `refetchOnWindowFocus: false`, so without an invalidation here the remount re-seeds
+  // from the ORIGINAL cached `assets`: a just-attached icon reads as unattached (Submit
+  // disabled again — the exact symptom this component exists to fix) and a removed
+  // screenshot's stale row id can be "removed" a second time → server error. Only
+  // `handleSubmit` invalidated before. Invalidating (rather than re-keying the step on
+  // shadowId+version) refreshes the cache WITHOUT remounting, so an in-flight upload in
+  // the mounted step is never thrown away.
+  const handleAssetMutated = useCallback(() => {
+    void utils.appListings.getMyListingForApp.invalidate({ appBlockId });
+  }, [utils, appBlockId]);
+
   // Track the asset floor so the submit button matches the server floor gate
   // (icon+cover required; screenshots optional). Submit is deliberately NOT gated on
   // scan completion — the server go-live scan gate is the safety net.
@@ -89,8 +105,23 @@ export function ListingMediaEditor({ appBlockId }: { appBlockId: string }) {
     }
   }
 
-  // FORBIDDEN (non-owner) / NOT_FOUND (no listing) both settle to NotFound.
-  if (listingError) return <NotFound />;
+  // FORBIDDEN (non-owner) / NOT_FOUND (no listing) are the genuine "this isn't yours /
+  // doesn't exist" cases → NotFound.
+  //
+  // 🔴 Anything ELSE must NOT collapse the page. `getMyListingForApp` now resolves the
+  // shadow server-side, so a `beginListingRevision` failure surfaces HERE — and those
+  // are BAD_REQUEST (`INVALID_REVISION`: "cannot edit a listing in status …", "failed to
+  // open a revision draft"). Blanket-NotFound'ing them made the inline alert below —
+  // which exists precisely to explain them — unreachable, and told the owner their live
+  // app didn't exist. Narrow the guard so everything else falls through to that alert.
+  const listingErrorCode = (listingError as { data?: { code?: string } } | null | undefined)?.data
+    ?.code;
+  if (listingError && (listingErrorCode === 'FORBIDDEN' || listingErrorCode === 'NOT_FOUND'))
+    return <NotFound />;
+
+  // The begin-revision failure and the (non-fatal) listing-resolve failure share one
+  // actionable surface.
+  const inlineError = beginError ?? (listingError ? listingError.message : null);
 
   return (
     <Stack gap="lg">
@@ -124,16 +155,19 @@ export function ListingMediaEditor({ appBlockId }: { appBlockId: string }) {
         </Alert>
       )}
 
-      {beginError && (
+      {inlineError && (
         <Alert color="red" variant="light" data-testid="apps-listing-media-begin-error">
-          <Text size="sm">{beginError}</Text>
+          <Text size="sm">{inlineError}</Text>
         </Alert>
       )}
 
       {listingLoading || !listing ? (
-        <Center py="xl">
-          <Loader />
-        </Center>
+        // A settled error is terminal — don't spin forever underneath the alert.
+        inlineError ? null : (
+          <Center py="xl">
+            <Loader />
+          </Center>
+        )
       ) : !shadowId ? (
         <Group gap={8} data-testid="apps-listing-media-preparing">
           <Loader size={16} />
@@ -159,6 +193,7 @@ export function ListingMediaEditor({ appBlockId }: { appBlockId: string }) {
               // there is no seed race.
               initial={listing.assets}
               allowRemove
+              onAssetMutated={handleAssetMutated}
               onCompletenessChange={handleCompletenessChange}
             />
           </div>

--- a/src/components/Apps/ListingMediaEditor.tsx
+++ b/src/components/Apps/ListingMediaEditor.tsx
@@ -125,21 +125,31 @@ export function ListingMediaEditor({ appBlockId }: { appBlockId: string }) {
 
   return (
     <Stack gap="lg">
-      {/* 🔴 Honest, up-front framing — mirrors ExternalListingEditForm's live-app notice. */}
-      <Alert
-        icon={<IconInfoCircle size={16} />}
-        color="blue"
-        variant="light"
-        title="Listing images"
-        data-testid="apps-listing-media-live-notice"
-      >
-        <Text size="sm">
-          This app is <b>live</b> — your image changes are staged as a revision and go live only
-          after a moderator re-approves. Update the icon, cover and screenshots below, then submit
-          for review. Media can be added while it is still scanning; it only goes live once its scan
-          finishes cleanly.
-        </Text>
-      </Alert>
+      {/* 🔴 Honest, up-front framing — mirrors ExternalListingEditForm's live-app notice.
+          Gated on a RESOLVED listing: it asserts "this app is live" and describes an
+          editor that is about to render. When the resolve settled to an error (a
+          `removed` listing, an INTERNAL_SERVER_ERROR, a client error with no
+          `data.code`) nothing below it renders, so an ungated notice put "This app is
+          live" directly above "cannot edit a listing in status removed" — a
+          contradictory half-UI where the pre-narrowing code showed a clean NotFound.
+          The red alert below still surfaces those non-gating errors (that improvement
+          stands); this notice just stops claiming context it doesn't have. */}
+      {listing && !listingError && (
+        <Alert
+          icon={<IconInfoCircle size={16} />}
+          color="blue"
+          variant="light"
+          title="Listing images"
+          data-testid="apps-listing-media-live-notice"
+        >
+          <Text size="sm">
+            This app is <b>live</b> — your image changes are staged as a revision and go live only
+            after a moderator re-approves. Update the icon, cover and screenshots below, then submit
+            for review. Media can be added while it is still scanning; it only goes live once its
+            scan finishes cleanly.
+          </Text>
+        </Alert>
+      )}
 
       {listing?.hasPendingRevision && (
         <Alert

--- a/src/components/Apps/ListingMediaEditor.tsx
+++ b/src/components/Apps/ListingMediaEditor.tsx
@@ -38,8 +38,13 @@ export function ListingMediaEditor({ appBlockId }: { appBlockId: string }) {
 
   const listingId = listing?.appListingId;
 
-  // 2) Begin (or resume) the editable shadow revision — idempotent. Every asset
-  //    mutation the step performs targets the shadow, never the live parent.
+  // 2) Begin (or resume) the editable shadow revision — idempotent, and it returns
+  //    the SAME shadow `getMyListingForApp` already resolved server-side (a parent
+  //    has at most one in-flight shadow), so `listing.assets` below always describes
+  //    exactly this id. Kept as the render gate + the error surface for a listing
+  //    that isn't revisable (a non-approved parent → "only an approved listing can
+  //    be revised"). Every asset mutation the step performs targets the shadow,
+  //    never the live parent.
   const [shadowId, setShadowId] = useState<string | null>(null);
   const [beginError, setBeginError] = useState<string | null>(null);
   const beginRevision = trpc.appListings.beginListingRevision.useMutation();
@@ -143,6 +148,16 @@ export function ListingMediaEditor({ appBlockId }: { appBlockId: string }) {
               listingId={shadowId}
               contentRating={listing.contentRating as OffsiteContentRating}
               suggestions={{}}
+              // 🔴 Prefill from the SHADOW's assets (what `getMyListingForApp`
+              // projects). Without this the step seeded every slot empty, so it
+              // rendered "Icon none / Cover none" for a listing that HAS both and
+              // its publish floor (icon+cover attached) could never be met —
+              // "Submit for review" was permanently disabled and the flow could
+              // not be completed by anyone. The step reads `initial` in its
+              // useState initialisers, and it only mounts once `shadowId` resolves
+              // (the query that carries the assets has long settled by then), so
+              // there is no seed race.
+              initial={listing.assets}
               allowRemove
               onCompletenessChange={handleCompletenessChange}
             />

--- a/src/server/routers/app-listings.router.ts
+++ b/src/server/routers/app-listings.router.ts
@@ -542,8 +542,12 @@ export const appListingsRouter = router({
    * read for the owner-facing on-site listing-media page (`/apps/<appBlockId>/listing`).
    * Returns the `AppListing.id` the page passes to `beginListingRevision` + the asset
    * procs, plus the listing status / content rating / whether a revision is already
-   * under review. Owner-bound in the service; typed failures map via `mapOffsiteError`
-   * (NOT_OWNED→FORBIDDEN, NOT_FOUND when no listing row exists for the app).
+   * under review, AND the EDITABLE target's current assets (`assets` + `shadowId`) so
+   * the media editor can prefill the icon/cover/screenshots it is about to edit and
+   * evaluate its publish floor. Owner-bound in the service (the assets are the
+   * CALLER'S OWN listing only — nothing here is exposed to a public listing DTO);
+   * typed failures map via `mapOffsiteError` (NOT_OWNED→FORBIDDEN, NOT_FOUND when no
+   * listing row exists for the app).
    */
   getMyListingForApp: appDeveloperProcedure
     .meta(listingMediaCliScope)

--- a/src/server/services/blocks/__tests__/offsite-listing.edit-consolidate.service.test.ts
+++ b/src/server/services/blocks/__tests__/offsite-listing.edit-consolidate.service.test.ts
@@ -99,14 +99,37 @@ function editViewRow(ssRowId: string, overrides: Record<string, unknown> = {}) {
 
 /**
  * Route `appListing.findUnique` by `select` shape (owner check vs edit-view) and, for
- * the edit-view, by `where.id` so the shadow's view carries shadow row ids.
+ * the edit-view, by `where.id` so the shadow's view carries shadow row ids. Wired on
+ * BOTH pools: the edit-view read of a SHADOW goes to the PRIMARY (`dbWrite`) — see the
+ * replica-lag test below.
+ *
+ * `replicaLagsOn` makes the REPLICA miss on the given ids while the PRIMARY still
+ * serves them — real replication lag.
  */
-function wireFindUnique(owned: unknown, viewByListingId: Record<string, unknown>) {
-  mockRead.appListing.findUnique.mockImplementation(async (args: unknown) => {
+function wireFindUnique(
+  owned: unknown,
+  viewByListingId: Record<string, unknown>,
+  opts: { replicaLagsOn?: string[] } = {}
+) {
+  const impl = (isReplica: boolean) => async (args: unknown) => {
     const a = args as { select?: Record<string, unknown>; where?: { id?: string } };
-    if ('icon' in (a.select ?? {})) return viewByListingId[a.where?.id ?? ''] ?? null;
+    if ('icon' in (a.select ?? {})) {
+      const id = a.where?.id ?? '';
+      if (isReplica && (opts.replicaLagsOn ?? []).includes(id)) return null;
+      return viewByListingId[id] ?? null;
+    }
     return owned;
-  });
+  };
+  mockRead.appListing.findUnique.mockImplementation(impl(true));
+  mockWrite.appListing.findUnique.mockImplementation(impl(false));
+}
+
+/** The listing ids whose `loadListingEditView` read landed on a given pool. */
+function editViewReads(client: { appListing: { findUnique: { mock: { calls: unknown[][] } } } }) {
+  return client.appListing.findUnique.mock.calls
+    .map(([a]) => a as { select?: Record<string, unknown>; where?: { id?: string } })
+    .filter((a) => 'icon' in (a?.select ?? {}))
+    .map((a) => a.where?.id ?? '');
 }
 
 beforeEach(() => {
@@ -181,10 +204,10 @@ describe('getMyListingForEdit', () => {
     expect(res.hasPendingRevision).toBe(true);
     expect(res.scalars.name).toBe('Vitrine (edited)');
     // 🔴 the edit-view read targeted the SHADOW, and the screenshot rows are the shadow's.
-    const viewCall = mockRead.appListing.findUnique.mock.calls.find(
-      (c) => 'icon' in ((c[0] as { select?: object }).select ?? {})
-    );
-    expect((viewCall?.[0] as { where: { id: string } }).where.id).toBe('apl_shadow_existing');
+    // A shadow is read from the PRIMARY even on the reuse path (`created: false`) — it
+    // may have been minted microseconds ago by another caller. See the lag test below.
+    expect(editViewReads(mockWrite)).toEqual(['apl_shadow_existing']);
+    expect(editViewReads(mockRead)).toEqual([]);
     expect(res.assets.screenshots[0].id).toBe('ss_shadow');
     // slug stays the PUBLIC parent slug.
     expect(res.slug).toBe('vitrine');
@@ -214,11 +237,82 @@ describe('getMyListingForEdit', () => {
     expect(mockWrite.appListing.create).toHaveBeenCalled();
     // 🔴 the returned asset rows are the SHADOW's copies — a removal would target these,
     // never the live parent's row ids.
-    const viewCall = mockRead.appListing.findUnique.mock.calls.find(
-      (c) => 'icon' in ((c[0] as { select?: object }).select ?? {})
-    );
-    expect((viewCall?.[0] as { where: { id: string } }).where.id).toBe('apl_shadow_created');
+    expect(editViewReads(mockWrite)).toEqual(['apl_shadow_created']);
+    expect(editViewReads(mockRead)).toEqual([]);
     expect(res.assets.screenshots[0].id).toBe('ss_shadow_new');
+  });
+
+  // -------------------------------------------------------------------------
+  // 🔴 READ-AFTER-WRITE (the `getMyListingForEdit` half of the same guard).
+  // The shadow is INSERTed on the PRIMARY; reading it back off the replica misses
+  // under replication lag → `loadListingEditView` throws NOT_FOUND → tRPC NOT_FOUND
+  // → the edit UI's query is `retry: false`, so the whole editor collapses. The
+  // routing predicate is "the target is a SHADOW", not "this call created it" —
+  // `created: false` only means someone ELSE minted it (the media editor's own
+  // client-side `beginListingRevision`, a second tab), which is just as likely to be
+  // microseconds old. Both branches are pinned below.
+  // -------------------------------------------------------------------------
+
+  it('🔴 a FRESHLY-CREATED shadow the replica lacks still resolves (reads the PRIMARY)', async () => {
+    wireFindUnique(
+      ownedRow({ status: 'approved' }),
+      {
+        apl_parent: editViewRow('ss_parent'),
+        apl_shadow_created: editViewRow('ss_shadow_new'),
+      },
+      // INSERTed on the primary this instant — the replica has not received it.
+      { replicaLagsOn: ['apl_shadow_created'] }
+    );
+    mockRead.appListing.findFirst.mockResolvedValue(null);
+    mockWrite.appListing.findFirst
+      .mockResolvedValueOnce(null)
+      .mockResolvedValue({ id: 'apl_shadow_created' });
+
+    // Routed to the replica this REJECTS with NOT_FOUND instead of resolving.
+    const res = await getMyListingForEdit({ listingId: 'apl_parent', userId: 7 });
+
+    expect(res.shadowId).toBe('apl_shadow_created');
+    expect(res.assets.screenshots[0].id).toBe('ss_shadow_new');
+    expect(editViewReads(mockWrite)).toEqual(['apl_shadow_created']);
+    expect(editViewReads(mockRead)).toEqual([]);
+  });
+
+  it('🔴 a REUSED shadow the replica lacks still resolves — `created: false` is not a visibility claim', async () => {
+    wireFindUnique(
+      ownedRow({ status: 'approved' }),
+      {
+        apl_parent: editViewRow('ss_parent'),
+        apl_shadow_existing: editViewRow('ss_shadow'),
+      },
+      // A concurrent request minted the shadow microseconds ago; it is on the primary
+      // but has not replicated. `beginListingRevision` reports created:FALSE.
+      { replicaLagsOn: ['apl_shadow_existing'] }
+    );
+    // The idempotency probe reads the replica and misses; the in-tx re-check on the
+    // primary finds the concurrent winner → no create, created:false.
+    mockRead.appListing.findFirst.mockResolvedValue(null);
+    mockWrite.appListing.findFirst.mockResolvedValue({ id: 'apl_shadow_existing' });
+
+    const res = await getMyListingForEdit({ listingId: 'apl_parent', userId: 7 });
+
+    expect(res.shadowId).toBe('apl_shadow_existing');
+    expect(mockWrite.appListing.create).not.toHaveBeenCalled();
+    // The shadow's own rows — never a silent fallback to the live parent's.
+    expect(res.assets.screenshots[0].id).toBe('ss_shadow');
+    expect(editViewReads(mockWrite)).toEqual(['apl_shadow_existing']);
+    expect(editViewReads(mockRead)).toEqual([]);
+  });
+
+  it('an IN-PLACE (non-shadow) target stays on the REPLICA — not a blanket primary redirect', async () => {
+    wireFindUnique(ownedRow({ status: 'draft' }), { apl_parent: editViewRow('ss_parent') });
+
+    const res = await getMyListingForEdit({ listingId: 'apl_parent', userId: 7 });
+
+    expect(res.shadowId).toBeNull();
+    // Nothing was written, so nothing needs the primary — the steady-state read load
+    // must stay on the replica pool.
+    expect(editViewReads(mockRead)).toEqual(['apl_parent']);
+    expect(editViewReads(mockWrite)).toEqual([]);
   });
 
   it('rejects a non-owner (NOT_OWNED)', async () => {

--- a/src/server/services/blocks/__tests__/offsite-listing.get-my-listing-for-app.service.test.ts
+++ b/src/server/services/blocks/__tests__/offsite-listing.get-my-listing-for-app.service.test.ts
@@ -109,25 +109,45 @@ function editViewRow(ssRowId: string, overrides: Record<string, unknown> = {}) {
 }
 
 /**
- * Route `appListing.findUnique` by call shape:
+ * Route `appListing.findUnique` by call shape, on BOTH pools:
  *   - `where.appBlockId`   → the entry resolve (id/userId/status/contentRating)
  *   - `select` has `icon`  → `loadListingEditView`, keyed by `where.id`
  *   - otherwise            → the owner/editable load (`beginListingRevision`)
+ *
+ * `replicaLagsOn` makes the REPLICA miss on the given ids while the PRIMARY still
+ * serves them — i.e. real replication lag, the condition that decides whether the
+ * create path is correct.
  */
 function wireFindUnique(opts: {
   entry: unknown;
   owned?: unknown;
   viewByListingId?: Record<string, unknown>;
+  /** Ids the replica has not received yet (a row INSERTed microseconds ago). */
+  replicaLagsOn?: string[];
 }) {
-  mockRead.appListing.findUnique.mockImplementation(async (args: unknown) => {
+  const impl = (isReplica: boolean) => async (args: unknown) => {
     const a = args as {
       select?: Record<string, unknown>;
       where?: { id?: string; appBlockId?: string };
     };
     if (a.where?.appBlockId != null) return opts.entry;
-    if ('icon' in (a.select ?? {})) return opts.viewByListingId?.[a.where?.id ?? ''] ?? null;
+    if ('icon' in (a.select ?? {})) {
+      const id = a.where?.id ?? '';
+      if (isReplica && (opts.replicaLagsOn ?? []).includes(id)) return null;
+      return opts.viewByListingId?.[id] ?? null;
+    }
     return opts.owned ?? null;
-  });
+  };
+  mockRead.appListing.findUnique.mockImplementation(impl(true));
+  mockWrite.appListing.findUnique.mockImplementation(impl(false));
+}
+
+/** The listing ids whose `loadListingEditView` read landed on a given pool. */
+function editViewReads(client: { appListing: { findUnique: { mock: { calls: unknown[][] } } } }) {
+  return client.appListing.findUnique.mock.calls
+    .map(([a]) => a as { select?: Record<string, unknown>; where?: { id?: string } })
+    .filter((a) => 'icon' in (a?.select ?? {}))
+    .map((a) => a.where?.id ?? '');
 }
 
 beforeEach(() => {
@@ -307,5 +327,61 @@ describe('getMyListingForApp', () => {
     // No shadow was opened for a draft (beginListingRevision would reject it anyway).
     expect(mockWrite.appListing.create).not.toHaveBeenCalled();
     expect(res.assets.screenshots.map((s) => s.id)).toEqual(['apls_OWN']);
+    // Nothing was written, so nothing needs the primary.
+    expect(editViewReads(mockRead)).toEqual(['apl_onsite']);
+    expect(editViewReads(mockWrite)).toEqual([]);
+  });
+
+  // -------------------------------------------------------------------------
+  // 🔴 READ-AFTER-WRITE: the shadow is INSERTed on the PRIMARY, so on the CREATE
+  // path it must be read back from the primary. Reading it off the replica
+  // microseconds later misses under lag → `loadListingEditView` throws NOT_FOUND →
+  // tRPC NOT_FOUND → the editor's query is `retry: false` and it renders <NotFound/>.
+  // That lands on the owner's VERY FIRST visit to the media tab — the exact flow
+  // this proc's asset projection exists to make usable.
+  // -------------------------------------------------------------------------
+
+  it('🔴 reads a FRESHLY-CREATED shadow from the PRIMARY, not the lagging replica', async () => {
+    wireFindUnique({
+      entry: { id: 'apl_onsite', userId: OWNER, status: 'approved', contentRating: 'pg13' },
+      owned: ownedRow(),
+      viewByListingId: {
+        apl_onsite: editViewRow('apls_PARENT'),
+        apl_new_1: editViewRow('apls_FRESH_SHADOW'),
+      },
+      // The shadow was INSERTed on the primary this instant — the replica misses it.
+      replicaLagsOn: ['apl_new_1'],
+    });
+    mockRead.appListing.findFirst.mockResolvedValue(null);
+    mockWrite.appListing.findFirst
+      .mockResolvedValueOnce(null)
+      .mockResolvedValue({ id: 'apl_new_1' });
+
+    // Routed to the replica this REJECTS with NOT_FOUND instead of resolving.
+    const res = await getMyListingForApp({ appBlockId: 'my-block', userId: OWNER });
+
+    expect(res.shadowId).toBe('apl_new_1');
+    expect(res.assets.screenshots.map((s) => s.id)).toEqual(['apls_FRESH_SHADOW']);
+    // …and it got there by reading the PRIMARY, never the replica.
+    expect(editViewReads(mockWrite)).toEqual(['apl_new_1']);
+    expect(editViewReads(mockRead)).toEqual([]);
+  });
+
+  it('🔴 a REUSED (pre-existing) shadow still reads from the REPLICA — not a blanket primary redirect', async () => {
+    wireFindUnique({
+      entry: { id: 'apl_onsite', userId: OWNER, status: 'approved', contentRating: 'pg13' },
+      owned: ownedRow(),
+      viewByListingId: { apl_shadow: editViewRow('apls_shadow') },
+    });
+    // An in-flight shadow already exists → `beginListingRevision` returns created:false.
+    mockRead.appListing.findFirst.mockResolvedValue({ id: 'apl_shadow' });
+
+    const res = await getMyListingForApp({ appBlockId: 'my-block', userId: OWNER });
+
+    expect(res.shadowId).toBe('apl_shadow');
+    // The steady state is the overwhelming majority of these reads; sending them all
+    // to the primary would move real read load off the replica pool for no benefit.
+    expect(editViewReads(mockRead)).toEqual(['apl_shadow']);
+    expect(editViewReads(mockWrite)).toEqual([]);
   });
 });

--- a/src/server/services/blocks/__tests__/offsite-listing.get-my-listing-for-app.service.test.ts
+++ b/src/server/services/blocks/__tests__/offsite-listing.get-my-listing-for-app.service.test.ts
@@ -7,53 +7,158 @@ import {
 
 /**
  * `getMyListingForApp` — the owner-gated `appBlockId` → `AppListing.id` resolver
- * for the on-site listing-media owner page. Covers the three contract branches:
- *   - owner happy-path → `{ appListingId, status, contentRating, hasPendingRevision }`
+ * for the on-site listing-media owner page. Covers the contract branches:
+ *   - owner happy-path → `{ appListingId, status, contentRating, hasPendingRevision,
+ *     shadowId, assets }`
  *   - a listing owned by ANOTHER user → NOT_OWNED (router maps → FORBIDDEN)
  *   - no listing row for the app → NOT_FOUND
  * plus the pending-revision flag (a queued shadow-revision request flips it true).
  *
- * DB is fully mocked — no real Prisma. Only the two reads the function makes are
- * stubbed (`appListing.findUnique`, `appListingPublishRequest.findFirst`).
+ * 🔴 REGRESSION GUARD — the media editor's asset PROJECTION. The proc used to
+ * return only `{ id, userId, status, contentRating }`, so the editor had no way to
+ * see the icon/cover it was about to edit: every slot rendered "none", its publish
+ * floor (icon+cover attached) could never be met, and "Submit for review" was
+ * permanently disabled — the on-site listing-media flow was uncompletable for
+ * everyone. The tests below pin that the proc projects the assets the editor's floor
+ * check needs, and that they come from the SHADOW revision (the editable target),
+ * never the live parent — returning the parent's `AppListingScreenshot` row ids
+ * would let a "remove screenshot" delete a row off the LIVE listing, bypassing
+ * moderator review.
+ *
+ * DB is fully mocked — no real Prisma. `getEdgeUrl` + the id generators are stubbed.
  */
 
-const { mockRead } = vi.hoisted(() => ({
-  mockRead: {
+const { mockRead, mockWrite, seq } = vi.hoisted(() => {
+  const makeClient = () => ({
     appListing: {
       findUnique: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
+      findFirst: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
+      create: vi.fn(async (args: { data: unknown }) => args.data),
+      update: vi.fn(async (args: { data: unknown }) => args.data),
+    },
+    appListingScreenshot: {
+      findMany: vi.fn(async (..._a: unknown[]): Promise<unknown[]> => []),
+      createMany: vi.fn(async (..._a: unknown[]) => ({ count: 0 })),
     },
     appListingPublishRequest: {
       findFirst: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
     },
-  },
-}));
+  });
+  const mockRead = makeClient();
+  const mockWrite = makeClient() as ReturnType<typeof makeClient> & {
+    $transaction: ReturnType<typeof vi.fn>;
+  };
+  mockWrite.$transaction = vi.fn(async (cb: (tx: unknown) => Promise<unknown>) => cb(mockWrite));
+  return { mockRead, mockWrite, seq: { n: 0 } };
+});
 
-vi.mock('~/server/db/client', () => ({ dbRead: mockRead, dbWrite: mockRead }));
+vi.mock('~/server/db/client', () => ({ dbRead: mockRead, dbWrite: mockWrite }));
+vi.mock('~/client-utils/cf-images-utils', () => ({ getEdgeUrl: (url: string) => `edge:${url}` }));
+vi.mock('~/server/utils/app-block-ids', () => ({
+  newAppListingId: () => `apl_new_${++seq.n}`,
+  newAppListingPublishRequestId: () => `alpr_new_${++seq.n}`,
+  newAppListingScreenshotId: () => `apls_new_${++seq.n}`,
+  newUlid: () => `ULID${++seq.n}`,
+}));
 
 const OWNER = 42;
 const OTHER = 99;
 
+/** The `editableListingSelect` shape `beginListingRevision` loads the parent with. */
+function ownedRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'apl_onsite',
+    kind: 'onsite',
+    slug: 'my-app',
+    status: 'approved',
+    userId: OWNER,
+    revisionOfId: null,
+    name: 'My App',
+    tagline: null,
+    description: null,
+    category: null,
+    contentRating: 'pg13',
+    externalUrl: null,
+    connectClientId: null,
+    connectRequestedScopes: null,
+    connectScopeJustifications: null,
+    iconId: 137918008,
+    coverId: 137918011,
+    ...overrides,
+  };
+}
+
+/** The `loadListingEditView` shape. `ssRowId` marks WHOSE screenshot rows these are. */
+function editViewRow(ssRowId: string, overrides: Record<string, unknown> = {}) {
+  return {
+    name: 'My App',
+    tagline: null,
+    description: null,
+    category: null,
+    contentRating: 'pg13',
+    externalUrl: null,
+    connectRequestedScopes: null,
+    connectScopeJustifications: null,
+    iconId: 137918008,
+    coverId: 137918011,
+    icon: { url: 'icon-key' },
+    cover: { url: 'cover-key' },
+    screenshots: [{ id: ssRowId, imageId: 30, order: 0, caption: null, image: { url: 'shot-key' } }],
+    ...overrides,
+  };
+}
+
+/**
+ * Route `appListing.findUnique` by call shape:
+ *   - `where.appBlockId`   → the entry resolve (id/userId/status/contentRating)
+ *   - `select` has `icon`  → `loadListingEditView`, keyed by `where.id`
+ *   - otherwise            → the owner/editable load (`beginListingRevision`)
+ */
+function wireFindUnique(opts: {
+  entry: unknown;
+  owned?: unknown;
+  viewByListingId?: Record<string, unknown>;
+}) {
+  mockRead.appListing.findUnique.mockImplementation(async (args: unknown) => {
+    const a = args as {
+      select?: Record<string, unknown>;
+      where?: { id?: string; appBlockId?: string };
+    };
+    if (a.where?.appBlockId != null) return opts.entry;
+    if ('icon' in (a.select ?? {})) return opts.viewByListingId?.[a.where?.id ?? ''] ?? null;
+    return opts.owned ?? null;
+  });
+}
+
 beforeEach(() => {
-  mockRead.appListing.findUnique.mockReset().mockResolvedValue(null);
-  mockRead.appListingPublishRequest.findFirst.mockReset().mockResolvedValue(null);
+  vi.clearAllMocks();
+  seq.n = 0;
+  mockRead.appListing.findUnique.mockResolvedValue(null);
+  mockRead.appListing.findFirst.mockResolvedValue(null);
+  mockRead.appListingScreenshot.findMany.mockResolvedValue([]);
+  mockRead.appListingPublishRequest.findFirst.mockResolvedValue(null);
+  mockWrite.appListing.findFirst.mockResolvedValue(null);
+  mockWrite.appListingScreenshot.findMany.mockResolvedValue([]);
 });
 
 describe('getMyListingForApp', () => {
   it('owner happy-path → returns the listing id + status + rating (no pending revision)', async () => {
-    mockRead.appListing.findUnique.mockResolvedValue({
-      id: 'apl_onsite',
-      userId: OWNER,
-      status: 'approved',
-      contentRating: 'pg13',
+    wireFindUnique({
+      entry: { id: 'apl_onsite', userId: OWNER, status: 'approved', contentRating: 'pg13' },
+      owned: ownedRow(),
+      viewByListingId: { apl_shadow: editViewRow('apls_shadow') },
     });
+    // An in-flight shadow already exists → beginListingRevision reuses it.
+    mockRead.appListing.findFirst.mockResolvedValue({ id: 'apl_shadow' });
 
     const res = await getMyListingForApp({ appBlockId: 'my-block', userId: OWNER });
 
-    expect(res).toEqual({
+    expect(res).toMatchObject({
       appListingId: 'apl_onsite',
       status: 'approved',
       contentRating: 'pg13',
       hasPendingRevision: false,
+      shadowId: 'apl_shadow',
     });
     // Resolved by the @unique appBlockId, not by id.
     expect(mockRead.appListing.findUnique).toHaveBeenCalledWith(
@@ -62,12 +167,12 @@ describe('getMyListingForApp', () => {
   });
 
   it('flags hasPendingRevision when a shadow-revision request is already queued', async () => {
-    mockRead.appListing.findUnique.mockResolvedValue({
-      id: 'apl_onsite',
-      userId: OWNER,
-      status: 'approved',
-      contentRating: 'g',
+    wireFindUnique({
+      entry: { id: 'apl_onsite', userId: OWNER, status: 'approved', contentRating: 'g' },
+      owned: ownedRow({ contentRating: 'g' }),
+      viewByListingId: { apl_shadow: editViewRow('apls_shadow') },
     });
+    mockRead.appListing.findFirst.mockResolvedValue({ id: 'apl_shadow' });
     mockRead.appListingPublishRequest.findFirst.mockResolvedValue({ id: 'alpr_pending' });
 
     const res = await getMyListingForApp({ appBlockId: 'my-block', userId: OWNER });
@@ -85,16 +190,13 @@ describe('getMyListingForApp', () => {
   });
 
   it('a listing owned by another user → NOT_OWNED', async () => {
-    mockRead.appListing.findUnique.mockResolvedValue({
-      id: 'apl_onsite',
-      userId: OTHER,
-      status: 'approved',
-      contentRating: 'g',
+    wireFindUnique({
+      entry: { id: 'apl_onsite', userId: OTHER, status: 'approved', contentRating: 'g' },
     });
 
-    await expect(getMyListingForApp({ appBlockId: 'my-block', userId: OWNER })).rejects.toMatchObject(
-      { name: 'OffsiteRequestError', code: 'NOT_OWNED' }
-    );
+    await expect(
+      getMyListingForApp({ appBlockId: 'my-block', userId: OWNER })
+    ).rejects.toMatchObject({ name: 'OffsiteRequestError', code: 'NOT_OWNED' });
     // Never probes the revision request once ownership fails.
     expect(mockRead.appListingPublishRequest.findFirst).not.toHaveBeenCalled();
   });
@@ -105,5 +207,105 @@ describe('getMyListingForApp', () => {
     const err = await getMyListingForApp({ appBlockId: 'ghost', userId: OWNER }).catch((e) => e);
     expect(err).toBeInstanceOf(OffsiteRequestError);
     expect(err.code).toBe('NOT_FOUND');
+  });
+
+  // -------------------------------------------------------------------------
+  // 🔴 The asset projection — what makes the media editor's Submit button usable.
+  // -------------------------------------------------------------------------
+
+  it('projects the editable target’s icon/cover/screenshots so the editor’s publish floor can be met', async () => {
+    wireFindUnique({
+      entry: { id: 'apl_onsite', userId: OWNER, status: 'approved', contentRating: 'pg13' },
+      owned: ownedRow(),
+      viewByListingId: { apl_shadow: editViewRow('apls_shadow') },
+    });
+    mockRead.appListing.findFirst.mockResolvedValue({ id: 'apl_shadow' });
+
+    const res = await getMyListingForApp({ appBlockId: 'my-block', userId: OWNER });
+
+    // The editor seeds an icon/cover slot as ATTACHED iff `imageId != null`, and its
+    // floor is `icon.attached && cover.attached`. A result without these fields is
+    // exactly the "Icon none / Cover none → Submit permanently disabled" bug.
+    expect(res.assets.icon.imageId).toBe(137918008);
+    expect(res.assets.cover.imageId).toBe(137918011);
+    const meetsPublishFloor = res.assets.icon.imageId != null && res.assets.cover.imageId != null;
+    expect(meetsPublishFloor).toBe(true);
+    // Edge-resolved preview URLs (so the attached slots render a thumbnail).
+    expect(res.assets.icon.url).toBe('edge:icon-key');
+    expect(res.assets.cover.url).toBe('edge:cover-key');
+    expect(res.assets.screenshots).toHaveLength(1);
+    expect(res.assets.screenshots[0]).toMatchObject({ imageId: 30, url: 'edge:shot-key' });
+  });
+
+  it('🔴 reads the assets from the SHADOW revision, never the live parent (reused shadow)', async () => {
+    wireFindUnique({
+      entry: { id: 'apl_onsite', userId: OWNER, status: 'approved', contentRating: 'pg13' },
+      owned: ownedRow(),
+      viewByListingId: {
+        // Distinct rows per listing id so we can tell WHICH one was read.
+        apl_onsite: editViewRow('apls_PARENT', { iconId: 1, icon: { url: 'parent-icon' } }),
+        apl_shadow: editViewRow('apls_SHADOW', { iconId: 2, icon: { url: 'shadow-icon' } }),
+      },
+    });
+    mockRead.appListing.findFirst.mockResolvedValue({ id: 'apl_shadow' });
+
+    const res = await getMyListingForApp({ appBlockId: 'my-block', userId: OWNER });
+
+    expect(res.shadowId).toBe('apl_shadow');
+    expect(res.assets.icon.imageId).toBe(2);
+    expect(res.assets.icon.url).toBe('edge:shadow-icon');
+    // The screenshot ROW ids are the shadow's — removing one must never touch the
+    // live listing's rows.
+    expect(res.assets.screenshots.map((s) => s.id)).toEqual(['apls_SHADOW']);
+    // And the edit-view read targeted the shadow, not the parent.
+    expect(mockRead.appListing.findUnique).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: 'apl_shadow' },
+        select: expect.objectContaining({ icon: expect.anything() }),
+      })
+    );
+  });
+
+  it('🔴 creates the shadow when none exists yet and reads THAT one (first entry)', async () => {
+    wireFindUnique({
+      entry: { id: 'apl_onsite', userId: OWNER, status: 'approved', contentRating: 'pg13' },
+      owned: ownedRow(),
+      viewByListingId: {
+        apl_onsite: editViewRow('apls_PARENT'),
+        // beginListingRevision mints `apl_new_1` (stubbed id gen, first call).
+        apl_new_1: editViewRow('apls_FRESH_SHADOW'),
+      },
+    });
+    // No shadow yet: the read probe and the in-transaction race re-check both miss,
+    // then the post-transaction "winner" re-read returns the row we just created.
+    mockRead.appListing.findFirst.mockResolvedValue(null);
+    mockWrite.appListing.findFirst
+      .mockResolvedValueOnce(null)
+      .mockResolvedValue({ id: 'apl_new_1' });
+
+    const res = await getMyListingForApp({ appBlockId: 'my-block', userId: OWNER });
+
+    expect(mockWrite.appListing.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ revisionOfId: 'apl_onsite', status: 'draft' }),
+      })
+    );
+    expect(res.shadowId).toBe('apl_new_1');
+    expect(res.assets.screenshots.map((s) => s.id)).toEqual(['apls_FRESH_SHADOW']);
+  });
+
+  it('a NON-approved listing has no shadow — assets come from the listing itself', async () => {
+    wireFindUnique({
+      entry: { id: 'apl_onsite', userId: OWNER, status: 'draft', contentRating: 'g' },
+      owned: ownedRow({ status: 'draft' }),
+      viewByListingId: { apl_onsite: editViewRow('apls_OWN') },
+    });
+
+    const res = await getMyListingForApp({ appBlockId: 'my-block', userId: OWNER });
+
+    expect(res.shadowId).toBeNull();
+    // No shadow was opened for a draft (beginListingRevision would reject it anyway).
+    expect(mockWrite.appListing.create).not.toHaveBeenCalled();
+    expect(res.assets.screenshots.map((s) => s.id)).toEqual(['apls_OWN']);
   });
 });

--- a/src/server/services/blocks/__tests__/offsite-listing.get-my-listing-for-app.service.test.ts
+++ b/src/server/services/blocks/__tests__/offsite-listing.get-my-listing-for-app.service.test.ts
@@ -115,8 +115,8 @@ function editViewRow(ssRowId: string, overrides: Record<string, unknown> = {}) {
  *   - otherwise            → the owner/editable load (`beginListingRevision`)
  *
  * `replicaLagsOn` makes the REPLICA miss on the given ids while the PRIMARY still
- * serves them — i.e. real replication lag, the condition that decides whether the
- * create path is correct.
+ * serves them — i.e. real replication lag, the condition that decides whether a
+ * shadow read is routed correctly (on BOTH the create and the reuse path).
  */
 function wireFindUnique(opts: {
   entry: unknown;
@@ -277,13 +277,15 @@ describe('getMyListingForApp', () => {
     // The screenshot ROW ids are the shadow's — removing one must never touch the
     // live listing's rows.
     expect(res.assets.screenshots.map((s) => s.id)).toEqual(['apls_SHADOW']);
-    // And the edit-view read targeted the shadow, not the parent.
-    expect(mockRead.appListing.findUnique).toHaveBeenCalledWith(
+    // And the edit-view read targeted the shadow, not the parent (on the primary —
+    // a shadow is always read there; see the read-after-write block below).
+    expect(mockWrite.appListing.findUnique).toHaveBeenCalledWith(
       expect.objectContaining({
         where: { id: 'apl_shadow' },
         select: expect.objectContaining({ icon: expect.anything() }),
       })
     );
+    expect(editViewReads(mockRead)).toEqual([]);
   });
 
   it('🔴 creates the shadow when none exists yet and reads THAT one (first entry)', async () => {
@@ -333,12 +335,15 @@ describe('getMyListingForApp', () => {
   });
 
   // -------------------------------------------------------------------------
-  // 🔴 READ-AFTER-WRITE: the shadow is INSERTed on the PRIMARY, so on the CREATE
-  // path it must be read back from the primary. Reading it off the replica
-  // microseconds later misses under lag → `loadListingEditView` throws NOT_FOUND →
-  // tRPC NOT_FOUND → the editor's query is `retry: false` and it renders <NotFound/>.
-  // That lands on the owner's VERY FIRST visit to the media tab — the exact flow
-  // this proc's asset projection exists to make usable.
+  // 🔴 READ-AFTER-WRITE: a SHADOW is INSERTed on the PRIMARY, so ANY read of one
+  // goes back to the primary — the predicate is "the target is a shadow", NOT
+  // "this call created it". `created: false` says only that another caller minted
+  // it, which here is routinely microseconds ago and in a different request (the
+  // editor's own client-side `beginListingRevision`, `getMyListingForEdit`, a second
+  // tab). Reading a shadow off the replica misses under lag → `loadListingEditView`
+  // throws NOT_FOUND → tRPC NOT_FOUND → the editor's query is `retry: false` and it
+  // renders <NotFound/>, discarding the editor and any in-flight upload. The client
+  // invalidates on every asset mutation, so the exposure is per-mutation.
   // -------------------------------------------------------------------------
 
   it('🔴 reads a FRESHLY-CREATED shadow from the PRIMARY, not the lagging replica', async () => {
@@ -367,7 +372,7 @@ describe('getMyListingForApp', () => {
     expect(editViewReads(mockRead)).toEqual([]);
   });
 
-  it('🔴 a REUSED (pre-existing) shadow still reads from the REPLICA — not a blanket primary redirect', async () => {
+  it('🔴 a REUSED (pre-existing) shadow ALSO reads from the PRIMARY — `created` is not a visibility claim', async () => {
     wireFindUnique({
       entry: { id: 'apl_onsite', userId: OWNER, status: 'approved', contentRating: 'pg13' },
       owned: ownedRow(),
@@ -379,9 +384,41 @@ describe('getMyListingForApp', () => {
     const res = await getMyListingForApp({ appBlockId: 'my-block', userId: OWNER });
 
     expect(res.shadowId).toBe('apl_shadow');
-    // The steady state is the overwhelming majority of these reads; sending them all
-    // to the primary would move real read load off the replica pool for no benefit.
-    expect(editViewReads(mockRead)).toEqual(['apl_shadow']);
-    expect(editViewReads(mockWrite)).toEqual([]);
+    // The routing predicate is "the target is a SHADOW", not "I inserted it". `created:
+    // false` only says another caller minted it — which in this flow is routinely
+    // microseconds ago and in a different request (the editor's own client-side
+    // `beginListingRevision`, `getMyListingForEdit`, a second tab). Only shadow reads
+    // move to the primary; the in-place draft/pending read below stays on the replica.
+    expect(editViewReads(mockWrite)).toEqual(['apl_shadow']);
+    expect(editViewReads(mockRead)).toEqual([]);
+  });
+
+  it('🔴 a REUSED shadow the replica has NOT caught up on still returns its assets (no NOT_FOUND)', async () => {
+    wireFindUnique({
+      entry: { id: 'apl_onsite', userId: OWNER, status: 'approved', contentRating: 'pg13' },
+      owned: ownedRow(),
+      viewByListingId: {
+        apl_onsite: editViewRow('apls_PARENT'),
+        apl_shadow: editViewRow('apls_SHADOW'),
+      },
+      // The shadow exists on the PRIMARY (a concurrent request minted it microseconds
+      // ago) but has not replicated yet. `beginListingRevision` reports created:FALSE.
+      replicaLagsOn: ['apl_shadow'],
+    });
+    // The idempotency probe reads the replica, misses, and the in-tx re-check on the
+    // primary finds the concurrent winner → returns { created: false }.
+    mockRead.appListing.findFirst.mockResolvedValue(null);
+    mockWrite.appListing.findFirst.mockResolvedValue({ id: 'apl_shadow' });
+
+    // Routed by `created` this reads the lagging replica → NOT_FOUND → the editor
+    // renders <NotFound /> (retry:false) and the in-flight upload is discarded.
+    const res = await getMyListingForApp({ appBlockId: 'my-block', userId: OWNER });
+
+    expect(res.shadowId).toBe('apl_shadow');
+    expect(res.assets.screenshots.map((s) => s.id)).toEqual(['apls_SHADOW']);
+    expect(editViewReads(mockWrite)).toEqual(['apl_shadow']);
+    expect(editViewReads(mockRead)).toEqual([]);
+    // And it never fell back to the live parent's rows.
+    expect(mockWrite.appListing.create).not.toHaveBeenCalled();
   });
 });

--- a/src/server/services/blocks/offsite-listing.service.ts
+++ b/src/server/services/blocks/offsite-listing.service.ts
@@ -1271,15 +1271,27 @@ export type GetMyListingForEditResult = {
 };
 
 /** Load a listing's scalars + current assets (edge-resolved URLs) + connect scope
- *  snapshot for edit prefill. */
-async function loadListingEditView(listingId: string): Promise<{
+ *  snapshot for edit prefill.
+ *
+ * 🔴 READ-AFTER-WRITE: defaults to the REPLICA (`dbRead`) — correct for the steady
+ * state, where the row was written long ago. A caller that JUST created the row it is
+ * about to read (`beginListingRevision(...).created === true` mints the shadow on the
+ * PRIMARY microseconds earlier) MUST pass `dbWrite`: the replica has not received the
+ * INSERT yet, the `findUnique` misses, and this throws NOT_FOUND → tRPC NOT_FOUND →
+ * the editor renders `<NotFound />` (its query has `retry: false`) on the owner's very
+ * FIRST visit. Same hazard the screenshot re-pack guards against in
+ * `app-listing-assets.service.ts`. Do NOT route the steady-state read to the primary. */
+async function loadListingEditView(
+  listingId: string,
+  db: typeof dbRead = dbRead
+): Promise<{
   scalars: ListingEditScalars;
   assets: GetMyListingForEditResult['assets'];
   connectRequestedScopes: number | null;
   connectScopeJustifications: Record<string, string> | null;
 }> {
   const { getEdgeUrl } = await import('~/client-utils/cf-images-utils');
-  const row = (await dbRead.appListing.findUnique({
+  const row = (await db.appListing.findUnique({
     where: { id: listingId },
     select: {
       name: true,
@@ -1422,10 +1434,14 @@ export async function getMyListingForEdit(opts: {
   let effectiveId = listingId;
   let shadowId: string | null = null;
   let hasPendingRevision = false;
+  // See `getMyListingForApp` / `loadListingEditView`: a shadow minted on the primary
+  // this instant is not on the replica yet, so read it back from the primary.
+  let createdShadow = false;
   if (listing.status === 'approved') {
     const begun = await beginListingRevision({ listingId, userId });
     shadowId = begun.shadowId;
     effectiveId = begun.shadowId;
+    createdShadow = begun.created;
     const pendingRevisionReq = await dbRead.appListingPublishRequest.findFirst({
       where: {
         status: 'pending',
@@ -1439,7 +1455,7 @@ export async function getMyListingForEdit(opts: {
     hasPendingRevision = !!pendingRevisionReq;
   }
 
-  const view = await loadListingEditView(effectiveId);
+  const view = await loadListingEditView(effectiveId, createdShadow ? dbWrite : dbRead);
 
   // Resolve the connect client's CURRENT allowedScopes — this is the derived
   // requested-scope set the edit form displays read-only + re-submits (the server
@@ -1551,12 +1567,18 @@ export async function getMyListingForApp(opts: {
   // edited in place, so it is its own effective target.
   let effectiveId = listing.id;
   let shadowId: string | null = null;
+  // 🔴 True when the shadow was INSERTed on the primary just now → read it back from
+  // the primary. Reading a microseconds-old row off the replica misses under lag and
+  // throws NOT_FOUND, which the editor renders as `<NotFound />` on the owner's very
+  // first visit to the media tab (its query is `retry: false`). See loadListingEditView.
+  let createdShadow = false;
   if (listing.status === 'approved') {
     const begun = await beginListingRevision({ listingId: listing.id, userId });
     shadowId = begun.shadowId;
     effectiveId = begun.shadowId;
+    createdShadow = begun.created;
   }
-  const { assets } = await loadListingEditView(effectiveId);
+  const { assets } = await loadListingEditView(effectiveId, createdShadow ? dbWrite : dbRead);
 
   return {
     appListingId: listing.id,

--- a/src/server/services/blocks/offsite-listing.service.ts
+++ b/src/server/services/blocks/offsite-listing.service.ts
@@ -1478,6 +1478,28 @@ export type GetMyListingForAppResult = {
   contentRating: string;
   /** Whether a shadow-revision publish request is already under review for this listing. */
   hasPendingRevision: boolean;
+  /**
+   * The in-progress SHADOW revision id for an APPROVED parent (resolved server-side,
+   * idempotently — the same id the client's `beginListingRevision` returns), else
+   * `null`. Mirrors `GetMyListingForEditResult.shadowId`.
+   */
+  shadowId: string | null;
+  /**
+   * The EDITABLE target's current assets, edge-resolved — icon / cover / screenshots.
+   *
+   * 🔴 These are the assets of the EFFECTIVE edit target: the SHADOW's rows for an
+   * approved parent, the listing's own rows otherwise. NEVER the live parent's rows
+   * when a shadow exists — the media editor mutates + floor-checks exactly what it
+   * is handed, so returning the parent's `AppListingScreenshot` ids here would let a
+   * "remove screenshot" delete a row from the LIVE served listing, bypassing
+   * moderator review. Same rule (and the same server-side shadow resolution) as
+   * `getMyListingForEdit`.
+   */
+  assets: {
+    icon: ListingEditAsset;
+    cover: ListingEditAsset;
+    screenshots: ListingEditScreenshot[];
+  };
 };
 
 /**
@@ -1489,6 +1511,15 @@ export type GetMyListingForAppResult = {
  * under review. Owner-bound: a listing owned by another user → NOT_OWNED
  * (→FORBIDDEN); no listing row for the app → NOT_FOUND. Kind-agnostic (works for
  * both on-site and off-site listings — the on-site owner UI is the first caller).
+ *
+ * ALSO projects the EDITABLE target's current `assets` (+ its `shadowId`). Without
+ * them the media editor had no way to see the icon/cover it is about to edit: it
+ * rendered every slot as "none" and its publish-floor check (icon+cover attached)
+ * could never be satisfied, so "Submit for review" stayed permanently disabled —
+ * the whole on-site listing-media flow was uncompletable. The assets come from the
+ * EFFECTIVE source (an approved parent's shadow, resolved here server-side and
+ * idempotently, exactly as `getMyListingForEdit` does — see the 🔴 note on
+ * `GetMyListingForAppResult.assets` for why the shadow's rows and not the parent's).
  */
 export async function getMyListingForApp(opts: {
   appBlockId: string;
@@ -1512,6 +1543,21 @@ export async function getMyListingForApp(opts: {
     where: { status: 'pending', appListing: { revisionOfId: listing.id } },
     select: { id: true },
   });
+
+  // Resolve the EFFECTIVE edit target before reading assets. For an approved parent
+  // that is the shadow revision — created/reused here (idempotent) so the asset rows
+  // the client receives are ALWAYS the shadow's, never the live listing's. A
+  // non-approved listing (draft / pending / rejected / removed) has no shadow and is
+  // edited in place, so it is its own effective target.
+  let effectiveId = listing.id;
+  let shadowId: string | null = null;
+  if (listing.status === 'approved') {
+    const begun = await beginListingRevision({ listingId: listing.id, userId });
+    shadowId = begun.shadowId;
+    effectiveId = begun.shadowId;
+  }
+  const { assets } = await loadListingEditView(effectiveId);
+
   return {
     appListingId: listing.id,
     status: listing.status,
@@ -1519,6 +1565,8 @@ export async function getMyListingForApp(opts: {
     // threshold is always defined.
     contentRating: listing.contentRating ?? 'g',
     hasPendingRevision: !!pendingRevisionReq,
+    shadowId,
+    assets,
   };
 }
 

--- a/src/server/services/blocks/offsite-listing.service.ts
+++ b/src/server/services/blocks/offsite-listing.service.ts
@@ -1273,14 +1273,24 @@ export type GetMyListingForEditResult = {
 /** Load a listing's scalars + current assets (edge-resolved URLs) + connect scope
  *  snapshot for edit prefill.
  *
- * 🔴 READ-AFTER-WRITE: defaults to the REPLICA (`dbRead`) — correct for the steady
- * state, where the row was written long ago. A caller that JUST created the row it is
- * about to read (`beginListingRevision(...).created === true` mints the shadow on the
- * PRIMARY microseconds earlier) MUST pass `dbWrite`: the replica has not received the
- * INSERT yet, the `findUnique` misses, and this throws NOT_FOUND → tRPC NOT_FOUND →
- * the editor renders `<NotFound />` (its query has `retry: false`) on the owner's very
- * FIRST visit. Same hazard the screenshot re-pack guards against in
- * `app-listing-assets.service.ts`. Do NOT route the steady-state read to the primary. */
+ * 🔴 READ-AFTER-WRITE: defaults to the REPLICA (`dbRead`) — correct only for a row that
+ * was written long ago. A caller reading a SHADOW revision MUST pass `dbWrite`.
+ *
+ * The predicate is "is the target a shadow?", NOT "did I just create it".
+ * `beginListingRevision(...).created === false` means only that *this* call did not do
+ * the INSERT — it says NOTHING about whether the replica has the row. The shadow is
+ * minted on the PRIMARY by whoever got there first, and in this flow that is routinely
+ * microseconds earlier and in a DIFFERENT request: the media editor fires its own
+ * client-side `beginListingRevision` mutation on mount, `getMyListingForEdit` mints one
+ * for the same parent, a second tab does either. So a `created === false` read off the
+ * replica misses under lag exactly like a `created === true` one: the `findUnique`
+ * returns null, this throws NOT_FOUND → tRPC NOT_FOUND → the editor renders
+ * `<NotFound />` (its query has `retry: false`), discarding the whole editor including
+ * any in-flight upload. Because the client invalidates on every asset mutation, that is
+ * once per mutation, not once per page load.
+ *
+ * Same hazard the screenshot re-pack guards against in `app-listing-assets.service.ts`.
+ * Do NOT route a non-shadow (in-place draft/pending) read to the primary. */
 async function loadListingEditView(
   listingId: string,
   db: typeof dbRead = dbRead
@@ -1434,14 +1444,10 @@ export async function getMyListingForEdit(opts: {
   let effectiveId = listingId;
   let shadowId: string | null = null;
   let hasPendingRevision = false;
-  // See `getMyListingForApp` / `loadListingEditView`: a shadow minted on the primary
-  // this instant is not on the replica yet, so read it back from the primary.
-  let createdShadow = false;
   if (listing.status === 'approved') {
     const begun = await beginListingRevision({ listingId, userId });
     shadowId = begun.shadowId;
     effectiveId = begun.shadowId;
-    createdShadow = begun.created;
     const pendingRevisionReq = await dbRead.appListingPublishRequest.findFirst({
       where: {
         status: 'pending',
@@ -1455,7 +1461,10 @@ export async function getMyListingForEdit(opts: {
     hasPendingRevision = !!pendingRevisionReq;
   }
 
-  const view = await loadListingEditView(effectiveId, createdShadow ? dbWrite : dbRead);
+  // 🔴 READ-AFTER-WRITE — same rule as `getMyListingForApp`: a SHADOW target is read
+  // from the PRIMARY (it may have been minted microseconds ago by ANY caller), an
+  // in-place target from the replica. See `loadListingEditView`.
+  const view = await loadListingEditView(effectiveId, effectiveId !== listingId ? dbWrite : dbRead);
 
   // Resolve the connect client's CURRENT allowedScopes — this is the derived
   // requested-scope set the edit form displays read-only + re-submits (the server
@@ -1567,18 +1576,23 @@ export async function getMyListingForApp(opts: {
   // edited in place, so it is its own effective target.
   let effectiveId = listing.id;
   let shadowId: string | null = null;
-  // 🔴 True when the shadow was INSERTed on the primary just now → read it back from
-  // the primary. Reading a microseconds-old row off the replica misses under lag and
-  // throws NOT_FOUND, which the editor renders as `<NotFound />` on the owner's very
-  // first visit to the media tab (its query is `retry: false`). See loadListingEditView.
-  let createdShadow = false;
   if (listing.status === 'approved') {
     const begun = await beginListingRevision({ listingId: listing.id, userId });
     shadowId = begun.shadowId;
     effectiveId = begun.shadowId;
-    createdShadow = begun.created;
   }
-  const { assets } = await loadListingEditView(effectiveId, createdShadow ? dbWrite : dbRead);
+  // 🔴 READ-AFTER-WRITE: read a SHADOW back from the PRIMARY — always, not just when
+  // THIS call inserted it. See the `loadListingEditView` doc: `created === false` only
+  // means "someone else minted it", which is routinely microseconds ago (the editor's
+  // own client-side `beginListingRevision` mutation, a second tab, `getMyListingForEdit`),
+  // so `created` is not a statement about replica visibility. A shadow read that misses
+  // on the replica throws NOT_FOUND → tRPC NOT_FOUND → `<NotFound />` (`retry: false`),
+  // discarding the editor mid-upload. Every non-shadow target (draft/pending edited in
+  // place) is old and stays on the replica.
+  const { assets } = await loadListingEditView(
+    effectiveId,
+    effectiveId !== listing.id ? dbWrite : dbRead
+  );
 
   return {
     appListingId: listing.id,

--- a/src/tests/pages/apps/listing-media-page.browser.test.tsx
+++ b/src/tests/pages/apps/listing-media-page.browser.test.tsx
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { page, userEvent } from 'vitest/browser';
 // `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
@@ -5,17 +6,24 @@ import { renderWithProviders } from '../../../../test/component-setup';
 import { useRouter } from 'next/router';
 
 /**
- * On-site listing-media OWNER page (`/apps/<appBlockId>/listing`) — route-shell
- * render test (browser mode, report-only in Tekton).
+ * On-site listing-media OWNER editor (`ListingMediaEditor`, the "Listing media" tab of
+ * `/apps/<appBlockId>/edit`) — render test (browser mode, report-only in Tekton).
  *
  * Asserts the client wiring: it resolves `appBlockId` → `appListingId`
  * (`getMyListingForApp`), begins the editable shadow revision
  * (`beginListingRevision`), re-hosts the reused `ListingAssetStep` against the
- * SHADOW id + the listing's content rating, surfaces the honest live-app framing
- * copy (+ the pending-revision notice when applicable), and fires
+ * SHADOW id + the listing's content rating, prefills it from the SHADOW's assets,
+ * re-pulls the projection after an asset mutation, surfaces the honest live-app
+ * framing copy (+ the pending-revision notice when applicable), and fires
  * `submitListingRevision({ shadowId })` from the Submit-for-review button. The
  * asset step itself is stubbed — its real behaviour is covered by
  * `ListingAssetStep.browser.test.tsx`.
+ *
+ * 🔴 This file used to import the default export of `~/pages/apps/[appBlockId]/listing`.
+ * That route is now a getServerSideProps REDIRECT stub whose default export renders
+ * `<NotFound />` and nothing else, so every test here rendered an empty not-found div
+ * and asserted nothing — a structurally dead suite that still reported green. It now
+ * targets the real component the route redirects to. Keep it pointed at a COMPONENT.
  */
 
 const state = vi.hoisted(() => ({
@@ -44,12 +52,6 @@ const state = vi.hoisted(() => ({
   flags: { appBlocks: true } as Record<string, boolean>,
 }));
 
-// The page's `getServerSideProps` calls createServerSideProps at module top — stub
-// it so importing the page in a browser test doesn't pull the server graph.
-vi.mock('~/server/utils/server-side-helpers', () => ({
-  createServerSideProps: () => async () => ({ props: {} }),
-}));
-
 vi.mock('~/providers/FeatureFlagsProvider', () => ({
   useFeatureFlags: () => state.flags,
 }));
@@ -57,7 +59,6 @@ vi.mock('~/providers/FeatureFlagsProvider', () => ({
 vi.mock('~/components/AppLayout/NotFound', () => ({
   NotFound: () => <div data-testid="not-found">Not found</div>,
 }));
-vi.mock('~/components/Meta/Meta', () => ({ Meta: () => null }));
 vi.mock('~/utils/notifications', () => ({
   showSuccessNotification: vi.fn(),
   showErrorNotification: vi.fn(),
@@ -70,14 +71,22 @@ vi.mock('~/components/Apps/ListingAssetStep', () => ({
     listingId: string;
     contentRating: string;
     initial?: { icon: { imageId: number | null }; cover: { imageId: number | null } };
+    onAssetMutated?: () => void;
     onCompletenessChange?: (s: { meetsFloor: boolean; complete: boolean }) => void;
   }) => {
     state.assetProps.last = props;
     // Mirror the real step: report the floor state up so the page can gate submit.
-    props.onCompletenessChange?.(state.floor);
+    // In an EFFECT, not during render — the real step reports from an effect, and
+    // calling the parent's setState mid-render trips React's cross-component warning.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    useEffect(() => props.onCompletenessChange?.(state.floor), []);
     return (
       <div data-testid="asset-step">
         assets:{props.listingId}:{props.contentRating}
+        {/* Stands in for a successful attach/remove inside the real step. */}
+        <button type="button" data-testid="asset-step-mutate" onClick={() => props.onAssetMutated?.()}>
+          mutate
+        </button>
       </div>
     );
   },
@@ -115,7 +124,10 @@ vi.mock('~/utils/trpc', () => ({
   },
 }));
 
-const ListingMediaPage = (await import('~/pages/apps/[appBlockId]/listing')).default;
+// 🔴 The REAL editor component — NOT the `/apps/[appBlockId]/listing` route module,
+// which is now a redirect stub that only ever renders <NotFound />.
+const { ListingMediaEditor } = await import('~/components/Apps/ListingMediaEditor');
+const ListingMediaPage = () => <ListingMediaEditor appBlockId="my-block" />;
 
 function setRouterQuery(query: Record<string, string>) {
   const router = (useRouter as unknown as () => { query: Record<string, string> })();
@@ -223,9 +235,44 @@ describe('ListingMediaPage — owner listing-media route shell', () => {
   });
 
   test('fails closed to NotFound when the owner resolve errors (non-owner / missing listing)', async () => {
-    state.query = { data: undefined, isLoading: false, error: { message: 'FORBIDDEN' } };
+    state.query = {
+      data: undefined,
+      isLoading: false,
+      error: { message: 'you can only manage your own listings', data: { code: 'FORBIDDEN' } },
+    };
     renderWithProviders(<ListingMediaPage />);
     await expect.element(page.getByTestId('not-found')).toBeInTheDocument();
     expect(page.getByTestId('asset-step').elements()).toHaveLength(0);
+  });
+
+  test('a NON-owner-gating error surfaces the inline alert instead of collapsing to NotFound', async () => {
+    // `getMyListingForApp` now resolves the shadow server-side, so an INVALID_REVISION
+    // ("cannot edit a listing in status …") arrives here as BAD_REQUEST. Blanket-
+    // NotFound'ing it hid the one surface that explains it and told the owner their
+    // LIVE app did not exist.
+    state.query = {
+      data: undefined,
+      isLoading: false,
+      error: { message: 'cannot edit a listing in status removed', data: { code: 'BAD_REQUEST' } },
+    };
+    renderWithProviders(<ListingMediaPage />);
+    const alert = page.getByTestId('apps-listing-media-begin-error');
+    await expect.element(alert).toBeInTheDocument();
+    await expect.element(alert).toHaveTextContent(/cannot edit a listing in status removed/i);
+    expect(page.getByTestId('not-found').elements()).toHaveLength(0);
+  });
+
+  test('re-pulls the projected assets after an asset mutation (stale-prefill guard)', async () => {
+    renderWithProviders(<ListingMediaPage />);
+    await expect.element(page.getByTestId('asset-step')).toBeInTheDocument();
+    expect(state.invalidate).not.toHaveBeenCalled();
+
+    // The step reports a successful attach/remove.
+    await userEvent.click(page.getByTestId('asset-step-mutate'));
+
+    // Without this the cached `assets` stay pre-mutation and the /edit page's
+    // `keepMounted={false}` tab round-trip re-seeds the step from them — a just-
+    // attached icon reads as unattached and Submit goes disabled again.
+    await vi.waitFor(() => expect(state.invalidate).toHaveBeenCalledWith({ appBlockId: 'my-block' }));
   });
 });

--- a/src/tests/pages/apps/listing-media-page.browser.test.tsx
+++ b/src/tests/pages/apps/listing-media-page.browser.test.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { page, userEvent } from 'vitest/browser';
 // `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
@@ -75,6 +75,11 @@ vi.mock('~/components/Apps/ListingAssetStep', () => ({
     onCompletenessChange?: (s: { meetsFloor: boolean; complete: boolean }) => void;
   }) => {
     state.assetProps.last = props;
+    // Mirror the real step's seeding EXACTLY: it reads `initial` in its useState
+    // INITIALISERS, so what it shows is whatever `initial` held at MOUNT — a mere
+    // re-render never re-seeds it, only a remount does. That is what makes the tab
+    // round-trip below an end-to-end assertion instead of a prop-passthrough one.
+    const [seededIcon] = useState(() => props.initial?.icon.imageId ?? null);
     // Mirror the real step: report the floor state up so the page can gate submit.
     // In an EFFECT, not during render — the real step reports from an effect, and
     // calling the parent's setState mid-render trips React's cross-component warning.
@@ -83,6 +88,7 @@ vi.mock('~/components/Apps/ListingAssetStep', () => ({
     return (
       <div data-testid="asset-step">
         assets:{props.listingId}:{props.contentRating}
+        <span data-testid="asset-step-seeded-icon">{String(seededIcon ?? 'none')}</span>
         {/* Stands in for a successful attach/remove inside the real step. */}
         <button type="button" data-testid="asset-step-mutate" onClick={() => props.onAssetMutated?.()}>
           mutate
@@ -129,6 +135,25 @@ vi.mock('~/utils/trpc', () => ({
 const { ListingMediaEditor } = await import('~/components/Apps/ListingMediaEditor');
 const ListingMediaPage = () => <ListingMediaEditor appBlockId="my-block" />;
 
+/**
+ * Stands in for the owning `/apps/[appBlockId]/edit` page's tab shell, which mounts
+ * its panels with `keepMounted={false}`: leaving the media tab and coming back
+ * genuinely UNMOUNTS and REMOUNTS the editor while the page itself stays put. The key
+ * bump reproduces that inside one render tree (a manual `unmount()` fights the
+ * scaffold's auto-`cleanup()` and blanks the following test's container).
+ */
+function TabRoundTrip() {
+  const [mountKey, setMountKey] = useState(0);
+  return (
+    <>
+      <button type="button" data-testid="tab-round-trip" onClick={() => setMountKey((n) => n + 1)}>
+        leave and re-enter the media tab
+      </button>
+      <ListingMediaEditor key={mountKey} appBlockId="my-block" />
+    </>
+  );
+}
+
 function setRouterQuery(query: Record<string, string>) {
   const router = (useRouter as unknown as () => { query: Record<string, string> })();
   router.query = query;
@@ -156,7 +181,11 @@ beforeEach(() => {
   state.submit = { calls: [], pending: false };
   state.floor = { meetsFloor: true, complete: false };
   state.assetProps.last = null;
-  state.invalidate.mockClear();
+  // mockRESET, not mockClear: a per-test `mockImplementation` (the round-trip test
+  // publishes a post-attach projection through it) otherwise leaks into every later
+  // test in the file.
+  state.invalidate.mockReset();
+  state.invalidate.mockResolvedValue(undefined);
   state.flags = { appBlocks: true };
   setRouterQuery({ appBlockId: 'my-block' });
 });
@@ -274,5 +303,70 @@ describe('ListingMediaPage — owner listing-media route shell', () => {
     // `keepMounted={false}` tab round-trip re-seeds the step from them — a just-
     // attached icon reads as unattached and Submit goes disabled again.
     await vi.waitFor(() => expect(state.invalidate).toHaveBeenCalledWith({ appBlockId: 'my-block' }));
+  });
+
+  test('a re-attached icon survives a tab round-trip: the REMOUNT re-seeds from the refreshed assets', async () => {
+    // Start below the floor — the shadow has no icon yet.
+    const before = {
+      icon: { imageId: null as number | null, url: null as string | null },
+      cover: { imageId: 137918011, url: 'edge:cover' },
+      screenshots: [] as unknown[],
+    };
+    state.query = {
+      data: {
+        appListingId: 'apl_onsite',
+        status: 'approved',
+        contentRating: 'pg13',
+        hasPendingRevision: false,
+        shadowId: 'apl_shadow',
+        assets: before,
+      },
+      isLoading: false,
+      error: null,
+    };
+    // The real `invalidate` refetches `getMyListingForApp`; stand in for that refetch
+    // by publishing the post-attach projection the server would now return.
+    state.invalidate.mockImplementation(async () => {
+      (state.query.data as { assets: typeof before }).assets = {
+        ...before,
+        icon: { imageId: 555, url: 'edge:new-icon' },
+      };
+    });
+
+    renderWithProviders(<TabRoundTrip />);
+    await expect.element(page.getByTestId('asset-step-seeded-icon')).toHaveTextContent('none');
+
+    // The step reports a successful icon attach.
+    await userEvent.click(page.getByTestId('asset-step-mutate'));
+    await vi.waitFor(() =>
+      expect(state.invalidate).toHaveBeenCalledWith({ appBlockId: 'my-block' })
+    );
+
+    // media → manifest → media: the editor UNMOUNTS and REMOUNTS, and the step re-runs
+    // its useState INITIALISERS against whatever `initial` holds now.
+    await userEvent.click(page.getByTestId('tab-round-trip'));
+
+    // Without the post-mutation invalidation the remount re-seeds from the ORIGINAL
+    // cached assets: the just-attached icon reads as unattached, the publish floor is
+    // unmet and Submit goes disabled again — the exact symptom this fix exists to kill.
+    await expect.element(page.getByTestId('asset-step-seeded-icon')).toHaveTextContent('555');
+  });
+
+  test('a settled error does NOT also claim "this app is live" (no contradictory half-UI)', async () => {
+    // A `removed` listing, an INTERNAL_SERVER_ERROR, or a client error with no
+    // `data.code` all land here. Narrowing the NotFound guard (so the inline alert is
+    // reachable) must not leave the blue live-app notice asserting context that never
+    // resolved — "This app is live" directly above "cannot edit a listing in status
+    // removed".
+    state.query = {
+      data: undefined,
+      isLoading: false,
+      error: { message: 'cannot edit a listing in status removed', data: { code: 'BAD_REQUEST' } },
+    };
+    renderWithProviders(<ListingMediaPage />);
+
+    await expect.element(page.getByTestId('apps-listing-media-begin-error')).toBeInTheDocument();
+    expect(page.getByTestId('apps-listing-media-live-notice').elements()).toHaveLength(0);
+    expect(page.getByTestId('asset-step').elements()).toHaveLength(0);
   });
 });

--- a/src/tests/pages/apps/listing-media-page.browser.test.tsx
+++ b/src/tests/pages/apps/listing-media-page.browser.test.tsx
@@ -30,7 +30,13 @@ const state = vi.hoisted(() => ({
   // submitListingRevision — captured args.
   submit: { calls: [] as unknown[], pending: false },
   // Props the stubbed ListingAssetStep received.
-  assetProps: { last: null as null | { listingId: string; contentRating: string } },
+  assetProps: {
+    last: null as null | {
+      listingId: string;
+      contentRating: string;
+      initial?: { icon: { imageId: number | null }; cover: { imageId: number | null } };
+    },
+  },
   // Floor state the stubbed step reports up via onCompletenessChange (drives the
   // submit button's disabled binding). Default meets-floor so the happy paths click.
   floor: { meetsFloor: true, complete: false },
@@ -63,6 +69,7 @@ vi.mock('~/components/Apps/ListingAssetStep', () => ({
   ListingAssetStep: (props: {
     listingId: string;
     contentRating: string;
+    initial?: { icon: { imageId: number | null }; cover: { imageId: number | null } };
     onCompletenessChange?: (s: { meetsFloor: boolean; complete: boolean }) => void;
   }) => {
     state.assetProps.last = props;
@@ -117,7 +124,19 @@ function setRouterQuery(query: Record<string, string>) {
 
 beforeEach(() => {
   state.query = {
-    data: { appListingId: 'apl_onsite', status: 'approved', contentRating: 'pg13', hasPendingRevision: false },
+    data: {
+      appListingId: 'apl_onsite',
+      status: 'approved',
+      contentRating: 'pg13',
+      hasPendingRevision: false,
+      shadowId: 'apl_shadow',
+      // The SHADOW's assets — what the proc now projects so the step can prefill.
+      assets: {
+        icon: { imageId: 137918008, url: 'edge:icon' },
+        cover: { imageId: 137918011, url: 'edge:cover' },
+        screenshots: [],
+      },
+    },
     isLoading: false,
     error: null,
   };
@@ -139,6 +158,18 @@ describe('ListingMediaPage — owner listing-media route shell', () => {
     await expect.element(page.getByTestId('asset-step')).toHaveTextContent('assets:apl_shadow:pg13');
     expect(state.assetProps.last).toMatchObject({ listingId: 'apl_shadow', contentRating: 'pg13' });
     expect(page.getByTestId('not-found').elements()).toHaveLength(0);
+  });
+
+  test('prefills the asset step with the SHADOW revision assets the proc projects', async () => {
+    renderWithProviders(<ListingMediaPage />);
+
+    await expect.element(page.getByTestId('asset-step')).toBeInTheDocument();
+    // Without this prop the step seeded every slot empty → "Icon none / Cover none"
+    // → the publish floor could never be met → Submit stayed permanently disabled.
+    expect(state.assetProps.last?.initial).toMatchObject({
+      icon: { imageId: 137918008 },
+      cover: { imageId: 137918011 },
+    });
   });
 
   test('surfaces the honest live-app framing copy', async () => {


### PR DESCRIPTION
## Root cause

The **Listing media** tab of `/apps/<appBlockId>/edit` renders "Icon **none** / Cover **none**" and *"Add an icon and cover to publish."* even when the listing has both — so **"Submit for review" is permanently disabled and nobody can complete the flow.**

It is a **server-side projection gap**, not a client render race.

`appListings.getMyListingForApp` returns only this (captured live from the browser):

```json
{"appListingId":"apl_01KWFP4FEEJRWN27CJA49CDY4Q","status":"approved","contentRating":"g","hasPendingRevision":false}
```

because its select in `src/server/services/blocks/offsite-listing.service.ts` was:

```ts
const listing = await dbRead.appListing.findUnique({
  where: { appBlockId },
  select: { id: true, userId: true, status: true, contentRating: true },
});
```

— no `iconId`, no `coverId`, no screenshots. `ListingMediaEditor` then rendered `ListingAssetStep` with **no `initial` prop**, so every slot seeded from `assetFromInitial(undefined)` → `emptyAsset` (`status: 'idle'` → the "none" text), and the step's publish floor

```ts
const meetsFloor = icon.status === 'attached' && cover.status === 'attached';
```

could never become true. The editor binds `disabled={!meetsFloor}` on Submit, so the button was dead on arrival. The page makes exactly two tRPC calls — `getMyListingForApp` and `beginListingRevision` — and **no asset query at all**.

The underlying data was never wrong: the shadow revision the page opens correctly inherits the parent's assets (`beginListingRevision` clones `iconId`/`coverId` and copies each screenshot row). The client just had no way to see it.

## The fix and why this shape

`getMyListingForApp` now projects the **editable target's** `assets` (icon / cover / screenshots, edge-resolved) plus its `shadowId`, and the client passes them straight through as `ListingAssetStep`'s `initial`.

Crucially, it resolves an approved parent's shadow **server-side** (the idempotent `beginListingRevision`) and reads the assets from *that* — which is the exact shape `getMyListingForEdit` already uses, adopted for the exact reason documented there:

> 🔴 SECURITY (do not weaken): the edit UI mutates the EFFECTIVE listing's asset ROWS. For an approved listing those MUST be the shadow's — NEVER the live parent's. If the prefill returned the parent's `AppListingScreenshot` ids […] a "remove screenshot" on the first edit would delete the row from the LIVE served listing, bypassing moderator review.

So the floor check and every mutation now read/write the **shadow** — the editable target — never the live parent. The alternative (have the client fetch assets for the shadow after `beginListingRevision` returns) was rejected: the existing `appListings.getAssets` proc returns no preview URLs, sits behind a different gate, and adds a round-trip plus a seed race against `ListingAssetStep`'s `useState` initialisers.

Security posture is unchanged. `getMyListingForApp` is an `appDeveloperProcedure` that already throws `NOT_OWNED` → FORBIDDEN for someone else's listing, so the assets returned are only ever the caller's own. No public listing DTO gains asset fields.

## Follow-up commit — four defects found by an adversarial audit of this PR

### 1. 🔴 Read-after-write against the read replica (a prod bug this PR itself introduced)

Resolving the shadow server-side means `getMyListingForApp` now **writes** (`beginListingRevision` INSERTs the shadow on `dbWrite`/primary) and then **reads it back** through `loadListingEditView`, which read `dbRead` — a genuinely separate replica pool.

On the **create** path the row is microseconds old. Under replication lag the `findUnique` misses → `loadListingEditView` throws `OffsiteRequestError('NOT_FOUND')` → the router maps it to tRPC `NOT_FOUND` → the editor's query is `retry: false`, so `if (listingError) return <NotFound />` fires. **The owner would get a blank "Not found" page on their very first visit to the media tab** — exactly the flow this PR exists to unblock. Only a reload recovered.

`loadListingEditView` now takes a db client (defaulting to `dbRead`) and both callers pass `dbWrite` **only** when `beginListingRevision` reports `created: true`. The steady state (shadow already existed) and every non-approved listing stay on the replica — this is deliberately *not* a blanket redirect of reads to the primary.

The identical latent instance in **`getMyListingForEdit`** (same begin-then-read-replica shape, pre-existing) is fixed in the same commit — it is the same one-line call site through the same helper.

### 2. 🟡 The browser test was structurally dead — and the previous "Chromium doesn't run locally" claim was wrong

The earlier revision of this PR blamed the browser suite's failures on the environment. **That was incorrect and is retracted.** Chromium runs fine locally (`PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH=/run/current-system/sw/bin/brave`).

The real cause: `src/tests/pages/apps/listing-media-page.browser.test.tsx` imported the **default export of `~/pages/apps/[appBlockId]/listing`** — and #3393 (already on `main`) converted that route into a `getServerSideProps` **redirect stub** whose default export renders `<NotFound />` and nothing else. So every test rendered an empty not-found div. Measured on this branch before the fix: **8 of 9 failing**, the only "pass" being the fails-closed-to-NotFound test, which passed vacuously. The "prefills the asset step with the SHADOW revision assets" coverage this PR advertised **did not exist**.

Repointed at the real `ListingMediaEditor` component. The stubbed step now reports completeness from an effect instead of during render (it was tripping React's cross-component setState warning once the parent became real). Suite is now **11/11 passing** (9 revived + 2 new).

This suite is in the report-only `component` project, so it was never a merge gate — but the PR claimed the coverage, so it now actually exists.

### 3. 🟡 Stale prefill on tab re-entry re-created the very symptom being fixed

`ListingAssetStep` seeds icon/cover/screenshots in `useState` **initialisers only**, and `/apps/[appBlockId]/edit` mounts its tabs with `keepMounted={false}` — so manifest → media → manifest → media **unmounts and remounts** the editor. The query is `staleTime: Infinity` + `refetchOnWindowFocus: false`, and no asset mutation invalidated `getMyListingForApp` (only `handleSubmit` did), so the remount re-seeded from the **original cached** assets:

- a just-attached icon read as unattached → **Submit disabled again**, the exact bug this PR fixes;
- a removed screenshot's stale row id could be "removed" a second time → server error.

The editor now passes `onAssetMutated` and invalidates `getMyListingForApp` on every successful asset mutation. Invalidating (rather than re-keying the step on `shadowId + version`) refreshes the cache **without remounting**, so an in-flight upload in the mounted step is never discarded.

### 4. 🟡 Error collapse hid the actionable alert

With the shadow now resolved inside `getMyListingForApp`, a `beginListingRevision` failure surfaces as the *listing query's* error. `INVALID_REVISION` maps to `BAD_REQUEST`, so the blanket `if (listingError) return <NotFound />` told the owner their **live** app did not exist, and made the dedicated inline alert — which exists precisely to explain those errors — unreachable.

The guard is narrowed to `FORBIDDEN` / `NOT_FOUND` (the genuine "not yours / doesn't exist" cases). Everything else falls through to the inline alert, which now carries the message.

## Sibling claim: `hasPendingRevision: false` with a draft shadow present

**Correct as-is — not a second bug, left alone.** The flag is driven by a *pending `AppListingPublishRequest`*, not by shadow existence. A shadow opened but never submitted has no publish request, so `false` is right, and it matches the UI copy it gates ("A revision of this app is already under review"). Deliberately unchanged.

## Impact

The owner UI shipped in #3384 and appears never to have been driven to completion. All 6 first-party onsite apps sit at **0 screenshots**, and there are **three abandoned shadow drafts** from three separate attempts on three different apps — the signature of people starting a revision, hitting a dead Submit, and giving up.

## What I tested

- **Regression coverage in the BLOCKING `unit` project** (`src/server/services/blocks/__tests__/offsite-listing.get-my-listing-for-app.service.test.ts`) — now **10/10 passing** (was 8). Asserts the proc projects icon/cover/screenshots, that the publish floor is satisfiable from them, that they come from the **shadow** on both the reused and the create paths, that a non-approved listing opens no shadow, and — new — that the create path reads the shadow from the **primary** under simulated replica lag while the reuse path stays on the **replica**.
- `src/server/services/blocks/`, full run: **1744/1746 passing**. The 2 failures are `manifest-schema-endpoint.test.ts`, failing on a missing `kysely` package, identically on unmodified `origin/main`.
- **Browser (`component`) project, run with real Chromium**: `listing-media-page.browser.test.tsx` **11/11 passing** (it was 8-of-9 *failing* before the repoint).
- `npx eslint` on all changed files: **0 errors** (only the pre-existing `_a is defined but never used` warnings already present in that test file's style).
- `tsc --noEmit`: **0 errors in any file I touched**; the 16 remaining are the known environmental ones (`packages/civitai-db*` kysely types, `image.service.ts`, `bitdex-stats.ts`).
- Three of the four files I touched were **already** unformatted on `origin/main`, so I left their formatting alone rather than adding unrelated churn.

## What I could NOT test

- **No end-to-end UI verification.** I did not drive a browser against a deployed environment and cannot reach a preview, so I have not watched the Submit button go from disabled → enabled on a real listing, nor exercised a real tab round-trip. That check is still owed.
- **The replica-lag path is verified by test simulation, not against a real replica.** The unit test makes the replica miss and the primary hit; it does not prove production lag characteristics.
- `src/components/Apps/ListingAssetStep.browser.test.tsx` fails 13/13 locally with an empty `<body>`, **identically on this branch with all my changes stashed** — a local browser-environment issue in a file this PR does not touch. Not investigated further.
- No DB migration is involved.

## Mutation verification

Every guard was broken, watched fail, and reverted.

| Mutation | Result |
|---|---|
| Strip the asset projection (restore the original gap) | **4 of 8 FAIL**, including "publish floor can be met" |
| Point the asset read at the **live parent** instead of the shadow | **5 of 8 FAIL**, including both 🔴 shadow-provenance tests |
| Drop the create-path primary read (`loadListingEditView(effectiveId)`) | **1 of 10 FAIL** — and it fails with the production symptom verbatim: `OffsiteRequestError: listing apl_new_1 not found` |
| Make it a **blanket** primary read (`loadListingEditView(effectiveId, dbWrite)`) | **3 of 10 FAIL** — the anti-fix is caught too |
| Point the browser test back at the `/apps/[appBlockId]/listing` redirect stub | suite fails to collect / renders nothing; pre-fix it was **8 of 9 FAIL** |
| Remove `onAssetMutated={handleAssetMutated}` from the editor | **1 of 11 FAIL** (the stale-prefill guard) |
| Restore the blanket `if (listingError) return <NotFound />` | **1 of 11 FAIL** (the inline-alert guard) |
| Reverted to the real fix | **unit 10/10 PASS, browser 11/11 PASS** |

---

## Second fix round — delta re-audit of the follow-up commit

A delta re-audit of the four fixes above found that **#1 was only half-closed**, and that **#3's per-mutation invalidation increased exposure to the surviving half**. Commit `d87f3e4`.

### 🔴 A — `created` was the wrong predicate; the shadow read could still hit a lagging replica

Round 1 routed the edit-view read to the primary **only when `beginListingRevision` reported `created: true`**. But `created` means *"**I** inserted it"* — it is **not** a claim that the row is replica-visible.

Traced failure under lag, with `created === false` throughout:

1. the idempotency probe reads the **replica** (`offsite-listing.service.ts` ~L983) and **misses**;
2. it opens the `dbWrite.$transaction`; the in-tx re-check on the **primary** **finds** the row → returns early → **`created === false`**;
3. the caller therefore reads the edit view from **`dbRead`**;
4. the replica misses that *same* row → `NOT_FOUND` → tRPC `NOT_FOUND` → the client's (now narrowed) guard still routes `NOT_FOUND` to `<NotFound />` → **the whole editor is discarded, including any in-flight upload.**

Any cross-request creator reproduces this, and in this flow they are the *common* case, not the exotic one: the editor fires its **own client-side `beginListingRevision` mutation on mount**, `getMyListingForEdit` mints a shadow for the same parent, a second tab does either. And because round 1 added an invalidation on every asset mutation, the exposure became **once per asset mutation** instead of once per page load.

**Fix (deterministic, not timing-dependent):** the predicate is now **structural — "is the resolved target a SHADOW?"** (`effectiveId !== <parent id>`), not "did I create it". A shadow is read from `dbWrite` regardless of who minted it; an in-place target (draft / pending edited in place) is old and stays on `dbRead`. Applied at **both** call sites (`getMyListingForApp`, `getMyListingForEdit`). This is still not a blanket redirect — the in-place read is pinned to the replica by its own test.

> This supersedes the round-1 mutation-table row *"Make it a blanket primary read"*: the anti-fix that row guarded against is now specifically "route the **in-place** read to the primary too", and that is what the in-place test pins.

**The existing REUSE test pinned the weaker behaviour.** `offsite-listing.get-my-listing-for-app.service.test.ts` asserted that a reused shadow *must* read the replica, with no lag modelled — i.e. it pinned the bug. Its assertion now reads:

```ts
it('🔴 a REUSED (pre-existing) shadow ALSO reads from the PRIMARY — `created` is not a visibility claim', …)
  expect(editViewReads(mockWrite)).toEqual(['apl_shadow']);
  expect(editViewReads(mockRead)).toEqual([]);
```

and a new test models a **reused-but-unreplicated** shadow (`replicaLagsOn: ['apl_shadow']`, `created: false`) and asserts the assets still come back.

### 🔴 B — the `getMyListingForEdit` half was structurally untested

Reverting that call site to `loadListingEditView(effectiveId)` left both covering suites **fully green** — a guard with no killing mutation.

Added to `offsite-listing.edit-consolidate.service.test.ts`: dual-pool `findUnique` wiring with a `replicaLagsOn` knob, a **freshly-created**-shadow lag test, a **reused**-shadow lag test, and an **in-place target stays on the replica** test.

### 🟡 C — contradictory half-UI on a settled error

The blue *"This app is **live** — your image changes are staged as a revision…"* alert rendered unconditionally. Once round 1 narrowed the `NotFound` guard, a `removed` listing showed **"This app is live"** directly above **"cannot edit a listing in status removed"**, with no editor beneath — and the same for `INTERNAL_SERVER_ERROR` and for a client error carrying no `data.code`. Pre-narrowing these were a clean `<NotFound />`.

The notice is now gated on a **resolved** listing (`listing && !listingError`). Round 1's improvement stands untouched: a non-gating error still surfaces the inline red alert rather than collapsing to `NotFound`.

### 🟡 D — the stale-prefill coverage did not actually test the round trip

The round-1 tests asserted prop pass-through and that `invalidate` fired, but **nothing ever unmounted the editor** and the stubbed step **ignored `initial`** — so the claim *"a re-attached icon no longer reads as unattached after a tab round-trip"* was untested end-to-end.

Strengthened: the stub now seeds from `initial` in a **`useState` initialiser** (exactly as the real `ListingAssetStep` does, so a mere re-render can never re-seed it), and a new test drives the whole loop — attach → `invalidate` → refreshed projection → **keyed remount** → re-seed — asserting the icon reads `555`, not `none`.

Honest limit: this test and the round-1 invalidation test share the same killing mutation (dropping `onAssetMutated`); the new one is strictly stronger but does not add an independently-killable guard. A manual `unmount()` was tried first and rejected — it fights the scaffold's auto-`cleanup()` and blanks the *next* test's container.

### 🟡 E — per-mutation invalidation chattiness: assessed, deliberately NOT changed

N screenshot mutations = N invalidations = N refetches, each re-entering a `.query()` that is architecturally a write path (it calls the idempotent `beginListingRevision`). Correct but wasteful. Every reduction considered (debounce, skip-if-unchanged, mutate the cache locally instead of invalidating) trades correctness or freshness for chattiness on the exact path this PR exists to make reliable, so **it is left as-is**. The read side is now cheaper in the way that matters: a shadow read is one primary query that cannot miss, rather than a replica query that can throw.

### Verification

Every new/changed guard was **mutation-verified**: broken → the specific new test watched fail → restored → green.

| Mutation | Result |
|---|---|
| Restore the `created` predicate in `getMyListingForApp` | **3 FAIL / 8 pass** — the reuse-lag test fails with the production symptom verbatim: `OffsiteRequestError: listing apl_shadow not found` |
| Revert `getMyListingForEdit` to `loadListingEditView(effectiveId)` | **4 FAIL / 54 pass** — both new lag tests throw the same `NOT_FOUND` (was 0 FAIL / 55 pass before this round) |
| Un-gate the live-app notice (`{true && <Alert …>}`) | **1 FAIL / 12 pass** |
| Remove `onAssetMutated={handleAssetMutated}` | **2 FAIL / 11 pass** |
| Restored | 7 app-listing/blocks unit suites **258/258 PASS**; browser suite **13/13 PASS** |

- **Full unit project:** 18 failed / 8268 passed. **All 18 reproduce identically in a clean, untouched `origin/main` worktree** (`hiddenBlocks`, `get-models-raw.transient-503`, `prisma-inconsistent-orphan-relations`, `manifest-schema-endpoint`) — this branch adds zero failures.
- **Browser suite:** run with `PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH=/run/current-system/sw/bin/brave` → **13/13 passing** (supersedes the 11/11 figure above; the `component` project remains report-only).
- `tsc --noEmit`: **16 errors, all pre-existing** (`kysely`, `event-engine-common` module resolution in `packages/civitai-db*` / `image.service.ts` / `bitdex-stats.ts`) — none in the touched files.
- `eslint` on the 5 changed files: **0 errors** (11 warnings, all the pre-existing `_a` hoisted-mock scaffold).
- Rebased onto `origin/main` before pushing.

### Still owed / not fixed

- **No end-to-end UI verification** — I cannot reach a deployed preview, so the disabled→enabled Submit transition and a real tab round-trip are still unwatched. Unchanged from round 1.
- **Replica lag is simulated, not real.** The tests make the replica miss and the primary hit; they do not characterise production lag.
- `beginListingRevision`'s idempotency probe still reads the replica. That is *correct* (a miss just falls through to the primary-side in-tx re-check, which returns the winner), but under lag it costs one extra `$transaction` round-trip. Left alone deliberately — moving it to the primary would be a hot-path read-load change for a latency nicety, and the correctness fix above no longer depends on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

