### PR TITLE
chore(skills): upgrade the ClickUp skill and fix its broken entrypoint

### DIFF
--- a/.claude/skills/clickup/.env.example
+++ b/.claude/skills/clickup/.env.example
@@ -1,3 +1,8 @@
+# NOTE: accounts.json is the preferred credential storage method.
+# This .env format is supported for backward compatibility and will be
+# auto-migrated to accounts.json on first run.
+# See SKILL.md for accounts.json setup instructions.
+
 # ClickUp Personal API Token
 # Generate at: ClickUp Settings > Apps > API Token
 # Tokens start with 'pk_'

--- a/.claude/skills/clickup/.gitignore
+++ b/.claude/skills/clickup/.gitignore
@@ -1,3 +1,16 @@
-# Ignore .env file with API token
-# Copy .env-example to .env and add your token
+# Credentials — copy .env.example / accounts.json.example and fill in
 .env
+accounts.json
+
+# Runtime state
+.cache/
+watchers.json
+webhook-url.txt
+webhook-latest.json
+webhooks.jsonl
+last-seen.txt
+
+# Windows artifact from a stray `2>nul` redirect
+nul
+
+node_modules/

--- a/.claude/skills/clickup/SKILL.md
+++ b/.claude/skills/clickup/SKILL.md
@@ -9,30 +9,102 @@ Interact with ClickUp tasks and documents via the API. Get task information, vie
 
 ## Setup
 
-1. Copy `.env-example` to `.env` in this skill directory
-2. Add your ClickUp Personal API Token (starts with `pk_`)
-3. Generate token at: ClickUp Settings > Apps > API Token
+**Install dependencies first — one time, per checkout:**
 
 ```bash
-cp .claude/skills/clickup/.env-example .claude/skills/clickup/.env
-# Edit .env and add your token
+cd .claude/skills/clickup && npm install
 ```
 
-Team ID and User ID are auto-detected and cached on first use.
+`lib/markdown.mjs` parses markdown with `remark`, and `query.mjs` reaches it through
+`lib/format.mjs` on startup. **Every** command — not just the comment ones — exits with
+`ERR_MODULE_NOT_FOUND` until this runs.
+
+Then create `accounts.json` in this skill directory with your API token:
+
+```json
+{
+  "defaultAccount": "bot",
+  "accounts": {
+    "bot": {
+      "apiToken": "pk_your_token_here"
+    }
+  }
+}
+```
+
+Generate token at: ClickUp Settings > Apps > API Token
+
+Or use the CLI to add accounts:
+
+```bash
+node query.mjs add-account bot --token pk_your_token_here
+```
+
+Team ID, User ID, and other fields are auto-detected and cached on first use.
+
+**Migration from .env**: If you have an existing `.env` file, credentials are auto-migrated to `accounts.json` on first run. The `.env` file is preserved; remove it when ready.
 
 ### Default List (Optional)
 
-Set `CLICKUP_DEFAULT_LIST_ID` in `.env` to enable creating tasks without specifying a list:
+Set `defaultListId` in your account to enable creating tasks without specifying a list:
+
+```json
+{
+  "defaultAccount": "bot",
+  "accounts": {
+    "bot": {
+      "apiToken": "pk_...",
+      "defaultListId": "901111220963"
+    }
+  }
+}
+```
+
+### Multi-Account
+
+Support multiple named accounts (e.g., "bot" for automation, "justin" for personal use):
+
+```json
+{
+  "defaultAccount": "bot",
+  "accounts": {
+    "bot": {
+      "apiToken": "pk_...",
+      "teamId": "8459928",
+      "userId": "75386805",
+      "defaultListId": "901111220963"
+    },
+    "justin": {
+      "apiToken": "pk_...",
+      "teamId": "8459928",
+      "userId": "10620972"
+    }
+  }
+}
+```
+
+Only `apiToken` is required per account. Other fields are auto-detected and cached.
+
+Use `--account <name>` with any command to target a specific account:
 
 ```bash
-# In .claude/skills/clickup/.env
-CLICKUP_DEFAULT_LIST_ID=901111220963
+node query.mjs me --account justin
+node query.mjs my-tasks --account bot
+```
+
+Account management commands:
+
+```bash
+node query.mjs accounts                          # List all accounts
+node query.mjs switch-account justin             # Change default
+node query.mjs add-account justin --token pk_... # Add account
+node query.mjs remove-account old-account        # Remove account
 ```
 
 ## Running Commands
 
 ```bash
-node .claude/skills/clickup/query.mjs <command> [options]
+node query.mjs <command> [options]
 ```
 
 ### Task Commands
@@ -40,14 +112,17 @@ node .claude/skills/clickup/query.mjs <command> [options]
 | Command | Description |
 |---------|-------------|
 | `get <url\|id>` | Get task details (name, description, status, assignees, etc.) |
-| `comments <url\|id>` | List comments on a task |
+| `comments <url\|id>` | List comments on a task (use `--threads` to expand replies inline) |
+| `thread <comment_id>` | View threaded replies on a specific comment |
+| `reply <comment_id> "message"` | Post a threaded reply to a comment |
 | `comment <url\|id> "message"` | Post a comment to a task (supports markdown) |
 | `status <url\|id> [status]` | Update task status (or list available statuses) |
 | `tasks <list_id>` | List tasks in a list |
 | `me` | Show current user info |
 | `create [list_id] "title"` | Create a new task (list_id optional if default set) |
 | `my-tasks` | List all tasks assigned to you across workspace |
-| `search "query"` | Search tasks by name or description |
+| `search [query]` | Search tasks — requires a scope: `--list`, `--folder`, `--me`, `--assignee`, `--status`, or `--all` |
+| `find-list "name"` | Find a list or folder by name (fast structural walk, no task fetch) |
 | `assign <task> <user>` | Assign task to a user (by name, email, or ID) |
 | `due <task> "date"` | Set due date (e.g., "tomorrow", "friday", "+3d") |
 | `priority <task> <level>` | Set priority (urgent, high, normal, low, none) |
@@ -56,9 +131,33 @@ node .claude/skills/clickup/query.mjs <command> [options]
 | `link <task> <url> ["desc"]` | Add external link reference (as comment) |
 | `checklist <task> "item"` | Add checklist item to task |
 | `delete-comment <comment_id>` | Delete a comment |
-| `watch <task> <user>` | Notify user via @mention comment (watchers not supported in API) |
+| `watch <task> <user>` | Add a user as watcher/follower on a task |
 | `tag <task> "tag_name"` | Add a tag to task |
 | `description <task> "text"` | Update task description (markdown supported) |
+| `start <task> "date"` | Set start date (same date formats as due) |
+| `schedule <task> "start" "due"` | Set both start and due dates |
+| `rename <task> "new name"` | Rename a task |
+| `depends <task> <other>` | Set task as waiting on another task |
+| `blocks <task> <other>` | Set task as blocking another task |
+| `task-link <task> <other>` | Create bidirectional link between tasks |
+| `update-comment <id> "text"` | Update a comment's text |
+| `resolve-comment <id>` | Resolve/close a comment |
+| `remove-tag <task> "tag"` | Remove a tag from task |
+| `unwatch <task> <user>` | Remove a watcher from task |
+| `archive <task>` | Archive a task (remove from active views) |
+| `unarchive <task>` | Restore an archived task |
+| `claim <task>` | Link your session to this task (sets Session ID custom field for resumability) |
+
+### List Commands
+
+| Command | Description |
+|---------|-------------|
+| `list <list_id>` | Get list details (name, statuses, task count) |
+| `create-list <space> "name"` | Create a new list in a space |
+| `update-list <list_id>` | Update list properties (`--name`, `--content`) |
+| `delete-list <list_id>` | Delete a list |
+| `lists <folder_id>` | List all lists in a folder |
+| `space-lists <space_id>` | List folderless lists in a space |
 
 ### Document Commands
 
@@ -68,18 +167,36 @@ node .claude/skills/clickup/query.mjs <command> [options]
 | `doc <doc_id>` | Get doc details and page listing |
 | `create-doc "title"` | Create a new doc (use `--content` for initial content) |
 | `page <doc_id> <page_id>` | Get page content (markdown format) |
-| `create-page <doc_id> "title"` | Add a new page to a doc (creates additional page) |
+| `create-page <doc_id> "title"` | Add a new page to a doc (use `--parent` for subpages) |
 | `edit-page <doc_id> <page_id>` | Edit a page's content or name |
+
+### Attachment Commands
+
+| Command | Description |
+|---------|-------------|
+| `attach <url\|id>` | Upload file attachment(s) to a task (`--attach path`, repeatable) |
+| `fetch-image <url>` | Download a ClickUp attachment to a local temp file (`--output path` for custom location) |
 
 ### Options
 
 | Flag | Description |
 |------|-------------|
 | `--json` | Output raw JSON response |
+| `--threads`, `-t` | Expand threaded replies inline when listing comments |
 | `--subtasks` | Include subtasks when getting task details |
 | `--me` | Filter to tasks assigned to me (for tasks command) |
-| `--content`, `-c` | Page content for create-page/edit-page (markdown) |
+| `--content`, `-c` | Inline content string (markdown). Use for short text only. |
+| `--file`, `-f` | Read content from a file path. **Preferred for anything longer than a sentence.** |
+| `--cleanup` | Delete the `--file` after successful execution |
 | `--name`, `-n` | New page name for edit-page |
+| `--parent`, `-p` | Parent page ID for create-page (creates as subpage) |
+| `--space`, `-s` | Space ID for create-doc (places doc in that space) |
+| `--assignee`, `-a` | Assignee for task creation |
+| `--due`, `-d` | Due date for task creation |
+| `--description`, `--desc` | Description for task creation (markdown) |
+| `--attach` | File path to upload as attachment (repeatable; for `attach` and `comment` commands) |
+| `--output` | Custom output path for fetch-image (default: temp directory) |
+| `--account` | Use a specific named account (from accounts.json) |
 
 ## Examples
 
@@ -87,171 +204,251 @@ node .claude/skills/clickup/query.mjs <command> [options]
 
 ```bash
 # Using full URL
-node .claude/skills/clickup/query.mjs get "https://app.clickup.com/t/86a1b2c3d"
+node query.mjs get "https://app.clickup.com/t/86a1b2c3d"
 
 # Using task ID directly
-node .claude/skills/clickup/query.mjs get 86a1b2c3d
+node query.mjs get 86a1b2c3d
 
 # Include subtasks
-node .claude/skills/clickup/query.mjs get 86a1b2c3d --subtasks
+node query.mjs get 86a1b2c3d --subtasks
 ```
 
 ### Create a Task
 
 ```bash
 # With explicit list ID
-node .claude/skills/clickup/query.mjs create 901111220963 "New feature: dark mode"
+node query.mjs create 901111220963 "New feature: dark mode"
 
 # Using default list (if CLICKUP_DEFAULT_LIST_ID is set)
-node .claude/skills/clickup/query.mjs create "Quick task"
+node query.mjs create "Quick task"
 ```
 
 ### List My Tasks
 
 ```bash
 # All tasks assigned to you across the workspace
-node .claude/skills/clickup/query.mjs my-tasks
+node query.mjs my-tasks
 ```
 
 ### Search Tasks
 
+ClickUp's v2 API has no native text search across tasks, so `search` requires a
+**scope** so the workspace crawl stays bounded. Pick whichever scope fits:
+
 ```bash
-node .claude/skills/clickup/query.mjs search "authentication"
+# Scope to a specific list (fastest, recommended)
+node query.mjs search "authentication" --list 901111220963
+
+# All tasks assigned to you with a particular status
+node query.mjs search --me --status "in progress"
+
+# Scope to a folder ("project") — scans every list in that folder
+node query.mjs search "oauth" --folder 90111122009
+
+# Filter by assignee + text
+node query.mjs search "migration" --assignee justin
+
+# Multiple statuses (comma-separated)
+node query.mjs search --me --status "in progress,review"
+
+# Unscoped full-workspace scan — slow, fetches every task. Use sparingly.
+node query.mjs search "dark mode" --all
 ```
+
+Without a scope flag (and without `--all`), `search` will exit with a helpful
+error instead of silently hammering the API.
+
+### Find a List or Folder by Name
+
+When you have a list name ("Red Launch", "Triage", "Sprint 12") but no ID,
+use `find-list` — it walks the workspace structure (spaces → folders → lists)
+using only metadata endpoints. Fast, no task fetches.
+
+```bash
+node query.mjs find-list "Red Launch"
+node query.mjs find-list "triage" --json
+```
+
+Matches rank: exact > starts-with > contains, case-insensitive. Returns both
+list matches and folder matches (with the folder's nested lists inlined), so
+if the thing you named is a folder you still see the lists you probably want.
 
 ### Update Task Status
 
 ```bash
 # List available statuses for a task
-node .claude/skills/clickup/query.mjs status 86a1b2c3d
+node query.mjs status 86a1b2c3d
 
 # Update status (case-insensitive, partial match)
-node .claude/skills/clickup/query.mjs status 86a1b2c3d "in progress"
-node .claude/skills/clickup/query.mjs status 86a1b2c3d "complete"
+node query.mjs status 86a1b2c3d "in progress"
+node query.mjs status 86a1b2c3d "complete"
 ```
 
 ### Assign Tasks
 
 ```bash
 # Assign by username
-node .claude/skills/clickup/query.mjs assign 86a1b2c3d justin
+node query.mjs assign 86a1b2c3d justin
 
 # Assign by email
-node .claude/skills/clickup/query.mjs assign 86a1b2c3d jane@example.com
+node query.mjs assign 86a1b2c3d jane@example.com
 ```
 
 ### Set Due Dates
 
 ```bash
-node .claude/skills/clickup/query.mjs due 86a1b2c3d "tomorrow"
-node .claude/skills/clickup/query.mjs due 86a1b2c3d "next friday"
-node .claude/skills/clickup/query.mjs due 86a1b2c3d "+3d"
-node .claude/skills/clickup/query.mjs due 86a1b2c3d "2024-01-15"
+node query.mjs due 86a1b2c3d "tomorrow"
+node query.mjs due 86a1b2c3d "next friday"
+node query.mjs due 86a1b2c3d "+3d"
+node query.mjs due 86a1b2c3d "2024-01-15"
 ```
 
 ### Set Priority
 
 ```bash
-node .claude/skills/clickup/query.mjs priority 86a1b2c3d urgent
-node .claude/skills/clickup/query.mjs priority 86a1b2c3d high
-node .claude/skills/clickup/query.mjs priority 86a1b2c3d none  # Clear priority
+node query.mjs priority 86a1b2c3d urgent
+node query.mjs priority 86a1b2c3d high
+node query.mjs priority 86a1b2c3d none  # Clear priority
 ```
 
 ### Create Subtasks
 
 ```bash
-node .claude/skills/clickup/query.mjs subtask 86a1b2c3d "Write unit tests"
-node .claude/skills/clickup/query.mjs subtask 86a1b2c3d "Update documentation"
+node query.mjs subtask 86a1b2c3d "Write unit tests"
+node query.mjs subtask 86a1b2c3d "Update documentation"
 ```
 
 ### Move Tasks
 
 ```bash
-node .claude/skills/clickup/query.mjs move 86a1b2c3d 901111220964
+node query.mjs move 86a1b2c3d 901111220964
 ```
 
 ### Add Links
 
 ```bash
 # Add link with description
-node .claude/skills/clickup/query.mjs link 86a1b2c3d "https://github.com/..." "PR #123"
+node query.mjs link 86a1b2c3d "https://github.com/..." "PR #123"
 
 # Add link without description
-node .claude/skills/clickup/query.mjs link 86a1b2c3d "https://docs.example.com/guide"
+node query.mjs link 86a1b2c3d "https://docs.example.com/guide"
 ```
 
 ### Add Checklist Items
 
 ```bash
-node .claude/skills/clickup/query.mjs checklist 86a1b2c3d "Review code"
-node .claude/skills/clickup/query.mjs checklist 86a1b2c3d "Run tests"
-node .claude/skills/clickup/query.mjs checklist 86a1b2c3d "Deploy to staging"
+node query.mjs checklist 86a1b2c3d "Review code"
+node query.mjs checklist 86a1b2c3d "Run tests"
+node query.mjs checklist 86a1b2c3d "Deploy to staging"
 ```
 
 ### List Tasks in a List
 
 ```bash
 # All tasks in a list
-node .claude/skills/clickup/query.mjs tasks 901111220963
+node query.mjs tasks 901111220963
 
 # Only tasks assigned to me
-node .claude/skills/clickup/query.mjs tasks 901111220963 --me
+node query.mjs tasks 901111220963 --me
 ```
 
 ### View Comments
 
 ```bash
-node .claude/skills/clickup/query.mjs comments "https://app.clickup.com/t/86a1b2c3d"
+node query.mjs comments "https://app.clickup.com/t/86a1b2c3d"
+
+# Expand all threaded replies inline
+node query.mjs comments 86a1b2c3d --threads
+
+# View replies on a specific comment thread
+node query.mjs thread 90110200841741
+
+# Reply to a comment thread
+node query.mjs reply 90110200841741 "Sounds good, I'll take care of it."
 ```
 
 ### Post a Comment
 
 ```bash
-node .claude/skills/clickup/query.mjs comment 86a1b2c3d "Starting work on this task"
+node query.mjs comment 86a1b2c3d "Starting work on this task"
 
 # Multi-line comment
-node .claude/skills/clickup/query.mjs comment 86a1b2c3d "Status update:
+node query.mjs comment 86a1b2c3d "Status update:
 - Completed initial review
 - Found 3 issues to address
 - Will submit PR by EOD"
 ```
 
+### @Mention Users in Comments
+
+The skill supports two mention syntaxes:
+
+1. **Explicit (preferred):** `@[identifier]` — bracket syntax with fuzzy matching by name, email, or user ID
+2. **Bare (auto-detected):** `@Name` or `@First Last` — automatically matched against workspace members
+
+Bare mentions are a **fallback** so mentions work even if agents forget the bracket syntax. Both produce the same ClickUp mention attribute.
+
+```bash
+# Explicit bracket syntax (preferred)
+node query.mjs comment 86a1b2c3d "Hey @[justin], can you review this?"
+
+# Bare mention (auto-detected against workspace members)
+node query.mjs comment 86a1b2c3d "Hey @Justin Maier, can you review this?"
+
+# Both work the same — these are equivalent:
+node query.mjs comment 86a1b2c3d "@[justin] please review"
+node query.mjs comment 86a1b2c3d "@Justin please review"
+
+# Mention by numeric user ID (bracket syntax only)
+node query.mjs comment 86a1b2c3d "@[10620972] please take a look"
+
+# Mention by email (bracket syntax only)
+node query.mjs comment 86a1b2c3d "Assigned to @[jane@example.com]"
+
+# Multiple mentions in one comment
+node query.mjs comment 86a1b2c3d "@[justin] and @[koen] - need your input on this"
+
+
+**Bracket syntax**: Fuzzy matches partial names, emails, or numeric IDs. `@[justin]` matches "Justin Maier". Unknown users throw an error.
+
+**Bare syntax**: Matches `@Name` against workspace member usernames (case-insensitive). Tries full name first (`@Justin Maier`), then first name (`@Justin`). Unmatched bare mentions are left as plain text (no error).
+
 ### Show Current User
 
 ```bash
-node .claude/skills/clickup/query.mjs me
+node query.mjs me
 ```
 
 ### Delete a Comment
 
 ```bash
 # Get comment IDs from the comments command (shown in --json output)
-node .claude/skills/clickup/query.mjs delete-comment 90110200841741
+node query.mjs delete-comment 90110200841741
 ```
 
-### Notify Users (Watch)
+### Add/Remove Watchers
 
 ```bash
-# Notify user via @mention comment (ClickUp API doesn't support adding watchers directly)
-node .claude/skills/clickup/query.mjs watch 86a1b2c3d koen
+# Add user as watcher on a task
+node query.mjs watch 86a1b2c3d koen
 
-# Notify by email
-node .claude/skills/clickup/query.mjs watch 86a1b2c3d jane@example.com
+# Remove watcher
+node query.mjs unwatch 86a1b2c3d koen
 ```
 
 ### Add Tags
 
 ```bash
 # Add a tag to a task
-node .claude/skills/clickup/query.mjs tag 86a1b2c3d "DevOps"
-node .claude/skills/clickup/query.mjs tag 86a1b2c3d "bug"
+node query.mjs tag 86a1b2c3d "DevOps"
+node query.mjs tag 86a1b2c3d "bug"
 ```
 
 ### Update Description
 
 ```bash
 # Update task description with markdown
-node .claude/skills/clickup/query.mjs description 86a1b2c3d "## Summary
+node query.mjs description 86a1b2c3d "## Summary
 This is a **bold** statement.
 
 - Item 1
@@ -260,34 +457,88 @@ This is a **bold** statement.
 See [documentation](https://example.com) for more info."
 ```
 
+### Archive / Restore Tasks
+
+```bash
+# Archive a task (removes from active views)
+node query.mjs archive 86a1b2c3d
+
+# Restore an archived task
+node query.mjs unarchive 86a1b2c3d
+```
+
+### Claim a Task (Session Linking)
+
+When you start working on a ClickUp task, **claim it immediately** so your session can be resumed later. This writes your Claude Code session ID to the task's "Session ID" custom field, allowing work to be picked up where you left off.
+
+```bash
+# Claim a task as soon as you begin working on it
+node query.mjs claim 86a1b2c3d
+
+# Works with URLs too
+node query.mjs claim "https://app.clickup.com/t/86a1b2c3d"
+```
+
+**Requirements:**
+- The task's list must have a text custom field with "Session" in its name (e.g., "Session ID")
+- Session ID resolution order: `$CLAUDE_SESSION_ID` → most-recently-modified `~/.claude/projects/*/*.jsonl` (within 60s). The fallback handles harnesses that don't expose the env var.
+
+**When to claim:** As soon as you start working on a ClickUp task. This is how we pick up where you left off if we need to continue work on the same task later.
+
+### Get List Details
+
+```bash
+# Get list info including statuses
+node query.mjs list 901111220963
+```
+
+### Create a List
+
+```bash
+# Create a list in a space using space ID
+node query.mjs create-list 20128955 "New List"
+
+# Create a list using space URL
+node query.mjs create-list "https://app.clickup.com/8459928/v/s/20128955" "Sprint Backlog"
+
+# Create a list with description
+node query.mjs create-list 20128955 "Bug Tracker" --content "Track all bugs here"
+```
+
+### Delete a List
+
+```bash
+node query.mjs delete-list 901111220963
+```
+
 ### List/Search Docs
 
 ```bash
 # List all docs in workspace
-node .claude/skills/clickup/query.mjs docs
+node query.mjs docs
 
 # Search docs by name
-node .claude/skills/clickup/query.mjs docs "API"
+node query.mjs docs "API"
 ```
 
 ### Get Doc Details
 
 ```bash
 # Get doc info and page listing
-node .claude/skills/clickup/query.mjs doc abc123def
+node query.mjs doc abc123def
 
 # Using a doc URL
-node .claude/skills/clickup/query.mjs doc "https://app.clickup.com/12345/v/dc/abc123def"
+node query.mjs doc "https://app.clickup.com/12345/v/dc/abc123def"
 ```
 
 ### Create a Doc
 
 ```bash
 # Create an empty doc
-node .claude/skills/clickup/query.mjs create-doc "Project Notes"
+node query.mjs create-doc "Project Notes"
 
 # Create a doc with initial content (populates the first page)
-node .claude/skills/clickup/query.mjs create-doc "API Documentation" --content "# API Documentation
+node query.mjs create-doc "API Documentation" --content "# API Documentation
 
 This document covers the API endpoints and usage.
 
@@ -299,17 +550,17 @@ This document covers the API endpoints and usage.
 
 ```bash
 # Get a specific page's content
-node .claude/skills/clickup/query.mjs page abc123def page456
+node query.mjs page abc123def page456
 ```
 
 ### Create a Page
 
 ```bash
 # Create a page with just a title
-node .claude/skills/clickup/query.mjs create-page abc123def "New Section"
+node query.mjs create-page abc123def "New Section"
 
 # Create a page with content
-node .claude/skills/clickup/query.mjs create-page abc123def "Getting Started" --content "# Welcome
+node query.mjs create-page abc123def "Getting Started" --content "# Welcome
 
 This is the getting started guide.
 
@@ -322,117 +573,117 @@ This is the getting started guide.
 
 ```bash
 # Update page content
-node .claude/skills/clickup/query.mjs edit-page abc123def page456 --content "Updated content here"
+node query.mjs edit-page abc123def page456 --content "Updated content here"
 
 # Rename a page
-node .claude/skills/clickup/query.mjs edit-page abc123def page456 --name "New Page Name"
+node query.mjs edit-page abc123def page456 --name "New Page Name"
 
 # Update both content and name
-node .claude/skills/clickup/query.mjs edit-page abc123def page456 --content "New content" --name "New Name"
+node query.mjs edit-page abc123def page456 --content "New content" --name "New Name"
 ```
 
-## Task/List/Doc URL Formats
+
+### Upload Attachments
+
+```bash
+# Upload a single file to a task
+node query.mjs attach 86a1b2c3d --attach ./screenshot.png
+
+# Upload multiple files
+node query.mjs attach 86a1b2c3d --attach ./screenshot1.png --attach ./report.pdf
+
+# Post a comment with file attachments (comment first, then files are attached)
+node query.mjs comment 86a1b2c3d "Here are the screenshots" --attach ./screenshot.png
+
+# Comment with multiple attachments
+node query.mjs comment 86a1b2c3d "Design review assets" --attach ./mockup.png --attach ./spec.pdf
+```
+
+**Supported file types**: Images (PNG, JPG, GIF, WebP, SVG), documents (PDF, DOCX, XLSX), archives (ZIP), and any other file type ClickUp accepts.
+
+**Note**: The ClickUp API attaches files to the task itself (visible in the task's attachment list). When using `--attach` with the `comment` command, the comment is posted first and then the files are uploaded as task attachments. They appear in the task but are not embedded inline in the comment text.
+
+### Viewing Attachments in Comments
+
+Comments containing images or file attachments display them inline in plain-text output:
+
+```
+[Feb 11, 2026, 04:55 PM] Justin Maier (id: 90110209630450):
+  [Attachment: image.png](https://t8459928.p.clickup-attachments.com/...)
+  If you look at the component, you'll see that...
+```
+
+To view the actual image, use `fetch-image` to download it locally:
+
+```bash
+# Download attachment from URL shown in comment output
+node query.mjs fetch-image "https://t8459928.p.clickup-attachments.com/t8459928/.../image.png"
+# → Downloaded: /tmp/clickup-attachments/image.png
+
+# Save to a specific path
+node query.mjs fetch-image "https://..." --output ./screenshot.png
+```
+
+After downloading, use your file viewer or `Read` tool to view the image.
+
+## File-based Content (Recommended)
+
+For any content longer than a sentence, **write to a markdown file first** and use `--file` instead of `--content`. This avoids shell escaping issues and supports proper multi-line markdown.
+
+### Workflow
+
+1. Write your content to a temporary markdown file
+2. Pass it with `--file path/to/file.md`
+3. Optionally add `--cleanup` to auto-delete the file after success
+
+### Examples
+
+```bash
+# Create a doc from a prepared markdown file
+node query.mjs create-doc "Architecture Spec" --file ./docs/spec.md --space 90114072520
+
+# Update a page from a file, then auto-delete the temp file
+node query.mjs edit-page abc123 page456 --file /tmp/updated-content.md --cleanup
+
+# Post a detailed comment from a file
+node query.mjs comment 86a1b2c3d --file ./review-notes.md
+
+# Set task description from a file
+node query.mjs description 86a1b2c3d --file ./task-brief.md
+```
+
+### When to use which
+
+| Approach | When to use |
+|----------|-------------|
+| `--content "short text"` | One-liners, simple status updates |
+| `--file path.md` | Multi-line content, markdown with formatting, specs, documentation |
+| `--file path.md --cleanup` | Temporary content (agent writes file, pushes to ClickUp, removes file) |
+
+`--file` works with: `create-doc`, `create-page`, `edit-page`, `comment`, `description`, `create-list`, `update-list`
+
+## Task/List/Space/Doc URL Formats
 
 The skill recognizes these ClickUp URL formats:
 
 **Tasks:**
 - `https://app.clickup.com/t/{task_id}`
 - `https://app.clickup.com/{team_id}/v/li/{list_id}?p={task_id}`
+- Custom task ID: `#DEV-123` or `DEV-123`
 - Direct task ID: `86a1b2c3d`
 
 **Lists:**
 - `https://app.clickup.com/{team_id}/v/li/{list_id}`
 - Direct list ID: `901111220963`
 
+**Spaces:**
+- `https://app.clickup.com/{team_id}/v/s/{space_id}`
+- Direct space ID: `20128955`
+
 **Docs:**
 - `https://app.clickup.com/{team_id}/v/dc/{doc_id}`
 - `https://app.clickup.com/{team_id}/docs/{doc_id}`
 - Direct doc ID: `abc123def`
-
-## Output Format
-
-### Task Details
-
-```
-Task: Implement user authentication
-Status: In Progress
-Priority: High
-Assignees: John Doe, Jane Smith
-Due: 2024-01-15
-Created: 2024-01-10
-URL: https://app.clickup.com/t/86a1b2c3d
-
-Description:
-Add OAuth2 authentication with Google and GitHub providers...
-```
-
-### Task List
-
-```
-[to do] Fix login bug
-  ID: 868h2cxat | Priority: high | Assignees: John Doe
-  https://app.clickup.com/t/868h2cxat
-
-[in progress] Update API docs
-  ID: 868g7c75u | Priority: None | Assignees: Jane Smith
-  https://app.clickup.com/t/868g7c75u
-
-Total: 2 task(s)
-```
-
-### Comments
-
-```
-[2024-01-12 14:30] John Doe:
-  Started working on this. Will push initial commit today.
-
-[2024-01-12 16:45] Jane Smith:
-  @John looks good! Let me know when ready for review.
-```
-
-### Doc Details
-
-```
-Doc: API Documentation
-ID: abc123def
-Created: Jan 10, 2024, 09:30 AM
-Updated: Jan 15, 2024, 02:45 PM
-Creator: John Doe
-Workspace: 12345678
-
-Pages:
-Introduction
-  ID: page001
-
-Getting Started
-  ID: page002
-
-API Reference
-  ID: page003
-
-Total: 3 page(s)
-```
-
-### Page Content
-
-```
-Page: Getting Started
-ID: page002
-Created: Jan 10, 2024, 10:00 AM
-Updated: Jan 14, 2024, 03:30 PM
-
-Content:
----
-# Getting Started
-
-Welcome to the API documentation.
-
-## Prerequisites
-- Node.js 18+
-- An API key
----
-```
-
 ## When to Use
 
 **Tasks:**
@@ -444,6 +695,7 @@ Welcome to the API documentation.
 - **Collaboration**: View recent comments for context, add watchers
 - **Task organization**: Add tags to categorize tasks
 - **Task linking**: Reference task IDs in commit messages
+- **Session tracking**: Claim tasks with `claim` so work can be resumed later
 
 **Documents:**
 - **Documentation**: Create and maintain project documentation
@@ -451,11 +703,21 @@ Welcome to the API documentation.
 - **Meeting notes**: Store meeting notes and decisions
 - **Specifications**: Write and update technical specs
 - **Quick edits**: Update doc content without leaving the terminal
+- **Doc collaboration**: Read and reply to doc comments for inline reviews
+
+## Comment Threading Best Practices
+
+When responding to task discussions, **always check for thread context first**:
+
+1. **Before posting a comment**, run `comments <task> --threads` to see existing conversations.
+2. **If the user's message or context references a specific comment thread** (e.g., they replied in a thread, or you're continuing a prior conversation), use `reply <comment_id> "text"` to post within that thread — NOT `comment <task> "text"`.
+3. **Only use `comment`** (top-level) for genuinely new topics that don't belong in an existing thread.
+4. **Rule of thumb**: If you previously posted a comment and someone replied to it in a thread, your next response belongs in that same thread via `reply`.
 
 ## Tips
 
-- Team ID, User ID, and default list ID are auto-cached in `.env`
-- Set `CLICKUP_DEFAULT_LIST_ID` to skip list_id when creating team tasks
+- Team ID, User ID, and other fields are auto-cached in `accounts.json`
+- Set `defaultListId` in your account to skip list_id when creating tasks
 - Use `my-tasks` for a quick overview of your assignments
 - Use natural language dates: "tomorrow", "next friday", "+3d"
 - Post comments to keep stakeholders updated on progress
@@ -463,27 +725,19 @@ Welcome to the API documentation.
 - Use `--json` for scripting or piping to other tools
 - Doc content uses markdown format for both input and output
 - The Docs API uses v3 endpoints (workspace-based instead of team-based)
+- Custom task IDs supported: `#DEV-123` or `DEV-123`
+- All task/comment queries auto-paginate (no manual page handling needed)
+- Rate limiting handled automatically with retry and backoff
 
-## Technical Notes
 
-### Markdown Handling
+## Reference
 
-ClickUp uses different content formats for different features:
+Less-common material lives in [reference.md](reference.md) — read it when you need it:
 
-| Feature | API Version | Content Format |
-|---------|-------------|----------------|
-| Comments | v2 | Proprietary JSON array (converted via `markdownToClickUp()`) |
-| Task descriptions | v2 | Native markdown via `markdown_description` field |
-| Docs/Pages | v3 | Native markdown (no conversion needed) |
-
-The Docs API (v3) accepts and returns markdown directly, so no conversion is required. This is different from comments which use a proprietary format that requires the `lib/markdown.mjs` conversion utilities.
-
-### Doc Page Structure
-
-When you create a doc via the API, ClickUp automatically creates an empty first page. This has implications:
-
-- **`create-doc`** - Creates a doc with an auto-generated first page. Use `--content` to populate that first page.
-- **`create-page`** - Adds an *additional* page to a doc (second page, third page, etc.)
-- **`edit-page`** - Modifies an existing page's content
-
-To add content to a new doc, use `create-doc "Title" --content "..."` rather than creating the doc and then using `create-page` (which would leave the first page empty).
+- **Output Format** — sample output shapes for tasks, lists, comments, docs, pages
+- **Technical Notes** — markdown handling per feature, @mention resolution, doc page structure, pagination
+- **Testing** — smoke-test suite
+- **Webhook Watchers** — real-time event monitoring via webhook.site + `listen.mjs`
+- **Task Watcher (polling)** — dependency-free single-task/list watcher via `watch.mjs`
+- **Batch Task Creation** — `batch-create` JSON plan schema and dependency wiring
+- **Team Workflow Patterns** — lead/worker/QA/doc-keeper and phase-gate patterns

--- a/.claude/skills/clickup/accounts.json.example
+++ b/.claude/skills/clickup/accounts.json.example
@@ -1,0 +1,8 @@
+{
+  "defaultAccount": "me",
+  "accounts": {
+    "me": {
+      "apiToken": "pk_your_token_here"
+    }
+  }
+}

--- a/.claude/skills/clickup/api/attachments.mjs
+++ b/.claude/skills/clickup/api/attachments.mjs
@@ -1,0 +1,140 @@
+/**
+ * ClickUp attachments API methods
+ *
+ * Uses multipart/form-data for file uploads (not JSON).
+ * Endpoint: POST /api/v2/task/{task_id}/attachment
+ */
+
+import { readFileSync } from 'fs';
+import { basename } from 'path';
+import { API_BASE, getActiveCredentials } from './client.mjs';
+
+const REQUEST_TIMEOUT_MS = 60000; // 60s for uploads (larger files)
+const MAX_RETRIES = 2;
+
+// Guess MIME type from file extension
+function guessMimeType(filename) {
+  const ext = filename.toLowerCase().split('.').pop();
+  const types = {
+    png: 'image/png',
+    jpg: 'image/jpeg',
+    jpeg: 'image/jpeg',
+    gif: 'image/gif',
+    webp: 'image/webp',
+    svg: 'image/svg+xml',
+    bmp: 'image/bmp',
+    ico: 'image/x-icon',
+    pdf: 'application/pdf',
+    doc: 'application/msword',
+    docx: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+    xls: 'application/vnd.ms-excel',
+    xlsx: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+    ppt: 'application/vnd.ms-powerpoint',
+    pptx: 'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+    txt: 'text/plain',
+    csv: 'text/csv',
+    json: 'application/json',
+    xml: 'application/xml',
+    zip: 'application/zip',
+    gz: 'application/gzip',
+    tar: 'application/x-tar',
+    mp4: 'video/mp4',
+    mp3: 'audio/mpeg',
+    wav: 'audio/wav',
+  };
+  return types[ext] || 'application/octet-stream';
+}
+
+/**
+ * Upload a single file attachment to a task.
+ *
+ * @param {string} taskId - ClickUp task ID
+ * @param {string} filePath - Absolute path to the file to upload
+ * @returns {Promise<object>} - ClickUp attachment response
+ */
+export async function uploadAttachment(taskId, filePath) {
+  const creds = getActiveCredentials();
+  const token = creds.apiToken;
+  if (!token) {
+    throw new Error('No API token configured. See SKILL.md for setup.');
+  }
+
+  const filename = basename(filePath);
+  const fileBuffer = readFileSync(filePath);
+  const mimeType = guessMimeType(filename);
+
+  // Build multipart/form-data using Node's built-in FormData + Blob
+  const formData = new FormData();
+  const blob = new Blob([fileBuffer], { type: mimeType });
+  formData.append('attachment', blob, filename);
+
+  const url = `${API_BASE}/task/${taskId}/attachment`;
+
+  // Retry logic for rate limiting
+  for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
+
+    try {
+      const response = await fetch(url, {
+        method: 'POST',
+        headers: {
+          Authorization: token,
+          // Do NOT set Content-Type — fetch sets it with the multipart boundary
+        },
+        body: formData,
+        signal: controller.signal,
+      });
+
+      clearTimeout(timeout);
+
+      if (response.status === 429 && attempt < MAX_RETRIES) {
+        const resetHeader = response.headers.get('X-RateLimit-Reset');
+        let waitMs = 60000;
+        if (resetHeader) {
+          waitMs = Math.max((parseInt(resetHeader) * 1000) - Date.now(), 1000);
+        }
+        console.error(`Rate limited. Waiting ${Math.ceil(waitMs / 1000)}s before retry...`);
+        await new Promise(r => setTimeout(r, waitMs));
+        continue;
+      }
+
+      if (!response.ok) {
+        const text = await response.text();
+        let parsed;
+        try { parsed = JSON.parse(text); } catch {}
+        const err = new Error(
+          parsed?.err || `ClickUp API error: ${response.status} - ${text}`
+        );
+        err.status = response.status;
+        throw err;
+      }
+
+      const text = await response.text();
+      if (!text) return {};
+      return JSON.parse(text);
+    } catch (err) {
+      clearTimeout(timeout);
+      if (err.name === 'AbortError') {
+        throw new Error(`Upload timed out after ${REQUEST_TIMEOUT_MS / 1000}s for ${filename}`);
+      }
+      throw err;
+    }
+  }
+}
+
+/**
+ * Upload multiple files to a task.
+ *
+ * @param {string} taskId - ClickUp task ID
+ * @param {string[]} filePaths - Array of absolute file paths
+ * @returns {Promise<object[]>} - Array of ClickUp attachment responses
+ */
+export async function uploadAttachments(taskId, filePaths) {
+  const results = [];
+  for (const filePath of filePaths) {
+    const result = await uploadAttachment(taskId, filePath);
+    results.push(result);
+  }
+  return results;
+}

--- a/.claude/skills/clickup/api/checklists.mjs
+++ b/.claude/skills/clickup/api/checklists.mjs
@@ -29,6 +29,29 @@ export async function getChecklists(taskId) {
   return response.checklists || [];
 }
 
+// Edit a checklist item (rename, assign, resolve/complete, nest)
+export async function editChecklistItem(checklistId, checklistItemId, updates = {}) {
+  const body = {};
+  if (updates.name !== undefined) body.name = updates.name;
+  if (updates.assignee !== undefined) body.assignee = updates.assignee;
+  if (updates.resolved !== undefined) body.resolved = updates.resolved;
+  if (updates.parent !== undefined) body.parent = updates.parent;
+
+  const response = await apiRequest(`/checklist/${checklistId}/checklist_item/${checklistItemId}`, {
+    method: 'PUT',
+    body: JSON.stringify(body),
+  });
+  return response;
+}
+
+// Delete a checklist item
+export async function deleteChecklistItem(checklistId, checklistItemId) {
+  const response = await apiRequest(`/checklist/${checklistId}/checklist_item/${checklistItemId}`, {
+    method: 'DELETE',
+  });
+  return response;
+}
+
 // Add item to first checklist, or create one if none exist
 export async function addChecklistItemToTask(taskId, itemName, checklistName = 'Checklist') {
   let checklists = await getChecklists(taskId);

--- a/.claude/skills/clickup/api/client.mjs
+++ b/.claude/skills/clickup/api/client.mjs
@@ -1,22 +1,69 @@
 /**
- * ClickUp API client - core HTTP layer and environment handling
+ * ClickUp API client - core HTTP layer and credential management
  */
 
 import { readFileSync, existsSync, appendFileSync } from 'fs';
 import { resolve, dirname } from 'path';
 import { fileURLToPath } from 'url';
+import { getAccountCredentials } from '../lib/accounts.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 export const ENV_PATH = resolve(__dirname, '..', '.env');
 export const API_BASE = 'https://api.clickup.com/api/v2';
 export const API_BASE_V3 = 'https://api.clickup.com/api/v3';
 
-// Load .env from skill directory
-export function loadEnv() {
-  if (!existsSync(ENV_PATH)) {
-    return false;
-  }
+const REQUEST_TIMEOUT_MS = 30000;
+const MAX_RETRIES = 2;
 
+// Active account credentials (set by initClient)
+let _activeCredentials = null;
+let _activeAccountId = null;
+
+/**
+ * Initialize the client with a specific account (or the default).
+ * Replaces the old loadEnv() approach.
+ */
+export function initClient(accountId) {
+  const creds = getAccountCredentials(accountId);
+  _activeCredentials = creds;
+  _activeAccountId = creds._accountId;
+  // Populate process.env for backward compat with modules that still read it
+  if (creds.apiToken) process.env.CLICKUP_API_TOKEN = creds.apiToken;
+  if (creds.teamId) process.env.CLICKUP_TEAM_ID = creds.teamId;
+  if (creds.userId) process.env.CLICKUP_USER_ID = creds.userId;
+  if (creds.defaultListId) process.env.CLICKUP_DEFAULT_LIST_ID = creds.defaultListId;
+  if (creds.jwt) process.env.CLICKUP_JWT = creds.jwt;
+  if (creds.internalApiUrl) process.env.CLICKUP_INTERNAL_API = creds.internalApiUrl;
+  if (creds.email) process.env.CLICKUP_EMAIL = creds.email;
+  if (creds.password) process.env.CLICKUP_PASSWORD = creds.password;
+  return true;
+}
+
+/**
+ * Get the active account's credentials object
+ */
+export function getActiveCredentials() {
+  if (!_activeCredentials) {
+    throw new Error('Client not initialized. Call initClient() first.');
+  }
+  return _activeCredentials;
+}
+
+/**
+ * Get the active account ID
+ */
+export function getActiveAccountId() {
+  return _activeAccountId;
+}
+
+/**
+ * @deprecated Use initClient(accountId) instead.
+ * Kept for transitional compatibility.
+ */
+export function loadEnv() {
+  if (_activeCredentials) return true;
+  // Legacy fallback: load from .env directly
+  if (!existsSync(ENV_PATH)) return false;
   try {
     const envContent = readFileSync(ENV_PATH, 'utf-8');
     for (const line of envContent.split('\n')) {
@@ -36,7 +83,9 @@ export function loadEnv() {
   }
 }
 
-// Append a value to .env file
+/**
+ * @deprecated Use updateAccountField from lib/accounts.mjs instead.
+ */
 export function appendToEnv(key, value, comment = null) {
   try {
     let content = '\n';
@@ -52,73 +101,109 @@ export function appendToEnv(key, value, comment = null) {
   }
 }
 
-// Make API request
-export async function apiRequest(endpoint, options = {}) {
+// Get API token or exit with setup instructions
+function getToken() {
+  if (_activeCredentials?.apiToken) {
+    return _activeCredentials.apiToken;
+  }
   const token = process.env.CLICKUP_API_TOKEN;
   if (!token) {
-    console.error('Error: CLICKUP_API_TOKEN not configured');
+    console.error('Error: No API token configured');
     console.error('');
     console.error('Setup:');
-    console.error('  1. Copy .env-example to .env in the skill directory');
-    console.error('  2. Add your ClickUp Personal API Token');
+    console.error('  1. Create accounts.json (see SKILL.md) or .env in the skill directory');
+    console.error('  2. Add your ClickUp Personal API Token (starts with pk_)');
     console.error('  3. Generate at: ClickUp Settings > Apps > API Token');
     process.exit(1);
   }
-
-  const url = `${API_BASE}${endpoint}`;
-  const response = await fetch(url, {
-    ...options,
-    headers: {
-      'Authorization': token,
-      'Content-Type': 'application/json',
-      ...options.headers,
-    },
-  });
-
-  if (!response.ok) {
-    const text = await response.text();
-    throw new Error(`ClickUp API error: ${response.status} - ${text}`);
-  }
-
-  // Handle empty responses (e.g., DELETE returns empty body)
-  const text = await response.text();
-  if (!text) {
-    return {};
-  }
-  return JSON.parse(text);
+  return token;
 }
 
-// Make API v3 request (used for Docs API)
-export async function apiRequestV3(endpoint, options = {}) {
-  const token = process.env.CLICKUP_API_TOKEN;
-  if (!token) {
-    console.error('Error: CLICKUP_API_TOKEN not configured');
-    console.error('');
-    console.error('Setup:');
-    console.error('  1. Copy .env-example to .env in the skill directory');
-    console.error('  2. Add your ClickUp Personal API Token');
-    console.error('  3. Generate at: ClickUp Settings > Apps > API Token');
-    process.exit(1);
-  }
+// Core fetch with timeout, rate limit handling, and structured error parsing
+async function fetchWithRetry(url, options, retries = 0) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS);
 
-  const url = `${API_BASE_V3}${endpoint}`;
-  const response = await fetch(url, {
-    ...options,
-    headers: {
-      'Authorization': token,
-      'Content-Type': 'application/json',
-      ...options.headers,
-    },
-  });
+  try {
+    const response = await fetch(url, {
+      ...options,
+      signal: controller.signal,
+    });
 
-  if (!response.ok) {
+    // Handle rate limiting (429)
+    if (response.status === 429 && retries < MAX_RETRIES) {
+      const resetHeader = response.headers.get('X-RateLimit-Reset');
+      let waitMs = 60000; // Default: wait 60s
+      if (resetHeader) {
+        waitMs = Math.max((parseInt(resetHeader) * 1000) - Date.now(), 1000);
+      }
+      console.error(`Rate limited. Waiting ${Math.ceil(waitMs / 1000)}s before retry...`);
+      await new Promise(r => setTimeout(r, waitMs));
+      return fetchWithRetry(url, options, retries + 1);
+    }
+
+    if (!response.ok) {
+      const text = await response.text();
+      let parsed;
+      try { parsed = JSON.parse(text); } catch {}
+      const err = new Error(
+        parsed?.err || `ClickUp API error: ${response.status} - ${text}`
+      );
+      err.status = response.status;
+      err.ecode = parsed?.ECODE || null;
+      throw err;
+    }
+
+    // Handle empty responses (e.g., DELETE returns empty body)
     const text = await response.text();
-    throw new Error(`ClickUp API error: ${response.status} - ${text}`);
+    if (!text) {
+      return {};
+    }
+    return JSON.parse(text);
+  } catch (err) {
+    if (err.name === 'AbortError') {
+      throw new Error(`ClickUp API request timed out after ${REQUEST_TIMEOUT_MS / 1000}s: ${url}`);
+    }
+    throw err;
+  } finally {
+    clearTimeout(timeout);
   }
+}
 
-  const text = await response.text();
-  if (!text) {
-    return {};
+// Internal: make API request to any base URL
+function makeRequest(baseUrl) {
+  return async function(endpoint, options = {}) {
+    const token = getToken();
+    const url = `${baseUrl}${endpoint}`;
+    return fetchWithRetry(url, {
+      ...options,
+      headers: {
+        'Authorization': token,
+        'Content-Type': 'application/json',
+        ...options.headers,
+      },
+    });
+  };
+}
+
+// Make API v2 request
+export const apiRequest = makeRequest(API_BASE);
+
+// Make API v3 request (used for Docs API)
+export const apiRequestV3 = makeRequest(API_BASE_V3);
+
+// Auto-paginate v2 task endpoints (page-based pagination)
+// Returns all items across all pages
+export async function fetchAllPages(endpoint, key = 'tasks') {
+  let page = 0;
+  let allItems = [];
+  while (true) {
+    const sep = endpoint.includes('?') ? '&' : '?';
+    const response = await apiRequest(`${endpoint}${sep}page=${page}`);
+    const items = response[key] || [];
+    allItems = allItems.concat(items);
+    if (response.last_page || items.length < 100) break;
+    page++;
   }
-  return JSON.parse(text);
+  return allItems;
 }

--- a/.claude/skills/clickup/api/comments.mjs
+++ b/.claude/skills/clickup/api/comments.mjs
@@ -3,28 +3,78 @@
  */
 
 import { apiRequest } from './client.mjs';
-import { markdownToClickUp } from '../lib/markdown.mjs';
+import { textToCommentArray } from '../lib/mentions.mjs';
 
-// Get task comments
+// Get task comments (paginates through all; API returns max 25 per request)
 export async function getComments(taskId) {
-  const response = await apiRequest(`/task/${taskId}/comment`);
-  return response.comments || [];
+  const PAGE_SIZE = 25;
+  let allComments = [];
+  let start = undefined;
+  let startId = undefined;
+
+  while (true) {
+    const params = new URLSearchParams();
+    if (start !== undefined) {
+      params.append('start', start);
+      params.append('start_id', startId);
+    }
+    const paramStr = params.toString();
+    const endpoint = `/task/${taskId}/comment${paramStr ? '?' + paramStr : ''}`;
+    const response = await apiRequest(endpoint);
+    const comments = response.comments || [];
+    allComments = allComments.concat(comments);
+
+    // If fewer than PAGE_SIZE returned, we've reached the end
+    if (comments.length < PAGE_SIZE) break;
+
+    // Use the last comment's date and id as cursor for next page
+    const lastComment = comments[comments.length - 1];
+    start = lastComment.date;
+    startId = lastComment.id;
+  }
+
+  return allComments;
 }
 
 // Post a comment (with optional markdown formatting)
-export async function postComment(taskId, text, useMarkdown = true) {
-  let body;
-
-  if (useMarkdown) {
-    const commentArray = markdownToClickUp(text);
-    body = JSON.stringify({ comment: commentArray });
-  } else {
-    body = JSON.stringify({ comment_text: text });
+// options: { useMarkdown: bool, notify_all: bool, assignee: number }
+// Backwards compatible: third arg can be a boolean (treated as useMarkdown)
+export async function postComment(taskId, text, options = {}) {
+  // Backwards compatibility: if options is a boolean, treat as useMarkdown
+  if (typeof options === 'boolean') {
+    options = { useMarkdown: options };
   }
+
+  const { useMarkdown = true, notify_all, assignee } = options;
+
+  let bodyObj;
+  if (useMarkdown) {
+    const commentArray = await textToCommentArray(text);
+    bodyObj = { comment: commentArray };
+  } else {
+    bodyObj = { comment_text: text };
+  }
+
+  if (notify_all !== undefined) bodyObj.notify_all = notify_all;
+  if (assignee !== undefined) bodyObj.assignee = assignee;
 
   const response = await apiRequest(`/task/${taskId}/comment`, {
     method: 'POST',
-    body,
+    body: JSON.stringify(bodyObj),
+  });
+  return response;
+}
+
+// Update a comment (edit text, resolve, reassign)
+export async function updateComment(commentId, updates = {}) {
+  const body = {};
+  if (updates.comment_text !== undefined) body.comment_text = updates.comment_text;
+  if (updates.assignee !== undefined) body.assignee = updates.assignee;
+  if (updates.resolved !== undefined) body.resolved = updates.resolved;
+
+  const response = await apiRequest(`/comment/${commentId}`, {
+    method: 'PUT',
+    body: JSON.stringify(body),
   });
   return response;
 }
@@ -33,6 +83,38 @@ export async function postComment(taskId, text, useMarkdown = true) {
 export async function deleteComment(commentId) {
   const response = await apiRequest(`/comment/${commentId}`, {
     method: 'DELETE',
+  });
+  return response;
+}
+
+// Get threaded replies for a comment
+export async function getThreadedComments(commentId) {
+  const response = await apiRequest(`/comment/${commentId}/reply`);
+  return response.comments || [];
+}
+
+// Post a threaded reply to a comment
+export async function replyToComment(commentId, text, options = {}) {
+  if (typeof options === 'boolean') {
+    options = { useMarkdown: options };
+  }
+
+  const { useMarkdown = true, notify_all, assignee } = options;
+
+  let bodyObj;
+  if (useMarkdown) {
+    const commentArray = await textToCommentArray(text);
+    bodyObj = { comment: commentArray };
+  } else {
+    bodyObj = { comment_text: text };
+  }
+
+  if (notify_all !== undefined) bodyObj.notify_all = notify_all;
+  if (assignee !== undefined) bodyObj.assignee = assignee;
+
+  const response = await apiRequest(`/comment/${commentId}/reply`, {
+    method: 'POST',
+    body: JSON.stringify(bodyObj),
   });
   return response;
 }

--- a/.claude/skills/clickup/api/docs.mjs
+++ b/.claude/skills/clickup/api/docs.mjs
@@ -24,13 +24,28 @@ import { apiRequestV3 } from './client.mjs';
  */
 export async function searchDocs(workspaceId, options = {}) {
   const params = new URLSearchParams();
-  if (options.query) {
-    params.set('query', options.query);
-  }
+  if (options.query) params.set('query', options.query);
+  if (options.includeArchived) params.set('include_archived', 'true');
+  if (options.limit) params.set('limit', String(options.limit));
+  if (options.cursor) params.set('cursor', options.cursor);
+
   const queryString = params.toString();
   const endpoint = `/workspaces/${workspaceId}/docs${queryString ? `?${queryString}` : ''}`;
   const response = await apiRequestV3(endpoint);
-  return response.docs || [];
+
+  let docs = response.docs || [];
+
+  // Client-side parent filtering (API doesn't support parent_type/parent_id natively)
+  if (options.parentType !== undefined && options.parentId) {
+    docs = docs.filter(d =>
+      d.parent && d.parent.type === options.parentType && d.parent.id === options.parentId
+    );
+  }
+
+  return {
+    docs,
+    nextCursor: response.next_cursor || null,
+  };
 }
 
 /**
@@ -50,26 +65,23 @@ export async function getDoc(workspaceId, docId) {
  * @param {string} name - The doc name
  * @param {object} options - Additional options
  * @param {string} options.content - Initial content for the first page (markdown)
- * @param {string} options.parent - Parent object (e.g., { id: "folderId", type: 6 })
- * @param {string} options.visibility - Doc visibility
- * @returns {Promise<object>} - Created doc (with firstPageId if content was set)
+ * @param {object} options.parent - Parent: { id: string, type: number }
+ *   type values: 4=Space, 5=Folder, 6=List, 7/12=Workspace level
+ * @param {string} options.visibility - "PUBLIC", "PRIVATE", "PERSONAL", or "HIDDEN"
+ * @param {boolean} options.createPage - Auto-create first page (default: true)
  */
 export async function createDoc(workspaceId, name, options = {}) {
   const body = { name };
-  if (options.parent) {
-    body.parent = options.parent;
-  }
-  if (options.visibility) {
-    body.visibility = options.visibility;
-  }
+  if (options.parent) body.parent = options.parent;
+  if (options.visibility) body.visibility = options.visibility;
+  if (options.createPage !== undefined) body.create_page = options.createPage;
 
   const response = await apiRequestV3(`/workspaces/${workspaceId}/docs`, {
     method: 'POST',
     body: JSON.stringify(body),
   });
 
-  // If content was provided, we need to edit the first page that ClickUp auto-creates
-  // (Creating a new page would add a second page, not populate the first one)
+  // If content was provided, edit the first page that ClickUp auto-creates
   if (options.content && response.id) {
     const pages = await getDocPageListing(workspaceId, response.id);
     if (pages.length > 0) {
@@ -89,8 +101,9 @@ export async function createDoc(workspaceId, name, options = {}) {
  * @returns {Promise<object[]>} - Array of page metadata
  */
 export async function getDocPageListing(workspaceId, docId) {
-  const response = await apiRequestV3(`/workspaces/${workspaceId}/docs/${docId}/pageListing`);
-  return response.pages || [];
+  const response = await apiRequestV3(`/workspaces/${workspaceId}/docs/${docId}/page_listing`);
+  // API returns flat array directly, not wrapped in { pages: [...] }
+  return Array.isArray(response) ? response : (response.pages || []);
 }
 
 /**
@@ -102,11 +115,11 @@ export async function getDocPageListing(workspaceId, docId) {
  * @returns {Promise<object>} - Page with content
  */
 export async function getPage(workspaceId, docId, pageId, contentFormat = 'text/md') {
-  const response = await apiRequestV3(`/workspaces/${workspaceId}/docs/${docId}/pages/${pageId}`, {
-    headers: {
-      'Accept': contentFormat,
-    },
-  });
+  const params = new URLSearchParams();
+  params.set('content_format', contentFormat);
+  const response = await apiRequestV3(
+    `/workspaces/${workspaceId}/docs/${docId}/pages/${pageId}?${params.toString()}`
+  );
   return response;
 }
 
@@ -123,15 +136,11 @@ export async function getPage(workspaceId, docId, pageId, contentFormat = 'text/
  */
 export async function createPage(workspaceId, docId, name, options = {}) {
   const body = { name };
-  if (options.content) {
-    body.content = options.content;
-  }
-  if (options.parentPageId) {
-    body.parent_page_id = options.parentPageId;
-  }
-  if (options.subTitle) {
-    body.sub_title = options.subTitle;
-  }
+  if (options.content) body.content = options.content;
+  if (options.parentPageId) body.parent_page_id = options.parentPageId;
+  if (options.subTitle) body.sub_title = options.subTitle;
+  if (options.contentFormat) body.content_format = options.contentFormat;
+  if (options.orderindex !== undefined) body.orderindex = options.orderindex;
 
   const response = await apiRequestV3(`/workspaces/${workspaceId}/docs/${docId}/pages`, {
     method: 'POST',
@@ -153,15 +162,12 @@ export async function createPage(workspaceId, docId, name, options = {}) {
  */
 export async function editPage(workspaceId, docId, pageId, updates) {
   const body = {};
-  if (updates.name !== undefined) {
-    body.name = updates.name;
-  }
-  if (updates.content !== undefined) {
-    body.content = updates.content;
-  }
-  if (updates.subTitle !== undefined) {
-    body.sub_title = updates.subTitle;
-  }
+  if (updates.name !== undefined) body.name = updates.name;
+  if (updates.content !== undefined) body.content = updates.content;
+  if (updates.subTitle !== undefined) body.sub_title = updates.subTitle;
+  if (updates.contentEditMode !== undefined) body.content_edit_mode = updates.contentEditMode;
+  if (updates.contentFormat !== undefined) body.content_format = updates.contentFormat;
+  if (updates.archived !== undefined) body.archived = updates.archived;
 
   const response = await apiRequestV3(`/workspaces/${workspaceId}/docs/${docId}/pages/${pageId}`, {
     method: 'PUT',

--- a/.claude/skills/clickup/api/links.mjs
+++ b/.claude/skills/clickup/api/links.mjs
@@ -2,23 +2,10 @@
  * ClickUp links and attachments API methods
  */
 
-import { apiRequest } from './client.mjs';
+import { addTaskLink, removeTaskLink } from './tasks.mjs';
 
-// Add a link dependency between tasks
-export async function addTaskLink(taskId, linkedTaskId) {
-  const response = await apiRequest(`/task/${taskId}/link/${linkedTaskId}`, {
-    method: 'POST',
-  });
-  return response;
-}
-
-// Remove a link dependency between tasks
-export async function removeTaskLink(taskId, linkedTaskId) {
-  const response = await apiRequest(`/task/${taskId}/link/${linkedTaskId}`, {
-    method: 'DELETE',
-  });
-  return response;
-}
+// Re-export from tasks.mjs to avoid duplication
+export { addTaskLink, removeTaskLink };
 
 // Add an external URL reference via comment
 // (ClickUp doesn't have a dedicated external links field, so we use comments)
@@ -26,8 +13,8 @@ export async function addExternalLink(taskId, url, description = null) {
   const { postComment } = await import('./comments.mjs');
 
   const text = description
-    ? `📎 **Reference**: [${description}](${url})`
-    : `📎 **Reference**: ${url}`;
+    ? `**Reference**: [${description}](${url})`
+    : `**Reference**: ${url}`;
 
   return postComment(taskId, text);
 }

--- a/.claude/skills/clickup/api/lists.mjs
+++ b/.claude/skills/clickup/api/lists.mjs
@@ -3,9 +3,256 @@
  */
 
 import { apiRequest } from './client.mjs';
+import { getSpaces, getFolders } from './spaces.mjs';
+
+/**
+ * Walk the workspace tree and return every list, with hierarchy context.
+ * Uses only structural endpoints (spaces → folders-with-lists → folderless lists)
+ * which return small metadata payloads. No task fetches.
+ *
+ * Returns: [{ id, name, space: {id,name}, folder: {id,name}|null, archived }]
+ */
+export async function getAllLists(teamId, options = {}) {
+  const archived = !!options.archived;
+  const spaces = await getSpaces(teamId, { archived });
+  const out = [];
+
+  for (const space of spaces) {
+    // Folders include their nested lists inline — one request per space
+    const folders = await getFolders(space.id, { archived });
+    for (const folder of folders) {
+      for (const list of (folder.lists || [])) {
+        out.push({
+          id: list.id,
+          name: list.name,
+          space: { id: space.id, name: space.name },
+          folder: { id: folder.id, name: folder.name },
+          archived: !!list.archived,
+        });
+      }
+    }
+
+    // Folderless lists in the space
+    const folderless = await getFolderlessLists(space.id, { archived });
+    for (const list of folderless) {
+      out.push({
+        id: list.id,
+        name: list.name,
+        space: { id: space.id, name: space.name },
+        folder: null,
+        archived: !!list.archived,
+      });
+    }
+  }
+
+  return out;
+}
+
+/**
+ * Find lists by name. Matches exact > starts-with > contains (all case-insensitive).
+ * Also accepts a folder-name match so `find-list "Red Launch"` can resolve to the
+ * folder's contents when the user gave us a folder name.
+ *
+ * Returns { lists: [...], folders: [...] }
+ */
+export async function findListByName(teamId, query, options = {}) {
+  const q = (query || '').toLowerCase().trim();
+  if (!q) {
+    throw new Error('findListByName requires a query string');
+  }
+
+  const archived = !!options.archived;
+  const spaces = await getSpaces(teamId, { archived });
+
+  const listMatches = [];
+  const folderMatches = [];
+
+  const rank = (name) => {
+    const n = name.toLowerCase();
+    if (n === q) return 0;
+    if (n.startsWith(q)) return 1;
+    if (n.includes(q)) return 2;
+    return -1;
+  };
+
+  for (const space of spaces) {
+    const folders = await getFolders(space.id, { archived });
+    for (const folder of folders) {
+      const fr = rank(folder.name);
+      if (fr >= 0) {
+        folderMatches.push({
+          rank: fr,
+          id: folder.id,
+          name: folder.name,
+          space: { id: space.id, name: space.name },
+          listCount: (folder.lists || []).length,
+          lists: (folder.lists || []).map(l => ({ id: l.id, name: l.name })),
+        });
+      }
+      for (const list of (folder.lists || [])) {
+        const lr = rank(list.name);
+        if (lr >= 0) {
+          listMatches.push({
+            rank: lr,
+            id: list.id,
+            name: list.name,
+            space: { id: space.id, name: space.name },
+            folder: { id: folder.id, name: folder.name },
+          });
+        }
+      }
+    }
+
+    const folderless = await getFolderlessLists(space.id, { archived });
+    for (const list of folderless) {
+      const lr = rank(list.name);
+      if (lr >= 0) {
+        listMatches.push({
+          rank: lr,
+          id: list.id,
+          name: list.name,
+          space: { id: space.id, name: space.name },
+          folder: null,
+        });
+      }
+    }
+  }
+
+  listMatches.sort((a, b) => a.rank - b.rank || a.name.localeCompare(b.name));
+  folderMatches.sort((a, b) => a.rank - b.rank || a.name.localeCompare(b.name));
+
+  return { lists: listMatches, folders: folderMatches };
+}
 
 // Get list details (including statuses)
 export async function getList(listId) {
   const response = await apiRequest(`/list/${listId}`);
+  return response;
+}
+
+/**
+ * Create a new list in a space (folderless list)
+ * @param {string} spaceId - The space ID
+ * @param {string} name - The list name
+ * @param {object} options - Additional options
+ * @param {string} options.content - List description
+ * @param {string} options.due_date - Due date timestamp
+ * @param {number} options.priority - Priority (1=urgent, 2=high, 3=normal, 4=low)
+ * @param {string} options.assignee - Assignee user ID
+ * @param {string} options.status - Default status for tasks
+ * @returns {Promise<object>} - Created list
+ */
+export async function createList(spaceId, name, options = {}) {
+  const body = { name };
+
+  if (options.content) {
+    body.content = options.content;
+  }
+  if (options.due_date) {
+    body.due_date = options.due_date;
+  }
+  if (options.due_date_time !== undefined) {
+    body.due_date_time = options.due_date_time;
+  }
+  if (options.priority) {
+    body.priority = options.priority;
+  }
+  if (options.assignee) {
+    body.assignee = options.assignee;
+  }
+  if (options.status) {
+    body.status = options.status;
+  }
+
+  const response = await apiRequest(`/space/${spaceId}/list`, {
+    method: 'POST',
+    body: JSON.stringify(body),
+  });
+  return response;
+}
+
+/**
+ * Create a new list in a folder
+ * @param {string} folderId - The folder ID
+ * @param {string} name - The list name
+ * @param {object} options - Additional options (same as createList)
+ * @returns {Promise<object>} - Created list
+ */
+export async function createListInFolder(folderId, name, options = {}) {
+  const body = { name };
+
+  if (options.content) {
+    body.content = options.content;
+  }
+  if (options.due_date) {
+    body.due_date = options.due_date;
+  }
+  if (options.due_date_time !== undefined) {
+    body.due_date_time = options.due_date_time;
+  }
+  if (options.priority) {
+    body.priority = options.priority;
+  }
+  if (options.assignee) {
+    body.assignee = options.assignee;
+  }
+  if (options.status) {
+    body.status = options.status;
+  }
+
+  const response = await apiRequest(`/folder/${folderId}/list`, {
+    method: 'POST',
+    body: JSON.stringify(body),
+  });
+  return response;
+}
+
+// Update a list
+export async function updateList(listId, updates = {}) {
+  const body = {};
+  const fields = ['name', 'content', 'due_date', 'due_date_time', 'priority', 'assignee', 'status', 'unset_status', 'color'];
+  for (const field of fields) {
+    if (updates[field] !== undefined) body[field] = updates[field];
+  }
+  const response = await apiRequest(`/list/${listId}`, {
+    method: 'PUT',
+    body: JSON.stringify(body),
+  });
+  return response;
+}
+
+// Get lists in a folder
+export async function getLists(folderId, options = {}) {
+  const params = new URLSearchParams();
+  if (options.archived) params.append('archived', 'true');
+  const queryString = params.toString();
+  const response = await apiRequest(`/folder/${folderId}/list${queryString ? `?${queryString}` : ''}`);
+  return response.lists || [];
+}
+
+// Get folderless lists in a space
+export async function getFolderlessLists(spaceId, options = {}) {
+  const params = new URLSearchParams();
+  if (options.archived) params.append('archived', 'true');
+  const queryString = params.toString();
+  const response = await apiRequest(`/space/${spaceId}/list${queryString ? `?${queryString}` : ''}`);
+  return response.lists || [];
+}
+
+// Get members with explicit access to a list
+export async function getListMembers(listId) {
+  const response = await apiRequest(`/list/${listId}/member`);
+  return response.members || response;
+}
+
+/**
+ * Delete a list
+ * @param {string} listId - The list ID
+ * @returns {Promise<object>} - Empty object on success
+ */
+export async function deleteList(listId) {
+  const response = await apiRequest(`/list/${listId}`, {
+    method: 'DELETE',
+  });
   return response;
 }

--- a/.claude/skills/clickup/api/spaces.mjs
+++ b/.claude/skills/clickup/api/spaces.mjs
@@ -1,0 +1,33 @@
+/**
+ * ClickUp Space + Folder API methods — structural metadata only.
+ * Used for walking the workspace tree to find lists/folders/spaces by name.
+ */
+
+import { apiRequest } from './client.mjs';
+
+// Get all spaces in a team (small response — team-level metadata)
+export async function getSpaces(teamId, options = {}) {
+  const params = new URLSearchParams();
+  if (options.archived) params.append('archived', 'true');
+  const qs = params.toString();
+  const response = await apiRequest(`/team/${teamId}/space${qs ? `?${qs}` : ''}`);
+  return response.spaces || [];
+}
+
+// Get a single space
+export async function getSpace(spaceId) {
+  return apiRequest(`/space/${spaceId}`);
+}
+
+// Get folders in a space (includes nested lists in the response)
+export async function getFolders(spaceId, options = {}) {
+  const params = new URLSearchParams();
+  if (options.archived) params.append('archived', 'true');
+  const qs = params.toString();
+  const response = await apiRequest(`/space/${spaceId}/folder${qs ? `?${qs}` : ''}`);
+  return response.folders || [];
+}
+
+export async function getFolder(folderId) {
+  return apiRequest(`/folder/${folderId}`);
+}

--- a/.claude/skills/clickup/api/tasks.mjs
+++ b/.claude/skills/clickup/api/tasks.mjs
@@ -2,12 +2,12 @@
  * ClickUp task API methods
  */
 
-import { apiRequest } from './client.mjs';
+import { apiRequest, apiRequestV3, fetchAllPages } from './client.mjs';
 import { getList } from './lists.mjs';
 
 // Get task details
 export async function getTask(taskId, includeSubtasks = false) {
-  const params = includeSubtasks ? '?subtasks=true' : '';
+  const params = includeSubtasks ? '?include_subtasks=true' : '';
   const task = await apiRequest(`/task/${taskId}${params}`);
   return task;
 }
@@ -18,8 +18,7 @@ export async function getTasksInList(listId, assigneeId = null) {
   if (assigneeId) {
     endpoint += `?assignees[]=${assigneeId}`;
   }
-  const response = await apiRequest(endpoint);
-  return response.tasks || [];
+  return fetchAllPages(endpoint, 'tasks');
 }
 
 // Update a task
@@ -98,27 +97,72 @@ export async function createSubtask(parentTaskId, name, options = {}) {
   return response;
 }
 
-// Search tasks across team
+/**
+ * Search tasks using the ClickUp v2 filtered-team-tasks endpoint.
+ *
+ * ClickUp v2 has no native text search, so a text `query` is applied in-process
+ * AFTER the server has already scoped the result set with native filters. To
+ * keep request volume bounded, at least one scoping filter is required:
+ * `assigneeId`, `list_ids`, `project_ids` (folders), `space_ids`, or `statuses`.
+ * Pass `options.all = true` to run unscoped across the whole workspace
+ * (expect multi-second latency on large teams).
+ */
 export async function searchTasks(teamId, query, options = {}) {
-  // ClickUp uses filtered views for search
-  // The team tasks endpoint with search doesn't exist directly,
-  // so we use the global search endpoint
-  const params = new URLSearchParams();
-  if (options.assigneeId) {
-    params.append('assignees[]', options.assigneeId);
+  const hasScope = !!(
+    options.assigneeId ||
+    (Array.isArray(options.list_ids) && options.list_ids.length) ||
+    (Array.isArray(options.project_ids) && options.project_ids.length) ||
+    (Array.isArray(options.space_ids) && options.space_ids.length) ||
+    (Array.isArray(options.statuses) && options.statuses.length)
+  );
+  if (!hasScope && !options.all) {
+    const err = new Error(
+      'searchTasks requires a scope (assigneeId / list_ids / project_ids / space_ids / statuses) ' +
+      'or options.all=true for a full-workspace scan.'
+    );
+    err.code = 'SCOPE_REQUIRED';
+    throw err;
   }
 
-  // Use the search endpoint
-  const endpoint = `/team/${teamId}/task?${params.toString()}`;
-  const response = await apiRequest(endpoint);
-  const tasks = response.tasks || [];
+  const params = new URLSearchParams();
 
-  // Filter by query client-side (ClickUp doesn't have direct text search)
+  if (options.assigneeId) params.append('assignees[]', options.assigneeId);
+
+  if (Array.isArray(options.statuses)) {
+    for (const status of options.statuses) params.append('statuses[]', status);
+  }
+
+  if (options.include_closed) params.append('include_closed', 'true');
+  if (options.subtasks) params.append('subtasks', 'true');
+
+  if (Array.isArray(options.space_ids)) {
+    for (const id of options.space_ids) params.append('space_ids[]', id);
+  }
+  if (Array.isArray(options.project_ids)) {
+    for (const id of options.project_ids) params.append('project_ids[]', id);
+  }
+  if (Array.isArray(options.list_ids)) {
+    for (const id of options.list_ids) params.append('list_ids[]', id);
+  }
+
+  const dateFilters = [
+    'date_created_gt', 'date_created_lt',
+    'date_updated_gt', 'date_updated_lt',
+    'due_date_gt', 'due_date_lt',
+  ];
+  for (const filter of dateFilters) {
+    if (options[filter]) params.append(filter, options[filter]);
+  }
+
+  const paramStr = params.toString();
+  const endpoint = `/team/${teamId}/task${paramStr ? '?' + paramStr : ''}`;
+  const tasks = await fetchAllPages(endpoint, 'tasks');
+
   if (query) {
-    const queryLower = query.toLowerCase();
+    const q = query.toLowerCase();
     return tasks.filter(t =>
-      t.name.toLowerCase().includes(queryLower) ||
-      (t.description && t.description.toLowerCase().includes(queryLower))
+      t.name.toLowerCase().includes(q) ||
+      (t.description && t.description.toLowerCase().includes(q))
     );
   }
 
@@ -132,8 +176,7 @@ export async function getMyTasks(teamId, userId) {
   params.append('subtasks', 'true');
 
   const endpoint = `/team/${teamId}/task?${params.toString()}`;
-  const response = await apiRequest(endpoint);
-  return response.tasks || [];
+  return fetchAllPages(endpoint, 'tasks');
 }
 
 // Update task assignees
@@ -160,7 +203,37 @@ export async function setDueDate(taskId, dueDate) {
     timestamp = parsed.getTime();
   }
 
-  const response = await updateTask(taskId, { due_date: timestamp });
+  const response = await updateTask(taskId, { due_date: timestamp, due_date_time: true });
+  return response;
+}
+
+// Update task start date
+export async function setStartDate(taskId, startDate) {
+  // Convert to timestamp if needed
+  let timestamp = null;
+  if (startDate) {
+    const parsed = parseDateInput(startDate);
+    timestamp = parsed.getTime();
+  }
+
+  const response = await updateTask(taskId, { start_date: timestamp, start_date_time: true });
+  return response;
+}
+
+// Update task dates (start and/or due)
+export async function setDates(taskId, options = {}) {
+  const updates = {};
+  if (options.start) {
+    const parsed = parseDateInput(options.start);
+    updates.start_date = parsed.getTime();
+    updates.start_date_time = true;
+  }
+  if (options.due) {
+    const parsed = parseDateInput(options.due);
+    updates.due_date = parsed.getTime();
+    updates.due_date_time = true;
+  }
+  const response = await updateTask(taskId, updates);
   return response;
 }
 
@@ -247,24 +320,36 @@ export async function setPriority(taskId, priorityInput) {
   return { task: response, priority: priorityInput };
 }
 
-// Move task to a different list
-export async function moveTask(taskId, targetListId) {
-  // Use the dedicated move endpoint
-  const response = await apiRequest(`/list/${targetListId}/task/${taskId}`, {
-    method: 'POST',
-  });
+// Move task to a different list (v3 endpoint)
+export async function moveTask(taskId, targetListId, workspaceId) {
+  const response = await apiRequestV3(
+    `/workspaces/${workspaceId}/tasks/${taskId}/home_list/${targetListId}`,
+    { method: 'PUT' }
+  );
   return response;
 }
 
-// Add a watcher/follower to a task
-// NOTE: ClickUp API v2 does not have a documented public endpoint for adding watchers.
-// Returns null to indicate watchers cannot be added programmatically via API.
-// Callers should use @mentions in comments as an alternative notification mechanism.
+// Archive a task (removes from active views, retrievable later)
+export async function archiveTask(taskId) {
+  const response = await updateTask(taskId, { archived: true });
+  return response;
+}
+
+// Unarchive a task (restore from archive)
+export async function unarchiveTask(taskId) {
+  const response = await updateTask(taskId, { archived: false });
+  return response;
+}
+
+// Add a watcher/follower to a task via UpdateTask
+// Note: ClickUp UI calls these "followers" but the API field is "watchers"
 export async function addWatcher(taskId, userId) {
-  throw new Error(
-    'ClickUp API v2 does not support adding watchers programmatically. ' +
-    'Use "@username" in a comment to notify someone instead.'
-  );
+  return updateTask(taskId, { watchers: { add: [parseInt(userId, 10)] } });
+}
+
+// Remove a watcher/follower from a task
+export async function removeWatcher(taskId, userId) {
+  return updateTask(taskId, { watchers: { rem: [parseInt(userId, 10)] } });
 }
 
 // Add a tag to a task
@@ -284,4 +369,85 @@ export async function removeTag(taskId, tagName) {
     method: 'DELETE',
   });
   return response;
+}
+
+// Add a dependency (task waits on another task)
+// depends_on: the task that must complete first
+// dependency_of: the task that is blocked
+// Only one of depends_on or dependency_of should be set
+export async function addDependency(taskId, options = {}) {
+  const body = {};
+  if (options.depends_on) {
+    body.depends_on = options.depends_on;
+  } else if (options.dependency_of) {
+    body.dependency_of = options.dependency_of;
+  } else {
+    throw new Error('Must specify either depends_on or dependency_of');
+  }
+  const response = await apiRequest(`/task/${taskId}/dependency`, {
+    method: 'POST',
+    body: JSON.stringify(body),
+  });
+  return response;
+}
+
+// Remove a dependency
+export async function removeDependency(taskId, options = {}) {
+  const params = new URLSearchParams();
+  if (options.depends_on) {
+    params.append('depends_on', options.depends_on);
+  } else if (options.dependency_of) {
+    params.append('dependency_of', options.dependency_of);
+  } else {
+    throw new Error('Must specify either depends_on or dependency_of');
+  }
+  const response = await apiRequest(`/task/${taskId}/dependency?${params.toString()}`, {
+    method: 'DELETE',
+  });
+  return response;
+}
+
+// Add a task link (bidirectional link between tasks)
+export async function addTaskLink(taskId, linksToTaskId) {
+  const response = await apiRequest(`/task/${taskId}/link/${linksToTaskId}`, {
+    method: 'POST',
+  });
+  return response;
+}
+
+// Remove a task link
+export async function removeTaskLink(taskId, linksToTaskId) {
+  const response = await apiRequest(`/task/${taskId}/link/${linksToTaskId}`, {
+    method: 'DELETE',
+  });
+  return response;
+}
+
+// Get members with explicit access to a task
+export async function getTaskMembers(taskId) {
+  const response = await apiRequest(`/task/${taskId}/member`);
+  return response.members || response;
+}
+
+// Set a custom field value on a task
+export async function setCustomField(taskId, fieldId, value) {
+  return apiRequest(`/task/${taskId}/field/${fieldId}`, {
+    method: 'POST',
+    body: JSON.stringify({ value }),
+  });
+}
+
+// Find a custom field on a task by name (case-insensitive partial match)
+export async function findCustomFieldByName(taskId, fieldName) {
+  const task = await getTask(taskId);
+  const fields = task.custom_fields || [];
+  const nameLower = fieldName.toLowerCase();
+
+  // Exact match first
+  const exact = fields.find(f => f.name.toLowerCase() === nameLower);
+  if (exact) return exact;
+
+  // Partial match
+  const partial = fields.find(f => f.name.toLowerCase().includes(nameLower));
+  return partial || null;
 }

--- a/.claude/skills/clickup/api/user.mjs
+++ b/.claude/skills/clickup/api/user.mjs
@@ -2,12 +2,14 @@
  * ClickUp user and team API methods
  */
 
-import { apiRequest, appendToEnv } from './client.mjs';
+import { apiRequest, getActiveCredentials, getActiveAccountId } from './client.mjs';
+import { updateAccountField } from '../lib/accounts.mjs';
 
 // Get team ID (fetch and cache if not set)
 export async function getTeamId() {
-  if (process.env.CLICKUP_TEAM_ID) {
-    return process.env.CLICKUP_TEAM_ID;
+  const creds = getActiveCredentials();
+  if (creds.teamId) {
+    return creds.teamId;
   }
 
   console.error('Fetching team ID from ClickUp...');
@@ -21,8 +23,8 @@ export async function getTeamId() {
   const team = teams[0];
   const teamId = team.id;
 
-  if (appendToEnv('CLICKUP_TEAM_ID', teamId, `Team: ${team.name} (auto-detected)`)) {
-    console.error(`Cached team ID ${teamId} (${team.name}) to .env\n`);
+  if (updateAccountField(getActiveAccountId(), 'teamId', teamId)) {
+    console.error(`Cached team ID ${teamId} (${team.name}) to accounts.json\n`);
   }
 
   return teamId;
@@ -30,8 +32,9 @@ export async function getTeamId() {
 
 // Get current user ID (fetch and cache if not set)
 export async function getUserId() {
-  if (process.env.CLICKUP_USER_ID) {
-    return process.env.CLICKUP_USER_ID;
+  const creds = getActiveCredentials();
+  if (creds.userId) {
+    return creds.userId;
   }
 
   console.error('Fetching user info from ClickUp...');
@@ -44,8 +47,8 @@ export async function getUserId() {
 
   const userId = user.id.toString();
 
-  if (appendToEnv('CLICKUP_USER_ID', userId, `User: ${user.username} (auto-detected)`)) {
-    console.error(`Cached user ID ${userId} (${user.username}) to .env\n`);
+  if (updateAccountField(getActiveAccountId(), 'userId', userId)) {
+    console.error(`Cached user ID ${userId} (${user.username}) to accounts.json\n`);
   }
 
   return userId;

--- a/.claude/skills/clickup/api/webhooks.mjs
+++ b/.claude/skills/clickup/api/webhooks.mjs
@@ -1,0 +1,156 @@
+/**
+ * ClickUp Webhook API — create, list, delete, update webhooks
+ *
+ * Webhooks can be scoped to task, list, folder, or space level.
+ * Unscoped webhooks fire for all events in the workspace.
+ */
+
+import { apiRequest } from './client.mjs';
+import { getTeamId } from './user.mjs';
+import { readFileSync, writeFileSync, existsSync } from 'fs';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const WATCHERS_FILE = resolve(__dirname, '..', 'watchers.json');
+
+// ── Persistent watcher registry ───────────────────────────────────────────
+
+function loadWatchers() {
+  if (!existsSync(WATCHERS_FILE)) return [];
+  try {
+    return JSON.parse(readFileSync(WATCHERS_FILE, 'utf-8'));
+  } catch {
+    return [];
+  }
+}
+
+function saveWatchers(watchers) {
+  writeFileSync(WATCHERS_FILE, JSON.stringify(watchers, null, 2));
+}
+
+export function addWatcherEntry(entry) {
+  const watchers = loadWatchers();
+  watchers.push(entry);
+  saveWatchers(watchers);
+}
+
+export function removeWatcherEntry(webhookId) {
+  const watchers = loadWatchers().filter(w => w.webhookId !== webhookId);
+  saveWatchers(watchers);
+}
+
+export function getWatcherEntries() {
+  return loadWatchers();
+}
+
+export function getWatcherSecret(webhookId) {
+  const entry = loadWatchers().find(w => w.webhookId === webhookId);
+  return entry?.secret || null;
+}
+
+export function clearAllWatcherEntries() {
+  saveWatchers([]);
+}
+
+// ── ClickUp Webhook API ───────────────────────────────────────────────────
+
+/**
+ * Create a webhook.
+ * @param {string} endpoint - URL to receive events
+ * @param {string[]} events - Event types to subscribe to
+ * @param {object} scope - Optional { taskId, listId, folderId, spaceId }
+ * @returns {object} Webhook object with id, secret, etc.
+ */
+export async function createWebhook(endpoint, events, scope = {}) {
+  const teamId = await getTeamId();
+  const body = { endpoint, events };
+  if (scope.taskId) body.task_id = scope.taskId;
+  if (scope.listId) body.list_id = scope.listId;
+  if (scope.folderId) body.folder_id = scope.folderId;
+  if (scope.spaceId) body.space_id = scope.spaceId;
+
+  const result = await apiRequest(`/team/${teamId}/webhook`, {
+    method: 'POST',
+    body: JSON.stringify(body),
+  });
+  return result.webhook || result;
+}
+
+/**
+ * List all webhooks for the workspace.
+ */
+export async function listWebhooks() {
+  const teamId = await getTeamId();
+  const result = await apiRequest(`/team/${teamId}/webhook`);
+  return result.webhooks || [];
+}
+
+/**
+ * Delete a webhook by ID.
+ */
+export async function deleteWebhook(webhookId) {
+  return apiRequest(`/webhook/${webhookId}`, { method: 'DELETE' });
+}
+
+/**
+ * Update a webhook (endpoint, events, status).
+ */
+export async function updateWebhook(webhookId, updates = {}) {
+  const body = {};
+  if (updates.endpoint) body.endpoint = updates.endpoint;
+  if (updates.events) body.events = updates.events;
+  if (updates.status) body.status = updates.status;
+
+  return apiRequest(`/webhook/${webhookId}`, {
+    method: 'PUT',
+    body: JSON.stringify(body),
+  });
+}
+
+// ── Default events for common watch commands ──────────────────────────────
+
+export const DEFAULT_TASK_EVENTS = [
+  'taskStatusUpdated',
+  'taskCommentPosted',
+  'taskUpdated',
+  'taskAssigneeUpdated',
+  'taskDueDateUpdated',
+];
+
+export const DEFAULT_LIST_EVENTS = [
+  'taskCreated',
+  'taskStatusUpdated',
+  'taskCommentPosted',
+  'taskUpdated',
+  'taskDeleted',
+];
+
+export const DEFAULT_SPACE_EVENTS = [
+  'taskCreated',
+  'taskStatusUpdated',
+  'taskCommentPosted',
+  'taskUpdated',
+  'taskDeleted',
+  'listCreated',
+  'listUpdated',
+  'listDeleted',
+];
+
+export const ALL_TASK_EVENTS = [
+  'taskCreated',
+  'taskUpdated',
+  'taskDeleted',
+  'taskPriorityUpdated',
+  'taskStatusUpdated',
+  'taskAssigneeUpdated',
+  'taskDueDateUpdated',
+  'taskTagUpdated',
+  'taskMoved',
+  'taskCommentPosted',
+  'taskCommentUpdated',
+  'taskTimeEstimateUpdated',
+  'taskTimeTrackedUpdated',
+  'taskAttachmentUploaded',
+  'taskCustomFieldUpdated',
+];

--- a/.claude/skills/clickup/lib/accounts.mjs
+++ b/.claude/skills/clickup/lib/accounts.mjs
@@ -1,0 +1,208 @@
+/**
+ * ClickUp Multi-Account Credential Manager
+ *
+ * Manages named accounts in accounts.json. Auto-migrates from .env on first run.
+ *
+ * Schema:
+ * {
+ *   "defaultAccount": "bot",
+ *   "accounts": {
+ *     "bot": { "apiToken": "pk_...", "teamId": "...", ... },
+ *     "justin": { "apiToken": "pk_...", ... }
+ *   }
+ * }
+ *
+ * Only apiToken is required. Other fields are auto-detected and cached.
+ */
+
+import { readFileSync, writeFileSync, existsSync, chmodSync } from 'fs';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SKILL_DIR = resolve(__dirname, '..');
+const ACCOUNTS_PATH = resolve(SKILL_DIR, 'accounts.json');
+const ENV_PATH = resolve(SKILL_DIR, '.env');
+
+// ENV key -> accounts.json field mapping
+const ENV_KEY_MAP = {
+  CLICKUP_API_TOKEN: 'apiToken',
+  CLICKUP_TEAM_ID: 'teamId',
+  CLICKUP_USER_ID: 'userId',
+  CLICKUP_DEFAULT_LIST_ID: 'defaultListId',
+  CLICKUP_EMAIL: 'email',
+  CLICKUP_PASSWORD: 'password',
+  CLICKUP_JWT: 'jwt',
+  CLICKUP_INTERNAL_API: 'internalApiUrl',
+};
+
+/**
+ * Parse a .env file into key-value pairs (skips comments and blank lines)
+ */
+function parseEnvFile(filePath) {
+  const pairs = {};
+  const content = readFileSync(filePath, 'utf-8');
+  for (const line of content.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    const eqIdx = trimmed.indexOf('=');
+    if (eqIdx === -1) continue;
+    pairs[trimmed.slice(0, eqIdx)] = trimmed.slice(eqIdx + 1);
+  }
+  return pairs;
+}
+
+/**
+ * Migrate credentials from .env to accounts.json format
+ */
+export function migrateFromEnv() {
+  if (!existsSync(ENV_PATH)) return null;
+  const envVars = parseEnvFile(ENV_PATH);
+  const creds = {};
+  for (const [envKey, jsonKey] of Object.entries(ENV_KEY_MAP)) {
+    if (envVars[envKey]) {
+      creds[jsonKey] = envVars[envKey];
+    }
+  }
+  if (!creds.apiToken) return null;
+
+  const config = {
+    defaultAccount: 'default',
+    accounts: { default: creds },
+  };
+  saveAccountConfig(config);
+  console.error('Migrated credentials from .env to accounts.json');
+  console.error('You can safely remove .env when ready (accounts.json is now the source of truth).');
+  return config;
+}
+
+/**
+ * Load accounts.json. Auto-migrates from .env if missing.
+ */
+export function loadAccountConfig() {
+  if (existsSync(ACCOUNTS_PATH)) {
+    try {
+      return JSON.parse(readFileSync(ACCOUNTS_PATH, 'utf-8'));
+    } catch (e) {
+      throw new Error(`Failed to parse accounts.json: ${e.message}`);
+    }
+  }
+  // Auto-migrate from .env
+  const migrated = migrateFromEnv();
+  if (migrated) return migrated;
+  return null;
+}
+
+/**
+ * Write accounts.json with restricted permissions
+ */
+export function saveAccountConfig(config) {
+  writeFileSync(ACCOUNTS_PATH, JSON.stringify(config, null, 2) + '\n');
+  try { chmodSync(ACCOUNTS_PATH, 0o600); } catch { /* Windows may not support */ }
+}
+
+/**
+ * Get credentials for a specific account (or the default)
+ */
+export function getAccountCredentials(accountId) {
+  const config = loadAccountConfig();
+  if (!config) {
+    throw new Error(
+      'No accounts configured.\n' +
+      'Setup: Create accounts.json or .env in the skill directory.\n' +
+      'See SKILL.md for details.'
+    );
+  }
+  const id = accountId || config.defaultAccount;
+  const creds = config.accounts?.[id];
+  if (!creds) {
+    const available = Object.keys(config.accounts || {}).join(', ');
+    throw new Error(
+      `Account "${id}" not found in accounts.json.\n` +
+      `Available accounts: ${available || '(none)'}`
+    );
+  }
+  return { ...creds, _accountId: id };
+}
+
+/**
+ * Update a single field on an account and persist
+ */
+export function updateAccountField(accountId, key, value) {
+  const config = loadAccountConfig();
+  if (!config) return false;
+  const id = accountId || config.defaultAccount;
+  if (!config.accounts?.[id]) return false;
+  config.accounts[id][key] = value;
+  saveAccountConfig(config);
+  return true;
+}
+
+/**
+ * Get the default account ID
+ */
+export function getDefaultAccount() {
+  const config = loadAccountConfig();
+  return config?.defaultAccount || null;
+}
+
+/**
+ * Set the default account
+ */
+export function setDefaultAccount(accountId) {
+  const config = loadAccountConfig();
+  if (!config) throw new Error('No accounts.json found');
+  if (!config.accounts?.[accountId]) {
+    throw new Error(`Account "${accountId}" not found`);
+  }
+  config.defaultAccount = accountId;
+  saveAccountConfig(config);
+}
+
+/**
+ * List all accounts (summary, no secrets)
+ */
+export function listAccounts() {
+  const config = loadAccountConfig();
+  if (!config) return [];
+  return Object.entries(config.accounts || {}).map(([id, creds]) => ({
+    id,
+    isDefault: id === config.defaultAccount,
+    hasApiToken: !!creds.apiToken,
+    hasJwt: !!creds.jwt,
+    teamId: creds.teamId || null,
+    userId: creds.userId || null,
+    email: creds.email || null,
+  }));
+}
+
+/**
+ * Add a new account
+ */
+export function addAccount(accountId, creds) {
+  let config = loadAccountConfig();
+  if (!config) {
+    config = { defaultAccount: accountId, accounts: {} };
+  }
+  if (config.accounts[accountId]) {
+    throw new Error(`Account "${accountId}" already exists. Remove it first.`);
+  }
+  config.accounts[accountId] = creds;
+  saveAccountConfig(config);
+}
+
+/**
+ * Remove an account
+ */
+export function removeAccount(accountId) {
+  const config = loadAccountConfig();
+  if (!config?.accounts?.[accountId]) {
+    throw new Error(`Account "${accountId}" not found`);
+  }
+  delete config.accounts[accountId];
+  if (config.defaultAccount === accountId) {
+    const remaining = Object.keys(config.accounts);
+    config.defaultAccount = remaining[0] || null;
+  }
+  saveAccountConfig(config);
+}

--- a/.claude/skills/clickup/lib/batch-create.mjs
+++ b/.claude/skills/clickup/lib/batch-create.mjs
@@ -1,0 +1,206 @@
+/**
+ * Batch Task Creator — create an entire project from a JSON plan
+ *
+ * Reads a JSON file with a tasks array, creates them in order,
+ * resolves inter-task dependencies using temporary IDs (ref keys),
+ * and sets up assignees, priorities, statuses, and subtasks.
+ *
+ * JSON Schema:
+ * {
+ *   "listId": "901111220963",       // default list (can override per task)
+ *   "tasks": [
+ *     {
+ *       "ref": "design",            // local ref for dependencies (optional)
+ *       "name": "Design system architecture",
+ *       "description": "Create the architecture doc",
+ *       "assignee": "justin",       // name, email, or ID
+ *       "priority": "high",         // urgent/high/normal/low/none
+ *       "status": "to do",          // status name
+ *       "dueDate": "+7d",           // relative or absolute date
+ *       "startDate": "today",
+ *       "tags": ["architecture"],
+ *       "listId": "901111220964",   // override default list
+ *       "dependsOn": ["other-ref"], // must complete before this task starts
+ *       "blocks": ["other-ref"],    // this task blocks other tasks
+ *       "subtasks": [
+ *         { "name": "Draft ERD", "assignee": "mark" },
+ *         { "name": "Review ERD", "assignee": "dakota" }
+ *       ]
+ *     }
+ *   ]
+ * }
+ */
+
+import { createTask, createSubtask, addDependency, setPriority, parseDateInput, setDueDate, setStartDate, assignTask, addTag } from '../api/tasks.mjs';
+import { findUser } from '../api/user.mjs';
+
+/**
+ * Execute a batch create plan.
+ * @param {object} plan - Parsed JSON plan
+ * @param {object} opts - { verbose, dryRun }
+ * @returns {object} Results with created tasks and any errors
+ */
+export async function executeBatchCreate(plan, opts = {}) {
+  const { verbose = false, dryRun = false } = opts;
+  const defaultListId = plan.listId;
+  const tasks = plan.tasks || [];
+
+  if (tasks.length === 0) {
+    return { created: [], errors: [], message: 'No tasks in plan' };
+  }
+
+  // Phase 1: Create all tasks and map refs to real IDs
+  const refToId = {};
+  const created = [];
+  const errors = [];
+
+  for (let i = 0; i < tasks.length; i++) {
+    const t = tasks[i];
+    const listId = t.listId || defaultListId;
+
+    if (!listId) {
+      errors.push({ ref: t.ref || i, error: 'No listId specified (and no default)' });
+      continue;
+    }
+
+    if (dryRun) {
+      const fakeId = `dry-run-${i}`;
+      if (t.ref) refToId[t.ref] = fakeId;
+      created.push({ ref: t.ref, id: fakeId, name: t.name, dryRun: true });
+      if (verbose) process.stderr.write(`[dry-run] Would create: "${t.name}" in list ${listId}\n`);
+      continue;
+    }
+
+    try {
+      // Build create options
+      const createOpts = {};
+      if (t.description) createOpts.markdown_description = t.description;
+      if (t.status) createOpts.status = t.status;
+      if (t.dueDate) {
+        try {
+          const date = parseDateInput(t.dueDate);
+          if (date) createOpts.due_date = date instanceof Date ? date.getTime() : date;
+        } catch (e) {
+          if (verbose) process.stderr.write(`  Warning: Could not parse due date "${t.dueDate}": ${e.message}\n`);
+        }
+      }
+      if (t.startDate) {
+        try {
+          const date = parseDateInput(t.startDate);
+          if (date) createOpts.start_date = date instanceof Date ? date.getTime() : date;
+        } catch (e) {
+          if (verbose) process.stderr.write(`  Warning: Could not parse start date "${t.startDate}": ${e.message}\n`);
+        }
+      }
+
+      const result = await createTask(listId, t.name, createOpts);
+      const taskId = result.id;
+
+      if (t.ref) refToId[t.ref] = taskId;
+      created.push({ ref: t.ref || null, id: taskId, name: t.name });
+
+      if (verbose) process.stderr.write(`[${i + 1}/${tasks.length}] Created "${t.name}" → ${taskId}\n`);
+
+      // Set priority
+      if (t.priority) {
+        await setPriority(taskId, t.priority);
+      }
+
+      // Assign
+      if (t.assignee) {
+        try {
+          const user = await findUser(t.assignee);
+          if (user) await assignTask(taskId, user.id);
+        } catch (e) {
+          if (verbose) process.stderr.write(`  Warning: Could not assign "${t.assignee}": ${e.message}\n`);
+        }
+      }
+
+      // Tags
+      if (t.tags && t.tags.length > 0) {
+        for (const tag of t.tags) {
+          try {
+            await addTag(taskId, tag);
+          } catch (e) {
+            if (verbose) process.stderr.write(`  Warning: Could not add tag "${tag}": ${e.message}\n`);
+          }
+        }
+      }
+
+      // Subtasks
+      if (t.subtasks && t.subtasks.length > 0) {
+        for (const sub of t.subtasks) {
+          try {
+            const subResult = await createSubtask(taskId, sub.name, {
+              description: sub.description || undefined,
+              status: sub.status || undefined,
+            });
+            if (verbose) process.stderr.write(`  ↳ Subtask "${sub.name}" → ${subResult.id}\n`);
+
+            // Assign subtask
+            if (sub.assignee) {
+              try {
+                const user = await findUser(sub.assignee);
+                if (user) await assignTask(subResult.id, user.id);
+              } catch {}
+            }
+          } catch (e) {
+            errors.push({ ref: t.ref, subtask: sub.name, error: e.message });
+          }
+        }
+      }
+    } catch (e) {
+      errors.push({ ref: t.ref || i, name: t.name, error: e.message });
+      if (verbose) process.stderr.write(`  Error creating "${t.name}": ${e.message}\n`);
+    }
+  }
+
+  // Phase 2: Wire up dependencies (now that all tasks exist)
+  if (!dryRun) {
+    for (const t of tasks) {
+      if (!t.ref || !refToId[t.ref]) continue;
+      const taskId = refToId[t.ref];
+
+      // dependsOn: this task depends on (waits for) the referenced tasks
+      if (t.dependsOn && t.dependsOn.length > 0) {
+        for (const depRef of t.dependsOn) {
+          const depId = refToId[depRef];
+          if (!depId) {
+            errors.push({ ref: t.ref, error: `Dependency ref "${depRef}" not found` });
+            continue;
+          }
+          try {
+            await addDependency(taskId, { depends_on: depId });
+            if (verbose) process.stderr.write(`  ${t.ref} depends on ${depRef}\n`);
+          } catch (e) {
+            errors.push({ ref: t.ref, dependency: depRef, error: e.message });
+          }
+        }
+      }
+
+      // blocks: this task blocks the referenced tasks
+      if (t.blocks && t.blocks.length > 0) {
+        for (const blockRef of t.blocks) {
+          const blockId = refToId[blockRef];
+          if (!blockId) {
+            errors.push({ ref: t.ref, error: `Block ref "${blockRef}" not found` });
+            continue;
+          }
+          try {
+            await addDependency(taskId, { dependency_of: blockId });
+            if (verbose) process.stderr.write(`  ${t.ref} blocks ${blockRef}\n`);
+          } catch (e) {
+            errors.push({ ref: t.ref, blocks: blockRef, error: e.message });
+          }
+        }
+      }
+    }
+  }
+
+  return {
+    created,
+    errors,
+    refMap: refToId,
+    message: `Created ${created.length}/${tasks.length} task(s)${errors.length > 0 ? `, ${errors.length} error(s)` : ''}`,
+  };
+}

--- a/.claude/skills/clickup/lib/bulk.mjs
+++ b/.claude/skills/clickup/lib/bulk.mjs
@@ -1,0 +1,100 @@
+/**
+ * Bulk operation utility for ClickUp skill.
+ *
+ * Splits comma-separated IDs and runs an async operation on each,
+ * with concurrency control to respect ClickUp rate limits.
+ *
+ * Usage:
+ *   import { bulkExecute, splitIds } from './bulk.mjs';
+ *
+ *   const ids = splitIds('abc,def,ghi');
+ *   const results = await bulkExecute(ids, id => getTask(id));
+ *   // results = { succeeded: [...], failed: [...], total: 3 }
+ */
+
+const DEFAULT_CONCURRENCY = 5;
+
+/**
+ * Split a comma-separated string of IDs into an array.
+ * Returns a single-element array if no commas are present.
+ * Trims whitespace and filters empty strings.
+ */
+export function splitIds(input) {
+  if (!input) return [];
+  return input.split(',').map(s => s.trim()).filter(Boolean);
+}
+
+/**
+ * Returns true if the input contains multiple IDs (has commas).
+ */
+export function isBulk(input) {
+  return input && input.includes(',');
+}
+
+/**
+ * Execute an async function on each item with concurrency control.
+ *
+ * @param {string[]} items - Array of IDs or values to process
+ * @param {(item: string) => Promise<any>} fn - Async function to run per item
+ * @param {object} [options]
+ * @param {number} [options.concurrency=5] - Max parallel operations
+ * @returns {{ succeeded: Array<{id, result}>, failed: Array<{id, error}>, total: number }}
+ */
+export async function bulkExecute(items, fn, { concurrency = DEFAULT_CONCURRENCY } = {}) {
+  const succeeded = [];
+  const failed = [];
+
+  // Process in chunks of `concurrency`
+  for (let i = 0; i < items.length; i += concurrency) {
+    const chunk = items.slice(i, i + concurrency);
+    const results = await Promise.allSettled(
+      chunk.map(async (item) => {
+        const result = await fn(item);
+        return { id: item, result };
+      })
+    );
+
+    for (const r of results) {
+      if (r.status === 'fulfilled') {
+        succeeded.push(r.value);
+      } else {
+        // Extract the item ID from the error context
+        const id = chunk[results.indexOf(r)];
+        failed.push({ id, error: r.reason?.message || String(r.reason) });
+      }
+    }
+  }
+
+  return { succeeded, failed, total: items.length };
+}
+
+/**
+ * Format bulk results for CLI output.
+ *
+ * @param {{ succeeded, failed, total }} results
+ * @param {object} [options]
+ * @param {string} [options.action='Processed'] - Past-tense verb for output
+ * @param {(item: {id, result}) => string} [options.formatItem] - Format each success line
+ */
+export function formatBulkResults(results, { action = 'Processed', formatItem } = {}) {
+  const lines = [];
+
+  if (results.succeeded.length > 0) {
+    if (formatItem) {
+      for (const item of results.succeeded) {
+        lines.push(formatItem(item));
+      }
+    } else {
+      lines.push(`${action} ${results.succeeded.length}/${results.total} items.`);
+    }
+  }
+
+  if (results.failed.length > 0) {
+    lines.push(`Failed (${results.failed.length}):`);
+    for (const f of results.failed) {
+      lines.push(`  ${f.id}: ${f.error}`);
+    }
+  }
+
+  return lines.join('\n');
+}

--- a/.claude/skills/clickup/lib/format.mjs
+++ b/.claude/skills/clickup/lib/format.mjs
@@ -40,11 +40,23 @@ export function formatPriority(priority) {
   return priorities[priority.priority] || priority.priority || 'None';
 }
 
+// Format time estimate from milliseconds to human-readable
+function formatTimeEstimate(ms) {
+  if (!ms) return null;
+  const totalMinutes = Math.round(ms / 60000);
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+  if (hours > 0 && minutes > 0) return `${hours}h ${minutes}m`;
+  if (hours > 0) return `${hours}h`;
+  return `${minutes}m`;
+}
+
 // Format task for display
 export function formatTask(task) {
   const lines = [];
 
   lines.push(`Task: ${task.name}`);
+  lines.push(`ID: ${task.id}`);
   lines.push(`Status: ${task.status?.status || 'Unknown'}`);
   lines.push(`Priority: ${formatPriority(task.priority)}`);
 
@@ -53,9 +65,30 @@ export function formatTask(task) {
     lines.push(`Assignees: ${names}`);
   }
 
+  if (task.watchers?.length > 0) {
+    lines.push(`Watchers: ${task.watchers.length}`);
+  }
+
   lines.push(`Due: ${formatDate(task.due_date)}`);
+  if (task.start_date) {
+    lines.push(`Start: ${formatDate(task.start_date)}`);
+  }
+  if (task.time_estimate) {
+    const formatted = formatTimeEstimate(task.time_estimate);
+    if (formatted) lines.push(`Time Estimate: ${formatted}`);
+  }
   lines.push(`Created: ${formatDate(task.date_created)}`);
   lines.push(`URL: ${task.url}`);
+
+  if (task.list?.name) {
+    lines.push(`List: ${task.list.name}`);
+  }
+  if (task.folder && !task.folder.hidden) {
+    lines.push(`Folder: ${task.folder.name}`);
+  }
+  if (task.space?.id) {
+    lines.push(`Space: ${task.space.id}`);
+  }
 
   if (task.description) {
     lines.push('');
@@ -103,8 +136,8 @@ export function formatTaskList(tasks) {
   return lines.join('\n');
 }
 
-// Format comments for display
-export function formatComments(comments) {
+// Format comments for display (with optional thread expansion)
+export function formatComments(comments, threadMap = {}) {
   if (comments.length === 0) {
     return 'No comments on this task.';
   }
@@ -115,10 +148,56 @@ export function formatComments(comments) {
     const user = comment.user?.username || comment.user?.email || 'Unknown';
     // Prefer the comment array (rich formatting) over comment_text (plain text)
     const text = comment.comment ? extractCommentText(comment.comment) : comment.comment_text || '';
+    const replyCount = parseInt(comment.reply_count, 10) || 0;
 
-    lines.push(`[${date}] ${user}:`);
+    lines.push(`[${date}] ${user} (id: ${comment.id}):`);
+    lines.push(`  ${text.split('\n').join('\n  ')}`);
+    if (replyCount > 0 && !threadMap[comment.id]) {
+      lines.push(`  [${replyCount} ${replyCount === 1 ? 'reply' : 'replies'} — use "thread ${comment.id}" to view]`);
+    }
+
+    // Show expanded thread replies if available
+    const replies = threadMap[comment.id];
+    if (replies && replies.length > 0) {
+      for (const reply of replies) {
+        const rDate = formatDateTime(reply.date);
+        const rUser = reply.user?.username || reply.user?.email || 'Unknown';
+        const rText = reply.comment ? extractCommentText(reply.comment) : reply.comment_text || '';
+        lines.push(`    ↳ [${rDate}] ${rUser} (id: ${reply.id}):`);
+        lines.push(`      ${rText.split('\n').join('\n      ')}`);
+      }
+    }
+
+    lines.push('');
+  }
+
+  return lines.join('\n').trim();
+}
+
+// Format threaded replies for display (standalone thread view)
+export function formatThread(parentComment, replies) {
+  const lines = [];
+
+  if (parentComment) {
+    const date = formatDateTime(parentComment.date);
+    const user = parentComment.user?.username || parentComment.user?.email || 'Unknown';
+    const text = parentComment.comment ? extractCommentText(parentComment.comment) : parentComment.comment_text || '';
+    lines.push(`[${date}] ${user} (id: ${parentComment.id}):`);
     lines.push(`  ${text.split('\n').join('\n  ')}`);
     lines.push('');
+  }
+
+  if (replies.length === 0) {
+    lines.push('  No replies in this thread.');
+  } else {
+    for (const reply of replies) {
+      const date = formatDateTime(reply.date);
+      const user = reply.user?.username || reply.user?.email || 'Unknown';
+      const text = reply.comment ? extractCommentText(reply.comment) : reply.comment_text || '';
+      lines.push(`  ↳ [${date}] ${user} (id: ${reply.id}):`);
+      lines.push(`    ${text.split('\n').join('\n    ')}`);
+      lines.push('');
+    }
   }
 
   return lines.join('\n').trim();
@@ -224,5 +303,33 @@ export function formatPageList(pages, indent = 0) {
   if (indent === 0) {
     lines.push(`Total: ${pages.length} page(s)`);
   }
+  return lines.join('\n');
+}
+
+// Format list for display
+export function formatList(list) {
+  const lines = [];
+
+  lines.push(`List: ${list.name}`);
+  lines.push(`ID: ${list.id}`);
+  if (list.deleted) {
+    lines.push(`Status: DELETED`);
+  }
+  if (list.content) {
+    lines.push(`Description: ${list.content}`);
+  }
+  if (list.space) {
+    lines.push(`Space: ${list.space.name || list.space.id}`);
+  }
+  if (list.folder && !list.folder.hidden) {
+    lines.push(`Folder: ${list.folder.name || list.folder.id}`);
+  }
+  if (list.task_count !== undefined) {
+    lines.push(`Tasks: ${list.task_count}`);
+  }
+  if (list.statuses?.length > 0) {
+    lines.push(`Statuses: ${list.statuses.map(s => s.status).join(', ')}`);
+  }
+
   return lines.join('\n');
 }

--- a/.claude/skills/clickup/lib/mentions.mjs
+++ b/.claude/skills/clickup/lib/mentions.mjs
@@ -1,0 +1,261 @@
+/**
+ * @mention support for ClickUp comments
+ *
+ * Two syntaxes supported:
+ *   1. Explicit: @[identifier] — always preferred, resolves via fuzzy match
+ *   2. Bare:     @Name or @First Last — auto-detected against workspace members
+ *
+ * The bare syntax is a fallback for agents that forget the brackets.
+ * It matches against workspace member usernames (case-insensitive).
+ *
+ * Examples:
+ *   @[justin]        → fuzzy matches "Justin Maier" (user 10620972)
+ *   @[10620972]      → direct user ID
+ *   @[jane@co.com]   → matches by email
+ *   @Justin Maier    → bare match against workspace members
+ *   @Justin          → bare partial match (first name only)
+ */
+
+import { findUser, getTeamId, getTeamMembers } from '../api/user.mjs';
+import { markdownToClickUp } from './markdown.mjs';
+
+/**
+ * Extract @[identifier] patterns from text
+ * @param {string} text
+ * @returns {{ raw: string, identifier: string, index: number }[]}
+ */
+export function extractMentionSyntax(text) {
+  const regex = /@\[([^\]]+)\]/g;
+  const mentions = [];
+  let match;
+  while ((match = regex.exec(text)) !== null) {
+    mentions.push({ raw: match[0], identifier: match[1], index: match.index });
+  }
+  return mentions;
+}
+
+/**
+ * Detect bare @Name mentions by matching against workspace members.
+ * Tries longest match first (e.g. "@Justin Maier" before "@Justin").
+ * Only matches at word boundaries to avoid false positives.
+ *
+ * @param {string} text - Text with @[...] patterns already removed/replaced
+ * @param {object[]} members - Array of { user: { id, username, email, ... } }
+ * @returns {{ raw: string, userId: number, displayName: string, index: number }[]}
+ */
+export function detectBareMentions(text, members) {
+  const found = [];
+
+  for (const member of members) {
+    const user = member.user;
+    const username = user.username;
+    if (!username) continue;
+
+    // Build candidate patterns: full name, then first name
+    const candidates = [`@${username}`];
+    const firstName = username.split(/\s+/)[0];
+    if (firstName && firstName !== username) {
+      candidates.push(`@${firstName}`);
+    }
+
+    for (const candidate of candidates) {
+      let searchFrom = 0;
+      while (true) {
+        const idx = text.toLowerCase().indexOf(candidate.toLowerCase(), searchFrom);
+        if (idx === -1) break;
+
+        const afterIdx = idx + candidate.length;
+        // Ensure it's not inside an already-resolved @[...] bracket pattern
+        // and the char after the match is a word boundary (space, punct, EOL)
+        const charAfter = text[afterIdx];
+        const isWordBoundary = !charAfter || /[\s,.:;!?)\]}>\/\-\n]/.test(charAfter);
+
+        if (isWordBoundary) {
+          // Check this position isn't already covered by a longer match
+          const alreadyCovered = found.some(
+            f => idx >= f.index && idx < f.index + f.raw.length
+          );
+          if (!alreadyCovered) {
+            found.push({
+              raw: text.slice(idx, afterIdx),
+              userId: user.id,
+              displayName: username,
+              index: idx,
+            });
+          }
+        }
+        searchFrom = afterIdx;
+      }
+    }
+  }
+
+  // Sort by position, prefer longer matches when overlapping
+  found.sort((a, b) => a.index - b.index || b.raw.length - a.raw.length);
+
+  // Deduplicate overlapping ranges (keep longest/first)
+  const deduped = [];
+  for (const m of found) {
+    const overlaps = deduped.some(
+      d => m.index >= d.index && m.index < d.index + d.raw.length
+    );
+    if (!overlaps) deduped.push(m);
+  }
+
+  return deduped;
+}
+
+/**
+ * Resolve mentions in text — explicit @[identifier] first, then bare @Name fallback.
+ * @param {string} text - Text containing mentions
+ * @returns {Promise<{ text: string, mentionMap: Map<string, number> }>}
+ */
+export async function resolveMentions(text) {
+  const syntaxes = extractMentionSyntax(text);
+  const hasBracketMentions = syntaxes.length > 0;
+
+  // Check for bare @ patterns (outside of brackets)
+  const bareAtPattern = /@(?!\[)\w/;
+  const mayHaveBareMentions = bareAtPattern.test(text);
+
+  if (!hasBracketMentions && !mayHaveBareMentions) {
+    return { text, mentionMap: new Map() };
+  }
+
+  const teamId = await getTeamId();
+  const mentionMap = new Map();
+  let resolvedText = text;
+
+  // Phase 1: Process explicit @[identifier] patterns (reverse order for index stability)
+  for (let i = syntaxes.length - 1; i >= 0; i--) {
+    const m = syntaxes[i];
+    const isNumeric = /^\d+$/.test(m.identifier);
+
+    let userId, displayName;
+
+    if (isNumeric) {
+      userId = parseInt(m.identifier);
+      try {
+        const user = await findUser(teamId, m.identifier);
+        displayName = user?.username || user?.email || `User ${userId}`;
+      } catch {
+        displayName = `User ${userId}`;
+      }
+    } else {
+      const user = await findUser(teamId, m.identifier);
+      if (!user) {
+        throw new Error(
+          `Could not find user matching "${m.identifier}" for @mention. ` +
+          `Use "me" to list users, or provide an exact username or user ID.`
+        );
+      }
+      userId = user.id;
+      displayName = user.username || user.email || `User ${userId}`;
+    }
+
+    const placeholder = `@${displayName}`;
+    mentionMap.set(placeholder, userId);
+    resolvedText =
+      resolvedText.slice(0, m.index) + placeholder + resolvedText.slice(m.index + m.raw.length);
+  }
+
+  // Phase 2: Detect bare @Name mentions in the resolved text
+  if (bareAtPattern.test(resolvedText)) {
+    const members = await getTeamMembers(teamId);
+    const bareMentions = detectBareMentions(resolvedText, members);
+
+    // Replace bare mentions with normalized @DisplayName and add to map
+    // Process in reverse order for index stability
+    for (let i = bareMentions.length - 1; i >= 0; i--) {
+      const m = bareMentions[i];
+      const placeholder = `@${m.displayName}`;
+
+      // Skip if this exact placeholder is already in the map (from bracket syntax)
+      if (!mentionMap.has(placeholder)) {
+        mentionMap.set(placeholder, m.userId);
+      }
+
+      // Replace the bare mention with the normalized form
+      if (m.raw !== placeholder) {
+        resolvedText =
+          resolvedText.slice(0, m.index) + placeholder + resolvedText.slice(m.index + m.raw.length);
+      }
+    }
+  }
+
+  return { text: resolvedText, mentionMap };
+}
+
+/**
+ * Post-process a comment array to inject mention attributes
+ * Finds text items containing resolved @DisplayName strings and splits them
+ * into separate items with the mention attribute.
+ *
+ * @param {object[]} commentArray - Output from markdownToClickUp()
+ * @param {Map<string, number>} mentionMap - Map of "@DisplayName" → userId
+ * @returns {object[]} - Comment array with mention attributes injected
+ */
+export function injectMentions(commentArray, mentionMap) {
+  if (!mentionMap || mentionMap.size === 0) return commentArray;
+
+  const result = [];
+
+  for (const item of commentArray) {
+    if (!item.text || typeof item.text !== 'string') {
+      result.push(item);
+      continue;
+    }
+
+    // Find all mention positions in this text item
+    const positions = [];
+    for (const [mentionText, userId] of mentionMap) {
+      let searchFrom = 0;
+      while (true) {
+        const idx = item.text.indexOf(mentionText, searchFrom);
+        if (idx === -1) break;
+        positions.push({ start: idx, end: idx + mentionText.length, text: mentionText, userId });
+        searchFrom = idx + mentionText.length;
+      }
+    }
+
+    if (positions.length === 0) {
+      result.push(item);
+      continue;
+    }
+
+    // Sort by position
+    positions.sort((a, b) => a.start - b.start);
+
+    // Split text at mention boundaries
+    let cursor = 0;
+    const baseAttrs = item.attributes || {};
+
+    for (const pos of positions) {
+      if (pos.start > cursor) {
+        result.push({ text: item.text.slice(cursor, pos.start), attributes: { ...baseAttrs } });
+      }
+      result.push({ text: pos.text, attributes: { ...baseAttrs, mention: pos.userId } });
+      cursor = pos.end;
+    }
+    if (cursor < item.text.length) {
+      result.push({ text: item.text.slice(cursor), attributes: { ...baseAttrs } });
+    }
+  }
+
+  return result;
+}
+
+/**
+ * Full pipeline: text with mentions → ClickUp comment array with mention attributes
+ *
+ * 1. Resolves @[identifier] patterns (explicit) and bare @Name patterns (auto-detected)
+ * 2. Converts markdown to ClickUp format
+ * 3. Injects mention attributes into the array
+ *
+ * @param {string} text - Markdown text with mentions (bracket or bare)
+ * @returns {Promise<object[]>} - ClickUp comment array ready for the API
+ */
+export async function textToCommentArray(text) {
+  const { text: resolvedText, mentionMap } = await resolveMentions(text);
+  const commentArray = markdownToClickUp(resolvedText);
+  return injectMentions(commentArray, mentionMap);
+}

--- a/.claude/skills/clickup/lib/parse.mjs
+++ b/.claude/skills/clickup/lib/parse.mjs
@@ -6,6 +6,16 @@
 export function parseTaskId(input) {
   if (!input) return null;
 
+  // Strip leading # prefix
+  if (input.startsWith('#')) {
+    input = input.slice(1);
+  }
+
+  // Custom task IDs with prefix (e.g., DEV-123, PROJ-456)
+  if (/^[a-zA-Z]+-\d+$/.test(input)) {
+    return input;
+  }
+
   // Already a task ID (alphanumeric, typically 9 chars)
   if (/^[a-zA-Z0-9]+$/.test(input) && !input.includes('/')) {
     return input;
@@ -78,4 +88,21 @@ export function parsePageId(input) {
   if (pageMatch) return pageMatch[1];
 
   return input; // Return as-is, let API handle validation
+}
+
+// Extract space ID from URL or return as-is
+// Space URL: https://app.clickup.com/{team_id}/v/s/{space_id}
+export function parseSpaceId(input) {
+  if (!input) return null;
+
+  // Already a space ID (numeric)
+  if (/^\d+$/.test(input)) {
+    return input;
+  }
+
+  // URL format: https://app.clickup.com/{team_id}/v/s/{space_id}
+  const spaceMatch = input.match(/\/s\/(\d+)/);
+  if (spaceMatch) return spaceMatch[1];
+
+  return null; // Not a valid space ID or URL
 }

--- a/.claude/skills/clickup/listen.mjs
+++ b/.claude/skills/clickup/listen.mjs
@@ -1,0 +1,430 @@
+#!/usr/bin/env node
+
+/**
+ * ClickUp Event Listener (webhook.site + local receiver)
+ *
+ * Receives ClickUp webhook events via webhook.site forwarding.
+ * Designed to be run as a background task so the agent gets notified
+ * when a watched event arrives (task status change, comment, etc.).
+ *
+ * KEY FEATURE: On startup, checks webhook.site API for events that
+ * arrived since last seen timestamp. Prevents gaps between restarts.
+ *
+ * Modes:
+ *   1. "wait" (default) — Check for missed events, then listen for ONE
+ *      new webhook, print it, and exit. Agent gets background task notification.
+ *
+ *   2. "server" — Stay running and log all events.
+ *
+ * Usage:
+ *   node listen.mjs [--since <ISO timestamp>] [--port 3458] [--timeout 600] [--mode wait|server]
+ *
+ * Configuration (accounts.json > webhookSiteToken):
+ *   Or environment: CLICKUP_WEBHOOK_SITE_TOKEN
+ *
+ * Exit codes:
+ *   0 — webhook received (wait mode)
+ *   1 — timeout or error
+ */
+
+import { spawn } from 'child_process';
+import http from 'http';
+import https from 'https';
+import crypto from 'crypto';
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const LOG_FILE = path.join(__dirname, 'webhooks.jsonl');
+const LATEST_FILE = path.join(__dirname, 'webhook-latest.json');
+const WEBHOOK_URL_FILE = path.join(__dirname, 'webhook-url.txt');
+const LAST_SEEN_FILE = path.join(__dirname, 'last-seen.txt');
+const WATCHERS_FILE = path.join(__dirname, 'watchers.json');
+
+// ── Load config ───────────────────────────────────────────────────────────
+
+// Try accounts.json first, then env
+function loadConfig() {
+  const accountsPath = path.join(__dirname, 'accounts.json');
+  if (fs.existsSync(accountsPath)) {
+    try {
+      const data = JSON.parse(fs.readFileSync(accountsPath, 'utf-8'));
+      return {
+        webhookSiteToken: data.webhookSiteToken || process.env.CLICKUP_WEBHOOK_SITE_TOKEN,
+        webhookSiteApiKey: data.webhookSiteApiKey || process.env.WEBHOOK_SITE_API_KEY,
+      };
+    } catch {}
+  }
+  return {
+    webhookSiteToken: process.env.CLICKUP_WEBHOOK_SITE_TOKEN,
+    webhookSiteApiKey: process.env.WEBHOOK_SITE_API_KEY,
+  };
+}
+
+const config = loadConfig();
+const WH_TOKEN = config.webhookSiteToken;
+const WH_API_KEY = config.webhookSiteApiKey;
+
+// ── Parse CLI args ────────────────────────────────────────────────────────
+
+const args = process.argv.slice(2);
+
+function getFlag(name) {
+  const idx = args.indexOf(name);
+  if (idx === -1 || idx + 1 >= args.length) return undefined;
+  return args[idx + 1];
+}
+
+const PORT = parseInt(getFlag('--port') || '3458', 10);
+const TIMEOUT = parseInt(getFlag('--timeout') || '600', 10) * 1000;
+const MODE = getFlag('--mode') || 'wait';
+
+// Filters — only deliver events matching these criteria
+const FILTER_STATUS = getFlag('--filter-status');    // e.g. "qa review" — only deliver status changes TO this status
+const FILTER_EVENT = getFlag('--filter-event');       // e.g. "taskCommentPosted" — only deliver this event type
+const FILTER_TASK = getFlag('--filter-task');          // e.g. "868abc123" — only deliver events for this task
+
+let SINCE = getFlag('--since');
+if (!SINCE && fs.existsSync(LAST_SEEN_FILE)) {
+  SINCE = fs.readFileSync(LAST_SEEN_FILE, 'utf8').trim();
+}
+
+if (!WH_TOKEN) {
+  console.error('Error: No webhook.site token configured.');
+  console.error('Add "webhookSiteToken" to accounts.json or set CLICKUP_WEBHOOK_SITE_TOKEN env var.');
+  console.error('Visit https://webhook.site to get a token (the UUID in the URL).');
+  process.exit(1);
+}
+
+const WEBHOOK_URL = `https://webhook.site/${WH_TOKEN}`;
+
+// Write the webhook URL so other commands can read it
+fs.writeFileSync(WEBHOOK_URL_FILE, WEBHOOK_URL);
+
+// ── Load watcher secrets for signature verification ───────────────────────
+
+function loadWatcherSecrets() {
+  if (!fs.existsSync(WATCHERS_FILE)) return {};
+  try {
+    const watchers = JSON.parse(fs.readFileSync(WATCHERS_FILE, 'utf-8'));
+    const secrets = {};
+    for (const w of watchers) {
+      if (w.webhookId && w.secret) secrets[w.webhookId] = w.secret;
+    }
+    return secrets;
+  } catch {
+    return {};
+  }
+}
+
+const WATCHER_SECRETS = loadWatcherSecrets();
+
+// ── Event Filtering ───────────────────────────────────────────────────────
+
+function matchesFilters(event) {
+  // Filter by event type
+  if (FILTER_EVENT) {
+    const allowed = FILTER_EVENT.split(',').map(s => s.trim().toLowerCase());
+    const eventType = (event.event || '').toLowerCase();
+    if (!allowed.includes(eventType)) return false;
+  }
+
+  // Filter by task ID
+  if (FILTER_TASK) {
+    const allowed = FILTER_TASK.split(',').map(s => s.trim());
+    if (!allowed.includes(event.task_id)) return false;
+  }
+
+  // Filter by target status (only deliver taskStatusUpdated where after.status matches)
+  if (FILTER_STATUS) {
+    const allowed = FILTER_STATUS.split(',').map(s => s.trim().toLowerCase());
+    const items = event.history_items || [];
+    // For status updates, check the "after" status
+    const hasMatch = items.some(item => {
+      const afterStatus = (item.after?.status || '').toLowerCase();
+      return allowed.includes(afterStatus);
+    });
+    // For non-status events, FILTER_STATUS doesn't apply — let them through
+    if (event.event === 'taskStatusUpdated' && !hasMatch) return false;
+  }
+
+  return true;
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────
+
+function verifySignature(rawBody, signature, webhookId) {
+  if (!signature) return null;
+  // Try the specific webhook's secret first
+  const secret = WATCHER_SECRETS[webhookId];
+  if (!secret) return null;
+
+  const hash = crypto
+    .createHmac('sha256', secret)
+    .update(rawBody)
+    .digest('hex');
+  return hash === signature;
+}
+
+function saveLastSeen(timestamp) {
+  fs.writeFileSync(LAST_SEEN_FILE, timestamp);
+}
+
+function processEvent(event, source = 'live', verified = 'skipped') {
+  const entry = {
+    received_at: new Date().toISOString(),
+    source,
+    verified,
+    ...event,
+  };
+
+  fs.appendFileSync(LOG_FILE, JSON.stringify(entry) + '\n');
+  fs.writeFileSync(LATEST_FILE, JSON.stringify(entry, null, 2));
+
+  if (entry._wh_created_at) {
+    saveLastSeen(entry._wh_created_at);
+  } else {
+    saveLastSeen(entry.received_at);
+  }
+
+  return entry;
+}
+
+function formatEventSummary(event) {
+  const type = event.event || 'unknown';
+  const taskId = event.task_id || '?';
+  const webhookId = event.webhook_id || '?';
+  const items = event.history_items || [];
+  let detail = '';
+
+  if (type === 'taskStatusUpdated' && items.length > 0) {
+    const item = items[0];
+    detail = ` | ${item.before?.status || '?'} → ${item.after?.status || '?'}`;
+  } else if (type === 'taskCommentPosted' && items.length > 0) {
+    const user = items[0]?.user?.username || '?';
+    detail = ` | by ${user}`;
+  } else if (items.length > 0) {
+    const user = items[0]?.user?.username;
+    if (user) detail = ` | by ${user}`;
+  }
+
+  return `${type} | task:${taskId} | wh:${webhookId}${detail}`;
+}
+
+// ── Catch-up: query webhook.site for missed events ────────────────────────
+
+function fetchMissedEvents(since) {
+  return new Promise((resolve, reject) => {
+    const sinceUtc = since.includes('Z') || since.includes('+') ? since : since.replace(' ', 'T') + 'Z';
+    const d = new Date(sinceUtc);
+    if (d.getMilliseconds() > 0) {
+      d.setSeconds(d.getSeconds() + 1);
+      d.setMilliseconds(0);
+    }
+    d.setSeconds(d.getSeconds() + 1);
+    const dateFrom = d.toISOString().replace('T', ' ').replace(/\.\d+Z$/, '');
+
+    const url = new URL(`https://webhook.site/token/${WH_TOKEN}/requests`);
+    url.searchParams.set('date_from', dateFrom);
+    url.searchParams.set('sorting', 'oldest');
+    url.searchParams.set('per_page', '10');
+
+    const headers = {};
+    if (WH_API_KEY) headers['Api-Key'] = WH_API_KEY;
+
+    https.get(url.toString(), { headers }, (res) => {
+      let data = '';
+      res.on('data', (chunk) => (data += chunk));
+      res.on('end', () => {
+        try {
+          const json = JSON.parse(data);
+          resolve(json);
+        } catch {
+          resolve({ data: [] });
+        }
+      });
+    }).on('error', (err) => {
+      process.stderr.write(`[catch-up] Failed to query webhook.site: ${err.message}\n`);
+      resolve({ data: [] });
+    });
+  });
+}
+
+function parseWebhookSiteRequest(req) {
+  try {
+    const event = JSON.parse(req.content);
+    event._wh_created_at = req.created_at;
+    return event;
+  } catch {
+    return null;
+  }
+}
+
+// ── Local HTTP server ─────────────────────────────────────────────────────
+
+let serverResolve;
+
+const server = http.createServer((req, res) => {
+  if (req.method === 'GET') {
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify({ status: 'listening', webhook_url: WEBHOOK_URL }));
+    return;
+  }
+
+  if (req.method === 'POST') {
+    let rawBody = '';
+    req.on('data', (chunk) => (rawBody += chunk));
+    req.on('end', () => {
+      try {
+        const event = JSON.parse(rawBody);
+        const signature = req.headers['x-signature'];
+        const webhookId = event.webhook_id;
+        const verified = verifySignature(rawBody, signature, webhookId);
+
+        const entry = {
+          received_at: new Date().toISOString(),
+          source: 'live',
+          verified: verified === null ? 'skipped' : verified,
+          ...event,
+        };
+
+        // Always ack the webhook to prevent ClickUp from marking it unhealthy
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ ok: true }));
+
+        // Always log and update cursor
+        fs.appendFileSync(LOG_FILE, JSON.stringify(entry) + '\n');
+        saveLastSeen(entry.received_at);
+
+        // Check filters — only deliver to agent if event matches
+        if (!matchesFilters(event)) {
+          process.stderr.write(`[filtered] ${formatEventSummary(event)}\n`);
+          return;
+        }
+
+        fs.writeFileSync(LATEST_FILE, JSON.stringify(entry, null, 2));
+
+        if (MODE === 'server') {
+          process.stderr.write(`[${entry.received_at}] ${formatEventSummary(event)}\n`);
+        } else {
+          console.log(JSON.stringify(entry, null, 2));
+          if (serverResolve) serverResolve();
+        }
+      } catch (err) {
+        res.writeHead(400, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ error: 'Invalid JSON' }));
+      }
+    });
+    return;
+  }
+
+  res.writeHead(404);
+  res.end('Not found');
+});
+
+// ── whcli forward process ─────────────────────────────────────────────────
+
+function startForwarder() {
+  const whArgs = [
+    'forward',
+    `--token=${WH_TOKEN}`,
+    `--target=http://localhost:${PORT}`,
+    '--listen-timeout=5',
+  ];
+  if (WH_API_KEY) whArgs.push(`--api-key=${WH_API_KEY}`);
+
+  const proc = spawn('whcli', whArgs, {
+    stdio: ['pipe', 'pipe', 'pipe'],
+    shell: true,
+  });
+
+  proc.stdout.on('data', (d) => process.stderr.write(`[whcli] ${d}`));
+  proc.stderr.on('data', (d) => process.stderr.write(`[whcli:err] ${d}`));
+  proc.on('error', (err) => process.stderr.write(`[whcli] Error: ${err.message}\n`));
+
+  return proc;
+}
+
+// ── Main ──────────────────────────────────────────────────────────────────
+
+async function main() {
+  process.stderr.write(`ClickUp Event Listener\n`);
+  process.stderr.write(`Webhook URL: ${WEBHOOK_URL}\n`);
+  process.stderr.write(`Mode: ${MODE} | Port: ${PORT} | Timeout: ${TIMEOUT / 1000}s\n`);
+  process.stderr.write(`Since: ${SINCE || 'none (first run)'}\n`);
+  process.stderr.write(`Tracked webhooks: ${Object.keys(WATCHER_SECRETS).length}\n`);
+  if (FILTER_STATUS) process.stderr.write(`Filter status: ${FILTER_STATUS}\n`);
+  if (FILTER_EVENT) process.stderr.write(`Filter event: ${FILTER_EVENT}\n`);
+  if (FILTER_TASK) process.stderr.write(`Filter task: ${FILTER_TASK}\n`);
+  process.stderr.write('\n');
+
+  // ── Step 1: Check for missed events ─────────────────────────────────────
+  if (SINCE && MODE === 'wait') {
+    process.stderr.write(`Checking webhook.site for events since ${SINCE}...\n`);
+    const result = await fetchMissedEvents(SINCE);
+    const requests = result.data || [];
+
+    if (requests.length > 0) {
+      // Find the first missed event that passes our filters
+      for (const req of requests) {
+        const event = parseWebhookSiteRequest(req);
+        if (!event) continue;
+
+        // Always update cursor even for filtered events
+        const entry = processEvent(event, 'catch-up');
+
+        if (matchesFilters(event)) {
+          process.stderr.write(`[catch-up] Found matching event (of ${requests.length} missed). Delivering.\n`);
+          console.log(JSON.stringify(entry, null, 2));
+          process.exit(0);
+        } else {
+          process.stderr.write(`[catch-up:filtered] ${event.event || 'unknown'} — skipped\n`);
+        }
+      }
+      process.stderr.write(`[catch-up] ${requests.length} missed event(s), none matched filters. Starting live listener.\n`);
+    } else {
+      process.stderr.write(`[catch-up] No missed events. Starting live listener.\n`);
+    }
+  }
+
+  // ── Step 2: Start live listener ─────────────────────────────────────────
+  await new Promise((resolve) => server.listen(PORT, resolve));
+  process.stderr.write(`Listening on port ${PORT}\n\n`);
+
+  const forwarder = startForwarder();
+
+  if (MODE === 'wait') {
+    const gotWebhook = new Promise((resolve) => { serverResolve = resolve; });
+    const timedOut = new Promise((_, reject) =>
+      setTimeout(() => reject(new Error('timeout')), TIMEOUT)
+    );
+
+    try {
+      await Promise.race([gotWebhook, timedOut]);
+      forwarder.kill();
+      server.close(() => process.exit(0));
+    } catch {
+      console.log(JSON.stringify({
+        error: 'timeout',
+        message: `No ClickUp event received within ${TIMEOUT / 1000}s`,
+        webhook_url: WEBHOOK_URL,
+      }));
+      forwarder.kill();
+      server.close(() => process.exit(1));
+    }
+  } else {
+    process.stderr.write('Running in server mode. Press Ctrl+C to stop.\n\n');
+
+    function cleanup() {
+      process.stderr.write('\nShutting down...\n');
+      forwarder.kill();
+      server.close(() => process.exit(0));
+    }
+
+    process.on('SIGINT', cleanup);
+    process.on('SIGTERM', cleanup);
+  }
+}
+
+main();

--- a/.claude/skills/clickup/package-lock.json
+++ b/.claude/skills/clickup/package-lock.json
@@ -1,0 +1,707 @@
+{
+  "name": "clickup-skill",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "clickup-skill",
+      "version": "1.0.0",
+      "dependencies": {
+        "remark-parse": "^11.0.0",
+        "unified": "^11.0.5"
+      }
+    },
+    "node_modules/@types/debug": {
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+      "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
+    },
+    "node_modules/bail": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+      "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decode-named-character-reference": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+      "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
+    },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mdast-util-from-markdown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
+      "integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark": "^4.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+      "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+      "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/debug": "^4.0.0",
+        "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-core-commonmark": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+      "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-destination": "^2.0.0",
+        "micromark-factory-label": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-title": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-html-tag-name": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-destination": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+      "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-label": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+      "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-space": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+      "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-title": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+      "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-whitespace": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+      "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-chunked": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+      "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-classify-character": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+      "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-combine-extensions": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+      "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-numeric-character-reference": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+      "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
+      "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-html-tag-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+      "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-normalize-identifier": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+      "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-resolve-all": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+      "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-subtokenize": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+      "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/remark-parse": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
+      "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/trough": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+      "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/unified": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+      "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "bail": "^2.0.0",
+        "devlop": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    }
+  }
+}

--- a/.claude/skills/clickup/package.json
+++ b/.claude/skills/clickup/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "clickup-skill",
+  "private": true,
+  "version": "1.0.0",
+  "description": "ClickUp CLI skill — tasks, docs, comments, watchers",
+  "dependencies": {
+    "remark-parse": "^11.0.0",
+    "unified": "^11.0.5"
+  }
+}

--- a/.claude/skills/clickup/query.mjs
+++ b/.claude/skills/clickup/query.mjs
@@ -5,43 +5,80 @@
  *
  * Task Commands:
  *   get <url|id>                  Get task details
- *   comments <url|id>             List task comments
+ *   comments <url|id>             List task comments (--threads to expand)
+ *   thread <comment_id>           View threaded replies on a comment
+ *   reply <comment_id> "msg"      Reply to a comment thread
  *   comment <url|id> "msg"        Post a comment
  *   status <url|id> "status"      Update task status
  *   tasks <list_id>               List tasks in a list
  *   me                            Show current user info
  *   create [list_id] "title"      Create a new task (list_id optional if default set)
  *   my-tasks                      List all tasks assigned to me
- *   search "query"                Search tasks across workspace
+ *   search [query]                Search tasks — requires a scope: --list, --folder, --me,
+ *                                 --assignee, --status, or --all. Text query optional.
+ *   find-list "name"              Find lists/folders by name (fast structural walk, no task fetch)
  *   assign <task> <user>          Assign task to user
  *   due <task> "date"             Set due date
+ *   start <task> "date"           Set start date
+ *   schedule <task> "start" "due" Set both start and due dates
+ *   rename <task> "new name"      Rename a task
  *   priority <task> <level>       Set priority (urgent/high/normal/low)
  *   subtask <task> "title"        Create a subtask
  *   move <task> <list_id>         Move task to different list
  *   link <task> <url> ["desc"]    Add external link reference
  *   checklist <task> "item"       Add checklist item
+ *   update-comment <comment_id> "text"  Update a comment's text
+ *   resolve-comment <comment_id>  Resolve/close a comment
  *   delete-comment <comment_id>   Delete a comment
  *   watch <task> <user>           Add a watcher to task
+ *   unwatch <task> <user>         Remove a watcher from task
  *   tag <task> "tag_name"         Add a tag to task
+ *   remove-tag <task> "tag_name"  Remove a tag from task
  *   description <task> "text"     Update task description (markdown supported)
+ *   depends <task> <other_task>   Set task as waiting on another task
+ *   blocks <task> <other_task>    Set task as blocking another task
+ *   task-link <task> <other>      Create bidirectional link between tasks
+ *   archive <task>                Archive a task
+ *   unarchive <task>              Restore an archived task
+ *   claim <task>                  Link your session to a task (sets Session ID custom field)
+ *
+ * List Commands:
+ *   list <list_id>                Get list details
+ *   lists <folder_id>             List all lists in a folder
+ *   space-lists <space_id>        List folderless lists in a space
+ *   create-list <space> "name"    Create a new list in a space
+ *   update-list <list_id>         Update list (--name, --content)
+ *   delete-list <list_id>         Delete a list
  *
  * Document Commands:
  *   docs ["query"]                Search/list docs in workspace
  *   doc <doc_id>                  Get doc details and page listing
- *   create-doc "title"            Create a new doc
+ *   create-doc "title"            Create a new doc (--space to place in space)
  *   page <doc_id> <page_id>       Get page content
  *   create-page <doc_id> "title"  Create a new page in a doc
  *   edit-page <doc_id> <page_id>  Edit a page's content
+ *
+ * Attachment Commands:
+ *   attach <url|id> --file <path> Upload file attachment(s) to a task
+ *   fetch-image <url>             Download attachment to local temp file (--output path)
  *
  * Options:
  *   --json       Output raw JSON
  *   --subtasks   Include subtasks (for get command)
  *   --me         Filter to tasks assigned to me (for tasks command)
- *   --content    Page content for create-page/edit-page
+ *   --content    Inline content (for short text)
+ *   --file       Read content from a file path (preferred for long content)
+ *   --cleanup    Delete --file after successful execution
+ *   --parent     Parent page ID for create-page (creates subpage)
  */
 
+import { readFileSync, existsSync, unlinkSync, writeFileSync, mkdirSync, readdirSync, statSync } from 'fs';
+import { resolve, join } from 'path';
+import { tmpdir, homedir } from 'os';
+
 // API imports
-import { loadEnv, appendToEnv } from './api/client.mjs';
+import { initClient, getActiveCredentials, getActiveAccountId } from './api/client.mjs';
+import { updateAccountField, listAccounts as listAccountsFn, setDefaultAccount, addAccount as addAccountFn, removeAccount as removeAccountFn } from './lib/accounts.mjs';
 import { getCurrentUser, getUserId, getTeamId, findUser } from './api/user.mjs';
 import {
   getTask,
@@ -55,15 +92,28 @@ import {
   getMyTasks,
   assignTask,
   setDueDate,
+  setStartDate,
+  setDates,
   setPriority,
   moveTask,
   parseDateInput,
   addWatcher,
   addTag,
+  addDependency,
+  removeDependency,
+  addTaskLink,
+  removeTaskLink,
+  archiveTask,
+  unarchiveTask,
+  removeWatcher,
+  removeTag,
+  setCustomField,
+  findCustomFieldByName,
 } from './api/tasks.mjs';
-import { getComments, postComment, deleteComment } from './api/comments.mjs';
-import { addChecklistItemToTask, getChecklists } from './api/checklists.mjs';
+import { getComments, postComment, updateComment, deleteComment, getThreadedComments, replyToComment } from './api/comments.mjs';
+import { addChecklistItemToTask, getChecklists, editChecklistItem, deleteChecklistItem } from './api/checklists.mjs';
 import { addExternalLink } from './api/links.mjs';
+import { getList, createList, deleteList, updateList, getLists, getFolderlessLists, getListMembers, findListByName } from './api/lists.mjs';
 import {
   searchDocs,
   getDoc,
@@ -73,17 +123,34 @@ import {
   createPage,
   editPage,
 } from './api/docs.mjs';
+import { uploadAttachment, uploadAttachments } from './api/attachments.mjs';
+import {
+  createWebhook,
+  listWebhooks,
+  deleteWebhook,
+  addWatcherEntry,
+  removeWatcherEntry,
+  getWatcherEntries,
+  clearAllWatcherEntries,
+  DEFAULT_TASK_EVENTS,
+  DEFAULT_LIST_EVENTS,
+  DEFAULT_SPACE_EVENTS,
+} from './api/webhooks.mjs';
 
 // Lib imports
-import { parseTaskId, parseListId, parseDocId, parsePageId } from './lib/parse.mjs';
+import { executeBatchCreate } from './lib/batch-create.mjs';
+import { splitIds, isBulk, bulkExecute, formatBulkResults } from './lib/bulk.mjs';
+import { parseTaskId, parseListId, parseDocId, parsePageId, parseSpaceId } from './lib/parse.mjs';
 import {
   formatTask,
   formatTaskList,
   formatComments,
+  formatThread,
   formatDoc,
   formatDocList,
   formatPage,
   formatPageList,
+  formatList,
 } from './lib/format.mjs';
 
 // Parse arguments
@@ -100,6 +167,20 @@ let dueArg = null;
 let descriptionArg = null;
 let contentArg = null;
 let nameArg = null;
+let parentArg = null;
+let spaceArg = null;
+let fileArg = null;
+let cleanupFlag = false;
+let archiveFlag = false;
+let pageArg = null;
+let accountArg = null;
+let threadsFlag = false;
+let attachArgs = [];
+let eventsArg = null;
+let listScopeArg = null;
+let folderScopeArg = null;
+let statusScopeArg = null;
+let allScopeFlag = false;
 
 for (let i = 0; i < args.length; i++) {
   const arg = args[i];
@@ -117,8 +198,36 @@ for (let i = 0; i < args.length; i++) {
     descriptionArg = args[++i];
   } else if (arg === '--content' || arg === '-c') {
     contentArg = args[++i];
+  } else if (arg === '--file' || arg === '-f') {
+    fileArg = args[++i];
+  } else if (arg === '--cleanup') {
+    cleanupFlag = true;
+  } else if (arg === '--archive') {
+    archiveFlag = true;
   } else if (arg === '--name' || arg === '-n') {
     nameArg = args[++i];
+  } else if (arg === '--parent' || arg === '-p') {
+    parentArg = args[++i];
+  } else if (arg === '--space' || arg === '-s') {
+    spaceArg = args[++i];
+  } else if (arg === '--page') {
+    pageArg = args[++i];
+  } else if (arg === '--threads' || arg === '-t') {
+    threadsFlag = true;
+  } else if (arg === '--attach') {
+    attachArgs.push(args[++i]);
+  } else if (arg === '--events' || arg === '-e') {
+    eventsArg = args[++i];
+  } else if (arg === '--account') {
+    accountArg = args[++i];
+  } else if (arg === '--list') {
+    listScopeArg = args[++i];
+  } else if (arg === '--folder') {
+    folderScopeArg = args[++i];
+  } else if (arg === '--status') {
+    statusScopeArg = args[++i];
+  } else if (arg === '--all') {
+    allScopeFlag = true;
   } else if (!command) {
     command = arg;
   } else if (!targetInput) {
@@ -130,7 +239,62 @@ for (let i = 0; i < args.length; i++) {
   }
 }
 
-// Backward compatibility
+// Unescape literal \n and \t in text args (CLI passes them as-is)
+function unescapeText(str) {
+  return str ? str.replace(/\\n/g, '\n').replace(/\\t/g, '\t') : str;
+}
+
+function detectClaudeSessionId() {
+  if (process.env.CLAUDE_SESSION_ID) return process.env.CLAUDE_SESSION_ID;
+  // Fallback: the active Claude Code session is the one currently writing to its
+  // jsonl transcript. Find the most-recently-modified jsonl across every project
+  // dir under ~/.claude/projects/. We can't key off process.cwd() because the
+  // caller may have cd'd into a skill dir before invoking node.
+  try {
+    const root = join(homedir(), '.claude', 'projects');
+    if (!existsSync(root)) return null;
+    let freshest = null;
+    for (const projectName of readdirSync(root)) {
+      const projectDir = join(root, projectName);
+      try {
+        if (!statSync(projectDir).isDirectory()) continue;
+      } catch {
+        continue;
+      }
+      for (const f of readdirSync(projectDir)) {
+        if (!f.endsWith('.jsonl')) continue;
+        const mtime = statSync(join(projectDir, f)).mtimeMs;
+        if (!freshest || mtime > freshest.mtime) {
+          freshest = { id: f.replace(/\.jsonl$/, ''), mtime };
+        }
+      }
+    }
+    // Only trust the pick if it was written within the last 60s — otherwise
+    // it's stale and could belong to any old session.
+    if (!freshest || Date.now() - freshest.mtime > 60_000) return null;
+    return freshest.id;
+  } catch {
+    return null;
+  }
+}
+contentArg = unescapeText(contentArg);
+descriptionArg = unescapeText(descriptionArg);
+arg2 = unescapeText(arg2);
+
+// --file overrides --content: read file contents as the content/text argument
+if (fileArg) {
+  const filePath = resolve(fileArg);
+  if (!existsSync(filePath)) {
+    console.error(`Error: File not found: ${filePath}`);
+    process.exit(1);
+  }
+  const fileContent = readFileSync(filePath, 'utf-8');
+  contentArg = fileContent;
+  // Also set arg2 so commands that use positional text (comment, description) pick it up
+  if (!arg2) arg2 = fileContent;
+}
+
+// Backward compatibility (commentText = arg2, which --file may have populated)
 const commentText = arg2;
 
 // Show usage
@@ -139,40 +303,103 @@ function showUsage() {
 
 Task Commands:
   get <url|id>                  Get task details
-  comments <url|id>             List task comments
+  comments <url|id>             List task comments (--threads to expand)
+  thread <comment_id>           View threaded replies on a comment
+  reply <comment_id> "msg"      Reply to a comment thread
   comment <url|id> "msg"        Post a comment
   status <url|id> "status"      Update task status
   tasks <list_id>               List tasks in a list
   me                            Show current user info
   create [list_id] "title"      Create a new task (list_id optional if default set)
   my-tasks                      List all tasks assigned to me
-  search "query"                Search tasks across workspace
+  search [query]                Search tasks — requires a scope flag (--list/--folder/--me/
+                                --assignee/--status) or --all. Text query optional.
+  find-list "name"              Find a list or folder by name (fast, structural only)
   assign <task> <user>          Assign task to user
   due <task> "date"             Set due date
+  start <task> "date"           Set start date
+  schedule <task> "start" "due" Set both start and due dates
+  rename <task> "new name"      Rename a task
   priority <task> <level>       Set priority (urgent/high/normal/low)
   subtask <task> "title"        Create a subtask
   move <task> <list_id>         Move task to different list
   link <task> <url> ["desc"]    Add external link reference
   checklist <task> "item"       Add checklist item
+  update-comment <comment_id> "text"  Update a comment's text
+  resolve-comment <comment_id>  Resolve/close a comment
   delete-comment <comment_id>   Delete a comment
   watch <task> <user>           Add a watcher to task
+  unwatch <task> <user>         Remove a watcher from task
   tag <task> "tag_name"         Add a tag to task
+  remove-tag <task> "tag_name"  Remove a tag from task
   description <task> "text"     Update task description (markdown supported)
+  depends <task> <other_task>   Set task as waiting on another task
+  blocks <task> <other_task>    Set task as blocking another task
+  task-link <task> <other>      Create bidirectional link between tasks
+  archive <task>                Archive a task (remove from active views)
+  unarchive <task>              Restore an archived task
+  claim <task>                  Link your session to this task (for resumability)
+
+List Commands:
+  list <list_id>                Get list details
+  lists <folder_id>             List all lists in a folder
+  space-lists <space_id>        List folderless lists in a space
+  create-list <space> "name"    Create a new list in a space (--content for description)
+  update-list <list_id>         Update list (--name "new name", --content "description")
+  delete-list <list_id>         Delete a list
 
 Document Commands:
   docs ["query"]                Search/list docs in workspace
   doc <doc_id>                  Get doc details and page listing
-  create-doc "title"            Create a new doc (--content for initial content)
+  create-doc "title"            Create a new doc (--content, --space)
   page <doc_id> <page_id>       Get page content
-  create-page <doc_id> "title"  Add a new page to a doc (--content for body)
+  create-page <doc_id> "title"  Add a new page to a doc (--content, --parent)
   edit-page <doc_id> <page_id>  Edit a page's content (--content and/or --name)
 
+Attachment Commands:
+  attach <url|id>               Upload file(s) to a task (--attach path, repeatable)
+  fetch-image <url>             Download attachment to local temp file (--output path)
+
+Project Setup:
+  batch-create --file plan.json  Create multiple tasks from JSON (with deps, subtasks, assignments)
+  batch-create --file plan.json --dry-run  Preview without creating
+
+Watcher Commands (webhook-based event monitoring):
+  watch-task <id>[,id2,...]     Watch task(s) for events (--events to customize)
+  watch-list <list_id>          Watch a list for events
+  watch-space <space_id>        Watch a space for events
+  watchers                      List active webhook watchers
+  webhooks                      List all webhooks in workspace (from API)
+  unwatch-webhook <wh_id>       Delete a webhook watcher
+  unwatch-webhook --all         Delete all webhook watchers
+
+  Listener (run as background task):
+  node listen.mjs [--timeout 600] [--port 3458] [--mode wait|server]
+
+Account Commands:
+  accounts                      List configured accounts
+  switch-account <name>         Change the default account
+  add-account <name>            Add a new account (--token required)
+  remove-account <name>         Remove an account
+
 Options:
+  --account  <name>  Use a specific account for this command
   --json       Output raw JSON
   --subtasks   Include subtasks (for get command)
   --me         Filter to tasks assigned to me (for tasks command)
-  --content    Page content for create-page/edit-page (markdown)
+  --content    Inline content (markdown). For short text only.
+  --file       Read content from a file path (preferred for long content)
+  --cleanup    Delete the --file after successful execution
   --name       New name for edit-page
+  --parent     Parent page ID for create-page (creates as subpage)
+  --attach     File path to upload as attachment (repeatable, for attach/comment)
+  --space      Space ID for create-doc (places doc in that space)
+  --events     Comma-separated event types for watch commands (e.g. taskStatusUpdated,taskCommentPosted)
+
+Bulk Operations (comma-separated IDs):
+  node query.mjs get id1,id2,id3              Fetch multiple tasks at once
+  node query.mjs status id1,id2 "complete"    Update status on multiple tasks
+  node query.mjs due id1,id2 "friday"         Set due date on multiple tasks
 
 Examples:
   node query.mjs get 86a1b2c3d --subtasks
@@ -182,7 +409,10 @@ Examples:
   node query.mjs create 901111220963 "New feature: dark mode"
   node query.mjs create "Quick task" (uses CLICKUP_DEFAULT_LIST_ID)
   node query.mjs my-tasks
-  node query.mjs search "dark mode"
+  node query.mjs search "dark mode" --list 901111220963
+  node query.mjs search --me --status "in progress"
+  node query.mjs search "bug" --all                       # full-workspace scan (slow)
+  node query.mjs find-list "Red Launch"                   # locate a list/folder by name
   node query.mjs assign 86a1b2c3d justin
   node query.mjs due 86a1b2c3d "tomorrow"
   node query.mjs priority 86a1b2c3d high
@@ -195,21 +425,97 @@ Examples:
   node query.mjs tag 86a1b2c3d "DevOps"
   node query.mjs description 86a1b2c3d "## Summary\\nThis is **bold** text"
 
+List Examples:
+  node query.mjs list 901111220963                        # Get list details
+  node query.mjs create-list 20128955 "New List"          # Create list in space
+  node query.mjs create-list "https://app.clickup.com/.../v/s/20128955" "New List"
+  node query.mjs delete-list 901111220963                 # Delete a list
+
 Document Examples:
   node query.mjs docs                                     # List all docs
   node query.mjs docs "API"                               # Search docs
   node query.mjs doc abc123                               # Get doc details
   node query.mjs create-doc "Project Notes"               # Create empty doc
-  node query.mjs create-doc "Guide" --content "# Guide\\nContent here"  # Doc with content
+  node query.mjs create-doc "Guide" --content "# Guide\\nContent here"  # Short inline content
   node query.mjs page abc123 page456                      # Get page content
   node query.mjs create-page abc123 "New Section"         # Add additional page
-  node query.mjs edit-page abc123 page456 --content "Updated content" --name "Renamed"`);
+  node query.mjs edit-page abc123 page456 --content "Updated content" --name "Renamed"
+
+File-based Content (recommended for anything longer than a sentence):
+  node query.mjs create-doc "Spec" --file ./spec.md --space 90114072520
+  node query.mjs edit-page abc123 p456 --file ./updated-content.md
+  node query.mjs comment 86a1b2c3d --file ./review-notes.md
+  node query.mjs description 86a1b2c3d --file ./task-description.md
+  node query.mjs create-doc "Temp" --file ./draft.md --cleanup  # Deletes draft.md after
+`);
   process.exit(1);
 }
 
 async function main() {
-  // Load environment
-  loadEnv();
+  // Account management commands (run before initClient since they manage the config)
+  if (command === 'accounts') {
+    const accounts = listAccountsFn();
+    if (accounts.length === 0) {
+      console.log('No accounts configured. Create accounts.json or .env in the skill directory.');
+    } else {
+      for (const a of accounts) {
+        const marker = a.isDefault ? ' (default)' : '';
+        const token = a.hasApiToken ? 'token' : 'no-token';
+        const jwt = a.hasJwt ? ', jwt' : '';
+        console.log(`  ${a.id}${marker} [${token}${jwt}]${a.email ? ` - ${a.email}` : ''}`);
+      }
+    }
+    return;
+  }
+
+  if (command === 'switch-account') {
+    if (!targetInput) {
+      console.error('Error: Account name required');
+      console.error('Usage: node query.mjs switch-account <name>');
+      process.exit(1);
+    }
+    setDefaultAccount(targetInput);
+    console.log(`Default account set to: ${targetInput}`);
+    return;
+  }
+
+  if (command === 'add-account') {
+    if (!targetInput) {
+      console.error('Error: Account name required');
+      console.error('Usage: node query.mjs add-account <name> --token pk_...');
+      process.exit(1);
+    }
+    // Look for --token in remaining args
+    let token = null;
+    for (let i = 0; i < args.length; i++) {
+      if (args[i] === '--token' && args[i + 1]) {
+        token = args[i + 1];
+        break;
+      }
+    }
+    if (!token) {
+      console.error('Error: --token is required');
+      console.error('Usage: node query.mjs add-account <name> --token pk_...');
+      process.exit(1);
+    }
+    addAccountFn(targetInput, { apiToken: token });
+    console.log(`Account "${targetInput}" added.`);
+    return;
+  }
+
+  if (command === 'remove-account') {
+    if (!targetInput) {
+      console.error('Error: Account name required');
+      console.error('Usage: node query.mjs remove-account <name>');
+      process.exit(1);
+    }
+    removeAccountFn(targetInput);
+    console.log(`Account "${targetInput}" removed.`);
+    return;
+  }
+
+  // Initialize client with selected account
+  initClient(accountArg);
 
   if (!command) {
     showUsage();
@@ -229,9 +535,10 @@ async function main() {
       }
 
       // Cache user ID if not already cached
-      if (!process.env.CLICKUP_USER_ID) {
-        appendToEnv('CLICKUP_USER_ID', user.id.toString(), `User: ${user.username} (auto-detected)`);
-        console.error('\nCached user ID to .env');
+      const creds = getActiveCredentials();
+      if (!creds.userId) {
+        updateAccountField(getActiveAccountId(), 'userId', user.id.toString());
+        console.error('\nCached user ID to accounts.json');
       }
     } catch (err) {
       console.error('Error:', err.message);
@@ -258,21 +565,81 @@ async function main() {
   }
 
   if (command === 'search') {
-    if (!targetInput) {
-      console.error('Error: Search query required');
-      console.error('Usage: node query.mjs search "query"');
+    const hasScope = !!(listScopeArg || folderScopeArg || statusScopeArg || filterMe || assigneeArg);
+    if (!hasScope && !allScopeFlag) {
+      console.error('Error: `search` requires a scope — text search across the entire workspace is expensive.');
+      console.error('');
+      console.error('Pick one of:');
+      console.error('  --list <id>      scope to a single list (fastest)');
+      console.error('  --folder <id>    scope to a folder');
+      console.error('  --me             tasks assigned to you');
+      console.error('  --assignee <u>   tasks assigned to a specific user');
+      console.error('  --status <name>  tasks with a given status (repeatable via comma)');
+      console.error('  --all            unscoped full-workspace scan (slow, use sparingly)');
+      console.error('');
+      console.error('Looking for a list or folder by name? Use `find-list "name"` instead.');
       process.exit(1);
     }
     try {
       const teamId = await getTeamId();
-      const tasks = await searchTasks(teamId, targetInput);
+      const opts = {};
+      if (listScopeArg) opts.list_ids = [listScopeArg];
+      if (folderScopeArg) opts.project_ids = [folderScopeArg];
+      if (statusScopeArg) opts.statuses = statusScopeArg.split(',').map(s => s.trim()).filter(Boolean);
+      if (filterMe || assigneeArg) {
+        const who = assigneeArg ? await findUser(teamId, assigneeArg) : null;
+        opts.assigneeId = filterMe ? await getUserId() : (who?.id || who);
+      }
+      if (allScopeFlag) opts.all = true;
+
+      const tasks = await searchTasks(teamId, targetInput || '', opts);
       if (jsonOutput) {
         console.log(JSON.stringify(tasks, null, 2));
+      } else if (tasks.length === 0) {
+        const q = targetInput ? ` matching "${targetInput}"` : '';
+        console.log(`No tasks found${q}`);
       } else {
-        if (tasks.length === 0) {
-          console.log(`No tasks found matching "${targetInput}"`);
-        } else {
-          console.log(formatTaskList(tasks));
+        console.log(formatTaskList(tasks));
+      }
+    } catch (err) {
+      console.error('Error:', err.message);
+      process.exit(1);
+    }
+    return;
+  }
+
+  if (command === 'find-list') {
+    if (!targetInput) {
+      console.error('Error: find-list requires a name query');
+      console.error('Usage: node query.mjs find-list "partial name"');
+      process.exit(1);
+    }
+    try {
+      const teamId = await getTeamId();
+      const { lists, folders } = await findListByName(teamId, targetInput);
+      if (jsonOutput) {
+        console.log(JSON.stringify({ lists, folders }, null, 2));
+      } else if (!lists.length && !folders.length) {
+        console.log(`No lists or folders matching "${targetInput}"`);
+      } else {
+        if (lists.length) {
+          console.log(`Lists (${lists.length}):`);
+          for (const l of lists) {
+            const loc = l.folder ? `${l.space.name} / ${l.folder.name}` : `${l.space.name} (folderless)`;
+            console.log(`  ${l.name}`);
+            console.log(`    id: ${l.id} — ${loc}`);
+          }
+        }
+        if (folders.length) {
+          if (lists.length) console.log('');
+          console.log(`Folders (${folders.length}):`);
+          for (const f of folders) {
+            console.log(`  ${f.name}`);
+            console.log(`    id: ${f.id} — ${f.space.name} — ${f.listCount} list(s)`);
+            for (const l of f.lists) {
+              console.log(`      • ${l.name} (list id: ${l.id})`);
+            }
+          }
         }
       }
     } catch (err) {
@@ -287,9 +654,10 @@ async function main() {
     try {
       const workspaceId = await getTeamId();
       const options = targetInput ? { query: targetInput } : {};
-      const docs = await searchDocs(workspaceId, options);
+      const result = await searchDocs(workspaceId, options);
+      const docs = result.docs || [];
       if (jsonOutput) {
-        console.log(JSON.stringify(docs, null, 2));
+        console.log(JSON.stringify(result, null, 2));
       } else {
         if (docs.length === 0) {
           console.log(targetInput ? `No docs found matching "${targetInput}"` : 'No docs found.');
@@ -307,7 +675,7 @@ async function main() {
   if (command === 'create-doc') {
     if (!targetInput) {
       console.error('Error: Doc title required');
-      console.error('Usage: node query.mjs create-doc "Doc Title" [--content "content"]');
+      console.error('Usage: node query.mjs create-doc "Doc Title" [--space <space_id>] [--content "content"]');
       process.exit(1);
     }
     try {
@@ -316,14 +684,152 @@ async function main() {
       if (contentArg) {
         options.content = contentArg;
       }
+      if (spaceArg) {
+        const spaceId = parseSpaceId(spaceArg);
+        options.parent = { id: spaceId, type: 4 };
+      }
       const doc = await createDoc(workspaceId, targetInput, options);
       if (jsonOutput) {
         console.log(JSON.stringify(doc, null, 2));
       } else {
         console.log(`Doc created: ${doc.name}`);
         console.log(`ID: ${doc.id}`);
+        if (spaceArg) {
+          console.log(`Space: ${spaceArg}`);
+        }
         if (doc.firstPageId) {
           console.log(`First page populated with content`);
+        }
+      }
+    } catch (err) {
+      console.error('Error:', err.message);
+      process.exit(1);
+    }
+    return;
+  }
+
+  if (command === 'lists') {
+    if (!targetInput) {
+      console.error('Error: Folder ID required');
+      console.error('Usage: node query.mjs lists <folder_id>');
+      process.exit(1);
+    }
+    try {
+      const folderId = targetInput;
+      const lists = await getLists(folderId);
+      if (jsonOutput) {
+        console.log(JSON.stringify(lists, null, 2));
+      } else {
+        if (lists.length === 0) {
+          console.log('No lists found in this folder.');
+        } else {
+          for (const l of lists) {
+            console.log(`  ${l.name} (ID: ${l.id})`);
+          }
+          console.log(`\nTotal: ${lists.length} list(s)`);
+        }
+      }
+    } catch (err) {
+      console.error('Error:', err.message);
+      process.exit(1);
+    }
+    return;
+  }
+
+  if (command === 'space-lists') {
+    if (!targetInput) {
+      console.error('Error: Space ID required');
+      console.error('Usage: node query.mjs space-lists <space_id>');
+      process.exit(1);
+    }
+    try {
+      const spaceId = parseSpaceId(targetInput);
+      const lists = await getFolderlessLists(spaceId);
+      if (jsonOutput) {
+        console.log(JSON.stringify(lists, null, 2));
+      } else {
+        if (lists.length === 0) {
+          console.log('No folderless lists found in this space.');
+        } else {
+          for (const l of lists) {
+            console.log(`  ${l.name} (ID: ${l.id})`);
+          }
+          console.log(`\nTotal: ${lists.length} list(s)`);
+        }
+      }
+    } catch (err) {
+      console.error('Error:', err.message);
+      process.exit(1);
+    }
+    return;
+  }
+
+  // Batch create from JSON file
+  if (command === 'batch-create') {
+    if (!fileArg && !contentArg) {
+      console.error('Error: --file or --content required with a JSON plan');
+      console.error('Usage: node query.mjs batch-create --file plan.json');
+      console.error('       node query.mjs batch-create --content \'{"listId":"...","tasks":[...]}\'');
+      process.exit(1);
+    }
+    try {
+      const planText = contentArg || readFileSync(resolve(fileArg), 'utf-8');
+      const plan = JSON.parse(planText);
+      const dryRun = args.includes('--dry-run');
+      const verbose = !jsonOutput; // verbose by default unless --json
+      const result = await executeBatchCreate(plan, { verbose, dryRun });
+      if (jsonOutput) {
+        console.log(JSON.stringify(result, null, 2));
+      } else {
+        console.log(`\n${result.message}`);
+        if (result.errors.length > 0) {
+          console.log('\nErrors:');
+          for (const e of result.errors) {
+            console.log(`  ${e.ref || e.name || '?'}: ${e.error}`);
+          }
+        }
+      }
+    } catch (err) {
+      console.error('Error:', err.message);
+      process.exit(1);
+    }
+    return;
+  }
+
+  // Watcher commands that don't require a target
+  if (command === 'watchers') {
+    const entries = getWatcherEntries();
+    if (entries.length === 0) {
+      console.log('No active watchers. Use watch-task, watch-list, or watch-space to create one.');
+    } else if (jsonOutput) {
+      console.log(JSON.stringify(entries, null, 2));
+    } else {
+      console.log(`Active watchers (${entries.length}):\n`);
+      for (const e of entries) {
+        console.log(`  ${e.webhookId} | ${e.scope}:${e.scopeId} | ${e.events.length} events | ${e.createdAt}`);
+      }
+    }
+    return;
+  }
+
+  if (command === 'webhooks') {
+    try {
+      const webhooks = await listWebhooks();
+      if (webhooks.length === 0) {
+        console.log('No webhooks registered in workspace.');
+      } else if (jsonOutput) {
+        console.log(JSON.stringify(webhooks, null, 2));
+      } else {
+        console.log(`Webhooks in workspace (${webhooks.length}):\n`);
+        for (const wh of webhooks) {
+          const health = wh.health?.status || '?';
+          const fails = wh.health?.fail_count || 0;
+          const scope = wh.task_id ? `task:${wh.task_id}` :
+                        wh.list_id ? `list:${wh.list_id}` :
+                        wh.folder_id ? `folder:${wh.folder_id}` :
+                        wh.space_id ? `space:${wh.space_id}` : 'workspace';
+          console.log(`  ${wh.id} | ${scope} | ${wh.events?.length || 0} events | ${health} (${fails} fails)`);
+          console.log(`    → ${wh.endpoint}`);
         }
       }
     } catch (err) {
@@ -341,16 +847,31 @@ async function main() {
   try {
     switch (command) {
       case 'get': {
-        const taskId = parseTaskId(targetInput);
-        if (!taskId) {
+        const ids = splitIds(targetInput).map(parseTaskId).filter(Boolean);
+        if (ids.length === 0) {
           console.error('Error: Could not parse task ID from input');
           process.exit(1);
         }
-        const task = await getTask(taskId, includeSubtasks);
-        if (jsonOutput) {
-          console.log(JSON.stringify(task, null, 2));
+        if (ids.length === 1) {
+          const task = await getTask(ids[0], includeSubtasks);
+          if (jsonOutput) {
+            console.log(JSON.stringify(task, null, 2));
+          } else {
+            console.log(formatTask(task));
+          }
         } else {
-          console.log(formatTask(task));
+          const results = await bulkExecute(ids, id => getTask(id, includeSubtasks));
+          if (jsonOutput) {
+            console.log(JSON.stringify(results.succeeded.map(s => s.result), null, 2));
+          } else {
+            for (const s of results.succeeded) {
+              console.log(formatTask(s.result));
+              console.log('');
+            }
+            if (results.failed.length > 0) {
+              console.log(formatBulkResults({ ...results, succeeded: [] }));
+            }
+          }
         }
         break;
       }
@@ -362,54 +883,167 @@ async function main() {
           process.exit(1);
         }
         const comments = await getComments(taskId);
+
+        // If --threads flag, auto-expand all threads with replies
+        let threadMap = {};
+        if (threadsFlag) {
+          const threaded = comments.filter(c => parseInt(c.reply_count, 10) > 0);
+          if (threaded.length > 0) {
+            const threadResults = await Promise.all(
+              threaded.map(c => getThreadedComments(c.id).then(replies => [c.id, replies]))
+            );
+            for (const [id, replies] of threadResults) {
+              threadMap[id] = replies;
+            }
+          }
+        }
+
         if (jsonOutput) {
-          console.log(JSON.stringify(comments, null, 2));
+          if (threadsFlag) {
+            // Embed replies into each comment for JSON output
+            const enriched = comments.map(c => ({
+              ...c,
+              replies: threadMap[c.id] || [],
+            }));
+            console.log(JSON.stringify(enriched, null, 2));
+          } else {
+            console.log(JSON.stringify(comments, null, 2));
+          }
         } else {
-          console.log(formatComments(comments));
+          console.log(formatComments(comments, threadMap));
+        }
+        break;
+      }
+
+      case 'thread': {
+        const commentId = targetInput;
+        if (!commentId) {
+          console.error('Error: Comment ID required');
+          console.error('Usage: node query.mjs thread <comment_id>');
+          process.exit(1);
+        }
+        const replies = await getThreadedComments(commentId);
+        if (jsonOutput) {
+          console.log(JSON.stringify(replies, null, 2));
+        } else {
+          console.log(formatThread(null, replies));
+        }
+        break;
+      }
+
+      case 'reply': {
+        const commentId = targetInput;
+        if (!commentId) {
+          console.error('Error: Comment ID required');
+          console.error('Usage: node query.mjs reply <comment_id> "reply text"');
+          process.exit(1);
+        }
+        if (!commentText) {
+          console.error('Error: Reply text required');
+          console.error('Usage: node query.mjs reply <comment_id> "reply text"');
+          process.exit(1);
+        }
+        const result = await replyToComment(commentId, commentText);
+        if (jsonOutput) {
+          console.log(JSON.stringify(result, null, 2));
+        } else {
+          console.log(`Reply posted successfully (ID: ${result.id || 'ok'})`);
         }
         break;
       }
 
       case 'comment': {
-        const taskId = parseTaskId(targetInput);
-        if (!taskId) {
+        const ids = splitIds(targetInput).map(parseTaskId).filter(Boolean);
+        if (ids.length === 0) {
           console.error('Error: Could not parse task ID from input');
           process.exit(1);
         }
         if (!commentText) {
           console.error('Error: Comment text required');
-          console.error('Usage: node query.mjs comment <url|id> "Your comment"');
+          console.error('Usage: node query.mjs comment <url|id[,id,...]> "Your comment" [--attach ./file.png]');
           process.exit(1);
         }
-        const result = await postComment(taskId, commentText);
-        if (jsonOutput) {
-          console.log(JSON.stringify(result, null, 2));
+        // Resolve --attach file paths for comment attachments
+        const commentAttachFiles = attachArgs.map(f => resolve(f));
+        if (commentAttachFiles.length > 0) {
+          for (const fp of commentAttachFiles) {
+            if (!existsSync(fp)) {
+              console.error(`Error: Attachment file not found: ${fp}`);
+              process.exit(1);
+            }
+          }
+        }
+        if (ids.length === 1) {
+          const result = await postComment(ids[0], commentText);
+          if (jsonOutput) {
+            const output = { comment: result };
+            if (commentAttachFiles.length > 0) {
+              output.attachments = await uploadAttachments(ids[0], commentAttachFiles);
+            }
+            console.log(JSON.stringify(output, null, 2));
+          } else {
+            console.log(`Comment posted successfully (ID: ${result.id})`);
+            if (commentAttachFiles.length > 0) {
+              const attResults = await uploadAttachments(ids[0], commentAttachFiles);
+              for (const r of attResults) {
+                const att = r.attachment || r;
+                console.log(`  Attached: ${att.title || att.name || 'file'}`);
+              }
+            }
+          }
         } else {
-          console.log(`Comment posted successfully (ID: ${result.id})`);
+          const results = await bulkExecute(ids, async (id) => {
+            const comment = await postComment(id, commentText);
+            let attachments;
+            if (commentAttachFiles.length > 0) {
+              attachments = await uploadAttachments(id, commentAttachFiles);
+            }
+            return { comment, attachments };
+          });
+          if (jsonOutput) {
+            console.log(JSON.stringify(results, null, 2));
+          } else {
+            console.log(formatBulkResults(results, { action: 'Comment posted on' }));
+            if (commentAttachFiles.length > 0) {
+              console.log(`  (${commentAttachFiles.length} file(s) attached to each task)`);
+            }
+          }
         }
         break;
       }
 
       case 'status': {
-        const taskId = parseTaskId(targetInput);
-        if (!taskId) {
+        const ids = splitIds(targetInput).map(parseTaskId).filter(Boolean);
+        if (ids.length === 0) {
           console.error('Error: Could not parse task ID from input');
           process.exit(1);
         }
         if (!commentText) {
-          // No status provided - show available statuses
-          const statuses = await getAvailableStatuses(taskId);
+          // No status provided - show available statuses (single task only)
+          const statuses = await getAvailableStatuses(ids[0]);
           console.log('Available statuses:');
           for (const s of statuses) {
             console.log(`  - "${s.status}" (${s.type})`);
           }
           break;
         }
-        const { task, matchedStatus } = await updateTaskStatus(taskId, commentText);
-        if (jsonOutput) {
-          console.log(JSON.stringify(task, null, 2));
+        if (ids.length === 1) {
+          const { task, matchedStatus } = await updateTaskStatus(ids[0], commentText);
+          if (jsonOutput) {
+            console.log(JSON.stringify(task, null, 2));
+          } else {
+            console.log(`Status updated to "${matchedStatus.status}"`);
+          }
         } else {
-          console.log(`Status updated to "${matchedStatus.status}"`);
+          const results = await bulkExecute(ids, id => updateTaskStatus(id, commentText));
+          if (jsonOutput) {
+            console.log(JSON.stringify(results, null, 2));
+          } else {
+            console.log(formatBulkResults(results, {
+              action: 'Updated',
+              formatItem: s => `${s.id}: status → "${s.result.matchedStatus.status}"`,
+            }));
+          }
         }
         break;
       }
@@ -444,11 +1078,11 @@ async function main() {
         // If targetInput doesn't parse as a list ID, treat it as the title
         if (!listId) {
           title = targetInput;
-          listId = process.env.CLICKUP_DEFAULT_LIST_ID;
+          listId = getActiveCredentials().defaultListId;
           if (!listId) {
-            console.error('Error: No list ID provided and CLICKUP_DEFAULT_LIST_ID not set');
+            console.error('Error: No list ID provided and no defaultListId set for this account');
             console.error('Usage: node query.mjs create <list_id> "Task title" [options]');
-            console.error('   Or: Set CLICKUP_DEFAULT_LIST_ID in .env to use: node query.mjs create "Task title"');
+            console.error('   Or: Set defaultListId in accounts.json to use: node query.mjs create "Task title"');
             console.error('Options: --assignee/-a <user>, --due/-d <date>, --description/--desc <text>');
             process.exit(1);
           }
@@ -463,11 +1097,14 @@ async function main() {
 
         // Build options from flags
         const options = {};
-        if (descriptionArg) {
+        // --file/--content populate contentArg; accept them here too so a long
+        // description doesn't have to go through a second `description` call.
+        const createDescription = descriptionArg || contentArg;
+        if (createDescription) {
           // Use markdown_description for proper markdown rendering in ClickUp
           // Note: Task descriptions use markdown_description (ClickUp parses),
           // while comments use JSON array format (we parse via markdownToClickUp)
-          options.markdown_description = descriptionArg;
+          options.markdown_description = createDescription;
         }
         if (dueArg) {
           const dueDate = parseDateInput(dueArg);
@@ -508,14 +1145,14 @@ async function main() {
       }
 
       case 'assign': {
-        const taskId = parseTaskId(targetInput);
-        if (!taskId) {
+        const ids = splitIds(targetInput).map(parseTaskId).filter(Boolean);
+        if (ids.length === 0) {
           console.error('Error: Could not parse task ID from input');
           process.exit(1);
         }
         if (!arg2) {
           console.error('Error: User required');
-          console.error('Usage: node query.mjs assign <task> <user>');
+          console.error('Usage: node query.mjs assign <task[,task,...]> <user>');
           process.exit(1);
         }
         const teamId = await getTeamId();
@@ -524,54 +1161,158 @@ async function main() {
           console.error(`Error: User "${arg2}" not found in team`);
           process.exit(1);
         }
-        const task = await assignTask(taskId, [user.id]);
-        if (jsonOutput) {
-          console.log(JSON.stringify(task, null, 2));
+        if (ids.length === 1) {
+          const task = await assignTask(ids[0], [user.id]);
+          if (jsonOutput) {
+            console.log(JSON.stringify(task, null, 2));
+          } else {
+            console.log(`Task assigned to ${user.username || user.email}`);
+          }
         } else {
-          console.log(`Task assigned to ${user.username || user.email}`);
+          const results = await bulkExecute(ids, id => assignTask(id, [user.id]));
+          if (jsonOutput) {
+            console.log(JSON.stringify(results, null, 2));
+          } else {
+            console.log(formatBulkResults(results, { action: `Assigned to ${user.username || user.email}:` }));
+          }
         }
         break;
       }
 
       case 'due': {
-        const taskId = parseTaskId(targetInput);
-        if (!taskId) {
+        const ids = splitIds(targetInput).map(parseTaskId).filter(Boolean);
+        if (ids.length === 0) {
           console.error('Error: Could not parse task ID from input');
           process.exit(1);
         }
         if (!arg2) {
           console.error('Error: Due date required');
-          console.error('Usage: node query.mjs due <task> "date"');
+          console.error('Usage: node query.mjs due <task[,task,...]> "date"');
           console.error('Examples: "tomorrow", "next friday", "2024-01-15", "+3d"');
           process.exit(1);
         }
-        const task = await setDueDate(taskId, arg2);
-        if (jsonOutput) {
-          console.log(JSON.stringify(task, null, 2));
+        if (ids.length === 1) {
+          const task = await setDueDate(ids[0], arg2);
+          if (jsonOutput) {
+            console.log(JSON.stringify(task, null, 2));
+          } else {
+            const dueDate = task.due_date ? new Date(parseInt(task.due_date, 10)).toLocaleDateString() : 'cleared';
+            console.log(`Due date set to: ${dueDate}`);
+          }
         } else {
-          const dueDate = task.due_date ? new Date(parseInt(task.due_date, 10)).toLocaleDateString() : 'cleared';
-          console.log(`Due date set to: ${dueDate}`);
+          const results = await bulkExecute(ids, id => setDueDate(id, arg2));
+          if (jsonOutput) {
+            console.log(JSON.stringify(results, null, 2));
+          } else {
+            console.log(formatBulkResults(results, { action: 'Due date set on' }));
+          }
         }
         break;
       }
 
-      case 'priority': {
+      case 'start': {
+        const ids = splitIds(targetInput).map(parseTaskId).filter(Boolean);
+        if (ids.length === 0) {
+          console.error('Error: Could not parse task ID from input');
+          process.exit(1);
+        }
+        if (!arg2) {
+          console.error('Error: Start date required');
+          console.error('Usage: node query.mjs start <task[,task,...]> "date"');
+          console.error('Examples: "today", "tomorrow", "2024-01-15", "+3d"');
+          process.exit(1);
+        }
+        if (ids.length === 1) {
+          const task = await setStartDate(ids[0], arg2);
+          if (jsonOutput) {
+            console.log(JSON.stringify(task, null, 2));
+          } else {
+            const startDate = task.start_date ? new Date(parseInt(task.start_date, 10)).toLocaleDateString() : 'cleared';
+            console.log(`Start date set to: ${startDate}`);
+          }
+        } else {
+          const results = await bulkExecute(ids, id => setStartDate(id, arg2));
+          if (jsonOutput) {
+            console.log(JSON.stringify(results, null, 2));
+          } else {
+            console.log(formatBulkResults(results, { action: 'Start date set on' }));
+          }
+        }
+        break;
+      }
+
+      case 'schedule': {
+        const taskId = parseTaskId(targetInput);
+        if (!taskId) {
+          console.error('Error: Could not parse task ID from input');
+          process.exit(1);
+        }
+        if (!arg2 || !arg3) {
+          console.error('Error: Both start and due dates required');
+          console.error('Usage: node query.mjs schedule <task> "start_date" "due_date"');
+          console.error('Examples: node query.mjs schedule abc123 "today" "friday"');
+          process.exit(1);
+        }
+        const task = await setDates(taskId, { start: arg2, due: arg3 });
+        if (jsonOutput) {
+          console.log(JSON.stringify(task, null, 2));
+        } else {
+          const startDate = task.start_date ? new Date(parseInt(task.start_date, 10)).toLocaleDateString() : 'not set';
+          const dueDate = task.due_date ? new Date(parseInt(task.due_date, 10)).toLocaleDateString() : 'not set';
+          console.log(`Scheduled: ${startDate} → ${dueDate}`);
+        }
+        break;
+      }
+
+      case 'rename': {
         const taskId = parseTaskId(targetInput);
         if (!taskId) {
           console.error('Error: Could not parse task ID from input');
           process.exit(1);
         }
         if (!arg2) {
-          console.error('Error: Priority level required');
-          console.error('Usage: node query.mjs priority <task> <level>');
-          console.error('Levels: urgent, high, normal, low, none');
+          console.error('Error: New name required');
+          console.error('Usage: node query.mjs rename <task> "new name"');
           process.exit(1);
         }
-        const { task, priority } = await setPriority(taskId, arg2);
+        const task = await updateTask(taskId, { name: arg2 });
         if (jsonOutput) {
           console.log(JSON.stringify(task, null, 2));
         } else {
-          console.log(`Priority set to: ${priority}`);
+          console.log(`Task renamed to: ${task.name}`);
+        }
+        break;
+      }
+
+      case 'priority': {
+        const ids = splitIds(targetInput).map(parseTaskId).filter(Boolean);
+        if (ids.length === 0) {
+          console.error('Error: Could not parse task ID from input');
+          process.exit(1);
+        }
+        if (!arg2) {
+          console.error('Error: Priority level required');
+          console.error('Usage: node query.mjs priority <task[,task,...]> <level>');
+          console.error('Levels: urgent, high, normal, low, none');
+          process.exit(1);
+        }
+        if (ids.length === 1) {
+          const { task, priority } = await setPriority(ids[0], arg2);
+          if (jsonOutput) {
+            console.log(JSON.stringify(task, null, 2));
+          } else {
+            console.log(`Priority set to: ${priority}`);
+          }
+        } else {
+          const results = await bulkExecute(ids, id => setPriority(id, arg2));
+          if (jsonOutput) {
+            console.log(JSON.stringify(results, null, 2));
+          } else {
+            console.log(formatBulkResults(results, {
+              action: 'Priority set on',
+              formatItem: s => `${s.id}: priority → ${s.result.priority}`,
+            }));
+          }
         }
         break;
       }
@@ -610,12 +1351,13 @@ async function main() {
           process.exit(1);
         }
         const listId = parseListId(arg2);
-        const task = await moveTask(taskId, listId);
+        const workspaceId = await getTeamId();
+        const task = await moveTask(taskId, listId, workspaceId);
         if (jsonOutput) {
           console.log(JSON.stringify(task, null, 2));
         } else {
           console.log(`Task moved successfully`);
-          console.log(`URL: ${task.url}`);
+          if (task.url) console.log(`URL: ${task.url}`);
         }
         break;
       }
@@ -660,6 +1402,43 @@ async function main() {
         break;
       }
 
+      case 'update-comment': {
+        const commentId = targetInput;
+        if (!commentId) {
+          console.error('Error: Comment ID required');
+          console.error('Usage: node query.mjs update-comment <comment_id> "new text"');
+          process.exit(1);
+        }
+        if (!arg2) {
+          console.error('Error: Comment text required');
+          console.error('Usage: node query.mjs update-comment <comment_id> "new text"');
+          process.exit(1);
+        }
+        const result = await updateComment(commentId, { comment_text: arg2 });
+        if (jsonOutput) {
+          console.log(JSON.stringify(result, null, 2));
+        } else {
+          console.log(`Comment ${commentId} updated`);
+        }
+        break;
+      }
+
+      case 'resolve-comment': {
+        const commentId = targetInput;
+        if (!commentId) {
+          console.error('Error: Comment ID required');
+          console.error('Usage: node query.mjs resolve-comment <comment_id>');
+          process.exit(1);
+        }
+        const result = await updateComment(commentId, { resolved: true });
+        if (jsonOutput) {
+          console.log(JSON.stringify(result, null, 2));
+        } else {
+          console.log(`Comment ${commentId} resolved`);
+        }
+        break;
+      }
+
       case 'delete-comment': {
         const commentId = targetInput;
         if (!commentId) {
@@ -693,35 +1472,95 @@ async function main() {
           console.error(`Error: User "${arg2}" not found in team`);
           process.exit(1);
         }
-        // ClickUp API v2 doesn't support adding watchers programmatically.
-        // Post a comment with @mention as an alternative to notify the user.
-        const mentionComment = `@${user.username} has been added as a watcher on this task.`;
-        const result = await postComment(taskId, mentionComment);
+        const result = await addWatcher(taskId, user.id);
         if (jsonOutput) {
-          console.log(JSON.stringify({ notified: true, user: user.username, comment_id: result.id }, null, 2));
+          console.log(JSON.stringify(result, null, 2));
         } else {
-          console.log(`Notified ${user.username || user.email} via @mention comment`);
-          console.log(`(Note: ClickUp API does not support adding watchers directly)`);
+          console.log(`Added ${user.username || user.email} as watcher`);
         }
         break;
       }
 
-      case 'tag': {
+      case 'unwatch': {
         const taskId = parseTaskId(targetInput);
         if (!taskId) {
           console.error('Error: Could not parse task ID from input');
           process.exit(1);
         }
         if (!arg2) {
-          console.error('Error: Tag name required');
-          console.error('Usage: node query.mjs tag <task> "tag_name"');
+          console.error('Error: User required');
+          console.error('Usage: node query.mjs unwatch <task> <user>');
           process.exit(1);
         }
-        await addTag(taskId, arg2);
+        const teamId = await getTeamId();
+        const user = await findUser(teamId, arg2);
+        if (!user) {
+          console.error(`Error: User "${arg2}" not found in team`);
+          process.exit(1);
+        }
+        const result = await removeWatcher(taskId, user.id);
         if (jsonOutput) {
-          console.log(JSON.stringify({ tagged: true, taskId, tag: arg2 }, null, 2));
+          console.log(JSON.stringify(result, null, 2));
         } else {
-          console.log(`Tag "${arg2}" added to task`);
+          console.log(`Removed ${user.username || user.email} as watcher`);
+        }
+        break;
+      }
+
+      case 'tag': {
+        const ids = splitIds(targetInput).map(parseTaskId).filter(Boolean);
+        if (ids.length === 0) {
+          console.error('Error: Could not parse task ID from input');
+          process.exit(1);
+        }
+        if (!arg2) {
+          console.error('Error: Tag name required');
+          console.error('Usage: node query.mjs tag <task[,task,...]> "tag_name"');
+          process.exit(1);
+        }
+        if (ids.length === 1) {
+          await addTag(ids[0], arg2);
+          if (jsonOutput) {
+            console.log(JSON.stringify({ tagged: true, taskId: ids[0], tag: arg2 }, null, 2));
+          } else {
+            console.log(`Tag "${arg2}" added to task`);
+          }
+        } else {
+          const results = await bulkExecute(ids, id => addTag(id, arg2));
+          if (jsonOutput) {
+            console.log(JSON.stringify(results, null, 2));
+          } else {
+            console.log(formatBulkResults(results, { action: `Tagged "${arg2}" on` }));
+          }
+        }
+        break;
+      }
+
+      case 'remove-tag': {
+        const ids = splitIds(targetInput).map(parseTaskId).filter(Boolean);
+        if (ids.length === 0) {
+          console.error('Error: Could not parse task ID from input');
+          process.exit(1);
+        }
+        if (!arg2) {
+          console.error('Error: Tag name required');
+          console.error('Usage: node query.mjs remove-tag <task[,task,...]> "tag_name"');
+          process.exit(1);
+        }
+        if (ids.length === 1) {
+          await removeTag(ids[0], arg2);
+          if (jsonOutput) {
+            console.log(JSON.stringify({ removed: true, taskId: ids[0], tag: arg2 }, null, 2));
+          } else {
+            console.log(`Tag "${arg2}" removed from task`);
+          }
+        } else {
+          const results = await bulkExecute(ids, id => removeTag(id, arg2));
+          if (jsonOutput) {
+            console.log(JSON.stringify(results, null, 2));
+          } else {
+            console.log(formatBulkResults(results, { action: `Removed tag "${arg2}" from` }));
+          }
         }
         break;
       }
@@ -747,6 +1586,255 @@ async function main() {
         } else {
           console.log('Task description updated');
           console.log(`URL: ${task.url}`);
+        }
+        break;
+      }
+
+      case 'depends': {
+        // Set task as waiting on another task
+        const taskId = parseTaskId(targetInput);
+        if (!taskId) {
+          console.error('Error: Could not parse task ID from input');
+          process.exit(1);
+        }
+        if (!arg2) {
+          console.error('Error: Other task ID required');
+          console.error('Usage: node query.mjs depends <task> <waits_on_task>');
+          console.error('This sets the first task as waiting on/blocked by the second task.');
+          process.exit(1);
+        }
+        const dependsOnId = parseTaskId(arg2);
+        if (!dependsOnId) {
+          console.error('Error: Could not parse dependency task ID');
+          process.exit(1);
+        }
+        const result = await addDependency(taskId, { depends_on: dependsOnId });
+        if (jsonOutput) {
+          console.log(JSON.stringify(result, null, 2));
+        } else {
+          console.log(`Task ${taskId} now waits on task ${dependsOnId}`);
+        }
+        break;
+      }
+
+      case 'blocks': {
+        // Set task as blocking another task
+        const taskId = parseTaskId(targetInput);
+        if (!taskId) {
+          console.error('Error: Could not parse task ID from input');
+          process.exit(1);
+        }
+        if (!arg2) {
+          console.error('Error: Other task ID required');
+          console.error('Usage: node query.mjs blocks <task> <blocked_task>');
+          console.error('This sets the first task as blocking the second task.');
+          process.exit(1);
+        }
+        const blocksId = parseTaskId(arg2);
+        if (!blocksId) {
+          console.error('Error: Could not parse blocked task ID');
+          process.exit(1);
+        }
+        const result = await addDependency(taskId, { dependency_of: blocksId });
+        if (jsonOutput) {
+          console.log(JSON.stringify(result, null, 2));
+        } else {
+          console.log(`Task ${taskId} now blocks task ${blocksId}`);
+        }
+        break;
+      }
+
+      case 'task-link': {
+        // Create bidirectional link between tasks
+        const taskId = parseTaskId(targetInput);
+        if (!taskId) {
+          console.error('Error: Could not parse task ID from input');
+          process.exit(1);
+        }
+        if (!arg2) {
+          console.error('Error: Other task ID required');
+          console.error('Usage: node query.mjs task-link <task> <other_task>');
+          console.error('This creates a bidirectional link between tasks.');
+          process.exit(1);
+        }
+        const linksToId = parseTaskId(arg2);
+        if (!linksToId) {
+          console.error('Error: Could not parse target task ID');
+          process.exit(1);
+        }
+        const result = await addTaskLink(taskId, linksToId);
+        if (jsonOutput) {
+          console.log(JSON.stringify(result, null, 2));
+        } else {
+          console.log(`Tasks ${taskId} and ${linksToId} are now linked`);
+        }
+        break;
+      }
+
+      case 'archive': {
+        const ids = splitIds(targetInput).map(parseTaskId).filter(Boolean);
+        if (ids.length === 0) {
+          console.error('Error: Could not parse task ID from input');
+          process.exit(1);
+        }
+        if (ids.length === 1) {
+          const task = await archiveTask(ids[0]);
+          if (jsonOutput) {
+            console.log(JSON.stringify(task, null, 2));
+          } else {
+            console.log(`Task archived: ${task.name || ids[0]}`);
+            if (task.url) console.log(`URL: ${task.url}`);
+          }
+        } else {
+          const results = await bulkExecute(ids, id => archiveTask(id));
+          if (jsonOutput) {
+            console.log(JSON.stringify(results, null, 2));
+          } else {
+            console.log(formatBulkResults(results, { action: 'Archived' }));
+          }
+        }
+        break;
+      }
+
+      case 'unarchive': {
+        const ids = splitIds(targetInput).map(parseTaskId).filter(Boolean);
+        if (ids.length === 0) {
+          console.error('Error: Could not parse task ID from input');
+          process.exit(1);
+        }
+        if (ids.length === 1) {
+          const task = await unarchiveTask(ids[0]);
+          if (jsonOutput) {
+            console.log(JSON.stringify(task, null, 2));
+          } else {
+            console.log(`Task restored: ${task.name || ids[0]}`);
+            if (task.url) console.log(`URL: ${task.url}`);
+          }
+        } else {
+          const results = await bulkExecute(ids, id => unarchiveTask(id));
+          if (jsonOutput) {
+            console.log(JSON.stringify(results, null, 2));
+          } else {
+            console.log(formatBulkResults(results, { action: 'Restored' }));
+          }
+        }
+        break;
+      }
+
+      case 'claim': {
+        const sessionId = detectClaudeSessionId();
+        if (!sessionId) {
+          console.error('Error: Could not determine Claude Code session ID.');
+          console.error('Tried: $CLAUDE_SESSION_ID, then most-recently-modified');
+          console.error('       ~/.claude/projects/*/*.jsonl (within 60s).');
+          console.error('Set CLAUDE_SESSION_ID explicitly if running outside a live session.');
+          process.exit(1);
+        }
+        const taskId = parseTaskId(targetInput);
+        if (!taskId) {
+          console.error('Error: Could not parse task ID from input');
+          process.exit(1);
+        }
+        const field = await findCustomFieldByName(taskId, 'session');
+        if (!field) {
+          console.error('Error: No "Session ID" custom field found on this task.');
+          console.error('Add a text custom field named "Session ID" to the task\'s list in ClickUp.');
+          process.exit(1);
+        }
+        await setCustomField(taskId, field.id, sessionId);
+        if (jsonOutput) {
+          console.log(JSON.stringify({ taskId, fieldId: field.id, fieldName: field.name, sessionId }, null, 2));
+        } else {
+          console.log(`Session linked to task ${taskId}`);
+          console.log(`Field: ${field.name}`);
+          console.log(`Session: ${sessionId}`);
+        }
+        break;
+      }
+
+      // List commands
+      case 'list': {
+        const listId = parseListId(targetInput);
+        if (!listId) {
+          console.error('Error: Could not parse list ID from input');
+          process.exit(1);
+        }
+        const list = await getList(listId);
+        if (jsonOutput) {
+          console.log(JSON.stringify(list, null, 2));
+        } else {
+          console.log(formatList(list));
+        }
+        break;
+      }
+
+      case 'create-list': {
+        const spaceId = parseSpaceId(targetInput);
+        if (!spaceId) {
+          console.error('Error: Could not parse space ID from input');
+          console.error('Usage: node query.mjs create-list <space_id|space_url> "List Name"');
+          process.exit(1);
+        }
+        if (!arg2) {
+          console.error('Error: List name required');
+          console.error('Usage: node query.mjs create-list <space_id|space_url> "List Name"');
+          process.exit(1);
+        }
+        const options = {};
+        if (contentArg) {
+          options.content = contentArg;
+        }
+        const list = await createList(spaceId, arg2, options);
+        if (jsonOutput) {
+          console.log(JSON.stringify(list, null, 2));
+        } else {
+          console.log(`List created: ${list.name}`);
+          console.log(`ID: ${list.id}`);
+        }
+        break;
+      }
+
+      case 'update-list': {
+        const listId = parseListId(targetInput);
+        if (!listId) {
+          console.error('Error: Could not parse list ID from input');
+          console.error('Usage: node query.mjs update-list <list_id> --name "new name" --content "description"');
+          process.exit(1);
+        }
+        if (!nameArg && !contentArg) {
+          console.error('Error: At least --name or --content is required');
+          console.error('Usage: node query.mjs update-list <list_id> --name "new name" --content "description"');
+          process.exit(1);
+        }
+        const updates = {};
+        if (nameArg) {
+          updates.name = nameArg;
+        }
+        if (contentArg) {
+          updates.content = contentArg;
+        }
+        const list = await updateList(listId, updates);
+        if (jsonOutput) {
+          console.log(JSON.stringify(list, null, 2));
+        } else {
+          console.log(`List updated: ${list.name || listId}`);
+          if (list.id) console.log(`ID: ${list.id}`);
+        }
+        break;
+      }
+
+      case 'delete-list': {
+        const listId = parseListId(targetInput);
+        if (!listId) {
+          console.error('Error: Could not parse list ID from input');
+          console.error('Usage: node query.mjs delete-list <list_id>');
+          process.exit(1);
+        }
+        await deleteList(listId);
+        if (jsonOutput) {
+          console.log(JSON.stringify({ deleted: true, listId }, null, 2));
+        } else {
+          console.log(`List ${listId} deleted`);
         }
         break;
       }
@@ -810,12 +1898,18 @@ async function main() {
         if (contentArg) {
           options.content = contentArg;
         }
+        if (parentArg) {
+          options.parentPageId = parentArg;
+        }
         const page = await createPage(workspaceId, docId, arg2, options);
         if (jsonOutput) {
           console.log(JSON.stringify(page, null, 2));
         } else {
           console.log(`Page created: ${page.name}`);
           console.log(`ID: ${page.id}`);
+          if (parentArg) {
+            console.log(`Parent: ${parentArg}`);
+          }
         }
         break;
       }
@@ -831,9 +1925,9 @@ async function main() {
           console.error('Usage: node query.mjs edit-page <doc_id> <page_id> [--content "content"] [--name "name"]');
           process.exit(1);
         }
-        if (!contentArg && !nameArg) {
-          console.error('Error: At least --content or --name is required');
-          console.error('Usage: node query.mjs edit-page <doc_id> <page_id> [--content "content"] [--name "name"]');
+        if (!contentArg && !nameArg && !archiveFlag) {
+          console.error('Error: At least --content, --name, or --archive is required');
+          console.error('Usage: node query.mjs edit-page <doc_id> <page_id> [--content "content"] [--name "name"] [--archive]');
           process.exit(1);
         }
         const pageId = parsePageId(arg2);
@@ -845,14 +1939,289 @@ async function main() {
         if (nameArg) {
           updates.name = nameArg;
         }
+        if (archiveFlag) {
+          updates.archived = true;
+        }
         const page = await editPage(workspaceId, docId, pageId, updates);
         if (jsonOutput) {
           console.log(JSON.stringify(page, null, 2));
         } else {
-          console.log('Page updated successfully');
+          if (archiveFlag) {
+            console.log('Page archived successfully');
+          } else {
+            console.log('Page updated successfully');
+          }
           if (page.id) {
             console.log(`ID: ${page.id}`);
           }
+        }
+        break;
+      }
+
+      case 'attach': {
+        const taskId = parseTaskId(targetInput);
+        if (!taskId) {
+          console.error('Error: Task ID or URL required');
+          console.error('Usage: node query.mjs attach <url|id> --attach ./file1.png --attach ./file2.pdf');
+          console.error('');
+          console.error('You can also use --file for a single file:');
+          console.error('  node query.mjs attach <url|id> --file ./screenshot.png');
+          process.exit(1);
+        }
+        // Collect files from --attach args and --file arg
+        const filesToUpload = [...attachArgs.map(f => resolve(f))];
+        if (fileArg && !filesToUpload.includes(resolve(fileArg))) {
+          filesToUpload.push(resolve(fileArg));
+        }
+        if (filesToUpload.length === 0) {
+          console.error('Error: At least one file required');
+          console.error('Usage: node query.mjs attach <url|id> --attach ./file1.png [--attach ./file2.pdf]');
+          process.exit(1);
+        }
+        // Validate all files exist before uploading
+        for (const fp of filesToUpload) {
+          if (!existsSync(fp)) {
+            console.error(`Error: File not found: ${fp}`);
+            process.exit(1);
+          }
+        }
+        const attachResults = await uploadAttachments(taskId, filesToUpload);
+        if (jsonOutput) {
+          console.log(JSON.stringify(attachResults, null, 2));
+        } else {
+          for (const result of attachResults) {
+            const att = result.attachment || result;
+            const title = att.title || att.name || 'file';
+            const url = att.url || att.url_w_query || '';
+            console.log(`Attached: ${title}${url ? ` (${url})` : ''}`);
+          }
+          console.log(`\n${filesToUpload.length} file(s) attached to task ${taskId}`);
+        }
+        break;
+      }
+
+      case 'fetch-image':
+      case 'fetch-attachment': {
+        const url = targetInput;
+        if (!url) {
+          console.error('Error: Attachment URL required');
+          console.error('Usage: node query.mjs fetch-image <url> [--output path]');
+          console.error('');
+          console.error('Downloads a ClickUp attachment to a local temp file.');
+          console.error('The URL is shown in comment output as [Attachment: name](url)');
+          process.exit(1);
+        }
+
+        // Determine output path
+        const outputFlag = args.indexOf('--output');
+        let outputPath;
+        if (outputFlag !== -1 && args[outputFlag + 1]) {
+          outputPath = resolve(args[outputFlag + 1]);
+        } else {
+          // Extract filename from URL or use a default
+          const urlPath = new URL(url).pathname;
+          const filename = urlPath.split('/').pop() || 'attachment';
+          const clickupTmp = join(tmpdir(), 'clickup-attachments');
+          mkdirSync(clickupTmp, { recursive: true });
+          outputPath = join(clickupTmp, filename);
+        }
+
+        // Fetch the attachment
+        const creds = getActiveCredentials();
+        const resp = await fetch(url, {
+          headers: { Authorization: creds.apiToken },
+        });
+        if (!resp.ok) {
+          // Retry without auth (CDN URLs may not need it)
+          const resp2 = await fetch(url);
+          if (!resp2.ok) {
+            console.error(`Error: Failed to fetch attachment (${resp2.status})`);
+            process.exit(1);
+          }
+          const buffer = Buffer.from(await resp2.arrayBuffer());
+          writeFileSync(outputPath, buffer);
+        } else {
+          const buffer = Buffer.from(await resp.arrayBuffer());
+          writeFileSync(outputPath, buffer);
+        }
+
+        if (jsonOutput) {
+          console.log(JSON.stringify({ path: outputPath, url }, null, 2));
+        } else {
+          console.log(`Downloaded: ${outputPath}`);
+        }
+        break;
+      }
+
+      // ── Webhook Watcher Commands ──────────────────────────────────────────
+
+      case 'watch-task': {
+        // watch-task <task_id>[,task_id2,...] [--events evt1,evt2]
+        if (!targetInput) {
+          console.error('Error: Task ID(s) required');
+          console.error('Usage: node query.mjs watch-task <task_id>[,id2,...] [--events evt1,evt2]');
+          process.exit(1);
+        }
+        const webhookUrlPath = join(resolve(import.meta.dirname), 'webhook-url.txt');
+        let webhookUrl;
+        if (existsSync(webhookUrlPath)) {
+          webhookUrl = readFileSync(webhookUrlPath, 'utf-8').trim();
+        } else {
+          // Read from accounts.json
+          const accountsPath = join(resolve(import.meta.dirname), 'accounts.json');
+          const accts = JSON.parse(readFileSync(accountsPath, 'utf-8'));
+          if (!accts.webhookSiteToken) {
+            console.error('Error: No webhook.site token configured.');
+            console.error('Add "webhookSiteToken" to accounts.json.');
+            process.exit(1);
+          }
+          webhookUrl = `https://webhook.site/${accts.webhookSiteToken}`;
+        }
+        const events = eventsArg ? eventsArg.split(',') : DEFAULT_TASK_EVENTS;
+        const taskIds = targetInput.split(',').map(id => parseTaskId(id));
+        const results = [];
+
+        for (const taskId of taskIds) {
+          const wh = await createWebhook(webhookUrl, events, { taskId });
+          const entry = {
+            webhookId: wh.id,
+            secret: wh.secret,
+            scope: 'task',
+            scopeId: taskId,
+            events,
+            endpoint: webhookUrl,
+            createdAt: new Date().toISOString(),
+          };
+          addWatcherEntry(entry);
+          results.push(entry);
+        }
+
+        if (jsonOutput) {
+          console.log(JSON.stringify(results, null, 2));
+        } else {
+          for (const r of results) {
+            console.log(`Watching task ${r.scopeId} (webhook: ${r.webhookId})`);
+            console.log(`  Events: ${r.events.join(', ')}`);
+          }
+          console.log(`\nStart listener: node query.mjs listen`);
+        }
+        break;
+      }
+
+      case 'watch-list': {
+        if (!targetInput) {
+          console.error('Error: List ID required');
+          console.error('Usage: node query.mjs watch-list <list_id> [--events evt1,evt2]');
+          process.exit(1);
+        }
+        const webhookUrlPath = join(resolve(import.meta.dirname), 'webhook-url.txt');
+        let webhookUrl;
+        if (existsSync(webhookUrlPath)) {
+          webhookUrl = readFileSync(webhookUrlPath, 'utf-8').trim();
+        } else {
+          const accountsPath = join(resolve(import.meta.dirname), 'accounts.json');
+          const accts = JSON.parse(readFileSync(accountsPath, 'utf-8'));
+          if (!accts.webhookSiteToken) {
+            console.error('Error: No webhook.site token configured.');
+            process.exit(1);
+          }
+          webhookUrl = `https://webhook.site/${accts.webhookSiteToken}`;
+        }
+        const listId = parseListId(targetInput);
+        const events = eventsArg ? eventsArg.split(',') : DEFAULT_LIST_EVENTS;
+        const wh = await createWebhook(webhookUrl, events, { listId });
+        const entry = {
+          webhookId: wh.id,
+          secret: wh.secret,
+          scope: 'list',
+          scopeId: listId,
+          events,
+          endpoint: webhookUrl,
+          createdAt: new Date().toISOString(),
+        };
+        addWatcherEntry(entry);
+
+        if (jsonOutput) {
+          console.log(JSON.stringify(entry, null, 2));
+        } else {
+          console.log(`Watching list ${listId} (webhook: ${wh.id})`);
+          console.log(`  Events: ${events.join(', ')}`);
+          console.log(`\nStart listener: node query.mjs listen`);
+        }
+        break;
+      }
+
+      case 'watch-space': {
+        if (!targetInput) {
+          console.error('Error: Space ID required');
+          console.error('Usage: node query.mjs watch-space <space_id> [--events evt1,evt2]');
+          process.exit(1);
+        }
+        const webhookUrlPath = join(resolve(import.meta.dirname), 'webhook-url.txt');
+        let webhookUrl;
+        if (existsSync(webhookUrlPath)) {
+          webhookUrl = readFileSync(webhookUrlPath, 'utf-8').trim();
+        } else {
+          const accountsPath = join(resolve(import.meta.dirname), 'accounts.json');
+          const accts = JSON.parse(readFileSync(accountsPath, 'utf-8'));
+          if (!accts.webhookSiteToken) {
+            console.error('Error: No webhook.site token configured.');
+            process.exit(1);
+          }
+          webhookUrl = `https://webhook.site/${accts.webhookSiteToken}`;
+        }
+        const spaceId = parseSpaceId(targetInput);
+        const events = eventsArg ? eventsArg.split(',') : DEFAULT_SPACE_EVENTS;
+        const wh = await createWebhook(webhookUrl, events, { spaceId });
+        const entry = {
+          webhookId: wh.id,
+          secret: wh.secret,
+          scope: 'space',
+          scopeId: spaceId,
+          events,
+          endpoint: webhookUrl,
+          createdAt: new Date().toISOString(),
+        };
+        addWatcherEntry(entry);
+
+        if (jsonOutput) {
+          console.log(JSON.stringify(entry, null, 2));
+        } else {
+          console.log(`Watching space ${spaceId} (webhook: ${wh.id})`);
+          console.log(`  Events: ${events.join(', ')}`);
+          console.log(`\nStart listener: node query.mjs listen`);
+        }
+        break;
+      }
+
+      case 'unwatch-webhook': {
+        if (!targetInput) {
+          console.error('Error: Webhook ID required (or --all to remove all)');
+          console.error('Usage: node query.mjs unwatch-webhook <webhook_id>');
+          console.error('       node query.mjs unwatch-webhook --all');
+          process.exit(1);
+        }
+        if (targetInput === '--all') {
+          const entries = getWatcherEntries();
+          if (entries.length === 0) {
+            console.log('No watchers to remove.');
+            break;
+          }
+          let removed = 0;
+          for (const e of entries) {
+            try {
+              await deleteWebhook(e.webhookId);
+              removed++;
+            } catch (err) {
+              console.error(`  Failed to delete ${e.webhookId}: ${err.message}`);
+            }
+          }
+          clearAllWatcherEntries();
+          console.log(`Removed ${removed}/${entries.length} webhook(s).`);
+        } else {
+          await deleteWebhook(targetInput);
+          removeWatcherEntry(targetInput);
+          console.log(`Webhook ${targetInput} deleted.`);
         }
         break;
       }
@@ -867,4 +2236,14 @@ async function main() {
   }
 }
 
-main();
+main().then(() => {
+  // --cleanup: delete the source file after successful execution
+  if (cleanupFlag && fileArg) {
+    const filePath = resolve(fileArg);
+    try {
+      unlinkSync(filePath);
+    } catch {
+      // Silently ignore cleanup failures
+    }
+  }
+});

--- a/.claude/skills/clickup/reference.md
+++ b/.claude/skills/clickup/reference.md
@@ -1,0 +1,575 @@
+# ClickUp Skill Reference
+
+Supporting detail for [SKILL.md](SKILL.md). Read the section you need rather than the whole file.
+
+
+## Output Format
+
+### Task Details
+
+```
+Task: Implement user authentication
+ID: 86a1b2c3d
+Status: In Progress
+Priority: High
+Assignees: John Doe, Jane Smith
+Watchers: 2
+Due: Jan 15, 2024
+Start: Jan 10, 2024
+Time Estimate: 4h
+Created: Jan 10, 2024
+URL: https://app.clickup.com/t/86a1b2c3d
+List: Sprint Backlog
+Folder: Development
+Space: 20128955
+
+Description:
+Add OAuth2 authentication with Google and GitHub providers...
+```
+
+### Task List
+
+```
+[to do] Fix login bug
+  ID: 868h2cxat | Priority: high | Assignees: John Doe
+  https://app.clickup.com/t/868h2cxat
+
+[in progress] Update API docs
+  ID: 868g7c75u | Priority: None | Assignees: Jane Smith
+  https://app.clickup.com/t/868g7c75u
+
+Total: 2 task(s)
+```
+
+### Comments
+
+```
+[2024-01-12 14:30] John Doe:
+  Started working on this. Will push initial commit today.
+
+[2024-01-12 16:45] Jane Smith:
+  @John looks good! Let me know when ready for review.
+```
+
+### Doc Details
+
+```
+Doc: API Documentation
+ID: abc123def
+Created: Jan 10, 2024, 09:30 AM
+Updated: Jan 15, 2024, 02:45 PM
+Creator: John Doe
+Workspace: 12345678
+
+Pages:
+Introduction
+  ID: page001
+
+Getting Started
+  ID: page002
+
+API Reference
+  ID: page003
+
+Total: 3 page(s)
+```
+
+### Page Content
+
+```
+Page: Getting Started
+ID: page002
+Created: Jan 10, 2024, 10:00 AM
+Updated: Jan 14, 2024, 03:30 PM
+
+Content:
+---
+# Getting Started
+
+Welcome to the API documentation.
+
+## Prerequisites
+- Node.js 18+
+- An API key
+---
+```
+## Technical Notes
+
+### Markdown Handling
+
+ClickUp uses different content formats for different features:
+
+| Feature | API Version | Content Format |
+|---------|-------------|----------------|
+| Comments | v2 | Proprietary JSON array (converted via `markdownToClickUp()`) |
+| Task descriptions | v2 | Native markdown via `markdown_description` field |
+| Docs/Pages | v3 | Native markdown (no conversion needed) |
+
+The Docs API (v3) accepts and returns markdown directly, so no conversion is required. Task comments use a proprietary JSON array format that requires the `lib/markdown.mjs` conversion utilities.
+
+### @Mentions
+
+Comments support two mention syntaxes. The pipeline (`lib/mentions.mjs`):
+
+1. **Phase 1 — Explicit**: Extract `@[identifier]` patterns, resolve via fuzzy matching
+2. **Phase 2 — Bare**: Detect remaining `@Name` patterns, match against workspace member usernames
+3. **Convert** markdown to ClickUp's JSON array format
+4. **Inject** mention attributes (`{"text": "@DisplayName", "attributes": {"mention": userId}}`)
+
+Explicit `@[identifier]` supports:
+- **Partial name**: `@[justin]` → fuzzy matches "Justin Maier"
+- **Email**: `@[jane@co.com]` → matches by email
+- **User ID**: `@[10620972]` → direct numeric ID
+
+Bare `@Name` auto-detection:
+- Matches `@First Last` or `@First` against workspace members (case-insensitive)
+- Tries full username first, then first name only
+- Unmatched bare mentions are left as plain text (no error, no API call wasted)
+- This is a **safety net** for agents that forget bracket syntax
+
+If an explicit `@[identifier]` can't be matched, an error is thrown. Bare mentions fail silently.
+
+### Doc Page Structure
+
+When you create a doc via the API, ClickUp automatically creates an empty first page. This has implications:
+
+- **`create-doc`** - Creates a doc with an auto-generated first page. Use `--content` to populate that first page.
+- **`create-page`** - Adds an *additional* page to a doc (second page, third page, etc.)
+- **`edit-page`** - Modifies an existing page's content
+
+To add content to a new doc, use `create-doc "Title" --content "..."` rather than creating the doc and then using `create-page` (which would leave the first page empty).
+
+### Pagination
+
+All list endpoints now automatically paginate through all results:
+- Task lists: Page-based (100 per page)
+- Comments: Cursor-based (25 per page)
+- Docs search: Cursor-based (returns `{ docs, nextCursor }`)
+
+Rate limiting is handled automatically with retry and backoff (max 2 retries).
+
+## Testing
+
+Smoke tests verify all commands against the live ClickUp API.
+
+```bash
+# Full test suite (creates test resources, validates, cleans up)
+node test/smoke-test.mjs
+
+# Read-only tests (safe, no writes)
+node test/smoke-test.mjs --readonly
+
+# Verbose output (shows details on failures)
+node test/smoke-test.mjs --verbose
+```
+
+When adding new features, add corresponding tests to `test/smoke-test.mjs`.
+
+## Webhook Watchers (Event Monitoring)
+
+Watch ClickUp tasks, lists, or spaces for real-time events via webhooks. Uses webhook.site as a public relay — no external infrastructure needed.
+
+### Setup
+
+Add your webhook.site token to `accounts.json`:
+
+```json
+{
+  "webhookSiteToken": "your-uuid-from-webhook.site",
+  "defaultAccount": "bot",
+  "accounts": { ... }
+}
+```
+
+Requires `@webhooksite/cli` (`whcli`) for live forwarding: `npm install -g @webhooksite/cli`
+
+### Commands
+
+```bash
+# Watch a task (or multiple tasks) for events
+node query.mjs watch-task <task_id>
+node query.mjs watch-task <id1>,<id2>,<id3>
+node query.mjs watch-task <task_id> --events taskStatusUpdated,taskCommentPosted
+
+# Watch a list or space
+node query.mjs watch-list <list_id>
+node query.mjs watch-space <space_id>
+
+# List active watchers (local registry)
+node query.mjs watchers
+
+# List all webhooks in workspace (from ClickUp API)
+node query.mjs webhooks
+
+# Remove a specific watcher
+node query.mjs unwatch-webhook <webhook_id>
+
+# Remove all watchers
+node query.mjs unwatch-webhook --all
+```
+
+### Listener
+
+The listener receives webhook events via webhook.site forwarding. Run as a background task:
+
+```bash
+# Wait mode (default): receive one event, print it, exit
+node listen.mjs --timeout 600
+
+# Server mode: stay running, log all events
+node listen.mjs --mode server
+
+# Options
+node listen.mjs --port 3458 --timeout 300 --mode wait
+```
+
+### Listener Filters
+
+Filter events so the listener only wakes the agent for relevant changes:
+
+```bash
+# Only deliver when a task moves to "qa review" status
+node listen.mjs --filter-status "qa review"
+
+# Only deliver comment events (ignore status changes etc.)
+node listen.mjs --filter-event taskCommentPosted
+
+# Only deliver events for a specific task
+node listen.mjs --filter-task 868abc123
+
+# Combine filters
+node listen.mjs --filter-status "complete,qa review" --filter-event taskStatusUpdated
+
+# Multiple values are comma-separated
+node listen.mjs --filter-status "in review,ready for qa"
+```
+
+Filter behavior:
+- `--filter-status` — For `taskStatusUpdated` events, only deliver if the *new* status matches. Non-status events pass through unaffected.
+- `--filter-event` — Only deliver events of this type. Comma-separated for multiple.
+- `--filter-task` — Only deliver events for this task ID. Comma-separated for multiple.
+- Filtered events are still logged to `webhooks.jsonl` and update the cursor, but don't trigger delivery to the agent.
+- Always returns 200 OK to ClickUp (even for filtered events) to keep the webhook healthy.
+
+### Agent Workflow
+
+Typical agent usage pattern:
+
+```bash
+# 1. Set up a watcher
+node query.mjs watch-task 868abc123 --events taskStatusUpdated,taskCommentPosted
+
+# 2. Start listener as background task (run_in_background=true)
+node listen.mjs --timeout 600
+
+# 3. Agent continues other work...
+
+# 4. When event arrives, background task exits with the event JSON
+# Agent reads webhook-latest.json or parses stdout
+
+# 5. Restart listener if more events expected
+node listen.mjs --timeout 600
+
+# 6. Clean up when done
+node query.mjs unwatch-webhook --all
+```
+
+### Default Events
+
+| Command | Default Events |
+|---------|---------------|
+| watch-task | taskStatusUpdated, taskCommentPosted, taskUpdated, taskAssigneeUpdated, taskDueDateUpdated |
+| watch-list | taskCreated, taskStatusUpdated, taskCommentPosted, taskUpdated, taskDeleted |
+| watch-space | taskCreated, taskStatusUpdated, taskCommentPosted, taskUpdated, taskDeleted, listCreated, listUpdated, listDeleted |
+
+Override defaults with `--events evt1,evt2,...`
+
+### Event Payload
+
+Events are saved to:
+- `webhook-latest.json` — Most recent event (pretty-printed)
+- `webhooks.jsonl` — Append-only log of all events
+- `last-seen.txt` — Timestamp cursor for catch-up
+
+The listener checks for missed events on startup (via webhook.site API), so gaps between listener restarts are handled automatically.
+
+### Available Event Types
+
+Task events: `taskCreated`, `taskUpdated`, `taskDeleted`, `taskPriorityUpdated`, `taskStatusUpdated`, `taskAssigneeUpdated`, `taskDueDateUpdated`, `taskTagUpdated`, `taskMoved`, `taskCommentPosted`, `taskCommentUpdated`, `taskTimeEstimateUpdated`, `taskTimeTrackedUpdated`, `taskAttachmentUploaded`, `taskCustomFieldUpdated`
+
+List/folder/space events: `listCreated`, `listUpdated`, `listDeleted`, `folderCreated`, `folderUpdated`, `folderDeleted`, `spaceCreated`, `spaceUpdated`, `spaceDeleted`
+
+## Task Watcher (polling)
+
+`watch.mjs` is a **self-contained, polling-based** watcher for a single task (or
+every task in a list). It snapshots the task's baseline, polls the ClickUp API
+on an interval, and **exits 0 the moment a watched change is detected** — printing
+a concise JSON of what changed. Run it with `run_in_background=true` and the
+parent agent gets a task-notification when it exits.
+
+Unlike the webhook watchers above (`watch-task` / `listen.mjs`), this needs **no
+webhook.site account and no `whcli`** — it works anywhere the API token works.
+Prefer it as the default; reach for the webhook path only when you need
+real-time, sub-second latency or workspace-wide event streams.
+
+### Usage
+
+```bash
+# Watch a single task (id or URL) for status / comment / assignee changes
+node watch.mjs 868kjbyvu
+node watch.mjs "https://app.clickup.com/t/868kjbyvu"
+
+# Watch every task in a list (tracks status/assignee changes + task created/deleted)
+node watch.mjs --list 901111220963
+
+# Wake only when the task reaches one of these statuses
+node watch.mjs 868kjbyvu --until-status "in progress,complete"
+
+# Only wake on specific change types
+node watch.mjs 868kjbyvu --on comments
+node watch.mjs 868kjbyvu --on status,assignee
+
+# Tune cadence + lifetime, and mirror the latest change to a state file
+node watch.mjs 868kjbyvu --timeout 3600 --interval 45 --state-file ./watch-latest.json
+
+# Target a specific account
+node watch.mjs 868kjbyvu --account justin
+```
+
+### Flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `<taskId\|url>` | — | Positional. The task to watch (id or any task URL). |
+| `--list <id\|url>` | — | Watch all tasks in a list instead of a single task. |
+| `--timeout <sec>` | `3600` | Max seconds to watch before exiting with a `timeout` result. |
+| `--interval <sec>` | `45` | Poll cadence (min 10 — be gentle on rate limits). |
+| `--on <types>` | `status,comments,assignee` | Comma list of change types that wake it. |
+| `--until-status <list>` | — | Only wake when the task reaches one of these statuses (implies `--on status`). |
+| `--account <name>` | default | Named account from `accounts.json`. |
+| `--state-file <path>` | — | Optional. Writes baseline + latest change JSON here (mirrors the webhook `webhook-latest.json` idea). |
+
+### What it detects
+
+- **status** — task status changed (`{from, to}`).
+- **comments** — new comment posted (latest comment id / count moved). *(single-task mode only; list mode skips per-task comment fetches to stay gentle on the API.)*
+- **assignee** — assignees added/removed.
+- **list mode** also reports `taskCreated` / `taskDeleted`.
+
+### Exit behavior
+
+- **Change detected** → prints `{"event":"change", ...}` and exits `0`.
+- **Timed out** → prints `{"event":"timeout", ...}` and exits `0`.
+- **Fatal config error** (bad id, no auth) → prints `ERROR:` and exits `1`.
+
+API/network/rate-limit errors during polling never crash the loop — they log to
+stderr and back off exponentially (capped at 60s), then keep polling.
+
+### Agent workflow
+
+```bash
+# 1. Start the watcher as a background task (run_in_background=true)
+node watch.mjs 868kjbyvu --until-status "in review" --timeout 3600
+
+# 2. Agent continues other work...
+
+# 3. When the task hits "in review", the background task exits 0 and the agent
+#    is notified. Read the printed JSON (or --state-file) to see what changed:
+#    {"event":"change","changes":[{"type":"status","from":"in progress","to":"in review"}], ...}
+
+# 4. Act on it, then re-arm the watcher if more changes are expected:
+node watch.mjs 868kjbyvu --until-status "complete" --timeout 3600
+```
+
+The change JSON includes the task URL, the fresh snapshot (status, assignees,
+comment count), and `elapsedSec`, so the agent can act without an extra `get`.
+
+## Batch Task Creation (Project Setup)
+
+Create an entire project's tasks from a single JSON file. Supports names, descriptions, assignments, priorities, subtasks, tags, dates, and inter-task dependencies.
+
+### Usage
+
+```bash
+# Create tasks from a JSON plan
+node query.mjs batch-create --file plan.json
+
+# Preview without creating (dry run)
+node query.mjs batch-create --file plan.json --dry-run
+
+# JSON output for programmatic use
+node query.mjs batch-create --file plan.json --json
+```
+
+### JSON Plan Schema
+
+```json
+{
+  "listId": "901111220963",
+  "tasks": [
+    {
+      "ref": "design",
+      "name": "Design system architecture",
+      "description": "Create the high-level architecture document",
+      "assignee": "justin",
+      "priority": "high",
+      "status": "to do",
+      "dueDate": "+7d",
+      "startDate": "today",
+      "tags": ["architecture", "phase-1"],
+      "subtasks": [
+        { "name": "Draft ERD", "assignee": "mark" },
+        { "name": "Review ERD", "assignee": "dakota" }
+      ]
+    },
+    {
+      "ref": "implement",
+      "name": "Implement core modules",
+      "assignee": "mark",
+      "priority": "normal",
+      "dependsOn": ["design"],
+      "subtasks": [
+        { "name": "Build data layer" },
+        { "name": "Build API endpoints" },
+        { "name": "Write unit tests" }
+      ]
+    },
+    {
+      "ref": "qa",
+      "name": "QA validation",
+      "assignee": "dakota",
+      "dependsOn": ["implement"],
+      "subtasks": [
+        { "name": "Integration tests" },
+        { "name": "Performance testing" }
+      ]
+    }
+  ]
+}
+```
+
+### Plan Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `ref` | string | Local reference ID for wiring dependencies between tasks |
+| `name` | string | Task title (required) |
+| `description` | string | Markdown description |
+| `assignee` | string | Name, email, or user ID |
+| `priority` | string | urgent, high, normal, low, none |
+| `status` | string | Status name (must match list's available statuses) |
+| `dueDate` | string | Absolute date or relative (+3d, +1w, tomorrow) |
+| `startDate` | string | Same format as dueDate |
+| `tags` | string[] | Tag names to apply |
+| `listId` | string | Override the default listId for this task |
+| `dependsOn` | string[] | Refs of tasks that must complete first |
+| `blocks` | string[] | Refs of tasks this one blocks |
+| `subtasks` | object[] | Array of { name, description, assignee, status } |
+
+### How Dependencies Work
+
+Use `ref` as a local identifier, then reference it in `dependsOn` or `blocks`:
+
+```json
+{
+  "tasks": [
+    { "ref": "a", "name": "Task A", "blocks": ["b"] },
+    { "ref": "b", "name": "Task B", "dependsOn": ["a"] }
+  ]
+}
+```
+
+Both `blocks` and `dependsOn` create the same ClickUp dependency — choose whichever reads more naturally. Tasks are created first, then dependencies are wired up in a second pass.
+
+## Team Workflow Patterns
+
+### Pattern 1: Team Lead Sets Up Project
+
+The team lead creates the entire project plan as JSON, then batch-creates it:
+
+```bash
+# 1. Write the plan (or have the agent generate it)
+# 2. Create all tasks in one shot
+node query.mjs batch-create --file project-plan.json
+
+# 3. Set up watchers on the list
+node query.mjs watch-list <list_id> --events taskStatusUpdated,taskCommentPosted
+
+# 4. Start listener to monitor progress
+node listen.mjs --timeout 3600 --mode server
+```
+
+### Pattern 2: Worker Agent Claims and Completes Tasks
+
+```bash
+# 1. Check assigned tasks
+node query.mjs my-tasks
+
+# 2. Claim a task (links session for resumability)
+node query.mjs claim <task_id>
+
+# 3. Move to in progress
+node query.mjs status <task_id> "in progress"
+
+# 4. Do the work...
+
+# 5. Move to review when done
+node query.mjs status <task_id> "in review"
+node query.mjs comment <task_id> "Implementation complete. Ready for review."
+```
+
+### Pattern 3: QA Reviewer Watches for Review State
+
+```bash
+# 1. Watch the list for status changes
+node query.mjs watch-list <list_id> --events taskStatusUpdated
+
+# 2. Start listener filtered to only "in review" status
+node listen.mjs --filter-status "in review" --timeout 3600
+
+# 3. When a task hits review, agent wakes up, reads the event
+# 4. Fetches the task, reviews, and either approves or sends back
+node query.mjs get <task_id>
+node query.mjs comments <task_id>
+
+# If approved:
+node query.mjs status <task_id> "complete"
+node query.mjs comment <task_id> "QA approved."
+
+# If needs changes:
+node query.mjs status <task_id> "in progress"
+node query.mjs comment <task_id> "Needs revision: [details]"
+
+# 5. Restart listener for next review
+node listen.mjs --filter-status "in review" --timeout 3600
+```
+
+### Pattern 4: Doc Keeper Gets Notified on Completion
+
+```bash
+# Watch for tasks completing
+node query.mjs watch-list <list_id> --events taskStatusUpdated
+node listen.mjs --filter-status "complete" --timeout 3600
+
+# When notified, update project documentation
+node query.mjs get <task_id>  # Read what was completed
+# Update docs accordingly...
+```
+
+### Pattern 5: Phase Gates
+
+For projects with sequential phases (design → implementation → QA → deploy):
+
+```json
+{
+  "listId": "...",
+  "tasks": [
+    { "ref": "phase1", "name": "Phase 1: Design", "tags": ["phase-gate"] },
+    { "ref": "phase2", "name": "Phase 2: Implementation", "dependsOn": ["phase1"], "tags": ["phase-gate"] },
+    { "ref": "phase3", "name": "Phase 3: QA", "dependsOn": ["phase2"], "tags": ["phase-gate"] },
+    { "ref": "phase4", "name": "Phase 4: Deploy", "dependsOn": ["phase3"], "tags": ["phase-gate"] }
+  ]
+}
+```
+
+A gate-keeper agent watches for phase-gate tasks completing and triggers the next phase's work.

--- a/.claude/skills/clickup/test/smoke-test.mjs
+++ b/.claude/skills/clickup/test/smoke-test.mjs
@@ -1,0 +1,502 @@
+#!/usr/bin/env node
+
+/**
+ * ClickUp Skill Smoke Tests
+ *
+ * Runs live API tests against the ClickUp workspace to verify all commands work.
+ * Creates test resources, validates them, then cleans up.
+ *
+ * Usage:
+ *   node test/smoke-test.mjs              # Run all tests
+ *   node test/smoke-test.mjs --readonly   # Skip write tests (safe for CI)
+ *   node test/smoke-test.mjs --verbose    # Show full output from each command
+ *
+ * Prerequisites:
+ *   - .env file configured with CLICKUP_API_TOKEN and CLICKUP_TEAM_ID
+ *   - CLICKUP_DEFAULT_LIST_ID set (or provide a test list ID)
+ */
+
+import { execFile } from 'child_process';
+import { writeFileSync, existsSync, unlinkSync } from 'fs';
+import { dirname, resolve } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const QUERY = resolve(__dirname, '..', 'query.mjs');
+
+// Config
+const VERBOSE = process.argv.includes('--verbose');
+const READONLY = process.argv.includes('--readonly');
+
+// Test infrastructure list (Meta - Infrastructure)
+const TEST_LIST_ID = '901113123527';
+const TEST_SPACE_ID = '90114072520';
+
+// Persistent smoke test doc (created once, reused across runs)
+// Pages created during tests are archived in cleanup
+const PERSISTENT_DOC_ID = '825mr-17091';
+
+// Tracking
+let passed = 0;
+let failed = 0;
+let skipped = 0;
+const failures = [];
+const cleanupTasks = [];
+
+// ─── Helpers ───────────────────────────────────────────────────────────
+
+function run(args, { timeout = 30000 } = {}) {
+  return new Promise((resolve, reject) => {
+    execFile('node', [QUERY, ...args], { timeout }, (err, stdout, stderr) => {
+      const output = (stdout || '') + (stderr || '');
+      if (err && err.killed) {
+        reject(new Error(`Timed out after ${timeout}ms`));
+      } else {
+        // Some commands exit(1) for usage errors - that's expected for validation tests
+        resolve({ code: err?.code || 0, output: output.trim(), stdout: (stdout || '').trim(), stderr: (stderr || '').trim() });
+      }
+    });
+  });
+}
+
+function runJson(args, options) {
+  return run([...args, '--json'], options);
+}
+
+async function test(name, fn) {
+  try {
+    await fn();
+    passed++;
+    console.log(`  \x1b[32m✓\x1b[0m ${name}`);
+  } catch (err) {
+    failed++;
+    failures.push({ name, error: err.message });
+    console.log(`  \x1b[31m✗\x1b[0m ${name}`);
+    if (VERBOSE) {
+      console.log(`    Error: ${err.message}`);
+    }
+  }
+}
+
+function skip(name, reason = 'readonly mode') {
+  skipped++;
+  console.log(`  \x1b[33m○\x1b[0m ${name} (skipped: ${reason})`);
+}
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message || 'Assertion failed');
+}
+
+function assertContains(text, substr, message) {
+  if (!text.includes(substr)) {
+    throw new Error(message || `Expected output to contain "${substr}", got: ${text.slice(0, 200)}`);
+  }
+}
+
+function assertJson(text) {
+  try {
+    return JSON.parse(text);
+  } catch {
+    throw new Error(`Expected valid JSON, got: ${text.slice(0, 200)}`);
+  }
+}
+
+// ─── Read-only Tests ───────────────────────────────────────────────────
+
+async function readOnlyTests() {
+  console.log('\n\x1b[1mRead-only Tests\x1b[0m');
+
+  await test('help: shows usage', async () => {
+    const { output } = await run([]);
+    assertContains(output, 'Usage:');
+    assertContains(output, 'Task Commands:');
+    assertContains(output, 'Document Commands:');
+    assertContains(output, 'List Commands:');
+  });
+
+  await test('me: returns user info', async () => {
+    const { output } = await run(['me']);
+    assertContains(output, 'User:');
+    assertContains(output, 'ID:');
+    assertContains(output, 'Email:');
+  });
+
+  await test('me --json: returns valid JSON', async () => {
+    const { stdout } = await runJson(['me']);
+    const data = assertJson(stdout);
+    assert(data.id, 'Expected user ID');
+    assert(data.username, 'Expected username');
+  });
+
+  await test('my-tasks: lists assigned tasks', async () => {
+    const { output } = await run(['my-tasks']);
+    // Should contain at least "Total: X task(s)" or list some tasks
+    assert(output.includes('task(s)') || output.includes('ID:'), 'Expected task listing');
+  });
+
+  await test('tasks: lists tasks in a list', async () => {
+    const { output } = await run(['tasks', TEST_LIST_ID]);
+    assert(output.includes('task(s)') || output.includes('ID:'), 'Expected task listing');
+  });
+
+  await test('docs: lists workspace docs', async () => {
+    const { output } = await run(['docs']);
+    assertContains(output, 'doc(s)');
+  });
+
+  await test('docs --json: returns valid JSON', async () => {
+    const { stdout } = await runJson(['docs']);
+    const data = assertJson(stdout);
+    assert(Array.isArray(data.docs || data), 'Expected docs array');
+  });
+
+  await test('space-lists: lists folderless lists', async () => {
+    const { output } = await run(['space-lists', TEST_SPACE_ID]);
+    // May have 0 lists, that's ok - should not error
+    assert(output.includes('list(s)') || output.includes('No folderless lists'), 'Expected list result');
+  });
+
+  await test('get: handles missing task ID', async () => {
+    const { output, code } = await run(['get']);
+    assert(code !== 0, 'Expected non-zero exit');
+    assertContains(output, 'Usage:');
+  });
+
+  await test('comment: handles missing text', async () => {
+    const { output, code } = await run(['comment', 'fakeid']);
+    assert(code !== 0, 'Expected non-zero exit');
+    assertContains(output, 'Error');
+  });
+}
+
+// ─── Write Tests ──────────────────────────────────────────────────────
+
+async function writeTests() {
+  console.log('\n\x1b[1mWrite Tests (create → verify → cleanup)\x1b[0m');
+
+  let testTaskId = null;
+  let testSubtaskId = null;
+  let testCommentId = null;
+  let testListId = null;
+  const testPageIds = [];  // Track pages to archive in cleanup
+
+  // ── Task CRUD ──
+
+  await test('create: creates a task', async () => {
+    const { stdout } = await runJson(['create', TEST_LIST_ID, 'SMOKE TEST: Delete me']);
+    const data = assertJson(stdout);
+    testTaskId = data.id;
+    assert(testTaskId, 'Expected task ID in response');
+    cleanupTasks.push({ type: 'task', id: testTaskId });
+    if (VERBOSE) console.log(`    Created task: ${testTaskId}`);
+  });
+
+  if (!testTaskId) {
+    skip('Remaining write tests', 'task creation failed');
+    return;
+  }
+
+  await test('get: retrieves created task', async () => {
+    const { output } = await run(['get', testTaskId]);
+    assertContains(output, 'SMOKE TEST: Delete me');
+    assertContains(output, testTaskId);
+  });
+
+  await test('get --json: returns full task JSON', async () => {
+    const { stdout } = await runJson(['get', testTaskId]);
+    const data = assertJson(stdout);
+    assert(data.id === testTaskId, 'Task ID mismatch');
+    assert(data.name === 'SMOKE TEST: Delete me', 'Task name mismatch');
+  });
+
+  await test('rename: renames a task', async () => {
+    const { output } = await run(['rename', testTaskId, 'SMOKE TEST: Renamed']);
+    assertContains(output, 'Renamed');
+  });
+
+  await test('priority: sets priority', async () => {
+    const { output } = await run(['priority', testTaskId, 'high']);
+    assertContains(output, 'high');
+  });
+
+  await test('due: sets due date', async () => {
+    const { output } = await run(['due', testTaskId, 'tomorrow']);
+    assertContains(output, 'Due date set');
+  });
+
+  await test('start: sets start date', async () => {
+    const { output } = await run(['start', testTaskId, 'today']);
+    assertContains(output, 'Start date set');
+  });
+
+  await test('tag: adds a tag', async () => {
+    const { output } = await run(['tag', testTaskId, 'smoke-test']);
+    assertContains(output, 'added');
+  });
+
+  await test('remove-tag: removes a tag', async () => {
+    const { output } = await run(['remove-tag', testTaskId, 'smoke-test']);
+    assertContains(output, 'removed');
+  });
+
+  await test('description: updates description', async () => {
+    const { output } = await run(['description', testTaskId, 'Test description\\nWith newline']);
+    assertContains(output, 'description updated');
+  });
+
+  // ── File-based Content ──
+
+  const tmpFile = resolve(__dirname, '.tmp-smoke-test.md');
+  const tmpFileCleanup = resolve(__dirname, '.tmp-smoke-cleanup.md');
+
+  await test('--file: posts comment from file', async () => {
+    writeFileSync(tmpFile, '# File-based Comment\n\nThis comment was loaded from a markdown file.\n\n- Item 1\n- Item 2\n');
+    const { stdout } = await runJson(['comment', testTaskId, '--file', tmpFile]);
+    const data = assertJson(stdout);
+    assert(data.id, 'Expected comment ID');
+    // Clean up the comment
+    await run(['delete-comment', data.id]);
+    // Clean up the temp file
+    unlinkSync(tmpFile);
+  });
+
+  await test('--file --cleanup: deletes file after success', async () => {
+    writeFileSync(tmpFileCleanup, 'Cleanup test content');
+    const { output } = await run(['description', testTaskId, '--file', tmpFileCleanup, '--cleanup']);
+    assertContains(output, 'description updated');
+    assert(!existsSync(tmpFileCleanup), 'Expected temp file to be deleted after --cleanup');
+  });
+
+  await test('--file: handles missing file', async () => {
+    const { output, code } = await run(['comment', testTaskId, '--file', '/nonexistent/path.md']);
+    assert(code !== 0, 'Expected non-zero exit');
+    assertContains(output, 'not found');
+  });
+
+  // ── Comments ──
+
+  await test('comment: posts a comment', async () => {
+    const { stdout } = await runJson(['comment', testTaskId, 'Smoke test comment']);
+    const data = assertJson(stdout);
+    testCommentId = data.id;
+    assert(testCommentId, 'Expected comment ID');
+    if (VERBOSE) console.log(`    Created comment: ${testCommentId}`);
+  });
+
+  await test('comments: lists comments', async () => {
+    const { output } = await run(['comments', testTaskId]);
+    assertContains(output, 'Smoke test comment');
+  });
+
+  if (testCommentId) {
+    await test('update-comment: updates comment text', async () => {
+      const { output } = await run(['update-comment', testCommentId, 'Updated smoke test comment']);
+      assertContains(output, 'updated');
+    });
+
+    await test('resolve-comment: resolves comment', async () => {
+      const { output } = await run(['resolve-comment', testCommentId]);
+      assertContains(output, 'resolved');
+    });
+
+    await test('delete-comment: deletes comment', async () => {
+      const { output } = await run(['delete-comment', testCommentId]);
+      assertContains(output, 'deleted');
+      testCommentId = null;
+    });
+  }
+
+  // ── @Mentions ──
+
+  await test('mention: posts comment with @[username] mention', async () => {
+    const { stdout } = await runJson(['comment', testTaskId, 'SMOKE TEST: Hey @[justin], take a look']);
+    const data = assertJson(stdout);
+    assert(data.id, 'Expected comment ID');
+    // Clean up
+    await run(['delete-comment', data.id]);
+  });
+
+  await test('mention: unknown user throws clear error', async () => {
+    const { output, code } = await run(['comment', testTaskId, 'SMOKE TEST: @[nonexistentuser99999xyz]']);
+    assert(code !== 0, 'Expected non-zero exit for unknown user');
+    assertContains(output, 'Could not find user');
+  });
+
+  await test('mention: plain comment without mentions still works', async () => {
+    const { stdout } = await runJson(['comment', testTaskId, 'SMOKE TEST: No mentions here']);
+    const data = assertJson(stdout);
+    assert(data.id, 'Expected comment ID');
+    // Clean up
+    await run(['delete-comment', data.id]);
+  });
+
+  // ── Checklist ──
+
+  await test('checklist: adds checklist item', async () => {
+    const { output } = await run(['checklist', testTaskId, 'Test checklist item']);
+    assertContains(output, 'checklist');
+  });
+
+  // ── Subtasks ──
+
+  await test('subtask: creates subtask', async () => {
+    const { stdout } = await runJson(['subtask', testTaskId, 'SMOKE TEST subtask']);
+    const data = assertJson(stdout);
+    testSubtaskId = data.id;
+    assert(testSubtaskId, 'Expected subtask ID');
+    cleanupTasks.push({ type: 'task', id: testSubtaskId });
+  });
+
+  await test('get --subtasks: shows subtasks', async () => {
+    const { output } = await run(['get', testTaskId, '--subtasks']);
+    assertContains(output, 'Subtask');
+  });
+
+  // ── List CRUD ──
+
+  await test('create-list: creates a list', async () => {
+    const { output } = await run(['create-list', TEST_SPACE_ID, 'SMOKE TEST: Delete me']);
+    assertContains(output, 'List created');
+    const match = output.match(/ID:\s*(\d+)/);
+    assert(match, 'Expected list ID in output');
+    testListId = match[1];
+    cleanupTasks.push({ type: 'list', id: testListId });
+    if (VERBOSE) console.log(`    Created list: ${testListId}`);
+  });
+
+  if (testListId) {
+    await test('list: retrieves list details', async () => {
+      const { output } = await run(['list', testListId]);
+      assertContains(output, 'SMOKE TEST');
+    });
+
+    await test('update-list: renames a list', async () => {
+      const { output } = await run(['update-list', testListId, '--name', 'SMOKE TEST: Renamed list']);
+      assertContains(output, 'updated');
+    });
+  }
+
+  // ── Doc CRUD (uses persistent doc to avoid orphaned docs) ──
+
+  const testDocId = PERSISTENT_DOC_ID;
+
+  await test('doc: retrieves doc details', async () => {
+    const { output } = await run(['doc', testDocId]);
+    assertContains(output, 'Smoke Test');
+    assertContains(output, 'page(s)');
+  });
+
+  await test('doc --json: page listing', async () => {
+    const { stdout } = await runJson(['doc', testDocId]);
+    const data = assertJson(stdout);
+    assert(data.pages && data.pages.length > 0, 'Expected at least one page');
+  });
+
+  // Get the first page to test page read
+  const { stdout: docJson } = await runJson(['doc', testDocId]);
+  const docData = JSON.parse(docJson);
+  const firstPageId = docData.pages?.[0]?.id;
+
+  if (firstPageId) {
+    await test('page: reads page content', async () => {
+      const { output } = await run(['page', testDocId, firstPageId]);
+      assertContains(output, 'Content:');
+    });
+  }
+
+  await test('create-page: adds new page to doc', async () => {
+    const { stdout } = await runJson(['create-page', testDocId, 'SMOKE TEST Page', '--content', '## Test\\nCreated by smoke test']);
+    const data = assertJson(stdout);
+    assert(data.id, 'Expected page ID');
+    testPageIds.push(data.id);
+    if (VERBOSE) console.log(`    Created page: ${data.id}`);
+  });
+
+  if (testPageIds.length > 0) {
+    await test('edit-page: updates page content', async () => {
+      const { output } = await run(['edit-page', testDocId, testPageIds[0], '--content', '# Updated\\nEdited by smoke test', '--name', 'SMOKE TEST Page (edited)']);
+      assertContains(output, 'updated');
+    });
+  }
+
+
+  // ── Archive/Unarchive ──
+
+  await test('archive: archives a task', async () => {
+    const { output } = await run(['archive', testTaskId]);
+    assertContains(output, 'archived');
+  });
+
+  await test('unarchive: restores a task', async () => {
+    const { output } = await run(['unarchive', testTaskId]);
+    assertContains(output, 'restored');
+  });
+
+  return { testPageIds };
+}
+
+// ─── Cleanup ───────────────────────────────────────────────────────────
+
+async function cleanup(testPageIds = []) {
+  console.log('\n\x1b[1mCleanup\x1b[0m');
+
+  // Archive test pages created during doc CRUD tests
+  for (const pageId of testPageIds) {
+    try {
+      await run(['edit-page', PERSISTENT_DOC_ID, pageId, '--archive']);
+      console.log(`  Archived page ${pageId}`);
+    } catch (err) {
+      console.log(`  ⚠ Failed to archive page ${pageId}: ${err.message}`);
+    }
+  }
+
+  for (const item of cleanupTasks.reverse()) {
+    try {
+      if (item.type === 'task') {
+        await run(['archive', item.id]);
+        console.log(`  Archived task ${item.id}`);
+      } else if (item.type === 'list') {
+        await run(['delete-list', item.id]);
+        console.log(`  Deleted list ${item.id}`);
+      }
+    } catch (err) {
+      console.log(`  ⚠ Failed to clean up ${item.type} ${item.id}: ${err.message}`);
+    }
+  }
+}
+
+// ─── Main ──────────────────────────────────────────────────────────────
+
+async function main() {
+  console.log('ClickUp Skill Smoke Tests');
+  console.log('========================');
+  console.log(`Mode: ${READONLY ? 'read-only' : 'full (read + write)'}`);
+
+  await readOnlyTests();
+
+  if (!READONLY) {
+    const { testPageIds } = await writeTests();
+    await cleanup(testPageIds);
+  }
+
+  // Summary
+  console.log('\n\x1b[1mResults\x1b[0m');
+  console.log(`  Passed:  ${passed}`);
+  if (failed > 0) console.log(`  \x1b[31mFailed:  ${failed}\x1b[0m`);
+  if (skipped > 0) console.log(`  Skipped: ${skipped}`);
+
+  if (failures.length > 0) {
+    console.log('\n\x1b[31mFailures:\x1b[0m');
+    for (const f of failures) {
+      console.log(`  - ${f.name}: ${f.error}`);
+    }
+  }
+
+  console.log('');
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+main().catch(err => {
+  console.error('Fatal error:', err);
+  process.exit(2);
+});

--- a/.claude/skills/clickup/watch.mjs
+++ b/.claude/skills/clickup/watch.mjs
@@ -1,0 +1,358 @@
+#!/usr/bin/env node
+
+/**
+ * watch.mjs — Polling-based watcher for ClickUp tasks (and lists)
+ *
+ * Snapshots a task's baseline (status, comment count / latest comment id,
+ * assignees, date_updated) then polls the ClickUp API on an interval. When a
+ * watched change is detected vs the baseline it prints a concise JSON summary
+ * of what changed and EXITS 0 — so a parent agent running this with
+ * run_in_background=true gets woken by the task-notification. On timeout it
+ * also exits 0 with a "timeout" summary.
+ *
+ * Unlike watch-task/listen.mjs (webhook.site + whcli relay), this watcher is
+ * fully self-contained: it needs nothing beyond a working ClickUp API token,
+ * so it runs anywhere the rest of the skill runs.
+ *
+ * Usage:
+ *   node watch.mjs <taskId|taskUrl>
+ *   node watch.mjs --list <listId|listUrl>
+ *
+ * Flags:
+ *   --timeout <sec>            Max seconds to watch before giving up (default 3600)
+ *   --interval <sec>           Poll cadence in seconds (default 45; min 10)
+ *   --on <types>              Comma list of change types that wake the watcher:
+ *                              status,comments,assignee  (default: all three)
+ *   --until-status <statuses>  Only wake when the task reaches one of these
+ *                              statuses (comma list). Implies --on status.
+ *   --account <name>           Use a specific named account from accounts.json
+ *   --json                     (default output is already JSON)
+ *   --state-file <path>        Optional: write latest change/snapshot JSON here
+ *
+ * Exit codes:
+ *   0  — a watched change fired, OR the watch timed out (both print JSON)
+ *   1  — fatal setup/config error (bad task id, no auth, etc.)
+ */
+
+import { writeFileSync } from 'fs';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+
+import { initClient } from './api/client.mjs';
+import { getTask, getTasksInList } from './api/tasks.mjs';
+import { getComments } from './api/comments.mjs';
+import { parseTaskId, parseListId } from './lib/parse.mjs';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+// ---------------------------------------------------------------------------
+// Args
+// ---------------------------------------------------------------------------
+
+const argv = process.argv.slice(2);
+function flag(name) {
+  const i = argv.indexOf(`--${name}`);
+  if (i === -1) return undefined;
+  return argv[i + 1];
+}
+function has(name) {
+  return argv.includes(`--${name}`);
+}
+
+function fatal(msg) {
+  console.error(`ERROR: ${msg}`);
+  process.exit(1);
+}
+
+// First positional (not a flag, not a flag value) is the task id/url.
+const positional = [];
+for (let i = 0; i < argv.length; i++) {
+  const a = argv[i];
+  if (a.startsWith('--')) {
+    // Boolean flags take no value; value flags consume the next token.
+    if (!['json'].includes(a.slice(2))) i++;
+    continue;
+  }
+  positional.push(a);
+}
+
+const listInput = flag('list');
+const taskInput = positional[0];
+
+if (!listInput && !taskInput) {
+  fatal(
+    'Provide a task id/url, or --list <listId>.\n' +
+      'Usage: node watch.mjs <taskId> [--timeout 3600] [--interval 45] ' +
+      '[--on status,comments,assignee] [--until-status "in progress,complete"]'
+  );
+}
+
+const timeoutSec = Math.max(parseInt(flag('timeout') || '3600', 10), 5);
+const intervalSec = Math.max(parseInt(flag('interval') || '45', 10), 10);
+const account = flag('account');
+const stateFile = flag('state-file');
+
+const untilStatusRaw = flag('until-status');
+const untilStatuses = untilStatusRaw
+  ? untilStatusRaw.split(',').map((s) => s.trim().toLowerCase()).filter(Boolean)
+  : null;
+
+let onTypes;
+const onRaw = flag('on');
+if (onRaw) {
+  onTypes = new Set(onRaw.split(',').map((s) => s.trim().toLowerCase()).filter(Boolean));
+} else {
+  onTypes = new Set(['status', 'comments', 'assignee']);
+}
+// --until-status is a status-based wake condition; make sure status is watched.
+if (untilStatuses) onTypes.add('status');
+
+// ---------------------------------------------------------------------------
+// Init
+// ---------------------------------------------------------------------------
+
+try {
+  initClient(account);
+} catch (err) {
+  fatal(err.message);
+}
+
+const mode = listInput ? 'list' : 'task';
+let targetId;
+if (mode === 'list') {
+  targetId = parseListId(listInput) || listInput;
+} else {
+  targetId = parseTaskId(taskInput);
+}
+if (!targetId) fatal(`Could not parse ${mode} id from input.`);
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+function writeState(obj) {
+  if (!stateFile) return;
+  try {
+    const p = resolve(stateFile);
+    writeFileSync(p, JSON.stringify(obj, null, 2) + '\n');
+  } catch {
+    /* best-effort */
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Snapshotting
+// ---------------------------------------------------------------------------
+
+// Reduce a raw task to the fields we compare across polls.
+function snapshotTask(task, comments) {
+  const assignees = (task.assignees || [])
+    .map((a) => a.id)
+    .sort((x, y) => String(x).localeCompare(String(y)));
+  const latest = comments && comments.length ? comments[comments.length - 1] : null;
+  return {
+    id: task.id,
+    name: task.name,
+    status: task.status?.status ?? null,
+    statusType: task.status?.type ?? null,
+    dateUpdated: task.date_updated ?? null,
+    assignees,
+    assigneeNames: (task.assignees || []).map((a) => a.username || a.email || String(a.id)),
+    commentCount: comments ? comments.length : null,
+    latestCommentId: latest ? latest.id : null,
+  };
+}
+
+async function snapshotTaskById(id) {
+  const task = await getTask(id);
+  let comments = null;
+  if (onTypes.has('comments')) {
+    try {
+      comments = await getComments(id);
+    } catch {
+      comments = null; // don't let a comment fetch failure abort snapshotting
+    }
+  }
+  return snapshotTask(task, comments);
+}
+
+// Compare two task snapshots and return array of change descriptors.
+function diffTask(prev, cur) {
+  const changes = [];
+
+  if (onTypes.has('status') && prev.status !== cur.status) {
+    changes.push({ type: 'status', from: prev.status, to: cur.status });
+  }
+
+  if (onTypes.has('assignee')) {
+    const a = new Set(prev.assignees.map(String));
+    const b = new Set(cur.assignees.map(String));
+    const added = [...b].filter((x) => !a.has(x));
+    const removed = [...a].filter((x) => !b.has(x));
+    if (added.length || removed.length) {
+      changes.push({
+        type: 'assignee',
+        added,
+        removed,
+        current: cur.assigneeNames,
+      });
+    }
+  }
+
+  if (onTypes.has('comments')) {
+    if (
+      prev.latestCommentId !== cur.latestCommentId ||
+      (prev.commentCount != null && cur.commentCount != null && cur.commentCount > prev.commentCount)
+    ) {
+      changes.push({
+        type: 'comments',
+        newCount: cur.commentCount,
+        prevCount: prev.commentCount,
+        latestCommentId: cur.latestCommentId,
+      });
+    }
+  }
+
+  return changes;
+}
+
+// A change only satisfies --until-status when the new status matches.
+function passesUntilStatus(changes, cur) {
+  if (!untilStatuses) return true;
+  const s = (cur.status || '').toLowerCase();
+  return untilStatuses.includes(s);
+}
+
+// ---------------------------------------------------------------------------
+// List-mode snapshot (map of taskId -> per-task snapshot)
+// ---------------------------------------------------------------------------
+
+async function snapshotList(id) {
+  const tasks = await getTasksInList(id);
+  const map = {};
+  for (const t of tasks) {
+    // In list mode we skip per-task comment fetches to stay gentle on the API;
+    // status + assignee + date_updated are compared. New/removed tasks tracked too.
+    map[t.id] = snapshotTask(t, null);
+  }
+  return map;
+}
+
+function diffList(prev, cur) {
+  const changes = [];
+  const prevIds = new Set(Object.keys(prev));
+  const curIds = new Set(Object.keys(cur));
+
+  for (const id of curIds) {
+    if (!prevIds.has(id)) {
+      changes.push({ type: 'taskCreated', taskId: id, name: cur[id].name, status: cur[id].status });
+      continue;
+    }
+    const sub = diffTask(prev[id], cur[id]);
+    for (const c of sub) {
+      changes.push({ ...c, taskId: id, name: cur[id].name });
+    }
+    if (onTypes.has('status') && prev[id].dateUpdated !== cur[id].dateUpdated && prev[id].status === cur[id].status) {
+      // date_updated moved without a status/assignee change we track; note as generic update
+      // (kept lightweight — only surfaced if nothing else fired for this task)
+    }
+  }
+  for (const id of prevIds) {
+    if (!curIds.has(id)) {
+      changes.push({ type: 'taskDeleted', taskId: id, name: prev[id].name });
+    }
+  }
+  return changes;
+}
+
+// ---------------------------------------------------------------------------
+// Main watch loop
+// ---------------------------------------------------------------------------
+
+async function main() {
+  const startedAt = Date.now();
+  const deadline = startedAt + timeoutSec * 1000;
+
+  let baseline;
+  try {
+    baseline = mode === 'list' ? await snapshotList(targetId) : await snapshotTaskById(targetId);
+  } catch (err) {
+    fatal(`Failed to snapshot ${mode} ${targetId}: ${err.message}`);
+  }
+
+  const baseInfo = {
+    mode,
+    targetId,
+    interval: intervalSec,
+    timeout: timeoutSec,
+    on: [...onTypes],
+    untilStatus: untilStatuses,
+    baseline: mode === 'task' ? baseline : { taskCount: Object.keys(baseline).length },
+    startedAt: new Date(startedAt).toISOString(),
+  };
+  writeState({ event: 'baseline', ...baseInfo });
+
+  let prev = baseline;
+  let consecutiveErrors = 0;
+
+  while (Date.now() < deadline) {
+    // Sleep first — the baseline was just taken, so poll after one interval.
+    const remaining = deadline - Date.now();
+    await sleep(Math.min(intervalSec * 1000, Math.max(remaining, 0)));
+    if (Date.now() >= deadline) break;
+
+    let cur;
+    try {
+      cur = mode === 'list' ? await snapshotList(targetId) : await snapshotTaskById(targetId);
+      consecutiveErrors = 0;
+    } catch (err) {
+      // Graceful backoff on API/network/rate-limit errors; never crash the loop.
+      consecutiveErrors++;
+      const backoff = Math.min(60, intervalSec * Math.pow(2, consecutiveErrors));
+      console.error(`poll error (${consecutiveErrors}): ${err.message} — backing off ${backoff}s`);
+      await sleep(backoff * 1000);
+      continue;
+    }
+
+    const changes = mode === 'list' ? diffList(prev, cur) : diffTask(prev, cur);
+
+    if (changes.length) {
+      const curSnap = mode === 'task' ? cur : { taskCount: Object.keys(cur).length };
+      if (mode === 'task' && !passesUntilStatus(changes, cur)) {
+        // A change happened but the until-status gate isn't satisfied yet;
+        // advance the baseline so we don't re-report the same change, keep waiting.
+        prev = cur;
+        continue;
+      }
+      const result = {
+        event: 'change',
+        mode,
+        targetId,
+        name: mode === 'task' ? cur.name : undefined,
+        changes,
+        snapshot: curSnap,
+        elapsedSec: Math.round((Date.now() - startedAt) / 1000),
+        url: mode === 'task' ? `https://app.clickup.com/t/${targetId}` : undefined,
+      };
+      writeState(result);
+      console.log(JSON.stringify(result));
+      process.exit(0);
+    }
+
+    prev = cur;
+  }
+
+  const result = {
+    event: 'timeout',
+    mode,
+    targetId,
+    timeout: timeoutSec,
+    elapsedSec: Math.round((Date.now() - startedAt) / 1000),
+    message: 'No watched change detected within timeout.',
+  };
+  writeState(result);
+  console.log(JSON.stringify(result));
+  process.exit(0);
+}
+
+main().catch((err) => {
+  fatal(`Unexpected error: ${err.message}`);
+});


### PR DESCRIPTION
## Why

`lib/markdown.mjs` has imported `unified` and `remark-parse` since `8486242b55`, but the skill ships no `package.json`. `query.mjs` reaches that import at startup through `lib/format.mjs`, so from a clean checkout **every** command fails — not just the comment ones:

```
$ git archive HEAD .claude/skills/clickup | tar -x -C /tmp/clean
$ cd /tmp/clean/.claude/skills/clickup && node query.mjs get 86a1b2c3d
Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'unified'
    imported from .../lib/markdown.mjs
```

Anyone using it successfully had `node_modules` in that directory from somewhere outside the repo.

This PR fixes that and brings the skill up to the version that's been maintained out-of-tree.

## Scope

Public ClickUp API only. The inbox and doc-comment commands are deliberately **not** included — they authenticate with a browser session token against undocumented endpoints, which isn't something to publish. They stay in individual local copies.

## What changed

**Dependency fix**
- Add `package.json` + `package-lock.json` (`unified`, `remark-parse`)
- `npm install` documented as a one-time setup step at the top of SKILL.md
- `node_modules` gitignored, not committed

**`create --file` silently dropped its input**
`create` only read `descriptionArg`, so `--file`/`--content` landed in `contentArg` and were discarded — while still exiting 0 and printing "Task created". Long descriptions vanished with no error. Now falls back to `contentArg`.

**Ported from the out-of-tree version** (21 commands → ~50)
`docs` / pages, `attach` + `fetch-image`, `find-list`, `claim`, `batch-create`, `@mentions` (explicit + bare auto-detect), multi-account credentials via `accounts.json`, `archive`/`unarchive`, dependencies/links, auto-pagination, rate-limit retry, and both watchers (`listen.mjs` webhook-based, `watch.mjs` polling/dependency-free).

**SKILL.md split** — was 1,395 lines loaded on every invocation. Core (setup, commands, examples, URL formats, tips) stays in `SKILL.md`; the rarely-needed half moves to `reference.md`: output samples, technical notes, testing, watchers, batch-create, team workflow patterns.

**`.gitignore` widened** — covered `.env` only. Now also `accounts.json`, `watchers.json` and `webhook-url.txt` (both hold live webhook relay secrets), `.cache/`, watcher state files, and the `nul` artifact Windows leaves from a stray `2>nul` redirect.

## Setup for reviewers

```bash
cd .claude/skills/clickup && npm install
cp accounts.json.example accounts.json   # add your pk_ token
```

Existing `.env` files keep working — they're auto-migrated to `accounts.json` on first run.

## Verification

- Reproduced the pre-fix failure on a plain `get` from a clean `git archive` extract with no `node_modules`
- Every `import` across all `.mjs` files audited: Node builtins, existing relative paths, or one of the two declared dependencies. No dynamic `import()` or `require()`, so no hidden runtime dependency
- `npm ci` resolves clean; `package-lock.json` consistent with `package.json`
- Re-extracted the final tree to a clean dir, `npm install`, and confirmed `node query.mjs` reaches "No accounts configured" — the correct next failure
- Live API: `get`, `find-list`, `docs`, and a comment with `**bold**` / `` `code` `` / a markdown link posted, rendered back, deleted
- `create --file` description persisted, verified by reading the task back
- SKILL.md → reference.md split checked heading-by-heading for content loss and dangling cross-references; none
- No `.env`, `accounts.json`, `watchers.json`, `nul`, or `node_modules` staged. The old `.env-example` had a real default list ID baked in; this PR drops it

## Known gaps, not addressed here

- `clickUpToMarkdown` is lossy on nested and ordered list round-trips (indentation flattens, ordinals drift). Pre-existing; affects rendering fetched comments back to markdown, not posting
- `--help` requires configured credentials before it will print usage, so commands aren't discoverable until you've set up a token

🤖 Generated with [Claude Code](https://claude.com/claude-code)
