### PR TITLE
fix(tests): unblock the permanently-red preview gate — a hung file, not a slow suite

### DIFF
--- a/src/components/Announcements/AnnouncementEditModal.browser.test.tsx
+++ b/src/components/Announcements/AnnouncementEditModal.browser.test.tsx
@@ -21,6 +21,30 @@ const mocks = vi.hoisted(() => ({
   behavior: 'success' as 'success' | 'fail' | 'hang',
   uploaded: { url: 'new-banner-key', objectUrl: 'blob:new', id: 'new-banner-key', type: 'image' },
   mutate: vi.fn(),
+  /**
+   * 🔴 REFERENTIALLY STABLE, and that is the whole point — not a tidy-up.
+   *
+   * `getAnnouncementTargets` feeds an effect keyed on the query RESULT:
+   *
+   *   const watchedTargets = form.watch('targetUserIds');            // subscribes
+   *   useEffect(() => {
+   *     if (targetsQuery.data) form.setValue('targetUserIds', targetsQuery.data.join(', '));
+   *   }, [targetsQuery.data]);
+   *
+   * Returning a fresh `{ data: [], isSuccess: true }` from the mock — as this file
+   * did — hands the effect a NEW array identity on every render. Real react-query
+   * memoises `data`, so the effect runs once; the mock made it run forever:
+   * effect → setValue → the watch subscriber re-renders → new `[]` → effect …
+   *
+   * That loop pegs the page's main thread, so Vitest's own in-page test timeout
+   * can never fire: the FILE hangs with zero output instead of reporting a
+   * failure. It consumed the whole 25-minute `component-tests` budget on every
+   * PR from 2026-07-29 (1e8d043695) onward — the run reached 110/111 files in
+   * ~2 minutes and then sat here until the runner killed it, which is why the
+   * check reported "exceeded its budget, no suite reported red" rather than a
+   * red test. Keep the identity stable, or the freeze comes straight back.
+   */
+  targetsQuery: { data: [] as number[], isSuccess: true },
 }));
 
 vi.mock('~/hooks/useCFImageUpload', async () => {
@@ -61,7 +85,8 @@ vi.mock('~/utils/trpc', async (importOriginal) => ({
         useMutation: () => ({ mutate: mocks.mutate, isPending: false }),
       },
       getAnnouncementTargets: {
-        useQuery: () => ({ data: [], isSuccess: true }),
+        // Stable identity — see the note on `mocks.targetsQuery`.
+        useQuery: () => mocks.targetsQuery,
       },
     },
   },

--- a/src/components/AppBlocks/PageBlockHost.tsx
+++ b/src/components/AppBlocks/PageBlockHost.tsx
@@ -135,8 +135,19 @@ function storageErrorMessage(err: unknown): string {
  *     its page but can't push the host off to an arbitrary route.
  */
 
-const BLOCK_READY_TIMEOUT_MS = 10_000;
-const TOKEN_WAIT_TIMEOUT_MS = 15_000;
+/**
+ * How long the host waits for the block to ack `BLOCK_READY` before settling on
+ * the `timeout` terminal, and how long it waits for a token before settling on
+ * `no_token`.
+ *
+ * 🔴 EXPORTED for the browser tests, which drive these windows on a VIRTUAL clock
+ * (`vi.useFakeTimers`) instead of sleeping through them in real time. Waiting them
+ * out for real cost ~99s in one file and was the single largest contributor to the
+ * component suite overrunning its CI budget; importing the real constants keeps the
+ * tests pinned to the host's actual windows rather than to copies that can drift.
+ */
+export const BLOCK_READY_TIMEOUT_MS = 10_000;
+export const TOKEN_WAIT_TIMEOUT_MS = 15_000;
 
 /**
  * LAUNCH REVEAL (feedback #3: "launching an app should feel magical … subtly

--- a/src/components/AppBlocks/PageBlockHostAutoRetry.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostAutoRetry.browser.test.tsx
@@ -32,13 +32,37 @@ import {
  *  5. FRAME-1 still holds — every state stays wrapped in AppBlockChrome.
  *
  * 🔴 THIS SUITE EXERCISES THE REAL PATH. It renders the REAL PageBlockHost with
- * REAL hooks and REAL timers: no `@mantine/hooks` module mock (the reduced-motion
- * case stubs `window.matchMedia` so `useReducedMotion` itself still runs), and no
- * stub of the status machine. Only the ambient tRPC client + useCurrentUser are
- * stubbed, exactly as the sibling PageBlockHost suites do — those are the
- * network/session Context the offline scaffold can't provide, NOT the condition
- * under test. Mocking the retry decision or the media query as a constant would
- * remove the very thing being asserted.
+ * REAL hooks: no `@mantine/hooks` module mock (the reduced-motion case stubs
+ * `window.matchMedia` so `useReducedMotion` itself still runs), and no stub of the
+ * status machine. Only the ambient tRPC client + useCurrentUser are stubbed,
+ * exactly as the sibling PageBlockHost suites do — those are the network/session
+ * Context the offline scaffold can't provide, NOT the condition under test.
+ * Mocking the retry decision or the media query as a constant would remove the
+ * very thing being asserted.
+ *
+ * 🔴 THE CLOCK IS VIRTUAL, THE BEHAVIOUR IS NOT.
+ * The host's recovery windows are 10s (BLOCK_READY), 15s (token wait) and a
+ * 2s/5s backoff. Sleeping through them for real cost this ONE file 99.5s of the
+ * component suite's 25-minute CI budget — a third of it in a single test — and
+ * budget exhaustion (rc=124, "no suite reported red") is what made the
+ * `preview / component-tests` check red on 100% of PRs.
+ *
+ * So the eleven long tests install a VIRTUAL clock (`vi.useFakeTimers`, timer
+ * functions only — `Date`, `performance`, `requestAnimationFrame` and
+ * `queueMicrotask` are left real so React's scheduler and Mantine are untouched)
+ * and JUMP those windows with `advance()`. Nothing about the host changes: the
+ * same effects arm the same `setTimeout`s, the same status machine runs, the same
+ * `performRetry` executes. What changes is only how long the test sits waiting.
+ *
+ * 🔴 AND THEY STILL DRIVE THE ASYNC PATH. A converted test that stopped
+ * exercising the retry would look identical to one that passes, so every
+ * converted case asserts the RETRY ACTUALLY RAN — a fresh loading surface, a
+ * re-mint call count, a beacon count — not merely that nothing threw.
+ *
+ * THREE tests deliberately keep REAL timers: the two that assert an
+ * already-instant render (nothing to wait for) and the manual-Retry case, which
+ * uses a real Playwright `.click()` — driver interactions must not race a faked
+ * clock, and that test costs 358ms as-is.
  */
 
 // AppBlockChrome calls useCurrentUser() for the platform-nav moderator gate; this
@@ -102,7 +126,11 @@ vi.mock('~/utils/trpc', () => ({
 }));
 
 // eslint-disable-next-line import/first
-import { PageBlockHost } from '~/components/AppBlocks/PageBlockHost';
+import {
+  BLOCK_READY_TIMEOUT_MS,
+  PageBlockHost,
+  TOKEN_WAIT_TIMEOUT_MS,
+} from '~/components/AppBlocks/PageBlockHost';
 
 // Same-origin so trustTier='internal' yields a pinned (non-opaque) transport
 // whose expectedOrigin equals this frame's origin — see PageBlockHost.browser.test.
@@ -129,6 +157,85 @@ const baseProps = {
 };
 
 const FIRST_BACKOFF_MS = AUTO_RETRY_BACKOFF_MS[0];
+const LAST_BACKOFF_MS = AUTO_RETRY_BACKOFF_MS[AUTO_RETRY_BACKOFF_MS.length - 1];
+
+/**
+ * The REAL `setTimeout`, captured at module load — before any test installs the
+ * virtual clock, so this binding is never the faked one. `pollFor` needs it: a
+ * poll that only advances VIRTUAL time hands the browser almost no real time, so
+ * anything genuinely asynchronous (an iframe mounting) can miss its window on a
+ * loaded box while the poll burns its whole budget in milliseconds.
+ */
+const realSetTimeout = globalThis.setTimeout.bind(globalThis);
+const realSleep = (ms: number) => new Promise((r) => realSetTimeout(r, ms));
+
+/**
+ * Install the VIRTUAL clock for one test (call it before `renderWithProviders`,
+ * so the host's effects arm their timers against it).
+ *
+ * `toFake` is deliberately restricted to the timer functions. Leaving `Date`,
+ * `performance`, `requestAnimationFrame` and `queueMicrotask` REAL keeps React's
+ * scheduler (MessageChannel/rAF), Mantine's transitions and the browser driver
+ * working exactly as they do under real timers — the only thing that becomes
+ * virtual is how long a `setTimeout` takes to fire, which is the whole point.
+ */
+function useVirtualClock() {
+  vi.useFakeTimers({
+    toFake: ['setTimeout', 'clearTimeout', 'setInterval', 'clearInterval'],
+  });
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+/**
+ * Move time forward by `ms` and let React commit. Works under either clock, so
+ * the helpers below are shared by the virtual-clock tests and the three
+ * real-timer ones. Under the virtual clock the elapsed time is EXACT — that is
+ * what makes the "not yet, then fired" boundary assertions deterministic instead
+ * of a race against the runner.
+ */
+async function advance(ms: number) {
+  if (vi.isFakeTimers()) {
+    await vi.advanceTimersByTimeAsync(ms);
+    // Flush the promise/effect chain the fired timers kicked off. Each async
+    // tick also yields a REAL macrotask, so the browser (iframe loads, React's
+    // scheduler) makes progress even while virtual time stands still.
+    for (let i = 0; i < 6; i++) await vi.advanceTimersByTimeAsync(0);
+    return;
+  }
+  await new Promise((r) => setTimeout(r, ms));
+}
+
+/**
+ * Poll `ready()`, nudging the clock in small steps.
+ *
+ * 🔴 Used ONLY for things that depend on real browser work — an iframe mounting,
+ * a React commit landing. NEVER to wait out one of the host's recovery windows:
+ * those are jumped with an explicit `advance(WINDOW)` so the test states exactly
+ * how much time it believes has passed.
+ *
+ * Two budgets, deliberately decoupled: at most 500ms of VIRTUAL time (well inside
+ * the shortest recovery window, 2s, so a poll can never silently trip the very
+ * behaviour the test is about to assert) and up to 5s of REAL time for the
+ * browser to actually do the work. Advancing virtual time alone would give the
+ * page only microtasks — the failure mode that makes a fake-timer poll report
+ * "iframe never mounted" on a saturated runner.
+ */
+async function pollFor(what: string, ready: () => boolean) {
+  const fake = vi.isFakeTimers();
+  for (let i = 0; i < 500; i++) {
+    if (ready()) return;
+    if (fake) {
+      await advance(1);
+      await realSleep(10);
+    } else {
+      await advance(20);
+    }
+  }
+  throw new Error(`timed out waiting for: ${what}`);
+}
 
 function postFromBlock(type: string, payload?: unknown) {
   const iframeEl = page.getByTestId('app-page-iframe').element() as HTMLIFrameElement;
@@ -143,15 +250,22 @@ function postFromBlock(type: string, payload?: unknown) {
   );
 }
 
+const iframeEl = () => page.getByTestId('app-page-iframe').query() as HTMLIFrameElement | null;
+const loadingEl = () => page.getByTestId('app-page-loading').query();
+const fallbackEl = () => page.getByTestId('app-page-fallback').query();
+const autoRetryLine = () =>
+  document.querySelector('[data-block-fallback-autoretry="true"]') as HTMLElement | null;
+const retryButton = () =>
+  document.querySelector('[data-block-fallback-retry="true"]') as HTMLButtonElement | null;
+
+/** Wait for a freshly-mounted iframe to have a contentWindow we can post from. */
+const awaitIframeMount = () => pollFor('iframe mount', () => !!iframeEl()?.contentWindow);
+
 async function driveToReady() {
-  await vi.waitFor(() => {
-    const el = page.getByTestId('app-page-iframe').element() as HTMLIFrameElement;
-    if (!el.contentWindow) throw new Error('not mounted yet');
-  });
-  await vi.waitFor(() => {
+  await awaitIframeMount();
+  await pollFor('BLOCK_READY ack', () => {
     postFromBlock('BLOCK_READY', {});
-    const el = page.getByTestId('app-page-iframe').element() as HTMLIFrameElement;
-    if (el.getAttribute('data-block-ready') !== 'true') throw new Error('not ready yet');
+    return iframeEl()?.getAttribute('data-block-ready') === 'true';
   });
 }
 
@@ -159,16 +273,11 @@ async function driveToReady() {
 async function driveToFatal() {
   await driveToReady();
   postFromBlock('BLOCK_ERROR', { fatal: true });
-  await expect.element(page.getByTestId('app-page-fallback')).toBeInTheDocument();
+  await pollFor('terminal fallback', () => fallbackEl() !== null);
+  // Let the scheduling effect arm its backoff timer before anyone measures from
+  // "now" — otherwise a boundary assertion would be off by the commit.
+  await advance(0);
 }
-
-const fallbackEl = () => page.getByTestId('app-page-fallback').query();
-const autoRetryLine = () =>
-  document.querySelector('[data-block-fallback-autoretry="true"]') as HTMLElement | null;
-const retryButton = () =>
-  document.querySelector('[data-block-fallback-retry="true"]') as HTMLButtonElement | null;
-
-const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
 /**
  * Drives the AUTH-failure loop the way the real route does: each `onRetryToken`
@@ -232,42 +341,51 @@ describe('PageBlockHost auto-retry — fires from a terminal state, bounded and 
   });
 
   test('the automatic attempt actually re-runs the load after the backoff (and says so)', async () => {
+    useVirtualClock();
     renderWithProviders(
       <PageBlockHost {...baseProps} onConsentGranted={vi.fn()} onRetryToken={vi.fn()} />
     );
     await driveToFatal();
-    // Still in the terminal state for the whole backoff — the retry is NOT instant
-    // (a 0ms "backoff" would be a hot loop against a down host).
-    await sleep(Math.floor(FIRST_BACKOFF_MS / 2));
-    expect(fallbackEl()).not.toBeNull();
 
-    // …then the host re-attempts on its own: back to the loading surface, with a
-    // fresh iframe, and copy that says a RETRY is under way rather than the
-    // identical "Starting …" (the "did the button do anything?" half of the
-    // report). Deliberately no attempt NUMBER here — the bounded count lives on
-    // the terminal card, so the two surfaces can't show disagreeing counters.
-    await vi.waitFor(() => expect(page.getByTestId('app-page-loading').query()).not.toBeNull(), {
-      timeout: FIRST_BACKOFF_MS + 4_000,
-      interval: 50,
-    });
-    await expect.element(page.getByText('Retrying Budgeted Generator…')).toBeInTheDocument();
-    const el = page.getByTestId('app-page-iframe').element() as HTMLIFrameElement;
-    expect(el.getAttribute('data-block-ready')).toBe('false');
-  }, 20_000);
+    // 🔴 A VIRTUAL clock lets this pin the backoff at its BOUNDARY, which the old
+    // real-time version could not: one millisecond-ish before the window elapses
+    // the host is still terminal and has NOT re-attempted (a 0ms "backoff" would
+    // be a hot loop against a down host)…
+    await advance(FIRST_BACKOFF_MS - 50);
+    expect(fallbackEl()).not.toBeNull();
+    expect(loadingEl()).toBeNull();
+
+    // …and just past it the host re-attempts ON ITS OWN: back to the loading
+    // surface, with a fresh iframe, and copy that says a RETRY is under way rather
+    // than the identical "Starting …" (the "did the button do anything?" half of
+    // the report). Deliberately no attempt NUMBER here — the bounded count lives
+    // on the terminal card, so the two surfaces can't show disagreeing counters.
+    await advance(100);
+    await pollFor('retry loading surface', () => loadingEl() !== null);
+    expect(page.getByText('Retrying Budgeted Generator…').query()).not.toBeNull();
+    expect(iframeEl()?.getAttribute('data-block-ready')).toBe('false');
+  });
 
   test('auto-retry also fires from the `timeout` terminal (block never acks BLOCK_READY)', async () => {
+    useVirtualClock();
     renderWithProviders(
       <PageBlockHost {...baseProps} onConsentGranted={vi.fn()} onRetryToken={vi.fn()} />
     );
-    // ~10s readiness window → 'timeout'.
-    await vi.waitFor(() => expect(fallbackEl()).not.toBeNull(), {
-      timeout: 13_000,
-      interval: 250,
-    });
+    // The readiness window is armed once the frame mounts; nothing acks, so
+    // burning it lands on 'timeout'.
+    await awaitIframeMount();
+    expect(fallbackEl()).toBeNull();
+    await advance(BLOCK_READY_TIMEOUT_MS);
+    await pollFor('timeout terminal', () => fallbackEl() !== null);
+    // Assert the line EXISTS before reading it — otherwise a host that stopped
+    // auto-retrying from `timeout` fails on `.toContain(undefined)`, whose message
+    // describes the assertion rather than the regression.
+    expect(autoRetryLine()).not.toBeNull();
     expect(autoRetryLine()?.textContent).toContain(`attempt 1 of ${MAX_AUTO_RETRIES}`);
-  }, 25_000);
+  });
 
   test('auto-retry also fires from the `no_token` terminal, and it RE-MINTS', async () => {
+    useVirtualClock();
     const onRetryToken = vi.fn();
     renderWithProviders(
       <PageBlockHost
@@ -278,34 +396,36 @@ describe('PageBlockHost auto-retry — fires from a terminal state, bounded and 
         onRetryToken={onRetryToken}
       />
     );
-    // ~15s token-wait window → 'no_token'.
-    await vi.waitFor(() => expect(fallbackEl()).not.toBeNull(), {
-      timeout: 19_000,
-      interval: 250,
-    });
+    // The token-wait window is still open — no terminal yet.
+    await advance(TOKEN_WAIT_TIMEOUT_MS - 100);
+    expect(fallbackEl()).toBeNull();
+    // …and burning the rest of it lands on 'no_token'.
+    await advance(200);
+    await pollFor('no_token terminal', () => fallbackEl() !== null);
     expect(onRetryToken).not.toHaveBeenCalled();
+
     // An auth terminal can ONLY be recovered by re-minting (the token is an
     // upstream prop) — so the automatic attempt must re-mint, not just remount.
-    await vi.waitFor(() => expect(onRetryToken).toHaveBeenCalledTimes(1), {
-      timeout: FIRST_BACKOFF_MS + 4_000,
-      interval: 50,
-    });
-  }, 30_000);
+    await advance(FIRST_BACKOFF_MS + 100);
+    await pollFor('re-mint', () => onRetryToken.mock.calls.length >= 1);
+    expect(onRetryToken).toHaveBeenCalledTimes(1);
+  });
 
   test('a NON-auth terminal auto-retries WITHOUT re-minting (the token was fine)', async () => {
+    useVirtualClock();
     const onRetryToken = vi.fn();
     renderWithProviders(
       <PageBlockHost {...baseProps} onConsentGranted={vi.fn()} onRetryToken={onRetryToken} />
     );
     await driveToFatal();
-    await vi.waitFor(() => expect(page.getByTestId('app-page-loading').query()).not.toBeNull(), {
-      timeout: FIRST_BACKOFF_MS + 4_000,
-      interval: 50,
-    });
+    await advance(FIRST_BACKOFF_MS + 100);
+    // The automatic attempt DID run — this is the assertion that keeps the test
+    // from passing vacuously once it no longer waits in real time.
+    await pollFor('retry loading surface', () => loadingEl() !== null);
     // The block crashed; the token was never the problem. Re-minting here would
     // burn the rate-limited endpoint for nothing.
     expect(onRetryToken).not.toHaveBeenCalled();
-  }, 20_000);
+  });
 });
 
 describe('PageBlockHost auto-retry — survives an UNSTABLE onRetryToken prop', () => {
@@ -317,9 +437,12 @@ describe('PageBlockHost auto-retry — survives an UNSTABLE onRetryToken prop', 
   // SILENTLY NEVER FIRE. The host reads the retry through a ref so the effect is
   // keyed on the decision alone.
   test('auto-retry still fires while the parent re-renders with a fresh callback each time', async () => {
+    useVirtualClock();
     const onRemint = vi.fn();
+    let renderCount = 0;
     function ChurningParent() {
       const [, setTick] = useState(0);
+      renderCount++;
       // Re-render faster than the backoff; each render hands the host a NEW
       // `onRetryToken` identity (an inline arrow, the shape a caller may well use).
       useEffect(() => {
@@ -338,62 +461,56 @@ describe('PageBlockHost auto-retry — survives an UNSTABLE onRetryToken prop', 
     }
     renderWithProviders(<ChurningParent />);
 
-    await vi.waitFor(() => expect(autoRetryLine()).not.toBeNull(), {
-      timeout: 5_000,
-      interval: 50,
-    });
-    // The attempt must still land despite ~20 re-renders during the backoff.
-    await vi.waitFor(() => expect(onRemint).toHaveBeenCalled(), {
-      timeout: FIRST_BACKOFF_MS + 5_000,
-      interval: 50,
-    });
-  }, 20_000);
+    await pollFor('auth terminal with pending retry', () => autoRetryLine() !== null);
+    const rendersBefore = renderCount;
+    // The attempt must still land despite the re-renders during the backoff. The
+    // 100ms interval is on the same virtual clock, so advancing the backoff also
+    // churns the parent ~20 times — the churn is the condition under test, so it
+    // is asserted, not assumed.
+    await advance(FIRST_BACKOFF_MS + 100);
+    expect(renderCount - rendersBefore).toBeGreaterThanOrEqual(15);
+    await pollFor('re-mint despite churn', () => onRemint.mock.calls.length > 0);
+    expect(onRemint).toHaveBeenCalled();
+  });
 });
 
 describe('PageBlockHost auto-retry — the caps (unbounded loops are the failure mode)', () => {
   test('AUTH terminals re-mint AT MOST MAX_AUTO_REMINTS times, then stop', async () => {
+    useVirtualClock();
     const onRemint = vi.fn();
     renderWithProviders(<AuthFailureHarness onRemint={onRemint} />);
 
     // 🔴 The advertised ceiling on the AUTH path is the RE-MINT budget, not the
     // attempt cap — the user must not be promised a retry that can never happen.
-    await vi.waitFor(() => expect(autoRetryLine()).not.toBeNull(), {
-      timeout: 5_000,
-      interval: 50,
-    });
+    await pollFor('auth terminal with pending retry', () => autoRetryLine() !== null);
     expect(autoRetryLine()?.textContent).toContain(`attempt 1 of ${MAX_AUTO_REMINTS}`);
     expect(autoRetryLine()?.textContent).not.toContain(`of ${MAX_AUTO_RETRIES}`);
 
     // The host burns its automatic budget …
-    await vi.waitFor(() => expect(onRemint).toHaveBeenCalledTimes(MAX_AUTO_REMINTS), {
-      timeout: 25_000,
-      interval: 100,
-    });
-
-    // 🔴 …and then STOPS. Waiting well past another full backoff must produce no
-    // further re-mint. This is the rate-limit guard: `/api/v1/block-tokens` is
-    // 60/min, and an unbounded auth-failure loop is exactly the shape that
-    // would burn it.
-    await sleep(AUTO_RETRY_BACKOFF_MS[AUTO_RETRY_BACKOFF_MS.length - 1] + 3_000);
+    await advance(FIRST_BACKOFF_MS + 100);
+    await pollFor('budget spent', () => onRemint.mock.calls.length >= MAX_AUTO_REMINTS);
     expect(onRemint).toHaveBeenCalledTimes(MAX_AUTO_REMINTS);
-  }, 45_000);
+
+    // 🔴 …and then STOPS. Advancing well past another full backoff must produce
+    // no further re-mint. This is the rate-limit guard: `/api/v1/block-tokens` is
+    // 60/min, and an unbounded auth-failure loop is exactly the shape that
+    // would burn it. On the virtual clock this now covers MANY multiples of the
+    // longest backoff instead of one, for no wall-clock cost at all.
+    await advance(10 * LAST_BACKOFF_MS);
+    expect(onRemint).toHaveBeenCalledTimes(MAX_AUTO_REMINTS);
+  });
 
   test('after exhaustion the host settles on a DEFINITIVE terminal state with a PROMINENT manual Retry', async () => {
+    useVirtualClock();
     const onRemint = vi.fn();
     renderWithProviders(<AuthFailureHarness onRemint={onRemint} />);
-    await vi.waitFor(() => expect(onRemint).toHaveBeenCalledTimes(MAX_AUTO_REMINTS), {
-      timeout: 25_000,
-      interval: 100,
-    });
+    await pollFor('auth terminal with pending retry', () => autoRetryLine() !== null);
+    await advance(FIRST_BACKOFF_MS + 100);
+    await pollFor('budget spent', () => onRemint.mock.calls.length >= MAX_AUTO_REMINTS);
 
     // Settle: the pending-retry line is gone and the fallback is final.
-    await vi.waitFor(
-      () => {
-        expect(fallbackEl()).not.toBeNull();
-        expect(autoRetryLine()).toBeNull();
-      },
-      { timeout: 20_000, interval: 100 }
-    );
+    await advance(LAST_BACKOFF_MS + 1_000);
+    await pollFor('settled terminal', () => fallbackEl() !== null && autoRetryLine() === null);
 
     // 🔴 THE ACTUAL REPORTED FAILURE: the manual affordance must now be
     // impossible to miss. It is filled + full-width rather than the small
@@ -411,9 +528,9 @@ describe('PageBlockHost auto-retry — the caps (unbounded loops are the failure
     );
     expect(spentNote?.textContent).toMatch(/already retried/);
     // Still reachable by its stable accessible name, and still inside the chrome.
-    await expect.element(page.getByRole('button', { name: 'Retry' })).toBeInTheDocument();
-    await expect.element(page.getByTestId('app-block-chrome')).toBeInTheDocument();
-  }, 60_000);
+    expect(page.getByRole('button', { name: 'Retry' }).query()).not.toBeNull();
+    expect(page.getByTestId('app-block-chrome').query()).not.toBeNull();
+  });
 });
 
 describe('PageBlockHost auto-retry — beacon semantics (one per mount, the settled outcome)', () => {
@@ -435,26 +552,24 @@ describe('PageBlockHost auto-retry — beacon semantics (one per mount, the sett
   });
 
   test('success on attempt 2 emits EXACTLY ONE `ok` beacon — and no `error` first', async () => {
+    useVirtualClock();
     renderWithProviders(
       <PageBlockHost {...baseProps} onConsentGranted={vi.fn()} onRetryToken={vi.fn()} />
     );
 
     // Attempt 1 fails by never acking → 'timeout'. It must emit NOTHING (an
     // automatic attempt is still coming — the host has not settled).
-    await vi.waitFor(() => expect(fallbackEl()).not.toBeNull(), {
-      timeout: 13_000,
-      interval: 250,
-    });
+    await awaitIframeMount();
+    await advance(BLOCK_READY_TIMEOUT_MS);
+    await pollFor('timeout terminal', () => fallbackEl() !== null);
     expect(beaconCalls()).toHaveLength(0);
 
-    // Attempt 2 succeeds.
-    await vi.waitFor(() => expect(page.getByTestId('app-page-loading').query()).not.toBeNull(), {
-      timeout: FIRST_BACKOFF_MS + 4_000,
-      interval: 50,
-    });
+    // Attempt 2 runs (a fresh loading surface) and succeeds.
+    await advance(FIRST_BACKOFF_MS + 100);
+    await pollFor('retry loading surface', () => loadingEl() !== null);
     await driveToReady();
 
-    await vi.waitFor(() => expect(beaconCalls()).toHaveLength(1));
+    await pollFor('ok beacon', () => beaconCalls().length >= 1);
     const [body] = beaconBodies();
     // The `ok` beacon carries no `status` field (see sendBlockRender).
     expect(body).toEqual({
@@ -462,10 +577,11 @@ describe('PageBlockHost auto-retry — beacon semantics (one per mount, the sett
       blockInstanceId: 'page_apb_test',
       slotId: 'app.page',
     });
-    // Give any stray emit a chance to show up before asserting exclusivity.
-    await sleep(300);
+    // Give any stray emit a chance to show up before asserting exclusivity — on
+    // the virtual clock that can be a generous window for free.
+    await advance(LAST_BACKOFF_MS + BLOCK_READY_TIMEOUT_MS);
     expect(beaconCalls()).toHaveLength(1);
-  }, 30_000);
+  });
 
   test('a mount that already reported `ok` never additionally reports `error` after a crash + failed recovery', async () => {
     // 🔴 THE EMIT-ONCE GUARD. `performRetry` must NOT reset
@@ -478,25 +594,32 @@ describe('PageBlockHost auto-retry — beacon semantics (one per mount, the sett
     // performRetry fails THIS test. The sibling "N failed attempts emit ONE
     // error" test does NOT catch it — the settled-gate alone keeps that path to
     // one beacon — which is why this case exists separately.)
+    useVirtualClock();
     renderWithProviders(
       <PageBlockHost {...baseProps} onConsentGranted={vi.fn()} onRetryToken={vi.fn()} />
     );
 
     // Load succeeds → exactly one `ok`.
     await driveToReady();
-    await vi.waitFor(() => expect(beaconCalls()).toHaveLength(1));
+    await pollFor('ok beacon', () => beaconCalls().length >= 1);
     expect(beaconBodies()[0]).not.toHaveProperty('status');
 
-    // Then the block crashes and every automatic recovery attempt fails
-    // (the fresh frames never ack, so each rides the readiness timeout).
+    // Then the block crashes and every automatic recovery attempt fails (the
+    // fresh frames never ack, so each rides the readiness timeout). Stepped
+    // explicitly rather than in one big jump, so the test asserts that each
+    // automatic attempt REALLY RAN — a fresh loading surface with a fresh frame —
+    // instead of only that the end state looks settled.
     postFromBlock('BLOCK_ERROR', { fatal: true });
-    await vi.waitFor(
-      () => {
-        expect(fallbackEl()).not.toBeNull();
-        expect(autoRetryLine()).toBeNull(); // settled: budget spent
-      },
-      { timeout: 40_000, interval: 250 }
-    );
+    await pollFor('fatal terminal', () => fallbackEl() !== null);
+    await advance(0);
+    for (const backoffMs of AUTO_RETRY_BACKOFF_MS.slice(0, MAX_AUTO_RETRIES)) {
+      await advance(backoffMs + 100);
+      await pollFor('automatic attempt runs', () => loadingEl() !== null);
+      await awaitIframeMount();
+      await advance(BLOCK_READY_TIMEOUT_MS);
+      await pollFor('attempt times out', () => fallbackEl() !== null);
+    }
+    expect(autoRetryLine()).toBeNull(); // settled: budget spent
 
     // Still exactly the one `ok` — no `error` beacon was re-opened.
     expect(beaconCalls()).toHaveLength(1);
@@ -513,31 +636,31 @@ describe('PageBlockHost auto-retry — beacon semantics (one per mount, the sett
     expect(spentNote?.textContent).toBe(
       `We already retried ${MAX_AUTO_RETRIES} times automatically.`
     );
-  }, 60_000);
+  });
 
   test('N failed automatic attempts emit ONE `error` beacon, not N', async () => {
+    useVirtualClock();
     const onRemint = vi.fn();
     renderWithProviders(<AuthFailureHarness onRemint={onRemint} />);
 
-    // Burn the whole automatic budget.
-    await vi.waitFor(() => expect(onRemint).toHaveBeenCalledTimes(MAX_AUTO_REMINTS), {
-      timeout: 25_000,
-      interval: 100,
-    });
+    // Burn the whole automatic budget — and assert it was actually burnt, so the
+    // "one beacon" claim below is about a real multi-attempt sequence.
+    await pollFor('auth terminal with pending retry', () => autoRetryLine() !== null);
+    await advance(FIRST_BACKOFF_MS + 100);
+    await pollFor('budget spent', () => onRemint.mock.calls.length >= MAX_AUTO_REMINTS);
+
     // Settle, then exactly ONE error beacon for the whole sequence.
-    await vi.waitFor(() => expect(beaconCalls()).toHaveLength(1), {
-      timeout: 20_000,
-      interval: 100,
-    });
+    await advance(LAST_BACKOFF_MS + 1_000);
+    await pollFor('error beacon', () => beaconCalls().length >= 1);
     const [body] = beaconBodies();
     expect(body.status).toBe('error');
     // errorClass stays inside the server-side KNOWN_ERROR_CLASSES enum, so the
     // existing prom label + its alert are unchanged by auto-retry.
     expect(['error', 'no_token']).toContain(body.errorClass);
 
-    await sleep(AUTO_RETRY_BACKOFF_MS[AUTO_RETRY_BACKOFF_MS.length - 1] + 2_000);
+    await advance(10 * LAST_BACKOFF_MS);
     expect(beaconCalls()).toHaveLength(1);
-  }, 60_000);
+  });
 });
 
 describe('PageBlockHost auto-retry — reduced motion', () => {
@@ -581,6 +704,10 @@ describe('PageBlockHost auto-retry — reduced motion', () => {
 });
 
 describe('PageBlockHost auto-retry — manual Retry interaction + teardown', () => {
+  // 🔴 REAL TIMERS ON PURPOSE. This is the only case driven by a real Playwright
+  // `.click()`, and the driver's own round-trip must not race a faked clock. It
+  // never waits out a recovery window (it deliberately takes over mid-backoff),
+  // so it costs ~0.4s as-is and has nothing to gain from a virtual clock.
   test('a manual Retry DURING a pending auto-retry runs once and does not consume the automatic budget', async () => {
     const onRetryToken = vi.fn();
     renderWithProviders(
@@ -606,6 +733,7 @@ describe('PageBlockHost auto-retry — manual Retry interaction + teardown', () 
   }, 20_000);
 
   test('unmounting mid-backoff leaks NO timer — the pending attempt never fires', async () => {
+    useVirtualClock();
     const onRemint = vi.fn();
     function Harness() {
       const [mounted, setMounted] = useState(true);
@@ -621,23 +749,23 @@ describe('PageBlockHost auto-retry — manual Retry interaction + teardown', () 
     renderWithProviders(<Harness />);
 
     // An auth terminal is reached and an automatic re-mint is scheduled …
-    await vi.waitFor(() => expect(autoRetryLine()).not.toBeNull(), {
-      timeout: 5_000,
-      interval: 50,
-    });
+    await pollFor('auth terminal with pending retry', () => autoRetryLine() !== null);
 
-    // … unmount before the backoff elapses.
-    await page.getByTestId('unmount-host').click();
-    await vi.waitFor(() => expect(page.getByTestId('app-page-frame').query()).toBeNull());
-    // Snapshot AT unmount rather than asserting zero beforehand: on a slow box a
-    // first automatic attempt may legitimately have already fired. The invariant
-    // under test is that NOTHING fires AFTER unmount, and that holds either way.
-    const remintsAtUnmount = onRemint.mock.calls.length;
+    // 🔴 On the virtual clock the backoff DEMONSTRABLY has not elapsed yet — the
+    // real-time version could only hope so, and had to snapshot a possibly-nonzero
+    // count to stay honest. Here the pending attempt is provably still pending, so
+    // the assertion below is "zero, and still zero", not "unchanged from whatever".
+    expect(onRemint).not.toHaveBeenCalled();
+
+    // … unmount before the backoff elapses. A native click (not a driver click)
+    // because the clock is virtual; the handler under test is React's onClick.
+    (page.getByTestId('unmount-host').element() as HTMLButtonElement).click();
+    await pollFor('host unmounted', () => page.getByTestId('app-page-frame').query() === null);
 
     // 🔴 A leaked timer would fire the scheduled attempt after unmount — hitting
-    // the rate-limited mint endpoint for a page nobody is looking at. Wait well
-    // past the backoff and assert the count never grew.
-    await sleep(FIRST_BACKOFF_MS + 2_000);
-    expect(onRemint.mock.calls.length).toBe(remintsAtUnmount);
-  }, 30_000);
+    // the rate-limited mint endpoint for a page nobody is looking at. Advance well
+    // past the backoff and assert nothing fired.
+    await advance(10 * LAST_BACKOFF_MS);
+    expect(onRemint).not.toHaveBeenCalled();
+  });
 });

--- a/src/server/utils/__tests__/og-metadata.test.ts
+++ b/src/server/utils/__tests__/og-metadata.test.ts
@@ -225,7 +225,21 @@ describe('extractListingMeta', () => {
      * (mutation-verified — see the PR that introduced these). The last test keeps
      * the real 1.5MB hostile inputs as a CORRECTNESS + no-hang check, with the
      * hang expressed as a per-test timeout rather than an elapsed-ms assertion.
+     *
+     * 🔴 The two BOUND tests below build their inputs FROM these constants, so
+     * they pin that truncation happens — never WHERE it happens. Widening a cap
+     * therefore keeps them green while silently restoring the cost this bound
+     * exists to remove: raising META_HTML_PARSE_CAP to 2_000_000 (above the
+     * ~1.5MB fetch byte cap, so truncation is dead for every real input) passed
+     * 26/26 while making the parse 6.6x more expensive. The VALUES are part of
+     * the cost contract, so they are pinned literally here — deriving them from
+     * the import would reproduce the same tautology.
      */
+
+    it('the cap VALUES are part of the cost contract, not free parameters', () => {
+      expect(META_HTML_PARSE_CAP).toBe(256_000);
+      expect(HEADER_NAV_BLOCK_MAX).toBe(8_000);
+    });
 
     it('BOUND 1 — truncates at META_HTML_PARSE_CAP: a tag past the cap is not parsed, the same tag ending exactly at it is', () => {
       const tag = '<meta property="og:title" content="Beyond The Cap">';

--- a/src/server/utils/__tests__/og-metadata.test.ts
+++ b/src/server/utils/__tests__/og-metadata.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest';
 
-import { extractListingMeta } from '~/server/utils/og-metadata';
+import {
+  extractListingMeta,
+  HEADER_NAV_BLOCK_MAX,
+  META_HTML_PARSE_CAP,
+} from '~/server/utils/og-metadata';
 
 /**
  * PURE OG/HTML metadata extraction — og:title/description/image + favicon/
@@ -195,25 +199,81 @@ describe('extractListingMeta', () => {
   });
 
   describe('adversarial-input cost (event-loop-freeze / ReDoS guard)', () => {
-    // Regression for the O(n^2) container-regex freeze: many unclosed <header>
-    // open tags forced the lazy backreference match to rescan to EOF at every
-    // start position. A ~1.5MB body froze the event loop ~45s. The parse cap +
-    // bounded lazy quantifier make it linear-with-small-constant. Threshold is
-    // generous (CI variance) but still ~10x under the broken time.
-    it('parses a 1.5MB run of unclosed <header> tags in bounded time', () => {
-      const html = '<header>'.repeat(200_000); // ~1.6MB, no closer, no <link icon>
-      const t0 = Date.now();
-      const r = extractListingMeta(html, BASE);
-      const elapsed = Date.now() - t0;
-      expect(r.iconImageUrl).toBeUndefined(); // nothing extractable, but no hang
-      expect(elapsed).toBeLessThan(4000);
+    /**
+     * Regression for the O(n^2) container-regex freeze: many unclosed <header>
+     * open tags forced the lazy backreference match to rescan to EOF at every
+     * start position, and a ~1.5MB body froze the event loop ~45s.
+     *
+     * 🔴 THESE USED TO ASSERT `elapsed < 4000ms`, WHICH TESTED THE RUNNER, NOT THE
+     * CODE. A wall-clock bound is unfalsifiable on a fast box and fails on a
+     * contended one: locally the parse takes ~350-460ms, but on the shared
+     * PR-preview runner the same assertion failed on 100% of PRs while the
+     * identical suite passed in GitHub Actions. A permanently-red gate is worse
+     * than no gate, so the assertion is now ALGORITHMIC.
+     *
+     * What actually makes the parse linear-with-small-constant is TWO EXPLICIT
+     * BOUNDS in the implementation, and both are OBSERVABLE — so they are pinned
+     * by behaviour, at their exact boundary, with no timing at all:
+     *
+     *   1. `META_HTML_PARSE_CAP` — the document is truncated before parsing, so
+     *      total work cannot grow past a fixed prefix however large the body is.
+     *   2. `HEADER_NAV_BLOCK_MAX` — the container regex's lazy inner capture is
+     *      length-bounded, so an unmatched `<header>` costs a bounded rescan
+     *      instead of a scan to EOF at every start position.
+     *
+     * Delete either bound and the matching test below fails deterministically
+     * (mutation-verified — see the PR that introduced these). The last test keeps
+     * the real 1.5MB hostile inputs as a CORRECTNESS + no-hang check, with the
+     * hang expressed as a per-test timeout rather than an elapsed-ms assertion.
+     */
+
+    it('BOUND 1 — truncates at META_HTML_PARSE_CAP: a tag past the cap is not parsed, the same tag ending exactly at it is', () => {
+      const tag = '<meta property="og:title" content="Beyond The Cap">';
+
+      // Ends exactly AT the cap → `html.length > cap` is false → nothing sliced.
+      const atCap = 'x'.repeat(META_HTML_PARSE_CAP - tag.length) + tag;
+      expect(atCap.length).toBe(META_HTML_PARSE_CAP);
+      expect(extractListingMeta(atCap, BASE).name).toBe('Beyond The Cap');
+
+      // Starts one byte PAST the cap → sliced away entirely before parsing. This
+      // is the assertion that goes red if the truncation is ever removed: without
+      // it the extractor reads the whole (unbounded) body and finds the title.
+      const pastCap = 'x'.repeat(META_HTML_PARSE_CAP) + tag;
+      expect(extractListingMeta(pastCap, BASE)).toEqual({});
     });
 
-    it('parses a 1.5MB run of mismatched header/nav tags in bounded time', () => {
-      const html = '<header>x</nav>'.repeat(120_000); // backref never satisfied
-      const t0 = Date.now();
-      extractListingMeta(html, BASE);
-      expect(Date.now() - t0).toBeLessThan(4000);
+    it('BOUND 2 — the header/nav container scan is length-bounded: a block longer than HEADER_NAV_BLOCK_MAX yields no icon, one exactly at it does', () => {
+      // No class/alt/id mentioning logo/header/brand, so this <img> is reachable
+      // ONLY through the <header> container scan — never the logo-attribute path.
+      const img = '<img src="/hero-pic.png">';
+      const header = (innerLen: number) =>
+        `<header>${'x'.repeat(innerLen - img.length)}${img}</header>`;
+
+      // Inner content exactly at the bound → still matched → icon suggested.
+      expect(extractListingMeta(header(HEADER_NAV_BLOCK_MAX), BASE).iconImageUrl).toBe(
+        'https://vendor.example.com/hero-pic.png'
+      );
+
+      // One byte over → the bounded lazy capture can no longer reach `</header>`,
+      // so the block is skipped rather than rescanned to EOF. Replacing the
+      // bounded quantifier with an unbounded `*?` makes this find the image, which
+      // is exactly the catastrophic-backtracking shape the bound exists to stop.
+      expect(extractListingMeta(header(HEADER_NAV_BLOCK_MAX + 1), BASE).iconImageUrl).toBe(
+        undefined
+      );
     });
+
+    it('the real 1.5MB hostile bodies parse correctly and cannot hang', () => {
+      // Both shapes are the original freeze vectors: unclosed opens, and a
+      // backreference that is never satisfied. With the bounds in place this test
+      // runs in ~0.6s; with BOTH bounds removed it was measured at 84s (the first
+      // body alone is ~29s on an idle box). So the per-test timeout is a genuine
+      // hang detector with ~25x headroom, where the old `elapsed < 4000ms`
+      // assertion had ~9x and lost that bet on a contended runner. It is a
+      // BACKSTOP for a superlinear regression introduced somewhere OTHER than the
+      // two bounds above — the deterministic boundary tests are the real guard.
+      expect(extractListingMeta('<header>'.repeat(200_000), BASE)).toEqual({});
+      expect(extractListingMeta('<header>x</nav>'.repeat(120_000), BASE)).toEqual({});
+    }, 15_000);
   });
 });

--- a/src/server/utils/og-metadata.ts
+++ b/src/server/utils/og-metadata.ts
@@ -30,14 +30,28 @@ const MAX_DESCRIPTION_LEN = 2000; // mirrors OFFSITE_DESCRIPTION_MAX
  * fallback skips it. A logo is never 32px or smaller on either declared side.
  */
 const MIN_HEADER_IMG_PX = 32;
-// Only the first slice of a document is parsed for metadata — all signals (og:*,
-// <title>, <link rel=icon>, brand/header <img>) live at the page top. Bounds the
-// cost of scanning adversarial HTML (see extractListingMeta).
-const META_HTML_PARSE_CAP = 256_000;
-// A single <header>/<nav> block is never anywhere near this large; bounding the
-// lazy inner capture stops the container regex from rescanning to EOF at every
-// unmatched open tag (the O(n^2) event-loop-freeze vector on hostile input).
-const HEADER_NAV_BLOCK_MAX = 8_000;
+/**
+ * Only the first slice of a document is parsed for metadata — all signals (og:*,
+ * <title>, <link rel=icon>, brand/header <img>) live at the page top. Bounds the
+ * cost of scanning adversarial HTML (see extractListingMeta).
+ *
+ * 🔴 EXPORTED because it is a COST CONTRACT, not an implementation detail: it is
+ * one of the two explicit bounds that make parsing linear-with-small-constant on
+ * hostile input, and the ReDoS regression tests assert it is enforced by
+ * OBSERVING the truncation (content past the cap is not extracted) rather than by
+ * timing the parse on whatever box happens to run CI.
+ */
+export const META_HTML_PARSE_CAP = 256_000;
+/**
+ * A single <header>/<nav> block is never anywhere near this large; bounding the
+ * lazy inner capture stops the container regex from rescanning to EOF at every
+ * unmatched open tag (the O(n^2) event-loop-freeze vector on hostile input).
+ *
+ * 🔴 EXPORTED for the same reason as {@link META_HTML_PARSE_CAP}: the bound is
+ * observable (a header block longer than this yields no icon candidate), which is
+ * what lets the regression test pin it deterministically.
+ */
+export const HEADER_NAV_BLOCK_MAX = 8_000;
 /**
  * Allowed inline-icon data-URI image MIME types (mirrors the server ingest
  * allowlist). A `data:text/html` / `data:application/*` / script URI is NEVER


### PR DESCRIPTION
## Why

`preview / component-tests` and `preview / unit-tests` are FAILURE on **100% of PRs** (identical on #3528, #3531, #3532, #3535). A permanently-red gate is worse than no gate — it trains everyone to click through, and three PRs merged through it today on the reasoning "it's red on unrelated PRs too". Neither failure was a correctness failure.

## 🔴 Correction to the diagnosis: component-tests is a HANG, not a slow suite

The check says *"exceeded its 25m budget (rc=124) — no suite reported red, the runner simply ran out of budget. Speed up or split the browser suite."* That reads as a suite that is too slow. **It isn't.**

Evidence, from PR #3535's own `component-tests` taskrun log and reproduced locally byte-for-byte:

| | CI (#3535) | local, `origin/main` |
|---|---|---|
| files that report | 110 of 111 | 110 of 111 |
| wall time to reach that point | — | **119s** (22:54:34 → 22:56:33) |
| then | killed at 25m | still nothing after 19m; I killed it |
| the one file that never reports | `AnnouncementEditModal.browser.test.tsx` | same file |

CI's per-test timings also match mine almost exactly (`PageBlockHostAutoRetry`: **99659ms** in CI vs **99480ms** here), so the runner is *not* meaningfully slower for this suite. The entire component suite is ~2 minutes of work; one file consumes the other 23.

### The mechanism

`AnnouncementEditModal.browser.test.tsx` mocks a query to return a fresh object literal per call:

```ts
getAnnouncementTargets: { useQuery: () => ({ data: [], isSuccess: true }) },
```

and the component keys an effect on that result while writing a **watched** form field:

```ts
const watchedTargets = form.watch('targetUserIds');          // subscribes
useEffect(() => {
  if (targetsQuery.data) form.setValue('targetUserIds', targetsQuery.data.join(', '));
}, [targetsQuery.data]);
```

Real react-query memoises `data`, so the effect runs once. The mock hands it a **new array identity every render**: effect → `setValue` → the watch subscriber re-renders → new `[]` → effect → …

That loop pegs the page's main thread, so **Vitest's own in-page test timeout can never fire**. The file hangs with *zero* output rather than reporting a failure — which is exactly why the status says "no suite reported red".

Introduced 2026-07-29 in `1e8d043695`. **Its 5 tests have not run since.**

**Fix:** hoist the query result so its identity is stable (one line + a note explaining why it must stay that way).

| | before | after |
|---|---|---|
| the file | never completes | **5 tests, 0.9s** |
| the full component suite | killed at 25m, verdict unknown | **completes, 90.25s** |
| tests reported | 1113 (5 silently dead) | **1118** — 1113 + exactly the 5 recovered |

### 🔴 "no suite reported red" was also wrong

Five tests **were** red in CI. The run was killed before the summary printed, so nobody saw them. They reproduce identically here on `origin/main`, and this PR does **not** fix them:

| file | tests | fails in isolation? |
|---|---|---|
| `AppBlockChrome.browser.test.tsx` | 1 | no — order/contention-dependent |
| `BlockHostTokenRetry.browser.test.tsx` | 3 | **yes** — `iframe never mounted`, deterministic |
| `AppsSubmitEditView.browser.test.tsx` | 1 | **yes** — `Cannot find element with locator: getByTestId('apps-offsite-edit-loading')` |

So this PR turns an **uninformative** red gate into an **informative** one: instead of "unknown after 25 minutes", it produces a real verdict in 90 seconds that names three genuine pre-existing bugs. Those need their own root-cause work (I probed the `BlockHostTokenRetry` one — it is *not* the poll-starvation class it resembles — and reverted). Follow-up, not scope creep here.

## Fix 2 — `PageBlockHostAutoRetry`: 99.5s → 2.8s

Not the cause of the overrun, but a third of one budget in one file and the longest single file on the critical path. It slept through the host's real 10s / 15s / 2s / 5s recovery windows.

Eleven of fourteen tests now use a **virtual clock** — `vi.useFakeTimers` restricted to `setTimeout`/`clearTimeout`/`setInterval`/`clearInterval`, leaving `Date`, `performance`, `requestAnimationFrame` and `queueMicrotask` real so React's scheduler and Mantine are untouched. Three keep real timers deliberately: two assert an already-instant render, and the manual-Retry case drives a real Playwright `.click()`, which must not race a faked clock.

| test | before | after |
|---|---:|---:|
| terminal renders the REAL error immediately | 132ms | 109ms |
| automatic attempt re-runs the load after the backoff | 2158ms | 284ms |
| fires from the `timeout` terminal | 10253ms | 197ms |
| fires from the `no_token` terminal, and RE-MINTS | 17054ms | 107ms |
| NON-auth terminal retries WITHOUT re-minting | 2171ms | 208ms |
| survives an UNSTABLE `onRetryToken` prop | 2055ms | 169ms |
| AUTH terminals re-mint AT MOST `MAX_AUTO_REMINTS` | 10055ms | 113ms |
| after exhaustion → definitive terminal + prominent Retry | 2104ms | 130ms |
| success on attempt 2 emits EXACTLY ONE `ok` beacon | 12407ms | 315ms |
| already-`ok` mount never additionally reports `error` | 27355ms | 574ms |
| N failed attempts emit ONE `error` beacon | 9103ms | 167ms |
| reduced motion — no spinner | 154ms | 66ms |
| manual Retry during a pending auto-retry | 358ms | 236ms |
| unmounting mid-backoff leaks NO timer | 4115ms | 105ms |
| **file total (`tests` / wall)** | **99.48s / 107.31s** | **2.99s / 4.74s** |

**Two assertions got stronger, not weaker,** because virtual time is exact:

- the backoff is now pinned at its **boundary** — still terminal and *not yet retried* at `FIRST_BACKOFF − 50ms`, fired by `+100ms`. The real-time version could only check halfway through.
- "…and then it STOPS" now advances **10×** the longest backoff instead of one, for zero wall-clock cost.

**Non-vacuity.** A converted test that stopped driving the async path would look identical to one that passes, so every converted case asserts the retry *actually ran* — a fresh loading surface, a re-mint call count, a beacon count. The exhaustion test steps attempt-by-attempt (`advance(backoff)` → assert a fresh loading surface → assert a fresh frame mounted → `advance(readyTimeout)`) rather than jumping to the end state.

Also hardened: polls that wait on real browser work now yield **real** time (a `setTimeout` captured before the clock is faked) as well as virtual time. Advancing virtual time alone gives the page only microtasks — the failure mode that makes a fake-timer poll report `iframe never mounted` on a loaded runner. Poll budgets are decoupled: ≤500ms virtual (well inside the 2s shortest window, so a poll can never trip the behaviour under test) and up to 5s real.

`BLOCK_READY_TIMEOUT_MS` / `TOKEN_WAIT_TIMEOUT_MS` are exported so the tests jump the host's **real** windows rather than copies that can drift.

### Mutation matrix — every test proven to still bite

Each mutation was applied to `PageBlockHost.tsx` / `pageBlockHostLogic.ts` alone, the file re-run, then reverted. Every run collected **14/14 tests** (a suite that fails to collect is not a caught mutation).

| # | mutation | test killed | failing assertion |
|---|---|---|---|
| J | mask the terminal while a retry is pending | terminal renders the REAL error immediately | `expected null not to be null` |
| D2 | `delayMs = 10` (retry lands before the window) | automatic attempt re-runs after the backoff | `expected null not to be null` (the T−50ms boundary) |
| I | `timeout` no longer auto-retryable | fires from the `timeout` terminal | `expected null not to be null` |
| F | `performRetry` never re-mints | fires from `no_token`, and RE-MINTS | *(timeout, specific to it)* |
| G | `performRetry` always re-mints | NON-auth terminal retries WITHOUT re-minting | `expected "vi.fn()" to not be called at all, but actually been called 1 times` |
| E | scheduling effect keyed on the callback identity | survives an UNSTABLE `onRetryToken` prop | *(timeout, specific to it — the effect re-arms forever)* |
| A | drop the `MAX_AUTO_REMINTS` cap | AUTH terminals re-mint AT MOST `MAX_AUTO_REMINTS` | `expected "vi.fn()" to be called 1 times, but got 2 times` |
| A | ” | after exhaustion → definitive terminal | `expected '2' to be '1'` (spent count) |
| K | `prominentRetry={false}` | after exhaustion → **prominent** manual Retry | `expected 'false' to be 'true'` |
| L | failure beacon no longer settled-gated | success on attempt 2 emits ONE `ok`, no `error` first | `expected [ [ '/api/track/block-render', …(1) ] ] to have a length of +0 but got 1` |
| B | `performRetry` resets `blockRenderEmittedRef` | already-`ok` mount never reports `error` | `expected [ […(2) ], […(2) ] ] to have a length of 1 but got 2` |
| N | **L + B together** | N failed attempts emit ONE `error` beacon, not N | `expected [ […(2) ], […(2) ] ] to have a length of 1 but got 2` |
| M | ignore `prefers-reduced-motion` | reduced motion — no spinner | `expected 'true' to be 'false'` |
| G | (as above) | manual Retry during a pending auto-retry | `expected "vi.fn()" to not be called at all, but actually been called 1 times` |
| C | drop the backoff timer's cleanup | unmounting mid-backoff leaks NO timer | `expected "vi.fn()" to not be called at all, but actually been called 1 times` |

Honest notes on this table:

- **12 of 14 die on their own assertion.** Two (`no_token` RE-MINTS, unstable-callback) die on a timeout. Both are still *specific* — the other 13 tests pass under those mutations — but a timeout is a weaker signal than an assertion, so I am flagging it rather than claiming a clean sweep.
- `N` had to be a **combination**: neither removing the settled-gate nor re-opening the emitted-ref alone can make the AUTH path emit more than one beacon, so "ONE error beacon, not N" is only violable by both at once. Worth knowing before anyone "simplifies" either guard.
- Polls were changed from `=== N` to `>= N` followed by an explicit `toHaveLength(N)`. Before that, an over-count made the poll spin until the test timed out; now it fails on the assertion. That change alone turned the `N`-mutation result for one test from a 15s timeout into a 200ms assertion failure.
- A mutation setting `delayMs = 0` killed all 14 (it hot-loops the host) — too blunt to attribute anything, so it is replaced by `D2` above.

## Fix 1 — the ReDoS guards were testing the runner

`src/server/utils/__tests__/og-metadata.test.ts` asserted `elapsed < 4000ms` on two 1.5MB adversarial inputs. Measured here: **463ms and 344ms** — nowhere near the budget. GitHub Actions runs the same suite on the same commits and passes; only the contended preview runner fails. So raising the budget would just move the flake, and the assertion is unfalsifiable on a fast box anyway.

The real invariant is *"parsing cost is not superlinear in input size"*, and what delivers it is **two explicit bounds that are both observable**. They are now pinned by behaviour at their exact ±1 boundary, with no timing:

- **`META_HTML_PARSE_CAP`** — a tag one byte past the cap is not parsed; the same tag ending *exactly* at it is.
- **`HEADER_NAV_BLOCK_MAX`** — a `<header>` block one byte over the bound yields no icon; one exactly at it does.

Both constants are now exported: they are a cost contract, not an implementation detail.

The 1.5MB hostile bodies are kept as a **correctness + no-hang** check, with the hang expressed as a per-test timeout rather than an elapsed-ms assertion.

| mutation | test | failing assertion |
|---|---|---|
| remove the parse-cap truncation | BOUND 1 | `expected { name: 'Beyond The Cap' } to deeply equal {}` |
| `{0,HEADER_NAV_BLOCK_MAX}?` → `*?` | BOUND 2 | `expected 'https://vendor.example.com/hero-pic.p…' to be undefined` |
| remove **both** | the 1.5MB hostile bodies | `Test timed out in 15000ms` (ran 84s, vs 0.6s intact) |

Each mutation kills exactly its own test; the other 25 stay green. The two deterministic tests cost **0ms** each. Headroom on the timeout backstop is now ~25× (was ~9× on the old assertion).

I deliberately did **not** add a timing-ratio test. It would catch a superlinear regression introduced somewhere *other* than these two bounds, but it re-introduces exactly the runner-sensitivity this PR removes. That gap is real and stated rather than papered over; the per-test timeout is the backstop for it.

## Fix 3 — `whatIfFromGraph`: investigated, NOT changed

Evidence from #3535's smoke log (taken ~3h ago, **before** the current DB restore window):

- it is the **only** failure — 60 passed, 1 failed;
- `TimeoutError: page.waitForResponse: Timeout 45000ms exceeded`, on **all 6 attempts** (3 Playwright retries × the test's own `retryFlaky(attempts: 2)`), 1.6m each;
- the predicate requires `status() === 200`, so this means no 200 from `orchestrator.whatIfFromGraph` within 45s of a `/generate` load — **six times**, over ~4.5 minutes, long after the pod is warm.

Six consecutive misses rules out the "cold pod" explanation the test's own comment offers. The two remaining candidates are (a) the query never fires because the default `/generate` form does not reach a valid preselected model against the preview's **dev** database (`useWhatIfFromGraph` gates on `!!queryPayload`, i.e. graph validation success, plus `!resourcesLoading`), or (b) it fires and returns non-200.

**I could not distinguish them, and I am not guessing.** Separating them needs a live preview run with the request/response observed, and `cnpg-cluster-dev` is currently mid-restore (`Setting up primary`, 0 ready instances, a ~89-minute WAL replay) — every preview is throwing Prisma login failures and `/api/v1/models` 500s, so nothing measured now is trustworthy.

**Recommendation:** keep the test. It guards a real money-path (the cost quote a user sees before spending Buzz) and it is not obviously mis-designed. Once `cnpg-cluster-dev` is ready, re-run it against a healthy preview with the network trace captured. If the request never fires, the fix is a fixture/seed problem in the dev DB (and the test should fail with "whatIf never fired", not a generic timeout) — not a reason to delete it. Do **not** raise the 45s budget: 6×45s of nothing is not a timeout problem.

## ✅ Authoritative result — this PR's own preview run (`pr-preview-3537-9nsbx`)

Measured on the real contended runner, not locally.

| check | before (every PR) | this PR |
|---|---|---|
| `preview / unit-tests` | **fail** — 2 failures / 10,440 | **PASS** — 732/732 files, 10,398 tests, 0 failures |
| `preview / component-tests` | **fail** — killed at 25m, *verdict unknown* | **completes in 79.06s**, real verdict: 1118 tests, 4 failed (all pre-existing) |

Detail from the runner's own logs:

- `AnnouncementEditModal.browser.test.tsx` — **5 tests, 1405ms**. It had never completed since 2026-07-29.
- `PageBlockHostAutoRetry.browser.test.tsx` — **14 tests, 5911ms**, was **99659ms** on this same runner. A **16.9×** reduction *in situ*, close to the 35× seen locally; the gap is the contention this file was never designed for.
- `og-metadata.test.ts` — 26 tests, **6534ms on the runner vs 877ms locally**. That ~7× contention factor is precisely why the old `elapsed < 4000ms` assertion lost its bet. The two new boundary tests are 0ms and do not care.
- Component failures on this run: `AppBlockChrome` ×1, `BlockHostTokenRetry` ×3 — all pre-existing (see table above). `AppsSubmitEditView` **passed** here while failing on `main` both in CI and locally, so that one is flaky rather than deterministic; corrected from my earlier note.

`preview / smoke-tests` reports **24 failures** on this run. That is the `cnpg-cluster-dev` restore described below, not this PR — the chronic baseline is 1.

## 🔴 Reading this PR's own preview

**The authoritative check is the preview run on this PR, not my local timings** — the whole premise of the original diagnosis was runner contention. Two caveats for whoever reads it:

1. **The shared preview DB is mid-restore.** `cnpg-cluster-dev` is at `Setting up primary` with 0 ready instances. `preview / smoke-tests` will be red with ~24 failures (chronic baseline is 1) and `render-check`/app behaviour will be unreliable. **That is not this PR.** The preview needs re-running once the cluster is ready.
2. **`preview / component-tests` is still red** — but for a *different and correct* reason, now confirmed above: it **completes in 79s** and reports 4 genuine pre-existing failures instead of "budget exceeded, verdict unknown". Fixing those 4 is follow-up work, not this PR.

## Verification performed

- **Local env** (NixOS, repo flake: Node 22.22.2, pnpm 10.28.1; system Chromium 151 via `PLAYWRIGHT_CHROMIUM_EXECUTABLE_PATH`). `prisma generate` **does** work here — the flake ships pinned engines — so the tree stayed clean.
- **Component suite, full:** 112 files, **1118 tests**, 90.25s, 5 failed. `origin/main` in the same environment: the run never completes, 1113 tests reported. `1113 + 5 = 1118` — no test lost, exactly the 5 recovered.
- **Unit suite, full:** 9683 passed / 4 skipped, **0 test failures**; `og-metadata.test.ts` → 26 tests, 877ms. 49 files fail to *collect* locally — all `Cannot find module '…/event-engine-common/…'`, the private submodule this checkout does not have. CI is authoritative there. Checked for the `panic: test timed out` truncation signature: none.
- **Typecheck** (`./node_modules/.bin/tsc --noEmit`, repo-local binary, `--max_old_space_size=8192`): 12 errors, all in `image.service.ts` / `bitdex-stats.ts`, all the same missing-submodule class. **None in any file this PR touches.**
- **ESLint / Prettier**, measured as a **delta against `origin/main` at the same paths** (both versions linted in-place so config resolves identically):
  - ESLint: 1 error + 1 warning, **both pre-existing** — the wholesale `vi.mock('~/utils/trpc')` in `PageBlockHostAutoRetry` (line 51 on main, 75 here) and an `<img>` warning in `AnnouncementEditModal`. Zero delta.
  - Prettier: 3 files are already non-clean on `origin/main` (`PageBlockHost.tsx`, `og-metadata.ts`, `og-metadata.test.ts`) and are left alone rather than reformatted into the diff. My edit made a 4th non-clean; that one is formatted. Net delta: zero.

### What I could NOT verify locally, and why

- **That the fix holds under real runner contention.** Local timings are a proxy. The hang, though, is deterministic and environment-independent — it reproduced identically in CI and here — so I have much higher confidence in that half.
- **Anything about `whatIfFromGraph`'s live behaviour** — the preview DB is mid-restore (above).
- **The 5 newly-visible component failures** are reported, not diagnosed. Three distinct causes; each needs its own root-cause pass.
- **Viewport/locale/timezone are not set explicitly** in the component project's browser config. Nothing I touched depends on them, and changing the global default would alter all 112 files — out of scope, but worth a follow-up given a past incident where two tests passed only because of the headless default window height.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wnxsw3bVq3s4DeQxZF6Tqp
