### PR TITLE
fix(monetization): stop tier price caps from capping Early Access

### DIFF
--- a/apps/creator-studio/src/lib/components/PaidAccessEditor.svelte
+++ b/apps/creator-studio/src/lib/components/PaidAccessEditor.svelte
@@ -73,11 +73,15 @@
   // Seed once from the version at mount (the parent remounts via `{#key version.id}` on open).
   let ea = $state(untrack(() => seed(version)));
 
+  // Membership caps bind PERMANENT paid access; a timed early-access window is priced freely at every
+  // tier (CU 868kk3avk), so the ceiling moves with the Access mode toggle.
+  const effectiveCap = $derived(ea.permanent ? priceCap : null);
+
   // max never drops below the stored price: the server blocks only RAISES, so clamping down would silently
   // cut a grandfathered price on any unrelated edit.
   const storedAccess = $derived(version.paidAccessConfig?.accessPrice ?? 0);
-  const accessMax = $derived(priceCap == null ? undefined : Math.max(priceCap, storedAccess));
-  const overCap = $derived(priceCap != null && (ea.accessPrice ?? 0) > priceCap);
+  const accessMax = $derived(effectiveCap == null ? undefined : Math.max(effectiveCap, storedAccess));
+  const overCap = $derived(effectiveCap != null && (ea.accessPrice ?? 0) > effectiveCap);
   // The generation-only tier can't exceed the access price, and neither may exceed the tier's ceiling.
   const genPriceMax = $derived(
     accessMax == null ? ea.accessPrice : Math.min(ea.accessPrice ?? accessMax, accessMax)
@@ -331,14 +335,14 @@
           <span class="text-xs text-dark-2">
             {isGenOnly
               ? 'What buyers pay to generate with this version on-site.'
-              : 'Buyers unlock download + generation.'}{#if priceCap != null}
-              Your membership allows up to {priceCap.toLocaleString()} ⚡.
+              : 'Buyers unlock download + generation.'}{#if effectiveCap != null}
+              Your membership allows up to {effectiveCap.toLocaleString()} ⚡.
             {/if}
           </span>
           <div>
             <CapUpsell
               value={ea.accessPrice}
-              cap={priceCap ?? Infinity}
+              cap={effectiveCap ?? Infinity}
               capTier={caps.capTier}
               capFor={(t) => maxPaidAccessPrice(t, capMediaType(version.baseModel))}
               title="Price for access"

--- a/apps/creator-studio/src/routes/(app)/models/+page.server.ts
+++ b/apps/creator-studio/src/routes/(app)/models/+page.server.ts
@@ -415,11 +415,11 @@ export const actions: Actions = {
     if (isCreatorUsageControl(usageControl))
       await setUsageControl(locals.user.id, versionId.data, usageControl);
 
-    // Price cap applies to timed and permanent alike — the charge is what's capped, not the duration. Only an
-    // INCREASE is rejected: the editor resubmits the stored price on every save, so capping the submitted
-    // value outright would make an over-cap version uneditable after a lapse (the same class of bug that
-    // 82f64846ba had to hot-fix in the main app). Lowering or leaving it alone always passes.
-    if (!locals.user.isModerator) {
+    // Price cap binds PERMANENT paid access only — a timed early-access window is priced freely at every
+    // tier (CU 868kk3avk). Only an INCREASE is rejected: the editor resubmits the stored price on every
+    // save, so capping the submitted value outright would make an over-cap version uneditable after a lapse
+    // (the same class of bug that 82f64846ba had to hot-fix in the main app).
+    if (permanent && !locals.user.isModerator) {
       const priceCap = maxPaidAccessPrice(
         cappedTier(membership),
         await strictestCapMediaType([versionId.data])

--- a/packages/civitai-buzz/src/paid-access.test.ts
+++ b/packages/civitai-buzz/src/paid-access.test.ts
@@ -8,13 +8,16 @@ import {
   grantsGeneration,
   isFreeGeneration,
   isPaidAccessActive,
+  isPermanentGate,
   isTimedGateActive,
   paidGenerationGrant,
   CAP_TIERS,
   nextCapTier,
   shouldUpsellCap,
   cappedTerms,
+  effectivePaidAccessPrice,
   maxPaidAccessPrice,
+  paidAccessPriceCap,
   maxPermanentAccessModels,
   tierCapRows,
   type ModelVersionTerms,
@@ -220,8 +223,46 @@ describe('video pricing — every ceiling is 5x on a video model', () => {
 
   it('prices gate terms against the video cap', () => {
     const terms = { download: { price: 5000 } };
-    expect(cappedTerms(terms, 'free', 'image')).toEqual({ download: { price: 500 } });
-    expect(cappedTerms(terms, 'free', 'video')).toEqual({ download: { price: 2500 } });
+    expect(cappedTerms(terms, 'free', { mediaType: 'image', permanent: true })).toEqual({
+      download: { price: 500 },
+    });
+    expect(cappedTerms(terms, 'free', { mediaType: 'video', permanent: true })).toEqual({
+      download: { price: 2500 },
+    });
+  });
+});
+
+describe('the cap binds permanent gates only (CU 868kk3avk)', () => {
+  it('leaves a timed gate at its stored price on the free tier', () => {
+    expect(effectivePaidAccessPrice(10000, null, { permanent: false })).toBe(10000);
+    expect(effectivePaidAccessPrice(10000, 'free', { permanent: false })).toBe(10000);
+    expect(effectivePaidAccessPrice(10000, 'bronze', { mediaType: 'video', permanent: false })).toBe(
+      10000
+    );
+  });
+
+  it('still caps a permanent gate at the owner tier', () => {
+    expect(effectivePaidAccessPrice(10000, null, { permanent: true })).toBe(500);
+    expect(effectivePaidAccessPrice(10000, 'free', { permanent: true })).toBe(500);
+    expect(effectivePaidAccessPrice(10000, 'silver', { permanent: true })).toBe(5000);
+    expect(effectivePaidAccessPrice(10000, 'gold', { permanent: true })).toBe(10000);
+  });
+
+  it('leaves both tiers of a timed gate uncapped', () => {
+    const terms = { download: { price: 15000 }, generation: { price: 9000, trialLimit: 10 } };
+    expect(cappedTerms(terms, 'free', { mediaType: 'image', permanent: false })).toEqual(terms);
+  });
+
+  it('reports Infinity as the ceiling for a timed gate', () => {
+    expect(paidAccessPriceCap({ permanent: false }, 'free')).toBe(Infinity);
+    expect(paidAccessPriceCap({ permanent: true }, 'free')).toBe(500);
+  });
+
+  it('reads permanence off timeframeDays — endsAt cannot tell a pending window apart', () => {
+    // A timed gate on an unpublished version also carries endsAt NULL until publish materializes it.
+    expect(isPermanentGate({ timeframeDays: null })).toBe(true);
+    expect(isPermanentGate({ timeframeDays: undefined })).toBe(true);
+    expect(isPermanentGate({ timeframeDays: 15 })).toBe(false);
   });
 });
 

--- a/packages/civitai-buzz/src/paid-access.ts
+++ b/packages/civitai-buzz/src/paid-access.ts
@@ -117,6 +117,13 @@ export const isTimedGateActive = (
 ): boolean => row.endsAt != null && row.endsAt > now;
 
 /**
+ * Permanent <=> the gate carries no window length. `endsAt` can't answer this: a timed gate on an
+ * unpublished version also has `endsAt` NULL until publish materializes it.
+ */
+export const isPermanentGate = (row: Pick<PaidAccessRow, 'timeframeDays'>): boolean =>
+  row.timeframeDays == null;
+
+/**
  * Free trial generations a paid generation-only tier grants before purchase (absent → default,
  * matching mini/[id].ts's COALESCE so the two endpoints agree; 0 = none).
  */
@@ -174,7 +181,10 @@ export function maxPermanentAccessModels(tier: string | null | undefined): numbe
   );
 }
 
-/** Highest price a tier may charge for paid access. Unknown/lapsed tiers get the FREE cap (see above). */
+/**
+ * Highest price a tier may charge for PERMANENT paid access. Unknown/lapsed tiers get the FREE cap
+ * (see above). Timed Early Access is not bound by it — use `paidAccessPriceCap` for a specific gate.
+ */
 export function maxPaidAccessPrice(
   tier: string | null | undefined,
   mediaType?: CapMediaType
@@ -182,6 +192,22 @@ export function maxPaidAccessPrice(
   const base =
     (tier ? PAID_ACCESS_PRICE_CAP_BY_TIER[tier] : undefined) ?? PAID_ACCESS_PRICE_CAP_BY_TIER.free;
   return mediaType === 'video' ? base * VIDEO_CAP_MULTIPLIER : base;
+}
+
+/** Which side of the cap rule a gate falls on. Derive it with `isPermanentGate` when you hold a row. */
+export type GateKind = { permanent: boolean };
+
+/**
+ * The price ceiling for ONE gate. Membership caps bind PERMANENT paid access only: a timed Early
+ * Access window charges the creator's stored price at every tier, as it did before the caps existed.
+ * Applying the tier cap to timed windows charged buyers 500 on 10k windows (CU 868kk3avk).
+ */
+export function paidAccessPriceCap(
+  { permanent }: GateKind,
+  tier: string | null | undefined,
+  mediaType?: CapMediaType
+): number {
+  return permanent ? maxPaidAccessPrice(tier, mediaType) : Infinity;
 }
 
 // Tiers a creator can actually be shown, cheapest first. `founder` is omitted deliberately: it's a legacy
@@ -300,17 +326,18 @@ export const raisesOverCap = (
 ): boolean => next != null && next > cap && next > current;
 
 /**
- * What a buyer is actually charged: the stored price, lowered to whatever the OWNER's current tier may
- * charge. A lapse drops prices to the free cap without touching the stored value, so re-subscribing
- * restores the original automatically (CU 868kj4q4j).
+ * What a buyer is actually charged on a PERMANENT gate: the stored price, lowered to whatever the
+ * OWNER's current tier may charge. A lapse drops prices to the free cap without touching the stored
+ * value, so re-subscribing restores the original automatically (CU 868kj4q4j). A timed gate passes
+ * `permanent: false` and keeps the stored price at every tier.
  */
 export function effectivePaidAccessPrice(
   storedPrice: number | null | undefined,
   ownerTier: string | null | undefined,
-  mediaType?: CapMediaType
+  opts: GateKind & { mediaType?: CapMediaType }
 ): number {
   if (storedPrice == null || storedPrice <= 0) return 0;
-  return Math.min(storedPrice, maxPaidAccessPrice(ownerTier, mediaType));
+  return Math.min(storedPrice, paidAccessPriceCap(opts, ownerTier, opts.mediaType));
 }
 
 /**
@@ -321,7 +348,7 @@ export function effectivePaidAccessPrice(
 export function cappedTerms(
   terms: ModelVersionTerms,
   ownerTier: string | null,
-  mediaType?: CapMediaType
+  opts: GateKind & { mediaType?: CapMediaType }
 ): ModelVersionTerms {
   const paidGen = paidGenerationGrant(terms);
   return {
@@ -330,7 +357,7 @@ export function cappedTerms(
       ? {
           download: {
             ...terms.download,
-            price: effectivePaidAccessPrice(terms.download.price, ownerTier, mediaType),
+            price: effectivePaidAccessPrice(terms.download.price, ownerTier, opts),
           },
         }
       : {}),
@@ -338,7 +365,7 @@ export function cappedTerms(
       ? {
           generation: {
             ...paidGen,
-            price: effectivePaidAccessPrice(paidGen.price, ownerTier, mediaType),
+            price: effectivePaidAccessPrice(paidGen.price, ownerTier, opts),
           },
         }
       : {}),

--- a/src/components/Resource/Forms/ModelVersionUpsertForm.tsx
+++ b/src/components/Resource/Forms/ModelVersionUpsertForm.tsx
@@ -88,6 +88,7 @@ import {
   maxLicensingFeeCeiling,
   capMediaType,
   maxPaidAccessPrice,
+  paidAccessPriceCap,
   ratioToFee,
   suggestedFeePerImage,
 } from '@civitai/buzz';
@@ -436,7 +437,12 @@ export function ModelVersionUpsertForm({
     ? [...FEE_IMAGE_OPTIONS]
     : feeImageOptionsForCap(feeCapTier, model?.type, feeMediaType);
   // Infinity (gold/moderator) falls back to MAX_DONATION_GOAL: an infinite `max` renders as no cap at all.
-  const tierPriceCap = maxPaidAccessPrice(feeCapTier, feeMediaType);
+  // A timed Early Access window is uncapped too, so switching Access mode moves the ceiling with it.
+  const tierPriceCap = paidAccessPriceCap(
+    { permanent: paidAccessConfig?.permanent ?? false },
+    feeCapTier,
+    feeMediaType
+  );
   const paidAccessCap =
     currentUser?.isModerator || !Number.isFinite(tierPriceCap) ? MAX_DONATION_GOAL : tierPriceCap;
   const storedTerms = version?.paidAccess?.terms as ModelVersionTerms | undefined;

--- a/src/server/services/__tests__/paid-access.service.test.ts
+++ b/src/server/services/__tests__/paid-access.service.test.ts
@@ -32,10 +32,10 @@ vi.mock('~/server/utils/cache-helpers', () => ({
 }));
 
 import {
+  assertPaidAccessCaps,
   assertPaidAccessInput,
   getViewerMonetization,
   materializePaidAccessEndsAt,
-  toModelVersionPaidAccessDto,
   toPublicPaidAccessDto,
   writePaidAccessForModelVersion,
 } from '~/server/services/paid-access.service';
@@ -226,18 +226,48 @@ describe('toPublicPaidAccessDto — the v1 public API view', () => {
   });
 });
 
+describe('assertPaidAccessCaps — the price ceiling on the write path', () => {
+  const caps = (over: Record<string, unknown>) => ({
+    userId: 7,
+    tier: null,
+    paidAccess: { terms: { download: { price: 10000 } } } as never,
+    ...over,
+  });
+
+  it('rejects an over-cap PERMANENT price on the free tier', async () => {
+    await expect(
+      assertPaidAccessCaps(
+        caps({ paidAccess: { permanent: true, terms: { download: { price: 10000 } } } })
+      )
+    ).rejects.toThrow(/500 Buzz/);
+  });
+
+  it('accepts the same price on a TIMED window — early access is not tier-capped', async () => {
+    await expect(
+      assertPaidAccessCaps(
+        caps({ paidAccess: { timeframeDays: 15, terms: { download: { price: 10000 } } } })
+      )
+    ).resolves.toBeUndefined();
+  });
+});
+
 describe('getViewerMonetization — gate price and licensing fee capped as one', () => {
   const OWNER = 7;
   const FUTURE = new Date('2099-01-01T00:00:00.000Z');
 
+  // Permanent by default — the only gate kind the tier price cap binds. Timed windows get their own
+  // cases below.
   const row = (over: Record<string, unknown> = {}) => ({
     entityId: 1,
     ownerId: OWNER,
-    endsAtMs: FUTURE.getTime(),
-    timeframeDays: 7,
+    endsAtMs: null as number | null,
+    timeframeDays: null as number | null,
     terms: { download: { price: 5000 } },
     ...over,
   });
+
+  const timedRow = (over: Record<string, unknown> = {}) =>
+    row({ endsAtMs: FUTURE.getTime(), timeframeDays: 7, ...over });
 
   const drive = (
     gates: Record<string, unknown>,
@@ -284,6 +314,34 @@ describe('getViewerMonetization — gate price and licensing fee capped as one',
     const out = await getViewerMonetization({ versions: [{ id: 1 }], viewer: { id: 2 } });
 
     expect(out[1].paidAccess?.terms).toEqual({ download: { price: 300 } });
+  });
+
+  it('leaves a TIMED gate at its stored price — the cap binds permanent access only', async () => {
+    drive({ 1: timedRow() });
+
+    const out = await getViewerMonetization({ versions: [{ id: 1 }], viewer: { id: 2 } });
+
+    expect(out[1].paidAccess?.terms).toEqual({ download: { price: 5000 } });
+  });
+
+  it('still caps the licensing fee on a timed gate, leaving the gate price alone', async () => {
+    drive({ 1: timedRow() });
+
+    const out = await getViewerMonetization({
+      versions: [{ id: 1, ownerId: OWNER, licensingFee: 8, modelType: 'Checkpoint' }],
+      viewer: { id: 2 },
+    });
+
+    expect(out[1].paidAccess?.terms).toEqual({ download: { price: 5000 } });
+    expect(out[1].licensingFee).toBe(1);
+  });
+
+  it('resolves no cap tier for a timed gate with no licensing fee', async () => {
+    drive({ 1: timedRow() });
+
+    await getViewerMonetization({ versions: [{ id: 1 }], viewer: { id: 2 } });
+
+    expect(mockCacheFetch.mock.calls.filter(([key]) => key === 'test:cap-tier')).toHaveLength(0);
   });
 
   it('caps a paid generation tier and keeps trialLimit', async () => {

--- a/src/server/services/model-version.service.ts
+++ b/src/server/services/model-version.service.ts
@@ -93,6 +93,7 @@ import {
   effectivePaidAccessPrice,
   generationPrice,
   isPaidAccessActive,
+  isPermanentGate,
   isTimedGateActive,
   paidGenerationGrant,
 } from '@civitai/buzz';
@@ -1989,13 +1990,14 @@ export const earlyAccessPurchase = async ({
   // Generation `price` is optional — `generationPrice` applies the download-price fallback (and is
   // unit-tested in @civitai/buzz, so the charged amount stays covered).
   //
-  // Charged at the OWNER's current cap, not the stored price: a lapsed membership drops what buyers pay to
-  // the free-tier cap (CU 868kj4q4j). The stored value is left alone, so re-subscribing restores it.
+  // A PERMANENT gate charges at the OWNER's current cap, not the stored price: a lapsed membership drops
+  // what buyers pay to the free-tier cap (CU 868kj4q4j). The stored value is left alone, so re-subscribing
+  // restores it. A timed Early Access window is never tier-capped (CU 868kk3avk).
   const ownerTier = await getCachedCapTier(modelVersion.model.userId);
   const amount = effectivePaidAccessPrice(
     type === 'download' ? terms.download?.price : generationPrice(terms),
     ownerTier,
-    capMediaType(modelVersion.baseModel)
+    { mediaType: capMediaType(modelVersion.baseModel), permanent: isPermanentGate(paidAccess) }
   );
 
   const accessRecord = await dbWrite.entityAccess.findFirst({

--- a/src/server/services/paid-access.service.ts
+++ b/src/server/services/paid-access.service.ts
@@ -6,6 +6,7 @@ import {
   effectiveLicensingFee,
   gatePrices,
   isPaidAccessActive,
+  isPermanentGate,
   maxPaidAccessPrice,
   maxPermanentAccessModels,
   raisesOverCap,
@@ -247,12 +248,16 @@ export async function getViewerMonetization({
     versions.map((v) => v.id)
   );
   const ownerOf = (v: { id: number; ownerId?: number }) => v.ownerId ?? rows[v.id]?.ownerId;
+  // A timed gate's price isn't tier-capped, so it needs no tier lookup on its own account — only a
+  // permanent gate's price or a licensing fee does.
   const cappable = versions.filter((v) => {
     const ownerId = ownerOf(v);
+    const row = rows[v.id];
+    const cappablePrice = !!row && isPermanentGate(row) && hasChargeablePrice(row.terms);
     return (
       ownerId != null &&
       !isOwnerOrModView(viewer, ownerId) &&
-      (hasChargeablePrice(rows[v.id]?.terms) || (v.licensingFee ?? 0) > 0)
+      (cappablePrice || (v.licensingFee ?? 0) > 0)
     );
   });
   const capTiers = await getCapTiers(cappable.map(ownerOf));
@@ -270,7 +275,13 @@ export async function getViewerMonetization({
     const mediaType = capMediaType(v.baseModel);
     out[v.id] = {
       paidAccess: row
-        ? { ...row, terms: cappedTerms(row.terms as ModelVersionTerms, tier, mediaType) }
+        ? {
+            ...row,
+            terms: cappedTerms(row.terms as ModelVersionTerms, tier, {
+              mediaType,
+              permanent: isPermanentGate(row),
+            }),
+          }
         : undefined,
       licensingFee:
         storedFee != null ? effectiveLicensingFee(storedFee, tier, v.modelType, mediaType) : null,
@@ -296,6 +307,9 @@ export async function assertPaidAccessCaps({
   baseModel?: string | null;
 }) {
   if (isModerator || !paidAccess) return;
+  // Both caps bind PERMANENT paid access only — a timed Early Access window may be priced freely at any
+  // tier, as it was before the caps existed (CU 868kk3avk).
+  if (!paidAccess.permanent) return;
 
   const existing = versionId
     ? (await getPaidAccess('ModelVersion', [versionId]))[versionId]
@@ -314,18 +328,16 @@ export async function assertPaidAccessCaps({
     );
 
   // Only the free tier keeps a COUNT limit, and only NEW permanent grants count against it.
-  if (paidAccess.permanent) {
-    const alreadyPermanent = existing != null && existing.timeframeDays == null;
-    const limit = maxPermanentAccessModels(tier);
-    if (!alreadyPermanent && Number.isFinite(limit)) {
-      const used = await countUserPermanentAccessVersions(userId, versionId);
-      if (used + 1 > limit)
-        throw throwBadRequestError(
-          `Your tier allows up to ${limit} permanent paid-access model${
-            limit === 1 ? '' : 's'
-          }. Upgrade your membership for more.`
-        );
-    }
+  const alreadyPermanent = existing != null && existing.timeframeDays == null;
+  const limit = maxPermanentAccessModels(tier);
+  if (!alreadyPermanent && Number.isFinite(limit)) {
+    const used = await countUserPermanentAccessVersions(userId, versionId);
+    if (used + 1 > limit)
+      throw throwBadRequestError(
+        `Your tier allows up to ${limit} permanent paid-access model${
+          limit === 1 ? '' : 's'
+        }. Upgrade your membership for more.`
+      );
   }
 }
 


### PR DESCRIPTION
Fixes CU [868kk3avk](https://app.clickup.com/t/8459928/868kk3avk) — **live revenue leak**, reported by MNeMiC / alexds9 / SubtleShader.

## Problem

The per-tier paid-access price cap (`078df52f15`, `3a6bf62700`, first prod tag `v5.0.2212` on 2026-07-31 06:17 UTC) is applied to **every** `PaidAccess` gate — nothing branched on timed vs permanent. `getCapTier` returns `null` for a creator with no good-standing subscription, which the cap helpers read as free → **500 Buzz**. So a 10k/15k Early Access window charged 500.

It bled into three places:

| Surface | Code |
|---|---|
| What the buyer is charged | `model-version.service.ts:1997` (`effectivePaidAccessPrice`) |
| What the buy button shows | `getViewerMonetization` → `cappedTerms` (model page, version page, creator shop, generation gating) |
| What a creator may save | `assertPaidAccessCaps` — a free-tier creator could no longer even *set* a 10k EA price |

Caps were only ever meant to bind **permanent** Paid Access.

## Measured impact (prod, at time of investigation)

- **76** currently-active timed EA gates priced above their owner's cap (69 free-tier, 7 bronze).
- Since `v5.0.2212`: **164 EA download purchases across 32 versions** — stored 780,892 ⚡ vs charged ~88,500 ⚡ → **~692K Buzz under-charged**.

Estimate uses *current* stored price and *current* owner tier, with the video 5× multiplier matched heuristically on base model. Order-of-magnitude, not accounting-grade.

**This PR stops the bleed; it does not back-fill.** Making the 32 affected creators whole is a separate call — buyers paid what the UI quoted them, so clawback isn't the right lever.

## Fix

Gate kind threaded through the shared helpers in `@civitai/buzz`, so all four surfaces follow one rule:

- `isPermanentGate(row)` reads **`timeframeDays`, not `endsAt`** — a timed gate on an unpublished version also carries `endsAt` NULL until publish materializes it, so `endsAt` can't tell the two apart.
- `paidAccessPriceCap({ permanent }, tier, mediaType)` → `Infinity` for a timed window.
- `effectivePaidAccessPrice` / `cappedTerms` take the gate kind as a **required** field, so the compiler forced every call site to decide rather than inherit a default.
- `assertPaidAccessCaps` returns early for timed gates — which also skips the `getPaidAccess` read those writes never needed. The two `permanent` branches are merged.

Clients follow the same rule: the onsite form's ceiling tracks the Access mode toggle (falling back to `MAX_DONATION_GOAL`, which also silences the over-cap warning and the upsell), and Creator Studio's editor derives `effectiveCap` from `ea.permanent`. `PaidAccessBulkBar` is untouched — it only ever sets permanent access.

Licensing-fee caps are a separate feature and stay tier-bound on every gate, including timed ones.

## Tests

`getViewerMonetization`'s fixture was a **timed** row (`timeframeDays: 7`) asserting 5000 → 500 — the suite encoded the bug, and 7 of its cases failed against the fix. Fixture flipped to permanent, plus new coverage: timed gate keeps its stored price, licensing fee still capped on a timed gate, no cap-tier fetch for a timed gate, and both directions of `assertPaidAccessCaps`.

- `@civitai/buzz` — 42 passed
- `paid-access.service.test.ts` + `paid-access-gating.test.ts` — 53 passed
- `licensing-fee.test.ts` — 9 passed
- `pnpm typecheck` — clean; Creator Studio `svelte-check` — 0 errors

No migration. No feature flag — this restores documented pre-cap behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)