### PR TITLE
feat(cosmetic-shop): community cosmetics hub section on /shop

### DIFF
--- a/src/components/CosmeticShop/CommunityCosmeticsSection.tsx
+++ b/src/components/CosmeticShop/CommunityCosmeticsSection.tsx
@@ -1,0 +1,93 @@
+import { Center, Loader } from '@mantine/core';
+import { useState } from 'react';
+import { useDebouncedValue } from '@mantine/hooks';
+import { ShopFiltersDropdown } from '~/components/CosmeticShop/ShopFiltersDropdown';
+import { useQueryCommunityCosmetics } from '~/components/CreatorShop/creator-shop.util';
+import { useOwnedCosmeticIds } from '~/components/CreatorShop/Storefront/storefront.util';
+import { creatorShopFilterTypes } from '~/components/CreatorShop/Submit/submit.constants';
+import { InViewLoader } from '~/components/InView/InViewLoader';
+import { NoContent } from '~/components/NoContent/NoContent';
+import { ShopItem } from '~/components/Shop/ShopItem';
+import { ShopSection } from '~/components/Shop/ShopSection';
+import type { GetShopInput } from '~/server/schema/cosmetic-shop.schema';
+import type { CosmeticShopItemGetById } from '~/types/router';
+
+// Global marketplace hub on /shop: one infinite feed of every published
+// community cosmetic across all creator shops, filterable by type. Placement,
+// banner, and copy come from the mod-managed section row (meta.communityHub).
+export function CommunityCosmeticsSection({
+  title,
+  description,
+  imageUrl,
+  hideTitle,
+  className,
+}: {
+  title: string;
+  description?: string | null;
+  imageUrl?: string | null;
+  hideTitle?: boolean;
+  className?: string;
+}) {
+  const [filters, setFilters] = useState<GetShopInput>({});
+  const [debouncedTypes] = useDebouncedValue(filters.cosmeticTypes, 500);
+  const { items, isLoading, isRefetching, fetchNextPage, hasNextPage } = useQueryCommunityCosmetics(
+    { cosmeticTypes: debouncedTypes?.length ? debouncedTypes : undefined }
+  );
+  const ownedCosmeticIds = useOwnedCosmeticIds();
+
+  // Nothing published yet — keep /shop clean rather than showing an empty hub.
+  if (!isLoading && !items.length && !filters.cosmeticTypes?.length) return null;
+
+  return (
+    <ShopSection
+      title={title}
+      description={description}
+      imageUrl={imageUrl}
+      hideTitle={hideTitle}
+      className={className}
+    >
+      <div className="flex flex-col gap-4">
+        <div className="ml-auto">
+          <ShopFiltersDropdown
+            filters={filters}
+            setFilters={setFilters}
+            availableTypes={creatorShopFilterTypes}
+            hideModifiers
+          />
+        </div>
+        {isLoading ? (
+          <Center p="xl">
+            <Loader />
+          </Center>
+        ) : items.length ? (
+          <>
+            <div className="grid gap-4 [grid-template-columns:repeat(auto-fill,minmax(240px,1fr))]">
+              {items.map((item) => (
+                <ShopItem
+                  key={item.id}
+                  layout="storefront"
+                  item={item as unknown as CosmeticShopItemGetById}
+                  sectionItemCreatedAt={item.createdAt}
+                  alreadyOwned={ownedCosmeticIds.has(item.cosmeticId)}
+                  // Attribute the purchase to the owner's shop so the creator
+                  // keeps their full pool (never the platform-reseller split).
+                  viaShopUserId={item.addedById ?? undefined}
+                  creator={item.cosmetic.creator}
+                />
+              ))}
+            </div>
+            {hasNextPage && (
+              <InViewLoader loadFn={fetchNextPage} loadCondition={!isRefetching}>
+                <Center p="xl" style={{ height: 36 }} mt="md">
+                  <Loader />
+                </Center>
+              </InViewLoader>
+            )}
+          </>
+        ) : (
+          <NoContent message="No cosmetics match your filters." />
+        )}
+      </div>
+    </ShopSection>
+  );
+}

--- a/src/components/CosmeticShop/CosmeticShopSectionUpsertForm.tsx
+++ b/src/components/CosmeticShop/CosmeticShopSectionUpsertForm.tsx
@@ -36,6 +36,7 @@ export const CosmeticShopSectionUpsertForm = ({ section, onSuccess, onCancel }: 
       ...section,
       meta: {
         hideTitle: false,
+        communityHub: false,
         ...((section?.meta ?? {}) as CosmeticShopSectionMeta),
       },
       items:
@@ -48,7 +49,7 @@ export const CosmeticShopSectionUpsertForm = ({ section, onSuccess, onCancel }: 
     shouldUnregister: false,
   });
 
-  const [image] = form.watch(['image']);
+  const [image, communityHub] = form.watch(['image', 'meta.communityHub']);
   const { upsertShopSection, upsertingShopSection } = useMutateCosmeticShop();
 
   const handleSubmit = async (data: z.infer<typeof formSchema>) => {
@@ -94,6 +95,11 @@ export const CosmeticShopSectionUpsertForm = ({ section, onSuccess, onCancel }: 
             label="Published"
             description="Makes this section visible on the store"
           />
+          <InputCheckbox
+            name="meta.communityHub"
+            label="Community Cosmetics Hub"
+            description="Shows the sitewide feed of every creator-made cosmetic (with type filters) instead of hand-picked items. Only visible to users with Creator Shop access"
+          />
           <InputRTE
             name="description"
             description="This description will be shown in the shop"
@@ -103,11 +109,13 @@ export const CosmeticShopSectionUpsertForm = ({ section, onSuccess, onCancel }: 
             withAsterisk
             stickyToolbar
           />
-          <InputSectionItems
-            name="items"
-            label="Items in section"
-            description="Items that will be sold in this section. The order displayed here is the order they will appear in"
-          />
+          {!communityHub && (
+            <InputSectionItems
+              name="items"
+              label="Items in section"
+              description="Items that will be sold in this section. The order displayed here is the order they will appear in"
+            />
+          )}
         </Stack>
         <Group justify="flex-end">
           {onCancel && (

--- a/src/components/CreatorShop/creator-shop.util.ts
+++ b/src/components/CreatorShop/creator-shop.util.ts
@@ -1,7 +1,10 @@
 import { useEffect, useMemo, useState } from 'react';
 import { trpc } from '~/utils/trpc';
 import type { RouterOutput } from '~/types/router';
-import type { GetPublicShopItemsInput } from '~/server/schema/creator-shop.schema';
+import type {
+  GetCommunityCosmeticsInput,
+  GetPublicShopItemsInput,
+} from '~/server/schema/creator-shop.schema';
 import type { CosmeticShopItemStatus, CosmeticType } from '~/shared/utils/prisma/enums';
 import { showErrorNotification, showSuccessNotification } from '~/utils/notifications';
 
@@ -37,6 +40,17 @@ export type CreatorShopPublicShopItem =
   RouterOutput['creatorShop']['getPublicShopItems']['items'][number];
 export const useQueryPublicShopItems = (filters: Partial<GetPublicShopItemsInput> = {}) => {
   const { data, ...rest } = trpc.creatorShop.getPublicShopItems.useInfiniteQuery(filters, {
+    getNextPageParam: (lastPage) => lastPage.nextCursor,
+  });
+  const items = useMemo(() => data?.pages.flatMap((page) => page.items) ?? [], [data]);
+  return { items, ...rest };
+};
+
+// Site-wide community cosmetics hub feed (/shop marketplace section).
+export type CommunityCosmeticItem =
+  RouterOutput['creatorShop']['getCommunityCosmetics']['items'][number];
+export const useQueryCommunityCosmetics = (filters: Partial<GetCommunityCosmeticsInput> = {}) => {
+  const { data, ...rest } = trpc.creatorShop.getCommunityCosmetics.useInfiniteQuery(filters, {
     getNextPageParam: (lastPage) => lastPage.nextCursor,
   });
   const items = useMemo(() => data?.pages.flatMap((page) => page.items) ?? [], [data]);

--- a/src/pages/shop/index.tsx
+++ b/src/pages/shop/index.tsx
@@ -37,6 +37,8 @@ import projectOdysseyProducts from '~/utils/shop/project-odyssey-products.json';
 import clsx from 'clsx';
 import { openUserProfileEditModal } from '~/components/Dialog/triggers/user-profile-edit';
 import { useQueryUserCosmetics } from '~/components/Cosmetics/cosmetics.util';
+import { CommunityCosmeticsSection } from '~/components/CosmeticShop/CommunityCosmeticsSection';
+import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
 
 const merchSections = {
   civitai: {
@@ -77,6 +79,7 @@ export default function CosmeticShopMain() {
   const [debouncedFilters] = useDebouncedValue({ cosmeticTypes: filters.cosmeticTypes }, 500);
   const { cosmeticShopSections, isLoading } = useQueryShop(debouncedFilters);
   const { data: userCosmetics, isFetching: loadingOwnedCosmetics } = useQueryUserCosmetics();
+  const features = useFeatureFlags();
 
   const { updateLastViewed, isFetched } = useShopLastViewed();
 
@@ -154,6 +157,19 @@ export default function CosmeticShopMain() {
               cosmeticShopSections.map((section, index) => {
                 const { image, items } = section;
                 const meta = section.meta as CosmeticShopSectionMeta;
+
+                if (meta.communityHub) {
+                  return features.creatorShop ? (
+                    <CommunityCosmeticsSection
+                      key={section.id}
+                      title={section.title}
+                      description={section.description}
+                      imageUrl={image?.url}
+                      hideTitle={meta.hideTitle}
+                      className={clsx(index === 0 ? 'order-1' : 'order-3')}
+                    />
+                  ) : null;
+                }
 
                 let filteredItems = items;
                 if (filters.modifier) {

--- a/src/server/routers/creator-shop.router.ts
+++ b/src/server/routers/creator-shop.router.ts
@@ -1,5 +1,6 @@
 import { getByIdSchema } from '~/server/schema/base.schema';
 import {
+  getCommunityCosmeticsSchema,
   getCreatorShopSchema,
   getCreatorShopSettingsSchema,
   getEarlyAccessPricesSchema,
@@ -15,6 +16,7 @@ import {
 import {
   archiveCreatorShopItem,
   deleteCreatorShopItem,
+  getCommunityCosmetics,
   getCreatorShop,
   getCreatorShopManageItems,
   getEarlyAccessModelPrices,
@@ -114,6 +116,11 @@ export const creatorShopRouter = router({
     .use(isFlagProtected('creatorShop'))
     .input(getEarlyAccessPricesSchema)
     .query(({ input }) => getEarlyAccessModelPrices(input)),
+  // Site-wide community cosmetics hub feed on /shop.
+  getCommunityCosmetics: publicProcedure
+    .use(isFlagProtected('creatorShop'))
+    .input(getCommunityCosmeticsSchema)
+    .query(({ input, ctx }) => getCommunityCosmetics({ ...input, viewerId: ctx.user?.id })),
   // #endregion
 
   // #region [Shop settings]

--- a/src/server/schema/cosmetic-shop.schema.ts
+++ b/src/server/schema/cosmetic-shop.schema.ts
@@ -104,6 +104,9 @@ export type CosmeticShopSectionMeta = z.infer<typeof cosmeticShopSectionMeta>;
 export const cosmeticShopSectionMeta = z.object({
   hideTitle: z.boolean().optional(),
   availableItemsMax: z.number().optional(),
+  // Renders the sitewide community-cosmetics feed in place of hand-picked
+  // items, so mods control the hub's placement/banner/copy like any section.
+  communityHub: z.boolean().optional(),
 });
 
 export type UpsertCosmeticShopSectionInput = z.infer<typeof upsertCosmeticShopSectionInput>;

--- a/src/server/schema/creator-shop.schema.ts
+++ b/src/server/schema/creator-shop.schema.ts
@@ -193,6 +193,15 @@ export const getPublicShopItemsSchema = z.object({
   query: z.string().optional(),
 });
 
+// Site-wide community cosmetics hub on /shop — one feed of every published
+// creator cosmetic from public shops, filterable by type.
+export type GetCommunityCosmeticsInput = z.infer<typeof getCommunityCosmeticsSchema>;
+export const getCommunityCosmeticsSchema = z.object({
+  limit: z.number().min(1).max(100).default(40),
+  cursor: z.number().optional(),
+  cosmeticTypes: z.array(z.enum(CosmeticType)).optional(),
+});
+
 export type ReviewCreatorShopItemInput = z.infer<typeof reviewCreatorShopItemSchema>;
 export const reviewCreatorShopItemSchema = z
   .object({

--- a/src/server/services/__tests__/cosmetic-shop-sections.service.test.ts
+++ b/src/server/services/__tests__/cosmetic-shop-sections.service.test.ts
@@ -97,4 +97,26 @@ describe('getShopSectionsWithItems viewer gating', () => {
     const sections = await getShopSectionsWithItems({});
     expect(sections).toHaveLength(0);
   });
+
+  it('keeps an item-less community-hub section (its feed loads separately)', async () => {
+    mocks.sectionFindMany.mockResolvedValue([
+      { ...sectionRow, items: [], meta: { communityHub: true } },
+    ]);
+
+    const sections = await getShopSectionsWithItems({ creatorShopEnabled: true });
+    expect(sections).toHaveLength(1);
+  });
+
+  it('only queries hub sections for viewers with the creatorShop flag', async () => {
+    await getShopSectionsWithItems({});
+    expect(mocks.sectionFindMany.mock.calls[0][0].where.OR).toEqual([{ items: { some: {} } }]);
+
+    mocks.sectionFindMany.mockClear();
+    mocks.sectionFindMany.mockResolvedValue([sectionRow]);
+    await getShopSectionsWithItems({ creatorShopEnabled: true });
+    expect(mocks.sectionFindMany.mock.calls[0][0].where.OR).toEqual([
+      { items: { some: {} } },
+      { meta: { path: ['communityHub'], equals: true } },
+    ]);
+  });
 });

--- a/src/server/services/__tests__/creator-shop-community.service.test.ts
+++ b/src/server/services/__tests__/creator-shop-community.service.test.ts
@@ -1,0 +1,89 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mocks } = vi.hoisted(() => ({
+  mocks: {
+    shopItemFindMany: vi.fn(),
+    blockedByGetCached: vi.fn(),
+    blockedGetCached: vi.fn(),
+  },
+}));
+
+vi.mock('~/server/db/client', () => ({
+  dbRead: { cosmeticShopItem: { findMany: mocks.shopItemFindMany } },
+  dbWrite: {},
+}));
+vi.mock('sharp', () => ({ default: vi.fn() }));
+vi.mock('~/server/services/buzz.service', () => ({
+  createBuzzTransaction: vi.fn(),
+  refundTransaction: vi.fn(),
+}));
+vi.mock('~/server/services/creator-program.service', () => ({
+  hasValidCreatorMembership: vi.fn(),
+}));
+vi.mock('~/server/services/notification.service', () => ({ createNotification: vi.fn() }));
+vi.mock('~/server/services/user-preferences.service', () => ({
+  BlockedByUsers: { getCached: mocks.blockedByGetCached },
+  BlockedUsers: { getCached: mocks.blockedGetCached },
+}));
+
+import { getCommunityCosmetics } from '../creator-shop.service';
+
+const itemRow = (id: number, meta: Record<string, unknown> = {}) => ({
+  id,
+  cosmeticId: id * 10,
+  unitAmount: 500,
+  title: `Item ${id}`,
+  addedById: 11,
+  meta: { purchases: 3, submissionTxId: 'tx-1', sellerShare: 20, imageHash: 'abc', ...meta },
+  cosmetic: { id: id * 10, name: `Cosmetic ${id}`, type: 'Badge', createdById: 11 },
+});
+
+describe('getCommunityCosmetics', () => {
+  beforeEach(() => {
+    Object.values(mocks).forEach((m) => m.mockReset());
+    mocks.shopItemFindMany.mockResolvedValue([]);
+    mocks.blockedByGetCached.mockResolvedValue([]);
+    mocks.blockedGetCached.mockResolvedValue([]);
+  });
+
+  it('strips payout/fee internals from item meta', async () => {
+    mocks.shopItemFindMany.mockResolvedValue([itemRow(2), itemRow(1)]);
+    const { items, nextCursor } = await getCommunityCosmetics({ limit: 40 });
+    expect(items.map((i) => i.id)).toEqual([2, 1]);
+    expect(items[0].meta).toEqual({ purchases: 3 });
+    expect(nextCursor).toBeUndefined();
+  });
+
+  it('pages with limit+1: pops the extra row into nextCursor', async () => {
+    mocks.shopItemFindMany.mockResolvedValue([itemRow(3), itemRow(2), itemRow(1)]);
+    const { items, nextCursor } = await getCommunityCosmetics({ limit: 2 });
+    expect(mocks.shopItemFindMany).toHaveBeenCalledWith(expect.objectContaining({ take: 3 }));
+    expect(items.map((i) => i.id)).toEqual([3, 2]);
+    expect(nextCursor).toBe(1);
+  });
+
+  it('only queries published creator items from public shops', async () => {
+    await getCommunityCosmetics({ limit: 40, cosmeticTypes: ['Badge' as never] });
+    const { where } = mocks.shopItemFindMany.mock.calls[0][0];
+    expect(where.status).toBe('Published');
+    expect(where.cosmetic.createdById).toEqual({ not: null });
+    expect(where.cosmetic.type).toEqual({ in: ['Badge'] });
+    expect(where.addedBy).toEqual({
+      settings: { path: ['creatorShop', 'enabled'], equals: true },
+    });
+  });
+
+  it('skips the block lookup for anonymous viewers', async () => {
+    await getCommunityCosmetics({ limit: 40 });
+    expect(mocks.blockedByGetCached).not.toHaveBeenCalled();
+    expect(mocks.shopItemFindMany.mock.calls[0][0].where.addedById).toBeUndefined();
+  });
+
+  it('excludes creators with a block in either direction from the viewer', async () => {
+    mocks.blockedByGetCached.mockResolvedValue([{ id: 5 }]);
+    mocks.blockedGetCached.mockResolvedValue([{ id: 6 }]);
+    await getCommunityCosmetics({ limit: 40, viewerId: 99 });
+    const { where } = mocks.shopItemFindMany.mock.calls[0][0];
+    expect(where.addedById.notIn).toEqual(expect.arrayContaining([5, 6]));
+  });
+});

--- a/src/server/services/cosmetic-shop.service.ts
+++ b/src/server/services/cosmetic-shop.service.ts
@@ -7,6 +7,7 @@ import type { GetByIdInput } from '~/server/schema/base.schema';
 import { TransactionType } from '~/shared/constants/buzz.constants';
 import type {
   CosmeticShopItemMeta,
+  CosmeticShopSectionMeta,
   GetAllCosmeticShopSections,
   GetPaginatedCosmeticShopItemInput,
   GetPreviewImagesInput,
@@ -498,12 +499,17 @@ export const getShopSectionsWithItems = async ({
       },
     },
     where: {
-      items: {
-        some: {},
-      },
+      // Community-hub sections carry no curated items — their feed is queried
+      // separately by the client — so they skip the has-items requirement. The
+      // feed itself is flag-gated, so hide the hub from unflagged viewers.
+      OR: [
+        { items: { some: {} } },
+        ...(isModerator || creatorShopEnabled
+          ? [{ meta: { path: ['communityHub'], equals: true } }]
+          : []),
+      ],
       published: true,
       ...(sectionId ? { id: sectionId } : undefined),
-      // id: sectionId ? { equals: sectionId } : undefined,
     },
     orderBy: {
       placement: 'asc',
@@ -512,8 +518,8 @@ export const getShopSectionsWithItems = async ({
 
   return (
     sections
-      // Ensures we don't return empty sections
-      .filter((s) => s.items.length > 0)
+      // Ensures we don't return empty sections (except the community hub)
+      .filter((s) => s.items.length > 0 || (s.meta as CosmeticShopSectionMeta | null)?.communityHub)
       .map((section) => ({
         ...section,
         image: !!section.image

--- a/src/server/services/creator-shop.service.ts
+++ b/src/server/services/creator-shop.service.ts
@@ -58,6 +58,7 @@ import type {
   AutoCheck,
   CosmeticImageMeta,
   CosmeticOffsets,
+  GetCommunityCosmeticsInput,
   GetEarlyAccessPricesInput,
   GetPublicShopItemsInput,
   GetReviewQueueInput,
@@ -742,6 +743,50 @@ export const getCreatorShop = async ({
     earlyAccessModelCount,
     membershipLapsed,
   };
+};
+
+// Site-wide hub feed of every published community cosmetic (creator-submitted
+// items from public shops), newest first. Powers the /shop marketplace section.
+export const getCommunityCosmetics = async ({
+  viewerId,
+  limit,
+  cursor,
+  cosmeticTypes,
+}: GetCommunityCosmeticsInput & { viewerId?: number }) => {
+  const now = new Date();
+  // A block between viewer and a cosmetic's creator (either direction) hides
+  // that creator's items from the feed.
+  const blockedPairIds = viewerId ? await getBlockedPairIds(viewerId) : [];
+  const raw = await dbRead.cosmeticShopItem.findMany({
+    where: {
+      status: CosmeticShopItemStatus.Published,
+      // Creator-submitted only (official cosmetics have no creator).
+      cosmetic: {
+        createdById: { not: null },
+        ...(cosmeticTypes?.length ? { type: { in: cosmeticTypes } } : {}),
+      },
+      // Only items whose owner's shop is public.
+      addedBy: { settings: { path: ['creatorShop', 'enabled'], equals: true } },
+      ...(blockedPairIds.length ? { addedById: { notIn: blockedPairIds } } : {}),
+      AND: [
+        { OR: [{ availableFrom: null }, { availableFrom: { lte: now } }] },
+        { OR: [{ availableTo: null }, { availableTo: { gte: now } }] },
+      ],
+    },
+    take: limit + 1,
+    ...(cursor ? { cursor: { id: cursor } } : {}),
+    orderBy: { id: 'desc' },
+    // addedById lets the client attribute the purchase to the owner's shop.
+    select: { ...creatorStorefrontItemSelect, addedById: true },
+  });
+  let nextCursor: number | undefined;
+  if (raw.length > limit) nextCursor = raw.pop()?.id;
+  // Same meta sanitation as the storefront — cards only need the purchase count.
+  const items = raw.map((item) => ({
+    ...item,
+    meta: { purchases: (item.meta as CosmeticShopItemMeta)?.purchases ?? 0 },
+  }));
+  return { items, nextCursor };
 };
 
 // Early Access download prices for the shop's Models section, keyed by model


### PR DESCRIPTION
Adds a mod-configured "Community Cosmetics" section to /shop: one infinite feed of every published creator cosmetic from public shops, filterable by type.

- New public creatorShop.getCommunityCosmetics endpoint (cursor-paged, newest first, block-aware, meta sanitized to purchase count).
- The hub is a regular CosmeticShopSection row flagged via meta.communityHub (checkbox on the section upsert form), so mods control title, banner image, description, placement, and publish state from the existing sections screen. Item-less hub sections are returned only for viewers with the creatorShop flag.
- Hub purchases attribute viaShopUserId = addedById so the creator keeps the full 70% pool.

ClickUp: 868kj4q5f