### PR TITLE
fix(test): repair three model-service suites failing at collection on main

### DIFF
--- a/src/server/services/__tests__/model-flag-side-effects.service.test.ts
+++ b/src/server/services/__tests__/model-flag-side-effects.service.test.ts
@@ -62,7 +62,13 @@ vi.mock('~/server/redis/caches', () => ({
 }));
 vi.mock('~/server/redis/client', () => ({
   redis: { del: mockRedisDel },
-  REDIS_KEYS: { MODEL: { GALLERY_SETTINGS: 'model:gallery-settings' } },
+  REDIS_KEYS: {
+    MODEL: { GALLERY_SETTINGS: 'model:gallery-settings' },
+    // Read at module scope through a transitive import (paid-access.service ->
+    // session-cache). Omitting it makes REDIS_KEYS.CACHES undefined and the file
+    // fails at collection, before any test runs.
+    CACHES: { PAID_ACCESS_CAP_TIER: 'packed:caches:paid-access-cap-tier' },
+  },
 }));
 vi.mock('~/server/search-index', () => ({
   collectionsSearchIndex: { queueUpdate: vi.fn() },
@@ -112,6 +118,14 @@ vi.mock('~/server/services/user.service', () => ({
 vi.mock('~/server/utils/cache-helpers', () => ({
   bustFetchThroughCache: vi.fn(),
   fetchThroughCache: vi.fn(),
+  // These are invoked at MODULE SCOPE by services this test only imports transitively
+  // (e.g. model-file.service's `filesForModelVersionCache`), so a wholesale factory that
+  // omits them fails at collection with "No <name> export is defined on the mock" — the
+  // whole file errors before a single test runs. They must return the cache-shaped object
+  // their callers immediately destructure. See the note in paid-access.service.ts, which
+  // dodges this by creating its cache lazily instead.
+  createCachedObject: vi.fn(() => ({ fetch: vi.fn(async () => ({})), bust: vi.fn() })),
+  createCachedArray: vi.fn(() => ({ fetch: vi.fn(async () => []), bust: vi.fn() })),
 }));
 vi.mock('~/utils/s3-utils', () => ({ deleteModelFileObjects: vi.fn() }));
 vi.mock('~/utils/storage-resolver', () => ({ deregisterFileLocationsBatch: vi.fn() }));

--- a/src/server/services/__tests__/model-locked-properties.service.test.ts
+++ b/src/server/services/__tests__/model-locked-properties.service.test.ts
@@ -55,7 +55,13 @@ vi.mock('~/server/redis/caches', () => ({
 }));
 vi.mock('~/server/redis/client', () => ({
   redis: { del: vi.fn() },
-  REDIS_KEYS: { MODEL: { GALLERY_SETTINGS: 'model:gallery-settings' } },
+  REDIS_KEYS: {
+    MODEL: { GALLERY_SETTINGS: 'model:gallery-settings' },
+    // Read at module scope through a transitive import (paid-access.service ->
+    // session-cache). Omitting it makes REDIS_KEYS.CACHES undefined and the file
+    // fails at collection, before any test runs.
+    CACHES: { PAID_ACCESS_CAP_TIER: 'packed:caches:paid-access-cap-tier' },
+  },
 }));
 vi.mock('~/server/search-index', () => ({
   collectionsSearchIndex: { queueUpdate: vi.fn() },
@@ -110,6 +116,14 @@ vi.mock('~/server/services/user.service', () => ({
 vi.mock('~/server/utils/cache-helpers', () => ({
   bustFetchThroughCache: vi.fn(),
   fetchThroughCache: vi.fn(),
+  // These are invoked at MODULE SCOPE by services this test only imports transitively
+  // (e.g. model-file.service's `filesForModelVersionCache`), so a wholesale factory that
+  // omits them fails at collection with "No <name> export is defined on the mock" — the
+  // whole file errors before a single test runs. They must return the cache-shaped object
+  // their callers immediately destructure. See the note in paid-access.service.ts, which
+  // dodges this by creating its cache lazily instead.
+  createCachedObject: vi.fn(() => ({ fetch: vi.fn(async () => ({})), bust: vi.fn() })),
+  createCachedArray: vi.fn(() => ({ fetch: vi.fn(async () => []), bust: vi.fn() })),
 }));
 vi.mock('~/utils/s3-utils', () => ({ deleteModelFileObjects: vi.fn() }));
 vi.mock('~/utils/storage-resolver', () => ({ deregisterFileLocationsBatch: vi.fn() }));

--- a/src/server/services/__tests__/set-model-minor.service.test.ts
+++ b/src/server/services/__tests__/set-model-minor.service.test.ts
@@ -65,7 +65,13 @@ vi.mock('~/server/redis/caches', () => ({
 }));
 vi.mock('~/server/redis/client', () => ({
   redis: { del: mockRedisDel },
-  REDIS_KEYS: { MODEL: { GALLERY_SETTINGS: 'model:gallery-settings' } },
+  REDIS_KEYS: {
+    MODEL: { GALLERY_SETTINGS: 'model:gallery-settings' },
+    // Read at module scope through a transitive import (paid-access.service ->
+    // session-cache). Omitting it makes REDIS_KEYS.CACHES undefined and the file
+    // fails at collection, before any test runs.
+    CACHES: { PAID_ACCESS_CAP_TIER: 'packed:caches:paid-access-cap-tier' },
+  },
 }));
 vi.mock('~/server/search-index', () => ({
   collectionsSearchIndex: { queueUpdate: vi.fn() },
@@ -119,6 +125,14 @@ vi.mock('~/server/services/user.service', () => ({
 vi.mock('~/server/utils/cache-helpers', () => ({
   bustFetchThroughCache: vi.fn(),
   fetchThroughCache: vi.fn(),
+  // These are invoked at MODULE SCOPE by services this test only imports transitively
+  // (e.g. model-file.service's `filesForModelVersionCache`), so a wholesale factory that
+  // omits them fails at collection with "No <name> export is defined on the mock" — the
+  // whole file errors before a single test runs. They must return the cache-shaped object
+  // their callers immediately destructure. See the note in paid-access.service.ts, which
+  // dodges this by creating its cache lazily instead.
+  createCachedObject: vi.fn(() => ({ fetch: vi.fn(async () => ({})), bust: vi.fn() })),
+  createCachedArray: vi.fn(() => ({ fetch: vi.fn(async () => []), bust: vi.fn() })),
 }));
 vi.mock('~/utils/s3-utils', () => ({ deleteModelFileObjects: vi.fn() }));
 vi.mock('~/utils/storage-resolver', () => ({ deregisterFileLocationsBatch: vi.fn() }));


### PR DESCRIPTION
## `Unit tests` is red on `main` for every open PR

Three suites under `src/server/services/__tests__` fail during **collection**, so none of their 57 tests execute:

- `model-flag-side-effects.service.test.ts`
- `model-locked-properties.service.test.ts`
- `set-model-minor.service.test.ts`

This is not caused by any one PR — it reproduces on a clean checkout of `main`. It surfaced while investigating a red check on an unrelated UI PR whose diff touches only `src/components/Apps/`.

## Cause

Both failures are the same shape: a wholesale `vi.mock` factory that has gone stale as the import chain beneath these services grew. The factory replaces the *entire* module, so any export it omits is simply absent — and the file errors before a single test runs.

**1. `~/server/utils/cache-helpers` omitted `createCachedObject` / `createCachedArray`.**
These are invoked at **module scope** by services reached only transitively — `model-file.service`'s `filesForModelVersionCache` — so the stubs must return the cache-shaped object their callers immediately use.
> `Error: No "createCachedObject" export is defined on the "~/server/utils/cache-helpers" mock`

**2. `~/server/redis/client` mocked `REDIS_KEYS` with only `MODEL`,** leaving `REDIS_KEYS.CACHES` undefined once `paid-access.service` → `session-cache` entered the chain.
> `TypeError: Cannot read properties of undefined (reading 'PAID_ACCESS_CAP_TIER')`

The second only appears once the first is fixed — vitest reports one collection error per file, so they had to be peeled in order.

## Fix

Complete both factories, with comments recording why each entry exists so the next person doesn't trim them back as unused.

## Verification

- All three files: **57/57 passing** on this branch, against current `main`.
- Both failure modes were reproduced *first* and re-observed after each individual patch, so each change is pinned to a break I actually saw rather than a guess.

## The durable alternative, deliberately not taken

`paid-access.service.ts` already dodges cause 1 — it creates its cache **lazily** rather than at module load, and carries a comment explaining exactly this hazard. Making `filesForModelVersionCache` lazy the same way would fix the class rather than the instance.

It also turns an exported `const` into a function and touches every caller, which is more than an unblock should carry. Worth doing separately.

Relatedly: #3487 added a static lint for wholesale `vi.mock('~/utils/trpc')` factories. This is the same failure mode on different modules, and the lint could plausibly be generalised — also out of scope here.
