### PR TITLE
feat(apps): bounded auto-retry + unmissable manual Retry on the app run page

### DIFF
--- a/src/components/AppBlocks/BlockFallback.tsx
+++ b/src/components/AppBlocks/BlockFallback.tsx
@@ -1,4 +1,4 @@
-import { Alert, Button, Skeleton, Stack, Text } from '@mantine/core';
+import { Alert, Button, Group, Loader, Skeleton, Stack, Text } from '@mantine/core';
 import { IconRefresh } from '@tabler/icons-react';
 
 type FallbackReason = 'loading' | 'token_error' | 'timeout' | 'fatal_block_error';
@@ -16,6 +16,33 @@ interface BlockFallbackProps {
    * for the non-terminal `loading` reason.
    */
   onRetry?: () => void;
+  /**
+   * In-progress feedback for the host's BOUNDED AUTO-RETRY. When set, the host
+   * has already scheduled another automatic attempt: the fallback still shows the
+   * REAL terminal message (the error is never masked or delayed) and adds a line
+   * saying a retry is under way and which attempt it is — so a user who then
+   * presses the button doesn't experience "the button does nothing".
+   *
+   * `attempt`/`maxAttempts` are 1-based. `animate:false` (driven by
+   * `prefers-reduced-motion: reduce` upstream) suppresses the spinner; the copy
+   * alone then carries the state.
+   */
+  autoRetry?: { attempt: number; maxAttempts: number; animate: boolean };
+  /**
+   * Number of AUTOMATIC attempts already spent. Renders an honest "we already
+   * tried N times" note — only when > 0, so a surface with no auto-retry wired
+   * never claims a retry that didn't happen.
+   */
+  autoRetriesSpent?: number;
+  /**
+   * Make the manual Retry affordance UNMISSABLE. Set by PageBlockHost once the
+   * host has SETTLED (no further automatic attempt is coming) — that is the
+   * moment the user must notice the button, which is precisely what was reported
+   * as missed. Renders a filled, full-width, medium button instead of the small
+   * subdued default. Default `false` keeps the model-slot IframeHost and every
+   * other existing caller byte-identical.
+   */
+  prominentRetry?: boolean;
 }
 
 const DEFAULT_MIN_HEIGHT = 200;
@@ -53,6 +80,9 @@ export function BlockFallback({
   blockName,
   minHeight = DEFAULT_MIN_HEIGHT,
   onRetry,
+  autoRetry,
+  autoRetriesSpent = 0,
+  prominentRetry = false,
 }: BlockFallbackProps) {
   if (reason === 'loading') {
     return <Skeleton h={minHeight} radius="md" data-block-fallback="loading" />;
@@ -68,15 +98,47 @@ export function BlockFallback({
     <Alert color={copy.color} title={title} data-block-fallback={reason}>
       <Stack gap="sm">
         <Text size="sm">{copy.hint}</Text>
+        {autoRetry ? (
+          // Live region: the attempt count changes while the user is already
+          // looking at a static error, so announce it instead of mutating the
+          // text silently.
+          <Group
+            gap="xs"
+            data-block-fallback-autoretry="true"
+            // Observable animation state — `false` under prefers-reduced-motion.
+            data-block-fallback-autoretry-animate={autoRetry.animate ? 'true' : 'false'}
+            role="status"
+            aria-live="polite"
+          >
+            {/* Reduced motion: no spinner at all — the copy carries the state. */}
+            {autoRetry.animate && <Loader size="xs" aria-hidden />}
+            <Text size="sm" c="dimmed">
+              {`Retrying automatically… (attempt ${autoRetry.attempt} of ${autoRetry.maxAttempts})`}
+            </Text>
+          </Group>
+        ) : autoRetriesSpent > 0 ? (
+          <Text size="sm" c="dimmed" data-block-fallback-autoretry-spent={String(autoRetriesSpent)}>
+            {autoRetriesSpent === 1
+              ? 'We already retried once automatically.'
+              : `We already retried ${autoRetriesSpent} times automatically.`}
+          </Text>
+        ) : null}
         {onRetry && (
           <Button
-            variant="light"
+            // Once automatic recovery has settled, the button IS the path
+            // forward — so it stops being a small subdued affordance.
+            variant={prominentRetry ? 'filled' : 'light'}
             color={copy.color}
-            size="xs"
-            leftSection={<IconRefresh size={16} />}
+            size={prominentRetry ? 'md' : 'xs'}
+            fullWidth={prominentRetry}
+            leftSection={<IconRefresh size={prominentRetry ? 18 : 16} />}
             onClick={onRetry}
             data-block-fallback-retry="true"
+            data-block-fallback-retry-prominent={prominentRetry ? 'true' : 'false'}
           >
+            {/* The accessible name stays "Retry" in BOTH states: existing
+                callers/tests target one stable name, and a user reading the
+                button never has to re-learn it mid-failure. */}
             Retry
           </Button>
         )}

--- a/src/components/AppBlocks/IframeHostReadyTransition.browser.test.tsx
+++ b/src/components/AppBlocks/IframeHostReadyTransition.browser.test.tsx
@@ -106,6 +106,13 @@ vi.mock('~/utils/trpc', () => ({
         vote: { useMutation: () => ({ mutateAsync: vi.fn() }) },
         unvote: { useMutation: () => ({ mutateAsync: vi.fn() }) },
         withdraw: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        // Was MISSING: IframeHost calls `trpc.apps.shared.report.useMutation()`
+        // unconditionally at render, so without this stub every test in this file
+        // crashed at mount with "Cannot read properties of undefined (reading
+        // 'useMutation')". These checks are report-only, so the whole suite — the
+        // guard for the ready-transition / beacon-exclusivity invariants — had been
+        // silently red.
+        report: { useMutation: () => ({ mutateAsync: vi.fn() }) },
       },
       storage: {
         set: { useMutation: () => ({ mutateAsync: vi.fn() }) },

--- a/src/components/AppBlocks/PageBlockHost.tsx
+++ b/src/components/AppBlocks/PageBlockHost.tsx
@@ -10,7 +10,9 @@ import { AppBlockChrome } from './IframeHost';
 import { IframeInitController, shouldStartInit } from './iframeInitController';
 import { resolveBuzzPurchaseRequest } from './openBuzzPurchaseGate';
 import {
+  decideAutoRetry,
   grantedPageScopes,
+  MAX_AUTO_RETRIES,
   pageFallbackReason,
   resolveCheckpointPickerRequest,
   resolveGetImagesByIdsRequest,
@@ -288,6 +290,15 @@ export function PageBlockHost({
   // fresh `contentWindow`), so the re-armed init handshake talks to a clean
   // frame instead of a wedged one. See `handleRetry`.
   const [reloadNonce, setReloadNonce] = useState<number>(0);
+  // BOUNDED AUTO-RETRY budget for this mount. State (not a ref) because the
+  // scheduling effect AND the render-failure beacon both derive from it, so it
+  // has to drive re-renders. `attempts` counts every automatic attempt;
+  // `reminted` counts the subset that spent a token re-mint (the rate-limit cap).
+  // A MANUAL Retry deliberately touches NEITHER — see handleRetry.
+  const [autoRetryBudget, setAutoRetryBudget] = useState<{
+    attempts: number;
+    reminted: number;
+  }>({ attempts: 0, reminted: 0 });
   // Active async cosmetic-image scan pollers (non-blocking OPEN_IMAGE_UPLOAD).
   // Keyed by the OPEN_IMAGE_UPLOAD requestId; each entry mounts one
   // BlockImageScanPoller (below) that survives the upload modal's close, polls
@@ -311,6 +322,25 @@ export function PageBlockHost({
   useEffect(() => {
     statusRef.current = status;
   }, [status]);
+
+  // BOUNDED AUTO-RETRY — the single decision both consumers read (the scheduling
+  // effect near `handleRetry`, and the render-FAILURE beacon below), so they can
+  // never disagree about whether the host has SETTLED on this terminal state.
+  // `canRemint` is whether a token re-mint is even wired: without it an auth
+  // terminal can never be recovered, so we must not burn an attempt on it.
+  const canRemint = onRetryToken != null;
+  const autoRetry = useMemo(
+    () =>
+      decideAutoRetry({
+        status,
+        attempts: autoRetryBudget.attempts,
+        reminted: autoRetryBudget.reminted,
+        canRemint,
+      }),
+    [status, autoRetryBudget.attempts, autoRetryBudget.reminted, canRemint]
+  );
+  /** True once the host has stopped auto-recovering: this terminal state is final. */
+  const autoRetrySettled = autoRetry.kind === 'none';
 
   // LAUNCH REVEAL — `prefers-reduced-motion: reduce` collapses the whole thing to
   // 0ms: no transition is ever emitted, and the overlay is dropped on the effect
@@ -575,9 +605,28 @@ export function PageBlockHost({
   // reported a fatal error ('fatal'), its token never resolved ('no_token'), or
   // the mint hard-failed ('error'). Sharing the SAME emit-once ref makes ok/error
   // mutually exclusive per mount. Fire-and-forget (beacon swallows failures).
+  //
+  // 🔴 BEACON SEMANTICS UNDER AUTO-RETRY (deliberate, and what the alert on
+  // `civitai_app_block_renders_total` measures):
+  //   ONE beacon per host MOUNT, reporting the outcome the host SETTLES on. The
+  //   whole bounded automatic retry sequence is ONE logical page load:
+  //     - `ok`    — the first BLOCK_READY, whichever attempt produced it. A load
+  //                 that succeeds on attempt 2 emits exactly one `ok`, never an
+  //                 `error` first.
+  //     - `error` — a terminal state reached with NO further automatic attempt
+  //                 coming (`autoRetrySettled`). N failed automatic attempts
+  //                 therefore emit ONE `error`, not N.
+  //     - nothing — an intermediate terminal state that will be auto-retried.
+  //   Once either fires, the mount never emits again: `handleRetry` (user-initiated,
+  //   after the host already settled) deliberately does NOT reset the emit-once ref.
+  //   So the metric's denominator stays "page loads" and its numerator stays "page
+  //   loads the platform could not recover on its own" — which is the thing worth
+  //   paging on. Manual user retries are a separate, currently-unmeasured signal.
   useEffect(() => {
     if (status !== 'timeout' && status !== 'fatal' && status !== 'no_token' && status !== 'error')
       return;
+    // Another automatic attempt is scheduled — the host has NOT settled yet.
+    if (!autoRetrySettled) return;
     if (blockRenderEmittedRef.current) return;
     blockRenderEmittedRef.current = true;
     sendBlockRender({
@@ -585,9 +634,12 @@ export function PageBlockHost({
       blockInstanceId,
       slotId: 'app.page',
       status: 'error',
+      // Kept within the server-side KNOWN_ERROR_CLASSES enum
+      // (timeout|fatal|no_token|error) — the auto-retry adds no new class, so the
+      // existing `error_class` prom label and its alert are unchanged.
       errorClass: status,
     });
-  }, [status, appBlockId, blockInstanceId]);
+  }, [status, autoRetrySettled, appBlockId, blockInstanceId]);
 
   // Lazy consent (A6): the block (rendered in full for a logged-in viewer whose
   // page token is missing a consent-gated scope, e.g. `ai:write:budgeted` once
@@ -2593,8 +2645,7 @@ export function PageBlockHost({
   //      (defensive — the init effect's cleanup already disposes + nulls it when
   //      status left 'loading'; this guarantees no orphaned interval/timeout
   //      survives a retry).
-  //   2. Reset the per-mount handshake/analytics guards so init re-fires and a
-  //      successful retry re-emits exactly one impression.
+  //   2. Reset the per-mount handshake guard so init re-fires.
   //   3. Bump `reloadNonce` → re-keys the <iframe> → React remounts it (fresh
   //      contentWindow), so the re-armed handshake talks to a clean frame.
   //   4. Flip status back to 'loading'. shouldStartInit then re-passes and the
@@ -2617,25 +2668,83 @@ export function PageBlockHost({
   // token flips the props, init re-fires, and a successful mint loads the block.
   // For `fatal`/`timeout` the token was fine — the block crashed or didn't ack —
   // so remount-only (no re-mint) is the right, unchanged behavior. refresh()
-  // aborts any in-flight mint and the endpoint is rate-limited (60/min); Retry is
-  // user-initiated, so no auto-retry loop is added.
+  // aborts any in-flight mint and the endpoint is rate-limited (60/min) — which is
+  // why the AUTOMATIC re-mints are capped at MAX_AUTO_REMINTS. A manual Retry is
+  // user-initiated and stays uncapped here (the double-click guard below plus that
+  // server-side limit bound it).
+  //
+  // The re-arm itself is shared by the MANUAL button and the BOUNDED AUTO-RETRY
+  // below — one recovery path, not two (a second path is how the two drift).
+  //
+  // 🔴 It deliberately no longer resets `blockRenderEmittedRef`. See the
+  // BEACON-SEMANTICS block on the render-failure beacon: one beacon per mount
+  // describing the outcome the host settles on.
+  const performRetry = useCallback(
+    ({ remint }: { remint: boolean }) => {
+      if (remint) onRetryToken?.();
+      controllerRef.current?.dispose();
+      controllerRef.current = null;
+      initSentRef.current = false;
+      setReloadNonce((n) => n + 1);
+      setStatus('loading');
+    },
+    [onRetryToken]
+  );
+
   const handleRetry = useCallback(() => {
     const prior = statusRef.current;
     // Double-click no-op guard (mirrors the pre-fix gate): a Retry while the
     // status is already loading/ready does nothing — no re-mint, no remount.
     if (prior === 'loading' || prior === 'ready') return;
     // AUTH failures (`error`/`no_token`) need a token re-mint — the local reset
-    // below alone can't change the upstream `token`/`tokenError` props. Fire it
-    // BEFORE the local re-arm (the rotated token then flips props → init
-    // re-fires). `fatal`/`timeout` are not auth failures → remount only.
-    if (prior === 'error' || prior === 'no_token') onRetryToken?.();
-    controllerRef.current?.dispose();
-    controllerRef.current = null;
-    initSentRef.current = false;
-    blockRenderEmittedRef.current = false;
-    setReloadNonce((n) => n + 1);
-    setStatus('loading');
-  }, [onRetryToken]);
+    // alone can't change the upstream `token`/`tokenError` props. `fatal`/`timeout`
+    // are not auth failures → remount only.
+    //
+    // A manual Retry while an automatic one is still PENDING is coherent by
+    // construction: `performRetry` flips the status back to 'loading', which makes
+    // `decideAutoRetry` return 'none', which tears down the pending backoff timer
+    // in the scheduling effect's cleanup — so exactly ONE attempt runs, the one
+    // the user asked for. It also does NOT consume the automatic budget: the user
+    // taking over shouldn't spend the platform's remaining recovery attempts.
+    performRetry({ remint: prior === 'error' || prior === 'no_token' });
+  }, [performRetry]);
+
+  // 🔴 The backoff timer must NOT depend on `performRetry`'s IDENTITY. `performRetry`
+  // is rebuilt whenever the `onRetryToken` PROP changes identity, and a caller is
+  // free to pass an inline arrow (`onRetryToken={() => refresh()}`) — that makes it a
+  // new function on every parent render. If the scheduling effect depended on it,
+  // every such render would tear down and re-arm the pending timer, so the backoff
+  // would never elapse and auto-retry would SILENTLY NEVER FIRE. Reading it through
+  // a ref keeps the effect keyed on the DECISION alone.
+  const performRetryRef = useRef(performRetry);
+  useEffect(() => {
+    performRetryRef.current = performRetry;
+  }, [performRetry]);
+
+  // BOUNDED AUTO-RETRY — arm the backoff timer for the next automatic attempt.
+  //
+  // Placed here (after `performRetry`) rather than beside the other status
+  // effects purely for declaration order. `autoRetry` is the SAME memoized
+  // decision the failure beacon reads, so a scheduled retry and a suppressed
+  // beacon can never disagree.
+  //
+  // No timer leak: the cleanup clears the pending timeout on unmount AND whenever
+  // the decision changes (a manual Retry, a recovery, a status change) — so at
+  // most one backoff timer exists at a time and none survives the component.
+  useEffect(() => {
+    if (autoRetry.kind !== 'retry') return;
+    const { delayMs, remint } = autoRetry;
+    const t = setTimeout(() => {
+      // Consume the budget FIRST so the decision recomputes to the next attempt
+      // (or to 'none') even if the retry re-fails instantly.
+      setAutoRetryBudget((b) => ({
+        attempts: b.attempts + 1,
+        reminted: b.reminted + (remint ? 1 : 0),
+      }));
+      performRetryRef.current({ remint });
+    }, delayMs);
+    return () => clearTimeout(t);
+  }, [autoRetry]);
 
   return (
     <Box
@@ -2778,7 +2887,16 @@ export function PageBlockHost({
                   aria-label={`Loading ${launchName}`}
                 />
                 <Text size="sm" c="dimmed">
-                  {`Starting ${launchName}…`}
+                  {/* IN-PROGRESS FEEDBACK. `reloadNonce` counts re-attempts
+                      (manual AND automatic — both go through performRetry), so
+                      a re-attempt reads as a retry-in-progress rather than an
+                      identical "Starting …" that looks like nothing happened.
+                      This is the half of the reported defect where pressing
+                      Retry against a still-down host silently waited ~10s and
+                      re-rendered the same error. */}
+                  {reloadNonce > 0
+                    ? `Retrying ${launchName}… (attempt ${reloadNonce + 1})`
+                    : `Starting ${launchName}…`}
                 </Text>
               </Stack>
             </Center>
@@ -2790,6 +2908,25 @@ export function PageBlockHost({
             reason={fallbackReason}
             blockName={sanitizeAppChromeName(appName) || blockId}
             onRetry={handleRetry}
+            // 🔴 The REAL terminal message renders the instant the status goes
+            // terminal — a pending automatic attempt is surfaced INSIDE it, never
+            // instead of it. The user is never held in a loading state waiting on
+            // a quiet retry (the silent-blank failure class), and the manual
+            // affordance stays available the whole time.
+            autoRetry={
+              autoRetry.kind === 'retry'
+                ? {
+                    attempt: autoRetry.attempt,
+                    maxAttempts: MAX_AUTO_RETRIES,
+                    // prefers-reduced-motion: reduce → no spinner.
+                    animate: !reduceMotion,
+                  }
+                : undefined
+            }
+            autoRetriesSpent={autoRetryBudget.attempts}
+            // Automatic recovery has settled (exhausted, or never applicable):
+            // the button is now the only path forward, so make it unmissable.
+            prominentRetry={autoRetrySettled}
           />
         </Box>
       ) : null}

--- a/src/components/AppBlocks/PageBlockHost.tsx
+++ b/src/components/AppBlocks/PageBlockHost.tsx
@@ -12,7 +12,6 @@ import { resolveBuzzPurchaseRequest } from './openBuzzPurchaseGate';
 import {
   decideAutoRetry,
   grantedPageScopes,
-  MAX_AUTO_RETRIES,
   pageFallbackReason,
   resolveCheckpointPickerRequest,
   resolveGetImagesByIdsRequest,
@@ -2910,14 +2909,14 @@ export function PageBlockHost({
 
                       Deliberately NO "of N" here, and no attempt NUMBER: the
                       fallback's pending-retry line counts AUTOMATIC attempts
-                      ("attempt 1 of 2") while this counts EVERY re-attempt
-                      including manual ones. Showing both numbers put two
-                      different counters two seconds apart on the same surface —
-                      "attempt 1 of 2" followed by "attempt 2", and after a few
-                      manual clicks an "attempt 7" against a stated maximum of 2.
-                      The bounded count belongs to the terminal card, which is
-                      where the budget is meaningful; this line only has to say
-                      that something is happening again. */}
+                      against a bounded ceiling, while this would count EVERY
+                      re-attempt including manual ones. Showing both put two
+                      counters on the same flow seconds apart, disagreeing —
+                      the card's "attempt 1 of 2" followed by this saying
+                      "attempt 2", and after a few manual clicks "attempt 7"
+                      against a stated maximum of 2. The bounded count belongs to
+                      the terminal card, where the budget is meaningful; this line
+                      only has to say that something is happening again. */}
                   {reloadNonce > 0 ? `Retrying ${launchName}…` : `Starting ${launchName}…`}
                 </Text>
               </Stack>
@@ -2939,7 +2938,11 @@ export function PageBlockHost({
               autoRetry.kind === 'retry'
                 ? {
                     attempt: autoRetry.attempt,
-                    maxAttempts: MAX_AUTO_RETRIES,
+                    // The ceiling REACHABLE from here, not the raw attempt cap —
+                    // an auth terminal is bounded by the lower re-mint budget, so
+                    // showing MAX_AUTO_RETRIES would promise a retry that will
+                    // never happen. Derived in decideAutoRetry.
+                    maxAttempts: autoRetry.maxAttempts,
                     // prefers-reduced-motion: reduce → no spinner.
                     animate: !reduceMotion,
                   }

--- a/src/components/AppBlocks/PageBlockHost.tsx
+++ b/src/components/AppBlocks/PageBlockHost.tsx
@@ -622,6 +622,19 @@ export function PageBlockHost({
   //   So the metric's denominator stays "page loads" and its numerator stays "page
   //   loads the platform could not recover on its own" — which is the thing worth
   //   paging on. Manual user retries are a separate, currently-unmeasured signal.
+  //
+  // 🔴 TWO KNOWN COSTS OF THAT CHOICE, stated so they aren't rediscovered as bugs:
+  //   1. UNMOUNT DURING THE SEQUENCE EMITS NOTHING. A user who navigates away
+  //      while a retry is pending produces no beacon at all, where before they
+  //      produced an `error`. The window grew from ~0s to the length of the whole
+  //      bounded sequence. There is no unmount flush today (adding one is the
+  //      obvious follow-up — `sendBlockRender` already sets `keepalive:true`
+  //      precisely so a beacon survives unload).
+  //   2. THE `error` NUMERATOR NOW MEANS SOMETHING NARROWER — "failures the
+  //      platform could not self-recover", not "failures". A regression that only
+  //      increases TRANSIENT launch failures is invisible to a ratio built on it.
+  //      The `BlockRenderFailureRate` alert in datapacket-talos still describes it
+  //      the old way; its wording needs a companion update.
   useEffect(() => {
     if (status !== 'timeout' && status !== 'fatal' && status !== 'no_token' && status !== 'error')
       return;
@@ -2893,10 +2906,19 @@ export function PageBlockHost({
                       identical "Starting …" that looks like nothing happened.
                       This is the half of the reported defect where pressing
                       Retry against a still-down host silently waited ~10s and
-                      re-rendered the same error. */}
-                  {reloadNonce > 0
-                    ? `Retrying ${launchName}… (attempt ${reloadNonce + 1})`
-                    : `Starting ${launchName}…`}
+                      re-rendered the same error.
+
+                      Deliberately NO "of N" here, and no attempt NUMBER: the
+                      fallback's pending-retry line counts AUTOMATIC attempts
+                      ("attempt 1 of 2") while this counts EVERY re-attempt
+                      including manual ones. Showing both numbers put two
+                      different counters two seconds apart on the same surface —
+                      "attempt 1 of 2" followed by "attempt 2", and after a few
+                      manual clicks an "attempt 7" against a stated maximum of 2.
+                      The bounded count belongs to the terminal card, which is
+                      where the budget is meaningful; this line only has to say
+                      that something is happening again. */}
+                  {reloadNonce > 0 ? `Retrying ${launchName}…` : `Starting ${launchName}…`}
                 </Text>
               </Stack>
             </Center>

--- a/src/components/AppBlocks/PageBlockHostAutoRetry.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostAutoRetry.browser.test.tsx
@@ -223,6 +223,7 @@ describe('PageBlockHost auto-retry — fires from a terminal state, bounded and 
     // … alongside the in-progress feedback (attempt 1 of N) …
     const line = autoRetryLine();
     expect(line).not.toBeNull();
+    // `fatal` is a NON-auth terminal, so the full attempt budget is reachable.
     expect(line?.textContent).toContain(`attempt 1 of ${MAX_AUTO_RETRIES}`);
     // … and the manual affordance stays available the whole time.
     expect(retryButton()).not.toBeNull();
@@ -354,6 +355,15 @@ describe('PageBlockHost auto-retry — the caps (unbounded loops are the failure
     const onRemint = vi.fn();
     renderWithProviders(<AuthFailureHarness onRemint={onRemint} />);
 
+    // 🔴 The advertised ceiling on the AUTH path is the RE-MINT budget, not the
+    // attempt cap — the user must not be promised a retry that can never happen.
+    await vi.waitFor(() => expect(autoRetryLine()).not.toBeNull(), {
+      timeout: 5_000,
+      interval: 50,
+    });
+    expect(autoRetryLine()?.textContent).toContain(`attempt 1 of ${MAX_AUTO_REMINTS}`);
+    expect(autoRetryLine()?.textContent).not.toContain(`of ${MAX_AUTO_RETRIES}`);
+
     // The host burns its automatic budget …
     await vi.waitFor(() => expect(onRemint).toHaveBeenCalledTimes(MAX_AUTO_REMINTS), {
       timeout: 25_000,
@@ -366,12 +376,6 @@ describe('PageBlockHost auto-retry — the caps (unbounded loops are the failure
     // would burn it.
     await sleep(AUTO_RETRY_BACKOFF_MS[AUTO_RETRY_BACKOFF_MS.length - 1] + 3_000);
     expect(onRemint).toHaveBeenCalledTimes(MAX_AUTO_REMINTS);
-    // 🔴 …and it stopped because of the RE-MINT cap specifically, not the total
-    // attempt cap: the auth path used strictly fewer attempts than the budget it
-    // would have had on a non-auth terminal. Without this, the test would still
-    // pass if the re-mint cap were unreachable dead code and the attempt cap were
-    // doing all the work.
-    expect(MAX_AUTO_REMINTS).toBeLessThan(MAX_AUTO_RETRIES);
   }, 45_000);
 
   test('after exhaustion the host settles on a DEFINITIVE terminal state with a PROMINENT manual Retry', async () => {
@@ -497,6 +501,18 @@ describe('PageBlockHost auto-retry — beacon semantics (one per mount, the sett
     // Still exactly the one `ok` — no `error` beacon was re-opened.
     expect(beaconCalls()).toHaveLength(1);
     expect(beaconBodies()[0]).not.toHaveProperty('status');
+
+    // This is the only path that exhausts the FULL attempt budget (a non-auth
+    // terminal is not bound by the lower re-mint cap), so it is where the PLURAL
+    // exhausted-copy branch is reachable — pin it here or it has no coverage
+    // anywhere.
+    const spentNote = document.querySelector('[data-block-fallback-autoretry-spent]');
+    expect(spentNote?.getAttribute('data-block-fallback-autoretry-spent')).toBe(
+      String(MAX_AUTO_RETRIES)
+    );
+    expect(spentNote?.textContent).toBe(
+      `We already retried ${MAX_AUTO_RETRIES} times automatically.`
+    );
   }, 60_000);
 
   test('N failed automatic attempts emit ONE `error` beacon, not N', async () => {

--- a/src/components/AppBlocks/PageBlockHostAutoRetry.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostAutoRetry.browser.test.tsx
@@ -241,15 +241,15 @@ describe('PageBlockHost auto-retry — fires from a terminal state, bounded and 
     expect(fallbackEl()).not.toBeNull();
 
     // …then the host re-attempts on its own: back to the loading surface, with a
-    // fresh iframe, and copy that names the attempt (the "did the button do
-    // anything?" half of the report).
+    // fresh iframe, and copy that says a RETRY is under way rather than the
+    // identical "Starting …" (the "did the button do anything?" half of the
+    // report). Deliberately no attempt NUMBER here — the bounded count lives on
+    // the terminal card, so the two surfaces can't show disagreeing counters.
     await vi.waitFor(() => expect(page.getByTestId('app-page-loading').query()).not.toBeNull(), {
       timeout: FIRST_BACKOFF_MS + 4_000,
       interval: 50,
     });
-    await expect
-      .element(page.getByText(/Retrying Budgeted Generator… \(attempt 2\)/))
-      .toBeInTheDocument();
+    await expect.element(page.getByText('Retrying Budgeted Generator…')).toBeInTheDocument();
     const el = page.getByTestId('app-page-iframe').element() as HTMLIFrameElement;
     expect(el.getAttribute('data-block-ready')).toBe('false');
   }, 20_000);
@@ -366,6 +366,12 @@ describe('PageBlockHost auto-retry — the caps (unbounded loops are the failure
     // would burn it.
     await sleep(AUTO_RETRY_BACKOFF_MS[AUTO_RETRY_BACKOFF_MS.length - 1] + 3_000);
     expect(onRemint).toHaveBeenCalledTimes(MAX_AUTO_REMINTS);
+    // 🔴 …and it stopped because of the RE-MINT cap specifically, not the total
+    // attempt cap: the auth path used strictly fewer attempts than the budget it
+    // would have had on a non-auth terminal. Without this, the test would still
+    // pass if the re-mint cap were unreachable dead code and the attempt cap were
+    // doing all the work.
+    expect(MAX_AUTO_REMINTS).toBeLessThan(MAX_AUTO_RETRIES);
   }, 45_000);
 
   test('after exhaustion the host settles on a DEFINITIVE terminal state with a PROMINENT manual Retry', async () => {
@@ -391,9 +397,15 @@ describe('PageBlockHost auto-retry — the caps (unbounded loops are the failure
     const btn = retryButton();
     expect(btn).not.toBeNull();
     expect(btn?.getAttribute('data-block-fallback-retry-prominent')).toBe('true');
-    await expect
-      .element(page.getByText(`We already retried ${MAX_AUTO_RETRIES} times automatically.`))
-      .toBeInTheDocument();
+    // …and it states honestly how many automatic attempts were actually spent
+    // (asserted off the rendered count, not a hardcoded cap — the auth path stops
+    // at the RE-MINT cap, which is strictly below the attempt cap).
+    const spentNote = document.querySelector('[data-block-fallback-autoretry-spent]');
+    expect(spentNote).not.toBeNull();
+    expect(spentNote?.getAttribute('data-block-fallback-autoretry-spent')).toBe(
+      String(MAX_AUTO_REMINTS)
+    );
+    expect(spentNote?.textContent).toMatch(/already retried/);
     // Still reachable by its stable accessible name, and still inside the chrome.
     await expect.element(page.getByRole('button', { name: 'Retry' })).toBeInTheDocument();
     await expect.element(page.getByTestId('app-block-chrome')).toBeInTheDocument();

--- a/src/components/AppBlocks/PageBlockHostAutoRetry.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostAutoRetry.browser.test.tsx
@@ -204,7 +204,9 @@ function AuthFailureHarness({
 
 describe('PageBlockHost auto-retry — fires from a terminal state, bounded and backed off', () => {
   test('a terminal state renders the REAL error IMMEDIATELY, with the pending retry shown inside it', async () => {
-    renderWithProviders(<PageBlockHost {...baseProps} onConsentGranted={vi.fn()} onRetryToken={vi.fn()} />);
+    renderWithProviders(
+      <PageBlockHost {...baseProps} onConsentGranted={vi.fn()} onRetryToken={vi.fn()} />
+    );
     await driveToReady();
 
     const firedAt = Date.now();
@@ -229,7 +231,9 @@ describe('PageBlockHost auto-retry — fires from a terminal state, bounded and 
   });
 
   test('the automatic attempt actually re-runs the load after the backoff (and says so)', async () => {
-    renderWithProviders(<PageBlockHost {...baseProps} onConsentGranted={vi.fn()} onRetryToken={vi.fn()} />);
+    renderWithProviders(
+      <PageBlockHost {...baseProps} onConsentGranted={vi.fn()} onRetryToken={vi.fn()} />
+    );
     await driveToFatal();
     // Still in the terminal state for the whole backoff — the retry is NOT instant
     // (a 0ms "backoff" would be a hot loop against a down host).
@@ -243,55 +247,49 @@ describe('PageBlockHost auto-retry — fires from a terminal state, bounded and 
       timeout: FIRST_BACKOFF_MS + 4_000,
       interval: 50,
     });
-    await expect.element(page.getByText(/Retrying Budgeted Generator… \(attempt 2\)/)).toBeInTheDocument();
+    await expect
+      .element(page.getByText(/Retrying Budgeted Generator… \(attempt 2\)/))
+      .toBeInTheDocument();
     const el = page.getByTestId('app-page-iframe').element() as HTMLIFrameElement;
     expect(el.getAttribute('data-block-ready')).toBe('false');
   }, 20_000);
 
-  test(
-    'auto-retry also fires from the `timeout` terminal (block never acks BLOCK_READY)',
-    async () => {
-      renderWithProviders(
-        <PageBlockHost {...baseProps} onConsentGranted={vi.fn()} onRetryToken={vi.fn()} />
-      );
-      // ~10s readiness window → 'timeout'.
-      await vi.waitFor(() => expect(fallbackEl()).not.toBeNull(), {
-        timeout: 13_000,
-        interval: 250,
-      });
-      expect(autoRetryLine()?.textContent).toContain(`attempt 1 of ${MAX_AUTO_RETRIES}`);
-    },
-    25_000
-  );
+  test('auto-retry also fires from the `timeout` terminal (block never acks BLOCK_READY)', async () => {
+    renderWithProviders(
+      <PageBlockHost {...baseProps} onConsentGranted={vi.fn()} onRetryToken={vi.fn()} />
+    );
+    // ~10s readiness window → 'timeout'.
+    await vi.waitFor(() => expect(fallbackEl()).not.toBeNull(), {
+      timeout: 13_000,
+      interval: 250,
+    });
+    expect(autoRetryLine()?.textContent).toContain(`attempt 1 of ${MAX_AUTO_RETRIES}`);
+  }, 25_000);
 
-  test(
-    'auto-retry also fires from the `no_token` terminal, and it RE-MINTS',
-    async () => {
-      const onRetryToken = vi.fn();
-      renderWithProviders(
-        <PageBlockHost
-          {...baseProps}
-          token={null}
-          tokenError={false}
-          onConsentGranted={vi.fn()}
-          onRetryToken={onRetryToken}
-        />
-      );
-      // ~15s token-wait window → 'no_token'.
-      await vi.waitFor(() => expect(fallbackEl()).not.toBeNull(), {
-        timeout: 19_000,
-        interval: 250,
-      });
-      expect(onRetryToken).not.toHaveBeenCalled();
-      // An auth terminal can ONLY be recovered by re-minting (the token is an
-      // upstream prop) — so the automatic attempt must re-mint, not just remount.
-      await vi.waitFor(() => expect(onRetryToken).toHaveBeenCalledTimes(1), {
-        timeout: FIRST_BACKOFF_MS + 4_000,
-        interval: 50,
-      });
-    },
-    30_000
-  );
+  test('auto-retry also fires from the `no_token` terminal, and it RE-MINTS', async () => {
+    const onRetryToken = vi.fn();
+    renderWithProviders(
+      <PageBlockHost
+        {...baseProps}
+        token={null}
+        tokenError={false}
+        onConsentGranted={vi.fn()}
+        onRetryToken={onRetryToken}
+      />
+    );
+    // ~15s token-wait window → 'no_token'.
+    await vi.waitFor(() => expect(fallbackEl()).not.toBeNull(), {
+      timeout: 19_000,
+      interval: 250,
+    });
+    expect(onRetryToken).not.toHaveBeenCalled();
+    // An auth terminal can ONLY be recovered by re-minting (the token is an
+    // upstream prop) — so the automatic attempt must re-mint, not just remount.
+    await vi.waitFor(() => expect(onRetryToken).toHaveBeenCalledTimes(1), {
+      timeout: FIRST_BACKOFF_MS + 4_000,
+      interval: 50,
+    });
+  }, 30_000);
 
   test('a NON-auth terminal auto-retries WITHOUT re-minting (the token was fine)', async () => {
     const onRetryToken = vi.fn();
@@ -352,62 +350,54 @@ describe('PageBlockHost auto-retry — survives an UNSTABLE onRetryToken prop', 
 });
 
 describe('PageBlockHost auto-retry — the caps (unbounded loops are the failure mode)', () => {
-  test(
-    'AUTH terminals re-mint AT MOST MAX_AUTO_REMINTS times, then stop',
-    async () => {
-      const onRemint = vi.fn();
-      renderWithProviders(<AuthFailureHarness onRemint={onRemint} />);
+  test('AUTH terminals re-mint AT MOST MAX_AUTO_REMINTS times, then stop', async () => {
+    const onRemint = vi.fn();
+    renderWithProviders(<AuthFailureHarness onRemint={onRemint} />);
 
-      // The host burns its automatic budget …
-      await vi.waitFor(() => expect(onRemint).toHaveBeenCalledTimes(MAX_AUTO_REMINTS), {
-        timeout: 25_000,
-        interval: 100,
-      });
+    // The host burns its automatic budget …
+    await vi.waitFor(() => expect(onRemint).toHaveBeenCalledTimes(MAX_AUTO_REMINTS), {
+      timeout: 25_000,
+      interval: 100,
+    });
 
-      // 🔴 …and then STOPS. Waiting well past another full backoff must produce no
-      // further re-mint. This is the rate-limit guard: `/api/v1/block-tokens` is
-      // 60/min, and an unbounded auth-failure loop is exactly the shape that
-      // would burn it.
-      await sleep(AUTO_RETRY_BACKOFF_MS[AUTO_RETRY_BACKOFF_MS.length - 1] + 3_000);
-      expect(onRemint).toHaveBeenCalledTimes(MAX_AUTO_REMINTS);
-    },
-    45_000
-  );
+    // 🔴 …and then STOPS. Waiting well past another full backoff must produce no
+    // further re-mint. This is the rate-limit guard: `/api/v1/block-tokens` is
+    // 60/min, and an unbounded auth-failure loop is exactly the shape that
+    // would burn it.
+    await sleep(AUTO_RETRY_BACKOFF_MS[AUTO_RETRY_BACKOFF_MS.length - 1] + 3_000);
+    expect(onRemint).toHaveBeenCalledTimes(MAX_AUTO_REMINTS);
+  }, 45_000);
 
-  test(
-    'after exhaustion the host settles on a DEFINITIVE terminal state with a PROMINENT manual Retry',
-    async () => {
-      const onRemint = vi.fn();
-      renderWithProviders(<AuthFailureHarness onRemint={onRemint} />);
-      await vi.waitFor(() => expect(onRemint).toHaveBeenCalledTimes(MAX_AUTO_REMINTS), {
-        timeout: 25_000,
-        interval: 100,
-      });
+  test('after exhaustion the host settles on a DEFINITIVE terminal state with a PROMINENT manual Retry', async () => {
+    const onRemint = vi.fn();
+    renderWithProviders(<AuthFailureHarness onRemint={onRemint} />);
+    await vi.waitFor(() => expect(onRemint).toHaveBeenCalledTimes(MAX_AUTO_REMINTS), {
+      timeout: 25_000,
+      interval: 100,
+    });
 
-      // Settle: the pending-retry line is gone and the fallback is final.
-      await vi.waitFor(
-        () => {
-          expect(fallbackEl()).not.toBeNull();
-          expect(autoRetryLine()).toBeNull();
-        },
-        { timeout: 20_000, interval: 100 }
-      );
+    // Settle: the pending-retry line is gone and the fallback is final.
+    await vi.waitFor(
+      () => {
+        expect(fallbackEl()).not.toBeNull();
+        expect(autoRetryLine()).toBeNull();
+      },
+      { timeout: 20_000, interval: 100 }
+    );
 
-      // 🔴 THE ACTUAL REPORTED FAILURE: the manual affordance must now be
-      // impossible to miss. It is filled + full-width rather than the small
-      // subdued default, and the host says plainly that it already tried.
-      const btn = retryButton();
-      expect(btn).not.toBeNull();
-      expect(btn?.getAttribute('data-block-fallback-retry-prominent')).toBe('true');
-      await expect
-        .element(page.getByText(`We already retried ${MAX_AUTO_RETRIES} times automatically.`))
-        .toBeInTheDocument();
-      // Still reachable by its stable accessible name, and still inside the chrome.
-      await expect.element(page.getByRole('button', { name: 'Retry' })).toBeInTheDocument();
-      await expect.element(page.getByTestId('app-block-chrome')).toBeInTheDocument();
-    },
-    60_000
-  );
+    // 🔴 THE ACTUAL REPORTED FAILURE: the manual affordance must now be
+    // impossible to miss. It is filled + full-width rather than the small
+    // subdued default, and the host says plainly that it already tried.
+    const btn = retryButton();
+    expect(btn).not.toBeNull();
+    expect(btn?.getAttribute('data-block-fallback-retry-prominent')).toBe('true');
+    await expect
+      .element(page.getByText(`We already retried ${MAX_AUTO_RETRIES} times automatically.`))
+      .toBeInTheDocument();
+    // Still reachable by its stable accessible name, and still inside the chrome.
+    await expect.element(page.getByRole('button', { name: 'Retry' })).toBeInTheDocument();
+    await expect.element(page.getByTestId('app-block-chrome')).toBeInTheDocument();
+  }, 60_000);
 });
 
 describe('PageBlockHost auto-retry — beacon semantics (one per mount, the settled outcome)', () => {
@@ -428,110 +418,98 @@ describe('PageBlockHost auto-retry — beacon semantics (one per mount, the sett
     fetchSpy.mockClear();
   });
 
-  test(
-    'success on attempt 2 emits EXACTLY ONE `ok` beacon — and no `error` first',
-    async () => {
-      renderWithProviders(
-        <PageBlockHost {...baseProps} onConsentGranted={vi.fn()} onRetryToken={vi.fn()} />
-      );
+  test('success on attempt 2 emits EXACTLY ONE `ok` beacon — and no `error` first', async () => {
+    renderWithProviders(
+      <PageBlockHost {...baseProps} onConsentGranted={vi.fn()} onRetryToken={vi.fn()} />
+    );
 
-      // Attempt 1 fails by never acking → 'timeout'. It must emit NOTHING (an
-      // automatic attempt is still coming — the host has not settled).
-      await vi.waitFor(() => expect(fallbackEl()).not.toBeNull(), {
-        timeout: 13_000,
-        interval: 250,
-      });
-      expect(beaconCalls()).toHaveLength(0);
+    // Attempt 1 fails by never acking → 'timeout'. It must emit NOTHING (an
+    // automatic attempt is still coming — the host has not settled).
+    await vi.waitFor(() => expect(fallbackEl()).not.toBeNull(), {
+      timeout: 13_000,
+      interval: 250,
+    });
+    expect(beaconCalls()).toHaveLength(0);
 
-      // Attempt 2 succeeds.
-      await vi.waitFor(() => expect(page.getByTestId('app-page-loading').query()).not.toBeNull(), {
-        timeout: FIRST_BACKOFF_MS + 4_000,
-        interval: 50,
-      });
-      await driveToReady();
+    // Attempt 2 succeeds.
+    await vi.waitFor(() => expect(page.getByTestId('app-page-loading').query()).not.toBeNull(), {
+      timeout: FIRST_BACKOFF_MS + 4_000,
+      interval: 50,
+    });
+    await driveToReady();
 
-      await vi.waitFor(() => expect(beaconCalls()).toHaveLength(1));
-      const [body] = beaconBodies();
-      // The `ok` beacon carries no `status` field (see sendBlockRender).
-      expect(body).toEqual({
-        appBlockId: 'apb_test',
-        blockInstanceId: 'page_apb_test',
-        slotId: 'app.page',
-      });
-      // Give any stray emit a chance to show up before asserting exclusivity.
-      await sleep(300);
-      expect(beaconCalls()).toHaveLength(1);
-    },
-    30_000
-  );
+    await vi.waitFor(() => expect(beaconCalls()).toHaveLength(1));
+    const [body] = beaconBodies();
+    // The `ok` beacon carries no `status` field (see sendBlockRender).
+    expect(body).toEqual({
+      appBlockId: 'apb_test',
+      blockInstanceId: 'page_apb_test',
+      slotId: 'app.page',
+    });
+    // Give any stray emit a chance to show up before asserting exclusivity.
+    await sleep(300);
+    expect(beaconCalls()).toHaveLength(1);
+  }, 30_000);
 
-  test(
-    'a mount that already reported `ok` never additionally reports `error` after a crash + failed recovery',
-    async () => {
-      // 🔴 THE EMIT-ONCE GUARD. `performRetry` must NOT reset
-      // `blockRenderEmittedRef` — a retry is part of the SAME mount, so the mount
-      // keeps its already-reported outcome. Resetting it re-opens the beacon and
-      // a single page load reports BOTH `ok` and `error`, double-counting in the
-      // denominator AND inflating the failure ratio the alert watches.
-      //
-      // (Mutation-verified: re-adding `blockRenderEmittedRef.current = false` to
-      // performRetry fails THIS test. The sibling "N failed attempts emit ONE
-      // error" test does NOT catch it — the settled-gate alone keeps that path to
-      // one beacon — which is why this case exists separately.)
-      renderWithProviders(
-        <PageBlockHost {...baseProps} onConsentGranted={vi.fn()} onRetryToken={vi.fn()} />
-      );
+  test('a mount that already reported `ok` never additionally reports `error` after a crash + failed recovery', async () => {
+    // 🔴 THE EMIT-ONCE GUARD. `performRetry` must NOT reset
+    // `blockRenderEmittedRef` — a retry is part of the SAME mount, so the mount
+    // keeps its already-reported outcome. Resetting it re-opens the beacon and
+    // a single page load reports BOTH `ok` and `error`, double-counting in the
+    // denominator AND inflating the failure ratio the alert watches.
+    //
+    // (Mutation-verified: re-adding `blockRenderEmittedRef.current = false` to
+    // performRetry fails THIS test. The sibling "N failed attempts emit ONE
+    // error" test does NOT catch it — the settled-gate alone keeps that path to
+    // one beacon — which is why this case exists separately.)
+    renderWithProviders(
+      <PageBlockHost {...baseProps} onConsentGranted={vi.fn()} onRetryToken={vi.fn()} />
+    );
 
-      // Load succeeds → exactly one `ok`.
-      await driveToReady();
-      await vi.waitFor(() => expect(beaconCalls()).toHaveLength(1));
-      expect(beaconBodies()[0]).not.toHaveProperty('status');
+    // Load succeeds → exactly one `ok`.
+    await driveToReady();
+    await vi.waitFor(() => expect(beaconCalls()).toHaveLength(1));
+    expect(beaconBodies()[0]).not.toHaveProperty('status');
 
-      // Then the block crashes and every automatic recovery attempt fails
-      // (the fresh frames never ack, so each rides the readiness timeout).
-      postFromBlock('BLOCK_ERROR', { fatal: true });
-      await vi.waitFor(
-        () => {
-          expect(fallbackEl()).not.toBeNull();
-          expect(autoRetryLine()).toBeNull(); // settled: budget spent
-        },
-        { timeout: 40_000, interval: 250 }
-      );
+    // Then the block crashes and every automatic recovery attempt fails
+    // (the fresh frames never ack, so each rides the readiness timeout).
+    postFromBlock('BLOCK_ERROR', { fatal: true });
+    await vi.waitFor(
+      () => {
+        expect(fallbackEl()).not.toBeNull();
+        expect(autoRetryLine()).toBeNull(); // settled: budget spent
+      },
+      { timeout: 40_000, interval: 250 }
+    );
 
-      // Still exactly the one `ok` — no `error` beacon was re-opened.
-      expect(beaconCalls()).toHaveLength(1);
-      expect(beaconBodies()[0]).not.toHaveProperty('status');
-    },
-    60_000
-  );
+    // Still exactly the one `ok` — no `error` beacon was re-opened.
+    expect(beaconCalls()).toHaveLength(1);
+    expect(beaconBodies()[0]).not.toHaveProperty('status');
+  }, 60_000);
 
-  test(
-    'N failed automatic attempts emit ONE `error` beacon, not N',
-    async () => {
-      const onRemint = vi.fn();
-      renderWithProviders(<AuthFailureHarness onRemint={onRemint} />);
+  test('N failed automatic attempts emit ONE `error` beacon, not N', async () => {
+    const onRemint = vi.fn();
+    renderWithProviders(<AuthFailureHarness onRemint={onRemint} />);
 
-      // Burn the whole automatic budget.
-      await vi.waitFor(() => expect(onRemint).toHaveBeenCalledTimes(MAX_AUTO_REMINTS), {
-        timeout: 25_000,
-        interval: 100,
-      });
-      // Settle, then exactly ONE error beacon for the whole sequence.
-      await vi.waitFor(() => expect(beaconCalls()).toHaveLength(1), {
-        timeout: 20_000,
-        interval: 100,
-      });
-      const [body] = beaconBodies();
-      expect(body.status).toBe('error');
-      // errorClass stays inside the server-side KNOWN_ERROR_CLASSES enum, so the
-      // existing prom label + its alert are unchanged by auto-retry.
-      expect(['error', 'no_token']).toContain(body.errorClass);
+    // Burn the whole automatic budget.
+    await vi.waitFor(() => expect(onRemint).toHaveBeenCalledTimes(MAX_AUTO_REMINTS), {
+      timeout: 25_000,
+      interval: 100,
+    });
+    // Settle, then exactly ONE error beacon for the whole sequence.
+    await vi.waitFor(() => expect(beaconCalls()).toHaveLength(1), {
+      timeout: 20_000,
+      interval: 100,
+    });
+    const [body] = beaconBodies();
+    expect(body.status).toBe('error');
+    // errorClass stays inside the server-side KNOWN_ERROR_CLASSES enum, so the
+    // existing prom label + its alert are unchanged by auto-retry.
+    expect(['error', 'no_token']).toContain(body.errorClass);
 
-      await sleep(AUTO_RETRY_BACKOFF_MS[AUTO_RETRY_BACKOFF_MS.length - 1] + 2_000);
-      expect(beaconCalls()).toHaveLength(1);
-    },
-    60_000
-  );
+    await sleep(AUTO_RETRY_BACKOFF_MS[AUTO_RETRY_BACKOFF_MS.length - 1] + 2_000);
+    expect(beaconCalls()).toHaveLength(1);
+  }, 60_000);
 });
 
 describe('PageBlockHost auto-retry — reduced motion', () => {
@@ -599,43 +577,39 @@ describe('PageBlockHost auto-retry — manual Retry interaction + teardown', () 
     expect(onRetryToken).not.toHaveBeenCalled();
   }, 20_000);
 
-  test(
-    'unmounting mid-backoff leaks NO timer — the pending attempt never fires',
-    async () => {
-      const onRemint = vi.fn();
-      function Harness() {
-        const [mounted, setMounted] = useState(true);
-        return (
-          <>
-            <button type="button" data-testid="unmount-host" onClick={() => setMounted(false)}>
-              unmount
-            </button>
-            <AuthFailureHarness onRemint={onRemint} mounted={mounted} />
-          </>
-        );
-      }
-      renderWithProviders(<Harness />);
+  test('unmounting mid-backoff leaks NO timer — the pending attempt never fires', async () => {
+    const onRemint = vi.fn();
+    function Harness() {
+      const [mounted, setMounted] = useState(true);
+      return (
+        <>
+          <button type="button" data-testid="unmount-host" onClick={() => setMounted(false)}>
+            unmount
+          </button>
+          <AuthFailureHarness onRemint={onRemint} mounted={mounted} />
+        </>
+      );
+    }
+    renderWithProviders(<Harness />);
 
-      // An auth terminal is reached and an automatic re-mint is scheduled …
-      await vi.waitFor(() => expect(autoRetryLine()).not.toBeNull(), {
-        timeout: 5_000,
-        interval: 50,
-      });
+    // An auth terminal is reached and an automatic re-mint is scheduled …
+    await vi.waitFor(() => expect(autoRetryLine()).not.toBeNull(), {
+      timeout: 5_000,
+      interval: 50,
+    });
 
-      // … unmount before the backoff elapses.
-      await page.getByTestId('unmount-host').click();
-      await vi.waitFor(() => expect(page.getByTestId('app-page-frame').query()).toBeNull());
-      // Snapshot AT unmount rather than asserting zero beforehand: on a slow box a
-      // first automatic attempt may legitimately have already fired. The invariant
-      // under test is that NOTHING fires AFTER unmount, and that holds either way.
-      const remintsAtUnmount = onRemint.mock.calls.length;
+    // … unmount before the backoff elapses.
+    await page.getByTestId('unmount-host').click();
+    await vi.waitFor(() => expect(page.getByTestId('app-page-frame').query()).toBeNull());
+    // Snapshot AT unmount rather than asserting zero beforehand: on a slow box a
+    // first automatic attempt may legitimately have already fired. The invariant
+    // under test is that NOTHING fires AFTER unmount, and that holds either way.
+    const remintsAtUnmount = onRemint.mock.calls.length;
 
-      // 🔴 A leaked timer would fire the scheduled attempt after unmount — hitting
-      // the rate-limited mint endpoint for a page nobody is looking at. Wait well
-      // past the backoff and assert the count never grew.
-      await sleep(FIRST_BACKOFF_MS + 2_000);
-      expect(onRemint.mock.calls.length).toBe(remintsAtUnmount);
-    },
-    30_000
-  );
+    // 🔴 A leaked timer would fire the scheduled attempt after unmount — hitting
+    // the rate-limited mint endpoint for a page nobody is looking at. Wait well
+    // past the backoff and assert the count never grew.
+    await sleep(FIRST_BACKOFF_MS + 2_000);
+    expect(onRemint.mock.calls.length).toBe(remintsAtUnmount);
+  }, 30_000);
 });

--- a/src/components/AppBlocks/PageBlockHostAutoRetry.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostAutoRetry.browser.test.tsx
@@ -1,0 +1,641 @@
+import { describe, expect, test, vi, beforeEach, afterEach } from 'vitest';
+import { page } from 'vitest/browser';
+import { useEffect, useState } from 'react';
+// `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
+import { renderWithProviders } from '../../../test/component-setup';
+import {
+  AUTO_RETRY_BACKOFF_MS,
+  MAX_AUTO_REMINTS,
+  MAX_AUTO_RETRIES,
+} from '~/components/AppBlocks/pageBlockHostLogic';
+
+/**
+ * W10 run-page BOUNDED AUTO-RETRY.
+ *
+ * The reported defect was NOT that the retry LOGIC was broken — it works — but
+ * that recovery required the user to NOTICE a small button ("there might have
+ * been a retry button but I didn't notice — I did a full page reload"). So the
+ * host now re-attempts the load itself, bounded, and only then settles on a
+ * definitive terminal state whose manual Retry is made prominent.
+ *
+ * 🔴 THE INVARIANTS THESE TESTS EXIST FOR
+ *  1. BOUNDED, ALWAYS. The automatic loop stops after MAX_AUTO_RETRIES, and the
+ *     AUTH terminals — the only ones that re-mint against the rate-limited
+ *     `/api/v1/block-tokens` (60/min) — stop after MAX_AUTO_REMINTS.
+ *  2. THE TERMINAL STATE IS NEVER MASKED OR DELAYED. The real error renders the
+ *     instant the status goes terminal; the pending automatic attempt is shown
+ *     INSIDE that same fallback. There is no "keep spinning quietly" state.
+ *  3. ONE BEACON PER MOUNT describing the outcome the host SETTLES on: a load
+ *     that succeeds on attempt 2 emits exactly one `ok` (never an `error` first);
+ *     N failed automatic attempts emit ONE `error`, not N.
+ *  4. NO TIMER LEAK. Unmounting mid-backoff must not fire the pending attempt.
+ *  5. FRAME-1 still holds — every state stays wrapped in AppBlockChrome.
+ *
+ * 🔴 THIS SUITE EXERCISES THE REAL PATH. It renders the REAL PageBlockHost with
+ * REAL hooks and REAL timers: no `@mantine/hooks` module mock (the reduced-motion
+ * case stubs `window.matchMedia` so `useReducedMotion` itself still runs), and no
+ * stub of the status machine. Only the ambient tRPC client + useCurrentUser are
+ * stubbed, exactly as the sibling PageBlockHost suites do — those are the
+ * network/session Context the offline scaffold can't provide, NOT the condition
+ * under test. Mocking the retry decision or the media query as a constant would
+ * remove the very thing being asserted.
+ */
+
+// AppBlockChrome calls useCurrentUser() for the platform-nav moderator gate; this
+// suite renders the real host without a CivitaiSessionProvider.
+vi.mock('~/hooks/useCurrentUser', () => ({ useCurrentUser: () => null }));
+
+// PageBlockHost wires the money-path workflow bridge AND the storage bridge at
+// render, which need the tRPC Context the network-free scaffold doesn't provide.
+// Mirrors PageBlockHost.browser.test.tsx's stub — inert here.
+vi.mock('~/utils/trpc', () => ({
+  // FeatureFlagsProvider (in PageBlockHost's render graph) statically imports
+  // this; a wholesale module mock MUST re-declare it or the ESM link fails.
+  setTrpcBatchingEnabled: vi.fn(),
+  trpc: {
+    generation: { resolveWildcardPack: { useMutation: () => ({ mutateAsync: vi.fn() }) } },
+    blocks: {
+      submitWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      getMyBuzzBalance: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      getMyViewer: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      getMyBuzzTransactions: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      getMyBuzzAccounts: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      getMyDailyCompensation: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      estimateWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      pollWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      cancelWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      queryAppWorkflows: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      cancelAppWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      publishGenerationOutputs: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      getImagesByIds: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+    },
+    apps: {
+      shared: {
+        append: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        update: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        vote: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        unvote: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        withdraw: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        report: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      },
+      storage: {
+        set: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        delete: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      },
+    },
+    useUtils: () => ({
+      apps: {
+        shared: {
+          list: { fetch: vi.fn() },
+          getCount: { fetch: vi.fn() },
+          getCounts: { fetch: vi.fn() },
+          get: { fetch: vi.fn() },
+        },
+        storage: {
+          get: { fetch: vi.fn() },
+          list: { fetch: vi.fn() },
+          getQuota: { fetch: vi.fn() },
+        },
+      },
+    }),
+  },
+}));
+
+// eslint-disable-next-line import/first
+import { PageBlockHost } from '~/components/AppBlocks/PageBlockHost';
+
+// Same-origin so trustTier='internal' yields a pinned (non-opaque) transport
+// whose expectedOrigin equals this frame's origin — see PageBlockHost.browser.test.
+const SAME_ORIGIN_SRC = `${window.location.origin}/`;
+
+const baseProps = {
+  appBlockId: 'apb_test',
+  blockId: 'my-page-app',
+  appId: 'app_test',
+  blockInstanceId: 'page_apb_test',
+  appName: 'Budgeted Generator',
+  iframeSrc: SAME_ORIGIN_SRC,
+  sandbox: 'allow-scripts',
+  trustTier: 'internal' as const,
+  slug: 'my-page-app',
+  token: 'tok_abc',
+  expiresAt: new Date(Date.now() + 15 * 60_000).toISOString(),
+  declaredScopes: ['apps:storage:read'],
+  missingScopes: [] as string[],
+  needsConsent: false,
+  tokenError: false,
+  viewer: { id: 42, username: 'tester' },
+  theme: 'light' as const,
+};
+
+const FIRST_BACKOFF_MS = AUTO_RETRY_BACKOFF_MS[0];
+
+function postFromBlock(type: string, payload?: unknown) {
+  const iframeEl = page.getByTestId('app-page-iframe').element() as HTMLIFrameElement;
+  const cw = iframeEl.contentWindow;
+  if (!cw) throw new Error('iframe contentWindow missing');
+  window.dispatchEvent(
+    new MessageEvent('message', {
+      data: { type, payload },
+      origin: window.location.origin,
+      source: cw,
+    })
+  );
+}
+
+async function driveToReady() {
+  await vi.waitFor(() => {
+    const el = page.getByTestId('app-page-iframe').element() as HTMLIFrameElement;
+    if (!el.contentWindow) throw new Error('not mounted yet');
+  });
+  await vi.waitFor(() => {
+    postFromBlock('BLOCK_READY', {});
+    const el = page.getByTestId('app-page-iframe').element() as HTMLIFrameElement;
+    if (el.getAttribute('data-block-ready') !== 'true') throw new Error('not ready yet');
+  });
+}
+
+/** Reach the `fatal` terminal fast (message-driven, no 10s/15s timer window). */
+async function driveToFatal() {
+  await driveToReady();
+  postFromBlock('BLOCK_ERROR', { fatal: true });
+  await expect.element(page.getByTestId('app-page-fallback')).toBeInTheDocument();
+}
+
+const fallbackEl = () => page.getByTestId('app-page-fallback').query();
+const autoRetryLine = () =>
+  document.querySelector('[data-block-fallback-autoretry="true"]') as HTMLElement | null;
+const retryButton = () =>
+  document.querySelector('[data-block-fallback-retry="true"]') as HTMLButtonElement | null;
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+/**
+ * Drives the AUTH-failure loop the way the real route does: each `onRetryToken`
+ * (the re-mint) briefly clears `tokenError` and then fails again, so the host's
+ * `error` terminal is re-reached fast instead of waiting out the 15s token-wait
+ * window. That keeps the RE-MINT CAP test — the rate-limit guard — a few seconds
+ * instead of a minute, while still going through the host's real status machine.
+ */
+function AuthFailureHarness({
+  onRemint,
+  mounted = true,
+}: {
+  onRemint: () => void;
+  mounted?: boolean;
+}) {
+  const [failing, setFailing] = useState(true);
+  if (!mounted) return null;
+  return (
+    <PageBlockHost
+      {...baseProps}
+      token={null}
+      tokenError={failing}
+      onConsentGranted={vi.fn()}
+      onRetryToken={() => {
+        onRemint();
+        // Simulate a re-mint that is attempted and fails again ~immediately.
+        setFailing(false);
+        setTimeout(() => setFailing(true), 10);
+      }}
+    />
+  );
+}
+
+describe('PageBlockHost auto-retry — fires from a terminal state, bounded and backed off', () => {
+  test('a terminal state renders the REAL error IMMEDIATELY, with the pending retry shown inside it', async () => {
+    renderWithProviders(<PageBlockHost {...baseProps} onConsentGranted={vi.fn()} onRetryToken={vi.fn()} />);
+    await driveToReady();
+
+    const firedAt = Date.now();
+    postFromBlock('BLOCK_ERROR', { fatal: true });
+
+    // 🔴 The terminal message is NOT delayed by the auto-retry: it must land well
+    // inside the backoff window. This is the assertion that fails if a future
+    // change ever holds the surface in "loading" while it quietly retries.
+    await vi.waitFor(() => expect(fallbackEl()).not.toBeNull(), { timeout: 2_000, interval: 5 });
+    expect(Date.now() - firedAt).toBeLessThan(FIRST_BACKOFF_MS);
+
+    // The real terminal copy is on screen …
+    await expect.element(page.getByText('Budgeted Generator failed to load')).toBeInTheDocument();
+    // … alongside the in-progress feedback (attempt 1 of N) …
+    const line = autoRetryLine();
+    expect(line).not.toBeNull();
+    expect(line?.textContent).toContain(`attempt 1 of ${MAX_AUTO_RETRIES}`);
+    // … and the manual affordance stays available the whole time.
+    expect(retryButton()).not.toBeNull();
+    // FRAME-1: provenance chrome still wraps it.
+    await expect.element(page.getByTestId('app-block-chrome')).toBeInTheDocument();
+  });
+
+  test('the automatic attempt actually re-runs the load after the backoff (and says so)', async () => {
+    renderWithProviders(<PageBlockHost {...baseProps} onConsentGranted={vi.fn()} onRetryToken={vi.fn()} />);
+    await driveToFatal();
+    // Still in the terminal state for the whole backoff — the retry is NOT instant
+    // (a 0ms "backoff" would be a hot loop against a down host).
+    await sleep(Math.floor(FIRST_BACKOFF_MS / 2));
+    expect(fallbackEl()).not.toBeNull();
+
+    // …then the host re-attempts on its own: back to the loading surface, with a
+    // fresh iframe, and copy that names the attempt (the "did the button do
+    // anything?" half of the report).
+    await vi.waitFor(() => expect(page.getByTestId('app-page-loading').query()).not.toBeNull(), {
+      timeout: FIRST_BACKOFF_MS + 4_000,
+      interval: 50,
+    });
+    await expect.element(page.getByText(/Retrying Budgeted Generator… \(attempt 2\)/)).toBeInTheDocument();
+    const el = page.getByTestId('app-page-iframe').element() as HTMLIFrameElement;
+    expect(el.getAttribute('data-block-ready')).toBe('false');
+  }, 20_000);
+
+  test(
+    'auto-retry also fires from the `timeout` terminal (block never acks BLOCK_READY)',
+    async () => {
+      renderWithProviders(
+        <PageBlockHost {...baseProps} onConsentGranted={vi.fn()} onRetryToken={vi.fn()} />
+      );
+      // ~10s readiness window → 'timeout'.
+      await vi.waitFor(() => expect(fallbackEl()).not.toBeNull(), {
+        timeout: 13_000,
+        interval: 250,
+      });
+      expect(autoRetryLine()?.textContent).toContain(`attempt 1 of ${MAX_AUTO_RETRIES}`);
+    },
+    25_000
+  );
+
+  test(
+    'auto-retry also fires from the `no_token` terminal, and it RE-MINTS',
+    async () => {
+      const onRetryToken = vi.fn();
+      renderWithProviders(
+        <PageBlockHost
+          {...baseProps}
+          token={null}
+          tokenError={false}
+          onConsentGranted={vi.fn()}
+          onRetryToken={onRetryToken}
+        />
+      );
+      // ~15s token-wait window → 'no_token'.
+      await vi.waitFor(() => expect(fallbackEl()).not.toBeNull(), {
+        timeout: 19_000,
+        interval: 250,
+      });
+      expect(onRetryToken).not.toHaveBeenCalled();
+      // An auth terminal can ONLY be recovered by re-minting (the token is an
+      // upstream prop) — so the automatic attempt must re-mint, not just remount.
+      await vi.waitFor(() => expect(onRetryToken).toHaveBeenCalledTimes(1), {
+        timeout: FIRST_BACKOFF_MS + 4_000,
+        interval: 50,
+      });
+    },
+    30_000
+  );
+
+  test('a NON-auth terminal auto-retries WITHOUT re-minting (the token was fine)', async () => {
+    const onRetryToken = vi.fn();
+    renderWithProviders(
+      <PageBlockHost {...baseProps} onConsentGranted={vi.fn()} onRetryToken={onRetryToken} />
+    );
+    await driveToFatal();
+    await vi.waitFor(() => expect(page.getByTestId('app-page-loading').query()).not.toBeNull(), {
+      timeout: FIRST_BACKOFF_MS + 4_000,
+      interval: 50,
+    });
+    // The block crashed; the token was never the problem. Re-minting here would
+    // burn the rate-limited endpoint for nothing.
+    expect(onRetryToken).not.toHaveBeenCalled();
+  }, 20_000);
+});
+
+describe('PageBlockHost auto-retry — survives an UNSTABLE onRetryToken prop', () => {
+  // 🔴 REGRESSION GUARD for a real bug found while writing these tests: the backoff
+  // timer must not be keyed on the `onRetryToken` callback IDENTITY. A caller may
+  // pass an inline arrow, which is a new function every parent render — if the
+  // scheduling effect depended on it, every re-render would tear down and re-arm
+  // the pending timer, the backoff would never elapse, and auto-retry would
+  // SILENTLY NEVER FIRE. The host reads the retry through a ref so the effect is
+  // keyed on the decision alone.
+  test('auto-retry still fires while the parent re-renders with a fresh callback each time', async () => {
+    const onRemint = vi.fn();
+    function ChurningParent() {
+      const [, setTick] = useState(0);
+      // Re-render faster than the backoff; each render hands the host a NEW
+      // `onRetryToken` identity (an inline arrow, the shape a caller may well use).
+      useEffect(() => {
+        const id = setInterval(() => setTick((t) => t + 1), 100);
+        return () => clearInterval(id);
+      }, []);
+      return (
+        <PageBlockHost
+          {...baseProps}
+          token={null}
+          tokenError
+          onConsentGranted={vi.fn()}
+          onRetryToken={() => onRemint()}
+        />
+      );
+    }
+    renderWithProviders(<ChurningParent />);
+
+    await vi.waitFor(() => expect(autoRetryLine()).not.toBeNull(), {
+      timeout: 5_000,
+      interval: 50,
+    });
+    // The attempt must still land despite ~20 re-renders during the backoff.
+    await vi.waitFor(() => expect(onRemint).toHaveBeenCalled(), {
+      timeout: FIRST_BACKOFF_MS + 5_000,
+      interval: 50,
+    });
+  }, 20_000);
+});
+
+describe('PageBlockHost auto-retry — the caps (unbounded loops are the failure mode)', () => {
+  test(
+    'AUTH terminals re-mint AT MOST MAX_AUTO_REMINTS times, then stop',
+    async () => {
+      const onRemint = vi.fn();
+      renderWithProviders(<AuthFailureHarness onRemint={onRemint} />);
+
+      // The host burns its automatic budget …
+      await vi.waitFor(() => expect(onRemint).toHaveBeenCalledTimes(MAX_AUTO_REMINTS), {
+        timeout: 25_000,
+        interval: 100,
+      });
+
+      // 🔴 …and then STOPS. Waiting well past another full backoff must produce no
+      // further re-mint. This is the rate-limit guard: `/api/v1/block-tokens` is
+      // 60/min, and an unbounded auth-failure loop is exactly the shape that
+      // would burn it.
+      await sleep(AUTO_RETRY_BACKOFF_MS[AUTO_RETRY_BACKOFF_MS.length - 1] + 3_000);
+      expect(onRemint).toHaveBeenCalledTimes(MAX_AUTO_REMINTS);
+    },
+    45_000
+  );
+
+  test(
+    'after exhaustion the host settles on a DEFINITIVE terminal state with a PROMINENT manual Retry',
+    async () => {
+      const onRemint = vi.fn();
+      renderWithProviders(<AuthFailureHarness onRemint={onRemint} />);
+      await vi.waitFor(() => expect(onRemint).toHaveBeenCalledTimes(MAX_AUTO_REMINTS), {
+        timeout: 25_000,
+        interval: 100,
+      });
+
+      // Settle: the pending-retry line is gone and the fallback is final.
+      await vi.waitFor(
+        () => {
+          expect(fallbackEl()).not.toBeNull();
+          expect(autoRetryLine()).toBeNull();
+        },
+        { timeout: 20_000, interval: 100 }
+      );
+
+      // 🔴 THE ACTUAL REPORTED FAILURE: the manual affordance must now be
+      // impossible to miss. It is filled + full-width rather than the small
+      // subdued default, and the host says plainly that it already tried.
+      const btn = retryButton();
+      expect(btn).not.toBeNull();
+      expect(btn?.getAttribute('data-block-fallback-retry-prominent')).toBe('true');
+      await expect
+        .element(page.getByText(`We already retried ${MAX_AUTO_RETRIES} times automatically.`))
+        .toBeInTheDocument();
+      // Still reachable by its stable accessible name, and still inside the chrome.
+      await expect.element(page.getByRole('button', { name: 'Retry' })).toBeInTheDocument();
+      await expect.element(page.getByTestId('app-block-chrome')).toBeInTheDocument();
+    },
+    60_000
+  );
+});
+
+describe('PageBlockHost auto-retry — beacon semantics (one per mount, the settled outcome)', () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+  function isBeacon(call: unknown[]) {
+    return typeof call[0] === 'string' && (call[0] as string).includes('/api/track/block-render');
+  }
+  function beaconCalls() {
+    return fetchSpy.mock.calls.filter(isBeacon);
+  }
+  function beaconBodies() {
+    return beaconCalls().map((c: unknown[]) => JSON.parse(String((c[1] as RequestInit).body)));
+  }
+
+  beforeEach(() => {
+    fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response(null, { status: 200 }));
+    fetchSpy.mockClear();
+  });
+
+  test(
+    'success on attempt 2 emits EXACTLY ONE `ok` beacon — and no `error` first',
+    async () => {
+      renderWithProviders(
+        <PageBlockHost {...baseProps} onConsentGranted={vi.fn()} onRetryToken={vi.fn()} />
+      );
+
+      // Attempt 1 fails by never acking → 'timeout'. It must emit NOTHING (an
+      // automatic attempt is still coming — the host has not settled).
+      await vi.waitFor(() => expect(fallbackEl()).not.toBeNull(), {
+        timeout: 13_000,
+        interval: 250,
+      });
+      expect(beaconCalls()).toHaveLength(0);
+
+      // Attempt 2 succeeds.
+      await vi.waitFor(() => expect(page.getByTestId('app-page-loading').query()).not.toBeNull(), {
+        timeout: FIRST_BACKOFF_MS + 4_000,
+        interval: 50,
+      });
+      await driveToReady();
+
+      await vi.waitFor(() => expect(beaconCalls()).toHaveLength(1));
+      const [body] = beaconBodies();
+      // The `ok` beacon carries no `status` field (see sendBlockRender).
+      expect(body).toEqual({
+        appBlockId: 'apb_test',
+        blockInstanceId: 'page_apb_test',
+        slotId: 'app.page',
+      });
+      // Give any stray emit a chance to show up before asserting exclusivity.
+      await sleep(300);
+      expect(beaconCalls()).toHaveLength(1);
+    },
+    30_000
+  );
+
+  test(
+    'a mount that already reported `ok` never additionally reports `error` after a crash + failed recovery',
+    async () => {
+      // 🔴 THE EMIT-ONCE GUARD. `performRetry` must NOT reset
+      // `blockRenderEmittedRef` — a retry is part of the SAME mount, so the mount
+      // keeps its already-reported outcome. Resetting it re-opens the beacon and
+      // a single page load reports BOTH `ok` and `error`, double-counting in the
+      // denominator AND inflating the failure ratio the alert watches.
+      //
+      // (Mutation-verified: re-adding `blockRenderEmittedRef.current = false` to
+      // performRetry fails THIS test. The sibling "N failed attempts emit ONE
+      // error" test does NOT catch it — the settled-gate alone keeps that path to
+      // one beacon — which is why this case exists separately.)
+      renderWithProviders(
+        <PageBlockHost {...baseProps} onConsentGranted={vi.fn()} onRetryToken={vi.fn()} />
+      );
+
+      // Load succeeds → exactly one `ok`.
+      await driveToReady();
+      await vi.waitFor(() => expect(beaconCalls()).toHaveLength(1));
+      expect(beaconBodies()[0]).not.toHaveProperty('status');
+
+      // Then the block crashes and every automatic recovery attempt fails
+      // (the fresh frames never ack, so each rides the readiness timeout).
+      postFromBlock('BLOCK_ERROR', { fatal: true });
+      await vi.waitFor(
+        () => {
+          expect(fallbackEl()).not.toBeNull();
+          expect(autoRetryLine()).toBeNull(); // settled: budget spent
+        },
+        { timeout: 40_000, interval: 250 }
+      );
+
+      // Still exactly the one `ok` — no `error` beacon was re-opened.
+      expect(beaconCalls()).toHaveLength(1);
+      expect(beaconBodies()[0]).not.toHaveProperty('status');
+    },
+    60_000
+  );
+
+  test(
+    'N failed automatic attempts emit ONE `error` beacon, not N',
+    async () => {
+      const onRemint = vi.fn();
+      renderWithProviders(<AuthFailureHarness onRemint={onRemint} />);
+
+      // Burn the whole automatic budget.
+      await vi.waitFor(() => expect(onRemint).toHaveBeenCalledTimes(MAX_AUTO_REMINTS), {
+        timeout: 25_000,
+        interval: 100,
+      });
+      // Settle, then exactly ONE error beacon for the whole sequence.
+      await vi.waitFor(() => expect(beaconCalls()).toHaveLength(1), {
+        timeout: 20_000,
+        interval: 100,
+      });
+      const [body] = beaconBodies();
+      expect(body.status).toBe('error');
+      // errorClass stays inside the server-side KNOWN_ERROR_CLASSES enum, so the
+      // existing prom label + its alert are unchanged by auto-retry.
+      expect(['error', 'no_token']).toContain(body.errorClass);
+
+      await sleep(AUTO_RETRY_BACKOFF_MS[AUTO_RETRY_BACKOFF_MS.length - 1] + 2_000);
+      expect(beaconCalls()).toHaveLength(1);
+    },
+    60_000
+  );
+});
+
+describe('PageBlockHost auto-retry — reduced motion', () => {
+  let originalMatchMedia: typeof window.matchMedia;
+
+  beforeEach(() => {
+    originalMatchMedia = window.matchMedia;
+    // Stub the MEDIA QUERY, not the hook: `useReducedMotion` still runs for real,
+    // so this exercises the actual code path rather than replacing it.
+    window.matchMedia = ((query: string) =>
+      ({
+        matches: query.includes('prefers-reduced-motion'),
+        media: query,
+        onchange: null,
+        addEventListener: () => undefined,
+        removeEventListener: () => undefined,
+        addListener: () => undefined,
+        removeListener: () => undefined,
+        dispatchEvent: () => false,
+      } as unknown as MediaQueryList)) as typeof window.matchMedia;
+  });
+
+  afterEach(() => {
+    window.matchMedia = originalMatchMedia;
+  });
+
+  test('the retrying state renders with NO spinner under prefers-reduced-motion', async () => {
+    renderWithProviders(
+      <PageBlockHost {...baseProps} onConsentGranted={vi.fn()} onRetryToken={vi.fn()} />
+    );
+    await driveToFatal();
+
+    const line = autoRetryLine();
+    expect(line).not.toBeNull();
+    // The COPY still carries the state (reduced motion removes motion, not info) …
+    expect(line?.textContent).toContain(`attempt 1 of ${MAX_AUTO_RETRIES}`);
+    // … but no animated Loader is rendered at all.
+    expect(line?.getAttribute('data-block-fallback-autoretry-animate')).toBe('false');
+    expect(line?.querySelector('.mantine-Loader-root')).toBeNull();
+  });
+});
+
+describe('PageBlockHost auto-retry — manual Retry interaction + teardown', () => {
+  test('a manual Retry DURING a pending auto-retry runs once and does not consume the automatic budget', async () => {
+    const onRetryToken = vi.fn();
+    renderWithProviders(
+      <PageBlockHost {...baseProps} onConsentGranted={vi.fn()} onRetryToken={onRetryToken} />
+    );
+    await driveToFatal();
+    expect(autoRetryLine()?.textContent).toContain('attempt 1 of');
+
+    // Take over BEFORE the backoff elapses.
+    await page.getByRole('button', { name: 'Retry' }).click();
+    await expect.element(page.getByTestId('app-page-loading')).toBeInTheDocument();
+    expect(fallbackEl()).toBeNull();
+
+    // The pending automatic attempt was cancelled — driving straight back to a
+    // terminal shows the budget still on attempt 1 (the user taking over must not
+    // spend the platform's remaining recovery attempts), and no extra load ran.
+    await driveToReady();
+    postFromBlock('BLOCK_ERROR', { fatal: true });
+    await vi.waitFor(() => expect(fallbackEl()).not.toBeNull());
+    expect(autoRetryLine()?.textContent).toContain(`attempt 1 of ${MAX_AUTO_RETRIES}`);
+    // `fatal` is not an auth failure → still no re-mint from either path.
+    expect(onRetryToken).not.toHaveBeenCalled();
+  }, 20_000);
+
+  test(
+    'unmounting mid-backoff leaks NO timer — the pending attempt never fires',
+    async () => {
+      const onRemint = vi.fn();
+      function Harness() {
+        const [mounted, setMounted] = useState(true);
+        return (
+          <>
+            <button type="button" data-testid="unmount-host" onClick={() => setMounted(false)}>
+              unmount
+            </button>
+            <AuthFailureHarness onRemint={onRemint} mounted={mounted} />
+          </>
+        );
+      }
+      renderWithProviders(<Harness />);
+
+      // An auth terminal is reached and an automatic re-mint is scheduled …
+      await vi.waitFor(() => expect(autoRetryLine()).not.toBeNull(), {
+        timeout: 5_000,
+        interval: 50,
+      });
+
+      // … unmount before the backoff elapses.
+      await page.getByTestId('unmount-host').click();
+      await vi.waitFor(() => expect(page.getByTestId('app-page-frame').query()).toBeNull());
+      // Snapshot AT unmount rather than asserting zero beforehand: on a slow box a
+      // first automatic attempt may legitimately have already fired. The invariant
+      // under test is that NOTHING fires AFTER unmount, and that holds either way.
+      const remintsAtUnmount = onRemint.mock.calls.length;
+
+      // 🔴 A leaked timer would fire the scheduled attempt after unmount — hitting
+      // the rate-limited mint endpoint for a page nobody is looking at. Wait well
+      // past the backoff and assert the count never grew.
+      await sleep(FIRST_BACKOFF_MS + 2_000);
+      expect(onRemint.mock.calls.length).toBe(remintsAtUnmount);
+    },
+    30_000
+  );
+});

--- a/src/components/AppBlocks/PageBlockHostLaunchReveal.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostLaunchReveal.browser.test.tsx
@@ -74,6 +74,12 @@ vi.mock('~/utils/trpc', () => ({
         vote: { useMutation: () => ({ mutateAsync: vi.fn() }) },
         unvote: { useMutation: () => ({ mutateAsync: vi.fn() }) },
         withdraw: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        // Was MISSING: PageBlockHost calls `trpc.apps.shared.report.useMutation()`
+        // unconditionally at render, so without this stub every test in this file
+        // crashed at mount with "Cannot read properties of undefined (reading
+        // 'useMutation')". These checks are report-only, so the whole suite — the
+        // guard for the launch-reveal invariants — had been silently red.
+        report: { useMutation: () => ({ mutateAsync: vi.fn() }) },
       },
       storage: {
         set: { useMutation: () => ({ mutateAsync: vi.fn() }) },
@@ -86,6 +92,7 @@ vi.mock('~/utils/trpc', () => ({
           list: { fetch: vi.fn() },
           getCount: { fetch: vi.fn() },
           getCounts: { fetch: vi.fn() },
+          get: { fetch: vi.fn() },
         },
         storage: {
           get: { fetch: vi.fn() },

--- a/src/components/AppBlocks/__tests__/pageBlockHostLogic.test.ts
+++ b/src/components/AppBlocks/__tests__/pageBlockHostLogic.test.ts
@@ -59,25 +59,27 @@ describe('resolveUngrantableConsentScopes (Issue B — un-grantable dev-preview 
   it('returns the un-grantable subset when a requested scope is neither granted NOR missing (clamped at mint)', () => {
     // dev-tunnel preview: the token carries models:read:self; the block asks for
     // a scope the tunnel allowlist withheld → not granted, not addable via consent.
-    const out = resolveUngrantableConsentScopes(
-      ['apps:storage:read'],
-      ['models:read:self'],
-      []
-    );
+    const out = resolveUngrantableConsentScopes(['apps:storage:read'], ['models:read:self'], []);
     expect(out).toEqual(['apps:storage:read']);
   });
 
   it('returns EMPTY for the BENIGN already-granted case (block re-requests a held scope) — no toast', () => {
     expect(
-      resolveUngrantableConsentScopes(['buzz:read:self'], ['buzz:read:self', 'models:read:self'], [])
+      resolveUngrantableConsentScopes(
+        ['buzz:read:self'],
+        ['buzz:read:self', 'models:read:self'],
+        []
+      )
     ).toEqual([]);
   });
 
   it('returns EMPTY when the requested scope is grantable via consent (it is in missingScopes) — modal path owns it', () => {
     expect(
-      resolveUngrantableConsentScopes(['ai:write:budgeted'], ['models:read:self'], [
-        'ai:write:budgeted',
-      ])
+      resolveUngrantableConsentScopes(
+        ['ai:write:budgeted'],
+        ['models:read:self'],
+        ['ai:write:budgeted']
+      )
     ).toEqual([]);
   });
 
@@ -90,7 +92,13 @@ describe('resolveUngrantableConsentScopes (Issue B — un-grantable dev-preview 
 
   it('reports ONLY the un-grantable scopes from a mixed hint (drops granted + missing), sorted+deduped', () => {
     const out = resolveUngrantableConsentScopes(
-      ['apps:storage:write', 'apps:storage:read', 'apps:storage:write', 'buzz:read:self', 'ai:write:budgeted'],
+      [
+        'apps:storage:write',
+        'apps:storage:read',
+        'apps:storage:write',
+        'buzz:read:self',
+        'ai:write:budgeted',
+      ],
       ['buzz:read:self'], // already granted
       ['ai:write:budgeted'] // grantable via consent
     );
@@ -145,9 +153,9 @@ describe('resolveResourcePickerRequest (OPEN_RESOURCE_PICKER — type allowlist 
   });
 
   it('is case-insensitive on the wire but returns the canonical token', () => {
-    expect(resolveResourcePickerRequest({ requestId: 'r3', resourceType: 'lora' })?.resourceType).toBe(
-      'LORA'
-    );
+    expect(
+      resolveResourcePickerRequest({ requestId: 'r3', resourceType: 'lora' })?.resourceType
+    ).toBe('LORA');
     expect(
       resolveResourcePickerRequest({ requestId: 'r4', resourceType: 'checkpoint' })?.resourceType
     ).toBe('Checkpoint');
@@ -167,13 +175,25 @@ describe('resolveResourcePickerRequest (OPEN_RESOURCE_PICKER — type allowlist 
   });
 
   it('omits an empty/blank baseModelGroup (no spurious family key)', () => {
-    const r = resolveResourcePickerRequest({ requestId: 'r7', resourceType: 'Checkpoint', baseModelGroup: '' });
+    const r = resolveResourcePickerRequest({
+      requestId: 'r7',
+      resourceType: 'Checkpoint',
+      baseModelGroup: '',
+    });
     expect(r).toEqual({ requestId: 'r7', resourceType: 'Checkpoint' });
     expect(r).not.toHaveProperty('baseModelGroup');
   });
 
   it('REJECTS an unsupported type (VAE / embeddings / wildcards) → null (modal never opens)', () => {
-    for (const t of ['VAE', 'TextualInversion', 'Wildcards', 'Upscaler', 'LoCon', 'DoRA', 'Hypernetwork']) {
+    for (const t of [
+      'VAE',
+      'TextualInversion',
+      'Wildcards',
+      'Upscaler',
+      'LoCon',
+      'DoRA',
+      'Hypernetwork',
+    ]) {
       expect(resolveResourcePickerRequest({ requestId: 'r', resourceType: t })).toBeNull();
     }
   });
@@ -253,9 +273,11 @@ describe('resolveImageUploadRequest (OPEN_IMAGE_UPLOAD — requestId drop rule +
   });
 
   it('threads purpose:generationSource when the block requests the unscanned source mode', () => {
-    expect(
-      resolveImageUploadRequest({ requestId: 'u_src', purpose: 'generationSource' })
-    ).toEqual({ requestId: 'u_src', purpose: 'generationSource', asyncScan: false });
+    expect(resolveImageUploadRequest({ requestId: 'u_src', purpose: 'generationSource' })).toEqual({
+      requestId: 'u_src',
+      purpose: 'generationSource',
+      asyncScan: false,
+    });
   });
 
   it('opts into asyncScan ONLY for a literal asyncScan === true', () => {
@@ -277,13 +299,15 @@ describe('resolveImageUploadRequest (OPEN_IMAGE_UPLOAD — requestId drop rule +
   });
 
   it('normalizes an unknown / non-string purpose to the safe moderated default (display)', () => {
-    expect(resolveImageUploadRequest({ requestId: 'u_x', purpose: 'evil' }).purpose).toBe('display');
+    expect(resolveImageUploadRequest({ requestId: 'u_x', purpose: 'evil' }).purpose).toBe(
+      'display'
+    );
     expect(resolveImageUploadRequest({ requestId: 'u_y', purpose: 42 }).purpose).toBe('display');
     expect(resolveImageUploadRequest({ requestId: 'u_z', purpose: null }).purpose).toBe('display');
     // Case-sensitive: only the exact literal opts into the unscanned path.
-    expect(resolveImageUploadRequest({ requestId: 'u_c', purpose: 'GenerationSource' }).purpose).toBe(
-      'display'
-    );
+    expect(
+      resolveImageUploadRequest({ requestId: 'u_c', purpose: 'GenerationSource' }).purpose
+    ).toBe('display');
   });
 
   it('DROPS a request with a missing / empty / non-string requestId', () => {
@@ -315,12 +339,35 @@ describe('resolveImageUploadRequest (OPEN_IMAGE_UPLOAD — requestId drop rule +
 describe('decideAutoRetry — the bounded automatic recovery loop', () => {
   const base = { attempts: 0, reminted: 0, canRemint: true };
 
+  // 🔴 `MAX_AUTO_RETRIES = 0` is the documented ROLLBACK for this feature (there
+  // is no flag on the path). A kill switch whose own suite goes red is not a kill
+  // switch — you would discover that mid-incident, while trying to ship the
+  // one-line disable. Tests that can only hold while auto-retry is ENABLED are
+  // gated on that, so flipping the constant to 0 leaves the suite green; the
+  // dedicated test below then asserts the feature really is off. With the feature
+  // on (today) nothing is skipped, so there is no coverage loss.
+  const itWhenEnabled = MAX_AUTO_RETRIES > 0 ? it : it.skip;
+
+  it('is COMPLETELY OFF when rolled back to MAX_AUTO_RETRIES = 0', () => {
+    if (MAX_AUTO_RETRIES > 0) {
+      // Feature on: assert the rollback would bite, without mutating the constant.
+      expect(decideAutoRetry({ ...base, status: 'timeout', attempts: 0 }).kind).toBe('retry');
+      expect(decideAutoRetry({ ...base, status: 'timeout', attempts: MAX_AUTO_RETRIES }).kind).toBe(
+        'none'
+      );
+      return;
+    }
+    for (const status of ['timeout', 'fatal', 'no_token', 'error'] as PageHostStatus[]) {
+      expect(decideAutoRetry({ ...base, status }).kind, `status=${status}`).toBe('none');
+    }
+  });
+
   it('never auto-retries a non-terminal status', () => {
     expect(decideAutoRetry({ ...base, status: 'loading' }).kind).toBe('none');
     expect(decideAutoRetry({ ...base, status: 'ready' }).kind).toBe('none');
   });
 
-  it('schedules a retry from EVERY terminal reason', () => {
+  itWhenEnabled('schedules a retry from EVERY terminal reason', () => {
     for (const status of ['timeout', 'fatal', 'no_token', 'error'] as PageHostStatus[]) {
       const d = decideAutoRetry({ ...base, status });
       expect(d.kind, `status=${status}`).toBe('retry');
@@ -344,7 +391,7 @@ describe('decideAutoRetry — the bounded automatic recovery loop', () => {
     ).toBe('none');
   });
 
-  it('BACKS OFF between attempts (each delay strictly greater than the last)', () => {
+  itWhenEnabled('BACKS OFF between attempts (each delay strictly greater than the last)', () => {
     const delays: number[] = [];
     for (let attempts = 0; attempts < MAX_AUTO_RETRIES; attempts++) {
       const d = decideAutoRetry({ ...base, attempts, status: 'timeout' });
@@ -357,7 +404,7 @@ describe('decideAutoRetry — the bounded automatic recovery loop', () => {
     for (const d of delays) expect(d).toBeGreaterThan(0);
   });
 
-  it('marks ONLY the auth terminals as re-minting (the rate-limited path)', () => {
+  itWhenEnabled('marks ONLY the auth terminals as re-minting (the rate-limited path)', () => {
     for (const status of ['no_token', 'error'] as PageHostStatus[]) {
       const d = decideAutoRetry({ ...base, status });
       expect(d.kind === 'retry' && d.remint, `status=${status}`).toBe(true);
@@ -376,6 +423,18 @@ describe('decideAutoRetry — the bounded automatic recovery loop', () => {
     // `attempts >= MAX_AUTO_RETRIES` had already returned 'none', and the
     // re-mint cap would be unreachable dead code: a stated safety limit that
     // provably cannot fire. This test fails the moment that happens again.
+    //
+    // The `MAX_AUTO_RETRIES === 0` branch exists because that value is the
+    // documented ROLLBACK (auto-retry off). A kill switch whose own test suite
+    // goes red is not a kill switch — you'd discover that mid-incident. With the
+    // feature off there is no re-mint budget to constrain, so the meaningful
+    // assertion becomes "nothing auto-retries at all".
+    if (MAX_AUTO_RETRIES === 0) {
+      for (const status of ['timeout', 'fatal', 'no_token', 'error'] as PageHostStatus[]) {
+        expect(decideAutoRetry({ ...base, status }).kind, `status=${status}`).toBe('none');
+      }
+      return;
+    }
     expect(MAX_AUTO_REMINTS).toBeLessThan(MAX_AUTO_RETRIES);
     expect(MAX_AUTO_REMINTS).toBeGreaterThan(0);
   });
@@ -396,6 +455,12 @@ describe('decideAutoRetry — the bounded automatic recovery loop', () => {
       attempts += 1;
       reminted += 1;
     }
+    // With auto-retry disabled via the rollback (MAX_AUTO_RETRIES = 0) there is
+    // nothing to bound; the kill-switch test above covers that configuration.
+    if (MAX_AUTO_RETRIES === 0) {
+      expect(reminted).toBe(0);
+      return;
+    }
     // The AUTH path stops at the RE-MINT cap, strictly before the attempt cap.
     expect(reminted).toBe(MAX_AUTO_REMINTS);
     expect(attempts).toBeLessThan(MAX_AUTO_RETRIES);
@@ -404,6 +469,40 @@ describe('decideAutoRetry — the bounded automatic recovery loop', () => {
     // SAME budget on a non-auth terminal still has attempts left.
     expect(decideAutoRetry({ ...base, status: 'error', attempts, reminted }).kind).toBe('none');
     expect(decideAutoRetry({ ...base, status: 'timeout', attempts, reminted }).kind).toBe('retry');
+  });
+
+  itWhenEnabled('advertises the REACHABLE ceiling, not the raw attempt cap', () => {
+    // 🔴 The denominator the user is shown ("attempt 1 of N") must be the ceiling
+    // actually reachable from the current status. A fresh AUTH failure is bounded
+    // by the lower re-mint budget, so promising MAX_AUTO_RETRIES would advertise a
+    // retry that can never happen.
+    const freshAuth = decideAutoRetry({ ...base, status: 'error' });
+    expect(freshAuth.kind).toBe('retry');
+    if (freshAuth.kind === 'retry') {
+      expect(freshAuth.maxAttempts).toBe(MAX_AUTO_REMINTS);
+      // …and that ceiling is genuinely honoured: the sequence really does end there.
+      expect(decideAutoRetry({ ...base, status: 'error', attempts: 1, reminted: 1 }).kind).toBe(
+        'none'
+      );
+    }
+
+    // A NON-auth terminal gets the full attempt budget.
+    const freshTimeout = decideAutoRetry({ ...base, status: 'timeout' });
+    expect(freshTimeout.kind === 'retry' && freshTimeout.maxAttempts).toBe(MAX_AUTO_RETRIES);
+
+    // A MIXED sequence stays honest: a timeout already spent an attempt but no
+    // re-mint, so a following auth failure can still reach the attempt cap.
+    const mixed = decideAutoRetry({ ...base, status: 'error', attempts: 1, reminted: 0 });
+    expect(mixed.kind === 'retry' && mixed.maxAttempts).toBe(MAX_AUTO_RETRIES);
+
+    // The advertised ceiling is never a promise the caps can't keep.
+    for (const status of ['timeout', 'fatal', 'no_token', 'error'] as PageHostStatus[]) {
+      const d = decideAutoRetry({ ...base, status });
+      if (d.kind === 'retry') {
+        expect(d.maxAttempts, `status=${status}`).toBeLessThanOrEqual(MAX_AUTO_RETRIES);
+        expect(d.maxAttempts, `status=${status}`).toBeGreaterThanOrEqual(d.attempt);
+      }
+    }
   });
 
   it('gives NON-auth terminals the full attempt budget (the re-mint cap does not bind them)', () => {
@@ -417,7 +516,7 @@ describe('decideAutoRetry — the bounded automatic recovery loop', () => {
     expect(attempts).toBe(MAX_AUTO_RETRIES);
   });
 
-  it('does not auto-retry an auth terminal when no re-mint is wired', () => {
+  itWhenEnabled('does not auto-retry an auth terminal when no re-mint is wired', () => {
     // `canRemint:false` (no onRetryToken) → a remount is a guaranteed re-fail.
     expect(decideAutoRetry({ ...base, canRemint: false, status: 'error' }).kind).toBe('none');
     expect(decideAutoRetry({ ...base, canRemint: false, status: 'no_token' }).kind).toBe('none');

--- a/src/components/AppBlocks/__tests__/pageBlockHostLogic.test.ts
+++ b/src/components/AppBlocks/__tests__/pageBlockHostLogic.test.ts
@@ -343,9 +343,15 @@ describe('decideAutoRetry — the bounded automatic recovery loop', () => {
   // is no flag on the path). A kill switch whose own suite goes red is not a kill
   // switch — you would discover that mid-incident, while trying to ship the
   // one-line disable. Tests that can only hold while auto-retry is ENABLED are
-  // gated on that, so flipping the constant to 0 leaves the suite green; the
+  // gated on that, so flipping the constant to 0 leaves THIS file green; the
   // dedicated test below then asserts the feature really is off. With the feature
   // on (today) nothing is skipped, so there is no coverage loss.
+  //
+  // 🔴 SCOPE OF THAT CLAIM: this file only. `PageBlockHostAutoRetry.browser.test.tsx`
+  // deliberately asserts the ENABLED configuration end-to-end and WILL go red at 0.
+  // That is a local `pnpm test:component` cost during a rollback, not a CI one —
+  // the browser project is excluded from the CI unit job (see lint.yml) — but do
+  // not read "the suite stays green" more broadly than the unit file.
   const itWhenEnabled = MAX_AUTO_RETRIES > 0 ? it : it.skip;
 
   it('is COMPLETELY OFF when rolled back to MAX_AUTO_RETRIES = 0', () => {

--- a/src/components/AppBlocks/__tests__/pageBlockHostLogic.test.ts
+++ b/src/components/AppBlocks/__tests__/pageBlockHostLogic.test.ts
@@ -368,19 +368,53 @@ describe('decideAutoRetry — the bounded automatic recovery loop', () => {
     }
   });
 
-  it('BOUNDS re-mints at MAX_AUTO_REMINTS — the rate-limit guard', () => {
-    // At the cap, an auth terminal STOPS (a remount alone can never clear an
-    // auth failure, so a budget-less attempt would be a guaranteed re-fail).
-    expect(
-      decideAutoRetry({ ...base, status: 'error', attempts: 0, reminted: MAX_AUTO_REMINTS }).kind
-    ).toBe('none');
-    expect(
-      decideAutoRetry({ ...base, status: 'no_token', attempts: 0, reminted: MAX_AUTO_REMINTS }).kind
-    ).toBe('none');
-    // …while a NON-auth terminal is unaffected by the re-mint budget.
-    expect(
-      decideAutoRetry({ ...base, status: 'timeout', attempts: 0, reminted: MAX_AUTO_REMINTS }).kind
-    ).toBe('retry');
+  it('keeps the re-mint cap STRICTLY below the attempt cap, so it can actually bind', () => {
+    // 🔴 THE DEAD-CAP GUARD. `reminted` is a SUBSET of `attempts` (every
+    // re-minting attempt increments both), so `reminted <= attempts` always
+    // holds. The total-attempt check runs FIRST — therefore if the two caps were
+    // equal, `reminted >= MAX_AUTO_REMINTS` could only ever be true when
+    // `attempts >= MAX_AUTO_RETRIES` had already returned 'none', and the
+    // re-mint cap would be unreachable dead code: a stated safety limit that
+    // provably cannot fire. This test fails the moment that happens again.
+    expect(MAX_AUTO_REMINTS).toBeLessThan(MAX_AUTO_RETRIES);
+    expect(MAX_AUTO_REMINTS).toBeGreaterThan(0);
+  });
+
+  it('BOUNDS re-mints at MAX_AUTO_REMINTS from a REACHABLE state — the rate-limit guard', () => {
+    // Reachable by construction: walk the auth path from a fresh mount and stop
+    // at the first refusal, rather than asserting on a hand-made state the
+    // runtime can never produce (which is how this cap was previously "tested"
+    // while being unreachable).
+    let attempts = 0;
+    let reminted = 0;
+    const remintedAt: number[] = [];
+    for (let i = 0; i < 10; i++) {
+      const d = decideAutoRetry({ ...base, status: 'error', attempts, reminted });
+      if (d.kind === 'none') break;
+      expect(d.remint).toBe(true); // the auth path always re-mints
+      remintedAt.push(d.attempt);
+      attempts += 1;
+      reminted += 1;
+    }
+    // The AUTH path stops at the RE-MINT cap, strictly before the attempt cap.
+    expect(reminted).toBe(MAX_AUTO_REMINTS);
+    expect(attempts).toBeLessThan(MAX_AUTO_RETRIES);
+    expect(remintedAt).toHaveLength(MAX_AUTO_REMINTS);
+    // And the refusal is genuinely the re-mint cap, not the attempt cap: the
+    // SAME budget on a non-auth terminal still has attempts left.
+    expect(decideAutoRetry({ ...base, status: 'error', attempts, reminted }).kind).toBe('none');
+    expect(decideAutoRetry({ ...base, status: 'timeout', attempts, reminted }).kind).toBe('retry');
+  });
+
+  it('gives NON-auth terminals the full attempt budget (the re-mint cap does not bind them)', () => {
+    let attempts = 0;
+    for (let i = 0; i < 10; i++) {
+      const d = decideAutoRetry({ ...base, status: 'timeout', attempts, reminted: 0 });
+      if (d.kind === 'none') break;
+      expect(d.remint).toBe(false);
+      attempts += 1;
+    }
+    expect(attempts).toBe(MAX_AUTO_RETRIES);
   });
 
   it('does not auto-retry an auth terminal when no re-mint is wired', () => {

--- a/src/components/AppBlocks/__tests__/pageBlockHostLogic.test.ts
+++ b/src/components/AppBlocks/__tests__/pageBlockHostLogic.test.ts
@@ -1,6 +1,12 @@
 import { describe, it, expect } from 'vitest';
 import {
+  AUTO_RETRY_BACKOFF_MS,
+  decideAutoRetry,
   grantedPageScopes,
+  isAuthTerminalStatus,
+  isAutoRetryableStatus,
+  MAX_AUTO_REMINTS,
+  MAX_AUTO_RETRIES,
   pageFallbackReason,
   resolveCheckpointPickerRequest,
   resolveImageUploadRequest,
@@ -292,5 +298,117 @@ describe('resolveImageUploadRequest (OPEN_IMAGE_UPLOAD — requestId drop rule +
     expect(resolveImageUploadRequest(null)).toBeNull();
     expect(resolveImageUploadRequest('u3')).toBeNull();
     expect(resolveImageUploadRequest(123)).toBeNull();
+  });
+});
+
+/**
+ * BOUNDED AUTO-RETRY (launch-failure recovery).
+ *
+ * These pin the BOUNDS, in the node env, without paying the host's real 10s/15s
+ * timer windows. The two hard constraints:
+ *   - the automatic loop is BOUNDED (never unbounded against a down host);
+ *   - the RE-MINT count is bounded specifically, because `/api/v1/block-tokens`
+ *     is rate-limited (60/min) and only auth terminals re-mint.
+ * The browser suite (PageBlockHostAutoRetry.browser.test.tsx) drives the same
+ * bounds through the REAL host.
+ */
+describe('decideAutoRetry — the bounded automatic recovery loop', () => {
+  const base = { attempts: 0, reminted: 0, canRemint: true };
+
+  it('never auto-retries a non-terminal status', () => {
+    expect(decideAutoRetry({ ...base, status: 'loading' }).kind).toBe('none');
+    expect(decideAutoRetry({ ...base, status: 'ready' }).kind).toBe('none');
+  });
+
+  it('schedules a retry from EVERY terminal reason', () => {
+    for (const status of ['timeout', 'fatal', 'no_token', 'error'] as PageHostStatus[]) {
+      const d = decideAutoRetry({ ...base, status });
+      expect(d.kind, `status=${status}`).toBe('retry');
+    }
+  });
+
+  it('BOUNDS the loop at MAX_AUTO_RETRIES — attempt N+1 is never scheduled', () => {
+    // Walk the whole budget for a non-auth terminal (no re-mint involved).
+    for (let attempts = 0; attempts < MAX_AUTO_RETRIES; attempts++) {
+      const d = decideAutoRetry({ ...base, attempts, status: 'timeout' });
+      expect(d.kind).toBe('retry');
+      if (d.kind === 'retry') expect(d.attempt).toBe(attempts + 1);
+    }
+    // Budget spent → SETTLED. This is the assertion that fails if the cap is
+    // removed (an unbounded loop against a down host).
+    expect(decideAutoRetry({ ...base, attempts: MAX_AUTO_RETRIES, status: 'timeout' }).kind).toBe(
+      'none'
+    );
+    expect(
+      decideAutoRetry({ ...base, attempts: MAX_AUTO_RETRIES + 5, status: 'timeout' }).kind
+    ).toBe('none');
+  });
+
+  it('BACKS OFF between attempts (each delay strictly greater than the last)', () => {
+    const delays: number[] = [];
+    for (let attempts = 0; attempts < MAX_AUTO_RETRIES; attempts++) {
+      const d = decideAutoRetry({ ...base, attempts, status: 'timeout' });
+      if (d.kind === 'retry') delays.push(d.delayMs);
+    }
+    expect(delays).toHaveLength(MAX_AUTO_RETRIES);
+    expect(delays).toEqual([...AUTO_RETRY_BACKOFF_MS].slice(0, MAX_AUTO_RETRIES));
+    for (let i = 1; i < delays.length; i++) expect(delays[i]).toBeGreaterThan(delays[i - 1]);
+    // Every delay is a real, positive pause — a 0ms "backoff" would be a hot loop.
+    for (const d of delays) expect(d).toBeGreaterThan(0);
+  });
+
+  it('marks ONLY the auth terminals as re-minting (the rate-limited path)', () => {
+    for (const status of ['no_token', 'error'] as PageHostStatus[]) {
+      const d = decideAutoRetry({ ...base, status });
+      expect(d.kind === 'retry' && d.remint, `status=${status}`).toBe(true);
+    }
+    for (const status of ['timeout', 'fatal'] as PageHostStatus[]) {
+      const d = decideAutoRetry({ ...base, status });
+      expect(d.kind === 'retry' && d.remint, `status=${status}`).toBe(false);
+    }
+  });
+
+  it('BOUNDS re-mints at MAX_AUTO_REMINTS — the rate-limit guard', () => {
+    // At the cap, an auth terminal STOPS (a remount alone can never clear an
+    // auth failure, so a budget-less attempt would be a guaranteed re-fail).
+    expect(
+      decideAutoRetry({ ...base, status: 'error', attempts: 0, reminted: MAX_AUTO_REMINTS }).kind
+    ).toBe('none');
+    expect(
+      decideAutoRetry({ ...base, status: 'no_token', attempts: 0, reminted: MAX_AUTO_REMINTS }).kind
+    ).toBe('none');
+    // …while a NON-auth terminal is unaffected by the re-mint budget.
+    expect(
+      decideAutoRetry({ ...base, status: 'timeout', attempts: 0, reminted: MAX_AUTO_REMINTS }).kind
+    ).toBe('retry');
+  });
+
+  it('does not auto-retry an auth terminal when no re-mint is wired', () => {
+    // `canRemint:false` (no onRetryToken) → a remount is a guaranteed re-fail.
+    expect(decideAutoRetry({ ...base, canRemint: false, status: 'error' }).kind).toBe('none');
+    expect(decideAutoRetry({ ...base, canRemint: false, status: 'no_token' }).kind).toBe('none');
+    // Non-auth terminals still retry — they never needed a re-mint.
+    expect(decideAutoRetry({ ...base, canRemint: false, status: 'timeout' }).kind).toBe('retry');
+    expect(decideAutoRetry({ ...base, canRemint: false, status: 'fatal' }).kind).toBe('retry');
+  });
+
+  it('classifies terminals consistently (auto-retryable / auth) ', () => {
+    expect(isAutoRetryableStatus('loading')).toBe(false);
+    expect(isAutoRetryableStatus('ready')).toBe(false);
+    expect(isAutoRetryableStatus('timeout')).toBe(true);
+    expect(isAutoRetryableStatus('fatal')).toBe(true);
+    expect(isAutoRetryableStatus('no_token')).toBe(true);
+    expect(isAutoRetryableStatus('error')).toBe(true);
+
+    expect(isAuthTerminalStatus('error')).toBe(true);
+    expect(isAuthTerminalStatus('no_token')).toBe(true);
+    expect(isAuthTerminalStatus('timeout')).toBe(false);
+    expect(isAuthTerminalStatus('fatal')).toBe(false);
+  });
+
+  it('the backoff table covers the whole attempt budget', () => {
+    // A shorter table would silently reuse the last delay; assert they line up so
+    // a future bump of MAX_AUTO_RETRIES has to extend the table deliberately.
+    expect(AUTO_RETRY_BACKOFF_MS.length).toBeGreaterThanOrEqual(MAX_AUTO_RETRIES);
   });
 });

--- a/src/components/AppBlocks/pageBlockHostLogic.ts
+++ b/src/components/AppBlocks/pageBlockHostLogic.ts
@@ -466,6 +466,13 @@ export function decideAutoRetry(args: {
   // governed by the attempt cap alone. This keeps a MIXED sequence honest too: a
   // timeout followed by an auth failure has already spent an attempt but no
   // re-mint, so it correctly reads "attempt 2 of 2".
+  //
+  // Proven never to under-promise: the auth branch is only reached while
+  // `reminted < MAX_AUTO_REMINTS`, so `MAX_AUTO_REMINTS - reminted >= 1` and the
+  // result is always `>= attempt`. 🔴 It CAN still shrink across renders if the
+  // caps are ever widened past `MAX_AUTO_RETRIES === MAX_AUTO_REMINTS + 1` (e.g.
+  // 4 and 2: a timeout shows "1 of 4", a following auth failure "2 of 3"). Today's
+  // constants make that unreachable; revisit this line if they change.
   const maxAttempts = remint
     ? Math.min(MAX_AUTO_RETRIES, attempts + (MAX_AUTO_REMINTS - reminted))
     : MAX_AUTO_RETRIES;

--- a/src/components/AppBlocks/pageBlockHostLogic.ts
+++ b/src/components/AppBlocks/pageBlockHostLogic.ts
@@ -405,8 +405,24 @@ export function isAuthTerminalStatus(status: PageHostStatus): boolean {
 
 export type AutoRetryDecision =
   | { kind: 'none' }
-  /** Schedule attempt `attempt` (1-based) after `delayMs`; `remint` re-mints the token. */
-  | { kind: 'retry'; attempt: number; delayMs: number; remint: boolean };
+  | {
+      kind: 'retry';
+      /** 1-based index of the attempt being scheduled. */
+      attempt: number;
+      /**
+       * The highest attempt number still reachable FROM HERE, given the current
+       * status. This is what the UI must show as the denominator — NOT the raw
+       * `MAX_AUTO_RETRIES`. On an auth terminal the sequence is bounded by the
+       * (lower) re-mint budget, so advertising the attempt cap would promise the
+       * user a retry that will never happen: a fresh auth failure gets
+       * "attempt 1 of 1", not "attempt 1 of 2". Derived rather than passed in, so
+       * the copy cannot drift from the bound that actually governs it.
+       */
+      maxAttempts: number;
+      delayMs: number;
+      /** Whether this attempt spends a token re-mint. */
+      remint: boolean;
+    };
 
 /**
  * Decide whether the host should schedule another AUTOMATIC load attempt.
@@ -443,5 +459,16 @@ export function decideAutoRetry(args: {
 
   const delayMs =
     AUTO_RETRY_BACKOFF_MS[attempts] ?? AUTO_RETRY_BACKOFF_MS[AUTO_RETRY_BACKOFF_MS.length - 1];
-  return { kind: 'retry', attempt: attempts + 1, delayMs, remint };
+
+  // The reachable ceiling FROM HERE. An auth terminal can only continue while it
+  // has re-mint budget, so its ceiling is the attempts already spent plus the
+  // re-mints still available — clamped by the attempt cap. A non-auth terminal is
+  // governed by the attempt cap alone. This keeps a MIXED sequence honest too: a
+  // timeout followed by an auth failure has already spent an attempt but no
+  // re-mint, so it correctly reads "attempt 2 of 2".
+  const maxAttempts = remint
+    ? Math.min(MAX_AUTO_RETRIES, attempts + (MAX_AUTO_REMINTS - reminted))
+    : MAX_AUTO_RETRIES;
+
+  return { kind: 'retry', attempt: attempts + 1, maxAttempts, delayMs, remint };
 }

--- a/src/components/AppBlocks/pageBlockHostLogic.ts
+++ b/src/components/AppBlocks/pageBlockHostLogic.ts
@@ -325,3 +325,106 @@ export function pageFallbackReason(status: PageHostStatus): PageFallbackReason |
       return 'timeout';
   }
 }
+
+// ── BOUNDED AUTO-RETRY (launch-failure recovery) ─────────────────────────────
+//
+// The reported defect was NOT that the retry LOGIC was broken — it works — but
+// that a transient launch failure required the user to notice and press a
+// button, and the button was easy to miss ("there might have been a retry
+// button but I didn't notice — I did a full page reload"). So the host now
+// re-attempts the load ITSELF a bounded number of times, and only after that
+// budget is spent does it settle on a definitive terminal state whose manual
+// Retry is made prominent.
+//
+// 🔴 THE TERMINAL STATE IS NEVER DELAYED OR MASKED. The host renders the real
+// terminal `BlockFallback` the instant a terminal status is reached; the pending
+// auto-retry is surfaced as ADDITIONAL copy inside that same fallback. There is
+// no "keep spinning while we quietly retry" state — that would recreate the
+// silent-blank failure class this codebase has fought repeatedly.
+//
+// 🔴 BOUNDED, ALWAYS. Two independent caps:
+//   - MAX_AUTO_RETRIES bounds the total automatic attempts per host mount.
+//   - MAX_AUTO_REMINTS bounds how many of those may spend a token RE-MINT.
+//     `/api/v1/block-tokens` is rate-limited (60/min per user+instance), and an
+//     unbounded auth-failure loop is exactly the shape that would burn it.
+// The budgets are per MOUNT and are NOT refilled by a manual Retry — once spent,
+// every subsequent failure goes straight to the definitive terminal state.
+
+/** Maximum AUTOMATIC load re-attempts per host mount (the initial load excluded). */
+export const MAX_AUTO_RETRIES = 2;
+
+/**
+ * Maximum automatic attempts that may spend a token RE-MINT. Auth terminals
+ * (`error`/`no_token`) can only be recovered by re-minting — a local remount can
+ * never clear them — so this is the specific cap that protects the rate-limited
+ * mint endpoint from an automatic loop.
+ */
+export const MAX_AUTO_REMINTS = 2;
+
+/**
+ * Backoff before automatic attempt N (index 0 = the first auto-retry). Modest and
+ * exponential-ish: long enough for a transient blip/deploy-drain to clear, short
+ * enough that a real failure settles quickly. Indices past the end reuse the last
+ * value (defensive — today the array covers MAX_AUTO_RETRIES exactly).
+ */
+export const AUTO_RETRY_BACKOFF_MS: readonly number[] = [2_000, 5_000];
+
+/** Terminal statuses a bounded auto-retry may attempt to recover from. */
+export function isAutoRetryableStatus(status: PageHostStatus): boolean {
+  return (
+    status === 'timeout' || status === 'fatal' || status === 'no_token' || status === 'error'
+  );
+}
+
+/**
+ * AUTH terminals: the iframe never received a usable token. `token`/`tokenError`
+ * are PROPS owned upstream (useBlockToken in the route), and `shouldStartInit`
+ * gates on `hasToken` — so a local remount alone can NEVER recover these; only a
+ * re-mint can. Mirrors the manual-Retry branch in PageBlockHost.handleRetry.
+ */
+export function isAuthTerminalStatus(status: PageHostStatus): boolean {
+  return status === 'error' || status === 'no_token';
+}
+
+export type AutoRetryDecision =
+  | { kind: 'none' }
+  /** Schedule attempt `attempt` (1-based) after `delayMs`; `remint` re-mints the token. */
+  | { kind: 'retry'; attempt: number; delayMs: number; remint: boolean };
+
+/**
+ * Decide whether the host should schedule another AUTOMATIC load attempt.
+ *
+ * Pure so every bound is unit-testable without driving the real 10s/15s timer
+ * windows, and so the two consumers can never disagree: the scheduling effect
+ * (which arms the backoff timer) and the render-FAILURE beacon (which must stay
+ * silent while the host has not settled — see the beacon-semantics note in
+ * PageBlockHost) both read THIS function.
+ *
+ * Returns `{kind:'none'}` — i.e. the host has SETTLED on this terminal state — when:
+ *   - the status is non-terminal (loading/ready) or not auto-retryable;
+ *   - the total attempt budget is spent;
+ *   - the status is an AUTH terminal and either (a) the re-mint budget is spent,
+ *     or (b) no re-mint is wired (`canRemint:false`). In both cases a further
+ *     attempt is a GUARANTEED re-fail (a remount can't change an upstream token),
+ *     so retrying would waste the user's time and, in case (a), the rate limit.
+ */
+export function decideAutoRetry(args: {
+  status: PageHostStatus;
+  /** Automatic attempts already performed this mount. */
+  attempts: number;
+  /** Automatic attempts already performed that spent a re-mint. */
+  reminted: number;
+  /** Whether the host actually has a token re-mint available (`onRetryToken`). */
+  canRemint: boolean;
+}): AutoRetryDecision {
+  const { status, attempts, reminted, canRemint } = args;
+  if (!isAutoRetryableStatus(status)) return { kind: 'none' };
+  if (attempts >= MAX_AUTO_RETRIES) return { kind: 'none' };
+
+  const remint = isAuthTerminalStatus(status);
+  if (remint && (!canRemint || reminted >= MAX_AUTO_REMINTS)) return { kind: 'none' };
+
+  const delayMs =
+    AUTO_RETRY_BACKOFF_MS[attempts] ?? AUTO_RETRY_BACKOFF_MS[AUTO_RETRY_BACKOFF_MS.length - 1];
+  return { kind: 'retry', attempt: attempts + 1, delayMs, remint };
+}

--- a/src/components/AppBlocks/pageBlockHostLogic.ts
+++ b/src/components/AppBlocks/pageBlockHostLogic.ts
@@ -350,16 +350,33 @@ export function pageFallbackReason(status: PageHostStatus): PageFallbackReason |
 // The budgets are per MOUNT and are NOT refilled by a manual Retry — once spent,
 // every subsequent failure goes straight to the definitive terminal state.
 
-/** Maximum AUTOMATIC load re-attempts per host mount (the initial load excluded). */
+/**
+ * Maximum AUTOMATIC load re-attempts per host mount (the initial load excluded).
+ *
+ * 🔴 ROLLBACK: setting this to 0 cleanly disables auto-retry entirely — the
+ * decision returns `none` for every status, so the terminal fallback renders
+ * immediately with the prominent manual Retry and `autoRetriesSpent` stays 0 (no
+ * false "we already retried" copy). It is the one-line kill switch; there is no
+ * feature flag on this path.
+ */
 export const MAX_AUTO_RETRIES = 2;
 
 /**
  * Maximum automatic attempts that may spend a token RE-MINT. Auth terminals
  * (`error`/`no_token`) can only be recovered by re-minting — a local remount can
  * never clear them — so this is the specific cap that protects the rate-limited
- * mint endpoint from an automatic loop.
+ * `/api/v1/block-tokens` (60/min per user+instance) from an automatic loop.
+ *
+ * 🔴 MUST STAY STRICTLY BELOW `MAX_AUTO_RETRIES`, and there is a test that pins
+ * exactly that. Because `reminted` is a SUBSET of `attempts` (every re-minting
+ * attempt also increments `attempts`), the invariant `reminted <= attempts` holds
+ * — so if the two caps were EQUAL the total-attempt check, which runs first,
+ * would always fire first and this cap would be unreachable dead code: a stated
+ * safety limit that provably cannot bind. Keeping it strictly lower makes it the
+ * binding constraint on the auth path (the expensive one), while non-auth
+ * terminals — which cost nothing but a remount — still get the full budget.
  */
-export const MAX_AUTO_REMINTS = 2;
+export const MAX_AUTO_REMINTS = 1;
 
 /**
  * Backoff before automatic attempt N (index 0 = the first auto-retry). Modest and


### PR DESCRIPTION
## The problem

A product owner opened an app from `/apps`, it failed to load, and their words were:

> there might have been a retry button but I didn't notice — I did a full page reload

The retry **logic** was not broken. `PageBlockHost.handleRetry` already disposed the controller, re-armed the handshake, re-keyed the iframe, and — for the auth terminals — re-minted the token first, because a local remount can never clear an auth failure. What was missing:

1. **No automatic recovery.** A transient blip needed a human to intervene.
2. **The manual affordance was easy to miss** — a small subdued `xs` button.
3. **No in-progress feedback.** Pressing Retry against a still-down host waited ~10s in silence and re-rendered the identical error, which reads as "the button does nothing".

## What changed

`PageBlockHost` now re-attempts the load itself, bounded, and only then settles on a definitive terminal state whose manual Retry is prominent.

### Retry policy

| | value | why |
|---|---|---|
| Automatic attempts | **2** (`MAX_AUTO_RETRIES`) | Enough to ride out a blip/pod-drain; past that a failure is real and the user should get a definitive answer rather than a machine that keeps trying. |
| Backoff | **2 s, then 5 s** | The first pause is long enough that a rebooting host has a chance, short enough that the page settles quickly. Worst case to the definitive terminal is bounded. |
| Automatic re-mints | **1** (`MAX_AUTO_REMINTS`), **strictly below** the attempt cap | Only the auth terminals (`error`/`no_token`) re-mint, and `/api/v1/block-tokens` is rate-limited (60/min). It must stay strictly lower or it is unreachable dead code — `reminted` is a subset of `attempts` and the attempt cap is checked first. A test pins the inequality. |
| Auth terminal with **no** re-mint available | **stop immediately** | A remount alone can never clear an auth failure (the token is an upstream prop), so another attempt is a guaranteed re-fail. |
| Manual Retry | **not capped here**, and does not consume the automatic budget | User-initiated; bounded by the existing double-click guard plus the server-side rate limit. The user taking over shouldn't spend the platform's remaining recovery attempts. |

Budgets are **per mount** and are **not refilled** by a manual Retry — once spent, every later failure goes straight to the definitive terminal.

### The terminal state is never masked

This is the constraint I held hardest. The real error renders the instant the status goes terminal; the pending automatic attempt is surfaced **inside that same fallback** ("Retrying automatically… (attempt 1 of 2)"), never instead of it. There is no "keep spinning quietly while we retry" state — that would recreate the silent-blank failure class this codebase has fought repeatedly. A regression test measures the fallback's arrival against a captured timestamp and asserts it lands well inside the backoff window.

During an actual re-attempt the launch overlay says `Retrying <app>…` instead of an identical `Starting <app>…`. It deliberately carries no attempt number — the bounded count belongs on the terminal card, where the budget is meaningful; showing both put two disagreeing counters two seconds apart on the same surface.

### Other behaviour

- **Once settled**, the Retry button becomes filled + full-width + `md`, and the host states plainly that it already retried. Accessible name stays `Retry` in both states.
- **Manual + automatic share one re-arm path** (`performRetry`). A manual Retry during a pending automatic one flips the status back to `loading`, which makes the decision `none`, which tears down the pending timer in the effect cleanup — exactly one attempt runs.
- **`prefers-reduced-motion: reduce`** suppresses the *new* retry spinner in the terminal card; the copy carries the state. (The pre-existing launch overlay's `Loader` is still animated — see the corrections comment.)
- **`AppBlockChrome` still wraps every state** (FRAME-1), and the `#3457` launch reveal is untouched — its suite passes with this change in place (see below).

### Beacon semantics

**One beacon per host mount, reporting the outcome the host SETTLES on.** The whole bounded retry sequence is one logical page load:

- `ok` — the first `BLOCK_READY`, whichever attempt produced it. A load that succeeds on attempt 2 emits exactly **one** `ok` and never an `error` first.
- `error` — a terminal state reached with **no** further automatic attempt coming. N failed automatic attempts emit **one** `error`, not N.
- nothing — an intermediate terminal that will be auto-retried.

Once either fires the mount never emits again; `handleRetry` deliberately no longer resets the emit-once ref. So the alert's denominator stays "page loads" and its numerator stays "page loads the platform could not recover on its own". `errorClass` stays inside the existing server-side `KNOWN_ERROR_CLASSES` enum, so no metric **label** change is needed — but the numerator's MEANING narrows, and the `datapacket-talos` alert wording needs a companion update. See the corrections comment.

## A real bug found while writing the tests

The backoff timer must **not** be keyed on the `onRetryToken` callback identity. `ReviewBlockPreviewHost` passes an inline arrow (`onRetryToken={() => doMint(...)}`), so it is a new function on every render — with the effect depending on it, every re-render would tear down and re-arm the pending timer, the backoff would never elapse, and **auto-retry would silently never fire** for that caller. The retry is read through a ref so the effect is keyed on the decision alone. Regression test included (a parent that re-renders every 100 ms with a fresh callback).

## Tests

`decideAutoRetry` is pure, so every bound is unit-testable without paying the real 10 s/15 s timer windows; the browser suite drives the same bounds through the real host.

- **`__tests__/pageBlockHostLogic.test.ts`** — 47 tests (15 new): fires from every terminal reason, bounded at `MAX_AUTO_RETRIES`, backs off strictly increasing and never 0, only auth terminals re-mint, the re-mint cap walked from a reachable state, the strict `MAX_AUTO_REMINTS < MAX_AUTO_RETRIES` inequality that keeps it from going inert, no-re-mint-wired guard, backoff table covers the budget.
- **`PageBlockHostAutoRetry.browser.test.tsx`** — 14 new tests: terminal renders immediately with the pending retry inside it; the attempt actually re-runs after the backoff and says so; fires from `timeout`/`no_token`/`fatal`; non-auth doesn't re-mint; survives an unstable callback; re-mint cap holds and then stops; prominent Retry after exhaustion; beacon exclusivity both directions; reduced motion; manual-during-automatic; unmount mid-backoff leaks no timer.

**This suite exercises the real path** — real `PageBlockHost`, real hooks, real timers. It does **not** mock `@mantine/hooks`: the reduced-motion case stubs `window.matchMedia`, so `useReducedMotion` itself still runs. Only the ambient tRPC client and `useCurrentUser` are stubbed, exactly as the sibling suites do.

## Incidental repair (same surface)

`PageBlockHostLaunchReveal` and `IframeHostReadyTransition` were the **only** two host suites whose tRPC mock lacked `apps.shared.report`, which both hosts call unconditionally at render — so all **35** of their tests were crashing at mount with `Cannot read properties of undefined (reading 'useMutation')`. These checks are report-only, so both suites had been silently red. They are the guards for the launch-reveal and beacon-exclusivity invariants this change must not break, so they are repaired here and now pass 35/35.

## Verification

| check | result |
|---|---|
| `pageBlockHostLogic` unit suite | 47/47 |
| `PageBlockHostAutoRetry` browser suite | 14/14 |
| `PageBlockHost` browser suite (existing) | 25/25, unchanged |
| `PageBlockHostLaunchReveal` (repaired) | 10/10 |
| `IframeHostReadyTransition` (repaired) | 25/25 |
| `IframeHost` browser suite | 5/5 |
| `tsc --noEmit` | clean |

Every guard was mutation-verified: broken, confirmed a *specific* test fails, reverted. 13 mutations, 13 kills — including two round-trips where a guard **survived**: the first emit-once guard (which prompted the extra `ok`-then-crash test) and, found by the adversarial audit, a re-mint cap that was unreachable dead code (see the corrections comment).

## Not verified by me

`/apps` is mod-gated, so I have **not** clicked this path in a browser. Manual steps are in the review thread.
