### PR TITLE
feat(memberships): gift memberships (GREEN/Stripe)

### DIFF
--- a/docs/gift-memberships-plan.md
+++ b/docs/gift-memberships-plan.md
@@ -1,0 +1,191 @@
+# Gift Memberships (GREEN / Stripe) — Implementation Plan
+
+**Status**: Implemented (phases 1–6) — pending review + QA. Migration `20260729200000_membership_gifts` must be applied manually.
+**Branch**: `worktree-gift-memberships`
+
+## Summary
+
+Let a user pre-pay N months of a GREEN (Stripe) membership as a gift for another user.
+
+- Gifter pays **once** via Stripe Checkout (`mode: 'payment'`) — no subscription is created for the gifter.
+- If the recipient **has an active green subscription** → their Stripe subscription gets N months free (they keep auto-renewing afterward at their normal price).
+- If the recipient **has no green subscription** → we create a Stripe subscription for them server-side that costs $0 for N months and auto-cancels at the end (they can attach a payment method to keep it going).
+
+This is deliberately **Stripe-native and independent of the redeemable-code system**. The code/prepaid-token machinery (`redeemableCode.service.ts`, `prepaid-membership-jobs.ts`) is built for `PaymentProvider.Civitai` / yellow-buzz memberships and is incompatible with green subs: `upsertSubscription` (`stripe.service.ts:581`) overwrites `CustomerSubscription.metadata` with Stripe's subscription metadata on every webhook, so any prepaid state stored there would be clobbered. All gift state therefore lives in Stripe (coupons/subscription fields) plus a small audit table on our side.
+
+## Why this design works with existing plumbing
+
+Verified against current code:
+
+- **`invoice.paid` grants monthly Buzz even for $0 invoices** (`stripe.service.ts:813` `manageInvoicePaid`): the Buzz grant only requires an invoice line for a membership product with `billing_reason` in `subscription_create|cycle|update` — it does not check `amount_paid`. A 100%-off coupon still produces a monthly `invoice.paid` at $0, so **monthly Buzz keeps flowing to gifted members with zero new code**.
+- **`customer.subscription.created/updated/deleted` webhooks** (`webhooks/stripe.ts:121`, `upsertSubscription`) already create/update the `CustomerSubscription` row, set vault storage, sync Freshdesk, and invalidate session/multiplier caches. A server-created gift subscription rides this path untouched.
+- **Attribution / referral safety**: App Blocks subscription attribution is already gated on `amount_paid > 0` (`stripe.service.ts:992`), so $0 gift invoices don't accrue publisher shares.
+
+## Mechanism
+
+### The gift coupon
+
+For each fulfillment we create a **single-use Stripe coupon**: `percent_off: 100`, `duration: 'repeating'`, `duration_in_months: N`, `max_redemptions: 1`, metadata `{ giftId }`. (One coupon per gift, not shared — auditable and revocable.)
+
+### Case A — recipient has an active green subscription (monthly interval)
+
+Apply the coupon to their existing subscription (`stripe.subscriptions.update(subId, { discounts: [{ coupon }] })`):
+
+- Their next N monthly invoices are $0; billing dates don't move; after N months Stripe resumes charging automatically. Economically identical to "extended by N months for free".
+- `invoice.paid` keeps firing monthly → Buzz keeps flowing; `customer.subscription.updated` keeps `currentPeriodEnd` in sync.
+- **Canceled-but-active subs** (`cancel_at_period_end: true`, remaining time left): the coupon alone would do nothing — the sub never generates another invoice, so the gift would silently evaporate. But plain un-canceling is wrong too: the user deliberately canceled, and reinstating them means Stripe resumes charging after the gift ends, without their consent. Instead we **defer the cancellation**: in the same `subscriptions.update` call, apply the coupon and replace `cancel_at_period_end: true` with `cancel_at = current_period_end + N months`. Their remaining paid time plays out, the next N renewals invoice at $0 (all fall inside the coupon window since remaining time ≤ 1 billing month), then the sub cancels — they're never billed again unless they explicitly reinstate (`reinstateSubscription` clears `cancel_at`). `upsertSubscription` already syncs `cancel_at` from the `customer.subscription.updated` webhook, so the membership page shows the pushed-out end date for free.
+  - Boundary edge: if the gift lands at the exact instant of a renewal, the Nth free invoice sits right on the coupon window boundary (rare off-by-one risk → N−1 free months). Mitigation: after applying, verify with `invoices.retrieveUpcoming` and log/alert on mismatch rather than over-engineering the window.
+
+### Case B — recipient has no green subscription (none, or canceled/incomplete)
+
+Create the subscription for them, server-side:
+
+```ts
+stripe.subscriptions.create({
+  customer,                             // createCustomer() if they've never had one
+  items: [{ price: monthlyPriceForTier }],
+  discounts: [{ coupon: giftCoupon }],  // 100% off for N months
+  cancel_at: now + N months,            // hard stop — never bills the recipient
+  metadata: { giftId, gift: 'true' },
+});
+```
+
+- Every invoice during the gift window is $0, so **no payment method is required**.
+- The existing webhook path creates the `CustomerSubscription` (buzzType `green` from product metadata), sets vault size, invalidates caches. Monthly Buzz flows via `invoice.paid`.
+- At `cancel_at`, Stripe cancels → `customer.subscription.deleted` webhook cleans up (row deleted, vault reset) exactly like any other cancellation.
+- **Conversion hook**: recipient can "keep my membership" by adding a payment method and removing `cancel_at` (the existing `reinstateSubscription` flow at `stripe.service.ts:1178` is close; small extension to also require a default payment method).
+
+### Edge cases in fulfillment
+
+| Recipient state                                    | Behavior                                                                                                                                                                                                |
+| -------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Active green sub, **same tier** as gifted, monthly | Case A                                                                                                                                                                                                  |
+| Active green sub, **`cancel_at_period_end: true`** | Case A + deferred cancellation: coupon applied and `cancel_at` pushed to `current_period_end + N months` — free months happen, then the sub still ends; no billing resumes without explicit reinstate   |
+| Active green sub, **different tier**               | See open question #1                                                                                                                                                                                    |
+| Active green sub, **annual interval**              | A repeating-months coupon would zero an entire annual invoice (over-gifting). See open question #2                                                                                                      |
+| Green sub `past_due` / `paused` / `incomplete`     | Treat as Case B is unsafe (customer may have a broken sub). v1: apply coupon (Case A) if status is `active` or `trialing`; otherwise credit as in open question #2, or fail with support-visible status |
+| Has **yellow (Civitai) membership** only           | Green and yellow rows coexist (`userId_buzzType` unique). Gift proceeds as Case B; entitlements already resolve via highest tier (`getHighestTierSubscription`)                                         |
+| Recipient is a banned/deleted user                 | Block at purchase time                                                                                                                                                                                  |
+
+## Data model
+
+New table for audit + idempotent fulfillment (migration in `packages/civitai-db-schema/prisma/migrations/` — **applied manually per environment, per repo policy**):
+
+```prisma
+model MembershipGift {
+  id           String    @id @default(cuid())
+  gifterId     Int
+  recipientId  Int
+  tier         String    // bronze | silver | gold
+  months       Int
+  amountCents  Int       // what the gifter paid
+  status       String    @default("pending") // pending | fulfilled | failed | refunded | revoked
+  message      String?   // optional gift note shown to recipient
+  anonymous    Boolean   @default(false)
+
+  stripeCheckoutSessionId String?  @unique
+  stripePaymentIntentId   String?  @unique
+  stripeCouponId          String?
+  stripeSubscriptionId    String?  // sub the gift was applied to / created
+
+  fulfilledAt  DateTime?
+  createdAt    DateTime  @default(now())
+  updatedAt    DateTime  @updatedAt
+
+  gifter    User @relation("giftsGiven", fields: [gifterId], references: [id])
+  recipient User @relation("giftsReceived", fields: [recipientId], references: [id])
+
+  @@index([recipientId])
+  @@index([gifterId])
+}
+```
+
+`status` transitions: `pending` (row created at checkout start) → `fulfilled` (webhook applied it) / `failed` (fulfillment threw; support follow-up) → `refunded`/`revoked` (chargeback/refund handling).
+
+## Purchase flow
+
+1. **UI** (modal, see below): gifter picks recipient (user search), tier, months (1 / 3 / 6), optional message + anonymous toggle. Price = flat months × the tier's monthly Stripe price (no bundle discount — decided).
+2. **tRPC** `membershipGift.createCheckoutSession` (protected):
+   - Validate recipient (exists, not banned, not self? — open question #5, recipient's sub state to pick Case A/B messaging).
+   - Create `MembershipGift` row (`pending`).
+   - Create Stripe Checkout session `mode: 'payment'` on the **gifter's** customer (`createCustomer` if needed), `line_items` via `price_data` (months × tier monthly unit amount, product = tier product so it reads nicely on receipts), `metadata: { type: 'membershipGift', giftId }` on both session and payment intent.
+   - Return redirect URL.
+3. **Webhook fulfillment** — in `webhooks/stripe.ts` `checkout.session.completed` (`mode === 'payment'` branch, before `manageCheckoutPayment`): if `session.metadata.type === 'membershipGift'` → `fulfillMembershipGift(giftId, paymentIntentId)` in a new `membership-gift.service.ts`:
+   - Load gift row; **idempotency**: bail if not `pending` (Stripe retries webhooks).
+   - Re-check recipient's green subscription → Case A or B above.
+   - Create coupon, apply/create subscription, stamp Stripe IDs on the row, mark `fulfilled`.
+   - `invalidateSubscriptionCaches(recipientId)` + `refreshSession(recipientId)`.
+   - Fire notifications (below). On error: mark `failed`, log to Axiom, **return non-2xx** so Stripe retries (fulfillment is idempotent via status check + re-entrant coupon lookup by `metadata.giftId`).
+
+## Refunds / chargebacks
+
+Extend the existing `charge.refunded` / `charge.dispute.created` branch (`webhooks/stripe.ts:334`): look up `MembershipGift` by `stripePaymentIntentId` →
+
+- Coupon not yet exhausted: delete the coupon / remove the discount from the subscription.
+- Gift-created sub (Case B): cancel it immediately.
+- Mark row `revoked`. Buzz already granted for elapsed months is not clawed back in v1 (matches how membership refunds behave today).
+
+## UI
+
+- **Entry points**:
+  - Pricing page (`src/pages/pricing/index.tsx`): "Gift this tier" secondary action per plan card.
+  - User profile action menu: "Gift a membership" (same placement pattern as `TipBuzzButton`).
+- **Gift modal** (dialog-registry): user autocomplete (reuse the user QuickSearch/autocomplete pieces, `user.getAll` username search), tier + months selectors, live price, message + anonymous toggle → redirect to Stripe Checkout.
+- **Success page**: reuse `/payment/success` with a gift variant message.
+- **Recipient surfaces**:
+  - Notification + optional email ("X gifted you N months of Gold!").
+  - Membership page (`/user/membership`): show gift state — "Gifted membership — N months remaining" (derivable from the Stripe discount / `cancel_at`), and for Case B a "Keep my membership" CTA (add payment method + clear `cancel_at`).
+- **Gifter surface**: a "Gifts sent" list (could live under account → payments) showing status. v1 can skip this if we want to trim scope.
+- **Feature flag**: `giftMemberships` in `feature-flags.service.ts` (start `['mod']`, roll to `['public']`), gating entry points and the tRPC mutations.
+
+## Notifications
+
+New `membership-gift.notifications.ts` (pattern: `buzz.notifications.ts` tip-received):
+
+- `membership-gift-received` → recipient (respects `anonymous`).
+- `membership-gift-fulfilled` → gifter confirmation.
+- Optional transactional email for the recipient (template pattern: `redeemableCodePurchase.email.ts`).
+
+## Work breakdown
+
+| Phase                        | Scope                                                                                                                                                                                                                       | Touches                                                                     |
+| ---------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------- |
+| 1. Schema + service skeleton | `MembershipGift` model + migration SQL; `membership-gift.service.ts` (create/fulfill/revoke, fully unit-testable); `membershipGift.router.ts` + zod schema                                                                  | `packages/civitai-db-schema/*`, `src/server/{services,routers,schema}`      |
+| 2. Checkout + webhook        | checkout-session mutation; `checkout.session.completed` + `charge.refunded` branches                                                                                                                                        | `src/server/services/stripe.service.ts`, `src/pages/api/webhooks/stripe.ts` |
+| 3. Fulfillment logic         | Case A/B, coupon creation, cancel_at handling, cache/session invalidation, edge-case matrix                                                                                                                                 | `membership-gift.service.ts`                                                |
+| 4. UI                        | modal, entry points, membership-page gift state, "keep membership" CTA                                                                                                                                                      | `src/components/*`, `src/pages/pricing`, `/user/membership`                 |
+| 5. Notifications             | processors + optional email                                                                                                                                                                                                 | `src/server/notifications/*`, `src/server/email/templates`                  |
+| 6. Testing + rollout         | unit tests for fulfillment matrix; debug endpoint `src/pages/api/testing/gift-membership.ts` (WebhookEndpoint, per-userId scoped) to simulate fulfillment/refund without paying; Stripe test-clock QA; feature flag rollout | `src/server/services/__tests__`, `src/pages/api/testing`                    |
+
+### Implementation notes (as built)
+
+- **Gift page**: `/pricing/gift` (`src/pages/pricing/gift.tsx`; SSR-gated on `giftMemberships` + login) — recipient picker (QuickSearchDropdown → CreatorCardV2 once selected), selectable tier cards with the selected tier's `PlanBenefitList` (same presentation as the upgrade modal), months 1/3/6, message + anonymous, sticky order summary, redirects to Stripe Checkout. Prefill via `?userId=` / `?tier=`. (Started as a modal; promoted to a page for a nicer purchase experience.)
+- **Entry points**: `PlanCard` "Gift this tier" → `/pricing/gift?tier=…` (Stripe products, giftable tiers only) and `UserContextMenu` "Gift a membership" → `/pricing/gift?userId=…` — both behind `features.giftMemberships`.
+- **Keep my membership**: `keepGiftMembership` service + `membershipGift.keepMembership` mutation. Clears `cancel_at`/`cancel_at_period_end`; if the customer has no payment method it returns a Stripe billing-portal (`payment_method_update`) URL and the membership page retries via `?flow=keep-membership` on return. Membership page shows a teal gift alert (detected via subscription `metadata.membershipGiftId`) instead of the red cancellation warning.
+- **Gifts list**: `MembershipGiftsCard` on `/user/account` (next to the subscription card) — received gifts (gifter unless anonymous, tier, months, message, date) and sent gifts (recipient, status badge, date), plus a "Gift a membership" shortcut. Hidden when the user has no gifts.
+- **Debug endpoint**: `POST /api/testing/gift-membership?token=…` — `dump` / `giftability` / `create-gift` / `fulfill` / `revoke` / `reset` (fulfill/revoke hit real test-mode Stripe).
+- **Tests**: 28 unit tests in `src/server/services/__tests__/membership-gift.service.test.ts` covering giftability, checkout, fulfillment matrix (extend, deferred-cancel, create, annual/billing-issue failures), revoke idempotency, and keep-membership.
+
+## Decisions (v1)
+
+1. **Tier mismatch** — locked: when the recipient already has an active green sub, the gift must match their current tier (UI pre-selects and locks the tier after picking the recipient; service rejects mismatches). Revisit post-v1.
+   @dev: Lets lock it for V1 at least.
+
+2. **Annual-interval recipients** — blocked in v1 (a repeating 100%-off coupon would zero a full annual invoice). Service returns `blocked: 'annual-interval'`; UI explains why.
+   @dev: Block them in the meantime.
+
+3. **Month options / pricing** — 1, 3, or 6 months only; flat months × the tier's monthly price, no bundle discount. (12 months dropped.)
+   @dev: lets do 1, 3 and 6 months. No bundle.
+
+4. **Self-gifting** — allowed; effectively prepaying your own membership. Watch how it's used.
+   @dev: Lets allow it and see how it goes.
+
+## Open questions (@dev)
+
+1. **Recipient sub in `past_due`/`paused`** — apply anyway, credit, or fail-with-support-status? v1 proposal (currently implemented): only `active`/`trialing` get Case A; no-subscription (or terminal-status) recipients get Case B; anything else is blocked at purchase time with a billing-issue message.
+
+2. **Anonymous gifting + message** — included in the schema above; cut if you want to trim v1.
+
+3. **Refund policy surface** — should refunding auto-revoke (as planned) also claw back Buzz already granted for elapsed gift months? v1 plan: no clawback.
+
+4. **Buzz color check** — gifted green memberships grant **green** monthly Buzz (product metadata `buzzType: 'green'` drives `toAccountType` in `manageInvoicePaid`). Confirm that's the intent for gifts too (I assume yes since these are real Stripe products).

--- a/packages/civitai-db-schema/prisma/migrations/20260729200000_membership_gifts/migration.sql
+++ b/packages/civitai-db-schema/prisma/migrations/20260729200000_membership_gifts/migration.sql
@@ -1,0 +1,33 @@
+-- Gift memberships (GREEN/Stripe): audit + idempotent-fulfillment table.
+-- Applied manually (we do NOT use prisma migrate deploy).
+
+CREATE TYPE "MembershipGiftStatus" AS ENUM ('Pending', 'Fulfilled', 'Failed', 'Refunded', 'Revoked');
+
+CREATE TABLE "MembershipGift" (
+    "id" TEXT NOT NULL,
+    "gifterId" INTEGER NOT NULL,
+    "recipientId" INTEGER NOT NULL,
+    "tier" TEXT NOT NULL,
+    "months" INTEGER NOT NULL,
+    "amountCents" INTEGER NOT NULL,
+    "status" "MembershipGiftStatus" NOT NULL DEFAULT 'Pending',
+    "message" TEXT,
+    "anonymous" BOOLEAN NOT NULL DEFAULT false,
+    "stripeCheckoutSessionId" TEXT,
+    "stripePaymentIntentId" TEXT,
+    "stripeCouponId" TEXT,
+    "stripeSubscriptionId" TEXT,
+    "fulfilledAt" TIMESTAMP(3),
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "MembershipGift_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "MembershipGift_stripeCheckoutSessionId_key" ON "MembershipGift"("stripeCheckoutSessionId");
+CREATE UNIQUE INDEX "MembershipGift_stripePaymentIntentId_key" ON "MembershipGift"("stripePaymentIntentId");
+CREATE INDEX "MembershipGift_recipientId_idx" ON "MembershipGift"("recipientId");
+CREATE INDEX "MembershipGift_gifterId_idx" ON "MembershipGift"("gifterId");
+
+ALTER TABLE "MembershipGift" ADD CONSTRAINT "MembershipGift_gifterId_fkey" FOREIGN KEY ("gifterId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "MembershipGift" ADD CONSTRAINT "MembershipGift_recipientId_fkey" FOREIGN KEY ("recipientId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/civitai-db-schema/prisma/schema.full.prisma
+++ b/packages/civitai-db-schema/prisma/schema.full.prisma
@@ -408,6 +408,8 @@ model User {
   createdAt               DateTime               @default(now())
   deletedAt               DateTime?
   subscriptions           CustomerSubscription[]
+  membershipGiftsGiven    MembershipGift[]       @relation("membershipGiftsGiven")
+  membershipGiftsReceived MembershipGift[]       @relation("membershipGiftsReceived")
   mutedAt                 DateTime? /// Set on moderator mute-confirmation; cleared via trigger on unmute
   muted                   Boolean                @default(false)
   muteExpiresAt           DateTime? /// For timed mutes from strike escalation
@@ -621,6 +623,40 @@ enum PaymentProvider {
   Stripe
   Paddle
   Civitai
+}
+
+enum MembershipGiftStatus {
+  Pending
+  Fulfilled
+  Failed
+  Refunded
+  Revoked
+}
+
+model MembershipGift {
+  id          String               @id @default(cuid())
+  gifterId    Int
+  gifter      User                 @relation("membershipGiftsGiven", fields: [gifterId], references: [id], onDelete: Cascade)
+  recipientId Int
+  recipient   User                 @relation("membershipGiftsReceived", fields: [recipientId], references: [id], onDelete: Cascade)
+  tier        String
+  months      Int
+  amountCents Int
+  status      MembershipGiftStatus @default(Pending)
+  message     String?
+  anonymous   Boolean              @default(false)
+
+  stripeCheckoutSessionId String? @unique
+  stripePaymentIntentId   String? @unique
+  stripeCouponId          String?
+  stripeSubscriptionId    String?
+
+  fulfilledAt DateTime?
+  createdAt   DateTime  @default(now())
+  updatedAt   DateTime  @updatedAt
+
+  @@index([recipientId])
+  @@index([gifterId])
 }
 
 model Product {

--- a/packages/civitai-db-schema/src/enums.ts
+++ b/packages/civitai-db-schema/src/enums.ts
@@ -107,6 +107,16 @@ export const PaymentProvider = {
 
 export type PaymentProvider = (typeof PaymentProvider)[keyof typeof PaymentProvider];
 
+export const MembershipGiftStatus = {
+  Pending: 'Pending',
+  Fulfilled: 'Fulfilled',
+  Failed: 'Failed',
+  Refunded: 'Refunded',
+  Revoked: 'Revoked',
+} as const;
+
+export type MembershipGiftStatus = (typeof MembershipGiftStatus)[keyof typeof MembershipGiftStatus];
+
 export const UserEngagementType = {
   Follow: 'Follow',
   Hide: 'Hide',

--- a/packages/civitai-db-schema/src/kysely/enums.ts
+++ b/packages/civitai-db-schema/src/kysely/enums.ts
@@ -90,6 +90,14 @@ export const PaymentProvider = {
   Civitai: 'Civitai',
 } as const;
 export type PaymentProvider = (typeof PaymentProvider)[keyof typeof PaymentProvider];
+export const MembershipGiftStatus = {
+  Pending: 'Pending',
+  Fulfilled: 'Fulfilled',
+  Failed: 'Failed',
+  Refunded: 'Refunded',
+  Revoked: 'Revoked',
+} as const;
+export type MembershipGiftStatus = (typeof MembershipGiftStatus)[keyof typeof MembershipGiftStatus];
 export const UserEngagementType = {
   Follow: 'Follow',
   Hide: 'Hide',

--- a/packages/civitai-db-schema/src/kysely/types.ts
+++ b/packages/civitai-db-schema/src/kysely/types.ts
@@ -15,6 +15,7 @@ import type {
   CryptoTransactionStatus,
   RewardsEligibility,
   PaymentProvider,
+  MembershipGiftStatus,
   UserEngagementType,
   LinkType,
   ModelType,
@@ -2367,6 +2368,24 @@ export type Link = {
   entityId: number;
   entityType: string;
 };
+export type MembershipGift = {
+  id: string;
+  gifterId: number;
+  recipientId: number;
+  tier: string;
+  months: number;
+  amountCents: number;
+  status: Generated<MembershipGiftStatus>;
+  message: string | null;
+  anonymous: Generated<boolean>;
+  stripeCheckoutSessionId: string | null;
+  stripePaymentIntentId: string | null;
+  stripeCouponId: string | null;
+  stripeSubscriptionId: string | null;
+  fulfilledAt: Timestamp | null;
+  createdAt: Generated<Timestamp>;
+  updatedAt: Timestamp;
+};
 export type ModActivity = {
   id: Generated<number>;
   userId: number | null;
@@ -4048,6 +4067,7 @@ export type DB = {
   License: License;
   LicensingRoot: LicensingRoot;
   Link: Link;
+  MembershipGift: MembershipGift;
   ModActivity: ModActivity;
   Model: Model;
   Model3D: Model3D;

--- a/packages/civitai-db-schema/src/models.ts
+++ b/packages/civitai-db-schema/src/models.ts
@@ -20,6 +20,8 @@ export type RewardsEligibility = "Eligible" | "Ineligible" | "Protected";
 
 export type PaymentProvider = "Stripe" | "Paddle" | "Civitai";
 
+export type MembershipGiftStatus = "Pending" | "Fulfilled" | "Failed" | "Refunded" | "Revoked";
+
 export type UserEngagementType = "Follow" | "Hide" | "Block";
 
 export type LinkType = "Sponsorship" | "Social" | "Other";
@@ -478,6 +480,8 @@ export interface User {
   createdAt: Date;
   deletedAt: Date | null;
   subscriptions?: CustomerSubscription[];
+  membershipGiftsGiven?: MembershipGift[];
+  membershipGiftsReceived?: MembershipGift[];
   mutedAt: Date | null;
   muted: boolean;
   muteExpiresAt: Date | null;
@@ -671,6 +675,27 @@ export interface CustomerSubscription {
   createdAt: Date;
   endedAt: Date | null;
   updatedAt: Date | null;
+}
+
+export interface MembershipGift {
+  id: string;
+  gifterId: number;
+  gifter?: User;
+  recipientId: number;
+  recipient?: User;
+  tier: string;
+  months: number;
+  amountCents: number;
+  status: MembershipGiftStatus;
+  message: string | null;
+  anonymous: boolean;
+  stripeCheckoutSessionId: string | null;
+  stripePaymentIntentId: string | null;
+  stripeCouponId: string | null;
+  stripeSubscriptionId: string | null;
+  fulfilledAt: Date | null;
+  createdAt: Date;
+  updatedAt: Date;
 }
 
 export interface Product {

--- a/src/components/Account/MembershipGiftsCard.tsx
+++ b/src/components/Account/MembershipGiftsCard.tsx
@@ -1,0 +1,193 @@
+import {
+  Badge,
+  Box,
+  Button,
+  Center,
+  Group,
+  Pagination,
+  Paper,
+  SegmentedControl,
+  Stack,
+  Text,
+  Title,
+} from '@mantine/core';
+import { IconGift } from '@tabler/icons-react';
+import { useMemo, useState } from 'react';
+import buzzClasses from '~/components/Buzz/buzz.module.scss';
+import { NextLink as Link } from '~/components/NextLink/NextLink';
+import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
+import { formatDate } from '~/utils/date-helpers';
+import { capitalize } from '~/utils/string-helpers';
+import { trpc } from '~/utils/trpc';
+
+const DEFAULT_PAGE_SIZE = 5;
+const COMPACT_PAGE_SIZE = 3;
+
+const statusColors: Record<string, string> = {
+  Fulfilled: 'green',
+  Failed: 'red',
+  Refunded: 'orange',
+  Revoked: 'orange',
+};
+
+type GiftRow = {
+  id: string;
+  kind: 'received' | 'sent';
+  tier: string;
+  months: number;
+  date: Date | null;
+  otherParty: string | null;
+  message?: string | null;
+  status?: string;
+};
+
+function GiftRowItem({ row }: { row: GiftRow }) {
+  const received = row.kind === 'received';
+  const accentColor = received ? 'var(--mantine-color-teal-5)' : 'var(--mantine-color-blue-5)';
+
+  return (
+    <Paper
+      p="sm"
+      radius="sm"
+      withBorder
+      className="border border-gray-200 bg-gray-50 dark:border-white/10 dark:bg-white/[0.03]"
+      style={{ borderLeft: `3px solid ${accentColor}` }}
+    >
+      <Group justify="space-between" wrap="nowrap" align="center">
+        <Stack gap={2} style={{ minWidth: 0 }}>
+          <Text size="sm" fw={700}>
+            {row.months}-mo {capitalize(row.tier)} Membership
+          </Text>
+          <Text size="xs" c="dimmed">
+            {received
+              ? row.otherParty
+                ? `from @${row.otherParty}`
+                : 'from an anonymous gifter'
+              : `to @${row.otherParty}`}
+          </Text>
+          {row.message && (
+            <Text size="xs" c="dimmed" fs="italic" lineClamp={2}>
+              &ldquo;{row.message}&rdquo;
+            </Text>
+          )}
+        </Stack>
+        <Stack gap={4} align="flex-end" style={{ flexShrink: 0 }}>
+          {received ? (
+            <Badge variant="light" color="teal" size="sm">
+              Received
+            </Badge>
+          ) : (
+            <Badge variant="light" color={statusColors[row.status ?? ''] ?? 'gray'} size="sm">
+              {row.status}
+            </Badge>
+          )}
+          {row.date && (
+            <Text size="xs" c="dimmed">
+              {formatDate(row.date)}
+            </Text>
+          )}
+        </Stack>
+      </Group>
+    </Paper>
+  );
+}
+
+type FilterType = 'all' | 'received' | 'sent';
+
+export function MembershipGiftsCard({
+  compact,
+  showGiftAction = true,
+}: { compact?: boolean; showGiftAction?: boolean } = {}) {
+  const features = useFeatureFlags();
+  const [page, setPage] = useState(1);
+  const [filter, setFilter] = useState<FilterType>('all');
+  const pageSize = compact ? COMPACT_PAGE_SIZE : DEFAULT_PAGE_SIZE;
+
+  const { data, isLoading } = trpc.membershipGift.getMyGifts.useQuery(undefined, {
+    enabled: features.giftMemberships,
+  });
+
+  const rows = useMemo<GiftRow[]>(() => {
+    if (!data) return [];
+    const received = data.received.map(
+      (gift: (typeof data)['received'][number]): GiftRow => ({
+        id: gift.id,
+        kind: 'received',
+        tier: gift.tier,
+        months: gift.months,
+        date: gift.fulfilledAt,
+        otherParty: gift.gifter?.username ?? null,
+        message: gift.message,
+      })
+    );
+    const sent = data.sent.map(
+      (gift: (typeof data)['sent'][number]): GiftRow => ({
+        id: gift.id,
+        kind: 'sent',
+        tier: gift.tier,
+        months: gift.months,
+        date: gift.createdAt,
+        otherParty: gift.recipient.username,
+        status: gift.status,
+      })
+    );
+    return [...received, ...sent].sort(
+      (a, b) => (b.date?.getTime() ?? 0) - (a.date?.getTime() ?? 0)
+    );
+  }, [data]);
+
+  if (!features.giftMemberships || isLoading || rows.length === 0) return null;
+
+  const hasBoth = rows.some((r) => r.kind === 'received') && rows.some((r) => r.kind === 'sent');
+  const filtered = filter === 'all' ? rows : rows.filter((r) => r.kind === filter);
+  const totalPages = Math.ceil(filtered.length / pageSize);
+  const paginated = filtered.slice((page - 1) * pageSize, page * pageSize);
+
+  return (
+    <Paper className={buzzClasses.tileCard} id="membership-gifts" p="lg" radius="md">
+      <Group justify="space-between" align="center" wrap="nowrap">
+        <Title order={4}>Membership Gifts</Title>
+        <Group gap="xs" wrap="nowrap">
+          {hasBoth && (
+            <SegmentedControl
+              size="xs"
+              value={filter}
+              onChange={(value) => {
+                setFilter(value as FilterType);
+                setPage(1);
+              }}
+              data={[
+                { label: 'All', value: 'all' },
+                { label: 'Received', value: 'received' },
+                { label: 'Sent', value: 'sent' },
+              ]}
+            />
+          )}
+          {showGiftAction && (
+            <Button
+              component={Link}
+              href="/pricing/gift"
+              size="compact-sm"
+              variant="light"
+              leftSection={<IconGift size={14} />}
+            >
+              Gift a membership
+            </Button>
+          )}
+        </Group>
+      </Group>
+      <Box mt="md">
+        <Stack gap="xs">
+          {paginated.map((row) => (
+            <GiftRowItem key={`${row.kind}-${row.id}`} row={row} />
+          ))}
+          {totalPages > 1 && (
+            <Center mt="sm">
+              <Pagination value={page} onChange={setPage} total={totalPages} size="sm" />
+            </Center>
+          )}
+        </Stack>
+      </Box>
+    </Paper>
+  );
+}

--- a/src/components/Profile/UserContextMenu.tsx
+++ b/src/components/Profile/UserContextMenu.tsx
@@ -9,6 +9,7 @@ import {
   IconCrystalBall,
   IconDotsVertical,
   IconFlag,
+  IconGift,
   IconInfoCircle,
   IconGraphOff,
   IconGraph,
@@ -366,6 +367,15 @@ export const UserContextMenu = ({ username }: { username: string }) => {
                 </>
               )}
             </>
+          )}
+          {features.giftMemberships && currentUser && (
+            <Menu.Item
+              leftSection={<IconGift size={14} stroke={1.5} />}
+              component={Link}
+              href={`/pricing/gift?userId=${user.id}`}
+            >
+              Gift a membership
+            </Menu.Item>
           )}
           {!isSameUser && <BlockUserButton userId={user.id} as="menu-item" />}
           {isSameUser && (

--- a/src/components/Subscriptions/PlanCard.tsx
+++ b/src/components/Subscriptions/PlanCard.tsx
@@ -1,6 +1,6 @@
 import type { ButtonProps } from '@mantine/core';
 import { Button, Card, Center, Divider, Group, Select, Stack, Text, Title } from '@mantine/core';
-import { IconChevronDown } from '@tabler/icons-react';
+import { IconChevronDown, IconGift } from '@tabler/icons-react';
 import { useCallback, useRef, useState } from 'react';
 import { dialogStore } from '~/components/Dialog/dialogStore';
 import { EdgeMedia } from '~/components/EdgeMedia/EdgeMedia';
@@ -203,7 +203,8 @@ export function PlanCard({ product, subscription }: PlanCardProps) {
                     classNames={{
                       root: 'mt-[2px] border-b-2 border-b-current',
                       input: 'h-[20px] min-h-[20px] text-start uppercase',
-                      option: 'px-[4px] text-center uppercase data-[checked]:bg-dark-5 data-[checked]:font-bold',
+                      option:
+                        'px-[4px] text-center uppercase data-[checked]:bg-dark-5 data-[checked]:font-bold',
                       section: 'mr-0',
                     }}
                   />
@@ -216,12 +217,7 @@ export function PlanCard({ product, subscription }: PlanCardProps) {
                         Manage your Membership
                       </Button>
                     ) : redirectToPrepaidPage ? (
-                      <Button
-                        component={Link}
-                        href="/purchase/buzz"
-                        radius="xl"
-                        {...btnProps}
-                      >
+                      <Button component={Link} href="/purchase/buzz" radius="xl" {...btnProps}>
                         Purchase Buzz
                       </Button>
                     ) : isDowngrade ? (
@@ -241,7 +237,8 @@ export function PlanCard({ product, subscription }: PlanCardProps) {
                           });
                         }}
                       >
-                        Downgrade to {capitalize(meta?.tier)} {isActivePlanDiffInterval ? ' (Monthly)' : ''}
+                        Downgrade to {capitalize(meta?.tier)}{' '}
+                        {isActivePlanDiffInterval ? ' (Monthly)' : ''}
                       </Button>
                     ) : isUpgrade ? (
                       <Button
@@ -259,19 +256,38 @@ export function PlanCard({ product, subscription }: PlanCardProps) {
                           });
                         }}
                       >
-                        Upgrade to {capitalize(meta?.tier)} {isActivePlanDiffInterval ? ' (Annual)' : ''}
+                        Upgrade to {capitalize(meta?.tier)}{' '}
+                        {isActivePlanDiffInterval ? ' (Annual)' : ''}
                       </Button>
                     ) : (
                       <SubscribeButton
                         priceId={priceId}
                         disabled={ctaDisabled}
-                        forceProvider={meta.buzzType === 'green' ? PaymentProvider.Stripe : undefined}
+                        forceProvider={
+                          meta.buzzType === 'green' ? PaymentProvider.Stripe : undefined
+                        }
                       >
                         <Button radius="xl" {...btnProps}>
-                          {isActivePlan ? `You are ${capitalize(meta?.tier)}` : `Subscribe to ${capitalize(meta?.tier)}`}
+                          {isActivePlan
+                            ? `You are ${capitalize(meta?.tier)}`
+                            : `Subscribe to ${capitalize(meta?.tier)}`}
                         </Button>
                       </SubscribeButton>
                     )}
+                    {features.giftMemberships &&
+                      product.provider === PaymentProvider.Stripe &&
+                      ['bronze', 'silver', 'gold'].includes(meta.tier) && (
+                        <Button
+                          radius="xl"
+                          variant="subtle"
+                          color="gray"
+                          leftSection={<IconGift size={16} />}
+                          component={Link}
+                          href={`/pricing/gift?tier=${meta.tier}`}
+                        >
+                          Gift this tier
+                        </Button>
+                      )}
                   </>
                 )}
               </Stack>

--- a/src/pages/api/testing/gift-membership.ts
+++ b/src/pages/api/testing/gift-membership.ts
@@ -1,0 +1,163 @@
+/**
+ * Debug endpoint for Gift Memberships (GREEN / Stripe).
+ * =============================================================================
+ *
+ * Hidden testing route. Guarded by the WEBHOOK_TOKEN via `?token=` query
+ * param. Lets you exercise the full gift lifecycle without paying — fulfill
+ * and revoke talk to the configured (test-mode in dev) Stripe account for
+ * real coupons/subscriptions.
+ *
+ * Usage:
+ *   POST /api/testing/gift-membership?token=$WEBHOOK_TOKEN
+ *   Content-Type: application/json
+ *   Body: { "action": "<action>", ...params }
+ *
+ * Actions (see the switch below for authoritative param list):
+ *   dump         - {userId}                                        Gift rows (sent/received) + green subscription snapshot
+ *   giftability  - {userId}                                        What getRecipientGiftability returns for the user
+ *   create-gift  - {gifterId, recipientId, tier, months,           Insert a Pending MembershipGift row with a debug
+ *                   message?, anonymous?}                          payment-intent id (skips Stripe Checkout)
+ *   fulfill      - {giftId}                                        Run fulfillMembershipGift (real Stripe coupon/sub)
+ *   revoke       - {giftId, reason?}                               Run revokeMembershipGift as if the payment was refunded
+ *   reset        - {userId, confirm: true}                         Delete all MembershipGift rows where the user is
+ *                                                                  gifter or recipient (does NOT touch Stripe)
+ *
+ * Flow: create-gift -> fulfill -> check /user/membership -> revoke -> reset.
+ *
+ * Permanent changes are scoped to a single user or gift per call so a misuse
+ * never cascades across the DB.
+ */
+
+import type { NextApiRequest, NextApiResponse } from 'next';
+import * as z from 'zod';
+import { dbRead, dbWrite } from '~/server/db/client';
+import {
+  fulfillMembershipGift,
+  getRecipientGiftability,
+  revokeMembershipGift,
+} from '~/server/services/membership-gift.service';
+import { WebhookEndpoint } from '~/server/utils/endpoint-helpers';
+import { MembershipGiftStatus } from '~/shared/utils/prisma/enums';
+
+const actionSchema = z.enum(['dump', 'giftability', 'create-gift', 'fulfill', 'revoke', 'reset']);
+
+const schema = z
+  .object({
+    action: actionSchema,
+    userId: z.coerce.number().int().positive().optional(),
+    gifterId: z.coerce.number().int().positive().optional(),
+    recipientId: z.coerce.number().int().positive().optional(),
+    tier: z.enum(['bronze', 'silver', 'gold']).optional(),
+    months: z.coerce.number().int().positive().optional(),
+    message: z.string().max(500).optional(),
+    anonymous: z.coerce.boolean().optional(),
+    giftId: z.string().optional(),
+    reason: z.enum(['refund', 'chargeback']).optional(),
+    confirm: z.coerce.boolean().optional(),
+  })
+  .superRefine((data, ctx) => {
+    if (['dump', 'giftability', 'reset'].includes(data.action) && !data.userId) {
+      ctx.addIssue({ code: 'custom', message: `${data.action} requires userId`, path: ['userId'] });
+    }
+    if (
+      data.action === 'create-gift' &&
+      (!data.gifterId || !data.recipientId || !data.tier || !data.months)
+    ) {
+      ctx.addIssue({
+        code: 'custom',
+        message: 'create-gift requires gifterId + recipientId + tier + months',
+      });
+    }
+    if (['fulfill', 'revoke'].includes(data.action) && !data.giftId) {
+      ctx.addIssue({ code: 'custom', message: `${data.action} requires giftId`, path: ['giftId'] });
+    }
+    if (data.action === 'reset' && !data.confirm) {
+      ctx.addIssue({ code: 'custom', message: 'reset requires confirm=true' });
+    }
+  });
+
+export default WebhookEndpoint(async function (req: NextApiRequest, res: NextApiResponse) {
+  const payload = schema.safeParse({ ...req.query, ...(req.body ?? {}) });
+  if (!payload.success) {
+    return res.status(400).json({ error: 'Invalid request', issues: payload.error.issues });
+  }
+  const input = payload.data;
+
+  switch (input.action) {
+    case 'dump': {
+      const userId = input.userId!;
+      const [sent, received, subscription] = await Promise.all([
+        dbRead.membershipGift.findMany({
+          where: { gifterId: userId },
+          orderBy: { createdAt: 'desc' },
+          take: 25,
+        }),
+        dbRead.membershipGift.findMany({
+          where: { recipientId: userId },
+          orderBy: { createdAt: 'desc' },
+          take: 25,
+        }),
+        dbRead.customerSubscription.findUnique({
+          where: { userId_buzzType: { userId, buzzType: 'green' } },
+          include: { product: { select: { id: true, metadata: true, provider: true } } },
+        }),
+      ]);
+      return res.status(200).json({ userId, sent, received, greenSubscription: subscription });
+    }
+
+    case 'giftability': {
+      const result = await getRecipientGiftability({ recipientUserId: input.userId! });
+      return res.status(200).json({ action: input.action, result });
+    }
+
+    case 'create-gift': {
+      const gift = await dbWrite.membershipGift.create({
+        data: {
+          gifterId: input.gifterId!,
+          recipientId: input.recipientId!,
+          tier: input.tier!,
+          months: input.months!,
+          amountCents: 0,
+          message: input.message,
+          anonymous: input.anonymous ?? false,
+          stripePaymentIntentId: `debug-pi:${Date.now()}`,
+        },
+      });
+      return res.status(200).json({ action: input.action, gift });
+    }
+
+    case 'fulfill': {
+      const result = await fulfillMembershipGift({ giftId: input.giftId! });
+      return res.status(200).json({ action: input.action, ...result });
+    }
+
+    case 'revoke': {
+      const gift = await dbWrite.membershipGift.findUnique({
+        where: { id: input.giftId! },
+        select: { stripePaymentIntentId: true },
+      });
+      if (!gift?.stripePaymentIntentId) {
+        return res.status(404).json({ error: 'Gift not found or has no payment intent id' });
+      }
+      const result = await revokeMembershipGift({
+        paymentIntentId: gift.stripePaymentIntentId,
+        reason: input.reason ?? 'refund',
+      });
+      return res.status(200).json({ action: input.action, revoked: result });
+    }
+
+    case 'reset': {
+      const userId = input.userId!;
+      const pendingOrDone = await dbWrite.membershipGift.deleteMany({
+        where: { OR: [{ gifterId: userId }, { recipientId: userId }] },
+      });
+      return res.status(200).json({
+        action: input.action,
+        deletedGifts: pendingOrDone.count,
+        note: `Stripe coupons/subscriptions are untouched — revoke ${MembershipGiftStatus.Fulfilled} gifts first if needed.`,
+      });
+    }
+  }
+
+  return res.status(400).json({ error: 'Unhandled action' });
+});

--- a/src/pages/api/webhooks/stripe.ts
+++ b/src/pages/api/webhooks/stripe.ts
@@ -167,6 +167,24 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
                   );
               }
             } else if (checkoutSession.mode === 'payment') {
+              if (checkoutSession.metadata?.type === 'membershipGift') {
+                const giftId = checkoutSession.metadata.giftId;
+                if (!giftId) throw new Error('membershipGift checkout session missing giftId');
+                const { fulfillMembershipGift } = await import(
+                  '~/server/services/membership-gift.service'
+                );
+                // Throws propagate to the outer catch → 400 → Stripe retries.
+                // fulfillMembershipGift is re-runnable (Fulfilled rows bail early).
+                await fulfillMembershipGift({
+                  giftId,
+                  paymentIntentId:
+                    typeof checkoutSession.payment_intent === 'string'
+                      ? checkoutSession.payment_intent
+                      : checkoutSession.payment_intent?.id,
+                });
+                break;
+              }
+
               // First, check if this payment is for Civitai AIR
 
               if (
@@ -348,6 +366,24 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
               }
             } catch {
               // lookup failed — still try with PI id so buzz-purchase path revokes
+            }
+            if (paymentIntentId) {
+              const { revokeMembershipGift } = await import(
+                '~/server/services/membership-gift.service'
+              );
+              await revokeMembershipGift({
+                paymentIntentId,
+                reason: event.type === 'charge.refunded' ? 'refund' : 'chargeback',
+              }).catch((err) => {
+                log({
+                  type: 'error',
+                  stage: 'membership-gift-revoke',
+                  eventType: event.type,
+                  paymentIntentId,
+                  error: (err as Error)?.message,
+                });
+                return false;
+              });
             }
             for (const sourceEventId of [paymentIntentId, invoiceId].filter(Boolean) as string[]) {
               await revokeForChargeback({

--- a/src/pages/pricing/gift.tsx
+++ b/src/pages/pricing/gift.tsx
@@ -1,0 +1,395 @@
+import {
+  Alert,
+  Badge,
+  Box,
+  Button,
+  Card,
+  Center,
+  Container,
+  Divider,
+  Grid,
+  Group,
+  Loader,
+  Paper,
+  SegmentedControl,
+  Stack,
+  Switch,
+  Text,
+  Textarea,
+  Title,
+  UnstyledButton,
+} from '@mantine/core';
+import { IconGift, IconInfoCircle } from '@tabler/icons-react';
+import clsx from 'clsx';
+import Router, { useRouter } from 'next/router';
+import { useState } from 'react';
+import * as z from 'zod';
+import { MembershipGiftsCard } from '~/components/Account/MembershipGiftsCard';
+import { CreatorCardV2 } from '~/components/CreatorCard/CreatorCard';
+import { EdgeMedia } from '~/components/EdgeMedia/EdgeMedia';
+import { Meta } from '~/components/Meta/Meta';
+import { QuickSearchDropdown } from '~/components/Search/QuickSearchDropdown';
+import { PlanBenefitList } from '~/components/Subscriptions/PlanBenefitList';
+import { getPlanDetails } from '~/components/Subscriptions/getPlanDetails';
+import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
+import type { GiftableTier } from '~/server/schema/membership-gift.schema';
+import { giftableTierSchema, giftMonthsOptions } from '~/server/schema/membership-gift.schema';
+import { createServerSideProps } from '~/server/utils/server-side-helpers';
+import { formatDate } from '~/utils/date-helpers';
+import { getLoginLink } from '~/utils/login-helpers';
+import { showErrorNotification } from '~/utils/notifications';
+import { capitalize, getStripeCurrencyDisplay } from '~/utils/string-helpers';
+import { trpc } from '~/utils/trpc';
+
+export const getServerSideProps = createServerSideProps({
+  useSession: true,
+  resolver: async ({ features, session, ctx }) => {
+    if (!features?.giftMemberships) return { notFound: true };
+    if (!session || !session.user)
+      return {
+        redirect: {
+          destination: getLoginLink({ returnUrl: ctx.resolvedUrl }),
+          permanent: false,
+        },
+      };
+  },
+});
+
+const querySchema = z.object({
+  userId: z.coerce.number().int().positive().optional(),
+  tier: giftableTierSchema.optional(),
+});
+
+type GiftRecipient = { id: number; username: string | null };
+type GiftMonths = (typeof giftMonthsOptions)[number];
+
+const blockedReasons: Record<string, string> = {
+  'annual-interval':
+    'This user is on an annual membership, which cannot receive gifted months yet.',
+  'billing-issue': "This user's membership has a billing issue and cannot receive gifts right now.",
+  'unsupported-provider': "This user's membership cannot receive gifted months.",
+};
+
+export default function GiftMembershipPage() {
+  const router = useRouter();
+  const features = useFeatureFlags();
+  const query = querySchema.safeParse(router.query);
+  const initialUserId = query.success ? query.data.userId : undefined;
+  const initialTier = (query.success && query.data.tier) || 'gold';
+
+  const [recipient, setRecipient] = useState<GiftRecipient | null>(
+    initialUserId ? { id: initialUserId, username: null } : null
+  );
+  const [tier, setTier] = useState<GiftableTier>(initialTier);
+  const [months, setMonths] = useState<GiftMonths>(3);
+  const [message, setMessage] = useState('');
+  const [anonymous, setAnonymous] = useState(false);
+
+  // Same query key CreatorCardV2 uses internally, so this is a cache hit
+  const { data: recipientCreator } = trpc.user.getCreator.useQuery(
+    { id: recipient?.id as number },
+    { enabled: !!recipient }
+  );
+  const recipientUsername = recipient?.username ?? recipientCreator?.username ?? null;
+
+  const { data: giftability, isLoading: giftabilityLoading } =
+    trpc.membershipGift.getRecipientGiftability.useQuery(
+      { recipientUserId: recipient?.id as number },
+      { enabled: !!recipient }
+    );
+
+  const { data: plans, isLoading: plansLoading } = trpc.subscriptions.getPlans.useQuery({
+    interval: 'month',
+    paymentProvider: 'Stripe',
+  });
+
+  const createCheckout = trpc.membershipGift.createCheckout.useMutation({
+    onSuccess: ({ url }) => {
+      if (url) Router.push(url);
+    },
+    onError: (error) =>
+      showErrorNotification({
+        title: 'Could not start gift checkout',
+        error: new Error(error.message),
+      }),
+  });
+
+  const lockedTier = giftability?.status === 'active' ? giftability.tier : null;
+  const effectiveTier = lockedTier ?? tier;
+  const blocked = giftability?.status === 'blocked';
+
+  const tierPlans = (plans ?? []).filter((p) =>
+    ['bronze', 'silver', 'gold'].includes(p.metadata.tier)
+  );
+  const selectedPlan = tierPlans.find((p) => p.metadata.tier === effectiveTier);
+  const selectedPlanDetails = selectedPlan ? getPlanDetails(selectedPlan, features) : null;
+  const monthlyDisplay = selectedPlan
+    ? getStripeCurrencyDisplay(selectedPlan.price.unitAmount, selectedPlan.price.currency)
+    : null;
+  const totalDisplay = selectedPlan
+    ? getStripeCurrencyDisplay(selectedPlan.price.unitAmount * months, selectedPlan.price.currency)
+    : null;
+
+  const canSubmit = !!recipient && !blocked && !giftabilityLoading && !!selectedPlan;
+
+  const handleSubmit = () => {
+    if (!recipient) return;
+    createCheckout.mutate({
+      recipientUserId: recipient.id,
+      tier: effectiveTier,
+      months,
+      message: message.trim() ? message.trim() : undefined,
+      anonymous,
+    });
+  };
+
+  return (
+    <>
+      <Meta title="Gift a Membership | Civitai" deIndex />
+      <Container size="lg" py="xl">
+        <Stack gap="xl">
+          <Stack gap={4} align="center">
+            <Group gap="xs">
+              <IconGift size={32} className="text-blue-4" />
+              <Title order={1}>Gift a Membership</Title>
+            </Group>
+            <Text c="dimmed" ta="center" maw={520}>
+              Treat someone to Civitai membership perks — monthly Buzz, more generation power, and
+              everything their tier includes. They never pay a thing.
+            </Text>
+          </Stack>
+
+          <Grid gutter="xl">
+            <Grid.Col span={{ base: 12, md: 7 }}>
+              <Stack gap="lg">
+                <Stack gap="xs">
+                  <Title order={4}>1. Who is it for?</Title>
+                  {recipient ? (
+                    <Stack gap={4} w={450} maw="100%" mx="auto">
+                      <CreatorCardV2 user={recipient} withActions={false} tipsEnabled={false} />
+                      <Button
+                        variant="subtle"
+                        size="compact-sm"
+                        className="self-end"
+                        onClick={() => setRecipient(null)}
+                      >
+                        Change recipient
+                      </Button>
+                    </Stack>
+                  ) : (
+                    <QuickSearchDropdown
+                      disableInitialSearch
+                      supportedIndexes={['users']}
+                      startingIndex="users"
+                      showIndexSelect={false}
+                      dropdownItemLimit={25}
+                      placeholder="Search for a user"
+                      onItemSelected={(_entity, item) => {
+                        const user = item as { id: number; username: string | null };
+                        setRecipient({ id: user.id, username: user.username });
+                      }}
+                      clearable
+                    />
+                  )}
+                  {recipient && giftabilityLoading && (
+                    <Group gap="xs">
+                      <Loader size="xs" />
+                      <Text size="sm" c="dimmed">
+                        Checking their membership…
+                      </Text>
+                    </Group>
+                  )}
+                  {recipient && giftability?.status === 'no-subscription' && (
+                    <Alert color="teal" icon={<IconGift size={18} />}>
+                      They don&rsquo;t have an active membership yet — your gift starts a{' '}
+                      {capitalize(effectiveTier)} membership for them the moment it&rsquo;s paid.
+                      Nothing needed on their end.
+                    </Alert>
+                  )}
+                  {recipient && giftability?.status === 'active' && (
+                    <Alert color="blue" icon={<IconInfoCircle size={18} />}>
+                      They&rsquo;re already on {capitalize(giftability.tier)}
+                      {giftability.renewsAt
+                        ? ` (renews ${formatDate(giftability.renewsAt)})`
+                        : ''}{' '}
+                      — your gift adds free months on top of their existing membership, so the tier
+                      is locked to match theirs.
+                      {giftability.cancelsAtPeriodEnd &&
+                        ' Their membership is set to cancel; the free months are added before it ends, and billing will not restart unless they choose to keep it.'}
+                    </Alert>
+                  )}
+                  {blocked && giftability && (
+                    <Alert color="yellow" icon={<IconInfoCircle size={18} />}>
+                      {blockedReasons[giftability.reason] ??
+                        'This user cannot receive gifted months.'}
+                    </Alert>
+                  )}
+                </Stack>
+
+                <Stack gap="xs">
+                  <Title order={4}>2. Pick a tier</Title>
+                  {plansLoading ? (
+                    <Center py="lg">
+                      <Loader />
+                    </Center>
+                  ) : (
+                    <Group grow align="stretch">
+                      {tierPlans.map((plan) => {
+                        const planTier = plan.metadata.tier as GiftableTier;
+                        const { image } = getPlanDetails(plan, features);
+                        const isSelected = planTier === effectiveTier;
+                        const isDisabled = blocked || (!!lockedTier && lockedTier !== planTier);
+                        return (
+                          <UnstyledButton
+                            key={plan.id}
+                            disabled={isDisabled}
+                            onClick={() => setTier(planTier)}
+                            className={clsx(
+                              'rounded-lg border-2 p-4 transition-colors',
+                              isSelected
+                                ? 'border-blue-5 bg-blue-5/10'
+                                : 'border-gray-3 dark:border-dark-4',
+                              isDisabled && 'opacity-40'
+                            )}
+                          >
+                            <Stack gap={4} align="center">
+                              {image && (
+                                <Box w={56}>
+                                  <EdgeMedia src={image} className="size-full object-cover" />
+                                </Box>
+                              )}
+                              <Text fw={600}>{capitalize(planTier)}</Text>
+                              <Text size="sm" c="dimmed">
+                                {getStripeCurrencyDisplay(
+                                  plan.price.unitAmount,
+                                  plan.price.currency
+                                )}
+                                /mo
+                              </Text>
+                            </Stack>
+                          </UnstyledButton>
+                        );
+                      })}
+                    </Group>
+                  )}
+                  {selectedPlanDetails?.benefits && (
+                    <Paper className="rounded-md bg-gray-0 p-5 dark:bg-dark-8" withBorder>
+                      <PlanBenefitList
+                        benefits={selectedPlanDetails.benefits}
+                        tier={effectiveTier}
+                        buzzType={selectedPlan?.metadata.buzzType}
+                      />
+                    </Paper>
+                  )}
+                </Stack>
+
+                <Stack gap="xs">
+                  <Title order={4}>3. How many months?</Title>
+                  <SegmentedControl
+                    size="md"
+                    value={String(months)}
+                    onChange={(value) => setMonths(Number(value) as GiftMonths)}
+                    disabled={blocked}
+                    data={giftMonthsOptions.map((m) => ({
+                      value: String(m),
+                      label: `${m} month${m === 1 ? '' : 's'}`,
+                    }))}
+                  />
+                </Stack>
+
+                <Stack gap="xs">
+                  <Title order={4}>4. Add a personal touch</Title>
+                  <Textarea
+                    placeholder="Enjoy the membership!"
+                    maxLength={500}
+                    autosize
+                    minRows={2}
+                    value={message}
+                    onChange={(e) => setMessage(e.currentTarget.value)}
+                  />
+                  <Switch
+                    label="Gift anonymously"
+                    description="Your username won't be shown to the recipient"
+                    checked={anonymous}
+                    onChange={(e) => setAnonymous(e.currentTarget.checked)}
+                  />
+                </Stack>
+              </Stack>
+            </Grid.Col>
+
+            <Grid.Col span={{ base: 12, md: 5 }}>
+              <Stack className="sticky top-4">
+                <Card withBorder radius="md" p="lg">
+                  <Stack>
+                    <Title order={4}>Gift summary</Title>
+                    <Divider />
+                    <Group justify="space-between">
+                      <Text c="dimmed">Recipient</Text>
+                      <Text fw={500}>
+                        {recipientUsername
+                          ? `@${recipientUsername}`
+                          : recipient
+                          ? '…'
+                          : 'Not selected'}
+                      </Text>
+                    </Group>
+                    <Group justify="space-between">
+                      <Text c="dimmed">Membership</Text>
+                      <Group gap={6}>
+                        <Text fw={500}>{capitalize(effectiveTier)}</Text>
+                        {lockedTier && (
+                          <Badge size="xs" variant="light">
+                            matches theirs
+                          </Badge>
+                        )}
+                      </Group>
+                    </Group>
+                    <Group justify="space-between">
+                      <Text c="dimmed">Duration</Text>
+                      <Text fw={500}>
+                        {months} month{months === 1 ? '' : 's'}
+                      </Text>
+                    </Group>
+                    {monthlyDisplay && (
+                      <Group justify="space-between">
+                        <Text c="dimmed">Price</Text>
+                        <Text fw={500}>
+                          {monthlyDisplay}/mo × {months}
+                        </Text>
+                      </Group>
+                    )}
+                    <Divider />
+                    <Group justify="space-between">
+                      <Text fw={600} size="lg">
+                        Total
+                      </Text>
+                      <Text fw={700} size="lg">
+                        {totalDisplay ?? '—'}
+                      </Text>
+                    </Group>
+                    <Button
+                      size="lg"
+                      radius="xl"
+                      leftSection={<IconGift size={20} />}
+                      disabled={!canSubmit}
+                      loading={createCheckout.isPending}
+                      onClick={handleSubmit}
+                    >
+                      Continue to payment
+                    </Button>
+                    <Text size="xs" c="dimmed">
+                      One-time payment via Stripe. If they already have a membership, your gift adds
+                      free months to it; otherwise a membership starts for them right away — no
+                      payment details needed on their end.
+                    </Text>
+                  </Stack>
+                </Card>
+                <MembershipGiftsCard compact showGiftAction={false} />
+              </Stack>
+            </Grid.Col>
+          </Grid>
+        </Stack>
+      </Container>
+    </>
+  );
+}

--- a/src/pages/user/account.tsx
+++ b/src/pages/user/account.tsx
@@ -10,6 +10,7 @@ import { DeleteCard } from '~/components/Account/DeleteCard';
 
 import { ProfileCard } from '~/components/Account/ProfileCard';
 import { SettingsCard } from '~/components/Account/SettingsCard';
+import { MembershipGiftsCard } from '~/components/Account/MembershipGiftsCard';
 import { SubscriptionCard } from '~/components/Account/SubscriptionCard';
 import { Meta } from '~/components/Meta/Meta';
 import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
@@ -54,6 +55,7 @@ export default function Account() {
           <AccountsCard />
           <UserPaymentConfigurationCard />
           {currentUser?.subscriptionId && <SubscriptionCard />}
+          <MembershipGiftsCard />
           <PaymentMethodsCard />
           {/* {buzz && <UserReferralCodesCard />} */}
           <NotificationsCard />

--- a/src/pages/user/membership.tsx
+++ b/src/pages/user/membership.tsx
@@ -17,6 +17,7 @@ import {
   Tooltip,
 } from '@mantine/core';
 import {
+  IconGift,
   IconInfoCircle,
   IconInfoTriangleFilled,
   IconRotateClockwise,
@@ -24,6 +25,7 @@ import {
 } from '@tabler/icons-react';
 import { capitalize } from 'lodash-es';
 import { useRouter } from 'next/router';
+import { useEffect, useRef } from 'react';
 import * as z from 'zod';
 import { AlertWithIcon } from '~/components/AlertWithIcon/AlertWithIcon';
 import { BuzzEnvironmentAlert } from '~/components/Buzz/BuzzEnvironmentAlert';
@@ -61,6 +63,7 @@ import { getLoginLink } from '~/utils/login-helpers';
 import { showErrorNotification, showSuccessNotification } from '~/utils/notifications';
 import { getStripeCurrencyDisplay } from '~/utils/string-helpers';
 import { syncAccount } from '~/utils/sync-account';
+import { trpc } from '~/utils/trpc';
 import { booleanString } from '~/utils/zod-helpers';
 import styles from './membership.module.scss';
 
@@ -91,6 +94,7 @@ const querySchema = z.object({
   tier: userTierSchema.optional(),
   updated: booleanString().optional(),
   downgraded: booleanString().optional(),
+  flow: z.enum(['keep-membership']).optional(),
 });
 
 export default function UserMembership() {
@@ -131,6 +135,38 @@ export default function UserMembership() {
   const downgradedTier = query.success ? isDrowngrade && query.data?.tier : null;
   const isUpdate = query.success ? query.data?.updated : false;
   const { refreshSubscription, refreshingSubscription } = useMutatePaddle();
+
+  const queryUtils = trpc.useUtils();
+  const keepMembershipMutation = trpc.membershipGift.keepMembership.useMutation({
+    onSuccess: async (result) => {
+      if (result.kept) {
+        showSuccessNotification({
+          title: 'Membership kept',
+          message: 'Your membership will continue after your free months end.',
+        });
+        await queryUtils.subscriptions.getUserSubscription.invalidate();
+        await currentUser?.refresh();
+      } else if (result.portalUrl) {
+        // No payment method on file — send them to the Stripe portal to add one
+        window.location.assign(result.portalUrl);
+      }
+    },
+    onError: (error) =>
+      showErrorNotification({
+        title: 'Unable to keep membership',
+        error: new Error(error.message),
+      }),
+  });
+
+  const keepFlowTriggered = useRef(false);
+  const keepFlowRequested = query.success && query.data.flow === 'keep-membership';
+  useEffect(() => {
+    if (!keepFlowRequested || !features.giftMemberships || keepFlowTriggered.current) return;
+    keepFlowTriggered.current = true;
+    keepMembershipMutation.mutate();
+    router.replace('/user/membership', undefined, { shallow: true });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [keepFlowRequested, features.giftMemberships]);
 
   const handleRedirectToOtherEnvironment = () => {
     const targetDomain = otherBuzzType === 'green' ? serverDomains.green : serverDomains.red;
@@ -247,6 +283,10 @@ export default function UserMembership() {
   const isFree = meta?.tier === 'free';
   const { image, benefits } = getPlanDetails(subscription.product, features);
   const isCivitaiProvider = subscriptionPaymentProvider === PaymentProvider.Civitai;
+  const isGiftedSub = !!(
+    subscription.metadata as (SubscriptionMetadata & { membershipGiftId?: string }) | null
+  )?.membershipGiftId;
+  const showKeepMembership = features.giftMemberships && isStripe && !!subscription.cancelAt;
 
   return (
     <>
@@ -459,12 +499,35 @@ export default function UserMembership() {
                         )}
                     </Stack>
                   </Group>
-                  {subscription.cancelAt && (
+                  {subscription.cancelAt && isGiftedSub && (
+                    <Alert color="teal" icon={<IconGift size={18} />}>
+                      This membership was gifted to you — it&rsquo;s free until{' '}
+                      {new Date(subscription.cancelAt).toLocaleDateString()}. Keep it to continue
+                      your benefits after that.
+                    </Alert>
+                  )}
+                  {subscription.cancelAt && !isGiftedSub && (
                     <Text c="red">
                       Your membership will be canceled on{' '}
                       {new Date(subscription.cancelAt).toLocaleDateString()}. You will lose your
                       benefits on that date.
                     </Text>
+                  )}
+                  {showKeepMembership && (
+                    <Group gap="xs">
+                      <Button
+                        size="xs"
+                        radius="xl"
+                        leftSection={<IconGift size={14} />}
+                        loading={keepMembershipMutation.isPending}
+                        onClick={() => keepMembershipMutation.mutate()}
+                      >
+                        Keep my membership
+                      </Button>
+                      <Text size="xs" c="dimmed">
+                        Billing resumes after your free months end — you keep your benefits.
+                      </Text>
+                    </Group>
                   )}
                   {isCivitaiProvider && (
                     <Text c="yellow">

--- a/src/server/notifications/membership-gift.notifications.ts
+++ b/src/server/notifications/membership-gift.notifications.ts
@@ -10,9 +10,9 @@ export const membershipGiftNotifications = createNotificationProcessor({
       const from = details.from ? `@${details.from}` : 'Someone';
       const note = details.message ? ` They said: "${details.message}"` : '';
       return {
-        message: `${from} gifted you ${details.months} month${
-          details.months === 1 ? '' : 's'
-        } of ${details.tier} membership! 🎁${note}`,
+        message: `${from} gifted you ${details.months} month${details.months === 1 ? '' : 's'} of ${
+          details.tier
+        } membership! 🎁${note}`,
         url: '/user/membership',
       };
     },
@@ -22,9 +22,9 @@ export const membershipGiftNotifications = createNotificationProcessor({
     category: NotificationCategory.System,
     toggleable: false,
     prepareMessage: ({ details }) => ({
-      message: `Your gift of ${details.months} month${
-        details.months === 1 ? '' : 's'
-      } of ${details.tier} membership has been delivered to @${details.to}`,
+      message: `Your gift of ${details.months} month${details.months === 1 ? '' : 's'} of ${
+        details.tier
+      } membership has been delivered to @${details.to}`,
       url: '/user/membership',
     }),
   },

--- a/src/server/notifications/membership-gift.notifications.ts
+++ b/src/server/notifications/membership-gift.notifications.ts
@@ -1,0 +1,31 @@
+import { NotificationCategory } from '~/server/common/enums';
+import { createNotificationProcessor } from '~/server/notifications/base.notifications';
+
+export const membershipGiftNotifications = createNotificationProcessor({
+  'membership-gift-received': {
+    displayName: 'Membership Gift Received',
+    category: NotificationCategory.System,
+    toggleable: false,
+    prepareMessage: ({ details }) => {
+      const from = details.from ? `@${details.from}` : 'Someone';
+      const note = details.message ? ` They said: "${details.message}"` : '';
+      return {
+        message: `${from} gifted you ${details.months} month${
+          details.months === 1 ? '' : 's'
+        } of ${details.tier} membership! 🎁${note}`,
+        url: '/user/membership',
+      };
+    },
+  },
+  'membership-gift-sent': {
+    displayName: 'Membership Gift Sent',
+    category: NotificationCategory.System,
+    toggleable: false,
+    prepareMessage: ({ details }) => ({
+      message: `Your gift of ${details.months} month${
+        details.months === 1 ? '' : 's'
+      } of ${details.tier} membership has been delivered to @${details.to}`,
+      url: '/user/membership',
+    }),
+  },
+});

--- a/src/server/notifications/utils.notifications.ts
+++ b/src/server/notifications/utils.notifications.ts
@@ -8,6 +8,7 @@ import { auctionNotifications } from '~/server/notifications/auction.notificatio
 import type { BareNotification } from '~/server/notifications/base.notifications';
 import { bountyNotifications } from '~/server/notifications/bounty.notifications';
 import { buzzNotifications } from '~/server/notifications/buzz.notifications';
+import { membershipGiftNotifications } from '~/server/notifications/membership-gift.notifications';
 import { challengeNotifications } from '~/server/notifications/challenge.notifications';
 import { collectionNotifications } from '~/server/notifications/collection.notifications';
 import { commentNotifications } from '~/server/notifications/comment.notifications';
@@ -59,6 +60,7 @@ export const notificationProcessors = {
   ...comicNotifications,
   ...strikeNotifications,
   ...referralNotifications,
+  ...membershipGiftNotifications,
 };
 
 // Sort notifications by priority and group them by priority

--- a/src/server/routers/index.ts
+++ b/src/server/routers/index.ts
@@ -94,6 +94,9 @@ export const appRouter = router({
   redeemableCode: lazy(() =>
     import('~/server/routers/redeemableCode.router').then((m) => m.redeemableCodeRouter)
   ),
+  membershipGift: lazy(() =>
+    import('~/server/routers/membership-gift.router').then((m) => m.membershipGiftRouter)
+  ),
   tool: lazy(() => import('~/server/routers/tool.router').then((m) => m.toolRouter)),
   cosmeticShop: lazy(() => import('~/server/routers/cosmetic-shop.router').then((m) => m.cosmeticShopRouter)),
   creatorShop: lazy(() => import('~/server/routers/creator-shop.router').then((m) => m.creatorShopRouter)),

--- a/src/server/routers/membership-gift.router.ts
+++ b/src/server/routers/membership-gift.router.ts
@@ -1,0 +1,39 @@
+import { TRPCError } from '@trpc/server';
+import { throwAuthorizationError } from '~/server/utils/errorHandling';
+import {
+  createMembershipGiftCheckoutSchema,
+  getRecipientGiftabilitySchema,
+} from '~/server/schema/membership-gift.schema';
+import {
+  createMembershipGiftCheckout,
+  getMyMembershipGifts,
+  getRecipientGiftability,
+  keepGiftMembership,
+} from '~/server/services/membership-gift.service';
+import { protectedProcedure, router } from '~/server/trpc';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
+
+const giftProcedure = protectedProcedure
+  .meta({ requiredScope: TokenScope.Full })
+  .use(({ ctx, next }) => {
+    if (!ctx.features.giftMemberships) throw new TRPCError({ code: 'FORBIDDEN' });
+    return next();
+  });
+
+export const membershipGiftRouter = router({
+  getRecipientGiftability: giftProcedure
+    .input(getRecipientGiftabilitySchema)
+    .query(({ input }) => getRecipientGiftability(input)),
+  createCheckout: giftProcedure
+    .input(createMembershipGiftCheckoutSchema)
+    .mutation(({ input, ctx }) => {
+      if (!ctx.user.email) throw throwAuthorizationError('email required');
+      return createMembershipGiftCheckout({
+        ...input,
+        gifterId: ctx.user.id,
+        gifterEmail: ctx.user.email,
+      });
+    }),
+  getMyGifts: giftProcedure.query(({ ctx }) => getMyMembershipGifts({ userId: ctx.user.id })),
+  keepMembership: giftProcedure.mutation(({ ctx }) => keepGiftMembership({ userId: ctx.user.id })),
+});

--- a/src/server/schema/membership-gift.schema.ts
+++ b/src/server/schema/membership-gift.schema.ts
@@ -1,0 +1,21 @@
+import * as z from 'zod';
+
+export const giftableTierSchema = z.enum(['bronze', 'silver', 'gold']);
+export type GiftableTier = z.infer<typeof giftableTierSchema>;
+
+export const giftMonthsOptions = [1, 3, 6] as const;
+const giftMonthsSchema = z.union([z.literal(1), z.literal(3), z.literal(6)]);
+
+export type CreateMembershipGiftCheckoutInput = z.infer<typeof createMembershipGiftCheckoutSchema>;
+export const createMembershipGiftCheckoutSchema = z.object({
+  recipientUserId: z.number(),
+  tier: giftableTierSchema,
+  months: giftMonthsSchema,
+  message: z.string().trim().max(500).optional(),
+  anonymous: z.boolean().default(false),
+});
+
+export type GetRecipientGiftabilityInput = z.infer<typeof getRecipientGiftabilitySchema>;
+export const getRecipientGiftabilitySchema = z.object({
+  recipientUserId: z.number(),
+});

--- a/src/server/services/__tests__/membership-gift.service.test.ts
+++ b/src/server/services/__tests__/membership-gift.service.test.ts
@@ -355,6 +355,7 @@ describe('fulfillMembershipGift', () => {
     expect(mockStripe.subscriptions.update).toHaveBeenCalledWith('sub_1', {
       coupon: 'coupon_1',
       cancel_at: expectedCancelAt,
+      cancel_at_period_end: false,
     });
   });
 
@@ -369,6 +370,7 @@ describe('fulfillMembershipGift', () => {
     expect(mockStripe.subscriptions.update).toHaveBeenCalledWith('sub_1', {
       coupon: 'coupon_1',
       cancel_at: dayjs.unix(scheduled).add(3, 'month').unix(),
+      cancel_at_period_end: false,
     });
   });
 
@@ -504,9 +506,35 @@ describe('revokeMembershipGift', () => {
 
     expect(mockStripe.subscriptions.deleteDiscount).toHaveBeenCalledWith('sub_1');
     expect(mockStripe.subscriptions.del).not.toHaveBeenCalled();
+    expect(mockStripe.subscriptions.update).not.toHaveBeenCalled();
     expect(mockDbWrite.membershipGift.update).toHaveBeenCalledWith(
       expect.objectContaining({ data: { status: 'Revoked' } })
     );
+  });
+
+  it('collapses a deferred cancellation back to period-end when revoking an extended sub', async () => {
+    mockDbWrite.membershipGift.findUnique.mockResolvedValue({
+      id: 'gift_1',
+      status: 'Fulfilled',
+      recipientId: 2,
+      stripeCouponId: 'coupon_1',
+      stripeSubscriptionId: 'sub_1',
+    });
+    mockStripe.subscriptions.retrieve.mockResolvedValue({
+      id: 'sub_1',
+      status: 'active',
+      metadata: {},
+      discount: { coupon: { id: 'coupon_1' } },
+      cancel_at: dayjs().add(3, 'month').unix(),
+    });
+
+    await revokeMembershipGift({ paymentIntentId: 'pi_1', reason: 'refund' });
+
+    expect(mockStripe.subscriptions.deleteDiscount).toHaveBeenCalledWith('sub_1');
+    expect(mockStripe.subscriptions.update).toHaveBeenCalledWith('sub_1', {
+      cancel_at: '',
+      cancel_at_period_end: true,
+    });
   });
 
   it('is idempotent for already-revoked gifts', async () => {
@@ -557,7 +585,23 @@ describe('keepGiftMembership', () => {
     expect(mockStripe.subscriptions.update).toHaveBeenCalledWith('sub_1', {
       cancel_at: '',
       cancel_at_period_end: false,
-      default_payment_method: 'pm_1',
+    });
+    expect(mockStripe.paymentMethods.list).not.toHaveBeenCalled();
+  });
+
+  it('accepts a legacy default_source without setting it as the subscription payment method', async () => {
+    mockStripe.subscriptions.retrieve.mockResolvedValue(
+      cancelingStripeSub({
+        customer: { id: 'cus_2', invoice_settings: {}, default_source: 'card_legacy' },
+      })
+    );
+
+    const result = await keepGiftMembership({ userId: 2 });
+
+    expect(result).toEqual({ kept: true });
+    expect(mockStripe.subscriptions.update).toHaveBeenCalledWith('sub_1', {
+      cancel_at: '',
+      cancel_at_period_end: false,
     });
   });
 

--- a/src/server/services/__tests__/membership-gift.service.test.ts
+++ b/src/server/services/__tests__/membership-gift.service.test.ts
@@ -1,0 +1,609 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import dayjs from 'dayjs';
+
+const { mockDbWrite, mockStripe, mockCreateCustomer, mockGetPlans, mockCreateNotification } =
+  vi.hoisted(() => {
+    const mockMembershipGift = {
+      findUnique: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn(),
+      delete: vi.fn(),
+      findMany: vi.fn(),
+    };
+    const mockCustomerSubscription = {
+      findUnique: vi.fn(),
+    };
+    const mockUser = {
+      findUnique: vi.fn(),
+    };
+
+    return {
+      mockDbWrite: {
+        membershipGift: mockMembershipGift,
+        customerSubscription: mockCustomerSubscription,
+        user: mockUser,
+      },
+      mockStripe: {
+        subscriptions: {
+          retrieve: vi.fn(),
+          update: vi.fn(),
+          create: vi.fn(),
+          del: vi.fn(),
+          deleteDiscount: vi.fn(),
+        },
+        coupons: {
+          create: vi.fn(),
+          retrieve: vi.fn(),
+          del: vi.fn(),
+        },
+        checkout: {
+          sessions: {
+            create: vi.fn(),
+          },
+        },
+        billingPortal: {
+          sessions: {
+            create: vi.fn(),
+          },
+        },
+        paymentMethods: {
+          list: vi.fn(),
+        },
+      },
+      mockCreateCustomer: vi.fn().mockResolvedValue('cus_recipient'),
+      mockGetPlans: vi.fn(),
+      mockCreateNotification: vi.fn().mockResolvedValue(undefined),
+    };
+  });
+
+vi.mock('~/server/db/client', () => ({
+  dbWrite: mockDbWrite,
+  dbRead: mockDbWrite,
+}));
+
+vi.mock('~/server/utils/get-server-stripe', () => ({
+  getServerStripe: vi.fn().mockResolvedValue(mockStripe),
+}));
+
+vi.mock('~/server/services/stripe.service', () => ({
+  createCustomer: mockCreateCustomer,
+}));
+
+vi.mock('~/server/services/subscriptions.service', () => ({
+  getPlans: mockGetPlans,
+}));
+
+vi.mock('~/server/services/notification.service', () => ({
+  createNotification: mockCreateNotification,
+}));
+
+vi.mock('~/server/utils/subscription.utils', () => ({
+  invalidateSubscriptionCaches: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('~/server/auth/session-invalidation', () => ({
+  refreshSession: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('~/server/logging/client', () => ({
+  logToAxiom: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('~/server/utils/url-helpers', () => ({
+  getBaseUrl: () => 'https://civitai.com',
+}));
+
+vi.mock('~/server/utils/errorHandling', () => ({
+  throwBadRequestError: (message: string) => {
+    throw new Error(message);
+  },
+  throwNotFoundError: (message: string) => {
+    throw new Error(message);
+  },
+}));
+
+import {
+  createMembershipGiftCheckout,
+  fulfillMembershipGift,
+  getRecipientGiftability,
+  keepGiftMembership,
+  revokeMembershipGift,
+} from '~/server/services/membership-gift.service';
+
+const goldPlan = {
+  id: 'prod_gold',
+  price: { id: 'price_gold_month', unitAmount: 1000, currency: 'usd', interval: 'month' },
+  metadata: { tier: 'gold' },
+};
+
+const baseGift = {
+  id: 'gift_1',
+  gifterId: 1,
+  recipientId: 2,
+  tier: 'gold',
+  months: 3,
+  amountCents: 3000,
+  status: 'Pending',
+  message: null,
+  anonymous: false,
+  stripeCheckoutSessionId: 'cs_1',
+  stripePaymentIntentId: 'pi_1',
+  stripeCouponId: null,
+  stripeSubscriptionId: null,
+  gifter: { id: 1, username: 'gifter' },
+  recipient: { id: 2, username: 'recipient', email: 'r@x.com' },
+};
+
+const activeMonthlySub = {
+  id: 'sub_1',
+  status: 'active',
+  cancelAtPeriodEnd: false,
+  cancelAt: null,
+  currentPeriodEnd: dayjs().add(10, 'day').toDate(),
+  product: { id: 'prod_gold', provider: 'Stripe', metadata: { tier: 'gold' } },
+  price: { id: 'price_gold_month', interval: 'month' },
+};
+
+const stripeActiveSub = ({
+  cancelAtPeriodEnd = false,
+  cancelAt = null as number | null,
+  interval = 'month',
+  discount = null as any,
+} = {}) => ({
+  id: 'sub_1',
+  status: 'active',
+  cancel_at_period_end: cancelAtPeriodEnd,
+  cancel_at: cancelAt,
+  current_period_end: dayjs().add(10, 'day').unix(),
+  discount,
+  metadata: {},
+  items: { data: [{ price: { recurring: { interval } } }] },
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGetPlans.mockResolvedValue([goldPlan]);
+  mockStripe.coupons.create.mockResolvedValue({ id: 'coupon_1' });
+  mockStripe.coupons.retrieve.mockResolvedValue({ id: 'coupon_1' });
+  mockStripe.coupons.del.mockResolvedValue({});
+  mockStripe.subscriptions.update.mockResolvedValue({});
+  mockStripe.subscriptions.del.mockResolvedValue({});
+  mockStripe.subscriptions.deleteDiscount.mockResolvedValue({});
+  mockDbWrite.membershipGift.update.mockResolvedValue({});
+  mockDbWrite.membershipGift.delete.mockResolvedValue({});
+  mockCreateCustomer.mockResolvedValue('cus_recipient');
+  mockStripe.paymentMethods.list.mockResolvedValue({ data: [] });
+  mockStripe.billingPortal.sessions.create.mockResolvedValue({ url: 'https://portal.stripe/x' });
+});
+
+describe('getRecipientGiftability', () => {
+  it('returns no-subscription when there is no green row', async () => {
+    mockDbWrite.customerSubscription.findUnique.mockResolvedValue(null);
+    expect(await getRecipientGiftability({ recipientUserId: 2 })).toEqual({
+      status: 'no-subscription',
+    });
+  });
+
+  it('returns no-subscription for terminal statuses', async () => {
+    mockDbWrite.customerSubscription.findUnique.mockResolvedValue({
+      ...activeMonthlySub,
+      status: 'canceled',
+    });
+    expect(await getRecipientGiftability({ recipientUserId: 2 })).toEqual({
+      status: 'no-subscription',
+    });
+  });
+
+  it('blocks annual subscriptions', async () => {
+    mockDbWrite.customerSubscription.findUnique.mockResolvedValue({
+      ...activeMonthlySub,
+      price: { id: 'price_gold_year', interval: 'year' },
+    });
+    expect(await getRecipientGiftability({ recipientUserId: 2 })).toMatchObject({
+      status: 'blocked',
+      reason: 'annual-interval',
+    });
+  });
+
+  it('blocks billing-issue statuses', async () => {
+    mockDbWrite.customerSubscription.findUnique.mockResolvedValue({
+      ...activeMonthlySub,
+      status: 'past_due',
+    });
+    expect(await getRecipientGiftability({ recipientUserId: 2 })).toMatchObject({
+      status: 'blocked',
+      reason: 'billing-issue',
+    });
+  });
+
+  it('blocks non-Stripe green subscriptions', async () => {
+    mockDbWrite.customerSubscription.findUnique.mockResolvedValue({
+      ...activeMonthlySub,
+      product: { ...activeMonthlySub.product, provider: 'Civitai' },
+    });
+    expect(await getRecipientGiftability({ recipientUserId: 2 })).toMatchObject({
+      status: 'blocked',
+      reason: 'unsupported-provider',
+    });
+  });
+
+  it('returns active with tier for a monthly Stripe sub', async () => {
+    mockDbWrite.customerSubscription.findUnique.mockResolvedValue(activeMonthlySub);
+    expect(await getRecipientGiftability({ recipientUserId: 2 })).toMatchObject({
+      status: 'active',
+      tier: 'gold',
+    });
+  });
+});
+
+describe('createMembershipGiftCheckout', () => {
+  const input = {
+    gifterId: 1,
+    gifterEmail: 'g@x.com',
+    recipientUserId: 2,
+    tier: 'gold' as const,
+    months: 3,
+    anonymous: false,
+  };
+
+  beforeEach(() => {
+    mockDbWrite.user.findUnique.mockResolvedValue({
+      id: 2,
+      username: 'recipient',
+      bannedAt: null,
+      deletedAt: null,
+    });
+    mockDbWrite.membershipGift.create.mockResolvedValue({ id: 'gift_1' });
+    mockStripe.checkout.sessions.create.mockResolvedValue({
+      id: 'cs_1',
+      url: 'https://stripe/checkout',
+    });
+  });
+
+  it('rejects tier mismatch against an active subscription', async () => {
+    mockDbWrite.customerSubscription.findUnique.mockResolvedValue({
+      ...activeMonthlySub,
+      product: { ...activeMonthlySub.product, metadata: { tier: 'bronze' } },
+    });
+    await expect(createMembershipGiftCheckout(input)).rejects.toThrow(/bronze membership/);
+  });
+
+  it('rejects annual recipients', async () => {
+    mockDbWrite.customerSubscription.findUnique.mockResolvedValue({
+      ...activeMonthlySub,
+      price: { id: 'price_gold_year', interval: 'year' },
+    });
+    await expect(createMembershipGiftCheckout(input)).rejects.toThrow(/annual membership/);
+  });
+
+  it('creates a pending gift and a payment-mode checkout session', async () => {
+    mockDbWrite.customerSubscription.findUnique.mockResolvedValue(null);
+
+    const result = await createMembershipGiftCheckout(input);
+
+    expect(mockDbWrite.membershipGift.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ amountCents: 3000, months: 3, tier: 'gold' }),
+      })
+    );
+    const sessionArgs = mockStripe.checkout.sessions.create.mock.calls[0][0];
+    expect(sessionArgs.mode).toBe('payment');
+    expect(sessionArgs.line_items[0].quantity).toBe(3);
+    expect(sessionArgs.metadata).toEqual({ type: 'membershipGift', giftId: 'gift_1' });
+    expect(sessionArgs.payment_intent_data.metadata).toEqual({
+      type: 'membershipGift',
+      giftId: 'gift_1',
+    });
+    expect(result).toMatchObject({ giftId: 'gift_1', sessionId: 'cs_1' });
+  });
+
+  it('deletes the pending row when session creation fails', async () => {
+    mockDbWrite.customerSubscription.findUnique.mockResolvedValue(null);
+    mockStripe.checkout.sessions.create.mockRejectedValue(new Error('stripe down'));
+
+    await expect(createMembershipGiftCheckout(input)).rejects.toThrow('stripe down');
+    expect(mockDbWrite.membershipGift.delete).toHaveBeenCalledWith({ where: { id: 'gift_1' } });
+  });
+});
+
+describe('fulfillMembershipGift', () => {
+  it('bails early when the gift was already fulfilled', async () => {
+    mockDbWrite.membershipGift.findUnique.mockResolvedValue({
+      ...baseGift,
+      status: 'Fulfilled',
+    });
+    const result = await fulfillMembershipGift({ giftId: 'gift_1' });
+    expect(result).toEqual({ alreadyProcessed: true });
+    expect(mockStripe.coupons.create).not.toHaveBeenCalled();
+  });
+
+  it('extends an active monthly subscription with a 100%-off repeating coupon', async () => {
+    mockDbWrite.membershipGift.findUnique.mockResolvedValue({ ...baseGift });
+    mockDbWrite.customerSubscription.findUnique.mockResolvedValue(activeMonthlySub);
+    mockStripe.subscriptions.retrieve.mockResolvedValue(stripeActiveSub());
+
+    const result = await fulfillMembershipGift({ giftId: 'gift_1', paymentIntentId: 'pi_1' });
+
+    expect(mockStripe.coupons.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        percent_off: 100,
+        duration: 'repeating',
+        duration_in_months: 3,
+        max_redemptions: 1,
+      })
+    );
+    expect(mockStripe.subscriptions.update).toHaveBeenCalledWith('sub_1', {
+      coupon: 'coupon_1',
+    });
+    expect(mockStripe.subscriptions.create).not.toHaveBeenCalled();
+    expect(result).toMatchObject({ fulfilled: true, applied: 'extended' });
+    expect(mockDbWrite.membershipGift.update).toHaveBeenCalledWith(
+      expect.objectContaining({ data: expect.objectContaining({ status: 'Fulfilled' }) })
+    );
+    expect(mockCreateNotification).toHaveBeenCalledTimes(2);
+  });
+
+  it('defers the cancellation instead of un-canceling a cancel_at_period_end sub', async () => {
+    mockDbWrite.membershipGift.findUnique.mockResolvedValue({ ...baseGift });
+    mockDbWrite.customerSubscription.findUnique.mockResolvedValue(activeMonthlySub);
+    const sub = stripeActiveSub({ cancelAtPeriodEnd: true });
+    mockStripe.subscriptions.retrieve.mockResolvedValue(sub);
+
+    await fulfillMembershipGift({ giftId: 'gift_1' });
+
+    const expectedCancelAt = dayjs.unix(sub.current_period_end).add(3, 'month').unix();
+    expect(mockStripe.subscriptions.update).toHaveBeenCalledWith('sub_1', {
+      coupon: 'coupon_1',
+      cancel_at: expectedCancelAt,
+    });
+  });
+
+  it('pushes out an existing scheduled cancel_at by the gifted months', async () => {
+    mockDbWrite.membershipGift.findUnique.mockResolvedValue({ ...baseGift });
+    mockDbWrite.customerSubscription.findUnique.mockResolvedValue(activeMonthlySub);
+    const scheduled = dayjs().add(5, 'day').unix();
+    mockStripe.subscriptions.retrieve.mockResolvedValue(stripeActiveSub({ cancelAt: scheduled }));
+
+    await fulfillMembershipGift({ giftId: 'gift_1' });
+
+    expect(mockStripe.subscriptions.update).toHaveBeenCalledWith('sub_1', {
+      coupon: 'coupon_1',
+      cancel_at: dayjs.unix(scheduled).add(3, 'month').unix(),
+    });
+  });
+
+  it('marks the gift Failed when the recipient sub is not billed monthly', async () => {
+    mockDbWrite.membershipGift.findUnique.mockResolvedValue({ ...baseGift });
+    mockDbWrite.customerSubscription.findUnique.mockResolvedValue(activeMonthlySub);
+    mockStripe.subscriptions.retrieve.mockResolvedValue(stripeActiveSub({ interval: 'year' }));
+
+    const result = await fulfillMembershipGift({ giftId: 'gift_1' });
+
+    expect(result).toMatchObject({ fulfilled: false });
+    expect(mockDbWrite.membershipGift.update).toHaveBeenCalledWith(
+      expect.objectContaining({ data: { status: 'Failed' } })
+    );
+    expect(mockStripe.subscriptions.update).not.toHaveBeenCalled();
+  });
+
+  it('creates a gift subscription when the recipient has none', async () => {
+    mockDbWrite.membershipGift.findUnique.mockResolvedValue({ ...baseGift });
+    mockDbWrite.customerSubscription.findUnique.mockResolvedValue(null);
+    mockStripe.subscriptions.create.mockResolvedValue({ id: 'sub_new', status: 'active' });
+
+    const result = await fulfillMembershipGift({ giftId: 'gift_1' });
+
+    const createArgs = mockStripe.subscriptions.create.mock.calls[0][0];
+    expect(createArgs.customer).toBe('cus_recipient');
+    expect(createArgs.coupon).toBe('coupon_1');
+    expect(createArgs.items).toEqual([{ price: 'price_gold_month' }]);
+    expect(createArgs.payment_behavior).toBe('default_incomplete');
+    expect(createArgs.metadata).toMatchObject({ membershipGiftId: 'gift_1' });
+    // cancel_at ≈ now + 3 months
+    expect(createArgs.cancel_at).toBeGreaterThan(dayjs().add(89, 'day').unix());
+    expect(result).toMatchObject({ fulfilled: true, applied: 'created' });
+  });
+
+  it('falls back to creating a subscription when the Stripe sub is canceled despite a live DB row', async () => {
+    mockDbWrite.membershipGift.findUnique.mockResolvedValue({ ...baseGift });
+    mockDbWrite.customerSubscription.findUnique.mockResolvedValue(activeMonthlySub);
+    mockStripe.subscriptions.retrieve.mockResolvedValue({
+      ...stripeActiveSub(),
+      status: 'canceled',
+    });
+    mockStripe.subscriptions.create.mockResolvedValue({ id: 'sub_new', status: 'active' });
+
+    const result = await fulfillMembershipGift({ giftId: 'gift_1' });
+
+    expect(mockStripe.subscriptions.create).toHaveBeenCalled();
+    expect(result).toMatchObject({ fulfilled: true, applied: 'created' });
+  });
+
+  it('reuses a previously created subscription on retry', async () => {
+    mockDbWrite.membershipGift.findUnique.mockResolvedValue({
+      ...baseGift,
+      stripeSubscriptionId: 'sub_prev',
+      stripeCouponId: 'coupon_1',
+    });
+    mockDbWrite.customerSubscription.findUnique.mockResolvedValue(null);
+    mockStripe.subscriptions.retrieve.mockResolvedValue({
+      id: 'sub_prev',
+      status: 'active',
+      metadata: { membershipGiftId: 'gift_1' },
+    });
+
+    const result = await fulfillMembershipGift({ giftId: 'gift_1' });
+
+    expect(mockStripe.subscriptions.create).not.toHaveBeenCalled();
+    expect(result).toMatchObject({ fulfilled: true, stripeSubscriptionId: 'sub_prev' });
+  });
+
+  it('marks Failed for a non-Stripe green subscription', async () => {
+    mockDbWrite.membershipGift.findUnique.mockResolvedValue({ ...baseGift });
+    mockDbWrite.customerSubscription.findUnique.mockResolvedValue({
+      ...activeMonthlySub,
+      product: { ...activeMonthlySub.product, provider: 'Civitai' },
+    });
+
+    const result = await fulfillMembershipGift({ giftId: 'gift_1' });
+
+    expect(result).toMatchObject({ fulfilled: false });
+    expect(mockDbWrite.membershipGift.update).toHaveBeenCalledWith(
+      expect.objectContaining({ data: { status: 'Failed' } })
+    );
+  });
+});
+
+describe('revokeMembershipGift', () => {
+  it('returns false when the payment intent is not a gift', async () => {
+    mockDbWrite.membershipGift.findUnique.mockResolvedValue(null);
+    expect(await revokeMembershipGift({ paymentIntentId: 'pi_x', reason: 'refund' })).toBe(false);
+  });
+
+  it('cancels a gift-created subscription and deletes the coupon', async () => {
+    mockDbWrite.membershipGift.findUnique.mockResolvedValue({
+      id: 'gift_1',
+      status: 'Fulfilled',
+      recipientId: 2,
+      stripeCouponId: 'coupon_1',
+      stripeSubscriptionId: 'sub_new',
+    });
+    mockStripe.subscriptions.retrieve.mockResolvedValue({
+      id: 'sub_new',
+      status: 'active',
+      metadata: { membershipGiftId: 'gift_1' },
+      discount: null,
+    });
+
+    const result = await revokeMembershipGift({ paymentIntentId: 'pi_1', reason: 'refund' });
+
+    expect(result).toBe(true);
+    expect(mockStripe.subscriptions.del).toHaveBeenCalledWith('sub_new');
+    expect(mockStripe.coupons.del).toHaveBeenCalledWith('coupon_1');
+    expect(mockDbWrite.membershipGift.update).toHaveBeenCalledWith(
+      expect.objectContaining({ data: { status: 'Refunded' } })
+    );
+  });
+
+  it('removes the discount from an extended subscription without canceling it', async () => {
+    mockDbWrite.membershipGift.findUnique.mockResolvedValue({
+      id: 'gift_1',
+      status: 'Fulfilled',
+      recipientId: 2,
+      stripeCouponId: 'coupon_1',
+      stripeSubscriptionId: 'sub_1',
+    });
+    mockStripe.subscriptions.retrieve.mockResolvedValue({
+      id: 'sub_1',
+      status: 'active',
+      metadata: {},
+      discount: { coupon: { id: 'coupon_1' } },
+    });
+
+    await revokeMembershipGift({ paymentIntentId: 'pi_1', reason: 'chargeback' });
+
+    expect(mockStripe.subscriptions.deleteDiscount).toHaveBeenCalledWith('sub_1');
+    expect(mockStripe.subscriptions.del).not.toHaveBeenCalled();
+    expect(mockDbWrite.membershipGift.update).toHaveBeenCalledWith(
+      expect.objectContaining({ data: { status: 'Revoked' } })
+    );
+  });
+
+  it('is idempotent for already-revoked gifts', async () => {
+    mockDbWrite.membershipGift.findUnique.mockResolvedValue({
+      id: 'gift_1',
+      status: 'Refunded',
+      recipientId: 2,
+      stripeCouponId: 'coupon_1',
+      stripeSubscriptionId: 'sub_1',
+    });
+
+    expect(await revokeMembershipGift({ paymentIntentId: 'pi_1', reason: 'refund' })).toBe(true);
+    expect(mockStripe.subscriptions.retrieve).not.toHaveBeenCalled();
+    expect(mockDbWrite.membershipGift.update).not.toHaveBeenCalled();
+  });
+});
+
+describe('keepGiftMembership', () => {
+  const cancelingStripeSub = ({
+    customer = {
+      id: 'cus_2',
+      invoice_settings: { default_payment_method: null },
+      default_source: null,
+    } as any,
+  } = {}) => ({
+    ...stripeActiveSub({ cancelAt: dayjs().add(2, 'month').unix() }),
+    customer,
+  });
+
+  beforeEach(() => {
+    mockDbWrite.customerSubscription.findUnique.mockResolvedValue({ ...activeMonthlySub });
+  });
+
+  it('clears the scheduled cancellation when a default payment method exists', async () => {
+    mockStripe.subscriptions.retrieve.mockResolvedValue(
+      cancelingStripeSub({
+        customer: {
+          id: 'cus_2',
+          invoice_settings: { default_payment_method: 'pm_1' },
+          default_source: null,
+        },
+      })
+    );
+
+    const result = await keepGiftMembership({ userId: 2 });
+
+    expect(result).toEqual({ kept: true });
+    expect(mockStripe.subscriptions.update).toHaveBeenCalledWith('sub_1', {
+      cancel_at: '',
+      cancel_at_period_end: false,
+      default_payment_method: 'pm_1',
+    });
+  });
+
+  it('falls back to an attached card when no default payment method is set', async () => {
+    mockStripe.subscriptions.retrieve.mockResolvedValue(cancelingStripeSub());
+    mockStripe.paymentMethods.list.mockResolvedValue({ data: [{ id: 'pm_2' }] });
+
+    const result = await keepGiftMembership({ userId: 2 });
+
+    expect(result).toEqual({ kept: true });
+    expect(mockStripe.subscriptions.update).toHaveBeenCalledWith(
+      'sub_1',
+      expect.objectContaining({ default_payment_method: 'pm_2' })
+    );
+  });
+
+  it('returns a billing-portal URL when there is no payment method at all', async () => {
+    mockStripe.subscriptions.retrieve.mockResolvedValue(cancelingStripeSub());
+
+    const result = await keepGiftMembership({ userId: 2 });
+
+    expect(result).toEqual({ kept: false, portalUrl: 'https://portal.stripe/x' });
+    expect(mockStripe.subscriptions.update).not.toHaveBeenCalled();
+    expect(mockStripe.billingPortal.sessions.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        customer: 'cus_2',
+        flow_data: { type: 'payment_method_update' },
+      })
+    );
+  });
+
+  it('is a no-op when nothing is scheduled to cancel', async () => {
+    mockStripe.subscriptions.retrieve.mockResolvedValue({
+      ...stripeActiveSub(),
+      customer: { id: 'cus_2', invoice_settings: {}, default_source: null },
+    });
+
+    const result = await keepGiftMembership({ userId: 2 });
+
+    expect(result).toEqual({ kept: true });
+    expect(mockStripe.subscriptions.update).not.toHaveBeenCalled();
+  });
+
+  it('throws when the user has no live green subscription', async () => {
+    mockDbWrite.customerSubscription.findUnique.mockResolvedValue(null);
+
+    await expect(keepGiftMembership({ userId: 2 })).rejects.toThrow('No active membership');
+  });
+});

--- a/src/server/services/feature-flags.service.ts
+++ b/src/server/services/feature-flags.service.ts
@@ -1,4 +1,5 @@
 import type { IncomingMessage } from 'http';
+import type * as FliptClient from '~/server/flipt/client';
 import { camelCase } from 'lodash-es';
 import type { NextApiRequest } from 'next';
 import type { SessionUser } from '~/types/session';
@@ -561,7 +562,7 @@ function checkRegionAccess(
 }
 
 // Lazy-loaded flipt module (server-only — avoids pulling ~/env/server into client bundle)
-type FliptModule = typeof import('~/server/flipt/client');
+type FliptModule = typeof FliptClient;
 let _fliptModule: FliptModule | null = null;
 let _fliptLoading: Promise<FliptModule | null> | null = null;
 

--- a/src/server/services/feature-flags.service.ts
+++ b/src/server/services/feature-flags.service.ts
@@ -354,6 +354,7 @@ const featureFlags = createFeatureFlags({
   annualMemberships: ['dev'],
   disablePayments: ['blue', 'red', 'public'],
   prepaidMemberships: ['public'],
+  giftMemberships: { availability: ['mod'], fliptKey: 'gift-memberships' },
   coinbasePayments: [],
   emerchantpayPayments: ['public'],
   nowpaymentPayments: [],

--- a/src/server/services/membership-gift.service.ts
+++ b/src/server/services/membership-gift.service.ts
@@ -1,0 +1,621 @@
+import type { Stripe } from 'stripe';
+import dayjs from '~/shared/utils/dayjs';
+import { NotificationCategory } from '~/server/common/enums';
+import { dbWrite } from '~/server/db/client';
+import { logToAxiom } from '~/server/logging/client';
+import type {
+  CreateMembershipGiftCheckoutInput,
+  GiftableTier,
+} from '~/server/schema/membership-gift.schema';
+import type { SubscriptionProductMetadata } from '~/server/schema/subscriptions.schema';
+import { refreshSession } from '~/server/auth/session-invalidation';
+import { createNotification } from '~/server/services/notification.service';
+import { getPlans } from '~/server/services/subscriptions.service';
+import { createCustomer } from '~/server/services/stripe.service';
+import { throwBadRequestError, throwNotFoundError } from '~/server/utils/errorHandling';
+import { getServerStripe } from '~/server/utils/get-server-stripe';
+import { invalidateSubscriptionCaches } from '~/server/utils/subscription.utils';
+import { getBaseUrl } from '~/server/utils/url-helpers';
+import { MembershipGiftStatus, PaymentProvider } from '~/shared/utils/prisma/enums';
+
+const baseUrl = getBaseUrl('green'); // Stripe lives in civitai green
+
+const log = (data: MixedObject) =>
+  logToAxiom({ name: 'membership-gift', ...data }, 'webhooks').catch(() => null);
+
+// Stripe subscription statuses that mean the row is dead and a fresh gift sub can be created.
+const TERMINAL_STATUSES = ['canceled', 'incomplete_expired'];
+// Statuses a gift coupon can safely be applied to.
+const EXTENDABLE_STATUSES = ['active', 'trialing'];
+
+export type RecipientGiftability =
+  | { status: 'no-subscription' }
+  | { status: 'active'; tier: GiftableTier; renewsAt: Date; cancelsAtPeriodEnd: boolean }
+  | { status: 'blocked'; reason: 'annual-interval' | 'billing-issue' | 'unsupported-provider' };
+
+async function getGreenSubscription(userId: number) {
+  // dbWrite: fulfillment runs off webhooks where replication lag matters
+  return dbWrite.customerSubscription.findUnique({
+    where: { userId_buzzType: { userId, buzzType: 'green' } },
+    select: {
+      id: true,
+      status: true,
+      cancelAtPeriodEnd: true,
+      cancelAt: true,
+      currentPeriodEnd: true,
+      product: { select: { id: true, provider: true, metadata: true } },
+      price: { select: { id: true, interval: true } },
+    },
+  });
+}
+
+export async function getRecipientGiftability({
+  recipientUserId,
+}: {
+  recipientUserId: number;
+}): Promise<RecipientGiftability> {
+  const subscription = await getGreenSubscription(recipientUserId);
+  if (!subscription || TERMINAL_STATUSES.includes(subscription.status)) {
+    return { status: 'no-subscription' };
+  }
+
+  if (subscription.product.provider !== PaymentProvider.Stripe) {
+    return { status: 'blocked', reason: 'unsupported-provider' };
+  }
+
+  if (!EXTENDABLE_STATUSES.includes(subscription.status)) {
+    return { status: 'blocked', reason: 'billing-issue' };
+  }
+
+  if (subscription.price.interval !== 'month') {
+    return { status: 'blocked', reason: 'annual-interval' };
+  }
+
+  const productMeta = subscription.product.metadata as SubscriptionProductMetadata;
+  return {
+    status: 'active',
+    tier: productMeta.tier as GiftableTier,
+    renewsAt: subscription.currentPeriodEnd,
+    cancelsAtPeriodEnd: subscription.cancelAtPeriodEnd || !!subscription.cancelAt,
+  };
+}
+
+async function getTierMonthlyPrice(tier: GiftableTier) {
+  const plans = await getPlans({ paymentProvider: PaymentProvider.Stripe, interval: 'month' });
+  const plan = plans.find((p) => p.metadata.tier === tier);
+  if (!plan?.price?.unitAmount) {
+    throw throwNotFoundError(`No active monthly Stripe price found for tier: ${tier}`);
+  }
+  return {
+    productId: plan.id,
+    priceId: plan.price.id,
+    unitAmount: plan.price.unitAmount,
+    currency: plan.price.currency,
+    productMeta: plan.metadata,
+  };
+}
+
+export async function createMembershipGiftCheckout({
+  gifterId,
+  gifterEmail,
+  recipientUserId,
+  tier,
+  months,
+  message,
+  anonymous,
+}: CreateMembershipGiftCheckoutInput & { gifterId: number; gifterEmail: string }) {
+  const stripe = await getServerStripe();
+  if (!stripe) throw throwBadRequestError('Stripe is not available');
+
+  const recipient = await dbWrite.user.findUnique({
+    where: { id: recipientUserId },
+    select: { id: true, username: true, bannedAt: true, deletedAt: true },
+  });
+  if (!recipient || recipient.deletedAt) throw throwNotFoundError('Recipient not found');
+  if (recipient.bannedAt) throw throwBadRequestError('This user cannot receive gifts');
+
+  const giftability = await getRecipientGiftability({ recipientUserId });
+  if (giftability.status === 'blocked') {
+    const reasons: Record<typeof giftability.reason, string> = {
+      'annual-interval':
+        'This user is on an annual membership, which cannot receive gifted months yet',
+      'billing-issue': "This user's membership has a billing issue and cannot receive gifts",
+      'unsupported-provider': "This user's membership cannot receive gifted months",
+    };
+    throw throwBadRequestError(reasons[giftability.reason]);
+  }
+  if (giftability.status === 'active' && giftability.tier !== tier) {
+    throw throwBadRequestError(
+      `This user already has a ${giftability.tier} membership — gifted months must match their current tier`
+    );
+  }
+
+  const { productId, unitAmount, currency } = await getTierMonthlyPrice(tier);
+
+  const gift = await dbWrite.membershipGift.create({
+    data: {
+      gifterId,
+      recipientId: recipientUserId,
+      tier,
+      months,
+      amountCents: unitAmount * months,
+      message,
+      anonymous,
+    },
+    select: { id: true },
+  });
+
+  const customerId = await createCustomer({ id: gifterId, email: gifterEmail });
+  const metadata = { type: 'membershipGift', giftId: gift.id };
+
+  let session: Stripe.Checkout.Session;
+  try {
+    session = await stripe.checkout.sessions.create({
+      customer: customerId,
+      mode: 'payment',
+      line_items: [
+        {
+          price_data: { currency, unit_amount: unitAmount, product: productId },
+          quantity: months,
+        },
+      ],
+      success_url: `${baseUrl}/payment/success?cid=${customerId.slice(-8)}&gift=true`,
+      cancel_url: `${baseUrl}/pricing?canceled=true`,
+      metadata,
+      payment_intent_data: { metadata },
+    });
+  } catch (error) {
+    // No session — the row can never be fulfilled, so don't leave a dangling Pending gift
+    await dbWrite.membershipGift.delete({ where: { id: gift.id } }).catch(() => null);
+    throw error;
+  }
+
+  await dbWrite.membershipGift.update({
+    where: { id: gift.id },
+    data: { stripeCheckoutSessionId: session.id },
+  });
+
+  return { giftId: gift.id, sessionId: session.id, url: session.url };
+}
+
+async function getOrCreateGiftCoupon({
+  stripe,
+  giftId,
+  existingCouponId,
+  tier,
+  months,
+}: {
+  stripe: Stripe;
+  giftId: string;
+  existingCouponId: string | null;
+  tier: string;
+  months: number;
+}) {
+  if (existingCouponId) {
+    return stripe.coupons.retrieve(existingCouponId);
+  }
+  return stripe.coupons.create({
+    percent_off: 100,
+    duration: 'repeating',
+    duration_in_months: months,
+    max_redemptions: 1,
+    name: `Gifted ${tier} membership (${months}mo)`,
+    metadata: { giftId },
+  });
+}
+
+/**
+ * Applies a paid gift to the recipient. Called from the Stripe webhook on
+ * checkout.session.completed — must be safe to re-run (Stripe retries on non-2xx):
+ * Fulfilled/Refunded/Revoked rows bail early, and both the coupon and the created
+ * subscription are re-used from the row when a prior attempt got partway through.
+ */
+export async function fulfillMembershipGift({
+  giftId,
+  paymentIntentId,
+}: {
+  giftId: string;
+  paymentIntentId?: string;
+}) {
+  const stripe = await getServerStripe();
+  if (!stripe) throw throwBadRequestError('Stripe is not available');
+
+  const gift = await dbWrite.membershipGift.findUnique({
+    where: { id: giftId },
+    include: {
+      gifter: { select: { id: true, username: true } },
+      recipient: { select: { id: true, username: true, email: true } },
+    },
+  });
+  if (!gift) throw throwNotFoundError(`MembershipGift not found: ${giftId}`);
+
+  // Failed rows stay retryable: a webhook redelivery is a legitimate recovery path
+  if (gift.status !== MembershipGiftStatus.Pending && gift.status !== MembershipGiftStatus.Failed) {
+    return { alreadyProcessed: true as const };
+  }
+
+  if (paymentIntentId && gift.stripePaymentIntentId !== paymentIntentId) {
+    await dbWrite.membershipGift.update({
+      where: { id: gift.id },
+      data: { stripePaymentIntentId: paymentIntentId },
+    });
+  }
+
+  const markFailed = async (reason: string) => {
+    await dbWrite.membershipGift.update({
+      where: { id: gift.id },
+      data: { status: MembershipGiftStatus.Failed },
+    });
+    await log({
+      type: 'error',
+      stage: 'fulfillment',
+      giftId: gift.id,
+      gifterId: gift.gifterId,
+      recipientId: gift.recipientId,
+      message: `Gift fulfillment needs support attention: ${reason}`,
+    });
+    return { fulfilled: false as const, reason };
+  };
+
+  const subscription = await getGreenSubscription(gift.recipientId);
+  const hasLiveRow = !!subscription && !TERMINAL_STATUSES.includes(subscription.status);
+
+  let stripeSubscriptionId: string;
+  let applied: 'extended' | 'created';
+
+  if (hasLiveRow) {
+    if (subscription.product.provider !== PaymentProvider.Stripe) {
+      return markFailed('recipient has a non-Stripe green subscription');
+    }
+
+    // The DB row can lag Stripe — the subscription itself is the source of truth here
+    const stripeSub = await stripe.subscriptions.retrieve(subscription.id);
+    if (TERMINAL_STATUSES.includes(stripeSub.status)) {
+      const result = await createGiftSubscription({ stripe, gift });
+      if (!result.ok) return markFailed(result.reason);
+      stripeSubscriptionId = result.subscriptionId;
+      applied = 'created';
+    } else {
+      if (!EXTENDABLE_STATUSES.includes(stripeSub.status)) {
+        return markFailed(`recipient subscription is in status "${stripeSub.status}"`);
+      }
+      if (stripeSub.items.data[0]?.price.recurring?.interval !== 'month') {
+        return markFailed('recipient subscription is not billed monthly');
+      }
+
+      const coupon = await getOrCreateGiftCoupon({
+        stripe,
+        giftId: gift.id,
+        existingCouponId: gift.stripeCouponId,
+        tier: gift.tier,
+        months: gift.months,
+      });
+      await dbWrite.membershipGift.update({
+        where: { id: gift.id },
+        data: { stripeCouponId: coupon.id },
+      });
+
+      // API 2022-11-15 has a single discount slot — applying our coupon replaces any
+      // existing one. 100%-off wins for the user during the gift, but log the
+      // replacement so support can restore a long-lived discount if one existed.
+      if (stripeSub.discount) {
+        await log({
+          type: 'warning',
+          stage: 'fulfillment',
+          giftId: gift.id,
+          message: `replacing existing discount (coupon ${stripeSub.discount.coupon?.id}) on subscription ${stripeSub.id}`,
+        });
+      }
+
+      const updateParams: Stripe.SubscriptionUpdateParams = { coupon: coupon.id };
+      // Recipient had canceled (or scheduled a cancel): defer the cancellation past the
+      // gifted months instead of un-canceling — the free months happen, then the sub
+      // still ends. Billing never resumes without an explicit reinstate.
+      const scheduledEnd = stripeSub.cancel_at
+        ? stripeSub.cancel_at
+        : stripeSub.cancel_at_period_end
+        ? stripeSub.current_period_end
+        : null;
+      if (scheduledEnd) {
+        updateParams.cancel_at = dayjs.unix(scheduledEnd).add(gift.months, 'month').unix();
+      }
+
+      await stripe.subscriptions.update(stripeSub.id, updateParams);
+      stripeSubscriptionId = stripeSub.id;
+      applied = 'extended';
+    }
+  } else {
+    const result = await createGiftSubscription({ stripe, gift });
+    if (!result.ok) return markFailed(result.reason);
+    stripeSubscriptionId = result.subscriptionId;
+    applied = 'created';
+  }
+
+  await dbWrite.membershipGift.update({
+    where: { id: gift.id },
+    data: {
+      status: MembershipGiftStatus.Fulfilled,
+      fulfilledAt: new Date(),
+      stripeSubscriptionId,
+    },
+  });
+
+  // Webhooks for the subscription change will also bust these, but don't rely on ordering
+  await invalidateSubscriptionCaches(gift.recipientId);
+  await refreshSession(gift.recipientId);
+
+  await createNotification({
+    type: 'membership-gift-received',
+    userId: gift.recipientId,
+    category: NotificationCategory.System,
+    key: `membership-gift-received:${gift.id}`,
+    details: {
+      giftId: gift.id,
+      tier: gift.tier,
+      months: gift.months,
+      message: gift.message,
+      from: gift.anonymous ? null : gift.gifter.username,
+    },
+  });
+  await createNotification({
+    type: 'membership-gift-sent',
+    userId: gift.gifterId,
+    category: NotificationCategory.System,
+    key: `membership-gift-sent:${gift.id}`,
+    details: {
+      giftId: gift.id,
+      tier: gift.tier,
+      months: gift.months,
+      to: gift.recipient.username,
+    },
+  });
+
+  await log({
+    type: 'info',
+    stage: 'fulfillment',
+    giftId: gift.id,
+    applied,
+    stripeSubscriptionId,
+  });
+
+  return { fulfilled: true as const, applied, stripeSubscriptionId };
+}
+
+async function createGiftSubscription({
+  stripe,
+  gift,
+}: {
+  stripe: Stripe;
+  gift: {
+    id: string;
+    tier: string;
+    months: number;
+    recipientId: number;
+    stripeCouponId: string | null;
+    stripeSubscriptionId: string | null;
+    recipient: { email: string | null };
+  };
+}): Promise<{ ok: true; subscriptionId: string } | { ok: false; reason: string }> {
+  // Re-entrancy: a prior attempt may have created the subscription before the row update
+  if (gift.stripeSubscriptionId) {
+    const existing = await stripe.subscriptions.retrieve(gift.stripeSubscriptionId);
+    if (existing.metadata?.membershipGiftId === gift.id) {
+      return { ok: true, subscriptionId: existing.id };
+    }
+  }
+
+  if (!gift.recipient.email) {
+    return { ok: false, reason: 'recipient has no email — cannot create a Stripe customer' };
+  }
+
+  const { priceId } = await getTierMonthlyPrice(gift.tier as GiftableTier);
+  const customerId = await createCustomer({ id: gift.recipientId, email: gift.recipient.email });
+
+  const coupon = await getOrCreateGiftCoupon({
+    stripe,
+    giftId: gift.id,
+    existingCouponId: gift.stripeCouponId,
+    tier: gift.tier,
+    months: gift.months,
+  });
+  await dbWrite.membershipGift.update({
+    where: { id: gift.id },
+    data: { stripeCouponId: coupon.id },
+  });
+
+  // Every invoice inside the gift window is $0 (100%-off coupon), so no payment method
+  // is needed; cancel_at guarantees the recipient is never billed. default_incomplete
+  // is a guard: if Stripe ever computed a non-zero amount due, the sub parks as
+  // `incomplete` instead of erroring or charging.
+  const subscription = await stripe.subscriptions.create({
+    customer: customerId,
+    items: [{ price: priceId }],
+    coupon: coupon.id,
+    cancel_at: dayjs().add(gift.months, 'month').unix(),
+    payment_behavior: 'default_incomplete',
+    metadata: { membershipGiftId: gift.id, membershipGift: 'true' },
+  });
+
+  if (!EXTENDABLE_STATUSES.includes(subscription.status)) {
+    await log({
+      type: 'error',
+      stage: 'fulfillment',
+      giftId: gift.id,
+      message: `gift subscription ${subscription.id} created in unexpected status "${subscription.status}"`,
+    });
+  }
+
+  return { ok: true, subscriptionId: subscription.id };
+}
+
+/**
+ * Undo a gift after a refund or chargeback on the gifter's payment.
+ * Best-effort by design: Buzz already granted for elapsed months is not clawed back.
+ * Returns false when the payment intent doesn't belong to a gift.
+ */
+export async function revokeMembershipGift({
+  paymentIntentId,
+  reason,
+}: {
+  paymentIntentId: string;
+  reason: 'refund' | 'chargeback';
+}) {
+  const gift = await dbWrite.membershipGift.findUnique({
+    where: { stripePaymentIntentId: paymentIntentId },
+    select: {
+      id: true,
+      status: true,
+      recipientId: true,
+      stripeCouponId: true,
+      stripeSubscriptionId: true,
+    },
+  });
+  if (!gift) return false;
+
+  const newStatus =
+    reason === 'refund' ? MembershipGiftStatus.Refunded : MembershipGiftStatus.Revoked;
+
+  if (
+    gift.status === MembershipGiftStatus.Refunded ||
+    gift.status === MembershipGiftStatus.Revoked
+  ) {
+    return true;
+  }
+
+  const stripe = await getServerStripe();
+  if (!stripe) throw throwBadRequestError('Stripe is not available');
+
+  if (gift.status === MembershipGiftStatus.Fulfilled && gift.stripeSubscriptionId) {
+    const subscription = await stripe.subscriptions
+      .retrieve(gift.stripeSubscriptionId)
+      .catch(() => null);
+
+    if (subscription && !TERMINAL_STATUSES.includes(subscription.status)) {
+      if (subscription.metadata?.membershipGiftId === gift.id) {
+        // Gift-created subscription — the whole thing exists only because of this payment
+        await stripe.subscriptions.del(subscription.id);
+      } else if (gift.stripeCouponId && subscription.discount?.coupon?.id === gift.stripeCouponId) {
+        // Existing subscription that got our coupon — strip the remaining free months
+        await stripe.subscriptions.deleteDiscount(subscription.id);
+      }
+    }
+  }
+
+  if (gift.stripeCouponId) {
+    await stripe.coupons.del(gift.stripeCouponId).catch(() => null);
+  }
+
+  await dbWrite.membershipGift.update({
+    where: { id: gift.id },
+    data: { status: newStatus },
+  });
+
+  await invalidateSubscriptionCaches(gift.recipientId);
+  await refreshSession(gift.recipientId);
+
+  await log({
+    type: 'warning',
+    stage: 'revoke',
+    giftId: gift.id,
+    reason,
+    paymentIntentId,
+  });
+
+  return true;
+}
+
+/**
+ * "Keep my membership": clears a scheduled cancellation (gift subs use cancel_at,
+ * regular cancels use cancel_at_period_end) so billing resumes after the free months.
+ * Requires a usable payment method — without one, returns a billing-portal URL so the
+ * user can add a card, then retry.
+ */
+export async function keepGiftMembership({ userId }: { userId: number }) {
+  const stripe = await getServerStripe();
+  if (!stripe) throw throwBadRequestError('Stripe is not available');
+
+  const subscription = await getGreenSubscription(userId);
+  if (!subscription || TERMINAL_STATUSES.includes(subscription.status)) {
+    throw throwNotFoundError('No active membership found');
+  }
+  if (subscription.product.provider !== PaymentProvider.Stripe) {
+    throw throwBadRequestError('This membership is not managed by Stripe');
+  }
+
+  const stripeSub = await stripe.subscriptions.retrieve(subscription.id, {
+    expand: ['customer'],
+  });
+  if (TERMINAL_STATUSES.includes(stripeSub.status)) {
+    throw throwNotFoundError('No active membership found');
+  }
+  if (!stripeSub.cancel_at && !stripeSub.cancel_at_period_end) {
+    return { kept: true as const };
+  }
+
+  const customer = stripeSub.customer as Stripe.Customer;
+  let paymentMethod = customer.invoice_settings?.default_payment_method ?? customer.default_source;
+  if (!paymentMethod) {
+    const methods = await stripe.paymentMethods.list({ customer: customer.id, type: 'card' });
+    paymentMethod = methods.data[0]?.id ?? null;
+  }
+  if (!paymentMethod) {
+    const portal = await stripe.billingPortal.sessions.create({
+      customer: customer.id,
+      return_url: `${baseUrl}/user/membership?flow=keep-membership`,
+      flow_data: { type: 'payment_method_update' },
+    });
+    return { kept: false as const, portalUrl: portal.url };
+  }
+
+  await stripe.subscriptions.update(stripeSub.id, {
+    cancel_at: '',
+    cancel_at_period_end: false,
+    default_payment_method: typeof paymentMethod === 'string' ? paymentMethod : paymentMethod.id,
+  });
+
+  await invalidateSubscriptionCaches(userId);
+  await refreshSession(userId);
+
+  await log({ type: 'info', stage: 'keep', userId, stripeSubscriptionId: stripeSub.id });
+
+  return { kept: true as const };
+}
+
+export async function getMyMembershipGifts({ userId }: { userId: number }) {
+  const [sent, received] = await Promise.all([
+    dbWrite.membershipGift.findMany({
+      where: { gifterId: userId, status: { not: MembershipGiftStatus.Pending } },
+      select: {
+        id: true,
+        tier: true,
+        months: true,
+        status: true,
+        createdAt: true,
+        fulfilledAt: true,
+        recipient: { select: { id: true, username: true } },
+      },
+      orderBy: { createdAt: 'desc' },
+    }),
+    dbWrite.membershipGift.findMany({
+      where: { recipientId: userId, status: MembershipGiftStatus.Fulfilled },
+      select: {
+        id: true,
+        tier: true,
+        months: true,
+        message: true,
+        anonymous: true,
+        fulfilledAt: true,
+        gifter: { select: { id: true, username: true } },
+      },
+      orderBy: { fulfilledAt: 'desc' },
+    }),
+  ]);
+
+  return {
+    sent,
+    received: received.map((g) => ({
+      ...g,
+      gifter: g.anonymous ? null : g.gifter,
+    })),
+  };
+}

--- a/src/server/services/membership-gift.service.ts
+++ b/src/server/services/membership-gift.service.ts
@@ -318,6 +318,9 @@ export async function fulfillMembershipGift({
         : null;
       if (scheduledEnd) {
         updateParams.cancel_at = dayjs.unix(scheduledEnd).add(gift.months, 'month').unix();
+        // cancel_at and cancel_at_period_end are mutually exclusive — leaving the
+        // flag set would still end the sub at period end, eating the gifted months.
+        updateParams.cancel_at_period_end = false;
       }
 
       await stripe.subscriptions.update(stripeSub.id, updateParams);
@@ -497,6 +500,16 @@ export async function revokeMembershipGift({
       } else if (gift.stripeCouponId && subscription.discount?.coupon?.id === gift.stripeCouponId) {
         // Existing subscription that got our coupon — strip the remaining free months
         await stripe.subscriptions.deleteDiscount(subscription.id);
+        // Fulfillment may have deferred the recipient's own cancellation past the
+        // gifted months (cancel_at pushed out). With the gift revoked that deferral
+        // would resume BILLING a user who had canceled — collapse it back to
+        // period-end so they keep what they paid for and are never charged again.
+        if (subscription.cancel_at) {
+          await stripe.subscriptions.update(subscription.id, {
+            cancel_at: '',
+            cancel_at_period_end: true,
+          });
+        }
       }
     }
   }
@@ -553,12 +566,18 @@ export async function keepGiftMembership({ userId }: { userId: number }) {
   }
 
   const customer = stripeSub.customer as Stripe.Customer;
-  let paymentMethod = customer.invoice_settings?.default_payment_method ?? customer.default_source;
-  if (!paymentMethod) {
+  // default_source is a legacy Source/Card — Stripe bills it as the customer
+  // default but rejects it as a subscription default_payment_method, so it only
+  // counts as "has a way to pay", never gets set on the sub.
+  let subscriptionPaymentMethod: string | null = null;
+  let hasBillingMethod =
+    !!customer.invoice_settings?.default_payment_method || !!customer.default_source;
+  if (!hasBillingMethod) {
     const methods = await stripe.paymentMethods.list({ customer: customer.id, type: 'card' });
-    paymentMethod = methods.data[0]?.id ?? null;
+    subscriptionPaymentMethod = methods.data[0]?.id ?? null;
+    hasBillingMethod = !!subscriptionPaymentMethod;
   }
-  if (!paymentMethod) {
+  if (!hasBillingMethod) {
     const portal = await stripe.billingPortal.sessions.create({
       customer: customer.id,
       return_url: `${baseUrl}/user/membership?flow=keep-membership`,
@@ -570,7 +589,7 @@ export async function keepGiftMembership({ userId }: { userId: number }) {
   await stripe.subscriptions.update(stripeSub.id, {
     cancel_at: '',
     cancel_at_period_end: false,
-    default_payment_method: typeof paymentMethod === 'string' ? paymentMethod : paymentMethod.id,
+    ...(subscriptionPaymentMethod ? { default_payment_method: subscriptionPaymentMethod } : {}),
   });
 
   await invalidateSubscriptionCaches(userId);


### PR DESCRIPTION
Let users pre-pay 1/3/6 months of a green membership as a gift. One-time Stripe Checkout on the gifter; fulfillment applies a single-use 100%-off repeating coupon to the recipient's existing monthly sub (deferring any scheduled cancellation) or creates a $0 auto-canceling sub for non-members. Existing invoice.paid/subscription webhooks handle Buzz and row sync; refunds/chargebacks revoke the coupon or cancel the gift sub.

- MembershipGift audit table (manual migration 20260729200000)
- membership-gift service + router + zod schema, 28 unit tests
- /pricing/gift page (recipient picker, tier cards w/ benefits, summary)
- Keep-my-membership flow (clears cancel_at; billing portal when no PM)
- Membership Gifts card on /user/account + compact variant on gift page
- Gift state on /user/membership, received/sent notifications
- Entry points: PlanCard + profile menu, behind giftMemberships flag
- Debug endpoint /api/testing/gift-membership