### PR TITLE
fix(apps): my-submissions row actions scroll instead of being clipped

### DIFF
--- a/src/components/Apps/MySubmissionsList.browser.test.tsx
+++ b/src/components/Apps/MySubmissionsList.browser.test.tsx
@@ -1061,8 +1061,19 @@ describe('MySubmissionsList — row actions scroll rather than clip (S3)', () =>
     const scrollEl = scroll.element();
     const table = scrollEl.querySelector('table');
     expect(table).not.toBeNull();
-    // The wrapper is the table's nearest scroll ancestor — i.e. the overflow is
-    // handled BEFORE the clipping Card, not by it.
-    expect(table?.closest('[data-testid="apps-submissions-table-scroll"]')).toBe(scrollEl);
+    // PLACEMENT, which is the whole fix: the scroll box must sit INSIDE the clipping
+    // Card (`.mantine-Card-root` is `overflow: hidden`), between it and the table.
+    // Hoisting the wrapper outside the Card restores the defect in full, and a
+    // presence-only assertion would not notice.
+    //
+    // (The obvious-looking `table.closest('[data-testid=…]') === scrollEl` is a
+    // TAUTOLOGY — `scrollEl.querySelector('table')` already found the table inside
+    // scrollEl, so its nearest such ancestor is scrollEl by construction. It proves
+    // nothing about the Card. Hence the two assertions below instead.)
+    const card = scrollEl.closest('.mantine-Card-root');
+    expect(card).not.toBeNull();
+    // …and no further Card sits between the wrapper and the table, which would
+    // re-introduce the clip below the scroll box.
+    expect(table?.closest('.mantine-Card-root')).toBe(card);
   });
 });

--- a/src/components/Apps/MySubmissionsList.browser.test.tsx
+++ b/src/components/Apps/MySubmissionsList.browser.test.tsx
@@ -1037,3 +1037,32 @@ describe('MySubmissionsList — P4 Open-live run-page branching (graceful, no de
     await expect.element(page.getByText('Runs on model pages', { exact: false })).toBeInTheDocument();
   });
 });
+
+/**
+ * S3 — the row actions must SCROLL, not be clipped.
+ *
+ * Measured defect: the table sits in `<Card withBorder p={0}>`, whose
+ * `.mantine-Card-root` is `overflow: hidden`, and the action cell is a
+ * `wrap="nowrap"` group of up to six buttons — so 138 px of actions were cut off
+ * with no scrollbar (card `clientWidth 1286` vs `scrollWidth 1424` at 1497 px).
+ *
+ * 🔴 This asserts DOM STRUCTURE only — that the table's nearest scroll wrapper IS
+ * the `Table.ScrollContainer`. It does NOT (and cannot) assert the computed
+ * `overflow-x` or that nothing is clipped: this env has no Mantine theme CSS and
+ * no real viewport. The clipping itself is verified by manual re-measurement.
+ */
+describe('MySubmissionsList — row actions scroll rather than clip (S3)', () => {
+  test('the table renders inside the Table.ScrollContainer wrapper', async () => {
+    renderWithProviders(
+      <MySubmissionsList submissions={[live({})]} onWithdraw={vi.fn()} withdrawing={false} />
+    );
+    const scroll = page.getByTestId('apps-submissions-table-scroll');
+    await expect.element(scroll).toBeInTheDocument();
+    const scrollEl = scroll.element();
+    const table = scrollEl.querySelector('table');
+    expect(table).not.toBeNull();
+    // The wrapper is the table's nearest scroll ancestor — i.e. the overflow is
+    // handled BEFORE the clipping Card, not by it.
+    expect(table?.closest('[data-testid="apps-submissions-table-scroll"]')).toBe(scrollEl);
+  });
+});

--- a/src/components/Apps/MySubmissionsList.tsx
+++ b/src/components/Apps/MySubmissionsList.tsx
@@ -45,6 +45,7 @@ import {
   groupSubmissionsByApp,
   OWNER_STATUS_BUCKETS,
   sortGroups,
+  SUBMISSIONS_TABLE_MIN_WIDTH,
   toDate,
   type SubmissionAccessors,
   type SubmissionGroup,
@@ -619,65 +620,80 @@ export function MySubmissionsList({
 
   const renderTable = (groups: SubmissionGroup<Submission>[]) => (
     <Card withBorder p={0}>
-      <Table verticalSpacing="md" horizontalSpacing="md">
-        <Table.Thead>
-          <Table.Tr>
-            <Table.Th>App</Table.Th>
-            <Table.Th>Version</Table.Th>
-            <Table.Th>Status</Table.Th>
-            <Table.Th>Submitted</Table.Th>
-            <Table.Th>Reviewed</Table.Th>
-            <Table.Th>Installs</Table.Th>
-            <Table.Th>Usage (30d)</Table.Th>
-            <Table.Th />
-          </Table.Tr>
-        </Table.Thead>
-        <Table.Tbody>
-          {groups.map((g) => {
-            const isExpanded = expanded.has(g.identity);
-            // Single source of truth for the "live" badge + "Open live" button:
-            // the newest approved version across this listing's history.
-            const publishedId = currentlyPublishedVersionId([g.latest, ...g.older]);
-            return (
-              <Fragment key={g.identity}>
-                <OnsiteRow
-                  s={g.latest}
-                  nested={false}
-                  isCurrentlyPublished={g.latest.id === publishedId}
-                  onWithdraw={onWithdraw}
-                  withdrawing={withdrawing}
-                  owner={owner}
-                  canOpenPage={canOpenPage}
-                  toggle={
-                    g.older.length > 0 ? (
-                      <VersionToggle
-                        expanded={isExpanded}
-                        count={g.versionCount}
-                        onToggle={() => toggle(g.identity)}
-                        variant="subtle"
-                        testId={`apps-submissions-versions-${g.identity}`}
+      {/*
+        `.mantine-Card-root` is `overflow: hidden`, and this row's action cell is a
+        `wrap="nowrap"` group of up to six buttons — so without a scroll container the
+        card silently CLIPS the actions (measured: 138 px cut at a 1497 px viewport,
+        no scrollbar). `type="native"` deliberately, not Mantine's default ScrollArea:
+        ScrollArea defaults to `type="hover"` (scrollbars hidden until hover), and the
+        whole defect is a MISSING affordance. A native `overflow-x: auto` box shows the
+        platform scrollbar and keeps native keyboard/trackpad scrolling.
+      */}
+      <Table.ScrollContainer
+        minWidth={SUBMISSIONS_TABLE_MIN_WIDTH}
+        type="native"
+        data-testid="apps-submissions-table-scroll"
+      >
+        <Table verticalSpacing="md" horizontalSpacing="md">
+          <Table.Thead>
+            <Table.Tr>
+              <Table.Th>App</Table.Th>
+              <Table.Th>Version</Table.Th>
+              <Table.Th>Status</Table.Th>
+              <Table.Th>Submitted</Table.Th>
+              <Table.Th>Reviewed</Table.Th>
+              <Table.Th>Installs</Table.Th>
+              <Table.Th>Usage (30d)</Table.Th>
+              <Table.Th />
+            </Table.Tr>
+          </Table.Thead>
+          <Table.Tbody>
+            {groups.map((g) => {
+              const isExpanded = expanded.has(g.identity);
+              // Single source of truth for the "live" badge + "Open live" button:
+              // the newest approved version across this listing's history.
+              const publishedId = currentlyPublishedVersionId([g.latest, ...g.older]);
+              return (
+                <Fragment key={g.identity}>
+                  <OnsiteRow
+                    s={g.latest}
+                    nested={false}
+                    isCurrentlyPublished={g.latest.id === publishedId}
+                    onWithdraw={onWithdraw}
+                    withdrawing={withdrawing}
+                    owner={owner}
+                    canOpenPage={canOpenPage}
+                    toggle={
+                      g.older.length > 0 ? (
+                        <VersionToggle
+                          expanded={isExpanded}
+                          count={g.versionCount}
+                          onToggle={() => toggle(g.identity)}
+                          variant="subtle"
+                          testId={`apps-submissions-versions-${g.identity}`}
+                        />
+                      ) : undefined
+                    }
+                  />
+                  {isExpanded &&
+                    g.older.map((older) => (
+                      <OnsiteRow
+                        key={older.id}
+                        s={older}
+                        nested
+                        isCurrentlyPublished={older.id === publishedId}
+                        onWithdraw={onWithdraw}
+                        withdrawing={withdrawing}
+                        owner={owner}
+                        canOpenPage={canOpenPage}
                       />
-                    ) : undefined
-                  }
-                />
-                {isExpanded &&
-                  g.older.map((older) => (
-                    <OnsiteRow
-                      key={older.id}
-                      s={older}
-                      nested
-                      isCurrentlyPublished={older.id === publishedId}
-                      onWithdraw={onWithdraw}
-                      withdrawing={withdrawing}
-                      owner={owner}
-                      canOpenPage={canOpenPage}
-                    />
-                  ))}
-              </Fragment>
-            );
-          })}
-        </Table.Tbody>
-      </Table>
+                    ))}
+                </Fragment>
+              );
+            })}
+          </Table.Tbody>
+        </Table>
+      </Table.ScrollContainer>
     </Card>
   );
 

--- a/src/components/Apps/OffsiteSubmissionsList.browser.test.tsx
+++ b/src/components/Apps/OffsiteSubmissionsList.browser.test.tsx
@@ -441,3 +441,22 @@ describe('OffsiteSubmissionsList — advisory listing-problems warning', () => {
     expect(page.getByTestId('apps-submission-problems').elements()).toHaveLength(0);
   });
 });
+
+/**
+ * S3 — same scroll wrapper as the on-site list (they share
+ * `SUBMISSIONS_TABLE_MIN_WIDTH`). Structural assertion only; see the note on the
+ * matching test in `MySubmissionsList.browser.test.tsx`.
+ */
+describe('OffsiteSubmissionsList — row actions scroll rather than clip (S3)', () => {
+  test('the table renders inside the Table.ScrollContainer wrapper', async () => {
+    renderWithProviders(
+      <OffsiteSubmissionsList submissions={[live({})]} onWithdraw={vi.fn()} withdrawing={false} />
+    );
+    const scroll = page.getByTestId('apps-offsite-submissions-table-scroll');
+    await expect.element(scroll).toBeInTheDocument();
+    const scrollEl = scroll.element();
+    const table = scrollEl.querySelector('table');
+    expect(table).not.toBeNull();
+    expect(table?.closest('[data-testid="apps-offsite-submissions-table-scroll"]')).toBe(scrollEl);
+  });
+});

--- a/src/components/Apps/OffsiteSubmissionsList.browser.test.tsx
+++ b/src/components/Apps/OffsiteSubmissionsList.browser.test.tsx
@@ -457,6 +457,9 @@ describe('OffsiteSubmissionsList — row actions scroll rather than clip (S3)', 
     const scrollEl = scroll.element();
     const table = scrollEl.querySelector('table');
     expect(table).not.toBeNull();
-    expect(table?.closest('[data-testid="apps-offsite-submissions-table-scroll"]')).toBe(scrollEl);
+    // Placement, not presence — see the note on the matching on-site test.
+    const card = scrollEl.closest('.mantine-Card-root');
+    expect(card).not.toBeNull();
+    expect(table?.closest('.mantine-Card-root')).toBe(card);
   });
 });

--- a/src/components/Apps/OffsiteSubmissionsList.tsx
+++ b/src/components/Apps/OffsiteSubmissionsList.tsx
@@ -47,6 +47,7 @@ import {
   groupSubmissionsByApp,
   OWNER_STATUS_BUCKETS,
   sortGroups,
+  SUBMISSIONS_TABLE_MIN_WIDTH,
   toDate,
   type SubmissionAccessors,
   type SubmissionGroup,
@@ -479,55 +480,66 @@ export function OffsiteSubmissionsList({
 
   const renderTable = (groups: SubmissionGroup<OffsiteSubmission>[]) => (
     <Card withBorder p={0}>
-      <Table verticalSpacing="md" horizontalSpacing="md">
-        <Table.Thead>
-          <Table.Tr>
-            <Table.Th>App</Table.Th>
-            <Table.Th>Link</Table.Th>
-            <Table.Th>Status</Table.Th>
-            <Table.Th>Submitted</Table.Th>
-            <Table.Th>Reviewed</Table.Th>
-            <Table.Th />
-          </Table.Tr>
-        </Table.Thead>
-        <Table.Tbody>
-          {groups.map((g) => {
-            const isExpanded = expanded.has(g.identity);
-            return (
-              <Fragment key={g.identity}>
-                <OffsiteRow
-                  submission={g.latest}
-                  nested={false}
-                  onWithdraw={onWithdraw}
-                  withdrawing={withdrawing}
-                  owner={owner}
-                  toggle={
-                    g.older.length > 0 ? (
-                      <VersionToggle
-                        expanded={isExpanded}
-                        count={g.versionCount}
-                        onToggle={() => toggle(g.identity)}
-                        testId={`apps-offsite-versions-${g.identity}`}
+      {/*
+        Same scroll container + shared floor as the onsite list (see
+        SUBMISSIONS_TABLE_MIN_WIDTH): `.mantine-Card-root` is `overflow: hidden`, so an
+        action cell that outgrows the card is silently clipped rather than scrolled.
+      */}
+      <Table.ScrollContainer
+        minWidth={SUBMISSIONS_TABLE_MIN_WIDTH}
+        type="native"
+        data-testid="apps-offsite-submissions-table-scroll"
+      >
+        <Table verticalSpacing="md" horizontalSpacing="md">
+          <Table.Thead>
+            <Table.Tr>
+              <Table.Th>App</Table.Th>
+              <Table.Th>Link</Table.Th>
+              <Table.Th>Status</Table.Th>
+              <Table.Th>Submitted</Table.Th>
+              <Table.Th>Reviewed</Table.Th>
+              <Table.Th />
+            </Table.Tr>
+          </Table.Thead>
+          <Table.Tbody>
+            {groups.map((g) => {
+              const isExpanded = expanded.has(g.identity);
+              return (
+                <Fragment key={g.identity}>
+                  <OffsiteRow
+                    submission={g.latest}
+                    nested={false}
+                    onWithdraw={onWithdraw}
+                    withdrawing={withdrawing}
+                    owner={owner}
+                    toggle={
+                      g.older.length > 0 ? (
+                        <VersionToggle
+                          expanded={isExpanded}
+                          count={g.versionCount}
+                          onToggle={() => toggle(g.identity)}
+                          testId={`apps-offsite-versions-${g.identity}`}
+                        />
+                      ) : undefined
+                    }
+                  />
+                  {isExpanded &&
+                    g.older.map((older) => (
+                      <OffsiteRow
+                        key={older.id}
+                        submission={older}
+                        nested
+                        onWithdraw={onWithdraw}
+                        withdrawing={withdrawing}
+                        owner={owner}
                       />
-                    ) : undefined
-                  }
-                />
-                {isExpanded &&
-                  g.older.map((older) => (
-                    <OffsiteRow
-                      key={older.id}
-                      submission={older}
-                      nested
-                      onWithdraw={onWithdraw}
-                      withdrawing={withdrawing}
-                      owner={owner}
-                    />
-                  ))}
-              </Fragment>
-            );
-          })}
-        </Table.Tbody>
-      </Table>
+                    ))}
+                </Fragment>
+              );
+            })}
+          </Table.Tbody>
+        </Table>
+      </Table.ScrollContainer>
     </Card>
   );
 

--- a/src/components/Apps/__tests__/submissionsTable.test.ts
+++ b/src/components/Apps/__tests__/submissionsTable.test.ts
@@ -12,12 +12,14 @@ import {
   filterGroups,
   groupSubmissionsByApp,
   matchesQuery,
+  MY_SUBMISSIONS_CONTAINER_SIZE,
   nextSortState,
   OWNER_STATUS_BUCKETS,
   sortGroups,
   statusBucket,
   statusRank,
   STATUS_SECTION_ORDER,
+  SUBMISSIONS_CONTAINER_CHROME,
   SUBMISSIONS_TABLE_MIN_WIDTH,
   toDate,
   type SortState,
@@ -663,15 +665,76 @@ describe('SUBMISSIONS_TABLE_MIN_WIDTH', () => {
   });
 });
 
+describe('MY_SUBMISSIONS_CONTAINER_SIZE', () => {
+  it('is wide enough that the table does NOT scroll at desktop width', () => {
+    // This is the invariant the scroll container alone did not give us. The page's
+    // old container (`AppsPageLayout` default `'xl'` = 1320) is a MAX-width, so the
+    // card was a CONSTANT 1286 px at every viewport >= 1320 — always below the
+    // floor, i.e. a permanent scrollbar on every desktop. The container must clear
+    // the floor plus the Container padding + Card border it loses on the way in.
+    expect(MY_SUBMISSIONS_CONTAINER_SIZE - SUBMISSIONS_CONTAINER_CHROME).toBeGreaterThanOrEqual(
+      SUBMISSIONS_TABLE_MIN_WIDTH
+    );
+  });
+
+  it('is a raw px number, not a Mantine size token (tokens cap at xl = 1320)', () => {
+    expect(typeof MY_SUBMISSIONS_CONTAINER_SIZE).toBe('number');
+    expect(Number.isFinite(MY_SUBMISSIONS_CONTAINER_SIZE)).toBe(true);
+  });
+});
+
+describe('/apps/my-submissions consumes the widened container (S3)', () => {
+  const PAGE = path.resolve(__dirname, '../../../pages/apps/my-submissions.tsx');
+  const src = () => readFileSync(PAGE, 'utf8');
+
+  it('passes MY_SUBMISSIONS_CONTAINER_SIZE to AppsPageLayout, not the layout default', () => {
+    // Dropping the prop silently falls back to the layout default `'xl'`, which is
+    // exactly the state that made the clip permanent — nothing else would fail.
+    // Anchored to the ELEMENT, not the file (see the `type="native"` guard below for
+    // why a whole-file regex is not a guard at all).
+    expect(src()).toMatch(/<AppsPageLayout\b[^>]*?\ssize=\{MY_SUBMISSIONS_CONTAINER_SIZE\}/s);
+  });
+});
+
 describe('both my-submissions tables scroll rather than clip (S3, structural)', () => {
   const APPS_DIR = path.resolve(__dirname, '..');
   const read = (file: string) => readFileSync(path.join(APPS_DIR, file), 'utf8');
   const LISTS = ['MySubmissionsList.tsx', 'OffsiteSubmissionsList.tsx'] as const;
 
+  /**
+   * 🔴 EVERY assertion here is ANCHORED TO THE `<Table.ScrollContainer …>` OPENING
+   * TAG (`<Table\.ScrollContainer\b[^>]*?\s<prop>` — `[^>]*?` cannot cross the `>`
+   * that closes the tag, so the match is confined to that element's attributes).
+   *
+   * A whole-file regex here is NOT a guard. These files carry prose comments that
+   * quote the very props being asserted (the block comment above each container
+   * explains why `type="native"` was chosen over `type="hover"`), so an unanchored
+   * `/type="native"/` is satisfied by the COMMENT and stays green while the real
+   * prop is mutated to anything at all. That is exactly what happened here before
+   * this rewrite. Same trap for the negative `minWidth` assertion, which an
+   * unrelated `minWidth={400}` anywhere in a ~700-line file would trip.
+   */
+  const inTag = (prop: string) => new RegExp(String.raw`<Table\.ScrollContainer\b[^>]*?\s${prop}`, 's');
+
   for (const file of LISTS) {
     describe(file, () => {
       it('wraps its Table in a Table.ScrollContainer', () => {
         expect(read(file)).toMatch(/<Table\.ScrollContainer\b/);
+      });
+
+      it('nests the scroll container INSIDE the clipping Card, wrapping the Table', () => {
+        // PLACEMENT is the entire fix. `.mantine-Card-root` is `overflow: hidden`, so
+        // the scroll box only does anything if it sits BETWEEN the Card and the
+        // table. Hoisting it outside the Card (`<Table.ScrollContainer><Card>…`)
+        // fully restores the defect while every presence-only assertion above — and
+        // both component tests — stay green. This is the assertion that catches it.
+        const src = read(file);
+        expect(src).toMatch(
+          /<Card\b[^>]*>\s*(?:\{\/\*[\s\S]*?\*\/\}\s*)*<Table\.ScrollContainer\b[^>]*>\s*<Table\b/
+        );
+        // …and it closes in the mirror order, so the table is genuinely nested in
+        // both rather than merely preceded by them.
+        expect(src).toMatch(/<\/Table>\s*<\/Table\.ScrollContainer>\s*<\/Card>/);
       });
 
       it('feeds that container the SHARED constant, not a width literal', () => {
@@ -681,15 +744,15 @@ describe('both my-submissions tables scroll rather than clip (S3, structural)', 
         expect(src).toMatch(/from '~\/components\/Apps\/submissionsTable'/);
         // …and the container must consume it rather than a hardcoded number, which
         // is how the two lists would silently diverge.
-        expect(src).toMatch(/minWidth=\{SUBMISSIONS_TABLE_MIN_WIDTH\}/);
-        expect(src).not.toMatch(/minWidth=\{\s*\d/);
+        expect(src).toMatch(inTag(String.raw`minWidth=\{SUBMISSIONS_TABLE_MIN_WIDTH\}`));
+        expect(src).not.toMatch(inTag(String.raw`minWidth=\{\s*\d`));
       });
 
       it('uses the native scroll box, so the scrollbar is not hover-hidden', () => {
         // Mantine's ScrollArea (Table.ScrollContainer's default) defaults to
         // `type="hover"` — scrollbars appear only on hover. The measured defect IS a
         // missing affordance, so the native overflow box is deliberate.
-        expect(read(file)).toMatch(/type="native"/);
+        expect(read(file)).toMatch(inTag('type="native"'));
       });
     });
   }

--- a/src/components/Apps/__tests__/submissionsTable.test.ts
+++ b/src/components/Apps/__tests__/submissionsTable.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from 'fs';
+import path from 'path';
 import { describe, expect, it } from 'vitest';
 import { isModRemovedListing } from '~/components/Apps/offsiteOwnerControls';
 import {
@@ -16,6 +18,7 @@ import {
   statusBucket,
   statusRank,
   STATUS_SECTION_ORDER,
+  SUBMISSIONS_TABLE_MIN_WIDTH,
   toDate,
   type SortState,
   type SubmissionAccessors,
@@ -178,7 +181,9 @@ describe('groupSubmissionsByApp — version collapse', () => {
     const block = groups.find((g: SubmissionGroup<Row>) => g.identity === 'block-123');
     expect(block?.versionCount).toBe(2);
     expect(block?.latest.id).toBe('onsite-2');
-    expect(groups.find((g: SubmissionGroup<Row>) => g.identity === 'my-slug')?.versionCount).toBe(1);
+    expect(groups.find((g: SubmissionGroup<Row>) => g.identity === 'my-slug')?.versionCount).toBe(
+      1
+    );
   });
 
   it('does not mutate the input array', () => {
@@ -207,7 +212,9 @@ describe('filterGroups — matches if ANY version matches', () => {
   });
 
   it('filters out a group when no version matches', () => {
-    expect(filterGroups(groups, 'Other', A).map((g: SubmissionGroup<Row>) => g.identity)).toEqual(['other']);
+    expect(filterGroups(groups, 'Other', A).map((g: SubmissionGroup<Row>) => g.identity)).toEqual([
+      'other',
+    ]);
   });
 
   it('an empty query returns all groups', () => {
@@ -239,7 +246,8 @@ describe('sortGroups — by the latest version of each group', () => {
     A.submittedAt
   );
 
-  const ids = (s: SortState) => sortGroups(groups, s, A).map((g: SubmissionGroup<Row>) => g.identity);
+  const ids = (s: SortState) =>
+    sortGroups(groups, s, A).map((g: SubmissionGroup<Row>) => g.identity);
 
   it('sorts by App text asc/desc', () => {
     expect(ids({ column: 'app', direction: 'asc' })).toEqual(['alpha', 'bravo']);
@@ -427,7 +435,10 @@ describe('statusBucket / bucketGroupsByStatus — status sections', () => {
     expect(buckets.pending.map((g: SubmissionGroup<Row>) => g.identity)).toEqual(['pending-app']);
     expect(buckets.rejected.map((g: SubmissionGroup<Row>) => g.identity)).toEqual(['rejected-app']);
     // Unknown status ('archived') falls back into the closed Withdrawn section.
-    expect(buckets.withdrawn.map((g: SubmissionGroup<Row>) => g.identity)).toEqual(['withdrawn-app', 'weird-app']);
+    expect(buckets.withdrawn.map((g: SubmissionGroup<Row>) => g.identity)).toEqual([
+      'withdrawn-app',
+      'weird-app',
+    ]);
   });
 
   it('preserves the incoming group order within a bucket (a pre-applied sort is kept)', () => {
@@ -533,7 +544,9 @@ describe('bucketGroupsByStatus — mod-removed override (precedence fix)', () =>
     const buckets = bucketize(rows);
     expect(buckets.pending.map((g: SubmissionGroup<Row>) => g.identity)).toEqual(['pending-app']);
     expect(buckets.rejected.map((g: SubmissionGroup<Row>) => g.identity)).toEqual(['rejected-app']);
-    expect(buckets.withdrawn.map((g: SubmissionGroup<Row>) => g.identity)).toEqual(['withdrawn-app']);
+    expect(buckets.withdrawn.map((g: SubmissionGroup<Row>) => g.identity)).toEqual([
+      'withdrawn-app',
+    ]);
     expect(buckets['mod-removed']).toEqual([]);
     expect(buckets.live).toEqual([]);
   });
@@ -611,4 +624,73 @@ describe('toDate', () => {
     expect(toDate(undefined)).toBeNull();
     expect(toDate('not-a-date')).toBeNull();
   });
+});
+
+/**
+ * S3 — /apps/my-submissions horizontal-overflow guard.
+ *
+ * Measured defect (1497 x 1152 CSS px, dark, logged-in): the onsite submissions
+ * `.mantine-Card-root` computed `clientWidth 1286` / `scrollWidth 1424` with
+ * `overflow-x: hidden` — 138 px of row actions clipped with NO scroll affordance.
+ * Six `Revenue` buttons computed `right: 1499` against `innerWidth: 1497`.
+ *
+ * 🔴 HONESTY NOTE — what these tests do and do not prove.
+ *   - They CANNOT prove "the buttons are no longer clipped". That is a computed
+ *     layout property of a real browser at a real viewport with the real Mantine
+ *     stylesheet loaded; no node test can observe it, and the browser-mode project
+ *     has no page CSS. The correctness gate for the clipping itself is the manual
+ *     re-measurement recorded in the PR body.
+ *   - The `SUBMISSIONS_TABLE_MIN_WIDTH` value assertion is a VALUE PIN (a
+ *     change-detector), same class as `appListingGrid.test.ts`. Its worth is that
+ *     "the floor was not silently narrowed below the measured need" becomes a real
+ *     assertion instead of a code-review promise.
+ *   - The structural assertions below ARE a real regression gate for the fix's
+ *     mechanism: they fail if either list loses its `Table.ScrollContainer`, or
+ *     hardcodes a width literal instead of importing the shared constant, or lets
+ *     the two lists diverge onto different floors. That is exactly how this defect
+ *     would come back.
+ */
+describe('SUBMISSIONS_TABLE_MIN_WIDTH', () => {
+  it('is at least the onsite table’s measured natural width (1424 px)', () => {
+    // Below this, the full six-button action row cannot be laid out without the
+    // columns collapsing — the state the measurement was taken in.
+    expect(SUBMISSIONS_TABLE_MIN_WIDTH).toBeGreaterThanOrEqual(1424);
+  });
+
+  it('is a finite positive pixel count (a scroll floor, not a sentinel)', () => {
+    expect(Number.isFinite(SUBMISSIONS_TABLE_MIN_WIDTH)).toBe(true);
+    expect(SUBMISSIONS_TABLE_MIN_WIDTH).toBeGreaterThan(0);
+  });
+});
+
+describe('both my-submissions tables scroll rather than clip (S3, structural)', () => {
+  const APPS_DIR = path.resolve(__dirname, '..');
+  const read = (file: string) => readFileSync(path.join(APPS_DIR, file), 'utf8');
+  const LISTS = ['MySubmissionsList.tsx', 'OffsiteSubmissionsList.tsx'] as const;
+
+  for (const file of LISTS) {
+    describe(file, () => {
+      it('wraps its Table in a Table.ScrollContainer', () => {
+        expect(read(file)).toMatch(/<Table\.ScrollContainer\b/);
+      });
+
+      it('feeds that container the SHARED constant, not a width literal', () => {
+        const src = read(file);
+        // The import must come from the shared pure module…
+        expect(src).toMatch(/SUBMISSIONS_TABLE_MIN_WIDTH/);
+        expect(src).toMatch(/from '~\/components\/Apps\/submissionsTable'/);
+        // …and the container must consume it rather than a hardcoded number, which
+        // is how the two lists would silently diverge.
+        expect(src).toMatch(/minWidth=\{SUBMISSIONS_TABLE_MIN_WIDTH\}/);
+        expect(src).not.toMatch(/minWidth=\{\s*\d/);
+      });
+
+      it('uses the native scroll box, so the scrollbar is not hover-hidden', () => {
+        // Mantine's ScrollArea (Table.ScrollContainer's default) defaults to
+        // `type="hover"` — scrollbars appear only on hover. The measured defect IS a
+        // missing affordance, so the native overflow box is deliberate.
+        expect(read(file)).toMatch(/type="native"/);
+      });
+    });
+  }
 });

--- a/src/components/Apps/submissionsTable.ts
+++ b/src/components/Apps/submissionsTable.ts
@@ -28,8 +28,25 @@
  * container converts that silent clip into a real horizontal scroll.
  *
  * The value is seeded from that measurement: 1424 px is the onsite table's measured
- * natural width with the full action set, so at container widths >= 1424 nothing
- * scrolls at all and below it every action stays reachable.
+ * natural width with the full action set, so the table scrolls exactly when the
+ * card is narrower than 1424 and not otherwise.
+ *
+ * 🔴 THE FLOOR ALONE WAS NOT ENOUGH — see {@link MY_SUBMISSIONS_CONTAINER_SIZE}.
+ * The page's container was `AppsPageLayout`'s default `'xl'`, i.e. Mantine's 1320 px
+ * token, which is a MAX-width: at every viewport >= 1320 px the card computed a
+ * constant 1320 − 32 (Container padding) − 2 (Card border) = 1286 px. 1286 < 1424,
+ * so a scroll container on its own left a permanent ~138 px scroll region on EVERY
+ * desktop viewport — the clip became a scrollbar rather than going away. The page
+ * therefore also widens its container past this floor.
+ *
+ * 🔴 The wrapper clips on BOTH axes. Mantine's `Table.ScrollContainer` sets only
+ * `overflow-x`; per the CSS overflow spec a non-`visible` value on one axis computes
+ * the other to `auto`, so `overflow-y` is `auto` too (browser-confirmed). That is
+ * safe today only because the two in-cell overlays these rows render explicitly pass
+ * `withinPortal` (`AppAnalyticsInline`'s `Tooltip` and `ListingProblemsIndicator`'s
+ * `HoverCard`) — and the repo theme sets `Popover: { defaultProps: { withinPortal: false } }`
+ * GLOBALLY, so any future non-portaled `Popover`/`HoverCard`/`Menu` rendered inside
+ * a cell WILL be clipped by this wrapper. Portal it, or it will be cut off.
  *
  * 🔴 SHARED BY BOTH LISTS ON PURPOSE. The offsite table (6 columns) is narrower
  * today and would not need this large a floor on its own, but:
@@ -46,6 +63,30 @@
  * constants HERE — do not hardcode a literal at a call site.
  */
 export const SUBMISSIONS_TABLE_MIN_WIDTH = 1424;
+
+/**
+ * Chrome (px) that `AppsPageLayout` + the submissions `Card` take out of the
+ * container width before the table sees it: Mantine `Container` pads `2 x 16`, and
+ * `<Card withBorder>` draws a `1 px` border on each side.
+ */
+export const SUBMISSIONS_CONTAINER_CHROME = 34;
+
+/**
+ * The `AppsPageLayout` container width (raw px) for /apps/my-submissions.
+ *
+ * `AppsPageLayout` defaults to `size='xl'` = Mantine's 1320 px token, and that is a
+ * MAX-width — so the card computed a CONSTANT 1286 px at every viewport >= 1320 px,
+ * permanently below {@link SUBMISSIONS_TABLE_MIN_WIDTH}. Left at `'xl'`, the scroll
+ * container would simply have converted the silent clip into a scrollbar that is
+ * always there on desktop. Widening the container past the floor is what actually
+ * removes the overflow at desktop widths; the scroll container remains the safety
+ * net below that (narrow desktop, tablet, mobile) and for future column growth.
+ *
+ * `Container` accepts a raw number — the store index already widens this way. The
+ * value is not viewport-clamped by us: `Container` is max-width, so a narrower
+ * viewport just yields a narrower container and the table scrolls, as intended.
+ */
+export const MY_SUBMISSIONS_CONTAINER_SIZE = 1500;
 
 /** Sortable columns shared by both tables. */
 export type SortColumn = 'app' | 'status' | 'submitted' | 'reviewed';

--- a/src/components/Apps/submissionsTable.ts
+++ b/src/components/Apps/submissionsTable.ts
@@ -12,6 +12,41 @@
  * concrete `Submission` / `OffsiteSubmission` types.
  */
 
+// ── layout ─────────────────────────────────────────────────────────────────────
+
+/**
+ * The horizontal floor (px) for BOTH /apps/my-submissions tables, handed to
+ * Mantine's `Table.ScrollContainer` as `minWidth`.
+ *
+ * Why it exists: both lists render `<Table>` inside `<Card withBorder p={0}>`, and
+ * Mantine's `.mantine-Card-root` sets `overflow: hidden`. The onsite row's action
+ * cell is a `<Group wrap="nowrap">` of up to six buttons (Open live · Unpublish /
+ * Republish · Edit · Listing images · Revenue · History), so the row has a hard
+ * min-content width that the card SILENTLY CLIPPED — measured at 1497 px viewport:
+ * card `clientWidth 1286` vs `scrollWidth 1424`, i.e. 138 px of row actions cut off
+ * with no scrollbar and no other affordance. Wrapping the table in a scroll
+ * container converts that silent clip into a real horizontal scroll.
+ *
+ * The value is seeded from that measurement: 1424 px is the onsite table's measured
+ * natural width with the full action set, so at container widths >= 1424 nothing
+ * scrolls at all and below it every action stays reachable.
+ *
+ * 🔴 SHARED BY BOTH LISTS ON PURPOSE. The offsite table (6 columns) is narrower
+ * today and would not need this large a floor on its own, but:
+ *   - the two tables are stacked sections of the SAME page, and a shared floor keeps
+ *     them the same width instead of stepping against each other;
+ *   - the offsite action cell is converging on the onsite one (Edit · Unpublish /
+ *     Republish · Withdraw · History · problems indicator · revision badge), so a
+ *     shared floor stops it silently re-acquiring the same clip as it grows;
+ *   - any separate offsite number would be invented — nobody has measured that
+ *     table's natural width.
+ * Accepted cost: on the offsite table this introduces horizontal scrolling at
+ * container widths between its own natural width and 1424 where there is none today.
+ * If someone measures the offsite table and wants its own floor, split this into two
+ * constants HERE — do not hardcode a literal at a call site.
+ */
+export const SUBMISSIONS_TABLE_MIN_WIDTH = 1424;
+
 /** Sortable columns shared by both tables. */
 export type SortColumn = 'app' | 'status' | 'submitted' | 'reviewed';
 export type SortDirection = 'asc' | 'desc';
@@ -345,10 +380,7 @@ export const MOD_STATUS_BUCKETS: StatusBucketConfig<ModStatusBucket> = {
  * key `B` so the owner view yields exactly `{live,pending,rejected,withdrawn}` and
  * the mod view yields its own set.
  */
-export type BucketedGroups<T, B extends string = StatusBucket> = Record<
-  B,
-  SubmissionGroup<T>[]
->;
+export type BucketedGroups<T, B extends string = StatusBucket> = Record<B, SubmissionGroup<T>[]>;
 
 /**
  * Partition already-grouped submissions into a consumer's status sections

--- a/src/pages/apps/my-submissions.tsx
+++ b/src/pages/apps/my-submissions.tsx
@@ -10,6 +10,7 @@ import {
   type OffsiteSubmission,
 } from '~/components/Apps/OffsiteSubmissionsList';
 import { Meta } from '~/components/Meta/Meta';
+import { MY_SUBMISSIONS_CONTAINER_SIZE } from '~/components/Apps/submissionsTable';
 import { useFeatureFlags } from '~/providers/FeatureFlagsProvider';
 import { isAppDeveloper } from '~/shared/utils/app-blocks-access';
 import { createServerSideProps } from '~/server/utils/server-side-helpers';
@@ -99,6 +100,10 @@ export default function MySubmissionsPage() {
     <>
       <Meta title="My app submissions — Civitai" deIndex />
       <AppsPageLayout
+        // Wider than the layout default (`xl` = 1320, a MAX-width that made the card
+        // a constant 1286 px on every desktop viewport — permanently narrower than
+        // the table needs). See MY_SUBMISSIONS_CONTAINER_SIZE.
+        size={MY_SUBMISSIONS_CONTAINER_SIZE}
         title="My submissions"
         subtitle="Status of every app submission you've made. Open a row's reviewer notes to see mod feedback; pending submissions can be withdrawn."
         actions={


### PR DESCRIPTION
> [!IMPORTANT]
> **Three verification claims below were found to be wrong by a later audit and are corrected in [this comment](https://github.com/civitai/civitai/pull/3492#issuecomment-5139660410).** In short: the `type="native"` break-it row is false (the guard was a whole-file regex satisfied by a code comment — now anchored); "each mutation failed exactly one test" is wrong for the wrapper drops (2 and 3); and the off-site scrollbar cost was every desktop width, not a band — the page container capped at 1286px, below the 1424px floor, so the floor alone left a permanent scrollbar. All three are fixed in the follow-up commit, which also adds a placement guard.

## The defect

On `/apps/my-submissions` the submissions table sits in `<Card withBorder p={0}>`, and Mantine's `.mantine-Card-root` is `overflow: hidden`. The row's action cell is a `<Group wrap="nowrap">` of up to six buttons (Open live · Unpublish/Republish · Edit · Listing images · Revenue · History), so the row has a hard min-content width that the card **silently clipped**.

Measured at a 1497 × 1152 CSS-px viewport, dark, signed in:

- the card computed `clientWidth 1286` / `scrollWidth 1424` with `overflow-x: hidden` — **138 px of row actions cut off, with no scrollbar and no other affordance**;
- six `Revenue` buttons computed `right: 1499` against `innerWidth: 1497`.

This is a creator's own submission-management page, and the clipped controls are the ones they manage a published app with.

## The fix

Wrap both submissions tables in Mantine's `Table.ScrollContainer`, with a shared pixel floor pinned in the existing pure module `submissionsTable.ts`.

```tsx
<Card withBorder p={0}>
  <Table.ScrollContainer minWidth={SUBMISSIONS_TABLE_MIN_WIDTH} type="native">
    <Table …>
```

Two deliberate choices worth reviewing:

**`type="native"`, not the default.** `Table.ScrollContainer` defaults to `type="scrollarea"` (Mantine `ScrollArea`), whose own default is `type="hover"` — scrollbars only appear on hover. The measured defect *is* a missing affordance, so the native `overflow-x: auto` box is the better answer: the platform scrollbar is drawn, and native keyboard/trackpad scrolling is preserved with no custom scroll implementation in between. This deviates from the two in-repo precedents (`ReportTabs.tsx`, `ManageItemsTable.tsx`), which both use the default — calling it out so it's a decision, not a slip.

**One shared constant across both lists.** The off-site table (6 columns) is narrower today and would not need a 1424 px floor on its own. It shares the constant anyway because (a) the two tables are stacked sections of the same page and a shared floor keeps them the same width instead of stepping against each other, (b) the off-site action cell is converging on the on-site one (Edit · Unpublish/Republish · Withdraw · History · problems indicator · revision badge), so a shared floor stops it silently re-acquiring the same clip as it grows, and (c) any separate off-site number would be invented — nobody has measured that table's natural width.

**Accepted cost of (c):** on the off-site table this introduces horizontal scrolling at container widths between its own natural width and 1424 px, where there is none today. The rationale and the "split it here, never at a call site" instruction are written into the constant's doc comment.

## What the tests actually prove — and what they don't

🔴 **No test here proves "the buttons are no longer clipped."** That is a computed layout property of a real browser at a real viewport with the real Mantine stylesheet loaded. The correctness gate for the clipping itself is manual re-measurement (below).

**Value pin (a change-detector, not a defect gate):**
- `SUBMISSIONS_TABLE_MIN_WIDTH >= 1424` — same class as `appListingGrid.test.ts`. Its worth is that "the floor was not silently narrowed below the measured need" becomes a real assertion instead of a code-review promise.
- `Number.isFinite(...) && > 0` — a sanity bound on the same constant.

**Real regression gates (node `unit`, runs locally).** A structural guard over both list sources, asserting each one: wraps its `<Table>` in a `Table.ScrollContainer`; feeds it the **shared constant** rather than a width literal; and uses `type="native"`. These fail on exactly the edits that would bring the defect back — removing the wrapper, hardcoding a number, or letting the two lists diverge onto different floors. (Precedent for the shape: `marketplace-category-icons-single-source.test.ts`.)

**Component project (report-only, CI-only).** One DOM-structure test per list asserting the table's nearest scroll wrapper *is* the `Table.ScrollContainer`. It asserts structure, never a computed `overflow` value — this env has no Mantine theme CSS. 🔴 **These were NOT executed locally** (browser mode needs Playwright Chromium, which cannot run on the authoring machine); they typecheck locally and execute only in CI.

### Break-it verification

Every new assertion was killed by a deliberate mutation, then reverted. Each mutation failed **exactly one** test — the intended one:

| Mutation | Test that failed |
|---|---|
| `SUBMISSIONS_TABLE_MIN_WIDTH` 1424 → 1286 (the measured clipped width) | `is at least the onsite table's measured natural width (1424 px)` |
| constant → `Number.POSITIVE_INFINITY` | `is a finite positive pixel count` |
| on-site: drop the `Table.ScrollContainer` wrapper | `MySubmissionsList.tsx > wraps its Table in a Table.ScrollContainer` |
| off-site: drop the `Table.ScrollContainer` wrapper | `OffsiteSubmissionsList.tsx > wraps its Table in a Table.ScrollContainer` |
| on-site: `minWidth={1424}` literal instead of the constant | `MySubmissionsList.tsx > feeds that container the SHARED constant` |
| off-site: `minWidth={960}` (the silent-divergence case) | `OffsiteSubmissionsList.tsx > feeds that container the SHARED constant` |
| on-site: drop `type="native"` | `MySubmissionsList.tsx > uses the native scroll box` |
| off-site: drop `type="native"` | `OffsiteSubmissionsList.tsx > uses the native scroll box` |

The two component tests were **not** mutation-checked — they cannot be executed on the authoring machine.

### Typecheck

`NODE_OPTIONS=--max_old_space_size=8192 npx tsc --noEmit` on this branch and on a clean checkout of the base commit produce a **byte-identical** 26-error list (missing sibling `event-engine-common` module graph, an unresolvable `kysely`, and stale `@civitai/buzz` exports — all pre-existing and environmental). **Zero errors in `src/components/Apps/`; this change adds none.**

## Accessibility review of the change

- The wrapper adds two `<div>`s **between the Card and the `<table>`** — outside the table's own element tree, so table/row/cell semantics and screen-reader table navigation are unchanged.
- No `role="region"`, `tabindex`, or `aria-label` is added, so there is **no new landmark and no new tab stop**. On this page that would have meant up to ten extra tab stops (two lists × five status sections).
- Keyboard reachability of the clipped controls is **improved, not traded**: every piece of content that was being cut off is a `<button>` or link, so Tab already brings it into view — and now it scrolls in a container the user can also drive directly. Modern Chromium additionally makes scroll containers focusable in their own right.
- 🔴 Known residual: the WCAG-adjacent belt for scrollable tables (`role="region"` + `tabindex="0"` + accessible name) is deliberately **not** applied here, on the grounds above. If the tab-stop cost is judged acceptable, it is a small follow-up.

## 🔴 What this presumes about narrow viewports — unverified

Nobody has measured this page below 1497 px, and that measurement has been **deferred**, so everything here is a reasoned expectation rather than an observation:

- **On-site table: strictly better at every width.** Today the card clips at *all* widths below the table's natural width, so a phone is already losing actions silently. After this change it scrolls instead.
- **Off-site table:** better on genuinely narrow screens (same reason), worse in the band between its natural width and 1424 px, where it gains a scrollbar it does not need today.
- **The presumption itself:** that "wide table + horizontal scroll" is an acceptable small-screen pattern for this page. It is not obviously right — a 1424 px floor on a 390 px phone is a ~3.6× scroll region. If mobile wants a stacked/card layout instead, this change does not block that; it just isn't it.
- This PR deliberately does **not** widen the page container, and does **not** collapse the six-button action row behind a `⋯` overflow menu. The menu is arguably the site-idiomatic answer to "six buttons in a table cell", but it hides actions behind a click — a product change, not the measured defect. Flagging it, not choosing it.

## Also noted, deliberately not changed

`AppListingsModerationTable.tsx` has the identical `<Card withBorder p={0}><Table>` shape (4 visible columns + actions) and is therefore latently exposed to the same clip. It is the moderator surface and out of scope here; left for a separate change so this one stays confined to `/apps/my-submissions`.

## Blast radius

`/apps/my-submissions` only. `MySubmissionsList` and `OffsiteSubmissionsList` have no other consumers. `submissionsTable.ts` is also imported by `AppListingsModerationTable` and `submissionsTableUi` — this adds an export and changes no existing behaviour there.

## Manual verification still owed (cannot be done from a test)

At 1497 × 1152, dark, signed in, on `/apps/my-submissions`:

- the clipping ancestor's computed `overflow-x` is `auto`/`scroll`, not `hidden` (today: `hidden` with a 1286/1424 delta);
- every `Revenue` button's `getBoundingClientRect().right <= window.innerWidth` at `scrollLeft: 0`, or reachable after scrolling the container (baseline: `right: 1499` vs `innerWidth: 1497`);
- both status-section tables still render, and section collapse/expand still works.

