### PR TITLE
feat(blocks): sourceImages[] multi-image conditioning with a per-ecosystem cap

### DIFF
--- a/src/server/routers/__tests__/blocks.router.workflow.test.ts
+++ b/src/server/routers/__tests__/blocks.router.workflow.test.ts
@@ -904,6 +904,24 @@ describe('blocks.estimateWorkflow', () => {
       })
     ).rejects.toMatchObject({ code: 'FORBIDDEN' });
   });
+
+  // The ARRAY form must hit the identical page-only gate. Gating only the
+  // deprecated singular field would leave a model-bound token a way in.
+  it('rejects sourceImages[] on a MODEL-bound token (array form, same page-only gate)', async () => {
+    mockVerifyBlockToken.mockResolvedValue(validClaims());
+    const caller = blocksRouter.createCaller(fakeCtx() as never);
+    await expect(
+      caller.estimateWorkflow({
+        blockToken: 'tok',
+        body: validBody({
+          sourceImages: [
+            { url: 'https://image.civitai.com/abc/a.jpeg', width: 768, height: 1024 },
+            { url: 'https://image.civitai.com/abc/b.jpeg', width: 768, height: 1024 },
+          ],
+        }),
+      })
+    ).rejects.toMatchObject({ code: 'FORBIDDEN' });
+  });
 });
 
 describe('blocks.submitWorkflow', () => {
@@ -2029,6 +2047,24 @@ describe('blocks.submitWorkflow', () => {
         }),
       })
     ).rejects.toMatchObject({ code: 'FORBIDDEN' });
+  });
+
+  it('rejects sourceImages[] on a MODEL-bound token (array form, same page-only gate)', async () => {
+    mockVerifyBlockToken.mockResolvedValue(validClaims({ buzzBudget: 1000 }));
+    const caller = blocksRouter.createCaller(fakeCtx() as never);
+    await expect(
+      caller.submitWorkflow({
+        blockToken: 'tok',
+        body: validBody({
+          sourceImages: [
+            { url: 'https://image.civitai.com/abc/a.jpeg', width: 768, height: 1024 },
+            { url: 'https://image.civitai.com/abc/b.jpeg', width: 768, height: 1024 },
+          ],
+        }),
+      })
+    ).rejects.toMatchObject({ code: 'FORBIDDEN' });
+    // Fail-closed BEFORE any orchestrator call / spend.
+    expect(mockSubmitWorkflow).not.toHaveBeenCalled();
   });
 
   it('rejects when prompt audit blocks the prompt', async () => {

--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -3633,11 +3633,15 @@ export const blocksRouter = router({
             message: 'additionalResources are not supported for model-bound blocks',
           });
         }
-        // IMAGE bridge (Phase-2a): img2img via `sourceImage` is a PAGE-ONLY
+        // IMAGE bridge (Phase-2a): img2img via source images is a PAGE-ONLY
         // feature. Custom Generators is a page app; model-bound img2img is out
         // of scope and unvetted for 2a, so reject it fail-closed on the model
         // path (mirrors the additionalResources guard above).
-        if (input.body.sourceImage) {
+        //
+        // BOTH wire shapes are gated identically — the deprecated singular
+        // `sourceImage` AND the array `sourceImages`. Gating only one would
+        // leave a model-bound token a way in through the other.
+        if (input.body.sourceImage || input.body.sourceImages?.length) {
           throw new TRPCError({
             code: 'FORBIDDEN',
             message: 'source image (img2img) is not supported for model-bound blocks',
@@ -3853,10 +3857,12 @@ export const blocksRouter = router({
             message: 'additionalResources are not supported for model-bound blocks',
           });
         }
-        // IMAGE bridge (Phase-2a): img2img via `sourceImage` is PAGE-ONLY.
+        // IMAGE bridge (Phase-2a): img2img via source images is PAGE-ONLY.
         // Reject it fail-closed on the model path (see estimateWorkflow for the
-        // same guard). Custom Generators is a page app.
-        if (input.body.sourceImage) {
+        // same guard). Custom Generators is a page app. BOTH wire shapes — the
+        // deprecated singular `sourceImage` and the array `sourceImages` — are
+        // gated identically; gating only one would leave a way in.
+        if (input.body.sourceImage || input.body.sourceImages?.length) {
           throw new TRPCError({
             code: 'FORBIDDEN',
             message: 'source image (img2img) is not supported for model-bound blocks',

--- a/src/server/schema/blocks/__tests__/workflow.schema.test.ts
+++ b/src/server/schema/blocks/__tests__/workflow.schema.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest';
 
 import {
+  BLOCK_SOURCE_IMAGES_WIRE_MAX,
+  DIM_MAX,
+  DIM_MIN,
   blockWorkflowBodySchema,
   LORA_STRENGTH_MAX,
   LORA_STRENGTH_MIN,
@@ -382,5 +385,101 @@ describe('blockWorkflowBodySchema — sourceImage URL canonicalization', () => {
       expect(raw.length).toBeLessThanOrEqual(SOURCE_IMAGE_URL_MAX);
       expect(emittedUrl(raw).length).toBeLessThanOrEqual(SOURCE_IMAGE_URL_MAX);
     });
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// sourceImages[] — multi-image conditioning
+// ─────────────────────────────────────────────────────────────────────────────
+//
+// `sourceImage` (singular) is a DEPRECATED ALIAS that must keep working — the
+// published developer docs and @civitai/app-sdk both ship it. `sourceImages` is
+// the current field. The security posture of the array form must be IDENTICAL
+// to the singular one, per element: a Civitai-hosted https URL and dimensions
+// inside DIM_MIN..DIM_MAX. Validating only `[0]` is the classic version of this
+// bug, so the host/dimension cases below deliberately put the BAD element LAST.
+describe('blockWorkflowBodySchema — sourceImages[] (multi-image conditioning)', () => {
+  const OK = 'https://image.civitai.com/abc/def.jpeg';
+  const img = (url = OK, over: Record<string, unknown> = {}) => ({
+    url,
+    width: 512,
+    height: 512,
+    ...over,
+  });
+  const parseImages = (sourceImages: unknown) =>
+    blockWorkflowBodySchema.parse(baseBody({ sourceImages }));
+
+  it('accepts an array and keeps every element', () => {
+    const parsed = parseImages([img(), img('https://orchestration.civitai.com/v2/x.jpeg')]);
+    const images = (parsed as { sourceImages?: Array<{ url: string }> }).sourceImages;
+    expect(images).toHaveLength(2);
+    expect(images?.[1].url).toBe('https://orchestration.civitai.com/v2/x.jpeg');
+  });
+
+  it('keeps the deprecated singular `sourceImage` working on its own', () => {
+    const parsed = blockWorkflowBodySchema.parse(baseBody({ sourceImage: img() }));
+    expect((parsed as { sourceImage?: { url: string } }).sourceImage?.url).toBe(OK);
+    expect((parsed as { sourceImages?: unknown }).sourceImages).toBeUndefined();
+  });
+
+  it('REJECTS supplying BOTH sourceImage and sourceImages (ambiguous)', () => {
+    expect(() =>
+      blockWorkflowBodySchema.parse(baseBody({ sourceImage: img(), sourceImages: [img()] }))
+    ).toThrow(/not both|ambiguous/i);
+  });
+
+  it('REJECTS an EMPTY sourceImages array rather than degrading to txt2img', () => {
+    // Explicit decision: `sourceImages: []` is a caller that computed an empty
+    // list and meant to send images. Silently generating txt2img would bill them
+    // for something they did not ask for. Omit the field for text-to-image.
+    expect(() => parseImages([])).toThrow(/must not be empty/i);
+  });
+
+  // ── HOST VALIDATION APPLIES TO EVERY ELEMENT ───────────────────────────────
+  it.each([
+    ['a non-Civitai host', 'https://evil.example/x.jpeg'],
+    ['a host-confusion URL containing the allowed host', 'https://evil.example/?x=image.civitai.com/a.jpeg'],
+    ['a non-https URL', 'http://image.civitai.com/x.jpeg'],
+    ['a URL with a lookalike suffix', 'https://image.civitai.com.evil.example/x.jpeg'],
+  ])('REJECTS %s in the LAST array element', (_label, badUrl) => {
+    expect(() => parseImages([img(), img(), img(badUrl)])).toThrow();
+  });
+
+  it('REJECTS a bad host in a MIDDLE element too', () => {
+    expect(() => parseImages([img(), img('https://evil.example/x.jpeg'), img()])).toThrow();
+  });
+
+  // ── DIMENSION BOUNDS APPLY TO EVERY ELEMENT ────────────────────────────────
+  it.each([
+    ['width below DIM_MIN', { width: DIM_MIN - 1 }],
+    ['width above DIM_MAX', { width: DIM_MAX + 1 }],
+    ['height below DIM_MIN', { height: DIM_MIN - 1 }],
+    ['height above DIM_MAX', { height: DIM_MAX + 1 }],
+  ])('REJECTS %s in the LAST array element', (_label, over) => {
+    expect(() => parseImages([img(), img(OK, over)])).toThrow();
+  });
+
+  it('accepts dimensions exactly at the bounds in every element', () => {
+    expect(() =>
+      parseImages([img(OK, { width: DIM_MIN, height: DIM_MIN }), img(OK, { width: DIM_MAX, height: DIM_MAX })])
+    ).not.toThrow();
+  });
+
+  // ── ABSOLUTE WIRE BOUND (not the real cap — that is per-ecosystem) ─────────
+  it('accepts exactly BLOCK_SOURCE_IMAGES_WIRE_MAX elements', () => {
+    const many = Array.from({ length: BLOCK_SOURCE_IMAGES_WIRE_MAX }, () => img());
+    expect(() => parseImages(many)).not.toThrow();
+  });
+
+  it('REJECTS more than BLOCK_SOURCE_IMAGES_WIRE_MAX elements', () => {
+    const tooMany = Array.from({ length: BLOCK_SOURCE_IMAGES_WIRE_MAX + 1 }, () => img());
+    expect(() => parseImages(tooMany)).toThrow();
+  });
+
+  it('is set ABOVE the largest per-ecosystem cap so no ecosystem is clamped here', () => {
+    // The wire bound exists to stop an unbounded array reaching the parser, not
+    // to be the product limit. If a future ecosystem raises its imagesNode max
+    // past this, the wire bound would start silently under-allowing it.
+    expect(BLOCK_SOURCE_IMAGES_WIRE_MAX).toBeGreaterThan(7);
   });
 });

--- a/src/server/schema/blocks/workflow.schema.ts
+++ b/src/server/schema/blocks/workflow.schema.ts
@@ -171,6 +171,20 @@ const blockSourceImageSchema = z.object({
   height: z.coerce.number().int().min(DIM_MIN).max(DIM_MAX),
 });
 
+export type BlockSourceImage = z.infer<typeof blockSourceImageSchema>;
+
+// ── Multi-image conditioning (App Blocks IMAGE bridge) ───────────────────────
+// ABSOLUTE wire bound on `sourceImages`, NOT the real cap. The real cap is
+// PER-ECOSYSTEM and derived from the graph's own `imagesNode` config at build
+// time (`getImagesLimit` — Boogu/Kontext/MAI/SD-family 1, Qwen/Qwen2/MageFlow
+// 3, Reve/HiDream-O1 4, WanImage 5, Flux.2/Klein/OpenAI/NanoBanana/Seedream/
+// Grok 7). This constant only stops an untrusted iframe from posting an
+// unbounded array before the body is even parsed — it is set ABOVE the largest
+// per-ecosystem cap on purpose so a future ecosystem raising its own limit is
+// not silently clamped here. Every element is validated individually against
+// `blockSourceImageSchema` (Civitai-host + dimension bounds), never just [0].
+export const BLOCK_SOURCE_IMAGES_WIRE_MAX = 10;
+
 const blockTextToImageBodySchema = z.object({
   kind: z.literal('textToImage'),
   modelId: z.number().int().positive(),
@@ -195,7 +209,34 @@ const blockTextToImageBodySchema = z.object({
   // buildImageWorkflowInput rejects fail-closed a checkpoint whose ecosystem
   // supports NEITHER img2img variant (deterministically via `isWorkflowAvailable`,
   // never relying on the graph's safeParse auto-correction).
+  //
+  // 🔴 DEPRECATED ALIAS — kept working indefinitely. The published developer
+  // docs and `@civitai/app-sdk` both ship `sourceImage` today, so removing it
+  // would break every deployed block. `sourceImages` (below) is the current
+  // field; the server normalizes the singular into a 1-element array
+  // (`normalizeBlockSourceImages`) and everything downstream sees only arrays.
   sourceImage: blockSourceImageSchema.optional(),
+  // Multi-image conditioning. The graph layer has always supported N images
+  // (`imagesNode({ min, max, slots })`); the block bridge could only ever
+  // express one. Each element is validated INDIVIDUALLY (Civitai-hosted https
+  // host check + DIM_MIN/DIM_MAX bounds) — the array form has exactly the same
+  // per-image posture as the singular one, with no "first element only" gap.
+  //
+  // Bounds: `.min(1)` — an EMPTY array is REJECTED rather than silently treated
+  // as "no source image". A caller that sends `sourceImages: []` computed an
+  // empty list and meant to send images; quietly downgrading that to a txt2img
+  // generation would bill them for something they did not ask for, which is the
+  // silent-wrong-answer failure mode this bridge has already been bitten by.
+  // Omit the field entirely for txt2img. `.max()` is the absolute wire bound —
+  // the REAL cap is per-ecosystem and enforced in buildImageWorkflowInput.
+  //
+  // Supplying BOTH `sourceImage` and `sourceImages` is rejected as ambiguous
+  // (see the union-level check below) rather than picking a winner.
+  sourceImages: z
+    .array(blockSourceImageSchema)
+    .min(1, 'sourceImages must not be empty — omit the field for text-to-image')
+    .max(BLOCK_SOURCE_IMAGES_WIRE_MAX)
+    .optional(),
   // Optional viewer-picked buzz account to spend (money page blocks). Absent →
   // unchanged Auto behavior (domain-allowed currencies drained blue-first). When
   // present, blocks.router moves it to the FRONT of the domain-allowed currency
@@ -232,6 +273,21 @@ const blockTextToImageBodySchema = z.object({
   }),
 });
 
+// Supplying BOTH the deprecated `sourceImage` and the current `sourceImages` is
+// AMBIGUOUS — we refuse rather than pick a winner. Silently preferring one is
+// exactly how a caller ends up conditioning on an image it thought it had
+// replaced. Enforced at the WIRE schema so both `estimateWorkflow` and
+// `submitWorkflow` inherit it from the single parse, with no way to reach the
+// translator holding both.
+const blockTextToImageBodySchemaChecked = blockTextToImageBodySchema.refine(
+  (body) => !(body.sourceImage && body.sourceImages),
+  {
+    path: ['sourceImages'],
+    message:
+      'send either `sourceImage` (deprecated) or `sourceImages`, not both — they are ambiguous together',
+  }
+);
+
 // App Blocks customComfy bridge (v1). Coarse fail-closed wire gate only:
 //  - `recipe` MUST be a REGISTERED recipe id (derived from the recipe registry
 //    keys) — an unregistered id is rejected at the union, before any translator
@@ -251,7 +307,7 @@ export const blockCustomComfyBodySchema = z
 
 export type BlockWorkflowBody = z.infer<typeof blockWorkflowBodySchema>;
 export const blockWorkflowBodySchema = z.discriminatedUnion('kind', [
-  blockTextToImageBodySchema,
+  blockTextToImageBodySchemaChecked,
   blockCustomComfyBodySchema,
 ]);
 

--- a/src/server/services/blocks/__tests__/workflow.service.test.ts
+++ b/src/server/services/blocks/__tests__/workflow.service.test.ts
@@ -26,6 +26,8 @@ import {
   BLOCK_IMAGE_WORKFLOW_TYPES,
   createBlockCustomComfyStep,
   isPageLoraResource,
+  assertSourceImageCount,
+  normalizeBlockSourceImages,
   projectAppWorkflow,
   resolveBlockImageWorkflowType,
   resolveBlockVersionContext,
@@ -40,7 +42,9 @@ import { getRecipe, REGISTERED_RECIPE_IDS } from '../recipes';
 // live in the browser-safe `shared/` tree (no DB/redis), so we import and run
 // them for real in the integration-style test below.
 import { generationGraph } from '~/shared/data-graph/generation/generation-graph';
-import { ECO } from '~/shared/constants/basemodel.constants';
+import { ECO, ecosystems } from '~/shared/constants/basemodel.constants';
+import { isWorkflowAvailable } from '~/shared/data-graph/generation/config/workflows';
+import { getImagesLimit } from '~/shared/data-graph/generation/images-limit';
 import { toStepMetadata } from '~/shared/utils/resource.utils';
 import { removeEmpty } from '~/utils/object-helpers';
 import type { GenerationCtx } from '~/shared/data-graph/generation/context';
@@ -1944,5 +1948,236 @@ describe('projectAppWorkflow: customComfy blobs', () => {
       cost: 47,
       createdAt: '2026-07-17T00:00:00.000Z',
     });
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Multi-image conditioning: sourceImages[] + PER-ECOSYSTEM cap
+// ─────────────────────────────────────────────────────────────────────────────
+//
+// The graph layer has always accepted N reference images (`imagesNode({min,max})`);
+// the block bridge could only express one. The cap is NOT a constant — it is
+// declared per ecosystem in the graph files and the real spread is 1 / 3 / 4 /
+// 5 / 7. These tests read the same real config the guard does, and pin the
+// ecosystem-specific behaviour rather than a flat number.
+describe('sourceImages[] — normalization + per-ecosystem cap', () => {
+  const IMG = (n = 0) => ({
+    url: `https://image.civitai.com/abc/${n}.jpeg`,
+    width: 1024,
+    height: 1024,
+  });
+  const body = (over: Record<string, unknown> = {}) => ({
+    kind: 'textToImage' as const,
+    modelId: 7,
+    modelVersionId: 99,
+    params: { prompt: 'edit the cat', quantity: 1 },
+    ...over,
+  });
+  const resolved = (checkpointBaseModel: string) => ({
+    baseModel: checkpointBaseModel,
+    modelType: 'Checkpoint',
+    checkpointVersionId: 99,
+    checkpointBaseModel,
+  });
+  const images = (n: number) => Array.from({ length: n }, (_, i) => IMG(i));
+  function catchError(fn: () => unknown): unknown {
+    try {
+      fn();
+    } catch (e) {
+      return e;
+    }
+    return undefined;
+  }
+
+  // ── normalization ──────────────────────────────────────────────────────────
+  it('normalizes the deprecated singular sourceImage to a 1-element array', () => {
+    expect(normalizeBlockSourceImages(body({ sourceImage: IMG(1) }) as never)).toEqual([IMG(1)]);
+  });
+
+  it('passes an array through unchanged', () => {
+    expect(normalizeBlockSourceImages(body({ sourceImages: images(3) }) as never)).toEqual(
+      images(3)
+    );
+  });
+
+  it('returns an empty array when the body carries neither (txt2img)', () => {
+    expect(normalizeBlockSourceImages(body() as never)).toEqual([]);
+  });
+
+  // ── the emitted graph input ────────────────────────────────────────────────
+  it('emits EVERY array element into the graph images[] (order preserved)', () => {
+    const out = buildImageWorkflowInput(body({ sourceImages: images(3) }) as never, resolved('Qwen'));
+    expect(out.workflow).toBe('img2img:edit');
+    expect(out.images).toEqual([
+      { url: 'https://image.civitai.com/abc/0.jpeg', width: 1024, height: 1024 },
+      { url: 'https://image.civitai.com/abc/1.jpeg', width: 1024, height: 1024 },
+      { url: 'https://image.civitai.com/abc/2.jpeg', width: 1024, height: 1024 },
+    ]);
+  });
+
+  it('produces an IDENTICAL graph input for the singular alias and a 1-element array', () => {
+    const singular = buildImageWorkflowInput(
+      body({ sourceImage: IMG(0) }) as never,
+      resolved('Qwen')
+    );
+    const array = buildImageWorkflowInput(
+      body({ sourceImages: [IMG(0)] }) as never,
+      resolved('Qwen')
+    );
+    expect(array).toEqual(singular);
+  });
+
+  it('routes an array on an SD-family checkpoint to plain img2img', () => {
+    const out = buildImageWorkflowInput(
+      body({ sourceImages: [IMG(0)] }) as never,
+      resolved('SDXL 1.0')
+    );
+    expect(out.workflow).toBe('img2img');
+    expect(out.images).toHaveLength(1);
+  });
+
+  // ── PER-ECOSYSTEM CAP ──────────────────────────────────────────────────────
+  // Caps read from each ecosystem's own imagesNode config. A flat constant would
+  // over-allow Boogu (1) and under-allow Flux.2 (7).
+  it.each([
+    ['Qwen', 'Qwen', 3],
+    ['Flux.2 D', 'Flux2', 7],
+    ['Boogu', 'Boogu', 1],
+    ['OpenAI', 'OpenAI', 7],
+    ['SDXL 1.0', 'SDXL', 1],
+    ['HiDream-O1', 'HiDream-O1', 4],
+  ])('accepts exactly the cap for %s (%s = %i)', (baseModel, _ecoKey, cap) => {
+    const out = buildImageWorkflowInput(
+      body({ sourceImages: images(cap) }) as never,
+      resolved(baseModel)
+    );
+    expect(out.images).toHaveLength(cap);
+  });
+
+  it.each([
+    ['Qwen', 4, 3],
+    ['Flux.2 D', 8, 7],
+    ['Boogu', 2, 1],
+    ['SDXL 1.0', 2, 1],
+  ])('REJECTS over-cap for %s (%i sent, cap %i)', (baseModel, count, cap) => {
+    const caught = catchError(() =>
+      buildImageWorkflowInput(body({ sourceImages: images(count) }) as never, resolved(baseModel))
+    ) as TRPCError;
+    expect(caught).toBeInstanceOf(TRPCError);
+    expect(caught).toMatchObject({ code: 'BAD_REQUEST' });
+    // The error names the limit AND the ecosystem, not a generic "too many".
+    expect(caught.message).toContain(String(cap));
+    expect(caught.message).toContain(String(count));
+    expect(caught.message).toMatch(/ecosystem/);
+  });
+
+  // The cap really is per-ecosystem: the SAME count is accepted on one and
+  // rejected on another. A flat constant cannot satisfy both of these.
+  it('accepts 3 images on Qwen but rejects 3 on Boogu (cap is per-ecosystem)', () => {
+    expect(
+      buildImageWorkflowInput(body({ sourceImages: images(3) }) as never, resolved('Qwen')).images
+    ).toHaveLength(3);
+    expect(
+      catchError(() =>
+        buildImageWorkflowInput(body({ sourceImages: images(3) }) as never, resolved('Boogu'))
+      )
+    ).toMatchObject({ code: 'BAD_REQUEST' });
+  });
+
+  it('accepts 7 images on Flux.2 but rejects 7 on Qwen', () => {
+    expect(
+      buildImageWorkflowInput(body({ sourceImages: images(7) }) as never, resolved('Flux.2 D'))
+        .images
+    ).toHaveLength(7);
+    expect(
+      catchError(() =>
+        buildImageWorkflowInput(body({ sourceImages: images(7) }) as never, resolved('Qwen'))
+      )
+    ).toMatchObject({ code: 'BAD_REQUEST' });
+  });
+
+  // ── the over-cap behaviour we are preventing ───────────────────────────────
+  it('documents that the graph SILENTLY TRUNCATES an over-cap images array', () => {
+    // imagesNode's input transform does `arr.slice(0, effectiveMax)`. Without
+    // the guard, an over-cap block body would be billed for a generation
+    // conditioned on fewer images than it sent, with nothing saying so.
+    const externalCtx: GenerationCtx = {
+      limits: { maxQuantity: 4, maxResources: 10, vidQuantity: 1 },
+      user: { isMember: false, tier: 'free' },
+      flags: {},
+      selfHostedDisabledEcosystems: [],
+      selfHostedMode: 'enabled',
+      gateRules: [],
+    };
+    const result = generationGraph.safeParse(
+      {
+        workflow: 'img2img:edit',
+        ecosystem: 'Qwen',
+        model: { id: 2558804 },
+        resources: [],
+        prompt: 'edit the cat',
+        sampler: 'Euler',
+        steps: 25,
+        quantity: 1,
+        priority: 'low',
+        images: images(6),
+      },
+      externalCtx
+    );
+    expect(result.success).toBe(true);
+    // 6 sent, 3 kept — silently.
+    expect((result.data as { images: unknown[] }).images).toHaveLength(3);
+  });
+
+  // ── fail-closed when the cap cannot be determined ──────────────────────────
+  //
+  // Unreachable through buildImageWorkflowInput today — the ecosystem/variant
+  // guard rejects a checkpoint whose ecosystem doesn't support the variant
+  // before we get here, and the population test below proves every supported
+  // pair HAS a readable cap. Exercised directly so the branch is not shipped
+  // untested: if the two guards ever drift apart, this must reject rather than
+  // hand the graph an images[] it has no node for.
+  it('REJECTS fail-closed when the (ecosystem, workflow) pair has no images node', () => {
+    // Flux1 is txt2img-only — no img2img node, so no derivable limit.
+    const caught = catchError(() =>
+      assertSourceImageCount({ ecosystem: 'Flux1', workflow: 'img2img', count: 1 })
+    ) as TRPCError;
+    expect(caught).toBeInstanceOf(TRPCError);
+    expect(caught).toMatchObject({ code: 'BAD_REQUEST' });
+    expect(caught.message).toMatch(/does not accept source images/);
+  });
+
+  it('REJECTS fail-closed for a pair the graph would re-route (unknown ecosystem)', () => {
+    expect(
+      catchError(() =>
+        assertSourceImageCount({ ecosystem: 'NotAnEcosystem', workflow: 'img2img:edit', count: 1 })
+      )
+    ).toMatchObject({ code: 'BAD_REQUEST' });
+  });
+
+  // ── every edit-capable ecosystem has a READABLE cap ────────────────────────
+  //
+  // Audit the POPULATION, not a handful: enumerate every ecosystem the real
+  // config marks as supporting an img2img variant and assert the bridge can
+  // read a cap for it. If a new ecosystem ships whose limit is not derivable,
+  // this fails instead of that ecosystem silently falling into the fail-closed
+  // "does not accept source images" branch.
+  it('derives a cap for EVERY ecosystem supporting an img2img variant', () => {
+    const missing: string[] = [];
+    let checked = 0;
+    for (const workflow of ['img2img', 'img2img:edit'] as const) {
+      for (const eco of ecosystems) {
+        if (!isWorkflowAvailable(workflow, eco.id)) continue;
+        checked += 1;
+        const limit = getImagesLimit(eco.key, workflow);
+        if (!limit || !(limit.max >= 1) || !(limit.min >= 0)) {
+          missing.push(`${eco.key}/${workflow}`);
+        }
+      }
+    }
+    expect(missing).toEqual([]);
+    // Guard the guard: if the enumeration ever silently matches nothing, an
+    // empty `missing` would look like a pass.
+    expect(checked).toBeGreaterThan(15);
   });
 });

--- a/src/server/services/blocks/workflow.service.ts
+++ b/src/server/services/blocks/workflow.service.ts
@@ -8,8 +8,10 @@ import { getBaseModelSetType } from '~/shared/constants/generation.constants';
 import { getEcosystem } from '~/shared/constants/basemodel.constants';
 import { isWorkflowAvailable } from '~/shared/data-graph/generation/config/workflows';
 import { resolveVersionWorkflowScope } from '~/shared/data-graph/generation/workflow-capability';
+import { getImagesLimit } from '~/shared/data-graph/generation/images-limit';
 import { ModelType } from '~/shared/utils/prisma/enums';
 import type {
+  BlockSourceImage,
   BlockWorkflowBody,
   BlockWorkflowSnapshot,
 } from '~/server/schema/blocks/workflow.schema';
@@ -426,6 +428,29 @@ function isBlockImageWorkflowType(workflow: string): workflow is BlockImageWorkf
 }
 
 /**
+ * THE single place the two source-image wire shapes collapse into one.
+ *
+ * `sourceImage` (singular) is a DEPRECATED ALIAS — the published developer docs
+ * and `@civitai/app-sdk` still ship it — and `sourceImages` is the current
+ * field. Everything downstream of this function sees ONLY an array, so no code
+ * path can accidentally handle one shape and miss the other.
+ *
+ * Supplying both is rejected at the WIRE schema (ambiguous), so it cannot reach
+ * here; the `sourceImages`-first order below is defensive, not a preference.
+ * Returns an empty array when the body carries neither — that is the txt2img
+ * case. An explicitly EMPTY `sourceImages: []` never reaches here either: the
+ * schema's `.min(1)` rejects it rather than let it degrade into a txt2img
+ * generation the caller did not ask for.
+ */
+export function normalizeBlockSourceImages(
+  body: Extract<BlockWorkflowBody, { kind: 'textToImage' }>
+): BlockSourceImage[] {
+  if (body.sourceImages?.length) return body.sourceImages;
+  if (body.sourceImage) return [body.sourceImage];
+  return [];
+}
+
+/**
  * Resolve which image graph workflow a block body maps to when combined with the
  * checkpoint's ecosystem:
  *   - no source image + txt2img-capable eco    → `txt2img`
@@ -457,7 +482,14 @@ export function resolveBlockImageWorkflowType(
   body: Extract<BlockWorkflowBody, { kind: 'textToImage' }>,
   ecosystemId?: number
 ): BlockImageWorkflowType {
-  if (!body.sourceImage) {
+  // 🔴 UNION OF TWO CHANGES — the CONDITION comes from the sourceImages[] work,
+  // the guard BODY from the edit-only work. Reading the NORMALIZED array (not the
+  // deprecated singular `body.sourceImage`) is load-bearing: an array-only body
+  // has `sourceImage` undefined, so the old literal check would route it to
+  // `txt2img`, silently DROP the images, and bill the caller for a text-to-image
+  // generation. That is the exact silent-wrong-answer class both changes exist to
+  // close, so it must not be reintroduced by a conflict resolution.
+  if (normalizeBlockSourceImages(body).length === 0) {
     if (
       ecosystemId != null &&
       !isWorkflowAvailable('txt2img', ecosystemId) &&
@@ -579,6 +611,61 @@ export function assertCheckpointVersionSupportsWorkflow(opts: {
       `${ecosystem} ecosystem — it is offered for ${scope.offeredFor.join(' / ')} only. ` +
       `Either ${remedy}${alternative}.`,
   });
+}
+
+/**
+ * Enforce the PER-ECOSYSTEM source-image cap.
+ *
+ * The cap is not a constant — it is declared per ecosystem in the graph's own
+ * `imagesNode({ min, max })` and the spread is wide: Boogu / Flux.1 Kontext /
+ * MAI / SD-family accept 1, Qwen / Qwen2 / MageFlow 3, Reve / HiDream-O1 4,
+ * WanImage 5, Flux.2 / Klein / OpenAI / NanoBanana / Seedream / Grok 7. A flat
+ * constant would over-allow the 1-image ecosystems and under-allow the 7-image
+ * ones, so `getImagesLimit` reads the real graph config instead.
+ *
+ * WHY REJECT RATHER THAN LET THE GRAPH HANDLE IT: `imagesNode`'s INPUT
+ * transform does `arr.slice(0, effectiveMax)` — an over-cap array is silently
+ * TRUNCATED, and the caller is billed for a generation conditioned on fewer
+ * images than it sent, with nothing in the response saying so. Same
+ * silent-wrong-answer class the ecosystem/variant guard above exists to stop.
+ *
+ * FAIL CLOSED when the limit cannot be determined: `getImagesLimit` returns
+ * `undefined` for a pair with no images node, which for a resolved img2img
+ * workflow means our routing and the graph's disagree. Rejecting is correct
+ * there — proceeding would hand the graph an `images` array it has no node for.
+ * The ecosystem/variant guard upstream makes that unreachable today (and a test
+ * enumerates every img2img-capable ecosystem to prove each one HAS a readable
+ * limit), so this is defense-in-depth against the two guards drifting apart —
+ * exported so it can be exercised directly rather than left unverified.
+ *
+ * The MINIMUM is deliberately NOT re-checked here. Every image workflow's
+ * `imagesNode` has `min: 1` today, and we only call this with `count >= 1`; if
+ * a future ecosystem raises its minimum, the graph's own OUTPUT schema
+ * (`.min(effectiveMin, 'At least N images are required')`) rejects LOUDLY
+ * during `safeParse` — that failure mode is already an error, not a silent
+ * wrong answer, so duplicating it here would only add a second place to drift.
+ */
+export function assertSourceImageCount(opts: {
+  ecosystem: string;
+  workflow: BlockImageWorkflowType;
+  count: number;
+}): void {
+  const { ecosystem, workflow, count } = opts;
+  const limit = getImagesLimit(ecosystem, workflow);
+  if (!limit) {
+    throw new TRPCError({
+      code: 'BAD_REQUEST',
+      message: `workflow '${workflow}' does not accept source images on the ${ecosystem} ecosystem`,
+    });
+  }
+  if (count > limit.max) {
+    throw new TRPCError({
+      code: 'BAD_REQUEST',
+      message:
+        `too many source images: ${count} sent, but the ${ecosystem} ecosystem accepts at most ` +
+        `${limit.max} for '${workflow}'`,
+    });
+  }
 }
 
 /**
@@ -754,19 +841,22 @@ export function buildImageWorkflowInput(
     // qwen-graph: `images` node shown `when: !workflow.startsWith('txt')`). The
     // denoise/edit node applies at its default and output dimensions derive from
     // the source (SD) or the ecosystem's aspectRatio default (edit) — so
-    // aspectRatio is OMITTED here. `sourceImage` is guaranteed present (the
-    // variant only resolves to an img2img* type when the body carries one); the
-    // fallback keeps the types honest for an explicit-type caller. The graph's
-    // imagesNode reads { url, width, height }; extra fields are stripped by its
-    // object parse.
-    if (body.sourceImage) {
-      input.images = [
-        {
-          url: body.sourceImage.url,
-          width: body.sourceImage.width,
-          height: body.sourceImage.height,
-        },
-      ];
+    // aspectRatio is OMITTED here. The graph's imagesNode reads
+    // { url, width, height }; extra fields are stripped by its object parse.
+    //
+    // MULTI-IMAGE: the source images are the NORMALIZED array, so the singular
+    // deprecated `sourceImage` and the array `sourceImages` produce identical
+    // downstream shapes. The count is checked against the ECOSYSTEM's real cap
+    // BEFORE emitting — the graph would otherwise silently truncate an over-cap
+    // array (see assertSourceImageCount).
+    const sourceImages = normalizeBlockSourceImages(body);
+    if (sourceImages.length) {
+      assertSourceImageCount({ ecosystem, workflow: workflowType, count: sourceImages.length });
+      input.images = sourceImages.map((img) => ({
+        url: img.url,
+        width: img.width,
+        height: img.height,
+      }));
     }
     return input;
   }

--- a/src/shared/data-graph/generation/images-limit.ts
+++ b/src/shared/data-graph/generation/images-limit.ts
@@ -1,0 +1,99 @@
+/**
+ * Per-ecosystem source-image limits, read from the REAL generation graph.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * How many reference/source images an image workflow accepts is declared ONLY
+ * inside the per-ecosystem graph files (`imagesNode({ min, max, slots })` in
+ * qwen-graph / flux2-graph / boogu-graph / …), never in a central table. The
+ * real spread today is wide — Boogu / Flux.1 Kontext / MAI / SD-family accept
+ * 1, Qwen / Qwen2 / MageFlow 3, Reve / HiDream-O1 4, WanImage 5, Flux.2 /
+ * Flux.2 Klein / OpenAI / NanoBanana / Seedream / Grok 7 — so a flat constant
+ * would simultaneously over-allow the 1-image ecosystems and under-allow the
+ * 7-image ones.
+ *
+ * Rather than copy that spread into a parallel table that rots the moment a
+ * graph file changes, this INSTANTIATES the real `generationGraph` for the
+ * (ecosystem, workflow) pair and reads the `images` node meta the generation
+ * form itself renders from — the single source of truth, by construction.
+ *
+ * NEUTRAL PROBE CONTEXT: the probe runs with a fixed, free-tier-shaped
+ * `GenerationCtx` carrying no gate rules. It answers "what does the CONFIG
+ * allow for this ecosystem?", not "what may THIS user generate?" — per-user
+ * limits and entitlement gating still run downstream in
+ * `createWorkflowStepsFromGraphInput`. Nothing in `imagesNode` reads `limits`,
+ * `user` or `gateRules`, so no per-user value can leak into the answer.
+ *
+ * COST: `clone() + init()` measured at ~1.4 ms; results are memoized per
+ * `${ecosystem}|${workflow}` since the underlying config is static per process.
+ *
+ * NOTE FOR REVIEW: civitai#3517 adds a sibling probe module
+ * (`workflow-capability.ts`) that reads the `model` node's meta the same way.
+ * The two are deliberately separate files so the PRs don't collide; once both
+ * land they should be folded into one probe helper.
+ */
+
+import { generationGraph } from './generation-graph';
+import type { GenerationCtx } from './context';
+
+/**
+ * Fixed capability-probe context. NOT a user's context — see the module note.
+ */
+const PROBE_CTX: GenerationCtx = {
+  limits: { maxQuantity: 4, maxResources: 10, vidQuantity: 1 },
+  user: { isMember: false, tier: 'free' },
+  flags: {},
+  selfHostedDisabledEcosystems: [],
+  selfHostedMode: 'enabled',
+  gateRules: [],
+};
+
+export type ImagesLimit = {
+  /** Minimum images the workflow requires (1 for every image workflow today). */
+  min: number;
+  /** Maximum images the workflow accepts. */
+  max: number;
+};
+
+const limitCache = new Map<string, ImagesLimit | undefined>();
+
+/**
+ * The `images` node's {min, max} for one (ecosystem, workflow) pair, or
+ * `undefined` when the pair has no images node at all.
+ *
+ * `undefined` means one of:
+ *   - the workflow does not take images (every `txt2*` workflow — the node
+ *     carries `when: !workflow.startsWith('txt')` and is absent from ctx), or
+ *   - the (ecosystem, workflow) pair is not a coherent combination, in which
+ *     case the graph's own effects re-route it. We verify the instantiated
+ *     context still holds the pair we asked about and report "no opinion"
+ *     rather than returning a limit that describes a different route.
+ *
+ * A caller MUST treat `undefined` as "cannot determine" and fail closed rather
+ * than as "unlimited".
+ */
+export function getImagesLimit(ecosystem: string, workflow: string): ImagesLimit | undefined {
+  const cacheKey = `${ecosystem}|${workflow}`;
+  if (limitCache.has(cacheKey)) return limitCache.get(cacheKey);
+
+  let limit: ImagesLimit | undefined;
+  try {
+    const clone = generationGraph.clone();
+    clone.init({ workflow, ecosystem } as never, PROBE_CTX, { skipStorage: true });
+    const ctx = clone.ctx as { workflow?: string; ecosystem?: string };
+    if (ctx.workflow === workflow && ctx.ecosystem === ecosystem) {
+      const meta = clone.getNodeMeta('images' as never) as
+        | { min?: number; max?: number }
+        | undefined;
+      if (typeof meta?.min === 'number' && typeof meta?.max === 'number') {
+        limit = { min: meta.min, max: meta.max };
+      }
+    }
+  } catch {
+    // A probe failure reports "cannot determine"; the caller fails closed.
+    limit = undefined;
+  }
+
+  limitCache.set(cacheKey, limit);
+  return limit;
+}


### PR DESCRIPTION
## The gap

Multi-image conditioning is table stakes for the edit ecosystems the bridge already supports, and the block body couldn't express it. **The graph layer already supports N images natively** — `imagesNode({ min, max, slots })` in `common.ts` — so this is a bridge schema/service change, not a platform change.

## The cap is per-ecosystem, not a constant

Read from each ecosystem's own `imagesNode` config, not a table I typed:

| max | ecosystems |
|---|---|
| 1 | SD-family (`img2img`), Flux.1 Kontext, Boogu, MAI |
| 3 | Qwen, Qwen2, MageFlow |
| 4 | Reve, HiDream-O1 |
| 5 | WanImage 2.7 |
| 7 | Flux.2, Flux.2 Klein (×4), OpenAI, NanoBanana, Seedream, Grok |

A flat cap would over-allow Boogu (1) and under-allow Flux.2 (7). New `src/shared/data-graph/generation/images-limit.ts` instantiates the real `generationGraph` for the (ecosystem, workflow) pair and reads the `images` node meta the generation form itself renders from. ~1.4 ms, memoized per pair.

The probe runs with a neutral, gate-rule-free context on purpose — it answers "what does the **config** allow?", not "what may **this user** generate?". Nothing in `imagesNode` reads `limits`/`user`/`gateRules`, so no per-user value can leak into the answer.

**A test enumerates the population**, not a handful: every ecosystem the real config marks as supporting `img2img` or `img2img:edit` (23 pairs today) must yield a readable cap. If a new ecosystem ships whose limit isn't derivable, that test fails instead of the ecosystem silently landing in the fail-closed branch.

### Why reject over-cap rather than let the graph handle it

`imagesNode`'s input transform is `arr.slice(0, effectiveMax)` — an over-cap array is **silently truncated**, and the caller is billed for a generation conditioned on fewer images than it sent, with nothing in the response saying so. Verified against the real graph, pinned by a test:

```
sent 6 images to Qwen img2img:edit → safeParse succeeds → data.images.length === 3
```

Same silent-wrong-answer class as civitai#3517.

## Backward compatibility

- `sourceImage` (singular) stays a **deprecated alias** and keeps working — the published developer docs and `@civitai/app-sdk` both ship it today.
- `sourceImages` is the current field.
- Both normalize to one array in `normalizeBlockSourceImages`, so **everything downstream sees only arrays** — no code path can handle one shape and miss the other. A test asserts the singular alias and a 1-element array produce a byte-identical graph input.
- Supplying **both** → rejected as ambiguous at the wire schema (so `estimateWorkflow` and `submitWorkflow` inherit it from the single parse). Silently preferring one is how a caller ends up conditioning on an image it thought it had replaced.

## Empty array — decided: **reject**

`sourceImages: []` is rejected (`.min(1)`), not treated as absent. A caller that sends an empty array computed an empty list and *meant* to send images; quietly downgrading that to a txt2img generation would bill them for something they did not ask for. Omit the field entirely for text-to-image. The error says so: `sourceImages must not be empty — omit the field for text-to-image`.

## Security

🔴 **Per-element validation, not `[0]`.** `sourceImages` is `z.array(blockSourceImageSchema)`, so every element goes through the same Civitai-hosted-https hostname check and `DIM_MIN`..`DIM_MAX` bounds as the singular field. The tests deliberately put the bad element **last** (and one case in the middle) — validating only `[0]` is the classic version of this bug and would pass a naive test.

🔴 **Page-only guard covers both shapes.** `estimateWorkflow` and `submitWorkflow` both now gate `input.body.sourceImage || input.body.sourceImages?.length`. Gating only the singular field would have left a model-bound token a way in through the array.

`BLOCK_SOURCE_IMAGES_WIRE_MAX = 10` is an **absolute wire bound, not the product cap** — it stops an untrusted iframe posting an unbounded array before the body is parsed, and is set above the largest per-ecosystem cap on purpose so a future ecosystem raising its own limit isn't silently clamped there. A test asserts it stays above 7.

## Tests

`workflow.schema.test.ts` (wire), `workflow.service.test.ts` (bridge), `blocks.router.workflow.test.ts` (token gate):

- array accepted, every element kept, order preserved into `input.images`
- singular alias still accepted; produces an identical graph input to a 1-element array
- both supplied → rejected as ambiguous
- **empty array rejected**
- host validation on the **last** element, a **middle** element, non-https, host-confusion, lookalike suffix
- dimension bounds on the last element (4 cases); exact-bound values accepted in every element
- over-cap rejected per ecosystem — Qwen at 4, Flux.2 at 8, Boogu at 2, SDXL at 2 — error names both the count and the ecosystem's limit
- at-cap accepted — Qwen 3, Flux.2 7, Boogu 1, OpenAI 7, SDXL 1, HiDream-O1 4
- the same count accepted on one ecosystem and rejected on another (3 on Qwen vs Boogu; 7 on Flux.2 vs Qwen) — a flat constant cannot satisfy both
- page-only guard rejects the array form on a MODEL-bound token, on **both** estimate and submit, before any orchestrator call
- fail-closed when the cap can't be derived
- wire max accepted at 10, rejected at 11
- population sweep: every img2img-capable ecosystem has a readable cap

### Mutation testing — every new guard proven to bite

| Mutation | Result |
|---|---|
| `z.array(blockSourceImageSchema)` → loose per-element object (drop host/dim checks) | **9 fail** — incl. every last-element and middle-element case |
| `getImagesLimit(...)` → flat `{min:1,max:7}` | **5 fail** — the per-ecosystem cases |
| `normalizeBlockSourceImages` returns only `sourceImages[0]` | **12 fail** |
| page-only guard checks only `sourceImage` | **2 fail** — estimate + submit array cases |
| drop `.min(1)` on `sourceImages` | **1 fail** — the empty-array case |
| remove the ambiguity refinement | **1 fail** |
| `assertSourceImageCount` never called | **6 fail** |
| fail-closed `!limit` branch → `return` | **initially SURVIVED** — see below |

The fail-closed branch had **no killing test** on the first pass, so I did not ship it unverified: `assertSourceImageCount` is now exported and exercised directly (`Flux1`/`img2img`, unknown ecosystem), and the mutation kills 2 tests. In the same pass I **removed** the `count < limit.min` check — every image workflow has `min: 1` and we only call with `count >= 1`, and if a future ecosystem raises its minimum the graph's own output schema rejects **loudly** during `safeParse`. That failure mode is already an error rather than a silent wrong answer, so a second copy of the check would only be somewhere to drift.

## Verification

```
NODE_OPTIONS=--max_old_space_size=8192 npx tsc --noEmit   → TSC_EXIT=0
npx vitest run src/server/services/blocks                 → 95 files, 1886 tests, all passing
npx vitest run src/server/schema/blocks \
    src/server/routers/__tests__/blocks.router.workflow.test.ts src/shared/data-graph
                                                          → 12 files, 422 tests, all passing
```

## Required follow-up — SDK (different repo)

🔴 **`@civitai/app-sdk` mirrors these wire types** in `blocks/types.ts` and lives in **`civitai-app-starters`**. `sourceImages` needs a corresponding SDK update before app authors can use the array form from a typed client — this PR only makes the server accept it. `sourceImage` keeps working meanwhile, so nothing breaks in the interim. Same for the published developer docs.

## Relationship to civitai#3517

Not stacked — this branches off `main`, per the repo's no-stacked-PRs rule. Whichever lands second will conflict in `workflow.service.ts` (`resolveBlockImageWorkflowType` / `buildImageWorkflowInput`) and at the append point of `workflow.service.test.ts`. Both changes are additive and independent; the merge is a union, not a choice.

The two probe modules (`images-limit.ts` here, `workflow-capability.ts` in #3517) are deliberately **separate files** so the PRs don't collide on a new-file add. They read different node metas the same way and should be folded into one probe helper once both land.

## Not verified

- No end-to-end run against a live orchestrator — the accepted paths were exercised through the real `generationGraph`, but no real multi-image generation was submitted.
- No app currently sends `sourceImages`, so there is no production traffic exercising the new field yet; the deprecated singular path is what remains live.
