### PR TITLE
fix(notifications): collapse duplicate notifications for one comment

### DIFF
--- a/apps/notifications/src/lib/server/create.behavioral.test.ts
+++ b/apps/notifications/src/lib/server/create.behavioral.test.ts
@@ -82,9 +82,12 @@ function payload(over: Partial<CreateNotificationPendingRow> = {}): CreateNotifi
   };
 }
 
-const settingsCall = () => h.state.mainCalls.find((c) => c.sql.includes('UserNotificationSettings'));
-const updateCall = () => h.state.notifCalls.find((c) => c.sql.includes('UPDATE "PendingNotification"'));
-const insertCall = () => h.state.notifCalls.find((c) => c.sql.includes('INSERT INTO "PendingNotification"'));
+const settingsCall = () =>
+  h.state.mainCalls.find((c) => c.sql.includes('UserNotificationSettings'));
+const updateCall = () =>
+  h.state.notifCalls.find((c) => c.sql.includes('UPDATE "PendingNotification"'));
+const insertCall = () =>
+  h.state.notifCalls.find((c) => c.sql.includes('INSERT INTO "PendingNotification"'));
 
 beforeEach(() => {
   h.reset();
@@ -177,12 +180,12 @@ describe('UPDATE-first → INSERT-ON-CONFLICT fallback', () => {
     expect(ret).toEqual({ queued: 2 });
   });
 
-  it('INSERT positional params + casts are indexed $1..$6 in the documented order', async () => {
+  it('INSERT positional params + casts are indexed $1..$7 in the documented order', async () => {
     h.state.updateRows = [];
     await createNotification(payload({ userIds: [11, 22], debounceSeconds: 300 }));
 
     const ins = insertCall()!;
-    // $1 key, $2 type, $3 category, $4 users, $5 details(json), $6 debounceSeconds
+    // $1 key, $2 type, $3 category, $4 users, $5 details(json), $6 debounceSeconds, $7 dedupeKey
     expect(ins.params).toEqual([
       'comment:1',
       'comment',
@@ -190,6 +193,7 @@ describe('UPDATE-first → INSERT-ON-CONFLICT fallback', () => {
       [11, 22],
       JSON.stringify({ foo: 'bar' }),
       300,
+      null,
     ]);
     // Casts must line up with the placeholders (the real off-by-one / cast-shape risk).
     expect(ins.sql).toContain('$3::"NotificationCategory"');

--- a/apps/notifications/src/lib/server/create.ts
+++ b/apps/notifications/src/lib/server/create.ts
@@ -51,8 +51,8 @@ export async function createNotification(
 
     if (updated.length === 0) {
       const insertResp = await notifDbWrite().cancellableQuery(
-        `INSERT INTO "PendingNotification" (key, type, category, users, details, "debounceSeconds")
-         VALUES ($1, $2, $3::"NotificationCategory", $4::int[], $5::jsonb, $6)
+        `INSERT INTO "PendingNotification" (key, type, category, users, details, "debounceSeconds", "dedupeKey")
+         VALUES ($1, $2, $3::"NotificationCategory", $4::int[], $5::jsonb, $6, $7)
          ON CONFLICT (key)
          DO UPDATE SET "users" = ARRAY(SELECT DISTINCT unnest("PendingNotification"."users" || excluded."users")), "lastTriggered" = NOW()`,
         [
@@ -62,6 +62,7 @@ export async function createNotification(
           targets,
           JSON.stringify(data.details),
           data.debounceSeconds ?? null,
+          data.dedupeKey ?? null,
         ]
       );
       await insertResp.result();

--- a/apps/notifications/src/lib/server/operations.createNotificationsBulk.test.ts
+++ b/apps/notifications/src/lib/server/operations.createNotificationsBulk.test.ts
@@ -116,3 +116,30 @@ describe('createNotificationsBulk dedupeKey passthrough', () => {
     expect(columns).toHaveLength(7);
   });
 });
+
+describe('createNotificationsBulk dedupeKey on the UPDATE-first path', () => {
+  it('back-fills dedupeKey onto a pending row that predates the column', async () => {
+    // A row queued by the previous build carries NULL; without this it fans out un-deduped.
+    h.state.updatedKeys = ['comment:1'];
+    await createNotificationsBulk([{ ...row('comment:1', [11]), dedupeKey: 'comment:v2:1' }]);
+
+    const upd = updateCall()!;
+    expect(upd.sql).toContain('"dedupeKey" = COALESCE(pn."dedupeKey", u."dedupeKey")');
+    expect(upd.sql).toContain("'comment:v2:1'");
+  });
+
+  it('never overwrites an existing dedupeKey (same key always means the same source event)', async () => {
+    h.state.updatedKeys = ['comment:1'];
+    await createNotificationsBulk([{ ...row('comment:1', [11]), dedupeKey: 'comment:v2:1' }]);
+
+    // COALESCE(existing, incoming) — not a bare assign, which would let a later batch retarget the row.
+    expect(updateCall()!.sql).not.toMatch(/"dedupeKey"\s*=\s*u\."dedupeKey"\s*[,\n]/);
+  });
+
+  it('VALUES tuples still line up with the aliased column list', async () => {
+    h.state.updatedKeys = ['comment:1'];
+    await createNotificationsBulk([row('comment:1', [11])]);
+
+    expect(updateCall()!.sql).toContain('AS u(key, users, "dedupeKey")');
+  });
+});

--- a/apps/notifications/src/lib/server/operations.createNotificationsBulk.test.ts
+++ b/apps/notifications/src/lib/server/operations.createNotificationsBulk.test.ts
@@ -39,12 +39,17 @@ vi.mock('./lag', () => ({
   isWritePool: () => false,
   preventReplicationLag: async () => {},
 }));
-vi.mock('./clients/axiom', () => ({ logToAxiom: vi.fn(async () => {}), safeError: (e: unknown) => e }));
+vi.mock('./clients/axiom', () => ({
+  logToAxiom: vi.fn(async () => {}),
+  safeError: (e: unknown) => e,
+}));
 
 import { createNotificationsBulk } from './operations';
 
-const updateCall = () => h.state.notifCalls.find((c) => c.sql.includes('UPDATE "PendingNotification"'));
-const insertCall = () => h.state.notifCalls.find((c) => c.sql.includes('INSERT INTO "PendingNotification"'));
+const updateCall = () =>
+  h.state.notifCalls.find((c) => c.sql.includes('UPDATE "PendingNotification"'));
+const insertCall = () =>
+  h.state.notifCalls.find((c) => c.sql.includes('INSERT INTO "PendingNotification"'));
 
 const row = (key: string, users: number[]) => ({
   key,
@@ -80,5 +85,34 @@ describe('createNotificationsBulk users-array merge on upsert', () => {
     expect(ins.sql).toContain('unnest("PendingNotification"."users" || excluded."users")');
     expect(ins.sql).toContain('SELECT DISTINCT');
     expect(ins.sql).not.toMatch(/"users"\s*=\s*excluded\."users"/);
+  });
+});
+
+describe('createNotificationsBulk dedupeKey passthrough', () => {
+  it('carries the dedupeKey into the PendingNotification INSERT so the worker can fan it out', async () => {
+    h.state.updatedKeys = [];
+    await createNotificationsBulk([{ ...row('comment:1', [11, 22]), dedupeKey: 'comment:v2:1' }]);
+
+    const ins = insertCall()!;
+    expect(ins.sql).toContain('"dedupeKey"');
+    expect(ins.sql).toContain("'comment:v2:1'");
+  });
+
+  it('emits NULL for rows that opt out of dedup', async () => {
+    h.state.updatedKeys = [];
+    await createNotificationsBulk([row('comment:1', [11, 22])]);
+
+    const ins = insertCall()!;
+    expect(ins.sql).toContain('"dedupeKey"');
+    expect(ins.sql).toContain('NULL');
+  });
+
+  it('columns and VALUES tuples stay the same arity (an off-by-one here shifts every column)', async () => {
+    h.state.updatedKeys = [];
+    await createNotificationsBulk([{ ...row('comment:1', [11]), dedupeKey: 'comment:v2:1' }]);
+
+    const ins = insertCall()!;
+    const columns = ins.sql.match(/INSERT INTO "PendingNotification" \(([^)]+)\)/)![1].split(',');
+    expect(columns).toHaveLength(7);
   });
 });

--- a/apps/notifications/src/lib/server/operations.ts
+++ b/apps/notifications/src/lib/server/operations.ts
@@ -29,12 +29,17 @@ export async function createNotificationsBulk(rows: CreateNotificationRow[]): Pr
     // calls nextval() for every VALUES row before the conflict check, so an all-conflict batch burns one
     // id per row. UPDATE the existing keys, then INSERT only the misses.
     const updateValues = batch
-      .map((d) => format('(%L, %L)', d.key, `{${d.users.join(',')}}`))
+      .map((d) => format('(%L, %L, %L)', d.key, `{${d.users.join(',')}}`, d.dedupeKey ?? null))
       .join(',');
+    // COALESCE, not a bare assign: the queued row may predate this column (a pending row written by the
+    // previous build carries NULL), and re-claiming it here is what keeps that deploy window deduped.
+    // An existing key is never overwritten — the same `key` always implies the same source event.
     const updateResp = await write.cancellableQuery<{ key: string }>(`
       UPDATE "PendingNotification" pn
-      SET "users" = ARRAY(SELECT DISTINCT unnest(pn."users" || u.users::int[])), "lastTriggered" = NOW()
-      FROM (VALUES ${updateValues}) AS u(key, users)
+      SET "users" = ARRAY(SELECT DISTINCT unnest(pn."users" || u.users::int[])),
+          "lastTriggered" = NOW(),
+          "dedupeKey" = COALESCE(pn."dedupeKey", u."dedupeKey")
+      FROM (VALUES ${updateValues}) AS u(key, users, "dedupeKey")
       WHERE pn."key" = u.key
       RETURNING pn."key"
     `);

--- a/apps/notifications/src/lib/server/operations.ts
+++ b/apps/notifications/src/lib/server/operations.ts
@@ -45,18 +45,19 @@ export async function createNotificationsBulk(rows: CreateNotificationRow[]): Pr
       const insertValues = toInsert
         .map((d) =>
           format(
-            '(%L, %L, %L::"NotificationCategory", %L, %L::jsonb, %L)',
+            '(%L, %L, %L::"NotificationCategory", %L, %L::jsonb, %L, %L)',
             d.key,
             d.type,
             d.category,
             `{${d.users.join(',')}}`,
             JSON.stringify(d.details),
-            d.debounceSeconds ?? null
+            d.debounceSeconds ?? null,
+            d.dedupeKey ?? null
           )
         )
         .join(',');
       const insertResp = await write.cancellableQuery(`
-        INSERT INTO "PendingNotification" (key, type, category, users, details, "debounceSeconds")
+        INSERT INTO "PendingNotification" (key, type, category, users, details, "debounceSeconds", "dedupeKey")
         VALUES ${insertValues}
         ON CONFLICT (key) DO UPDATE SET "users" = ARRAY(SELECT DISTINCT unnest("PendingNotification"."users" || excluded."users")), "lastTriggered" = NOW()
       `);
@@ -268,9 +269,7 @@ export function markNotificationsRead(input: MarkReadInput): void {
   });
 }
 
-async function runMarkReadWithRetry(
-  input: MarkReadInput & { all: boolean }
-): Promise<void> {
+async function runMarkReadWithRetry(input: MarkReadInput & { all: boolean }): Promise<void> {
   const { userId, all, category } = input;
   for (let attempt = 1; attempt <= MARK_READ_MAX_ATTEMPTS; attempt++) {
     try {
@@ -351,6 +350,7 @@ async function markReadImpl(input: MarkReadInput & { all: boolean }): Promise<vo
       [id]
     );
     const catData = await catQuery.result();
-    if (catData.length) notificationCache.decrementUser(userId, catData[0].category).catch(() => null);
+    if (catData.length)
+      notificationCache.decrementUser(userId, catData[0].category).catch(() => null);
   }
 }

--- a/apps/notifications/src/worker/poll-loop.behavioral.test.ts
+++ b/apps/notifications/src/worker/poll-loop.behavioral.test.ts
@@ -61,20 +61,24 @@ vi.mock('../env', () => ({ signalsEndpoint: 'http://signals.test' }));
 
 import { create, handleDebounce, handleNormal, run } from './poll-loop';
 import { notificationCache } from '../lib/server/cache';
-import {
-  notificationsFannedOutTotal,
-  workerPendingProcessedTotal,
-} from '../lib/server/metrics';
+import { notificationsFannedOutTotal, workerPendingProcessedTotal } from '../lib/server/metrics';
 
 // ---- Fake PoolClient -------------------------------------------------------------------------------------
 // query(sql) dispatches on the SQL shape and returns a per-key canned response. A response is either
 // `{ rows }` or `{ throw: err }`; a key's value may be a single response (reused) or an array consumed in
 // call order (so the 23505 retry can be `[<empty select>, <select returns id>]`).
 type Resp = { rows?: any[]; throw?: any };
-type Responses = Partial<Record<
-  'notifSelect' | 'notifUpdate' | 'notifInsert' | 'userInsert' | 'pendingDelete' | 'pendingUpdate',
-  Resp | Resp[]
->>;
+type Responses = Partial<
+  Record<
+    | 'notifSelect'
+    | 'notifUpdate'
+    | 'notifInsert'
+    | 'userInsert'
+    | 'pendingDelete'
+    | 'pendingUpdate',
+    Resp | Resp[]
+  >
+>;
 
 function keyFor(sql: string): keyof Responses | 'txn' | null {
   if (sql === 'BEGIN' || sql === 'COMMIT' || sql === 'ROLLBACK') return 'txn';
@@ -127,7 +131,10 @@ beforeEach(() => {
   h.state.connectClient = null;
   h.state.connectError = null;
   h.state.pendingRows = [];
-  vi.stubGlobal('fetch', vi.fn(async () => ({ ok: true }) as any));
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () => ({ ok: true } as any))
+  );
 });
 
 afterEach(() => {
@@ -185,7 +192,13 @@ describe('handleNormal', () => {
     const ret = await handleNormal({ ...baseRow, debounceSeconds: null } as any, client);
 
     // SELECT, INSERT(throws), SELECT(retry), then fan-out on the recovered id.
-    expect(client.keys()).toEqual(['notifSelect', 'notifInsert', 'notifSelect', 'userInsert', 'pendingDelete']);
+    expect(client.keys()).toEqual([
+      'notifSelect',
+      'notifInsert',
+      'notifSelect',
+      'userInsert',
+      'pendingDelete',
+    ]);
     const userSql = client.calls.find((s: string) => keyFor(s) === 'userInsert')!;
     expect(userSql).toContain("'777'"); // recovered id from the re-SELECT reaches fan-out
     expect(ret).toEqual([{ id: 3, userId: 11, createdAt: 'z' }]);
@@ -196,7 +209,9 @@ describe('handleNormal', () => {
       notifSelect: { rows: [] },
       notifInsert: { throw: { code: '23502' } }, // not_null_violation — a real bug, must surface
     });
-    await expect(handleNormal({ ...baseRow, debounceSeconds: null } as any, client)).rejects.toEqual({
+    await expect(
+      handleNormal({ ...baseRow, debounceSeconds: null } as any, client)
+    ).rejects.toEqual({
       code: '23502',
     });
     // No re-SELECT, no fan-out, no delete after a hard failure.
@@ -207,7 +222,12 @@ describe('handleNormal', () => {
     // 2 users, default insertBatchSize (5000) → single batch; assert both fanned rows returned.
     const client = makeClient({
       notifSelect: { rows: [{ id: 1 }] },
-      userInsert: { rows: [{ id: 10, userId: 11, createdAt: 'a' }, { id: 11, userId: 22, createdAt: 'b' }] },
+      userInsert: {
+        rows: [
+          { id: 10, userId: 11, createdAt: 'a' },
+          { id: 11, userId: 22, createdAt: 'b' },
+        ],
+      },
     });
     const ret = await handleNormal({ ...baseRow, debounceSeconds: null } as any, client);
     expect(ret).toHaveLength(2);
@@ -384,7 +404,10 @@ describe('run (poll pass)', () => {
   it('counts an errored outcome and skips fan-out when create returns undefined', async () => {
     // A handler error inside the txn → create() ROLLBACKs and returns undefined (the only path to
     // undefined; connect() throwing would propagate out of create, so it must fail mid-transaction).
-    const client = makeClient({ notifSelect: { rows: [] }, notifInsert: { throw: { code: '23502' } } });
+    const client = makeClient({
+      notifSelect: { rows: [] },
+      notifInsert: { throw: { code: '23502' } },
+    });
     h.state.connectClient = client;
     h.state.pendingRows = [{ ...baseRow, debounceSeconds: null }];
 
@@ -395,7 +418,7 @@ describe('run (poll pass)', () => {
     // No fan-out side effects for a failed row.
     expect(notificationsFannedOutTotal.inc).not.toHaveBeenCalled();
     expect(notificationCache.incrementUser).not.toHaveBeenCalled();
-    expect((globalThis.fetch as any)).not.toHaveBeenCalled();
+    expect(globalThis.fetch as any).not.toHaveBeenCalled();
   });
 
   it('fans out: increments the per-user cache and POSTs a realtime signal per affected user', async () => {
@@ -425,6 +448,93 @@ describe('run (poll pass)', () => {
     h.state.pendingRows = [];
     await run();
     expect(workerPendingProcessedTotal.inc).not.toHaveBeenCalled();
-    expect((globalThis.fetch as any)).not.toHaveBeenCalled();
+    expect(globalThis.fetch as any).not.toHaveBeenCalled();
+  });
+});
+
+// =========================================================================================================
+// Cross-type dedup. A single comment can match several notification types at once (@mention + thread reply
+// + comment-on-your-model), each arriving as its OWN PendingNotification row with its own `key`. They share
+// a `dedupeKey`, and the partial UNIQUE ("userId", "dedupeKey") is what collapses them to one per recipient.
+describe('handleNormal — dedupeKey fan-out', () => {
+  it('writes the dedupeKey onto each UserNotification row', async () => {
+    const client = makeClient({
+      notifSelect: { rows: [{ id: 500 }] },
+      userInsert: { rows: [{ id: 1, userId: 11, createdAt: 'x' }] },
+    });
+    await handleNormal(
+      { ...baseRow, debounceSeconds: null, dedupeKey: 'comment:v2:1' } as any,
+      client
+    );
+
+    const userSql = client.calls.find((s: string) => keyFor(s) === 'userInsert')!;
+    expect(userSql).toContain('"dedupeKey"');
+    // Once per recipient — the key is per-EVENT, so every user in the row carries the same one.
+    expect(userSql.match(/comment:v2:1/g)).toHaveLength(baseRow.users.length);
+  });
+
+  it('leaves the column NULL when the type opts out of dedup', async () => {
+    const client = makeClient({
+      notifSelect: { rows: [{ id: 500 }] },
+      userInsert: { rows: [{ id: 1, userId: 11, createdAt: 'x' }] },
+    });
+    await handleNormal({ ...baseRow, debounceSeconds: null, dedupeKey: null } as any, client);
+
+    const userSql = client.calls.find((s: string) => keyFor(s) === 'userInsert')!;
+    expect(userSql).toContain('NULL');
+  });
+
+  it('keeps ON CONFLICT UNTARGETED so the dedupe index can absorb the conflict too', async () => {
+    // A targeted `ON CONFLICT ("notificationId","userId")` would NOT cover the dedupe index — a duplicate
+    // would raise 23505 and abort the transaction instead of being silently skipped.
+    const client = makeClient({ notifSelect: { rows: [{ id: 1 }] }, userInsert: { rows: [] } });
+    await handleNormal(
+      { ...baseRow, debounceSeconds: null, dedupeKey: 'comment:v2:1' } as any,
+      client
+    );
+
+    const userSql = client.calls.find((s: string) => keyFor(s) === 'userInsert')!;
+    expect(userSql).toContain('ON CONFLICT DO NOTHING');
+    expect(userSql).not.toMatch(/ON CONFLICT\s*\(/);
+  });
+
+  it('a deduped recipient is absent from RETURNING → no signal, no unread bump', async () => {
+    // The second type to fire for the same comment: the insert conflicts, so RETURNING comes back empty.
+    h.state.pendingRows = [
+      { ...baseRow, users: [11], debounceSeconds: null, dedupeKey: 'comment:v2:1' },
+    ];
+    h.state.connectClient = makeClient({
+      notifSelect: { rows: [{ id: 1 }] },
+      userInsert: { rows: [] },
+    });
+    await run();
+
+    expect(notificationsFannedOutTotal.inc).toHaveBeenCalledWith(0);
+    expect(notificationCache.incrementUser).not.toHaveBeenCalled();
+    expect(globalThis.fetch as any).not.toHaveBeenCalled();
+  });
+});
+
+describe('handleDebounce — dedupeKey', () => {
+  it('never writes a dedupeKey (its targeted ON CONFLICT could not absorb that conflict)', async () => {
+    const client = makeClient({
+      notifUpdate: { rows: [{ id: 300 }] },
+      userInsert: { rows: [{ id: 3, userId: 11, createdAt: 'z' }] },
+    });
+    await handleDebounce(
+      {
+        ...baseRow,
+        debounceSeconds: 60,
+        dedupeKey: 'comment:v2:1',
+        lastTriggered: '2026-01-01T00:00:00Z',
+        nextSendAt: '2026-01-01T00:00:00Z',
+      } as any,
+      client
+    );
+
+    const userSql = client.calls.find((s: string) => keyFor(s) === 'userInsert')!;
+    expect(userSql).not.toContain('"dedupeKey"');
+    expect(userSql).not.toContain('comment:v2:1');
+    expect(userSql).toContain('ON CONFLICT ("notificationId", "userId")');
   });
 });

--- a/apps/notifications/src/worker/poll-loop.test.ts
+++ b/apps/notifications/src/worker/poll-loop.test.ts
@@ -18,7 +18,9 @@ describe('PENDING_CLAIM_QUERY', () => {
     // FOR UPDATE SKIP LOCKED must sit after LIMIT (inside the CTE) so only the claimed batch is locked.
     // Order matters: `... LIMIT <n> FOR UPDATE SKIP LOCKED )` then the outer UPDATE.
     expect(sql).toMatch(/LIMIT \d+ FOR UPDATE SKIP LOCKED \)/);
-    expect(sql.indexOf('FOR UPDATE SKIP LOCKED')).toBeLessThan(sql.indexOf('UPDATE "PendingNotification" pn'));
+    expect(sql.indexOf('FOR UPDATE SKIP LOCKED')).toBeLessThan(
+      sql.indexOf('UPDATE "PendingNotification" pn')
+    );
   });
 
   it('claims by stamping claimedAt and reclaims rows stuck past the too-old window', () => {
@@ -34,5 +36,12 @@ describe('PENDING_CLAIM_QUERY', () => {
 
   it('returns the claimed rows so the worker can fan them out', () => {
     expect(sql).toMatch(/RETURNING \*$/);
+  });
+});
+
+describe('PENDING_CLAIM_QUERY — dedupeKey', () => {
+  it('selects dedupeKey so the fan-out can stamp it onto UserNotification', () => {
+    // Omitting it here makes the column silently undefined at fan-out and cross-type dedup a no-op.
+    expect(sql).toContain('"dedupeKey"');
   });
 });

--- a/apps/notifications/src/worker/poll-loop.ts
+++ b/apps/notifications/src/worker/poll-loop.ts
@@ -184,11 +184,12 @@ export const handleDebounce = async (
     respId = insRes.rows[0]?.id;
   }
 
-  // Debounced rows deliberately leave "dedupeKey" NULL (the column default). This INSERT targets ONE
-  // constraint so it can re-surface a debounced notification (createdAt/viewed reset); a row that also
-  // carried a dedupeKey could violate the OTHER unique index, which a targeted ON CONFLICT cannot absorb
-  // — it would abort the transaction. Cross-type dedup is a normal-path concern only (no debounced type
-  // shares a source event with another type today); revisit here before setting dedupeKey on one.
+  // This INSERT omits "dedupeKey" entirely, so a debounced row writes NULL and is excluded from the
+  // partial unique index — a dedupeKey on a debounced row is silently DROPPED, not honored. That is
+  // deliberate: the targeted ON CONFLICT below is what lets a debounce re-surface a notification
+  // (createdAt/viewed reset), and it could not absorb a violation of the other index. The producer
+  // contract rejects the combination outright (see createNotificationPendingRow), so this is
+  // unreachable — belt and braces. Teaching debounced types to dedup means reworking this INSERT.
   if (respId) {
     const userMappedData = users.map((u) => [respId, u]);
     for (const batch of chunk(userMappedData, insertBatchSize)) {

--- a/apps/notifications/src/worker/poll-loop.ts
+++ b/apps/notifications/src/worker/poll-loop.ts
@@ -31,6 +31,7 @@ type PendingReturnRow = {
   debounceSeconds: number | null;
   lastTriggered: string;
   nextSendAt: string;
+  dedupeKey: string | null;
 };
 
 type RetData = {
@@ -64,7 +65,7 @@ export const PENDING_CLAIM_QUERY = `
     return_data AS (
       SELECT
         id, type, category, key, users, details,
-        "debounceSeconds", "lastTriggered", "nextSendAt"
+        "debounceSeconds", "lastTriggered", "nextSendAt", "dedupeKey"
       FROM "PendingNotification"
       WHERE
         ("claimedAt" IS NULL OR "claimedAt" < NOW() - INTERVAL '${tooOld}')
@@ -94,8 +95,11 @@ const getPending = async (): Promise<PendingReturnRow[]> => {
 };
 
 // Exported for behavioral unit tests (fake PoolClient). Export-for-test only — logic unchanged.
-export const handleNormal = async (row: PendingReturnRow, client: PoolClient): Promise<RetData[]> => {
-  const { id, key, type, category, details, users } = row;
+export const handleNormal = async (
+  row: PendingReturnRow,
+  client: PoolClient
+): Promise<RetData[]> => {
+  const { id, key, type, category, details, users, dedupeKey } = row;
   let retData: RetData[] = [];
 
   // SELECT first to avoid burning a Notification.id sequence value when the key already exists.
@@ -124,11 +128,16 @@ export const handleNormal = async (row: PendingReturnRow, client: PoolClient): P
 
   // Always run fan-out — Notification.key is shared across users, so a pre-existing key may still have
   // new users in this row. UserNotification's UNIQUE (notificationId, userId) dedups safely.
+  //
+  // The untargeted ON CONFLICT DO NOTHING covers BOTH unique constraints, which is what makes cross-type
+  // dedup work: a recipient who already has a row carrying this `dedupeKey` (from a different type fired
+  // for the same source event) trips the partial UNIQUE ("userId", "dedupeKey") and is skipped. Skipped
+  // rows are absent from RETURNING, so they also produce no signal and no unread-count increment.
   if (respId) {
-    const userMappedData = users.map((u) => [respId, u]);
+    const userMappedData = users.map((u) => [respId, u, dedupeKey]);
     for (const batch of chunk(userMappedData, insertBatchSize)) {
       const insertUsersQuery = format(
-        `INSERT INTO "UserNotification" ("notificationId", "userId")
+        `INSERT INTO "UserNotification" ("notificationId", "userId", "dedupeKey")
          VALUES %L ON CONFLICT DO NOTHING RETURNING id, "userId", "createdAt"`,
         batch
       );
@@ -142,8 +151,12 @@ export const handleNormal = async (row: PendingReturnRow, client: PoolClient): P
 };
 
 // Exported for behavioral unit tests (fake PoolClient). Export-for-test only — logic unchanged.
-export const handleDebounce = async (row: PendingReturnRow, client: PoolClient): Promise<RetData[]> => {
-  const { id, key, type, category, details, users, debounceSeconds, lastTriggered, nextSendAt } = row;
+export const handleDebounce = async (
+  row: PendingReturnRow,
+  client: PoolClient
+): Promise<RetData[]> => {
+  const { id, key, type, category, details, users, debounceSeconds, lastTriggered, nextSendAt } =
+    row;
   let retData: RetData[] = [];
 
   if (
@@ -171,6 +184,11 @@ export const handleDebounce = async (row: PendingReturnRow, client: PoolClient):
     respId = insRes.rows[0]?.id;
   }
 
+  // Debounced rows deliberately leave "dedupeKey" NULL (the column default). This INSERT targets ONE
+  // constraint so it can re-surface a debounced notification (createdAt/viewed reset); a row that also
+  // carried a dedupeKey could violate the OTHER unique index, which a targeted ON CONFLICT cannot absorb
+  // — it would abort the transaction. Cross-type dedup is a normal-path concern only (no debounced type
+  // shares a source event with another type today); revisit here before setting dedupeKey on one.
   if (respId) {
     const userMappedData = users.map((u) => [respId, u]);
     for (const batch of chunk(userMappedData, insertBatchSize)) {

--- a/containers/notification-db/docker-init/01_all_ddl.sql
+++ b/containers/notification-db/docker-init/01_all_ddl.sql
@@ -141,3 +141,13 @@ DROP INDEX "UserNotification_viewed_idx";
 DROP INDEX "UserNotification_userId_idx";
 DROP INDEX "UserNotification_createdAt_idx";
 DROP INDEX "UserNotification_userId_viewed_createdAt_idx";
+
+-- Cross-type notification dedup: one source event (e.g. a single comment) can match several
+-- notification types at once; each carries the same "dedupeKey" so a recipient only ever gets the
+-- first one to land. NULL opts a row out of dedup entirely (every non-comment type today).
+ALTER TABLE "PendingNotification" ADD COLUMN "dedupeKey" TEXT;
+ALTER TABLE "UserNotification" ADD COLUMN "dedupeKey" TEXT;
+
+CREATE UNIQUE INDEX CONCURRENTLY "UserNotification_userId_dedupeKey_uniq"
+    ON "UserNotification" ("userId", "dedupeKey")
+    WHERE "dedupeKey" IS NOT NULL;

--- a/packages/civitai-notifications/src/schema.ts
+++ b/packages/civitai-notifications/src/schema.ts
@@ -8,11 +8,21 @@ import { notificationCategories } from './constants';
 
 const notificationCategory = z.enum(notificationCategories);
 
+/**
+ * Identifies the underlying *event* a notification was derived from, shared by every type that can fire
+ * for it (a comment that is simultaneously an @mention, a thread reply, and a comment on your model
+ * carries one `dedupeKey` across all three). A partial UNIQUE ("userId", "dedupeKey") on
+ * `UserNotification` collapses those to the first one that lands; `key` stays per-type so the queue and
+ * `Notification` rows are unaffected. Null opts a type out of cross-type dedup entirely.
+ */
+const dedupeKey = z.string().nullish();
+
 export const notificationSingleRow = z.object({
   key: z.string(),
   userId: z.number(),
   type: z.string(),
   details: z.record(z.string(), z.any()),
+  dedupeKey,
 });
 export type NotificationSingleRow = z.infer<typeof notificationSingleRow>;
 
@@ -26,11 +36,13 @@ export type NotificationSingleRowFull = z.infer<typeof notificationSingleRowFull
  * `debounceSeconds` opts the row into the debounce path (a settle window before fan-out). This is the
  * exact shape the monolith's `createNotification` accepted, lifted into the shared seam.
  */
-export const createNotificationPendingRow = notificationSingleRowFull.omit({ userId: true }).extend({
-  userId: z.number().optional(),
-  userIds: z.array(z.number()).optional(),
-  debounceSeconds: z.number().optional(),
-});
+export const createNotificationPendingRow = notificationSingleRowFull
+  .omit({ userId: true })
+  .extend({
+    userId: z.number().optional(),
+    userIds: z.array(z.number()).optional(),
+    debounceSeconds: z.number().optional(),
+  });
 export type CreateNotificationPendingRow = z.infer<typeof createNotificationPendingRow>;
 
 // --- Read / count / mark / exists / bulk / cleanup contracts (the app's authed API) ------------------
@@ -92,6 +104,7 @@ export const createNotificationRow = z.object({
   users: z.array(z.number()),
   details: z.record(z.string(), z.any()),
   debounceSeconds: z.number().optional(),
+  dedupeKey,
 });
 export type CreateNotificationRow = z.infer<typeof createNotificationRow>;
 export const createNotificationsBulkInput = z.array(createNotificationRow);

--- a/packages/civitai-notifications/src/schema.ts
+++ b/packages/civitai-notifications/src/schema.ts
@@ -42,6 +42,13 @@ export const createNotificationPendingRow = notificationSingleRowFull
     userId: z.number().optional(),
     userIds: z.array(z.number()).optional(),
     debounceSeconds: z.number().optional(),
+  })
+  // The debounce fan-out path writes UserNotification with a TARGETED ON CONFLICT that cannot absorb a
+  // violation of the dedupe index, so it never writes "dedupeKey" — a row asking for both would have its
+  // dedupeKey silently dropped. Reject it here instead of failing quietly at fan-out.
+  .refine((row) => !(row.dedupeKey && row.debounceSeconds !== undefined), {
+    message: 'dedupeKey is not supported on debounced notifications',
+    path: ['dedupeKey'],
   });
 export type CreateNotificationPendingRow = z.infer<typeof createNotificationPendingRow>;
 

--- a/src/server/jobs/send-notifications.ts
+++ b/src/server/jobs/send-notifications.ts
@@ -91,6 +91,7 @@ export const sendNotificationsJob = createJob('send-notifications', '*/1 * * * *
                   type: r.type,
                   category: category,
                   details: r.details,
+                  dedupeKey: r.dedupeKey ?? null,
                   users: [r.userId],
                 };
               } else {

--- a/src/server/notifications/__tests__/comment.dedupe-key.test.ts
+++ b/src/server/notifications/__tests__/comment.dedupe-key.test.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from 'fs';
 import { describe, expect, it } from 'vitest';
 import {
   CommentNotificationPriority,
@@ -24,7 +25,6 @@ const sqlFor = (type: string) => defs[type].prepareQuery!({ lastSent: '2026-01-0
 
 /** The types that fired for MNeMiC's one comment, plus the rest of the comment-derived family. */
 const V2_TYPES = [
-  'new-comment-reply',
   'new-review-response',
   'new-image-comment',
   'new-article-comment',
@@ -45,18 +45,36 @@ describe('comment notifications — shared dedupe key', () => {
     expect(sqlFor(type)).toContain(`concat('comment:v2:', details->>'commentId') "dedupeKey"`);
   });
 
-  it('new-thread-response picks its namespace from details.version (it UNIONs both tables)', () => {
-    const sql = sqlFor('new-thread-response');
-    expect(sql).toContain(
-      `concat('comment:', case when details->>'version' is not null then 'v2:' else 'v1:' end, details->>'commentId') "dedupeKey"`
-    );
-  });
+  it.each(['new-thread-response', 'new-comment-reply'])(
+    '%s picks its namespace from details.version (it can see both comment tables)',
+    (type) => {
+      expect(sqlFor(type)).toContain(commentDedupeKeyByVersion);
+    }
+  );
 
   it('the v1/v2 namespace is load-bearing — Comment and CommentV2 ids overlap', () => {
     // Same id, different table: these must NOT collide, or a legacy-comment notification would
     // suppress an unrelated CommentV2 one.
     expect(sqlFor('new-comment')).not.toContain(`'comment:v2:'`);
-    expect(sqlFor('new-comment-reply')).not.toContain(`'comment:v1:'`);
+    expect(sqlFor('new-comment-nested')).not.toContain(`'comment:v2:'`);
+  });
+
+  it.each(['new-comment-reply', 'new-thread-response'])(
+    '%s only claims the key for a thread threadUrlMap can address',
+    (type) => {
+      // Both fall back to threadType 'comment' for an unmapped Thread entity (comicProject, clubPost,
+      // model3dReview), which renders a dead link. Claiming there would suppress a working owner
+      // notification — that is exactly how the mention/challenge regression got in.
+      expect(sqlFor(type)).toContain(`when details->>'threadType' <> 'comment' then`);
+      // V1 rows have no threadType and build their URL from modelId, so they always claim.
+      expect(sqlFor(type)).toContain(`when details->>'version' is null then`);
+    }
+  );
+
+  it('new-comic-comment shares the key so it can claim the comic threads those two skip', () => {
+    // Created inline in the router, not by a cron processor, so assert the call site directly.
+    const router = readFileSync('src/server/routers/comics.router.ts', 'utf8');
+    expect(router).toContain('dedupeKey: `comment:v2:${comment.id}`');
   });
 
   it('new-mention dedupes comment mentions but leaves model-description mentions alone', () => {

--- a/src/server/notifications/__tests__/comment.dedupe-key.test.ts
+++ b/src/server/notifications/__tests__/comment.dedupe-key.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   CommentNotificationPriority,
+  commentDedupeKeyByVersion,
   commentNotifications,
 } from '~/server/notifications/comment.notifications';
 import { mentionNotifications } from '~/server/notifications/mention.notifications';
@@ -60,10 +61,10 @@ describe('comment notifications — shared dedupe key', () => {
 
   it('new-mention dedupes comment mentions but leaves model-description mentions alone', () => {
     const sql = sqlFor('new-mention');
-    // Comment mentions share the source event with the comment.notifications types...
-    expect(sql).toContain(`case when details->>'mentionedIn' = 'comment' then`);
-    // ...a mention in a model description has no commentId, so it must stay opted out (NULL).
-    expect(sql).toContain(`details->>'commentId') end "dedupeKey"`);
+    // A mention in a model description has no comment behind it, so it must stay opted out (NULL).
+    expect(sql).toContain(`when details->>'mentionedIn' <> 'comment' then null`);
+    // Comment mentions share the source event with the comment.notifications types.
+    expect(sql).toContain(commentDedupeKeyByVersion);
   });
 
   it('every dedupeKey is derived from commentId only — never from the recipient or the type', () => {
@@ -98,9 +99,15 @@ describe('comment notifications — priority decides which duplicate survives', 
   });
 
   it('every processor that emits a dedupeKey also declares a priority', () => {
-    // Without one it lands in batch 0 and could beat the mention to the shared key.
-    for (const [type, def] of Object.entries(defs)) {
-      if (!def.prepareQuery?.({ lastSent: '2026-01-01' }).includes('"dedupeKey"')) continue;
+    // Without one it lands in batch 0 and could beat the mention to the shared key. Iterate the FULL
+    // registry, not just the comment family — a dedupe key added in any other file has the same problem.
+    for (const [type, def] of Object.entries(notificationProcessors)) {
+      const query = def.prepareQuery?.({
+        lastSent: '2026-01-01',
+        lastSentDate: new Date('2026-01-01'),
+        clickhouse: undefined,
+      });
+      if (typeof query !== 'string' || !query.includes('"dedupeKey"')) continue;
       expect(def.priority, `${type} declares a priority`).toBeGreaterThan(0);
     }
   });
@@ -117,5 +124,127 @@ describe('comment notifications — priority decides which duplicate survives', 
     expect(batchIndex('new-mention')).toBeLessThan(batchIndex('new-thread-response'));
     expect(batchIndex('new-thread-response')).toBeLessThan(batchIndex('new-comment-nested'));
     expect(priorityOf('new-mention')).toBeLessThan(priorityOf('new-comment-nested'));
+  });
+});
+
+/**
+ * Claiming the dedupe key SUPPRESSES the other notifications for that comment, so a type that claims it
+ * had better render. `NotificationList` drops any notification whose `prepareMessage` returns undefined,
+ * and `threadUrlMap` returns undefined for a thread type it can't address — either one turns a
+ * suppressed-but-working notification into a blank row or a dead link.
+ */
+describe('a type that claims the dedupe key must render', () => {
+  const detailsFor = (type: string): Record<string, any>[] => {
+    const base = { username: 'someone', commentId: 42 };
+    switch (type) {
+      case 'new-mention':
+        return [
+          // Only the shapes that still claim the key — see the CASE in new-mention's SQL.
+          {
+            ...base,
+            mentionedIn: 'comment',
+            version: 2,
+            threadId: 7,
+            threadType: 'model',
+            threadParentId: 1,
+          },
+          {
+            ...base,
+            mentionedIn: 'comment',
+            version: 2,
+            threadId: 7,
+            threadType: 'challenge',
+            threadParentId: 1,
+          },
+          {
+            ...base,
+            mentionedIn: 'comment',
+            version: 2,
+            threadId: 7,
+            threadType: 'model3d',
+            threadParentId: 1,
+          },
+          {
+            ...base,
+            mentionedIn: 'comment',
+            parentType: 'comment',
+            parentId: 5,
+            modelId: 1,
+            modelName: 'M',
+          },
+        ];
+      // Unions both comment tables, so it must render for both detail shapes.
+      case 'new-thread-response':
+        return [
+          { ...base, version: 2, threadId: 7, threadType: 'model', threadParentId: 1 },
+          { ...base, modelId: 1, modelName: 'M', parentId: 5, parentType: 'comment' },
+        ];
+      // CommentV2 only — its SQL always stamps version 2.
+      case 'new-comment-reply':
+        return [{ ...base, version: 2, threadId: 7, threadType: 'model', threadParentId: 1 }];
+      case 'new-review-response':
+        return [{ ...base, version: 2, reviewId: 3, modelId: 1, modelName: 'M' }];
+      case 'new-image-comment':
+        return [{ ...base, version: 2, imageId: 9, modelName: 'M', modelId: 1 }];
+      case 'new-article-comment':
+        return [{ ...base, version: 2, articleId: 4, articleTitle: 'A' }];
+      case 'new-bounty-comment':
+        return [{ ...base, version: 2, bountyId: 4, bountyTitle: 'B' }];
+      case 'new-challenge-comment':
+        return [{ ...base, version: 2, challengeId: 4, challengeTitle: 'C' }];
+      case 'new-comment':
+      case 'new-comment-response':
+      case 'new-comment-nested':
+        return [{ ...base, modelId: 1, modelName: 'M', parentId: 5, parentType: 'comment' }];
+      default:
+        return [{ ...base, version: 2, model3dId: 8, model3dName: '3D', parentId: 5 }];
+    }
+  };
+
+  const claimants = Object.keys(defs).filter((type) =>
+    defs[type].prepareQuery?.({ lastSent: '2026-01-01' }).includes('"dedupeKey"')
+  );
+
+  it.each(claimants)(
+    '%s produces a message and a URL for every shape that claims the key',
+    (type) => {
+      for (const details of detailsFor(type)) {
+        const msg = notificationProcessors[type].prepareMessage({ type, details });
+        expect(msg, `${type} renders for ${JSON.stringify(details)}`).toBeDefined();
+        expect(msg!.message).toBeTruthy();
+        // A dead link is the failure mode threadUrlMap produces for an unhandled thread type.
+        expect(msg!.url, `${type} has a URL for ${JSON.stringify(details)}`).toBeDefined();
+      }
+    }
+  );
+
+  it('new-mention does NOT claim the key for the shapes it cannot render', () => {
+    const sql = defs['new-mention'].prepareQuery!({ lastSent: '2026-01-01' });
+    // A model-description mention has no comment behind it.
+    expect(sql).toContain(`when details->>'mentionedIn' <> 'comment' then null`);
+    // The v2 'comment' fallback means threadUrlMap can't address the entity → dead link.
+    expect(sql).toContain(`when details->>'threadType' <> 'comment' then`);
+    // The v1 'review' shape makes prepareMessage return undefined → the row renders as nothing.
+    expect(sql).toContain(`when details->>'parentType' = 'comment' then`);
+
+    // Prove the bail-out those guards exist for is real, so this can't rot into a no-op.
+    const mention = notificationProcessors['new-mention'];
+    expect(
+      mention.prepareMessage({
+        type: 'new-mention',
+        details: { mentionedIn: 'comment', parentType: 'review', username: 'x', commentId: 1 },
+      })
+    ).toBeUndefined();
+  });
+
+  it('new-mention resolves the same thread entities as the types it outranks', () => {
+    // It suppresses new-thread-response, so anything that one can address, this one must address too.
+    const mention = defs['new-mention'].prepareQuery!({ lastSent: '2026-01-01' });
+    for (const entity of ['challengeId', 'model3dId']) {
+      expect(mention, `new-mention resolves ${entity}`).toContain(`t."${entity}"`);
+    }
+    // ...and it skips appListing threads for the same reason the reply processors do.
+    expect(mention).toContain('root."appListingId" IS NULL');
+    expect(mention).toContain('t."appListingId" IS NULL');
   });
 });

--- a/src/server/notifications/__tests__/comment.dedupe-key.test.ts
+++ b/src/server/notifications/__tests__/comment.dedupe-key.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from 'vitest';
+import {
+  CommentNotificationPriority,
+  commentNotifications,
+} from '~/server/notifications/comment.notifications';
+import { mentionNotifications } from '~/server/notifications/mention.notifications';
+import {
+  notificationBatches,
+  notificationProcessors,
+} from '~/server/notifications/utils.notifications';
+
+/**
+ * One comment can satisfy several notification types at once — MNeMiC's report was a single reply
+ * arriving three times (@mention + thread reply + comment on his model). Each processor emits its own
+ * per-type `key`, so nothing collapsed them. They now also emit a shared `dedupeKey` scoped to the
+ * SOURCE comment, which the notifications app enforces one-per-recipient.
+ */
+
+type Def = { prepareQuery?: (args: { lastSent: string }) => string; priority?: number };
+const defs = { ...commentNotifications, ...mentionNotifications } as unknown as Record<string, Def>;
+
+const sqlFor = (type: string) => defs[type].prepareQuery!({ lastSent: '2026-01-01' });
+
+/** The types that fired for MNeMiC's one comment, plus the rest of the comment-derived family. */
+const V2_TYPES = [
+  'new-comment-reply',
+  'new-review-response',
+  'new-image-comment',
+  'new-article-comment',
+  'new-bounty-comment',
+  'new-challenge-comment',
+  'new-3d-model-comment',
+  'new-3d-model-comment-response',
+  'new-3d-model-comment-nested',
+];
+const V1_TYPES = ['new-comment', 'new-comment-response', 'new-comment-nested'];
+
+describe('comment notifications — shared dedupe key', () => {
+  it.each(V1_TYPES)('%s selects a v1-namespaced dedupeKey', (type) => {
+    expect(sqlFor(type)).toContain(`concat('comment:v1:', details->>'commentId') "dedupeKey"`);
+  });
+
+  it.each(V2_TYPES)('%s selects a v2-namespaced dedupeKey', (type) => {
+    expect(sqlFor(type)).toContain(`concat('comment:v2:', details->>'commentId') "dedupeKey"`);
+  });
+
+  it('new-thread-response picks its namespace from details.version (it UNIONs both tables)', () => {
+    const sql = sqlFor('new-thread-response');
+    expect(sql).toContain(
+      `concat('comment:', case when details->>'version' is not null then 'v2:' else 'v1:' end, details->>'commentId') "dedupeKey"`
+    );
+  });
+
+  it('the v1/v2 namespace is load-bearing — Comment and CommentV2 ids overlap', () => {
+    // Same id, different table: these must NOT collide, or a legacy-comment notification would
+    // suppress an unrelated CommentV2 one.
+    expect(sqlFor('new-comment')).not.toContain(`'comment:v2:'`);
+    expect(sqlFor('new-comment-reply')).not.toContain(`'comment:v1:'`);
+  });
+
+  it('new-mention dedupes comment mentions but leaves model-description mentions alone', () => {
+    const sql = sqlFor('new-mention');
+    // Comment mentions share the source event with the comment.notifications types...
+    expect(sql).toContain(`case when details->>'mentionedIn' = 'comment' then`);
+    // ...a mention in a model description has no commentId, so it must stay opted out (NULL).
+    expect(sql).toContain(`details->>'commentId') end "dedupeKey"`);
+  });
+
+  it('every dedupeKey is derived from commentId only — never from the recipient or the type', () => {
+    // A key that varied per user or per type would dedupe nothing; this is the whole mechanism.
+    for (const type of [...V1_TYPES, ...V2_TYPES, 'new-thread-response']) {
+      const dedupeExpr = sqlFor(type).match(/(concat\('comment:.*?) "dedupeKey"/s)?.[1];
+      expect(dedupeExpr, `${type} selects a dedupeKey`).toBeDefined();
+      expect(dedupeExpr).toContain(`details->>'commentId'`);
+      expect(dedupeExpr).not.toContain('ownerId');
+      expect(dedupeExpr).not.toContain('userId');
+    }
+  });
+});
+
+describe('comment notifications — priority decides which duplicate survives', () => {
+  it('orders mention > direct response > thread response > entity owner', () => {
+    const { Mention, DirectResponse, ThreadResponse, EntityOwner } = CommentNotificationPriority;
+    expect(Mention).toBeLessThan(DirectResponse);
+    expect(DirectResponse).toBeLessThan(ThreadResponse);
+    expect(ThreadResponse).toBeLessThan(EntityOwner);
+  });
+
+  it('assigns the three types from the report in the order the user would want them', () => {
+    // The exact trio in MNeMiC's screenshot, most-wanted first.
+    expect(defs['new-mention'].priority).toBe(CommentNotificationPriority.Mention);
+    expect(defs['new-thread-response'].priority).toBe(CommentNotificationPriority.ThreadResponse);
+    expect(defs['new-comment-nested'].priority).toBe(CommentNotificationPriority.EntityOwner);
+    expect(defs['new-mention'].priority!).toBeLessThan(defs['new-thread-response'].priority!);
+    expect(defs['new-thread-response'].priority!).toBeLessThan(
+      defs['new-comment-nested'].priority!
+    );
+  });
+
+  it('every processor that emits a dedupeKey also declares a priority', () => {
+    // Without one it lands in batch 0 and could beat the mention to the shared key.
+    for (const [type, def] of Object.entries(defs)) {
+      if (!def.prepareQuery?.({ lastSent: '2026-01-01' }).includes('"dedupeKey"')) continue;
+      expect(def.priority, `${type} declares a priority`).toBeGreaterThan(0);
+    }
+  });
+
+  it('batches run in numeric priority order, so a lower priority claims the key first', () => {
+    const priorityOf = (type: string) => notificationProcessors[type]?.priority ?? 0;
+    const batchIndex = (type: string) =>
+      notificationBatches.findIndex((batch) => batch.some((n) => n.key === type));
+
+    // Guards a lexicographic .sort(), which would order priority 10 ahead of priority 2.
+    const seen = notificationBatches.map((batch) => batch[0]!.priority ?? 0);
+    expect(seen).toEqual([...seen].sort((a, b) => a - b));
+
+    expect(batchIndex('new-mention')).toBeLessThan(batchIndex('new-thread-response'));
+    expect(batchIndex('new-thread-response')).toBeLessThan(batchIndex('new-comment-nested'));
+    expect(priorityOf('new-mention')).toBeLessThan(priorityOf('new-comment-nested'));
+  });
+});

--- a/src/server/notifications/comment.notifications.ts
+++ b/src/server/notifications/comment.notifications.ts
@@ -40,6 +40,24 @@ export const commentDedupeKey = (version: 'v1' | 'v2') =>
 export const commentDedupeKeyByVersion = `concat('comment:', case when details->>'version' is not null then 'v2:' else 'v1:' end, details->>'commentId')`;
 
 /**
+ * The same key, but only claimed when the notification can actually be linked to. Claiming SUPPRESSES
+ * every other notification for that comment, so a claimant that renders a dead link would silently
+ * replace one that works.
+ *
+ * `threadType` resolves to the `'comment'` fallback for any `Thread` entity `threadUrlMap` doesn't
+ * address (comicProject, clubPost, model3dReview today). Those threads stay unclaimed, which is what
+ * lets a purpose-built owner notification like `new-comic-comment` own the key instead. V1 rows carry no
+ * `threadType` and build their URL from `modelId`, so they always render and always claim.
+ *
+ * Add a `Thread` entity column WITHOUT a `threadUrlMap` entry and this keeps the dedupe correct on its
+ * own — that omission is exactly how the mention/challenge regression got in.
+ */
+export const commentDedupeKeyIfAddressable = `case
+          when details->>'version' is null then ${commentDedupeKeyByVersion}
+          when details->>'threadType' <> 'comment' then ${commentDedupeKeyByVersion}
+        end`;
+
+/**
  * Batch order for the comment family, lowest first. `send-notifications` runs each priority as its own
  * sequential batch, so this decides WHICH of several competing notifications a user actually receives:
  * the most specific one runs first and claims the dedupe key. Being named beats being replied to, which
@@ -235,7 +253,7 @@ export const commentNotifications = createNotificationProcessor({
       )
       SELECT
         concat('new-comment-reply:owner:v2:', details->>'commentId') "key",
-        ${commentDedupeKey('v2')} "dedupeKey",
+        ${commentDedupeKeyIfAddressable} "dedupeKey",
         "ownerId"    "userId",
         'new-comment-reply' "type",
         details
@@ -374,7 +392,7 @@ export const commentNotifications = createNotificationProcessor({
       )
       SELECT
         concat('new-thread-response:user:', case when details->>'version' is not null then 'v2:' else 'v1:' end, details->>'commentId') "key",
-        ${commentDedupeKeyByVersion} "dedupeKey",
+        ${commentDedupeKeyIfAddressable} "dedupeKey",
         "ownerId"    "userId",
         'new-thread-response' "type",
         details

--- a/src/server/notifications/comment.notifications.ts
+++ b/src/server/notifications/comment.notifications.ts
@@ -27,12 +27,38 @@ export const threadUrlMap = ({ threadType, threadParentId, ...details }: any) =>
   }[threadType as string] as string;
 };
 
+/**
+ * SQL for the `dedupeKey` column every comment-derived processor selects. One comment can satisfy
+ * several types at once (an @mention that is also a thread reply on a model you own); they all emit the
+ * same dedupe key, and the notifications app hands the recipient only the first one to land. `v1` is the
+ * legacy `Comment` table, `v2` is `CommentV2` — their ids overlap, so the namespace is load-bearing.
+ */
+export const commentDedupeKey = (version: 'v1' | 'v2') =>
+  `concat('comment:${version}:', details->>'commentId')`;
+
+/** Same, for queries that UNION both comment tables and mark the V2 branch with `details.version`. */
+export const commentDedupeKeyByVersion = `concat('comment:', case when details->>'version' is not null then 'v2:' else 'v1:' end, details->>'commentId')`;
+
+/**
+ * Batch order for the comment family, lowest first. `send-notifications` runs each priority as its own
+ * sequential batch, so this decides WHICH of several competing notifications a user actually receives:
+ * the most specific one runs first and claims the dedupe key. Being named beats being replied to, which
+ * beats being in the thread, which beats owning the thing it happened on.
+ */
+export const CommentNotificationPriority = {
+  Mention: 1,
+  DirectResponse: 2,
+  ThreadResponse: 3,
+  EntityOwner: 4,
+} as const;
+
 // Moveable (all)
 
 export const commentNotifications = createNotificationProcessor({
   'new-comment': {
     displayName: 'New comments on your models',
     category: NotificationCategory.Comment,
+    priority: CommentNotificationPriority.EntityOwner,
     prepareMessage: ({ details }) => ({
       message: `${details.username} commented on your ${details.modelName} model`,
       url: `/models/${details.modelId}?dialog=commentThread&commentId=${details.commentId}`,
@@ -57,6 +83,7 @@ export const commentNotifications = createNotificationProcessor({
       )
       SELECT
         concat('new-comment-model:owner:v1:', details->>'commentId') "key",
+        ${commentDedupeKey('v1')} "dedupeKey",
         "ownerId"    "userId",
         'new-comment' "type",
         details
@@ -68,6 +95,7 @@ export const commentNotifications = createNotificationProcessor({
   'new-comment-response': {
     displayName: 'New comment responses (Models)',
     category: NotificationCategory.Comment,
+    priority: CommentNotificationPriority.DirectResponse,
     prepareMessage: ({ details }) => ({
       message: `${details.username} responded to your comment on the ${details.modelName} model`,
       url: `/models/${details.modelId}?dialog=commentThread&commentId=${
@@ -95,6 +123,7 @@ export const commentNotifications = createNotificationProcessor({
       )
       SELECT
         concat('new-comment-response:owner:v1:', details->>'commentId') "key",
+        ${commentDedupeKey('v1')} "dedupeKey",
         "ownerId"    "userId",
         'new-comment-response' "type",
         details
@@ -106,6 +135,7 @@ export const commentNotifications = createNotificationProcessor({
   'new-comment-nested': {
     displayName: 'New responses to comments and reviews on your models',
     category: NotificationCategory.Comment,
+    priority: CommentNotificationPriority.EntityOwner,
     prepareMessage: ({ details }) => ({
       message: `${details.username} responded to a ${details.parentType} on your ${details.modelName} model`,
       url: `/models/${details.modelId}?dialog=${details.parentType}Thread&${details.parentType}Id=${details.parentId}&highlight=${details.commentId}`,
@@ -132,6 +162,7 @@ export const commentNotifications = createNotificationProcessor({
       )
       SELECT
         concat('new-comment-nested:user:v1:', details->>'commentId') "key",
+        ${commentDedupeKey('v1')} "dedupeKey",
         "ownerId"    "userId",
         'new-comment-nested' "type",
         details
@@ -143,6 +174,7 @@ export const commentNotifications = createNotificationProcessor({
   'new-comment-reply': {
     displayName: 'New comment replies',
     category: NotificationCategory.Comment,
+    priority: CommentNotificationPriority.DirectResponse,
     prepareMessage: ({ details }) => {
       const url = threadUrlMap(details);
       return {
@@ -203,6 +235,7 @@ export const commentNotifications = createNotificationProcessor({
       )
       SELECT
         concat('new-comment-reply:owner:v2:', details->>'commentId') "key",
+        ${commentDedupeKey('v2')} "dedupeKey",
         "ownerId"    "userId",
         'new-comment-reply' "type",
         details
@@ -214,6 +247,7 @@ export const commentNotifications = createNotificationProcessor({
   'new-thread-response': {
     displayName: 'New replies to comment threads you are in',
     category: NotificationCategory.Comment,
+    priority: CommentNotificationPriority.ThreadResponse,
     prepareMessage: ({ details }) => {
       if (!details.version) {
         return {
@@ -340,6 +374,7 @@ export const commentNotifications = createNotificationProcessor({
       )
       SELECT
         concat('new-thread-response:user:', case when details->>'version' is not null then 'v2:' else 'v1:' end, details->>'commentId') "key",
+        ${commentDedupeKeyByVersion} "dedupeKey",
         "ownerId"    "userId",
         'new-thread-response' "type",
         details
@@ -351,6 +386,7 @@ export const commentNotifications = createNotificationProcessor({
   'new-review-response': {
     displayName: 'New review responses',
     category: NotificationCategory.Comment,
+    priority: CommentNotificationPriority.DirectResponse,
     prepareMessage: ({ details }) => {
       if (details.version !== 2) {
         return {
@@ -387,6 +423,7 @@ export const commentNotifications = createNotificationProcessor({
       )
       SELECT
         concat('new-review-response:owner:v2:', details->>'commentId') "key",
+        ${commentDedupeKey('v2')} "dedupeKey",
         "ownerId"    "userId",
         'new-review-response' "type",
         details
@@ -398,6 +435,7 @@ export const commentNotifications = createNotificationProcessor({
   'new-image-comment': {
     displayName: 'New comments on your images',
     category: NotificationCategory.Comment,
+    priority: CommentNotificationPriority.EntityOwner,
     prepareMessage: ({ details }) => {
       if (details.version === 2) {
         let message = `${details.username} commented on your image`;
@@ -457,6 +495,7 @@ export const commentNotifications = createNotificationProcessor({
       )
       SELECT
         concat('new-comment-image:owner:v2:', details->>'commentId') "key",
+        ${commentDedupeKey('v2')} "dedupeKey",
         "ownerId"    "userId",
         'new-image-comment' "type",
         details
@@ -468,6 +507,7 @@ export const commentNotifications = createNotificationProcessor({
   'new-article-comment': {
     displayName: 'New comments on your articles',
     category: NotificationCategory.Comment,
+    priority: CommentNotificationPriority.EntityOwner,
     prepareMessage: ({ details }) =>
       details && !isEmpty(details)
         ? {
@@ -496,6 +536,7 @@ export const commentNotifications = createNotificationProcessor({
       )
       SELECT
         concat('new-comment-article:owner:v2:', details->>'commentId') "key",
+        ${commentDedupeKey('v2')} "dedupeKey",
         "ownerId"    "userId",
         'new-article-comment' "type",
         details
@@ -507,6 +548,7 @@ export const commentNotifications = createNotificationProcessor({
   'new-bounty-comment': {
     displayName: 'New comments on your bounty',
     category: NotificationCategory.Comment,
+    priority: CommentNotificationPriority.EntityOwner,
     prepareMessage: ({ details }) => ({
       message: `${details.username} commented on your bounty: "${details.bountyTitle}"`,
       url: `/bounties/${details.bountyId}?highlight=${details.commentId}`,
@@ -533,6 +575,7 @@ export const commentNotifications = createNotificationProcessor({
       )
       SELECT
         concat('new-comment-bounty:owner:v2:', details->>'commentId') "key",
+        ${commentDedupeKey('v2')} "dedupeKey",
         "ownerId"    "userId",
         'new-bounty-comment' "type",
         details
@@ -544,6 +587,7 @@ export const commentNotifications = createNotificationProcessor({
   'new-challenge-comment': {
     displayName: 'New comments on your challenges',
     category: NotificationCategory.Comment,
+    priority: CommentNotificationPriority.EntityOwner,
     prepareMessage: ({ details }) => ({
       message: `${details.username} commented on your challenge: "${details.challengeTitle}"`,
       url: `/challenges/${details.challengeId}?highlight=${details.commentId}`,
@@ -569,6 +613,7 @@ export const commentNotifications = createNotificationProcessor({
       )
       SELECT
         concat('new-comment-challenge:owner:v2:', details->>'commentId') "key",
+        ${commentDedupeKey('v2')} "dedupeKey",
         "ownerId" "userId",
         'new-challenge-comment' "type",
         details
@@ -585,6 +630,7 @@ export const commentNotifications = createNotificationProcessor({
   'new-3d-model-comment': {
     displayName: 'New comments on your 3D models',
     category: NotificationCategory.Comment,
+    priority: CommentNotificationPriority.EntityOwner,
     defaultDisabled: true,
     prepareMessage: ({ details }) => ({
       message: `${details.username} commented on your 3D model: "${details.model3dName}"`,
@@ -611,6 +657,7 @@ export const commentNotifications = createNotificationProcessor({
       )
       SELECT
         concat('new-comment-model3d:owner:v2:', details->>'commentId') "key",
+        ${commentDedupeKey('v2')} "dedupeKey",
         "ownerId"    "userId",
         'new-3d-model-comment' "type",
         details
@@ -622,6 +669,7 @@ export const commentNotifications = createNotificationProcessor({
   'new-3d-model-comment-response': {
     displayName: 'New responses to your comments on 3D models',
     category: NotificationCategory.Comment,
+    priority: CommentNotificationPriority.DirectResponse,
     defaultDisabled: true,
     prepareMessage: ({ details }) => ({
       message: `${details.username} responded to your comment on the 3D model "${details.model3dName}"`,
@@ -655,6 +703,7 @@ export const commentNotifications = createNotificationProcessor({
       )
       SELECT
         concat('new-comment-response-model3d:owner:v2:', details->>'commentId') "key",
+        ${commentDedupeKey('v2')} "dedupeKey",
         "ownerId"    "userId",
         'new-3d-model-comment-response' "type",
         details
@@ -666,6 +715,7 @@ export const commentNotifications = createNotificationProcessor({
   'new-3d-model-comment-nested': {
     displayName: 'New nested comments on your 3D models',
     category: NotificationCategory.Comment,
+    priority: CommentNotificationPriority.EntityOwner,
     defaultDisabled: true,
     prepareMessage: ({ details }) => ({
       message: `${details.username} responded to a comment on your 3D model "${details.model3dName}"`,
@@ -700,6 +750,7 @@ export const commentNotifications = createNotificationProcessor({
       )
       SELECT
         concat('new-comment-nested-model3d:user:v2:', details->>'commentId') "key",
+        ${commentDedupeKey('v2')} "dedupeKey",
         "ownerId"    "userId",
         'new-3d-model-comment-nested' "type",
         details

--- a/src/server/notifications/mention.notifications.ts
+++ b/src/server/notifications/mention.notifications.ts
@@ -1,6 +1,10 @@
 import { NotificationCategory } from '~/server/common/enums';
 import { createNotificationProcessor } from '~/server/notifications/base.notifications';
-import { threadUrlMap } from '~/server/notifications/comment.notifications';
+import {
+  CommentNotificationPriority,
+  commentDedupeKeyByVersion,
+  threadUrlMap,
+} from '~/server/notifications/comment.notifications';
 
 // Moveable (possibly)
 
@@ -8,6 +12,7 @@ export const mentionNotifications = createNotificationProcessor({
   'new-mention': {
     displayName: 'New @mentions',
     category: NotificationCategory.Comment,
+    priority: CommentNotificationPriority.Mention,
     prepareMessage: ({ details }) => {
       const isCommentV2 = details.mentionedIn === 'comment' && details.threadId !== undefined;
       if (isCommentV2) {
@@ -147,6 +152,9 @@ export const mentionNotifications = createNotificationProcessor({
       )
       SELECT
         concat('new-mention:user:', case when details->>'mentionedIn' = 'model' then 'model:' when details->>'version' is not null then 'v2:' else 'v1:' end, coalesce(details->>'commentId', details->>'modelId')) "key",
+        -- Only comment mentions share a source event with the comment.notifications types. A mention in a
+        -- model DESCRIPTION has no commentId and stays NULL (opted out of dedup).
+        case when details->>'mentionedIn' = 'comment' then ${commentDedupeKeyByVersion} end "dedupeKey",
         "ownerId"    "userId",
         'new-mention' "type",
         details

--- a/src/server/notifications/mention.notifications.ts
+++ b/src/server/notifications/mention.notifications.ts
@@ -55,6 +55,8 @@ export const mentionNotifications = createNotificationProcessor({
                 root."articleId",
                 root."bountyId",
                 root."bountyEntryId",
+                root."challengeId",
+                root."model3dId",
                 t."imageId",
                 t."modelId",
                 t."postId",
@@ -63,7 +65,9 @@ export const mentionNotifications = createNotificationProcessor({
                 t."reviewId",
                 t."articleId",
                 t."bountyId",
-                t."bountyEntryId"
+                t."bountyEntryId",
+                t."challengeId",
+                t."model3dId"
              ),
             'threadType', CASE
               WHEN COALESCE(root."imageId", t."imageId") IS NOT NULL THEN 'image'
@@ -75,6 +79,8 @@ export const mentionNotifications = createNotificationProcessor({
               WHEN COALESCE(root."articleId", t."articleId") IS NOT NULL THEN 'article'
               WHEN COALESCE(root."bountyId", t."bountyId") IS NOT NULL THEN 'bounty'
               WHEN COALESCE(root."bountyEntryId", t."bountyEntryId") IS NOT NULL THEN 'bountyEntry'
+              WHEN COALESCE(root."challengeId", t."challengeId") IS NOT NULL THEN 'challenge'
+              WHEN COALESCE(root."model3dId", t."model3dId") IS NOT NULL THEN 'model3d'
               ELSE 'comment'
             END,
              'commentParentId', COALESCE(
@@ -87,6 +93,8 @@ export const mentionNotifications = createNotificationProcessor({
                 t."articleId",
                 t."bountyId",
                 t."bountyEntryId",
+                t."challengeId",
+                t."model3dId",
                 t."commentId"
              ),
              'commentParentType', CASE
@@ -99,6 +107,8 @@ export const mentionNotifications = createNotificationProcessor({
                 WHEN t."articleId" IS NOT NULL THEN 'article'
                 WHEN t."bountyId" IS NOT NULL THEN 'bounty'
                 WHEN t."bountyEntryId" IS NOT NULL THEN 'bountyEntry'
+                WHEN t."challengeId" IS NOT NULL THEN 'challenge'
+                WHEN t."model3dId" IS NOT NULL THEN 'model3d'
                 ELSE 'comment'
               END,
             'username', u.username
@@ -112,6 +122,10 @@ export const mentionNotifications = createNotificationProcessor({
           -- Unhandled thread types...
           AND t."questionId" IS NULL
           AND t."answerId" IS NULL
+          -- Same appListing exclusion the reply processors carry: those threads are addressed by SLUG,
+          -- so threadUrlMap can't build a URL for them yet.
+          AND root."appListingId" IS NULL
+          AND t."appListingId" IS NULL
 
         UNION
 
@@ -152,9 +166,21 @@ export const mentionNotifications = createNotificationProcessor({
       )
       SELECT
         concat('new-mention:user:', case when details->>'mentionedIn' = 'model' then 'model:' when details->>'version' is not null then 'v2:' else 'v1:' end, coalesce(details->>'commentId', details->>'modelId')) "key",
-        -- Only comment mentions share a source event with the comment.notifications types. A mention in a
-        -- model DESCRIPTION has no commentId and stays NULL (opted out of dedup).
-        case when details->>'mentionedIn' = 'comment' then ${commentDedupeKeyByVersion} end "dedupeKey",
+        -- Claiming the dedupe key SUPPRESSES every other notification for this comment, so only claim it
+        -- when this mention is a worthy replacement — i.e. prepareMessage above yields a message AND a
+        -- working URL. Three ways it doesn't:
+        --   * mentionedIn = 'model' — a model DESCRIPTION mention, no comment behind it at all
+        --   * v2 threadType 'comment' — the fallback for a thread entity threadUrlMap can't address
+        --     (comicProject, clubPost, ...), which renders a dead link
+        --   * v1 parentType 'review' — prepareMessage bails and returns undefined, so the row renders as
+        --     NOTHING. Left unguarded this silently swallows the new-comment the user should have got.
+        -- Anything excluded here still delivers as its own (lower-priority) notification, unchanged.
+        case
+          when details->>'mentionedIn' <> 'comment' then null
+          when details->>'version' is not null then
+            case when details->>'threadType' <> 'comment' then ${commentDedupeKeyByVersion} end
+          when details->>'parentType' = 'comment' then ${commentDedupeKeyByVersion}
+        end "dedupeKey",
         "ownerId"    "userId",
         'new-mention' "type",
         details

--- a/src/server/notifications/utils.notifications.ts
+++ b/src/server/notifications/utils.notifications.ts
@@ -76,9 +76,13 @@ for (const notification of notifications) {
   notificationPriorities[priority] ??= [];
   notificationPriorities[priority].push(notification);
 }
+// Numeric sort, not lexicographic: `send-notifications` runs these batches in order and the comment
+// family relies on that order to decide which of several competing notifications wins the shared dedupe
+// key. A default .sort() would put priority 10 ahead of priority 2.
 export const notificationBatches = Object.keys(notificationPriorities)
-  .sort()
-  .map((key) => notificationPriorities[key as unknown as number]);
+  .map(Number)
+  .sort((a, b) => a - b)
+  .map((key) => notificationPriorities[key]);
 
 export function getNotificationMessage(notification: Omit<BareNotification, 'id'>) {
   const { prepareMessage } = notificationProcessors[notification.type] ?? {};

--- a/src/server/routers/comics.router.ts
+++ b/src/server/routers/comics.router.ts
@@ -6454,6 +6454,9 @@ export const comicsRouter = router({
           type: 'new-comic-comment',
           key: `new-comic-comment:${input.projectId}:${input.chapterPosition}:${comment.id}`,
           category: NotificationCategory.Comment,
+          // Same CommentV2 row is also swept by new-mention / new-thread-response; this shares their
+          // dedupe key so the project owner gets one notification, not two.
+          dedupeKey: `comment:v2:${comment.id}`,
           userId: project.userId,
           details: {
             comicProjectId: String(input.projectId),

--- a/src/server/schema/notification.schema.ts
+++ b/src/server/schema/notification.schema.ts
@@ -29,6 +29,8 @@ export const notificationSingleRow = z.object({
   userId: z.number(),
   type: z.string(),
   details: z.record(z.string(), z.any()),
+  // Shared across every type derivable from the same source event — see @civitai/notifications.
+  dedupeKey: z.string().nullish(),
 });
 
 export type NotificationSingleRowFull = z.infer<typeof notificationSingleRowFull>;

--- a/src/server/services/notification.service.ts
+++ b/src/server/services/notification.service.ts
@@ -20,6 +20,13 @@ export const createNotificationPendingRow = notificationSingleRowFull
     userId: z.number().optional(),
     userIds: z.array(z.number()).optional(),
     debounceSeconds: z.number().optional(),
+  })
+  // Mirrors the same refine on @civitai/notifications' copy. Without it, callers that validate against
+  // THIS schema (e.g. /api/mod/send-mod-notification) accept the pair, then the package schema rejects it
+  // inside createNotification below — which logs and swallows, so the request 200s and nothing sends.
+  .refine((row) => !(row.dedupeKey && row.debounceSeconds !== undefined), {
+    message: 'dedupeKey is not supported on debounced notifications',
+    path: ['dedupeKey'],
   });
 export type CreateNotificationPendingRow = z.infer<typeof createNotificationPendingRow>;
 


### PR DESCRIPTION
Closes the duplicate-notification report from MNeMiC: a single comment arriving as three separate bell entries.

> goku **mentioned you in a comment on** SomethingSomething [Base Model]
> goku  **responded to the comment thread on the** SomethingSomething [Base Model] **model**
> goku  **responded to a comment on your** SomethingSomething [Base Model] **model**

One comment. Three notifications. He has all six comment settings enabled because all six are legitimately relevant to him — the problem is that nothing collapses the overlap.

## Root cause

Each notification type in `src/server/notifications/` is an independent SQL processor with its own cursor, and each builds its own `Notification.key`:

```
new-mention:user:v2:<commentId>
new-thread-response:user:v2:<commentId>
new-comment-nested:user:v1:<commentId>
```

Those keys are unique *per type*, so the notifications app only ever dedupes a type against itself. `UserNotification`'s `UNIQUE (notificationId, userId)` stops the same notification landing twice but does nothing across types. Every matching processor produces a row, and the user gets all of them.

## The fix

Give every notification derived from the same source event a shared **dedupe key**, and enforce one-per-recipient on it.

1. **Producers** — the 14 comment-derived processors select a `dedupeKey` alongside their existing `key`: `comment:v1:<commentId>` for the legacy `Comment` table, `comment:v2:<commentId>` for `CommentV2`. The namespace is load-bearing; ids overlap between the two tables. A mention in a model *description* has no comment behind it and stays `NULL` (opted out).
2. **Transport** — `dedupeKey` joins the `@civitai/notifications` contract and rides through `PendingNotification` to the fan-out worker.
3. **Enforcement** — `UserNotification` gets a `dedupeKey` column and a partial `UNIQUE ("userId", "dedupeKey") WHERE "dedupeKey" IS NOT NULL`. The worker's fan-out already used an *untargeted* `ON CONFLICT DO NOTHING`, which covers every unique constraint — so the second and third notification for that recipient are simply skipped. Skipped rows are absent from `RETURNING`, so they also produce no realtime signal and no unread-count increment.

### Only a claimant that renders

Claiming the key silences every other notification for that comment, so a type only claims it when it will actually produce a message *and* a working URL. `new-mention` emits `NULL` for the shapes it cannot render, and those fall through to their own lower-priority notification unchanged:

| mention shape | why it can't render | claims key |
|---|---|---|
| model description | no comment behind it | no |
| v2 `threadType` = `comment` fallback | `threadUrlMap` can't address the entity -> dead link | no |
| v1 `parentType` = `review` | `prepareMessage` returns undefined -> row renders as nothing | no |

`new-mention` was also missing `challengeId` / `model3dId` in its thread resolution and had no `appListing` exclusion, both of which the types it outranks already had. Brought to parity, so challenge and 3D-model mentions now resolve correctly and win on merit.

The same guard applies to `new-thread-response` and `new-comment-reply` via a shared `commentDedupeKeyIfAddressable`: they share the identical `'comment'` fallback for any `Thread` entity `threadUrlMap` can't link to (`comicProject`, `clubPost`, `model3dReview`). Leaving them unguarded worked only by accident — `new-comic-comment` is created synchronously in the router, so its queue row lands first and wins the claim. Now those threads stay unclaimed by the cron processors and `new-comic-comment` owns the key by design. Cost over 6 hours of production: 8 unclaimed rows out of 3457, while 190 duplicates are still suppressed.

### Which one survives

Previously this would have been a race between concurrent processors. The comment family now declares explicit priorities, and `send-notifications` runs each priority as its own sequential batch, so the most specific type claims the key first:

| Priority | Types | Message |
|---|---|---|
| 1 Mention | `new-mention` | someone named you |
| 2 DirectResponse | `new-comment-reply`, `new-comment-response`, `new-review-response`, `new-3d-model-comment-response` | someone replied to **you** |
| 3 ThreadResponse | `new-thread-response` | someone replied in a thread you're in |
| 4 EntityOwner | `new-comment`, `new-comment-nested`, `new-image-comment`, `new-article-comment`, `new-bounty-comment`, `new-challenge-comment`, `new-3d-model-comment`, `new-3d-model-comment-nested` | something happened on a thing you own |

This also required switching the batch sort in `utils.notifications.ts` from lexicographic to numeric — the old one would order priority 10 ahead of priority 2. No processor declared a priority before this PR, so nothing else changes order.

## Measured against production

One hour of live data, running all 14 processors and grouping by `(userId, dedupeKey)`:

| | |
|---|---|
| Notification rows generated | 373 |
| After dedupe | 344 |
| Comments that fired **twice** for one user | 15 |
| Comments that fired **three times** for one user | 7 |

And over 14 days, confirming no notification is lost — every non-rendering mention shape claims the key zero times:

| mention shape | rows | claims key |
|---|---|---|
| `v1:review` | 28 | **0** |
| `v2:comment` (fallback) | 25 | **0** |
| `model-description` | 159 | **0** |
| `v2:challenge` (now resolves) | 30 | 30 |

The most common overlaps were exactly the ones in the report — `new-mention` + `new-thread-response`, `new-image-comment` + `new-thread-response`, and the three-way `new-comment-response` + `new-mention` + `new-thread-response`.

## ✅ DDL — already applied to production

**Applied 2026-08-01.** The worker's fan-out INSERT references `"dedupeKey"`, so the column had to exist *before* this ships — if the app deployed first, all notification fan-out would fail, not just comment types. That ordering constraint is now satisfied; this branch is safe to deploy whenever.

There is only one notifications database (`notification_prod` on the `notifications-db` cnpg cluster) — no dev instance.

```sql
ALTER TABLE "PendingNotification" ADD COLUMN "dedupeKey" TEXT;
ALTER TABLE "UserNotification" ADD COLUMN "dedupeKey" TEXT;

CREATE UNIQUE INDEX CONCURRENTLY "UserNotification_userId_dedupeKey_uniq"
    ON "UserNotification" ("userId", "dedupeKey")
    WHERE "dedupeKey" IS NOT NULL;
```

Verified after apply: index `indisvalid = true`, `indisunique = true`, predicate `("dedupeKey" IS NOT NULL)`, size 8 KB. Both columns nullable `text`. The notifications service stayed healthy throughout — no restarts, 336 notifications fanned out in the following 5 minutes.

Notes for anyone replaying this elsewhere: `UserNotification` is ~1.03B rows / 154 GB. `ADD COLUMN` with no default is metadata-only and instant on PG18. The index ends up **empty** (every existing row is NULL, excluded by the partial predicate) but `CONCURRENTLY` still scans the full heap twice to prove it — that took ~2 minutes here, non-blocking for writes. It is forward-only; there is no backfill and existing duplicate notifications are left as they are.

## Not touched

- Per-type `key`s, so the queue and `Notification` rows are unaffected.
- Per-type opt-out settings. Disabling `new-mention` still lets `new-thread-response` through, and the dedupe key is only claimed by notifications that were actually going to be sent.
- Debounced types. Their fan-out uses a *targeted* `ON CONFLICT` that could not absorb a second constraint's violation, so they never write `dedupeKey` — and the producer schema now rejects the combination outright rather than dropping it silently. No debounced type shares a source event with another type today.
- Every non-comment notification.

## Out of scope

MNeMiC's second ask in the same conversation — **muting / unsubscribing from a thread** — is a separate feature and needs its own task.

## Adversarial review

Reviewed by a subagent over two rounds. The first found two real regressions in the priority choice; the second verified those fixes and caught the asymmetry below. Findings and disposition:

- **Fixed** — `new-mention` suppressing notifications it could not render (see above); measured at ~46 legacy top-level cases per 30 days and ~40 challenge/3D mentions per 90 days.
- **Fixed** — `new-comic-comment` was missed and still duplicated against `new-mention` / `new-thread-response`.
- **Fixed** — the bulk `UPDATE`-first path dropped `dedupeKey`, leaving rows queued by the previous build undeduped across the deploy window. Now back-filled with `COALESCE`.
- **Fixed** — a comment on the debounce path claimed a `dedupeKey` there would abort the transaction. It never could (the column is omitted, so the value is silently dropped). Corrected, and the schema now rejects the combination outright.
- **Fixed (round 2)** — the render guard was asymmetric: `new-thread-response` (priority 3, outranks every entity-owner type) and `new-comment-reply` still claimed unconditionally despite having the same dead-link fallback. Now guarded too.
- **Fixed (round 2)** — the `dedupeKey`/`debounceSeconds` refine existed only on the package schema, so `/api/mod/send-mod-notification` validated against the monolith's copy, accepted the pair, and then swallowed the package schema's throw — returning 200 with nothing sent. Mirrored onto the monolith copy.
- **Accepted** — ties *within* a priority batch are nondeterministic (e.g. `new-review-response` vs `new-comment-reply` when you authored both the review and the comment). Both messages are reasonable; "most specific wins" holds across batches, not within one.
- **Accepted** — `question`/`answer` thread types are emitted by the CASE but commented out of `threadUrlMap`, and a thread whose *root* is a question can slip past the `WHERE` filter. Three such threads exist in the entire database, none with mentions; questions are a dead feature.
- **Accepted** — if a processor's cursor lags (its query times out), a lower-priority type can claim the key first and the better message is lost for that comment. Bounded and rare; the user still gets exactly one notification.

## Testing

- 36 new tests: dedupe-key SQL shape and namespacing per processor, priority ordering and the numeric batch sort, worker fan-out (key is written, NULL passthrough, untargeted `ON CONFLICT` preserved, a deduped recipient produces no signal/no unread bump), debounce-path exclusion, and bulk-insert column arity.
- All 14 processor queries were executed against a live database to confirm they parse and return the expected `dedupeKey`.
- A render-parity test asserts that **every** type claiming a dedupe key produces both a message and a defined URL for each of its own detail shapes — the test that catches this whole class of bug.
- `pnpm typecheck` clean; 101/101 notifications-app tests and 83/83 monolith notification tests pass.

[ClickUp task](https://app.clickup.com/t/868kk491e)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
