### PR TITLE
fix(apps): moderators are told their listing-media edits are staged, but they apply to the live listing immediately

### DIFF
--- a/src/components/Apps/ListingMediaEditor.tsx
+++ b/src/components/Apps/ListingMediaEditor.tsx
@@ -31,11 +31,24 @@ import { trpc } from '~/utils/trpc';
  *     live listing (the deliberate curation bypass). IMMEDIATE.
  *   - MODERATOR, shadow ALREADY exists → 🔴 STAGED, same as an owner.
  *     `getMyListingForApp` resolves `editTargetId` to an existing shadow with no
- *     moderator branch of its own, and the asset step is hosted against that id. The
- *     mod bypass then does nothing (the target already has `revisionOfId != null`), so
- *     the write applies to the SHADOW and only goes live on re-approval. Gating the
- *     "applies immediately" copy on `isModerator` alone lies to exactly this case —
- *     and it is common, not theoretical (see the 78% figure in the note below).
+ *     moderator branch of its own, so the asset step is hosted against the SHADOW's id
+ *     — and `resolveOwnerAssetEditTarget` returns its target UNCHANGED for a moderator
+ *     (`if (user.isModerator) return listing;` is the first line; the `revisionOfId`
+ *     check below it is never reached for a mod, and describes the OWNER branch). Here
+ *     "unchanged" means the shadow, so the write applies to the shadow and only goes
+ *     live on re-approval. Gating the "applies immediately" copy on `isModerator`
+ *     alone lies to exactly this case.
+ *
+ *     🔴 HOW OFTEN this state occurs is UNMEASURED — and the gate's correctness does
+ *     not depend on it, which is the only reason not to go measure it. Do NOT justify
+ *     this branch with the 78%-of-approved-parents-carry-a-shadow figure in the note
+ *     below: that counted the PRE-fix prevalence manufactured by the write-on-view bug
+ *     lazy creation removed, under preconditions that no longer hold. Post-fix a shadow
+ *     exists only after a real owner edit, and a moderator's own asset edits never mint
+ *     one — so the rate could be near zero, or still high if those legacy never-edited
+ *     shadows were never purged (no cleanup migration is known to have run). Citing a
+ *     measurement taken under different preconditions is the exact error that produced
+ *     the first, wrong version of this gate. If you need the number, go count it.
  *
  * NOTE: the "Back to app" affordance lives on the OWNING page (so the tabbed /edit
  * page has a single back control), not here.
@@ -83,7 +96,14 @@ export function ListingMediaEditor({ appBlockId }: { appBlockId: string }) {
   // it says "the asset step is hosted against the LIVE parent". A moderator whose
   // listing already carries a shadow is editing that shadow and IS staged — they must
   // get the owner copy. `isModerator` alone would tell them the opposite.
-  const modDirectLiveEdit = isModerator && isApproved && !shadowId;
+  //
+  // Deliberately NOT `&& isApproved`: both consumers already sit inside an `isApproved`
+  // gate, so the conjunct flipped no state while making the expression read as a
+  // different rule from the one the comments state. Keep this identical to the header's
+  // `isModerator && !shadowId`. 🔴 If you ever consume it OUTSIDE an `isApproved` gate,
+  // add the approval check THERE — a draft/pending listing has no shadow, so this alone
+  // would be true for a moderator on one.
+  const modDirectLiveEdit = isModerator && !shadowId;
 
   // 3) Re-pull the projected assets after EVERY successful asset mutation.
   //

--- a/src/components/Apps/ListingMediaEditor.tsx
+++ b/src/components/Apps/ListingMediaEditor.tsx
@@ -1,9 +1,10 @@
 import { Alert, Button, Center, Group, Loader, Stack, Text } from '@mantine/core';
-import { IconInfoCircle, IconSend } from '@tabler/icons-react';
+import { IconAlertTriangle, IconInfoCircle, IconSend } from '@tabler/icons-react';
 import { useRouter } from 'next/router';
 import { useCallback, useState } from 'react';
 import { NotFound } from '~/components/AppLayout/NotFound';
 import { ListingAssetStep } from '~/components/Apps/ListingAssetStep';
+import { useCurrentUser } from '~/hooks/useCurrentUser';
 import type { OffsiteContentRating } from '~/server/schema/blocks/offsite-listing.schema';
 import { showErrorNotification, showSuccessNotification } from '~/utils/notifications';
 import { trpc } from '~/utils/trpc';
@@ -15,8 +16,16 @@ import { trpc } from '~/utils/trpc';
  * of the unified `/apps/[appBlockId]/edit` page (and reused anywhere else).
  *
  * Owner gating is single-sourced at the tRPC layer: `getMyListingForApp` throws
- * FORBIDDEN (non-owner) / NOT_FOUND (no listing) → this renders NotFound. All asset
- * edits target a SHADOW revision (mod re-review) so the live listing keeps serving.
+ * FORBIDDEN (non-owner) / NOT_FOUND (no listing) → this renders NotFound.
+ *
+ * 🔴 TWO DIFFERENT WRITE SEMANTICS, and the copy MUST match the caller's:
+ *   - OWNER (non-mod), approved listing → the first asset mutation mints a SHADOW
+ *     revision server-side; the live listing keeps serving until a mod re-approves.
+ *   - MODERATOR → `resolveOwnerAssetEditTarget` / `assertOwnerAssetEditable` both
+ *     short-circuit on `user.isModerator`, so NO shadow is minted and the write lands
+ *     DIRECTLY on the live approved listing (the deliberate curation bypass). Telling
+ *     a mod their edits are "staged for re-approval" is simply false — observed in
+ *     production, where mod screenshot adds on live listings created zero revisions.
  *
  * NOTE: the "Back to app" affordance lives on the OWNING page (so the tabbed /edit
  * page has a single back control), not here.
@@ -24,6 +33,11 @@ import { trpc } from '~/utils/trpc';
 export function ListingMediaEditor({ appBlockId }: { appBlockId: string }) {
   const router = useRouter();
   const utils = trpc.useUtils();
+  const currentUser = useCurrentUser();
+  // Drives WHICH live-app notice renders — see the 🔴 note above. Read from the
+  // session hook (the established client idiom, e.g. `ExternalSubmitForm`) rather
+  // than threaded as a prop, so every host of this editor is correct by default.
+  const isModerator = !!currentUser?.isModerator;
 
   // 1) Owner-gated resolve of the backing listing id for this app block. A non-owner
   //    (FORBIDDEN) or a missing listing (NOT_FOUND) both settle to NotFound.
@@ -126,22 +140,45 @@ export function ListingMediaEditor({ appBlockId }: { appBlockId: string }) {
           contradictory half-UI where the pre-narrowing code showed a clean NotFound.
           The red alert below still surfaces those non-gating errors (that improvement
           stands); this notice just stops claiming context it doesn't have. */}
-      {listing && !listingError && isApproved && !editBlockedReason && (
-        <Alert
-          icon={<IconInfoCircle size={16} />}
-          color="blue"
-          variant="light"
-          title="Listing images"
-          data-testid="apps-listing-media-live-notice"
-        >
-          <Text size="sm">
-            This app is <b>live</b> — your image changes are staged as a revision and go live only
-            after a moderator re-approves. Update the icon, cover and screenshots below, then submit
-            for review. Media can be added while it is still scanning; it only goes live once its
-            scan finishes cleanly.
-          </Text>
-        </Alert>
-      )}
+      {listing &&
+        !listingError &&
+        isApproved &&
+        !editBlockedReason &&
+        (isModerator ? (
+          // 🔴 MODERATOR variant. The server's curation bypass writes straight to the
+          // live listing — no shadow, no re-approval — so this must NOT repeat the
+          // owner copy's "staged as a revision" claim. Own testid so a test can tell
+          // the two variants apart (and so the owner testid keeps meaning "owner").
+          <Alert
+            icon={<IconAlertTriangle size={16} />}
+            color="orange"
+            variant="light"
+            title="Editing the live listing"
+            data-testid="apps-listing-media-mod-live-notice"
+          >
+            <Text size="sm">
+              This app is <b>live</b> and you are editing it as a <b>moderator</b> — your image
+              changes are <b>not</b> staged as a revision and need no re-approval. They apply to the
+              live listing immediately. Media can be added while it is still scanning; it only
+              appears once its scan finishes cleanly.
+            </Text>
+          </Alert>
+        ) : (
+          <Alert
+            icon={<IconInfoCircle size={16} />}
+            color="blue"
+            variant="light"
+            title="Listing images"
+            data-testid="apps-listing-media-live-notice"
+          >
+            <Text size="sm">
+              This app is <b>live</b> — your image changes are staged as a revision and go live only
+              after a moderator re-approves. Update the icon, cover and screenshots below, then
+              submit for review. Media can be added while it is still scanning; it only goes live
+              once its scan finishes cleanly.
+            </Text>
+          </Alert>
+        ))}
 
       {listing?.hasPendingRevision && (
         <Alert

--- a/src/components/Apps/ListingMediaEditor.tsx
+++ b/src/components/Apps/ListingMediaEditor.tsx
@@ -16,16 +16,26 @@ import { trpc } from '~/utils/trpc';
  * of the unified `/apps/[appBlockId]/edit` page (and reused anywhere else).
  *
  * Owner gating is single-sourced at the tRPC layer: `getMyListingForApp` throws
- * FORBIDDEN (non-owner) / NOT_FOUND (no listing) → this renders NotFound.
+ * NOT_OWNED→FORBIDDEN (non-owner) / NOT_FOUND (no listing) → this renders NotFound.
+ * 🔴 That owner check has NO moderator branch, so this editor is only ever reachable
+ * for the caller's OWN listing — including for a moderator (the production incident
+ * behind the notice below was an owner-AND-moderator editing their own live apps).
  *
- * 🔴 TWO DIFFERENT WRITE SEMANTICS, and the copy MUST match the caller's:
- *   - OWNER (non-mod), approved listing → the first asset mutation mints a SHADOW
- *     revision server-side; the live listing keeps serving until a mod re-approves.
- *   - MODERATOR → `resolveOwnerAssetEditTarget` / `assertOwnerAssetEditable` both
- *     short-circuit on `user.isModerator`, so NO shadow is minted and the write lands
- *     DIRECTLY on the live approved listing (the deliberate curation bypass). Telling
- *     a mod their edits are "staged for re-approval" is simply false — observed in
- *     production, where mod screenshot adds on live listings created zero revisions.
+ * 🔴 THREE WRITE SEMANTICS on an APPROVED listing, and the copy MUST match. The
+ * discriminator is `isModerator && !shadowId` — NOT `isModerator` alone:
+ *   - OWNER (non-mod) → the first asset mutation mints a SHADOW revision server-side;
+ *     the live listing keeps serving until a mod re-approves. STAGED.
+ *   - MODERATOR, NO shadow yet → `editTargetId` is the live parent, and
+ *     `resolveOwnerAssetEditTarget` / `assertOwnerAssetEditable` both short-circuit on
+ *     `user.isModerator`, so no shadow is minted and the write lands DIRECTLY on the
+ *     live listing (the deliberate curation bypass). IMMEDIATE.
+ *   - MODERATOR, shadow ALREADY exists → 🔴 STAGED, same as an owner.
+ *     `getMyListingForApp` resolves `editTargetId` to an existing shadow with no
+ *     moderator branch of its own, and the asset step is hosted against that id. The
+ *     mod bypass then does nothing (the target already has `revisionOfId != null`), so
+ *     the write applies to the SHADOW and only goes live on re-approval. Gating the
+ *     "applies immediately" copy on `isModerator` alone lies to exactly this case —
+ *     and it is common, not theoretical (see the 78% figure in the note below).
  *
  * NOTE: the "Back to app" affordance lives on the OWNING page (so the tabbed /edit
  * page has a single back control), not here.
@@ -34,9 +44,10 @@ export function ListingMediaEditor({ appBlockId }: { appBlockId: string }) {
   const router = useRouter();
   const utils = trpc.useUtils();
   const currentUser = useCurrentUser();
-  // Drives WHICH live-app notice renders — see the 🔴 note above. Read from the
-  // session hook (the established client idiom, e.g. `ExternalSubmitForm`) rather
-  // than threaded as a prop, so every host of this editor is correct by default.
+  // Read from the session hook (the established client idiom, e.g.
+  // `ExternalSubmitForm`) rather than threaded as a prop, so every host of this
+  // editor is correct by default. NOT sufficient on its own as the copy
+  // discriminator — see `modDirectLiveEdit` below.
   const isModerator = !!currentUser?.isModerator;
 
   // 1) Owner-gated resolve of the backing listing id for this app block. A non-owner
@@ -65,6 +76,14 @@ export function ListingMediaEditor({ appBlockId }: { appBlockId: string }) {
   const shadowId = listing?.shadowId ?? null;
   const editBlockedReason = listing?.editBlockedReason ?? null;
   const isApproved = listing?.status === 'approved';
+
+  // 🔴 THE ONE DISCRIMINATOR for "this edit goes live immediately" — see the header.
+  // `!shadowId` is what makes it correct: it is exactly `editTargetId === appListingId`
+  // (the server sets `shadowId` and redirects `editTargetId` together, or neither), so
+  // it says "the asset step is hosted against the LIVE parent". A moderator whose
+  // listing already carries a shadow is editing that shadow and IS staged — they must
+  // get the owner copy. `isModerator` alone would tell them the opposite.
+  const modDirectLiveEdit = isModerator && isApproved && !shadowId;
 
   // 3) Re-pull the projected assets after EVERY successful asset mutation.
   //
@@ -144,11 +163,14 @@ export function ListingMediaEditor({ appBlockId }: { appBlockId: string }) {
         !listingError &&
         isApproved &&
         !editBlockedReason &&
-        (isModerator ? (
-          // 🔴 MODERATOR variant. The server's curation bypass writes straight to the
-          // live listing — no shadow, no re-approval — so this must NOT repeat the
-          // owner copy's "staged as a revision" claim. Own testid so a test can tell
-          // the two variants apart (and so the owner testid keeps meaning "owner").
+        (modDirectLiveEdit ? (
+          // 🔴 MODERATOR-ON-THE-LIVE-PARENT variant (`isModerator && !shadowId`). The
+          // server's curation bypass writes straight to the live listing — no shadow,
+          // no re-approval — so this must NOT repeat the owner copy's "staged as a
+          // revision" claim. A moderator WITH a shadow falls through to the owner copy
+          // below, which is correct for them: that write goes to the shadow. Own testid
+          // so a test can tell the variants apart (and so the owner testid keeps
+          // meaning "the staged-revision copy").
           <Alert
             icon={<IconAlertTriangle size={16} />}
             color="orange"
@@ -238,7 +260,14 @@ export function ListingMediaEditor({ appBlockId }: { appBlockId: string }) {
               onCompletenessChange={handleCompletenessChange}
             />
           </div>
-          {isApproved && (
+          {/* 🔴 Same discriminator as the notice above, deliberately. For a moderator
+              editing the LIVE parent, no edit will ever mint a shadow, so "Change an
+              image to stage a revision" is false and `disabled={… || !shadowId}` makes
+              Submit permanently dead — a broken control contradicting the notice four
+              lines above it. There is nothing to submit: their change is already live.
+              🔴 Do NOT widen this to `isModerator` — a moderator WITH a shadow has a
+              real revision that still needs submitting for re-approval. */}
+          {isApproved && !modDirectLiveEdit && (
             <Group justify="flex-end" align="center">
               {!shadowId && (
                 <Text size="xs" c="dimmed" data-testid="apps-listing-media-no-changes">

--- a/src/tests/pages/apps/listing-media-page.browser.test.tsx
+++ b/src/tests/pages/apps/listing-media-page.browser.test.tsx
@@ -54,10 +54,18 @@ const state = vi.hoisted(() => ({
   floor: { meetsFloor: true, complete: false },
   invalidate: vi.fn().mockResolvedValue(undefined),
   flags: { appBlocks: true } as Record<string, boolean>,
+  // Drives WHICH live-app notice the editor renders. `useCurrentUser()` throws
+  // without a CivitaiSessionProvider (which `renderWithProviders` deliberately does
+  // not mount), so it is mocked rather than provided.
+  currentUser: null as null | { id: number; username: string; isModerator?: boolean },
 }));
 
 vi.mock('~/providers/FeatureFlagsProvider', () => ({
   useFeatureFlags: () => state.flags,
+}));
+
+vi.mock('~/hooks/useCurrentUser', () => ({
+  useCurrentUser: () => state.currentUser,
 }));
 
 vi.mock('~/components/AppLayout/NotFound', () => ({
@@ -183,6 +191,7 @@ beforeEach(() => {
   state.invalidate.mockReset();
   state.invalidate.mockResolvedValue(undefined);
   state.flags = { appBlocks: true };
+  state.currentUser = { id: 7, username: 'owner' };
   setRouterQuery({ appBlockId: 'my-block' });
 });
 
@@ -280,6 +289,65 @@ describe('ListingMediaPage — owner listing-media route shell', () => {
     await expect.element(notice).toBeInTheDocument();
     await expect.element(notice).toHaveTextContent(/live/i);
     await expect.element(notice).toHaveTextContent(/moderator re-approves/i);
+  });
+
+  // -------------------------------------------------------------------------
+  // 🔴 The live-app notice must match the CALLER's actual write semantics.
+  //
+  // `resolveOwnerAssetEditTarget` + `assertOwnerAssetEditable` BOTH short-circuit on
+  // `user.isModerator`, so a moderator's icon/cover/screenshot edit is written
+  // DIRECTLY to the live approved listing — no shadow revision is minted and nothing
+  // is re-approved. (Confirmed in production: mod screenshot adds against live
+  // listings created zero revisions.) The single ungated notice therefore told every
+  // moderator the exact opposite of what the server does with their edit.
+  // -------------------------------------------------------------------------
+
+  test('🔴 a MODERATOR is told they are editing the LIVE listing directly — never that it is staged', async () => {
+    state.currentUser = { id: 1, username: 'mod', isModerator: true };
+    renderWithProviders(<ListingMediaPage />);
+
+    const notice = page.getByTestId('apps-listing-media-mod-live-notice');
+    await expect.element(notice).toBeInTheDocument();
+    await expect.element(notice).toHaveTextContent(/live/i);
+    await expect.element(notice).toHaveTextContent(/apply to the live listing immediately/i);
+    await expect.element(notice).toHaveTextContent(/not.*staged as a revision/i);
+
+    // The owner variant — the one carrying the false "staged / re-approval" claim —
+    // must be GONE, not merely supplemented.
+    expect(page.getByTestId('apps-listing-media-live-notice').elements()).toHaveLength(0);
+    // And no surviving copy anywhere may assert the staged/re-approval semantics.
+    expect(page.getByText(/go live only after a moderator re-approves/i).elements()).toHaveLength(
+      0
+    );
+  });
+
+  test('🔴 a NON-moderator owner keeps the staged-revision copy (and never sees the mod variant)', async () => {
+    state.currentUser = { id: 7, username: 'owner', isModerator: false };
+    renderWithProviders(<ListingMediaPage />);
+
+    const notice = page.getByTestId('apps-listing-media-live-notice');
+    await expect.element(notice).toBeInTheDocument();
+    await expect.element(notice).toHaveTextContent(/staged as a revision/i);
+    await expect.element(notice).toHaveTextContent(/go live only after a moderator re-approves/i);
+
+    expect(page.getByTestId('apps-listing-media-mod-live-notice').elements()).toHaveLength(0);
+  });
+
+  test('a MODERATOR on a non-approved (draft) listing sees NEITHER live notice', async () => {
+    // The bypass only matters for an APPROVED, non-shadow listing — a draft is edited
+    // in place for everyone, so neither "this is live" framing applies.
+    state.currentUser = { id: 1, username: 'mod', isModerator: true };
+    state.query.data = {
+      ...(state.query.data as Record<string, unknown>),
+      status: 'draft',
+      shadowId: null,
+      editTargetId: 'apl_draft',
+    };
+    renderWithProviders(<ListingMediaPage />);
+
+    await expect.element(page.getByTestId('asset-step')).toBeInTheDocument();
+    expect(page.getByTestId('apps-listing-media-mod-live-notice').elements()).toHaveLength(0);
+    expect(page.getByTestId('apps-listing-media-live-notice').elements()).toHaveLength(0);
   });
 
   test('Submit for review fires submitListingRevision with the shadow id', async () => {

--- a/src/tests/pages/apps/listing-media-page.browser.test.tsx
+++ b/src/tests/pages/apps/listing-media-page.browser.test.tsx
@@ -303,10 +303,14 @@ describe('ListingMediaPage — owner listing-media route shell', () => {
   // listing.)
   //
   // 🔴 But `getMyListingForApp` redirects `editTargetId` to an EXISTING shadow with no
-  // moderator branch of its own. A moderator whose listing already carries a shadow is
-  // therefore editing the SHADOW — the bypass is a no-op there (`revisionOfId != null`)
-  // — and IS staged. Gating on `isModerator` alone replaces one false banner with
-  // another, for a case that is common rather than theoretical.
+  // moderator branch of its own, so the step is hosted against the SHADOW's id — and
+  // `resolveOwnerAssetEditTarget` returns its target UNCHANGED for a moderator (the
+  // `isModerator` early return is its FIRST line; the `revisionOfId` check below it is
+  // the OWNER branch and is never reached for a mod). "Unchanged" is the shadow, so
+  // that write IS staged. Gating on `isModerator` alone replaces one false banner with
+  // another. How OFTEN a mod hits that state is unmeasured and the gate does not depend
+  // on it — see the header comment in `ListingMediaEditor` before reaching for the 78%
+  // figure quoted above, which measured a pre-fix condition that no longer holds.
   //
   // The four states below are the whole matrix; each has a test.
   // -------------------------------------------------------------------------

--- a/src/tests/pages/apps/listing-media-page.browser.test.tsx
+++ b/src/tests/pages/apps/listing-media-page.browser.test.tsx
@@ -292,19 +292,39 @@ describe('ListingMediaPage — owner listing-media route shell', () => {
   });
 
   // -------------------------------------------------------------------------
-  // 🔴 The live-app notice must match the CALLER's actual write semantics.
+  // 🔴 The live-app notice must match the CALLER's actual write semantics, and the
+  // discriminator is `isModerator && !shadowId` — NOT `isModerator`.
   //
-  // `resolveOwnerAssetEditTarget` + `assertOwnerAssetEditable` BOTH short-circuit on
-  // `user.isModerator`, so a moderator's icon/cover/screenshot edit is written
-  // DIRECTLY to the live approved listing — no shadow revision is minted and nothing
-  // is re-approved. (Confirmed in production: mod screenshot adds against live
-  // listings created zero revisions.) The single ungated notice therefore told every
-  // moderator the exact opposite of what the server does with their edit.
+  // With NO shadow, `editTargetId` is the live parent and
+  // `resolveOwnerAssetEditTarget` + `assertOwnerAssetEditable` both short-circuit on
+  // `user.isModerator`, so a moderator's edit is written DIRECTLY to the live listing.
+  // (Confirmed in production, on listings the moderator also OWNED — this editor's
+  // read is owner-bound with no mod branch, so it is only ever reachable for your own
+  // listing.)
+  //
+  // 🔴 But `getMyListingForApp` redirects `editTargetId` to an EXISTING shadow with no
+  // moderator branch of its own. A moderator whose listing already carries a shadow is
+  // therefore editing the SHADOW — the bypass is a no-op there (`revisionOfId != null`)
+  // — and IS staged. Gating on `isModerator` alone replaces one false banner with
+  // another, for a case that is common rather than theoretical.
+  //
+  // The four states below are the whole matrix; each has a test.
   // -------------------------------------------------------------------------
 
-  test('🔴 a MODERATOR is told they are editing the LIVE listing directly — never that it is staged', async () => {
+  test('🔴 MOD + NO shadow: told they are editing the LIVE listing directly — never that it is staged', async () => {
     state.currentUser = { id: 1, username: 'mod', isModerator: true };
+    // The mod bypass only reaches the live parent when there is no shadow to redirect
+    // the edit target onto. (The shared fixture carries a shadow — see the next test.)
+    state.query.data = {
+      ...(state.query.data as Record<string, unknown>),
+      shadowId: null,
+      editTargetId: 'apl_onsite',
+    };
     renderWithProviders(<ListingMediaPage />);
+
+    // The step really is hosted against the LIVE parent — the precondition for the
+    // copy, asserted rather than assumed.
+    await expect.element(page.getByTestId('asset-step')).toHaveTextContent('assets:apl_onsite:');
 
     const notice = page.getByTestId('apps-listing-media-mod-live-notice');
     await expect.element(notice).toBeInTheDocument();
@@ -321,6 +341,27 @@ describe('ListingMediaPage — owner listing-media route shell', () => {
     );
   });
 
+  test('🔴 MOD + shadow ALREADY exists: the edit IS staged, so the STAGED copy must render', async () => {
+    // `getMyListingForApp` redirects `editTargetId` onto an existing shadow with no
+    // moderator branch, so this write goes to the shadow and only goes live on
+    // re-approval. Gating the "applies immediately" copy on `isModerator` alone told
+    // this moderator the opposite. The shared fixture is exactly this shape.
+    state.currentUser = { id: 1, username: 'mod', isModerator: true };
+    renderWithProviders(<ListingMediaPage />);
+
+    // Precondition: the step is hosted against the SHADOW, not the live parent.
+    await expect.element(page.getByTestId('asset-step')).toHaveTextContent('assets:apl_shadow:');
+
+    const notice = page.getByTestId('apps-listing-media-live-notice');
+    await expect.element(notice).toBeInTheDocument();
+    await expect.element(notice).toHaveTextContent(/staged as a revision/i);
+    await expect.element(notice).toHaveTextContent(/go live only after a moderator re-approves/i);
+
+    // The immediate-edit claim must NOT appear for this moderator.
+    expect(page.getByTestId('apps-listing-media-mod-live-notice').elements()).toHaveLength(0);
+    expect(page.getByText(/apply to the live listing immediately/i).elements()).toHaveLength(0);
+  });
+
   test('🔴 a NON-moderator owner keeps the staged-revision copy (and never sees the mod variant)', async () => {
     state.currentUser = { id: 7, username: 'owner', isModerator: false };
     renderWithProviders(<ListingMediaPage />);
@@ -330,6 +371,22 @@ describe('ListingMediaPage — owner listing-media route shell', () => {
     await expect.element(notice).toHaveTextContent(/staged as a revision/i);
     await expect.element(notice).toHaveTextContent(/go live only after a moderator re-approves/i);
 
+    expect(page.getByTestId('apps-listing-media-mod-live-notice').elements()).toHaveLength(0);
+  });
+
+  test('a NON-moderator owner with NO shadow still gets the STAGED copy (their first edit mints one)', async () => {
+    // `!shadowId` alone must not flip the copy — it only means "immediate" for a mod.
+    state.currentUser = { id: 7, username: 'owner', isModerator: false };
+    state.query.data = {
+      ...(state.query.data as Record<string, unknown>),
+      shadowId: null,
+      editTargetId: 'apl_onsite',
+    };
+    renderWithProviders(<ListingMediaPage />);
+
+    await expect
+      .element(page.getByTestId('apps-listing-media-live-notice'))
+      .toHaveTextContent(/staged as a revision/i);
     expect(page.getByTestId('apps-listing-media-mod-live-notice').elements()).toHaveLength(0);
   });
 
@@ -348,6 +405,39 @@ describe('ListingMediaPage — owner listing-media route shell', () => {
     await expect.element(page.getByTestId('asset-step')).toBeInTheDocument();
     expect(page.getByTestId('apps-listing-media-mod-live-notice').elements()).toHaveLength(0);
     expect(page.getByTestId('apps-listing-media-live-notice').elements()).toHaveLength(0);
+  });
+
+  // -------------------------------------------------------------------------
+  // The Submit affordance must follow the SAME discriminator as the notice.
+  // -------------------------------------------------------------------------
+
+  test('🔴 MOD + NO shadow: no dead Submit button and no "stage a revision" hint', async () => {
+    // No edit by this moderator will ever mint a shadow, so `disabled={… || !shadowId}`
+    // would leave Submit permanently dead beneath a banner correctly saying the change
+    // is already live, next to a hint promising a revision that never appears.
+    state.currentUser = { id: 1, username: 'mod', isModerator: true };
+    state.query.data = {
+      ...(state.query.data as Record<string, unknown>),
+      shadowId: null,
+      editTargetId: 'apl_onsite',
+    };
+    renderWithProviders(<ListingMediaPage />);
+
+    await expect.element(page.getByTestId('asset-step')).toBeInTheDocument();
+    expect(page.getByTestId('apps-listing-media-submit').elements()).toHaveLength(0);
+    expect(page.getByTestId('apps-listing-media-no-changes').elements()).toHaveLength(0);
+  });
+
+  test('🔴 MOD + shadow: Submit REMAINS — that revision still needs re-approval', async () => {
+    // The mirror of the test above: hiding Submit on `isModerator` alone would strand a
+    // real revision with no way to send it for review.
+    state.currentUser = { id: 1, username: 'mod', isModerator: true };
+    state.floor = { meetsFloor: true, complete: false };
+    renderWithProviders(<ListingMediaPage />);
+
+    const submit = page.getByTestId('apps-listing-media-submit');
+    await expect.element(submit).toBeInTheDocument();
+    await expect.element(submit).not.toBeDisabled();
   });
 
   test('Submit for review fires submitListingRevision with the shadow id', async () => {


### PR DESCRIPTION
## The defect

The "Listing media" tab of `/apps/[appBlockId]/edit` renders one informational notice to everyone:

> This app is **live** — your image changes are staged as a revision and go live only after a moderator re-approves. …

That is false for a **moderator editing a live listing that has no revision in progress**. The asset-edit path deliberately bypasses the shadow-revision flow for moderators (they curate live listings on purpose), so in that state their icon / cover / screenshot edit is written **directly to the live listing** — no revision is staged and nothing is re-approved. The banner told them the opposite of what the server does with their edit.

Observed in production: a moderator added screenshots to six live listings and every write applied to the live listing, with zero revisions created. (This editor's read is owner-bound with no moderator branch, so it is only ever reachable for your *own* listing — the moderator owned all six.)

## The fix

Copy/UI only — **no server behaviour is changed**. The bypass is intended; only the banner was wrong.

The discriminator is **`isModerator && !shadowId`**, not `isModerator`. That distinction is load-bearing: when a revision already exists, the read resolves the editor's target onto it with no moderator branch, so a moderator in that state is editing the revision and **is** staged. Gating on `isModerator` alone would just relocate the false claim onto that (common) case.

Four states, each now correct and each pinned by a test:

| caller | listing state | notice |
|---|---|---|
| non-moderator | approved | staged (blue) |
| moderator | approved, no revision in progress | **immediate (orange)** |
| moderator | approved, revision already in progress | staged (blue) — it *is* staged |
| anyone | draft / pending | neither |

Also folded in, on the **same** discriminator:

- The "Change an image to stage a revision." hint and the "Submit for review" button are hidden for a moderator editing the live listing. No edit of theirs mints a revision, so that button was permanently disabled directly under a banner correctly saying the change was already live. Deliberately *not* widened to `isModerator` — a moderator with a revision in progress still needs to submit it, and a test pins that.
- Moderator status is read via `useCurrentUser()`, the established client idiom in this area (same as `ExternalSubmitForm`), so every host of the editor is correct without threading a prop.
- The component's JSDoc previously stated the moderator write lands directly on the live listing *unconditionally*. That over-generalisation is exactly what produced the first, wrong version of this fix, so it now spells out the exception.

## Sibling copy checked, not changed

`ExternalListingEditForm` carries similar "your edits are staged as a revision" copy. I traced the path it actually submits to and **the same bypass does not apply**, so it is left alone:

- Its revision is resolved server-side by `getMyListingForEdit`, which calls `beginListingRevision`.
- `beginListingRevision` gates on `loadOwnedEditableListing`, which is strictly owner-only and has **no moderator branch**. An approved listing therefore always yields a revision, for moderators too.
- The form hosts its asset step against that revision id, and scalar saves go to the revision-draft procedures. Because the target is already a revision, the asset-service moderator bypass is a no-op for everyone.

So its copy is accurate for moderators as written.

## Tests

24 in the file now (17 pre-existing + 7 added). The two that **discriminate** — i.e. that fail if the gating is wrong — are:

- **moderator with a revision in progress** sees the staged copy and *not* the immediate one (this is the one that catches using `isModerator` alone);
- **moderator with no revision** gets no dead Submit button and no "stage a revision" hint.

Mutation-checked against the previous commit on this branch (the `isModerator`-only version):

```
Tests  2 failed | 22 passed (24)

FAIL … > 🔴 MOD + shadow ALREADY exists: the edit IS staged, so the STAGED copy must render
  VitestBrowserElementError: Cannot find element with locator:
  getByTestId('apps-listing-media-live-notice')

FAIL … > 🔴 MOD + NO shadow: no dead Submit button and no "stage a revision" hint
  AssertionError: expected [ <button …(7)>…(1)</button> ] to have a length of +0 but got 1
```

With the fix in place: **24/24 green**.

The other added tests (non-moderator keeps the staged copy; non-moderator with no revision still gets the staged copy; moderator on a draft sees neither notice; moderator with a revision keeps Submit) also pass against the unfixed component — they are regression pins for the remaining quadrants, not mutation-detectors, and are described that way deliberately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
