### PR TITLE
fix(apps): stop rendering a link inside the OAuth picker's listbox

### DIFF
--- a/src/components/Apps/ExternalSubmitForm.browser.test.tsx
+++ b/src/components/Apps/ExternalSubmitForm.browser.test.tsx
@@ -426,6 +426,40 @@ describe('ExternalSubmitForm — OAuth step: mod global-search + create deeplink
     await expect.element(link).toHaveAttribute('target', '_blank');
     await expect.element(link).toHaveAttribute('rel', expect.stringContaining('noopener'));
   });
+
+  test('the mod no-results message is NON-INTERACTIVE prose — no anchor in the listbox, exactly ONE create-client control', async () => {
+    // a11y REGRESSION GUARD. Mantine renders `nothingFoundMessage` as `Combobox.Empty`
+    // INSIDE `Combobox.Options`, which carries `role="listbox"`. Supplying the prop also
+    // flips `hiddenWhenEmpty` to false, and `Combobox` defaults to `keepMounted: true`,
+    // so that node sits in the DOM (merely `display:none`) whenever the option list is
+    // empty. It therefore must NOT be an anchor: `link` is not a permitted child role of
+    // `listbox` and it breaks the combobox's arrow/Enter semantics while open. It also
+    // must not duplicate the persistent create-client deeplink — pre-fix BOTH were the
+    // same <a> with the same `data-testid`, visible at once on exactly the no-results
+    // path this message exists for (and a bare testid query matched 2 → strict-mode
+    // violation). Moderators are the only role whose picker can reach an empty list.
+    mocks.currentUser = { id: 1, username: 'mod', isModerator: true };
+    mocks.search = { data: { items: [], nextCursor: undefined }, isFetching: false };
+    renderWithProviders(<ExternalSubmitForm />);
+    await advanceFromUrl();
+
+    // Open the picker so this is the state a moderator actually sees, not just the DOM.
+    await page.getByTestId('apps-offsite-client-search').click();
+
+    const empty = page.getByTestId('apps-offsite-client-search-empty');
+    await expect.element(empty).toBeInTheDocument();
+
+    // The empty-state copy carries no interactive control of its own…
+    expect(empty.element().querySelector('a,button,[role="link"],[role="button"]')).toBeNull();
+    // …and NO anchor is rendered inside the listbox at all.
+    expect(document.querySelector('[role="listbox"] a')).toBeNull();
+
+    // Exactly ONE "create an OAuth client" control in the document — the persistent
+    // in-form deeplink, which stays a real working link.
+    const links = page.getByTestId('apps-offsite-create-client-link');
+    expect(links.elements()).toHaveLength(1);
+    await expect.element(links).toHaveAttribute('href', '/user/account');
+  });
 });
 
 /**

--- a/src/components/Apps/ExternalSubmitForm.tsx
+++ b/src/components/Apps/ExternalSubmitForm.tsx
@@ -363,7 +363,8 @@ function ExternalCreateForm() {
 
   // Create-client deeplink for EVERYONE (mods + regular devs) — opens the OAuth-apps
   // card on /user/account in a NEW TAB so the in-progress wizard isn't lost. Rendered
-  // persistently below the picker AND reused as the Select's `nothingFoundMessage`.
+  // ONCE, persistently below the picker. Deliberately NOT reused as the mod Select's
+  // `nothingFoundMessage` — see `noClientsFoundMessage` for why.
   const createClientLink = (
     <Anchor
       href="/user/account"
@@ -376,6 +377,23 @@ function ExternalCreateForm() {
       Don’t see your app? Create an OAuth client
       <IconExternalLink size={12} />
     </Anchor>
+  );
+
+  // Empty-state copy for the mod global-search Select. Mantine renders
+  // `nothingFoundMessage` via `Combobox.Empty` INSIDE `Combobox.Options`, which carries
+  // `role="listbox"` — and because setting `nothingFoundMessage` flips `hiddenWhenEmpty`
+  // to false while `Combobox` defaults to `keepMounted: true`, that node stays in the DOM
+  // (merely `display:none`) whenever the option list is empty, open or not. So this must
+  // stay NON-INTERACTIVE prose: an <a> here would be a `link` inside a `listbox` (not a
+  // permitted child role, and it breaks combobox arrow/Enter semantics while the dropdown
+  // is open), and it would duplicate `createClientLink` — two identical controls with the
+  // same accessible name reachable at once on exactly the no-results path this message
+  // exists for. The actionable affordance is the persistent link rendered below.
+  const noClientsFoundMessage = (
+    <Text size="xs" c="dimmed" data-testid="apps-offsite-client-search-empty">
+      No matching apps. Use the “Create an OAuth client” link below the picker to register
+      one.
+    </Text>
   );
 
   return (
@@ -533,7 +551,7 @@ function ExternalCreateForm() {
                   error={errors.connectClientId}
                   disabled={busy}
                   required
-                  nothingFoundMessage={createClientLink}
+                  nothingFoundMessage={noClientsFoundMessage}
                   rightSection={modSearchQuery.isFetching ? <Loader size={14} /> : undefined}
                   data-testid="apps-offsite-client-search"
                 />


### PR DESCRIPTION
## The defect

`ExternalSubmitForm` built **one** `createClientLink` anchor and rendered it in **two** places — persistently below the OAuth picker, and as the moderator `Select`'s `nothingFoundMessage`.

Mantine renders `nothingFoundMessage` through `Combobox.Empty`, **inside `Combobox.Options`**, which carries `role="listbox"`. Verified against the pinned `@mantine/core` 7.17.x:

- `Select` passes `hiddenWhenEmpty: !nothingFoundMessage` → supplying the prop makes it `false`
- `OptionsDropdown` then computes `hidden: hidden || hiddenWhenEmpty && isEmpty` → no longer hides on empty
- `Combobox` defaults to `keepMounted: true`, and `ComboboxDropdown` renders `hidden` as a `data-hidden` attribute (CSS `display:none`), not an unmount

So whenever the option list is empty, that subtree is **in the DOM**. Two real consequences:

1. **a11y** — an `<a>` (role `link`) was a child of `role="listbox"`. That is not a permitted child role, and it breaks the combobox's arrow/Enter semantics while the dropdown is open.
2. **Duplicate control** — on the exact no-results path the message exists for, **both identical links were visible at once**: same `href`, same accessible name, same `data-testid`.

Only moderators can reach an empty option list (they get the async global client search). The non-moderator own-clients dropdown passes no `nothingFoundMessage` and is untouched.

## The fix

The dropdown empty state becomes **non-interactive prose** that points at the persistent link; the persistent link stays a real, working `<a href="/user/account" target="_blank">` — it is the affordance that lets someone actually go create an OAuth client.

Making the dropdown copy prose resolves *both* problems in one change. The alternative — giving the two renderings distinct `data-testid`s — would only resolve the test ambiguity, leaving an anchor inside `role="listbox"` and two identical controls reachable at once.

### Residual, stated honestly

`Combobox.Empty` still renders a `div` inside `role="listbox"`, which is also not strictly permitted content. That is inherent to Mantine's `nothingFoundMessage` API; the alternative is dropping the prop entirely, which costs moderators their empty-state feedback. The **interactive** control — the part that is focusable, duplicated, and semantically disruptive — is what this PR removes from the listbox.

## Test coverage

Adds one browser test asserting the **dropdown** copy specifically (the gap left by scoping the query instead). With a moderator whose search returns no results, it opens the picker and asserts:

- the empty-state message renders
- it carries no interactive control of its own
- **no anchor exists inside `[role="listbox"]`**
- exactly **one** create-client control is in the document, and it still points at `/user/account`

Both assertions were **mutation-verified**: restoring the anchor as `nothingFoundMessage` fails the test, and — to prove the a11y assertion isn't merely riding on the new testid — injecting an anchor *into* the prose fails it too (`expected <a …></a> to be null`).

## Verification

`ExternalSubmitForm` browser suites (3 files), run locally against real Chromium:

| | Test files | Tests | Duration |
|---|---|---|---|
| before (`main`) | 2 failed / 1 passed | 3 failed / 40 passed (43) | ~39s |
| after | 2 failed / 1 passed | 2 failed / 42 passed (44) | ~22s |

The moderator-deeplink failure — the true signal this PR is about — is **gone**.

The 2 remaining failures are **pre-existing on `main` and are not this defect**; they are the ones #3482 repairs (a missing `useCurrentUser` mock in the reduced-motion suite, and a missing step-advance before `pickClient()`). I deliberately did **not** touch them, to keep this diff from conflicting with that PR.

Non-moderator path confirmed unaffected — the own-clients dropdown tests pass, and that `Select` is untouched by this diff.

`npx tsc --noEmit`: no new errors. The 4 errors reported in this file are `implicitly has an 'any' type` on lines identical in `origin/main`, all before this diff's first change, from an unrelated local codegen issue.

## Relationship to #3482

#3482 is open and scopes the moderator deeplink query to the form to make it pass. That silences a true signal and leaves nothing asserting on the dropdown copy. This PR fixes the product instead, so the **unscoped** query at that test passes again on its own — meaning this diff touches none of #3482's lines and the two should merge in either order. If #3482 lands first, its scoping remains harmless (it still matches exactly one element) and can be un-scoped in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
