### PR TITLE
fix(paid-access): make capTierCache lazy, fixing at the source what #3505 patched per-suite

### DIFF
--- a/src/server/services/__tests__/model-flag-side-effects.service.test.ts
+++ b/src/server/services/__tests__/model-flag-side-effects.service.test.ts
@@ -62,13 +62,7 @@ vi.mock('~/server/redis/caches', () => ({
 }));
 vi.mock('~/server/redis/client', () => ({
   redis: { del: mockRedisDel },
-  REDIS_KEYS: {
-    MODEL: { GALLERY_SETTINGS: 'model:gallery-settings' },
-    // Read at module scope through a transitive import (paid-access.service ->
-    // session-cache). Omitting it makes REDIS_KEYS.CACHES undefined and the file
-    // fails at collection, before any test runs.
-    CACHES: { PAID_ACCESS_CAP_TIER: 'packed:caches:paid-access-cap-tier' },
-  },
+  REDIS_KEYS: { MODEL: { GALLERY_SETTINGS: 'model:gallery-settings' } },
 }));
 vi.mock('~/server/search-index', () => ({
   collectionsSearchIndex: { queueUpdate: vi.fn() },
@@ -118,14 +112,6 @@ vi.mock('~/server/services/user.service', () => ({
 vi.mock('~/server/utils/cache-helpers', () => ({
   bustFetchThroughCache: vi.fn(),
   fetchThroughCache: vi.fn(),
-  // These are invoked at MODULE SCOPE by services this test only imports transitively
-  // (e.g. model-file.service's `filesForModelVersionCache`), so a wholesale factory that
-  // omits them fails at collection with "No <name> export is defined on the mock" — the
-  // whole file errors before a single test runs. They must return the cache-shaped object
-  // their callers immediately destructure. See the note in paid-access.service.ts, which
-  // dodges this by creating its cache lazily instead.
-  createCachedObject: vi.fn(() => ({ fetch: vi.fn(async () => ({})), bust: vi.fn() })),
-  createCachedArray: vi.fn(() => ({ fetch: vi.fn(async () => []), bust: vi.fn() })),
 }));
 vi.mock('~/utils/s3-utils', () => ({ deleteModelFileObjects: vi.fn() }));
 vi.mock('~/utils/storage-resolver', () => ({ deregisterFileLocationsBatch: vi.fn() }));

--- a/src/server/services/__tests__/model-locked-properties.service.test.ts
+++ b/src/server/services/__tests__/model-locked-properties.service.test.ts
@@ -55,13 +55,7 @@ vi.mock('~/server/redis/caches', () => ({
 }));
 vi.mock('~/server/redis/client', () => ({
   redis: { del: vi.fn() },
-  REDIS_KEYS: {
-    MODEL: { GALLERY_SETTINGS: 'model:gallery-settings' },
-    // Read at module scope through a transitive import (paid-access.service ->
-    // session-cache). Omitting it makes REDIS_KEYS.CACHES undefined and the file
-    // fails at collection, before any test runs.
-    CACHES: { PAID_ACCESS_CAP_TIER: 'packed:caches:paid-access-cap-tier' },
-  },
+  REDIS_KEYS: { MODEL: { GALLERY_SETTINGS: 'model:gallery-settings' } },
 }));
 vi.mock('~/server/search-index', () => ({
   collectionsSearchIndex: { queueUpdate: vi.fn() },
@@ -116,14 +110,6 @@ vi.mock('~/server/services/user.service', () => ({
 vi.mock('~/server/utils/cache-helpers', () => ({
   bustFetchThroughCache: vi.fn(),
   fetchThroughCache: vi.fn(),
-  // These are invoked at MODULE SCOPE by services this test only imports transitively
-  // (e.g. model-file.service's `filesForModelVersionCache`), so a wholesale factory that
-  // omits them fails at collection with "No <name> export is defined on the mock" — the
-  // whole file errors before a single test runs. They must return the cache-shaped object
-  // their callers immediately destructure. See the note in paid-access.service.ts, which
-  // dodges this by creating its cache lazily instead.
-  createCachedObject: vi.fn(() => ({ fetch: vi.fn(async () => ({})), bust: vi.fn() })),
-  createCachedArray: vi.fn(() => ({ fetch: vi.fn(async () => []), bust: vi.fn() })),
 }));
 vi.mock('~/utils/s3-utils', () => ({ deleteModelFileObjects: vi.fn() }));
 vi.mock('~/utils/storage-resolver', () => ({ deregisterFileLocationsBatch: vi.fn() }));

--- a/src/server/services/__tests__/set-model-minor.service.test.ts
+++ b/src/server/services/__tests__/set-model-minor.service.test.ts
@@ -65,13 +65,7 @@ vi.mock('~/server/redis/caches', () => ({
 }));
 vi.mock('~/server/redis/client', () => ({
   redis: { del: mockRedisDel },
-  REDIS_KEYS: {
-    MODEL: { GALLERY_SETTINGS: 'model:gallery-settings' },
-    // Read at module scope through a transitive import (paid-access.service ->
-    // session-cache). Omitting it makes REDIS_KEYS.CACHES undefined and the file
-    // fails at collection, before any test runs.
-    CACHES: { PAID_ACCESS_CAP_TIER: 'packed:caches:paid-access-cap-tier' },
-  },
+  REDIS_KEYS: { MODEL: { GALLERY_SETTINGS: 'model:gallery-settings' } },
 }));
 vi.mock('~/server/search-index', () => ({
   collectionsSearchIndex: { queueUpdate: vi.fn() },
@@ -125,14 +119,6 @@ vi.mock('~/server/services/user.service', () => ({
 vi.mock('~/server/utils/cache-helpers', () => ({
   bustFetchThroughCache: vi.fn(),
   fetchThroughCache: vi.fn(),
-  // These are invoked at MODULE SCOPE by services this test only imports transitively
-  // (e.g. model-file.service's `filesForModelVersionCache`), so a wholesale factory that
-  // omits them fails at collection with "No <name> export is defined on the mock" — the
-  // whole file errors before a single test runs. They must return the cache-shaped object
-  // their callers immediately destructure. See the note in paid-access.service.ts, which
-  // dodges this by creating its cache lazily instead.
-  createCachedObject: vi.fn(() => ({ fetch: vi.fn(async () => ({})), bust: vi.fn() })),
-  createCachedArray: vi.fn(() => ({ fetch: vi.fn(async () => []), bust: vi.fn() })),
 }));
 vi.mock('~/utils/s3-utils', () => ({ deleteModelFileObjects: vi.fn() }));
 vi.mock('~/utils/storage-resolver', () => ({ deregisterFileLocationsBatch: vi.fn() }));

--- a/src/server/services/paid-access.service.ts
+++ b/src/server/services/paid-access.service.ts
@@ -153,25 +153,39 @@ export async function countUserPermanentAccessVersions(
 // Busted from clearSessionCache, which Stripe's webhook reaches via refreshSession on every subscription
 // change, so an upgrade/downgrade/lapse applies on the next read; the TTL is only a missed-webhook backstop.
 type CachedCapTier = { userId: number; tier: string | null };
-const capTierCache = createCachedObject<CachedCapTier>({
-  key: REDIS_KEYS.CACHES.PAID_ACCESS_CAP_TIER,
-  idKey: 'userId',
-  ttl: CacheTTL.hour,
-  // Money gate: SWR off so a bust truly clears rather than serving one more stale price.
-  staleWhileRevalidate: false,
-  lookupFn: async (ids) => {
-    const userIds = (Array.isArray(ids) ? ids : [ids]).filter((id) => id != null);
-    if (!userIds.length) return {};
-    const rows = await Promise.all(
-      userIds.map(async (userId) => ({ userId, tier: await getCapTier(userId) }))
-    );
-    return Object.fromEntries(rows.map((r) => [String(r.userId), r]));
-  },
-});
+// Lazily created (on first use) rather than at module load, for exactly the reason the
+// paidAccessCaches comment above gives: a top-level createCachedObject() runs during module
+// evaluation, so ANY test that wholesale-mocks `~/server/utils/cache-helpers` or
+// `~/server/redis/client` and merely imports this service transitively fails at COLLECTION —
+// before a single test runs — with "No createCachedObject export is defined on the mock" or
+// "Cannot read properties of undefined (reading 'PAID_ACCESS_CAP_TIER')". ~130 suites mock
+// those modules wholesale, so this is a broad tripwire, not a hypothetical.
+function createCapTierCache() {
+  return createCachedObject<CachedCapTier>({
+    key: REDIS_KEYS.CACHES.PAID_ACCESS_CAP_TIER,
+    idKey: 'userId',
+    ttl: CacheTTL.hour,
+    // Money gate: SWR off so a bust truly clears rather than serving one more stale price.
+    staleWhileRevalidate: false,
+    lookupFn: async (ids) => {
+      const userIds = (Array.isArray(ids) ? ids : [ids]).filter((id) => id != null);
+      if (!userIds.length) return {};
+      const rows = await Promise.all(
+        userIds.map(async (userId) => ({ userId, tier: await getCapTier(userId) }))
+      );
+      return Object.fromEntries(rows.map((r) => [String(r.userId), r]));
+    },
+  });
+}
+
+let capTierCacheInstance: ReturnType<typeof createCapTierCache> | undefined;
+function capTierCache() {
+  return (capTierCacheInstance ??= createCapTierCache());
+}
 
 /** The owner tier a buyer's price is clamped against. Cached — see capTierCache. */
 export async function getCachedCapTier(userId: number): Promise<string | null> {
-  return (await capTierCache.fetch([userId]))[userId]?.tier ?? null;
+  return (await capTierCache().fetch([userId]))[userId]?.tier ?? null;
 }
 
 /** Per-tier paid-access caps (CU 868kj4q4j). Shared because the tRPC handler and the REST endpoint both write gates. */


### PR DESCRIPTION
> [!NOTE]
> **Corrected after an adversarial audit of this PR.** Two claims below were overstated or mis-attributed:
>
> 1. This does **not** fix the whole class. **28 module-scope eager `createCachedObject`/`createCachedArray` constructors remain** — 22 of them in `src/server/redis/caches.ts` alone (a more widely imported module than this one), plus `model-file.service.ts:52`, `image.service.ts`, `buzz.service.ts`, `user.service.ts`, `creator-program.service.ts`, `redis/resource-data.redis.ts`. This PR removes **1 of 29** (an AST sweep found one more than the original grep-based count: a line-wrapped `export const x =\n  createCachedObject(` is invisible to a line-anchored grep) — real, and on a hot import path, but the class stays open. The three suites stay green only because they *also* wholesale-mock `~/server/redis/caches` and `~/server/services/model-file.service`.
> 2. The environmental-failure causes cited in Verification are wrong. The ~88 local unit failures are dominated by unbuilt **`kysely` (54)**, not Prisma; the 16 local `tsc` errors are `kysely` (4) + `event-engine-common` (9) + 3 implicit-`any` in `image.service.ts`, with **none** from `@civitai/buzz`. The counts and the byte-identical-set comparisons are unaffected — only the attributed causes were wrong, which is worth correcting in a PR whose own premise is a mis-attributed cause.

Follow-up to #3505. That PR unblocked a red `Unit tests` on `main` — three suites in `src/server/services/__tests__` were failing at collection, so none of their 57 tests ran — and unblocking CI was the right call. This fixes the same break at its trigger instead, and reverts #3505's three test-file changes.

## Why replace it

Three things established after #3505 merged:

**1. The stated cause was wrong.** The trigger is `paid-access.service.ts`'s module-scope `const capTierCache = createCachedObject(...)`, not `model-file.service`'s `filesForModelVersionCache`. All three suites mock `~/server/services/model-file.service` wholesale, so that module's scope never executes. The collection stack points at `paid-access.service.ts:156:22`, reached via `model.service.ts:171`.

Both symptoms come from that one line. `createCachedObject` is evaluated before its arguments, so a suite mocking `cache-helpers` hits `No "createCachedObject" export is defined on the mock` and one mocking `redis/client` without `CACHES` hits `Cannot read properties of undefined (reading 'PAID_ACCESS_CAP_TIER')`.

**2. #3505's stubs were inert.** Ablation-verified: deleting `createCachedArray`, or making `createCachedObject` return `undefined`, or setting `CACHES: {}` — each still passes 57/57. The comments claiming the stubs "must return the cache-shaped object their callers immediately destructure" are therefore false, and they were written as durable guidance the next reader would trust. They're removed here.

**3. The lazy fix was declined on a mistaken premise.** #3505 assessed it against `filesForModelVersionCache` (exported, many callers) and judged it too invasive. The actual trigger, `capTierCache`, is module-private with exactly one caller — `getCachedCapTier`, in the same file.

`paid-access.service.ts` already documents this exact hazard ~50 lines above, where `paidAccessCaches` is built lazily "rather than at module load — a top-level createCachedObject() call would break any test that partially mocks `cache-helpers` and merely transitively imports this service". `capTierCache` violated the rule its own file states.

## Scope

~130 suites wholesale-mock `~/server/redis/client` without `CACHES`; ~26 mock `cache-helpers`. Each is one transitive import away from this identical break. #3505 immunised three of them; fixing the trigger covers the class.

This is a small, contained change — one module-private const becomes a lazily-initialised function, plus a revert. Its value is the class, not the size.

## Invalidation is unchanged

`clearSessionCache` deletes the raw redis key `${REDIS_KEYS.CACHES.PAID_ACCESS_CAP_TIER}:${userId}` rather than going through the cache object, and `createCachedArray` reads/writes that same `${key}:${id}` shape. The key derives only from a module-level constant, so deferring construction cannot move it. Checked, not assumed.

## Verification

- **57/57** across all three suites with the lazy fix **and** the test files reverted — that combination is the claim.
- **Break-it:** restoring the eager `const` with the tests still reverted returns all three to collection failure (`Test Files 3 failed`, `Tests no tests`). The fix is load-bearing, not decorative.
- **Full `unit` project:** failing-file set byte-identical to a pristine `origin/main` baseline worktree (88 pre-existing local environmental failures — Prisma engine not found). No regression; 8769 passed on both.
- **`tsc --noEmit`:** error set byte-identical to the same baseline — 16 pre-existing environmental errors (unbuilt `@civitai/buzz`, `kysely`). This touches production code, so it was diffed against a baseline rather than counted.
- ESLint clean on all four changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


