### PR TITLE
feat(generation): make silent checkpoint substitution observable (#3520 phase 1)

### DIFF
--- a/src/server/metrics/__tests__/generation-model-substitution.metrics.test.ts
+++ b/src/server/metrics/__tests__/generation-model-substitution.metrics.test.ts
@@ -2,8 +2,10 @@ import client from 'prom-client';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
+  GENERATION_SURFACES,
   MODEL_SUBSTITUTION_REASONS,
   createModelSubstitutionCollector,
+  type GenerationSurface,
   type ModelSubstitutionReason,
 } from '~/shared/data-graph/generation/model-substitution';
 import { emitModelSubstitutions } from '../emit-model-substitutions';
@@ -28,21 +30,37 @@ import {
  *      unguarded prom-client error here would turn a working generation into a
  *      500 — observability causing the outage.
  *
- * 🔴 CARDINALITY is the other load-bearing property: `reason` over a 3-value
- * code-owned union = 3 series, total, forever, across ~130 scraped pods where
- * prom-client retains every distinct label set in the Node heap for the process
- * lifetime. Widening it has to get past these tests.
+ * 🔴 CARDINALITY is the other load-bearing property: `reason` (3 values) x
+ * `surface` (3 values) = 9 series, total, forever, across ~130 scraped pods
+ * where prom-client retains every distinct label set in the Node heap for the
+ * process lifetime. Widening it has to get past these tests.
+ *
+ * 🔴 SURFACE is load-bearing for a different reason: `validateInput` is shared
+ * by the on-site generator, the App Blocks bridge and preset generation, and
+ * #3520 calls the substitution CORRECT on-site and unobservable through the
+ * bridge. Summed into one series the counter measures a contaminated quantity,
+ * which is exactly what phase 2 is supposed to produce a clean number for.
  */
 
 const METRIC = 'civitai_generation_model_substitutions_total';
 
-async function readReason(reason: string): Promise<number> {
+async function readSeries(reason: string, surface: string): Promise<number> {
   const metric = client.register.getSingleMetric(METRIC) as
     | { get(): Promise<{ values: Array<{ labels: Record<string, string>; value: number }> }> }
     | undefined;
   if (!metric) return Number.NaN;
   const { values } = await metric.get();
-  return values.find((v) => v.labels.reason === reason)?.value ?? 0;
+  return values.find((v) => v.labels.reason === reason && v.labels.surface === surface)?.value ?? 0;
+}
+
+/** Sum across surfaces — the CONTAMINATED read the surface label exists to split. */
+async function readReasonAcrossSurfaces(reason: string): Promise<number> {
+  const metric = client.register.getSingleMetric(METRIC) as
+    | { get(): Promise<{ values: Array<{ labels: Record<string, string>; value: number }> }> }
+    | undefined;
+  if (!metric) return Number.NaN;
+  const { values } = await metric.get();
+  return values.filter((v) => v.labels.reason === reason).reduce((sum, v) => sum + v.value, 0);
 }
 
 beforeEach(() => {
@@ -58,30 +76,71 @@ describe('civitai_generation_model_substitutions_total', () => {
     expect(client.register.getSingleMetric(METRIC)).toBeDefined();
   });
 
-  it.each(MODEL_SUBSTITUTION_REASONS.map((r) => [r] as [ModelSubstitutionReason]))(
-    'increments the `%s` series',
-    async (reason) => {
-      recordGenerationModelSubstitution(reason);
-      expect(await readReason(reason)).toBe(1);
+  it.each(
+    MODEL_SUBSTITUTION_REASONS.flatMap((reason) =>
+      GENERATION_SURFACES.map(
+        (surface) => [reason, surface] as [ModelSubstitutionReason, GenerationSurface]
+      )
+    )
+  )('increments the (`%s`, `%s`) series', async (reason, surface) => {
+    recordGenerationModelSubstitution(reason, surface);
+    expect(await readSeries(reason, surface)).toBe(1);
+  });
+
+  it('🔴 the SURFACES are separate series — on-site (correct) never inflates the block number', async () => {
+    // The whole point of the label. #3520 defends the on-site substitution as
+    // intended behaviour and indicts the bridge one; phase 3's decision is gated
+    // on the BLOCK incidence, so an un-split counter would report a number that
+    // is mostly the case nobody wants to change.
+    recordGenerationModelSubstitution('unrecognized', 'onsite');
+    recordGenerationModelSubstitution('unrecognized', 'onsite');
+    recordGenerationModelSubstitution('unrecognized', 'onsite');
+    recordGenerationModelSubstitution('unrecognized', 'block');
+    recordGenerationModelSubstitution('unrecognized', 'preset');
+
+    expect(await readSeries('unrecognized', 'block')).toBe(1);
+    expect(await readSeries('unrecognized', 'onsite')).toBe(3);
+    expect(await readSeries('unrecognized', 'preset')).toBe(1);
+    // …and the contaminated read the split exists to avoid.
+    expect(await readReasonAcrossSurfaces('unrecognized')).toBe(5);
+  });
+
+  it.each([
+    ['undefined', undefined],
+    ['an unknown surface', 'cli'],
+    ['a number', 7],
+  ])(
+    '🔴 DROPS an increment whose surface is %s — the label set stays bounded',
+    async (_l, bogus) => {
+      recordGenerationModelSubstitution('unrecognized', bogus as never as GenerationSurface);
+      expect(client.register.getSingleMetric(METRIC)).toBeUndefined();
     }
   );
+
+  it.each([
+    ['undefined', undefined],
+    ['an unknown reason', 'because'],
+  ])('🔴 DROPS an increment whose reason is %s', async (_l, bogus) => {
+    recordGenerationModelSubstitution(bogus as never as ModelSubstitutionReason, 'block');
+    expect(client.register.getSingleMetric(METRIC)).toBeUndefined();
+  });
 
   it('🔴 the reasons are SEPARATE series — an entitlement swap never reads as a wrong-mode swap', async () => {
     // The three reasons demand different responses: `wrong-workflow` is an
     // app-authoring bug, `unrecognized` is a retired/unknown model (the case
     // degradation exists to survive), `gated` is an entitlement decision. One
     // undifferentiated counter would send an operator to the wrong place.
-    recordGenerationModelSubstitution('wrong-workflow');
-    recordGenerationModelSubstitution('unrecognized');
-    recordGenerationModelSubstitution('unrecognized');
-    recordGenerationModelSubstitution('gated');
+    recordGenerationModelSubstitution('wrong-workflow', 'block');
+    recordGenerationModelSubstitution('unrecognized', 'block');
+    recordGenerationModelSubstitution('unrecognized', 'block');
+    recordGenerationModelSubstitution('gated', 'block');
 
-    expect(await readReason('wrong-workflow')).toBe(1);
-    expect(await readReason('unrecognized')).toBe(2);
-    expect(await readReason('gated')).toBe(1);
+    expect(await readSeries('wrong-workflow', 'block')).toBe(1);
+    expect(await readSeries('unrecognized', 'block')).toBe(2);
+    expect(await readSeries('gated', 'block')).toBe(1);
   });
 
-  it('🔴 DECLARES exactly one label, `reason` — the cardinality bound is structural', async () => {
+  it('🔴 DECLARES exactly `reason` + `surface` — the cardinality bound is structural', async () => {
     // 🔴 Asserted against the DECLARED `labelNames`, NOT the emitted series.
     // prom-client omits a declared-but-never-supplied label from its output, so
     // inspecting `values[].labels` stays green while the metric is declared wide
@@ -89,34 +148,40 @@ describe('civitai_generation_model_substitutions_total', () => {
     // nothing ever having failed.
     ensureRegisterGenerationModelSubstitutionMetrics();
     const metric = client.register.getSingleMetric(METRIC) as unknown as { labelNames: string[] };
-    expect([...metric.labelNames].sort()).toEqual(['reason']);
+    expect([...metric.labelNames].sort()).toEqual(['reason', 'surface']);
 
-    recordGenerationModelSubstitution('unrecognized');
+    recordGenerationModelSubstitution('unrecognized', 'block');
     const emitted = client.register.getSingleMetric(METRIC) as unknown as {
       get(): Promise<{ values: Array<{ labels: Record<string, string> }> }>;
     };
     const { values } = await emitted.get();
     expect(values.length).toBeGreaterThan(0);
-    for (const v of values) expect(Object.keys(v.labels)).toEqual(['reason']);
+    for (const v of values) expect(Object.keys(v.labels).sort()).toEqual(['reason', 'surface']);
   });
 
-  it('🔴 the reason union is EXACTLY these three values — 3 series is the whole budget', () => {
-    // Literal, not derived: the union is simultaneously the metric label AND the
-    // `BlockWorkflowSnapshot.modelSubstitutions[].reason` wire contract, so a
-    // fourth value added on either side has to come through here.
+  it('🔴 both unions are EXACTLY these values — 3 x 3 = 9 series is the whole budget', () => {
+    // Literal, not derived: the reason union is simultaneously the metric label
+    // AND the `BlockWorkflowSnapshot.modelSubstitutions[].reason` wire contract,
+    // so a fourth value added on either side has to come through here. The
+    // surface union bounds the other axis.
     expect([...MODEL_SUBSTITUTION_REASONS]).toEqual(['wrong-workflow', 'unrecognized', 'gated']);
+    expect([...GENERATION_SURFACES]).toEqual(['block', 'onsite', 'preset']);
   });
 
-  it('🔴 emits AT MOST 3 series no matter how many substitutions land', async () => {
+  it('🔴 emits AT MOST 9 series no matter how many substitutions land', async () => {
     for (let i = 0; i < 100; i++) {
-      for (const reason of MODEL_SUBSTITUTION_REASONS) recordGenerationModelSubstitution(reason);
+      for (const reason of MODEL_SUBSTITUTION_REASONS) {
+        for (const surface of GENERATION_SURFACES) {
+          recordGenerationModelSubstitution(reason, surface);
+        }
+      }
     }
     const metric = client.register.getSingleMetric(METRIC) as unknown as {
       get(): Promise<{ values: Array<{ labels: Record<string, string> }> }>;
     };
     const { values } = await metric.get();
-    expect(values).toHaveLength(3);
-    expect(await readReason('wrong-workflow')).toBe(100);
+    expect(values).toHaveLength(9);
+    expect(await readSeries('wrong-workflow', 'block')).toBe(100);
   });
 
   it('is idempotent to register — a double module import does not throw', () => {
@@ -126,11 +191,11 @@ describe('civitai_generation_model_substitutions_total', () => {
     }).not.toThrow();
   });
 
-  it('appears in the scrape output under its exact name', async () => {
-    recordGenerationModelSubstitution('gated');
+  it('appears in the scrape output under its exact name, with both labels', async () => {
+    recordGenerationModelSubstitution('gated', 'block');
     const scrape = await client.register.metrics();
     expect(scrape).toContain(METRIC);
-    expect(scrape).toContain(`${METRIC}{reason="gated"}`);
+    expect(scrape).toContain(`${METRIC}{reason="gated",surface="block"}`);
   });
 
   it('🔴 the emitter NEVER throws — a broken registry cannot fail a generation', () => {
@@ -145,7 +210,7 @@ describe('civitai_generation_model_substitutions_total', () => {
       registers: [client.register],
     });
 
-    expect(() => recordGenerationModelSubstitution('unrecognized')).not.toThrow();
+    expect(() => recordGenerationModelSubstitution('unrecognized', 'block')).not.toThrow();
   });
 
   it('the poisoned-registry case really would throw unguarded (the guard is reachable)', () => {
@@ -158,14 +223,14 @@ describe('civitai_generation_model_substitutions_total', () => {
       labelNames: ['unrelated'],
       registers: [client.register],
     });
-    expect(() => poisoned.inc({ reason: 'unrecognized' })).toThrow();
+    expect(() => poisoned.inc({ reason: 'unrecognized', surface: 'block' })).toThrow();
   });
 });
 
 describe('emitModelSubstitutions — the drain the generation path calls', () => {
-  function collectorWith(...reasons: ModelSubstitutionReason[]) {
+  function collectorWith(surface: GenerationSurface, ...reasons: ModelSubstitutionReason[]) {
     let i = 0;
-    const collector = createModelSubstitutionCollector(() => reasons[i++]);
+    const collector = createModelSubstitutionCollector(() => reasons[i++], surface);
     reasons.forEach((_, n) =>
       collector.record({ requested: 1000 + n, applied: 1, ecosystem: 'Qwen', workflow: 'txt2img' })
     );
@@ -173,20 +238,35 @@ describe('emitModelSubstitutions — the drain the generation path calls', () =>
   }
 
   it('emits one increment per recorded substitution, with the reason recorded', async () => {
-    await emitModelSubstitutions(collectorWith('wrong-workflow', 'unrecognized', 'unrecognized'));
-    expect(await readReason('wrong-workflow')).toBe(1);
-    expect(await readReason('unrecognized')).toBe(2);
+    await emitModelSubstitutions(
+      collectorWith('block', 'wrong-workflow', 'unrecognized', 'unrecognized')
+    );
+    expect(await readSeries('wrong-workflow', 'block')).toBe(1);
+    expect(await readSeries('unrecognized', 'block')).toBe(2);
+  });
+
+  it("🔴 labels every increment with the COLLECTOR's surface, not a guess", async () => {
+    // The emitter sits inside `validateInput`, which is shared by all three
+    // surfaces; the only surface information that exists at that point is the one
+    // the caller fixed when it built the context. Two collectors, two surfaces,
+    // same reason — they must not merge.
+    await emitModelSubstitutions(collectorWith('onsite', 'unrecognized'));
+    await emitModelSubstitutions(collectorWith('preset', 'unrecognized'));
+
+    expect(await readSeries('unrecognized', 'onsite')).toBe(1);
+    expect(await readSeries('unrecognized', 'preset')).toBe(1);
+    expect(await readSeries('unrecognized', 'block')).toBe(0);
   });
 
   it('🔴 a SECOND drain of the same collector emits nothing — no double-counting', async () => {
-    const collector = collectorWith('wrong-workflow');
+    const collector = collectorWith('block', 'wrong-workflow');
     await emitModelSubstitutions(collector);
     await emitModelSubstitutions(collector);
-    expect(await readReason('wrong-workflow')).toBe(1);
+    expect(await readSeries('wrong-workflow', 'block')).toBe(1);
   });
 
   it('emits nothing when nothing was substituted (an alert on this must mean something)', async () => {
-    await emitModelSubstitutions(createModelSubstitutionCollector(() => 'unrecognized'));
+    await emitModelSubstitutions(createModelSubstitutionCollector(() => 'unrecognized', 'block'));
     expect(client.register.getSingleMetric(METRIC)).toBeUndefined();
   });
 
@@ -203,13 +283,14 @@ describe('emitModelSubstitutions — the drain the generation path calls', () =>
       labelNames: ['unrelated'],
       registers: [client.register],
     });
-    await expect(emitModelSubstitutions(collectorWith('gated'))).resolves.toBeUndefined();
+    await expect(emitModelSubstitutions(collectorWith('block', 'gated'))).resolves.toBeUndefined();
   });
 
   it('🔴 RESOLVES when the collector itself throws on drain', async () => {
     // Covers the `await import` / destructure side of the guard too: the throw
     // happens before the metrics module is ever reached.
     const broken = {
+      surface: 'block' as const,
       record: vi.fn(),
       list: vi.fn(() => []),
       takeUnemitted: vi.fn(() => {

--- a/src/server/metrics/__tests__/generation-model-substitution.metrics.test.ts
+++ b/src/server/metrics/__tests__/generation-model-substitution.metrics.test.ts
@@ -1,0 +1,222 @@
+import client from 'prom-client';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  MODEL_SUBSTITUTION_REASONS,
+  createModelSubstitutionCollector,
+  type ModelSubstitutionReason,
+} from '~/shared/data-graph/generation/model-substitution';
+import { emitModelSubstitutions } from '../emit-model-substitutions';
+import {
+  ensureRegisterGenerationModelSubstitutionMetrics,
+  recordGenerationModelSubstitution,
+} from '../generation-model-substitution.metrics';
+
+/**
+ * The REAL prom-client side of the silent-checkpoint-SUBSTITUTION signal
+ * (issue #3520, phase 1), plus the drain helper the generation path calls.
+ *
+ * Two failure classes are pinned here that a graph-level test structurally
+ * cannot see:
+ *
+ *   1. A metric-name or label-name typo. That sails through every test that
+ *      mocks this module and yields an alert rule which silently never fires —
+ *      the exact failure class this signal exists to prevent. So this file
+ *      drives the real default registry.
+ *   2. 🔴 A throw escaping into the generation path. This emits on a SUCCESSFUL
+ *      generation submit (the substitution is a success, not a rejection), so an
+ *      unguarded prom-client error here would turn a working generation into a
+ *      500 — observability causing the outage.
+ *
+ * 🔴 CARDINALITY is the other load-bearing property: `reason` over a 3-value
+ * code-owned union = 3 series, total, forever, across ~130 scraped pods where
+ * prom-client retains every distinct label set in the Node heap for the process
+ * lifetime. Widening it has to get past these tests.
+ */
+
+const METRIC = 'civitai_generation_model_substitutions_total';
+
+async function readReason(reason: string): Promise<number> {
+  const metric = client.register.getSingleMetric(METRIC) as
+    | { get(): Promise<{ values: Array<{ labels: Record<string, string>; value: number }> }> }
+    | undefined;
+  if (!metric) return Number.NaN;
+  const { values } = await metric.get();
+  return values.find((v) => v.labels.reason === reason)?.value ?? 0;
+}
+
+beforeEach(() => {
+  // `clear()` (not `resetMetrics()`): one case deliberately registers a POISONED
+  // metric under this name, and a values-only reset would leak it into every
+  // later case.
+  client.register.clear();
+});
+
+describe('civitai_generation_model_substitutions_total', () => {
+  it('is registered on the default registry that /api/metrics scrapes', () => {
+    ensureRegisterGenerationModelSubstitutionMetrics();
+    expect(client.register.getSingleMetric(METRIC)).toBeDefined();
+  });
+
+  it.each(MODEL_SUBSTITUTION_REASONS.map((r) => [r] as [ModelSubstitutionReason]))(
+    'increments the `%s` series',
+    async (reason) => {
+      recordGenerationModelSubstitution(reason);
+      expect(await readReason(reason)).toBe(1);
+    }
+  );
+
+  it('🔴 the reasons are SEPARATE series — an entitlement swap never reads as a wrong-mode swap', async () => {
+    // The three reasons demand different responses: `wrong-workflow` is an
+    // app-authoring bug, `unrecognized` is a retired/unknown model (the case
+    // degradation exists to survive), `gated` is an entitlement decision. One
+    // undifferentiated counter would send an operator to the wrong place.
+    recordGenerationModelSubstitution('wrong-workflow');
+    recordGenerationModelSubstitution('unrecognized');
+    recordGenerationModelSubstitution('unrecognized');
+    recordGenerationModelSubstitution('gated');
+
+    expect(await readReason('wrong-workflow')).toBe(1);
+    expect(await readReason('unrecognized')).toBe(2);
+    expect(await readReason('gated')).toBe(1);
+  });
+
+  it('🔴 DECLARES exactly one label, `reason` — the cardinality bound is structural', async () => {
+    // 🔴 Asserted against the DECLARED `labelNames`, NOT the emitted series.
+    // prom-client omits a declared-but-never-supplied label from its output, so
+    // inspecting `values[].labels` stays green while the metric is declared wide
+    // open — and the next caller to pass a version id blows the budget with
+    // nothing ever having failed.
+    ensureRegisterGenerationModelSubstitutionMetrics();
+    const metric = client.register.getSingleMetric(METRIC) as unknown as { labelNames: string[] };
+    expect([...metric.labelNames].sort()).toEqual(['reason']);
+
+    recordGenerationModelSubstitution('unrecognized');
+    const emitted = client.register.getSingleMetric(METRIC) as unknown as {
+      get(): Promise<{ values: Array<{ labels: Record<string, string> }> }>;
+    };
+    const { values } = await emitted.get();
+    expect(values.length).toBeGreaterThan(0);
+    for (const v of values) expect(Object.keys(v.labels)).toEqual(['reason']);
+  });
+
+  it('🔴 the reason union is EXACTLY these three values — 3 series is the whole budget', () => {
+    // Literal, not derived: the union is simultaneously the metric label AND the
+    // `BlockWorkflowSnapshot.modelSubstitutions[].reason` wire contract, so a
+    // fourth value added on either side has to come through here.
+    expect([...MODEL_SUBSTITUTION_REASONS]).toEqual(['wrong-workflow', 'unrecognized', 'gated']);
+  });
+
+  it('🔴 emits AT MOST 3 series no matter how many substitutions land', async () => {
+    for (let i = 0; i < 100; i++) {
+      for (const reason of MODEL_SUBSTITUTION_REASONS) recordGenerationModelSubstitution(reason);
+    }
+    const metric = client.register.getSingleMetric(METRIC) as unknown as {
+      get(): Promise<{ values: Array<{ labels: Record<string, string> }> }>;
+    };
+    const { values } = await metric.get();
+    expect(values).toHaveLength(3);
+    expect(await readReason('wrong-workflow')).toBe(100);
+  });
+
+  it('is idempotent to register — a double module import does not throw', () => {
+    expect(() => {
+      ensureRegisterGenerationModelSubstitutionMetrics();
+      ensureRegisterGenerationModelSubstitutionMetrics();
+    }).not.toThrow();
+  });
+
+  it('appears in the scrape output under its exact name', async () => {
+    recordGenerationModelSubstitution('gated');
+    const scrape = await client.register.metrics();
+    expect(scrape).toContain(METRIC);
+    expect(scrape).toContain(`${METRIC}{reason="gated"}`);
+  });
+
+  it('🔴 the emitter NEVER throws — a broken registry cannot fail a generation', () => {
+    // Poison the default registry: something already registered under this name
+    // with a DIFFERENT labelset (the shape a name collision takes). The
+    // get-or-create guard hands that instance back and prom-client then throws
+    // on `.inc({ reason })` because `reason` was never declared on it.
+    new client.Counter({
+      name: METRIC,
+      help: 'poisoned duplicate with an incompatible labelset',
+      labelNames: ['unrelated'],
+      registers: [client.register],
+    });
+
+    expect(() => recordGenerationModelSubstitution('unrecognized')).not.toThrow();
+  });
+
+  it('the poisoned-registry case really would throw unguarded (the guard is reachable)', () => {
+    // Proves the case above is not vacuous: the underlying prom-client call DOES
+    // throw, so `not.toThrow()` there is testing the guard rather than an inert
+    // no-op.
+    const poisoned = new client.Counter({
+      name: METRIC,
+      help: 'poisoned duplicate with an incompatible labelset',
+      labelNames: ['unrelated'],
+      registers: [client.register],
+    });
+    expect(() => poisoned.inc({ reason: 'unrecognized' })).toThrow();
+  });
+});
+
+describe('emitModelSubstitutions — the drain the generation path calls', () => {
+  function collectorWith(...reasons: ModelSubstitutionReason[]) {
+    let i = 0;
+    const collector = createModelSubstitutionCollector(() => reasons[i++]);
+    reasons.forEach((_, n) =>
+      collector.record({ requested: 1000 + n, applied: 1, ecosystem: 'Qwen', workflow: 'txt2img' })
+    );
+    return collector;
+  }
+
+  it('emits one increment per recorded substitution, with the reason recorded', async () => {
+    await emitModelSubstitutions(collectorWith('wrong-workflow', 'unrecognized', 'unrecognized'));
+    expect(await readReason('wrong-workflow')).toBe(1);
+    expect(await readReason('unrecognized')).toBe(2);
+  });
+
+  it('🔴 a SECOND drain of the same collector emits nothing — no double-counting', async () => {
+    const collector = collectorWith('wrong-workflow');
+    await emitModelSubstitutions(collector);
+    await emitModelSubstitutions(collector);
+    expect(await readReason('wrong-workflow')).toBe(1);
+  });
+
+  it('emits nothing when nothing was substituted (an alert on this must mean something)', async () => {
+    await emitModelSubstitutions(createModelSubstitutionCollector(() => 'unrecognized'));
+    expect(client.register.getSingleMetric(METRIC)).toBeUndefined();
+  });
+
+  it('tolerates an ABSENT collector (the client-side context has none)', async () => {
+    await expect(emitModelSubstitutions(undefined)).resolves.toBeUndefined();
+  });
+
+  it('🔴 RESOLVES even when the metrics module is poisoned — it never rejects into the request', async () => {
+    // `validateInput` calls this with `void`; an unhandled rejection here would
+    // be an unhandled rejection on the generation submit path.
+    new client.Counter({
+      name: METRIC,
+      help: 'poisoned duplicate with an incompatible labelset',
+      labelNames: ['unrelated'],
+      registers: [client.register],
+    });
+    await expect(emitModelSubstitutions(collectorWith('gated'))).resolves.toBeUndefined();
+  });
+
+  it('🔴 RESOLVES when the collector itself throws on drain', async () => {
+    // Covers the `await import` / destructure side of the guard too: the throw
+    // happens before the metrics module is ever reached.
+    const broken = {
+      record: vi.fn(),
+      list: vi.fn(() => []),
+      takeUnemitted: vi.fn(() => {
+        throw new Error('collector exploded');
+      }),
+    };
+    await expect(emitModelSubstitutions(broken)).resolves.toBeUndefined();
+    expect(broken.takeUnemitted).toHaveBeenCalled();
+  });
+});

--- a/src/server/metrics/emit-model-substitutions.ts
+++ b/src/server/metrics/emit-model-substitutions.ts
@@ -1,0 +1,38 @@
+import type { ModelSubstitutionCollector } from '~/shared/data-graph/generation/model-substitution';
+
+/**
+ * Drain a request's silent-checkpoint-substitution collector into
+ * `civitai_generation_model_substitutions_total` (issue #3520, phase 1).
+ *
+ * WHY ITS OWN MODULE. The caller (`validateInput` in orchestration-new.service)
+ * is SYNCHRONOUS and sits on the generation submit path, and the prom-client
+ * module must stay out of its static import graph — the same reason
+ * `app-spend-cap.service` reaches its emitters through `await import(...)`. This
+ * module is the seam that lets both hold: it owns the dynamic import, and it is
+ * small enough to unit-test the guarantee that matters (it can never reject into
+ * the request).
+ *
+ * 🔴 NEVER REJECTS. The returned promise resolves on every path — a failed
+ * dynamic import, a module whose shape changed, a prom-client registry
+ * collision, a label mismatch. Callers `void` it; an unhandled rejection there
+ * would be an unhandled rejection on the generation path, i.e. observability
+ * converting a working generation into an incident. It also does no work at all
+ * when nothing was substituted, which is the overwhelmingly common case.
+ *
+ * IDEMPOTENT via `takeUnemitted()`, which marks what it hands out — a second
+ * call for the same request emits nothing rather than double-counting.
+ */
+export async function emitModelSubstitutions(
+  collector: ModelSubstitutionCollector | undefined
+): Promise<void> {
+  try {
+    const pending = collector?.takeUnemitted();
+    if (!pending?.length) return;
+    const { recordGenerationModelSubstitution } = await import(
+      '~/server/metrics/generation-model-substitution.metrics'
+    );
+    for (const substitution of pending) recordGenerationModelSubstitution(substitution.reason);
+  } catch {
+    /* observability must never break the generation it observes */
+  }
+}

--- a/src/server/metrics/emit-model-substitutions.ts
+++ b/src/server/metrics/emit-model-substitutions.ts
@@ -26,12 +26,20 @@ export async function emitModelSubstitutions(
   collector: ModelSubstitutionCollector | undefined
 ): Promise<void> {
   try {
-    const pending = collector?.takeUnemitted();
-    if (!pending?.length) return;
+    if (!collector) return;
+    const pending = collector.takeUnemitted();
+    if (!pending.length) return;
+    // The SURFACE comes off the collector, which got it from whoever built this
+    // request's context (`buildGenerationContext(..., surface)`) — never guessed
+    // here. `validateInput` is shared by the on-site generator, the App Blocks
+    // bridge and preset generation, so this function structurally cannot tell
+    // them apart and must not try.
+    const { surface } = collector;
     const { recordGenerationModelSubstitution } = await import(
       '~/server/metrics/generation-model-substitution.metrics'
     );
-    for (const substitution of pending) recordGenerationModelSubstitution(substitution.reason);
+    for (const substitution of pending)
+      recordGenerationModelSubstitution(substitution.reason, surface);
   } catch {
     /* observability must never break the generation it observes */
   }

--- a/src/server/metrics/generation-model-substitution.metrics.ts
+++ b/src/server/metrics/generation-model-substitution.metrics.ts
@@ -1,0 +1,100 @@
+// Silent checkpoint SUBSTITUTION counter (issue #3520, phase 1).
+//
+// On a `modelLocked` ecosystem the generation graph replaces a checkpoint
+// version id that is not in the current workflow's visible list with that
+// workflow's `defaultModelId`, returns success, and bills the user — with
+// nothing in the response, the snapshot, or the `block_workflows` read-model
+// saying a different model ran. The behaviour is deliberate and is NOT changed
+// by this counter; the counter exists because the swap is otherwise
+// unmeasurable, and every later decision about it (reject `wrong-workflow`?
+// keep degrading `unrecognized`?) needs a real traffic number first.
+//
+// Emitted from `validateInput` in orchestration-new.service — the single choke
+// point through which every SERVER-side `generationGraph.safeParse` runs
+// (on-site submit, whatIf, and the App Blocks bridge alike). The in-browser form
+// parse never reaches here: only the server attaches a substitution collector.
+//
+// 🔴 WHAT ONE INCREMENT MEANS: one GRAPH VALIDATION that substituted — NOT one
+// user-visible generation. The App Blocks generate path validates TWICE for a
+// single submit (a whatIf cost preflight, then the real submit), each with its
+// own per-request collector, so one block generation with an out-of-list version
+// contributes 2. Read this as a RATE and a TREND, not as a headcount of affected
+// generations; a "how many generations were served the wrong model" figure has
+// to come from the snapshot/log side, not from here.
+//
+// 🔴 ALERTING: use `max_over_time(...[window])`, NOT `rate()`. This is a RARE
+// per-pod counter across ~130 pods: a pod that substitutes once creates its
+// labelled child at 1 and never increments it again, so `rate()`/`increase()`
+// over that child is structurally 0 and an alert keyed on it silently never
+// fires — the counter looks healthy precisely because the event is rare, which
+// is the failure mode this signal exists to prevent.
+//
+// prom-client GOTCHA (same as ~/server/metrics/app-block-runtime.metrics.ts):
+// Next.js can import a module twice (hot reload / route bundling) and prom-client
+// throws if a metric name is registered twice, so the getter below is a
+// get-or-create guard against the DEFAULT global registry.
+//
+// 🔴 CARDINALITY: `reason` is the ONLY label, over a 3-value code-owned union →
+// 3 series, TOTAL, forever. Deliberately NO version id, model id, app id, or
+// user id: this fires once per substituted parse with nothing caching it, the
+// requested version id is caller-controlled and effectively unbounded, and
+// prom-client retains every distinct label set in the Node heap forever (the
+// --max-old-space-size exit-139 OOM class) across ~130 scraped pods. Attribution
+// belongs in the snapshot the caller already receives (which carries the exact
+// requested/applied ids) — alert on the metric, attribute from the snapshot.
+import client, { type Counter, type Registry } from 'prom-client';
+
+import type { ModelSubstitutionReason } from '~/shared/data-graph/generation/model-substitution';
+
+function getOrCreateCounter(
+  reg: Registry,
+  name: string,
+  help: string,
+  labelNames: string[]
+): Counter<string> {
+  const existing = reg.getSingleMetric(name) as Counter<string> | undefined;
+  if (existing) return existing;
+  return new client.Counter({ name, help, labelNames, registers: [reg] });
+}
+
+/**
+ * Idempotent: safe to call on every request. Returns the counter instance
+ * (existing or newly created) from the default registry that /api/metrics
+ * scrapes.
+ */
+export function ensureRegisterGenerationModelSubstitutionMetrics(reg: Registry = client.register): {
+  modelSubstitutionsTotal: Counter<string>;
+} {
+  const modelSubstitutionsTotal = getOrCreateCounter(
+    reg,
+    'civitai_generation_model_substitutions_total',
+    'Server-side generation graph validations in which a modelLocked ecosystem SILENTLY replaced the requested checkpoint version with the workflow default, by reason ' +
+      '(wrong-workflow = the version is scoped to a different workflow of the same ecosystem; unrecognized = the version is in no scoped list at all; gated = the version IS offered for this workflow but a gate rule hid it from this user)',
+    ['reason']
+  );
+  return { modelSubstitutionsTotal };
+}
+
+/**
+ * Fail-soft emit of one recorded substitution.
+ *
+ * 🔴 TOTAL, like every emitter in `app-block-runtime.metrics.ts`. This
+ * instruments the GENERATION SUBMIT path: a metrics error (registry collision,
+ * label mismatch) must never propagate, or observing a successful degradation
+ * would turn it into a failed generation — the observability converting a
+ * working request into an outage. The caller guards independently too; the
+ * duplication is deliberate, because the guarantee must not rest on either layer
+ * alone.
+ *
+ * COST: one in-heap counter increment, and only on a parse that actually
+ * substituted. A submit that names an in-list version never reaches here, so the
+ * steady state on healthy traffic is zero emits.
+ */
+export function recordGenerationModelSubstitution(reason: ModelSubstitutionReason): void {
+  try {
+    const { modelSubstitutionsTotal } = ensureRegisterGenerationModelSubstitutionMetrics();
+    modelSubstitutionsTotal.inc({ reason });
+  } catch {
+    /* instrument-only — never let a metrics error touch the generation path */
+  }
+}

--- a/src/server/metrics/generation-model-substitution.metrics.ts
+++ b/src/server/metrics/generation-model-substitution.metrics.ts
@@ -15,12 +15,25 @@
 // parse never reaches here: only the server attaches a substitution collector.
 //
 // 🔴 WHAT ONE INCREMENT MEANS: one GRAPH VALIDATION that substituted — NOT one
-// user-visible generation. The App Blocks generate path validates TWICE for a
-// single submit (a whatIf cost preflight, then the real submit), each with its
-// own per-request collector, so one block generation with an out-of-list version
-// contributes 2. Read this as a RATE and a TREND, not as a headcount of affected
-// generations; a "how many generations were served the wrong model" figure has
-// to come from the snapshot/log side, not from here.
+// user-visible generation, and NOT a fixed multiple of one either. The ratio of
+// increments to user-visible generations is VARIABLE, and the variance is not
+// small. On the `block` surface, for ONE user-visible generation:
+//
+//   • 2   — the normal successful submit (whatIf cost preflight, then the real
+//           submit; each builds its own per-request collector).
+//   • 1   — when the whatIf estimate exceeds the block's per-call buzz budget:
+//           `blocks.router.ts` returns the insufficient-budget snapshot BEFORE
+//           the idempotency claim and the real submit, so only the preflight ran.
+//   • +1  — per `blocks.estimateWorkflow` call the block chooses to make. That
+//           is a separate procedure a block may call any number of times (a live
+//           cost readout as the user types), so this term is UNBOUNDED.
+//   • +1  — per idempotency REPLAY that re-enters the procedure (a retried
+//           submit re-runs the preflight before the claim short-circuits).
+//
+// So: read this as a RATE and a TREND per surface. It is NOT a headcount of
+// affected generations, and dividing by 2 does NOT produce one. A real
+// "generations served the wrong model" figure has to come from the snapshot/log
+// side (where each record is tied to one workflow id), not from here.
 //
 // 🔴 ALERTING: use `max_over_time(...[window])`, NOT `rate()`. This is a RARE
 // per-pod counter across ~130 pods: a pod that substitutes once creates its
@@ -34,17 +47,35 @@
 // throws if a metric name is registered twice, so the getter below is a
 // get-or-create guard against the DEFAULT global registry.
 //
-// 🔴 CARDINALITY: `reason` is the ONLY label, over a 3-value code-owned union →
-// 3 series, TOTAL, forever. Deliberately NO version id, model id, app id, or
+// 🔴 SURFACE, and why it is not optional. `validateInput` is shared by the
+// on-site generator, the App Blocks bridge, and comics/preset generation. #3520
+// defends the on-site substitution as CORRECT (a stale localStorage id after an
+// ecosystem switch, visibly corrected in the picker) and indicts the bridge one
+// as unobservable — opposite verdicts, and without a `surface` label they land
+// in the same series. Phase 2's job is to produce a real incidence number that
+// gates phase 3's policy decision; summed across surfaces that number measures a
+// contaminated quantity. The label is supplied BY THE CALLER at context-build
+// time (`buildGenerationContext(..., surface)`), never inferred here.
+//
+// 🔴 CARDINALITY: exactly two labels, each over a code-owned union declared once
+// in `model-substitution.ts` → 3 reasons × 3 surfaces = 9 series, TOTAL,
+// forever. Deliberately NO version id, model id, ecosystem, workflow, app id, or
 // user id: this fires once per substituted parse with nothing caching it, the
 // requested version id is caller-controlled and effectively unbounded, and
 // prom-client retains every distinct label set in the Node heap forever (the
 // --max-old-space-size exit-139 OOM class) across ~130 scraped pods. Attribution
 // belongs in the snapshot the caller already receives (which carries the exact
 // requested/applied ids) — alert on the metric, attribute from the snapshot.
+// Both label values are NARROWED AT RUNTIME before `inc()` so the bound rests on
+// code rather than on erased types.
 import client, { type Counter, type Registry } from 'prom-client';
 
-import type { ModelSubstitutionReason } from '~/shared/data-graph/generation/model-substitution';
+import {
+  isGenerationSurface,
+  isModelSubstitutionReason,
+  type GenerationSurface,
+  type ModelSubstitutionReason,
+} from '~/shared/data-graph/generation/model-substitution';
 
 function getOrCreateCounter(
   reg: Registry,
@@ -68,9 +99,11 @@ export function ensureRegisterGenerationModelSubstitutionMetrics(reg: Registry =
   const modelSubstitutionsTotal = getOrCreateCounter(
     reg,
     'civitai_generation_model_substitutions_total',
-    'Server-side generation graph validations in which a modelLocked ecosystem SILENTLY replaced the requested checkpoint version with the workflow default, by reason ' +
-      '(wrong-workflow = the version is scoped to a different workflow of the same ecosystem; unrecognized = the version is in no scoped list at all; gated = the version IS offered for this workflow but a gate rule hid it from this user)',
-    ['reason']
+    'Server-side generation GRAPH VALIDATIONS in which a modelLocked ecosystem SILENTLY replaced the requested checkpoint version with the workflow default. ' +
+      'NOT a count of user-visible generations: the ratio is VARIABLE — a block submit normally validates twice (whatIf preflight + real submit), once if the preflight exceeds the buzz budget, plus one per estimateWorkflow call (unbounded) and one per idempotency replay. Use as a rate/trend per surface; attribute individual cases from the snapshot. ' +
+      'reason (wrong-workflow = the version is scoped to a different workflow of the same ecosystem; unrecognized = the version is in no scoped list at all; gated = the version IS offered for this workflow but a gate rule hid it from this user). ' +
+      'surface (block = the App Blocks bridge, where the id was deliberate and the correction was unobservable; onsite = the on-site generator, where this substitution is the intended graceful degradation and is visible to the user; preset = comics/preset server-composed generation)',
+    ['reason', 'surface']
   );
   return { modelSubstitutionsTotal };
 }
@@ -90,10 +123,18 @@ export function ensureRegisterGenerationModelSubstitutionMetrics(reg: Registry =
  * substituted. A submit that names an in-list version never reaches here, so the
  * steady state on healthy traffic is zero emits.
  */
-export function recordGenerationModelSubstitution(reason: ModelSubstitutionReason): void {
+export function recordGenerationModelSubstitution(
+  reason: ModelSubstitutionReason,
+  surface: GenerationSurface
+): void {
   try {
+    // 🔴 The cardinality bound rests HERE, on code, not on the erased types
+    // above. An unknown reason or surface is DROPPED, not passed through and not
+    // relabelled to a plausible default — either would make the "9 series
+    // forever" claim a wish. Reachable today only by defeating the types.
+    if (!isModelSubstitutionReason(reason) || !isGenerationSurface(surface)) return;
     const { modelSubstitutionsTotal } = ensureRegisterGenerationModelSubstitutionMetrics();
-    modelSubstitutionsTotal.inc({ reason });
+    modelSubstitutionsTotal.inc({ reason, surface });
   } catch {
     /* instrument-only — never let a metrics error touch the generation path */
   }

--- a/src/server/routers/__tests__/blocks.router.workflow.test.ts
+++ b/src/server/routers/__tests__/blocks.router.workflow.test.ts
@@ -400,6 +400,10 @@ import { recordScopeInvocation } from '~/server/services/blocks/user-app-surface
 // lags by ~a test, making the fire-and-forget queue write's timing flaky.
 import '~/server/services/blocks/block-workflows.service';
 import { TransactionType } from '~/shared/constants/buzz.constants';
+// #3520 — real collector (not a stub): the router reads `.list()` off the
+// context's collector, so using the genuine implementation keeps the test
+// honest about the shape it consumes.
+import { createModelSubstitutionCollector } from '~/shared/data-graph/generation/model-substitution';
 
 function validClaims(over: Record<string, unknown> = {}) {
   return {
@@ -6635,6 +6639,257 @@ describe("step-type registry bridge (kind: 'step')", () => {
         caller().submitWorkflow({ blockToken: 'tok', body: stepBody() })
       ).rejects.toMatchObject({ code: 'FORBIDDEN' });
       expect(mockReserveAppSpend).not.toHaveBeenCalled();
+    });
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// #3520 — silent checkpoint substitution: the SURFACE label and the field's
+// SURVIVAL to the poll.
+//
+// Two distinct properties, both of which the first cut of this feature got
+// wrong:
+//
+//   1. The `surface` label on `civitai_generation_model_substitutions_total` is
+//      supplied by the CALLER (`buildGenerationContext(..., 'block')`), because
+//      `validateInput` — where the metric is emitted — is shared with the on-site
+//      generator and preset generation and cannot tell them apart. The on-site
+//      substitution is the behaviour #3520 defends as CORRECT, so summing them
+//      contaminates the number that gates the phase-3 policy decision.
+//
+//   2. The record must reach the snapshot the block ACTUALLY RENDERS FROM. That
+//      is the terminal POLL (the only snapshot carrying `imageUrls`), and
+//      `pollWorkflow` builds it from a freshly fetched Workflow with none of the
+//      submitting request's context. Persisting the record on the orchestrator
+//      workflow's own `metadata` at submit is what closes that; `block_workflows`
+//      does not retain the submitted body, so nothing else can.
+// ─────────────────────────────────────────────────────────────────────────────
+describe('blocks — #3520 model substitution observability', () => {
+  const SUBSTITUTION = { requested: 2558804, applied: 2552908, reason: 'wrong-workflow' as const };
+
+  /** A server-shaped context whose collector already holds `records`. */
+  function ctxWithSubstitutions(...records: Array<typeof SUBSTITUTION>) {
+    const collector = createModelSubstitutionCollector(
+      (e) => records.find((r) => r.requested === e.requested)?.reason ?? 'unrecognized',
+      'block'
+    );
+    for (const r of records) {
+      collector.record({
+        requested: r.requested,
+        applied: r.applied,
+        ecosystem: 'Qwen',
+        workflow: 'txt2img',
+      });
+    }
+    return { externalCtx: { modelSubstitutions: collector } };
+  }
+
+  describe('surface label', () => {
+    it('the App Blocks bridge builds its generation context with surface `block`', async () => {
+      mockVerifyBlockToken.mockResolvedValue(validClaims({ buzzBudget: 100 }));
+      happyVersionLookup();
+      happyUser();
+      mockSubmitWorkflow
+        .mockResolvedValueOnce({ id: '', status: 'succeeded', cost: { total: 25 }, steps: [] })
+        .mockResolvedValueOnce({
+          id: 'wf_real',
+          status: 'unassigned',
+          cost: { total: 25 },
+          steps: [],
+        });
+
+      const caller = blocksRouter.createCaller(fakeCtx() as never);
+      await caller.submitWorkflow({ blockToken: 'tok', body: validBody() });
+
+      expect(mockBuildGenerationContext).toHaveBeenCalled();
+      for (const call of mockBuildGenerationContext.mock.calls) {
+        // By INDEX (4th positional arg), so a value passed in the wrong slot
+        // fails rather than passing on a `toHaveBeenCalledWith(...expect.anything())`.
+        expect(call[3]).toBe('block');
+        expect(call[3]).not.toBe('onsite');
+        expect(call[3]).not.toBe('preset');
+      }
+    });
+  });
+
+  describe('🔴 survival to the poll (the record is persisted on the workflow)', () => {
+    it('the REAL submit body carries the substitutions on workflow metadata', async () => {
+      mockVerifyBlockToken.mockResolvedValue(validClaims({ buzzBudget: 100 }));
+      happyVersionLookup();
+      happyUser();
+      mockBuildGenerationContext.mockResolvedValue(ctxWithSubstitutions(SUBSTITUTION));
+      // The graph yields workflowMetadata only on a REAL (non-whatIf) call.
+      mockCreateStepsFromGraph.mockResolvedValue({
+        steps: [{ $type: 'textToImage', name: 's1', input: {} }],
+        workflowMetadata: { params: { prompt: 'a cat' } },
+      });
+      mockSubmitWorkflow
+        .mockResolvedValueOnce({ id: '', status: 'succeeded', cost: { total: 25 }, steps: [] })
+        .mockResolvedValueOnce({
+          id: 'wf_real',
+          status: 'unassigned',
+          cost: { total: 25 },
+          steps: [],
+        });
+
+      const caller = blocksRouter.createCaller(fakeCtx() as never);
+      await caller.submitWorkflow({ blockToken: 'tok', body: validBody() });
+
+      const realSubmit = mockSubmitWorkflow.mock.calls[1][0];
+      expect(realSubmit.body.metadata).toEqual({
+        params: { prompt: 'a cat' },
+        modelSubstitutions: [SUBSTITUTION],
+      });
+    });
+
+    it('does NOT touch the metadata when nothing was substituted', async () => {
+      // The overwhelmingly common case: the submitted body must be byte-identical
+      // to before this feature existed.
+      mockVerifyBlockToken.mockResolvedValue(validClaims({ buzzBudget: 100 }));
+      happyVersionLookup();
+      happyUser();
+      mockBuildGenerationContext.mockResolvedValue(ctxWithSubstitutions());
+      mockCreateStepsFromGraph.mockResolvedValue({
+        steps: [{ $type: 'textToImage', name: 's1', input: {} }],
+        workflowMetadata: { params: { prompt: 'a cat' } },
+      });
+      mockSubmitWorkflow
+        .mockResolvedValueOnce({ id: '', status: 'succeeded', cost: { total: 25 }, steps: [] })
+        .mockResolvedValueOnce({
+          id: 'wf_real',
+          status: 'unassigned',
+          cost: { total: 25 },
+          steps: [],
+        });
+
+      const caller = blocksRouter.createCaller(fakeCtx() as never);
+      const result = await caller.submitWorkflow({ blockToken: 'tok', body: validBody() });
+
+      expect(mockSubmitWorkflow.mock.calls[1][0].body.metadata).toEqual({
+        params: { prompt: 'a cat' },
+      });
+      expect('modelSubstitutions' in result.snapshot).toBe(false);
+    });
+
+    it('🔴 pollWorkflow REPORTS the substitutions recorded at submit', async () => {
+      // The failure this closes: the field existed only on the submit reply, so
+      // it was gone by the time the block had images to display beside it.
+      mockVerifyBlockToken.mockResolvedValue(validClaims());
+      mockGetWorkflow.mockResolvedValue({
+        id: 'wf_1',
+        status: 'succeeded',
+        cost: { total: 10 },
+        metadata: { params: { prompt: 'a cat' }, modelSubstitutions: [SUBSTITUTION] },
+        steps: [
+          {
+            $type: 'textToImage',
+            name: 's',
+            status: 'succeeded',
+            metadata: {},
+            output: { images: [{ id: 'b', url: 'https://cdn/i.png', available: true }] },
+          },
+        ],
+      });
+
+      const caller = blocksRouter.createCaller(fakeCtx() as never);
+      const result = await caller.pollWorkflow({ blockToken: 'tok', workflowId: 'wf_1' });
+
+      // Present ALONGSIDE the images — the whole point.
+      expect(result.snapshot.imageUrls).toEqual(['https://cdn/i.png']);
+      expect(result.snapshot.modelSubstitutions).toEqual([SUBSTITUTION]);
+    });
+
+    it('pollWorkflow OMITS the field for a workflow that substituted nothing', async () => {
+      mockVerifyBlockToken.mockResolvedValue(validClaims());
+      mockGetWorkflow.mockResolvedValue({
+        id: 'wf_1',
+        status: 'succeeded',
+        cost: { total: 10 },
+        metadata: { params: { prompt: 'a cat' } },
+        steps: [],
+      });
+      const caller = blocksRouter.createCaller(fakeCtx() as never);
+      const result = await caller.pollWorkflow({ blockToken: 'tok', workflowId: 'wf_1' });
+      expect('modelSubstitutions' in result.snapshot).toBe(false);
+    });
+
+    it('cancelWorkflow reports them too (same read path)', async () => {
+      mockVerifyBlockToken.mockResolvedValue(validClaims());
+      mockCancelWorkflow.mockResolvedValue(undefined);
+      mockGetWorkflow.mockResolvedValue({
+        id: 'wf_1',
+        status: 'canceled',
+        cost: { total: 3 },
+        metadata: { modelSubstitutions: [SUBSTITUTION] },
+        steps: [],
+      });
+      const caller = blocksRouter.createCaller(fakeCtx() as never);
+      const result = await caller.cancelWorkflow({ blockToken: 'tok', workflowId: 'wf_1' });
+      expect(result.snapshot.modelSubstitutions).toEqual([SUBSTITUTION]);
+    });
+  });
+
+  describe('🔴 the in-generate cost preflight no longer discards its substitutions', () => {
+    it('the insufficient-budget reply reports what the quote was actually priced for', async () => {
+      // This exit returns a COST and no workflow — the one reply in the flow that
+      // would otherwise quote a price with no way to learn which model it was for.
+      mockVerifyBlockToken.mockResolvedValue(validClaims({ buzzBudget: 5 }));
+      happyVersionLookup();
+      happyUser();
+      mockBuildGenerationContext.mockResolvedValue(ctxWithSubstitutions(SUBSTITUTION));
+      mockSubmitWorkflow.mockResolvedValueOnce({
+        id: '',
+        status: 'succeeded',
+        cost: { total: 25 },
+        steps: [],
+      });
+
+      const caller = blocksRouter.createCaller(fakeCtx() as never);
+      const result = await caller.submitWorkflow({ blockToken: 'tok', body: validBody() });
+
+      expect(result.snapshot.status).toBe('failed');
+      expect(result.snapshot.cost).toEqual({ total: 25 });
+      expect((result.snapshot as { modelSubstitutions?: unknown }).modelSubstitutions).toEqual([
+        SUBSTITUTION,
+      ]);
+      // Only the preflight ran — no real submit.
+      expect(mockSubmitWorkflow).toHaveBeenCalledTimes(1);
+    });
+
+    it('the insufficient-budget reply is unchanged when nothing was substituted', async () => {
+      mockVerifyBlockToken.mockResolvedValue(validClaims({ buzzBudget: 5 }));
+      happyVersionLookup();
+      happyUser();
+      mockBuildGenerationContext.mockResolvedValue(ctxWithSubstitutions());
+      mockSubmitWorkflow.mockResolvedValueOnce({
+        id: '',
+        status: 'succeeded',
+        cost: { total: 25 },
+        steps: [],
+      });
+      const caller = blocksRouter.createCaller(fakeCtx() as never);
+      const result = await caller.submitWorkflow({ blockToken: 'tok', body: validBody() });
+      expect('modelSubstitutions' in result.snapshot).toBe(false);
+    });
+  });
+
+  describe('estimateWorkflow', () => {
+    it('reports the substitutions on the estimate reply (nothing is persisted there)', async () => {
+      // A whatIf creates no persisted workflow, so the reply is the ONLY place
+      // this can appear on the estimate path.
+      mockVerifyBlockToken.mockResolvedValue(validClaims({ buzzBudget: 100 }));
+      happyVersionLookup();
+      happyUser();
+      mockBuildGenerationContext.mockResolvedValue(ctxWithSubstitutions(SUBSTITUTION));
+      mockSubmitWorkflow.mockResolvedValueOnce({
+        id: '',
+        status: 'succeeded',
+        cost: { total: 25 },
+        steps: [],
+      });
+      const caller = blocksRouter.createCaller(fakeCtx() as never);
+      const result = await caller.estimateWorkflow({ blockToken: 'tok', body: validBody() });
+      expect(result.snapshot.modelSubstitutions).toEqual([SUBSTITUTION]);
     });
   });
 });

--- a/src/server/routers/__tests__/blocks.router.workflow.test.ts
+++ b/src/server/routers/__tests__/blocks.router.workflow.test.ts
@@ -404,6 +404,7 @@ import { TransactionType } from '~/shared/constants/buzz.constants';
 // context's collector, so using the genuine implementation keeps the test
 // honest about the shape it consumes.
 import { createModelSubstitutionCollector } from '~/shared/data-graph/generation/model-substitution';
+import type { ModelSubstitutionReason } from '~/shared/data-graph/generation/model-substitution';
 
 function validClaims(over: Record<string, unknown> = {}) {
   return {
@@ -6665,10 +6666,15 @@ describe("step-type registry bridge (kind: 'step')", () => {
 //      does not retain the submitted body, so nothing else can.
 // ─────────────────────────────────────────────────────────────────────────────
 describe('blocks — #3520 model substitution observability', () => {
-  const SUBSTITUTION = { requested: 2558804, applied: 2552908, reason: 'wrong-workflow' as const };
+  type SubstitutionRecord = { requested: number; applied: number; reason: ModelSubstitutionReason };
+  const SUBSTITUTION: SubstitutionRecord = {
+    requested: 2558804,
+    applied: 2552908,
+    reason: 'wrong-workflow',
+  };
 
   /** A server-shaped context whose collector already holds `records`. */
-  function ctxWithSubstitutions(...records: Array<typeof SUBSTITUTION>) {
+  function ctxWithSubstitutions(...records: SubstitutionRecord[]) {
     const collector = createModelSubstitutionCollector(
       (e) => records.find((r) => r.requested === e.requested)?.reason ?? 'unrecognized',
       'block'
@@ -6870,6 +6876,137 @@ describe('blocks — #3520 model substitution observability', () => {
       const caller = blocksRouter.createCaller(fakeCtx() as never);
       const result = await caller.submitWorkflow({ blockToken: 'tok', body: validBody() });
       expect('modelSubstitutions' in result.snapshot).toBe(false);
+    });
+  });
+
+  // ── The OTHER three exits that quote a cost without submitting.
+  //
+  // The insufficient-budget reply above is not the only one: the per-user daily
+  // Buzz cap, the per-app aggregate spend/velocity cap and the dev-tunnel session
+  // cap all return `cost: { total: cost }` from the SAME whatIf, with
+  // `workflowId: 'failed'` — i.e. no id the caller could poll to find out later
+  // which model that quote was priced for. A distinct substitution record per
+  // exit so a mutation on one exit cannot be killed by a neighbour's assertion.
+  describe('🔴 every cost-quoting exit that does not submit carries the record', () => {
+    const SUB_DAILY_CAP: SubstitutionRecord = {
+      requested: 101,
+      applied: 102,
+      reason: 'wrong-workflow',
+    };
+    const SUB_APP_CAP: SubstitutionRecord = {
+      requested: 201,
+      applied: 202,
+      reason: 'unrecognized',
+    };
+    const SUB_DEV_CAP: SubstitutionRecord = { requested: 301, applied: 302, reason: 'gated' };
+
+    /**
+     * Per-call budget high enough to clear the FIRST gate, so the request runs on
+     * past the insufficient-budget exit and reaches the cap under test. Only the
+     * whatIf submit is stubbed — none of these exits reaches the real submit.
+     *
+     * The three cap drivers are RE-NEUTRALIZED here, not just in `beforeEach`:
+     * the last test drives all three exits inside one `it`, and a cap left armed
+     * from the previous leg would short-circuit the next one at the WRONG exit
+     * (a green test for the wrong reason).
+     */
+    function reachesTheCaps(...records: SubstitutionRecord[]) {
+      mockVerifyBlockToken.mockResolvedValue(validClaims({ buzzBudget: 1000 }));
+      happyVersionLookup();
+      happyUser();
+      mockBuildGenerationContext.mockResolvedValue(ctxWithSubstitutions(...records));
+      mockSysRedis.incrBy.mockResolvedValue(0);
+      mockReserveAppSpend.mockResolvedValue({
+        allowed: true,
+        dailyTotal: 0,
+        velocityCount: 1,
+        dailyKey: 'system:blocks:app-spend-cap:apb_test:day',
+      });
+      mockGetActiveDevTunnel.mockResolvedValue(null);
+      mockReserveDevSessionBuzz.mockResolvedValue({ allowed: true, total: 0 });
+      mockSubmitWorkflow.mockResolvedValueOnce({
+        id: '',
+        status: 'succeeded',
+        cost: { total: 25 },
+        steps: [],
+      });
+    }
+
+    it('the DAILY Buzz cap reply reports what the quote was priced for', async () => {
+      reachesTheCaps(SUB_DAILY_CAP);
+      mockSysRedis.incrBy.mockResolvedValue(50015); // reservation trips the 50,000 cap
+
+      const caller = blocksRouter.createCaller(fakeCtx() as never);
+      const result = await caller.submitWorkflow({ blockToken: 'tok', body: validBody() });
+
+      expect(result.snapshot.error).toMatch(/daily Buzz cap reached/);
+      expect(result.snapshot.cost).toEqual({ total: 25 });
+      expect(result.snapshot.modelSubstitutions).toEqual([SUB_DAILY_CAP]);
+      expect(mockSubmitWorkflow).toHaveBeenCalledTimes(1); // whatIf only, no submit
+    });
+
+    it('the PER-APP spend/velocity cap reply reports what the quote was priced for', async () => {
+      reachesTheCaps(SUB_APP_CAP);
+      mockReserveAppSpend.mockResolvedValue({
+        allowed: false,
+        reason: 'daily',
+        dailyTotal: 999,
+        velocityCount: 0,
+      });
+
+      const caller = blocksRouter.createCaller(fakeCtx() as never);
+      const result = await caller.submitWorkflow({ blockToken: 'tok', body: validBody() });
+
+      expect(result.snapshot.error).toMatch(/app daily spend cap reached/);
+      expect(result.snapshot.cost).toEqual({ total: 25 });
+      expect(result.snapshot.modelSubstitutions).toEqual([SUB_APP_CAP]);
+      // The ceiling itself is still not leaked — the message stays number-free.
+      expect(result.snapshot.error).not.toMatch(/\d/);
+      expect(mockSubmitWorkflow).toHaveBeenCalledTimes(1);
+    });
+
+    it('the DEV-TUNNEL session cap reply reports what the quote was priced for', async () => {
+      reachesTheCaps(SUB_DEV_CAP);
+      mockGetActiveDevTunnel.mockResolvedValue({ sessionId: 'bki_dev', spendCapBuzz: 5000 });
+      mockReserveDevSessionBuzz.mockResolvedValue({ allowed: false, total: 5000 });
+
+      const caller = blocksRouter.createCaller(fakeCtx() as never);
+      const result = await caller.submitWorkflow({ blockToken: 'tok', body: validBody() });
+
+      expect(result.snapshot.error).toMatch(/dev tunnel session Buzz cap reached/);
+      expect(result.snapshot.cost).toEqual({ total: 25 });
+      expect(result.snapshot.modelSubstitutions).toEqual([SUB_DEV_CAP]);
+      expect(mockSubmitWorkflow).toHaveBeenCalledTimes(1);
+    });
+
+    // 🔴 The no-behaviour-change half: with nothing substituted every one of the
+    // three replies must be byte-identical to what it returned before this PR.
+    it('all three are UNCHANGED when nothing was substituted', async () => {
+      const caller = () => blocksRouter.createCaller(fakeCtx() as never);
+
+      reachesTheCaps();
+      mockSysRedis.incrBy.mockResolvedValue(50015);
+      const daily = await caller().submitWorkflow({ blockToken: 'tok', body: validBody() });
+      expect(daily.snapshot.error).toMatch(/daily Buzz cap reached/);
+      expect('modelSubstitutions' in daily.snapshot).toBe(false);
+
+      reachesTheCaps();
+      mockReserveAppSpend.mockResolvedValue({
+        allowed: false,
+        reason: 'daily',
+        dailyTotal: 999,
+        velocityCount: 0,
+      });
+      const app = await caller().submitWorkflow({ blockToken: 'tok', body: validBody() });
+      expect(app.snapshot.error).toMatch(/app daily spend cap reached/);
+      expect('modelSubstitutions' in app.snapshot).toBe(false);
+
+      reachesTheCaps();
+      mockGetActiveDevTunnel.mockResolvedValue({ sessionId: 'bki_dev', spendCapBuzz: 5000 });
+      mockReserveDevSessionBuzz.mockResolvedValue({ allowed: false, total: 5000 });
+      const dev = await caller().submitWorkflow({ blockToken: 'tok', body: validBody() });
+      expect(dev.snapshot.error).toMatch(/dev tunnel session Buzz cap reached/);
+      expect('modelSubstitutions' in dev.snapshot).toBe(false);
     });
   });
 

--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -133,6 +133,7 @@ import {
   resolveBlockVersionContext,
   resolvePageResourceContext,
   snapshotFromWorkflow,
+  WORKFLOW_METADATA_MODEL_SUBSTITUTIONS_KEY,
 } from '~/server/services/blocks/workflow.service';
 // App Blocks customComfy bridge (v1). The recipe registry is the code-reviewed
 // trust root; the schema already gated `recipe` to a registered id, so `getRecipe`
@@ -989,10 +990,16 @@ async function createBlockTextToImageStep(opts: {
   whatIf?: boolean;
   isGreen?: boolean;
 }) {
-  const { externalCtx } = await buildGenerationContext(opts.user.tier ?? 'free', undefined, {
-    id: opts.user.id,
-    isModerator: opts.user.isModerator,
-  });
+  const { externalCtx } = await buildGenerationContext(
+    opts.user.tier ?? 'free',
+    undefined,
+    { id: opts.user.id, isModerator: opts.user.isModerator },
+    // #3520: the App Blocks bridge — the surface the issue is actually about.
+    // Here the checkpoint version id was written by an app author (deliberate),
+    // and until this PR the correction was undetectable by the caller. This is
+    // the population phase 3's reject/degrade decision has to be measured on.
+    'block'
+  );
   const { steps, workflowMetadata } = await createWorkflowStepsFromGraphInput({
     input: opts.input,
     externalCtx,
@@ -1025,16 +1032,32 @@ async function createBlockTextToImageStep(opts: {
   // object — so it describes THIS submit and no one else's. Behaviour is
   // unchanged; the caller folds this into the snapshot so the block can detect
   // that it was billed for a model it did not ask for.
+  const modelSubstitutions = externalCtx.modelSubstitutions
+    ?.list()
+    .map(({ requested, applied, reason }) => ({ requested, applied, reason }));
+
+  // 🔴 PERSIST it on the workflow's own metadata, not only on the submit reply.
+  // A block renders from the TERMINAL POLL (the only snapshot carrying
+  // `imageUrls`), and `pollWorkflow` rebuilds its snapshot from a freshly
+  // fetched Workflow with none of this request's context — so a reply-only field
+  // is gone before there is anything to show beside it, and `block_workflows`
+  // does not retain the submitted body to recover it from. Riding on the
+  // orchestrator metadata the submit body already carries makes it readable on
+  // EVERY later read, with no schema/DB change. See
+  // `WORKFLOW_METADATA_MODEL_SUBSTITUTIONS_KEY`.
+  //
+  // Byte-identical when nothing was substituted (the overwhelmingly common
+  // case): the key is only added when there is something to add, and
+  // `workflowMetadata` is `undefined` on whatIf — where there is no persisted
+  // workflow to read back from anyway, so the estimate reply carries the record
+  // directly instead.
   return {
     step,
-    workflowMetadata,
-    modelSubstitutions: externalCtx.modelSubstitutions
-      ?.list()
-      .map(({ requested, applied, reason }) => ({
-        requested,
-        applied,
-        reason,
-      })),
+    workflowMetadata:
+      workflowMetadata && modelSubstitutions?.length
+        ? { ...workflowMetadata, [WORKFLOW_METADATA_MODEL_SUBSTITUTIONS_KEY]: modelSubstitutions }
+        : workflowMetadata,
+    modelSubstitutions,
   };
 }
 
@@ -4042,11 +4065,23 @@ export const blocksRouter = router({
       // resources/params the real submit uses.
       // whatIf cost preflight: `workflowMetadata` is undefined here (graph omits
       // it on whatIf), and the whatif body never carries `metadata` anyway.
-      const { step: stepForCostCheck } = await createBlockTextToImageStep({
-        input: generateInput,
-        user,
-        whatIf: true,
-      });
+      //
+      // #3520 — the preflight's OWN substitutions. This validation is what
+      // produces the cost the budget check below is made against, so if the graph
+      // swapped the checkpoint here, the quote the block is judged on is priced
+      // for a model it did not ask for. On the SUCCESS path the real submit
+      // re-validates the same input and its record is what the snapshot carries
+      // (identical by construction, and tied to a real workflow id) — so these
+      // are only surfaced on the one exit that returns a quote WITHOUT a submit:
+      // the insufficient-budget reply below, which would otherwise be the single
+      // reply in the whole flow that reports a cost with no way to learn which
+      // model it was for.
+      const { step: stepForCostCheck, modelSubstitutions: preflightSubstitutions } =
+        await createBlockTextToImageStep({
+          input: generateInput,
+          user,
+          whatIf: true,
+        });
       const tags = buildWorkflowTags(claims, resolved.baseModel);
       const whatIfResult = await submitWorkflow({
         token,
@@ -4070,6 +4105,12 @@ export const blocksRouter = router({
             status: 'failed' as const,
             cost: { total: cost },
             error: `insufficient buzz budget: estimate ${cost} exceeds budget ${claims.buzzBudget}`,
+            // Additive + omitted when empty, exactly like every other snapshot
+            // site, so this reply is byte-identical whenever nothing was
+            // substituted.
+            ...(preflightSubstitutions?.length
+              ? { modelSubstitutions: preflightSubstitutions }
+              : {}),
           },
         };
       }

--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -4071,11 +4071,24 @@ export const blocksRouter = router({
       // swapped the checkpoint here, the quote the block is judged on is priced
       // for a model it did not ask for. On the SUCCESS path the real submit
       // re-validates the same input and its record is what the snapshot carries
-      // (identical by construction, and tied to a real workflow id) — so these
-      // are only surfaced on the one exit that returns a quote WITHOUT a submit:
-      // the insufficient-budget reply below, which would otherwise be the single
-      // reply in the whole flow that reports a cost with no way to learn which
-      // model it was for.
+      // (identical by construction, and tied to a real workflow id), so a second
+      // copy there would be redundant.
+      //
+      // THE RULE: every exit that quotes a cost WITHOUT submitting carries this
+      // record. There are FOUR below, all returning this same whatIf `cost` and
+      // no workflow id the caller could poll to learn the answer later:
+      //
+      //   1. insufficient per-call budget            (`cost > claims.buzzBudget`)
+      //   2. per-user daily / review-session Buzz cap (`total > buzzCap`)
+      //   3. per-app aggregate spend + velocity cap   (G8, `!appSpend.allowed`)
+      //   4. dev-tunnel per-session spend backstop    (F4, `!reserved.allowed`)
+      //
+      // 2–4 sit after the idempotency claim, but every one of them RELEASEs it
+      // rather than finalizing, so none of these snapshots is ever cached and
+      // replayed — each is produced fresh from this request's own preflight.
+      // Adding the field leaks nothing the caller does not already own: it is
+      // the caller's own requested id and the id that would have run, never any
+      // cap value (exit 3's message stays deliberately number-free).
       const { step: stepForCostCheck, modelSubstitutions: preflightSubstitutions } =
         await createBlockTextToImageStep({
           input: generateInput,
@@ -4202,6 +4215,12 @@ export const blocksRouter = router({
               : `daily Buzz cap reached: ${total - Math.ceil(cost)} already spent today ` +
                 `across your installed apps, this generation costs ${cost}, ` +
                 `daily cap is ${buzzCap}`,
+            // #3520 exit 2 — quotes `cost` with no workflow. Additive + omitted
+            // when empty, so this reply is byte-identical whenever nothing was
+            // substituted.
+            ...(preflightSubstitutions?.length
+              ? { modelSubstitutions: preflightSubstitutions }
+              : {}),
           },
         };
       }
@@ -4253,6 +4272,12 @@ export const blocksRouter = router({
                   : appSpend.reason === 'unavailable'
                   ? 'generation temporarily unavailable — please retry shortly'
                   : "app daily spend cap reached: this app has hit its aggregate daily generation-spend ceiling — please try again later",
+              // #3520 exit 3 — quotes `cost` with no workflow. Carries only the
+              // caller's own requested/applied version ids, so it does NOT
+              // weaken the deliberately number-free message above.
+              ...(preflightSubstitutions?.length
+                ? { modelSubstitutions: preflightSubstitutions }
+                : {}),
             },
           };
         }
@@ -4314,6 +4339,12 @@ export const blocksRouter = router({
                   `dev tunnel session Buzz cap reached: ${reserved.total} already spent ` +
                   `this dev session, this generation costs ${Math.ceil(cost)}, ` +
                   `session cap is ${devTunnel.spendCapBuzz}`,
+                // #3520 exit 4 — quotes `cost` with no workflow. This is the
+                // path an app AUTHOR iterating locally hits, i.e. exactly the
+                // audience that needs to see a substituted checkpoint.
+                ...(preflightSubstitutions?.length
+                  ? { modelSubstitutions: preflightSubstitutions }
+                  : {}),
               },
             };
           }

--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -1018,7 +1018,24 @@ async function createBlockTextToImageStep(opts: {
   // resources). It is `undefined` on whatIf calls (the graph omits it then), so
   // callers can attach it to the REAL submit body only — mirroring the normal
   // path's `isWhatIf ? undefined : metadata` semantics — without a separate flag.
-  return { step, workflowMetadata };
+  //
+  // `modelSubstitutions` (issue #3520): checkpoint versions the graph SILENTLY
+  // replaced during the validation just performed. Read from the per-request
+  // collector on the `externalCtx` built two lines above — never a shared/cached
+  // object — so it describes THIS submit and no one else's. Behaviour is
+  // unchanged; the caller folds this into the snapshot so the block can detect
+  // that it was billed for a model it did not ask for.
+  return {
+    step,
+    workflowMetadata,
+    modelSubstitutions: externalCtx.modelSubstitutions
+      ?.list()
+      .map(({ requested, applied, reason }) => ({
+        requested,
+        applied,
+        reason,
+      })),
+  };
 }
 
 export const blocksRouter = router({
@@ -3759,7 +3776,11 @@ export const blocksRouter = router({
       // whatIf: no `metadata` on the body — matches the normal path
       // (`generateFromGraph` builds workflowMetadata only for real submits) and
       // `createBlockTextToImageStep` returns `workflowMetadata: undefined` here.
-      const { step } = await createBlockTextToImageStep({ input: generateInput, user, whatIf: true });
+      const { step, modelSubstitutions } = await createBlockTextToImageStep({
+        input: generateInput,
+        user,
+        whatIf: true,
+      });
       const workflow = await submitWorkflow({
         token,
         body: {
@@ -3770,7 +3791,10 @@ export const blocksRouter = router({
         },
         query: { whatif: true },
       });
-      return { snapshot: snapshotFromWorkflow(workflow) };
+      // #3520: the ESTIMATE reports the substitution too — a block that quotes a
+      // cost for model A and is silently priced for model B has the same
+      // detectability problem as the submit, one step earlier.
+      return { snapshot: snapshotFromWorkflow(workflow, { modelSubstitutions }) };
     }),
 
   /**
@@ -4293,7 +4317,7 @@ export const blocksRouter = router({
         // `createBlockTextToImageStep` returns it. Mirrors the normal form path
         // (`generateFromGraph` passes `metadata: workflowMetadata`). `removeEmpty`
         // already stripped fields the block context lacks (e.g. remixOfId).
-        const { step, workflowMetadata } = await createBlockTextToImageStep({
+        const { step, workflowMetadata, modelSubstitutions } = await createBlockTextToImageStep({
           input: generateInput,
           user,
           isGreen,
@@ -4317,7 +4341,9 @@ export const blocksRouter = router({
             externalId: blockExternalId,
           },
         });
-        snapshot = snapshotFromWorkflow(submitted);
+        // #3520: fold in any checkpoint the graph silently swapped during the
+        // validation inside `createBlockTextToImageStep` above.
+        snapshot = snapshotFromWorkflow(submitted, { modelSubstitutions });
         realizedTransactions = submitted.transactions;
       } catch (e) {
         // No resolved submit → undo the reservation (net-equivalent to the old

--- a/src/server/routers/orchestrator.router.ts
+++ b/src/server/routers/orchestrator.router.ts
@@ -345,10 +345,18 @@ export const orchestratorRouter = router({
       } = input;
       const tags = ctx.domain === 'green' ? ['green', ...(inputTags ?? [])] : inputTags ?? [];
       const userTier = ctx.user.tier ?? 'free';
-      const { externalCtx, status } = await buildGenerationContext(userTier, ctx.features, {
-        id: ctx.user.id,
-        isModerator: ctx.user.isModerator,
-      });
+      const { externalCtx, status } = await buildGenerationContext(
+        userTier,
+        ctx.features,
+        { id: ctx.user.id, isModerator: ctx.user.isModerator },
+        // #3520: the ON-SITE generator. A substitution here is the DELIBERATE,
+        // correct graceful degradation the issue defends — a stale localStorage
+        // version id after an ecosystem switch, with the picker visibly snapping
+        // back. Labelling it keeps it out of the App Blocks incidence number that
+        // gates the phase-3 policy decision, instead of inflating it with the one
+        // case everyone agrees is working as intended.
+        'onsite'
+      );
 
       // Workflow-level feature-flag gate. `filterWorkflowsByFeatureFlags` only
       // hides the option in the picker UI — a crafted submission payload would
@@ -419,10 +427,18 @@ export const orchestratorRouter = router({
     .input(z.any())
     .query(async ({ ctx, input }) => {
       const userTier = ctx.user.tier ?? 'free';
-      const { externalCtx, status } = await buildGenerationContext(userTier, ctx.features, {
-        id: ctx.user.id,
-        isModerator: ctx.user.isModerator,
-      });
+      const { externalCtx, status } = await buildGenerationContext(
+        userTier,
+        ctx.features,
+        { id: ctx.user.id, isModerator: ctx.user.isModerator },
+        // #3520: the ON-SITE generator. A substitution here is the DELIBERATE,
+        // correct graceful degradation the issue defends — a stale localStorage
+        // version id after an ecosystem switch, with the picker visibly snapping
+        // back. Labelling it keeps it out of the App Blocks incidence number that
+        // gates the phase-3 policy decision, instead of inflating it with the one
+        // case everyone agrees is working as intended.
+        'onsite'
+      );
 
       // Mirror of the gate in `generateFromGraph`. Reject what-if costing for
       // flag-gated workflows the user can't reach so we don't leak pricing

--- a/src/server/schema/blocks/workflow.schema.ts
+++ b/src/server/schema/blocks/workflow.schema.ts
@@ -7,6 +7,7 @@ import {
   civitaiHostedImageUrlSchema,
   SOURCE_IMAGE_URL_MAX,
 } from '~/server/schema/blocks/civitai-image-url';
+import type { ModelSubstitutionReason } from '~/shared/data-graph/generation/model-substitution';
 
 // The spendable buzz account types a viewer may pick for a (money) page block.
 // Reuse the authoritative `buzzSpendTypes` (blue/green/yellow — `red` is
@@ -327,4 +328,30 @@ export type BlockWorkflowSnapshot = {
     amount: number;
     accountType: 'yellow' | 'blue' | 'red' | 'green';
   };
+  /**
+   * Checkpoint versions the generation graph SILENTLY replaced (issue #3520).
+   *
+   * On a `modelLocked` ecosystem the graph swaps any version id that is not in
+   * the current workflow's visible list for that workflow's default, returns
+   * success, and bills the user. That is deliberate graceful degradation — it is
+   * what keeps an app pinned to a since-retired version working instead of
+   * hard-failing — but through this bridge the id was DELIBERATE and the
+   * correction was previously undetectable. `requested` is what the block asked
+   * for, `applied` is what actually ran.
+   *
+   * 🔴 BEHAVIOUR IS UNCHANGED: the same model runs as before; this field only
+   * reports it. OPTIONAL + additive, and OMITTED entirely when nothing was
+   * substituted, so every existing snapshot stays byte-identical and a consumer
+   * that does not read it is unaffected.
+   *
+   * 🔴 WIRE CONTRACT: this is an ADDITIVE field on the type
+   * `@civitai/app-sdk`'s `blocks/types.ts` mirrors. The SDK's inbound validator
+   * does not know it yet, so a block reads it only after the SDK type is widened
+   * in that repo — tracked separately; nothing here edits another repo.
+   */
+  modelSubstitutions?: Array<{
+    requested: number;
+    applied: number;
+    reason: ModelSubstitutionReason;
+  }>;
 };

--- a/src/server/schema/blocks/workflow.schema.ts
+++ b/src/server/schema/blocks/workflow.schema.ts
@@ -344,6 +344,16 @@ export type BlockWorkflowSnapshot = {
    * substituted, so every existing snapshot stays byte-identical and a consumer
    * that does not read it is unaffected.
    *
+   * WHERE IT APPEARS. On the submit reply, on the `estimateWorkflow` reply, on
+   * the insufficient-budget reply from `generate`, and — because the submit
+   * persists it on the orchestrator workflow's `metadata` — on every subsequent
+   * `pollWorkflow` / `cancelWorkflow` read of that workflow. The poll is the one
+   * that matters in practice: it is the snapshot carrying `imageUrls`, i.e. the
+   * one a block actually renders from, so the record is present next to the
+   * images it describes rather than only on a reply the block may have discarded.
+   * The estimate reply is the exception — a whatIf creates no persisted workflow,
+   * so there the record exists only on that reply.
+   *
    * 🔴 WIRE CONTRACT: this is an ADDITIVE field on the type
    * `@civitai/app-sdk`'s `blocks/types.ts` mirrors. The SDK's inbound validator
    * does not know it yet, so a block reads it only after the SDK type is widened

--- a/src/server/schema/blocks/workflow.schema.ts
+++ b/src/server/schema/blocks/workflow.schema.ts
@@ -345,9 +345,11 @@ export type BlockWorkflowSnapshot = {
    * that does not read it is unaffected.
    *
    * WHERE IT APPEARS. On the submit reply, on the `estimateWorkflow` reply, on
-   * the insufficient-budget reply from `generate`, and — because the submit
-   * persists it on the orchestrator workflow's `metadata` — on every subsequent
-   * `pollWorkflow` / `cancelWorkflow` read of that workflow. The poll is the one
+   * EVERY reply from `submitWorkflow` that quotes a cost without submitting
+   * (insufficient per-call budget, the per-user daily / review Buzz cap, the
+   * per-app aggregate spend+velocity cap, the dev-tunnel session cap), and —
+   * because the submit persists it on the orchestrator workflow's `metadata` —
+   * on every subsequent `pollWorkflow` / `cancelWorkflow` read. The poll is the one
    * that matters in practice: it is the snapshot carrying `imageUrls`, i.e. the
    * one a block actually renders from, so the record is present next to the
    * images it describes rather than only on a reply the block may have discarded.

--- a/src/server/services/blocks/__tests__/workflow.service.test.ts
+++ b/src/server/services/blocks/__tests__/workflow.service.test.ts
@@ -167,10 +167,13 @@ describe('snapshotFromWorkflow', () => {
 
   // ---- #3520: silent model substitutions surfaced on the snapshot ----------
   //
-  // The orchestrator Workflow cannot carry these — the substitution happened
-  // during graph validation, before anything was submitted — so they arrive as
-  // an explicit second argument. The invariant being protected is "a caller
-  // billed for model A and given model B must be able to find that out".
+  // The substitution happens during graph validation, before anything is
+  // submitted, so it arrives EITHER as an explicit second argument (submit /
+  // estimate replies, where the request's collector is still in scope) OR — and
+  // this is the one that matters — off the workflow's persisted `metadata`, which
+  // is what makes it survive to the TERMINAL POLL, the snapshot a block actually
+  // renders from. The invariant being protected is "a caller billed for model A
+  // and given model B must be able to find that out".
   it('surfaces modelSubstitutions passed alongside the workflow', () => {
     const snap = snapshotFromWorkflow(fakeWorkflow() as never, {
       modelSubstitutions: [{ requested: 2558804, applied: 2552908, reason: 'wrong-workflow' }],
@@ -188,6 +191,113 @@ describe('snapshotFromWorkflow', () => {
       const snap = snapshotFromWorkflow(fakeWorkflow() as never, extra);
       expect('modelSubstitutions' in snap).toBe(false);
     }
+  });
+
+  // ---- 🔴 #3520 FIX 1: the record must SURVIVE TO THE POLL -----------------
+  //
+  // `pollWorkflow` / `cancelWorkflow` call `snapshotFromWorkflow(workflow)` with
+  // NO second argument — they only have a freshly fetched Workflow. The poll is
+  // also the only snapshot that carries `imageUrls`, i.e. the one a block renders
+  // from. A submit-reply-only field is therefore gone before there is anything to
+  // display beside it, and `block_workflows` does not retain the submitted body
+  // to recover it from. These pin the metadata round-trip that closes that.
+  describe('recovered from the workflow metadata (the poll path)', () => {
+    const persisted = [
+      { requested: 2558804, applied: 2552908, reason: 'wrong-workflow' },
+      { requested: 987654321, applied: 2552908, reason: 'unrecognized' },
+    ];
+
+    it('reads modelSubstitutions off workflow.metadata with NO extra argument', () => {
+      const snap = snapshotFromWorkflow(
+        fakeWorkflow({
+          metadata: { params: { prompt: 'a cat' }, modelSubstitutions: persisted },
+        }) as never
+      );
+      expect(snap.modelSubstitutions).toEqual(persisted);
+    });
+
+    it('is present on the TERMINAL poll shape — alongside the imageUrls it describes', () => {
+      // The shape `pollWorkflow` actually hands to the block: succeeded, with
+      // outputs. This is the exact call the fix exists for.
+      const snap = snapshotFromWorkflow(
+        fakeWorkflow({
+          status: 'succeeded',
+          metadata: { modelSubstitutions: persisted },
+          steps: [
+            {
+              $type: 'textToImage',
+              name: 's1',
+              status: 'succeeded',
+              metadata: {},
+              output: {
+                images: [{ id: 'b1', url: 'https://cdn/img1.png', available: true, type: 'image' }],
+              },
+            },
+          ],
+        }) as never
+      );
+      expect(snap.imageUrls).toEqual(['https://cdn/img1.png']);
+      expect(snap.modelSubstitutions).toEqual(persisted);
+    });
+
+    it('an EXPLICIT extra wins over the metadata (the submit reply is authoritative)', () => {
+      const fromRequest = [{ requested: 1, applied: 2, reason: 'gated' as const }];
+      const snap = snapshotFromWorkflow(
+        fakeWorkflow({ metadata: { modelSubstitutions: persisted } }) as never,
+        { modelSubstitutions: fromRequest }
+      );
+      expect(snap.modelSubstitutions).toEqual(fromRequest);
+    });
+
+    it('still OMITS the field when the metadata has none (unchanged wire payload)', () => {
+      for (const metadata of [
+        {},
+        { params: { prompt: 'x' } },
+        { modelSubstitutions: [] },
+        { modelSubstitutions: null },
+        { modelSubstitutions: 'nope' },
+      ]) {
+        const snap = snapshotFromWorkflow(fakeWorkflow({ metadata }) as never);
+        expect('modelSubstitutions' in snap).toBe(false);
+      }
+    });
+
+    // 🔴 The metadata crosses a service boundary and feeds a PUBLIC wire field
+    // whose `reason` is also a bounded prom label, so it is validated, not cast.
+    it.each([
+      ['a non-array', { modelSubstitutions: { requested: 1, applied: 2, reason: 'gated' } }],
+      ['a null entry', { modelSubstitutions: [null] }],
+      [
+        'a non-numeric requested',
+        { modelSubstitutions: [{ requested: '1', applied: 2, reason: 'gated' }] },
+      ],
+      [
+        'a NaN applied',
+        { modelSubstitutions: [{ requested: 1, applied: Number.NaN, reason: 'gated' }] },
+      ],
+      ['a missing reason', { modelSubstitutions: [{ requested: 1, applied: 2 }] }],
+      [
+        'an unknown reason',
+        { modelSubstitutions: [{ requested: 1, applied: 2, reason: 'because' }] },
+      ],
+    ])('DROPS %s from the metadata rather than putting it on the wire', (_label, metadata) => {
+      const snap = snapshotFromWorkflow(fakeWorkflow({ metadata }) as never);
+      expect('modelSubstitutions' in snap).toBe(false);
+    });
+
+    it('keeps the VALID entries when a malformed one rides alongside', () => {
+      const snap = snapshotFromWorkflow(
+        fakeWorkflow({
+          metadata: {
+            modelSubstitutions: [
+              { requested: 1, applied: 2, reason: 'because' },
+              { requested: 3, applied: 4, reason: 'gated' },
+            ],
+          },
+        }) as never
+      );
+      expect(snap.modelSubstitutions).toEqual([{ requested: 3, applied: 4, reason: 'gated' }]);
+    });
   });
 
   // ---- image extraction across ALL image-producing step types --------------

--- a/src/server/services/blocks/__tests__/workflow.service.test.ts
+++ b/src/server/services/blocks/__tests__/workflow.service.test.ts
@@ -165,6 +165,31 @@ describe('snapshotFromWorkflow', () => {
     expect(snap.imageUrls).toBeUndefined();
   });
 
+  // ---- #3520: silent model substitutions surfaced on the snapshot ----------
+  //
+  // The orchestrator Workflow cannot carry these — the substitution happened
+  // during graph validation, before anything was submitted — so they arrive as
+  // an explicit second argument. The invariant being protected is "a caller
+  // billed for model A and given model B must be able to find that out".
+  it('surfaces modelSubstitutions passed alongside the workflow', () => {
+    const snap = snapshotFromWorkflow(fakeWorkflow() as never, {
+      modelSubstitutions: [{ requested: 2558804, applied: 2552908, reason: 'wrong-workflow' }],
+    });
+    expect(snap.modelSubstitutions).toEqual([
+      { requested: 2558804, applied: 2552908, reason: 'wrong-workflow' },
+    ]);
+  });
+
+  it('OMITS modelSubstitutions when nothing was substituted (byte-identical to before)', () => {
+    // Three shapes that all mean "nothing to report": no second argument at all
+    // (every pre-existing call site), an empty object, and an empty array. None
+    // may add a key to the wire payload.
+    for (const extra of [undefined, {}, { modelSubstitutions: [] }]) {
+      const snap = snapshotFromWorkflow(fakeWorkflow() as never, extra);
+      expect('modelSubstitutions' in snap).toBe(false);
+    }
+  });
+
   // ---- image extraction across ALL image-producing step types --------------
   // The extractor accepts THREE step types (textToImage / imageGen / comfy);
   // the happy-path test above only exercises textToImage. These pin the other

--- a/src/server/services/blocks/workflow.service.ts
+++ b/src/server/services/blocks/workflow.service.ts
@@ -37,7 +37,18 @@ const ORCH_STATUS_MAP: Record<WorkflowStatus, BlockWorkflowSnapshot['status']> =
  * surfaced — pending/blocked blobs are dropped rather than sending dead links
  * the block would render as broken images.
  */
-export function snapshotFromWorkflow(workflow: Workflow): BlockWorkflowSnapshot {
+export function snapshotFromWorkflow(
+  workflow: Workflow,
+  /**
+   * Facts about the SUBMIT that the orchestrator Workflow cannot carry, because
+   * they happened during graph validation before anything was submitted.
+   * Currently only the silent checkpoint substitutions recorded on the request's
+   * `GenerationCtx` (issue #3520) — see `BlockWorkflowSnapshot.modelSubstitutions`.
+   * Optional so every existing call site is unchanged and its snapshot stays
+   * byte-identical.
+   */
+  extra?: { modelSubstitutions?: BlockWorkflowSnapshot['modelSubstitutions'] }
+): BlockWorkflowSnapshot {
   const status = ORCH_STATUS_MAP[workflow.status] ?? 'pending';
   const imageUrls: string[] = [];
   for (const step of workflow.steps ?? []) {
@@ -109,6 +120,9 @@ export function snapshotFromWorkflow(workflow: Workflow): BlockWorkflowSnapshot 
     // optional — omitted when there's no debit to report so every existing
     // snapshot stays byte-identical to before.
     ...(spentAccountType ? { spentAccountType } : {}),
+    // Omitted entirely when nothing was substituted — the common case — so a
+    // normal snapshot is unchanged on the wire.
+    ...(extra?.modelSubstitutions?.length ? { modelSubstitutions: extra.modelSubstitutions } : {}),
   };
 }
 

--- a/src/server/services/blocks/workflow.service.ts
+++ b/src/server/services/blocks/workflow.service.ts
@@ -9,6 +9,7 @@ import { getBaseModelSetType } from '~/shared/constants/generation.constants';
 import { getEcosystem } from '~/shared/constants/basemodel.constants';
 import { isWorkflowAvailable } from '~/shared/data-graph/generation/config/workflows';
 import { resolveVersionWorkflowScope } from '~/shared/data-graph/generation/workflow-capability';
+import { isModelSubstitutionReason } from '~/shared/data-graph/generation/model-substitution';
 import { getImagesLimit } from '~/shared/data-graph/generation/images-limit';
 import { ModelType } from '~/shared/utils/prisma/enums';
 import type {
@@ -32,6 +33,66 @@ const ORCH_STATUS_MAP: Record<WorkflowStatus, BlockWorkflowSnapshot['status']> =
 };
 
 /**
+ * 🔴 KEY under which the submit path stores the request's silent checkpoint
+ * substitutions on the ORCHESTRATOR WORKFLOW's `metadata` (issue #3520).
+ *
+ * WHY THE ORCHESTRATOR AND NOT A COLUMN. The record is produced during graph
+ * validation, which happens once, at submit. But blocks render from the
+ * TERMINAL POLL — that is the only snapshot that carries `imageUrls` — and
+ * `pollWorkflow` / `cancelWorkflow` build their snapshot from a freshly fetched
+ * `Workflow` with no access to that long-gone request context. A submit-reply-
+ * only field is therefore gone by the time there is anything to display beside
+ * it, and `block_workflows` does not retain the submitted body, so it is not
+ * recoverable afterwards either — i.e. the field would not achieve the thing
+ * #3520 asks for ("a caller billed for model A and given model B must be able to
+ * find that out").
+ *
+ * `WorkflowTemplate.metadata` is a free-form `{ [key: string]: unknown }` bag
+ * that the orchestrator persists and echoes back on every read of the workflow,
+ * which makes it the natural carrier: written once at submit, readable on every
+ * subsequent poll, and NO database change (no Prisma migration — which in this
+ * org is a manually-applied, per-environment human operation, not something a
+ * code PR should imply).
+ *
+ * The app already relies on this round-trip for its own non-standard top-level
+ * metadata keys — `remixOfId` and `isPrivateGeneration` are written here at
+ * submit and read back from `workflow.metadata` in
+ * `orchestration-new.service.ts`'s workflow formatter — so this is an existing,
+ * exercised path rather than a new assumption. The formatter builds its
+ * normalized metadata from a fixed key list, so an extra key is inert there.
+ */
+export const WORKFLOW_METADATA_MODEL_SUBSTITUTIONS_KEY = 'modelSubstitutions';
+
+/**
+ * Read substitutions back off a fetched workflow's metadata.
+ *
+ * 🔴 VALIDATED, not cast. This crosses a service boundary: the value is whatever
+ * the orchestrator hands back, and the snapshot it feeds is a public wire
+ * contract whose `reason` is also a bounded prom label. So each entry is checked
+ * structurally and its `reason` narrowed against the code-owned union; anything
+ * else is dropped. Returns `undefined` (not `[]`) when there is nothing to
+ * report, so the caller can keep OMITTING the field entirely.
+ */
+function readModelSubstitutionsFromMetadata(
+  workflow: Workflow
+): BlockWorkflowSnapshot['modelSubstitutions'] {
+  const raw = (workflow.metadata as Record<string, unknown> | null | undefined)?.[
+    WORKFLOW_METADATA_MODEL_SUBSTITUTIONS_KEY
+  ];
+  if (!Array.isArray(raw)) return undefined;
+  const out: NonNullable<BlockWorkflowSnapshot['modelSubstitutions']> = [];
+  for (const entry of raw) {
+    if (!entry || typeof entry !== 'object') continue;
+    const { requested, applied, reason } = entry as Record<string, unknown>;
+    if (typeof requested !== 'number' || !Number.isFinite(requested)) continue;
+    if (typeof applied !== 'number' || !Number.isFinite(applied)) continue;
+    if (!isModelSubstitutionReason(reason)) continue;
+    out.push({ requested, applied, reason });
+  }
+  return out.length ? out : undefined;
+}
+
+/**
  * Flatten an orchestrator Workflow into the wire-stable shape the iframe
  * receives. Only image URLs that are `available` and have a non-null url are
  * surfaced — pending/blocked blobs are dropped rather than sending dead links
@@ -40,12 +101,17 @@ const ORCH_STATUS_MAP: Record<WorkflowStatus, BlockWorkflowSnapshot['status']> =
 export function snapshotFromWorkflow(
   workflow: Workflow,
   /**
-   * Facts about the SUBMIT that the orchestrator Workflow cannot carry, because
-   * they happened during graph validation before anything was submitted.
-   * Currently only the silent checkpoint substitutions recorded on the request's
-   * `GenerationCtx` (issue #3520) — see `BlockWorkflowSnapshot.modelSubstitutions`.
-   * Optional so every existing call site is unchanged and its snapshot stays
-   * byte-identical.
+   * Facts known to the SUBMITTING request that the orchestrator Workflow object
+   * does not itself model — currently only the silent checkpoint substitutions
+   * recorded on the request's `GenerationCtx` (issue #3520).
+   *
+   * Optional, and only an OVERRIDE: when omitted, the same information is
+   * recovered from the workflow's persisted metadata (see
+   * {@link WORKFLOW_METADATA_MODEL_SUBSTITUTIONS_KEY}), which is what lets a
+   * poll — the snapshot a block actually renders from — still report it. Passing
+   * it explicitly is preferred on the submit and estimate replies, where the
+   * request's own collector is in scope and is authoritative for that exact
+   * validation (and where, on the estimate path, nothing was persisted at all).
    */
   extra?: { modelSubstitutions?: BlockWorkflowSnapshot['modelSubstitutions'] }
 ): BlockWorkflowSnapshot {
@@ -103,6 +169,13 @@ export function snapshotFromWorkflow(
   }
   const total = workflow.cost?.total;
   const spentAccountType = primaryDebitedAccountType(workflow.transactions);
+  // #3520 — prefer the CALLER-SUPPLIED record (the submit/estimate reply, where
+  // the request's own collector is still in scope and is authoritative for this
+  // exact validation) and otherwise recover it from the workflow's persisted
+  // metadata, which is what makes the field survive to the terminal poll.
+  const modelSubstitutions = extra?.modelSubstitutions?.length
+    ? extra.modelSubstitutions
+    : readModelSubstitutionsFromMetadata(workflow);
   return {
     // A whatif/estimate workflow has no orchestrator id. The block SDK's
     // inbound validator (isValidWorkflowSnapshot) DROPS any snapshot whose
@@ -122,7 +195,7 @@ export function snapshotFromWorkflow(
     ...(spentAccountType ? { spentAccountType } : {}),
     // Omitted entirely when nothing was substituted — the common case — so a
     // normal snapshot is unchanged on the wire.
-    ...(extra?.modelSubstitutions?.length ? { modelSubstitutions: extra.modelSubstitutions } : {}),
+    ...(modelSubstitutions?.length ? { modelSubstitutions } : {}),
   };
 }
 

--- a/src/server/services/orchestrator/__tests__/generation-surface-wiring.test.ts
+++ b/src/server/services/orchestrator/__tests__/generation-surface-wiring.test.ts
@@ -33,6 +33,15 @@ import { GENERATION_SURFACES } from '~/shared/data-graph/generation/model-substi
 
 const REPO_ROOT = path.resolve(__dirname, '../../../../..');
 
+/** The declaration itself — not a call site. */
+const DEFINITION_FILE = 'src/server/services/orchestrator/orchestration-new.service.ts';
+/**
+ * This guard's own source. It mentions `buildGenerationContext(` inside STRING
+ * literals (the grep needle), which `stripComments` deliberately does not touch,
+ * so it has to be excluded by path or it enumerates itself as a call site.
+ */
+const GUARD_FILE = 'src/server/services/orchestrator/__tests__/generation-surface-wiring.test.ts';
+
 /**
  * Every file allowed to build a generation context, and the surface it must
  * declare. Adding a generation entry point means adding a row here — a
@@ -62,8 +71,14 @@ function stripComments(source: string): string {
     .replace(/(^|[^:'"`\\])\/\/[^\n]*/g, (m, lead) => lead + ' '.repeat(m.length - lead.length));
 }
 
-/** Enumerate call sites from the TREE, not from a hand-kept list. */
-function findCallSiteFiles(): string[] {
+/**
+ * Enumerate call sites from the TREE, not from a hand-kept list.
+ *
+ * `includeTests: false` is the PRODUCTION population (what the surface table
+ * below pins). `includeTests: true` adds the test tree, which `tsconfig.json`
+ * EXCLUDES (`src/**\/__tests__/**`) — see the arity guard for why that matters.
+ */
+function findCallSiteFiles({ includeTests }: { includeTests: boolean }): string[] {
   const out = execFileSync(
     'grep',
     ['-rl', '--include=*.ts', '--include=*.tsx', 'buildGenerationContext(', 'src'],
@@ -73,13 +88,8 @@ function findCallSiteFiles(): string[] {
     .split('\n')
     .map((l) => l.trim())
     .filter(Boolean)
-    .filter(
-      (f) =>
-        // The definition itself, and tests, are not call sites.
-        f !== 'src/server/services/orchestrator/orchestration-new.service.ts' &&
-        !f.includes('__tests__') &&
-        !f.endsWith('.test.ts')
-    )
+    .filter((f) => f !== DEFINITION_FILE && f !== GUARD_FILE)
+    .filter((f) => includeTests || !(f.includes('__tests__') || f.endsWith('.test.ts')))
     .filter(
       (f) =>
         argumentListsOf(
@@ -87,6 +97,47 @@ function findCallSiteFiles(): string[] {
           'buildGenerationContext('
         ).length > 0
     );
+}
+
+/**
+ * Split a call's argument text into its TOP-LEVEL arguments, ignoring commas
+ * nested inside parens / brackets / braces / string literals — so `f('a', {},
+ * {}, 'onsite')` counts 4, not 6.
+ */
+function topLevelArgs(argText: string): string[] {
+  if (argText.trim() === '') return [];
+  const args: string[] = [];
+  let depth = 0;
+  let quote: string | null = null;
+  let current = '';
+  for (let i = 0; i < argText.length; i++) {
+    const c = argText[i];
+    if (quote) {
+      if (c === '\\') {
+        current += c + (argText[i + 1] ?? '');
+        i += 1;
+        continue;
+      }
+      if (c === quote) quote = null;
+      current += c;
+      continue;
+    }
+    if (c === "'" || c === '"' || c === '`') {
+      quote = c;
+      current += c;
+      continue;
+    }
+    if (c === '(' || c === '[' || c === '{') depth += 1;
+    else if (c === ')' || c === ']' || c === '}') depth -= 1;
+    if (c === ',' && depth === 0) {
+      args.push(current);
+      current = '';
+      continue;
+    }
+    current += c;
+  }
+  args.push(current);
+  return args.map((a) => a.trim()).filter(Boolean);
 }
 
 /**
@@ -114,7 +165,7 @@ function argumentListsOf(source: string, needle: string): string[] {
 }
 
 describe('generation-context surface wiring', () => {
-  const files = findCallSiteFiles();
+  const files = findCallSiteFiles({ includeTests: false });
 
   it('finds the call sites at all (guard the guard)', () => {
     // Without this, a broken enumeration would make every assertion below pass
@@ -143,6 +194,43 @@ describe('generation-context surface wiring', () => {
       }
     }
   );
+
+  /**
+   * 🔴 THE TEST-CODE HOLE. "Required, not defaulted, so a new entry point is a
+   * compile error" is a claim about what `tsc` sees — and `tsconfig.json`
+   * EXCLUDES `src/[**]/__tests__/[**]`. A three-argument call inside a test tree
+   * therefore typechecks clean, builds a collector with `surface: undefined`,
+   * and no gate anywhere notices. Harmless while such a call only ever runs in a
+   * test, but a test HELPER that wraps `buildGenerationContext` would propagate
+   * unlabelled collectors with nothing catching it.
+   *
+   * Deliberately an ARITY check, NOT a surface-value check. Pinning WHICH
+   * surface a test must pass would false-alarm on legitimate fixtures — a
+   * table-driven test sweeping `GENERATION_SURFACES`, or one passing the value
+   * through a variable, are both perfectly valid and neither carries a literal
+   * this file could predict. Arity is exactly the guarantee `tsc` gives the
+   * production tree, extended to the part of the tree `tsc` never reads, and it
+   * constrains nothing else.
+   */
+  it('🔴 EVERY call site — test code included — passes the 4th `surface` argument', () => {
+    const allFiles = findCallSiteFiles({ includeTests: true });
+    const offenders: string[] = [];
+    let totalCalls = 0;
+
+    for (const file of allFiles) {
+      const source = stripComments(readFileSync(path.join(REPO_ROOT, file), 'utf8'));
+      for (const args of argumentListsOf(source, 'buildGenerationContext(')) {
+        totalCalls += 1;
+        const arity = topLevelArgs(args).length;
+        if (arity !== 4) offenders.push(`${file}: ${arity} args`);
+      }
+    }
+
+    // Guard the guard: a broken enumeration must not pass vacuously.
+    expect(allFiles.length).toBeGreaterThanOrEqual(Object.keys(EXPECTED_SURFACE_BY_FILE).length);
+    expect(totalCalls).toBeGreaterThanOrEqual(allFiles.length);
+    expect(offenders).toEqual([]);
+  });
 
   it('the expectation table covers every declared surface (no orphan label)', () => {
     // A surface value with no call site would be a series that can never be

--- a/src/server/services/orchestrator/__tests__/generation-surface-wiring.test.ts
+++ b/src/server/services/orchestrator/__tests__/generation-surface-wiring.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'fs';
+import path from 'path';
+import { execFileSync } from 'child_process';
+
+import { GENERATION_SURFACES } from '~/shared/data-graph/generation/model-substitution';
+
+/**
+ * 🔴 POPULATION GUARD for the `surface` label of
+ * `civitai_generation_model_substitutions_total` (issue #3520).
+ *
+ * `validateInput` is the single choke point every SERVER-side
+ * `generationGraph.safeParse` runs through, and it structurally cannot tell which
+ * caller it is serving. The surface therefore has to be fixed by whoever builds
+ * the request's context — `buildGenerationContext(userTier, flags, user, surface)`
+ * — and the guarantee this test protects is that EVERY such call site does so,
+ * with the surface that matches what that call site actually is.
+ *
+ * WHY A SOURCE-LEVEL GUARD AND NOT ONLY BEHAVIOURAL TESTS. The behavioural tests
+ * exist too (the App Blocks bridge in `blocks.router.workflow.test.ts`, preset
+ * generation in `preset-image-gen.surface.test.ts`), but each of those can only
+ * cover a call site that ALREADY EXISTS. The failure this signal is most exposed
+ * to is a SIXTH entry point added later and labelled with whatever surface was
+ * nearest to hand — which silently contaminates exactly the number phase 3's
+ * policy decision is gated on. That is a claim about the population, so it is
+ * checked against the population: every occurrence in `src/`, enumerated from the
+ * tree rather than from a list someone maintains.
+ *
+ * TypeScript already forces the argument to EXIST (it is required, not
+ * defaulted). What it cannot check is that the value is the RIGHT one for that
+ * file, which is what the expected-by-path table below pins.
+ */
+
+const REPO_ROOT = path.resolve(__dirname, '../../../../..');
+
+/**
+ * Every file allowed to build a generation context, and the surface it must
+ * declare. Adding a generation entry point means adding a row here — a
+ * deliberate, reviewable act, rather than a silent widening.
+ */
+const EXPECTED_SURFACE_BY_FILE: Record<string, string> = {
+  // The on-site generator. #3520 calls this substitution CORRECT: the only way
+  // the form holds an out-of-list id is a stale localStorage value after an
+  // ecosystem switch, and the user visibly sees the picker snap back.
+  'src/server/routers/orchestrator.router.ts': 'onsite',
+  // The App Blocks bridge — the surface the issue is about. The id was written
+  // by an app author and the correction was unobservable.
+  'src/server/routers/blocks.router.ts': 'block',
+  // Comics / preset image generation: server-composed graph input.
+  'src/server/services/orchestrator/preset-image-gen.service.ts': 'preset',
+};
+
+/**
+ * Blank out comments so a doc-comment that MENTIONS `buildGenerationContext(...)`
+ * is not mistaken for a call site. Whitespace-preserving, so offsets are stable.
+ * Deliberately simple: it only has to be right about this repo's own source, and
+ * it can only ever produce a FALSE ALARM (a real call hidden), never a false pass.
+ */
+function stripComments(source: string): string {
+  return source
+    .replace(/\/\*[\s\S]*?\*\//g, (m) => m.replace(/[^\n]/g, ' '))
+    .replace(/(^|[^:'"`\\])\/\/[^\n]*/g, (m, lead) => lead + ' '.repeat(m.length - lead.length));
+}
+
+/** Enumerate call sites from the TREE, not from a hand-kept list. */
+function findCallSiteFiles(): string[] {
+  const out = execFileSync(
+    'grep',
+    ['-rl', '--include=*.ts', '--include=*.tsx', 'buildGenerationContext(', 'src'],
+    { cwd: REPO_ROOT, encoding: 'utf8' }
+  );
+  return out
+    .split('\n')
+    .map((l) => l.trim())
+    .filter(Boolean)
+    .filter(
+      (f) =>
+        // The definition itself, and tests, are not call sites.
+        f !== 'src/server/services/orchestrator/orchestration-new.service.ts' &&
+        !f.includes('__tests__') &&
+        !f.endsWith('.test.ts')
+    )
+    .filter(
+      (f) =>
+        argumentListsOf(
+          stripComments(readFileSync(path.join(REPO_ROOT, f), 'utf8')),
+          'buildGenerationContext('
+        ).length > 0
+    );
+}
+
+/**
+ * The argument list of every `<needle>` call in `source`, extracted by BALANCED
+ * PARENTHESES rather than by a line pattern — a formatter reflow (prettier
+ * collapsing a multi-line call, or the reverse) must not be able to make this
+ * guard silently inspect the wrong text and pass.
+ */
+function argumentListsOf(source: string, needle: string): string[] {
+  const out: string[] = [];
+  let from = 0;
+  for (;;) {
+    const at = source.indexOf(needle, from);
+    if (at === -1) break;
+    let depth = 1;
+    let i = at + needle.length;
+    for (; i < source.length && depth > 0; i++) {
+      if (source[i] === '(') depth += 1;
+      else if (source[i] === ')') depth -= 1;
+    }
+    out.push(source.slice(at + needle.length, i - 1));
+    from = i;
+  }
+  return out;
+}
+
+describe('generation-context surface wiring', () => {
+  const files = findCallSiteFiles();
+
+  it('finds the call sites at all (guard the guard)', () => {
+    // Without this, a broken enumeration would make every assertion below pass
+    // vacuously over an empty list.
+    expect(files.length).toBeGreaterThanOrEqual(Object.keys(EXPECTED_SURFACE_BY_FILE).length);
+  });
+
+  it('every file that builds a generation context is a KNOWN surface', () => {
+    const unexpected = files.filter((f) => !(f in EXPECTED_SURFACE_BY_FILE));
+    // A new generation entry point must declare which population it belongs to;
+    // inheriting a neighbour's surface silently contaminates the number that
+    // gates the phase-3 policy decision.
+    expect(unexpected).toEqual([]);
+  });
+
+  it.each(Object.entries(EXPECTED_SURFACE_BY_FILE))(
+    '%s passes the surface %s at EVERY buildGenerationContext call',
+    (file, expectedSurface) => {
+      const source = stripComments(readFileSync(path.join(REPO_ROOT, file), 'utf8'));
+      const calls = argumentListsOf(source, 'buildGenerationContext(');
+      expect(calls.length).toBeGreaterThan(0);
+      for (const args of calls) {
+        const found = GENERATION_SURFACES.filter((s) => args.includes(`'${s}'`));
+        // Exactly one surface literal, and it is this file's.
+        expect(found).toEqual([expectedSurface]);
+      }
+    }
+  );
+
+  it('the expectation table covers every declared surface (no orphan label)', () => {
+    // A surface value with no call site would be a series that can never be
+    // emitted — an alert keyed on it would then be structurally silent, which is
+    // the exact failure class this counter exists to avoid.
+    expect([...new Set(Object.values(EXPECTED_SURFACE_BY_FILE))].sort()).toEqual(
+      [...GENERATION_SURFACES].sort()
+    );
+  });
+});

--- a/src/server/services/orchestrator/__tests__/orchestration-new.getGenerationStatus.sysredis-soft.test.ts
+++ b/src/server/services/orchestrator/__tests__/orchestration-new.getGenerationStatus.sysredis-soft.test.ts
@@ -79,7 +79,7 @@ describe('buildGenerationContext → local getGenerationStatus — sysRedis soft
   it('happy path: reads status through withSysReadDeadline, resolves, no fail-open', async () => {
     mockHGet.mockResolvedValue(JSON.stringify({ available: true }));
 
-    const result = await buildGenerationContext('free', {}, {});
+    const result = await buildGenerationContext('free', {}, {}, 'onsite');
 
     expect(result).toBeDefined();
     expect(mockWithSysReadDeadline).toHaveBeenCalledTimes(1);
@@ -89,7 +89,7 @@ describe('buildGenerationContext → local getGenerationStatus — sysRedis soft
   it('DOWN: hGet throws → local status fails open to defaults, resolves, logs defaults-firing', async () => {
     mockHGet.mockRejectedValue(new Error('sysRedis connection is down'));
 
-    const result = await buildGenerationContext('free', {}, {});
+    const result = await buildGenerationContext('free', {}, {}, 'onsite');
 
     expect(result).toBeDefined(); // did NOT throw
     expect(mockLogSysRedisFailOpen).toHaveBeenCalledTimes(1);
@@ -102,7 +102,7 @@ describe('buildGenerationContext → local getGenerationStatus — sysRedis soft
     mockHGet.mockReturnValue(new Promise(() => undefined));
     mockWithSysReadDeadline.mockRejectedValue(new Error('sysRedis read timed out after 2000ms'));
 
-    const result = await buildGenerationContext('free', {}, {});
+    const result = await buildGenerationContext('free', {}, {}, 'onsite');
 
     expect(result).toBeDefined();
     expect(mockWithSysReadDeadline).toHaveBeenCalledTimes(1);

--- a/src/server/services/orchestrator/__tests__/preset-image-gen.surface.test.ts
+++ b/src/server/services/orchestrator/__tests__/preset-image-gen.surface.test.ts
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockBuildGenerationContext = vi.fn();
+const mockGenerateFromGraph = vi.fn();
+const mockWhatIfFromGraph = vi.fn();
+
+vi.mock('~/server/services/orchestrator/orchestration-new.service', () => ({
+  buildGenerationContext: (...args: unknown[]) => mockBuildGenerationContext(...args),
+  generateFromGraph: (...args: unknown[]) => mockGenerateFromGraph(...args),
+  whatIfFromGraph: (...args: unknown[]) => mockWhatIfFromGraph(...args),
+}));
+
+import {
+  PRESET_MODEL_CONFIG,
+  submitPresetImageGen,
+  whatIfPresetImageGen,
+} from '../preset-image-gen.service';
+
+/**
+ * 🔴 BEHAVIOURAL proof that the preset generation surface labels ITSELF (issue
+ * #3520 fix 2), by actually calling the exported entry points and reading the
+ * argument that reaches `buildGenerationContext`.
+ *
+ * Why this matters: `civitai_generation_model_substitutions_total` is emitted
+ * from `validateInput`, which is shared by the on-site generator, the App Blocks
+ * bridge and this path, and which cannot tell them apart. Comics/preset volume
+ * summed into the App Blocks series would inflate the number that gates the
+ * phase-3 policy decision with a population that has nothing to do with it.
+ *
+ * The companion `generation-surface-wiring.test.ts` guards the POPULATION of call
+ * sites; this one proves the value actually flows on a real call.
+ */
+
+// Any real registry entry — the surface is a property of the CALL SITE, not of
+// the model, so which one is irrelevant as long as it is a genuine config.
+const modelConfig = Object.values(PRESET_MODEL_CONFIG)[0];
+const user = { id: 42, isModerator: false, tier: 'free' } as never;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockBuildGenerationContext.mockResolvedValue({ externalCtx: {}, status: { mode: 'enabled' } });
+  mockGenerateFromGraph.mockResolvedValue({ id: 'wf_1' });
+  mockWhatIfFromGraph.mockResolvedValue({ cost: { total: 10 }, ready: true });
+});
+
+describe('preset image generation declares the `preset` surface', () => {
+  it('submitPresetImageGen builds its context with surface `preset`', async () => {
+    await submitPresetImageGen({
+      prompt: 'a cat',
+      aspectRatio: '1:1',
+      modelConfig,
+      user,
+      token: 'tok',
+      currencies: [],
+      tags: ['comics'],
+    });
+
+    expect(mockBuildGenerationContext).toHaveBeenCalledTimes(1);
+    // 4th positional argument — asserted by INDEX, not by "contains", so a
+    // surface passed in the wrong slot fails instead of passing.
+    expect(mockBuildGenerationContext.mock.calls[0][3]).toBe('preset');
+    // …and not one of the other two, which is the failure this is really about.
+    expect(mockBuildGenerationContext.mock.calls[0][3]).not.toBe('block');
+    expect(mockBuildGenerationContext.mock.calls[0][3]).not.toBe('onsite');
+  });
+
+  it('whatIfPresetImageGen builds its context with surface `preset` too', async () => {
+    // The what-if is a SECOND graph validation for the same user action, so it
+    // increments the counter independently. If only the submit path were
+    // labelled, half of preset volume would land on whatever surface the default
+    // named.
+    await whatIfPresetImageGen({
+      prompt: 'a cat',
+      aspectRatio: '1:1',
+      modelConfig,
+      user,
+      token: 'tok',
+      currencies: [],
+    });
+
+    expect(mockBuildGenerationContext).toHaveBeenCalledTimes(1);
+    expect(mockBuildGenerationContext.mock.calls[0][3]).toBe('preset');
+  });
+});

--- a/src/server/services/orchestrator/orchestration-new.service.ts
+++ b/src/server/services/orchestrator/orchestration-new.service.ts
@@ -45,6 +45,9 @@ import {
   getSelfHostedDisabledEcosystems,
 } from '~/server/services/generation/generation.service';
 import { applicableRulesFor } from '~/shared/data-graph/generation/gates';
+import { emitModelSubstitutions } from '~/server/metrics/emit-model-substitutions';
+import { createModelSubstitutionCollector } from '~/shared/data-graph/generation/model-substitution';
+import { classifyModelSubstitutionReason } from '~/shared/data-graph/generation/workflow-capability';
 import type { GenerationResource } from '~/shared/types/generation.types';
 import {
   redis,
@@ -309,6 +312,15 @@ export async function buildGenerationContext(
         isMember: userTier !== 'free',
         hasTestingAccess: ecosystemConfig.hasTestingAccess,
       }),
+      // 🔴 PER-REQUEST, and attached to THIS freshly-built object literal only
+      // (issue #3520). `status` / `ecosystemConfig` / `gateRules` above are
+      // awaited from process- and redis-level CACHES; hanging a mutable
+      // collector off anything reachable through them would accumulate
+      // substitutions across users and leak one caller's requested model id into
+      // another caller's snapshot. This function returns a brand-new object on
+      // every call with no memoization, so the collector's lifetime is exactly
+      // one request.
+      modelSubstitutions: createModelSubstitutionCollector(classifyModelSubstitutionReason),
     },
     status: {
       mode: status.mode,
@@ -531,6 +543,18 @@ function normalizeInput(input: Record<string, unknown>): Record<string, unknown>
  */
 function validateInput(input: Record<string, unknown>, externalCtx: GenerationCtx) {
   const result = generationGraph.safeParse(normalizeInput(input), externalCtx);
+
+  // Issue #3520 — count silent checkpoint substitutions. This is the single
+  // choke point every SERVER-side graph validation passes through (submit,
+  // whatIf, and the App Blocks bridge), so one emit here covers all of them.
+  // Runs regardless of `result.success`: a parse that substituted and THEN
+  // failed on some other node still substituted, and dropping those would bias
+  // the number toward "this never happens".
+  //
+  // `void` is safe by contract — `emitModelSubstitutions` resolves on every
+  // path and never rejects (see its module note). It is deliberately NOT
+  // awaited: this function is synchronous and on the submit path.
+  void emitModelSubstitutions(externalCtx.modelSubstitutions);
 
   if (!result.success) {
     const errorMessages = Object.entries(result.errors)

--- a/src/server/services/orchestrator/orchestration-new.service.ts
+++ b/src/server/services/orchestrator/orchestration-new.service.ts
@@ -46,7 +46,10 @@ import {
 } from '~/server/services/generation/generation.service';
 import { applicableRulesFor } from '~/shared/data-graph/generation/gates';
 import { emitModelSubstitutions } from '~/server/metrics/emit-model-substitutions';
-import { createModelSubstitutionCollector } from '~/shared/data-graph/generation/model-substitution';
+import {
+  createModelSubstitutionCollector,
+  type GenerationSurface,
+} from '~/shared/data-graph/generation/model-substitution';
 import { classifyModelSubstitutionReason } from '~/shared/data-graph/generation/workflow-capability';
 import type { GenerationResource } from '~/shared/types/generation.types';
 import {
@@ -269,12 +272,22 @@ async function getGenerationStatus(): Promise<GenerationStatus> {
  * @param userTier - The user's subscription tier
  * @param flags - Feature access flags
  * @param user - User info used to resolve mod-only / testing gating
+ * @param surface - 🔴 REQUIRED, and deliberately not defaulted (issue #3520).
+ *   Which caller is validating: `onsite` (the on-site generator), `block` (the
+ *   App Blocks bridge) or `preset` (comics / preset generation). It becomes the
+ *   `surface` label on `civitai_generation_model_substitutions_total`, and the
+ *   split is load-bearing: #3520 calls the substitution CORRECT on-site and
+ *   unobservable through the bridge, so one un-split series measures a
+ *   contaminated quantity. Required (not optional-with-a-default) so a NEW
+ *   generation entry point is a compile error here rather than silent
+ *   misattribution to whichever surface the default happened to name.
  * @returns GenerationCtx with limits, user info, and gated IDs, plus status for availability checks
  */
 export async function buildGenerationContext(
   userTier: GenerationCtx['user']['tier'] = 'free',
-  flags?: Partial<FeatureAccess>,
-  user?: { id?: number; isModerator?: boolean }
+  flags: Partial<FeatureAccess> | undefined,
+  user: { id?: number; isModerator?: boolean } | undefined,
+  surface: GenerationSurface
 ): Promise<GenerationContextResult> {
   const [status, ecosystemConfig, gateRules] = await Promise.all([
     getGenerationStatus(),
@@ -319,8 +332,13 @@ export async function buildGenerationContext(
       // substitutions across users and leak one caller's requested model id into
       // another caller's snapshot. This function returns a brand-new object on
       // every call with no memoization, so the collector's lifetime is exactly
-      // one request.
-      modelSubstitutions: createModelSubstitutionCollector(classifyModelSubstitutionReason),
+      // one request. The `surface` rides on the collector because `validateInput`
+      // (where the metric is emitted) is shared by every surface and cannot tell
+      // them apart.
+      modelSubstitutions: createModelSubstitutionCollector(
+        classifyModelSubstitutionReason,
+        surface
+      ),
     },
     status: {
       mode: status.mode,

--- a/src/server/services/orchestrator/preset-image-gen.service.ts
+++ b/src/server/services/orchestrator/preset-image-gen.service.ts
@@ -281,10 +281,16 @@ export async function submitPresetImageGen({
     versionId,
   });
 
-  const { externalCtx } = await buildGenerationContext(user.tier ?? 'free', flags, {
-    id: user.id,
-    isModerator: user.isModerator,
-  });
+  const { externalCtx } = await buildGenerationContext(
+    user.tier ?? 'free',
+    flags,
+    { id: user.id, isModerator: user.isModerator },
+    // #3520: comics / preset generation composes the graph input SERVER-side, so
+    // a substitution here is a config/preset-registry problem, not an app-author
+    // or a stale-localStorage one. Its own `surface` keeps it out of both the
+    // on-site and the App Blocks numbers.
+    'preset'
+  );
 
   return generateFromGraph({
     input,
@@ -329,10 +335,16 @@ export async function whatIfPresetImageGen({
     versionId,
   });
 
-  const { externalCtx } = await buildGenerationContext(user.tier ?? 'free', flags, {
-    id: user.id,
-    isModerator: user.isModerator,
-  });
+  const { externalCtx } = await buildGenerationContext(
+    user.tier ?? 'free',
+    flags,
+    { id: user.id, isModerator: user.isModerator },
+    // #3520: comics / preset generation composes the graph input SERVER-side, so
+    // a substitution here is a config/preset-registry problem, not an app-author
+    // or a stale-localStorage one. Its own `surface` keeps it out of both the
+    // on-site and the App Blocks numbers.
+    'preset'
+  );
 
   const result = await whatIfFromGraph({
     input,

--- a/src/shared/data-graph/generation/common.ts
+++ b/src/shared/data-graph/generation/common.ts
@@ -978,6 +978,24 @@ export function createCheckpointGraph(
             // Valid version options are allowed through for ecosystems with version selectors.
             if (modelLocked && modelVersionId && val.id !== modelVersionId) {
               if (!validVersionIds?.has(val.id)) {
+                // 🔴 OBSERVE ONLY — issue #3520 phase 1. The substitution below is
+                // deliberate graceful degradation and is UNCHANGED; this records
+                // that it happened so a caller who is billed for model A and given
+                // model B can find that out. On-site the correction is visible (the
+                // picker snaps); through the App Blocks bridge the id is deliberate
+                // and the correction is invisible — same code, same behaviour,
+                // observable in one context and not the other.
+                //
+                // The collector is present only on server-built contexts, and
+                // `record` is write-once + never-throwing, so the client pays
+                // nothing and a metrics/classifier fault cannot fail a parse that
+                // would otherwise have succeeded.
+                ext.modelSubstitutions?.record({
+                  requested: val.id,
+                  applied: modelVersionId,
+                  ecosystem: ctx.ecosystem,
+                  workflow: ctx.workflow,
+                });
                 return { id: modelVersionId, model: { type: 'Checkpoint' } };
               }
             }

--- a/src/shared/data-graph/generation/context.ts
+++ b/src/shared/data-graph/generation/context.ts
@@ -1,5 +1,6 @@
 import type { FeatureAccess } from '~/server/services/feature-flags.service';
 import type { GateRule } from './gates';
+import type { ModelSubstitutionCollector } from './model-substitution';
 
 export type GenerationCtx = {
   /** User's generation limits based on their tier */
@@ -41,4 +42,15 @@ export type GenerationCtx = {
    * resolver drives hide/disable/upsell on both client and server.
    */
   gateRules?: GateRule[];
+  /**
+   * Per-REQUEST side channel recording silent checkpoint substitutions the
+   * `modelLocked` clamp performs (issue #3520). Purely observational — see
+   * `model-substitution.ts` for why the record cannot ride on the parsed value
+   * (the model node's output schema strips unknown keys) and why the collector
+   * must be attached to a freshly-built context object.
+   *
+   * ABSENT on the client: only the server's `buildGenerationContext` attaches
+   * one, so an in-form parse in the browser records nothing and pays nothing.
+   */
+  modelSubstitutions?: ModelSubstitutionCollector;
 };

--- a/src/shared/data-graph/generation/model-substitution.no-behaviour-change.test.ts
+++ b/src/shared/data-graph/generation/model-substitution.no-behaviour-change.test.ts
@@ -1,0 +1,210 @@
+import { describe, expect, it } from 'vitest';
+
+import { ecosystems } from '~/shared/constants/basemodel.constants';
+import { generationGraph } from './generation-graph';
+import type { GenerationCtx } from './context';
+import {
+  createModelSubstitutionCollector,
+  type ModelSubstitutionClassifier,
+} from './model-substitution';
+import { classifyModelSubstitutionReason, getWorkflowCapability } from './workflow-capability';
+import { getWorkflowsForEcosystem } from './config/workflows';
+
+/**
+ * 🔴 THE HARD CONSTRAINT OF #3520 PHASE 1, CHECKED OVER THE WHOLE POPULATION.
+ *
+ * Phase 1 is RECORD-ONLY: which model runs, whether the parse succeeds, and what
+ * it returns must be byte-identical to a run with no collector attached — because
+ * a context with no `modelSubstitutions` field IS the pre-change shape, so
+ * "without" is a direct before/after comparison rather than a proxy for one.
+ *
+ * The companion tests in `model-substitution.test.ts` check FOUR hand-picked
+ * Qwen cases and only the resulting `model.id`. This file exists because that is
+ * a sample and a projection: it can neither see a perturbation on some other
+ * ecosystem, nor one on a field other than the model id (a changed error set, a
+ * dropped computed key, a different `success`). So this compares the FULL parse
+ * result — serialized, in full — across EVERY (ecosystem, workflow) pair the
+ * config offers.
+ *
+ * Two adversarial conditions are covered:
+ *
+ *   1. The real classifier, over every pair. This is the ordinary path.
+ *   2. A classifier that THROWS ON EVERY CALL, over every modelLocked pair. The
+ *      collector swallows classifier faults by contract; this proves the swallow
+ *      also leaves the PARSE untouched, i.e. that a broken observability
+ *      dependency cannot change a generation. (It is also the condition under
+ *      which the write-once `seen` bookkeeping is most likely to diverge —
+ *      nothing is ever recorded, so every clamp hit re-attempts.)
+ *
+ * COST: ~4 parses per pair. The whole file runs in a couple of seconds.
+ */
+
+function baseCtx(): GenerationCtx {
+  return {
+    limits: { maxQuantity: 4, maxResources: 10, vidQuantity: 1 },
+    user: { isMember: false, tier: 'free' },
+    flags: {},
+    selfHostedDisabledEcosystems: [],
+    selfHostedMode: 'enabled',
+    gateRules: [],
+  };
+}
+
+/** An id no ecosystem has ever heard of — forces the clamp on every locked pair. */
+const UNRECOGNIZED_ID = 987654321;
+
+/**
+ * Serialize the ENTIRE parse result, not just `data.model.id`. `JSON.stringify`
+ * with sorted keys so a key-ordering difference cannot masquerade as a value
+ * difference (or hide one). `undefined` is stringified explicitly so a field
+ * that disappears is not silently equal to one that was never there.
+ */
+function serializeResult(value: unknown): string {
+  const seen = new WeakSet<object>();
+  const normalize = (v: unknown): unknown => {
+    if (v === undefined) return '__undefined__';
+    if (v === null || typeof v !== 'object') {
+      return typeof v === 'function' ? '__function__' : v;
+    }
+    if (seen.has(v as object)) return '__circular__';
+    seen.add(v as object);
+    if (Array.isArray(v)) return v.map(normalize);
+    if (v instanceof Error) return { __error__: v.message };
+    const out: Record<string, unknown> = {};
+    for (const key of Object.keys(v as Record<string, unknown>).sort()) {
+      out[key] = normalize((v as Record<string, unknown>)[key]);
+    }
+    return out;
+  };
+  return JSON.stringify(normalize(value));
+}
+
+function parseFull(input: Record<string, unknown>, ctx: GenerationCtx): string {
+  return serializeResult(generationGraph.safeParse(input as never, ctx));
+}
+
+function inputFor(ecosystem: string, workflow: string, modelVersionId: number) {
+  return {
+    workflow,
+    ecosystem,
+    model: { id: modelVersionId },
+    resources: [],
+    prompt: 'a cat',
+    sampler: 'Euler',
+    steps: 25,
+    quantity: 1,
+    priority: 'low' as const,
+  };
+}
+
+type Pair = { ecosystem: string; workflow: string; locked: boolean; defaultModelId?: number };
+
+const ALL_PAIRS: Pair[] = [];
+for (const eco of ecosystems) {
+  for (const option of getWorkflowsForEcosystem(eco.id)) {
+    const cap = getWorkflowCapability(eco.key, option.graphKey);
+    ALL_PAIRS.push({
+      ecosystem: eco.key,
+      workflow: option.graphKey,
+      locked: !!cap?.modelLocked && !!cap?.defaultModelId,
+      defaultModelId: cap?.defaultModelId,
+    });
+  }
+}
+const LOCKED_PAIRS = ALL_PAIRS.filter((p) => p.locked);
+
+/** The probe ids each pair is exercised with. */
+function probeIdsFor(pair: Pair): number[] {
+  // The unrecognized id forces the clamp everywhere it can fire; the pair's own
+  // default is the pass-through control (no substitution → the collector must
+  // still be inert).
+  return pair.defaultModelId ? [UNRECOGNIZED_ID, pair.defaultModelId] : [UNRECOGNIZED_ID];
+}
+
+const THROWING_CLASSIFIER: ModelSubstitutionClassifier = () => {
+  throw new Error('classifier is down');
+};
+
+describe('#3520 phase 1 changes NO behaviour, over the FULL (ecosystem, workflow) population', () => {
+  it('the population is non-empty and contains locked pairs (guard the guard)', () => {
+    // Without this, every sweep below would pass vacuously over an empty list —
+    // and a "zero diffs" result would mean nothing was compared.
+    expect(ALL_PAIRS.length).toBeGreaterThanOrEqual(100);
+    expect(LOCKED_PAIRS.length).toBeGreaterThanOrEqual(23);
+  });
+
+  it('the FULL parse result is identical with and without a collector, on every pair', () => {
+    const diffs: string[] = [];
+    let compared = 0;
+    for (const pair of ALL_PAIRS) {
+      for (const id of probeIdsFor(pair)) {
+        const input = inputFor(pair.ecosystem, pair.workflow, id);
+        const withCollector = parseFull(input, {
+          ...baseCtx(),
+          modelSubstitutions: createModelSubstitutionCollector(
+            classifyModelSubstitutionReason,
+            'block'
+          ),
+        });
+        // No `modelSubstitutions` field at all == the pre-change context shape.
+        const without = parseFull(input, baseCtx());
+        compared += 1;
+        if (withCollector !== without) {
+          diffs.push(`${pair.ecosystem}/${pair.workflow}#${id}`);
+        }
+      }
+    }
+    expect(compared).toBeGreaterThanOrEqual(ALL_PAIRS.length);
+    expect(diffs).toEqual([]);
+  });
+
+  it('…and identical with a classifier that THROWS on every call, on every locked pair', () => {
+    const diffs: string[] = [];
+    let compared = 0;
+    for (const pair of LOCKED_PAIRS) {
+      for (const id of probeIdsFor(pair)) {
+        const input = inputFor(pair.ecosystem, pair.workflow, id);
+        const collector = createModelSubstitutionCollector(THROWING_CLASSIFIER, 'block');
+        const withBroken = parseFull(input, { ...baseCtx(), modelSubstitutions: collector });
+        const without = parseFull(input, baseCtx());
+        compared += 1;
+        if (withBroken !== without) diffs.push(`${pair.ecosystem}/${pair.workflow}#${id}`);
+        // The throw really was swallowed, and nothing was recorded.
+        expect(collector.list()).toEqual([]);
+      }
+    }
+    expect(compared).toBeGreaterThanOrEqual(LOCKED_PAIRS.length);
+    expect(diffs).toEqual([]);
+  });
+
+  it('…and identical with a classifier that returns a BOGUS reason', () => {
+    // The runtime narrowing drops such a record. That drop must also be inert
+    // with respect to the parse.
+    const diffs: string[] = [];
+    for (const pair of LOCKED_PAIRS) {
+      const input = inputFor(pair.ecosystem, pair.workflow, UNRECOGNIZED_ID);
+      const collector = createModelSubstitutionCollector(
+        (() => undefined) as unknown as ModelSubstitutionClassifier,
+        'block'
+      );
+      const withBogus = parseFull(input, { ...baseCtx(), modelSubstitutions: collector });
+      const without = parseFull(input, baseCtx());
+      if (withBogus !== without) diffs.push(`${pair.ecosystem}/${pair.workflow}`);
+      expect(collector.list()).toEqual([]);
+    }
+    expect(diffs).toEqual([]);
+  });
+
+  it('the comparison can actually SEE a difference (negative control)', () => {
+    // 🔴 A "zero diffs" result is worthless if the comparator is blind. Two
+    // parses that genuinely differ must compare unequal, or every sweep above is
+    // a green light from an instrument that reads zero no matter what.
+    const locked = LOCKED_PAIRS[0];
+    const a = parseFull(inputFor(locked.ecosystem, locked.workflow, UNRECOGNIZED_ID), baseCtx());
+    const b = parseFull(
+      { ...inputFor(locked.ecosystem, locked.workflow, UNRECOGNIZED_ID), prompt: 'a dog' },
+      baseCtx()
+    );
+    expect(a).not.toEqual(b);
+  });
+});

--- a/src/shared/data-graph/generation/model-substitution.test.ts
+++ b/src/shared/data-graph/generation/model-substitution.test.ts
@@ -6,6 +6,10 @@ import type { GenerationCtx } from './context';
 import type { GateRule } from './gates';
 import {
   createModelSubstitutionCollector,
+  GENERATION_SURFACES,
+  isGenerationSurface,
+  isModelSubstitutionReason,
+  MODEL_SUBSTITUTION_REASONS,
   type ModelSubstitution,
   type ModelSubstitutionCollector,
 } from './model-substitution';
@@ -51,7 +55,7 @@ function ctxWithCollector(overrides?: Partial<GenerationCtx>): {
   ctx: GenerationCtx;
   collector: ModelSubstitutionCollector;
 } {
-  const collector = createModelSubstitutionCollector(classifyModelSubstitutionReason);
+  const collector = createModelSubstitutionCollector(classifyModelSubstitutionReason, 'block');
   return { ctx: { ...baseCtx(overrides), modelSubstitutions: collector }, collector };
 }
 
@@ -342,7 +346,7 @@ describe('createModelSubstitutionCollector', () => {
 
   it('classifies via the injected classifier', () => {
     const classify = vi.fn().mockReturnValue('unrecognized' as const);
-    const collector = createModelSubstitutionCollector(classify);
+    const collector = createModelSubstitutionCollector(classify, 'block');
     collector.record(event);
     expect(classify).toHaveBeenCalledWith(event);
     expect(collector.list()).toEqual([{ ...event, reason: 'unrecognized' }]);
@@ -351,23 +355,130 @@ describe('createModelSubstitutionCollector', () => {
   it('SWALLOWS a throwing classifier — observability must not break a parse', () => {
     const collector = createModelSubstitutionCollector(() => {
       throw new Error('boom');
-    });
+    }, 'block');
     expect(() => collector.record(event)).not.toThrow();
     expect(collector.list()).toEqual([]);
   });
 
   it('list() returns a copy — a caller cannot mutate the collector', () => {
-    const collector = createModelSubstitutionCollector(() => 'unrecognized');
+    const collector = createModelSubstitutionCollector(() => 'unrecognized', 'block');
     collector.record(event);
     collector.list().push({ ...event, reason: 'gated' });
     expect(collector.list()).toHaveLength(1);
   });
 
   it('two collectors do not share state (per-request isolation)', () => {
-    const a = createModelSubstitutionCollector(() => 'unrecognized');
-    const b = createModelSubstitutionCollector(() => 'unrecognized');
+    const a = createModelSubstitutionCollector(() => 'unrecognized', 'block');
+    const b = createModelSubstitutionCollector(() => 'unrecognized', 'onsite');
     a.record(event);
     expect(b.list()).toEqual([]);
+  });
+
+  it('carries the SURFACE it was constructed with', () => {
+    // The surface is fixed by whoever built the request context; `validateInput`
+    // (where the metric is emitted) is shared by every surface and cannot infer
+    // it. Pinning it here is what makes the emitter's label attributable.
+    expect(createModelSubstitutionCollector(() => 'unrecognized', 'block').surface).toBe('block');
+    expect(createModelSubstitutionCollector(() => 'unrecognized', 'onsite').surface).toBe('onsite');
+    expect(createModelSubstitutionCollector(() => 'unrecognized', 'preset').surface).toBe('preset');
+  });
+
+  // ── 🔴 a classifier that THROWS must not permanently drop the key ──────────
+  //
+  // `seen` is the write-once dedupe. Marking the key BEFORE calling `classify`
+  // meant a classifier that threw on its first call lost that substitution for
+  // the entire request: the throw was swallowed, nothing was pushed, and every
+  // later attempt short-circuited on `seen.has(key)`. Harmless with today's pure
+  // classifier — and exactly the kind of "only under a fault" data loss that is
+  // invisible until the fault happens.
+  it('a classifier that throws ONCE does not permanently drop the key', () => {
+    let calls = 0;
+    const collector = createModelSubstitutionCollector(() => {
+      calls += 1;
+      if (calls === 1) throw new Error('boom');
+      return 'unrecognized';
+    }, 'block');
+
+    collector.record(event);
+    expect(collector.list()).toEqual([]); // the throw was swallowed
+
+    // Same key again — must be RE-ATTEMPTED, not short-circuited by `seen`.
+    collector.record(event);
+    expect(calls).toBe(2);
+    expect(collector.list()).toEqual([{ ...event, reason: 'unrecognized' }]);
+  });
+
+  it('an always-throwing classifier still leaves the key retryable', () => {
+    let calls = 0;
+    const collector = createModelSubstitutionCollector(() => {
+      calls += 1;
+      throw new Error('boom');
+    }, 'block');
+    collector.record(event);
+    collector.record(event);
+    expect(calls).toBe(2);
+    expect(collector.list()).toEqual([]);
+  });
+
+  // ── 🔴 a bogus classifier return cannot reach the wire or the metric ───────
+  //
+  // `ModelSubstitutionReason` is erased at runtime, so the "3 values forever"
+  // guarantee has to be enforced in code. A classifier returning `undefined` (a
+  // refactor that forgets a branch, a stub, a `.js` caller) would otherwise put
+  // `reason: undefined` on the public snapshot AND into `inc({ reason })`, which
+  // is how a bounded label set stops being bounded.
+  it.each([
+    ['undefined', undefined],
+    ['null', null],
+    ['an unknown string', 'not-a-reason'],
+    ['a number', 7],
+    ['an object', { reason: 'unrecognized' }],
+  ])('DROPS a classifier return that is %s', (_label, bogus) => {
+    const collector = createModelSubstitutionCollector(
+      () => bogus as never as (typeof MODEL_SUBSTITUTION_REASONS)[number],
+      'block'
+    );
+    collector.record(event);
+    expect(collector.list()).toEqual([]);
+    expect(collector.takeUnemitted()).toEqual([]);
+  });
+
+  it('records every reason the code-owned union declares (guard the guard)', () => {
+    // Without this, the drop-test above would also pass if `record` dropped
+    // EVERYTHING — a guard that rejects the whole population is not a guard.
+    for (const reason of MODEL_SUBSTITUTION_REASONS) {
+      const collector = createModelSubstitutionCollector(() => reason, 'block');
+      collector.record(event);
+      expect(collector.list()).toEqual([{ ...event, reason }]);
+    }
+  });
+});
+
+describe('runtime narrowing helpers', () => {
+  it('isModelSubstitutionReason accepts exactly the declared union', () => {
+    for (const reason of MODEL_SUBSTITUTION_REASONS) {
+      expect(isModelSubstitutionReason(reason)).toBe(true);
+    }
+    for (const bogus of [undefined, null, '', 'gated ', 'GATED', 7, {}, []]) {
+      expect(isModelSubstitutionReason(bogus)).toBe(false);
+    }
+  });
+
+  it('isGenerationSurface accepts exactly the declared union', () => {
+    for (const surface of GENERATION_SURFACES) {
+      expect(isGenerationSurface(surface)).toBe(true);
+    }
+    for (const bogus of [undefined, null, '', 'blocks', 'Onsite', 7, {}, []]) {
+      expect(isGenerationSurface(bogus)).toBe(false);
+    }
+  });
+
+  it('the surface union is exactly the three wired call sites', () => {
+    // 3 reasons x 3 surfaces = 9 series. Adding a value here is a deliberate,
+    // reviewable widening of the counter's cardinality, so it has to fail a test
+    // rather than land silently.
+    expect([...GENERATION_SURFACES]).toEqual(['block', 'onsite', 'preset']);
+    expect([...MODEL_SUBSTITUTION_REASONS]).toEqual(['wrong-workflow', 'unrecognized', 'gated']);
   });
 });
 

--- a/src/shared/data-graph/generation/model-substitution.test.ts
+++ b/src/shared/data-graph/generation/model-substitution.test.ts
@@ -1,0 +1,401 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { ecosystems } from '~/shared/constants/basemodel.constants';
+import { generationGraph } from './generation-graph';
+import type { GenerationCtx } from './context';
+import type { GateRule } from './gates';
+import {
+  createModelSubstitutionCollector,
+  type ModelSubstitution,
+  type ModelSubstitutionCollector,
+} from './model-substitution';
+import {
+  classifyModelSubstitutionReason,
+  getWorkflowCapability,
+  type WorkflowCapability,
+} from './workflow-capability';
+import { getWorkflowsForEcosystem } from './config/workflows';
+
+/**
+ * Silent checkpoint substitution — OBSERVABILITY, not behaviour (issue #3520,
+ * phase 1).
+ *
+ * These tests drive the REAL `generationGraph.safeParse` (the exact validator
+ * `validateInput` runs server-side) — nothing about the clamp, the classifier,
+ * or the graph is mocked. Two things are being pinned:
+ *
+ *   1. The recording branch is REACHABLE and produces the right reason. A metric
+ *      in a structurally unreachable branch is worse than none, so every reason
+ *      is proven from a real parse rather than by calling the classifier alone.
+ *   2. BEHAVIOUR IS UNCHANGED. Every substitution case asserts the model id the
+ *      graph returns is byte-identical with and without a collector attached.
+ *      Phase 1 must not alter which model runs.
+ */
+
+// A free user's server-shaped generation context, minus the collector. Same
+// shape `buildGenerationContext` produces; hand-built so the test stays off
+// sysRedis/DB.
+function baseCtx(overrides?: Partial<GenerationCtx>): GenerationCtx {
+  return {
+    limits: { maxQuantity: 4, maxResources: 10, vidQuantity: 1 },
+    user: { isMember: false, tier: 'free' },
+    flags: {},
+    selfHostedDisabledEcosystems: [],
+    selfHostedMode: 'enabled',
+    gateRules: [],
+    ...overrides,
+  };
+}
+
+function ctxWithCollector(overrides?: Partial<GenerationCtx>): {
+  ctx: GenerationCtx;
+  collector: ModelSubstitutionCollector;
+} {
+  const collector = createModelSubstitutionCollector(classifyModelSubstitutionReason);
+  return { ctx: { ...baseCtx(overrides), modelSubstitutions: collector }, collector };
+}
+
+function txt2imgInput(ecosystem: string, modelVersionId: number): Record<string, unknown> {
+  return {
+    workflow: 'txt2img',
+    ecosystem,
+    model: { id: modelVersionId },
+    resources: [],
+    prompt: 'a cat',
+    sampler: 'Euler',
+    steps: 25,
+    quantity: 1,
+    priority: 'low',
+  };
+}
+
+/**
+ * Run the REAL validator and read back the model id it settled on. `as never` on
+ * the input mirrors every other graph test in the repo — `safeParse` is typed
+ * against the per-ecosystem discriminated union, and these inputs are built
+ * dynamically from the config rather than as narrowable literals.
+ */
+function parse(
+  input: Record<string, unknown>,
+  ctx: GenerationCtx
+): { success: boolean; modelId: number | undefined } {
+  const result = generationGraph.safeParse(input as never, ctx) as {
+    success: boolean;
+    data?: { model?: { id?: number } };
+  };
+  return { success: result.success, modelId: result.data?.model?.id };
+}
+
+// ── the reproduction from the issue's executed evidence table ────────────────
+//
+// Qwen is `modelLocked` with DISJOINT workflow-scoped version lists: 2558804 is
+// an `img2img:edit` version, 2552908 is the `txt2img` default. Both ids are
+// re-derived from the real config below so a config change fails loudly here
+// rather than silently making these tests assert about ids that no longer exist.
+const QWEN_TXT2IMG = getWorkflowCapability('Qwen', 'txt2img');
+const QWEN_EDIT = getWorkflowCapability('Qwen', 'img2img:edit');
+
+function versionIdsOf(cap: WorkflowCapability | undefined): number[] {
+  const out: number[] = [];
+  const walk = (group: NonNullable<WorkflowCapability['versions']>) => {
+    for (const opt of group.options) {
+      out.push(opt.value);
+      if (opt.children) walk(opt.children);
+    }
+  };
+  if (cap?.versions) walk(cap.versions);
+  return out;
+}
+
+describe('Qwen fixtures are still what these tests assume', () => {
+  it('Qwen/txt2img is modelLocked with a default, and Qwen/img2img:edit has a disjoint version', () => {
+    expect(QWEN_TXT2IMG?.modelLocked).toBe(true);
+    expect(typeof QWEN_TXT2IMG?.defaultModelId).toBe('number');
+    const txt2imgIds = versionIdsOf(QWEN_TXT2IMG);
+    const editOnly = versionIdsOf(QWEN_EDIT).filter((id) => !txt2imgIds.includes(id));
+    expect(editOnly.length).toBeGreaterThan(0);
+  });
+});
+
+const QWEN_DEFAULT = QWEN_TXT2IMG?.defaultModelId as number;
+const QWEN_EDIT_ONLY = versionIdsOf(QWEN_EDIT).filter(
+  (id) => !versionIdsOf(QWEN_TXT2IMG).includes(id)
+)[0];
+const QWEN_TXT2IMG_ALT = versionIdsOf(QWEN_TXT2IMG).filter((id) => id !== QWEN_DEFAULT)[0];
+/** An id no ecosystem has ever heard of — the issue's `unrecognized` probe. */
+const UNRECOGNIZED_ID = 987654321;
+
+describe('records a silent substitution on the REAL graph path', () => {
+  it("reason 'wrong-workflow' — an edit-only version sent to txt2img", () => {
+    const { ctx, collector } = ctxWithCollector();
+    const result = parse(txt2imgInput('Qwen', QWEN_EDIT_ONLY), ctx);
+
+    expect(result.success).toBe(true);
+    expect(result.modelId).toBe(QWEN_DEFAULT);
+    expect(collector.list()).toEqual<ModelSubstitution[]>([
+      {
+        requested: QWEN_EDIT_ONLY,
+        applied: QWEN_DEFAULT,
+        reason: 'wrong-workflow',
+        ecosystem: 'Qwen',
+        workflow: 'txt2img',
+      },
+    ]);
+  });
+
+  it("reason 'unrecognized' — an id in no scoped list at all", () => {
+    const { ctx, collector } = ctxWithCollector();
+    const result = parse(txt2imgInput('Qwen', UNRECOGNIZED_ID), ctx);
+
+    expect(result.success).toBe(true);
+    expect(result.modelId).toBe(QWEN_DEFAULT);
+    expect(collector.list()).toEqual<ModelSubstitution[]>([
+      {
+        requested: UNRECOGNIZED_ID,
+        applied: QWEN_DEFAULT,
+        reason: 'unrecognized',
+        ecosystem: 'Qwen',
+        workflow: 'txt2img',
+      },
+    ]);
+  });
+
+  it("reason 'gated' — the version IS offered for this workflow but a gate rule hides it", () => {
+    // The clamp compares against the GATE-FILTERED visible list, so a rule that
+    // hides an otherwise-valid txt2img version makes the clamp fire on an id the
+    // config itself considers supported. That is neither of the two reasons the
+    // issue names, and folding it into `unrecognized` would report an
+    // entitlement decision as a retired model.
+    const rule: GateRule = {
+      id: 'test-gate',
+      name: 'test',
+      availableTo: 'moderators',
+      presentation: 'hidden',
+      ecosystems: [],
+      workflows: [],
+      modelVersionIds: [QWEN_TXT2IMG_ALT],
+    };
+    const { ctx, collector } = ctxWithCollector({ gateRules: [rule] });
+    const result = parse(txt2imgInput('Qwen', QWEN_TXT2IMG_ALT), ctx);
+
+    expect(result.success).toBe(true);
+    expect(result.modelId).toBe(QWEN_DEFAULT);
+    expect(collector.list()).toEqual<ModelSubstitution[]>([
+      {
+        requested: QWEN_TXT2IMG_ALT,
+        applied: QWEN_DEFAULT,
+        reason: 'gated',
+        ecosystem: 'Qwen',
+        workflow: 'txt2img',
+      },
+    ]);
+  });
+
+  // ── pass-through: no substitution, no record ──────────────────────────────
+  it('records NOTHING when the requested version IS in the workflow list', () => {
+    const { ctx, collector } = ctxWithCollector();
+    const result = parse(txt2imgInput('Qwen', QWEN_TXT2IMG_ALT), ctx);
+
+    expect(result.success).toBe(true);
+    expect(result.modelId).toBe(QWEN_TXT2IMG_ALT);
+    expect(collector.list()).toEqual([]);
+  });
+
+  it('records NOTHING when the requested version IS the workflow default', () => {
+    const { ctx, collector } = ctxWithCollector();
+    const result = parse(txt2imgInput('Qwen', QWEN_DEFAULT), ctx);
+
+    expect(result.success).toBe(true);
+    expect(result.modelId).toBe(QWEN_DEFAULT);
+    expect(collector.list()).toEqual([]);
+  });
+
+  it('records NOTHING on a non-modelLocked ecosystem (the id passes through)', () => {
+    const { ctx, collector } = ctxWithCollector();
+    const result = parse(txt2imgInput('SDXL', UNRECOGNIZED_ID), ctx);
+
+    expect(result.modelId).toBe(UNRECOGNIZED_ID);
+    expect(collector.list()).toEqual([]);
+  });
+});
+
+// ── 🔴 NO BEHAVIOUR CHANGE ──────────────────────────────────────────────────
+//
+// The headline risk of this PR is that observing the clamp perturbs it. Parse
+// each case twice — once with a collector on the context, once without — and
+// require the returned model id to be identical. The `without` run is exactly
+// what `origin/main` does (a context with no `modelSubstitutions` field is the
+// pre-change shape), so this is a direct before/after comparison.
+describe('behaviour is unchanged by the recording', () => {
+  it.each([
+    ['wrong-workflow input', () => QWEN_EDIT_ONLY],
+    ['unrecognized input', () => UNRECOGNIZED_ID],
+    ['in-list input', () => QWEN_TXT2IMG_ALT],
+    ['default input', () => QWEN_DEFAULT],
+  ])('returns the same model id with and without a collector: %s', (_label, id) => {
+    const withCollector = parse(txt2imgInput('Qwen', id()), ctxWithCollector().ctx);
+    const without = parse(txt2imgInput('Qwen', id()), baseCtx());
+
+    expect(without.success).toBe(withCollector.success);
+    expect(withCollector.modelId).toBe(without.modelId);
+    // Guard the guard: an `undefined === undefined` comparison would pass
+    // vacuously if the parse stopped producing a model at all.
+    expect(typeof without.modelId).toBe('number');
+  });
+});
+
+// ── 🔴 IDEMPOTENCY ──────────────────────────────────────────────────────────
+//
+// A zod `.transform()` is not contractually single-shot, and a naive `push`
+// would inflate the metric on any re-parse. MEASURED on the real path: the clamp
+// runs EXACTLY ONCE per `generationGraph.safeParse` today (instrumented with a
+// counter inside the clamp — 1 hit per parse, for both the wrong-workflow and
+// unrecognized inputs). The dedupe is therefore the GUARANTEE, not the
+// observation: this test re-parses the same context and requires the record
+// count to stay at one, so a future zod/data-graph change that re-runs the
+// transform cannot silently double-count.
+describe('idempotency', () => {
+  it('two parses on the SAME context produce exactly ONE record', () => {
+    const { ctx, collector } = ctxWithCollector();
+    parse(txt2imgInput('Qwen', QWEN_EDIT_ONLY), ctx);
+    parse(txt2imgInput('Qwen', QWEN_EDIT_ONLY), ctx);
+    expect(collector.list()).toHaveLength(1);
+  });
+
+  it('a DIFFERENT requested id on the same context is a separate record', () => {
+    const { ctx, collector } = ctxWithCollector();
+    parse(txt2imgInput('Qwen', QWEN_EDIT_ONLY), ctx);
+    parse(txt2imgInput('Qwen', UNRECOGNIZED_ID), ctx);
+    expect(collector.list().map((r) => r.requested)).toEqual([QWEN_EDIT_ONLY, UNRECOGNIZED_ID]);
+  });
+
+  it('takeUnemitted hands each record out once, so a double drain cannot double-count', () => {
+    const { ctx, collector } = ctxWithCollector();
+    parse(txt2imgInput('Qwen', QWEN_EDIT_ONLY), ctx);
+    expect(collector.takeUnemitted()).toHaveLength(1);
+    expect(collector.takeUnemitted()).toEqual([]);
+    // …but `list()` is a read, not a drain — the snapshot still sees it.
+    expect(collector.list()).toHaveLength(1);
+  });
+});
+
+// ── 🔴 POPULATION: every modelLocked ecosystem reports ──────────────────────
+//
+// Derived from the real config at runtime (`getWorkflowCapability` reads the
+// `model` node meta the form itself renders), NOT from the list in the issue.
+// A NEW modelLocked ecosystem added later is picked up automatically and must
+// report its substitution — it cannot silently inherit the unobservable
+// behaviour this PR exists to close.
+describe('every modelLocked (ecosystem, workflow) pair records its substitution', () => {
+  const lockedPairs: Array<{ ecosystem: string; workflow: string; defaultModelId: number }> = [];
+  for (const eco of ecosystems) {
+    for (const option of getWorkflowsForEcosystem(eco.id)) {
+      const cap = getWorkflowCapability(eco.key, option.graphKey);
+      if (!cap?.modelLocked || !cap.defaultModelId) continue;
+      lockedPairs.push({
+        ecosystem: eco.key,
+        workflow: option.graphKey,
+        defaultModelId: cap.defaultModelId,
+      });
+    }
+  }
+
+  it('the enumeration is non-empty (guard the guard)', () => {
+    // Without this an empty sweep would make the per-pair assertion below pass
+    // vacuously.
+    //
+    // MEASURED at the time of writing: 89 (ecosystem, workflow) pairs across 43
+    // ecosystems. That is much wider than the ~23 IMAGE ecosystems the issue
+    // enumerates, because the enumeration here is derived from live config and
+    // covers video/audio ecosystems and per-workflow variants too — which is
+    // exactly the point of deriving it rather than transcribing the list. A
+    // FLOOR, not the exact count, so adding an ecosystem doesn't fail this line
+    // spuriously; the per-pair assertion below is what actually has to hold.
+    expect(lockedPairs.length).toBeGreaterThanOrEqual(23);
+  });
+
+  it('records a substitution for an unrecognized id on EVERY locked pair', () => {
+    const silent: string[] = [];
+    for (const pair of lockedPairs) {
+      const { ctx, collector } = ctxWithCollector();
+      // The parse may FAIL for unrelated reasons on some workflows (a missing
+      // source image, a video field, …). That is fine and deliberate: the clamp
+      // runs during input parsing regardless, and `validateInput` emits
+      // regardless of `result.success` — a parse that substituted and then
+      // failed elsewhere still substituted.
+      parse({ ...txt2imgInput(pair.ecosystem, UNRECOGNIZED_ID), workflow: pair.workflow }, ctx);
+      const records = collector.list();
+      const ok =
+        records.length === 1 &&
+        records[0].requested === UNRECOGNIZED_ID &&
+        records[0].applied === pair.defaultModelId &&
+        records[0].reason === 'unrecognized';
+      if (!ok) silent.push(`${pair.ecosystem}/${pair.workflow} -> ${JSON.stringify(records)}`);
+    }
+    expect(silent).toEqual([]);
+  });
+});
+
+// ── collector unit behaviour ────────────────────────────────────────────────
+describe('createModelSubstitutionCollector', () => {
+  const event = { requested: 1, applied: 2, ecosystem: 'Qwen', workflow: 'txt2img' };
+
+  it('classifies via the injected classifier', () => {
+    const classify = vi.fn().mockReturnValue('unrecognized' as const);
+    const collector = createModelSubstitutionCollector(classify);
+    collector.record(event);
+    expect(classify).toHaveBeenCalledWith(event);
+    expect(collector.list()).toEqual([{ ...event, reason: 'unrecognized' }]);
+  });
+
+  it('SWALLOWS a throwing classifier — observability must not break a parse', () => {
+    const collector = createModelSubstitutionCollector(() => {
+      throw new Error('boom');
+    });
+    expect(() => collector.record(event)).not.toThrow();
+    expect(collector.list()).toEqual([]);
+  });
+
+  it('list() returns a copy — a caller cannot mutate the collector', () => {
+    const collector = createModelSubstitutionCollector(() => 'unrecognized');
+    collector.record(event);
+    collector.list().push({ ...event, reason: 'gated' });
+    expect(collector.list()).toHaveLength(1);
+  });
+
+  it('two collectors do not share state (per-request isolation)', () => {
+    const a = createModelSubstitutionCollector(() => 'unrecognized');
+    const b = createModelSubstitutionCollector(() => 'unrecognized');
+    a.record(event);
+    expect(b.list()).toEqual([]);
+  });
+});
+
+// ── classifier ──────────────────────────────────────────────────────────────
+describe('classifyModelSubstitutionReason', () => {
+  it('reuses resolveVersionWorkflowScope in BOTH directions (not just txt2img)', () => {
+    // The reverse direction — a txt2img-only version sent WITH a source image —
+    // is the case the narrower `assertCheckpointVersionSupportsWorkflow` guard
+    // deliberately left open. The resolver was always direction-agnostic; this
+    // pins that the classifier uses it that way.
+    expect(
+      classifyModelSubstitutionReason({
+        requested: QWEN_DEFAULT,
+        applied: QWEN_EDIT_ONLY,
+        ecosystem: 'Qwen',
+        workflow: 'img2img:edit',
+      })
+    ).toBe('wrong-workflow');
+  });
+
+  it('falls back to unrecognized for an ecosystem key the config does not know', () => {
+    expect(
+      classifyModelSubstitutionReason({
+        requested: UNRECOGNIZED_ID,
+        applied: 1,
+        ecosystem: 'NotAnEcosystem',
+        workflow: 'txt2img',
+      })
+    ).toBe('unrecognized');
+  });
+});

--- a/src/shared/data-graph/generation/model-substitution.ts
+++ b/src/shared/data-graph/generation/model-substitution.ts
@@ -1,0 +1,175 @@
+/**
+ * SILENT MODEL SUBSTITUTION — the record side (issue #3520, phase 1).
+ *
+ * WHAT IS BEING OBSERVED
+ * ----------------------
+ * On a `modelLocked` ecosystem, `createCheckpointGraph`'s `checkpointInputSchema`
+ * (see `common.ts`) replaces any checkpoint version id that is not in the current
+ * workflow's visible list with that workflow's `defaultModelId`. The parse
+ * SUCCEEDS, images come back, the user is billed — and nothing in the response
+ * says a different model ran.
+ *
+ * That is deliberate, correct graceful degradation for the ON-SITE generator:
+ * the only way the form holds an out-of-list id is a stale `localStorage` value
+ * after an ecosystem switch, and the user visibly sees the picker snap back. It
+ * became a problem when the same graph went API-driven through the App Blocks
+ * bridge, where the id IS deliberate (an app author wrote it) and the correction
+ * is unobservable.
+ *
+ * 🔴 THIS MODULE CHANGES NO BEHAVIOUR. It records that the substitution happened
+ * so the swap is detectable and countable. Which model actually runs is
+ * identical before and after — deciding whether any case should REJECT is a
+ * later phase, gated on what the counter measures.
+ *
+ * WHY A SIDE CHANNEL AND NOT A MARKER ON THE VALUE
+ * ------------------------------------------------
+ * The obvious implementation — returning `{ id, model, __substitution }` from
+ * the clamp — is INERT, and quietly so. The model node's `output` is
+ * `resourceSchema.optional()`, and `resourceSchema` is a plain `z.object()`,
+ * which STRIPS unknown keys (zod 4.0.17). The marker would be silently dropped:
+ * the code compiles, a unit test against the input transform passes, and nothing
+ * is observed. Verified by execution, with `z.looseObject` (marker survives) and
+ * a declared key (survives) as controls. So the record travels on the CONTEXT,
+ * not on the parsed value.
+ *
+ * 🔴 WHY THE COLLECTOR IS PER-REQUEST. It is attached to the fresh `externalCtx`
+ * object literal `buildGenerationContext` constructs on every call. It must
+ * NEVER be hung off anything reachable from that function's awaited inputs
+ * (`getGenerationStatus`, `getGenerationEcosystemConfig`, `getGateRules`) — those
+ * read process/redis-level caches, and a mutable array behind one of them would
+ * accumulate substitutions ACROSS USERS and then report one user's requested
+ * model id to another.
+ *
+ * 🔴 WHY THE CLASSIFIER IS INJECTED rather than imported. Classifying the reason
+ * means asking the real graph config which workflow a version belongs to, i.e.
+ * `resolveVersionWorkflowScope` in `workflow-capability.ts` — which imports
+ * `generation-graph.ts`. A static import of that from `common.ts` creates a
+ * module cycle that is FATAL in one direction: measured, importing `common.ts`
+ * first crashes at module-eval with `TypeError: Cannot read properties of
+ * undefined (reading 'entries')` in `DataGraph.merge` (the ecosystem graphs run
+ * their top-level `createCheckpointGraph(...)` against a half-initialised
+ * `common` namespace). Importing `generation-graph.ts` first happens to work,
+ * which is exactly what makes the cycle dangerous. Injection removes the edge
+ * entirely: this module imports nothing from the graph, and the server hands in
+ * the classifier at collector-construction time.
+ */
+
+/**
+ * Why the graph substituted a different checkpoint version than the caller sent.
+ *
+ * 🔴 DECLARED ONCE, HERE. This union is simultaneously (a) the wire contract on
+ * `BlockWorkflowSnapshot.modelSubstitutions[].reason` and (b) the ONLY label of
+ * `civitai_generation_model_substitutions_total`. One declaration is what stops
+ * the label set and the contract from drifting: a new cause cannot be recorded
+ * without appearing here, and adding one here is a deliberate, reviewable
+ * widening of the metric's cardinality. (#3532's app-block metrics declare their
+ * union in the metrics module because it originates there; this one originates
+ * as a shared wire type, so the direction is reversed and the metrics module
+ * imports it TYPE-ONLY — nothing pulls prom-client into shared graph code.)
+ *
+ *  - `wrong-workflow` — the id IS one of this ecosystem's workflow-scoped
+ *                       checkpoint versions, but belongs to a DIFFERENT workflow
+ *                       (e.g. an edit-only version sent to `txt2img`). The
+ *                       caller named a real version for the wrong mode, so there
+ *                       is a specific right answer they probably wanted.
+ *  - `unrecognized`   — the id is in NO scoped list of this ecosystem: a
+ *                       community checkpoint, or a version retired since the app
+ *                       shipped. Degrading here is what keeps an app pinned to a
+ *                       deprecated version alive instead of hard-failing.
+ *  - `gated`          — the id IS offered for THIS workflow by the config, but a
+ *                       gate rule applicable to THIS user hid it from the version
+ *                       selector. Neither of the two cases the issue names: the
+ *                       app is not wrong and the version is not retired — the
+ *                       viewer simply may not use it. Kept distinct because the
+ *                       operator response differs (an entitlement question, not a
+ *                       config or app-authoring one) and folding it into
+ *                       `unrecognized` would mislabel it.
+ */
+export const MODEL_SUBSTITUTION_REASONS = ['wrong-workflow', 'unrecognized', 'gated'] as const;
+
+export type ModelSubstitutionReason = (typeof MODEL_SUBSTITUTION_REASONS)[number];
+
+/** One recorded silent checkpoint substitution. */
+export type ModelSubstitution = {
+  /** The checkpoint version id the caller actually sent. */
+  requested: number;
+  /** The version id the graph ran instead (the workflow's `defaultModelId`). */
+  applied: number;
+  reason: ModelSubstitutionReason;
+  /** Ecosystem key the parse resolved to, e.g. `'Qwen'`. */
+  ecosystem: string;
+  /** Workflow key the parse resolved to, e.g. `'txt2img'`. */
+  workflow: string;
+};
+
+/** The facts the clamp knows at the moment it substitutes. */
+export type ModelSubstitutionEvent = Omit<ModelSubstitution, 'reason'>;
+
+/**
+ * Resolves the REASON for one substitution. Server-supplied (see the module
+ * note on why this is injected); `classifyModelSubstitutionReason` in
+ * `workflow-capability.ts` is the only implementation.
+ */
+export type ModelSubstitutionClassifier = (
+  event: ModelSubstitutionEvent
+) => ModelSubstitutionReason;
+
+export type ModelSubstitutionCollector = {
+  /**
+   * Record one substitution. WRITE-ONCE per
+   * `(workflow, ecosystem, requested, applied)`: a zod `.transform()` is not
+   * contractually single-shot, and a repeat parse of the same context must not
+   * inflate the metric or duplicate the snapshot entry. (Measured on the real
+   * path: the clamp runs exactly ONCE per `generationGraph.safeParse` today —
+   * the dedupe is the guarantee, not the observation.)
+   *
+   * Never throws: an observability failure must not break a parse that would
+   * otherwise have succeeded.
+   */
+  record(event: ModelSubstitutionEvent): void;
+  /** Everything recorded on this request, in first-seen order. */
+  list(): ModelSubstitution[];
+  /**
+   * Records not yet handed out for metric emission, marking them emitted.
+   * Idempotent by construction: a second call returns `[]`, so a code path that
+   * drains twice cannot double-count.
+   */
+  takeUnemitted(): ModelSubstitution[];
+};
+
+function keyOf(event: ModelSubstitutionEvent): string {
+  return `${event.workflow}|${event.ecosystem}|${event.requested}|${event.applied}`;
+}
+
+/**
+ * Build a fresh per-request collector. 🔴 Call this per request and attach the
+ * result to a freshly constructed context object — see the module note.
+ */
+export function createModelSubstitutionCollector(
+  classify: ModelSubstitutionClassifier
+): ModelSubstitutionCollector {
+  const records: ModelSubstitution[] = [];
+  const seen = new Set<string>();
+  let emitted = 0;
+
+  return {
+    record(event) {
+      try {
+        const key = keyOf(event);
+        if (seen.has(key)) return;
+        seen.add(key);
+        records.push({ ...event, reason: classify(event) });
+      } catch {
+        /* observability must never break the parse it observes */
+      }
+    },
+    list() {
+      return records.slice();
+    },
+    takeUnemitted() {
+      const pending = records.slice(emitted);
+      emitted = records.length;
+      return pending;
+    },
+  };
+}

--- a/src/shared/data-graph/generation/model-substitution.ts
+++ b/src/shared/data-graph/generation/model-substitution.ts
@@ -58,14 +58,16 @@
  * Why the graph substituted a different checkpoint version than the caller sent.
  *
  * 🔴 DECLARED ONCE, HERE. This union is simultaneously (a) the wire contract on
- * `BlockWorkflowSnapshot.modelSubstitutions[].reason` and (b) the ONLY label of
- * `civitai_generation_model_substitutions_total`. One declaration is what stops
+ * `BlockWorkflowSnapshot.modelSubstitutions[].reason` and (b) one of the two
+ * labels of `civitai_generation_model_substitutions_total` (the other being
+ * {@link GENERATION_SURFACES}). One declaration is what stops
  * the label set and the contract from drifting: a new cause cannot be recorded
  * without appearing here, and adding one here is a deliberate, reviewable
  * widening of the metric's cardinality. (#3532's app-block metrics declare their
  * union in the metrics module because it originates there; this one originates
  * as a shared wire type, so the direction is reversed and the metrics module
- * imports it TYPE-ONLY — nothing pulls prom-client into shared graph code.)
+ * imports FROM here. This module still imports nothing at all, so that direction
+ * cannot pull prom-client — or any server module — into shared graph code.)
  *
  *  - `wrong-workflow` — the id IS one of this ecosystem's workflow-scoped
  *                       checkpoint versions, but belongs to a DIFFERENT workflow
@@ -88,6 +90,62 @@
 export const MODEL_SUBSTITUTION_REASONS = ['wrong-workflow', 'unrecognized', 'gated'] as const;
 
 export type ModelSubstitutionReason = (typeof MODEL_SUBSTITUTION_REASONS)[number];
+
+const MODEL_SUBSTITUTION_REASON_SET: ReadonlySet<string> = new Set(MODEL_SUBSTITUTION_REASONS);
+
+/**
+ * Runtime narrowing of a reason. 🔴 The "3 values, forever" guarantee must rest
+ * on CODE, not on the type system: `ModelSubstitutionReason` is erased at
+ * runtime, so a classifier that returns something else — a refactor that forgets
+ * a branch and falls through to `undefined`, a stubbed/mocked classifier, a
+ * `.js` caller — would put that value on the wire AND into
+ * `inc({ reason: <whatever> })`, which is exactly how an "impossible" label
+ * becomes an unbounded series. Only reachable by defeating the types today; the
+ * check is one `Set.has` on a path that only runs when a substitution actually
+ * happened.
+ */
+export function isModelSubstitutionReason(value: unknown): value is ModelSubstitutionReason {
+  return typeof value === 'string' && MODEL_SUBSTITUTION_REASON_SET.has(value);
+}
+
+/**
+ * WHICH CALLER's graph validation substituted — the second (and final) label of
+ * `civitai_generation_model_substitutions_total`.
+ *
+ * 🔴 WHY THIS LABEL EXISTS. `validateInput` is the choke point for EVERY
+ * server-side `generationGraph.safeParse`, so without it the counter mixes three
+ * populations whose meanings are opposite:
+ *
+ *   - `onsite`  — the on-site generator, where the substitution is the DELIBERATE,
+ *                 CORRECT graceful degradation (#3520 defends it: a stale
+ *                 localStorage id after an ecosystem switch, and the user visibly
+ *                 sees the picker snap back).
+ *   - `block`   — the App Blocks bridge, where the id was written by an app author
+ *                 and the correction is unobservable. This is the population
+ *                 phase 3's policy decision is actually about.
+ *   - `preset`  — comics / preset image generation, server-composed input.
+ *
+ * Phase 2 exists to produce a real incidence number that GATES phase 3. Summing
+ * on-site's correct behaviour into the bridge's incorrect behaviour measures a
+ * contaminated quantity, so the split is load-bearing, not decoration.
+ *
+ * 🔴 BOUNDED, AND KEPT THAT WAY: 3 reasons × 3 surfaces = 9 series, total,
+ * forever. This is the ONLY dimension added; version id / ecosystem / workflow /
+ * app id / user id are all caller-controlled or high-cardinality and stay out
+ * (prom-client retains every distinct label set in the Node heap forever, across
+ * ~130 scraped pods). Attribution belongs in the snapshot the caller already
+ * receives.
+ */
+export const GENERATION_SURFACES = ['block', 'onsite', 'preset'] as const;
+
+export type GenerationSurface = (typeof GENERATION_SURFACES)[number];
+
+const GENERATION_SURFACE_SET: ReadonlySet<string> = new Set(GENERATION_SURFACES);
+
+/** Runtime narrowing of a surface — same reasoning as {@link isModelSubstitutionReason}. */
+export function isGenerationSurface(value: unknown): value is GenerationSurface {
+  return typeof value === 'string' && GENERATION_SURFACE_SET.has(value);
+}
 
 /** One recorded silent checkpoint substitution. */
 export type ModelSubstitution = {
@@ -115,6 +173,12 @@ export type ModelSubstitutionClassifier = (
 ) => ModelSubstitutionReason;
 
 export type ModelSubstitutionCollector = {
+  /**
+   * WHICH surface's validation this collector belongs to — fixed at construction
+   * by the caller that built the request's `GenerationCtx`, never inferred at the
+   * clamp. See {@link GenerationSurface}.
+   */
+  readonly surface: GenerationSurface;
   /**
    * Record one substitution. WRITE-ONCE per
    * `(workflow, ecosystem, requested, applied)`: a zod `.transform()` is not
@@ -144,21 +208,43 @@ function keyOf(event: ModelSubstitutionEvent): string {
 /**
  * Build a fresh per-request collector. 🔴 Call this per request and attach the
  * result to a freshly constructed context object — see the module note.
+ *
+ * `surface` names the caller (block / onsite / preset) and becomes the second
+ * label on the counter. It is supplied by whoever builds the request context —
+ * never guessed from the parse — because `validateInput` is shared by all three
+ * and cannot tell them apart.
  */
 export function createModelSubstitutionCollector(
-  classify: ModelSubstitutionClassifier
+  classify: ModelSubstitutionClassifier,
+  surface: GenerationSurface
 ): ModelSubstitutionCollector {
   const records: ModelSubstitution[] = [];
   const seen = new Set<string>();
   let emitted = 0;
 
   return {
+    surface,
     record(event) {
       try {
         const key = keyOf(event);
         if (seen.has(key)) return;
+        const reason = classify(event);
+        // 🔴 RUNTIME narrowing, not a type assertion. An unknown reason is
+        // DROPPED rather than recorded: letting it through would put an
+        // unbounded, caller-shaped value on the wire contract AND into the
+        // counter's label set. Dropping loses one observation of an event that
+        // is already only reachable by defeating the types; admitting it would
+        // lose the cardinality bound permanently.
+        if (!isModelSubstitutionReason(reason)) return;
+        records.push({ ...event, reason });
+        // 🔴 AFTER the successful push, not before. `seen` is the write-once
+        // dedupe; marking the key before `classify` could throw meant a
+        // classifier that threw on its first call PERMANENTLY dropped that key
+        // for the whole request — the catch below swallowed the throw, nothing
+        // was recorded, and the retry short-circuited on `seen.has(key)`
+        // (measured: classifyCalls === 1, `list()` stayed `[]`). Harmless with
+        // today's pure classifier; free to make correct.
         seen.add(key);
-        records.push({ ...event, reason: classify(event) });
       } catch {
         /* observability must never break the parse it observes */
       }

--- a/src/shared/data-graph/generation/workflow-capability.ts
+++ b/src/shared/data-graph/generation/workflow-capability.ts
@@ -32,9 +32,12 @@
  * a hot path pays it at most once per pair.
  */
 
+import { ecosystemByKey } from '~/shared/constants/basemodel.constants';
 import { generationGraph } from './generation-graph';
 import { getAllVersionIds, type VersionGroup, type VersionOption } from './common';
+import { getWorkflowsForEcosystem } from './config/workflows';
 import type { GenerationCtx } from './context';
+import type { ModelSubstitutionEvent, ModelSubstitutionReason } from './model-substitution';
 
 /**
  * Fixed capability-probe context. NOT a user's context — see the module note.
@@ -60,6 +63,15 @@ export type WorkflowCapability = {
   versions: VersionGroup | undefined;
   /** The version this (ecosystem, workflow) defaults to, when it has one. */
   defaultModelId: number | undefined;
+  /**
+   * Whether this (ecosystem, workflow) LOCKS the checkpoint — i.e. whether the
+   * `checkpointInputSchema` clamp in `common.ts` will silently rewrite an
+   * out-of-list version id to `defaultModelId` (issue #3520). Read from the same
+   * `model` node meta the form renders, so a caller enumerating "which
+   * ecosystems substitute?" derives it from the real config instead of keeping a
+   * hand-maintained list that goes stale the moment a new ecosystem ships.
+   */
+  modelLocked: boolean;
 };
 
 const capabilityCache = new Map<string, WorkflowCapability | undefined>();
@@ -87,11 +99,12 @@ export function getWorkflowCapability(
     const ctx = clone.ctx as { workflow?: string; ecosystem?: string };
     if (ctx.workflow === workflow && ctx.ecosystem === ecosystem) {
       const modelMeta = clone.getNodeMeta('model' as never) as
-        | { versions?: VersionGroup; defaultModelId?: number }
+        | { versions?: VersionGroup; defaultModelId?: number; modelLocked?: boolean }
         | undefined;
       capability = {
         versions: modelMeta?.versions,
         defaultModelId: modelMeta?.defaultModelId,
+        modelLocked: !!modelMeta?.modelLocked,
       };
     }
   } catch {
@@ -202,4 +215,54 @@ export function resolveVersionWorkflowScope(opts: {
     (index >= 0 ? targetOptions[index]?.value : undefined) ?? target?.defaultModelId;
 
   return { kind: 'wrong-workflow', offeredFor, suggestedVersionId };
+}
+
+/**
+ * Classify ONE silent checkpoint substitution (issue #3520, phase 1) into the
+ * reason recorded on `BlockWorkflowSnapshot` and used as the sole prom label of
+ * `civitai_generation_model_substitutions_total`.
+ *
+ * 🔴 REUSES `resolveVersionWorkflowScope` — it is deliberately NOT a second,
+ * parallel notion of "does this version belong to this workflow". That function
+ * already answers the question direction-agnostically, and the only reason the
+ * txt2img-direction guard in `blocks/workflow.service.ts` looks narrower is that
+ * it chooses to ACT on one verdict; the resolver itself never was. Generalising
+ * its use (any workflow, either direction) is the point of this call site.
+ *
+ * `candidateWorkflows` is EVERY workflow the ecosystem offers, not the App
+ * Blocks image subset — this runs on all server-side graph validations
+ * (on-site submit and bridge alike), so bounding it to the bridge's three
+ * workflows would misclassify a real `wrong-workflow` case as `unrecognized`
+ * the moment an ecosystem scopes versions across some other pair of workflows.
+ *
+ * The `supported` verdict maps to `gated`, and that mapping is the whole reason
+ * the third reason exists. The clamp tests `val.id` against `validVersionIds`,
+ * which is the GATE-FILTERED visible list; this resolver probes with an EMPTY
+ * `gateRules` (see PROBE_CTX). So "the config offers this version for this
+ * workflow, yet the clamp still replaced it" can only mean a gate rule
+ * applicable to this user hid it. Folding that into `unrecognized` would label
+ * an entitlement decision as a retired/unknown model.
+ *
+ * Never throws: `resolveVersionWorkflowScope` is probe-guarded internally, and
+ * an unknown ecosystem key simply yields no candidates (→ `unrecognized`), which
+ * is the honest verdict when the config has no opinion.
+ */
+export function classifyModelSubstitutionReason(
+  event: ModelSubstitutionEvent
+): ModelSubstitutionReason {
+  const ecosystem = ecosystemByKey.get(event.ecosystem);
+  const candidateWorkflows = ecosystem
+    ? getWorkflowsForEcosystem(ecosystem.id).map((w) => w.graphKey)
+    : [];
+
+  const scope = resolveVersionWorkflowScope({
+    ecosystem: event.ecosystem,
+    workflow: event.workflow,
+    candidateWorkflows,
+    versionId: event.requested,
+  });
+
+  if (scope.kind === 'wrong-workflow') return 'wrong-workflow';
+  if (scope.kind === 'supported') return 'gated';
+  return 'unrecognized';
 }


### PR DESCRIPTION
Closes phase 1 of #3520.

## 🔴 Fix round (adversarial audit)

Five findings, all addressed. The no-behaviour-change property was **re-proved after the changes**, not assumed — see *Re-proof* below.

### 1. `modelSubstitutions` disappeared before any consumer could read it — **fixed via orchestrator workflow metadata; NO DB change**

As originally built, the field was **submit-reply-only**. `pollWorkflow` (`blocks.router.ts`) and `cancelWorkflow` call `snapshotFromWorkflow(workflow)` with no `extra`, and the normal block pattern renders from the **terminal poll** — the only snapshot that carries `imageUrls`. So the record was gone by the time there was anything to display beside it, and `block_workflows` does not retain the submitted body, making it unrecoverable. Phase 1 did not achieve its own goal.

**Route taken: the orchestrator workflow's own `metadata`.** `createBlockTextToImageStep` already returns a `workflowMetadata` that the real submit attaches to the submit body; the record is now folded into it under `modelSubstitutions`, and `snapshotFromWorkflow` reads it back off `workflow.metadata` when no explicit `extra` is supplied.

Why this works:

- `WorkflowTemplate.metadata` is `?: null | { [key: string]: unknown }` and `Workflow.metadata` is `{ [key: string]: unknown }` — a free-form bag the orchestrator persists and returns on every read.
- **The app already depends on this exact round-trip for non-standard top-level keys**: `remixOfId` and `isPrivateGeneration` are written into workflow metadata at submit and read back from `workflow.metadata` in the workflow formatter (`orchestration-new.service.ts`). This is an exercised path, not a new assumption.
- The formatter builds its normalized metadata from a **fixed key list**, so an extra key is inert on the on-site normalization path.

**No Prisma migration, no schema change, no new column.** Given that this org applies migrations manually per environment, turning a code PR into a coordinated DB operation was not warranted when a durable carrier already existed on the submit body.

Precedence: an explicit `extra` (submit / estimate replies, where the request's own collector is in scope) wins; otherwise the metadata is read. The metadata read is **validated, not cast** — it crosses a service boundary and feeds a public wire field whose `reason` is also a bounded prom label, so every entry is structurally checked and its `reason` narrowed against the code-owned union, with malformed entries dropped.

Where the field now appears: the submit reply, the `estimateWorkflow` reply, the insufficient-budget reply, **and every subsequent `pollWorkflow` / `cancelWorkflow`**. The estimate path is the one exception — a whatIf creates no persisted workflow, so there it lives only on the reply.

**Checked, because putting a new field on the POLL reply is riskier than putting it on the submit reply:** the block SDK's inbound validator cannot drop a snapshot because of it. `isValidWorkflowSnapshot` (`@civitai/blocks-react`, `internal/validate.js`) is a whitelist of per-field checks over `workflowId` / `status` / `cost` / `imageUrls` / `error` / `autoClaim` and then `return true` — it has no unknown-key rejection. And `extractSnapshot` in `internal/liveHost.js` returns the parsed `snapshot` object **by reference**; nothing re-picks its fields. So an additive key neither invalidates the snapshot nor is stripped at runtime — only the SDK's TypeScript type needs widening before a block can read it, as noted below.

🔴 **Not verified locally:** that the orchestrator round-trips this specific key end-to-end. The evidence is the type contract plus the two existing keys that already rely on it; nothing here was exercised against a live orchestrator.

### 2. The metric was a contaminated signal — **`surface` label added**

`validateInput` is the choke point for *every* server-side graph validation, so one un-split series mixed three populations whose verdicts are opposite. The on-site generator's substitution is the behaviour #3520 explicitly defends as **correct**; preset/comics generation is server-composed input; only the App Blocks bridge is the population phase 3's decision is about.

`civitai_generation_model_substitutions_total{reason, surface}` — `surface` ∈ `block` | `onsite` | `preset`. **3 × 3 = 9 series, total, forever.** No version id, ecosystem, workflow, app id or user id.

The surface is supplied **by the caller** at context-build time: `buildGenerationContext(userTier, flags, user, surface)`, where the parameter is **required, not defaulted** — a new generation entry point is a compile error rather than silent misattribution. All three call-site files are wired (`orchestrator.router.ts` → `onsite`, `blocks.router.ts` → `block`, `preset-image-gen.service.ts` → `preset`), and a population guard enumerates every `buildGenerationContext(` call site from the tree and fails on an unknown one.

**Honest multiplier.** One increment is **one graph validation that substituted** — not one generation, and *not a fixed multiple of one either*. On the `block` surface, for one user-visible generation:

| term | when |
|---|---|
| **2** | the normal successful submit (whatIf cost preflight + real submit, each with its own per-request collector) |
| **1** | when the whatIf estimate exceeds the block's per-call buzz budget — the procedure returns before the idempotency claim and the real submit |
| **+1 each** | per `blocks.estimateWorkflow` call the block chooses to make — a separate procedure a block may call any number of times, so this term is **unbounded** |
| **+1** | per idempotency **replay** that re-enters the procedure (the preflight re-runs before the claim short-circuits) |

So: **read it as a rate and a trend, per surface.** It is not a headcount of affected generations, and dividing by 2 does not produce one. A real "generations served the wrong model" figure has to come from the snapshot/log side, where each record is tied to one workflow id. This is now stated in the metric's own help text, not only in the source comment.

### 3. The in-generate preflight discarded its substitutions

`blocks.router.ts` destructured only `{ step: stepForCostCheck }`, so the validation that produced the cost the budget check is made against threw its record away.

**Surfaced on the insufficient-budget reply**, and deliberately only there. On the success path the real submit re-validates the same input and its record is what the snapshot carries (identical by construction, and tied to a real workflow id) — adding a second copy would be redundant. The budget-reject exit is the one reply in the whole flow that returns a **cost with no workflow**, so without this it is the only place a block is quoted a price with no way to learn which model it was for.

### 4. `seen.add` ran before `classify`

A classifier throwing on its first call **permanently dropped that key for the request** — the throw was swallowed, nothing was recorded, and the retry short-circuited on `seen.has(key)`. `seen.add` now runs only after a successful push, so a transient classifier fault leaves the key retryable. Harmless with today's pure classifier; free to make correct.

### 5. No runtime narrowing of the classifier's return

A classifier returning `undefined` would have put `reason: undefined` on the wire **and** into `inc({ reason: undefined })` — which is how a "bounded forever" label set stops being bounded. Both unions are now narrowed **at runtime** (`isModelSubstitutionReason` / `isGenerationSurface`), in two places guarding two different exits: `record()` drops an out-of-union reason before it can reach the snapshot, and `recordGenerationModelSubstitution` drops an out-of-union reason *or* surface before `inc()`. The cardinality bound now rests on code, not on erased types.

---

## 🔴 Re-proof: no behaviour change, after the fixes

New file `model-substitution.no-behaviour-change.test.ts` parses the **full result object** (serialized with sorted keys, `undefined` made explicit) with and without a collector — a context with no `modelSubstitutions` field *is* the pre-change shape, so this is a direct before/after comparison, not a proxy.

| sweep | population | comparisons | diffs |
|---|---|---|---|
| real classifier | **552** (ecosystem, workflow) pairs across 82 ecosystems | 684 | **0** |
| classifier that **throws on every call** | all **89** modelLocked pairs | 178 | **0** |
| classifier returning a **bogus reason** | all 89 modelLocked pairs | 89 | **0** |

Plus a **negative control** in the same file: two genuinely different parses must compare unequal, so a "zero diffs" result cannot come from a blind comparator. And mutation **N20** injects a real perturbation into the clamp when a collector is present — the sweep goes red with `expected [ 'Flux1Kontext/txt2img', …(39) ] to deeply equal []`, so the instrument is proven able to see the thing it reports absent.

## Mutation results — 20/20 killed, each by its OWN guard's assertion

| # | mutation | killed by | assertion |
|---|---|---|---|
| N1 | `seen.add(key)` moved back before `classify` | `a classifier that throws ONCE does not permanently drop the key`; `an always-throwing classifier still leaves the key retryable` | `expected 1 to be 2` |
| N2 | delete the reason narrowing in `record()` | 5× `DROPS a classifier return that is …` | `expected [ { requested: 1, applied: 2, …(3) } ] to deeply equal []` |
| N3 | invert the narrowing predicate | 16 tests incl. all three reason reproductions | `expected [] to deeply equal [ { requested: 2133258, …(4) } ]` |
| N4 | `isModelSubstitutionReason` accepts everything | 5× `DROPS a classifier return …` + `isModelSubstitutionReason accepts exactly the declared union` | `expected true to be false` |
| N5 | delete the label narrowing before `inc()` | 3× `DROPS an increment whose surface is …`, 2× `… whose reason is …` | `expected Counter{ labelNames: [ …(2) ], …(5) } to be undefined` |
| N6 | drop `surface` from the counter's `labelNames` | 17 tests incl. `DECLARES exactly reason + surface` | `expected [ 'reason' ] to deeply equal [ 'reason', 'surface' ]` |
| N7 | emitter hardcodes the surface | `labels every increment with the COLLECTOR's surface, not a guess` | `expected 2 to be 1` |
| N8 | collector ignores its `surface` argument | `carries the SURFACE it was constructed with` (+3) | `expected 'onsite' to be 'block'` |
| N9 | block call site labelled `onsite` | `the App Blocks bridge builds its generation context with surface block`; the wiring guard | `expected 'onsite' to be 'block'`; `expected [ 'onsite' ] to deeply equal [ 'block' ]` |
| N10 | preset call sites labelled `block` | `submitPresetImageGen builds its context with surface preset` (+2) | `expected 'block' to be 'preset'`; `expected [ 'block' ] to deeply equal [ 'preset' ]` |
| N11 | on-site call sites labelled `block` | `orchestrator.router.ts passes the surface onsite at EVERY buildGenerationContext call` | `expected [ 'block' ] to deeply equal [ 'onsite' ]` |
| N12 | snapshot stops reading `workflow.metadata` | `pollWorkflow REPORTS the substitutions recorded at submit` (+4) | `expected undefined to deeply equal [ { requested: 2558804, …(2) } ]` |
| N13 | metadata `reason` not validated | `DROPS an unknown reason from the metadata …` (+2) | `expected true to be false` |
| N14 | metadata `requested`/`applied` not validated | `DROPS a non-numeric requested …`; `DROPS a NaN applied …` | `expected true to be false` |
| N15 | `extra` no longer wins over the metadata | `an EXPLICIT extra wins over the metadata` | `expected [ { requested: 2558804, …(2) }, …(1) ] to deeply equal [ { requested: 1, applied: 2, …(1) } ]` |
| N16 | submit stops folding the record into `workflowMetadata` | `the REAL submit body carries the substitutions on workflow metadata` | `expected { params: { prompt: 'a cat' } } to deeply equal { params: { prompt: 'a cat' }, …(1) }` |
| N17 | submit writes the key even when empty | `does NOT touch the metadata when nothing was substituted` | `expected { params: …, …(1) } to deeply equal { params: { prompt: 'a cat' } }` |
| N18 | budget-reject reply drops the record | `the insufficient-budget reply reports what the quote was actually priced for` | `expected undefined to deeply equal [ { requested: 2558804, …(2) } ]` |
| N19 | budget-reject reply emits an empty array | `the insufficient-budget reply is unchanged when nothing was substituted` | `expected true to be false` |
| N20 | clamp perturbs behaviour when a collector is present | the 3 full-population sweeps | `expected [ 'Flux1Kontext/txt2img', …(39) ] to deeply equal []` |

Each mutation was checked to die to **its own** guard's assertion, not a neighbour's.

## Local verification (NixOS; CI is authoritative)

Measured in a clean worktree with the repo's own toolchain (`node_modules/.bin/tsc` 5.9.2, `NODE_OPTIONS=--max_old_space_size=8192`), against a same-environment baseline worktree at the pre-fix commit `f5e6099`.

- **tsc**: `0` errors at the baseline, `0` errors after the fixes — **delta 0**. (This environment has a generated Prisma client, so the count is a real 0 rather than the stale-client artifact reported earlier in this PR.)
- **eslint** on all changed files: baseline `26 problems (21 errors, 5 warnings)` → after `26 problems (21 errors, 5 warnings)`. Identical set; all pre-existing `no-explicit-any` / `no-unused-vars` in untouched code.
- **prettier `--list-different`**: the only non-conforming files are the four that were **already** non-conforming at the baseline commit (`blocks.router.ts`, `workflow.schema.ts`, `blocks.router.workflow.test.ts`, `workflow.service.test.ts`) and were deliberately not reformatted. Every prettier hunk in those files was intersected against this change's added-line ranges: **0 overlap** — none of them are mine.
- **vitest `--project unit`** over `src/shared/data-graph src/server/metrics src/server/services/blocks src/server/services/orchestrator src/server/routers`:
  - baseline (`f5e6099`, same env): **165 files, 3236 tests, 0 failing**
  - after: **168 files, 3294 tests, 0 failing**
  - net **+3 files, +58 tests**, all passing, no regressions.

### Not verified locally

- **Nothing was run against a live orchestrator.** The metadata round-trip that fix 1 depends on is argued from the type contract plus the two existing top-level keys (`remixOfId`, `isPrivateGeneration`) the app already writes and reads back — it has **not** been observed end-to-end. That is the one assumption worth checking on staging before relying on the poll-side field.
- The counter has still not been observed on a real `/api/metrics` scrape — only against the prom-client default registry in-process.
- No end-to-end block submit was driven; the bridge plumbing is covered by unit tests on both ends.
- The `onsite` surface has no router-level behavioural test (`orchestrator.router.ts` has no existing test harness); it is covered by the source-level population guard, while `block` and `preset` have behavioural tests that read the argument actually passed.

---

## The behaviour, unchanged

On a `modelLocked` ecosystem, `createCheckpointGraph`'s `checkpointInputSchema` replaces any checkpoint version id that is not in the current workflow's visible list with that workflow's `defaultModelId`. The parse succeeds, images return, the user is billed — and nothing in the response, the snapshot, or the `block_workflows` read-model says a different model ran.

That is deliberate graceful degradation, and correct for the on-site generator: the only way the form holds an out-of-list id is a stale `localStorage` value after an ecosystem switch, and the user visibly sees the picker snap back. It also keeps an app pinned to a since-retired version alive instead of hard-failing. It became a problem when the same graph went API-driven through the App Blocks bridge, where the id **is** deliberate (an app author wrote it) and the correction **is** unobservable.

## 🔴 Scope: RECORD ONLY

**No behaviour change.** Which model runs is byte-identical before and after — a test parses every case twice, once with a collector on the context and once without (the pre-change shape), and requires the same model id, with a `typeof … === 'number'` check so an `undefined === undefined` comparison can't pass vacuously. Whether any case should *reject* is a later phase, gated on what the counter below measures.

## What lands

| | |
|---|---|
| `GenerationCtx.modelSubstitutions` | Per-request collector; records `{ requested, applied, reason, ecosystem, workflow }` at the clamp. Write-once, never-throwing. |
| `classifyModelSubstitutionReason` | Reuses `resolveVersionWorkflowScope` — **no parallel guard** — direction-agnostically, over every workflow the ecosystem offers. |
| `BlockWorkflowSnapshot.modelSubstitutions` | Additive + optional; **omitted entirely** when nothing was substituted. Surfaced on both the submit and the whatIf/estimate reply. |
| `civitai_generation_model_substitutions_total{reason,surface}` | Two bounded labels, both code-owned unions → **9 series total** (3 reasons x 3 surfaces). Emitted fail-soft from `validateInput`; the surface is supplied by the caller at context-build time. |

### Reasons

- **`wrong-workflow`** — the id IS one of the ecosystem's workflow-scoped versions but belongs to a different workflow (an edit-only version sent to `txt2img`).
- **`unrecognized`** — the id is in no scoped list at all: a community checkpoint, or a version retired since the app shipped. The case degradation exists to survive.
- **`gated`** — 🔴 **a third case the issue's two-way split does not cover, found while implementing.** The clamp compares against the **gate-filtered** visible list; `resolveVersionWorkflowScope` probes with an **empty** `gateRules`. So "the config offers this version for this workflow, yet the clamp still replaced it" can only mean a gate rule applicable to *this user* hid it. That is neither an app-authoring bug nor a retired model — it is an entitlement decision, and folding it into `unrecognized` would mislabel it. Reachability is proven from a real parse with a real `GateRule`, not from the classifier alone. Happy to fold it back into `unrecognized` if you'd rather hold the union at two.

## Two design constraints settled by execution, not reasoning

**1. An in-value marker would have been inert.** The model node's `output` is `resourceSchema.optional()`, and `resourceSchema` is a plain `z.object()`, which **strips unknown keys** (zod 4.0.17, as pinned here). Returning `{ id, model, __substitution }` from the clamp compiles, unit-tests green against the transform, and observes nothing. Verified by execution with two controls: `z.looseObject` keeps the marker, and a declared key (`id`) survives. Hence the side channel on `GenerationCtx`.

**2. The classifier is injected, not imported.** Classifying means asking the real graph config which workflow a version belongs to — `resolveVersionWorkflowScope`, which imports `generation-graph.ts`. A static import of that from `common.ts` creates a module cycle that is **fatal in one direction**, and silently fine in the other:

| import order | result |
|---|---|
| `generation-graph.ts` first | loads and parses correctly |
| `common.ts` first | **`TypeError: Cannot read properties of undefined (reading 'entries')` at `DataGraph.merge`**, from `flux-graph.ts` → `ecosystem-graph.ts` running its top-level `createCheckpointGraph(...)` against a half-initialised `common` namespace |

Both orders measured. The second is exactly why the first is dangerous. Injection removes the edge: `model-substitution.ts` imports nothing from the graph, and `buildGenerationContext` (server, where `workflow-capability` already loads safely) hands in the classifier.

## Per-request lifetime of the collector

Attached to the **fresh object literal** `buildGenerationContext` returns — verified to be newly constructed on every call with no memoisation. Its three awaited inputs (`getGenerationStatus`, `getGenerationEcosystemConfig`, `getGateRules`) all read process- or redis-level caches, so a mutable array hung off anything reachable through them would accumulate substitutions **across users** and report one caller's requested model id to another. The collector is attached at the top level of the returned literal only, and a test asserts two collectors share no state.

The client never has one: only the server attaches it, so an in-form parse in the browser records nothing and pays nothing.

## Idempotency

**Measured:** the clamp runs **exactly once** per `generationGraph.safeParse` on the real path today (instrumented with a counter inside the clamp; 1 hit per parse for both the wrong-workflow and unrecognized inputs). A zod `.transform()` is not contractually single-shot, so the dedupe is the *guarantee*, not the observation:

- `record()` is write-once per `(workflow, ecosystem, requested, applied)`.
- `takeUnemitted()` marks what it hands out, so a second drain emits nothing.

Both are covered by tests that re-parse / re-drain and require exactly one record / one increment.

## Reproduction of both reasons (real `generationGraph.safeParse`, Qwen, free-tier ctx)

```
txt2img + 2558804 (edit-only v2511) -> model.id 2552908   success: true
txt2img + 987654321 (unrecognized)  -> model.id 2552908   success: true
```

Matching the issue's evidence table. Recorded by the clamp as:

```
{ requested: 2558804,   applied: 2552908, reason: 'wrong-workflow', ecosystem: 'Qwen', workflow: 'txt2img' }
{ requested: 987654321, applied: 2552908, reason: 'unrecognized',   ecosystem: 'Qwen', workflow: 'txt2img' }
```

The version ids in the test are **re-derived from the live config**, not transcribed, so a config change fails the fixture guard rather than silently asserting about ids that no longer exist.

## Population coverage

The ecosystem sweep is derived from the source config **at runtime** — `getWorkflowCapability` now also reports `modelLocked`, read from the same `model` node meta the form renders. **Measured: 89 (ecosystem, workflow) pairs across 43 ecosystems** are `modelLocked` with a default — wider than the ~23 image ecosystems the issue enumerates, because live config also covers video/audio ecosystems and per-workflow variants. Every one of them must record. A new `modelLocked` ecosystem added later is picked up automatically and fails loudly rather than silently inheriting the unobservable behaviour.

## 🔴 Consumer-side trap — alert with `max_over_time`, NOT `rate()`

This is a rare per-pod counter across ~130 pods. A pod that substitutes once creates its labelled child at 1 and never increments it again, so `rate()`/`increase()` over that child is structurally 0 and an alert keyed on it **silently never fires** — the counter looks healthy precisely because the event is rare. Noted in the metrics module. No dashboard/alert rule is created by this PR.

## 🔴 What one increment means

One **graph validation** that substituted, not one user-visible generation — and **not a fixed multiple of one either**. See "Honest multiplier" in the fix-round section above: the ratio is 2 on a normal block submit, 1 on a budget reject, **+1 per `estimateWorkflow` call (unbounded)**, and +1 per idempotency replay. Read it as a rate and a trend, **per surface**; a headcount of affected generations has to come from the snapshot/log side.

## 🔴 Wire-contract implication

`workflow.schema.ts` states that `BlockWorkflowSnapshot` mirrors the type in `@civitai/app-sdk`'s `blocks/types.ts`. `modelSubstitutions` is **additive and optional**, and is omitted when empty, so no existing consumer is affected and every existing snapshot is byte-identical. But the SDK type does not carry the field yet, so a block cannot read it until that type is widened in the SDK repo. **Nothing in this PR edits another repo** — that widening needs a separate change there.

## Testing

40 new tests (22 graph-path + 18 metrics) plus 2 on `snapshotFromWorkflow`. All drive the real `generationGraph.safeParse` and the real prom-client default registry — the clamp, the classifier, the graph, and the counter are not mocked.

### Mutation results — every guard broken on purpose, killed by its OWN assertion

| # | Mutation | Killed by | Assertion |
|---|---|---|---|
| M1 | delete the `record(...)` call in the clamp | `reason 'wrong-workflow' …` (+6 more) | `expected [] to deeply equal [ { requested: 2133258, …(4) } ]` |
| M2 | clamp records `applied: val.id` (the requested id) | `reason 'wrong-workflow' …` (+3) | `expected [ { requested: 2133258, …(4) } ] to deeply equal [ { requested: 2133258, …(4) } ]` |
| M3 | remove the write-once dedupe | `two parses on the SAME context produce exactly ONE record` | `expected [ …, …(1) ] to have a length of 1 but got 2` |
| M4 | `takeUnemitted()` stops marking | `a SECOND drain … emits nothing`; `takeUnemitted hands each record out once` | `expected 2 to be 1`; `expected [ { requested: 2133258, …(4) } ] to deeply equal []` |
| M5 | remove `record()`'s try/catch | `SWALLOWS a throwing classifier` | `expected [Function] to not throw an error but 'Error: boom' was thrown` |
| M6 | `list()` returns the internal array | `list() returns a copy` | `expected [ …(2) ] to have a length of 1 but got 2` |
| M7 | drop the `wrong-workflow` branch in the classifier | `reason 'wrong-workflow' …`; `reuses resolveVersionWorkflowScope in BOTH directions` | `expected 'unrecognized' to be 'wrong-workflow'` |
| M8 | fold `gated` into `unrecognized` | `reason 'gated' …` | `expected [ { requested: 2110043, …(4) } ] to deeply equal [ … ]` |
| M9 | hardcode `modelLocked: true` in the capability probe | `records a substitution … on EVERY locked pair` | `expected [ 'Flux1/txt2img -> []', …(42) ] to deeply equal []` |
| M10 | widen the counter to `['reason','version_id']` | `DECLARES exactly one label` | `expected [ 'reason', 'version_id' ] to deeply equal [ 'reason' ]` |
| M11 | remove the emitter's try/catch | `the emitter NEVER throws` | `expected [Function] to not throw an error but 'Error: Added label "reason" is not included in initial labelset: [ 'unrelated' ]' was thrown` |
| M12 | remove `emitModelSubstitutions`' try/catch | `RESOLVES when the collector itself throws on drain` | `promise rejected "Error: collector exploded" instead of resolving` |
| M13 | snapshot spreads a truthy empty array | `OMITS modelSubstitutions when nothing was substituted` | `expected true to be false` |
| M14 | snapshot drops the field entirely | `surfaces modelSubstitutions passed alongside the workflow` | `expected undefined to deeply equal [ { requested: 2558804, …(2) } ]` |

**14/14 killed.** The metric-name/label tests drive the real registry (a name or label typo sails through any test that mocks the metrics module and yields an alert that silently never fires), and the poisoned-registry case is paired with a control proving the unguarded call really does throw — so `not.toThrow()` there is testing the guard, not an inert no-op.

## Local verification — FIRST ROUND (superseded by the fix-round numbers above)

> The tsc/eslint/vitest figures below were measured in an environment without a generated Prisma client, which is why the absolute error count is large. The fix-round section above re-measured everything in an environment that does have one; prefer those numbers.


- **tsc** (repo-local `tsc` 5.9.2, `NODE_OPTIONS=--max_old_space_size=8192`), against an `origin/main` baseline captured in the same environment: **3950 → 3965 errors**, delta accounted for exactly — 15 in the new test file (now fixed to 0) and 2 pre-existing `blocks.router.ts` `TS7006` errors that only shifted line number (2160/2161 → 2175/2176). **Zero new production-code type errors.** The large absolute count is the known stale-Prisma-client artifact (`prisma generate` cannot run on this box); it is identical on both sides.
- **eslint** on all changed files: identical result to the `origin/main` baseline — same 4 errors + 5 warnings, all pre-existing, only line-shifted. **Zero new lint issues.**
- **prettier `--list-different`**: clean on every file this PR touches. Three files (`blocks.router.ts`, `workflow.schema.ts`, `workflow.service.test.ts`) were already non-conforming on `main` and were deliberately **not** reformatted; the one hunk of mine that was non-conforming was fixed by hand.
- **vitest `--project unit`** over `src/shared/data-graph src/server/metrics src/server/services/blocks src/server/services/orchestrator src/server/routers src/store`:
  - baseline (`origin/main`, same env): 169 files, 2127 tests, **61 files / 18 tests failing**
  - this branch: 171 files, 2169 tests, **61 files / 18 tests failing**
  - **Identical failing-file set** (set-diff empty). Those failures are environmental — missing `.prisma/client` and the `sharp` native binding — not code.
  - Net **+42 tests, +2 files**, all passing.

### Not verified locally

- Nothing was run against a live server or a real block. The bridge plumbing (`createBlockTextToImageStep` → `snapshotFromWorkflow`) is covered by unit tests on both ends but **not** by an end-to-end block submit.
- The counter has not been observed on a real `/api/metrics` scrape — only against the prom-client default registry in-process.
- `prisma generate` cannot run on this host, so the local `tsc` run is only meaningful as a **delta** against the same-environment baseline. CI is the authority.

