### PR TITLE
test(lint): catch module-scope createCachedObject/createCachedArray statically

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -121,6 +121,46 @@ module.exports = {
     ],
   },
 
+  overrides: [
+    {
+      // Services must build their Redis caches LAZILY. A module-scope
+      // `createCachedObject(...)` runs on IMPORT, so it needs `createCachedObject`
+      // and `REDIS_KEYS.CACHES` to exist at module-evaluation time — which they do
+      // not in the ~150 suites that wholesale-mock `~/server/redis/client` and the
+      // ~26 that mock `~/server/utils/cache-helpers`. Any of those suites that
+      // reaches the service TRANSITIVELY then dies during COLLECTION, and the error
+      // names a file the suite never mentions. That is how one eager `capTierCache`
+      // took out three model-service suites (57 tests) and turned `Unit tests` red
+      // on `main` for every open PR (#3505 / #3506).
+      //
+      // 'error', matching no-wholesale-module-mock and for the same reason: at
+      // 'warn' it gates nothing, because the only BLOCKING ESLint step in
+      // .github/workflows/lint.yml ("ESLint (added files)") runs without
+      // --max-warnings.
+      //
+      // Blast radius on the existing tree — 29 module-scope caches exist in total
+      // (grep says 28; it misses a wrapped `export const x =\n  createCachedObject(`
+      // in caches.ts that the AST finds — the rule is the accurate census):
+      //   7 reported here: 6 services (buzz, paid-access, model-file, user,
+      //     creator-program, image) + redis/resource-data.redis.ts. 6 once #3506
+      //     lands. Each is one lazy getter away; #3506 is the worked example.
+      //  22 in src/server/redis/caches.ts, silenced by a file-level disable AT
+      //     that file, with the reasoning written there. It is a real backlog, not
+      //     a safe shape — all 22 are keyed off REDIS_KEYS at module scope,
+      //     exactly like the capTierCache that broke main, and caches.ts is
+      //     imported far more widely than paid-access.service.ts was.
+      //
+      // All are pre-existing FILES, so a PR touching one reaches only the
+      // report-only modified-files step. What the rule can BLOCK is a newly ADDED
+      // service or redis module — the case where the three-line lazy fix is
+      // cheapest, and the one that grows the backlog.
+      files: ['src/server/services/**/*.ts', 'src/server/redis/**/*.ts'],
+      rules: {
+        'local-rules/no-module-scope-cache': 'error',
+      },
+    },
+  ],
+
   // No type-aware linting: `parserOptions.project` costs ~40s of program build plus
   // ~2.3s/file (2h40m across the repo). If a type-aware rule is ever worth that, add
   // an `overrides` entry scoped to the narrowest possible file set.

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -138,22 +138,41 @@ module.exports = {
       // .github/workflows/lint.yml ("ESLint (added files)") runs without
       // --max-warnings.
       //
-      // Blast radius on the existing tree — 29 module-scope caches exist in total
-      // (grep says 28; it misses a wrapped `export const x =\n  createCachedObject(`
+      // Blast radius on the existing tree — 30 module-scope caches exist in total
+      // (grep says 29; it misses a wrapped `export const x =\n  createCachedObject(`
       // in caches.ts that the AST finds — the rule is the accurate census):
-      //   7 reported here: 6 services (buzz, paid-access, model-file, user,
-      //     creator-program, image) + redis/resource-data.redis.ts. 6 once #3506
-      //     lands. Each is one lazy getter away; #3506 is the worked example.
+      //   8 reported here: 7 services (buzz, paid-access, model-file, user,
+      //     creator-program, image, bug) + redis/resource-data.redis.ts. 7 once
+      //     #3506 lands. Each is one lazy getter away; #3506 is the worked example.
       //  22 in src/server/redis/caches.ts, silenced by a file-level disable AT
       //     that file, with the reasoning written there. It is a real backlog, not
       //     a safe shape — all 22 are keyed off REDIS_KEYS at module scope,
       //     exactly like the capTierCache that broke main, and caches.ts is
       //     imported far more widely than paid-access.service.ts was.
       //
+      // The 8th (`bugReportCounter` in bug.service.ts) is a `cachedCounter`, the
+      // third cache-helpers factory with this hazard. It is REPORTED, not silenced
+      // and not converted here: every other member of the backlog is reported, and
+      // converting one of them inside the rule's own PR would change a service
+      // export's shape (`bugReportCounter.get` -> `bugReportCounter().get`) in a
+      // diff that is otherwise pure lint infrastructure. It gets #3506's treatment
+      // in its own change.
+      //
+      // Two more `cachedCounter` calls live at module scope in src/server/routers/
+      // (redeemableCode, research) — outside this override, and left there
+      // deliberately: routers are not the shape that took out three suites, and
+      // widening the glob is a separate blast-radius decision.
+      //
       // All are pre-existing FILES, so a PR touching one reaches only the
       // report-only modified-files step. What the rule can BLOCK is a newly ADDED
       // service or redis module — the case where the three-line lazy fix is
       // cheapest, and the one that grows the backlog.
+      //
+      // SCOPE: this guards eager cache CONSTRUCTION, not eager `REDIS_KEYS` reads.
+      // A bare `const CACHE_KEY = REDIS_KEYS.CACHES.X;` at module scope throws the
+      // same collection-time TypeError and is deliberately NOT covered — one exists
+      // in scope today (nowpayments.service.ts). Counts and the reasoning are in
+      // the rule header in eslint-local-rules.js.
       files: ['src/server/services/**/*.ts', 'src/server/redis/**/*.ts'],
       rules: {
         'local-rules/no-module-scope-cache': 'error',

--- a/eslint-local-rules.js
+++ b/eslint-local-rules.js
@@ -711,9 +711,9 @@ const noWholesaleModuleMock = {
 /**
  * no-module-scope-cache
  *
- * Flags a `createCachedObject(...)` / `createCachedArray(...)` call that runs at
- * MODULE SCOPE — i.e. during module evaluation, as a side effect of anyone
- * merely importing the file.
+ * Flags a `createCachedObject(...)` / `createCachedArray(...)` / `cachedCounter(...)`
+ * call that runs at MODULE SCOPE — i.e. during module evaluation, as a side
+ * effect of anyone merely importing the file.
  *
  * This is the OTHER end of the same failure that `no-wholesale-module-mock`
  * catches. That rule guards the mock; this one guards the trigger.
@@ -728,6 +728,12 @@ const noWholesaleModuleMock = {
  *   "No createCachedObject export is defined on the mock"   (cache-helpers)
  *   "Cannot read properties of undefined (reading 'PAID_ACCESS_CAP_TIER')"
  *                                                           (REDIS_KEYS.CACHES)
+ *
+ * Both signatures come from the SAME statement: building the cache eagerly needs
+ * the creator to exist AND evaluates its `REDIS_KEYS.*` key argument, right there
+ * at module scope. Which of the two you see depends on which module the suite
+ * mocked. See "What this rule does NOT catch" below — the second signature has
+ * other sources, and this rule guards only this one.
  *
  * Collection errors are reported one file at a time, so the causes peel off one
  * per fix, and the blast radius is not the file you edited — it is every suite
@@ -766,7 +772,7 @@ const noWholesaleModuleMock = {
  * Applied via an `overrides` entry in .eslintrc.js to `src/server/services/**`
  * and `src/server/redis/**` — the two places module-scope caches actually live.
  *
- * There are 29 of them today. 7 are reported; the 22 in
+ * There are 30 of them today. 8 are reported; the 22 in
  * `src/server/redis/caches.ts` are silenced by a documented file-level disable
  * in that file. Do NOT read that disable as "caches.ts is safe" — it is the
  * hotter tripwire, not the exempt one: all 22 are keyed off `REDIS_KEYS` at
@@ -783,6 +789,36 @@ const noWholesaleModuleMock = {
  * tripwire on a module no suite knows to mock, which is exactly how one
  * `capTierCache` took out three unrelated suites.
  *
+ * ---------------------------------------------------------------------------
+ * What this rule does NOT catch, stated because its own message names the
+ * symptom rather than the construct
+ * ---------------------------------------------------------------------------
+ *
+ * The guarded construct is eager cache CONSTRUCTION. The rule does not know
+ * anything about `REDIS_KEYS`; it happens to cover the `REDIS_KEYS` dereference
+ * only because that dereference is the creator call's own argument.
+ *
+ * A bare module-scope read — `const CACHE_KEY = REDIS_KEYS.CACHES.X;`, with no
+ * creator call anywhere near it — reproduces the identical
+ * `TypeError: Cannot read properties of undefined (reading '<KEY>')` at
+ * collection time, and this rule reports 0 against it. There is one in scope
+ * today: src/server/services/nowpayments.service.ts.
+ *
+ * That shape is deliberately left unguarded, and the measurement is the reason.
+ * Counting module-scope `REDIS_KEYS.*` reads with this rule's own module-scope
+ * walk: 32 in the scoped dirs (plus 6 outside them). But 22 of the 32 are in
+ * caches.ts, already silenced by the file-level disable; 8 more ARE the key
+ * arguments of the 8 creator calls this rule already reports, so guarding them
+ * would double-report the same statements unless the rule also grew a
+ * "skip reads inside a call I already flagged" pass; and 1 of the remaining 2 is
+ * a test file's own `const KEY = REDIS_KEYS.CACHES.ACTIVE_AUCTIONS` (a suite that
+ * mocks the module itself, where the read is correct). So the extension buys ONE
+ * genuinely new guarded site at the cost of ~10 new reports, a dedup pass, and a
+ * rule whose name no longer describes what it does. Not worth it — the shape is
+ * written down here instead. Revisit if a second bare read appears.
+ *
+ * ---------------------------------------------------------------------------
+ *
  * "Module scope" is decided structurally, by walking to the nearest enclosing
  * function. A call inside a function is deferred and therefore fine — EXCEPT
  * when that function is immediately invoked (`(() => createCachedObject())()`),
@@ -792,7 +828,14 @@ const noWholesaleModuleMock = {
  *   - eager invocation through a callback the rule cannot classify:
  *     `TYPES.map(() => createCachedObject(...))` at module scope is eager, but
  *     the arrow makes it look deferred. Detecting this needs to know which
- *     callees run their argument synchronously;
+ *     callees run their argument synchronously.
+ *     🔴 If you close this gap, do NOT do it by loosening `isImmediatelyInvoked`
+ *     to "the function is an argument to some call". `describe(() => ...)`,
+ *     `register(() => createCachedObject(...))` and every other deferred
+ *     callback stored for later are arguments to a call too, and that edit
+ *     flags all of them. The `valid` cases named "🔴 M8" in
+ *     src/server/services/__tests__/no-module-scope-cache.test.ts pin exactly
+ *     this and are the ones that go red if you try it;
  *   - the callee is matched by NAME, not resolved to its import. A local helper
  *     that happens to be called `createCachedObject` is reported (one disable
  *     comment), and a cache built through an aliased import is not;
@@ -803,9 +846,22 @@ const noWholesaleModuleMock = {
  * Intentional exceptions should use:
  *   // eslint-disable-next-line local-rules/no-module-scope-cache -- <reason>
  */
-const DEFAULT_CACHE_CREATORS = ['createCachedObject', 'createCachedArray'];
+// All three are `~/server/utils/cache-helpers` exports that (a) are absent from a
+// wholesale mock of that module and (b) take a `REDIS_KEYS.*` key as their first
+// argument, so an eager call carries both collection-failure signatures.
+// `cachedCounter` is the same hazard in a different wrapper — see
+// `bugReportCounter` in src/server/services/bug.service.ts.
+const DEFAULT_CACHE_CREATORS = ['createCachedObject', 'createCachedArray', 'cachedCounter'];
 
-/** `(() => ...)()` / `(function () { ... })()` — the function runs where it sits. */
+/**
+ * `(() => ...)()` / `(function () { ... })()` — the function runs where it sits.
+ *
+ * The `parent.callee === fn` half is load-bearing and is NOT redundant with the
+ * `CallExpression` check: without it, a function passed as an ARGUMENT
+ * (`describe(() => ...)`, `register(() => createCachedObject(...))`) reads as an
+ * IIFE, and every deferred callback in the scoped dirs gets reported. Pinned by
+ * the "🔴 M8" valid cases in the rule's test file.
+ */
 function isImmediatelyInvoked(fn) {
   const parent = fn.parent;
   return !!parent && parent.type === 'CallExpression' && parent.callee === fn;
@@ -853,7 +909,7 @@ const noModuleScopeCache = {
     type: 'problem',
     docs: {
       description:
-        'Require createCachedObject/createCachedArray in services to be built lazily — a module-scope call breaks test COLLECTION for every suite that wholesale-mocks cache-helpers or redis/client and transitively imports the service.',
+        'Require createCachedObject/createCachedArray/cachedCounter in services to be built lazily — a module-scope call breaks test COLLECTION for every suite that wholesale-mocks cache-helpers or redis/client and transitively imports the service. Guards eager cache CONSTRUCTION only: a bare module-scope `REDIS_KEYS.*` read that feeds no creator call produces the same collection error and is deliberately not covered (reasoning and counts in the rule header).',
       recommended: true,
     },
     schema: [
@@ -867,7 +923,7 @@ const noModuleScopeCache = {
     ],
     messages: {
       moduleScopeCache:
-        '`{{creator}}(...)` at MODULE SCOPE — it runs when this file is IMPORTED, not when the cache is used. ~150 suites wholesale-mock `~/server/redis/client` and ~26 mock `~/server/utils/cache-helpers`; every one of them that reaches this service transitively then fails at COLLECTION, before any test runs, with "No {{creator}} export is defined on the mock" or "Cannot read properties of undefined (reading \'<KEY>\')". Nothing in the failing suite mentions this file. Build it lazily instead: `function createX() { return {{creator}}({ ... }); }` plus `let xInstance: ReturnType<typeof createX> | undefined; function x() { return (xInstance ??= createX()); }`, and call `x().fetch(...)`. Runtime behaviour is unchanged — still one instance per process, built on first USE instead of first IMPORT. Canonical example: `paidAccessCache` in src/server/services/paid-access.service.ts. If this one really must be eager, silence it explicitly: `// eslint-disable-next-line local-rules/no-module-scope-cache -- <reason>`',
+        '`{{creator}}(...)` at MODULE SCOPE — it runs when this file is IMPORTED, not when the cache is used, so importing this file needs `{{creator}}` to exist AND evaluates the `REDIS_KEYS.*` key argument on this line. ~150 suites wholesale-mock `~/server/redis/client` and ~26 mock `~/server/utils/cache-helpers`; every one of them that reaches this service transitively then fails at COLLECTION, before any test runs — "No {{creator}} export is defined on the mock" if cache-helpers was the mocked one, or "Cannot read properties of undefined (reading \'<KEY>\')" from this line\'s key argument if it was redis/client. Nothing in the failing suite mentions this file. Build it lazily instead: `function createX() { return {{creator}}({ ... }); }` plus `let xInstance: ReturnType<typeof createX> | undefined; function x() { return (xInstance ??= createX()); }`, and call through the getter (`x().fetch(...)`). Runtime behaviour is unchanged — still one instance per process, built on first USE instead of first IMPORT. Canonical example: `paidAccessCache` in src/server/services/paid-access.service.ts. If this one really must be eager, silence it explicitly: `// eslint-disable-next-line local-rules/no-module-scope-cache -- <reason>`. (Scope: this rule guards eager cache CONSTRUCTION. A bare module-scope `REDIS_KEYS.*` read that feeds no creator call throws the same TypeError and is NOT guarded — see the rule header for why.)',
     },
   },
   create(context) {

--- a/eslint-local-rules.js
+++ b/eslint-local-rules.js
@@ -708,7 +708,190 @@ const noWholesaleModuleMock = {
   },
 };
 
+/**
+ * no-module-scope-cache
+ *
+ * Flags a `createCachedObject(...)` / `createCachedArray(...)` call that runs at
+ * MODULE SCOPE — i.e. during module evaluation, as a side effect of anyone
+ * merely importing the file.
+ *
+ * This is the OTHER end of the same failure that `no-wholesale-module-mock`
+ * catches. That rule guards the mock; this one guards the trigger.
+ *
+ * A test suite that wholesale-mocks `~/server/utils/cache-helpers` or
+ * `~/server/redis/client` replaces the entire module, so any export the factory
+ * omits is simply absent. If a service builds its cache at module scope, then
+ * every suite that mocks one of those modules and imports that service — even
+ * TRANSITIVELY, three hops down an import chain it never mentions — fails
+ * during COLLECTION, before a single test runs:
+ *
+ *   "No createCachedObject export is defined on the mock"   (cache-helpers)
+ *   "Cannot read properties of undefined (reading 'PAID_ACCESS_CAP_TIER')"
+ *                                                           (REDIS_KEYS.CACHES)
+ *
+ * Collection errors are reported one file at a time, so the causes peel off one
+ * per fix, and the blast radius is not the file you edited — it is every suite
+ * whose import graph happens to reach it. ~150 suites mock `redis/client` and
+ * ~26 mock `cache-helpers` today, so this is a broad live tripwire, not a
+ * hypothetical: adding one eager `capTierCache` to paid-access.service.ts
+ * killed three model-service suites (57 tests) and turned `Unit tests` red on
+ * `main` for every open PR (PRs #3505 / #3506).
+ *
+ * Fixing the ~150 mocks is the wrong end of the problem — each one is correct
+ * for what it tests, and the list only grows. Building the cache lazily is a
+ * three-line change that makes the whole class impossible.
+ *
+ * The fix — the house pattern, already documented in the file that broke:
+ *
+ *   function createCapTierCache() {
+ *     return createCachedObject<CachedCapTier>({ key: ..., lookupFn: ... });
+ *   }
+ *   let capTierCacheInstance: ReturnType<typeof createCapTierCache> | undefined;
+ *   function capTierCache() {
+ *     return (capTierCacheInstance ??= createCapTierCache());
+ *   }
+ *
+ * Call sites become `capTierCache().fetch(...)`. Nothing about runtime
+ * behaviour changes — the cache is still a per-process singleton, it is just
+ * built on first USE instead of on first IMPORT.
+ *
+ * Canonical in-repo example: `paidAccessCache` in
+ * src/server/services/paid-access.service.ts, whose comment gives this exact
+ * reasoning — the eager `capTierCache` was added directly beneath it.
+ *
+ * ---------------------------------------------------------------------------
+ * Scope, and why it is narrow
+ * ---------------------------------------------------------------------------
+ *
+ * Applied via an `overrides` entry in .eslintrc.js to `src/server/services/**`
+ * and `src/server/redis/**` — the two places module-scope caches actually live.
+ *
+ * There are 29 of them today. 7 are reported; the 22 in
+ * `src/server/redis/caches.ts` are silenced by a documented file-level disable
+ * in that file. Do NOT read that disable as "caches.ts is safe" — it is the
+ * hotter tripwire, not the exempt one: all 22 are keyed off `REDIS_KEYS` at
+ * module scope, and the module is imported far more widely than
+ * paid-access.service.ts was. The three suites #3505 repaired stay green only
+ * because they ALSO mock `~/server/redis/caches`; the next suite that mocks
+ * `~/server/redis/client` without `CACHES` and reaches caches.ts unmocked dies
+ * the same way, and making one service's cache lazy does not prevent that.
+ *
+ * The disable is a blast-radius decision, written down where the next author
+ * will read it: converting 22 call sites in the busiest cache module wants to be
+ * its own reviewable change. What the rule buys meanwhile is that the backlog
+ * stops GROWING — a new eager cache in a service creates a brand-new transitive
+ * tripwire on a module no suite knows to mock, which is exactly how one
+ * `capTierCache` took out three unrelated suites.
+ *
+ * "Module scope" is decided structurally, by walking to the nearest enclosing
+ * function. A call inside a function is deferred and therefore fine — EXCEPT
+ * when that function is immediately invoked (`(() => createCachedObject())()`),
+ * which runs at module scope after all and is handled.
+ *
+ * Known gaps (deliberate):
+ *   - eager invocation through a callback the rule cannot classify:
+ *     `TYPES.map(() => createCachedObject(...))` at module scope is eager, but
+ *     the arrow makes it look deferred. Detecting this needs to know which
+ *     callees run their argument synchronously;
+ *   - the callee is matched by NAME, not resolved to its import. A local helper
+ *     that happens to be called `createCachedObject` is reported (one disable
+ *     comment), and a cache built through an aliased import is not;
+ *   - a cache built at module scope by a helper the rule can't see through
+ *     (`const c = makeCache()` where makeCache calls createCachedObject) is not
+ *     reported. The hazard is real there too, but the shape is not in the tree.
+ *
+ * Intentional exceptions should use:
+ *   // eslint-disable-next-line local-rules/no-module-scope-cache -- <reason>
+ */
+const DEFAULT_CACHE_CREATORS = ['createCachedObject', 'createCachedArray'];
+
+/** `(() => ...)()` / `(function () { ... })()` — the function runs where it sits. */
+function isImmediatelyInvoked(fn) {
+  const parent = fn.parent;
+  return !!parent && parent.type === 'CallExpression' && parent.callee === fn;
+}
+
+/**
+ * Does this node evaluate during module evaluation?
+ *
+ * Walk to the Program. Any enclosing function DEFERS the call (its body runs
+ * when it is called, not when the module loads) — unless the function is itself
+ * immediately invoked, in which case we keep walking from the invocation. A
+ * non-static class property initialiser runs per instantiation, so it defers
+ * too; a static one does not.
+ */
+function isEvaluatedAtModuleScope(node) {
+  let current = node;
+  let parent = current.parent;
+
+  while (parent) {
+    if (
+      parent.type === 'FunctionDeclaration' ||
+      parent.type === 'FunctionExpression' ||
+      parent.type === 'ArrowFunctionExpression'
+    ) {
+      if (!isImmediatelyInvoked(parent)) return false;
+      // An IIFE: resume the walk from the call that invokes it.
+      current = parent.parent;
+      parent = current.parent;
+      continue;
+    }
+
+    if (parent.type === 'PropertyDefinition' && parent.value === current && !parent.static) {
+      return false;
+    }
+
+    current = parent;
+    parent = current.parent;
+  }
+
+  return current.type === 'Program';
+}
+
+const noModuleScopeCache = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Require createCachedObject/createCachedArray in services to be built lazily — a module-scope call breaks test COLLECTION for every suite that wholesale-mocks cache-helpers or redis/client and transitively imports the service.',
+      recommended: true,
+    },
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          creators: { type: 'array', items: { type: 'string' }, minItems: 1 },
+        },
+        additionalProperties: false,
+      },
+    ],
+    messages: {
+      moduleScopeCache:
+        '`{{creator}}(...)` at MODULE SCOPE — it runs when this file is IMPORTED, not when the cache is used. ~150 suites wholesale-mock `~/server/redis/client` and ~26 mock `~/server/utils/cache-helpers`; every one of them that reaches this service transitively then fails at COLLECTION, before any test runs, with "No {{creator}} export is defined on the mock" or "Cannot read properties of undefined (reading \'<KEY>\')". Nothing in the failing suite mentions this file. Build it lazily instead: `function createX() { return {{creator}}({ ... }); }` plus `let xInstance: ReturnType<typeof createX> | undefined; function x() { return (xInstance ??= createX()); }`, and call `x().fetch(...)`. Runtime behaviour is unchanged — still one instance per process, built on first USE instead of first IMPORT. Canonical example: `paidAccessCache` in src/server/services/paid-access.service.ts. If this one really must be eager, silence it explicitly: `// eslint-disable-next-line local-rules/no-module-scope-cache -- <reason>`',
+    },
+  },
+  create(context) {
+    const options = context.options[0] || {};
+    const creators = new Set(options.creators || DEFAULT_CACHE_CREATORS);
+
+    return {
+      CallExpression(node) {
+        const callee = node.callee;
+        if (!callee || callee.type !== 'Identifier' || !creators.has(callee.name)) return;
+        if (!isEvaluatedAtModuleScope(node)) return;
+
+        context.report({
+          node,
+          messageId: 'moduleScopeCache',
+          data: { creator: callee.name },
+        });
+      },
+    };
+  },
+};
+
 module.exports = {
   'no-io-in-transaction': noIoInTransaction,
+  'no-module-scope-cache': noModuleScopeCache,
   'no-wholesale-module-mock': noWholesaleModuleMock,
 };

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "test:unit": "vitest --project unit",
     "test:unit:run": "vitest run --project unit",
     "test:unit:coverage": "vitest run --project unit --coverage",
-    "test:lint-rules": "vitest run --project unit src/server/services/__tests__/no-io-in-transaction.test.ts src/server/services/__tests__/no-wholesale-module-mock.test.ts",
+    "test:lint-rules": "vitest run --project unit src/server/services/__tests__/no-io-in-transaction.test.ts src/server/services/__tests__/no-module-scope-cache.test.ts src/server/services/__tests__/no-wholesale-module-mock.test.ts",
     "test:component": "vitest run --project component",
     "test:component:watch": "vitest --project component",
     "meilisearch:migrate": "NODE_ENV=development tsx scripts/oneoffs/meilisearch-migration.ts",

--- a/src/server/redis/caches.ts
+++ b/src/server/redis/caches.ts
@@ -1,3 +1,22 @@
+/* eslint-disable local-rules/no-module-scope-cache --
+ * 22 module-scope caches, every one of them keyed off REDIS_KEYS during module
+ * evaluation. This is a tracked BACKLOG, not a safe shape: it is structurally the
+ * same tripwire as the eager `capTierCache` that broke three suites at collection
+ * and turned `Unit tests` red on main (#3505 / #3506), and this module is imported
+ * far more widely than paid-access.service.ts was. Any suite that wholesale-mocks
+ * `~/server/redis/client` without `REDIS_KEYS.CACHES` and reaches this file
+ * unmocked dies during COLLECTION — the three suites in #3505 stay green only
+ * because they additionally mock this module.
+ *
+ * Disabled file-wide rather than converted here because that is 22 call-site
+ * migrations across the busiest cache module in the repo, and it wants to be its
+ * own reviewable change. The file-wide form also silences a NEW cache added here,
+ * which is accepted: a 23rd cache in this file adds no NEW tripwire, because
+ * anything reaching this module already has to mock it. A new cache in a SERVICE
+ * does add one, and that is what the rule is scoped to catch.
+ *
+ * Delete this disable once the caches below are lazy — the rule then guards them.
+ */
 import type { ResourceInfo } from '@civitai/client';
 import { Prisma } from '@prisma/client';
 import { env } from '~/env/server';

--- a/src/server/services/__tests__/no-module-scope-cache.test.ts
+++ b/src/server/services/__tests__/no-module-scope-cache.test.ts
@@ -1,0 +1,190 @@
+import path from 'path';
+import { RuleTester } from 'eslint';
+// The rule lives at the repo root (loaded in prod via eslint-plugin-local-rules).
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const localRules = require(path.resolve(__dirname, '../../../../eslint-local-rules.js'));
+
+const rule = localRules['no-module-scope-cache'];
+
+// Same harness shape as no-wholesale-module-mock.test.ts: RuleTester drives the
+// test framework's globals, so `ruleTester.run(...)` must be called at the top
+// level of the module (NOT nested inside a vitest `it()`). `parser` is a valid
+// top-level RuleTester option in ESLint 8 (eslintrc mode) but @types/eslint's
+// config type omits it — build untyped and cast so `tsc --noEmit` stays green.
+const ruleTesterConfig: Record<string, unknown> = {
+  parser: require.resolve('@typescript-eslint/parser'),
+  parserOptions: { ecmaVersion: 'latest', sourceType: 'module' },
+};
+const ruleTester = new RuleTester(ruleTesterConfig as ConstructorParameters<typeof RuleTester>[0]);
+
+ruleTester.run('no-module-scope-cache', rule, {
+  valid: [
+    // ================================================================
+    // The canonical lazy pattern — the house rule this enforces
+    // ================================================================
+    // `paidAccessCache` in src/server/services/paid-access.service.ts, reduced.
+    // The call is inside a function, so it runs on first USE, not on import.
+    `function createPaidAccessCache(entityType) {
+       return createCachedObject({ key: REDIS_KEYS.CACHES.PAID_ACCESS, idKey: 'entityId' });
+     }
+     const caches = {};
+     function paidAccessCache(entityType) {
+       return (caches[entityType] ??= createPaidAccessCache(entityType));
+     }`,
+    // The memoised-singleton spelling PR #3506 uses for capTierCache.
+    `function createCapTierCache() {
+       return createCachedObject({ key: REDIS_KEYS.CACHES.PAID_ACCESS_CAP_TIER });
+     }
+     let instance;
+     function capTierCache() {
+       return (instance ??= createCapTierCache());
+     }`,
+    // An arrow, not just a function declaration.
+    `const cache = () => createCachedObject({ key: 'k' });`,
+    // Inside a method — deferred like any other function body.
+    `class Service {
+       cache() { return createCachedArray({ key: 'k' }); }
+     }`,
+    // A NON-STATIC class property initialiser runs per instantiation, not on
+    // module evaluation, so it is deferred.
+    `class Service { cache = createCachedObject({ key: 'k' }); }`,
+    // Nested two functions deep — still deferred.
+    `function outer() {
+       function inner() { return createCachedObject({ key: 'k' }); }
+       return inner;
+     }`,
+    // A default parameter value is evaluated per CALL, not at module scope.
+    `function get(cache = createCachedObject({ key: 'k' })) { return cache; }`,
+    // Deferred inside a callback that is not invoked here (the lazy-init idiom
+    // via a thunk stored for later).
+    `const lazy = { get: () => createCachedObject({ key: 'k' }) };`,
+    // 🔴 The boundary of the IIFE cases in `invalid` below: an IIFE nested
+    // inside a function that is NOT invoked here is genuinely deferred. The
+    // walk must resume through the invocation and then stop at the real
+    // function, not report everything that has an IIFE anywhere above it.
+    `const get = () => (() => createCachedObject({ key: 'k' }))();`,
+
+    // ================================================================
+    // Not a cache creator at all
+    // ================================================================
+    `const x = createSomethingElse({ key: 'k' });`,
+    // A member call, not a bare identifier — a different (namespaced) API.
+    `const x = helpers.createCachedObject({ key: 'k' });`,
+    // The creator merely REFERENCED, not called: re-exporting is harmless.
+    `export { createCachedObject };`,
+    // Shadowed name is still matched by name (documented gap), but a plain
+    // identifier reference is not a call and must stay silent.
+    `const fn = createCachedObject;`,
+
+    // ================================================================
+    // The `creators` option narrows what counts
+    // ================================================================
+    {
+      code: `const cache = createCachedArray({ key: 'k' });`,
+      options: [{ creators: ['createCachedObject'] }],
+    },
+  ],
+
+  invalid: [
+    // ================================================================
+    // 🔴 THE HISTORICAL REGRESSION
+    // ================================================================
+    // The eager `capTierCache` added to paid-access.service.ts, reduced to its
+    // shape. This is the exact code that killed three model-service suites at
+    // COLLECTION (57 tests) and turned `Unit tests` red on main for every open
+    // PR. If this case stops failing, the rule has stopped guarding anything.
+    {
+      code: `const capTierCache = createCachedObject<CachedCapTier>({
+         key: REDIS_KEYS.CACHES.PAID_ACCESS_CAP_TIER,
+         idKey: 'userId',
+         ttl: CacheTTL.hour,
+         staleWhileRevalidate: false,
+         lookupFn: async (ids) => ({}),
+       });`,
+      errors: [{ messageId: 'moduleScopeCache' }],
+    },
+    // The second symptom's source: an EXPORTED module-scope cache
+    // (`filesForModelVersionCache` in model-file.service.ts). Exported is
+    // worse, not better — importers reach it directly.
+    {
+      code: `export const filesForModelVersionCache = createCachedObject({ key: 'k' });`,
+      errors: [{ messageId: 'moduleScopeCache' }],
+    },
+    // createCachedArray is the same hazard (resource-data.redis.ts's shape).
+    {
+      code: `export const resourceDataCache = createCachedArray({ key: 'k' });`,
+      errors: [{ messageId: 'moduleScopeCache' }],
+    },
+
+    // ================================================================
+    // Module scope in its other spellings
+    // ================================================================
+    // Bare expression statement, no binding at all.
+    {
+      code: `createCachedObject({ key: 'k' });`,
+      errors: [{ messageId: 'moduleScopeCache' }],
+    },
+    // Inside a module-scope object literal — still evaluated on import.
+    {
+      code: `const caches = { files: createCachedObject({ key: 'k' }) };`,
+      errors: [{ messageId: 'moduleScopeCache' }],
+    },
+    // Inside a module-scope array literal.
+    {
+      code: `const all = [createCachedObject({ key: 'a' }), createCachedArray({ key: 'b' })];`,
+      errors: [{ messageId: 'moduleScopeCache' }, { messageId: 'moduleScopeCache' }],
+    },
+    // Inside a module-scope `if` — conditional, but still on import.
+    {
+      code: `let c; if (flag) { c = createCachedObject({ key: 'k' }); }`,
+      errors: [{ messageId: 'moduleScopeCache' }],
+    },
+    // A STATIC class property initialiser DOES run during module evaluation,
+    // unlike the instance property in the valid cases above.
+    {
+      code: `class Service { static cache = createCachedObject({ key: 'k' }); }`,
+      errors: [{ messageId: 'moduleScopeCache' }],
+    },
+    // A class static block runs at module evaluation too.
+    {
+      code: `class Service { static { createCachedObject({ key: 'k' }); } }`,
+      errors: [{ messageId: 'moduleScopeCache' }],
+    },
+    // A top-level await does not defer anything.
+    {
+      code: `const c = await Promise.resolve(createCachedObject({ key: 'k' }));`,
+      errors: [{ messageId: 'moduleScopeCache' }],
+    },
+
+    // ================================================================
+    // 🔴 The IIFE bypass — a function wrapper that is NOT deferral
+    // ================================================================
+    // The obvious way to get past a naive "is it inside a function?" check.
+    // These run at module scope regardless of the arrow around them, so a rule
+    // that stops at the first enclosing function is wrong here.
+    {
+      code: `const cache = (() => createCachedObject({ key: 'k' }))();`,
+      errors: [{ messageId: 'moduleScopeCache' }],
+    },
+    {
+      code: `const cache = (function () { return createCachedObject({ key: 'k' }); })();`,
+      errors: [{ messageId: 'moduleScopeCache' }],
+    },
+    // Two IIFEs deep — the walk has to resume from each invocation, not stop.
+    {
+      code: `const cache = (() => (() => createCachedObject({ key: 'k' }))())();`,
+      errors: [{ messageId: 'moduleScopeCache' }],
+    },
+    // (The boundary case — an IIFE nested inside a function that is not itself
+    // invoked — is genuinely lazy and is pinned in `valid` above.)
+
+    // ================================================================
+    // The `creators` option, in the reporting direction
+    // ================================================================
+    {
+      code: `const c = makeOurCache({ key: 'k' });`,
+      options: [{ creators: ['makeOurCache'] }],
+      errors: [{ messageId: 'moduleScopeCache' }],
+    },
+  ],
+});

--- a/src/server/services/__tests__/no-module-scope-cache.test.ts
+++ b/src/server/services/__tests__/no-module-scope-cache.test.ts
@@ -65,6 +65,33 @@ ruleTester.run('no-module-scope-cache', rule, {
     `const get = () => (() => createCachedObject({ key: 'k' }))();`,
 
     // ================================================================
+    // 🔴 M8 — a cache-creating function passed as a CALL ARGUMENT is not an
+    // IIFE. These pin the `parent.callee === fn` half of isImmediatelyInvoked.
+    // ================================================================
+    // A mutant that drops that check (so "the function's parent is a
+    // CallExpression" alone counts as immediate invocation) survives every
+    // other case in this file — every existing valid case puts the creator in a
+    // function that is either declared, assigned, or a class member, never
+    // passed as an argument. It is a live risk rather than a hypothetical: the
+    // rule's own "Known gaps" comment invites closing the
+    // `TYPES.map(() => createCachedObject(...))` gap, and dropping that check is
+    // the naive way to try. It would ship green and then report every deferred
+    // callback in src/server/services/** and src/server/redis/**.
+    //
+    // A callback stored by a registrar and invoked later — the shape the mutant
+    // breaks, and the one the lazy-init idiom actually uses.
+    `register(() => createCachedObject({ key: 'k' }));`,
+    // The test-framework spelling of the same thing, which is why the mutant is
+    // not merely noisy but wrong: this is deferred by definition.
+    `describe('caches', () => {
+       const cache = createCachedObject({ key: 'k' });
+     });`,
+    // A function EXPRESSION argument, not just an arrow.
+    `onReady(function () { return createCachedArray({ key: 'k' }); });`,
+    // The argument is not even the first one — position must not matter.
+    `withRetry(3, () => cachedCounter(REDIS_KEYS.COUNTERS.X));`,
+
+    // ================================================================
     // Not a cache creator at all
     // ================================================================
     `const x = createSomethingElse({ key: 'k' });`,
@@ -77,10 +104,25 @@ ruleTester.run('no-module-scope-cache', rule, {
     `const fn = createCachedObject;`,
 
     // ================================================================
+    // cachedCounter — the third cache-helpers factory with the same hazard
+    // ================================================================
+    // Lazy is lazy for every creator in the default list.
+    `let instance;
+     function bugReportCounter() {
+       return (instance ??= cachedCounter(REDIS_KEYS.COUNTERS.BUG_REPORTS));
+     }`,
+
+    // ================================================================
     // The `creators` option narrows what counts
     // ================================================================
     {
       code: `const cache = createCachedArray({ key: 'k' });`,
+      options: [{ creators: ['createCachedObject'] }],
+    },
+    // An explicit `creators` list REPLACES the default, so a creator that is in
+    // the default but not in the list must go quiet.
+    {
+      code: `const c = cachedCounter(REDIS_KEYS.COUNTERS.BUG_REPORTS);`,
       options: [{ creators: ['createCachedObject'] }],
     },
   ],
@@ -113,6 +155,21 @@ ruleTester.run('no-module-scope-cache', rule, {
     // createCachedArray is the same hazard (resource-data.redis.ts's shape).
     {
       code: `export const resourceDataCache = createCachedArray({ key: 'k' });`,
+      errors: [{ messageId: 'moduleScopeCache' }],
+    },
+    // cachedCounter is the THIRD cache-helpers factory with the identical
+    // hazard, and it is in the default creators list for that reason: it is an
+    // export of `~/server/utils/cache-helpers` (so it is `undefined` on a
+    // wholesale mock of that module) and its first argument dereferences
+    // `REDIS_KEYS` at module scope (so it throws on a mock of
+    // `~/server/redis/client` with no `COUNTERS`). This is `bugReportCounter` in
+    // src/server/services/bug.service.ts, reduced — the 8th in-scope finding.
+    {
+      code: `export const bugReportCounter = cachedCounter<number>(
+         REDIS_KEYS.COUNTERS.BUG_REPORTS,
+         async (bugId) => 0,
+         { ttl: CacheTTL.hour }
+       );`,
       errors: [{ messageId: 'moduleScopeCache' }],
     },
 


### PR DESCRIPTION
## The failure class

A `createCachedObject(...)` / `createCachedArray(...)` / `cachedCounter(...)` at **module scope** runs when the file is *imported*, not when the cache is used.

That makes it a tripwire for every suite that wholesale-mocks `~/server/utils/cache-helpers` or `~/server/redis/client`. Such a factory replaces the entire module, so any export it omits is absent — and any suite that reaches the service **transitively** then fails during **collection**, before a single test runs:

```
No createCachedObject export is defined on the mock
Cannot read properties of undefined (reading 'PAID_ACCESS_CAP_TIER')
```

Nothing in the failing suite mentions the file that caused it, and collection errors surface one file at a time, so the causes peel off one per fix.

That is exactly what one eager `capTierCache` in `paid-access.service.ts` did: three model-service suites (57 tests) stopped collecting and `Unit tests` went red on `main` for every open PR. #3505 completed the mock factories; #3506 makes that one cache lazy. **Neither is a guard** — nothing stops the next one.

## Why guard the trigger, not the mocks

The obvious alternative is to widen `local-rules/no-wholesale-module-mock` (#3487) to cover `~/server/redis/client` and `~/server/utils/cache-helpers`. I measured it: **169 new error-severity findings across 152 files** (from a baseline of 0). Every one is a mock that is correct for what it tests, and the list only grows. That needs a baseline mechanism to be shippable at all, and it would not have caught this regression anyway — the three suites that broke were never touched by the PR that broke them.

Guarding the trigger is bounded instead by how many eager caches exist, and it fires on the line that actually introduces the hazard.

## What this adds

- **`local-rules/no-module-scope-cache`**, extending the existing `eslint-plugin-local-rules` mechanism (no new dependency). "Module scope" is decided structurally by walking to the nearest enclosing function, so a call inside a function passes — except an IIFE, which runs where it sits.
- Scoped to `src/server/services/**` + `src/server/redis/**` via an `overrides` entry, at `'error'` for the same reason as `no-wholesale-module-mock`: the only **blocking** ESLint step in `lint.yml` runs without `--max-warnings`, so `'warn'` would gate nothing.
- **35 RuleTester cases**, wired into `test:lint-rules`.

## Scope — what this guards, and what it deliberately does not

🔴 **The guarded construct is eager cache CONSTRUCTION, not eager `REDIS_KEYS` dereference.** The rule knows nothing about `REDIS_KEYS`; it covers that dereference only because the dereference is the creator call's own key argument. Both error signatures above come from the same statement — which one you see depends on which module the suite mocked.

A *bare* module-scope read — `const CACHE_KEY = REDIS_KEYS.CACHES.X;`, with no creator call near it — throws the identical `TypeError` at collection time and this rule reports **0** against it. There is one in scope today: `nowpayments.service.ts`.

I measured the extension before rejecting it. Counting module-scope `REDIS_KEYS.*` reads with the rule's own module-scope walk: **32 in the scoped dirs**, 6 more outside them. But

| | |
|---|---|
| 22 of the 32 | are in `caches.ts`, already behind the file-level disable — no new coverage |
| 8 more | **are** the key arguments of the 8 creator calls the rule already reports — covering them double-reports the same statements unless the rule also grows a "skip reads inside a call I already flagged" pass |
| 1 of the last 2 | is a test file's own `const KEY = REDIS_KEYS.CACHES.ACTIVE_AUCTIONS` — a suite that mocks the module itself, where the read is correct |

Net: **one** genuinely new guarded site, for ~10 new reports, a dedup pass, and a rule whose name stops describing what it does. So the message was **narrowed** instead: it now attributes the `TypeError` to *this line's* key argument and says plainly that the bare-read shape is not guarded. The counts and the condition for revisiting are in the rule header, in `.eslintrc.js`, and in `meta.docs.description`.

A rule whose text overstates its coverage is worse than a narrow rule, because the next author reads the message as a promise.

## Blast radius — 30 existing sites, 8 reported

| | |
|---|---|
| Reported | **8** — 7 services (`buzz`, `paid-access`, `model-file`, `user`, `creator-program`, `image`, `bug`) + `redis/resource-data.redis.ts`. **7** once #3506 lands. |
| Silenced | **22** in `src/server/redis/caches.ts`, via a documented file-level disable in that file. |

The 8th is `bugReportCounter` in `bug.service.ts` — a **`cachedCounter`**, the third `cache-helpers` factory with this hazard, and structurally identical to the `capTierCache` that broke `main`: it is an export of `cache-helpers` (so `undefined` on a wholesale mock of it) and its first argument dereferences `REDIS_KEYS.COUNTERS` at module scope. It sat inside the rule's own scope reporting **0**. Adding `'cachedCounter'` to the default creators list is the whole fix.

**It is reported, not silenced and not converted here.** The other 7 are reported; exempting this one would make the census inconsistent in exactly the way this PR argues against, and converting it would change a service export's shape (`bugReportCounter.get` → `bugReportCounter().get`, 2 call sites in 2 files) inside a diff that is otherwise pure lint infrastructure and carries no test for `bug.service.ts`. It gets #3506's treatment in its own change.

Two more module-scope `cachedCounter` calls live in `src/server/routers/` (`redeemableCode`, `research`) — outside this override, and left there: widening the glob is a separate blast-radius decision.

All 8 are pre-existing **files**, so a PR touching one reaches only the report-only modified-files step. What the rule can *block* is a newly added service or redis module — where the three-line lazy fix is cheapest, and the case that grows the backlog.

**The `caches.ts` disable is a blast-radius decision, not an absolution.** That file is the *hotter* tripwire, not the exempt one: all 22 of its caches are keyed off `REDIS_KEYS` at module scope, and it is imported far more widely than `paid-access.service.ts` was. The three suites #3505 repaired stay green only because they *also* mock `~/server/redis/caches` — the next suite that mocks `~/server/redis/client` without `CACHES` and reaches `caches.ts` unmocked dies identically, and making one service's cache lazy does not prevent that. Converting 22 call sites in the busiest cache module wants to be its own reviewable change; the reasoning and the condition for deleting the disable are written at the top of the file. Meanwhile the backlog stops growing, which is the part that keeps re-breaking collection.

Incidentally: the AST finds **30** sites where grep finds 29. A wrapped `export const x =\n  createCachedObject(` in `caches.ts` is invisible to a line-anchored pattern.

## The fix the rule asks for

The house pattern, already documented in the file that broke (`paidAccessCache`, same file, ~50 lines above where the eager one was added):

```ts
function createCapTierCache() {
  return createCachedObject<CachedCapTier>({ key: ..., lookupFn: ... });
}
let capTierCacheInstance: ReturnType<typeof createCapTierCache> | undefined;
function capTierCache() {
  return (capTierCacheInstance ??= createCapTierCache());
}
```

Runtime behaviour is unchanged — still one instance per process, built on first *use* instead of first *import*.

## Verification

**Killing mutations** — a guard that cannot fail is not a guard. Every new assertion has one:

1. **On the real regression, in real code.** The rule flags `paid-access.service.ts:156` on unmodified `main` — the exact eager `capTierCache` that broke `Unit tests`. Swapping in #3506's lazy version drops it to **0**; swapping back returns **1**.
2. **`createPaidAccessCache` in the same file is not flagged** — same call, inside a function. The negative control shares everything but the thing under test.
3. **Rule mutations kill tests.** Walk always returns `false` → 14 failures. Drop IIFE handling → the 3 IIFE cases fail. Drop the static/instance class-property distinction → 1 failure. Function bodies no longer defer → 13 failures.
4. **Drop `'cachedCounter'` from the default creators** → the new `bugReportCounter` case fails, alone.
5. **Make `creators` merge with the defaults instead of replacing them** → the new narrowed-options case fails.
6. **The `caches.ts` disable suppresses 22 real findings**, not zero — removing it reports 22, restoring it reports 0. A no-op disable comment would have looked identical from the outside.

**🔴 The mutation that survived, and the four cases that now catch it.** Dropping `parent.callee === fn` from `isImmediatelyInvoked` — so a function passed as a *call argument* counts as an IIFE — survived all 28 original cases, and changes nothing on today's tree either (still 8 findings, so the live population cannot catch it). Only a test can. It matters because the rule's own "Known gaps" comment invites closing the `TYPES.map(() => createCachedObject(...))` gap, and this *is* the naive attempt: it would ship green and then report every deferred callback added to the scoped dirs — `register(() => ...)`, `describe(...)`, any thunk stored for later. Four `valid` cases now pin it (arrow argument, `describe` block, function-expression argument, non-first-position argument); under the mutation exactly those four fail and nothing else. The rule header and `isImmediatelyInvoked`'s own doc comment now say so.

**Gates:**
- `test:lint-rules` — **152 passed** (3 files; this file 28 → 35 cases).
- The 3 suites #3505 repaired — **57 passed**.
- `tsc --noEmit` — **16 errors, byte-identical to a pristine baseline worktree at this branch's merge-base** (unbuilt `kysely`, uninitialised `event-engine-common`, pre-existing `image.service.ts` implicit-`any`). None in files touched here. (Current `origin/main` has 17: one more landed in `ModelVersionUpsertForm.tsx` after this branch's base, unrelated.)
- ESLint + Prettier on every added/changed file — clean.

**Not verified locally:** the full unit suite. Unbuilt `kysely` fails ~54 files locally regardless of this change, so a local run proves nothing; CI's `Unit tests` job covers it. This PR changes no runtime code.

Based on `main`, not stacked on #3506. The two are independent: #3506 fixes one site, this stops new ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
