### PR TITLE
fix(apps): mint listing-media revisions on first EDIT, and show mods what a revision replaces

### DIFF
--- a/src/components/Apps/ListingMediaEditor.tsx
+++ b/src/components/Apps/ListingMediaEditor.tsx
@@ -1,7 +1,7 @@
 import { Alert, Button, Center, Group, Loader, Stack, Text } from '@mantine/core';
 import { IconInfoCircle, IconSend } from '@tabler/icons-react';
 import { useRouter } from 'next/router';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useState } from 'react';
 import { NotFound } from '~/components/AppLayout/NotFound';
 import { ListingAssetStep } from '~/components/Apps/ListingAssetStep';
 import type { OffsiteContentRating } from '~/server/schema/blocks/offsite-listing.schema';
@@ -36,31 +36,21 @@ export function ListingMediaEditor({ appBlockId }: { appBlockId: string }) {
     { enabled: !!appBlockId, retry: false }
   );
 
-  const listingId = listing?.appListingId;
-
-  // 2) Begin (or resume) the editable shadow revision — idempotent, and it returns
-  //    the SAME shadow `getMyListingForApp` already resolved server-side (a parent
-  //    has at most one in-flight shadow), so `listing.assets` below always describes
-  //    exactly this id. Kept as the render gate + the error surface for a listing
-  //    that isn't revisable (a non-approved parent → "only an approved listing can
-  //    be revised"). Every asset mutation the step performs targets the shadow,
-  //    never the live parent.
-  const [shadowId, setShadowId] = useState<string | null>(null);
-  const [beginError, setBeginError] = useState<string | null>(null);
-  const beginRevision = trpc.appListings.beginListingRevision.useMutation();
-  useEffect(() => {
-    if (!listingId || shadowId || beginRevision.isPending) return;
-    beginRevision.mutate(
-      { listingId },
-      {
-        onSuccess: (res) => setShadowId(res.shadowId),
-        onError: (e) => setBeginError(e.message),
-      }
-    );
-    // Fire once per resolved listing id; the mutation object identity is stable enough
-    // and re-adding it would loop on each render.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [listingId]);
+  // 2) The asset step's target, resolved server-side WITHOUT writing anything:
+  //    the in-flight shadow revision when one exists, else the listing itself.
+  //
+  //    🔴 NO `beginListingRevision` on mount. Firing it here made merely OPENING this
+  //    tab create a `draft` AppListing — 78% of approved onsite parents on prod carried
+  //    a shadow that represented no edit, three of them minted 1.5 s apart by opening
+  //    three apps in a row, and they self-refilled the moment anyone looked. The shadow
+  //    is now minted by the FIRST asset mutation, server-side, inside the asset procs
+  //    (which also re-key any parent screenshot row id onto the fresh clone). The
+  //    "isn't revisable" error this call used to surface (`removed` / `rejected` /
+  //    an internal shadow) now arrives on the read as `editBlockedReason`.
+  const editTargetId = listing?.editTargetId ?? null;
+  const shadowId = listing?.shadowId ?? null;
+  const editBlockedReason = listing?.editBlockedReason ?? null;
+  const isApproved = listing?.status === 'approved';
 
   // 3) Re-pull the projected assets after EVERY successful asset mutation.
   //
@@ -87,7 +77,9 @@ export function ListingMediaEditor({ appBlockId }: { appBlockId: string }) {
     []
   );
 
-  // 4) Submit the prepared shadow for moderator re-approval.
+  // 4) Submit the prepared shadow for moderator re-approval. Only reachable once a
+  //    shadow EXISTS — i.e. once the owner has actually changed something. With no
+  //    edits there is nothing to review (and no shadow id to submit).
   const submitRevision = trpc.appListings.submitListingRevision.useMutation();
   async function handleSubmit() {
     if (!shadowId) return;
@@ -108,20 +100,20 @@ export function ListingMediaEditor({ appBlockId }: { appBlockId: string }) {
   // FORBIDDEN (non-owner) / NOT_FOUND (no listing) are the genuine "this isn't yours /
   // doesn't exist" cases → NotFound.
   //
-  // 🔴 Anything ELSE must NOT collapse the page. `getMyListingForApp` now resolves the
-  // shadow server-side, so a `beginListingRevision` failure surfaces HERE — and those
-  // are BAD_REQUEST (`INVALID_REVISION`: "cannot edit a listing in status …", "failed to
-  // open a revision draft"). Blanket-NotFound'ing them made the inline alert below —
-  // which exists precisely to explain them — unreachable, and told the owner their live
-  // app didn't exist. Narrow the guard so everything else falls through to that alert.
+  // 🔴 Anything ELSE must NOT collapse the page — a BAD_REQUEST from the resolve, or an
+  // INTERNAL_SERVER_ERROR, belongs in the inline alert below (which exists precisely to
+  // explain them). Blanket-NotFound'ing them made that alert unreachable and told the
+  // owner their live app didn't exist. Narrow the guard so everything else falls through.
   const listingErrorCode = (listingError as { data?: { code?: string } } | null | undefined)?.data
     ?.code;
   if (listingError && (listingErrorCode === 'FORBIDDEN' || listingErrorCode === 'NOT_FOUND'))
     return <NotFound />;
 
-  // The begin-revision failure and the (non-fatal) listing-resolve failure share one
-  // actionable surface.
-  const inlineError = beginError ?? (listingError ? listingError.message : null);
+  // The "this listing can't be edited at all" verdict (`removed` / `rejected` / an
+  // internal shadow — previously delivered as the on-mount `beginListingRevision`'s
+  // INVALID_REVISION) and the (non-fatal) listing-resolve failure share one actionable
+  // surface. Either one keeps the editor unmounted.
+  const inlineError = editBlockedReason ?? (listingError ? listingError.message : null);
 
   return (
     <Stack gap="lg">
@@ -134,7 +126,7 @@ export function ListingMediaEditor({ appBlockId }: { appBlockId: string }) {
           contradictory half-UI where the pre-narrowing code showed a clean NotFound.
           The red alert below still surfaces those non-gating errors (that improvement
           stands); this notice just stops claiming context it doesn't have. */}
-      {listing && !listingError && (
+      {listing && !listingError && isApproved && !editBlockedReason && (
         <Alert
           icon={<IconInfoCircle size={16} />}
           color="blue"
@@ -171,53 +163,63 @@ export function ListingMediaEditor({ appBlockId }: { appBlockId: string }) {
         </Alert>
       )}
 
-      {listingLoading || !listing ? (
+      {listingLoading || !listing || !editTargetId ? (
         // A settled error is terminal — don't spin forever underneath the alert.
         inlineError ? null : (
           <Center py="xl">
             <Loader />
           </Center>
         )
-      ) : !shadowId ? (
-        <Group gap={8} data-testid="apps-listing-media-preparing">
-          <Loader size={16} />
-          <Text size="sm" c="dimmed">
-            Preparing your revision…
-          </Text>
-        </Group>
-      ) : (
+      ) : editBlockedReason ? null : (
         <Stack gap="md">
           <div data-testid="apps-listing-media-assets-panel">
             <ListingAssetStep
-              listingId={shadowId}
+              // The EDIT TARGET: the in-flight shadow when one exists, else the listing
+              // itself. For an approved listing with no shadow yet this is the LIVE
+              // parent id — and the first mutation against it mints the shadow
+              // server-side and applies there, never to the parent.
+              listingId={editTargetId}
               contentRating={listing.contentRating as OffsiteContentRating}
               suggestions={{}}
-              // 🔴 Prefill from the SHADOW's assets (what `getMyListingForApp`
+              // 🔴 Prefill from the EDIT TARGET's assets (what `getMyListingForApp`
               // projects). Without this the step seeded every slot empty, so it
               // rendered "Icon none / Cover none" for a listing that HAS both and
               // its publish floor (icon+cover attached) could never be met —
               // "Submit for review" was permanently disabled and the flow could
               // not be completed by anyone. The step reads `initial` in its
-              // useState initialisers, and it only mounts once `shadowId` resolves
-              // (the query that carries the assets has long settled by then), so
-              // there is no seed race.
+              // useState initialisers and only mounts once the query has settled,
+              // so there is no seed race.
+              //
+              // 🔴 Before the first edit these are the PARENT's screenshot ROW ids.
+              // That is safe ONLY because every row-id-keyed proc re-keys them onto the
+              // freshly-minted shadow's clone server-side, and fails closed if it can't
+              // — see `resolveOwnerScreenshotTarget`. Do NOT add a client path that
+              // mutates a screenshot row outside those procs.
               initial={listing.assets}
               allowRemove
               onAssetMutated={handleAssetMutated}
               onCompletenessChange={handleCompletenessChange}
             />
           </div>
-          <Group justify="flex-end">
-            <Button
-              onClick={() => void handleSubmit()}
-              loading={submitRevision.isPending}
-              disabled={!meetsFloor}
-              leftSection={<IconSend size={16} />}
-              data-testid="apps-listing-media-submit"
-            >
-              Submit for review
-            </Button>
-          </Group>
+          {isApproved && (
+            <Group justify="flex-end" align="center">
+              {!shadowId && (
+                <Text size="xs" c="dimmed" data-testid="apps-listing-media-no-changes">
+                  Change an image to stage a revision.
+                </Text>
+              )}
+              <Button
+                onClick={() => void handleSubmit()}
+                loading={submitRevision.isPending}
+                // No shadow ⇒ nothing has changed ⇒ there is no revision to submit.
+                disabled={!meetsFloor || !shadowId}
+                leftSection={<IconSend size={16} />}
+                data-testid="apps-listing-media-submit"
+              >
+                Submit for review
+              </Button>
+            </Group>
+          )}
         </Stack>
       )}
     </Stack>

--- a/src/components/Apps/OffsiteReviewQueue.tsx
+++ b/src/components/Apps/OffsiteReviewQueue.tsx
@@ -46,6 +46,13 @@ import {
   reasonMeetsMin,
 } from '~/components/Apps/ReasonGatedActionModal';
 import { getOffsiteReviewChecklist } from '~/components/Apps/offsiteReviewChecklist';
+import {
+  assetSlotDriftLabel,
+  computeListingRevisionDrift,
+  listingAssetSnapshot,
+  screenshotDriftSummary,
+  type AssetSlotDrift,
+} from '~/components/Apps/listingRevisionDrift';
 import { ConnectScopesPanel } from '~/components/Apps/ConnectScopesPanel';
 import { getReportReasonLabel } from '~/components/Apps/appListingReportView';
 import {
@@ -110,6 +117,13 @@ export type OffsitePendingRow = {
     connectRequestedScopes?: number | null;
     connectScopeJustifications?: Record<string, string> | null;
     connectClient?: { name: string | null } | null;
+    /**
+     * Set when `appListingId` points at a SHADOW revision — it is the LIVE parent's
+     * `AppListing.id`. `submissionSelect` has always projected it; nothing in the
+     * review UI resolved the parent from it, which is exactly why a mod could not
+     * see what a media revision was about to replace. The drift panel uses it.
+     */
+    revisionOfId?: string | null;
   } | null;
   submittedBy: OffsiteUser | null;
 };
@@ -617,6 +631,10 @@ export function OffsiteReviewModalBody({
           </Stack>
         </Card>
 
+        {/* 🔴 The BEFORE, immediately above the AFTER. Renders nothing unless the
+            request targets a shadow revision (`revisionOfId` set). */}
+        <RevisionDriftSection request={request} />
+
         <ListingPreviewSection request={request} />
 
         {isConnect && (
@@ -916,6 +934,171 @@ function ListingPreviewSection({ request }: { request: OffsitePendingRow }) {
       <Card withBorder p="md" data-testid="apps-listing-preview-detail">
         <AppListingDetailBody detail={detail} preview />
       </Card>
+    </Stack>
+  );
+}
+
+/** Badge colour for a slot verdict — only a REMOVAL is alarming on its own. */
+function slotDriftColor(drift: AssetSlotDrift): string {
+  if (drift === 'removed') return 'red';
+  if (drift === 'same') return 'gray';
+  return 'blue';
+}
+
+/**
+ * 🔴 CURRENTLY LIVE — the before/after a revision review needs and did not have.
+ *
+ * Every query in this modal keys on `request.appListingId`, which for a revision IS
+ * the shadow id, so the mod was shown the proposal alone: an icon, never "the icon is
+ * going backwards". There is no baseline column and no parent fetch anywhere else in
+ * the review surface. #3383 gave the reviewer a SAFETY signal (maturity / cap) and
+ * #3412 a PRESENTATION signal (card + detail preview); this is the missing CHANGE
+ * signal.
+ *
+ * It matters because `applyApprovedRevision` copies the shadow's icon/cover over the
+ * parent's unconditionally and does a DESTRUCTIVE FULL REPLACE of the screenshot set
+ * (`deleteMany({ appListingId: parentId })`, then move the shadow's rows). A revision
+ * with no screenshots therefore DELETES every live screenshot — reachable with no
+ * unusual behaviour from anyone, since the mod-only `backfillListingAssets` can add
+ * screenshots to a parent and screenshots are not in the publish floor.
+ *
+ * Read-only and additive: it reuses the EXISTING mod-gated `getAssets` +
+ * `getListingPreviewForReview` procs against the PARENT id, so there is no new server
+ * surface and no second image-URL builder. Renders nothing at all for a non-revision
+ * request (`revisionOfId == null`) — a first-time submission has no "before".
+ */
+function RevisionDriftSection({ request }: { request: OffsitePendingRow }) {
+  const features = useFeatureFlags();
+  const parentId = request.appListing?.revisionOfId ?? null;
+  const enabled = !!features?.appBlocks && !!parentId;
+
+  // The LIVE parent's assets + its store projection — same procs the shadow half of
+  // the modal already uses, pointed at the parent.
+  const parentAssetsQuery = trpc.appListings.getAssets.useQuery(
+    { listingId: parentId ?? '' },
+    { enabled, retry: false }
+  );
+  const parentPreviewQuery = trpc.appListings.getListingPreviewForReview.useQuery(
+    { listingId: parentId ?? '' },
+    { enabled, retry: false }
+  );
+  const shadowAssetsQuery = trpc.appListings.getAssets.useQuery(
+    { listingId: request.appListingId ?? '' },
+    { enabled: enabled && !!request.appListingId, retry: false }
+  );
+
+  if (!parentId) return null;
+
+  const live = listingAssetSnapshot(parentAssetsQuery.data);
+  const proposed = listingAssetSnapshot(shadowAssetsQuery.data);
+  // 🔴 Only compare once BOTH sides have loaded. An unloaded parent read as "empty"
+  // would flag every revision as a destructive replace — warning fatigue that makes
+  // the real signal worthless.
+  const drift = live && proposed ? computeListingRevisionDrift(live, proposed) : null;
+
+  return (
+    <Stack gap="xs" data-testid="apps-listing-revision-drift">
+      <Divider
+        label={
+          <Group gap={6}>
+            <IconHistory size={14} />
+            <Text size="sm" fw={600}>
+              Currently live
+            </Text>
+          </Group>
+        }
+        labelPosition="left"
+      />
+      <Text size="xs" c="dimmed">
+        This is a revision of a LIVE listing. Approving REPLACES the media below —
+        screenshots are replaced wholesale, not merged.
+      </Text>
+
+      {drift == null ? (
+        <Group gap={8} data-testid="apps-listing-revision-drift-loading">
+          <Loader size={14} />
+          <Text size="xs" c="dimmed">
+            Comparing with the live listing…
+          </Text>
+        </Group>
+      ) : (
+        <Stack gap={6}>
+          {drift.screenshots.destructiveReplace && (
+            <Alert
+              color="red"
+              variant="light"
+              icon={<IconAlertTriangle size={16} />}
+              title="This revision deletes every live screenshot"
+              data-testid="apps-listing-revision-drift-destructive"
+            >
+              <Text size="sm">{screenshotDriftSummary(drift.screenshots)}.</Text>
+            </Alert>
+          )}
+          {!drift.hasChanges && (
+            <Alert
+              color="gray"
+              variant="light"
+              icon={<IconInfoCircle size={16} />}
+              data-testid="apps-listing-revision-drift-none"
+            >
+              <Text size="sm">
+                This revision’s media is IDENTICAL to what is live — approving changes
+                nothing.
+              </Text>
+            </Alert>
+          )}
+          <Group gap={12} data-testid="apps-listing-revision-drift-badges">
+            <Group gap={6}>
+              <Text size="xs" c="dimmed">
+                Icon
+              </Text>
+              <Badge
+                size="sm"
+                variant="light"
+                color={slotDriftColor(drift.icon)}
+                data-testid="apps-listing-revision-drift-icon"
+              >
+                {assetSlotDriftLabel(drift.icon)}
+              </Badge>
+            </Group>
+            <Group gap={6}>
+              <Text size="xs" c="dimmed">
+                Cover
+              </Text>
+              <Badge
+                size="sm"
+                variant="light"
+                color={slotDriftColor(drift.cover)}
+                data-testid="apps-listing-revision-drift-cover"
+              >
+                {assetSlotDriftLabel(drift.cover)}
+              </Badge>
+            </Group>
+            <Group gap={6}>
+              <Text size="xs" c="dimmed">
+                Screenshots
+              </Text>
+              <Badge
+                size="sm"
+                variant="light"
+                color={drift.screenshots.destructiveReplace ? 'red' : 'blue'}
+                data-testid="apps-listing-revision-drift-screenshots"
+              >
+                {drift.screenshots.liveCount} → {drift.screenshots.proposedCount}
+              </Badge>
+              <Text size="xs" c="dimmed">
+                {screenshotDriftSummary(drift.screenshots)}
+              </Text>
+            </Group>
+          </Group>
+        </Stack>
+      )}
+
+      {parentPreviewQuery.data && (
+        <div style={{ maxWidth: 340 }} data-testid="apps-listing-revision-drift-live-card">
+          <AppListingCard card={parentPreviewQuery.data.card} />
+        </div>
+      )}
     </Stack>
   );
 }

--- a/src/components/Apps/OffsiteReviewQueue.tsx
+++ b/src/components/Apps/OffsiteReviewQueue.tsx
@@ -49,7 +49,10 @@ import { getOffsiteReviewChecklist } from '~/components/Apps/offsiteReviewCheckl
 import {
   assetSlotDriftLabel,
   computeListingRevisionDrift,
+  driftPanelState,
+  identicalAssetsNotice,
   listingAssetSnapshot,
+  revisionApplyScope,
   screenshotDriftSummary,
   type AssetSlotDrift,
 } from '~/components/Apps/listingRevisionDrift';
@@ -994,7 +997,19 @@ function RevisionDriftSection({ request }: { request: OffsitePendingRow }) {
   // 🔴 Only compare once BOTH sides have loaded. An unloaded parent read as "empty"
   // would flag every revision as a destructive replace — warning fatigue that makes
   // the real signal worthless.
-  const drift = live && proposed ? computeListingRevisionDrift(live, proposed) : null;
+  //
+  // 🔴 The apply scope is threaded from the row's KIND. An off-site apply also copies
+  // the listing scalars (name/tagline/description/category/link + the requested OAuth
+  // SCOPES), so the "changes nothing" claim below is licensed only for onsite. See
+  // `listingRevisionDrift`.
+  const applyScope = revisionApplyScope(request.kind);
+  const drift =
+    live && proposed ? computeListingRevisionDrift(live, proposed, { applyScope }) : null;
+  // 🔴 `retry: false` on both queries means an error is TERMINAL. Without this the
+  // panel sat on an indefinite "Comparing with the live listing…" spinner — a mod
+  // next to the destructive-replace case would see a spinner, not "could not load".
+  const driftError = parentAssetsQuery.error ?? shadowAssetsQuery.error ?? null;
+  const panelState = driftPanelState({ hasError: driftError != null, drift });
 
   return (
     <Stack gap="xs" data-testid="apps-listing-revision-drift">
@@ -1010,11 +1025,40 @@ function RevisionDriftSection({ request }: { request: OffsitePendingRow }) {
         labelPosition="left"
       />
       <Text size="xs" c="dimmed">
-        This is a revision of a LIVE listing. Approving REPLACES the media below —
-        screenshots are replaced wholesale, not merged.
+        This is a revision of a LIVE listing. Approving REPLACES the media below — screenshots are
+        replaced wholesale, not merged.
+        {applyScope === 'assets-and-scalars' &&
+          ' Approving ALSO copies this revision’s name, tagline, description, category, link and requested OAuth scopes onto the live listing; those are not compared here.'}
       </Text>
 
-      {drift == null ? (
+      {panelState === 'error' ? (
+        <Alert
+          color="orange"
+          variant="light"
+          icon={<IconAlertTriangle size={16} />}
+          title="Couldn’t load the live listing"
+          data-testid="apps-listing-revision-drift-error"
+        >
+          <Stack gap={6} align="flex-start">
+            <Text size="sm">
+              The before/after comparison is unavailable. Approving still REPLACES the live media
+              wholesale — review manually before deciding.
+            </Text>
+            <Button
+              size="compact-xs"
+              variant="light"
+              loading={parentAssetsQuery.isFetching || shadowAssetsQuery.isFetching}
+              onClick={() => {
+                void parentAssetsQuery.refetch();
+                void shadowAssetsQuery.refetch();
+              }}
+              data-testid="apps-listing-revision-drift-retry"
+            >
+              Retry
+            </Button>
+          </Stack>
+        </Alert>
+      ) : panelState === 'loading' || drift == null ? (
         <Group gap={8} data-testid="apps-listing-revision-drift-loading">
           <Loader size={14} />
           <Text size="xs" c="dimmed">
@@ -1034,17 +1078,23 @@ function RevisionDriftSection({ request }: { request: OffsitePendingRow }) {
               <Text size="sm">{screenshotDriftSummary(drift.screenshots)}.</Text>
             </Alert>
           )}
-          {!drift.hasChanges && (
+          {/* 🔴 The claim is KIND-SCOPED. `noOpApproval` (grey, "changes nothing") is
+              reachable only when the compared set IS the apply set — onsite. An
+              off-site revision with identical media still copies its scalars,
+              INCLUDING the requested OAuth scopes, so it gets the amber notice that
+              names what was not compared instead of a false all-clear. */}
+          {!drift.assetsChanged && (
             <Alert
-              color="gray"
+              color={drift.noOpApproval ? 'gray' : 'yellow'}
               variant="light"
               icon={<IconInfoCircle size={16} />}
-              data-testid="apps-listing-revision-drift-none"
+              data-testid={
+                drift.noOpApproval
+                  ? 'apps-listing-revision-drift-none'
+                  : 'apps-listing-revision-drift-assets-only'
+              }
             >
-              <Text size="sm">
-                This revision’s media is IDENTICAL to what is live — approving changes
-                nothing.
-              </Text>
+              <Text size="sm">{identicalAssetsNotice(drift)}</Text>
             </Alert>
           )}
           <Group gap={12} data-testid="apps-listing-revision-drift-badges">

--- a/src/components/Apps/OffsiteReviewQueue.tsx
+++ b/src/components/Apps/OffsiteReviewQueue.tsx
@@ -54,6 +54,7 @@ import {
   listingAssetSnapshot,
   revisionApplyScope,
   screenshotDriftSummary,
+  uncomparedApplyFieldsSentence,
   type AssetSlotDrift,
 } from '~/components/Apps/listingRevisionDrift';
 import { ConnectScopesPanel } from '~/components/Apps/ConnectScopesPanel';
@@ -1027,8 +1028,7 @@ function RevisionDriftSection({ request }: { request: OffsitePendingRow }) {
       <Text size="xs" c="dimmed">
         This is a revision of a LIVE listing. Approving REPLACES the media below — screenshots are
         replaced wholesale, not merged.
-        {applyScope === 'assets-and-scalars' &&
-          ' Approving ALSO copies this revision’s name, tagline, description, category, link and requested OAuth scopes onto the live listing; those are not compared here.'}
+        {applyScope === 'assets-and-scalars' && uncomparedApplyFieldsSentence()}
       </Text>
 
       {panelState === 'error' ? (

--- a/src/components/Apps/__tests__/listingRevisionDrift.test.ts
+++ b/src/components/Apps/__tests__/listingRevisionDrift.test.ts
@@ -9,6 +9,8 @@ import {
   listingAssetSnapshot,
   revisionApplyScope,
   screenshotDriftSummary,
+  uncomparedApplyFieldsSentence,
+  OFFSITE_UNCOMPARED_APPLY_FIELDS,
   type ListingAssetSnapshot,
 } from '~/components/Apps/listingRevisionDrift';
 
@@ -339,5 +341,30 @@ describe('driftPanelState', () => {
   it('no error + both sides loaded → ready', () => {
     const d = computeListingRevisionDrift(snap(), snap(), ONSITE);
     expect(driftPanelState({ hasError: false, drift: d })).toBe('ready');
+  });
+});
+
+describe('uncomparedApplyFieldsSentence', () => {
+  it('🔴 names EVERY field an offsite approve copies — no hand-maintained second copy', () => {
+    const sentence = uncomparedApplyFieldsSentence();
+    // The review header used to hard-code its own list, and it had already drifted:
+    // `scope justifications` was missing, so the panel implied the justifications were
+    // not part of the apply. Deriving it makes that unrepresentable — this assertion
+    // fails the moment a field is added to the constant and the prose is not derived.
+    for (const field of OFFSITE_UNCOMPARED_APPLY_FIELDS) {
+      expect(sentence).toContain(field);
+    }
+    expect(sentence).toContain('scope justifications');
+  });
+
+  it('reads as a list — the last field is joined with “and”, not a comma', () => {
+    expect(uncomparedApplyFieldsSentence(['name', 'tagline', 'link'])).toContain(
+      'name, tagline and link'
+    );
+  });
+
+  it('degrades sanely for a one-field and an empty list', () => {
+    expect(uncomparedApplyFieldsSentence(['name'])).toContain('revision’s name onto');
+    expect(() => uncomparedApplyFieldsSentence([])).not.toThrow();
   });
 });

--- a/src/components/Apps/__tests__/listingRevisionDrift.test.ts
+++ b/src/components/Apps/__tests__/listingRevisionDrift.test.ts
@@ -4,7 +4,10 @@ import {
   assetSlotDrift,
   assetSlotDriftLabel,
   computeListingRevisionDrift,
+  driftPanelState,
+  identicalAssetsNotice,
   listingAssetSnapshot,
+  revisionApplyScope,
   screenshotDriftSummary,
   type ListingAssetSnapshot,
 } from '~/components/Apps/listingRevisionDrift';
@@ -23,8 +26,17 @@ import {
  */
 
 function snap(overrides: Partial<ListingAssetSnapshot> = {}): ListingAssetSnapshot {
-  return { iconId: 10, coverId: 20, screenshotImageIds: [30, 31], ...overrides };
+  const merged = { iconId: 10, coverId: 20, screenshotImageIds: [30, 31], ...overrides };
+  return {
+    ...merged,
+    // Captions default to "none", aligned 1:1 with whatever image set the test chose.
+    screenshotCaptions: overrides.screenshotCaptions ?? merged.screenshotImageIds.map(() => null),
+  };
 }
+
+/** An ONSITE revision — the only kind whose apply set is fully covered by an asset
+ *  comparison, and therefore the only kind that may be called a no-op. */
+const ONSITE = { applyScope: revisionApplyScope('onsite') };
 
 describe('listingAssetSnapshot', () => {
   it('orders screenshots by `order` and drops rows whose Image was deleted', () => {
@@ -32,12 +44,28 @@ describe('listingAssetSnapshot', () => {
       iconId: 1,
       coverId: 2,
       screenshots: [
-        { imageId: 33, order: 2 },
-        { imageId: null, order: 1 }, // Image deleted (onDelete: SetNull) — displays nothing.
-        { imageId: 31, order: 0 },
+        { imageId: 33, order: 2, caption: 'last' },
+        { imageId: null, order: 1, caption: 'gone' }, // Image deleted (SetNull) — displays nothing.
+        { imageId: 31, order: 0, caption: 'first' },
       ],
     });
-    expect(s).toEqual({ iconId: 1, coverId: 2, screenshotImageIds: [31, 33] });
+    expect(s).toEqual({
+      iconId: 1,
+      coverId: 2,
+      screenshotImageIds: [31, 33],
+      // Captions stay aligned with the SURVIVING rows — a deleted-Image row must not
+      // shift them, or a caption comparison would report phantom drift.
+      screenshotCaptions: ['first', 'last'],
+    });
+  });
+
+  it('normalises an empty-string caption to null (they render identically)', () => {
+    const s = listingAssetSnapshot({
+      iconId: null,
+      coverId: null,
+      screenshots: [{ imageId: 31, order: 0, caption: '' }],
+    });
+    expect(s!.screenshotCaptions).toEqual([null]);
   });
 
   it('🔴 returns null for an UNLOADED payload — "not loaded" must not read as "empty"', () => {
@@ -72,20 +100,20 @@ describe('computeListingRevisionDrift', () => {
       reordered: false,
       destructiveReplace: false,
     });
-    expect(d.hasChanges).toBe(false);
+    expect(d.assetsChanged).toBe(false);
   });
 
   it('a DIFFERENT icon is flagged as drift', () => {
     const d = computeListingRevisionDrift(snap(), snap({ iconId: 999 }));
     expect(d.icon).toBe('changed');
     expect(d.cover).toBe('same');
-    expect(d.hasChanges).toBe(true);
+    expect(d.assetsChanged).toBe(true);
   });
 
   it('a cover added onto an empty slot reads as `added`, not `changed`', () => {
     const d = computeListingRevisionDrift(snap({ coverId: null }), snap({ coverId: 21 }));
     expect(d.cover).toBe('added');
-    expect(d.hasChanges).toBe(true);
+    expect(d.assetsChanged).toBe(true);
   });
 
   it('🔴 parent has N screenshots and the revision has 0 → DESTRUCTIVE replace', () => {
@@ -99,7 +127,7 @@ describe('computeListingRevisionDrift', () => {
     expect(d.screenshots.liveCount).toBe(3);
     expect(d.screenshots.proposedCount).toBe(0);
     expect(d.screenshots.removedImageIds).toEqual([30, 31, 32]);
-    expect(d.hasChanges).toBe(true);
+    expect(d.assetsChanged).toBe(true);
   });
 
   it('a revision that ADDS screenshots to an empty parent is NOT destructive', () => {
@@ -118,7 +146,7 @@ describe('computeListingRevisionDrift', () => {
       snap({ screenshotImageIds: [] })
     );
     expect(d.screenshots.destructiveReplace).toBe(false);
-    expect(d.hasChanges).toBe(false);
+    expect(d.assetsChanged).toBe(false);
   });
 
   it('reports a partial screenshot swap as added + removed', () => {
@@ -139,7 +167,7 @@ describe('computeListingRevisionDrift', () => {
     expect(d.screenshots.reordered).toBe(true);
     expect(d.screenshots.addedImageIds).toEqual([]);
     expect(d.screenshots.removedImageIds).toEqual([]);
-    expect(d.hasChanges).toBe(true);
+    expect(d.assetsChanged).toBe(true);
   });
 
   it('counts DUPLICATE images as a multiset (removing one of two is one removal)', () => {
@@ -181,10 +209,135 @@ describe('summaries', () => {
     );
   });
 
+  it('a caption-only revision does NOT read as unchanged', () => {
+    const d = computeListingRevisionDrift(
+      snap({ screenshotImageIds: [30, 31], screenshotCaptions: [null, null] }),
+      snap({ screenshotImageIds: [30, 31], screenshotCaptions: [null, 'now with words'] }),
+      ONSITE
+    );
+    expect(screenshotDriftSummary(d.screenshots)).toBe('captions edited');
+  });
+
   it('labels the slot verdicts', () => {
     expect(assetSlotDriftLabel('same')).toBe('unchanged');
     expect(assetSlotDriftLabel('added')).toBe('added');
     expect(assetSlotDriftLabel('removed')).toBe('removed');
     expect(assetSlotDriftLabel('changed')).toBe('replaced');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 🔴 THE NO-OP CLAIM IS KIND-SCOPED.
+//
+// `applyApprovedRevision` is kind-aware. The ONSITE branch copies iconId/coverId
+// (plus the screenshot reparent) and nothing else, so an asset comparison covers its
+// whole apply set. The OFFSITE branch ALSO copies name / tagline / description /
+// category / externalUrl / connectClientId / connectRequestedScopes /
+// connectScopeJustifications. Reporting "IDENTICAL — approving changes nothing" off
+// the asset comparison alone therefore told a moderator that a SCOPE-CHANGING
+// off-site revision was a no-op: a false statement in the one surface that exists to
+// stop one, and strictly worse than showing no panel at all.
+// ---------------------------------------------------------------------------
+
+describe('apply scope — what a "changes nothing" claim is allowed to mean', () => {
+  it.each([
+    ['onsite', 'assets-only'],
+    ['offsite', 'assets-and-scalars'],
+    [null, 'assets-and-scalars'],
+    [undefined, 'assets-and-scalars'],
+    ['something-new', 'assets-and-scalars'],
+  ])('kind=%s → %s', (kind, expected) => {
+    expect(revisionApplyScope(kind as string | null | undefined)).toBe(expected);
+  });
+
+  it('🔴 an ONSITE revision with identical assets IS a no-op — the claim is licensed', () => {
+    const d = computeListingRevisionDrift(snap(), snap(), ONSITE);
+    expect(d.assetsChanged).toBe(false);
+    expect(d.noOpApproval).toBe(true);
+    expect(d.uncomparedApplyFields).toEqual([]);
+    expect(identicalAssetsNotice(d)).toMatch(/approving changes nothing/);
+  });
+
+  it('🔴 an OFFSITE revision with identical assets is NEVER reported as changing nothing', () => {
+    // The concrete case: the owner revised ONLY `connectRequestedScopes` (asking for
+    // broader OAuth access). Every asset id is byte-identical, so the asset comparison
+    // sees nothing — and the approve copies the new scope set onto the LIVE listing.
+    const d = computeListingRevisionDrift(snap(), snap(), {
+      applyScope: revisionApplyScope('offsite'),
+    });
+    expect(d.assetsChanged).toBe(false);
+    expect(d.noOpApproval).toBe(false);
+    const notice = identicalAssetsNotice(d);
+    expect(notice).not.toMatch(/changes nothing/);
+    // It must NAME the requested OAuth scopes as uncompared, not merely hedge.
+    expect(d.uncomparedApplyFields).toContain('requested OAuth scopes');
+    expect(notice).toMatch(/requested OAuth scopes/);
+    expect(notice).toMatch(/NOT compared here/);
+  });
+
+  it('🔴 an UNKNOWN kind fails safe — no no-op claim without knowing the apply set', () => {
+    // `kind` is optional on the review row. A missing value must not be read as onsite.
+    const d = computeListingRevisionDrift(snap(), snap());
+    expect(d.applyScope).toBe('assets-and-scalars');
+    expect(d.noOpApproval).toBe(false);
+  });
+
+  it('🔴 a CAPTION-only revision is not a no-op on either kind', () => {
+    // Captions ride along on the screenshot reparent, so approving DOES change the
+    // live listing. Comparing image ids alone reported this as "changes nothing".
+    const live = snap({ screenshotImageIds: [30, 31], screenshotCaptions: ['a', 'b'] });
+    const proposed = snap({ screenshotImageIds: [30, 31], screenshotCaptions: ['a', 'B!'] });
+    const d = computeListingRevisionDrift(live, proposed, ONSITE);
+    expect(d.screenshots.captionsChanged).toBe(true);
+    expect(d.assetsChanged).toBe(true);
+    expect(d.noOpApproval).toBe(false);
+  });
+
+  it('an identical caption set is not drift', () => {
+    const live = snap({ screenshotImageIds: [30, 31], screenshotCaptions: ['a', null] });
+    const proposed = snap({ screenshotImageIds: [30, 31], screenshotCaptions: ['a', null] });
+    const d = computeListingRevisionDrift(live, proposed, ONSITE);
+    expect(d.screenshots.captionsChanged).toBe(false);
+    expect(d.noOpApproval).toBe(true);
+  });
+
+  it('a REORDER already reports itself — captionsChanged stays false', () => {
+    // captionsChanged is only meaningful when the image sequence is identical; a
+    // reorder shifts the caption array with it and must not double-report.
+    const live = snap({ screenshotImageIds: [30, 31], screenshotCaptions: ['a', 'b'] });
+    const proposed = snap({ screenshotImageIds: [31, 30], screenshotCaptions: ['b', 'a'] });
+    const d = computeListingRevisionDrift(live, proposed, ONSITE);
+    expect(d.screenshots.reordered).toBe(true);
+    expect(d.screenshots.captionsChanged).toBe(false);
+    expect(d.assetsChanged).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 🔴 THE PANEL MUST NOT SPIN FOREVER ON AN ERROR.
+//
+// Both drift queries run with `retry: false`, so a failure is TERMINAL and `drift`
+// stays null. Branching on `drift == null` first left a moderator — sitting right
+// next to the destructive-replace case — looking at an indefinite "Comparing with the
+// live listing…" spinner, indistinguishable from "loading, no warning yet".
+// ---------------------------------------------------------------------------
+
+describe('driftPanelState', () => {
+  it('🔴 an error OUTRANKS loading — a failed comparison never renders as a spinner', () => {
+    expect(driftPanelState({ hasError: true, drift: null })).toBe('error');
+  });
+
+  it('an error wins even if a stale drift is present', () => {
+    const d = computeListingRevisionDrift(snap(), snap(), ONSITE);
+    expect(driftPanelState({ hasError: true, drift: d })).toBe('error');
+  });
+
+  it('no error + not loaded → loading', () => {
+    expect(driftPanelState({ hasError: false, drift: null })).toBe('loading');
+  });
+
+  it('no error + both sides loaded → ready', () => {
+    const d = computeListingRevisionDrift(snap(), snap(), ONSITE);
+    expect(driftPanelState({ hasError: false, drift: d })).toBe('ready');
   });
 });

--- a/src/components/Apps/__tests__/listingRevisionDrift.test.ts
+++ b/src/components/Apps/__tests__/listingRevisionDrift.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  assetSlotDrift,
+  assetSlotDriftLabel,
+  computeListingRevisionDrift,
+  listingAssetSnapshot,
+  screenshotDriftSummary,
+  type ListingAssetSnapshot,
+} from '~/components/Apps/listingRevisionDrift';
+
+/**
+ * Listing-media revision DRIFT — the review surface's before/after verdict.
+ *
+ * 🔴 WHY. A mod reviewing a media revision saw the SHADOW's assets alone (both review
+ * queries key on `request.appListingId`, which IS the shadow id), so a revision that
+ * silently reverts or DELETES live media was indistinguishable from one that improves
+ * it. `applyApprovedRevision` copies icon/cover unconditionally and does a destructive
+ * FULL REPLACE of the screenshot set, so "approve" on a 0-screenshot revision deletes
+ * every live screenshot — and the reachable path needs nobody to do anything unusual
+ * (the mod-only `backfillListingAssets` adds screenshots to a parent; screenshots
+ * aren't in the publish floor, so the owner can submit a revision without them).
+ */
+
+function snap(overrides: Partial<ListingAssetSnapshot> = {}): ListingAssetSnapshot {
+  return { iconId: 10, coverId: 20, screenshotImageIds: [30, 31], ...overrides };
+}
+
+describe('listingAssetSnapshot', () => {
+  it('orders screenshots by `order` and drops rows whose Image was deleted', () => {
+    const s = listingAssetSnapshot({
+      iconId: 1,
+      coverId: 2,
+      screenshots: [
+        { imageId: 33, order: 2 },
+        { imageId: null, order: 1 }, // Image deleted (onDelete: SetNull) — displays nothing.
+        { imageId: 31, order: 0 },
+      ],
+    });
+    expect(s).toEqual({ iconId: 1, coverId: 2, screenshotImageIds: [31, 33] });
+  });
+
+  it('🔴 returns null for an UNLOADED payload — "not loaded" must not read as "empty"', () => {
+    // Treating a still-loading parent as empty would flag EVERY revision as a
+    // destructive replace: the exact warning-fatigue failure that makes a drift
+    // signal worthless.
+    expect(listingAssetSnapshot(undefined)).toBeNull();
+    expect(listingAssetSnapshot(null)).toBeNull();
+  });
+});
+
+describe('assetSlotDrift', () => {
+  it.each([
+    [null, null, 'same'],
+    [10, 10, 'same'],
+    [null, 10, 'added'],
+    [10, null, 'removed'],
+    [10, 11, 'changed'],
+  ])('live=%s proposed=%s → %s', (live, proposed, expected) => {
+    expect(assetSlotDrift(live as number | null, proposed as number | null)).toBe(expected);
+  });
+});
+
+describe('computeListingRevisionDrift', () => {
+  it('shadow == parent → NO drift at all', () => {
+    const d = computeListingRevisionDrift(snap(), snap());
+    expect(d.icon).toBe('same');
+    expect(d.cover).toBe('same');
+    expect(d.screenshots).toMatchObject({
+      addedImageIds: [],
+      removedImageIds: [],
+      reordered: false,
+      destructiveReplace: false,
+    });
+    expect(d.hasChanges).toBe(false);
+  });
+
+  it('a DIFFERENT icon is flagged as drift', () => {
+    const d = computeListingRevisionDrift(snap(), snap({ iconId: 999 }));
+    expect(d.icon).toBe('changed');
+    expect(d.cover).toBe('same');
+    expect(d.hasChanges).toBe(true);
+  });
+
+  it('a cover added onto an empty slot reads as `added`, not `changed`', () => {
+    const d = computeListingRevisionDrift(snap({ coverId: null }), snap({ coverId: 21 }));
+    expect(d.cover).toBe('added');
+    expect(d.hasChanges).toBe(true);
+  });
+
+  it('🔴 parent has N screenshots and the revision has 0 → DESTRUCTIVE replace', () => {
+    const d = computeListingRevisionDrift(
+      snap({ screenshotImageIds: [30, 31, 32] }),
+      snap({ screenshotImageIds: [] })
+    );
+    // Approving runs `deleteMany({ appListingId: parentId })` and moves nothing back:
+    // all three live screenshots are gone, and today the mod sees no sign of it.
+    expect(d.screenshots.destructiveReplace).toBe(true);
+    expect(d.screenshots.liveCount).toBe(3);
+    expect(d.screenshots.proposedCount).toBe(0);
+    expect(d.screenshots.removedImageIds).toEqual([30, 31, 32]);
+    expect(d.hasChanges).toBe(true);
+  });
+
+  it('a revision that ADDS screenshots to an empty parent is NOT destructive', () => {
+    const d = computeListingRevisionDrift(
+      snap({ screenshotImageIds: [] }),
+      snap({ screenshotImageIds: [40] })
+    );
+    expect(d.screenshots.destructiveReplace).toBe(false);
+    expect(d.screenshots.addedImageIds).toEqual([40]);
+    expect(d.screenshots.removedImageIds).toEqual([]);
+  });
+
+  it('both sides empty is not destructive (nothing to lose)', () => {
+    const d = computeListingRevisionDrift(
+      snap({ screenshotImageIds: [] }),
+      snap({ screenshotImageIds: [] })
+    );
+    expect(d.screenshots.destructiveReplace).toBe(false);
+    expect(d.hasChanges).toBe(false);
+  });
+
+  it('reports a partial screenshot swap as added + removed', () => {
+    const d = computeListingRevisionDrift(
+      snap({ screenshotImageIds: [30, 31] }),
+      snap({ screenshotImageIds: [31, 32] })
+    );
+    expect(d.screenshots.addedImageIds).toEqual([32]);
+    expect(d.screenshots.removedImageIds).toEqual([30]);
+    expect(d.screenshots.reordered).toBe(false);
+  });
+
+  it('detects a pure REORDER (same set, different sequence)', () => {
+    const d = computeListingRevisionDrift(
+      snap({ screenshotImageIds: [30, 31, 32] }),
+      snap({ screenshotImageIds: [32, 30, 31] })
+    );
+    expect(d.screenshots.reordered).toBe(true);
+    expect(d.screenshots.addedImageIds).toEqual([]);
+    expect(d.screenshots.removedImageIds).toEqual([]);
+    expect(d.hasChanges).toBe(true);
+  });
+
+  it('counts DUPLICATE images as a multiset (removing one of two is one removal)', () => {
+    const d = computeListingRevisionDrift(
+      snap({ screenshotImageIds: [30, 30] }),
+      snap({ screenshotImageIds: [30] })
+    );
+    expect(d.screenshots.removedImageIds).toEqual([30]);
+    expect(d.screenshots.addedImageIds).toEqual([]);
+    expect(d.screenshots.destructiveReplace).toBe(false);
+  });
+});
+
+describe('summaries', () => {
+  it('the destructive case says so in words, with the count', () => {
+    const d = computeListingRevisionDrift(
+      snap({ screenshotImageIds: [30, 31] }),
+      snap({ screenshotImageIds: [] })
+    );
+    expect(screenshotDriftSummary(d.screenshots)).toMatch(/all 2 live screenshots will be DELETED/);
+  });
+
+  it('singularises a one-screenshot destructive replace', () => {
+    const d = computeListingRevisionDrift(
+      snap({ screenshotImageIds: [30] }),
+      snap({ screenshotImageIds: [] })
+    );
+    expect(screenshotDriftSummary(d.screenshots)).toMatch(/all 1 live screenshot will be DELETED/);
+  });
+
+  it('an ordinary change reads plainly', () => {
+    const d = computeListingRevisionDrift(
+      snap({ screenshotImageIds: [30] }),
+      snap({ screenshotImageIds: [30, 31] })
+    );
+    expect(screenshotDriftSummary(d.screenshots)).toBe('1 added');
+    expect(screenshotDriftSummary(computeListingRevisionDrift(snap(), snap()).screenshots)).toBe(
+      'unchanged'
+    );
+  });
+
+  it('labels the slot verdicts', () => {
+    expect(assetSlotDriftLabel('same')).toBe('unchanged');
+    expect(assetSlotDriftLabel('added')).toBe('added');
+    expect(assetSlotDriftLabel('removed')).toBe('removed');
+    expect(assetSlotDriftLabel('changed')).toBe('replaced');
+  });
+});

--- a/src/components/Apps/listingRevisionDrift.ts
+++ b/src/components/Apps/listingRevisionDrift.ts
@@ -79,6 +79,24 @@ export const OFFSITE_UNCOMPARED_APPLY_FIELDS = [
 ] as const;
 
 /**
+ * The review panel's HEADER sentence naming what an offsite approve also copies.
+ *
+ * 🔴 DERIVED from {@link OFFSITE_UNCOMPARED_APPLY_FIELDS} rather than written out.
+ * The header used to hard-code its own copy of the list, which had already drifted:
+ * it omitted `scope justifications`. A moderator reading "name, tagline, description,
+ * category, link and requested OAuth scopes" would conclude the justifications were
+ * NOT part of the apply — in the one surface whose whole job is to not imply that.
+ * Single-sourcing it makes the drift unrepresentable instead of merely fixed.
+ */
+export function uncomparedApplyFieldsSentence(
+  fields: readonly string[] = OFFSITE_UNCOMPARED_APPLY_FIELDS
+): string {
+  const last = fields[fields.length - 1] ?? '';
+  const list = fields.length > 1 ? `${fields.slice(0, -1).join(', ')} and ${last}` : last;
+  return ` Approving ALSO copies this revision’s ${list} onto the live listing; those are not compared here.`;
+}
+
+/**
  * The apply scope for a review row's listing kind.
  *
  * 🔴 UNKNOWN kind → `'assets-and-scalars'`, the CONSERVATIVE answer. `kind` is

--- a/src/components/Apps/listingRevisionDrift.ts
+++ b/src/components/Apps/listingRevisionDrift.ts
@@ -20,12 +20,74 @@
  * This module computes what CHANGES between the live listing and the proposed
  * revision, so the review surface can show a before/after instead of an after.
  *
+ * 🔴 IT COMPARES ASSETS, AND SAYS SO. `applyApprovedRevision` is KIND-AWARE: the
+ * onsite branch copies icon/cover (+ the screenshot reparent) and nothing else, so an
+ * asset comparison covers its whole apply set. The OFFSITE branch ALSO copies
+ * `name`/`tagline`/`description`/`category`/`externalUrl`/`connectClientId`/
+ * `connectRequestedScopes`/`connectScopeJustifications`. Reporting "identical —
+ * approving changes nothing" off an asset comparison alone therefore told a moderator
+ * that a SCOPE-CHANGING off-site revision was a no-op — a false statement in the exact
+ * safety surface this panel exists to provide, worse than showing nothing. Hence
+ * {@link RevisionApplyScope}: `noOpApproval` (the only field that licenses that claim)
+ * can only be true when the compared set IS the apply set.
+ *
  * Pure + separately unit-tested — the drift verdict must be checkable without
  * mounting the review page (same reasoning as `offsiteReviewChecklist`).
  */
 
 /** How one single-valued asset slot (icon / cover) differs between live and proposed. */
 export type AssetSlotDrift = 'same' | 'changed' | 'added' | 'removed';
+
+/**
+ * What `applyApprovedRevision` COPIES from the shadow onto the live parent, which is
+ * KIND-DEPENDENT (`offsite-listing.service.ts`, the `parent.kind === 'onsite'` branch):
+ *
+ *   - `'assets-only'`   — ONSITE. Copies `iconId`/`coverId` only (+ the screenshot
+ *     reparent). Every manifest-governed scalar is deliberately left alone, so the
+ *     asset comparison below covers the WHOLE apply set.
+ *   - `'assets-and-scalars'` — OFFSITE. ALSO copies `name`, `tagline`, `description`,
+ *     `category`, `externalUrl`, `connectClientId`, **`connectRequestedScopes`** and
+ *     `connectScopeJustifications`. The asset comparison covers only PART of the
+ *     apply set.
+ */
+export type RevisionApplyScope = 'assets-only' | 'assets-and-scalars';
+
+/**
+ * The listing fields an OFFSITE approve copies that this module does NOT compare.
+ *
+ * 🔴 WHY NOT COMPARE THEM. Both sides' `name` / `tagline` / `description` /
+ * `category` / `externalUrl` are reachable from the two `getListingPreviewForReview`
+ * projections, but `connectRequestedScopes` / `connectScopeJustifications` are NOT
+ * exposed for the PARENT by any mod-gated read — the only projection that carries
+ * them is the OWNER's `getMyListingForEdit`. Surfacing them would mean widening the
+ * PUBLIC `ListingDetail` DTO (served by `getAppDetail`) to carry OAuth-scope data, a
+ * far larger blast radius than a review panel warrants.
+ *
+ * And a PARTIAL scalar comparison would not fix the problem — it would only move the
+ * lie: "identical" while the requested OAuth scopes changed underneath is exactly the
+ * failure this list exists to prevent. So the honest contract is: compare the assets,
+ * and NAME the fields that were not compared instead of implying they were.
+ */
+export const OFFSITE_UNCOMPARED_APPLY_FIELDS = [
+  'name',
+  'tagline',
+  'description',
+  'category',
+  'link',
+  'requested OAuth scopes',
+  'scope justifications',
+] as const;
+
+/**
+ * The apply scope for a review row's listing kind.
+ *
+ * 🔴 UNKNOWN kind → `'assets-and-scalars'`, the CONSERVATIVE answer. `kind` is
+ * optional on the review row (`listPendingRequests` defaults it to off-site), and a
+ * missing value must never license a "changes nothing" claim.
+ */
+export function revisionApplyScope(kind: string | null | undefined): RevisionApplyScope {
+  return kind === 'onsite' ? 'assets-only' : 'assets-and-scalars';
+}
 
 /** The comparable asset state of ONE listing (live parent or shadow revision). */
 export type ListingAssetSnapshot = {
@@ -35,6 +97,14 @@ export type ListingAssetSnapshot = {
    *  (`imageId → null` via `onDelete: SetNull`) are excluded — they display nothing,
    *  so counting them would make a "destructive replace" read as a partial one. */
   screenshotImageIds: number[];
+  /**
+   * Captions aligned 1:1 with {@link screenshotImageIds} (same filter, same order).
+   * A caption is part of what the screenshot reparent carries onto the live listing,
+   * so a caption-ONLY revision is a real change — without this it read as "identical
+   * — approving changes nothing". Empty string is normalised to `null` (they render
+   * the same, so flipping between them is not a change).
+   */
+  screenshotCaptions: (string | null)[];
 };
 
 export type ScreenshotDrift = {
@@ -48,6 +118,14 @@ export type ScreenshotDrift = {
   /** Same set of images, different order. */
   reordered: boolean;
   /**
+   * Same images in the same order, but at least one CAPTION differs. Captions ride
+   * along on the reparent, so this is a real change to the live listing — and it is
+   * the one screenshot change that is invisible in every other field here.
+   * Only meaningful when the image sequence is identical; any add / remove / reorder
+   * already reports itself and sets `assetsChanged`.
+   */
+  captionsChanged: boolean;
+  /**
    * 🔴 The live listing has screenshots and the revision has NONE. Approving deletes
    * all of them and puts nothing back. Called out separately from `removedImageIds`
    * because it is the total-loss case and it can be reached without anyone
@@ -60,8 +138,27 @@ export type ListingRevisionDrift = {
   icon: AssetSlotDrift;
   cover: AssetSlotDrift;
   screenshots: ScreenshotDrift;
-  /** True when approving this revision changes ANY asset on the live listing. */
-  hasChanges: boolean;
+  /**
+   * True when approving this revision changes any asset COMPARED HERE (icon, cover,
+   * screenshot set / order / captions).
+   *
+   * 🔴 `assetsChanged === false` does NOT mean "approving changes nothing" — see
+   * {@link noOpApproval}. It was called `hasChanges` and read as exactly that, which
+   * is how an off-site revision that changed only `connectRequestedScopes` was
+   * reported to a moderator as a no-op.
+   */
+  assetsChanged: boolean;
+  /** What `applyApprovedRevision` will copy for this revision's kind. */
+  applyScope: RevisionApplyScope;
+  /** Fields the apply copies that this comparison did NOT read (empty for onsite). */
+  uncomparedApplyFields: readonly string[];
+  /**
+   * 🔴 The ONLY field that licenses an "approving changes nothing" statement: every
+   * field the apply copies for this kind was compared AND is identical. Necessarily
+   * `false` for an off-site revision, whose apply also copies the listing scalars
+   * (including the requested OAuth scopes) that this module cannot see.
+   */
+  noOpApproval: boolean;
 };
 
 /** The `getListingAssets` view shape this module can read (structurally typed so it
@@ -69,7 +166,7 @@ export type ListingRevisionDrift = {
 export type ListingAssetsLike = {
   iconId: number | null;
   coverId: number | null;
-  screenshots: { imageId: number | null; order: number }[];
+  screenshots: { imageId: number | null; order: number; caption?: string | null }[];
 };
 
 /**
@@ -82,13 +179,18 @@ export function listingAssetSnapshot(
   view: ListingAssetsLike | null | undefined
 ): ListingAssetSnapshot | null {
   if (!view) return null;
+  const rows = [...view.screenshots]
+    .sort((a, b) => a.order - b.order)
+    .filter(
+      (s): s is { imageId: number; order: number; caption?: string | null } => s.imageId != null
+    );
   return {
     iconId: view.iconId ?? null,
     coverId: view.coverId ?? null,
-    screenshotImageIds: [...view.screenshots]
-      .sort((a, b) => a.order - b.order)
-      .map((s) => s.imageId)
-      .filter((id): id is number => id != null),
+    screenshotImageIds: rows.map((s) => s.imageId),
+    // '' and null render identically — normalise so flipping between them is not a
+    // reported change.
+    screenshotCaptions: rows.map((s) => (s.caption == null || s.caption === '' ? null : s.caption)),
   };
 }
 
@@ -123,17 +225,24 @@ function multisetDifference(a: number[], b: number[]): number[] {
  * decision-useful half a moderator actually needs and it costs nothing. An ordinary
  * icon swap therefore reads as `changed` — informative, not alarming — while the
  * total-loss case gets its own flag.
+ *
+ * 🔴 `applyScope` decides whether a "changes nothing" claim is even ALLOWED. It
+ * defaults to the conservative `'assets-and-scalars'`: a caller that does not thread
+ * the listing kind gets `noOpApproval === false`, never a false all-clear.
  */
 export function computeListingRevisionDrift(
   live: ListingAssetSnapshot,
-  proposed: ListingAssetSnapshot
+  proposed: ListingAssetSnapshot,
+  opts: { applyScope?: RevisionApplyScope } = {}
 ): ListingRevisionDrift {
+  const applyScope = opts.applyScope ?? 'assets-and-scalars';
   const addedImageIds = multisetDifference(proposed.screenshotImageIds, live.screenshotImageIds);
   const removedImageIds = multisetDifference(live.screenshotImageIds, proposed.screenshotImageIds);
-  const reordered =
-    addedImageIds.length === 0 &&
-    removedImageIds.length === 0 &&
-    live.screenshotImageIds.join(',') !== proposed.screenshotImageIds.join(',');
+  const sameSequence = live.screenshotImageIds.join(',') === proposed.screenshotImageIds.join(',');
+  const reordered = addedImageIds.length === 0 && removedImageIds.length === 0 && !sameSequence;
+  const captionsChanged =
+    sameSequence &&
+    JSON.stringify(live.screenshotCaptions) !== JSON.stringify(proposed.screenshotCaptions);
 
   const screenshots: ScreenshotDrift = {
     liveCount: live.screenshotImageIds.length,
@@ -141,6 +250,7 @@ export function computeListingRevisionDrift(
     addedImageIds,
     removedImageIds,
     reordered,
+    captionsChanged,
     destructiveReplace:
       live.screenshotImageIds.length > 0 && proposed.screenshotImageIds.length === 0,
   };
@@ -148,17 +258,43 @@ export function computeListingRevisionDrift(
   const icon = assetSlotDrift(live.iconId, proposed.iconId);
   const cover = assetSlotDrift(live.coverId, proposed.coverId);
 
+  const assetsChanged =
+    icon !== 'same' ||
+    cover !== 'same' ||
+    addedImageIds.length > 0 ||
+    removedImageIds.length > 0 ||
+    reordered ||
+    captionsChanged;
+
   return {
     icon,
     cover,
     screenshots,
-    hasChanges:
-      icon !== 'same' ||
-      cover !== 'same' ||
-      addedImageIds.length > 0 ||
-      removedImageIds.length > 0 ||
-      reordered,
+    assetsChanged,
+    applyScope,
+    uncomparedApplyFields: applyScope === 'assets-only' ? [] : OFFSITE_UNCOMPARED_APPLY_FIELDS,
+    noOpApproval: !assetsChanged && applyScope === 'assets-only',
   };
+}
+
+/**
+ * What the drift panel should RENDER. Pure so the one rule that matters is pinned in
+ * the blocking unit project rather than left to a browser test.
+ *
+ * 🔴 `'error'` OUTRANKS `'loading'`. Both queries run with `retry: false`, so a failure
+ * is TERMINAL — `drift` stays `null` forever. Branching on `drift == null` first left a
+ * moderator staring at an indefinite "Comparing with the live listing…" spinner right
+ * next to the destructive-replace case: indistinguishable from "still loading, no
+ * warning yet", when the truth is "the live listing could not be read at all".
+ */
+export type DriftPanelState = 'error' | 'loading' | 'ready';
+
+export function driftPanelState(args: {
+  hasError: boolean;
+  drift: ListingRevisionDrift | null;
+}): DriftPanelState {
+  if (args.hasError) return 'error';
+  return args.drift == null ? 'loading' : 'ready';
 }
 
 /** Human label for a slot verdict (shared by the badge + its tests). */
@@ -186,6 +322,26 @@ export function screenshotDriftSummary(drift: ScreenshotDrift): string {
   if (drift.addedImageIds.length > 0) parts.push(`${drift.addedImageIds.length} added`);
   if (drift.removedImageIds.length > 0) parts.push(`${drift.removedImageIds.length} removed`);
   if (parts.length === 0 && drift.reordered) parts.push('reordered');
+  // Captions ride along on the reparent; a caption-only revision has nothing else to
+  // report, so without this it reads as 'unchanged'.
+  if (drift.captionsChanged) parts.push('captions edited');
   if (parts.length === 0) return 'unchanged';
   return parts.join(', ');
+}
+
+/**
+ * The honest one-liner for "the media is identical" — kind-aware.
+ *
+ * 🔴 For an OFFSITE revision the media being identical says nothing about what
+ * approving does: the apply also copies the listing scalars, including
+ * `connectRequestedScopes`. Stating "approving changes nothing" there is a FALSE
+ * statement in the one surface that exists to prevent one.
+ */
+export function identicalAssetsNotice(drift: ListingRevisionDrift): string {
+  if (drift.noOpApproval) {
+    return 'This revision’s media is IDENTICAL to what is live — approving changes nothing.';
+  }
+  return `This revision’s MEDIA is identical to what is live. Approving still copies this revision’s ${drift.uncomparedApplyFields.join(
+    ', '
+  )} onto the live listing — those are NOT compared here, so review them above before approving.`;
 }

--- a/src/components/Apps/listingRevisionDrift.ts
+++ b/src/components/Apps/listingRevisionDrift.ts
@@ -1,0 +1,191 @@
+/**
+ * App Store Listings — listing-media REVISION DRIFT (PURE view-model).
+ *
+ * A moderator reviewing a listing-media revision was shown the SHADOW's assets and
+ * nothing else. Both review queries key on `request.appListingId`, which IS the
+ * shadow id, so the modal rendered "an icon" — never "the icon is going backwards".
+ * There was no parent fetch anywhere in the review surface, so "a mod would catch a
+ * silent revert" was simply false.
+ *
+ * That matters because `applyApprovedRevision` is unconditional in both directions:
+ * it copies the shadow's `iconId`/`coverId` over the parent's, and for screenshots it
+ * does a DESTRUCTIVE FULL REPLACE — `deleteMany({ appListingId: parentId })` and then
+ * moves the shadow's rows across. So a revision that carries zero screenshots DELETES
+ * every screenshot the live listing has, and nothing in the flow says so out loud.
+ * The reachable path needs no unusual behaviour from anyone: the moderator-only
+ * `backfillListingAssets` migrates bundle screenshots onto a parent that has none,
+ * screenshots are NOT in the publish floor, so an owner can submit a 0-screenshot
+ * revision and the approve wipes them.
+ *
+ * This module computes what CHANGES between the live listing and the proposed
+ * revision, so the review surface can show a before/after instead of an after.
+ *
+ * Pure + separately unit-tested — the drift verdict must be checkable without
+ * mounting the review page (same reasoning as `offsiteReviewChecklist`).
+ */
+
+/** How one single-valued asset slot (icon / cover) differs between live and proposed. */
+export type AssetSlotDrift = 'same' | 'changed' | 'added' | 'removed';
+
+/** The comparable asset state of ONE listing (live parent or shadow revision). */
+export type ListingAssetSnapshot = {
+  iconId: number | null;
+  coverId: number | null;
+  /** Backing `Image` ids of the screenshots, in `order`. Rows with a deleted Image
+   *  (`imageId → null` via `onDelete: SetNull`) are excluded — they display nothing,
+   *  so counting them would make a "destructive replace" read as a partial one. */
+  screenshotImageIds: number[];
+};
+
+export type ScreenshotDrift = {
+  liveCount: number;
+  proposedCount: number;
+  /** Images the revision ADDS (present in proposed, not in live). */
+  addedImageIds: number[];
+  /** Images the revision DROPS (present in live, not in proposed) — these rows are
+   *  DELETED from the live listing on approve. */
+  removedImageIds: number[];
+  /** Same set of images, different order. */
+  reordered: boolean;
+  /**
+   * 🔴 The live listing has screenshots and the revision has NONE. Approving deletes
+   * all of them and puts nothing back. Called out separately from `removedImageIds`
+   * because it is the total-loss case and it can be reached without anyone
+   * deliberately removing anything (a shadow cloned BEFORE a backfill added them).
+   */
+  destructiveReplace: boolean;
+};
+
+export type ListingRevisionDrift = {
+  icon: AssetSlotDrift;
+  cover: AssetSlotDrift;
+  screenshots: ScreenshotDrift;
+  /** True when approving this revision changes ANY asset on the live listing. */
+  hasChanges: boolean;
+};
+
+/** The `getListingAssets` view shape this module can read (structurally typed so it
+ *  accepts the tRPC result without importing the service). */
+export type ListingAssetsLike = {
+  iconId: number | null;
+  coverId: number | null;
+  screenshots: { imageId: number | null; order: number }[];
+};
+
+/**
+ * Normalise a `getListingAssets` payload into a comparable snapshot. Returns `null`
+ * for a missing payload so callers can distinguish "not loaded yet" from "no assets"
+ * — reporting an unloaded parent as empty would flag every revision as a destructive
+ * replace, which is precisely the warning-fatigue failure this must avoid.
+ */
+export function listingAssetSnapshot(
+  view: ListingAssetsLike | null | undefined
+): ListingAssetSnapshot | null {
+  if (!view) return null;
+  return {
+    iconId: view.iconId ?? null,
+    coverId: view.coverId ?? null,
+    screenshotImageIds: [...view.screenshots]
+      .sort((a, b) => a.order - b.order)
+      .map((s) => s.imageId)
+      .filter((id): id is number => id != null),
+  };
+}
+
+/** Slot-level comparison: null↔null is `same`, null→value is `added`, value→null is
+ *  `removed`, and a different non-null value is `changed`. */
+export function assetSlotDrift(live: number | null, proposed: number | null): AssetSlotDrift {
+  if (live === proposed) return 'same';
+  if (live == null) return 'added';
+  if (proposed == null) return 'removed';
+  return 'changed';
+}
+
+/** Multiset difference `a \ b` preserving `a`'s order (an image attached twice is two
+ *  entries, so removing one of them reports exactly one removal). */
+function multisetDifference(a: number[], b: number[]): number[] {
+  const remaining = [...b];
+  const out: number[] = [];
+  for (const id of a) {
+    const i = remaining.indexOf(id);
+    if (i >= 0) remaining.splice(i, 1);
+    else out.push(id);
+  }
+  return out;
+}
+
+/**
+ * Compare the LIVE listing's current assets against the revision's proposed assets.
+ *
+ * The comparison is deliberately "what will approving this CHANGE on the live
+ * listing", not "did the parent move since the shadow was cloned". Distinguishing
+ * those two needs a clone-time baseline, which needs a schema migration; this is the
+ * decision-useful half a moderator actually needs and it costs nothing. An ordinary
+ * icon swap therefore reads as `changed` — informative, not alarming — while the
+ * total-loss case gets its own flag.
+ */
+export function computeListingRevisionDrift(
+  live: ListingAssetSnapshot,
+  proposed: ListingAssetSnapshot
+): ListingRevisionDrift {
+  const addedImageIds = multisetDifference(proposed.screenshotImageIds, live.screenshotImageIds);
+  const removedImageIds = multisetDifference(live.screenshotImageIds, proposed.screenshotImageIds);
+  const reordered =
+    addedImageIds.length === 0 &&
+    removedImageIds.length === 0 &&
+    live.screenshotImageIds.join(',') !== proposed.screenshotImageIds.join(',');
+
+  const screenshots: ScreenshotDrift = {
+    liveCount: live.screenshotImageIds.length,
+    proposedCount: proposed.screenshotImageIds.length,
+    addedImageIds,
+    removedImageIds,
+    reordered,
+    destructiveReplace:
+      live.screenshotImageIds.length > 0 && proposed.screenshotImageIds.length === 0,
+  };
+
+  const icon = assetSlotDrift(live.iconId, proposed.iconId);
+  const cover = assetSlotDrift(live.coverId, proposed.coverId);
+
+  return {
+    icon,
+    cover,
+    screenshots,
+    hasChanges:
+      icon !== 'same' ||
+      cover !== 'same' ||
+      addedImageIds.length > 0 ||
+      removedImageIds.length > 0 ||
+      reordered,
+  };
+}
+
+/** Human label for a slot verdict (shared by the badge + its tests). */
+export function assetSlotDriftLabel(drift: AssetSlotDrift): string {
+  switch (drift) {
+    case 'added':
+      return 'added';
+    case 'removed':
+      return 'removed';
+    case 'changed':
+      return 'replaced';
+    default:
+      return 'unchanged';
+  }
+}
+
+/** One-line summary of the screenshot change, for the review surface. */
+export function screenshotDriftSummary(drift: ScreenshotDrift): string {
+  if (drift.destructiveReplace) {
+    return `all ${drift.liveCount} live screenshot${
+      drift.liveCount === 1 ? '' : 's'
+    } will be DELETED — this revision has none`;
+  }
+  const parts: string[] = [];
+  if (drift.addedImageIds.length > 0) parts.push(`${drift.addedImageIds.length} added`);
+  if (drift.removedImageIds.length > 0) parts.push(`${drift.removedImageIds.length} removed`);
+  if (parts.length === 0 && drift.reordered) parts.push('reordered');
+  if (parts.length === 0) return 'unchanged';
+  return parts.join(', ');
+}

--- a/src/server/routers/__tests__/app-listings.router.asset-error-mapping.test.ts
+++ b/src/server/routers/__tests__/app-listings.router.asset-error-mapping.test.ts
@@ -1,0 +1,225 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { TRPCError } from '@trpc/server';
+
+/**
+ * 🔴 The OWNER ASSET procs must map typed service errors, like every other proc here.
+ *
+ * WHY THIS SUITE EXISTS. Under LAZY shadow-revision minting each of the six asset
+ * mutations calls `resolveOwnerAssetEditTarget` → `beginListingRevision`, which throws
+ * `OffsiteRequestError` — a plain `Error` subclass, NOT a `TRPCError`. These six procs
+ * were the only mutations in this router with no `mapOffsiteError` wrapper, because
+ * before lazy minting they could not reach that code at all. The reachable trigger is
+ * an ordinary status race: a moderator delists (or the owner withdraws) the listing
+ * between the client's read and this write, so `beginListingRevision` throws
+ * `INVALID_REVISION` / `'failed to open a revision draft'` — and the owner got an
+ * opaque 500 with a generic message instead of the typed, actionable one.
+ *
+ * Drives the REAL router via `createCaller`, so the wrapper wiring (not a mock)
+ * decides. The services are mocked so importing the router never drags in Prisma.
+ */
+
+const {
+  mockSetIcon,
+  mockSetCover,
+  mockAddScreenshot,
+  mockReorder,
+  mockUpdateCaption,
+  mockRemoveScreenshot,
+  mockIsAppBlocksEnabled,
+  mockIsAppBlocksAuthorEnabled,
+} = vi.hoisted(() => ({
+  mockSetIcon: vi.fn(async () => ({ status: 'attached', iconId: 5 })),
+  mockSetCover: vi.fn(async () => ({ status: 'attached', coverId: 6 })),
+  mockAddScreenshot: vi.fn(async () => ({ status: 'attached', id: 'apls_1', order: 0 })),
+  mockReorder: vi.fn(async () => ({ reordered: 1 })),
+  mockUpdateCaption: vi.fn(async () => ({ id: 'apls_1' })),
+  mockRemoveScreenshot: vi.fn(async () => ({ removed: 'apls_1' })),
+  mockIsAppBlocksEnabled: vi.fn(),
+  mockIsAppBlocksAuthorEnabled: vi.fn(),
+}));
+
+vi.mock('~/server/services/blocks/app-listing-assets.service', () => ({
+  setListingIcon: mockSetIcon,
+  setListingCover: mockSetCover,
+  addListingScreenshot: mockAddScreenshot,
+  reorderListingScreenshots: mockReorder,
+  updateListingScreenshotCaption: mockUpdateCaption,
+  removeListingScreenshot: mockRemoveScreenshot,
+}));
+vi.mock('~/server/services/app-blocks-flag', () => ({
+  isAppBlocksEnabled: mockIsAppBlocksEnabled,
+  isAppBlocksAuthorEnabled: mockIsAppBlocksAuthorEnabled,
+}));
+vi.mock('~/server/services/feature-flags.service', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  // `appDeveloperProcedure` gates on `getFeatureFlags(ctx).appBlocksAuthor`; the
+  // asset procs are `protectedProcedure` + the author FLAG middleware, but the router
+  // module graph still evaluates this.
+  return { ...actual, getFeatureFlags: () => ({ appBlocksAuthor: true }) };
+});
+vi.mock('~/server/middleware.trpc', async () => {
+  const { middleware } = await import('~/server/trpc');
+  return { rateLimit: () => middleware(async ({ next }) => next()) };
+});
+vi.mock('~/server/utils/server-domain', () => ({ isHostForColor: () => false }));
+
+import { appListingsRouter } from '../app-listings.router';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
+
+function fakeCtx(user: unknown) {
+  return {
+    acceptableOrigin: true,
+    user,
+    apiKeyId: null,
+    tokenScope: TokenScope.Full,
+    req: { headers: {} } as never,
+    res: { setHeader: () => undefined } as never,
+    cache: { edgeTTL: 0 },
+    features: {} as never,
+    track: undefined,
+  };
+}
+
+/**
+ * A typed `OffsiteRequestError`-shaped throwable, WITHOUT importing the (mocked)
+ * service. The router duck-types on `name === 'OffsiteRequestError'` + a string
+ * `code`, so this exercises the real mapping path — the same fixture the other
+ * router suites use.
+ */
+function offsiteErr(code: string, message: string): Error {
+  return Object.assign(new Error(message), { name: 'OffsiteRequestError', code });
+}
+
+const owner = { id: 2, isModerator: false, tier: 'free', username: 'dev', onboarding: 0x1f };
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockIsAppBlocksEnabled.mockResolvedValue(true);
+  mockIsAppBlocksAuthorEnabled.mockResolvedValue(true);
+});
+
+/** Every asset proc, with a valid input and the service mock it routes to. */
+const ASSET_PROCS = [
+  {
+    name: 'setIcon' as const,
+    input: { listingId: 'apl_1', imageId: 5 },
+    mock: mockSetIcon,
+  },
+  {
+    name: 'setCover' as const,
+    input: { listingId: 'apl_1', imageId: 5 },
+    mock: mockSetCover,
+  },
+  {
+    name: 'addScreenshot' as const,
+    input: { listingId: 'apl_1', imageId: 5 },
+    mock: mockAddScreenshot,
+  },
+  {
+    name: 'reorderScreenshots' as const,
+    input: { listingId: 'apl_1', orderedIds: ['apls_1'] },
+    mock: mockReorder,
+  },
+  {
+    name: 'updateScreenshotCaption' as const,
+    input: { screenshotId: 'apls_1', caption: 'hi' },
+    mock: mockUpdateCaption,
+  },
+  {
+    name: 'removeScreenshot' as const,
+    input: { screenshotId: 'apls_1' },
+    mock: mockRemoveScreenshot,
+  },
+];
+
+function call(name: (typeof ASSET_PROCS)[number]['name'], input: unknown) {
+  const caller = appListingsRouter.createCaller(fakeCtx(owner) as never);
+  return (caller[name] as (i: unknown) => Promise<unknown>)(input);
+}
+
+describe('owner asset procs — typed service errors are MAPPED, never leaked as a 500', () => {
+  it.each(ASSET_PROCS)(
+    '$name: a lazy-mint INVALID_REVISION surfaces as BAD_REQUEST with the real message',
+    async ({ name, input, mock }) => {
+      // The reachable race: a mod delists the listing between the client's read and
+      // this write, so `beginListingRevision` refuses to open a revision draft.
+      mock.mockRejectedValueOnce(
+        offsiteErr('INVALID_REVISION', 'only an approved listing can be revised') as never
+      );
+
+      const err = await call(name, input).then(
+        () => null,
+        (e: unknown) => e
+      );
+
+      expect(err).toBeInstanceOf(TRPCError);
+      expect((err as TRPCError).code).toBe('BAD_REQUEST');
+      // The actionable message survives — this is the whole point of mapping.
+      expect((err as TRPCError).message).toBe('only an approved listing can be revised');
+    }
+  );
+
+  it.each(ASSET_PROCS)(
+    '$name: a typed NOT_FOUND maps to NOT_FOUND',
+    async ({ name, input, mock }) => {
+      mock.mockRejectedValueOnce(offsiteErr('NOT_FOUND', 'listing not found') as never);
+      const err = await call(name, input).then(
+        () => null,
+        (e: unknown) => e
+      );
+      expect((err as TRPCError).code).toBe('NOT_FOUND');
+    }
+  );
+
+  it.each(ASSET_PROCS)(
+    '$name: a typed NOT_OWNED maps to FORBIDDEN',
+    async ({ name, input, mock }) => {
+      mock.mockRejectedValueOnce(
+        offsiteErr('NOT_OWNED', 'you can only manage your own listings') as never
+      );
+      const err = await call(name, input).then(
+        () => null,
+        (e: unknown) => e
+      );
+      expect((err as TRPCError).code).toBe('FORBIDDEN');
+    }
+  );
+
+  it.each(ASSET_PROCS)(
+    '$name: a TRPCError the service already shaped passes through UNCHANGED',
+    async ({ name, input, mock }) => {
+      // The asset validators + the fail-closed row-id re-map already throw TRPCErrors;
+      // wrapping must not re-code or re-word them.
+      const shaped = new TRPCError({ code: 'BAD_REQUEST', message: 'Icon must be square' });
+      mock.mockRejectedValueOnce(shaped as never);
+      const err = await call(name, input).then(
+        () => null,
+        (e: unknown) => e
+      );
+      expect(err).toBe(shaped);
+    }
+  );
+
+  it.each(ASSET_PROCS)(
+    '$name: an UNEXPECTED infra failure is a generic 500 — no raw message leak',
+    async ({ name, input, mock }) => {
+      mock.mockRejectedValueOnce(
+        new Error('connect ECONNREFUSED 10.0.0.7:5432 pgbouncer-pooler-nvme0') as never
+      );
+      const err = await call(name, input).then(
+        () => null,
+        (e: unknown) => e
+      );
+      expect((err as TRPCError).code).toBe('INTERNAL_SERVER_ERROR');
+      expect((err as TRPCError).message).not.toMatch(/ECONNREFUSED|pgbouncer/);
+    }
+  );
+
+  it.each(ASSET_PROCS)(
+    '$name: the happy path is untouched by the wrapper',
+    async ({ name, input, mock }) => {
+      await expect(call(name, input)).resolves.toBeDefined();
+      expect(mock).toHaveBeenCalledTimes(1);
+    }
+  );
+});

--- a/src/server/routers/app-listings.router.ts
+++ b/src/server/routers/app-listings.router.ts
@@ -294,13 +294,31 @@ export const appListingsRouter = router({
       return getAssetScanStatuses(input.imageIds, ctx.user);
     }),
 
+  // -------------------------------------------------------------------------
+  // OWNER ASSET MUTATIONS.
+  //
+  // 🔴 ALL SIX MAP THROUGH `mapOffsiteError`. Under LAZY shadow-revision minting each
+  // of these calls `resolveOwnerAssetEditTarget` → `beginListingRevision`, which
+  // throws a typed `OffsiteRequestError` (a plain `Error` subclass, NOT a
+  // `TRPCError`) — e.g. `INVALID_REVISION` when a moderator delists the listing
+  // between the client's read and this write, or the 'failed to open a revision
+  // draft' race. Unwrapped, those surfaced as an opaque 500 with a generic message
+  // instead of the typed, actionable one; the escape only exists because the mint
+  // moved onto this path. `TRPCError`s the service already shaped (the asset
+  // validators, the fail-closed row-id re-map) pass straight through.
+  // -------------------------------------------------------------------------
+
   setIcon: protectedProcedure
     .meta(listingMediaCliScope)
     .use(enforceAppBlocksAuthorFlag)
     .input(setListingIconSchema)
     .mutation(async ({ ctx, input }) => {
       const { setListingIcon } = await import('~/server/services/blocks/app-listing-assets.service');
-      return setListingIcon(input, ctx.user);
+      try {
+        return await setListingIcon(input, ctx.user);
+      } catch (err) {
+        throw mapOffsiteError(err);
+      }
     }),
 
   setCover: protectedProcedure
@@ -309,7 +327,11 @@ export const appListingsRouter = router({
     .input(setListingCoverSchema)
     .mutation(async ({ ctx, input }) => {
       const { setListingCover } = await import('~/server/services/blocks/app-listing-assets.service');
-      return setListingCover(input, ctx.user);
+      try {
+        return await setListingCover(input, ctx.user);
+      } catch (err) {
+        throw mapOffsiteError(err);
+      }
     }),
 
   addScreenshot: protectedProcedure
@@ -320,7 +342,11 @@ export const appListingsRouter = router({
       const { addListingScreenshot } = await import(
         '~/server/services/blocks/app-listing-assets.service'
       );
-      return addListingScreenshot(input, ctx.user);
+      try {
+        return await addListingScreenshot(input, ctx.user);
+      } catch (err) {
+        throw mapOffsiteError(err);
+      }
     }),
 
   reorderScreenshots: protectedProcedure
@@ -331,9 +357,20 @@ export const appListingsRouter = router({
       const { reorderListingScreenshots } = await import(
         '~/server/services/blocks/app-listing-assets.service'
       );
-      return reorderListingScreenshots(input, ctx.user);
+      try {
+        return await reorderListingScreenshots(input, ctx.user);
+      } catch (err) {
+        throw mapOffsiteError(err);
+      }
     }),
 
+  /**
+   * 🔴 Returns `{ id }` = the row that was WRITTEN, which differs from the
+   * `screenshotId` passed in when this call minted the shadow revision (the parent row
+   * id is re-keyed onto the clone). Treat it as the new id, not an echo. Input schema
+   * unchanged — released `civitai` CLI versions calling this under `AppBlocksSubmit`
+   * keep working.
+   */
   updateScreenshotCaption: protectedProcedure
     .meta(listingMediaCliScope)
     .use(enforceAppBlocksAuthorFlag)
@@ -342,9 +379,18 @@ export const appListingsRouter = router({
       const { updateListingScreenshotCaption } = await import(
         '~/server/services/blocks/app-listing-assets.service'
       );
-      return updateListingScreenshotCaption(input, ctx.user);
+      try {
+        return await updateListingScreenshotCaption(input, ctx.user);
+      } catch (err) {
+        throw mapOffsiteError(err);
+      }
     }),
 
+  /**
+   * 🔴 Returns `{ removed }` = the row actually DELETED, which differs from the
+   * `screenshotId` passed in when this call minted the shadow revision (the clone is
+   * deleted, never the live parent's row). Treat it as the new id, not an echo.
+   */
   removeScreenshot: protectedProcedure
     .meta(listingMediaCliScope)
     .use(enforceAppBlocksAuthorFlag)
@@ -353,7 +399,11 @@ export const appListingsRouter = router({
       const { removeListingScreenshot } = await import(
         '~/server/services/blocks/app-listing-assets.service'
       );
-      return removeListingScreenshot(input, ctx.user);
+      try {
+        return await removeListingScreenshot(input, ctx.user);
+      } catch (err) {
+        throw mapOffsiteError(err);
+      }
     }),
 
   /**

--- a/src/server/services/blocks/__tests__/app-listing-assets.lazy-revision.service.test.ts
+++ b/src/server/services/blocks/__tests__/app-listing-assets.lazy-revision.service.test.ts
@@ -88,8 +88,40 @@ const { store, db, readDb, ids } = vi.hoisted(() => {
      * whole class of bug (#3476) could not be pinned here.
      */
     replicaLagsOn: new Set<string>(),
+    /**
+     * 🔴 Fires after every `update`/`updateMany` the fake performs on a screenshot row
+     * — i.e. after each individual ORDER write. The reparent-race suites use it to
+     * commit a CONCURRENT `applyApprovedRevision` BETWEEN two statements of an
+     * interactive transaction, which is the only window in which "does the refusal
+     * actually roll back?" is a real question rather than a restatement of the code.
+     */
+    afterShotOrderWrite: null as null | (() => void),
   };
   const ids = { n: 0 };
+
+  /**
+   * UNDO LOG for the interactive-`$transaction` fake (see `$transaction` below).
+   * Writes performed while a transaction callback is running push their inverse here;
+   * if the callback throws, the inverses are applied in reverse — the transaction
+   * ROLLS BACK.
+   *
+   * 🔴 An undo LOG rather than a whole-store snapshot, deliberately: the reparent-race
+   * tests land a CONCURRENT committed `applyApprovedRevision` by mutating the store
+   * directly mid-transaction, and a real ROLLBACK does not undo another transaction's
+   * committed work. A snapshot would, and would then let a test "pass" by asserting a
+   * state Postgres could never produce.
+   */
+  const txn = { undo: null as null | (() => void)[] };
+  const journal = (undo: () => void) => {
+    if (txn.undo) txn.undo.push(undo);
+  };
+  /** Journal an in-place field write so it can be reverted to the pre-write values. */
+  const journalPatch = <T extends object>(row: T, data: Partial<T>) => {
+    if (!txn.undo) return;
+    const prev = {} as Partial<T>;
+    for (const k of Object.keys(data) as (keyof T)[]) prev[k] = row[k];
+    journal(() => Object.assign(row, prev));
+  };
 
   const matchListing = (row: ListingRow, where: Record<string, unknown>) =>
     Object.entries(where).every(([k, v]) => (row as unknown as Record<string, unknown>)[k] === v);
@@ -104,11 +136,15 @@ const { store, db, readDb, ids } = vi.hoisted(() => {
     create: vi.fn(async (args: { data: Partial<ListingRow> }) => {
       const row = { ...(args.data as ListingRow) };
       store.listings.push(row);
+      journal(() => {
+        store.listings = store.listings.filter((l) => l !== row);
+      });
       return row;
     }),
     update: vi.fn(async (args: { where: { id: string }; data: Partial<ListingRow> }) => {
       const row = store.listings.find((l) => l.id === args.where.id);
       if (!row) throw new Error(`no listing ${args.where.id}`);
+      journalPatch(row, args.data);
       Object.assign(row, args.data);
       return row;
     }),
@@ -143,23 +179,35 @@ const { store, db, readDb, ids } = vi.hoisted(() => {
         store.shots.filter((s) => s.appListingId === args.where.appListingId).length
     ),
     create: vi.fn(async (args: { data: ShotRow }) => {
-      store.shots.push({ ...args.data });
+      const row = { ...args.data };
+      store.shots.push(row);
+      journal(() => {
+        store.shots = store.shots.filter((s) => s !== row);
+      });
       return args.data;
     }),
     createMany: vi.fn(async (args: { data: ShotRow[] }) => {
-      for (const d of args.data) store.shots.push({ ...d });
+      const rows = args.data.map((d) => ({ ...d }));
+      for (const r of rows) store.shots.push(r);
+      journal(() => {
+        store.shots = store.shots.filter((s) => !rows.includes(s));
+      });
       return { count: args.data.length };
     }),
     update: vi.fn(async (args: { where: { id: string }; data: Partial<ShotRow> }) => {
       const row = store.shots.find((s) => s.id === args.where.id);
       if (!row) throw new Error(`no screenshot ${args.where.id}`);
+      journalPatch(row, args.data);
       Object.assign(row, args.data);
+      store.afterShotOrderWrite?.();
       return row;
     }),
     delete: vi.fn(async (args: { where: { id: string } }) => {
       const i = store.shots.findIndex((s) => s.id === args.where.id);
       if (i < 0) throw new Error(`no screenshot ${args.where.id}`);
-      return store.shots.splice(i, 1)[0];
+      const [row] = store.shots.splice(i, 1);
+      journal(() => store.shots.splice(i, 0, row));
+      return row;
     }),
     // The LISTING-SCOPED write forms. A compound `{ id, appListingId }` filter is the
     // whole point: it must match ZERO rows once `applyApprovedRevision` has reparented
@@ -171,11 +219,16 @@ const { store, db, readDb, ids } = vi.hoisted(() => {
             (args.where.id === undefined || s.id === args.where.id) &&
             (args.where.appListingId === undefined || s.appListingId === args.where.appListingId)
         );
-        for (const r of rows) Object.assign(r, args.data);
+        for (const r of rows) {
+          journalPatch(r, args.data);
+          Object.assign(r, args.data);
+        }
+        store.afterShotOrderWrite?.();
         return { count: rows.length };
       }
     ),
     deleteMany: vi.fn(async (args: { where: { id?: string; appListingId?: string } }) => {
+      const before = store.shots;
       const keep: ShotRow[] = [];
       let count = 0;
       for (const s of store.shots) {
@@ -186,6 +239,7 @@ const { store, db, readDb, ids } = vi.hoisted(() => {
         else keep.push(s);
       }
       store.shots = keep;
+      if (count > 0) journal(() => (store.shots = before));
       return { count };
     }),
   };
@@ -204,7 +258,26 @@ const { store, db, readDb, ids } = vi.hoisted(() => {
     appListingScreenshot,
     image,
     $transaction: vi.fn(async (arg: unknown) => {
-      if (typeof arg === 'function') return (arg as (tx: unknown) => unknown)(db);
+      // 🔴 The INTERACTIVE form rolls back on throw (via the undo log above). Modelling
+      // that is the whole point: `reorderListingScreenshots` now raises its refusal
+      // INSIDE the callback specifically so the orders already written are undone, and
+      // without a fake that can roll back, "leaves no partial order writes" would be an
+      // assertion nothing could falsify.
+      if (typeof arg === 'function') {
+        const outer = txn.undo;
+        const log: (() => void)[] = [];
+        txn.undo = log;
+        try {
+          return await (arg as (tx: unknown) => unknown)(db);
+        } catch (e) {
+          for (let i = log.length - 1; i >= 0; i--) log[i]();
+          throw e;
+        } finally {
+          txn.undo = outer;
+        }
+      }
+      // The ARRAY form has no such property — it COMMITS, and only then are its
+      // results inspected. Left un-rolled-back on purpose so a regression to it fails.
       return Promise.all(arg as Promise<unknown>[]);
     }),
   };
@@ -350,6 +423,7 @@ beforeEach(() => {
   store.shots = [];
   store.images = [];
   store.replicaLagsOn = new Set();
+  store.afterShotOrderWrite = null;
 });
 
 // ---------------------------------------------------------------------------
@@ -777,6 +851,99 @@ describe('the reparent race — a resolved row id that became a LIVE row must no
       ['apls_parent_a', 0],
       ['apls_parent_b', 1],
     ]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 🔴 …AND THE REFUSAL HAS TO ROLL BACK.
+//
+// The two suites above land the approve BEFORE the first write, so every statement
+// misses and "nothing was written" is true for free. The interesting window is the
+// approve committing BETWEEN two statements: then one order IS already written when
+// the next one finds nothing. `$transaction([...])` (the array form) had COMMITTED by
+// the time its results were inspected, so that case left some orders written AND threw
+// — the worst of both. The refusal is raised inside an INTERACTIVE transaction now, so
+// it rolls back; these tests are what makes that claim falsifiable.
+// ---------------------------------------------------------------------------
+
+/** `seedShadowWithClonedRows` plus a third pair, so there IS a middle statement. */
+function seedShadowWithThreeClonedRows() {
+  seedShadowWithClonedRows();
+  seedShot('apls_parent_c', PARENT_ID, 302, 2);
+  seedShot('apls_shadow_c', 'apl_shadow', 302, 2);
+}
+
+/** Commit the approve's reparent right after the Nth screenshot ORDER write. */
+function reparentAfterOrderWrite(n: number, shadowId = 'apl_shadow') {
+  let writes = 0;
+  store.afterShotOrderWrite = () => {
+    if (++writes === n) simulateApprovalReparent(shadowId);
+  };
+}
+
+describe('a refusal raised mid-transaction must ROLL BACK, not half-write', () => {
+  it('🔴 reorderScreenshots raced MID-TRANSACTION leaves NO partial order writes', async () => {
+    seedShadowWithThreeClonedRows();
+    // The first `updateMany` lands on the shadow; the approve commits; the second finds
+    // nothing (it is scoped to the shadow, and the rows are on the parent now).
+    reparentAfterOrderWrite(1);
+
+    await expect(
+      reorderListingScreenshots(
+        {
+          listingId: 'apl_shadow',
+          orderedIds: ['apls_shadow_c', 'apls_shadow_b', 'apls_shadow_a'],
+        },
+        OWNER
+      )
+    ).rejects.toThrow(/no longer available on your revision/);
+
+    // 🔴 THE ASSERTION. These rows are on the LIVE listing now. The one order the
+    // transaction did write (c → 0) was rolled back with it, so the live listing
+    // carries exactly the ordering the approve gave it — not a half-applied reorder
+    // with `c` yanked to the front of a listing no one reviewed.
+    expect(shotsOf(PARENT_ID).map((s) => [s.id, s.order])).toEqual([
+      ['apls_shadow_a', 0],
+      ['apls_shadow_b', 1],
+      ['apls_shadow_c', 2],
+    ]);
+  });
+
+  it('🔴 the post-delete RE-PACK is listing-scoped — an approve mid-repack writes no order onto the live rows', async () => {
+    seedShadowWithThreeClonedRows();
+    // The delete commits normally (it is not an order write, so it does not tick the
+    // counter); the approve lands after the first re-pack write.
+    reparentAfterOrderWrite(1);
+
+    // The removal itself SUCCEEDS. It committed before the approve, and it is exactly
+    // what the owner asked for — see the `count !== 1` note on the re-pack: abandoning
+    // a cosmetic densification is a no-op, refusing would report a failed removal that
+    // in fact happened.
+    const res = await removeListingScreenshot({ screenshotId: 'apls_shadow_a' }, OWNER);
+    expect(res).toEqual({ removed: 'apls_shadow_a' });
+
+    // 🔴 THE ASSERTION. By the time the re-pack runs, `_b` and `_c` are rows on the
+    // LIVE served listing. The unscoped `update({ where: { id } })` this replaced would
+    // have written 0/1 onto them — reordering a listing no moderator reviewed. Scoped,
+    // it matches nothing, aborts, and rolls back the one order it had written; the rows
+    // keep the orders `applyApprovedRevision` moved them with.
+    expect(shotsOf(PARENT_ID).map((s) => [s.id, s.order])).toEqual([
+      ['apls_shadow_b', 1],
+      ['apls_shadow_c', 2],
+    ]);
+  });
+
+  it('the ordinary (unraced) re-pack still densifies the survivors to 0..n-1', async () => {
+    seedShadowWithThreeClonedRows();
+
+    await removeListingScreenshot({ screenshotId: 'apls_shadow_a' }, OWNER);
+
+    // Scoping the write must not have cost the re-pack its actual job.
+    expect(shotsOf('apl_shadow').map((s) => [s.id, s.order])).toEqual([
+      ['apls_shadow_b', 0],
+      ['apls_shadow_c', 1],
+    ]);
+    expect(shotsOf(PARENT_ID)).toHaveLength(3);
   });
 });
 

--- a/src/server/services/blocks/__tests__/app-listing-assets.lazy-revision.service.test.ts
+++ b/src/server/services/blocks/__tests__/app-listing-assets.lazy-revision.service.test.ts
@@ -24,8 +24,13 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
  *
  * The DB is an in-memory FAKE rather than call-shape stubs, deliberately: the
  * assertion that matters is "the PARENT's rows are still there afterwards", and only
- * a store that actually holds rows can make that claim honestly. It backs BOTH
- * `dbRead` and `dbWrite`, so the REAL `beginListingRevision` clone runs against it.
+ * a store that actually holds rows can make that claim honestly. One store backs both
+ * pools, so the REAL `beginListingRevision` clone runs against it.
+ *
+ * 🔴 `dbRead` and `dbWrite` are DISTINCT fakes over that store (`readDb` / `db`), with
+ * a `store.replicaLagsOn` set the REPLICA cannot see. They used to be the same object,
+ * which made every "this read must go to the PRIMARY" claim in the service
+ * unfalsifiable — a guard nothing could break is a guard nothing verifies.
  */
 
 type ListingRow = {
@@ -69,11 +74,20 @@ type ImageRow = {
   nsfwLevel: number;
 };
 
-const { store, db, ids } = vi.hoisted(() => {
+const { store, db, readDb, ids } = vi.hoisted(() => {
   const store = {
     listings: [] as ListingRow[],
     shots: [] as ShotRow[],
     images: [] as ImageRow[],
+    /**
+     * 🔴 REPLICA LAG. Ids (listing OR screenshot row) the REPLICA has not received
+     * yet. `dbRead` below hides them; `dbWrite` still serves them — i.e. exactly the
+     * read-after-write condition that decides whether a just-minted shadow's rows are
+     * reachable. Without a `dbRead` that can differ from `dbWrite` the pool routing is
+     * structurally untestable, which is why the two used to be the SAME fake and this
+     * whole class of bug (#3476) could not be pinned here.
+     */
+    replicaLagsOn: new Set<string>(),
   };
   const ids = { n: 0 };
 
@@ -147,6 +161,33 @@ const { store, db, ids } = vi.hoisted(() => {
       if (i < 0) throw new Error(`no screenshot ${args.where.id}`);
       return store.shots.splice(i, 1)[0];
     }),
+    // The LISTING-SCOPED write forms. A compound `{ id, appListingId }` filter is the
+    // whole point: it must match ZERO rows once `applyApprovedRevision` has reparented
+    // the shadow's rows onto the live parent.
+    updateMany: vi.fn(
+      async (args: { where: { id?: string; appListingId?: string }; data: Partial<ShotRow> }) => {
+        const rows = store.shots.filter(
+          (s) =>
+            (args.where.id === undefined || s.id === args.where.id) &&
+            (args.where.appListingId === undefined || s.appListingId === args.where.appListingId)
+        );
+        for (const r of rows) Object.assign(r, args.data);
+        return { count: rows.length };
+      }
+    ),
+    deleteMany: vi.fn(async (args: { where: { id?: string; appListingId?: string } }) => {
+      const keep: ShotRow[] = [];
+      let count = 0;
+      for (const s of store.shots) {
+        const hit =
+          (args.where.id === undefined || s.id === args.where.id) &&
+          (args.where.appListingId === undefined || s.appListingId === args.where.appListingId);
+        if (hit) count += 1;
+        else keep.push(s);
+      }
+      store.shots = keep;
+      return { count };
+    }),
   };
 
   const image = {
@@ -168,10 +209,66 @@ const { store, db, ids } = vi.hoisted(() => {
     }),
   };
 
-  return { store, db, ids };
+  /**
+   * The REPLICA. Same store, but rows in `store.replicaLagsOn` are invisible —
+   * replication has not caught up. Only the READ surface is modelled; every write in
+   * the service goes through `dbWrite` by construction, and a write landing here would
+   * be a bug worth failing on.
+   */
+  const lagging = (id: string) => store.replicaLagsOn.has(id);
+  const readDb = {
+    appListing: {
+      findUnique: vi.fn(async (args: { where: Record<string, unknown> }) => {
+        const row = store.listings.find((l) => matchListing(l, args.where));
+        return row && !lagging(row.id) ? row : null;
+      }),
+      findFirst: vi.fn(async (args: { where: Record<string, unknown> }) => {
+        const row = store.listings.find((l) => matchListing(l, args.where));
+        return row && !lagging(row.id) ? row : null;
+      }),
+      findMany: vi.fn(async () => [] as ListingRow[]),
+    },
+    appListingScreenshot: {
+      findUnique: vi.fn(
+        async (args: { where: { id: string }; select?: Record<string, unknown> }) => {
+          const row = store.shots.find((s) => s.id === args.where.id);
+          if (!row || lagging(row.id) || lagging(row.appListingId)) return null;
+          if (args.select && 'appListing' in args.select) {
+            const listing = store.listings.find((l) => l.id === row.appListingId) ?? null;
+            return { ...row, appListing: listing };
+          }
+          return row;
+        }
+      ),
+      findMany: vi.fn(
+        async (args: {
+          where: { appListingId?: string };
+          orderBy?: { order?: 'asc' | 'desc' };
+        }) => {
+          let rows = store.shots.filter(
+            (s) => s.appListingId === args.where.appListingId && !lagging(s.id)
+          );
+          if (args.orderBy?.order === 'desc') rows = [...rows].sort((a, b) => b.order - a.order);
+          else rows = [...rows].sort((a, b) => a.order - b.order);
+          return rows.map((r) => ({ ...r }));
+        }
+      ),
+      count: vi.fn(
+        async (args: { where: { appListingId?: string } }) =>
+          store.shots.filter((s) => s.appListingId === args.where.appListingId && !lagging(s.id))
+            .length
+      ),
+    },
+    image,
+  };
+
+  return { store, db, readDb, ids };
 });
 
-vi.mock('~/server/db/client', () => ({ dbRead: db, dbWrite: db }));
+// 🔴 dbRead and dbWrite are DISTINCT fakes over one store. They used to be the same
+// object, which silently made every "reads the primary" claim in this module
+// unfalsifiable.
+vi.mock('~/server/db/client', () => ({ dbRead: readDb, dbWrite: db }));
 vi.mock('~/server/utils/app-block-ids', () => ({
   newAppListingId: () => `apl_gen_${++ids.n}`,
   newAppListingPublishRequestId: () => `alpr_gen_${++ids.n}`,
@@ -252,6 +349,7 @@ beforeEach(() => {
   store.listings = [];
   store.shots = [];
   store.images = [];
+  store.replicaLagsOn = new Set();
 });
 
 // ---------------------------------------------------------------------------
@@ -511,5 +609,207 @@ describe('matchClonedScreenshotRow', () => {
     expect(matchClonedScreenshotRow({ imageId: null, order: 9 }, nulls)).toBeNull();
     // …but an exact (null, order) pair is unambiguous and DOES match.
     expect(matchClonedScreenshotRow({ imageId: null, order: 1 }, nulls)).toBe('s2');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 🔴 READ-AFTER-WRITE on the row-id-keyed procs.
+//
+// The client now receives freshly-minted SHADOW row ids sourced from the PRIMARY
+// (`getMyListingForApp` probes `dbWrite` for the shadow). `resolveOwnerScreenshotTarget`
+// then read the screenshot row AND its listing off the REPLICA, so under replication
+// lag the owner's second edit 404'd on a row that demonstrably exists — the same class
+// of bug #3476 fixed for `loadListingEditView`, whose window this change widened by
+// moving the mint onto the write path.
+// ---------------------------------------------------------------------------
+
+/** A live parent + its shadow revision, cloned rows and all. */
+function seedShadowWithClonedRows() {
+  store.listings.push(listing());
+  store.listings.push(
+    listing({
+      id: 'apl_shadow',
+      status: 'draft',
+      revisionOfId: PARENT_ID,
+      appBlockId: null,
+      slug: 'rev-x',
+    })
+  );
+  seedShot('apls_parent_a', PARENT_ID, 300, 0);
+  seedShot('apls_parent_b', PARENT_ID, 301, 1);
+  seedShot('apls_shadow_a', 'apl_shadow', 300, 0);
+  seedShot('apls_shadow_b', 'apl_shadow', 301, 1);
+}
+
+/**
+ * What `applyApprovedRevision` does to the screenshot rows: drop the parent's set,
+ * then REPARENT the shadow's rows onto the parent (`updateMany appListingId →
+ * parentId`). After this, a row id resolved a moment ago as a SHADOW row is a row on
+ * the LIVE listing.
+ */
+function simulateApprovalReparent(shadowId: string) {
+  store.shots = store.shots.filter((s) => s.appListingId !== PARENT_ID);
+  for (const s of store.shots) if (s.appListingId === shadowId) s.appListingId = PARENT_ID;
+}
+
+describe('replica lag — a shadow row id must not 404 on the pool that cannot see it yet', () => {
+  it('🔴 removeScreenshot resolves a JUST-MINTED shadow row the replica has not received', () => {
+    seedShadowWithClonedRows();
+    // Replication has not caught up on the shadow listing or its cloned rows.
+    store.replicaLagsOn = new Set(['apl_shadow', 'apls_shadow_a', 'apls_shadow_b']);
+
+    return removeListingScreenshot({ screenshotId: 'apls_shadow_a' }, OWNER).then((res) => {
+      expect(res).toEqual({ removed: 'apls_shadow_a' });
+      // It came off the SHADOW…
+      expect(shotsOf('apl_shadow').map((s) => s.id)).toEqual(['apls_shadow_b']);
+      // …and the live listing is untouched.
+      expect(shotsOf(PARENT_ID).map((s) => s.id)).toEqual(['apls_parent_a', 'apls_parent_b']);
+    });
+  });
+
+  it('🔴 updateScreenshotCaption likewise — neither the row read nor the listing read may trust the replica', async () => {
+    seedShadowWithClonedRows();
+    store.replicaLagsOn = new Set(['apl_shadow', 'apls_shadow_a', 'apls_shadow_b']);
+
+    await updateListingScreenshotCaption(
+      { screenshotId: 'apls_shadow_b', caption: 'staged on the revision' },
+      OWNER
+    );
+
+    expect(store.shots.find((s) => s.id === 'apls_shadow_b')!.caption).toBe(
+      'staged on the revision'
+    );
+    // The live row that shares the image keeps its own caption.
+    expect(store.shots.find((s) => s.id === 'apls_parent_b')!.caption).toBeNull();
+  });
+
+  it('a row that exists on NEITHER pool is still a genuine NOT_FOUND', async () => {
+    seedShadowWithClonedRows();
+    await expect(removeListingScreenshot({ screenshotId: 'apls_nope' }, OWNER)).rejects.toThrow(
+      /Screenshot not found/
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 🔴 LISTING-SCOPED WRITES.
+//
+// `applyApprovedRevision` REPARENTS the shadow's screenshot rows onto the live parent.
+// A moderator approving between the resolve and the write turns a resolved SHADOW row
+// id into a PARENT row id — and the writes were `delete({ where: { id } })` /
+// `update({ where: { id } })`, i.e. they would have landed on the LIVE served listing.
+// Scoping every write to `{ id, appListingId: <resolved listing> }` and requiring
+// `count === 1` makes that structurally impossible rather than merely improbable.
+// ---------------------------------------------------------------------------
+
+describe('the reparent race — a resolved row id that became a LIVE row must not be written', () => {
+  it('🔴 removeScreenshot refuses instead of deleting off the live listing', async () => {
+    seedShadowWithClonedRows();
+    // Approve lands right after the ownership/target resolve reads the listing.
+    vi.mocked(readDb.appListing.findUnique).mockImplementationOnce(async (args: unknown) => {
+      const id = (args as { where: { id?: string } }).where.id;
+      const row = store.listings.find((l) => l.id === id) ?? null;
+      simulateApprovalReparent('apl_shadow');
+      return row;
+    });
+
+    await expect(removeListingScreenshot({ screenshotId: 'apls_shadow_a' }, OWNER)).rejects.toThrow(
+      /no longer available on your revision/
+    );
+
+    // The row survived — it is now a LIVE screenshot and nothing deleted it.
+    expect(shotsOf(PARENT_ID).map((s) => s.id)).toEqual(['apls_shadow_a', 'apls_shadow_b']);
+  });
+
+  it('🔴 updateScreenshotCaption refuses instead of re-captioning a live row', async () => {
+    seedShadowWithClonedRows();
+    vi.mocked(readDb.appListing.findUnique).mockImplementationOnce(async (args: unknown) => {
+      const id = (args as { where: { id?: string } }).where.id;
+      const row = store.listings.find((l) => l.id === id) ?? null;
+      simulateApprovalReparent('apl_shadow');
+      return row;
+    });
+
+    await expect(
+      updateListingScreenshotCaption({ screenshotId: 'apls_shadow_a', caption: 'oops' }, OWNER)
+    ).rejects.toThrow(/no longer available on your revision/);
+
+    expect(store.shots.find((s) => s.id === 'apls_shadow_a')!.caption).toBeNull();
+  });
+
+  it('🔴 reorderScreenshots refuses instead of re-ordering the live listing', async () => {
+    seedShadowWithClonedRows();
+    // The approve lands AFTER the permutation check's primary read — the only window
+    // in which the scoped write is the thing that saves the live listing.
+    vi.mocked(db.appListingScreenshot.findMany).mockImplementationOnce(async (args: unknown) => {
+      const where = (args as { where: { appListingId?: string } }).where;
+      const rows = store.shots
+        .filter((s) => s.appListingId === where.appListingId)
+        .map((r) => ({ ...r }));
+      simulateApprovalReparent('apl_shadow');
+      return rows;
+    });
+
+    await expect(
+      reorderListingScreenshots(
+        { listingId: 'apl_shadow', orderedIds: ['apls_shadow_b', 'apls_shadow_a'] },
+        OWNER
+      )
+    ).rejects.toThrow(/no longer available on your revision/);
+
+    // The now-live rows kept their original order — the reorder did not land.
+    expect(shotsOf(PARENT_ID).map((s) => [s.id, s.order])).toEqual([
+      ['apls_shadow_a', 0],
+      ['apls_shadow_b', 1],
+    ]);
+  });
+
+  it('the ordinary (unraced) reorder still works and writes exactly the resolved listing', async () => {
+    seedShadowWithClonedRows();
+    const res = await reorderListingScreenshots(
+      { listingId: 'apl_shadow', orderedIds: ['apls_shadow_b', 'apls_shadow_a'] },
+      OWNER
+    );
+    expect(res).toEqual({ reordered: 2 });
+    expect(shotsOf('apl_shadow').map((s) => s.id)).toEqual(['apls_shadow_b', 'apls_shadow_a']);
+    // The live listing's ordering is untouched.
+    expect(shotsOf(PARENT_ID).map((s) => [s.id, s.order])).toEqual([
+      ['apls_parent_a', 0],
+      ['apls_parent_b', 1],
+    ]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Return-shape contract (FIX 5): these two procs answer with the row they actually
+// WROTE, which is NOT the id the caller passed when this call minted the shadow.
+// ---------------------------------------------------------------------------
+
+describe('row-id-keyed procs return the RESOLVED row id, not an echo of the input', () => {
+  it('🔴 removeScreenshot reports the SHADOW clone it deleted, not the parent id it was given', async () => {
+    store.listings.push(listing());
+    seedShot('apls_parent_a', PARENT_ID, 300, 0);
+
+    const res = await removeListingScreenshot({ screenshotId: 'apls_parent_a' }, OWNER);
+
+    // Deliberate: echoing back `apls_parent_a` would report deleting a row off the
+    // LIVE listing — a deletion that must never happen and here did not.
+    expect(res.removed).not.toBe('apls_parent_a');
+    expect(shotsOf(PARENT_ID).map((s) => s.id)).toEqual(['apls_parent_a']);
+    expect(shotsOf(shadow()!.id)).toEqual([]);
+  });
+
+  it('🔴 updateScreenshotCaption reports the SHADOW clone it wrote', async () => {
+    store.listings.push(listing());
+    seedShot('apls_parent_a', PARENT_ID, 300, 0);
+
+    const res = await updateListingScreenshotCaption(
+      { screenshotId: 'apls_parent_a', caption: 'hello' },
+      OWNER
+    );
+
+    expect(res.id).not.toBe('apls_parent_a');
+    expect(store.shots.find((s) => s.id === res.id)!.appListingId).toBe(shadow()!.id);
+    expect(store.shots.find((s) => s.id === 'apls_parent_a')!.caption).toBeNull();
   });
 });

--- a/src/server/services/blocks/__tests__/app-listing-assets.lazy-revision.service.test.ts
+++ b/src/server/services/blocks/__tests__/app-listing-assets.lazy-revision.service.test.ts
@@ -1,0 +1,515 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * LAZY shadow-revision minting on the owner asset procs — Part 1 of the
+ * listing-revision staleness fix.
+ *
+ * `getMyListingForApp` no longer calls `beginListingRevision`: opening the media tab
+ * used to CREATE a `draft` `AppListing`. Measured on prod 2026-07-30 — 7 shadows,
+ * 7/7 with `updated_at == created_at` (never written since their clone tx), 6 minted
+ * that day by page views alone, three of them 1.5 s apart from opening three apps in
+ * a row; 78% of approved onsite parents carried a shadow that represented no edit,
+ * and they refilled the instant anyone looked again. So the shadow is minted here, by
+ * the first asset MUTATION.
+ *
+ * 🔴 THE HAZARD THIS SUITE EXISTS FOR. `removeScreenshot` / `reorderScreenshots` /
+ * `updateScreenshotCaption` take `AppListingScreenshot` ROW ids, and until a shadow
+ * exists the ids the client holds are the LIVE PARENT's rows. Applied naively, a
+ * "remove screenshot" would DELETE A ROW OFF THE SERVED LISTING with no moderator
+ * review — the exact data-loss path the 🔴 SECURITY note on
+ * `GetMyListingForAppResult.assets` warns about. The write path therefore mints the
+ * shadow and RE-KEYS the row id onto the fresh clone before touching anything, and
+ * `assertOwnerAssetEditable` runs on the RESOLVED target as fail-closed defence in
+ * depth.
+ *
+ * The DB is an in-memory FAKE rather than call-shape stubs, deliberately: the
+ * assertion that matters is "the PARENT's rows are still there afterwards", and only
+ * a store that actually holds rows can make that claim honestly. It backs BOTH
+ * `dbRead` and `dbWrite`, so the REAL `beginListingRevision` clone runs against it.
+ */
+
+type ListingRow = {
+  id: string;
+  kind: string;
+  slug: string;
+  status: string;
+  userId: number;
+  revisionOfId: string | null;
+  appBlockId: string | null;
+  name: string;
+  tagline: string | null;
+  description: string | null;
+  category: string | null;
+  contentRating: string | null;
+  externalUrl: string | null;
+  connectClientId: string | null;
+  connectRequestedScopes: number | null;
+  connectScopeJustifications: unknown;
+  iconId: number | null;
+  coverId: number | null;
+};
+
+type ShotRow = {
+  id: string;
+  appListingId: string;
+  imageId: number | null;
+  order: number;
+  caption: string | null;
+};
+
+type ImageRow = {
+  id: number;
+  userId: number;
+  type: string;
+  width: number;
+  height: number;
+  mimeType: string;
+  metadata: { size: number };
+  ingestion: string;
+  nsfwLevel: number;
+};
+
+const { store, db, ids } = vi.hoisted(() => {
+  const store = {
+    listings: [] as ListingRow[],
+    shots: [] as ShotRow[],
+    images: [] as ImageRow[],
+  };
+  const ids = { n: 0 };
+
+  const matchListing = (row: ListingRow, where: Record<string, unknown>) =>
+    Object.entries(where).every(([k, v]) => (row as unknown as Record<string, unknown>)[k] === v);
+
+  const appListing = {
+    findUnique: vi.fn(async (args: { where: Record<string, unknown> }) => {
+      return store.listings.find((l) => matchListing(l, args.where)) ?? null;
+    }),
+    findFirst: vi.fn(async (args: { where: Record<string, unknown> }) => {
+      return store.listings.find((l) => matchListing(l, args.where)) ?? null;
+    }),
+    create: vi.fn(async (args: { data: Partial<ListingRow> }) => {
+      const row = { ...(args.data as ListingRow) };
+      store.listings.push(row);
+      return row;
+    }),
+    update: vi.fn(async (args: { where: { id: string }; data: Partial<ListingRow> }) => {
+      const row = store.listings.find((l) => l.id === args.where.id);
+      if (!row) throw new Error(`no listing ${args.where.id}`);
+      Object.assign(row, args.data);
+      return row;
+    }),
+    findMany: vi.fn(async () => [] as ListingRow[]),
+  };
+
+  const appListingScreenshot = {
+    findUnique: vi.fn(async (args: { where: { id: string }; select?: Record<string, unknown> }) => {
+      const row = store.shots.find((s) => s.id === args.where.id);
+      if (!row) return null;
+      // Hydrate the `appListing` relation when selected (the row-id-keyed procs use it
+      // for the ownership check).
+      if (args.select && 'appListing' in args.select) {
+        const listing = store.listings.find((l) => l.id === row.appListingId) ?? null;
+        return { ...row, appListing: listing };
+      }
+      return row;
+    }),
+    findMany: vi.fn(
+      async (args: {
+        where: { appListingId?: string; imageId?: unknown };
+        orderBy?: { order?: 'asc' | 'desc' };
+      }) => {
+        let rows = store.shots.filter((s) => s.appListingId === args.where.appListingId);
+        if (args.orderBy?.order === 'desc') rows = [...rows].sort((a, b) => b.order - a.order);
+        else rows = [...rows].sort((a, b) => a.order - b.order);
+        return rows.map((r) => ({ ...r }));
+      }
+    ),
+    count: vi.fn(
+      async (args: { where: { appListingId?: string } }) =>
+        store.shots.filter((s) => s.appListingId === args.where.appListingId).length
+    ),
+    create: vi.fn(async (args: { data: ShotRow }) => {
+      store.shots.push({ ...args.data });
+      return args.data;
+    }),
+    createMany: vi.fn(async (args: { data: ShotRow[] }) => {
+      for (const d of args.data) store.shots.push({ ...d });
+      return { count: args.data.length };
+    }),
+    update: vi.fn(async (args: { where: { id: string }; data: Partial<ShotRow> }) => {
+      const row = store.shots.find((s) => s.id === args.where.id);
+      if (!row) throw new Error(`no screenshot ${args.where.id}`);
+      Object.assign(row, args.data);
+      return row;
+    }),
+    delete: vi.fn(async (args: { where: { id: string } }) => {
+      const i = store.shots.findIndex((s) => s.id === args.where.id);
+      if (i < 0) throw new Error(`no screenshot ${args.where.id}`);
+      return store.shots.splice(i, 1)[0];
+    }),
+  };
+
+  const image = {
+    findUnique: vi.fn(async (args: { where: { id: number } }) => {
+      return store.images.find((i) => i.id === args.where.id) ?? null;
+    }),
+    findMany: vi.fn(async (args: { where: { id: { in: number[] } } }) =>
+      store.images.filter((i) => args.where.id.in.includes(i.id))
+    ),
+  };
+
+  const db = {
+    appListing,
+    appListingScreenshot,
+    image,
+    $transaction: vi.fn(async (arg: unknown) => {
+      if (typeof arg === 'function') return (arg as (tx: unknown) => unknown)(db);
+      return Promise.all(arg as Promise<unknown>[]);
+    }),
+  };
+
+  return { store, db, ids };
+});
+
+vi.mock('~/server/db/client', () => ({ dbRead: db, dbWrite: db }));
+vi.mock('~/server/utils/app-block-ids', () => ({
+  newAppListingId: () => `apl_gen_${++ids.n}`,
+  newAppListingPublishRequestId: () => `alpr_gen_${++ids.n}`,
+  newAppListingScreenshotId: () => `apls_gen_${++ids.n}`,
+  newUlid: () => `ULID${++ids.n}`,
+}));
+
+import {
+  addListingScreenshot,
+  matchClonedScreenshotRow,
+  removeListingScreenshot,
+  reorderListingScreenshots,
+  setListingCover,
+  setListingIcon,
+  updateListingScreenshotCaption,
+} from '~/server/services/blocks/app-listing-assets.service';
+
+const OWNER = { id: 42, isModerator: false } as never;
+const MOD = { id: 7, isModerator: true } as never;
+
+const PARENT_ID = 'apl_parent';
+
+function listing(overrides: Partial<ListingRow> = {}): ListingRow {
+  return {
+    id: PARENT_ID,
+    kind: 'onsite',
+    slug: 'my-app',
+    status: 'approved',
+    userId: 42,
+    revisionOfId: null,
+    appBlockId: 'ab_1',
+    name: 'My App',
+    tagline: null,
+    description: null,
+    category: null,
+    contentRating: 'pg13',
+    externalUrl: null,
+    connectClientId: null,
+    connectRequestedScopes: null,
+    connectScopeJustifications: null,
+    iconId: 100,
+    coverId: 101,
+    ...overrides,
+  };
+}
+
+/**
+ * A clean, scan-complete image the owner owns (so attach always succeeds). Square by
+ * default (valid icon/screenshot); `landscape` gives a 16:9 that clears the cover
+ * aspect gate (1.3–2.4).
+ */
+function seedImage(id: number, opts: { userId?: number; landscape?: boolean } = {}) {
+  store.images.push({
+    id,
+    userId: opts.userId ?? 42,
+    type: 'image',
+    width: opts.landscape ? 1920 : 1024,
+    height: opts.landscape ? 1080 : 1024,
+    mimeType: 'image/png',
+    metadata: { size: 50_000 },
+    ingestion: 'Scanned',
+    nsfwLevel: 1,
+  });
+}
+
+function seedShot(id: string, appListingId: string, imageId: number, order: number) {
+  store.shots.push({ id, appListingId, imageId, order, caption: null });
+}
+
+/** The shadow of PARENT_ID, if the code under test minted one. */
+const shadow = () => store.listings.find((l) => l.revisionOfId === PARENT_ID) ?? null;
+const shotsOf = (listingId: string) =>
+  store.shots.filter((s) => s.appListingId === listingId).sort((a, b) => a.order - b.order);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  ids.n = 0;
+  store.listings = [];
+  store.shots = [];
+  store.images = [];
+});
+
+// ---------------------------------------------------------------------------
+// Mint on first edit — icon / cover / add-screenshot (id-safe: they carry an
+// imageId + a target listing id, so there is nothing to re-map).
+// ---------------------------------------------------------------------------
+
+describe('lazy shadow minting — the first asset mutation opens the revision', () => {
+  it('🔴 setIcon on a live approved listing mints the shadow and writes to IT, never the parent', async () => {
+    store.listings.push(listing());
+    seedImage(200);
+
+    const res = await setListingIcon({ listingId: PARENT_ID, imageId: 200 }, OWNER);
+
+    expect(res).toMatchObject({ status: 'attached', iconId: 200 });
+    const sh = shadow();
+    expect(sh).not.toBeNull();
+    expect(sh!.status).toBe('draft');
+    // The revision carries the new icon…
+    expect(sh!.iconId).toBe(200);
+    // …and the LIVE listing is byte-identical to what it was. This is the whole point.
+    expect(store.listings.find((l) => l.id === PARENT_ID)!.iconId).toBe(100);
+  });
+
+  it('setCover likewise stages on the shadow', async () => {
+    store.listings.push(listing());
+    seedImage(201, { landscape: true });
+
+    await setListingCover({ listingId: PARENT_ID, imageId: 201 }, OWNER);
+
+    expect(shadow()!.coverId).toBe(201);
+    expect(store.listings.find((l) => l.id === PARENT_ID)!.coverId).toBe(101);
+  });
+
+  it('🔴 addScreenshot appends to the SHADOW — the live listing’s set is untouched', async () => {
+    store.listings.push(listing());
+    seedShot('apls_parent_a', PARENT_ID, 300, 0);
+    seedImage(301);
+
+    await addListingScreenshot({ listingId: PARENT_ID, imageId: 301 }, OWNER);
+
+    // The clone copied the parent's one screenshot; the add landed on top of it.
+    expect(shotsOf(shadow()!.id).map((s) => s.imageId)).toEqual([300, 301]);
+    // The live listing still has exactly its original row, same id, same order.
+    expect(shotsOf(PARENT_ID)).toEqual([
+      { id: 'apls_parent_a', appListingId: PARENT_ID, imageId: 300, order: 0, caption: null },
+    ]);
+  });
+
+  it('reuses an EXISTING shadow — never a second one (the UNIQUE index on revision_of_id holds)', async () => {
+    store.listings.push(listing());
+    store.listings.push(
+      listing({
+        id: 'apl_existing',
+        status: 'draft',
+        revisionOfId: PARENT_ID,
+        appBlockId: null,
+        slug: 'rev-x',
+        iconId: 555,
+      })
+    );
+    seedImage(202);
+
+    await setListingIcon({ listingId: PARENT_ID, imageId: 202 }, OWNER);
+
+    expect(store.listings.filter((l) => l.revisionOfId === PARENT_ID).map((l) => l.id)).toEqual([
+      'apl_existing',
+    ]);
+    expect(db.appListing.create).not.toHaveBeenCalled();
+    // The owner's in-progress edits are preserved — the reused shadow just took the
+    // new icon; nothing re-cloned over it.
+    expect(shadow()!.iconId).toBe(202);
+  });
+
+  it('a shadow itself is edited in place (no revision of a revision)', async () => {
+    store.listings.push(listing());
+    const sh = listing({
+      id: 'apl_shadow',
+      status: 'draft',
+      revisionOfId: PARENT_ID,
+      appBlockId: null,
+      slug: 'rev-x',
+    });
+    store.listings.push(sh);
+    seedImage(203);
+
+    await setListingIcon({ listingId: 'apl_shadow', imageId: 203 }, OWNER);
+
+    expect(store.listings.filter((l) => l.revisionOfId === 'apl_shadow')).toHaveLength(0);
+    expect(sh.iconId).toBe(203);
+  });
+
+  it.each(['draft', 'pending'])(
+    'an in-place editable (%s) listing is edited DIRECTLY — no shadow, unchanged behaviour',
+    async (status) => {
+      store.listings.push(listing({ status }));
+      seedImage(204);
+
+      await setListingIcon({ listingId: PARENT_ID, imageId: 204 }, OWNER);
+
+      expect(shadow()).toBeNull();
+      expect(db.appListing.create).not.toHaveBeenCalled();
+      expect(store.listings.find((l) => l.id === PARENT_ID)!.iconId).toBe(204);
+    }
+  );
+
+  it('a MODERATOR still curates the LIVE listing directly (the documented bypass)', async () => {
+    store.listings.push(listing());
+    seedImage(205, { userId: 7 });
+
+    await setListingIcon({ listingId: PARENT_ID, imageId: 205 }, MOD);
+
+    expect(shadow()).toBeNull();
+    expect(store.listings.find((l) => l.id === PARENT_ID)!.iconId).toBe(205);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 🔴 THE ROW-ID HAZARD. These three procs are keyed on AppListingScreenshot.id.
+// ---------------------------------------------------------------------------
+
+describe('🔴 screenshot ROW-ID re-map — a parent row id must never mutate the live listing', () => {
+  beforeEach(() => {
+    store.listings.push(listing());
+    seedShot('apls_parent_a', PARENT_ID, 300, 0);
+    seedShot('apls_parent_b', PARENT_ID, 301, 1);
+  });
+
+  it('🔴 removeScreenshot with a PARENT row id deletes from the SHADOW, leaving the live rows intact', async () => {
+    const res = await removeListingScreenshot({ screenshotId: 'apls_parent_a' }, OWNER);
+
+    // 🔴 THE ASSERTION. Without the re-map this deletes a screenshot off the listing
+    // that is currently being served, with no moderator review — the exact data-loss
+    // path the security note on `getMyListingForApp.assets` describes.
+    expect(shotsOf(PARENT_ID).map((s) => s.id)).toEqual(['apls_parent_a', 'apls_parent_b']);
+    // It removed the CORRESPONDING row on the revision instead (matched by imageId).
+    const sh = shadow();
+    expect(sh).not.toBeNull();
+    expect(shotsOf(sh!.id).map((s) => s.imageId)).toEqual([301]);
+    // …and it reports the row it actually removed, not the id it was handed.
+    expect(res.removed).not.toBe('apls_parent_a');
+    // Survivors are re-packed to contiguous 0..n-1 on the SHADOW.
+    expect(shotsOf(sh!.id).map((s) => s.order)).toEqual([0]);
+  });
+
+  it('🔴 updateScreenshotCaption with a PARENT row id re-captions the SHADOW’s clone', async () => {
+    await updateListingScreenshotCaption(
+      { screenshotId: 'apls_parent_b', caption: 'staged caption' },
+      OWNER
+    );
+
+    expect(store.shots.find((s) => s.id === 'apls_parent_b')!.caption).toBeNull();
+    const staged = shotsOf(shadow()!.id).find((s) => s.imageId === 301);
+    expect(staged!.caption).toBe('staged caption');
+  });
+
+  it('🔴 reorderScreenshots with PARENT row ids reorders the SHADOW’s clones', async () => {
+    const res = await reorderListingScreenshots(
+      { listingId: PARENT_ID, orderedIds: ['apls_parent_b', 'apls_parent_a'] },
+      OWNER
+    );
+
+    expect(res.reordered).toBe(2);
+    // Live order unchanged.
+    expect(shotsOf(PARENT_ID).map((s) => s.imageId)).toEqual([300, 301]);
+    // Revision order swapped.
+    expect(shotsOf(shadow()!.id).map((s) => s.imageId)).toEqual([301, 300]);
+  });
+
+  it('an UNMAPPABLE row id is REFUSED (fail-closed), and nothing is deleted anywhere', async () => {
+    // A row on the parent whose image the clone can't reproduce: delete the parent row
+    // AFTER the client read it, so the re-map source lookup misses.
+    store.shots = store.shots.filter((s) => s.id !== 'apls_parent_a');
+    store.shots.push({
+      id: 'apls_orphan',
+      appListingId: PARENT_ID,
+      imageId: null,
+      order: 5,
+      caption: null,
+    });
+    // Two null-image rows on the parent → the clone produces two indistinguishable
+    // candidates, so `matchClonedScreenshotRow` refuses rather than guessing.
+    store.shots.push({
+      id: 'apls_orphan2',
+      appListingId: PARENT_ID,
+      imageId: null,
+      order: 6,
+      caption: null,
+    });
+    store.shots.find((s) => s.id === 'apls_orphan')!.order = 6;
+
+    await expect(
+      removeListingScreenshot({ screenshotId: 'apls_orphan' }, OWNER)
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+
+    // The live listing kept every row.
+    expect(shotsOf(PARENT_ID)).toHaveLength(3);
+  });
+
+  it('once the shadow exists, the client’s SHADOW row ids pass straight through (no re-map)', async () => {
+    // Mint it via a first edit, then act on the ids the client now holds.
+    seedImage(400);
+    await setListingIcon({ listingId: PARENT_ID, imageId: 400 }, OWNER);
+    const sh = shadow()!;
+    const target = shotsOf(sh.id)[0];
+
+    const res = await removeListingScreenshot({ screenshotId: target.id }, OWNER);
+
+    expect(res.removed).toBe(target.id);
+    expect(shotsOf(sh.id).map((s) => s.imageId)).toEqual([301]);
+    expect(shotsOf(PARENT_ID)).toHaveLength(2);
+  });
+
+  it('a MODERATOR’s row-id remove still hits the LIVE row (curation bypass preserved)', async () => {
+    await removeListingScreenshot({ screenshotId: 'apls_parent_a' }, MOD);
+
+    expect(shadow()).toBeNull();
+    expect(shotsOf(PARENT_ID).map((s) => s.id)).toEqual(['apls_parent_b']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The pure matcher, in isolation.
+// ---------------------------------------------------------------------------
+
+describe('matchClonedScreenshotRow', () => {
+  const rows = [
+    { id: 's1', imageId: 10, order: 0 },
+    { id: 's2', imageId: 11, order: 1 },
+  ];
+
+  it('matches an exact (imageId, order) pair — the fresh-clone case', () => {
+    expect(matchClonedScreenshotRow({ imageId: 11, order: 1 }, rows)).toBe('s2');
+  });
+
+  it('falls back to a UNIQUE imageId when the target was reordered', () => {
+    expect(matchClonedScreenshotRow({ imageId: 11, order: 5 }, rows)).toBe('s2');
+  });
+
+  it('refuses an AMBIGUOUS match (same image attached twice) rather than guessing', () => {
+    const dupes = [
+      { id: 's1', imageId: 10, order: 0 },
+      { id: 's2', imageId: 10, order: 1 },
+    ];
+    expect(matchClonedScreenshotRow({ imageId: 10, order: 7 }, dupes)).toBeNull();
+  });
+
+  it('refuses when the image is absent from the target', () => {
+    expect(matchClonedScreenshotRow({ imageId: 99, order: 0 }, rows)).toBeNull();
+  });
+
+  it('refuses a null-image row that has no unique (null, order) partner', () => {
+    const nulls = [
+      { id: 's1', imageId: null, order: 0 },
+      { id: 's2', imageId: null, order: 1 },
+    ];
+    expect(matchClonedScreenshotRow({ imageId: null, order: 9 }, nulls)).toBeNull();
+    // …but an exact (null, order) pair is unambiguous and DOES match.
+    expect(matchClonedScreenshotRow({ imageId: null, order: 1 }, nulls)).toBe('s2');
+  });
+});

--- a/src/server/services/blocks/__tests__/app-listing-assets.service.test.ts
+++ b/src/server/services/blocks/__tests__/app-listing-assets.service.test.ts
@@ -42,6 +42,11 @@ const { mockDb, ids } = vi.hoisted(() => ({
       createMany: vi.fn(async (..._a: unknown[]) => ({ count: 0 })),
       update: vi.fn(async (args: { where: unknown; data: unknown }) => args.data),
       delete: vi.fn(async (..._a: unknown[]) => ({})),
+      // The LISTING-SCOPED write forms the row-id-keyed procs now use — a bare
+      // `{ id }` write could land on the live parent after an approve reparents the
+      // shadow's rows (`applyApprovedRevision`).
+      updateMany: vi.fn(async (..._a: unknown[]) => ({ count: 1 })),
+      deleteMany: vi.fn(async (..._a: unknown[]) => ({ count: 1 })),
     },
     $transaction: vi.fn(async (ops: unknown[]) => Promise.all(ops as Promise<unknown>[])),
   },
@@ -73,6 +78,8 @@ function resetDb() {
   mockDb.appListingScreenshot.createMany.mockReset().mockResolvedValue({ count: 0 });
   mockDb.appListingScreenshot.update.mockReset().mockImplementation(async (a: { data: unknown }) => a.data);
   mockDb.appListingScreenshot.delete.mockReset().mockResolvedValue({});
+  mockDb.appListingScreenshot.updateMany.mockReset().mockResolvedValue({ count: 1 });
+  mockDb.appListingScreenshot.deleteMany.mockReset().mockResolvedValue({ count: 1 });
   mockDb.$transaction.mockReset().mockImplementation(async (arg: unknown) => {
     // Interactive (callback) form: run it with mockDb as the tx client (dbRead ===
     // dbWrite === mockDb here). Array form: resolve the batched ops.
@@ -487,15 +494,17 @@ describe('screenshot CRUD', () => {
       owner
     );
     expect(res.reordered).toBe(3);
-    expect(mockDb.appListingScreenshot.update).toHaveBeenCalledTimes(3);
-    const orders = mockDb.appListingScreenshot.update.mock.calls.map(
-      (c) => (c[0] as { where: { id: string }; data: { order: number } })
+    expect(mockDb.appListingScreenshot.updateMany).toHaveBeenCalledTimes(3);
+    const orders = mockDb.appListingScreenshot.updateMany.mock.calls.map(
+      (c) => c[0] as { where: { id: string; appListingId: string }; data: { order: number } }
     );
     expect(orders.map((o) => [o.where.id, o.data.order])).toEqual([
       ['c', 0],
       ['a', 1],
       ['b', 2],
     ]);
+    // 🔴 Every write is scoped to the RESOLVED listing, not the bare row id.
+    expect(orders.every((o) => o.where.appListingId === 'apl_1')).toBe(true);
   });
 
   it('updateScreenshotCaption enforces ownership via the parent listing', async () => {
@@ -506,8 +515,11 @@ describe('screenshot CRUD', () => {
     mockDb.appListing.findUnique.mockResolvedValue({ ...listingRow, status: 'draft', revisionOfId: null });
     const { updateListingScreenshotCaption } = await import('../app-listing-assets.service');
     await updateListingScreenshotCaption({ screenshotId: 'a', caption: 'hi' }, owner);
-    expect(mockDb.appListingScreenshot.update).toHaveBeenCalledWith(
-      expect.objectContaining({ where: { id: 'a' }, data: { caption: 'hi' } })
+    expect(mockDb.appListingScreenshot.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: 'a', appListingId: 'apl_1' },
+        data: { caption: 'hi' },
+      })
     );
     // non-owner rejected
     await expect(
@@ -524,7 +536,9 @@ describe('screenshot CRUD', () => {
     const { removeListingScreenshot } = await import('../app-listing-assets.service');
     const res = await removeListingScreenshot({ screenshotId: 'b' }, owner);
     expect(res.removed).toBe('b');
-    expect(mockDb.appListingScreenshot.delete).toHaveBeenCalledWith({ where: { id: 'b' } });
+    expect(mockDb.appListingScreenshot.deleteMany).toHaveBeenCalledWith({
+      where: { id: 'b', appListingId: 'apl_1' },
+    });
     const orders = mockDb.appListingScreenshot.update.mock.calls.map(
       (c) => c[0] as { where: { id: string }; data: { order: number } }
     );
@@ -563,7 +577,7 @@ describe('screenshot CRUD', () => {
     await expect(removeListingScreenshot({ screenshotId: 'b' }, owner)).rejects.toThrow(
       /live; edit its assets through a revision/
     );
-    expect(mockDb.appListingScreenshot.delete).not.toHaveBeenCalled();
+    expect(mockDb.appListingScreenshot.deleteMany).not.toHaveBeenCalled();
   });
 
   it('removeScreenshot ALLOWS removal on a SHADOW revision draft (revisionOfId set)', async () => {
@@ -582,7 +596,11 @@ describe('screenshot CRUD', () => {
     const { removeListingScreenshot } = await import('../app-listing-assets.service');
     const res = await removeListingScreenshot({ screenshotId: 'b' }, owner);
     expect(res.removed).toBe('b');
-    expect(mockDb.appListingScreenshot.delete).toHaveBeenCalledWith({ where: { id: 'b' } });
+    // Scoped to the SHADOW, so an approve that reparents its rows makes this a no-op
+    // rather than a delete off the live parent.
+    expect(mockDb.appListingScreenshot.deleteMany).toHaveBeenCalledWith({
+      where: { id: 'b', appListingId: 'apl_shadow' },
+    });
   });
 
   it('a MODERATOR bypasses the guard (may curate a live approved listing)', async () => {
@@ -828,7 +846,7 @@ describe('screenshot CRUD', () => {
     await expect(removeListingScreenshot({ screenshotId: 'b' }, otherUser)).rejects.toThrow(
       /do not own/
     );
-    expect(mockDb.appListingScreenshot.delete).not.toHaveBeenCalled();
+    expect(mockDb.appListingScreenshot.deleteMany).not.toHaveBeenCalled();
   });
 
   it('completeness ignores a null-imageId screenshot row (deleted Image → SetNull)', async () => {

--- a/src/server/services/blocks/__tests__/app-listing-assets.service.test.ts
+++ b/src/server/services/blocks/__tests__/app-listing-assets.service.test.ts
@@ -539,13 +539,18 @@ describe('screenshot CRUD', () => {
     expect(mockDb.appListingScreenshot.deleteMany).toHaveBeenCalledWith({
       where: { id: 'b', appListingId: 'apl_1' },
     });
-    const orders = mockDb.appListingScreenshot.update.mock.calls.map(
-      (c) => c[0] as { where: { id: string }; data: { order: number } }
+    const orders = mockDb.appListingScreenshot.updateMany.mock.calls.map(
+      (c) => c[0] as { where: { id: string; appListingId: string }; data: { order: number } }
     );
     expect(orders.map((o) => [o.where.id, o.data.order])).toEqual([
       ['a', 0],
       ['c', 1],
     ]);
+    // 🔴 The re-pack is LISTING-SCOPED like every other screenshot write here. It used
+    // to be a bare `update({ where: { id } })`, which is the one write that could still
+    // land `order` on the LIVE listing if an approve reparented the shadow's rows
+    // between the survivor read and these writes.
+    expect(orders.every((o) => o.where.appListingId === 'apl_1')).toBe(true);
   });
 
   // -------------------------------------------------------------------------

--- a/src/server/services/blocks/__tests__/app-listing-assets.service.test.ts
+++ b/src/server/services/blocks/__tests__/app-listing-assets.service.test.ts
@@ -24,7 +24,10 @@ const { mockDb, ids } = vi.hoisted(() => ({
   mockDb: {
     appListing: {
       findUnique: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
+      // The lazy-mint shadow probe (`beginListingRevision`'s idempotent reuse).
+      findFirst: vi.fn(async (..._a: unknown[]): Promise<unknown> => null),
       findMany: vi.fn(async (..._a: unknown[]): Promise<unknown[]> => []),
+      create: vi.fn(async (args: { data: unknown }) => args.data),
       update: vi.fn(async (args: { data: unknown }) => ({ ...(args as object) })),
     },
     image: {
@@ -57,7 +60,9 @@ const mod = { id: 7, isModerator: true } as never;
 function resetDb() {
   ids.n = 0;
   mockDb.appListing.findUnique.mockReset().mockResolvedValue(null);
+  mockDb.appListing.findFirst.mockReset().mockResolvedValue(null);
   mockDb.appListing.findMany.mockReset().mockResolvedValue([]);
+  mockDb.appListing.create.mockReset().mockImplementation(async (a: { data: unknown }) => a.data);
   mockDb.appListing.update.mockReset().mockResolvedValue({});
   mockDb.image.findUnique.mockReset().mockResolvedValue(null);
   mockDb.image.findMany.mockReset().mockResolvedValue([]);
@@ -495,8 +500,10 @@ describe('screenshot CRUD', () => {
 
   it('updateScreenshotCaption enforces ownership via the parent listing', async () => {
     mockDb.appListingScreenshot.findUnique.mockResolvedValue({
-      id: 'a', appListing: { userId: 42 },
+      id: 'a', appListingId: 'apl_1', appListing: { userId: 42 },
     });
+    // An in-place-editable (draft) listing → no shadow, no row-id re-map.
+    mockDb.appListing.findUnique.mockResolvedValue({ ...listingRow, status: 'draft', revisionOfId: null });
     const { updateListingScreenshotCaption } = await import('../app-listing-assets.service');
     await updateListingScreenshotCaption({ screenshotId: 'a', caption: 'hi' }, owner);
     expect(mockDb.appListingScreenshot.update).toHaveBeenCalledWith(
@@ -512,6 +519,7 @@ describe('screenshot CRUD', () => {
     mockDb.appListingScreenshot.findUnique.mockResolvedValue({
       id: 'b', appListingId: 'apl_1', appListing: { userId: 42 },
     });
+    mockDb.appListing.findUnique.mockResolvedValue({ ...listingRow, status: 'draft', revisionOfId: null });
     mockDb.appListingScreenshot.findMany.mockResolvedValue([{ id: 'a' }, { id: 'c' }]);
     const { removeListingScreenshot } = await import('../app-listing-assets.service');
     const res = await removeListingScreenshot({ screenshotId: 'b' }, owner);
@@ -527,17 +535,30 @@ describe('screenshot CRUD', () => {
   });
 
   // -------------------------------------------------------------------------
-  // 🔴 Owner asset-edit guard (audit #3010): a LIVE approved, non-shadow listing
-  // must NOT have its assets mutated directly by its owner — that would bypass mod
-  // review. Edits route through a shadow revision (revisionOfId != null). Mods bypass.
+  // 🔴 Owner asset-edit guard (audit #3010): an owner's asset mutation must never
+  // land on a LIVE approved, non-shadow listing — that bypasses mod review.
+  //
+  // Under LAZY shadow creation the owner is no longer REFUSED: the mutation mints
+  // (or reuses) the shadow and applies there — see
+  // `app-listing-assets.lazy-revision.service.test.ts`, which asserts end-to-end
+  // against an in-memory store that the parent's rows survive untouched. What
+  // remains here is the guard's role as FAIL-CLOSED defence in depth: it runs on the
+  // RESOLVED target, so if the resolution ever yields the live parent the write is
+  // still refused. Mods bypass (deliberate live curation).
   // -------------------------------------------------------------------------
 
-  it('removeScreenshot REFUSES a live approved (non-shadow) listing for a non-mod owner', async () => {
+  it('🔴 removeScreenshot STILL REFUSES when the resolve yields the LIVE listing (fail-closed)', async () => {
     mockDb.appListingScreenshot.findUnique.mockResolvedValue({
       id: 'b',
       appListingId: 'apl_live',
-      appListing: { userId: 42, status: 'approved', revisionOfId: null },
+      appListing: { userId: 42 },
     });
+    const live = { ...listingRow, id: 'apl_live', status: 'approved', revisionOfId: null };
+    mockDb.appListing.findUnique.mockResolvedValue(live);
+    // FAULT INJECTION: the shadow probe resolves to the PARENT's own id, so the
+    // "shadow" the resolver loads back IS the live listing. The guard is the last
+    // thing between that and a delete off the served listing.
+    mockDb.appListing.findFirst.mockResolvedValue({ id: 'apl_live' });
     const { removeListingScreenshot } = await import('../app-listing-assets.service');
     await expect(removeListingScreenshot({ screenshotId: 'b' }, owner)).rejects.toThrow(
       /live; edit its assets through a revision/
@@ -549,7 +570,13 @@ describe('screenshot CRUD', () => {
     mockDb.appListingScreenshot.findUnique.mockResolvedValue({
       id: 'b',
       appListingId: 'apl_shadow',
-      appListing: { userId: 42, status: 'draft', revisionOfId: 'apl_parent' },
+      appListing: { userId: 42 },
+    });
+    mockDb.appListing.findUnique.mockResolvedValue({
+      ...listingRow,
+      id: 'apl_shadow',
+      status: 'draft',
+      revisionOfId: 'apl_parent',
     });
     mockDb.appListingScreenshot.findMany.mockResolvedValue([]);
     const { removeListingScreenshot } = await import('../app-listing-assets.service');
@@ -562,20 +589,30 @@ describe('screenshot CRUD', () => {
     mockDb.appListingScreenshot.findUnique.mockResolvedValue({
       id: 'b',
       appListingId: 'apl_live',
-      appListing: { userId: 42, status: 'approved', revisionOfId: null },
+      appListing: { userId: 42 },
+    });
+    mockDb.appListing.findUnique.mockResolvedValue({
+      ...listingRow,
+      id: 'apl_live',
+      status: 'approved',
+      revisionOfId: null,
     });
     mockDb.appListingScreenshot.findMany.mockResolvedValue([]);
     const { removeListingScreenshot } = await import('../app-listing-assets.service');
     const res = await removeListingScreenshot({ screenshotId: 'b' }, mod);
     expect(res.removed).toBe('b');
+    // A mod's edit is NOT staged on a shadow — nothing was cloned.
+    expect(mockDb.appListing.create).not.toHaveBeenCalled();
   });
 
-  it('setIcon REFUSES a live approved (non-shadow) listing for a non-mod owner (no write)', async () => {
+  it('🔴 setIcon STILL REFUSES when the resolve yields the LIVE listing (fail-closed)', async () => {
     mockDb.appListing.findUnique.mockResolvedValue({
       ...listingRow,
       status: 'approved',
       revisionOfId: null,
     });
+    // Same fault injection: the "shadow" resolves back to the live parent.
+    mockDb.appListing.findFirst.mockResolvedValue({ id: 'apl_1' });
     const { setListingIcon } = await import('../app-listing-assets.service');
     await expect(setListingIcon({ listingId: 'apl_1', imageId: 9 }, owner)).rejects.toThrow(
       /live; edit its assets through a revision/
@@ -692,7 +729,7 @@ describe('screenshot CRUD', () => {
       expect.objectContaining({ where: { id: 'apl_1' }, data: { iconId: 9 } })
     );
     // A shadow revision would be a NEW AppListing row (revisionOfId set) — never created.
-    expect(mockDb.appListing.create).toBeUndefined();
+    expect(mockDb.appListing.create).not.toHaveBeenCalled();
   });
 
   // A TERMINAL ingestion failure stays BAD_REQUEST, so the client stops polling

--- a/src/server/services/blocks/__tests__/offsite-listing.get-my-listing-for-app.service.test.ts
+++ b/src/server/services/blocks/__tests__/offsite-listing.get-my-listing-for-app.service.test.ts
@@ -9,7 +9,7 @@ import {
  * `getMyListingForApp` — the owner-gated `appBlockId` → `AppListing.id` resolver
  * for the on-site listing-media owner page. Covers the contract branches:
  *   - owner happy-path → `{ appListingId, status, contentRating, hasPendingRevision,
- *     shadowId, assets }`
+ *     shadowId, editTargetId, editBlockedReason, assets }`
  *   - a listing owned by ANOTHER user → NOT_OWNED (router maps → FORBIDDEN)
  *   - no listing row for the app → NOT_FOUND
  * plus the pending-revision flag (a queued shadow-revision request flips it true).
@@ -20,10 +20,15 @@ import {
  * floor (icon+cover attached) could never be met, and "Submit for review" was
  * permanently disabled — the on-site listing-media flow was uncompletable for
  * everyone. The tests below pin that the proc projects the assets the editor's floor
- * check needs, and that they come from the SHADOW revision (the editable target),
- * never the live parent — returning the parent's `AppListingScreenshot` row ids
- * would let a "remove screenshot" delete a row off the LIVE listing, bypassing
- * moderator review.
+ * check needs, and that they come from the SHADOW revision WHEN ONE EXISTS.
+ *
+ * 🔴 REGRESSION GUARD — LAZY shadow creation. This proc is a `.query` and must NOT
+ * WRITE. It used to call `beginListingRevision`, so merely OPENING the media tab
+ * minted a `draft` `AppListing`: measured on prod 2026-07-30, 7 shadows existed and
+ * 7/7 had `updated_at == created_at` (never written since their clone tx), 6 minted
+ * that day by page views alone, three of them 1.5 s apart. 78% of approved onsite
+ * parents carried a shadow representing no edit, and deleting them just refilled on
+ * the next view. The shadow is now minted by the first asset MUTATION.
  *
  * DB is fully mocked — no real Prisma. `getEdgeUrl` + the id generators are stubbed.
  */
@@ -144,6 +149,21 @@ function wireFindUnique(opts: {
   mockWrite.appListing.findUnique.mockImplementation(impl(false));
 }
 
+/**
+ * Wire the SHADOW-existence probe. It reads the PRIMARY (`dbWrite`) on purpose: the
+ * client invalidates this query after every asset mutation, and the FIRST mutation is
+ * what mints the shadow — so the very next call is a read-after-write on a row
+ * inserted milliseconds ago, and missing it on a lagging replica would re-project the
+ * PARENT's rows (and their screenshot row ids) just as the shadow started diverging.
+ */
+function withShadow(shadowId: string | null) {
+  mockWrite.appListing.findFirst.mockImplementation(async (args: unknown) => {
+    const a = args as { where?: { revisionOfId?: string } };
+    if (a.where?.revisionOfId != null) return shadowId ? { id: shadowId } : null;
+    return null;
+  });
+}
+
 /** The listing ids whose `loadListingEditView` read landed on a given pool. */
 function editViewReads(client: { appListing: { findUnique: { mock: { calls: unknown[][] } } } }) {
   return client.appListing.findUnique.mock.calls
@@ -171,8 +191,8 @@ describe('getMyListingForApp', () => {
       owned: ownedRow(),
       viewByListingId: { apl_shadow: editViewRow('apls_shadow') },
     });
-    // An in-flight shadow already exists → beginListingRevision reuses it.
-    mockRead.appListing.findFirst.mockResolvedValue({ id: 'apl_shadow' });
+    // An in-flight shadow already exists → it is reused (never a second one).
+    withShadow('apl_shadow');
 
     const res = await getMyListingForApp({ appBlockId: 'my-block', userId: OWNER });
 
@@ -182,7 +202,12 @@ describe('getMyListingForApp', () => {
       contentRating: 'pg13',
       hasPendingRevision: false,
       shadowId: 'apl_shadow',
+      editTargetId: 'apl_shadow',
+      editBlockedReason: null,
     });
+    // Reuse, not re-create: the UNIQUE index on revision_of_id (one shadow per parent)
+    // is never even challenged.
+    expect(mockWrite.appListing.create).not.toHaveBeenCalled();
     // Resolved by the @unique appBlockId, not by id.
     expect(mockRead.appListing.findUnique).toHaveBeenCalledWith(
       expect.objectContaining({ where: { appBlockId: 'my-block' } })
@@ -195,7 +220,7 @@ describe('getMyListingForApp', () => {
       owned: ownedRow({ contentRating: 'g' }),
       viewByListingId: { apl_shadow: editViewRow('apls_shadow') },
     });
-    mockRead.appListing.findFirst.mockResolvedValue({ id: 'apl_shadow' });
+    withShadow('apl_shadow');
     mockRead.appListingPublishRequest.findFirst.mockResolvedValue({ id: 'alpr_pending' });
 
     const res = await getMyListingForApp({ appBlockId: 'my-block', userId: OWNER });
@@ -242,7 +267,7 @@ describe('getMyListingForApp', () => {
       owned: ownedRow(),
       viewByListingId: { apl_shadow: editViewRow('apls_shadow') },
     });
-    mockRead.appListing.findFirst.mockResolvedValue({ id: 'apl_shadow' });
+    withShadow('apl_shadow');
 
     const res = await getMyListingForApp({ appBlockId: 'my-block', userId: OWNER });
 
@@ -270,7 +295,7 @@ describe('getMyListingForApp', () => {
         apl_shadow: editViewRow('apls_SHADOW', { iconId: 2, icon: { url: 'shadow-icon' } }),
       },
     });
-    mockRead.appListing.findFirst.mockResolvedValue({ id: 'apl_shadow' });
+    withShadow('apl_shadow');
 
     const res = await getMyListingForApp({ appBlockId: 'my-block', userId: OWNER });
 
@@ -291,32 +316,71 @@ describe('getMyListingForApp', () => {
     expect(editViewReads(mockRead)).toEqual([]);
   });
 
-  it('🔴 creates the shadow when none exists yet and reads THAT one (first entry)', async () => {
+  // -------------------------------------------------------------------------
+  // 🔴 LAZY CREATION — the read must NOT mint a shadow. This is a `.query`.
+  // -------------------------------------------------------------------------
+
+  it('🔴 NO shadow yet → projects the PARENT’s assets and creates NOTHING', async () => {
+    wireFindUnique({
+      entry: {
+        id: 'apl_onsite',
+        userId: OWNER,
+        status: 'approved',
+        contentRating: 'pg13',
+        revisionOfId: null,
+      },
+      owned: ownedRow(),
+      viewByListingId: { apl_onsite: editViewRow('apls_PARENT') },
+    });
+    withShadow(null);
+
+    const res = await getMyListingForApp({ appBlockId: 'my-block', userId: OWNER });
+
+    // 🔴 THE GUARD: opening the media tab writes NOTHING. On prod this write-in-a-query
+    // produced 7 shadows, 7/7 never edited (updated_at == created_at), 6 minted in one
+    // day by page views alone — and they refilled the instant anyone looked again.
+    expect(mockWrite.appListing.create).not.toHaveBeenCalled();
+    expect(mockWrite.appListingScreenshot.createMany).not.toHaveBeenCalled();
+    expect(res.shadowId).toBeNull();
+    // …and the editor still sees real assets to edit + a target to mutate: the PARENT.
+    // Safe only because the WRITE side re-keys any parent screenshot row id onto the
+    // shadow it mints (see the app-listing-assets lazy-mint suite).
+    expect(res.editTargetId).toBe('apl_onsite');
+    expect(res.editBlockedReason).toBeNull();
+    expect(res.assets.icon.imageId).toBe(137918008);
+    expect(res.assets.screenshots.map((s) => s.id)).toEqual(['apls_PARENT']);
+    // No shadow ⇒ no read-after-write ⇒ the edit-view read stays on the replica.
+    expect(editViewReads(mockRead)).toEqual(['apl_onsite']);
+    expect(editViewReads(mockWrite)).toEqual([]);
+  });
+
+  it('🔴 the shadow-existence probe reads the PRIMARY (read-after-write on the first edit)', async () => {
     wireFindUnique({
       entry: { id: 'apl_onsite', userId: OWNER, status: 'approved', contentRating: 'pg13' },
       owned: ownedRow(),
       viewByListingId: {
         apl_onsite: editViewRow('apls_PARENT'),
-        // beginListingRevision mints `apl_new_1` (stubbed id gen, first call).
-        apl_new_1: editViewRow('apls_FRESH_SHADOW'),
+        apl_shadow: editViewRow('apls_SHADOW'),
       },
+      // The shadow was INSERTed on the primary microseconds ago (the owner's first
+      // asset mutation) — the replica has not caught up.
+      replicaLagsOn: ['apl_shadow'],
     });
-    // No shadow yet: the read probe and the in-transaction race re-check both miss,
-    // then the post-transaction "winner" re-read returns the row we just created.
+    // The replica does NOT see the shadow; the primary does.
     mockRead.appListing.findFirst.mockResolvedValue(null);
-    mockWrite.appListing.findFirst
-      .mockResolvedValueOnce(null)
-      .mockResolvedValue({ id: 'apl_new_1' });
+    withShadow('apl_shadow');
 
     const res = await getMyListingForApp({ appBlockId: 'my-block', userId: OWNER });
 
-    expect(mockWrite.appListing.create).toHaveBeenCalledWith(
-      expect.objectContaining({
-        data: expect.objectContaining({ revisionOfId: 'apl_onsite', status: 'draft' }),
-      })
+    // Probing the REPLICA here would report "no shadow" and hand the client the LIVE
+    // parent's rows right after the shadow started diverging — the client invalidates
+    // this query after every mutation, so that is the common case, not a rare one.
+    expect(res.shadowId).toBe('apl_shadow');
+    expect(res.editTargetId).toBe('apl_shadow');
+    expect(res.assets.screenshots.map((s) => s.id)).toEqual(['apls_SHADOW']);
+    expect(mockWrite.appListing.findFirst).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { revisionOfId: 'apl_onsite' } })
     );
-    expect(res.shadowId).toBe('apl_new_1');
-    expect(res.assets.screenshots.map((s) => s.id)).toEqual(['apls_FRESH_SHADOW']);
   });
 
   it('a NON-approved listing has no shadow — assets come from the listing itself', async () => {
@@ -329,101 +393,111 @@ describe('getMyListingForApp', () => {
     const res = await getMyListingForApp({ appBlockId: 'my-block', userId: OWNER });
 
     expect(res.shadowId).toBeNull();
-    // No shadow was opened for a draft (beginListingRevision would reject it anyway).
+    // No shadow is ever opened for a draft — it is edited IN PLACE, unchanged.
     expect(mockWrite.appListing.create).not.toHaveBeenCalled();
+    expect(res.editTargetId).toBe('apl_onsite');
+    expect(res.editBlockedReason).toBeNull();
     expect(res.assets.screenshots.map((s) => s.id)).toEqual(['apls_OWN']);
     // Nothing was written, so nothing needs the primary.
     expect(editViewReads(mockRead)).toEqual(['apl_onsite']);
     expect(editViewReads(mockWrite)).toEqual([]);
+    // A draft has no shadow to probe for at all.
+    expect(mockWrite.appListing.findFirst).not.toHaveBeenCalled();
   });
 
-  // -------------------------------------------------------------------------
-  // 🔴 READ-AFTER-WRITE: a SHADOW is INSERTed on the PRIMARY, so ANY read of one
-  // goes back to the primary — the predicate is "the target is a shadow", NOT
-  // "this call created it". `created: false` says only that another caller minted
-  // it, which here is routinely microseconds ago and in a different request (the
-  // editor's own client-side `beginListingRevision`, `getMyListingForEdit`, a second
-  // tab). Reading a shadow off the replica misses under lag → `loadListingEditView`
-  // throws NOT_FOUND → tRPC NOT_FOUND → the editor's query is `retry: false` and it
-  // renders <NotFound/>, discarding the editor and any in-flight upload. The client
-  // invalidates on every asset mutation, so the exposure is per-mutation.
-  // -------------------------------------------------------------------------
-
-  it('🔴 reads a FRESHLY-CREATED shadow from the PRIMARY, not the lagging replica', async () => {
+  it('a PENDING listing is likewise edited in place (unchanged)', async () => {
     wireFindUnique({
-      entry: { id: 'apl_onsite', userId: OWNER, status: 'approved', contentRating: 'pg13' },
-      owned: ownedRow(),
-      viewByListingId: {
-        apl_onsite: editViewRow('apls_PARENT'),
-        apl_new_1: editViewRow('apls_FRESH_SHADOW'),
-      },
-      // The shadow was INSERTed on the primary this instant — the replica misses it.
-      replicaLagsOn: ['apl_new_1'],
+      entry: { id: 'apl_onsite', userId: OWNER, status: 'pending', contentRating: 'g' },
+      viewByListingId: { apl_onsite: editViewRow('apls_OWN') },
     });
-    mockRead.appListing.findFirst.mockResolvedValue(null);
-    mockWrite.appListing.findFirst
-      .mockResolvedValueOnce(null)
-      .mockResolvedValue({ id: 'apl_new_1' });
 
-    // Routed to the replica this REJECTS with NOT_FOUND instead of resolving.
     const res = await getMyListingForApp({ appBlockId: 'my-block', userId: OWNER });
 
-    expect(res.shadowId).toBe('apl_new_1');
-    expect(res.assets.screenshots.map((s) => s.id)).toEqual(['apls_FRESH_SHADOW']);
-    // …and it got there by reading the PRIMARY, never the replica.
-    expect(editViewReads(mockWrite)).toEqual(['apl_new_1']);
-    expect(editViewReads(mockRead)).toEqual([]);
+    expect(res).toMatchObject({
+      status: 'pending',
+      shadowId: null,
+      editTargetId: 'apl_onsite',
+      editBlockedReason: null,
+    });
+    expect(mockWrite.appListing.create).not.toHaveBeenCalled();
   });
 
-  it('🔴 a REUSED (pre-existing) shadow ALSO reads from the PRIMARY — `created` is not a visibility claim', async () => {
+  // -------------------------------------------------------------------------
+  // 🔴 The editability VERDICT. The client used to learn "this listing can't be
+  // revised" from the on-mount `beginListingRevision`'s INVALID_REVISION, which is
+  // the only thing that kept the media editor from mounting against a removed /
+  // rejected listing. Lazy creation removes that call, so the verdict must arrive on
+  // the READ — otherwise the owner gets a fully-functional editor over a dead
+  // listing (or a blank page).
+  // -------------------------------------------------------------------------
+
+  it.each([
+    ['removed', 'this listing has been removed by a moderator and can no longer be edited'],
+    ['rejected', 'this listing was rejected; submit a new listing instead of editing it'],
+  ])('🔴 a %s listing returns an inline editBlockedReason, not a blank page', async (
+    status,
+    expected
+  ) => {
+    wireFindUnique({
+      entry: { id: 'apl_onsite', userId: OWNER, status, contentRating: 'g', revisionOfId: null },
+      viewByListingId: { apl_onsite: editViewRow('apls_OWN') },
+    });
+
+    const res = await getMyListingForApp({ appBlockId: 'my-block', userId: OWNER });
+
+    expect(res.editBlockedReason).toBe(expected);
+    expect(res.status).toBe(status);
+    // It is a VERDICT, not a throw — the page still renders (alert + no editor), which
+    // is what the "don't collapse to NotFound" narrowing exists to preserve.
+    expect(mockWrite.appListing.create).not.toHaveBeenCalled();
+  });
+
+  it('🔴 an internal SHADOW resolved directly is not an editable page', async () => {
+    wireFindUnique({
+      entry: {
+        id: 'apl_shadow',
+        userId: OWNER,
+        status: 'draft',
+        contentRating: 'g',
+        revisionOfId: 'apl_onsite',
+      },
+      viewByListingId: { apl_shadow: editViewRow('apls_SHADOW') },
+    });
+
+    const res = await getMyListingForApp({ appBlockId: 'my-block', userId: OWNER });
+
+    expect(res.editBlockedReason).toBe(
+      'this listing is an internal revision draft and cannot be edited directly'
+    );
+  });
+
+  // -------------------------------------------------------------------------
+  // 🔴 READ-AFTER-WRITE: a SHADOW is INSERTed on the PRIMARY (by the owner's first
+  // asset mutation), so ANY read of one goes back to the primary — the predicate is
+  // "the target is a shadow", not "this call created it". Reading a shadow off the
+  // replica misses under lag → `loadListingEditView` throws NOT_FOUND → tRPC
+  // NOT_FOUND → the editor's query is `retry: false` and it renders <NotFound/>,
+  // discarding the editor and any in-flight upload. The client invalidates on every
+  // asset mutation, so the exposure is per-mutation.
+  // -------------------------------------------------------------------------
+
+  it('🔴 a shadow ALWAYS reads from the PRIMARY, never the replica', async () => {
     wireFindUnique({
       entry: { id: 'apl_onsite', userId: OWNER, status: 'approved', contentRating: 'pg13' },
       owned: ownedRow(),
       viewByListingId: { apl_shadow: editViewRow('apls_shadow') },
     });
-    // An in-flight shadow already exists → `beginListingRevision` returns created:false.
-    mockRead.appListing.findFirst.mockResolvedValue({ id: 'apl_shadow' });
+    withShadow('apl_shadow');
 
     const res = await getMyListingForApp({ appBlockId: 'my-block', userId: OWNER });
 
     expect(res.shadowId).toBe('apl_shadow');
-    // The routing predicate is "the target is a SHADOW", not "I inserted it". `created:
-    // false` only says another caller minted it — which in this flow is routinely
-    // microseconds ago and in a different request (the editor's own client-side
-    // `beginListingRevision`, `getMyListingForEdit`, a second tab). Only shadow reads
-    // move to the primary; the in-place draft/pending read below stays on the replica.
+    // Only shadow reads move to the primary; the in-place draft/pending read (and an
+    // approved parent with no shadow yet) stays on the replica.
     expect(editViewReads(mockWrite)).toEqual(['apl_shadow']);
     expect(editViewReads(mockRead)).toEqual([]);
   });
 
-  it('🔴 a REUSED shadow the replica has NOT caught up on still returns its assets (no NOT_FOUND)', async () => {
-    wireFindUnique({
-      entry: { id: 'apl_onsite', userId: OWNER, status: 'approved', contentRating: 'pg13' },
-      owned: ownedRow(),
-      viewByListingId: {
-        apl_onsite: editViewRow('apls_PARENT'),
-        apl_shadow: editViewRow('apls_SHADOW'),
-      },
-      // The shadow exists on the PRIMARY (a concurrent request minted it microseconds
-      // ago) but has not replicated yet. `beginListingRevision` reports created:FALSE.
-      replicaLagsOn: ['apl_shadow'],
-    });
-    // The idempotency probe reads the replica, misses, and the in-tx re-check on the
-    // primary finds the concurrent winner → returns { created: false }.
-    mockRead.appListing.findFirst.mockResolvedValue(null);
-    mockWrite.appListing.findFirst.mockResolvedValue({ id: 'apl_shadow' });
-
-    // Routed by `created` this reads the lagging replica → NOT_FOUND → the editor
-    // renders <NotFound /> (retry:false) and the in-flight upload is discarded.
-    const res = await getMyListingForApp({ appBlockId: 'my-block', userId: OWNER });
-
-    expect(res.shadowId).toBe('apl_shadow');
-    expect(res.assets.screenshots.map((s) => s.id)).toEqual(['apls_SHADOW']);
-    expect(editViewReads(mockWrite)).toEqual(['apl_shadow']);
-    expect(editViewReads(mockRead)).toEqual([]);
-    // And it never fell back to the live parent's rows.
-    expect(mockWrite.appListing.create).not.toHaveBeenCalled();
-  });
 });
 
 // W13 draft-at-submit — a FIRST-version app has no AppBlock yet, so the owner-media

--- a/src/server/services/blocks/__tests__/offsite-listing.onsite-revision.service.test.ts
+++ b/src/server/services/blocks/__tests__/offsite-listing.onsite-revision.service.test.ts
@@ -415,6 +415,25 @@ describe('mod queue procs — widened to kind IN (onsite, offsite), each row car
     expect(res.items.map((r: { kind: string }) => r.kind)).toEqual(['onsite', 'offsite']);
   });
 
+  it('🔴 every mod queue projects appListing.revisionOfId — the review drift panel’s only handle on the LIVE parent', async () => {
+    // A revision request's `appListingId` IS the shadow id, so `revisionOfId` is the
+    // ONLY way the review surface can reach the listing that is currently being
+    // served. Drop it and `RevisionDriftSection` silently renders nothing: the mod is
+    // back to approving a destructive screenshot replace with no before/after — the
+    // gap this projection exists to close. Guarded on all three queues because the
+    // history tabs render the same modal body.
+    await listPendingOffsiteRequests({});
+    await listApprovedOffsiteRequests({});
+    await listRejectedOffsiteRequests({});
+    const selects = mockRead.appListingPublishRequest.findMany.mock.calls.map(
+      (c) =>
+        (c[0] as { select: { appListing: { select: Record<string, unknown> } } }).select.appListing
+          .select
+    );
+    expect(selects).toHaveLength(3);
+    for (const select of selects) expect(select.revisionOfId).toBe(true);
+  });
+
   it('listApprovedOffsiteRequests + listRejectedOffsiteRequests both widen the kind filter', async () => {
     await listApprovedOffsiteRequests({});
     await listRejectedOffsiteRequests({});

--- a/src/server/services/blocks/app-listing-assets.service.ts
+++ b/src/server/services/blocks/app-listing-assets.service.ts
@@ -459,6 +459,16 @@ function throwScreenshotNoLongerOnRevision(): never {
   });
 }
 
+/**
+ * Aborts the post-delete re-pack transaction WITHOUT surfacing an error.
+ *
+ * The re-pack is the one screenshot write on this path where `count !== 1` must NOT
+ * become a refusal — see the note at its call site in {@link removeListingScreenshot}.
+ * Rolling back needs a throw, but the caller's delete already succeeded, so the throw
+ * is caught and swallowed one frame up. Never escapes this module.
+ */
+class ListingScreenshotRepackAborted extends Error {}
+
 async function remapScreenshotRowIds(args: {
   screenshotIds: string[];
   sourceListingId: string;
@@ -1030,15 +1040,21 @@ export async function reorderListingScreenshots(
   // reparents the shadow's rows onto the live parent between the check above and here,
   // every `updateMany` matches 0 rows — the live listing's ordering is left alone and
   // the owner is told to refresh, instead of the reorder silently landing on it.
-  const results = await dbWrite.$transaction(
-    orderedIds.map((id, index) =>
-      dbWrite.appListingScreenshot.updateMany({
-        where: { id, appListingId: listing.id },
+  //
+  // 🔴 …and the refusal is raised INSIDE an INTERACTIVE transaction so it actually
+  // ROLLS BACK. The array form (`$transaction([...])`) COMMITS before its results are
+  // inspected, so a reparent landing mid-flight under READ COMMITTED left some orders
+  // written AND threw — the worst of both. All-or-nothing is the property this guard
+  // claims, so it has to be the property it has.
+  await dbWrite.$transaction(async (tx) => {
+    for (let index = 0; index < orderedIds.length; index++) {
+      const { count } = await tx.appListingScreenshot.updateMany({
+        where: { id: orderedIds[index], appListingId: listing.id },
         data: { order: index },
-      })
-    )
-  );
-  if (results.some((r) => r.count !== 1)) throwScreenshotNoLongerOnRevision();
+      });
+      if (count !== 1) throwScreenshotNoLongerOnRevision();
+    }
+  });
   return { reordered: orderedIds.length };
 }
 
@@ -1161,20 +1177,45 @@ export async function removeListingScreenshot(
   // (no re-derive: removal/reorder/caption can never RAISE the derived rating)
 
   // Re-pack: contiguous orders over the survivors (ordered by their old order).
-  // Read the survivor set from dbWrite (primary): under replica lag the replica
-  // may still return the just-deleted row → an `update` on it would P2025/500
-  // after the delete already committed.
+  // Read the survivor set from dbWrite (primary): under replica lag the replica may
+  // still return the just-deleted row, and the scoped write below would then match 0
+  // rows on it and abandon the whole re-pack (before the write was scoped, the same
+  // stale row was a P2025/500 after the delete had already committed).
   const remaining = await dbWrite.appListingScreenshot.findMany({
     where: { appListingId: listing.id },
     select: { id: true },
     orderBy: { order: 'asc' },
   });
   if (remaining.length > 0) {
-    await dbWrite.$transaction(
-      remaining.map((s, index) =>
-        dbWrite.appListingScreenshot.update({ where: { id: s.id }, data: { order: index } })
-      )
-    );
+    // 🔴 LISTING-SCOPED, like every other screenshot write on this path. The unscoped
+    // `update({ where: { id } })` this replaces was the last hole in the invariant:
+    // an approve reparenting the shadow's rows onto the live parent between the
+    // `findMany` above and these writes would have written `order` onto rows that now
+    // belong to the LIVE served listing.
+    //
+    // 🔴 `count !== 1` here is a deliberate NO-OP, NOT the refusal the other three
+    // writes raise — this is the one place where refusing is the worse answer. The
+    // delete has ALREADY committed and is exactly what the owner asked for; a reparent
+    // landing afterwards is a moderator's approve, not user error, so reporting a
+    // failure would name a removal that in fact succeeded. And there is no state left
+    // to protect: the re-pack only densifies `order`, and the reparented rows keep the
+    // orders `applyApprovedRevision` moved them with. The abort is still raised INSIDE
+    // the interactive transaction so the rows re-packed before the race are rolled
+    // back — abandoning it half-done would leave exactly the `order` gaps the re-pack
+    // exists to remove.
+    await dbWrite
+      .$transaction(async (tx) => {
+        for (let index = 0; index < remaining.length; index++) {
+          const { count } = await tx.appListingScreenshot.updateMany({
+            where: { id: remaining[index].id, appListingId: listing.id },
+            data: { order: index },
+          });
+          if (count !== 1) throw new ListingScreenshotRepackAborted();
+        }
+      })
+      .catch((e) => {
+        if (!(e instanceof ListingScreenshotRepackAborted)) throw e;
+      });
   }
   return { removed: screenshotId };
 }

--- a/src/server/services/blocks/app-listing-assets.service.ts
+++ b/src/server/services/blocks/app-listing-assets.service.ts
@@ -312,8 +312,18 @@ export { nsfwLevelFromContentRating };
  * Load a listing and assert the caller owns it (or is a moderator). Throws
  * NOT_FOUND for a missing listing, FORBIDDEN for a non-owner non-mod.
  */
-async function loadOwnedListing(listingId: string, user: SessionUser): Promise<OwnedListing> {
-  const listing = await dbRead.appListing.findUnique({
+async function loadOwnedListing(
+  listingId: string,
+  user: SessionUser,
+  /**
+   * Pool override. Defaults to the replica. Pass `dbWrite` when the row may have
+   * been INSERTed milliseconds ago — i.e. a shadow this request just minted
+   * ({@link resolveOwnerAssetEditTarget}); the replica would miss it and the load
+   * would 404 the owner's very first edit.
+   */
+  db: typeof dbRead = dbRead
+): Promise<OwnedListing> {
+  const listing = await db.appListing.findUnique({
     where: { id: listingId },
     select: {
       id: true,
@@ -334,6 +344,126 @@ async function loadOwnedListing(listingId: string, user: SessionUser): Promise<O
     throw new TRPCError({ code: 'FORBIDDEN', message: 'You do not own this listing' });
   }
   return listing;
+}
+
+// ---------------------------------------------------------------------------
+// LAZY shadow-revision minting — "a shadow exists once you EDIT, not once you LOOK".
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve the EFFECTIVE target of an OWNER asset mutation, minting the shadow
+ * revision on the FIRST edit.
+ *
+ * `getMyListingForApp` no longer creates a shadow just to render the media editor
+ * (a `.query` that writes; measured on prod as 78% of approved onsite parents
+ * carrying a never-edited shadow, self-refilling on every page view). So the id the
+ * client hands an asset proc is the LIVE PARENT until the first mutation. This is
+ * where that mutation becomes a revision:
+ *
+ *   - moderator → returns the listing UNCHANGED. Mods deliberately curate the live
+ *     row ({@link assertOwnerAssetEditable}'s bypass + {@link
+ *     reDeriveContentRatingForModLiveEdit}); auto-staging their edit on a shadow
+ *     would silently change what "mod edits a live listing" means.
+ *   - not `approved`, or already a shadow → UNCHANGED (edited in place, as before).
+ *   - owner + `approved` + not a shadow → `beginListingRevision` (idempotent: reuses
+ *     an in-flight shadow) and the shadow becomes the target.
+ *
+ * Read back from the PRIMARY — the shadow may have been INSERTed microseconds ago.
+ *
+ * 🔴 Callers MUST still run {@link assertOwnerAssetEditable} on the RESOLVED target.
+ * That is the defence-in-depth that makes this fail CLOSED: if this ever returns the
+ * live parent for an owner (a bug here, a `beginListingRevision` that resolved to the
+ * wrong row), the guard throws BAD_REQUEST instead of mutating the served listing.
+ */
+async function resolveOwnerAssetEditTarget(
+  listing: OwnedListing,
+  user: SessionUser
+): Promise<OwnedListing> {
+  if (user.isModerator) return listing;
+  if (listing.status !== 'approved' || listing.revisionOfId != null) return listing;
+  // Dynamic import: `offsite-listing.service` imports THIS module (the floor gates),
+  // so a static import would close a cycle at module-eval time.
+  const { beginListingRevision } = await import('~/server/services/blocks/offsite-listing.service');
+  const { shadowId } = await beginListingRevision({ listingId: listing.id, userId: user.id });
+  return loadOwnedListing(shadowId, user, dbWrite);
+}
+
+/**
+ * Match ONE screenshot row against the clone-set of another listing — the pure core
+ * of the parent-row-id re-map.
+ *
+ * 🔴 WHY THIS EXISTS. `removeListingScreenshot` / `updateListingScreenshotCaption` /
+ * `reorderListingScreenshots` take `AppListingScreenshot` ROW ids. Before a shadow
+ * exists the ids the client holds are the LIVE PARENT's rows — so a "remove
+ * screenshot" issued against them would delete a row from the listing that is
+ * currently being served, bypassing moderator review entirely. That is the exact
+ * data-loss hazard the 🔴 SECURITY note on `GetMyListingForAppResult.assets` warns
+ * about. Under lazy creation the write path therefore re-keys the row id onto the
+ * freshly-cloned shadow row before mutating anything.
+ *
+ * `beginListingRevision` clones each parent screenshot with the SAME `imageId`,
+ * `order` and `caption`, so immediately after a mint the mapping is exact. Matching
+ * is deliberately conservative and FAILS CLOSED (`null` → the caller throws and asks
+ * the client to refresh) rather than guessing:
+ *
+ *   1. exactly one candidate with the same `(imageId, order)` — the fresh-clone case;
+ *   2. else exactly one candidate with the same non-null `imageId` — survives a
+ *      reorder on the shadow (a second tab) that moved the row;
+ *   3. else `null` — ambiguous (the same image attached twice) or gone.
+ *
+ * Re-keying on `imageId` rather than changing the procs' signatures keeps the wire
+ * contract (and the `civitai` CLI's `AppBlocksSubmit`-scoped calls) unchanged.
+ */
+export function matchClonedScreenshotRow(
+  source: { imageId: number | null; order: number },
+  candidates: { id: string; imageId: number | null; order: number }[]
+): string | null {
+  const exact = candidates.filter(
+    (c) => c.imageId === source.imageId && c.order === source.order
+  );
+  if (exact.length === 1) return exact[0].id;
+  if (source.imageId != null) {
+    const byImage = candidates.filter((c) => c.imageId === source.imageId);
+    if (byImage.length === 1) return byImage[0].id;
+  }
+  return null;
+}
+
+/**
+ * Re-map screenshot ROW ids from `sourceListingId` onto `targetListingId` (the shadow
+ * that {@link resolveOwnerAssetEditTarget} just minted). Reads BOTH sides from the
+ * PRIMARY — the target's rows were created in the mint transaction. Throws
+ * BAD_REQUEST if any id can't be matched, so an unmappable request is refused rather
+ * than applied to the wrong row (and never to the parent's).
+ */
+async function remapScreenshotRowIds(args: {
+  screenshotIds: string[];
+  sourceListingId: string;
+  targetListingId: string;
+}): Promise<string[]> {
+  const [sourceRows, targetRows] = await Promise.all([
+    dbWrite.appListingScreenshot.findMany({
+      where: { appListingId: args.sourceListingId },
+      select: { id: true, imageId: true, order: true },
+    }),
+    dbWrite.appListingScreenshot.findMany({
+      where: { appListingId: args.targetListingId },
+      select: { id: true, imageId: true, order: true },
+    }),
+  ]);
+  const sourceById = new Map(sourceRows.map((r) => [r.id, r]));
+  return args.screenshotIds.map((id) => {
+    const source = sourceById.get(id);
+    const mapped = source ? matchClonedScreenshotRow(source, targetRows) : null;
+    if (!mapped) {
+      throw new TRPCError({
+        code: 'BAD_REQUEST',
+        message:
+          'This screenshot is no longer available on your revision. Refresh the page and try again.',
+      });
+    }
+    return mapped;
+  });
 }
 
 /**
@@ -734,13 +864,14 @@ export async function setListingIcon(
   args: { listingId: string; imageId: number },
   user: SessionUser
 ): Promise<SetListingIconResult> {
-  const listing = await loadOwnedListing(args.listingId, user);
+  // LAZY MINT: an owner's first edit of a live listing opens the shadow revision here.
+  const listing = await resolveOwnerAssetEditTarget(await loadOwnedListing(args.listingId, user), user);
   assertOwnerAssetEditable(listing, user);
   const validated = await loadValidatedImage(args.imageId, 'icon', user, { allowPending: true });
   if (validated.pending) return { status: 'pending' };
   await dbWrite.$transaction(async (tx) => {
     await tx.appListing.update({
-      where: { id: args.listingId },
+      where: { id: listing.id },
       data: { iconId: validated.imageId },
     });
     await reDeriveContentRatingForModLiveEdit(tx, listing, user);
@@ -752,13 +883,14 @@ export async function setListingCover(
   args: { listingId: string; imageId: number },
   user: SessionUser
 ): Promise<SetListingCoverResult> {
-  const listing = await loadOwnedListing(args.listingId, user);
+  // LAZY MINT: an owner's first edit of a live listing opens the shadow revision here.
+  const listing = await resolveOwnerAssetEditTarget(await loadOwnedListing(args.listingId, user), user);
   assertOwnerAssetEditable(listing, user);
   const validated = await loadValidatedImage(args.imageId, 'cover', user, { allowPending: true });
   if (validated.pending) return { status: 'pending' };
   await dbWrite.$transaction(async (tx) => {
     await tx.appListing.update({
-      where: { id: args.listingId },
+      where: { id: listing.id },
       data: { coverId: validated.imageId },
     });
     await reDeriveContentRatingForModLiveEdit(tx, listing, user);
@@ -770,7 +902,8 @@ export async function addListingScreenshot(
   args: { listingId: string; imageId: number; caption?: string | null },
   user: SessionUser
 ): Promise<AddListingScreenshotResult> {
-  const listing = await loadOwnedListing(args.listingId, user);
+  // LAZY MINT: an owner's first edit of a live listing opens the shadow revision here.
+  const listing = await resolveOwnerAssetEditTarget(await loadOwnedListing(args.listingId, user), user);
   assertOwnerAssetEditable(listing, user);
   const validated = await loadValidatedImage(args.imageId, 'screenshot', user, {
     allowPending: true,
@@ -784,13 +917,13 @@ export async function addListingScreenshot(
   // replica lag two concurrent adds could both pass `count < 8` (a 9th row) or
   // compute the same `order`.
   const existing = await dbWrite.appListingScreenshot.findMany({
-    where: { appListingId: args.listingId },
+    where: { appListingId: listing.id },
     select: { order: true },
     orderBy: { order: 'desc' },
     take: 1,
   });
   const count = await dbWrite.appListingScreenshot.count({
-    where: { appListingId: args.listingId },
+    where: { appListingId: listing.id },
   });
   if (count >= MAX_LISTING_SCREENSHOTS) {
     throw new TRPCError({
@@ -804,7 +937,7 @@ export async function addListingScreenshot(
     await tx.appListingScreenshot.create({
       data: {
         id,
-        appListingId: args.listingId,
+        appListingId: listing.id,
         imageId,
         order: nextOrder,
         caption: args.caption ?? null,
@@ -824,20 +957,34 @@ export async function reorderListingScreenshots(
   args: { listingId: string; orderedIds: string[] },
   user: SessionUser
 ): Promise<{ reordered: number }> {
-  assertOwnerAssetEditable(await loadOwnedListing(args.listingId, user), user);
+  // LAZY MINT: an owner's first edit of a live listing opens the shadow revision here.
+  const listing = await resolveOwnerAssetEditTarget(await loadOwnedListing(args.listingId, user), user);
+  assertOwnerAssetEditable(listing, user);
+  // 🔴 `orderedIds` are PARENT row ids whenever the mint above just happened. Re-key
+  // them onto the shadow's clones BEFORE the permutation check — otherwise the check
+  // fails (parent ids aren't in the shadow's set) or, worse without the retarget,
+  // reorders the LIVE listing's rows.
+  const orderedIds =
+    listing.id === args.listingId
+      ? args.orderedIds
+      : await remapScreenshotRowIds({
+          screenshotIds: args.orderedIds,
+          sourceListingId: args.listingId,
+          targetListingId: listing.id,
+        });
   // Read the current set from dbWrite (primary): under replica lag the reorder
   // could target a just-deleted id (P2025 → 500 after the delete committed) or
   // miss a just-added row.
   const current = await dbWrite.appListingScreenshot.findMany({
-    where: { appListingId: args.listingId },
+    where: { appListingId: listing.id },
     select: { id: true },
   });
   const currentIds = new Set(current.map((s) => s.id));
-  const nextIds = new Set(args.orderedIds);
+  const nextIds = new Set(orderedIds);
   const samePermutation =
     currentIds.size === nextIds.size &&
-    args.orderedIds.length === current.length &&
-    args.orderedIds.every((id) => currentIds.has(id));
+    orderedIds.length === current.length &&
+    orderedIds.every((id) => currentIds.has(id));
   if (!samePermutation) {
     throw new TRPCError({
       code: 'BAD_REQUEST',
@@ -845,34 +992,62 @@ export async function reorderListingScreenshots(
     });
   }
   await dbWrite.$transaction(
-    args.orderedIds.map((id, index) =>
+    orderedIds.map((id, index) =>
       dbWrite.appListingScreenshot.update({ where: { id }, data: { order: index } })
     )
   );
-  return { reordered: args.orderedIds.length };
+  return { reordered: orderedIds.length };
+}
+
+/**
+ * Resolve a ROW-ID-keyed screenshot mutation onto its EFFECTIVE row.
+ *
+ * 🔴 THE data-loss guard for lazy shadow creation. `screenshotId` is an
+ * `AppListingScreenshot` row id, and before a shadow exists the client holds the
+ * LIVE PARENT's row ids — so this is the one place where a stale id could delete /
+ * reorder / re-caption a row off the listing that is currently being served, with no
+ * moderator review. It loads the row, enforces ownership, mints the shadow via
+ * {@link resolveOwnerAssetEditTarget}, and RE-KEYS the row id onto the shadow's clone
+ * ({@link matchClonedScreenshotRow}) — failing closed if it can't.
+ *
+ * Returns the row id + listing id the caller must use. Callers MUST run
+ * {@link assertOwnerAssetEditable} on the returned `listing` (defence in depth: it
+ * throws if the resolution ever yields the live parent for an owner).
+ */
+async function resolveOwnerScreenshotTarget(
+  screenshotId: string,
+  user: SessionUser
+): Promise<{ screenshotId: string; listing: OwnedListing }> {
+  const shot = await dbRead.appListingScreenshot.findUnique({
+    where: { id: screenshotId },
+    select: { id: true, appListingId: true, appListing: { select: { userId: true } } },
+  });
+  if (!shot) throw new TRPCError({ code: 'NOT_FOUND', message: 'Screenshot not found' });
+  if (shot.appListing.userId !== user.id && !user.isModerator) {
+    throw new TRPCError({ code: 'FORBIDDEN', message: 'You do not own this listing' });
+  }
+  const sourceListing = await loadOwnedListing(shot.appListingId, user);
+  const listing = await resolveOwnerAssetEditTarget(sourceListing, user);
+  if (listing.id === shot.appListingId) return { screenshotId, listing };
+  const [mapped] = await remapScreenshotRowIds({
+    screenshotIds: [screenshotId],
+    sourceListingId: shot.appListingId,
+    targetListingId: listing.id,
+  });
+  return { screenshotId: mapped, listing };
 }
 
 export async function updateListingScreenshotCaption(
   args: { screenshotId: string; caption?: string | null },
   user: SessionUser
 ): Promise<{ id: string }> {
-  const shot = await dbRead.appListingScreenshot.findUnique({
-    where: { id: args.screenshotId },
-    select: {
-      id: true,
-      appListing: { select: { userId: true, status: true, revisionOfId: true } },
-    },
-  });
-  if (!shot) throw new TRPCError({ code: 'NOT_FOUND', message: 'Screenshot not found' });
-  if (shot.appListing.userId !== user.id && !user.isModerator) {
-    throw new TRPCError({ code: 'FORBIDDEN', message: 'You do not own this listing' });
-  }
-  assertOwnerAssetEditable(shot.appListing, user);
+  const { screenshotId, listing } = await resolveOwnerScreenshotTarget(args.screenshotId, user);
+  assertOwnerAssetEditable(listing, user);
   await dbWrite.appListingScreenshot.update({
-    where: { id: args.screenshotId },
+    where: { id: screenshotId },
     data: { caption: args.caption ?? null },
   });
-  return { id: args.screenshotId };
+  return { id: screenshotId };
 }
 
 /**
@@ -883,22 +1058,15 @@ export async function removeListingScreenshot(
   args: { screenshotId: string },
   user: SessionUser
 ): Promise<{ removed: string }> {
-  const shot = await dbRead.appListingScreenshot.findUnique({
-    where: { id: args.screenshotId },
-    select: {
-      id: true,
-      appListingId: true,
-      appListing: { select: { userId: true, status: true, revisionOfId: true } },
-    },
-  });
-  if (!shot) throw new TRPCError({ code: 'NOT_FOUND', message: 'Screenshot not found' });
-  if (shot.appListing.userId !== user.id && !user.isModerator) {
-    throw new TRPCError({ code: 'FORBIDDEN', message: 'You do not own this listing' });
-  }
+  // 🔴 Re-key a PARENT row id onto the (lazily minted) shadow's clone BEFORE deleting
+  // anything — a delete against a parent row id would destroy a screenshot off the
+  // LIVE served listing with no moderator review. Fails closed if unmappable.
+  const { screenshotId, listing } = await resolveOwnerScreenshotTarget(args.screenshotId, user);
   // 🔴 Never delete a screenshot from a LIVE approved listing directly (bypasses
-  // review) — edits go through a shadow revision. Mods bypass (curation).
-  assertOwnerAssetEditable(shot.appListing, user);
-  await dbWrite.appListingScreenshot.delete({ where: { id: args.screenshotId } });
+  // review) — edits go through a shadow revision. Mods bypass (curation). Evaluated
+  // on the RESOLVED target, so a re-map that failed to leave the parent throws here.
+  assertOwnerAssetEditable(listing, user);
+  await dbWrite.appListingScreenshot.delete({ where: { id: screenshotId } });
   // (no re-derive: removal/reorder/caption can never RAISE the derived rating)
 
   // Re-pack: contiguous orders over the survivors (ordered by their old order).
@@ -906,7 +1074,7 @@ export async function removeListingScreenshot(
   // may still return the just-deleted row → an `update` on it would P2025/500
   // after the delete already committed.
   const remaining = await dbWrite.appListingScreenshot.findMany({
-    where: { appListingId: shot.appListingId },
+    where: { appListingId: listing.id },
     select: { id: true },
     orderBy: { order: 'asc' },
   });
@@ -917,7 +1085,7 @@ export async function removeListingScreenshot(
       )
     );
   }
-  return { removed: args.screenshotId };
+  return { removed: screenshotId };
 }
 
 export type ListingAssetsView = {

--- a/src/server/services/blocks/app-listing-assets.service.ts
+++ b/src/server/services/blocks/app-listing-assets.service.ts
@@ -418,9 +418,7 @@ export function matchClonedScreenshotRow(
   source: { imageId: number | null; order: number },
   candidates: { id: string; imageId: number | null; order: number }[]
 ): string | null {
-  const exact = candidates.filter(
-    (c) => c.imageId === source.imageId && c.order === source.order
-  );
+  const exact = candidates.filter((c) => c.imageId === source.imageId && c.order === source.order);
   if (exact.length === 1) return exact[0].id;
   if (source.imageId != null) {
     const byImage = candidates.filter((c) => c.imageId === source.imageId);
@@ -436,6 +434,31 @@ export function matchClonedScreenshotRow(
  * BAD_REQUEST if any id can't be matched, so an unmappable request is refused rather
  * than applied to the wrong row (and never to the parent's).
  */
+/**
+ * 🔴 A row-id-keyed write matched NOTHING under the listing it was RESOLVED against.
+ *
+ * Every screenshot write below is scoped `{ id, appListingId: <resolved listing> }`
+ * rather than `{ id }`, because the resolved id can stop belonging to that listing
+ * between the resolve and the write: `applyApprovedRevision` REPARENTS the shadow's
+ * rows onto the live parent (`updateMany({ where: { appListingId: shadowId } }, {
+ * appListingId: parentId })`). A moderator approving in that window would turn a
+ * resolved SHADOW row id into a PARENT row id — and an unscoped
+ * `delete({ where: { id } })` would then delete a screenshot off the LIVE served
+ * listing, which is the exact hazard the whole re-map exists to prevent. Scoping the
+ * write makes it structurally impossible: the write matches 0 rows and this throws,
+ * instead of hitting the parent.
+ *
+ * Same client-facing copy as the fail-closed re-map — from the owner's side it is the
+ * same situation (their revision moved under them; refresh and retry).
+ */
+function throwScreenshotNoLongerOnRevision(): never {
+  throw new TRPCError({
+    code: 'BAD_REQUEST',
+    message:
+      'This screenshot is no longer available on your revision. Refresh the page and try again.',
+  });
+}
+
 async function remapScreenshotRowIds(args: {
   screenshotIds: string[];
   sourceListingId: string;
@@ -865,7 +888,10 @@ export async function setListingIcon(
   user: SessionUser
 ): Promise<SetListingIconResult> {
   // LAZY MINT: an owner's first edit of a live listing opens the shadow revision here.
-  const listing = await resolveOwnerAssetEditTarget(await loadOwnedListing(args.listingId, user), user);
+  const listing = await resolveOwnerAssetEditTarget(
+    await loadOwnedListing(args.listingId, user),
+    user
+  );
   assertOwnerAssetEditable(listing, user);
   const validated = await loadValidatedImage(args.imageId, 'icon', user, { allowPending: true });
   if (validated.pending) return { status: 'pending' };
@@ -884,7 +910,10 @@ export async function setListingCover(
   user: SessionUser
 ): Promise<SetListingCoverResult> {
   // LAZY MINT: an owner's first edit of a live listing opens the shadow revision here.
-  const listing = await resolveOwnerAssetEditTarget(await loadOwnedListing(args.listingId, user), user);
+  const listing = await resolveOwnerAssetEditTarget(
+    await loadOwnedListing(args.listingId, user),
+    user
+  );
   assertOwnerAssetEditable(listing, user);
   const validated = await loadValidatedImage(args.imageId, 'cover', user, { allowPending: true });
   if (validated.pending) return { status: 'pending' };
@@ -903,7 +932,10 @@ export async function addListingScreenshot(
   user: SessionUser
 ): Promise<AddListingScreenshotResult> {
   // LAZY MINT: an owner's first edit of a live listing opens the shadow revision here.
-  const listing = await resolveOwnerAssetEditTarget(await loadOwnedListing(args.listingId, user), user);
+  const listing = await resolveOwnerAssetEditTarget(
+    await loadOwnedListing(args.listingId, user),
+    user
+  );
   assertOwnerAssetEditable(listing, user);
   const validated = await loadValidatedImage(args.imageId, 'screenshot', user, {
     allowPending: true,
@@ -958,7 +990,10 @@ export async function reorderListingScreenshots(
   user: SessionUser
 ): Promise<{ reordered: number }> {
   // LAZY MINT: an owner's first edit of a live listing opens the shadow revision here.
-  const listing = await resolveOwnerAssetEditTarget(await loadOwnedListing(args.listingId, user), user);
+  const listing = await resolveOwnerAssetEditTarget(
+    await loadOwnedListing(args.listingId, user),
+    user
+  );
   assertOwnerAssetEditable(listing, user);
   // 🔴 `orderedIds` are PARENT row ids whenever the mint above just happened. Re-key
   // them onto the shadow's clones BEFORE the permutation check — otherwise the check
@@ -991,11 +1026,19 @@ export async function reorderListingScreenshots(
       message: 'orderedIds must be exactly the listing’s current screenshot ids',
     });
   }
-  await dbWrite.$transaction(
+  // 🔴 LISTING-SCOPED writes (see `throwScreenshotNoLongerOnRevision`): if an approve
+  // reparents the shadow's rows onto the live parent between the check above and here,
+  // every `updateMany` matches 0 rows — the live listing's ordering is left alone and
+  // the owner is told to refresh, instead of the reorder silently landing on it.
+  const results = await dbWrite.$transaction(
     orderedIds.map((id, index) =>
-      dbWrite.appListingScreenshot.update({ where: { id }, data: { order: index } })
+      dbWrite.appListingScreenshot.updateMany({
+        where: { id, appListingId: listing.id },
+        data: { order: index },
+      })
     )
   );
+  if (results.some((r) => r.count !== 1)) throwScreenshotNoLongerOnRevision();
   return { reordered: orderedIds.length };
 }
 
@@ -1018,15 +1061,31 @@ async function resolveOwnerScreenshotTarget(
   screenshotId: string,
   user: SessionUser
 ): Promise<{ screenshotId: string; listing: OwnedListing }> {
-  const shot = await dbRead.appListingScreenshot.findUnique({
-    where: { id: screenshotId },
-    select: { id: true, appListingId: true, appListing: { select: { userId: true } } },
-  });
+  const select = {
+    id: true,
+    appListingId: true,
+    appListing: { select: { userId: true } },
+  } as const;
+  // 🔴 READ-AFTER-WRITE. The replica answers first, but a MISS off the replica is NOT
+  // authoritative here: once the first mutation mints the shadow, `getMyListingForApp`
+  // re-projects the SHADOW's row ids from the PRIMARY, so the very next call arrives
+  // holding ids for rows INSERTed milliseconds ago. Trusting a lagging replica turns
+  // the owner's second edit into a spurious `NOT_FOUND: Screenshot not found` — the
+  // same class of bug #3476 fixed for `loadListingEditView`, whose window this PR
+  // widened by moving the mint onto the write path. A hit on the replica means the row
+  // is old, and its listing (created in the SAME clone transaction) is old too, so the
+  // pool that answered is also the right pool for the listing load.
+  let db: typeof dbRead = dbRead;
+  let shot = await dbRead.appListingScreenshot.findUnique({ where: { id: screenshotId }, select });
+  if (!shot) {
+    db = dbWrite;
+    shot = await dbWrite.appListingScreenshot.findUnique({ where: { id: screenshotId }, select });
+  }
   if (!shot) throw new TRPCError({ code: 'NOT_FOUND', message: 'Screenshot not found' });
   if (shot.appListing.userId !== user.id && !user.isModerator) {
     throw new TRPCError({ code: 'FORBIDDEN', message: 'You do not own this listing' });
   }
-  const sourceListing = await loadOwnedListing(shot.appListingId, user);
+  const sourceListing = await loadOwnedListing(shot.appListingId, user, db);
   const listing = await resolveOwnerAssetEditTarget(sourceListing, user);
   if (listing.id === shot.appListingId) return { screenshotId, listing };
   const [mapped] = await remapScreenshotRowIds({
@@ -1037,22 +1096,47 @@ async function resolveOwnerScreenshotTarget(
   return { screenshotId: mapped, listing };
 }
 
+/**
+ * Set/clear a screenshot's caption.
+ *
+ * 🔴 RETURN-SHAPE NOTE — `id` is the row that was actually written, which is NOT
+ * necessarily `args.screenshotId`. When this call is the owner's FIRST edit of a live
+ * approved listing it mints the shadow revision and re-keys the caller's PARENT row id
+ * onto the shadow's clone ({@link resolveOwnerScreenshotTarget}); the returned id is
+ * that clone's. Reporting the caller's own id back would name a row this call did not
+ * touch — on the live listing — so the resolved id is the honest answer. Any caller
+ * that echoes or compares it (the `civitai` CLI is wire-reachable here under
+ * `AppBlocksSubmit`) must treat it as the NEW id, not a round-trip of its input. The
+ * INPUT schema is unchanged, so no released client breaks.
+ */
 export async function updateListingScreenshotCaption(
   args: { screenshotId: string; caption?: string | null },
   user: SessionUser
 ): Promise<{ id: string }> {
   const { screenshotId, listing } = await resolveOwnerScreenshotTarget(args.screenshotId, user);
   assertOwnerAssetEditable(listing, user);
-  await dbWrite.appListingScreenshot.update({
-    where: { id: screenshotId },
+  // 🔴 LISTING-SCOPED write — see `throwScreenshotNoLongerOnRevision`.
+  const { count } = await dbWrite.appListingScreenshot.updateMany({
+    where: { id: screenshotId, appListingId: listing.id },
     data: { caption: args.caption ?? null },
   });
+  if (count !== 1) throwScreenshotNoLongerOnRevision();
+  // NB: `id` is the RESOLVED row id, which differs from `args.screenshotId` whenever
+  // this call minted the shadow (the parent row id was re-keyed onto its clone).
   return { id: screenshotId };
 }
 
 /**
  * Remove a screenshot, then RE-PACK the remaining orders to a contiguous 0..n-1
  * so no gaps accumulate (the read path can rely on dense ordering).
+ *
+ * 🔴 RETURN-SHAPE NOTE — `removed` is the row that was actually deleted, which is NOT
+ * necessarily `args.screenshotId`: a first edit of a live listing mints the shadow and
+ * re-keys the caller's PARENT row id onto the clone, and it is the CLONE that is
+ * deleted (deleting the parent's row is the data-loss hazard this whole path exists to
+ * prevent). Echoing the caller's id back would therefore report a deletion that did not
+ * happen. Same wire-contract note as {@link updateListingScreenshotCaption}: input
+ * schema unchanged, only the returned id can differ from the one passed in.
  */
 export async function removeListingScreenshot(
   args: { screenshotId: string },
@@ -1066,7 +1150,14 @@ export async function removeListingScreenshot(
   // review) — edits go through a shadow revision. Mods bypass (curation). Evaluated
   // on the RESOLVED target, so a re-map that failed to leave the parent throws here.
   assertOwnerAssetEditable(listing, user);
-  await dbWrite.appListingScreenshot.delete({ where: { id: screenshotId } });
+  // 🔴 LISTING-SCOPED delete — see `throwScreenshotNoLongerOnRevision`. This is the
+  // one write where the reparent race is destructive: an unscoped
+  // `delete({ where: { id } })` would remove the row from the LIVE listing it had just
+  // been moved onto.
+  const { count } = await dbWrite.appListingScreenshot.deleteMany({
+    where: { id: screenshotId, appListingId: listing.id },
+  });
+  if (count !== 1) throwScreenshotNoLongerOnRevision();
   // (no re-derive: removal/reorder/caption can never RAISE the derived rating)
 
   // Re-pack: contiguous orders over the survivors (ordered by their old order).

--- a/src/server/services/blocks/offsite-listing.service.ts
+++ b/src/server/services/blocks/offsite-listing.service.ts
@@ -1510,15 +1510,36 @@ export type GetMyListingForAppResult = {
    */
   shadowId: string | null;
   /**
+   * The id the client hands to the asset procs: `shadowId` when a shadow already
+   * exists, else `appListingId`. Under LAZY shadow creation the first asset mutation
+   * on an approved parent arrives carrying the PARENT id — the asset service mints the
+   * shadow and re-targets (and re-maps screenshot row ids) server-side. See
+   * `resolveOwnerAssetEditTarget` in `app-listing-assets.service`.
+   */
+  editTargetId: string;
+  /**
+   * Non-null when this listing's media CANNOT be edited at all (`removed` / `rejected`
+   * / the row is itself an internal shadow). The editor renders it as its inline alert
+   * instead of mounting the asset step — the same surface the client's on-mount
+   * `beginListingRevision` used to produce via `INVALID_REVISION`. `null` for every
+   * editable listing (`draft` / `pending` edited in place; `approved` via a revision).
+   */
+  editBlockedReason: string | null;
+  /**
    * The EDITABLE target's current assets, edge-resolved — icon / cover / screenshots.
    *
-   * 🔴 These are the assets of the EFFECTIVE edit target: the SHADOW's rows for an
-   * approved parent, the listing's own rows otherwise. NEVER the live parent's rows
+   * 🔴 These are the assets of the EFFECTIVE edit target: the SHADOW's rows when a
+   * shadow EXISTS, the listing's own rows otherwise. NEVER the live parent's rows
    * when a shadow exists — the media editor mutates + floor-checks exactly what it
-   * is handed, so returning the parent's `AppListingScreenshot` ids here would let a
-   * "remove screenshot" delete a row from the LIVE served listing, bypassing
-   * moderator review. Same rule (and the same server-side shadow resolution) as
-   * `getMyListingForEdit`.
+   * is handed, so returning the parent's `AppListingScreenshot` ids alongside a live
+   * shadow would let a "remove screenshot" delete a row from the LIVE served listing,
+   * bypassing moderator review. Same rule as `getMyListingForEdit`.
+   *
+   * 🔴 Under LAZY creation an approved parent with NO shadow yet projects the PARENT's
+   * rows — which IS the hazard above, so it is contained on the WRITE side: every
+   * screenshot proc re-maps a parent row id onto the freshly-minted shadow's clone
+   * before mutating, and `assertOwnerAssetEditable` fires (fail-closed) if that re-map
+   * ever hands back the parent. See `resolveOwnerAssetEditTarget`.
    */
   assets: {
     icon: ListingEditAsset;
@@ -1546,11 +1567,18 @@ export type GetMyListingForAppResult = {
  * rendered every slot as "none" and its publish-floor check (icon+cover attached)
  * could never be satisfied, so "Submit for review" stayed permanently disabled —
  * the whole on-site listing-media flow was uncompletable. The assets come from the
- * EFFECTIVE source (an approved parent's shadow, resolved here server-side and
- * idempotently, exactly as `getMyListingForEdit` does — see the 🔴 note on
- * `GetMyListingForAppResult.assets` for why the shadow's rows and not the parent's).
- * A pre-approval DRAFT is NOT approved, so it has no shadow and is its own effective
- * target — edited in place, exactly like any other non-approved listing.
+ * EFFECTIVE source: an approved parent's shadow WHEN ONE ALREADY EXISTS, else the
+ * listing's own rows.
+ *
+ * 🔴 THIS IS A READ. It does NOT create a shadow. It used to call
+ * `beginListingRevision`, so merely OPENING the media tab minted a `draft`
+ * `AppListing` — measured on prod 2026-07-30: 7 shadows, 7/7 with
+ * `updated_at == created_at` (never written since their clone tx), 6 of them minted
+ * that day purely by page views, three 1.5 s apart; 78% of approved onsite parents
+ * carried a shadow representing no edit, and they self-refilled on sight. A `.query`
+ * must not write. The shadow is now minted LAZILY by the first asset MUTATION (see
+ * `resolveOwnerAssetEditTarget` in `app-listing-assets.service`), so every shadow
+ * that exists represents real work.
  */
 export async function getMyListingForApp(opts: {
   appBlockId?: string;
@@ -1558,10 +1586,17 @@ export async function getMyListingForApp(opts: {
   userId: number;
 }): Promise<GetMyListingForAppResult> {
   const { appBlockId, slug, userId } = opts;
+  const entrySelect = {
+    id: true,
+    userId: true,
+    status: true,
+    contentRating: true,
+    revisionOfId: true,
+  } as const;
   let listing = appBlockId
     ? await dbRead.appListing.findUnique({
         where: { appBlockId },
-        select: { id: true, userId: true, status: true, contentRating: true },
+        select: entrySelect,
       })
     : null;
   // (W13 draft-at-submit) Pre-approval DRAFT fallback: a FIRST-version app has no
@@ -1574,7 +1609,7 @@ export async function getMyListingForApp(opts: {
   if (!listing && slug) {
     listing = await dbRead.appListing.findFirst({
       where: { slug, kind: 'onsite', appBlockId: null, status: 'draft' },
-      select: { id: true, userId: true, status: true, contentRating: true },
+      select: entrySelect,
     });
   }
   if (!listing) {
@@ -1594,26 +1629,32 @@ export async function getMyListingForApp(opts: {
     select: { id: true },
   });
 
-  // Resolve the EFFECTIVE edit target before reading assets. For an approved parent
-  // that is the shadow revision — created/reused here (idempotent) so the asset rows
-  // the client receives are ALWAYS the shadow's, never the live listing's. A
-  // non-approved listing (draft / pending / rejected / removed) has no shadow and is
-  // edited in place, so it is its own effective target.
+  // Resolve the EFFECTIVE edit target before reading assets — WITHOUT creating one.
+  // For an approved parent that is its shadow revision IF one already exists; a
+  // non-approved listing (draft / pending) has no shadow and is edited in place.
+  //
+  // 🔴 The existence probe reads the PRIMARY, not the replica. The client invalidates
+  // this query after EVERY asset mutation, and the FIRST such mutation is what mints
+  // the shadow — so the very next call is a read-after-write on a row inserted
+  // milliseconds ago. Missing it on a lagging replica would re-project the PARENT's
+  // rows (and their screenshot row ids) right after the shadow started diverging.
   let effectiveId = listing.id;
   let shadowId: string | null = null;
-  if (listing.status === 'approved') {
-    const begun = await beginListingRevision({ listingId: listing.id, userId });
-    shadowId = begun.shadowId;
-    effectiveId = begun.shadowId;
+  if (listing.status === 'approved' && listing.revisionOfId == null) {
+    const existing = await dbWrite.appListing.findFirst({
+      where: { revisionOfId: listing.id },
+      select: { id: true },
+    });
+    if (existing) {
+      shadowId = existing.id;
+      effectiveId = existing.id;
+    }
   }
-  // 🔴 READ-AFTER-WRITE: read a SHADOW back from the PRIMARY — always, not just when
-  // THIS call inserted it. See the `loadListingEditView` doc: `created === false` only
-  // means "someone else minted it", which is routinely microseconds ago (the editor's
-  // own client-side `beginListingRevision` mutation, a second tab, `getMyListingForEdit`),
-  // so `created` is not a statement about replica visibility. A shadow read that misses
-  // on the replica throws NOT_FOUND → tRPC NOT_FOUND → `<NotFound />` (`retry: false`),
-  // discarding the editor mid-upload. Every non-shadow target (draft/pending edited in
-  // place) is old and stays on the replica.
+  // 🔴 READ-AFTER-WRITE: read a SHADOW back from the PRIMARY — always. A shadow read
+  // that misses on the replica throws NOT_FOUND → tRPC NOT_FOUND → `<NotFound />`
+  // (`retry: false`), discarding the editor mid-upload. Every non-shadow target
+  // (draft/pending edited in place, or an approved parent with no shadow yet) is old
+  // and stays on the replica.
   const { assets } = await loadListingEditView(
     effectiveId,
     effectiveId !== listing.id ? dbWrite : dbRead
@@ -1627,8 +1668,44 @@ export async function getMyListingForApp(opts: {
     contentRating: listing.contentRating ?? 'g',
     hasPendingRevision: !!pendingRevisionReq,
     shadowId,
+    editTargetId: effectiveId,
+    editBlockedReason: listingMediaEditBlockedReason(listing),
     assets,
   };
+}
+
+/**
+ * Why this listing's MEDIA cannot be edited at all, or `null` when it can.
+ *
+ * The client used to learn this by firing `beginListingRevision` on mount and
+ * rendering its `INVALID_REVISION` message inline — the only thing that stopped the
+ * media editor mounting against a `removed` / `rejected` listing. Lazy creation
+ * removes that call, so the verdict is computed here (read-only) and surfaced on the
+ * read. Mirrors `updateListing`'s state routing: draft/pending edit in place,
+ * approved edits through a revision, rejected → resubmit, removed → terminal. An
+ * internal shadow (`revisionOfId != null`) is not a page the owner addresses directly.
+ *
+ * Pure + exported so the branch table is unit-testable without a DB.
+ */
+export function listingMediaEditBlockedReason(listing: {
+  status: string;
+  revisionOfId: string | null;
+}): string | null {
+  if (listing.revisionOfId != null) {
+    return 'this listing is an internal revision draft and cannot be edited directly';
+  }
+  switch (listing.status) {
+    case 'draft':
+    case 'pending':
+    case 'approved':
+      return null;
+    case 'rejected':
+      return 'this listing was rejected; submit a new listing instead of editing it';
+    case 'removed':
+      return 'this listing has been removed by a moderator and can no longer be edited';
+    default:
+      return `cannot edit a listing in status ${listing.status}`;
+  }
 }
 
 /**

--- a/src/tests/pages/apps/listing-media-page.browser.test.tsx
+++ b/src/tests/pages/apps/listing-media-page.browser.test.tsx
@@ -10,14 +10,20 @@ import { useRouter } from 'next/router';
  * `/apps/<appBlockId>/edit`) — render test (browser mode, report-only in Tekton).
  *
  * Asserts the client wiring: it resolves `appBlockId` → `appListingId`
- * (`getMyListingForApp`), begins the editable shadow revision
- * (`beginListingRevision`), re-hosts the reused `ListingAssetStep` against the
- * SHADOW id + the listing's content rating, prefills it from the SHADOW's assets,
- * re-pulls the projection after an asset mutation, surfaces the honest live-app
- * framing copy (+ the pending-revision notice when applicable), and fires
- * `submitListingRevision({ shadowId })` from the Submit-for-review button. The
+ * (`getMyListingForApp`), re-hosts the reused `ListingAssetStep` against the
+ * server-resolved `editTargetId` + the listing's content rating, prefills it from that
+ * target's assets, re-pulls the projection after an asset mutation, surfaces the
+ * honest live-app framing copy (+ the pending-revision notice when applicable), and
+ * fires `submitListingRevision({ shadowId })` from the Submit-for-review button. The
  * asset step itself is stubbed — its real behaviour is covered by
  * `ListingAssetStep.browser.test.tsx`.
+ *
+ * 🔴 NO `beginListingRevision` ON MOUNT. Firing it here made merely OPENING the tab
+ * create a `draft` AppListing (78% of approved onsite parents on prod carried a
+ * never-edited shadow, self-refilling on every view). The shadow is minted by the
+ * first asset MUTATION, server-side. `editTargetId` is the shadow when one exists and
+ * the listing itself otherwise; `editBlockedReason` carries the "this can't be edited"
+ * verdict the on-mount call used to deliver as INVALID_REVISION.
  *
  * 🔴 This file used to import the default export of `~/pages/apps/[appBlockId]/listing`.
  * That route is now a getServerSideProps REDIRECT stub whose default export renders
@@ -33,8 +39,6 @@ const state = vi.hoisted(() => ({
     isLoading: false,
     error: null as unknown,
   },
-  // beginListingRevision — resolves to a shadow id via onSuccess.
-  begin: { shadowId: 'apl_shadow' as string | null, error: null as string | null, pending: false },
   // submitListingRevision — captured args.
   submit: { calls: [] as unknown[], pending: false },
   // Props the stubbed ListingAssetStep received.
@@ -105,23 +109,14 @@ vi.mock('~/utils/trpc', () => ({
     }),
     appListings: {
       getMyListingForApp: { useQuery: () => state.query },
-      beginListingRevision: {
-        useMutation: () => ({
-          mutate: (
-            _vars: unknown,
-            opts?: { onSuccess?: (r: { shadowId: string }) => void; onError?: (e: { message: string }) => void }
-          ) => {
-            if (state.begin.error) opts?.onError?.({ message: state.begin.error });
-            else if (state.begin.shadowId) opts?.onSuccess?.({ shadowId: state.begin.shadowId });
-          },
-          isPending: state.begin.pending,
-        }),
-      },
+      // 🔴 `beginListingRevision` is deliberately ABSENT from this mock. If the editor
+      // ever re-adds an on-mount call to it, these tests crash rather than silently
+      // re-introducing the write-on-view that this change removed.
       submitListingRevision: {
         useMutation: () => ({
           mutateAsync: async (vars: unknown) => {
             state.submit.calls.push(vars);
-            return { publishRequestId: 'alpr_1', shadowId: state.begin.shadowId, slug: 'my-app' };
+            return { publishRequestId: 'alpr_1', shadowId: 'apl_shadow', slug: 'my-app' };
           },
           isPending: state.submit.pending,
         }),
@@ -167,6 +162,8 @@ beforeEach(() => {
       contentRating: 'pg13',
       hasPendingRevision: false,
       shadowId: 'apl_shadow',
+      editTargetId: 'apl_shadow',
+      editBlockedReason: null,
       // The SHADOW's assets — what the proc now projects so the step can prefill.
       assets: {
         icon: { imageId: 137918008, url: 'edge:icon' },
@@ -177,7 +174,6 @@ beforeEach(() => {
     isLoading: false,
     error: null,
   };
-  state.begin = { shadowId: 'apl_shadow', error: null, pending: false };
   state.submit = { calls: [], pending: false };
   state.floor = { meetsFloor: true, complete: false };
   state.assetProps.last = null;
@@ -191,14 +187,79 @@ beforeEach(() => {
 });
 
 describe('ListingMediaPage — owner listing-media route shell', () => {
-  test('resolves the listing, begins the shadow revision, and renders the asset step against the SHADOW id + rating', async () => {
+  test('resolves the listing and renders the asset step against the server-resolved edit target + rating', async () => {
     renderWithProviders(<ListingMediaPage />);
 
-    // The reused asset step is hosted against the shadow id + the listing's rating.
+    // The reused asset step is hosted against the edit target + the listing's rating.
     await expect.element(page.getByTestId('asset-step')).toBeInTheDocument();
     await expect.element(page.getByTestId('asset-step')).toHaveTextContent('assets:apl_shadow:pg13');
     expect(state.assetProps.last).toMatchObject({ listingId: 'apl_shadow', contentRating: 'pg13' });
     expect(page.getByTestId('not-found').elements()).toHaveLength(0);
+  });
+
+  // -------------------------------------------------------------------------
+  // 🔴 LAZY CREATION — no shadow yet.
+  // -------------------------------------------------------------------------
+
+  test('🔴 with NO shadow yet, the editor mounts against the PARENT id and never opens a revision', async () => {
+    state.query.data = {
+      ...(state.query.data as Record<string, unknown>),
+      shadowId: null,
+      editTargetId: 'apl_onsite',
+    };
+    renderWithProviders(<ListingMediaPage />);
+
+    // It renders (no "Preparing your revision…" gate — there is nothing to prepare),
+    // hosted against the LIVE listing id. The first mutation mints the shadow
+    // server-side and applies there.
+    await expect.element(page.getByTestId('asset-step')).toHaveTextContent('assets:apl_onsite:pg13');
+  });
+
+  test('🔴 Submit is DISABLED until a shadow exists — no edits means no revision to submit', async () => {
+    state.query.data = {
+      ...(state.query.data as Record<string, unknown>),
+      shadowId: null,
+      editTargetId: 'apl_onsite',
+    };
+    state.floor = { meetsFloor: true, complete: false };
+    renderWithProviders(<ListingMediaPage />);
+
+    const submit = page.getByTestId('apps-listing-media-submit');
+    await expect.element(submit).toBeDisabled();
+    await expect.element(page.getByTestId('apps-listing-media-no-changes')).toBeInTheDocument();
+  });
+
+  test('🔴 editBlockedReason renders the inline alert and keeps the editor unmounted', async () => {
+    state.query.data = {
+      ...(state.query.data as Record<string, unknown>),
+      status: 'removed',
+      shadowId: null,
+      editTargetId: 'apl_onsite',
+      editBlockedReason: 'this listing has been removed by a moderator and can no longer be edited',
+    };
+    renderWithProviders(<ListingMediaPage />);
+
+    const alert = page.getByTestId('apps-listing-media-begin-error');
+    await expect.element(alert).toHaveTextContent(/removed by a moderator/i);
+    // No editor over a dead listing, and no contradictory "this app is live" notice.
+    expect(page.getByTestId('asset-step').elements()).toHaveLength(0);
+    expect(page.getByTestId('apps-listing-media-live-notice').elements()).toHaveLength(0);
+    expect(page.getByTestId('not-found').elements()).toHaveLength(0);
+  });
+
+  test('a DRAFT listing is edited in place — no live notice, no revision Submit button', async () => {
+    state.query.data = {
+      ...(state.query.data as Record<string, unknown>),
+      status: 'draft',
+      shadowId: null,
+      editTargetId: 'apl_draft',
+      editBlockedReason: null,
+    };
+    renderWithProviders(<ListingMediaPage />);
+
+    await expect.element(page.getByTestId('asset-step')).toHaveTextContent('assets:apl_draft:pg13');
+    expect(page.getByTestId('apps-listing-media-live-notice').elements()).toHaveLength(0);
+    expect(page.getByTestId('apps-listing-media-submit').elements()).toHaveLength(0);
   });
 
   test('prefills the asset step with the SHADOW revision assets the proc projects', async () => {
@@ -247,7 +308,15 @@ describe('ListingMediaPage — owner listing-media route shell', () => {
 
   test('shows the pending-revision notice when a revision is already under review', async () => {
     state.query = {
-      data: { appListingId: 'apl_onsite', status: 'approved', contentRating: 'g', hasPendingRevision: true },
+      data: {
+        appListingId: 'apl_onsite',
+        status: 'approved',
+        contentRating: 'g',
+        hasPendingRevision: true,
+        shadowId: 'apl_shadow',
+        editTargetId: 'apl_shadow',
+        editBlockedReason: null,
+      },
       isLoading: false,
       error: null,
     };
@@ -275,10 +344,9 @@ describe('ListingMediaPage — owner listing-media route shell', () => {
   });
 
   test('a NON-owner-gating error surfaces the inline alert instead of collapsing to NotFound', async () => {
-    // `getMyListingForApp` now resolves the shadow server-side, so an INVALID_REVISION
-    // ("cannot edit a listing in status …") arrives here as BAD_REQUEST. Blanket-
-    // NotFound'ing it hid the one surface that explains it and told the owner their
-    // LIVE app did not exist.
+    // Anything that isn't FORBIDDEN/NOT_FOUND arrives here as a settled query error.
+    // Blanket-NotFound'ing it hid the one surface that explains it and told the owner
+    // their LIVE app did not exist.
     state.query = {
       data: undefined,
       isLoading: false,
@@ -319,6 +387,8 @@ describe('ListingMediaPage — owner listing-media route shell', () => {
         contentRating: 'pg13',
         hasPendingRevision: false,
         shadowId: 'apl_shadow',
+        editTargetId: 'apl_shadow',
+        editBlockedReason: null,
         assets: before,
       },
       isLoading: false,


### PR DESCRIPTION
Editing a **live (`approved`)** onsite listing's media goes through a *shadow revision*: `beginListingRevision` clones the parent into a `draft` `AppListing` (`revisionOfId = parent.id`), the owner edits the clone, a mod approves, and `applyApprovedRevision` copies the clone's assets onto the parent.

Two things were wrong with that, and together they make a silent, destructive, invisible failure mode.

### 1. A shadow was minted on VIEW, not on edit

`getMyListingForApp` is a tRPC `.query` that **wrote**: it called `beginListingRevision`, so merely opening the "Listing media" tab created a `draft` `AppListing`. The client fired the same mutation again on mount.

Measured on production: **7 shadows existed, 7/7 with `updated_at == created_at`** — never written since their clone transaction. 6 were minted in a single day purely by people opening the page, three of them **1.5 s apart** from opening three apps in a row. **78% of approved onsite parents carried a shadow representing no edit**, and deleting them just refilled on the next view.

### 2. Review could not see what was being replaced

Both review queries key on `request.appListingId` — which **is** the shadow id — so the modal rendered the proposal alone. There is no parent fetch anywhere in the review surface. A mod saw "an icon", never "the icon is going backwards". **"A mod would catch it" was false.**

### Why that combination bites

`applyApprovedRevision` is unconditional in both directions: it copies the shadow's `iconId`/`coverId` over the parent's, and for screenshots it does a **destructive full replace** — `deleteMany({ appListingId: parentId })`, then move the shadow's rows across. So a revision carrying **zero** screenshots **deletes every live screenshot**.

The reachable trigger needs nobody to do anything unusual: the mod-only `backfillListingAssets` migrates bundle screenshots onto a parent that has none; screenshots are **not** in the publish floor; so an owner can submit a 0-screenshot revision and approving wipes them. **6 of 9 approved onsite parents are in exactly that pre-loaded state today.**

Measured harm so far: **zero** — no publish request has ever pointed at a shadow. This is a fix ahead of the incident, not after it.

---

## Part 1 — lazy shadow creation (commit 1)

A shadow now exists only once the owner actually mutates an asset.

- `getMyListingForApp` **resolves** a shadow if one exists and **creates nothing**. It returns `editTargetId` (shadow ?? listing) and `editBlockedReason`.
- The client no longer fires `beginListingRevision` on mount. `beginListingRevision` is deliberately **absent from the test's tRPC mock**, so re-adding an on-mount call crashes the suite rather than quietly restoring write-on-view.
- The owner asset procs mint the shadow (`resolveOwnerAssetEditTarget`) and apply there. **Moderators are untouched** — they still curate the live row directly (the documented bypass + `reDeriveContentRatingForModLiveEdit`).

**Preserving the error surface.** The client used to learn "this listing isn't revisable" from the on-mount call's `INVALID_REVISION` — that was the only thing keeping the editor from mounting over a `removed`/`rejected` listing. Removing the call without replacing it would have handed the owner a fully-functional editor over a dead listing. `editBlockedReason` carries that verdict on the read instead, still rendered as the inline alert (never a blank page, never `NotFound`).

**The probe reads the PRIMARY, not the replica.** The client invalidates this query after every asset mutation, and the *first* mutation is what mints the shadow — so the very next call is a read-after-write on a row inserted milliseconds ago. Missing it on a lagging replica would re-project the **parent's** rows, and their screenshot row ids, exactly as the shadow began to diverge.

### 🔴 The row-id hazard, and the design chosen

`removeScreenshot` / `reorderScreenshots` / `updateScreenshotCaption` take `AppListingScreenshot` **row ids**. Before a shadow exists, the ids the client holds are the **parent's** rows. Applied naively, a "remove screenshot" **deletes a row off the served listing with no moderator review** — the exact hazard the 🔴 SECURITY note on `GetMyListingForAppResult.assets` warns about.

**Chosen: mint-then-re-key** (`resolveOwnerScreenshotTarget` → `matchClonedScreenshotRow`). The row id is mapped onto the freshly-cloned shadow row by `(imageId, order)`, then by a unique `imageId` (survives a concurrent reorder in another tab), else **refused**.

*Why this over re-keying the procs on `imageId` + `listingId`:* that is a wire-contract change, and these procs are reachable by the `civitai` CLI under the `AppBlocksSubmit` scope — it would break released CLI versions. The re-map keeps every signature identical. The mapping is also *total* immediately after a clone, because `beginListingRevision` copies `imageId`/`order`/`caption` verbatim; the fallbacks only cover concurrent divergence.

*Why it fails closed:* an ambiguous match (the same image attached twice) or a missing row returns `null` and the proc throws `BAD_REQUEST` asking the client to refresh, rather than guessing at a row to delete.

**`assertOwnerAssetEditable` is retained as defence in depth** and now runs on the **resolved** target: if resolution ever yields the live parent for an owner, the write is refused instead of hitting the served listing. Both fail-closed paths are exercised by fault injection in the tests, not merely asserted to exist.

### 🔴 Two RACES on that path, closed structurally (fix round)

Both were found by an adversarial audit of this PR and both are windows this PR itself widened or opened.

**(a) Read-after-write on the resolve.** `resolveOwnerScreenshotTarget` read the screenshot row *and* `loadOwnedListing` from **`dbRead`**, while the client now holds shadow row ids sourced from the **primary**. Under replication lag the owner's second edit 404'd on a row that demonstrably exists (`Screenshot not found` / `Listing not found`) — the same class #3476 fixed for `loadListingEditView`. A replica miss is no longer authoritative: the row is re-read from the primary, and the pool that answered is threaded into the listing load.

**(b) The reparent race.** `applyApprovedRevision` **reparents** the shadow's screenshot rows onto the live parent (`updateMany appListingId → parentId`). A moderator approving between the resolve and the write turned a resolved SHADOW row id into a **PARENT** row id — and the writes were `delete({ where: { id } })` / `update({ where: { id } })`, i.e. they would have landed on the **live served listing**, which is the entire hazard the re-map exists to prevent. All **four** row-id writes are now **listing-scoped** (`deleteMany`/`updateMany` on `{ id, appListingId: <resolved listing> }`, else the same typed refusal). The write matches zero rows instead of hitting the parent.

**Error mapping (fix round).** The six owner asset procs were the only mutations in `app-listings.router.ts` with **no `mapOffsiteError` wrapper** — an escape this PR introduced, because they only started reaching `beginListingRevision` (which throws `OffsiteRequestError`, a plain `Error` subclass, not a `TRPCError`) once the mint moved onto the write path. A status race, or `'failed to open a revision draft'`, surfaced as an opaque **500** with a generic message instead of the typed, actionable one. Now wrapped consistently with the rest of the router.

**Return-shape note (fix round).** `removeScreenshot` returns `{ removed }` and `updateScreenshotCaption` `{ id }` = the row that was actually **written**, which differs from the id passed in whenever the call minted the shadow. That is deliberate and is now documented on both the service and router docstrings: echoing the caller's id back would report a deletion/write against a row on the **live** listing that never happened. **Input schemas are unchanged**, so released `civitai` CLI versions calling these under `AppBlocksSubmit` are unaffected.

### 🔴 Closing the last two holes in that invariant (final round)

A delta re-audit found the invariant above was asserted but not quite true, and that its refusal did not have the property it claimed.

**(c) The post-delete RE-PACK was still unscoped.** After `removeScreenshot` deletes a row it re-packs the survivors' `order` to a contiguous `0..n-1`, and that loop was still a bare `update({ where: { id } })` — so "every screenshot row-id write is listing-scoped" was false. Same reparent window: an approve landing between the survivor `findMany` and the re-pack wrote `order` onto rows that now belong to the **live** listing. Non-destructive (an `order`, not a delete), but it is the exact race the fix exists to close. Now scoped like the other three.

`count !== 1` there is a deliberate **no-op**, not a refusal — the one write on this path where refusing is the worse answer. The delete has already committed and is exactly what the owner asked for; a reparent landing afterwards is a moderator's approve, not user error, so a refusal would report a failure for a removal that succeeded. There is also no state left to protect: the re-pack only densifies `order`, and the reparented rows keep the orders `applyApprovedRevision` moved them with. The abort is still raised **inside** the transaction so a half-re-packed set rolls back rather than leaving the very `order` gaps the re-pack exists to remove.

**(d) The reorder's refusal fired AFTER its write committed.** `reorderScreenshots` used the array form `$transaction([...])`, which **commits** before its results are inspected — so the `count !== 1` check ran post-commit. Under READ COMMITTED a reparent landing between statements left **some orders written and** an exception thrown: the worst of both. Moved to the interactive form so the throw actually rolls back. (Still strictly better than pre-fix, which silently wrote to the live listing — but "rolls back" is the property the code was claiming, so it should be the property it has.)

Testing this needed the fake `$transaction` to model rollback. It does so with an undo **log**, not a store snapshot: the race tests commit a *concurrent* approve mid-transaction, and a real `ROLLBACK` does not undo another transaction's committed work — a snapshot would, and would let a test pass by asserting a state Postgres could never produce. A new `afterShotOrderWrite` hook lands that approve **between** two statements, which is the only window where "does the refusal roll back?" is a real question; the pre-existing race tests land it before the first write, where "nothing was written" is true for free.

**(e) The review header duplicated `OFFSITE_UNCOMPARED_APPLY_FIELDS` in prose — and had drifted**, omitting `scope justifications`. A moderator reading "name, tagline, description, category, link and requested OAuth scopes" would conclude the justifications were not part of the apply, in the one surface whose job is to avoid implying that. Now derived from the constant via a pure `uncomparedApplyFieldsSentence`, pinned by a test that iterates the constant — so the duplication is unrepresentable rather than merely fixed.

## Part 2 — drift-visible review (commit 2)

A "Currently live" section above the existing preview, rendered **only** when the request targets a shadow (`appListing.revisionOfId` — already projected by `submissionSelect`, just never resolved by the UI):

- per-slot icon/cover verdicts (unchanged / added / removed / replaced);
- a screenshot **`N → M`** count with an added/removed/reordered/captions-edited summary;
- a **red alert** when approving deletes every live screenshot;
- a note when the revision's media is identical to what is live — **kind-scoped**, see below;
- an explicit **error state** when the live listing can't be read;
- the live listing's store card, for a visual before/after.

Reuses the existing mod-gated `getAssets` + `getListingPreviewForReview` procs pointed at the parent id — **no new server surface, no second image-URL builder**, read-only and `moderatorProcedure`-gated throughout. The verdict is a pure module, unit-testable without mounting the review page (same split as `offsiteReviewChecklist`).

### 🔴 The panel LIED for off-site revisions (fix round)

As first written the panel rendered for **any** request with `revisionOfId != null` and reported **"IDENTICAL — approving changes nothing"** from a comparison of icon/cover/screenshot image ids alone. But `applyApprovedRevision` is **kind-aware**: the onsite branch copies icon/cover only, while the **off-site** branch also copies `name`, `tagline`, `description`, `category`, `externalUrl`, `connectClientId`, **`connectRequestedScopes`** and `connectScopeJustifications` onto the parent.

So a moderator could be told that a **scope-changing** off-site revision was a no-op. That is a false statement in the exact safety surface Part 2 exists to provide — worse than having no panel at all.

The claim is now **structurally** kind-scoped rather than worded around:

- `computeListingRevisionDrift` takes a `RevisionApplyScope` (`revisionApplyScope(kind)`), defaulting to the conservative `'assets-and-scalars'` so an unknown/missing kind can never license a no-op claim.
- `hasChanges` is **renamed `assetsChanged`**. The rename is the fix: "hasChanges === false" reading as "nothing happens" is precisely what produced the lie.
- A new `noOpApproval` is the **only** field that licenses the "changes nothing" copy, and it can be true only when the compared set **is** the apply set (onsite). An off-site revision with identical media now renders an amber notice that **names** the fields that were not compared.

*Why not compare the off-site scalars instead:* `name`/`tagline`/`description`/`category`/`externalUrl` are reachable from the two preview projections, but **`connectRequestedScopes` is not exposed for the PARENT by any mod-gated read** — surfacing it means widening the **public** `ListingDetail` DTO (served by `getAppDetail`) to carry OAuth-scope data, a far larger blast radius than a review panel warrants. And a *partial* scalar comparison would not fix anything: it would only move the lie to "identical" while the scopes changed underneath. Naming the uncompared fields is the honest contract.

**Captions are now compared too** (same round). They ride along on the screenshot reparent, so a caption-only revision was likewise reported as changing nothing.

**No error state → indefinite spinner (fix round).** Both drift queries run `retry: false`, so a failure is terminal and the panel sat on "Comparing with the live listing…" forever — a moderator next to the destructive-replace case saw a spinner, not "could not load the live listing". The decision now lives in the pure `driftPanelState` (**error outranks loading**) so it is pinned in the blocking `unit` project, and the UI renders an explicit alert with a retry.

Two deliberate calls:

- The comparison is **"what approving CHANGES on the live listing"**, not "did the parent move since the shadow was cloned". Telling those apart requires a clone-time baseline, which requires a schema migration; this is the decision-useful half and costs nothing.
- Drift is computed **only once both sides have loaded**. Reading an unloaded parent as empty would flag *every* revision as a destructive replace — warning fatigue that makes the real signal worthless. Pinned by a test.

`submissionSelect.appListing.revisionOfId` is now guarded across all three mod queues: it is the panel's only handle on the live parent, and dropping it would silently restore the blind spot rather than fail.

---

## No schema migration

Neither part needs one, by design — including every fix in the audit round. Selective-apply (copy only what the owner actually changed) is the fuller fix and *does* need new baseline columns — deliberately **not** built here; it becomes worth estimating the moment the Part 2 drift signal reports real divergence.

## Verification

**Mutation-verified — every new guard was broken, watched fail, and restored.**

Commits 1–2 (12/12 killed): re-introduce the write-on-view (1) · shadow probe reads the replica (1) · editability verdict always `null` (3) · resolver returns the live listing (1) · **skip the parent→shadow row-id re-map (2)** · drop `assertOwnerAssetEditable` from `removeScreenshot` (1) · matcher guesses instead of failing closed (3) · hard-code `destructiveReplace: false` (2) · hard-code every slot verdict `same` (2) / `changed` (1) · unloaded parent read as empty (1) · drop `revisionOfId` from `submissionSelect` (1).

Fix round (13/13 killed):

| # | Guard broken | Targeted tests failed |
|---|---|---|
| M1 | no-op claim ignores the apply scope | 2 |
| M2 | every kind treated as onsite | 5 |
| M3 | the notice always claims a no-op | 1 |
| M4 | captions never compared | 2 |
| M5 | the snapshot drops captions | 1 |
| M6 | loading outranks error | 1 |
| M7 | `removeScreenshot` unwrapped (no `mapOffsiteError`) | 4 |
| M8 | `setIcon` unwrapped | 4 |
| M9 | screenshot row read trusts the replica only | 2 |
| M10 | listing load trusts the replica only | 2 |
| M11 | **unscoped `delete({ where: { id } })`** | 3 |
| M12 | unscoped caption `update` | 2 |
| M13 | unscoped reorder `update` | 2 |

**The `dbRead`/`dbWrite` split.** The lazy-revision suite backed both pools with the *same* fake object, which made every "this read must go to the PRIMARY" claim in the service **unfalsifiable** — a guard nothing can break is a guard nothing verifies. They are now distinct clients over one store with a `replicaLagsOn` set (mirroring `offsite-listing.get-my-listing-for-app.service.test.ts`), which is what makes M9/M10 possible at all.

Final round (3/3 killed, each broken → watched the *named* test fail → restored → green): **M14** revert the reorder to the committing array form → the mid-transaction rollback test fails (1 failed / 30 passed) · **M15** revert the re-pack to the unscoped `update({ where: { id } })` → the re-pack scoping test fails (1 / 30) · **M16** keep the scoping but drop the abort → same test fails on the precise signal, a survivor left at `order 0` instead of `1` (1 / 30). Plus **M17** for the derived header sentence: drop the last field from the constant → the "names every field" test fails (1 / 39).

**Full `unit` suite at the PR tip vs a clean `origin/main` worktree, both run in the same freshly-installed environment — failing sets compared by NAME:**

| | `origin/main` | PR tip |
|---|---|---|
| Failing tests | 7 | 7 |
| Failing files | 49 | 49 |
| Passing tests | 8705 | 8813 |
| `tsc --noEmit` errors | 12 | 12 |

`comm` on the sorted failing-entry sets returns **empty in both directions — 0 new, 0 disappeared**. All 7 failures are the pre-existing `hiddenBlocks` suite, on both refs. The `tsc` error sets are **byte-identical** (10 in `image.service.ts`, 2 in `bitdex-stats.ts`), so **0 new type errors**; none are in PR files. Browser suite `listing-media-page.browser.test.tsx` → **17/17**.

> ⚠️ **The `tsc` number is environment-sensitive, and earlier readings of it were wrong.** The same tip measured **26** errors in a long-lived worktree whose `pnpm` install was stale (its `@civitai/buzz` workspace link could not resolve `gatePrices` / `maxPaidAccessPrice` / `raisesOverCap`, which alone accounted for 10 phantom errors across `ModelVersionUpsertForm.tsx`, `model-version.controller.ts` and `paid-access.service.ts`). Those files are untouched by this PR. The **12** above is from a clean checkout with a fresh install — measure it that way or the number is noise.

`npx eslint` on every changed file → **0 errors**. Prettier: the 5 violations the audit flagged as introduced by this PR in `app-listing-assets.service.ts` are fixed, plus the 2 in the drift panel's copy; the files' pre-existing unformatted regions are left alone.

**Not verified — stated plainly:** I could not reach a deployed preview, so **no UI was exercised in a browser**. That is exactly why the drift panel's error-vs-loading precedence was extracted into a pure function and pinned in the blocking `unit` project rather than left to a component test.

## Found, not fixed

- **`applyApprovedRevision`'s destructive screenshot replace is unchanged.** Part 2 makes it *visible* to the reviewer; it does not make it safe. That is the selective-apply work above.
- **The off-site scalars are still not diffed for the reviewer.** The panel now says so instead of implying otherwise. Doing it properly needs a mod-gated read that exposes the parent's `connectRequestedScopes` — a small new server surface, worth its own PR.
- **Known follow-ups from the delta audit, deliberately not taken here** (each is a behaviour change or needs a harness, and this was a polish pass): the drift-panel **UI wiring** has no test coverage — `driftPanelState` is pinned as a pure function, the wiring around it is not; **`contentRating` is missing** from `OFFSITE_UNCOMPARED_APPLY_FIELDS` (adding it changes what the panel claims, so it wants its own look at the apply set); on a failed **background refetch** an error outranks an already-loaded drift, which is right for the first load but arguably wrong once a good drift is on screen; and **Retry does not refetch `parentPreviewQuery`**.
- **The 7 existing shadows are left in place** (out of scope). With lazy creation merged they stop refilling, so a cleanup is now durable rather than cosmetic — worth doing as a follow-up, from a *fresh* untouched-check rather than a blanket predicate.
- **Pre-existing, unrelated to this PR:** a `draft`/`pending` listing's media tab was previously unreachable through the UI — the client's unconditional on-mount `beginListingRevision` threw `INVALID_REVISION` for any non-approved status, leaving a permanent "Preparing your revision…" spinner under an error alert. Lazy creation incidentally fixes it (those listings are edited in place, as the server always intended). Only reachable via the CLI's by-slug path today, so no user-visible change is expected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

