### PR TITLE
fix(generation): guard the resource card against a model with no images

### DIFF
--- a/src/components/ImageGeneration/GenerationForm/ResourceSelectModal/ResourceSelectCard.tsx
+++ b/src/components/ImageGeneration/GenerationForm/ResourceSelectModal/ResourceSelectCard.tsx
@@ -133,7 +133,9 @@ export function ResourceSelectCard({
     data.lastVersionAt > aDayAgo &&
     data.lastVersionAt.getTime() - data.publishedAt.getTime() > constants.timeCutOffs.updatedModel;
 
-  const originalAspectRatio = image.width && image.height ? image.width / image.height : 1;
+  // `image` is optional — the featured podium renders raw items, bypassing the
+  // hidden-preferences pass that drops zero-image models everywhere else.
+  const originalAspectRatio = image?.width && image?.height ? image.width / image.height : 1;
   const width = originalAspectRatio > 1 ? IMAGE_CARD_WIDTH * originalAspectRatio : IMAGE_CARD_WIDTH;
 
   return (


### PR DESCRIPTION
Part of #3499. Second of five. One line.

`image` is `data.images[0]`. Every use in the render path sits behind the `{image && ...}` guard except the aspect-ratio computation ten lines above it, which dereferenced `image.width` unconditionally.

## Why it is reachable

The featured podium builds `topItems` from raw query items on purpose, so auction winners always show. That path skips the `useApplyHiddenPreferences` pass which drops zero-image models everywhere else. A podium model whose versions are all `Unsearchable` has no index images, and the card throws `Cannot read properties of undefined (reading 'width')`, taking down the whole modal rather than one card.

Latent rather than active: no model in the two production pages I sampled had zero images.

## Verified

- Confirmed by grep that line 136 is the only unguarded dereference in the render path. Lines 96 to 101 sit inside `handleSelect`, run on click, and tolerate `undefined`.
- Full-repo typecheck: **0 errors** on this branch and 0 on `main`. (This line previously said "14 pre-existing errors" — that was true when written; `main` has since been cleaned up.) TypeScript narrows the optional chain, so the division in the true branch still checks.
- eslint and prettier clean.

## Left alone on purpose

Two unused imports in this file that eslint warns about, and `handleSelect` awaiting `fetchGenerationData` with no `.catch`, which leaves the Select button spinning forever on failure. Both are real. CONTRIBUTING says a second bug found while fixing the first gets its own PR rather than widening this one, so they are recorded in #3499 instead.

