### PR TITLE
fix(monetization): clear licensing fee to null on removal + restore payouts

### DIFF
--- a/src/server/services/model-version.service.ts
+++ b/src/server/services/model-version.service.ts
@@ -485,12 +485,23 @@ export const upsertModelVersion = async ({
     ? (await dbRead.modelVersion.findUnique({ where: { id }, select: { flags: true } }))?.flags ?? 0
     : 0;
 
-  // Versions with a license fee earn through that channel, so they opt out of
-  // tip + creator-comp payouts. We only ever ADD the flag — clearing the fee
-  // doesn't strip it, since a creator may have set the bit independently.
+  // Clearing a fee must persist NULL, not 0: a stored 0 still reads as "has a
+  // fee" and pays out 0 instead of restoring base compensation + tips.
+  const hasLicensingFee = data.licensingFee != null && data.licensingFee > 0;
+  if (!hasLicensingFee) {
+    data.licensingFee = null;
+    data.licensingFeeType = null;
+    data.licensingFeeSettlementCurrency = null;
+  }
+
+  // A fee opts the version out of tip + creator-comp payouts via DisablePayout.
+  // This is the flag's only set site, so clearing the fee must strip it —
+  // otherwise the version keeps earning nothing after the fee is removed.
   let flagsOverride: number | undefined;
-  if (data.licensingFee != null && data.licensingFee > 0) {
+  if (hasLicensingFee) {
     flagsOverride = Flags.addFlag(existingFlags, ModelVersionFlag.DisablePayout);
+  } else if (Flags.hasFlag(existingFlags, ModelVersionFlag.DisablePayout)) {
+    flagsOverride = Flags.removeFlag(existingFlags, ModelVersionFlag.DisablePayout);
   }
 
   // Get model information to check NSFW + restricted base model combination
@@ -803,6 +814,16 @@ export const upsertModelVersion = async ({
     ingestModelById({ id: version.modelId }).catch((error) =>
       logToAxiom({ type: 'error', name: 'model-ingestion', error, modelId: version.modelId })
     );
+
+    // A licensing-fee or payout-flag change has to invalidate the orchestrator's
+    // cached pricing/payout for this version; otherwise it keeps repricing (and
+    // paying) against the stale value and the fee removal reads as "still earning
+    // nothing". The version-save path didn't bust on its own.
+    const feeBefore =
+      existingVersion.licensingFee != null ? Number(existingVersion.licensingFee) : null;
+    if (feeBefore !== (data.licensingFee ?? null) || flagsOverride !== undefined) {
+      await bustMvCache(version.id, version.modelId, actorUserId);
+    }
 
     return version;
   }


### PR DESCRIPTION
## Problem
Removing a licensing fee left the creator earning **nothing** — reported by IcebergMM (ClickUp 868kk4j2k). His IcebergMix v3.0 (ModelVersion 3184124) had `licensingFee = 0.00` while his other versions were correctly NULL. Manually nulled + orchestrator-cache-busted to unstick him; this fixes it for everyone.

## Root causes (in the version upsert, `model-version.service.ts`)
1. **Fee cleared → persisted `0`, not `NULL`.** A stored `0` reads as "has a fee" and pays out 0 instead of restoring base compensation + tips. Now any non-positive/absent fee is coerced to NULL (`licensingFee`, `licensingFeeType`, `licensingFeeSettlementCurrency`).
2. **`DisablePayout` flag never stripped on clear.** Setting a fee adds the version-level `ModelVersionFlag.DisablePayout` (opts out of tip + creator-comp payouts). The old code only ever ADDED it, with a comment assuming a creator might set it independently — but this flag has **exactly one set site** (the fee path; confirmed by grep). So clearing the fee can and must strip it, or the version keeps earning nothing after removal. `UserFlag.DisablePayout` (a separate, moderation flag) is untouched.
3. **Version-save path didn't bust the orchestrator cache.** Wired `bustMvCache(...)` to fire when the fee or payout flag actually changed, so the corrected value propagates to generation pricing/payout instead of the orchestrator repricing against stale data.

## ⚠️ For Briant — please review
- **The `DisablePayout` strip (cause 2)** reverses a deliberate "only ever add" behavior. I'm confident it's correct (single set site, and it's the actual reason removal leaves earnings at zero), but it changes payout-flag semantics, so please confirm there's truly no other path that sets the version-level flag.
- **Note on the orchestrator cache bust:** `bustOrchestratorModelCache` in `services/orchestrator/models.ts` is **already working on main** (it was restored after being commented out for ~2.5 months). This PR does NOT touch it — it only *invokes* it (via `bustMvCache`) on the fee-change path, which wasn't happening. If you'd prefer a lighter, orchestrator-only bust here instead of full `bustMvCache`, easy to swap.

Do not merge without Briant's review of the payout-flag change.