### PR TITLE
fix(generation): add a stable sort tiebreaker to the resource picker

### DIFF
--- a/src/server/services/resource-select.service.ts
+++ b/src/server/services/resource-select.service.ts
@@ -44,15 +44,25 @@ function skipBaseModelForOwnTabs(
   return (tab === 'mine' || tab === 'official') && selectSource === 'modelVersion';
 }
 
-function meiliSortFor(sort: GetResourceSelectInput['sort']): string[] | undefined {
+// `id:desc` is a stable final tiebreaker: without one Meili breaks ties on internal
+// document order, which index writes reshuffle, so offset pagination repeats or skips
+// models across pages. thumbsUpCount ties are dense enough to collide at the page seam.
+//
+// A text query must keep `sort` unset — an explicit sort activates the `sort` ranking
+// rule, which would outrank words/proximity/exactness. With no query those are no-ops
+// and `metrics.thumbsUpCount:desc` already decides the order, so naming it is a no-op.
+function meiliSortFor(
+  sort: GetResourceSelectInput['sort'],
+  hasQuery: boolean
+): string[] | undefined {
   switch (sort) {
     case 'popularity':
-      return ['metrics.thumbsUpCount:desc'];
+      return ['metrics.thumbsUpCount:desc', 'id:desc'];
     case 'newest':
-      return ['createdAt:desc'];
+      return ['createdAt:desc', 'id:desc'];
     case 'relevance':
     default:
-      return undefined;
+      return hasQuery ? undefined : ['metrics.thumbsUpCount:desc', 'id:desc'];
   }
 }
 
@@ -285,7 +295,7 @@ export async function getResourceSelectModels(
 
   const results = await searchModels(query, {
     filter: filter ?? undefined,
-    sort: meiliSortFor(sort),
+    sort: meiliSortFor(sort, query.length > 0),
     offset,
     limit: take,
   });


### PR DESCRIPTION
Part of #3499. Five lines of behaviour change; the ops analysis that used to ride along in this PR now lives in [a comment on #3499](https://github.com/civitai/civitai/issues/3499) so it can be triaged without holding up a merge.

## The defect

`meiliSortFor` emitted no tiebreaker, so Meili fell back to **internal document order** for ties. Index writes reshuffle that order, which lets offset pagination repeat or skip a model between pages.

That isn't theoretical: `thumbsUpCount` ties are dense enough to land on the 50-item page seam. `4315` is shared by two adjacent Illustrious checkpoints near offset 46.

## The change

`id:desc` is appended to every explicit sort. **`popularity` had the same defect, not just `relevance`** — worth noting because the obvious reading is that only the unsorted case was affected.

For `relevance` the sort is now named explicitly *when there is no query*, since that is what the `metrics.thumbsUpCount:desc` ranking rule was already doing. Verified against production that `sort=relevance` and `sort=popularity` return byte-identical ordering.

**With a query the sort stays unset**, deliberately: passing one activates Meili's `sort` ranking rule, which would outrank `words`/`proximity`/`exactness` and make text search materially worse. That asymmetry is the one thing here worth a reviewer's attention.

## No reindex needed

Both `metrics.thumbsUpCount` and `id` are already in `sortableAttributes`, so this takes effect on deploy.

## Verified

- Full-repo typecheck: 0 errors (`main` is also 0).
- eslint + prettier clean.
- Rebased on current `main`; `meiliSortFor` there still has no tiebreaker, so the defect is live.

## Not verified

No production query run post-change — the byte-identical `relevance`/`popularity` finding above was measured against prod *before* the fix. Worth confirming after deploy that paging through a picker twice returns the same set, which is the actual symptom.