### PR TITLE
fix(challenge): stop a slow metadata write from clobbering a challenge claimed for completion

### DIFF
--- a/src/__tests__/pages/api/mod/daily-challenge/backfill-theme-elements.test.ts
+++ b/src/__tests__/pages/api/mod/daily-challenge/backfill-theme-elements.test.ts
@@ -12,11 +12,14 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 // reset propagates NULL and so never selects such a row: the challenge wedges permanently.
 // `?force=true` widens the exposure to every themed Active/Scheduled challenge at once.
 
-const { mockQueryRaw, mockExecuteRaw, mockGenerateThemeElements } = vi.hoisted(() => ({
-  mockQueryRaw: vi.fn(),
-  mockExecuteRaw: vi.fn(),
-  mockGenerateThemeElements: vi.fn(),
-}));
+const { mockQueryRaw, mockExecuteRaw, mockGenerateThemeElements, mockLogToAxiom } = vi.hoisted(
+  () => ({
+    mockQueryRaw: vi.fn(),
+    mockExecuteRaw: vi.fn(),
+    mockGenerateThemeElements: vi.fn(),
+    mockLogToAxiom: vi.fn(),
+  })
+);
 
 vi.mock('~/server/db/client', () => ({
   dbRead: { $queryRaw: mockQueryRaw },
@@ -32,7 +35,7 @@ vi.mock('~/server/games/daily-challenge/generative-content', () => ({
   generateThemeElements: mockGenerateThemeElements,
 }));
 
-vi.mock('~/server/logging/client', () => ({ logToAxiom: vi.fn() }));
+vi.mock('~/server/logging/client', () => ({ logToAxiom: mockLogToAxiom }));
 
 vi.mock('~/server/schema/challenge.schema', () => ({
   parseChallengeMetadata: (m: unknown) => (m ?? {}) as Record<string, unknown>,
@@ -70,7 +73,26 @@ vi.mock('~/env/server', () => ({
 const handler = (await import('~/pages/api/mod/daily-challenge/backfill-theme-elements')).default;
 
 /** Reassemble the SQL text from the tagged-template call `$executeRaw` received. */
-const sqlOf = (call: unknown[]) => (call[0] as string[]).join('?').replace(/\s+/g, ' ');
+const sqlOf = (call: unknown[]) => (call[0] as string[]).join('?').replace(/\s+/g, ' ').trim();
+
+// The statement is pinned WHOLE rather than by feature-regexes. These assertions can only ever
+// check TEXT — there is no Postgres in a unit test to give them semantics — and partial regexes
+// proved far weaker than they looked: an earlier version pinned the presence of `||` and
+// `jsonb_typeof`, and three semantically-broken statements still passed. All three are text-level
+// edits that a whole-statement match rejects outright:
+//   - swapping the `||` operands (stored value wins; ?force=true becomes a silent no-op)
+//   - inverting the CASE branches (unconditionally WIPES existing metadata — worse than the bug)
+//   - commenting out the status predicate (disables this PR's primary guard, yet the text remains
+//     present for any regex looking for it)
+// Cost of pinning it whole: a cosmetic reformat of the SQL fails this test and must be mirrored
+// here. That is the intended trade for a statement whose exact shape is the fix.
+const EXPECTED_SQL =
+  `UPDATE "Challenge" ` +
+  `SET metadata = ` +
+  `CASE WHEN jsonb_typeof(metadata) = 'object' THEN metadata ELSE '{}'::jsonb END ` +
+  `|| ?::jsonb ` +
+  `WHERE id = ? ` +
+  `AND status IN ('Active', 'Scheduled')`;
 
 const runRequest = (query: Record<string, string> = {}) => {
   const req = {
@@ -89,7 +111,15 @@ const runRequest = (query: Record<string, string> = {}) => {
   return { promise: handler(req, res), res };
 };
 
-const CHALLENGE = { id: 42, theme: 'Neon', judgeId: 1, metadata: {} };
+// Metadata must be NON-EMPTY and carry sibling keys. With `metadata: {}` a bound patch and a
+// rebuilt whole-snapshot payload are byte-identical, so the "only the patch is bound" assertion
+// below could not tell the fix from the defect it replaced.
+const CHALLENGE = {
+  id: 42,
+  theme: 'Neon',
+  judgeId: 1,
+  metadata: { completingClaimedAt: '2026-01-01T00:00:00.000Z', reviewedAt: 17 },
+};
 
 describe('backfill-theme-elements — must not clobber a challenge claimed for completion', () => {
   beforeEach(() => {
@@ -104,27 +134,20 @@ describe('backfill-theme-elements — must not clobber a challenge claimed for c
     await promise;
 
     expect(mockExecuteRaw).toHaveBeenCalledTimes(1);
-    const sql = sqlOf(mockExecuteRaw.mock.calls[0]);
-    expect(sql).toMatch(/UPDATE "Challenge"/);
-    // Without this predicate the write lands on a Completing challenge and wedges it.
-    expect(sql).toMatch(/AND status IN \('Active', 'Scheduled'\)/);
+    // Without the status predicate the write lands on a Completing challenge and wedges it.
+    expect(sqlOf(mockExecuteRaw.mock.calls[0])).toBe(EXPECTED_SQL);
   });
 
   it('merges onto the stored metadata instead of replacing the whole column', async () => {
     const { promise } = runRequest();
     await promise;
 
-    const sql = sqlOf(mockExecuteRaw.mock.calls[0]);
-    // `||` concatenation touches only themeElements, so a field written during the LLM window
+    // `stored || patch` touches only themeElements, so a field written during the LLM window
     // (e.g. completingClaimedAt) survives even inside Active/Scheduled.
-    expect(sql).toMatch(/jsonb_typeof\(metadata\) = 'object'/);
-    // ORDER IS LOAD-BEARING, so pin it rather than just the presence of `||`. jsonb concatenation
-    // lets the RIGHT operand win on key collision, so the patch must come second. Swapping the
-    // operands (`patch || stored`) still contains a `||` and a jsonb_typeof, but inverts the
-    // merge: the stored value would win and `?force=true` would become a silent no-op for every
-    // challenge that already has themeElements.
-    expect(sql).toMatch(/END\s*\|\|\s*\?::jsonb/);
-    // Only the themeElements patch is bound — not a rebuilt copy of the whole snapshot.
+    expect(sqlOf(mockExecuteRaw.mock.calls[0])).toBe(EXPECTED_SQL);
+    // Only the themeElements patch is bound — NOT a rebuilt copy of the whole snapshot. The
+    // fixture's sibling keys must be absent here: rebinding them is the original defect, and the
+    // database (not this process) is what supplies them via the `||` above.
     expect(JSON.parse(mockExecuteRaw.mock.calls[0][1] as string)).toEqual({
       themeElements: ['neon', 'glow'],
     });
@@ -139,11 +162,16 @@ describe('backfill-theme-elements — must not clobber a challenge claimed for c
     const payload = (res.json as unknown as ReturnType<typeof vi.fn>).mock.calls[0][0];
     expect(payload.backfilled).toBe(0);
     expect(payload.failures).toBe(0);
-    // Counted, so the shortfall against `total` is explained rather than silent.
+    // Counted, so `attempted === backfilled + failures + skipped` closes.
     expect(payload.skipped).toBe(1);
     expect(payload.results).toEqual([
       { id: 42, theme: 'Neon', status: 'skipped: no longer Active/Scheduled' },
     ]);
+    // The race is otherwise invisible: `skipped:` in the response covers three different reasons,
+    // so the log is the only thing that identifies THIS one. Assert it fires.
+    expect(mockLogToAxiom).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'backfill-theme-elements-skipped', challengeId: 42 })
+    );
   });
 
   it('still counts a genuine write as backfilled', async () => {
@@ -152,14 +180,17 @@ describe('backfill-theme-elements — must not clobber a challenge claimed for c
 
     const payload = (res.json as unknown as ReturnType<typeof vi.fn>).mock.calls[0][0];
     expect(payload.backfilled).toBe(1);
+    expect(payload.skipped).toBe(0);
+    expect(payload.attempted).toBe(1);
     expect(payload.results[0].status).toBe('ok');
+    // No skip, so nothing to report.
+    expect(mockLogToAxiom).not.toHaveBeenCalled();
   });
 
   it('force=true does not bypass the status predicate', async () => {
     const { promise } = runRequest({ force: 'true' });
     await promise;
 
-    const sql = sqlOf(mockExecuteRaw.mock.calls[0]);
-    expect(sql).toMatch(/AND status IN \('Active', 'Scheduled'\)/);
+    expect(sqlOf(mockExecuteRaw.mock.calls[0])).toBe(EXPECTED_SQL);
   });
 });

--- a/src/__tests__/pages/api/mod/daily-challenge/backfill-theme-elements.test.ts
+++ b/src/__tests__/pages/api/mod/daily-challenge/backfill-theme-elements.test.ts
@@ -117,8 +117,13 @@ describe('backfill-theme-elements — must not clobber a challenge claimed for c
     const sql = sqlOf(mockExecuteRaw.mock.calls[0]);
     // `||` concatenation touches only themeElements, so a field written during the LLM window
     // (e.g. completingClaimedAt) survives even inside Active/Scheduled.
-    expect(sql).toMatch(/\|\|/);
     expect(sql).toMatch(/jsonb_typeof\(metadata\) = 'object'/);
+    // ORDER IS LOAD-BEARING, so pin it rather than just the presence of `||`. jsonb concatenation
+    // lets the RIGHT operand win on key collision, so the patch must come second. Swapping the
+    // operands (`patch || stored`) still contains a `||` and a jsonb_typeof, but inverts the
+    // merge: the stored value would win and `?force=true` would become a silent no-op for every
+    // challenge that already has themeElements.
+    expect(sql).toMatch(/END\s*\|\|\s*\?::jsonb/);
     // Only the themeElements patch is bound — not a rebuilt copy of the whole snapshot.
     expect(JSON.parse(mockExecuteRaw.mock.calls[0][1] as string)).toEqual({
       themeElements: ['neon', 'glow'],
@@ -134,6 +139,8 @@ describe('backfill-theme-elements — must not clobber a challenge claimed for c
     const payload = (res.json as unknown as ReturnType<typeof vi.fn>).mock.calls[0][0];
     expect(payload.backfilled).toBe(0);
     expect(payload.failures).toBe(0);
+    // Counted, so the shortfall against `total` is explained rather than silent.
+    expect(payload.skipped).toBe(1);
     expect(payload.results).toEqual([
       { id: 42, theme: 'Neon', status: 'skipped: no longer Active/Scheduled' },
     ]);

--- a/src/__tests__/pages/api/mod/daily-challenge/backfill-theme-elements.test.ts
+++ b/src/__tests__/pages/api/mod/daily-challenge/backfill-theme-elements.test.ts
@@ -12,14 +12,19 @@ import type { NextApiRequest, NextApiResponse } from 'next';
 // reset propagates NULL and so never selects such a row: the challenge wedges permanently.
 // `?force=true` widens the exposure to every themed Active/Scheduled challenge at once.
 
-const { mockQueryRaw, mockExecuteRaw, mockGenerateThemeElements, mockLogToAxiom } = vi.hoisted(
-  () => ({
-    mockQueryRaw: vi.fn(),
-    mockExecuteRaw: vi.fn(),
-    mockGenerateThemeElements: vi.fn(),
-    mockLogToAxiom: vi.fn(),
-  })
-);
+const {
+  mockQueryRaw,
+  mockExecuteRaw,
+  mockGenerateThemeElements,
+  mockLogToAxiom,
+  mockGetChallengeConfig,
+} = vi.hoisted(() => ({
+  mockQueryRaw: vi.fn(),
+  mockExecuteRaw: vi.fn(),
+  mockGenerateThemeElements: vi.fn(),
+  mockLogToAxiom: vi.fn().mockResolvedValue(undefined),
+  mockGetChallengeConfig: vi.fn(),
+}));
 
 vi.mock('~/server/db/client', () => ({
   dbRead: { $queryRaw: mockQueryRaw },
@@ -27,7 +32,7 @@ vi.mock('~/server/db/client', () => ({
 }));
 
 vi.mock('~/server/games/daily-challenge/daily-challenge.utils', () => ({
-  getChallengeConfig: vi.fn().mockResolvedValue({ defaultJudgeId: 1 }),
+  getChallengeConfig: mockGetChallengeConfig,
   getJudgingConfig: vi.fn().mockResolvedValue({ userId: 1 }),
 }));
 
@@ -127,6 +132,8 @@ describe('backfill-theme-elements — must not clobber a challenge claimed for c
     mockQueryRaw.mockResolvedValue([CHALLENGE]);
     mockGenerateThemeElements.mockResolvedValue(['neon', 'glow']);
     mockExecuteRaw.mockResolvedValue(1);
+    mockGetChallengeConfig.mockResolvedValue({ defaultJudgeId: 1 });
+    mockLogToAxiom.mockResolvedValue(undefined);
   });
 
   it('predicates the metadata write on the challenge still being Active/Scheduled', async () => {
@@ -187,10 +194,90 @@ describe('backfill-theme-elements — must not clobber a challenge claimed for c
     expect(mockLogToAxiom).not.toHaveBeenCalled();
   });
 
-  it('force=true does not bypass the status predicate', async () => {
-    const { promise } = runRequest({ force: 'true' });
+  it('binds THIS challenge id, not a fixed one from the batch', async () => {
+    // The whole-statement pin above can only see SQL TEXT. `WHERE id = ${challenge.id}` rewritten
+    // to a constant (e.g. the first row of the batch) emits byte-identical SQL and would update
+    // the wrong challenge on every iteration — a single-row fixture cannot notice.
+    mockQueryRaw.mockResolvedValue([
+      { ...CHALLENGE, id: 7 },
+      { ...CHALLENGE, id: 99 },
+    ]);
+
+    const { promise } = runRequest();
     await promise;
 
-    expect(sqlOf(mockExecuteRaw.mock.calls[0])).toBe(EXPECTED_SQL);
+    expect(mockExecuteRaw).toHaveBeenCalledTimes(2);
+    expect(mockExecuteRaw.mock.calls[0][2]).toBe(7);
+    expect(mockExecuteRaw.mock.calls[1][2]).toBe(99);
+  });
+
+  it('force=true widens the set to challenges that ALREADY have theme elements', async () => {
+    // This is what force actually does, and it is the amplifier the guard exists to survive:
+    // without it the pre-filled challenge is never attempted, so a test using only a bare
+    // fixture passes whether force widens anything or not.
+    const withElements = { ...CHALLENGE, id: 43, metadata: { themeElements: ['existing'] } };
+    mockQueryRaw.mockResolvedValue([CHALLENGE, withElements]);
+
+    const { promise: unforced, res: unforcedRes } = runRequest();
+    await unforced;
+    const unforcedPayload = (unforcedRes.json as unknown as ReturnType<typeof vi.fn>).mock
+      .calls[0][0];
+    expect(unforcedPayload.attempted).toBe(1);
+    expect(mockExecuteRaw.mock.calls.map((c) => c[2])).toEqual([42]);
+
+    vi.clearAllMocks();
+    mockQueryRaw.mockResolvedValue([CHALLENGE, withElements]);
+    mockGenerateThemeElements.mockResolvedValue(['neon', 'glow']);
+    mockExecuteRaw.mockResolvedValue(1);
+    mockGetChallengeConfig.mockResolvedValue({ defaultJudgeId: 1 });
+
+    const { promise: forced, res: forcedRes } = runRequest({ force: 'true' });
+    await forced;
+    const forcedPayload = (forcedRes.json as unknown as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(forcedPayload.attempted).toBe(2);
+    expect(mockExecuteRaw.mock.calls.map((c) => c[2])).toEqual([42, 43]);
+    // Widened, but every write still carries the predicate.
+    expect(sqlOf(mockExecuteRaw.mock.calls[1])).toBe(EXPECTED_SQL);
+  });
+
+  it('counts a challenge with no resolvable judge as skipped', async () => {
+    mockQueryRaw.mockResolvedValue([{ ...CHALLENGE, judgeId: null }]);
+    mockGetChallengeConfig.mockResolvedValueOnce({ defaultJudgeId: null });
+
+    const { promise, res } = runRequest();
+    await promise;
+
+    const payload = (res.json as unknown as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(mockExecuteRaw).not.toHaveBeenCalled();
+    expect(payload.skipped).toBe(1);
+    expect(payload.attempted).toBe(1);
+    expect(payload.results[0].status).toBe('skipped: no judge');
+  });
+
+  it('counts an empty generation result as skipped', async () => {
+    mockGenerateThemeElements.mockResolvedValue([]);
+
+    const { promise, res } = runRequest();
+    await promise;
+
+    const payload = (res.json as unknown as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(mockExecuteRaw).not.toHaveBeenCalled();
+    expect(payload.skipped).toBe(1);
+    expect(payload.attempted).toBe(1);
+    expect(payload.results[0].status).toBe('skipped: generation returned empty');
+  });
+
+  it('reports attempted=0 rather than omitting the field when nothing needs backfilling', async () => {
+    // The documented identity `attempted === backfilled + failures + skipped` must hold on EVERY
+    // response shape, including this early return.
+    mockQueryRaw.mockResolvedValue([{ ...CHALLENGE, metadata: { themeElements: ['already'] } }]);
+
+    const { promise, res } = runRequest();
+    await promise;
+
+    const payload = (res.json as unknown as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(payload.attempted).toBe(0);
+    expect(payload.backfilled).toBe(0);
+    expect(mockExecuteRaw).not.toHaveBeenCalled();
   });
 });

--- a/src/__tests__/pages/api/mod/daily-challenge/backfill-theme-elements.test.ts
+++ b/src/__tests__/pages/api/mod/daily-challenge/backfill-theme-elements.test.ts
@@ -242,7 +242,7 @@ describe('backfill-theme-elements — must not clobber a challenge claimed for c
 
   it('counts a challenge with no resolvable judge as skipped', async () => {
     mockQueryRaw.mockResolvedValue([{ ...CHALLENGE, judgeId: null }]);
-    mockGetChallengeConfig.mockResolvedValueOnce({ defaultJudgeId: null });
+    mockGetChallengeConfig.mockResolvedValue({ defaultJudgeId: null });
 
     const { promise, res } = runRequest();
     await promise;
@@ -278,6 +278,8 @@ describe('backfill-theme-elements — must not clobber a challenge claimed for c
     const payload = (res.json as unknown as ReturnType<typeof vi.fn>).mock.calls[0][0];
     expect(payload.attempted).toBe(0);
     expect(payload.backfilled).toBe(0);
+    expect(payload.failures).toBe(0);
+    expect(payload.skipped).toBe(0);
     expect(mockExecuteRaw).not.toHaveBeenCalled();
   });
 });

--- a/src/__tests__/pages/api/mod/daily-challenge/backfill-theme-elements.test.ts
+++ b/src/__tests__/pages/api/mod/daily-challenge/backfill-theme-elements.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+// Regression guard for the "backfill wedges a challenge forever" defect.
+//
+// The handler SELECTs Active/Scheduled challenges from the READ REPLICA, spends multiple seconds
+// in an LLM call (generateThemeElements), then writes metadata back. The original write was keyed
+// on `id` alone and replaced the whole column from the pre-LLM snapshot. If
+// `claimChallengeForCompletion` flipped the challenge to Completing inside that window — stamping
+// metadata.completingClaimedAt as it went — the write restored the pre-claim snapshot on top of
+// the fresh stamp, leaving status=Completing with NO completingClaimedAt. The stuck-challenge
+// reset propagates NULL and so never selects such a row: the challenge wedges permanently.
+// `?force=true` widens the exposure to every themed Active/Scheduled challenge at once.
+
+const { mockQueryRaw, mockExecuteRaw, mockGenerateThemeElements } = vi.hoisted(() => ({
+  mockQueryRaw: vi.fn(),
+  mockExecuteRaw: vi.fn(),
+  mockGenerateThemeElements: vi.fn(),
+}));
+
+vi.mock('~/server/db/client', () => ({
+  dbRead: { $queryRaw: mockQueryRaw },
+  dbWrite: { $executeRaw: mockExecuteRaw },
+}));
+
+vi.mock('~/server/games/daily-challenge/daily-challenge.utils', () => ({
+  getChallengeConfig: vi.fn().mockResolvedValue({ defaultJudgeId: 1 }),
+  getJudgingConfig: vi.fn().mockResolvedValue({ userId: 1 }),
+}));
+
+vi.mock('~/server/games/daily-challenge/generative-content', () => ({
+  generateThemeElements: mockGenerateThemeElements,
+}));
+
+vi.mock('~/server/logging/client', () => ({ logToAxiom: vi.fn() }));
+
+vi.mock('~/server/schema/challenge.schema', () => ({
+  parseChallengeMetadata: (m: unknown) => (m ?? {}) as Record<string, unknown>,
+}));
+
+// Run the generated tasks sequentially so assertions are deterministic.
+vi.mock('~/server/utils/concurrency-helpers', () => ({
+  limitConcurrency: async (tasks: Array<() => Promise<void>>) => {
+    for (const t of tasks) await t();
+  },
+}));
+
+type ApiHandler = (req: NextApiRequest, res: NextApiResponse) => unknown;
+
+vi.mock('~/server/utils/endpoint-helpers', () => ({
+  WebhookEndpoint: (handler: ApiHandler) => handler,
+}));
+
+vi.mock('~/utils/logging', () => ({ createLogger: vi.fn(() => vi.fn()) }));
+
+vi.mock('~/env/server', () => ({
+  env: new Proxy(
+    {},
+    {
+      get(_t, prop: string) {
+        if (prop === 'WEBHOOK_TOKEN') return 'mock-webhook-token';
+        if (prop === 'IS_BUILD') return false;
+        if (prop === 'LOGGING') return [];
+        return 'mock-value';
+      },
+    }
+  ),
+}));
+
+const handler = (await import('~/pages/api/mod/daily-challenge/backfill-theme-elements')).default;
+
+/** Reassemble the SQL text from the tagged-template call `$executeRaw` received. */
+const sqlOf = (call: unknown[]) => (call[0] as string[]).join('?').replace(/\s+/g, ' ');
+
+const runRequest = (query: Record<string, string> = {}) => {
+  const req = {
+    method: 'POST',
+    query: { token: 'mock-webhook-token', ...query },
+    headers: { host: 'localhost:3000' },
+    body: {},
+  } as unknown as NextApiRequest;
+
+  const res = {
+    status: vi.fn().mockReturnThis(),
+    json: vi.fn().mockReturnThis(),
+    send: vi.fn().mockReturnThis(),
+  } as unknown as NextApiResponse;
+
+  return { promise: handler(req, res), res };
+};
+
+const CHALLENGE = { id: 42, theme: 'Neon', judgeId: 1, metadata: {} };
+
+describe('backfill-theme-elements — must not clobber a challenge claimed for completion', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockQueryRaw.mockResolvedValue([CHALLENGE]);
+    mockGenerateThemeElements.mockResolvedValue(['neon', 'glow']);
+    mockExecuteRaw.mockResolvedValue(1);
+  });
+
+  it('predicates the metadata write on the challenge still being Active/Scheduled', async () => {
+    const { promise } = runRequest();
+    await promise;
+
+    expect(mockExecuteRaw).toHaveBeenCalledTimes(1);
+    const sql = sqlOf(mockExecuteRaw.mock.calls[0]);
+    expect(sql).toMatch(/UPDATE "Challenge"/);
+    // Without this predicate the write lands on a Completing challenge and wedges it.
+    expect(sql).toMatch(/AND status IN \('Active', 'Scheduled'\)/);
+  });
+
+  it('merges onto the stored metadata instead of replacing the whole column', async () => {
+    const { promise } = runRequest();
+    await promise;
+
+    const sql = sqlOf(mockExecuteRaw.mock.calls[0]);
+    // `||` concatenation touches only themeElements, so a field written during the LLM window
+    // (e.g. completingClaimedAt) survives even inside Active/Scheduled.
+    expect(sql).toMatch(/\|\|/);
+    expect(sql).toMatch(/jsonb_typeof\(metadata\) = 'object'/);
+    // Only the themeElements patch is bound — not a rebuilt copy of the whole snapshot.
+    expect(JSON.parse(mockExecuteRaw.mock.calls[0][1] as string)).toEqual({
+      themeElements: ['neon', 'glow'],
+    });
+  });
+
+  it('reports a challenge that left Active/Scheduled as skipped, not backfilled', async () => {
+    mockExecuteRaw.mockResolvedValue(0); // predicate matched nothing — it was claimed mid-flight
+
+    const { promise, res } = runRequest();
+    await promise;
+
+    const payload = (res.json as unknown as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(payload.backfilled).toBe(0);
+    expect(payload.failures).toBe(0);
+    expect(payload.results).toEqual([
+      { id: 42, theme: 'Neon', status: 'skipped: no longer Active/Scheduled' },
+    ]);
+  });
+
+  it('still counts a genuine write as backfilled', async () => {
+    const { promise, res } = runRequest();
+    await promise;
+
+    const payload = (res.json as unknown as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(payload.backfilled).toBe(1);
+    expect(payload.results[0].status).toBe('ok');
+  });
+
+  it('force=true does not bypass the status predicate', async () => {
+    const { promise } = runRequest({ force: 'true' });
+    await promise;
+
+    const sql = sqlOf(mockExecuteRaw.mock.calls[0]);
+    expect(sql).toMatch(/AND status IN \('Active', 'Scheduled'\)/);
+  });
+});

--- a/src/pages/api/mod/daily-challenge/backfill-theme-elements.ts
+++ b/src/pages/api/mod/daily-challenge/backfill-theme-elements.ts
@@ -68,6 +68,7 @@ export default WebhookEndpoint(async function (_req: NextApiRequest, res: NextAp
 
   let successes = 0;
   let failures = 0;
+  let skipped = 0;
   const results: Array<{ id: number; theme: string; status: string; elements?: string[] }> = [];
 
   const tasks = toBackfill.map((challenge) => async () => {
@@ -120,6 +121,16 @@ export default WebhookEndpoint(async function (_req: NextApiRequest, res: NextAp
       `;
 
       if (updatedRows === 0) {
+        // The whole point of the predicate is a race nobody is watching for. Without a log the
+        // only evidence it ever fired is a reader noticing that
+        // `backfilled + failures + skipped < total` in the response JSON.
+        logToAxiom({
+          type: 'warning',
+          name: 'backfill-theme-elements-skipped',
+          challengeId: challenge.id,
+          message: `Challenge ${challenge.id} left Active/Scheduled during theme generation; metadata write skipped`,
+        });
+        skipped++;
         results.push({
           id: challenge.id,
           theme: challenge.theme,
@@ -153,11 +164,14 @@ export default WebhookEndpoint(async function (_req: NextApiRequest, res: NextAp
 
   await limitConcurrency(tasks, 3);
 
-  log(`Backfill complete: ${successes} successes, ${failures} failures`);
+  log(`Backfill complete: ${successes} successes, ${failures} failures, ${skipped} skipped`);
   return res.status(200).json({
     total: challenges.length,
     backfilled: successes,
     failures,
+    // Reported so `backfilled + failures` adding up to less than the attempted set is explained
+    // rather than looking like a silent shortfall.
+    skipped,
     force,
     results,
   });

--- a/src/pages/api/mod/daily-challenge/backfill-theme-elements.ts
+++ b/src/pages/api/mod/daily-challenge/backfill-theme-elements.ts
@@ -93,15 +93,40 @@ export default WebhookEndpoint(async function (_req: NextApiRequest, res: NextAp
         return;
       }
 
-      // Merge into existing metadata
-      const existingMetadata = parseChallengeMetadata(challenge.metadata);
-      const newMetadata = { ...existingMetadata, themeElements: elements };
-
-      await dbWrite.$executeRaw`
+      // Merge server-side rather than writing back the snapshot read before the (multi-second)
+      // generation call above. Two separate reasons, both load-bearing:
+      //
+      // 1. STATUS PREDICATE. The SELECT ran on the read replica and only filtered
+      //    Active/Scheduled. `claimChallengeForCompletion` can flip this challenge to Completing
+      //    while `generateThemeElements` is in flight, stamping metadata.completingClaimedAt as it
+      //    goes. An unpredicated write would then restore the PRE-CLAIM snapshot on top of the
+      //    fresh stamp, leaving status=Completing with no completingClaimedAt — a state the
+      //    NULL-propagating stuck-challenge reset never selects, so the challenge wedges
+      //    permanently. `?force=true` widens the exposure to every themed Active/Scheduled
+      //    challenge at once. Same guard shape (and same reasoning) as the conditional updateMany
+      //    in upsertChallenge.
+      // 2. JSONB MERGE. Even inside Active/Scheduled, writing the whole column clobbers any other
+      //    metadata field written during the generation window. Concatenating onto the CURRENT
+      //    stored value touches only themeElements. The CASE normalises a NULL/non-object metadata
+      //    to {} so the result stays an object (`||` would otherwise concatenate arrays).
+      const themeElementsPatch = JSON.stringify({ themeElements: elements });
+      const updatedRows = await dbWrite.$executeRaw`
         UPDATE "Challenge"
-        SET metadata = ${JSON.stringify(newMetadata)}::jsonb
+        SET metadata =
+          CASE WHEN jsonb_typeof(metadata) = 'object' THEN metadata ELSE '{}'::jsonb END
+          || ${themeElementsPatch}::jsonb
         WHERE id = ${challenge.id}
+          AND status IN ('Active', 'Scheduled')
       `;
+
+      if (updatedRows === 0) {
+        results.push({
+          id: challenge.id,
+          theme: challenge.theme,
+          status: 'skipped: no longer Active/Scheduled',
+        });
+        return;
+      }
 
       successes++;
       results.push({

--- a/src/pages/api/mod/daily-challenge/backfill-theme-elements.ts
+++ b/src/pages/api/mod/daily-challenge/backfill-theme-elements.ts
@@ -75,6 +75,7 @@ export default WebhookEndpoint(async function (_req: NextApiRequest, res: NextAp
     try {
       const resolvedJudgeId = challenge.judgeId ?? defaultJudgeId;
       if (!resolvedJudgeId) {
+        skipped++;
         results.push({ id: challenge.id, theme: challenge.theme, status: 'skipped: no judge' });
         return;
       }
@@ -86,6 +87,7 @@ export default WebhookEndpoint(async function (_req: NextApiRequest, res: NextAp
       });
 
       if (!elements.length) {
+        skipped++;
         results.push({
           id: challenge.id,
           theme: challenge.theme,
@@ -121,9 +123,8 @@ export default WebhookEndpoint(async function (_req: NextApiRequest, res: NextAp
       `;
 
       if (updatedRows === 0) {
-        // The whole point of the predicate is a race nobody is watching for. Without a log the
-        // only evidence it ever fired is a reader noticing that
-        // `backfilled + failures + skipped < total` in the response JSON.
+        // The whole point of the predicate is a race nobody is watching for, so log it — the
+        // response JSON alone cannot single it out (it is one of three `skipped:` reasons).
         logToAxiom({
           type: 'warning',
           name: 'backfill-theme-elements-skipped',
@@ -167,10 +168,13 @@ export default WebhookEndpoint(async function (_req: NextApiRequest, res: NextAp
   log(`Backfill complete: ${successes} successes, ${failures} failures, ${skipped} skipped`);
   return res.status(200).json({
     total: challenges.length,
+    // `total` counts every themed Active/Scheduled challenge; without force, most of them already
+    // have themeElements and are never attempted. Report the attempted set separately so the
+    // identity that actually closes is `attempted === backfilled + failures + skipped` — against
+    // `total` a shortfall is the ordinary steady state and carries no signal.
+    attempted: toBackfill.length,
     backfilled: successes,
     failures,
-    // Reported so `backfilled + failures` adding up to less than the attempted set is explained
-    // rather than looking like a silent shortfall.
     skipped,
     force,
     results,

--- a/src/pages/api/mod/daily-challenge/backfill-theme-elements.ts
+++ b/src/pages/api/mod/daily-challenge/backfill-theme-elements.ts
@@ -56,7 +56,12 @@ export default WebhookEndpoint(async function (_req: NextApiRequest, res: NextAp
     return res.status(200).json({
       message: 'No challenges need backfilling',
       total: challenges.length,
+      // Present even here so `attempted === backfilled + failures + skipped` holds on EVERY
+      // response shape rather than only the one the happy path returns.
+      attempted: 0,
       backfilled: 0,
+      failures: 0,
+      skipped: 0,
     });
   }
 

--- a/src/server/prom/challenge.metrics.ts
+++ b/src/server/prom/challenge.metrics.ts
@@ -463,15 +463,19 @@ const COMPLETING_STUCK_MINUTES = 30;
  *
  * Declaring `completingClaimedAt` in `challengeMetadataSchema` does not close it. The destroyer is
  * not the zod strip — it is a STALE FULL-COLUMN REPLACE. Six sites in total do a stale-replica
- * full-column metadata replace; of those, TWO could leave the row still IN `Completing` (the rest
- * either set a terminal status in the same statement or are predicated to a non-`Completing`
- * status, so they cannot strand one). Those two read a challenge (from the REPLICA), spend real
- * time, then wrote the whole metadata column back keyed only on `id`, with no status predicate:
- * `backfill-theme-elements.ts` (a multi-second LLM call sits between its read and its write, and
- * `?force=true` widens it to every themed Active/Scheduled challenge) and `challenge.service.ts`'s
- * `upsertChallenge`. If `claimChallengeForCompletion` landed in that window, the pre-claim snapshot
- * overwrote the fresh stamp — and the stamp was never IN that snapshot, so there was nothing for
- * the schema to have preserved.
+ * full-column metadata replace. Two of them read a challenge (from the REPLICA), spend real time,
+ * then wrote the whole metadata column back keyed only on `id` with no status predicate, so
+ * `claimChallengeForCompletion` could land in the window and have the pre-claim snapshot overwrite
+ * the fresh stamp. The stamp was never IN that snapshot, so there was nothing for the schema to
+ * have preserved. Their damage differed, and only the first is what THIS gauge would have seen:
+ *
+ *   - `backfill-theme-elements.ts` wrote metadata and NOT status, so it left the row IN
+ *     `Completing` with no stamp — the stranded state this gauge counts. A multi-second LLM call
+ *     sits between its read and its write, and `?force=true` widens it to every themed
+ *     Active/Scheduled challenge.
+ *   - `challenge.service.ts`'s `upsertChallenge` also wrote `status`, pinned back to the
+ *     Active/Scheduled value it had READ — so it did not strand a stampless `Completing` row, it
+ *     UN-CLAIMED a challenge mid-completion. Invisible to this gauge; the damage lands elsewhere.
  *
  * BOTH WRITES ARE NOW PREDICATED (2026-07-31): the backfill's UPDATE carries
  * `AND status IN ('Active','Scheduled')` and merges with jsonb `||` instead of replacing the

--- a/src/server/prom/challenge.metrics.ts
+++ b/src/server/prom/challenge.metrics.ts
@@ -461,20 +461,31 @@ const COMPLETING_STUCK_MINUTES = 30;
  * compares `(metadata->>'completingClaimedAt')::timestamptz`, which is NULL-propagating, so a
  * stampless row is never selected and never reset — it stays `Completing` forever.
  *
- * IT IS STILL REACHABLE, and declaring `completingClaimedAt` in `challengeMetadataSchema` does not
- * close it. The destroyer is not the zod strip — it is a STALE FULL-COLUMN REPLACE. Six sites in
- * total do a stale-replica full-column metadata replace; of those, TWO can leave the row still IN
- * `Completing` (the rest either set a terminal status in the same statement or are predicated to a
- * non-`Completing` status, so they cannot strand one). Those two read a challenge (from the
- * REPLICA), spend real time, then write the whole metadata column back keyed only on `id`, with no
- * status predicate: `backfill-theme-elements.ts` (a multi-second LLM call
- * sits between its read and its write, and `?force=true` widens it to every themed Active/Scheduled
- * challenge) and `challenge.service.ts`'s `upsertChallenge`. If `claimChallengeForCompletion` lands
- * in that window, the pre-claim snapshot overwrites the fresh stamp. The stamp was never IN that
- * snapshot, so there is nothing for the schema to have preserved — behaviour is identical before
- * and after this field was declared. Closing it for real means predicating those writes
- * (`AND status <> 'Completing'`, or the `updateMany` + `count === 0` pattern already used
- * elsewhere in that service); that is a separate change and has not been made.
+ * Declaring `completingClaimedAt` in `challengeMetadataSchema` does not close it. The destroyer is
+ * not the zod strip — it is a STALE FULL-COLUMN REPLACE. Six sites in total do a stale-replica
+ * full-column metadata replace; of those, TWO could leave the row still IN `Completing` (the rest
+ * either set a terminal status in the same statement or are predicated to a non-`Completing`
+ * status, so they cannot strand one). Those two read a challenge (from the REPLICA), spend real
+ * time, then wrote the whole metadata column back keyed only on `id`, with no status predicate:
+ * `backfill-theme-elements.ts` (a multi-second LLM call sits between its read and its write, and
+ * `?force=true` widens it to every themed Active/Scheduled challenge) and `challenge.service.ts`'s
+ * `upsertChallenge`. If `claimChallengeForCompletion` landed in that window, the pre-claim snapshot
+ * overwrote the fresh stamp — and the stamp was never IN that snapshot, so there was nothing for
+ * the schema to have preserved.
+ *
+ * BOTH WRITES ARE NOW PREDICATED (2026-07-31): the backfill's UPDATE carries
+ * `AND status IN ('Active','Scheduled')` and merges with jsonb `||` instead of replacing the
+ * column; `upsertChallenge` uses the `updateMany` + `count === 0` pattern keyed on the status it
+ * read. Neither can strand a row in `Completing` any more, so this gauge should no longer see a
+ * stampless `Completing` row from those paths.
+ *
+ * 🔴 It does NOT follow that the class is gone. `upsertChallenge` still writes the WHOLE metadata
+ * column from its replica snapshot (`{ ...existingMetadata, themeElements }`) — the predicate only
+ * stops it landing on a DIFFERENT status, not on a same-status racing write. That is no longer a
+ * wedge, but it still silently drops concurrent metadata (e.g. the `reviewedAt` watermark, which
+ * rewinds incremental review to the challenge start), and a declared-key type violation still makes
+ * `parseChallengeMetadata` return `{}` and wipe the column. Converting that write to the same jsonb
+ * `||` merge is the remaining work.
  *
  * So the design is not merely the cheap direction to be wrong in — it is load-bearing. A legacy or
  * malformed stamp lands here too, and treating such rows as "not stuck" would make the gauge

--- a/src/server/services/__tests__/challenge-upsert-completing-claim-guard.service.test.ts
+++ b/src/server/services/__tests__/challenge-upsert-completing-claim-guard.service.test.ts
@@ -1,0 +1,220 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Regression guard for the second half of the "claimed-for-completion gets clobbered" defect.
+//
+// `upsertChallenge`'s update branch reads the challenge from the READ REPLICA, validates its
+// status, and may then spend seconds inside `tryGenerateThemeElements` (an LLM call) before it
+// writes. `claimChallengeForCompletion` can flip the challenge to Completing in that window.
+//
+// The write used to be an unconditional `tx.challenge.update({ where: { id } })`. Because the
+// Active branch pins `data.status` back to the status that was READ, that unconditional write
+// would set a mid-completion challenge back to Active and restore the stale metadata snapshot
+// over the fresh `completingClaimedAt` stamp — un-claiming the challenge and dropping the marker
+// the stuck-challenge reset keys off. It is now a status-predicated `updateMany` + `count === 0`,
+// matching the Scheduled-only edit path elsewhere in this service.
+
+const { mockDbRead, mockDbWrite, mockTx, mockCreateImage, mockGenerateThemeElements } = vi.hoisted(
+  () => {
+    const tx = {
+      challenge: {
+        updateMany: vi.fn().mockResolvedValue({ count: 1 }),
+        findUniqueOrThrow: vi.fn().mockResolvedValue({ id: 1 }),
+        create: vi.fn().mockResolvedValue({ id: 2 }),
+      },
+      collection: {
+        create: vi.fn().mockResolvedValue({ id: 10 }),
+        update: vi.fn().mockResolvedValue({ id: 10 }),
+        findUnique: vi.fn().mockResolvedValue({ metadata: {} }),
+      },
+    };
+    return {
+      mockTx: tx,
+      mockDbRead: {
+        challenge: { findUnique: vi.fn() },
+        challengeJudge: { findUnique: vi.fn().mockResolvedValue({ userId: 1 }) },
+      },
+      mockDbWrite: { $transaction: vi.fn(async (cb: (tx: unknown) => unknown) => cb(tx)) },
+      mockCreateImage: vi.fn(),
+      mockGenerateThemeElements: vi.fn().mockResolvedValue([]),
+    };
+  }
+);
+
+vi.mock('~/server/db/client', () => ({ dbRead: mockDbRead, dbWrite: mockDbWrite }));
+
+vi.mock('~/server/flipt/client', () => ({
+  FLIPT_FEATURE_FLAGS: {},
+  isFlipt: vi.fn().mockResolvedValue(false),
+}));
+
+vi.mock('~/server/logging/client', () => ({ logToAxiom: vi.fn() }));
+
+vi.mock('~/server/games/daily-challenge/challenge-helpers', () => ({
+  claimChallengeForCompletion: vi.fn(),
+  closeChallengeCollection: vi.fn(),
+  createChallengeWinner: vi.fn(),
+  getChallengeById: vi.fn(),
+  getChallengeWinners: vi.fn().mockResolvedValue([]),
+  getExistingWinnersForRetry: vi.fn().mockResolvedValue([]),
+  resolveEventContext: vi.fn(),
+}));
+
+vi.mock('~/server/games/daily-challenge/daily-challenge.utils', () => ({
+  getChallengeConfig: vi.fn().mockResolvedValue({ defaultJudgeId: 1 }),
+  setChallengeConfig: vi.fn(),
+  deriveChallengeNsfwLevel: vi.fn(() => 1),
+  getJudgingConfig: vi.fn(),
+  refreshDefaultJudgeCache: vi.fn(),
+  parseJudgeScore: vi.fn(),
+}));
+
+vi.mock('~/server/games/daily-challenge/generative-content', () => ({
+  generateArticle: vi.fn(),
+  generateReview: vi.fn(),
+  generateThemeElements: mockGenerateThemeElements,
+  generateWinners: vi.fn(),
+}));
+
+vi.mock('~/server/games/daily-challenge/template-engine', () => ({
+  reviewTemplateSchema: { safeParse: vi.fn() },
+}));
+
+vi.mock('~/server/jobs/daily-challenge-processing', () => ({
+  getCoverOfModel: vi.fn(),
+  getJudgedEntries: vi.fn(),
+}));
+
+vi.mock('~/server/games/daily-challenge/challenge-funding', () => ({
+  chargeInitialPrize: vi.fn(),
+  refundUserChallengeFunds: vi.fn().mockResolvedValue({ refundedEntries: 0 }),
+}));
+
+vi.mock('~/server/services/buzz.service', () => ({
+  createBuzzTransaction: vi.fn(),
+  createBuzzTransactionMany: vi.fn(),
+  getTransactionByExternalId: vi.fn(),
+}));
+
+vi.mock('~/server/services/notification.service', () => ({ createNotification: vi.fn() }));
+
+vi.mock('~/server/services/image.service', () => ({
+  createImage: mockCreateImage,
+  imagesForModelVersionsCache: { bust: vi.fn() },
+}));
+
+vi.mock('~/server/services/user.service', () => ({
+  getCosmeticsForUsers: vi.fn(() => ({})),
+  getProfilePicturesForUsers: vi.fn(() => ({})),
+}));
+
+vi.mock('~/server/services/challenge-eligibility.service', () => ({
+  assertCanCreateUserChallenge: vi.fn(),
+}));
+
+vi.mock('~/server/integrations/moderation', () => ({ extModeration: {} }));
+
+vi.mock('~/server/search-index', () => ({ collectionsSearchIndex: { queueUpdate: vi.fn() } }));
+
+vi.mock('~/utils/errorHandling', () => ({ withRetries: vi.fn((fn: () => unknown) => fn()) }));
+
+vi.mock('~/utils/logging', () => ({ createLogger: vi.fn(() => vi.fn()) }));
+
+const { upsertChallenge } = await import('~/server/services/challenge.service');
+const { ChallengeStatus } = await import('~/shared/utils/prisma/enums');
+
+const storedChallenge = (status: string) => ({
+  collectionId: null,
+  metadata: { completingClaimedAt: null },
+  status,
+  startsAt: new Date(Date.now() - 86400000),
+  modelVersionIds: [],
+  allowedNsfwLevel: 1,
+  source: 'Mod',
+  maxEntriesPerUser: 20,
+  entryPrizeRequirement: 10,
+  prizeMode: 'Fixed',
+  basePrizePool: 0,
+  buzzPerAction: 0,
+  poolTrigger: null,
+  maxPrizePool: null,
+  prizeDistribution: null,
+  judgingCategories: null,
+});
+
+const baseInput = {
+  userId: 999,
+  title: 'A test challenge',
+  theme: 'Neon',
+  coverImage: { id: 555, url: 'unused' },
+  themeElements: ['already', 'provided'],
+  nsfwLevel: 1,
+  allowedNsfwLevel: 1,
+  modelVersionIds: [],
+  judgeId: 1,
+  judgingPrompt: 'prompt',
+  reviewPercentage: 100,
+  maxEntriesPerUser: 20,
+  prizes: [],
+  entryPrizeRequirement: 10,
+  prizePool: 0,
+  operationBudget: 0,
+  prizeMode: 'Fixed',
+  basePrizePool: 0,
+  buzzPerAction: 0,
+  reviewCostType: 'None',
+  reviewCost: 0,
+  startsAt: new Date(Date.now() - 86400000),
+  endsAt: new Date(Date.now() + 2 * 86400000),
+  visibleAt: new Date(),
+  status: ChallengeStatus.Active,
+  source: 'Mod',
+};
+
+describe('upsertChallenge — must not overwrite a challenge claimed for completion', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockTx.challenge.updateMany.mockResolvedValue({ count: 1 });
+    mockTx.challenge.findUniqueOrThrow.mockResolvedValue({ id: 1 });
+    mockDbWrite.$transaction.mockImplementation(async (cb: (tx: unknown) => unknown) => cb(mockTx));
+  });
+
+  it('scopes the write to the status it validated, not to the id alone', async () => {
+    mockDbRead.challenge.findUnique.mockResolvedValue(storedChallenge(ChallengeStatus.Active));
+
+    await upsertChallenge({ ...baseInput, id: 1 } as never);
+
+    expect(mockTx.challenge.updateMany).toHaveBeenCalledTimes(1);
+    const where = mockTx.challenge.updateMany.mock.calls[0][0].where;
+    expect(where).toEqual({ id: 1, status: ChallengeStatus.Active });
+  });
+
+  it('aborts instead of writing when the challenge was claimed mid-save', async () => {
+    mockDbRead.challenge.findUnique.mockResolvedValue(storedChallenge(ChallengeStatus.Active));
+    // The predicate matched nothing: claimChallengeForCompletion moved it to Completing while
+    // theme generation was in flight.
+    mockTx.challenge.updateMany.mockResolvedValue({ count: 0 });
+
+    await expect(upsertChallenge({ ...baseInput, id: 1 } as never)).rejects.toMatchObject({
+      code: 'PRECONDITION_FAILED',
+    });
+
+    // Nothing downstream of the guard may run — in particular the collection must not be
+    // re-dated for a challenge that is already completing.
+    expect(mockTx.challenge.findUniqueOrThrow).not.toHaveBeenCalled();
+    expect(mockTx.collection.update).not.toHaveBeenCalled();
+  });
+
+  it('returns the re-read row on a successful update', async () => {
+    mockDbRead.challenge.findUnique.mockResolvedValue(storedChallenge(ChallengeStatus.Scheduled));
+    mockTx.challenge.findUniqueOrThrow.mockResolvedValue({ id: 1, title: 'A test challenge' });
+
+    const result = await upsertChallenge({
+      ...baseInput,
+      id: 1,
+      status: ChallengeStatus.Scheduled,
+    } as never);
+
+    expect(result).toEqual({ id: 1, title: 'A test challenge' });
+    expect(mockTx.challenge.findUniqueOrThrow).toHaveBeenCalledWith({ where: { id: 1 } });
+  });
+});

--- a/src/server/services/__tests__/challenge-upsert-completing-claim-guard.service.test.ts
+++ b/src/server/services/__tests__/challenge-upsert-completing-claim-guard.service.test.ts
@@ -13,32 +13,38 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 // the stuck-challenge reset keys off. It is now a status-predicated `updateMany` + `count === 0`,
 // matching the Scheduled-only edit path elsewhere in this service.
 
-const { mockDbRead, mockDbWrite, mockTx, mockCreateImage, mockGenerateThemeElements } = vi.hoisted(
-  () => {
-    const tx = {
-      challenge: {
-        updateMany: vi.fn().mockResolvedValue({ count: 1 }),
-        findUniqueOrThrow: vi.fn().mockResolvedValue({ id: 1 }),
-        create: vi.fn().mockResolvedValue({ id: 2 }),
-      },
-      collection: {
-        create: vi.fn().mockResolvedValue({ id: 10 }),
-        update: vi.fn().mockResolvedValue({ id: 10 }),
-        findUnique: vi.fn().mockResolvedValue({ metadata: {} }),
-      },
-    };
-    return {
-      mockTx: tx,
-      mockDbRead: {
-        challenge: { findUnique: vi.fn() },
-        challengeJudge: { findUnique: vi.fn().mockResolvedValue({ userId: 1 }) },
-      },
-      mockDbWrite: { $transaction: vi.fn(async (cb: (tx: unknown) => unknown) => cb(tx)) },
-      mockCreateImage: vi.fn(),
-      mockGenerateThemeElements: vi.fn().mockResolvedValue([]),
-    };
-  }
-);
+const {
+  mockDbRead,
+  mockDbWrite,
+  mockTx,
+  mockCreateImage,
+  mockGenerateThemeElements,
+  mockLogToAxiom,
+} = vi.hoisted(() => {
+  const tx = {
+    challenge: {
+      updateMany: vi.fn().mockResolvedValue({ count: 1 }),
+      findUniqueOrThrow: vi.fn().mockResolvedValue({ id: 1 }),
+      create: vi.fn().mockResolvedValue({ id: 2 }),
+    },
+    collection: {
+      create: vi.fn().mockResolvedValue({ id: 10 }),
+      update: vi.fn().mockResolvedValue({ id: 10 }),
+      findUnique: vi.fn().mockResolvedValue({ metadata: {} }),
+    },
+  };
+  return {
+    mockTx: tx,
+    mockDbRead: {
+      challenge: { findUnique: vi.fn() },
+      challengeJudge: { findUnique: vi.fn().mockResolvedValue({ userId: 1 }) },
+    },
+    mockDbWrite: { $transaction: vi.fn(async (cb: (tx: unknown) => unknown) => cb(tx)) },
+    mockCreateImage: vi.fn(),
+    mockGenerateThemeElements: vi.fn().mockResolvedValue([]),
+    mockLogToAxiom: vi.fn().mockResolvedValue(undefined),
+  };
+});
 
 vi.mock('~/server/db/client', () => ({ dbRead: mockDbRead, dbWrite: mockDbWrite }));
 
@@ -47,11 +53,10 @@ vi.mock('~/server/flipt/client', () => ({
   isFlipt: vi.fn().mockResolvedValue(false),
 }));
 
-// Must resolve a promise, not undefined: the guard chains `.catch()` on it, matching how the
-// rest of challenge.service.ts calls logToAxiom.
-vi.mock('~/server/logging/client', () => ({
-  logToAxiom: vi.fn().mockResolvedValue(undefined),
-}));
+// Must resolve a promise, not undefined: production `logToAxiom` is async and the guard chains
+// `.catch()` on it (as two other sites in challenge.service.ts do). A bare `vi.fn()` returns
+// undefined and TypeErrors — which is also what proves the guard path is genuinely exercised.
+vi.mock('~/server/logging/client', () => ({ logToAxiom: mockLogToAxiom }));
 
 vi.mock('~/server/games/daily-challenge/challenge-helpers', () => ({
   claimChallengeForCompletion: vi.fn(),
@@ -206,6 +211,14 @@ describe('upsertChallenge — must not overwrite a challenge claimed for complet
     // re-dated for a challenge that is already completing.
     expect(mockTx.challenge.findUniqueOrThrow).not.toHaveBeenCalled();
     expect(mockTx.collection.update).not.toHaveBeenCalled();
+    // Rare by construction, so the log is the only way to know the guard ever fired.
+    expect(mockLogToAxiom).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'challenge-upsert-status-precondition-failed',
+        challengeId: 1,
+        readStatus: ChallengeStatus.Active,
+      })
+    );
   });
 
   it('returns the re-read row on a successful update', async () => {

--- a/src/server/services/__tests__/challenge-upsert-completing-claim-guard.service.test.ts
+++ b/src/server/services/__tests__/challenge-upsert-completing-claim-guard.service.test.ts
@@ -47,7 +47,11 @@ vi.mock('~/server/flipt/client', () => ({
   isFlipt: vi.fn().mockResolvedValue(false),
 }));
 
-vi.mock('~/server/logging/client', () => ({ logToAxiom: vi.fn() }));
+// Must resolve a promise, not undefined: the guard chains `.catch()` on it, matching how the
+// rest of challenge.service.ts calls logToAxiom.
+vi.mock('~/server/logging/client', () => ({
+  logToAxiom: vi.fn().mockResolvedValue(undefined),
+}));
 
 vi.mock('~/server/games/daily-challenge/challenge-helpers', () => ({
   claimChallengeForCompletion: vi.fn(),

--- a/src/server/services/__tests__/challenge-upsert-mod-judging-categories.service.test.ts
+++ b/src/server/services/__tests__/challenge-upsert-mod-judging-categories.service.test.ts
@@ -15,7 +15,10 @@ const { mockDbRead, mockDbWrite, mockTx, mockCreateImage, mockGetChallengeConfig
   () => {
     const tx = {
       challenge: {
-        update: vi.fn().mockResolvedValue({ id: 1 }),
+        // The update path writes through a status-predicated `updateMany` (so a challenge claimed
+        // for completion mid-save is not silently un-claimed), then re-reads the row to return it.
+        updateMany: vi.fn().mockResolvedValue({ count: 1 }),
+        findUniqueOrThrow: vi.fn().mockResolvedValue({ id: 1 }),
         create: vi.fn().mockResolvedValue({ id: 2 }),
       },
       collection: {
@@ -192,7 +195,8 @@ const baseInput = {
 describe('upsertChallenge (moderator path) — judgingCategories', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockTx.challenge.update.mockResolvedValue({ id: 1 });
+    mockTx.challenge.updateMany.mockResolvedValue({ count: 1 });
+    mockTx.challenge.findUniqueOrThrow.mockResolvedValue({ id: 1 });
     mockTx.challenge.create.mockResolvedValue({ id: 2 });
     mockTx.collection.create.mockResolvedValue({ id: 10 });
     mockDbWrite.$transaction.mockImplementation(async (cb: (tx: unknown) => unknown) => cb(mockTx));
@@ -250,8 +254,8 @@ describe('upsertChallenge (moderator path) — judgingCategories', () => {
       judgingCategories: VALID_CATEGORIES,
     } as never);
 
-    expect(mockTx.challenge.update).toHaveBeenCalledTimes(1);
-    const callArg = mockTx.challenge.update.mock.calls[0][0];
+    expect(mockTx.challenge.updateMany).toHaveBeenCalledTimes(1);
+    const callArg = mockTx.challenge.updateMany.mock.calls[0][0];
     expect(callArg.data.judgingCategories).toEqual(RESOLVED_CATEGORIES);
     expect(callArg.data.judgingPrompt).toBe('Custom AI persona prompt');
   });
@@ -277,7 +281,7 @@ describe('upsertChallenge (moderator path) — judgingCategories', () => {
 
     await upsertChallenge({ ...baseInput, id: 1, judgingCategories: null } as never);
 
-    const callArg = mockTx.challenge.update.mock.calls[0][0];
+    const callArg = mockTx.challenge.updateMany.mock.calls[0][0];
     expect(callArg.data.judgingCategories).toBe(Prisma.JsonNull);
   });
 
@@ -311,7 +315,7 @@ describe('upsertChallenge (moderator path) — judgingCategories', () => {
       judgingCategories: VALID_CATEGORIES,
     } as never);
 
-    const callArg = mockTx.challenge.update.mock.calls[0][0];
+    const callArg = mockTx.challenge.updateMany.mock.calls[0][0];
     expect(callArg.data.judgingCategories).toEqual(stored);
   });
 
@@ -342,7 +346,7 @@ describe('upsertChallenge (moderator path) — judgingCategories', () => {
       judgingCategories: VALID_CATEGORIES,
     } as never);
 
-    const callArg = mockTx.challenge.update.mock.calls[0][0];
+    const callArg = mockTx.challenge.updateMany.mock.calls[0][0];
     expect(callArg.data.judgingCategories).toBe(Prisma.JsonNull);
   });
 });

--- a/src/server/services/challenge.service.ts
+++ b/src/server/services/challenge.service.ts
@@ -1439,6 +1439,14 @@ export async function upsertChallenge({
             ? (data.prizeDistribution as unknown as Prisma.InputJsonValue)
             : Prisma.JsonNull,
           judgingCategories: effectiveJudgingCategories,
+          // 🔴 REMAINING WORK: this is still a stale full-column replace. `existingMetadata`
+          // comes from the REPLICA read above, so a SAME-status write that commits during
+          // `tryGenerateThemeElements` is silently dropped — notably the `reviewedAt` watermark,
+          // whose loss rewinds incremental review to the challenge start and re-judges the whole
+          // backlog at LLM cost. The status predicate on this updateMany does NOT cover that; only
+          // converting this to the jsonb `||` merge used by backfill-theme-elements.ts does.
+          // Routine rather than rare: the edit form pre-fills themeElements, so this branch runs
+          // on most mod saves. See the long note in server/prom/challenge.metrics.ts.
           ...(themeElements && {
             metadata: { ...existingMetadata, themeElements },
           }),

--- a/src/server/services/challenge.service.ts
+++ b/src/server/services/challenge.service.ts
@@ -1444,11 +1444,26 @@ export async function upsertChallenge({
           }),
         },
       });
-      if (count === 0)
+      if (count === 0) {
+        // Rare by construction, so log it — otherwise there is no way to tell whether this guard
+        // has ever fired, or to distinguish a genuine race from replica lag (below).
+        logToAxiom({
+          type: 'warning',
+          name: 'challenge-upsert-status-precondition-failed',
+          challengeId: id,
+          message: `upsertChallenge aborted: challenge ${id} was no longer '${challenge.status}' at write time`,
+          readStatus: challenge.status,
+        }).catch(() => undefined);
+        // Deliberately NOT "reload and try again": `challenge.status` came from the read REPLICA,
+        // so this also fires when a transition already committed on the primary and has not
+        // replicated yet — a reload re-reads the same lagging replica and cannot clear it. It also
+        // fires when the row was deleted outright, where "status changed" is the wrong diagnosis.
         throw new TRPCError({
           code: 'PRECONDITION_FAILED',
-          message: 'Challenge status changed while saving. Reload and try again.',
+          message:
+            'This challenge changed while you were saving (it may have started, been completed, or been cancelled). Re-open it in a moment to see its current state.',
         });
+      }
       const updated = await tx.challenge.findUniqueOrThrow({ where: { id } });
 
       // Sync collection metadata if challenge has a collection

--- a/src/server/services/challenge.service.ts
+++ b/src/server/services/challenge.service.ts
@@ -1417,9 +1417,15 @@ export async function upsertChallenge({
 
     // Use transaction to update both challenge and collection metadata atomically
     const updatedChallenge = await dbWrite.$transaction(async (tx) => {
-      // Update the challenge
-      const updated = await tx.challenge.update({
-        where: { id },
+      // Conditional on the status we VALIDATED, for the same reason as the Scheduled-only edit
+      // path below: the findUnique above ran on the read replica, and `tryGenerateThemeElements`
+      // can spend seconds in an LLM call before we get here. `claimChallengeForCompletion` may
+      // have flipped the challenge to Completing in that window. An unconditional update would
+      // then write `data.status` (pinned back to the pre-read Active) and the stale metadata
+      // snapshot over the fresh claim — un-claiming a challenge mid-completion and dropping the
+      // completingClaimedAt stamp the stuck-challenge reset keys off.
+      const { count } = await tx.challenge.updateMany({
+        where: { id, status: challenge.status },
         data: {
           ...data,
           nsfwLevel: deriveChallengeNsfwLevel(data.allowedNsfwLevel ?? 1),
@@ -1438,6 +1444,12 @@ export async function upsertChallenge({
           }),
         },
       });
+      if (count === 0)
+        throw new TRPCError({
+          code: 'PRECONDITION_FAILED',
+          message: 'Challenge status changed while saving. Reload and try again.',
+        });
+      const updated = await tx.challenge.findUniqueOrThrow({ where: { id } });
 
       // Sync collection metadata if challenge has a collection
       if (challenge.collectionId) {

--- a/src/server/services/challenge.service.ts
+++ b/src/server/services/challenge.service.ts
@@ -1439,14 +1439,19 @@ export async function upsertChallenge({
             ? (data.prizeDistribution as unknown as Prisma.InputJsonValue)
             : Prisma.JsonNull,
           judgingCategories: effectiveJudgingCategories,
-          // 🔴 REMAINING WORK: this is still a stale full-column replace. `existingMetadata`
-          // comes from the REPLICA read above, so a SAME-status write that commits during
-          // `tryGenerateThemeElements` is silently dropped — notably the `reviewedAt` watermark,
-          // whose loss rewinds incremental review to the challenge start and re-judges the whole
-          // backlog at LLM cost. The status predicate on this updateMany does NOT cover that; only
-          // converting this to the jsonb `||` merge used by backfill-theme-elements.ts does.
-          // Routine rather than rare: the edit form pre-fills themeElements, so this branch runs
-          // on most mod saves. See the long note in server/prom/challenge.metrics.ts.
+          // 🔴 REMAINING WORK: this is still a stale full-column replace. `existingMetadata` comes
+          // from the REPLICA read above, so any SAME-status write that commits between that read
+          // and this one is silently dropped — notably the `reviewedAt` watermark, whose loss
+          // rewinds incremental review to the challenge start and re-judges the whole backlog at
+          // LLM cost. The status predicate on this updateMany does NOT cover that; only converting
+          // this to the jsonb `||` merge used by backfill-theme-elements.ts does.
+          //
+          // Two branches reach here, with very different windows — do not conflate them:
+          //   - themeElements supplied by the caller (the edit form pre-fills them, so this is the
+          //     common save): NO LLM call, window is replica lag plus the request itself.
+          //   - auto-generate (theme set, no stored elements): `tryGenerateThemeElements` puts a
+          //     multi-second LLM call in the window. Rarer, but far wider.
+          // See the long note in server/prom/challenge.metrics.ts.
           ...(themeElements && {
             metadata: { ...existingMetadata, themeElements },
           }),


### PR DESCRIPTION
## Problem

Two write paths read a challenge from the **read replica**, spend seconds in an LLM call (`generateThemeElements`), and then write `metadata` back keyed only on `id`:

- `src/pages/api/mod/daily-challenge/backfill-theme-elements.ts`
- `upsertChallenge` (`challenge.service.ts`), update branch

If `claimChallengeForCompletion` flips the challenge to `Completing` inside that window — stamping `metadata.completingClaimedAt` as it goes — the write restores the **pre-claim snapshot** on top of the fresh stamp. The challenge is then `Completing` with no `completingClaimedAt`, and the stuck-challenge reset propagates NULL so it never selects that row: **the challenge wedges permanently.**

`?force=true` widens the backfill's exposure from "challenges missing theme elements" to *every* themed `Active`/`Scheduled` challenge at once.

`upsertChallenge` is worse in one respect: its `Active` branch pins `data.status` back to the status it **read**, so the unconditional write also sets a mid-completion challenge back to `Active` — un-claiming it outright.

## Fix

**Backfill endpoint** — predicate the `UPDATE` on `status IN ('Active','Scheduled')`, and merge the patch onto the *current* stored value with `jsonb ||` rather than replacing the whole column. The predicate closes the wedge; the merge additionally stops any *other* metadata field written during the generation window from being clobbered, even when the status never changed. A zero-row result is reported as `skipped`, not counted as backfilled.

```sql
SET metadata =
  CASE WHEN jsonb_typeof(metadata) = 'object' THEN metadata ELSE '{}'::jsonb END
  || $patch::jsonb
WHERE id = $id
  AND status IN ('Active', 'Scheduled')
```

**`upsertChallenge`** — convert the unconditional `update` to a status-predicated `updateMany` + `count === 0`, matching [the Scheduled-only edit path already in this service](https://github.com/civitai/civitai/blob/main/src/server/services/challenge.service.ts), then re-read the row to return it.

## Tests

8 new (5 endpoint, 3 service), plus the existing judging-categories suite updated for `update` → `updateMany`.

Both guards are **mutation-verified**: removing either status predicate fails 3 of the new tests. (Checked explicitly rather than assumed — a guard whose test still passes with the guard removed isn't testing anything.)

## Verification

- `vitest --project unit challenge` → **627/627 pass** (71 files)
- `eslint` clean on all five changed files
- `prettier` clean on the four it was already clean on. `challenge.service.ts` is unformatted on `main`; the change introduces **no new hunks** (formatter hunk set is identical to baseline, offset only by added lines)
- `tsc --noEmit` output is **byte-identical to pristine `origin/main`**, which is currently red on an unrelated `ModelVersionUpsertForm` error (`freeGeneration`). So this branch adds no type errors — and the `updateMany` data shape typechecks.

## Notes

- Behaviour change: a save that races a completion now returns `PRECONDITION_FAILED` ("Challenge status changed while saving. Reload and try again.") instead of silently winning. That is the intended trade — the previous silent win corrupted the challenge.
- The backfill no longer rewrites metadata fields it did not intend to change, so the endpoint stops normalising the column as a side effect of running.
