### PR TITLE
fix(models): keep the download card on unpublished models

### DIFF
--- a/src/components/Model/ModelVersions/ModelVersionDetails.tsx
+++ b/src/components/Model/ModelVersions/ModelVersionDetails.tsx
@@ -94,6 +94,7 @@ import {
   useModelVersionPermission,
   useQueryModelVersionsEngagement,
 } from '~/components/Model/ModelVersions/model-version.utils';
+import { getModelVersionActionLayout } from '~/components/Model/ModelVersions/model-version-layout';
 import ModelVersionDonationGoal from '~/components/Model/ModelVersions/ModelVersionDonationGoal';
 import { ModelVersionEarlyAccessPurchase } from '~/components/Model/ModelVersions/ModelVersionEarlyAccessPurchase';
 import { NextLink as Link } from '~/components/NextLink/NextLink';
@@ -506,6 +507,58 @@ function ModelVersionDetailsContent({ model, version, image, onFavoriteClick }: 
       !model.allowDerivatives ||
       model.allowDifferentLicense);
 
+  const { branch, showDownloadSection } = getModelVersionActionLayout({
+    showRequestReview,
+    showPublishButton: !!showPublishButton,
+    hideDownload,
+    isComponentOnlyModel,
+    hasVisibleFiles,
+  });
+
+  const downloadSection = showDownloadSection ? (
+      <Card withBorder>
+        <Card.Section withBorder inheritPadding py="xs" px="sm">
+          <Group justify="space-between">
+            <Text size="sm" fw={600}>
+              Download
+            </Text>
+            <Group gap="xs">
+              {isOwnerOrMod && (
+                <RoutedDialogLink name="filesEdit" state={{ modelVersionId: version.id }}>
+                  <Text c="blue.4" size="xs">
+                    Manage
+                  </Text>
+                </RoutedDialogLink>
+              )}
+              <Text size="xs" c="dimmed">
+                {modelFilesVisible.length} variant
+                {modelFilesVisible.length !== 1 ? 's' : ''} available
+              </Text>
+            </Group>
+          </Group>
+        </Card.Section>
+        <Card.Section>
+          <DownloadVariantDropdown
+            files={filesVisible}
+            versionId={version.id}
+            modelType={model.type}
+            userPreferences={user?.filePreferences}
+            selectedFileId={selectedFileId}
+            onSelectFileId={setSelectedFileId}
+            canDownload={canDownload}
+            downloadPrice={
+              !hasDownloadPermissions && !isLoadingAccess && paidAccessTerms?.download
+                ? paidAccessTerms.download.price
+                : undefined
+            }
+            isLoadingAccess={isLoadingAccess}
+            archived={archived}
+            onPurchase={() => onPurchase('download')}
+          />
+        </Card.Section>
+      </Card>
+    ) : null;
+
   return (
     <ContainerGrid2 gutter={{ base: 'xl', sm: 'sm', md: 'xl' }}>
       <TrackView entityId={version.id} entityType="ModelVersion" type="ModelVersionView" />
@@ -549,7 +602,7 @@ function ModelVersionDetailsContent({ model, version, image, onFavoriteClick }: 
               theme: colorScheme === 'dark' ? 'dark' : 'light',
             }}
           />
-          {showRequestReview ? (
+          {branch === 'request-review' ? (
             <Button
               color="yellow"
               onClick={handleRequestReviewClick}
@@ -559,7 +612,7 @@ function ModelVersionDetailsContent({ model, version, image, onFavoriteClick }: 
             >
               Request a Review
             </Button>
-          ) : showPublishButton ? (
+          ) : branch === 'publish-pending' ? (
             <Stack gap={4}>
               {canGenerate && isOwnerOrMod && (
                 <GenerateButton
@@ -630,6 +683,7 @@ function ModelVersionDetailsContent({ model, version, image, onFavoriteClick }: 
                   </Group>
                 </Stack>
               )}
+              {downloadSection}
             </Stack>
           ) : (
             <Stack gap="md">
@@ -896,49 +950,7 @@ function ModelVersionDetailsContent({ model, version, image, onFavoriteClick }: 
                 </AlertWithIcon>
               )}
               {/* Download Section */}
-              {!hideDownload && !isComponentOnlyModel && hasVisibleFiles && (
-                <Card withBorder>
-                  <Card.Section withBorder inheritPadding py="xs" px="sm">
-                    <Group justify="space-between">
-                      <Text size="sm" fw={600}>
-                        Download
-                      </Text>
-                      <Group gap="xs">
-                        {isOwnerOrMod && (
-                          <RoutedDialogLink name="filesEdit" state={{ modelVersionId: version.id }}>
-                            <Text c="blue.4" size="xs">
-                              Manage
-                            </Text>
-                          </RoutedDialogLink>
-                        )}
-                        <Text size="xs" c="dimmed">
-                          {modelFilesVisible.length} variant
-                          {modelFilesVisible.length !== 1 ? 's' : ''} available
-                        </Text>
-                      </Group>
-                    </Group>
-                  </Card.Section>
-                  <Card.Section>
-                    <DownloadVariantDropdown
-                      files={filesVisible}
-                      versionId={version.id}
-                      modelType={model.type}
-                      userPreferences={user?.filePreferences}
-                      selectedFileId={selectedFileId}
-                      onSelectFileId={setSelectedFileId}
-                      canDownload={canDownload}
-                      downloadPrice={
-                        !hasDownloadPermissions && !isLoadingAccess && paidAccessTerms?.download
-                          ? paidAccessTerms.download.price
-                          : undefined
-                      }
-                      isLoadingAccess={isLoadingAccess}
-                      archived={archived}
-                      onPurchase={() => onPurchase('download')}
-                    />
-                  </Card.Section>
-                </Card>
-              )}
+              {downloadSection}
             </Stack>
           )}
           {/* Download-related alert */}

--- a/src/components/Model/ModelVersions/model-version-layout.test.ts
+++ b/src/components/Model/ModelVersions/model-version-layout.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest';
+import { getModelVersionActionLayout } from './model-version-layout';
+
+// A downloadable version with visible files — the inputs that decide the branch are varied per test.
+const downloadable = {
+  showRequestReview: false,
+  showPublishButton: false,
+  hideDownload: false,
+  isComponentOnlyModel: false,
+  hasVisibleFiles: true,
+};
+
+describe('getModelVersionActionLayout', () => {
+  describe('branch selection', () => {
+    it('prefers request-review over publish-pending when both apply', () => {
+      const { branch } = getModelVersionActionLayout({
+        ...downloadable,
+        showRequestReview: true,
+        showPublishButton: true,
+      });
+
+      expect(branch).toBe('request-review');
+    });
+
+    it('routes an owner-or-moderator on an unpublished version to publish-pending', () => {
+      const { branch } = getModelVersionActionLayout({ ...downloadable, showPublishButton: true });
+
+      expect(branch).toBe('publish-pending');
+    });
+
+    it('falls back to default when neither publish nor review applies', () => {
+      const { branch } = getModelVersionActionLayout(downloadable);
+
+      expect(branch).toBe('default');
+    });
+  });
+
+  describe('download availability', () => {
+    // The regression this module exists for: the download card used to live inside the `default`
+    // branch's JSX, so routing to publish-pending (owner or moderator, unpublished, has files +
+    // posts) removed every download control — including for a moderator reviewing a takedown, who
+    // the server already answers with a signed URL.
+    it('keeps the download section in the publish-pending branch', () => {
+      const { branch, showDownloadSection } = getModelVersionActionLayout({
+        ...downloadable,
+        showPublishButton: true,
+      });
+
+      expect(branch).toBe('publish-pending');
+      expect(showDownloadSection).toBe(true);
+    });
+
+    it('keeps the download section in the default branch', () => {
+      expect(getModelVersionActionLayout(downloadable).showDownloadSection).toBe(true);
+    });
+
+    it('drops the download section in the request-review branch', () => {
+      const { showDownloadSection } = getModelVersionActionLayout({
+        ...downloadable,
+        showRequestReview: true,
+      });
+
+      expect(showDownloadSection).toBe(false);
+    });
+
+    it.each([
+      ['downloads are disabled for the version', { hideDownload: true }],
+      ['the model is component-only', { isComponentOnlyModel: true }],
+      ['there are no visible files', { hasVisibleFiles: false }],
+    ])('hides the download section when %s, even while publish-pending', (_label, overrides) => {
+      const { showDownloadSection } = getModelVersionActionLayout({
+        ...downloadable,
+        showPublishButton: true,
+        ...overrides,
+      });
+
+      expect(showDownloadSection).toBe(false);
+    });
+  });
+});

--- a/src/components/Model/ModelVersions/model-version-layout.ts
+++ b/src/components/Model/ModelVersions/model-version-layout.ts
@@ -1,0 +1,40 @@
+export type ModelVersionActionBranch = 'request-review' | 'publish-pending' | 'default';
+
+export type ModelVersionActionLayout = {
+  branch: ModelVersionActionBranch;
+  showDownloadSection: boolean;
+};
+
+/**
+ * The action column renders exactly one of three branches. Download availability is deliberately
+ * NOT derived from that branch: it used to live inside the `default` branch's JSX, so an
+ * owner-or-moderator reviewing an unpublished model — routed to `publish-pending` — silently lost
+ * every download control on the models they most need the file for.
+ */
+export function getModelVersionActionLayout({
+  showRequestReview,
+  showPublishButton,
+  hideDownload,
+  isComponentOnlyModel,
+  hasVisibleFiles,
+}: {
+  showRequestReview: boolean;
+  showPublishButton: boolean;
+  hideDownload: boolean;
+  isComponentOnlyModel: boolean;
+  hasVisibleFiles: boolean;
+}): ModelVersionActionLayout {
+  const branch: ModelVersionActionBranch = showRequestReview
+    ? 'request-review'
+    : showPublishButton
+    ? 'publish-pending'
+    : 'default';
+
+  return {
+    branch,
+    // `request-review` is the one branch that stays a lone button: it is shown only to a non-moderator
+    // owner of TOS-violating content, where the actionable next step is the appeal, not the file.
+    showDownloadSection:
+      branch !== 'request-review' && !hideDownload && !isComponentOnlyModel && hasVisibleFiles,
+  };
+}

--- a/src/server/services/__tests__/file-download-lookup.test.ts
+++ b/src/server/services/__tests__/file-download-lookup.test.ts
@@ -125,6 +125,16 @@ function publishedModelVersion(overrides: Record<string, unknown> = {}) {
   };
 }
 
+function unpublishedModelVersion(overrides: Record<string, unknown> = {}) {
+  const base = publishedModelVersion();
+  return {
+    ...base,
+    status: 'Unpublished',
+    model: { ...base.model, status: 'Unpublished', publishedAt: null },
+    ...overrides,
+  };
+}
+
 const aFile = {
   id: 55,
   url: 'https://abcd1234.r2.cloudflarestorage.com/civitai/files/x.safetensors',
@@ -263,5 +273,67 @@ describe('getFileForModelVersion — orphan model relation + unresolvable URL', 
 
     expect(result.status).toBe('early-access');
     if (result.status === 'early-access') expect(result.details.deadline).toEqual(endsAt);
+  });
+
+  // --- Unpublished models: the review path ---------------------------------
+  // Moderators review unpublished models constantly (takedowns, TOS checks) and need the actual
+  // file to decide. The publish-state gate must keep answering them — and the owner — with the
+  // file while still hiding it from everyone else.
+  describe('unpublished models', () => {
+    beforeEach(() => {
+      modelVersionFindFirst.mockResolvedValue(unpublishedModelVersion());
+      resolveDownloadUrlMock.mockResolvedValue({
+        url: 'https://cdn.example.com/signed',
+        urlExpiryDate: new Date(),
+      });
+    });
+
+    it('serves the file to a moderator', async () => {
+      const result = await getFileForModelVersion({
+        modelVersionId: 1,
+        user: { id: 7, isModerator: true },
+      });
+
+      expect(result.status).toBe('success');
+    });
+
+    it('serves the file to the owner', async () => {
+      const result = await getFileForModelVersion({
+        modelVersionId: 1,
+        user: { id: 999, isModerator: false },
+      });
+
+      expect(result.status).toBe('success');
+    });
+
+    it('returns not-found for a signed-in user who is neither owner nor moderator', async () => {
+      const result = await getFileForModelVersion({
+        modelVersionId: 1,
+        user: { id: 1234, isModerator: false },
+      });
+
+      expect(result.status).toBe('not-found');
+    });
+
+    it('returns not-found for an anonymous request', async () => {
+      const result = await getFileForModelVersion({ modelVersionId: 1 });
+
+      expect(result.status).toBe('not-found');
+    });
+
+    it('still hides a deleted model from its own owner', async () => {
+      modelVersionFindFirst.mockResolvedValue(
+        unpublishedModelVersion({
+          model: { ...publishedModelVersion().model, status: 'Deleted' },
+        })
+      );
+
+      const result = await getFileForModelVersion({
+        modelVersionId: 1,
+        user: { id: 999, isModerator: false },
+      });
+
+      expect(result.status).toBe('not-found');
+    });
   });
 });


### PR DESCRIPTION
Fixes [CU-868kj33wy](https://app.clickup.com/t/8459928/868kj33wy) — *Mods can't download unpublished models*.

## The bug is in the UI, not in permissions

The action column renders `showRequestReview ? … : showPublishButton ? … : …`, and the publish-pending branch contained only the publish/republish button. Every download control lived in the final branch, so an owner or moderator viewing an unpublished model that has files and posts lost the Download card entirely — the exact state a moderator is in while reviewing a takedown.

The server already permits both roles. `getFileForModelVersion` short-circuits its published-state check on `isMod` and `isOwner`, and `/api/download/models/[id]` answers either with a `307` to the signed URL while an anonymous request gets `404`. Verified against a local dev server before touching anything:

| request | result |
| --- | --- |
| `/api/download/models/3165430` as moderator | `307` → signed `.safetensors` |
| same, anonymous | `404` File not found |

So this was never a publish-gate on the download path — mods simply had no way to reach a URL they were already allowed to fetch.

**This is not a regression from #3456.** That PR only split `unauthorized` into `unauthorized` / `no-access`; the moderator bypass it inherited still works. The ternary predates it — the download controls sat inside the same `else` branch before the April Model UI Overhaul (#1964), and the three-way structure goes back to 2023.

## The fix

Move the branch decision into `getModelVersionActionLayout`, a zero-import leaf module returning the branch **and** `showDownloadSection` independently, so download availability can no longer be an accident of JSX nesting. The card now renders in both the `publish-pending` and `default` branches.

`request-review` deliberately stays a lone button: it is shown only to a non-moderator owner of TOS-violating content, where the actionable next step is the appeal, not the file. Happy to change that if reviewers disagree.

The leaf module is deliberate — `model-version.utils.ts` pulls trpc and signals, and a heavy import graph in a node test risks a module-init failure that vitest reports as a *passing* zero-collection run.

## Test plan

`pnpm vitest run src/components/Model/ModelVersions/model-version-layout.test.ts src/server/services/__tests__/file-download-lookup.test.ts` → **21 passed** (9 + 12; counts reconcile, so no silent zero-collection).

- `model-version-layout.test.ts` (new, 9) — branch precedence, download survives `publish-pending`, suppressed for `hideDownload` / component-only / no visible files. Load-bearing: reverting the rule to the pre-fix `branch === 'default'` fails it at the publish-pending assertion.
- `file-download-lookup.test.ts` (+5) — on an unpublished model, moderator and owner get the file; another signed-in user, an anonymous request, and a deleted model's own owner do not.

`pnpm run typecheck` → exit 0. Prettier clean on all touched files.

## Manual verification

Local dev server, unpublished model 2807245 / version 3165430:

| viewer | before | after |
| --- | --- | --- |
| moderator | no Download card | card + model-file link, `307` signed |
| owner (non-mod) | no Download card | card + model-file link, `307` signed |
| anonymous | no download links | unchanged |
| published model, any viewer | card renders | unchanged |

## Known gaps, deliberately not in this PR

1. Moderators also lose `ModelModerationCard`, vault and report in that branch — same root cause, wider blast radius.
2. Generation-only versions still hide the card from moderators, even though the server bypasses `usageControl` for them.

No migrations. No server-side behavior change — this PR only stops the UI from hiding a download the server already authorizes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)