### PR TITLE
docs(blocks): fix stale INERT/DARK comment on the customComfy workflow body

### DIFF
--- a/src/server/schema/blocks/workflow.schema.ts
+++ b/src/server/schema/blocks/workflow.schema.ts
@@ -36,10 +36,12 @@ const blockAccountTypeSchema = z.enum(buzzSpendTypes as [BuzzSpendType, ...BuzzS
 // `WorkflowBodyCustomComfy` (civitai-app-starters PR #171) — keep the two in
 // lockstep.
 //
-// INERT/DARK: blocks.router still handles ONLY `textToImage` — the submit /
-// estimate branch on `kind==='customComfy'` (+ the post-paid budget belt) is the
-// separate PR6. This member only widens the accepted wire shape; no live code
-// path reads it yet.
+// LIVE: blocks.router now branches on `kind==='customComfy'` in BOTH
+// `estimateWorkflow` and `submitWorkflow` (see `estimateCustomComfyWorkflow` /
+// `submitCustomComfyWorkflow`), backed by the post-paid budget belt
+// (`settleCustomComfySpend`) and the `buildCustomComfyWorkflowInput` translator.
+// The earlier "INERT/DARK — router handles ONLY textToImage" note is obsolete;
+// both members of this union are wired end-to-end.
 //
 // Caps are intentionally tighter than the platform-wide generateImageSchema —
 // blocks run in untrusted iframes and the token issuer caps per-call buzz at


### PR DESCRIPTION
## What

Comment-only fix. `src/server/schema/blocks/workflow.schema.ts`'s `blockWorkflowBodySchema` discriminated-union comment still said:

> `INERT/DARK: blocks.router still handles ONLY textToImage` — the submit / estimate branch on `kind==='customComfy'` (+ the post-paid budget belt) is the separate PR6. … no live code path reads it yet.

That is no longer true. The router branches on `kind==='customComfy'` end-to-end:
- `estimateWorkflow` → `estimateCustomComfyWorkflow` (`blocks.router.ts:3507-3508`)
- `submitWorkflow` → `submitCustomComfyWorkflow` (`blocks.router.ts:3675-3676`)
- backed by the post-paid budget belt (`settleCustomComfySpend`) and the `buildCustomComfyWorkflowInput` translator (`workflow.service.ts:658`).

The comment now describes the shipped reality (both union members wired). No code tokens changed — the diff is `//` lines only, so there is no type/behaviour surface.

## Why

Surfaced by an App Blocks generation-bridge public-docs audit (`datapacket-talos:claudedocs/app-blocks-bridge-public-docs-assessment-2026-07-27.md`, finding #5) while closing the bridge-docs gap on developer.civitai.com. The docs are correct that Comfy Cloud is live; it was the code comment that lagged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)