### PR TITLE
feat(cosmetic-shop): creators can accept Blue Buzz for shop items (Cl…

### DIFF
--- a/src/components/CosmeticShop/CosmeticShopItemPreviewModal.tsx
+++ b/src/components/CosmeticShop/CosmeticShopItemPreviewModal.tsx
@@ -137,7 +137,7 @@ export const CosmeticShopItemPreviewModal = ({ shopItem, viaShopUserId }: Props)
   const resaleShare = parsedMeta.success ? parsedMeta.data.sellerShare : undefined;
 
   // Blue-accepting items let the buyer choose how to pay: the domain color
-  // (default), blue only, or blue first with the rest in the domain color.
+  // (default), or blue first with the rest in the domain color.
   const acceptsBlue = parsedMeta.success && !!parsedMeta.data.acceptsBlueBuzz;
   const [domainType] = useAvailableBuzz();
   const [payWith, setPayWith] = useState<PayWithOption>('default');

--- a/src/components/CosmeticShop/CosmeticShopItemPreviewModal.tsx
+++ b/src/components/CosmeticShop/CosmeticShopItemPreviewModal.tsx
@@ -13,9 +13,14 @@ import {
   UnstyledButton,
   useMantineTheme,
 } from '@mantine/core';
+import { useState } from 'react';
 import { CosmeticType } from '~/shared/utils/prisma/enums';
 import { useRouter } from 'next/router';
 import { BuzzTransactionButton } from '~/components/Buzz/BuzzTransactionButton';
+import { useAvailableBuzz } from '~/components/Buzz/useAvailableBuzz';
+import type { PayWithOption } from '~/components/CosmeticShop/PayWithSelector';
+import { PayWithSelector } from '~/components/CosmeticShop/PayWithSelector';
+import type { BuzzSpendType } from '~/shared/constants/buzz.constants';
 import { useMutateCosmeticShop } from '~/components/CosmeticShop/cosmetic-shop.util';
 import {
   useEquipProfileDecoration,
@@ -130,6 +135,14 @@ export const CosmeticShopItemPreviewModal = ({ shopItem, viaShopUserId }: Props)
   // Resold items carry the seller share so the buyer sees who earns what.
   const parsedMeta = cosmeticShopItemMeta.safeParse(shopItem.meta);
   const resaleShare = parsedMeta.success ? parsedMeta.data.sellerShare : undefined;
+
+  // Blue-accepting items let the buyer choose how to pay: the domain color
+  // (default), blue only, or blue first with the rest in the domain color.
+  const acceptsBlue = parsedMeta.success && !!parsedMeta.data.acceptsBlueBuzz;
+  const [domainType] = useAvailableBuzz();
+  const [payWith, setPayWith] = useState<PayWithOption>('default');
+  const accountTypes: BuzzSpendType[] =
+    !acceptsBlue || payWith === 'default' ? [domainType] : ['blue', domainType];
   // The split note only shows for cross-creator resale — not on the official
   // Civitai shop, and not when buying the creator's own item on their own
   // storefront (the creator keeps the full pool there).
@@ -146,7 +159,11 @@ export const CosmeticShopItemPreviewModal = ({ shopItem, viaShopUserId }: Props)
 
   const handlePurchaseShopItem = async () => {
     try {
-      const userCosmetic = await purchaseShopItem({ shopItemId: shopItem.id, viaShopUserId });
+      const userCosmetic = await purchaseShopItem({
+        shopItemId: shopItem.id,
+        viaShopUserId,
+        payWith: acceptsBlue ? payWith : undefined,
+      });
 
       showSuccessNotification({
         message: 'Your purchase has been completed and your cosmetic is now available to equip',
@@ -223,14 +240,25 @@ export const CosmeticShopItemPreviewModal = ({ shopItem, viaShopUserId }: Props)
                   </Paper>
                 )}
                 {canPurchase ? (
-                  <BuzzTransactionButton
-                    disabled={purchasingShopItem || !isAvailable}
-                    loading={purchasingShopItem}
-                    buzzAmount={shopItem.unitAmount}
-                    radius="xl"
-                    onPerformTransaction={handlePurchaseShopItem}
-                    label="Purchase"
-                  />
+                  <Stack gap={6}>
+                    {acceptsBlue && isAvailable && (
+                      <PayWithSelector
+                        value={payWith}
+                        onChange={setPayWith}
+                        domainType={domainType}
+                      />
+                    )}
+                    <BuzzTransactionButton
+                      disabled={purchasingShopItem || !isAvailable}
+                      loading={purchasingShopItem}
+                      buzzAmount={shopItem.unitAmount}
+                      radius="xl"
+                      onPerformTransaction={handlePurchaseShopItem}
+                      label="Purchase"
+                      accountTypes={accountTypes}
+                      showTypePct={acceptsBlue && payWith === 'blue-first'}
+                    />
+                  </Stack>
                 ) : (
                   <Stack gap={4}>
                     <Button radius="xl" onClick={handleEquipDecoration} loading={isEquipping}>

--- a/src/components/CosmeticShop/PayWithSelector.stories.tsx
+++ b/src/components/CosmeticShop/PayWithSelector.stories.tsx
@@ -1,0 +1,28 @@
+import { useState } from 'react';
+import type { PayWithOption } from '~/components/CosmeticShop/PayWithSelector';
+import { PayWithSelector } from '~/components/CosmeticShop/PayWithSelector';
+import type { BuzzSpendType } from '~/shared/constants/buzz.constants';
+
+function Preview({
+  initial = 'default',
+  domainType = 'yellow',
+}: {
+  initial?: PayWithOption;
+  domainType?: BuzzSpendType;
+}) {
+  const [value, setValue] = useState<PayWithOption>(initial);
+  return (
+    <div style={{ width: 330, minHeight: 150 }}>
+      <PayWithSelector value={value} onChange={setValue} domainType={domainType} />
+    </div>
+  );
+}
+
+/** Yellow domain, domain color selected (default state) */
+export const Default = () => <Preview />;
+
+/** Blue + Yellow selected */
+export const BothSelected = () => <Preview initial="blue-first" />;
+
+/** Green domain (civitai.green) */
+export const GreenDomain = () => <Preview domainType="green" />;

--- a/src/components/CosmeticShop/PayWithSelector.tsx
+++ b/src/components/CosmeticShop/PayWithSelector.tsx
@@ -1,0 +1,131 @@
+import { Group, Popover, Text, UnstyledButton } from '@mantine/core';
+import { IconBolt, IconCheck, IconChevronDown } from '@tabler/icons-react';
+import clsx from 'clsx';
+import { useState } from 'react';
+import type { BuzzSpendType } from '~/shared/constants/buzz.constants';
+import { getBuzzCurrencyConfig } from '~/shared/constants/currency.constants';
+
+export type PayWithOption = 'default' | 'blue-first';
+
+const Bolt = ({ type }: { type: BuzzSpendType }) => {
+  const { color } = getBuzzCurrencyConfig(type);
+  return <IconBolt size={16} color={color} fill={color} className="shrink-0" />;
+};
+
+// Payment picker for blue-accepting shop items: the domain color alone, or
+// blue first with the rest in the domain color. A compact select-style trigger
+// that opens a dropdown, so it takes a single row in the purchase modal.
+export function PayWithSelector({
+  value,
+  onChange,
+  domainType,
+}: {
+  value: PayWithOption;
+  onChange: (value: PayWithOption) => void;
+  domainType: BuzzSpendType;
+}) {
+  const [opened, setOpened] = useState(false);
+  const domainLabel = domainType === 'green' ? 'Green' : 'Yellow';
+  const domainColor = getBuzzCurrencyConfig(domainType).color;
+  const blueColor = getBuzzCurrencyConfig('blue').color;
+  const wash = (color: string) => `color-mix(in srgb, ${color} 14%, transparent)`;
+
+  const options: {
+    value: PayWithOption;
+    label: string;
+    caption: string;
+    bolts: BuzzSpendType[];
+    background: string;
+  }[] = [
+    {
+      value: 'default',
+      label: `${domainLabel} Buzz`,
+      caption: `Pay the full price in ${domainLabel}`,
+      bolts: [domainType],
+      background: wash(domainColor),
+    },
+    {
+      value: 'blue-first',
+      label: `Blue + ${domainLabel}`,
+      caption: `Use your Blue first, the rest in ${domainLabel}`,
+      bolts: ['blue', domainType],
+      background: `linear-gradient(90deg, ${wash(blueColor)}, ${wash(domainColor)})`,
+    },
+  ];
+  const selected = options.find((option) => option.value === value) ?? options[0];
+
+  return (
+    <Popover
+      opened={opened}
+      onChange={setOpened}
+      width="target"
+      position="bottom"
+      radius="md"
+      shadow="md"
+    >
+      <Popover.Target>
+        <UnstyledButton
+          onClick={() => setOpened((o) => !o)}
+          aria-label="Choose how to pay"
+          className="w-full rounded-md border border-solid border-gray-3 px-3 py-2 transition-colors hover:bg-gray-0 dark:border-dark-4 dark:hover:bg-dark-5"
+        >
+          <Group gap={8} wrap="nowrap" justify="space-between">
+            <Group gap={8} wrap="nowrap">
+              <Text size="xs" c="dimmed" className="shrink-0">
+                Pay with
+              </Text>
+              <Group gap={2} wrap="nowrap">
+                {selected.bolts.map((type) => (
+                  <Bolt key={type} type={type} />
+                ))}
+              </Group>
+              <Text size="sm" fw={500} lh={1.3} truncate>
+                {selected.label}
+              </Text>
+            </Group>
+            <IconChevronDown
+              size={16}
+              className={clsx('shrink-0 transition-transform', opened && 'rotate-180')}
+            />
+          </Group>
+        </UnstyledButton>
+      </Popover.Target>
+      <Popover.Dropdown p={4}>
+        <div className="flex flex-col gap-1">
+          {options.map((option) => {
+            const isSelected = option.value === value;
+            return (
+              <UnstyledButton
+                key={option.value}
+                onClick={() => {
+                  onChange(option.value);
+                  setOpened(false);
+                }}
+                aria-pressed={isSelected}
+                className="rounded-md px-2 py-1.5 transition-colors hover:bg-gray-1 dark:hover:bg-dark-5"
+                style={isSelected ? { background: option.background } : undefined}
+              >
+                <Group gap={8} wrap="nowrap">
+                  <Group gap={2} wrap="nowrap">
+                    {option.bolts.map((type) => (
+                      <Bolt key={type} type={type} />
+                    ))}
+                  </Group>
+                  <div className="flex min-w-0 flex-1 flex-col">
+                    <Text size="sm" fw={isSelected ? 600 : 500} lh={1.3}>
+                      {option.label}
+                    </Text>
+                    <Text size="xs" c="dimmed" lh={1.3}>
+                      {option.caption}
+                    </Text>
+                  </div>
+                  {isSelected && <IconCheck size={16} className="shrink-0 text-green-500" />}
+                </Group>
+              </UnstyledButton>
+            );
+          })}
+        </div>
+      </Popover.Dropdown>
+    </Popover>
+  );
+}

--- a/src/components/CreatorShop/CreatorShopSubmitModal.tsx
+++ b/src/components/CreatorShop/CreatorShopSubmitModal.tsx
@@ -53,6 +53,7 @@ export function CreatorShopSubmitModal({ item }: { item?: CreatorShopManageItem 
     animated,
     sellableByOthers,
     sellerShare,
+    acceptsBlueBuzz,
     offsets,
     offsetsChanged,
     imageId,
@@ -88,8 +89,14 @@ export function CreatorShopSubmitModal({ item }: { item?: CreatorShopManageItem 
       description !== (item?.description ?? '') ||
       price !== (item?.unitAmount ?? COSMETIC_PRICE_FLOOR) ||
       offsetsChanged ||
+      form.acceptsBlueBuzzChanged ||
       !!localUrl
-    : !!imageId || !!name.trim() || !!description.trim() || sellableByOthers || offsetsChanged;
+    : !!imageId ||
+      !!name.trim() ||
+      !!description.trim() ||
+      sellableByOthers ||
+      acceptsBlueBuzz ||
+      offsetsChanged;
 
   const handleCancel = () => {
     if (!isDirty) return dialog.onClose();
@@ -262,6 +269,12 @@ export function CreatorShopSubmitModal({ item }: { item?: CreatorShopManageItem 
           </Text>
         </Group>
 
+        <Switch
+          checked={acceptsBlueBuzz}
+          onChange={(e) => form.setAcceptsBlueBuzz(e.currentTarget.checked)}
+          label="Accept Blue Buzz"
+          description="Buyers can pay with Blue Buzz — fully, or combined with their regular Buzz. You're paid blue for the blue-paid portion."
+        />
         {!isEdit && (
           <Stack gap={6}>
             <Switch

--- a/src/components/CreatorShop/Submit/useSubmitCreatorShopForm.ts
+++ b/src/components/CreatorShop/Submit/useSubmitCreatorShopForm.ts
@@ -56,6 +56,10 @@ export function useSubmitCreatorShopForm({
   );
   const [sellableByOthers, setSellableByOthers] = useState(false);
   const [sellerShare, setSellerShare] = useState(0);
+  const itemAcceptsBlueBuzz = !!(item?.meta as { acceptsBlueBuzz?: boolean } | null)
+    ?.acceptsBlueBuzz;
+  const [acceptsBlueBuzz, setAcceptsBlueBuzz] = useState(itemAcceptsBlueBuzz);
+  const acceptsBlueBuzzChanged = acceptsBlueBuzz !== itemAcceptsBlueBuzz;
   // Avatar-decoration fit adjustment (per side, -5..5); all-zero = none stored.
   const [offsets, setOffsetsState] = useState<CosmeticOffsets>(
     (item?.cosmetic.data as { offsets?: CosmeticOffsets } | null)?.offsets ?? {
@@ -174,6 +178,7 @@ export function useSubmitCreatorShopForm({
           payload.animated = animated;
         }
         if (offsetsChanged) payload.offsets = normalizedOffsets;
+        if (acceptsBlueBuzzChanged) payload.acceptsBlueBuzz = acceptsBlueBuzz;
         await updateItem.mutateAsync(payload);
       } else {
         await submitItem.mutateAsync({
@@ -187,6 +192,7 @@ export function useSubmitCreatorShopForm({
           buzzType,
           sellableByOthers,
           sellerShare: sellableByOthers ? sellerShare : 0,
+          acceptsBlueBuzz,
           offsets: normalizedOffsets,
         });
       }
@@ -229,6 +235,9 @@ export function useSubmitCreatorShopForm({
     setSellableByOthers,
     sellerShare,
     setSellerShare,
+    acceptsBlueBuzz,
+    setAcceptsBlueBuzz,
+    acceptsBlueBuzzChanged,
     offsets,
     setOffset,
     offsetsChanged,

--- a/src/server/schema/cosmetic-shop.schema.ts
+++ b/src/server/schema/cosmetic-shop.schema.ts
@@ -54,6 +54,9 @@ export const cosmeticShopItemMeta = z.object({
   // of price (0-70, out of the creator's 70% pool) the reseller keeps.
   sellableByOthers: z.boolean().optional(),
   sellerShare: z.number().optional(),
+  // Creator opt-in: buyers may pay with Blue Buzz (fully or partially). The
+  // creator is paid blue for the blue-paid portion of each sale.
+  acceptsBlueBuzz: z.boolean().optional(),
 });
 
 export type UpsertCosmeticInput = z.infer<typeof upsertCosmeticInput>;
@@ -134,6 +137,10 @@ export const purchaseCosmeticShopItemInput = z.object({
   // The creator whose shop this was bought through — used to credit a reseller
   // (Creator Shop cross-creator selling). Verified server-side.
   viaShopUserId: z.number().optional(),
+  // Buyer's payment choice for items that accept Blue Buzz: the domain color
+  // only (default), or blue first with the remainder in the domain color.
+  // Rejected server-side if the item doesn't accept blue.
+  payWith: z.enum(['default', 'blue-first']).optional(),
 });
 
 export type GetPreviewImagesInput = z.infer<typeof getPreviewImagesInput>;

--- a/src/server/schema/creator-shop.schema.ts
+++ b/src/server/schema/creator-shop.schema.ts
@@ -145,6 +145,9 @@ export const submitCreatorShopItemSchema = z.object({
   // price (0-70, out of the creator's 70% pool).
   sellableByOthers: z.boolean().default(false),
   sellerShare: z.number().int().min(0).max(70).default(0),
+  // Accept Blue Buzz from buyers (fully or partially); the creator is paid
+  // blue for the blue-paid portion.
+  acceptsBlueBuzz: z.boolean().default(false),
   // ProfileDecoration only — per-side fit adjustment (ignored for other types).
   offsets: cosmeticOffsetsSchema.nullish(),
 });
@@ -159,6 +162,8 @@ export const updateCreatorShopItemSchema = z.object({
   animated: z.boolean().optional(),
   price: z.number().int().min(COSMETIC_PRICE_FLOOR).optional(),
   availableQuantity: z.number().int().positive().nullish(),
+  // Payment term like price/quantity — editable on published items, no re-review.
+  acceptsBlueBuzz: z.boolean().optional(),
   // ProfileDecoration only — null clears the adjustment; treated as a content
   // change (same rules as name/description/artwork).
   offsets: cosmeticOffsetsSchema.nullish(),

--- a/src/server/services/__tests__/cosmetic-shop-payout.service.test.ts
+++ b/src/server/services/__tests__/cosmetic-shop-payout.service.test.ts
@@ -9,7 +9,8 @@ const { mocks } = vi.hoisted(() => ({
     purchasesCreate: vi.fn(),
     userCosmeticCreate: vi.fn(),
     createBuzzTransaction: vi.fn(),
-    refundTransaction: vi.fn(),
+    createMultiTx: vi.fn(),
+    refundMultiTx: vi.fn(),
     logToAxiom: vi.fn(),
     getBlockedPairIds: vi.fn(),
   },
@@ -34,9 +35,9 @@ vi.mock('~/server/prom/client', () => ({ dbReadFallbackCounter: { inc: vi.fn() }
 vi.mock('~/server/logging/client', () => ({ logToAxiom: mocks.logToAxiom }));
 vi.mock('~/server/services/buzz.service', () => ({
   createBuzzTransaction: mocks.createBuzzTransaction,
-  createMultiAccountBuzzTransaction: vi.fn(),
-  refundMultiAccountTransaction: vi.fn(),
-  refundTransaction: mocks.refundTransaction,
+  createMultiAccountBuzzTransaction: mocks.createMultiTx,
+  refundMultiAccountTransaction: mocks.refundMultiTx,
+  refundTransaction: vi.fn(),
 }));
 vi.mock('~/server/services/image.service', () => ({
   createEntityImages: vi.fn(),
@@ -84,8 +85,15 @@ const sellCalls = () =>
     .map(([arg]) => arg)
     .filter((arg) => arg.type === TransactionType.Sell);
 
-const purchase = (viaShopUserId?: number) =>
-  purchaseCosmeticShopItem({ userId: BUYER_ID, shopItemId: SHOP_ITEM_ID, viaShopUserId });
+// The buyer's charge, per funding account. Defaults to the whole price in yellow.
+const chargeResponse = (charges: { accountType: string; amount: number }[]) => ({
+  transactionIds: charges.map((c, i) => ({ transactionId: `tx-${i}`, ...c })),
+  totalAmount: charges.reduce((sum, c) => sum + c.amount, 0),
+  transactionCount: charges.length,
+});
+
+const purchase = (viaShopUserId?: number, payWith?: 'default' | 'blue-first') =>
+  purchaseCosmeticShopItem({ userId: BUYER_ID, shopItemId: SHOP_ITEM_ID, viaShopUserId, payWith });
 
 describe('purchaseCosmeticShopItem payouts', () => {
   beforeEach(() => {
@@ -94,6 +102,9 @@ describe('purchaseCosmeticShopItem payouts', () => {
     mocks.userCosmeticFindFirst.mockResolvedValue(null); // buyer doesn't own it yet
     mocks.userCosmeticCreate.mockResolvedValue({ userId: BUYER_ID, cosmeticId: 7 });
     mocks.createBuzzTransaction.mockResolvedValue({ transactionId: 'tx-1' });
+    mocks.createMultiTx.mockResolvedValue(
+      chargeResponse([{ accountType: 'yellow', amount: PRICE }])
+    );
     mocks.getBlockedPairIds.mockResolvedValue([]);
   });
 
@@ -101,7 +112,7 @@ describe('purchaseCosmeticShopItem payouts', () => {
     mocks.getBlockedPairIds.mockResolvedValue([CREATOR_ID]);
 
     await expect(purchase()).rejects.toThrow('Cosmetic is not available');
-    expect(mocks.createBuzzTransaction).not.toHaveBeenCalled();
+    expect(mocks.createMultiTx).not.toHaveBeenCalled();
   });
 
   it('official items (no creator) skip the block lookup entirely', async () => {
@@ -114,13 +125,17 @@ describe('purchaseCosmeticShopItem payouts', () => {
   it('charges the buyer the full price to the bank before paying anyone', async () => {
     await purchase();
 
-    const charge = mocks.createBuzzTransaction.mock.calls[0][0];
+    const charge = mocks.createMultiTx.mock.calls[0][0];
     expect(charge).toMatchObject({
       fromAccountId: BUYER_ID,
+      fromAccountTypes: ['yellow'],
       toAccountId: 0,
       amount: PRICE,
       type: TransactionType.Purchase,
     });
+    expect(charge.externalTransactionIdPrefix).toMatch(
+      new RegExp(`^cosmetic-purchase-${BUYER_ID}-${SHOP_ITEM_ID}-`)
+    );
   });
 
   it('own-storefront purchase (shop enabled) pays the creator the full 70% pool: 7000', async () => {
@@ -137,7 +152,7 @@ describe('purchaseCosmeticShopItem payouts', () => {
         fromAccountId: 0,
         toAccountId: CREATOR_ID,
         amount: 7000,
-        externalTransactionId: 'tx-1',
+        externalTransactionId: expect.stringMatching(`:sell:${CREATOR_ID}:yellow$`),
       }),
     ]);
   });
@@ -204,13 +219,13 @@ describe('purchaseCosmeticShopItem payouts', () => {
           fromAccountId: 0,
           toAccountId: CREATOR_ID,
           amount: 5000,
-          externalTransactionId: `tx-1:${CREATOR_ID}`,
+          externalTransactionId: expect.stringMatching(`:sell:${CREATOR_ID}:yellow$`),
         }),
         expect.objectContaining({
           fromAccountId: 0,
           toAccountId: RESELLER_ID,
           amount: 2000,
-          externalTransactionId: `tx-1:${RESELLER_ID}`,
+          externalTransactionId: expect.stringMatching(`:sell:${RESELLER_ID}:yellow$`),
         }),
       ])
     );
@@ -259,8 +274,16 @@ describe('purchaseCosmeticShopItem payouts', () => {
     await purchase(undefined);
 
     expect(sellCalls()).toEqual([
-      expect.objectContaining({ toAccountId: 11, amount: 5000, externalTransactionId: 'tx-1:11' }),
-      expect.objectContaining({ toAccountId: 22, amount: 5000, externalTransactionId: 'tx-1:22' }),
+      expect.objectContaining({
+        toAccountId: 11,
+        amount: 5000,
+        externalTransactionId: expect.stringMatching(':sell:11:yellow$'),
+      }),
+      expect.objectContaining({
+        toAccountId: 22,
+        amount: 5000,
+        externalTransactionId: expect.stringMatching(':sell:22:yellow$'),
+      }),
     ]);
   });
 
@@ -273,8 +296,8 @@ describe('purchaseCosmeticShopItem payouts', () => {
 
     expect(sellCalls()).toHaveLength(0);
     // The only transaction is the buyer's charge.
-    expect(mocks.createBuzzTransaction).toHaveBeenCalledTimes(1);
-    expect(mocks.createBuzzTransaction.mock.calls[0][0].type).toBe(TransactionType.Purchase);
+    expect(mocks.createBuzzTransaction).not.toHaveBeenCalled();
+    expect(mocks.createMultiTx).toHaveBeenCalledTimes(1);
     // And the payout block didn't silently blow up either.
     expect(mocks.logToAxiom).not.toHaveBeenCalled();
   });
@@ -283,7 +306,77 @@ describe('purchaseCosmeticShopItem payouts', () => {
     await purchase(undefined);
 
     expect(mocks.logToAxiom).not.toHaveBeenCalled();
-    expect(mocks.refundTransaction).not.toHaveBeenCalled();
+    expect(mocks.refundMultiTx).not.toHaveBeenCalled();
+  });
+});
+
+describe('purchaseCosmeticShopItem blue buzz payments', () => {
+  beforeEach(() => {
+    Object.values(mocks).forEach((m) => m.mockReset());
+    mocks.shopItemFindUnique.mockResolvedValue(
+      shopItemRow({ meta: { sellableByOthers: false, acceptsBlueBuzz: true } })
+    );
+    mocks.userCosmeticFindFirst.mockResolvedValue(null);
+    mocks.userCosmeticCreate.mockResolvedValue({ userId: BUYER_ID, cosmeticId: 7 });
+    mocks.createBuzzTransaction.mockResolvedValue({ transactionId: 'tx-1' });
+    mocks.createMultiTx.mockResolvedValue(chargeResponse([{ accountType: 'blue', amount: PRICE }]));
+    mocks.getBlockedPairIds.mockResolvedValue([]);
+  });
+
+  it('rejects blue payment for items that do not accept it, before any charge', async () => {
+    mocks.shopItemFindUnique.mockResolvedValue(shopItemRow({ meta: { sellableByOthers: false } }));
+
+    await expect(purchase(undefined, 'blue-first')).rejects.toThrow('does not accept Blue Buzz');
+    expect(mocks.createMultiTx).not.toHaveBeenCalled();
+  });
+
+  it('fully-covered blue-first purchase pays the creator the whole pool in blue', async () => {
+    await purchase(undefined, 'blue-first');
+
+    expect(mocks.createMultiTx.mock.calls[0][0].fromAccountTypes).toEqual(['blue', 'yellow']);
+    expect(sellCalls()).toEqual([
+      expect.objectContaining({
+        toAccountId: CREATOR_ID,
+        toAccountType: 'blue',
+        amount: 7000,
+        externalTransactionId: expect.stringMatching(`:sell:${CREATOR_ID}:blue$`),
+      }),
+    ]);
+  });
+
+  it('blue-first: drains blue then the domain color, payout pro-rated per color', async () => {
+    // Buyer had 6000 blue; the remaining 4000 came from yellow.
+    mocks.createMultiTx.mockResolvedValue(
+      chargeResponse([
+        { accountType: 'blue', amount: 6000 },
+        { accountType: 'yellow', amount: 4000 },
+      ])
+    );
+
+    await purchase(undefined, 'blue-first');
+
+    expect(mocks.createMultiTx.mock.calls[0][0].fromAccountTypes).toEqual(['blue', 'yellow']);
+    // Creator pool 7000 → floor(7000 * 6000/10000) = 4200 blue + 2800 yellow.
+    expect(sellCalls()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ toAccountId: CREATOR_ID, toAccountType: 'blue', amount: 4200 }),
+        expect.objectContaining({ toAccountId: CREATOR_ID, toAccountType: 'yellow', amount: 2800 }),
+      ])
+    );
+    expect(sellCalls()).toHaveLength(2);
+  });
+
+  it('default payment on a blue-accepting item stays on the domain color', async () => {
+    mocks.createMultiTx.mockResolvedValue(
+      chargeResponse([{ accountType: 'yellow', amount: PRICE }])
+    );
+
+    await purchase(undefined, 'default');
+
+    expect(mocks.createMultiTx.mock.calls[0][0].fromAccountTypes).toEqual(['yellow']);
+    expect(sellCalls()).toEqual([
+      expect.objectContaining({ toAccountId: CREATOR_ID, toAccountType: 'yellow', amount: 7000 }),
+    ]);
   });
 });
 

--- a/src/server/services/__tests__/creator-shop-community.service.test.ts
+++ b/src/server/services/__tests__/creator-shop-community.service.test.ts
@@ -47,7 +47,7 @@ describe('getCommunityCosmetics', () => {
     mocks.shopItemFindMany.mockResolvedValue([itemRow(2), itemRow(1)]);
     const { items, nextCursor } = await getCommunityCosmetics({ limit: 40 });
     expect(items.map((i) => i.id)).toEqual([2, 1]);
-    expect(items[0].meta).toEqual({ purchases: 3 });
+    expect(items[0].meta).toEqual({ purchases: 3, acceptsBlueBuzz: false });
     expect(nextCursor).toBeUndefined();
   });
 

--- a/src/server/services/cosmetic-shop.service.ts
+++ b/src/server/services/cosmetic-shop.service.ts
@@ -26,7 +26,6 @@ import {
   createBuzzTransaction,
   createMultiAccountBuzzTransaction,
   refundMultiAccountTransaction,
-  refundTransaction,
 } from '~/server/services/buzz.service';
 import type { FeatureAccess } from '~/server/services/feature-flags.service';
 import { getBlockedPairIds } from '~/server/services/user-preferences.service';
@@ -552,6 +551,7 @@ export const purchaseCosmeticShopItem = async ({
   userId,
   shopItemId,
   viaShopUserId,
+  payWith = 'default',
   buzzType = 'yellow',
 }: PurchaseCosmeticShopItemInput & {
   userId: number;
@@ -664,22 +664,31 @@ export const purchaseCosmeticShopItem = async ({
 
   const meta = (shopItem.meta ?? {}) as CosmeticShopItemMeta;
 
-  // Confirms user has enough buzz:
-  const transaction = await createBuzzTransaction({
+  // Blue payment is a per-item creator opt-in (meta.acceptsBlueBuzz).
+  if (payWith !== 'default' && !meta.acceptsBlueBuzz) {
+    throw new Error('This item does not accept Blue Buzz');
+  }
+  // 'blue-first' drains blue before completing with the domain color.
+  const fromAccountTypes: BuzzSpendType[] =
+    payWith === 'blue-first' ? ['blue', buzzType] : [buzzType];
+
+  // Confirms user has enough buzz across the chosen accounts:
+  const transactionId = `cosmetic-purchase-${userId}-${shopItemId}-${Date.now()}`;
+  const transaction = await createMultiAccountBuzzTransaction({
     fromAccountId: userId,
-    // Can use a combination of all these accounts:
-    fromAccountType: buzzType,
+    fromAccountTypes,
     toAccountId: 0, // bank
     amount: shopItem.unitAmount,
     type: TransactionType.Purchase,
     description: `Cosmetic purchase - ${shopItem.title}`,
-    externalTransactionId: `cosmetic-purchase-${userId}-${shopItemId}-${Date.now()}`,
+    externalTransactionIdPrefix: transactionId,
   });
-
-  const transactionId = transaction.transactionId;
-  if (!transactionId) {
+  if (!transaction.transactionCount) {
     throw new Error('There was an error creating the transaction');
   }
+  const bluePaid = transaction.transactionIds
+    .filter((t) => t.accountType === 'blue')
+    .reduce((sum, t) => sum + t.amount, 0);
 
   try {
     const data = await dbWrite.$transaction(async (tx) => {
@@ -791,20 +800,29 @@ export const purchaseCosmeticShopItem = async ({
           }));
         }
 
+        // Pay recipients in the same Buzz color(s) the buyer paid with: the
+        // blue-paid portion of the price pays out as blue (pro-rated per
+        // recipient, floored), the rest in the domain color.
+        const payouts = recipients.flatMap((r) => {
+          const blueAmount = price > 0 ? Math.floor((r.amount * bluePaid) / price) : 0;
+          return [
+            { userId: r.userId, amount: blueAmount, color: 'blue' as BuzzSpendType },
+            { userId: r.userId, amount: r.amount - blueAmount, color: buzzType },
+          ].filter((p) => p.amount > 0);
+        });
+
         await Promise.all(
-          recipients.map((r) =>
+          payouts.map((p) =>
             createBuzzTransaction({
               fromAccountId: 0,
-              toAccountId: r.userId,
-              // Pay creators/resellers in the same Buzz color the buyer paid with.
-              toAccountType: buzzType,
-              amount: r.amount,
+              toAccountId: p.userId,
+              toAccountType: p.color,
+              amount: p.amount,
               type: TransactionType.Sell,
               description: `A user has purchased your cosmetic - ${shopItem.title}`,
-              // Unique per recipient when the pool is split, so the two payouts
-              // don't collide on the same external id.
-              externalTransactionId:
-                recipients.length > 1 ? `${transactionId}:${r.userId}` : transactionId,
+              // Unique per recipient and color so payouts never collide on the
+              // same external id.
+              externalTransactionId: `${transactionId}:sell:${p.userId}:${p.color}`,
               details: { purchasedBy: userId, originalAmount: shopItem.unitAmount },
             })
           )
@@ -826,7 +844,10 @@ export const purchaseCosmeticShopItem = async ({
 
     return data;
   } catch (error) {
-    await refundTransaction(transactionId, `Failed to purchase cosmetic - ${shopItem.title}`);
+    await refundMultiAccountTransaction({
+      externalTransactionIdPrefix: transactionId,
+      description: `Failed to purchase cosmetic - ${shopItem.title}`,
+    });
 
     throw new Error('Failed to purchase cosmetic');
   }

--- a/src/server/services/cosmetic-shop.service.ts
+++ b/src/server/services/cosmetic-shop.service.ts
@@ -672,7 +672,11 @@ export const purchaseCosmeticShopItem = async ({
   const fromAccountTypes: BuzzSpendType[] =
     payWith === 'blue-first' ? ['blue', buzzType] : [buzzType];
 
-  // Confirms user has enough buzz across the chosen accounts:
+  // Confirms user has enough buzz across the chosen accounts. The bank credit
+  // lands under the API's default account type — that's bookkeeping only: the
+  // bank is the system ledger, not a balance-constrained account, so the
+  // per-color payouts below don't depend on what the bank was credited in
+  // (auction bids and green-domain purchases have always worked this way).
   const transactionId = `cosmetic-purchase-${userId}-${shopItemId}-${Date.now()}`;
   const transaction = await createMultiAccountBuzzTransaction({
     fromAccountId: userId,

--- a/src/server/services/creator-shop.service.ts
+++ b/src/server/services/creator-shop.service.ts
@@ -221,6 +221,7 @@ export const submitCreatorShopItem = async ({
   buzzType,
   sellableByOthers,
   sellerShare,
+  acceptsBlueBuzz,
   offsets,
 }: SubmitCreatorShopItemInput & { userId: number }) => {
   // Validate the artwork server-side BEFORE charging anything.
@@ -282,6 +283,7 @@ export const submitCreatorShopItem = async ({
             imageHash,
             sellableByOthers,
             sellerShare: sellableByOthers ? sellerShare : 0,
+            acceptsBlueBuzz,
           } satisfies CosmeticShopItemMeta,
         },
         select: creatorShopItemSelect,
@@ -326,6 +328,7 @@ export const updateCreatorShopItem = async ({
   animated,
   price,
   availableQuantity,
+  acceptsBlueBuzz,
   offsets,
 }: UpdateCreatorShopItemInput & { userId: number; isModerator?: boolean }) => {
   const existing = await getOwnedItemOrThrow(id, userId, isModerator);
@@ -348,11 +351,15 @@ export const updateCreatorShopItem = async ({
     : offsets;
 
   // Cross-listings point at another creator's shared cosmetic — the seller may
-  // never touch its art/name/description, only price & quantity.
+  // never touch its art/name/description/payment terms, only price & quantity.
   const isOriginalCreator = isModerator || existing.cosmetic.createdById === userId;
   if (
     !isOriginalCreator &&
-    (name !== undefined || description !== undefined || imageUrl !== undefined || offsetsChange)
+    (name !== undefined ||
+      description !== undefined ||
+      imageUrl !== undefined ||
+      acceptsBlueBuzz !== undefined ||
+      offsetsChange)
   )
     throw throwBadRequestError(
       "You can only change price and quantity for another creator's cosmetic"
@@ -451,6 +458,7 @@ export const updateCreatorShopItem = async ({
       ...(backToReview ? { rejectionReason: null, reviewedById: null, reviewedAt: null } : {}),
       meta: {
         ...meta,
+        ...(acceptsBlueBuzz !== undefined ? { acceptsBlueBuzz } : {}),
         ...(artwork
           ? {
               autoChecks: artwork.checks,
@@ -661,11 +669,14 @@ export const getCreatorShop = async ({
     `.then((r) => r[0]?.count ?? 0),
   ]);
 
-  // Sanitize meta to only the purchase count the card needs — never the creator
+  // Sanitize meta to what the card/checkout needs — never the creator
   // payout/fee internals.
   const sanitize = (item: (typeof items)[number]) => ({
     ...item,
-    meta: { purchases: (item.meta as CosmeticShopItemMeta)?.purchases ?? 0 },
+    meta: {
+      purchases: (item.meta as CosmeticShopItemMeta)?.purchases ?? 0,
+      acceptsBlueBuzz: (item.meta as CosmeticShopItemMeta)?.acceptsBlueBuzz ?? false,
+    },
   });
   const cosmetics = items.map(sanitize);
   // Resold items keep the seller share so the buyer can see the split at checkout.
@@ -674,6 +685,7 @@ export const getCreatorShop = async ({
     meta: {
       purchases: (item.meta as CosmeticShopItemMeta)?.purchases ?? 0,
       sellerShare: (item.meta as CosmeticShopItemMeta)?.sellerShare ?? 0,
+      acceptsBlueBuzz: (item.meta as CosmeticShopItemMeta)?.acceptsBlueBuzz ?? false,
     },
   });
   const resold = preview
@@ -746,10 +758,13 @@ export const getCommunityCosmetics = async ({
   });
   let nextCursor: number | undefined;
   if (raw.length > limit) nextCursor = raw.pop()?.id;
-  // Same meta sanitation as the storefront — cards only need the purchase count.
+  // Same meta sanitation as the storefront.
   const items = raw.map((item) => ({
     ...item,
-    meta: { purchases: (item.meta as CosmeticShopItemMeta)?.purchases ?? 0 },
+    meta: {
+      purchases: (item.meta as CosmeticShopItemMeta)?.purchases ?? 0,
+      acceptsBlueBuzz: (item.meta as CosmeticShopItemMeta)?.acceptsBlueBuzz ?? false,
+    },
   }));
   return { items, nextCursor };
 };


### PR DESCRIPTION
…ickUp 868kjbyvu)

Creator opt-in per item ("Accept Blue Buzz" on the submit modal, also toggleable while editing — a payment term like price/quantity, no re-review). Buyers of blue-accepting items pick how to pay via a select-style dropdown in the purchase modal: the domain color (default) or Blue + domain (drains blue first, remainder from the domain color).

The purchase charge moves to the multi-account Buzz transaction API with prefix-based refunds. Payouts stay in the colors the buyer paid: the blue-paid share of the price pays out as blue (pro-rated per recipient, floored), the rest in the domain color — across creator, reseller, and legacy paidToUserIds splits. The platform cut still banks, so blue spent here remains a sink.