### PR TITLE
feat(blocks): create on-site store AppListing as a DRAFT at submit (settable while pending)

### DIFF
--- a/src/server/routers/app-listings.router.ts
+++ b/src/server/routers/app-listings.router.ts
@@ -558,7 +558,11 @@ export const appListingsRouter = router({
         '~/server/services/blocks/offsite-listing.service'
       );
       try {
-        return await getMyListingForApp({ appBlockId: input.appBlockId, userId: ctx.user.id });
+        return await getMyListingForApp({
+          appBlockId: input.appBlockId,
+          slug: input.slug,
+          userId: ctx.user.id,
+        });
       } catch (err) {
         throw mapOffsiteError(err);
       }

--- a/src/server/schema/blocks/offsite-listing.schema.ts
+++ b/src/server/schema/blocks/offsite-listing.schema.ts
@@ -219,9 +219,16 @@ export type BeginListingRevisionInput = z.infer<typeof beginListingRevisionSchem
  * `beginListingRevision` + the asset procs). Owner-bound in the service
  * (NOT_OWNED→FORBIDDEN, NOT_FOUND when no listing row exists for the app).
  */
-export const getMyListingForAppSchema = z.object({
-  appBlockId: z.string().min(1).max(64),
-});
+export const getMyListingForAppSchema = z
+  .object({
+    appBlockId: z.string().min(1).max(64).optional(),
+    // W13 draft-at-submit: a FIRST-version app has no AppBlock yet, so the
+    // owner-media page resolves its pre-approval draft BY SLUG while pending.
+    slug: z.string().min(1).max(64).optional(),
+  })
+  .refine((v) => v.appBlockId != null || v.slug != null, {
+    message: 'either appBlockId or slug is required',
+  });
 export type GetMyListingForAppInput = z.infer<typeof getMyListingForAppSchema>;
 
 /**

--- a/src/server/services/blocks/__tests__/app-listing-assets.service.test.ts
+++ b/src/server/services/blocks/__tests__/app-listing-assets.service.test.ts
@@ -669,6 +669,32 @@ describe('screenshot CRUD', () => {
     );
   });
 
+  // W13 draft-at-submit — media set on the PRE-APPROVAL DRAFT (status='draft',
+  // revisionOfId=null) is a DIRECT edit: `assertOwnerAssetEditable` only throws for an
+  // `approved && revisionOfId==null` (live) listing, so a draft edits in place — it must
+  // NOT open a shadow revision. Assert the write targets the SAME listing id directly.
+  it('setIcon on a pre-approval DRAFT → DIRECT write to the same listing (NO shadow revision)', async () => {
+    mockDb.appListing.findUnique.mockResolvedValue({
+      ...listingRow,
+      status: 'draft',
+      revisionOfId: null,
+    });
+    mockDb.image.findUnique.mockResolvedValue({
+      id: 9, userId: 42, type: 'image', width: 512, height: 512, mimeType: 'image/png',
+      metadata: {}, ingestion: 'Scanned', nsfwLevel: 1,
+    });
+    const { setListingIcon } = await import('../app-listing-assets.service');
+    const res = await setListingIcon({ listingId: 'apl_1', imageId: 9 }, owner);
+
+    expect(res).toEqual({ status: 'attached', iconId: 9 });
+    // DIRECT edit: writes iconId onto the draft's OWN id, no revision clone.
+    expect(mockDb.appListing.update).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: 'apl_1' }, data: { iconId: 9 } })
+    );
+    // A shadow revision would be a NEW AppListing row (revisionOfId set) — never created.
+    expect(mockDb.appListing.create).toBeUndefined();
+  });
+
   // A TERMINAL ingestion failure stays BAD_REQUEST, so the client stops polling
   // and shows a clear "upload it manually" error instead of an eternal scanning
   // spinner. This is the client-resilience half of the OG-pull-ingest fix — a

--- a/src/server/services/blocks/__tests__/app-listing-assets.service.test.ts
+++ b/src/server/services/blocks/__tests__/app-listing-assets.service.test.ts
@@ -1186,6 +1186,84 @@ describe('backfillListingAssets', () => {
 // `ingestion` and throws unless EVERY asset is terminally `Scanned`.
 // ---------------------------------------------------------------------------
 
+// ---------------------------------------------------------------------------
+// resolveListingRatingFloorInTx — the GO-LIVE rating floor for a listing whose media
+// was attached while it was directly asset-editable (pre-approval draft / reset
+// pending). The attach path DELIBERATELY accepts an image above the declared rating
+// (see "setIcon ATTACHES an over-declared-rating image" above) because draft/pending
+// listings are "rated at approve" — this helper IS that rating. Raise-only.
+// ---------------------------------------------------------------------------
+
+describe('resolveListingRatingFloorInTx (go-live rating floor, raise-only)', () => {
+  beforeEach(resetDb);
+
+  it('RAISES a g-declared listing to r when the pending media is R-rated', async () => {
+    mockDb.appListing.findUnique.mockResolvedValue({ iconId: 1, coverId: null });
+    mockDb.appListingScreenshot.findMany.mockResolvedValue([]);
+    mockDb.image.findMany.mockResolvedValue([{ nsfwLevel: NsfwLevel.R }]);
+    const { resolveListingRatingFloorInTx } = await import('../app-listing-assets.service');
+    // 🔴 The exact bypass this guards: manifest declares 'g', the author attached an
+    // R-rated (Scanned, not Blocked) icon while pending. Approve must NOT stamp 'g'.
+    await expect(resolveListingRatingFloorInTx(mockDb as never, 'apl_1', 'g')).resolves.toBe('r');
+  });
+
+  it('RAISES a null-declared listing (null → SFW floor) to the derived rating', async () => {
+    mockDb.appListing.findUnique.mockResolvedValue({ iconId: null, coverId: 2 });
+    mockDb.appListingScreenshot.findMany.mockResolvedValue([]);
+    mockDb.image.findMany.mockResolvedValue([{ nsfwLevel: NsfwLevel.X }]);
+    const { resolveListingRatingFloorInTx } = await import('../app-listing-assets.service');
+    await expect(resolveListingRatingFloorInTx(mockDb as never, 'apl_1', null)).resolves.toBe('x');
+  });
+
+  it('does NOT lower an x-declared listing whose media is only PG (raise-only)', async () => {
+    mockDb.appListing.findUnique.mockResolvedValue({ iconId: 1, coverId: 2 });
+    mockDb.appListingScreenshot.findMany.mockResolvedValue([]);
+    mockDb.image.findMany.mockResolvedValue([{ nsfwLevel: NsfwLevel.PG }, { nsfwLevel: NsfwLevel.PG }]);
+    const { resolveListingRatingFloorInTx } = await import('../app-listing-assets.service');
+    await expect(resolveListingRatingFloorInTx(mockDb as never, 'apl_1', 'x')).resolves.toBe('x');
+  });
+
+  it('takes the MAX across icon + cover + screenshots (a single mature screenshot raises)', async () => {
+    mockDb.appListing.findUnique.mockResolvedValue({ iconId: 1, coverId: 2 });
+    mockDb.appListingScreenshot.findMany.mockResolvedValue([{ imageId: 10 }, { imageId: 11 }]);
+    mockDb.image.findMany.mockResolvedValue([
+      { nsfwLevel: NsfwLevel.PG }, { nsfwLevel: NsfwLevel.PG },
+      { nsfwLevel: NsfwLevel.PG }, { nsfwLevel: NsfwLevel.R },
+    ]);
+    const { resolveListingRatingFloorInTx } = await import('../app-listing-assets.service');
+    await expect(resolveListingRatingFloorInTx(mockDb as never, 'apl_1', 'pg')).resolves.toBe('r');
+    // Every attached asset id is considered — icon, cover AND both screenshots.
+    expect(mockDb.image.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: { in: [1, 2, 10, 11] } } })
+    );
+  });
+
+  it('returns the declared rating unchanged when the listing has NO assets (no image query)', async () => {
+    mockDb.appListing.findUnique.mockResolvedValue({ iconId: null, coverId: null });
+    mockDb.appListingScreenshot.findMany.mockResolvedValue([]);
+    const { resolveListingRatingFloorInTx } = await import('../app-listing-assets.service');
+    await expect(resolveListingRatingFloorInTx(mockDb as never, 'apl_1', 'pg')).resolves.toBe('pg');
+    expect(mockDb.image.findMany).not.toHaveBeenCalled();
+  });
+
+  it('returns the declared rating when the listing row is missing (no blind widening)', async () => {
+    mockDb.appListing.findUnique.mockResolvedValue(null);
+    const { resolveListingRatingFloorInTx } = await import('../app-listing-assets.service');
+    await expect(resolveListingRatingFloorInTx(mockDb as never, 'apl_gone', 'pg')).resolves.toBe('pg');
+  });
+
+  it('ignores a null-imageId screenshot row (deleted Image → SetNull)', async () => {
+    mockDb.appListing.findUnique.mockResolvedValue({ iconId: 1, coverId: null });
+    mockDb.appListingScreenshot.findMany.mockResolvedValue([{ imageId: null }]);
+    mockDb.image.findMany.mockResolvedValue([{ nsfwLevel: NsfwLevel.PG }]);
+    const { resolveListingRatingFloorInTx } = await import('../app-listing-assets.service');
+    await expect(resolveListingRatingFloorInTx(mockDb as never, 'apl_1', 'pg')).resolves.toBe('pg');
+    expect(mockDb.image.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { id: { in: [1] } } })
+    );
+  });
+});
+
 describe('assertAssetsScanClean', () => {
   beforeEach(resetDb);
 

--- a/src/server/services/blocks/__tests__/app-listing.public-scope.test.ts
+++ b/src/server/services/blocks/__tests__/app-listing.public-scope.test.ts
@@ -158,6 +158,26 @@ describe('listAvailableListings — STORE-SCOPE kind gate in the keyset WHERE', 
     expect(capturedSql()).not.toMatch(/al\.kind = 'offsite'/i);
   });
 
+  // 🔴 SECURITY (W13 draft-at-submit): a pre-approval DRAFT onsite listing exists in
+  // `app_listings` from submit time. The store LIST keyset WHERE must hard-gate
+  // `status='approved'` (+ `revision_of_id IS NULL`) under EVERY scope so a draft can
+  // NEVER surface on `/api/v1/apps` (or the tRPC store grid). This is the security
+  // crux — assert the gate is present regardless of the store-visibility scope.
+  it('DRAFTS CANNOT LEAK — the keyset WHERE hard-gates status=approved + revision_of_id IS NULL (both scopes)', async () => {
+    await listAvailableListings({ kind: 'all', sort: 'newest', limit: 20 }, { scope: 'full' });
+    const full = capturedSql();
+    expect(full).toMatch(/al\.status = 'approved'/i);
+    expect(full).toMatch(/al\.revision_of_id IS NULL/i);
+
+    await listAvailableListings(
+      { kind: 'all', sort: 'newest', limit: 20 },
+      { scope: 'public-external' }
+    );
+    const ext = capturedSql();
+    expect(ext).toMatch(/al\.status = 'approved'/i);
+    expect(ext).toMatch(/al\.revision_of_id IS NULL/i);
+  });
+
   it("public-external + client override input.kind='onsite' → offsite predicate STILL wins (empty)", async () => {
     // Security-audit (a): a public viewer cannot escape the offsite-only gate by
     // asking for onsite. The scope predicate `al.kind = 'offsite'` is emitted
@@ -220,6 +240,26 @@ describe('getListingDetail — STORE-SCOPE kind gate (app-layer)', () => {
   it('default scope (none passed) → full: ONSITE shown (back-compat)', async () => {
     mockDbRead.appListing.findFirst.mockResolvedValueOnce({ ...onsiteRow(), status: 'approved' });
     expect(await getListingDetail({ slug: 'cool-app' })).not.toBeNull();
+  });
+
+  // 🔴 SECURITY (W13 draft-at-submit): the DETAIL proc app-layer gate returns null for
+  // ANY non-approved row (`row.status !== 'approved'`), so a pre-approval DRAFT (or a
+  // PENDING) onsite listing is indistinguishable from a missing one — even under the
+  // most-permissive `full` scope. A crafted slug/id can never reach a draft's data on
+  // the public REST `/api/v1/apps/[slug]` or the tRPC store detail.
+  it("DRAFT CANNOT LEAK — a pre-approval DRAFT onsite listing → null under full scope", async () => {
+    mockDbRead.appListing.findFirst.mockResolvedValueOnce({
+      ...onsiteRow(),
+      status: 'draft',
+      appBlockId: null,
+      appBlock: null,
+    });
+    expect(await getListingDetail({ slug: 'cool-app' }, { scope: 'full' })).toBeNull();
+  });
+
+  it('DRAFT CANNOT LEAK — a PENDING onsite listing → null under full scope', async () => {
+    mockDbRead.appListing.findFirst.mockResolvedValueOnce({ ...onsiteRow(), status: 'pending' });
+    expect(await getListingDetail({ slug: 'cool-app' }, { scope: 'full' })).toBeNull();
   });
 
   it('none → HIDES (null) even an approved listing, and never touches the DB (default-closed guard)', async () => {

--- a/src/server/services/blocks/__tests__/offsite-listing.get-my-listing-for-app.service.test.ts
+++ b/src/server/services/blocks/__tests__/offsite-listing.get-my-listing-for-app.service.test.ts
@@ -154,6 +154,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   seq.n = 0;
   mockRead.appListing.findUnique.mockResolvedValue(null);
+  // (W13 draft-at-submit) the pre-approval DRAFT by-slug fallback reads through findFirst.
   mockRead.appListing.findFirst.mockResolvedValue(null);
   mockRead.appListingScreenshot.findMany.mockResolvedValue([]);
   mockRead.appListingPublishRequest.findFirst.mockResolvedValue(null);
@@ -420,5 +421,75 @@ describe('getMyListingForApp', () => {
     expect(editViewReads(mockRead)).toEqual([]);
     // And it never fell back to the live parent's rows.
     expect(mockWrite.appListing.create).not.toHaveBeenCalled();
+  });
+});
+
+// W13 draft-at-submit — a FIRST-version app has no AppBlock yet, so the owner-media
+// page reaches its pre-approval draft BY SLUG (`appBlockId IS NULL`). These lock the
+// slug fallback: the owner reaches their pending draft; ownership is still enforced.
+describe('getMyListingForApp — pre-approval DRAFT slug resolver (pending, no AppBlock)', () => {
+  it('resolves the pending draft BY SLUG when only a slug is given (no appBlockId lookup)', async () => {
+    mockRead.appListing.findFirst.mockResolvedValue({
+      id: 'apl_draft',
+      userId: OWNER,
+      status: 'draft',
+      contentRating: 'g',
+    });
+
+    const res = await getMyListingForApp({ slug: 'my-app', userId: OWNER });
+
+    expect(res).toEqual({
+      appListingId: 'apl_draft',
+      status: 'draft',
+      contentRating: 'g',
+      hasPendingRevision: false,
+    });
+    // Never touches the appBlockId path when no appBlockId is supplied.
+    expect(mockRead.appListing.findUnique).not.toHaveBeenCalled();
+    // Scoped to the EXACT pre-approval-draft shape (onsite / null appBlockId / draft).
+    expect(mockRead.appListing.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { slug: 'my-app', kind: 'onsite', appBlockId: null, status: 'draft' },
+      })
+    );
+  });
+
+  it('falls back to the slug draft when the appBlockId lookup misses', async () => {
+    mockRead.appListing.findUnique.mockResolvedValue(null); // no approved listing yet
+    mockRead.appListing.findFirst.mockResolvedValue({
+      id: 'apl_draft',
+      userId: OWNER,
+      status: 'draft',
+      contentRating: 'pg',
+    });
+
+    const res = await getMyListingForApp({ appBlockId: 'maybe', slug: 'my-app', userId: OWNER });
+
+    expect(res.appListingId).toBe('apl_draft');
+    expect(mockRead.appListing.findUnique).toHaveBeenCalledOnce();
+    expect(mockRead.appListing.findFirst).toHaveBeenCalledOnce();
+  });
+
+  it("a draft owned by ANOTHER user → NOT_OWNED (ownership still enforced on the slug path)", async () => {
+    mockRead.appListing.findFirst.mockResolvedValue({
+      id: 'apl_draft',
+      userId: OTHER,
+      status: 'draft',
+      contentRating: 'g',
+    });
+
+    await expect(getMyListingForApp({ slug: 'my-app', userId: OWNER })).rejects.toMatchObject({
+      name: 'OffsiteRequestError',
+      code: 'NOT_OWNED',
+    });
+    expect(mockRead.appListingPublishRequest.findFirst).not.toHaveBeenCalled();
+  });
+
+  it('no draft for the slug → NOT_FOUND', async () => {
+    mockRead.appListing.findFirst.mockResolvedValue(null);
+
+    const err = await getMyListingForApp({ slug: 'ghost', userId: OWNER }).catch((e) => e);
+    expect(err).toBeInstanceOf(OffsiteRequestError);
+    expect(err.code).toBe('NOT_FOUND');
   });
 });

--- a/src/server/services/blocks/__tests__/offsite-listing.get-my-listing-for-app.service.test.ts
+++ b/src/server/services/blocks/__tests__/offsite-listing.get-my-listing-for-app.service.test.ts
@@ -103,7 +103,9 @@ function editViewRow(ssRowId: string, overrides: Record<string, unknown> = {}) {
     coverId: 137918011,
     icon: { url: 'icon-key' },
     cover: { url: 'cover-key' },
-    screenshots: [{ id: ssRowId, imageId: 30, order: 0, caption: null, image: { url: 'shot-key' } }],
+    screenshots: [
+      { id: ssRowId, imageId: 30, order: 0, caption: null, image: { url: 'shot-key' } },
+    ],
     ...overrides,
   };
 }
@@ -435,17 +437,30 @@ describe('getMyListingForApp — pre-approval DRAFT slug resolver (pending, no A
       status: 'draft',
       contentRating: 'g',
     });
+    // A draft is NOT approved → no shadow revision; it is its own EFFECTIVE edit target,
+    // so the edit-view assets are read straight off `apl_draft` (#3476 projection).
+    wireFindUnique({ entry: null, viewByListingId: { apl_draft: editViewRow('apls_draft') } });
 
     const res = await getMyListingForApp({ slug: 'my-app', userId: OWNER });
 
-    expect(res).toEqual({
+    expect(res).toMatchObject({
       appListingId: 'apl_draft',
       status: 'draft',
       contentRating: 'g',
       hasPendingRevision: false,
+      // Edited in place while pending — no shadow is minted for a draft.
+      shadowId: null,
     });
-    // Never touches the appBlockId path when no appBlockId is supplied.
-    expect(mockRead.appListing.findUnique).not.toHaveBeenCalled();
+    // The media editor can SEE the icon/cover it is about to edit on a pending draft.
+    expect(res.assets.icon).not.toBeNull();
+    expect(res.assets.cover).not.toBeNull();
+    // The only findUnique is the edit-view read — never the appBlockId entry resolve.
+    expect(editViewReads(mockRead)).toEqual(['apl_draft']);
+    expect(
+      mockRead.appListing.findUnique.mock.calls.some(
+        ([a]) => (a as { where?: { appBlockId?: string } })?.where?.appBlockId != null
+      )
+    ).toBe(false);
     // Scoped to the EXACT pre-approval-draft shape (onsite / null appBlockId / draft).
     expect(mockRead.appListing.findFirst).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -455,7 +470,8 @@ describe('getMyListingForApp — pre-approval DRAFT slug resolver (pending, no A
   });
 
   it('falls back to the slug draft when the appBlockId lookup misses', async () => {
-    mockRead.appListing.findUnique.mockResolvedValue(null); // no approved listing yet
+    // Entry resolve by appBlockId MISSES (no approved listing yet) → slug fallback wins.
+    wireFindUnique({ entry: null, viewByListingId: { apl_draft: editViewRow('apls_draft') } });
     mockRead.appListing.findFirst.mockResolvedValue({
       id: 'apl_draft',
       userId: OWNER,
@@ -466,11 +482,11 @@ describe('getMyListingForApp — pre-approval DRAFT slug resolver (pending, no A
     const res = await getMyListingForApp({ appBlockId: 'maybe', slug: 'my-app', userId: OWNER });
 
     expect(res.appListingId).toBe('apl_draft');
-    expect(mockRead.appListing.findUnique).toHaveBeenCalledOnce();
     expect(mockRead.appListing.findFirst).toHaveBeenCalledOnce();
+    expect(editViewReads(mockRead)).toEqual(['apl_draft']);
   });
 
-  it("a draft owned by ANOTHER user → NOT_OWNED (ownership still enforced on the slug path)", async () => {
+  it('a draft owned by ANOTHER user → NOT_OWNED (ownership still enforced on the slug path)', async () => {
     mockRead.appListing.findFirst.mockResolvedValue({
       id: 'apl_draft',
       userId: OTHER,

--- a/src/server/services/blocks/__tests__/publish-request.draftAtSubmit.test.ts
+++ b/src/server/services/blocks/__tests__/publish-request.draftAtSubmit.test.ts
@@ -67,7 +67,9 @@ const SUBMITTER = 4242;
 
 beforeEach(() => {
   vi.clearAllMocks();
-  db.write.appBlockPublishRequest.update.mockImplementation(async (a: { data?: unknown }) => a?.data ?? {});
+  db.write.appBlockPublishRequest.update.mockImplementation(
+    async (a: { data?: unknown }) => a?.data ?? {}
+  );
   db.write.appBlockPublishRequest.updateMany.mockResolvedValue({ count: 1 });
   db.write.appListing.deleteMany.mockResolvedValue({ count: 1 });
   db.read.appListing.findFirst.mockResolvedValue(null);

--- a/src/server/services/blocks/__tests__/publish-request.draftAtSubmit.test.ts
+++ b/src/server/services/blocks/__tests__/publish-request.draftAtSubmit.test.ts
@@ -1,0 +1,175 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * W13 draft-at-submit — REJECT / WITHDRAW cleanup of the pre-approval on-site DRAFT
+ * `AppListing`.
+ *
+ * On reject or withdraw of a first-version on-site publish request, the draft listing
+ * minted at submit must be DELETED (release the slug + drop unreviewed media),
+ * mirroring the off-site `closeTerminalListing` draft branch: a status-guarded
+ * `deleteMany({ status:'draft' })` — the DB FKs then cascade `AppListingScreenshot`
+ * and SetNull the `Image` rows (verified structurally, not in this mock). Resolved BY
+ * SLUG (the on-site request has no appListingId FK). A subsequent-version / legacy
+ * pre-ship request has no such draft → the `deleteMany` is a harmless 0-row no-op.
+ *
+ * DB fully mocked — only the reads/writes reject/withdraw make are stubbed.
+ */
+
+const { db } = vi.hoisted(() => {
+  const make = () => ({
+    appBlockPublishRequest: {
+      findUnique: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
+      update: vi.fn(async (a: { data?: unknown }) => a?.data ?? {}),
+      updateMany: vi.fn(async (..._a: unknown[]) => ({ count: 1 })),
+    },
+    appListing: {
+      // reset-listing probe (closeOnsiteResetListingOnWithdraw) — null = not a reset.
+      findFirst: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
+      // the draft cleanup.
+      deleteMany: vi.fn(async (..._a: unknown[]) => ({ count: 1 })),
+    },
+    appReviewAgentReport: {
+      findFirst: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
+      updateMany: vi.fn(async (..._a: unknown[]) => ({ count: 0 })),
+    },
+    $transaction: vi.fn(async (fn: unknown) =>
+      typeof fn === 'function' ? (fn as (tx: unknown) => unknown)(db.write) : undefined
+    ),
+  });
+  const db = { read: make(), write: make() };
+  return { db };
+});
+
+vi.mock('~/server/db/client', () => ({ dbRead: db.read, dbWrite: db.write }));
+vi.mock('~/env/server', () => ({
+  env: { APPS_DOMAIN: 'apps.example', NEXTAUTH_URL: 'https://civitai.example' },
+}));
+vi.mock('~/utils/bundle-s3', () => ({
+  getBundleBucket: () => 'bundles',
+  getBundleS3Client: () => ({ send: vi.fn(async () => ({})) }),
+  bundleKey: (sha: string) => `bundles/${sha}.zip`,
+  deleteStagedBundle: vi.fn(async () => undefined),
+}));
+vi.mock('~/server/services/blocks/forgejo.service', () => ({
+  ensureReviewRepo: vi.fn(async () => undefined),
+  commitFiles: vi.fn(async () => ({ sha: 'x' })),
+}));
+vi.mock('~/server/services/blocks/app-block-notify', () => ({
+  notifyAppBlockSubmitter: vi.fn(async () => undefined),
+}));
+
+const { rejectRequest, withdrawRequest } = await import(
+  '~/server/services/blocks/publish-request.service'
+);
+
+const SLUG = 'cool-app';
+const SUBMITTER = 4242;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  db.write.appBlockPublishRequest.update.mockImplementation(async (a: { data?: unknown }) => a?.data ?? {});
+  db.write.appBlockPublishRequest.updateMany.mockResolvedValue({ count: 1 });
+  db.write.appListing.deleteMany.mockResolvedValue({ count: 1 });
+  db.read.appListing.findFirst.mockResolvedValue(null);
+  db.write.appReviewAgentReport.findFirst.mockResolvedValue(null);
+});
+
+/** The scoped draft-delete call (ignores any unrelated appListing writes). */
+function draftDeleteCalls() {
+  return db.write.appListing.deleteMany.mock.calls.filter((c) => {
+    const w = (c[0] as { where?: Record<string, unknown> })?.where ?? {};
+    return w.kind === 'onsite' && w.status === 'draft' && w.appBlockId === null;
+  });
+}
+
+describe('rejectRequest — deletes the pre-approval draft (status-guarded, by slug)', () => {
+  beforeEach(() => {
+    db.read.appBlockPublishRequest.findUnique.mockResolvedValue({
+      id: 'req_1',
+      status: 'pending',
+      deployState: null,
+      slug: SLUG,
+      version: '0.1.0',
+      manifest: { name: 'Cool App' },
+      submittedByUserId: SUBMITTER,
+    });
+  });
+
+  it('flips the request → rejected AND deletes the on-site draft for the slug (cascade screenshots, SetNull images)', async () => {
+    await rejectRequest({
+      publishRequestId: 'req_1',
+      reviewerUserId: 9,
+      rejectionReason: 'not good enough for production',
+    });
+
+    expect(db.write.appBlockPublishRequest.update).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ status: 'rejected' }) })
+    );
+    const deletes = draftDeleteCalls();
+    expect(deletes).toHaveLength(1);
+    // Status-guarded delete (can never remove an approved/removed row).
+    expect(deletes[0][0]).toEqual({
+      where: { slug: SLUG, kind: 'onsite', appBlockId: null, status: 'draft' },
+    });
+  });
+
+  it('reject STANDS even if the draft cleanup throws (best-effort)', async () => {
+    db.write.appListing.deleteMany.mockRejectedValueOnce(new Error('db blip'));
+    await expect(
+      rejectRequest({
+        publishRequestId: 'req_1',
+        reviewerUserId: 9,
+        rejectionReason: 'not good enough for production',
+      })
+    ).resolves.toBeUndefined();
+    expect(db.write.appBlockPublishRequest.update).toHaveBeenCalled();
+  });
+});
+
+describe('withdrawRequest — deletes the pre-approval draft (first-version)', () => {
+  beforeEach(() => {
+    db.read.appBlockPublishRequest.findUnique.mockResolvedValue({
+      id: 'req_1',
+      status: 'pending',
+      submittedByUserId: SUBMITTER,
+      deployState: null,
+      slug: SLUG,
+    });
+  });
+
+  it('flips the request → withdrawn AND deletes the on-site draft for the slug', async () => {
+    await withdrawRequest({ publishRequestId: 'req_1', userId: SUBMITTER });
+
+    expect(db.write.appBlockPublishRequest.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: 'req_1', status: 'pending' },
+        data: { status: 'withdrawn' },
+      })
+    );
+    const deletes = draftDeleteCalls();
+    expect(deletes).toHaveLength(1);
+    expect(deletes[0][0]).toEqual({
+      where: { slug: SLUG, kind: 'onsite', appBlockId: null, status: 'draft' },
+    });
+  });
+
+  it('withdraw STANDS even if the draft cleanup throws (best-effort)', async () => {
+    db.write.appListing.deleteMany.mockRejectedValueOnce(new Error('db blip'));
+    await expect(
+      withdrawRequest({ publishRequestId: 'req_1', userId: SUBMITTER })
+    ).resolves.toBeUndefined();
+    expect(db.write.appBlockPublishRequest.updateMany).toHaveBeenCalled();
+  });
+
+  it('an already-withdrawn request is an idempotent no-op — no draft delete', async () => {
+    db.read.appBlockPublishRequest.findUnique.mockResolvedValue({
+      id: 'req_1',
+      status: 'withdrawn',
+      submittedByUserId: SUBMITTER,
+      deployState: null,
+      slug: SLUG,
+    });
+    await withdrawRequest({ publishRequestId: 'req_1', userId: SUBMITTER });
+    expect(draftDeleteCalls()).toHaveLength(0);
+  });
+});

--- a/src/server/services/blocks/__tests__/publish-request.listingSync.test.ts
+++ b/src/server/services/blocks/__tests__/publish-request.listingSync.test.ts
@@ -105,9 +105,16 @@ vi.mock('~/utils/bundle-s3', () => ({
 }));
 // W13 draft-at-submit: the (3b-transition) + (3b-reset) go-live scan-clean gate is a
 // no-op here (media scan-clean is exercised in the assets-service suite). Both are
-// dynamic imports, so mocking just the one helper the approve path pulls is safe.
+// dynamic imports, so mocking just the helpers the approve path pulls is safe.
+// `resolveListingRatingFloorInTx` defaults to IDENTITY (returns the declared rating
+// unchanged = no mature media attached); the raise-only derive itself is unit-tested
+// for real in the assets-service suite. A test below overrides it to pin that the
+// transition writes the FLOOR's result, not the raw AppBlock rating.
 vi.mock('~/server/services/blocks/app-listing-assets.service', () => ({
   assertListingAssetsScanCleanInTx: vi.fn(async () => undefined),
+  resolveListingRatingFloorInTx: vi.fn(
+    async (_db: unknown, _id: string, declared: string | null) => declared
+  ),
 }));
 
 const { approveRequest } = await import('~/server/services/blocks/publish-request.service');
@@ -471,5 +478,60 @@ describe('approveRequest (3b-transition) — draft-at-submit transitions the pen
     await approveRequest({ publishRequestId: 'req_1', reviewerUserId: 9 });
 
     expect(db.write.appListing.create).toHaveBeenCalledTimes(1);
+  });
+
+  // -------------------------------------------------------------------------
+  // 🔴 RATING FLOOR at go-live. The AppBlock's contentRating is MANIFEST-declared
+  // (author-controlled) and the attach path deliberately accepts an image ABOVE the
+  // declared rating (see the assets suite: "setIcon ATTACHES an over-declared-rating
+  // image (X image on a g listing)") because draft/pending listings are "rated at
+  // approve". This is that approve — so it must stamp the FLOORED rating, never the
+  // raw declared one, or mature media goes live on a g-rated card and passes
+  // listingMatureFilter(redCapable=false) to SFW-only users.
+  // -------------------------------------------------------------------------
+  it('stamps the MEDIA-DERIVED floor, not the manifest-declared rating, when the pending media is more mature', async () => {
+    const assets = await import('~/server/services/blocks/app-listing-assets.service');
+    // The draft carries an R-rated icon the author attached while pending; the
+    // AppBlock/manifest still declares 'pg'.
+    // `Once` so the identity default is restored for the following tests (clearAllMocks
+    // clears calls, not implementations).
+    vi.mocked(assets.resolveListingRatingFloorInTx).mockResolvedValueOnce('r');
+    db.write.appListing.findFirst.mockImplementation(draftFor('apl_draft'));
+    db.write.appListing.updateMany.mockResolvedValue({ count: 1 });
+
+    await approveRequest({ publishRequestId: 'req_1', reviewerUserId: 9 });
+
+    // The floor is resolved against THIS draft's id, on the primary client.
+    expect(assets.resolveListingRatingFloorInTx).toHaveBeenCalledWith(
+      expect.anything(),
+      'apl_draft',
+      'pg'
+    );
+    const transitionCall = db.write.appListing.updateMany.mock.calls.find(
+      (c) => 'appBlockId' in (((c[0] as { data?: Record<string, unknown> })?.data ?? {}) as object)
+    );
+    const data = (transitionCall![0] as { data: Record<string, unknown> }).data;
+    // 🔴 The RAISED rating is what goes live — NOT the declared 'pg'.
+    expect(data.contentRating).toBe('r');
+  });
+
+  // -------------------------------------------------------------------------
+  // 🔴 OWNER SCOPE. The transition carries the draft's `userId` forward untouched, so
+  // transitioning a draft owned by ANOTHER user would hand them ownership of this
+  // submitter's approved listing (the asset procs gate on AppListing.userId).
+  // -------------------------------------------------------------------------
+  it('resolves the draft OWNER-SCOPED to the request submitter (a foreign draft is not transitioned)', async () => {
+    db.write.appListing.findFirst.mockImplementation(draftFor('apl_draft'));
+    db.write.appListing.updateMany.mockResolvedValue({ count: 1 });
+
+    await approveRequest({ publishRequestId: 'req_1', reviewerUserId: 9 });
+
+    const draftProbe = db.write.appListing.findFirst.mock.calls
+      .map((c) => (c[0] as { where?: Record<string, unknown> })?.where ?? {})
+      .find((w) => w.status === 'draft' && w.appBlockId === null);
+    expect(draftProbe).toBeDefined();
+    // Scoped to the submitter (the fixture request's submittedByUserId) — a same-slug
+    // draft owned by anyone else cannot match.
+    expect(draftProbe!.userId).toBe(4242);
   });
 });

--- a/src/server/services/blocks/__tests__/publish-request.listingSync.test.ts
+++ b/src/server/services/blocks/__tests__/publish-request.listingSync.test.ts
@@ -103,6 +103,12 @@ vi.mock('~/utils/bundle-s3', () => ({
   getBundleBucket: () => 'bundles',
   getBundleS3Client: () => s3,
 }));
+// W13 draft-at-submit: the (3b-transition) + (3b-reset) go-live scan-clean gate is a
+// no-op here (media scan-clean is exercised in the assets-service suite). Both are
+// dynamic imports, so mocking just the one helper the approve path pulls is safe.
+vi.mock('~/server/services/blocks/app-listing-assets.service', () => ({
+  assertListingAssetsScanCleanInTx: vi.fn(async () => undefined),
+}));
 
 const { approveRequest } = await import('~/server/services/blocks/publish-request.service');
 
@@ -395,5 +401,75 @@ describe('approveRequest (3b-sync) — SUBSEQUENT approve re-syncs manifest-gove
       )
     ).toBe(false);
     warn.mockRestore();
+  });
+});
+
+describe('approveRequest (3b-transition) — draft-at-submit transitions the pending draft → approved', () => {
+  // Return the pre-approval draft for the slug-scoped resolve, null for the
+  // (3b-reset) appBlockId+pending probe (so the unrelated reset branch stays inert).
+  function draftFor(id: string) {
+    return async (args: { where?: Record<string, unknown> }) => {
+      const w = args?.where ?? {};
+      if (w.status === 'draft' && w.appBlockId === null) return { id };
+      return null;
+    };
+  }
+
+  it('TRANSITIONS the draft in place (appBlockId+approved+scalars) and does NOT create a second listing; media (icon/cover) is NEVER touched', async () => {
+    db.write.appListing.findFirst.mockImplementation(draftFor('apl_draft'));
+    db.write.appListing.updateMany.mockResolvedValue({ count: 1 });
+
+    await approveRequest({ publishRequestId: 'req_1', reviewerUserId: 9 });
+
+    // No fresh create — the existing draft BECOMES the approved listing (media preserved).
+    expect(db.write.appListing.create).not.toHaveBeenCalled();
+
+    // The transition updateMany carries appBlockId + status:approved + manifest scalars,
+    // status-guarded on the draft.
+    const transitionCall = db.write.appListing.updateMany.mock.calls.find((c) => {
+      const d = (c[0] as { data?: Record<string, unknown> })?.data ?? {};
+      return 'appBlockId' in d;
+    });
+    expect(transitionCall).toBeDefined();
+    const arg = transitionCall![0] as {
+      where: Record<string, unknown>;
+      data: Record<string, unknown>;
+    };
+    expect(arg.where).toEqual({ id: 'apl_draft', status: 'draft' });
+    expect(arg.data).toEqual({
+      appBlockId: 'apb_1',
+      status: 'approved',
+      contentRating: 'pg',
+      name: 'Cool App v2',
+      description: 'Now with more cool.',
+      tagline: 'The coolest app',
+      category: 'utility',
+    });
+    // 🔴 Media columns are NEVER in the transition payload — icon/cover survive approval.
+    expect(arg.data).not.toHaveProperty('iconId');
+    expect(arg.data).not.toHaveProperty('coverId');
+  });
+
+  it('FLOOR STAYS ADVISORY: approve is NOT blocked when the draft has no icon/cover (transition still runs)', async () => {
+    // No `assertListingMeetsFloor` on the onsite approve path — a media-less draft still
+    // transitions to approved (the floor gates PUBLISH visibility, not approve — D2).
+    db.write.appListing.findFirst.mockImplementation(draftFor('apl_draft'));
+    db.write.appListing.updateMany.mockResolvedValue({ count: 1 });
+
+    await expect(
+      approveRequest({ publishRequestId: 'req_1', reviewerUserId: 9 })
+    ).resolves.toMatchObject({ publishRequestId: 'req_1', appBlockId: 'apb_1' });
+    expect(db.write.appListing.create).not.toHaveBeenCalled();
+  });
+
+  it('LEGACY COMPAT: a pending request with NO draft (pre-ship) still CREATES the listing the old way at approve', async () => {
+    // Simulate a request that predates draft-at-submit: no draft resolvable by slug, and
+    // no listing keyed by appBlockId → falls through to the legacy mapper-create path.
+    db.write.appListing.findFirst.mockResolvedValue(null);
+    db.read.appListing.findUnique.mockResolvedValue(null);
+
+    await approveRequest({ publishRequestId: 'req_1', reviewerUserId: 9 });
+
+    expect(db.write.appListing.create).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/server/services/blocks/__tests__/publish-request.service.test.ts
+++ b/src/server/services/blocks/__tests__/publish-request.service.test.ts
@@ -25,16 +25,21 @@ const dbMocks = vi.hoisted(() => ({
   pubReqFindFirst: vi.fn(),
   appBlockFindFirst: vi.fn(),
   userFindUnique: vi.fn(),
+  // W13 draft-at-submit — the pre-approval draft AppListing pre-check (read) + create (write).
+  appListingFindFirst: vi.fn(),
+  appListingCreate: vi.fn(),
 }));
 
 vi.mock('~/server/db/client', () => ({
   dbRead: {
     appBlockPublishRequest: { findFirst: dbMocks.pubReqFindFirst },
     appBlock: { findFirst: dbMocks.appBlockFindFirst },
+    appListing: { findFirst: dbMocks.appListingFindFirst },
     user: { findUnique: dbMocks.userFindUnique },
   },
   dbWrite: {
     appBlockPublishRequest: { create: dbMocks.createPublishRequest },
+    appListing: { create: dbMocks.appListingCreate },
   },
 }));
 
@@ -539,6 +544,9 @@ describe('submitVersion — sensitive-scope justification gate (enforced AT SUBM
     dbMocks.appBlockFindFirst.mockResolvedValue(null);
     dbMocks.userFindUnique.mockResolvedValue({ username: 'dev' });
     dbMocks.createPublishRequest.mockResolvedValue({});
+    // Default: the store slug is free → a first-version submit mints the draft.
+    dbMocks.appListingFindFirst.mockResolvedValue(null);
+    dbMocks.appListingCreate.mockResolvedValue({ id: 'apl_draft' });
   });
 
   it('rejects a NEW sensitive-scope submit with NO scopeJustifications (was: accepted → pending)', async () => {
@@ -578,5 +586,72 @@ describe('submitVersion — sensitive-scope justification gate (enforced AT SUBM
     const result = await submitVersion({ bundleBuffer: buf, submittedByUserId: 1 });
     expect(result.slug).toBe('my-app');
     expect(dbMocks.createPublishRequest).toHaveBeenCalledTimes(1);
+  });
+
+  // W13 draft-at-submit — a FIRST-version submit mints the on-site store AppListing as
+  // a pre-approval DRAFT (kind='onsite', status='draft', appBlockId=NULL) so the author
+  // can set media while pending.
+  it('creates a pre-approval DRAFT AppListing at submit (first version, owned by submitter)', async () => {
+    const buf = await makeBundle({ ...baseManifest, scopes: [] });
+    await submitVersion({ bundleBuffer: buf, submittedByUserId: 1 });
+
+    expect(dbMocks.appListingCreate).toHaveBeenCalledTimes(1);
+    const data = (dbMocks.appListingCreate.mock.calls[0][0] as { data: Record<string, unknown> })
+      .data;
+    expect(data).toMatchObject({
+      kind: 'onsite',
+      status: 'draft',
+      appBlockId: null,
+      slug: 'my-app',
+      name: 'My App',
+      tagline: null,
+      description: null,
+      category: null,
+      contentRating: 'g',
+      userId: 1, // the submitter owns the draft
+    });
+    expect(typeof data.id).toBe('string');
+    expect(data.id as string).toMatch(/^apl_/);
+  });
+
+  it('does NOT create a draft on a SUBSEQUENT-version submit (an AppBlock already exists)', async () => {
+    dbMocks.appBlockFindFirst.mockResolvedValue({ id: 'apb_existing', appId: 'app_1' });
+    const buf = await makeBundle({ ...baseManifest, version: '0.2.0', scopes: [] });
+    await submitVersion({ bundleBuffer: buf, submittedByUserId: 1 });
+
+    expect(dbMocks.createPublishRequest).toHaveBeenCalledTimes(1);
+    expect(dbMocks.appListingCreate).not.toHaveBeenCalled();
+  });
+
+  it('re-submit does NOT duplicate — a reusable on-site orphan draft is reused, not re-created', async () => {
+    // A first-version re-submit whose prior draft survived (cleanup didn't run) →
+    // the pre-check finds the reusable on-site pre-approval draft and skips the create.
+    dbMocks.appListingFindFirst.mockResolvedValue({
+      id: 'apl_orphan',
+      kind: 'onsite',
+      status: 'draft',
+      appBlockId: null,
+    });
+    const buf = await makeBundle({ ...baseManifest, scopes: [] });
+    await submitVersion({ bundleBuffer: buf, submittedByUserId: 1 });
+
+    expect(dbMocks.createPublishRequest).toHaveBeenCalledTimes(1);
+    expect(dbMocks.appListingCreate).not.toHaveBeenCalled();
+  });
+
+  it('a slug already taken by a NON-reusable listing → friendly "slug taken" (before any insert)', async () => {
+    dbMocks.appListingFindFirst.mockResolvedValue({
+      id: 'apl_live',
+      kind: 'offsite',
+      status: 'approved',
+      appBlockId: null,
+    });
+    const buf = await makeBundle({ ...baseManifest, scopes: [] });
+    await expect(submitVersion({ bundleBuffer: buf, submittedByUserId: 1 })).rejects.toThrow(
+      /already taken by another store listing/
+    );
+    // Fail-fast: neither the request nor the draft is inserted.
+    expect(dbMocks.createPublishRequest).not.toHaveBeenCalled();
+    expect(dbMocks.appListingCreate).not.toHaveBeenCalled();
   });
 });

--- a/src/server/services/blocks/__tests__/publish-request.service.test.ts
+++ b/src/server/services/blocks/__tests__/publish-request.service.test.ts
@@ -631,12 +631,49 @@ describe('submitVersion — sensitive-scope justification gate (enforced AT SUBM
       kind: 'onsite',
       status: 'draft',
       appBlockId: null,
+      userId: 1, // owned by THIS submitter — reuse is owner-scoped
     });
     const buf = await makeBundle({ ...baseManifest, scopes: [] });
     await submitVersion({ bundleBuffer: buf, submittedByUserId: 1 });
 
     expect(dbMocks.createPublishRequest).toHaveBeenCalledTimes(1);
     expect(dbMocks.appListingCreate).not.toHaveBeenCalled();
+  });
+
+  // -------------------------------------------------------------------------
+  // 🔴 Orphan reuse is OWNER-SCOPED. An orphan draft keeps its original `userId`, and
+  // the approve transition carries that `userId` forward untouched — so reusing
+  // ANOTHER user's orphan would hand them ownership of THIS submitter's approved
+  // listing (the asset procs gate on AppListing.userId, so they'd control its media).
+  // -------------------------------------------------------------------------
+  it('REFUSES to reuse an orphan draft owned by a DIFFERENT user (no cross-user listing takeover)', async () => {
+    dbMocks.appListingFindFirst.mockResolvedValue({
+      id: 'apl_orphan_foreign',
+      kind: 'onsite',
+      status: 'draft',
+      appBlockId: null,
+      userId: 999, // someone ELSE's abandoned draft on this slug
+    });
+    const buf = await makeBundle({ ...baseManifest, scopes: [] });
+    // Treated as TAKEN, exactly like any other foreign listing on the slug.
+    await expect(submitVersion({ bundleBuffer: buf, submittedByUserId: 1 })).rejects.toThrow(
+      /already taken by another store listing/
+    );
+    // Fail-fast: nothing is inserted, and the foreign draft is never adopted.
+    expect(dbMocks.createPublishRequest).not.toHaveBeenCalled();
+    expect(dbMocks.appListingCreate).not.toHaveBeenCalled();
+  });
+
+  it('the slug pre-check SELECTS userId (the owner-scope decision cannot be made without it)', async () => {
+    const buf = await makeBundle({ ...baseManifest, scopes: [] });
+    await submitVersion({ bundleBuffer: buf, submittedByUserId: 1 });
+
+    const call = dbMocks.appListingFindFirst.mock.calls[0][0] as {
+      where: Record<string, unknown>;
+      select: Record<string, unknown>;
+    };
+    expect(call.where).toEqual({ slug: 'my-app' });
+    expect(call.select).toMatchObject({ userId: true });
   });
 
   it('a slug already taken by a NON-reusable listing → friendly "slug taken" (before any insert)', async () => {

--- a/src/server/services/blocks/app-listing-assets.service.ts
+++ b/src/server/services/blocks/app-listing-assets.service.ts
@@ -563,6 +563,58 @@ export async function assertListingAssetsScanCleanInTx(
   );
 }
 
+/**
+ * Go-live RATING FLOOR for a listing whose media was attached while it was directly
+ * asset-editable (a pre-approval `draft` / reset `pending` listing). Re-derives the
+ * rating from the current assets' max `nsfwLevel` and returns `declaredRating` RAISED
+ * to the derived value when the media is more mature — never lowered.
+ *
+ * 🔴 The on-site counterpart of the off-site approve's `resolveApprovalContentRating`
+ * floor. It upholds the invariant stated at {@link reDeriveContentRatingForModLiveEdit}:
+ * *draft/pending/shadow listings are rated at approve*. Without it a manifest-declared
+ * `contentRating` (author-controlled) is stamped verbatim over media the author attached
+ * while pending — and nothing else catches it, because the attach path
+ * ({@link loadValidatedImage}) rejects only `Blocked`/`NotFound` images, never a
+ * `Scanned` mature one. An under-rated listing then passes
+ * `listingMatureFilter(redCapable=false)` (`content_rating NOT IN ('r','x')`) and shows
+ * mature store art to SFW-only users.
+ *
+ * RAISE-ONLY, so it can only ever tighten: a deliberately higher rating is never
+ * auto-lowered by tamer media, and a listing with no attached assets (or a missing row)
+ * returns `declaredRating` unchanged. `db` is typed `Prisma.TransactionClient` so an
+ * in-tx caller passes its `tx`; a non-transactional caller may pass `dbWrite` (a
+ * `PrismaClient` is structurally a `TransactionClient` for these reads).
+ */
+export async function resolveListingRatingFloorInTx(
+  db: Prisma.TransactionClient,
+  appListingId: string,
+  declaredRating: string | null
+): Promise<string | null> {
+  const listing = await db.appListing.findUnique({
+    where: { id: appListingId },
+    select: { iconId: true, coverId: true },
+  });
+  if (!listing) return declaredRating;
+  const shots = await db.appListingScreenshot.findMany({
+    where: { appListingId, imageId: { not: null } },
+    select: { imageId: true },
+  });
+  const imageIds = [listing.iconId, listing.coverId, ...shots.map((s) => s.imageId)].filter(
+    (v): v is number => v != null
+  );
+  if (imageIds.length === 0) return declaredRating;
+  const images = await db.image.findMany({
+    where: { id: { in: imageIds } },
+    select: { nsfwLevel: true },
+  });
+  const derived = deriveContentRatingFromAssets(images.map((i) => ({ nsfwLevel: i.nsfwLevel })));
+  // Floor: only raise. `nsfwLevelFromContentRating` maps null → the SFW floor, so a null
+  // declared rating is raised by any mature asset.
+  return nsfwLevelFromContentRating(derived) > nsfwLevelFromContentRating(declaredRating)
+    ? derived
+    : declaredRating;
+}
+
 // ---------------------------------------------------------------------------
 // Per-asset scan-status poll (owner/mod-gated). The client attaches an in-flight
 // image IMMEDIATELY (the server stores the pending id), then polls THIS to flip a

--- a/src/server/services/blocks/offsite-listing.service.ts
+++ b/src/server/services/blocks/offsite-listing.service.ts
@@ -1528,14 +1528,18 @@ export type GetMyListingForAppResult = {
 };
 
 /**
- * OWNER: resolve the caller's OWN listing by its backing `appBlockId`
- * (`AppListing.appBlockId` is `@unique`) — the entry read for the owner-facing
- * on-site listing-media page. Returns the `AppListing.id` (the target the page
- * then passes to `beginListingRevision` + the owner-gated asset procs), the
- * listing's lifecycle status + content rating, and whether a revision is already
- * under review. Owner-bound: a listing owned by another user → NOT_OWNED
- * (→FORBIDDEN); no listing row for the app → NOT_FOUND. Kind-agnostic (works for
- * both on-site and off-site listings — the on-site owner UI is the first caller).
+ * OWNER: resolve the caller's OWN listing for the owner-facing on-site
+ * listing-media page. Resolves by backing `appBlockId` (`AppListing.appBlockId` is
+ * `@unique`) when the app is approved; falls back to the pre-approval DRAFT BY SLUG
+ * (`kind='onsite', appBlockId IS NULL, status='draft'`) for a FIRST-version app that
+ * is still pending (no AppBlock exists yet) — the W13 draft-at-submit wiring gap that
+ * lets the author set media WHILE pending. At least one of `appBlockId` / `slug` must
+ * be given. Returns the `AppListing.id` (the target the page then passes to
+ * `beginListingRevision` + the owner-gated asset procs), the listing's lifecycle
+ * status + content rating, and whether a revision is already under review.
+ * Owner-bound: a listing owned by another user → NOT_OWNED (→FORBIDDEN); no listing
+ * row for the app → NOT_FOUND. Kind-agnostic (works for both on-site and off-site
+ * listings — the on-site owner UI is the first caller).
  *
  * ALSO projects the EDITABLE target's current `assets` (+ its `shadowId`). Without
  * them the media editor had no way to see the icon/cover it is about to edit: it
@@ -1545,18 +1549,39 @@ export type GetMyListingForAppResult = {
  * EFFECTIVE source (an approved parent's shadow, resolved here server-side and
  * idempotently, exactly as `getMyListingForEdit` does — see the 🔴 note on
  * `GetMyListingForAppResult.assets` for why the shadow's rows and not the parent's).
+ * A pre-approval DRAFT is NOT approved, so it has no shadow and is its own effective
+ * target — edited in place, exactly like any other non-approved listing.
  */
 export async function getMyListingForApp(opts: {
-  appBlockId: string;
+  appBlockId?: string;
+  slug?: string;
   userId: number;
 }): Promise<GetMyListingForAppResult> {
-  const { appBlockId, userId } = opts;
-  const listing = await dbRead.appListing.findUnique({
-    where: { appBlockId },
-    select: { id: true, userId: true, status: true, contentRating: true },
-  });
+  const { appBlockId, slug, userId } = opts;
+  let listing = appBlockId
+    ? await dbRead.appListing.findUnique({
+        where: { appBlockId },
+        select: { id: true, userId: true, status: true, contentRating: true },
+      })
+    : null;
+  // (W13 draft-at-submit) Pre-approval DRAFT fallback: a FIRST-version app has no
+  // backing AppBlock yet, so its draft listing (minted at submit) has
+  // `appBlockId = NULL` and is only reachable BY SLUG. Resolve it when the appBlockId
+  // lookup missed (or only a slug was supplied) so the owner-media page can reach the
+  // draft to set icon/cover/screenshots WHILE the app is pending. Scoped to the exact
+  // pre-approval-draft shape so this can never resolve some other kind/status by slug.
+  // Owner-bound below (unchanged).
+  if (!listing && slug) {
+    listing = await dbRead.appListing.findFirst({
+      where: { slug, kind: 'onsite', appBlockId: null, status: 'draft' },
+      select: { id: true, userId: true, status: true, contentRating: true },
+    });
+  }
   if (!listing) {
-    throw new OffsiteRequestError('NOT_FOUND', `no listing found for app ${appBlockId}`);
+    throw new OffsiteRequestError(
+      'NOT_FOUND',
+      `no listing found for app ${appBlockId ?? slug ?? '(unspecified)'}`
+    );
   }
   if (listing.userId !== userId) {
     throw new OffsiteRequestError('NOT_OWNED', 'you can only manage your own listings');

--- a/src/server/services/blocks/publish-request.service.ts
+++ b/src/server/services/blocks/publish-request.service.ts
@@ -1126,11 +1126,18 @@ export async function submitVersion(params: SubmitVersionParams): Promise<Submit
   // slug pre-check. An existing on-site pre-approval DRAFT for this slug (no backing
   // AppBlock) is a REUSABLE orphan (a prior submit whose reject/withdraw cleanup didn't
   // run) — reuse it idempotently rather than error, so a re-submit never duplicates.
+  //
+  // 🔴 Reuse is OWNER-SCOPED (`userId === submittedByUserId`). An orphan draft keeps its
+  // original owner, and the approve transition carries that `userId` FORWARD untouched —
+  // so reusing ANOTHER user's orphan would hand them ownership of THIS submitter's
+  // approved store listing (the listing-media procs gate on `AppListing.userId`, so they
+  // would control its media). A same-slug orphan owned by someone else is therefore
+  // treated as TAKEN, exactly like any other foreign listing on the slug.
   let createDraftListing = false;
   if (existingApp == null) {
     const existingSlugListing = await dbRead.appListing.findFirst({
       where: { slug },
-      select: { id: true, kind: true, status: true, appBlockId: true },
+      select: { id: true, kind: true, status: true, appBlockId: true, userId: true },
     });
     if (!existingSlugListing) {
       createDraftListing = true;
@@ -1138,15 +1145,16 @@ export async function submitVersion(params: SubmitVersionParams): Promise<Submit
       !(
         existingSlugListing.kind === 'onsite' &&
         existingSlugListing.status === 'draft' &&
-        existingSlugListing.appBlockId == null
+        existingSlugListing.appBlockId == null &&
+        existingSlugListing.userId === submittedByUserId
       )
     ) {
       throw new Error(
         `store slug "${slug}" is already taken by another store listing; choose a different blockId`
       );
     }
-    // else: a reusable on-site pre-approval draft already exists for this slug →
-    // reuse it (idempotent re-submit), so createDraftListing stays false.
+    // else: a reusable on-site pre-approval draft owned by THIS submitter already exists
+    // for this slug → reuse it (idempotent re-submit), so createDraftListing stays false.
   }
 
   // Deep manifest validation (contentRating / scopes / iframe.sandbox /
@@ -2539,9 +2547,22 @@ export async function approveRequest(params: ApproveRequestParams): Promise<Appr
     // draft exists — a request pending BEFORE this shipped (new-submits-only compat,
     // no backfill) or a subsequent-version approve keyed by appBlockId — this no-ops
     // and the UNCHANGED create-or-sync-by-appBlockId path below runs.
+    //
+    // 🔴 OWNER-SCOPED (`userId: request.submittedByUserId`) — defense-in-depth mirroring
+    // the submit-side reuse gate. The transition carries the draft's `userId` forward
+    // untouched, so transitioning a draft owned by ANOTHER user would hand them
+    // ownership of THIS submitter's approved listing (the listing-media procs gate on
+    // `AppListing.userId`). A foreign same-slug draft does NOT match here and falls
+    // through to the legacy create path below.
     let handledByDraftTransition = false;
     const draftListing = await dbWrite.appListing.findFirst({
-      where: { slug: request.slug, kind: 'onsite', appBlockId: null, status: 'draft' },
+      where: {
+        slug: request.slug,
+        kind: 'onsite',
+        appBlockId: null,
+        status: 'draft',
+        userId: request.submittedByUserId,
+      },
       select: { id: true },
     });
     if (draftListing) {
@@ -2556,7 +2577,7 @@ export async function approveRequest(params: ApproveRequestParams): Promise<Appr
       // still deploys, and a re-approve after the scan lands transitions it. No-op for
       // scan-clean media. Upholds: no approved listing may reference unscanned/Blocked
       // media.
-      const { assertListingAssetsScanCleanInTx } = await import(
+      const { assertListingAssetsScanCleanInTx, resolveListingRatingFloorInTx } = await import(
         '~/server/services/blocks/app-listing-assets.service'
       );
       await assertListingAssetsScanCleanInTx(dbWrite, draftListing.id);
@@ -2565,6 +2586,22 @@ export async function approveRequest(params: ApproveRequestParams): Promise<Appr
         select: { blockId: true, manifest: true, category: true, contentRating: true },
       });
       if (abForTransition) {
+        // 🔴 RATING FLOOR (go-live). The AppBlock's `contentRating` is MANIFEST-declared
+        // (author-controlled), but the author attached the icon/cover/screenshots
+        // DIRECTLY to this draft while pending, and the attach path never compares an
+        // image's `nsfwLevel` against the listing rating (it rejects only
+        // `Blocked`/`NotFound`). Stamping the declared rating verbatim would therefore
+        // let mature-but-Scanned media go live on a `g`-rated card and pass
+        // `listingMatureFilter(redCapable=false)` to SFW-only users. Raise the declared
+        // rating to the media-derived one when the media is more mature (RAISE-ONLY — a
+        // deliberately higher declaration is never lowered). Same floor the off-site
+        // approve applies via `resolveApprovalContentRating`; upholds the
+        // "draft/pending listings are rated at approve" invariant.
+        const flooredRating = await resolveListingRatingFloorInTx(
+          dbWrite,
+          draftListing.id,
+          abForTransition.contentRating
+        );
         const transitioned = await dbWrite.appListing.updateMany({
           // Status-guarded (draft): a re-approve after a mid-flight failure finds the
           // row already `approved` (0-count, benign) → converges without a duplicate.
@@ -2573,9 +2610,10 @@ export async function approveRequest(params: ApproveRequestParams): Promise<Appr
             // Link the now-existing AppBlock (was NULL) — first writer satisfies @unique.
             appBlockId,
             status: 'approved',
-            // Mirror the runtime AppBlock rating (single source of truth — same as the
-            // mapper's create path), re-synced from the authoritative AppBlock column.
-            contentRating: abForTransition.contentRating,
+            // The runtime AppBlock rating (single source of truth — same as the mapper's
+            // create path), FLOORED at the rating derived from the media the author
+            // attached while pending (raise-only; see the comment above).
+            contentRating: flooredRating,
             // Manifest-governed scalars ONLY. iconId/coverId/screenshots, featured,
             // slug are NOT touched, so the author's pending media carries forward.
             ...buildListingScalarSync({

--- a/src/server/services/blocks/publish-request.service.ts
+++ b/src/server/services/blocks/publish-request.service.ts
@@ -994,11 +994,12 @@ async function getPreviousApprovedState(
  * second round-trip.
  */
 export async function submitVersion(params: SubmitVersionParams): Promise<SubmitVersionResult> {
-  const [{ dbRead, dbWrite }, { newUlid }, { SEMVER_REGEX, SLUG_REGEX }] = await Promise.all([
-    import('~/server/db/client'),
-    import('~/server/utils/app-block-ids'),
-    import('~/server/schema/blocks/publish-request.schema'),
-  ]);
+  const [{ dbRead, dbWrite }, { newUlid, newAppListingId }, { SEMVER_REGEX, SLUG_REGEX }] =
+    await Promise.all([
+      import('~/server/db/client'),
+      import('~/server/utils/app-block-ids'),
+      import('~/server/schema/blocks/publish-request.schema'),
+    ]);
   const { bundleBuffer, submittedByUserId } = params;
 
   if (bundleBuffer.length > MAX_BUNDLE_SIZE_BYTES) {
@@ -1110,6 +1111,44 @@ export async function submitVersion(params: SubmitVersionParams): Promise<Submit
     select: { id: true, appId: true },
   });
 
+  // (submit-draft pre-check) W13 draft-at-submit — a FIRST-version submit now also
+  // mints the on-site store `AppListing` as a pre-approval DRAFT (kind='onsite',
+  // status='draft', appBlockId=NULL) so the author can set listing media
+  // (icon/cover/screenshots) WHILE the app is still pending review (they carry
+  // forward on approve). Mirrors the proven off-site `submitExternalListing` shape (a
+  // draft listing minted at submit, deleted on reject/withdraw). Only a first-version
+  // submit (`existingApp == null`) is meaningful: a subsequent version already has an
+  // approved listing whose media edits go through the shadow-revision path.
+  //
+  // Fail fast (BEFORE the MinIO upload + review-repo push) if the store slug is
+  // already taken in `app_listings` by a NON-reusable listing — the draft reserves
+  // `AppListing.slug @unique`, and the friendly error mirrors `submitExternalListing`'s
+  // slug pre-check. An existing on-site pre-approval DRAFT for this slug (no backing
+  // AppBlock) is a REUSABLE orphan (a prior submit whose reject/withdraw cleanup didn't
+  // run) — reuse it idempotently rather than error, so a re-submit never duplicates.
+  let createDraftListing = false;
+  if (existingApp == null) {
+    const existingSlugListing = await dbRead.appListing.findFirst({
+      where: { slug },
+      select: { id: true, kind: true, status: true, appBlockId: true },
+    });
+    if (!existingSlugListing) {
+      createDraftListing = true;
+    } else if (
+      !(
+        existingSlugListing.kind === 'onsite' &&
+        existingSlugListing.status === 'draft' &&
+        existingSlugListing.appBlockId == null
+      )
+    ) {
+      throw new Error(
+        `store slug "${slug}" is already taken by another store listing; choose a different blockId`
+      );
+    }
+    // else: a reusable on-site pre-approval draft already exists for this slug →
+    // reuse it (idempotent re-submit), so createDraftListing stays false.
+  }
+
   // Deep manifest validation (contentRating / scopes / iframe.sandbox /
   // targets / scope subset / iframe.src origin) happens at the
   // BlockManifestValidator step in the approve flow, when the
@@ -1199,6 +1238,58 @@ export async function submitVersion(params: SubmitVersionParams): Promise<Submit
       );
     }
     throw err;
+  }
+
+  // (submit-draft) W13 draft-at-submit — mint the pre-approval on-site draft
+  // `AppListing` now that the pending request exists. Ordered AFTER the request create
+  // so there is never a draft orphaned without a request: a request without a draft
+  // simply falls back to the legacy approve-time create path (new-submits-only compat),
+  // while a draft can only exist alongside its request.
+  //
+  // BEST-EFFORT (log-and-continue, same posture as the approve-path listing writes):
+  // the store listing is a convenience and must NEVER fail the primary submit. If the
+  // draft create loses a rare slug race (P2002) the pre-check above missed, or hits a
+  // transient DB error, the submit still succeeds — the author just can't set media
+  // until approve mints the listing the legacy way. Only created for a first-version
+  // submit that didn't reuse an existing orphan draft.
+  if (createDraftListing) {
+    try {
+      const { buildListingScalarSync } = await import('./app-listing-mapper');
+      const scalars = buildListingScalarSync({
+        manifest,
+        blockId: slug,
+        category: typeof manifest.category === 'string' ? manifest.category : null,
+      });
+      await dbWrite.appListing.create({
+        data: {
+          id: newAppListingId(),
+          kind: 'onsite',
+          status: 'draft',
+          slug,
+          name: scalars.name,
+          tagline: scalars.tagline,
+          description: scalars.description,
+          category: scalars.category,
+          // Seed the maturity rating from the submitted manifest (approve re-syncs it
+          // authoritatively from the AppBlock); default SFW so an omitted rating is never
+          // mature. Drives the asset NSFW-scan threshold while pending.
+          contentRating: typeof manifest.contentRating === 'string' ? manifest.contentRating : 'g',
+          // No backing AppBlock until approve — the draft is tied to its pending request
+          // purely by the shared, @unique slug.
+          appBlockId: null,
+          userId: submittedByUserId,
+        },
+      });
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        `[submitVersion] pre-approval draft AppListing create failed (slug=${slug}); submit STANDS — ` +
+          `the app is still reviewable and its store listing is minted at approve the legacy way, so the ` +
+          `author sets media after approval instead of while pending: ${
+            err instanceof Error ? err.message : String(err)
+          }`
+      );
+    }
   }
 
   // Fire-and-forget Discord notify to the mod queue. Don't await — a
@@ -1338,6 +1429,24 @@ async function closeOnsiteResetListingOnWithdraw(opts: {
 }
 
 /**
+ * W13 draft-at-submit cleanup — on REJECT or WITHDRAW of a first-version on-site
+ * publish request, delete the pre-approval DRAFT `AppListing` minted at submit so the
+ * store slug is released and the unreviewed media is discarded. Mirrors the off-site
+ * `closeTerminalListing` draft branch: a status-guarded `deleteMany` (`status:'draft'`)
+ * can never remove an approved/removed row; `AppListingScreenshot` is
+ * `onDelete: Cascade` so screenshots go with it, and the underlying `Image` rows are
+ * `onDelete: SetNull` (DETACHED, not hard-deleted — same as off-site). Resolved BY SLUG
+ * (no request→listing FK). No-op for a subsequent-version request (no such draft), an
+ * already-cleaned draft, or a legacy pre-ship pending request.
+ */
+async function deleteOnsiteDraftListingForSlug(opts: { slug: string }): Promise<void> {
+  const { dbWrite } = await import('~/server/db/client');
+  await dbWrite.appListing.deleteMany({
+    where: { slug: opts.slug, kind: 'onsite', appBlockId: null, status: 'draft' },
+  });
+}
+
+/**
  * Dev-facing withdrawal of their own pending request. Idempotent
  * (re-withdrawing is a no-op if already withdrawn). Throws a typed
  * {@link WithdrawRequestError} on a missing row, another user's row, or a
@@ -1411,6 +1520,21 @@ export async function withdrawRequest(opts: {
     // owner self-restore — a mod must `relistListing` (which also un-suspends the
     // block). A first-time submission withdraw has no `pending` onsite listing → no-op.
     await closeOnsiteResetListingOnWithdraw({ slug: row.slug, actorUserId: userId });
+    // W13 draft-at-submit — also delete a FIRST-version pre-approval DRAFT listing
+    // (disjoint from the reset case above, which targets a `pending` on-site listing;
+    // a first-time draft is `status='draft'`). Release the slug + drop unreviewed
+    // media. Best-effort: the withdraw has already committed, so a cleanup failure must
+    // never fail the outcome (the slug stays reserved until a later cleanup / mod
+    // delete — recoverable).
+    try {
+      await deleteOnsiteDraftListingForSlug({ slug: row.slug });
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        `[withdrawRequest] pre-approval draft cleanup failed (id=${publishRequestId}, slug=${row.slug}); ` +
+          `withdraw STANDS: ${err instanceof Error ? err.message : String(err)}`
+      );
+    }
     // MOD REVIEW SANDBOX (#2831) — tear down any review env spun up for this
     // request. Best-effort + non-blocking (mirrors approveRequest/rejectRequest):
     // the withdraw has already committed, so a teardown failure must never affect
@@ -2404,11 +2528,90 @@ export async function approveRequest(params: ApproveRequestParams): Promise<Appr
   // first listing minted now on a subsequent-version approve.
   const { mapAppBlockToListing, buildListingScalarSync } = await import('./app-listing-mapper');
   try {
-    const existingListing = await dbRead.appListing.findUnique({
-      where: { appBlockId },
-      select: { id: true, kind: true },
+    // (3b-transition) W13 draft-at-submit — an app SUBMITTED after this feature
+    // shipped has a pre-approval on-site DRAFT AppListing (kind='onsite',
+    // appBlockId=NULL, status='draft', slug=request.slug) minted at submit, carrying
+    // any listing media the author set while pending. TRANSITION that draft in place
+    // → approved (PRESERVING its icon/cover/screenshots) rather than minting a fresh
+    // media-less listing via the mapper. Resolved BY SLUG on the PRIMARY (the
+    // `AppBlockPublishRequest` has no appListingId FK; the primary read is
+    // read-your-writes-safe + consistent with the (3b-reset) resolve below). If NO
+    // draft exists — a request pending BEFORE this shipped (new-submits-only compat,
+    // no backfill) or a subsequent-version approve keyed by appBlockId — this no-ops
+    // and the UNCHANGED create-or-sync-by-appBlockId path below runs.
+    let handledByDraftTransition = false;
+    const draftListing = await dbWrite.appListing.findFirst({
+      where: { slug: request.slug, kind: 'onsite', appBlockId: null, status: 'draft' },
+      select: { id: true },
     });
-    if (!existingListing) {
+    if (draftListing) {
+      // A draft existed → this app's listing is handled here; NEVER fall through to
+      // the create branch (that would mint a second, media-less listing).
+      handledByDraftTransition = true;
+      // Scan-clean go-live gate (same invariant + shared helper as the (3b-reset)
+      // restore below and the off-site approve flip): the draft was directly
+      // asset-editable while pending, so before making it PUBLICLY visible re-assert
+      // its media is `Scanned` (never `Pending`/`Blocked`). A throw here is caught by
+      // THIS try (log-and-continue) → the draft stays `draft` (re-review), the app
+      // still deploys, and a re-approve after the scan lands transitions it. No-op for
+      // scan-clean media. Upholds: no approved listing may reference unscanned/Blocked
+      // media.
+      const { assertListingAssetsScanCleanInTx } = await import(
+        '~/server/services/blocks/app-listing-assets.service'
+      );
+      await assertListingAssetsScanCleanInTx(dbWrite, draftListing.id);
+      const abForTransition = await dbWrite.appBlock.findUnique({
+        where: { id: appBlockId },
+        select: { blockId: true, manifest: true, category: true, contentRating: true },
+      });
+      if (abForTransition) {
+        const transitioned = await dbWrite.appListing.updateMany({
+          // Status-guarded (draft): a re-approve after a mid-flight failure finds the
+          // row already `approved` (0-count, benign) → converges without a duplicate.
+          where: { id: draftListing.id, status: 'draft' },
+          data: {
+            // Link the now-existing AppBlock (was NULL) — first writer satisfies @unique.
+            appBlockId,
+            status: 'approved',
+            // Mirror the runtime AppBlock rating (single source of truth — same as the
+            // mapper's create path), re-synced from the authoritative AppBlock column.
+            contentRating: abForTransition.contentRating,
+            // Manifest-governed scalars ONLY. iconId/coverId/screenshots, featured,
+            // slug are NOT touched, so the author's pending media carries forward.
+            ...buildListingScalarSync({
+              manifest: abForTransition.manifest,
+              blockId: abForTransition.blockId,
+              category: abForTransition.category,
+            }),
+          },
+        });
+        if (transitioned.count === 0) {
+          // eslint-disable-next-line no-console
+          console.warn(
+            `[approveRequest] draft→approved transition matched 0 rows (slug=${request.slug}, appBlockId=${appBlockId}); ` +
+              `the draft may have been concurrently cleaned/approved — re-approve or backfill converges`
+          );
+        }
+      } else {
+        // Anomalous (the just-approved AppBlock read null) — leave the draft as-is
+        // (recoverable via re-approve / backfill) rather than mint a duplicate.
+        // eslint-disable-next-line no-console
+        console.warn(
+          `[approveRequest] draft→approved transition skipped: AppBlock ${appBlockId} not readable ` +
+            `(slug=${request.slug}); the draft stays 'draft' until a re-approve/backfill`
+        );
+      }
+    }
+
+    const existingListing = handledByDraftTransition
+      ? null
+      : await dbRead.appListing.findUnique({
+          where: { appBlockId },
+          select: { id: true, kind: true },
+        });
+    if (handledByDraftTransition) {
+      // Already transitioned the pre-approval draft above — nothing more to do.
+    } else if (!existingListing) {
       const ab = await dbWrite.appBlock.findUnique({
         where: { id: appBlockId },
         select: {
@@ -4560,6 +4763,21 @@ export async function rejectRequest(params: RejectRequestParams): Promise<void> 
       rejectionReason: reason,
     },
   });
+
+  // W13 draft-at-submit — a first-version REJECT discards the pre-approval DRAFT
+  // listing (release the slug + drop unreviewed media), mirroring the off-site
+  // `closeTerminalListing` draft branch. No-op for a subsequent version (no draft) or a
+  // legacy pre-ship pending request. Best-effort: the reject has already committed, so a
+  // cleanup failure must never fail the outcome.
+  try {
+    await deleteOnsiteDraftListingForSlug({ slug: row.slug });
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      `[rejectRequest] pre-approval draft cleanup failed (id=${params.publishRequestId}, slug=${row.slug}); ` +
+        `reject STANDS: ${err instanceof Error ? err.message : String(err)}`
+    );
+  }
 
   // MOD REVIEW SANDBOX (#2831) — tear down any review env the mod spun up.
   // Best-effort + non-blocking: the reject has landed, so a teardown failure


### PR DESCRIPTION
## What

The on-site App Blocks store `AppListing` is now created as a **DRAFT at app-submit time** instead of at moderator approval, so an author can set listing media (icon / cover / screenshots) **while their app is still pending review**. The media then carries forward on approve.

This mirrors the already-proven **off-site** path (`submitExternalListing` creates a `status='draft'` listing at submit; `closeTerminalListing` deletes it on reject/withdraw) — low-risk because the pattern exists and works.

## Design (slug-join, **no schema migration**)

The pre-approval draft is represented by reusing the existing `status='draft'` value with `kind='onsite'`, `appBlockId=NULL`, tied to the pending `AppBlockPublishRequest` by `(slug, kind='onsite', appBlockId IS NULL, status='draft')`. No `appListingId` FK is added.

- **Create at submit** (`submitVersion`) — first-version submits mint `AppListing(kind='onsite', status='draft', appBlockId=NULL, slug=blockId, owner=submitter)`. Idempotent: a reusable orphan draft (a prior submit whose cleanup didn't run) is reused, not duplicated; a slug already taken by another store listing fails fast with a friendly error. Best-effort — the store listing is a convenience and never fails the primary submit.
- **Owner reaches the draft** (`getMyListingForApp`) — adds a BY-SLUG resolution so the owner-media page reaches the draft while `appBlockId` is still NULL. Ownership check unchanged.
- **Approve = transition** (`approveRequest` `(3b)`) — finds the existing draft by the slug-join and transitions it in place → `approved`, **preserving its media** (a scalar-only `updateMany`; does **not** re-run `mapAppBlockToListing`, which would null icon/cover). It re-asserts the media scan-clean go-live gate first (same invariant + helper as the reset-restore and off-site approve flips), so a draft can't go public with unscanned/`Blocked` media. If no draft exists (a request that was pending **before** this ships, or a subsequent-version approve), it falls back to the unchanged approve-time create — **new-submits-only, no backfill**.
- **Reject / withdraw = cleanup** — delete the draft + cascade `AppListingScreenshot`; `Image` rows are `SetNull` (detached, not hard-deleted), matching the off-site path. Status-guarded, best-effort.
- **Floor stays advisory at approve** — no new hard icon+cover gate; the floor gates *publish*, not approve (matches today's behaviour).

## Security: a draft can never leak on public reads

Public reads already hard-gate `status='approved'` — the list (`listAvailableListings`) and detail (`getListingDetail`) both exclude any non-approved row, so a `draft` is invisible on `/api/v1/apps` (list + detail) by construction. This PR adds nothing that exposes a draft on a public/anon path. Both are asserted in tests (list SQL carries `status='approved'` + `revision_of_id IS NULL` under every scope; detail returns null for a draft/pending onsite row even under `full` scope).

## Tests

Full coverage added, matching the existing publish-request / offsite-listing style:

- Draft created at `submitVersion` (kind=onsite, status=draft, appBlockId=null, owned by submitter); re-submit does not duplicate; slug-taken → friendly error; no draft on a subsequent version.
- 🔴 Draft is **not** returned by the public list **or** detail (anon + `full` scope) — the security-critical assertion.
- Owner reaches the draft via `getMyListingForApp` slug resolver while pending; ownership still enforced.
- Media set on a pending draft is a **direct** edit (`setIcon` writes the draft's own id; no shadow revision row).
- Approve transitions draft→approved and **preserves** media (icon/cover never in the transition payload).
- Approve of a **legacy** pending request (no draft) still creates the listing the old way (compat).
- Reject **and** withdraw delete the draft (status-guarded), best-effort.
- Floor stays advisory at approve (media-less draft still approves).

`NODE_OPTIONS=--max_old_space_size=8192 npx tsc --noEmit` → **0 errors**. Blocks suite: **90 files / 1711 tests passing** (incl. the new tests and the status-constants drift guard — no new status value added).

## 🔴 Required follow-on (separate PRs — NOT in this backend PR)

This **inverts** the "the store listing is created when your app is approved" contract into "you can set listing media now, while your app is pending." Two downstream surfaces assert the OLD behaviour and MUST be updated:

1. **CLI release beyond `v0.1.88`** (`civitai/cli`, references civitai/cli#186) — reword `civitai app listing` long help + `status` help, the `resolveListing` "no listing yet" error, and the appapi 404 mapping (all say the listing is "created once a moderator approves it"); update the two `listing_test.go` assertions that pin the old wording; bump + release (GoReleaser → brew/npm `@civitai/cli`).
2. **developer-docs "Store-listing media" section** — flip the `apps/guide/quickstart.md` submit heads-up + the "Store-listing media" section from "created when a moderator approves your app, not when you submit it" to "settable while pending," and **regenerate** the committed CLI-help snapshot (`appblocks-snapshots/civitai-cli-help.txt`, rendered by `apps/reference/cli.md`) after the CLI strings change.

Do NOT change the surfaces that describe deploy/serving-at-approval (`app submit` "on approval it builds + deploys", `app status` "serves after approved and deployed", OAuth/git/slug provisioning) — those stay correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
