### PR TITLE
test(lint): catch wholesale vi.mock('~/utils/trpc') factories statically

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -44,6 +44,26 @@ module.exports = {
     // ready to gate on it.
     'local-rules/no-io-in-transaction': 'warn',
 
+    // Flags a `vi.mock('~/utils/trpc', () => ({ ... }))` whose factory hand-writes
+    // the module instead of spreading the real one via `importOriginal`. A
+    // wholesale factory breaks the whole test FILE the day the module gains an
+    // export it omits — and a file that fails to load collects 0 tests rather
+    // than failing an assertion, so nothing turns red. See eslint-local-rules.js
+    // for the full write-up and the canonical fix.
+    //
+    // Deliberately scoped to `~/utils/trpc` (the module with the widest
+    // transitive reach and the one that actually bit us) rather than every
+    // wholesale mock in the repo: mocking a narrow leaf module wholesale is a
+    // normal, safe thing to do, and flagging it would make the rule noisy enough
+    // to get switched off. Extend `modules` if another hub module starts biting.
+    //
+    // 'warn', matching no-io-in-transaction above: there is a pre-existing
+    // backlog of ~66 wholesale trpc mocks, and converting them in bulk without
+    // being able to run the browser suite risks re-creating the very
+    // 0-tests-collected failure this rule exists to catch. Escalate to 'error'
+    // once that backlog is burned down.
+    'local-rules/no-wholesale-module-mock': ['warn', { modules: ['~/utils/trpc'] }],
+
     // aligns closing brackets for tags
     'react/jsx-closing-bracket-location': ['error', 'line-aligned'],
 

--- a/eslint-local-rules.js
+++ b/eslint-local-rules.js
@@ -175,6 +175,184 @@ const noIoInTransaction = {
   },
 };
 
+/**
+ * no-wholesale-module-mock
+ *
+ * Flags a `vi.mock('<module>', () => ({ ... }))` whose factory hand-writes a
+ * replacement object instead of spreading the REAL module via `importOriginal`.
+ *
+ * Why this is a test-infrastructure hazard and not a style nit:
+ *
+ * A wholesale factory pins the module's export surface to whatever the author
+ * happened to need on the day they wrote it. The moment the real module gains a
+ * new export that some OTHER file in the test's module graph imports, that
+ * import resolves to `undefined` and the ENTIRE test file fails to LOAD. A file
+ * that fails to load produces no failing assertion — it collects **0 tests**.
+ * Nothing goes red; the suite just quietly stops existing.
+ *
+ * That is exactly what happened to `~/utils/trpc`: adding `trpcVanilla` (and,
+ * separately, `OffsiteReviewModalBody`) silently disabled five browser suites
+ * and ~36 tests. It went undiagnosed partly because a cold Vite `optimizeDeps`
+ * cache ALSO yields "0 tests collected" ("Vitest failed to find the runner"),
+ * so the signature is ambiguous at runtime — which is the argument for catching
+ * it statically, here, instead.
+ *
+ * The fix is to override narrowly and keep every other export real:
+ *
+ *   vi.mock('~/utils/trpc', async (importOriginal) => ({
+ *     ...(await importOriginal<typeof import('~/utils/trpc')>()),
+ *     trpc: { ...only what this test overrides... },
+ *   }));
+ *
+ * Canonical in-repo example (with the same warning in a comment):
+ *   src/components/Challenge/__tests__/ChallengeUpsertForm.browser.test.tsx
+ *
+ * A factory is accepted when the object it returns has a top-level spread AND
+ * the factory actually references `importOriginal`/`importActual` — a spread of
+ * some local stub object is not a fix. `vi.mock('mod')` with no factory
+ * (automock) is untouched: it preserves the real export shape by construction.
+ *
+ * Scoped by the `modules` option (default: just `~/utils/trpc`) rather than
+ * applied to every mock in the repo — see the .eslintrc.js note. Extend the
+ * list rather than broadening the rule.
+ *
+ * Intentional exceptions should use:
+ *   // eslint-disable-next-line local-rules/no-wholesale-module-mock -- <reason>
+ */
+const DEFAULT_WHOLESALE_MOCK_MODULES = ['~/utils/trpc'];
+
+/** Is this `vi.mock(...)` / `vitest.mock(...)`? */
+function isViMockCall(node) {
+  const callee = node.callee;
+  return (
+    callee &&
+    callee.type === 'MemberExpression' &&
+    callee.object &&
+    callee.object.type === 'Identifier' &&
+    (callee.object.name === 'vi' || callee.object.name === 'vitest') &&
+    callee.property &&
+    callee.property.type === 'Identifier' &&
+    (callee.property.name === 'mock' || callee.property.name === 'doMock')
+  );
+}
+
+/**
+ * Generic AST walk that does NOT descend into nested functions — so a
+ * `return` belonging to an inner callback is never mistaken for the factory's
+ * own return value.
+ */
+function walkSkippingFunctions(node, visit) {
+  if (!node || typeof node.type !== 'string') return;
+  visit(node);
+  for (const key of Object.keys(node)) {
+    if (key === 'parent') continue;
+    const value = node[key];
+    const children = Array.isArray(value) ? value : [value];
+    for (const child of children) {
+      if (!child || typeof child.type !== 'string') continue;
+      if (
+        child.type === 'FunctionDeclaration' ||
+        child.type === 'FunctionExpression' ||
+        child.type === 'ArrowFunctionExpression'
+      ) {
+        continue;
+      }
+      walkSkippingFunctions(child, visit);
+    }
+  }
+}
+
+/** Does this ObjectExpression have a top-level `...spread`? */
+function hasTopLevelSpread(objectExpression) {
+  return (
+    objectExpression.type === 'ObjectExpression' &&
+    objectExpression.properties.some((p) => p.type === 'SpreadElement')
+  );
+}
+
+const noWholesaleModuleMock = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        "Require vi.mock factories for sensitive modules to spread the real module via importOriginal — a wholesale factory breaks the whole test FILE (0 tests collected) the day the module gains an export it omits.",
+      recommended: true,
+    },
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          modules: { type: 'array', items: { type: 'string' }, minItems: 1 },
+        },
+        additionalProperties: false,
+      },
+    ],
+    messages: {
+      wholesaleMock:
+        "Wholesale vi.mock('{{module}}') factory — it replaces the module with a hand-written object, so the day '{{module}}' gains an export this factory omits, every importer in this test's module graph gets `undefined` and the whole FILE fails to load: 0 tests collected, no failing assertion, silently 'green' (this disabled ~36 tests via `trpcVanilla`). Spread the real module and override only what you need: add `import type * as Mod from '{{module}}';` then `vi.mock('{{module}}', async (importOriginal) => ({ ...(await importOriginal<typeof Mod>()), /* overrides */ }));` — use the type-only namespace import, NOT `typeof import('...')`, which @typescript-eslint/consistent-type-imports rejects. Canonical example: src/components/Challenge/__tests__/ChallengeUpsertForm.browser.test.tsx",
+    },
+  },
+  create(context) {
+    const options = context.options[0] || {};
+    const targets = new Set(options.modules || DEFAULT_WHOLESALE_MOCK_MODULES);
+    const sourceCode = context.sourceCode || context.getSourceCode();
+
+    return {
+      CallExpression(node) {
+        if (!isViMockCall(node)) return;
+
+        const [moduleArg, factory] = node.arguments;
+        if (!moduleArg || moduleArg.type !== 'Literal' || !targets.has(moduleArg.value)) return;
+        // `vi.mock('mod')` (automock) keeps the real export shape — nothing to do.
+        if (
+          !factory ||
+          (factory.type !== 'ArrowFunctionExpression' && factory.type !== 'FunctionExpression')
+        ) {
+          return;
+        }
+
+        // The factory must actually reach for the original module. A spread of
+        // a locally-built object is not a fix, so check this over the factory
+        // subtree only (a sibling mock's `importActual` must not count).
+        const factoryText = sourceCode.getText(factory);
+        const usesOriginal =
+          /\bimportOriginal\b/.test(factoryText) || /\bimportActual\b/.test(factoryText);
+
+        // Collect the object literal(s) the factory itself returns.
+        const returnedObjects = [];
+        if (factory.body.type === 'ObjectExpression') {
+          returnedObjects.push(factory.body); // concise arrow: () => ({ ... })
+        } else if (factory.body.type !== 'BlockStatement') {
+          // Concise body that isn't an object literal, e.g. `() => makeMock()`
+          // (wholesale, still caught below via `usesOriginal`) or
+          // `async (importOriginal) => importOriginal()` (a full passthrough).
+        } else {
+          walkSkippingFunctions(factory.body, (n) => {
+            if (n.type === 'ReturnStatement' && n.argument) returnedObjects.push(n.argument);
+          });
+        }
+
+        // Safe iff the factory reaches for the original AND every object
+        // literal it returns spreads at the top level. When it returns no
+        // object literal at all there is nothing to inspect, so `importOriginal`
+        // usage alone is the signal (e.g. a straight passthrough).
+        const objectLiterals = returnedObjects.filter((n) => n.type === 'ObjectExpression');
+        const spreadsOriginal =
+          usesOriginal && (objectLiterals.length === 0 || objectLiterals.every(hasTopLevelSpread));
+
+        if (spreadsOriginal) return;
+
+        context.report({
+          node,
+          messageId: 'wholesaleMock',
+          data: { module: String(moduleArg.value) },
+        });
+      },
+    };
+  },
+};
+
 module.exports = {
   'no-io-in-transaction': noIoInTransaction,
+  'no-wholesale-module-mock': noWholesaleModuleMock,
 };

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "test:unit": "vitest --project unit",
     "test:unit:run": "vitest run --project unit",
     "test:unit:coverage": "vitest run --project unit --coverage",
-    "test:lint-rules": "vitest run --project unit src/server/services/__tests__/no-io-in-transaction.test.ts",
+    "test:lint-rules": "vitest run --project unit src/server/services/__tests__/no-io-in-transaction.test.ts src/server/services/__tests__/no-wholesale-module-mock.test.ts",
     "test:component": "vitest run --project component",
     "test:component:watch": "vitest --project component",
     "meilisearch:migrate": "NODE_ENV=development tsx scripts/oneoffs/meilisearch-migration.ts",

--- a/src/components/Apps/AppEditPage.browser.test.tsx
+++ b/src/components/Apps/AppEditPage.browser.test.tsx
@@ -1,6 +1,9 @@
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { page } from 'vitest/browser';
 import { useRouter } from 'next/router';
+// Type-only: gives the `importOriginal` spread below the real module's type
+// without an `import()` type annotation (banned by consistent-type-imports).
+import type * as TrpcModule from '~/utils/trpc';
 // `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
 import { renderWithProviders } from '../../../test/component-setup';
 
@@ -42,7 +45,13 @@ vi.mock('~/providers/FeatureFlagsProvider', () => ({
 // is the established idiom (see `src/tests/pages/payment/success.browser.test.tsx`).
 const router = useRouter();
 
-vi.mock('~/utils/trpc', () => ({
+// Only the `trpc` client itself is overridden — every other `~/utils/trpc` export
+// (trpcVanilla, queryClient, setTrpcBatchingEnabled, ...) is kept real via
+// importOriginal. A wholesale factory silently breaks this whole FILE (0 tests
+// collected, no failing assertion) the day the module gains an export some other
+// file in this test's graph imports. See local-rules/no-wholesale-module-mock.
+vi.mock('~/utils/trpc', async (importOriginal) => ({
+  ...(await importOriginal<typeof TrpcModule>()),
   trpc: {
     blocks: {
       getMyAppManifest: {

--- a/src/components/Apps/ExternalSubmitForm.browser.test.tsx
+++ b/src/components/Apps/ExternalSubmitForm.browser.test.tsx
@@ -2,6 +2,9 @@ import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { page } from 'vitest/browser';
 // `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
 import { renderWithProviders } from '../../../test/component-setup';
+// Type-only: gives the `importOriginal` spread below the real module's type
+// without an `import()` type annotation (banned by consistent-type-imports).
+import type * as TrpcModule from '~/utils/trpc';
 
 /**
  * W13 — /apps/submit external-app WIZARD (redesigned, MERGED external+connect model).
@@ -46,9 +49,16 @@ const mocks = vi.hoisted(() => ({
   currentUser: null as null | { id: number; username: string; isModerator?: boolean },
 }));
 
-vi.mock('~/utils/trpc', () => {
+// Only the `trpc` client itself is overridden — every other `~/utils/trpc` export
+// (trpcVanilla, queryClient, setTrpcBatchingEnabled, ...) is kept real via
+// importOriginal. A wholesale factory silently breaks this whole FILE (0 tests
+// collected, no failing assertion) the day the module gains an export some other
+// file in this test's graph imports. See local-rules/no-wholesale-module-mock.
+vi.mock('~/utils/trpc', async (importOriginal) => {
+  const actual = await importOriginal<typeof TrpcModule>();
   const mutation = () => ({ mutate: vi.fn(), mutateAsync: vi.fn(), isPending: false });
   return {
+    ...actual,
     trpc: {
       // ListingAssetStep (reached on the Assets step) calls `trpc.useUtils()` and
       // `utils.appListings.getAssetScanStatuses.fetch` on an accept — stub both.

--- a/src/components/Apps/ExternalSubmitForm.reducedMotion.browser.test.tsx
+++ b/src/components/Apps/ExternalSubmitForm.reducedMotion.browser.test.tsx
@@ -1,6 +1,9 @@
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { page } from 'vitest/browser';
 import { renderWithProviders } from '../../../test/component-setup';
+// Type-only: gives the `importOriginal` spread below the real module's type
+// without an `import()` type annotation (banned by consistent-type-imports).
+import type * as TrpcModule from '~/utils/trpc';
 
 /**
  * W13 — the redesigned submit wizard must honour `prefers-reduced-motion`. With the
@@ -25,9 +28,16 @@ const mocks = vi.hoisted(() => ({
   },
 }));
 
-vi.mock('~/utils/trpc', () => {
+// Only the `trpc` client itself is overridden — every other `~/utils/trpc` export
+// (trpcVanilla, queryClient, setTrpcBatchingEnabled, ...) is kept real via
+// importOriginal. A wholesale factory silently breaks this whole FILE (0 tests
+// collected, no failing assertion) the day the module gains an export some other
+// file in this test's graph imports. See local-rules/no-wholesale-module-mock.
+vi.mock('~/utils/trpc', async (importOriginal) => {
+  const actual = await importOriginal<typeof TrpcModule>();
   const mutation = () => ({ mutate: vi.fn(), mutateAsync: vi.fn(), isPending: false });
   return {
+    ...actual,
     trpc: {
       appListings: {
         submitExternalListing: {

--- a/src/components/Challenge/__tests__/ChallengeUpsertForm.browser.test.tsx
+++ b/src/components/Challenge/__tests__/ChallengeUpsertForm.browser.test.tsx
@@ -9,6 +9,9 @@ import {
   PoolTrigger,
   PrizeMode,
 } from '~/shared/utils/prisma/enums';
+// Type-only: gives the `importOriginal` spread below the real module's type
+// without an `import()` type annotation (banned by consistent-type-imports).
+import type * as TrpcModule from '~/utils/trpc';
 
 /**
  * D6-seed — mod "Customize judging categories" toggle. `ChallengeUpsertForm.judging-categories
@@ -25,7 +28,7 @@ import {
 // transitively-imported consumer elsewhere in the tree (e.g. session/provider chains) still
 // gets a real binding instead of the whack-a-mole of hand-naming every export they touch.
 vi.mock('~/utils/trpc', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('~/utils/trpc')>();
+  const actual = await importOriginal<typeof TrpcModule>();
   const noopQuery = () => ({ data: undefined, isLoading: false });
   const noopMutation = () => ({ mutate: vi.fn(), mutateAsync: vi.fn(), isPending: false });
   return {

--- a/src/server/services/__tests__/no-wholesale-module-mock.test.ts
+++ b/src/server/services/__tests__/no-wholesale-module-mock.test.ts
@@ -1,0 +1,157 @@
+import path from 'path';
+import { RuleTester } from 'eslint';
+// The rule lives at the repo root (loaded in prod via eslint-plugin-local-rules).
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const localRules = require(path.resolve(__dirname, '../../../../eslint-local-rules.js'));
+
+const rule = localRules['no-wholesale-module-mock'];
+
+// Same harness shape as no-io-in-transaction.test.ts: RuleTester drives the test
+// framework's globals, so `ruleTester.run(...)` must be called at the top level
+// of the module (NOT nested inside a vitest `it()`). `parser` is a valid
+// top-level RuleTester option in ESLint 8 (eslintrc mode) but @types/eslint's
+// config type omits it — build untyped and cast so `tsc --noEmit` stays green.
+const ruleTesterConfig: Record<string, unknown> = {
+  parser: require.resolve('@typescript-eslint/parser'),
+  parserOptions: { ecmaVersion: 'latest', sourceType: 'module' },
+};
+const ruleTester = new RuleTester(
+  ruleTesterConfig as ConstructorParameters<typeof RuleTester>[0]
+);
+
+ruleTester.run('no-wholesale-module-mock', rule, {
+  valid: [
+    // ---- The canonical pattern (ChallengeUpsertForm.browser.test.tsx) ----
+    // Block body: await importOriginal() into a local, spread it in the return.
+    `vi.mock('~/utils/trpc', async (importOriginal) => {
+       const actual = await importOriginal<typeof import('~/utils/trpc')>();
+       return { ...actual, trpc: { useUtils: () => ({}) } };
+     });`,
+    // Concise body variant (AnnouncementEditModal.browser.test.tsx).
+    `vi.mock('~/utils/trpc', async (importOriginal) => ({
+       ...(await importOriginal<Record<string, unknown>>()),
+       trpc: { useUtils: () => ({}) },
+     }));`,
+    // The form the rule's message actually recommends: a type-only namespace
+    // import instead of `typeof import('...')`, which @typescript-eslint's
+    // consistent-type-imports rejects ("`import()` type annotations are
+    // forbidden"). Both must stay valid here.
+    `import type * as TrpcModule from '~/utils/trpc';
+     vi.mock('~/utils/trpc', async (importOriginal) => ({
+       ...(await importOriginal<typeof TrpcModule>()),
+       trpc: {},
+     }));`,
+    // vi.importActual is equally acceptable as the source of the spread.
+    `vi.mock('~/utils/trpc', async () => {
+       const actual = await vi.importActual<typeof import('~/utils/trpc')>('~/utils/trpc');
+       return { ...actual, trpc: {} };
+     });`,
+    // Straight passthrough — returns the original, no object literal to inspect.
+    `vi.mock('~/utils/trpc', async (importOriginal) => importOriginal());`,
+    // Automock (no factory) preserves the real export shape by construction.
+    `vi.mock('~/utils/trpc');`,
+
+    // ---- Out of scope: other modules ----
+    // The rule is scoped to its `modules` option (default just ~/utils/trpc);
+    // a wholesale mock of any other module must NOT fire. This is what keeps
+    // the rule quiet enough to stay enabled.
+    `vi.mock('~/hooks/useCFImageUpload', () => ({ useCFImageUpload: () => ({}) }));`,
+    `vi.mock('@mantine/hooks', () => ({ useMediaQuery: () => false }));`,
+    // Non-literal specifier (computed) — nothing to match against.
+    `vi.mock(SOME_MODULE, () => ({ trpc: {} }));`,
+    // Not a vi.mock call at all.
+    `foo.mock('~/utils/trpc', () => ({ trpc: {} }));`,
+
+    // ---- Nested-function isolation ----
+    // A `return` inside an inner callback must not be mistaken for the
+    // factory's own return value; the factory's real return spreads correctly.
+    `vi.mock('~/utils/trpc', async (importOriginal) => {
+       const actual = await importOriginal<Record<string, unknown>>();
+       const useQuery = () => { return { data: undefined, isLoading: false }; };
+       return { ...actual, trpc: { model: { getAll: { useQuery } } } };
+     });`,
+  ],
+  invalid: [
+    // ---- The exact shape that broke five suites / ~36 tests ----
+    // Concise arrow returning a hand-written object (AppEditPage.browser.test.tsx).
+    {
+      code: `vi.mock('~/utils/trpc', () => ({ trpc: { blocks: { getMyAppManifest: { useQuery: () => ({}) } }, useUtils: () => ({}) } }));`,
+      errors: [{ messageId: 'wholesaleMock', data: { module: '~/utils/trpc' } }],
+    },
+    // Block body with a local helper then a hand-written return
+    // (ExternalSubmitForm.browser.test.tsx).
+    {
+      code: `vi.mock('~/utils/trpc', () => {
+         const mutation = () => ({ mutate: vi.fn(), isPending: false });
+         return { trpc: { appListings: { persistAssetImage: { useMutation: mutation } } } };
+       });`,
+      errors: [{ messageId: 'wholesaleMock' }],
+    },
+    // Minimal wholesale factory (WorkflowInput.browser.test.tsx) — a neighbouring
+    // mock's importActual must not launder this one.
+    {
+      code: `vi.mock('~/utils/trpc', () => ({ trpc: {} }));`,
+      errors: [{ messageId: 'wholesaleMock' }],
+    },
+    // Double-quoted specifier.
+    {
+      code: `vi.mock("~/utils/trpc", () => ({ trpc: {} }));`,
+      errors: [{ messageId: 'wholesaleMock' }],
+    },
+    // vi.doMock is the same hazard.
+    {
+      code: `vi.doMock('~/utils/trpc', () => ({ trpc: {} }));`,
+      errors: [{ messageId: 'wholesaleMock' }],
+    },
+    // `vitest.mock` alias.
+    {
+      code: `vitest.mock('~/utils/trpc', () => ({ trpc: {} }));`,
+      errors: [{ messageId: 'wholesaleMock' }],
+    },
+    // A spread of a LOCAL stub is not a fix — the real module is still gone.
+    {
+      code: `vi.mock('~/utils/trpc', () => ({ ...baseStub, trpc: {} }));`,
+      errors: [{ messageId: 'wholesaleMock' }],
+    },
+    // importOriginal is awaited but the result is never spread — the omitted
+    // exports are still missing.
+    {
+      code: `vi.mock('~/utils/trpc', async (importOriginal) => {
+         const actual = await importOriginal<Record<string, unknown>>();
+         return { trpc: { q: actual.queryClient } };
+       });`,
+      errors: [{ messageId: 'wholesaleMock' }],
+    },
+    // Spread nested one level deep does not protect the module's top-level
+    // export surface.
+    {
+      code: `vi.mock('~/utils/trpc', async (importOriginal) => {
+         const actual = await importOriginal<Record<string, unknown>>();
+         return { trpc: { ...actual } };
+       });`,
+      errors: [{ messageId: 'wholesaleMock' }],
+    },
+    // Factory delegating to a helper — cannot be proven safe, and in practice
+    // is the wholesale pattern.
+    {
+      code: `vi.mock('~/utils/trpc', () => makeTrpcMock());`,
+      errors: [{ messageId: 'wholesaleMock' }],
+    },
+    // Two return paths, only one of which spreads — the unguarded branch still
+    // drops the real exports.
+    {
+      code: `vi.mock('~/utils/trpc', async (importOriginal) => {
+         const actual = await importOriginal<Record<string, unknown>>();
+         if (flag) return { trpc: {} };
+         return { ...actual, trpc: {} };
+       });`,
+      errors: [{ messageId: 'wholesaleMock' }],
+    },
+    // The `modules` option extends the scope to another module.
+    {
+      code: `vi.mock('~/utils/other', () => ({ thing: 1 }));`,
+      options: [{ modules: ['~/utils/other'] }],
+      errors: [{ messageId: 'wholesaleMock', data: { module: '~/utils/other' } }],
+    },
+  ],
+});


### PR DESCRIPTION
## The failure class

A `vi.mock('~/utils/trpc', () => ({ ... }))` whose factory hand-writes a replacement object pins the module's export surface to whatever the author needed that day. The moment `src/utils/trpc.ts` gains an export that some *other* file in the test's module graph imports, that import resolves to `undefined` and the whole test **file fails to load** — collecting **0 tests** instead of failing an assertion.

That's the dangerous part: nothing turns red. The suite just quietly stops existing. Adding `trpcVanilla` (and, separately, `OffsiteReviewModalBody`) silently disabled five browser suites and ~36 tests this way, and in the report-only `preview / component-tests` Tekton job it reads as a pass.

### 🔴 Why "0 tests collected" is an ambiguous signature

A cold Vite `optimizeDeps` cache produces `Vitest failed to find the runner` → **also 0 tests collected**. One cause is a real break, the other is environmental, and they are indistinguishable from the summary line.

I hit this repeatedly while verifying this PR, and it is worth recording concretely. Running the four affected browser suites against **unmodified `main`**:

| run | result |
|---|---|
| 1st (cold dep cache) | `Test Files 3 failed \| 1 passed` — **33 failed / 0 collected**, `Cannot read properties of null (reading 'useState')` |
| 2nd (warm, identical code) | `Test Files 4 passed` — **36 passed** |

Same commit, same machine, opposite verdicts. That ambiguity is a large part of why the original breakage went undiagnosed, and it is the argument for catching the wholesale-mock hazard **statically** rather than trusting a run.

## The rule

Adds `local-rules/no-wholesale-module-mock`, **extending the existing `eslint-plugin-local-rules` mechanism** that already hosts `no-io-in-transaction` — no new plugin dependency, and it reuses the established `RuleTester` harness and `pnpm test:lint-rules` script.

I evaluated a pure `no-restricted-syntax` selector first, since that would be lower friction. It can express "a `vi.mock` factory containing no `SpreadElement`", but only coarsely: any spread anywhere in the factory silences it (so `{ trpc: { ...someLocalStub } }` passes), and it cannot check that the spread actually comes from the *original module*. Because `eslint-local-rules.js` already exists with a documented rule in it, the marginal cost of a precise rule was one file edit — so precision won.

A factory is accepted only when it **both** references `importOriginal`/`importActual` **and** every object literal it returns has a top-level spread. Scoped to `~/utils/trpc` via a `modules` option.

**Scope decision.** Deliberately narrow. Mocking a small leaf module wholesale (`~/hooks/useCFImageUpload`, `@mantine/hooks`) is normal and safe; `~/utils/trpc` is the hub whose transitive reach makes omissions fatal, and it is the one that actually bit us. A rule that flagged every wholesale mock in the repo would be noisy enough to get switched off, which is worse than no rule.

**Severity: `warn`**, matching `no-io-in-transaction` directly above it (same rationale, same comment style). See the backlog note below.

## 🔴 The premise was understated: 70 offenders, not 3

The brief named three files. The rule finds **70**.

| | files |
|---|---|
| `vi.mock('~/utils/trpc', …)` total (on `main`) | 72 |
| already correct (`importOriginal` spread) | 2 |
| **wholesale — flagged** | **70** |
| converted in this PR | 3 |
| **remaining backlog** | **67** |

All 70 carry the identical latent break. The five suites that actually died were simply the ones whose graph happened to import the new symbol first.

I did **not** bulk-convert the other 67, and want to be explicit that this is a judgement call rather than an oversight. Converting ~67 browser suites in one PR would collide with a large number of in-flight branches, and — more importantly — a botched conversion fails *silently as 0 collected*, i.e. it would risk re-creating the exact failure mode this PR exists to close, at scale, in a suite that is report-only in CI. `warn` keeps the tree green, puts the squiggle in the editor at authoring time (where the rule earns most of its value), and leaves a countable backlog. **Escalate to `error` once that backlog is burned down.**

## Offenders converted

- `src/components/Apps/ExternalSubmitForm.browser.test.tsx`
- `src/components/Apps/ExternalSubmitForm.reducedMotion.browser.test.tsx`
- `src/components/Apps/AppEditPage.browser.test.tsx`

PR #3482 has since **merged**, so the anticipated conflict on these three files did not materialise — it fixed other problems (import failures, timeout-burning mocks) and left the wholesale factories intact. This PR is rebased on top of it.

## One deviation from the canonical example

`ChallengeUpsertForm.browser.test.tsx` is the right idiom, but its exact spelling — `importOriginal<typeof import('~/utils/trpc')>()` — trips `@typescript-eslint/consistent-type-imports` (`` `import()` type annotations are forbidden ``), which is an **error** in this repo. Copying it verbatim into three files would have added three new lint errors.

So the conversions use a type-only namespace import instead, which keeps full typing and lints clean:

```ts
import type * as TrpcModule from '~/utils/trpc';

vi.mock('~/utils/trpc', async (importOriginal) => ({
  ...(await importOriginal<typeof TrpcModule>()),
  trpc: { /* only what this test overrides */ },
}));
```

The rule's message teaches this form, and the canonical file is updated to match (net **−1** pre-existing lint error) so the example the message points at is actually exemplary.

## Verification

**Rule fires** — removing *only* the `...actual,` line from the canonical `ChallengeUpsertForm` mock flips it from clean to flagged; restored afterwards. Plus **23 `RuleTester` cases** (11 valid / 12 invalid) covering: concise + block-body factories, `vi.doMock`/`vitest.mock`, double quotes, automock, `Record<>` and namespace-import spreads, a spread of a *local* stub (still flagged), `importOriginal` awaited but never spread (flagged), spread nested one level deep (flagged), a mixed-return-path factory (flagged), and the `modules` option.

**No false positives** — `70 → 67` flagged after converting exactly 3. The 2 correct `importOriginal` files are not flagged. The rule's finding set is a strict subset of a naive grep — it invents nothing.

**No new lint errors** — the three converted files plus the canonical file lint **identically to baseline** (`1 rules-of-hooks` + `1 consistent-type-imports`, both pre-existing), except the canonical file which improves by one.

**Tests** — `pnpm test:lint-rules` green (43 tests: 20 existing + 23 new; the existing rule's suite is unaffected).

**Browser suites — actually run, not assumed.** Playwright's bundled Chromium does not run on NixOS, but `vitest.config.mts` already supports `PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH`; with a Nix system Chromium 150 the component project runs. The four affected suites: **36 passed / 4 files, both before and after the conversion.** The change is behaviour-neutral, and the `importOriginal` spread does **not** drag a server graph into the browser realm (`AppRouter` is `import type`, so it erases).

⚠️ Both figures are from *warm-cache* runs. As documented above, the first run after a cold cache reports 0 collected regardless of code — so treat a single cold "0 collected" as uninformative, not as a failure.

**Typecheck** — `NODE_OPTIONS=--max_old_space_size=8192 npx tsc --noEmit`: 16 errors, all pre-existing `TS2307` module-resolution noise from a local `prisma generate`/workspace-build failure that reproduces on unmodified `main`. **Zero** in any file touched here.

### Unrelated pre-existing breakage noticed

`pnpm lint` (`eslint src/`) currently **crashes** on `main`, exit 2:

```
TypeError: Cannot read properties of undefined (reading 'length')
Occurred while linting src/components/Comics/PanelCard.tsx:1
Rule: "@typescript-eslint/consistent-type-imports"
```

Reproduced in a clean worktree at `origin/main` — not introduced here, and not fixed here. Flagging it because it means the repo-wide lint gate aborts before reaching most files, which is worth a separate look.

## Follow-ups

1. Burn down the 67 remaining wholesale mocks (ideally in themed batches, each verified with a warm-cache browser run), then flip the rule to `error`.
2. Make `preview / component-tests` fail on a suite that collects 0 tests — the static rule closes the authoring path, but a runtime guard would close the environmental one.
3. Fix the `PanelCard.tsx` lint crash so `pnpm lint` completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
