### PR TITLE
fix(generation): stop pinning official models the picker then hides

### DIFF
--- a/src/server/services/resource-select.service.ts
+++ b/src/server/services/resource-select.service.ts
@@ -242,6 +242,7 @@ export async function getResourceSelectModels(
   { user }: { user: ServiceUser }
 ) {
   const { tab, query = '', sort, cursor, limit, filterTypes, filterBaseModels, tagName } = input;
+  const { canGenerate } = input;
 
   const featuredModels = tab === 'featured' ? await getFeaturedModels() : undefined;
   const tabIds = await resolveTabIds(input, user);
@@ -303,7 +304,16 @@ export async function getResourceSelectModels(
       const baseModels = input.resources
         .filter((r) => r.type === m.type)
         .flatMap((r) => r.baseModels);
-      return baseModels.length === 0 || m.versions.some((v) => baseModels.includes(v.baseModel));
+      // Mirrors the client's filterResourceVersions: ONE version has to satisfy both
+      // the base model and generatability, not one each. Checking them independently
+      // pinned models that the client then dropped, so the card never rendered —
+      // ControlNetXL (131 versions, none generatable) shipped 166,651 bytes to the
+      // front of every default checkpoint browse and was never seen.
+      return m.versions.some(
+        (v) =>
+          (baseModels.length === 0 || baseModels.includes(v.baseModel)) &&
+          (canGenerate === undefined || canGenerate === v.canGenerate)
+      );
     });
     // The Meili stream already excludes these ids, so no cross-page dupes.
     items = [...officialItems, ...items];


### PR DESCRIPTION
Part of #3499. Fourth of five. Five lines.

The official-model pin checked base model and generatability as independent existentials: keep the model if any version matches the ecosystem, and ignore the request's `canGenerate` entirely. The client's `filterResourceVersions` requires one version to satisfy both. So the pin could prepend a model the client then stripped to zero versions, rendering no card.

`ControlNetXL (CNXL)` is the live case. It is `isOfficial`, has 131 published versions, an Illustrious one among them, and zero that can generate. It went to the front of every default checkpoint browse at 166,651 B, which is 10.7% of the page, and never rendered. It was also excluded from the Meili stream to avoid a duplicate, so the page returned 51 items where only 50 were usable.

## What changed

The pin now applies the same conjunction the client does.

The exclusion from the Meili stream stays as it was, and stays correct: a pinned model failing `canGenerate` would have been filtered out of the Meili results by that same flag, so nothing goes missing.

## Not fixed here

The pin still hydrates full search-index records from Postgres on every cold first page: `model.findMany` with the whole index selector, plus `getCosmeticsForEntity`, `modelTagCache`, `imagesForModelVersionsCache`, and inside `transformData` another `user.findMany`, a `PaidAccess` raw query and `getValidCreatorMembershipMap`.

Caching that needs a new key in `packages/civitai-redis` plus wiring into the existing `bustFetchThroughCache` call for `OFFICIAL_MODELS`. Skip the wiring and a moderator toggling `isOfficial` clears the id list while stale hydrated records survive for the TTL. Worth doing, and it is a different change from this one.

## Verified

Full-repo typecheck identical to `origin/main`. eslint and prettier clean.

## Not verified

No `.env` in my checkout, so no browser run. After merge, confirm `ControlNetXL` no longer appears in the Illustrious checkpoint picker, and that an official model which does generate still pins to the front.
