### PR TITLE
fix(creator-program): show min-withdrawal message to returning users …

### DIFF
--- a/src/components/Buzz/CreatorProgramV2/CreatorProgramV2.tsx
+++ b/src/components/Buzz/CreatorProgramV2/CreatorProgramV2.tsx
@@ -905,8 +905,8 @@ const WithdrawCashCard = () => {
     return null; // Failed to load.
   }
 
-  const canWithdraw =
-    (userCash?.ready ?? 0) >= MIN_WITHDRAWAL_AMOUNT || (userCash?.withdrawn ?? 0) > 0;
+  const hasMinBalance = (userCash?.ready ?? 0) >= MIN_WITHDRAWAL_AMOUNT;
+  const canWithdraw = hasMinBalance || (userCash?.withdrawn ?? 0) > 0;
 
   return (
     <div className={clsx(cardProps.className, 'basis-1/4 gap-6')}>
@@ -975,7 +975,7 @@ const WithdrawCashCard = () => {
           </Table.Tbody>
         </Table>
 
-        {!canWithdraw && (
+        {!hasMinBalance && (
           <Alert color="red" className="mt-auto p-2">
             <div className="flex items-center gap-2">
               <IconLock size={24} className="shrink-0" />


### PR DESCRIPTION
…below $50

Returning users with a prior payout but ready balance under $50 saw a disabled withdraw button with no explanation: canWithdraw resolved true via the has-withdrawn-before branch, which suppressed the min-balance alert. Split hasMinBalance out of canWithdraw and gate the alert on it so the explanation always shows when ready < MIN_WITHDRAWAL_AMOUNT.

ClickUp: https://app.clickup.com/t/868kc39vh (FD #68018)