### PR TITLE
feat(app-blocks): step-type registry (kind:'step') + verified Tranche 1 — RFC #3515 steps 1–2

### DIFF
--- a/src/server/metrics/app-block-runtime.metrics.ts
+++ b/src/server/metrics/app-block-runtime.metrics.ts
@@ -234,6 +234,7 @@ type Bundle = {
   customComfyWallclockSeconds: Histogram<string>;
   capLimitsDegradedTotal: Counter<string>;
   spendCapRejectionsTotal: Counter<string>;
+  stepPriceDivergenceTotal: Counter<string>;
 };
 
 // ── customComfy per-engine runtime/cost buckets ──────────────────────────────
@@ -377,6 +378,30 @@ export function ensureRegisterAppBlockRuntimeMetrics(reg: Registry = client.regi
     ['reason']
   );
 
+  // ── `kind: 'step'` prepaidFixed PRICE DIVERGENCE ─────────────────────────────
+  // 🔴 This counter instruments the ONE input to the step bridge's money path
+  // that could not be verified before shipping: the orchestrator's ACTUAL price
+  // for a `prepaidFixed` step type. The registry DECLARES an exact price, gates
+  // the block token's per-call budget against it, and reserves it on every cap
+  // before submit. If the orchestrator ever bills MORE than the declared price,
+  // the declaration is wrong and the entry needs a higher price — or a different
+  // billing mode entirely, because "deterministic cost knowable before
+  // execution" would have turned out to be false for it.
+  //
+  // The submit path corrects the cap counters for the overage itself; this
+  // counter is what makes the correction VISIBLE instead of silent. A non-zero
+  // rate here is a registry bug, not a user problem.
+  //
+  // Cardinality: one `step` label, drawn from the code-owned registry keys
+  // (never client input — the wire enum is derived from those same keys, so an
+  // unregistered id cannot reach here). One series per registered step type.
+  const stepPriceDivergenceTotal = getOrCreateCounter(
+    reg,
+    'civitai_app_block_step_price_divergence_total',
+    "App Block `kind:'step'` submits whose REALIZED orchestrator cost exceeded the registry's DECLARED prepaidFixed price, by step id. Non-zero means the declared price is wrong.",
+    ['step']
+  );
+
   return {
     requestsTotal,
     requestDurationSeconds,
@@ -385,7 +410,25 @@ export function ensureRegisterAppBlockRuntimeMetrics(reg: Registry = client.regi
     customComfyWallclockSeconds,
     capLimitsDegradedTotal,
     spendCapRejectionsTotal,
+    stepPriceDivergenceTotal,
   };
+}
+
+/**
+ * Fail-soft emit of one `prepaidFixed` step price divergence (realized cost
+ * exceeded the registry's declared price). Called from the step submit path
+ * AFTER the money has already moved.
+ *
+ * 🔴 TOTAL, like every emitter in this module. It reports on an already-billed
+ * submit; a metrics error must never turn a successful generation into a 500.
+ */
+export function recordStepPriceDivergence(step: string): void {
+  try {
+    const { stepPriceDivergenceTotal } = ensureRegisterAppBlockRuntimeMetrics();
+    stepPriceDivergenceTotal.inc({ step });
+  } catch {
+    /* instrument-only — never let a metrics error touch an already-billed submit */
+  }
 }
 
 /**

--- a/src/server/metrics/app-block-runtime.metrics.ts
+++ b/src/server/metrics/app-block-runtime.metrics.ts
@@ -234,7 +234,7 @@ type Bundle = {
   customComfyWallclockSeconds: Histogram<string>;
   capLimitsDegradedTotal: Counter<string>;
   spendCapRejectionsTotal: Counter<string>;
-  stepPriceDivergenceTotal: Counter<string>;
+  stepPriceCheckTotal: Counter<string>;
 };
 
 // ── customComfy per-engine runtime/cost buckets ──────────────────────────────
@@ -378,28 +378,43 @@ export function ensureRegisterAppBlockRuntimeMetrics(reg: Registry = client.regi
     ['reason']
   );
 
-  // ── `kind: 'step'` prepaidFixed PRICE DIVERGENCE ─────────────────────────────
-  // 🔴 This counter instruments the ONE input to the step bridge's money path
-  // that could not be verified before shipping: the orchestrator's ACTUAL price
-  // for a `prepaidFixed` step type. The registry DECLARES an exact price, gates
-  // the block token's per-call budget against it, and reserves it on every cap
-  // before submit. If the orchestrator ever bills MORE than the declared price,
-  // the declaration is wrong and the entry needs a higher price — or a different
-  // billing mode entirely, because "deterministic cost knowable before
-  // execution" would have turned out to be false for it.
+  // ── `kind: 'step'` prepaidFixed PRICE CHECK ──────────────────────────────────
+  // 🔴 Instruments whether the registry's DECLARED price still matches what the
+  // orchestrator actually bills for a `prepaidFixed` step type. A declared price
+  // that drifts below the real one leaves every cap counter short.
   //
-  // The submit path corrects the cap counters for the overage itself; this
-  // counter is what makes the correction VISIBLE instead of silent. A non-zero
-  // rate here is a registry bug, not a user problem.
+  // 🔴 WHY THIS FIRES ON EVERY SUBMIT, NOT ONLY ON A DIVERGENCE. A
+  // divergence-only counter cannot distinguish "the price is right" from "the
+  // detector never ran" — both read as a flat zero forever, and the second is
+  // the state where the mitigation is inert. That is not a hypothetical: the
+  // detector reads `snapshot.cost?.total`, which `snapshotFromWorkflow` OMITS
+  // when the orchestrator returns no numeric cost, and the step submit passes no
+  // `wait`, so the response returns as soon as the job queues. (Measured
+  // 2026-08-02 against the live orchestrator: a queued `convertImage` submit —
+  // HTTP 202, status `processing` — DOES carry `cost.total`, so the precondition
+  // holds today. It was unverified before, and it is not guaranteed for a future
+  // step type.)
   //
-  // Cardinality: one `step` label, drawn from the code-owned registry keys
-  // (never client input — the wire enum is derived from those same keys, so an
-  // unregistered id cannot reach here). One series per registered step type.
-  const stepPriceDivergenceTotal = getOrCreateCounter(
+  // So the `outcome` label carries the non-divergent case too:
+  //   exact  — realized cost ≤ the reservation. The healthy state, and PROOF the
+  //            detector is live.
+  //   over   — realized cost EXCEEDED the reservation. A registry bug: the entry
+  //            needs a higher price, or a different billing mode, because
+  //            "deterministic cost knowable before execution" was false for it.
+  //   absent — no numeric cost on the snapshot, so nothing could be compared.
+  //            The state that used to be indistinguishable from `exact`.
+  //
+  // Alert on `outcome="over"`; read `outcome="exact"` to confirm the check runs
+  // at all; investigate a rising `outcome="absent"`.
+  //
+  // Cardinality: `step` is drawn from the code-owned registry keys (never client
+  // input — the wire enum derives from those same keys, so an unregistered id
+  // cannot reach here); `outcome` is a closed 3-value set. Bounded and small.
+  const stepPriceCheckTotal = getOrCreateCounter(
     reg,
-    'civitai_app_block_step_price_divergence_total',
-    "App Block `kind:'step'` submits whose REALIZED orchestrator cost exceeded the registry's DECLARED prepaidFixed price, by step id. Non-zero means the declared price is wrong.",
-    ['step']
+    'civitai_app_block_step_price_check_total',
+    "App Block `kind:'step'` prepaidFixed price checks at submit, by step id and outcome (exact = realized cost within the reservation; over = the orchestrator billed MORE than reserved, i.e. the declared price is wrong; absent = the snapshot carried no numeric cost, so no comparison was possible)",
+    ['step', 'outcome']
   );
 
   return {
@@ -410,22 +425,32 @@ export function ensureRegisterAppBlockRuntimeMetrics(reg: Registry = client.regi
     customComfyWallclockSeconds,
     capLimitsDegradedTotal,
     spendCapRejectionsTotal,
-    stepPriceDivergenceTotal,
+    stepPriceCheckTotal,
   };
 }
 
 /**
- * Fail-soft emit of one `prepaidFixed` step price divergence (realized cost
- * exceeded the registry's declared price). Called from the step submit path
- * AFTER the money has already moved.
+ * The closed outcome set for `civitai_app_block_step_price_check_total`. Keeping
+ * it a union (rather than a bare string) is what bounds the label cardinality at
+ * the type level — a caller cannot invent a fourth value.
+ */
+export type StepPriceCheckOutcome = 'exact' | 'over' | 'absent';
+
+/**
+ * Fail-soft emit of ONE `prepaidFixed` step price check. Called from the step
+ * submit path on EVERY submit, after the money has already moved.
+ *
+ * 🔴 Emitted unconditionally — including `outcome: 'exact'` — so a flat
+ * divergence line can be told apart from a detector that never ran. See the
+ * counter's definition above for why that distinction is load-bearing.
  *
  * 🔴 TOTAL, like every emitter in this module. It reports on an already-billed
  * submit; a metrics error must never turn a successful generation into a 500.
  */
-export function recordStepPriceDivergence(step: string): void {
+export function recordStepPriceCheck(step: string, outcome: StepPriceCheckOutcome): void {
   try {
-    const { stepPriceDivergenceTotal } = ensureRegisterAppBlockRuntimeMetrics();
-    stepPriceDivergenceTotal.inc({ step });
+    const { stepPriceCheckTotal } = ensureRegisterAppBlockRuntimeMetrics();
+    stepPriceCheckTotal.inc({ step, outcome });
   } catch {
     /* instrument-only — never let a metrics error touch an already-billed submit */
   }

--- a/src/server/routers/__tests__/blocks.router.workflow.test.ts
+++ b/src/server/routers/__tests__/blocks.router.workflow.test.ts
@@ -135,17 +135,33 @@ const {
 // F4: submitWorkflow dynamically imports the dev-tunnel spend backstop. Mock the
 // module so the default (no active tunnel → getActiveDevTunnel null) leaves every
 // existing test unchanged, and the F4 tests can drive an active dev session.
-const { mockGetActiveDevTunnel, mockReserveDevSessionBuzz, mockRefundDevSessionBuzz } = vi.hoisted(
-  () => ({
-    mockGetActiveDevTunnel: vi.fn(async () => null as unknown),
-    mockReserveDevSessionBuzz: vi.fn(async () => ({ allowed: true, total: 0 })),
-    mockRefundDevSessionBuzz: vi.fn(async () => undefined),
-  })
-);
+const {
+  mockGetActiveDevTunnel,
+  mockReserveDevSessionBuzz,
+  mockRefundDevSessionBuzz,
+  mockChargeDevSessionOverage,
+} = vi.hoisted(() => ({
+  mockGetActiveDevTunnel: vi.fn(async () => null as unknown),
+  mockReserveDevSessionBuzz: vi.fn(async () => ({ allowed: true, total: 0 })),
+  mockRefundDevSessionBuzz: vi.fn(async () => undefined),
+  mockChargeDevSessionOverage: vi.fn(async () => undefined),
+}));
+// 🔴 FIX 7 — the price-CHECK counter fires on EVERY step submit, not only on a
+// divergence, so a flat "no divergence" line can be told apart from a detector
+// that never ran. Mocked so the outcome label is assertable; the real emitter is
+// fail-soft and would swallow everything silently.
+const { mockRecordStepPriceCheck } = vi.hoisted(() => ({
+  mockRecordStepPriceCheck: vi.fn(() => undefined),
+}));
+vi.mock('~/server/metrics/app-block-runtime.metrics', () => ({
+  recordStepPriceCheck: (...a: unknown[]) => mockRecordStepPriceCheck(...(a as [])),
+}));
+
 vi.mock('~/server/services/blocks/dev-tunnel.service', () => ({
   getActiveDevTunnel: (...a: unknown[]) => mockGetActiveDevTunnel(...(a as [])),
   reserveDevSessionBuzz: (...a: unknown[]) => mockReserveDevSessionBuzz(...(a as [])),
   refundDevSessionBuzz: (...a: unknown[]) => mockRefundDevSessionBuzz(...(a as [])),
+  chargeDevSessionOverage: (...a: unknown[]) => mockChargeDevSessionOverage(...(a as [])),
 }));
 
 // G8 (per-app spend/velocity cap) + G6 (persistent output queue) — submitWorkflow
@@ -495,6 +511,8 @@ beforeEach(() => {
     mockGetActiveDevTunnel,
     mockReserveDevSessionBuzz,
     mockRefundDevSessionBuzz,
+    mockChargeDevSessionOverage,
+    mockRecordStepPriceCheck,
     mockReserveAppSpend,
     mockRefundAppSpend,
     mockChargeAppSpendOverage,
@@ -556,6 +574,7 @@ beforeEach(() => {
   mockGetActiveDevTunnel.mockResolvedValue(null);
   mockReserveDevSessionBuzz.mockResolvedValue({ allowed: true, total: 0 });
   mockRefundDevSessionBuzz.mockResolvedValue(undefined);
+  mockChargeDevSessionOverage.mockResolvedValue(undefined);
   // W3 flow A default: the spend-attribution write resolves successfully.
   // Tests that exercise best-effort override it to reject.
   mockRecordSpendAttribution.mockResolvedValue({
@@ -5861,6 +5880,48 @@ describe("step-type registry bridge (kind: 'step')", () => {
     });
   }
 
+  // 🔴 A step submit makes TWO orchestrator calls: the `whatif:true` PRICE QUOTE
+  // that backs the per-call `buzzBudget` gate, then the real submit. The quote is
+  // free and side-effect-free; the REAL submit is the one that spends. Assertions
+  // about "did we spend" must therefore look at the real calls only —
+  // `mockSubmitWorkflow` alone can no longer tell the two apart, and a test that
+  // ignored the difference would silently stop proving anything about spend.
+  // (This mirrors the txt2img path, which has run whatIf → budget gate → cap
+  // reservations → real submit since before this PR.)
+  const isWhatIfCall = (c: unknown[]) =>
+    (c[0] as { query?: { whatif?: boolean } } | undefined)?.query?.whatif === true;
+  const realSubmitCalls = () => mockSubmitWorkflow.mock.calls.filter((c) => !isWhatIfCall(c));
+  const whatIfSubmitCalls = () => mockSubmitWorkflow.mock.calls.filter((c) => isWhatIfCall(c));
+
+  /**
+   * Drive the two orchestrator calls INDEPENDENTLY: what the quote says, and
+   * what the real submit ends up costing.
+   *
+   * 🔴 Needed because they are no longer the same number. A price DIVERGENCE now
+   * means "the quote under-read what was billed" — with `mockResolvedValue`
+   * returning one cost for both, a divergence test would reserve the high number
+   * from the quote and then find no overage at all, i.e. pass while proving
+   * nothing.
+   */
+  function stepSubmitQuoting(quotedCost: number | null, realizedCost: number) {
+    mockSubmitWorkflow.mockImplementation(async (opts: { query?: { whatif?: boolean } }) => {
+      if (opts?.query?.whatif === true) {
+        return {
+          id: 'wf_quote',
+          status: 'unassigned',
+          steps: [],
+          ...(quotedCost === null ? {} : { cost: { total: quotedCost } }),
+        };
+      }
+      return {
+        id: 'wf_step_1',
+        status: 'processing',
+        steps: [{ $type: 'convertImage', output: {} }],
+        cost: { total: realizedCost },
+      };
+    });
+  }
+
   const caller = () => blocksRouter.createCaller(fakeCtx() as never);
 
   describe('estimateWorkflow', () => {
@@ -5886,7 +5947,12 @@ describe("step-type registry bridge (kind: 'step')", () => {
       expect(mockReserveAppSpend).toHaveBeenCalledWith('apb_test', estimate.snapshot.cost.total);
     });
 
-    it('REJECTS an out-of-bounds param through the step .strict() schema', async () => {
+    // 🔴 FIX 6 — the CODE is the assertion. `paramSchema.parse()` threw a raw
+    // ZodError from inside the resolver, which tRPC's getTRPCErrorFromUnknown
+    // maps to INTERNAL_SERVER_ERROR — so this app-author-driven surface reported
+    // routine param typos as 5xx. `.rejects.toThrow()` passed either way and
+    // pinned nothing.
+    it('REJECTS an out-of-bounds param as BAD_REQUEST (not a 500)', async () => {
       mockVerifyBlockToken.mockResolvedValue(stepClaims());
       happyUser();
       await expect(
@@ -5896,7 +5962,24 @@ describe("step-type registry bridge (kind: 'step')", () => {
             params: { image: 'https://evil.example/x.png', output: { format: 'webp' } },
           }),
         })
-      ).rejects.toThrow();
+      ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+    });
+
+    it('REJECTS an out-of-RANGE bounded param as BAD_REQUEST', async () => {
+      mockVerifyBlockToken.mockResolvedValue(stepClaims());
+      happyUser();
+      await expect(
+        caller().estimateWorkflow({
+          blockToken: 'tok',
+          body: stepBody({
+            params: {
+              image: 'https://image.civitai.com/source.png',
+              output: { format: 'webp' },
+              transforms: [{ type: 'resize', targetWidth: 99999 }],
+            },
+          }),
+        })
+      ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
     });
 
     it('REJECTS a model token (registry steps are page-only)', async () => {
@@ -5938,12 +6021,16 @@ describe("step-type registry bridge (kind: 'step')", () => {
           dailyKey: 'system:blocks:app-spend-cap:apb_test:day',
         };
       });
-      mockSubmitWorkflow.mockImplementation(async () => {
-        order.push('submitWorkflow');
+      mockSubmitWorkflow.mockImplementation(async (opts: { query?: { whatif?: boolean } }) => {
+        order.push(opts?.query?.whatif === true ? 'whatIfQuote' : 'submitWorkflow');
         return { id: 'wf_step_1', status: 'processing', steps: [], cost: { total: 1 } };
       });
       await caller().submitWorkflow({ blockToken: 'tok', body: stepBody() });
-      expect(order).toEqual(['reserveAppSpend', 'submitWorkflow']);
+      // 🔴 The free QUOTE precedes the cap belt (so the per-call budget gate runs
+      // against the orchestrator's own number), and the SPENDING submit follows
+      // the per-app reservation. Both halves matter: a reserve after the real
+      // submit would be a spend the cap never saw.
+      expect(order).toEqual(['whatIfQuote', 'reserveAppSpend', 'submitWorkflow']);
     });
 
     it('a per-app DAILY cap rejection returns the daily reason and NEVER submits', async () => {
@@ -5963,7 +6050,10 @@ describe("step-type registry bridge (kind: 'step')", () => {
         cost: { total: STEP_PRICE },
       });
       expect(result.snapshot.error).toMatch(/app daily spend cap reached/);
-      expect(mockSubmitWorkflow).not.toHaveBeenCalled();
+      expect(
+        realSubmitCalls(),
+        'the free QUOTE may have run; NOTHING may have been SPENT'
+      ).toHaveLength(0);
       // The viewer's OWN daily ceiling is given back — a rejected submit must not
       // burn it for a spend that never happened.
       expect(mockSysRedis.decrBy).toHaveBeenCalledWith(
@@ -5984,7 +6074,10 @@ describe("step-type registry bridge (kind: 'step')", () => {
       });
       const result = await caller().submitWorkflow({ blockToken: 'tok', body: stepBody() });
       expect(result.snapshot.error).toMatch(/app generation rate limit reached/);
-      expect(mockSubmitWorkflow).not.toHaveBeenCalled();
+      expect(
+        realSubmitCalls(),
+        'the free QUOTE may have run; NOTHING may have been SPENT'
+      ).toHaveLength(0);
     });
 
     it('a fail-closed cap (redis unavailable) rejects without exposing the ceiling', async () => {
@@ -6001,13 +6094,24 @@ describe("step-type registry bridge (kind: 'step')", () => {
       expect(result.snapshot.error).toMatch(/temporarily unavailable/);
       // A hostile app must not be able to probe its exact ceiling from the message.
       expect(result.snapshot.error).not.toMatch(/\d{3,}/);
-      expect(mockSubmitWorkflow).not.toHaveBeenCalled();
+      expect(
+        realSubmitCalls(),
+        'the free QUOTE may have run; NOTHING may have been SPENT'
+      ).toHaveLength(0);
     });
 
     it('refunds the PER-APP reservation when the orchestrator submit throws', async () => {
       mockVerifyBlockToken.mockResolvedValue(stepClaims());
       happyUser();
-      mockSubmitWorkflow.mockRejectedValue(new Error('orchestrator down'));
+      // The QUOTE succeeds, the REAL submit throws — otherwise the failure lands
+      // before any reservation exists and this test would prove nothing about
+      // refunds (it would pass with the whole refund block deleted).
+      mockSubmitWorkflow.mockImplementation(async (opts: { query?: { whatif?: boolean } }) => {
+        if (opts?.query?.whatif === true) {
+          return { id: 'wf_quote', status: 'unassigned', steps: [], cost: { total: 1 } };
+        }
+        throw new Error('orchestrator down');
+      });
       await expect(
         caller().submitWorkflow({ blockToken: 'tok', body: stepBody() })
       ).rejects.toThrow(/orchestrator down/);
@@ -6050,10 +6154,17 @@ describe("step-type registry bridge (kind: 'step')", () => {
       });
       expect(first.snapshot.workflowId).toBe('wf_step_1');
       expect(second.snapshot.workflowId).toBe('wf_step_1');
-      expect(mockSubmitWorkflow).toHaveBeenCalledTimes(1);
+      // ONE spending submit across both calls — the replay never re-submits.
+      expect(realSubmitCalls()).toHaveLength(1);
       expect(mockReserveAppSpend).toHaveBeenCalledTimes(1);
       // The single real submit carried the namespaced externalId (2nd defense layer).
-      expect(mockSubmitWorkflow.mock.calls[0][0].body.externalId).toBe('blk08apb_teststep-key');
+      expect(realSubmitCalls()[0][0].body.externalId).toBe('blk08apb_teststep-key');
+      // 🔴 And the free QUOTE must never carry it: an externalId on the whatif
+      // would burn the caller's idempotency key on a preflight that spends
+      // nothing, so the real submit's own dedupe layer would be defeated.
+      for (const call of whatIfSubmitCalls()) {
+        expect(call[0].body.externalId).toBeUndefined();
+      }
     });
 
     it('a concurrent same-key submit is a 409 with NO reserve and NO submit', async () => {
@@ -6065,7 +6176,10 @@ describe("step-type registry bridge (kind: 'step')", () => {
         caller().submitWorkflow({ blockToken: 'tok', body: stepBody(), idempotencyKey: 'k' })
       ).rejects.toMatchObject({ code: 'CONFLICT' });
       expect(mockReserveAppSpend).not.toHaveBeenCalled();
-      expect(mockSubmitWorkflow).not.toHaveBeenCalled();
+      expect(
+        realSubmitCalls(),
+        'the free QUOTE may have run; NOTHING may have been SPENT'
+      ).toHaveLength(0);
     });
 
     it('an over-budget price fails the STATIC gate before any reservation or submit', async () => {
@@ -6082,7 +6196,10 @@ describe("step-type registry bridge (kind: 'step')", () => {
         /insufficient buzz budget: step price 1 exceeds budget 0.5/
       );
       expect(mockReserveAppSpend).not.toHaveBeenCalled();
-      expect(mockSubmitWorkflow).not.toHaveBeenCalled();
+      expect(
+        realSubmitCalls(),
+        'the free QUOTE may have run; NOTHING may have been SPENT'
+      ).toHaveLength(0);
     });
   });
 
@@ -6132,7 +6249,7 @@ describe("step-type registry bridge (kind: 'step')", () => {
       happyUser();
       happyStepSubmit();
       await caller().submitWorkflow({ blockToken: 'tok', body: stepBody() });
-      const tags: string[] = mockSubmitWorkflow.mock.calls[0][0].body.tags;
+      const tags: string[] = realSubmitCalls()[0][0].body.tags;
       expect(tags).toContain('step');
       expect(tags).toContain(STEP_ID);
       expect(tags).not.toContain('txt2img');
@@ -6145,7 +6262,7 @@ describe("step-type registry bridge (kind: 'step')", () => {
       happyUser();
       happyStepSubmit();
       await caller().submitWorkflow({ blockToken: 'tok', body: stepBody() });
-      const step = mockSubmitWorkflow.mock.calls[0][0].body.steps[0];
+      const step = realSubmitCalls()[0][0].body.steps[0];
       expect(step.$type).toBe('convertImage');
       expect(step.timeout).toBeUndefined();
       expect(step.input).toMatchObject({
@@ -6163,7 +6280,10 @@ describe("step-type registry bridge (kind: 'step')", () => {
       // for every subsequent submit.
       mockVerifyBlockToken.mockResolvedValue(stepClaims());
       happyUser();
-      happyStepSubmit(9); // realized 9 vs declared 1 → overage 8
+      // Quote 1 (matching the declared price), realized 9 → overage 8. The quote
+      // must UNDER-read for a divergence to exist at all: with the quote gate in
+      // place, a quote of 9 would simply have been reserved at 9.
+      stepSubmitQuoting(1, 9);
       await caller().submitWorkflow({ blockToken: 'tok', body: stepBody() });
       expect(mockChargeAppSpendOverage).toHaveBeenCalledWith(
         'system:blocks:app-spend-cap:apb_test:day',
@@ -6176,15 +6296,35 @@ describe("step-type registry bridge (kind: 'step')", () => {
       );
     });
 
-    it('does NOT correct when the realized cost is at or below the declared price', async () => {
+    // 🔴 THE THIRD RESERVATION. The correction used to touch the per-user and
+    // per-app counters only, while its own comment claimed it corrected "both cap
+    // counters" — there are THREE reservations on a step submit, and the
+    // dev-session one was skipped. A divergent submit inside a dev tunnel left
+    // that counter under-reading by the overage: the exact drift direction the
+    // same comment forbids.
+    it('CORRECTS the DEV-SESSION counter too (three reservations, not two)', async () => {
       mockVerifyBlockToken.mockResolvedValue(stepClaims());
       happyUser();
-      happyStepSubmit(1);
+      mockGetActiveDevTunnel.mockResolvedValue({
+        sessionId: 'devsess_1',
+        spendCapBuzz: 500,
+      });
+      mockReserveDevSessionBuzz.mockResolvedValue({ allowed: true, total: 1 });
+      stepSubmitQuoting(1, 9);
+      await caller().submitWorkflow({ blockToken: 'tok', body: stepBody() });
+      expect(mockChargeDevSessionOverage).toHaveBeenCalledWith('devsess_1', 8);
+    });
+
+    it('does NOT correct when the realized cost is at or below the reservation', async () => {
+      mockVerifyBlockToken.mockResolvedValue(stepClaims());
+      happyUser();
+      stepSubmitQuoting(1, 1);
       await caller().submitWorkflow({ blockToken: 'tok', body: stepBody() });
       expect(mockChargeAppSpendOverage).not.toHaveBeenCalled();
+      expect(mockChargeDevSessionOverage).not.toHaveBeenCalled();
 
       mockChargeAppSpendOverage.mockClear();
-      happyStepSubmit(0);
+      stepSubmitQuoting(1, 0);
       await caller().submitWorkflow({ blockToken: 'tok', body: stepBody() });
       expect(mockChargeAppSpendOverage).not.toHaveBeenCalled();
     });
@@ -6192,10 +6332,154 @@ describe("step-type registry bridge (kind: 'step')", () => {
     it('a failing correction NEVER breaks an already-billed submit', async () => {
       mockVerifyBlockToken.mockResolvedValue(stepClaims());
       happyUser();
-      happyStepSubmit(9);
+      stepSubmitQuoting(1, 9);
       mockChargeAppSpendOverage.mockRejectedValue(new Error('redis down'));
       const result = await caller().submitWorkflow({ blockToken: 'tok', body: stepBody() });
       expect(result.snapshot.workflowId).toBe('wf_step_1');
+    });
+  });
+
+  // ───────────────────────────────────────────────────────────────────────────
+  // 🔴 FIX 2 — the per-call `buzzBudget` ceiling is enforced against the
+  // ORCHESTRATOR'S OWN QUOTE, not against a number Civitai asserted.
+  //
+  // Before this, the gate compared the token budget to the registry's DECLARED
+  // price. `prepaidFixed` stamps no step timeout (deliberately — a timeout is
+  // not its cap), so unlike `customComfy` there was no physical ceiling either.
+  // If the declared price were ever below the real one, EVERY submit would
+  // exceed `buzzBudget` by the overage — not just the first — until a human read
+  // a counter and shipped code. The divergence correction adjusts CAP COUNTERS;
+  // it never touched the price or this gate.
+  // ───────────────────────────────────────────────────────────────────────────
+  describe('🔴 submitWorkflow — the per-call budget gate uses the orchestrator quote', () => {
+    it('runs a real whatif:true quote BEFORE the budget gate, with no externalId', async () => {
+      mockVerifyBlockToken.mockResolvedValue(stepClaims());
+      happyUser();
+      stepSubmitQuoting(1, 1);
+      await caller().submitWorkflow({
+        blockToken: 'tok',
+        body: stepBody(),
+        idempotencyKey: 'k1',
+      });
+      expect(whatIfSubmitCalls()).toHaveLength(1);
+      expect(whatIfSubmitCalls()[0][0].query).toMatchObject({ whatif: true });
+      expect(whatIfSubmitCalls()[0][0].body.externalId).toBeUndefined();
+    });
+
+    // 🔴 THE FIX, mutation-target. With the gate reading the declared price
+    // (always 1) this submit passes and SPENDS; with the quote it is rejected.
+    it('REJECTS when the ORCHESTRATOR quote exceeds the budget even though the DECLARED price does not', async () => {
+      // budget 5: declared price 1 passes the old static gate; quoted 40 must not.
+      mockVerifyBlockToken.mockResolvedValue(stepClaims({ buzzBudget: 5 }));
+      happyUser();
+      stepSubmitQuoting(40, 40);
+      const result = await caller().submitWorkflow({ blockToken: 'tok', body: stepBody() });
+      expect(result.snapshot.status).toBe('failed');
+      expect(result.snapshot.error).toMatch(
+        /insufficient buzz budget: step price 40 exceeds budget 5/
+      );
+      expect(realSubmitCalls(), 'nothing may be SPENT past the budget ceiling').toHaveLength(0);
+      expect(mockReserveAppSpend).not.toHaveBeenCalled();
+    });
+
+    it('RESERVES the quoted price when it exceeds the declared one (caps see the real number)', async () => {
+      mockVerifyBlockToken.mockResolvedValue(stepClaims({ buzzBudget: 50 }));
+      happyUser();
+      stepSubmitQuoting(12, 12);
+      await caller().submitWorkflow({ blockToken: 'tok', body: stepBody() });
+      expect(mockReserveAppSpend).toHaveBeenCalledWith('apb_test', 12);
+      expect(mockSysRedis.incrBy).toHaveBeenCalledWith(
+        expect.stringMatching(/^system:blocks:buzz-cap:42:/),
+        12
+      );
+    });
+
+    it('keeps the DECLARED price as the floor when the quote comes in lower (it is what the block was SHOWN)', async () => {
+      mockVerifyBlockToken.mockResolvedValue(stepClaims());
+      happyUser();
+      stepSubmitQuoting(0, 0);
+      await caller().submitWorkflow({ blockToken: 'tok', body: stepBody() });
+      expect(mockReserveAppSpend).toHaveBeenCalledWith('apb_test', STEP_PRICE);
+    });
+
+    it('FAILS CLOSED when the orchestrator returns NO price quote (no submit, no reserve)', async () => {
+      mockVerifyBlockToken.mockResolvedValue(stepClaims());
+      happyUser();
+      mockSubmitWorkflow.mockImplementation(async (opts: { query?: { whatif?: boolean } }) => {
+        if (opts?.query?.whatif === true) {
+          return { id: 'wf_quote', status: 'unassigned', steps: [] }; // no `cost`
+        }
+        return { id: 'wf_step_1', status: 'processing', steps: [], cost: { total: 1 } };
+      });
+      const result = await caller().submitWorkflow({ blockToken: 'tok', body: stepBody() });
+      expect(result.snapshot.status).toBe('failed');
+      expect(result.snapshot.error).toMatch(/no price quote/);
+      expect(realSubmitCalls()).toHaveLength(0);
+      expect(mockReserveAppSpend).not.toHaveBeenCalled();
+    });
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // 🔴 FIX 7 — "the price is right" and "the detector never ran" must not look
+    // the same. The correction reads `snapshot.cost?.total`, which
+    // `snapshotFromWorkflow` OMITS when there is no numeric cost, and the step
+    // submit passes no `wait` — so the precondition was assumed, never checked.
+    // (Measured live 2026-08-02: a queued convertImage submit DOES carry
+    // `cost.total`. It holds today; it is not guaranteed for a future entry.)
+    // ─────────────────────────────────────────────────────────────────────────
+    it("records outcome 'exact' on a healthy submit — the PROOF the check is live", async () => {
+      mockVerifyBlockToken.mockResolvedValue(stepClaims());
+      happyUser();
+      stepSubmitQuoting(1, 1);
+      await caller().submitWorkflow({ blockToken: 'tok', body: stepBody() });
+      expect(mockRecordStepPriceCheck).toHaveBeenCalledWith(STEP_ID, 'exact');
+    });
+
+    it("records outcome 'over' when the orchestrator bills above the reservation", async () => {
+      mockVerifyBlockToken.mockResolvedValue(stepClaims());
+      happyUser();
+      stepSubmitQuoting(1, 9);
+      await caller().submitWorkflow({ blockToken: 'tok', body: stepBody() });
+      expect(mockRecordStepPriceCheck).toHaveBeenCalledWith(STEP_ID, 'over');
+      expect(mockRecordStepPriceCheck).not.toHaveBeenCalledWith(STEP_ID, 'exact');
+    });
+
+    it("records outcome 'absent' when the submit snapshot carries NO numeric cost", async () => {
+      // The state in which the correction is INERT. Before the outcome label,
+      // this was indistinguishable from a healthy zero.
+      mockVerifyBlockToken.mockResolvedValue(stepClaims());
+      happyUser();
+      mockSubmitWorkflow.mockImplementation(async (opts: { query?: { whatif?: boolean } }) => {
+        if (opts?.query?.whatif === true) {
+          return { id: 'wf_quote', status: 'unassigned', steps: [], cost: { total: 1 } };
+        }
+        return { id: 'wf_step_1', status: 'processing', steps: [] }; // no `cost`
+      });
+      await caller().submitWorkflow({ blockToken: 'tok', body: stepBody() });
+      expect(mockRecordStepPriceCheck).toHaveBeenCalledWith(STEP_ID, 'absent');
+    });
+
+    it('the outcome label is drawn from a CLOSED 3-value set (bounded cardinality)', async () => {
+      mockVerifyBlockToken.mockResolvedValue(stepClaims());
+      happyUser();
+      stepSubmitQuoting(1, 1);
+      await caller().submitWorkflow({ blockToken: 'tok', body: stepBody() });
+      stepSubmitQuoting(1, 9);
+      await caller().submitWorkflow({ blockToken: 'tok', body: stepBody() });
+      for (const call of mockRecordStepPriceCheck.mock.calls) {
+        expect(['exact', 'over', 'absent']).toContain(call[1]);
+        expect(call[0]).toBe(STEP_ID);
+      }
+    });
+
+    it('a THROWING quote fails before any reservation exists (nothing to refund)', async () => {
+      mockVerifyBlockToken.mockResolvedValue(stepClaims());
+      happyUser();
+      mockSubmitWorkflow.mockRejectedValue(new Error('orchestrator down'));
+      await expect(
+        caller().submitWorkflow({ blockToken: 'tok', body: stepBody() })
+      ).rejects.toThrow(/orchestrator down/);
+      expect(mockReserveAppSpend).not.toHaveBeenCalled();
+      expect(mockRefundAppSpend).not.toHaveBeenCalled();
     });
   });
 
@@ -6234,7 +6518,7 @@ describe("step-type registry bridge (kind: 'step')", () => {
             },
           }),
         })
-      ).rejects.toThrow();
+      ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
       expect(mockReserveAppSpend).not.toHaveBeenCalled();
       expect(mockSubmitWorkflow).not.toHaveBeenCalled();
     });
@@ -6253,7 +6537,7 @@ describe("step-type registry bridge (kind: 'step')", () => {
             },
           }),
         })
-      ).rejects.toThrow();
+      ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
       expect(mockReserveAppSpend).not.toHaveBeenCalled();
       expect(mockSubmitWorkflow).not.toHaveBeenCalled();
     });

--- a/src/server/routers/__tests__/blocks.router.workflow.test.ts
+++ b/src/server/routers/__tests__/blocks.router.workflow.test.ts
@@ -6465,6 +6465,13 @@ describe("step-type registry bridge (kind: 'step')", () => {
       await caller().submitWorkflow({ blockToken: 'tok', body: stepBody() });
       stepSubmitQuoting(1, 9);
       await caller().submitWorkflow({ blockToken: 'tok', body: stepBody() });
+      // 🔴 THE DENOMINATOR. Without this, the loop below iterates whatever
+      // `mock.calls` happens to hold — so deleting EVERY `recordStepPriceCheck`
+      // call site leaves it iterating zero calls and passing. That is a vacuous
+      // guard, and it is the same position as the disclosed M36 survivor except
+      // that this one is trivially fixable rather than structurally unreachable.
+      // Two submits, one emit each.
+      expect(mockRecordStepPriceCheck).toHaveBeenCalledTimes(2);
       for (const call of mockRecordStepPriceCheck.mock.calls) {
         expect(['exact', 'over', 'absent']).toContain(call[1]);
         expect(call[0]).toBe(STEP_ID);
@@ -6540,6 +6547,74 @@ describe("step-type registry bridge (kind: 'step')", () => {
       ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
       expect(mockReserveAppSpend).not.toHaveBeenCalled();
       expect(mockSubmitWorkflow).not.toHaveBeenCalled();
+    });
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // 🔴 ENTITLEMENT, at REQUEST time. The registry's clause-7 AIR probe runs at
+    // LOAD, against `buildStep(canonicalParamsFor(v))` — the CANONICAL params.
+    // An entry whose AIR-bearing field is OPTIONAL and absent from its canonical
+    // params registers cleanly and then forwards whatever the untrusted iframe
+    // sent. Before this guard, `moderationPosture` was re-asserted at submit and
+    // `resourcePolicy` was not, so entitlement was a review-process guarantee
+    // with no runtime backstop.
+    //
+    // This test reaches the guard through the REAL registered entry rather than
+    // a fixture: `convert-image`'s `image` param is forwarded verbatim into the
+    // submitted input, so an AIR URN embedded in an otherwise-valid
+    // Civitai-hosted url arrives in `built.input` and the deep scan sees it. The
+    // condition therefore genuinely varies today — this is regression coverage,
+    // not an invariant guard. (It is also, deliberately, a false positive: the
+    // scan is a substring test, and rejecting a pathological url is the
+    // fail-closed direction.)
+    // ─────────────────────────────────────────────────────────────────────────
+    it("a built step that smuggles an AIR is rejected at SUBMIT under resourcePolicy 'none'", async () => {
+      mockVerifyBlockToken.mockResolvedValue(stepClaims());
+      happyUser();
+      happyStepSubmit();
+      await expect(
+        caller().submitWorkflow({
+          blockToken: 'tok',
+          body: stepBody({
+            params: {
+              image: 'https://image.civitai.com/urn:air:sdxl:checkpoint:civitai:4384@128713.png',
+              output: { format: 'webp' },
+            },
+          }),
+        })
+      ).rejects.toMatchObject({
+        code: 'FORBIDDEN',
+        // 🔴 The MESSAGE, not just the code. Several other seams on this path
+        // also reject with FORBIDDEN (page-only, missing scope, missing budget),
+        // so a code-only assertion would be satisfied by the wrong guard and
+        // would survive deleting this one.
+        message: expect.stringContaining(
+          "declares resourcePolicy 'none' but the submitted step carries an AIR reference"
+        ),
+      });
+      // Rejected BEFORE the free quote, so not even the whatIf round-trip fired.
+      expect(mockSubmitWorkflow).not.toHaveBeenCalled();
+      expect(mockReserveAppSpend).not.toHaveBeenCalled();
+      expect(mockRefundAppSpend).not.toHaveBeenCalled();
+    });
+
+    it('the SAME params without the AIR are accepted (the guard is not rejecting the url shape)', async () => {
+      // 🔴 The NEGATIVE CONTROL for the test above. Without it, a guard that
+      // rejected every `convert-image` submit would pass it just as well, and
+      // the pair would prove nothing about the AIR being what was detected.
+      mockVerifyBlockToken.mockResolvedValue(stepClaims());
+      happyUser();
+      stepSubmitQuoting(1, 1);
+      const result = await caller().submitWorkflow({
+        blockToken: 'tok',
+        body: stepBody({
+          params: {
+            image: 'https://image.civitai.com/sdxl:checkpoint:civitai:4384@128713.png',
+            output: { format: 'webp' },
+          },
+        }),
+      });
+      expect(result.snapshot.status).toBe('processing');
+      expect(realSubmitCalls()).toHaveLength(1);
     });
 
     it('a MODEL token is rejected fail-closed BEFORE any spend (page-only)', async () => {

--- a/src/server/routers/__tests__/blocks.router.workflow.test.ts
+++ b/src/server/routers/__tests__/blocks.router.workflow.test.ts
@@ -155,12 +155,16 @@ vi.mock('~/server/services/blocks/dev-tunnel.service', () => ({
 const {
   mockReserveAppSpend,
   mockRefundAppSpend,
+  mockChargeAppSpendOverage,
   mockUpsertBlockWorkflow,
   mockListMyBlockWorkflows,
   mockUpdateBlockWorkflowStatus,
 } = vi.hoisted(() => ({
   mockReserveAppSpend: vi.fn(),
   mockRefundAppSpend: vi.fn(async () => undefined),
+  // `kind:'step'` prepaidFixed price-divergence correction — a plain INCRBY on
+  // the pinned daily key with no allow/deny semantics (see the service).
+  mockChargeAppSpendOverage: vi.fn(async () => undefined),
   mockUpsertBlockWorkflow: vi.fn(async () => undefined),
   mockListMyBlockWorkflows: vi.fn(),
   // G6 — the read-model terminal flip pollWorkflow fires best-effort when it
@@ -171,6 +175,7 @@ const {
 vi.mock('~/server/services/blocks/app-spend-cap.service', () => ({
   reserveAppSpend: (...a: unknown[]) => mockReserveAppSpend(...(a as [])),
   refundAppSpend: (...a: unknown[]) => mockRefundAppSpend(...(a as [])),
+  chargeAppSpendOverage: (...a: unknown[]) => mockChargeAppSpendOverage(...(a as [])),
 }));
 vi.mock('~/server/services/blocks/block-workflows.service', () => ({
   upsertBlockWorkflowOnSubmit: (...a: unknown[]) => mockUpsertBlockWorkflow(...(a as [])),
@@ -492,6 +497,7 @@ beforeEach(() => {
     mockRefundDevSessionBuzz,
     mockReserveAppSpend,
     mockRefundAppSpend,
+    mockChargeAppSpendOverage,
     mockUpsertBlockWorkflow,
     mockListMyBlockWorkflows,
     mockUpdateBlockWorkflowStatus,
@@ -508,6 +514,7 @@ beforeEach(() => {
     dailyKey: 'system:blocks:app-spend-cap:apb_test:day',
   });
   mockRefundAppSpend.mockResolvedValue(undefined);
+  mockChargeAppSpendOverage.mockResolvedValue(undefined);
   mockUpsertBlockWorkflow.mockResolvedValue(undefined);
   mockListMyBlockWorkflows.mockResolvedValue({ items: [], nextCursor: null });
   // G6 read-model flip: default to a resolved 1-row UPDATE. Tests exercising the
@@ -5800,6 +5807,475 @@ describe('customComfy bridge (submit/estimate/settle)', () => {
         workflowId: 'wf_cc_1',
         actualCost: 12,
       });
+    });
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// App Blocks STEP-TYPE bridge (`kind: 'step'`) — RFC #3515 migration step 1.
+//
+// 🔴 THE POINT OF THIS SUITE IS THE MONEY PATH. A step submit opens a NEW spend
+// surface, and the requirement is that it is covered by the SAME guardrails as
+// every other kind — above all the per-app aggregate `reserveAppSpend` cap
+// (daily Buzz + velocity). If it were not, the cap would silently not apply to
+// this whole class of generation and the
+// `civitai_app_block_spend_cap_rejections_total` counter would never fire for
+// it either, so the gap would also be invisible in monitoring.
+//
+// The `reserveAppSpend` assertions below are mutation-proven: deleting the
+// reserve call from the router makes them fail on their OWN assertion (see the
+// mutation table in the PR body).
+// ─────────────────────────────────────────────────────────────────────────────
+describe("step-type registry bridge (kind: 'step')", () => {
+  const STEP_ID = 'convert-image';
+  const STEP_PRICE = 1; // CONVERT_IMAGE_PRICE_BUZZ — the declared prepaidFixed price.
+
+  // A PAGE token (ctx.entityType==='none') — registry steps are page-only in v1.
+  function stepClaims(over: Record<string, unknown> = {}) {
+    return validClaims({
+      ctx: { entityType: 'none', slotId: 'page' },
+      appBlockId: 'apb_test',
+      buzzBudget: 50,
+      ...over,
+    });
+  }
+
+  function stepBody(over: Record<string, unknown> = {}) {
+    return {
+      kind: 'step' as const,
+      step: STEP_ID,
+      params: {
+        image: 'https://image.civitai.com/source.png',
+        output: { format: 'webp', quality: 90 },
+      },
+      ...over,
+    };
+  }
+
+  function happyStepSubmit(cost = 1) {
+    mockSubmitWorkflow.mockResolvedValue({
+      id: 'wf_step_1',
+      status: 'processing',
+      steps: [{ $type: 'convertImage', output: {} }],
+      cost: { total: cost },
+    });
+  }
+
+  const caller = () => blocksRouter.createCaller(fakeCtx() as never);
+
+  describe('estimateWorkflow', () => {
+    it('returns the registry DISPLAY estimate with NO orchestrator round-trip', async () => {
+      mockVerifyBlockToken.mockResolvedValue(stepClaims());
+      happyUser();
+      const result = await caller().estimateWorkflow({ blockToken: 'tok', body: stepBody() });
+      expect(result.snapshot).toMatchObject({
+        workflowId: 'wf_estimate',
+        status: 'pending',
+        cost: { total: STEP_PRICE },
+      });
+      // 🔴 "Deterministic cost knowable BEFORE execution" — no whatIf, no submit.
+      expect(mockSubmitWorkflow).not.toHaveBeenCalled();
+    });
+
+    it('the estimate EQUALS what submit reserves and charges', async () => {
+      mockVerifyBlockToken.mockResolvedValue(stepClaims());
+      happyUser();
+      const estimate = await caller().estimateWorkflow({ blockToken: 'tok', body: stepBody() });
+      happyStepSubmit();
+      await caller().submitWorkflow({ blockToken: 'tok', body: stepBody() });
+      expect(mockReserveAppSpend).toHaveBeenCalledWith('apb_test', estimate.snapshot.cost.total);
+    });
+
+    it('REJECTS an out-of-bounds param through the step .strict() schema', async () => {
+      mockVerifyBlockToken.mockResolvedValue(stepClaims());
+      happyUser();
+      await expect(
+        caller().estimateWorkflow({
+          blockToken: 'tok',
+          body: stepBody({
+            params: { image: 'https://evil.example/x.png', output: { format: 'webp' } },
+          }),
+        })
+      ).rejects.toThrow();
+    });
+
+    it('REJECTS a model token (registry steps are page-only)', async () => {
+      mockVerifyBlockToken.mockResolvedValue(validClaims()); // model token (ctx.modelId)
+      happyUser();
+      await expect(
+        caller().estimateWorkflow({ blockToken: 'tok', body: stepBody() })
+      ).rejects.toMatchObject({ code: 'FORBIDDEN' });
+    });
+  });
+
+  describe('🔴 submitWorkflow — the money path', () => {
+    it('reserves the EXACT declared price on the per-user daily cap AND the PER-APP cap', async () => {
+      mockVerifyBlockToken.mockResolvedValue(stepClaims());
+      happyUser();
+      happyStepSubmit();
+      const result = await caller().submitWorkflow({ blockToken: 'tok', body: stepBody() });
+      expect(result.snapshot.workflowId).toBe('wf_step_1');
+      // per-user cumulative cap
+      expect(mockSysRedis.incrBy).toHaveBeenCalledWith(
+        expect.stringMatching(/^system:blocks:buzz-cap:42:/),
+        STEP_PRICE
+      );
+      // 🔴 THE REQUIREMENT: the per-app aggregate spend/velocity cap.
+      expect(mockReserveAppSpend).toHaveBeenCalledWith('apb_test', STEP_PRICE);
+      expect(mockReserveAppSpend).toHaveBeenCalledTimes(1);
+    });
+
+    it('reserves the per-app cap BEFORE the orchestrator submit (never after the spend)', async () => {
+      mockVerifyBlockToken.mockResolvedValue(stepClaims());
+      happyUser();
+      const order: string[] = [];
+      mockReserveAppSpend.mockImplementation(async () => {
+        order.push('reserveAppSpend');
+        return {
+          allowed: true,
+          dailyTotal: 0,
+          velocityCount: 1,
+          dailyKey: 'system:blocks:app-spend-cap:apb_test:day',
+        };
+      });
+      mockSubmitWorkflow.mockImplementation(async () => {
+        order.push('submitWorkflow');
+        return { id: 'wf_step_1', status: 'processing', steps: [], cost: { total: 1 } };
+      });
+      await caller().submitWorkflow({ blockToken: 'tok', body: stepBody() });
+      expect(order).toEqual(['reserveAppSpend', 'submitWorkflow']);
+    });
+
+    it('a per-app DAILY cap rejection returns the daily reason and NEVER submits', async () => {
+      mockVerifyBlockToken.mockResolvedValue(stepClaims());
+      happyUser();
+      happyStepSubmit();
+      mockReserveAppSpend.mockResolvedValue({
+        allowed: false,
+        reason: 'daily',
+        dailyTotal: 0,
+        velocityCount: 0,
+      });
+      const result = await caller().submitWorkflow({ blockToken: 'tok', body: stepBody() });
+      expect(result.snapshot).toMatchObject({
+        workflowId: 'failed',
+        status: 'failed',
+        cost: { total: STEP_PRICE },
+      });
+      expect(result.snapshot.error).toMatch(/app daily spend cap reached/);
+      expect(mockSubmitWorkflow).not.toHaveBeenCalled();
+      // The viewer's OWN daily ceiling is given back — a rejected submit must not
+      // burn it for a spend that never happened.
+      expect(mockSysRedis.decrBy).toHaveBeenCalledWith(
+        expect.stringMatching(/^system:blocks:buzz-cap:42:/),
+        STEP_PRICE
+      );
+    });
+
+    it('a per-app VELOCITY cap rejection returns the velocity reason and NEVER submits', async () => {
+      mockVerifyBlockToken.mockResolvedValue(stepClaims());
+      happyUser();
+      happyStepSubmit();
+      mockReserveAppSpend.mockResolvedValue({
+        allowed: false,
+        reason: 'velocity',
+        dailyTotal: 0,
+        velocityCount: 999,
+      });
+      const result = await caller().submitWorkflow({ blockToken: 'tok', body: stepBody() });
+      expect(result.snapshot.error).toMatch(/app generation rate limit reached/);
+      expect(mockSubmitWorkflow).not.toHaveBeenCalled();
+    });
+
+    it('a fail-closed cap (redis unavailable) rejects without exposing the ceiling', async () => {
+      mockVerifyBlockToken.mockResolvedValue(stepClaims());
+      happyUser();
+      happyStepSubmit();
+      mockReserveAppSpend.mockResolvedValue({
+        allowed: false,
+        reason: 'unavailable',
+        dailyTotal: 0,
+        velocityCount: 0,
+      });
+      const result = await caller().submitWorkflow({ blockToken: 'tok', body: stepBody() });
+      expect(result.snapshot.error).toMatch(/temporarily unavailable/);
+      // A hostile app must not be able to probe its exact ceiling from the message.
+      expect(result.snapshot.error).not.toMatch(/\d{3,}/);
+      expect(mockSubmitWorkflow).not.toHaveBeenCalled();
+    });
+
+    it('refunds the PER-APP reservation when the orchestrator submit throws', async () => {
+      mockVerifyBlockToken.mockResolvedValue(stepClaims());
+      happyUser();
+      mockSubmitWorkflow.mockRejectedValue(new Error('orchestrator down'));
+      await expect(
+        caller().submitWorkflow({ blockToken: 'tok', body: stepBody() })
+      ).rejects.toThrow(/orchestrator down/);
+      expect(mockRefundAppSpend).toHaveBeenCalledWith(
+        'system:blocks:app-spend-cap:apb_test:day',
+        STEP_PRICE
+      );
+      expect(mockSysRedis.decrBy).toHaveBeenCalledWith(
+        expect.stringMatching(/^system:blocks:buzz-cap:42:/),
+        STEP_PRICE
+      );
+    });
+
+    it('SKIPS the per-app cap for a DEV token (synthetic non-FK appBlockId), like every other kind', async () => {
+      mockVerifyBlockToken.mockResolvedValue(stepClaims({ dev: true }));
+      happyUser();
+      happyStepSubmit();
+      await caller().submitWorkflow({ blockToken: 'tok', body: stepBody() });
+      expect(mockReserveAppSpend).not.toHaveBeenCalled();
+      // The per-user cap still applies.
+      expect(mockSysRedis.incrBy).toHaveBeenCalledWith(
+        expect.stringMatching(/^system:blocks:buzz-cap:42:/),
+        STEP_PRICE
+      );
+    });
+
+    it('IDEMPOTENCY: a replayed submit does NOT double-charge (one reserve, one submit)', async () => {
+      mockVerifyBlockToken.mockResolvedValue(stepClaims());
+      happyUser();
+      happyStepSubmit();
+      const first = await caller().submitWorkflow({
+        blockToken: 'tok',
+        body: stepBody(),
+        idempotencyKey: 'step-key',
+      });
+      const second = await caller().submitWorkflow({
+        blockToken: 'tok',
+        body: stepBody(),
+        idempotencyKey: 'step-key',
+      });
+      expect(first.snapshot.workflowId).toBe('wf_step_1');
+      expect(second.snapshot.workflowId).toBe('wf_step_1');
+      expect(mockSubmitWorkflow).toHaveBeenCalledTimes(1);
+      expect(mockReserveAppSpend).toHaveBeenCalledTimes(1);
+      // The single real submit carried the namespaced externalId (2nd defense layer).
+      expect(mockSubmitWorkflow.mock.calls[0][0].body.externalId).toBe('blk08apb_teststep-key');
+    });
+
+    it('a concurrent same-key submit is a 409 with NO reserve and NO submit', async () => {
+      mockVerifyBlockToken.mockResolvedValue(stepClaims());
+      happyUser();
+      happyStepSubmit();
+      mockClaimGen.mockResolvedValue({ state: 'in_progress' });
+      await expect(
+        caller().submitWorkflow({ blockToken: 'tok', body: stepBody(), idempotencyKey: 'k' })
+      ).rejects.toMatchObject({ code: 'CONFLICT' });
+      expect(mockReserveAppSpend).not.toHaveBeenCalled();
+      expect(mockSubmitWorkflow).not.toHaveBeenCalled();
+    });
+
+    it('an over-budget price fails the STATIC gate before any reservation or submit', async () => {
+      // buzzBudget below the declared price → deterministic rejection, no redis,
+      // no orchestrator. (The gate is reachable: nothing earlier rejects a
+      // well-formed body with a small budget.)
+      mockVerifyBlockToken.mockResolvedValue(stepClaims({ buzzBudget: 0.5 }));
+      happyUser();
+      happyStepSubmit();
+      const result = await caller().submitWorkflow({ blockToken: 'tok', body: stepBody() });
+      expect(result.snapshot.workflowId).toBe('failed');
+      expect(result.snapshot.status).toBe('failed');
+      expect(result.snapshot.error).toMatch(
+        /insufficient buzz budget: step price 1 exceeds budget 0.5/
+      );
+      expect(mockReserveAppSpend).not.toHaveBeenCalled();
+      expect(mockSubmitWorkflow).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('submitWorkflow — prepaidFixed settle behaviour', () => {
+    it('does NOT touch the post-paid settle machinery (no settle record persisted)', async () => {
+      // 🔴 The defining property of `prepaidFixed`: the price is exact, so the
+      // reservation is FINAL. A settle record would make the terminal poll refund
+      // `ceiling - actual`, which for a fixed price is refunding money that was
+      // correctly charged.
+      mockVerifyBlockToken.mockResolvedValue(stepClaims());
+      happyUser();
+      happyStepSubmit();
+      await caller().submitWorkflow({ blockToken: 'tok', body: stepBody() });
+      expect(mockPersistCustomComfySettle).not.toHaveBeenCalled();
+    });
+
+    it('still writes the durable audit + attribution trail (a step bills real Buzz)', async () => {
+      // Not in the shared beforeEach reset list — clear so this test's detached
+      // call is the one asserted.
+      vi.mocked(recordScopeInvocation).mockClear();
+      mockVerifyBlockToken.mockResolvedValue(stepClaims());
+      happyUser();
+      happyStepSubmit();
+      await caller().submitWorkflow({ blockToken: 'tok', body: stepBody() });
+      await new Promise((r) => setTimeout(r, 0)); // fire-and-forget writes
+      expect(vi.mocked(recordScopeInvocation)).toHaveBeenCalledWith(
+        expect.objectContaining({
+          userId: 42,
+          appBlockId: 'apb_test',
+          scope: 'ai:write:budgeted',
+          endpoint: 'workflow:submit:wf_step_1',
+        })
+      );
+      expect(mockRecordSpendAttribution).toHaveBeenCalledWith(
+        expect.objectContaining({
+          userId: 42,
+          workflowId: 'wf_step_1',
+          appBlockId: 'apb_test',
+          modelId: null,
+          sharedContentKey: null,
+        })
+      );
+    });
+
+    it('emits the step id (never txt2img) as the workflow-type tag, preserving app-block provenance', async () => {
+      mockVerifyBlockToken.mockResolvedValue(stepClaims());
+      happyUser();
+      happyStepSubmit();
+      await caller().submitWorkflow({ blockToken: 'tok', body: stepBody() });
+      const tags: string[] = mockSubmitWorkflow.mock.calls[0][0].body.tags;
+      expect(tags).toContain('step');
+      expect(tags).toContain(STEP_ID);
+      expect(tags).not.toContain('txt2img');
+      expect(tags).toContain('app-block');
+      expect(tags).toContain('app-block:instance:bki_test');
+    });
+
+    it('stamps NO step timeout for a prepaidFixed step (a timeout is not its cap)', async () => {
+      mockVerifyBlockToken.mockResolvedValue(stepClaims());
+      happyUser();
+      happyStepSubmit();
+      await caller().submitWorkflow({ blockToken: 'tok', body: stepBody() });
+      const step = mockSubmitWorkflow.mock.calls[0][0].body.steps[0];
+      expect(step.$type).toBe('convertImage');
+      expect(step.timeout).toBeUndefined();
+      expect(step.input).toMatchObject({
+        image: 'https://image.civitai.com/source.png',
+        output: { format: 'webp', quality: 90, hideMetadata: true },
+      });
+    });
+  });
+
+  describe('submitWorkflow — prepaidFixed PRICE DIVERGENCE correction', () => {
+    it('CORRECTS both cap counters when the orchestrator bills ABOVE the declared price', async () => {
+      // The one input to this money path that could not be verified locally: the
+      // orchestrator's real price. If it comes in high, the caps are short by the
+      // difference — correct them, or the per-app abuse cap runs that much looser
+      // for every subsequent submit.
+      mockVerifyBlockToken.mockResolvedValue(stepClaims());
+      happyUser();
+      happyStepSubmit(9); // realized 9 vs declared 1 → overage 8
+      await caller().submitWorkflow({ blockToken: 'tok', body: stepBody() });
+      expect(mockChargeAppSpendOverage).toHaveBeenCalledWith(
+        'system:blocks:app-spend-cap:apb_test:day',
+        8
+      );
+      // The per-user counter is topped up by the same overage.
+      expect(mockSysRedis.incrBy).toHaveBeenCalledWith(
+        expect.stringMatching(/^system:blocks:buzz-cap:42:/),
+        8
+      );
+    });
+
+    it('does NOT correct when the realized cost is at or below the declared price', async () => {
+      mockVerifyBlockToken.mockResolvedValue(stepClaims());
+      happyUser();
+      happyStepSubmit(1);
+      await caller().submitWorkflow({ blockToken: 'tok', body: stepBody() });
+      expect(mockChargeAppSpendOverage).not.toHaveBeenCalled();
+
+      mockChargeAppSpendOverage.mockClear();
+      happyStepSubmit(0);
+      await caller().submitWorkflow({ blockToken: 'tok', body: stepBody() });
+      expect(mockChargeAppSpendOverage).not.toHaveBeenCalled();
+    });
+
+    it('a failing correction NEVER breaks an already-billed submit', async () => {
+      mockVerifyBlockToken.mockResolvedValue(stepClaims());
+      happyUser();
+      happyStepSubmit(9);
+      mockChargeAppSpendOverage.mockRejectedValue(new Error('redis down'));
+      const result = await caller().submitWorkflow({ blockToken: 'tok', body: stepBody() });
+      expect(result.snapshot.workflowId).toBe('wf_step_1');
+    });
+  });
+
+  describe('submitWorkflow — fail-closed seams', () => {
+    it('an unregistered step id is rejected at the WIRE SCHEMA (never reaches the handler)', async () => {
+      mockVerifyBlockToken.mockResolvedValue(stepClaims());
+      happyUser();
+      happyStepSubmit();
+      await expect(
+        caller().submitWorkflow({
+          blockToken: 'tok',
+          body: { kind: 'step', step: 'no-such-step', params: {} } as never,
+        })
+      ).rejects.toThrow();
+      // The schema rejected it — the token was never even verified.
+      expect(mockVerifyBlockToken).not.toHaveBeenCalled();
+      expect(mockReserveAppSpend).not.toHaveBeenCalled();
+      expect(mockSubmitWorkflow).not.toHaveBeenCalled();
+    });
+
+    it('an UNKNOWN param is REJECTED, not silently dropped', async () => {
+      // 🔴 The `.strict()` requirement, at the request boundary. A dropped param
+      // on a money path is a wrong-generation bug: this is the class that let an
+      // older host strip `sourceImages` and bill the wrong generation.
+      mockVerifyBlockToken.mockResolvedValue(stepClaims());
+      happyUser();
+      happyStepSubmit();
+      await expect(
+        caller().submitWorkflow({
+          blockToken: 'tok',
+          body: stepBody({
+            params: {
+              image: 'https://image.civitai.com/source.png',
+              output: { format: 'webp' },
+              upscaleFactor: 4, // not in the schema
+            },
+          }),
+        })
+      ).rejects.toThrow();
+      expect(mockReserveAppSpend).not.toHaveBeenCalled();
+      expect(mockSubmitWorkflow).not.toHaveBeenCalled();
+    });
+
+    it('a NON-Civitai image host is rejected before any spend (SSRF bound)', async () => {
+      mockVerifyBlockToken.mockResolvedValue(stepClaims());
+      happyUser();
+      happyStepSubmit();
+      await expect(
+        caller().submitWorkflow({
+          blockToken: 'tok',
+          body: stepBody({
+            params: {
+              image: 'https://evil.example/?x=image.civitai.com',
+              output: { format: 'webp' },
+            },
+          }),
+        })
+      ).rejects.toThrow();
+      expect(mockReserveAppSpend).not.toHaveBeenCalled();
+      expect(mockSubmitWorkflow).not.toHaveBeenCalled();
+    });
+
+    it('a MODEL token is rejected fail-closed BEFORE any spend (page-only)', async () => {
+      mockVerifyBlockToken.mockResolvedValue(validClaims()); // model token
+      happyUser();
+      happyStepSubmit();
+      await expect(
+        caller().submitWorkflow({ blockToken: 'tok', body: stepBody() })
+      ).rejects.toMatchObject({ code: 'FORBIDDEN' });
+      expect(mockReserveAppSpend).not.toHaveBeenCalled();
+      expect(mockSubmitWorkflow).not.toHaveBeenCalled();
+    });
+
+    it('a token without ai:write:budgeted is rejected', async () => {
+      mockVerifyBlockToken.mockResolvedValue(stepClaims({ scopes: [] }));
+      happyUser();
+      await expect(
+        caller().submitWorkflow({ blockToken: 'tok', body: stepBody() })
+      ).rejects.toMatchObject({ code: 'FORBIDDEN' });
+      expect(mockReserveAppSpend).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -143,7 +143,15 @@ import { getRecipe, recipeCivitaiVersionIds } from '~/server/services/blocks/rec
 // registry is. `estimateStepBuzz` / `planStepSpend` dispatch on the entry's
 // declared `billingMode` — this router contains NO per-step and NO per-mode
 // branch, which is what makes adding a capability additive.
-import { estimateStepBuzz, getStep, planStepSpend } from '~/server/services/blocks/steps';
+// `containsAirReference` is the SAME deep scan the registry's load-time clause 7
+// runs; imported (not re-implemented) so the request-time re-assertion below can
+// never drift from the load-time one — one rule, one place.
+import {
+  containsAirReference,
+  estimateStepBuzz,
+  getStep,
+  planStepSpend,
+} from '~/server/services/blocks/steps';
 // Instrument-only: records EVERY prepaidFixed step price check at submit —
 // `exact` / `over` / `absent` — so a flat "no divergence" line can be told apart
 // from a detector that never ran. Never throws.
@@ -6418,11 +6426,29 @@ async function assertStepRequestAllowed(claims: BlockClaims): Promise<number> {
 }
 
 /**
- * STEP ESTIMATE. Returns the registry's declared, deterministic estimate — no
- * orchestrator round-trip. For `prepaidFixed` that estimate is enforced at
- * registry LOAD to equal the exact price the submit path reserves and the
- * viewer is charged, so an estimate can never quote a different number than the
- * submit bills.
+ * STEP ESTIMATE. Returns the registry's DECLARED, deterministic estimate — no
+ * orchestrator round-trip. For `prepaidFixed`, registry load enforces that this
+ * number equals the entry's declared price (`estimateBuzz === priceForVariant`),
+ * so the estimate and the declared price can never disagree with each other.
+ *
+ * 🔴 THE ESTIMATE AND THE SUBMIT CAN DIVERGE, and that is deliberate. Submit no
+ * longer trusts the declared price as the ceiling: it runs a real `whatif:true`
+ * quote against the orchestrator and gates + reserves `max(declared, quoted)`
+ * (see the ORCHESTRATOR QUOTE section in `submitStepWorkflow`). So when the
+ * orchestrator's live price is ABOVE the declared one — a rate-card move — the
+ * block is shown the declared number here and the submit enforces the higher
+ * one. Concretely, at a live price of 40 against a declared 1: this returns
+ * `cost.total: 1`, and the submit either returns
+ * `insufficient buzz budget: step price 40 exceeds budget <n>` or reserves 40
+ * against every cap.
+ *
+ * That is fail-closed and correct — the caller is never billed more than the
+ * caps it reserved against, and the divergence is counted as
+ * `civitai_app_block_step_price_check_total{outcome="over"}`. But do NOT read
+ * this estimate as a binding quote: it is the declared floor, not the enforced
+ * ceiling. (This comment previously asserted the inverse — that an estimate can
+ * never quote a different number than the submit bills. That was true before the
+ * quote-backed gate existed and is now false.)
  *
  * Fail-closed on an out-of-bounds param (BAD_REQUEST via `parseStepParams`),
  * exactly as submit does — the same `.strict()` schema runs on both paths.
@@ -6523,6 +6549,42 @@ async function submitStepWorkflow(opts: {
   // a timeout on a fixed-price step would be a liveness knob and stamping one
   // here would imply a Buzz-cap relationship that does not exist.
   const built = step.buildStep(params);
+
+  // ── ENTITLEMENT posture, re-asserted at REQUEST time on the value actually
+  // submitted. Mirrors the `moderationPosture` re-assertion above, on the axis
+  // this PR's own triage named as the real risk (`imageUpscaler` was
+  // disqualified precisely because its `model` field takes an arbitrary AIR
+  // URN).
+  //
+  // 🔴 WHY IT IS NEEDED DESPITE CLAUSE 7. The registry's load-time AIR probe
+  // (clause 7) scans `buildStep(canonicalParamsFor(v))` — the CANONICAL params.
+  // An entry whose AIR-bearing field is OPTIONAL and absent from its canonical
+  // params therefore registers cleanly, and at request time `buildStep` forwards
+  // whatever the untrusted iframe sent straight into the submitted input. Load
+  // time proved a property of one fixed input; this proves it of THIS input.
+  // Without it, `resourcePolicy` was enforced at registry load only — a
+  // review-process guard, not a runtime one — while `moderationPosture` was
+  // enforced at both.
+  //
+  // Placed before the quote and before every reservation, so a rejection here
+  // costs no orchestrator call and has nothing to refund.
+  //
+  // FAIL-CLOSED DIRECTION, stated honestly: the scan is a substring test for
+  // `urn:air:` anywhere in the built input, so a param that merely EMBEDS that
+  // literal (e.g. a Civitai-hosted image URL whose path contains it) is rejected
+  // too. That is a false positive, and it is the direction we want — refusing a
+  // pathological url costs a caller one bounced request; forwarding an
+  // unentitled AIR costs the entitlement belt.
+  if (step.resourcePolicy.kind === 'none' && containsAirReference(built.input)) {
+    throw new TRPCError({
+      code: 'FORBIDDEN',
+      message:
+        `step '${step.id}' declares resourcePolicy 'none' but the submitted step carries an ` +
+        'AIR reference — a step that reaches an AIR resource bypasses the generation-graph ' +
+        'entitlement belt',
+    });
+  }
+
   const orchestratorStep = {
     $type: built.$type,
     name: BLOCK_STEP_NAME,

--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -144,10 +144,10 @@ import { getRecipe, recipeCivitaiVersionIds } from '~/server/services/blocks/rec
 // declared `billingMode` — this router contains NO per-step and NO per-mode
 // branch, which is what makes adding a capability additive.
 import { estimateStepBuzz, getStep, planStepSpend } from '~/server/services/blocks/steps';
-// Instrument-only: surfaces a prepaidFixed step whose REALIZED orchestrator cost
-// exceeded the registry's DECLARED price (see the submit path's divergence
-// correction). Never throws.
-import { recordStepPriceDivergence } from '~/server/metrics/app-block-runtime.metrics';
+// Instrument-only: records EVERY prepaidFixed step price check at submit —
+// `exact` / `over` / `absent` — so a flat "no divergence" line can be told apart
+// from a detector that never ran. Never throws.
+import { recordStepPriceCheck } from '~/server/metrics/app-block-runtime.metrics';
 // Post-paid SETTLE-TO-ACTUAL for customComfy (plan §5.3). `persist*` is awaited in
 // submit (after reserving the ceiling); `settle*` is a best-effort call on the
 // terminal poll/cancel hook. Static import (both are light) — the heavy
@@ -6370,6 +6370,31 @@ function resolveBlockStep(body: StepBody) {
 }
 
 /**
+ * Parse a step's params against its own `.strict()` schema, as a CALLER error.
+ *
+ * 🔴 `paramSchema.parse()` throws a raw `ZodError` from inside the resolver, and
+ * tRPC's `getTRPCErrorFromUnknown` maps an unrecognized throw to
+ * INTERNAL_SERVER_ERROR — verified by execution, not assumed. So an app author
+ * sending an out-of-range `targetWidth` got a 500. This surface is entirely
+ * app-author-driven: routine iteration against the param contract would have
+ * registered as a server-error rate, burying real 5xx in developer typos.
+ *
+ * `safeParse` + an explicit BAD_REQUEST makes the caller error a caller error.
+ * The zod message is included because the app author is the one who has to fix
+ * it, and the params are the app's OWN input — nothing server-side is disclosed.
+ */
+function parseStepParams(step: ReturnType<typeof resolveBlockStep>, raw: unknown) {
+  const parsed = step.paramSchema.safeParse(raw);
+  if (!parsed.success) {
+    throw new TRPCError({
+      code: 'BAD_REQUEST',
+      message: `invalid params for step '${step.id}': ${parsed.error.message}`,
+    });
+  }
+  return parsed.data;
+}
+
+/**
  * The gates every step request passes before anything else happens, in the same
  * order and with the same fail-closed posture as the customComfy handlers.
  * Shared by estimate and submit so the two can never drift — a gate that holds
@@ -6399,14 +6424,14 @@ async function assertStepRequestAllowed(claims: BlockClaims): Promise<number> {
  * viewer is charged, so an estimate can never quote a different number than the
  * submit bills.
  *
- * Fail-closed on an out-of-bounds param (ZodError → BAD_REQUEST), exactly as
- * submit does — the same `.strict()` schema runs on both paths.
+ * Fail-closed on an out-of-bounds param (BAD_REQUEST via `parseStepParams`),
+ * exactly as submit does — the same `.strict()` schema runs on both paths.
  */
 async function estimateStepWorkflow(opts: { claims: BlockClaims; body: StepBody }) {
   const { claims, body } = opts;
   await assertStepRequestAllowed(claims);
   const step = resolveBlockStep(body);
-  const params = step.paramSchema.parse(body.params);
+  const params = parseStepParams(step, body.params);
   return {
     snapshot: {
       // Non-empty sentinel: the SDK's inbound validator drops empty-workflowId
@@ -6457,8 +6482,8 @@ async function submitStepWorkflow(opts: {
   // The registry entry's OWN `.strict()` schema is the real param contract (the
   // wire schema only gated the `step` id). An unknown param is REJECTED here,
   // never silently dropped — enforced for every registered entry at registry
-  // load. An invalid param throws → fail-closed.
-  const params = step.paramSchema.parse(body.params);
+  // load. An invalid param is a BAD_REQUEST → fail-closed.
+  const params = parseStepParams(step, body.params);
 
   // ── Moderation posture. Tranche 1 declares 'none' (no free-text input, no
   // free-text output → no new moderation surface), and the registry's load-time
@@ -6474,7 +6499,10 @@ async function submitStepWorkflow(opts: {
     });
   }
 
-  const user = await getBlockSessionUser(userId);
+  // NOTE: no `getBlockSessionUser` call here. A registry step carries no model
+  // binding, no checkpoint resolution and no entitlement belt, so nothing on
+  // this path reads the session user — fetching one cost a `getUserById` per
+  // submit for a value that was never used (and an unused-var eslint warning).
   const { allowMatureContent, isGreen } = resolveBlockMaturity(claims);
   // A registry step has no `accountType` field on its wire body (params are the
   // step's own bounded contract), so currency selection is Auto — the
@@ -6487,13 +6515,98 @@ async function submitStepWorkflow(opts: {
   // single place the money shape is decided; the rest of this function is
   // mode-agnostic and never re-inspects `billingMode`.
   const plan = planStepSpend(step, params);
-  const reserveBuzz = Math.ceil(plan.reserveBuzz);
+  const declaredBuzz = Math.ceil(plan.reserveBuzz);
 
-  // (1) STATIC pre-submit gate against the token's per-call budget. For a
-  // `prepaidFixed` step this is exact: the price is known before execution, so
-  // a submit that passes here cannot exceed the per-call budget — unless the
-  // orchestrator bills above the declared price, which is precisely what the
-  // divergence counter below exists to surface.
+  // Built ONCE, then used for the quote and the real submit, so the two can
+  // never price different things. `timeout` is stamped ONLY for a billing mode
+  // whose cap IS a timeout (`timeBounded`); `prepaidFixed` returns null, because
+  // a timeout on a fixed-price step would be a liveness knob and stamping one
+  // here would imply a Buzz-cap relationship that does not exist.
+  const built = step.buildStep(params);
+  const orchestratorStep = {
+    $type: built.$type,
+    name: BLOCK_STEP_NAME,
+    ...(plan.stepTimeoutSeconds !== null
+      ? { timeout: formatStepTimeout(plan.stepTimeoutSeconds) }
+      : {}),
+    input: built.input,
+  };
+  // Parameterized tags: emit the step id as both the workflow-type tag and the
+  // `baseModel` slot (a registry step has no base model), preserving the
+  // `app-block:*` provenance tags the per-app subqueue read depends on.
+  const tags = buildWorkflowTags(claims, step.id, 'step');
+
+  // ── (0) ORCHESTRATOR QUOTE — a real `whatif:true` submit, BEFORE the per-call
+  // budget gate.
+  //
+  // 🔴 WHY THE DECLARED PRICE CANNOT BE THE CEILING. Before this, the per-call
+  // `buzzBudget` gate compared the token's budget against a number Civitai had
+  // simply asserted in the registry. That made this the FIRST block spend path
+  // whose per-call ceiling rested on nothing the platform enforces:
+  // `textToImage` submit gates on a real `whatif` quote from the orchestrator,
+  // and `customComfy` stamps a step `timeout` the orchestrator physically
+  // enforces as the Buzz ceiling. A `prepaidFixed` step does neither —
+  // `stepTimeoutSeconds` is deliberately `null` — so if the declared price were
+  // ever below the real one, EVERY submit would exceed `buzzBudget` by the
+  // overage, forever, until a human read a counter and shipped code. The
+  // downstream divergence correction adjusts the CAP COUNTERS; it never touched
+  // the declared price or this gate, so it was never a backstop for it.
+  //
+  // 🔴 `prepaidFixed` means "cost knowable before execution" — which is exactly
+  // what `whatif:true` returns. Asking the orchestrator is therefore not a
+  // workaround for the mode, it is the mode's own premise made enforceable.
+  //
+  // No `externalId` on the quote (mirrors the txt2img whatIf preflight): the
+  // idempotency key belongs to the REAL submit only.
+  //
+  // Cost of this: one extra orchestrator round-trip per step submit — the same
+  // one the txt2img path already pays. A throw here propagates BEFORE any
+  // reservation exists, so there is nothing to refund.
+  const whatIfResult = await submitWorkflow({
+    token,
+    body: {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      steps: [orchestratorStep as any],
+      tags,
+      currencies,
+      ...(allowMatureContent === false ? { allowMatureContent: false } : {}),
+    },
+    query: { whatif: true },
+  });
+  const quotedTotal = whatIfResult.cost?.total;
+  const quotedBuzz =
+    typeof quotedTotal === 'number' && Number.isFinite(quotedTotal) ? Math.ceil(quotedTotal) : null;
+
+  // Fail CLOSED on an unquotable step. A missing quote means the mode's premise
+  // ("cost knowable before execution") did not hold for this submit, which puts
+  // the ceiling back on the unenforced declared constant — the exact state this
+  // gate exists to remove. Reported as a recoverable failed-shape snapshot (the
+  // same shape every other cap rejection returns) rather than a throw, and
+  // counted as `outcome: 'absent'` so it is visible rather than silent.
+  if (quotedBuzz === null) {
+    recordStepPriceCheck(step.id, 'absent');
+    return {
+      snapshot: {
+        workflowId: 'failed',
+        status: 'failed' as const,
+        cost: { total: declaredBuzz },
+        error:
+          'generation temporarily unavailable: the orchestrator returned no price quote for ' +
+          'this step, so its cost could not be bounded before execution — please retry shortly',
+      },
+    };
+  }
+
+  // 🔴 The reservation is the LARGER of the two. The quote is what makes the
+  // ceiling real (a quote above the declared price must be gated and reserved at
+  // the real number, not the asserted one); the declared price is the floor
+  // because it is what `estimateBuzz` SHOWED the block, and the registry's
+  // load-time invariant forces those to agree. Over-reserving only makes a cap
+  // stricter.
+  const reserveBuzz = Math.max(declaredBuzz, quotedBuzz);
+
+  // (1) Pre-submit gate against the token's per-call budget — now enforced
+  // against the ORCHESTRATOR'S OWN NUMBER, not a declared constant.
   if (reserveBuzz > claims.buzzBudget) {
     return {
       snapshot: {
@@ -6645,23 +6758,9 @@ async function submitStepWorkflow(opts: {
   let realizedTransactions: Awaited<ReturnType<typeof submitWorkflow>>['transactions'];
   const submittedAt = Date.now();
   try {
-    const built = step.buildStep(params);
-    // The step envelope. `timeout` is stamped ONLY for a billing mode whose cap
-    // IS a timeout (`timeBounded`); `prepaidFixed` returns null, because a
-    // timeout on a fixed-price step would be a liveness knob and stamping one
-    // here would imply a Buzz-cap relationship that does not exist.
-    const orchestratorStep = {
-      $type: built.$type,
-      name: BLOCK_STEP_NAME,
-      ...(plan.stepTimeoutSeconds !== null
-        ? { timeout: formatStepTimeout(plan.stepTimeoutSeconds) }
-        : {}),
-      input: built.input,
-    };
-    // Parameterized tags: emit the step id as both the workflow-type tag and the
-    // `baseModel` slot (a registry step has no base model), preserving the
-    // `app-block:*` provenance tags the per-app subqueue read depends on.
-    const tags = buildWorkflowTags(claims, step.id, 'step');
+    // `orchestratorStep` + `tags` were built above the quote — the SAME objects
+    // the whatif priced, so the quote and the charge can never describe
+    // different work.
     const submitted = await submitWorkflow({
       token,
       body: {
@@ -6695,42 +6794,77 @@ async function submitStepWorkflow(opts: {
   const genResult = { snapshot };
   if (genClaimKey) await finalizeGenIdempotency(genClaimKey, genResult);
 
-  // ── PRICE DIVERGENCE CORRECTION (prepaidFixed's residual risk, made visible).
+  // ── PRICE CHECK + RESERVATION-OVERAGE CORRECTION.
   //
-  // A `prepaidFixed` entry DECLARES an exact price and we reserved exactly that
-  // on every cap. If the orchestrator billed MORE, those counters are short by
-  // the difference and the per-app abuse cap would be that much looser for every
-  // subsequent submit — the one direction a spend cap must never drift. Correct
-  // both counters for the overage (an accounting correction for money already
-  // spent, NOT a gate: `chargeAppSpendOverage` deliberately has no deny path)
-  // and emit the counter that says the DECLARED PRICE IS WRONG and the registry
-  // entry needs fixing.
+  // We reserved an EXACT amount on every cap. If the orchestrator billed MORE,
+  // those counters are short by the difference and the per-app abuse cap would
+  // be that much looser for every subsequent submit — the one direction a spend
+  // cap must never drift. Correct ALL THREE reservations for the overage (an
+  // accounting correction for money already spent, NOT a gate: every `charge*`
+  // helper deliberately has no deny path) and record the outcome.
+  //
+  // 🔴 GATED ON THE PLAN, NOT RUN UNCONDITIONALLY. This correction is
+  // `prepaidFixed`-shaped: it is only right when the reservation was an exact
+  // price. A future `timeBounded` entry reserves a CEILING, and a submit-time
+  // cost above it would be topped up here AND then settled ceiling→actual by the
+  // post-paid machinery off the un-topped-up ceiling. `plan.correctReservationOverage`
+  // is how the MODE decides, keeping this function mode-agnostic — the property
+  // the registry exists to guarantee.
   //
   // Under-billing needs no correction: over-reserving only makes the cap
-  // stricter, and a `prepaidFixed` reservation is final by definition (there is
-  // no post-paid settle to refund it down).
-  const realizedCost = snapshot.cost?.total;
-  if (typeof realizedCost === 'number' && Number.isFinite(realizedCost)) {
-    const overage = Math.ceil(realizedCost) - reserveBuzz;
-    if (overage > 0) {
-      recordStepPriceDivergence(step.id);
-      // Best-effort on both keys; each guarded independently so one failing
-      // cannot skip the other, and neither can break an already-billed submit.
-      try {
-        await reserveBlockBuzzSpendForClaims(claims, userId, overage);
-      } catch {
-        /* best-effort correction — a lost one under-counts by the overage only */
-      }
-      if (appSpendReserve) {
+  // stricter, and an exact reservation is final by definition (there is no
+  // post-paid settle to refund it down).
+  if (plan.correctReservationOverage) {
+    const realizedCost = snapshot.cost?.total;
+    if (typeof realizedCost === 'number' && Number.isFinite(realizedCost)) {
+      const overage = Math.ceil(realizedCost) - reserveBuzz;
+      if (overage > 0) {
+        // 🔴 The declared price is wrong (or the rate card moved). Alert on this.
+        recordStepPriceCheck(step.id, 'over');
+        // Best-effort on ALL THREE keys; each guarded independently so one
+        // failing cannot skip the others, and none can break an already-billed
+        // submit.
+        //
+        // 🔴 THE DEV-SESSION KEY IS ONE OF THE THREE. The earlier version
+        // corrected the per-user and per-app counters only, while its own
+        // comment claimed "both cap counters" — there are three reservations, and
+        // a divergent submit inside a dev tunnel left that counter under-reading
+        // by the overage: precisely the drift direction the same comment forbids.
         try {
-          const { chargeAppSpendOverage } = await import(
-            '~/server/services/blocks/app-spend-cap.service'
-          );
-          await chargeAppSpendOverage(appSpendReserve.key, overage);
+          await reserveBlockBuzzSpendForClaims(claims, userId, overage);
         } catch {
-          /* best-effort correction */
+          /* best-effort correction — a lost one under-counts by the overage only */
         }
+        if (appSpendReserve) {
+          try {
+            const { chargeAppSpendOverage } = await import(
+              '~/server/services/blocks/app-spend-cap.service'
+            );
+            await chargeAppSpendOverage(appSpendReserve.key, overage);
+          } catch {
+            /* best-effort correction */
+          }
+        }
+        if (devSessionReserve) {
+          try {
+            const { chargeDevSessionOverage } = await import(
+              '~/server/services/blocks/dev-tunnel.service'
+            );
+            await chargeDevSessionOverage(devSessionReserve.sessionId, overage);
+          } catch {
+            /* best-effort correction */
+          }
+        }
+      } else {
+        // Healthy — AND the proof that this check runs at all. Without this
+        // emit, a flat divergence line could not be told apart from a detector
+        // that never executed.
+        recordStepPriceCheck(step.id, 'exact');
       }
+    } else {
+      // No numeric cost on the snapshot → nothing to compare. Distinguished from
+      // `exact` on purpose: this is the state in which the correction is inert.
+      recordStepPriceCheck(step.id, 'absent');
     }
   }
 

--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -127,6 +127,7 @@ import {
   buildCustomComfyWorkflowInput,
   buildTextToImageInput,
   createBlockCustomComfyStep,
+  formatStepTimeout,
   isPageLoraResource,
   projectAppWorkflow,
   resolveBlockVersionContext,
@@ -137,6 +138,16 @@ import {
 // trust root; the schema already gated `recipe` to a registered id, so `getRecipe`
 // never returns undefined for a schema-valid body (defensively re-checked).
 import { getRecipe, recipeCivitaiVersionIds } from '~/server/services/blocks/recipes';
+// App Blocks STEP-TYPE bridge (`kind: 'step'`) — RFC #3515 migration step 1.
+// The step registry is the code-reviewed trust root, exactly as the recipe
+// registry is. `estimateStepBuzz` / `planStepSpend` dispatch on the entry's
+// declared `billingMode` — this router contains NO per-step and NO per-mode
+// branch, which is what makes adding a capability additive.
+import { estimateStepBuzz, getStep, planStepSpend } from '~/server/services/blocks/steps';
+// Instrument-only: surfaces a prepaidFixed step whose REALIZED orchestrator cost
+// exceeded the registry's DECLARED price (see the submit path's divergence
+// correction). Never throws.
+import { recordStepPriceDivergence } from '~/server/metrics/app-block-runtime.metrics';
 // Post-paid SETTLE-TO-ACTUAL for customComfy (plan §5.3). `persist*` is awaited in
 // submit (after reserving the ceiling); `settle*` is a best-effort call on the
 // terminal poll/cancel hook. Static import (both are light) — the heavy
@@ -3604,6 +3615,12 @@ export const blocksRouter = router({
       if (input.body.kind === 'customComfy') {
         return await estimateCustomComfyWorkflow({ claims, body: input.body });
       }
+      // App Blocks STEP-TYPE bridge (RFC #3515 migration step 1). A registered
+      // step's cost comes from its declared billing mode, not a whatIf. The
+      // textToImage path below stays byte-identical (we only ADD a branch).
+      if (input.body.kind === 'step') {
+        return await estimateStepWorkflow({ claims, body: input.body });
+      }
       // Context binding. A MODEL token pins `ctx.modelId`; the body must match
       // it. A PAGE token (ctx.entityType==='none') has NO model binding — it
       // lets the viewer pick a model, so the modelId match is SKIPPED and
@@ -3796,6 +3813,19 @@ export const blocksRouter = router({
       // return `input.body` narrows to the textToImage member for the rest.
       if (input.body.kind === 'customComfy') {
         return await submitCustomComfyWorkflow({
+          ctx,
+          claims,
+          body: input.body,
+          idempotencyKey: input.idempotencyKey,
+        });
+      }
+      // App Blocks STEP-TYPE bridge (RFC #3515 migration step 1) — a SPEND
+      // path. Branch to the registry-backed handler, which runs the same
+      // developer/page gates and the SAME cap belt (per-user daily +
+      // `reserveAppSpend` per-app aggregate + dev-session) the other kinds use.
+      // The textToImage path below stays byte-identical (we only ADD a branch).
+      if (input.body.kind === 'step') {
+        return await submitStepWorkflow({
           ctx,
           claims,
           body: input.body,
@@ -6283,6 +6313,530 @@ async function submitCustomComfyWorkflow(opts: {
         // customComfy is recipe-based (no single user-picked model to attribute).
         modelId: null,
         // customComfy has no sharedContentKey field (recipe+params only) → omit.
+        sharedContentKey: null,
+      });
+    })().catch(() => {
+      /* best-effort: a failed attribution write never breaks submit */
+    });
+  }
+
+  // Same object already cached under the idempotency key (see genResult above).
+  return genResult;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// App Blocks STEP-TYPE bridge (`kind: 'step'`) — estimate + submit handlers.
+// RFC #3515 migration step 1.
+//
+// A `step` body carries `{ kind, step, params }` — NO model binding. Everything
+// the capability needs lives in its REGISTRY ENTRY
+// (`~/server/services/blocks/steps`): a bounded `.strict()` param schema, a pure
+// builder, a declared BILLING MODE, and a declared MODERATION POSTURE.
+//
+// 🔴 THE DISPATCH RULE. These two handlers contain NO per-step branch and NO
+// per-billing-mode branch. Estimate reads `estimateStepBuzz(entry, params)` and
+// submit reads `planStepSpend(entry, params)`; both dispatch on the entry's
+// declared `billingMode` inside the registry module. Registering a capability
+// touches one new file plus one registry line — never this router. If you find
+// yourself adding `if (step.id === …)` or `if (billingMode === …)` here, the
+// abstraction has been defeated and the RFC's whole premise with it.
+//
+// 🔴 THE MONEY RULE. A step submit runs the SAME cap belt every other spending
+// kind runs — the per-user daily cap, the per-app aggregate `reserveAppSpend`
+// (daily Buzz + velocity), and the dev-session backstop — reserved BEFORE the
+// orchestrator submit and refunded on every non-committed exit. `kind: 'step'`
+// must not be a money surface the guardrail cannot see; if it were, the
+// `civitai_app_block_spend_cap_rejections_total` counter would not fire for it
+// either, so the gap would also be invisible.
+// ─────────────────────────────────────────────────────────────────────────────
+
+type StepBody = Extract<BlockWorkflowBody, { kind: 'step' }>;
+
+/** Orchestrator step name stamped on a block step submission. */
+const BLOCK_STEP_NAME = 'block-step';
+
+/**
+ * Resolve the registry entry from the (schema-gated) `step` id. The wire
+ * schema's `z.enum(REGISTERED_STEP_IDS)` already rejected any unregistered id at
+ * the union, so this never returns undefined for a schema-valid body — the
+ * guard is defense-in-depth against a registry/schema desync. Fail closed.
+ */
+function resolveBlockStep(body: StepBody) {
+  const step = getStep(body.step);
+  if (!step) {
+    throw new TRPCError({ code: 'BAD_REQUEST', message: 'unknown step type' });
+  }
+  return step;
+}
+
+/**
+ * The gates every step request passes before anything else happens, in the same
+ * order and with the same fail-closed posture as the customComfy handlers.
+ * Shared by estimate and submit so the two can never drift — a gate that holds
+ * on submit but not on estimate lets a caller probe what it may not run.
+ *
+ * PAGE-ONLY in v1, mirroring `customComfy`. A registry step carries no model
+ * binding, so a MODEL token has nothing to bind it to; rejecting it is the
+ * conservative direction and widening later is not a wire change.
+ */
+async function assertStepRequestAllowed(claims: BlockClaims): Promise<number> {
+  if (!isPageToken(claims)) {
+    throw new TRPCError({ code: 'FORBIDDEN', message: 'registry steps are page-only' });
+  }
+  const userId = parseSubjectUserId(claims.sub);
+  if (userId == null) {
+    throw new TRPCError({ code: 'UNAUTHORIZED', message: 'step requires authenticated viewer' });
+  }
+  await assertAppBlocksEnabledForTokenUser(userId);
+  await assertViewerIsAppDeveloper(userId);
+  return userId;
+}
+
+/**
+ * STEP ESTIMATE. Returns the registry's declared, deterministic estimate — no
+ * orchestrator round-trip. For `prepaidFixed` that estimate is enforced at
+ * registry LOAD to equal the exact price the submit path reserves and the
+ * viewer is charged, so an estimate can never quote a different number than the
+ * submit bills.
+ *
+ * Fail-closed on an out-of-bounds param (ZodError → BAD_REQUEST), exactly as
+ * submit does — the same `.strict()` schema runs on both paths.
+ */
+async function estimateStepWorkflow(opts: { claims: BlockClaims; body: StepBody }) {
+  const { claims, body } = opts;
+  await assertStepRequestAllowed(claims);
+  const step = resolveBlockStep(body);
+  const params = step.paramSchema.parse(body.params);
+  return {
+    snapshot: {
+      // Non-empty sentinel: the SDK's inbound validator drops empty-workflowId
+      // snapshots. The block treats estimate as a cost quote and never polls it.
+      workflowId: 'wf_estimate',
+      status: 'pending' as const,
+      cost: { total: estimateStepBuzz(step, params) },
+    },
+  };
+}
+
+/**
+ * STEP SUBMIT. Order: gates → per-step `.strict()` param parse → moderation
+ * posture → spend plan (dispatched on billing mode) → static budget gate →
+ * idempotency claim → reserve on the per-user cap → reserve on the PER-APP cap
+ * → reserve on the dev-session cap → build + submit → settle bookkeeping →
+ * durable audit + attribution.
+ *
+ * Over-cap / rejections return a failed-shape snapshot (recoverable by the
+ * block); a throw AFTER reserving refunds every reservation.
+ */
+async function submitStepWorkflow(opts: {
+  ctx: Context;
+  claims: BlockClaims;
+  body: StepBody;
+  /** OPTIONAL client idempotency key → orchestrator externalId. */
+  idempotencyKey?: string;
+}) {
+  const { ctx, claims, body, idempotencyKey } = opts;
+
+  // Namespaced idempotency externalId — ALWAYS SET, same as the other kinds: a
+  // server-minted `bls<uuid>` when the block sends no key, so `submitWorkflow`'s
+  // own 3× retry of the real submit can never create (and charge for) a second
+  // workflow after a 502/504. Minted ONCE here — the body built below is the
+  // object the retry wrapper reuses across attempts.
+  const blockExternalId = idempotencyKey
+    ? composeBlockExternalId(claims.appBlockId, idempotencyKey)
+    : mintServerBlockExternalId();
+
+  const userId = await assertStepRequestAllowed(claims);
+  // The outer proc already gated this, but re-narrow here (defense-in-depth) so
+  // `buzzBudget` is a positive number the static gate can compare against.
+  if (typeof claims.buzzBudget !== 'number' || claims.buzzBudget <= 0) {
+    throw new TRPCError({ code: 'FORBIDDEN', message: 'block token missing budget' });
+  }
+
+  const step = resolveBlockStep(body);
+  // The registry entry's OWN `.strict()` schema is the real param contract (the
+  // wire schema only gated the `step` id). An unknown param is REJECTED here,
+  // never silently dropped — enforced for every registered entry at registry
+  // load. An invalid param throws → fail-closed.
+  const params = step.paramSchema.parse(body.params);
+
+  // ── Moderation posture. Tranche 1 declares 'none' (no free-text input, no
+  // free-text output → no new moderation surface), and the registry's load-time
+  // invariant REJECTS any entry declaring a posture whose handler is not
+  // implemented. So there is nothing to run here today, and a future
+  // text-producing step cannot reach this line without someone having
+  // implemented — and reviewed — its posture. Re-asserted rather than assumed:
+  // this is the seam a policy mistake would arrive through.
+  if (step.moderationPosture !== 'none') {
+    throw new TRPCError({
+      code: 'INTERNAL_SERVER_ERROR',
+      message: `step '${step.id}' declares an unimplemented moderation posture`,
+    });
+  }
+
+  const user = await getBlockSessionUser(userId);
+  const { allowMatureContent, isGreen } = resolveBlockMaturity(claims);
+  // A registry step has no `accountType` field on its wire body (params are the
+  // step's own bounded contract), so currency selection is Auto — the
+  // domain-allowed set, drained blue-first.
+  const currencies = resolveBlockCurrenciesForAccount(isGreen, undefined);
+
+  const token = await getOrchestratorToken(userId, ctx);
+
+  // ── SPEND PLAN — dispatched on the entry's declared BILLING MODE. This is the
+  // single place the money shape is decided; the rest of this function is
+  // mode-agnostic and never re-inspects `billingMode`.
+  const plan = planStepSpend(step, params);
+  const reserveBuzz = Math.ceil(plan.reserveBuzz);
+
+  // (1) STATIC pre-submit gate against the token's per-call budget. For a
+  // `prepaidFixed` step this is exact: the price is known before execution, so
+  // a submit that passes here cannot exceed the per-call budget — unless the
+  // orchestrator bills above the declared price, which is precisely what the
+  // divergence counter below exists to surface.
+  if (reserveBuzz > claims.buzzBudget) {
+    return {
+      snapshot: {
+        workflowId: 'failed',
+        status: 'failed' as const,
+        cost: { total: reserveBuzz },
+        error: `insufficient buzz budget: step price ${reserveBuzz} exceeds budget ${claims.buzzBudget}`,
+      },
+    };
+  }
+
+  // ── GEN IDEMPOTENCY CLAIM — taken BEFORE the cap reservations + orchestrator
+  //    submit so two CONCURRENT same-key submits can't BOTH reserve + BOTH
+  //    charge, and a replay can't double-INCR the cap counters. Absent key → no
+  //    claim. Fail-CLOSED on a redis error; a resolved submit FINALIZEs, every
+  //    non-committed exit RELEASEs. The orchestrator externalId dedupe stays as
+  //    a 2nd layer.
+  let genClaimKey: string | null = null;
+  if (idempotencyKey) {
+    let claim: BlockGenIdempotencyClaim<{ snapshot: ReturnType<typeof snapshotFromWorkflow> }>;
+    try {
+      claim = await claimGenIdempotency<{ snapshot: ReturnType<typeof snapshotFromWorkflow> }>(
+        userId,
+        claims.appBlockId,
+        idempotencyKey
+      );
+    } catch {
+      throw new TRPCError({
+        code: 'INTERNAL_SERVER_ERROR',
+        message: 'generation idempotency unavailable; please retry',
+      });
+    }
+    if (claim.state === 'replay') return claim.result;
+    if (claim.state === 'in_progress') {
+      throw new TRPCError({
+        code: 'CONFLICT',
+        message: 'a generation with this idempotency key is already in progress',
+      });
+    }
+    genClaimKey = claim.key;
+  }
+
+  // (2) Reserve against the per-user cumulative cap. THROWS fail-closed on a
+  // redis error; release the claim first.
+  let reservation: Awaited<ReturnType<typeof reserveBlockBuzzSpendForClaims>>;
+  try {
+    reservation = await reserveBlockBuzzSpendForClaims(claims, userId, reserveBuzz);
+  } catch (e) {
+    if (genClaimKey) await releaseGenIdempotency(genClaimKey);
+    throw e;
+  }
+  const { total, key: buzzCapKey, cap: buzzCap } = reservation;
+  if (total > buzzCap) {
+    await refundBlockBuzzSpend(buzzCapKey, reserveBuzz);
+    if (genClaimKey) await releaseGenIdempotency(genClaimKey);
+    return {
+      snapshot: {
+        workflowId: 'failed',
+        status: 'failed' as const,
+        cost: { total: reserveBuzz },
+        error:
+          claims.reviewRunForReal === true
+            ? `review run-for-real Buzz cap reached: ${total - reserveBuzz} already ` +
+              `spent this review session, this step costs ${reserveBuzz}, ` +
+              `session cap is ${buzzCap}`
+            : `daily Buzz cap reached: ${total - reserveBuzz} already spent today ` +
+              `across your installed apps, this step costs ${reserveBuzz}, ` +
+              `daily cap is ${buzzCap}`,
+      },
+    };
+  }
+
+  // 🔴 (3) Reserve against the PER-APP aggregate cap (daily Buzz + velocity).
+  // This is the guardrail the per-user cap structurally cannot provide — it is
+  // keyed on `appBlockId` with the spender deliberately absent from the key, so
+  // a Sybil ring funnelling many accounts' spend through ONE app is bounded.
+  // Skipped ONLY for DEV tokens (synthetic non-FK appBlockId), matching every
+  // other kind.
+  let appSpendReserve: { key: AppSpendDailyKey; cost: number } | null = null;
+  if (claims.dev !== true) {
+    const { reserveAppSpend } = await import('~/server/services/blocks/app-spend-cap.service');
+    const appSpend = await reserveAppSpend(claims.appBlockId, reserveBuzz);
+    if (!appSpend.allowed) {
+      // Roll back the per-user reservation so a rejected submit doesn't burn the
+      // viewer's own daily ceiling for a spend that never happened.
+      await refundBlockBuzzSpend(buzzCapKey, reserveBuzz);
+      // No money moved → release the idempotency claim so a genuine retry runs.
+      if (genClaimKey) await releaseGenIdempotency(genClaimKey);
+      return {
+        snapshot: {
+          workflowId: 'failed',
+          status: 'failed' as const,
+          cost: { total: reserveBuzz },
+          error:
+            appSpend.reason === 'velocity'
+              ? 'app generation rate limit reached: this app has run too many generations in a short window — please retry shortly'
+              : appSpend.reason === 'unavailable'
+              ? 'generation temporarily unavailable — please retry shortly'
+              : 'app daily spend cap reached: this app has hit its aggregate daily generation-spend ceiling — please try again later',
+        },
+      };
+    }
+    if (appSpend.dailyKey) appSpendReserve = { key: appSpend.dailyKey, cost: reserveBuzz };
+  }
+
+  // (4) APP DEV TUNNEL per-session spend backstop — mirror every other kind.
+  // Bounds cumulative spend within ONE dev session so a runaway LOCAL submit
+  // loop can't drain Buzz.
+  let devSessionReserve: { sessionId: string; cost: number } | null = null;
+  {
+    const { getActiveDevTunnel, reserveDevSessionBuzz } = await import(
+      '~/server/services/blocks/dev-tunnel.service'
+    );
+    const devTunnel = await getActiveDevTunnel(userId, claims.blockId).catch(() => null);
+    if (devTunnel) {
+      const reserved = await reserveDevSessionBuzz(
+        devTunnel.sessionId,
+        reserveBuzz,
+        devTunnel.spendCapBuzz
+      );
+      if (!reserved.allowed) {
+        await refundBlockBuzzSpend(buzzCapKey, reserveBuzz);
+        if (appSpendReserve) {
+          const { refundAppSpend } = await import('~/server/services/blocks/app-spend-cap.service');
+          await refundAppSpend(appSpendReserve.key, appSpendReserve.cost);
+        }
+        if (genClaimKey) await releaseGenIdempotency(genClaimKey);
+        return {
+          snapshot: {
+            workflowId: 'failed',
+            status: 'failed' as const,
+            cost: { total: reserveBuzz },
+            error:
+              `dev tunnel session Buzz cap reached: ${reserved.total} already spent ` +
+              `this dev session, this step costs ${reserveBuzz}, ` +
+              `session cap is ${devTunnel.spendCapBuzz}`,
+          },
+        };
+      }
+      devSessionReserve = { sessionId: devTunnel.sessionId, cost: reserveBuzz };
+    }
+  }
+
+  // ── Build + submit. On ANY throw AFTER reserving, refund on ALL reservation
+  // keys and re-throw (refund-on-throw).
+  let snapshot: ReturnType<typeof snapshotFromWorkflow>;
+  // Hoisted out of the try so the post-submit spend-attribution closure can read
+  // the REALIZED per-account debit.
+  let realizedTransactions: Awaited<ReturnType<typeof submitWorkflow>>['transactions'];
+  const submittedAt = Date.now();
+  try {
+    const built = step.buildStep(params);
+    // The step envelope. `timeout` is stamped ONLY for a billing mode whose cap
+    // IS a timeout (`timeBounded`); `prepaidFixed` returns null, because a
+    // timeout on a fixed-price step would be a liveness knob and stamping one
+    // here would imply a Buzz-cap relationship that does not exist.
+    const orchestratorStep = {
+      $type: built.$type,
+      name: BLOCK_STEP_NAME,
+      ...(plan.stepTimeoutSeconds !== null
+        ? { timeout: formatStepTimeout(plan.stepTimeoutSeconds) }
+        : {}),
+      input: built.input,
+    };
+    // Parameterized tags: emit the step id as both the workflow-type tag and the
+    // `baseModel` slot (a registry step has no base model), preserving the
+    // `app-block:*` provenance tags the per-app subqueue read depends on.
+    const tags = buildWorkflowTags(claims, step.id, 'step');
+    const submitted = await submitWorkflow({
+      token,
+      body: {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        steps: [orchestratorStep as any],
+        tags,
+        currencies,
+        // Authoritative maturity clamp on the real submit — token-claim derived.
+        ...(allowMatureContent === false ? { allowMatureContent: false } : {}),
+        externalId: blockExternalId,
+      },
+    });
+    snapshot = snapshotFromWorkflow(submitted);
+    realizedTransactions = submitted.transactions;
+  } catch (e) {
+    await refundBlockBuzzSpend(buzzCapKey, reserveBuzz);
+    if (appSpendReserve) {
+      const { refundAppSpend } = await import('~/server/services/blocks/app-spend-cap.service');
+      await refundAppSpend(appSpendReserve.key, appSpendReserve.cost);
+    }
+    if (devSessionReserve) {
+      const { refundDevSessionBuzz } = await import('~/server/services/blocks/dev-tunnel.service');
+      await refundDevSessionBuzz(devSessionReserve.sessionId, devSessionReserve.cost);
+    }
+    if (genClaimKey) await releaseGenIdempotency(genClaimKey);
+    throw e;
+  }
+
+  // A resolved submit is money-COMMITTED. Cache the terminal result under the
+  // idempotency key so a lost-response retry replays it. Best-effort.
+  const genResult = { snapshot };
+  if (genClaimKey) await finalizeGenIdempotency(genClaimKey, genResult);
+
+  // ── PRICE DIVERGENCE CORRECTION (prepaidFixed's residual risk, made visible).
+  //
+  // A `prepaidFixed` entry DECLARES an exact price and we reserved exactly that
+  // on every cap. If the orchestrator billed MORE, those counters are short by
+  // the difference and the per-app abuse cap would be that much looser for every
+  // subsequent submit — the one direction a spend cap must never drift. Correct
+  // both counters for the overage (an accounting correction for money already
+  // spent, NOT a gate: `chargeAppSpendOverage` deliberately has no deny path)
+  // and emit the counter that says the DECLARED PRICE IS WRONG and the registry
+  // entry needs fixing.
+  //
+  // Under-billing needs no correction: over-reserving only makes the cap
+  // stricter, and a `prepaidFixed` reservation is final by definition (there is
+  // no post-paid settle to refund it down).
+  const realizedCost = snapshot.cost?.total;
+  if (typeof realizedCost === 'number' && Number.isFinite(realizedCost)) {
+    const overage = Math.ceil(realizedCost) - reserveBuzz;
+    if (overage > 0) {
+      recordStepPriceDivergence(step.id);
+      // Best-effort on both keys; each guarded independently so one failing
+      // cannot skip the other, and neither can break an already-billed submit.
+      try {
+        await reserveBlockBuzzSpendForClaims(claims, userId, overage);
+      } catch {
+        /* best-effort correction — a lost one under-counts by the overage only */
+      }
+      if (appSpendReserve) {
+        try {
+          const { chargeAppSpendOverage } = await import(
+            '~/server/services/blocks/app-spend-cap.service'
+          );
+          await chargeAppSpendOverage(appSpendReserve.key, overage);
+        } catch {
+          /* best-effort correction */
+        }
+      }
+    }
+  }
+
+  // ── Post-paid settle bookkeeping, driven by the PLAN — not by the kind and not
+  // by the step id. `prepaidFixed` sets `postPaidSettle: false`: the price is
+  // exact, the reservation is final, and the post-paid ceiling→actual settle
+  // machinery is never touched (no settle record is persisted, so the terminal
+  // poll/cancel hook has nothing to read and no refund is owed). A future
+  // `timeBounded` entry sets it true and reuses the same machinery customComfy
+  // does, with no change to this function's shape.
+  if (
+    plan.postPaidSettle &&
+    snapshot.workflowId &&
+    snapshot.workflowId !== 'failed' &&
+    snapshot.workflowId !== 'whatif'
+  ) {
+    await persistCustomComfySettle({
+      workflowId: snapshot.workflowId,
+      buzzCapKey,
+      appSpendKey: appSpendReserve?.key ?? null,
+      ...(devSessionReserve ? { devSessionId: devSessionReserve.sessionId } : {}),
+      ceiling: reserveBuzz,
+      engine: step.resolveVariant(params),
+      recipe: step.id,
+      submittedAt,
+    });
+  }
+
+  // G6 — persistent output queue (best-effort, non-dev), so a step gen rebuilds
+  // in listMyWorkflows on reload. Same posture as every other kind.
+  if (
+    snapshot.workflowId &&
+    snapshot.workflowId !== 'failed' &&
+    snapshot.workflowId !== 'whatif' &&
+    claims.dev !== true
+  ) {
+    const realWorkflowId = snapshot.workflowId;
+    void (async () => {
+      const { upsertBlockWorkflowOnSubmit } = await import(
+        '~/server/services/blocks/block-workflows.service'
+      );
+      await upsertBlockWorkflowOnSubmit({
+        workflowId: realWorkflowId,
+        appBlockId: claims.appBlockId,
+        blockInstanceId: claims.blockInstanceId,
+        userId,
+        status: snapshot.status,
+      });
+    })().catch(() => {
+      /* best-effort: a failed queue write never breaks (or slows) submit */
+    });
+  }
+
+  // ── Durable audit + attribution (parity with the txt2img + customComfy paths).
+  // A step generation bills real Buzz, so it must leave the same durable trail:
+  // a per-user activity row and an author-bounty spend basis. Both are
+  // server-derived from the VERIFIED token claims (never client input), and both
+  // are fire-and-forget with their OWN try/catch so an audit failure can never
+  // add latency to — or break — the already-billed submit response.
+  {
+    const invocationCost = snapshot.cost?.total ?? reserveBuzz;
+    void (async () => {
+      const { recordScopeInvocation } = await import(
+        '~/server/services/blocks/user-app-surface.service'
+      );
+      await recordScopeInvocation({
+        userId,
+        appBlockId: claims.appBlockId,
+        blockInstanceId: claims.blockInstanceId,
+        scope: 'ai:write:budgeted',
+        endpoint: `workflow:submit:${snapshot.workflowId || 'pending'}`,
+        statusCode: snapshot.status === 'failed' ? 500 : 200,
+        detail: {
+          action: 'workflow.submit',
+          amount: typeof invocationCost === 'number' ? -Math.abs(invocationCost) : undefined,
+          outcome: snapshot.status === 'failed' ? 'failed' : 'ok',
+        },
+        dev: claims.dev === true,
+      });
+    })().catch(() => {
+      /* swallowed inside helper */
+    });
+  }
+
+  const spendWorkflowId = snapshot.workflowId;
+  if (spendWorkflowId && spendWorkflowId !== 'failed' && snapshot.status !== 'failed') {
+    void (async () => {
+      const { recordSpendAttribution } = await import(
+        '~/server/services/blocks/buzz-attribution.service'
+      );
+      const { buzzType, buzzAmount } = deriveBlockSpendBasis(
+        realizedTransactions,
+        isGreen,
+        snapshot.cost?.total ?? reserveBuzz
+      );
+      await recordSpendAttribution({
+        userId,
+        buzzAmount,
+        buzzType,
+        workflowId: spendWorkflowId,
+        appId: claims.appId,
+        appBlockId: claims.appBlockId,
+        blockInstanceId: claims.blockInstanceId,
+        // A registry step is not model-based (no user-picked model to attribute).
+        modelId: null,
+        // A step body is `{ kind, step, params }` `.strict()` — no sharedContentKey.
         sharedContentKey: null,
       });
     })().catch(() => {

--- a/src/server/schema/blocks/__tests__/workflow.schema.step.test.ts
+++ b/src/server/schema/blocks/__tests__/workflow.schema.step.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it } from 'vitest';
+import {
+  blockStepBodySchema,
+  blockWorkflowBodySchema,
+  makeBlockStepBodySchema,
+} from '~/server/schema/blocks/workflow.schema';
+import { REGISTERED_STEP_IDS } from '~/server/services/blocks/steps';
+
+/**
+ * Wire-contract coverage for the THIRD discriminated-union member,
+ * `kind: 'step'` (RFC #3515 migration step 1).
+ *
+ * The properties under test are the ones that are expensive to get wrong,
+ * because `@civitai/app-sdk` mirrors this shape and every published app ships
+ * against it:
+ *   1. an unregistered step id fails closed AT THE SCHEMA, not deeper in the stack
+ *   2. the id enum is DERIVED from the registry keys, not hardcoded
+ *   3. adding the member did not change how the existing two members parse
+ */
+
+const VALID_STEP_ID = REGISTERED_STEP_IDS[0];
+
+describe("blockWorkflowBodySchema — kind: 'step'", () => {
+  it('accepts a registered step id with opaque params', () => {
+    const parsed = blockWorkflowBodySchema.safeParse({
+      kind: 'step',
+      step: VALID_STEP_ID,
+      params: { image: 'https://image.civitai.com/x.png', output: { format: 'webp' } },
+    });
+    expect(parsed.success).toBe(true);
+  });
+
+  // 🔴 FAIL CLOSED AT THE SCHEMA. Not in the handler, not at the orchestrator —
+  // an unregistered id must never reach a translator or a spend reservation.
+  it('REJECTS an unregistered step id at the wire schema', () => {
+    const parsed = blockWorkflowBodySchema.safeParse({
+      kind: 'step',
+      step: 'not-a-registered-step',
+      params: {},
+    });
+    expect(parsed.success).toBe(false);
+    // The failure is on the `step` field specifically — i.e. the enum rejected
+    // it, not some unrelated shape check.
+    expect(
+      parsed.success === false && parsed.error.issues.some((i) => i.path.includes('step'))
+    ).toBe(true);
+  });
+
+  it('REJECTS an unknown top-level field (.strict())', () => {
+    const parsed = blockWorkflowBodySchema.safeParse({
+      kind: 'step',
+      step: VALID_STEP_ID,
+      params: {},
+      surpriseField: 1,
+    });
+    expect(parsed.success).toBe(false);
+  });
+
+  it('REJECTS a missing step id and a missing params object', () => {
+    expect(blockWorkflowBodySchema.safeParse({ kind: 'step', params: {} }).success).toBe(false);
+    expect(blockWorkflowBodySchema.safeParse({ kind: 'step', step: VALID_STEP_ID }).success).toBe(
+      false
+    );
+  });
+
+  // 🔴 DERIVATION, proven rather than asserted. The enum is built by a factory
+  // over an id list, so widening the list widens the enum — which is what makes
+  // "register a step, no schema surgery" true. A hardcoded enum would pass every
+  // other test in this file and fail this one.
+  it('derives its id enum from the registry keys — a widened list widens the enum', () => {
+    const widened = makeBlockStepBodySchema([...REGISTERED_STEP_IDS, 'fixture-only-step']);
+
+    // The shipped schema rejects the fixture id...
+    expect(
+      blockStepBodySchema.safeParse({ kind: 'step', step: 'fixture-only-step', params: {} }).success
+    ).toBe(false);
+    // ...and the same factory over a widened list accepts it, with no other change.
+    expect(widened.safeParse({ kind: 'step', step: 'fixture-only-step', params: {} }).success).toBe(
+      true
+    );
+    // Every real id still parses under both.
+    for (const id of REGISTERED_STEP_IDS) {
+      expect(blockStepBodySchema.safeParse({ kind: 'step', step: id, params: {} }).success).toBe(
+        true
+      );
+      expect(widened.safeParse({ kind: 'step', step: id, params: {} }).success).toBe(true);
+    }
+  });
+});
+
+describe('blockWorkflowBodySchema — the existing members are unchanged', () => {
+  // Adding a union member must be purely additive. These pin the two shapes that
+  // are already public; a regression here breaks every deployed block.
+  const textToImageBody = {
+    kind: 'textToImage' as const,
+    modelId: 123,
+    modelVersionId: 456,
+    params: { prompt: 'a cat', quantity: 1 },
+  };
+
+  it('textToImage still parses and still produces the same normalized body', () => {
+    const parsed = blockWorkflowBodySchema.safeParse(textToImageBody);
+    expect(parsed.success).toBe(true);
+    expect(parsed.success && parsed.data).toEqual({
+      kind: 'textToImage',
+      modelId: 123,
+      modelVersionId: 456,
+      params: { prompt: 'a cat', quantity: 1 },
+    });
+  });
+
+  it('textToImage still canonicalizes a sourceImage URL and still rejects a non-Civitai host', () => {
+    // The Civitai-host predicate MOVED to its own module in this change; these
+    // pin that the behaviour did not move with it.
+    const ok = blockWorkflowBodySchema.safeParse({
+      ...textToImageBody,
+      sourceImage: { url: 'https://image.civitai.com/abc.png', width: 512, height: 512 },
+    });
+    expect(ok.success).toBe(true);
+    expect(ok.success && (ok.data as { sourceImage: { url: string } }).sourceImage.url).toBe(
+      'https://image.civitai.com/abc.png'
+    );
+
+    const evil = blockWorkflowBodySchema.safeParse({
+      ...textToImageBody,
+      sourceImage: { url: 'https://evil.example/?x=image.civitai.com', width: 512, height: 512 },
+    });
+    expect(evil.success).toBe(false);
+  });
+
+  it('customComfy still parses and still rejects an unregistered recipe', () => {
+    const ok = blockWorkflowBodySchema.safeParse({
+      kind: 'customComfy',
+      recipe: 'seamless-pano-360',
+      params: { prompt: 'x' },
+    });
+    expect(ok.success).toBe(true);
+
+    const bad = blockWorkflowBodySchema.safeParse({
+      kind: 'customComfy',
+      recipe: 'not-a-recipe',
+      params: {},
+    });
+    expect(bad.success).toBe(false);
+  });
+
+  it('an unknown kind is still rejected', () => {
+    expect(
+      blockWorkflowBodySchema.safeParse({ kind: 'chatCompletion', model: 'x', messages: [] })
+        .success
+    ).toBe(false);
+  });
+});

--- a/src/server/schema/blocks/civitai-image-url.ts
+++ b/src/server/schema/blocks/civitai-image-url.ts
@@ -1,0 +1,129 @@
+import * as z from 'zod';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// The Civitai-hosted image-URL bound, shared by EVERY App Blocks wire surface
+// that accepts an image URL from an untrusted iframe.
+//
+// 🔴 WHY THIS IS ITS OWN MODULE. This rule originally lived inline in
+// `workflow.schema.ts` (as `blockSourceImageSchema`'s `url` field) because
+// `textToImage` was the only member that took an image. The `kind: 'step'`
+// registry adds a SECOND class of consumer (`convertImage`, and every future
+// image-taking step type), and the registry cannot import `workflow.schema.ts`
+// — that module imports the registry to derive its wire enums, so the
+// dependency would be a cycle. Copying the rule into the registry instead would
+// give the same predicate two homes, which is how one copy gets a fix and the
+// other doesn't. So it lives here, imported by both, with zero local imports of
+// its own (client-safe: `workflow.schema.ts` is `import type`'d by a client
+// component, so this module must stay free of server-only imports).
+//
+// The rule itself is UNCHANGED from the inline version — the extraction is a
+// move, not a rewrite. Its reasoning, preserved:
+//
+// An init/source image MUST NOT be an arbitrary remote URL the generator would
+// fetch (SSRF / arbitrary-fetch). It is bounded to a Civitai-controlled host.
+// An uploaded image resolves to an `https://orchestration…civitai.com` URL, so
+// this same bound covers the "uploaded image" case WITHOUT widening to
+// attacker-controlled origins.
+//
+// This is validated by parsed URL HOSTNAME (not a substring match), which is
+// intentionally tighter than the platform's server `sourceImageSchema`
+// (`.includes('image.civitai.com')`) — a substring check would accept
+// `https://evil.example/?x=image.civitai.com`; a hostname check rejects it and
+// also rejects non-https and userinfo.
+//
+// 🔴 A hostname check ALONE is not sufficient, because it validates a PARSED
+// url while the schema used to emit the ORIGINAL string. Every consumer
+// downstream then re-parses those original bytes, and a parser that disagrees
+// with WHATWG about them sees a DIFFERENT host than the one we approved. Two
+// concrete WHATWG-specific behaviours were being relied on as security
+// properties, both verified to pass the bare hostname check:
+//   - backslash-in-authority: WHATWG treats a backslash as a slash for special
+//     schemes, so an authority of `civitai.com` + backslash + `@evil.com`
+//     parses with host `civitai.com`. A parser that splits the authority on the
+//     last `@` without treating the backslash as a delimiter reads
+//     host = `evil.com`.
+//   - TAB / CR / LF deletion: WHATWG strips those three bytes from ANYWHERE in
+//     the url, so `evil.com` + CRLF + `.civitai.com` normalizes to the
+//     (nonexistent) subdomain `evil.com.civitai.com` and passes — while the raw
+//     string, CRLF intact, is what got forwarded. CRLF inside a value a
+//     consumer concatenates into a request line or header is a
+//     request-splitting / log-injection primitive.
+// So the bound is enforced in three layers, in this order:
+//   1. REJECT ambiguous bytes before parsing. No legitimate url carries a raw
+//      backslash or control byte — they must be percent-encoded — so this costs
+//      nothing, and it closes the differential class at the door rather than
+//      silently rewriting a plainly hostile input into an accepted one.
+//   2. Validate the parsed hostname.
+//   3. CANONICALIZE to `URL.href`, so the bytes we emit are exactly the bytes
+//      we validated. This also covers normalization classes beyond the bytes
+//      above (percent-encoding, default-port stripping, empty-path, host
+//      case-folding).
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const CIVITAI_IMAGE_HOSTS = ['civitai.com', 'civitai.red', 'civitai.green'] as const;
+
+/** Backslash. */
+const CHAR_BACKSLASH = 0x5c;
+/** Highest C0 control code point. */
+const CHAR_C0_MAX = 0x1f;
+/** DEL. */
+const CHAR_DEL = 0x7f;
+
+/**
+ * True when the string carries a backslash, a C0 control, or DEL — a superset
+ * of the TAB/CR/LF bytes WHATWG deletes and the leading/trailing C0 it strips,
+ * so no byte the parser silently removes or reinterprets can survive into the
+ * value we approve.
+ *
+ * Written as a code-point scan rather than the equivalent character-class
+ * regex on purpose: that class needs stacked backslash escapes to express, and
+ * a security predicate whose meaning hinges on escaping is exactly the literal
+ * that gets silently corrupted in transit and still compiles. (It did, while
+ * this file was being written: the escapes were resolved into RAW control bytes
+ * embedded in the source, which reads identically in an editor, still parses,
+ * and quietly changes what the class matches.)
+ */
+export function hasUrlAmbiguousBytes(raw: string): boolean {
+  for (let i = 0; i < raw.length; i++) {
+    const code = raw.charCodeAt(i);
+    if (code === CHAR_BACKSLASH || code <= CHAR_C0_MAX || code === CHAR_DEL) return true;
+  }
+  return false;
+}
+
+// Bound applies to BOTH the raw input and the canonicalized output: percent-
+// encoding can inflate a string ~9x (a 2048-char path of CJK canonicalizes to
+// 18272 chars), so the pre-transform cap does NOT bound what we emit.
+export const SOURCE_IMAGE_URL_MAX = 2048;
+
+export function isCivitaiHostedImageUrl(raw: string): boolean {
+  if (hasUrlAmbiguousBytes(raw)) return false;
+  let parsed: URL;
+  try {
+    parsed = new URL(raw);
+  } catch {
+    return false;
+  }
+  if (parsed.protocol !== 'https:') return false;
+  const host = parsed.hostname.toLowerCase();
+  return CIVITAI_IMAGE_HOSTS.some((h) => host === h || host.endsWith(`.${h}`));
+}
+
+/**
+ * The reusable bounded-and-canonicalized Civitai image URL string schema.
+ *
+ * Order is load-bearing. A `.transform()` that THROWS propagates out of
+ * `safeParse` (it does not become a parse failure) — so `new URL()` here must
+ * be total. Zod skips the transform entirely when an earlier check on the same
+ * string failed (verified against zod 4), so by the time it runs, the refine
+ * above has already proven the string parses. Do not reorder these.
+ */
+export const civitaiHostedImageUrlSchema = z
+  .string()
+  .max(SOURCE_IMAGE_URL_MAX)
+  .refine(isCivitaiHostedImageUrl, 'source image must be a Civitai-hosted https image URL')
+  .transform((raw) => new URL(raw).href)
+  .refine(
+    (href) => href.length <= SOURCE_IMAGE_URL_MAX,
+    'source image URL exceeds the maximum length once canonicalized'
+  );

--- a/src/server/schema/blocks/workflow.schema.ts
+++ b/src/server/schema/blocks/workflow.schema.ts
@@ -2,6 +2,11 @@ import * as z from 'zod';
 import { buzzSpendTypes } from '~/shared/constants/buzz.constants';
 import type { BuzzSpendType } from '~/shared/constants/buzz.constants';
 import { REGISTERED_RECIPE_IDS } from '~/server/services/blocks/recipes';
+import { REGISTERED_STEP_IDS } from '~/server/services/blocks/steps';
+import {
+  civitaiHostedImageUrlSchema,
+  SOURCE_IMAGE_URL_MAX,
+} from '~/server/schema/blocks/civitai-image-url';
 
 // The spendable buzz account types a viewer may pick for a (money) page block.
 // Reuse the authoritative `buzzSpendTypes` (blue/green/yellow — `red` is
@@ -89,82 +94,22 @@ const blockAdditionalResourceSchema = z.object({
 // ── img2img source image (App Blocks IMAGE bridge, Phase-2a) ─────────────────
 // The block body is UNTRUSTED iframe input, so an init/source image MUST NOT be
 // an arbitrary remote URL the generator would fetch (SSRF / arbitrary-fetch).
-// It is bounded to a Civitai-controlled host. An uploaded image resolves to an
-// `https://orchestration…civitai.com` URL, so this same bound covers the
-// "uploaded image" case WITHOUT widening to attacker-controlled origins.
+// It is bounded to a Civitai-controlled host by `civitaiHostedImageUrlSchema`.
 //
-// This is validated by parsed URL HOSTNAME (not a substring match), which is
-// intentionally tighter than the platform's server `sourceImageSchema`
-// (`.includes('image.civitai.com')`) — a substring check would accept
-// `https://evil.example/?x=image.civitai.com`; a hostname check rejects it and
-// also rejects non-https and userinfo. Kept LOCAL (rather than importing the
-// server orchestrator schema) so this module stays client-safe — it is
-// `import type`'d by a client component (failureSnapshot).
+// 🔴 That predicate MOVED — unchanged — to `~/server/schema/blocks/civitai-image-url`,
+// which is where its full reasoning now lives (hostname-not-substring, the two
+// WHATWG parser-differential classes it closes, and the canonicalize-what-you-
+// validate rule). It moved because the `kind: 'step'` registry needs the SAME
+// bound for every step type that takes an image URL (`convert-image` today) and
+// cannot import this module — this module imports the registry to derive its
+// wire enums, so it would be a cycle. One rule, one place.
 //
-// 🔴 A hostname check ALONE is not sufficient, because it validates a PARSED
-// url while the schema used to emit the ORIGINAL string. Every consumer
-// downstream (the graph's `imagesNode` is `url: z.string()` — no URL check —
-// so this schema is the only gate) then re-parses those original bytes, and a
-// parser that disagrees with WHATWG about them sees a DIFFERENT host than the
-// one we approved. Two concrete WHATWG-specific behaviours were being relied on
-// as security properties, both verified to pass the bare hostname check:
-//   - backslash-in-authority: WHATWG treats `\` as `/` for special schemes, so
-//     `https://civitai.com\@evil.com/x.png` parses with host `civitai.com`. A
-//     parser that splits the authority on the last `@` without treating `\` as
-//     a delimiter reads host = `evil.com`.
-//   - tab/CR/LF deletion: WHATWG strips `\t\r\n` from ANYWHERE in the url, so
-//     `https://evil.com\r\n.civitai.com/x.png` normalizes to the (nonexistent)
-//     subdomain `evil.com.civitai.com` and passes — while the raw string, CRLF
-//     intact, is what got forwarded. CRLF inside a value a consumer
-//     concatenates into a request line or header is a request-splitting /
-//     log-injection primitive.
-// So the bound is enforced in three layers, in this order:
-//   1. REJECT ambiguous bytes before parsing (below). No legitimate url carries
-//      a raw backslash or control byte — they must be percent-encoded — so this
-//      costs nothing, and it closes the differential class at the door rather
-//      than silently rewriting a plainly hostile input into an accepted one.
-//   2. Validate the parsed hostname (unchanged).
-//   3. CANONICALIZE to `URL.href`, so the bytes we emit are exactly the bytes
-//      we validated. This is the posture fix: it also covers normalization
-//      classes beyond the four bytes above (percent-encoding, default-port
-//      stripping, empty-path → `/`, host case-folding).
-const CIVITAI_IMAGE_HOSTS = ['civitai.com', 'civitai.red', 'civitai.green'] as const;
-// Backslash + C0 controls + DEL. Superset of the `\t\r\n` WHATWG deletes and
-// the leading/trailing C0 it strips, so no byte that the parser silently
-// removes or reinterprets can survive into the value we approve.
-const URL_AMBIGUOUS_BYTES = /[\\\u0000-\u001f\u007f]/;
-// Bound applies to BOTH the raw input and the canonicalized output: percent-
-// encoding can inflate a string ~9x (a 2048-char path of CJK canonicalizes to
-// 18272 chars), so the pre-transform cap does NOT bound what we emit.
-export const SOURCE_IMAGE_URL_MAX = 2048;
-function isCivitaiHostedImageUrl(raw: string): boolean {
-  if (URL_AMBIGUOUS_BYTES.test(raw)) return false;
-  let parsed: URL;
-  try {
-    parsed = new URL(raw);
-  } catch {
-    return false;
-  }
-  if (parsed.protocol !== 'https:') return false;
-  const host = parsed.hostname.toLowerCase();
-  return CIVITAI_IMAGE_HOSTS.some((h) => host === h || host.endsWith(`.${h}`));
-}
+// Re-exported here because `SOURCE_IMAGE_URL_MAX` was part of this module's
+// public surface before the move.
+export { SOURCE_IMAGE_URL_MAX };
 
 const blockSourceImageSchema = z.object({
-  // Order is load-bearing. A `.transform()` that THROWS propagates out of
-  // `safeParse` (it does not become a parse failure) — so `new URL()` here must
-  // be total. Zod skips the transform entirely when an earlier check on the
-  // same string failed (verified against zod 4), so by the time it runs, the
-  // refine above has already proven the string parses. Do not reorder these.
-  url: z
-    .string()
-    .max(SOURCE_IMAGE_URL_MAX)
-    .refine(isCivitaiHostedImageUrl, 'source image must be a Civitai-hosted https image URL')
-    .transform((raw) => new URL(raw).href)
-    .refine(
-      (href) => href.length <= SOURCE_IMAGE_URL_MAX,
-      'source image URL exceeds the maximum length once canonicalized'
-    ),
+  url: civitaiHostedImageUrlSchema,
   // Dimension hints for the graph's denoise/aspect derivation. Bounded to the
   // same block caps as params so an iframe can't send absurd dimensions.
   width: z.coerce.number().int().min(DIM_MIN).max(DIM_MAX),
@@ -305,10 +250,57 @@ export const blockCustomComfyBodySchema = z
   })
   .strict();
 
+// ── App Blocks STEP-TYPE bridge (`kind: 'step'`) — RFC #3515 migration step 1 ──
+//
+// The THIRD union member, added ALONGSIDE the existing two. `textToImage` and
+// `customComfy` are untouched: this member only ADDS a discriminant, so every
+// deployed block and every published `@civitai/app-sdk` body keeps parsing and
+// behaving exactly as before.
+//
+// Where the other two members each hand-wrote a capability, this one is
+// REGISTRY-BACKED: `step` must be a registered id (`REGISTERED_STEP_IDS`,
+// derived from the step-registry keys), and everything about the capability —
+// its bounded params, its billing mode, its moderation posture, its builder —
+// lives in that entry. Adding a capability is a registry entry, not a new union
+// member and not a router branch. That is the point: sibling union members are
+// what make consolidation a breaking change for every published app once the
+// wire contract is public.
+//
+// The wire gate here is deliberately COARSE, exactly mirroring `customComfy`:
+//  - `step` MUST be a REGISTERED id — an unregistered id is rejected AT THE
+//    UNION, before any translator, any spend reservation, or any orchestrator
+//    call. Fail-closed at the schema.
+//  - `params` is an opaque `Record<string, unknown>` here; the per-step
+//    `.strict()` param schema is applied by the handler, which is the single
+//    place a step's real param contract lives. That keeps the wire surface
+//    step-agnostic, so registering a step never edits this file.
+//  - `.strict()` rejects any extra top-level field on the body.
+//
+// 🔴 `customComfy` is NOT migrated behind the registry here. That is the RFC's
+// migration step 3 (with `kind: 'customComfy'` retained as a deprecated alias)
+// and is deliberately out of scope — step 1 is "land the registry alongside the
+// existing members; nothing breaks".
+//
+// Built through a FACTORY rather than inline so the "enum is derived from the
+// registry, not hardcoded" property is directly testable: a test can build the
+// same schema over a widened id list and assert the enum grew.
+export function makeBlockStepBodySchema(stepIds: [string, ...string[]]) {
+  return z
+    .object({
+      kind: z.literal('step'),
+      step: z.enum(stepIds),
+      params: z.record(z.string(), z.unknown()),
+    })
+    .strict();
+}
+
+export const blockStepBodySchema = makeBlockStepBodySchema(REGISTERED_STEP_IDS);
+
 export type BlockWorkflowBody = z.infer<typeof blockWorkflowBodySchema>;
 export const blockWorkflowBodySchema = z.discriminatedUnion('kind', [
   blockTextToImageBodySchemaChecked,
   blockCustomComfyBodySchema,
+  blockStepBodySchema,
 ]);
 
 // Mirrors BlockWorkflowSnapshot in @civitai/app-sdk's blocks/types.ts.

--- a/src/server/services/blocks/__tests__/dev-tunnel.service.test.ts
+++ b/src/server/services/blocks/__tests__/dev-tunnel.service.test.ts
@@ -94,6 +94,7 @@ import {
   buildDevTunnelApplyJob,
   buildDevTunnelIngressRoute,
   buildDevTunnelMiddleware,
+  chargeDevSessionOverage,
   deleteDevTunnelDns,
   deleteDevTunnelRoute,
   getActiveDevTunnel,
@@ -488,6 +489,39 @@ describe('reserveDevSessionBuzz / refundDevSessionBuzz (F4 support)', () => {
     await refundDevSessionBuzz('sess', 60);
     // back under the cap → a fresh 60 fits again
     expect(await reserveDevSessionBuzz('sess', 60, cap)).toEqual({ allowed: true, total: 60 });
+  });
+});
+
+// 🔴 FIX 5 — the THIRD reservation. A step submit reserves on the per-user
+// daily cap, the per-app aggregate cap AND the dev session; the price-divergence
+// correction touched only the first two while claiming it corrected "both". A
+// divergent submit inside a dev tunnel left this counter under-reading by the
+// overage — the one direction a backstop must never drift.
+describe('chargeDevSessionOverage (divergence correction, third reservation)', () => {
+  it('tops the counter up unconditionally — with NO deny path, even past the cap', async () => {
+    const cap = 100;
+    await reserveDevSessionBuzz('sess', 60, cap);
+    // 60 + 80 = 140, well past the cap. Money that has already moved is an
+    // accounting fact, not a request to approve: unlike `reserveDevSessionBuzz`
+    // this must NOT roll back, or the counter would under-read real spend.
+    await chargeDevSessionOverage('sess', 80);
+    // Proven by effect: the session is now over its ceiling, so any further
+    // reservation is denied — which is exactly the stricter posture wanted.
+    expect(await reserveDevSessionBuzz('sess', 1, cap)).toEqual({ allowed: false, total: 140 });
+  });
+
+  it('is a no-op for a zero/negative overage and ROUNDS UP a fractional one', async () => {
+    const cap = 1000;
+    await chargeDevSessionOverage('sess', 0);
+    await chargeDevSessionOverage('sess', -5);
+    expect(await reserveDevSessionBuzz('sess', 10, cap)).toEqual({ allowed: true, total: 10 });
+    await chargeDevSessionOverage('sess', 2.1);
+    expect(await reserveDevSessionBuzz('sess', 0, cap)).toEqual({ allowed: true, total: 13 });
+  });
+
+  it('NEVER throws on a redis error (best-effort; an already-billed submit must not break)', async () => {
+    sysRedis.incrBy.mockRejectedValueOnce(new Error('redis down'));
+    await expect(chargeDevSessionOverage('sess', 5)).resolves.toBeUndefined();
   });
 });
 

--- a/src/server/services/blocks/__tests__/workflow.service.test.ts
+++ b/src/server/services/blocks/__tests__/workflow.service.test.ts
@@ -36,6 +36,13 @@ import {
 } from '../workflow.service';
 import { blockWorkflowBodySchema } from '~/server/schema/blocks/workflow.schema';
 import { getRecipe, REGISTERED_RECIPE_IDS } from '../recipes';
+import {
+  getStepByOrchestratorType,
+  listRegisteredSteps,
+  NATIVELY_EXTRACTED_STEP_TYPES,
+  type AnyBlockStep,
+} from '../steps';
+import { nsfwLevelFromContentRating } from '~/shared/constants/browsingLevel.constants';
 // REAL param-building path (no mocks): the generation graph validator and the
 // step-metadata snapshot fn are the exact functions the orchestrator's
 // `createWorkflowStepsFromGraph` runs to derive `workflowMetadata.params`. Both
@@ -1948,6 +1955,205 @@ describe('projectAppWorkflow: customComfy blobs', () => {
       cost: 47,
       createdAt: '2026-07-17T00:00:00.000Z',
     });
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 🔴 FIX 1 — REGISTERED STEP OUTPUT must be reachable on BOTH read surfaces.
+//
+// Both extractors used to `continue` on any `$type` outside
+// `customComfy | textToImage | imageGen | comfy`, and `convertImage`'s output is
+// `{ blob }` — SINGULAR, not `images` and not `blobs`. So they were blind to a
+// registered step in TWO independent ways: the `$type` AND the key. The lived
+// consequence: an app submits, is charged Buzz, polls to `succeeded`, and
+// `snapshot.imageUrls` is absent on every poll while `queryAppWorkflows` returns
+// `images: []`. It paid for a result it can never retrieve.
+//
+// These tests run over the REAL REGISTRY population, so a step registered
+// tomorrow whose output is unreachable fails here — the property a fourth
+// hardcoded `if ($type === 'convertImage')` branch could never have.
+// ─────────────────────────────────────────────────────────────────────────────
+describe('🔴 registered step output — surfaced on the snapshot AND the projection', () => {
+  /**
+   * Build a fake completed workflow carrying the registry entry's OWN canonical
+   * completed-step object, which is itself copied from a real captured
+   * orchestrator response. Nothing here re-describes the output shape — a test
+   * that invented its own would only prove the test agrees with the test.
+   */
+  function workflowWithRegisteredStep(step: AnyBlockStep, variant: string) {
+    return fakeWorkflow({
+      id: 'wf_step',
+      createdAt: '2026-08-02T00:00:00.000Z',
+      status: 'succeeded',
+      cost: { total: 1 },
+      steps: [step.canonicalOutputFor(variant)],
+    });
+  }
+
+  it('EVERY registered step surfaces its output on snapshotFromWorkflow.imageUrls', () => {
+    for (const [id, step] of listRegisteredSteps()) {
+      for (const variant of step.variants) {
+        const expected = step.extractOutput(step.canonicalOutputFor(variant)).map((m) => m.url);
+        expect(expected.length, `step '${id}' produced no expected urls`).toBeGreaterThan(0);
+        const snap = snapshotFromWorkflow(workflowWithRegisteredStep(step, variant) as never);
+        expect(
+          snap.imageUrls,
+          `step '${id}' variant '${variant}': the caller is CHARGED for this step and its ` +
+            'result is absent from every poll'
+        ).toEqual(expected);
+      }
+    }
+  });
+
+  it('EVERY registered step surfaces its output on projectAppWorkflow.images', () => {
+    for (const [id, step] of listRegisteredSteps()) {
+      for (const variant of step.variants) {
+        const expected = step.extractOutput(step.canonicalOutputFor(variant));
+        const projected = projectAppWorkflow(workflowWithRegisteredStep(step, variant) as never);
+        expect(
+          projected.images.map((i) => i.url),
+          `step '${id}' variant '${variant}': queryAppWorkflows returns images: [] for a ` +
+            'generation the app paid for'
+        ).toEqual(expected.map((m) => m.url));
+        expect(projected.images.map((i) => [i.width, i.height])).toEqual(
+          expected.map((m) => [m.width, m.height])
+        );
+      }
+    }
+  });
+
+  // The concrete shape, pinned literally rather than derived from the extractor
+  // — so this fails if `convertImage`'s output key or availability rule changes.
+  it('convert-image: the SINGULAR output.blob reaches both surfaces', () => {
+    const wf = fakeWorkflow({
+      id: 'wf_conv',
+      createdAt: '2026-08-02T00:00:00.000Z',
+      status: 'succeeded',
+      cost: { total: 1 },
+      steps: [
+        {
+          $type: 'convertImage',
+          name: 'block-step',
+          status: 'succeeded',
+          metadata: {},
+          output: {
+            blob: {
+              id: 'b1',
+              url: 'https://orchestration/blobs/out.webp',
+              available: true,
+              width: 797,
+              height: 1024,
+              nsfwLevel: 'pg13',
+            },
+          },
+        },
+      ],
+    });
+    expect(snapshotFromWorkflow(wf as never).imageUrls).toEqual([
+      'https://orchestration/blobs/out.webp',
+    ]);
+    expect(projectAppWorkflow(wf as never).images).toEqual([
+      {
+        url: 'https://orchestration/blobs/out.webp',
+        width: 797,
+        height: 1024,
+        // Mapped through the SAME canonical helper the native branches use — the
+        // registry hands over the raw rating string, never a bitflag.
+        nsfwLevel: nsfwLevelFromContentRating('pg13'),
+      },
+    ]);
+  });
+
+  it('convert-image: a NOT-YET-AVAILABLE blob is dropped, not surfaced as a dead link', () => {
+    // The real orchestrator returns `available: false` at submit time and flips
+    // it to true when the blob lands (observed live 2026-08-02).
+    const wf = fakeWorkflow({
+      id: 'wf_conv_pending',
+      createdAt: '2026-08-02T00:00:00.000Z',
+      status: 'processing',
+      steps: [
+        {
+          $type: 'convertImage',
+          name: 'block-step',
+          status: 'processing',
+          metadata: {},
+          output: {
+            blob: { id: 'b1', url: 'https://orchestration/blobs/out.webp', available: false },
+          },
+        },
+      ],
+    });
+    expect(snapshotFromWorkflow(wf as never).imageUrls).toBeUndefined();
+    expect(projectAppWorkflow(wf as never).images).toEqual([]);
+  });
+
+  // 🔴 NO-REGRESSION. The registry branch is evaluated BEFORE the native `$type`
+  // filter, so this pins that it cannot shadow the pre-existing kinds. The
+  // structural guarantee is the load-time invariant forbidding a registered
+  // entry from claiming a natively-extracted `$type`; this is the behavioural
+  // half of the same claim.
+  it('does NOT change extraction for the natively-handled $types', () => {
+    for (const nativeType of NATIVELY_EXTRACTED_STEP_TYPES) {
+      expect(getStepByOrchestratorType(nativeType)).toBeUndefined();
+    }
+    const wf = fakeWorkflow({
+      id: 'wf_native',
+      createdAt: '2026-08-02T00:00:00.000Z',
+      status: 'succeeded',
+      cost: { total: 5 },
+      steps: [
+        {
+          $type: 'textToImage',
+          name: 'txt2img',
+          status: 'succeeded',
+          metadata: {},
+          output: {
+            images: [
+              {
+                id: 'i1',
+                url: 'https://cdn/a.png',
+                available: true,
+                width: 8,
+                height: 9,
+                nsfwLevel: 'pg',
+              },
+              { id: 'i2', url: 'https://cdn/b.png', available: false },
+            ],
+          },
+        },
+      ],
+    });
+    expect(snapshotFromWorkflow(wf as never).imageUrls).toEqual(['https://cdn/a.png']);
+    expect(projectAppWorkflow(wf as never).images).toEqual([
+      {
+        url: 'https://cdn/a.png',
+        width: 8,
+        height: 9,
+        nsfwLevel: nsfwLevelFromContentRating('pg'),
+      },
+    ]);
+  });
+
+  // An UNREGISTERED, non-native `$type` must still be skipped — the branch is
+  // additive for registered steps only, not a wildcard that starts reading
+  // arbitrary step outputs.
+  it('still skips an unregistered, non-native $type', () => {
+    const wf = fakeWorkflow({
+      id: 'wf_other',
+      createdAt: '2026-08-02T00:00:00.000Z',
+      status: 'succeeded',
+      steps: [
+        {
+          $type: 'imageBackgroundRemoval',
+          name: 'x',
+          status: 'succeeded',
+          metadata: {},
+          output: { blob: { id: 'b', url: 'https://cdn/nope.png', available: true } },
+        },
+      ],
+    });
+    expect(snapshotFromWorkflow(wf as never).imageUrls).toBeUndefined();
+    expect(projectAppWorkflow(wf as never).images).toEqual([]);
   });
 });
 

--- a/src/server/services/blocks/app-spend-cap.service.ts
+++ b/src/server/services/blocks/app-spend-cap.service.ts
@@ -342,3 +342,35 @@ export async function refundAppSpend(key: AppSpendDailyKey, cost: number): Promi
     /* best-effort — a lost refund over-counts (stricter cap), never looser */
   });
 }
+
+/**
+ * Add `cost` to the per-app daily counter on the EXACT key a previous
+ * `reserveAppSpend` returned, with NO allow/deny semantics — the exact mirror of
+ * `refundAppSpend`.
+ *
+ * 🔴 WHY THIS IS NOT `reserveAppSpend`. This is an ACCOUNTING CORRECTION for
+ * money that has ALREADY been spent, not a gate on a spend that has not happened
+ * yet. `reserveAppSpend` is a gate: when the increment would breach the ceiling
+ * it REFUNDS its own increment and denies, because the correct response to "this
+ * submit would exceed the cap" is "don't run this submit". That behaviour is
+ * exactly wrong here — the submit already ran and the viewer was already
+ * charged, so rolling the increment back would leave the counter UNDER-reading
+ * real spend, which is the one direction an abuse cap must never drift.
+ *
+ * The caller is the `kind: 'step'` prepaidFixed path, when the orchestrator's
+ * realized cost came in above the registry's declared price: it reserved the
+ * declared price before submit, so the counter is short by the difference. This
+ * makes it exact regardless of what the orchestrator actually charged.
+ *
+ * Best-effort and never throws into the caller (the submit is already
+ * committed). A lost correction under-counts by the overage only — which is why
+ * the paired `civitai_app_block_step_price_divergence_total` counter is the
+ * signal to fix the declared price rather than rely on this correction.
+ */
+export async function chargeAppSpendOverage(key: AppSpendDailyKey, cost: number): Promise<void> {
+  const amount = Math.ceil(cost);
+  if (amount <= 0) return;
+  await sysRedis.incrBy(key, amount).catch(() => {
+    /* best-effort — a lost correction under-counts by the overage only */
+  });
+}

--- a/src/server/services/blocks/dev-tunnel.service.ts
+++ b/src/server/services/blocks/dev-tunnel.service.ts
@@ -1030,6 +1030,29 @@ export async function refundDevSessionBuzz(sessionId: string, costBuzz: number):
   });
 }
 
+/**
+ * Top up a dev session's spend counter by an overage the orchestrator billed
+ * ABOVE what was reserved. A plain INCRBY with NO deny path — the exact mirror
+ * of `chargeAppSpendOverage`, and deliberately not `reserveDevSessionBuzz`:
+ * money that has already moved is an accounting fact, not a request to approve,
+ * and rolling it back on a cap breach would leave the counter UNDER-reading real
+ * spend — the one direction a backstop must never drift.
+ *
+ * 🔴 There are THREE reservations on a step submit (per-user daily, per-app
+ * aggregate, dev session), and the divergence correction originally touched only
+ * the first two while its own comment claimed "both". A divergent submit inside
+ * a dev tunnel left this counter short by the overage.
+ *
+ * Best-effort and total: never throws into an already-billed submit.
+ */
+export async function chargeDevSessionOverage(sessionId: string, costBuzz: number): Promise<void> {
+  const cost = Math.max(0, Math.ceil(costBuzz));
+  if (cost === 0) return;
+  await sysRedis.incrBy(spendKey(sessionId), cost).catch(() => {
+    /* best-effort — a lost correction under-counts by the overage only */
+  });
+}
+
 // ---------------------------------------------------------------------------
 // Reaper (server-authoritative — NOT CLI-dependent)
 // ---------------------------------------------------------------------------

--- a/src/server/services/blocks/steps/__tests__/step-registry.test.ts
+++ b/src/server/services/blocks/steps/__tests__/step-registry.test.ts
@@ -1,0 +1,403 @@
+import { describe, expect, it } from 'vitest';
+import * as z from 'zod';
+import {
+  assertStepInvariants,
+  estimateStepBuzz,
+  getStep,
+  isBillingModeImplemented,
+  isModerationPostureImplemented,
+  listRegisteredSteps,
+  planStepSpend,
+  REGISTERED_STEP_IDS,
+  STEP_BILLING_MODES,
+  STEP_MODERATION_POSTURES,
+  STRICTNESS_PROBE_KEY,
+  type AnyBlockStep,
+  type BlockStep,
+  type StepBillingMode,
+} from '~/server/services/blocks/steps';
+
+/**
+ * Coverage for the App Blocks step-type registry (RFC #3515 migration step 1).
+ *
+ * The tests that matter here are the ones that run over the REAL POPULATION
+ * (`listRegisteredSteps()`), not over a hardcoded list — a newly registered
+ * entry that violates an invariant must fail THESE tests, not slip through
+ * because nobody added it to a fixture array.
+ *
+ * Every guard in `assertStepInvariants` is additionally mutation-tested below
+ * with a fixture that violates EXACTLY ONE clause, and each assertion pins the
+ * specific message of the guard under test — so a test cannot pass because a
+ * neighbouring guard threw first.
+ */
+
+// ─────────────────────────────────────────────────────────────────────────────
+// A minimal, VALID fixture entry. Every mutation test derives from this by
+// breaking one thing, which is what makes "this guard, not its neighbour" a
+// property of the fixture rather than a hope.
+// ─────────────────────────────────────────────────────────────────────────────
+type FixtureParams = { value: number };
+
+const fixtureParamSchema = z.object({ value: z.number().int().min(1).max(10) }).strict();
+
+function makeFixtureStep(overrides: Partial<AnyBlockStep> = {}): AnyBlockStep {
+  const base = {
+    id: 'fixture-step',
+    orchestratorType: 'fixtureType',
+    billingMode: 'prepaidFixed',
+    moderationPosture: 'none',
+    paramSchema: fixtureParamSchema,
+    variants: ['default'],
+    resolveVariant: () => 'default',
+    canonicalParamsFor: (): FixtureParams => ({ value: 1 }),
+    priceForVariant: () => 7,
+    estimateBuzz: () => 7,
+    buildStep: (p: FixtureParams) => ({ $type: 'fixtureType', input: { value: p.value } }),
+  } satisfies BlockStep<FixtureParams>;
+  return { ...base, ...overrides } as AnyBlockStep;
+}
+
+describe('block step registry — the shipped population', () => {
+  it('registers at least one step and derives the wire ids from the registry keys', () => {
+    const entries = listRegisteredSteps();
+    expect(entries.length).toBeGreaterThan(0);
+    expect(REGISTERED_STEP_IDS).toEqual(entries.map(([id]) => id));
+  });
+
+  it('resolves every registered id and rejects an unregistered one', () => {
+    for (const id of REGISTERED_STEP_IDS) expect(getStep(id)).toBeDefined();
+    expect(getStep('definitely-not-registered')).toBeUndefined();
+  });
+
+  // 🔴 The population test. Enumerated from the registry at RUNTIME, so a step
+  // added tomorrow is covered by this test today.
+  it('every registered entry satisfies every load-time invariant', () => {
+    for (const [id, step] of listRegisteredSteps()) {
+      expect(() => assertStepInvariants(id, step)).not.toThrow();
+    }
+  });
+
+  it("every registered entry's paramSchema is .strict() — an unknown param is REJECTED", () => {
+    for (const [id, step] of listRegisteredSteps()) {
+      for (const variant of step.variants) {
+        const params = step.canonicalParamsFor(variant) as Record<string, unknown>;
+        expect(step.paramSchema.safeParse(params).success).toBe(true);
+        const withUnknown = { ...params, [STRICTNESS_PROBE_KEY]: 1 };
+        expect(
+          step.paramSchema.safeParse(withUnknown).success,
+          `step '${id}' variant '${variant}' silently ACCEPTED an unknown param — ` +
+            'an unknown param on a money path is a wrong-generation bug, not a validation nit'
+        ).toBe(false);
+      }
+    }
+  });
+
+  it('every registered entry declares an IMPLEMENTED billing mode and moderation posture', () => {
+    for (const [id, step] of listRegisteredSteps()) {
+      expect(STEP_BILLING_MODES).toContain(step.billingMode);
+      expect(STEP_MODERATION_POSTURES).toContain(step.moderationPosture);
+      expect(isBillingModeImplemented(step.billingMode), `step '${id}' billingMode`).toBe(true);
+      expect(
+        isModerationPostureImplemented(step.moderationPosture),
+        `step '${id}' moderationPosture`
+      ).toBe(true);
+    }
+  });
+
+  // Tranche 1's defining property, asserted over the population rather than
+  // named per-entry: a deterministic price, computable with no orchestrator
+  // round-trip, that equals what the block is shown.
+  it('every prepaidFixed entry has an exact positive price that equals its estimate', () => {
+    for (const [id, step] of listRegisteredSteps()) {
+      if (step.billingMode !== 'prepaidFixed') continue;
+      for (const variant of step.variants) {
+        const price = step.priceForVariant(variant);
+        expect(Number.isSafeInteger(price), `step '${id}' price is an integer`).toBe(true);
+        expect(price, `step '${id}' price is positive`).toBeGreaterThan(0);
+        const params = step.paramSchema.parse(step.canonicalParamsFor(variant));
+        expect(estimateStepBuzz(step, params)).toBe(price);
+        expect(planStepSpend(step, params).reserveBuzz).toBe(price);
+      }
+    }
+  });
+
+  it('all three billing modes are DECLARED so future step types are additive', () => {
+    // The wire/type surface is the expensive thing to change once the SDK
+    // mirrors it, so every mode exists from day one even though only one is
+    // implemented. This pins that intent.
+    expect([...STEP_BILLING_MODES].sort()).toEqual(['prepaidFixed', 'timeBounded', 'tokenMetered']);
+    expect(isBillingModeImplemented('prepaidFixed')).toBe(true);
+    expect(isBillingModeImplemented('timeBounded')).toBe(false);
+    expect(isBillingModeImplemented('tokenMetered')).toBe(false);
+  });
+
+  it('a step with a free-text surface has NO implemented moderation posture', () => {
+    // 🔴 The mechanism that makes `chatCompletion` / captioning impossible to
+    // register without an explicit, reviewed policy answer in code. If this ever
+    // flips to true, someone made that policy decision — make sure they meant to.
+    expect(isModerationPostureImplemented('none')).toBe(true);
+    expect(isModerationPostureImplemented('promptAudit')).toBe(false);
+    expect(isModerationPostureImplemented('textOutput')).toBe(false);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// MUTATION TESTS. One violated clause each; every assertion pins the message of
+// the guard under test, so a green result cannot come from a different guard
+// firing first.
+// ─────────────────────────────────────────────────────────────────────────────
+describe('block step registry — load-time invariants (each guard, mutation-proven)', () => {
+  it('the unmutated fixture passes — so every failure below is the mutation, not the fixture', () => {
+    expect(() => assertStepInvariants('fixture-step', makeFixtureStep())).not.toThrow();
+  });
+
+  it('rejects a registry key that disagrees with step.id', () => {
+    expect(() => assertStepInvariants('other-key', makeFixtureStep())).toThrow(
+      /registry key must equal step\.id \(got 'fixture-step'\)/
+    );
+  });
+
+  it('rejects a billing mode with no implemented money-path handler', () => {
+    expect(() =>
+      assertStepInvariants(
+        'fixture-step',
+        makeFixtureStep({
+          billingMode: 'tokenMetered',
+          // A VALID budget, so this fixture clears every earlier clause and the
+          // mode gate is provably what fires — not a missing accessor or a bad
+          // budget further up.
+          maxBuzzForVariant: () => 5,
+        } as Partial<AnyBlockStep>)
+      )
+    ).toThrow(/billingMode 'tokenMetered' has no implemented money-path handler/);
+  });
+
+  it('rejects a moderation posture with no implemented handler', () => {
+    expect(() =>
+      assertStepInvariants('fixture-step', makeFixtureStep({ moderationPosture: 'textOutput' }))
+    ).toThrow(/moderationPosture 'textOutput' has no implemented handler/);
+  });
+
+  it('rejects an entry declaring no variants', () => {
+    expect(() => assertStepInvariants('fixture-step', makeFixtureStep({ variants: [] }))).toThrow(
+      /must declare at least one variant/
+    );
+  });
+
+  it('rejects canonical params that do not satisfy the param schema', () => {
+    expect(() =>
+      assertStepInvariants(
+        'fixture-step',
+        makeFixtureStep({ canonicalParamsFor: () => ({ value: 999 }) })
+      )
+    ).toThrow(/canonicalParamsFor\(\) must satisfy paramSchema/);
+  });
+
+  it('rejects canonical params that are not a plain object', () => {
+    expect(() =>
+      assertStepInvariants(
+        'fixture-step',
+        makeFixtureStep({
+          paramSchema: z.number(),
+          canonicalParamsFor: () => 5,
+        } as Partial<AnyBlockStep>)
+      )
+    ).toThrow(/canonicalParamsFor\(\) must return a plain params object/);
+  });
+
+  // 🔴 THE STRICTNESS GUARD. `blockTextToImageBodySchema` is not `.strict()`, and
+  // that is exactly what let an older host silently strip `sourceImages` and bill
+  // the wrong generation. This mutation is that bug, in registry form.
+  it('rejects a paramSchema that is NOT .strict() (an unknown param would be silently dropped)', () => {
+    expect(() =>
+      assertStepInvariants(
+        'fixture-step',
+        makeFixtureStep({
+          // Same shape, WITHOUT `.strict()` — an unknown key is dropped, not rejected.
+          paramSchema: z.object({ value: z.number().int().min(1).max(10) }),
+        } as Partial<AnyBlockStep>)
+      )
+    ).toThrow(/paramSchema must be \.strict\(\) — it accepted an unknown param/);
+  });
+
+  it('rejects canonical params that resolve to a DIFFERENT variant than they were built for', () => {
+    expect(() =>
+      assertStepInvariants(
+        'fixture-step',
+        makeFixtureStep({
+          variants: ['default', 'other'],
+          resolveVariant: () => 'default',
+          canonicalParamsFor: (): FixtureParams => ({ value: 1 }),
+        } as Partial<AnyBlockStep>)
+      )
+    ).toThrow(/canonicalParamsFor\(\) resolves to variant 'default', not 'other'/);
+  });
+
+  // 🔴 THE prepaidFixed INVARIANT — its OWN enforced clause, not an exemption
+  // from the timeBounded one.
+  it('rejects a prepaidFixed price that is not a positive integer', () => {
+    expect(() =>
+      assertStepInvariants('fixture-step', makeFixtureStep({ priceForVariant: () => 0 }))
+    ).toThrow(/prepaidFixed price \(0\) must be a positive safe integer/);
+
+    expect(() =>
+      assertStepInvariants('fixture-step', makeFixtureStep({ priceForVariant: () => 2.5 }))
+    ).toThrow(/prepaidFixed price \(2\.5\) must be a positive safe integer/);
+
+    expect(() =>
+      assertStepInvariants('fixture-step', makeFixtureStep({ priceForVariant: () => -3 }))
+    ).toThrow(/prepaidFixed price \(-3\) must be a positive safe integer/);
+  });
+
+  it('rejects a prepaidFixed estimate that disagrees with the declared price', () => {
+    // The money-relevant clause: the block is SHOWN the estimate and CHARGED the
+    // price. This is the divergence a bare "the price is an integer" check misses.
+    expect(() =>
+      assertStepInvariants('fixture-step', makeFixtureStep({ estimateBuzz: () => 3 }))
+    ).toThrow(/prepaidFixed estimateBuzz \(3\) must equal the declared price \(7\)/);
+  });
+
+  // 🔴 REACHABILITY. The per-variant budget invariants run BEFORE the
+  // implemented-billing-mode gate on purpose. Had the gate run first, these two
+  // branches would be structurally unable to execute for `timeBounded` /
+  // `tokenMetered` — the gate rejects every such entry — and the registry would
+  // carry two invariants that no mutation could ever kill. Ordered as they are,
+  // a fixture reaches its own budget guard and the tests below genuinely prove
+  // it, so the invariant is real on the day those modes are implemented rather
+  // than the day someone notices it never ran.
+  it('enforces the timeBounded maxBuzz === ceil(stepTimeoutSeconds) invariant', () => {
+    const timeBounded = (over: Record<string, unknown>) =>
+      makeFixtureStep({ billingMode: 'timeBounded', ...over } as Partial<AnyBlockStep>);
+
+    // maxBuzz below what the timeout physically enforces → the job can outspend
+    // the reservation.
+    expect(() =>
+      assertStepInvariants(
+        'fixture-step',
+        timeBounded({ budgetForVariant: () => ({ maxBuzz: 90, stepTimeoutSeconds: 150 }) })
+      )
+    ).toThrow(/timeBounded maxBuzz \(90\) must equal ceil\(stepTimeoutSeconds\) \(150\)/);
+
+    // maxBuzz above it → a ceiling the timeout cannot guarantee.
+    expect(() =>
+      assertStepInvariants(
+        'fixture-step',
+        timeBounded({ budgetForVariant: () => ({ maxBuzz: 150, stepTimeoutSeconds: 90 }) })
+      )
+    ).toThrow(/timeBounded maxBuzz \(150\) must equal ceil\(stepTimeoutSeconds\) \(90\)/);
+
+    // A non-positive timeout is rejected by its own clause, not the equality one.
+    expect(() =>
+      assertStepInvariants(
+        'fixture-step',
+        timeBounded({ budgetForVariant: () => ({ maxBuzz: 0, stepTimeoutSeconds: 0 }) })
+      )
+    ).toThrow(/timeBounded stepTimeoutSeconds \(0\) must be positive/);
+
+    // A CONSISTENT budget passes the budget clause and is then rejected by the
+    // separate implemented-handler gate — proving the two guards are distinct
+    // and that a correct budget is not what makes the mode unregisterable.
+    expect(() =>
+      assertStepInvariants(
+        'fixture-step',
+        timeBounded({ budgetForVariant: () => ({ maxBuzz: 150, stepTimeoutSeconds: 150 }) })
+      )
+    ).toThrow(/billingMode 'timeBounded' has no implemented money-path handler/);
+  });
+
+  it('enforces the tokenMetered positive-maxBuzz invariant', () => {
+    expect(() =>
+      assertStepInvariants(
+        'fixture-step',
+        makeFixtureStep({
+          billingMode: 'tokenMetered',
+          maxBuzzForVariant: () => 0,
+        } as Partial<AnyBlockStep>)
+      )
+    ).toThrow(/tokenMetered maxBuzz \(0\) must be a positive safe integer/);
+
+    // A valid maxBuzz clears the budget clause and falls through to the
+    // implemented-handler gate.
+    expect(() =>
+      assertStepInvariants(
+        'fixture-step',
+        makeFixtureStep({
+          billingMode: 'tokenMetered',
+          maxBuzzForVariant: () => 500,
+        } as Partial<AnyBlockStep>)
+      )
+    ).toThrow(/billingMode 'tokenMetered' has no implemented money-path handler/);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// DISPATCH. The RFC's core claim: adding a capability must be additive, and
+// adding a MODE must not require router surgery.
+// ─────────────────────────────────────────────────────────────────────────────
+describe('block step registry — billing-mode dispatch', () => {
+  it('prepaidFixed plans a FINAL reservation that never touches the post-paid settle machinery', () => {
+    const step = makeFixtureStep();
+    const params = step.paramSchema.parse(step.canonicalParamsFor('default'));
+    const plan = planStepSpend(step, params);
+    expect(plan).toEqual({ reserveBuzz: 7, postPaidSettle: false, stepTimeoutSeconds: null });
+  });
+
+  // 🔴 STRUCTURAL PROOF that dispatch is on `billingMode`, not on the step id and
+  // not on the wire `kind`. A fixture declaring a DIFFERENT mode is routed to
+  // that mode's handler — reaching it needs no change to the router, the schema,
+  // or this dispatcher's call sites. The `timeBounded` handler is currently a
+  // fail-closed "not implemented", which is the CORRECT routing outcome for a
+  // mode with no money path yet: it can never silently ride prepaidFixed's
+  // reservation logic.
+  it('routes a fixture entry with a DIFFERENT billing mode to that mode — no router change', () => {
+    const timeBounded = makeFixtureStep({
+      billingMode: 'timeBounded',
+      budgetForVariant: () => ({ maxBuzz: 150, stepTimeoutSeconds: 150 }),
+    } as Partial<AnyBlockStep>);
+    const params = timeBounded.paramSchema.parse(timeBounded.canonicalParamsFor('default'));
+
+    // It reached the timeBounded slot — NOT prepaidFixed's (which would have
+    // happily returned `{ reserveBuzz: 7 }` from the fixture's `priceForVariant`).
+    expect(() => planStepSpend(timeBounded, params)).toThrow(
+      /billing mode 'timeBounded' has no money-path handler/
+    );
+    expect(() => estimateStepBuzz(timeBounded, params)).toThrow(
+      /billing mode 'timeBounded' has no money-path handler/
+    );
+
+    const tokenMetered = makeFixtureStep({
+      billingMode: 'tokenMetered',
+      maxBuzzForVariant: () => 500,
+    } as Partial<AnyBlockStep>);
+    expect(() => planStepSpend(tokenMetered, params)).toThrow(
+      /billing mode 'tokenMetered' has no money-path handler/
+    );
+  });
+
+  it('the dispatcher is TOTAL over the declared billing modes', () => {
+    // No mode may be absent from the handler table — an absent key would read as
+    // `undefined` at runtime and throw a TypeError that looks like a bug rather
+    // than a deliberate fail-closed gate.
+    const step = makeFixtureStep();
+    const params = step.paramSchema.parse(step.canonicalParamsFor('default'));
+    for (const mode of STEP_BILLING_MODES) {
+      const entry = makeFixtureStep({
+        billingMode: mode,
+        budgetForVariant: () => ({ maxBuzz: 1, stepTimeoutSeconds: 1 }),
+        maxBuzzForVariant: () => 1,
+      } as Partial<AnyBlockStep>);
+      let error: unknown;
+      try {
+        planStepSpend(entry, params);
+      } catch (e) {
+        error = e;
+      }
+      if (isBillingModeImplemented(mode as StepBillingMode)) {
+        expect(error).toBeUndefined();
+      } else {
+        // A deliberate, named failure — never `undefined is not a function`.
+        expect(String(error)).toContain(`billing mode '${mode}' has no money-path handler`);
+      }
+    }
+  });
+});

--- a/src/server/services/blocks/steps/__tests__/step-registry.test.ts
+++ b/src/server/services/blocks/steps/__tests__/step-registry.test.ts
@@ -1,12 +1,18 @@
 import { describe, expect, it } from 'vitest';
 import * as z from 'zod';
 import {
+  assertOrchestratorTypesUnique,
   assertStepInvariants,
+  containsAirReference,
   estimateStepBuzz,
   getStep,
+  getStepByOrchestratorType,
   isBillingModeImplemented,
   isModerationPostureImplemented,
+  isResourcePolicyImplemented,
   listRegisteredSteps,
+  mediaFromBlobs,
+  NATIVELY_EXTRACTED_STEP_TYPES,
   planStepSpend,
   REGISTERED_STEP_IDS,
   STEP_BILLING_MODES,
@@ -16,6 +22,7 @@ import {
   type BlockStep,
   type StepBillingMode,
 } from '~/server/services/blocks/steps';
+import type { OrchestratorBlobLike } from '~/server/services/blocks/steps/output';
 
 /**
  * Coverage for the App Blocks step-type registry (RFC #3515 migration step 1).
@@ -40,12 +47,21 @@ type FixtureParams = { value: number };
 
 const fixtureParamSchema = z.object({ value: z.number().int().min(1).max(10) }).strict();
 
+/** The orchestrator-shaped completed step the fixture's extractor reads. */
+const FIXTURE_OUTPUT_STEP = {
+  $type: 'fixtureType',
+  output: {
+    blob: { url: 'https://blobs.example/fixture.webp', available: true, width: 4, height: 5 },
+  },
+};
+
 function makeFixtureStep(overrides: Partial<AnyBlockStep> = {}): AnyBlockStep {
   const base = {
     id: 'fixture-step',
     orchestratorType: 'fixtureType',
     billingMode: 'prepaidFixed',
     moderationPosture: 'none',
+    resourcePolicy: { kind: 'none' },
     paramSchema: fixtureParamSchema,
     variants: ['default'],
     resolveVariant: () => 'default',
@@ -53,6 +69,12 @@ function makeFixtureStep(overrides: Partial<AnyBlockStep> = {}): AnyBlockStep {
     priceForVariant: () => 7,
     estimateBuzz: () => 7,
     buildStep: (p: FixtureParams) => ({ $type: 'fixtureType', input: { value: p.value } }),
+    extractOutput: (step: unknown) =>
+      mediaFromBlobs(
+        (step as { output?: { blob?: OrchestratorBlobLike | null } } | null | undefined)?.output
+          ?.blob
+      ),
+    canonicalOutputFor: (): unknown => FIXTURE_OUTPUT_STEP,
   } satisfies BlockStep<FixtureParams>;
   return { ...base, ...overrides } as AnyBlockStep;
 }
@@ -87,6 +109,49 @@ describe('block step registry — the shipped population', () => {
           step.paramSchema.safeParse(withUnknown).success,
           `step '${id}' variant '${variant}' silently ACCEPTED an unknown param — ` +
             'an unknown param on a money path is a wrong-generation bug, not a validation nit'
+        ).toBe(false);
+      }
+    }
+  });
+
+  // 🔴 THE FIX-1 POPULATION TEST. Every registered step must be RETRIEVABLE on
+  // BOTH read surfaces. Run over `listRegisteredSteps()` so a step registered
+  // tomorrow is covered by this test today — which is the whole reason output
+  // extraction became a registry field instead of a fourth hardcoded branch.
+  it('every registered entry is resolvable by $type and surfaces media from its canonical output', () => {
+    for (const [id, step] of listRegisteredSteps()) {
+      expect(
+        getStepByOrchestratorType(step.orchestratorType),
+        `step '${id}' is not resolvable by its own orchestratorType — both workflow.service ` +
+          'extractors would skip it and its output would be unreachable'
+      ).toBe(step);
+      expect(
+        NATIVELY_EXTRACTED_STEP_TYPES,
+        `step '${id}' shadows a natively-extracted $type`
+      ).not.toContain(step.orchestratorType);
+      for (const variant of step.variants) {
+        const media = step.extractOutput(step.canonicalOutputFor(variant));
+        expect(
+          media.length,
+          `step '${id}' variant '${variant}' extracted no media`
+        ).toBeGreaterThan(0);
+        for (const item of media) expect(item.url.length).toBeGreaterThan(0);
+      }
+    }
+  });
+
+  it('every registered entry declares an IMPLEMENTED resource policy, enforced against its BUILT step', () => {
+    for (const [id, step] of listRegisteredSteps()) {
+      expect(isResourcePolicyImplemented(step.resourcePolicy), `step '${id}' resourcePolicy`).toBe(
+        true
+      );
+      if (step.resourcePolicy.kind !== 'none') continue;
+      for (const variant of step.variants) {
+        const params = step.paramSchema.parse(step.canonicalParamsFor(variant));
+        expect(
+          containsAirReference(step.buildStep(params).input),
+          `step '${id}' declares resourcePolicy 'none' but its built step carries an AIR — ` +
+            'that reaches the orchestrator around the generation-graph entitlement belt'
         ).toBe(false);
       }
     }
@@ -176,6 +241,137 @@ describe('block step registry — load-time invariants (each guard, mutation-pro
     expect(() =>
       assertStepInvariants('fixture-step', makeFixtureStep({ moderationPosture: 'textOutput' }))
     ).toThrow(/moderationPosture 'textOutput' has no implemented handler/);
+  });
+
+  // ── 🔴 FIX 3 — the ENTITLEMENT axis ────────────────────────────────────────
+  // `BlockRecipe` carries `resourceAllowlist` + `checkpointPolicy`; the first
+  // draft of this generalization dropped both, while this PR's own triage
+  // disqualified `imageUpscaler` PRECISELY because its arbitrary-AIR `model`
+  // field would reach the orchestrator around the entitlement belt. Without a
+  // required, fail-closed field, an entry with exactly that shape registers
+  // cleanly and every other invariant passes.
+
+  it('rejects a resource policy with no implemented handler', () => {
+    expect(() =>
+      assertStepInvariants(
+        'fixture-step',
+        makeFixtureStep({
+          resourcePolicy: { kind: 'staticAllowlist', airs: ['urn:air:sdxl:checkpoint:x@1'] },
+        } as Partial<AnyBlockStep>)
+      )
+    ).toThrow(/resourcePolicy 'staticAllowlist' has no implemented handler/);
+  });
+
+  // 🔴 THE `imageUpscaler` CASE, as a registry-level guard. The entry declares
+  // 'none' honestly-looking, but its builder forwards an AIR URN. Every other
+  // invariant passes: the params parse, the schema is strict, the price is a
+  // positive integer that equals the estimate, the variant resolves, the output
+  // extracts. Only this clause catches it.
+  it("rejects a resourcePolicy 'none' whose BUILT step actually carries an AIR reference", () => {
+    expect(() =>
+      assertStepInvariants(
+        'fixture-step',
+        makeFixtureStep({
+          buildStep: (p: { value: number }) => ({
+            $type: 'fixtureType',
+            input: {
+              value: p.value,
+              model: 'urn:air:sdxl:checkpoint:civitai:4384@128713',
+            },
+          }),
+        } as Partial<AnyBlockStep>)
+      )
+    ).toThrow(/resourcePolicy 'none' is contradicted — buildStep\(\) emitted an AIR reference/);
+  });
+
+  it('finds an AIR nested anywhere in the built input, not just at the top level', () => {
+    expect(() =>
+      assertStepInvariants(
+        'fixture-step',
+        makeFixtureStep({
+          buildStep: (p: { value: number }) => ({
+            $type: 'fixtureType',
+            input: { value: p.value, nested: { deep: [{ air: 'URN:AIR:SDXL:lora:civitai:1@2' }] } },
+          }),
+        } as Partial<AnyBlockStep>)
+      )
+    ).toThrow(/resourcePolicy 'none' is contradicted/);
+  });
+
+  // ── 🔴 FIX 1 — output extraction ───────────────────────────────────────────
+  // A registered step whose output nothing can read is a capability the caller
+  // is CHARGED for and can never retrieve: it polls to `succeeded` with an empty
+  // result forever. No other invariant here can see that.
+
+  it('rejects an entry whose extractOutput surfaces NOTHING for its own canonical output', () => {
+    expect(() =>
+      assertStepInvariants(
+        'fixture-step',
+        makeFixtureStep({ extractOutput: () => [] } as Partial<AnyBlockStep>)
+      )
+    ).toThrow(/extractOutput\(\) returned no media for canonicalOutputFor\(\)/);
+  });
+
+  // The realistic shape of the shipped bug: the extractor reads the WRONG key
+  // (`images`/`blobs` instead of the singular `blob` convertImage returns), so
+  // it silently yields nothing on a real response.
+  it('rejects an extractOutput that reads the wrong output key', () => {
+    expect(() =>
+      assertStepInvariants(
+        'fixture-step',
+        makeFixtureStep({
+          extractOutput: (step: unknown) =>
+            mediaFromBlobs(
+              (step as { output?: { blobs?: OrchestratorBlobLike[] } } | undefined)?.output?.blobs
+            ),
+        } as Partial<AnyBlockStep>)
+      )
+    ).toThrow(/extractOutput\(\) returned no media for canonicalOutputFor\(\)/);
+  });
+
+  it('rejects extracted media with an empty url (a block would render a dead link)', () => {
+    expect(() =>
+      assertStepInvariants(
+        'fixture-step',
+        makeFixtureStep({
+          extractOutput: () => [{ url: '', width: null, height: null, nsfwLevel: null }],
+        } as Partial<AnyBlockStep>)
+      )
+    ).toThrow(/extractOutput\(\) returned media with no url/);
+  });
+
+  it('rejects an orchestratorType that SHADOWS a natively-extracted $type', () => {
+    // Placing the registry branch before workflow.service's native `$type` filter
+    // is only safe because of this guard — otherwise a registered entry could
+    // silently take over textToImage extraction.
+    for (const nativeType of NATIVELY_EXTRACTED_STEP_TYPES) {
+      expect(() =>
+        assertStepInvariants(
+          'fixture-step',
+          makeFixtureStep({ orchestratorType: nativeType } as Partial<AnyBlockStep>)
+        )
+      ).toThrow(
+        /is natively extracted by workflow\.service — a registered step must not shadow it/
+      );
+    }
+  });
+
+  it('rejects two entries claiming the SAME orchestratorType (single-winner lookup)', () => {
+    expect(() =>
+      assertOrchestratorTypesUnique([
+        ['a', makeFixtureStep({ id: 'a' } as Partial<AnyBlockStep>)],
+        ['b', makeFixtureStep({ id: 'b' } as Partial<AnyBlockStep>)],
+      ])
+    ).toThrow(/orchestratorType 'fixtureType' is already claimed by 'a'/);
+  });
+
+  it('accepts distinct orchestratorTypes', () => {
+    expect(() =>
+      assertOrchestratorTypesUnique([
+        ['a', makeFixtureStep({ id: 'a' } as Partial<AnyBlockStep>)],
+        ['b', makeFixtureStep({ id: 'b', orchestratorType: 'otherType' } as Partial<AnyBlockStep>)],
+      ])
+    ).not.toThrow();
   });
 
   it('rejects an entry declaring no variants', () => {
@@ -339,7 +535,40 @@ describe('block step registry — billing-mode dispatch', () => {
     const step = makeFixtureStep();
     const params = step.paramSchema.parse(step.canonicalParamsFor('default'));
     const plan = planStepSpend(step, params);
-    expect(plan).toEqual({ reserveBuzz: 7, postPaidSettle: false, stepTimeoutSeconds: null });
+    expect(plan).toEqual({
+      reserveBuzz: 7,
+      postPaidSettle: false,
+      // 🔴 The reservation is an EXACT price, so an overage is a permanent cap
+      // shortfall the submit path must top up. This flag is what keeps that
+      // `prepaidFixed`-shaped correction from running for a mode whose
+      // reservation is a CEILING (which the post-paid settle would then unwind
+      // from the un-topped-up number). Mutually exclusive with `postPaidSettle`.
+      correctReservationOverage: true,
+      stepTimeoutSeconds: null,
+    });
+  });
+
+  // 🔴 LABELLED HONESTLY: this is an INVARIANT GUARD, not regression coverage.
+  // Only `prepaidFixed` is registered, so `correctReservationOverage` is always
+  // true and `postPaidSettle` always false — no mutation of the ROUTER'S gate on
+  // this flag can fail today (verified: deleting `if (plan.correctReservationOverage)`
+  // kills zero tests). What IS proven is that the flag is load-bearing: flipping
+  // it to false in the handler kills 6 tests, so the router really reads it. The
+  // false branch becomes reachable — and this guard becomes real coverage — when
+  // a `timeBounded` entry is registered.
+  it('correctReservationOverage and postPaidSettle are MUTUALLY EXCLUSIVE for every mode', () => {
+    // Over the real population, not a fixture: a future entry that sets both
+    // would double-handle its overage — topped up here AND settled down there.
+    for (const [id, step] of listRegisteredSteps()) {
+      for (const variant of step.variants) {
+        const params = step.paramSchema.parse(step.canonicalParamsFor(variant));
+        const plan = planStepSpend(step, params);
+        expect(
+          plan.correctReservationOverage && plan.postPaidSettle,
+          `step '${id}' plans BOTH an overage correction and a post-paid settle`
+        ).toBe(false);
+      }
+    }
   });
 
   // 🔴 STRUCTURAL PROOF that dispatch is on `billingMode`, not on the step id and
@@ -399,5 +628,67 @@ describe('block step registry — billing-mode dispatch', () => {
         expect(String(error)).toContain(`billing mode '${mode}' has no money-path handler`);
       }
     }
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// The shared extraction primitives. `mediaFromBlobs` is the ONE copy of the
+// availability filter every entry uses — a per-entry reimplementation is how one
+// copy gets a fix and the others don't.
+// ─────────────────────────────────────────────────────────────────────────────
+describe('mediaFromBlobs — the shared availability filter', () => {
+  const url = 'https://blobs.example/a.webp';
+
+  it('accepts a SINGLE blob (the convertImage shape) and a list alike', () => {
+    const single = mediaFromBlobs({ url, available: true, width: 3, height: 4 });
+    expect(single).toEqual([{ url, width: 3, height: 4, nsfwLevel: null }]);
+    expect(mediaFromBlobs([{ url, available: true }])).toEqual([
+      { url, width: null, height: null, nsfwLevel: null },
+    ]);
+  });
+
+  it('DROPS unavailable, url-less and empty-url blobs rather than handing over dead links', () => {
+    expect(
+      mediaFromBlobs([
+        { url, available: false },
+        { url: '', available: true },
+        { url: null, available: true },
+        { available: true },
+      ])
+    ).toEqual([]);
+  });
+
+  it('is total over absent/null input and skips null entries', () => {
+    expect(mediaFromBlobs(undefined)).toEqual([]);
+    expect(mediaFromBlobs(null)).toEqual([]);
+    expect(mediaFromBlobs([null, undefined, { url, available: true }])).toHaveLength(1);
+  });
+
+  it('passes the RAW orchestrator rating string through — never a mapped bitflag', () => {
+    // The numeric browsing-level mapping lives in exactly one place
+    // (`nsfwLevelFromContentRating`, in the projection). A registry entry must
+    // not be able to invent its own.
+    expect(mediaFromBlobs({ url, available: true, nsfwLevel: 'pg13' })[0].nsfwLevel).toBe('pg13');
+    expect(mediaFromBlobs({ url, available: true, nsfwLevel: 'na' })[0].nsfwLevel).toBe('na');
+  });
+});
+
+describe('containsAirReference — the entitlement probe', () => {
+  it('finds an AIR in a string, an array, and a nested object, case-insensitively', () => {
+    expect(containsAirReference('urn:air:sdxl:checkpoint:civitai:4384@128713')).toBe(true);
+    expect(containsAirReference(['x', 'URN:AIR:sdxl:lora:civitai:1@2'])).toBe(true);
+    expect(containsAirReference({ a: { b: [{ c: 'urn:air:flux:vae:x@1' }] } })).toBe(true);
+  });
+
+  it('does not false-positive on ordinary step input', () => {
+    expect(
+      containsAirReference({
+        image: 'https://image.civitai.com/x.png',
+        output: { format: 'webp', quality: 90, hideMetadata: true },
+        transforms: [{ type: 'resize', targetWidth: 512 }],
+      })
+    ).toBe(false);
+    expect(containsAirReference(null)).toBe(false);
+    expect(containsAirReference(42)).toBe(false);
   });
 });

--- a/src/server/services/blocks/steps/convert-image.step.ts
+++ b/src/server/services/blocks/steps/convert-image.step.ts
@@ -147,8 +147,16 @@ export type ConvertImageStepParams = z.infer<typeof convertImageParamsSchema>;
  * `convertImage` workflow polled to `succeeded`): `step.output` had exactly the
  * key `blob`, with `available` transitioning false→true, plus `url`, `width`
  * (797) and `height` (1024). No `images` key and no `blobs` key were present.
+ *
+ * 🔴 EXPORTED SO IT CAN BE ANCHORED TO THE GENERATED CONTRACT. `extractOutput`
+ * takes `unknown` and reaches this shape through a cast, so nothing at the call
+ * site links it to the orchestrator's own types. `type-contract.ts` asserts that
+ * a real `ConvertImageStep` from `@civitai/client` satisfies it and that every
+ * key it reads exists on the generated `ConvertImageOutput` / `ImageBlob` — which
+ * moves the anchor for THIS entry off the author and onto a type Civitai does not
+ * hand-write.
  */
-type ConvertImageOutputStepLike = {
+export type ConvertImageOutputStepLike = {
   output?: {
     blob?: {
       url?: string | null;

--- a/src/server/services/blocks/steps/convert-image.step.ts
+++ b/src/server/services/blocks/steps/convert-image.step.ts
@@ -1,0 +1,148 @@
+import * as z from 'zod';
+import { civitaiHostedImageUrlSchema } from '~/server/schema/blocks/civitai-image-url';
+import type { BlockStep, OrchestratorStepTemplate } from './index';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tranche 1, entry 1 — `convertImage`.
+//
+// WHY THIS ONE QUALIFIES (the four bars, checked against the orchestrator's own
+// generated types in `@civitai/client`):
+//
+//  1. A GENUINE STANDALONE `$type`. `ConvertImageStep` / `ConvertImageStepTemplate`
+//     with `$type: 'convertImage'` are first-class in the generated client, and
+//     the orchestrator exposes it as a standalone consumer recipe at
+//     `/v2/consumer/recipes/convertImage`. It is not an internal helper (unlike
+//     `preprocessImage`, which `controlnets.helper.ts` emits in front of a
+//     generation) and not a Comfy workflow feature. Civitai already submits it
+//     server-side as a single-step workflow (`product-badge.service.ts`
+//     `resizeBadgeImage`), so the shape is proven in production.
+//
+//  2. DETERMINISTIC COST. Format conversion + a resize transform is a fixed CPU
+//     operation on a bounded input. There is no GPU model, no sampler, no
+//     variable step count and no wall-clock dependence, so the cost is knowable
+//     before execution → `prepaidFixed`.
+//
+//  3. NO NEW MODERATION SURFACE. Input is an image URL bounded to a
+//     Civitai-controlled host; output is an image blob. There is no free-text
+//     input to audit and no free-text output to moderate → posture `'none'`.
+//
+//  4. NO CHECKPOINT/LoRA ENTITLEMENT ENTANGLEMENT. The step references no AIR
+//     resource of any kind, so there is nothing for the entitlement belt to gate
+//     and no way to reach a gated / early-access / Private model version through
+//     it.
+//
+// 🔴 THE ONE THING THAT IS NOT LOCALLY VERIFIABLE is the orchestrator's ACTUAL
+// price for this step. It could not be measured from this environment (it needs
+// a real orchestrator token and a live `whatif` call). `PRICE_BUZZ` below is
+// therefore a DECLARED CEILING chosen conservatively, and the router treats a
+// realized cost ABOVE it as a cap-accounting shortfall it must top up and
+// report — see `civitai_app_block_step_price_divergence_total` in
+// `blocks.router.ts`. That instrumentation exists precisely because this number
+// is the one input to the money path that was not verified before shipping.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * The declared exact price, in Buzz.
+ *
+ * Reserved against the per-user daily cap, the per-app aggregate cap and (when
+ * present) the dev-session cap BEFORE submit, and gated against the block
+ * token's per-call `buzzBudget`. Must be a positive integer — enforced at
+ * registry load (`assertStepInvariants`).
+ *
+ * Set to 1: this is a CPU-only transform, so the honest expectation is that the
+ * orchestrator charges at or near zero. A price of 1 is the smallest value the
+ * invariant permits and errs in the SAFE direction (over-reserving against an
+ * abuse cap is stricter; under-reserving is a hole). It is not a claim about
+ * the orchestrator's rate card — see the header.
+ */
+export const CONVERT_IMAGE_PRICE_BUZZ = 1;
+
+/** The only variant in v1. Kept explicit so pricing can diverge per output format later. */
+const DEFAULT_VARIANT = 'default';
+
+// Bounds on the resize transform. Deliberately the SAME image-dimension bounds
+// the `textToImage` block body enforces (`DIM_MIN`/`DIM_MAX` in
+// workflow.schema) — a block cannot ask for a larger canvas through the step
+// bridge than it can through the generation bridge. Restated as local constants
+// rather than imported, because importing `workflow.schema` from the registry
+// would be a cycle (that module imports the registry for its wire enum).
+const TARGET_WIDTH_MIN = 64;
+const TARGET_WIDTH_MAX = 2048;
+const QUALITY_MIN = 1;
+const QUALITY_MAX = 100;
+
+/**
+ * The bounded transform surface.
+ *
+ * v1 exposes ONLY `resize`. The orchestrator's `ImageTransform` base is an open
+ * `{ type: string }` with several concrete subtypes (`resize`, `blur` with
+ * region masks, …); forwarding an open discriminator from an untrusted iframe
+ * would put the whole transform surface — including region-masked blur — on the
+ * public wire contract sight-unseen. Widening later is additive; narrowing is
+ * breaking, so start narrow.
+ */
+const resizeTransformSchema = z
+  .object({
+    type: z.literal('resize'),
+    targetWidth: z.number().int().min(TARGET_WIDTH_MIN).max(TARGET_WIDTH_MAX),
+  })
+  .strict();
+
+const outputFormatSchema = z
+  .object({
+    format: z.enum(['png', 'jpeg', 'webp']),
+    /** Only meaningful for jpeg/webp; the orchestrator ignores it for png. */
+    quality: z.number().int().min(QUALITY_MIN).max(QUALITY_MAX).optional(),
+    /** webp only; ignored elsewhere. */
+    lossless: z.boolean().optional(),
+    /**
+     * Defaults to TRUE here, unlike the orchestrator's own default of false.
+     * A block converts images on behalf of an end user, and silently carrying
+     * that user's EXIF (which routinely includes GPS and device identity)
+     * through an app-controlled pipeline is a privacy leak the app author never
+     * has to think about. Opting out is explicit.
+     */
+    hideMetadata: z.boolean().default(true),
+  })
+  .strict();
+
+const convertImageParamsSchema = z
+  .object({
+    /**
+     * 🔴 Bounded to a Civitai-hosted https URL — never an arbitrary remote URL.
+     * This param comes from an untrusted iframe and the orchestrator FETCHES it,
+     * so an open URL here is a server-side-request-forgery primitive. Reuses the
+     * exact predicate the `textToImage` bridge's `sourceImage` uses (one rule,
+     * one place: `~/server/schema/blocks/civitai-image-url`).
+     */
+    image: civitaiHostedImageUrlSchema,
+    transforms: z.array(resizeTransformSchema).max(4).optional(),
+    output: outputFormatSchema,
+  })
+  .strict();
+
+export type ConvertImageStepParams = z.infer<typeof convertImageParamsSchema>;
+
+export const convertImageStep = {
+  id: 'convert-image',
+  orchestratorType: 'convertImage',
+  billingMode: 'prepaidFixed',
+  moderationPosture: 'none',
+  paramSchema: convertImageParamsSchema,
+  variants: [DEFAULT_VARIANT],
+  resolveVariant: () => DEFAULT_VARIANT,
+  canonicalParamsFor: (): ConvertImageStepParams => ({
+    image: 'https://image.civitai.com/probe.png',
+    output: { format: 'webp', hideMetadata: true },
+  }),
+  priceForVariant: () => CONVERT_IMAGE_PRICE_BUZZ,
+  estimateBuzz: () => CONVERT_IMAGE_PRICE_BUZZ,
+  buildStep: (params: ConvertImageStepParams): OrchestratorStepTemplate => ({
+    $type: 'convertImage',
+    input: {
+      image: params.image,
+      ...(params.transforms ? { transforms: params.transforms } : {}),
+      output: params.output,
+    },
+  }),
+} satisfies BlockStep<ConvertImageStepParams>;

--- a/src/server/services/blocks/steps/convert-image.step.ts
+++ b/src/server/services/blocks/steps/convert-image.step.ts
@@ -1,5 +1,7 @@
 import * as z from 'zod';
 import { civitaiHostedImageUrlSchema } from '~/server/schema/blocks/civitai-image-url';
+import { mediaFromBlobs } from './output';
+import type { StepOutputMedia } from './output';
 import type { BlockStep, OrchestratorStepTemplate } from './index';
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -31,29 +33,36 @@ import type { BlockStep, OrchestratorStepTemplate } from './index';
 //     and no way to reach a gated / early-access / Private model version through
 //     it.
 //
-// 🔴 THE ONE THING THAT IS NOT LOCALLY VERIFIABLE is the orchestrator's ACTUAL
-// price for this step. It could not be measured from this environment (it needs
-// a real orchestrator token and a live `whatif` call). `PRICE_BUZZ` below is
-// therefore a DECLARED CEILING chosen conservatively, and the router treats a
-// realized cost ABOVE it as a cap-accounting shortfall it must top up and
-// report — see `civitai_app_block_step_price_divergence_total` in
-// `blocks.router.ts`. That instrumentation exists precisely because this number
-// is the one input to the money path that was not verified before shipping.
+// ✅ THE PRICE IS NOW MEASURED, NOT DECLARED. A real `whatif:true` submit of
+// this exact step shape was run against the live orchestrator from the PR
+// preview environment on 2026-08-02, and a real (non-whatif) submit was run and
+// polled to `succeeded`. Both returned `cost.total = 1`
+// (`cost: {base:1, factors:{base:1}, fixed:{}, tips:{...}, total:1}`), and the
+// per-job cost was likewise `1`. `PRICE_BUZZ = 1` therefore matches the
+// orchestrator's own quote rather than being a conservative guess.
+//
+// 🔴 That measurement does NOT make the price self-enforcing, so the submit path
+// no longer trusts it as the ceiling: it runs its own `whatif` before the
+// per-call `buzzBudget` gate and reserves `max(declared, quoted)`. See the
+// ORCHESTRATOR QUOTE section in `blocks.router.ts`. A single measurement is one
+// point on a rate card that can change; the gate must not depend on it.
 // ─────────────────────────────────────────────────────────────────────────────
 
 /**
  * The declared exact price, in Buzz.
  *
  * Reserved against the per-user daily cap, the per-app aggregate cap and (when
- * present) the dev-session cap BEFORE submit, and gated against the block
- * token's per-call `buzzBudget`. Must be a positive integer — enforced at
- * registry load (`assertStepInvariants`).
+ * present) the dev-session cap BEFORE submit. Must be a positive integer —
+ * enforced at registry load (`assertStepInvariants`).
  *
- * Set to 1: this is a CPU-only transform, so the honest expectation is that the
- * orchestrator charges at or near zero. A price of 1 is the smallest value the
- * invariant permits and errs in the SAFE direction (over-reserving against an
- * abuse cap is stricter; under-reserving is a hole). It is not a claim about
- * the orchestrator's rate card — see the header.
+ * Set to 1 because that is what the orchestrator actually quoted for this step
+ * shape (see the header for the measurement). It is also the value `estimateBuzz`
+ * shows the block, and the registry's load-time invariant forces those two to
+ * agree.
+ *
+ * 🔴 It is NOT the enforced ceiling. The per-call `buzzBudget` gate runs against
+ * the orchestrator's live `whatif` quote, so a rate-card change is caught at
+ * submit rather than by a human reading a counter later.
  */
 export const CONVERT_IMAGE_PRICE_BUZZ = 1;
 
@@ -123,11 +132,43 @@ const convertImageParamsSchema = z
 
 export type ConvertImageStepParams = z.infer<typeof convertImageParamsSchema>;
 
+/**
+ * The orchestrator's completed-step shape for `convertImage`.
+ *
+ * 🔴 SINGULAR `blob`, not `images` and not `blobs` — `ConvertImageOutput` in
+ * `@civitai/client` is `{ blob?: ImageBlob }`, and `product-badge.service.ts`
+ * reads `step.output.blob.url`. This is the whole reason output extraction had
+ * to become a registry field: both `workflow.service` extractors were blind to
+ * this step in TWO independent ways (the `$type` was not in their allowlist, and
+ * the key is not one they read), so a paid-for conversion could never be
+ * retrieved.
+ *
+ * Shape confirmed against a REAL orchestrator response (2026-08-02, live
+ * `convertImage` workflow polled to `succeeded`): `step.output` had exactly the
+ * key `blob`, with `available` transitioning false→true, plus `url`, `width`
+ * (797) and `height` (1024). No `images` key and no `blobs` key were present.
+ */
+type ConvertImageOutputStepLike = {
+  output?: {
+    blob?: {
+      url?: string | null;
+      available?: boolean;
+      width?: number | null;
+      height?: number | null;
+      nsfwLevel?: string | null;
+    } | null;
+  } | null;
+};
+
 export const convertImageStep = {
   id: 'convert-image',
   orchestratorType: 'convertImage',
   billingMode: 'prepaidFixed',
   moderationPosture: 'none',
+  // References no AIR resource of any kind — no checkpoint, no LoRA, no upscale
+  // model. Nothing for the entitlement belt to gate. ENFORCED at registry load,
+  // not just declared: clause 7 deep-scans the built step for an AIR URN.
+  resourcePolicy: { kind: 'none' },
   paramSchema: convertImageParamsSchema,
   variants: [DEFAULT_VARIANT],
   resolveVariant: () => DEFAULT_VARIANT,
@@ -143,6 +184,37 @@ export const convertImageStep = {
       image: params.image,
       ...(params.transforms ? { transforms: params.transforms } : {}),
       output: params.output,
+    },
+  }),
+  /**
+   * The SINGULAR `blob` this step type returns → the shared media shape. The
+   * availability + non-empty-url filter comes from `mediaFromBlobs`, so it is
+   * the same rule the other extraction paths apply, in one place.
+   */
+  extractOutput: (step: unknown): StepOutputMedia[] =>
+    mediaFromBlobs((step as ConvertImageOutputStepLike | null | undefined)?.output?.blob),
+  /**
+   * A canonical COMPLETED step, for the load-time extraction probe.
+   *
+   * 🔴 Copied from a real captured orchestrator response (2026-08-02), not
+   * invented to match `extractOutput`. A sample written from the extractor would
+   * make the probe assert only that the code agrees with itself — the exact
+   * both-wrong-blind failure where the fake encodes the same wrong shape as the
+   * code under test. Field names, nesting and the `available` flag here are the
+   * observed ones; only the url/signature are shortened.
+   */
+  canonicalOutputFor: (): unknown => ({
+    $type: 'convertImage',
+    name: 'block-step',
+    status: 'succeeded',
+    output: {
+      blob: {
+        id: 'W9E3ZK1G1RJSH6S88HT3GW5ZW0.webp',
+        url: 'https://orchestration-new.civitai.com/v2/consumer/blobs/W9E3ZK1G1RJSH6S88HT3GW5ZW0.webp?sig=probe',
+        available: true,
+        width: 797,
+        height: 1024,
+      },
     },
   }),
 } satisfies BlockStep<ConvertImageStepParams>;

--- a/src/server/services/blocks/steps/index.ts
+++ b/src/server/services/blocks/steps/index.ts
@@ -1,5 +1,6 @@
 import type * as z from 'zod';
 import { convertImageStep } from './convert-image.step';
+import type { StepOutputMedia } from './output';
 
 // ─────────────────────────────────────────────────────────────────────────────
 // App Blocks STEP-TYPE registry (`kind: 'step'`) — RFC #3515 migration step 1.
@@ -121,6 +122,111 @@ export type OrchestratorStepTemplate = {
   input: Record<string, unknown>;
 };
 
+// ─────────────────────────────────────────────────────────────────────────────
+// Resource / entitlement posture — REQUIRED, for the same reason
+// `moderationPosture` is.
+//
+// 🔴 `BlockRecipe` — the interface this registry generalizes — carries
+// `resourceAllowlist` AND `checkpointPolicy`. Neither survived the first draft
+// of the generalization, and that omission was the sharper half of the pair:
+// entitlement is the axis this PR's OWN Tranche-1 triage named as the real
+// risk. `imageUpscaler` was disqualified PRECISELY because its `model` field
+// takes an arbitrary AIR URN, which would let an untrusted iframe reach the
+// orchestrator around the generation-graph entitlement belt. With no declared
+// field, a future entry with exactly that shape would register cleanly and
+// every other load-time invariant would pass — the registry would look guarded
+// on the axis it is least guarded on.
+//
+// 🔴 Only `'none'` has an implemented handler. A step that reaches ANY AIR
+// resource needs a real, reviewed allowlist implementation (checkpoint policy
+// included — a checkpoint IS an AIR, so it is a `staticAllowlist` case, not a
+// separate field), and until one exists it fails at registry LOAD. Same
+// unskippable property moderation already had.
+// ─────────────────────────────────────────────────────────────────────────────
+export type StepResourcePolicy =
+  /**
+   * The step references NO AIR resource of any kind — there is nothing for the
+   * entitlement belt to gate and no way to reach a gated / early-access /
+   * Private model version through it. The ONLY policy with an implemented
+   * handler today, and it is ENFORCED, not merely declared: the built step is
+   * probed at load and must contain no AIR reference (see `assertStepInvariants`).
+   */
+  | { kind: 'none' }
+  /**
+   * A fixed, code-reviewed set of AIRs the step may reach — the generalization
+   * of `BlockRecipe.resourceAllowlist` + `checkpointPolicy`.
+   * NOT IMPLEMENTED — registering an entry with this policy fails at load.
+   */
+  | { kind: 'staticAllowlist'; airs: readonly string[] };
+
+/** True iff the resource policy has an implemented handler. */
+export function isResourcePolicyImplemented(policy: StepResourcePolicy): boolean {
+  return policy.kind === 'none';
+}
+
+/** The AIR URN scheme prefix. Lowercase; the scan lowercases its input. */
+const AIR_URN_PREFIX = 'urn:air:';
+
+/**
+ * True when any string ANYWHERE in the value is (or embeds) an AIR URN.
+ *
+ * Deliberately a deep scan rather than a check of a known field name: the point
+ * is to catch an AIR arriving through a field NOBODY thought to look at, which
+ * is the only way the `'none'` declaration can become a lie.
+ */
+export function containsAirReference(value: unknown): boolean {
+  if (typeof value === 'string') return value.toLowerCase().includes(AIR_URN_PREFIX);
+  if (Array.isArray(value)) return value.some(containsAirReference);
+  if (value !== null && typeof value === 'object') {
+    return Object.values(value as Record<string, unknown>).some(containsAirReference);
+  }
+  return false;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// OUTPUT EXTRACTION — registering a step and surfacing its result are ONE
+// action.
+//
+// 🔴 WHY THIS IS A REGISTRY FIELD AND NOT A BRANCH IN `workflow.service`.
+// `snapshotFromWorkflow` (the poll/submit snapshot) and `projectAppWorkflow`
+// (the `queryAppWorkflows` subqueue read) each carried a hardcoded `$type`
+// allowlist — `customComfy | textToImage | imageGen | comfy` — and `continue`d
+// on everything else. `convertImage`'s output is `{ blob?: ImageBlob }`
+// (SINGULAR `blob`, not `images` and not `blobs`), so BOTH extractors were
+// blind to it in two independent ways: the `$type` and the key. The result was
+// a capability that charges Buzz, reaches `succeeded`, and can never return its
+// result to the caller — inert, but only after the money moved.
+//
+// A fourth hardcoded `if ($type === 'convertImage')` branch would have fixed
+// today and guaranteed the next registered step repeated it; the same class had
+// already recurred twice elsewhere. So the entry DECLARES its own extraction,
+// the two extractors consult the registry by `$type`, and a new entry that gets
+// it wrong is a LOAD-TIME failure (clause 8) rather than a silent inert
+// capability.
+// ─────────────────────────────────────────────────────────────────────────────
+
+// The extraction primitives live in the leaf module `./output` (see its header
+// for why). Re-exported here so `~/server/services/blocks/steps` stays the one
+// import site for consumers that aren't registry entries.
+export type { StepOutputMedia } from './output';
+export { mediaFromBlobs } from './output';
+
+/**
+ * The `$type` values `workflow.service`'s two extractors handle NATIVELY, with
+ * their own long-standing inline branches.
+ *
+ * 🔴 A registered step MUST NOT claim one of these (enforced, clause 9). That
+ * invariant is what makes the registry branch safe to place BEFORE the native
+ * `$type` filter: it cannot shadow an existing branch, so `textToImage` /
+ * `imageGen` / `comfy` / `customComfy` extraction stays byte-identical.
+ */
+export const NATIVELY_EXTRACTED_STEP_TYPES: readonly string[] = [
+  'customComfy',
+  'textToImage',
+  'imageGen',
+  'comfy',
+] as const;
+
 /**
  * Fields every registered step declares, regardless of billing mode.
  *
@@ -135,6 +241,12 @@ interface BlockStepBase<P> {
   billingMode: StepBillingMode;
   /** 🔴 REQUIRED. See `StepModerationPosture`. */
   moderationPosture: StepModerationPosture;
+  /**
+   * 🔴 REQUIRED. See `StepResourcePolicy`. The entitlement axis — the one this
+   * PR's own triage identified as the real bypass risk, and the one a
+   * generalization of `BlockRecipe` must not drop.
+   */
+  resourcePolicy: StepResourcePolicy;
   /**
    * Bounded param schema. MUST be `.strict()` — an unknown param is REJECTED,
    * never silently dropped. Enforced behaviourally at registry load.
@@ -175,6 +287,37 @@ interface BlockStepBase<P> {
   buildStep(params: P): OrchestratorStepTemplate;
   /** The Buzz figure `estimateWorkflow` shows the block. */
   estimateBuzz(params: P): number;
+  /**
+   * 🔴 REQUIRED. PURE extractor: the orchestrator's completed step object → the
+   * output media the caller gets back. Called by BOTH `snapshotFromWorkflow`
+   * (`imageUrls`) and `projectAppWorkflow` (`images`), so one declaration
+   * surfaces the result on both read surfaces.
+   *
+   * MUST apply the availability filter — use the shared `mediaFromBlobs` helper
+   * rather than reimplementing it.
+   *
+   * Takes the whole step (not `step.output`) because the output KEY is
+   * step-type-specific: `convertImage` returns `{ blob }`, `customComfy`
+   * returns `{ blobs }`, the image steps return `{ images }`. Typed `unknown`
+   * because the orchestrator step union is wider than any one entry knows;
+   * narrow it inside the entry.
+   */
+  extractOutput(step: unknown): StepOutputMedia[];
+  /**
+   * A canonical, orchestrator-SHAPED completed step object for the given
+   * variant, carrying at least one available output blob.
+   *
+   * Exists SOLELY for the load-time extraction probe (clause 8), the same way
+   * `canonicalParamsFor` exists for the budget/strictness probes. Without it,
+   * `extractOutput` would be a required field that a new entry could satisfy
+   * with `() => []` — compiling, registering, and shipping the exact inert
+   * capability this field exists to prevent.
+   *
+   * 🔴 Populate it from a REAL observed orchestrator response, not from what the
+   * extractor expects. A sample written to match the code proves only that the
+   * code matches itself.
+   */
+  canonicalOutputFor(variant: string): unknown;
 }
 
 /**
@@ -266,6 +409,24 @@ export type StepSpendPlan = {
    */
   postPaidSettle: boolean;
   /**
+   * True when a REALIZED cost above `reserveBuzz` must be topped up onto the cap
+   * counters immediately, at submit.
+   *
+   * 🔴 THIS IS `prepaidFixed`-SHAPED AND MUST NOT RUN FOR EVERY MODE. It is
+   * correct only when the reservation is an EXACT price: the counters are then
+   * genuinely short by the difference and nothing else will ever fix them. For a
+   * mode whose reservation is a CEILING (`timeBounded`), a submit-time cost
+   * above the ceiling would be topped up here AND then settled ceiling→actual by
+   * the post-paid machinery off the UN-topped-up ceiling — double-counting the
+   * overage and then unwinding the wrong number. The correction used to fire
+   * unconditionally on `overage > 0`, which is a latent version of exactly that,
+   * and it defeats the additivity this registry exists to guarantee. So the mode
+   * decides, here, and the router stays mode-agnostic.
+   *
+   * Mutually exclusive with `postPaidSettle` by construction.
+   */
+  correctReservationOverage: boolean;
+  /**
    * The orchestrator step `timeout` to stamp, for modes whose cap IS a timeout.
    * `null` when the mode does not use one (`prepaidFixed`: the price is not a
    * function of wall-clock, so a timeout would be a liveness knob, not a Buzz
@@ -311,6 +472,8 @@ const billingModeHandlers: Record<StepBillingMode, BillingModeHandler> = {
         // Exact price → the reservation is final; never touch the post-paid
         // settle machinery.
         postPaidSettle: false,
+        // Exact price → an overage IS a permanent cap shortfall, so correct it.
+        correctReservationOverage: true,
         stepTimeoutSeconds: null,
       };
     },
@@ -395,6 +558,23 @@ export const REGISTERED_STEP_IDS = Object.keys(stepRegistry) as [
 /** Resolve a step by id. Returns `undefined` for an unregistered id. */
 export function getStep(id: string): AnyBlockStep | undefined {
   return (stepRegistry as Record<string, AnyBlockStep>)[id];
+}
+
+/**
+ * Resolve a step by the orchestrator `$type` it submits as — the lookup the two
+ * `workflow.service` extractors use, since a returned Workflow carries the
+ * `$type`, never the registry id.
+ *
+ * Returns `undefined` for an unregistered `$type`, so a caller keeps whatever
+ * fallback it had. Uniqueness of `orchestratorType` across the registry is
+ * enforced at load (`assertOrchestratorTypesUnique`) — without it this lookup
+ * would silently pick whichever entry happened to be declared last.
+ */
+export function getStepByOrchestratorType(orchestratorType: string): AnyBlockStep | undefined {
+  for (const [, step] of listRegisteredSteps()) {
+    if (step.orchestratorType === orchestratorType) return step;
+  }
+  return undefined;
 }
 
 /**
@@ -532,13 +712,73 @@ export function assertStepInvariants(id: string, step: AnyBlockStep): void {
         break;
       }
     }
+
+    // (7) RESOURCE POLICY, enforced rather than merely declared. A `'none'`
+    // entry claims it reaches no AIR resource; prove it against the step this
+    // entry actually BUILDS, by deep-scanning for an AIR URN anywhere in the
+    // submitted input. This is what stops a future `imageUpscaler`-shaped entry
+    // — an arbitrary AIR URN forwarded from an untrusted iframe, straight past
+    // the generation-graph entitlement belt — from registering with a `'none'`
+    // declaration and passing every other invariant.
+    //
+    // 🔴 HONEST LIMIT, stated so nobody over-trusts it: this probes the
+    // CANONICAL params, so it cannot see an AIR that only appears when an
+    // OPTIONAL air-bearing field is supplied. It is a floor, not a proof. The
+    // load-bearing guard for that case is the required declaration itself plus
+    // the unimplemented `staticAllowlist` gate (clause 11): an entry whose
+    // params can carry an AIR cannot honestly declare `'none'`, and declaring
+    // `'staticAllowlist'` fails at load until someone implements and reviews it.
+    if (step.resourcePolicy.kind === 'none') {
+      const built = step.buildStep(parsed.data);
+      if (containsAirReference(built.input)) {
+        throw new Error(
+          `${vWhere}: resourcePolicy 'none' is contradicted — buildStep() emitted an AIR ` +
+            'reference. A step that reaches an AIR resource bypasses the generation-graph ' +
+            'entitlement belt and needs a declared, implemented resource allowlist'
+        );
+      }
+    }
+
+    // (8) OUTPUT EXTRACTION must actually surface something. A registered step
+    // whose output nothing can read is a capability the caller is CHARGED for
+    // and can never retrieve — it polls to `succeeded` with an empty result
+    // forever. That failure is invisible to every other invariant here, and it
+    // is exactly what shipped before this clause existed.
+    const sampleStep = step.canonicalOutputFor(variant);
+    const media = step.extractOutput(sampleStep);
+    if (!Array.isArray(media) || media.length === 0) {
+      throw new Error(
+        `${vWhere}: extractOutput() returned no media for canonicalOutputFor() — the step's ` +
+          'result would be unreachable on both the snapshot and the app-workflow projection'
+      );
+    }
+    for (const item of media) {
+      if (typeof item?.url !== 'string' || item.url.length === 0) {
+        throw new Error(
+          `${vWhere}: extractOutput() returned media with no url — a block would render a dead link`
+        );
+      }
+    }
   }
 
-  // (7) LAST: the declared billing mode must have an implemented money-path
+  // (9) The orchestrator `$type` must not shadow one of the `$type` values
+  // `workflow.service`'s extractors handle NATIVELY. The registry branch there
+  // is evaluated BEFORE the native `$type` filter (it has to be — that filter
+  // `continue`s on everything else), so without this guard a registered entry
+  // could silently take over `textToImage` extraction. With it, the placement is
+  // provably behaviour-preserving for the existing kinds.
+  if (NATIVELY_EXTRACTED_STEP_TYPES.includes(step.orchestratorType)) {
+    throw new Error(
+      `${where}: orchestratorType '${step.orchestratorType}' is natively extracted by ` +
+        'workflow.service — a registered step must not shadow it'
+    );
+  }
+
+  // (10) LAST-1: the declared billing mode must have an implemented money-path
   // handler. This is what stops a newly declared mode from riding another
   // mode's reservation logic — it is a BUILD failure, not a runtime one.
   //
-  // Placed last so the structural per-variant invariants above stay reachable
+  // Placed late so the structural per-variant invariants above stay reachable
   // (see clause 6). Position does not weaken it: every clause here throws at
   // module load, so an entry declaring an unimplemented mode still cannot
   // register regardless of which guard reports first.
@@ -547,6 +787,41 @@ export function assertStepInvariants(id: string, step: AnyBlockStep): void {
       `${where}: billingMode '${step.billingMode}' has no implemented money-path handler`
     );
   }
+
+  // (11) LAST: the declared resource policy must have an implemented handler.
+  // Same fail-closed shape and same reason as the billing-mode gate, on the
+  // entitlement axis. Placed last for the same reachability reason: with it
+  // first, clause 7's `'none'` branch would still run (it only applies to
+  // `'none'`), but any future per-policy structural invariant would not.
+  if (!isResourcePolicyImplemented(step.resourcePolicy)) {
+    throw new Error(
+      `${where}: resourcePolicy '${step.resourcePolicy.kind}' has no implemented handler — ` +
+        'a step that reaches AIR resources needs a reviewed entitlement gate first'
+    );
+  }
+}
+
+/**
+ * Cross-entry invariant: no two registered steps may claim the same orchestrator
+ * `$type`. `getStepByOrchestratorType` is a single-winner lookup, so a duplicate
+ * would silently route one step's output extraction through the other's
+ * extractor — a wrong-shape read on a money path.
+ *
+ * Separate from `assertStepInvariants` because it is a property of the
+ * POPULATION, not of any one entry.
+ */
+export function assertOrchestratorTypesUnique(entries: [string, AnyBlockStep][]): void {
+  const seen = new Map<string, string>();
+  for (const [id, step] of entries) {
+    const prior = seen.get(step.orchestratorType);
+    if (prior !== undefined) {
+      throw new Error(
+        `block step '${id}': orchestratorType '${step.orchestratorType}' is already claimed by ` +
+          `'${prior}' — output extraction would silently resolve to one of them`
+      );
+    }
+    seen.set(step.orchestratorType, id);
+  }
 }
 
 // Fail-fast every invariant at module load. A registry that violates one is a
@@ -554,3 +829,4 @@ export function assertStepInvariants(id: string, step: AnyBlockStep): void {
 for (const [id, step] of listRegisteredSteps()) {
   assertStepInvariants(id, step);
 }
+assertOrchestratorTypesUnique(listRegisteredSteps());

--- a/src/server/services/blocks/steps/index.ts
+++ b/src/server/services/blocks/steps/index.ts
@@ -1,0 +1,556 @@
+import type * as z from 'zod';
+import { convertImageStep } from './convert-image.step';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// App Blocks STEP-TYPE registry (`kind: 'step'`) — RFC #3515 migration step 1.
+//
+// WHAT THIS IS. A generalization of the `customComfy` recipe registry
+// (`~/server/services/blocks/recipes`) from "Comfy recipes" to "orchestrator
+// step types". A registered step bundles a stable id, a bounded `.strict()`
+// param schema, a pure builder onto an orchestrator step template, a DECLARED
+// BILLING MODE, and a DECLARED MODERATION POSTURE.
+//
+// The block schema's `step` enum is DERIVED from this registry's keys
+// (`REGISTERED_STEP_IDS`), so an unregistered id fails closed at the WIRE
+// schema — before any translator, any spend reservation, or any orchestrator
+// call. Adding a capability is one small reviewed civitai PR: write a
+// `<name>.step.ts`, register it below, add tests. The `kind` (`step`) and the
+// router are untouched.
+//
+// 🔴 THE REGISTRY IS A CODE-REVIEWED, NON-DB-EDITABLE TRUST ROOT. Exactly the
+// posture the recipe registry has, and it must not change. This module has no
+// DB access and loads at import time, before any request context.
+//
+// 🔴 THIS IS ON THE SPEND PATH. A change here changes what a block can spend.
+// Treat every edit as a spend-safety review, not a content edit.
+//
+// WHAT THIS IS NOT (deliberately, per the RFC):
+//   - It does NOT absorb `kind: 'textToImage'`. That member carries entitlement
+//     gating over the checkpoint AND the LoRA stack, availability gates,
+//     model-token binding, the page-only `sourceImage` rule, `accountType`
+//     currency ordering, `sharedContentKey` attribution, and POI handling.
+//     Two kinds — a rich first-class generation path plus a uniform registry
+//     for everything else — is the honest split.
+//   - It does NOT absorb `kind: 'customComfy'`. Migrating that member behind
+//     this registry (with `kind: 'customComfy'` retained as a deprecated alias)
+//     is the RFC's migration step 3 and is deliberately OUT OF SCOPE here.
+//     Step 1 is "land the registry alongside the existing members; nothing
+//     breaks."
+// ─────────────────────────────────────────────────────────────────────────────
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Billing mode — "the one field the current interface is missing" (RFC).
+//
+// `BlockRecipe.budgetFor` encodes `maxBuzz === ceil(stepTimeoutSeconds × 1)`,
+// which is elegant *because* it is time-bounded: the aggressive step timeout is
+// the physical cap at ~1 Buzz/GPU-second. That invariant does not generalize to
+// every step type, so the mode is declared per entry and the money path
+// DISPATCHES ON IT.
+//
+// 🔴 ALL THREE VALUES ARE DEFINED NOW even though the registry only uses
+// `prepaidFixed` today. That is the point: the wire contract and the type
+// surface are the expensive things to change once `@civitai/app-sdk` mirrors
+// them, so future step types must be ADDITIVE (register an entry) rather than a
+// schema change. A mode with no registered entry has no money-path handler yet
+// and FAILS AT REGISTRY LOAD (see `assertStepInvariants`) — it can never
+// silently ride another mode's reservation logic.
+// ─────────────────────────────────────────────────────────────────────────────
+export type StepBillingMode =
+  /** GPU work with variable duration; the step timeout is the physical cap. */
+  | 'timeBounded'
+  /** Deterministic cost, exactly knowable before execution. */
+  | 'prepaidFixed'
+  /** Cost scales with tokens, not wall-clock. */
+  | 'tokenMetered';
+
+export const STEP_BILLING_MODES: readonly StepBillingMode[] = [
+  'timeBounded',
+  'prepaidFixed',
+  'tokenMetered',
+] as const;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Moderation posture — REQUIRED, and required for a reason.
+//
+// `BlockRecipe.negativePrompt` exists so the prompt-audit re-point has
+// something to read. That hook does not generalize: a step with no prompt
+// (image conversion) has no such surface, and a step with a TEXT OUTPUT
+// (`chatCompletion`, `mediaCaptioning`, `audioCaptioning`, `transcription`) has
+// a NEW one that the prompt audit does not cover at all.
+//
+// 🔴 MAKING THIS FIELD REQUIRED IS THE WHOLE MECHANISM. Registering a
+// text-producing step later is impossible without someone explicitly answering
+// the policy question in code — it cannot be quietly skipped, because a posture
+// with no implemented handler fails at registry LOAD (a build-time error), not
+// at request time on a Friday. That policy decision is deliberately NOT made
+// here.
+// ─────────────────────────────────────────────────────────────────────────────
+export type StepModerationPosture =
+  /**
+   * No free-text input and no free-text output — the step introduces no new
+   * moderation surface. The ONLY posture with an implemented handler today.
+   */
+  | 'none'
+  /**
+   * Free-text INPUT that must go through the existing server prompt audit
+   * (`auditPromptServer`), as `textToImage` / `customComfy` do.
+   * NOT IMPLEMENTED — registering an entry with this posture fails at load.
+   */
+  | 'promptAudit'
+  /**
+   * Free-text OUTPUT — a moderation surface the prompt audit does not cover.
+   * NOT IMPLEMENTED — registering an entry with this posture fails at load.
+   */
+  | 'textOutput';
+
+export const STEP_MODERATION_POSTURES: readonly StepModerationPosture[] = [
+  'none',
+  'promptAudit',
+  'textOutput',
+] as const;
+
+/**
+ * The orchestrator step template a step builder emits: the `$type` discriminator
+ * plus its bounded `input`. The envelope concerns the router owns (`name`, and
+ * the `timeout` a `timeBounded` entry would stamp) are added at submit — keep
+ * builders free of them, exactly as `CustomComfyStepInput` is kept free of the
+ * customComfy step envelope.
+ */
+export type OrchestratorStepTemplate = {
+  $type: string;
+  input: Record<string, unknown>;
+};
+
+/**
+ * Fields every registered step declares, regardless of billing mode.
+ *
+ * `P` is the step's bounded param type (inferred from `paramSchema`).
+ */
+interface BlockStepBase<P> {
+  /** Stable id. The wire `step` enum is DERIVED from the registry keys. */
+  id: string;
+  /** The orchestrator `$type` this step submits as. */
+  orchestratorType: string;
+  /** 🔴 REQUIRED. Drives estimate/submit/settle dispatch. */
+  billingMode: StepBillingMode;
+  /** 🔴 REQUIRED. See `StepModerationPosture`. */
+  moderationPosture: StepModerationPosture;
+  /**
+   * Bounded param schema. MUST be `.strict()` — an unknown param is REJECTED,
+   * never silently dropped. Enforced behaviourally at registry load.
+   *
+   * 🔴 This is not a style preference. `blockTextToImageBodySchema` is NOT
+   * `.strict()`, and that non-strictness is exactly what let an older host
+   * silently strip `sourceImages` and bill the wrong generation. A dropped
+   * param on a money path is a wrong-generation bug, not a validation nit.
+   */
+  paramSchema: z.ZodType<P>;
+  /**
+   * The variants this step exposes — the generalization of `BlockRecipe.engines`
+   * ("which variant did this resolve to?", an open question in the RFC). Every
+   * billing mode keys its price/budget off a variant, which is what lets the
+   * load-time invariant loop enumerate the population WITHOUT constructing full
+   * params (the same reason `budgetForEngine` exists on `BlockRecipe`).
+   */
+  variants: readonly string[];
+  /**
+   * The SINGLE source of truth for "which variant did this submit resolve to?".
+   * The price/budget, the built step, and the display estimate MUST all agree on
+   * this one value, so they all derive it here. Returns a bounded id from
+   * `variants` — never a client-raw string.
+   */
+  resolveVariant(params: P): string;
+  /**
+   * A canonical, schema-valid params object for the given variant.
+   *
+   * Exists SOLELY for the load-time invariant loop, which must evaluate
+   * `estimateBuzz` and the strictness probe — both of which need real params —
+   * without a request context. Without it the `prepaidFixed` invariant would
+   * degrade to "the declared price is an integer", which cannot catch the
+   * failure that actually costs money: an `estimateBuzz` that disagrees with
+   * the price the caller is charged.
+   */
+  canonicalParamsFor(variant: string): P;
+  /** PURE builder: bounded params → the orchestrator step template. */
+  buildStep(params: P): OrchestratorStepTemplate;
+  /** The Buzz figure `estimateWorkflow` shows the block. */
+  estimateBuzz(params: P): number;
+}
+
+/**
+ * Deterministic cost, exactly knowable before execution.
+ *
+ * 🔴 `prepaidFixed` HAS ITS OWN ENFORCED LOAD-TIME INVARIANT — it is NOT
+ * exempted from the registry's structural guard. The `timeBounded` invariant
+ * (`maxBuzz === ceil(stepTimeoutSeconds)`) rests on a step timeout being a
+ * PHYSICAL cap at ~1 Buzz/GPU-second; a fixed-price step has no such time
+ * relationship and cannot satisfy it. If `prepaidFixed` entries merely SKIPPED
+ * the check, the guard would still exist but would no longer be reachable for
+ * the new class — structurally the worst outcome, because the registry would
+ * look guarded while new entries were unguarded. So this mode declares an
+ * equivalent invariant, validated at load with the same fail-fast shape:
+ *
+ *   for every variant v:
+ *     priceForVariant(v) is a positive safe integer
+ *     estimateBuzz(canonicalParamsFor(v)) === priceForVariant(v)
+ *
+ * The second clause is the money-relevant one: the price is what gets RESERVED
+ * against every cap, and `estimateBuzz` is what the app is SHOWN. A divergence
+ * means the block quotes one number and the viewer is charged another.
+ */
+interface PrepaidFixedStep<P> extends BlockStepBase<P> {
+  billingMode: 'prepaidFixed';
+  /** The exact Buzz price. Positive integer, constant per variant. */
+  priceForVariant(variant: string): number;
+}
+
+/**
+ * GPU work with variable duration. Carries the `BlockRecipe` invariant verbatim
+ * (`maxBuzz === ceil(stepTimeoutSeconds)`) because it rests on the same physics.
+ *
+ * Declared now so the type surface is stable; NO entry uses it yet, and its
+ * money-path handler is not implemented, so registering one fails at load.
+ */
+interface TimeBoundedStep<P> extends BlockStepBase<P> {
+  billingMode: 'timeBounded';
+  budgetForVariant(variant: string): { maxBuzz: number; stepTimeoutSeconds: number };
+}
+
+/**
+ * Cost scales with tokens, not wall-clock — the mode that genuinely does not
+ * fit today's model, and the reason to sequence LLM steps last (RFC).
+ *
+ * Declared now so the type surface is stable; NO entry uses it yet, and its
+ * money-path handler is not implemented, so registering one fails at load.
+ */
+interface TokenMeteredStep<P> extends BlockStepBase<P> {
+  billingMode: 'tokenMetered';
+  maxBuzzForVariant(variant: string): number;
+}
+
+/**
+ * A registered step. A DISCRIMINATED UNION on `billingMode`, which is what makes
+ * a missing or unknown `billingMode` a COMPILE error rather than a runtime
+ * surprise (no union member matches), and what gives each mode its own required
+ * price/budget accessor.
+ */
+export type BlockStep<P = unknown> = PrepaidFixedStep<P> | TimeBoundedStep<P> | TokenMeteredStep<P>;
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type AnyBlockStep = BlockStep<any>;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Spend planning — the money-path dispatch.
+//
+// 🔴 estimate / submit / settle dispatch on `billingMode`, NEVER on `kind` and
+// never on the step id. The router calls `planStepSpend` / `estimateStepBuzz`
+// and reads the returned plan; it contains no per-step and no per-mode branch.
+// Adding a capability is register-an-entry; adding a MODE is add-a-handler
+// here — neither is router surgery. That is the whole point of the RFC.
+// ─────────────────────────────────────────────────────────────────────────────
+
+export type StepSpendPlan = {
+  /**
+   * The Buzz reserved against EVERY cap (per-user daily, per-app aggregate,
+   * dev-session) BEFORE the orchestrator submit, and gated against the token's
+   * per-call `buzzBudget`.
+   */
+  reserveBuzz: number;
+  /**
+   * True when `reserveBuzz` is a CEILING that a terminal poll/cancel must settle
+   * down to the real accrued cost (the post-paid machinery `customComfy` uses).
+   *
+   * `prepaidFixed` is FALSE: the price is exact and known before execution, so
+   * the reservation is final and the post-paid settle machinery is never
+   * touched — no settle record is persisted and no terminal refund is owed.
+   */
+  postPaidSettle: boolean;
+  /**
+   * The orchestrator step `timeout` to stamp, for modes whose cap IS a timeout.
+   * `null` when the mode does not use one (`prepaidFixed`: the price is not a
+   * function of wall-clock, so a timeout would be a liveness knob, not a Buzz
+   * ceiling, and stamping one here would imply a cap relationship that does not
+   * exist).
+   */
+  stepTimeoutSeconds: number | null;
+};
+
+type BillingModeHandler = {
+  estimateBuzz(step: AnyBlockStep, params: unknown): number;
+  planSpend(step: AnyBlockStep, params: unknown): StepSpendPlan;
+};
+
+/**
+ * A mode that is DECLARED (so the type + wire surface is stable and future
+ * additions are additive) but whose money path is not implemented yet.
+ *
+ * This is a fail-closed gate, not a placeholder: registering an entry with such
+ * a mode is rejected at registry LOAD by `assertStepInvariants`, so these
+ * functions are unreachable for any registered step. They exist so that the
+ * handler table is TOTAL over `StepBillingMode` — which is what makes the
+ * "unimplemented" state a compile-visible, enumerable fact rather than a
+ * missing object key that reads as `undefined` at runtime.
+ */
+function unimplementedMode(mode: StepBillingMode): BillingModeHandler {
+  const fail = (): never => {
+    throw new Error(
+      `billing mode '${mode}' has no money-path handler — implement one in ` +
+        'services/blocks/steps before registering a step that declares it'
+    );
+  };
+  return { estimateBuzz: fail, planSpend: fail };
+}
+
+const billingModeHandlers: Record<StepBillingMode, BillingModeHandler> = {
+  prepaidFixed: {
+    estimateBuzz: (step, params) => step.estimateBuzz(params),
+    planSpend: (step, params) => {
+      const entry = step as PrepaidFixedStep<unknown>;
+      return {
+        reserveBuzz: entry.priceForVariant(entry.resolveVariant(params)),
+        // Exact price → the reservation is final; never touch the post-paid
+        // settle machinery.
+        postPaidSettle: false,
+        stepTimeoutSeconds: null,
+      };
+    },
+  },
+  timeBounded: unimplementedMode('timeBounded'),
+  tokenMetered: unimplementedMode('tokenMetered'),
+};
+
+/** True iff the mode has an implemented money-path handler. */
+export function isBillingModeImplemented(mode: StepBillingMode): boolean {
+  return mode === 'prepaidFixed';
+}
+
+/** The display estimate for a step, dispatched on its declared billing mode. */
+export function estimateStepBuzz(step: AnyBlockStep, params: unknown): number {
+  return billingModeHandlers[step.billingMode].estimateBuzz(step, params);
+}
+
+/** The spend plan for a step submit, dispatched on its declared billing mode. */
+export function planStepSpend(step: AnyBlockStep, params: unknown): StepSpendPlan {
+  return billingModeHandlers[step.billingMode].planSpend(step, params);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Moderation dispatch. Same shape, same reasoning: total over the posture
+// union, and every posture without an implemented handler is rejected at load.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** True iff the posture has an implemented handler. */
+export function isModerationPostureImplemented(posture: StepModerationPosture): boolean {
+  // 'none' is implemented by construction: a step with no free-text input and
+  // no free-text output introduces no surface, so there is nothing to run. Both
+  // other postures need a real, policy-reviewed implementation.
+  return posture === 'none';
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// The registry object. Its keys ARE the source of truth for the wire enum.
+//
+// TRANCHE 1 (RFC migration step 2): deterministic, `prepaidFixed`, no new
+// moderation surface. See `convert-image.step.ts` for why that entry qualifies.
+//
+// 🔴 The RFC named Tranche 1 as "background removal, upscale, convert". Only
+// CONVERT made it. Enumerating the orchestrator's real `$type` values from the
+// generated `@civitai/client` types found that the other two DO exist —
+// `imageBackgroundRemoval` and `imageUpscaler` — but neither is `prepaidFixed`:
+//   - `imageBackgroundRemoval`: the client's own doc string says it "builds a
+//     ComfyUI graph under the hood and runs it as a comfy job", i.e. GPU work
+//     with variable duration. That is `timeBounded`, not a deterministic price.
+//   - `imageUpscaler`: also GPU work, AND its `model` field takes an arbitrary
+//     AIR URN. An AIR chosen by an untrusted iframe reaches the orchestrator
+//     without the generation-graph entitlement belt — the same bypass class the
+//     customComfy `resources` array carries — so it needs a resource gate first.
+// Both are good Tranche 2 candidates once `timeBounded` has a money-path
+// handler. Registering either now would have meant declaring a fixed price for
+// something whose cost is not fixed.
+//
+// Also considered and NOT registered: `mediaHash` passes all four bars
+// (standalone `$type` with a consumer-recipe endpoint, deterministic CPU
+// hashing, bounded hash-string output, no resources) but has no demonstrated
+// developer demand, and every registered id is a permanent public wire
+// commitment. Adding it later is one file plus one line here — which is the
+// entire point of the registry.
+// ─────────────────────────────────────────────────────────────────────────────
+const stepRegistry = {
+  'convert-image': convertImageStep,
+};
+
+export type RegisteredStepId = keyof typeof stepRegistry & string;
+
+/**
+ * The registered step ids, DERIVED from the registry keys. Consumed by
+ * `workflow.schema`'s `blockStepBodySchema` as the fail-closed `step` enum (an
+ * unregistered id is rejected at the union). Typed as a non-empty tuple so
+ * `z.enum` accepts it.
+ */
+export const REGISTERED_STEP_IDS = Object.keys(stepRegistry) as [
+  RegisteredStepId,
+  ...RegisteredStepId[]
+];
+
+/** Resolve a step by id. Returns `undefined` for an unregistered id. */
+export function getStep(id: string): AnyBlockStep | undefined {
+  return (stepRegistry as Record<string, AnyBlockStep>)[id];
+}
+
+/**
+ * The registered steps as `[id, step]` pairs.
+ *
+ * Exported so tests can enumerate the REAL population rather than a hardcoded
+ * list — a newly added entry that violates an invariant then fails loudly in
+ * CI instead of being silently uncovered.
+ */
+export function listRegisteredSteps(): [string, AnyBlockStep][] {
+  return Object.entries(stepRegistry as Record<string, AnyBlockStep>);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// LOAD-TIME INVARIANTS (fail-fast at module import, mirroring the recipe
+// registry's `maxBuzz === ceil(stepTimeoutSeconds)` loop).
+//
+// Exported as a function over an arbitrary entry so the tests can (a) run it
+// against the real population and (b) mutation-test each clause with a fixture
+// that violates exactly one of them. A guard that can only be exercised by
+// editing the shipped registry is a guard nobody exercises.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** The key used to probe that a step's `paramSchema` really is `.strict()`. */
+export const STRICTNESS_PROBE_KEY = '__unregisteredBlockStepParamProbe__';
+
+export function assertStepInvariants(id: string, step: AnyBlockStep): void {
+  const where = `block step '${id}'`;
+
+  // (0) The registry key IS the wire id. A mismatch would mean the enum says one
+  // thing and every log/metric/error says another.
+  if (step.id !== id) {
+    throw new Error(`${where}: registry key must equal step.id (got '${step.id}')`);
+  }
+
+  // (1) The declared moderation posture must have an implemented handler. A
+  // text-producing step cannot be registered until someone answers the policy
+  // question in code.
+  if (!isModerationPostureImplemented(step.moderationPosture)) {
+    throw new Error(
+      `${where}: moderationPosture '${step.moderationPosture}' has no implemented handler — ` +
+        'a step with a free-text input or output needs a declared, implemented posture'
+    );
+  }
+
+  // (2) At least one variant, or nothing below can be enumerated.
+  if (step.variants.length === 0) {
+    throw new Error(`${where}: must declare at least one variant`);
+  }
+
+  for (const variant of step.variants) {
+    const vWhere = `${where} variant '${variant}'`;
+    const params = step.canonicalParamsFor(variant);
+
+    // (3) The canonical params must PARSE. If they don't, every clause below is
+    // testing a value the schema would have rejected.
+    const parsed = step.paramSchema.safeParse(params);
+    if (!parsed.success) {
+      throw new Error(
+        `${vWhere}: canonicalParamsFor() must satisfy paramSchema (${parsed.error.message})`
+      );
+    }
+
+    // (4) `.strict()` — an UNKNOWN param must be REJECTED, not silently dropped.
+    // Probed behaviourally rather than by inspecting the zod internals, so it
+    // holds for any schema shape that achieves strictness.
+    if (typeof params !== 'object' || params === null || Array.isArray(params)) {
+      throw new Error(`${vWhere}: canonicalParamsFor() must return a plain params object`);
+    }
+    const withUnknown = { ...(params as Record<string, unknown>), [STRICTNESS_PROBE_KEY]: 1 };
+    if (step.paramSchema.safeParse(withUnknown).success) {
+      throw new Error(
+        `${vWhere}: paramSchema must be .strict() — it accepted an unknown param ` +
+          `('${STRICTNESS_PROBE_KEY}'), which means an unknown param is silently DROPPED`
+      );
+    }
+
+    // (5) The canonical params for a variant must RESOLVE to that variant, or
+    // the price/budget asserted below is not the one this params object buys.
+    const resolved = step.resolveVariant(parsed.data);
+    if (resolved !== variant) {
+      throw new Error(
+        `${vWhere}: canonicalParamsFor() resolves to variant '${resolved}', not '${variant}'`
+      );
+    }
+
+    // (6) Per-mode budget invariant. Runs BEFORE the implemented-handler gate
+    // below, deliberately: if the gate ran first, these branches would be
+    // structurally UNREACHABLE for `timeBounded` / `tokenMetered` (the gate
+    // rejects every such entry, so their clauses could never execute) and the
+    // registry would carry two invariants nothing could ever exercise. Ordered
+    // this way, a fixture declaring an unimplemented mode still reaches — and
+    // can mutation-prove — its own budget guard.
+    switch (step.billingMode) {
+      case 'prepaidFixed': {
+        const price = step.priceForVariant(variant);
+        if (!Number.isSafeInteger(price) || price <= 0) {
+          throw new Error(
+            `${vWhere}: prepaidFixed price (${price}) must be a positive safe integer — ` +
+              'it is the exact amount reserved against every spend cap'
+          );
+        }
+        const estimate = step.estimateBuzz(parsed.data);
+        if (estimate !== price) {
+          throw new Error(
+            `${vWhere}: prepaidFixed estimateBuzz (${estimate}) must equal the declared ` +
+              `price (${price}) — the block is SHOWN the estimate and CHARGED the price`
+          );
+        }
+        break;
+      }
+      case 'timeBounded': {
+        const budget = step.budgetForVariant(variant);
+        const enforced = Math.ceil(budget.stepTimeoutSeconds);
+        if (!Number.isSafeInteger(enforced) || enforced <= 0) {
+          throw new Error(
+            `${vWhere}: timeBounded stepTimeoutSeconds (${budget.stepTimeoutSeconds}) must be positive`
+          );
+        }
+        if (budget.maxBuzz !== enforced) {
+          throw new Error(
+            `${vWhere}: timeBounded maxBuzz (${budget.maxBuzz}) must equal ` +
+              `ceil(stepTimeoutSeconds) (${enforced}) — the step timeout is the physical Buzz ceiling`
+          );
+        }
+        break;
+      }
+      case 'tokenMetered': {
+        const maxBuzz = step.maxBuzzForVariant(variant);
+        if (!Number.isSafeInteger(maxBuzz) || maxBuzz <= 0) {
+          throw new Error(
+            `${vWhere}: tokenMetered maxBuzz (${maxBuzz}) must be a positive safe integer`
+          );
+        }
+        break;
+      }
+    }
+  }
+
+  // (7) LAST: the declared billing mode must have an implemented money-path
+  // handler. This is what stops a newly declared mode from riding another
+  // mode's reservation logic — it is a BUILD failure, not a runtime one.
+  //
+  // Placed last so the structural per-variant invariants above stay reachable
+  // (see clause 6). Position does not weaken it: every clause here throws at
+  // module load, so an entry declaring an unimplemented mode still cannot
+  // register regardless of which guard reports first.
+  if (!isBillingModeImplemented(step.billingMode)) {
+    throw new Error(
+      `${where}: billingMode '${step.billingMode}' has no implemented money-path handler`
+    );
+  }
+}
+
+// Fail-fast every invariant at module load. A registry that violates one is a
+// BUILD-time error, not a runtime surprise on a spend path.
+for (const [id, step] of listRegisteredSteps()) {
+  assertStepInvariants(id, step);
+}

--- a/src/server/services/blocks/steps/output.ts
+++ b/src/server/services/blocks/steps/output.ts
@@ -1,0 +1,76 @@
+// ─────────────────────────────────────────────────────────────────────────────
+// Step OUTPUT extraction primitives — a LEAF module, imported by both the
+// registry (`./index`) and every entry (`./<name>.step`).
+//
+// 🔴 WHY THIS IS NOT IN `./index`. `index.ts` imports each entry to build the
+// registry object, so an entry importing a VALUE back out of `index.ts` is a
+// runtime import cycle. The existing `import type { BlockStep } from './index'`
+// is fine — types erase — but `mediaFromBlobs` is a real function, and a cycle
+// whose safety rests on function-declaration hoisting is one transpiler setting
+// away from a `undefined is not a function` on a read path. A leaf module has no
+// cycle to reason about.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * One piece of output media a registered step produced.
+ *
+ * Serves BOTH `workflow.service` extractors from one call, which is what makes
+ * "register a step" and "its result is retrievable" the same action:
+ * `snapshotFromWorkflow` reads `url`, `projectAppWorkflow` reads all four.
+ *
+ * `nsfwLevel` is the RAW orchestrator content-rating string (`'pg13'`, `'na'`,
+ * …), NOT the numeric civitai browsing-level bitflag. Mapping it is the
+ * projection's job and stays in exactly one place
+ * (`nsfwLevelFromContentRating`) — a registry entry must not be able to invent
+ * its own mapping.
+ */
+export type StepOutputMedia = {
+  url: string;
+  width: number | null;
+  height: number | null;
+  nsfwLevel: string | null;
+};
+
+/** The orchestrator blob shape every media-producing step output shares. */
+export type OrchestratorBlobLike = {
+  url?: string | null;
+  available?: boolean;
+  width?: number | null;
+  height?: number | null;
+  nsfwLevel?: string | null;
+};
+
+/**
+ * Blobs → `StepOutputMedia[]`, applying the availability + non-empty-url filter.
+ *
+ * 🔴 EXPORTED SO EVERY ENTRY USES ONE COPY OF THE FILTER. The rule — "only blobs
+ * that are `available` with a non-null url are surfaced; pending/blocked ones
+ * are dropped rather than handing the block dead links" — is the same rule the
+ * two `workflow.service` extractors already applied inline. A per-entry
+ * reimplementation is how one copy gets a fix and the others don't.
+ *
+ * Tolerates a single blob, a list, or absent: `convertImage` returns
+ * `{ blob }` (SINGULAR), `customComfy` returns `{ blobs }`.
+ */
+export function mediaFromBlobs(
+  blobs:
+    | OrchestratorBlobLike
+    | readonly (OrchestratorBlobLike | null | undefined)[]
+    | null
+    | undefined
+): StepOutputMedia[] {
+  const list: readonly (OrchestratorBlobLike | null | undefined)[] =
+    blobs == null ? [] : Array.isArray(blobs) ? blobs : [blobs as OrchestratorBlobLike];
+  const media: StepOutputMedia[] = [];
+  for (const blob of list) {
+    if (!blob) continue;
+    if (!blob.available || typeof blob.url !== 'string' || blob.url.length === 0) continue;
+    media.push({
+      url: blob.url,
+      width: typeof blob.width === 'number' ? blob.width : null,
+      height: typeof blob.height === 'number' ? blob.height : null,
+      nsfwLevel: typeof blob.nsfwLevel === 'string' ? blob.nsfwLevel : null,
+    });
+  }
+  return media;
+}

--- a/src/server/services/blocks/steps/type-contract.ts
+++ b/src/server/services/blocks/steps/type-contract.ts
@@ -4,9 +4,11 @@
  * checking the file, and a violated contract fails the build. "Using" them
  * somewhere would add runtime weight and prove nothing extra.
  */
+import type { ConvertImageOutput, ConvertImageStep, ImageBlob } from '@civitai/client';
 import type * as z from 'zod';
+import type { ConvertImageOutputStepLike } from './convert-image.step';
 import type { BlockStep } from './index';
-import type { StepOutputMedia } from './output';
+import type { OrchestratorBlobLike, StepOutputMedia } from './output';
 
 // ─────────────────────────────────────────────────────────────────────────────
 // COMPILE-TIME contract for the step registry: `billingMode` and
@@ -143,4 +145,79 @@ type _RequiresExtractOutput = Expect<
 // shipping the same inert capability.
 type _RequiresCanonicalOutput = Expect<
   NotAssignable<Omit<CompleteStep, 'canonicalOutputFor'>, BlockStep<Params>>
+>;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// OUTPUT-SHAPE ANCHORING — tie the hand-written read shapes to the GENERATED
+// orchestrator contract.
+//
+// 🔴 WHY, AND WHAT IT DOES *NOT* FIX. The registry's load-time clause 8 probes
+// `extractOutput(canonicalOutputFor(v))` — but BOTH sides of that probe are
+// authored by the same person in the same file, so it is a SELF-CONSISTENT PAIR,
+// not a contract check. It only catches an extractor that surfaces nothing for
+// its own sample; it cannot catch an extractor and a sample that agree with each
+// other while both being wrong about the orchestrator. Two escapes were
+// reproduced: an extractor that ignores its argument paired with
+// `canonicalOutputFor: () => ({})`, and an extractor reading `output.images`
+// paired with a sample that also encodes `output.images`. Both register cleanly.
+//
+// The assertions below close that for `convert-image` specifically, by making
+// `@civitai/client`'s generated types — which Civitai does not hand-write — the
+// authority for the shape the extractor reads.
+//
+// 🔴 HONEST LIMIT: this does NOT make clause 8 a general guard. A FUTURE entry
+// still supplies its own read shape and its own sample, and nothing here forces
+// it to add an assertion of its own — the escape stays open for entry #2. What
+// is anchored is the one registered entry. Making the anchoring REQUIRED for
+// every entry needs a `$type` → generated-step-type mapping the registry can
+// consult at the type level; `@civitai/client` exports no discriminated union of
+// all step types (only the individual `<Name>Step` aliases), so that map would
+// itself be hand-written — which is why it is proposed rather than built here.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * A REAL `ConvertImageStep` must satisfy the hand-written shape `extractOutput`
+ * casts to. This is the assertion that fails if the generated output type ever
+ * changes in a way the extractor's read would not survive (a retyped `url`, a
+ * `blob` that stops being optional-nullable, and so on).
+ */
+type _RealConvertImageStepSatisfiesReadShape = Expect<
+  ConvertImageStep extends ConvertImageOutputStepLike ? true : false
+>;
+
+/**
+ * Every key the read shape declares under `output` must EXIST on the generated
+ * `ConvertImageOutput`.
+ *
+ * 🔴 This is the assertion that catches the exact shipped-bug shape (reading
+ * `blobs` where the orchestrator returns `blob`). Assignability alone does not:
+ * a read shape whose properties are all optional is satisfied by anything, so
+ * renaming `blob` → `blobs` would still compile against the assertion above.
+ * `keyof` is what makes the key name itself load-bearing.
+ */
+type _ConvertImageReadKeysExist = Expect<
+  keyof NonNullable<ConvertImageOutputStepLike['output']> extends keyof ConvertImageOutput
+    ? true
+    : false
+>;
+
+/** Same, one level down: every blob field the extractor reads is a real `ImageBlob` field. */
+type _ConvertImageBlobReadKeysExist = Expect<
+  keyof NonNullable<
+    NonNullable<ConvertImageOutputStepLike['output']>['blob']
+  > extends keyof ImageBlob
+    ? true
+    : false
+>;
+
+/**
+ * The SHARED filter's input contract, anchored once for every entry that uses it.
+ * `mediaFromBlobs` is the one copy of the availability + non-empty-url rule, and
+ * `OrchestratorBlobLike` is the shape it promises to handle — so a real
+ * `ImageBlob` must be assignable to it. Unlike the three above, this assertion
+ * is not entry-specific: it covers any future entry that feeds a generated blob
+ * through `mediaFromBlobs`.
+ */
+type _MediaFromBlobsAcceptsGeneratedImageBlob = Expect<
+  ImageBlob extends OrchestratorBlobLike ? true : false
 >;

--- a/src/server/services/blocks/steps/type-contract.ts
+++ b/src/server/services/blocks/steps/type-contract.ts
@@ -1,0 +1,104 @@
+/* eslint-disable @typescript-eslint/no-unused-vars --
+ * Every declaration in this file is INTENTIONALLY unused at runtime. The
+ * assertions are the type aliases themselves: `tsc` evaluates each one while
+ * checking the file, and a violated contract fails the build. "Using" them
+ * somewhere would add runtime weight and prove nothing extra.
+ */
+import type * as z from 'zod';
+import type { BlockStep } from './index';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// COMPILE-TIME contract for the step registry: `billingMode` and
+// `moderationPosture` are REQUIRED, the mode must be one of the three declared
+// values, and each mode must supply its OWN price/budget accessor. Omitting any
+// of these is a BUILD failure, not a runtime one.
+//
+// 🔴 WHY THIS FILE IS NOT UNDER `__tests__/`. `tsconfig.json` EXCLUDES
+// `src/**/__tests__/**`, and `pnpm run typecheck` (the blocking CI job) is
+// `tsc --noEmit` against that config — so a type-level test placed in
+// `__tests__/` is never typechecked by anything. It would sit there looking like
+// a guarantee, pass every run, and be incapable of ever failing. (That is
+// exactly what the first draft of this file was, and a clean `tsc` run "proving"
+// it worked was the tell that it did not.) Vitest does not typecheck either, so
+// there is no second mechanism to fall back on. Living here — inside the
+// `src` include — is what makes these assertions real.
+//
+// Everything below is TYPE-ONLY: no values, no exports with runtime
+// representation, so this module compiles to nothing and adds no bundle weight.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Compiles only when `T` is exactly `true`. */
+type Expect<T extends true> = T;
+
+/** `true` when `T` is NOT assignable to `U` — i.e. `U` genuinely requires more. */
+type NotAssignable<T, U> = [T] extends [U] ? false : true;
+
+type Params = { value: number };
+type ParamSchema = z.ZodType<Params>;
+
+/** A complete, well-formed entry. The CONTROL for every negative case below. */
+type CompleteStep = {
+  id: string;
+  orchestratorType: string;
+  billingMode: 'prepaidFixed';
+  moderationPosture: 'none';
+  paramSchema: ParamSchema;
+  variants: readonly string[];
+  resolveVariant(params: Params): string;
+  canonicalParamsFor(variant: string): Params;
+  priceForVariant(variant: string): number;
+  estimateBuzz(params: Params): number;
+  buildStep(params: Params): { $type: string; input: Record<string, unknown> };
+};
+
+// 🔴 THE CONTROL. If this ever stops compiling, every assertion below is
+// meaningless — they would all "pass" because the BASE shape is broken, not
+// because the field under test is missing.
+type _Control = Expect<CompleteStep extends BlockStep<Params> ? true : false>;
+
+// ── `billingMode` is REQUIRED ────────────────────────────────────────────────
+// It drives estimate/submit/settle dispatch; an entry without one has no money
+// path at all.
+type _RequiresBillingMode = Expect<
+  NotAssignable<Omit<CompleteStep, 'billingMode'>, BlockStep<Params>>
+>;
+
+// ── `moderationPosture` is REQUIRED ──────────────────────────────────────────
+// 🔴 This is the mechanism that makes registering a text-producing step
+// (`chatCompletion`, captioning, transcription) impossible without someone
+// explicitly answering the moderation-policy question in code. If this assertion
+// ever fails, the field became optional and that question became skippable.
+type _RequiresModerationPosture = Expect<
+  NotAssignable<Omit<CompleteStep, 'moderationPosture'>, BlockStep<Params>>
+>;
+
+// ── the mode must be one of the three DECLARED values ────────────────────────
+type _RejectsUnknownBillingMode = Expect<
+  NotAssignable<
+    Omit<CompleteStep, 'billingMode'> & { billingMode: 'freeForAll' },
+    BlockStep<Params>
+  >
+>;
+
+// ── each mode must supply its OWN price/budget accessor ──────────────────────
+// A `prepaidFixed` entry without `priceForVariant` has nothing to reserve; a
+// `timeBounded` one without `budgetForVariant` has no ceiling. The discriminated
+// union is what makes both a compile error rather than an `undefined is not a
+// function` on the spend path.
+type _PrepaidFixedNeedsPrice = Expect<
+  NotAssignable<Omit<CompleteStep, 'priceForVariant'>, BlockStep<Params>>
+>;
+
+type _TimeBoundedNeedsBudget = Expect<
+  NotAssignable<
+    Omit<CompleteStep, 'billingMode' | 'priceForVariant'> & { billingMode: 'timeBounded' },
+    BlockStep<Params>
+  >
+>;
+
+type _TokenMeteredNeedsMaxBuzz = Expect<
+  NotAssignable<
+    Omit<CompleteStep, 'billingMode' | 'priceForVariant'> & { billingMode: 'tokenMetered' },
+    BlockStep<Params>
+  >
+>;

--- a/src/server/services/blocks/steps/type-contract.ts
+++ b/src/server/services/blocks/steps/type-contract.ts
@@ -6,6 +6,7 @@
  */
 import type * as z from 'zod';
 import type { BlockStep } from './index';
+import type { StepOutputMedia } from './output';
 
 // ─────────────────────────────────────────────────────────────────────────────
 // COMPILE-TIME contract for the step registry: `billingMode` and
@@ -42,6 +43,7 @@ type CompleteStep = {
   orchestratorType: string;
   billingMode: 'prepaidFixed';
   moderationPosture: 'none';
+  resourcePolicy: { kind: 'none' };
   paramSchema: ParamSchema;
   variants: readonly string[];
   resolveVariant(params: Params): string;
@@ -49,6 +51,8 @@ type CompleteStep = {
   priceForVariant(variant: string): number;
   estimateBuzz(params: Params): number;
   buildStep(params: Params): { $type: string; input: Record<string, unknown> };
+  extractOutput(step: unknown): StepOutputMedia[];
+  canonicalOutputFor(variant: string): unknown;
 };
 
 // 🔴 THE CONTROL. If this ever stops compiling, every assertion below is
@@ -101,4 +105,42 @@ type _TokenMeteredNeedsMaxBuzz = Expect<
     Omit<CompleteStep, 'billingMode' | 'priceForVariant'> & { billingMode: 'tokenMetered' },
     BlockStep<Params>
   >
+>;
+
+// ── `resourcePolicy` is REQUIRED ─────────────────────────────────────────────
+// 🔴 The ENTITLEMENT axis. `BlockRecipe` carried `resourceAllowlist` +
+// `checkpointPolicy` and the first draft of this generalization dropped both —
+// while the PR's own triage disqualified `imageUpscaler` precisely because its
+// arbitrary-AIR `model` field would reach the orchestrator around the
+// generation-graph entitlement belt. If this assertion ever fails, the field
+// became optional and a future AIR-taking entry can register without declaring
+// anything.
+type _RequiresResourcePolicy = Expect<
+  NotAssignable<Omit<CompleteStep, 'resourcePolicy'>, BlockStep<Params>>
+>;
+
+// ── the policy must be one of the DECLARED shapes ────────────────────────────
+type _RejectsUnknownResourcePolicy = Expect<
+  NotAssignable<
+    Omit<CompleteStep, 'resourcePolicy'> & { resourcePolicy: { kind: 'anythingGoes' } },
+    BlockStep<Params>
+  >
+>;
+
+// ── `extractOutput` is REQUIRED ──────────────────────────────────────────────
+// 🔴 This is what makes "register a step" and "its result is retrievable" ONE
+// action. Without it, both `workflow.service` extractors `continue` past the new
+// `$type` and the capability is inert AFTER the caller has been charged — which
+// is exactly what shipped. If this assertion ever fails, a new entry can be
+// registered with no way to return its output.
+type _RequiresExtractOutput = Expect<
+  NotAssignable<Omit<CompleteStep, 'extractOutput'>, BlockStep<Params>>
+>;
+
+// ── `canonicalOutputFor` is REQUIRED ─────────────────────────────────────────
+// The probe input for the load-time extraction invariant. Without it,
+// `extractOutput` could be satisfied by `() => []` — compiling, registering, and
+// shipping the same inert capability.
+type _RequiresCanonicalOutput = Expect<
+  NotAssignable<Omit<CompleteStep, 'canonicalOutputFor'>, BlockStep<Params>>
 >;

--- a/src/server/services/blocks/workflow.service.ts
+++ b/src/server/services/blocks/workflow.service.ts
@@ -908,7 +908,7 @@ export const BLOCK_CUSTOM_COMFY_STEP_NAME = 'block-custom-comfy';
 
 // Format a whole-second timeout as the orchestrator's `HH:MM:SS` step-timeout
 // string (WorkflowStep.timeout). 180 → '00:03:00'.
-function formatStepTimeout(totalSeconds: number): string {
+export function formatStepTimeout(totalSeconds: number): string {
   const s = Math.max(0, Math.ceil(totalSeconds));
   const pad = (n: number) => String(n).padStart(2, '0');
   return `${pad(Math.floor(s / 3600))}:${pad(Math.floor((s % 3600) / 60))}:${pad(s % 60)}`;

--- a/src/server/services/blocks/workflow.service.ts
+++ b/src/server/services/blocks/workflow.service.ts
@@ -1,6 +1,7 @@
 import { TRPCError } from '@trpc/server';
 import type { CustomComfyStepTemplate, Workflow, WorkflowStatus } from '@civitai/client';
 import type { AnyBlockRecipe, CustomComfyStepInput, ResolvedRecipeResources } from './recipes';
+import { getStepByOrchestratorType } from './steps';
 import type { BuzzSpendType } from '~/shared/constants/buzz.constants';
 import { dbRead } from '~/server/db/client';
 import { nsfwLevelFromContentRating } from '~/shared/constants/browsingLevel.constants';
@@ -53,6 +54,25 @@ export function snapshotFromWorkflow(workflow: Workflow): BlockWorkflowSnapshot 
         if (blob.available && typeof blob.url === 'string' && blob.url.length > 0) {
           imageUrls.push(blob.url);
         }
+      }
+      continue;
+    }
+    // A REGISTERED step type (`kind: 'step'`) declares its OWN output extraction
+    // in its registry entry, because the output key is step-type-specific —
+    // `convertImage` returns `{ blob }` (SINGULAR). Without this branch the
+    // native `$type` filter below `continue`s on every registered step and its
+    // result is unreachable: the caller is charged, the workflow reaches
+    // `succeeded`, and `imageUrls` is absent on every poll.
+    //
+    // 🔴 ADDITIVE BY CONSTRUCTION. A registry entry may not claim one of the
+    // natively-extracted `$type` values (`NATIVELY_EXTRACTED_STEP_TYPES`,
+    // enforced at registry load), so this branch cannot shadow the customComfy /
+    // textToImage / imageGen / comfy behaviour below — it only reaches `$type`s
+    // that used to fall through to `continue`.
+    const registeredStep = getStepByOrchestratorType(step.$type);
+    if (registeredStep) {
+      for (const media of registeredStep.extractOutput(step)) {
+        imageUrls.push(media.url);
       }
       continue;
     }
@@ -169,6 +189,29 @@ export function projectAppWorkflow(workflow: Workflow): AppWorkflow {
           nsfwLevel:
             blob.nsfwLevel && blob.nsfwLevel !== 'na'
               ? nsfwLevelFromContentRating(blob.nsfwLevel)
+              : null,
+        });
+      }
+      continue;
+    }
+    // A REGISTERED step type — same registry-declared extraction the snapshot
+    // uses, so a capability is retrievable on BOTH read surfaces from ONE
+    // declaration. Without it `queryAppWorkflows` returns `images: []` for a
+    // step the app paid for. See the snapshotFromWorkflow branch for why this is
+    // additive and cannot shadow the native `$type`s below.
+    const registeredStep = getStepByOrchestratorType(step.$type);
+    if (registeredStep) {
+      for (const media of registeredStep.extractOutput(step)) {
+        images.push({
+          url: media.url,
+          width: media.width,
+          height: media.height,
+          // The RAW orchestrator rating string is mapped by the SAME canonical
+          // helper the native branches use — the registry hands over the string,
+          // never a bitflag, so the mapping stays in one place.
+          nsfwLevel:
+            media.nsfwLevel && media.nsfwLevel !== 'na'
+              ? nsfwLevelFromContentRating(media.nsfwLevel)
               : null,
         });
       }


### PR DESCRIPTION
Implements [#3515](https://github.com/civitai/civitai/issues/3515) migration **steps 1 and 2**: land the step-type registry + `kind: 'step'` alongside the existing union members, and register a verified Tranche 1.

Unblocks the shape question ahead of [#3527](https://github.com/civitai/civitai/issues/3527) — though `chatCompletion` itself is explicitly **not** enabled by this PR (see Moderation posture below).

---

## 🔴 Task 0 first: what is actually exposable

The RFC named Tranche 1 as *"background removal, upscale, convert"* and flagged it as **inferred, not verified**. I enumerated every `$type` in the orchestrator's generated types (`@civitai/client@0.2.0-beta.83`, `dist/generated/types.gen.d.ts` — **43 distinct `$type` values**, alongside **47** standalone `/v2/consumer/recipes/<name>` endpoints; the endpoint list is a superset, since a few step *templates* have an endpoint without appearing as a `$type` in a Step union) and checked each against four bars:

1. a genuine standalone orchestrator `$type` (not an internal helper, not a Comfy workflow feature)
2. **deterministic cost knowable before execution** (`prepaidFixed`)
3. **no new moderation surface** — nothing with a free-text output
4. no checkpoint/LoRA entitlement entanglement

**Correction to the premise in both directions.** `imageBackgroundRemoval` and `imageUpscaler` **do** exist as first-class `$type` values with standalone `/v2/consumer/recipes/<name>` endpoints — they are not missing. But neither qualifies for Tranche 1:

| Step type | Verdict | Why |
|---|---|---|
| **`convertImage`** | ✅ **REGISTERED** | Standalone `$type` + consumer-recipe endpoint. Pure CPU format conversion + resize: no GPU model, no sampler, no step count, no wall-clock dependence. Output is an image blob, input is a bounded image URL → no free-text either side. References no AIR resource at all. Already submitted server-side as a single-step workflow by `product-badge.service.ts`, so the shape is proven in production. |
| `imageBackgroundRemoval` | ❌ fails bar 2 | The client's **own doc string**: *"removes the background from an image using BiRefNet (**builds a ComfyUI graph under the hood and runs it as a comfy job**)"*. That is GPU work with variable duration — `timeBounded`, not a deterministic price. Strong Tranche 2 candidate. |
| `imageUpscaler` | ❌ fails bars 2 and 4 | GPU work, and `numberOfRepeats` (1–3, each doubling resolution) makes cost input-dependent. Separately, `model` takes an **arbitrary AIR URN** — an AIR chosen by an untrusted iframe reaches the orchestrator without the generation-graph entitlement belt, the same bypass class the `customComfy` `resources` array carries. Needs a resource gate before exposure. |
| `imageToSvg` | ❌ fails bar 2 | *"using a local StarVector or OmniSVG model"* — model inference. |
| `mediaHash` | ⚠️ **passes all four, deliberately not registered** | Standalone `$type` + consumer endpoint, deterministic CPU hashing, bounded hash-string output, no resources. But it has no demonstrated developer demand, and every registered id is a permanent public wire commitment. Adding it later is one file + one registry line — which is the entire point of the registry. Not padding the tranche to hit a number. |
| `transcode` | ❌ | `destinationUrl` is a caller-supplied write target (SSRF/write primitive). |
| `chatCompletion`, `mediaCaptioning`, `audioCaptioning`, `transcription`, `promptEnhancement`, `textToSpeech` | ❌ bar 3 | Free-text output (or free-text input, for TTS) — a new moderation surface. Out regardless of convenience. |
| `mediaRating`, `ageClassification`, `wdTagging`, `xGuardModeration` | ❌ policy | Moderation classifiers. Exposing them lets an app probe the moderation stack — a policy call, not an engineering one. |
| `preprocessImage` | ❌ bar 1 | Internal helper `controlnets.helper.ts` emits in front of a generation. |
| `textToImage`, `imageGen`, `comfy`, `customComfy`, `videoGen`, `polyGen`, `aceStepAudio`, `videoUpscaler`, `videoEnhancement`, `videoInterpolation`, `videoBackgroundRemoval` | ❌ bar 2/4 | GPU generation: timeBounded + entitlement. |
| `training`, `imageResourceTraining`, `model*Scan`, `modelHash`, `modelParseMetadata`, `comfyNodepackSnapshot`, `qwenImageBench`, `blobArchive`, `imageUpload`, `composeMedia`, `echo`, `videoFrameExtraction`, `videoMetadata`, `repeat`, `humanoidImageMask`, `tryOnU`, `batchOCRSafetyClassification`, `model3DPreview` | ❌ bar 1 | Internal/infra plumbing. |

**Tranche 1 = `convert-image` only.**

---

## The registry

`src/server/services/blocks/steps/` — a generalization of `BlockRecipe`, keeping its security posture verbatim: a **code-reviewed, non-DB-editable trust root** (no DB access, loads at import time before any request context), whose **keys derive the wire enum**, so an unregistered id fails closed at the schema before any translator, spend reservation, or orchestrator call.

### The three required fields

**1. `billingMode: 'timeBounded' | 'prepaidFixed' | 'tokenMetered'` — required.**
All three values are declared now even though Tranche 1 only uses one. That is the point: the wire contract and type surface are the expensive things to change once the SDK mirrors them, so future step types must be *additive*. A mode with no implemented money-path handler **fails at registry load**, so it can never silently ride another mode's reservation logic.

**2. `prepaidFixed` gets its OWN enforced load-time invariant — not an exemption.**
The existing `maxBuzz === ceil(stepTimeoutSeconds)` invariant works because a step timeout is a *physical* cap at ~1 Buzz/GPU-second. A fixed-price step has no such time relationship and cannot satisfy it. If `prepaidFixed` entries simply *skipped* the check, the registry's structural guard would still exist but would no longer be reachable for the new class — the worst outcome, because the registry would look guarded while new entries were not. So `prepaidFixed` declares an equivalent invariant, validated at load with the same fail-fast shape:

```
for every variant v:
  priceForVariant(v) is a positive safe integer
  estimateBuzz(canonicalParamsFor(v)) === priceForVariant(v)
```

The second clause is the money-relevant one: the price is what gets **reserved against every cap**, `estimateBuzz` is what the app is **shown**. A divergence means the block quotes one number and the viewer is charged another. Evaluating it needs real params, which is why entries declare `canonicalParamsFor(variant)` — the same reason `budgetForEngine` exists on `BlockRecipe` (the load loop enumerates without a request context).

**3. `moderationPosture: 'none' | 'promptAudit' | 'textOutput'` — required.**
Only `'none'` has an implemented handler; the other two fail at registry **load**. Registering `chatCompletion` (or captioning, or transcription) is therefore impossible without someone explicitly answering the policy question in code. **That policy decision is not made here and is out of scope** — this PR only makes it unskippable. Enforced twice: at load, and again as a compile error (below).

Plus: **every `paramSchema` must be `.strict()`**, probed behaviourally at load (`{...canonicalParams, <probe key>}` must be rejected). `blockTextToImageBodySchema` is *not* strict, and that non-strictness is exactly what let an older host silently strip `sourceImages` and bill the wrong generation. A dropped param on a money path is a wrong-generation bug, not a validation nit.

### Guard ordering is load-bearing

The per-variant budget invariants run **before** the implemented-billing-mode gate, deliberately. With the gate first, the `timeBounded` / `tokenMetered` budget branches were **structurally unable to execute** — the gate rejects every such entry, so no mutation could ever kill them. The first mutation sweep caught exactly this; reordering made them genuinely reachable and mutation-proven (M20–M22 below).

---

## 🔴 The money path

A step submit runs the **same cap belt** as every other spending kind, reserved **before** the orchestrator submit and refunded on every non-committed exit:

1. static per-call `buzzBudget` gate (exact for `prepaidFixed` — the price is known before execution)
2. gen-idempotency claim
3. per-user cumulative daily cap
4. 🔴 **per-app aggregate `reserveAppSpend`** — daily Buzz + velocity
5. dev-session backstop

If `kind: 'step'` bypassed (4), this PR would open a new money surface the guardrail cannot see — and `civitai_app_block_spend_cap_rejections_total` would not fire for it either, so the gap would also be invisible in monitoring. Mutation-proven: bypassing the reserve kills 7 tests (M1).

`prepaidFixed` never touches the post-paid settle machinery — the price is exact, so the reservation is final, no settle record is persisted, and the terminal poll/cancel hook has nothing to read.

### The price is now MEASURED, and the ceiling no longer depends on it

**Two live calls against the PR preview's orchestrator (2026-08-02):**

| call | result |
|---|---|
| `POST /v2/consumer/workflows?whatif=true`, one `convertImage` step | HTTP 200, `cost: {base:1, factors:{base:1}, fixed:{}, tips:{...}, **total: 1**}` |
| real (non-whatif) submit of the same step, polled to `succeeded` | HTTP 202, `status: processing`, `cost.total: 1`; per-job `cost: 1` |

**The orchestrator's real price for `convertImage` is 1 Buzz.** `CONVERT_IMAGE_PRICE_BUZZ = 1` was correct — it is no longer a guess.

🔴 **The earlier residual statement in this PR was wrong, in the direction that costs money, and is retracted.** It said the *first* divergent submit could exceed the per-call budget. In fact the divergence correction only ever adjusted the **cap counters** — it never touched the declared price or the static gate — so **every** submit would have exceeded `buzzBudget` by the overage, forever, until a human read the metric and shipped code.

That is fixed structurally rather than by trusting the measurement. This was the **first** block spend path whose per-call ceiling rested solely on a number Civitai asserted: `textToImage` submit issues a real `submitWorkflow(…, query:{whatif:true})` and gates on the orchestrator's own quote, and `customComfy` stamps a step `timeout` the orchestrator physically enforces as the Buzz ceiling. The step path did neither — `stepTimeoutSeconds` is deliberately `null` for `prepaidFixed`.

**Submit now runs a real `whatif:true` quote BEFORE the per-call budget gate** and reserves `max(declared, quoted)`:

- `prepaidFixed` means *"cost knowable before execution"* — which is exactly what `whatif:true` returns. Asking the orchestrator is not a workaround for the mode; it is the mode's own premise made enforceable.
- The quote is free, side-effect-free and carries **no `externalId`** (the idempotency key belongs to the real submit only — mirrors the txt2img whatIf preflight).
- **Fail-closed on an unquotable step**: a missing quote means the premise did not hold, which puts the ceiling back on the unenforced constant. Returns a recoverable failed-shape snapshot and counts `outcome: 'absent'`.
- Ordering is `quote → budget gate → per-user cap → per-app cap → dev session → real submit` — **byte-for-byte the ordering `textToImage` has used since before this PR**. The accepted cost: a cap-rejected or replayed submit now makes one extra free orchestrator call, exactly as txt2img already does.

The declared price stays as the **floor** (it is what `estimateBuzz` showed the block, and the load-time invariant forces those to agree); the quote raises it when the rate card moves.

## Dispatch

estimate/submit/settle dispatch on **`billingMode`**, via `estimateStepBuzz(entry, params)` / `planStepSpend(entry, params)`. Verified structurally: the two handlers (~440 lines) contain **zero** code references to `billingMode`, a mode literal, or a step id — every occurrence is in a comment. Adding a capability = one file + one registry line. Adding a *mode* = one handler in the registry module. Neither is router surgery.

---

## Explicitly out of scope

- **`customComfy` is NOT migrated behind the registry.** RFC migration step 3.
- **`textToImage` stays its own `kind`** — entitlement over checkpoint *and* LoRA stack, availability gates, model-token binding, page-only `sourceImage`, `accountType` ordering, `sharedContentKey`, POI.
- **No SDK changes.** `@civitai/app-sdk` mirroring is a separate PR after the host deploys (the #205 lesson: an SDK shipped before the host silently strips the field).
- **Scopes stay coarse** — `ai:write:budgeted` gates all generation.
- ~~`snapshotFromWorkflow` is **not** modified~~ — **superseded.** It (and `projectAppWorkflow`) now carry an ADDITIVE registry branch; see "Output extraction" below. ⚠️ **PR #3535 also touches `snapshotFromWorkflow`** — the overlap is one inserted branch placed *before* the native `$type` filter and *after* the `customComfy` branch; no existing line is modified. Re-read the merged region rather than trusting a clean textual merge.

### Rebase notes for in-flight PRs

- **#3535** adds a required 4th `surface` param to `buildGenerationContext`. **This PR's step path never calls that function**, so no `'block'` argument is needed on rebase. It does *call* `snapshotFromWorkflow` (reading only the existing `workflowId` / `status` / `cost.total` fields), so if #3535 changes that return shape, the divergence check and audit writes are the places to re-read.

---

## Verification

**tsc** — `tsc --noEmit` at HEAD and at `origin/main` in the same environment produce a **byte-identical** 6-error set (all pre-existing: ungenerated Prisma client + a `@civitai/shared` build artifact — `prisma generate` cannot run on this NixOS box). **Zero new errors.**

**Tests** — same globs as baseline (`src/server/services/blocks`, `src/server/schema/blocks`, `src/server/routers/__tests__`):

| | Files | Tests |
|---|---|---|
| `origin/main` | 147 | 3141 |
| HEAD | 149 | 3200 |
| **delta** | **+2** | **+59** |

+59 = 24 registry + 9 wire-schema + 26 router money-path. Counted from `--reporter=verbose`, not from an exit code.

The pre-existing 51-test suite covering the moved SSRF/URL predicate (backslash-in-authority, TAB in host, CRLF in host, CR/LF elsewhere, NUL and other C0 bytes, backslash in path, canonicalization round-trip) passes untouched — evidence the extraction is behaviour-preserving.

**eslint / prettier** — added files: clean on both. Modified files: eslint error count identical to baseline (16 → 16, all pre-existing `no-explicit-any`); prettier's unformatted-file set is identical to baseline (3 files, pre-existing), and every hunk **inside the regions this PR adds** is prettier-conformant.

### Mutation table

Every guard was broken on purpose, its test file re-run, and the file restored from a **byte-exact backup with a sha256 equality check** (never a `str.replace` revert). All 22 mutations were killed; each by a test whose assertion names the mutated guard.

| # | Mutation | Test that failed | Killing assertion |
|---|---|---|---|
| M1 | bypass `reserveAppSpend` on the step submit path | *reserves the EXACT declared price on the per-user daily cap AND the PER-APP cap* (+6 more) | `expected "vi.fn()" to be called with arguments: [ 'apb_test', 1 ]` |
| M2 | drop the per-app refund on the submit-throw path | *refunds the PER-APP reservation when the orchestrator submit throws* | `expected "vi.fn()" to be called with arguments: [ …(2) ]` |
| M3 | drop the static per-call budget gate | *an over-budget price fails the STATIC gate before any reservation or submit* | `expected 'wf_step_1' to be 'failed'` |
| M4 | drop the price-divergence correction | *CORRECTS both cap counters when the orchestrator bills ABOVE the declared price* | `expected "vi.fn()" to be called with arguments: [ …(2) ]` |
| M5 | flip `prepaidFixed` to `postPaidSettle: true` | *does NOT touch the post-paid settle machinery* | `expected "vi.fn()" to not be called at all, but actually been called 1 times` |
| M6 | drop the page-only guard | *REJECTS a model token* + *a MODEL token is rejected fail-closed BEFORE any spend* | `promise resolved "{ snapshot: { …(3) } }" instead of rejecting` |
| M7 | drop the registry-key === `step.id` guard | *rejects a registry key that disagrees with step.id* | `expected [Function] to throw an error` (regex `/registry key must equal step\.id/`) |
| M8 | drop the implemented-billing-mode guard | *rejects a billing mode with no implemented money-path handler* (+2) | `expected [Function] to throw an error` |
| M9 | drop the implemented-moderation-posture guard | *rejects a moderation posture with no implemented handler* | `expected [Function] to throw an error` |
| M10 | drop the non-empty-variants guard | *rejects an entry declaring no variants* | `expected [Function] to throw an error` |
| M11 | drop the canonical-params-parse guard | *rejects canonical params that do not satisfy the param schema* | `expected [Function] to throw an error` |
| M12 | drop the plain-object guard | *rejects canonical params that are not a plain object* | `expected [Function] to throw an error` |
| M13 | drop the `.strict()` probe guard | *rejects a paramSchema that is NOT .strict()* | `expected [Function] to throw an error` |
| M14 | drop the variant-resolution guard | *rejects canonical params that resolve to a DIFFERENT variant* | `expected [Function] to throw an error` |
| M15 | drop the `prepaidFixed` positive-integer-price guard | *rejects a prepaidFixed price that is not a positive integer* | `expected [Function] to throw error matching /prepaidFixed price \(0\) must be a po…/ but got 'block step 'fixture-step' variant …'` |
| M16 | drop the `prepaidFixed` estimate===price guard | *rejects a prepaidFixed estimate that disagrees with the declared price* | `expected [Function] to throw an error` |
| M17 | make `timeBounded` silently ride `prepaidFixed`'s logic | *routes a fixture entry with a DIFFERENT billing mode* + *the dispatcher is TOTAL* | `expected 'undefined' to contain 'billing mode 'timeBounded' has no m…'` |
| M18 | hardcode the step-id enum instead of deriving it | *derives its id enum from the registry keys* | `expected false to be true` |
| M19 | drop `.strict()` from the step wire body | *REJECTS an unknown top-level field* | `expected true to be false` |
| M20 | drop the `timeBounded` maxBuzz===ceil(timeout) guard | *enforces the timeBounded maxBuzz === ceil(stepTimeoutSeconds) invariant* | `expected [Function] to throw error matching /timeBounded maxBuzz \(90\) must equal…/ but got 'block step 'fixture-step': billingM…'` |
| M21 | drop the `timeBounded` positive-timeout guard | *(same test)* | `expected [Function] to throw error matching /timeBounded stepTimeoutSeconds \(0\) …/ but got 'block step 'fixture-step': billingM…'` |
| M22 | drop the `tokenMetered` positive-maxBuzz guard | *enforces the tokenMetered positive-maxBuzz invariant* | `expected [Function] to throw error matching /tokenMetered maxBuzz \(0\) must be a …/ but got 'block step 'fixture-step': billingM…'` |

M15 and M20–M22 are the interesting rows: with the guard removed the fixture falls through to a *neighbouring* guard and still throws — and the test fails anyway, because it demands **its own guard's message**. That is the difference between "a test failed" and "this guard is tested".

**Compile-time contract, also mutation-proven.** 🔴 The first draft put the type-level assertions in `__tests__/` — where they were **never typechecked**, because `tsconfig.json` excludes `src/**/__tests__/**` and `pnpm run typecheck` is `tsc --noEmit` against that config. A clean `tsc` run "proving" they worked was the tell that they could not fail. They now live in `src/server/services/blocks/steps/type-contract.ts` (inside the `src` include, type-only so it compiles to nothing), and were verified by mutation:

| Mutation | Result |
|---|---|
| `billingMode?:` optional on the `PrepaidFixedStep` member | ✅ `type-contract.ts(57,3): error TS2344` (`_RequiresBillingMode`) |
| `moderationPosture?:` optional | ✅ `type-contract.ts(66,3): error TS2344` (`_RequiresModerationPosture`) |
| widen `billingMode` to `string` | ✅ `type-contract.ts(71,3): error TS2344` (`_RejectsUnknownBillingMode`) |
| `priceForVariant?:` optional | ✅ `type-contract.ts(83,3): error TS2344` (`_PrepaidFixedNeedsPrice`) |

*(One earlier mutation — making `billingMode` optional on the shared **base** interface — did **not** kill, correctly: each union member redeclares the field, so the base modifier is overridden. The mutation was wrong, not the guard; re-run against the member, it kills.)*

### What I could NOT verify

- **End-to-end through the block bridge itself.** The two orchestrator calls above were made directly against the preview's orchestrator with the preview's own token (`ORCHESTRATOR_MODE=dev`, so a block submit uses that same token) — not driven through a real iframe holding a real block JWT. The step's own submit path is covered by mocked tests only.
- **The real wire contract as an app author sees it** — blind validation by the #3527 author against the preview host is still worth more than any of the above.
- **A `timeBounded` / `tokenMetered` entry end-to-end.** Both modes fail at registry load by design, so their handlers have never executed against a real orchestrator.
- Browser/component tests were not run (node project only; unchanged by this PR).

---

# Fix round — adversarial audit response

Two blockers and six supporting fixes. Everything the audit confirmed by execution is preserved: the derived enum, the load-time fail-closed invariants, `type-contract.ts` being genuinely typechecked and able to fail, complete refund coverage on every exit, and byte-identical behaviour for `textToImage` / `customComfy` (re-proved below).

## 🔴 FIX 1 — the only registered capability's output was unreachable

`snapshotFromWorkflow` (~:59) and `projectAppWorkflow` (~:177) both `continue`d on any `$type` outside `customComfy | textToImage | imageGen | comfy`. `convertImage`'s output is **`{ blob?: ImageBlob }` — SINGULAR `blob`**, not `images` and not `blobs`. Both extractors were blind in **two independent ways**: the `$type` *and* the key. An app would submit, be charged, poll to `succeeded`, and find `snapshot.imageUrls` absent on every poll while `queryAppWorkflows` returned `images: []`. It paid for a result it could never retrieve.

**Fixed registry-driven, not with a fourth hardcoded branch.** A one-off `if ($type === 'convertImage')` would fix today and guarantee the next entry repeats it — this was the third instance of the class.

Two new **required** fields on `BlockStepBase`:

| field | what it does |
|---|---|
| `extractOutput(step): StepOutputMedia[]` | the entry declares its own extraction. One call serves BOTH read surfaces: the snapshot reads `url`, the projection reads `url`/`width`/`height`/`nsfwLevel`. Registering a step and surfacing its result are now **one action**. |
| `canonicalOutputFor(variant)` | a canonical **completed** step for the load-time probe. Without it `extractOutput` could be satisfied by `() => []` — compiling, registering, and shipping the same inert capability. |

Both are **compile-enforced** (`type-contract.ts`, mutation-proven below) *and* probed at registry load (clause 8: `extractOutput(canonicalOutputFor(v))` must yield ≥1 media with a non-empty url). So a new entry that gets this wrong is a **build or load failure**, never a silent inert capability.

Supporting pieces:

- **`mediaFromBlobs`** in a new leaf module `steps/output.ts` — ONE copy of the availability filter every entry uses. A leaf module, not `steps/index.ts`, because an entry importing a *value* back out of `index.ts` is a runtime import cycle whose safety would rest on function-declaration hoisting.
- **`getStepByOrchestratorType`** — the lookup both extractors use (a returned Workflow carries the `$type`, never the registry id), with cross-entry uniqueness enforced at load.
- 🔴 **Clause 9 forbids a registered entry from claiming a natively-extracted `$type`.** That is what makes placing the registry branch *before* the native `$type` filter provably behaviour-preserving — it can only reach `$type`s that previously fell through to `continue`.
- `convertImage`'s `canonicalOutputFor` is **copied from a real captured orchestrator response**, not written to match the extractor. A sample derived from the code would prove only that the code agrees with itself.

## 🔴 FIX 2 — the per-call `buzzBudget` ceiling was unenforced, permanently

See "The price is now MEASURED" above. The PR's earlier residual statement is retracted and corrected there.

## 🟡 FIX 3 — the registry had no entitlement declaration

`BlockRecipe` carries `resourceAllowlist` **and** `checkpointPolicy`; neither survived the generalization. That is the sharper omission of the pair, because entitlement is the axis this PR's own triage named as the real risk — `imageUpscaler` was disqualified *precisely* because its `model` takes an arbitrary AIR URN that would reach the orchestrator around the generation-graph entitlement belt. As written, a future entry with exactly that shape registered cleanly and every other invariant passed.

New required field `resourcePolicy: { kind: 'none' } | { kind: 'staticAllowlist'; airs }`. `checkpointPolicy` is folded in rather than duplicated — a checkpoint IS an AIR, so it is a `staticAllowlist` case. Only `'none'` is implemented; anything else fails at load (clause 11), the same unskippable property moderation already had. `convertImage` declares `'none'`.

🔴 **Enforced, not merely declared:** clause 7 deep-scans the **built** step for an AIR URN and rejects a `'none'` entry that emits one. **Honest limit, stated in the code:** it probes the *canonical* params, so it cannot see an AIR that appears only when an optional AIR-bearing field is supplied. It is a floor. The load-bearing guard for that case is the required declaration plus the unimplemented `staticAllowlist` gate.

## 🟡 FIX 4 — divergence correction was `prepaidFixed`-shaped code in the mode-agnostic section

It fired on `overage > 0` unconditionally. A future `timeBounded` entry reserves a *ceiling*; a submit-time cost above it would be topped up here **and** then settled ceiling→actual off the un-topped-up ceiling. Now gated on a new `plan.correctReservationOverage` — **the mode decides, the router stays mode-agnostic**, which is the property the registry exists to guarantee.

## 🟡 FIX 5 — the dev-session cap was not corrected on divergence

The comment said "correct **both** cap counters"; there are **three** reservations. A divergent submit inside a dev tunnel left `devSessionReserve` under-reading by the overage — the exact drift direction the same comment forbids. Added `chargeDevSessionOverage` (a plain INCRBY with no deny path, the exact mirror of `chargeAppSpendOverage`), wired it in, and corrected the comment.

## 🟡 FIX 6 — a bad param was a 500, and the tests pinned nothing

`estimateStepWorkflow`'s doc asserted "ZodError → BAD_REQUEST". **False by execution:** `paramSchema.parse` throws a raw ZodError from inside the resolver on both estimate and submit, and `getTRPCErrorFromUnknown` maps it to `INTERNAL_SERVER_ERROR`. The two covering tests asserted only `.rejects.toThrow()` — they passed either way. Now `safeParse` + an explicit `BAD_REQUEST`, and the tests assert the **code**.

*(Out of scope, noted for a follow-up: `customComfy`'s recipe param parse at `blocks.router.ts:5829`/`:5890` has the same shape. Changing it is a behaviour change to an existing kind and does not belong in this PR.)*

## 🟡 FIX 7 — the divergence detector could not report "never observed"

The correction reads `snapshot.cost?.total`, which `snapshotFromWorkflow` **omits** when there is no numeric cost, and the step submit passes no `wait`. Whether a queued `convertImage` carries `cost.total` was verified nowhere.

**Determined empirically:** a real non-whatif submit returned HTTP 202 / `status: processing` **with `cost.total: 1`**. The precondition holds today.

It is still not guaranteed for a future entry, so the counter is now `civitai_app_block_step_price_check_total{step, outcome}` — emitted on **every** submit with `outcome ∈ exact | over | absent`:

- `exact` rising = the price is right **and** the detector is provably live.
- `over` = the declared price is wrong (alert on this).
- `absent` = no numeric cost, so the correction is inert — the state that used to be indistinguishable from a healthy zero.

Both labels bounded and small; `outcome` is a TypeScript union so a caller cannot invent a fourth value.

## 🟢 FIX 8 — unused `getBlockSessionUser` in the step submit

Removed. Cost a `getUserById` per submit for a value never read, and was the 1 eslint warning the PR added.

---

## Verification

**Live orchestrator calls** — the whatif + real submit above; the real submit's terminal poll confirmed `step.output` has exactly the key `blob` (`available` false→true, `width` 797, `height` 1024), with **no `images` key and no `blobs` key**.

**Tests** — same globs as baseline, counted from `--reporter=verbose` (not an exit code), no `panic`/timeout truncation:

| | Files | Tests |
|---|---|---|
| pre-fix PR head `601052429b` | 149 | 3200 |
| this fix round | 149 | 3239 |
| **delta** | **0** | **+39** |

Both runs also report the same 1 pre-existing unhandled Prisma engine-load error (`prisma generate` cannot run on this NixOS box).

**tsc** — 6 errors at both the pre-fix head and here, byte-identical (ungenerated Prisma client + a `@civitai/shared` build artifact). **Zero new.**

**eslint / prettier** — measured over the identical changed-file set in a clean worktree at `601052429b` vs here:

| | errors | warnings |
|---|---|---|
| `601052429b` | 28 | 2 (`blocks.router.ts:6477 'user' unused`, `dev-tunnel.service.ts:670 'n' unused`) |
| here | 28 | 1 (only the pre-existing `dev-tunnel.service.ts:670`) |

prettier: the set of non-conforming files is unchanged from baseline (5, all pre-existing), and for each of them the **non-conforming regions are byte-identical** to baseline — i.e. every hunk this round adds is prettier-conformant, and no already-non-conforming file was reformatted. `step-registry.test.ts` was conforming at baseline and is conforming again.

### 🔴 No-regression re-proof for the existing kinds

A differential harness ran the **origin/main** extractors and the **HEAD** extractors side by side over a generated population — 15 `$type` values × 8 workflow statuses × available/unavailable × 8 content ratings × 4 output-key shapes, plus empty/absent/multi-step edge cases.

*(The PR's only pre-existing change to `workflow.service.ts` was exporting `formatStepTimeout`, so `origin/main` and `601052429b` are byte-identical for both extractors — one baseline covers both.)*

| | |
|---|---|
| population | **4611** workflow bodies |
| bodies containing ONLY natively-handled `$type`s | **2050** |
| **diffs on those 2050, `snapshotFromWorkflow`** | **0** |
| **diffs on those 2050, `projectAppWorkflow`** | **0** |
| total changed bodies | 46 — **every one contains `convertImage`** |

On the mixed multi-step body the pre-existing urls are preserved **in order** and the registered step's url is appended (`[a, b] → [a, b, c]`).

### Mutation table

Every guard added or changed was broken on purpose, its tests re-run, and the file restored **from a byte-exact backup with a sha256 equality assertion** — never a `str.replace` revert.

| # | Mutation | Test that failed | Killing assertion |
|---|---|---|---|
| M23 | drop the `resourcePolicy 'none'` AIR probe (clause 7) | *rejects a resourcePolicy 'none' whose BUILT step actually carries an AIR reference* (+1) | `expected [Function] to throw an error` (regex `/resourcePolicy 'none' is contradicted — buildStep\(\) emitted an AIR reference/`) |
| M24 | drop the `extractOutput` non-empty probe (clause 8) | *rejects an entry whose extractOutput surfaces NOTHING for its own canonical output* (+1) | `expected [Function] to throw an error` (regex `/extractOutput\(\) returned no media for canonicalOutputFor/`) |
| M25 | drop the extracted-media url check | *rejects extracted media with an empty url (a block would render a dead link)* | `expected [Function] to throw an error` (regex `/extractOutput\(\) returned media with no url/`) |
| M26 | drop the natively-extracted-`$type` shadow guard (clause 9) | *rejects an orchestratorType that SHADOWS a natively-extracted $type* | `expected [Function] to throw an error` (regex `/is natively extracted by workflow\.service/`) |
| M27 | drop the implemented-resource-policy gate (clause 11) | *rejects a resource policy with no implemented handler* | `expected [Function] to throw an error` (regex `/resourcePolicy 'staticAllowlist' has no implemented handler/`) |
| M28 | drop the cross-entry `orchestratorType` uniqueness guard | *rejects two entries claiming the SAME orchestratorType (single-winner lookup)* | `expected [Function] to throw an error` (regex `/orchestratorType 'fixtureType' is already claimed by 'a'/`) |
| M29 | drop the availability filter from `mediaFromBlobs` | *convert-image: a NOT-YET-AVAILABLE blob is dropped, not surfaced as a dead link* (+1) | `expected [ Array(1) ] to be undefined` |
| M30 | `convert-image` `extractOutput` reads `.blobs` instead of `.blob` — **the real shipped bug shape** | registry LOAD fails (module import) | `Error: block step 'convert-image' variant 'default': extractOutput() returned no media for canonicalOutputFor() — the step's result would be unreachable on both the snapshot and the app-workflow projection` |
| M31 | remove the registry branch from `snapshotFromWorkflow` — **the shipped bug** | *EVERY registered step surfaces its output on snapshotFromWorkflow.imageUrls* (+1) | `step 'convert-image' variant 'default': the caller is CHARGED for this step and its result is absent from every poll: expected undefined to deeply equal [ 'https://…' ]` |
| M32 | remove the registry branch from `projectAppWorkflow` — **the shipped bug, second surface** | *EVERY registered step surfaces its output on projectAppWorkflow.images* (+1) | `step 'convert-image' variant 'default': queryAppWorkflows returns images: [] for a generation the app paid for: expected [] to deeply equal [ Array(1) ]` |
| M33 | gate the per-call budget on the DECLARED price again (**the pre-fix behaviour**) | *REJECTS when the ORCHESTRATOR quote exceeds the budget even though the DECLARED price does not* | `expected 'processing' to be 'failed'` |
| M34 | reserve the declared price, ignoring the quote | *REJECTS when the ORCHESTRATOR quote exceeds the budget…* (+1: *RESERVES the quoted price…*) | `expected 'processing' to be 'failed'` |
| M35 | fail OPEN on an unquotable step | *FAILS CLOSED when the orchestrator returns NO price quote (no submit, no reserve)* | `expected 'processing' to be 'failed'` |
| M37 | drop the DEV-SESSION overage correction | *CORRECTS the DEV-SESSION counter too (three reservations, not two)* | `expected "vi.fn()" to be called with arguments: [ 'devsess_1', 8 ]` |
| M38 | revert to a raw `paramSchema.parse` (ZodError → 500) | *REJECTS an out-of-bounds param as BAD_REQUEST (not a 500)* (+3) | `expected TRPCError: […] to match object { code: 'BAD_REQUEST' }` |
| M39 | stop emitting the non-divergent `'exact'` outcome | *records outcome 'exact' on a healthy submit — the PROOF the check is live* | `expected "vi.fn()" to be called with arguments: [ 'convert-image', 'exact' ]` |
| M40 | put the caller's `externalId` on the FREE quote | *IDEMPOTENCY: a replayed submit does NOT double-charge* (+1) | `expected 'blk08apb_teststep-key' to be undefined` |
| M41 | make `chargeDevSessionOverage` a DECRBY | *tops the counter up unconditionally — with NO deny path, even past the cap* (+1) | `expected { allowed: true, total: -19 } to deeply equal { allowed: false, total: 140 }` |
| M42 | flip `prepaidFixed`'s `correctReservationOverage` to `false` | **6 tests** — *CORRECTS both cap counters…*, *…DEV-SESSION counter too*, all three `outcome` tests, *prepaidFixed plans a FINAL reservation…* | `expected "vi.fn()" to be called with arguments: [ …(2) ]` |

**Compile-time contract, mutation-proven** (`tsc --noEmit`, since vitest does not typecheck):

| Mutation | Result |
|---|---|
| `resourcePolicy?:` optional on `BlockStepBase` | ✅ `type-contract.ts(119,3): error TS2344` (`_RequiresResourcePolicy`) |
| widen `StepResourcePolicy.kind` to `string` | ✅ `type-contract.ts(124,3): error TS2344` (`_RejectsUnknownResourcePolicy`) |
| `extractOutput?:` optional | ✅ `type-contract.ts(137,3): error TS2344` (`_RequiresExtractOutput`) |
| `canonicalOutputFor?:` optional | ✅ `type-contract.ts(145,3): error TS2344` (`_RequiresCanonicalOutput`) |

**Reachability re-check.** Renumbering the invariant clauses could have re-broken the ordering bug the first audit found (clauses that no earlier guard lets you reach). Re-ran the three order-sensitive pre-existing mutations: all still die to **their own** message, not a neighbour's —

- M20-re (drop `timeBounded maxBuzz===ceil`) → `expected [Function] to throw error matching /timeBounded maxBuzz \(90\) must equal…/ but got 'block step 'fixture-step': billingM…'`
- M21-re (drop `timeBounded` positive-timeout) → `…matching /timeBounded stepTimeoutSeconds \(0\) …/ but got 'block step 'fixture-step': billingM…'`
- M22-re (drop `tokenMetered` positive-maxBuzz) → `…matching /tokenMetered maxBuzz \(0\) must be a …/ but got 'block step 'fixture-step': billingM…'`

That "but got" is the point: with the guard removed the fixture falls through to a *neighbouring* guard and still throws — and the test fails anyway, because it demands its own guard's message.

### 🔴 One mutation SURVIVED — reported, not hidden

**M36: deleting FIX 4's `if (plan.correctReservationOverage)` gate kills ZERO tests.** Only `prepaidFixed` is registered, so the flag is always `true` and removing the gate cannot change behaviour today. **This is an INVARIANT GUARD, not regression coverage, and it is labelled as such in the test file.** What *is* proven is that the flag is load-bearing: M42 (flipping it to `false`) kills 6 tests, so the router genuinely reads it. The false branch — and real coverage for this guard — arrives when a `timeBounded` entry is registered.
