### PR TITLE
test(challenge): pin the winner-payout telemetry the last round left unguarded

### DIFF
--- a/src/server/games/daily-challenge/__tests__/challenge-winner-payout-dedupe.test.ts
+++ b/src/server/games/daily-challenge/__tests__/challenge-winner-payout-dedupe.test.ts
@@ -4,6 +4,7 @@ import client from 'prom-client';
 // — the repo forbids inline `typeof import(...)` annotations.
 import type * as FliptClient from '~/server/flipt/client';
 import type * as ChallengeFunding from '~/server/games/daily-challenge/challenge-funding';
+import type * as ErrorHandling from '~/utils/errorHandling';
 
 // Winner-prize payouts are deduped ONLY by their externalTransactionId, which embeds the winner's
 // PLACE (`challenge-winner-prize-{challengeId}-{userId}-place-{place}`) — `createBuzzTransactionMany`
@@ -42,6 +43,8 @@ const {
   mockCreateChallengeWinner,
   mockGetChallengeById,
   mockCreateBuzzTransactionMany,
+  mockWithRetries,
+  mockBuildWinnerPayoutTransactions,
 } = vi.hoisted(() => ({
   mockDbReadQueryRaw: vi.fn(),
   mockDbReadChallengeFindUnique: vi.fn(),
@@ -64,6 +67,12 @@ const {
   mockCreateChallengeWinner: vi.fn(),
   mockGetChallengeById: vi.fn().mockResolvedValue(null),
   mockCreateBuzzTransactionMany: vi.fn().mockResolvedValue(undefined),
+  // Real `withRetries` re-invokes its closure up to 4 times on a flaky payout. Doubled so a test can
+  // drive that deterministically instead of making the buzz mock throw and waiting on real retries.
+  mockWithRetries: vi.fn(),
+  // A SPY that delegates to the real (pure) builder — assertions still run against genuine
+  // externalTransactionId strings, but the number of times the payout is BUILT becomes observable.
+  mockBuildWinnerPayoutTransactions: vi.fn(),
 }));
 
 vi.mock('~/server/db/client', () => ({
@@ -158,12 +167,19 @@ vi.mock('~/server/services/reaction.service', () => ({
 // assertions below run against the genuine externalTransactionId strings.
 vi.mock('~/server/games/daily-challenge/challenge-funding', async (importOriginal) => {
   const actual = await importOriginal<typeof ChallengeFunding>();
+  mockBuildWinnerPayoutTransactions.mockImplementation(actual.buildWinnerPayoutTransactions);
   return {
     ...actual,
+    buildWinnerPayoutTransactions: mockBuildWinnerPayoutTransactions,
     refundUserChallengeFunds: mockRefundUserChallengeFunds,
     getChallengeBuzzType: vi.fn().mockResolvedValue('yellow'),
     reportPoolFundingShortfall: vi.fn().mockResolvedValue(undefined),
   };
+});
+
+vi.mock('~/utils/errorHandling', async (importOriginal) => {
+  const actual = await importOriginal<typeof ErrorHandling>();
+  return { ...actual, withRetries: mockWithRetries };
 });
 
 vi.mock('~/utils/logging', () => ({
@@ -331,6 +347,8 @@ beforeEach(() => {
   mockDbWriteChallengeFindUnique.mockResolvedValue({ prizePool: 0, prizeDistribution: null });
   mockGetChallengeById.mockResolvedValue(null);
   mockCreateBuzzTransactionMany.mockResolvedValue(undefined);
+  // Default: the happy path, one invocation — same as real `withRetries` when nothing throws.
+  mockWithRetries.mockImplementation((fn: (remaining: number) => unknown) => fn(3));
 });
 
 describe('winner payout keys on the PERSISTED placement (duplicate-payout guard)', () => {
@@ -617,6 +635,74 @@ describe('one creator named twice in a single pick is paid once (duplicate-pick 
     expect(await counterValue(DUPLICATE_PICK_METRIC, { source: 'System' })).toBe(1);
   });
 
+  // `origin` was asserted nowhere, so the two values were interchangeable and the label could be
+  // flipped with every test still green. It is the sharpest label on this counter to get wrong:
+  // `chokepoint` means "a caller reached the money path with duplicates and did NOT report it", i.e.
+  // real prize money silently not paid, and an operator seeing it on a drop the caller DID report
+  // would go hunting a payout failure that never happened.
+  it('tags the drop as origin=caller — this path reported it, the choke point did not catch it', async () => {
+    mockChallengeJudgeRow(ChallengeSource.System);
+    mockJudgedEntryRows([
+      { imageId: 1, userId: 100, username: 'alice' },
+      { imageId: 2, userId: 200, username: 'bob' },
+    ]);
+    mockDbWriteQueryRaw.mockResolvedValueOnce([]);
+    mockGenerateWinners.mockResolvedValue({
+      process: 'llm',
+      outcome: 'llm-picked',
+      model: 'test-model',
+      usage: {},
+      winners: [
+        { creator: 'alice', creatorId: 100, reason: 'best' },
+        { creator: 'alice', creatorId: 100, reason: 'again' },
+      ],
+    });
+    stubUniqueWinnerTable();
+
+    await pickWinnersForChallenge(currentChallenge, BASE_CONFIG);
+
+    expect(await counterValue(DUPLICATE_PICK_METRIC, { source: 'System', origin: 'caller' })).toBe(
+      1
+    );
+    // And the choke-point series must not exist: the caller dropped the duplicate before the
+    // builder ever saw it, so the builder's own guard is a genuine no-op here.
+    expect(await counterValue(DUPLICATE_PICK_METRIC, { origin: 'chokepoint' })).toBeUndefined();
+  });
+
+  // The judge row is typed `| undefined` (the SELECT is `LIMIT 1` against a replica), and the emit
+  // defaults its source the same way the judging call upstream does. Nothing pinned that default, so
+  // it could be dropped and the `unknown` bucket would quietly absorb the emit — and `unknown` is
+  // reserved for "the source could not be read", which is a different operator question from "a
+  // System challenge dropped a placement".
+  it('defaults the source to System when the judge row could not be read', async () => {
+    // No judge row at all — the destructure yields `undefined`, which is exactly what a replica that
+    // has not seen the challenge row (or a row deleted mid-run) produces.
+    mockDbReadQueryRaw.mockResolvedValueOnce([]);
+    mockJudgedEntryRows([
+      { imageId: 1, userId: 100, username: 'alice' },
+      { imageId: 2, userId: 200, username: 'bob' },
+    ]);
+    mockDbWriteQueryRaw.mockResolvedValueOnce([]);
+    mockGenerateWinners.mockResolvedValue({
+      process: 'llm',
+      outcome: 'llm-picked',
+      model: 'test-model',
+      usage: {},
+      winners: [
+        { creator: 'alice', creatorId: 100, reason: 'best' },
+        { creator: 'alice', creatorId: 100, reason: 'again' },
+      ],
+    });
+    stubUniqueWinnerTable();
+
+    await pickWinnersForChallenge(currentChallenge, BASE_CONFIG);
+
+    expect(await counterValue(DUPLICATE_PICK_METRIC, { source: 'System', origin: 'caller' })).toBe(
+      1
+    );
+    expect(await counterValue(DUPLICATE_PICK_METRIC, { source: 'unknown' })).toBeUndefined();
+  });
+
   it('leaves a clean pick alone — the guard does not over-trigger', async () => {
     mockChallengeJudgeRow(ChallengeSource.System);
     mockJudgedEntryRows([
@@ -645,5 +731,74 @@ describe('one creator named twice in a single pick is paid once (duplicate-pick 
     expect(mockCreateChallengeWinner).toHaveBeenCalledTimes(2);
     // Absent series, not zero — the counter must never have been touched.
     expect(await counterValue(DUPLICATE_PICK_METRIC, { source: 'System' })).toBeUndefined();
+  });
+});
+
+// `buildWinnerPayoutTransactions` is called OUTSIDE the `withRetries` closure. The output is
+// deterministic so rebuilding it would not move different money — but the builder increments the
+// duplicate-pick counter on its drop branch, and `withRetries` re-invokes up to 4 times. Inside the
+// closure, a flaky payout would record up to 4x the placements actually dropped, on exactly the run
+// where the number matters most. Nothing pinned the placement of that one line.
+describe('the winner payout is built ONCE, outside the retry closure', () => {
+  const wireCleanTwoWinnerPick = () => {
+    mockChallengeJudgeRow(ChallengeSource.System);
+    mockJudgedEntryRows([
+      { imageId: 1, userId: 100, username: 'alice' },
+      { imageId: 2, userId: 200, username: 'bob' },
+    ]);
+    mockDbWriteQueryRaw.mockResolvedValueOnce([]);
+    mockGenerateWinners.mockResolvedValue({
+      process: 'llm',
+      outcome: 'llm-picked',
+      model: 'test-model',
+      usage: {},
+      winners: [
+        { creator: 'alice', creatorId: 100, reason: 'best' },
+        { creator: 'bob', creatorId: 200, reason: 'second' },
+      ],
+    });
+    stubUniqueWinnerTable();
+  };
+
+  it('a payout that retries three times still builds the transactions exactly once', async () => {
+    wireCleanTwoWinnerPick();
+    // What real `withRetries` does to its closure when the buzz call keeps failing.
+    mockWithRetries.mockImplementation(async (fn: (remaining: number) => Promise<unknown>) => {
+      await fn(3);
+      await fn(2);
+      await fn(1);
+    });
+
+    await pickWinnersForChallenge(currentChallenge, BASE_CONFIG);
+
+    // The retry itself must still happen — otherwise this test would pass on a build that never
+    // retries at all, which is a different bug.
+    expect(mockCreateBuzzTransactionMany).toHaveBeenCalledTimes(3);
+    expect(mockBuildWinnerPayoutTransactions).toHaveBeenCalledTimes(1);
+  });
+
+  it('every retry submits the SAME transaction array instance, not a rebuilt one', async () => {
+    wireCleanTwoWinnerPick();
+    mockWithRetries.mockImplementation(async (fn: (remaining: number) => Promise<unknown>) => {
+      await fn(3);
+      await fn(2);
+    });
+
+    await pickWinnersForChallenge(currentChallenge, BASE_CONFIG);
+
+    const [first] = mockCreateBuzzTransactionMany.mock.calls[0];
+    const [second] = mockCreateBuzzTransactionMany.mock.calls[1];
+    // Identity, not deep equality: a rebuild produces an equal-but-distinct array, so `toEqual`
+    // would pass on the very mutation this pins.
+    expect(second).toBe(first);
+  });
+
+  it('does not rebuild on the happy path either — one build, one submit', async () => {
+    wireCleanTwoWinnerPick();
+
+    await pickWinnersForChallenge(currentChallenge, BASE_CONFIG);
+
+    expect(mockCreateBuzzTransactionMany).toHaveBeenCalledTimes(1);
+    expect(mockBuildWinnerPayoutTransactions).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/server/games/daily-challenge/__tests__/challenge-winner-persistence.test.ts
+++ b/src/server/games/daily-challenge/__tests__/challenge-winner-persistence.test.ts
@@ -21,6 +21,7 @@ const {
   mockFindUnique,
   mockLogToAxiom,
   mockRecordDivergence,
+  mockRecordUnresolved,
 } = vi.hoisted(() => ({
   mockDbReadQueryRaw: vi.fn().mockResolvedValue([]),
   mockDbWriteQueryRaw: vi.fn().mockResolvedValue([]),
@@ -28,6 +29,7 @@ const {
   mockFindUnique: vi.fn(),
   mockLogToAxiom: vi.fn().mockResolvedValue(undefined),
   mockRecordDivergence: vi.fn(),
+  mockRecordUnresolved: vi.fn(),
 }));
 
 vi.mock('~/server/db/client', () => ({
@@ -44,7 +46,11 @@ vi.mock('~/server/logging/client', () => ({
 }));
 vi.mock('~/server/prom/challenge.metrics', async (importOriginal) => {
   const actual = await importOriginal<typeof ChallengeMetrics>();
-  return { ...actual, recordChallengeWinnerPlaceDivergence: mockRecordDivergence };
+  return {
+    ...actual,
+    recordChallengeWinnerPlaceDivergence: mockRecordDivergence,
+    recordChallengeWinnerConflictUnresolved: mockRecordUnresolved,
+  };
 });
 
 const { createChallengeWinner, getExistingWinnersForRetry } = await import(
@@ -155,6 +161,29 @@ describe('createChallengeWinner (P0-b)', () => {
     expect(mockRecordDivergence).toHaveBeenCalledWith({ field: 'place' });
   });
 
+  // The third `field` value. Nothing asserted it, so the prize-only arm of the ternary that picks
+  // the label was free to be wrong — and it is the arm that matters most for money: the place, and
+  // therefore the transaction id, is unchanged, so the ONLY thing that diverged is how much the user
+  // is owed. An operator seeing `field=place` for that would go looking for a re-ordering that never
+  // happened.
+  it('labels a prize-only divergence as prize', async () => {
+    mockCreate.mockRejectedValue(p2002());
+    // Same place as INPUT (1), different buzzAwarded.
+    mockFindUnique.mockResolvedValue({ id: 5, place: 1, buzzAwarded: 250, pointsAwarded: 10 });
+
+    await createChallengeWinner(INPUT);
+
+    expect(mockRecordDivergence).toHaveBeenCalledWith({ field: 'prize' });
+    expect(mockLogToAxiom).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'warning',
+        name: 'challenge-winner-place-divergence',
+        storedBuzzAwarded: 250,
+        attemptedBuzzAwarded: 500,
+      })
+    );
+  });
+
   it('an identical duplicate stays info-level and does not touch the divergence metric', async () => {
     mockCreate.mockRejectedValue(p2002());
     mockFindUnique.mockResolvedValue({ id: 5, place: 1, buzzAwarded: 500, pointsAwarded: 10 });
@@ -173,7 +202,13 @@ describe('createChallengeWinner (P0-b)', () => {
     );
   });
 
-  it('returns null and warns when the conflict resolves to no readable row', async () => {
+  // THE remaining mint path. Returning `null` makes `reconcileWinnerToPersisted` pass the entry
+  // through untouched, so the caller settles a freshly-picked `-place-N` id with no ChallengeWinner
+  // row to key it to. It is reachable, not theoretical: (challengeId, userId) is not this table's
+  // only unique constraint — `id Int @id @default(autoincrement())` is one too — so a sequence left
+  // behind by a restore or a manual insert raises P2002 on `id`, and the (challengeId, userId)
+  // re-read then correctly finds nothing.
+  it('returns null, warns, and RECORDS the unresolved conflict — the mint path is not silent', async () => {
     mockCreate.mockRejectedValue(p2002());
     mockFindUnique.mockResolvedValue(null);
 
@@ -184,6 +219,30 @@ describe('createChallengeWinner (P0-b)', () => {
         name: 'challenge-winner-conflict-unresolved',
       })
     );
+    // Without this the counter suite reads exactly 0 in the one case where money may have moved
+    // twice — an Axiom log is not a metric and nothing can alert on its absence.
+    expect(mockRecordUnresolved).toHaveBeenCalledTimes(1);
+    // And NOT onto the divergence counter: that one's contract is "the payout was reconciled onto
+    // the stored row", which is exactly what did not happen here.
+    expect(mockRecordDivergence).not.toHaveBeenCalled();
+  });
+
+  it('a resolved conflict does not touch the unresolved counter', async () => {
+    mockCreate.mockRejectedValue(p2002());
+    mockFindUnique.mockResolvedValue({ id: 5, place: 3, buzzAwarded: 100, pointsAwarded: 2 });
+
+    await createChallengeWinner(INPUT);
+
+    expect(mockRecordUnresolved).not.toHaveBeenCalled();
+  });
+
+  it('a clean insert touches neither money-path counter', async () => {
+    mockCreate.mockResolvedValue({ id: 5, place: 1, buzzAwarded: 500, pointsAwarded: 10 });
+
+    await createChallengeWinner(INPUT);
+
+    expect(mockRecordUnresolved).not.toHaveBeenCalled();
+    expect(mockRecordDivergence).not.toHaveBeenCalled();
   });
 
   it('rethrows a non-P2002 error', async () => {

--- a/src/server/games/daily-challenge/challenge-funding.ts
+++ b/src/server/games/daily-challenge/challenge-funding.ts
@@ -380,8 +380,16 @@ export async function reportPoolFundingShortfall({
   }).catch(() => {});
 }
 
-/** The idempotency key a winner-prize payout is settled under. */
-export function winnerPayoutExternalId(challengeId: number, userId: number, position: number) {
+/**
+ * The idempotency key a winner-prize payout is settled under.
+ *
+ * Module-private on purpose. It has no consumer outside this file, and 15 test suites mock
+ * `challenge-funding` with an explicit export list — so an unused export here is a live tripwire:
+ * the first file to import it gets `undefined` under those mocks rather than a missing-export error.
+ * Tests that assert on payout keys spell the string out literally instead, deliberately, so that a
+ * change to the format fails them rather than being mirrored into the expectation.
+ */
+function winnerPayoutExternalId(challengeId: number, userId: number, position: number) {
   return `challenge-winner-prize-${challengeId}-${userId}-place-${position}`;
 }
 

--- a/src/server/games/daily-challenge/challenge-helpers.ts
+++ b/src/server/games/daily-challenge/challenge-helpers.ts
@@ -559,8 +559,9 @@ export type CreateWinnerInput = {
  * Create the `ChallengeWinner` record for one winner and return the placement that is actually
  * PERSISTED — which is not always the placement passed in.
  *
- * The table is uniquely keyed on (challengeId, userId), so a user who was already recorded as a
- * winner of this challenge cannot get a second row: the insert conflicts (P2002) and the stored
+ * The table has a (challengeId, userId) unique key — note it is NOT the only one, see the P2002
+ * handling below — so a user already recorded as a winner of this challenge normally cannot get a
+ * second row: the insert conflicts (P2002) and the stored
  * row keeps its ORIGINAL place. This used to return `null` on that conflict, which read as "record
  * skipped, carry on" — and the caller then paid the freshly-picked place. Because the winner-prize
  * externalTransactionId embeds the place, that paid under a brand-new key and MINTED A SECOND
@@ -595,9 +596,11 @@ export async function createChallengeWinner(
     });
     return { ...winner, created: true };
   } catch (error) {
-    // P2002 = unique constraint violation on (challengeId, userId) — this user is already recorded
-    // as a winner of this challenge, from an earlier run of the same completion or from a
-    // concurrent run that re-picked winners.
+    // P2002 = unique constraint violation. USUALLY that is (challengeId, userId) — this user is
+    // already recorded as a winner of this challenge, from an earlier run of the same completion or
+    // from a concurrent run that re-picked winners. Do NOT read it as a guarantee that such a row
+    // exists: this table carries more than one unique key, so the re-read below can legitimately
+    // come back empty. That case is handled and instrumented at the end of this block.
     if (error instanceof Prisma.PrismaClientKnownRequestError && error.code === 'P2002') {
       // Read from the PRIMARY: the row we are conflicting with may have been written moments ago,
       // and a replica read that missed it would send us straight back down the mint path.

--- a/src/server/games/daily-challenge/challenge-helpers.ts
+++ b/src/server/games/daily-challenge/challenge-helpers.ts
@@ -3,6 +3,7 @@ import { dbRead, dbWrite } from '~/server/db/client';
 import { logToAxiom } from '~/server/logging/client';
 import {
   recordChallengeOperationSpentBuzz,
+  recordChallengeWinnerConflictUnresolved,
   recordChallengeWinnerPlaceDivergence,
 } from '~/server/prom/challenge.metrics';
 import { removeTags } from '~/utils/string-helpers';
@@ -606,10 +607,23 @@ export async function createChallengeWinner(
       });
 
       if (!persisted) {
-        // Structurally unreachable — (challengeId, userId) is this table's only unique constraint,
-        // so a P2002 here means the row exists. Surfaced loudly rather than silently, and the
-        // caller is deliberately left on its in-memory placement: refusing to pay would introduce
-        // an UNDER-payment failure mode on a path where nobody has ever been underpaid.
+        // NOT structurally unreachable. (challengeId, userId) is not this table's only unique
+        // constraint — `id Int @id @default(autoincrement())` is one too — so a P2002 here does not
+        // imply that a (challengeId, userId) row exists. A sequence that has fallen behind the
+        // table, the routine aftermath of a restore or a manual insert, makes the INSERT collide on
+        // `id`; that conflict says nothing about (challengeId, userId), and the re-read above
+        // correctly finds nothing.
+        //
+        // This is the only branch left in this function that can settle an unreconciled payout key.
+        // The caller is deliberately left on its in-memory placement — refusing to pay would
+        // introduce an UNDER-payment failure mode on a path where nobody has ever been underpaid —
+        // so the prize goes out under a freshly-picked `-place-N` id with NO ChallengeWinner row to
+        // key it to. Nothing durable then records what was paid, and a later completion that re-picks
+        // this user at any other place settles a second, non-conflicting id.
+        //
+        // Hence a counter of its own, not the divergence counter below it: that one means "the
+        // payout was reconciled onto the stored row", which is exactly what did NOT happen here, and
+        // it reads 0 on this path.
         logToAxiom({
           type: 'warning',
           name: 'challenge-winner-conflict-unresolved',
@@ -618,6 +632,7 @@ export async function createChallengeWinner(
           userId: input.userId,
           attemptedPlace: input.place,
         });
+        recordChallengeWinnerConflictUnresolved();
         return null;
       }
 

--- a/src/server/games/daily-challenge/challenge-winner-reconcile.ts
+++ b/src/server/games/daily-challenge/challenge-winner-reconcile.ts
@@ -39,9 +39,14 @@ export type WinnerPayoutEntry = {
  * Fold a freshly-picked winner entry onto the placement that is actually persisted.
  *
  * - Fresh insert (`created: true`) — nothing to reconcile, the row matches what we picked.
- * - `null` — the create neither inserted nor resolved to a readable row (structurally unreachable:
- *   (challengeId, userId) is the table's only unique constraint). Left untouched deliberately, so
- *   this fix can never turn into an UNDER-payment; the create path logs it loudly instead.
+ * - `null` — the create neither inserted nor resolved to a readable row. This is NOT structurally
+ *   unreachable: (challengeId, userId) is not the table's only unique constraint, `id Int @id
+ *   @default(autoincrement())` is one too, so a sequence left behind by a restore or a manual insert
+ *   collides on `id` and the (challengeId, userId) re-read that follows finds nothing. Left
+ *   untouched deliberately, so this fix can never turn into an UNDER-payment — which does mean the
+ *   entry is paid under an unreconciled place. The create path logs it loudly and increments
+ *   `challenge_winner_conflict_unresolved_total`; it is the one remaining branch there that can
+ *   settle a second transaction id for a user.
  * - Existing row — its place/prize win. Paying the freshly-picked place instead is exactly the
  *   double-mint: the user was already paid under the recorded place's transaction id.
  *
@@ -84,9 +89,18 @@ export function reconcileWinnerToPersisted<T extends WinnerPayoutEntry>(
  * the unique key means a creator has at most one row per challenge, so a repeat of that creator is
  * always a duplicate of the same award and never a second one they were owed.
  *
- * The FIRST occurrence wins. Entries are built in placement order, so the first holds the best
- * place and therefore the largest prize — keeping a later, worse placement instead would turn a
- * duplicate pick into an under-payment.
+ * The FIRST occurrence wins — which means the BEST PLACE, and that is not the same claim as the
+ * largest prize. Entries are built in placement order, so the survivor is the lowest-numbered place;
+ * but nothing makes prizes descend with place. `prizeDistributionSchema` validates only three values
+ * in 1..100 summing to 100, descending order is not enforced, and `distributePrizes` maps the
+ * percentages positionally — so `[20, 50, 30]` is a legal distribution under which place 1 pays LESS
+ * than place 2 and first-wins keeps the smaller prize.
+ *
+ * Kept anyway, because place is the payout's IDENTITY rather than a ranking: the externalTransactionId
+ * embeds it and the `ChallengeWinner` row records it, so the surviving entry has to be the one the
+ * stored row will agree with. "Keep whichever pays more" would select a placement no row will hold
+ * and put the record and the ledger back into the disagreement this module exists to prevent. Which
+ * duplicate survives is payout semantics, not telemetry, and changing it is out of scope here.
  *
  * Lives in this module rather than beside `buildWinnerPayoutTransactions` for a mundane but real
  * reason: `challenge-funding` is mocked with an explicit export list by 15 test files, so a new

--- a/src/server/prom/__tests__/challenge.metrics.test.ts
+++ b/src/server/prom/__tests__/challenge.metrics.test.ts
@@ -8,6 +8,10 @@ import {
   normPaid,
   normVoidReason,
   normRefundReason,
+  normDivergenceField,
+  recordChallengeWinnerDuplicatePick,
+  recordChallengeWinnerPlaceDivergence,
+  recordChallengeWinnerConflictUnresolved,
   recordChallengeCreated,
   recordChallengeScanResult,
   recordChallengeEntrySubmitted,
@@ -276,6 +280,108 @@ describe('economy counters — inc by buzz amount, skip non-positive', () => {
         reason: 'void',
       })
     ).toBe(2);
+  });
+});
+
+// The two money-path anomaly counters. Every other counter in this file is a volume signal where an
+// off-by-one is noise; these are documented as sitting FLAT AT ZERO, so a unit that should not have
+// been recorded is not a rounding error — it is the whole signal being wrong.
+describe('money-path anomaly counters — a unit must mean exactly one real event', () => {
+  /**
+   * Absent series vs a series holding 0. `valueFor` above collapses both to 0, which is precisely
+   * the distinction these counters live or die on, so they get their own reader.
+   */
+  async function seriesValue(
+    name: string,
+    labels: Record<string, string>
+  ): Promise<number | undefined> {
+    const values = await readMetric(name);
+    return values.find((v) => Object.entries(labels).every(([k, val]) => v.labels[k] === val))
+      ?.value;
+  }
+
+  const DUPLICATE_PICK = 'civitai_app_challenge_winner_duplicate_pick_total';
+  const DIVERGENCE = 'civitai_app_challenge_winner_place_divergence_total';
+  const UNRESOLVED = 'civitai_app_challenge_winner_conflict_unresolved_total';
+
+  it('an explicit count of 0 records NOTHING — "I dropped nothing" must never read as one drop', async () => {
+    recordChallengeWinnerDuplicatePick({ source: 'System', count: 0, origin: 'caller' });
+
+    // Absent, not zero: the emit must not have happened at all. Without the guard the count falls
+    // through to the `isPositiveFinite` default and this series reads 1 — a phantom dropped
+    // placement, i.e. phantom unpaid money, on a counter whose contract is that it stays at zero.
+    expect(
+      await seriesValue(DUPLICATE_PICK, { source: 'System', origin: 'caller' })
+    ).toBeUndefined();
+    expect(await readMetric(DUPLICATE_PICK)).toHaveLength(0);
+  });
+
+  it('an explicitly garbage count records NOTHING either — negative, NaN and Infinity', async () => {
+    // A caller that computed one of these has a bug; recording 1 for it invents a drop that did not
+    // happen and hides the bug behind a plausible-looking value.
+    recordChallengeWinnerDuplicatePick({ source: 'System', count: -1, origin: 'caller' });
+    recordChallengeWinnerDuplicatePick({ source: 'System', count: NaN, origin: 'caller' });
+    recordChallengeWinnerDuplicatePick({ source: 'System', count: Infinity, origin: 'caller' });
+
+    expect(await readMetric(DUPLICATE_PICK)).toHaveLength(0);
+  });
+
+  it('an OMITTED count still means one drop — the default is not collateral damage of the guard', async () => {
+    recordChallengeWinnerDuplicatePick({ source: 'System', origin: 'caller' });
+
+    expect(await seriesValue(DUPLICATE_PICK, { source: 'System', origin: 'caller' })).toBe(1);
+  });
+
+  it('a real count is recorded verbatim, and origin/source are kept apart', async () => {
+    recordChallengeWinnerDuplicatePick({ source: 'User', count: 2, origin: 'caller' });
+    recordChallengeWinnerDuplicatePick({ count: 1, origin: 'chokepoint' });
+
+    expect(await seriesValue(DUPLICATE_PICK, { source: 'User', origin: 'caller' })).toBe(2);
+    // The choke point has no challenge in scope, so its source normalizes to `unknown` — the exact
+    // ambiguity the `origin` label exists to resolve.
+    expect(await seriesValue(DUPLICATE_PICK, { source: 'unknown', origin: 'chokepoint' })).toBe(1);
+    expect(
+      await seriesValue(DUPLICATE_PICK, { source: 'User', origin: 'chokepoint' })
+    ).toBeUndefined();
+  });
+
+  it('normDivergenceField bounds to place|prize|both, else other', () => {
+    expect(normDivergenceField('place')).toBe('place');
+    expect(normDivergenceField('prize')).toBe('prize');
+    expect(normDivergenceField('both')).toBe('both');
+    expect(normDivergenceField('points')).toBe('other');
+    expect(normDivergenceField(undefined)).toBe('other');
+  });
+
+  it('the divergence counter keeps its three field values separate', async () => {
+    recordChallengeWinnerPlaceDivergence({ field: 'place' });
+    recordChallengeWinnerPlaceDivergence({ field: 'prize' });
+    recordChallengeWinnerPlaceDivergence({ field: 'both' });
+
+    expect(await seriesValue(DIVERGENCE, { field: 'place' })).toBe(1);
+    expect(await seriesValue(DIVERGENCE, { field: 'prize' })).toBe(1);
+    expect(await seriesValue(DIVERGENCE, { field: 'both' })).toBe(1);
+  });
+
+  it('the unresolved-conflict counter is its own series, unlabelled, and starts at a real 0', async () => {
+    // Unlabelled is load-bearing: it emits 0 from process start instead of being absent until the
+    // first increment, so a `> 0` rule on it cannot fail open the way one on a label-bearing
+    // counter can.
+    expect(await seriesValue(UNRESOLVED, {})).toBe(0);
+
+    recordChallengeWinnerConflictUnresolved();
+    expect(await seriesValue(UNRESOLVED, {})).toBe(1);
+
+    // And it must NOT be folded into the divergence counter: that one means "the payout was
+    // reconciled onto the stored row", the opposite money verdict.
+    expect(await readMetric(DIVERGENCE)).toHaveLength(0);
+  });
+
+  it('both helpers stay never-throw', () => {
+    expect(() =>
+      recordChallengeWinnerDuplicatePick({ count: undefined, origin: 'caller' })
+    ).not.toThrow();
+    expect(() => recordChallengeWinnerConflictUnresolved()).not.toThrow();
   });
 });
 

--- a/src/server/prom/__tests__/challenge.metrics.test.ts
+++ b/src/server/prom/__tests__/challenge.metrics.test.ts
@@ -383,6 +383,20 @@ describe('money-path anomaly counters — a unit must mean exactly one real even
     ).not.toThrow();
     expect(() => recordChallengeWinnerConflictUnresolved()).not.toThrow();
   });
+
+  // The "starts at a real 0" assertion above is only meaningful if the reset helper actually clears
+  // this counter — and because counters live on a process-global registry, that assertion passes on
+  // execution ORDER alone as long as it happens to run before anything increments. That is the exact
+  // hazard __resetChallengeMetricsForTest exists to remove, so it needs its own guard rather than
+  // relying on file order: increment FIRST, then re-assert zero after a reset.
+  it('the reset helper clears the unresolved-conflict counter, not just the labelled ones', async () => {
+    recordChallengeWinnerConflictUnresolved();
+    expect(await seriesValue(UNRESOLVED, {})).toBe(1);
+
+    __resetChallengeMetricsForTest();
+
+    expect(await seriesValue(UNRESOLVED, {})).toBe(0);
+  });
 });
 
 describe('never-throw guarantee', () => {

--- a/src/server/prom/challenge.metrics.ts
+++ b/src/server/prom/challenge.metrics.ts
@@ -171,13 +171,21 @@ const winnerDuplicatePickCounter = registerCounterWithLabels({
 // label report "reconciled" for the one case where money may have moved twice.
 //
 // The causes differ as much as the verdicts. Divergence is triggered by a completion re-picking
-// winners over an existing record; remediation is finding out why a completion ran twice. This one's
-// reachable trigger is a P2002 raised by a DIFFERENT unique constraint: `ChallengeWinner` also has
-// `id Int @id @default(autoincrement())`, and a sequence left behind by a restore or a manual insert
-// collides on `id` — a conflict that says nothing about (challengeId, userId), so the re-read that
-// follows finds no row. Remediation there is resyncing the sequence. Same function, different
-// constraint, different fix; the module's existing split (duplicate-pick vs divergence) draws the
-// line in exactly the same place.
+// winners over an existing record; remediation is finding out why a completion ran twice.
+//
+// This one fires whenever a P2002 is followed by a re-read that finds nothing, and there is more
+// than one way to get there. Do NOT treat the list below as exhaustive — the counter's meaning is
+// "the conflict did not resolve to a row", not "the sequence is desynced":
+//   - a P2002 on a DIFFERENT unique key. `ChallengeWinner` also has `id Int @id
+//     @default(autoincrement())`, so a sequence left behind by a restore or a manual insert
+//     collides on `id`, which says nothing about (challengeId, userId). Remediation: resync the
+//     sequence. Structurally real, but note it is not what prod looks like today.
+//   - a genuine (challengeId, userId) conflict whose row disappears between the failed INSERT and
+//     the re-read. Both FKs are `onDelete: Cascade` and no application code deletes these rows, so
+//     the realistic actor is a cascade or a human doing post-incident cleanup. Remediation: find
+//     out who deleted winner rows, which is a very different investigation.
+// Same function, different constraint, different fix; the module's existing split (duplicate-pick
+// vs divergence) draws the line in exactly the same place.
 //
 // UNLABELLED on purpose, and that is a feature here. `createChallengeWinner` is handed a winner row,
 // not a challenge, so the `source` every other counter in this file slices by is genuinely not in

--- a/src/server/prom/challenge.metrics.ts
+++ b/src/server/prom/challenge.metrics.ts
@@ -3,7 +3,7 @@ import client from 'prom-client';
 // definitions + record helpers stay a runtime-light leaf that a unit test can load without booting
 // the app graph. The DB used by the state gauges is pulled in LAZILY (dynamic import inside the
 // gauge refresh) so importing this module never statically drags in pgDb/env.
-import { registerCounterWithLabels } from '@civitai/telemetry/client';
+import { registerCounter, registerCounterWithLabels } from '@civitai/telemetry/client';
 
 /**
  * CHALLENGE observability (additive telemetry only — no behavior change).
@@ -161,6 +161,33 @@ const winnerDuplicatePickCounter = registerCounterWithLabels({
   // choke point caught what a caller missed" from "a caller emitted without a readable source".
   // Those want different responses, so they get different label values rather than a shared bucket.
   labelNames: ['source', 'origin'] as const,
+});
+// Money-path anomaly, and DELIBERATELY ITS OWN COUNTER rather than another `field` value on
+// `challenge_winner_place_divergence_total`. That counter means "a stored row disagreed with a
+// re-pick and the payout WAS reconciled onto it" — the record was wrong, the money is safe. This one
+// means the conflict could NOT be resolved: no stored row was readable, so the payout is left on the
+// freshly-picked place and settles a `-place-N` transaction id with no ChallengeWinner row to key it
+// to. Opposite money verdicts, so sharing a series would make any read that did not break out the
+// label report "reconciled" for the one case where money may have moved twice.
+//
+// The causes differ as much as the verdicts. Divergence is triggered by a completion re-picking
+// winners over an existing record; remediation is finding out why a completion ran twice. This one's
+// reachable trigger is a P2002 raised by a DIFFERENT unique constraint: `ChallengeWinner` also has
+// `id Int @id @default(autoincrement())`, and a sequence left behind by a restore or a manual insert
+// collides on `id` — a conflict that says nothing about (challengeId, userId), so the re-read that
+// follows finds no row. Remediation there is resyncing the sequence. Same function, different
+// constraint, different fix; the module's existing split (duplicate-pick vs divergence) draws the
+// line in exactly the same place.
+//
+// UNLABELLED on purpose, and that is a feature here. `createChallengeWinner` is handed a winner row,
+// not a challenge, so the `source` every other counter in this file slices by is genuinely not in
+// scope, and adding a parameter for it would change a money-path signature to carry a telemetry
+// label. The side effect is that an unlabelled counter emits `0` from process start instead of
+// emitting no series until its first increment — so a `> 0` rule on it cannot fail open the way one
+// on a label-bearing counter can.
+const winnerConflictUnresolvedCounter = registerCounter({
+  name: 'challenge_winner_conflict_unresolved_total',
+  help: 'ChallengeWinner inserts that conflicted (P2002) but whose stored row could not be read; the payout was LEFT on the freshly-picked place with no winner row to key it to (expected to stay at zero)',
 });
 
 // ---------------------------------------------------------------------------
@@ -331,11 +358,34 @@ export function recordChallengeWinnerPlaceDivergence(args: { field: 'place' | 'p
 }
 
 /**
+ * The winner-insert conflict that could NOT be resolved to a stored row — the one branch of
+ * `createChallengeWinner` that still settles an unreconciled payout key. See the counter definition
+ * above for why this is not a `field` value on the divergence counter.
+ */
+export function recordChallengeWinnerConflictUnresolved() {
+  try {
+    winnerConflictUnresolvedCounter.inc();
+  } catch {
+    /* never throw from telemetry */
+  }
+}
+
+/**
  * `count` = how many placements were dropped, not how many picks contained a duplicate.
  *
- * An explicit `count: 0` records NOTHING. This counter is documented as sitting flat at zero and is
- * an alert trigger, so "I dropped nothing" must never read as "I dropped one" — an omitted `count`
- * still defaults to 1, which is the only case where 1 is the honest answer.
+ * An EXPLICITLY SUPPLIED `count` that is not a positive finite number records NOTHING — `0`, but
+ * equally `-1`, `NaN` and `Infinity`. This counter's contract is that it sits flat at zero and that
+ * every unit of it is a real placement dropped before payout, so neither "I dropped nothing" nor "my
+ * caller computed garbage" may be rounded up into "I dropped one". An OMITTED `count` still defaults
+ * to 1: that caller is not supplying a number at all, it is saying "one drop", which is the only
+ * case where 1 is the honest answer.
+ *
+ * NOT AN ALERT TRIGGER TODAY — no rule, no dashboard panel and no recording rule consumes this
+ * counter or `challenge_winner_place_divergence_total`; both are scrape-only signals, and that
+ * wiring is tracked separately from this repo. The INTENT is that any non-zero value is actionable
+ * and worth paging on, which is why the emit sites are this careful about what a unit means. Read
+ * "expected to stay at zero" as a contract on the emitters, not as a promise that somebody is
+ * notified when it doesn't.
  */
 export function recordChallengeWinnerDuplicatePick(args: {
   source?: string | null;
@@ -343,7 +393,7 @@ export function recordChallengeWinnerDuplicatePick(args: {
   origin: 'caller' | 'chokepoint';
 }) {
   try {
-    if (args.count === 0) return;
+    if (args.count !== undefined && !isPositiveFinite(args.count)) return;
     const count = isPositiveFinite(args.count) ? args.count : 1;
     winnerDuplicatePickCounter.inc(
       { source: normSource(args.source), origin: args.origin },
@@ -667,6 +717,7 @@ export function __resetChallengeMetricsForTest(): void {
   // which is precisely backwards for a metric whose whole contract is "expected to sit at zero".
   winnerPlaceDivergenceCounter.reset();
   winnerDuplicatePickCounter.reset();
+  winnerConflictUnresolvedCounter.reset();
 }
 
 /**

--- a/src/server/prom/challenge.metrics.ts
+++ b/src/server/prom/challenge.metrics.ts
@@ -380,12 +380,17 @@ export function recordChallengeWinnerConflictUnresolved() {
  * to 1: that caller is not supplying a number at all, it is saying "one drop", which is the only
  * case where 1 is the honest answer.
  *
- * NOT AN ALERT TRIGGER TODAY — no rule, no dashboard panel and no recording rule consumes this
- * counter or `challenge_winner_place_divergence_total`; both are scrape-only signals, and that
- * wiring is tracked separately from this repo. The INTENT is that any non-zero value is actionable
- * and worth paging on, which is why the emit sites are this careful about what a unit means. Read
- * "expected to stay at zero" as a contract on the emitters, not as a promise that somebody is
- * notified when it doesn't.
+ * Alerting for this counter and for `challenge_winner_place_divergence_total` lives in the infra
+ * repo, not here, so treat any claim in this file about whether something is wired as unverifiable
+ * from inside this codebase and liable to rot. What this file CAN promise is the emitter contract:
+ * "expected to stay at zero" is a statement about what the emit sites do, not a promise that
+ * anybody is notified when it doesn't hold. The intent is that any non-zero value is actionable —
+ * which is why the emit sites are this careful about what one unit means.
+ *
+ * Note for whoever wires or re-checks it: an un-deployed build and a genuinely quiet counter are
+ * the SAME empty vector in Prometheus. A rule that reads "expected to stay at zero" over a series
+ * that never existed is indistinguishable from a healthy one, so confirm the series exists before
+ * trusting a quiet alert.
  */
 export function recordChallengeWinnerDuplicatePick(args: {
   source?: string | null;
@@ -395,10 +400,7 @@ export function recordChallengeWinnerDuplicatePick(args: {
   try {
     if (args.count !== undefined && !isPositiveFinite(args.count)) return;
     const count = isPositiveFinite(args.count) ? args.count : 1;
-    winnerDuplicatePickCounter.inc(
-      { source: normSource(args.source), origin: args.origin },
-      count
-    );
+    winnerDuplicatePickCounter.inc({ source: normSource(args.source), origin: args.origin }, count);
   } catch {
     /* never throw from telemetry */
   }

--- a/src/server/services/__tests__/challenge-winner-payout-dedupe.service.test.ts
+++ b/src/server/services/__tests__/challenge-winner-payout-dedupe.service.test.ts
@@ -27,6 +27,8 @@ const {
   mockCreateChallengeWinner,
   mockCreateBuzzTransactionMany,
   mockGetExistingWinnersForRetry,
+  mockWithRetries,
+  mockBuildWinnerPayoutTransactions,
 } = vi.hoisted(() => ({
   mockDbWrite: {
     $queryRaw: vi.fn().mockResolvedValue([]),
@@ -42,6 +44,12 @@ const {
   mockCreateChallengeWinner: vi.fn(),
   mockCreateBuzzTransactionMany: vi.fn().mockResolvedValue(undefined),
   mockGetExistingWinnersForRetry: vi.fn().mockResolvedValue([]),
+  // Real `withRetries` re-invokes its closure up to 4 times on a flaky payout; doubled so a test can
+  // drive that deterministically.
+  mockWithRetries: vi.fn(),
+  // A SPY that delegates to the real (pure) builder — the transaction ids stay genuine, but the
+  // number of times the payout is BUILT becomes observable.
+  mockBuildWinnerPayoutTransactions: vi.fn(),
 }));
 
 vi.mock('~/server/db/client', () => ({
@@ -115,8 +123,10 @@ vi.mock('~/server/jobs/daily-challenge-processing', () => ({
 // against the genuine externalTransactionId strings — the actual money keys.
 vi.mock('~/server/games/daily-challenge/challenge-funding', async (importOriginal) => {
   const actual = await importOriginal<typeof ChallengeFunding>();
+  mockBuildWinnerPayoutTransactions.mockImplementation(actual.buildWinnerPayoutTransactions);
   return {
     ...actual,
+    buildWinnerPayoutTransactions: mockBuildWinnerPayoutTransactions,
     chargeInitialPrize: vi.fn(),
     refundUserChallengeFunds: vi.fn().mockResolvedValue({ refundedEntries: 0 }),
     reportPoolFundingShortfall: vi.fn().mockResolvedValue(undefined),
@@ -170,7 +180,7 @@ vi.mock('~/server/search-index', () => ({
 }));
 
 vi.mock('~/utils/errorHandling', () => ({
-  withRetries: vi.fn((fn: () => unknown) => fn()),
+  withRetries: mockWithRetries,
 }));
 
 vi.mock('~/utils/logging', () => ({ createLogger: vi.fn(() => vi.fn()) }));
@@ -302,6 +312,8 @@ beforeEach(() => {
   mockGetExistingWinnersForRetry.mockResolvedValue([]);
   mockGetJudgedEntries.mockResolvedValue(JUDGED_ENTRIES);
   mockCreateBuzzTransactionMany.mockResolvedValue(undefined);
+  // Default: the happy path, one invocation — same as real `withRetries` when nothing throws.
+  mockWithRetries.mockImplementation((fn: (remaining: number) => unknown) => fn(3));
   stubUniqueWinnerTable();
 });
 
@@ -407,6 +419,32 @@ describe('endChallengeAndPickWinners — one creator named twice is paid once', 
     expect(await counterValue(DUPLICATE_PICK_METRIC, { source: ChallengeSource.System })).toBe(1);
   });
 
+  // `origin` was asserted nowhere on either path, so its two values were interchangeable and the
+  // label could be flipped with the whole suite still green. Mislabelling a caller emit as
+  // `chokepoint` produces exactly the operator misreading the label was introduced to prevent: the
+  // choke point's own drop means "a caller reached the money path with duplicates and did NOT report
+  // it" — real prize money silently unpaid — so an operator would open an incident for a payout
+  // failure that never happened, on the human-triggered path where someone is already watching.
+  it('tags the drop as origin=caller — this path reported it, the choke point did not catch it', async () => {
+    llmWinners([
+      { creatorId: 100, creator: 'alice' },
+      { creatorId: 100, creator: 'alice' },
+      { creatorId: 200, creator: 'bob' },
+    ]);
+
+    await endChallengeAndPickWinners(CHALLENGE_ID);
+
+    expect(
+      await counterValue(DUPLICATE_PICK_METRIC, {
+        source: ChallengeSource.System,
+        origin: 'caller',
+      })
+    ).toBe(1);
+    // The duplicate was dropped before the builder saw it, so the choke point's guard is a genuine
+    // no-op here and must leave no series behind.
+    expect(await counterValue(DUPLICATE_PICK_METRIC, { origin: 'chokepoint' })).toBeUndefined();
+  });
+
   it('leaves a clean pick alone — the guard does not over-trigger', async () => {
     llmWinners([
       { creatorId: 100, creator: 'alice' },
@@ -422,5 +460,57 @@ describe('endChallengeAndPickWinners — one creator named twice is paid once', 
       `challenge-winner-prize-${CHALLENGE_ID}-300-place-3`,
     ]);
     expect(mockCreateChallengeWinner).toHaveBeenCalledTimes(3);
+  });
+});
+
+// Parity with the cron path: the builder is called OUTSIDE the `withRetries` closure. Its output is
+// deterministic so a rebuild would not move different money — but it increments the duplicate-pick
+// counter on its drop branch, and `withRetries` re-invokes up to 4 times, so inside the closure a
+// flaky payout would record up to 4x the placements actually dropped.
+describe('endChallengeAndPickWinners — the payout is built ONCE, outside the retry closure', () => {
+  const cleanPick = () =>
+    llmWinners([
+      { creatorId: 100, creator: 'alice' },
+      { creatorId: 200, creator: 'bob' },
+    ]);
+
+  it('a payout that retries three times still builds the transactions exactly once', async () => {
+    cleanPick();
+    mockWithRetries.mockImplementation(async (fn: (remaining: number) => Promise<unknown>) => {
+      await fn(3);
+      await fn(2);
+      await fn(1);
+    });
+
+    await endChallengeAndPickWinners(CHALLENGE_ID);
+
+    // The retry must genuinely have happened — otherwise this passes on a build that never retries.
+    expect(mockCreateBuzzTransactionMany).toHaveBeenCalledTimes(3);
+    expect(mockBuildWinnerPayoutTransactions).toHaveBeenCalledTimes(1);
+  });
+
+  it('every retry submits the SAME transaction array instance, not a rebuilt one', async () => {
+    cleanPick();
+    mockWithRetries.mockImplementation(async (fn: (remaining: number) => Promise<unknown>) => {
+      await fn(3);
+      await fn(2);
+    });
+
+    await endChallengeAndPickWinners(CHALLENGE_ID);
+
+    const [first] = mockCreateBuzzTransactionMany.mock.calls[0];
+    const [second] = mockCreateBuzzTransactionMany.mock.calls[1];
+    // Identity, not deep equality: a rebuild yields an equal-but-distinct array, so `toEqual` would
+    // pass on the very mutation this pins.
+    expect(second).toBe(first);
+  });
+
+  it('does not rebuild on the happy path either — one build, one submit', async () => {
+    cleanPick();
+
+    await endChallengeAndPickWinners(CHALLENGE_ID);
+
+    expect(mockCreateBuzzTransactionMany).toHaveBeenCalledTimes(1);
+    expect(mockBuildWinnerPayoutTransactions).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
Follow-ups from a blind adversarial audit of #3470, which is merged. Telemetry correctness and test coverage only — **no behaviour change on the money path**. Winner selection, payout logic, dedupe semantics and the reconcile are untouched.

The audit's finding was that the fixes added in #3470's final round are unpinned and several of its comments are false. Five mutations could be applied to `main` today with the entire challenge test set green.

## A — five mutations, now pinned

Each has a killing test, and each test was mutation-checked: mutation applied, failure captured, reverted, re-run green.

| # | Mutation | Killed by |
|---|---|---|
| 1 | delete the `count === 0` guard in `recordChallengeWinnerDuplicatePick` | `challenge.metrics.test.ts` — "an explicit count of 0 records NOTHING" |
| 2 | move `buildWinnerPayoutTransactions` back inside the `withRetries` closure (both completion paths) | both dedupe suites — "a payout that retries three times still builds the transactions exactly once" |
| 3 | flip the cron path's `origin: 'caller'` to `'chokepoint'` | `challenge-winner-payout-dedupe.test.ts` — "tags the drop as origin=caller" |
| 4 | same flip on the moderator path | `challenge-winner-payout-dedupe.service.test.ts` — same test name |
| 5 | drop `?? ChallengeSource.System` on the cron path's `source` | `challenge-winner-payout-dedupe.test.ts` — "defaults the source to System when the judge row could not be read" |

Notes on how a few of these are pinned:

- **#2** is pinned on the builder's *call count*, with `withRetries` doubled to invoke its closure three times, plus an **identity** assertion (`expect(second).toBe(first)`) that each retry submits the same array instance. `toEqual` would pass on the mutation, since a rebuild produces an equal-but-distinct array.
- **#3/#4** were previously invisible because the existing assertions matched on `{ source }` only, which matches either `origin`. They now assert `{ source, origin: 'caller' }` **and** that no `origin: 'chokepoint'` series exists.
- Also covered: the `'prize'` value of `challenge_winner_place_divergence_total`'s `field` label, which nothing asserted — so the prize-only arm of the ternary that picks it was free to be wrong.

## B — three false comments, corrected

Each was verified against the code before rewriting; all three characterisations held.

1. **`challenge.metrics.ts`** said the duplicate-pick counter "is an alert trigger". It is not — nothing consumes either new counter yet. Rewritten to state the intent (a non-zero value should be actionable and is worth paging on, which is why the emit sites are careful about what a unit means) without asserting a state that isn't true.
2. **`challenge-helpers.ts`** said `(challengeId, userId)` is "this table's only unique constraint", and used that to call the unresolved-conflict branch structurally unreachable. `ChallengeWinner` also has `id Int @id @default(autoincrement())`. A sequence left behind by a restore or a manual insert collides on `id`; that P2002 says nothing about `(challengeId, userId)`, so the re-read correctly finds nothing and the branch executes. Corrected here and in the mirror of the same claim in `challenge-winner-reconcile.ts`.
3. **`challenge-winner-reconcile.ts`** said first-wins keeps "the best place and therefore the largest prize". `prizeDistributionSchema` validates only three values in `1..100` summing to 100 — descending order is not enforced — and `distributePrizes` maps them positionally, so `[20, 50, 30]` makes place 1 pay *less* than place 2. Corrected to say first-wins keeps the best **place**, and to give the actual reason it is right anyway: place is the payout's identity (the transaction id embeds it, the winner row records it), so the survivor has to be the one the stored row will agree with. Which duplicate survives is payout semantics and is deliberately not changed here.

## C — the one branch that can still mint now emits

In `createChallengeWinner`, when the P2002 re-read returns no row the function returns `null`, `reconcileWinnerToPersisted` passes the entry through untouched, and the caller settles a brand-new `-place-N` id with no winner row to key it to. That branch incremented nothing, so `challenge_winner_place_divergence_total` read exactly `0` in the one case where money may have moved twice.

It now increments a new **`challenge_winner_conflict_unresolved_total`**, deliberately not a new `field` value on the divergence counter:

- **Opposite money verdicts.** Divergence means "a stored row disagreed with a re-pick and the payout *was* reconciled onto it" — the record was wrong, the money is safe. This means the payout was *not* reconciled. Sharing a series would make any read that didn't break out the label report "reconciled" for the one case where it wasn't.
- **Different root cause, different remediation.** Divergence is triggered by a completion re-picking winners over an existing record (find out why a completion ran twice); this is triggered by a P2002 on a *different* constraint (resync the sequence). The module's existing split — duplicate-pick vs divergence — draws the line in exactly the same place: different cause gets a counter, different sub-case of one cause gets a label.
- **Unlabelled, which helps here.** `createChallengeWinner` is handed a winner row, not a challenge, so the `source` every other counter slices by is genuinely not in scope, and adding a parameter for it would change a money-path signature to carry a telemetry label. The side effect is that an unlabelled counter emits `0` from process start rather than being absent until first increment — so a `> 0` rule on it can't fail open the way one on a label-bearing counter can.

Per B2 the branch is reachable, not theoretical, and both the code comment and the test say so.

## D — the two nits

- `recordChallengeWinnerDuplicatePick` now drops **any** explicitly supplied non-positive-finite `count` (`0`, `-1`, `NaN`, `Infinity`), not just `0`. A caller that computed one of those has a bug, and recording `1` invents a drop that didn't happen on a counter whose contract is that it stays at zero. An **omitted** `count` still defaults to `1` — that caller isn't supplying a number, it's saying "one drop".
- `winnerPayoutExternalId` had no consumer, so it is now module-private. It was a live tripwire rather than dead weight: 15 suites mock `challenge-funding` with an explicit export list, so the first file to import it would get `undefined` under those mocks instead of a missing-export error.

## Verification

```
pnpm exec eslint <8 changed files>                             → exit 0
pnpm exec prettier --check <8 changed files>                   → 4 files warn, all 4 already
                                                                 unformatted on main (verified by
                                                                 re-checking at the merge base);
                                                                 this PR introduces no new
                                                                 formatting deltas
NODE_OPTIONS=--max_old_space_size=8192 npx tsc --noEmit         → exit 2, 10 errors, all pre-existing
                                                                 @civitai/buzz import errors present
                                                                 identically at the merge base; none
                                                                 in a touched file
npx vitest run --project unit src/server/games/daily-challenge \
  src/server/jobs src/server/services src/server/prom src/server/notifications
                                                               → Test Files  320 passed (320)
                                                                 Tests  4349 passed (4349)
```

The vitest runner exits non-zero on 4 unhandled `PrismaClientInitializationError`s from a local `linux-nixos` query-engine mismatch in unrelated files; no test file failed.

## Out of scope, deliberately

No pre-payout ledger check, no change to payout logic, winner selection, dedupe semantics or the reconcile, and no changes to `backfill-theme-elements.ts` or `upsertChallenge`.
