### PR TITLE
fix(lint): make no-wholesale-module-mock structural, then gate on it at 'error'

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -57,12 +57,31 @@ module.exports = {
     // normal, safe thing to do, and flagging it would make the rule noisy enough
     // to get switched off. Extend `modules` if another hub module starts biting.
     //
-    // 'warn', matching no-io-in-transaction above: there is a pre-existing
-    // backlog of ~66 wholesale trpc mocks, and converting them in bulk without
-    // being able to run the browser suite risks re-creating the very
-    // 0-tests-collected failure this rule exists to catch. Escalate to 'error'
-    // once that backlog is burned down.
-    'local-rules/no-wholesale-module-mock': ['warn', { modules: ['~/utils/trpc'] }],
+    // 'error', NOT 'warn' — unlike no-io-in-transaction above, and deliberately.
+    // The severity has to be read against .github/workflows/lint.yml, which
+    // splits ESLint by how the PR touched the file:
+    //
+    //   ADDED files    -> BLOCKING, errors only, no --max-warnings (lint.yml:97)
+    //   MODIFIED files -> report-only, continue-on-error: true    (lint.yml:125)
+    //
+    // At 'warn' this rule gates NOTHING anywhere: the added-files step ignores
+    // warnings by design (the repo carries ~3,470 of them), so a brand-new
+    // browser test with a wholesale trpc mock merges green — which is precisely
+    // the authoring path the rule exists to close.
+    //
+    // At 'error' the blast radius on the pre-existing backlog is ZERO: all 63
+    // remaining offenders are pre-existing files, so a PR touching one reaches
+    // only the report-only modified-files step. Nothing else in CI runs a
+    // whole-src lint (`pnpm lint` is not invoked by any workflow, and
+    // .husky/pre-push runs typecheck only, and only on `main`). The rule can
+    // therefore only block a NEWLY ADDED file — the one case where "fix it
+    // before it merges" is both cheap and correct.
+    //
+    // Scope note: the check is proof-based, so an exotic-but-safe factory it
+    // cannot walk is reported (`unprovableMock`) rather than assumed safe.
+    // That is the intended direction: a false positive costs one disable
+    // comment, a false negative costs a silently-empty test suite.
+    'local-rules/no-wholesale-module-mock': ['error', { modules: ['~/utils/trpc'] }],
 
     // aligns closing brackets for tags
     'react/jsx-closing-bracket-location': ['error', 'line-aligned'],

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -61,15 +61,18 @@ module.exports = {
     // The severity has to be read against .github/workflows/lint.yml, which
     // splits ESLint by how the PR touched the file:
     //
-    //   ADDED files    -> BLOCKING, errors only, no --max-warnings (lint.yml:97)
-    //   MODIFIED files -> report-only, continue-on-error: true    (lint.yml:125)
+    //   ADDED files    -> BLOCKING, errors only, no --max-warnings
+    //                     (lint.yml, "ESLint (added files)": no
+    //                      continue-on-error, no --max-warnings)
+    //   MODIFIED files -> report-only, continue-on-error: true
+    //                     (lint.yml, "ESLint (modified files, report-only)")
     //
     // At 'warn' this rule gates NOTHING anywhere: the added-files step ignores
     // warnings by design (the repo carries ~3,470 of them), so a brand-new
     // browser test with a wholesale trpc mock merges green — which is precisely
     // the authoring path the rule exists to close.
     //
-    // At 'error' the blast radius on the pre-existing backlog is ZERO: all 63
+    // At 'error' the blast radius on the pre-existing backlog is ZERO: all 65
     // remaining offenders are pre-existing files, so a PR touching one reaches
     // only the report-only modified-files step. Nothing else in CI runs a
     // whole-src lint (`pnpm lint` is not invoked by any workflow, and
@@ -77,10 +80,19 @@ module.exports = {
     // therefore only block a NEWLY ADDED file — the one case where "fix it
     // before it merges" is both cheap and correct.
     //
+    // One exception to "the backlog only ever reaches the report-only step":
+    // `--diff-filter=A` sees a MOVED file as added when git's rename detection
+    // misses it (a move plus edits below the ~50% similarity threshold
+    // decomposes into A + D). Relocating a backlog file with substantial edits
+    // can therefore land it in the blocking step. Fixing the factory at that
+    // point is the right outcome, but it is a real cost, not zero.
+    //
     // Scope note: the check is proof-based, so an exotic-but-safe factory it
     // cannot walk is reported (`unprovableMock`) rather than assumed safe.
     // That is the intended direction: a false positive costs one disable
-    // comment, a false negative costs a silently-empty test suite.
+    // comment, a false negative costs a silently-empty test suite. The known
+    // false-positive shapes are listed in eslint-local-rules.js so a blocked
+    // author can recognise their own and reach for a disable comment.
     'local-rules/no-wholesale-module-mock': ['error', { modules: ['~/utils/trpc'] }],
 
     // aligns closing brackets for tags

--- a/eslint-local-rules.js
+++ b/eslint-local-rules.js
@@ -197,31 +197,90 @@ const noIoInTransaction = {
  * so the signature is ambiguous at runtime — which is the argument for catching
  * it statically, here, instead.
  *
+ * TypeScript cannot catch this. On the string-path overload Vitest types the
+ * factory's return as `Promisable<Partial<M>>` with `M = unknown`, so an
+ * omitted export is not a type error — not even under Vitest 4's typed
+ * `vi.mock(import('...'))` form. This rule is the only static gate available.
+ *
  * The fix is to override narrowly and keep every other export real:
  *
+ *   import type * as TrpcModule from '~/utils/trpc';
+ *
  *   vi.mock('~/utils/trpc', async (importOriginal) => ({
- *     ...(await importOriginal<typeof import('~/utils/trpc')>()),
+ *     ...(await importOriginal<typeof TrpcModule>()),
  *     trpc: { ...only what this test overrides... },
  *   }));
  *
  * Canonical in-repo example (with the same warning in a comment):
  *   src/components/Challenge/__tests__/ChallengeUpsertForm.browser.test.tsx
  *
- * A factory is accepted when the object it returns has a top-level spread AND
- * the factory actually references `importOriginal`/`importActual` — a spread of
- * some local stub object is not a fix. `vi.mock('mod')` with no factory
- * (automock) is untouched: it preserves the real export shape by construction.
+ * ---------------------------------------------------------------------------
+ * How the check works, and why it is structural rather than textual
+ * ---------------------------------------------------------------------------
+ *
+ * The question the rule answers is: "can I PROVE, from the AST, that everything
+ * this factory returns carries the original module's exports forward?" It is
+ * deliberately proof-based, so the failure mode is a false POSITIVE (a noisy
+ * squiggle on an exotic-but-safe factory, fixable with a disable comment) and
+ * never a false NEGATIVE (a silently-broken suite, which is the whole point).
+ *
+ * Two consequences worth stating, because both were real holes in the first cut
+ * of this rule:
+ *
+ *  1. The `importOriginal` reference is matched as a BINDING, not as text. The
+ *     factory's first parameter IS `importOriginal` whatever the author named
+ *     it (`async (orig) => ...` is correct and must pass), and conversely the
+ *     mere presence of the word — an unused parameter, a comment, a string —
+ *     proves nothing. A textual `/\bimportOriginal\b/` over the factory source
+ *     accepts `(importOriginal) => ({ ...localStub })` and rejects
+ *     `(orig) => ({ ...(await orig()) })`: wrong in both directions.
+ *
+ *  2. "Returns something I can't read" is NOT a pass. `return {...} as any`,
+ *     `return out`, `Object.assign({}, {...})`, `cached || {...}` and a factory
+ *     with no `return` at all are all wholesale mocks wearing a hat. Anything
+ *     the analysis cannot walk to an original-bearing spread is reported (as
+ *     `unprovableMock`, with a message that says so) rather than assumed safe.
+ *
+ * What counts as "carries the original forward" (`isOriginalPreserving`):
+ *   - `importOriginal(...)` where the callee resolves to the factory's own
+ *     first parameter, or `vi.importActual('<the same module>')`;
+ *   - an `await` of either;
+ *   - a local `const` whose initialiser is one of those (the common
+ *     `const actual = await importOriginal()` shape) — as long as the name is
+ *     not redeclared or reassigned;
+ *   - an object literal with a top-level spread of something original-bearing;
+ *   - `Object.assign(...)` where any argument is original-bearing (every source
+ *     argument's keys land on the result);
+ *   - a conditional / logical / sequence expression where every branch that can
+ *     be the value is itself original-bearing.
+ * Everything else is not provable, and is reported.
+ *
+ * Notably NOT accepted: `await import('<the mocked module>')` inside its own
+ * factory. Vitest intercepts that import and hands back the mock, so it is a
+ * self-reference, not the original — `importOriginal`/`vi.importActual` exist
+ * precisely because a plain dynamic import does not work here.
+ *
+ * `vi.mock('mod')` with no factory (automock) is untouched: it preserves the
+ * real export shape by construction. So is `vi.mock('mod', { spy: true })`.
  *
  * Scoped by the `modules` option (default: just `~/utils/trpc`) rather than
  * applied to every mock in the repo — see the .eslintrc.js note. Extend the
- * list rather than broadening the rule.
+ * list rather than broadening the rule. Specifiers are compared after
+ * canonicalisation, so the `~/utils/trpc` target also matches a template
+ * literal and an equivalent relative path (`../../utils/trpc`).
+ *
+ * Known gaps (deliberate, documented rather than papered over):
+ *   - a factory passed as an identifier (`vi.mock(mod, factoryFn)`) is not
+ *     analysed — the definition may be anywhere, and the shape is unused here;
+ *   - `modules` entries are matched per-module, not by glob;
+ *   - only files ESLint already covers (`src/`, `packages/`) are seen at all.
  *
  * Intentional exceptions should use:
  *   // eslint-disable-next-line local-rules/no-wholesale-module-mock -- <reason>
  */
 const DEFAULT_WHOLESALE_MOCK_MODULES = ['~/utils/trpc'];
 
-/** Is this `vi.mock(...)` / `vitest.mock(...)`? */
+/** Is this `vi.mock(...)` / `vitest.mock(...)` / `.doMock(...)`? */
 function isViMockCall(node) {
   const callee = node.callee;
   return (
@@ -236,10 +295,46 @@ function isViMockCall(node) {
   );
 }
 
+/** Is this `vi.importActual(...)` / `vitest.importActual(...)`? */
+function isImportActualCallee(callee) {
+  return (
+    callee &&
+    callee.type === 'MemberExpression' &&
+    callee.object &&
+    callee.object.type === 'Identifier' &&
+    (callee.object.name === 'vi' || callee.object.name === 'vitest') &&
+    callee.property &&
+    callee.property.type === 'Identifier' &&
+    callee.property.name === 'importActual'
+  );
+}
+
+/**
+ * Strip the wrappers that change an expression's TYPE but not its VALUE, so the
+ * shape underneath can be inspected. `return { trpc: {} } as any` must be read
+ * as the object literal it is — reaching for `as any` is the first thing an
+ * author does when fighting a squiggle, which makes it the likeliest bypass.
+ */
+function unwrapExpression(node) {
+  let current = node;
+  while (
+    current &&
+    (current.type === 'TSAsExpression' ||
+      current.type === 'TSSatisfiesExpression' ||
+      current.type === 'TSNonNullExpression' ||
+      current.type === 'TSTypeAssertion' ||
+      current.type === 'TSInstantiationExpression' ||
+      current.type === 'ChainExpression')
+  ) {
+    current = current.expression;
+  }
+  return current;
+}
+
 /**
  * Generic AST walk that does NOT descend into nested functions — so a
  * `return` belonging to an inner callback is never mistaken for the factory's
- * own return value.
+ * own return value, and an inner `const actual = ...` never leaks out.
  */
 function walkSkippingFunctions(node, visit) {
   if (!node || typeof node.type !== 'string') return;
@@ -262,12 +357,199 @@ function walkSkippingFunctions(node, visit) {
   }
 }
 
-/** Does this ObjectExpression have a top-level `...spread`? */
-function hasTopLevelSpread(objectExpression) {
-  return (
-    objectExpression.type === 'ObjectExpression' &&
-    objectExpression.properties.some((p) => p.type === 'SpreadElement')
-  );
+/** Read a static module specifier: a string literal or an expressionless template. */
+function readModuleSpecifier(node) {
+  if (!node) return null;
+  if (node.type === 'Literal' && typeof node.value === 'string') return node.value;
+  if (
+    node.type === 'TemplateLiteral' &&
+    node.expressions.length === 0 &&
+    node.quasis.length === 1
+  ) {
+    return node.quasis[0].value.cooked;
+  }
+  return null;
+}
+
+/**
+ * Reduce a module specifier to a comparable form so that the configured target
+ * `~/utils/trpc` also matches `` `~/utils/trpc` `` and `../../utils/trpc`.
+ *
+ * `~/x` is this repo's tsconfig alias for `src/x`, so both are reduced to their
+ * `src/`-relative path; a relative specifier is resolved against the linted
+ * file first. Anything that does not reduce (a bare package name, a path that
+ * resolves outside `src/`) is compared verbatim, which is the conservative
+ * outcome: it simply will not match a `~/`-style target.
+ */
+function stripModuleExtension(modulePath) {
+  return modulePath.replace(/\.(?:m|c)?[jt]sx?$/, '').replace(/\/index$/, '');
+}
+
+function canonicalModulePath(specifier, fromFile) {
+  if (typeof specifier !== 'string' || specifier.length === 0) return null;
+  if (specifier.startsWith('~/')) return stripModuleExtension(specifier.slice(2));
+  if (specifier.startsWith('./') || specifier.startsWith('../')) {
+    if (!fromFile) return null;
+    const posixFile = String(fromFile).split(pathSep).join('/');
+    const resolved = posixNormalize(`${posixDirname(posixFile)}/${specifier}`);
+    const marker = resolved.lastIndexOf('/src/');
+    if (marker !== -1) return stripModuleExtension(resolved.slice(marker + '/src/'.length));
+    // A repo-relative filename (RuleTester, or eslint invoked with relative paths)
+    // has no leading slash for the marker above to find.
+    if (resolved.startsWith('src/')) return stripModuleExtension(resolved.slice('src/'.length));
+    return null;
+  }
+  return stripModuleExtension(specifier);
+}
+
+// Tiny posix path helpers — `eslint-local-rules.js` is loaded by ESLint in
+// contexts where pulling in node:path is fine, but keeping these local makes
+// the reduction above explicit and platform-independent.
+const pathSep = require('path').sep;
+function posixDirname(p) {
+  const i = p.lastIndexOf('/');
+  return i === -1 ? '.' : p.slice(0, i) || '/';
+}
+function posixNormalize(p) {
+  const out = [];
+  for (const seg of p.split('/')) {
+    if (seg === '' || seg === '.') continue;
+    if (seg === '..') out.pop();
+    else out.push(seg);
+  }
+  return `${p.startsWith('/') ? '/' : ''}${out.join('/')}`;
+}
+
+/**
+ * Build the "does this expression carry the original module forward?" predicate
+ * for one factory. Everything it needs is factory-local: the `importOriginal`
+ * BINDING (the first parameter, whatever its name) and the factory's own
+ * top-level `const` initialisers.
+ */
+function createOriginalAnalyzer(factory, targetCanonical, filename) {
+  const firstParam = factory.params && factory.params[0];
+  const originalBinding = firstParam && firstParam.type === 'Identifier' ? firstParam.name : null;
+
+  // Local `const actual = await importOriginal()` bindings. A name that is
+  // declared twice or reassigned is poisoned: we can no longer say which value
+  // reaches the spread, and "unsure" must mean "report".
+  const locals = new Map();
+  const poisoned = new Set();
+  if (factory.body && factory.body.type === 'BlockStatement') {
+    walkSkippingFunctions(factory.body, (n) => {
+      if (n.type === 'VariableDeclarator' && n.id && n.id.type === 'Identifier') {
+        if (locals.has(n.id.name)) poisoned.add(n.id.name);
+        locals.set(n.id.name, n.init || null);
+      } else if (n.type === 'AssignmentExpression' && n.left && n.left.type === 'Identifier') {
+        poisoned.add(n.left.name);
+      } else if (
+        (n.type === 'UpdateExpression' || n.type === 'UnaryExpression') &&
+        n.argument &&
+        n.argument.type === 'Identifier'
+      ) {
+        poisoned.add(n.argument.name);
+      }
+    });
+  }
+
+  /** `importOriginal()` or `vi.importActual('<the module being mocked>')`. */
+  function isOriginalCall(call) {
+    if (call.type !== 'CallExpression') return false;
+    const callee = call.callee;
+    if (originalBinding && callee.type === 'Identifier' && callee.name === originalBinding) {
+      return true;
+    }
+    if (isImportActualCallee(callee)) {
+      // Must be the SAME module. `vi.importActual('~/utils/other')` spread into
+      // a `~/utils/trpc` mock leaves every trpc export missing.
+      const spec = readModuleSpecifier(call.arguments && call.arguments[0]);
+      return canonicalModulePath(spec, filename) === targetCanonical;
+    }
+    return false;
+  }
+
+  const seen = new Set();
+
+  function isOriginalPreserving(node) {
+    const expr = unwrapExpression(node);
+    if (!expr || typeof expr.type !== 'string') return false;
+    // Cycle guard: `let a = a` and friends must terminate, not blow the stack.
+    if (seen.has(expr)) return false;
+    seen.add(expr);
+    try {
+      switch (expr.type) {
+        case 'AwaitExpression':
+          return isOriginalPreserving(expr.argument);
+
+        case 'CallExpression': {
+          if (isOriginalCall(expr)) return true;
+          // `Object.assign(target, ...sources)` — every source's own enumerable
+          // keys land on the result, so one original-bearing argument is enough.
+          const callee = expr.callee;
+          if (
+            callee.type === 'MemberExpression' &&
+            callee.object &&
+            callee.object.type === 'Identifier' &&
+            callee.object.name === 'Object' &&
+            callee.property &&
+            callee.property.type === 'Identifier' &&
+            callee.property.name === 'assign'
+          ) {
+            return (expr.arguments || []).some(
+              (arg) => arg.type !== 'SpreadElement' && isOriginalPreserving(arg)
+            );
+          }
+          return false;
+        }
+
+        case 'ObjectExpression':
+          return expr.properties.some(
+            (p) => p.type === 'SpreadElement' && isOriginalPreserving(p.argument)
+          );
+
+        case 'Identifier': {
+          if (poisoned.has(expr.name) || !locals.has(expr.name)) return false;
+          const init = locals.get(expr.name);
+          return init ? isOriginalPreserving(init) : false;
+        }
+
+        case 'ConditionalExpression':
+          // Either branch can be the value, so BOTH must be safe.
+          return isOriginalPreserving(expr.consequent) && isOriginalPreserving(expr.alternate);
+
+        case 'LogicalExpression':
+          return isOriginalPreserving(expr.left) && isOriginalPreserving(expr.right);
+
+        case 'SequenceExpression':
+          return isOriginalPreserving(expr.expressions[expr.expressions.length - 1]);
+
+        default:
+          // ImportExpression (`await import('~/utils/trpc')` returns the MOCK,
+          // not the original), member access, `new`, template literals, ...
+          return false;
+      }
+    } finally {
+      seen.delete(expr);
+    }
+  }
+
+  return isOriginalPreserving;
+}
+
+/**
+ * Every expression the factory itself can return. `null` marks a bare `return;`
+ * or a block with no reachable `return` at all — both hand Vitest `undefined`,
+ * which is as wholesale as it gets.
+ */
+function collectFactoryReturns(factory) {
+  if (!factory.body) return [null];
+  if (factory.body.type !== 'BlockStatement') return [factory.body];
+
+  const returns = [];
+  walkSkippingFunctions(factory.body, (n) => {
+    if (n.type === 'ReturnStatement') returns.push(n.argument || null);
+  });
+  return returns.length ? returns : [null];
 }
 
 const noWholesaleModuleMock = {
@@ -275,7 +557,7 @@ const noWholesaleModuleMock = {
     type: 'problem',
     docs: {
       description:
-        "Require vi.mock factories for sensitive modules to spread the real module via importOriginal — a wholesale factory breaks the whole test FILE (0 tests collected) the day the module gains an export it omits.",
+        'Require vi.mock factories for sensitive modules to spread the real module via importOriginal — a wholesale factory breaks the whole test FILE (0 tests collected) the day the module gains an export it omits.',
       recommended: true,
     },
     schema: [
@@ -289,63 +571,60 @@ const noWholesaleModuleMock = {
     ],
     messages: {
       wholesaleMock:
-        "Wholesale vi.mock('{{module}}') factory — it replaces the module with a hand-written object, so the day '{{module}}' gains an export this factory omits, every importer in this test's module graph gets `undefined` and the whole FILE fails to load: 0 tests collected, no failing assertion, silently 'green' (this disabled ~36 tests via `trpcVanilla`). Spread the real module and override only what you need: add `import type * as Mod from '{{module}}';` then `vi.mock('{{module}}', async (importOriginal) => ({ ...(await importOriginal<typeof Mod>()), /* overrides */ }));` — use the type-only namespace import, NOT `typeof import('...')`, which @typescript-eslint/consistent-type-imports rejects. Canonical example: src/components/Challenge/__tests__/ChallengeUpsertForm.browser.test.tsx",
+        "Wholesale vi.mock('{{module}}') factory — it replaces the module with a hand-written object, so the day '{{module}}' gains an export this factory omits, every importer in this test's module graph gets `undefined` and the whole FILE fails to load: 0 tests collected, no failing assertion, silently 'green' (this disabled ~36 tests via `trpcVanilla`). TypeScript cannot catch it — the factory's return is typed `Partial<unknown>`. Spread the real module and override only what you need: add `import type * as Mod from '{{module}}';` then `vi.mock('{{module}}', async (importOriginal) => ({ ...(await importOriginal<typeof Mod>()), /* overrides */ }));` — use the type-only namespace import, NOT `typeof import('...')`, which @typescript-eslint/consistent-type-imports rejects. Canonical example: src/components/Challenge/__tests__/ChallengeUpsertForm.browser.test.tsx",
+      unprovableMock:
+        "vi.mock('{{module}}') factory returns a value this rule cannot prove carries the real module's exports ({{shape}}). That is reported rather than assumed safe: if '{{module}}' gains an export the factory omits, the whole test FILE fails to load and collects 0 tests with nothing turning red. Return an object literal that spreads the original directly — `vi.mock('{{module}}', async (importOriginal) => ({ ...(await importOriginal<typeof Mod>()), /* overrides */ }))` (with `import type * as Mod from '{{module}}';`) — so the spread is visible statically. Note `... as any` / `satisfies` do not change this; the spread itself is what has to be there. If this factory really is safe, silence it explicitly: `// eslint-disable-next-line local-rules/no-wholesale-module-mock -- <reason>`. Canonical example: src/components/Challenge/__tests__/ChallengeUpsertForm.browser.test.tsx",
     },
   },
   create(context) {
     const options = context.options[0] || {};
-    const targets = new Set(options.modules || DEFAULT_WHOLESALE_MOCK_MODULES);
-    const sourceCode = context.sourceCode || context.getSourceCode();
+    const filename = (context.filename || (context.getFilename && context.getFilename())) ?? null;
+    const targets = new Set(
+      (options.modules || DEFAULT_WHOLESALE_MOCK_MODULES)
+        .map((m) => canonicalModulePath(m, filename))
+        .filter(Boolean)
+    );
 
     return {
       CallExpression(node) {
         if (!isViMockCall(node)) return;
 
         const [moduleArg, factory] = node.arguments;
-        if (!moduleArg || moduleArg.type !== 'Literal' || !targets.has(moduleArg.value)) return;
-        // `vi.mock('mod')` (automock) keeps the real export shape — nothing to do.
-        if (
-          !factory ||
-          (factory.type !== 'ArrowFunctionExpression' && factory.type !== 'FunctionExpression')
-        ) {
+        const specifier = readModuleSpecifier(moduleArg);
+        const targetCanonical = canonicalModulePath(specifier, filename);
+        if (!targetCanonical || !targets.has(targetCanonical)) return;
+
+        // Only an inline function factory is analysable. Everything else here
+        // is intentionally left alone:
+        //   - `vi.mock('mod')` (automock) and `vi.mock('mod', { spy: true })`
+        //     keep the real export shape by construction;
+        //   - a factory passed by reference (`vi.mock('mod', makeFactory)`) is
+        //     the documented gap above — its definition may be anywhere.
+        if (!factory) return;
+        if (factory.type !== 'ArrowFunctionExpression' && factory.type !== 'FunctionExpression') {
           return;
         }
 
-        // The factory must actually reach for the original module. A spread of
-        // a locally-built object is not a fix, so check this over the factory
-        // subtree only (a sibling mock's `importActual` must not count).
-        const factoryText = sourceCode.getText(factory);
-        const usesOriginal =
-          /\bimportOriginal\b/.test(factoryText) || /\bimportActual\b/.test(factoryText);
+        const isOriginalPreserving = createOriginalAnalyzer(factory, targetCanonical, filename);
 
-        // Collect the object literal(s) the factory itself returns.
-        const returnedObjects = [];
-        if (factory.body.type === 'ObjectExpression') {
-          returnedObjects.push(factory.body); // concise arrow: () => ({ ... })
-        } else if (factory.body.type !== 'BlockStatement') {
-          // Concise body that isn't an object literal, e.g. `() => makeMock()`
-          // (wholesale, still caught below via `usesOriginal`) or
-          // `async (importOriginal) => importOriginal()` (a full passthrough).
-        } else {
-          walkSkippingFunctions(factory.body, (n) => {
-            if (n.type === 'ReturnStatement' && n.argument) returnedObjects.push(n.argument);
-          });
+        let wholesale = false;
+        let unprovable = null;
+        for (const returned of collectFactoryReturns(factory)) {
+          if (returned && isOriginalPreserving(returned)) continue;
+          const shape = returned ? unwrapExpression(returned) : null;
+          if (shape && shape.type === 'ObjectExpression') {
+            wholesale = true;
+          } else if (!unprovable) {
+            unprovable = shape ? shape.type : 'no return value';
+          }
         }
 
-        // Safe iff the factory reaches for the original AND every object
-        // literal it returns spreads at the top level. When it returns no
-        // object literal at all there is nothing to inspect, so `importOriginal`
-        // usage alone is the signal (e.g. a straight passthrough).
-        const objectLiterals = returnedObjects.filter((n) => n.type === 'ObjectExpression');
-        const spreadsOriginal =
-          usesOriginal && (objectLiterals.length === 0 || objectLiterals.every(hasTopLevelSpread));
-
-        if (spreadsOriginal) return;
+        if (!wholesale && !unprovable) return;
 
         context.report({
           node,
-          messageId: 'wholesaleMock',
-          data: { module: String(moduleArg.value) },
+          messageId: wholesale ? 'wholesaleMock' : 'unprovableMock',
+          data: { module: specifier, shape: unprovable || 'ObjectExpression' },
         });
       },
     };

--- a/eslint-local-rules.js
+++ b/eslint-local-rules.js
@@ -271,9 +271,29 @@ const noIoInTransaction = {
  *
  * Known gaps (deliberate, documented rather than papered over):
  *   - a factory passed as an identifier (`vi.mock(mod, factoryFn)`) is not
- *     analysed — the definition may be anywhere, and the shape is unused here;
+ *     analysed — the definition may be anywhere, and the shape is unused here.
+ *     DO NOT reach for it to get past this rule: `const f = () => ({ trpc: {} });
+ *     vi.mock('~/utils/trpc', f)` is silently accepted and, unlike a disable
+ *     comment, leaves NOTHING for a reviewer or a later grep to find. If a
+ *     factory genuinely has to be exempt, use the disable comment below — it is
+ *     greppable and it carries your reason;
  *   - `modules` entries are matched per-module, not by glob;
  *   - only files ESLint already covers (`src/`, `packages/`) are seen at all.
+ *
+ * Known FALSE POSITIVES — safe shapes the analysis cannot walk, so they report
+ * `unprovableMock`. None exist in the tree today; they are listed so an author
+ * who hits one recognises their own shape and reaches for the disable comment
+ * instead of reshaping working code (or switching the rule off):
+ *   - destructure-and-rebuild: `const { trpc, ...rest } = await importOriginal();
+ *     return { ...rest, trpc: {} }` — `rest` comes from a destructuring pattern,
+ *     not an initialiser this rule tracks;
+ *   - `const [actual] = await Promise.all([importOriginal()])` — same reason;
+ *   - an aliased binding: `const f = importOriginal; return { ...(await f()) }`
+ *     — only the parameter itself is recognised as the original call;
+ *   - the `vi.hoisted` idiom, where the spread source is built outside the
+ *     factory entirely.
+ * Each is a one-line disable away, which is the intended cost: a false positive
+ * costs a comment, a false negative costs a silently-empty test suite.
  *
  * Intentional exceptions should use:
  *   // eslint-disable-next-line local-rules/no-wholesale-module-mock -- <reason>
@@ -380,6 +400,15 @@ function readModuleSpecifier(node) {
  * file first. Anything that does not reduce (a bare package name, a path that
  * resolves outside `src/`) is compared verbatim, which is the conservative
  * outcome: it simply will not match a `~/`-style target.
+ *
+ * The `src/` that `~` aliases is the ONE at the repo root — the directory
+ * beside this file — not any `src/` anywhere in the path. A workspace package
+ * has its own: from `packages/blocks-react/src/foo/x.test.tsx`, the specifier
+ * `../utils/trpc` means `packages/blocks-react/src/utils/trpc`, a DIFFERENT
+ * module from `~/utils/trpc`, and matching it would flag a file for mocking
+ * something the rule was never pointed at. Resolving against `REPO_SRC` rather
+ * than "the last `/src/` in the string" keeps the alias inside its own package
+ * boundary.
  */
 function stripModuleExtension(modulePath) {
   return modulePath.replace(/\.(?:m|c)?[jt]sx?$/, '').replace(/\/index$/, '');
@@ -392,10 +421,16 @@ function canonicalModulePath(specifier, fromFile) {
     if (!fromFile) return null;
     const posixFile = String(fromFile).split(pathSep).join('/');
     const resolved = posixNormalize(`${posixDirname(posixFile)}/${specifier}`);
-    const marker = resolved.lastIndexOf('/src/');
-    if (marker !== -1) return stripModuleExtension(resolved.slice(marker + '/src/'.length));
-    // A repo-relative filename (RuleTester, or eslint invoked with relative paths)
-    // has no leading slash for the marker above to find.
+    // Absolute (how ESLint actually invokes the rule): must land under the
+    // repo's OWN src/, not a workspace package's.
+    if (resolved.startsWith('/')) {
+      return resolved.startsWith(`${REPO_SRC}/`)
+        ? stripModuleExtension(resolved.slice(REPO_SRC.length + 1))
+        : null;
+    }
+    // A repo-relative filename (RuleTester, or eslint invoked with relative
+    // paths) is already rooted at the repo, so a leading `src/` is the alias
+    // root and a leading `packages/` is not.
     if (resolved.startsWith('src/')) return stripModuleExtension(resolved.slice('src/'.length));
     return null;
   }
@@ -406,6 +441,9 @@ function canonicalModulePath(specifier, fromFile) {
 // contexts where pulling in node:path is fine, but keeping these local makes
 // the reduction above explicit and platform-independent.
 const pathSep = require('path').sep;
+// The repo root is this file's own directory (ESLint loads `eslint-local-rules`
+// from it), so `<root>/src` is exactly what the `~` alias points at.
+const REPO_SRC = require('path').resolve(__dirname, 'src').split(pathSep).join('/');
 function posixDirname(p) {
   const i = p.lastIndexOf('/');
   return i === -1 ? '.' : p.slice(0, i) || '/';
@@ -427,7 +465,13 @@ function posixNormalize(p) {
  * top-level `const` initialisers.
  */
 function createOriginalAnalyzer(factory, targetCanonical, filename) {
-  const firstParam = factory.params && factory.params[0];
+  // The first parameter IS importOriginal, whatever it is named. A default
+  // value (`async (importOriginal = x) => ...`) parses as an AssignmentPattern
+  // wrapping the identifier, so unwrap that too — otherwise a correct factory
+  // written with a default is reported. A destructured or rest parameter has no
+  // single binding to call, and stays unrecognised.
+  let firstParam = factory.params && factory.params[0];
+  if (firstParam && firstParam.type === 'AssignmentPattern') firstParam = firstParam.left;
   const originalBinding = firstParam && firstParam.type === 'Identifier' ? firstParam.name : null;
 
   // Local `const actual = await importOriginal()` bindings. A name that is
@@ -442,12 +486,25 @@ function createOriginalAnalyzer(factory, targetCanonical, filename) {
         locals.set(n.id.name, n.init || null);
       } else if (n.type === 'AssignmentExpression' && n.left && n.left.type === 'Identifier') {
         poisoned.add(n.left.name);
-      } else if (
-        (n.type === 'UpdateExpression' || n.type === 'UnaryExpression') &&
-        n.argument &&
-        n.argument.type === 'Identifier'
-      ) {
+      } else if (n.type === 'UpdateExpression' && n.argument && n.argument.type === 'Identifier') {
+        // `actual++` / `--actual` rebinds the name to a number.
         poisoned.add(n.argument.name);
+      } else if (n.type === 'UnaryExpression' && n.operator === 'delete') {
+        // `delete actual.trpcVanilla` is the ONLY unary that mutates, and it is
+        // precisely the historical bug: the spread still looks right, but an
+        // export has been removed from the object being spread. Every other
+        // unary on a bare identifier — `!actual`, `typeof actual`, `void actual`,
+        // `-actual` — reads the value and cannot change it, so it must NOT
+        // poison: `if (!actual) throw ...` is correct defensive code and used to
+        // be reported.
+        let target = n.argument;
+        while (
+          target &&
+          (target.type === 'MemberExpression' || target.type === 'ChainExpression')
+        ) {
+          target = target.type === 'ChainExpression' ? target.expression : target.object;
+        }
+        if (target && target.type === 'Identifier') poisoned.add(target.name);
       }
     });
   }
@@ -495,9 +552,11 @@ function createOriginalAnalyzer(factory, targetCanonical, filename) {
             callee.property.type === 'Identifier' &&
             callee.property.name === 'assign'
           ) {
-            return (expr.arguments || []).some(
-              (arg) => arg.type !== 'SpreadElement' && isOriginalPreserving(arg)
-            );
+            // A `...sources` argument needs no special case: `SpreadElement`
+            // is not an expression type this analysis accepts, so it falls
+            // through to `false` on its own. (An explicit exclusion here was
+            // redundant — no input could distinguish it.)
+            return (expr.arguments || []).some((arg) => isOriginalPreserving(arg));
           }
           return false;
         }
@@ -571,7 +630,7 @@ const noWholesaleModuleMock = {
     ],
     messages: {
       wholesaleMock:
-        "Wholesale vi.mock('{{module}}') factory — it replaces the module with a hand-written object, so the day '{{module}}' gains an export this factory omits, every importer in this test's module graph gets `undefined` and the whole FILE fails to load: 0 tests collected, no failing assertion, silently 'green' (this disabled ~36 tests via `trpcVanilla`). TypeScript cannot catch it — the factory's return is typed `Partial<unknown>`. Spread the real module and override only what you need: add `import type * as Mod from '{{module}}';` then `vi.mock('{{module}}', async (importOriginal) => ({ ...(await importOriginal<typeof Mod>()), /* overrides */ }));` — use the type-only namespace import, NOT `typeof import('...')`, which @typescript-eslint/consistent-type-imports rejects. Canonical example: src/components/Challenge/__tests__/ChallengeUpsertForm.browser.test.tsx",
+        "Wholesale vi.mock('{{module}}') factory — it replaces the module with a hand-written object, so the day '{{module}}' gains an export this factory omits, every importer in this test's module graph gets `undefined` and the whole FILE fails to load: 0 tests collected, no failing assertion, silently 'green' (this disabled ~36 tests via `trpcVanilla`). TypeScript cannot catch it — the factory's return is typed `Partial<unknown>`. Spread the real module and override only what you need: add `import type * as Mod from '{{module}}';` then `vi.mock('{{module}}', async (importOriginal) => ({ ...(await importOriginal<typeof Mod>()), /* overrides */ }));` — use the type-only namespace import, NOT `typeof import('...')`, which @typescript-eslint/consistent-type-imports rejects. If this factory really is intentional and safe, silence it explicitly rather than reshaping it: `// eslint-disable-next-line local-rules/no-wholesale-module-mock -- <reason>`. Canonical example: src/components/Challenge/__tests__/ChallengeUpsertForm.browser.test.tsx",
       unprovableMock:
         "vi.mock('{{module}}') factory returns a value this rule cannot prove carries the real module's exports ({{shape}}). That is reported rather than assumed safe: if '{{module}}' gains an export the factory omits, the whole test FILE fails to load and collects 0 tests with nothing turning red. Return an object literal that spreads the original directly — `vi.mock('{{module}}', async (importOriginal) => ({ ...(await importOriginal<typeof Mod>()), /* overrides */ }))` (with `import type * as Mod from '{{module}}';`) — so the spread is visible statically. Note `... as any` / `satisfies` do not change this; the spread itself is what has to be there. If this factory really is safe, silence it explicitly: `// eslint-disable-next-line local-rules/no-wholesale-module-mock -- <reason>`. Canonical example: src/components/Challenge/__tests__/ChallengeUpsertForm.browser.test.tsx",
     },
@@ -607,13 +666,31 @@ const noWholesaleModuleMock = {
 
         const isOriginalPreserving = createOriginalAnalyzer(factory, targetCanonical, filename);
 
+        // Classify each un-provable return so the AUTHOR gets advice they can
+        // act on. The split is "did you even try to spread?":
+        //
+        //   no top-level spread at all -> `wholesaleMock`, whose advice is
+        //     "spread the real module" — exactly what is missing;
+        //   a spread the analysis cannot walk to the original (`...localStub`,
+        //     `...(actual ?? {})`, `...(await import('./elsewhere'))`), or any
+        //     non-object return -> `unprovableMock`, which says the spread is
+        //     unprovable and names the escape hatch.
+        //
+        // Telling an author who ALREADY spreads to "spread the real module" is
+        // how a rule gets switched off, and at 'error' that advice blocks them.
         let wholesale = false;
         let unprovable = null;
         for (const returned of collectFactoryReturns(factory)) {
           if (returned && isOriginalPreserving(returned)) continue;
           const shape = returned ? unwrapExpression(returned) : null;
           if (shape && shape.type === 'ObjectExpression') {
-            wholesale = true;
+            const spreads = shape.properties.filter((p) => p.type === 'SpreadElement');
+            if (spreads.length === 0) {
+              wholesale = true;
+            } else if (!unprovable) {
+              unprovable =
+                'an object literal whose spread does not provably carry the original module';
+            }
           } else if (!unprovable) {
             unprovable = shape ? shape.type : 'no return value';
           }

--- a/src/components/Announcements/AnnouncementEditModal.browser.test.tsx
+++ b/src/components/Announcements/AnnouncementEditModal.browser.test.tsx
@@ -1,6 +1,7 @@
 import { describe, expect, test, vi, beforeEach } from 'vitest';
 // `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
 import { renderWithProviders } from '../../../test/component-setup';
+import type * as TrpcModule from '~/utils/trpc';
 
 /**
  * The announcement banner cannot be destroyed by an interrupted or failed upload.
@@ -50,7 +51,7 @@ vi.mock('~/hooks/useCFImageUpload', async () => {
 // Partial mock: other modules in the graph import unrelated named exports from here
 // (`setTrpcBatchingEnabled`), and replacing the module wholesale breaks their import.
 vi.mock('~/utils/trpc', async (importOriginal) => ({
-  ...(await importOriginal<Record<string, unknown>>()),
+  ...(await importOriginal<typeof TrpcModule>()),
   trpc: {
     useUtils: () => ({
       announcement: { getAnnouncementsPaged: { invalidate: vi.fn() } },

--- a/src/components/Apps/CombinedReviewModal.browser.test.tsx
+++ b/src/components/Apps/CombinedReviewModal.browser.test.tsx
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { page } from 'vitest/browser';
 // `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
 import { renderWithProviders } from '../../../test/component-setup';
+import type * as TrpcModule from '~/utils/trpc';
 
 /**
  * The COMBINED code + listing-media review surface (Item 4) — browser-mode render
@@ -155,7 +156,7 @@ vi.mock('~/utils/notifications', () => ({
 // Without the spread, a LATER PR adding an export to `~/utils/trpc` breaks this file's ESM
 // link ("does not provide an export named X") and the whole file collects 0 tests.
 vi.mock('~/utils/trpc', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('~/utils/trpc')>();
+  const actual = await importOriginal<typeof TrpcModule>();
   const mutation =
     (name: string) =>
     (opts?: { onSuccess?: () => void; onError?: (e: { message: string }) => void }) => ({

--- a/src/components/Apps/ConnectScopesPanel.browser.test.tsx
+++ b/src/components/Apps/ConnectScopesPanel.browser.test.tsx
@@ -3,6 +3,7 @@ import { page } from 'vitest/browser';
 // `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
 import { renderWithProviders } from '../../../test/component-setup';
 import { TokenScope } from '~/shared/constants/token-scope.constants';
+import type * as TrpcModule from '~/utils/trpc';
 
 /**
  * PR3 — OAuth-connect mod review UI. Two seams:
@@ -32,7 +33,7 @@ vi.mock('~/utils/notifications', () => ({
 // Without the spread, a LATER PR adding an export to `~/utils/trpc` breaks this file's ESM
 // link ("does not provide an export named X") and the whole file collects 0 tests.
 vi.mock('~/utils/trpc', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('~/utils/trpc')>();
+  const actual = await importOriginal<typeof TrpcModule>();
   const mutation = () => ({ mutate: vi.fn(), mutateAsync: vi.fn(), isPending: false });
   return {
     ...actual,

--- a/src/components/Apps/OffsiteReportsQueue.browser.test.tsx
+++ b/src/components/Apps/OffsiteReportsQueue.browser.test.tsx
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { page } from 'vitest/browser';
 // `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
 import { renderWithProviders } from '../../../test/component-setup';
+import type * as TrpcModule from '~/utils/trpc';
 
 /**
  * /apps/review reports queue — the `ReportActionModal` now routes its reason field +
@@ -46,7 +47,7 @@ vi.mock('~/utils/notifications', () => ({
 // Without the spread, a LATER PR adding an export to `~/utils/trpc` breaks this file's ESM
 // link ("does not provide an export named X") and the whole file collects 0 tests.
 vi.mock('~/utils/trpc', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('~/utils/trpc')>();
+  const actual = await importOriginal<typeof TrpcModule>();
   const mutation =
     (name: string) =>
     (opts?: { onSuccess?: () => void; onError?: (e: { message: string }) => void }) => ({

--- a/src/components/Apps/OffsiteReviewQueue.browser.test.tsx
+++ b/src/components/Apps/OffsiteReviewQueue.browser.test.tsx
@@ -3,6 +3,7 @@ import { page } from 'vitest/browser';
 import { formatDate } from '~/utils/date-helpers';
 // `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
 import { renderWithProviders } from '../../../test/component-setup';
+import type * as TrpcModule from '~/utils/trpc';
 
 /**
  * W13 P3a — /apps/review off-site (external-link) queue. Browser-mode render test
@@ -68,7 +69,7 @@ vi.mock('~/utils/notifications', () => ({
 // Without the spread, a LATER PR adding an export to `~/utils/trpc` breaks this file's ESM
 // link ("does not provide an export named X") and the whole file collects 0 tests.
 vi.mock('~/utils/trpc', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('~/utils/trpc')>();
+  const actual = await importOriginal<typeof TrpcModule>();
   return {
     ...actual,
     trpc: {

--- a/src/server/services/__tests__/no-wholesale-module-mock.test.ts
+++ b/src/server/services/__tests__/no-wholesale-module-mock.test.ts
@@ -15,13 +15,18 @@ const ruleTesterConfig: Record<string, unknown> = {
   parser: require.resolve('@typescript-eslint/parser'),
   parserOptions: { ecmaVersion: 'latest', sourceType: 'module' },
 };
-const ruleTester = new RuleTester(
-  ruleTesterConfig as ConstructorParameters<typeof RuleTester>[0]
-);
+const ruleTester = new RuleTester(ruleTesterConfig as ConstructorParameters<typeof RuleTester>[0]);
+
+// A realistic `src/`-relative filename, needed by the cases that use a RELATIVE
+// module specifier: the rule resolves those against the linted file before
+// comparing them with the configured `~/utils/trpc` target.
+const TEST_FILE = 'src/components/Foo/__tests__/foo.browser.test.tsx';
 
 ruleTester.run('no-wholesale-module-mock', rule, {
   valid: [
-    // ---- The canonical pattern (ChallengeUpsertForm.browser.test.tsx) ----
+    // ================================================================
+    // The canonical pattern, in each spelling that appears in the repo
+    // ================================================================
     // Block body: await importOriginal() into a local, spread it in the return.
     `vi.mock('~/utils/trpc', async (importOriginal) => {
        const actual = await importOriginal<typeof import('~/utils/trpc')>();
@@ -46,12 +51,92 @@ ruleTester.run('no-wholesale-module-mock', rule, {
        const actual = await vi.importActual<typeof import('~/utils/trpc')>('~/utils/trpc');
        return { ...actual, trpc: {} };
      });`,
+    // A `function` expression factory, not just an arrow.
+    `vi.mock('~/utils/trpc', async function (importOriginal) {
+       const actual = await importOriginal();
+       return { ...actual, trpc: {} };
+     });`,
     // Straight passthrough — returns the original, no object literal to inspect.
     `vi.mock('~/utils/trpc', async (importOriginal) => importOriginal());`,
     // Automock (no factory) preserves the real export shape by construction.
     `vi.mock('~/utils/trpc');`,
+    // Vitest's options form (`{ spy: true }`) also keeps the real module.
+    `vi.mock('~/utils/trpc', { spy: true });`,
 
-    // ---- Out of scope: other modules ----
+    // ================================================================
+    // 🔴 The `importOriginal` BINDING is what matters, not the token
+    // ================================================================
+    // Regression guard, and the reason the textual check had to go: the factory
+    // parameter IS importOriginal whatever it is named. A rule that greps the
+    // factory source for /\bimportOriginal\b/ REJECTS this correct code — the
+    // textual check was wrong in both directions, not merely permissive.
+    `vi.mock('~/utils/trpc', async (orig) => ({ ...(await orig()), trpc: {} }));`,
+
+    // ================================================================
+    // Return shapes that are unusual but still provably safe
+    // ================================================================
+    // `as any` / `satisfies` over a return that DOES spread the original: the
+    // type wrapper is unwrapped, and the spread underneath is found.
+    `vi.mock('~/utils/trpc', async (importOriginal) => {
+       const actual = await importOriginal();
+       return { ...actual, trpc: {} } as any;
+     });`,
+    `vi.mock('~/utils/trpc', async (importOriginal) => {
+       const actual = await importOriginal();
+       return { ...actual, trpc: {} } satisfies Record<string, unknown>;
+     });`,
+    // Object.assign with the original as a source: every source's keys land on
+    // the result, so the export surface is preserved.
+    `vi.mock('~/utils/trpc', async (importOriginal) =>
+       Object.assign({}, await importOriginal(), { trpc: {} }));`,
+    // Returning a local whose initialiser spreads the original.
+    `vi.mock('~/utils/trpc', async (importOriginal) => {
+       const actual = await importOriginal();
+       const out = { ...actual, trpc: {} };
+       return out;
+     });`,
+    // Spread of a local that itself spreads the original (one hop further).
+    `vi.mock('~/utils/trpc', async (importOriginal) => {
+       const actual = await importOriginal();
+       const base = { ...actual };
+       return { ...base, trpc: {} };
+     });`,
+    // Both branches of a ternary spread the original.
+    `vi.mock('~/utils/trpc', async (importOriginal) => {
+       const actual = await importOriginal();
+       return flag ? { ...actual, trpc: {} } : { ...actual, trpc: {} };
+     });`,
+    // Every return path spreads the original.
+    `vi.mock('~/utils/trpc', async (importOriginal) => {
+       const actual = await importOriginal();
+       if (flag) return { ...actual, trpc: { a: 1 } };
+       return { ...actual, trpc: { b: 2 } };
+     });`,
+
+    // ================================================================
+    // Specifier forms
+    // ================================================================
+    // Template literal with no expressions is the same specifier.
+    {
+      code: 'vi.mock(`~/utils/trpc`, async (importOriginal) => ({ ...(await importOriginal()), trpc: {} }));',
+      filename: TEST_FILE,
+    },
+    // A relative specifier that resolves to the SAME module, done correctly.
+    {
+      code: `vi.mock('../../../utils/trpc', async (importOriginal) => ({ ...(await importOriginal()), trpc: {} }));`,
+      filename: TEST_FILE,
+    },
+    // A relative specifier that resolves to a DIFFERENT module must not fire,
+    // even though it is wholesale — the rule is scoped, and over-reach is what
+    // gets a rule switched off.
+    {
+      code: `vi.mock('../../../utils/other', () => ({ trpc: {} }));`,
+      filename: TEST_FILE,
+    },
+
+    // ================================================================
+    // Out of scope
+    // ================================================================
     // The rule is scoped to its `modules` option (default just ~/utils/trpc);
     // a wholesale mock of any other module must NOT fire. This is what keeps
     // the rule quiet enough to stay enabled.
@@ -59,10 +144,16 @@ ruleTester.run('no-wholesale-module-mock', rule, {
     `vi.mock('@mantine/hooks', () => ({ useMediaQuery: () => false }));`,
     // Non-literal specifier (computed) — nothing to match against.
     `vi.mock(SOME_MODULE, () => ({ trpc: {} }));`,
+    // Template literal WITH an expression is not statically readable.
+    'vi.mock(`~/utils/${name}`, () => ({ trpc: {} }));',
     // Not a vi.mock call at all.
     `foo.mock('~/utils/trpc', () => ({ trpc: {} }));`,
+    // Documented gap: a factory passed by reference is not analysed.
+    `vi.mock('~/utils/trpc', makeTrpcFactory);`,
 
-    // ---- Nested-function isolation ----
+    // ================================================================
+    // Nested-function isolation
+    // ================================================================
     // A `return` inside an inner callback must not be mistaken for the
     // factory's own return value; the factory's real return spreads correctly.
     `vi.mock('~/utils/trpc', async (importOriginal) => {
@@ -71,8 +162,11 @@ ruleTester.run('no-wholesale-module-mock', rule, {
        return { ...actual, trpc: { model: { getAll: { useQuery } } } };
      });`,
   ],
+
   invalid: [
-    // ---- The exact shape that broke five suites / ~36 tests ----
+    // ================================================================
+    // The exact shape that broke five suites / ~36 tests
+    // ================================================================
     // Concise arrow returning a hand-written object (AppEditPage.browser.test.tsx).
     {
       code: `vi.mock('~/utils/trpc', () => ({ trpc: { blocks: { getMyAppManifest: { useQuery: () => ({}) } }, useUtils: () => ({}) } }));`,
@@ -108,6 +202,135 @@ ruleTester.run('no-wholesale-module-mock', rule, {
       code: `vitest.mock('~/utils/trpc', () => ({ trpc: {} }));`,
       errors: [{ messageId: 'wholesaleMock' }],
     },
+
+    // ================================================================
+    // 🔴 Laundering the TEXTUAL check — the token is present, the
+    //    original module is not. Every one of these PASSED the first
+    //    cut of this rule, which grepped the factory source.
+    // ================================================================
+    // An unused parameter named `importOriginal` satisfied the regex. This is
+    // the sharpest one: it is the rule's own minimal invalid case plus a single
+    // word, and it is one keystroke away from any of the backlog factories.
+    {
+      code: `vi.mock('~/utils/trpc', (importOriginal) => ({ ...localStub, trpc: {} }));`,
+      errors: [{ messageId: 'wholesaleMock' }],
+    },
+    // A COMMENT mentioning importOriginal satisfied it too — and a large share
+    // of the existing backlog factories already carry an explanatory comment.
+    {
+      code: `vi.mock('~/utils/trpc', () => ({ /* TODO: switch to importOriginal */ ...localStub, trpc: {} }));`,
+      errors: [{ messageId: 'wholesaleMock' }],
+    },
+    // ...as did the bare string, anywhere in the factory.
+    {
+      code: `vi.mock('~/utils/trpc', () => ({ note: 'importOriginal', ...localStub, trpc: {} }));`,
+      errors: [{ messageId: 'wholesaleMock' }],
+    },
+    // Spreading a dynamic import of some OTHER module is not the original.
+    {
+      code: `vi.mock('~/utils/trpc', async (importOriginal) => ({ ...(await import('./elsewhere')), trpc: {} }));`,
+      errors: [{ messageId: 'wholesaleMock' }],
+    },
+    // `vi.importActual` of a DIFFERENT module leaves every trpc export missing.
+    {
+      code: `vi.mock('~/utils/trpc', async () => ({ ...(await vi.importActual('~/utils/other')), trpc: {} }));`,
+      errors: [{ messageId: 'wholesaleMock' }],
+    },
+    // A dynamic import of the module being mocked is a SELF-reference: Vitest
+    // serves the mock, not the original. Only importOriginal/importActual work.
+    {
+      code: `vi.mock('~/utils/trpc', async () => ({ ...(await import('~/utils/trpc')), trpc: {} }));`,
+      errors: [{ messageId: 'wholesaleMock' }],
+    },
+
+    // ================================================================
+    // 🔴 Return shapes that bypassed "no object literal ⇒ assume safe"
+    // ================================================================
+    // `as any` is the idiomatic first reach when fighting a type squiggle in
+    // this repo, which makes it the likeliest accidental bypass.
+    {
+      code: `vi.mock('~/utils/trpc', async (importOriginal) => {
+         const actual = await importOriginal();
+         return { trpc: {} } as any;
+       });`,
+      errors: [{ messageId: 'wholesaleMock' }],
+    },
+    {
+      code: `vi.mock('~/utils/trpc', async (importOriginal) => {
+         const actual = await importOriginal();
+         return { trpc: {} } satisfies Record<string, unknown>;
+       });`,
+      errors: [{ messageId: 'wholesaleMock' }],
+    },
+    // Returning a local built without the original.
+    {
+      code: `vi.mock('~/utils/trpc', async (importOriginal) => {
+         const actual = await importOriginal();
+         const out = { trpc: {} };
+         return out;
+       });`,
+      errors: [{ messageId: 'unprovableMock' }],
+    },
+    // Object.assign with no original-bearing source.
+    {
+      code: `vi.mock('~/utils/trpc', async (importOriginal) => Object.assign({}, { trpc: {} }));`,
+      errors: [{ messageId: 'unprovableMock' }],
+    },
+    // A logical expression where one side is a bare hand-written object.
+    {
+      code: `vi.mock('~/utils/trpc', async (importOriginal) => cached || { trpc: {} });`,
+      errors: [{ messageId: 'unprovableMock' }],
+    },
+    // ...and the memoised variant where the SAFE side is the fallback: `cached`
+    // is an unknown value that can be the result, so a correct-looking
+    // right-hand side does not redeem it. Both sides have to be provable.
+    {
+      code: `vi.mock('~/utils/trpc', async (importOriginal) => {
+         const actual = await importOriginal();
+         return cached || { ...actual, trpc: {} };
+       });`,
+      errors: [{ messageId: 'unprovableMock' }],
+    },
+    // A ternary where only ONE branch spreads the original.
+    {
+      code: `vi.mock('~/utils/trpc', async (importOriginal) => {
+         const actual = await importOriginal();
+         return flag ? { ...actual } : { trpc: {} };
+       });`,
+      errors: [{ messageId: 'unprovableMock' }],
+    },
+    // No return statement at all — the factory hands Vitest `undefined`.
+    {
+      code: `vi.mock('~/utils/trpc', async (importOriginal) => { await importOriginal(); });`,
+      errors: [{ messageId: 'unprovableMock' }],
+    },
+    // A bare `return;` is the same thing, written out.
+    {
+      code: `vi.mock('~/utils/trpc', async (importOriginal) => { await importOriginal(); return; });`,
+      errors: [{ messageId: 'unprovableMock' }],
+    },
+    // The local is reassigned after being loaded, so the value reaching the
+    // spread is no longer knowable — "unsure" must mean "report".
+    {
+      code: `vi.mock('~/utils/trpc', async (importOriginal) => {
+         let actual = await importOriginal();
+         actual = {};
+         return { ...actual, trpc: {} };
+       });`,
+      errors: [{ messageId: 'wholesaleMock' }],
+    },
+    // Spreading a PROPERTY of the original is not spreading the original.
+    {
+      code: `vi.mock('~/utils/trpc', async (importOriginal) => {
+         const mod = await importOriginal();
+         return { ...mod.default, trpc: {} };
+       });`,
+      errors: [{ messageId: 'wholesaleMock' }],
+    },
+
+    // ================================================================
+    // Spread present, but not of the original
+    // ================================================================
     // A spread of a LOCAL stub is not a fix — the real module is still gone.
     {
       code: `vi.mock('~/utils/trpc', () => ({ ...baseStub, trpc: {} }));`,
@@ -135,7 +358,7 @@ ruleTester.run('no-wholesale-module-mock', rule, {
     // is the wholesale pattern.
     {
       code: `vi.mock('~/utils/trpc', () => makeTrpcMock());`,
-      errors: [{ messageId: 'wholesaleMock' }],
+      errors: [{ messageId: 'unprovableMock' }],
     },
     // Two return paths, only one of which spreads — the unguarded branch still
     // drops the real exports.
@@ -147,6 +370,34 @@ ruleTester.run('no-wholesale-module-mock', rule, {
        });`,
       errors: [{ messageId: 'wholesaleMock' }],
     },
+
+    // ================================================================
+    // Specifier forms the first cut did not see at all
+    // ================================================================
+    // A template literal is a perfectly ordinary way to write the specifier and
+    // was skipped entirely (only `Literal` was matched).
+    {
+      code: 'vi.mock(`~/utils/trpc`, () => ({ trpc: {} }));',
+      filename: TEST_FILE,
+      errors: [{ messageId: 'wholesaleMock' }],
+    },
+    // A relative specifier reaching the same module. `modules` was raw string
+    // equality with no path resolution, so this was invisible.
+    {
+      code: `vi.mock('../../../utils/trpc', () => ({ trpc: {} }));`,
+      filename: TEST_FILE,
+      errors: [{ messageId: 'wholesaleMock' }],
+    },
+    // ...including with an explicit extension.
+    {
+      code: `vi.mock('../../../utils/trpc.ts', () => ({ trpc: {} }));`,
+      filename: TEST_FILE,
+      errors: [{ messageId: 'wholesaleMock' }],
+    },
+
+    // ================================================================
+    // Options
+    // ================================================================
     // The `modules` option extends the scope to another module.
     {
       code: `vi.mock('~/utils/other', () => ({ thing: 1 }));`,

--- a/src/server/services/__tests__/no-wholesale-module-mock.test.ts
+++ b/src/server/services/__tests__/no-wholesale-module-mock.test.ts
@@ -22,6 +22,14 @@ const ruleTester = new RuleTester(ruleTesterConfig as ConstructorParameters<type
 // comparing them with the configured `~/utils/trpc` target.
 const TEST_FILE = 'src/components/Foo/__tests__/foo.browser.test.tsx';
 
+// ESLint invokes rules with ABSOLUTE filenames, and that is the branch where a
+// relative specifier is resolved against the repo's own `src/`. The cases that
+// pin the package boundary have to use real absolute paths under this repo, or
+// they exercise the repo-relative branch instead and prove nothing.
+const REPO_ROOT = path.resolve(__dirname, '../../../..');
+const SRC_FILE_ABS = path.join(REPO_ROOT, TEST_FILE);
+const PKG_FILE_ABS = path.join(REPO_ROOT, 'packages/blocks-react/src/__tests__/foo.test.tsx');
+
 ruleTester.run('no-wholesale-module-mock', rule, {
   valid: [
     // ================================================================
@@ -152,6 +160,104 @@ ruleTester.run('no-wholesale-module-mock', rule, {
     `vi.mock('~/utils/trpc', makeTrpcFactory);`,
 
     // ================================================================
+    // 🔴 A plain unary READS the local, it cannot mutate it
+    // ================================================================
+    // These four were all reported before: the poisoning clause matched every
+    // `UnaryExpression` with an Identifier argument, so `!actual`, `typeof
+    // actual`, `void actual` and `-actual` each marked `actual` unknowable and
+    // turned correct code into an `error`. None of them can change a binding.
+    // Defensive null-check — the shape most likely to be written by an author
+    // who has actually been bitten by a bad importOriginal.
+    `vi.mock('~/utils/trpc', async (importOriginal) => {
+       const actual = await importOriginal();
+       if (!actual) throw new Error('trpc module missing');
+       return { ...actual, trpc: {} };
+     });`,
+    // An assertion about the module, ditto.
+    `vi.mock('~/utils/trpc', async (importOriginal) => {
+       const actual = await importOriginal();
+       expect(typeof actual).toBe('object');
+       return { ...actual, trpc: {} };
+     });`,
+    // `void` as a deliberate "yes, I know this is unused".
+    `vi.mock('~/utils/trpc', async (importOriginal) => {
+       const actual = await importOriginal();
+       void actual;
+       return { ...actual, trpc: {} };
+     });`,
+    // Arithmetic negation is still only a read.
+    `vi.mock('~/utils/trpc', async (importOriginal) => {
+       const actual = await importOriginal();
+       const n = -actual;
+       return { ...actual, trpc: {} };
+     });`,
+
+    // ================================================================
+    // Guards that had no discriminating case before
+    // ================================================================
+    // SequenceExpression: the LAST element is the value, and it is safe here.
+    // Without the last-element rule this would be read as unprovable.
+    `vi.mock('~/utils/trpc', async (importOriginal) => {
+       const actual = await importOriginal();
+       return (0, { ...actual, trpc: {} });
+     });`,
+    // LogicalExpression where BOTH sides are provably original-bearing. The
+    // invalid cases below only pin the failing side.
+    `vi.mock('~/utils/trpc', async (importOriginal) => {
+       const actual = await importOriginal();
+       const other = await importOriginal();
+       return actual || other;
+     });`,
+    // TSNonNullExpression must be unwrapped before the spread is inspected.
+    `vi.mock('~/utils/trpc', async (importOriginal) => ({
+       ...(await importOriginal())!,
+       trpc: {},
+     }));`,
+    // ChainExpression: `importOriginal?.()` parses as a ChainExpression wrapping
+    // the call, so without unwrapping it the original is not recognised.
+    `vi.mock('~/utils/trpc', async (importOriginal) => ({
+       ...(await importOriginal?.()),
+       trpc: {},
+     }));`,
+    // The old-style TS cast `<any>expr` is a TSTypeAssertion, a different node
+    // from `expr as any`. It must be unwrapped too, or a SAFE factory wearing
+    // one is reported. (Only parses with JSX off, i.e. a `.ts` file — which is
+    // why RuleTester's default filename is left in place for this case.)
+    `vi.mock('~/utils/trpc', async (importOriginal) => {
+       const actual = await importOriginal();
+       return <any>{ ...actual, trpc: {} };
+     });`,
+    // A template literal WITH an expression is not a statically-readable
+    // specifier, even when its literal prefix happens to equal the target.
+    // Reading just the first quasi here would flag a mock of some OTHER module.
+    'vi.mock(`~/utils/trpc${suffix}`, () => ({ trpc: {} }));',
+    // A first parameter with a DEFAULT is still the importOriginal binding —
+    // it parses as an AssignmentPattern wrapping the identifier.
+    `vi.mock('~/utils/trpc', async (importOriginal = fallback) => ({
+       ...(await importOriginal()),
+       trpc: {},
+     }));`,
+
+    // ================================================================
+    // 🔴 The `~` alias stops at the package boundary
+    // ================================================================
+    // `~/utils/trpc` is the alias for the REPO-ROOT src/utils/trpc. A workspace
+    // package has its own src/, so from packages/blocks-react the specifier
+    // `../utils/trpc` names a DIFFERENT module and must not be flagged.
+    // Resolving on "the last /src/ in the path" matched it; over-reach at
+    // 'error' is exactly what gets a rule switched off.
+    {
+      code: `vi.mock('../utils/trpc', () => ({ trpc: {} }));`,
+      filename: 'packages/blocks-react/src/__tests__/foo.test.tsx',
+    },
+    // The same, with the ABSOLUTE filename ESLint really passes — this is the
+    // branch the fix changed, so it is the case that actually pins it.
+    {
+      code: `vi.mock('../utils/trpc', () => ({ trpc: {} }));`,
+      filename: PKG_FILE_ABS,
+    },
+
+    // ================================================================
     // Nested-function isolation
     // ================================================================
     // A `return` inside an inner callback must not be mistaken for the
@@ -213,34 +319,34 @@ ruleTester.run('no-wholesale-module-mock', rule, {
     // word, and it is one keystroke away from any of the backlog factories.
     {
       code: `vi.mock('~/utils/trpc', (importOriginal) => ({ ...localStub, trpc: {} }));`,
-      errors: [{ messageId: 'wholesaleMock' }],
+      errors: [{ messageId: 'unprovableMock' }],
     },
     // A COMMENT mentioning importOriginal satisfied it too — and a large share
     // of the existing backlog factories already carry an explanatory comment.
     {
       code: `vi.mock('~/utils/trpc', () => ({ /* TODO: switch to importOriginal */ ...localStub, trpc: {} }));`,
-      errors: [{ messageId: 'wholesaleMock' }],
+      errors: [{ messageId: 'unprovableMock' }],
     },
     // ...as did the bare string, anywhere in the factory.
     {
       code: `vi.mock('~/utils/trpc', () => ({ note: 'importOriginal', ...localStub, trpc: {} }));`,
-      errors: [{ messageId: 'wholesaleMock' }],
+      errors: [{ messageId: 'unprovableMock' }],
     },
     // Spreading a dynamic import of some OTHER module is not the original.
     {
       code: `vi.mock('~/utils/trpc', async (importOriginal) => ({ ...(await import('./elsewhere')), trpc: {} }));`,
-      errors: [{ messageId: 'wholesaleMock' }],
+      errors: [{ messageId: 'unprovableMock' }],
     },
     // `vi.importActual` of a DIFFERENT module leaves every trpc export missing.
     {
       code: `vi.mock('~/utils/trpc', async () => ({ ...(await vi.importActual('~/utils/other')), trpc: {} }));`,
-      errors: [{ messageId: 'wholesaleMock' }],
+      errors: [{ messageId: 'unprovableMock' }],
     },
     // A dynamic import of the module being mocked is a SELF-reference: Vitest
     // serves the mock, not the original. Only importOriginal/importActual work.
     {
       code: `vi.mock('~/utils/trpc', async () => ({ ...(await import('~/utils/trpc')), trpc: {} }));`,
-      errors: [{ messageId: 'wholesaleMock' }],
+      errors: [{ messageId: 'unprovableMock' }],
     },
 
     // ================================================================
@@ -317,7 +423,7 @@ ruleTester.run('no-wholesale-module-mock', rule, {
          actual = {};
          return { ...actual, trpc: {} };
        });`,
-      errors: [{ messageId: 'wholesaleMock' }],
+      errors: [{ messageId: 'unprovableMock' }],
     },
     // Spreading a PROPERTY of the original is not spreading the original.
     {
@@ -325,7 +431,7 @@ ruleTester.run('no-wholesale-module-mock', rule, {
          const mod = await importOriginal();
          return { ...mod.default, trpc: {} };
        });`,
-      errors: [{ messageId: 'wholesaleMock' }],
+      errors: [{ messageId: 'unprovableMock' }],
     },
 
     // ================================================================
@@ -334,7 +440,7 @@ ruleTester.run('no-wholesale-module-mock', rule, {
     // A spread of a LOCAL stub is not a fix — the real module is still gone.
     {
       code: `vi.mock('~/utils/trpc', () => ({ ...baseStub, trpc: {} }));`,
-      errors: [{ messageId: 'wholesaleMock' }],
+      errors: [{ messageId: 'unprovableMock' }],
     },
     // importOriginal is awaited but the result is never spread — the omitted
     // exports are still missing.
@@ -394,6 +500,216 @@ ruleTester.run('no-wholesale-module-mock', rule, {
       filename: TEST_FILE,
       errors: [{ messageId: 'wholesaleMock' }],
     },
+    // A relative specifier under the repo's own src/, with the ABSOLUTE
+    // filename ESLint really passes. The package-boundary fix must not have
+    // narrowed the real case away — this is the other half of the valid
+    // PKG_FILE_ABS case above.
+    {
+      code: `vi.mock('../../../utils/trpc', () => ({ trpc: {} }));`,
+      filename: SRC_FILE_ABS,
+      errors: [{ messageId: 'wholesaleMock' }],
+    },
+
+    // ================================================================
+    // 🔴 `delete` — the one unary that really does mutate
+    // ================================================================
+    // This is the historical bug in its purest form: the spread still looks
+    // right, but an export has been removed from the object being spread. It is
+    // statically decidable and used to pass SILENTLY, because the old poisoning
+    // clause only matched a unary whose argument was a bare Identifier — and
+    // `delete actual.trpcVanilla` takes a MemberExpression.
+    {
+      code: `vi.mock('~/utils/trpc', async (importOriginal) => {
+         const actual = await importOriginal();
+         delete actual.trpcVanilla;
+         return { ...actual, trpc: {} };
+       });`,
+      errors: [{ messageId: 'unprovableMock' }],
+    },
+    // Computed member access is the same deletion.
+    {
+      code: `vi.mock('~/utils/trpc', async (importOriginal) => {
+         const actual = await importOriginal();
+         delete actual['trpcVanilla'];
+         return { ...actual, trpc: {} };
+       });`,
+      errors: [{ messageId: 'unprovableMock' }],
+    },
+    // ...and so is one reached through an optional chain.
+    {
+      code: `vi.mock('~/utils/trpc', async (importOriginal) => {
+         const actual = await importOriginal();
+         delete actual?.trpc.vanilla;
+         return { ...actual, trpc: {} };
+       });`,
+      errors: [{ messageId: 'unprovableMock' }],
+    },
+    // An UpdateExpression rebinds the name to a number. The reassignment case
+    // above covers `=`; this pins `++` specifically, which is the half of the
+    // old clause that was doing real work.
+    {
+      code: `vi.mock('~/utils/trpc', async (importOriginal) => {
+         let actual = await importOriginal();
+         actual++;
+         return { ...actual, trpc: {} };
+       });`,
+      errors: [{ messageId: 'unprovableMock' }],
+    },
+
+    // ================================================================
+    // Guards that had no discriminating case before
+    // ================================================================
+    // A name declared TWICE is poisoned: which value reaches the spread is no
+    // longer knowable. The order matters for whether this discriminates — only
+    // the LAST declarator is recorded in `locals`, so the redeclaration has to
+    // be the SAFE-looking one. Here the value that actually reaches the spread
+    // depends on `flag`, and without the double-declaration check the rule
+    // would read only the conditional `await importOriginal()` and call a mock
+    // that may be `localStub` clean.
+    {
+      code: `vi.mock('~/utils/trpc', async (importOriginal) => {
+         var actual = localStub;
+         if (flag) { var actual = await importOriginal(); }
+         return { ...actual, trpc: {} };
+       });`,
+      errors: [{ messageId: 'unprovableMock' }],
+    },
+    // The plain-sequential spelling of the same hazard, kept because it is the
+    // shape an author is most likely to write.
+    {
+      code: `vi.mock('~/utils/trpc', async (importOriginal) => {
+         var actual = await importOriginal();
+         var actual = { trpc: {} };
+         return { ...actual };
+       });`,
+      errors: [{ messageId: 'unprovableMock' }],
+    },
+    // SequenceExpression: the LAST element is the value. Here the safe-looking
+    // first element is discarded at runtime, so the mock is wholesale.
+    {
+      code: `vi.mock('~/utils/trpc', async (importOriginal) => {
+         const actual = await importOriginal();
+         return ({ ...actual }, { trpc: {} });
+       });`,
+      errors: [{ messageId: 'unprovableMock' }],
+    },
+    // Cycle guard: a self-referential initialiser must terminate rather than
+    // recurse forever. Without the `seen` set this blows the stack and the rule
+    // crashes ESLint on the file instead of reporting.
+    {
+      code: `vi.mock('~/utils/trpc', () => { const a = a; return a; });`,
+      errors: [{ messageId: 'unprovableMock' }],
+    },
+    // LogicalExpression: the right-hand side is unknown, so the whole
+    // expression is. The `cached || {...}` case above pins the LEFT side.
+    {
+      code: `vi.mock('~/utils/trpc', async (importOriginal) => {
+         const actual = await importOriginal();
+         return actual || fallbackStub;
+       });`,
+      errors: [{ messageId: 'unprovableMock' }],
+    },
+    // A local declared with NO initialiser cannot carry anything forward, so
+    // spreading it is not provable — the `init ? ... : false` fallback.
+    {
+      code: `vi.mock('~/utils/trpc', async (importOriginal) => {
+         let actual;
+         return { ...actual, trpc: {} };
+       });`,
+      errors: [{ messageId: 'unprovableMock' }],
+    },
+    // The old-style TS cast is unwrapped in the reporting direction too: the
+    // object literal underneath is what gets classified.
+    {
+      code: `vi.mock('~/utils/trpc', () => { return <any>{ trpc: {} }; });`,
+      errors: [{ messageId: 'wholesaleMock' }],
+    },
+    // Specifier canonicalisation strips a trailing `/index`, so the directory
+    // form of the target is the same module.
+    {
+      code: `vi.mock('~/utils/trpc/index', () => ({ trpc: {} }));`,
+      errors: [{ messageId: 'wholesaleMock' }],
+    },
+    // 🔴 EVERY return is inspected, not just the first. The two-returns case
+    // above has the BAD return first, so it passes even if the analysis stops
+    // after one; this one has the SAFE return first and is the only case that
+    // fails if it does.
+    {
+      code: `vi.mock('~/utils/trpc', async (importOriginal) => {
+         const actual = await importOriginal();
+         if (flag) return { ...actual, trpc: {} };
+         return { trpc: {} };
+       });`,
+      errors: [{ messageId: 'wholesaleMock' }],
+    },
+
+    // ================================================================
+    // 🔴 Which message an author gets, and why it matters at 'error'
+    // ================================================================
+    // An object literal with NO spread at all gets `wholesaleMock`, whose
+    // advice — "spread the real module" — is precisely what is missing.
+    {
+      code: `vi.mock('~/utils/trpc', () => ({ trpc: { useUtils: () => ({}) } }));`,
+      errors: [{ messageId: 'wholesaleMock' }],
+    },
+    // An object literal that DOES spread, but of something unprovable, gets
+    // `unprovableMock` instead. Telling an author who already wrote a spread to
+    // "spread the real module" is unactionable, and `unprovableMock` is the
+    // message that names the disable-comment escape hatch.
+    {
+      code: `vi.mock('~/utils/trpc', () => ({ ...someUnknown, trpc: {} }));`,
+      errors: [{ messageId: 'unprovableMock' }],
+    },
+    // The same, one level of defensiveness deeper: `(actual ?? {})` is a
+    // LogicalExpression whose right side is a bare object literal, so the
+    // spread is not provable even though `actual` is.
+    {
+      code: `vi.mock('~/utils/trpc', async (o) => {
+         const actual = await o();
+         return { ...(actual ?? {}), trpc: {} };
+       });`,
+      errors: [{ messageId: 'unprovableMock' }],
+    },
+
+    // ================================================================
+    // Documented FALSE POSITIVES — safe shapes reported as unprovable
+    // ================================================================
+    // These are pinned so the cost of the proof-based design stays visible and
+    // a future change to it is a deliberate decision, not a surprise. None
+    // exists in the tree today; each is one disable comment away. See the
+    // "Known FALSE POSITIVES" list in eslint-local-rules.js.
+    // Destructure-and-rebuild: `rest` comes from a pattern, not a tracked
+    // initialiser.
+    {
+      code: `vi.mock('~/utils/trpc', async (importOriginal) => {
+         const { trpc, ...rest } = await importOriginal();
+         return { ...rest, trpc: {} };
+       });`,
+      errors: [{ messageId: 'unprovableMock' }],
+    },
+    // Array destructuring out of Promise.all — same reason.
+    {
+      code: `vi.mock('~/utils/trpc', async (importOriginal) => {
+         const [actual] = await Promise.all([importOriginal()]);
+         return { ...actual, trpc: {} };
+       });`,
+      errors: [{ messageId: 'unprovableMock' }],
+    },
+    // An aliased binding: only the parameter itself is recognised as the
+    // original call.
+    {
+      code: `vi.mock('~/utils/trpc', async (importOriginal) => {
+         const f = importOriginal;
+         return { ...(await f()), trpc: {} };
+       });`,
+      errors: [{ messageId: 'unprovableMock' }],
+    },
+    // The `vi.hoisted` idiom builds the spread source outside the factory.
+    {
+      code: `const { actual } = vi.hoisted(() => ({ actual: {} }));
+       vi.mock('~/utils/trpc', () => ({ ...actual, trpc: {} }));`,
+      errors: [{ messageId: 'unprovableMock' }],
+    },
 
     // ================================================================
     // Options
@@ -403,6 +719,53 @@ ruleTester.run('no-wholesale-module-mock', rule, {
       code: `vi.mock('~/utils/other', () => ({ thing: 1 }));`,
       options: [{ modules: ['~/utils/other'] }],
       errors: [{ messageId: 'wholesaleMock', data: { module: '~/utils/other' } }],
+    },
+    // ...including a BARE package specifier, which canonicalises to itself.
+    // The doc says "extend `modules` rather than broadening the rule", so the
+    // non-`~/` shape of the option has to actually work.
+    {
+      code: `vi.mock('@mantine/hooks', () => ({ useMediaQuery: () => false }));`,
+      options: [{ modules: ['@mantine/hooks'] }],
+      errors: [{ messageId: 'wholesaleMock', data: { module: '@mantine/hooks' } }],
+    },
+
+    // ================================================================
+    // The `{{shape}}` placeholder is user-facing message content
+    // ================================================================
+    // `unprovableMock` names the shape it could not walk. Pin two distinct
+    // values so a constant-shape regression is visible.
+    {
+      code: `vi.mock('~/utils/trpc', async (importOriginal) => { await importOriginal(); });`,
+      errors: [
+        { messageId: 'unprovableMock', data: { module: '~/utils/trpc', shape: 'no return value' } },
+      ],
+    },
+    {
+      code: `vi.mock('~/utils/trpc', () => makeTrpcMock());`,
+      errors: [
+        { messageId: 'unprovableMock', data: { module: '~/utils/trpc', shape: 'CallExpression' } },
+      ],
+    },
+    // A generic reference with the CALL forgotten parses as a
+    // TSInstantiationExpression; unwrapping it is what lets the message name
+    // the `Identifier` underneath instead of a node type no author recognises.
+    {
+      code: `vi.mock('~/utils/trpc', () => { return makeTrpcMock<TrpcModule>; });`,
+      errors: [
+        { messageId: 'unprovableMock', data: { module: '~/utils/trpc', shape: 'Identifier' } },
+      ],
+    },
+    {
+      code: `vi.mock('~/utils/trpc', () => ({ ...someUnknown, trpc: {} }));`,
+      errors: [
+        {
+          messageId: 'unprovableMock',
+          data: {
+            module: '~/utils/trpc',
+            shape: 'an object literal whose spread does not provably carry the original module',
+          },
+        },
+      ],
     },
   ],
 });


### PR DESCRIPTION
Follow-up to #3487, which shipped `local-rules/no-wholesale-module-mock` at `warn`. This hardens the check from a textual match to an AST proof, and raises the severity to `error`.

> **Revision note.** An adversarial audit of the first version of this PR found three real defects in it (a false-positive generator that was also inverted, a message that never reaches the case it was written for, and a specifier match that crossed the package boundary), and established that an earlier draft of *this description* got its central story wrong. Both are fixed below; the incorrect claim is called out explicitly in §1 rather than quietly dropped.

## 1. Why `error`, and why the severity is the whole point

**An earlier version of this description claimed an incident that did not happen.** It said two files — `BlockHostTokenRetry.browser.test.tsx` and `PageBlockHostTokenTerminal.browser.test.tsx` — were added to `main` *after* the rule went live at `warn`, and that the backlog grew 63 → 65 "in the hours after". Measured:

```
30493cea12  2026-07-30T20:24:53-05:00  #3489   <- both files added here
645c081fa4  2026-07-30T20:25:59-05:00  #3487   <- the rule
```

They landed **66 seconds before** the rule, in #3489, which is an *ancestor* of #3487's squash — and #3487's own parent carries no rule at any severity (`git show 645c081fa4^:.eslintrc.js | grep no-wholesale-module-mock` → nothing). So the failure did not occur while the rule was live, `error` would not have stopped them, and the 63 → 65 delta was a merge-base artefact, not growth. That argument is withdrawn.

**The mechanism is sound independently, and it is verified.** `.github/workflows/lint.yml` splits ESLint by how the PR touched the file:

| files | step | behaviour |
|---|---|---|
| **added** (`git diff --diff-filter=A`) | `ESLint (added files)` | **blocking** — no `continue-on-error`, and **no `--max-warnings`** |
| modified/renamed (`--diff-filter=CMR`) | `ESLint (modified files, report-only)` | `continue-on-error: true` |

The added-files step ignores warnings *by design* — the repo carries ~3,470 of them, and the workflow header says so. So at `warn` the rule is invisible to the one gate built to catch a brand-new file, and visible only in a step that cannot fail. **At `warn` it gates nothing anywhere.** `error` is what makes the added-files step able to stop a newly authored wholesale mock; nothing else in this repo's CI runs ESLint (two workflows total; `pnpm lint` is wired to no gate; `.husky/pre-push` runs typecheck only, and only on `main`).

**Blast radius on the existing backlog:** all 65 offenders are pre-existing files, so a PR touching one reaches only the report-only step. One documented exception, inferred from the workflow rather than reproduced: `--diff-filter=A` sees a **moved** file as added when git's rename detection misses it (a move plus edits below the ~50% similarity threshold decomposes into `A` + `D`). Relocating a backlog file with substantial edits can therefore put it in the blocking step. Fixing the factory at that point is the right outcome, but it is a real cost, not zero.

## 2. The tightening flags zero additional files

**65 flagged — the identical file set as the merged rule**, measured on the same tree with both rule versions, absolute filenames, 0 files in the symmetric difference. The finding set is also a **strict subset** of a naive `grep "vi.mock('~/utils/trpc'"`: 0 findings fall outside it, and 0 fall outside a broader grep that also catches relative-path specifiers.

Every shape the hardening closes is **latent** — no file in the tree uses one today — so the hardening and the severity flip are independently safe: neither is doing the other's work, and neither can be blamed for the other's blast radius.

## What was wrong with the check

The first cut asked two questions: does the factory's **raw source text** match `/\bimportOriginal|importActual\b/`, and does every returned object literal have *a* top-level spread. Both halves were bypassable. Every row below was measured, not reasoned about — `pass` means the rule was silent.

**Textual match — the word, not the binding:**

| factory | before | after |
|---|---|---|
| `(importOriginal) => ({ ...localStub, trpc: {} })` — unused param | pass | **unprovableMock** |
| `() => ({ /* TODO: use importOriginal */ ...localStub, trpc: {} })` | pass | **unprovableMock** |
| `() => ({ note: 'importOriginal', ...localStub, trpc: {} })` | pass | **unprovableMock** |
| `async (importOriginal) => ({ ...(await import('./elsewhere')), trpc: {} })` | pass | **unprovableMock** |
| `async () => ({ ...(await vi.importActual('~/utils/other')), trpc: {} })` | pass | **unprovableMock** |
| `async () => ({ ...(await import('~/utils/trpc')), trpc: {} })` — self-reference; Vitest serves the *mock* here | pass | **unprovableMock** |

The first row is the previous suite's own invalid case plus **one unused parameter**.

### 🔴 The textual check produced FALSE POSITIVES too

```ts
// Correct code. Flagged by the merged rule, because the token
// `importOriginal` never appears — the parameter is named `orig`.
vi.mock('~/utils/trpc', async (orig) => ({ ...(await orig()), trpc: {} }));
```

The factory's first parameter **is** `importOriginal` whatever the author names it, and conversely the mere presence of the word — in a parameter, a comment, a string — proves nothing. Matching the **binding** instead of the text fixes both directions at once.

**"Returns no object literal ⇒ assume safe"** was an unconditional bypass once the regex was satisfied:

| factory return | before | after |
|---|---|---|
| `return { trpc: {} } as any` | pass | **wholesaleMock** |
| `return { trpc: {} } satisfies X` | pass | **wholesaleMock** |
| `const out = { trpc: {} }; return out` | pass | **unprovableMock** |
| `Object.assign({}, { trpc: {} })` | pass | **unprovableMock** |
| `cached \|\| { trpc: {} }` | pass | **unprovableMock** |
| `flag ? { ...actual } : { trpc: {} }` — half-safe ternary | pass | **unprovableMock** |
| no `return` at all / bare `return;` | pass | **unprovableMock** |
| `let actual = await importOriginal(); actual = {}; return { ...actual }` | pass | **unprovableMock** |
| `return { ...mod.default, trpc: {} }` | pass | **unprovableMock** |

`as any` is the sharp one — idiomatic in a TS repo and the first reach when fighting a squiggle.

**Specifier matching** was raw string equality on a `Literal` node:

| specifier | before | after |
|---|---|---|
| `` vi.mock(`~/utils/trpc`, …) `` | pass (skipped entirely) | **wholesaleMock** |
| `vi.mock('../../../utils/trpc', …)` | pass (no path resolution) | **wholesaleMock** |
| `vi.mock('../../../utils/trpc.ts', …)` | pass | **wholesaleMock** |

## The replacement: a proof, not a heuristic

The question the rule now answers is: *can I prove, from the AST, that everything this factory returns carries the original module's exports forward?* An expression is original-preserving iff it is

- a call to the factory's **own first parameter**, or `vi.importActual('<the same module>')`;
- an `await` of either;
- a local `const` initialised from one of those, provided the name is not redeclared, reassigned, or `delete`d from;
- an object literal with a top-level spread of something original-preserving;
- `Object.assign(...)` with an original-preserving argument;
- a conditional / logical / sequence expression **every** branch of which qualifies.

TS `as` / `satisfies` / `!` / `<T>` wrappers and optional-call `ChainExpression`s are unwrapped first. `vi.mock('mod')` (automock), `vi.mock('mod', { spy: true })`, and a factory passed by reference are left alone.

## 🔴 Fixes from the adversarial audit of this PR

### 1. The unary-poisoning clause was a false-positive generator — and it was inverted

The local-poisoning walk marked a binding unknowable on *any* `UnaryExpression` over a bare identifier:

```js
(n.type === 'UpdateExpression' || n.type === 'UnaryExpression') && n.argument.type === 'Identifier'
```

A plain unary **cannot mutate anything**. So this correct, defensive code was reported — merge-blocking at `error`:

```ts
vi.mock('~/utils/trpc', async (importOriginal) => {
  const actual = await importOriginal();
  if (!actual) throw new Error('trpc module missing');   // poisoned `actual`
  return { ...actual, trpc: {} };                        // reported
});
```

`expect(typeof actual)`, `void actual` and `-actual` behaved identically. Meanwhile the one unary that **does** mutate — `delete actual.trpcVanilla`, i.e. the historical bug in its purest form — takes a `MemberExpression` argument, so it was **not** poisoned and passed **silently**: a statically-decidable false negative producing exactly the bug this rule exists to catch.

Now: `UpdateExpression` poisons; `delete` poisons (walking through member access and optional chains to the root binding); every other unary does not. Four valid cases and four invalid cases pin it.

### 2. `unprovableMock` was structurally unreachable for the common case

`unprovableMock` could only fire when the returned expression was **not** an object literal. Every unprovable object literal — *including one that visibly does spread* — got `wholesaleMock`, whose advice is *"Spread the real module"*. Telling an author who already wrote a spread to add a spread is unactionable, and unactionable advice at `error` is how a rule gets switched off. Worse, only `unprovableMock` documented the disable-comment escape hatch, so the branch that actually fires never mentioned it.

The split is now "did you even try to spread?":

- object literal with **no** top-level spread → `wholesaleMock` ("spread the real module" — exactly what is missing);
- object literal with a spread that cannot be walked to the original, or any non-object return → `unprovableMock`, which names the shape and the escape hatch.

Both messages now document `// eslint-disable-next-line local-rules/no-wholesale-module-mock -- <reason>`. This re-labels 9 existing invalid cases; **no case became clean** — every one still reports.

### 3. The specifier match crossed the package boundary

`canonicalModulePath` sliced at the **last** `/src/`, so from `packages/blocks-react/src/…` the specifier `../utils/trpc` resolved onto `~/utils/trpc` and was flagged — a different module. `~` is the alias for the **repo-root** `src/`, so resolution is now anchored to the directory containing `eslint-local-rules.js` rather than to "the last `/src/` in the string". Latent (no such module exists today), but over-reach at `error` is what gets a rule disabled.

### 4. Smaller items

- A first parameter with a **default** (`async (importOriginal = fallback) => …`) parses as an `AssignmentPattern` and was not recognised as the `importOriginal` binding, so a correct factory was reported. Now unwrapped.
- An explicit `SpreadElement` exclusion in the `Object.assign` branch was **provably redundant** (no input could distinguish it — `SpreadElement` already falls through to `false`). Deleted rather than tested, matching the treatment of the redundant early return found in the first pass.

### `unprovableMock`: an undecidable shape is REPORTED, not assumed safe

This is a deliberate asymmetry, and the single most important design decision here: **a false positive costs one disable comment; a false negative costs a silently-empty test suite that nobody notices for months.**

The conservatism costs nothing today — **all 65 findings are `wholesaleMock`; there are zero `unprovableMock` in the tree** — but the shapes it *would* misfire on are now enumerated in the rule so a blocked author recognises their own instead of switching the rule off:

- destructure-and-rebuild (`const { trpc, ...rest } = await importOriginal()`);
- `const [actual] = await Promise.all([importOriginal()])`;
- an aliased binding (`const f = importOriginal; …(await f())`);
- the `vi.hoisted` idiom.

None exists in the tree; each is one disable comment away. All four are pinned as invalid cases so the cost stays visible and any future change to it is deliberate.

**Known gaps** (documented in the rule): a factory passed as an identifier is not analysed — and the doc now says explicitly **not to use that to silence the rule**, because unlike a disable comment it leaves nothing for a reviewer or a grep to find; `modules` matches per-module, not by glob; only files ESLint already covers (`src/`, `packages/`) are seen.

### 🔴 Why this has to be a lint rule at all

On the string-path overload Vitest types the factory's return as `Promisable<Partial<M>>` with `M = unknown`. `Partial<unknown>` accepts any object, so an omitted export is **never** a type error — and this does not improve under Vitest 4's typed `vi.mock(import('...'))` form. TypeScript cannot catch this class of bug.

## Inventory

Measured on current `main` (`645c081fa4`) in a clean worktree, absolute filenames, with **both** the merged rule and this one — they agree exactly:

| | files |
|---|---|
| `vi.mock('~/utils/trpc', …)` grep hits | **75** |
| flagged (wholesale) | **65** |
| already correct (spreads the original) | **9** |
| the rule's own RuleTester fixture | **1** |

The 9 already-correct: `ChallengeUpsertForm`, `AnnouncementEditModal`, `AppEditPage`, `CombinedReviewModal`, `ConnectScopesPanel`, `ExternalSubmitForm`, `ExternalSubmitForm.reducedMotion`, `OffsiteReportsQueue`, `OffsiteReviewQueue`. Five of them are converted here from `typeof import('...')` / `Record<string, unknown>` to `import type * as TrpcModule` + `typeof TrpcModule`, because four carried a `consistent-type-imports` **error** — meaning the rule's own message was pointing at examples that contradicted it. Net **−4** pre-existing lint errors.

*(An earlier draft of this table mixed bases — 72 total / 66 wholesale is the pre-#3487 tree, not current `main`. The numbers above are all one base.)*

## Verification

Everything below was driven through ESLint's `Linter`/`RuleTester` API directly — no vitest, no Vite cache.

**Tests — 97 `RuleTester` cases** (39 valid / 58 invalid), up from 58 in the first version of this PR and 23 on `main`.

> ⚠️ `Unit tests pass` in CI is **not** evidence for this suite: that job is `continue-on-error: true`, and `pnpm test:lint-rules` is invoked by no workflow at all. The suite here was run under plain `node` via esbuild (ESLint 8's `RuleTester` supplies its own `describe`/`it`).

**Mutation-tested — 63 independent mutations, 61 killed.** The mutations were written from the rule's *guards*, not from the cases that exist; the previous round's "14/14, 0 survivors" measured self-consistency, and an independent 14-mutation set against it had **9 survivors**. Newly-pinned guards that were untested before: unary/`delete` poisoning, double-declaration poisoning, `SequenceExpression` last-element, the `seen` cycle guard, `/index` stripping, `LogicalExpression` right-hand side, `TSNonNullExpression`/`TSTypeAssertion`/`ChainExpression` unwrapping, bare-package `modules` entries, the `{{shape}}` message data, and — the substantive one — **that every `return` is inspected, not just the first**. The old suite had a multi-return case whose *first* return was bad, so truncating the analysis to `returns[0]` passed the whole suite; there is now a case whose first return is safe and whose second is wholesale.

**The 2 survivors are equivalent mutants**, reported rather than hidden:

| survivor | why no input can distinguish it |
|---|---|
| treat a destructured first param as the binding | the mutant yields a binding name (`@@`) that is not a writable JS identifier, so no call can resolve to it |
| accept a non-string `Literal` as a specifier | `canonicalModulePath` rejects a non-string anyway, so both paths return `null` |

**Conversions proven behaviour-neutral without running them** — all five are type-only erasures, so the emitted JS must be byte-identical:

```
IDENTICAL  AnnouncementEditModal.browser.test.tsx  (6541 bytes)
IDENTICAL  CombinedReviewModal.browser.test.tsx    (9382 bytes)
IDENTICAL  ConnectScopesPanel.browser.test.tsx     (6324 bytes)
IDENTICAL  OffsiteReportsQueue.browser.test.tsx    (5874 bytes)
IDENTICAL  OffsiteReviewQueue.browser.test.tsx     (16692 bytes)
```

This matters beyond convenience: a cold Vite `optimizeDeps` cache yields `Vitest failed to find the runner` → **0 tests collected**, indistinguishable from the very bug this rule targets, and that ambiguity has produced false readings twice in this workstream. A byte-diff sidesteps it.

> The first version of this PR reported the same check with slightly different byte counts. Those were produced by an invocation that passed `--loader=tsx` on a *file* input, which esbuild rejects — with stderr discarded, so it was comparing two **empty** outputs and would have reported `IDENTICAL` for any change whatsoever. The numbers above come from a corrected script that asserts the transform succeeded and that the output is non-trivial.

**Invariants re-checked after every change:** finding set is a strict subset of the grep baseline (0 outside); flagged set identical to the merged rule's on the same tree (65 = 65, symmetric difference 0). Unchanged by any fix in this round — expected, since all three fixes are latent in this tree.

**Typecheck / lint / format** — `NODE_OPTIONS=--max_old_space_size=8192 tsc --noEmit` run on this branch and on `main`: **26 errors on each, the identical set** (all pre-existing, none in a file touched here). ESLint on the modified suite: clean. `prettier --check` on `eslint-local-rules.js`, `.eslintrc.js` and the suite: clean.

## Follow-ups

1. Burn down the 65 remaining wholesale mocks in themed batches.
2. Make `preview / component-tests` fail on a suite that collects 0 tests — the static rule closes the authoring path; a runtime guard would close the environmental one.
3. Wire `test:lint-rules` into a workflow, or the suite above is never run by CI.
4. Fix the `PanelCard.tsx` `consistent-type-imports` crash so `pnpm lint` completes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
