### PR TITLE
docs(blocks): the customComfy recipe registry is LIVE, not inert

### DIFF
--- a/src/server/services/blocks/recipes/index.ts
+++ b/src/server/services/blocks/recipes/index.ts
@@ -17,8 +17,16 @@ import { starterComfyTxt2imgRecipe } from './starter-comfy-txt2img.recipe';
 // `<name>.recipe.ts`, register it below, add golden-graph tests. The `kind`
 // (`customComfy`) and the SDK are untouched — only the recipe id enum widens.
 //
-// INERT/DARK: nothing here is wired into the live blocks.router submit/estimate
-// path yet — PR6 (router + post-paid budget belt) is what will call `getRecipe`.
+// 🔴 LIVE — this registry is on the SECURITY-CRITICAL post-paid submit path.
+// `blocks.router` branches on `kind === 'customComfy'` and resolves the recipe
+// through `getRecipe`, then runs the §5.3 timeout-cap budget belt over the
+// recipe's declared `budgetFor()` ceiling. A change here changes what a block
+// can spend, so treat every edit as a spend-safety review, not a content edit.
+//
+// (Previously marked INERT/DARK pending PR6 — that shipped; the router calls
+// `getRecipe` on the live path. Kept as a note because a stale "nothing here is
+// wired up yet" on a spend-critical trust root is exactly the comment that gets
+// a future reviewer to wave a change through.)
 // ─────────────────────────────────────────────────────────────────────────────
 
 /** A ComfyUI /prompt graph node: class_type + inputs, link refs `['id', slot]`. */


### PR DESCRIPTION
The recipe registry header still says:

> INERT/DARK: nothing here is wired into the live blocks.router submit/estimate path yet — PR6 (router + post-paid budget belt) is what will call `getRecipe`.

**PR6 shipped.** On `main` today:

- `blocks.router.ts:3547` — branches on `input.body.kind === 'customComfy'`
- `blocks.router.ts:5705` — calls `getRecipe(body.recipe)`
- the post-paid settle/refund path (`custom-comfy-settle.service`) is wired

So the registry sits on the live, security-critical post-paid submit path, and each recipe's `budgetFor()` ceiling is what bounds what a block can spend.

## Why this is worth a PR

This isn't cosmetic rot. The comment tells a reviewer that a **spend-critical trust root is dark**. Someone tuning a recipe's `maxBuzz` / `stepTimeoutSeconds` in good faith could reasonably read that header and conclude nothing they change reaches production — on the one file where that assumption is most expensive to get wrong.

Replaced with a statement of what the registry actually gates, plus a short note recording the correction so the same "not wired up yet" reading can't recur.

## Scope

Comment-only — every changed line in the diff is a `//` line. No local test run: the worktree has no deps and a comment cannot alter behaviour; CI covers it.

Found while evaluating the bridge design ahead of broadening App Blocks access.

🤖 Generated with [Claude Code](https://claude.com/claude-code)