### PR TITLE
fix(app-blocks): emit a render beacon when a ready page loses its credential mid-session

### DIFF
--- a/src/components/AppBlocks/PageBlockHost.tsx
+++ b/src/components/AppBlocks/PageBlockHost.tsx
@@ -382,9 +382,27 @@ export function PageBlockHost({
   // 🔴 Deliberately conservative: this resets to `false` rather than re-deriving
   // from `status`, because under host reuse `status` is itself STALE (it is still
   // app A's 'ready'). Re-deriving would re-create the misattribution this fixes.
-  // The cost is that if app B does reach ready and then loses its credential
-  // WITHOUT `status` ever changing value, its beacon is missed — under-reporting,
-  // never mis-reporting. That is the right side to err on for an alerting signal.
+  //
+  // Be precise about the cost, because it is NOT an edge case: under host reuse
+  // `status` is structurally frozen at app A's 'ready' — every `setStatus` here is
+  // gated on the current value, and the only unconditional reset to 'loading' is
+  // `performRetry`. So after a soft nav the latch re-arms only via a manual or
+  // automatic Retry, and until then app B can emit no mid-session beacon at all.
+  //
+  // That costs nothing real TODAY, because on the same path app B never gets a
+  // working session to lose: `shouldStartInit` returns false for any non-'loading'
+  // status, so BLOCK_INIT is never sent and app B cannot reach a genuine ready
+  // state. The missed beacon is therefore unreachable — it describes a state the
+  // pre-existing host-reuse bug already prevents. Net vs. before this reset:
+  // strictly better (we traded a FALSE POSITIVE on app B's launch failure for a
+  // beacon that could not have fired anyway). Under-reporting, never
+  // mis-reporting — the right side to err on for an alerting signal.
+  //
+  // 🔴 The DECLARATION ORDER below is load-bearing: this effect must be declared
+  // BEFORE the status-sync effect that sets `reachedReadyRef`, so that a commit
+  // changing both `blockInstanceId` and `status` resets first and latches second.
+  // No current test detects a swap (no reachable case distinguishes them today) —
+  // so if you reorder these, reason it through rather than trusting the suite.
   //
   // NOTE: the wider host-reuse problem is PRE-EXISTING and NOT fixed here — stale
   // `status` and the leaked `blockRenderEmittedRef` (so app B loses its `ok`

--- a/src/components/AppBlocks/PageBlockHost.tsx
+++ b/src/components/AppBlocks/PageBlockHost.tsx
@@ -620,12 +620,20 @@ export function PageBlockHost({
     // Fire-and-forget beacon — failures are a no-op. `errorClass` is a member of
     // the server-side KNOWN_ERROR_CLASSES allowlist, so it survives as a real
     // `error_class` prom label instead of collapsing into 'other'.
+    //
+    // 🔴 `secondary: true` is REQUIRED here, not decorative. This mount already
+    // sent its `ok` impression, and the `blockRenders` CH row carries no status —
+    // so without this flag the follow-up would write a SECOND byte-identical row
+    // for one mount, un-de-duplicatable, inflating every CH-derived impression
+    // figure for exactly the sessions that were revoked. The flag keeps the prom
+    // counter firing (that is what the alert reads) while skipping the insert.
     sendBlockRender({
       appBlockId,
       blockInstanceId,
       slotId: 'app.page',
       status: 'error',
       errorClass: MID_SESSION_LOSS_ERROR_CLASS,
+      secondary: true,
     });
   }, [status, tokenTerminal, token, appBlockId, blockInstanceId]);
 

--- a/src/components/AppBlocks/PageBlockHost.tsx
+++ b/src/components/AppBlocks/PageBlockHost.tsx
@@ -15,6 +15,7 @@ import {
   buildReviewConsentNotification,
   grantedPageScopes,
   INITIAL_REVIEW_CONSENT_LATCH,
+  MID_SESSION_LOSS_ERROR_CLASS,
   pageFallbackReason,
   resolveCheckpointPickerRequest,
   resolveGetImagesByIdsRequest,
@@ -23,6 +24,7 @@ import {
   resolveResourcePickerRequest,
   resolveReviewConsentNotice,
   resolveUngrantableConsentScopes,
+  shouldEmitMidSessionLossBeacon,
 } from './pageBlockHostLogic';
 import ConfirmDialog from '~/components/Dialog/Common/ConfirmDialog';
 import { projectSafeGenerationResource } from '~/server/schema/blocks/generation-resource-projection';
@@ -338,10 +340,39 @@ export function PageBlockHost({
   // makes the per-mount emit deterministic regardless of ack timing.
   const blockRenderEmittedRef = useRef<boolean>(false);
 
+  // 🔴 A SEPARATE at-most-once latch for the MID-SESSION credential-loss beacon,
+  // and it MUST NOT be `blockRenderEmittedRef`.
+  //
+  // `blockRenderEmittedRef` encodes an ANALYTICS invariant — exactly ONE
+  // impression per host mount — that the `blockRenders` denominator and the
+  // BlockRenderFailureRate alert both depend on. Reusing it here would be wrong
+  // in both directions: a `ready` host has already consumed it (so the beacon
+  // would never fire — the precise reason a real prod revocation recorded zero
+  // error beacons on 2026-07-31), and clearing/relaxing it to make room would
+  // retroactively change what the already-sent `ok` impression means.
+  //
+  // The teardown is a genuinely DIFFERENT event from the page load, so it gets a
+  // different latch. Net effect on the wire for a revoked session: `ok` (the load
+  // really did succeed) followed by ONE
+  // `error{error_class="token_lost_midsession"}` (it was later revoked). Bounded
+  // per mount by this ref; the impression accounting above is untouched.
+  const midSessionLossEmittedRef = useRef<boolean>(false);
+  // Latches on the first committed `ready`. This is what tells a `ready → error`
+  // teardown apart from a `loading → error` launch failure — `status === 'error'`
+  // alone cannot (both transitions land on it). A ref, not state: it must not
+  // cause a render, and `handleRetry` deliberately does not clear it (a mount
+  // that ever launched has launched).
+  const reachedReadyRef = useRef<boolean>(false);
+
   // Keep statusRef tracking the live status so handleRetry can branch on the
   // prior terminal state without reading it inside the setStatus updater.
   useEffect(() => {
     statusRef.current = status;
+    // Latch "this mount reached ready" off the COMMITTED status, for the same
+    // reason the impression beacon does (see its comment): keying off a
+    // setStatus updater's side effect silently drops the observation whenever
+    // another state update is already queued on this component.
+    if (status === 'ready') reachedReadyRef.current = true;
   }, [status]);
 
   // BOUNDED AUTO-RETRY — the single decision both consumers read (the scheduling
@@ -546,14 +577,57 @@ export function PageBlockHost({
   // (an `error` status is an AUTH terminal, so its one automatic attempt spends a
   // re-mint) and surfaces the prominent manual Retry once that settles too.
   //
-  // 🔴 NO SECOND BEACON. A host that reached `ready` already fired its ONE `ok`
-  // impression, and `blockRenderEmittedRef` is per-mount — so the failure beacon
-  // below is inert here by construction. The episode stays one beacon, reporting
-  // that the page load itself succeeded (which it did).
+  // 🔴 THE IMPRESSION BEACON IS STILL EXACTLY ONE. A host that reached `ready`
+  // already fired its ONE `ok` impression, and `blockRenderEmittedRef` is
+  // per-mount — so the launch-failure beacon below remains inert here by
+  // construction, and the `ok` already sent still means what it always meant
+  // (the page load succeeded — which it did). The teardown is reported by the
+  // SEPARATE mid-session beacon effect immediately after this one, on its own
+  // latch, so observability is gained without touching impression accounting.
   useEffect(() => {
     if (!tokenTerminal || token) return;
     setStatus((current) => (current === 'ready' ? 'error' : current));
   }, [tokenTerminal, token]);
+
+  // MID-SESSION credential-loss render beacon — the observability half of the
+  // teardown above.
+  //
+  // 🔴 WHY THIS EXISTS AT ALL (measured on production 2026-07-31): a real
+  // revocation teardown was driven end-to-end against a live app and the
+  // platform recorded ZERO error beacons for it. The only trace of the incident
+  // was the earlier successful `ok` impression, so every render metric said the
+  // app was healthy while it was dead in the viewer's tab. A mid-session
+  // teardown is exactly the failure mode a third-party app platform must be able
+  // to see — it is what a delist/suspend/revoke looks like from the runtime.
+  //
+  // Keys off the COMMITTED `status` (not a setStatus updater's side effect) for
+  // the same batching reason documented on the impression beacon below. The full
+  // decision — including WHY it is gated on `reachedReady` and on the settled
+  // `tokenTerminal` rather than a bare `tokenError` — lives in the pure,
+  // unit-tested `shouldEmitMidSessionLossBeacon`.
+  useEffect(() => {
+    if (
+      !shouldEmitMidSessionLossBeacon({
+        status,
+        reachedReady: reachedReadyRef.current,
+        tokenTerminal,
+        hasToken: !!token,
+        alreadyEmitted: midSessionLossEmittedRef.current,
+      })
+    )
+      return;
+    midSessionLossEmittedRef.current = true;
+    // Fire-and-forget beacon — failures are a no-op. `errorClass` is a member of
+    // the server-side KNOWN_ERROR_CLASSES allowlist, so it survives as a real
+    // `error_class` prom label instead of collapsing into 'other'.
+    sendBlockRender({
+      appBlockId,
+      blockInstanceId,
+      slotId: 'app.page',
+      status: 'error',
+      errorClass: MID_SESSION_LOSS_ERROR_CLASS,
+    });
+  }, [status, tokenTerminal, token, appBlockId, blockInstanceId]);
 
   // Token never resolves → surface a no_token state instead of an endless
   // skeleton.

--- a/src/components/AppBlocks/PageBlockHost.tsx
+++ b/src/components/AppBlocks/PageBlockHost.tsx
@@ -383,11 +383,13 @@ export function PageBlockHost({
   // from `status`, because under host reuse `status` is itself STALE (it is still
   // app A's 'ready'). Re-deriving would re-create the misattribution this fixes.
   //
-  // Be precise about the cost, because it is NOT an edge case: under host reuse
-  // `status` is structurally frozen at app A's 'ready' — every `setStatus` here is
-  // gated on the current value, and the only unconditional reset to 'loading' is
-  // `performRetry`. So after a soft nav the latch re-arms only via a manual or
-  // automatic Retry, and until then app B can emit no mid-session beacon at all.
+  // Be precise about the cost, because it is NOT an edge case. `status` inherited
+  // from app A can still move FORWARD out of 'ready' (→ 'error' on a terminal
+  // token, → 'fatal' on BLOCK_ERROR) — it is not frozen. What it cannot do is go
+  // BACK: every `setStatus` here is gated on the current value, and the only
+  // unconditional reset to 'loading' is `performRetry`. Since re-reaching 'ready'
+  // requires passing through 'loading', app B can never earn a genuine `ready`
+  // after a soft nav, so the latch re-arms only via a manual or automatic Retry.
   //
   // That costs nothing real TODAY, because on the same path app B never gets a
   // working session to lose: `shouldStartInit` returns false for any non-'loading'

--- a/src/components/AppBlocks/PageBlockHost.tsx
+++ b/src/components/AppBlocks/PageBlockHost.tsx
@@ -364,6 +364,38 @@ export function PageBlockHost({
   // that ever launched has launched).
   const reachedReadyRef = useRef<boolean>(false);
 
+  // 🔴 BOTH REFS ABOVE ARE PER-MOUNT, BUT THIS HOST IS NOT ALWAYS REMOUNTED.
+  //
+  // `/apps/run/[slug]/[[...path]]` renders <PageBlockHost> with NO `key`, and
+  // `_app.tsx` renders <Component> with no key either — so a SOFT navigation
+  // between two apps (appA → appB, e.g. via the "Recently run" menu) reuses this
+  // component instance: same mount, different `blockInstanceId`.
+  //
+  // Left alone, app A's latches would leak onto app B and produce a WRONG,
+  // MISATTRIBUTED signal: B's launch failure would inherit `reachedReady === true`
+  // and be reported as `token_lost_midsession` for an app that never launched —
+  // exactly the launch-vs-teardown confusion this whole feature exists to avoid.
+  // (Conversely a spent emit-latch would silently swallow B's genuine loss.)
+  //
+  // So the latches are scoped to the block INSTANCE, not the React mount.
+  //
+  // 🔴 Deliberately conservative: this resets to `false` rather than re-deriving
+  // from `status`, because under host reuse `status` is itself STALE (it is still
+  // app A's 'ready'). Re-deriving would re-create the misattribution this fixes.
+  // The cost is that if app B does reach ready and then loses its credential
+  // WITHOUT `status` ever changing value, its beacon is missed — under-reporting,
+  // never mis-reporting. That is the right side to err on for an alerting signal.
+  //
+  // NOTE: the wider host-reuse problem is PRE-EXISTING and NOT fixed here — stale
+  // `status` and the leaked `blockRenderEmittedRef` (so app B loses its `ok`
+  // impression) both predate this change. The real fix is `key={blockInstanceId}`
+  // on the run page, which would also change impression COUNTS, so it belongs in
+  // its own PR rather than riding along on an observability change.
+  useEffect(() => {
+    reachedReadyRef.current = false;
+    midSessionLossEmittedRef.current = false;
+  }, [blockInstanceId]);
+
   // Keep statusRef tracking the live status so handleRetry can branch on the
   // prior terminal state without reading it inside the setStatus updater.
   useEffect(() => {

--- a/src/components/AppBlocks/PageBlockHostTokenTerminal.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostTokenTerminal.browser.test.tsx
@@ -409,6 +409,68 @@ describe('a READY page whose credential is GONE for good', () => {
   }, 25_000);
 });
 
+describe('app → app soft navigation (the host is NOT remounted)', () => {
+  /**
+   * 🔴 `/apps/run/[slug]` renders <PageBlockHost> with NO `key`, and `_app.tsx`
+   * renders <Component> with no key either — so navigating appA → appB (the
+   * "Recently run" menu) REUSES this component instance: same React mount, new
+   * `blockInstanceId`.
+   *
+   * The credential-loss latches are per-MOUNT refs, so without scoping them to
+   * the block instance they leak across that boundary and produce a WRONG,
+   * MISATTRIBUTED signal: app B's LAUNCH failure inherits app A's
+   * `reachedReady === true` and gets reported as `token_lost_midsession` for an
+   * app that never launched — the exact launch-vs-teardown confusion this
+   * feature exists to eliminate, now with the wrong app's id on it.
+   *
+   * (The wider host-reuse breakage — stale `status`, and app B losing its `ok`
+   * impression to the leaked `blockRenderEmittedRef` — is PRE-EXISTING and not
+   * fixed here. This only pins that the new signal cannot be misattributed.)
+   */
+  test('🔴 does NOT report app B’s launch failure as app A’s mid-session loss', async () => {
+    const { rerender } = await renderWithProviders(
+      <PageBlockHost {...baseProps} onConsentGranted={vi.fn()} onRetryToken={vi.fn()} />
+    );
+    await driveToReady();
+    expect(beaconStatuses()).toEqual(['ok']);
+
+    // Soft-navigate to a DIFFERENT app: same mount, new identifiers.
+    const appB = {
+      ...baseProps,
+      appBlockId: 'apb_other',
+      blockInstanceId: 'page_apb_other',
+      blockId: 'other-page-app',
+      slug: 'other-page-app',
+    };
+
+    // App B's mint fails terminally — it NEVER reached ready.
+    await rerender(
+      <PageBlockHost
+        {...appB}
+        token={null}
+        tokenError
+        tokenTerminal
+        onConsentGranted={vi.fn()}
+        onRetryToken={vi.fn()}
+      />
+    );
+    await new Promise((r) => setTimeout(r, 9_000));
+
+    // No `token_lost_midsession` may be attributed to app B.
+    const midSession = beaconBodies().filter((b) => b.errorClass === 'token_lost_midsession');
+    expect(midSession).toEqual([]);
+    // And nothing may be attributed to app B's id at all via this path.
+    const forAppB = beaconCalls().filter((c: unknown[]) => {
+      const init = c[1] as RequestInit | undefined;
+      return String(init?.body ?? '').includes('apb_other');
+    });
+    expect(forAppB.map((c: unknown[]) => {
+      const init = c[1] as RequestInit | undefined;
+      return (JSON.parse(String(init?.body ?? '{}')) as { errorClass?: string }).errorClass;
+    })).not.toContain('token_lost_midsession');
+  }, 20_000);
+});
+
 describe('backward compatibility', () => {
   test('🔴 omitting `tokenTerminal` leaves a ready page byte-identical', async () => {
     // Every pre-existing caller (ReviewBlockPreviewHost, the dev-tunnel page

--- a/src/components/AppBlocks/PageBlockHostTokenTerminal.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostTokenTerminal.browser.test.tsx
@@ -114,10 +114,14 @@ let fetchSpy: ReturnType<typeof vi.spyOn>;
 const isBeacon = (call: unknown[]) =>
   typeof call[0] === 'string' && (call[0] as string).includes('/api/track/block-render');
 const beaconCalls = () => fetchSpy.mock.calls.filter(isBeacon);
-const beaconBodies = (): Array<{ status?: string; errorClass?: string }> =>
+const beaconBodies = (): Array<{ status?: string; errorClass?: string; secondary?: boolean }> =>
   beaconCalls().map((c: unknown[]) => {
     const init = c[1] as RequestInit | undefined;
-    return JSON.parse(String(init?.body ?? '{}')) as { status?: string; errorClass?: string };
+    return JSON.parse(String(init?.body ?? '{}')) as {
+      status?: string;
+      errorClass?: string;
+      secondary?: boolean;
+    };
   });
 const beaconStatuses = (): string[] => beaconBodies().map((b) => b.status ?? 'ok');
 
@@ -279,12 +283,23 @@ describe('a READY page whose credential is GONE for good', () => {
     // Exactly TWO, in order, and the impression is still the untouched `ok`.
     expect(beaconStatuses()).toEqual(['ok', 'error']);
     const bodies = beaconBodies();
-    // The original impression is byte-identical to before: no status, no class.
+    // The original impression is byte-identical to before: no status, no class,
+    // and NOT flagged secondary — it is the mount's first beacon and must still
+    // write its ClickHouse impression row.
     expect(bodies[0].status).toBeUndefined();
     expect(bodies[0].errorClass).toBeUndefined();
+    expect(bodies[0].secondary).toBeUndefined();
     // The teardown carries the class that makes it distinguishable from a launch
     // failure ('error'/'no_token'/'timeout'/'fatal') in `sum by(error_class)`.
-    expect(bodies[1]).toMatchObject({ status: 'error', errorClass: 'token_lost_midsession' });
+    //
+    // 🔴 …and `secondary: true`, WITHOUT which the server would write a second
+    // byte-identical `blockRenders` row for this one mount, inflating every
+    // CH-derived impression figure for revoked sessions.
+    expect(bodies[1]).toMatchObject({
+      status: 'error',
+      errorClass: 'token_lost_midsession',
+      secondary: true,
+    });
   }, 20_000);
 
   test('🔴 emits the teardown beacon AT MOST ONCE despite the host RE-ENTERING `error`', async () => {

--- a/src/components/AppBlocks/PageBlockHostTokenTerminal.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostTokenTerminal.browser.test.tsx
@@ -114,11 +114,12 @@ let fetchSpy: ReturnType<typeof vi.spyOn>;
 const isBeacon = (call: unknown[]) =>
   typeof call[0] === 'string' && (call[0] as string).includes('/api/track/block-render');
 const beaconCalls = () => fetchSpy.mock.calls.filter(isBeacon);
-const beaconStatuses = (): string[] =>
+const beaconBodies = (): Array<{ status?: string; errorClass?: string }> =>
   beaconCalls().map((c: unknown[]) => {
     const init = c[1] as RequestInit | undefined;
-    return (JSON.parse(String(init?.body ?? '{}')) as { status?: string }).status ?? 'ok';
+    return JSON.parse(String(init?.body ?? '{}')) as { status?: string; errorClass?: string };
   });
+const beaconStatuses = (): string[] => beaconBodies().map((b) => b.status ?? 'ok');
 
 beforeEach(() => {
   fetchSpy = vi
@@ -235,7 +236,24 @@ describe('a READY page whose credential is GONE for good', () => {
     expect(document.querySelector('[data-block-fallback-retry="true"]')).not.toBeNull();
   });
 
-  test('🔴 emits NO second beacon — the mount already reported its outcome', async () => {
+  test('🔴 REPORTS the teardown — exactly one extra beacon, tagged as a credential loss', async () => {
+    /**
+     * 🔴 THIS ASSERTION IS INVERTED FROM WHAT IT ORIGINALLY SAID, deliberately.
+     *
+     * It used to assert `['ok']` — no second beacon — on the reasoning that the
+     * page LOAD did succeed and a second beacon would corrupt the impression
+     * denominator. The load-succeeded half is still true (and still asserted:
+     * the first beacon is untouched). The no-second-beacon half was a MEASURED
+     * production defect: on 2026-07-31 a real revocation teardown was driven
+     * against a live app and the platform recorded ZERO error beacons for it.
+     * Its only record of the incident was that `ok` impression, so every render
+     * metric read "healthy" while the app was dead in the viewer's tab.
+     *
+     * The fix does NOT relax the impression latch (that would retroactively
+     * change what the `ok` means). The teardown gets its OWN at-most-once latch
+     * and its OWN error class, so the two events stay separable: one `ok` (the
+     * load) plus one `error{token_lost_midsession}` (the revocation).
+     */
     const { rerender } = await renderWithProviders(
       <PageBlockHost {...baseProps} onConsentGranted={vi.fn()} onRetryToken={vi.fn()} />
     );
@@ -253,13 +271,67 @@ describe('a READY page whose credential is GONE for good', () => {
       />
     );
     await expect.element(page.getByTestId('app-page-fallback')).toBeInTheDocument();
-    // Let #3480's bounded auto-retry run its whole course too.
+    // Let #3480's bounded auto-retry run its whole course too — the re-arm walks
+    // back through 'loading' and lands on 'error' again, which is exactly the
+    // re-entry the at-most-once latch has to absorb.
     await new Promise((r) => setTimeout(r, 9_000));
 
-    // Exactly one, and it still says `ok`: the page LOAD did succeed. Counting an
-    // `error` here would corrupt the denominator the BlockRenderFailureRate alert
-    // is built on ("page loads the platform could not recover on its own").
+    // Exactly TWO, in order, and the impression is still the untouched `ok`.
+    expect(beaconStatuses()).toEqual(['ok', 'error']);
+    const bodies = beaconBodies();
+    // The original impression is byte-identical to before: no status, no class.
+    expect(bodies[0].status).toBeUndefined();
+    expect(bodies[0].errorClass).toBeUndefined();
+    // The teardown carries the class that makes it distinguishable from a launch
+    // failure ('error'/'no_token'/'timeout'/'fatal') in `sum by(error_class)`.
+    expect(bodies[1]).toMatchObject({ status: 'error', errorClass: 'token_lost_midsession' });
+  }, 20_000);
+
+  test('🔴 emits the teardown beacon AT MOST ONCE despite the host RE-ENTERING `error`', async () => {
+    /**
+     * 🔴 THIS IS THE TEST THAT PROVES THE LATCH IS REACHABLE, and it has to drive
+     * a REAL re-entry to do it. Re-rendering with identical props does NOT
+     * exercise the latch — the effect's deps are unchanged, so React never
+     * re-runs it and the assertion passes with the latch deleted (verified: an
+     * earlier version of this test did exactly that and stayed green under a
+     * mutation that defeated the latch entirely).
+     *
+     * The re-entry that actually happens in production is the bounded auto-retry:
+     * a re-mint ATTEMPT briefly clears the failure props (host → 'loading'), the
+     * mint fails again, and the host lands back on 'error'. Without the per-mount
+     * latch that second pass emits a second beacon for ONE incident — which is
+     * how a single revocation would inflate the failure count.
+     */
+    function Harness({ dead }: { dead: boolean }) {
+      const [failing, setFailing] = useState(true);
+      const gone = dead && failing;
+      return (
+        <PageBlockHost
+          {...baseProps}
+          token={dead ? null : baseProps.token}
+          tokenError={gone}
+          tokenTerminal={gone}
+          onConsentGranted={vi.fn()}
+          onRetryToken={() => {
+            // Mirrors useBlockToken.refresh: an attempt clears the terminal, then
+            // it re-fails — walking the host error → loading → error.
+            setFailing(false);
+            setTimeout(() => setFailing(true), 10);
+          }}
+        />
+      );
+    }
+
+    const { rerender } = await renderWithProviders(<Harness dead={false} />);
+    await driveToReady();
     expect(beaconStatuses()).toEqual(['ok']);
+
+    await rerender(<Harness dead />);
+    await expect.element(page.getByTestId('app-page-fallback')).toBeInTheDocument();
+    // Long enough for the whole bounded auto-retry sequence to run and re-enter.
+    await new Promise((r) => setTimeout(r, 9_000));
+
+    expect(beaconStatuses()).toEqual(['ok', 'error']);
   }, 20_000);
 
   test("re-arms #3480's bounded auto-retry, which re-mints ONCE then settles", async () => {
@@ -315,8 +387,10 @@ describe('a READY page whose credential is GONE for good', () => {
     // manual Retry — the path forward, never a dead end.
     expect(document.querySelector('[data-block-fallback="token_error"]')).not.toBeNull();
     expect(document.querySelector('[data-block-fallback-retry-prominent="true"]')).not.toBeNull();
-    // And still exactly one beacon for the whole episode.
-    expect(beaconStatuses()).toEqual(['ok']);
+    // And still exactly TWO beacons for the whole episode — the impression plus
+    // ONE credential-loss report, no matter how many times the re-mint loop
+    // re-enters the terminal.
+    expect(beaconStatuses()).toEqual(['ok', 'error']);
   }, 25_000);
 });
 

--- a/src/components/AppBlocks/PageBlockHostTokenTerminal.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostTokenTerminal.browser.test.tsx
@@ -463,10 +463,17 @@ describe('app → app soft navigation (the host is NOT remounted)', () => {
     // And pin the FULL beacon set, which documents the pre-existing host-reuse
     // state this PR deliberately does NOT fix: app B emits NOTHING AT ALL — not
     // even its own launch-failure `error` — because `blockRenderEmittedRef` is
-    // per-mount and was already spent by app A's impression. So the whole
-    // soft-nav session is under-reported, which is exactly why the real fix is
-    // `key={blockInstanceId}` on the run page (its own PR — it changes
-    // impression COUNTS).
+    // per-mount and was already spent by app A's impression, so the whole
+    // soft-nav session is under-reported.
+    //
+    // Scope of that pin, stated exactly so it isn't misread: this test renders
+    // PageBlockHost DIRECTLY and unkeyed, so it pins the HOST's behaviour under
+    // instance reuse. Landing the real fix (`key={blockInstanceId}` on the run
+    // page) would NOT fail this test — it removes the scenario in production
+    // while this test keeps reproducing it here. The only change that would trip
+    // `['ok']` is scoping `blockRenderEmittedRef` per instance, which this PR
+    // reasons against above (the per-mount impression invariant). So it is
+    // over-specified BY DESIGN and unlikely to obstruct the named follow-up.
     //
     // 🔴 Asserting the whole set matters: an earlier version of this test added a
     // second "nothing attributed to app B's id" filter that looked like an extra

--- a/src/components/AppBlocks/PageBlockHostTokenTerminal.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostTokenTerminal.browser.test.tsx
@@ -456,18 +456,24 @@ describe('app → app soft navigation (the host is NOT remounted)', () => {
     );
     await new Promise((r) => setTimeout(r, 9_000));
 
-    // No `token_lost_midsession` may be attributed to app B.
+    // THE assertion: no `token_lost_midsession` may be attributed to app B.
     const midSession = beaconBodies().filter((b) => b.errorClass === 'token_lost_midsession');
     expect(midSession).toEqual([]);
-    // And nothing may be attributed to app B's id at all via this path.
-    const forAppB = beaconCalls().filter((c: unknown[]) => {
-      const init = c[1] as RequestInit | undefined;
-      return String(init?.body ?? '').includes('apb_other');
-    });
-    expect(forAppB.map((c: unknown[]) => {
-      const init = c[1] as RequestInit | undefined;
-      return (JSON.parse(String(init?.body ?? '{}')) as { errorClass?: string }).errorClass;
-    })).not.toContain('token_lost_midsession');
+
+    // And pin the FULL beacon set, which documents the pre-existing host-reuse
+    // state this PR deliberately does NOT fix: app B emits NOTHING AT ALL — not
+    // even its own launch-failure `error` — because `blockRenderEmittedRef` is
+    // per-mount and was already spent by app A's impression. So the whole
+    // soft-nav session is under-reported, which is exactly why the real fix is
+    // `key={blockInstanceId}` on the run page (its own PR — it changes
+    // impression COUNTS).
+    //
+    // 🔴 Asserting the whole set matters: an earlier version of this test added a
+    // second "nothing attributed to app B's id" filter that looked like an extra
+    // guard but was VACUOUS — the filtered list is empty, so the assertion held
+    // trivially and would have held with the fix deleted. This line pins the real
+    // observable state instead.
+    expect(beaconStatuses()).toEqual(['ok']);
   }, 20_000);
 });
 

--- a/src/components/AppBlocks/__tests__/pageBlockHostLogic.test.ts
+++ b/src/components/AppBlocks/__tests__/pageBlockHostLogic.test.ts
@@ -10,7 +10,10 @@ import {
   isAutoRetryableStatus,
   MAX_AUTO_REMINTS,
   MAX_AUTO_RETRIES,
+  MID_SESSION_LOSS_ERROR_CLASS,
   pageFallbackReason,
+  shouldEmitMidSessionLossBeacon,
+  type MidSessionLossBeaconArgs,
   resolveCheckpointPickerRequest,
   resolveImageUploadRequest,
   resolveResourcePickerRequest,
@@ -761,5 +764,111 @@ describe('decideAutoRetry — the bounded automatic recovery loop', () => {
     // A shorter table would silently reuse the last delay; assert they line up so
     // a future bump of MAX_AUTO_RETRIES has to extend the table deliberately.
     expect(AUTO_RETRY_BACKOFF_MS.length).toBeGreaterThanOrEqual(MAX_AUTO_RETRIES);
+  });
+});
+
+/**
+ * MID-SESSION credential-loss beacon.
+ *
+ * 🔴 THE MEASURED DEFECT (production, 2026-07-31): a real revocation teardown was
+ * driven against a live app and the platform recorded ZERO error beacons. The
+ * host's single emit-once ref had already been spent on the `ok` impression when
+ * it reached `ready`, so the launch-failure beacon was inert by construction and
+ * the incident's only trace was a record saying the app rendered fine.
+ *
+ * These cases pin the four conditions that make the replacement signal both
+ * REACHABLE (a real teardown emits) and HONEST (nothing else does).
+ */
+describe('shouldEmitMidSessionLossBeacon', () => {
+  /** A host that launched, then had its credential settle as permanently gone. */
+  const teardown: MidSessionLossBeaconArgs = {
+    status: 'error',
+    reachedReady: true,
+    tokenTerminal: true,
+    hasToken: false,
+    alreadyEmitted: false,
+  };
+
+  it('🔴 EMITS on the real mid-session teardown (the case that recorded nothing)', () => {
+    expect(shouldEmitMidSessionLossBeacon(teardown)).toBe(true);
+  });
+
+  it('🔴 does NOT emit for a LAUNCH failure — that is the existing beacon’s job', () => {
+    // `loading → error` (mint hard-failed before the block ever rendered). The
+    // launch-failure beacon covers it with errorClass 'error'; emitting here too
+    // would double-count one failed page load as two failures.
+    expect(shouldEmitMidSessionLossBeacon({ ...teardown, reachedReady: false })).toBe(false);
+  });
+
+  it('🔴 does NOT emit while recovery is still pending (transient blip)', () => {
+    // The upstream hook retries a failed refresh on a bounded backoff. Reporting
+    // a teardown that the platform then recovers from would inflate the failure
+    // signal with events no user ever saw.
+    expect(shouldEmitMidSessionLossBeacon({ ...teardown, tokenTerminal: false })).toBe(false);
+  });
+
+  it('🔴 does NOT emit while a usable token remains', () => {
+    // `terminal` with a token still in hand is not a teardown — the host is not
+    // torn down either (the effect gates on `!token` identically).
+    expect(shouldEmitMidSessionLossBeacon({ ...teardown, hasToken: true })).toBe(false);
+  });
+
+  it('🔴 is at-most-once per mount', () => {
+    // The effect re-runs on token/status/prop churn; without this latch each
+    // re-render would fire another beacon for one incident.
+    expect(shouldEmitMidSessionLossBeacon({ ...teardown, alreadyEmitted: true })).toBe(false);
+  });
+
+  it('does NOT re-tag a BLOCK failure as a credential loss', () => {
+    // A block that reached ready and then crashed / stopped acking is a different
+    // failure with its own class. Only the `error` status is a credential loss.
+    for (const status of ['fatal', 'timeout', 'no_token', 'ready', 'loading'] as PageHostStatus[]) {
+      expect(shouldEmitMidSessionLossBeacon({ ...teardown, status })).toBe(false);
+    }
+  });
+
+  it('requires EVERY condition — no single one is sufficient', () => {
+    // Guards against a future simplification that collapses the conjunction.
+    const off: MidSessionLossBeaconArgs = {
+      status: 'loading',
+      reachedReady: false,
+      tokenTerminal: false,
+      hasToken: true,
+      alreadyEmitted: true,
+    };
+    expect(shouldEmitMidSessionLossBeacon(off)).toBe(false);
+    expect(shouldEmitMidSessionLossBeacon({ ...off, status: 'error' })).toBe(false);
+    expect(shouldEmitMidSessionLossBeacon({ ...off, reachedReady: true })).toBe(false);
+    expect(shouldEmitMidSessionLossBeacon({ ...off, tokenTerminal: true })).toBe(false);
+    expect(shouldEmitMidSessionLossBeacon({ ...off, hasToken: false })).toBe(false);
+    expect(shouldEmitMidSessionLossBeacon({ ...off, alreadyEmitted: false })).toBe(false);
+  });
+
+  it('🔴 uses a class that is DISTINCT from every launch-failure class', () => {
+    // If it collided with one of these, the whole point (telling "never launched"
+    // apart from "launched, then revoked") would be lost.
+    expect(['timeout', 'fatal', 'no_token', 'error', 'error_boundary']).not.toContain(
+      MID_SESSION_LOSS_ERROR_CLASS
+    );
+  });
+});
+
+/**
+ * 🔴 CROSS-MODULE CONTRACT. The beacon route clamps `errorClass` to a code-owned
+ * server-side allowlist; anything outside it collapses to 'other'. A client class
+ * that is not on that list is therefore INERT — it reaches the server, is
+ * accepted, and then silently merges into the generic bucket, which is exactly
+ * the "computed, sent, bounded, then dropped" failure this work exists to fix.
+ * This test fails if the two halves ever drift apart.
+ */
+describe('MID_SESSION_LOSS_ERROR_CLASS survives the server-side allowlist', () => {
+  it('is preserved as its own error_class label, not bucketed to "other"', async () => {
+    const { normalizeErrorClass } = await import('~/server/metrics/app-block-runtime.metrics');
+    expect(normalizeErrorClass('error', MID_SESSION_LOSS_ERROR_CLASS)).toBe(
+      MID_SESSION_LOSS_ERROR_CLASS
+    );
+    // Control: an unknown class really does collapse, so the assertion above is
+    // proving membership rather than proving normalizeErrorClass is a no-op.
+    expect(normalizeErrorClass('error', 'not_a_real_class')).toBe('other');
   });
 });

--- a/src/components/AppBlocks/pageBlockHostLogic.ts
+++ b/src/components/AppBlocks/pageBlockHostLogic.ts
@@ -651,3 +651,88 @@ export function decideAutoRetry(args: {
 
   return { kind: 'retry', attempt: attempts + 1, maxAttempts, delayMs, remint };
 }
+
+// ── MID-SESSION CREDENTIAL-LOSS render beacon ────────────────────────────────
+//
+// 🔴 THE GAP THIS CLOSES (measured on production 2026-07-31): a real revocation
+// teardown was driven end-to-end against a live app and the platform recorded
+// ZERO error beacons. Its only record of the incident was the earlier,
+// successful `ok` impression — so from the metric's point of view the app was
+// perfectly healthy while it was, in fact, dead in every viewer's tab.
+//
+// WHY IT WAS ZERO. The host's ONE-beacon-per-mount rule is enforced by a single
+// emit-once ref shared by the `ok` impression and the launch-FAILURE beacon.
+// A host that reached `ready` has already spent that ref on `ok`, so when the
+// `tokenTerminal` effect later tears it down to `error`, the failure beacon is
+// inert BY CONSTRUCTION — not by accident, and not fixable by relaxing the ref
+// (that would retroactively double-count impressions and corrupt the denominator
+// the alert is built on, which is "page loads").
+//
+// THE FIX IS A SECOND, INDEPENDENT AT-MOST-ONCE CHANNEL. The mid-session beacon
+// gets its OWN ref, so:
+//   - the `ok` impression already sent is untouched (analytics unchanged);
+//   - the teardown is reported exactly once per mount;
+//   - it is tagged `token_lost_midsession`, which no launch failure can emit,
+//     so the two are trivially separable in PromQL.
+// A mount that loses its credential mid-session therefore emits TWO beacons —
+// `ok` then `error{error_class="token_lost_midsession"}` — and that is the
+// intended, documented shape: they describe two DIFFERENT events (the load
+// succeeded; the session was later revoked), not one event counted twice.
+
+/** Inputs to the mid-session credential-loss beacon decision. */
+export type MidSessionLossBeaconArgs = {
+  /** The COMMITTED host status (never read inside a setStatus updater). */
+  status: PageHostStatus;
+  /** True once this mount has observed `status === 'ready'` at least once. */
+  reachedReady: boolean;
+  /** `useBlockToken.terminal`: the mint has PERMANENTLY failed. */
+  tokenTerminal: boolean;
+  /** Whether a usable token remains. */
+  hasToken: boolean;
+  /** Whether this mount's mid-session beacon has ALREADY been emitted. */
+  alreadyEmitted: boolean;
+};
+
+/**
+ * Decide whether to emit the mid-session credential-loss render beacon.
+ *
+ * TRUE requires ALL of:
+ *   1. `reachedReady` — the block DID launch. Without this the failure is a
+ *      LAUNCH failure, already covered by the existing failure beacon under its
+ *      own class ('error'/'no_token'/…); emitting here too would double-count.
+ *   2. `status === 'error'` — the host has actually been torn down. `'error'` is
+ *      reachable from exactly two places in PageBlockHost: `loading → error`
+ *      (launch-time mint failure) and `ready → error` (this case). Requiring
+ *      `reachedReady` picks out the second. Deliberately NOT `'fatal'` /
+ *      `'timeout'` / `'no_token'`: those describe the BLOCK failing, not its
+ *      credential being revoked, and mis-tagging them would make the class lie.
+ *   3. `tokenTerminal && !hasToken` — the credential loss is SETTLED. The
+ *      upstream hook retries a failed refresh on a bounded backoff and keeps a
+ *      still-valid token while it does, so a transient blip must never reach
+ *      here. This mirrors the teardown effect's own gate exactly: emitting on a
+ *      weaker condition than the one that tore the host down would report an
+ *      event that never happened to the user.
+ *   4. `!alreadyEmitted` — at most once per mount, independent of the impression
+ *      ref. Re-renders (token prop churn, retry-budget updates) re-run the
+ *      effect; without this every one of them would fire another beacon.
+ */
+export function shouldEmitMidSessionLossBeacon(args: MidSessionLossBeaconArgs): boolean {
+  const { status, reachedReady, tokenTerminal, hasToken, alreadyEmitted } = args;
+  if (alreadyEmitted) return false;
+  if (!reachedReady) return false;
+  if (status !== 'error') return false;
+  if (!tokenTerminal || hasToken) return false;
+  return true;
+}
+
+/**
+ * The `errorClass` the mid-session beacon carries. Distinct from every
+ * launch-failure class so `sum by(error_class)` separates "never launched" from
+ * "launched, then revoked".
+ *
+ * 🔴 MUST be a member of KNOWN_ERROR_CLASSES in
+ * `~/server/metrics/app-block-runtime.metrics` — the beacon route clamps anything
+ * else to 'other', which would silently merge this signal back into the generic
+ * bucket. Pinned by a test in `__tests__/pageBlockHostLogic.test.ts`.
+ */
+export const MID_SESSION_LOSS_ERROR_CLASS = 'token_lost_midsession';

--- a/src/components/AppBlocks/sendBlockRender.ts
+++ b/src/components/AppBlocks/sendBlockRender.ts
@@ -43,6 +43,14 @@ export type BlockRenderBeaconInput = {
   // `Tracker.blockRender`'s parameter type has no field for either. So it drives
   // the prom label only.
   errorClass?: string;
+  // Mark this as a FOLLOW-UP beacon for a mount that has already reported an
+  // outcome (today: the mid-session credential-loss report that follows an `ok`
+  // impression). It still drives the prom counter, but the server SKIPS the
+  // `blockRenders` ClickHouse insert for it — that table counts impressions, and
+  // a second row for one mount would be byte-identical to the first and so
+  // impossible to de-duplicate later. Omit (or false) for a mount's FIRST
+  // beacon, including a launch failure, which must still be recorded.
+  secondary?: boolean;
 };
 
 export function sendBlockRender(input: BlockRenderBeaconInput) {

--- a/src/components/AppBlocks/sendBlockRender.ts
+++ b/src/components/AppBlocks/sendBlockRender.ts
@@ -23,9 +23,25 @@ export type BlockRenderBeaconInput = {
   // iframe never reaching BLOCK_READY within its timeout). Drives the
   // `civitai_app_block_renders_total{result}` prom counter server-side.
   status?: 'ok' | 'error';
-  // Optional low-cardinality failure discriminator (e.g. 'timeout', 'fatal',
-  // 'no_token', 'error_boundary'). Accepted + bounded server-side; reserved for a
-  // future ClickHouse column (NOT a prom label, NOT in the CH insert today).
+  // Optional low-cardinality failure discriminator: 'timeout' | 'fatal' |
+  // 'no_token' | 'error' | 'error_boundary' | 'token_lost_midsession'.
+  //
+  // This DRIVES the `error_class` label on the `civitai_app_block_renders_total`
+  // prom counter — it is the only thing that can say WHY a render failed, so an
+  // alert on that counter can name a cause instead of just "something broke".
+  // (The stale comment this replaces said "NOT a prom label"; the label landed in
+  // #3119 and the doc never caught up.)
+  //
+  // 🔴 It is CLAMPED server-side to a code-owned allowlist (KNOWN_ERROR_CLASSES in
+  // ~/server/metrics/app-block-runtime.metrics — anything else becomes 'other'),
+  // so a value added here is INERT for observability until it is added there too.
+  //
+  // It is STILL not a ClickHouse column, and that half of the old comment is
+  // verified rather than inherited: both writers (the /api/track/block-render
+  // beacon route and the track.blockRender tRPC procedure) destructure
+  // `status`/`errorClass` OUT before handing the rest to the tracker, and
+  // `Tracker.blockRender`'s parameter type has no field for either. So it drives
+  // the prom label only.
   errorClass?: string;
 };
 

--- a/src/pages/api/track/block-render.ts
+++ b/src/pages/api/track/block-render.ts
@@ -67,12 +67,17 @@ export default PublicEndpoint(
     const result = blockRenderSchema.safeParse(parsed);
     if (!result.success) return res.status(400).send('invalid input');
 
-    // `status`/`errorClass` drive the prom render counter ONLY — they are NOT
-    // forwarded to the ClickHouse insert (the `blockRenders` table is provisioned
-    // out-of-repo by the tracker service; adding columns is out of scope here).
-    // Strip them so the CH payload stays byte-identical to the pre-change insert.
-    // `errorClass` still drives the prom label below (normalized), never the CH insert.
-    const { status, errorClass, ...renderData } = result.data;
+    // `status`/`errorClass`/`secondary` drive the prom render counter ONLY — they
+    // are NOT forwarded to the ClickHouse insert (the `blockRenders` table is
+    // provisioned out-of-repo by the tracker service; adding columns is out of
+    // scope here). Strip them so the CH payload stays byte-identical to the
+    // pre-change insert. `errorClass` still drives the prom label below
+    // (normalized), never the CH insert.
+    //
+    // 🔴 `secondary` ALSO GATES THE CH INSERT ENTIRELY (see below). Every beacon
+    // increments the prom counter, but only a mount's FIRST beacon writes a
+    // `blockRenders` row — that table counts IMPRESSIONS, one per host mount.
+    const { status, errorClass, secondary, ...renderData } = result.data;
 
     // Per-app render/impression outcome (additive + dark). `result` ∈ ok|error.
     // ALL labels are BOUNDED even though the beacon body is client-supplied and
@@ -96,6 +101,27 @@ export default PublicEndpoint(
     } catch {
       // swallow — observability must not affect the response
     }
+
+    // 🔴 SECONDARY (follow-up) BEACON → prom only, NO ClickHouse row. Return here,
+    // AFTER the counter above and BEFORE the insert below.
+    //
+    // `blockRenders` is an IMPRESSION table and its rows carry no status, so one
+    // mount must produce at most one row. A host now emits a SECOND beacon when an
+    // outcome it already reported later changes (a page that rendered fine and
+    // then lost its credential mid-session). Inserting for that would write a row
+    // BYTE-IDENTICAL to the first — undedupable after the fact — silently
+    // inflating `civitai_app_blocks_impressions_24h`, `renders_by_app_24h`, the
+    // digest CronJob and the author-analytics tab for precisely the sessions that
+    // suffered a revocation. An observability fix must not corrupt an analytics
+    // series.
+    //
+    // 🔴 The gate is the FLAG, not `status === 'error'`. A LAUNCH failure is a
+    // mount's only beacon and MUST still write its row — it is a real attempted
+    // render. Only a follow-up to an already-reported mount is suppressed.
+    //
+    // Returning early also skips the session resolve, which the insert was the
+    // only reason to pay for.
+    if (secondary) return res.status(200).end();
 
     // Resolve the session ONCE here so we can derive isAnon, then hand it to the
     // Tracker (3rd ctor arg) so it isn't re-resolved. `isAnon` is SERVER-derived

--- a/src/server/metrics/app-block-runtime.metrics.ts
+++ b/src/server/metrics/app-block-runtime.metrics.ts
@@ -73,9 +73,30 @@ const KNOWN_SLOT_IDS = new Set([
  *   - no_token       — the block token never resolved
  *   - error          — a hard token-mint failure (PageBlockHost only)
  *   - error_boundary — the host React tree threw (BlockErrorBoundary caught it)
+ *   - token_lost_midsession — the host had ALREADY reached `ready` and then lost its
+ *                      credential terminally (delist/suspend/revoke → the mint
+ *                      settled on a terminal 4xx with nothing usable left). This is
+ *                      the ONLY class that describes a teardown of a page load that
+ *                      had already SUCCEEDED, which is exactly why it must be
+ *                      distinguishable from the launch-failure classes above: on the
+ *                      wire it arrives as a SECOND beacon for a mount whose first
+ *                      beacon said `ok`. See the mid-session effect in PageBlockHost.
  * Anything else is bucketed to 'other'. A successful render uses 'none'.
+ *
+ * 🔴 THE ALLOWLIST IS THE CARDINALITY BOUND. `errorClass` arrives in a public,
+ * client-supplied beacon body (schema-capped at 64 chars but otherwise free-form).
+ * Adding a member here is the ONLY way a new value can become a prom label — every
+ * other string collapses to the single 'other' bucket in `normalizeErrorClass`
+ * below. Keep this set small and code-owned; never derive it from input.
  */
-const KNOWN_ERROR_CLASSES = new Set(['timeout', 'fatal', 'no_token', 'error', 'error_boundary']);
+const KNOWN_ERROR_CLASSES = new Set([
+  'timeout',
+  'fatal',
+  'no_token',
+  'error',
+  'error_boundary',
+  'token_lost_midsession',
+]);
 
 /**
  * Clamp a client-supplied slotId to the enumerated slot set (unknown → 'other')
@@ -195,17 +216,18 @@ export function ensureRegisterAppBlockRuntimeMetrics(reg: Registry = client.regi
     // default buckets are fine for this REST surface
   );
 
-  // Cardinality: renders_total ≈ (A+1) × 5 slot_id × 7 error_class ≈ 1785 at
+  // Cardinality: renders_total ≈ (A+1) × 5 slot_id × 8 error_class ≈ 2040 at
   // A=50, where A = approved apps (+1 for the 'other' bucket), slot_id = 4 known
-  // + 'other', and error_class = 'none' + 5 known + 'other' (7). `result` is NOT
+  // + 'other', and error_class = 'none' + 6 known + 'other' (8). `result` is NOT
   // an independent multiplier — it's coupled to error_class ('none' pairs only
-  // with result=ok; the 5-known+'other' pair only with result=error), so the 7
+  // with result=ok; the 6-known+'other' pair only with result=error), so the 8
   // error_class values already encode the result split. Every factor is strictly
-  // bounded, so the series count stays small.
+  // bounded (see the KNOWN_* sets + boundAppBlockIdLabel), so the series count
+  // stays small and CANNOT be grown by client input — only by a code change here.
   const rendersTotal = getOrCreateCounter(
     reg,
     'civitai_app_block_renders_total',
-    'App Block host render/impression outcomes by app, slot, result (ok|error), and error_class (none when ok; timeout|fatal|no_token|error|error_boundary|other on error)',
+    'App Block host render/impression outcomes by app, slot, result (ok|error), and error_class (none when ok; timeout|fatal|no_token|error|error_boundary|token_lost_midsession|other on error)',
     ['app_block_id', 'slot_id', 'result', 'error_class']
   );
 

--- a/src/server/routers/__tests__/track.router.blockRender.test.ts
+++ b/src/server/routers/__tests__/track.router.blockRender.test.ts
@@ -122,6 +122,45 @@ describe('track.blockRender', () => {
     expect(mockBlockRender.mock.calls[0][0].isAnon).toBe(true);
   });
 
+  /**
+   * 🔴 The `secondary` (follow-up) beacon must NOT write a `blockRenders` row on
+   * THIS path either. `blockRenders` counts IMPRESSIONS — one row per host mount
+   * — and its rows carry no status, so a duplicate would be byte-identical and
+   * undedupable. The REST beacon route gates this; if the tRPC procedure did not,
+   * a bearer/API-key caller could reintroduce exactly the double-count the beacon
+   * route prevents. That makes this the security-relevant branch, so it is pinned
+   * here rather than left to the REST tests.
+   */
+  it('🔴 suppresses the Tracker insert for a `secondary` follow-up beacon', async () => {
+    const caller = trackRouter.createCaller(fakeCtx({ id: 1 }) as never);
+    await caller.blockRender({
+      ...validInput(),
+      status: 'error',
+      errorClass: 'token_lost_midsession',
+      secondary: true,
+    } as never);
+
+    expect(mockBlockRender).not.toHaveBeenCalled();
+  });
+
+  it('🔴 still writes the row for a LAUNCH failure (secondary defaults to false)', async () => {
+    // The discriminator is the FLAG, not `status === 'error'`. A mount's only
+    // beacon represents a real attempted render and must keep being recorded.
+    const caller = trackRouter.createCaller(fakeCtx({ id: 1 }) as never);
+    await caller.blockRender({
+      ...validInput(),
+      status: 'error',
+      errorClass: 'no_token',
+    } as never);
+
+    expect(mockBlockRender).toHaveBeenCalledTimes(1);
+    const arg = mockBlockRender.mock.calls[0][0];
+    // status/errorClass/secondary are all stripped — none is a ClickHouse column.
+    expect(arg).not.toHaveProperty('status');
+    expect(arg).not.toHaveProperty('errorClass');
+    expect(arg).not.toHaveProperty('secondary');
+  });
+
   it('rejects a missing identifier with a BAD_REQUEST and no Tracker call', async () => {
     const caller = trackRouter.createCaller(fakeCtx({ id: 1 }) as never);
     await expect(

--- a/src/server/routers/track.router.ts
+++ b/src/server/routers/track.router.ts
@@ -26,11 +26,19 @@ export const trackRouter = router({
   // for any bearer/API-key (non-cookie) caller, consistent with `addView`.
   blockRender: publicProcedure
     .input(blockRenderSchema)
-    // `status`/`errorClass` are consumed only by the /api/track/block-render
-    // beacon (prom render counter); this legacy tRPC path keeps the CH insert
-    // byte-identical by stripping them before dispatch.
+    // `status`/`errorClass`/`secondary` are consumed only by the
+    // /api/track/block-render beacon (prom render counter); this legacy tRPC path
+    // keeps the CH insert byte-identical by stripping them before dispatch.
+    //
+    // 🔴 `secondary` additionally SUPPRESSES the insert, matching the beacon route
+    // exactly. `blockRenders` counts IMPRESSIONS (one row per host mount) and its
+    // rows carry no status, so a follow-up beacon for an already-reported mount
+    // would write an undedupable duplicate. Both writers must agree on this or a
+    // bearer/API-key caller could reintroduce the double-count the beacon route
+    // prevents.
     .mutation(({ input, ctx }) => {
-      const { status: _status, errorClass: _errorClass, ...renderData } = input;
+      const { status: _status, errorClass: _errorClass, secondary, ...renderData } = input;
+      if (secondary) return;
       return ctx.track.blockRender({ ...renderData, isAnon: !ctx.user });
     }),
   trackShare: publicProcedure

--- a/src/server/schema/__tests__/track.blockRender.schema.test.ts
+++ b/src/server/schema/__tests__/track.blockRender.schema.test.ts
@@ -25,6 +25,21 @@ describe('blockRenderSchema — status/errorClass', () => {
     expect(blockRenderSchema.safeParse({ ...base, status: 'weird' }).success).toBe(false);
   });
 
+  it('defaults `secondary` to false so an ordinary beacon still writes its CH row', () => {
+    // The CH insert is suppressed only for an explicit follow-up. A legacy or
+    // launch-failure beacon that sends no flag must keep being recorded.
+    expect(blockRenderSchema.parse(base).secondary).toBe(false);
+    expect(blockRenderSchema.parse({ ...base, status: 'error', errorClass: 'no_token' }).secondary).toBe(
+      false
+    );
+  });
+
+  it('accepts an explicit `secondary: true` follow-up beacon', () => {
+    expect(blockRenderSchema.parse({ ...base, status: 'error', secondary: true }).secondary).toBe(
+      true
+    );
+  });
+
   it('rejects an over-long errorClass (bounded to 64 chars)', () => {
     expect(
       blockRenderSchema.safeParse({ ...base, errorClass: 'x'.repeat(65) }).success

--- a/src/server/schema/track.schema.ts
+++ b/src/server/schema/track.schema.ts
@@ -68,7 +68,7 @@ export const blockRenderSchema = z.object({
   // timeout). Drives the `civitai_app_block_renders_total{result}` prom counter.
   status: z.enum(['ok', 'error']).default('ok'),
   // Optional low-cardinality failure discriminator (e.g. 'timeout', 'fatal',
-  // 'no_token', 'error', 'error_boundary'). Drives the bounded `error_class`
+  // 'no_token', 'error', 'error_boundary', 'token_lost_midsession'). Drives the bounded `error_class`
   // label on `civitai_app_block_renders_total` (via `normalizeErrorClass`, which
   // clamps any value outside the known set to 'other'). It is STILL stripped from
   // the ClickHouse insert — it never reaches the tracker payload, only the prom

--- a/src/server/schema/track.schema.ts
+++ b/src/server/schema/track.schema.ts
@@ -74,6 +74,27 @@ export const blockRenderSchema = z.object({
   // the ClickHouse insert — it never reaches the tracker payload, only the prom
   // label.
   errorClass: z.string().trim().min(1).max(64).optional(),
+  // 🔴 SECONDARY (follow-up) BEACON — drives the prom counter ONLY, never a
+  // `blockRenders` ClickHouse row.
+  //
+  // `blockRenders` is an IMPRESSION table: historically one host mount emitted
+  // exactly ONE beacon (`ok` XOR `error`), so one mount == one row, and every
+  // CH-derived figure counts rows as impressions.
+  //
+  // A host may now emit a SECOND beacon for the same mount when an outcome it
+  // already reported later changes — today: a page that rendered fine and then
+  // lost its credential mid-session (`token_lost_midsession`). That is a status
+  // UPDATE about an impression already counted, NOT a new impression. Since the
+  // CH row carries no status, a second row would be byte-identical to the first
+  // and therefore impossible to de-duplicate after the fact — silently inflating
+  // impressions/renders for exactly the sessions that suffered a revocation.
+  //
+  // So the emitter marks the follow-up and the server skips the insert for it.
+  // 🔴 The discriminator is deliberately THIS FLAG and not `status === 'error'`:
+  // a LAUNCH failure is a mount's ONLY beacon and MUST still write its row (it
+  // is a real attempted render). What is suppressed is specifically a second
+  // beacon for a mount that already reported.
+  secondary: z.boolean().optional().default(false),
 });
 
 export type TrackShareInput = z.infer<typeof trackShareSchema>;

--- a/src/tests/api/track/block-render.test.ts
+++ b/src/tests/api/track/block-render.test.ts
@@ -339,6 +339,73 @@ describe('POST /api/track/block-render — civitai_app_block_renders_total count
     }
   });
 
+  /**
+   * 🔴 THE IMPRESSION TABLE MUST STAY 1 ROW PER MOUNT.
+   *
+   * `blockRenders` counts IMPRESSIONS and its rows carry NO status, so two rows
+   * for one mount are byte-identical and cannot be de-duplicated afterwards.
+   * Since a host can now emit a SECOND beacon for a mount whose outcome changed
+   * (rendered fine, then lost its credential), an unguarded insert would inflate
+   * every CH-derived impression figure for exactly the revoked sessions.
+   *
+   * The gate is the `secondary` FLAG, not `status === 'error'` — a LAUNCH failure
+   * is a mount's only beacon and must still be recorded. These two cases pin both
+   * halves of that rule.
+   */
+  it('🔴 a SECONDARY beacon counts in prom but writes NO ClickHouse row', async () => {
+    const before = await renderCounterValue(
+      'apb_test',
+      'app.page',
+      'error',
+      'token_lost_midsession'
+    );
+    const handler = (await import('~/pages/api/track/block-render')).default;
+    const res = makeRes();
+
+    await handler(
+      makeReq({
+        origin: 'https://civitai.com',
+        body: {
+          ...validInput,
+          status: 'error',
+          errorClass: 'token_lost_midsession',
+          secondary: true,
+        },
+      }) as any,
+      res
+    );
+
+    // The observability signal still fires — this is what the alert reads.
+    expect(
+      await renderCounterValue('apb_test', 'app.page', 'error', 'token_lost_midsession')
+    ).toBe(before + 1);
+    // …but the impression table is untouched.
+    expect(mockBlockRender).not.toHaveBeenCalled();
+    // And the request still succeeds (fire-and-forget beacon).
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+
+  it('🔴 a LAUNCH failure is NOT secondary — it still writes its ClickHouse row', async () => {
+    // The discriminator must not be `status === 'error'`. A mount that never
+    // rendered emits exactly one beacon, and that beacon represents a real
+    // attempted render that analytics must keep counting.
+    const handler = (await import('~/pages/api/track/block-render')).default;
+
+    await handler(
+      makeReq({
+        origin: 'https://civitai.com',
+        body: { ...validInput, status: 'error', errorClass: 'no_token' },
+      }) as any,
+      makeRes()
+    );
+
+    expect(mockBlockRender).toHaveBeenCalledTimes(1);
+    const arg = mockBlockRender.mock.calls[0][0];
+    expect(arg).toEqual({ ...validInput, isAnon: true });
+    // `secondary` is stripped like status/errorClass — never a CH column.
+    expect(arg).not.toHaveProperty('secondary');
+  });
+
   it('clamps an UNKNOWN error_class to "other" (bounds the label) and still strips it from the CH insert', async () => {
     const before = await renderCounterValue('apb_test', 'app.page', 'error', 'other');
     const handler = (await import('~/pages/api/track/block-render')).default;

--- a/src/tests/api/track/block-render.test.ts
+++ b/src/tests/api/track/block-render.test.ts
@@ -314,7 +314,19 @@ describe('POST /api/track/block-render — civitai_app_block_renders_total count
 
   it('preserves each KNOWN error_class on the label', async () => {
     const handler = (await import('~/pages/api/track/block-render')).default;
-    for (const ec of ['fatal', 'no_token', 'error', 'error_boundary'] as const) {
+    for (const ec of [
+      'fatal',
+      'no_token',
+      'error',
+      'error_boundary',
+      // MID-SESSION credential loss (PageBlockHost). Distinct from every launch
+      // failure above because it describes a page load that ALREADY SUCCEEDED and
+      // was later torn down (delist/suspend/revoke). It has to survive the
+      // allowlist as itself: bucketed to 'other' it would be indistinguishable
+      // from client garbage, which is what made the 2026-07-31 production
+      // revocation unattributable.
+      'token_lost_midsession',
+    ] as const) {
       const before = await renderCounterValue('apb_test', 'app.page', 'error', ec);
       await handler(
         makeReq({


### PR DESCRIPTION
## Summary

App Blocks render failures had a blind spot: a page host that **already reached `ready`** and then lost its credential produced **no telemetry at all**. This PR closes it.

It is deliberately small. The work started as two changes; the second turned out to be **already shipped**, so this is **one real fix plus a stale-comment correction** — see "Change B" below rather than padding.

## Measured evidence

- A real revocation teardown was driven end-to-end against a live app on production on **2026-07-31**. The platform recorded **zero** error beacons for it. Its only record of the incident was the earlier successful `ok` impression — so every render metric read "healthy" while the app was dead in the viewer's tab.
- The render alert fires correctly on real data today: a genuine render failure earlier the same day produced `{result="error", error_class="timeout"}`, and `sum by(app_block_id)(max_over_time(civitai_app_block_renders_total{...,result="error",...}[24h])) > 0.5` fired on it.

## Change A — emit a beacon on mid-session credential loss (the real work)

`PageBlockHost` has an effect gated on `tokenTerminal && !token` that transitions a host which already reached `ready` into `error` (delist / suspend / revoke → the mint settled on a terminal 4xx with nothing usable left). Its own comment said the failure beacon was *"inert here by construction"* — and that was accurate:

> one-beacon-per-mount is enforced by a **single** emit-once ref (`blockRenderEmittedRef`) shared by the `ok` impression and the launch-failure beacon. A host that reached `ready` has already spent that ref on `ok`, so the failure beacon can never fire.

**Relaxing that ref would be the wrong fix.** It encodes an analytics invariant — exactly one impression per host mount — that the `blockRenders` denominator and the `BlockRenderFailureRate` alert both depend on. Clearing it would retroactively change what the already-sent `ok` means.

So the teardown gets its **own** at-most-once latch (`midSessionLossEmittedRef`) and its **own** error class. A revoked session now emits:

| beacon | meaning |
|---|---|
| `ok` | the page load succeeded — which it did |
| `error{error_class="token_lost_midsession"}` | that session was later revoked |

Two different events, not one counted twice. **Impression accounting is byte-identical.**

A second ref, `reachedReadyRef`, latches on the first committed `ready`. It is what tells a `ready → error` teardown apart from a `loading → error` launch failure — `status === 'error'` alone cannot, since both transitions land on it.

🔴 **Scope note — this closes the credential-loss blind spot, not every mid-session blind spot.** The gate is `status === 'error'`, so a host that reached `ready` and then *crashed* (`BLOCK_ERROR{fatal:true}` → `fatal`) still emits nothing beyond its `ok`. That is deliberate — a crash is a different failure with its own class, and mis-tagging it would make `token_lost_midsession` lie — but it means "a mid-session teardown is now observable" is true specifically for **credential loss**. The existing test *"a mount that already reported `ok` never additionally reports `error` after a crash + failed recovery"* still passes, confirming the boundary. Mid-session crash reporting is a reasonable follow-up.

🔴 **The latches are scoped to the block INSTANCE, not the React mount** (third commit, from audit). `/apps/run/[slug]` renders this host with no `key`, so an appA → appB soft navigation reuses the instance. Left unscoped, app B's *launch* failure inherited app A's `reachedReady` and was emitted as `token_lost_midsession` **for an app that never launched**. Mutation-verified as a real, reachable defect: removing the reset makes the new test fail with `expected [ { appBlockId: 'apb_other', … } ] to deeply equal []`. The wider host-reuse breakage (stale `status`; app B losing its `ok` impression to the leaked `blockRenderEmittedRef`) is **pre-existing and deliberately not fixed here** — the real fix is `key={blockInstanceId}` on the run page, which would also change impression *counts*, so it belongs in its own PR.

Decision logic is extracted into the pure, node-unit-testable `shouldEmitMidSessionLossBeacon` (following the established `blockTokenRetry.ts` / `pageBlockHostLogic.ts` / `hostRenderDecision.ts` pattern), because the `unit` vitest project runs `environment: 'node'` and only collects `*.test.ts`.

`token_lost_midsession` is added to the server-side `KNOWN_ERROR_CLASSES` allowlist. Without that the beacon route would clamp it to `other` and the signal would merge straight back into the generic bucket — the value would be computed, sent, accepted, and silently dropped.

### 🔴 Second commit: keeping the ClickHouse impression table at one row per mount

**Found in review of this PR's own second-order effects — a defect this PR introduced, caught before merge.**

`/api/track/block-render` strips `status`/`errorClass` and then calls `tracker.blockRender(...)` **unconditionally**, so every beacon writes one `blockRenders` ClickHouse row *that carries no status*.

- **Before:** one beacon per mount ⇒ one row. Clean 1:1.
- **After Change A:** a revoked session emits `ok` **and** `error` ⇒ **two byte-identical rows for one mount.**

Being identical, they cannot be de-duplicated afterwards — this would have silently inflated `civitai_app_blocks_impressions_24h`, `renders_by_app_24h`, the digest CronJob and the author-analytics tab, for *exactly* the sessions that suffered a revocation. An observability fix quietly corrupting an analytics series.

The prom side was already correct (`blockRenderEmittedRef` untouched); only the CH insert regressed.

**Fix:** `blockRenders` is an **impression** table, and a mid-session credential loss is a status *update* about an impression already counted — not a new impression. So the emitter marks the follow-up (`secondary: true` in `blockRenderSchema`) and the route skips the insert, returning before the session resolve that the insert was the only reason to pay for. **The prom counter still fires for both beacons** — that is what the alert reads.

🔴 **The discriminator is the flag, not `status === 'error'`.** A **launch failure is a mount's only beacon and must still write its row** — it represents a real attempted render. Only a follow-up to an already-reported mount is suppressed. Chosen over hard-coding the `token_lost_midsession` value so it generalizes to any future second beacon.

The legacy `track.blockRender` tRPC procedure gets the same suppression, so a bearer/API-key caller cannot reintroduce the double-count.

*(Precision, since an earlier draft overstated it: the tRPC procedure **never** touched the prom counter, before or after — it only ever wrote the CH row. So for a `secondary` beacon that path is a total no-op, not "prom-only". No impact today: every host uses `sendBlockRender` → the REST beacon. Both `secondary` branches are now pinned by tests.)*

### `IframeHost` (model-slot host) — intentionally unchanged

The equivalent is **moot there, structurally** — not skipped:

- `IframeHost` takes `token: string` (non-nullable) and has **no `tokenTerminal` / `tokenError` prop**; its `Status` union is `'loading' | 'ready' | 'timeout' | 'fatal' | 'no_token'` — there is **no `error` state and no ready→error transition to observe**.
- Mid-session terminal loss is handled one level up: `BlockHost` does `if (terminal) return null`, which **unmounts `IframeHost` entirely** (the deliberate collapse-on-terminal behaviour — an error card for a block the viewer never asked for, on someone else's model page, is worse than silence).

So there is no host state change to hang an effect on. The only way to report it would be an **unmount flush**, which is a different change with a real design question attached: an unmount cleanup cannot, by itself, tell a terminal teardown from an ordinary navigation away from the model page, so a naive version would emit an error beacon on every page navigation. `sendBlockRender` already sets `keepalive: true` precisely so such a flush is possible later; the existing code comments already flag "unmount during the sequence emits nothing" as a known, accepted cost. Out of scope here.

## Change B — `errorClass` as a Prometheus label: **already shipped, no code change**

The brief for this PR was based on the comment at `sendBlockRender.ts` which read *"reserved for a future ClickHouse column (NOT a prom label, NOT in the CH insert today)"*. **That comment is stale.** `error_class` has been a live label on `civitai_app_block_renders_total` since #3119.

Confirmed against production dp-1 (`/api/v1/series`, last 24h) — the live label set is:

```
__name__, app_block_id, cluster, container, error_class, instance, job,
namespace, node, pod, result, service, slot_id
```

with real series `{result="ok", error_class="none"}` and `{result="error", error_class="timeout"}`.

**So no label was added, and nothing was reverted — there is no duplicate/conflicting label definition in this PR.** What this PR does instead:

1. **Corrects the stale comment.** It now states what is true: `errorClass` drives the `error_class` prom label, and it is clamped server-side.
2. **The ClickHouse half is now stated as *verified*, not inherited.** Both writers (`/api/track/block-render` and the `track.blockRender` tRPC procedure) destructure `status`/`errorClass` **out** before handing the rest to the tracker, and `Tracker.blockRender`'s parameter type is `{appBlockId, blockInstanceId, slotId, isAnon}` — no field for either. So it drives the prom label only. (I checked the code rather than trusting the adjacent comment — that is exactly the mistake this section exists to undo.)

### Cardinality audit — the existing bound is sound

I audited the bound rather than assuming it. Every label on this counter is clamped server-side, after the same-origin and schema gates, and none can be grown by client input:

| label | bound | unknown → |
|---|---|---|
| `error_class` | `KNOWN_ERROR_CLASSES` code-owned `Set` in `normalizeErrorClass` | `other` |
| `slot_id` | `KNOWN_SLOT_IDS` via `normalizeSlotId` | `other` |
| `app_block_id` | approved-app set via `boundAppBlockIdLabel` (TTL-cached, no per-request DB hit) | `other` |
| `result` | zod `z.enum(['ok','error']).default('ok')` | n/a |

`result="ok"` rows always carry the constant `error_class="none"`, so the label is always present and consistent. A client-supplied string **cannot** reach the label unbounded: `errorClass` is schema-capped at 64 chars and then must be an exact member of the code-owned set. Adding a member to that `Set` is the only way a new value can ever become a label — which is why `token_lost_midsession` had to be added there explicitly, and why the allowlist now carries a 🔴 comment saying so.

Worst case with the new class: `(A+1) × 5 slot_id × 8 error_class ≈ 2040` series at `A=50` approved apps. `result` is not an independent multiplier — it is coupled to `error_class` (`none` pairs only with `ok`; the rest only with `error`), so the 8 values already encode the split. The cardinality comment in the metrics module is updated from 7→8 to match.

## Series-identity note

The new `token_lost_midsession` value is a **new label value, not a new label**, so existing series are unaffected — no supersession, no gap. (Had a label been *added*, series identity would change and existing series would be superseded; that already happened in #3119 and is not repeated here.)

🔴 **CORRECTION — an earlier version of this description claimed "the alert is unaffected". That was wrong.** See the [pinned correction comment](https://github.com/civitai/civitai/pull/3516#issuecomment-5146949634) for the full detail.

- ✅ Series identity is genuinely fine: `error_class` was already a registered label, so a new *value* creates a new series without superseding existing ones.
- ❌ **The alert's firing behaviour changes materially.** The live rule selects on `result="error"` and **not** on `error_class`. A `token_lost_midsession` beacon carries `result="error"`, so it lands in the selector. Pre-PR a revocation emitted **zero** error beacons (the rule's own description says so, "verified live 2026-07-31"); post-PR it emits one, crossing the `> 0.5` threshold and firing for the full 24h window.

🔴 **Decision needed before merge:** `tokenTerminal` means the mint permanently failed — app **delist / suspend / scope-revoke / uninstall**. So every deliberate moderation action will now raise a Warning-Discord alert titled "an SSR render failed" for 24h. That may be correct (the app really did die in the viewer's tab), but it should be chosen, not inherited. Options: accept it · exclude via `error_class!="token_lost_midsession"` · split into its own rule. **No alert rule is touched in this PR.**

🔴 **A lockstep `datapacket-talos` PR is required**: the alert's `description` states that mid-session loss "emits nothing at all" (false after this merges) and that "error_class is NOT a Prometheus label yet" (already false since #3119). Otherwise the alert this PR causes to fire tells the on-call that the discriminator explaining it doesn't exist.

## Not changed, deliberately

- 🔴 **No alert-rule changes.**
- 🔴 **`max_over_time` is retained; nothing switched to `rate()`/`increase()`.** This is a per-pod counter whose series are born at 1 and never increment at current volume, so `rate`/`increase` are structurally **0** on it. This was measured and is precisely why the rule uses `max_over_time`.

## Test coverage

**New, in `src/components/AppBlocks/__tests__/pageBlockHostLogic.test.ts`** (node `unit` project) — 8 cases pinning `shouldEmitMidSessionLossBeacon`: emits on the real teardown; does not emit for a launch failure, during a transient blip, while a token remains, on `fatal`/`timeout`/`no_token`/`ready`/`loading`, or twice. Plus a **cross-module contract test** asserting `normalizeErrorClass('error', MID_SESSION_LOSS_ERROR_CLASS)` returns the class itself and not `other` — with an unknown-class control so it proves membership rather than proving `normalizeErrorClass` is a no-op.

**Updated `PageBlockHostTokenTerminal.browser.test.tsx`** (real Chromium, real hooks, real timers). Two of its assertions are **deliberately inverted** — they previously asserted `['ok']`, i.e. *no second beacon*. The "load succeeded" half of that reasoning is still true and still asserted (the first beacon is checked to be untouched: no `status`, no `errorClass`); the "no second beacon" half was the production defect. Now: `['ok','error']`, with the second body matched on `{status:'error', errorClass:'token_lost_midsession'}`. Plus a new at-most-once case.

**Updated `src/tests/api/track/block-render.test.ts`** — `token_lost_midsession` added to the known-classes loop, asserting it survives the allowlist as its own label.

No new hook or mutation was added to `PageBlockHost` (only `useRef`/`useEffect`), so **no `PageBlockHost*.browser.test.tsx` trpc mock needed re-stubbing.**

### Mutation verification — every guard proven reachable

Each guard was broken, the test run confirmed failing **with that guard's specific assertion**, then reverted:

| mutation | killed by | failure |
|---|---|---|
| drop `alreadyEmitted` guard | `is at-most-once per mount` | `expected true to be false` |
| drop `reachedReady` guard | `does NOT emit for a LAUNCH failure` | `expected true to be false` |
| remove `token_lost_midsession` from allowlist | cross-module contract + API route test | `expected 'other' to be 'token_lost_midsession'`; `expected +0 to be 1` |
| disable the beacon emit in the host | 3 browser tests | `expected [ 'ok' ] to deeply equal [ 'ok', 'error' ]` |
| defeat the at-most-once latch in the host | at-most-once + auto-retry browser tests | `expected [ 'ok', 'error', 'error' ] to deeply equal [ 'ok', 'error' ]` |
| **remove the CH-insert guard** | `a SECONDARY beacon ... writes NO ClickHouse row` | `expected vi.fn() to not be called at all, but actually been called 1 times` |
| **set the guard to the WRONG discriminator (`status === 'error'`)** | `a LAUNCH failure is NOT secondary` | `expected vi.fn() to be called 1 times, but got 0 times` |
| **omit `secondary: true` on the client** | teardown browser test | fails on the missing `"secondary": true` field |
| **leak `reachedReadyRef` across block instances** | `does NOT report app B's launch failure as app A's mid-session loss` | `expected [ { appBlockId: 'apb_other', … } ] to deeply equal []` |
| **disable the tRPC `secondary` guard** | `suppresses the Tracker insert for a secondary follow-up beacon` | `expected vi.fn() to not be called at all, but actually been called 1 times` |

🔴 **One test was green for the wrong reason and was fixed.** The first version of the at-most-once browser test re-rendered with *identical props*, so React never re-ran the effect (deps unchanged) — it passed even with the latch defeated. It now drives the **real** re-entry the bounded auto-retry produces (`error → loading → error` via a re-mint attempt that re-fails), and the table above records it killing the mutation.

## Verified vs. needs the preview

**Verified — run and observed:**
- ✅ **CI Typecheck: pass.** Also ran `tsc --noEmit` locally: **zero errors in any file this PR touches** (the residual local errors are environmental — missing `event-engine-common` sibling checkout, unresolvable `kysely`, stale `@civitai/buzz` build output — and are present on clean `main` too).
- ✅ **CI ESLint + Prettier: pass.**
- ✅ **CI Unit tests: pass** (4m26s).
- ✅ **CI `event-engine-common` pin: pass.** All four GitHub checks green.
- ✅ `pageBlockHostLogic`, `block-render` API route, `app-block-runtime.metrics`, `track.blockRender` schema suites — **105 tests pass** locally, re-run after rebasing onto current `main`.
- ✅ `PageBlockHostTokenTerminal.browser.test.tsx` — **8/8 pass** in real Chromium (Playwright).
- ✅ All five mutations in the table above, each killed with that guard's own assertion.
- ✅ Clean test-merge against current `origin/main` (`git merge-tree` rc=0); `main` has not touched any file in this PR since the branch point.
- ✅ **Formatting:** the 4 touched files that `prettier --list-different` flags are flagged **identically on clean `origin/main`**, and running prettier shows it would only reformat pre-existing regions (`generatorSubmitSchema`, the `renderCounterValue` helper) — **none of my added lines**. That churn was deliberately reverted to keep the diff minimal.
- ✅ **Lint debt is untouched, not introduced:** `eslint` reports 22 errors across the two test files I modified (a wholesale `vi.mock('~/utils/trpc')` and `as any` casts). `git diff -U0` confirms **every one is on a pre-existing line I did not author.** CI treats modified-file lint as report-only (`continue-on-error: true`); only *added* files block, and this PR adds none.

**Not verified — flagged honestly:**
- ⏳ The **Tekton pr-preview** (`next build`) was still running when this was written. No file was added under `src/pages/` — the new pure logic is in `src/components/AppBlocks/pageBlockHostLogic.ts`, its test in `src/components/AppBlocks/__tests__/` — so the `PagesPageConfig`/`ApiRouteConfig` failure class should not apply, but the build is the authority.
- ⏳ **The full component (browser) suite** was still running locally; only the directly-affected file is confirmed green. It is report-only in the preview anyway.
- 🔴 **Nothing here has been observed against production**, and it cannot be until a real mid-session revocation happens after deploy — the change is by definition unexercised until then. Suggested check once live:
  ```promql
  sum by(app_block_id, error_class)(max_over_time(civitai_app_block_renders_total{result="error"}[24h]))
  ```
  A `token_lost_midsession` bucket should start appearing where the incident previously produced nothing at all. Until that is seen, this is **deployed, not verified**.
