### PR TITLE
fix(tests): repair the component-suite baseline (import failures + timeout-burning mocks)

### DIFF
--- a/src/components/AppBlocks/PageBlockHost.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHost.browser.test.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { describe, expect, test, vi, beforeEach } from 'vitest';
+import { describe, expect, test, vi, beforeEach, afterEach } from 'vitest';
 import { page } from 'vitest/browser';
 import { useDialogStore } from '~/components/Dialog/dialogStore';
 // `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
@@ -160,6 +160,37 @@ const baseProps = {
   viewer: { id: 42, username: 'tester' },
   theme: 'light' as const,
 };
+
+/**
+ * Six tests below exercise PageBlockHost's two REAL product timeout windows —
+ * `BLOCK_READY_TIMEOUT_MS` (10s) and `TOKEN_WAIT_TIMEOUT_MS` (15s) in PageBlockHost.tsx.
+ * Sleeping through them in real time cost ~76s, ~95% of this file's runtime. Instead:
+ *
+ *   useFakeClock()  — install Vitest's fake clock BEFORE the render, so the product's
+ *                     `setTimeout` is scheduled on it (installing it after the render
+ *                     does nothing: the timer is already on the real clock).
+ *                     `shouldAdvanceTime` keeps the fake clock ticking with real time so
+ *                     browser-mode locator polling still progresses while it's installed.
+ *   advancePastWindow(ms) — jump the window, then hand control straight back to REAL
+ *                     timers, so every later assertion, `vi.waitFor` and (crucially)
+ *                     `userEvent`/locator click runs on the normal clock. No test
+ *                     interacts with the DOM while the fake clock is installed.
+ *
+ * These do NOT weaken the tests: each still asserts the same terminal DOM state, and
+ * the elapsed window is now explicit (advance 11s past a 10s window) rather than implied
+ * by a generous real-time poll. The `afterEach` below is a safety net so a mid-test
+ * failure can never leak the fake clock into the next test.
+ */
+function useFakeClock() {
+  vi.useFakeTimers({ shouldAdvanceTime: true });
+}
+async function advancePastWindow(ms: number) {
+  await vi.advanceTimersByTimeAsync(ms);
+  vi.useRealTimers();
+}
+afterEach(() => {
+  vi.useRealTimers();
+});
 
 // Drive the handshake to BLOCK_READY (status='ready') so the consent gate's
 // `status === 'ready'` precondition is satisfied — same prerequisite a real
@@ -398,17 +429,19 @@ describe('PageBlockHost loading indicator (Task 1)', () => {
       // NEVER ack BLOCK_READY → after BLOCK_READY_TIMEOUT_MS (10s) onReadyTimeout
       // flips status 'loading' → 'timeout', clearing the loader and rendering the
       // fallback.
+      useFakeClock();
       renderWithProviders(<PageBlockHost {...baseProps} onConsentGranted={vi.fn()} />);
 
       await expect.element(page.getByTestId('app-page-loading')).toBeInTheDocument();
 
-      // Wait out the real 10s readiness window (poll with generous timeout). The
-      // loader must clear and the timeout fallback render.
+      // Jump the 10s readiness window on the fake clock instead of sleeping through it.
+      await advancePastWindow(11_000);
+      // The loader must clear and the timeout fallback render.
       await vi.waitFor(
         () => {
           expect(page.getByTestId('app-page-loading').query()).toBeNull();
         },
-        { timeout: 13_000, interval: 250 }
+        { timeout: 5_000, interval: 100 }
       );
       await expect.element(page.getByTestId('app-page-fallback')).toBeInTheDocument();
     },
@@ -423,17 +456,19 @@ describe('PageBlockHost loading indicator (Task 1)', () => {
       // TOKEN_WAIT_TIMEOUT_MS (15s) timer flips status 'loading' → 'no_token',
       // clearing the loader and rendering the fallback. (With a null token the
       // iframe still mounts in the loading state, so the overlay is shown first.)
+      useFakeClock();
       renderWithProviders(
         <PageBlockHost {...baseProps} token={null} tokenError={false} onConsentGranted={vi.fn()} />
       );
 
       await expect.element(page.getByTestId('app-page-loading')).toBeInTheDocument();
 
+      await advancePastWindow(16_000);
       await vi.waitFor(
         () => {
           expect(page.getByTestId('app-page-loading').query()).toBeNull();
         },
-        { timeout: 18_000, interval: 250 }
+        { timeout: 5_000, interval: 100 }
       );
       await expect.element(page.getByTestId('app-page-fallback')).toBeInTheDocument();
     },
@@ -490,14 +525,16 @@ describe('PageBlockHost terminal error surface (Task: readable error + Retry)', 
     'timeout terminal state: readable timeout message + Retry, not the loader',
     async () => {
       // token present, never ack BLOCK_READY → readiness timeout (10s) → 'timeout'.
+      useFakeClock();
       renderWithProviders(<PageBlockHost {...baseProps} onConsentGranted={vi.fn()} />);
       await expect.element(page.getByTestId('app-page-loading')).toBeInTheDocument();
 
+      await advancePastWindow(11_000);
       await vi.waitFor(
         () => {
           expect(page.getByTestId('app-page-fallback').query()).not.toBeNull();
         },
-        { timeout: 13_000, interval: 250 }
+        { timeout: 5_000, interval: 100 }
       );
       await expect
         .element(page.getByText("This app didn't load in time"))
@@ -512,16 +549,18 @@ describe('PageBlockHost terminal error surface (Task: readable error + Retry)', 
     'no_token terminal state: readable auth message + Retry, not the loader',
     async () => {
       // token=null, no error → token-wait timeout (15s) → 'no_token' → token_error copy.
+      useFakeClock();
       renderWithProviders(
         <PageBlockHost {...baseProps} token={null} tokenError={false} onConsentGranted={vi.fn()} />
       );
       await expect.element(page.getByTestId('app-page-loading')).toBeInTheDocument();
 
+      await advancePastWindow(16_000);
       await vi.waitFor(
         () => {
           expect(page.getByTestId('app-page-fallback').query()).not.toBeNull();
         },
-        { timeout: 18_000, interval: 250 }
+        { timeout: 5_000, interval: 100 }
       );
       await expect
         .element(page.getByText("Couldn't authenticate this app"))
@@ -652,6 +691,7 @@ describe('PageBlockHost Retry re-mints the token on AUTH failures (the HIGH)', (
     async () => {
       const onRetryToken = vi.fn();
       // token=null, no error → token-wait timeout (15s) → `no_token` terminal.
+      useFakeClock();
       renderWithProviders(
         <PageBlockHost
           {...baseProps}
@@ -661,11 +701,15 @@ describe('PageBlockHost Retry re-mints the token on AUTH failures (the HIGH)', (
           onRetryToken={onRetryToken}
         />
       );
+      // The loader is the precondition — and it also guarantees the render has committed
+      // (so the product's token-wait timer is on the fake clock) before we advance it.
+      await expect.element(page.getByTestId('app-page-loading')).toBeInTheDocument();
+      await advancePastWindow(16_000);
       await vi.waitFor(
         () => {
           expect(page.getByTestId('app-page-fallback').query()).not.toBeNull();
         },
-        { timeout: 18_000, interval: 250 }
+        { timeout: 5_000, interval: 100 }
       );
       expect(onRetryToken).not.toHaveBeenCalled();
 
@@ -705,14 +749,19 @@ describe('PageBlockHost Retry re-mints the token on AUTH failures (the HIGH)', (
     async () => {
       const onRetryToken = vi.fn();
       // token present, never ack BLOCK_READY → readiness timeout (10s) → `timeout`.
+      useFakeClock();
       renderWithProviders(
         <PageBlockHost {...baseProps} onConsentGranted={vi.fn()} onRetryToken={onRetryToken} />
       );
+      // The loader is the precondition — and it also guarantees the render has committed
+      // (so the product's readiness timer is on the fake clock) before we advance it.
+      await expect.element(page.getByTestId('app-page-loading')).toBeInTheDocument();
+      await advancePastWindow(11_000);
       await vi.waitFor(
         () => {
           expect(page.getByTestId('app-page-fallback').query()).not.toBeNull();
         },
-        { timeout: 13_000, interval: 250 }
+        { timeout: 5_000, interval: 100 }
       );
 
       await page.getByRole('button', { name: 'Retry' }).click();

--- a/src/components/Apps/AppEditPage.browser.test.tsx
+++ b/src/components/Apps/AppEditPage.browser.test.tsx
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { page } from 'vitest/browser';
+import { useRouter } from 'next/router';
 // `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
 import { renderWithProviders } from '../../../test/component-setup';
 
@@ -22,7 +23,6 @@ const mocks = vi.hoisted(() => ({
     isLoading: false,
     error: null as unknown,
   },
-  routerQuery: { appBlockId: 'blk-1', tab: undefined as string | undefined },
 }));
 
 // The page statically imports createServerSideProps — stub it so importing the page
@@ -35,14 +35,12 @@ vi.mock('~/providers/FeatureFlagsProvider', () => ({
   useFeatureFlags: () => ({ appBlocks: true }),
 }));
 
-vi.mock('next/router', () => ({
-  useRouter: () => ({
-    query: mocks.routerQuery,
-    replace: vi.fn(),
-    push: vi.fn(),
-    back: vi.fn(),
-  }),
-}));
+// NOTE: this file used to carry its own `vi.mock('next/router', ...)`. It SILENTLY LOST to
+// the scaffold's mock in `test/component-setup.tsx` (a setup-file mock the per-file one does
+// not override here), so `router.query` was always `{}` — `?tab=media` could never select the
+// media tab. Use the scaffold's SHARED router object and seed `query` per test instead, which
+// is the established idiom (see `src/tests/pages/payment/success.browser.test.tsx`).
+const router = useRouter();
 
 vi.mock('~/utils/trpc', () => ({
   trpc: {
@@ -67,13 +65,19 @@ vi.mock('~/components/Apps/ListingMediaEditor', () => ({
 vi.mock('~/components/AppLayout/NotFound', () => ({
   NotFound: () => <div data-testid="mock-notfound">not found</div>,
 }));
+// The page renders `<Meta>`, which calls `useBrowserRouter()` — that hook THROWS
+// ("missing context") without a BrowserRouterProvider, which `renderWithProviders`
+// deliberately doesn't mount. Unmocked it takes the whole page render down (empty
+// <body>), so every assertion here fails by burning its 5s timeout. Same stub the
+// review-queue-nav page test uses.
+vi.mock('~/components/Meta/Meta', () => ({ Meta: () => null }));
 
 const AppEditPage = (await import('../../pages/apps/[appBlockId]/edit')).default;
 
 beforeEach(() => {
   mocks.manifestQuery.error = null;
   mocks.manifestQuery.isLoading = false;
-  mocks.routerQuery = { appBlockId: 'blk-1', tab: undefined };
+  router.query = { appBlockId: 'blk-1' };
 });
 
 describe('AppEditPage (/apps/[appBlockId]/edit)', () => {
@@ -88,7 +92,7 @@ describe('AppEditPage (/apps/[appBlockId]/edit)', () => {
   });
 
   test('?tab=media selects the media tab (renders the media editor)', async () => {
-    mocks.routerQuery = { appBlockId: 'blk-1', tab: 'media' };
+    router.query = { appBlockId: 'blk-1', tab: 'media' };
     renderWithProviders(<AppEditPage />);
     await expect.element(page.getByTestId('mock-media-editor')).toBeInTheDocument();
     await expect.element(page.getByText(/media editor for blk-1/i)).toBeInTheDocument();

--- a/src/components/Apps/CombinedReviewModal.browser.test.tsx
+++ b/src/components/Apps/CombinedReviewModal.browser.test.tsx
@@ -148,7 +148,14 @@ vi.mock('~/utils/notifications', () => ({
   showErrorNotification: vi.fn(),
 }));
 
-vi.mock('~/utils/trpc', () => {
+// Only the `trpc` client itself is overridden — the rest of `~/utils/trpc`'s real exports
+// (setTrpcBatchingEnabled, trpcVanilla, queryClient, ...) are kept via importOriginal so any
+// transitively-imported consumer elsewhere in the tree (e.g. session/provider chains) still
+// gets a real binding instead of the whack-a-mole of hand-naming every export they touch.
+// Without the spread, a LATER PR adding an export to `~/utils/trpc` breaks this file's ESM
+// link ("does not provide an export named X") and the whole file collects 0 tests.
+vi.mock('~/utils/trpc', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('~/utils/trpc')>();
   const mutation =
     (name: string) =>
     (opts?: { onSuccess?: () => void; onError?: (e: { message: string }) => void }) => ({
@@ -179,6 +186,7 @@ vi.mock('~/utils/trpc', () => {
     },
   };
   return {
+    ...actual,
     trpc: {
       useUtils: () => utils,
       blocks: {
@@ -231,9 +239,13 @@ describe('CombinedReviewModal', () => {
   test('renders BOTH section headers, the code ReportTabs, and the media preview + assets', async () => {
     renderWithProviders(<CombinedReviewModal selection={SELECTION} onClose={vi.fn()} />);
 
-    // Both stacked section headers.
+    // Both stacked section headers. `getByText` is SUBSTRING-matching by default, and
+    // #3412 added the `apps-offsite-onsite-note` prose ("Listing media update — ...")
+    // which also contains "Listing media" — two matches, and a strict query throws.
+    // `exact: true` pins the HEADER itself (the thing this assertion is about) rather
+    // than loosening to `.first()`, which the note alone would satisfy.
     await expect.element(page.getByText('App code review')).toBeInTheDocument();
-    await expect.element(page.getByText('Listing media')).toBeInTheDocument();
+    await expect.element(page.getByText('Listing media', { exact: true })).toBeInTheDocument();
 
     // Code section: the agent ReportTabs (its tabs) render.
     await expect.element(page.getByRole('tab', { name: /Scopes/ })).toBeInTheDocument();

--- a/src/components/Apps/ConnectScopesPanel.browser.test.tsx
+++ b/src/components/Apps/ConnectScopesPanel.browser.test.tsx
@@ -25,9 +25,17 @@ vi.mock('~/utils/notifications', () => ({
   showSuccessNotification: vi.fn(),
   showErrorNotification: vi.fn(),
 }));
-vi.mock('~/utils/trpc', () => {
+// Only the `trpc` client itself is overridden — the rest of `~/utils/trpc`'s real exports
+// (setTrpcBatchingEnabled, trpcVanilla, queryClient, ...) are kept via importOriginal so any
+// transitively-imported consumer elsewhere in the tree (e.g. session/provider chains) still
+// gets a real binding instead of the whack-a-mole of hand-naming every export they touch.
+// Without the spread, a LATER PR adding an export to `~/utils/trpc` breaks this file's ESM
+// link ("does not provide an export named X") and the whole file collects 0 tests.
+vi.mock('~/utils/trpc', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('~/utils/trpc')>();
   const mutation = () => ({ mutate: vi.fn(), mutateAsync: vi.fn(), isPending: false });
   return {
+    ...actual,
     trpc: {
       useUtils: () => ({
         appListings: {

--- a/src/components/Apps/ExternalSubmitForm.browser.test.tsx
+++ b/src/components/Apps/ExternalSubmitForm.browser.test.tsx
@@ -420,7 +420,14 @@ describe('ExternalSubmitForm — OAuth step: mod global-search + create deeplink
     mocks.currentUser = { id: 1, username: 'mod', isModerator: true };
     renderWithProviders(<ExternalSubmitForm />);
     await advanceFromUrl();
-    const link = page.getByTestId('apps-offsite-create-client-link');
+    // ExternalSubmitForm renders `createClientLink` in TWO places by design — persistently
+    // below the picker AND as the Select's `nothingFoundMessage`. For a moderator the
+    // global-search Select has no results, so the nothingFound copy is mounted too and a
+    // bare testid query matches 2 elements (strict-mode violation). Scope to the persistent
+    // in-form one — the affordance this test is about — not the dropdown's copy.
+    const link = page
+      .getByTestId('apps-offsite-submit-form')
+      .getByTestId('apps-offsite-create-client-link');
     await expect.element(link).toBeInTheDocument();
     await expect.element(link).toHaveAttribute('href', '/user/account');
     await expect.element(link).toHaveAttribute('target', '_blank');
@@ -474,6 +481,11 @@ describe('ExternalSubmitForm — auto-trigger, status, re-pull, data-URI icon', 
     await expect
       .element(page.getByTestId('apps-offsite-submit-autofill-applied'))
       .toBeInTheDocument();
+    // The OAuth picker lives on the SECOND (App) step — advance before `pickClient()`,
+    // which otherwise waits out its timeout on a control that is not mounted yet. (The
+    // fill+blur above is deliberately inlined rather than using `fillUrlAndAdvance` so the
+    // assertion above proves the pull fired on BLUR, with no button click.)
+    await page.getByTestId('apps-offsite-wizard-next-url').click();
     await pickClient();
     await page.getByTestId('apps-offsite-wizard-next-app').click();
     await expect

--- a/src/components/Apps/ExternalSubmitForm.reducedMotion.browser.test.tsx
+++ b/src/components/Apps/ExternalSubmitForm.reducedMotion.browser.test.tsx
@@ -36,14 +36,30 @@ vi.mock('~/utils/trpc', () => {
         fetchListingMetaFromUrl: { useQuery: () => mocks.meta },
         persistAssetImage: { useMutation: mutation },
         ingestAssetFromUrl: { useMutation: mutation },
+        ingestAssetFromDataUri: { useMutation: mutation },
         setIcon: { useMutation: mutation },
         setCover: { useMutation: mutation },
         addScreenshot: { useMutation: mutation },
+        removeScreenshot: { useMutation: mutation },
       },
-      oauthClient: { getAll: { useQuery: () => mocks.clients } },
+      oauthClient: {
+        getAll: { useQuery: () => mocks.clients },
+        // The OAuth picker is role-aware and calls BOTH hooks unconditionally (rules of
+        // hooks) — the moderator global-search one too, even for a non-mod caller. Omitted
+        // from a wholesale trpc mock it reads `undefined.useQuery` and throws during
+        // render, so nothing mounts. Mirrors ExternalSubmitForm.browser.test.tsx.
+        searchForModerator: { useQuery: () => ({ data: { items: [] }, isFetching: false }) },
+      },
     },
   };
 });
+
+// `ExternalSubmitForm` reads `useCurrentUser` to pick which OAuth-client picker to render,
+// and that hook THROWS ("missing CivitaiSessionContext") because the harness mounts no
+// session context. Unmocked it takes the whole render down (empty <body>) and every
+// assertion below fails by burning its timeout. `null` = the non-moderator path, which is
+// the own-clients `apps-offsite-client-select` dropdown this test drives.
+vi.mock('~/hooks/useCurrentUser', () => ({ useCurrentUser: () => null }));
 
 vi.mock('~/hooks/useCFImageUpload', () => ({
   useCFImageUpload: () => ({ uploadToCF: vi.fn(), files: [], resetFiles: vi.fn(), removeImage: vi.fn() }),

--- a/src/components/Apps/ListingAssetStep.browser.test.tsx
+++ b/src/components/Apps/ListingAssetStep.browser.test.tsx
@@ -37,6 +37,8 @@ const mocks = vi.hoisted(() => ({
   setCoverAsync: vi.fn(),
   addScreenshotAsync: vi.fn(),
   removeAsync: vi.fn(),
+  // `ListingAssetStep` rasterises a data-URI (e.g. SVG) icon through this procedure.
+  ingestDataUriAsync: vi.fn(),
   persistAsync: vi.fn(),
   uploadToCF: vi.fn(),
   // Item 1: the per-asset scan-status poll (utils.appListings.getAssetScanStatuses.fetch).
@@ -57,6 +59,18 @@ vi.mock('~/utils/trpc', () => {
         },
         ingestAssetFromUrl: {
           useMutation: () => ({ mutate: vi.fn(), mutateAsync: mocks.ingestAsync, isPending: false }),
+        },
+        // `ListingAssetStep` calls `trpc.appListings.ingestAssetFromDataUri.useMutation()`
+        // unconditionally at the top of the component. A wholesale `vi.mock` of
+        // `~/utils/trpc` that omits it makes that read `undefined.useMutation` — an
+        // unhandled THROW during render, so nothing mounts and all 13 tests fail by
+        // burning their 5s timeout (~178s of wall clock).
+        ingestAssetFromDataUri: {
+          useMutation: () => ({
+            mutate: vi.fn(),
+            mutateAsync: mocks.ingestDataUriAsync,
+            isPending: false,
+          }),
         },
         setIcon: {
           useMutation: () => ({ mutate: vi.fn(), mutateAsync: mocks.setIconAsync, isPending: false }),

--- a/src/components/Apps/OffsiteReportsQueue.browser.test.tsx
+++ b/src/components/Apps/OffsiteReportsQueue.browser.test.tsx
@@ -39,7 +39,14 @@ vi.mock('~/utils/notifications', () => ({
   showErrorNotification: vi.fn(),
 }));
 
-vi.mock('~/utils/trpc', () => {
+// Only the `trpc` client itself is overridden — the rest of `~/utils/trpc`'s real exports
+// (setTrpcBatchingEnabled, trpcVanilla, queryClient, ...) are kept via importOriginal so any
+// transitively-imported consumer elsewhere in the tree (e.g. session/provider chains) still
+// gets a real binding instead of the whack-a-mole of hand-naming every export they touch.
+// Without the spread, a LATER PR adding an export to `~/utils/trpc` breaks this file's ESM
+// link ("does not provide an export named X") and the whole file collects 0 tests.
+vi.mock('~/utils/trpc', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('~/utils/trpc')>();
   const mutation =
     (name: string) =>
     (opts?: { onSuccess?: () => void; onError?: (e: { message: string }) => void }) => ({
@@ -52,6 +59,7 @@ vi.mock('~/utils/trpc', () => {
       isPending: false,
     });
   return {
+    ...actual,
     trpc: {
       useUtils: () => ({
         appListings: { listListingReports: { invalidate: mocks.invalidate } },

--- a/src/components/Apps/OffsiteReviewQueue.browser.test.tsx
+++ b/src/components/Apps/OffsiteReviewQueue.browser.test.tsx
@@ -61,9 +61,16 @@ vi.mock('~/utils/notifications', () => ({
   showErrorNotification: vi.fn(),
 }));
 
-vi.mock('~/utils/trpc', () => {
-  const mutation = () => ({ mutate: vi.fn(), mutateAsync: vi.fn(), isPending: false });
+// Only the `trpc` client itself is overridden — the rest of `~/utils/trpc`'s real exports
+// (setTrpcBatchingEnabled, trpcVanilla, queryClient, ...) are kept via importOriginal so any
+// transitively-imported consumer elsewhere in the tree (e.g. session/provider chains) still
+// gets a real binding instead of the whack-a-mole of hand-naming every export they touch.
+// Without the spread, a LATER PR adding an export to `~/utils/trpc` breaks this file's ESM
+// link ("does not provide an export named X") and the whole file collects 0 tests.
+vi.mock('~/utils/trpc', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('~/utils/trpc')>();
   return {
+    ...actual,
     trpc: {
       useUtils: () => ({
         appListings: {
@@ -324,7 +331,14 @@ describe('OffsiteReviewModal — approve-notes gating, friendly date, field labe
     await expect.element(page.getByText('Content rating', { exact: true })).toBeInTheDocument();
     // The badge values they label are still rendered.
     await expect.element(page.getByText('utility', { exact: true })).toBeInTheDocument();
-    await expect.element(page.getByText('g', { exact: true })).toBeInTheDocument();
+    // #3412 added the listing-preview detail pane (`apps-listing-preview-detail`), which
+    // renders its OWN content-rating badge — so a bare exact 'g' now matches 2 elements and
+    // the strict query throws. Scope to the Content-rating FIELD GROUP this test is about,
+    // asserting its full text (label + badge value + qualifier). That still fails if the
+    // badge value is wrong or missing, rather than being satisfied by the preview's copy.
+    const ratingLabel = page.getByText('Content rating', { exact: true });
+    await expect.element(ratingLabel).toBeInTheDocument();
+    expect(ratingLabel.element().parentElement?.textContent).toBe('Content ratinggdeclared');
   });
 });
 

--- a/src/components/Apps/ReportTabs.browser.test.tsx
+++ b/src/components/Apps/ReportTabs.browser.test.tsx
@@ -78,6 +78,9 @@ describe('ReportTabs — tab IA (Item 1/2: drop Summary, reorder, default Scopes
   test('renders exactly three tabs in order Scopes → Security → Code review, no Summary', async () => {
     renderWithProviders(<ReportTabs report={REPORT} costCapped={false} />);
 
+    // Browser-mode render is ASYNC-committed, so the sync `.elements()` read below races
+    // the mount and sees an empty DOM unless we anchor on an awaited element first.
+    await expect.element(page.getByRole('tab', { name: /Scopes/ })).toBeInTheDocument();
     const tabs = page.getByRole('tab').elements();
     expect(tabs).toHaveLength(3);
     const labels = tabs.map((t) => t.textContent ?? '');

--- a/src/tests/pages/apps/review/review-queue-nav.browser.test.tsx
+++ b/src/tests/pages/apps/review/review-queue-nav.browser.test.tsx
@@ -53,9 +53,14 @@ vi.mock('~/components/Apps/AppListingsModerationTable', () => ({
 vi.mock('~/components/Apps/ActivePreviewsPanel', () => ({ ActivePreviewsPanel: () => null }));
 // The off-site review modal is now PAGE-OWNED (rendered by the page) — stub it + the
 // reports queue so this test isolates the on-site pending queue's selection path.
+// NOTE: this is a WHOLESALE module mock, so it must re-stub EVERY export of
+// `OffsiteReviewQueue.tsx` that anything in the page's graph statically imports —
+// `CombinedReviewModal` imports `OffsiteReviewModalBody` from here. Miss one and the
+// file's ESM link fails ("does not provide an export named ...") and it collects 0 tests.
 vi.mock('~/components/Apps/OffsiteReviewQueue', () => ({
   OffsiteReportsQueue: () => null,
   OffsiteReviewModal: () => null,
+  OffsiteReviewModalBody: () => null,
 }));
 vi.mock('~/components/Meta/Meta', () => ({ Meta: () => null }));
 


### PR DESCRIPTION
These are **pre-existing failures on `main`**, not regressions from any open PR. Every change is **test-side only** — no product source is modified.

The `component` project sets no `testTimeout`, so it inherits the 5s default. A large share of the suite's clock was these failures idling on that timeout, and five whole files were failing to *import* — collecting 0 tests, which reads as "green" because `component-tests` is report-only.

`src/tests/pages/apps/listing-media-page.browser.test.tsx` and `src/pages/apps/[appBlockId]/listing.tsx` are **deliberately excluded — #3476 owns those.**

## Measured before / after

Each file run in isolation (`vitest run --project component <file>`), real Chromium.

### Group A — whole-file import failures (collected 0 tests)

| File | Before | After |
|---|---|---|
| `Apps/OffsiteReviewQueue.browser.test.tsx` | **0 collected**, 2.00s | 21 passed, 4.89s |
| `Apps/CombinedReviewModal.browser.test.tsx` | **0 collected**, 2.29s | 3 passed, 2.09s |
| `Apps/ConnectScopesPanel.browser.test.tsx` | **0 collected**, 2.02s | 6 passed, 2.71s |
| `Apps/OffsiteReportsQueue.browser.test.tsx` | **0 collected**, 2.03s | 4 passed, 2.93s |
| `tests/pages/apps/review/review-queue-nav.browser.test.tsx` | **0 collected**, 2.23s | 2 passed, 2.36s |

Four of these wholesale-`vi.mock('~/utils/trpc')` and omitted `trpcVanilla` (`src/utils/trpc.ts:371`), so the file's ESM link failed:

```
SyntaxError: The requested module '/src/utils/trpc.ts' does not provide an export named 'trpcVanilla'
```

Fixed with the canonical in-repo `importOriginal`-spread partial mock (matching `Challenge/__tests__/ChallengeUpsertForm.browser.test.tsx:27`, which carries a comment naming this exact trap) so the next added export can't break them again. The fifth wholesale-mocks `OffsiteReviewQueue` and was missing `OffsiteReviewModalBody`, which `CombinedReviewModal` imports.

Two **stale assertions** surfaced underneath, both because the same text is now rendered twice and a strict single-match query throws. Both were scoped, not loosened:

- `CombinedReviewModal` — `getByText` is substring-matching, and the `apps-offsite-onsite-note` prose also contains "Listing media". Pinned with `exact: true` (the header), not `.first()` (which the note alone would satisfy).
- `OffsiteReviewQueue` — the listing-preview detail pane renders its own content-rating badge, so a bare exact `'g'` matched twice. Scoped to the Content-rating field group and asserted on its full text.

### Group B — tests failing by burning their 5s timeout

| File | Before | After |
|---|---|---|
| `Apps/ListingAssetStep.browser.test.tsx` | 13 failed, **176.48s** | 13 passed, **4.35s** |
| `Apps/ExternalSubmitForm.browser.test.tsx` | 2 failed / 25 passed, 36.18s | 27 passed, 6.50s |
| `Apps/AppEditPage.browser.test.tsx` | 2 failed / 1 passed, 31.46s | 3 passed, 1.82s |
| `Apps/ExternalSubmitForm.reducedMotion.browser.test.tsx` | 1 failed, 16.31s | 1 passed, 1.64s |
| `Apps/ReportTabs.browser.test.tsx` | 1 failed / 9 passed, 1.62s | 10 passed, 1.54s |

Causes, each read off the observed failure output:

- **ListingAssetStep** — the trpc mock omitted `ingestAssetFromDataUri`, which `ListingAssetStep.tsx:177` calls unconditionally → `Uncaught TypeError: Cannot read properties of undefined (reading 'useMutation')` during render. Nothing mounted, so all 13 tests waited out their timeout.
- **ExternalSubmitForm** — (a) `createClientLink` is rendered **twice by design** (persistently below the picker *and* as the Select's `nothingFoundMessage`); for a moderator the global-search Select has no results so both are mounted → strict-mode violation. Scoped to the in-form one. (b) One test called `pickClient()` without first advancing to the App step, so it waited on a control that was never mounted.
- **AppEditPage** — two independent causes. (a) The page renders `<Meta>` → `useBrowserRouter()`, which **throws** `missing context` without a `BrowserRouterProvider` (the harness mounts none), taking the whole render down. (b) The file carried its own `vi.mock('next/router', ...)` which **silently lost** to the scaffold's mock in `test/component-setup.tsx`, so `router.query` was always `{}` and `?tab=media` could never select the media tab. Switched to the established idiom of seeding the scaffold's shared router (see `src/tests/pages/payment/success.browser.test.tsx`). This file has never passed — it and the page landed together in #3393.
- **ExternalSubmitForm.reducedMotion** — `useCurrentUser` unmocked → **throws** `missing CivitaiSessionContext`. Fixing that exposed a second throw underneath: the role-aware picker calls `oauthClient.searchForModerator.useQuery` unconditionally (rules of hooks) and the mock omitted it.
- **ReportTabs** — a sync `page.getByRole('tab').elements()` read racing the async-committed browser-mode render (`expected [] to have a length of 3`). Anchored on an awaited element first.

### Group C — PageBlockHost real-timer sleep

| File | Before | After |
|---|---|---|
| `AppBlocks/PageBlockHost.browser.test.tsx` | 25 passed, **81.14s** | 25 passed, **6.09s** |

This file already passed. Six tests slept through the product's real `BLOCK_READY_TIMEOUT_MS` (10s) and `TOKEN_WAIT_TIMEOUT_MS` (15s) windows — ~76s, 95% of the file. They now install Vitest's fake clock **before** the render (installing it after does nothing — the timer is already on the real clock), jump the window, then hand straight back to real timers, so no assertion, `vi.waitFor` or `userEvent` click ever runs on a faked clock. An `afterEach(() => vi.useRealTimers())` prevents leakage on a mid-test failure. Ran 4× consecutively, stable.

## Totals

**353.8s → 36.9s across the 11 files — ~5.3 min recovered** (~4.0 min of it from Groups A+B alone).
**60 → 115 passing tests: +55 restored, 36 of which were not being collected at all.**

## Verification

Run locally against real Chromium via the Playwright provider. All 10 Group A+B files together: **10 files / 90 tests passed, 10.2s**. `PageBlockHost`: 25 passed, 4 consecutive runs.

Mutation-checked (each broken, confirmed failing, reverted):

- Removed the `...actual` spread from `ConnectScopesPanel` → back to **0 collected** with the exact `trpcVanilla` error.
- Removed the `OffsiteReviewModalBody` stub from `review-queue-nav` → back to **0 collected** with the exact missing-export error.
- Changed the `OffsiteReviewQueue` fixture's declared rating `'g' → 'pg'` → the rewritten assertion fails (`expected 'Content ratingpgdeclared' to be 'Content ratinggdeclared'`), so it is not tautological.
- Renamed `CombinedReviewModal`'s product header `"Listing media" → "Listing MEDIA"` → the `exact: true` query fails, confirming it is not satisfied by the note that shares the substring.
- Widened both `PageBlockHost` product windows to 60s → **exactly the six converted tests fail and no others**, so they still pin the real windows.

Every Group B fix is also mutation-proven by construction: the pre-fix run *is* the failing state, observed in this same worktree.

No test was weakened, skipped or deleted. `tsc --noEmit` reports 0 errors in any `.browser.test.tsx` file (all 100 are in the program); the tree-wide errors in this sandbox are a local `prisma generate` artifact and are present on `main` too.

## Follow-up (not in this PR)

Several other browser tests still wholesale-`vi.mock('~/utils/trpc')` without the `importOriginal` spread (e.g. `ExternalSubmitForm.browser.test.tsx`, `ExternalSubmitForm.reducedMotion.browser.test.tsx`, `AppEditPage.browser.test.tsx`). They pass today but carry the same latent break — the next trpc export added will silently zero them out. A lint rule requiring the spread on any wholesale `~/utils/trpc` mock would close the class deterministically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
