### PR TITLE
feat(apps): retire the legacy /apps/[appBlockId] detail page — redirect to the store detail

### DIFF
--- a/src/components/Apps/__tests__/resolveLegacyAppRedirect.test.ts
+++ b/src/components/Apps/__tests__/resolveLegacyAppRedirect.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from 'vitest';
+import { resolveLegacyAppRedirect, STORE_PREVIEW_PATH_PREFIX } from '../resolveLegacyAppRedirect';
+
+/**
+ * S8 / PR-2 — the retirement decision for the legacy `/apps/[appBlockId]` detail
+ * route. These are a REAL gate, not a change-detector: the whole PR is two
+ * branches, and the second one (no approved listing → `notFound`) is a product
+ * decision that a future "helpful" edit would otherwise silently invert into a
+ * redirect to `/apps` with nothing failing.
+ *
+ * Break-it checks these are written to survive:
+ *   - turn the no-listing branch into `{ redirect: { destination: '/apps' } }`
+ *     → the `notFound` cases below must FAIL.
+ *   - drop `encodeURIComponent` → the escaping case must FAIL.
+ *   - flip `permanent` to true → the 302 case must FAIL.
+ */
+
+describe('resolveLegacyAppRedirect — approved listing → store-preview redirect', () => {
+  it('redirects to /apps/store-preview/<slug> as a temporary (302) redirect', () => {
+    expect(resolveLegacyAppRedirect({ slug: 'model-benchmarking' })).toEqual({
+      redirect: {
+        destination: '/apps/store-preview/model-benchmarking',
+        permanent: false,
+      },
+    });
+  });
+
+  it('is never a permanent redirect (the route retirement is still reversible)', () => {
+    const result = resolveLegacyAppRedirect({ slug: 'vitrine' });
+    expect(result).toHaveProperty('redirect');
+    if (!('redirect' in result)) throw new Error('expected a redirect');
+    expect(result.redirect.permanent).toBe(false);
+    expect(result).not.toHaveProperty('notFound');
+  });
+
+  it('always lands under the store-preview path prefix', () => {
+    const result = resolveLegacyAppRedirect({ slug: 'some-app' });
+    if (!('redirect' in result)) throw new Error('expected a redirect');
+    expect(result.redirect.destination.startsWith(STORE_PREVIEW_PATH_PREFIX)).toBe(true);
+  });
+});
+
+describe('resolveLegacyAppRedirect — NO approved listing → site-standard 404', () => {
+  // 🔴 The decided miss behaviour. Listings are created at APPROVAL, so a
+  // pending / rejected / never-approved app has no slug to send anyone to. This
+  // must be `notFound` — NOT a redirect to `/apps`, which silently dead-ends the
+  // owner looking for their own pending app.
+  it('slug null (no listing row) → notFound, never a redirect', () => {
+    const result = resolveLegacyAppRedirect({ slug: null });
+    expect(result).toEqual({ notFound: true });
+    expect(result).not.toHaveProperty('redirect');
+  });
+
+  it('slug undefined / key absent → notFound, never a redirect', () => {
+    expect(resolveLegacyAppRedirect({ slug: undefined })).toEqual({ notFound: true });
+    expect(resolveLegacyAppRedirect({})).toEqual({ notFound: true });
+    const result = resolveLegacyAppRedirect({});
+    expect(result).not.toHaveProperty('redirect');
+  });
+
+  it('empty / whitespace-only slug → notFound (not a redirect to the bare prefix)', () => {
+    expect(resolveLegacyAppRedirect({ slug: '' })).toEqual({ notFound: true });
+    expect(resolveLegacyAppRedirect({ slug: '   ' })).toEqual({ notFound: true });
+    expect(resolveLegacyAppRedirect({ slug: '\t\n' })).toEqual({ notFound: true });
+  });
+
+  it('a non-string slug (defensive: untyped/JSON input) → notFound', () => {
+    // Guards the runtime edge a `string | null` type does not: a DB/serialization
+    // surprise must fail closed to 404, never build `/apps/store-preview/[object Object]`.
+    expect(resolveLegacyAppRedirect({ slug: 123 as unknown as string })).toEqual({
+      notFound: true,
+    });
+    expect(resolveLegacyAppRedirect({ slug: {} as unknown as string })).toEqual({
+      notFound: true,
+    });
+  });
+
+  it('never returns a redirect to /apps for a missing listing', () => {
+    // Named guard for the rejected alternative, so an edit back to it fails here
+    // with an obvious message rather than only tripping the toEqual above.
+    for (const slug of [null, undefined, '', '  ']) {
+      const result = resolveLegacyAppRedirect({ slug });
+      const destination = 'redirect' in result ? result.redirect.destination : null;
+      expect(destination).not.toBe('/apps');
+      expect(destination).toBeNull();
+    }
+  });
+});
+
+describe('resolveLegacyAppRedirect — slug encoding / open-redirect containment', () => {
+  it('percent-encodes URL-unsafe characters in the slug', () => {
+    const result = resolveLegacyAppRedirect({ slug: 'a b/c?d#e' });
+    if (!('redirect' in result)) throw new Error('expected a redirect');
+    expect(result.redirect.destination).toBe('/apps/store-preview/a%20b%2Fc%3Fd%23e');
+  });
+
+  it('a protocol-relative slug cannot escape to another origin', () => {
+    // `//evil.example` un-encoded would be a protocol-relative URL — an open
+    // redirect off civitai.com. Encoded, it stays a path segment.
+    const result = resolveLegacyAppRedirect({ slug: '//evil.example' });
+    if (!('redirect' in result)) throw new Error('expected a redirect');
+    expect(result.redirect.destination).toBe('/apps/store-preview/%2F%2Fevil.example');
+    expect(result.redirect.destination.startsWith(STORE_PREVIEW_PATH_PREFIX)).toBe(true);
+  });
+
+  it('path traversal in a slug cannot climb out of /apps/store-preview/', () => {
+    const result = resolveLegacyAppRedirect({ slug: '../../login' });
+    if (!('redirect' in result)) throw new Error('expected a redirect');
+    expect(result.redirect.destination).toBe('/apps/store-preview/..%2F..%2Flogin');
+  });
+
+  it('an ordinary hyphenated slug is passed through unchanged (no over-escaping)', () => {
+    const result = resolveLegacyAppRedirect({ slug: 'df-qwen-canvas' });
+    if (!('redirect' in result)) throw new Error('expected a redirect');
+    expect(result.redirect.destination).toBe('/apps/store-preview/df-qwen-canvas');
+  });
+
+  it('trims surrounding whitespace rather than encoding it into the path', () => {
+    const result = resolveLegacyAppRedirect({ slug: '  vitrine  ' });
+    if (!('redirect' in result)) throw new Error('expected a redirect');
+    expect(result.redirect.destination).toBe('/apps/store-preview/vitrine');
+  });
+});

--- a/src/components/Apps/__tests__/resolveLegacyAppRedirect.test.ts
+++ b/src/components/Apps/__tests__/resolveLegacyAppRedirect.test.ts
@@ -13,11 +13,15 @@ import {
  * decision that a future "helpful" edit would otherwise silently invert into a
  * redirect to `/apps` with nothing failing.
  *
- * Break-it checks these are written to survive:
+ * Break-it checks these are written to survive — each was run against the source
+ * and confirmed to fail before being reverted:
  *   - turn the no-listing branch into `{ redirect: { destination: '/apps' } }`
- *     → the `notFound` cases below must FAIL.
- *   - drop `encodeURIComponent` → the escaping case must FAIL.
- *   - flip `permanent` to true → the 302 case must FAIL.
+ *     → 5 FAIL (the `notFound` cases).
+ *   - drop `encodeURIComponent` → 3 FAIL (the encoding/containment cases).
+ *   - flip `permanent` to true → 2 FAIL.
+ *   - move the store-visibility gate AFTER the lookup → 2 FAIL (the ordering
+ *     cases in `resolveLegacyAppRoute`).
+ *   - drop `status: 'approved'` from the query → 1 FAIL (the query-shape pin).
  */
 
 describe('resolveLegacyAppRedirect — approved listing → store-preview redirect', () => {
@@ -38,10 +42,16 @@ describe('resolveLegacyAppRedirect — approved listing → store-preview redire
     expect(result).not.toHaveProperty('notFound');
   });
 
-  it('always lands under the store-preview path prefix', () => {
+  it('the slug occupies exactly one path segment under the prefix', () => {
+    // NB: asserting `startsWith(STORE_PREVIEW_PATH_PREFIX)` would be a tautology —
+    // the destination is built by concatenating that same exported constant, so it
+    // cannot fail. What CAN fail, and is the property worth pinning, is that the
+    // slug never introduces a second segment.
     const result = resolveLegacyAppRedirect({ slug: 'some-app' });
     if (!('redirect' in result)) throw new Error('expected a redirect');
-    expect(result.redirect.destination.startsWith(STORE_PREVIEW_PATH_PREFIX)).toBe(true);
+    const slugSegment = result.redirect.destination.slice(STORE_PREVIEW_PATH_PREFIX.length);
+    expect(slugSegment).toBe('some-app');
+    expect(slugSegment.includes('/')).toBe(false);
   });
 });
 
@@ -103,7 +113,11 @@ describe('resolveLegacyAppRedirect — slug encoding / open-redirect containment
     const result = resolveLegacyAppRedirect({ slug: '//evil.example' });
     if (!('redirect' in result)) throw new Error('expected a redirect');
     expect(result.redirect.destination).toBe('/apps/store-preview/%2F%2Fevil.example');
-    expect(result.redirect.destination.startsWith(STORE_PREVIEW_PATH_PREFIX)).toBe(true);
+    // The property that actually matters: no slash survives into the slug segment,
+    // so the destination can never resolve as `//host` or climb a directory.
+    expect(result.redirect.destination.slice(STORE_PREVIEW_PATH_PREFIX.length).includes('/')).toBe(
+      false
+    );
   });
 
   it('path traversal in a slug cannot climb out of /apps/store-preview/', () => {

--- a/src/components/Apps/__tests__/resolveLegacyAppRedirect.test.ts
+++ b/src/components/Apps/__tests__/resolveLegacyAppRedirect.test.ts
@@ -1,5 +1,10 @@
-import { describe, it, expect } from 'vitest';
-import { resolveLegacyAppRedirect, STORE_PREVIEW_PATH_PREFIX } from '../resolveLegacyAppRedirect';
+import { describe, it, expect, vi } from 'vitest';
+import {
+  approvedListingSlugQuery,
+  resolveLegacyAppRedirect,
+  resolveLegacyAppRoute,
+  STORE_PREVIEW_PATH_PREFIX,
+} from '../resolveLegacyAppRedirect';
 
 /**
  * S8 / PR-2 — the retirement decision for the legacy `/apps/[appBlockId]` detail
@@ -80,9 +85,7 @@ describe('resolveLegacyAppRedirect — NO approved listing → site-standard 404
     // with an obvious message rather than only tripping the toEqual above.
     for (const slug of [null, undefined, '', '  ']) {
       const result = resolveLegacyAppRedirect({ slug });
-      const destination = 'redirect' in result ? result.redirect.destination : null;
-      expect(destination).not.toBe('/apps');
-      expect(destination).toBeNull();
+      expect('redirect' in result, `slug ${JSON.stringify(slug)} must not redirect`).toBe(false);
     }
   });
 });
@@ -119,5 +122,118 @@ describe('resolveLegacyAppRedirect — slug encoding / open-redirect containment
     const result = resolveLegacyAppRedirect({ slug: '  vitrine  ' });
     if (!('redirect' in result)) throw new Error('expected a redirect');
     expect(result.redirect.destination).toBe('/apps/store-preview/vitrine');
+  });
+});
+
+/**
+ * The SSR half. The string concat above is the easy part; the parts that can
+ * actually hurt are the GATE ORDERING and the APPROVED-ONLY precondition, and
+ * neither is visible to a test of `resolveLegacyAppRedirect` alone — by the time
+ * it runs, the gate has already been passed and the slug already handed over.
+ * `resolveLegacyAppRoute` takes the lookup as an argument precisely so both are
+ * assertable here.
+ */
+describe('resolveLegacyAppRoute — SSR gate ordering', () => {
+  const lookup = (slug: string | null) => vi.fn(async (): Promise<string | null> => slug);
+
+  it('no store visibility → notFound, and the DB is NEVER QUERIED', async () => {
+    // 🔴 The load-bearing assertion. Returning notFound is not enough: if the
+    // lookup runs first and the gate second, an ungranted viewer still causes a
+    // query, and timing/load become a side channel. Assert the call count.
+    const findApprovedListingSlug = lookup('model-benchmarking');
+    const result = await resolveLegacyAppRoute({
+      features: { appBlocks: false, appListings: false },
+      appBlockId: 'apb_01KXPENN70SG0RXQKN7WMJMJHF',
+      findApprovedListingSlug,
+    });
+    expect(result).toEqual({ notFound: true });
+    expect(findApprovedListingSlug).not.toHaveBeenCalled();
+  });
+
+  it('absent / null features → notFound, no query (fails closed)', async () => {
+    for (const features of [undefined, null, {}]) {
+      const findApprovedListingSlug = lookup('vitrine');
+      expect(
+        await resolveLegacyAppRoute({ features, appBlockId: 'apb_x', findApprovedListingSlug })
+      ).toEqual({ notFound: true });
+      expect(findApprovedListingSlug).not.toHaveBeenCalled();
+    }
+  });
+
+  it('either store-visibility flag grants access (the OR-fallback is preserved)', async () => {
+    for (const features of [
+      { appBlocks: true, appListings: false },
+      { appBlocks: false, appListings: true },
+    ]) {
+      const findApprovedListingSlug = lookup('vitrine');
+      expect(
+        await resolveLegacyAppRoute({ features, appBlockId: 'apb_x', findApprovedListingSlug })
+      ).toEqual({
+        redirect: { destination: '/apps/store-preview/vitrine', permanent: false },
+      });
+      expect(findApprovedListingSlug).toHaveBeenCalledWith('apb_x');
+    }
+  });
+});
+
+describe('resolveLegacyAppRoute — route param handling', () => {
+  const granted = { appBlocks: true };
+
+  it('a missing / non-string route param → notFound without querying', async () => {
+    for (const appBlockId of [undefined, null, '', '   ', 123, ['apb_x']]) {
+      const findApprovedListingSlug = vi.fn(async () => 'vitrine');
+      expect(
+        await resolveLegacyAppRoute({ features: granted, appBlockId, findApprovedListingSlug })
+      ).toEqual({ notFound: true });
+      expect(findApprovedListingSlug).not.toHaveBeenCalled();
+    }
+  });
+
+  it('a granted viewer + an app WITH an approved listing → the store-preview redirect', async () => {
+    const findApprovedListingSlug = vi.fn(async () => 'model-benchmarking');
+    expect(
+      await resolveLegacyAppRoute({
+        features: granted,
+        appBlockId: 'apb_01KXPENN70SG0RXQKN7WMJMJHF',
+        findApprovedListingSlug,
+      })
+    ).toEqual({
+      redirect: { destination: '/apps/store-preview/model-benchmarking', permanent: false },
+    });
+  });
+
+  it('a granted viewer + an app with NO approved listing → notFound, never /apps', async () => {
+    const findApprovedListingSlug = vi.fn(async () => null);
+    const result = await resolveLegacyAppRoute({
+      features: granted,
+      appBlockId: 'apb_pending',
+      findApprovedListingSlug,
+    });
+    expect(result).toEqual({ notFound: true });
+    expect('redirect' in result).toBe(false);
+  });
+});
+
+describe('approvedListingSlugQuery — the approved-only precondition', () => {
+  /**
+   * 🔴 This is a contract pin, and it is deliberate. Without it, deleting
+   * `status: 'approved'` from the query is a one-word edit that inverts the
+   * decided behaviour — every pending and rejected app would start redirecting
+   * into the store — while every other test in this file still passes, because
+   * they all begin AFTER the lookup has returned.
+   */
+  it('filters to an approved, non-shadow listing for the given app block', () => {
+    expect(approvedListingSlugQuery('apb_01KXPENN70SG0RXQKN7WMJMJHF')).toEqual({
+      where: {
+        appBlockId: 'apb_01KXPENN70SG0RXQKN7WMJMJHF',
+        status: 'approved',
+        revisionOfId: null,
+      },
+      select: { slug: true },
+    });
+  });
+
+  it('selects the slug and nothing else (no incidental data pulled into SSR)', () => {
+    expect(Object.keys(approvedListingSlugQuery('apb_x').select)).toEqual(['slug']);
   });
 });

--- a/src/components/Apps/__tests__/resolveLegacyAppRedirect.test.ts
+++ b/src/components/Apps/__tests__/resolveLegacyAppRedirect.test.ts
@@ -13,15 +13,29 @@ import {
  * decision that a future "helpful" edit would otherwise silently invert into a
  * redirect to `/apps` with nothing failing.
  *
- * Break-it checks these are written to survive — each was run against the source
- * and confirmed to fail before being reverted:
+ * Break-it checks these are written to survive. Each mutation was applied to the
+ * source, the suite run, the named failures confirmed, and the source reverted —
+ * the counts below are MEASURED, not estimated:
  *   - turn the no-listing branch into `{ redirect: { destination: '/apps' } }`
- *     → 5 FAIL (the `notFound` cases).
- *   - drop `encodeURIComponent` → 3 FAIL (the encoding/containment cases).
- *   - flip `permanent` to true → 2 FAIL.
+ *     → 6 FAIL (the `notFound` cases).
+ *   - drop `encodeURIComponent` → 4 FAIL (the encoding/containment cases).
+ *   - flip `permanent` to true → 5 FAIL.
+ *   - drop the `.trim()` on the slug → 3 FAIL.
  *   - move the store-visibility gate AFTER the lookup → 2 FAIL (the ordering
  *     cases in `resolveLegacyAppRoute`).
  *   - drop `status: 'approved'` from the query → 1 FAIL (the query-shape pin).
+ *   - pass the UNTRIMMED `args.appBlockId` to the lookup while still guarding the
+ *     trimmed value → 1 FAIL (the trim case). 🔴 This one previously survived the
+ *     WHOLE suite; see that test for why.
+ *   - rewrite a dot-only slug in the destination → 1 FAIL (the narrowed
+ *     traversal-claim pin).
+ *
+ * 🔴 Two assertions in this file were REMOVED rather than kept, because they could
+ * not fail: an `includes('/')` sub-assertion following a literal-equality assertion
+ * over the same string, twice. They were themselves added by an earlier audit
+ * looking for exactly that defect. The property they claimed to guard now lives in
+ * its own `it` over inputs no literal in this file constrains. A no-op wearing the
+ * name of a guard is worse than no guard — it reads as coverage.
  */
 
 describe('resolveLegacyAppRedirect — approved listing → store-preview redirect', () => {
@@ -47,11 +61,35 @@ describe('resolveLegacyAppRedirect — approved listing → store-preview redire
     // the destination is built by concatenating that same exported constant, so it
     // cannot fail. What CAN fail, and is the property worth pinning, is that the
     // slug never introduces a second segment.
+    //
+    // 🔴 This `it` used to carry a trailing `expect(slugSegment.includes('/'))
+    // .toBe(false)`. It was DEAD: the literal equality on the same string one line
+    // above already fails for any mutation that admits a `/`, so the sub-assertion
+    // could never be the thing that failed. Proven, not assumed — the killed-test
+    // set was byte-identical across all 8 mutations with it deleted. The real
+    // no-second-segment property is now pinned below over inputs that NO literal
+    // in this file constrains, which is what makes it able to fail on its own.
     const result = resolveLegacyAppRedirect({ slug: 'some-app' });
     if (!('redirect' in result)) throw new Error('expected a redirect');
     const slugSegment = result.redirect.destination.slice(STORE_PREVIEW_PATH_PREFIX.length);
     expect(slugSegment).toBe('some-app');
-    expect(slugSegment.includes('/')).toBe(false);
+  });
+
+  it('NO slug value can introduce a second path segment', () => {
+    // The containment property on its own terms: a set of separator-bearing slugs,
+    // none of which is pinned by a literal-equality assertion anywhere in this file,
+    // asserted structurally. Drop `encodeURIComponent` and every case here fails —
+    // which is the point: this `it` can be the sole reason a mutation is caught.
+    for (const slug of ['a/b', '/', '//', '%2F', 'x/../y', 'a//b/c', '/leading', 'trailing/']) {
+      const result = resolveLegacyAppRedirect({ slug });
+      if (!('redirect' in result))
+        throw new Error(`expected a redirect for ${JSON.stringify(slug)}`);
+      const segments = result.redirect.destination
+        .slice(STORE_PREVIEW_PATH_PREFIX.length)
+        .split('/')
+        .filter(Boolean);
+      expect(segments, `slug ${JSON.stringify(slug)} must stay one path segment`).toHaveLength(1);
+    }
   });
 });
 
@@ -110,20 +148,52 @@ describe('resolveLegacyAppRedirect — slug encoding / open-redirect containment
   it('a protocol-relative slug cannot escape to another origin', () => {
     // `//evil.example` un-encoded would be a protocol-relative URL — an open
     // redirect off civitai.com. Encoded, it stays a path segment.
+    //
+    // 🔴 A trailing `...includes('/')).toBe(false)` used to sit here and was DEAD
+    // for the same reason as the one removed above: the literal equality on the
+    // whole destination already fails for any mutation that lets a `/` through.
+    // The separator property now lives in its own `it` over un-pinned inputs.
     const result = resolveLegacyAppRedirect({ slug: '//evil.example' });
     if (!('redirect' in result)) throw new Error('expected a redirect');
     expect(result.redirect.destination).toBe('/apps/store-preview/%2F%2Fevil.example');
-    // The property that actually matters: no slash survives into the slug segment,
-    // so the destination can never resolve as `//host` or climb a directory.
-    expect(result.redirect.destination.slice(STORE_PREVIEW_PATH_PREFIX.length).includes('/')).toBe(
-      false
-    );
   });
 
-  it('path traversal in a slug cannot climb out of /apps/store-preview/', () => {
+  it('a SEPARATOR-BEARING traversal slug cannot climb out of /apps/store-preview/', () => {
     const result = resolveLegacyAppRedirect({ slug: '../../login' });
     if (!('redirect' in result)) throw new Error('expected a redirect');
     expect(result.redirect.destination).toBe('/apps/store-preview/..%2F..%2Flogin');
+  });
+
+  it('a DOT-ONLY slug stays on-origin, but does NOT stay under the prefix', () => {
+    // 🔴 Narrowing an overstated claim. `encodeURIComponent('..') === '..'` — the
+    // encode does nothing to a slug with no separator in it, so a slug of exactly
+    // `..` yields `/apps/store-preview/..`, and dot-segment removal (RFC 3986 §5.2.4,
+    // which every browser and Next's router apply) resolves that to `/apps/`. The
+    // previous docstring said traversal "cannot climb out of /apps/store-preview/";
+    // it was pinned only by the slash-bearing `../../login` case above, and for the
+    // dot-only input the claim is false.
+    //
+    // What DOES hold, and is all that was ever security-relevant: the destination
+    // never leaves the origin and never reaches an arbitrary path — one level up
+    // from the detail route is the apps index, which is where the redirect's own
+    // rejected-alternative branch would have sent people anyway.
+    //
+    // Unreachable in practice: a stored slug must match SLUG_REGEX
+    // (`/^[a-z][a-z0-9-]*[a-z0-9]$/`, publish-request.schema.ts), which admits no
+    // `.` at all. Pinned so the claim in the docstring matches the code's actual
+    // guarantee rather than a stronger one.
+    for (const slug of ['..', '.']) {
+      const result = resolveLegacyAppRedirect({ slug });
+      if (!('redirect' in result)) throw new Error(`expected a redirect for ${slug}`);
+      expect(result.redirect.destination).toBe(`/apps/store-preview/${slug}`);
+      // Still a relative, same-origin path — the only property claimed.
+      expect(new URL(result.redirect.destination, 'https://civitai.com').origin).toBe(
+        'https://civitai.com'
+      );
+    }
+    // And the resolved form, stated explicitly rather than implied: `..` lands on
+    // the apps index, NOT anywhere a viewer could not already reach.
+    expect(new URL('/apps/store-preview/..', 'https://civitai.com').pathname).toBe('/apps/');
   });
 
   it('an ordinary hyphenated slug is passed through unchanged (no over-escaping)', () => {
@@ -201,6 +271,28 @@ describe('resolveLegacyAppRoute — route param handling', () => {
       ).toEqual({ notFound: true });
       expect(findApprovedListingSlug).not.toHaveBeenCalled();
     }
+  });
+
+  it('the route param is TRIMMED before it reaches the lookup', async () => {
+    // 🔴 The guard and the lookup must read the SAME value. `resolveLegacyAppRoute`
+    // trims the param, rejects the trimmed empty, and must then query the TRIMMED
+    // string. Passing `args.appBlockId` (untrimmed) to `findApprovedListingSlug`
+    // while still guarding the trimmed value is a one-word mutation that left the
+    // suite fully green before this case existed — every other fixture id in this
+    // file is whitespace-free, and the only `toHaveBeenCalledWith` used a clean
+    // `'apb_x'`, so nothing could see the difference. In production that mutation
+    // sends `'  apb_x  '` to a Prisma equality filter on a ULID column: it matches
+    // nothing, and an approved app 404s instead of redirecting.
+    const findApprovedListingSlug = vi.fn(async () => 'vitrine');
+    expect(
+      await resolveLegacyAppRoute({
+        features: granted,
+        appBlockId: '  apb_x  ',
+        findApprovedListingSlug,
+      })
+    ).toEqual({ redirect: { destination: '/apps/store-preview/vitrine', permanent: false } });
+    expect(findApprovedListingSlug).toHaveBeenCalledWith('apb_x');
+    expect(findApprovedListingSlug).toHaveBeenCalledTimes(1);
   });
 
   it('a granted viewer + an app WITH an approved listing → the store-preview redirect', async () => {

--- a/src/components/Apps/resolveLegacyAppRedirect.ts
+++ b/src/components/Apps/resolveLegacyAppRedirect.ts
@@ -7,8 +7,9 @@
  * `visit` fallback, Edit manifest → the untouched sibling `/apps/[appBlockId]/edit*`
  * routes, independently reachable from my-submissions and the store card's owner
  * Edit). The legacy route is kept alive as a REDIRECT — not deleted — so a stale
- * bookmark, an external link, or one of the three in-repo callsites
- * (`AppBlockCard`, `ManifestEditForm`, `liveAppDetailHref`) simply hops.
+ * bookmark, an external link, or one of the four in-repo callsites
+ * (`AppBlockCard`, `ManifestEditForm`, `liveAppDetailHref`, and the editor's own
+ * "Back") simply hops.
  *
  * Pure + React-free + I/O-free on purpose: the branch is the whole point of the
  * change, so it must be assertable in the node-env `unit` project without booting
@@ -41,6 +42,8 @@
  * `../`, a `//host`, or a `?`/`#` in a slug from steering the path off
  * `/apps/store-preview/` (an open redirect) or splicing a query/fragment onto it.
  */
+import { resolveAppsPageAccess } from '~/components/Apps/resolveAppsPageAccess';
+
 export type LegacyAppRedirectResult =
   | { redirect: { destination: string; permanent: false } }
   | { notFound: true };
@@ -68,4 +71,68 @@ export function resolveLegacyAppRedirect(args: {
       permanent: false,
     },
   };
+}
+
+/**
+ * The Prisma `findFirst` args that resolve an app block's store slug.
+ *
+ * 🔴 Built here rather than inline in the page so the APPROVED-ONLY precondition
+ * is pinned by a test. This filter is the entire difference between "redirect to
+ * the app's store detail" and "redirect any pending or rejected app to a store
+ * URL that refuses to serve it" — dropping `status: 'approved'` is a silent,
+ * behaviour-inverting one-word edit that the decision tests above cannot see,
+ * because by then the slug has already been handed over.
+ *
+ * `revisionOfId: null` is defense-in-depth. A shadow revision is a draft (so the
+ * status filter already excludes it) and cannot carry an `appBlockId` while its
+ * parent holds that UNIQUE value — but this is a public read, so never let it
+ * reach one.
+ */
+export function approvedListingSlugQuery(appBlockId: string) {
+  return {
+    where: { appBlockId, status: 'approved', revisionOfId: null },
+    select: { slug: true },
+  };
+}
+
+/**
+ * The WHOLE server-side decision for the retired route, with the database read
+ * injected.
+ *
+ * 🔴 The injection is the point. The security-relevant half of this change is not
+ * the string concat — it is the ORDERING: the store-visibility gate must run
+ * before the route param is read and before any query is issued. A test that only
+ * exercises `resolveLegacyAppRedirect` cannot see that ordering at all. With the
+ * lookup injected, a test can assert that it was never even CALLED for an
+ * ungranted viewer, which turns the invariant into something that actually fails
+ * when someone reorders it.
+ *
+ * ⚠️ Scope of that claim, stated precisely so nobody over-trusts it: gate-first
+ * means a viewer WITHOUT store visibility learns nothing — identical `notFound`,
+ * no `Location` header, no query. It does NOT mean the route discloses nothing to
+ * a viewer WITH store visibility. For them 302-vs-404 is a new HTTP-level signal
+ * that the old page did not emit (it answered 200 either way), and it is not
+ * filtered by the two further gates the destination applies — a maturity gate and
+ * an on-site "never deployed" gate. So an app caught by either would have its
+ * slug disclosed one hop before the destination refuses to serve it. Those
+ * viewers can already enumerate approved listings from the store grid, and no
+ * live app is in either state, so this is a disclosed residual rather than a
+ * hole — but replicating those two gates here is the fix if we want it airtight
+ * before the store widens past its current audience.
+ */
+export async function resolveLegacyAppRoute(args: {
+  features?: { appBlocks?: boolean; appListings?: boolean } | null;
+  appBlockId?: unknown;
+  /** Approved-only slug lookup. Use `approvedListingSlugQuery` to build it. */
+  findApprovedListingSlug: (appBlockId: string) => Promise<string | null | undefined>;
+}): Promise<LegacyAppRedirectResult> {
+  // 🔒 GATE FIRST — before the param is read, before anything is queried.
+  const access = resolveAppsPageAccess({ features: args.features });
+  if ('notFound' in access) return { notFound: true };
+
+  const appBlockId = typeof args.appBlockId === 'string' ? args.appBlockId.trim() : '';
+  if (!appBlockId) return { notFound: true };
+
+  const slug = await args.findApprovedListingSlug(appBlockId);
+  return resolveLegacyAppRedirect({ slug });
 }

--- a/src/components/Apps/resolveLegacyAppRedirect.ts
+++ b/src/components/Apps/resolveLegacyAppRedirect.ts
@@ -2,14 +2,27 @@
  * S8 / PR-2 — the redirect decision for the RETIRED legacy per-app detail route
  * `/apps/[appBlockId]`.
  *
- * That page is superseded by the unified store detail `/apps/store-preview/<slug>`,
- * which covers its whole action set (Open app → the `open` branch, Open live → the
- * `visit` fallback, Edit manifest → the untouched sibling `/apps/[appBlockId]/edit*`
- * routes, independently reachable from my-submissions and the store card's owner
- * Edit). The legacy route is kept alive as a REDIRECT — not deleted — so a stale
- * bookmark, an external link, or one of the four in-repo callsites
- * (`AppBlockCard`, `ManifestEditForm`, `liveAppDetailHref`, and the editor's own
- * "Back") simply hops.
+ * That page is superseded by the unified store detail `/apps/store-preview/<slug>`:
+ * Open app → the `open` branch, Open live → the `visit` fallback, Edit manifest →
+ * the untouched sibling `/apps/[appBlockId]/edit*` routes (independently reachable
+ * from my-submissions and the store card's owner Edit). The legacy route is kept
+ * alive as a REDIRECT — not deleted — so a stale bookmark, an external link, or one
+ * of the four in-repo callsites (`AppBlockCard`, `ManifestEditForm`,
+ * `liveAppDetailHref`, and the editor's own "Back") simply hops.
+ *
+ * ⚠️ ONE affordance is NOT carried over: the legacy page's Install / Manage CTA.
+ * `AppListingDetailBody` has no install surface at all, so a MODEL-SLOT app (one
+ * that installs into a slot rather than opening a page) has nowhere on the store
+ * detail to install from. That is vacuous today — every approved on-site listing
+ * declares a page, so none takes that branch — but it is the real gap to close
+ * before a model-slot app is approved, and it is the reason the follow-up should
+ * RETARGET the `info`-mode CTA rather than simply delete this route.
+ *
+ * Sibling precedent: `listingEditNav.ts`'s `legacyEditRedirect` does the same
+ * "legacy route → 302, missing id → notFound" job for the owner-edit routes. It
+ * unwraps a `string[]` param where this module fails closed on any non-string;
+ * for a non-catch-all `[appBlockId]` segment Next always yields a string, so the
+ * two agree in practice and the stricter form is kept deliberately.
  *
  * Pure + React-free + I/O-free on purpose: the branch is the whole point of the
  * change, so it must be assertable in the node-env `unit` project without booting

--- a/src/components/Apps/resolveLegacyAppRedirect.ts
+++ b/src/components/Apps/resolveLegacyAppRedirect.ts
@@ -125,13 +125,40 @@ export function approvedListingSlugQuery(appBlockId: string) {
  * no `Location` header, no query. It does NOT mean the route discloses nothing to
  * a viewer WITH store visibility. For them 302-vs-404 is a new HTTP-level signal
  * that the old page did not emit (it answered 200 either way), and it is not
- * filtered by the two further gates the destination applies — a maturity gate and
- * an on-site "never deployed" gate. So an app caught by either would have its
- * slug disclosed one hop before the destination refuses to serve it. Those
- * viewers can already enumerate approved listings from the store grid, and no
- * live app is in either state, so this is a disclosed residual rather than a
- * hole — but replicating those two gates here is the fix if we want it airtight
- * before the store widens past its current audience.
+ * filtered by the further gates the destination applies.
+ *
+ * 🔴 THERE ARE **THREE** SUCH GATES, not two. `getListingDetail`
+ * (`app-listing.service.ts`) rejects a row on any of:
+ *
+ *   1. STORE-SCOPE KIND — `scope === 'public-external' && row.kind !== 'offsite'`.
+ *   2. DEPLOY — `row.kind === 'onsite' && appBlock.currentVersionDeployedAt == null`.
+ *   3. MATURITY — `!redCapable && isMatureContentRating(row.contentRating)`.
+ *
+ * (2) and (3) are 0-instance today and would each affect a handful of apps at
+ * most. (1) is categorically different and is the reason this disclosure is worth
+ * reading twice: this route's param is an `AppBlock.id`, and EVERY listing that
+ * carries an `appBlockId` is `kind='onsite'` — so **every** listing this route can
+ * resolve is exactly the set `public-external` exists to hide. Under that scope
+ * the coverage gap is 100%, not a corner.
+ *
+ * It is UNREACHABLE TODAY, and only by an accident of flag alignment: the page
+ * gate (`resolveAppsPageAccess`) grants on `features.appListings || appBlocks`,
+ * and `features.appListings` reads the same `app-listings` Flipt key that
+ * `resolveStoreVisibilityScope`'s axis 1 uses to return `full`. So any viewer who
+ * gets past the page gate resolves `full`, where the kind gate is a no-op, and any
+ * viewer who would resolve `public-external` is already 404'd by the page gate. If
+ * `app-listings-public-external` is switched on and the PAGE gate is widened
+ * alongside it, that alignment breaks and every `/apps/<appBlockId>` becomes a 302
+ * disclosing an on-site app's slug to a viewer whose store scope excludes on-site
+ * entirely.
+ *
+ * So: replicating gates here needs all THREE — a store-scope check (which for this
+ * route reduces to "`public-external` → `notFound`", since the resolvable set is
+ * wholly on-site), a `currentVersionDeployedAt` filter, and a `contentRating`
+ * filter keyed on the request's red-capability. NOT DONE IN THIS CHANGE and still
+ * owed: it needs the resolved store scope and red-capability threaded into this
+ * SSR resolver, neither of which it takes today. Doing it before the store widens
+ * past its current audience is the fix.
  */
 export async function resolveLegacyAppRoute(args: {
   features?: { appBlocks?: boolean; appListings?: boolean } | null;

--- a/src/components/Apps/resolveLegacyAppRedirect.ts
+++ b/src/components/Apps/resolveLegacyAppRedirect.ts
@@ -1,0 +1,71 @@
+/**
+ * S8 / PR-2 — the redirect decision for the RETIRED legacy per-app detail route
+ * `/apps/[appBlockId]`.
+ *
+ * That page is superseded by the unified store detail `/apps/store-preview/<slug>`,
+ * which covers its whole action set (Open app → the `open` branch, Open live → the
+ * `visit` fallback, Edit manifest → the untouched sibling `/apps/[appBlockId]/edit*`
+ * routes, independently reachable from my-submissions and the store card's owner
+ * Edit). The legacy route is kept alive as a REDIRECT — not deleted — so a stale
+ * bookmark, an external link, or one of the three in-repo callsites
+ * (`AppBlockCard`, `ManifestEditForm`, `liveAppDetailHref`) simply hops.
+ *
+ * Pure + React-free + I/O-free on purpose: the branch is the whole point of the
+ * change, so it must be assertable in the node-env `unit` project without booting
+ * the page's Mantine/tRPC module graph. Same extraction precedent as
+ * `resolveAppsPageAccess.ts`, `deploy-status.ts`, `sortInstallsForSlot.ts`.
+ *
+ * 🔴 TWO decided branches — do not add a third, and do not soften either:
+ *
+ *   1. An app WITH an approved `AppListing` → 302 to that listing's store detail.
+ *
+ *   2. An app with NO approved listing → the SITE-STANDARD 404 (`notFound`), NOT
+ *      a redirect to `/apps`. On-site listings are created at APPROVAL, so a
+ *      pending / rejected / never-approved app has no listing and therefore no
+ *      store-preview target. The person most likely to open this URL is the app's
+ *      OWNER following a link to their own pending app; bouncing them to a store
+ *      that by construction does not list unapproved apps is a silent dead end —
+ *      it reads as "my app vanished" with no signal why. A 404 is the honest
+ *      answer ("there is no public detail page for this app"), it matches the
+ *      posture `blocks.getAppDetail` already has (NOT_FOUND for a missing /
+ *      unapproved app) and what `/apps/store-preview/<bogus>` already renders, and
+ *      the owner's real surface is `/apps/my-submissions` with its status sections.
+ *
+ * `permanent: false` (302, not 301): the route's final disposition is a tracked
+ * follow-up (delete the body once the redirect has soaked and inbound traffic has
+ * dried up). A 301 is cached by browsers indefinitely and would make that
+ * reversible decision irreversible in the field.
+ *
+ * The slug is `encodeURIComponent`-ed. It comes from our own DB column, but the
+ * destination is a string built by concatenation, so encoding is what keeps a
+ * `../`, a `//host`, or a `?`/`#` in a slug from steering the path off
+ * `/apps/store-preview/` (an open redirect) or splicing a query/fragment onto it.
+ */
+export type LegacyAppRedirectResult =
+  | { redirect: { destination: string; permanent: false } }
+  | { notFound: true };
+
+/** Path prefix of the unified store detail route. Exported so the test pins it. */
+export const STORE_PREVIEW_PATH_PREFIX = '/apps/store-preview/';
+
+export function resolveLegacyAppRedirect(args: {
+  /**
+   * The `AppListing.slug` of the APPROVED listing backing this app block, or
+   * null/undefined when the app has none (pending / rejected / never-approved).
+   * The caller is responsible for the approved-only lookup; this function only
+   * decides what to do with the result.
+   */
+  slug?: string | null;
+}): LegacyAppRedirectResult {
+  const slug = typeof args?.slug === 'string' ? args.slug.trim() : '';
+  // No approved listing (or a blank/whitespace slug, which is not addressable) →
+  // the site-standard 404. Never a redirect to `/apps`.
+  if (!slug) return { notFound: true };
+
+  return {
+    redirect: {
+      destination: `${STORE_PREVIEW_PATH_PREFIX}${encodeURIComponent(slug)}`,
+      permanent: false,
+    },
+  };
+}

--- a/src/pages/apps/[appBlockId]/index.tsx
+++ b/src/pages/apps/[appBlockId]/index.tsx
@@ -517,7 +517,9 @@ export default function AppDetailPage() {
                         }
                       >
                         {scopes.map((scope) => (
-                          <List.Item key={scope}>{SCOPE_DESCRIPTIONS[scope] ?? scope}</List.Item>
+                          <List.Item key={scope}>
+                            {SCOPE_DESCRIPTIONS[scope] ?? scope}
+                          </List.Item>
                         ))}
                       </List>
                     )}

--- a/src/pages/apps/[appBlockId]/index.tsx
+++ b/src/pages/apps/[appBlockId]/index.tsx
@@ -31,6 +31,7 @@ import { NotFound } from '~/components/AppLayout/NotFound';
 import { AppBlockReviews } from '~/components/Apps/AppBlockReviews';
 import { openAppSettingsModal } from '~/components/Apps/AppSettingsModal';
 import { resolveAppsPageAccess } from '~/components/Apps/resolveAppsPageAccess';
+import { resolveLegacyAppRedirect } from '~/components/Apps/resolveLegacyAppRedirect';
 import { LoginRedirect } from '~/components/LoginRedirect/LoginRedirect';
 import { Meta } from '~/components/Meta/Meta';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
@@ -45,14 +46,36 @@ import {
   SCOPE_DESCRIPTIONS,
   SLOT_DESCRIPTIONS,
 } from '~/server/services/blocks/scope-descriptions.constants';
+import { dbRead } from '~/server/db/client';
 import { createServerSideProps } from '~/server/utils/server-side-helpers';
 import { hasInstallSlot } from '~/shared/constants/slot-registry';
 import { trpc } from '~/utils/trpc';
 
 /**
- * F-E E2 — per-app marketplace detail page (`/apps/<appBlockId>`).
+ * 🔴 RETIRED (S8 / PR-2) — this route no longer renders. `getServerSideProps`
+ * redirects it to the unified store detail `/apps/store-preview/<slug>`.
  *
- * 🔒 GATING INVARIANT (E2 — same as E1, do not violate):
+ * WHY: it was a second, diverging detail surface for the same app. It rendered
+ * `by <app name>` where the store correctly renders the owner's username, and its
+ * raw bridge-less `<iframe>` "Live preview" painted a permanent light-theme panel
+ * on a dark page (nothing ever posts `BLOCK_INIT` to that frame, so the block's
+ * shell never learns the host theme). The store detail already covers this page's
+ * whole action set — "Open app" → its `open` branch, "Open live" → its `visit`
+ * fallback, and "Edit manifest" is the SIBLING route `/apps/[appBlockId]/edit*`,
+ * untouched here and independently reachable from `/apps/my-submissions` and the
+ * store card's owner Edit.
+ *
+ * REDIRECT, NOT DELETE — deliberately. The page BODY below is retained for at
+ * least one release so a stale bookmark or an external link resolves through the
+ * hop, and so the three in-repo callsites (`AppBlockCard`, `ManifestEditForm`,
+ * `liveAppDetailHref`) keep working untouched. Deleting the body and cleaning up
+ * those callsites is a tracked follow-up; keeping it out of this change is what
+ * makes this a one-file change that cannot collide with the parallel work on
+ * `appListingDetailView.ts`. The component is unreachable in the meantime (both
+ * SSR and client-side `/_next/data` navigations honour the redirect) — do not
+ * "fix" anything in it.
+ *
+ * 🔒 GATING INVARIANT (E2 — unchanged, do not violate):
  *   - The SSR resolver runs `resolveAppsPageAccess` FIRST: the `features.appBlocks`
  *     flag gate is the ONLY access control. A real anon / non-mod viewer does not
  *     satisfy the mod-segmented Flipt `app-blocks-enabled` flag, so they get
@@ -68,9 +91,42 @@ import { trpc } from '~/utils/trpc';
  */
 export const getServerSideProps = createServerSideProps({
   useSession: true,
-  // Flag gate FIRST and ONLY (no session→login redirect): the detail page renders
-  // for a session-less request BEHIND the flag (dark today; lit at segment-widen).
-  resolver: async ({ features }) => resolveAppsPageAccess({ features }),
+  resolver: async ({ ctx, features }) => {
+    // 🔒 STORE-VISIBILITY FLAG GATE STAYS FIRST — before the route param is read
+    // and before any DB access. A viewer the flag does not grant gets the same
+    // `notFound` it gets today, and the retirement never becomes an existence
+    // oracle for them: no redirect, no `Location` header, not even a query.
+    const access = resolveAppsPageAccess({ features });
+    if ('notFound' in access) return access;
+
+    const appBlockId = typeof ctx.params?.appBlockId === 'string' ? ctx.params.appBlockId : '';
+    if (!appBlockId) return { notFound: true };
+
+    // Resolve `AppBlock.id` (the `apb_<ULID>` route param) → the store slug.
+    //
+    // 🔴 Key on `AppListing.slug`, NOT `AppBlock.blockId`. For an on-site app the
+    // two hold the same value today (`mapAppBlockToListing` mints the listing with
+    // `slug: ab.blockId`), so reading `blockId` would usually produce the same
+    // string — but it would answer the WRONG question. The destination
+    // (`appListings.getAppDetail`) resolves BY LISTING, approved-only; a pending,
+    // rejected or never-approved app has a `blockId` and no listing, so a
+    // `blockId`-keyed redirect would bounce that owner to a store URL that 404s
+    // instead of 404-ing here. Reading the listing row makes the existence of an
+    // approved listing the actual precondition of the redirect — the decided
+    // behaviour — and it stays correct if a slug ever diverges from its block id
+    // (off-site listings already choose their own slugs).
+    //
+    // `status: 'approved'` mirrors the destination's own approved-only filter, and
+    // `revisionOfId: null` is defense-in-depth: a shadow revision is a draft (so
+    // already excluded) and cannot carry an `appBlockId` (the column is UNIQUE),
+    // but never let this read reach one.
+    const listing = await dbRead.appListing.findFirst({
+      where: { appBlockId, status: 'approved', revisionOfId: null },
+      select: { slug: true },
+    });
+
+    return resolveLegacyAppRedirect({ slug: listing?.slug });
+  },
 });
 
 function slotLabel(slotId?: string): string {

--- a/src/pages/apps/[appBlockId]/index.tsx
+++ b/src/pages/apps/[appBlockId]/index.tsx
@@ -69,14 +69,36 @@ import { trpc } from '~/utils/trpc';
  *
  * REDIRECT, NOT DELETE — deliberately. The page BODY below is retained for at
  * least one release so a stale bookmark or an external link resolves through the
- * hop. FOUR in-repo callsites point here and are all left untouched:
- * `AppBlockCard.tsx`, `ManifestEditForm.tsx` (post-save "Cancel"),
- * `appListingDetailView.ts`'s `liveAppDetailHref`, and `[appBlockId]/edit.tsx`'s
- * "Back". Deleting the body and cleaning those up is a tracked follow-up; keeping
- * it out of this change is what makes this a one-file change that cannot collide
- * with the parallel work on `appListingDetailView.ts`. The component is
- * unreachable in the meantime (both SSR and client-side `/_next/data` navigations
- * honour the redirect) — do not "fix" anything in it.
+ * hop. FOUR in-repo FILES link here and are all left untouched — five link sites,
+ * because `AppBlockCard.tsx` links twice (its title at ~:204 and its description
+ * at ~:257): `AppBlockCard.tsx` (×2), `ManifestEditForm.tsx` (post-save
+ * "Cancel"), `appListingDetailView.ts`'s `liveAppDetailHref`, and
+ * `[appBlockId]/edit.tsx`'s "Back". Deleting the body and cleaning those up is a
+ * tracked follow-up; keeping it out of this change is what makes this a one-file
+ * change that cannot collide with the parallel work on `appListingDetailView.ts`.
+ * The component is unreachable in the meantime (both SSR and client-side
+ * `/_next/data` navigations honour the redirect) — do not "fix" anything in it.
+ *
+ * ⚠️ The hop DROPS THE QUERY STRING. `getServerSideProps` returns a destination
+ * built from the slug alone, and this page only ever read `router.query.appBlockId`
+ * (a route param, preserved in the destination path), so nothing in-product breaks
+ * — but an external link carrying tracking params (`?utm_*`, `?ref=`) loses them
+ * at the hop. Named so it is a decision, not a surprise; forwarding them is a
+ * one-line change if anyone wants it.
+ *
+ * 🔴 SOMETHING **IS** ORPHANED — an earlier draft of this change claimed nothing
+ * was, and that was wrong. The legacy 5-star `AppBlockReview` WRITE form
+ * (`<AppBlockReviews>` below) has exactly two hosts: this page, and
+ * `AppDetailsModal`. `AppDetailsModal` is opened only from `AppBlockCard`;
+ * `AppBlockCard` renders only from `MarketplaceBody` and `RecentlyOpenedApps`
+ * (whose `RecentlyOpenedAppsView` itself renders only inside `MarketplaceBody`);
+ * and `MarketplaceBody` has had NO importer in app code since `/apps` swapped to
+ * `AppListingsMarketplaceBody` — it is retained purely as a documented one-line
+ * rollback. So after this redirect the whole 5-star review surface has no
+ * reachable entry point. Harmless today — `app_block_reviews` is empty in
+ * production, and the store detail carries the listing review surface — but the
+ * follow-up that deletes this body must decide the legacy review form's fate
+ * explicitly rather than inherit a "still reachable" assumption that is false.
  *
  * ⚠️ Two consequences of leaving those callsites alone, known and accepted:
  *   - An owner backing out of the editor on a PENDING app now lands on a real
@@ -517,9 +539,7 @@ export default function AppDetailPage() {
                         }
                       >
                         {scopes.map((scope) => (
-                          <List.Item key={scope}>
-                            {SCOPE_DESCRIPTIONS[scope] ?? scope}
-                          </List.Item>
+                          <List.Item key={scope}>{SCOPE_DESCRIPTIONS[scope] ?? scope}</List.Item>
                         ))}
                       </List>
                     )}

--- a/src/pages/apps/[appBlockId]/index.tsx
+++ b/src/pages/apps/[appBlockId]/index.tsx
@@ -30,8 +30,10 @@ import { useMemo } from 'react';
 import { NotFound } from '~/components/AppLayout/NotFound';
 import { AppBlockReviews } from '~/components/Apps/AppBlockReviews';
 import { openAppSettingsModal } from '~/components/Apps/AppSettingsModal';
-import { resolveAppsPageAccess } from '~/components/Apps/resolveAppsPageAccess';
-import { resolveLegacyAppRedirect } from '~/components/Apps/resolveLegacyAppRedirect';
+import {
+  approvedListingSlugQuery,
+  resolveLegacyAppRoute,
+} from '~/components/Apps/resolveLegacyAppRedirect';
 import { LoginRedirect } from '~/components/LoginRedirect/LoginRedirect';
 import { Meta } from '~/components/Meta/Meta';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
@@ -67,13 +69,24 @@ import { trpc } from '~/utils/trpc';
  *
  * REDIRECT, NOT DELETE — deliberately. The page BODY below is retained for at
  * least one release so a stale bookmark or an external link resolves through the
- * hop, and so the three in-repo callsites (`AppBlockCard`, `ManifestEditForm`,
- * `liveAppDetailHref`) keep working untouched. Deleting the body and cleaning up
- * those callsites is a tracked follow-up; keeping it out of this change is what
- * makes this a one-file change that cannot collide with the parallel work on
- * `appListingDetailView.ts`. The component is unreachable in the meantime (both
- * SSR and client-side `/_next/data` navigations honour the redirect) — do not
- * "fix" anything in it.
+ * hop. FOUR in-repo callsites point here and are all left untouched:
+ * `AppBlockCard.tsx`, `ManifestEditForm.tsx` (post-save "Cancel"),
+ * `appListingDetailView.ts`'s `liveAppDetailHref`, and `[appBlockId]/edit.tsx`'s
+ * "Back". Deleting the body and cleaning those up is a tracked follow-up; keeping
+ * it out of this change is what makes this a one-file change that cannot collide
+ * with the parallel work on `appListingDetailView.ts`. The component is
+ * unreachable in the meantime (both SSR and client-side `/_next/data` navigations
+ * honour the redirect) — do not "fix" anything in it.
+ *
+ * ⚠️ Two consequences of leaving those callsites alone, known and accepted:
+ *   - An owner backing out of the editor on a PENDING app now lands on a real
+ *     404 rather than a not-found rendered inside the app shell. Same end state,
+ *     blunter presentation; the follow-up that retargets those links fixes it.
+ *   - `liveAppDetailHref` feeds the store detail's own `info`-mode CTA for a
+ *     MODEL-SLOT app, so on that page the primary button now hops back to the
+ *     page the viewer is already on. No live app is in that state today (every
+ *     approved on-site listing declares a page), but it is why the follow-up
+ *     should retarget that branch, not merely delete the route.
  *
  * 🔒 GATING INVARIANT (E2 — unchanged, do not violate):
  *   - The SSR resolver runs `resolveAppsPageAccess` FIRST: the `features.appBlocks`
@@ -91,42 +104,30 @@ import { trpc } from '~/utils/trpc';
  */
 export const getServerSideProps = createServerSideProps({
   useSession: true,
-  resolver: async ({ ctx, features }) => {
-    // 🔒 STORE-VISIBILITY FLAG GATE STAYS FIRST — before the route param is read
-    // and before any DB access. A viewer the flag does not grant gets the same
-    // `notFound` it gets today, and the retirement never becomes an existence
-    // oracle for them: no redirect, no `Location` header, not even a query.
-    const access = resolveAppsPageAccess({ features });
-    if ('notFound' in access) return access;
-
-    const appBlockId = typeof ctx.params?.appBlockId === 'string' ? ctx.params.appBlockId : '';
-    if (!appBlockId) return { notFound: true };
-
-    // Resolve `AppBlock.id` (the `apb_<ULID>` route param) → the store slug.
-    //
-    // 🔴 Key on `AppListing.slug`, NOT `AppBlock.blockId`. For an on-site app the
-    // two hold the same value today (`mapAppBlockToListing` mints the listing with
-    // `slug: ab.blockId`), so reading `blockId` would usually produce the same
-    // string — but it would answer the WRONG question. The destination
-    // (`appListings.getAppDetail`) resolves BY LISTING, approved-only; a pending,
-    // rejected or never-approved app has a `blockId` and no listing, so a
-    // `blockId`-keyed redirect would bounce that owner to a store URL that 404s
-    // instead of 404-ing here. Reading the listing row makes the existence of an
-    // approved listing the actual precondition of the redirect — the decided
-    // behaviour — and it stays correct if a slug ever diverges from its block id
-    // (off-site listings already choose their own slugs).
-    //
-    // `status: 'approved'` mirrors the destination's own approved-only filter, and
-    // `revisionOfId: null` is defense-in-depth: a shadow revision is a draft (so
-    // already excluded) and cannot carry an `appBlockId` (the column is UNIQUE),
-    // but never let this read reach one.
-    const listing = await dbRead.appListing.findFirst({
-      where: { appBlockId, status: 'approved', revisionOfId: null },
-      select: { slug: true },
-    });
-
-    return resolveLegacyAppRedirect({ slug: listing?.slug });
-  },
+  // The decision (gate ordering, param handling, the approved-listing
+  // precondition, the destination) lives in `resolveLegacyAppRoute` with the DB
+  // read injected, so all of it is asserted in the node unit project. This
+  // resolver is only the wiring.
+  //
+  // 🔴 Resolve `AppBlock.id` (the `apb_<ULID>` route param) → the store slug via
+  // `AppListing.slug`, NOT `AppBlock.blockId`. For an on-site app the two hold
+  // the same value today (`mapAppBlockToListing` mints the listing with
+  // `slug: ab.blockId`), so reading `blockId` would usually produce the same
+  // string — but it would answer the WRONG question. The destination
+  // (`appListings.getAppDetail`) resolves BY LISTING, approved-only; a pending,
+  // rejected or never-approved app has a `blockId` and no listing, so a
+  // `blockId`-keyed redirect would bounce that owner to a store URL that refuses
+  // to serve it instead of 404-ing here. Reading the listing row makes the
+  // existence of an approved listing the actual precondition of the redirect —
+  // the decided behaviour — and it stays correct if a slug ever diverges from
+  // its block id (off-site listings already choose their own slugs).
+  resolver: async ({ ctx, features }) =>
+    resolveLegacyAppRoute({
+      features,
+      appBlockId: ctx.params?.appBlockId,
+      findApprovedListingSlug: async (appBlockId) =>
+        (await dbRead.appListing.findFirst(approvedListingSlugQuery(appBlockId)))?.slug ?? null,
+    }),
 });
 
 function slotLabel(slotId?: string): string {
@@ -516,9 +517,7 @@ export default function AppDetailPage() {
                         }
                       >
                         {scopes.map((scope) => (
-                          <List.Item key={scope}>
-                            {SCOPE_DESCRIPTIONS[scope] ?? scope}
-                          </List.Item>
+                          <List.Item key={scope}>{SCOPE_DESCRIPTIONS[scope] ?? scope}</List.Item>
                         ))}
                       </List>
                     )}

--- a/src/pages/apps/index.tsx
+++ b/src/pages/apps/index.tsx
@@ -43,6 +43,10 @@ export default function AppsPage() {
           (`MarketplaceBody` → `AppBlockCard`) is intentionally retained in the
           tree; swap this back to `<MarketplaceBody />` (re-import it) to fall
           back to the AppBlock-backed grid.
+          ⚠️ That rollback is now PARTIAL: `AppBlockCard`'s title/description link
+          to `/apps/<appBlockId>`, which is retired and redirects to the store
+          detail. Restoring the old grid therefore no longer restores the old
+          detail surface — undo the route retirement too if that is the intent.
 
           The grid will be EMPTY until the mod-only backfills run on prod
           (`blocks.backfillAppListings` → `appListings.backfillListingAssets`,

--- a/tests/preview-apps-marketplace.spec.ts
+++ b/tests/preview-apps-marketplace.spec.ts
@@ -190,8 +190,45 @@ test.describe('App Blocks marketplace discovery + detail render (mod)', () => {
       landedOn,
       `the retired /apps/${first.id} should land on the unified store detail, not render itself`
     ).toMatch(/^\/apps\/store-preview\/.+/);
-    expect(landedOn, 'the retirement must not leave the viewer on the legacy route').not.toBe(
-      `/apps/${first.id}`
-    );
+
+    // 🔴 The two assertions below replace an earlier `.not.toBe('/apps/<id>')`, which
+    // COULD NOT FAIL: given the `toMatch` above has passed, `landedOn` already starts
+    // `/apps/store-preview/`, and `/apps/<appBlockId>` never can — so the inequality
+    // held by construction. It wore the name of a guard while guarding nothing. Both
+    // replacements pin a property the `toMatch` genuinely leaves open.
+
+    // (a) The slug occupies EXACTLY ONE path segment. `/^\/apps\/store-preview\/.+/`
+    //     happily accepts `/apps/store-preview/a/b` — i.e. a destination that climbed
+    //     out of the detail route into some other page. This is the browser-level
+    //     twin of the containment property the unit test pins on the built string.
+    const slugSegment = landedOn.slice('/apps/store-preview/'.length);
+    expect(
+      slugSegment.split('/').filter(Boolean),
+      `the store slug must be one path segment, got "${slugSegment}"`
+    ).toHaveLength(1);
+
+    // (b) The retirement happened at the HTTP layer — a real server redirect out of
+    //     the legacy route — not a client-side bounce rendered by the page. Walk the
+    //     redirect chain of the response we landed on and require the legacy path in
+    //     it. This fails if anyone reimplements the retirement as a `router.replace`
+    //     in the component (which would reintroduce exactly the render-then-race this
+    //     leg was rewritten to avoid), and it fails if a future `/apps/*` middleware
+    //     or rewrite starts serving the store detail directly without the 302.
+    const redirectChain: string[] = [];
+    for (
+      let req = detailResp?.request().redirectedFrom();
+      req && redirectChain.length < 10;
+      req = req.redirectedFrom()
+    ) {
+      redirectChain.push(new URL(req.url()).pathname);
+    }
+    expect(
+      redirectChain.map((p) => decodeURIComponent(p)),
+      `GET /apps/${
+        first.id
+      } must reach the store detail via a SERVER redirect out of the legacy route (chain: ${
+        redirectChain.join(' -> ') || '<none>'
+      })`
+    ).toContain(`/apps/${first.id}`);
   });
 });

--- a/tests/preview-apps-marketplace.spec.ts
+++ b/tests/preview-apps-marketplace.spec.ts
@@ -5,7 +5,7 @@ import { trpcQuery } from './preview-trpc';
 /**
  * Preview-e2e (F-C): App Blocks MARKETPLACE discovery + per-app detail — the
  * anon-capable PUBLIC read path (`blocks.listAvailable` → `blocks.getAppDetail`)
- * plus the two host pages that render them (`/apps`, `/apps/<appBlockId>`).
+ * plus `/apps`, and the retirement of the legacy `/apps/<appBlockId>` route.
  * Otherwise untested by the preview suite; a PR that broke the marketplace
  * listing/detail projection or the `features.appBlocks` page gate passes every
  * other preview spec today.
@@ -43,10 +43,11 @@ import { trpcQuery } from './preview-trpc';
  *    / non-approved id (the router then throws NOT_FOUND — our helper would
  *    surface that as a thrown error). We assert the shape of a discovered,
  *    known-approved id, so a non-null detail is expected.
- *  - Detail page (`/apps/[appBlockId]/index.tsx`) renders the block name as
- *    `<Title order={2}>{name}</Title>` where
- *    `name = detail.manifest.name ?? detail.blockId ?? appBlockId` — so the
- *    visible host-rendered name == `manifest.name || blockId`.
+ *  - Legacy detail page (`/apps/[appBlockId]/index.tsx`) is RETIRED: its
+ *    `getServerSideProps` now resolves the app's approved `AppListing` and
+ *    redirects to `/apps/store-preview/<slug>` (or `notFound` when the app has no
+ *    approved listing). It no longer renders, so this spec asserts the REDIRECT
+ *    rather than a heading on it.
  *  - Marketplace page (`/apps/index.tsx`) renders the `AppsSubNav` tabs bar — its
  *    first tab is `{ href: '/apps', label: 'Marketplace' }` (AppsSubNav.tsx:55) —
  *    plus a search `TextInput` (placeholder "Search by name or block id"). It no
@@ -161,16 +162,39 @@ test.describe('App Blocks marketplace discovery + detail render (mod)', () => {
       'detail.manifest.targets should be an array (slot badges)'
     ).toBe(true);
 
-    // The DETAIL PAGE renders that block's name (host-rendered <Title> text). This
-    // proves the page's getAppDetail query + SSR appBlocks gate work end-to-end,
-    // not just the bare tRPC call. domcontentloaded ONLY.
+    // The legacy per-app route `/apps/<appBlockId>` is RETIRED: it now redirects to
+    // the unified store detail. This leg used to assert that route rendered the
+    // block's name; that page no longer renders at all, so asserting a heading here
+    // would either test the store detail by accident or race its client-side query.
+    // Assert the RETIREMENT instead — the invariant this route now has.
+    //
+    // Deliberately asserts the destination PATH PREFIX, not `/apps/store-preview/
+    // <blockId>`: the redirect resolves the store slug from the listing row, and
+    // pinning blockId here would re-import the very assumption the redirect avoids.
+    //
+    // 🔴 A 404 here is a real signal, not flake: it means this approved app has no
+    // approved `AppListing` row. Auto-create-on-approve is best-effort (it logs and
+    // continues on failure) and apps approved before it shipped were backfilled by
+    // hand, so the gap is recoverable but does not self-heal. Fix the data (run the
+    // mod-only listing backfill), don't relax this assertion. domcontentloaded ONLY.
     const detailResp = await page.goto(`/apps/${encodeURIComponent(first.id)}`, {
       waitUntil: 'domcontentloaded',
     });
-    expect(detailResp?.status(), `GET /apps/${first.id} status`).toBeLessThan(400);
-    await expect(
-      page.getByRole('heading', { name: detailName }),
-      `the detail page should render the block name "${detailName}"`
-    ).toBeVisible();
+    expect(
+      detailResp?.status(),
+      `GET /apps/${first.id} should follow the retirement redirect to a served page (a 404 means this approved app has no approved AppListing row)`
+    ).toBeLessThan(400);
+
+    const landedOn = new URL(page.url()).pathname;
+    expect(
+      landedOn,
+      `the retired /apps/${first.id} should land on the unified store detail, not render itself`
+    ).toMatch(/^\/apps\/store-preview\/.+/);
+    // The display name resolved above still has to exist — it is what the store
+    // detail is keyed on — but it is no longer this page's rendering assertion.
+    expect(
+      detailName.length,
+      'the discovered app should still expose a display name'
+    ).toBeGreaterThan(0);
   });
 });

--- a/tests/preview-apps-marketplace.spec.ts
+++ b/tests/preview-apps-marketplace.spec.ts
@@ -190,11 +190,8 @@ test.describe('App Blocks marketplace discovery + detail render (mod)', () => {
       landedOn,
       `the retired /apps/${first.id} should land on the unified store detail, not render itself`
     ).toMatch(/^\/apps\/store-preview\/.+/);
-    // The display name resolved above still has to exist — it is what the store
-    // detail is keyed on — but it is no longer this page's rendering assertion.
-    expect(
-      detailName.length,
-      'the discovered app should still expose a display name'
-    ).toBeGreaterThan(0);
+    expect(landedOn, 'the retirement must not leave the viewer on the legacy route').not.toBe(
+      `/apps/${first.id}`
+    );
   });
 });


### PR DESCRIPTION
## What

Retires the legacy per-app detail route `/apps/<appBlockId>` by redirecting it to the unified store detail `/apps/store-preview/<slug>` from `getServerSideProps`.

That route was a **second, diverging detail surface for the same app**, and it carried two measured bugs the store detail does not have:

- it rendered `by <app name>` where the store card/detail correctly render the **owner's username**;
- its "Live preview" was a raw, bridge-less `<iframe>`. Nothing ever posts `BLOCK_INIT` into that frame, so the block's design-system shell never learns the host theme and renders its **default light palette** — a permanent near-white panel on a dark page. (Not a browser paint artifact; the frame's shell element resolves `--civitai-color-body` under `data-theme="light"`.)

## Behaviour

| Case | Result |
|---|---|
| App **with** an approved store listing | `302` → `/apps/store-preview/<slug>` |
| App with **no** approved listing (pending / rejected / never-approved) | site-standard **404** (`notFound`) |
| Viewer the store-visibility flag does not grant | `notFound`, exactly as today — the gate runs **first**, before the route param is read and before any DB access |

**Why 404 and not a bounce to `/apps` for the miss.** On-site listings are created at **approval**, so a pending/rejected app has no store target. The person most likely to open this URL is the app's **owner** following a link to their own pending app; sending them to a store that by construction does not list unapproved apps is a silent dead end — it reads as "my app vanished", with no signal why. A 404 is the honest answer, it matches the posture `blocks.getAppDetail` already has (`NOT_FOUND` for a missing/unapproved app) and what `/apps/store-preview/<bogus>` already renders, and the owner's real surface is `/apps/my-submissions` with its status sections.

`permanent: false` (302, not 301) on purpose: a 301 is cached by browsers indefinitely, which would make the route's still-open final disposition irreversible in the field.

## `AppBlock.blockId` vs `AppListing.slug` — the finding

The scope left this open. **Both.** The two hold the same value today, but the redirect keys on `AppListing.slug`, and that is load-bearing:

- `mapAppBlockToListing` (`src/server/services/blocks/app-listing-mapper.ts`) mints an on-site listing with `slug: ab.blockId`, and the `AppListing.slug` column comment says the same. Verified against live data: **20/20** listings that back an `AppBlock` have `slug == block_id`. So reading `blockId` would usually produce the same string.
- But it would answer the **wrong question**. The destination resolves **by listing, approved-only**. A pending/rejected app has a `blockId` and no listing, so a `blockId`-keyed redirect would bounce its owner to a store URL that 404s instead of 404-ing here — losing the decided miss behaviour entirely. Keying on the listing row makes "an approved listing exists" the actual precondition of the redirect, and it stays correct if a slug ever diverges from its block id (off-site listings already choose their own slugs).

Since the route param is `AppBlock.id` (`apb_<ULID>`), not the slug, a lookup is required either way — so keying on the listing costs nothing.

## Is anything live going to start 404-ing?

No. Checked against live data:

- **0** approved apps lack an approved listing (9 approved apps ↔ 13 approved listings, all covered). The `notFound` branch cannot fire for a currently-visible app.
- The only apps that now 404 are non-approved ones — which **already** rendered `<NotFound />` at this URL, because `blocks.getAppDetail` is approved-only. Same user-visible outcome, decided server-side instead of after a client round-trip.

⚠️ **That "0" is a fact about today, not a guarantee.** Auto-create-on-approve is best-effort — it logs and continues on failure, and is skipped when no owner resolves — and apps approved before it shipped only get a listing on a later re-approve. Recovery is the mod-only listing backfill; nothing self-heals. So an approved, serving app *can* end up without a listing row and would then 404 here where it previously rendered. The retargeted e2e leg below is what makes that state visible instead of silent: it asserts the redirect against a runtime-discovered approved app and names a 404 as a data signal, not flake.

## Deliberately not in this PR

**Redirect, not delete.** The page body stays, and the inbound links are untouched — they simply hop. **Four files, five link sites** (an earlier draft of this said "four callsites", which conflated the two): `AppBlockCard` links **twice** (title ~`:204` and description ~`:257`), plus `ManifestEditForm` (post-save Cancel), `liveAppDetailHref` in `appListingDetailView.ts`, and the editor's own **Back** (`[appBlockId]/edit.tsx`).

⚠️ **The hop drops the query string.** The destination is built from the slug alone. Harmless in-product — the legacy page only ever read `router.query.appBlockId`, a route param that survives in the destination path — but an external link carrying `?utm_*` / `?ref=` loses those at the hop. Named as a decision, not a surprise; forwarding them is a one-line change if anyone wants it. That keeps a stale bookmark or external link working, and keeps this a one-file change. Deleting the body and retargeting those hops is a tracked follow-up, sequenced after the in-flight work on `appListingDetailView.ts` so it cannot collide with it.

**Two consequences of leaving them alone — found in review, named rather than discovered later:**

1. 🔴 **The store detail's own CTA for a model-slot app now hops back to itself.** `getDetailPrimaryAction`'s `info` branch (an on-site app with no launch page) sets `href: liveAppDetailHref(appBlockId)` — so on `/apps/store-preview/<slug>` the primary button "Runs on model pages" goes to `/apps/<appBlockId>`, which now redirects back to the page the viewer is already on. It is a click-driven no-op, not a machine loop, and **no live app is in that state** (all 9 approved on-site listings declare a page, so they take the `open`/`visit` branch). But it is latent for the whole `model.sidebar_top` product line, and fixing it means editing `appListingDetailView.ts` — the exact file the follow-up is sequenced around. **Flagging rather than fixing: pulling that edit in here would re-create the same-file collision this PR's scoping exists to avoid.** The follow-up should *retarget* that branch, not merely delete the route.
2. An owner backing out of the editor on a **pending** app now lands on a real 404 instead of a not-found rendered inside the app shell. Same end state, blunter presentation; the follow-up that retargets those links fixes it.

Checked, not assumed: *Open app* → the store detail's `open` branch, *Open live* → its `visit` fallback, *Edit manifest* → the **sibling** route `/apps/[appBlockId]/edit-manifest`, which is untouched here and independently reachable from `/apps/my-submissions` and the store card's owner Edit. Sibling routes `/edit`, `/edit-manifest`, `/listing`, `/revenue` are unaffected (distinct route paths).

🔴 **One affordance is genuinely NOT carried over, and my first draft of this PR wrongly claimed otherwise: the Install / Manage CTA.** `AppListingDetailBody` has no install surface at all, so a model-slot app would have nowhere on the store detail to install from. Same population as the self-loop above — **0 apps today** — but it is the substantive gap to close before a model-slot app is approved, and together with (1) it is why the follow-up must *retarget* that branch rather than simply delete the route.

🔴 **One knock-on, and my earlier statement of it was wrong.** The legacy 5-star `AppBlockReview` write form lived on this page. I claimed it "stays reachable through `AppDetailsModal` (opened from `AppBlockCard`), so nothing is orphaned". **It does not, and something is.** `AppBlockCard` renders only from `MarketplaceBody` and `RecentlyOpenedApps` — and `RecentlyOpenedAppsView` itself renders only inside `MarketplaceBody`, which has had **no importer in app code** since `/apps` swapped to `AppListingsMarketplaceBody`; it is retained purely as a documented one-line rollback. So after this PR the whole 5-star review surface has **no reachable entry point**.

Harmless today — `app_block_reviews` is **0 rows** in production, and the store detail carries the listing review surface — but the claim was wrong and a reviewer could have relied on it. The consequence is for the follow-up that deletes this body: it must decide the legacy review form's fate **explicitly**, rather than inherit a "still reachable" assumption that is false.

## Tests

New pure module `src/components/Apps/resolveLegacyAppRedirect.ts` — I/O-free and React-free so the branch is assertable in the node `unit` project without booting the page's module graph (same extraction precedent as `resolveAppsPageAccess.ts`, `deploy-status.ts`, `sortInstallsForSlot.ts`).

The review's sharpest finding was that the **security-relevant half of the change was the untested half**: a test of the string-builder alone cannot see the gate-before-query ordering, and deleting `status: 'approved'` from the query inverted the decided behaviour while every test still passed. Both are now covered, so the module exports three things:

- `resolveLegacyAppRedirect({ slug })` — the redirect-vs-404 decision;
- `approvedListingSlugQuery(appBlockId)` — the Prisma args, built here so the approved-only precondition is pinned;
- `resolveLegacyAppRoute({ features, appBlockId, findApprovedListingSlug })` — the whole SSR decision **with the DB read injected**, so a test can assert the lookup was never even *called* for a viewer without store visibility.

`src/components/Apps/__tests__/resolveLegacyAppRedirect.test.ts` — **24 tests**: the redirect happy path, the `notFound` miss by name, null / undefined / absent / empty / whitespace / non-string slugs, slug encoding, one-path-segment containment, gate-before-query ordering, route-param trimming, the either-flag OR-fallback, route-param handling, and the query shape.

**These are a real gate, not a change-detector — verified by mutation.** Each mutation was applied to the source, the suite run, and the failure confirmed before reverting:

| Mutation | Result |
|---|---|
| `notFound` branch → `redirect` to `/apps` (the rejected alternative) | **6 tests fail** |
| drop `encodeURIComponent` from the destination | **4 tests fail** |
| `permanent: false` → `true` | **5 tests fail** |
| move the store-visibility gate **after** the lookup | **2 tests fail** |
| drop `.trim()` on the slug | **3 tests fail** |
| drop `status: 'approved'` from the query | **1 test fails** |
| pass the **untrimmed** `appBlockId` to the lookup while still guarding the trimmed value | **1 test fails** |
| rewrite a dot-only slug in the destination | **1 test fails** |

Reverted; 24/24 green, and the full `src/components/Apps/__tests__` directory is 511/511.

🔴 **Three test defects of my own were found and fixed after the table above was first written — two of them assertions that could not fail, added by an earlier audit pass looking for exactly that:**

- The **untrimmed-`appBlockId`** mutation (last row) previously **survived the whole suite**. The resolver trims the route param, guards the trimmed value, then queries — but every fixture id in the file was whitespace-free and the only `toHaveBeenCalledWith` used a clean `'apb_x'`, so passing the untrimmed string to the lookup changed nothing observable. In production that sends `'  apb_x  '` to an equality filter on a ULID column: an approved app 404s instead of redirecting. A granted-viewer case with `'  apb_x  '` now catches it.
- Two `expect(...includes('/')).toBe(false)` sub-assertions each **followed a literal-equality assertion over the same string in the same `it`** — so any mutation admitting a `/` broke the literal first and the sub-assertion could never be the thing that failed. **Removed**, and the containment property now lives in its own `it` over separator-bearing inputs that no literal in the file constrains (that `it` is one of the four killed by dropping `encodeURIComponent`).
- The traversal test's claim was **overstated**: `encodeURIComponent('..') === '..'`, so a slug of exactly `..` yields `/apps/store-preview/..`, which dot-segment removal resolves to `/apps/` — it does *not* stay under the prefix. It never leaves the origin, and `SLUG_REGEX` (`/^[a-z][a-z0-9-]*[a-z0-9]$/`) admits no `.` so it is unreachable, but the test pinned only the slash-bearing `'../../login'` while the docstring claimed more than the code holds. The claim is now narrowed and the dot-only case pinned explicitly.

**`tests/preview-apps-marketplace.spec.ts` retargeted.** Its last leg navigated to `/apps/<id>` and asserted a heading — on the page this PR retires. Left alone it would have asserted against the store detail by accident, while racing that page's client-side query behind a loader. It now asserts the **retirement** (that the route lands under `/apps/store-preview/`), pinned on the path prefix rather than on `<blockId>` so it does not re-import the slug assumption the redirect deliberately avoids.

🔴 **A follow-up assertion in that leg could not fail and has been replaced.** It asserted `landedOn` matched `/^\/apps\/store-preview\/.+/` and then that it `!== '/apps/<id>'` — given the first passed, the second held by construction. It is replaced by two that can fail: (a) the store slug occupies **exactly one path segment** (the prefix regex happily accepts `/apps/store-preview/a/b`), and (b) the response's **redirect chain contains the legacy path**, which pins that the retirement happens at the HTTP layer and fails if anyone reimplements it as a client-side bounce or a rewrite. ⚠️ That suite is report-only and runs against a preview deployment, so these two were reasoned rather than executed; they typecheck (`tests/` is inside `tsconfig`'s `include`).

No component/browser tests were added — there is no component left to render on this route.

`NODE_OPTIONS=--max_old_space_size=8192 npx tsc --noEmit`: **26 errors on this branch, 26 on a pristine baseline worktree checked out at this branch's merge-base — and the two error sets are byte-identical** (measured by diffing the sorted `error TS` lines, not by comparing counts). All pre-existing, none in the touched files.

## Security review of the diff

- **Open redirect:** the slug is `encodeURIComponent`-ed, so `//host`, `../`, `?` and `#` in a slug stay path segments under `/apps/store-preview/` rather than steering the destination off-origin or splicing a query onto it. Three tests pin this, and dropping the encode fails them. The value comes from our own column, so this is defence in depth.
- **Existence oracle:** the store-visibility gate runs **before** the route param is read and before the DB query, so a viewer without store access gets an identical `notFound` to today — no `Location` header, no query, and now a test that fails if anyone reorders it.
  - **Stated precisely, because the first draft of this claim was too broad:** gate-first protects viewers *without* store visibility. For a viewer *with* it, 302-vs-404 is a **new HTTP-level signal that the old page did not emit** (it answered 200 either way), and it is not filtered by the further gates the destination applies.
  - 🔴 **There are THREE such gates, not two — an earlier draft of this section named only two, and its proposed remediation was therefore a two-thirds fix.** `getListingDetail` rejects a row on any of:
     1. **store-scope kind** — `scope === 'public-external' && row.kind !== 'offsite'`;
     2. **deploy** — `row.kind === 'onsite' && appBlock.currentVersionDeployedAt == null`;
     3. **maturity** — `!redCapable && isMatureContentRating(row.contentRating)`.

     (2) and (3) are the two I originally named, and both are **0 live instances** (no approved listing is rated `r`/`x`; no approved on-site listing's app is undeployed). **(1) is the one I missed, and it is categorically different.** This route's param is an `AppBlock.id`, and **every** listing carrying an `appBlockId` is `kind='onsite'` — 20/20 across all statuses in live data. So every listing this route can resolve is *precisely* the set `public-external` exists to hide. Under that scope the coverage gap is **100% of the route's resolvable set**, not a corner.

     It is **unreachable today**, and only by an accident of flag alignment: the page gate grants on `features.appListings || features.appBlocks`, and `features.appListings` reads the same `app-listings` Flipt key that `resolveStoreVisibilityScope`'s first axis uses to return `full`. Anyone past the page gate resolves `full`, where the kind gate is a no-op; anyone who would resolve `public-external` is already 404'd by the page gate. **If `app-listings-public-external` is switched on and the page gate is widened alongside it, that alignment breaks** and every `/apps/<appBlockId>` becomes a 302 disclosing an on-site app's slug to a viewer whose store scope excludes on-site entirely.

     Disclosed residual, not a hole today. **Remediation, restated correctly: all three** — a store-scope check (which for this route reduces to "`public-external` → `notFound`", the resolvable set being wholly on-site), a `currentVersionDeployedAt` filter, and a `contentRating` filter keyed on the request's red-capability. **Not implemented in this PR and still owed** — it needs the resolved store scope and the red-capability threaded into an SSR resolver that takes neither today, which is more than this redirect-only change should carry. Doing it before the store widens past its current audience is the fix.
  - Also unchecked on both hops now: `AppBlock.status`. The old route 404'd a suspended app; the listing-keyed path does not look at it. **0 live instances** (no approved listing is attached to a non-approved app block), but the drift is reachable, since the block-status flip on relist is non-fatal.
- **Owner vs anonymous vs moderator:** no divergence introduced. The redirect decision reads no session and no ownership — every viewer past the flag gate gets the same answer for the same app. Owners are the group the `notFound` branch was chosen *for* (see above); anonymous viewers are unchanged (still gated out); moderators get the hop.
- **A manifest edit re-enters review, but does not strand the redirect:** the lookup keys on `AppListing.status`, which is independent of `AppBlock.status`, so an app whose *code* is back in review keeps resolving to its still-approved listing. (Live data: no approved listing is attached to a non-approved app, and the `app_block_id` column is UNIQUE, so at most one row can ever match.)

## Two smaller notes, named rather than left to be found

- **One DB read is added to this route.** It is a single lookup on a UNIQUE column, on a route that is flag-gated to a small audience and now renders nothing — negligible.
- **New failure mode, judged acceptable:** if that read throws, `getServerSideProps` throws and the route 500s, where previously the page rendered and settled into a client-side not-found. Deliberately not wrapped in a `try/catch` fallback: swallowing it into a 404 would disguise an outage as "this app doesn't exist", and every other SSR route on the site fails the same way under the same condition.

## Review

Two independent adversarial passes over the diff (component suites are report-only here, so the audit is the real correctness gate). Everything above that is marked as a residual, a latent issue, or a corrected claim came out of them; the fixes are in commits 2–4. Between them they corrected three things I had stated wrongly — the callsite count (three → four), "the store detail covers the whole action set" (Install is not covered), and an over-broad existence-oracle claim — and found two assertions that could not fail.

Also confirmed clean by both, with evidence:

- **No redirect loop.** `/apps/store-preview` is a static segment that outranks the dynamic one; the detail route has no server-side redirect of its own; no `/apps` rules in middleware or `next.config`.
- **Open redirect contained.** No slug can produce `//host`, a `?`/`#` splice, or CR/LF header injection; `%2F` is not decoded before routing, so an encoded traversal stays one path segment.
- **No client-bundle or vitest-browser leakage** from the `dbRead` import — no `*.browser.test.tsx` imports this page, and `dbRead` in a page is the established pattern (29 other pages do it).
- **At most one listing row can ever match** — `app_block_id` is UNIQUE, so `findFirst` is deterministic. The route param is `AppBlock.id`, matching what the old page queried, so there is no id/blockId mismatch.
- **No owner / anon / moderator regression.** The old page was already approved-only for everyone including mods, so an owner or mod on a pending app saw a not-found before and gets a 404 now.

One gate-parity item is left open on purpose and is the sharpest thing a reviewer should push on: the redirect does not replicate the **three** gates the destination applies — store-scope kind, deploy, and maturity (see the security section, and note that an earlier draft of this line named only the last two). The deploy and maturity gates are empty today; the **kind** gate covers 100% of this route's resolvable set under a `public-external` scope and is held back only by the page gate happening to key on the same flag. The fix is all three filters, and it is a reasonable ask before the store widens.

## Verification owed after merge

- `GET /apps/<approved app id>` → `302`, `Location: /apps/store-preview/<slug>` (assert on status + header, not a rendered page).
- An app with no approved listing → site-standard 404, no redirect loop.
- `/apps/<id>/edit`, `/edit-manifest`, `/listing`, `/revenue` all still load.

