### PR TITLE
fix(challenge): declare reviewedAt and completingClaimedAt in the metadata schema

### DIFF
--- a/src/server/prom/challenge.metrics.ts
+++ b/src/server/prom/challenge.metrics.ts
@@ -337,9 +337,12 @@ const COMPLETING_STUCK_MINUTES = 30;
  * stampless row is never selected and never reset — it stays `Completing` forever.
  *
  * IT IS STILL REACHABLE, and declaring `completingClaimedAt` in `challengeMetadataSchema` does not
- * close it. The destroyer is not the zod strip — it is a STALE FULL-COLUMN REPLACE. Two sites read
- * a challenge (from the REPLICA), spend real time, then write the whole metadata column back keyed
- * only on `id`, with no status predicate: `backfill-theme-elements.ts` (a multi-second LLM call
+ * close it. The destroyer is not the zod strip — it is a STALE FULL-COLUMN REPLACE. Six sites in
+ * total do a stale-replica full-column metadata replace; of those, TWO can leave the row still IN
+ * `Completing` (the rest either set a terminal status in the same statement or are predicated to a
+ * non-`Completing` status, so they cannot strand one). Those two read a challenge (from the
+ * REPLICA), spend real time, then write the whole metadata column back keyed only on `id`, with no
+ * status predicate: `backfill-theme-elements.ts` (a multi-second LLM call
  * sits between its read and its write, and `?force=true` widens it to every themed Active/Scheduled
  * challenge) and `challenge.service.ts`'s `upsertChallenge`. If `claimChallengeForCompletion` lands
  * in that window, the pre-claim snapshot overwrites the fresh stamp. The stamp was never IN that

--- a/src/server/prom/challenge.metrics.ts
+++ b/src/server/prom/challenge.metrics.ts
@@ -336,15 +336,23 @@ const COMPLETING_STUCK_MINUTES = 30;
  * compares `(metadata->>'completingClaimedAt')::timestamptz`, which is NULL-propagating, so a
  * stampless row is never selected and never reset — it stays `Completing` forever.
  *
- * No CURRENTLY KNOWN write produces one. `completingClaimedAt` is declared in
- * `challengeMetadataSchema`, so a parse-then-write-back no longer strips it, and every such write
- * site is either status-predicated away from `Completing` or sets a terminal status in the same
- * statement. (An earlier version of this comment cited the strip as a live reachable cause; that
- * was true when written and is no longer.) The design stands anyway, because it is the cheap
- * direction to be wrong in: a legacy or malformed stamp still lands here, and treating such rows as
- * "not stuck" would make the gauge silently blind to the only permanently-wedged state — the same
- * fail-open the zero-emit note below exists to prevent. The competing worry, legacy rows pinning
- * the gauge high, does not apply: there are no `Completing` rows in prod today.
+ * IT IS STILL REACHABLE, and declaring `completingClaimedAt` in `challengeMetadataSchema` does not
+ * close it. The destroyer is not the zod strip — it is a STALE FULL-COLUMN REPLACE. Two sites read
+ * a challenge (from the REPLICA), spend real time, then write the whole metadata column back keyed
+ * only on `id`, with no status predicate: `backfill-theme-elements.ts` (a multi-second LLM call
+ * sits between its read and its write, and `?force=true` widens it to every themed Active/Scheduled
+ * challenge) and `challenge.service.ts`'s `upsertChallenge`. If `claimChallengeForCompletion` lands
+ * in that window, the pre-claim snapshot overwrites the fresh stamp. The stamp was never IN that
+ * snapshot, so there is nothing for the schema to have preserved — behaviour is identical before
+ * and after this field was declared. Closing it for real means predicating those writes
+ * (`AND status <> 'Completing'`, or the `updateMany` + `count === 0` pattern already used
+ * elsewhere in that service); that is a separate change and has not been made.
+ *
+ * So the design is not merely the cheap direction to be wrong in — it is load-bearing. A legacy or
+ * malformed stamp lands here too, and treating such rows as "not stuck" would make the gauge
+ * silently blind to the only permanently-wedged state — the same fail-open the zero-emit note below
+ * exists to prevent. The competing worry, legacy rows pinning the gauge high, does not apply: there
+ * are no `Completing` rows in prod today.
  *
  * TEXT COMPARISON, NOT `::timestamptz`. The cast is not an option here: `('garbage')::timestamptz`
  * RAISES, which would fail the whole gauge query, get swallowed by the never-throw catch, and freeze

--- a/src/server/prom/challenge.metrics.ts
+++ b/src/server/prom/challenge.metrics.ts
@@ -334,13 +334,17 @@ const COMPLETING_STUCK_MINUTES = 30;
  * MISSING / MALFORMED STAMP COUNTS AS STUCK. A `Completing` row without a usable stamp is the most
  * broken state there is, and the one thing nothing can recover: `resetStuckCompletingChallenges`
  * compares `(metadata->>'completingClaimedAt')::timestamptz`, which is NULL-propagating, so a
- * stampless row is never selected and never reset — it stays `Completing` forever. It is reachable:
- * a metadata write that rebuilds the object from `parseChallengeMetadata` drops the stamp (the zod
- * object strips unknown keys and `completingClaimedAt` is not in the schema), and at least one such
- * write is neither status-predicated nor status-setting. Treating those rows as "not stuck" would
- * make the gauge silently blind to the only permanently-wedged state — the same fail-open the
- * zero-emit note below exists to prevent. The competing worry, legacy rows predating the stamp
- * pinning the gauge high, does not apply: there are no `Completing` rows in prod today.
+ * stampless row is never selected and never reset — it stays `Completing` forever.
+ *
+ * No CURRENTLY KNOWN write produces one. `completingClaimedAt` is declared in
+ * `challengeMetadataSchema`, so a parse-then-write-back no longer strips it, and every such write
+ * site is either status-predicated away from `Completing` or sets a terminal status in the same
+ * statement. (An earlier version of this comment cited the strip as a live reachable cause; that
+ * was true when written and is no longer.) The design stands anyway, because it is the cheap
+ * direction to be wrong in: a legacy or malformed stamp still lands here, and treating such rows as
+ * "not stuck" would make the gauge silently blind to the only permanently-wedged state — the same
+ * fail-open the zero-emit note below exists to prevent. The competing worry, legacy rows pinning
+ * the gauge high, does not apply: there are no `Completing` rows in prod today.
  *
  * TEXT COMPARISON, NOT `::timestamptz`. The cast is not an option here: `('garbage')::timestamptz`
  * RAISES, which would fail the whole gauge query, get swallowed by the never-throw catch, and freeze

--- a/src/server/schema/__tests__/challenge-metadata-round-trip.test.ts
+++ b/src/server/schema/__tests__/challenge-metadata-round-trip.test.ts
@@ -50,9 +50,22 @@ describe('parseChallengeMetadata round-trip', () => {
     expect(parsed).not.toHaveProperty('notARealField');
   });
 
-  it('ignores a wrong-typed value instead of throwing', () => {
-    // A bad value must not blow up a completion run; the whole parse falls back to {}.
-    expect(() => parseChallengeMetadata({ reviewedAt: 'not-a-number' })).not.toThrow();
-    expect(parseChallengeMetadata({ reviewedAt: 'not-a-number' })).toEqual({});
+  it('does not throw on a wrong-typed value — but loses the WHOLE object, siblings included', () => {
+    // A bad value must not blow up a completion run. What it does instead is worse than the
+    // one-key fixture this test used to carry would suggest: `parseChallengeMetadata` returns `{}`
+    // for the entire object, and the call sites that write the parsed result back would persist
+    // that — taking `reconciliation.paidUserIds` (which gates participation back-pay) with it.
+    // Asserted with siblings present precisely so the blast radius is visible in the test, not just
+    // in a comment. This is the cost of DECLARING a key: undeclared, a bad value is merely stripped
+    // and its siblings survive.
+    const withSiblings = {
+      challengeType: 'daily',
+      articleId: 42,
+      reconciliation: { paidUserIds: [1, 2, 3] },
+      reviewedAt: 'not-a-number',
+    };
+
+    expect(() => parseChallengeMetadata(withSiblings)).not.toThrow();
+    expect(parseChallengeMetadata(withSiblings)).toEqual({});
   });
 });

--- a/src/server/schema/__tests__/challenge-metadata-round-trip.test.ts
+++ b/src/server/schema/__tests__/challenge-metadata-round-trip.test.ts
@@ -31,11 +31,15 @@ describe('parseChallengeMetadata round-trip', () => {
 
   it('survives the parse-then-write-back cycle that strips undeclared keys', () => {
     // The shape that actually loses data in production: parse, then persist the parsed object.
+    // `migratedAt` is here so the declaration that has no reader is still held in place by a test —
+    // otherwise it could be deleted with a fully green suite, which is exactly the silent-drop this
+    // schema exists to prevent.
     const stored = {
       challengeType: 'daily',
       articleId: 42,
       reviewedAt: 1753920000000,
       completingClaimedAt: '2026-07-30T00:03:00.000Z',
+      migratedAt: '2026-05-01T00:00:00.000Z',
     };
 
     const afterRewrite = parseChallengeMetadata(parseChallengeMetadata(stored));

--- a/src/server/schema/__tests__/challenge-metadata-round-trip.test.ts
+++ b/src/server/schema/__tests__/challenge-metadata-round-trip.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseChallengeMetadata } from '~/server/schema/challenge.schema';
+
+/**
+ * `parseChallengeMetadata` strips undeclared keys, and several call sites parse the metadata and
+ * then write the parsed object straight back to the column. Any key written to Challenge.metadata
+ * by raw SQL but missing from `challengeMetadataSchema` is therefore destroyed by the next such
+ * rewrite.
+ *
+ * These two fields are written by raw jsonb merges and read back by SQL that never goes near zod,
+ * so nothing else in the type system connects the write to the read. That is what makes a
+ * round-trip test the only thing holding them in place.
+ */
+describe('parseChallengeMetadata round-trip', () => {
+  it('preserves reviewedAt, the round-robin ordering key', () => {
+    // Written as a bare JSON number by daily-challenge-processing, read via
+    // `cast(metadata->>'reviewedAt' as bigint)`.
+    const raw = { reviewedAt: 1753920000000 };
+
+    expect(parseChallengeMetadata(raw).reviewedAt).toBe(1753920000000);
+  });
+
+  it('preserves completingClaimedAt, the completion claim stamp', () => {
+    // Written as an ISO string by claimChallengeForCompletion; read by the stuck-challenge reset
+    // and the claim-ownership check.
+    const raw = { completingClaimedAt: '2026-07-30T00:03:00.000Z' };
+
+    expect(parseChallengeMetadata(raw).completingClaimedAt).toBe('2026-07-30T00:03:00.000Z');
+  });
+
+  it('survives the parse-then-write-back cycle that strips undeclared keys', () => {
+    // The shape that actually loses data in production: parse, then persist the parsed object.
+    const stored = {
+      challengeType: 'daily',
+      articleId: 42,
+      reviewedAt: 1753920000000,
+      completingClaimedAt: '2026-07-30T00:03:00.000Z',
+    };
+
+    const afterRewrite = parseChallengeMetadata(parseChallengeMetadata(stored));
+
+    expect(afterRewrite).toEqual(stored);
+  });
+
+  it('still drops genuinely unknown keys rather than widening the column', () => {
+    const parsed = parseChallengeMetadata({ reviewedAt: 1, notARealField: 'nope' });
+
+    expect(parsed.reviewedAt).toBe(1);
+    expect(parsed).not.toHaveProperty('notARealField');
+  });
+
+  it('ignores a wrong-typed value instead of throwing', () => {
+    // A bad value must not blow up a completion run; the whole parse falls back to {}.
+    expect(() => parseChallengeMetadata({ reviewedAt: 'not-a-number' })).not.toThrow();
+    expect(parseChallengeMetadata({ reviewedAt: 'not-a-number' })).toEqual({});
+  });
+});

--- a/src/server/schema/challenge.schema.ts
+++ b/src/server/schema/challenge.schema.ts
@@ -115,6 +115,12 @@ const challengeCompletionSummarySchema = z.object({
 export type ChallengeCompletionSummary = z.infer<typeof challengeCompletionSummarySchema>;
 
 // Zod schema for Challenge.metadata (Json? column)
+//
+// Every key the column can hold must be declared here. `parseChallengeMetadata` uses this schema's
+// default strip behaviour, so an undeclared key is SILENTLY DROPPED — and several call sites parse
+// the metadata and then write the parsed object back wholesale, which deletes anything missing from
+// this list. Two fields written by raw SQL elsewhere were lost that way; see the notes below. When
+// adding a key to Challenge.metadata anywhere in the codebase, add it here in the same change.
 export const challengeMetadataSchema = z.object({
   challengeType: z.string().optional(),
   resourceUserId: z.number().optional(),
@@ -122,6 +128,18 @@ export const challengeMetadataSchema = z.object({
   articleId: z.number().optional(),
   themeElements: z.array(z.string()).optional(),
   completionSummary: challengeCompletionSummarySchema.optional(),
+  // Epoch millis of the last review pass, written as a bare JSON number by a raw jsonb merge in
+  // daily-challenge-processing, and read back by getActiveChallengesFromDb's
+  // `cast(metadata->>'reviewedAt' as bigint)` round-robin ordering. Dropping it made a reviewed
+  // challenge sort as never-reviewed (NULLS FIRST), so it was picked again ahead of its peers —
+  // defeating the rotation that ordering exists to provide.
+  reviewedAt: z.number().optional(),
+  // ISO timestamp stamped by claimChallengeForCompletion when a run claims a challenge into
+  // Completing. Read back two ways: the time-based stuck-challenge reset, and the completion job's
+  // claim-ownership check that gates its telemetry. Dropping it made the ownership check fail open,
+  // and a stampless Completing row is never selected by the reset (its comparison is
+  // NULL-propagating), so such a row is wedged rather than recovered.
+  completingClaimedAt: z.string().optional(),
   reconciliation: z
     .object({
       paidUserIds: z.array(z.number()).optional(),

--- a/src/server/schema/challenge.schema.ts
+++ b/src/server/schema/challenge.schema.ts
@@ -138,11 +138,21 @@ export const challengeMetadataSchema = z.object({
   themeElements: z.array(z.string()).optional(),
   completionSummary: challengeCompletionSummarySchema.optional(),
   // Epoch millis of the last review pass, written as a bare JSON number by a raw jsonb merge in
-  // daily-challenge-processing, and read back by getActiveChallengesFromDb's
-  // `cast(metadata->>'reviewedAt' as bigint)` round-robin ordering. Dropping it made a reviewed
-  // challenge sort as never-reviewed (NULLS FIRST). That ordering only decides anything once the
-  // Active set exceeds CHALLENGE_JOB_BATCH_SIZE, which it does not today (200 vs ~31), so the
-  // observable impact is currently nil — this keeps the key alive for when it isn't.
+  // daily-challenge-processing. TWO readers, and the second is the one that matters:
+  //
+  //   1. getActiveChallengesFromDb's `ORDER BY cast(metadata->>'reviewedAt' as bigint) NULLS FIRST`
+  //      round-robin. Only decides anything once the Active set exceeds CHALLENGE_JOB_BATCH_SIZE
+  //      (200 vs ~31 today), so on its own this reader would make the key look inconsequential.
+  //   2. The INCREMENTAL-REVIEW WATERMARK in the review job: `lastReviewedAt` defaults to the
+  //      challenge's start date and is overwritten by this key, then gates the candidate pool with
+  //      `AND ci."reviewedAt" >= ${lastReviewedAt}`. Losing the key rewinds that watermark to the
+  //      START OF THE CHALLENGE, so every entry since then re-enters the pool. This has nothing to
+  //      do with batch size and is not bounded by the Active count.
+  //
+  // Reader 2 is why this is not cosmetic: for PAID user challenges `judgeAllEntries` skips the
+  // sampling cap entirely, so a rewound watermark means the whole accumulated backlog is judged in
+  // a single run — re-judging work already paid for, at LLM cost. Do not reason about this key from
+  // the ordering alone.
   reviewedAt: z.number().optional(),
   // ISO timestamp stamped by claimChallengeForCompletion when a run claims a challenge into
   // Completing. Read back two ways: the time-based stuck-challenge reset, and the completion job's

--- a/src/server/schema/challenge.schema.ts
+++ b/src/server/schema/challenge.schema.ts
@@ -121,6 +121,15 @@ export type ChallengeCompletionSummary = z.infer<typeof challengeCompletionSumma
 // the metadata and then write the parsed object back wholesale, which deletes anything missing from
 // this list. Two fields written by raw SQL elsewhere were lost that way; see the notes below. When
 // adding a key to Challenge.metadata anywhere in the codebase, add it here in the same change.
+//
+// 🔴 DECLARING A KEY RAISES THE STAKES ON ITS TYPE. An undeclared key with a bad value is merely
+// stripped and its siblings survive; a DECLARED key with a bad value fails the whole `safeParse`,
+// and `parseChallengeMetadata` then returns `{}` — so the write-back sites above would wipe the
+// ENTIRE metadata column, including `reconciliation.paidUserIds`, which gates participation
+// back-pay. There is no live exposure today (every writer is type-safe by construction —
+// `Date.now()` for the numbers, `toISOString()` for the strings — and all production rows conform),
+// but a new key whose writer can emit a wrong type is a much bigger liability declared than
+// undeclared. Prefer a permissive type over an exact one when the writer is not provably narrow.
 export const challengeMetadataSchema = z.object({
   challengeType: z.string().optional(),
   resourceUserId: z.number().optional(),
@@ -141,8 +150,10 @@ export const challengeMetadataSchema = z.object({
   // so the strip never affected a read — what it cost was durability across a parse-then-write-back.
   // The one concrete case: a slow run whose claim was reset would strip the stamp on its late write,
   // so the run that re-claimed saw none, failed open, and both emitted. Declaring it makes that a
-  // single emit. A stampless Completing row would also be unrecoverable (the reset's comparison is
-  // NULL-propagating, so it is never selected) — no known write produces one, and this keeps it so.
+  // single emit. NOTE this does NOT make a stampless Completing row impossible — that row is
+  // unrecoverable (the reset's comparison is NULL-propagating, so it is never selected), and it is
+  // still reachable via a stale full-column metadata replace that was never carrying the stamp to
+  // begin with. See the note on the completing-stuck gauge in challenge.metrics.ts.
   completingClaimedAt: z.string().optional(),
   // Written once by the admin/temp challenge migration endpoint. No reader today, so losing it is
   // cosmetic — declared because the rule above is only worth anything if it is applied uniformly.

--- a/src/server/schema/challenge.schema.ts
+++ b/src/server/schema/challenge.schema.ts
@@ -131,15 +131,22 @@ export const challengeMetadataSchema = z.object({
   // Epoch millis of the last review pass, written as a bare JSON number by a raw jsonb merge in
   // daily-challenge-processing, and read back by getActiveChallengesFromDb's
   // `cast(metadata->>'reviewedAt' as bigint)` round-robin ordering. Dropping it made a reviewed
-  // challenge sort as never-reviewed (NULLS FIRST), so it was picked again ahead of its peers —
-  // defeating the rotation that ordering exists to provide.
+  // challenge sort as never-reviewed (NULLS FIRST). That ordering only decides anything once the
+  // Active set exceeds CHALLENGE_JOB_BATCH_SIZE, which it does not today (200 vs ~31), so the
+  // observable impact is currently nil — this keeps the key alive for when it isn't.
   reviewedAt: z.number().optional(),
   // ISO timestamp stamped by claimChallengeForCompletion when a run claims a challenge into
   // Completing. Read back two ways: the time-based stuck-challenge reset, and the completion job's
-  // claim-ownership check that gates its telemetry. Dropping it made the ownership check fail open,
-  // and a stampless Completing row is never selected by the reset (its comparison is
-  // NULL-propagating), so such a row is wedged rather than recovered.
+  // claim-ownership check that gates its telemetry. Both read the RAW jsonb, not a parsed object,
+  // so the strip never affected a read — what it cost was durability across a parse-then-write-back.
+  // The one concrete case: a slow run whose claim was reset would strip the stamp on its late write,
+  // so the run that re-claimed saw none, failed open, and both emitted. Declaring it makes that a
+  // single emit. A stampless Completing row would also be unrecoverable (the reset's comparison is
+  // NULL-propagating, so it is never selected) — no known write produces one, and this keeps it so.
   completingClaimedAt: z.string().optional(),
+  // Written once by the admin/temp challenge migration endpoint. No reader today, so losing it is
+  // cosmetic — declared because the rule above is only worth anything if it is applied uniformly.
+  migratedAt: z.string().optional(),
   reconciliation: z
     .object({
       paidUserIds: z.array(z.number()).optional(),


### PR DESCRIPTION
## What

`parseChallengeMetadata` uses zod's default **strip**, and several call sites parse `Challenge.metadata` and then write the parsed object straight back to the column. Any key written by raw SQL but absent from `challengeMetadataSchema` is destroyed by the next such rewrite — and nothing in the type system connects those raw-SQL writes to their raw-SQL reads.

Declares the three keys that were in that state, plus a round-trip test and a header rule.

## The keys

**`reviewedAt`** — epoch millis, written by a jsonb merge in `daily-challenge-processing.ts`. **Two readers:**
1. `getActiveChallengesFromDb`'s `ORDER BY cast(metadata->>'reviewedAt' as bigint) NULLS FIRST` round-robin. Only decides anything once the Active set exceeds `CHALLENGE_JOB_BATCH_SIZE` (200 vs ~31 today), so on its own this reader makes the key look inconsequential.
2. The **incremental-review watermark**: `lastReviewedAt` defaults to the challenge start date, is overwritten by this key, then gates the candidate pool with `AND ci."reviewedAt" >= ${lastReviewedAt}`. Losing the key **rewinds that watermark to the start of the challenge**, so every entry since then re-enters the pool. Independent of batch size.

Reader 2 is the one with a cost: for **paid** user challenges `judgeAllEntries` skips the sampling cap, so a rewound watermark means the whole accumulated backlog is judged in a single run — re-judging work already paid for, at LLM cost.

**`completingClaimedAt`** — ISO stamp written by `claimChallengeForCompletion`. Both readers (the stuck reset and the completion job's claim-ownership check) read the **raw jsonb**, not a parsed object, so the strip never affected a read. What it cost is durability across a parse-then-write-back: a slow run whose claim was reset would strip the stamp on its late write, so the run that re-claimed saw none, failed open, and both emitted. Declaring it makes that a single emit.

🔴 **This does NOT fix the unrecoverable stampless-`Completing` row.** That row is still reachable, via a *stale full-column replace* that was never carrying the stamp to begin with (`backfill-theme-elements.ts` and `upsertChallenge` both read from the replica, spend real time, then write the whole column keyed only on `id`). Behaviour there is identical before and after this PR. Closing it means predicating those writes — a separate change, not made here.

**`migratedAt`** — written by the admin/temp migration endpoint, one prod row, no reader. Cosmetic on its own; declared because the header rule is only worth anything applied uniformly.

## 🔴 Declaring a key raises the stakes on its type

An **undeclared** key with a bad value is stripped and its siblings survive. A **declared** key with a bad value fails the whole `safeParse`, and `parseChallengeMetadata` returns `{}` — which the write-back sites would persist, taking `reconciliation.paidUserIds` (which gates participation back-pay) with it.

No live exposure: every writer is type-safe by construction (`Date.now()`, `toISOString()`), and all 253 production rows conform. But a future key whose writer can emit a wrong type is a bigger liability declared than undeclared. The round-trip test asserts this **with siblings present**, so the blast radius is visible in the test rather than only in a comment.

## Verification

```
$ npx vitest run --project unit src/server/schema src/server/prom \
    src/server/games/daily-challenge src/server/jobs
 Test Files  65 passed (65)
      Tests  644 passed (644)
     Errors  2   (pre-existing NixOS Prisma linux-nixos engine failures, unrelated files)

$ NODE_OPTIONS=--max_old_space_size=8192 npx tsc --noEmit
TSC_EXIT=0
```

Note the vitest runner exits non-zero in this environment despite zero test failures — those unhandled Prisma rejections are the cause. Judge by the `Test Files` line.

Each declaration is mutation-checked: removing `reviewedAt`, `completingClaimedAt`, or `migratedAt` individually fails the round-trip test, as does retyping `reviewedAt` to `z.string()`.

## Not verified

Whether the strip ever actually fired in production before this PR — `reviewedAt` is present on 51 of 253 rows and there is no audit trail distinguishing "never written" from "written then stripped". The magnitude of the widened review window is reasoned from the code path, not measured against a live challenge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)