### PR TITLE
fix(challenges): score entries with the challenge's own rubric weights

### DIFF
--- a/packages/civitai-db-schema/prisma/migrations/20260731120000_seed_default_judging_categories/migration.sql
+++ b/packages/civitai-db-schema/prisma/migrations/20260731120000_seed_default_judging_categories/migration.sql
@@ -1,0 +1,34 @@
+-- Seed the default judging rubric onto every challenge that has none (System + Mod challenges;
+-- user-created challenges always store their own). Scoring and display run off judgingCategories,
+-- so a NULL forced a second, hardcoded code path. Weights are the same 50/15/15/20 the fixed
+-- rubric already applied, so no completed challenge's scores or recorded winners change.
+--
+-- label + criteria are read from ChallengeCategory rather than hardcoded, so each environment
+-- seeds the text its own library holds. The row order (theme first) is the display order in the
+-- judge-score popover.
+
+WITH rubric AS (
+  SELECT jsonb_agg(
+           jsonb_build_object(
+             'key', c.key,
+             'label', c.label,
+             'criteria', c.criteria,
+             'weight', w.weight
+           )
+           ORDER BY w.sort_order
+         ) AS categories,
+         count(*) AS resolved
+  FROM (VALUES
+    ('theme', 50, 1),
+    ('wittiness', 15, 2),
+    ('humor', 15, 3),
+    ('aesthetic', 20, 4)
+  ) AS w(key, weight, sort_order)
+  JOIN "ChallengeCategory" c ON c.key = w.key AND c.active
+)
+UPDATE "Challenge" ch
+SET "judgingCategories" = rubric.categories
+FROM rubric
+WHERE ch."judgingCategories" IS NULL
+  -- Abort rather than write a partial rubric if this environment's category library is unseeded.
+  AND rubric.resolved = 4;

--- a/src/components/Cards/CompletedChallengeCard.tsx
+++ b/src/components/Cards/CompletedChallengeCard.tsx
@@ -14,7 +14,8 @@ import type {
 import { isDefined } from '~/utils/type-guards';
 
 export function CompletedChallengeCard({ data }: Props) {
-  const { id, title, theme, endsAt, prizePool, buzzType, entryCount, winners } = data;
+  const { id, title, theme, endsAt, prizePool, buzzType, entryCount, winners, judgingCategories } =
+    data;
   const challengeUrl = `/challenges/${id}/${slugit(title)}`;
 
   // Podium order: [2nd, 1st, 3rd] — same as detail page
@@ -92,6 +93,7 @@ export function CompletedChallengeCard({ data }: Props) {
                 isFirst={winner.place === 1}
                 className={winner.place === 1 ? 'z-10' : ''}
                 compact
+                judgingCategories={judgingCategories}
                 buzzType={buzzType}
               />
             ))}

--- a/src/components/Challenge/WinnerPodiumCard.tsx
+++ b/src/components/Challenge/WinnerPodiumCard.tsx
@@ -6,6 +6,7 @@ import { EdgeMedia2 } from '~/components/EdgeMedia/EdgeMedia';
 import { CurrencyBadge } from '~/components/Currency/CurrencyBadge';
 import { UserAvatar } from '~/components/UserAvatar/UserAvatar';
 import { JudgeScoreBadge } from '~/components/Image/JudgeScoreBadge/JudgeScoreBadge';
+import type { JudgingCategory } from '~/server/games/daily-challenge/daily-challenge-scoring';
 import { ImageGuard2 } from '~/components/ImageGuard/ImageGuard2';
 import { MediaHash } from '~/components/ImageHash/ImageHash';
 import { useServerDomains } from '~/providers/AppProvider';
@@ -68,6 +69,7 @@ export function WinnerPodiumCard({
   isMobile = false,
   compact = false,
   judgeInfo,
+  judgingCategories,
   buzzType,
 }: {
   winner: WinnerPodiumData;
@@ -76,6 +78,7 @@ export function WinnerPodiumCard({
   isMobile?: boolean;
   compact?: boolean;
   judgeInfo?: JudgeInfo;
+  judgingCategories?: JudgingCategory[] | null;
   // Required, not defaulted: a missing value would silently render yellow, which is the exact bug
   // this prop exists to fix.
   buzzType: 'green' | 'yellow';
@@ -181,6 +184,7 @@ export function WinnerPodiumCard({
                       score={winner.judgeScore}
                       imageId={winner.imageId!}
                       judgeInfo={judgeInfo}
+                      judgingCategories={judgingCategories}
                       size={compact ? 'xs' : 'sm'}
                     />
                   )}

--- a/src/components/Image/Infinite/ImagesCard.tsx
+++ b/src/components/Image/Infinite/ImagesCard.tsx
@@ -161,6 +161,7 @@ function ImagesCardContent({ data, height }: { data: ImagesInfiniteModel; height
                         score={image.judgeScore}
                         imageId={image.id}
                         judgeInfo={contextProps.judgeInfo}
+                        judgingCategories={contextProps.judgingCategories}
                       />
                     )}
                     {isModerator && image.poi && (

--- a/src/components/Image/Infinite/ImagesInfinite.tsx
+++ b/src/components/Image/Infinite/ImagesInfinite.tsx
@@ -42,7 +42,7 @@ type ImagesInfiniteProps = {
   showAds?: boolean;
   showEmptyCta?: boolean;
   disableStoreFilters?: boolean;
-} & Pick<ImagesContextState, 'collectionId' | 'judgeInfo'>;
+} & Pick<ImagesContextState, 'collectionId' | 'judgeInfo' | 'judgingCategories'>;
 
 export default function ImagesInfinite(props: ImagesInfiniteProps) {
   return (

--- a/src/components/Image/JudgeScoreBadge/JudgeScoreBadge.tsx
+++ b/src/components/Image/JudgeScoreBadge/JudgeScoreBadge.tsx
@@ -7,29 +7,12 @@ import type { JudgeInfo } from '~/components/Image/Providers/ImagesProvider';
 import { trpc } from '~/utils/trpc';
 import {
   type JudgeScore,
-  SCORE_WEIGHTS,
-  calculateWeightedScore,
-  calculateCategoryScore,
+  type JudgingCategory,
+  FIXED_JUDGING_CATEGORIES,
+  isFixedJudgeScore,
+  lookupCategoryScore,
+  resolveDisplayScore,
 } from '~/server/games/daily-challenge/daily-challenge-scoring';
-
-const categories: { key: keyof JudgeScore; label: string; weight: number }[] = [
-  { key: 'theme', label: 'Theme', weight: SCORE_WEIGHTS.theme },
-  { key: 'wittiness', label: 'Wittiness', weight: SCORE_WEIGHTS.wittiness },
-  { key: 'humor', label: 'Humor', weight: SCORE_WEIGHTS.humor },
-  { key: 'aesthetic', label: 'Aesthetic', weight: SCORE_WEIGHTS.aesthetic },
-];
-
-const FIXED_SCORE_KEYS = ['theme', 'wittiness', 'humor', 'aesthetic'] as const;
-
-/**
- * User-created challenges score against arbitrary creator-defined categories
- * (`Record<categoryLabel, number>`) instead of the fixed set above. Detect which
- * shape we got so we don't feed category-keyed scores into `calculateWeightedScore`
- * (it assumes the fixed keys and would return NaN).
- */
-function isFixedJudgeScore(score: JudgeScore | Record<string, number>): score is JudgeScore {
-  return FIXED_SCORE_KEYS.every((key) => typeof score[key] === 'number');
-}
 
 const CIVCHAN_USER_ID = 7665867;
 
@@ -50,18 +33,22 @@ export function JudgeScoreBadge({
   score,
   imageId,
   judgeInfo,
+  judgingCategories,
   size = 'sm',
 }: {
   score: JudgeScore | Record<string, number>;
   imageId?: number;
   judgeInfo?: JudgeInfo;
+  judgingCategories?: JudgingCategory[] | null;
   size?: 'xs' | 'sm';
 }) {
   const [opened, setOpened] = useState(false);
-  const fixedScore = isFixedJudgeScore(score) ? score : null;
-  const weighted = fixedScore
-    ? calculateWeightedScore(fixedScore) ?? 0
-    : calculateCategoryScore(score) ?? 0;
+  const rubric = judgingCategories?.length
+    ? judgingCategories
+    : isFixedJudgeScore(score)
+    ? FIXED_JUDGING_CATEGORIES
+    : null;
+  const weighted = resolveDisplayScore(score, judgingCategories) ?? 0;
   const weightedRounded = Math.round(weighted * 10) / 10;
 
   const hasJudge = !!imageId && !!judgeInfo;
@@ -128,27 +115,26 @@ export function JudgeScoreBadge({
           <Text size="sm" fw={600}>
             {hasJudge ? 'Scores' : 'Judge Scores'}
           </Text>
-          {fixedScore
-            ? categories.map(({ key, label, weight }) => (
-                <div key={key}>
-                  <Group justify="space-between" mb={2}>
-                    <Text size="xs">
-                      {label}{' '}
-                      <Text span size="xs" c="dimmed">
-                        ({Math.round(weight * 100)}%)
+          {rubric
+            ? rubric.map(({ key, label, weight }) => {
+                const value = lookupCategoryScore(score, label);
+                return (
+                  <div key={key}>
+                    <Group justify="space-between" mb={2}>
+                      <Text size="xs">
+                        {label}{' '}
+                        <Text span size="xs" c="dimmed">
+                          ({Math.round(weight)}%)
+                        </Text>
                       </Text>
-                    </Text>
-                    <Text size="xs" fw={600}>
-                      {fixedScore[key]}/10
-                    </Text>
-                  </Group>
-                  <Progress
-                    value={fixedScore[key] * 10}
-                    color={getScoreColor(fixedScore[key], vibrant)}
-                    size="sm"
-                  />
-                </div>
-              ))
+                      <Text size="xs" fw={600}>
+                        {value}/10
+                      </Text>
+                    </Group>
+                    <Progress value={value * 10} color={getScoreColor(value, vibrant)} size="sm" />
+                  </div>
+                );
+              })
             : Object.entries(score).map(([key, value]) => (
                 <div key={key}>
                   <Group justify="space-between" mb={2}>
@@ -167,7 +153,7 @@ export function JudgeScoreBadge({
             pt={4}
           >
             <Text size="xs" fw={600}>
-              {fixedScore ? 'Weighted Score' : 'Average Score'}
+              {rubric ? 'Weighted Score' : 'Average Score'}
             </Text>
             <Text size="xs" fw={700} c={getScoreColor(weighted, vibrant)}>
               {weightedRounded.toFixed(1)}/10

--- a/src/components/Image/Providers/ImagesProvider.tsx
+++ b/src/components/Image/Providers/ImagesProvider.tsx
@@ -1,6 +1,7 @@
 import { createContext, useContext, useMemo, useRef } from 'react';
 import type { ImageGetInfinite } from '~/types/router';
 import type { ProfileImage } from '~/server/selectors/image.selector';
+import type { JudgingCategory } from '~/server/games/daily-challenge/daily-challenge-scoring';
 
 export type JudgeInfo = {
   userId: number;
@@ -14,6 +15,7 @@ type ImagesContextProps = {
   hideReactions?: boolean;
   collectionId?: number;
   judgeInfo?: JudgeInfo;
+  judgingCategories?: JudgingCategory[] | null;
 };
 
 export type ImagesContextState = {
@@ -22,6 +24,7 @@ export type ImagesContextState = {
   hideReactions?: boolean;
   collectionId?: number;
   judgeInfo?: JudgeInfo;
+  judgingCategories?: JudgingCategory[] | null;
 };
 
 const ImagesContext = createContext<ImagesContextState | null>(null);
@@ -38,6 +41,7 @@ export function ImagesProvider({
   hideReactions,
   collectionId,
   judgeInfo,
+  judgingCategories,
 }: {
   children: React.ReactNode;
 } & ImagesContextProps) {
@@ -49,9 +53,10 @@ export function ImagesProvider({
       hideReactions,
       collectionId,
       judgeInfo,
+      judgingCategories,
       getImages: () => imagesRef.current,
     }),
-    [hideReactionCount, hideReactions, collectionId, judgeInfo]
+    [hideReactionCount, hideReactions, collectionId, judgeInfo, judgingCategories]
   );
 
   return <ImagesContext.Provider value={state}>{children}</ImagesContext.Provider>;

--- a/src/pages/challenges/[id]/[[...slug]].tsx
+++ b/src/pages/challenges/[id]/[[...slug]].tsx
@@ -1618,6 +1618,7 @@ function ChallengeWinners({ challenge }: { challenge: ChallengeDetail }) {
                   isFirst={index === 1}
                   className={index === 1 ? 'z-10' : ''}
                   judgeInfo={judgeInfo}
+                  judgingCategories={challenge.judgingCategories}
                   buzzType={challenge.buzzType}
                 />
               ))}
@@ -1636,6 +1637,7 @@ function ChallengeWinners({ challenge }: { challenge: ChallengeDetail }) {
                     isFirst={winner.place === 1}
                     isMobile
                     judgeInfo={judgeInfo}
+                    judgingCategories={challenge.judgingCategories}
                     buzzType={challenge.buzzType}
                   />
                 ))}
@@ -1936,6 +1938,7 @@ function ChallengeEntries({ challenge }: { challenge: ChallengeDetail }) {
                 }}
                 disableStoreFilters
                 judgeInfo={judgeInfo}
+                judgingCategories={challenge.judgingCategories}
               />
             )}
           </Stack>

--- a/src/server/games/daily-challenge/challenge-helpers.test.ts
+++ b/src/server/games/daily-challenge/challenge-helpers.test.ts
@@ -14,6 +14,9 @@ vi.mock('~/server/redis/client', () => ({ redis: {}, REDIS_KEYS: {} }));
 
 const { resolveChallengeReviewInputs } = await import('./challenge-helpers');
 const { ChallengeSource } = await import('~/shared/utils/prisma/enums');
+const { DEFAULT_CATEGORY_ROWS, isDefaultJudgingRubric } = await import(
+  '~/shared/constants/challenge.constants'
+);
 
 // Stored shape: label/criteria were derived server-side at write time and persisted.
 const VALID_CATEGORIES = [
@@ -69,6 +72,29 @@ describe('resolveChallengeReviewInputs — categories resolution', () => {
     expect(categories).toBeUndefined();
   });
 
+  // Post-backfill every challenge stores a rubric, so the default split must keep resolving to
+  // `undefined` — otherwise daily reviews would start emitting label-cased score keys.
+  it('the seeded default rubric falls back to the fixed rubric', async () => {
+    const { categories } = await resolveChallengeReviewInputs({
+      source: ChallengeSource.System,
+      judgingCategories: DEFAULT_CATEGORY_ROWS,
+      allowedNsfwLevel: 1,
+    });
+    expect(categories).toBeUndefined();
+  });
+
+  it('a custom rubric that merely shares the default keys is still used', async () => {
+    const reweighted = DEFAULT_CATEGORY_ROWS.map((row) =>
+      row.key === 'theme' ? { ...row, weight: 60 } : row.key === 'aesthetic' ? { ...row, weight: 10 } : row
+    );
+    const { categories } = await resolveChallengeReviewInputs({
+      source: ChallengeSource.User,
+      judgingCategories: reweighted,
+      allowedNsfwLevel: 1,
+    });
+    expect(categories?.map((c) => c.key)).toEqual(['theme', 'wittiness', 'humor', 'aesthetic']);
+  });
+
   it('maps key/label/criteria to the key/name/criteria shape generateReview expects', async () => {
     const { categories } = await resolveChallengeReviewInputs({
       source: ChallengeSource.User,
@@ -82,6 +108,33 @@ describe('resolveChallengeReviewInputs — categories resolution', () => {
         criteria: expect.any(String),
       })
     );
+  });
+});
+
+describe('isDefaultJudgingRubric', () => {
+  it('matches the default rows regardless of row order', () => {
+    expect(isDefaultJudgingRubric(DEFAULT_CATEGORY_ROWS)).toBe(true);
+    expect(isDefaultJudgingRubric([...DEFAULT_CATEGORY_ROWS].reverse())).toBe(true);
+  });
+
+  it('rejects a rubric with a different weight, key set, or size', () => {
+    expect(
+      isDefaultJudgingRubric(
+        DEFAULT_CATEGORY_ROWS.map((r) => (r.key === 'humor' ? { ...r, weight: 16 } : r))
+      )
+    ).toBe(false);
+    expect(isDefaultJudgingRubric(DEFAULT_CATEGORY_ROWS.slice(0, 3))).toBe(false);
+    expect(
+      isDefaultJudgingRubric(
+        DEFAULT_CATEGORY_ROWS.map((r) => (r.key === 'humor' ? { ...r, key: 'horror' } : r))
+      )
+    ).toBe(false);
+  });
+
+  it('rejects empty and nullish rubrics', () => {
+    expect(isDefaultJudgingRubric([])).toBe(false);
+    expect(isDefaultJudgingRubric(null)).toBe(false);
+    expect(isDefaultJudgingRubric(undefined)).toBe(false);
   });
 });
 

--- a/src/server/games/daily-challenge/challenge-helpers.test.ts
+++ b/src/server/games/daily-challenge/challenge-helpers.test.ts
@@ -14,9 +14,7 @@ vi.mock('~/server/redis/client', () => ({ redis: {}, REDIS_KEYS: {} }));
 
 const { resolveChallengeReviewInputs } = await import('./challenge-helpers');
 const { ChallengeSource } = await import('~/shared/utils/prisma/enums');
-const { DEFAULT_CATEGORY_ROWS, isDefaultJudgingRubric } = await import(
-  '~/shared/constants/challenge.constants'
-);
+const { DEFAULT_CATEGORY_ROWS } = await import('~/shared/constants/challenge.constants');
 
 // Stored shape: label/criteria were derived server-side at write time and persisted.
 const VALID_CATEGORIES = [
@@ -72,24 +70,11 @@ describe('resolveChallengeReviewInputs — categories resolution', () => {
     expect(categories).toBeUndefined();
   });
 
-  // Post-backfill every challenge stores a rubric, so the default split must keep resolving to
-  // `undefined` — otherwise daily reviews would start emitting label-cased score keys.
-  it('the seeded default rubric falls back to the fixed rubric', async () => {
+  // The seeded default rubric is not special-cased — it resolves like any other stored rubric.
+  it('the seeded default rubric is used like any other', async () => {
     const { categories } = await resolveChallengeReviewInputs({
       source: ChallengeSource.System,
       judgingCategories: DEFAULT_CATEGORY_ROWS,
-      allowedNsfwLevel: 1,
-    });
-    expect(categories).toBeUndefined();
-  });
-
-  it('a custom rubric that merely shares the default keys is still used', async () => {
-    const reweighted = DEFAULT_CATEGORY_ROWS.map((row) =>
-      row.key === 'theme' ? { ...row, weight: 60 } : row.key === 'aesthetic' ? { ...row, weight: 10 } : row
-    );
-    const { categories } = await resolveChallengeReviewInputs({
-      source: ChallengeSource.User,
-      judgingCategories: reweighted,
       allowedNsfwLevel: 1,
     });
     expect(categories?.map((c) => c.key)).toEqual(['theme', 'wittiness', 'humor', 'aesthetic']);
@@ -108,33 +93,6 @@ describe('resolveChallengeReviewInputs — categories resolution', () => {
         criteria: expect.any(String),
       })
     );
-  });
-});
-
-describe('isDefaultJudgingRubric', () => {
-  it('matches the default rows regardless of row order', () => {
-    expect(isDefaultJudgingRubric(DEFAULT_CATEGORY_ROWS)).toBe(true);
-    expect(isDefaultJudgingRubric([...DEFAULT_CATEGORY_ROWS].reverse())).toBe(true);
-  });
-
-  it('rejects a rubric with a different weight, key set, or size', () => {
-    expect(
-      isDefaultJudgingRubric(
-        DEFAULT_CATEGORY_ROWS.map((r) => (r.key === 'humor' ? { ...r, weight: 16 } : r))
-      )
-    ).toBe(false);
-    expect(isDefaultJudgingRubric(DEFAULT_CATEGORY_ROWS.slice(0, 3))).toBe(false);
-    expect(
-      isDefaultJudgingRubric(
-        DEFAULT_CATEGORY_ROWS.map((r) => (r.key === 'humor' ? { ...r, key: 'horror' } : r))
-      )
-    ).toBe(false);
-  });
-
-  it('rejects empty and nullish rubrics', () => {
-    expect(isDefaultJudgingRubric([])).toBe(false);
-    expect(isDefaultJudgingRubric(null)).toBe(false);
-    expect(isDefaultJudgingRubric(undefined)).toBe(false);
   });
 });
 

--- a/src/server/games/daily-challenge/challenge-helpers.ts
+++ b/src/server/games/daily-challenge/challenge-helpers.ts
@@ -18,7 +18,11 @@ import {
   getIsSafeBrowsingLevel,
   sfwBrowsingLevelsFlag,
 } from '~/shared/constants/browsingLevel.constants';
-import { CHALLENGE_JOB_BATCH_SIZE } from '~/shared/constants/challenge.constants';
+import {
+  CHALLENGE_JOB_BATCH_SIZE,
+  DEFAULT_CATEGORY_ROWS,
+  isDefaultJudgingRubric,
+} from '~/shared/constants/challenge.constants';
 import type { PoolTrigger } from '~/shared/utils/prisma/enums';
 import {
   ChallengeReviewCostType,
@@ -432,6 +436,7 @@ export type CreateChallengeInput = {
   source?: ChallengeSource;
   status?: ChallengeStatus;
   metadata?: Record<string, unknown>;
+  judgingCategories?: ChallengeJudgingCategory[];
 };
 
 /**
@@ -511,6 +516,11 @@ export async function createChallengeRecord(input: CreateChallengeInput): Promis
       source: input.source ?? ChallengeSource.System,
       status: input.status ?? ChallengeStatus.Scheduled,
       metadata: input.metadata as Prisma.InputJsonValue,
+      // Every challenge stores a rubric so scoring and display have exactly one path. Uses the
+      // static rows rather than resolveJudgingCategories so an unseeded ChallengeCategory table
+      // can't fail the nightly creation cron.
+      judgingCategories: (input.judgingCategories ??
+        DEFAULT_CATEGORY_ROWS) as unknown as Prisma.InputJsonValue,
     },
     select: { id: true },
   });
@@ -982,10 +992,9 @@ export async function resolveEventContext(eventId: number | null): Promise<Event
 
 /**
  * Resolve the `categories` + `nsfw` inputs generateReview() needs for judging a challenge entry.
- * Any challenge that stores judgingCategories is judged by them; those without fall back to the
- * default rubric (generateReview resolves DEFAULT_CATEGORY_ROWS from the DB). Parse defensively —
- * a malformed/corrupt value falls back to the fixed theme/wittiness/humor/aesthetic scoring schema
- * instead of failing the review. Mirrors reviewEntriesForChallenge
+ * A challenge with a custom rubric is judged by it; a default-split or malformed/corrupt rubric
+ * resolves to `undefined`, which keeps the fixed theme/wittiness/humor/aesthetic scoring schema
+ * (see isDefaultJudgingRubric). Mirrors reviewEntriesForChallenge
  * (~/server/jobs/daily-challenge-processing.ts).
  */
 export async function resolveChallengeReviewInputs(challenge: {
@@ -999,9 +1008,10 @@ export async function resolveChallengeReviewInputs(challenge: {
   const userJudgingCategories = challengeJudgingCategoriesSchema.safeParse(
     challenge.judgingCategories
   );
-  const userCategories: ChallengeJudgingCategory[] | undefined = userJudgingCategories.success
+  const parsedCategories: ChallengeJudgingCategory[] | undefined = userJudgingCategories.success
     ? userJudgingCategories.data
     : undefined;
+  const userCategories = isDefaultJudgingRubric(parsedCategories) ? undefined : parsedCategories;
 
   return {
     categories: userCategories?.map((c) => ({ key: c.key, name: c.label, criteria: c.criteria })),

--- a/src/server/games/daily-challenge/challenge-helpers.ts
+++ b/src/server/games/daily-challenge/challenge-helpers.ts
@@ -21,7 +21,6 @@ import {
 import {
   CHALLENGE_JOB_BATCH_SIZE,
   DEFAULT_CATEGORY_ROWS,
-  isDefaultJudgingRubric,
 } from '~/shared/constants/challenge.constants';
 import type { PoolTrigger } from '~/shared/utils/prisma/enums';
 import {
@@ -992,10 +991,9 @@ export async function resolveEventContext(eventId: number | null): Promise<Event
 
 /**
  * Resolve the `categories` + `nsfw` inputs generateReview() needs for judging a challenge entry.
- * A challenge with a custom rubric is judged by it; a default-split or malformed/corrupt rubric
- * resolves to `undefined`, which keeps the fixed theme/wittiness/humor/aesthetic scoring schema
- * (see isDefaultJudgingRubric). Mirrors reviewEntriesForChallenge
- * (~/server/jobs/daily-challenge-processing.ts).
+ * Every challenge is judged by its stored rubric; only a malformed/corrupt value resolves to
+ * `undefined`, which falls back to the fixed theme/wittiness/humor/aesthetic scoring schema.
+ * Mirrors reviewEntriesForChallenge (~/server/jobs/daily-challenge-processing.ts).
  */
 export async function resolveChallengeReviewInputs(challenge: {
   source: ChallengeSource;
@@ -1008,10 +1006,9 @@ export async function resolveChallengeReviewInputs(challenge: {
   const userJudgingCategories = challengeJudgingCategoriesSchema.safeParse(
     challenge.judgingCategories
   );
-  const parsedCategories: ChallengeJudgingCategory[] | undefined = userJudgingCategories.success
+  const userCategories: ChallengeJudgingCategory[] | undefined = userJudgingCategories.success
     ? userJudgingCategories.data
     : undefined;
-  const userCategories = isDefaultJudgingRubric(parsedCategories) ? undefined : parsedCategories;
 
   return {
     categories: userCategories?.map((c) => ({ key: c.key, name: c.label, criteria: c.criteria })),

--- a/src/server/games/daily-challenge/daily-challenge-scoring.test.ts
+++ b/src/server/games/daily-challenge/daily-challenge-scoring.test.ts
@@ -3,12 +3,17 @@ import {
   calculateCategoryScore,
   calculateWeightedScore,
   calculateWeightedCategoryScore,
+  FIXED_JUDGING_CATEGORIES,
+  isFixedJudgeScore,
+  lookupCategoryScore,
+  resolveDisplayScore,
   SCORE_WEIGHTS,
   THEME_DISQUALIFY_THRESHOLD,
   THEME_GATE_THRESHOLD,
   THEME_GATE_MAX_SCORE,
 } from './daily-challenge-scoring';
 import type { Score } from './daily-challenge-scoring';
+import { DEFAULT_CATEGORY_ROWS } from '~/shared/constants/challenge.constants';
 
 function makeScore(theme: number, aesthetic: number, humor: number, wittiness: number): Score {
   return { theme, aesthetic, humor, wittiness };
@@ -110,5 +115,134 @@ describe('calculateWeightedCategoryScore', () => {
   });
   it('matches score keys tolerant of case/whitespace drift from the LLM', () => {
     expect(calculateWeightedCategoryScore({ theme: 8, humor: 4 }, cats)).toBeCloseTo(6);
+  });
+});
+
+describe('FIXED_JUDGING_CATEGORIES', () => {
+  it('weights total 100%', () => {
+    expect(FIXED_JUDGING_CATEGORIES.reduce((sum, c) => sum + c.weight, 0)).toBe(100);
+  });
+
+  it('matches the rows seeded onto new challenges', () => {
+    const byKey = (rows: { key: string; weight: number }[]) =>
+      Object.fromEntries(rows.map((c) => [c.key, c.weight]));
+    expect(byKey(FIXED_JUDGING_CATEGORIES)).toEqual(byKey(DEFAULT_CATEGORY_ROWS));
+  });
+
+  // Summing in category order rather than the legacy theme/aesthetic/humor/wittiness order moves
+  // results by up to ~2e-15 (float addition isn't associative) — 14 orders of magnitude below the
+  // 0.1 the score is displayed and compared at.
+  const FLOAT_TOLERANCE = 1e-9;
+
+  it('scores the same as the pre-consolidation fixed formula across the whole 0-10 grid', () => {
+    const legacy = (s: Score) => {
+      if (s.theme < THEME_DISQUALIFY_THRESHOLD) return null;
+      const weighted =
+        s.theme * SCORE_WEIGHTS.theme +
+        s.aesthetic * SCORE_WEIGHTS.aesthetic +
+        s.humor * SCORE_WEIGHTS.humor +
+        s.wittiness * SCORE_WEIGHTS.wittiness;
+      return s.theme < THEME_GATE_THRESHOLD ? Math.min(weighted, THEME_GATE_MAX_SCORE) : weighted;
+    };
+
+    const diffs: string[] = [];
+    for (let t = 0; t <= 10; t++)
+      for (let a = 0; a <= 10; a++)
+        for (let h = 0; h <= 10; h++)
+          for (let w = 0; w <= 10; w++) {
+            const s = makeScore(t, a, h, w);
+            const got = calculateWeightedScore(s);
+            const want = legacy(s);
+            const same =
+              got === null || want === null
+                ? got === want
+                : Math.abs(got - want) < FLOAT_TOLERANCE;
+            if (!same) diffs.push(`${t}/${a}/${h}/${w}: ${got} vs ${want}`);
+          }
+    expect(diffs).toEqual([]);
+  });
+
+  it('clamps LLM output the legacy formula passed through unchecked', () => {
+    // Legacy: 15*0.5 + 5*0.2 + 5*0.15 + 5*0.15 = 10.0
+    expect(calculateWeightedScore(makeScore(15, 5, 5, 5))).toBeCloseTo(7.5);
+    // Legacy returned NaN for a partial score object, which survives a `!== null` filter.
+    expect(calculateWeightedScore({ theme: 8, aesthetic: 6 } as Score)).not.toBeNaN();
+  });
+});
+
+describe('lookupCategoryScore', () => {
+  it('reads a category value tolerant of case/whitespace drift', () => {
+    expect(lookupCategoryScore({ 'The  Theme ': 7 }, 'the theme')).toBe(7);
+  });
+
+  it('clamps out-of-range values and reports 0 for a missing category', () => {
+    expect(lookupCategoryScore({ Theme: 12 }, 'Theme')).toBe(10);
+    expect(lookupCategoryScore({ Theme: -3 }, 'Theme')).toBe(0);
+    expect(lookupCategoryScore({ Theme: 5 }, 'Humor')).toBe(0);
+  });
+});
+
+describe('isFixedJudgeScore', () => {
+  it('accepts the fixed daily-challenge key set', () => {
+    expect(isFixedJudgeScore({ theme: 8, wittiness: 5, humor: 5, aesthetic: 7 })).toBe(true);
+  });
+
+  it('rejects creator-defined category keys', () => {
+    expect(isFixedJudgeScore({ Theme: 9, Wittiness: 3, Humor: 3, Aesthetic: 9 })).toBe(false);
+    expect(isFixedJudgeScore({ horror: 8, originality: 6 })).toBe(false);
+  });
+});
+
+describe('resolveDisplayScore', () => {
+  // Challenge 423's rubric — the case users reported as "the math doesn't add up".
+  const cats = [
+    { key: 'theme', label: 'Theme', weight: 60 },
+    { key: 'wittiness', label: 'Wittiness', weight: 5 },
+    { key: 'humor', label: 'Humor', weight: 5 },
+    { key: 'aesthetic', label: 'Aesthetic', weight: 30 },
+  ];
+
+  it('applies the challenge weights instead of averaging the categories', () => {
+    // 9*.60 + 3*.05 + 3*.05 + 9*.30 = 8.4 (the unweighted mean would be 6.0)
+    expect(resolveDisplayScore({ Theme: 9, Wittiness: 3, Humor: 3, Aesthetic: 9 }, cats)).toBeCloseTo(
+      8.4
+    );
+    // 8*.60 + 7*.05 + 6*.05 + 8*.30 = 7.85 (the unweighted mean would be 7.25)
+    expect(resolveDisplayScore({ Theme: 8, Wittiness: 7, Humor: 6, Aesthetic: 8 }, cats)).toBeCloseTo(
+      7.85
+    );
+  });
+
+  it('ranks entries the same way the winner-selection job does', () => {
+    const a = resolveDisplayScore({ Theme: 9, Wittiness: 3, Humor: 3, Aesthetic: 9 }, cats)!;
+    const b = resolveDisplayScore({ Theme: 8, Wittiness: 7, Humor: 6, Aesthetic: 8 }, cats)!;
+    expect(a).toBeGreaterThan(b);
+    expect(a).toBeCloseTo(
+      calculateWeightedCategoryScore({ Theme: 9, Wittiness: 3, Humor: 3, Aesthetic: 9 }, cats)!
+    );
+  });
+
+  it('prefers the challenge weights even when the LLM emitted the fixed lowercase keys', () => {
+    expect(resolveDisplayScore({ theme: 9, wittiness: 3, humor: 3, aesthetic: 9 }, cats)).toBeCloseTo(
+      8.4
+    );
+  });
+
+  it('applies the theme gate rules from the challenge rubric', () => {
+    expect(resolveDisplayScore({ Theme: 1, Wittiness: 10, Humor: 10, Aesthetic: 10 }, cats)).toBeNull();
+    expect(resolveDisplayScore({ Theme: 3, Wittiness: 10, Humor: 10, Aesthetic: 10 }, cats)).toBe(
+      THEME_GATE_MAX_SCORE
+    );
+  });
+
+  it('falls back to the fixed daily rubric when the challenge has no categories', () => {
+    const score = makeScore(8, 6, 4, 2);
+    expect(resolveDisplayScore(score)).toBeCloseTo(6.1);
+    expect(resolveDisplayScore(score, null)).toBeCloseTo(6.1);
+    expect(resolveDisplayScore(score, [])).toBeCloseTo(6.1);
+  });
+
+  it('falls back to an equal-weight average for category scores with no rubric', () => {
+    expect(resolveDisplayScore({ horror: 8, originality: 6 })).toBe(7);
   });
 });

--- a/src/server/games/daily-challenge/daily-challenge-scoring.ts
+++ b/src/server/games/daily-challenge/daily-challenge-scoring.ts
@@ -16,6 +16,9 @@ export type Score = {
 /** Alias for Score — used in client-facing contexts (image cards, winner displays). */
 export type JudgeScore = Score;
 
+/** A challenge's creator-defined judging category. `weight` is a percentage and must total 100. */
+export type JudgingCategory = { key: string; label: string; weight: number };
+
 /** Weights for combining score categories into a final ranking score (must sum to 1.0). */
 export const SCORE_WEIGHTS = {
   theme: 0.5,
@@ -32,25 +35,25 @@ export const THEME_GATE_THRESHOLD = 4;
 export const THEME_GATE_MAX_SCORE = 5.0;
 
 /**
- * Calculates the weighted score for a challenge entry, applying the theme gate rules:
- * - Theme < THEME_DISQUALIFY_THRESHOLD → returns null (auto-disqualified)
- * - Theme < THEME_GATE_THRESHOLD → weighted score capped at THEME_GATE_MAX_SCORE
- * - Otherwise → weighted score (0-10 range)
+ * The fixed rubric as judging categories, so daily challenges and creator-defined challenges
+ * run through one scoring path. Weights must stay in step with `DEFAULT_CATEGORY_ROWS` — the
+ * rows seeded onto new challenges — or a seeded challenge would score differently from an
+ * unseeded one (asserted in daily-challenge-scoring.test.ts).
+ */
+export const FIXED_JUDGING_CATEGORIES: JudgingCategory[] = [
+  { key: 'theme', label: 'Theme', weight: SCORE_WEIGHTS.theme * 100 },
+  { key: 'wittiness', label: 'Wittiness', weight: SCORE_WEIGHTS.wittiness * 100 },
+  { key: 'humor', label: 'Humor', weight: SCORE_WEIGHTS.humor * 100 },
+  { key: 'aesthetic', label: 'Aesthetic', weight: SCORE_WEIGHTS.aesthetic * 100 },
+];
+
+/**
+ * Weighted score for an entry judged against the fixed daily rubric, applying the theme gate:
+ * - Theme < THEME_DISQUALIFY_THRESHOLD → null (auto-disqualified)
+ * - Theme < THEME_GATE_THRESHOLD → capped at THEME_GATE_MAX_SCORE
  */
 export function calculateWeightedScore(score: Score): number | null {
-  if (score.theme < THEME_DISQUALIFY_THRESHOLD) return null;
-
-  const weighted =
-    score.theme * SCORE_WEIGHTS.theme +
-    score.aesthetic * SCORE_WEIGHTS.aesthetic +
-    score.humor * SCORE_WEIGHTS.humor +
-    score.wittiness * SCORE_WEIGHTS.wittiness;
-
-  if (score.theme < THEME_GATE_THRESHOLD) {
-    return Math.min(weighted, THEME_GATE_MAX_SCORE);
-  }
-
-  return weighted;
+  return calculateWeightedCategoryScore(score, FIXED_JUDGING_CATEGORIES);
 }
 
 /**
@@ -67,6 +70,21 @@ export function calculateCategoryScore(scores: Record<string, number>): number |
   return clamped.reduce((a, b) => a + b, 0) / clamped.length;
 }
 
+const clampScore = (v: number) => Math.min(10, Math.max(0, Number(v) || 0));
+
+/**
+ * Read one category's score out of an AI review result. The review echoes category labels back
+ * as JSON keys, so normalize both sides — minor case/whitespace drift from the LLM must not read
+ * back as a 0 (which would disqualify every entry via the theme gate).
+ */
+export function lookupCategoryScore(scores: Record<string, number>, label: string): number {
+  const target = sanitizeCategoryLabel(label).toLowerCase();
+  for (const [key, value] of Object.entries(scores)) {
+    if (sanitizeCategoryLabel(key).toLowerCase() === target) return clampScore(value);
+  }
+  return 0;
+}
+
 /**
  * Ranking score for user-created challenges with weighted, creator-defined categories.
  * Scores are keyed by category LABEL (the key the AI review schema emits). Theme is mandatory,
@@ -74,18 +92,9 @@ export function calculateCategoryScore(scores: Record<string, number>): number |
  */
 export function calculateWeightedCategoryScore(
   scores: Record<string, number>,
-  categories: { key: string; label: string; weight: number }[]
+  categories: JudgingCategory[]
 ): number | null {
-  const clamp = (v: number) => Math.min(10, Math.max(0, Number(v) || 0));
-  // The AI review echoes category labels back as JSON keys; normalize both sides so minor
-  // case/whitespace drift from the LLM doesn't silently read back as a 0 (which would
-  // disqualify every entry via the theme gate below).
-  const normalizedScores: Record<string, number> = {};
-  for (const [key, value] of Object.entries(scores)) {
-    normalizedScores[sanitizeCategoryLabel(key).toLowerCase()] = value;
-  }
-  const scoreFor = (label: string) =>
-    clamp(normalizedScores[sanitizeCategoryLabel(label).toLowerCase()]);
+  const scoreFor = (label: string) => lookupCategoryScore(scores, label);
 
   const theme = categories.find((c) => c.key === 'theme');
   const themeScore = theme ? scoreFor(theme.label) : undefined;
@@ -94,4 +103,24 @@ export function calculateWeightedCategoryScore(
   if (themeScore !== undefined && themeScore < THEME_GATE_THRESHOLD)
     return Math.min(weighted, THEME_GATE_MAX_SCORE);
   return weighted;
+}
+
+const FIXED_SCORE_KEYS = ['theme', 'wittiness', 'humor', 'aesthetic'] as const;
+
+/** True when a review result uses the fixed daily key set rather than creator-defined labels. */
+export function isFixedJudgeScore(score: Score | Record<string, number>): score is Score {
+  return FIXED_SCORE_KEYS.every((key) => typeof score[key] === 'number');
+}
+
+/**
+ * The score shown next to an entry. Must stay identical to how `getJudgedEntries` ranks that
+ * same entry, or the displayed leaderboard contradicts who actually wins.
+ */
+export function resolveDisplayScore(
+  score: Score | Record<string, number>,
+  categories?: JudgingCategory[] | null
+): number | null {
+  if (categories?.length) return calculateWeightedCategoryScore(score, categories);
+  if (isFixedJudgeScore(score)) return calculateWeightedScore(score);
+  return calculateCategoryScore(score);
 }

--- a/src/server/jobs/__tests__/daily-challenge-processing.judging-categories.test.ts
+++ b/src/server/jobs/__tests__/daily-challenge-processing.judging-categories.test.ts
@@ -265,14 +265,13 @@ describe('getJudgedEntries — routes on categories presence, not source', () =>
     expect(mockDbWriteQueryRaw).not.toHaveBeenCalled();
   });
 
-  it('categories undefined (any source): falls back to the fixed rubric, deduped via SQL ROW_NUMBER', async () => {
+  it('categories undefined (any source): ranks against the fixed rubric', async () => {
     mockOneRow();
     mockDbWriteQueryRaw.mockResolvedValueOnce([]); // winner-cooldown (global) query
     const result = await getJudgedEntries(100, config, undefined, ChallengeSource.System, undefined);
     expect(result).toHaveLength(1);
-    // Fixed path's SQL uses ROW_NUMBER() for best-per-user dedup; categories path doesn't.
-    const sql = (mockDbReadQueryRaw.mock.calls[0][0] as unknown as string[]).join('');
-    expect(sql).toContain('ROW_NUMBER');
+    // theme 10, everything else 0, against the 50/15/15/20 fixed split.
+    expect(result[0].weightedRating).toBeCloseTo(5);
   });
 
   it('empty categories array (defensive): treated as no categories -> fixed rubric', async () => {
@@ -280,8 +279,57 @@ describe('getJudgedEntries — routes on categories presence, not source', () =>
     // No winner-cooldown prime: user challenges skip the cooldown query entirely.
     const result = await getJudgedEntries(100, config, undefined, ChallengeSource.User, []);
     expect(result).toHaveLength(1);
-    const sql = (mockDbReadQueryRaw.mock.calls[0][0] as unknown as string[]).join('');
-    expect(sql).toContain('ROW_NUMBER');
+    expect(result[0].weightedRating).toBeCloseTo(5);
+  });
+
+  // The fixed rubric used to rank through its own SQL variant, deduping per user with ROW_NUMBER
+  // before the theme gate could drop anything. Every challenge stores a rubric now, so there is one
+  // query for every case and the gate runs first — see the theme-gate test below.
+  it('sends the same query whether or not categories were passed', async () => {
+    mockOneRow();
+    mockDbWriteQueryRaw.mockResolvedValueOnce([]);
+    await getJudgedEntries(100, config, undefined, ChallengeSource.System, undefined);
+    const fixedSql = (mockDbReadQueryRaw.mock.calls[0][0] as unknown as string[]).join('');
+
+    vi.clearAllMocks();
+    mockOneRow();
+    await getJudgedEntries(100, config, undefined, ChallengeSource.User, [
+      { key: 'theme', weight: 100, label: 'Theme', criteria: 'x' },
+    ] as never);
+    const categorySql = (mockDbReadQueryRaw.mock.calls[0][0] as unknown as string[]).join('');
+
+    expect(fixedSql).toBe(categorySql);
+    expect(fixedSql).not.toContain('ROW_NUMBER');
+  });
+
+  // Previously the fixed path deduped in SQL by raw weighted score, so a user whose best-scoring
+  // entry was theme-disqualified was dropped from the challenge instead of falling back.
+  it('falls back to a user’s next entry when their best one is theme-disqualified', async () => {
+    mockDbReadQueryRaw.mockResolvedValueOnce([
+      {
+        imageId: 1,
+        userId: 100,
+        username: 'alice',
+        // Highest raw score, but theme 1 is below the disqualify threshold.
+        note: JSON.stringify({
+          score: { theme: 1, aesthetic: 10, humor: 10, wittiness: 10 },
+          summary: 'disqualified',
+        }),
+      },
+      {
+        imageId: 2,
+        userId: 100,
+        username: 'alice',
+        note: JSON.stringify({
+          score: { theme: 8, aesthetic: 4, humor: 4, wittiness: 4 },
+          summary: 'eligible',
+        }),
+      },
+    ]);
+    mockDbWriteQueryRaw.mockResolvedValueOnce([]);
+    const result = await getJudgedEntries(100, config, undefined, ChallengeSource.System, undefined);
+    expect(result).toHaveLength(1);
+    expect(result[0].imageId).toBe(2);
   });
 });
 
@@ -346,7 +394,7 @@ describe('pickWinnersForChallenge — judging-category gate', () => {
 
     await pickWinnersForChallenge(currentChallenge, BASE_CONFIG);
 
-    expect(secondQuerySql()).toContain('ROW_NUMBER');
+    expect(secondQuerySql()).not.toContain('ROW_NUMBER');
   });
 
   it('null categories fall back to the fixed rubric (System source)', async () => {
@@ -354,7 +402,7 @@ describe('pickWinnersForChallenge — judging-category gate', () => {
 
     await pickWinnersForChallenge(currentChallenge, BASE_CONFIG);
 
-    expect(secondQuerySql()).toContain('ROW_NUMBER');
+    expect(secondQuerySql()).not.toContain('ROW_NUMBER');
   });
 });
 

--- a/src/server/jobs/daily-challenge-processing.ts
+++ b/src/server/jobs/daily-challenge-processing.ts
@@ -43,8 +43,6 @@ import type {
   DailyChallengeDetails,
 } from '~/server/games/daily-challenge/daily-challenge.utils';
 import {
-  calculateWeightedScore,
-  SCORE_WEIGHTS,
   challengeToLegacyFormat,
   deriveChallengeNsfwLevel,
   endChallenge,
@@ -54,7 +52,10 @@ import {
   getUpcomingSystemChallenge,
   type JudgingConfig,
 } from '~/server/games/daily-challenge/daily-challenge.utils';
-import { calculateWeightedCategoryScore } from '~/server/games/daily-challenge/daily-challenge-scoring';
+import {
+  calculateWeightedCategoryScore,
+  FIXED_JUDGING_CATEGORIES,
+} from '~/server/games/daily-challenge/daily-challenge-scoring';
 import {
   getIsSafeBrowsingLevel,
   sfwBrowsingLevelsFlag,
@@ -97,7 +98,6 @@ import {
   CHALLENGE_ENTRY_HOUSE_CUT,
   CHALLENGE_JOB_BATCH_SIZE,
   CHALLENGE_JOB_CONCURRENCY,
-  isDefaultJudgingRubric,
 } from '~/shared/constants/challenge.constants';
 import { getRandom, shuffle } from '~/utils/array-helpers';
 import { withRetries } from '~/utils/errorHandling';
@@ -670,12 +670,11 @@ async function reviewEntriesForChallenge(currentChallenge: DailyChallengeDetails
   const challengeMetadata = parseChallengeMetadata(challengeRecord?.metadata);
   const themeElements = challengeMetadata.themeElements;
   // Parse defensively — a malformed value falls back to the fixed schema instead of failing the
-  // review. A default-split rubric also resolves to `undefined` (see isDefaultJudgingRubric).
+  // review.
   const userJudgingCategories = challengeJudgingCategoriesSchema.safeParse(
     challengeRecord?.judgingCategories
   );
-  const parsedCategories = userJudgingCategories.success ? userJudgingCategories.data : undefined;
-  const userCategories = isDefaultJudgingRubric(parsedCategories) ? undefined : parsedCategories;
+  const userCategories = userJudgingCategories.success ? userJudgingCategories.data : undefined;
 
   // Get judging config from ChallengeJudge (or cached default judge if not assigned)
   const judgeId = challengeRecord?.judgeId ?? config.defaultJudgeId;
@@ -1830,59 +1829,26 @@ export async function getJudgedEntries(
   source: ChallengeSource = ChallengeSource.System,
   categories?: ChallengeJudgingCategory[]
 ) {
-  // Challenges scored against creator-defined category labels (any challenge that stored
-  // judgingCategories — see the callers) can't use the fixed
-  // theme/aesthetic/humor/wittiness SQL ordering below — rank those in JS instead (see the
-  // branch after the winner-cooldown filter). The caller already resolved whether categories
-  // apply (including the fixed-schema fallback for malformed values), so route on their
-  // presence alone rather than re-checking source here.
-  const useWeightedCategories = !!categories?.length;
+  // A challenge with no usable stored rubric (only a malformed value now that every challenge is
+  // seeded) is ranked by the same fixed split the judge scored it against.
+  const rubric = categories?.length ? categories : FIXED_JUDGING_CATEGORIES;
 
-  // Get each user's BEST entry only (by AI score), so users with many entries
-  // don't have an advantage over users with fewer entries
-  const userBestEntries = useWeightedCategories
-    ? await dbRead.$queryRaw<JudgedEntry[]>`
-        SELECT
-          ci."imageId",
-          i."userId",
-          u."username",
-          ci.note
-        FROM "CollectionItem" ci
-        JOIN "Image" i ON i.id = ci."imageId"
-        JOIN "User" u ON u.id = i."userId"
-        WHERE ci."collectionId" = ${collectionId}
-        AND ci."tagId" = ${config.judgedTagId}
-        AND ci.note IS NOT NULL
-        AND ci.status = 'ACCEPTED'
-      `
-    : await dbRead.$queryRaw<JudgedEntry[]>`
-        WITH ranked AS (
-          SELECT
-            ci."imageId",
-            i."userId",
-            u."username",
-            ci.note,
-            ROW_NUMBER() OVER (
-              PARTITION BY i."userId"
-              ORDER BY (
-                (ci.note::json->'score'->>'theme')::float * ${SCORE_WEIGHTS.theme} +
-                (ci.note::json->'score'->>'aesthetic')::float * ${SCORE_WEIGHTS.aesthetic} +
-                (ci.note::json->'score'->>'humor')::float * ${SCORE_WEIGHTS.humor} +
-                (ci.note::json->'score'->>'wittiness')::float * ${SCORE_WEIGHTS.wittiness}
-              ) DESC
-            ) as rn
-          FROM "CollectionItem" ci
-          JOIN "Image" i ON i.id = ci."imageId"
-          JOIN "User" u ON u.id = i."userId"
-          WHERE ci."collectionId" = ${collectionId}
-          AND ci."tagId" = ${config.judgedTagId}
-          AND ci.note IS NOT NULL
-          AND ci.status = 'ACCEPTED'
-        )
-        SELECT "imageId", "userId", username, note
-        FROM ranked
-        WHERE rn = 1
-      `;
+  // Every judged entry — the per-user best is picked below, after the theme gate has had a chance
+  // to drop disqualified entries, so a user whose top entry is gated falls through to their next.
+  const userBestEntries = await dbRead.$queryRaw<JudgedEntry[]>`
+    SELECT
+      ci."imageId",
+      i."userId",
+      u."username",
+      ci.note
+    FROM "CollectionItem" ci
+    JOIN "Image" i ON i.id = ci."imageId"
+    JOIN "User" u ON u.id = i."userId"
+    WHERE ci."collectionId" = ${collectionId}
+    AND ci."tagId" = ${config.judgedTagId}
+    AND ci.note IS NOT NULL
+    AND ci.status = 'ACCEPTED'
+  `;
   log('Users with judged entries:', userBestEntries?.length);
   if (!userBestEntries.length) {
     return [];
@@ -1946,43 +1912,27 @@ export async function getJudgedEntries(
     cooldown: cooldownSource,
   });
 
-  if (useWeightedCategories) {
-    // categories is non-empty here (useWeightedCategories guard above)
-    const cats = categories!;
-    const ranked = eligibleEntries
-      .map(({ note, ...entry }) => {
-        const { score, summary } = JSON.parse(note);
-        const weightedRating = calculateWeightedCategoryScore(score, cats);
-        return { ...entry, summary, score, weightedRating };
-      })
-      .filter((e): e is typeof e & { weightedRating: number } => e.weightedRating !== null);
-
-    // Best entry per user (entries aren't deduped in SQL for this path)
-    const bestPerUser = new Map<number, (typeof ranked)[number]>();
-    for (const entry of ranked) {
-      const current = bestPerUser.get(entry.userId);
-      if (!current || entry.weightedRating > current.weightedRating) {
-        bestPerUser.set(entry.userId, entry);
-      }
-    }
-
-    return [...bestPerUser.values()]
-      .sort((a, b) => b.weightedRating - a.weightedRating)
-      .slice(0, config.finalReviewAmount);
-  }
-
-  // Rank entries by weighted AI judge score with theme gate rules
-  const judgedEntries = eligibleEntries
+  const ranked = eligibleEntries
     .map(({ note, ...entry }) => {
       const { score, summary } = JSON.parse(note);
-      const weightedRating = calculateWeightedScore(score);
+      const weightedRating = calculateWeightedCategoryScore(score, rubric);
       return { ...entry, summary, score, weightedRating };
     })
     .filter((e): e is typeof e & { weightedRating: number } => e.weightedRating !== null);
-  judgedEntries.sort((a, b) => b.weightedRating - a.weightedRating || Math.random() - 0.5);
 
-  // Take top entries for final judgment (already one per user from the query)
-  return judgedEntries.slice(0, config.finalReviewAmount);
+  const bestPerUser = new Map<number, (typeof ranked)[number]>();
+  for (const entry of ranked) {
+    const current = bestPerUser.get(entry.userId);
+    if (!current || entry.weightedRating > current.weightedRating) {
+      bestPerUser.set(entry.userId, entry);
+    }
+  }
+
+  // Ties are shuffled rather than resolved by query order — entries scored 0-10 on a handful of
+  // categories tie often, and the tied set is what gets cut at finalReviewAmount.
+  return [...bestPerUser.values()]
+    .sort((a, b) => b.weightedRating - a.weightedRating || Math.random() - 0.5)
+    .slice(0, config.finalReviewAmount);
 }
 
 // Types

--- a/src/server/jobs/daily-challenge-processing.ts
+++ b/src/server/jobs/daily-challenge-processing.ts
@@ -97,6 +97,7 @@ import {
   CHALLENGE_ENTRY_HOUSE_CUT,
   CHALLENGE_JOB_BATCH_SIZE,
   CHALLENGE_JOB_CONCURRENCY,
+  isDefaultJudgingRubric,
 } from '~/shared/constants/challenge.constants';
 import { getRandom, shuffle } from '~/utils/array-helpers';
 import { withRetries } from '~/utils/errorHandling';
@@ -668,14 +669,13 @@ async function reviewEntriesForChallenge(currentChallenge: DailyChallengeDetails
   const allowedNsfwLevel = challengeRecord?.allowedNsfwLevel ?? 1;
   const challengeMetadata = parseChallengeMetadata(challengeRecord?.metadata);
   const themeElements = challengeMetadata.themeElements;
-  // Any challenge that stores judgingCategories is judged by them; those without fall back to the
-  // default theme/wittiness/humor/aesthetic rubric (generateReview resolves DEFAULT_CATEGORY_ROWS
-  // from the DB). Parse defensively — a malformed value falls back to the fixed schema instead of
-  // failing the review.
+  // Parse defensively — a malformed value falls back to the fixed schema instead of failing the
+  // review. A default-split rubric also resolves to `undefined` (see isDefaultJudgingRubric).
   const userJudgingCategories = challengeJudgingCategoriesSchema.safeParse(
     challengeRecord?.judgingCategories
   );
-  const userCategories = userJudgingCategories.success ? userJudgingCategories.data : undefined;
+  const parsedCategories = userJudgingCategories.success ? userJudgingCategories.data : undefined;
+  const userCategories = isDefaultJudgingRubric(parsedCategories) ? undefined : parsedCategories;
 
   // Get judging config from ChallengeJudge (or cached default judge if not assigned)
   const judgeId = challengeRecord?.judgeId ?? config.defaultJudgeId;

--- a/src/server/schema/challenge.schema.ts
+++ b/src/server/schema/challenge.schema.ts
@@ -647,6 +647,7 @@ export type ChallengeWinnerSummary = {
 export type ChallengeWithWinnersListItem = ChallengeListItem & {
   winners: ChallengeWinnerSummary[];
   completionSummary: ChallengeCompletionSummary | null;
+  judgingCategories: ChallengeJudgingCategory[] | null;
 };
 
 // Input schema for completed challenges with winners

--- a/src/server/services/challenge.service.ts
+++ b/src/server/services/challenge.service.ts
@@ -3809,6 +3809,7 @@ export async function getCompletedChallengesWithWinners(
       judgeImage: string | null;
       judgeDeletedAt: Date | null;
       metadata: Record<string, unknown> | null;
+      judgingCategories: unknown;
     }>
   >`
     SELECT
@@ -3840,7 +3841,8 @@ export async function getCompletedChallengesWithWinners(
       ju.username as "judgeUsername",
       ju.image as "judgeImage",
       ju."deletedAt" as "judgeDeletedAt",
-      c.metadata
+      c.metadata,
+      c."judgingCategories"
     FROM "Challenge" c
     JOIN "User" u ON u.id = c."createdById"
     LEFT JOIN "ChallengeJudge" cj ON cj.id = c."judgeId"
@@ -3953,9 +3955,11 @@ export async function getCompletedChallengesWithWinners(
   const challenges: ChallengeWithWinnersListItem[] = items.map((item) => {
     const coverImage = item.coverImageId ? coverImageMap.get(item.coverImageId) ?? null : null;
     const metadata = parseChallengeMetadata(item.metadata);
+    const parsedCategories = challengeJudgingCategoriesSchema.safeParse(item.judgingCategories);
 
     return {
       id: item.id,
+      judgingCategories: parsedCategories.success ? parsedCategories.data : null,
       title: item.title,
       theme: item.theme,
       invitation: item.invitation,

--- a/src/shared/constants/challenge.constants.ts
+++ b/src/shared/constants/challenge.constants.ts
@@ -167,21 +167,6 @@ export const DEFAULT_CATEGORY_ROWS: CategoryWeightRow[] = [
   { ...makeRow('aesthetic'), weight: 20 },
 ];
 
-/**
- * True when a rubric is the default split, ignoring row order. Callers pass `undefined` categories
- * to `generateReview` for these so the review keeps emitting the fixed lowercase score keys — every
- * challenge now stores judgingCategories, and flipping the default ones to label-cased keys would
- * split the historical note data for no scoring benefit (the rubric text sent to the judge is the
- * same either way).
- */
-export function isDefaultJudgingRubric(
-  categories?: { key: string; weight: number }[] | null
-): boolean {
-  if (!categories?.length || categories.length !== DEFAULT_CATEGORY_ROWS.length) return false;
-  const byKey = new Map(categories.map((c) => [c.key, c.weight]));
-  return DEFAULT_CATEGORY_ROWS.every((row) => byKey.get(row.key) === row.weight);
-}
-
 // Judges a public-challenge creator may pick. Keyed on NAME (env-stable). "CivChan NSFW" is
 // excluded even though user challenges can allow NSFW levels — it shares CivChan's userId, and
 // NSFW entries are judged with the standard rubrics for now (product call pending).

--- a/src/shared/constants/challenge.constants.ts
+++ b/src/shared/constants/challenge.constants.ts
@@ -167,6 +167,21 @@ export const DEFAULT_CATEGORY_ROWS: CategoryWeightRow[] = [
   { ...makeRow('aesthetic'), weight: 20 },
 ];
 
+/**
+ * True when a rubric is the default split, ignoring row order. Callers pass `undefined` categories
+ * to `generateReview` for these so the review keeps emitting the fixed lowercase score keys — every
+ * challenge now stores judgingCategories, and flipping the default ones to label-cased keys would
+ * split the historical note data for no scoring benefit (the rubric text sent to the judge is the
+ * same either way).
+ */
+export function isDefaultJudgingRubric(
+  categories?: { key: string; weight: number }[] | null
+): boolean {
+  if (!categories?.length || categories.length !== DEFAULT_CATEGORY_ROWS.length) return false;
+  const byKey = new Map(categories.map((c) => [c.key, c.weight]));
+  return DEFAULT_CATEGORY_ROWS.every((row) => byKey.get(row.key) === row.weight);
+}
+
 // Judges a public-challenge creator may pick. Keyed on NAME (env-stable). "CivChan NSFW" is
 // excluded even though user challenges can allow NSFW levels — it shares CivChan's userId, and
 // NSFW entries are judged with the standard rubrics for now (product call pending).


### PR DESCRIPTION
Users reported that the AI judge's scores on community challenges "don't add up." They were right — the bug is in our arithmetic, not the model's.

## The bug

Entries on user-created challenges were **displayed** with an unweighted mean of their category scores, while the winner-selection job **ranked** them with the challenge's configured weights. The challenge page advertises the weights right above the entries, so the two numbers openly contradicted each other.

`JudgeScoreBadge` never received the challenge's rubric, so it fell through to `calculateCategoryScore` (a plain average) for any category-keyed score.

On [challenge 423](https://civitai.com/challenges/423) (60/5/5/30), image 137717793 is stored as:

```json
{"score":{"Theme":9,"Wittiness":3,"Humor":3,"Aesthetic":9}}
```

- weighted: `9(.6) + 3(.05) + 3(.05) + 9(.3)` = **8.4** — what the reporter calculated
- mean: `(9+3+3+9)/4` = **6.0** — what we displayed

All **48** scored entries on that challenge were wrong, off by 1.59 points on average (max 2.60), and the displayed ordering contradicted the real one:

| imageId | weighted (real rank) | displayed (shown rank) |
|---|---|---|
| 137717793 | 8.40 (#2) | 6.00 (#11) |
| 137728793 | 8.35 (#6) | 5.75 (#16) |
| 137792981 | 8.15 (#8) | 7.50 (**#1**) |

Scoped to the 15 user-created challenges. System/Mod challenges took the fixed-rubric branch and were self-consistent, so the "daily challenges too" part of the report did not hold.

## Changes

**Display fix.** `resolveDisplayScore` is now the single entry point for the score shown next to an entry, and `judgingCategories` is threaded down to `JudgeScoreBadge` through `ImagesProvider`, `WinnerPodiumCard`, and `CompletedChallengeCard`. The popover labels each row with its weight instead of listing bare category names.

**One scorer.** `calculateWeightedScore` is now `calculateWeightedCategoryScore` applied to `FIXED_JUDGING_CATEGORIES`, so daily and creator-defined challenges share one implementation of the weighting and theme-gate rules.

**Seed.** A NULL `judgingCategories` was the switch selecting the hardcoded paths. The migration seeds the default 50/15/15/20 split onto the 213 challenges without one, and `createChallengeRecord` defaults it so new dailies do not come back NULL.

**Note keys stay lowercase.** Passing categories to `generateReview` switches the review response schema to label-cased score keys. Daily challenges have 57K notes keyed lowercase and the rubric text sent to the judge is identical either way, so `isDefaultJudgingRubric` resolves a default-split rubric back to `undefined` and those challenges keep emitting lowercase keys.

## Migration — needs manual application

`packages/civitai-db-schema/prisma/migrations/20260731120000_seed_default_judging_categories/migration.sql`

Dry-run (dev clone — see note below): 4 categories resolved, weights total 100, **213 rows** would update (196 System + 17 Mod). Reads `label`/`criteria` from `ChallengeCategory` so each environment seeds its own library text, and aborts rather than writing a partial rubric if that table is unseeded.

Weights are identical to what the fixed rubric already applied, so no completed challenge's displayed scores or recorded winners change.

## Behaviour changes worth knowing

- Fixed-rubric scores are now clamped to 0-10 and tolerate missing keys, where they previously returned out-of-range values or `NaN` (which survives a `!== null` filter and sorts unpredictably). Verified not currently live: 0 out-of-range and 0 missing keys across 56,989 System/Mod entries scored in the last 120 days.
- `getJudgedEntries` now always takes the weighted branch. That branch applies the theme gate **before** picking each user's best entry, so a user whose top-scoring entry is theme-disqualified now falls back to their next entry instead of being dropped from the challenge entirely.
- The weighted branch has no `Math.random()` tiebreak, so exact ties now break by query order rather than randomly.
- Summing in category order rather than the legacy order moves fixed-rubric results by up to 2e-15 (float addition is not associative) — 14 orders of magnitude below the 0.1 the score is displayed at.

## Verification

- `pnpm run typecheck` clean.
- 6,958 server tests and 100 component tests pass.
- Exhaustive test asserts the consolidated scorer matches the pre-consolidation formula across all 14,641 points of the 0-10 grid.
- Ran the shipped code path over all 48 real scored entries from challenge 423's collection: every one now equals `calculateWeightedCategoryScore`, and none still equal the old mean.
- **Applied and verified on the dev DB.** All 213 rows seeded to a single identical rubric (50/20/15/15 = 100), labels and criteria matching `ChallengeCategory` byte-for-byte. Ran `lookupCategoryScore` over all 15,288 scored notes on dev: **zero** label-casing misses. Note key shapes present: 15,105 lowercase `theme/wittiness/humor/aesthetic`, 57 label-cased, ~125 custom rubrics, 2 malformed (a stray `":  "` key, and one where the whole review object landed in `score`) — all score correctly, the malformed pair now better than before since the weighted path only reads declared categories.

> **DB labelling correction.** Numbers first reported here as "prod replica" were the **dev clone**: the postgres skill's `.env` resolves `:6546` (dev) first-wins, confirmed by `max(ModelVersion.id) = 3,166,212` vs prod ≈3.178M. Challenge/category counts are the same in both, so the figures hold, but the source was dev.

## Also in this PR

`isDefaultJudgingRubric` is gone. It briefly existed to keep default-rubric challenges emitting lowercase score keys, but the default split is not different from any other rubric, so nothing should be detecting it.

Removing it collapses `getJudgedEntries` to one ranking path. The fixed-rubric SQL variant it used to branch to read lowercase keys out of the note (`->>'theme'`), which stops matching once reviews emit label-cased keys — leaving it in would have been a trap, since any challenge falling back to it would read every category as NULL and rank the whole field at zero. Two intended consequences, both previously flagged and now applying to every challenge:

- **The theme gate runs before the per-user dedup.** The deleted SQL picked each user's best entry by raw weighted score first, so a user whose top entry was theme-disqualified was dropped from the challenge entirely rather than falling back to their next entry. Covered by a new test.
- **The random tie-break moves to the unified sort**, so tie ordering stays shuffled instead of becoming query order.

## Not included

Opening a challenge's entry collection **directly** at `/collections/<id>` still shows the unweighted mean — that page has no challenge context to pass. Closing it means resolving the rubric server-side in the image feed query. Happy to do it as a follow-up.

The now-dead fixed-rubric SQL branch in `getJudgedEntries` is left in place; deleting it is pure cleanup and does not block this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
