### PR TITLE
feat(app-blocks): instrument per-app spend-cap REJECTIONS (the signal that can size user impact)

### DIFF
--- a/src/server/metrics/__tests__/app-block-spend-cap-rejections.metrics.test.ts
+++ b/src/server/metrics/__tests__/app-block-spend-cap-rejections.metrics.test.ts
@@ -1,0 +1,170 @@
+import client from 'prom-client';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  APP_SPEND_CAP_REJECTION_REASONS,
+  ensureRegisterAppBlockRuntimeMetrics,
+  recordAppSpendCapRejection,
+  type AppSpendCapRejectionReason,
+} from '../app-block-runtime.metrics';
+
+/**
+ * The REAL prom-client side of the per-app spend-cap REJECTION signal.
+ *
+ * The service-level test (app-spend-cap-rejection-signal.test.ts) mocks this
+ * module, which proves `reserveAppSpend` CALLS the emitter on every deny — it
+ * cannot prove the emitter produces a scrapeable series with the right name and
+ * the right label. A metric-name typo or a label-name mismatch sails straight
+ * through that test and yields an alert rule that silently never fires, which is
+ * the exact failure class this signal exists to prevent. So this file drives the
+ * real default registry.
+ *
+ * 🔴 The cardinality bound is the load-bearing property here. This counter emits
+ * once per DENIED submit with nothing caching or rate-limiting it, across ~130
+ * scraped pods, and prom-client retains every distinct label set in the Node heap
+ * for the process lifetime. One label over a 3-value code-owned union = 3 series,
+ * total, forever. Widening it is a code change that has to get past these tests.
+ */
+
+const METRIC = 'civitai_app_block_spend_cap_rejections_total';
+
+/** Read one `{reason}` series' current value from the default registry. */
+async function readReason(reason: string): Promise<number> {
+  const metric = client.register.getSingleMetric(METRIC) as
+    | { get(): Promise<{ values: Array<{ labels: Record<string, string>; value: number }> }> }
+    | undefined;
+  if (!metric) return Number.NaN;
+  const { values } = await metric.get();
+  return values.find((v) => v.labels.reason === reason)?.value ?? 0;
+}
+
+beforeEach(() => {
+  // `clear()` (not `resetMetrics()`): one case deliberately registers a POISONED
+  // metric under this name, and a values-only reset would leak it into every
+  // later case. A fully empty default registry makes each case order-independent.
+  client.register.clear();
+});
+
+describe('civitai_app_block_spend_cap_rejections_total', () => {
+  it('is registered on the default registry that /api/metrics scrapes', () => {
+    ensureRegisterAppBlockRuntimeMetrics();
+    expect(client.register.getSingleMetric(METRIC)).toBeDefined();
+  });
+
+  it.each(APP_SPEND_CAP_REJECTION_REASONS.map((r) => [r] as [AppSpendCapRejectionReason]))(
+    'increments the `%s` series',
+    async (reason) => {
+      recordAppSpendCapRejection(reason);
+      expect(await readReason(reason)).toBe(1);
+    }
+  );
+
+  it('🔴 the three reasons are SEPARATE series — infra denials never read as abuse denials', async () => {
+    // `unavailable` is not an abuse signal at all: it is a Redis/limit-resolution
+    // failure that denies EVERY app at once. Folding it in with `daily`/`velocity`
+    // would make a Redis blip look like a wave of abusive apps, which is the
+    // wrong incident and the wrong response.
+    recordAppSpendCapRejection('daily');
+    recordAppSpendCapRejection('velocity');
+    recordAppSpendCapRejection('velocity');
+    recordAppSpendCapRejection('unavailable');
+
+    expect(await readReason('daily')).toBe(1);
+    expect(await readReason('velocity')).toBe(2);
+    expect(await readReason('unavailable')).toBe(1);
+  });
+
+  it('🔴 DECLARES exactly one label, `reason` — the cardinality bound is structural', async () => {
+    // 🔴 Asserted against the DECLARED `labelNames`, NOT against the emitted
+    // series. prom-client omits a declared-but-never-supplied label from its
+    // output, so an inspection of `values[].labels` stays green while the metric
+    // is declared wide open — and the next caller to pass an `app_block_id` then
+    // blows the cardinality budget with nothing ever having failed.
+    ensureRegisterAppBlockRuntimeMetrics();
+    const metric = client.register.getSingleMetric(METRIC) as unknown as { labelNames: string[] };
+    expect([...metric.labelNames].sort()).toEqual(['reason']);
+
+    // …and the emitted series carries only that label too.
+    recordAppSpendCapRejection('daily');
+    const emitted = client.register.getSingleMetric(METRIC) as unknown as {
+      get(): Promise<{ values: Array<{ labels: Record<string, string> }> }>;
+    };
+    const { values } = await emitted.get();
+    expect(values.length).toBeGreaterThan(0);
+    for (const v of values) {
+      expect(Object.keys(v.labels)).toEqual(['reason']);
+    }
+  });
+
+  it('🔴 the reason union is EXACTLY these three values — 3 series is the whole budget', () => {
+    // Literal, not derived: this is the number an operator's cardinality budget
+    // is sized against, and the union is simultaneously the metric label AND
+    // `ReserveAppSpendResult['reason']`, so a fourth value silently added on the
+    // service side has to come through here.
+    expect([...APP_SPEND_CAP_REJECTION_REASONS]).toEqual(['daily', 'velocity', 'unavailable']);
+  });
+
+  it('🔴 emits AT MOST 3 series no matter how many rejections land', async () => {
+    // The end-state assertion the label-name check implies: drive 300 rejections
+    // across every reason and the scrape still carries 3 lines for this metric.
+    for (let i = 0; i < 100; i++) {
+      for (const reason of APP_SPEND_CAP_REJECTION_REASONS) recordAppSpendCapRejection(reason);
+    }
+    const metric = client.register.getSingleMetric(METRIC) as unknown as {
+      get(): Promise<{ values: Array<{ labels: Record<string, string> }> }>;
+    };
+    const { values } = await metric.get();
+    expect(values).toHaveLength(3);
+    expect(await readReason('daily')).toBe(100);
+  });
+
+  it('is idempotent to register — a double module import does not throw', () => {
+    // prom-client throws on a duplicate metric name; Next.js can import a module
+    // twice (hot reload / route bundling), so the get-or-create guard is what
+    // keeps that from taking the process down.
+    expect(() => {
+      ensureRegisterAppBlockRuntimeMetrics();
+      ensureRegisterAppBlockRuntimeMetrics();
+    }).not.toThrow();
+  });
+
+  it('appears in the scrape output under its exact name', async () => {
+    recordAppSpendCapRejection('velocity');
+    const scrape = await client.register.metrics();
+    expect(scrape).toContain(METRIC);
+    expect(scrape).toContain(`${METRIC}{reason="velocity"}`);
+  });
+
+  it('🔴 the emitter NEVER throws — a broken registry cannot turn a 402 into a 500', () => {
+    // Poison the default registry: something is already registered under this
+    // name with a DIFFERENT labelset (the shape a name collision takes). The
+    // get-or-create guard hands that instance back, and prom-client then throws
+    // on `.inc({ reason })` because `reason` was never declared on it.
+    //
+    // Without the emitter's own try/catch that throw lands on the deny path of a
+    // generation submit — i.e. the instrumentation would convert a working abuse
+    // guardrail into a 500.
+    new client.Counter({
+      name: METRIC,
+      help: 'poisoned duplicate with an incompatible labelset',
+      labelNames: ['unrelated'],
+      registers: [client.register],
+    });
+
+    expect(() => recordAppSpendCapRejection('daily')).not.toThrow();
+  });
+
+  it('the poisoned-registry case really would throw unguarded (the guard is reachable)', () => {
+    // Proves the case above is not vacuous: the underlying prom-client call DOES
+    // throw, so `not.toThrow()` there is testing the guard rather than an inert
+    // no-op. Without this, deleting the try/catch could leave the case green
+    // because the mechanism never actually failed.
+    const poisoned = new client.Counter({
+      name: METRIC,
+      help: 'poisoned duplicate with an incompatible labelset',
+      labelNames: ['unrelated'],
+      registers: [client.register],
+    });
+    expect(() => poisoned.inc({ reason: 'daily' })).toThrow();
+  });
+});

--- a/src/server/metrics/app-block-runtime.metrics.ts
+++ b/src/server/metrics/app-block-runtime.metrics.ts
@@ -14,6 +14,12 @@
 //      route (ok at BLOCK_READY, error on a host render failure).
 //   3. Cap-limit DEGRADE signal — emitted from app-cap-limits.service when the
 //      per-app spend/velocity resolver falls back to the strictest tier.
+//   4. Spend-cap REJECTION signal — emitted from app-spend-cap.service for every
+//      generation submit the per-app aggregate cap actually DENIES. (3) counts
+//      how often the LIMITS could not be resolved; (4) counts how many real
+//      generations were turned away. They are not substitutes: (3) is
+//      rate-capped by a 5s fallback cache, so a 10-submit degrade and a
+//      10,000-submit degrade produce the same counter value.
 //
 // prom-client GOTCHA: Next.js can import a module twice (hot reload / route
 // bundling), and prom-client throws if a metric name is registered twice. Every
@@ -85,6 +91,33 @@ export type AppBlockRenderResult = 'ok' | 'error';
  * rejections it did not earn.
  */
 export type AppCapLimitsDegradeReason = 'db_error' | 'missing_row';
+
+/**
+ * Why `reserveAppSpend` REJECTED one block-initiated generation submit. This is
+ * the SINGLE SOURCE for the union — `ReserveAppSpendResult['reason']` in
+ * `app-spend-cap.service.ts` is this same type (imported type-only, so nothing
+ * pulls prom-client into that module's static graph). Keeping one declaration is
+ * what stops the label set and the service's own contract from drifting apart:
+ * a new rejection cause cannot be returned without appearing here, and adding
+ * one here is a deliberate, reviewable widening of the metric's cardinality.
+ *
+ *   - `daily`       — the per-app daily Buzz ceiling would be exceeded. The
+ *                     MONEY bound: this app's viewers have collectively spent
+ *                     its budget for the UTC day. Expected to be sticky (it
+ *                     stays denied until the day rolls over).
+ *   - `velocity`    — the per-app short-window generation ceiling was exceeded.
+ *                     The RATE bound: bursty and self-clearing within one
+ *                     window, and the one a legitimately busy app trips first.
+ *   - `unavailable` — a Redis error, or a limit-resolution throw, on the reserve
+ *                     path → fail closed (deny, no spend). NOT an abuse signal
+ *                     at all: it is infra, and every app is denied at once.
+ *
+ * 🔴 EXACTLY THESE THREE, and `reason` is the ONLY label. See the counter below
+ * for why no app/user/block id may join them.
+ */
+export const APP_SPEND_CAP_REJECTION_REASONS = ['daily', 'velocity', 'unavailable'] as const;
+
+export type AppSpendCapRejectionReason = (typeof APP_SPEND_CAP_REJECTION_REASONS)[number];
 
 /** Known render slots. Anything else is bucketed to 'other' to bound the label. */
 const KNOWN_SLOT_IDS = new Set([
@@ -200,6 +233,7 @@ type Bundle = {
   customComfyActualBuzz: Histogram<string>;
   customComfyWallclockSeconds: Histogram<string>;
   capLimitsDegradedTotal: Counter<string>;
+  spendCapRejectionsTotal: Counter<string>;
 };
 
 // ── customComfy per-engine runtime/cost buckets ──────────────────────────────
@@ -316,6 +350,33 @@ export function ensureRegisterAppBlockRuntimeMetrics(reg: Registry = client.regi
     ['reason']
   );
 
+  // ── per-app spend-cap REJECTIONS ─────────────────────────────────────────────
+  // The signal that can size USER IMPACT. `capLimitsDegradedTotal` above counts
+  // cap-limit RESOLUTIONS that fell back — and it is rate-capped by the 5s
+  // fallback cache + single-flight, so a degrade affecting 10 submits and one
+  // affecting 10,000 produce the SAME counter value. It structurally cannot
+  // answer "how many generations were turned away", which is the question the
+  // whole cap-observability arc exists for ("users hitting abuse rejections they
+  // did not earn"). This counter answers it: one increment per DENIED submit, no
+  // cache in front of it.
+  //
+  // 🔴 EXACTLY ONE LABEL, `reason`, over a 3-value code-owned union → 3 series,
+  // TOTAL, forever. Deliberately NO `app_block_id` / `user_id` / block id: this
+  // fires once per denied submit (unlike the degrade counter, nothing caches or
+  // rate-limits it), so a per-app label would multiply an unbounded-ish
+  // population by a per-request emit rate, and prom-client retains every distinct
+  // label set in the Node heap forever (the --max-old-space-size exit-139 OOM
+  // class) across ~130 scraped pods. Attribution belongs in the caller's log line
+  // / trace, which already carries appBlockId, userId, and the resolved ceilings
+  // (`ReserveAppSpendResult.limits`). Alert on the metric, attribute from the log
+  // — the same split as the degrade counter above.
+  const spendCapRejectionsTotal = getOrCreateCounter(
+    reg,
+    'civitai_app_block_spend_cap_rejections_total',
+    'App Block generation submits DENIED by the per-app aggregate spend/velocity cap, by reason (daily = the per-app daily Buzz ceiling would be exceeded; velocity = the per-app short-window gen ceiling was exceeded; unavailable = a Redis/limit-resolution error, fail-closed deny)',
+    ['reason']
+  );
+
   return {
     requestsTotal,
     requestDurationSeconds,
@@ -323,6 +384,7 @@ export function ensureRegisterAppBlockRuntimeMetrics(reg: Registry = client.regi
     customComfyActualBuzz,
     customComfyWallclockSeconds,
     capLimitsDegradedTotal,
+    spendCapRejectionsTotal,
   };
 }
 
@@ -346,6 +408,29 @@ export function recordAppCapLimitsDegrade(reason: AppCapLimitsDegradeReason): vo
     capLimitsDegradedTotal.inc({ reason });
   } catch {
     /* instrument-only — never let a metrics error touch the cap guardrail */
+  }
+}
+
+/**
+ * Fail-soft emit of one per-app spend-cap REJECTION (`reserveAppSpend` denied a
+ * submit). Called from `app-spend-cap.service`.
+ *
+ * 🔴 TOTAL, like every emitter in this module. The thing it instruments is the
+ * money/abuse guardrail on the generation submit path: a metrics error (registry
+ * collision, label mismatch) must never propagate, or an intended 402/429
+ * rejection becomes a 500 — i.e. the observability would convert a working
+ * guardrail into an outage. The caller guards independently too; the duplication
+ * is deliberate, because the guarantee must not rest on either layer alone.
+ *
+ * COST: one in-heap counter increment on an already-rejecting path. An ALLOWED
+ * submit never reaches here, so the steady state on a healthy app is zero emits.
+ */
+export function recordAppSpendCapRejection(reason: AppSpendCapRejectionReason): void {
+  try {
+    const { spendCapRejectionsTotal } = ensureRegisterAppBlockRuntimeMetrics();
+    spendCapRejectionsTotal.inc({ reason });
+  } catch {
+    /* instrument-only — never let a metrics error touch the spend guardrail */
   }
 }
 

--- a/src/server/services/blocks/__tests__/app-spend-cap-rejection-signal.test.ts
+++ b/src/server/services/blocks/__tests__/app-spend-cap-rejection-signal.test.ts
@@ -1,0 +1,343 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * OBSERVABILITY of the per-app spend-cap REJECTION path.
+ *
+ * ── Why this signal exists ───────────────────────────────────────────────────
+ * The motivation for the whole cap-observability arc is "users hitting abuse
+ * rejections they did not earn". A REJECTION is literally that event, and it was
+ * uninstrumented: `reserveAppSpend` returned `reason: 'daily' | 'velocity' |
+ * 'unavailable'` with no counter behind it.
+ *
+ * Its sibling `civitai_app_block_cap_limits_degraded_total` (#3528) cannot stand
+ * in. That one counts cap-limit RESOLUTIONS that fell back to the strictest tier,
+ * and it is rate-capped by a 5s fallback cache + single-flight — so a degrade
+ * that affects 10 submits and one that affects 10,000 produce the SAME counter
+ * value. It can say "something degraded"; it structurally cannot say how many
+ * generations were turned away. This counter is one increment per DENIED submit,
+ * with nothing in front of it, which is what makes it able to size impact.
+ *
+ * Three properties are load-bearing and pinned below:
+ *   1. EVERY deny emits, with the reason that actually applied, and an ALLOWED
+ *      submit emits nothing (an alert on this must mean something).
+ *   2. It is NOT cached/deduplicated — N denials emit N times. This is the whole
+ *      difference from the degrade counter.
+ *   3. 🔴 It is NOT a failure path. A rejection is a deliberate, user-visible
+ *      402/429; a throwing or broken metrics module must never convert it into a
+ *      500, and must never change the rejection's own reason or refund.
+ *
+ * sysRedis is the same stateful in-memory fake as app-spend-cap.service.test.ts
+ * so the real INCRBY accumulation drives the real deny branches; the limit
+ * resolver is mocked so each case can pin the ceiling it is testing.
+ */
+
+const SPEND_CAP_PREFIX = 'system:blocks:app-spend-cap';
+
+const { store, ttls, mockSysRedis, mockResolveAppCapLimits, mockRecordRejection, metricsModule } =
+  vi.hoisted(() => {
+    const store = new Map<string, number>();
+    const ttls = new Map<string, number>();
+    const mockSysRedis = {
+      incrBy: vi.fn(async (key: string, n: number) => {
+        const next = (store.get(key) ?? 0) + n;
+        store.set(key, next);
+        return next;
+      }),
+      decrBy: vi.fn(async (key: string, n: number) => {
+        const next = (store.get(key) ?? 0) - n;
+        store.set(key, next);
+        return next;
+      }),
+      expire: vi.fn(async (key: string, seconds: number) => {
+        ttls.set(key, seconds);
+        return 1;
+      }),
+      ttl: vi.fn(async (key: string) => (ttls.has(key) ? ttls.get(key)! : 1000)),
+    };
+    const mockResolveAppCapLimits = vi.fn(
+      async (_appBlockId: string): Promise<{ dailyBuzz: number; velocityMaxGens: number }> => ({
+        dailyBuzz: 5_000_000,
+        velocityMaxGens: 600,
+      })
+    );
+    const mockRecordRejection = vi.fn((_reason: string): void => undefined);
+    // `brokenExport` simulates the metrics module itself being unusable (a failed
+    // dynamic import / a module whose shape is broken), as distinct from an
+    // emitter that throws. Both must be swallowed, and they hit the guard from
+    // different directions.
+    const metricsModule = { brokenExport: false };
+    return {
+      store,
+      ttls,
+      mockSysRedis,
+      mockResolveAppCapLimits,
+      mockRecordRejection,
+      metricsModule,
+    };
+  });
+
+vi.mock('~/server/redis/client', () => ({
+  sysRedis: mockSysRedis,
+  REDIS_SYS_KEYS: { BLOCKS: { APP_SPEND_CAP: 'system:blocks:app-spend-cap' } },
+}));
+
+vi.mock('~/server/services/blocks/app-cap-limits.service', () => ({
+  resolveAppCapLimits: (appBlockId: string) => mockResolveAppCapLimits(appBlockId),
+  invalidateAppCapLimits: vi.fn(),
+  normalizeCapOverrideInput: vi.fn(),
+  __resetAppCapLimitsCacheForTests: vi.fn(),
+}));
+
+// The service dynamic-imports the metrics module, so this mock applies. Only the
+// rejection emitter is stubbed; the real prom-client module (name, label,
+// cardinality) is exercised in
+// src/server/metrics/__tests__/app-block-spend-cap-rejections.metrics.test.ts.
+vi.mock('~/server/metrics/app-block-runtime.metrics', () => ({
+  get recordAppSpendCapRejection() {
+    if (metricsModule.brokenExport) throw new Error('metrics module failed to load');
+    return mockRecordRejection;
+  },
+}));
+
+import { STRICTEST_APP_CAP_LIMITS } from '../app-cap-limits.constants';
+import { reserveAppSpend } from '../app-spend-cap.service';
+
+const APP_BLOCK_ID = 'apb_reject_test';
+
+function dailyKey(app = APP_BLOCK_ID): string {
+  const today = new Date().toISOString().slice(0, 10);
+  return `${SPEND_CAP_PREFIX}:${app}:${today}`;
+}
+
+/** Reasons passed to the rejection emitter, in call order. */
+function reasons(): string[] {
+  return mockRecordRejection.mock.calls.map((c) => c[0] as string);
+}
+
+beforeEach(() => {
+  store.clear();
+  ttls.clear();
+  for (const fn of [
+    mockSysRedis.incrBy,
+    mockSysRedis.decrBy,
+    mockSysRedis.expire,
+    mockSysRedis.ttl,
+  ]) {
+    fn.mockReset();
+  }
+  // 🔴 Implementations are RE-ESTABLISHED, not merely cleared: a fault-injection
+  // case leaves a `mockRejectedValue` behind, which would otherwise leak into
+  // every later test in the file.
+  mockSysRedis.incrBy.mockImplementation(async (key: string, n: number) => {
+    const next = (store.get(key) ?? 0) + n;
+    store.set(key, next);
+    return next;
+  });
+  mockSysRedis.decrBy.mockImplementation(async (key: string, n: number) => {
+    const next = (store.get(key) ?? 0) - n;
+    store.set(key, next);
+    return next;
+  });
+  mockSysRedis.expire.mockImplementation(async (key: string, seconds: number) => {
+    ttls.set(key, seconds);
+    return 1;
+  });
+  mockSysRedis.ttl.mockImplementation(async (key: string) =>
+    ttls.has(key) ? ttls.get(key)! : 1000
+  );
+
+  mockResolveAppCapLimits.mockReset();
+  mockResolveAppCapLimits.mockResolvedValue({ dailyBuzz: 5_000_000, velocityMaxGens: 600 });
+
+  mockRecordRejection.mockReset();
+  mockRecordRejection.mockImplementation(() => undefined);
+  metricsModule.brokenExport = false;
+});
+
+describe('spend-cap rejection signal — every deny is counted, with the reason that applied', () => {
+  it('a DAILY-ceiling deny emits `daily`', async () => {
+    mockResolveAppCapLimits.mockResolvedValue({ dailyBuzz: 100, velocityMaxGens: 600 });
+
+    const res = await reserveAppSpend(APP_BLOCK_ID, 101);
+
+    expect(res.allowed).toBe(false);
+    expect(res.reason).toBe('daily');
+    expect(reasons()).toEqual(['daily']);
+  });
+
+  it('a VELOCITY-ceiling deny emits `velocity`', async () => {
+    mockResolveAppCapLimits.mockResolvedValue({ dailyBuzz: 5_000_000, velocityMaxGens: 2 });
+
+    expect((await reserveAppSpend(APP_BLOCK_ID, 0)).allowed).toBe(true);
+    expect((await reserveAppSpend(APP_BLOCK_ID, 0)).allowed).toBe(true);
+    const third = await reserveAppSpend(APP_BLOCK_ID, 0);
+
+    expect(third.allowed).toBe(false);
+    expect(third.reason).toBe('velocity');
+    expect(reasons()).toEqual(['velocity']);
+  });
+
+  it('a fail-closed deny (Redis error) emits `unavailable`', async () => {
+    mockSysRedis.incrBy.mockRejectedValue(new Error('redis down'));
+
+    const res = await reserveAppSpend(APP_BLOCK_ID, 100);
+
+    expect(res.allowed).toBe(false);
+    expect(res.reason).toBe('unavailable');
+    expect(reasons()).toEqual(['unavailable']);
+  });
+
+  it('a LIMIT-RESOLUTION throw also emits `unavailable` — infra, not abuse', async () => {
+    // The other way into the fail-closed branch. It must not be mistaken for an
+    // app burning its budget: nothing about this app was over any ceiling.
+    mockResolveAppCapLimits.mockRejectedValue(new Error('resolver exploded'));
+
+    const res = await reserveAppSpend(APP_BLOCK_ID, 100);
+
+    expect(res.reason).toBe('unavailable');
+    expect(reasons()).toEqual(['unavailable']);
+    expect(res.limits).toEqual(STRICTEST_APP_CAP_LIMITS);
+  });
+
+  it('🔴 the emitted reason always MATCHES the reason the caller is told', async () => {
+    // The counter and the user-facing rejection must not be able to disagree —
+    // an operator correlating a support report against the metric is relying on
+    // exactly that. Drives all three branches in one pass.
+    const observed: string[] = [];
+
+    mockResolveAppCapLimits.mockResolvedValue({ dailyBuzz: 100, velocityMaxGens: 600 });
+    observed.push((await reserveAppSpend('apb_a', 101)).reason!);
+
+    mockResolveAppCapLimits.mockResolvedValue({ dailyBuzz: 5_000_000, velocityMaxGens: 1 });
+    await reserveAppSpend('apb_b', 0);
+    observed.push((await reserveAppSpend('apb_b', 0)).reason!);
+
+    mockSysRedis.incrBy.mockRejectedValue(new Error('redis down'));
+    observed.push((await reserveAppSpend('apb_c', 5)).reason!);
+
+    expect(observed).toEqual(['daily', 'velocity', 'unavailable']);
+    expect(reasons()).toEqual(['daily', 'velocity', 'unavailable']);
+  });
+
+  it('an ALLOWED submit emits NOTHING (an alert on this must mean something)', async () => {
+    for (let i = 0; i < 10; i++) {
+      expect((await reserveAppSpend(APP_BLOCK_ID, 10)).allowed).toBe(true);
+    }
+    expect(mockRecordRejection).not.toHaveBeenCalled();
+  });
+
+  it('🔴 counts AFFECTED GENERATIONS, not degradation events — N denials emit N times', async () => {
+    // The property that makes this metric able to size impact, and the exact
+    // property `civitai_app_block_cap_limits_degraded_total` lacks: that one is
+    // rate-capped by a 5s fallback cache, so a burst against one degraded app
+    // emits ONCE however many submits it turned away. Nothing caches this one.
+    mockResolveAppCapLimits.mockResolvedValue({ dailyBuzz: 5_000_000, velocityMaxGens: 3 });
+
+    let denied = 0;
+    for (let i = 0; i < 50; i++) {
+      if (!(await reserveAppSpend(APP_BLOCK_ID, 0)).allowed) denied++;
+    }
+
+    expect(denied).toBe(47);
+    expect(mockRecordRejection).toHaveBeenCalledTimes(47);
+    expect(new Set(reasons())).toEqual(new Set(['velocity']));
+  });
+});
+
+describe('🔴 the rejection signal is NOT a failure path', () => {
+  it('a THROWING emitter leaves a DAILY deny intact — same reason, no second refund', async () => {
+    // The deny path already refunded the reserve before signalling. If the emit
+    // escaped, the outer catch would (a) relabel this as `unavailable` — an abuse
+    // rejection reported as infra — and (b) refund a SECOND time, driving the
+    // per-app daily counter negative and handing the app free headroom.
+    mockRecordRejection.mockImplementation(() => {
+      throw new Error('prom registry exploded');
+    });
+    mockResolveAppCapLimits.mockResolvedValue({ dailyBuzz: 100, velocityMaxGens: 600 });
+
+    // Land the counter at 100 (exactly at the ceiling) with an allowed submit…
+    expect((await reserveAppSpend(APP_BLOCK_ID, 100)).allowed).toBe(true);
+    mockSysRedis.decrBy.mockClear();
+
+    // …then a submit that breaches it.
+    const res = await reserveAppSpend(APP_BLOCK_ID, 50);
+
+    expect(res.allowed).toBe(false);
+    expect(res.reason).toBe('daily');
+    // Exactly ONE refund of exactly the attempted cost.
+    expect(mockSysRedis.decrBy).toHaveBeenCalledTimes(1);
+    expect(mockSysRedis.decrBy).toHaveBeenCalledWith(dailyKey(), 50);
+    expect(store.get(dailyKey())).toBe(100);
+  });
+
+  it('a THROWING emitter leaves a VELOCITY deny intact (still `velocity`, still denied)', async () => {
+    mockRecordRejection.mockImplementation(() => {
+      throw new Error('prom registry exploded');
+    });
+    mockResolveAppCapLimits.mockResolvedValue({ dailyBuzz: 5_000_000, velocityMaxGens: 1 });
+
+    expect((await reserveAppSpend(APP_BLOCK_ID, 0)).allowed).toBe(true);
+    const res = await reserveAppSpend(APP_BLOCK_ID, 0);
+
+    expect(res.allowed).toBe(false);
+    expect(res.reason).toBe('velocity');
+  });
+
+  it('🔴 a THROWING emitter on the fail-closed path RESOLVES — it never rejects into the caller', async () => {
+    // The `unavailable` emit runs inside `reserveAppSpend`'s own catch, where
+    // there is no outer belt left: an unguarded throw there escapes the function
+    // entirely and the submit handler returns a 500 instead of the intended
+    // fail-closed rejection. That is observability causing an outage.
+    mockRecordRejection.mockImplementation(() => {
+      throw new Error('prom registry exploded');
+    });
+    mockSysRedis.incrBy.mockRejectedValue(new Error('redis down'));
+
+    const res = await reserveAppSpend(APP_BLOCK_ID, 100);
+
+    expect(res.allowed).toBe(false);
+    expect(res.reason).toBe('unavailable');
+    // The payload is intact too — the ceilings resolved before Redis failed, so
+    // the caller still logs what this app was actually judged against.
+    expect(res.limits).toEqual({ dailyBuzz: 5_000_000, velocityMaxGens: 600 });
+  });
+
+  it('a BROKEN metrics module (the import/destructure itself throws) does not break the deny', async () => {
+    // Distinct from a throwing emitter: here the module never yields a usable
+    // export at all — a failed dynamic import, a bundling break, a module whose
+    // shape changed. The guard has to cover the `await import(...)` too, not just
+    // the call.
+    metricsModule.brokenExport = true;
+    mockResolveAppCapLimits.mockResolvedValue({ dailyBuzz: 100, velocityMaxGens: 600 });
+
+    const res = await reserveAppSpend(APP_BLOCK_ID, 101);
+
+    expect(res.allowed).toBe(false);
+    expect(res.reason).toBe('daily');
+    expect(mockRecordRejection).not.toHaveBeenCalled();
+  });
+
+  it('a broken metrics module does not stop LATER rejections from being counted', async () => {
+    // A transient metrics failure must not leave the signal permanently dark —
+    // there is no memoised import result or one-shot disable to get stuck.
+    metricsModule.brokenExport = true;
+    mockResolveAppCapLimits.mockResolvedValue({ dailyBuzz: 100, velocityMaxGens: 600 });
+    await reserveAppSpend(APP_BLOCK_ID, 101);
+    expect(mockRecordRejection).not.toHaveBeenCalled();
+
+    metricsModule.brokenExport = false;
+    await reserveAppSpend(APP_BLOCK_ID, 101);
+    expect(reasons()).toEqual(['daily']);
+  });
+
+  it('a throwing emitter does not perturb an ALLOWED submit either', async () => {
+    mockRecordRejection.mockImplementation(() => {
+      throw new Error('prom registry exploded');
+    });
+    const res = await reserveAppSpend(APP_BLOCK_ID, 100);
+
+    expect(res.allowed).toBe(true);
+    expect(res.dailyKey).toBe(dailyKey());
+    expect(store.get(dailyKey())).toBe(100);
+  });
+});

--- a/src/server/services/blocks/app-spend-cap.service.ts
+++ b/src/server/services/blocks/app-spend-cap.service.ts
@@ -1,3 +1,4 @@
+import type { AppSpendCapRejectionReason } from '~/server/metrics/app-block-runtime.metrics';
 import { REDIS_SYS_KEYS, sysRedis } from '~/server/redis/client';
 import {
   BLOCK_APP_SPEND_VELOCITY_WINDOW_SECONDS,
@@ -140,8 +141,15 @@ export type ReserveAppSpendResult = {
    *   - 'velocity'    the per-app short-window gen ceiling was exceeded
    *   - 'unavailable' a Redis error → fail closed (deny, no spend)
    * Undefined when allowed.
+   *
+   * 🔴 The union is declared ONCE, in `app-block-runtime.metrics.ts`, because it
+   * is simultaneously this contract and the `reason` label of
+   * `civitai_app_block_spend_cap_rejections_total`. One declaration means a new
+   * rejection cause cannot be added on one side only — which would either emit
+   * an unlabelled series or leave a whole rejection class uncounted. The import
+   * is TYPE-ONLY, so prom-client stays out of this module's static graph.
    */
-  reason?: 'daily' | 'velocity' | 'unavailable';
+  reason?: AppSpendCapRejectionReason;
   /** Running per-app daily Buzz total AFTER this reservation (for logging). */
   dailyTotal: number;
   /** Running per-app velocity count in the current window (for logging). */
@@ -162,6 +170,47 @@ export type ReserveAppSpendResult = {
    */
   limits: AppCapLimits;
 };
+
+/**
+ * THE SINGLE EXIT for every denied reservation: emit the rejection signal, then
+ * build the `allowed: false` result. Every `return` on a deny path in
+ * `reserveAppSpend` goes through here, so instrumenting a rejection is not a
+ * thing a future rejection cause can forget to do — the counter and the contract
+ * are produced by the same call.
+ *
+ * 🔴 THE EMIT CAN NEVER BREAK THE REQUEST. A rejection is a deliberate,
+ * user-visible 402/429 on the generation submit path; a metrics module that
+ * failed to import, or an emitter that threw, must not convert that into a 500.
+ * So the whole signal is swallowed here, and `recordAppSpendCapRejection` is
+ * independently total on its own side — two layers, because the guarantee must
+ * not depend on either alone. (The `unavailable` call site is inside
+ * `reserveAppSpend`'s own `catch`, where there is no outer belt left at all: an
+ * unguarded throw there escapes the function entirely.)
+ *
+ * The metrics module is dynamically imported, matching `app-cap-limits.service`
+ * — it keeps prom-client out of the deliberately-light static import graph of
+ * the spend-cap path.
+ *
+ * VOLUME. Unlike the degrade signal (bounded by a 5s fallback cache), this emits
+ * once per DENIED submit, with nothing in front of it — that is the entire point:
+ * a cached signal cannot size how many generations were actually turned away.
+ * The cost is one in-heap increment on a path that is already returning a
+ * failure, over a label set fixed at 3 series.
+ */
+async function denyAppSpend(
+  reason: AppSpendCapRejectionReason,
+  fields: { dailyTotal: number; velocityCount: number; limits: AppCapLimits }
+): Promise<ReserveAppSpendResult> {
+  try {
+    const { recordAppSpendCapRejection } = await import(
+      '~/server/metrics/app-block-runtime.metrics'
+    );
+    recordAppSpendCapRejection(reason);
+  } catch {
+    /* observability must never break the guardrail it observes */
+  }
+  return { allowed: false, reason, ...fields };
+}
 
 /**
  * Atomically reserve one block-initiated generation against this APP's
@@ -187,6 +236,15 @@ export type ReserveAppSpendResult = {
  *
  * On a Redis error anywhere, best-effort roll back any partial daily
  * reservation and deny (`reason: 'unavailable'`) — fail-safe, no spend.
+ *
+ * 🔴 EVERY DENY IS COUNTED. All three deny paths exit through `denyAppSpend`
+ * below, which emits `civitai_app_block_spend_cap_rejections_total{reason}`.
+ * This is the signal that can size USER IMPACT — the motivation for the whole
+ * cap-observability arc is "users hitting abuse rejections they did not earn",
+ * and a rejection is precisely that event. Its sibling
+ * `civitai_app_block_cap_limits_degraded_total` cannot answer it: that one counts
+ * limit RESOLUTIONS and is rate-capped by a 5s fallback cache, so 10 affected
+ * submits and 10,000 affected submits read identically.
  */
 export async function reserveAppSpend(
   appBlockId: string,
@@ -220,7 +278,13 @@ export async function reserveAppSpend(
       if (dailyTotal > limits.dailyBuzz) {
         // Over the daily cap → refund the full cost (all-or-nothing) and deny.
         await refundAppSpend(dailyKey, want);
-        return { allowed: false, reason: 'daily', dailyTotal, velocityCount: 0, limits };
+        // `return await` (not a bare `return`) keeps the deny inside this try, so
+        // a throw from the signal would be caught here rather than escaping. It
+        // is defence-in-depth ONLY: `denyAppSpend` is fully guarded, so with the
+        // guard in place the two spellings are behaviourally identical —
+        // mutating `return await` → `return` kills no test, and deliberately so.
+        // It buys something only in the both-guards-removed case.
+        return await denyAppSpend('daily', { dailyTotal, velocityCount: 0, limits });
       }
     }
 
@@ -238,7 +302,7 @@ export async function reserveAppSpend(
       // velocity counter itself is left incremented (a rejected attempt still
       // consumed a rate slot; the bucket self-expires).
       if (dailyReserved > 0) await refundAppSpend(dailyKey, dailyReserved);
-      return { allowed: false, reason: 'velocity', dailyTotal, velocityCount, limits };
+      return await denyAppSpend('velocity', { dailyTotal, velocityCount, limits });
     }
 
     return {
@@ -253,7 +317,7 @@ export async function reserveAppSpend(
     // back any daily reservation we managed to make so the counter doesn't
     // over-count a denied submit, then deny with no spend.
     if (dailyReserved > 0) await refundAppSpend(dailyKey, dailyReserved);
-    return { allowed: false, reason: 'unavailable', dailyTotal, velocityCount: 0, limits };
+    return denyAppSpend('unavailable', { dailyTotal, velocityCount: 0, limits });
   }
 }
 


### PR DESCRIPTION
Follow-up to #3528, closing the gap that PR's own audit flagged.

## The gap

The motivation for the whole cap-observability arc is **"users hitting abuse rejections they did not earn"** — and the rejection itself was uninstrumented. `reserveAppSpend` returns `reason: 'daily' | 'velocity' | 'unavailable'` and nothing counted it.

`civitai_app_block_cap_limits_degraded_total{reason}` (#3528) cannot stand in. It counts cap-limit **resolutions** that fell back to the strictest tier, and it is rate-capped by the 5s fallback cache + single-flight — so a degrade affecting 10 submits and a degrade affecting 10,000 submits produce the **same counter value**. It can say "something degraded"; it structurally cannot say how many generations were turned away. That is a property of its design, not a tuning problem.

## What this adds

`civitai_app_block_spend_cap_rejections_total{reason}` — one increment per **denied submit**, nothing cached in front of it.

| `reason` | meaning | operator response |
|---|---|---|
| `daily` | the per-app daily Buzz ceiling would be exceeded | the MONEY bound; sticky until the UTC day rolls over |
| `velocity` | the per-app short-window gen ceiling was exceeded | the RATE bound; bursty, self-clearing, what a legitimately busy app trips first |
| `unavailable` | a Redis error or a limit-resolution throw → fail-closed deny | **not an abuse signal at all** — infra, denies every app at once |

Deliberately three series rather than one: folding `unavailable` in with the two abuse reasons would make a Redis blip read as a wave of abusive apps.

Follows the existing convention in `src/server/metrics/app-block-runtime.metrics.ts` (get-or-create against the default registry + a total emit wrapper). No new mechanism.

## Emit sites

All three deny paths exit through one choke point, `denyAppSpend` (`app-spend-cap.service.ts:200`):

- `app-spend-cap.service.ts:287` — `daily`
- `app-spend-cap.service.ts:305` — `velocity`
- `app-spend-cap.service.ts:320` — `unavailable`

Instrumenting a rejection is therefore not something a future deny path can forget to do: the counter and the `allowed:false` contract are produced by the same call.

## 🔴 Cardinality

**Exactly one label, over a 3-value code-owned union → 3 series, forever.**

No `app_block_id`, `user_id`, or block id. Unlike the degrade counter, this emits once per denied submit with nothing rate-limiting it, and prom-client retains every distinct label set in the Node heap for the process lifetime, across ~130 scraped pods. Attribution belongs in the caller's log line / trace, which already carries `appBlockId`, `userId`, and the resolved ceilings (`ReserveAppSpendResult.limits`). **Alert on the metric, attribute from the log** — the same split as #3528.

The union is declared **once** (`APP_SPEND_CAP_REJECTION_REASONS`, `app-block-runtime.metrics.ts:118`) and is simultaneously the prom label **and** `ReserveAppSpendResult['reason']` (imported type-only, so prom-client stays out of the spend-cap path's static import graph). A new rejection cause cannot be added on one side only — which would otherwise either emit an undeclared label or leave a whole rejection class uncounted.

## 🔴 The emit can never break a generation request

A rejection is a deliberate, user-visible 402/429. A metrics failure must not turn it into a 500 — i.e. the observability must not convert a working guardrail into an outage.

Two independent layers, because the guarantee must not rest on either alone:
- `denyAppSpend` swallows the whole signal (covering the `await import(...)` as well as the call);
- `recordAppSpendCapRejection` is total on its own side.

The `unavailable` call site is the sharp one: it runs inside `reserveAppSpend`'s own `catch`, where there is no outer belt left at all — an unguarded throw there escapes the function entirely.

## ⚠️ Note for whoever writes the alert

**Do not reach for `rate()`.** On a ~130-pod fleet a rare per-pod counter is born at 1 and never increments again on that pod, so `rate()` is structurally 0 and the alert silently never fires. Use `max_over_time(...)` (or `increase()` over a window long enough to contain a second increment). Rejections should be more frequent than #3528's degrades, so this bites less hard here — but the failure mode is the same and it is silent, so it is worth stating. A sibling change is writing the alert for #3528's metric in the infra repo.

Reasonable starting shape once volume is observed:
- `unavailable` non-zero at all → infra, page-worthy (it means every app is being denied).
- `daily` / `velocity` sustained → an app is at its ceiling; correlate with `civitai_app_block_cap_limits_degraded_total` to tell "genuinely at its budget" from "pinned to the strictest tier because its limits could not be resolved" — which is exactly the *"rejections they did not earn"* case, and the reason both counters are worth having.

## Tests

25 new across two files, mirroring #3528's split:

- `src/server/metrics/__tests__/app-block-spend-cap-rejections.metrics.test.ts` (12) — drives the **real** prom-client registry: name, label declaration, 3 separate series, at-most-3-series under 300 rejections, scrape output, idempotent registration, and the emitter's never-throw contract against a poisoned registry.
- `src/server/services/blocks/__tests__/app-spend-cap-rejection-signal.test.ts` (13) — drives the real deny branches through the in-memory Redis fake: each reason emits, the emitted reason always matches what the caller is told, an allowed submit emits nothing, N denials emit N times, and a throwing/broken metrics module changes neither the outcome nor the refund.

Expected values are literal, never derived from the implementation.

### Mutation results

Every guard was broken on purpose and confirmed to fail with **that guard's own** error:

| # | Mutation | Test killed | Failure |
|---|---|---|---|
| M1 | remove the try/catch in `denyAppSpend` | 5 tests in *"the rejection signal is NOT a failure path"* | `Error: prom registry exploded` / `Error: metrics module failed to load` escaping `reserveAppSpend` |
| M2 | remove the try/catch in `recordAppSpendCapRejection` | *"🔴 the emitter NEVER throws — a broken registry cannot turn a 402 into a 500"* | `expected [Function] to not throw an error but 'Error: Added label "reason" is not in…' was thrown` |
| M3 | `labelNames: ['reason']` → `['reason','app_block_id']` | *"🔴 DECLARES exactly one label, `reason` — the cardinality bound is structural"* | `expected [ 'app_block_id', 'reason' ] to deeply equal [ 'reason' ]` |
| M4 | typo the metric name | 6 tests in the metrics file | `expected undefined to be defined`, `expected NaN to be 1` |
| M5 | add a 4th value to `APP_SPEND_CAP_REJECTION_REASONS` | *"🔴 the reason union is EXACTLY these three values"* + *"🔴 emits AT MOST 3 series"* | `expected [ 'daily', 'velocity', …(2) ] to deeply equal [ 'daily', 'velocity', 'unavailable' ]`; `expected [ …(4) ] to have a length of 3 but got 4` |
| M6 | bypass the choke point on the `daily` deny | *"a DAILY-ceiling deny emits `daily`"* | `expected [] to deeply equal [ 'daily' ]` |
| M7 | bypass the choke point on the `velocity` deny | *"a VELOCITY-ceiling deny emits `velocity`"* | `expected [] to deeply equal [ 'velocity' ]`; `expected "vi.fn()" to be called 47 times, but got 0 times` |
| M8 | bypass the choke point on the fail-closed deny | *"a fail-closed deny (Redis error) emits `unavailable`"* | `expected [] to deeply equal [ 'unavailable' ]` |

One mutation **survived**, disclosed rather than hidden: `return await denyAppSpend(...)` → `return denyAppSpend(...)` on the in-`try` deny paths kills no test. It is defence-in-depth that only differs in the both-guards-removed case, and the code comment now says exactly that instead of claiming it is load-bearing.

### Local verification

- **Unit suite** (`src/server/metrics` + `src/server/services/blocks`), verbose, per-file collection confirmed: `origin/main` **2119 tests / 106 files, 2 failing**; this branch **2144 tests / 108 files, 2 failing** — the same two pre-existing `manifest-schema-endpoint.test.ts` failures (`Cannot find package 'kysely'`, a local-env gap). Delta: **+25 tests, +2 files, 0 new failures.** Both new files appear in the verbose output with their expected counts (12 and 13).
- **Typecheck**: `tsc --noEmit` diffed against an `origin/main` baseline captured in the same environment — **byte-identical output**, 16 pre-existing errors (missing `kysely`, missing `event-engine-common` submodule), none in any file this PR touches. Local `prisma generate` cannot run on this machine, so **CI is authoritative**.
- **Lint**: `eslint` on the 4 changed files — 0 errors; 2 `no-unused-vars` warnings on `_`-prefixed mock params, the same house-style warnings `origin/main`'s own `app-spend-cap.service.test.ts` and `app-cap-limits-degrade-signal.test.ts` already emit.
- **Prettier**: `--list-different` clean on all 4 files.

Not verified locally: the metric under a real `/api/metrics` scrape in a running pod (no local Next.js runtime here) — the registration and scrape-output shape are covered against the real default registry in the metrics test instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wnxsw3bVq3s4DeQxZF6Tqp
