### PR TITLE
fix(tensor-metadata): stop edge-caching transient 422s for a year

### DIFF
--- a/src/components/Model/ModelVersions/ModelTensorMetadata.tsx
+++ b/src/components/Model/ModelVersions/ModelTensorMetadata.tsx
@@ -20,6 +20,7 @@ import type { ModelById } from '~/types/router';
 import { formatBytes, numberWithCommas } from '~/utils/number-helpers';
 import {
   buildTensorDisplayRows,
+  buildTensorMetadataUrl,
   inferTensorMetadataFormat,
   type ModelTensorAnalysis,
   type ModelTensorDisplayGroup,
@@ -378,7 +379,7 @@ function formatShape(shape: number[]) {
 }
 
 async function fetchTensorSummary(fileId: number) {
-  const response = await fetch(`/api/v1/model-files/${fileId}/tensor-metadata?summaryOnly=true`);
+  const response = await fetch(buildTensorMetadataUrl(fileId, { summaryOnly: true }));
   if (!response.ok) {
     const body = (await response.json().catch(() => null)) as { error?: string } | null;
     throw new Error(body?.error ?? 'Failed to load tensor metadata');
@@ -388,7 +389,7 @@ async function fetchTensorSummary(fileId: number) {
 }
 
 async function fetchTensorMetadata(fileId: number) {
-  const response = await fetch(`/api/v1/model-files/${fileId}/tensor-metadata`);
+  const response = await fetch(buildTensorMetadataUrl(fileId));
   if (!response.ok) {
     const body = (await response.json().catch(() => null)) as { error?: string } | null;
     throw new Error(body?.error ?? 'Failed to load tensor metadata');

--- a/src/pages/api/v1/model-files/[id]/tensor-metadata.ts
+++ b/src/pages/api/v1/model-files/[id]/tensor-metadata.ts
@@ -20,13 +20,14 @@ const schema = z.object({
   summaryOnly: z.preprocess((val) => val === 'true' || val === true, z.boolean().optional()),
 });
 const TENSOR_METADATA_CACHE_CONTROL = 'public, max-age=31536000, s-maxage=31536000, immutable';
+const NO_STORE_CACHE_CONTROL = 'private, no-store';
 
 export default MixedAuthEndpoint(async function handler(
   req: NextApiRequest,
   res: NextApiResponse,
   user: Session['user'] | undefined
 ) {
-  res.setHeader('Cache-Control', 'private, no-store');
+  res.setHeader('Cache-Control', NO_STORE_CACHE_CONTROL);
 
   const result = schema.safeParse(req.query);
   if (!result.success)
@@ -105,8 +106,6 @@ export default MixedAuthEndpoint(async function handler(
         )
       );
 
-    res.setHeader('Cache-Control', TENSOR_METADATA_CACHE_CONTROL);
-
     if (summaryOnly) {
       const summary = await fetchThroughCache(
         `${REDIS_KEYS.CACHES.TENSOR_METADATA_SUMMARY}:${id}`,
@@ -117,12 +116,18 @@ export default MixedAuthEndpoint(async function handler(
         },
         { ttl: CacheTTL.month }
       );
+      res.setHeader('Cache-Control', TENSOR_METADATA_CACHE_CONTROL);
       return res.status(200).json(summary);
     }
 
     const analysis = await fetchFull();
+    res.setHeader('Cache-Control', TENSOR_METADATA_CACHE_CONTROL);
     res.status(200).json(analysis);
   } catch (error) {
+    // The upstream byte-range fetch fails transiently. If this 422 ever inherits the immutable
+    // header, Cloudflare freezes the error for a year and the file's panel never recovers.
+    res.setHeader('Cache-Control', NO_STORE_CACHE_CONTROL);
+
     const err = error instanceof Error ? error : new Error(String(error));
     logToAxiom({
       name: 'model-file-tensor-metadata',

--- a/src/tests/api/v1/model-files/tensor-metadata-cache-headers.test.ts
+++ b/src/tests/api/v1/model-files/tensor-metadata-cache-headers.test.ts
@@ -1,0 +1,173 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Regression test for CU 868khnkuc: the 1-year `immutable` Cache-Control was set BEFORE the
+ * upstream byte-range fetch, so a transient 422 inherited it and Cloudflare froze the error at
+ * the edge for a year (207K byte-range errors / 14d, each poisoning that file's Tensors panel).
+ * Only 200 responses may carry the immutable header; every error path must stay no-store.
+ */
+
+const IMMUTABLE = 'public, max-age=31536000, s-maxage=31536000, immutable';
+const NO_STORE = 'private, no-store';
+
+const { mockFindUnique, mockGetFileForModelVersion, mockGetFullTensorAnalysisCached } = vi.hoisted(
+  () => ({
+    mockFindUnique: vi.fn(),
+    mockGetFileForModelVersion: vi.fn(),
+    mockGetFullTensorAnalysisCached: vi.fn(),
+  })
+);
+
+vi.mock('~/server/utils/endpoint-helpers', () => ({
+  MixedAuthEndpoint: (handler: any) => (req: any, res: any) => handler(req, res, undefined),
+}));
+
+vi.mock('~/server/db/client', () => ({
+  dbRead: { modelFile: { findUnique: (...args: any[]) => mockFindUnique(...args) } },
+}));
+
+vi.mock('~/server/services/file.service', () => ({
+  getFileForModelVersion: (...args: any[]) => mockGetFileForModelVersion(...args),
+}));
+
+vi.mock('~/server/services/tensor-metadata.service', () => ({
+  getFullTensorAnalysisCached: (...args: any[]) => mockGetFullTensorAnalysisCached(...args),
+}));
+
+// Both caches are pass-through here: this test pins response headers, not cache behaviour
+// (that contract lives in tensor-metadata-cache-split.test.ts).
+vi.mock('~/server/utils/cache-helpers', () => ({
+  fetchThroughCache: (_key: string, fetcher: () => Promise<unknown>) => fetcher(),
+}));
+
+vi.mock('~/server/redis/client', () => ({
+  REDIS_KEYS: {
+    CACHES: {
+      TENSOR_METADATA: 'packed:caches:tensor-metadata',
+      TENSOR_METADATA_SUMMARY: 'packed:caches:tensor-metadata-summary',
+    },
+  },
+}));
+
+vi.mock('~/server/logging/client', () => ({ logToAxiom: vi.fn().mockResolvedValue(undefined) }));
+
+const analysis = {
+  format: 'SafeTensor',
+  tensorCount: 1,
+  totalTensorBytes: 8,
+  dtypes: [],
+  largestTensor: null,
+  vramEstimate: null,
+  tensors: [{ name: 'weight', shape: [2, 2], dtype: 'F16', sizeBytes: 8 }],
+};
+
+let handler: (req: NextApiRequest, res: NextApiResponse) => Promise<void> | void;
+
+beforeAll(async () => {
+  const mod = await import('~/pages/api/v1/model-files/[id]/tensor-metadata');
+  handler = mod.default as any;
+}, 120000);
+
+function fakeRes() {
+  const headers: Record<string, string> = {};
+  const res: any = {
+    setHeader(key: string, value: string) {
+      headers[key.toLowerCase()] = value;
+      return this;
+    },
+    status(code: number) {
+      this.statusCode = code;
+      return this;
+    },
+    json(body: unknown) {
+      this.body = body;
+      return this;
+    },
+    _getHeader: (key: string) => headers[key.toLowerCase()],
+  };
+  return res as NextApiResponse & {
+    statusCode?: number;
+    body?: any;
+    _getHeader: (key: string) => string | undefined;
+  };
+}
+
+async function invoke(query: Record<string, unknown>) {
+  const res = fakeRes();
+  await handler({ method: 'GET', query } as unknown as NextApiRequest, res);
+  return res;
+}
+
+describe('/api/v1/model-files/[id]/tensor-metadata cache headers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFindUnique.mockResolvedValue({
+      id: 3057178,
+      modelVersionId: 3176604,
+      name: 'moody-cutie-mix.safetensors',
+      type: 'Model',
+      sizeKB: 24_000_000,
+      metadata: { format: 'SafeTensor' },
+      modelVersion: { model: { type: 'Checkpoint' } },
+    });
+    mockGetFileForModelVersion.mockResolvedValue({
+      status: 'success',
+      url: 'https://delivery.example/file.safetensors',
+    });
+    mockGetFullTensorAnalysisCached.mockResolvedValue(analysis);
+  });
+
+  it('caches a successful full analysis for a year', async () => {
+    const res = await invoke({ id: '3057178' });
+
+    expect(res.statusCode).toBe(200);
+    expect(res._getHeader('Cache-Control')).toBe(IMMUTABLE);
+  });
+
+  it('caches a successful summary for a year', async () => {
+    const res = await invoke({ id: '3057178', summaryOnly: 'true' });
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).not.toHaveProperty('tensors');
+    expect(res._getHeader('Cache-Control')).toBe(IMMUTABLE);
+  });
+
+  it('does NOT cache the 422 when the upstream byte-range fetch fails', async () => {
+    mockGetFullTensorAnalysisCached.mockRejectedValue(
+      new Error('Model host does not support byte-range requests')
+    );
+
+    const res = await invoke({ id: '3057178' });
+
+    expect(res.statusCode).toBe(422);
+    expect(res._getHeader('Cache-Control')).toBe(NO_STORE);
+  });
+
+  it('does NOT cache the 422 on the summaryOnly path either', async () => {
+    mockGetFullTensorAnalysisCached.mockRejectedValue(
+      new Error('Model host does not support byte-range requests')
+    );
+
+    const res = await invoke({ id: '3057178', summaryOnly: 'true' });
+
+    expect(res.statusCode).toBe(422);
+    expect(res._getHeader('Cache-Control')).toBe(NO_STORE);
+  });
+
+  it('ignores the cache-busting version param the client sends', async () => {
+    const res = await invoke({ id: '3057178', summaryOnly: 'true', v: '2' });
+
+    expect(res.statusCode).toBe(200);
+    expect(res._getHeader('Cache-Control')).toBe(IMMUTABLE);
+  });
+
+  it('does not cache the access-denied response', async () => {
+    mockGetFileForModelVersion.mockResolvedValue({ status: 'no-access' });
+
+    const res = await invoke({ id: '3057178' });
+
+    expect(res.statusCode).toBe(403);
+    expect(res._getHeader('Cache-Control')).toBe(NO_STORE);
+  });
+});

--- a/src/utils/__tests__/model-tensor-metadata-range-fallback.test.ts
+++ b/src/utils/__tests__/model-tensor-metadata-range-fallback.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest';
+import { parseModelTensorMetadata } from '~/utils/model-tensor-metadata';
+
+/**
+ * CU 868khnkuc: the delivery hosts intermittently answer a `Range` request with 200 + the whole
+ * file instead of 206. That was a hard failure ("Model host does not support byte-range requests",
+ * 207K hits / 14d) even though a 200 body still contains the header we want at offset 0. We now
+ * slice the wanted window off the stream and abort — without ever buffering the 24 GB body.
+ */
+
+const CHUNK_SIZE = 64 * 1024;
+const CHUNK_COUNT = 16;
+
+function buildSafetensorsFile() {
+  const header = JSON.stringify({
+    weight: { dtype: 'F16', shape: [2, 2], data_offsets: [0, 8] },
+    bias: { dtype: 'F16', shape: [2], data_offsets: [8, 12] },
+  });
+  const headerBytes = new TextEncoder().encode(header);
+  const file = new Uint8Array(CHUNK_SIZE * CHUNK_COUNT);
+  new DataView(file.buffer).setUint32(0, headerBytes.length, true);
+  file.set(headerBytes, 8);
+  return file;
+}
+
+/** Emits the file in fixed-size chunks and records how many were actually pulled. */
+function chunkedBody(file: Uint8Array, pulled: { count: number }) {
+  let offset = 0;
+  return new ReadableStream<Uint8Array>({
+    pull(controller) {
+      if (offset >= file.length) return controller.close();
+      controller.enqueue(file.slice(offset, offset + CHUNK_SIZE));
+      offset += CHUNK_SIZE;
+      pulled.count += 1;
+    },
+  });
+}
+
+describe('parseModelTensorMetadata with a host that ignores Range', () => {
+  it('parses the SafeTensor header from a 200 full-body response', async () => {
+    const file = buildSafetensorsFile();
+    const pulled = { count: 0 };
+    const fetchImpl = (async () =>
+      new Response(chunkedBody(file, pulled), { status: 200 })) as unknown as typeof fetch;
+
+    const analysis = await parseModelTensorMetadata({
+      url: 'https://delivery.example/file.safetensors',
+      format: 'SafeTensor',
+      fileSizeBytes: file.length,
+      estimateVram: false,
+      fetchImpl,
+    });
+
+    expect(analysis.tensors.map((tensor) => tensor.name)).toEqual(['weight', 'bias']);
+  });
+
+  it('aborts the body instead of buffering the whole file', async () => {
+    const file = buildSafetensorsFile();
+    const pulled = { count: 0 };
+    const fetchImpl = (async () =>
+      new Response(chunkedBody(file, pulled), { status: 200 })) as unknown as typeof fetch;
+
+    await parseModelTensorMetadata({
+      url: 'https://delivery.example/file.safetensors',
+      format: 'SafeTensor',
+      fileSizeBytes: file.length,
+      estimateVram: false,
+      fetchImpl,
+    });
+
+    // Two range reads (8-byte prefix, then the header) — both satisfied by the first chunk.
+    expect(pulled.count).toBeLessThanOrEqual(4);
+  });
+
+  it('still fails on a non-ok response', async () => {
+    const fetchImpl = (async () =>
+      new Response('nope', { status: 404 })) as unknown as typeof fetch;
+
+    await expect(
+      parseModelTensorMetadata({
+        url: 'https://delivery.example/file.safetensors',
+        format: 'SafeTensor',
+        estimateVram: false,
+        fetchImpl,
+      })
+    ).rejects.toThrow('Failed to fetch model metadata range: 404');
+  });
+
+  it('still honours a real 206 partial response', async () => {
+    const file = buildSafetensorsFile();
+    const fetchImpl = (async (_url: string, init?: RequestInit) => {
+      const range = (init?.headers as Record<string, string>).Range;
+      const [start, end] = range.replace('bytes=', '').split('-').map(Number);
+      return new Response(file.slice(start, end + 1), { status: 206 });
+    }) as unknown as typeof fetch;
+
+    const analysis = await parseModelTensorMetadata({
+      url: 'https://delivery.example/file.safetensors',
+      format: 'SafeTensor',
+      estimateVram: false,
+      fetchImpl,
+    });
+
+    expect(analysis.tensors.map((tensor) => tensor.name)).toEqual(['weight', 'bias']);
+  });
+});

--- a/src/utils/__tests__/model-tensor-metadata-url.test.ts
+++ b/src/utils/__tests__/model-tensor-metadata-url.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest';
-import { buildTensorMetadataUrl, TENSOR_METADATA_CACHE_VERSION } from '~/utils/model-tensor-metadata';
+import {
+  buildTensorMetadataUrl,
+  TENSOR_METADATA_CACHE_VERSION,
+} from '~/utils/model-tensor-metadata';
 
 /**
  * CU 868khnkuc: ~200K 422s are already sitting in the Cloudflare edge under `immutable` and do not

--- a/src/utils/__tests__/model-tensor-metadata-url.test.ts
+++ b/src/utils/__tests__/model-tensor-metadata-url.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { buildTensorMetadataUrl, TENSOR_METADATA_CACHE_VERSION } from '~/utils/model-tensor-metadata';
+
+/**
+ * CU 868khnkuc: ~200K 422s are already sitting in the Cloudflare edge under `immutable` and do not
+ * expire for a year. Shipping the header fix alone leaves every one of those files broken, so the
+ * request carries a cache-key version the poisoned entries were never stored under. Bump it if we
+ * ever poison the edge again.
+ */
+describe('buildTensorMetadataUrl', () => {
+  it('carries the cache version on the summary request', () => {
+    const url = buildTensorMetadataUrl(3057178, { summaryOnly: true });
+
+    expect(url).toContain('/api/v1/model-files/3057178/tensor-metadata?');
+    expect(new URL(url, 'https://civitai.com').searchParams.get('summaryOnly')).toBe('true');
+    expect(new URL(url, 'https://civitai.com').searchParams.get('v')).toBe(
+      String(TENSOR_METADATA_CACHE_VERSION)
+    );
+  });
+
+  it('carries the cache version on the full request', () => {
+    const url = buildTensorMetadataUrl(3057178);
+    const params = new URL(url, 'https://civitai.com').searchParams;
+
+    expect(params.get('summaryOnly')).toBeNull();
+    expect(params.get('v')).toBe(String(TENSOR_METADATA_CACHE_VERSION));
+  });
+
+  it('is past the version the poisoned entries were cached under', () => {
+    expect(TENSOR_METADATA_CACHE_VERSION).toBeGreaterThan(1);
+  });
+});

--- a/src/utils/model-tensor-metadata.ts
+++ b/src/utils/model-tensor-metadata.ts
@@ -179,6 +179,24 @@ export function inferTensorMetadataFormat(file: {
   return null;
 }
 
+/**
+ * Part of the cache key, so bumping it orphans every edge entry stored under the old value. At 1,
+ * a transient 422 inherited a 1-year `immutable` header (CU 868khnkuc) and ~200K responses are
+ * still poisoned at the edge — they can only be reached under `v=1`.
+ */
+export const TENSOR_METADATA_CACHE_VERSION = 2;
+
+export function buildTensorMetadataUrl(
+  fileId: number,
+  { summaryOnly = false }: { summaryOnly?: boolean } = {}
+) {
+  const params = new URLSearchParams();
+  if (summaryOnly) params.set('summaryOnly', 'true');
+  params.set('v', String(TENSOR_METADATA_CACHE_VERSION));
+
+  return `/api/v1/model-files/${fileId}/tensor-metadata?${params.toString()}`;
+}
+
 function estimateComfyDynamicOffloadVram(tensors: ModelTensorInfo[]): ModelVramEstimate {
   const layerGroups = buildLayerGroups(tensors);
   let residentWeightsBytes = 0;
@@ -443,14 +461,58 @@ async function fetchByteRange(
   });
 
   if (!response.ok) throw new Error(`Failed to fetch model metadata range: ${response.status}`);
-  if (response.status !== 206) {
-    throw new Error('Model host does not support byte-range requests');
-  }
 
-  const bytes = new Uint8Array(await response.arrayBuffer());
+  const bytes =
+    response.status === 206
+      ? new Uint8Array(await response.arrayBuffer())
+      : await readRangeFromFullBody(response, start, end);
+
   const expectedLength = end - start + 1;
   if (!allowShort && bytes.length < expectedLength) {
     throw new Error('Model metadata range response was shorter than expected');
+  }
+
+  return bytes;
+}
+
+/**
+ * The delivery hosts intermittently answer a `Range` request with 200 and the whole file. The
+ * bytes we want are still there at their real offsets, so slice them off the stream and abort —
+ * never buffer the body, these files run to 24 GB.
+ */
+async function readRangeFromFullBody(response: Response, start: number, end: number) {
+  if (!response.body) throw new Error('Model host does not support byte-range requests');
+
+  const wanted = end - start + 1;
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let collected = 0;
+  let position = 0;
+
+  try {
+    while (collected < wanted) {
+      const { done, value } = await reader.read();
+      if (done) break;
+
+      const chunk = value as Uint8Array;
+      if (position + chunk.length > start) {
+        const from = Math.max(0, start - position);
+        const to = Math.min(chunk.length, from + wanted - collected);
+        const slice = chunk.subarray(from, to);
+        chunks.push(slice);
+        collected += slice.length;
+      }
+      position += chunk.length;
+    }
+  } finally {
+    await reader.cancel().catch(() => undefined);
+  }
+
+  const bytes = new Uint8Array(collected);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.length;
   }
 
   return bytes;


### PR DESCRIPTION
Fixes [CU 868khnkuc](https://app.clickup.com/t/868khnkuc).

## Problem

`GET /api/v1/model-files/:id/tensor-metadata` set the 1-year `immutable` Cache-Control **before** the upstream byte-range fetch ran. When that fetch threw, the `catch` returned a 422 that inherited the header, so Cloudflare stored the error for `s-maxage=31536000`. One transient hiccup permanently killed that file's Tensors/VRAM panel.

```
HTTP/2 422
cache-control: public, max-age=31536000, s-maxage=31536000, immutable   <-- on an ERROR response
age: 62659
cf-cache-status: HIT
{"error":"Model host does not support byte-range requests"}
```

Not one model: 207,078 byte-range errors in Axiom over 14 days, 5K–43K/day across 3.4K–18.7K distinct file ids/day. Introduced in `d4e3ebdc61` (#2500).

Redis was never poisoned — the throw escapes `fetchThroughCache` — so the edge is the only stale layer.

## Changes

**1. `immutable` only on 200s** — `src/pages/api/v1/model-files/[id]/tensor-metadata.ts`

The header set moves from before the awaited fetch to just before each `res.status(200)`, and the `catch` explicitly resets `private, no-store`. The 403/404/410 branches were already fine (they return before the old line 108).

**2. Tolerate a non-206 response** — `src/utils/model-tensor-metadata.ts`

Both delivery hosts do support ranges — I range-probed them on cache HIT, MISS and BYPASS and got 206 every time. The 200 is intermittent (CF cache-fill, presigned-URL churn, upstream blip), and a 200 body still contains the SafeTensor/GGUF header at offset 0. We now slice the requested window off the stream and cancel the reader instead of throwing away a response we could have parsed. The body is never buffered — these files run to 24 GB. Handles `start > 0` (safetensors' second read begins at byte 8). Non-ok responses and real 206s are unchanged.

**3. Cache-key version bump (`?v=2`)** — `buildTensorMetadataUrl()`

Change 1 only helps files that fail *after* deploy. Responses already cached under `immutable` do not expire for up to a year, and the poisoned URL set is too large and too unknown to enumerate for a URL-list purge (`purgeCache` is URL-list based at ~1000/min). Bumping the cache-key version orphans every one of them at once, on both zones, with no ops dependency. Zod strips the unknown param; a test pins that so a future `.strict()` can't silently break the panel.

## Tests

- `src/tests/api/v1/model-files/tensor-metadata-cache-headers.test.ts` — 200 full and summary carry `immutable`; both 422 paths and the access-denied path carry `no-store`; the `v` param is ignored.
- `src/utils/__tests__/model-tensor-metadata-range-fallback.test.ts` — parses from a 200 full-body response; aborts the stream instead of buffering (asserts chunks pulled); still fails on non-ok; still honours a real 206.
- `src/utils/__tests__/model-tensor-metadata-url.test.ts` — both request shapes carry the version.

208 tests pass including the two pre-existing tensor test files. `pnpm run typecheck` clean.

## Not in this PR

- **Optional follow-up for ops:** a Cloudflare *prefix* purge on `/api/v1/model-files/` would clear the poisoned entries outright. Change 3 makes them unreachable without it, so this is belt-and-braces.
- `Cannot destructure property 'tensors' of '(intermediate value)'` (85 hits) — a real crash in the `summaryOnly` branch when the full fetch resolves `undefined`. Tracked separately per the ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)