### PR TITLE
fix(app-blocks): page through the source repo tree instead of throwing on apps over 1000 files

### DIFF
--- a/src/server/services/blocks/__tests__/forgejo.service.test.ts
+++ b/src/server/services/blocks/__tests__/forgejo.service.test.ts
@@ -225,17 +225,326 @@ describe('listRepoTreeAtRef pagination', () => {
     expect(treeCalls()).toHaveLength(1);
   });
 
-  it('gives up with a limit-naming error rather than paging forever', async () => {
+  it('gives up rather than paging forever when the host never says it is done', async () => {
     const { listRepoTreeAtRef } = await import('../forgejo.service');
-    // A server that always claims there is more: the pager must bail out at the
-    // bound instead of looping.
-    for (let i = 0; i < 20; i++) {
+    // A server that always claims there is more, one entry at a time: the pager
+    // must bail out at the REQUEST backstop instead of looping. The entry bound
+    // (8000) is nowhere near reached, so the error must name the real reason
+    // rather than blaming the app's file count.
+    for (let i = 0; i < 200; i++) {
       fm.enqueue({ tree: [{ path: `f${i}.txt`, type: 'blob', sha: `s${i}` }], truncated: true });
     }
 
-    await expect(listRepoTreeAtRef('runaway', 'ref_sha')).rejects.toThrow(/at most 2000 files/);
-    // Bounded: MAX_FILES_IN_BUNDLE * 4 entries / 1000 per page = 8 pages.
+    await expect(listRepoTreeAtRef('runaway', 'ref_sha')).rejects.toThrow(
+      /did not finish within 64 requests/
+    );
+    expect(treeCalls()).toHaveLength(64);
+  });
+
+  // --- The runaway bound must be on ENTRIES READ, not on page count. ---------
+  // Deriving the request cap as MAX_TREE_ENTRIES / TREE_PAGE_SIZE assumes the
+  // host honours the per_page we ask for — the exact assumption the stop
+  // condition refuses to make. Under a host that clamps per_page, that pairing
+  // rejects a legal tree with a message about a limit it never approached.
+  it('reads a legal tree to completion even when the host clamps per_page far below the request', async () => {
+    const { listRepoTreeAtRef } = await import('../forgejo.service');
+    // 1500 entries — comfortably legal (under both 2000 files and 8000 entries)
+    // — served 100 at a time because the host clamped per_page.
+    const CLAMPED = 100;
+    const TOTAL = 1500;
+    for (let page = 0; page * CLAMPED < TOTAL; page++) {
+      fm.enqueue({
+        tree: Array.from({ length: CLAMPED }, (_, i) => ({
+          path: `f${page * CLAMPED + i}.txt`,
+          type: 'blob',
+          sha: `s${page * CLAMPED + i}`,
+        })),
+        truncated: true,
+        total_count: TOTAL,
+      });
+    }
+
+    const result = await listRepoTreeAtRef('clamped', 'ref_sha');
+    expect(result.size).toBe(TOTAL);
+    expect(result.get('f0.txt')).toBe('s0');
+    expect(result.get('f1499.txt')).toBe('s1499');
+    expect(treeCalls()).toHaveLength(TOTAL / CLAMPED);
+  });
+
+  it('names the entry bound — not the request bound — when the tree is genuinely oversized', async () => {
+    const { listRepoTreeAtRef } = await import('../forgejo.service');
+    // Full 1000-entry pages of DIRECTORY entries, so the entry bound (8000) is
+    // what trips rather than the blob/file cap.
+    for (let page = 0; page < 12; page++) {
+      fm.enqueue({
+        tree: Array.from({ length: 1000 }, (_, i) => ({
+          path: `d${page}/${i}`,
+          type: 'tree',
+          sha: `st${page}_${i}`,
+        })),
+        truncated: true,
+      });
+    }
+
+    await expect(listRepoTreeAtRef('huge', 'ref_sha')).rejects.toThrow(/exceeds 8000 entries/);
+    // 8000 entries / 1000 per page = 8 requests, then the entry bound stops it.
     expect(treeCalls()).toHaveLength(8);
+  });
+
+  // --- An empty response BODY is an error, not a past-the-end marker. --------
+  // `unwrap` returns null for an empty body. Treating that the same as an
+  // envelope with a null `tree` would return a silently PARTIAL tree, which
+  // downstream becomes an incomplete approved bundle / a mirror that deletes
+  // the files it failed to read.
+  it('throws instead of silently truncating when a page comes back with an empty body', async () => {
+    const { listRepoTreeAtRef } = await import('../forgejo.service');
+    fm.enqueue({
+      tree: [
+        { path: 'p1-a.txt', type: 'blob', sha: 's1a' },
+        { path: 'p1-b.txt', type: 'blob', sha: 's1b' },
+        { path: 'p1-c.txt', type: 'blob', sha: 's1c' },
+      ],
+      truncated: true,
+      total_count: 9,
+    });
+    // Empty 200 mid-walk: 3 of 9 entries read. Must NOT resolve.
+    fm.enqueue(null);
+
+    await expect(listRepoTreeAtRef('partial', 'ref_sha')).rejects.toThrow(
+      /empty response body on page 2/
+    );
+  });
+
+  // --- A too-small total_count must not be trusted into a short read. --------
+  it('keeps paging past an under-reporting total_count when the page came back exactly full', async () => {
+    const { listRepoTreeAtRef } = await import('../forgejo.service');
+    // total_count lies: it says 1000 while there are really 1002 entries. The
+    // page came back EXACTLY full, which alone justifies one more probe.
+    fm.enqueue({
+      tree: Array.from({ length: 1000 }, (_, i) => ({
+        path: `f${i}.txt`,
+        type: 'blob',
+        sha: `s${i}`,
+      })),
+      truncated: true,
+      total_count: 1000,
+    });
+    fm.enqueue({
+      tree: [
+        { path: 'last-a.txt', type: 'blob', sha: 'sa' },
+        { path: 'last-b.txt', type: 'blob', sha: 'sb' },
+      ],
+      truncated: false,
+      total_count: 1000,
+    });
+
+    const result = await listRepoTreeAtRef('lying', 'ref_sha');
+    // The two entries an under-reporting total_count would have dropped.
+    expect(result.get('last-a.txt')).toBe('sa');
+    expect(result.get('last-b.txt')).toBe('sb');
+    expect(result.size).toBe(1002);
+    expect(treeCalls()).toHaveLength(2);
+  });
+
+  it('keeps paging past an exactly-full page carrying neither total_count nor truncated', async () => {
+    const { listRepoTreeAtRef } = await import('../forgejo.service');
+    // Neither field present: without the exactly-full probe this returns after
+    // page 1 (truncated !== true) and silently drops page 2.
+    fm.enqueue({
+      tree: Array.from({ length: 1000 }, (_, i) => ({
+        path: `f${i}.txt`,
+        type: 'blob',
+        sha: `s${i}`,
+      })),
+    });
+    fm.enqueue({ tree: [{ path: 'tail.txt', type: 'blob', sha: 'st' }] });
+
+    const result = await listRepoTreeAtRef('nometa', 'ref_sha');
+    expect(result.get('tail.txt')).toBe('st');
+    expect(result.size).toBe(1001);
+    expect(treeCalls()).toHaveLength(2);
+  });
+
+  // --- The `total > 0` guard. -----------------------------------------------
+  // A total_count of 0 alongside a non-empty page is self-contradictory, so it
+  // must NOT be taken as authoritative — `seen >= 0` is true immediately and
+  // would end the walk after page 1. The guard makes the code fall through to
+  // the `truncated` fallback instead.
+  it('ignores a total_count of 0 and falls through to the truncated fallback', async () => {
+    const { listRepoTreeAtRef } = await import('../forgejo.service');
+    fm.enqueue({
+      tree: [{ path: 'p1.txt', type: 'blob', sha: 's1' }],
+      truncated: true,
+      total_count: 0,
+    });
+    fm.enqueue({
+      tree: [{ path: 'p2.txt', type: 'blob', sha: 's2' }],
+      truncated: true,
+      total_count: 0,
+    });
+    fm.enqueue({
+      tree: [{ path: 'p3.txt', type: 'blob', sha: 's3' }],
+      truncated: false,
+      total_count: 0,
+    });
+
+    const result = await listRepoTreeAtRef('zerototal', 'ref_sha');
+    expect([...result.keys()].sort()).toEqual(['p1.txt', 'p2.txt', 'p3.txt']);
+    expect(treeCalls()).toHaveLength(3);
+  });
+
+  // --- The seen >= total boundary. ------------------------------------------
+  // 🔴 The multi-page fixture above steps 3+3+2 onto a total of 8, so `seen`
+  // only ever meets `total` exactly on the nose and an off-by-one on the LOW
+  // side (`seen + 1 >= total`) stays invisible. The discriminating shape is a
+  // page that leaves `seen` exactly ONE short of `total` while a further page
+  // still exists: there, `seen + 1 >= total` fires a page early and silently
+  // drops the tail. Note an OVERSHOOTING fixture (e.g. 3+3+3 against 8) does
+  // NOT discriminate — both forms stop on the same page.
+  it('does not stop a page early when a page lands exactly one entry short of total_count', async () => {
+    const { listRepoTreeAtRef } = await import('../forgejo.service');
+    // 3 + 4 + 1 = 8 against total_count 8: after page 2, seen === total - 1.
+    fm.enqueue({
+      tree: [
+        { path: 'p1-a.txt', type: 'blob', sha: 's1a' },
+        { path: 'p1-b.txt', type: 'blob', sha: 's1b' },
+        { path: 'p1-c.txt', type: 'blob', sha: 's1c' },
+      ],
+      truncated: true,
+      total_count: 8,
+    });
+    fm.enqueue({
+      tree: [
+        { path: 'p2-a.txt', type: 'blob', sha: 's2a' },
+        { path: 'p2-b.txt', type: 'blob', sha: 's2b' },
+        { path: 'p2-c.txt', type: 'blob', sha: 's2c' },
+        { path: 'p2-d.txt', type: 'blob', sha: 's2d' },
+      ],
+      truncated: true,
+      total_count: 8,
+    });
+    // The single trailing entry an off-by-one loses.
+    fm.enqueue({
+      tree: [{ path: 'p3-tail.txt', type: 'blob', sha: 's3tail' }],
+      truncated: true,
+      total_count: 8,
+    });
+
+    const result = await listRepoTreeAtRef('boundary', 'ref_sha');
+    expect(result.get('p3-tail.txt')).toBe('s3tail');
+    expect(result.size).toBe(8);
+    expect(treeCalls()).toHaveLength(3);
+  });
+
+  // The mirror case: a page that OVERSHOOTS `total_count` must still terminate
+  // on that page rather than paging on past the end.
+  it('stops on a page that overshoots total_count', async () => {
+    const { listRepoTreeAtRef } = await import('../forgejo.service');
+    // 3 + 3 + 3 = 9 entries read against a total of 8.
+    for (const page of [1, 2, 3]) {
+      fm.enqueue({
+        tree: [
+          { path: `p${page}-a.txt`, type: 'blob', sha: `s${page}a` },
+          { path: `p${page}-b.txt`, type: 'blob', sha: `s${page}b` },
+          { path: `p${page}-c.txt`, type: 'blob', sha: `s${page}c` },
+        ],
+        truncated: true,
+        total_count: 8,
+      });
+    }
+
+    const result = await listRepoTreeAtRef('overshoot', 'ref_sha');
+    expect(result.get('p3-c.txt')).toBe('s3c');
+    expect(result.size).toBe(9);
+    expect(treeCalls()).toHaveLength(3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// The file cap. MAX_TREE_ENTRIES bounds tree ENTRIES (blobs + directories) as a
+// loop guard; this bounds BLOBS — the quantity the limit error actually names,
+// and the one submit-time validation caps. Without it the pager would hand back
+// several thousand files from a function promising at most 2000.
+// ---------------------------------------------------------------------------
+describe('listRepoTreeAtRef file cap', () => {
+  const treeCalls = () => fm.calls.filter((c) => c.url.includes('/git/trees/'));
+
+  const blobPage = (start: number, count: number, extra: Record<string, unknown>) => ({
+    tree: Array.from({ length: count }, (_, i) => ({
+      path: `f${start + i}.txt`,
+      type: 'blob',
+      sha: `s${start + i}`,
+    })),
+    ...extra,
+  });
+
+  it('rejects a tree holding more blobs than an app may contain', async () => {
+    const { listRepoTreeAtRef } = await import('../forgejo.service');
+    // 3000 blobs across 3 full pages — under the 8000-entry loop guard, but
+    // over the 2000-file cap the error message names.
+    fm.enqueue(blobPage(0, 1000, { truncated: true, total_count: 3000 }));
+    fm.enqueue(blobPage(1000, 1000, { truncated: true, total_count: 3000 }));
+    fm.enqueue(blobPage(2000, 1000, { truncated: false, total_count: 3000 }));
+    // An exactly-full final page always costs one confirming probe.
+    fm.enqueue({ tree: [], truncated: false, total_count: 3000 });
+
+    await expect(listRepoTreeAtRef('toomany', 'ref_sha')).rejects.toThrow(
+      /holds 3000 files; an app may contain at most 2000/
+    );
+  });
+
+  it('accepts a tree of exactly MAX_FILES_IN_BUNDLE files', async () => {
+    const { listRepoTreeAtRef } = await import('../forgejo.service');
+    fm.enqueue(blobPage(0, 1000, { truncated: true, total_count: 2000 }));
+    fm.enqueue(blobPage(1000, 1000, { truncated: false, total_count: 2000 }));
+    fm.enqueue({ tree: [], truncated: false, total_count: 2000 });
+
+    const result = await listRepoTreeAtRef('atcap', 'ref_sha');
+    expect(result.size).toBe(2000);
+  });
+
+  it('does not disturb the sub-cap happy path — one request, identical result', async () => {
+    const { listRepoTreeAtRef } = await import('../forgejo.service');
+    fm.enqueue({
+      tree: [
+        { path: 'block.manifest.json', type: 'blob', sha: 'sm' },
+        { path: 'src', type: 'tree', sha: 'sd' },
+        { path: 'src/index.tsx', type: 'blob', sha: 'si' },
+      ],
+      truncated: false,
+      total_count: 3,
+    });
+
+    const result = await listRepoTreeAtRef('small', 'ref_sha');
+    expect([...result.entries()]).toEqual([
+      ['block.manifest.json', 'sm'],
+      ['src/index.tsx', 'si'],
+    ]);
+    // Exactly one round-trip — the cap adds no request and no behaviour change
+    // for a normal app.
+    expect(treeCalls()).toHaveLength(1);
+  });
+
+  // The cap is on BLOBS, not entries: a directory-heavy repo under the file cap
+  // must still pass even though its entry count is higher.
+  it('counts blobs, not directory entries, against the file cap', async () => {
+    const { listRepoTreeAtRef } = await import('../forgejo.service');
+    // 1500 blobs + 1500 directory entries = 3000 entries, but only 1500 files.
+    const entries = [
+      ...Array.from({ length: 1500 }, (_, i) => ({
+        path: `f${i}.txt`,
+        type: 'blob',
+        sha: `s${i}`,
+      })),
+      ...Array.from({ length: 1500 }, (_, i) => ({ path: `d${i}`, type: 'tree', sha: `st${i}` })),
+    ];
+    fm.enqueue({ tree: entries.slice(0, 1000), truncated: true, total_count: 3000 });
+    fm.enqueue({ tree: entries.slice(1000, 2000), truncated: true, total_count: 3000 });
+    fm.enqueue({ tree: entries.slice(2000), truncated: false, total_count: 3000 });
+    fm.enqueue({ tree: [], truncated: false, total_count: 3000 });
+
+    const result = await listRepoTreeAtRef('dirheavy', 'ref_sha');
+    expect(result.size).toBe(1500);
   });
 });
 

--- a/src/server/services/blocks/__tests__/forgejo.service.test.ts
+++ b/src/server/services/blocks/__tests__/forgejo.service.test.ts
@@ -88,25 +88,16 @@ describe('listRepoTree', () => {
     expect(fm.calls[0].url).toBe(
       'https://forgejo.example/api/v1/repos/civitai-apps/hello/branches/main'
     );
-    // Recursive=true + per_page=1000.
+    // Recursive=true + per_page=1000 (the endpoint's own ceiling) + page=1.
     expect(fm.calls[1].url).toBe(
-      'https://forgejo.example/api/v1/repos/civitai-apps/hello/git/trees/commit_sha?recursive=true&per_page=1000'
+      'https://forgejo.example/api/v1/repos/civitai-apps/hello/git/trees/commit_sha?recursive=true&per_page=1000&page=1'
     );
+    // A tree that fits in one page costs exactly one tree request.
+    expect(fm.calls.filter((c) => c.url.includes('/git/trees/'))).toHaveLength(1);
     // Auth header carried.
     expect((fm.calls[0].init?.headers as Record<string, string>)['Authorization']).toBe(
       'token tok-test'
     );
-  });
-
-  it('throws when the tree is truncated (>1000 entries; no pagination yet)', async () => {
-    const { listRepoTree } = await import('../forgejo.service');
-    fm.enqueue({ commit: { id: 'commit_sha' } });
-    fm.enqueue({
-      tree: [{ path: 'a', type: 'blob', sha: 'b1' }],
-      truncated: true,
-    });
-
-    await expect(listRepoTree('hello', 'main')).rejects.toThrow(/truncated/);
   });
 
   it('URL-encodes the branch name', async () => {
@@ -121,6 +112,130 @@ describe('listRepoTree', () => {
     const { listRepoTree } = await import('../forgejo.service');
     fm.enqueue({ message: 'branch not found' }, 404);
     await expect(listRepoTree('hello', 'main')).rejects.toThrow(/404/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tree pagination. Submit-time validation accepts up to MAX_FILES_IN_BUNDLE
+// (2000) files but a single tree response holds at most 1000 entries, so an app
+// over 1000 files MUST be read across pages. Before the fix this threw on the
+// `truncated` flag, which made such an app impossible to approve / diff /
+// preview once accepted.
+//
+// The pages below are deliberately SMALLER than the requested per_page: the
+// server is free to clamp `per_page` down, so "a short page means the last
+// page" is not a safe stop condition and the walk must not end on one.
+// ---------------------------------------------------------------------------
+describe('listRepoTreeAtRef pagination', () => {
+  const treeCalls = () => fm.calls.filter((c) => c.url.includes('/git/trees/'));
+
+  it('walks every page — including the final partial one — using total_count', async () => {
+    const { listRepoTreeAtRef } = await import('../forgejo.service');
+    fm.enqueue({
+      tree: [
+        { path: 'p1-a.txt', type: 'blob', sha: 's1a' },
+        { path: 'dir', type: 'tree', sha: 'st1' },
+        { path: 'p1-b.txt', type: 'blob', sha: 's1b' },
+      ],
+      truncated: true,
+      total_count: 8,
+    });
+    fm.enqueue({
+      tree: [
+        { path: 'p2-a.txt', type: 'blob', sha: 's2a' },
+        { path: 'p2-b.txt', type: 'blob', sha: 's2b' },
+        { path: 'p2-c.txt', type: 'blob', sha: 's2c' },
+      ],
+      truncated: true,
+      total_count: 8,
+    });
+    fm.enqueue({
+      tree: [
+        { path: 'p3-a.txt', type: 'blob', sha: 's3a' },
+        { path: 'p3-b.txt', type: 'blob', sha: 's3b' },
+      ],
+      truncated: true,
+      total_count: 8,
+    });
+
+    const result = await listRepoTreeAtRef('big', 'ref_sha');
+
+    // Every page contributed — the LAST page is the one a loop that stops early
+    // loses, so assert it explicitly.
+    expect(result.get('p1-a.txt')).toBe('s1a');
+    expect(result.get('p1-b.txt')).toBe('s1b');
+    expect(result.get('p2-a.txt')).toBe('s2a');
+    expect(result.get('p2-c.txt')).toBe('s2c');
+    expect(result.get('p3-a.txt')).toBe('s3a');
+    expect(result.get('p3-b.txt')).toBe('s3b');
+    // Blobs only, all 7 of them; the directory entry is still excluded.
+    expect(result.size).toBe(7);
+    expect(result.has('dir')).toBe(false);
+
+    // page= increments, per_page stays at the endpoint ceiling, and total_count
+    // means no wasted trailing request.
+    expect(treeCalls()).toHaveLength(3);
+    expect(treeCalls()[0].url).toContain('recursive=true&per_page=1000&page=1');
+    expect(treeCalls()[1].url).toContain('recursive=true&per_page=1000&page=2');
+    expect(treeCalls()[2].url).toContain('recursive=true&per_page=1000&page=3');
+  });
+
+  it('walks every page when the response carries no total_count (truncated fallback)', async () => {
+    const { listRepoTreeAtRef } = await import('../forgejo.service');
+    fm.enqueue({
+      tree: [{ path: 'p1.txt', type: 'blob', sha: 's1' }],
+      truncated: true,
+    });
+    fm.enqueue({
+      tree: [{ path: 'p2.txt', type: 'blob', sha: 's2' }],
+      truncated: true,
+    });
+    // Short final page — must NOT be mistaken for "done"; only the empty page
+    // that follows ends the walk.
+    fm.enqueue({
+      tree: [{ path: 'p3.txt', type: 'blob', sha: 's3' }],
+      truncated: true,
+    });
+    fm.enqueue({ tree: [], truncated: true });
+
+    const result = await listRepoTreeAtRef('big', 'ref_sha');
+    expect([...result.keys()].sort()).toEqual(['p1.txt', 'p2.txt', 'p3.txt']);
+    expect(treeCalls()).toHaveLength(4);
+  });
+
+  it('tolerates a null tree past the end of the listing', async () => {
+    const { listRepoTreeAtRef } = await import('../forgejo.service');
+    fm.enqueue({ tree: [{ path: 'a.txt', type: 'blob', sha: 's1' }], truncated: true });
+    fm.enqueue({ tree: null, truncated: true });
+
+    const result = await listRepoTreeAtRef('big', 'ref_sha');
+    expect(result.get('a.txt')).toBe('s1');
+  });
+
+  it('stops after a single page when the tree is not truncated', async () => {
+    const { listRepoTreeAtRef } = await import('../forgejo.service');
+    fm.enqueue({
+      tree: [{ path: 'only.txt', type: 'blob', sha: 's1' }],
+      truncated: false,
+      total_count: 1,
+    });
+
+    const result = await listRepoTreeAtRef('small', 'ref_sha');
+    expect(result.size).toBe(1);
+    expect(treeCalls()).toHaveLength(1);
+  });
+
+  it('gives up with a limit-naming error rather than paging forever', async () => {
+    const { listRepoTreeAtRef } = await import('../forgejo.service');
+    // A server that always claims there is more: the pager must bail out at the
+    // bound instead of looping.
+    for (let i = 0; i < 20; i++) {
+      fm.enqueue({ tree: [{ path: `f${i}.txt`, type: 'blob', sha: `s${i}` }], truncated: true });
+    }
+
+    await expect(listRepoTreeAtRef('runaway', 'ref_sha')).rejects.toThrow(/at most 2000 files/);
+    // Bounded: MAX_FILES_IN_BUNDLE * 4 entries / 1000 per page = 8 pages.
+    expect(treeCalls()).toHaveLength(8);
   });
 });
 

--- a/src/server/services/blocks/forgejo.service.ts
+++ b/src/server/services/blocks/forgejo.service.ts
@@ -305,15 +305,34 @@ export async function listRepoTree(
 const TREE_PAGE_SIZE = 1000;
 
 /**
- * Runaway guard for the tree pager — the most entries we are willing to read
+ * Size bound for the tree pager — the most entries we are willing to read
  * before giving up, derived from the submit-time file cap rather than a magic
  * number. A tree listing returns a directory entry per folder on top of one
  * entry per file, so allow headroom over MAX_FILES_IN_BUNDLE; a well-formed
- * app stops long before this. Exists purely so a pathological or misbehaving
- * repo can never spin the loop forever.
+ * app stops long before this.
+ *
+ * This bounds TREE SIZE. It is not the anti-infinite-loop backstop (that is
+ * MAX_TREE_REQUESTS below), and it is not the file limit the caller cares
+ * about (that is MAX_FILES_IN_BUNDLE, applied to blobs at the end) — the three
+ * bounds are deliberately distinct.
  */
 const MAX_TREE_ENTRIES = MAX_FILES_IN_BUNDLE * 4;
-const MAX_TREE_PAGES = Math.ceil(MAX_TREE_ENTRIES / TREE_PAGE_SIZE);
+
+/**
+ * Anti-infinite-loop backstop on the number of REQUESTS, which is a separate
+ * bound from MAX_TREE_ENTRIES (the bound on entries actually read).
+ *
+ * 🔴 They must stay separate. Deriving this from MAX_TREE_ENTRIES /
+ * TREE_PAGE_SIZE would assume the host honours the `per_page` we ask for —
+ * precisely the assumption the stop condition below deliberately refuses to
+ * make. A host that clamped `per_page` to 100 would exhaust an 8-request
+ * budget after only 800 entries and then reject a perfectly legal 1500-entry
+ * tree for "exceeding 8000 entries": a false ceiling an order of magnitude
+ * below the real one. Sizing the request budget well above
+ * MAX_TREE_ENTRIES / TREE_PAGE_SIZE keeps a full-size tree readable even when
+ * the host serves it in much smaller pages, while still bounding the walk.
+ */
+const MAX_TREE_REQUESTS = 64;
 
 /**
  * Recursively list every blob in the repo at an arbitrary git ref —
@@ -335,11 +354,31 @@ const MAX_TREE_PAGES = Math.ceil(MAX_TREE_ENTRIES / TREE_PAGE_SIZE);
  * Stop condition, in priority order — deliberately NOT "a short page means the
  * last page", because the server is free to clamp `per_page` below what we ask
  * for, which would make the very first page look short and end the walk early:
- *   1. an empty page  → nothing left;
- *   2. `total_count`  → authoritative entry total; stop once we have seen it
- *                       all (saves the trailing empty-page round-trip);
- *   3. `truncated`    → fallback for a response without `total_count`: keep
+ *   1. an empty page      → nothing left;
+ *   2. an exactly-FULL page → always probe once more. A page that filled to the
+ *                       requested size is the one case where "there is more"
+ *                       needs no corroboration from the host's own metadata,
+ *                       so this costs nothing and removes the only branch that
+ *                       could silently under-read (a `total_count` that
+ *                       under-reports, or a response carrying neither
+ *                       `total_count` nor `truncated`);
+ *   3. `total_count`      → authoritative entry total; stop once we have seen it
+ *                       all (saves the trailing empty-page round-trip — but only
+ *                       when the final page came back PARTIAL, which is the
+ *                       normal case; a tree whose size is an exact multiple of
+ *                       the page size still pays one confirming probe, per (2));
+ *   4. `truncated`        → fallback for a response without `total_count`: keep
  *                       paging while the flag says the tree overflows a page.
+ *
+ * 🔴 An empty response BODY is not a stop condition — it is an error. `unwrap`
+ * returns null for one, which is a different thing from an envelope carrying a
+ * null `tree` (the host's legitimate past-the-end marker). Collapsing the two
+ * would let a 204, a truncated body or a gateway artifact mid-walk return a
+ * SILENTLY PARTIAL tree, and every caller treats what it gets back as the
+ * complete tree: `reconstructBundleFromForgejo` would make an incomplete bundle
+ * the approved artifact (with a bundleSha256 over the partial set), and
+ * `commitFiles(replaceAllFiles: true)` would emit deletes only for the paths it
+ * managed to read, silently leaving stale files behind.
  */
 export async function listRepoTreeAtRef(
   slug: string,
@@ -348,8 +387,9 @@ export async function listRepoTreeAtRef(
 ): Promise<Map<string, string>> {
   const result = new Map<string, string>();
   let seen = 0;
+  let complete = false;
 
-  for (let page = 1; page <= MAX_TREE_PAGES; page++) {
+  for (let page = 1; seen < MAX_TREE_ENTRIES && page <= MAX_TREE_REQUESTS; page++) {
     const treeRes = await fjFetch(
       `/api/v1/repos/${org}/${slug}/git/trees/${encodeURIComponent(
         ref
@@ -361,27 +401,79 @@ export async function listRepoTreeAtRef(
       tree?: Array<{ path: string; type: string; sha: string }> | null;
       truncated?: boolean;
       total_count?: number;
-    }>(treeRes);
+    } | null>(treeRes);
 
-    const entries = tree?.tree ?? [];
+    // No envelope at all — an empty body, not a past-the-end marker. Refuse to
+    // pass off however much we happened to read as the complete tree.
+    if (tree == null)
+      throw new Error(
+        `Forgejo tree for ${slug}@${ref}: empty response body on page ${page} after ` +
+          `${seen} entries — refusing to treat a partial tree as complete`
+      );
+
+    const entries = tree.tree ?? [];
     for (const item of entries) {
       if (item.type === 'blob') result.set(item.path, item.sha);
     }
     seen += entries.length;
 
-    if (entries.length === 0) return result;
-    const total = typeof tree?.total_count === 'number' ? tree.total_count : undefined;
+    if (entries.length === 0) {
+      complete = true;
+      break;
+    }
+    // An exactly-full page always warrants one more probe, whatever the host's
+    // metadata claims. This cannot resurrect the short-page bug guarded against
+    // above (it only ever continues, never stops), and stays inside the loop
+    // bounds.
+    if (entries.length >= TREE_PAGE_SIZE) continue;
+
+    const total = typeof tree.total_count === 'number' ? tree.total_count : undefined;
     if (total !== undefined && total > 0) {
-      if (seen >= total) return result;
-    } else if (tree?.truncated !== true) {
-      return result;
+      if (seen >= total) {
+        complete = true;
+        break;
+      }
+    } else if (tree.truncated !== true) {
+      complete = true;
+      break;
     }
   }
 
-  throw new Error(
-    `Forgejo tree for ${slug}@${ref} exceeds ${MAX_TREE_ENTRIES} entries; an app may contain at ` +
-      `most ${MAX_FILES_IN_BUNDLE} files — reduce the file count and re-submit`
-  );
+  // Name the bound that actually tripped: "too big" and "the host is paginating
+  // in unexpectedly small pages" are different operator problems.
+  if (!complete) {
+    if (seen >= MAX_TREE_ENTRIES)
+      throw new Error(
+        `Forgejo tree for ${slug}@${ref} exceeds ${MAX_TREE_ENTRIES} entries; an app may contain ` +
+          `at most ${MAX_FILES_IN_BUNDLE} files — reduce the file count and re-submit`
+      );
+    throw new Error(
+      `Forgejo tree for ${slug}@${ref} did not finish within ${MAX_TREE_REQUESTS} requests ` +
+        `(${seen} entries read); the source host is paginating in unexpectedly small pages`
+    );
+  }
+
+  // 🔴 Bound the quantity the caller actually cares about. MAX_TREE_ENTRIES
+  // bounds tree ENTRIES (blobs + directories) as a loop guard; nothing above
+  // bounds BLOBS, so without this a repo could hand back several thousand files
+  // from a function whose limit error promises at most MAX_FILES_IN_BUNDLE.
+  //
+  // This is a real gate, not just an honest message. On the git-push path
+  // MAX_FILES_IN_BUNDLE is otherwise unenforced: `enrichPushRequestRow` wraps
+  // the cap-applying diff computation in a catch that only logs (the row still
+  // parks as pending), and the approve path's bundle extraction caps total
+  // bytes but not file count. Before this function paged, its `truncated` throw
+  // was incidentally enforcing a ceiling here; keeping an explicit one means
+  // paging did not quietly raise it. Every caller is app-repo-scoped — the
+  // canonical `civitai-apps/<slug>` or its review mirror, whose contents ARE
+  // the bundle — so none legitimately needs more than this.
+  if (result.size > MAX_FILES_IN_BUNDLE)
+    throw new Error(
+      `Forgejo tree for ${slug}@${ref} holds ${result.size} files; an app may contain at most ` +
+        `${MAX_FILES_IN_BUNDLE} — reduce the file count and re-submit`
+    );
+
+  return result;
 }
 
 /**

--- a/src/server/services/blocks/forgejo.service.ts
+++ b/src/server/services/blocks/forgejo.service.ts
@@ -19,6 +19,7 @@
 
 import { randomBytes } from 'crypto';
 import { env } from '~/env/server';
+import { MAX_FILES_IN_BUNDLE } from '~/server/schema/blocks/publish-request.schema';
 
 export const FORGEJO_ORG = 'civitai-apps';
 const FORGEJO_REVIEW_ORG = 'civitai-apps-review';
@@ -280,6 +281,9 @@ export async function setCommitStatus(opts: {
  * delete-vs-update, and to look up blob SHAs for updates. Also used
  * by the W1 backfill to know what files to pull when reconstructing
  * a bundle from a live Forgejo repo.
+ *
+ * Delegates the tree read to `listRepoTreeAtRef`, so it inherits that
+ * function's pagination over trees larger than one page.
  */
 export async function listRepoTree(
   slug: string,
@@ -294,6 +298,24 @@ export async function listRepoTree(
 }
 
 /**
+ * Page size for the recursive tree listing. 1000 is the API's own ceiling
+ * for this endpoint (a larger `per_page` is silently clamped down to it), so
+ * this is the fewest round-trips a full tree read can cost.
+ */
+const TREE_PAGE_SIZE = 1000;
+
+/**
+ * Runaway guard for the tree pager — the most entries we are willing to read
+ * before giving up, derived from the submit-time file cap rather than a magic
+ * number. A tree listing returns a directory entry per folder on top of one
+ * entry per file, so allow headroom over MAX_FILES_IN_BUNDLE; a well-formed
+ * app stops long before this. Exists purely so a pathological or misbehaving
+ * repo can never spin the loop forever.
+ */
+const MAX_TREE_ENTRIES = MAX_FILES_IN_BUNDLE * 4;
+const MAX_TREE_PAGES = Math.ceil(MAX_TREE_ENTRIES / TREE_PAGE_SIZE);
+
+/**
  * Recursively list every blob in the repo at an arbitrary git ref —
  * a commit SHA (NOT just a branch name) — as Map<path, blob-sha>. Same
  * shape as `listRepoTree`, but skips the branch→commit lookup so the
@@ -302,29 +324,64 @@ export async function listRepoTree(
  *
  * Forgejo's `git/trees/<ref>` resolves a commit ref to its root tree, so
  * passing a commit SHA returns that commit's full recursive blob list.
+ *
+ * 🔴 PAGINATED. The endpoint caps a single response at TREE_PAGE_SIZE entries
+ * and flags the overflow with `truncated`, while submit-time validation accepts
+ * up to MAX_FILES_IN_BUNDLE (2000) files — so an app between 1001 and 2000
+ * files produces a tree this function MUST page through. It used to throw on
+ * `truncated` instead, which made such an app impossible to approve, diff or
+ * preview once accepted.
+ *
+ * Stop condition, in priority order — deliberately NOT "a short page means the
+ * last page", because the server is free to clamp `per_page` below what we ask
+ * for, which would make the very first page look short and end the walk early:
+ *   1. an empty page  → nothing left;
+ *   2. `total_count`  → authoritative entry total; stop once we have seen it
+ *                       all (saves the trailing empty-page round-trip);
+ *   3. `truncated`    → fallback for a response without `total_count`: keep
+ *                       paging while the flag says the tree overflows a page.
  */
 export async function listRepoTreeAtRef(
   slug: string,
   ref: string,
   org: string = FORGEJO_ORG
 ): Promise<Map<string, string>> {
-  const treeRes = await fjFetch(
-    `/api/v1/repos/${org}/${slug}/git/trees/${encodeURIComponent(ref)}?recursive=true&per_page=1000`
-  );
-  const tree = await unwrap<{
-    tree: Array<{ path: string; type: string; sha: string }>;
-    truncated?: boolean;
-  }>(treeRes);
-  if (tree.truncated) {
-    throw new Error(
-      `Forgejo tree for ${slug}@${ref} is truncated (>1000 entries); pagination not implemented`
-    );
-  }
   const result = new Map<string, string>();
-  for (const item of tree.tree) {
-    if (item.type === 'blob') result.set(item.path, item.sha);
+  let seen = 0;
+
+  for (let page = 1; page <= MAX_TREE_PAGES; page++) {
+    const treeRes = await fjFetch(
+      `/api/v1/repos/${org}/${slug}/git/trees/${encodeURIComponent(
+        ref
+      )}?recursive=true&per_page=${TREE_PAGE_SIZE}&page=${page}`
+    );
+    const tree = await unwrap<{
+      // Past the end of the tree the API answers with a null/absent list, so
+      // this is not guaranteed to be an array.
+      tree?: Array<{ path: string; type: string; sha: string }> | null;
+      truncated?: boolean;
+      total_count?: number;
+    }>(treeRes);
+
+    const entries = tree?.tree ?? [];
+    for (const item of entries) {
+      if (item.type === 'blob') result.set(item.path, item.sha);
+    }
+    seen += entries.length;
+
+    if (entries.length === 0) return result;
+    const total = typeof tree?.total_count === 'number' ? tree.total_count : undefined;
+    if (total !== undefined && total > 0) {
+      if (seen >= total) return result;
+    } else if (tree?.truncated !== true) {
+      return result;
+    }
   }
-  return result;
+
+  throw new Error(
+    `Forgejo tree for ${slug}@${ref} exceeds ${MAX_TREE_ENTRIES} entries; an app may contain at ` +
+      `most ${MAX_FILES_IN_BUNDLE} files — reduce the file count and re-submit`
+  );
 }
 
 /**


### PR DESCRIPTION
## The mismatch

Submit-time validation accepts an app of up to `MAX_FILES_IN_BUNDLE` = **2000** files
(`src/server/schema/blocks/publish-request.schema.ts`).

`listRepoTreeAtRef` (`src/server/services/blocks/forgejo.service.ts`) read the source
host's recursive tree listing as a **single page** and hard-threw when the host flagged
the response as truncated — which it does past **1000** entries:

```ts
if (tree.truncated) {
  throw new Error(`... is truncated (>1000 entries); pagination not implemented`);
}
```

So an app between **1001 and 2000 files** passes submit and then breaks everything
downstream that reads its tree.

## Blast radius

- `reconstructBundleFromForgejo` → `approveRequest` for git-push submissions,
  `getPublishRequestDiff`, and the review-preview mirror path
- `listRepoTree` → `commitFiles`, and the review-preview short-circuit added in #3496

Net effect: **a submission over 1000 files could not be approved, diffed, or previewed** —
a hard throw on the *approve* path, i.e. a confusing dead end for both the developer and
the moderator.

Currently latent: no app has crossed 1000 files yet. This fixes it before the first one does.

## What the fix does

Replaces the throw with a real pager over the tree endpoint's `page` / `per_page` params.

The stop condition is deliberately **not** "a short page means the last page". The host is
free to clamp `per_page` below what we ask for, which would make the very first page look
short and end the walk early — silently returning an incomplete tree, which downstream
reads as "these files were deleted". Instead, in priority order:

1. **an empty page** → nothing left;
2. **`total_count`** → authoritative entry total when present; stop once we have seen it all
   (also saves the trailing empty-page round-trip);
3. **`truncated`** → fallback when a response carries no `total_count`: keep paging while the
   flag says the tree overflows a page.

None of those assume a page size, so a server-side clamp can't truncate the walk.

Unchanged for trees under the cap: page size stays at the endpoint's own **1000-entry
ceiling** (a larger `per_page` is clamped down to it anyway), so a tree that fits in one page
still costs **exactly one request** and returns the same blob-only `Map<path, sha>`, in the
same order, with the same error handling. `listRepoTree` delegates to `listRepoTreeAtRef`,
so it gets the fix for free.

A runaway guard bounds the loop — derived from `MAX_FILES_IN_BUNDLE` rather than a new magic
number (files, plus a directory entry per folder, plus headroom) — and if a repo genuinely
exceeds it, throws an error naming the real 2000-file limit and what to do.

Not touched: `MAX_FILES_IN_BUNDLE`, any submit-time validation, `approveRequest`'s logic, the
diff, or the preview mirror. They simply stop breaking. No migration.

## Verified

- **Mutation check.** The natural failure here is a pager that silently stops early, so both
  variants were introduced deliberately and confirmed to fail:
  - stop after the first page → **3 of the new tests fail** (multi-page walk, no-`total_count`
    fallback, runaway bound)
  - treat a short page as the last page → **the same 3 fail**
  - reverted; suite green again.
- **New tests**: a 3-page walk with a **final partial page**, asserting entries from every page
  *including the last*, plus the `page=` increments and that `total_count` avoids a 4th request;
  the no-`total_count` (`truncated`) fallback terminating on an empty page; a `null` tree past
  the end of the listing; the single-page fast path still costing exactly one request; and the
  runaway bound throwing with the file limit named. Pages in the tests are intentionally
  *smaller* than the requested `per_page`, so a short page can never be mistaken for the end.
- **Suites** (`vitest --project unit`):
  - `src/server/services/blocks` — before **1846 passed / 2 failed**, after **1850 passed / 2 failed**
    (+4 = 5 new tests, 1 obsolete "throws when truncated" test removed)
  - `src/tests/api/internal/blocks` + `blocks.router.getMyAppRepo` + `purge-review-snapshots` —
    **191 passed** before and after
  - The 2 failures are **pre-existing and identical on `main`** in the same worktree: a local
    `Cannot find package 'kysely'` module-resolution error in `manifest-schema-endpoint.test.ts`
    (package not installed locally). Not touched by this change.
- **Typecheck**: full-repo `tsc --noEmit` gives **16 errors on this branch and 16 on `main`** —
  identical, all pre-existing missing-module/implicit-any noise from packages that aren't
  installed locally. **Zero** errors in the touched files.
- **Lint**: eslint clean on both touched files. (Prettier reports pre-existing formatting drift
  in both files on `main` too; deliberately not reformatted, to keep the diff readable.)

## Not verified

- **No end-to-end run against a real >1000-file app.** The pagination is exercised against a
  mocked multi-page response only — no such app exists yet, which is exactly why the bug is
  latent. The response-field assumptions (`page`, `per_page`, `truncated`, `total_count`, and a
  null `tree` past the end) come from the endpoint's documented behaviour, not from a live call.
  The stop logic is written so that any one of those fields being absent still terminates
  correctly, but the first real large submission is the true confirmation.
- CI is the real gate for the full test + build matrix; only the suites listed above were run
  locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
