### PR TITLE
fix(apps): recover from a mid-session block-token refresh failure

### DIFF
--- a/src/components/AppBlocks/BlockFallback.tsx
+++ b/src/components/AppBlocks/BlockFallback.tsx
@@ -1,4 +1,5 @@
 import { Alert, Button, Group, Loader, Skeleton, Stack, Text } from '@mantine/core';
+import { useReducedMotion } from '@mantine/hooks';
 import { IconRefresh } from '@tabler/icons-react';
 
 type FallbackReason = 'loading' | 'token_error' | 'timeout' | 'fatal_block_error';
@@ -84,8 +85,27 @@ export function BlockFallback({
   autoRetriesSpent = 0,
   prominentRetry = false,
 }: BlockFallbackProps) {
+  // `true` = fail SAFE (assume reduced motion) until the media query resolves —
+  // the same default PageBlockHost passes.
+  const reduceMotion = useReducedMotion(true);
+
   if (reason === 'loading') {
-    return <Skeleton h={minHeight} radius="md" data-block-fallback="loading" />;
+    // The loading skeleton used to be a sub-second flash on first mount, so its
+    // shimmer was unremarkable. It now also covers the model slot's bounded
+    // token-refresh RETRY window (`BlockHost` keeps the slot alive instead of
+    // collapsing), where it can persist for tens of seconds — long enough that an
+    // indefinitely looping animation is exactly what
+    // `prefers-reduced-motion: reduce` exists to suppress. Mantine's `animate`
+    // prop drops the shimmer and keeps the (static) placeholder box, so the
+    // layout reservation is unchanged.
+    //
+    // 🔴 The test asserts Mantine's OWN `data-animate` attribute (rendered from
+    // this prop: present when true, absent when false). A separate mirror
+    // attribute derived from `reduceMotion` was tried first and REJECTED — it
+    // stayed correct even with `animate` hardcoded to true, so the test passed
+    // while the shimmer kept running. Mutation testing caught it; assert the
+    // prop's real rendered effect, never a restatement of the intent.
+    return <Skeleton h={minHeight} radius="md" animate={!reduceMotion} data-block-fallback="loading" />;
   }
 
   const copy = REASON_COPY[reason];

--- a/src/components/AppBlocks/BlockHost.tsx
+++ b/src/components/AppBlocks/BlockHost.tsx
@@ -16,14 +16,24 @@ interface BlockHostProps {
  * so v2 can light it up without a structural refactor.
  */
 export function BlockHost({ blockInstall, slotContext }: BlockHostProps) {
-  const { token, expiresAt, error, pending, missingScopes, domain, maxBrowsingLevel, refresh } =
+  const { token, expiresAt, terminal, pending, missingScopes, domain, maxBrowsingLevel, refresh } =
     useBlockToken(blockInstall, slotContext);
 
-  // Terminal token-mint failure → collapse (render null, take no space)
-  // rather than show a visible "authorization error" card. Matches the
-  // IframeHost terminal-failure collapse: a block that can't load shows
-  // nothing. The brief loading skeleton below is preserved.
-  if (error) {
+  // TERMINAL token-mint failure → collapse (render null, take no space) rather
+  // than show a visible "authorization error" card. Matches the IframeHost
+  // terminal-failure collapse (`hostRenderDecision`): an error card for a block
+  // the viewer never asked for, on someone else's model page, is worse than
+  // silence. The brief loading skeleton below is preserved.
+  //
+  // 🔴 GATE ON `terminal`, NOT `error`. This used to read `if (error) return null`,
+  // which collapsed the slot on ANY mint failure — including a TRANSIENT
+  // mid-session refresh blip. That unmounted IframeHost, destroying whatever the
+  // user had in progress, and the eventual recovery REMOUNTED it: a fresh
+  // BLOCK_INIT and a SECOND impression beacon for one logical view (the beacon's
+  // emit-once guard is per IframeHost mount). `terminal` is true only once the
+  // hook has exhausted its bounded automatic retries AND no usable token remains,
+  // so a recoverable failure now keeps the block alive instead of erasing it.
+  if (terminal) {
     return null;
   }
   if (pending || !token || !expiresAt) {

--- a/src/components/AppBlocks/BlockHostTokenRetry.browser.test.tsx
+++ b/src/components/AppBlocks/BlockHostTokenRetry.browser.test.tsx
@@ -1,0 +1,351 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { page } from 'vitest/browser';
+import { cleanup } from 'vitest-browser-react';
+// `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
+import { renderWithProviders } from '../../../test/component-setup';
+import { MAX_REFRESH_RETRIES, REFRESH_RETRY_BACKOFF_MS } from '~/components/AppBlocks/blockTokenRetry';
+
+/**
+ * MODEL SLOT — a transient token-refresh failure must NOT erase the block.
+ *
+ * 🔴 THE DEFECT. `BlockHost` did `if (error) return null`, so ANY mint failure —
+ * including a momentary mid-session refresh blip — collapsed the slot. That
+ * unmounted `IframeHost`, destroying whatever the user had in progress, and the
+ * eventual recovery REMOUNTED it: a fresh BLOCK_INIT and, because the impression
+ * beacon's emit-once guard is per IframeHost MOUNT, a SECOND impression beacon
+ * for one logical view. PR #3480 fixed the beacon's per-mount semantics on the
+ * page host; nothing stopped the model slot from manufacturing extra mounts.
+ *
+ * 🔴 THIS SUITE EXERCISES THE REAL PATH. It renders the REAL `BlockHost` driving
+ * the REAL `useBlockToken` against a stubbed `fetch` — the network boundary, i.e.
+ * the failure being injected. The hook is NOT mocked: mocking it as a constant
+ * would remove the very state transitions under test (and make the fiber
+ * quiescent, the exact blind spot documented in IframeHostReadyTransition).
+ *
+ * The load-bearing assertion is DOM NODE IDENTITY: React reuses the same <iframe>
+ * element iff it never unmounted. A remount is otherwise invisible in a snapshot —
+ * the markup looks identical — which is precisely how this shipped.
+ */
+
+// AppBlockChrome calls useCurrentUser() for the platform-nav moderator gate.
+vi.mock('~/hooks/useCurrentUser', () => ({ useCurrentUser: () => null }));
+
+// IframeHost drives two tRPC queries at render plus the SDK bridges. Stub them so
+// the host mounts network-free AND the init handshake may start immediately
+// (getEffectiveCheckpoint must report isLoading:false so `shouldStartInit` fires).
+vi.mock('~/utils/trpc', () => ({
+  // FeatureFlagsProvider (in the render graph) statically imports this; a
+  // wholesale module mock MUST re-declare it or the ESM link fails.
+  setTrpcBatchingEnabled: vi.fn(),
+  trpc: {
+    blocks: {
+      getEffectiveCheckpoint: { useQuery: () => ({ data: { checkpoint: null }, isLoading: false }) },
+      getShowcaseImages: { useQuery: () => ({ data: [], isLoading: false }) },
+      submitWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      estimateWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      pollWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      cancelWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      updateUserSettings: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      getMyBuzzBalance: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+    },
+    apps: {
+      shared: {
+        append: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        update: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        vote: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        unvote: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        withdraw: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        report: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      },
+      storage: {
+        set: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        delete: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      },
+    },
+    useUtils: () => ({
+      apps: {
+        shared: {
+          list: { fetch: vi.fn() },
+          getCount: { fetch: vi.fn() },
+          getCounts: { fetch: vi.fn() },
+        },
+        storage: { get: { fetch: vi.fn() }, list: { fetch: vi.fn() }, getQuota: { fetch: vi.fn() } },
+      },
+    }),
+  },
+}));
+
+// eslint-disable-next-line import/first
+import { BlockHost } from '~/components/AppBlocks/BlockHost';
+// eslint-disable-next-line import/first
+import type { BlockInstall, ModelSlotContext } from '~/components/AppBlocks/types';
+
+const SAME_ORIGIN_SRC = `${window.location.origin}/`;
+
+const install: BlockInstall = {
+  blockInstanceId: 'inst_retry',
+  blockId: 'my-model-app',
+  appId: 'app_test',
+  appBlockId: 'apb_test',
+  manifest: {
+    name: 'Background Remover',
+    scopes: ['ai:write:budgeted'],
+    iframe: {
+      src: SAME_ORIGIN_SRC,
+      minHeight: 200,
+      maxHeight: 800,
+      resizable: true,
+      sandbox: 'allow-scripts',
+    },
+  },
+  publisherSettings: {},
+  enabled: true,
+  renderMode: 'iframe',
+  trustTier: 'internal',
+};
+
+const context: ModelSlotContext = {
+  slotId: 'model.sidebar_top',
+  entityType: 'model',
+  modelId: 123,
+  modelVersionId: 456,
+  modelName: 'Some Model',
+  modelType: 'Checkpoint',
+  modelNsfwLevel: 1,
+  creatorUserId: 7,
+  viewerUserId: 42,
+  viewerNsfwEnabled: false,
+  viewerUsername: 'tester',
+  theme: 'light',
+};
+
+const TOKEN_TTL_MS = 15 * 60_000;
+const REFRESH_AT_MS = TOKEN_TTL_MS - 2 * 60_000;
+
+let mintCount = 0;
+let fetchSpy: ReturnType<typeof vi.fn>;
+
+const BEACON_URL = '/api/track/block-render';
+const isBeacon = (call: unknown[]) =>
+  typeof call[0] === 'string' && (call[0] as string).includes(BEACON_URL);
+const beaconCalls = () => fetchSpy.mock.calls.filter(isBeacon);
+
+function mintOk(nth: number) {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => ({
+      token: `tok_${nth}`,
+      expiresAt: new Date(Date.now() + TOKEN_TTL_MS).toISOString(),
+      needsConsent: false,
+      missingScopes: [],
+      domain: 'blue',
+      maxBrowsingLevel: 3,
+    }),
+  } as unknown as Response;
+}
+const mintFail = { ok: false, status: 500, json: async () => ({}) } as unknown as Response;
+
+/** Route mint requests through `next()`; anything else (the beacon) resolves OK. */
+function respondWith(next: () => Response) {
+  fetchSpy.mockImplementation(async (url: unknown) => {
+    if (typeof url === 'string' && url.includes('/api/v1/block-tokens')) return next();
+    return { ok: true, status: 200, json: async () => ({}) } as unknown as Response;
+  });
+}
+
+beforeEach(() => {
+  mintCount = 0;
+  vi.useFakeTimers({ shouldAdvanceTime: true });
+  fetchSpy = vi.fn();
+  vi.stubGlobal('fetch', fetchSpy);
+  respondWith(() => mintOk(++mintCount));
+});
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+async function advance(ms: number) {
+  await vi.advanceTimersByTimeAsync(ms);
+  for (let i = 0; i < 4; i++) await vi.advanceTimersByTimeAsync(0);
+}
+
+const iframeQuery = () => page.getByTestId('block-iframe').query() as HTMLIFrameElement | null;
+const fallbackQuery = () => document.querySelector('[data-block-fallback]') as HTMLElement | null;
+
+async function waitForIframe(): Promise<HTMLIFrameElement> {
+  for (let i = 0; i < 200; i++) {
+    const el = iframeQuery();
+    if (el) return el;
+    await advance(1);
+  }
+  throw new Error('iframe never mounted');
+}
+
+/** Ack BLOCK_READY so the host commits `ready` and fires its ONE `ok` beacon. */
+async function driveToReady(el: HTMLIFrameElement) {
+  for (let i = 0; i < 200; i++) {
+    const cw = el.contentWindow;
+    if (cw) {
+      window.dispatchEvent(
+        new MessageEvent('message', {
+          data: { type: 'BLOCK_READY', payload: {} },
+          origin: window.location.origin,
+          source: cw,
+        })
+      );
+    }
+    if (el.getAttribute('data-block-ready') === 'true') return;
+    await advance(5);
+  }
+  throw new Error('block never became ready');
+}
+
+describe('a TRANSIENT refresh failure', () => {
+  test('🔴 does NOT unmount the block — same <iframe> node, no second beacon', async () => {
+    renderWithProviders(<BlockHost blockInstall={install} slotContext={context} />);
+    const first = await waitForIframe();
+    await driveToReady(first);
+    expect(beaconCalls()).toHaveLength(1);
+
+    // The scheduled refresh (T-2min) fails — twice, so we are demonstrably deep
+    // into the bounded retry sequence and not merely observing a single tick.
+    respondWith(() => mintFail);
+    await advance(REFRESH_AT_MS);
+    await advance(REFRESH_RETRY_BACKOFF_MS[0] + 5);
+
+    const after = iframeQuery();
+    // 🔴 IDENTITY, not presence: a remount would also yield a non-null iframe.
+    expect(after).not.toBeNull();
+    expect(after).toBe(first);
+    // Still ready — the block kept its live token and never re-handshook.
+    expect(after?.getAttribute('data-block-ready')).toBe('true');
+    // The slot never fell back to a skeleton/error card.
+    expect(fallbackQuery()).toBeNull();
+    // 🔴 ONE beacon for the whole episode. A vanish-and-remount emitted two.
+    expect(beaconCalls()).toHaveLength(1);
+  });
+
+  test('survives recovery too: the token rotates with the block still mounted', async () => {
+    renderWithProviders(<BlockHost blockInstall={install} slotContext={context} />);
+    const first = await waitForIframe();
+    await driveToReady(first);
+
+    respondWith(() => mintFail);
+    await advance(REFRESH_AT_MS);
+
+    respondWith(() => mintOk(++mintCount));
+    await advance(REFRESH_RETRY_BACKOFF_MS[0] + 5);
+
+    expect(iframeQuery()).toBe(first);
+    expect(beaconCalls()).toHaveLength(1);
+  });
+});
+
+describe('a TERMINAL failure', () => {
+  test('🔴 still collapses to null once recovery has SETTLED with no token left', async () => {
+    renderWithProviders(<BlockHost blockInstall={install} slotContext={context} />);
+    const first = await waitForIframe();
+    await driveToReady(first);
+
+    respondWith(() => mintFail);
+    await advance(REFRESH_AT_MS);
+    for (let i = 0; i < MAX_REFRESH_RETRIES; i++) {
+      await advance(REFRESH_RETRY_BACKOFF_MS[i] + 5);
+    }
+    // Settled but the held token is still live → the block keeps working.
+    expect(iframeQuery()).toBe(first);
+
+    // Past its real expiry the credential is swept and nothing is recoverable.
+    await advance(TOKEN_TTL_MS);
+
+    // The documented model-slot contract (hostRenderDecision): COLLAPSE, never a
+    // visible error card — an error for a block the viewer never asked for, on
+    // someone else's model page, is worse than silence.
+    expect(iframeQuery()).toBeNull();
+    expect(fallbackQuery()).toBeNull();
+    expect(document.querySelector('[data-block-fallback-retry="true"]')).toBeNull();
+  });
+
+  test('an initial-load failure collapses only after the budget is spent', async () => {
+    respondWith(() => mintFail);
+    renderWithProviders(<BlockHost blockInstall={install} slotContext={context} />);
+
+    // While recovery is pending the slot holds its (non-destructive) skeleton
+    // rather than collapsing — the user is not shown a blank hole mid-recovery.
+    await advance(50);
+    expect(fallbackQuery()?.getAttribute('data-block-fallback')).toBe('loading');
+
+    for (let i = 0; i < MAX_REFRESH_RETRIES; i++) {
+      await advance(REFRESH_RETRY_BACKOFF_MS[i] + 5);
+    }
+    await advance(50);
+
+    expect(fallbackQuery()).toBeNull();
+    expect(iframeQuery()).toBeNull();
+  });
+});
+
+describe('reduced motion', () => {
+  test('🔴 the retry-window skeleton drops its shimmer under prefers-reduced-motion', async () => {
+    // Stub the MEDIA QUERY, not the hook — `useReducedMotion` still runs for real.
+    const original = window.matchMedia;
+    window.matchMedia = ((query: string) =>
+      ({
+        matches: query.includes('prefers-reduced-motion'),
+        media: query,
+        onchange: null,
+        addListener: () => undefined,
+        removeListener: () => undefined,
+        addEventListener: () => undefined,
+        removeEventListener: () => undefined,
+        dispatchEvent: () => false,
+      } as unknown as MediaQueryList)) as typeof window.matchMedia;
+
+    try {
+      respondWith(() => mintFail);
+      renderWithProviders(<BlockHost blockInstall={install} slotContext={context} />);
+      await advance(50);
+
+      const skeleton = fallbackQuery();
+      expect(skeleton?.getAttribute('data-block-fallback')).toBe('loading');
+      // 🔴 Assert Mantine's OWN `data-animate` — the attribute it renders FROM the
+      // `animate` prop — not a mirror attribute recomputed from `reduceMotion`.
+      // The first version of this test did the latter and SURVIVED a mutation that
+      // hardcoded `animate` to true: the assertion restated the intent instead of
+      // observing the effect. The skeleton now covers the whole bounded retry
+      // window (tens of seconds), not a sub-second flash, so a looping shimmer is
+      // exactly what `prefers-reduced-motion: reduce` exists to suppress.
+      expect(skeleton?.hasAttribute('data-animate')).toBe(false);
+    } finally {
+      window.matchMedia = original;
+    }
+  });
+
+  test('keeps the shimmer when reduced motion is NOT requested', async () => {
+    const original = window.matchMedia;
+    window.matchMedia = ((query: string) =>
+      ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: () => undefined,
+        removeListener: () => undefined,
+        addEventListener: () => undefined,
+        removeEventListener: () => undefined,
+        dispatchEvent: () => false,
+      } as unknown as MediaQueryList)) as typeof window.matchMedia;
+
+    try {
+      respondWith(() => mintFail);
+      renderWithProviders(<BlockHost blockInstall={install} slotContext={context} />);
+      await advance(50);
+      expect(fallbackQuery()?.hasAttribute('data-animate')).toBe(true);
+    } finally {
+      window.matchMedia = original;
+    }
+  });
+});

--- a/src/components/AppBlocks/BlockHostTokenRetry.browser.test.tsx
+++ b/src/components/AppBlocks/BlockHostTokenRetry.browser.test.tsx
@@ -3,7 +3,10 @@ import { page } from 'vitest/browser';
 import { cleanup } from 'vitest-browser-react';
 // `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
 import { renderWithProviders } from '../../../test/component-setup';
-import { MAX_REFRESH_RETRIES, REFRESH_RETRY_BACKOFF_MS } from '~/components/AppBlocks/blockTokenRetry';
+import {
+  MAX_REFRESH_RETRIES,
+  REFRESH_RETRY_BACKOFF_MS,
+} from '~/components/AppBlocks/blockTokenRetry';
 
 /**
  * MODEL SLOT — a transient token-refresh failure must NOT erase the block.
@@ -39,7 +42,9 @@ vi.mock('~/utils/trpc', () => ({
   setTrpcBatchingEnabled: vi.fn(),
   trpc: {
     blocks: {
-      getEffectiveCheckpoint: { useQuery: () => ({ data: { checkpoint: null }, isLoading: false }) },
+      getEffectiveCheckpoint: {
+        useQuery: () => ({ data: { checkpoint: null }, isLoading: false }),
+      },
       getShowcaseImages: { useQuery: () => ({ data: [], isLoading: false }) },
       submitWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
       estimateWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
@@ -69,7 +74,11 @@ vi.mock('~/utils/trpc', () => ({
           getCount: { fetch: vi.fn() },
           getCounts: { fetch: vi.fn() },
         },
-        storage: { get: { fetch: vi.fn() }, list: { fetch: vi.fn() }, getQuota: { fetch: vi.fn() } },
+        storage: {
+          get: { fetch: vi.fn() },
+          list: { fetch: vi.fn() },
+          getQuota: { fetch: vi.fn() },
+        },
       },
     }),
   },

--- a/src/components/AppBlocks/PageBlockHost.tsx
+++ b/src/components/AppBlocks/PageBlockHost.tsx
@@ -198,8 +198,25 @@ export interface PageBlockHostProps {
    *  not granted (the token still mints with the granted subset). */
   needsConsent?: boolean;
   /** #3/#6: the token mint errored. Surface an error state instead of hanging at
-   *  `no_token`. */
+   *  `no_token`. Only escalates a host still in `loading` — see `tokenTerminal`
+   *  for the mid-session case. */
   tokenError?: boolean;
+  /**
+   * The mint has PERMANENTLY failed: no usable token remains AND the upstream
+   * hook's bounded automatic re-mints are exhausted (`useBlockToken.terminal`).
+   *
+   * 🔴 THIS IS THE ONLY THING THAT MAY TEAR DOWN A `ready` PAGE. Before it, the
+   * `tokenError` effect below transitioned out of `loading` ONLY — so a token
+   * that died mid-session left the host sitting at `ready` on a dead credential
+   * with `TOKEN_REFRESH` early-returning on `!token`, and the block just silently
+   * 401'd forever with no signal to the user or the platform. Gating on the
+   * SETTLED signal (rather than a bare `tokenError`) is what keeps a merely
+   * TRANSIENT refresh blip from ripping a working app out from under the user
+   * while it is still being recovered.
+   *
+   * Optional + default false → every existing caller is byte-identical.
+   */
+  tokenTerminal?: boolean;
   /** Advisory color-domain maturity signal (BLOCK_INIT). Server-authoritative
    *  values from the token mint — forwarded, never derived client-side. */
   domain?: 'green' | 'blue' | 'red' | null;
@@ -260,6 +277,7 @@ export function PageBlockHost({
   missingScopes,
   needsConsent,
   tokenError,
+  tokenTerminal = false,
   domain,
   maxBrowsingLevel,
   viewer,
@@ -509,6 +527,29 @@ export function PageBlockHost({
     if (!tokenError || token) return;
     setStatus((current) => (current === 'loading' ? 'error' : current));
   }, [tokenError, token]);
+
+  // MID-SESSION credential loss. The effect above only escalates a host still in
+  // `loading`, so a token that died AFTER the block went `ready` left the host
+  // parked on `ready` holding nothing: the `TOKEN_REFRESH` push early-returns on
+  // `!token`, so the block kept its now-dead credential and silently 401'd every
+  // call — no signal to the user, none to the platform.
+  //
+  // 🔴 GATED ON `tokenTerminal`, NOT `tokenError`. The upstream hook now retries a
+  // failed refresh on a bounded backoff and KEEPS a still-valid token while it
+  // does, so a transient blip never reaches here at all. Only once recovery has
+  // provably settled with nothing usable left do we replace the running app with
+  // the real terminal state — which also re-arms the bounded auto-retry below
+  // (an `error` status is an AUTH terminal, so its one automatic attempt spends a
+  // re-mint) and surfaces the prominent manual Retry once that settles too.
+  //
+  // 🔴 NO SECOND BEACON. A host that reached `ready` already fired its ONE `ok`
+  // impression, and `blockRenderEmittedRef` is per-mount — so the failure beacon
+  // below is inert here by construction. The episode stays one beacon, reporting
+  // that the page load itself succeeded (which it did).
+  useEffect(() => {
+    if (!tokenTerminal || token) return;
+    setStatus((current) => (current === 'ready' ? 'error' : current));
+  }, [tokenTerminal, token]);
 
   // Token never resolves → surface a no_token state instead of an endless
   // skeleton.

--- a/src/components/AppBlocks/PageBlockHostTokenTerminal.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostTokenTerminal.browser.test.tsx
@@ -75,7 +75,11 @@ vi.mock('~/utils/trpc', () => ({
           getCounts: { fetch: vi.fn() },
           get: { fetch: vi.fn() },
         },
-        storage: { get: { fetch: vi.fn() }, list: { fetch: vi.fn() }, getQuota: { fetch: vi.fn() } },
+        storage: {
+          get: { fetch: vi.fn() },
+          list: { fetch: vi.fn() },
+          getQuota: { fetch: vi.fn() },
+        },
       },
     }),
   },
@@ -130,7 +134,11 @@ function postFromBlock(type: string, payload?: unknown) {
   const cw = iframeEl.contentWindow;
   if (!cw) throw new Error('iframe contentWindow missing');
   window.dispatchEvent(
-    new MessageEvent('message', { data: { type, payload }, origin: window.location.origin, source: cw })
+    new MessageEvent('message', {
+      data: { type, payload },
+      origin: window.location.origin,
+      source: cw,
+    })
   );
 }
 

--- a/src/components/AppBlocks/PageBlockHostTokenTerminal.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostTokenTerminal.browser.test.tsx
@@ -1,0 +1,355 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { page } from 'vitest/browser';
+import { useState } from 'react';
+// `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
+import { renderWithProviders } from '../../../test/component-setup';
+
+/**
+ * W10 run page — MID-SESSION credential loss.
+ *
+ * 🔴 THE DEFECT. The `tokenError` effect only transitioned a host still in
+ * `loading`. So a token that died AFTER the block went `ready` did nothing at
+ * all: the host stayed `ready` holding nothing, the `TOKEN_REFRESH` push
+ * early-returns on `!token`, and the block kept its now-dead credential and
+ * silently 401'd every call — no signal to the user, none to the platform.
+ *
+ * 🔴 THE FIX IS DELIBERATELY GATED ON A *SETTLED* FAILURE (`tokenTerminal`), not
+ * on a bare `tokenError`. `useBlockToken` now retries a failed refresh on a
+ * bounded backoff and KEEPS a still-valid token while it does, so a transient
+ * blip must never reach here. Escalating on `tokenError` would rip a working app
+ * out from under the user for a two-second network hiccup — trading a silent
+ * failure for a louder, more destructive one.
+ *
+ * 🔴 AND IT MUST NOT DOUBLE-COUNT. PR #3480 established the contract: ONE beacon
+ * per host MOUNT, reporting the outcome the host settles on. A page that reached
+ * `ready` already emitted its `ok`; escalating later must emit nothing further.
+ *
+ * This suite renders the REAL host with REAL hooks and REAL timers, mirroring
+ * PageBlockHostAutoRetry — only the ambient tRPC client and useCurrentUser are
+ * stubbed (the network/session Context the offline scaffold can't provide, NOT
+ * the condition under test).
+ */
+
+vi.mock('~/hooks/useCurrentUser', () => ({ useCurrentUser: () => null }));
+
+vi.mock('~/utils/trpc', () => ({
+  // FeatureFlagsProvider statically imports this; a wholesale module mock MUST
+  // re-declare it or the ESM link fails.
+  setTrpcBatchingEnabled: vi.fn(),
+  trpc: {
+    generation: { resolveWildcardPack: { useMutation: () => ({ mutateAsync: vi.fn() }) } },
+    blocks: {
+      submitWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      getMyBuzzBalance: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      getMyViewer: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      getMyBuzzTransactions: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      getMyBuzzAccounts: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      getMyDailyCompensation: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      estimateWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      pollWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      cancelWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      queryAppWorkflows: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      cancelAppWorkflow: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      publishGenerationOutputs: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      getImagesByIds: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+    },
+    apps: {
+      shared: {
+        append: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        update: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        vote: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        unvote: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        withdraw: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        report: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      },
+      storage: {
+        set: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+        delete: { useMutation: () => ({ mutateAsync: vi.fn() }) },
+      },
+    },
+    useUtils: () => ({
+      apps: {
+        shared: {
+          list: { fetch: vi.fn() },
+          getCount: { fetch: vi.fn() },
+          getCounts: { fetch: vi.fn() },
+          get: { fetch: vi.fn() },
+        },
+        storage: { get: { fetch: vi.fn() }, list: { fetch: vi.fn() }, getQuota: { fetch: vi.fn() } },
+      },
+    }),
+  },
+}));
+
+// eslint-disable-next-line import/first
+import { PageBlockHost } from '~/components/AppBlocks/PageBlockHost';
+
+const SAME_ORIGIN_SRC = `${window.location.origin}/`;
+
+const baseProps = {
+  appBlockId: 'apb_test',
+  blockId: 'my-page-app',
+  appId: 'app_test',
+  blockInstanceId: 'page_apb_test',
+  appName: 'Budgeted Generator',
+  iframeSrc: SAME_ORIGIN_SRC,
+  sandbox: 'allow-scripts',
+  trustTier: 'internal' as const,
+  slug: 'my-page-app',
+  token: 'tok_abc',
+  expiresAt: new Date(Date.now() + 15 * 60_000).toISOString(),
+  declaredScopes: ['apps:storage:read'],
+  missingScopes: [] as string[],
+  needsConsent: false,
+  tokenError: false,
+  viewer: { id: 42, username: 'tester' },
+  theme: 'light' as const,
+};
+
+let fetchSpy: ReturnType<typeof vi.spyOn>;
+const isBeacon = (call: unknown[]) =>
+  typeof call[0] === 'string' && (call[0] as string).includes('/api/track/block-render');
+const beaconCalls = () => fetchSpy.mock.calls.filter(isBeacon);
+const beaconStatuses = (): string[] =>
+  beaconCalls().map((c: unknown[]) => {
+    const init = c[1] as RequestInit | undefined;
+    return (JSON.parse(String(init?.body ?? '{}')) as { status?: string }).status ?? 'ok';
+  });
+
+beforeEach(() => {
+  fetchSpy = vi
+    .spyOn(globalThis, 'fetch')
+    .mockResolvedValue({ ok: true, status: 200, json: async () => ({}) } as Response);
+});
+afterEach(() => {
+  fetchSpy.mockRestore();
+});
+
+function postFromBlock(type: string, payload?: unknown) {
+  const iframeEl = page.getByTestId('app-page-iframe').element() as HTMLIFrameElement;
+  const cw = iframeEl.contentWindow;
+  if (!cw) throw new Error('iframe contentWindow missing');
+  window.dispatchEvent(
+    new MessageEvent('message', { data: { type, payload }, origin: window.location.origin, source: cw })
+  );
+}
+
+async function driveToReady() {
+  await vi.waitFor(() => {
+    const el = page.getByTestId('app-page-iframe').element() as HTMLIFrameElement;
+    if (!el.contentWindow) throw new Error('not mounted yet');
+  });
+  await vi.waitFor(() => {
+    postFromBlock('BLOCK_READY', {});
+    const el = page.getByTestId('app-page-iframe').element() as HTMLIFrameElement;
+    if (el.getAttribute('data-block-ready') !== 'true') throw new Error('not ready yet');
+  });
+}
+
+const fallbackQuery = () => page.getByTestId('app-page-fallback').query();
+const iframeQuery = () => page.getByTestId('app-page-iframe').query();
+
+describe('a READY page with a transient token failure', () => {
+  test('🔴 is NOT torn down while recovery is still pending', async () => {
+    const { rerender } = await renderWithProviders(
+      <PageBlockHost {...baseProps} onConsentGranted={vi.fn()} onRetryToken={vi.fn()} />
+    );
+    await driveToReady();
+    expect(beaconCalls()).toHaveLength(1);
+
+    // The upstream hook is retrying: it reports the failure (`tokenError`) but has
+    // NOT settled, so `tokenTerminal` stays false. Even with the token already
+    // gone, the running app must be left alone.
+    await rerender(
+      <PageBlockHost
+        {...baseProps}
+        token={null}
+        tokenError
+        tokenTerminal={false}
+        onConsentGranted={vi.fn()}
+        onRetryToken={vi.fn()}
+      />
+    );
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(fallbackQuery()).toBeNull();
+    expect(iframeQuery()).not.toBeNull();
+    expect(beaconCalls()).toHaveLength(1);
+  });
+
+  test('is untouched when the hook RETAINED a live token through the blip', async () => {
+    const { rerender } = await renderWithProviders(
+      <PageBlockHost {...baseProps} onConsentGranted={vi.fn()} onRetryToken={vi.fn()} />
+    );
+    await driveToReady();
+
+    // The common case: refresh failed, but the held credential is still valid, so
+    // the hook keeps serving it. `tokenError` is set; the page must ignore it.
+    await rerender(
+      <PageBlockHost
+        {...baseProps}
+        tokenError
+        tokenTerminal={false}
+        onConsentGranted={vi.fn()}
+        onRetryToken={vi.fn()}
+      />
+    );
+    await new Promise((r) => setTimeout(r, 50));
+
+    expect(fallbackQuery()).toBeNull();
+    expect(beaconCalls()).toHaveLength(1);
+  });
+});
+
+describe('a READY page whose credential is GONE for good', () => {
+  test('🔴 escalates to the real terminal state instead of silently 401ing', async () => {
+    const onRetryToken = vi.fn();
+    const { rerender } = await renderWithProviders(
+      <PageBlockHost {...baseProps} onConsentGranted={vi.fn()} onRetryToken={onRetryToken} />
+    );
+    await driveToReady();
+
+    await rerender(
+      <PageBlockHost
+        {...baseProps}
+        token={null}
+        tokenError
+        tokenTerminal
+        onConsentGranted={vi.fn()}
+        onRetryToken={onRetryToken}
+      />
+    );
+
+    // The user now SEES the failure and has a way forward — previously the page
+    // just sat there looking fine while every call 401'd.
+    await expect.element(page.getByTestId('app-page-fallback')).toBeInTheDocument();
+    expect(document.querySelector('[data-block-fallback="token_error"]')).not.toBeNull();
+    expect(document.querySelector('[data-block-fallback-retry="true"]')).not.toBeNull();
+  });
+
+  test('🔴 emits NO second beacon — the mount already reported its outcome', async () => {
+    const { rerender } = await renderWithProviders(
+      <PageBlockHost {...baseProps} onConsentGranted={vi.fn()} onRetryToken={vi.fn()} />
+    );
+    await driveToReady();
+    expect(beaconStatuses()).toEqual(['ok']);
+
+    await rerender(
+      <PageBlockHost
+        {...baseProps}
+        token={null}
+        tokenError
+        tokenTerminal
+        onConsentGranted={vi.fn()}
+        onRetryToken={vi.fn()}
+      />
+    );
+    await expect.element(page.getByTestId('app-page-fallback')).toBeInTheDocument();
+    // Let #3480's bounded auto-retry run its whole course too.
+    await new Promise((r) => setTimeout(r, 9_000));
+
+    // Exactly one, and it still says `ok`: the page LOAD did succeed. Counting an
+    // `error` here would corrupt the denominator the BlockRenderFailureRate alert
+    // is built on ("page loads the platform could not recover on its own").
+    expect(beaconStatuses()).toEqual(['ok']);
+  }, 20_000);
+
+  test("re-arms #3480's bounded auto-retry, which re-mints ONCE then settles", async () => {
+    /**
+     * Drives the re-mint loop the way the real route does. `onRetryToken` is
+     * `useBlockToken.refresh`, so a re-mint ATTEMPT briefly clears the failure
+     * props and then fails again — which is what re-reaches the terminal fast
+     * instead of waiting out the 15s token-wait window. An inert `vi.fn()` here
+     * would leave the props frozen and the host parked in `loading`, testing
+     * nothing.
+     */
+    function Harness({ dead, onRemint }: { dead: boolean; onRemint: () => void }) {
+      const [failing, setFailing] = useState(true);
+      const gone = dead && failing;
+      return (
+        <PageBlockHost
+          {...baseProps}
+          token={dead ? null : baseProps.token}
+          tokenError={gone}
+          tokenTerminal={gone}
+          onConsentGranted={vi.fn()}
+          onRetryToken={() => {
+            onRemint();
+            setFailing(false);
+            setTimeout(() => setFailing(true), 10);
+          }}
+        />
+      );
+    }
+
+    const onRemint = vi.fn();
+    const { rerender } = await renderWithProviders(<Harness dead={false} onRemint={onRemint} />);
+    await driveToReady();
+    expect(onRemint).not.toHaveBeenCalled();
+
+    await rerender(<Harness dead onRemint={onRemint} />);
+    await expect.element(page.getByTestId('app-page-fallback')).toBeInTheDocument();
+
+    // `error` is an AUTH terminal, so the one automatic attempt spends a re-mint…
+    await vi.waitFor(
+      () => {
+        if (onRemint.mock.calls.length < 1) throw new Error('no automatic re-mint yet');
+      },
+      { timeout: 8_000 }
+    );
+
+    // …and then it SETTLES: bounded, never an unbounded auth loop against the
+    // rate-limited mint endpoint. MAX_AUTO_REMINTS is 1.
+    await new Promise((r) => setTimeout(r, 8_000));
+    expect(onRemint.mock.calls.length).toBe(1);
+
+    // What the user is left with: the real terminal message plus an UNMISSABLE
+    // manual Retry — the path forward, never a dead end.
+    expect(document.querySelector('[data-block-fallback="token_error"]')).not.toBeNull();
+    expect(document.querySelector('[data-block-fallback-retry-prominent="true"]')).not.toBeNull();
+    // And still exactly one beacon for the whole episode.
+    expect(beaconStatuses()).toEqual(['ok']);
+  }, 25_000);
+});
+
+describe('backward compatibility', () => {
+  test('🔴 omitting `tokenTerminal` leaves a ready page byte-identical', async () => {
+    // Every pre-existing caller (ReviewBlockPreviewHost, the dev-tunnel page
+    // before it was wired) passes no `tokenTerminal`. A ready page must behave
+    // exactly as before: `tokenError` alone can never tear it down.
+    const { rerender } = await renderWithProviders(
+      <PageBlockHost {...baseProps} onConsentGranted={vi.fn()} onRetryToken={vi.fn()} />
+    );
+    await driveToReady();
+
+    await rerender(
+      <PageBlockHost
+        {...baseProps}
+        token={null}
+        tokenError
+        onConsentGranted={vi.fn()}
+        onRetryToken={vi.fn()}
+      />
+    );
+    await new Promise((r) => setTimeout(r, 100));
+
+    expect(fallbackQuery()).toBeNull();
+    expect(beaconCalls()).toHaveLength(1);
+  });
+
+  test('a LOADING page still escalates on `tokenError` alone (unchanged)', async () => {
+    renderWithProviders(
+      <PageBlockHost
+        {...baseProps}
+        token={null}
+        tokenError
+        onConsentGranted={vi.fn()}
+        onRetryToken={vi.fn()}
+      />
+    );
+    // Unchanged pre-existing behaviour: a hard mint failure before the block ever
+    // loaded is terminal immediately, rather than waiting out the 15s token-wait.
+    await expect.element(page.getByTestId('app-page-fallback')).toBeInTheDocument();
+    expect(document.querySelector('[data-block-fallback="token_error"]')).not.toBeNull();
+  });
+});

--- a/src/components/AppBlocks/__tests__/blockTokenRetry.test.ts
+++ b/src/components/AppBlocks/__tests__/blockTokenRetry.test.ts
@@ -72,9 +72,7 @@ describe('decideRefreshRetry — the bounded automatic re-mint', () => {
 
   test('a garbage attempt count cannot widen the budget', () => {
     expect(decideRefreshRetry({ attempts: -3 }).kind).toBe('retry');
-    expect(decideRefreshRetry({ attempts: 2.9 })).toEqual(
-      decideRefreshRetry({ attempts: 2 })
-    );
+    expect(decideRefreshRetry({ attempts: 2.9 })).toEqual(decideRefreshRetry({ attempts: 2 }));
   });
 });
 
@@ -84,9 +82,9 @@ describe('shouldRetainTokenOnFailure — keeping the block alive through a blip'
 
   test('retains a token that is still live (the T-2min refresh-failure case)', () => {
     // The real shape: refresh fires 2 minutes before expiry and fails.
-    expect(
-      shouldRetainTokenOnFailure({ token: 'tok', expiresAt: iso(2 * 60_000), now })
-    ).toBe(true);
+    expect(shouldRetainTokenOnFailure({ token: 'tok', expiresAt: iso(2 * 60_000), now })).toBe(
+      true
+    );
     expect(shouldRetainTokenOnFailure({ token: 'tok', expiresAt: iso(1), now })).toBe(true);
   });
 

--- a/src/components/AppBlocks/__tests__/blockTokenRetry.test.ts
+++ b/src/components/AppBlocks/__tests__/blockTokenRetry.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, test } from 'vitest';
 import {
   MAX_REFRESH_RETRIES,
   REFRESH_RETRY_BACKOFF_MS,
+  TERMINAL_MINT_STATUSES,
   decideRefreshRetry,
+  isTerminalMintStatus,
   msUntilExpiry,
   shouldRetainTokenOnFailure,
 } from '~/components/AppBlocks/blockTokenRetry';
@@ -117,5 +119,51 @@ describe('msUntilExpiry — the settled-token sweep deadline', () => {
   test('returns null when there is no usable expiry to sweep at', () => {
     expect(msUntilExpiry(null, now)).toBeNull();
     expect(msUntilExpiry('nonsense', now)).toBeNull();
+  });
+});
+
+describe('🔴 terminal mint refusals — never retry, never keep serving the token', () => {
+  const now = 1_700_000_000_000;
+  const live = { token: 'tok', expiresAt: new Date(now + 5 * 60_000).toISOString(), now };
+
+  test('a terminal status settles immediately, spending NO retries', () => {
+    for (const status of TERMINAL_MINT_STATUSES) {
+      expect(decideRefreshRetry({ attempts: 0, mintStatus: status })).toEqual({ kind: 'settled' });
+    }
+  });
+
+  test('🔴 a terminal status REFUSES to retain an otherwise-live token', () => {
+    // Without this the block would keep a signature-valid, unexpired credential
+    // for the rest of its lifetime after a ban / mod-delist / scope revocation —
+    // an authorization extension introduced by a resilience feature. The mint's
+    // 4xx IS the revocation signal for those (the runtime middleware only
+    // re-checks uninstall/disable).
+    for (const status of TERMINAL_MINT_STATUSES) {
+      expect(shouldRetainTokenOnFailure({ ...live, mintStatus: status })).toBe(false);
+    }
+    // Control: the same token IS retained on a transient failure.
+    expect(shouldRetainTokenOnFailure(live)).toBe(true);
+  });
+
+  test('TRANSIENT failures keep the full retry + retention behaviour', () => {
+    // 5xx, 429 (has its own jittered in-band pause), and network/abort
+    // (status undefined) must all stay retryable and retainable.
+    for (const status of [undefined, 429, 500, 502, 503, 504]) {
+      expect(decideRefreshRetry({ attempts: 0, mintStatus: status }).kind).toBe('retry');
+      expect(shouldRetainTokenOnFailure({ ...live, mintStatus: status })).toBe(true);
+    }
+  });
+
+  test('429 is deliberately NOT terminal', () => {
+    // It is the one 4xx that explicitly means "try again later", and fetchOnce
+    // already honours it with a jittered ~60s in-band pause.
+    expect(isTerminalMintStatus(429)).toBe(false);
+    expect(TERMINAL_MINT_STATUSES).not.toContain(429);
+  });
+
+  test('isTerminalMintStatus is closed over the enumerated set', () => {
+    expect(isTerminalMintStatus(undefined)).toBe(false);
+    for (const s of [200, 418, 500, 502, 503]) expect(isTerminalMintStatus(s)).toBe(false);
+    for (const s of TERMINAL_MINT_STATUSES) expect(isTerminalMintStatus(s)).toBe(true);
   });
 });

--- a/src/components/AppBlocks/__tests__/blockTokenRetry.test.ts
+++ b/src/components/AppBlocks/__tests__/blockTokenRetry.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, test } from 'vitest';
+import {
+  MAX_REFRESH_RETRIES,
+  REFRESH_RETRY_BACKOFF_MS,
+  decideRefreshRetry,
+  msUntilExpiry,
+  shouldRetainTokenOnFailure,
+} from '~/components/AppBlocks/blockTokenRetry';
+
+/**
+ * Bounds + retention rules for `useBlockToken`'s refresh-failure recovery.
+ *
+ * These are the cheap, exhaustive, node-env half of the coverage. The hook
+ * itself — the REAL path, with real React, real timers and a real fetch
+ * boundary — is driven in `useBlockToken.browser.test.tsx`; a suite that only
+ * exercised these pure functions would prove the rules are right and nothing
+ * about whether the hook actually applies them.
+ *
+ * 🔴 REACHABILITY IS ASSERTED, NOT ASSUMED. This codebase has shipped a stated
+ * cap that provably could never fire because an earlier check always won. Every
+ * bound below is proven binding by walking the state that reaches it.
+ */
+
+describe('decideRefreshRetry — the bounded automatic re-mint', () => {
+  test('every attempt up to the cap is REACHABLE and schedules a retry', () => {
+    // Walk the real sequence: 0 attempts spent → 1 → 2 → … Each step must be
+    // reachable, i.e. actually return `retry`, or the cap below is dead code.
+    const reached: number[] = [];
+    for (let attempts = 0; attempts < MAX_REFRESH_RETRIES; attempts++) {
+      const d = decideRefreshRetry({ attempts });
+      expect(d.kind).toBe('retry');
+      if (d.kind !== 'retry') throw new Error('unreachable');
+      expect(d.attempt).toBe(attempts + 1);
+      reached.push(d.attempt);
+    }
+    // Not a tautology: proves the loop really produced every attempt number and
+    // that MAX_REFRESH_RETRIES > 0 (a 0 cap would make the whole feature inert).
+    expect(reached).toEqual([1, 2, 3]);
+    expect(MAX_REFRESH_RETRIES).toBeGreaterThan(0);
+  });
+
+  test('the cap BINDS: the attempt after the budget settles', () => {
+    expect(decideRefreshRetry({ attempts: MAX_REFRESH_RETRIES })).toEqual({ kind: 'settled' });
+    expect(decideRefreshRetry({ attempts: MAX_REFRESH_RETRIES + 5 })).toEqual({ kind: 'settled' });
+  });
+
+  test('backoff is escalating and covers exactly the attempt budget', () => {
+    // 🔴 Pins the two constants to each other. If MAX_REFRESH_RETRIES is raised
+    // without extending the table, the extra attempts silently reuse the last
+    // delay — survivable, but not what the comment promises.
+    expect(REFRESH_RETRY_BACKOFF_MS).toHaveLength(MAX_REFRESH_RETRIES);
+    for (let i = 1; i < REFRESH_RETRY_BACKOFF_MS.length; i++) {
+      expect(REFRESH_RETRY_BACKOFF_MS[i]).toBeGreaterThan(REFRESH_RETRY_BACKOFF_MS[i - 1]);
+    }
+    for (let attempts = 0; attempts < MAX_REFRESH_RETRIES; attempts++) {
+      const d = decideRefreshRetry({ attempts });
+      if (d.kind !== 'retry') throw new Error('unreachable');
+      expect(d.delayMs).toBe(REFRESH_RETRY_BACKOFF_MS[attempts]);
+    }
+  });
+
+  test('🔴 the WHOLE budget stays far under the endpoint rate limit', () => {
+    // /api/v1/block-tokens allows 60/min per (user, instance). The worst case —
+    // every automatic attempt failing — must not be able to approach that.
+    const totalWindowMs = REFRESH_RETRY_BACKOFF_MS.reduce((a, b) => a + b, 0);
+    expect(MAX_REFRESH_RETRIES).toBeLessThanOrEqual(5);
+    expect(totalWindowMs).toBeGreaterThanOrEqual(30_000);
+    // Requests per minute implied by the automatic loop, generously rounded up.
+    const perMinute = (MAX_REFRESH_RETRIES / totalWindowMs) * 60_000;
+    expect(perMinute).toBeLessThan(10);
+  });
+
+  test('a garbage attempt count cannot widen the budget', () => {
+    expect(decideRefreshRetry({ attempts: -3 }).kind).toBe('retry');
+    expect(decideRefreshRetry({ attempts: 2.9 })).toEqual(
+      decideRefreshRetry({ attempts: 2 })
+    );
+  });
+});
+
+describe('shouldRetainTokenOnFailure — keeping the block alive through a blip', () => {
+  const now = 1_700_000_000_000;
+  const iso = (offsetMs: number) => new Date(now + offsetMs).toISOString();
+
+  test('retains a token that is still live (the T-2min refresh-failure case)', () => {
+    // The real shape: refresh fires 2 minutes before expiry and fails.
+    expect(
+      shouldRetainTokenOnFailure({ token: 'tok', expiresAt: iso(2 * 60_000), now })
+    ).toBe(true);
+    expect(shouldRetainTokenOnFailure({ token: 'tok', expiresAt: iso(1), now })).toBe(true);
+  });
+
+  test('drops an expired token — never serve a dead credential', () => {
+    expect(shouldRetainTokenOnFailure({ token: 'tok', expiresAt: iso(0), now })).toBe(false);
+    expect(shouldRetainTokenOnFailure({ token: 'tok', expiresAt: iso(-1), now })).toBe(false);
+  });
+
+  test('🔴 FAILS CLOSED on an absent or unparseable expiry', () => {
+    // We cannot prove the token is live → drop it, rather than hand the block a
+    // credential of unknown validity that would silently 401.
+    expect(shouldRetainTokenOnFailure({ token: 'tok', expiresAt: null, now })).toBe(false);
+    expect(shouldRetainTokenOnFailure({ token: 'tok', expiresAt: 'not-a-date', now })).toBe(false);
+    expect(shouldRetainTokenOnFailure({ token: 'tok', expiresAt: '', now })).toBe(false);
+  });
+
+  test('nothing to retain when there is no token (the initial-load failure)', () => {
+    expect(shouldRetainTokenOnFailure({ token: null, expiresAt: iso(60_000), now })).toBe(false);
+  });
+});
+
+describe('msUntilExpiry — the settled-token sweep deadline', () => {
+  const now = 1_700_000_000_000;
+
+  test('returns the remaining lifetime, floored at 0', () => {
+    expect(msUntilExpiry(new Date(now + 5_000).toISOString(), now)).toBe(5_000);
+    expect(msUntilExpiry(new Date(now - 5_000).toISOString(), now)).toBe(0);
+  });
+
+  test('returns null when there is no usable expiry to sweep at', () => {
+    expect(msUntilExpiry(null, now)).toBeNull();
+    expect(msUntilExpiry('nonsense', now)).toBeNull();
+  });
+});

--- a/src/components/AppBlocks/blockTokenRetry.ts
+++ b/src/components/AppBlocks/blockTokenRetry.ts
@@ -48,6 +48,38 @@ export const MAX_REFRESH_RETRIES = 3;
  */
 export const REFRESH_RETRY_BACKOFF_MS: readonly number[] = [2_000, 8_000, 30_000];
 
+/**
+ * Mint failures the server will keep refusing. Retrying cannot help — and, the
+ * security-relevant half, CONTINUING TO SERVE the held token would extend
+ * authorization past a decision the server has already made.
+ *
+ * 🔴 WHY THIS EXISTS. The mint enforces ban, moderator delist ("Block is not
+ * approved"), account-level app access, per-viewer scope narrowing, and the
+ * `.red` domain gate — and for most of those the block-scope middleware has NO
+ * runtime re-check (only uninstall/disable are re-checked live, via
+ * `BlockRevocation`). So the mint's 4xx IS the revocation signal. Before this
+ * PR, any mint failure unmounted the block within ~0s, which incidentally
+ * destroyed the block's in-memory copy of the JWT. Retention is right for a
+ * transient 5xx/network blip and WRONG here: it would keep a signature-valid,
+ * unexpired credential live for the rest of its lifetime (~2 min normally, up to
+ * the full ~15 min if a `visibilitychange` mint is what failed, and up to 4h for
+ * a dev-tunnel token). Status-blind retention would have been an authorization
+ * extension introduced by a resilience feature.
+ *
+ * 409/422 are included as "the server rejected this request on its merits";
+ * 429 is deliberately ABSENT (it is explicitly transient and already has its own
+ * jittered in-band pause), as is every 5xx.
+ */
+export const TERMINAL_MINT_STATUSES: readonly number[] = [401, 403, 404, 409, 422];
+
+/** An Error carrying the mint response's HTTP status (absent for network/abort). */
+export type MintError = Error & { status?: number };
+
+/** True when the mint's HTTP status means "refused, and will stay refused". */
+export function isTerminalMintStatus(status: number | undefined): boolean {
+  return status !== undefined && TERMINAL_MINT_STATUSES.includes(status);
+}
+
 export type RefreshRetryDecision =
   /** Arm a backoff timer for another automatic attempt. */
   | {
@@ -68,7 +100,16 @@ export type RefreshRetryDecision =
  * `attempts` is the number of automatic attempts ALREADY performed in this
  * failure episode (0 on the first failure after a success).
  */
-export function decideRefreshRetry(args: { attempts: number }): RefreshRetryDecision {
+export function decideRefreshRetry(args: {
+  attempts: number;
+  /** HTTP status of the failed mint, when the failure was an HTTP response. */
+  mintStatus?: number;
+}): RefreshRetryDecision {
+  // 🔴 A terminal refusal settles IMMEDIATELY. Retrying a 403 cannot succeed:
+  // it just burns 3 more POSTs against a rate-limited endpoint and delays the
+  // honest terminal state by ~40s (on the model slot, 40s of animated skeleton
+  // where the documented contract is to collapse instantly).
+  if (isTerminalMintStatus(args.mintStatus)) return { kind: 'settled' };
   const attempts = Math.max(0, Math.floor(args.attempts));
   if (attempts >= MAX_REFRESH_RETRIES) return { kind: 'settled' };
   const delayMs =
@@ -104,8 +145,14 @@ export function shouldRetainTokenOnFailure(args: {
   token: string | null;
   expiresAt: string | null;
   now: number;
+  /** HTTP status of the failed mint, when the failure was an HTTP response. */
+  mintStatus?: number;
 }): boolean {
-  const { token, expiresAt, now } = args;
+  const { token, expiresAt, now, mintStatus } = args;
+  // 🔴 NEVER retain past a terminal refusal — see TERMINAL_MINT_STATUSES. This is
+  // the difference between "the network blipped, keep working" and "you have been
+  // banned/delisted, keep working anyway".
+  if (isTerminalMintStatus(mintStatus)) return false;
   if (!token || !expiresAt) return false;
   const ms = new Date(expiresAt).getTime();
   if (!Number.isFinite(ms)) return false;

--- a/src/components/AppBlocks/blockTokenRetry.ts
+++ b/src/components/AppBlocks/blockTokenRetry.ts
@@ -1,0 +1,122 @@
+// Pure decisions for `useBlockToken`'s mid-session refresh-failure recovery.
+//
+// Extracted from the hook for the same reason `pageBlockHostLogic` was extracted
+// from PageBlockHost: civitai-web's `unit` vitest project runs `environment:
+// 'node'` and only collects `*.test.ts`, so a decision that lives inside a React
+// hook can only ever be exercised through a browser test. The BOUNDS below are
+// the security/cost-relevant part (they gate an automatic loop against a
+// rate-limited endpoint), so they get cheap, exhaustive, node-env coverage —
+// and the hook keeps ONE code path, reading these functions rather than
+// re-deriving the rules inline.
+//
+// ── THE DEFECT THESE EXIST FOR ───────────────────────────────────────────────
+// A refresh that FAILED mid-session used to set `error`, null the token, and
+// schedule NOTHING. The success path was the only place a timer was ever armed,
+// so the sole route back was the user hiding and re-showing the tab
+// (`visibilitychange`). Downstream that read as: the model-slot block VANISHING
+// mid-session (BlockHost collapses on `error`) and taking in-progress state with
+// it, or the page host silently sitting on a dead token while the block 401s.
+
+/**
+ * Maximum AUTOMATIC re-mint attempts after a refresh failure, per failure
+ * episode (reset on the next success).
+ *
+ * 🔴 BOUNDED, DELIBERATELY. `/api/v1/block-tokens` is rate-limited to 60/min per
+ * (user, instance). An unbounded auth-failure loop is exactly the shape that
+ * burns that budget and turns a brief upstream blip into a self-inflicted
+ * rate-limit event. After this many attempts the hook SETTLES: `terminal` goes
+ * true, consumers show their real terminal state, and recovery is user-driven
+ * (the page host's manual Retry, a `visibilitychange`, or an explicit
+ * `refresh()`).
+ *
+ * 🔴 ROLLBACK: setting this to 0 cleanly restores the pre-fix behaviour — every
+ * failure settles immediately and no automatic timer is ever armed. There is no
+ * feature flag on this path; this constant is the kill switch.
+ */
+export const MAX_REFRESH_RETRIES = 3;
+
+/**
+ * Backoff before automatic attempt N (index 0 = the first retry). Escalating, so
+ * a one-off blip clears in seconds while a sustained outage stops hammering.
+ *
+ * 🔴 The last entry (30s) is deliberately HALF the 60s rate-limit window, so even
+ * the worst case — every attempt failing — spends 3 requests across ~40s, an
+ * order of magnitude under the 60/min ceiling.
+ *
+ * Indices past the end reuse the last value (defensive; today the array covers
+ * MAX_REFRESH_RETRIES exactly, and a test pins that).
+ */
+export const REFRESH_RETRY_BACKOFF_MS: readonly number[] = [2_000, 8_000, 30_000];
+
+export type RefreshRetryDecision =
+  /** Arm a backoff timer for another automatic attempt. */
+  | { kind: 'retry'; /** 1-based index of the attempt being scheduled. */ attempt: number; delayMs: number }
+  /** Budget spent — no further AUTOMATIC attempt. The hook is now `terminal`. */
+  | { kind: 'settled' };
+
+/**
+ * Decide whether another automatic re-mint should be scheduled after a failure.
+ *
+ * Pure so the bound is provable without driving real 2s/8s/30s windows, and so
+ * the hook cannot disagree with itself: the same decision drives BOTH the timer
+ * that is armed AND the `terminal` flag consumers key their destructive UI on.
+ *
+ * `attempts` is the number of automatic attempts ALREADY performed in this
+ * failure episode (0 on the first failure after a success).
+ */
+export function decideRefreshRetry(args: { attempts: number }): RefreshRetryDecision {
+  const attempts = Math.max(0, Math.floor(args.attempts));
+  if (attempts >= MAX_REFRESH_RETRIES) return { kind: 'settled' };
+  const delayMs =
+    REFRESH_RETRY_BACKOFF_MS[attempts] ??
+    REFRESH_RETRY_BACKOFF_MS[REFRESH_RETRY_BACKOFF_MS.length - 1];
+  return { kind: 'retry', attempt: attempts + 1, delayMs };
+}
+
+/**
+ * Should a REFRESH failure keep the token we already hold?
+ *
+ * 🔴 THIS IS THE FIX FOR THE MODEL-SLOT VANISH. A refresh failure means we could
+ * not obtain a NEW credential — it says nothing about the one already in hand.
+ * Refreshes are scheduled at T-2min, so at failure time the held token normally
+ * has ~2 minutes of life left. Nulling it (the old behaviour) unmounted the
+ * whole iframe: in-progress user state was destroyed, and the eventual recovery
+ * REMOUNTED the host, re-running BLOCK_INIT and emitting a SECOND impression
+ * beacon for one logical view. Retaining it keeps the block mounted and working
+ * through the entire retry window, so a transient blip is invisible.
+ *
+ * 🔴 FAIL CLOSED on an unusable expiry. A missing/unparseable `expiresAt` means
+ * we cannot prove the token is still live, so we drop it rather than serve a
+ * credential of unknown validity — that would be the "silently 401s" failure
+ * this change exists to end.
+ *
+ * NOTE the caller re-evaluates this on EVERY failure, so a token that expires
+ * part-way through the retry sequence is dropped at the next attempt. The one
+ * case that needs separate handling is a token retained at the moment the budget
+ * SETTLES (no further failure will re-evaluate it) — `msUntilExpiry` gives the
+ * caller the deadline to sweep it at.
+ */
+export function shouldRetainTokenOnFailure(args: {
+  token: string | null;
+  expiresAt: string | null;
+  now: number;
+}): boolean {
+  const { token, expiresAt, now } = args;
+  if (!token || !expiresAt) return false;
+  const ms = new Date(expiresAt).getTime();
+  if (!Number.isFinite(ms)) return false;
+  return ms > now;
+}
+
+/**
+ * Milliseconds until `expiresAt`, floored at 0, or `null` when the expiry is
+ * absent/unparseable. Used to arm the one-shot sweep that drops a token retained
+ * across a SETTLED failure — without it the host would hold an expired token
+ * forever and quietly 401, which is precisely the page-host half of the defect.
+ */
+export function msUntilExpiry(expiresAt: string | null, now: number): number | null {
+  if (!expiresAt) return null;
+  const ms = new Date(expiresAt).getTime();
+  if (!Number.isFinite(ms)) return null;
+  return Math.max(0, ms - now);
+}

--- a/src/components/AppBlocks/blockTokenRetry.ts
+++ b/src/components/AppBlocks/blockTokenRetry.ts
@@ -50,7 +50,11 @@ export const REFRESH_RETRY_BACKOFF_MS: readonly number[] = [2_000, 8_000, 30_000
 
 export type RefreshRetryDecision =
   /** Arm a backoff timer for another automatic attempt. */
-  | { kind: 'retry'; /** 1-based index of the attempt being scheduled. */ attempt: number; delayMs: number }
+  | {
+      kind: 'retry';
+      /** 1-based index of the attempt being scheduled. */ attempt: number;
+      delayMs: number;
+    }
   /** Budget spent — no further AUTOMATIC attempt. The hook is now `terminal`. */
   | { kind: 'settled' };
 

--- a/src/components/AppBlocks/useBlockToken.browser.test.tsx
+++ b/src/components/AppBlocks/useBlockToken.browser.test.tsx
@@ -1,0 +1,403 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+// `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
+import { cleanup } from 'vitest-browser-react';
+import { renderWithProviders } from '../../../test/component-setup';
+import { useBlockToken } from '~/components/AppBlocks/useBlockToken';
+import {
+  MAX_REFRESH_RETRIES,
+  REFRESH_RETRY_BACKOFF_MS,
+} from '~/components/AppBlocks/blockTokenRetry';
+import type { BlockInstall, SlotContext } from '~/components/AppBlocks/types';
+
+/**
+ * `useBlockToken` MID-SESSION REFRESH-FAILURE RECOVERY.
+ *
+ * 🔴 THE DEFECT THIS SUITE EXISTS FOR. A refresh that failed set `error`, nulled
+ * the token, and scheduled NOTHING — the success path was the only place a timer
+ * was ever armed. The sole route back was the user hiding and re-showing the tab.
+ * Downstream that read as the model-slot block VANISHING mid-session (taking
+ * in-progress state with it, then remounting and double-counting its impression),
+ * or the page host silently sitting on a dead token while the block 401'd.
+ *
+ * 🔴 THIS SUITE EXERCISES THE REAL PATH — that is its whole point. It renders the
+ * REAL hook with real React, real state, and the real timer machinery (only the
+ * CLOCK is faked, via `shouldAdvanceTime` so DOM polling still works). The ONLY
+ * thing stubbed is `fetch` — the network boundary, i.e. the failure being
+ * injected — never the hook, never the decision functions, never a timer wrapper.
+ * Stubbing any of those would make the fiber quiescent and hide exactly the
+ * batching/ordering behaviour these assertions depend on.
+ *
+ * The bounds themselves get exhaustive cheap coverage in the node-env
+ * `__tests__/blockTokenRetry.test.ts`; here we prove the hook APPLIES them.
+ */
+
+const INSTANCE_ID = 'bki_test_instance';
+
+// The hook reads only `install.blockInstanceId` and forwards `context` verbatim.
+const install = { blockInstanceId: INSTANCE_ID } as unknown as BlockInstall;
+const context = { slotId: 'model.sidebar_top', modelId: 123 } as unknown as SlotContext;
+
+/** A token whose refresh (T-2min) lands well before expiry, so a failure at the
+ *  refresh moment still leaves a comfortably-live credential to retain. */
+const TOKEN_TTL_MS = 15 * 60_000;
+const REFRESH_AT_MS = TOKEN_TTL_MS - 2 * 60_000; // REFRESH_LEAD_MS
+
+let mintCount = 0;
+
+function mintOk(nth: number) {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => ({
+      token: `tok_${nth}`,
+      expiresAt: new Date(Date.now() + TOKEN_TTL_MS).toISOString(),
+      needsConsent: false,
+      missingScopes: [],
+      domain: 'blue',
+      maxBrowsingLevel: 3,
+    }),
+  } as unknown as Response;
+}
+const mintFail = { ok: false, status: 500, json: async () => ({}) } as unknown as Response;
+const mint429 = { ok: false, status: 429, json: async () => ({}) } as unknown as Response;
+
+/** Surfaces the hook's returned contract as observable DOM attributes. */
+function TokenProbe() {
+  const r = useBlockToken(install, context);
+  return (
+    <div
+      data-testid="probe"
+      data-token={r.token ?? ''}
+      data-pending={String(r.pending)}
+      data-error={r.error ? 'true' : 'false'}
+      data-retrying={String(r.retrying)}
+      data-terminal={String(r.terminal)}
+    />
+  );
+}
+
+// React 18 commits ASYNCHRONOUSLY, so the probe is absent for the first few
+// ticks after render — every reader must tolerate that rather than throw.
+const probe = () => document.querySelector('[data-testid="probe"]') as HTMLElement | null;
+const attr = (name: string) => probe()?.getAttribute(name) ?? null;
+const readToken = () => attr('data-token');
+const readRetrying = () => attr('data-retrying') === 'true';
+const readTerminal = () => attr('data-terminal') === 'true';
+const readError = () => attr('data-error') === 'true';
+
+/** Advance the fake clock and let React flush the resulting state updates. */
+async function advance(ms: number) {
+  await vi.advanceTimersByTimeAsync(ms);
+  // Extra zero-length turns: the fetch promise chain resolves across several
+  // microtask ticks before React schedules and commits.
+  for (let i = 0; i < 4; i++) await vi.advanceTimersByTimeAsync(0);
+}
+
+async function waitForToken(expected: string) {
+  for (let i = 0; i < 200; i++) {
+    if (readToken() === expected) return;
+    await advance(1);
+  }
+  throw new Error(`token never became ${expected}; last=${String(readToken())}`);
+}
+
+let fetchSpy: ReturnType<typeof vi.fn>;
+/** Fake-clock instant of every mint request, so the tests can assert the SHAPE
+ *  of the request pattern (e.g. that a 60s pause really elapsed) rather than
+ *  just counting calls. */
+let callTimes: number[] = [];
+
+beforeEach(() => {
+  mintCount = 0;
+  callTimes = [];
+  // `shouldAdvanceTime` keeps real time moving so DOM polling can't deadlock.
+  vi.useFakeTimers({ shouldAdvanceTime: true });
+  fetchSpy = vi.fn(async () => {
+    callTimes.push(Date.now());
+    return mintOk(++mintCount);
+  });
+  vi.stubGlobal('fetch', fetchSpy);
+});
+
+/** Swap the mint outcome while keeping the call-time recording. */
+function respondWith(next: () => Response) {
+  fetchSpy.mockImplementation(async () => {
+    callTimes.push(Date.now());
+    return next();
+  });
+}
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+  vi.unstubAllGlobals();
+});
+
+describe('refresh failure at a healthy session', () => {
+  test('🔴 KEEPS the still-live token and SCHEDULES a bounded retry (was: null + nothing)', async () => {
+    renderWithProviders(<TokenProbe />);
+    await waitForToken('tok_1');
+    expect(readRetrying()).toBe(false);
+
+    // The scheduled refresh at T-2min now fails.
+    respondWith(() => mintFail);
+    await advance(REFRESH_AT_MS);
+
+    expect(readError()).toBe(true);
+    // (1) The credential we already hold is NOT destroyed. This is what keeps the
+    //     iframe mounted — the whole model-slot vanish/remount/double-beacon class.
+    expect(readToken()).toBe('tok_1');
+    // (2) A retry IS pending. Pre-fix this was false forever: nothing was armed.
+    expect(readRetrying()).toBe(true);
+    // (3) Not terminal — recovery is still under way, so no consumer may collapse.
+    expect(readTerminal()).toBe(false);
+  });
+
+  test('recovers on a later attempt: the token ROTATES and the state clears', async () => {
+    renderWithProviders(<TokenProbe />);
+    await waitForToken('tok_1');
+
+    respondWith(() => mintFail);
+    await advance(REFRESH_AT_MS);
+    expect(readRetrying()).toBe(true);
+    expect(readToken()).toBe('tok_1');
+
+    // First backoff attempt fails too…
+    await advance(REFRESH_RETRY_BACKOFF_MS[0] + 5);
+    expect(readToken()).toBe('tok_1'); // still retained
+    expect(readRetrying()).toBe(true);
+
+    // …the second succeeds.
+    respondWith(() => mintOk(++mintCount));
+    await advance(REFRESH_RETRY_BACKOFF_MS[1] + 5);
+
+    await waitForToken('tok_2');
+    expect(readRetrying()).toBe(false);
+    expect(readTerminal()).toBe(false);
+    expect(readError()).toBe(false);
+  });
+
+  test('a SUCCESS refills the retry budget for the next episode', async () => {
+    renderWithProviders(<TokenProbe />);
+    await waitForToken('tok_1');
+
+    // Episode 1: fail once, then recover.
+    respondWith(() => mintFail);
+    await advance(REFRESH_AT_MS);
+    respondWith(() => mintOk(++mintCount));
+    await advance(REFRESH_RETRY_BACKOFF_MS[0] + 5);
+    await waitForToken('tok_2');
+
+    // Episode 2 must get the FULL budget again, not the remainder of the first.
+    respondWith(() => mintFail);
+    await advance(REFRESH_AT_MS);
+    let scheduled = 0;
+    for (let i = 0; i < MAX_REFRESH_RETRIES; i++) {
+      if (readRetrying()) scheduled++;
+      await advance(REFRESH_RETRY_BACKOFF_MS[i] + 5);
+    }
+    expect(scheduled).toBe(MAX_REFRESH_RETRIES);
+  });
+});
+
+describe('exhaustion — bounded, then SETTLE', () => {
+  test('🔴 stops after MAX_REFRESH_RETRIES and never retries again on its own', async () => {
+    renderWithProviders(<TokenProbe />);
+    await waitForToken('tok_1');
+
+    respondWith(() => mintFail);
+    await advance(REFRESH_AT_MS);
+    const afterFirstFailure = fetchSpy.mock.calls.length;
+
+    for (let i = 0; i < MAX_REFRESH_RETRIES; i++) {
+      expect(readRetrying()).toBe(true);
+      await advance(REFRESH_RETRY_BACKOFF_MS[i] + 5);
+    }
+
+    // Settled: no further automatic attempt.
+    expect(readRetrying()).toBe(false);
+    const afterExhaustion = fetchSpy.mock.calls.length;
+    expect(afterExhaustion - afterFirstFailure).toBe(MAX_REFRESH_RETRIES);
+
+    // 🔴 NOT MASKED BY INDEFINITE RETRYING: a long wait issues nothing more.
+    await advance(10 * 60_000);
+    expect(fetchSpy.mock.calls.length).toBe(afterExhaustion);
+    expect(readRetrying()).toBe(false);
+  });
+
+  test('the retained token is swept at its real expiry, so `terminal` becomes TRUE', async () => {
+    renderWithProviders(<TokenProbe />);
+    await waitForToken('tok_1');
+
+    respondWith(() => mintFail);
+    await advance(REFRESH_AT_MS);
+    for (let i = 0; i < MAX_REFRESH_RETRIES; i++) {
+      await advance(REFRESH_RETRY_BACKOFF_MS[i] + 5);
+    }
+
+    // Settled, but the held token is still live → the app keeps working and the
+    // host must NOT be told the session is over yet.
+    expect(readToken()).toBe('tok_1');
+    expect(readTerminal()).toBe(false);
+
+    // 🔴 The loose end the sweep closes: without it the hook would hold this token
+    // past expiry forever and the block would quietly 401 — the exact page-host
+    // half of the reported defect, reintroduced.
+    await advance(TOKEN_TTL_MS);
+    expect(readToken()).toBe('');
+    expect(readTerminal()).toBe(true);
+  });
+});
+
+describe('HTTP 429 — the existing jittered pause is respected, not aborted', () => {
+  test('🔴 no automatic caller interrupts the in-band 60s backoff (no retry storm)', async () => {
+    renderWithProviders(<TokenProbe />);
+    await waitForToken('tok_1');
+
+    // Every mint now rate-limits. `fetchOnce` handles the FIRST 429 by sleeping
+    // ~60s (jittered +/-15s) before its single in-band retry.
+    respondWith(() => mint429);
+    // Step to just past the refresh moment so we are provably INSIDE that pause.
+    await advance(REFRESH_AT_MS - 5_000);
+    await advance(6_000);
+    const rateLimitedAt = callTimes[callTimes.length - 1];
+    const duringPause = fetchSpy.mock.calls.length;
+    expect(duringPause).toBe(2); // initial mint + the 429'd refresh
+
+    // Mid-pause, drive BOTH automatic entry points that could preempt it.
+    // 🔴 Pre-guard, either would abort the controller and immediately re-hit the
+    // endpoint that had JUST told us to back off — turning a platform-wide
+    // rate-limit event into a self-inflicted storm.
+    for (let i = 0; i < 4; i++) {
+      document.dispatchEvent(new Event('visibilitychange'));
+      await advance(5_000);
+      expect(fetchSpy.mock.calls.length).toBe(duringPause);
+    }
+
+    // Let the pause elapse. The next request must be the hook's OWN in-band
+    // retry, and it must land a full backoff later — that gap IS the invariant.
+    await advance(80_000);
+    expect(fetchSpy.mock.calls.length).toBeGreaterThan(duringPause);
+    const resumedAt = callTimes[duringPause];
+    expect(resumedAt - rateLimitedAt).toBeGreaterThanOrEqual(
+      // 60s base minus the full -15s jitter.
+      45_000
+    );
+  });
+
+  test('a sustained 429 outage stays far under the 60/min endpoint budget', async () => {
+    renderWithProviders(<TokenProbe />);
+    await waitForToken('tok_1');
+    const before = fetchSpy.mock.calls.length;
+
+    respondWith(() => mint429);
+    await advance(REFRESH_AT_MS);
+    // Run the whole budget out, generously past every pause + backoff.
+    for (let i = 0; i < MAX_REFRESH_RETRIES; i++) {
+      await advance(80_000 + REFRESH_RETRY_BACKOFF_MS[i]);
+    }
+    await advance(5 * 60_000);
+
+    const issued = fetchSpy.mock.calls.length - before;
+    // (1 + MAX_REFRESH_RETRIES) episodes x at most 2 requests each.
+    expect(issued).toBeLessThanOrEqual(2 * (MAX_REFRESH_RETRIES + 1));
+    expect(readRetrying()).toBe(false);
+  });
+});
+
+describe('visibilitychange recovery', () => {
+  test('🔴 does NOT double-fire alongside a pending backoff timer', async () => {
+    renderWithProviders(<TokenProbe />);
+    await waitForToken('tok_1');
+
+    respondWith(() => mintFail);
+    await advance(REFRESH_AT_MS);
+    const afterFailure = fetchSpy.mock.calls.length;
+    expect(readRetrying()).toBe(true);
+
+    // Inside the backoff window the armed timer is the single attempt: the
+    // visibility handler must stand down (it now shares `refreshAtRef`).
+    document.dispatchEvent(new Event('visibilitychange'));
+    await advance(REFRESH_RETRY_BACKOFF_MS[0] / 4);
+    expect(fetchSpy.mock.calls.length).toBe(afterFailure);
+
+    // The timer — and only the timer — produces the next attempt.
+    await advance(REFRESH_RETRY_BACKOFF_MS[0]);
+    expect(fetchSpy.mock.calls.length).toBe(afterFailure + 1);
+  });
+
+  test('STILL WORKS as the escape hatch once automatic recovery has settled', async () => {
+    renderWithProviders(<TokenProbe />);
+    await waitForToken('tok_1');
+
+    respondWith(() => mintFail);
+    await advance(REFRESH_AT_MS);
+    for (let i = 0; i < MAX_REFRESH_RETRIES; i++) {
+      await advance(REFRESH_RETRY_BACKOFF_MS[i] + 5);
+    }
+    expect(readRetrying()).toBe(false);
+    const settled = fetchSpy.mock.calls.length;
+
+    // The user backgrounds and returns; the outage has cleared.
+    respondWith(() => mintOk(++mintCount));
+    document.dispatchEvent(new Event('visibilitychange'));
+    await advance(50);
+
+    expect(fetchSpy.mock.calls.length).toBe(settled + 1);
+    await waitForToken('tok_2');
+    expect(readTerminal()).toBe(false);
+    expect(readError()).toBe(false);
+  });
+});
+
+describe('lifecycle', () => {
+  test('🔴 NO TIMER LEAK: unmounting mid-backoff fires nothing', async () => {
+    renderWithProviders(<TokenProbe />);
+    await waitForToken('tok_1');
+
+    respondWith(() => mintFail);
+    await advance(REFRESH_AT_MS);
+    expect(readRetrying()).toBe(true);
+    const atUnmount = fetchSpy.mock.calls.length;
+    // 🔴 A pending backoff timer really is armed right now — otherwise the
+    // assertion below would be vacuous.
+    expect(vi.getTimerCount()).toBeGreaterThan(0);
+
+    // `cleanup()` unmounts the tree — vitest-browser-react's render result has no
+    // `unmount`. This runs the hook's effect teardown, i.e. the real code path.
+    await cleanup();
+
+    // 🔴 ASSERT THE TIMER ITSELF IS GONE, not merely that no request followed.
+    // The first version of this test only checked the request count and SURVIVED
+    // a mutation that deleted the cleanup's clearTimeout — because the callback's
+    // own `!mountedRef.current` guard suppresses the fetch anyway. That guard
+    // makes the leak HARMLESS, not absent: the timer still fires and, for the
+    // expiry sweep, keeps a closure alive for up to a full token lifetime.
+    expect(vi.getTimerCount()).toBe(0);
+
+    // Well past every remaining backoff AND the token's expiry sweep.
+    await vi.advanceTimersByTimeAsync(TOKEN_TTL_MS + 60_000);
+    expect(fetchSpy.mock.calls.length).toBe(atUnmount);
+  });
+
+  test('🔴 NO TIMER LEAK: unmounting while the expiry sweep is armed fires nothing', async () => {
+    renderWithProviders(<TokenProbe />);
+    await waitForToken('tok_1');
+
+    respondWith(() => mintFail);
+    await advance(REFRESH_AT_MS);
+    for (let i = 0; i < MAX_REFRESH_RETRIES; i++) {
+      await advance(REFRESH_RETRY_BACKOFF_MS[i] + 5);
+    }
+    const atUnmount = fetchSpy.mock.calls.length;
+    // The settled state arms a one-shot sweep at the token's expiry — up to a
+    // full token lifetime away, so this is the longest-lived timer of the lot.
+    expect(vi.getTimerCount()).toBeGreaterThan(0);
+
+    await cleanup();
+    expect(vi.getTimerCount()).toBe(0);
+
+    await vi.advanceTimersByTimeAsync(TOKEN_TTL_MS + 60_000);
+    expect(fetchSpy.mock.calls.length).toBe(atUnmount);
+  });
+});

--- a/src/components/AppBlocks/useBlockToken.browser.test.tsx
+++ b/src/components/AppBlocks/useBlockToken.browser.test.tsx
@@ -59,11 +59,13 @@ function mintOk(nth: number) {
   } as unknown as Response;
 }
 const mintFail = { ok: false, status: 500, json: async () => ({}) } as unknown as Response;
+/** A TERMINAL refusal — ban / mod-delist / scope revocation / domain gate. */
+const mintForbidden = { ok: false, status: 403, json: async () => ({}) } as unknown as Response;
 const mint429 = { ok: false, status: 429, json: async () => ({}) } as unknown as Response;
 
 /** Surfaces the hook's returned contract as observable DOM attributes. */
-function TokenProbe() {
-  const r = useBlockToken(install, context);
+function TokenProbe({ instanceId = INSTANCE_ID }: { instanceId?: string }) {
+  const r = useBlockToken({ blockInstanceId: instanceId } as unknown as BlockInstall, context);
   return (
     <div
       data-testid="probe"
@@ -399,5 +401,105 @@ describe('lifecycle', () => {
 
     await vi.advanceTimersByTimeAsync(TOKEN_TTL_MS + 60_000);
     expect(fetchSpy.mock.calls.length).toBe(atUnmount);
+  });
+});
+
+describe('identity scope — the hook can outlive the app instance', () => {
+  /**
+   * 🔴 The two standalone routes (`/apps/run/[slug]`, `/apps/dev/[blockId]`) call
+   * this hook from the PAGE component, and Next does NOT remount a page on a
+   * same-route dynamic-segment navigation — so the hook instance, and every ref
+   * in it, survives an app change. The model slot is already safe (it renders
+   * with `key={install.blockInstanceId}`), which is exactly why this needs its
+   * own coverage: the safe consumer would hide the bug.
+   *
+   * Retaining a token through a failed refresh is what makes this dangerous:
+   * before that, every failure nulled the token unconditionally.
+   */
+  test('🔴 never serves the PREVIOUS app instance token after the id changes', async () => {
+    const { rerender } = await renderWithProviders(<TokenProbe instanceId="bki_app_A" />);
+    await waitForToken('tok_1');
+
+    // 🔴 The new instance's mint HANGS (never resolves). This is what isolates
+    // the identity guard: with a mint that resolves — even one that fails — the
+    // failure path nulls the token by itself, so the assertion below would pass
+    // whether or not the guard exists. A mutation defeating the guard SURVIVED
+    // the first version of this test for exactly that reason. With nothing ever
+    // resolving, the ONLY thing that can clear appA's credential is the guard.
+    fetchSpy.mockImplementation(() => new Promise<Response>(() => undefined));
+
+    // Navigate to a different app. The hook is NOT remounted (no key upstream).
+    await rerender(<TokenProbe instanceId="bki_app_B" />);
+
+    // appA's credential must be gone IMMEDIATELY — not one frame later, and not
+    // "once the new mint resolves". A stale token here is handed to appB through
+    // BLOCK_INIT / TOKEN_REFRESH.
+    expect(readToken()).toBe('');
+
+    // Still gone while the new instance has resolved nothing at all.
+    await advance(5_000);
+    expect(readToken()).toBe('');
+  });
+
+  test('the new instance gets a FULL retry budget, not the old one remainder', async () => {
+    const { rerender } = await renderWithProviders(<TokenProbe instanceId="bki_app_A" />);
+    await waitForToken('tok_1');
+
+    // Burn appA's entire automatic budget.
+    respondWith(() => mintFail);
+    await advance(REFRESH_AT_MS);
+    for (let i = 0; i < MAX_REFRESH_RETRIES; i++) {
+      await advance(REFRESH_RETRY_BACKOFF_MS[i] + 5);
+    }
+    expect(readRetrying()).toBe(false);
+
+    // Switching apps must not inherit "budget already spent" — appB would then
+    // never retry at all.
+    await rerender(<TokenProbe instanceId="bki_app_B" />);
+    await advance(50);
+    let scheduled = 0;
+    for (let i = 0; i < MAX_REFRESH_RETRIES; i++) {
+      if (readRetrying()) scheduled++;
+      await advance(REFRESH_RETRY_BACKOFF_MS[i] + 5);
+    }
+    expect(scheduled).toBe(MAX_REFRESH_RETRIES);
+  });
+});
+
+describe('🔴 a TERMINAL mint refusal (403) is not a blip', () => {
+  test('drops the held token IMMEDIATELY and settles with no retries', async () => {
+    await renderWithProviders(<TokenProbe />);
+    await waitForToken('tok_1');
+    const before = fetchSpy.mock.calls.length;
+
+    // The user was banned / the app was delisted mid-session. The mint's 4xx is
+    // the revocation signal — the block-scope middleware does NOT re-check these
+    // per request, so continuing to serve the held (still-unexpired) token would
+    // extend authorization past a decision the server already made.
+    respondWith(() => mintForbidden);
+    await advance(REFRESH_AT_MS);
+
+    expect(readToken()).toBe('');
+    expect(readRetrying()).toBe(false);
+    expect(readTerminal()).toBe(true);
+
+    // 🔴 Exactly ONE mint POST — no 3-attempt backoff against a refusal that
+    // cannot change, and no 40s of pretending the app still works.
+    expect(fetchSpy.mock.calls.length).toBe(before + 1);
+    await advance(5 * 60_000);
+    expect(fetchSpy.mock.calls.length).toBe(before + 1);
+  });
+
+  test('a 500 with the SAME held token still retains and retries (the control)', async () => {
+    await renderWithProviders(<TokenProbe />);
+    await waitForToken('tok_1');
+
+    respondWith(() => mintFail);
+    await advance(REFRESH_AT_MS);
+
+    // Same token, same moment in its lifetime — only the status differs.
+    expect(readToken()).toBe('tok_1');
+    expect(readRetrying()).toBe(true);
+    expect(readTerminal()).toBe(false);
   });
 });

--- a/src/components/AppBlocks/useBlockToken.ts
+++ b/src/components/AppBlocks/useBlockToken.ts
@@ -1,4 +1,9 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  decideRefreshRetry,
+  msUntilExpiry,
+  shouldRetainTokenOnFailure,
+} from './blockTokenRetry';
 import type { BlockInstall, SlotContext } from './types';
 
 interface UseBlockTokenResult {
@@ -20,6 +25,21 @@ interface UseBlockTokenResult {
   /** Advisory: the bitwise browsing-level ceiling for the domain (SFW on
    *  green/blue, all on red). undefined on legacy responses → fail closed. */
   maxBrowsingLevel: number | undefined;
+  /**
+   * A bounded automatic re-mint is scheduled after a refresh failure — i.e. the
+   * hook has NOT settled. Consumers must not take a destructive action (collapse
+   * the slot, tear down a ready page) while this is true: the failure is still
+   * being recovered from.
+   */
+  retrying: boolean;
+  /**
+   * 🔴 THE FLAG DESTRUCTIVE UI MUST KEY ON. True only when the mint has failed,
+   * NO usable token remains, AND no automatic recovery is pending. Derived here
+   * rather than left to each consumer so the model slot and the page host cannot
+   * disagree about what "the token is gone for good" means (they did: the slot
+   * collapsed on any `error`, the page ignored the error entirely once ready).
+   */
+  terminal: boolean;
   refresh: () => Promise<void>;
 }
 
@@ -70,11 +90,42 @@ export function useBlockToken(
   const [missingScopes, setMissingScopes] = useState<string[]>([]);
   const [domain, setDomain] = useState<'green' | 'blue' | 'red' | null>(null);
   const [maxBrowsingLevel, setMaxBrowsingLevel] = useState<number | undefined>(undefined);
+  // A bounded automatic re-mint is scheduled. State (not a ref) because it is
+  // part of the returned contract — it drives whether a consumer may take a
+  // destructive action — so it has to re-render.
+  const [retrying, setRetrying] = useState<boolean>(false);
   // M4 (audit-10): peek the current token via a ref instead of running a
   // side-effect inside a state-updater. React 18 strict-mode calls updaters
   // twice in dev; a counter/increment side-effect there would silently
   // double. Keeping the ref synchronized via the same setter avoids the trap.
   const tokenRef = useRef<string | null>(null);
+  // Mirror of `expiresAt` for the failure branch, which runs inside the
+  // `requestToken` callback and must not close over stale state to decide
+  // whether the held token is still live.
+  const expiresAtRef = useRef<string | null>(null);
+  // Automatic re-mints already spent in the CURRENT failure episode. Reset to 0
+  // on every success, so a token that refreshes cleanly for hours always gets a
+  // full budget the next time something breaks.
+  const retryAttemptsRef = useRef<number>(0);
+  // A request (INCLUDING the 60s jittered 429 pause inside fetchOnce) is in
+  // flight. 🔴 The AUTOMATIC callers gate on this so they never abort a live
+  // request: `requestToken` begins by aborting the previous controller, and
+  // aborting mid-429-pause would immediately re-hit an endpoint that JUST told
+  // us to back off — turning a platform-wide rate-limit event into a storm.
+  // Manual `refresh()` deliberately keeps abort-and-restart semantics (a
+  // consent grant must re-mint NOW, with the new scopes).
+  const inFlightRef = useRef<boolean>(false);
+  // Timers armed INSIDE `requestToken` need the idle-guarded entry point, which
+  // is defined after it. Reading it through a ref (assigned during render, like
+  // `contextRef`/`buildInitPayloadRef` below and PageBlockHost's
+  // `performRetryRef`) avoids the forward reference AND keeps every automatic
+  // path on ONE guarded entry point — three inline copies of the in-flight rule
+  // is how they drift.
+  const requestTokenIfIdleRef = useRef<() => void>(() => undefined);
+  // ONE timer ref for every scheduled follow-up: the success refresh, the
+  // failure backoff retry, and the settled-token expiry sweep. They are mutually
+  // exclusive by construction, so a single ref means at most one pending timer
+  // and the unmount cleanup below provably cannot leak one.
   const refreshTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   // Absolute Unix-ms moment we should refresh by. Source of truth for the
   // visibility-resume logic — refreshTimeoutRef alone was a poor proxy
@@ -105,6 +156,11 @@ export function useBlockToken(
     // strict-mode dev).
     if (tokenRef.current == null) setPending(true);
     setError(null);
+    // A new attempt is under way, so no timer is pending any more. Clearing this
+    // here (rather than only in the failure branch) keeps `retrying` honest for
+    // the manual/visibility entry points too.
+    setRetrying(false);
+    inFlightRef.current = true;
 
     const instanceId = install.blockInstanceId;
     const fetchOnce = async (signal: AbortSignal): Promise<TokenResponse> => {
@@ -136,7 +192,10 @@ export function useBlockToken(
     try {
       const data = await fetchOnce(controller.signal);
       if (controller.signal.aborted || !mountedRef.current) return;
+      // Recovered — hand the next failure episode a full retry budget.
+      retryAttemptsRef.current = 0;
       tokenRef.current = data.token;
+      expiresAtRef.current = data.expiresAt;
       setToken(data.token);
       setExpiresAt(data.expiresAt);
       setNeedsConsent(data.needsConsent === true);
@@ -168,18 +227,111 @@ export function useBlockToken(
         refreshTimeoutRef.current = null;
         // Pause refresh while tab is hidden — visibilitychange picks it up.
         if (typeof document !== 'undefined' && document.hidden) return;
-        void requestToken();
+        requestTokenIfIdleRef.current();
       }, refreshDelay);
     } catch (err) {
       if (controller.signal.aborted || !mountedRef.current) return;
       const e = err instanceof Error ? err : new Error(String(err));
       setError(e);
-      tokenRef.current = null;
-      setToken(null);
-      setExpiresAt(null);
       setPending(false);
+
+      // ── REFRESH-FAILURE RECOVERY ────────────────────────────────────────────
+      // 🔴 Before this, the failure branch set `error`, nulled the token and
+      // scheduled NOTHING — the success path was the only place a timer was ever
+      // armed, so the only route back was the user hiding and re-showing the tab.
+      //
+      // (1) KEEP a still-live token. A failed REFRESH says nothing about the
+      //     credential already in hand (refresh runs at T-2min, so it normally
+      //     has ~2 minutes left). Retaining it keeps the iframe MOUNTED — no lost
+      //     in-progress state, and no remount, which is what used to emit a
+      //     second impression beacon for one logical view.
+      const now = Date.now();
+      const retained = shouldRetainTokenOnFailure({
+        token: tokenRef.current,
+        expiresAt: expiresAtRef.current,
+        now,
+      });
+      if (!retained) {
+        tokenRef.current = null;
+        expiresAtRef.current = null;
+        setToken(null);
+        setExpiresAt(null);
+      }
+
+      // (2) Schedule a BOUNDED automatic re-mint, or settle. Never unbounded:
+      //     /api/v1/block-tokens is rate-limited 60/min per (user, instance).
+      const decision = decideRefreshRetry({ attempts: retryAttemptsRef.current });
+      if (refreshTimeoutRef.current) clearTimeout(refreshTimeoutRef.current);
+      refreshTimeoutRef.current = null;
+
+      if (decision.kind === 'retry') {
+        retryAttemptsRef.current += 1;
+        // refreshAtRef is the SINGLE source of truth for "when should we next
+        // try". Pointing it at the backoff moment is what stops `visibilitychange`
+        // from double-firing alongside this timer: the visibility handler skips
+        // while we are still inside the backoff window.
+        refreshAtRef.current = now + decision.delayMs;
+        setRetrying(true);
+        refreshTimeoutRef.current = setTimeout(() => {
+          refreshTimeoutRef.current = null;
+          // Same hidden-tab pause as the success refresh; visibilitychange resumes.
+          if (typeof document !== 'undefined' && document.hidden) return;
+          // Through the ref, like the success timer above — `requestTokenIfIdle`
+          // is declared below, and one indirection for both timers keeps them
+          // from drifting apart.
+          requestTokenIfIdleRef.current();
+        }, decision.delayMs);
+        return;
+      }
+
+      // SETTLED — the automatic budget is spent. Leave refreshAtRef in the past
+      // so the USER-driven escape hatches still work unchanged (`visibilitychange`
+      // and an explicit `refresh()`); we simply stop trying on our own.
+      refreshAtRef.current = now;
+      setRetrying(false);
+
+      // 🔴 One loose end the settle would otherwise leave: a token RETAINED at the
+      // moment we stopped retrying is never re-evaluated (no further failure will
+      // run the check above), so the host would hold it past its expiry and the
+      // block would quietly 401 — exactly the page-host half of the defect. Arm a
+      // one-shot sweep at the expiry so the terminal state becomes visible then.
+      if (retained) {
+        const ttl = msUntilExpiry(expiresAtRef.current, now);
+        if (ttl !== null) {
+          refreshTimeoutRef.current = setTimeout(() => {
+            refreshTimeoutRef.current = null;
+            if (!mountedRef.current) return;
+            tokenRef.current = null;
+            expiresAtRef.current = null;
+            setToken(null);
+            setExpiresAt(null);
+          }, ttl);
+        }
+      }
+    } finally {
+      // Only the CURRENT request may clear the flag — a newer request that
+      // aborted this one has already set it for itself.
+      if (abortRef.current === controller) inFlightRef.current = false;
     }
   }, [install.blockInstanceId]);
+
+  /**
+   * The entry point every AUTOMATIC caller uses (scheduled refresh, failure
+   * backoff, visibility resume).
+   *
+   * 🔴 It refuses to start while a request is in flight. `requestToken` opens by
+   * aborting the previous controller, and `fetchOnce` handles HTTP 429 by
+   * sleeping ~60s (jittered) before its single in-band retry. Without this guard
+   * an automatic caller firing during that pause would abort it and immediately
+   * re-hit the endpoint that had just asked us to back off. Skipping is safe and
+   * self-healing: the in-flight request either succeeds (rescheduling the normal
+   * refresh) or fails (scheduling the next bounded backoff).
+   */
+  const requestTokenIfIdle = useCallback(() => {
+    if (inFlightRef.current) return;
+    void requestToken();
+  }, [requestToken]);
+  requestTokenIfIdleRef.current = requestTokenIfIdle;
 
   useEffect(() => {
     mountedRef.current = true;
@@ -206,13 +358,19 @@ export function useBlockToken(
     if (typeof document === 'undefined') return;
     const onVisible = () => {
       if (document.hidden || !mountedRef.current) return;
+      // 🔴 NO DOUBLE-FIRE WITH THE FAILURE BACKOFF. `refreshAtRef` now also
+      // carries the pending retry moment, so while we are inside a backoff
+      // window this is a no-op and the armed timer remains the single attempt.
+      // Past the moment (including the settled case, where refreshAtRef is left
+      // in the past) this stays the user-driven escape hatch it has always been.
       if (refreshAtRef.current === 0 || Date.now() >= refreshAtRef.current) {
-        void requestToken();
+        // Guarded: must never abort an in-flight 429 backoff. See requestTokenIfIdle.
+        requestTokenIfIdle();
       }
     };
     document.addEventListener('visibilitychange', onVisible);
     return () => document.removeEventListener('visibilitychange', onVisible);
-  }, [requestToken]);
+  }, [requestTokenIfIdle]);
 
   const refresh = useCallback(async () => {
     await requestToken();
@@ -227,6 +385,11 @@ export function useBlockToken(
     missingScopes,
     domain,
     maxBrowsingLevel,
+    retrying,
+    // The mint failed, nothing usable is left, and no automatic attempt is
+    // coming. This — NOT a bare `error` — is what a consumer may act
+    // destructively on.
+    terminal: error != null && token == null && !retrying,
     refresh,
   };
 }

--- a/src/components/AppBlocks/useBlockToken.ts
+++ b/src/components/AppBlocks/useBlockToken.ts
@@ -141,11 +141,20 @@ export function useBlockToken(
   contextRef.current = context;
 
   const requestToken = useCallback(async (): Promise<void> => {
+    // 🔴 BAIL BEFORE CLAIMING `abortRef`. This check used to sit just below the
+    // claim, which was harmless when nothing tracked in-flight state but is a
+    // trap now: a no-op call would take ownership of `abortRef` without ever
+    // entering the try/finally, so an actually-in-flight sibling's `finally`
+    // would no longer recognise itself as current and would leave `inFlightRef`
+    // stuck TRUE — permanently disabling every automatic recovery path, silently.
+    // The unmount cleanup already aborts the live controller, so returning here
+    // drops nothing.
+    if (!mountedRef.current) return;
+
     abortRef.current?.abort();
     const controller = new AbortController();
     abortRef.current = controller;
 
-    if (!mountedRef.current) return;
     // H-3: only flip pending=true when we don't already have a token.
     // On refresh, the iframe should stay mounted with the prior token;
     // unmounting it every 2 minutes (the refresh cadence) was tearing

--- a/src/components/AppBlocks/useBlockToken.ts
+++ b/src/components/AppBlocks/useBlockToken.ts
@@ -1,9 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
-import {
-  decideRefreshRetry,
-  msUntilExpiry,
-  shouldRetainTokenOnFailure,
-} from './blockTokenRetry';
+import { decideRefreshRetry, msUntilExpiry, shouldRetainTokenOnFailure } from './blockTokenRetry';
+import type { MintError } from './blockTokenRetry';
 import type { BlockInstall, SlotContext } from './types';
 
 interface UseBlockTokenResult {
@@ -78,10 +75,7 @@ const MIN_REFRESH_MS = 30 * 1000;
  * `blockInstanceId`. If a caller needs to force a refresh on context change,
  * use the returned `refresh()`.
  */
-export function useBlockToken(
-  install: BlockInstall,
-  context: SlotContext
-): UseBlockTokenResult {
+export function useBlockToken(install: BlockInstall, context: SlotContext): UseBlockTokenResult {
   const [token, setToken] = useState<string | null>(null);
   const [expiresAt, setExpiresAt] = useState<string | null>(null);
   const [error, setError] = useState<Error | null>(null);
@@ -107,6 +101,16 @@ export function useBlockToken(
   // on every success, so a token that refreshes cleanly for hours always gets a
   // full budget the next time something breaks.
   const retryAttemptsRef = useRef<number>(0);
+  // 🔴 IDENTITY SCOPE. The blockInstanceId the currently-held token was minted
+  // for. Everything above (token, expiry, retry budget) belongs to exactly ONE
+  // instance, and this hook can OUTLIVE an instance change: the two standalone
+  // routes call it from the PAGE component, and Next does not remount a page on
+  // a same-route dynamic-segment navigation (/apps/run/appA -> /apps/run/appB),
+  // so these refs survive. Without this guard, retaining a token through a
+  // refresh failure right after such a navigation would hand appA's credential
+  // to appB via BLOCK_INIT/TOKEN_REFRESH. (The model slot is already safe — it
+  // renders with key={install.blockInstanceId}, forcing a fresh hook instance.)
+  const heldInstanceRef = useRef<string | null>(null);
   // A request (INCLUDING the 60s jittered 429 pause inside fetchOnce) is in
   // flight. 🔴 The AUTOMATIC callers gate on this so they never abort a live
   // request: `requestToken` begins by aborting the previous controller, and
@@ -192,7 +196,14 @@ export function useBlockToken(
           if (signal.aborted) throw new Error('aborted');
           continue;
         }
-        if (!res.ok) throw new Error(`block-tokens HTTP ${res.status}`);
+        if (!res.ok) {
+          // Carry the STATUS, not just a message. Retention + retry are both
+          // status-aware now (a 403 means revoked, not "try again"), and a
+          // stringly-typed error would force them to re-parse this text.
+          const err = new Error(`block-tokens HTTP ${res.status}`) as MintError;
+          err.status = res.status;
+          throw err;
+        }
         return (await res.json()) as TokenResponse;
       }
       throw new Error('block-tokens unreachable');
@@ -203,6 +214,8 @@ export function useBlockToken(
       if (controller.signal.aborted || !mountedRef.current) return;
       // Recovered — hand the next failure episode a full retry budget.
       retryAttemptsRef.current = 0;
+      // Stamp which instance this credential belongs to (see heldInstanceRef).
+      heldInstanceRef.current = instanceId;
       tokenRef.current = data.token;
       expiresAtRef.current = data.expiresAt;
       setToken(data.token);
@@ -222,10 +235,7 @@ export function useBlockToken(
       setPending(false);
 
       const expiresAtMs = new Date(data.expiresAt).getTime();
-      const refreshDelay = Math.max(
-        expiresAtMs - Date.now() - REFRESH_LEAD_MS,
-        MIN_REFRESH_MS
-      );
+      const refreshDelay = Math.max(expiresAtMs - Date.now() - REFRESH_LEAD_MS, MIN_REFRESH_MS);
       refreshAtRef.current = Date.now() + refreshDelay;
       if (refreshTimeoutRef.current) clearTimeout(refreshTimeoutRef.current);
       refreshTimeoutRef.current = setTimeout(() => {
@@ -243,6 +253,10 @@ export function useBlockToken(
       const e = err instanceof Error ? err : new Error(String(err));
       setError(e);
       setPending(false);
+      // undefined for a network/abort failure (no HTTP response) — which is
+      // treated as TRANSIENT, i.e. retained + retried. Only an explicit terminal
+      // status opts out.
+      const mintStatus = (e as MintError).status;
 
       // ── REFRESH-FAILURE RECOVERY ────────────────────────────────────────────
       // 🔴 Before this, the failure branch set `error`, nulled the token and
@@ -259,6 +273,7 @@ export function useBlockToken(
         token: tokenRef.current,
         expiresAt: expiresAtRef.current,
         now,
+        mintStatus,
       });
       if (!retained) {
         tokenRef.current = null;
@@ -269,7 +284,7 @@ export function useBlockToken(
 
       // (2) Schedule a BOUNDED automatic re-mint, or settle. Never unbounded:
       //     /api/v1/block-tokens is rate-limited 60/min per (user, instance).
-      const decision = decideRefreshRetry({ attempts: retryAttemptsRef.current });
+      const decision = decideRefreshRetry({ attempts: retryAttemptsRef.current, mintStatus });
       if (refreshTimeoutRef.current) clearTimeout(refreshTimeoutRef.current);
       refreshTimeoutRef.current = null;
 
@@ -385,9 +400,30 @@ export function useBlockToken(
     await requestToken();
   }, [requestToken]);
 
+  // 🔴 IDENTITY SCOPE, ENFORCED. Drop everything held the moment the instance
+  // changes. Done synchronously DURING RENDER (not in an effect) so no consumer
+  // can observe even a single frame holding the previous app's credential —
+  // effects run after commit, which would be one render too late. Mutating refs
+  // here is the same pattern `contextRef`/`requestTokenIfIdleRef` already use,
+  // and it is idempotent under StrictMode's double render.
+  if (heldInstanceRef.current !== null && heldInstanceRef.current !== install.blockInstanceId) {
+    heldInstanceRef.current = null;
+    tokenRef.current = null;
+    expiresAtRef.current = null;
+    // A new app gets a full recovery budget, not the previous one's remainder.
+    retryAttemptsRef.current = 0;
+  }
+  // The `token`/`expiresAt` STATE still holds the previous instance's values
+  // until the new mint resolves (a plain setState can't be issued from render),
+  // so gate what we hand out on the identity actually matching. Consumers then
+  // see `token: null` and render their loading state, exactly as on a cold mount.
+  const tokenMatchesInstance = heldInstanceRef.current === install.blockInstanceId;
+  const scopedToken = tokenMatchesInstance ? token : null;
+  const scopedExpiresAt = tokenMatchesInstance ? expiresAt : null;
+
   return {
-    token,
-    expiresAt,
+    token: scopedToken,
+    expiresAt: scopedExpiresAt,
     error,
     pending,
     needsConsent,
@@ -398,7 +434,7 @@ export function useBlockToken(
     // The mint failed, nothing usable is left, and no automatic attempt is
     // coming. This — NOT a bare `error` — is what a consumer may act
     // destructively on.
-    terminal: error != null && token == null && !retrying,
+    terminal: error != null && scopedToken == null && !retrying,
     refresh,
   };
 }

--- a/src/pages/apps/dev/[blockId].tsx
+++ b/src/pages/apps/dev/[blockId].tsx
@@ -258,7 +258,7 @@ export default function DevTunnelPage(props: DevTunnelProps) {
             domain={domain}
             maxBrowsingLevel={maxBrowsingLevel}
             tokenError={error != null}
-          tokenTerminal={terminal}
+            tokenTerminal={terminal}
             viewer={viewer}
             theme={theme}
             onConsentGranted={refresh}

--- a/src/pages/apps/dev/[blockId].tsx
+++ b/src/pages/apps/dev/[blockId].tsx
@@ -182,8 +182,21 @@ export default function DevTunnelPage(props: DevTunnelProps) {
     [blockId, currentUser, theme]
   );
 
-  const { token, expiresAt, needsConsent, missingScopes, domain, maxBrowsingLevel, error, refresh } =
-    useBlockToken(install, context);
+  const {
+    token,
+    expiresAt,
+    needsConsent,
+    missingScopes,
+    domain,
+    maxBrowsingLevel,
+    error,
+    // `terminal` = the mint failed, nothing usable is left, AND the hook's
+    // bounded automatic re-mints are spent. A bare `error` is NOT enough to tear
+    // down a running page — a transient refresh blip sets it while recovery is
+    // still under way — so the mid-session escalation keys on this instead.
+    terminal,
+    refresh,
+  } = useBlockToken(install, context);
 
   const viewer = currentUser
     ? { id: currentUser.id, username: currentUser.username ?? null }
@@ -245,6 +258,7 @@ export default function DevTunnelPage(props: DevTunnelProps) {
             domain={domain}
             maxBrowsingLevel={maxBrowsingLevel}
             tokenError={error != null}
+          tokenTerminal={terminal}
             viewer={viewer}
             theme={theme}
             onConsentGranted={refresh}

--- a/src/pages/apps/run/[slug]/[[...path]].tsx
+++ b/src/pages/apps/run/[slug]/[[...path]].tsx
@@ -156,8 +156,21 @@ export default function AppPage(props: PageProps) {
   // flow to the block via TOKEN_REFRESH (wired to PageBlockHost.onConsentGranted,
   // mirroring how IframeHost re-mints on REQUEST_CONSENT). The rotated token's
   // TOKEN_REFRESH push delivers the granted scopes and the block retries.
-  const { token, expiresAt, needsConsent, missingScopes, domain, maxBrowsingLevel, error, refresh } =
-    useBlockToken(install, context);
+  const {
+    token,
+    expiresAt,
+    needsConsent,
+    missingScopes,
+    domain,
+    maxBrowsingLevel,
+    error,
+    // `terminal` = the mint failed, nothing usable is left, AND the hook's
+    // bounded automatic re-mints are spent. A bare `error` is NOT enough to tear
+    // down a running page — a transient refresh blip sets it while recovery is
+    // still under way — so the mid-session escalation keys on this instead.
+    terminal,
+    refresh,
+  } = useBlockToken(install, context);
 
   const viewer = currentUser
     ? { id: currentUser.id, username: currentUser.username ?? null }
@@ -185,6 +198,7 @@ export default function AppPage(props: PageProps) {
           domain={domain}
           maxBrowsingLevel={maxBrowsingLevel}
           tokenError={error != null}
+          tokenTerminal={terminal}
           viewer={viewer}
           theme={theme}
           onConsentGranted={refresh}


### PR DESCRIPTION
## The defect

A **mid-session block-token refresh failure was unhandled**, and the two hosts failed differently — both badly.

`useBlockToken` armed a timer **only on the success path**. On failure it set `error`, nulled the token, and scheduled nothing. The sole route back was the user hiding and re-showing the tab (`visibilitychange`).

Downstream:

- **Model slot** — `BlockHost` did `if (error) return null`, so the block **vanished from the model page mid-session**, taking any in-progress state with it. On eventual recovery it remounted, re-ran `BLOCK_INIT`, and emitted a **second impression beacon** for one logical view (the beacon's emit-once guard is per `IframeHost` mount).
- **Page host** — the `tokenError` effect only transitioned out of `loading`, so at `ready` nothing happened. The host sat on a dead token, `TOKEN_REFRESH` early-returned on `!token`, and the block **silently 401'd** with no signal to the user or the platform.

## What changed

**`useBlockToken` (the root fix)**

1. **Keeps a still-live token through a failed refresh.** A failed *refresh* says nothing about the credential already in hand — refreshes run at T-2min, so it normally has ~2 minutes left. Retaining it keeps the iframe mounted, so a transient blip is invisible. Fails closed on a missing/unparseable expiry.
2. **Bounded backoff retry** — 3 attempts at 2s / 8s / 30s, reset on success, then it **settles**. Worst case is 3 requests across ~40s against an endpoint that allows 60/min.
3. **Never interrupts an in-flight request.** Every automatic caller (scheduled refresh, backoff retry, `visibilitychange`) goes through one idle-guarded entry point, so it can't abort the existing jittered ~60s HTTP-429 pause and re-hit an endpoint that just asked us to back off. Manual `refresh()` keeps its abort-and-restart semantics (a consent grant must re-mint now).
4. **One timer ref** for the refresh, the backoff and a settled-token expiry sweep — mutually exclusive by construction, so the existing unmount cleanup provably can't leak one. `refreshAtRef` now also carries the pending retry moment, which is what stops `visibilitychange` double-firing alongside the timer.
5. New returned contract: **`retrying`** (an automatic attempt is pending) and **`terminal`** (failed · nothing usable left · nothing more coming). `terminal` is derived in the hook so the two hosts can't disagree about what "gone for good" means — they did.

**Consumers**

- `BlockHost` gates the collapse on **`terminal`, not `error`**. Terminal behaviour is unchanged (collapse to `null`, per the documented `hostRenderDecision` contract — no new visible error state for third-party viewers on someone else's model page).
- `PageBlockHost` gains an optional **`tokenTerminal`** prop and a new effect that escalates **`ready` → `error`** only on a *settled* failure. Gating on a bare `tokenError` would rip a working app out for a two-second hiccup — trading a silent failure for a louder, more destructive one. Omitting the prop leaves every existing caller byte-identical.
- `BlockFallback`'s loading skeleton honours `prefers-reduced-motion: reduce`. It used to be a sub-second flash; it now also covers the model slot's retry window (tens of seconds), which is long enough for a looping shimmer to matter.

## Beacon behaviour (asserted, not emergent)

Still **one beacon per host mount**, per #3480. A refresh-failure episode on a page that reached `ready` emits exactly one `ok` and nothing further — the page *load* did succeed, and the emit-once ref makes the later escalation inert by construction. Keeping the block mounted removes the model slot's remount, which is what produced the second beacon there. Both are asserted directly.

## Interaction with #3480

`decideAutoRetry`, the retry budget and the ref-read scheduling effect are untouched. The new `ready → error` escalation deliberately **re-arms** that bounded auto-retry: `error` is an auth terminal, so it spends its one re-mint and then settles with the prominent manual Retry. Covered by a test that drives the re-mint the way the real route does.

## Tests

25 new tests. `useBlockToken.browser.test.tsx` and `BlockHostTokenRetry.browser.test.tsx` exercise the **real** path — real hook, real React, real timer machinery, with only `fetch` (the network boundary) stubbed. The model-slot test asserts **DOM node identity**, because a remount is otherwise invisible in a snapshot.

Every new guard was mutation-verified: broken, confirmed a specific test failed, reverted. Two mutations **survived** the first pass and both were real test weaknesses, now fixed:

- the reduced-motion test asserted a mirror attribute recomputed from `reduceMotion` rather than Mantine's own `data-animate`, so it stayed green with `animate` hardcoded true;
- the timer-leak tests asserted only that no request followed, which the callback's own `!mountedRef.current` guard already ensures — they now assert `vi.getTimerCount()` drops to 0.

## Risk / rollback

Additive and default-off at every seam. `MAX_REFRESH_RETRIES = 0` cleanly restores the pre-fix behaviour (no timer ever armed); dropping `tokenTerminal` from the two routes restores the old page-host behaviour. No schema change, no new endpoint, no flag.
