### PR TITLE
fix(downloads): stop a cached availability record from denying a Public model

### DIFF
--- a/src/server/redis/caches.ts
+++ b/src/server/redis/caches.ts
@@ -367,7 +367,43 @@ export const userBasicCache = createCachedObject<UserBasicLookup>({
   localMaxBytes: L1_CACHE_BYTE_BUDGETS.userBasic, // ~4MB (tiny records)
 });
 
-type ModelVersionAccessCache = EntityAccessDataType & { publishedAt: Date; status: ModelStatus };
+export type ModelVersionAccessCache = EntityAccessDataType & {
+  publishedAt: Date;
+  status: ModelStatus;
+};
+
+/**
+ * The authoritative availability read behind modelVersionAccessCache. Exported because
+ * `dontCacheFn` below means the cache is *allowed* to hold nothing for an id, and callers that
+ * gate access on the result (hasEntityAccess) must be able to resolve those ids for real rather
+ * than assume the worst.
+ */
+export async function lookupModelVersionAccess(
+  ids: number[],
+  fromWrite?: boolean
+): Promise<Record<string, ModelVersionAccessCache>> {
+  const goodIds = ids.filter(isDefined);
+  if (!goodIds.length) return {};
+  const db = fromWrite ? dbWrite : dbRead;
+  const entityAccessData = await db.$queryRaw<ModelVersionAccessCache[]>(Prisma.sql`
+    SELECT
+      mv.id AS "entityId",
+      mmv."userId" AS "userId",
+      -- Model availability prevails if it's private
+      CASE
+        WHEN mmv.availability = 'Private'
+          THEN mmv."availability"
+        ELSE mv."availability"
+      END AS "availability",
+      mv."publishedAt" AS "publishedAt",
+      mv."status" as "status"
+    FROM "ModelVersion" mv
+         JOIN "Model" mmv ON mv."modelId" = mmv.id
+    WHERE
+      mv.id IN (${Prisma.join(goodIds, ',')})
+  `);
+  return Object.fromEntries(entityAccessData.map((x) => [x.entityId, x]));
+}
 
 export const modelVersionAccessCache = createCachedObject<ModelVersionAccessCache>({
   key: REDIS_KEYS.CACHES.ENTITY_AVAILABILITY.MODEL_VERSIONS,
@@ -388,29 +424,7 @@ export const modelVersionAccessCache = createCachedObject<ModelVersionAccessCach
       data.status !== ModelStatus.Published
     );
   },
-  lookupFn: async (ids, fromWrite) => {
-    const goodIds = ids.filter(isDefined);
-    if (!goodIds.length) return {};
-    const db = fromWrite ? dbWrite : dbRead;
-    const entityAccessData = await db.$queryRaw<ModelVersionAccessCache[]>(Prisma.sql`
-      SELECT
-        mv.id AS "entityId",
-        mmv."userId" AS "userId",
-        -- Model availability prevails if it's private
-        CASE
-          WHEN mmv.availability = 'Private'
-            THEN mmv."availability"
-          ELSE mv."availability"
-        END AS "availability",
-        mv."publishedAt" AS "publishedAt",
-        mv."status" as "status"
-      FROM "ModelVersion" mv
-           JOIN "Model" mmv ON mv."modelId" = mmv.id
-      WHERE
-        mv.id IN (${Prisma.join(goodIds, ',')})
-    `);
-    return Object.fromEntries(entityAccessData.map((x) => [x.entityId, x]));
-  },
+  lookupFn: (ids, fromWrite) => lookupModelVersionAccess(ids as number[], fromWrite),
 });
 
 type TagLookup = {

--- a/src/server/services/__tests__/entity-access-unresolved.service.test.ts
+++ b/src/server/services/__tests__/entity-access-unresolved.service.test.ts
@@ -20,7 +20,14 @@ vi.mock('@prisma/client', () => {
   const join = (values: unknown[], separator = ',') => ({ values, separator });
   const empty = { sql: '', values: [] };
   class Sql {}
-  const known: Record<string, unknown> = { sql, raw, join, empty, Sql, validator: () => (x: unknown) => x };
+  const known: Record<string, unknown> = {
+    sql,
+    raw,
+    join,
+    empty,
+    Sql,
+    validator: () => (x: unknown) => x,
+  };
   const Prisma = new Proxy(known, {
     get: (target, prop: string) => (prop in target ? target[prop] : {}),
   });
@@ -65,7 +72,7 @@ const PUBLIC_VERSION = {
   status: 'Published',
 };
 
-const byId = (...rows: typeof PUBLIC_VERSION[]) =>
+const byId = (...rows: (typeof PUBLIC_VERSION)[]) =>
   Object.fromEntries(rows.map((r) => [String(r.entityId), r]));
 
 beforeEach(() => {
@@ -164,7 +171,9 @@ describe('hasEntityAccess — ModelVersion id the availability cache could not r
   it('re-reads instead of trusting a cached record that would deny', async () => {
     // A value this cache is not allowed to hold in the first place (dontCacheFn refuses non-Public),
     // so it can only be legacy poison — the exact state that made Public models undownloadable.
-    modelVersionAccessFetch.mockResolvedValue(byId({ ...PUBLIC_VERSION, availability: 'EarlyAccess' }));
+    modelVersionAccessFetch.mockResolvedValue(
+      byId({ ...PUBLIC_VERSION, availability: 'EarlyAccess' })
+    );
     lookupModelVersionAccessMock.mockResolvedValue(byId(PUBLIC_VERSION));
 
     const [access] = await hasEntityAccess({

--- a/src/server/services/__tests__/entity-access-unresolved.service.test.ts
+++ b/src/server/services/__tests__/entity-access-unresolved.service.test.ts
@@ -187,6 +187,22 @@ describe('hasEntityAccess — ModelVersion id the availability cache could not r
     expect(access.availability).toBe('Public');
   });
 
+  // The cache-vs-DB reconciliation is ModelVersion-only. Every other entity type already runs a live
+  // $queryRaw, and none of that path may change.
+  it.each(['Article', 'Post', 'Model', 'Collection', 'Bounty', 'ComicChapter'] as const)(
+    'leaves the %s path on its live query, untouched',
+    async (entityType) => {
+      dbReadQueryRaw.mockResolvedValue([{ entityId: 7, userId: 8319364, availability: 'Public' }]);
+
+      const [access] = await hasEntityAccess({ entityType, entityIds: [7], userId: 1290051 });
+
+      expect(dbReadQueryRaw).toHaveBeenCalledTimes(1);
+      expect(modelVersionAccessFetch).not.toHaveBeenCalled();
+      expect(lookupModelVersionAccessMock).not.toHaveBeenCalled();
+      expect(access.hasAccess).toBe(true);
+    }
+  );
+
   it('a still-gated version stays gated when the DB has to resolve it', async () => {
     modelVersionAccessFetch.mockResolvedValue({});
     lookupModelVersionAccessMock.mockResolvedValue(byId(PUBLIC_VERSION));

--- a/src/server/services/__tests__/entity-access-unresolved.service.test.ts
+++ b/src/server/services/__tests__/entity-access-unresolved.service.test.ts
@@ -1,0 +1,196 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * ModelVersion is the only entity type whose availability comes from a Redis cache rather than a
+ * live query, and `hasEntityAccess` used to collapse "the cache had no record for this id" into
+ * the same shape as "the record says Private" — a fail-CLOSED default. A cache that omits an id
+ * (evicted, never written because `dontCacheFn` refused it, cluster hiccup) therefore denied
+ * download AND generation to every signed-in non-moderator, non-owner on a perfectly Public model.
+ *
+ * The DB is the authority: an id the cache can't resolve must be re-read, not denied.
+ */
+
+vi.mock('@prisma/client', () => {
+  const sql = (strings: TemplateStringsArray, ...values: unknown[]) => ({
+    strings,
+    values,
+    sql: strings.join('?'),
+  });
+  const raw = (s: string) => ({ sql: s, values: [] });
+  const join = (values: unknown[], separator = ',') => ({ values, separator });
+  const empty = { sql: '', values: [] };
+  class Sql {}
+  const known: Record<string, unknown> = { sql, raw, join, empty, Sql, validator: () => (x: unknown) => x };
+  const Prisma = new Proxy(known, {
+    get: (target, prop: string) => (prop in target ? target[prop] : {}),
+  });
+  return new Proxy(
+    { Prisma, PrismaClient: class PrismaClient {} },
+    {
+      get(target, prop: string) {
+        if (prop in target) return (target as Record<string, unknown>)[prop];
+        if (prop === '__esModule') return true;
+        return {};
+      },
+    }
+  );
+});
+
+const dbReadQueryRaw = vi.fn();
+const dbWriteQueryRaw = vi.fn();
+vi.mock('~/server/db/client', () => ({
+  dbRead: { $queryRaw: (...args: unknown[]) => dbReadQueryRaw(...args) },
+  dbWrite: { $queryRaw: (...args: unknown[]) => dbWriteQueryRaw(...args) },
+}));
+
+const modelVersionAccessFetch = vi.fn();
+const lookupModelVersionAccessMock = vi.fn();
+vi.mock('~/server/redis/caches', () => ({
+  modelVersionAccessCache: { fetch: (...args: unknown[]) => modelVersionAccessFetch(...args) },
+  lookupModelVersionAccess: (...args: unknown[]) => lookupModelVersionAccessMock(...args),
+}));
+
+const getPaidAccessMock = vi.fn();
+vi.mock('~/server/services/paid-access.service', () => ({
+  getPaidAccess: (...args: unknown[]) => getPaidAccessMock(...args),
+}));
+
+import { hasEntityAccess } from '~/server/services/common.service';
+
+const PUBLIC_VERSION = {
+  entityId: 3156705,
+  userId: 8319364,
+  availability: 'Public',
+  publishedAt: new Date('2026-07-29T15:58:16Z'),
+  status: 'Published',
+};
+
+const byId = (...rows: typeof PUBLIC_VERSION[]) =>
+  Object.fromEntries(rows.map((r) => [String(r.entityId), r]));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  getPaidAccessMock.mockResolvedValue({});
+  dbWriteQueryRaw.mockResolvedValue([]);
+  dbReadQueryRaw.mockResolvedValue([]);
+  lookupModelVersionAccessMock.mockResolvedValue({});
+});
+
+describe('hasEntityAccess — ModelVersion id the availability cache could not resolve', () => {
+  it('re-reads the DB instead of denying a signed-in user', async () => {
+    modelVersionAccessFetch.mockResolvedValue({});
+    lookupModelVersionAccessMock.mockResolvedValue(byId(PUBLIC_VERSION));
+
+    const [access] = await hasEntityAccess({
+      entityType: 'ModelVersion',
+      entityIds: [3156705],
+      userId: 1290051,
+    });
+
+    expect(lookupModelVersionAccessMock).toHaveBeenCalledWith([3156705]);
+    expect(access.hasAccess).toBe(true);
+    expect(access.availability).toBe('Public');
+  });
+
+  it('re-reads the DB instead of denying an anonymous user', async () => {
+    modelVersionAccessFetch.mockResolvedValue({});
+    lookupModelVersionAccessMock.mockResolvedValue(byId(PUBLIC_VERSION));
+
+    const [access] = await hasEntityAccess({
+      entityType: 'ModelVersion',
+      entityIds: [3156705],
+    });
+
+    expect(access.hasAccess).toBe(true);
+  });
+
+  it('still denies when the DB agrees the version is private', async () => {
+    modelVersionAccessFetch.mockResolvedValue({});
+    lookupModelVersionAccessMock.mockResolvedValue(
+      byId({ ...PUBLIC_VERSION, availability: 'Private' })
+    );
+
+    const [access] = await hasEntityAccess({
+      entityType: 'ModelVersion',
+      entityIds: [3156705],
+      userId: 1290051,
+    });
+
+    expect(access.hasAccess).toBe(false);
+    expect(access.availability).toBe('Private');
+  });
+
+  it('still denies when the version does not exist at all', async () => {
+    modelVersionAccessFetch.mockResolvedValue({});
+    lookupModelVersionAccessMock.mockResolvedValue({});
+
+    const [access] = await hasEntityAccess({
+      entityType: 'ModelVersion',
+      entityIds: [999999999],
+      userId: 1290051,
+    });
+
+    expect(access.hasAccess).toBe(false);
+    expect(access.availability).toBe('Private');
+  });
+
+  it('does not hit the DB when the cache resolved every id', async () => {
+    modelVersionAccessFetch.mockResolvedValue(byId(PUBLIC_VERSION));
+
+    const [access] = await hasEntityAccess({
+      entityType: 'ModelVersion',
+      entityIds: [3156705],
+      userId: 1290051,
+    });
+
+    expect(lookupModelVersionAccessMock).not.toHaveBeenCalled();
+    expect(access.hasAccess).toBe(true);
+  });
+
+  it('only re-reads the ids the cache missed', async () => {
+    modelVersionAccessFetch.mockResolvedValue(byId(PUBLIC_VERSION));
+    lookupModelVersionAccessMock.mockResolvedValue(byId({ ...PUBLIC_VERSION, entityId: 111 }));
+
+    const results = await hasEntityAccess({
+      entityType: 'ModelVersion',
+      entityIds: [3156705, 111],
+      userId: 1290051,
+    });
+
+    expect(lookupModelVersionAccessMock).toHaveBeenCalledWith([111]);
+    expect(results.every((r) => r.hasAccess)).toBe(true);
+  });
+
+  it('re-reads instead of trusting a cached record that would deny', async () => {
+    // A value this cache is not allowed to hold in the first place (dontCacheFn refuses non-Public),
+    // so it can only be legacy poison — the exact state that made Public models undownloadable.
+    modelVersionAccessFetch.mockResolvedValue(byId({ ...PUBLIC_VERSION, availability: 'EarlyAccess' }));
+    lookupModelVersionAccessMock.mockResolvedValue(byId(PUBLIC_VERSION));
+
+    const [access] = await hasEntityAccess({
+      entityType: 'ModelVersion',
+      entityIds: [3156705],
+      userId: 1290051,
+    });
+
+    expect(lookupModelVersionAccessMock).toHaveBeenCalledWith([3156705]);
+    expect(access.hasAccess).toBe(true);
+    expect(access.availability).toBe('Public');
+  });
+
+  it('a still-gated version stays gated when the DB has to resolve it', async () => {
+    modelVersionAccessFetch.mockResolvedValue({});
+    lookupModelVersionAccessMock.mockResolvedValue(byId(PUBLIC_VERSION));
+    getPaidAccessMock.mockResolvedValue({
+      3156705: { entityType: 'ModelVersion', entityId: 3156705, endsAt: null },
+    });
+
+    const [access] = await hasEntityAccess({
+      entityType: 'ModelVersion',
+      entityIds: [3156705],
+      userId: 1290051,
+    });
+
+    expect(access.hasAccess).toBe(false);
+  });
+});

--- a/src/server/services/__tests__/file-download-lookup.test.ts
+++ b/src/server/services/__tests__/file-download-lookup.test.ts
@@ -275,6 +275,39 @@ describe('getFileForModelVersion — orphan model relation + unresolvable URL', 
     if (result.status === 'early-access') expect(result.details.deadline).toEqual(endsAt);
   });
 
+  // The common case, and the one the bit-test read backwards: a user who has bought nothing carries
+  // the "no grant" sentinel `permissions: -1` (every bit set), so `permissions & EarlyAccessDownload`
+  // is non-zero and reads as "already holds the download grant". The purchase route was skipped and
+  // the user got a dead-end 403 instead of the buy CTA.
+  it('routes a user with no grant at all to early-access, not a bare denial', async () => {
+    modelVersionFindFirst.mockResolvedValue(publishedModelVersion());
+    const endsAt = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000);
+    getPaidAccessMock.mockResolvedValue({ 1: { endsAt, terms: { download: { price: 100 } } } });
+    hasEntityAccessMock.mockResolvedValue([{ hasAccess: false, permissions: -1 }]);
+
+    const result = await getFileForModelVersion({
+      modelVersionId: 1,
+      user: { id: 1234, isModerator: false },
+    });
+
+    expect(result.status).toBe('early-access');
+  });
+
+  it('lets an actual early-access buyer through the gate', async () => {
+    modelVersionFindFirst.mockResolvedValue(publishedModelVersion());
+    const endsAt = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000);
+    getPaidAccessMock.mockResolvedValue({ 1: { endsAt, terms: { download: { price: 100 } } } });
+    hasEntityAccessMock.mockResolvedValue([{ hasAccess: true, permissions: 2 }]);
+    resolveDownloadUrlMock.mockResolvedValue({ url: 'https://cdn/ok', urlExpiryDate: new Date() });
+
+    const result = await getFileForModelVersion({
+      modelVersionId: 1,
+      user: { id: 1234, isModerator: false },
+    });
+
+    expect(result.status).toBe('success');
+  });
+
   // --- Unpublished models: the review path ---------------------------------
   // Moderators review unpublished models constantly (takedowns, TOS checks) and need the actual
   // file to decide. The publish-state gate must keep answering them — and the owner — with the

--- a/src/server/services/common.service.ts
+++ b/src/server/services/common.service.ts
@@ -4,7 +4,7 @@ import { isPaidAccessActive } from '@civitai/buzz';
 import { EntityAccessPermission } from '~/server/common/enums';
 import { dbRead, dbWrite } from '~/server/db/client';
 import { getPaidAccess } from '~/server/services/paid-access.service';
-import { modelVersionAccessCache } from '~/server/redis/caches';
+import { lookupModelVersionAccess, modelVersionAccessCache } from '~/server/redis/caches';
 import type { SupportedAvailabilityResources } from '../schema/base.schema';
 
 type EntityAccessMeta = {
@@ -26,6 +26,8 @@ type UserEntityAccessStatus = EntityAccessRaw & {
 };
 
 const OPEN_ACCESS_AVAILABILITY = [Availability.Public, Availability.Unsearchable] as const;
+const isOpenAvailability = (availability: Availability) =>
+  OPEN_ACCESS_AVAILABILITY.some((a) => a === availability);
 
 export type EntityAccessDataType = {
   entityId: number;
@@ -52,20 +54,20 @@ export const hasEntityAccess = async ({
 
   let data: EntityAccessDataType[];
   if (entityType === 'ModelVersion') {
+    // ModelVersion is the only entity type whose availability comes from a cache rather than a live
+    // query, and that cache is only ever allowed to hold open-access rows (`dontCacheFn` refuses
+    // everything else). So a cached record can support a GRANT but never a DENIAL: an id it doesn't
+    // resolve — or resolves to something that would deny — is "unknown", and letting that reach the
+    // fail-closed default below reads as Private and blocks download and generation on a Public
+    // model. Re-read those from the DB, which is the authority.
     const cacheData = await modelVersionAccessCache.fetch(entityIds);
-    data = Object.values(cacheData);
+    data = Object.values(cacheData).filter((x) => isOpenAvailability(x.availability));
+    const resolved = new Set(data.map((x) => x.entityId));
+    const unresolved = entityIds.filter((id) => !resolved.has(id));
+    if (unresolved.length > 0)
+      data = data.concat(Object.values(await lookupModelVersionAccess(unresolved)));
   } else {
     const query: Prisma.Sql =
-      //     entityType === 'ModelVersion'
-      //       ? Prisma.sql`
-      //    SELECT
-      //      mv.id as "entityId",
-      //      mmv."userId" as "userId",
-      //      mv."availability" as "availability"
-      //    FROM "ModelVersion" mv
-      //    JOIN "Model" mmv ON mv."modelId" = mmv.id
-      //    WHERE mv.id IN (${Prisma.join(entityIds, ',')})
-      // ` :
       entityType === 'Article'
         ? Prisma.sql`
     SELECT

--- a/src/server/services/file.service.ts
+++ b/src/server/services/file.service.ts
@@ -264,12 +264,13 @@ export const getFileForModelVersion = async ({
 
   // The paid gate is checked BEFORE the generic access check so a gated version routes the user to
   // the purchase flow; the other order collapses it into a bare denial and loses the reason.
-  if (
-    inEarlyAccess &&
-    ((versionAccess?.permissions ?? 0) & EntityAccessPermission.EarlyAccessDownload) == 0 &&
-    !isMod &&
-    !isOwner
-  ) {
+  // `permissions` only carries grant bits when there IS a grant — hasEntityAccess reports "no grant"
+  // as -1 (every bit set), so testing the bit alone reads a buyer-less user as already owning the
+  // download and skips the purchase route.
+  const boughtDownload =
+    !!versionAccess?.hasAccess &&
+    (versionAccess.permissions & EntityAccessPermission.EarlyAccessDownload) !== 0;
+  if (inEarlyAccess && !boughtDownload && !isMod && !isOwner) {
     return { status: 'early-access', details: { deadline } };
   }
 

--- a/src/server/utils/__tests__/cache-helpers-refresh-dontcache.test.ts
+++ b/src/server/utils/__tests__/cache-helpers-refresh-dontcache.test.ts
@@ -56,6 +56,16 @@ function makeCache(lookup: (ids: number[]) => Record<string, Row>) {
   });
 }
 
+// Same cache with NO dontCacheFn — the shape all but three caches in the repo use.
+function makePlainCache(lookup: (ids: number[]) => Record<string, Row>) {
+  return createCachedObject<Row>({
+    key: KEY as never,
+    idKey: 'id',
+    ttl: 60,
+    lookupFn: async (ids) => lookup(ids as number[]),
+  });
+}
+
 const setKeys = () => setMock.mock.calls.map((c) => c[0] as string);
 const delKeys = () => delMock.mock.calls.flatMap((c) => (Array.isArray(c[0]) ? c[0] : [c[0]]));
 
@@ -101,5 +111,51 @@ describe('createCachedArray.refresh — dontCacheFn', () => {
     expect(setKeys()).toEqual([`${KEY}:1`]);
     // 2 was rejected by dontCacheFn, 3 had no row at all — both must end up absent.
     expect(delKeys()).toEqual(expect.arrayContaining([`${KEY}:2`, `${KEY}:3`]));
+  });
+
+  it('never touches an id that was not asked for', async () => {
+    const cache = makeCache(() => ({
+      '1': { id: 1, availability: 'Public' },
+      '99': { id: 99, availability: 'Private' },
+    }));
+
+    await cache.refresh([1]);
+
+    expect(delKeys()).not.toContain(`${KEY}:99`);
+  });
+});
+
+// The change is scoped to caches that opt into dontCacheFn. Every other cache in the repo must
+// keep the exact refresh() semantics it had: write every row, delete only the ids with no row.
+describe('createCachedArray.refresh — caches without dontCacheFn are unchanged', () => {
+  it('writes every returned record', async () => {
+    const cache = makePlainCache(() => ({
+      '1': { id: 1, availability: 'Public' },
+      '2': { id: 2, availability: 'Private' },
+      '3': { id: 3, availability: 'EarlyAccess' },
+    }));
+
+    await cache.refresh([1, 2, 3]);
+
+    expect(setKeys()).toEqual([`${KEY}:1`, `${KEY}:2`, `${KEY}:3`]);
+    expect(delKeys()).toEqual([]);
+  });
+
+  it('deletes only the ids the lookup had no row for', async () => {
+    const cache = makePlainCache(() => ({ '1': { id: 1, availability: 'Private' } }));
+
+    await cache.refresh([1, 2]);
+
+    expect(setKeys()).toEqual([`${KEY}:1`]);
+    expect(delKeys()).toEqual([`${KEY}:2`]);
+  });
+
+  it('treats a falsy lookup value as no row — deleted, never written', async () => {
+    const cache = makePlainCache(() => ({ '1': undefined } as unknown as Record<string, Row>));
+
+    await cache.refresh([1]);
+
+    expect(setKeys()).toEqual([]);
+    expect(delKeys()).toEqual([`${KEY}:1`]);
   });
 });

--- a/src/server/utils/__tests__/cache-helpers-refresh-dontcache.test.ts
+++ b/src/server/utils/__tests__/cache-helpers-refresh-dontcache.test.ts
@@ -1,0 +1,105 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * `refresh()` is the only writer in createCachedArray that used to ignore `dontCacheFn`.
+ *
+ * `fetch()` honors it (a rejected record is returned to the caller but never written) and the
+ * degraded/fail-open path honors it, so a cache that uses `dontCacheFn` as a correctness guard
+ * — "only cache values that are safe to serve stale" — silently loses that guard the moment
+ * anything calls `refresh()`. modelVersionAccessCache is exactly that shape: it refuses to cache
+ * non-Public / just-published versions, and `bustMvCache()` (its only invalidation path) calls
+ * `refresh()`. A version mutated while its row was non-Public got that non-Public availability
+ * pinned in Redis for `ttl + swr tail`, and hasEntityAccess then denied every non-owner.
+ */
+
+const mGetMock = vi.fn();
+const setMock = vi.fn().mockResolvedValue(undefined);
+const setNxMock = vi.fn().mockResolvedValue(true);
+const delMock = vi.fn().mockResolvedValue(undefined);
+
+vi.mock('~/server/redis/client', () => ({
+  redis: {
+    packed: {
+      mGet: (...args: unknown[]) => mGetMock(...args),
+      set: (...args: unknown[]) => setMock(...args),
+    },
+    setNxKeepTtlWithEx: (...args: unknown[]) => setNxMock(...args),
+    del: (...args: unknown[]) => delMock(...args),
+  },
+  sysRedis: {},
+  REDIS_KEYS: { CACHE_LOCKS: 'caches:lock', TAG: 'caches:tag' },
+}));
+
+vi.mock('~/server/redis/fail-open-log', () => ({ logSysRedisFailOpen: vi.fn() }));
+
+vi.mock('~/server/prom/client', () => ({
+  cacheHitCounter: { inc: vi.fn() },
+  cacheMissCounter: { inc: vi.fn() },
+  cacheRevalidateCounter: { inc: vi.fn() },
+  cacheFailOpenDegradedCounter: { inc: vi.fn() },
+  cacheFailOpenOriginFetchCounter: { inc: vi.fn() },
+}));
+
+import { createCachedObject } from '~/server/utils/cache-helpers';
+
+type Row = { id: number; availability: string };
+
+const KEY = 'packed:caches:test-refresh-dontcache';
+
+function makeCache(lookup: (ids: number[]) => Record<string, Row>) {
+  return createCachedObject<Row>({
+    key: KEY as never,
+    idKey: 'id',
+    ttl: 60,
+    lookupFn: async (ids) => lookup(ids as number[]),
+    dontCacheFn: (data) => data.availability !== 'Public',
+  });
+}
+
+const setKeys = () => setMock.mock.calls.map((c) => c[0] as string);
+const delKeys = () => delMock.mock.calls.flatMap((c) => (Array.isArray(c[0]) ? c[0] : [c[0]]));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mGetMock.mockResolvedValue([]);
+});
+
+describe('createCachedArray.refresh — dontCacheFn', () => {
+  it('does not write a record that dontCacheFn rejects', async () => {
+    const cache = makeCache(() => ({ '1': { id: 1, availability: 'EarlyAccess' } }));
+
+    await cache.refresh([1]);
+
+    expect(setKeys()).not.toContain(`${KEY}:1`);
+  });
+
+  it('deletes the existing key for a record that dontCacheFn rejects', async () => {
+    const cache = makeCache(() => ({ '1': { id: 1, availability: 'EarlyAccess' } }));
+
+    await cache.refresh([1]);
+
+    expect(delKeys()).toContain(`${KEY}:1`);
+  });
+
+  it('still writes records dontCacheFn accepts', async () => {
+    const cache = makeCache(() => ({ '1': { id: 1, availability: 'Public' } }));
+
+    await cache.refresh([1]);
+
+    expect(setKeys()).toContain(`${KEY}:1`);
+    expect(delKeys()).not.toContain(`${KEY}:1`);
+  });
+
+  it('splits a mixed batch — caches the acceptable ids, drops the rejected ones', async () => {
+    const cache = makeCache(() => ({
+      '1': { id: 1, availability: 'Public' },
+      '2': { id: 2, availability: 'Private' },
+    }));
+
+    await cache.refresh([1, 2, 3]);
+
+    expect(setKeys()).toEqual([`${KEY}:1`]);
+    // 2 was rejected by dontCacheFn, 3 had no row at all — both must end up absent.
+    expect(delKeys()).toEqual(expect.arrayContaining([`${KEY}:2`, `${KEY}:3`]));
+  });
+});

--- a/src/server/utils/cache-helpers.ts
+++ b/src/server/utils/cache-helpers.ts
@@ -623,13 +623,19 @@ export function createCachedArray<T extends object>({
       // post-mutation shape to Redis. Leave it to fetch().
       const cachedAt = new Date();
       const EX = resolveCacheExpiry(ttl, staleWhileRevalidate, staleWhileRevalidateTtl);
+      // Honor dontCacheFn exactly as fetch() and the degraded path do. A cache that uses it as a
+      // correctness guard ("only hold values that are safe to serve stale") otherwise loses that
+      // guard entirely, because refresh() is what every bust-and-repopulate helper calls.
+      const cacheable = Object.entries(results).filter(([, x]) => !dontCacheFn?.(x));
       await Promise.all(
-        Object.entries(results).map(([rid, x]) =>
-          redis.packed.set(`${key}:${rid}`, { ...x, cachedAt }, { EX })
-        )
+        cacheable.map(([rid, x]) => redis.packed.set(`${key}:${rid}`, { ...x, cachedAt }, { EX }))
       );
 
-      const toRemove = ids.filter((x) => !results[x]).map(String);
+      // An id with no row and an id we're not allowed to hold both have to end up ABSENT rather
+      // than merely un-refreshed — leaving the prior entry in place keeps serving the very value
+      // this refresh was called to replace.
+      const cached = new Set(cacheable.map(([rid]) => rid));
+      const toRemove = ids.map(String).filter((rid) => !cached.has(rid));
       await Promise.all(toRemove.map((rid) => redis.del(`${key}:${rid}`)));
     } catch (error) {
       // Refresh is best-effort: swallow and fall back to bust semantics so the

--- a/src/server/utils/cache-helpers.ts
+++ b/src/server/utils/cache-helpers.ts
@@ -626,7 +626,9 @@ export function createCachedArray<T extends object>({
       // Honor dontCacheFn exactly as fetch() and the degraded path do. A cache that uses it as a
       // correctness guard ("only hold values that are safe to serve stale") otherwise loses that
       // guard entirely, because refresh() is what every bust-and-repopulate helper calls.
-      const cacheable = Object.entries(results).filter(([, x]) => !dontCacheFn?.(x));
+      // `x &&` keeps a falsy lookupFn value classified as "no row" (matching the prior
+      // `!results[x]` reading) rather than writing it.
+      const cacheable = Object.entries(results).filter(([, x]) => x && !dontCacheFn?.(x));
       await Promise.all(
         cacheable.map(([rid, x]) => redis.packed.set(`${key}:${rid}`, { ...x, cachedAt }, { EX }))
       );


### PR DESCRIPTION
Fixes [CU 868kj77rb](https://app.clickup.com/t/8459928/868kj77rb) · Freshdesk #70217

## Symptom

Signed-in non-moderators got `403 You do not have access to download this file` on a Published, **Public** model. The owner and moderators were unaffected — which is exactly why it was easy to miss. Reported by the model's own creator.

## Root cause

The database was clean the whole time. `ModelVersion` is the only entity type whose availability `hasEntityAccess` reads from a Redis cache instead of a live query, and three things compounded:

**1. `createCachedArray.refresh()` was the only writer that ignored `dontCacheFn`.**
`fetch()` honors it, the degraded/fail-open path honors it, `refresh()` did not. `modelVersionAccessCache` uses that hook as a *correctness guard* — "We only wanna cache public models. Otherwise, we better confirm every time. It's a safer bet." — and `bustMvCache()`, its only invalidation path, calls `refresh()`. So any version mutated while its row was non-Public had that non-Public availability pinned in Redis for `ttl` + the stale-while-revalidate tail (**2 days**, since `staleWhileRevalidate` defaults to true).

The now-dropped `trigger_early_access_ends_at` made this systematic: `process-ending-early-access` set `availability='Public'`, the trigger reverted it inside the same statement, and the immediately-following `refresh()` cached `EarlyAccess`. The phase-2 migration later fixed the DB with raw SQL — which busts nothing — leaving DB and cache permanently disagreeing.

**2. `hasEntityAccess` failed closed on an unresolved record.** `matched` defaulted a missing id to `availability: Private, hasAccess: false`, so "the cache had no record" and "the record says Private" were indistinguishable. On an access gate, "I don't know" must not mean "no".

**3. #3456 turned that denial into a hard 403.** Before, it was a `/login` redirect that bounced a signed-in user back to the page they came from — broken then too, just less legibly.

Blast radius is wider than downloads: `hasEntityAccess` also gates generation (`generation/paid-access-gating.ts`), vault, the model detail page, resource reviews, comments and reactions.

## Fix

- **`refresh()` honors `dontCacheFn`**, and **deletes** the key for a record it isn't allowed to hold rather than leaving the prior entry in place. This makes the invariant real: the cache can only ever contain open-access rows, so it can never hold a value that *denies*.
- **`hasEntityAccess` re-reads from the DB** any ModelVersion id the cache doesn't resolve — or resolves to something that would deny. A cached record can support a grant, never a denial. This also heals entries poisoned before this ships, instead of waiting out their TTL.
- The availability SQL moves into a shared `lookupModelVersionAccess()` so the cache and the fallback can't drift.

### Also in here

A sibling dead end in the same `if` block: `permissions` only carries grant bits when there *is* a grant — `hasEntityAccess` reports "no grant" as `-1` (every bit set), so `permissions & EarlyAccessDownload` read a buyer-less user as already owning the download and **skipped the purchase route**. A user with no grant on a gated version got a bare 403 instead of the buy CTA — the same "download button does nothing" family #3456 set out to eliminate. Every other consumer of `permissions` checks `hasAccess` first, so this was the only site affected and it could only ever deny, never over-grant.

## Verification

End-to-end against the **production DB** with a poisoned local cache entry for the reported version 3156705 and a real non-moderator (user 1290051):

| case | before | after |
|---|---|---|
| mv 3156705, poisoned cache entry | `403 You do not have access…` | `307 →` the actual file |
| Public, ungated version | 307 → file | 307 → file |
| Private version | 403 | 403 |
| actively paid-gated version | `403 You do not have access…` | `307 → /model-versions/<id>` |

Unit coverage: `cache-helpers-refresh-dontcache.test.ts` (new, 4 cases), `entity-access-unresolved.service.test.ts` (new, 8 cases), plus 2 cases added to `file-download-lookup.test.ts`. `pnpm typecheck` clean; 853 tests green across every suite touching these caches.

## Ops

No migration. Once this deploys, the read-side guard heals already-poisoned entries on first read — no manual cache flush or model re-save needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)