### PR TITLE
fix(blocks): canonicalize the block sourceImage URL instead of forwarding raw bytes

### DIFF
--- a/src/server/schema/blocks/__tests__/workflow.schema.test.ts
+++ b/src/server/schema/blocks/__tests__/workflow.schema.test.ts
@@ -5,6 +5,7 @@ import {
   LORA_STRENGTH_MAX,
   LORA_STRENGTH_MIN,
   MAX_ADDITIONAL_RESOURCES,
+  SOURCE_IMAGE_URL_MAX,
 } from '../workflow.schema';
 
 /**
@@ -205,5 +206,181 @@ describe('blockWorkflowBodySchema — sourceImage host allowlist (generationSour
     expect(() =>
       withSource('http://orchestration.civitai.com/v2/consumer/blobs/abc.jpeg')
     ).toThrow();
+  });
+});
+
+/**
+ * sourceImage URL canonicalization (validate-the-parse / forward-the-raw gap).
+ *
+ * The host allowlist validates a PARSED url but the schema used to emit the
+ * ORIGINAL string, and nothing downstream re-validates (the graph's imagesNode
+ * is a bare `url: z.string()`). That made two WHATWG-specific normalizations
+ * load-bearing as security properties: `\` is treated as `/` in the authority,
+ * and tab/CR/LF are deleted from anywhere in the url. Both let a raw string
+ * carrying a foreign host — or raw CRLF — pass the check and reach the
+ * orchestrator unmodified.
+ *
+ * These lock in the three-layer bound: ambiguous bytes are rejected, the parsed
+ * host is checked, and the EMITTED value is `URL.href` (so the bytes we forward
+ * are the bytes we validated) re-capped at SOURCE_IMAGE_URL_MAX.
+ *
+ * Every assertion below is on the EMITTED value or on an explicit rejection —
+ * never merely on "parse succeeded".
+ */
+describe('blockWorkflowBodySchema — sourceImage URL canonicalization', () => {
+  // The bytes under test are written as explicit code points rather than string
+  // escapes: this is exactly the class of character an editor, formatter, or
+  // copy/paste can silently rewrite, which would quietly defang the test.
+  const BACKSLASH = String.fromCharCode(0x5c);
+  const TAB = String.fromCharCode(0x09);
+  const CR = String.fromCharCode(0x0d);
+  const LF = String.fromCharCode(0x0a);
+  const NUL = String.fromCharCode(0x00);
+
+  const parseSource = (url: string) =>
+    blockWorkflowBodySchema.safeParse(baseBody({ sourceImage: { url, width: 512, height: 512 } }));
+
+  const emittedUrl = (url: string): string => {
+    const res = parseSource(url);
+    if (!res.success)
+      throw new Error(`expected ${JSON.stringify(url)} to parse, but it was rejected`);
+    return (res.data as { sourceImage: { url: string } }).sourceImage.url;
+  };
+
+  describe('rejects the parser-differential shapes that used to pass', () => {
+    it('rejects a backslash in the authority', () => {
+      const raw = `https://civitai.com${BACKSLASH}@evil.com/x.png`;
+      // The WHATWG behaviour that WAS being relied on: `\` acts as `/`, so the
+      // hostname check saw `civitai.com` and passed. A parser that splits the
+      // authority on the last `@` without treating `\` as a delimiter reads
+      // host = evil.com — a different origin than the one we approved.
+      expect(new URL(raw).hostname).toBe('civitai.com');
+      expect(parseSource(raw).success).toBe(false);
+    });
+
+    it('rejects a TAB inside the host', () => {
+      const raw = `https://evil.com${TAB}.civitai.com/x.png`;
+      // WHATWG deletes the tab, yielding an allowlist-passing subdomain — while
+      // the raw bytes, tab intact, were what got forwarded.
+      expect(new URL(raw).hostname).toBe('evil.com.civitai.com');
+      expect(parseSource(raw).success).toBe(false);
+    });
+
+    it('rejects CRLF inside the host', () => {
+      const raw = `https://evil.com${CR}${LF}.civitai.com/x.png`;
+      expect(new URL(raw).hostname).toBe('evil.com.civitai.com');
+      expect(parseSource(raw).success).toBe(false);
+    });
+
+    it('rejects CR/LF elsewhere in the URL, not just in the host', () => {
+      // Raw CRLF in a value a consumer concatenates into a request line or a
+      // log record is a request-splitting / log-injection primitive, whatever
+      // part of the URL it sits in.
+      expect(parseSource(`https://civitai.com/x.png${CR}${LF}Host: evil.com`).success).toBe(false);
+      expect(parseSource(`https://civitai.com/${LF}x.png`).success).toBe(false);
+      expect(parseSource(`https://civitai.com/x.png?a=${CR}${LF}b`).success).toBe(false);
+    });
+
+    it('rejects NUL and other C0 control bytes', () => {
+      expect(parseSource(`https://civitai.com/x${NUL}.png`).success).toBe(false);
+      expect(parseSource(`${String.fromCharCode(0x01)}https://civitai.com/x.png`).success).toBe(
+        false
+      );
+      expect(parseSource(`https://civitai.com/x.png${String.fromCharCode(0x7f)}`).success).toBe(
+        false
+      );
+    });
+
+    it('rejects a backslash anywhere, including the path', () => {
+      expect(parseSource(`https://civitai.com/a${BACKSLASH}b.png`).success).toBe(false);
+    });
+  });
+
+  describe('emits a canonicalized value, never the raw input', () => {
+    it('emits URL.href (root path added, default port dropped, host case folded)', () => {
+      expect(emittedUrl('https://civitai.com')).toBe('https://civitai.com/');
+      expect(emittedUrl('https://CIVITAI.com:443/x.png')).toBe('https://civitai.com/x.png');
+      expect(emittedUrl('https://civitai.com/a/../b.png')).toBe('https://civitai.com/b.png');
+    });
+
+    it('emits a value free of backslash, tab, CR and LF', () => {
+      for (const url of [
+        'https://civitai.com',
+        'https://civitai.com/images/xyz.jpeg',
+        'https://image.civitai.com/abc/def.jpeg',
+        'https://CIVITAI.com:443/x.png',
+      ]) {
+        const out = emittedUrl(url);
+        expect(out).not.toContain(BACKSLASH);
+        expect(out).not.toContain(TAB);
+        expect(out).not.toContain(CR);
+        expect(out).not.toContain(LF);
+      }
+    });
+  });
+
+  describe('legitimate URLs are unchanged', () => {
+    it('round-trips every real Civitai image host byte-for-byte', () => {
+      // Canonicalization must be a no-op for the URLs production actually
+      // sends — otherwise this would be a behaviour change, not a hardening.
+      for (const url of [
+        'https://civitai.com/images/xyz.jpeg',
+        'https://image.civitai.com/abc/def.jpeg',
+        'https://orchestration.civitai.com/v2/consumer/blobs/AB1.jpeg?sig=abc&exp=2030-01-01T00:00:00Z',
+        'https://orchestration-new.civitai.com/v2/consumer/blobs/E8S6FBPH50ENNVF2PD5.jpeg',
+        'https://civitai.red/x.png',
+        'https://image.civitai.green/x.png',
+      ]) {
+        expect(emittedUrl(url), url).toBe(url);
+      }
+    });
+  });
+
+  describe('previously-rejected hostile URLs stay rejected', () => {
+    it('rejects userinfo, host confusion, bad schemes, homographs and IP literals', () => {
+      const cyrillicEs = String.fromCharCode(0x0441); // looks like ASCII 'c'
+      for (const url of [
+        'https://civitai.com@evil.com/x.png', // userinfo — real host is evil.com
+        'https://civitai.com%40evil.com/x.png', // percent-encoded userinfo
+        'https://civitai.com.evil.example/x.png', // allowed host as a prefix
+        'https://evilcivitai.com/x.png', // no dot boundary before the allowed host
+        'https://evil.example/?x=image.civitai.com', // allowed host only as a substring
+        'http://image.civitai.com/x.png', // non-https
+        'ftp://image.civitai.com/x.png',
+        'javascript:alert(1)//civitai.com',
+        'data:image/png;base64,AAAA',
+        `https://${cyrillicEs}ivitai.com/x.png`, // homograph -> punycode host
+        'https://civitai.com./x.png', // trailing dot
+        'https://127.0.0.1/x.png',
+        'https://[::1]/x.png',
+        'https://169.254.169.254/latest/meta-data/', // cloud metadata
+      ]) {
+        expect(parseSource(url).success, url).toBe(false);
+      }
+    });
+  });
+
+  describe('the length cap bounds the EMITTED value', () => {
+    it('rejects a raw URL over the cap', () => {
+      const raw = `https://civitai.com/${'a'.repeat(SOURCE_IMAGE_URL_MAX)}`;
+      expect(raw.length).toBeGreaterThan(SOURCE_IMAGE_URL_MAX);
+      expect(parseSource(raw).success).toBe(false);
+    });
+
+    it('rejects an in-cap URL that canonicalization inflates past the cap', () => {
+      // Percent-encoding expands a non-ASCII path ~9x (each CJK code point ->
+      // 3 UTF-8 bytes -> 9 chars). The pre-transform `.max()` therefore does
+      // NOT bound what we emit; the post-transform re-check is what does.
+      const raw = `https://civitai.com/${'中'.repeat(2000)}`;
+      expect(raw.length).toBeLessThanOrEqual(SOURCE_IMAGE_URL_MAX);
+      expect(new URL(raw).href.length).toBeGreaterThan(SOURCE_IMAGE_URL_MAX);
+      expect(parseSource(raw).success).toBe(false);
+    });
+
+    it('accepts a long-but-in-bounds URL and emits it within the cap', () => {
+      const raw = `https://civitai.com/${'a'.repeat(2000)}`;
+      expect(raw.length).toBeLessThanOrEqual(SOURCE_IMAGE_URL_MAX);
+      expect(emittedUrl(raw).length).toBeLessThanOrEqual(SOURCE_IMAGE_URL_MAX);
+    });
   });
 });

--- a/src/server/schema/blocks/workflow.schema.ts
+++ b/src/server/schema/blocks/workflow.schema.ts
@@ -97,11 +97,48 @@ const blockAdditionalResourceSchema = z.object({
 // intentionally tighter than the platform's server `sourceImageSchema`
 // (`.includes('image.civitai.com')`) — a substring check would accept
 // `https://evil.example/?x=image.civitai.com`; a hostname check rejects it and
-// also rejects non-https, userinfo, and host-confusion tricks. Kept LOCAL
-// (rather than importing the server orchestrator schema) so this module stays
-// client-safe — it is `import type`'d by a client component (failureSnapshot).
+// also rejects non-https and userinfo. Kept LOCAL (rather than importing the
+// server orchestrator schema) so this module stays client-safe — it is
+// `import type`'d by a client component (failureSnapshot).
+//
+// 🔴 A hostname check ALONE is not sufficient, because it validates a PARSED
+// url while the schema used to emit the ORIGINAL string. Every consumer
+// downstream (the graph's `imagesNode` is `url: z.string()` — no URL check —
+// so this schema is the only gate) then re-parses those original bytes, and a
+// parser that disagrees with WHATWG about them sees a DIFFERENT host than the
+// one we approved. Two concrete WHATWG-specific behaviours were being relied on
+// as security properties, both verified to pass the bare hostname check:
+//   - backslash-in-authority: WHATWG treats `\` as `/` for special schemes, so
+//     `https://civitai.com\@evil.com/x.png` parses with host `civitai.com`. A
+//     parser that splits the authority on the last `@` without treating `\` as
+//     a delimiter reads host = `evil.com`.
+//   - tab/CR/LF deletion: WHATWG strips `\t\r\n` from ANYWHERE in the url, so
+//     `https://evil.com\r\n.civitai.com/x.png` normalizes to the (nonexistent)
+//     subdomain `evil.com.civitai.com` and passes — while the raw string, CRLF
+//     intact, is what got forwarded. CRLF inside a value a consumer
+//     concatenates into a request line or header is a request-splitting /
+//     log-injection primitive.
+// So the bound is enforced in three layers, in this order:
+//   1. REJECT ambiguous bytes before parsing (below). No legitimate url carries
+//      a raw backslash or control byte — they must be percent-encoded — so this
+//      costs nothing, and it closes the differential class at the door rather
+//      than silently rewriting a plainly hostile input into an accepted one.
+//   2. Validate the parsed hostname (unchanged).
+//   3. CANONICALIZE to `URL.href`, so the bytes we emit are exactly the bytes
+//      we validated. This is the posture fix: it also covers normalization
+//      classes beyond the four bytes above (percent-encoding, default-port
+//      stripping, empty-path → `/`, host case-folding).
 const CIVITAI_IMAGE_HOSTS = ['civitai.com', 'civitai.red', 'civitai.green'] as const;
+// Backslash + C0 controls + DEL. Superset of the `\t\r\n` WHATWG deletes and
+// the leading/trailing C0 it strips, so no byte that the parser silently
+// removes or reinterprets can survive into the value we approve.
+const URL_AMBIGUOUS_BYTES = /[\\\u0000-\u001f\u007f]/;
+// Bound applies to BOTH the raw input and the canonicalized output: percent-
+// encoding can inflate a string ~9x (a 2048-char path of CJK canonicalizes to
+// 18272 chars), so the pre-transform cap does NOT bound what we emit.
+export const SOURCE_IMAGE_URL_MAX = 2048;
 function isCivitaiHostedImageUrl(raw: string): boolean {
+  if (URL_AMBIGUOUS_BYTES.test(raw)) return false;
   let parsed: URL;
   try {
     parsed = new URL(raw);
@@ -114,10 +151,20 @@ function isCivitaiHostedImageUrl(raw: string): boolean {
 }
 
 const blockSourceImageSchema = z.object({
+  // Order is load-bearing. A `.transform()` that THROWS propagates out of
+  // `safeParse` (it does not become a parse failure) — so `new URL()` here must
+  // be total. Zod skips the transform entirely when an earlier check on the
+  // same string failed (verified against zod 4), so by the time it runs, the
+  // refine above has already proven the string parses. Do not reorder these.
   url: z
     .string()
-    .max(2048)
-    .refine(isCivitaiHostedImageUrl, 'source image must be a Civitai-hosted https image URL'),
+    .max(SOURCE_IMAGE_URL_MAX)
+    .refine(isCivitaiHostedImageUrl, 'source image must be a Civitai-hosted https image URL')
+    .transform((raw) => new URL(raw).href)
+    .refine(
+      (href) => href.length <= SOURCE_IMAGE_URL_MAX,
+      'source image URL exceeds the maximum length once canonicalized'
+    ),
   // Dimension hints for the graph's denoise/aspect derivation. Bounded to the
   // same block caps as params so an iframe can't send absurd dimensions.
   width: z.coerce.number().int().min(DIM_MIN).max(DIM_MAX),


### PR DESCRIPTION
## The gap

`blockSourceImageSchema` (`src/server/schema/blocks/workflow.schema.ts`) bounded the img2img source image to a Civitai-hosted host by parsing the string and checking `URL.hostname`. It had no `.transform()`, so the **original string** — not the parsed/normalized one — was what got stored and emitted downstream.

That makes two WHATWG-URL-specific normalizations load-bearing as security properties:

- **backslash-in-authority** — WHATWG treats `\` as `/` for special schemes, so `https://civitai.com\@evil.com/x.png` parses with host `civitai.com` and passes. A parser that splits the authority on the last `@` without treating `\` as a delimiter (Python `urlsplit`; Go, before it errors) reads host = `evil.com`.
- **tab/CR/LF deletion** — WHATWG strips `\t\r\n` from anywhere in the URL, so `https://evil.com\r\n.civitai.com/x.png` normalizes to the (nonexistent) subdomain `evil.com.civitai.com` and passes — while the raw string, **CRLF intact**, is what was forwarded. Raw CRLF in a value a consumer concatenates into a request line, header, or log record is a request-splitting / log-injection primitive.

Reproduced against the pre-change predicate:

```
ACCEPTED  host=civitai.com           raw="https://civitai.com\@evil.com/x.png"
ACCEPTED  host=evil.com.civitai.com  raw="https://evil.com\t.civitai.com/x.png"
ACCEPTED  host=evil.com.civitai.com  raw="https://evil.com\r\n.civitai.com/x.png"
```

Nothing downstream re-validates: the graph's `imagesNode` object form is `url: z.string()` (`src/shared/data-graph/generation/common.ts`) with no URL check. **This schema is the only gate.** The file's own comment claimed the check rejected "host-confusion tricks", which was demonstrably incomplete; that comment is corrected here.

**Exploitability is plausible, not confirmed.** Whether the foreign host is actually reachable depends on the orchestrator's .NET URL parser, which was not tested as part of this change. The posture is wrong regardless — validating a parse and forwarding the original bytes is the bug, independent of which consumer currently disagrees.

**This is pre-existing**, on the singular `sourceImage`, and equally reachable today. It was not introduced by any open PR.

## The fix

Canonicalize rather than validate-and-forward, in three ordered layers:

1. **Reject** bytes the URL parser silently deletes or reinterprets — backslash, C0 controls, DEL — *before* parsing. No legitimate URL carries these raw (they must be percent-encoded), so this has zero legitimate-traffic cost, and it closes the parser-differential class at the door instead of silently rewriting a plainly hostile input into an accepted one. (Canonicalization alone would have *accepted* the CRLF case, normalizing it into an allowlist-passing subdomain.)
2. **Validate the parsed hostname** — unchanged.
3. **Canonicalize to `URL.href`**, so the bytes emitted are exactly the bytes validated. This is the posture fix, and it also covers normalization classes beyond those four bytes (percent-encoding, default-port stripping, empty-path to `/`, host case-folding).

Both layers are kept because they address different failure modes: (1) the check and the consumer disagreeing about the host, (2) the emitted value differing from the validated one at all.

### Length cap ordering

`.max(2048)` applies to the **raw** string, and canonicalization can *lengthen* it — percent-encoding inflates a non-ASCII path ~9x (a 2048-char CJK path canonicalizes to 18,272 chars). The cap is therefore **re-applied after the transform**, and a test asserts an in-cap input that inflates past the cap is rejected.

### Ordering is load-bearing

A `.transform()` that throws **propagates out of `safeParse`** rather than becoming a parse failure — so `new URL()` in the transform must be total. Zod skips the transform entirely when an earlier check on the same string failed (verified against the pinned zod 4), so the refine has already proven the string parses. Noted in a comment so a future reorder doesn't turn a 400 into a 500.

## Consumers that compare the URL by equality

Swept the workflow path for anything that would silently change behaviour now that the emitted string can differ from the raw input. **Nothing affected:**

- **No cache/dedupe/idempotency key is body-derived.** `genIdemRedisKey` uses a client-supplied key; `composeBlockExternalId` / `mintServerBlockExternalId` use identifiers and a UUID; spend caps key on `(userId, day)` / `(appBlockId, day)`. There is no hash of the workflow body anywhere in the blocks path, and `estimateWorkflow` is a mutation, so there is no query cache either.
- **No persistence of the URL.** `upsertBlockWorkflowOnSubmit`, `recordSpendAttribution` and `recordScopeInvocation` store no URL field.
- **No echo to the client.** `BlockWorkflowSnapshot` has no `sourceImage`, so there is no byte-identity contract with the iframe.
- **Estimate and submit both parse through this same schema**, so they canonicalize identically — no path mismatch.
- One URL-keyed lookup exists (`buildResolvedSource`'s `sourceMetadataMap`), but it is **not reachable from blocks** — only the onsite remix path populates it. Worth knowing if blocks ever thread source metadata.
- `shouldRefreshBlobUrl` does run on the block's source URL, and is canonicalization-tolerant: it already parses through `new URL` and matches on a path substring.

Verified that `href` is a **no-op for real traffic** — the orchestrator consumer-blob URLs the shipped upload flow produces (base64 `sig` containing `+`, `/`, `=`, and a colon-bearing ISO `exp`) round-trip byte-for-byte. A test locks this in for all six real host shapes.

## Tests

13 new cases in `src/server/schema/blocks/__tests__/workflow.schema.test.ts` (file goes 21 to 34 tests), all asserting the **emitted** value or an explicit rejection — never merely that parse succeeded:

- Each of the three bypass shapes is rejected, with an assertion that the WHATWG behaviour it relied on is still present (so the test documents *why* it was accepted before).
- CR/LF rejected elsewhere in the URL, not just in the host; NUL/C0/DEL rejected; backslash rejected in the path too.
- Emitted value is `URL.href` (root path added, default port dropped, host case folded) and contains no backslash, tab, CR or LF.
- All six real Civitai image-host URLs round-trip byte-for-byte.
- Previously-rejected hostile inputs stay rejected: `@evil.com` userinfo, `%40` userinfo, suffix confusion, no-dot-boundary, substring-in-query, `http://`, `ftp://`, `javascript:`, `data:`, Cyrillic homograph to punycode, trailing dot, IPv4 literal, IPv6 literal, cloud metadata IP.
- Length cap holds pre- and post-transform.

The bytes under test are built with `String.fromCharCode` rather than string escapes, so a formatter or copy/paste cannot silently defang them.

### Mutation results

Each guard was broken, the specific failing test recorded, then reverted:

| Mutation | Tests killed |
|---|---|
| Ambiguous-byte guard removed entirely | **6** — all three bypass shapes, plus CR/LF-elsewhere, NUL/C0/DEL, backslash-in-path |
| Backslash dropped from the byte class (C0/DEL kept) | **2** — backslash-in-authority, backslash-in-path |
| Canonicalization removed (transform emits raw) | **2** — emits-`URL.href`, post-transform length cap |
| Post-transform length re-check neutralized | **1** — canonicalization-inflates-past-cap |

Control run: 34/34 pass unmutated.

## Verification

- `npx vitest run src/server/services/blocks src/server/schema/blocks` — **105 files, 2040 tests, all passing.**
- `tsc --noEmit` (repo-local `node_modules/.bin/tsc`, TypeScript 5.9.2) — exit 2, **19 errors, byte-identical to the `main` baseline** measured in the same environment. All 19 are in `membership-gift` files and come from a stale generated Prisma client in the local install (`MembershipGift` does exist in `packages/civitai-db-schema/prisma/schema.full.prisma`). **This change contributes zero type errors.**
- No `prettier --write` on existing files; only the one new line of mine that prettier flagged was fixed by hand. The two remaining prettier warnings in these files are pre-existing on `main`.

## Conflict note

**Expect a conflict with #3518**, which widens this same schema from a singular `sourceImage` to an array — multiplying this surface ~7x. This PR is based directly on `main` and is deliberately **not** stacked on it. The fix lands at the shared `blockSourceImageSchema`, so it benefits both the singular and array shapes; the resolution is additive whichever merges first.
