### PR TITLE
fix(app-blocks): review preview tells the moderator why a consent request did nothing

### DIFF
--- a/src/components/AppBlocks/PageBlockHost.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHost.browser.test.tsx
@@ -317,7 +317,13 @@ describe('PageBlockHost REQUEST_CONSENT (W10 lazy-consent wiring)', () => {
     expect(useDialogStore.getState().dialogs).toHaveLength(0);
   });
 
-  test('Issue B: reviewMode never toasts an un-grantable consent request (untrusted preview stays silent)', async () => {
+  test('reviewMode surfaces a passive reduced-permissions notice and NEVER a consent modal', async () => {
+    // Was: reviewMode dropped REQUEST_CONSENT silently, so a moderator clicking a
+    // consent-gated action in the review preview got nothing at all and the app
+    // parked forever on its consent card. The modal ban is unchanged (untrusted
+    // review code must never pop a permission prompt at the mod) — only the
+    // silence is fixed. Full coverage lives in
+    // PageBlockHostReviewMode.browser.test.tsx.
     renderWithProviders(
       <PageBlockHost
         {...baseProps}
@@ -330,10 +336,10 @@ describe('PageBlockHost REQUEST_CONSENT (W10 lazy-consent wiring)', () => {
     );
 
     await driveToReady();
-    postFromBlock('REQUEST_CONSENT', { scopes: ['apps:storage:write'] });
-
-    await new Promise((r) => setTimeout(r, 150));
-    expect(showNotificationSpy).not.toHaveBeenCalled();
+    await vi.waitFor(() => {
+      postFromBlock('REQUEST_CONSENT', { scopes: ['apps:storage:write'] });
+      expect(showNotificationSpy).toHaveBeenCalledTimes(1);
+    });
     expect(useDialogStore.getState().dialogs).toHaveLength(0);
   });
 });

--- a/src/components/AppBlocks/PageBlockHost.tsx
+++ b/src/components/AppBlocks/PageBlockHost.tsx
@@ -11,7 +11,10 @@ import { IframeInitController, shouldStartInit } from './iframeInitController';
 import { resolveBuzzPurchaseRequest } from './openBuzzPurchaseGate';
 import {
   decideAutoRetry,
+  advanceReviewConsentLatch,
+  buildReviewConsentNotification,
   grantedPageScopes,
+  INITIAL_REVIEW_CONSENT_LATCH,
   pageFallbackReason,
   resolveCheckpointPickerRequest,
   resolveGetImagesByIdsRequest,
@@ -50,7 +53,7 @@ import { PAGE_SLOT_ID } from '~/shared/constants/slot-registry';
 import { usePostMessage } from './usePostMessage';
 import type { BlockInitPayload, PageContext } from './types';
 import { dialogStore } from '~/components/Dialog/dialogStore';
-import { showNotification } from '@mantine/notifications';
+import { hideNotification, showNotification } from '@mantine/notifications';
 import { openLoginPopup } from '~/utils/auth-helpers';
 import type { BuyBuzzModalProps } from '~/components/Modals/BuyBuzzModal';
 import { openResourceSelectModal } from '~/components/Dialog/triggers/resource-select';
@@ -695,10 +698,12 @@ export function PageBlockHost({
     });
   }, [status, autoRetrySettled, appBlockId, blockInstanceId]);
 
-  // MOD REVIEW SANDBOX — emit-once latch for the reduced-permissions notice in
-  // the consent handler below. ONE per host MOUNT (the review chrome remounts the
-  // host on a render-only ↔ run-for-real flip, so each mode gets its own notice).
-  const reviewConsentNoticeShownRef = useRef<boolean>(false);
+  // MOD REVIEW SANDBOX — anti-spam latch for the reduced-permissions notice in
+  // the consent handler below. Bounded to at most TWO per host MOUNT (one generic
+  // + one scope-named upgrade — see `advanceReviewConsentLatch`). The review
+  // chrome remounts the host on a render-only ↔ run-for-real flip, so each mode
+  // gets its own budget, and the notification ids are mode-specific to match.
+  const reviewConsentLatchRef = useRef(INITIAL_REVIEW_CONSENT_LATCH);
   // Lazy consent (A6): the block (rendered in full for a logged-in viewer whose
   // page token is missing a consent-gated scope, e.g. `ai:write:budgeted` once
   // the page money scope is enabled) asks the host to open the consent UI when
@@ -744,26 +749,33 @@ export function PageBlockHost({
         // 🔴 ANTI-SPAM (required, not a nicety): the reviewed app is UNTRUSTED
         // code and can post REQUEST_CONSENT in a loop, so one toast per message
         // would let a hostile submission carpet-bomb the reviewing mod's screen
-        // (and bury the review chrome). Latch it to ONE notice per host mount.
-        // The stable `id` is a second, independent guard — Mantine dedupes a
-        // notification that is already displayed even if the latch is bypassed.
-        if (reviewConsentNoticeShownRef.current) return;
-        reviewConsentNoticeShownRef.current = true;
+        // (and bury the review chrome). The latch caps this at TWO notices per
+        // host mount — one generic, plus at most one upgrade to the scope-NAMED
+        // copy. It is NOT a plain "already notified" boolean: the SDK's `scopes`
+        // hint is optional, so a hint-less request on load would otherwise win
+        // the latch and permanently suppress the later, informative one.
+        const { show, next } = advanceReviewConsentLatch(
+          reviewConsentLatchRef.current,
+          notice.scopes.length > 0
+        );
+        reviewConsentLatchRef.current = next;
+        if (!show) return;
         // `notice.scopes` is filtered to the known block-scope vocabulary, so no
         // attacker-controlled text can reach this string; Mantine renders
         // `message` as React text (escaped) — never as HTML.
-        const what =
-          notice.scopes.length > 0
-            ? `This app requested ${notice.scopes.join(', ')}.`
-            : 'This app requested a permission it doesn’t have here.';
-        const how = reviewRunForReal
-          ? 'Review previews always run with reduced permissions.'
-          : 'Review previews run with reduced permissions — use “Run for real…” to grant the app its real permissions.';
+        const notification = buildReviewConsentNotification({
+          appBlockId,
+          runForReal: reviewRunForReal,
+          scopes: notice.scopes,
+        });
+        // Upgrade path only: retire the generic notice this one replaces, so the
+        // reviewer sees ONE notice, not a stack. A no-op when it already closed.
+        if (notification.supersedesId) hideNotification(notification.supersedesId);
         showNotification({
-          id: `review-consent-${appBlockId}`,
+          id: notification.id,
           color: 'yellow',
-          title: 'Permission unavailable in review',
-          message: `${what} ${how}`,
+          title: notification.title,
+          message: notification.message,
         });
         return;
       }

--- a/src/components/AppBlocks/PageBlockHost.tsx
+++ b/src/components/AppBlocks/PageBlockHost.tsx
@@ -18,6 +18,7 @@ import {
   resolveImageUploadRequest,
   resolvePublishGenerationOutputsRequest,
   resolveResourcePickerRequest,
+  resolveReviewConsentNotice,
   resolveUngrantableConsentScopes,
 } from './pageBlockHostLogic';
 import ConfirmDialog from '~/components/Dialog/Common/ConfirmDialog';
@@ -694,6 +695,10 @@ export function PageBlockHost({
     });
   }, [status, autoRetrySettled, appBlockId, blockInstanceId]);
 
+  // MOD REVIEW SANDBOX — emit-once latch for the reduced-permissions notice in
+  // the consent handler below. ONE per host MOUNT (the review chrome remounts the
+  // host on a render-only ↔ run-for-real flip, so each mode gets its own notice).
+  const reviewConsentNoticeShownRef = useRef<boolean>(false);
   // Lazy consent (A6): the block (rendered in full for a logged-in viewer whose
   // page token is missing a consent-gated scope, e.g. `ai:write:budgeted` once
   // the page money scope is enabled) asks the host to open the consent UI when
@@ -713,10 +718,6 @@ export function PageBlockHost({
   // the void and the block hung on "confirm in the Civitai dialog".
   useEffect(() => {
     const off = onMessage<{ scopes?: unknown } | undefined>('REQUEST_CONSENT', (payload) => {
-      // reviewMode: a consent grant re-mints the token with WIDER scopes — never
-      // let untrusted review code pop a permission modal at the mod. Fire-and-
-      // forget ⇒ dropping it never hangs the block.
-      if (reviewMode) return;
       // PageBlockHost's local Status carries an extra terminal `'error'` variant
       // (a hard mint failure) the shared gate's HostStatus union doesn't model.
       // The gate only ever grants when status === 'ready', and `'error'` is a
@@ -727,6 +728,46 @@ export function PageBlockHost({
       // Only act on a post-handshake request; a pre-handshake block never gets a
       // modal OR a toast (same posture as the consent gate itself).
       if (gateStatus !== 'ready') return;
+
+      // reviewMode: a consent grant re-mints the token with WIDER scopes — never
+      // let untrusted review code pop a permission modal at the mod. That stays
+      // absolute; the request is still fire-and-forget (dropping the GRANT never
+      // hangs the block). What changed: dropping it SILENTLY meant the reviewer
+      // got nothing at all — no modal, no toast, no error — while the app parked
+      // forever on its consent card, which reads as "this app is broken" rather
+      // than "the preview deliberately withholds this permission". So review mode
+      // now emits a PASSIVE, non-interactive notice (never a modal, nothing to
+      // click, no scope is granted) pointing at the existing opt-in escape hatch.
+      if (reviewMode) {
+        const notice = resolveReviewConsentNotice(payload?.scopes, grantedScopes);
+        if (!notice.notify) return;
+        // 🔴 ANTI-SPAM (required, not a nicety): the reviewed app is UNTRUSTED
+        // code and can post REQUEST_CONSENT in a loop, so one toast per message
+        // would let a hostile submission carpet-bomb the reviewing mod's screen
+        // (and bury the review chrome). Latch it to ONE notice per host mount.
+        // The stable `id` is a second, independent guard — Mantine dedupes a
+        // notification that is already displayed even if the latch is bypassed.
+        if (reviewConsentNoticeShownRef.current) return;
+        reviewConsentNoticeShownRef.current = true;
+        // `notice.scopes` is filtered to the known block-scope vocabulary, so no
+        // attacker-controlled text can reach this string; Mantine renders
+        // `message` as React text (escaped) — never as HTML.
+        const what =
+          notice.scopes.length > 0
+            ? `This app requested ${notice.scopes.join(', ')}.`
+            : 'This app requested a permission it doesn’t have here.';
+        const how = reviewRunForReal
+          ? 'Review previews always run with reduced permissions.'
+          : 'Review previews run with reduced permissions — use “Run for real…” to grant the app its real permissions.';
+        showNotification({
+          id: `review-consent-${appBlockId}`,
+          color: 'yellow',
+          title: 'Permission unavailable in review',
+          message: `${what} ${how}`,
+        });
+        return;
+      }
+
       const scopesToGrant = resolveRequestConsent(gateStatus, missingScopes ?? []);
       if (scopesToGrant != null) {
         dialogStore.trigger({
@@ -772,6 +813,7 @@ export function PageBlockHost({
     appName,
     onConsentGranted,
     reviewMode,
+    reviewRunForReal,
   ]);
 
   // Deep-link bridge — block requests in-page navigation. The block may push a

--- a/src/components/AppBlocks/PageBlockHostReviewMode.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostReviewMode.browser.test.tsx
@@ -3,6 +3,10 @@ import { page } from 'vitest/browser';
 import { useDialogStore } from '~/components/Dialog/dialogStore';
 // `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
 import { renderWithProviders } from '../../../test/component-setup';
+// Type-only (erased at runtime, so it can't defeat vi.mock hoisting) — lets the
+// `importOriginal` generic below be written without an inline `import()` type,
+// which the repo's `consistent-type-imports` rule forbids.
+import type * as MantineNotifications from '@mantine/notifications';
 
 /**
  * MOD REVIEW SANDBOX (#2831) — PageBlockHost `reviewMode` read-only gate.
@@ -35,6 +39,14 @@ const mocks = vi.hoisted(() => ({
 // AppBlockChrome (in the host frame) calls useCurrentUser() for the platform-nav
 // moderator gate; render the real host without a CivitaiSessionProvider.
 vi.mock('~/hooks/useCurrentUser', () => ({ useCurrentUser: () => null }));
+
+// Spy on the toast so the reviewMode consent-feedback path is assertable without
+// mounting the full Notifications provider. Preserve the module's other exports.
+const showNotificationSpy = vi.fn();
+vi.mock('@mantine/notifications', async (importOriginal) => {
+  const actual = await importOriginal<typeof MantineNotifications>();
+  return { ...actual, showNotification: (args: unknown) => showNotificationSpy(args) };
+});
 
 vi.mock('~/utils/trpc', () => ({
   setTrpcBatchingEnabled: vi.fn(),
@@ -170,6 +182,7 @@ beforeEach(() => {
   mocks.storageSet.mockClear();
   mocks.sharedAppend.mockClear();
   mocks.wildcard.mockClear();
+  showNotificationSpy.mockClear();
 });
 
 describe('PageBlockHost reviewMode — side-effecting handlers fail-fast NACK, never reach the mutation', () => {
@@ -287,6 +300,142 @@ describe('PageBlockHost reviewMode — side-effecting handlers fail-fast NACK, n
     await vi.waitFor(() => expect(mocks.viewer).toHaveBeenCalledTimes(1));
     await vi.waitFor(() => expect(l.last('VIEWER_RESULT')).toBeTruthy());
     l.stop();
+  });
+});
+
+describe('PageBlockHost reviewMode — REQUEST_CONSENT gives the mod feedback, never a modal', () => {
+  // THE BUG: reviewMode dropped REQUEST_CONSENT with a bare `return` ABOVE the
+  // "permission unavailable" toast, so a moderator clicking a consent-gated action
+  // in the review preview got NOTHING — no modal, no toast, no error — while the
+  // app parked forever on its consent card. The modal ban is correct and stays
+  // (a grant would re-mint the mod's token with WIDER scopes at the request of
+  // unapproved code, and the review mint's scope-stripping is deliberate); only
+  // the silence is fixed, with a passive notice pointing at "Run for real…".
+  const lastNotification = () =>
+    showNotificationSpy.mock.calls.at(-1)?.[0] as
+      | { id?: string; title?: string; message?: string }
+      | undefined;
+
+  test('a consent request the preview can never grant surfaces a notice (and NO consent modal)', async () => {
+    renderWithProviders(<PageBlockHost {...baseProps} reviewMode onConsentGranted={vi.fn()} />);
+    await driveToReady();
+
+    // Re-post inside waitFor: `data-block-ready` can lead the host's message-gate
+    // state by a tick, and a dropped fire-and-forget message is never retried.
+    await vi.waitFor(() => {
+      postFromBlock('REQUEST_CONSENT', { scopes: ['buzz:read:self'] });
+      expect(showNotificationSpy).toHaveBeenCalledTimes(1);
+    });
+
+    const notice = lastNotification();
+    // Names the specific requested scope (useful to a reviewer) …
+    expect(notice?.message).toContain('buzz:read:self');
+    // … and points at the existing opt-in escape hatch.
+    expect(notice?.message).toContain('Run for real');
+    // 🔴 The security invariant: untrusted review code still cannot pop a
+    // permission modal at the moderator.
+    expect(useDialogStore.getState().dialogs).toHaveLength(0);
+  });
+
+  test('a hint-less REQUEST_CONSENT (the fire-and-forget SDK call) still notifies', async () => {
+    // `useRequestConsent()` sends no requestId and need not send a `scopes` hint.
+    // The prod path stays silent without one (it cannot tell "already granted"
+    // from "clamped"); in review there is nothing to tell apart — consent is
+    // structurally unavailable — so the mod is told regardless.
+    renderWithProviders(<PageBlockHost {...baseProps} reviewMode onConsentGranted={vi.fn()} />);
+    await driveToReady();
+
+    await vi.waitFor(() => {
+      postFromBlock('REQUEST_CONSENT', {});
+      expect(showNotificationSpy).toHaveBeenCalledTimes(1);
+    });
+    expect(useDialogStore.getState().dialogs).toHaveLength(0);
+  });
+
+  test('🔴 ANTI-SPAM: a REQUEST_CONSENT flood produces exactly ONE notice', async () => {
+    // The reviewed app is UNTRUSTED code and can post in a loop; one toast per
+    // message would let a hostile submission carpet-bomb the reviewing mod's
+    // screen and bury the review chrome. The transport's generic 30-msg/s limiter
+    // is NOT sufficient on its own — 30 toasts a second is still a carpet bomb —
+    // so the host latches the notice to one per mount. The flood below is
+    // deliberately kept UNDER that transport budget so this asserts the LATCH.
+    renderWithProviders(<PageBlockHost {...baseProps} reviewMode onConsentGranted={vi.fn()} />);
+    await driveToReady();
+
+    await vi.waitFor(() => {
+      postFromBlock('REQUEST_CONSENT', { scopes: ['buzz:read:self'] });
+      expect(showNotificationSpy).toHaveBeenCalledTimes(1);
+    });
+
+    for (let i = 0; i < 4; i++) {
+      postFromBlock('REQUEST_CONSENT', { scopes: ['buzz:read:self'] });
+      postFromBlock('REQUEST_CONSENT', {});
+    }
+    await new Promise((r) => setTimeout(r, 150));
+    expect(showNotificationSpy).toHaveBeenCalledTimes(1);
+    expect(useDialogStore.getState().dialogs).toHaveLength(0);
+  });
+
+  test('🔴 the mod-facing copy can only contain KNOWN scope strings (untrusted manifest text is dropped)', async () => {
+    renderWithProviders(<PageBlockHost {...baseProps} reviewMode onConsentGranted={vi.fn()} />);
+    await driveToReady();
+
+    await vi.waitFor(() => {
+      postFromBlock('REQUEST_CONSENT', {
+        scopes: ['<img src=x onerror=alert(1)>', 'totally:made:up', 'buzz:read:self'],
+      });
+      expect(showNotificationSpy).toHaveBeenCalledTimes(1);
+    });
+
+    const message = lastNotification()?.message ?? '';
+    expect(message).toContain('buzz:read:self');
+    expect(message).not.toContain('onerror');
+    expect(message).not.toContain('totally:made:up');
+  });
+
+  test('a benign re-request of an ALREADY-GRANTED scope stays silent', async () => {
+    // baseProps.declaredScopes carries models:read:self with nothing withheld, so
+    // the block already holds it — nothing is blocked, so nothing to report.
+    renderWithProviders(<PageBlockHost {...baseProps} reviewMode onConsentGranted={vi.fn()} />);
+    await driveToReady();
+
+    postFromBlock('REQUEST_CONSENT', { scopes: ['models:read:self'] });
+
+    await new Promise((r) => setTimeout(r, 150));
+    expect(showNotificationSpy).not.toHaveBeenCalled();
+    expect(useDialogStore.getState().dialogs).toHaveLength(0);
+  });
+
+  test('in run-for-real the copy does NOT tell the mod to use "Run for real…" (they already did)', async () => {
+    renderWithProviders(
+      <PageBlockHost {...baseProps} reviewMode reviewRunForReal onConsentGranted={vi.fn()} />
+    );
+    await driveToReady();
+
+    await vi.waitFor(() => {
+      postFromBlock('REQUEST_CONSENT', { scopes: ['buzz:read:self'] });
+      expect(showNotificationSpy).toHaveBeenCalledTimes(1);
+    });
+
+    const message = lastNotification()?.message ?? '';
+    expect(message).toContain('buzz:read:self');
+    expect(message).not.toContain('Run for real');
+  });
+
+  test('the NON-review path is unchanged (generic #3190 toast, and the modal path still works)', async () => {
+    renderWithProviders(<PageBlockHost {...baseProps} onConsentGranted={vi.fn()} />);
+    await driveToReady();
+
+    await vi.waitFor(() => {
+      postFromBlock('REQUEST_CONSENT', { scopes: ['buzz:read:self'] });
+      expect(showNotificationSpy).toHaveBeenCalledTimes(1);
+    });
+
+    // The prod un-grantable toast, NOT the review copy.
+    const notice = lastNotification();
+    expect(notice?.title).toBe('Permission unavailable');
+    expect(notice?.message).not.toContain('Run for real');
+    expect(notice?.message).not.toContain('buzz:read:self');
   });
 });
 

--- a/src/components/AppBlocks/PageBlockHostReviewMode.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostReviewMode.browser.test.tsx
@@ -43,9 +43,17 @@ vi.mock('~/hooks/useCurrentUser', () => ({ useCurrentUser: () => null }));
 // Spy on the toast so the reviewMode consent-feedback path is assertable without
 // mounting the full Notifications provider. Preserve the module's other exports.
 const showNotificationSpy = vi.fn();
+// `hideNotification` is the generic→named UPGRADE path: the named notice carries
+// its OWN id (Mantine no-ops a duplicate id, and `updateNotification` would drop
+// the upgrade once the generic auto-closed), so it retires the generic explicitly.
+const hideNotificationSpy = vi.fn();
 vi.mock('@mantine/notifications', async (importOriginal) => {
   const actual = await importOriginal<typeof MantineNotifications>();
-  return { ...actual, showNotification: (args: unknown) => showNotificationSpy(args) };
+  return {
+    ...actual,
+    showNotification: (args: unknown) => showNotificationSpy(args),
+    hideNotification: (id: unknown) => hideNotificationSpy(id),
+  };
 });
 
 vi.mock('~/utils/trpc', () => ({
@@ -183,6 +191,7 @@ beforeEach(() => {
   mocks.sharedAppend.mockClear();
   mocks.wildcard.mockClear();
   showNotificationSpy.mockClear();
+  hideNotificationSpy.mockClear();
 });
 
 describe('PageBlockHost reviewMode — side-effecting handlers fail-fast NACK, never reach the mutation', () => {
@@ -330,8 +339,13 @@ describe('PageBlockHost reviewMode — REQUEST_CONSENT gives the mod feedback, n
     const notice = lastNotification();
     // Names the specific requested scope (useful to a reviewer) …
     expect(notice?.message).toContain('buzz:read:self');
-    // … and points at the existing opt-in escape hatch.
+    // … and points at the existing opt-in escape hatch …
     expect(notice?.message).toContain('Run for real');
+    // … while saying what that opt-in COSTS the mod. Untrusted code can emit this
+    // toast unprompted, and "Run for real…" re-mints against the moderator's OWN
+    // account and spends the moderator's OWN Buzz (`ai:write:budgeted`, session-
+    // capped) — so it must not read as a free "make it work" button.
+    expect(notice?.message).toContain('your own account and Buzz');
     // 🔴 The security invariant: untrusted review code still cannot pop a
     // permission modal at the moderator.
     expect(useDialogStore.getState().dialogs).toHaveLength(0);
@@ -352,13 +366,15 @@ describe('PageBlockHost reviewMode — REQUEST_CONSENT gives the mod feedback, n
     expect(useDialogStore.getState().dialogs).toHaveLength(0);
   });
 
-  test('🔴 ANTI-SPAM: a REQUEST_CONSENT flood produces exactly ONE notice', async () => {
+  test('🔴 ANTI-SPAM: a flood AFTER the scope-named notice produces no further notices', async () => {
     // The reviewed app is UNTRUSTED code and can post in a loop; one toast per
     // message would let a hostile submission carpet-bomb the reviewing mod's
     // screen and bury the review chrome. The transport's generic 30-msg/s limiter
     // is NOT sufficient on its own — 30 toasts a second is still a carpet bomb —
-    // so the host latches the notice to one per mount. The flood below is
-    // deliberately kept UNDER that transport budget so this asserts the LATCH.
+    // so the host latches. Once the NAMED (most informative) notice is out there
+    // is nothing left to say, so the latch is closed for the rest of the mount.
+    // The flood below is deliberately kept UNDER the transport budget so this
+    // asserts the LATCH, not the rate limiter.
     renderWithProviders(<PageBlockHost {...baseProps} reviewMode onConsentGranted={vi.fn()} />);
     await driveToReady();
 
@@ -370,10 +386,97 @@ describe('PageBlockHost reviewMode — REQUEST_CONSENT gives the mod feedback, n
     for (let i = 0; i < 4; i++) {
       postFromBlock('REQUEST_CONSENT', { scopes: ['buzz:read:self'] });
       postFromBlock('REQUEST_CONSENT', {});
+      postFromBlock('REQUEST_CONSENT', { scopes: ['social:tip:self'] });
     }
     await new Promise((r) => setTimeout(r, 150));
     expect(showNotificationSpy).toHaveBeenCalledTimes(1);
     expect(useDialogStore.getState().dialogs).toHaveLength(0);
+  });
+
+  test('🔴 a hint-less request first does NOT bury the later scope-NAMED one (one upgrade allowed)', async () => {
+    // THE FIRST-NOTICE-WINS BUG. `useRequestConsent()`'s `scopes` hint is
+    // OPTIONAL, so a hint-less REQUEST_CONSENT on load is an ordinary path. With
+    // a plain "already notified" latch it won, the mod got only the generic copy,
+    // and the app's later specific request was suppressed for the whole mount —
+    // the reviewer never learned WHICH permission was blocked.
+    renderWithProviders(<PageBlockHost {...baseProps} reviewMode onConsentGranted={vi.fn()} />);
+    await driveToReady();
+
+    await vi.waitFor(() => {
+      postFromBlock('REQUEST_CONSENT', {});
+      expect(showNotificationSpy).toHaveBeenCalledTimes(1);
+    });
+    const generic = lastNotification();
+    expect(generic?.message).not.toContain('buzz:read:self');
+
+    postFromBlock('REQUEST_CONSENT', { scopes: ['buzz:read:self'] });
+    await vi.waitFor(() => expect(showNotificationSpy).toHaveBeenCalledTimes(2));
+
+    const named = lastNotification();
+    expect(named?.message).toContain('buzz:read:self');
+    // Distinct id, or Mantine would silently dedupe the upgrade away …
+    expect(named?.id).not.toBe(generic?.id);
+    // … and the superseded generic is retired so the mod sees ONE notice.
+    expect(hideNotificationSpy).toHaveBeenCalledWith(generic?.id);
+    expect(useDialogStore.getState().dialogs).toHaveLength(0);
+  });
+
+  test('🔴 ANTI-SPAM BOUND: generic-then-flood is capped at TWO notices for the whole mount', async () => {
+    // The upgrade must not reopen an unbounded path: after the named notice the
+    // latch is closed again, so a hostile loop mixing hint-less and hinted (and
+    // differently-hinted) requests still tops out at two toasts per mount.
+    renderWithProviders(<PageBlockHost {...baseProps} reviewMode onConsentGranted={vi.fn()} />);
+    await driveToReady();
+
+    await vi.waitFor(() => {
+      postFromBlock('REQUEST_CONSENT', {});
+      expect(showNotificationSpy).toHaveBeenCalledTimes(1);
+    });
+
+    for (let i = 0; i < 4; i++) {
+      postFromBlock('REQUEST_CONSENT', {});
+      postFromBlock('REQUEST_CONSENT', { scopes: ['buzz:read:self'] });
+      postFromBlock('REQUEST_CONSENT', { scopes: ['social:tip:self'] });
+      postFromBlock('REQUEST_CONSENT', { scopes: ['ai:write:budgeted', 'buzz:read:self'] });
+    }
+    await new Promise((r) => setTimeout(r, 200));
+    expect(showNotificationSpy).toHaveBeenCalledTimes(2);
+    expect(useDialogStore.getState().dialogs).toHaveLength(0);
+  });
+
+  test('🔴 the notice id is MODE-SPECIFIC (render-only and run-for-real cannot dedupe each other)', async () => {
+    // Mantine no-ops showNotification for an id already displayed or queued
+    // (default autoClose 4000ms). With one shared id the realistic sequence
+    // "notice fires in render-only → mod clicks Run for real… → the chrome
+    // REMOUNTS the host → the latch resets by design → the app re-requests within
+    // 4s" silently swallowed the run-for-real notice — the original bug, in the
+    // other mode. The ids must differ per mode.
+    // `render` is async in vitest-browser-react v2 — await it to get `unmount`.
+    const first = await renderWithProviders(
+      <PageBlockHost {...baseProps} reviewMode onConsentGranted={vi.fn()} />
+    );
+    await driveToReady();
+    await vi.waitFor(() => {
+      postFromBlock('REQUEST_CONSENT', { scopes: ['buzz:read:self'] });
+      expect(showNotificationSpy).toHaveBeenCalledTimes(1);
+    });
+    const renderOnlyId = lastNotification()?.id;
+    expect(renderOnlyId).toBeTruthy();
+    await first.unmount();
+
+    // The run-for-real flip: same appBlockId, fresh mount.
+    renderWithProviders(
+      <PageBlockHost {...baseProps} reviewMode reviewRunForReal onConsentGranted={vi.fn()} />
+    );
+    await driveToReady();
+    await vi.waitFor(() => {
+      postFromBlock('REQUEST_CONSENT', { scopes: ['buzz:read:self'] });
+      expect(showNotificationSpy).toHaveBeenCalledTimes(2);
+    });
+    const runForRealId = lastNotification()?.id;
+
+    expect(runForRealId).toBeTruthy();
+    expect(runForRealId).not.toBe(renderOnlyId);
   });
 
   test('🔴 the mod-facing copy can only contain KNOWN scope strings (untrusted manifest text is dropped)', async () => {

--- a/src/components/AppBlocks/__tests__/pageBlockHostLogic.test.ts
+++ b/src/components/AppBlocks/__tests__/pageBlockHostLogic.test.ts
@@ -11,6 +11,7 @@ import {
   resolveCheckpointPickerRequest,
   resolveImageUploadRequest,
   resolveResourcePickerRequest,
+  resolveReviewConsentNotice,
   resolveUngrantableConsentScopes,
   PAGE_RESOURCE_PICKER_TYPES,
   type PageHostStatus,
@@ -109,6 +110,65 @@ describe('resolveUngrantableConsentScopes (Issue B — un-grantable dev-preview 
     expect(
       resolveUngrantableConsentScopes(['apps:storage:read'], ['models:read:self'], undefined)
     ).toEqual(['apps:storage:read']);
+  });
+});
+
+describe('resolveReviewConsentNotice (mod review — silent REQUEST_CONSENT → visible notice)', () => {
+  const granted = ['models:read:self', 'user:read:self', 'collections:read:self'];
+
+  it('notifies and NAMES the un-granted scopes the review mint stripped', () => {
+    expect(resolveReviewConsentNotice(['buzz:read:self'], granted)).toEqual({
+      notify: true,
+      scopes: ['buzz:read:self'],
+    });
+  });
+
+  it('notifies with NO hint at all — the regression: the fire-and-forget SDK call sends none', () => {
+    // Unlike the prod path (which stays silent because it cannot tell "already
+    // granted" from "clamped"), review has nothing to tell apart: consent can
+    // never be granted here, so a hint-less request is still a dead end.
+    expect(resolveReviewConsentNotice(undefined, granted)).toEqual({ notify: true, scopes: [] });
+    expect(resolveReviewConsentNotice([], granted)).toEqual({ notify: true, scopes: [] });
+    expect(resolveReviewConsentNotice('nope', granted)).toEqual({ notify: true, scopes: [] });
+    expect(resolveReviewConsentNotice([1, null, ''], granted)).toEqual({
+      notify: true,
+      scopes: [],
+    });
+  });
+
+  it('stays SILENT for the benign already-granted re-request (nothing is actually blocked)', () => {
+    expect(resolveReviewConsentNotice(['models:read:self'], granted)).toEqual({
+      notify: false,
+      scopes: [],
+    });
+    expect(resolveReviewConsentNotice(['models:read:self', 'user:read:self'], granted)).toEqual({
+      notify: false,
+      scopes: [],
+    });
+  });
+
+  it('🔴 drops UNKNOWN scope strings from the mod-facing set (untrusted manifest text)', () => {
+    // The hint comes from the reviewed app's own frame. Only the fixed platform
+    // vocabulary may ever reach a string rendered at the moderator.
+    const out = resolveReviewConsentNotice(
+      ['<img src=x onerror=alert(1)>', 'totally:made:up', 'buzz:read:self'],
+      granted
+    );
+    expect(out.notify).toBe(true);
+    expect(out.scopes).toEqual(['buzz:read:self']);
+  });
+
+  it('still notifies (generically) when EVERY un-granted scope is unknown', () => {
+    const out = resolveReviewConsentNotice(['totally:made:up'], granted);
+    expect(out).toEqual({ notify: true, scopes: [] });
+  });
+
+  it('dedupes + sorts the named scopes and ignores the ones already granted', () => {
+    const out = resolveReviewConsentNotice(
+      ['social:tip:self', 'buzz:read:self', 'social:tip:self', 'models:read:self'],
+      granted
+    );
+    expect(out.scopes).toEqual(['buzz:read:self', 'social:tip:self']);
   });
 });
 

--- a/src/components/AppBlocks/__tests__/pageBlockHostLogic.test.ts
+++ b/src/components/AppBlocks/__tests__/pageBlockHostLogic.test.ts
@@ -1,8 +1,11 @@
 import { describe, it, expect } from 'vitest';
 import {
+  advanceReviewConsentLatch,
   AUTO_RETRY_BACKOFF_MS,
+  buildReviewConsentNotification,
   decideAutoRetry,
   grantedPageScopes,
+  INITIAL_REVIEW_CONSENT_LATCH,
   isAuthTerminalStatus,
   isAutoRetryableStatus,
   MAX_AUTO_REMINTS,
@@ -169,6 +172,155 @@ describe('resolveReviewConsentNotice (mod review — silent REQUEST_CONSENT → 
       granted
     );
     expect(out.scopes).toEqual(['buzz:read:self', 'social:tip:self']);
+  });
+
+  it('🔴 drops inherited Object.prototype keys (isKnownBlockScope prototype-chain bypass)', () => {
+    // `payload.scopes` is untrusted runtime input from the reviewed app's frame
+    // and reaches NO regex shape-check on this path (unlike the manifest
+    // validator's SCOPE_RE). While `isKnownBlockScope` used `in`, every inherited
+    // Object.prototype key answered "known scope" and would have been printed
+    // verbatim into the moderator-facing toast.
+    expect(resolveReviewConsentNotice(['constructor', '__proto__'], granted).scopes).toEqual([]);
+    expect(
+      resolveReviewConsentNotice(
+        ['toString', 'valueOf', 'hasOwnProperty', 'isPrototypeOf', 'buzz:read:self'],
+        granted
+      ).scopes
+    ).toEqual(['buzz:read:self']);
+    // Still a real, un-grantable request — the mod gets the GENERIC copy, not silence.
+    expect(resolveReviewConsentNotice(['constructor'], granted)).toEqual({
+      notify: true,
+      scopes: [],
+    });
+  });
+});
+
+describe('advanceReviewConsentLatch (🔴 anti-spam bound + the generic→named upgrade)', () => {
+  it('shows the first notice of either kind', () => {
+    expect(advanceReviewConsentLatch(INITIAL_REVIEW_CONSENT_LATCH, false)).toEqual({
+      show: true,
+      next: { shown: true, named: false },
+    });
+    expect(advanceReviewConsentLatch(INITIAL_REVIEW_CONSENT_LATCH, true)).toEqual({
+      show: true,
+      next: { shown: true, named: true },
+    });
+  });
+
+  it('allows exactly ONE upgrade generic → named (the first-notice-wins bug)', () => {
+    // The SDK's `scopes` hint is OPTIONAL, so a hint-less request on load is an
+    // ordinary path. Under a plain boolean latch it won the latch and the app's
+    // later, specific request was suppressed for the rest of the mount — the mod
+    // never learned WHICH permission was blocked.
+    const afterGeneric = advanceReviewConsentLatch(INITIAL_REVIEW_CONSENT_LATCH, false).next;
+    const upgrade = advanceReviewConsentLatch(afterGeneric, true);
+    expect(upgrade.show).toBe(true);
+    expect(upgrade.next).toEqual({ shown: true, named: true });
+  });
+
+  it('suppresses a repeat GENERIC after a generic (it adds nothing)', () => {
+    const afterGeneric = advanceReviewConsentLatch(INITIAL_REVIEW_CONSENT_LATCH, false).next;
+    expect(advanceReviewConsentLatch(afterGeneric, false)).toEqual({
+      show: false,
+      next: afterGeneric,
+    });
+  });
+
+  it('suppresses EVERYTHING once a named notice has been shown (no downgrade, no repeat)', () => {
+    const afterNamed = advanceReviewConsentLatch(INITIAL_REVIEW_CONSENT_LATCH, true).next;
+    expect(advanceReviewConsentLatch(afterNamed, true).show).toBe(false);
+    expect(advanceReviewConsentLatch(afterNamed, false).show).toBe(false);
+  });
+
+  it('🔴 BOUND: a hostile flood of ANY mix of requests emits at most TWO notices', () => {
+    // This is the security property the latch exists for — an untrusted app can
+    // post REQUEST_CONSENT in a loop. Exercise every ordering of a long flood.
+    const floods: boolean[][] = [
+      Array.from({ length: 200 }, () => true),
+      Array.from({ length: 200 }, () => false),
+      Array.from({ length: 200 }, (_, i) => i % 2 === 0),
+      Array.from({ length: 200 }, (_, i) => i % 2 === 1),
+      Array.from({ length: 200 }, () => Math.random() < 0.5),
+    ];
+    for (const flood of floods) {
+      let latch = INITIAL_REVIEW_CONSENT_LATCH;
+      let shows = 0;
+      for (const isNamed of flood) {
+        const r = advanceReviewConsentLatch(latch, isNamed);
+        latch = r.next;
+        if (r.show) shows++;
+      }
+      expect(shows).toBeLessThanOrEqual(2);
+      expect(shows).toBeGreaterThanOrEqual(1);
+    }
+  });
+
+  it('never mutates the latch it is given', () => {
+    const latch = { shown: false, named: false };
+    advanceReviewConsentLatch(latch, true);
+    expect(latch).toEqual({ shown: false, named: false });
+    expect(INITIAL_REVIEW_CONSENT_LATCH).toEqual({ shown: false, named: false });
+  });
+});
+
+describe('buildReviewConsentNotification (🔴 mode-specific ids + honest Run-for-real copy)', () => {
+  const build = (runForReal: boolean, scopes: string[] = []) =>
+    buildReviewConsentNotification({ appBlockId: 'pubreq_X', runForReal, scopes });
+
+  it('🔴 render-only and run-for-real produce DISTINCT ids', () => {
+    // Mantine no-ops showNotification for an id already displayed/queued (default
+    // autoClose 4000ms). A single shared id meant: notice fires in render-only →
+    // mod clicks "Run for real…" → host remounts → latch resets by design → the
+    // app re-requests within 4s → the run-for-real notice is SILENTLY SWALLOWED,
+    // re-creating the original silent-drop bug in the other mode.
+    expect(build(false).id).not.toBe(build(true).id);
+    expect(build(false, ['buzz:read:self']).id).not.toBe(build(true, ['buzz:read:self']).id);
+    expect(build(false).id).toBe('review-consent-pubreq_X-render');
+    expect(build(true).id).toBe('review-consent-pubreq_X-real');
+  });
+
+  it('🔴 the generic and the named upgrade use DISTINCT ids, and the upgrade supersedes the generic', () => {
+    // Same dedupe trap in the other direction: reusing the generic id would make
+    // the upgrade a no-op while the generic is still displayed, and
+    // updateNotification would drop it once the generic had auto-closed.
+    for (const runForReal of [false, true]) {
+      const generic = build(runForReal);
+      const named = build(runForReal, ['buzz:read:self']);
+      expect(named.id).not.toBe(generic.id);
+      expect(generic.supersedesId).toBeNull();
+      expect(named.supersedesId).toBe(generic.id);
+    }
+  });
+
+  it('names the scopes when it has them, and falls back to generic copy when it does not', () => {
+    expect(build(false, ['buzz:read:self', 'social:tip:self']).message).toContain(
+      'buzz:read:self, social:tip:self'
+    );
+    expect(build(false).message).toContain('doesn’t have here');
+  });
+
+  it('🔴 render-only copy states that "Run for real…" spends the MODERATOR\'S OWN Buzz', () => {
+    // Untrusted code can emit this toast unprompted right after BLOCK_READY, and
+    // it is the one surface pointing a reviewer at the opt-in. The opt-in grants
+    // `ai:write:budgeted` against the mod's OWN account under a session Buzz cap,
+    // so the copy must not read as a free "make it work" button.
+    const message = build(false, ['buzz:read:self']).message;
+    expect(message).toContain('Run for real');
+    expect(message).toContain('your own account and Buzz');
+  });
+
+  it('run-for-real copy does NOT point at the opt-in the mod already took', () => {
+    const message = build(true, ['buzz:read:self']).message;
+    expect(message).not.toContain('Run for real');
+    expect(message).not.toContain('your own account and Buzz');
+  });
+
+  it('keeps a stable, non-empty title in every variant', () => {
+    for (const runForReal of [false, true]) {
+      for (const scopes of [[], ['buzz:read:self']]) {
+        expect(build(runForReal, scopes).title).toBe('Permission unavailable in review');
+      }
+    }
   });
 });
 

--- a/src/components/AppBlocks/pageBlockHostLogic.ts
+++ b/src/components/AppBlocks/pageBlockHostLogic.ts
@@ -102,6 +102,11 @@ export type ReviewConsentNotice = {
  * `isKnownBlockScope`, so only the fixed platform vocabulary can ever reach a
  * moderator-facing string — an attacker can't smuggle arbitrary display text into
  * a toast aimed at the reviewer. (Callers must still render it as React text.)
+ * That claim depends on `isKnownBlockScope` being an OWN-property test: it used
+ * to use `in`, which walks the prototype chain and let 12 inherited
+ * `Object.prototype` keys (`constructor`, `__proto__`, `toString`, …) through as
+ * "known scopes". Fixed at the predicate; the unit tests below pin it here too,
+ * because THIS is the caller that feeds untrusted runtime input to it.
  */
 export function resolveReviewConsentNotice(
   rawScopesHint: unknown,
@@ -118,6 +123,119 @@ export function resolveReviewConsentNotice(
   if (ungranted.length === 0) return { notify: false, scopes: [] };
 
   return { notify: true, scopes: ungranted.filter((s) => isKnownBlockScope(s)) };
+}
+
+/**
+ * Emit latch for the review consent notice — the ANTI-SPAM bound.
+ *
+ * `shown` — any notice has been emitted this mount.
+ * `named` — the emitted notice NAMED at least one scope (the informative one).
+ */
+export type ReviewConsentLatch = { shown: boolean; named: boolean };
+
+export const INITIAL_REVIEW_CONSENT_LATCH: ReviewConsentLatch = { shown: false, named: false };
+
+/**
+ * 🔴 ANTI-SPAM, and the reason it is not a plain boolean.
+ *
+ * The reviewed app is UNTRUSTED code that can post `REQUEST_CONSENT` in a loop,
+ * so the notice MUST be bounded per host mount. A plain "already notified"
+ * boolean bounded it to one — but at the cost of first-notice-wins: the SDK's
+ * `useRequestConsent()` takes an OPTIONAL `scopes` hint, so a hint-less request
+ * on load is an ordinary path, not an edge case. That first request produced the
+ * generic "requested a permission it doesn't have here" copy, set the latch, and
+ * then permanently suppressed the app's LATER, specific `['buzz:read:self']`
+ * request. The moderator never learned WHICH permission — defeating the point of
+ * naming scopes at all.
+ *
+ * So the latch tracks whether a scope-NAMED notice has been shown, and allows
+ * exactly ONE upgrade generic → named.
+ *
+ * BOUND (this is the security property, and it is why the transitions are
+ * written as an explicit state machine): at most TWO notices per host mount.
+ *   - `named` set        ⇒ never show again (the best notice is already up);
+ *   - `shown && !isNamed` ⇒ never show again (a repeat generic adds nothing).
+ * Every accepted transition sets `shown`, and only a `!named → named` step can
+ * follow an accepted generic — so the accept sequence is at most
+ * `generic, named`. A flood of any mix is capped at 2, not 2-per-distinct-scope.
+ */
+export function advanceReviewConsentLatch(
+  latch: ReviewConsentLatch,
+  isNamed: boolean
+): { show: boolean; next: ReviewConsentLatch } {
+  // The informative notice is already up — nothing left to tell the reviewer.
+  if (latch.named) return { show: false, next: latch };
+  // A generic notice is already up and this request names nothing new.
+  if (latch.shown && !isNamed) return { show: false, next: latch };
+  return { show: true, next: { shown: true, named: isNamed } };
+}
+
+/** A ready-to-render review consent notification. */
+export type ReviewConsentNotification = {
+  id: string;
+  /**
+   * The id this notice REPLACES (the generic one), or null. Non-null only on
+   * the generic → named upgrade.
+   */
+  supersedesId: string | null;
+  title: string;
+  message: string;
+};
+
+/**
+ * Build the moderator-facing review-consent notification.
+ *
+ * 🔴 THE `id` IS LOAD-BEARING, TWICE.
+ *
+ * (1) MODE-SPECIFIC. Mantine's `showNotification` is a NO-OP when a notification
+ * with the same id is already displayed or queued (default autoClose 4000ms). A
+ * single `review-consent-<appBlockId>` id was therefore identical across
+ * render-only and run-for-real — so the realistic sequence "notice fires in
+ * render-only → mod clicks Run for real… → host remounts → latch resets by
+ * design → app re-requests within 4s" SILENTLY SWALLOWED the run-for-real
+ * notice, re-creating the original silent-drop bug in the other mode. The mode
+ * is part of the id.
+ *
+ * (2) NAMED vs GENERIC. The generic → named upgrade must not be swallowed the
+ * same way, and it cannot use `updateNotification` either: that only maps over
+ * notifications that are still live, so once the generic has auto-closed the
+ * upgrade would vanish. The named notice therefore carries its OWN id and
+ * reports the generic id as `supersedesId`, which the caller passes to
+ * `hideNotification` first — a harmless no-op if the generic already closed.
+ * Net effect: exactly one visible notice, in BOTH timing cases.
+ *
+ * `scopes` must already be filtered by `resolveReviewConsentNotice` (known
+ * vocabulary only); callers must render `message` as React text, never HTML.
+ */
+export function buildReviewConsentNotification(opts: {
+  appBlockId: string;
+  runForReal: boolean;
+  scopes: string[];
+}): ReviewConsentNotification {
+  const { appBlockId, runForReal, scopes } = opts;
+  const baseId = `review-consent-${appBlockId}-${runForReal ? 'real' : 'render'}`;
+  const named = scopes.length > 0;
+
+  const what = named
+    ? `This app requested ${scopes.join(', ')}.`
+    : 'This app requested a permission it doesn’t have here.';
+  // 🔴 The opt-in is NOT free: "Run for real…" re-mints the token against the
+  // MODERATOR'S OWN account and spends the MODERATOR'S OWN Buzz (it grants
+  // `ai:write:budgeted` under a per-session cap). Untrusted code can emit this
+  // toast unprompted right after BLOCK_READY, so the one surface that points a
+  // reviewer at that opt-in must say what it costs them — pointing at a
+  // spend-your-own-money button without saying so is how a hostile app gets a
+  // mod to click it.
+  const how = runForReal
+    ? 'Review previews always run with reduced permissions.'
+    : 'Review previews run with reduced permissions — use “Run for real…” (runs against your own account and Buzz) to grant the app its real permissions.';
+
+  return {
+    id: named ? `${baseId}-scoped` : baseId,
+    supersedesId: named ? baseId : null,
+    title: 'Permission unavailable in review',
+    message: `${what} ${how}`,
+  };
 }
 
 // ── OPEN_RESOURCE_PICKER (Design 1 host-chrome resource picker) ──────────────

--- a/src/components/AppBlocks/pageBlockHostLogic.ts
+++ b/src/components/AppBlocks/pageBlockHostLogic.ts
@@ -3,6 +3,8 @@
 // (no RTL — civitai-web's unit project runs `environment: 'node'` and only
 // collects `*.test.ts`). Mirrors the IframeHost `hostRenderDecision` pattern.
 
+import { isKnownBlockScope } from '~/shared/constants/block-scope.constants';
+
 export type PageHostStatus =
   | 'loading'
   | 'ready'
@@ -64,6 +66,58 @@ export function resolveUngrantableConsentScopes(
   return Array.from(
     new Set(requested.filter((s: string) => !granted.has(s) && !missing.has(s)))
   ).sort();
+}
+
+/** What a reviewMode REQUEST_CONSENT should surface to the moderator. */
+export type ReviewConsentNotice = {
+  /** Whether the mod gets a (passive, non-interactive) notice at all. */
+  notify: boolean;
+  /**
+   * The requested scopes safe to NAME in that notice: the un-granted subset,
+   * filtered to the known block-scope vocabulary. Empty ⇒ use generic copy.
+   */
+  scopes: string[];
+};
+
+/**
+ * MOD REVIEW SANDBOX — decide what a `reviewMode` REQUEST_CONSENT tells the
+ * moderator. The review host NEVER opens a consent modal (a grant would re-mint
+ * the mod's token with WIDER scopes at the request of unapproved code), and the
+ * review mint deliberately strips the app's scopes — so in review a consent
+ * round-trip can NEVER resolve. Dropping it silently (the old behaviour) left the
+ * app parked on its consent card with zero feedback at the reviewer.
+ *
+ * Differs from `resolveUngrantableConsentScopes` in exactly one way, and that
+ * difference is the bug this fixes: with NO usable `scopes` hint the prod path
+ * must stay silent (it can't tell "already granted" from "clamped"), but in
+ * review there is nothing to tell apart — consent is structurally unavailable, so
+ * a hint-less request is still a dead end and still deserves the notice. (The
+ * SDK's `useRequestConsent()` is fire-and-forget and need not send a hint at all.)
+ *
+ * The one case that stays SILENT is the benign one the hint proves: every
+ * requested scope is already granted, so nothing is actually blocked.
+ *
+ * 🔴 `rawScopesHint` is UNTRUSTED (it comes from the reviewed app's own frame, via
+ * its manifest). The returned `scopes` are therefore filtered through
+ * `isKnownBlockScope`, so only the fixed platform vocabulary can ever reach a
+ * moderator-facing string — an attacker can't smuggle arbitrary display text into
+ * a toast aimed at the reviewer. (Callers must still render it as React text.)
+ */
+export function resolveReviewConsentNotice(
+  rawScopesHint: unknown,
+  grantedScopes: string[]
+): ReviewConsentNotice {
+  const requested = Array.isArray(rawScopesHint)
+    ? rawScopesHint.filter((s): s is string => typeof s === 'string' && s.length > 0)
+    : [];
+  if (requested.length === 0) return { notify: true, scopes: [] };
+
+  const granted = new Set<string>(grantedScopes);
+  const ungranted = Array.from(new Set(requested.filter((s) => !granted.has(s)))).sort();
+  // Benign: the block re-requested scopes it already holds — nothing is blocked.
+  if (ungranted.length === 0) return { notify: false, scopes: [] };
+
+  return { notify: true, scopes: ungranted.filter((s) => isKnownBlockScope(s)) };
 }
 
 // ── OPEN_RESOURCE_PICKER (Design 1 host-chrome resource picker) ──────────────

--- a/src/shared/constants/__tests__/block-scope.constants.test.ts
+++ b/src/shared/constants/__tests__/block-scope.constants.test.ts
@@ -50,6 +50,46 @@ describe('block-scope.constants', () => {
     expect(isKnownBlockScope('not:a:scope')).toBe(false);
   });
 
+  // 🔴 `in` walks the prototype chain, so with `scope in BLOCK_SCOPE_TO_OAUTH_BIT`
+  // every inherited Object.prototype key answered "known scope". Callers treat a
+  // `true` here as "part of the fixed platform vocabulary" and several then read
+  // BLOCK_SCOPE_TO_OAUTH_BIT[scope] expecting a number — for these keys that read
+  // returns a FUNCTION. The predicate is an OWN-property test; this pins it.
+  const PROTOTYPE_KEYS = [
+    '__proto__',
+    'constructor',
+    'toString',
+    'valueOf',
+    'hasOwnProperty',
+    'isPrototypeOf',
+    'propertyIsEnumerable',
+    'toLocaleString',
+    '__defineGetter__',
+    '__defineSetter__',
+    '__lookupGetter__',
+    '__lookupSetter__',
+  ];
+
+  it('isKnownBlockScope rejects inherited Object.prototype keys (no prototype-chain bypass)', () => {
+    for (const key of PROTOTYPE_KEYS) {
+      expect(isKnownBlockScope(key), `${key} must not be a known scope`).toBe(false);
+    }
+    // The bypass this guards against: `in` says yes to every one of them.
+    expect(PROTOTYPE_KEYS.filter((k) => k in BLOCK_SCOPE_TO_OAUTH_BIT)).toHaveLength(
+      PROTOTYPE_KEYS.length
+    );
+  });
+
+  it('prototype keys contribute nothing downstream of the predicate', () => {
+    // deriveOauthBitmaskFromBlockScopes and validateBlockScopesAgainstOauthClient
+    // both index the map right after the predicate; a prototype key must never
+    // reach that indexing.
+    expect(deriveOauthBitmaskFromBlockScopes(PROTOTYPE_KEYS)).toBe(0);
+    const check = validateBlockScopesAgainstOauthClient(PROTOTYPE_KEYS, TokenScope.Full);
+    expect(check.valid).toBe(false);
+    expect(check.rejectedScopes.sort()).toEqual([...PROTOTYPE_KEYS].sort());
+  });
+
   describe('SENSITIVE_BLOCK_SCOPES / isSensitiveBlockScope', () => {
     const EXPECTED_SENSITIVE = [
       'ai:write:budgeted',

--- a/src/shared/constants/block-scope.constants.ts
+++ b/src/shared/constants/block-scope.constants.ts
@@ -133,8 +133,33 @@ export type BlockScopeString = keyof typeof BLOCK_SCOPE_TO_OAUTH_BIT;
  */
 export const REVIEW_RUN_FOR_REAL_BUZZ_CAP = 5000;
 
+/**
+ * Membership test against the authoritative scope vocabulary.
+ *
+ * 🔴 OWN-PROPERTY ONLY — deliberately `hasOwnProperty`, never `in`. `in` walks
+ * the prototype chain, so `BLOCK_SCOPE_TO_OAUTH_BIT` being a plain object
+ * literal made 12 inherited `Object.prototype` keys answer "known scope":
+ * `__proto__`, `constructor`, `toString`, `valueOf`, `hasOwnProperty`,
+ * `isPrototypeOf`, `propertyIsEnumerable`, `toLocaleString`, and the four
+ * `__define*`/`__lookup*` accessors. Every caller treats a `true` here as
+ * "this string is part of the fixed platform vocabulary" and several then read
+ * `BLOCK_SCOPE_TO_OAUTH_BIT[scope]` expecting a number — for those keys that
+ * read yields a FUNCTION.
+ *
+ * The registration-time manifest path was never reachable (its `SCOPE_RE`
+ * requires at least one colon and rejects all 12 before this predicate runs),
+ * so this is defense-in-depth for the paths that call the predicate on
+ * untrusted runtime input WITHOUT a shape check first — notably the review
+ * host's REQUEST_CONSENT notice, whose `payload.scopes` comes straight from
+ * the reviewed app's own frame and whose filtered output is rendered into
+ * moderator-facing text.
+ *
+ * `Object.prototype.hasOwnProperty.call(...)` rather than
+ * `BLOCK_SCOPE_TO_OAUTH_BIT.hasOwnProperty(...)` so a future map that is
+ * null-prototype or that ever declares its own `hasOwnProperty` key still works.
+ */
 export function isKnownBlockScope(scope: string): scope is BlockScopeString {
-  return scope in BLOCK_SCOPE_TO_OAUTH_BIT;
+  return Object.prototype.hasOwnProperty.call(BLOCK_SCOPE_TO_OAUTH_BIT, scope);
 }
 
 /**


### PR DESCRIPTION
## Symptom

A moderator reviewing a pending app at `/apps/review/preview/<publishRequestId>` clicks a button in the app that calls the SDK's `useRequestConsent()`. **Nothing happens** — no modal, no toast, no error — and the app parks forever on its own "grant permission to continue" card. From the reviewer's seat the submission looks broken, which is the wrong conclusion: the preview is *deliberately* withholding the permission.

## Root cause

`src/components/AppBlocks/PageBlockHost.tsx:714-719` (before this change) — the `REQUEST_CONSENT` handler dropped review-mode requests with a bare early `return`:

```ts
const off = onMessage<{ scopes?: unknown } | undefined>('REQUEST_CONSENT', (payload) => {
  // reviewMode: a consent grant re-mints the token with WIDER scopes — never
  // let untrusted review code pop a permission modal at the mod. Fire-and-
  // forget ⇒ dropping it never hangs the block.
  if (reviewMode) return;
```

That `return` sits ~40 lines **above** the existing "Permission unavailable" `showNotification(...)` fallback (`PageBlockHost.tsx:759-763`), so review mode skipped the entire feedback path — not just the modal. The comment's intent (no permission modal at the mod) was right; the blast radius was too wide.

## Why this is feedback-only, not a permissions change

Nothing about what the preview can do changes:

- **No scope allowlist is touched.** The review mint still strips the app's declared scopes down to the read-only review set. That is correct policy — a mod previewing someone else's app must not leak their own balance/storage — and it stays exactly as-is.
- **Review mode still never opens a consent/permission modal.** A grant would re-mint the mod's token with wider scopes at the request of unapproved code. A passive, non-interactive notification is the ceiling; there is nothing to click and no scope is granted.
- **`REQUEST_CONSENT` stays fire-and-forget** — no requestId, no reply, no timeout (see `hostHandlerParity.ts`, `{ request: false, reply: '' }`). Dropping the *grant* still never hangs the app.

The escape hatch for actually exercising the app's real permissions already exists and is unchanged: the **"Run for real…"** opt-in in the preview chrome, which re-mints against the run-for-real allowlist. The new copy points the reviewer at it.

## Copy shipped

Title: `Permission unavailable in review`

Message = `<what>` + `<how>`:

- `what` (scopes known): `This app requested buzz:read:self.`
- `what` (nothing nameable): `This app requested a permission it doesn’t have here.`
- `how` (render-only): `Review previews run with reduced permissions — use “Run for real…” to grant the app its real permissions.`
- `how` (already in run-for-real): `Review previews always run with reduced permissions.`

Yellow, matching the existing "Permission unavailable" toast next to it.

## Naming the requested scopes — and the hardening that makes it safe

The message names the specific scope(s), because "which permission?" is the first thing a reviewer needs. Those strings come from the **untrusted** app's own frame/manifest, so:

- they are filtered through `isKnownBlockScope` (`src/shared/constants/block-scope.constants.ts`) before they can reach a moderator-facing string — only the fixed platform vocabulary is ever displayed, and anything else is silently dropped (falling back to the generic copy);
- they are rendered as ordinary React text by the notification component — no `dangerouslySetInnerHTML` anywhere on this path.

A test asserts that an injected string (`<img src=x onerror=alert(1)>`) and a made-up scope never appear in the message while a real scope still does.

## Anti-spam guard

Untrusted review code can post `REQUEST_CONSENT` in a loop, so a naive toast-per-message would let a hostile submission carpet-bomb the reviewing mod's screen and bury the review chrome. Two layers:

1. **A per-host-mount latch** (`reviewConsentNoticeShownRef`) — the notice fires at most once per mount. The review chrome remounts the host on a render-only ↔ run-for-real flip, so each mode still gets exactly one notice.
2. **A stable notification `id`** — an independent second guard; the toast library dedupes an already-displayed notification even if the latch were bypassed.

The transport's generic 30-messages/second limiter is **not** sufficient on its own: 30 toasts a second is still a carpet bomb. The flood test is deliberately kept *under* that transport budget so it asserts the latch, not the limiter.

One deliberate silent case is preserved: if the hint proves every requested scope is **already granted**, nothing is actually blocked, so nothing is reported.

## Behaviour outside review mode

Byte-identical. The review branch was moved *below* the existing post-handshake readiness gate, so the non-review path evaluates in the same order it always did and lands on the same code. The pre-existing tests for the dev-tunnel / "Permission unavailable" fallback and for the normal consent-modal path are unchanged and still pass; one existing test that asserted review mode stays *silent* was updated, since that silence is the bug.

## Tests

New unit cases for the pure decision (`resolveReviewConsentNotice`) and new browser cases for the host:

- review mode + `REQUEST_CONSENT` → notice fires, **no** consent modal opens;
- a hint-less request (the fire-and-forget SDK call sends no `scopes`) still notifies — the prod path stays silent without a hint because it can't tell "already granted" from "withheld"; in review there is nothing to tell apart;
- **anti-spam**: 9 messages → exactly 1 notice;
- unknown/injected scope strings never reach the message;
- benign re-request of an already-granted scope stays silent;
- run-for-real copy variant;
- non-review path unchanged (generic toast, no review copy).

### Mutation check

Both guards were verified by breaking them and watching the tests go red:

1. Reverted the handler to the original bare `if (reviewMode) return;` → **5 of the new browser tests failed** (`expected "vi.fn()" to be called 1 times, but got 0 times`); the pre-existing suites stayed green.
2. Removed **only** the anti-spam latch, leaving the notice in place → the flood test failed with `expected 1 times, but got 9 times`, confirming the latch (not the transport rate limiter) is what holds the line.

Both mutations were then reverted and the suites re-run green.

## Verified locally vs. not

**Ran and passed:**
- `vitest --project unit src/components/AppBlocks/__tests__/pageBlockHostLogic.test.ts` — 55/55.
- `vitest --project component` on `PageBlockHostReviewMode.browser.test.tsx` + `PageBlockHost.browser.test.tsx` — 48/48 (real Chromium).
- Both mutation checks above.
- ESLint on the five changed files: the only findings are a **pre-existing** `no-wholesale-module-mock` error on the two browser test files' `vi.mock('~/utils/trpc')` factories, present unchanged on `main`. Prettier: the three source files were already unformatted on `main`; the lines this PR adds are prettier-clean (reformatting the whole files would bury the diff).

**Could not run / not verified:**
- A clean full-repo `tsc --noEmit` — this machine can't generate the Prisma client, so the run is swamped by unrelated generated-client type errors. Filtered to the touched area, there are **zero** errors in `src/components/AppBlocks/**`, but treat CI's typecheck as the real gate.
- The rest of the unit suite (one unrelated pre-existing failure locally in `hiddenBlocks.test.ts`, which imports nothing this PR touches).
- No end-to-end click-through of a real review preview — I did not reproduce the original moderator click path against a running app. The browser tests drive the real postMessage bridge into the real host component, which is the closest deterministic proxy.
