### PR TITLE
fix(generation): stop the resource picker looping on a failed page

### DIFF
--- a/src/components/ImageGeneration/GenerationForm/ResourceSelectModal/ResourceHitList.tsx
+++ b/src/components/ImageGeneration/GenerationForm/ResourceSelectModal/ResourceHitList.tsx
@@ -1,7 +1,7 @@
 import { Button, Center, Loader, Stack, Text, ThemeIcon, Title } from '@mantine/core';
 import { IconCloudOff } from '@tabler/icons-react';
 import clsx from 'clsx';
-import { useCallback, useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
 import cardClasses from '~/components/Cards/Cards.module.css';
 import { useApplyHiddenPreferences } from '~/components/HiddenPreferences/useApplyHiddenPreferences';
 import { useResourceSelectContext } from '~/components/ImageGeneration/GenerationForm/ResourceSelectProvider';
@@ -15,6 +15,10 @@ import { skipBaseModelForOwnTabs } from '~/components/ImageGeneration/Generation
 import { useResourceSelectInfinite } from './useResourceSelectInfinite';
 import { isDefined } from '~/utils/type-guards';
 
+// A page whose every model filters out client-side still advances the cursor, so keep
+// going — but stop after this many so a permanently over-filtered query can't spin.
+const MAX_CONSECUTIVE_EMPTY_PAGES = 5;
+
 export function ResourceHitList({ query }: { query: string }) {
   const { canGenerate, resources, selectSource, excludedIds, tab } = useResourceSelectContext();
 
@@ -24,9 +28,9 @@ export function ResourceHitList({ query }: { query: string }) {
 
   const {
     items,
+    data: queryData,
     isLoading,
     isFetching,
-    isFetchingNextPage,
     fetchNextPage,
     hasNextPage,
     isError,
@@ -132,6 +136,22 @@ export function ResourceHitList({ query }: { query: string }) {
     return ret;
   }, [canGenerate, featured, models, resources, tab, filterVersions]);
 
+  // Bounds the auto-continue below. Counts pages that arrived and contributed no
+  // renderable card; resets as soon as one does, or when the query changes. Keyed on
+  // `data.pages.length` growing rather than on a render, so unrelated re-renders don't
+  // consume the budget.
+  const emptyPageStreakRef = useRef(0);
+  const lastPageCountRef = useRef(0);
+  const pageCount = queryData?.pages.length ?? 0;
+  if (filtered.length > 0) emptyPageStreakRef.current = 0;
+  else if (pageCount > lastPageCountRef.current) emptyPageStreakRef.current += 1;
+  lastPageCountRef.current = pageCount;
+  useEffect(() => {
+    emptyPageStreakRef.current = 0;
+    lastPageCountRef.current = 0;
+  }, [query, tab]);
+  const emptyPageStreak = emptyPageStreakRef.current;
+
   const renderCard = useCallback(
     ({ data, height }: { data: TransformedModel; height: number }) => (
       <ResourceSelectCard data={data} height={height} selectSource={selectSource} />
@@ -170,6 +190,27 @@ export function ResourceHitList({ query }: { query: string }) {
             </Button>
           </Stack>
         </Center>
+      </div>
+    );
+
+  // A page can load perfectly well and still render nothing: the server filter is a
+  // superset of what filterVersions and the hidden-preferences pass accept. Falling
+  // through to the empty state would be terminal, because it returns before the
+  // InViewLoader below ever mounts — so keep paginating instead. Bounded, because a
+  // zero-height sentinel is instantly in view and would otherwise chain-fetch as fast
+  // as the server answers.
+  if (!filtered.length && hasNextPage && emptyPageStreak < MAX_CONSECUTIVE_EMPTY_PAGES)
+    return (
+      <div className="p-3 py-5">
+        {hiddenCount > 0 && (
+          <Text c="dimmed">{hiddenCount} models have been hidden due to your settings.</Text>
+        )}
+        <Center mt="md">
+          <Loader />
+        </Center>
+        <InViewLoader loadFn={fetchNextPage} loadCondition={!isFetching}>
+          <Center style={{ height: 36 }} my="md" />
+        </InViewLoader>
       </div>
     );
 
@@ -237,12 +278,25 @@ export function ResourceHitList({ query }: { query: string }) {
         />
       </MasonryProvider>
 
-      {items.length > 0 && hasNextPage && (
-        <InViewLoader loadFn={fetchNextPage} loadCondition={!isFetchingNextPage}>
+      {/* `!isError` is the loop fix, and unmounting is the only thing that works:
+          `fetchNextPage` resolves rather than rejects on error (query-core only
+          rethrows for a per-call `throwOnError`), so the failed page never lands in
+          `data`, `hasNextPage` stays true, and the sentinel re-fires every
+          `loadTimeout` — roughly every 500ms, indefinitely — each fire holding a
+          slot on the one Meili limiter that bypasses the circuit breaker. */}
+      {items.length > 0 && hasNextPage && !isError && (
+        <InViewLoader loadFn={fetchNextPage} loadCondition={!isFetching}>
           <Center style={{ height: 36 }} my="md">
             <Loader />
           </Center>
         </InViewLoader>
+      )}
+      {items.length > 0 && isError && (
+        <Center my="md">
+          <Button onClick={() => refetch()} variant="light" size="xs">
+            Load more
+          </Button>
+        </Center>
       )}
     </div>
   );


### PR DESCRIPTION
Part of #3499. Narrowed today — see the note at the bottom for what was dropped and why.

Two defects that survive the error card already on `main`. That card is guarded on `isError && !filtered.length`, so it never fires once a page has rendered — which is exactly when both of these bite.

## 1. A failed page re-fires forever

`fetchNextPage` **resolves** rather than rejects on error: query-core only rethrows when a caller passes a per-call `throwOnError`, and this one doesn't. So the failed page never lands in `data`, `hasNextPage` stays true, the sentinel stays in view, and `InViewLoader`'s `canLoad` flips back after `loadTimeout` — roughly one request every 500 ms for as long as the backend keeps failing.

Each fire holds a slot on the 500-concurrency `resourceSelect` limiter, which is the one backend that deliberately bypasses the Meili circuit breaker. One user parked at the bottom of a failing picker occupies a slot ~93% of the time.

**Unmounting the sentinel is the fix.** Adding `.catch` is not — there is no rejection to catch. A "Load more" button takes its place so the user isn't stranded with a half-loaded grid and no way forward.

## 2. An over-filtered page dead-ends

The server filter is a superset of what `filterVersions` and the hidden-preferences pass accept, so a page can load perfectly and contribute zero cards. That fell through to the terminal "No models found" — which returns *before* the sentinel mounts, so the picker never recovered even when later pages had results.

Now it keeps paginating, bounded at 5 consecutive empty pages. The bound matters: that branch has no content above its sentinel, so the sentinel is instantly in view and would otherwise chain-fetch as fast as the server answers. The streak advances on `data.pages.length` growing rather than on a render, so unrelated re-renders don't consume the budget.

## One detail that's easy to get backwards

`loadCondition` moves from `!isFetchingNextPage` to `!isFetching`. With `placeholderData: keepPreviousData`, a filter change keeps the old grid **and its sentinel** mounted while the new query refetches, and the narrower condition would fire `fetchNextPage` against a query being reset.

## Verified

- Full-repo typecheck: 0 errors (`main` is also 0).
- eslint + prettier clean.
- One file, +58/-4.

## Not verified

No browser run — no `.env` in this checkout, and this is React state and timers, which typecheck says nothing about. Before merge:

1. Fail `model.getResourceSelect` after page 1 and confirm the grid survives, a "Load more" button appears, and the network panel shows the request **stops** rather than repeating every ~500 ms.
2. Find a query whose first page filters out entirely and confirm it advances instead of showing "No models found".

## What this PR used to be

It previously also extracted `useSearchRetry` out of `ImagesInfinite` and gave the picker automatic retry with exponential backoff and a slow-fetch abort (+281/-133 across 5 files). Dropped deliberately:

- `main` has since landed a manual **Retry** card, which covers the reported symptom.
- The extraction was behaviour-neutral churn on the **highest-traffic feed** in the app — real review cost, no user-visible gain.
- The slow-fetch abort was a behaviour *change* (3 s banner, 8 s abort) on an endpoint whose own timeout is 10 s. That's a product call, not a bug fix.

What's left is only the two things `main` still gets wrong. If you do want the auto-retry, say so and I'll reopen it as its own PR against the current error card.