### PR TITLE
docs(app-blocks): restore inverted cap-ceiling precedence comment

### DIFF
--- a/src/server/services/blocks/app-cap-limits.constants.ts
+++ b/src/server/services/blocks/app-cap-limits.constants.ts
@@ -477,11 +477,11 @@ export type AppCapLimitsRow = {
  * abusive app without demoting its tier is a first-class use of this surface.
  *
  * 🔴 The GLOBAL ceilings are applied LAST, after the override. An operator who
- * clamps `BLOCK_APP_SPEND_ABSOLUTE_MAX_GENS_PER_WINDOW=50` during an incident must
- * out-ranked by a per-app override written last week — the deploy-time knob is
- * the outermost bound on every path, tier and override alike. (The moderator
- * read surface returns the raw override alongside the effective pair, so a
- * clamp is visible rather than silent.)
+ * clamps `BLOCK_APP_SPEND_ABSOLUTE_MAX_GENS_PER_WINDOW=50` during an incident
+ * must not be out-ranked by a per-app override written last week — the
+ * deploy-time knob is the outermost bound on every path, tier and override
+ * alike. (The moderator read surface returns the raw override alongside the
+ * effective pair, so a clamp is visible rather than silent.)
  */
 export function resolveLimitsFromRow(row: AppCapLimitsRow): AppCapLimits {
   const base = limitsForSpendTier(row.spendTier);


### PR DESCRIPTION
Follow-up to #3528. Comment-only, no behaviour change.

## What happened

The env-var rename in #3528 lengthened `BLOCK_APP_SPEND_VELOCITY_MAX_GENS` to `BLOCK_APP_SPEND_ABSOLUTE_MAX_GENS_PER_WINDOW`, pushing a line over the wrap width. The reflow dropped the words **"not be"** from `app-cap-limits.constants.ts`:

```
 * clamps `BLOCK_APP_SPEND_ABSOLUTE_MAX_GENS_PER_WINDOW=50` during an incident must
 * out-ranked by a per-app override written last week — ...
```

As written it is ungrammatical. Repaired the natural way — *"must be out-ranked by"* — it asserts the **exact inverse** of what the code does.

## Why it matters

`resolveLimitsFromRow` applies the global ceiling **last**:

```ts
dailyBuzz: Math.min(dailyOverride ?? base.dailyBuzz, BLOCK_APP_SPEND_ABSOLUTE_MAX_BUZZ_PER_DAY),
velocityMaxGens: Math.min(velocityOverride ?? base.velocityMaxGens, BLOCK_APP_SPEND_ABSOLUTE_MAX_GENS_PER_WINDOW),
```

So the deploy-time clamp **wins** over a per-app override — the operator's clamp must **not** be out-ranked. The 🔴 marker on that paragraph is there because this is the file someone reads mid-incident to work out which cap actually applies; a comment that states the opposite precedence is worse than no comment.

Restored `not be` and reflowed the paragraph so it fits the new name.

## Verification

- Diffed against the pre-rename base (`5933977b8e`) to confirm the original wording was `must not be` / `out-ranked by`.
- Read `resolveLimitsFromRow` to confirm the restored claim matches the implementation, rather than trusting the base wording.

Found by an adversarial audit of #3528 (finding T5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wnxsw3bVq3s4DeQxZF6Tqp