### PR TITLE
fix(apps): make in-review submission snapshots private, backfill, and reclaim them

### DIFF
--- a/src/components/Apps/CombinedReviewModal.browser.test.tsx
+++ b/src/components/Apps/CombinedReviewModal.browser.test.tsx
@@ -252,7 +252,7 @@ describe('CombinedReviewModal', () => {
     await expect.element(page.getByRole('tab', { name: /Scopes/ })).toBeInTheDocument();
     await expect.element(page.getByRole('tab', { name: /Code review/ })).toBeInTheDocument();
     // Code section: the on-site bundle affordance.
-    await expect.element(page.getByText('View full source')).toBeInTheDocument();
+    await expect.element(page.getByText('Show code diff')).toBeInTheDocument();
 
     // Media section: the listing PREVIEW (card + detail) + the content-review surface.
     await expect.element(page.getByTestId('apps-listing-preview')).toBeInTheDocument();

--- a/src/components/Apps/OnsiteReviewModal.browser.test.tsx
+++ b/src/components/Apps/OnsiteReviewModal.browser.test.tsx
@@ -9,8 +9,10 @@ import { renderWithProviders } from '../../../test/component-setup';
  * `OnsiteReviewModal.tsx` (mirrors #3154) so it is importable WITHOUT the page's
  * `getServerSideProps` server graph — this suite is the coverage that extraction
  * unlocks. Asserts:
- *  - onsite-specific visibility (View full source link + the mod Review-preview panel +
- *    the structured manifest render);
+ *  - onsite-specific visibility (the in-app code-diff affordance + the mod
+ *    Review-preview panel + the structured manifest render), and that NO
+ *    raw-source deep-link is offered (retired in #3495 — in-review snapshots are
+ *    private, so such a link would 404 for the moderator who clicked it);
  *  - Approve FIRES `blocks.approveRequest` with the request id;
  *  - the reject reason gate (disabled < 3 chars) AND that Reject FIRES
  *    `blocks.rejectRequest` with `{ publishRequestId, rejectionReason }`;
@@ -165,14 +167,22 @@ beforeEach(() => {
 });
 
 describe('OnsiteReviewModal — onsite-specific contract', () => {
-  test('a pending selection renders the View full source link, the mod Review-preview panel, and the structured manifest', async () => {
+  test('a pending selection renders the in-app code diff, the mod Review-preview panel, and the structured manifest — and NO raw-source link', async () => {
     renderWithProviders(
       <OnsiteReviewModal selection={{ request: ONSITE_PENDING, mode: 'pending' }} onClose={vi.fn()} />
     );
-    // The on-site code-review affordance (off-site has no bundle/code).
-    await expect.element(page.getByText('View full source')).toBeInTheDocument();
-    // The old "View code in Forgejo" copy is gone.
+    // The on-site code-review affordance (off-site has no bundle/code) is the
+    // in-app diff, not an external link.
+    await expect.element(page.getByText('Show code diff')).toBeInTheDocument();
+    // 🔴 #3495 regression guard: in-review snapshots are private, so ANY raw
+    // deep-link out to them is a dead link for the moderator who clicks it.
+    // None of these affordances may come back.
+    expect(page.getByText('View full source').elements()).toHaveLength(0);
+    expect(page.getByText('View in Forgejo').elements()).toHaveLength(0);
     expect(page.getByText('View code in Forgejo').elements()).toHaveLength(0);
+    expect(
+      document.querySelectorAll(`a[href="${ONSITE_PENDING.reviewRepoUrl}"]`).length
+    ).toBe(0);
     // The mod Review-preview sandbox panel — on-site pending only.
     await expect.element(page.getByText('Review preview')).toBeInTheDocument();
     await expect.element(page.getByRole('button', { name: 'Start preview' })).toBeInTheDocument();
@@ -567,7 +577,7 @@ describe('OnsiteReviewModal — busy close-guard while a mutation is in flight',
       <OnsiteReviewModal selection={{ request: ONSITE_PENDING, mode: 'pending' }} onClose={onClose} />
     );
     // Modal is open (body rendered).
-    await expect.element(page.getByText('View full source')).toBeInTheDocument();
+    await expect.element(page.getByText('Show code diff')).toBeInTheDocument();
 
     // Close vector 1 — the modal's close (X) button (Mantine static class).
     const closeBtn = document.querySelector<HTMLButtonElement>('.mantine-Modal-close');
@@ -580,7 +590,7 @@ describe('OnsiteReviewModal — busy close-guard while a mutation is in flight',
     // The busy guard swallowed both — the parent onClose was never called and the
     // modal is still mounted.
     expect(onClose).not.toHaveBeenCalled();
-    await expect.element(page.getByText('View full source')).toBeInTheDocument();
+    await expect.element(page.getByText('Show code diff')).toBeInTheDocument();
   });
 });
 

--- a/src/components/Apps/OnsiteReviewModal.browser.test.tsx
+++ b/src/components/Apps/OnsiteReviewModal.browser.test.tsx
@@ -11,7 +11,7 @@ import { renderWithProviders } from '../../../test/component-setup';
  * unlocks. Asserts:
  *  - onsite-specific visibility (the in-app code-diff affordance + the mod
  *    Review-preview panel + the structured manifest render), and that NO
- *    raw-source deep-link is offered (retired in #3495 — in-review snapshots are
+ *    raw-source deep-link is offered (retired in #3498 — in-review snapshots are
  *    private, so such a link would 404 for the moderator who clicked it);
  *  - Approve FIRES `blocks.approveRequest` with the request id;
  *  - the reject reason gate (disabled < 3 chars) AND that Reject FIRES
@@ -174,7 +174,7 @@ describe('OnsiteReviewModal — onsite-specific contract', () => {
     // The on-site code-review affordance (off-site has no bundle/code) is the
     // in-app diff, not an external link.
     await expect.element(page.getByText('Show code diff')).toBeInTheDocument();
-    // 🔴 #3495 regression guard: in-review snapshots are private, so ANY raw
+    // 🔴 #3498 regression guard: in-review snapshots are private, so ANY raw
     // deep-link out to them is a dead link for the moderator who clicks it.
     // None of these affordances may come back.
     expect(page.getByText('View full source').elements()).toHaveLength(0);

--- a/src/components/Apps/OnsiteReviewModal.browser.test.tsx
+++ b/src/components/Apps/OnsiteReviewModal.browser.test.tsx
@@ -174,11 +174,13 @@ describe('OnsiteReviewModal — onsite-specific contract', () => {
     // The on-site code-review affordance (off-site has no bundle/code) is the
     // in-app diff, not an external link.
     await expect.element(page.getByText('Show code diff')).toBeInTheDocument();
-    // 🔴 #3498 regression guard: in-review snapshots are private, so ANY raw
-    // deep-link out to them is a dead link for the moderator who clicks it.
-    // None of these affordances may come back.
+    // 🔴 #3498 regression guard: the modal's own raw-source affordances are
+    // retired and may not come back. (The per-FILE fallback that used to sit
+    // inside an elided diff row is guarded where it actually renders —
+    // `src/tests/pages/apps/review-diff-panels.browser.test.tsx`. Asserting it
+    // here would prove nothing: the code-diff panel is collapsed by default, so
+    // no file row is mounted at this point.)
     expect(page.getByText('View full source').elements()).toHaveLength(0);
-    expect(page.getByText('View in Forgejo').elements()).toHaveLength(0);
     expect(page.getByText('View code in Forgejo').elements()).toHaveLength(0);
     expect(
       document.querySelectorAll(`a[href="${ONSITE_PENDING.reviewRepoUrl}"]`).length

--- a/src/components/Apps/OnsiteReviewModal.tsx
+++ b/src/components/Apps/OnsiteReviewModal.tsx
@@ -414,7 +414,7 @@ export function OnsiteReviewModalBody({
             )}
           </Group>
           {/* The raw-source deep-link that used to sit here has been retired
-              (#3495). In-review snapshots are private now, so an anonymous
+              (#3498). In-review snapshots are private now, so an anonymous
               click on it 404s — a dead link is worse than no link. Source
               review happens in the "Show code diff" panel below, which reads
               the submitted artifact server-side and needs no second login.

--- a/src/components/Apps/OnsiteReviewModal.tsx
+++ b/src/components/Apps/OnsiteReviewModal.tsx
@@ -22,7 +22,6 @@ import {
   IconAdjustmentsAlt,
   IconAlertTriangle,
   IconCheck,
-  IconCode,
   IconExternalLink,
   IconInfoCircle,
   IconKey,
@@ -414,28 +413,22 @@ export function OnsiteReviewModalBody({
               </Badge>
             )}
           </Group>
-          <Button
-            component="a"
-            href={request.pushCommitUrl ?? request.reviewRepoUrl}
-            target="_blank"
-            rel="noopener"
-            variant="default"
-            leftSection={<IconCode size={14} />}
-            rightSection={<IconExternalLink size={12} />}
-          >
-            View full source
-          </Button>
+          {/* The raw-source deep-link that used to sit here has been retired
+              (#3495). In-review snapshots are private now, so an anonymous
+              click on it 404s — a dead link is worse than no link. Source
+              review happens in the "Show code diff" panel below, which reads
+              the submitted artifact server-side and needs no second login.
+              `request.reviewRepoUrl` / `request.pushCommitUrl` are intentionally
+              still carried on the payload: a richer in-app file browser is
+              being designed separately and will reuse them. */}
           {mds.kind === 'update' && (
             <FileListPreview added={fs.added} removed={fs.removed} changed={fs.changed} />
           )}
           {/* Line-level code diff — lazy (only fetched when the mod toggles it
               open) so the modal stays light by default. Bounded server-side;
-              binary / oversized / huge-diff files fall back to the Forgejo link
-              above. */}
-          <CodeDiffPanel
-            publishRequestId={request.id}
-            forgejoUrl={request.pushCommitUrl ?? request.reviewRepoUrl}
-          />
+              binary / oversized / huge-diff files are labelled as not-shown
+              rather than linked out. */}
+          <CodeDiffPanel publishRequestId={request.id} />
         </Stack>
 
         <Stack gap={4}>
@@ -854,8 +847,8 @@ function CurationPanel({ appBlockId }: { appBlockId: string }) {
 // Line-level code diff — expands the file-level summary with the actual unified
 // line diff per changed/added text file. Lazy: the query only fires once the mod
 // toggles "Show code diff" on, so the modal default stays light. Bounded
-// server-side (text-only, byte/line/file caps); elided files render a "view in
-// Forgejo" fallback rather than inlining unbounded content.
+// server-side (text-only, byte/line/file caps); elided files are labelled with
+// WHY they were skipped rather than inlining unbounded content.
 //
 // The presentational panels (FileListPreview / FileDiffEntry / DiffHunkView /
 // ManifestDiffPreview) + the FileLineDiff type live in the server-free
@@ -863,13 +856,7 @@ function CurationPanel({ appBlockId }: { appBlockId: string }) {
 // browser mode without importing this page's tRPC server graph.
 // ---------------------------------------------------------------------------
 
-function CodeDiffPanel({
-  publishRequestId,
-  forgejoUrl,
-}: {
-  publishRequestId: string;
-  forgejoUrl: string;
-}) {
+function CodeDiffPanel({ publishRequestId }: { publishRequestId: string }) {
   const features = useFeatureFlags();
   const [show, setShow] = useState(false);
 
@@ -894,7 +881,7 @@ function CodeDiffPanel({
         {show && !isLoading && !error && (
           <Text size="xs" c="dimmed">
             {files.length} file{files.length === 1 ? '' : 's'} changed
-            {data?.truncated ? ' (some elided — view in Forgejo)' : ''}
+            {data?.truncated ? ' (some elided)' : ''}
           </Text>
         )}
       </Group>
@@ -915,7 +902,7 @@ function CodeDiffPanel({
         ) : (
           <Stack gap={6}>
             {files.map((f) => (
-              <FileDiffEntry key={f.path} file={f} forgejoUrl={forgejoUrl} />
+              <FileDiffEntry key={f.path} file={f} />
             ))}
           </Stack>
         ))}

--- a/src/components/Apps/ReviewDetailView.browser.test.tsx
+++ b/src/components/Apps/ReviewDetailView.browser.test.tsx
@@ -141,7 +141,7 @@ describe('ReviewDetailView — sticky action bar', () => {
       <ReviewDetailView selection={{ request: PENDING, mode: 'pending' }} onClose={vi.fn()} />
     );
     // Body content is present (shared review body).
-    await expect.element(page.getByText('View full source')).toBeInTheDocument();
+    await expect.element(page.getByText('Show code diff')).toBeInTheDocument();
     // The pinned action bar (labelled group) with both terminal actions.
     const bar = page.getByRole('group', { name: 'Review actions' });
     await expect.element(bar).toBeInTheDocument();

--- a/src/components/Apps/reviewDiffPanels.tsx
+++ b/src/components/Apps/reviewDiffPanels.tsx
@@ -72,7 +72,7 @@ export type FileLineDiff = {
 /**
  * Why a file has no inline diff. These used to end in "— view in Forgejo" next
  * to a deep-link into the raw in-review snapshot; that link was retired in
- * #3495 when snapshots became private (an anonymous click 404s, and a dead link
+ * #3498 when snapshots became private (an anonymous click 404s, and a dead link
  * is worse than none). The labels now just state the reason — the mod knows the
  * file changed and why it isn't rendered, which is what the label is for.
  */

--- a/src/components/Apps/reviewDiffPanels.tsx
+++ b/src/components/Apps/reviewDiffPanels.tsx
@@ -1,5 +1,4 @@
-import { Badge, Button, Card, Code, Group, ScrollArea, Stack, Text } from '@mantine/core';
-import { IconCode, IconExternalLink } from '@tabler/icons-react';
+import { Badge, Card, Code, Group, ScrollArea, Stack, Text } from '@mantine/core';
 import { useState } from 'react';
 
 /**
@@ -70,14 +69,21 @@ export type FileLineDiff = {
   removed: number;
 };
 
+/**
+ * Why a file has no inline diff. These used to end in "— view in Forgejo" next
+ * to a deep-link into the raw in-review snapshot; that link was retired in
+ * #3495 when snapshots became private (an anonymous click 404s, and a dead link
+ * is worse than none). The labels now just state the reason — the mod knows the
+ * file changed and why it isn't rendered, which is what the label is for.
+ */
 const SKIP_LABEL: Record<NonNullable<FileLineDiff['skipReason']>, string> = {
-  binary: 'Binary file — view in Forgejo',
-  'too-large': 'File too large to diff — view in Forgejo',
-  'diff-too-large': 'Diff too large to display — view in Forgejo',
-  'file-cap': 'Too many changed files — view this one in Forgejo',
+  binary: 'Binary file — no inline diff',
+  'too-large': 'File too large to diff',
+  'diff-too-large': 'Diff too large to display',
+  'file-cap': 'Too many changed files — this one not diffed',
 };
 
-export function FileDiffEntry({ file, forgejoUrl }: { file: FileLineDiff; forgejoUrl: string }) {
+export function FileDiffEntry({ file }: { file: FileLineDiff }) {
   const [open, setOpen] = useState(false);
   const elided = file.skipReason !== null;
 
@@ -127,23 +133,6 @@ export function FileDiffEntry({ file, forgejoUrl }: { file: FileLineDiff; forgej
           )}
         </Group>
       </Group>
-
-      {elided && (
-        <Group p={8} pt={0}>
-          <Button
-            component="a"
-            href={forgejoUrl}
-            target="_blank"
-            rel="noopener"
-            size="compact-xs"
-            variant="subtle"
-            leftSection={<IconCode size={12} />}
-            rightSection={<IconExternalLink size={10} />}
-          >
-            View in Forgejo
-          </Button>
-        </Group>
-      )}
 
       {open && !elided && (
         <ScrollArea.Autosize mah={320} style={{ background: PANEL_BG }}>

--- a/src/pages/api/internal/blocks/git-push.ts
+++ b/src/pages/api/internal/blocks/git-push.ts
@@ -127,11 +127,10 @@ const SLUG_RE = /^[a-z][a-z0-9-]{1,38}[a-z0-9]$/;
  * org matches; otherwise null. Pulled out as a pure function for unit
  * testing the M-WEBHOOK org gate without driving the full webhook handler.
  *
- * The shared FORGEJO_WEBHOOK_SECRET authenticates the Forgejo *instance*,
- * not a single repo/org — the same instance also serves the
- * `civitai-apps-review` org (anonymous in-review browsing) and could serve
- * others. Without this gate a signature-valid push to a same-slug repo in a
- * different org would drive a build + auto-approve of the canonical row.
+ * The shared FORGEJO_WEBHOOK_SECRET authenticates the Forgejo *instance*, not a
+ * single repo/org, and the instance hosts more than one org. Without this gate a
+ * signature-valid push to a same-slug repo in a different org would drive a
+ * build + auto-approve of the canonical row.
  */
 export function parseExpectedRepo(fullName: unknown, expectedOrg: string): { slug: string } | null {
   if (typeof fullName !== 'string' || !fullName.includes('/')) return null;

--- a/src/pages/api/webhooks/run-jobs/[[...run]].ts
+++ b/src/pages/api/webhooks/run-jobs/[[...run]].ts
@@ -23,6 +23,7 @@ import { checkImageExistence } from '~/server/jobs/confirm-image-existence';
 import { confirmMutes } from '~/server/jobs/confirm-mutes';
 import { confirmPendingBlockAttributions } from '~/server/jobs/confirm-pending-block-attributions';
 import { bulkPayoutBlockAttributions } from '~/server/jobs/bulk-payout-block-attributions';
+import { purgeReviewSnapshotsJob } from '~/server/jobs/purge-review-snapshots';
 import { reapDevTunnelsJob } from '~/server/jobs/reap-dev-tunnels';
 import { sweepStaleAgentReviewsJob } from '~/server/jobs/sweep-stale-agent-reviews';
 import { custodySweepJob } from '~/server/jobs/custody-sweep';
@@ -171,6 +172,7 @@ export const jobs: Job[] = [
   bulkPayoutBlockAttributions,
   reapDevTunnelsJob,
   sweepStaleAgentReviewsJob,
+  purgeReviewSnapshotsJob,
   checkImageExistence,
   fullImageExistence,
   rewardsAdImpressions,

--- a/src/server/jobs/__tests__/purge-review-snapshots.test.ts
+++ b/src/server/jobs/__tests__/purge-review-snapshots.test.ts
@@ -166,12 +166,12 @@ describe('purgeExpiredReviewSnapshots — the 30-day retention boundary', () => 
    * otherwise the assertion is tautological (it would pass for any window,
    * including zero). `due` and `notYetDue` straddle the 30-day mark by an hour.
    */
-  it('purges a request that is due and RETAINS one an hour short of the window', async () => {
-    const due = row('due-app', new Date(NOW.getTime() - REVIEW_SNAPSHOT_PURGE_AFTER_MS - 3600_000));
-    const notYetDue = row(
-      'not-due-app',
-      new Date(NOW.getTime() - REVIEW_SNAPSHOT_PURGE_AFTER_MS + 3600_000)
-    );
+  it('purges a request terminal 31 days ago and RETAINS one terminal 29 days ago', async () => {
+    // ABSOLUTE dates, deliberately not derived from the constant: fixtures
+    // expressed relative to REVIEW_SNAPSHOT_PURGE_AFTER_MS move with it, so
+    // they would straddle the boundary for ANY window value including zero.
+    const due = row('due-app', new Date('2026-06-30T00:00:00.000Z')); // 31d before NOW
+    const notYetDue = row('not-due-app', new Date('2026-07-02T00:00:00.000Z')); // 29d before NOW
     mockFindMany.mockImplementation(async (args: { where: Record<string, any> }) =>
       [due, notYetDue].filter(
         (r) =>
@@ -194,18 +194,15 @@ describe('purgeExpiredReviewSnapshots — the 30-day retention boundary', () => 
    * retained above becomes eligible once the full window has elapsed. Proves
    * the boundary is a delay, not a permanent exclusion.
    */
-  it('purges that same request once the full window HAS elapsed', async () => {
-    const notYetDue = row(
-      'not-due-app',
-      new Date(NOW.getTime() - REVIEW_SNAPSHOT_PURGE_AFTER_MS + 3600_000)
-    );
+  it('purges that same 29-day-old request once the clock reaches day 31', async () => {
+    const notYetDue = row('not-due-app', new Date('2026-07-02T00:00:00.000Z'));
     mockFindMany.mockImplementation(async (args: { where: Record<string, any> }) =>
       [notYetDue].filter(
         (r) => r.updatedAt > args.where.updatedAt.gt && r.updatedAt < args.where.updatedAt.lt
       )
     );
 
-    const later = new Date(NOW.getTime() + 2 * 3600_000);
+    const later = new Date('2026-08-02T00:00:00.000Z'); // 31d after the decision
     const result = await purgeExpiredReviewSnapshots({ now: later });
 
     expect(mockDelete).toHaveBeenCalledWith('not-due-app');

--- a/src/server/jobs/__tests__/purge-review-snapshots.test.ts
+++ b/src/server/jobs/__tests__/purge-review-snapshots.test.ts
@@ -52,6 +52,8 @@ const longAgo = (extraMs = 24 * 60 * 60 * 1000) =>
   new Date(NOW.getTime() - REVIEW_SNAPSHOT_PURGE_AFTER_MS - extraMs);
 
 type Row = { id: string; slug: string; status: string; updatedAt: Date };
+/** The shape of the where-clause the sweep builds, for predicate-applying mocks. */
+type PurgeWhere = { status: { in: string[] }; updatedAt: { gt: Date; lt: Date } };
 const row = (slug: string, updatedAt = longAgo(), status = 'rejected'): Row => ({
   id: `pubreq_${slug}`,
   slug,
@@ -172,7 +174,7 @@ describe('purgeExpiredReviewSnapshots — the 30-day retention boundary', () => 
     // they would straddle the boundary for ANY window value including zero.
     const due = row('due-app', new Date('2026-06-30T00:00:00.000Z')); // 31d before NOW
     const notYetDue = row('not-due-app', new Date('2026-07-02T00:00:00.000Z')); // 29d before NOW
-    mockFindMany.mockImplementation(async (args: { where: Record<string, any> }) =>
+    mockFindMany.mockImplementation(async (args: { where: PurgeWhere }) =>
       [due, notYetDue].filter(
         (r) =>
           args.where.status.in.includes(r.status) &&
@@ -196,7 +198,7 @@ describe('purgeExpiredReviewSnapshots — the 30-day retention boundary', () => 
    */
   it('purges that same 29-day-old request once the clock reaches day 31', async () => {
     const notYetDue = row('not-due-app', new Date('2026-07-02T00:00:00.000Z'));
-    mockFindMany.mockImplementation(async (args: { where: Record<string, any> }) =>
+    mockFindMany.mockImplementation(async (args: { where: PurgeWhere }) =>
       [notYetDue].filter(
         (r) => r.updatedAt > args.where.updatedAt.gt && r.updatedAt < args.where.updatedAt.lt
       )

--- a/src/server/jobs/__tests__/purge-review-snapshots.test.ts
+++ b/src/server/jobs/__tests__/purge-review-snapshots.test.ts
@@ -1,0 +1,316 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Coverage for the in-review snapshot retention sweep.
+ *
+ * The two properties that MUST hold, because getting either wrong destroys work
+ * a moderator or developer is relying on:
+ *  1. THE PENDING GATE — snapshots are keyed per-slug and overwritten on every
+ *     submit, so a purge triggered by an old rejected request must NOT delete a
+ *     snapshot a different, still-pending request for the same slug owns.
+ *  2. THE 30-DAY BOUNDARY — a request that went terminal less than
+ *     REVIEW_SNAPSHOT_PURGE_AFTER_MS ago is retained, not reclaimed.
+ */
+
+const { mockFindMany, mockFindFirst, mockDelete, mockLogToAxiom, mockGetJobDate, mockSetCursor } =
+  vi.hoisted(() => ({
+    mockFindMany: vi.fn(),
+    mockFindFirst: vi.fn(),
+    mockDelete: vi.fn(),
+    mockLogToAxiom: vi.fn(() => Promise.resolve(undefined)),
+    mockGetJobDate: vi.fn(),
+    mockSetCursor: vi.fn(() => Promise.resolve(undefined)),
+  }));
+
+vi.mock('~/server/db/client', () => ({
+  dbRead: { appBlockPublishRequest: { findMany: (...a: unknown[]) => mockFindMany(...a) } },
+  dbWrite: { appBlockPublishRequest: { findFirst: (...a: unknown[]) => mockFindFirst(...a) } },
+}));
+vi.mock('~/server/services/blocks/forgejo.service', () => ({
+  deleteReviewRepo: (...a: unknown[]) => mockDelete(...a),
+}));
+vi.mock('~/server/logging/client', () => ({
+  logToAxiom: (...a: unknown[]) => mockLogToAxiom(...a),
+}));
+// createJob wraps the handler in lock/metric machinery we don't need here — stub
+// it to hand back the bare handler (mirrors the sibling block-job tests).
+vi.mock('../job', () => ({
+  createJob: (_name: string, _cron: string, fn: () => unknown) => fn,
+  getJobDate: (...a: unknown[]) => mockGetJobDate(...a),
+}));
+
+import {
+  purgeExpiredReviewSnapshots,
+  purgeReviewSnapshotsJob,
+  REVIEW_SNAPSHOT_PURGE_AFTER_MS,
+  REVIEW_SNAPSHOT_PURGE_BATCH_SIZE,
+} from '../purge-review-snapshots';
+
+const NOW = new Date('2026-07-31T00:00:00.000Z');
+/** Terminal exactly this long ago = comfortably past the retention window. */
+const longAgo = (extraMs = 24 * 60 * 60 * 1000) =>
+  new Date(NOW.getTime() - REVIEW_SNAPSHOT_PURGE_AFTER_MS - extraMs);
+
+type Row = { id: string; slug: string; status: string; updatedAt: Date };
+const row = (slug: string, updatedAt = longAgo(), status = 'rejected'): Row => ({
+  id: `pubreq_${slug}`,
+  slug,
+  status,
+  updatedAt,
+});
+
+beforeEach(() => {
+  mockFindMany.mockReset();
+  mockFindFirst.mockReset();
+  mockDelete.mockReset();
+  mockLogToAxiom.mockReset();
+  mockLogToAxiom.mockReturnValue(Promise.resolve(undefined));
+  mockSetCursor.mockReset();
+  mockSetCursor.mockReturnValue(Promise.resolve(undefined));
+  mockGetJobDate.mockReset();
+  mockGetJobDate.mockResolvedValue([new Date(0), mockSetCursor]);
+  // Default: nothing pending, delete succeeds.
+  mockFindFirst.mockResolvedValue(null);
+  mockDelete.mockResolvedValue('deleted');
+});
+
+describe('purgeExpiredReviewSnapshots — the pending gate', () => {
+  /**
+   * 🔴 THE gate. Sequence this reproduces: v1 submitted → rejected 40 days ago;
+   * v2 submitted yesterday and is still pending. The snapshot repo now holds
+   * v2's source. Purging on v1's rejection would delete the in-flight review.
+   */
+  it('does NOT delete when a pending request exists for the same slug', async () => {
+    mockFindMany.mockResolvedValue([row('gen-matrix')]);
+    mockFindFirst.mockResolvedValue({ id: 'pubreq_v2_pending' });
+
+    const result = await purgeExpiredReviewSnapshots({ now: NOW });
+
+    expect(mockDelete).not.toHaveBeenCalled();
+    expect(result.skippedPending).toBe(1);
+    expect(result.deleted).toBe(0);
+  });
+
+  it('DOES delete when no pending request exists for the slug', async () => {
+    mockFindMany.mockResolvedValue([row('gen-matrix')]);
+    mockFindFirst.mockResolvedValue(null);
+
+    const result = await purgeExpiredReviewSnapshots({ now: NOW });
+
+    expect(mockDelete).toHaveBeenCalledWith('gen-matrix');
+    expect(result.deleted).toBe(1);
+    expect(result.skippedPending).toBe(0);
+  });
+
+  it('gates per SLUG, not per row — a pending sibling protects only its own slug', async () => {
+    mockFindMany.mockResolvedValue([row('protected-app'), row('free-app')]);
+    mockFindFirst.mockImplementation(async (args: { where: { slug: string } }) =>
+      args.where.slug === 'protected-app' ? { id: 'pubreq_pending' } : null
+    );
+
+    const result = await purgeExpiredReviewSnapshots({ now: NOW });
+
+    expect(mockDelete).toHaveBeenCalledTimes(1);
+    expect(mockDelete).toHaveBeenCalledWith('free-app');
+    expect(result.skippedPending).toBe(1);
+    expect(result.deleted).toBe(1);
+  });
+
+  it('queries the gate with status pending on the exact slug', async () => {
+    mockFindMany.mockResolvedValue([row('gen-matrix')]);
+
+    await purgeExpiredReviewSnapshots({ now: NOW });
+
+    expect(mockFindFirst).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { slug: 'gen-matrix', status: 'pending' } })
+    );
+  });
+
+  /**
+   * The blocking row can be seconds old while the triggering row is 30+ days
+   * old, so a lagging replica would hide exactly the row whose presence is
+   * load-bearing. The gate must read the primary.
+   */
+  it('reads the gate from the PRIMARY, not the replica', async () => {
+    const db = await import('~/server/db/client');
+    mockFindMany.mockResolvedValue([row('gen-matrix')]);
+
+    await purgeExpiredReviewSnapshots({ now: NOW });
+
+    // The gate's findFirst is bound to dbWrite; dbRead exposes no findFirst at all.
+    expect(mockFindFirst).toHaveBeenCalledTimes(1);
+    expect(
+      (db.dbRead.appBlockPublishRequest as Record<string, unknown>).findFirst
+    ).toBeUndefined();
+  });
+});
+
+describe('purgeExpiredReviewSnapshots — the 30-day retention boundary', () => {
+  it('is a single named constant of exactly 30 days', () => {
+    expect(REVIEW_SNAPSHOT_PURGE_AFTER_MS).toBe(30 * 24 * 60 * 60 * 1000);
+  });
+
+  it('selects only rows that went terminal MORE than the window ago', async () => {
+    mockFindMany.mockResolvedValue([]);
+
+    await purgeExpiredReviewSnapshots({ now: NOW });
+
+    const args = mockFindMany.mock.calls[0][0];
+    const cutoff: Date = args.where.updatedAt.lt;
+    expect(cutoff.getTime()).toBe(NOW.getTime() - REVIEW_SNAPSHOT_PURGE_AFTER_MS);
+  });
+
+  /**
+   * The boundary is enforced by the query predicate, so prove it against the
+   * predicate itself: a row that went terminal one hour short of the window
+   * falls outside `updatedAt < cutoff` and is therefore never a candidate.
+   */
+  it('retains a request that is not yet due (one hour short of the window)', async () => {
+    mockFindMany.mockResolvedValue([]);
+
+    await purgeExpiredReviewSnapshots({ now: NOW });
+
+    const cutoff: Date = mockFindMany.mock.calls[0][0].where.updatedAt.lt;
+    const notYetDue = new Date(NOW.getTime() - REVIEW_SNAPSHOT_PURGE_AFTER_MS + 60 * 60 * 1000);
+    const due = new Date(NOW.getTime() - REVIEW_SNAPSHOT_PURGE_AFTER_MS - 60 * 60 * 1000);
+
+    expect(notYetDue.getTime() < cutoff.getTime()).toBe(false); // excluded
+    expect(due.getTime() < cutoff.getTime()).toBe(true); // included
+    expect(mockDelete).not.toHaveBeenCalled();
+  });
+
+  it('only considers rejected/withdrawn — approved snapshots are out of scope', async () => {
+    mockFindMany.mockResolvedValue([]);
+
+    await purgeExpiredReviewSnapshots({ now: NOW });
+
+    const statuses = mockFindMany.mock.calls[0][0].where.status.in;
+    expect([...statuses].sort()).toEqual(['rejected', 'withdrawn']);
+    expect(statuses).not.toContain('approved');
+    expect(statuses).not.toContain('pending');
+  });
+});
+
+describe('purgeExpiredReviewSnapshots — batching, resumability, resilience', () => {
+  it('bounds the scan with the named batch size and takes oldest-first', async () => {
+    mockFindMany.mockResolvedValue([]);
+
+    await purgeExpiredReviewSnapshots({ now: NOW });
+
+    const args = mockFindMany.mock.calls[0][0];
+    expect(args.take).toBe(REVIEW_SNAPSHOT_PURGE_BATCH_SIZE);
+    expect(args.orderBy).toEqual({ updatedAt: 'asc' });
+  });
+
+  it('resumes from the stored cursor and advances it past the batch', async () => {
+    const cursor = new Date('2026-01-01T00:00:00.000Z');
+    const last = longAgo(1000);
+    mockGetJobDate.mockResolvedValue([cursor, mockSetCursor]);
+    mockFindMany.mockResolvedValue([row('a', longAgo(5000)), row('b', last)]);
+
+    await purgeExpiredReviewSnapshots({ now: NOW });
+
+    expect(mockFindMany.mock.calls[0][0].where.updatedAt.gt).toBe(cursor);
+    expect(mockSetCursor).toHaveBeenCalledWith(last);
+  });
+
+  it('is a no-op (and leaves the cursor alone) when nothing is due', async () => {
+    mockFindMany.mockResolvedValue([]);
+
+    const result = await purgeExpiredReviewSnapshots({ now: NOW });
+
+    expect(result).toMatchObject({ scanned: 0, candidates: 0, deleted: 0 });
+    expect(mockDelete).not.toHaveBeenCalled();
+    expect(mockSetCursor).not.toHaveBeenCalled();
+  });
+
+  it('dedupes to ONE delete per slug when several old requests share it', async () => {
+    mockFindMany.mockResolvedValue([
+      row('gen-matrix', longAgo(9000)),
+      row('gen-matrix', longAgo(8000), 'withdrawn'),
+      row('gen-matrix', longAgo(7000)),
+    ]);
+
+    const result = await purgeExpiredReviewSnapshots({ now: NOW });
+
+    expect(mockDelete).toHaveBeenCalledTimes(1);
+    expect(result.scanned).toBe(3);
+    expect(result.candidates).toBe(1);
+    expect(result.deleted).toBe(1);
+  });
+
+  it('counts an already-gone repo as success, not failure (idempotent re-run)', async () => {
+    mockFindMany.mockResolvedValue([row('gen-matrix')]);
+    mockDelete.mockResolvedValue('already-gone');
+
+    const result = await purgeExpiredReviewSnapshots({ now: NOW });
+
+    expect(result.alreadyGone).toBe(1);
+    expect(result.deleted).toBe(0);
+    expect(result.failed).toBe(0);
+  });
+
+  it('logs-and-continues past a per-repo failure', async () => {
+    mockFindMany.mockResolvedValue([row('bad'), row('good')]);
+    mockDelete.mockImplementation(async (slug: string) => {
+      if (slug === 'bad') throw new Error('forgejo 500');
+      return 'deleted';
+    });
+
+    const result = await purgeExpiredReviewSnapshots({ now: NOW });
+
+    expect(result.failed).toBe(1);
+    expect(result.deleted).toBe(1);
+    expect(mockDelete).toHaveBeenCalledWith('good');
+    expect(mockLogToAxiom).toHaveBeenCalledWith(
+      expect.objectContaining({ slug: 'bad', outcome: 'failed', level: 'error' }),
+      'webhooks'
+    );
+  });
+
+  it('logs a per-repo outcome for every slug it acts on', async () => {
+    mockFindMany.mockResolvedValue([row('a'), row('b')]);
+
+    await purgeExpiredReviewSnapshots({ now: NOW });
+
+    const slugsLogged = mockLogToAxiom.mock.calls
+      .map((c) => c[0] as { slug?: string })
+      .filter((d) => !!d.slug)
+      .map((d) => d.slug);
+    expect(slugsLogged).toEqual(['a', 'b']);
+  });
+});
+
+describe('purgeReviewSnapshotsJob wrapper', () => {
+  it('returns the sweep result', async () => {
+    mockFindMany.mockResolvedValue([row('gen-matrix')]);
+
+    const result = await (purgeReviewSnapshotsJob as unknown as () => Promise<{ deleted: number }>)();
+
+    expect(result.deleted).toBe(1);
+  });
+
+  it('FAIL-OPEN: swallows a thrown sweep failure so the runner is never crashed', async () => {
+    mockFindMany.mockRejectedValue(new Error('db down'));
+
+    const result = await (purgeReviewSnapshotsJob as unknown as () => Promise<{
+      error?: boolean;
+      deleted: number;
+    }>)();
+
+    expect(result.error).toBe(true);
+    expect(result.deleted).toBe(0);
+    expect(mockLogToAxiom).toHaveBeenCalledWith(
+      expect.objectContaining({ outcome: 'run-failed', level: 'error' }),
+      'webhooks'
+    );
+  });
+
+  it('stays silent on a no-op run', async () => {
+    mockFindMany.mockResolvedValue([]);
+
+    await (purgeReviewSnapshotsJob as unknown as () => Promise<unknown>)();
+
+    expect(mockLogToAxiom).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/jobs/__tests__/purge-review-snapshots.test.ts
+++ b/src/server/jobs/__tests__/purge-review-snapshots.test.ts
@@ -161,22 +161,55 @@ describe('purgeExpiredReviewSnapshots — the 30-day retention boundary', () => 
   });
 
   /**
-   * The boundary is enforced by the query predicate, so prove it against the
-   * predicate itself: a row that went terminal one hour short of the window
-   * falls outside `updatedAt < cutoff` and is therefore never a candidate.
+   * The boundary is enforced by the query predicate, so this drives it through
+   * a findMany mock that actually APPLIES the where-clause the sweep builds —
+   * otherwise the assertion is tautological (it would pass for any window,
+   * including zero). `due` and `notYetDue` straddle the 30-day mark by an hour.
    */
-  it('retains a request that is not yet due (one hour short of the window)', async () => {
-    mockFindMany.mockResolvedValue([]);
+  it('purges a request that is due and RETAINS one an hour short of the window', async () => {
+    const due = row('due-app', new Date(NOW.getTime() - REVIEW_SNAPSHOT_PURGE_AFTER_MS - 3600_000));
+    const notYetDue = row(
+      'not-due-app',
+      new Date(NOW.getTime() - REVIEW_SNAPSHOT_PURGE_AFTER_MS + 3600_000)
+    );
+    mockFindMany.mockImplementation(async (args: { where: Record<string, any> }) =>
+      [due, notYetDue].filter(
+        (r) =>
+          args.where.status.in.includes(r.status) &&
+          r.updatedAt > args.where.updatedAt.gt &&
+          r.updatedAt < args.where.updatedAt.lt
+      )
+    );
 
-    await purgeExpiredReviewSnapshots({ now: NOW });
+    const result = await purgeExpiredReviewSnapshots({ now: NOW });
 
-    const cutoff: Date = mockFindMany.mock.calls[0][0].where.updatedAt.lt;
-    const notYetDue = new Date(NOW.getTime() - REVIEW_SNAPSHOT_PURGE_AFTER_MS + 60 * 60 * 1000);
-    const due = new Date(NOW.getTime() - REVIEW_SNAPSHOT_PURGE_AFTER_MS - 60 * 60 * 1000);
+    expect(mockDelete).toHaveBeenCalledTimes(1);
+    expect(mockDelete).toHaveBeenCalledWith('due-app');
+    expect(mockDelete).not.toHaveBeenCalledWith('not-due-app');
+    expect(result.deleted).toBe(1);
+  });
 
-    expect(notYetDue.getTime() < cutoff.getTime()).toBe(false); // excluded
-    expect(due.getTime() < cutoff.getTime()).toBe(true); // included
-    expect(mockDelete).not.toHaveBeenCalled();
+  /**
+   * Same predicate-applying mock, walked forward in time: the row that was
+   * retained above becomes eligible once the full window has elapsed. Proves
+   * the boundary is a delay, not a permanent exclusion.
+   */
+  it('purges that same request once the full window HAS elapsed', async () => {
+    const notYetDue = row(
+      'not-due-app',
+      new Date(NOW.getTime() - REVIEW_SNAPSHOT_PURGE_AFTER_MS + 3600_000)
+    );
+    mockFindMany.mockImplementation(async (args: { where: Record<string, any> }) =>
+      [notYetDue].filter(
+        (r) => r.updatedAt > args.where.updatedAt.gt && r.updatedAt < args.where.updatedAt.lt
+      )
+    );
+
+    const later = new Date(NOW.getTime() + 2 * 3600_000);
+    const result = await purgeExpiredReviewSnapshots({ now: later });
+
+    expect(mockDelete).toHaveBeenCalledWith('not-due-app');
+    expect(result.deleted).toBe(1);
   });
 
   it('only considers rejected/withdrawn — approved snapshots are out of scope', async () => {

--- a/src/server/jobs/__tests__/purge-review-snapshots.test.ts
+++ b/src/server/jobs/__tests__/purge-review-snapshots.test.ts
@@ -5,9 +5,11 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
  *
  * The two properties that MUST hold, because getting either wrong destroys work
  * a moderator or developer is relying on:
- *  1. THE PENDING GATE — snapshots are keyed per-slug and overwritten on every
- *     submit, so a purge triggered by an old rejected request must NOT delete a
- *     snapshot a different, still-pending request for the same slug owns.
+ *  1. THE PROTECTION GATE — snapshots are keyed per-slug and overwritten on every
+ *     submit, and a terminal request does not reserve its slug, so a purge
+ *     triggered by an old rejected request must NOT delete a snapshot that a
+ *     different request for the same slug — pending OR approved, and possibly a
+ *     different owner's — currently holds.
  *  2. THE 30-DAY BOUNDARY — a request that went terminal less than
  *     REVIEW_SNAPSHOT_PURGE_AFTER_MS ago is retained, not reclaimed.
  */
@@ -42,9 +44,14 @@ vi.mock('../job', () => ({
 import {
   purgeExpiredReviewSnapshots,
   purgeReviewSnapshotsJob,
+  PURGEABLE_TERMINAL_STATUSES,
   REVIEW_SNAPSHOT_PURGE_AFTER_MS,
   REVIEW_SNAPSHOT_PURGE_BATCH_SIZE,
+  SNAPSHOT_PROTECTING_STATUSES,
 } from '../purge-review-snapshots';
+
+/** The DB pins this vocabulary: CHECK ("status" IN (…)) on the request table. */
+const ALL_STATUSES = ['pending', 'approved', 'rejected', 'withdrawn'] as const;
 
 const NOW = new Date('2026-07-31T00:00:00.000Z');
 /** Terminal exactly this long ago = comfortably past the retention window. */
@@ -76,7 +83,22 @@ beforeEach(() => {
   mockDelete.mockResolvedValue('deleted');
 });
 
-describe('purgeExpiredReviewSnapshots — the pending gate', () => {
+/**
+ * A `findFirst` mock that APPLIES the gate's where-clause against a fake table.
+ * Load-bearing: a mock that returns a blocking row unconditionally would pass
+ * for ANY status filter — including one that has stopped covering a status the
+ * gate is supposed to protect — so the predicate has to be evaluated for real.
+ */
+const gateOver =
+  (table: Array<{ id: string; slug: string; status: string }>) =>
+  async (args: { where: { slug: string; status: string | { in: string[] } } }) => {
+    const { slug, status } = args.where;
+    const matches = (s: string) =>
+      typeof status === 'string' ? status === s : status.in.includes(s);
+    return table.find((r) => r.slug === slug && matches(r.status)) ?? null;
+  };
+
+describe('purgeExpiredReviewSnapshots — the protection gate', () => {
   /**
    * 🔴 THE gate. Sequence this reproduces: v1 submitted → rejected 40 days ago;
    * v2 submitted yesterday and is still pending. The snapshot repo now holds
@@ -84,48 +106,89 @@ describe('purgeExpiredReviewSnapshots — the pending gate', () => {
    */
   it('does NOT delete when a pending request exists for the same slug', async () => {
     mockFindMany.mockResolvedValue([row('gen-matrix')]);
-    mockFindFirst.mockResolvedValue({ id: 'pubreq_v2_pending' });
+    mockFindFirst.mockImplementation(
+      gateOver([{ id: 'pubreq_v2_pending', slug: 'gen-matrix', status: 'pending' }])
+    );
 
     const result = await purgeExpiredReviewSnapshots({ now: NOW });
 
     expect(mockDelete).not.toHaveBeenCalled();
-    expect(result.skippedPending).toBe(1);
+    expect(result.skippedProtected).toBe(1);
     expect(result.deleted).toBe(0);
   });
 
-  it('DOES delete when no pending request exists for the slug', async () => {
+  /**
+   * 🔴 The same gate, one status over. A terminal request does NOT reserve its
+   * slug, so after A's rejection ages out the slug can have been taken by B and
+   * approved — at which point the snapshot holds B's live source, not A's. The
+   * file-level comment says approved snapshots are out of scope for this sweep;
+   * this is the assertion that makes that true of the CODE and not just of the
+   * eligibility list (which only decides which rows TRIGGER a purge).
+   */
+  it('does NOT delete when an APPROVED request owns the slug (different-owner takeover)', async () => {
+    mockFindMany.mockResolvedValue([row('gen-matrix')]); // user A, rejected 31d ago
+    mockFindFirst.mockImplementation(
+      gateOver([{ id: 'pubreq_b_approved', slug: 'gen-matrix', status: 'approved' }])
+    );
+
+    const result = await purgeExpiredReviewSnapshots({ now: NOW });
+
+    expect(mockDelete).not.toHaveBeenCalled();
+    expect(result.skippedProtected).toBe(1);
+    expect(result.deleted).toBe(0);
+  });
+
+  it('DOES delete when only terminal requests exist for the slug', async () => {
     mockFindMany.mockResolvedValue([row('gen-matrix')]);
-    mockFindFirst.mockResolvedValue(null);
+    mockFindFirst.mockImplementation(
+      gateOver([
+        { id: 'pubreq_old_rejected', slug: 'gen-matrix', status: 'rejected' },
+        { id: 'pubreq_old_withdrawn', slug: 'gen-matrix', status: 'withdrawn' },
+      ])
+    );
 
     const result = await purgeExpiredReviewSnapshots({ now: NOW });
 
     expect(mockDelete).toHaveBeenCalledWith('gen-matrix');
     expect(result.deleted).toBe(1);
-    expect(result.skippedPending).toBe(0);
+    expect(result.skippedProtected).toBe(0);
   });
 
-  it('gates per SLUG, not per row — a pending sibling protects only its own slug', async () => {
+  it('gates per SLUG, not per row — a protecting sibling protects only its own slug', async () => {
     mockFindMany.mockResolvedValue([row('protected-app'), row('free-app')]);
-    mockFindFirst.mockImplementation(async (args: { where: { slug: string } }) =>
-      args.where.slug === 'protected-app' ? { id: 'pubreq_pending' } : null
+    mockFindFirst.mockImplementation(
+      gateOver([{ id: 'pubreq_pending', slug: 'protected-app', status: 'pending' }])
     );
 
     const result = await purgeExpiredReviewSnapshots({ now: NOW });
 
     expect(mockDelete).toHaveBeenCalledTimes(1);
     expect(mockDelete).toHaveBeenCalledWith('free-app');
-    expect(result.skippedPending).toBe(1);
+    expect(result.skippedProtected).toBe(1);
     expect(result.deleted).toBe(1);
   });
 
-  it('queries the gate with status pending on the exact slug', async () => {
+  it('queries the gate for every protecting status on the exact slug', async () => {
     mockFindMany.mockResolvedValue([row('gen-matrix')]);
 
     await purgeExpiredReviewSnapshots({ now: NOW });
 
-    expect(mockFindFirst).toHaveBeenCalledWith(
-      expect.objectContaining({ where: { slug: 'gen-matrix', status: 'pending' } })
-    );
+    const where = mockFindFirst.mock.calls[0][0].where;
+    expect(where.slug).toBe('gen-matrix');
+    expect([...where.status.in].sort()).toEqual(['approved', 'pending']);
+  });
+
+  /**
+   * The two sets are meant to PARTITION the closed status vocabulary, which is
+   * what lets the gate be read as "not terminal for this sweep". A new status
+   * (or a status moved between the lists) that breaks the partition would leave
+   * a value that is neither purgeable nor protecting — a silent gap.
+   */
+  it('the purgeable and protecting sets partition the closed status vocabulary', () => {
+    const purgeable = [...PURGEABLE_TERMINAL_STATUSES] as string[];
+    const protecting = [...SNAPSHOT_PROTECTING_STATUSES] as string[];
+    expect([...purgeable, ...protecting].sort()).toEqual([...ALL_STATUSES].sort());
+    expect(purgeable.filter((s) => protecting.includes(s))).toEqual([]);
   });
 
   /**
@@ -139,11 +202,120 @@ describe('purgeExpiredReviewSnapshots — the pending gate', () => {
 
     await purgeExpiredReviewSnapshots({ now: NOW });
 
-    // The gate's findFirst is bound to dbWrite; dbRead exposes no findFirst at all.
-    expect(mockFindFirst).toHaveBeenCalledTimes(1);
+    // Every gate read (the pre-delete gate + the post-delete re-check) is bound
+    // to dbWrite; dbRead exposes no findFirst at all.
+    expect(mockFindFirst).toHaveBeenCalledTimes(2);
     expect(
       (db.dbRead.appBlockPublishRequest as Record<string, unknown>).findFirst
     ).toBeUndefined();
+  });
+});
+
+/**
+ * The gate cannot be perfectly tight: submit writes the snapshot before it
+ * inserts the row that protects it, so a submission starting between the gate
+ * read and the delete is invisible to the gate. The re-check does not close that
+ * window — it converts a silent broken review into a loud, actionable log line.
+ */
+describe('purgeExpiredReviewSnapshots — post-delete re-check', () => {
+  /** Gate read #1 sees nothing; the re-check (call #2) sees a new pending row. */
+  const raceAfterDelete = (pendingId: string) => {
+    let call = 0;
+    mockFindFirst.mockImplementation(async () => (++call === 1 ? null : { id: pendingId }));
+  };
+
+  it('logs at error level when a pending request appears after the delete', async () => {
+    mockFindMany.mockResolvedValue([row('gen-matrix')]);
+    raceAfterDelete('pubreq_raced');
+
+    const result = await purgeExpiredReviewSnapshots({ now: NOW });
+
+    expect(result.deleted).toBe(1);
+    expect(mockLogToAxiom).toHaveBeenCalledWith(
+      expect.objectContaining({
+        slug: 'gen-matrix',
+        outcome: 'deleted-under-new-submission',
+        pendingId: 'pubreq_raced',
+        level: 'error',
+      }),
+      'webhooks'
+    );
+  });
+
+  it('stays quiet on the normal path — no error log when nothing raced', async () => {
+    mockFindMany.mockResolvedValue([row('gen-matrix')]);
+
+    await purgeExpiredReviewSnapshots({ now: NOW });
+
+    const outcomes = mockLogToAxiom.mock.calls.map((c) => (c[0] as { outcome?: string }).outcome);
+    expect(outcomes).not.toContain('deleted-under-new-submission');
+    expect(outcomes).not.toContain('failed');
+  });
+
+  it('does not re-check (or warn) when the repo was already gone', async () => {
+    mockFindMany.mockResolvedValue([row('gen-matrix')]);
+    mockDelete.mockResolvedValue('already-gone');
+    raceAfterDelete('pubreq_raced');
+
+    const result = await purgeExpiredReviewSnapshots({ now: NOW });
+
+    // Nothing was destroyed, so there is nothing to warn about: only the gate ran.
+    expect(result.alreadyGone).toBe(1);
+    expect(mockFindFirst).toHaveBeenCalledTimes(1);
+    const outcomes = mockLogToAxiom.mock.calls.map((c) => (c[0] as { outcome?: string }).outcome);
+    expect(outcomes).not.toContain('deleted-under-new-submission');
+  });
+});
+
+describe('purgeExpiredReviewSnapshots — cancellation', () => {
+  /**
+   * The webhook drops this job's run-lock when its HTTP request closes, so the
+   * loop must stop rather than keep deleting past the lock.
+   */
+  it('stops the loop when the job context reports cancellation', async () => {
+    mockFindMany.mockResolvedValue([row('a'), row('b'), row('c')]);
+    let seen = 0;
+    const jobContext = {
+      checkIfCanceled: () => {
+        if (++seen > 1) throw new Error('Job was canceled');
+      },
+    };
+
+    await expect(purgeExpiredReviewSnapshots({ now: NOW, jobContext })).rejects.toThrow(
+      'Job was canceled'
+    );
+
+    // First slug processed, then the cancel stopped it — and because the sweep
+    // never reached the cursor write, the batch is simply re-walked next run.
+    expect(mockDelete).toHaveBeenCalledTimes(1);
+    expect(mockSetCursor).not.toHaveBeenCalled();
+  });
+
+  /**
+   * The cancel check sits OUTSIDE the per-slug try/catch. If it were inside, the
+   * per-repo "log and continue" handler would swallow it and the loop would run
+   * to completion — exactly what cancellation is supposed to prevent.
+   */
+  it('does not absorb the cancellation as a per-slug failure', async () => {
+    mockFindMany.mockResolvedValue([row('a'), row('b'), row('c')]);
+    const jobContext = {
+      checkIfCanceled: () => {
+        throw new Error('Job was canceled');
+      },
+    };
+
+    await expect(purgeExpiredReviewSnapshots({ now: NOW, jobContext })).rejects.toThrow(
+      'Job was canceled'
+    );
+    expect(mockDelete).not.toHaveBeenCalled();
+  });
+
+  it('runs to completion when no job context is supplied', async () => {
+    mockFindMany.mockResolvedValue([row('a'), row('b')]);
+
+    const result = await purgeExpiredReviewSnapshots({ now: NOW });
+
+    expect(result.deleted).toBe(2);
   });
 });
 

--- a/src/server/jobs/purge-review-snapshots.ts
+++ b/src/server/jobs/purge-review-snapshots.ts
@@ -1,0 +1,219 @@
+import { dbRead, dbWrite } from '~/server/db/client';
+import { logToAxiom } from '~/server/logging/client';
+import { createJob, getJobDate } from './job';
+
+/**
+ * RETENTION SWEEP — purge the in-review source snapshot of an app whose publish
+ * request has been terminally rejected/withdrawn for long enough.
+ *
+ * Every submission pushes the developer's source into a per-slug in-review
+ * snapshot repo so moderators can review it. Once a request is rejected or
+ * withdrawn nobody reads that snapshot again, but it sits there holding a full
+ * copy of third-party source indefinitely. Keeping unreviewed third-party code
+ * around forever, for no reader, is the kind of quiet accumulation that turns
+ * one future misconfiguration into a large disclosure. So we reclaim it.
+ *
+ * WHY THIS IS SAFE TO DELETE: the snapshot is a DERIVED CACHE, never the system
+ * of record. A ZIP submission's bundle lives in object storage under
+ * `bundleKey`; a push submission's source lives in the canonical app repo at the
+ * pinned `forgejoCommitSha`. Purging a snapshot loses nothing irreplaceable.
+ *
+ * WHY A SWEEP AND NOT AN INLINE DELETE ON REJECT: a sweep survives a missed
+ * event (a reject that happened while this was broken/undeployed still gets
+ * collected on a later run), it is naturally batched and bounded, and it keeps
+ * the reject path — a moderator-facing write — free of a slow external call
+ * that could fail it. Mirrors the existing ephemeral-resource reapers
+ * (`reap-dev-tunnels`, `sweep-stale-agent-reviews`).
+ */
+
+/**
+ * How long a publish request must have sat in a terminal (rejected/withdrawn)
+ * state before its slug's snapshot is reclaimed.
+ *
+ * The delay is the point: it leaves a window in which a moderator can revisit a
+ * contested rejection, or a developer can appeal, with the exact submitted tree
+ * still browsable. Shortening this trades that window for storage; lengthening
+ * it just holds third-party source longer. 30 days is comfortably past any
+ * realistic appeal.
+ */
+export const REVIEW_SNAPSHOT_PURGE_AFTER_MS = 30 * 24 * 60 * 60 * 1000;
+
+/**
+ * Max terminal rows examined per run. Bounds the work AND the number of delete
+ * calls a single run can make against the review source host, so a large
+ * backlog drains over several runs instead of in one burst.
+ */
+export const REVIEW_SNAPSHOT_PURGE_BATCH_SIZE = 50;
+
+/** KeyValue cursor key — the resume point between runs. */
+const PURGE_CURSOR_KEY = 'purge-review-snapshots';
+
+/**
+ * Terminal statuses that make a slug's snapshot eligible for reclamation.
+ *
+ * 🔴 `approved` is deliberately NOT here. An approved app's snapshot is out of
+ * scope for this sweep — approval is a different lifecycle with its own
+ * artifacts, and reclaiming there is a separate decision.
+ */
+const PURGEABLE_TERMINAL_STATUSES = ['rejected', 'withdrawn'] as const;
+
+export type PurgeReviewSnapshotsResult = {
+  /** Terminal rows examined this run. */
+  scanned: number;
+  /** Distinct slugs considered (rows dedupe to one delete attempt per slug). */
+  candidates: number;
+  /** Snapshots actually reclaimed. */
+  deleted: number;
+  /** Snapshots that were already gone — idempotent re-run, counted not failed. */
+  alreadyGone: number;
+  /** Slugs held back because a pending request still owns the snapshot. */
+  skippedPending: number;
+  /** Per-slug failures; the sweep continued past each. */
+  failed: number;
+};
+
+const logPurge = (data: Record<string, unknown>) =>
+  logToAxiom({ name: 'purge-review-snapshots', ...data }, 'webhooks').catch(() => undefined);
+
+/**
+ * Core sweep (exported for unit tests, mirroring the service-fn +
+ * thin-job-wrapper split used by the sibling reapers).
+ */
+export async function purgeExpiredReviewSnapshots(
+  opts: { now?: Date; batchSize?: number } = {}
+): Promise<PurgeReviewSnapshotsResult> {
+  const now = opts.now ?? new Date();
+  const batchSize = opts.batchSize ?? REVIEW_SNAPSHOT_PURGE_BATCH_SIZE;
+  const cutoff = new Date(now.getTime() - REVIEW_SNAPSHOT_PURGE_AFTER_MS);
+
+  const result: PurgeReviewSnapshotsResult = {
+    scanned: 0,
+    candidates: 0,
+    deleted: 0,
+    alreadyGone: 0,
+    skippedPending: 0,
+    failed: 0,
+  };
+
+  // Resumable cursor over the terminal-transition timestamp. `updatedAt` is the
+  // reliable "when did this row go terminal" signal: `reviewedAt` is NULL for
+  // withdrawn rows (the DB's review-pair CHECK exempts them), so it cannot be
+  // used as the sole ordering key. A terminal row is never written again, so its
+  // `updatedAt` is stable — which is what makes it safe to order and resume on.
+  const [cursor, setCursor] = await getJobDate(PURGE_CURSOR_KEY, new Date(0));
+
+  const rows = await dbRead.appBlockPublishRequest.findMany({
+    where: {
+      status: { in: [...PURGEABLE_TERMINAL_STATUSES] },
+      // gt cursor: don't re-walk what previous runs already handled.
+      // lt cutoff: THE RETENTION GATE — not yet 30 days terminal, not eligible.
+      updatedAt: { gt: cursor, lt: cutoff },
+    },
+    orderBy: { updatedAt: 'asc' },
+    take: batchSize,
+    select: { id: true, slug: true, status: true, updatedAt: true },
+  });
+
+  result.scanned = rows.length;
+  if (rows.length === 0) return result;
+
+  // One delete attempt per slug even if several of its old requests aged out in
+  // the same batch — the snapshot is per-slug, not per-request.
+  const slugs = Array.from(new Set(rows.map((r) => r.slug)));
+  result.candidates = slugs.length;
+
+  const { deleteReviewRepo } = await import('~/server/services/blocks/forgejo.service');
+
+  for (const slug of slugs) {
+    try {
+      // 🔴 THE CORRECTNESS GATE. Snapshots are keyed per-slug and OVERWRITTEN on
+      // every submit, so the repo a 40-day-old rejection points at may today
+      // hold a brand-new, still-pending submission's source. Deleting it would
+      // destroy an in-flight review. `pending` is the only non-terminal status,
+      // so "a pending row exists for this slug" is exactly "someone still needs
+      // this snapshot" — and we hold back.
+      //
+      // Read from the PRIMARY (`dbWrite`), not the replica: the row that must
+      // block us can be seconds old (a developer resubmitting right now) while
+      // the row that made us eligible is 30+ days old. A replica lagging by even
+      // a moment would hide exactly the row whose presence is load-bearing, and
+      // the failure mode is destroying live work — so this read does not get to
+      // be eventually consistent.
+      const pending = await dbWrite.appBlockPublishRequest.findFirst({
+        where: { slug, status: 'pending' },
+        select: { id: true },
+      });
+      if (pending) {
+        result.skippedPending += 1;
+        logPurge({ type: 'info', slug, outcome: 'skipped-pending', pendingId: pending.id });
+        continue;
+      }
+
+      const outcome = await deleteReviewRepo(slug);
+      if (outcome === 'deleted') result.deleted += 1;
+      else result.alreadyGone += 1;
+      logPurge({ type: 'info', slug, outcome });
+    } catch (error) {
+      result.failed += 1;
+      logPurge({
+        type: 'error',
+        level: 'error',
+        slug,
+        outcome: 'failed',
+        message: (error as Error)?.message,
+      });
+    }
+  }
+
+  // Advance the cursor past the whole batch, INCLUDING rows that failed or were
+  // held back. Deliberate: this sweep must always make forward progress. Parking
+  // the cursor on a permanently-failing slug would wedge ALL future purging on
+  // one bad repo, and a purge miss costs storage, not safety — the actual
+  // security control is that snapshots are private, not that they are deleted.
+  // Failures are logged at error level with the slug so they stay actionable,
+  // and a held-back slug re-enters the queue the next time it goes terminal.
+  // Rows are ordered ascending and every row is < cutoff, so this can never
+  // advance past something that was not yet due.
+  const maxUpdatedAt = rows[rows.length - 1].updatedAt;
+  await setCursor(maxUpdatedAt);
+
+  return result;
+}
+
+/**
+ * Cadence: hourly. The eligibility gate is 30 days, so cadence sets only how
+ * quickly the backlog drains (batchSize per run), never whether something is
+ * reclaimed on time.
+ *
+ * FAIL-OPEN: a janitor failure must never mark the runner failed or page. We
+ * catch, log, and return a benign summary; the next tick retries.
+ */
+export const purgeReviewSnapshotsJob = createJob(
+  'purge-review-snapshots',
+  '20 * * * *',
+  async () => {
+    try {
+      const result = await purgeExpiredReviewSnapshots();
+      // Stay silent on a no-op run; only report when the sweep did something.
+      if (result.scanned > 0) logPurge({ type: 'info', outcome: 'summary', ...result });
+      return result;
+    } catch (error) {
+      logPurge({
+        type: 'error',
+        level: 'error',
+        outcome: 'run-failed',
+        message: (error as Error)?.message,
+        stack: (error as Error)?.stack,
+      });
+      return {
+        scanned: 0,
+        candidates: 0,
+        deleted: 0,
+        alreadyGone: 0,
+        skippedPending: 0,
+        failed: 0,
+        error: true as const,
+      };
+    }
+  }
+);

--- a/src/server/jobs/purge-review-snapshots.ts
+++ b/src/server/jobs/purge-review-snapshots.ts
@@ -1,5 +1,6 @@
 import { dbRead, dbWrite } from '~/server/db/client';
 import { logToAxiom } from '~/server/logging/client';
+import type { JobContext } from './job';
 import { createJob, getJobDate } from './job';
 
 /**
@@ -49,13 +50,31 @@ export const REVIEW_SNAPSHOT_PURGE_BATCH_SIZE = 50;
 const PURGE_CURSOR_KEY = 'purge-review-snapshots';
 
 /**
+ * The status vocabulary is closed at the DB — `CHECK ("status" IN ('pending',
+ * 'approved','rejected','withdrawn'))` — which is what lets the two sets below
+ * be written as an exact partition rather than a best-effort list.
+ *
  * Terminal statuses that make a slug's snapshot eligible for reclamation.
  *
  * 🔴 `approved` is deliberately NOT here. An approved app's snapshot is out of
  * scope for this sweep — approval is a different lifecycle with its own
- * artifacts, and reclaiming there is a separate decision.
+ * artifacts, and reclaiming there is a separate decision. That exclusion is
+ * ENFORCED by `SNAPSHOT_PROTECTING_STATUSES` below, not just by this list:
+ * eligibility is per-ROW while the snapshot is per-SLUG, so a row's status
+ * alone cannot decide whether the snapshot may go.
  */
-const PURGEABLE_TERMINAL_STATUSES = ['rejected', 'withdrawn'] as const;
+export const PURGEABLE_TERMINAL_STATUSES = ['rejected', 'withdrawn'] as const;
+
+/**
+ * Statuses whose presence on a slug PROTECTS that slug's snapshot — the exact
+ * complement of `PURGEABLE_TERMINAL_STATUSES` over the closed vocabulary, i.e.
+ * "not terminal for the purposes of this sweep".
+ *
+ * `pending` — someone is mid-review and the snapshot is the thing under review.
+ * `approved` — the snapshot belongs to a live app, which this sweep does not
+ * touch by design (see above).
+ */
+export const SNAPSHOT_PROTECTING_STATUSES = ['pending', 'approved'] as const;
 
 export type PurgeReviewSnapshotsResult = {
   /** Terminal rows examined this run. */
@@ -66,8 +85,8 @@ export type PurgeReviewSnapshotsResult = {
   deleted: number;
   /** Snapshots that were already gone — idempotent re-run, counted not failed. */
   alreadyGone: number;
-  /** Slugs held back because a pending request still owns the snapshot. */
-  skippedPending: number;
+  /** Slugs held back because a protecting request still owns the snapshot. */
+  skippedProtected: number;
   /** Per-slug failures; the sweep continued past each. */
   failed: number;
 };
@@ -80,7 +99,18 @@ const logPurge = (data: Record<string, unknown>) =>
  * thin-job-wrapper split used by the sibling reapers).
  */
 export async function purgeExpiredReviewSnapshots(
-  opts: { now?: Date; batchSize?: number } = {}
+  opts: {
+    now?: Date;
+    batchSize?: number;
+    /**
+     * Cancellation hook from the job runner. The webhook releases this job's
+     * Redis run-lock when its HTTP request closes, so without a cancel check a
+     * long batch keeps deleting after the lock is gone and a re-trigger can run
+     * beside it. Deletes are idempotent so the overlap is not destructive, but
+     * checking makes the lock mean what it looks like it means.
+     */
+    jobContext?: Pick<JobContext, 'checkIfCanceled'>;
+  } = {}
 ): Promise<PurgeReviewSnapshotsResult> {
   const now = opts.now ?? new Date();
   const batchSize = opts.batchSize ?? REVIEW_SNAPSHOT_PURGE_BATCH_SIZE;
@@ -91,15 +121,26 @@ export async function purgeExpiredReviewSnapshots(
     candidates: 0,
     deleted: 0,
     alreadyGone: 0,
-    skippedPending: 0,
+    skippedProtected: 0,
     failed: 0,
   };
 
   // Resumable cursor over the terminal-transition timestamp. `updatedAt` is the
-  // reliable "when did this row go terminal" signal: `reviewedAt` is NULL for
-  // withdrawn rows (the DB's review-pair CHECK exempts them), so it cannot be
-  // used as the sole ordering key. A terminal row is never written again, so its
-  // `updatedAt` is stable — which is what makes it safe to order and resume on.
+  // best available "when did this row go terminal" signal: `reviewedAt` is NULL
+  // for withdrawn rows (the DB's review-pair CHECK exempts them), so it cannot
+  // be used as the sole ordering key.
+  //
+  // ⚠️ `updatedAt` is NOT frozen once a row goes terminal — Prisma's `@updatedAt`
+  // bumps on any later write, and one such write exists today: the reject path
+  // clears the request's deploy-state fields right after setting the terminal
+  // status. Both directions are benign at this scale: a bump before the sweep
+  // first sees the row only restarts its 30-day clock (that one lands seconds
+  // later), and a bump after the cursor passed it re-presents the row for an
+  // idempotent re-delete. What this is NOT robust against is a future BULK write
+  // over terminal rows, which would silently reset every retention clock at
+  // once. Keying on a frozen decision timestamp is the fix if that becomes real
+  // — it changes which rows are eligible, so it is a deliberate follow-up, not
+  // something to slip in here.
   const [cursor, setCursor] = await getJobDate(PURGE_CURSOR_KEY, new Date(0));
 
   const rows = await dbRead.appBlockPublishRequest.findMany({
@@ -125,13 +166,23 @@ export async function purgeExpiredReviewSnapshots(
   const { deleteReviewRepo } = await import('~/server/services/blocks/forgejo.service');
 
   for (const slug of slugs) {
+    // Checked OUTSIDE the per-slug try on purpose: that catch exists to absorb
+    // one repo's failure and continue, and swallowing a cancellation there would
+    // do the exact opposite of stopping.
+    opts.jobContext?.checkIfCanceled();
     try {
       // 🔴 THE CORRECTNESS GATE. Snapshots are keyed per-slug and OVERWRITTEN on
-      // every submit, so the repo a 40-day-old rejection points at may today
-      // hold a brand-new, still-pending submission's source. Deleting it would
-      // destroy an in-flight review. `pending` is the only non-terminal status,
-      // so "a pending row exists for this slug" is exactly "someone still needs
-      // this snapshot" — and we hold back.
+      // every submit, and a terminal request does not reserve its slug — so the
+      // repo a 40-day-old rejected row points at may today hold an entirely
+      // different request's source, possibly a different owner's. The row that
+      // made us eligible therefore cannot decide the delete on its own; only the
+      // slug's CURRENT holder can.
+      //
+      // `SNAPSHOT_PROTECTING_STATUSES` is the complement of the purgeable set
+      // over the closed status vocabulary, so "a protecting row exists for this
+      // slug" is exactly "the snapshot is not in scope for reclamation right
+      // now" — covering both a review in flight (`pending`) and a live app
+      // (`approved`) — and we hold back.
       //
       // Read from the PRIMARY (`dbWrite`), not the replica: the row that must
       // block us can be seconds old (a developer resubmitting right now) while
@@ -139,13 +190,19 @@ export async function purgeExpiredReviewSnapshots(
       // a moment would hide exactly the row whose presence is load-bearing, and
       // the failure mode is destroying live work — so this read does not get to
       // be eventually consistent.
-      const pending = await dbWrite.appBlockPublishRequest.findFirst({
-        where: { slug, status: 'pending' },
-        select: { id: true },
+      const protectedBy = await dbWrite.appBlockPublishRequest.findFirst({
+        where: { slug, status: { in: [...SNAPSHOT_PROTECTING_STATUSES] } },
+        select: { id: true, status: true },
       });
-      if (pending) {
-        result.skippedPending += 1;
-        logPurge({ type: 'info', slug, outcome: 'skipped-pending', pendingId: pending.id });
+      if (protectedBy) {
+        result.skippedProtected += 1;
+        logPurge({
+          type: 'info',
+          slug,
+          outcome: 'skipped-protected',
+          protectedById: protectedBy.id,
+          protectedByStatus: protectedBy.status,
+        });
         continue;
       }
 
@@ -153,6 +210,34 @@ export async function purgeExpiredReviewSnapshots(
       if (outcome === 'deleted') result.deleted += 1;
       else result.alreadyGone += 1;
       logPurge({ type: 'info', slug, outcome });
+
+      // POST-DELETE RE-CHECK — the gate above cannot be perfectly tight, because
+      // submit writes the snapshot BEFORE it inserts the row that protects it
+      // (`ensureReviewRepo` + `commitFiles` run first, the `create` last). A
+      // submission that begins between this slug's gate read and this delete is
+      // therefore invisible to the gate. The window is one round-trip, and the
+      // outcome is a live request whose snapshot is missing: the in-app diff
+      // still renders (it reads object storage), but the review preview cannot
+      // start. Re-reading here does not close the race — it makes it LOUD, so
+      // the mod-facing failure has an explanation and the developer can simply
+      // resubmit. Reordering the submit path so the row lands before the
+      // snapshot push is the real fix; that is a user-facing write path and is
+      // deliberately out of scope for this sweep.
+      if (outcome === 'deleted') {
+        const raced = await dbWrite.appBlockPublishRequest.findFirst({
+          where: { slug, status: 'pending' },
+          select: { id: true },
+        });
+        if (raced) {
+          logPurge({
+            type: 'error',
+            level: 'error',
+            slug,
+            outcome: 'deleted-under-new-submission',
+            pendingId: raced.id,
+          });
+        }
+      }
     } catch (error) {
       result.failed += 1;
       logPurge({
@@ -174,6 +259,14 @@ export async function purgeExpiredReviewSnapshots(
   // and a held-back slug re-enters the queue the next time it goes terminal.
   // Rows are ordered ascending and every row is < cutoff, so this can never
   // advance past something that was not yet due.
+  //
+  // ACCEPTED LIMITATION: because the next run resumes with `gt`, a row sharing
+  // the last row's exact `updatedAt` that fell outside this batch's `take` is
+  // never revisited. The column is `timestamptz(6)` and the rows are
+  // independent moderator/developer actions, so colliding at microsecond
+  // resolution is vanishingly unlikely, and the cost if it happens is one
+  // snapshot that is never reclaimed — storage, never a wrong delete. Accepted
+  // rather than paid for with a composite `(updatedAt, id)` keyset cursor.
   const maxUpdatedAt = rows[rows.length - 1].updatedAt;
   await setCursor(maxUpdatedAt);
 
@@ -191,9 +284,9 @@ export async function purgeExpiredReviewSnapshots(
 export const purgeReviewSnapshotsJob = createJob(
   'purge-review-snapshots',
   '20 * * * *',
-  async () => {
+  async (jobContext) => {
     try {
-      const result = await purgeExpiredReviewSnapshots();
+      const result = await purgeExpiredReviewSnapshots({ jobContext });
       // Stay silent on a no-op run; only report when the sweep did something.
       if (result.scanned > 0) logPurge({ type: 'info', outcome: 'summary', ...result });
       return result;
@@ -210,7 +303,7 @@ export const purgeReviewSnapshotsJob = createJob(
         candidates: 0,
         deleted: 0,
         alreadyGone: 0,
-        skippedPending: 0,
+        skippedProtected: 0,
         failed: 0,
         error: true as const,
       };

--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -1892,7 +1892,7 @@ export const blocksRouter = router({
 
   /**
    * ONE-OFF moderator-only backfill — flip every EXISTING in-review snapshot
-   * repo to private (#3495). New snapshots are created private, but the create
+   * repo to private (#3498). New snapshots are created private, but the create
    * call is idempotent on an existing repo, so pre-change snapshots keep their
    * original visibility until this walks the org and patches them.
    *

--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -1891,6 +1891,37 @@ export const blocksRouter = router({
     }),
 
   /**
+   * ONE-OFF moderator-only backfill — flip every EXISTING in-review snapshot
+   * repo to private (#3495). New snapshots are created private, but the create
+   * call is idempotent on an existing repo, so pre-change snapshots keep their
+   * original visibility until this walks the org and patches them.
+   *
+   * 🔴 A human must run this ONCE for the privacy fix to be complete. Safe to
+   * re-run: already-private repos are skipped, a vanished repo counts `missing`,
+   * and per-repo failures are collected rather than thrown. `dryRun` reports
+   * exactly which slugs a real run would touch without changing anything.
+   */
+  backfillReviewRepoPrivacy: moderatorProcedure
+    .use(enforceAppBlocksFlag)
+    .input(
+      z.object({
+        limit: z.number().int().min(1).max(1000).optional(),
+        dryRun: z.boolean().optional(),
+      })
+    )
+    .mutation(async ({ ctx, input }) => {
+      if (!ctx.user?.isModerator) {
+        throw throwAuthorizationError(
+          'Review snapshot privacy backfill is restricted to civitai team'
+        );
+      }
+      const { backfillReviewRepoPrivacy } = await import(
+        '~/server/services/blocks/review-repo-privacy.service'
+      );
+      return backfillReviewRepoPrivacy({ limit: input.limit, dryRun: input.dryRun });
+    }),
+
+  /**
    * Reject a pending publish request. Reason is required
    * (≥`PUBLISH_REJECTION_REASON_MIN` — the shared `OFFSITE_MOD_REASON_MIN`, 3 —
    * chars) and shown to the dev inline on /apps/my-submissions.

--- a/src/server/services/blocks/__tests__/forgejo.service.reviewSnapshot.test.ts
+++ b/src/server/services/blocks/__tests__/forgejo.service.reviewSnapshot.test.ts
@@ -1,0 +1,223 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Coverage for the in-review SNAPSHOT repo lifecycle on the Forgejo client:
+ * create-private (the #3495 security fix), enumerate, flip-to-private (backfill)
+ * and delete (retention).
+ *
+ * Strategy mirrors forgejo.service.test.ts: mock global.fetch and assert on the
+ * URLs + bodies the service sends. No real HTTP, no real Forgejo.
+ */
+
+vi.mock('~/env/server', () => ({
+  env: {
+    FORGEJO_BASE_URL: 'https://forgejo.example',
+    FORGEJO_ADMIN_TOKEN: 'tok-test',
+    FORGEJO_WEBHOOK_SECRET: 'sec-test',
+    APPS_DOMAIN: 'civit.ai',
+    FORGEJO_API_TIMEOUT_MS: 15000,
+    FORGEJO_COMMIT_TIMEOUT_MS: 120000,
+  },
+}));
+
+type FetchCall = { url: string; init?: RequestInit };
+
+function makeFetchMock() {
+  const calls: FetchCall[] = [];
+  const responses: Array<Response> = [];
+  const fn = vi.fn(async (url: URL | string, init?: RequestInit) => {
+    calls.push({ url: String(url), init });
+    if (responses.length === 0) {
+      throw new Error(`fetch mock: no queued response for ${String(url)}`);
+    }
+    return responses.shift()!;
+  });
+  return {
+    fn,
+    calls,
+    enqueue(body: unknown, status = 200) {
+      const text = body == null ? '' : JSON.stringify(body);
+      responses.push(new Response(text, { status, headers: { 'Content-Type': 'application/json' } }));
+    },
+    enqueueRaw(response: Response) {
+      responses.push(response);
+    },
+  };
+}
+
+let fm: ReturnType<typeof makeFetchMock>;
+
+beforeEach(() => {
+  fm = makeFetchMock();
+  vi.stubGlobal('fetch', fm.fn);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+const bodyOf = (call: FetchCall) => JSON.parse(String(call.init?.body ?? '{}'));
+
+describe('ensureReviewRepo — snapshot visibility', () => {
+  /**
+   * 🔴 THE SECURITY ASSERTION. In-review snapshots hold the full source of an
+   * UNAPPROVED third-party submission, keyed by a guessable slug. `private:true`
+   * is the only control that survives a change to how requests reach the review
+   * source host — which is exactly the composition that made this a bug.
+   */
+  it('creates the snapshot repo PRIVATE', async () => {
+    const { ensureReviewRepo } = await import('../forgejo.service');
+    fm.enqueue({ id: 1 }); // org create
+    fm.enqueue({ id: 2 }); // repo create
+
+    await ensureReviewRepo('gen-matrix');
+
+    const repoCreate = fm.calls.find((c) => c.url.endsWith('/orgs/civitai-apps-review/repos'));
+    expect(repoCreate, 'repo-create call').toBeTruthy();
+    expect(bodyOf(repoCreate!).private).toBe(true);
+    // auto_init must survive the change — commitFiles pushes to `main` right after.
+    expect(bodyOf(repoCreate!).auto_init).toBe(true);
+  });
+
+  it('keeps the containing org private too', async () => {
+    const { ensureReviewRepo } = await import('../forgejo.service');
+    fm.enqueue({ id: 1 });
+    fm.enqueue({ id: 2 });
+
+    await ensureReviewRepo('gen-matrix');
+
+    const orgCreate = fm.calls.find((c) => c.url.endsWith('/api/v1/orgs'));
+    expect(bodyOf(orgCreate!).visibility).toBe('private');
+  });
+
+  it('stays idempotent: 409/422 on an existing repo is not an error', async () => {
+    const { ensureReviewRepo } = await import('../forgejo.service');
+    fm.enqueue({ message: 'org exists' }, 422);
+    fm.enqueue({ message: 'repo exists' }, 409);
+
+    await expect(ensureReviewRepo('gen-matrix')).resolves.toBeUndefined();
+  });
+});
+
+describe('deleteReviewRepo', () => {
+  it('DELETEs the per-slug repo and reports `deleted`', async () => {
+    const { deleteReviewRepo } = await import('../forgejo.service');
+    fm.enqueueRaw(new Response(null, { status: 204 }));
+
+    await expect(deleteReviewRepo('gen-matrix')).resolves.toBe('deleted');
+
+    expect(fm.calls[0].url).toBe('https://forgejo.example/api/v1/repos/civitai-apps-review/gen-matrix');
+    expect(fm.calls[0].init?.method).toBe('DELETE');
+  });
+
+  /**
+   * Idempotency is what lets the sweep be re-run / resumed freely: a repo that
+   * a previous run already reclaimed must not read as a failure.
+   */
+  it('treats 404 as SUCCESS (`already-gone`), not an error', async () => {
+    const { deleteReviewRepo } = await import('../forgejo.service');
+    fm.enqueue({ message: 'not found' }, 404);
+
+    await expect(deleteReviewRepo('gen-matrix')).resolves.toBe('already-gone');
+  });
+
+  it('throws on a real failure (403/500) so the caller counts it as failed', async () => {
+    const { deleteReviewRepo } = await import('../forgejo.service');
+    fm.enqueue({ message: 'nope' }, 403);
+    await expect(deleteReviewRepo('gen-matrix')).rejects.toThrow(/403/);
+
+    fm.enqueue({ message: 'boom' }, 500);
+    await expect(deleteReviewRepo('gen-matrix')).rejects.toThrow(/500/);
+  });
+
+  /**
+   * The snapshot org is a derived cache; the canonical `civitai-apps` org is the
+   * system of record for a pushed app. This function must be structurally unable
+   * to point at the latter.
+   */
+  it('can only ever target the in-review org, never the canonical app org', async () => {
+    const { deleteReviewRepo } = await import('../forgejo.service');
+    fm.enqueueRaw(new Response(null, { status: 204 }));
+
+    await deleteReviewRepo('gen-matrix');
+
+    expect(fm.calls[0].url).toContain('/repos/civitai-apps-review/');
+    expect(fm.calls[0].url).not.toContain('/repos/civitai-apps/');
+  });
+
+  it('url-encodes the slug', async () => {
+    const { deleteReviewRepo } = await import('../forgejo.service');
+    fm.enqueueRaw(new Response(null, { status: 204 }));
+
+    await deleteReviewRepo('weird/slug');
+
+    expect(fm.calls[0].url).toContain('weird%2Fslug');
+  });
+});
+
+describe('setReviewRepoPrivate', () => {
+  it('PATCHes private:true on the per-slug repo', async () => {
+    const { setReviewRepoPrivate } = await import('../forgejo.service');
+    fm.enqueue({ id: 1, private: true });
+
+    await expect(setReviewRepoPrivate('gen-matrix')).resolves.toBe('updated');
+
+    expect(fm.calls[0].url).toBe('https://forgejo.example/api/v1/repos/civitai-apps-review/gen-matrix');
+    expect(fm.calls[0].init?.method).toBe('PATCH');
+    expect(bodyOf(fm.calls[0])).toEqual({ private: true });
+  });
+
+  it('reports `missing` on 404 rather than throwing (tolerates a vanished repo)', async () => {
+    const { setReviewRepoPrivate } = await import('../forgejo.service');
+    fm.enqueue({ message: 'not found' }, 404);
+
+    await expect(setReviewRepoPrivate('gen-matrix')).resolves.toBe('missing');
+  });
+
+  it('throws on a non-404 failure', async () => {
+    const { setReviewRepoPrivate } = await import('../forgejo.service');
+    fm.enqueue({ message: 'nope' }, 403);
+
+    await expect(setReviewRepoPrivate('gen-matrix')).rejects.toThrow(/403/);
+  });
+});
+
+describe('listReviewRepos', () => {
+  it('pages until a short page and returns name + private for each', async () => {
+    const { listReviewRepos } = await import('../forgejo.service');
+    fm.enqueue([
+      { name: 'a', private: false },
+      { name: 'b', private: true },
+    ]);
+    fm.enqueue([{ name: 'c', private: false }]);
+
+    const repos = await listReviewRepos({ perPage: 2 });
+
+    expect(repos).toEqual([
+      { name: 'a', private: false },
+      { name: 'b', private: true },
+      { name: 'c', private: false },
+    ]);
+    expect(fm.calls).toHaveLength(2);
+    expect(fm.calls[0].url).toContain('page=1&limit=2');
+    expect(fm.calls[1].url).toContain('page=2&limit=2');
+  });
+
+  it('returns empty when the org does not exist yet (404), rather than throwing', async () => {
+    const { listReviewRepos } = await import('../forgejo.service');
+    fm.enqueue({ message: 'not found' }, 404);
+
+    await expect(listReviewRepos()).resolves.toEqual([]);
+  });
+
+  it('stops at maxPages so a looping pager can never spin forever', async () => {
+    const { listReviewRepos } = await import('../forgejo.service');
+    // Always a FULL page → the "short page" stop condition never fires.
+    for (let i = 0; i < 5; i++) fm.enqueue([{ name: `r${i}`, private: false }]);
+
+    const repos = await listReviewRepos({ perPage: 1, maxPages: 3 });
+
+    expect(repos).toHaveLength(3);
+    expect(fm.calls).toHaveLength(3);
+  });
+});

--- a/src/server/services/blocks/__tests__/forgejo.service.reviewSnapshot.test.ts
+++ b/src/server/services/blocks/__tests__/forgejo.service.reviewSnapshot.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 /**
  * Coverage for the in-review SNAPSHOT repo lifecycle on the Forgejo client:
- * create-private (the #3495 security fix), enumerate, flip-to-private (backfill)
+ * create-private (the #3498 security fix), enumerate, flip-to-private (backfill)
  * and delete (retention).
  *
  * Strategy mirrors forgejo.service.test.ts: mock global.fetch and assert on the

--- a/src/server/services/blocks/__tests__/review-repo-privacy.service.test.ts
+++ b/src/server/services/blocks/__tests__/review-repo-privacy.service.test.ts
@@ -1,0 +1,146 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Coverage for the one-off "flip existing in-review snapshots to private"
+ * backfill. The properties that matter are the ones that make it safe for a
+ * human to run it, re-run it, and trust the report: idempotent, tolerant of a
+ * vanished repo, log-and-continue on a per-repo failure, and a dryRun that
+ * changes nothing while still naming what it would touch.
+ */
+
+const { mockList, mockSetPrivate, mockLogToAxiom } = vi.hoisted(() => ({
+  mockList: vi.fn(),
+  mockSetPrivate: vi.fn(),
+  mockLogToAxiom: vi.fn(() => Promise.resolve(undefined)),
+}));
+
+vi.mock('../forgejo.service', () => ({
+  listReviewRepos: (...a: unknown[]) => mockList(...a),
+  setReviewRepoPrivate: (...a: unknown[]) => mockSetPrivate(...a),
+}));
+vi.mock('~/server/logging/client', () => ({
+  logToAxiom: (...a: unknown[]) => mockLogToAxiom(...a),
+}));
+
+import { backfillReviewRepoPrivacy } from '../review-repo-privacy.service';
+
+beforeEach(() => {
+  mockList.mockReset();
+  mockSetPrivate.mockReset();
+  mockSetPrivate.mockResolvedValue('updated');
+  mockLogToAxiom.mockReset();
+  mockLogToAxiom.mockReturnValue(Promise.resolve(undefined));
+});
+
+describe('backfillReviewRepoPrivacy', () => {
+  it('flips the public repos and leaves the already-private ones untouched', async () => {
+    mockList.mockResolvedValue([
+      { name: 'a', private: false },
+      { name: 'b', private: true },
+      { name: 'c', private: false },
+    ]);
+
+    const result = await backfillReviewRepoPrivacy();
+
+    expect(mockSetPrivate.mock.calls.map((c) => c[0])).toEqual(['a', 'c']);
+    expect(result).toMatchObject({
+      scanned: 3,
+      updated: 2,
+      alreadyPrivate: 1,
+      missing: 0,
+      dryRun: false,
+    });
+    expect(result.updatedSlugs).toEqual(['a', 'c']);
+    expect(result.failed).toEqual([]);
+  });
+
+  /** Re-running after a completed backfill must be a pure no-op. */
+  it('is idempotent: a second run over an all-private org patches nothing', async () => {
+    mockList.mockResolvedValue([
+      { name: 'a', private: true },
+      { name: 'b', private: true },
+    ]);
+
+    const result = await backfillReviewRepoPrivacy();
+
+    expect(mockSetPrivate).not.toHaveBeenCalled();
+    expect(result).toMatchObject({ scanned: 2, updated: 0, alreadyPrivate: 2 });
+  });
+
+  it('counts a repo that vanished mid-run as `missing`, not failed', async () => {
+    mockList.mockResolvedValue([{ name: 'a', private: false }]);
+    mockSetPrivate.mockResolvedValue('missing');
+
+    const result = await backfillReviewRepoPrivacy();
+
+    expect(result.missing).toBe(1);
+    expect(result.updated).toBe(0);
+    expect(result.failed).toEqual([]);
+  });
+
+  it('logs-and-continues past a per-repo failure', async () => {
+    mockList.mockResolvedValue([
+      { name: 'bad', private: false },
+      { name: 'good', private: false },
+    ]);
+    mockSetPrivate.mockImplementation(async (slug: string) => {
+      if (slug === 'bad') throw new Error('forgejo 403');
+      return 'updated';
+    });
+
+    const result = await backfillReviewRepoPrivacy();
+
+    expect(result.failed).toEqual([{ slug: 'bad', error: 'forgejo 403' }]);
+    expect(result.updated).toBe(1);
+    expect(mockSetPrivate).toHaveBeenCalledWith('good');
+  });
+
+  it('dryRun names the slugs it would flip but issues no PATCH', async () => {
+    mockList.mockResolvedValue([
+      { name: 'a', private: false },
+      { name: 'b', private: true },
+    ]);
+
+    const result = await backfillReviewRepoPrivacy({ dryRun: true });
+
+    expect(mockSetPrivate).not.toHaveBeenCalled();
+    expect(result).toMatchObject({ dryRun: true, updated: 0, alreadyPrivate: 1 });
+    expect(result.updatedSlugs).toEqual(['a']);
+  });
+
+  it('honours `limit`', async () => {
+    mockList.mockResolvedValue([
+      { name: 'a', private: false },
+      { name: 'b', private: false },
+      { name: 'c', private: false },
+    ]);
+
+    const result = await backfillReviewRepoPrivacy({ limit: 2 });
+
+    expect(result.scanned).toBe(2);
+    expect(mockSetPrivate).toHaveBeenCalledTimes(2);
+  });
+
+  it('logs a per-repo outcome plus a summary', async () => {
+    mockList.mockResolvedValue([{ name: 'a', private: false }]);
+
+    await backfillReviewRepoPrivacy();
+
+    const payloads = mockLogToAxiom.mock.calls.map((c) => c[0] as Record<string, unknown>);
+    expect(payloads).toContainEqual(
+      expect.objectContaining({ slug: 'a', outcome: 'updated' })
+    );
+    expect(payloads).toContainEqual(
+      expect.objectContaining({ outcome: 'summary', scanned: 1, updated: 1 })
+    );
+  });
+
+  it('handles an org with no repos at all', async () => {
+    mockList.mockResolvedValue([]);
+
+    const result = await backfillReviewRepoPrivacy();
+
+    expect(result).toMatchObject({ scanned: 0, updated: 0, alreadyPrivate: 0 });
+    expect(mockSetPrivate).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/services/blocks/forgejo.service.ts
+++ b/src/server/services/blocks/forgejo.service.ts
@@ -597,14 +597,24 @@ export async function ensureReviewRepo(slug: string): Promise<void> {
   // immediately push to `main` (Forgejo refuses to push to a missing
   // branch). 409 / 422 = already exists.
   //
-  // `private: false` is deliberate: the security boundary on
-  // forgejo.civitai.com is oauth2-proxy (GH `oauth` team gate), which
-  // sits in front of every Forgejo request. Inside that boundary,
-  // making review repos public lets mods anonymously browse the file
-  // tree from /apps/review's deep-link without needing a separate
-  // Forgejo login session (Forgejo's own login form is currently
-  // throwing CSRF errors for moderator browsing flows — orthogonal
-  // issue, tracked separately).
+  // 🔴 `private: true` is load-bearing, NOT a default. These snapshots hold the
+  // FULL SOURCE of a third-party submission that has NOT been approved yet —
+  // unreviewed code belonging to someone else, keyed by a guessable app slug.
+  // Nothing needs anonymous read to make the product work: the review build
+  // authenticates to the review source host with its own credential, and mods
+  // read the submission through the in-app diff in the review modal rather than
+  // by browsing the raw repo. So `private` costs us nothing and is the only
+  // control that holds no matter how the request reaches the host.
+  //
+  // This was `private: false` until #3495. That flag leaned on an
+  // authentication layer sitting in front of every request to the review source
+  // host — true when it was written, no longer true after that host's routing
+  // was later changed for an unrelated reason. Two individually-reasonable
+  // changes composed into anonymous public read of unapproved third-party
+  // source. DO NOT flip this back to `false` for browsing convenience: the repo
+  // itself must be the boundary, so that no future routing/auth change upstream
+  // can silently re-open it.
+  //
   // auto_init:true makes Forgejo materialise a real git repo on disk, which on
   // first submit is the slow part of the review-repo path (it shares the same
   // worst-case as the bundle commit). Use the generous commit timeout so a
@@ -616,7 +626,7 @@ export async function ensureReviewRepo(slug: string): Promise<void> {
       body: JSON.stringify({
         name: slug,
         description: `Pending publish-request bundle for ${slug}.`,
-        private: false,
+        private: true,
         auto_init: true,
         default_branch: 'main',
       }),
@@ -627,6 +637,84 @@ export async function ensureReviewRepo(slug: string): Promise<void> {
     const body = await repoRes.text().catch(() => '');
     throw new Error(`Forgejo review repo create ${repoRes.status}: ${body.slice(0, 240)}`);
   }
+}
+
+/**
+ * Page through every repo in the in-review org. Used by the one-off privacy
+ * backfill to enumerate snapshots created BEFORE `ensureReviewRepo` started
+ * setting `private: true` — the create call is idempotent on an existing repo,
+ * so a re-submit does NOT retroactively flip an old repo's visibility.
+ *
+ * Bounded: stops at `maxPages` so a runaway/looping pager can never spin
+ * forever against the API.
+ */
+export async function listReviewRepos(
+  opts: { perPage?: number; maxPages?: number } = {}
+): Promise<Array<{ name: string; private: boolean }>> {
+  const perPage = opts.perPage ?? 50;
+  const maxPages = opts.maxPages ?? 100;
+  const out: Array<{ name: string; private: boolean }> = [];
+  for (let page = 1; page <= maxPages; page++) {
+    const res = await fjFetch(
+      `/api/v1/orgs/${FORGEJO_REVIEW_ORG}/repos?page=${page}&limit=${perPage}`
+    );
+    // 404 = the org has never been created (no submissions yet) — an empty
+    // result, not an error. Anything else non-2xx is a real failure.
+    if (res.status === 404) return out;
+    const rows = await unwrap<Array<{ name: string; private: boolean }>>(res);
+    if (!rows || rows.length === 0) return out;
+    for (const r of rows) out.push({ name: r.name, private: !!r.private });
+    if (rows.length < perPage) return out;
+  }
+  return out;
+}
+
+/**
+ * Flip an in-review snapshot repo to private. Idempotent — Forgejo accepts a
+ * PATCH that sets `private: true` on an already-private repo, and a 404 (repo
+ * gone) is reported as `missing` rather than thrown, so the backfill can be
+ * re-run safely at any time.
+ *
+ * Scoped to the in-review org on purpose: nothing here should ever be able to
+ * mutate the visibility of a canonical `civitai-apps/<slug>` repo.
+ */
+export async function setReviewRepoPrivate(
+  slug: string
+): Promise<'updated' | 'missing'> {
+  const res = await fjFetch(`/api/v1/repos/${FORGEJO_REVIEW_ORG}/${encodeURIComponent(slug)}`, {
+    method: 'PATCH',
+    body: JSON.stringify({ private: true }),
+  });
+  if (res.status === 404) return 'missing';
+  if (!res.ok) {
+    const body = await res.text().catch(() => '');
+    throw new Error(`Forgejo review repo patch ${res.status}: ${body.slice(0, 240)}`);
+  }
+  return 'updated';
+}
+
+/**
+ * Delete an in-review snapshot repo. Idempotent: a 404 (already gone) is
+ * SUCCESS, reported as `already-gone` so a caller can distinguish "I reclaimed
+ * something" from "there was nothing to reclaim" without either being an error.
+ *
+ * Deliberately scoped to the in-review org — this function cannot be pointed at
+ * `civitai-apps/<slug>`, which is the system of record for a pushed app. The
+ * in-review repo is a DERIVED CACHE: a ZIP submission's bundle lives in object
+ * storage under `bundleKey`, and a push submission's source lives in the
+ * canonical repo at the pinned `forgejoCommitSha`. Purging a snapshot therefore
+ * loses nothing that cannot be rebuilt.
+ */
+export async function deleteReviewRepo(slug: string): Promise<'deleted' | 'already-gone'> {
+  const res = await fjFetch(`/api/v1/repos/${FORGEJO_REVIEW_ORG}/${encodeURIComponent(slug)}`, {
+    method: 'DELETE',
+  });
+  if (res.status === 404) return 'already-gone';
+  if (!res.ok && res.status !== 204) {
+    const body = await res.text().catch(() => '');
+    throw new Error(`Forgejo review repo delete ${res.status}: ${body.slice(0, 240)}`);
+  }
+  return 'deleted';
 }
 
 /**

--- a/src/server/services/blocks/forgejo.service.ts
+++ b/src/server/services/blocks/forgejo.service.ts
@@ -606,7 +606,7 @@ export async function ensureReviewRepo(slug: string): Promise<void> {
   // by browsing the raw repo. So `private` costs us nothing and is the only
   // control that holds no matter how the request reaches the host.
   //
-  // This was `private: false` until #3495. That flag leaned on an
+  // This was `private: false` until #3498. That flag leaned on an
   // authentication layer sitting in front of every request to the review source
   // host — true when it was written, no longer true after that host's routing
   // was later changed for an unrelated reason. Two individually-reasonable

--- a/src/server/services/blocks/publish-request.service.ts
+++ b/src/server/services/blocks/publish-request.service.ts
@@ -4716,8 +4716,9 @@ async function getPreviousApprovedFiles(
  * Re-fetches the pending bundle (MinIO ZIP path or Forgejo push path, mirroring
  * getPublishRequestScreenshots) + the previous approved bundle's bytes, then
  * runs the pure, bounded computeBundleLineDiff. Binary / oversized / huge-diff
- * files are explicitly marked elided (never inlined) so the UI shows the Forgejo
- * fallback. First version ⇒ every file is a whole-file add.
+ * files are explicitly marked elided (never inlined) so the UI labels them with
+ * the reason instead of rendering them. First version ⇒ every file is a
+ * whole-file add.
  *
  * Mod-only at the router layer.
  */

--- a/src/server/services/blocks/review-repo-privacy.service.ts
+++ b/src/server/services/blocks/review-repo-privacy.service.ts
@@ -1,0 +1,107 @@
+import { logToAxiom } from '~/server/logging/client';
+
+/**
+ * ONE-OFF BACKFILL — flip every EXISTING in-review snapshot repo to private.
+ *
+ * `ensureReviewRepo` now creates snapshots with `private: true`, but that only
+ * fixes repos created from this change forward. The create call is idempotent
+ * on an already-existing repo (Forgejo answers 409/422 and changes nothing), so
+ * a re-submit of an old app does NOT retroactively flip its snapshot. Every
+ * snapshot created before this change therefore stays readable until something
+ * walks the org and patches it — which is what this does.
+ *
+ * 🔴 The privacy fix is INCOMPLETE until a human runs this once. Until then the
+ * already-created snapshots keep whatever visibility they were created with.
+ *
+ * Properties (it is expected to be re-run, possibly repeatedly):
+ *  - IDEMPOTENT: setting `private: true` on an already-private repo is a no-op,
+ *    and we skip those without even issuing the PATCH.
+ *  - TOLERANT: a repo that vanished between the LIST and the PATCH is counted
+ *    `missing`, not failed.
+ *  - LOG-AND-CONTINUE: a per-repo failure is recorded in `failed[]` and the
+ *    walk continues, so one bad repo cannot strand the rest.
+ *  - OBSERVABLE: one structured log line per repo acted on, plus a summary.
+ */
+
+export type BackfillReviewRepoPrivacyParams = {
+  /** Cap the number of repos processed this run. Omit = all. */
+  limit?: number;
+  /** Preview only: enumerate + classify, but issue no PATCH. */
+  dryRun?: boolean;
+};
+
+export type BackfillReviewRepoPrivacyResult = {
+  /** Repos enumerated from the in-review org (after `limit`). */
+  scanned: number;
+  /** Repos that were public and are now private (0 when `dryRun`). */
+  updated: number;
+  /** Repos already private — the steady state on a re-run. */
+  alreadyPrivate: number;
+  /** Repos that disappeared between the LIST and the PATCH. */
+  missing: number;
+  dryRun: boolean;
+  /** Slugs that were (or, under `dryRun`, would be) flipped. */
+  updatedSlugs: string[];
+  /** Per-repo failures — the walk continued past each of these. */
+  failed: { slug: string; error: string }[];
+};
+
+const logBackfill = (data: Record<string, unknown>) =>
+  logToAxiom({ name: 'backfill-review-repo-privacy', ...data }, 'webhooks').catch(() => undefined);
+
+export async function backfillReviewRepoPrivacy(
+  params: BackfillReviewRepoPrivacyParams = {}
+): Promise<BackfillReviewRepoPrivacyResult> {
+  const { limit, dryRun = false } = params;
+  const { listReviewRepos, setReviewRepoPrivate } = await import('./forgejo.service');
+
+  const all = await listReviewRepos();
+  const repos = typeof limit === 'number' ? all.slice(0, limit) : all;
+
+  const result: BackfillReviewRepoPrivacyResult = {
+    scanned: repos.length,
+    updated: 0,
+    alreadyPrivate: 0,
+    missing: 0,
+    dryRun,
+    updatedSlugs: [],
+    failed: [],
+  };
+
+  for (const repo of repos) {
+    if (repo.private) {
+      result.alreadyPrivate += 1;
+      continue;
+    }
+    // Record the intent BEFORE the dryRun short-circuit so a preview run tells
+    // the operator exactly which slugs a real run would touch.
+    result.updatedSlugs.push(repo.name);
+    if (dryRun) {
+      logBackfill({ type: 'info', slug: repo.name, outcome: 'would-update' });
+      continue;
+    }
+    try {
+      const outcome = await setReviewRepoPrivate(repo.name);
+      if (outcome === 'missing') result.missing += 1;
+      else result.updated += 1;
+      logBackfill({ type: 'info', slug: repo.name, outcome });
+    } catch (err) {
+      const error = err instanceof Error ? err.message : String(err);
+      result.failed.push({ slug: repo.name, error });
+      logBackfill({ type: 'error', level: 'error', slug: repo.name, outcome: 'failed', error });
+    }
+  }
+
+  logBackfill({
+    type: 'info',
+    outcome: 'summary',
+    scanned: result.scanned,
+    updated: result.updated,
+    alreadyPrivate: result.alreadyPrivate,
+    missing: result.missing,
+    failed: result.failed.length,
+    dryRun,
+  });
+
+  return result;
+}

--- a/src/tests/pages/apps/review-diff-panels.browser.test.tsx
+++ b/src/tests/pages/apps/review-diff-panels.browser.test.tsx
@@ -122,3 +122,59 @@ describe('reviewDiffPanels — dark-theme-aware backgrounds (Bug 2)', () => {
     assertNoLightOnlyDiffBg();
   });
 });
+
+/**
+ * #3498 regression guard for the ELIDED-file row.
+ *
+ * A file that cannot be diffed inline (binary, too large, over the diff/file
+ * cap) used to render a per-file button linking straight out to the raw
+ * in-review snapshot, and its label ended in "— view in Forgejo". That
+ * affordance was removed; the row now just states the reason.
+ *
+ * This is the only place that guard can be asserted for real: an elided row only
+ * exists when `FileDiffEntry` is mounted with a non-null `skipReason`, so a
+ * "no external link" assertion made anywhere the component isn't mounted (e.g.
+ * against the review modal, whose code-diff panel is collapsed by default) is
+ * vacuous — it passes on the unfixed code too.
+ */
+const ELIDED_LABELS: Array<[NonNullable<FileLineDiff['skipReason']>, string]> = [
+  ['binary', 'Binary file — no inline diff'],
+  ['too-large', 'File too large to diff'],
+  ['diff-too-large', 'Diff too large to display'],
+  ['file-cap', 'Too many changed files — this one not diffed'],
+];
+
+const elidedFile = (skipReason: NonNullable<FileLineDiff['skipReason']>): FileLineDiff => ({
+  path: 'assets/logo.png',
+  changeKind: 'changed',
+  skipReason,
+  added: 0,
+  removed: 0,
+  hunks: [],
+});
+
+describe('reviewDiffPanels — an elided file offers no external link (#3498)', () => {
+  for (const [skipReason, label] of ELIDED_LABELS) {
+    test(`skipReason "${skipReason}" states the reason and renders no link out`, async () => {
+      const { container } = await renderWithProviders(
+        <FileDiffEntry file={elidedFile(skipReason)} />
+      );
+
+      // The row is mounted and the reason is what the mod is shown instead.
+      await expect.element(page.getByText(label)).toBeInTheDocument();
+      await expect.element(page.getByText('assets/logo.png')).toBeInTheDocument();
+
+      // 🔴 THE GUARD: no anchor at all — not the old button, not any other
+      // deep-link out of the in-app diff.
+      expect(container.querySelectorAll('a').length, 'anchors inside the file row').toBe(0);
+      expect(document.querySelectorAll('a[href]').length, 'anchors on the page').toBe(0);
+      expect(page.getByText('View in Forgejo').elements()).toHaveLength(0);
+
+      // Clicking an elided row must not expand a link into existence either —
+      // an elided entry has nothing to expand.
+      await page.getByText('assets/logo.png').click();
+      expect(document.querySelectorAll('a[href]').length, 'anchors after click').toBe(0);
+      expect(page.getByText('View in Forgejo').elements()).toHaveLength(0);
+    });
+  }
+});

--- a/src/tests/pages/apps/review-diff-panels.browser.test.tsx
+++ b/src/tests/pages/apps/review-diff-panels.browser.test.tsx
@@ -105,7 +105,7 @@ describe('reviewDiffPanels — dark-theme-aware backgrounds (Bug 2)', () => {
         },
       ],
     };
-    renderWithProviders(<FileDiffEntry file={file} forgejoUrl="https://forge.example/x" />);
+    renderWithProviders(<FileDiffEntry file={file} />);
 
     // Collapsed by default → no diff panel painted yet.
     expect(


### PR DESCRIPTION
## The problem

When a developer submits an app for review, we push their source into a per-slug **in-review snapshot repository** so moderators can read it. Those snapshots were created with **broader read access than intended** — they hold the full source of a submission that has **not been approved yet**, i.e. someone else's unreviewed code.

## How it happened

Neither change that produced this was wrong on its own.

1. The snapshots were created with relaxed visibility **deliberately**, with a comment explaining why: an access control sitting elsewhere in the request path meant the relaxed setting only ever widened access *to reviewers*. That was true when it was written.
2. Later, that other layer was changed for an unrelated reason, and the property the comment depended on no longer held.

Change 1 was correct given the world it was written in. Change 2 was correct given its own goal. The setting from change 1 was never re-checked against the world change 2 created, and there was nothing to force that — the justification lived in a code comment describing a property of a system owned somewhere else.

That's the shape of the bug worth remembering: **a security decision that depends on a property owned somewhere else, with no mechanism that re-checks it.** The fix below deliberately moves the boundary into the repository itself, so it holds regardless of how a request arrives.

## What each change does

**1. Snapshots are created private** (`ensureReviewRepo`). Nothing needs relaxed read: the review build authenticates with its own credential, and moderators read submissions through the in-app diff. The replaced comment now states the real posture and says not to flip it back without re-checking the surrounding auth posture.

**2. A moderator-only backfill for existing snapshots** (`blocks.backfillReviewRepoPrivacy`). The create call is idempotent on an already-existing repo, so a re-submit does **not** retroactively change an old repo's visibility — pre-existing snapshots keep their original setting until something walks the org and patches them. Built to be re-run: already-private repos are skipped without a PATCH, a repo that vanished mid-run counts `missing` rather than failed, per-repo failures are collected and the walk continues, and `dryRun` reports exactly which slugs a real run would touch while changing nothing. **This requires a human to run it — see below.**

**3. The raw-source deep-link in the review modal is retired.** Once snapshots are private, the "View full source" button and the per-file external fallback both fail for the moderator who clicks them, and a dead link is worse than none — it reads as a working affordance and sends the reviewer somewhere broken mid-review. Moderators already have the in-app code diff in the same modal; that is now the sole source-review path, and elided files (binary / too large) say *why* they have no inline diff instead of linking out. The `reviewRepoUrl` / `pushCommitUrl` service values are **kept** on the payload — a richer in-app file browser is being designed separately and will reuse them. Only the user-facing dead link is removed.

> **Known gap until that browser lands:** a moderator reviewing a file the diff cannot render (binary, or over the size cap) now has no path to those bytes. Worth stating to the mod team explicitly.

**4. Retention: snapshots are reclaimed 30 days after a terminal decision** (`purge-review-snapshots` job). Once a request is rejected or withdrawn nobody reads its snapshot again, but it sits there holding a full copy of third-party source indefinitely. Safe to delete because the snapshot is a **derived cache, never the system of record**: a ZIP submission's bundle lives in object storage under `bundleKey`, and a push submission's source lives in the canonical repo at the pinned `forgejoCommitSha`.

Implemented as a **sweep**, not an inline delete on the reject path, so a decision made while this was undeployed or broken still gets collected later, and so a moderator-facing write never depends on a slow external call. Bounded per run (50 rows), resumable via a `KeyValue` cursor, log-and-continue per repo, fail-open. Window is a single named constant `REVIEW_SNAPSHOT_PURGE_AFTER_MS`.

### The correctness gate in the sweep

Snapshots are keyed **per-slug and overwritten on every submit**, so the repo a 40-day-old rejection points at may today hold a brand-new, still-pending submission's source. Purging on the old rejection would destroy an in-flight review.

The sweep holds back any slug with a pending publish request, and reads that check **from the primary, not the replica** — the blocking row can be seconds old while the triggering row is 30+ days old, so a lagging replica would hide exactly the row whose presence is load-bearing, and the failure mode is destroying live work.

## 🔴 Two manual steps a human owes before this is complete

**A. Run the backfill.** Merging fixes new snapshots only. Every snapshot created before this merge keeps its original visibility until a moderator runs `blocks.backfillReviewRepoPrivacy` **once**. Suggested: `{ dryRun: true }` first to see the slug list, then `{}` for real. Safe to re-run. **Run it in the same window as the merge.**

**B. Refresh the scheduler.** A newly-registered recurring job in this codebase is **not live on deploy** — the external scheduler does not sync on start or restart. `purge-review-snapshots` will not run until `GET /refresh` is hit on the scheduler. To verify one run manually without waiting for the cron, trigger it directly at the jobs webhook: `?run=purge-review-snapshots` (`&noCheck=true` to bypass the run lock). Expect `{ scanned, candidates, deleted, alreadyGone, skippedPending, failed }`.

Note the retention sweep is a no-op until (B) is done, and the visibility fix is incomplete until (A) is done. Neither blocks the other.

## No DB migration

Nothing here needs a schema change. The resume cursor uses the existing `KeyValue` table via `getJobDate`, and the sweep reads existing columns (`status`, `slug`, `updatedAt`).

## Verified vs not

**Verified locally:**
- `src/server/services/blocks` + `src/server/jobs` unit suites: **120 files / 2034 tests passing** (baseline at `main`: 117 / 1992). +3 files, +42 tests, zero regressions.
- **15 mutation checks, all killed** — every guard was broken, the failure confirmed, and the file restored:
  - `private: true` → `false`; `setReviewRepoPrivate` patching `false`
  - `deleteReviewRepo` losing its 404-is-success branch; retargeted at the canonical app org
  - the pending gate removed entirely; the pending gate reading the replica instead of the primary
  - the retention window zeroed; quietly shortened 30d → 7d; the `lt cutoff` predicate removed
  - per-slug dedupe removed; the cursor never advancing; `approved` added to the purgeable statuses
  - both log-and-continue catches rethrowing; `dryRun` still issuing the PATCH
- Two boundary tests were **strengthened during this** — they originally derived their fixtures from the retention constant, so they stayed green when it was mutated to zero. They now drive a `findMany` mock that applies the real where-clause, with fixtures pinned to absolute dates 29 and 31 days out.
- `tsc --noEmit`: **22 errors before and after, none in any touched file.**
- `eslint` on every touched file: **13 errors before and after, all pre-existing.**

**NOT verified — CI is the gate:**
- **Browser-mode component tests did not run locally** (no matching Playwright build available on this machine). The four touched `.browser.test.tsx` files are updated and typecheck clean, but I have not seen them execute. This includes the regression guard asserting no raw-source link renders — and one assertion in that group is known to be vacuous (the string it looks for only renders inside a collapsed panel that the test never expands); it is being replaced.
- `src/server/routers` has **21 pre-existing failing files at `main`** on this machine (missing generated Prisma client / `event-engine-common`). Identical before and after — but that means the new `backfillReviewRepoPrivacy` procedure's registration is **not** covered by a locally-executed test.
- **Nothing has been run against a real review source host.** No backfill run, no purge run, no live delete. The review build's authenticated clone against a now-private snapshot is the one path that must be exercised post-merge — trigger one review preview and confirm the clone step succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
