### PR TITLE
fix(generation): scope the #3520 wire contract to txt2img and make the surface guard call-site-scoped

### DIFF
--- a/src/server/routers/__tests__/blocks.router.workflow.test.ts
+++ b/src/server/routers/__tests__/blocks.router.workflow.test.ts
@@ -7029,4 +7029,157 @@ describe('blocks — #3520 model substitution observability', () => {
       expect(result.snapshot.modelSubstitutions).toEqual([SUBSTITUTION]);
     });
   });
+
+  // ───────────────────────────────────────────────────────────────────────────
+  // 🔴 THE `kind:'step'` PATH — the record is ABSENT on the WRITE half, and the
+  // absence is MEANINGFUL because the READ half is proven not blind.
+  //
+  // The step-type registry bridge (`kind:'step'`, #3538) landed alongside this
+  // feature and neither PR's suite covers the interaction. `submitStepWorkflow`
+  // resolves no checkpoint through the generation graph, so it never builds a
+  // generation context, calls `snapshotFromWorkflow(submitted)` with NO `extra`,
+  // and writes no `modelSubstitutions` key into the submitted `body.metadata`.
+  // That is correct today — a registry step carries no model binding, so nothing
+  // can be substituted — and it is what the wire contract in
+  // `workflow.schema.ts` now says, scoped to `kind:'textToImage'`.
+  //
+  // 🔴 WHY THE NEGATIVE CONTROL IS THE POINT. "The field is absent" passes just
+  // as happily if the READ path were structurally blind to a registered step's
+  // workflow — the exact opposite of what needs pinning, and the state a future
+  // step that DID substitute would be shipped into. The planted-metadata test
+  // below proves `snapshotFromWorkflow` recovers the record from a workflow
+  // whose only step is a registered `$type`, so the absence on a real submit is
+  // a statement about the WRITE half alone. If someone teaches a step to resolve
+  // a checkpoint, the read half is already there; the write half is what they
+  // have to add, and these two tests together say exactly that.
+  // ───────────────────────────────────────────────────────────────────────────
+  describe("🔴 kind:'step' — absent on the WRITE half, readable on the READ half", () => {
+    // Registry steps are PAGE-only in v1 (`assertStepRequestAllowed`).
+    const stepClaims = () =>
+      validClaims({ ctx: { entityType: 'none', slotId: 'page' }, appBlockId: 'apb_test' });
+    const stepBody = () => ({
+      kind: 'step' as const,
+      step: 'convert-image',
+      params: {
+        image: 'https://image.civitai.com/source.png',
+        output: { format: 'webp', quality: 90 },
+      },
+    });
+    /** A completed `convertImage` step — SINGULAR `blob`, per the registry entry. */
+    const convertImageStep = (url: string) => ({
+      $type: 'convertImage',
+      name: 'block-step',
+      status: 'succeeded',
+      output: { blob: { id: 'b1', url, available: true, width: 797, height: 1024 } },
+    });
+    const textToImageStep = (url: string) => ({
+      $type: 'textToImage',
+      name: 's1',
+      status: 'succeeded',
+      metadata: {},
+      output: { images: [{ id: 'i1', url, available: true }] },
+    });
+    const isWhatIf = (c: unknown[]) =>
+      (c[0] as { query?: { whatif?: boolean } } | undefined)?.query?.whatif === true;
+
+    it('🔴 a step SUBMIT builds no generation context and plumbs no record', async () => {
+      mockVerifyBlockToken.mockResolvedValue(stepClaims());
+      happyUser();
+      // PLANTED: even with a context that would report a substitution, nothing
+      // may appear — so a green result here is about the step path not asking,
+      // not about "nothing happened to be substituted".
+      mockBuildGenerationContext.mockResolvedValue(ctxWithSubstitutions(SUBSTITUTION));
+      mockSubmitWorkflow.mockResolvedValue({
+        id: 'wf_step_1',
+        status: 'processing',
+        steps: [convertImageStep('https://cdn/out.webp')],
+        cost: { total: 1 },
+      });
+
+      const caller = blocksRouter.createCaller(fakeCtx() as never);
+      const result = await caller.submitWorkflow({ blockToken: 'tok', body: stepBody() });
+
+      // The structural reason the field is absent — no context is built at all.
+      expect(mockBuildGenerationContext).not.toHaveBeenCalled();
+      expect(result.snapshot.workflowId).toBe('wf_step_1');
+      expect('modelSubstitutions' in result.snapshot).toBe(false);
+      // …and nothing was persisted for a later poll to recover either. (`metadata`
+      // is asserted on the REAL submit, not the free whatIf quote.)
+      const realSubmit = mockSubmitWorkflow.mock.calls.filter((c) => !isWhatIf(c));
+      expect(realSubmit).toHaveLength(1);
+      expect(
+        (realSubmit[0][0] as { body: { metadata?: Record<string, unknown> } }).body.metadata
+      ).toBeUndefined();
+    });
+
+    it('the subsequent POLL of that step workflow carries no record either', async () => {
+      mockVerifyBlockToken.mockResolvedValue(stepClaims());
+      mockGetWorkflow.mockResolvedValue({
+        id: 'wf_step_1',
+        status: 'succeeded',
+        cost: { total: 1 },
+        metadata: {},
+        steps: [convertImageStep('https://cdn/out.webp')],
+      });
+      const caller = blocksRouter.createCaller(fakeCtx() as never);
+      const result = await caller.pollWorkflow({ blockToken: 'tok', workflowId: 'wf_step_1' });
+
+      // The step's own output IS surfaced — so this poll is a live one, not a
+      // snapshot the reader failed to parse.
+      expect(result.snapshot.imageUrls).toEqual(['https://cdn/out.webp']);
+      expect('modelSubstitutions' in result.snapshot).toBe(false);
+    });
+
+    it('🔴 NEGATIVE CONTROL — a step workflow WITH the key planted DOES surface it', async () => {
+      // Without this, the two assertions above are equally consistent with a
+      // reader that is blind on a registered `$type`.
+      mockVerifyBlockToken.mockResolvedValue(stepClaims());
+      mockGetWorkflow.mockResolvedValue({
+        id: 'wf_step_1',
+        status: 'succeeded',
+        cost: { total: 1 },
+        metadata: { modelSubstitutions: [SUBSTITUTION] },
+        steps: [convertImageStep('https://cdn/out.webp')],
+      });
+      const caller = blocksRouter.createCaller(fakeCtx() as never);
+      const result = await caller.pollWorkflow({ blockToken: 'tok', workflowId: 'wf_step_1' });
+
+      expect(result.snapshot.imageUrls).toEqual(['https://cdn/out.webp']);
+      expect(result.snapshot.modelSubstitutions).toEqual([SUBSTITUTION]);
+    });
+
+    // A MIXED workflow — one txt2img step (which CAN substitute) and one
+    // registered step (which cannot) — is the shape a future multi-step block
+    // produces, and is covered by neither #3535's nor #3538's suite. Both orders,
+    // because the registered-step branch and the native `$type` branch are
+    // different arms of the same loop in `snapshotFromWorkflow` and an early
+    // `continue` in either would drop the other's output.
+    it.each([
+      ['textToImage first', ['t2i', 'step']],
+      ['registered step first', ['step', 't2i']],
+    ] as const)(
+      'a MIXED workflow (%s) surfaces both outputs in steps order AND the record',
+      async (_label, order) => {
+        mockVerifyBlockToken.mockResolvedValue(stepClaims());
+        mockGetWorkflow.mockResolvedValue({
+          id: 'wf_mixed',
+          status: 'succeeded',
+          cost: { total: 26 },
+          metadata: { params: { prompt: 'a cat' }, modelSubstitutions: [SUBSTITUTION] },
+          steps: order.map((k) =>
+            k === 't2i'
+              ? textToImageStep('https://cdn/t2i.png')
+              : convertImageStep('https://cdn/conv.webp')
+          ),
+        });
+        const caller = blocksRouter.createCaller(fakeCtx() as never);
+        const result = await caller.pollWorkflow({ blockToken: 'tok', workflowId: 'wf_mixed' });
+
+        expect(result.snapshot.imageUrls).toEqual(
+          order.map((k) => (k === 't2i' ? 'https://cdn/t2i.png' : 'https://cdn/conv.webp'))
+        );
+        expect(result.snapshot.modelSubstitutions).toEqual([SUBSTITUTION]);
+      }
+    );
+  });
 });

--- a/src/server/schema/blocks/workflow.schema.ts
+++ b/src/server/schema/blocks/workflow.schema.ts
@@ -344,17 +344,44 @@ export type BlockWorkflowSnapshot = {
    * substituted, so every existing snapshot stays byte-identical and a consumer
    * that does not read it is unaffected.
    *
-   * WHERE IT APPEARS. On the submit reply, on the `estimateWorkflow` reply, on
-   * EVERY reply from `submitWorkflow` that quotes a cost without submitting
-   * (insufficient per-call budget, the per-user daily / review Buzz cap, the
-   * per-app aggregate spend+velocity cap, the dev-tunnel session cap), and —
-   * because the submit persists it on the orchestrator workflow's `metadata` —
-   * on every subsequent `pollWorkflow` / `cancelWorkflow` read. The poll is the one
-   * that matters in practice: it is the snapshot carrying `imageUrls`, i.e. the
-   * one a block actually renders from, so the record is present next to the
-   * images it describes rather than only on a reply the block may have discarded.
+   * WHERE IT APPEARS. 🔴 ON THE `kind: 'textToImage'` PATH ONLY. That is the
+   * only wire body whose handler resolves a checkpoint through the generation
+   * graph (`createBlockTextToImageStep` → `buildGenerationContext`), so it is
+   * the only one that can substitute anything. On that path: the submit reply,
+   * the `estimateWorkflow` reply, EVERY reply from `submitWorkflow` that quotes
+   * a cost without submitting (insufficient per-call budget, the per-user daily
+   * / review Buzz cap, the per-app aggregate spend+velocity cap, the dev-tunnel
+   * session cap), and — because the submit persists it on the orchestrator
+   * workflow's `metadata` — every subsequent `pollWorkflow` / `cancelWorkflow`
+   * read of that workflow. The poll is the one that matters in practice: it is
+   * the snapshot carrying `imageUrls`, i.e. the one a block actually renders
+   * from, so the record is present next to the images it describes rather than
+   * only on a reply the block may have discarded.
    * The estimate reply is the exception — a whatIf creates no persisted workflow,
    * so there the record exists only on that reply.
+   *
+   * 🔴 IT DOES **NOT** APPEAR ON `kind: 'customComfy'` OR `kind: 'step'`. Each of
+   * those has its own four cost-quoting exits, and none of the eight carries this
+   * field — correctly, because neither handler builds a generation context: a
+   * customComfy body binds a server-authored recipe and a registry step carries
+   * no model binding at all, so there is nothing to substitute and nothing to
+   * report.
+   *
+   * 🔴 IF YOU ARE EXTENDING A STEP TO RESOLVE A CHECKPOINT THROUGH THE GRAPH,
+   * READ THIS. The paragraph above is a statement about the txt2img handler's
+   * plumbing, NOT a property of the bridge — do not assume the field will flow
+   * on your path because it flows there. The READ half is kind-agnostic (the
+   * poll recovers the record from `workflow.metadata` for any workflow), but the
+   * WRITE half is per-handler: your handler must pass the request's collector to
+   * `snapshotFromWorkflow(..., { modelSubstitutions })` on the reply AND write
+   * `WORKFLOW_METADATA_MODEL_SUBSTITUTIONS_KEY` into the submitted
+   * `body.metadata`, or the substitution stays exactly as unobservable as it was
+   * before #3520 — on the one surface #3520 exists to make observable.
+   * `submitStepWorkflow` does neither today. Pinned by
+   * `generation-surface-wiring.test.ts` (every `buildGenerationContext` call site
+   * enumerated from the tree and pinned to its ENCLOSING FUNCTION, so a new one
+   * inside a step handler fails there) and by the `kind:'step'` absence tests +
+   * their planted-metadata control in `blocks.router.workflow.test.ts`.
    *
    * 🔴 WIRE CONTRACT: this is an ADDITIVE field on the type
    * `@civitai/app-sdk`'s `blocks/types.ts` mirrors. The SDK's inbound validator

--- a/src/server/services/orchestrator/__tests__/generation-surface-wiring.test.ts
+++ b/src/server/services/orchestrator/__tests__/generation-surface-wiring.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { readFileSync } from 'fs';
 import path from 'path';
 import { execFileSync } from 'child_process';
+import ts from 'typescript';
 
 import { GENERATION_SURFACES } from '~/shared/data-graph/generation/model-substitution';
 
@@ -28,7 +29,43 @@ import { GENERATION_SURFACES } from '~/shared/data-graph/generation/model-substi
  *
  * TypeScript already forces the argument to EXIST (it is required, not
  * defaulted). What it cannot check is that the value is the RIGHT one for that
- * file, which is what the expected-by-path table below pins.
+ * call site, which is what the expectation table below pins.
+ *
+ * ─────────────────────────────────────────────────────────────────────────────
+ * 🔴 WHY THE PIN IS PER-FUNCTION AND NOT PER-FILE.
+ *
+ * The first cut of this guard keyed the expectation on the FILE. But the
+ * property it is standing in for is a property of the CALL SITE, and the two
+ * came apart the moment `blocks.router.ts` grew a second generation-submitting
+ * handler (`submitStepWorkflow`, the `kind:'step'` bridge from #3538).
+ *
+ * Concretely, under a file-keyed table: a `buildGenerationContext(..., 'block')`
+ * added inside `submitStepWorkflow` PASSES — the file already claims `'block'` —
+ * and the counter's `surface="block"` incidence starts rising. But
+ * `submitStepWorkflow` calls `snapshotFromWorkflow(submitted)` with no `extra`
+ * and writes no `modelSubstitutions` key into the submitted `body.metadata`, so
+ * NO block can see which generation was substituted. The metric moves, the wire
+ * does not, and the gap #3520 exists to close is silently reopened — with a
+ * green guard.
+ *
+ * The honest property is therefore: A PATH THAT BUILDS A GENERATION CONTEXT (and
+ * can therefore record a substitution) MUST ALSO PLUMB THAT RECORD TO THE WIRE.
+ * That coupling cannot be checked by a grep, but its trigger can: pin the
+ * ENCLOSING FUNCTION of every call site, so that adding one inside a handler
+ * that does not plumb fails loudly and names the handler, and the author has to
+ * either wire it up or amend the table on purpose. A new row here is the
+ * reviewable act — the same design as before, moved to the granularity the
+ * property actually has.
+ *
+ * MECHANISM: the TypeScript AST, not a regex. Call sites are matched by
+ * IDENTIFIER (so `mockBuildGenerationContext(...)` is not a call to
+ * `buildGenerationContext`, which a substring needle cannot distinguish),
+ * arguments are counted by `node.arguments.length` (so a prettier reflow cannot
+ * change the answer), and comments and string literals are excluded by
+ * construction rather than by a hand-rolled stripper. Walking up `node.parent`
+ * for the nearest named function/method/`const fn = () =>`/object-property is
+ * what yields the enclosing name — including through a tRPC procedure builder,
+ * where the arrow passed to `.mutation(...)` resolves to its procedure key.
  */
 
 const REPO_ROOT = path.resolve(__dirname, '../../../../..');
@@ -36,52 +73,76 @@ const REPO_ROOT = path.resolve(__dirname, '../../../../..');
 /** The declaration itself — not a call site. */
 const DEFINITION_FILE = 'src/server/services/orchestrator/orchestration-new.service.ts';
 /**
- * This guard's own source. It mentions `buildGenerationContext(` inside STRING
- * literals (the grep needle), which `stripComments` deliberately does not touch,
- * so it has to be excluded by path or it enumerates itself as a call site.
+ * This guard's own source. It mentions `buildGenerationContext` only in comments
+ * and string literals, which the AST walk already ignores, but it is excluded by
+ * path as well so the enumeration can never depend on that.
  */
 const GUARD_FILE = 'src/server/services/orchestrator/__tests__/generation-surface-wiring.test.ts';
 
-/**
- * Every file allowed to build a generation context, and the surface it must
- * declare. Adding a generation entry point means adding a row here — a
- * deliberate, reviewable act, rather than a silent widening.
- */
-const EXPECTED_SURFACE_BY_FILE: Record<string, string> = {
-  // The on-site generator. #3520 calls this substitution CORRECT: the only way
-  // the form holds an out-of-list id is a stale localStorage value after an
-  // ecosystem switch, and the user visibly sees the picker snap back.
-  'src/server/routers/orchestrator.router.ts': 'onsite',
-  // The App Blocks bridge — the surface the issue is about. The id was written
-  // by an app author and the correction was unobservable.
-  'src/server/routers/blocks.router.ts': 'block',
-  // Comics / preset image generation: server-composed graph input.
-  'src/server/services/orchestrator/preset-image-gen.service.ts': 'preset',
-};
+/** `file::enclosingFunction` — the key the expectation table is written in. */
+type CallSiteKey = string;
 
-/**
- * Blank out comments so a doc-comment that MENTIONS `buildGenerationContext(...)`
- * is not mistaken for a call site. Whitespace-preserving, so offsets are stable.
- * Deliberately simple: it only has to be right about this repo's own source, and
- * it can only ever produce a FALSE ALARM (a real call hidden), never a false pass.
- */
-function stripComments(source: string): string {
-  return source
-    .replace(/\/\*[\s\S]*?\*\//g, (m) => m.replace(/[^\n]/g, ' '))
-    .replace(/(^|[^:'"`\\])\/\/[^\n]*/g, (m, lead) => lead + ' '.repeat(m.length - lead.length));
+interface CallSite {
+  /** Repo-relative path. */
+  file: string;
+  /** Nearest named enclosing function / method / procedure key. */
+  fn: string;
+  /** 1-based line of the call, for a failure message a human can act on. */
+  line: number;
+  /** Number of top-level arguments actually passed. */
+  arity: number;
+  /** Every `GENERATION_SURFACES` member passed as a bare string literal. */
+  surfaceLiterals: string[];
 }
 
 /**
- * Enumerate call sites from the TREE, not from a hand-kept list.
+ * Every PRODUCTION call site allowed to build a generation context, keyed by
+ * `file::enclosingFunction`, with the surface it must declare.
+ *
+ * 🔴 Adding a row means asserting that the enclosing function plumbs a recorded
+ * substitution onward in whatever way its surface requires — for `'block'`, onto
+ * the `BlockWorkflowSnapshot` wire (see
+ * `src/server/schema/blocks/workflow.schema.ts`'s `modelSubstitutions` contract).
+ * A row added without that is the failure described above, just made official.
+ */
+const EXPECTED_SURFACE_BY_CALL_SITE: Record<CallSiteKey, string> = {
+  // The on-site generator. #3520 calls this substitution CORRECT: the only way
+  // the form holds an out-of-list id is a stale localStorage value after an
+  // ecosystem switch, and the user visibly sees the picker snap back.
+  'src/server/routers/orchestrator.router.ts::generateFromGraph': 'onsite',
+  'src/server/routers/orchestrator.router.ts::whatIfFromGraph': 'onsite',
+  // The App Blocks bridge — the surface the issue is about. The id was written
+  // by an app author and the correction was unobservable. This ONE function is
+  // also the only place the block wire contract's `modelSubstitutions` field
+  // originates: it returns the collected records to the router, which persists
+  // them on `body.metadata` and passes them to `snapshotFromWorkflow`.
+  //
+  // 🔴 `submitStepWorkflow` / the `customComfy` handlers are DELIBERATELY ABSENT.
+  // They live in this same file and quote costs on four exits each, and neither
+  // builds a context nor plumbs the record. Adding a call site there without the
+  // plumbing must fail — that is the whole reason this table is keyed on the
+  // function and not on the file.
+  'src/server/routers/blocks.router.ts::createBlockTextToImageStep': 'block',
+  // Comics / preset image generation: server-composed graph input.
+  'src/server/services/orchestrator/preset-image-gen.service.ts::submitPresetImageGen': 'preset',
+  'src/server/services/orchestrator/preset-image-gen.service.ts::whatIfPresetImageGen': 'preset',
+};
+
+/**
+ * Candidate files, enumerated from the TREE rather than from a hand-kept list.
+ *
+ * The grep needle is the BARE identifier (no trailing paren): it only has to
+ * over-approximate, because the AST walk below decides what is really a call.
+ * That removes every formatting dependency from the enumeration.
  *
  * `includeTests: false` is the PRODUCTION population (what the surface table
- * below pins). `includeTests: true` adds the test tree, which `tsconfig.json`
- * EXCLUDES (`src/**\/__tests__/**`) — see the arity guard for why that matters.
+ * pins). `includeTests: true` adds the test tree, which `tsconfig.json` EXCLUDES
+ * (`src/**\/__tests__/**`) — see the arity guard for why that matters.
  */
-function findCallSiteFiles({ includeTests }: { includeTests: boolean }): string[] {
+function candidateFiles({ includeTests }: { includeTests: boolean }): string[] {
   const out = execFileSync(
     'grep',
-    ['-rl', '--include=*.ts', '--include=*.tsx', 'buildGenerationContext(', 'src'],
+    ['-rl', '--include=*.ts', '--include=*.tsx', 'buildGenerationContext', 'src'],
     { cwd: REPO_ROOT, encoding: 'utf8' }
   );
   return out
@@ -89,111 +150,140 @@ function findCallSiteFiles({ includeTests }: { includeTests: boolean }): string[
     .map((l) => l.trim())
     .filter(Boolean)
     .filter((f) => f !== DEFINITION_FILE && f !== GUARD_FILE)
-    .filter((f) => includeTests || !(f.includes('__tests__') || f.endsWith('.test.ts')))
-    .filter(
-      (f) =>
-        argumentListsOf(
-          stripComments(readFileSync(path.join(REPO_ROOT, f), 'utf8')),
-          'buildGenerationContext('
-        ).length > 0
-    );
+    .filter((f) => includeTests || !(f.includes('__tests__') || f.endsWith('.test.ts')));
 }
 
 /**
- * Split a call's argument text into its TOP-LEVEL arguments, ignoring commas
- * nested inside parens / brackets / braces / string literals — so `f('a', {},
- * {}, 'onsite')` counts 4, not 6.
+ * The nearest NAMED enclosing scope of `node`, walking up the parent chain.
+ *
+ * Handles the four shapes this repo actually uses:
+ *   - `async function createBlockTextToImageStep(...)`   → FunctionDeclaration
+ *   - `const submitPresetImageGen = async () => {}`      → VariableDeclaration
+ *   - `{ method() {} }`                                  → MethodDeclaration
+ *   - `generateFromGraph: proc.mutation(async () => {})` → PropertyAssignment
+ *
+ * The last one is why an anonymous function-like node does not terminate the
+ * walk: the arrow handed to `.mutation(...)` has a CallExpression for a parent,
+ * and the procedure key sits several nodes further up. A name is only accepted
+ * from a variable/property once a function boundary has been crossed, so a call
+ * sitting directly in an object literal is not mislabelled as "inside" it.
  */
-function topLevelArgs(argText: string): string[] {
-  if (argText.trim() === '') return [];
-  const args: string[] = [];
-  let depth = 0;
-  let quote: string | null = null;
-  let current = '';
-  for (let i = 0; i < argText.length; i++) {
-    const c = argText[i];
-    if (quote) {
-      if (c === '\\') {
-        current += c + (argText[i + 1] ?? '');
-        i += 1;
-        continue;
+function enclosingFunctionName(node: ts.Node): string {
+  let sawFunctionBoundary = false;
+  let cur: ts.Node | undefined = node.parent;
+  while (cur) {
+    if (ts.isFunctionDeclaration(cur)) {
+      if (cur.name) return cur.name.text;
+      sawFunctionBoundary = true;
+    } else if (ts.isMethodDeclaration(cur) && ts.isIdentifier(cur.name)) {
+      return cur.name.text;
+    } else if (ts.isFunctionExpression(cur)) {
+      if (cur.name) return cur.name.text;
+      sawFunctionBoundary = true;
+    } else if (ts.isArrowFunction(cur)) {
+      sawFunctionBoundary = true;
+    } else if (sawFunctionBoundary && ts.isVariableDeclaration(cur) && ts.isIdentifier(cur.name)) {
+      return cur.name.text;
+    } else if (sawFunctionBoundary && ts.isPropertyAssignment(cur) && ts.isIdentifier(cur.name)) {
+      return cur.name.text;
+    }
+    cur = cur.parent;
+  }
+  return '<module scope>';
+}
+
+/** Every real `buildGenerationContext(...)` call in `file`, with its context. */
+function callSitesIn(file: string): CallSite[] {
+  const text = readFileSync(path.join(REPO_ROOT, file), 'utf8');
+  const source = ts.createSourceFile(
+    file,
+    text,
+    ts.ScriptTarget.Latest,
+    /* setParentNodes */ true,
+    file.endsWith('.tsx') ? ts.ScriptKind.TSX : ts.ScriptKind.TS
+  );
+  const found: CallSite[] = [];
+  const visit = (node: ts.Node): void => {
+    if (ts.isCallExpression(node)) {
+      const callee = node.expression;
+      // Identifier equality — NOT a substring match, so `mockBuildGenerationContext(...)`
+      // (a real pattern in this repo's test tree) is correctly not a call site.
+      const calleeName = ts.isIdentifier(callee)
+        ? callee.text
+        : ts.isPropertyAccessExpression(callee) && ts.isIdentifier(callee.name)
+        ? callee.name.text
+        : null;
+      if (calleeName === 'buildGenerationContext') {
+        found.push({
+          file,
+          fn: enclosingFunctionName(node),
+          line: source.getLineAndCharacterOfPosition(node.getStart(source)).line + 1,
+          arity: node.arguments.length,
+          surfaceLiterals: node.arguments
+            .filter((a): a is ts.StringLiteral => ts.isStringLiteral(a))
+            .map((a) => a.text)
+            .filter((v) => (GENERATION_SURFACES as readonly string[]).includes(v)),
+        });
       }
-      if (c === quote) quote = null;
-      current += c;
-      continue;
     }
-    if (c === "'" || c === '"' || c === '`') {
-      quote = c;
-      current += c;
-      continue;
-    }
-    if (c === '(' || c === '[' || c === '{') depth += 1;
-    else if (c === ')' || c === ']' || c === '}') depth -= 1;
-    if (c === ',' && depth === 0) {
-      args.push(current);
-      current = '';
-      continue;
-    }
-    current += c;
-  }
-  args.push(current);
-  return args.map((a) => a.trim()).filter(Boolean);
+    ts.forEachChild(node, visit);
+  };
+  visit(source);
+  return found;
 }
 
-/**
- * The argument list of every `<needle>` call in `source`, extracted by BALANCED
- * PARENTHESES rather than by a line pattern — a formatter reflow (prettier
- * collapsing a multi-line call, or the reverse) must not be able to make this
- * guard silently inspect the wrong text and pass.
- */
-function argumentListsOf(source: string, needle: string): string[] {
-  const out: string[] = [];
-  let from = 0;
-  for (;;) {
-    const at = source.indexOf(needle, from);
-    if (at === -1) break;
-    let depth = 1;
-    let i = at + needle.length;
-    for (; i < source.length && depth > 0; i++) {
-      if (source[i] === '(') depth += 1;
-      else if (source[i] === ')') depth -= 1;
-    }
-    out.push(source.slice(at + needle.length, i - 1));
-    from = i;
-  }
-  return out;
+function collectCallSites({ includeTests }: { includeTests: boolean }): CallSite[] {
+  return candidateFiles({ includeTests }).flatMap(callSitesIn);
 }
+
+const keyOf = (c: CallSite): CallSiteKey => `${c.file}::${c.fn}`;
 
 describe('generation-context surface wiring', () => {
-  const files = findCallSiteFiles({ includeTests: false });
+  const sites = collectCallSites({ includeTests: false });
 
   it('finds the call sites at all (guard the guard)', () => {
     // Without this, a broken enumeration would make every assertion below pass
     // vacuously over an empty list.
-    expect(files.length).toBeGreaterThanOrEqual(Object.keys(EXPECTED_SURFACE_BY_FILE).length);
+    expect(sites.length).toBeGreaterThanOrEqual(Object.keys(EXPECTED_SURFACE_BY_CALL_SITE).length);
+    // And no call site may resolve to an unnamed scope — that would collapse
+    // distinct handlers onto one key and re-create the file-scoped hole.
+    expect(sites.filter((c) => c.fn === '<module scope>')).toEqual([]);
   });
 
-  it('every file that builds a generation context is a KNOWN surface', () => {
-    const unexpected = files.filter((f) => !(f in EXPECTED_SURFACE_BY_FILE));
-    // A new generation entry point must declare which population it belongs to;
-    // inheriting a neighbour's surface silently contaminates the number that
-    // gates the phase-3 policy decision.
+  it('🔴 every FUNCTION that builds a generation context is a pinned call site', () => {
+    // The mutation this exists for: a `buildGenerationContext(..., "block")`
+    // added inside `submitStepWorkflow` (or any other handler in an
+    // already-listed file) that does NOT plumb the record onto the wire. A
+    // file-keyed table passes that; this one names the offending function.
+    const unexpected = sites
+      .filter((c) => !(keyOf(c) in EXPECTED_SURFACE_BY_CALL_SITE))
+      .map((c) => `${c.file}:${c.line} inside ${c.fn}()`);
     expect(unexpected).toEqual([]);
   });
 
-  it.each(Object.entries(EXPECTED_SURFACE_BY_FILE))(
-    '%s passes the surface %s at EVERY buildGenerationContext call',
-    (file, expectedSurface) => {
-      const source = stripComments(readFileSync(path.join(REPO_ROOT, file), 'utf8'));
-      const calls = argumentListsOf(source, 'buildGenerationContext(');
-      expect(calls.length).toBeGreaterThan(0);
-      for (const args of calls) {
-        const found = GENERATION_SURFACES.filter((s) => args.includes(`'${s}'`));
-        // Exactly one surface literal, and it is this file's.
-        expect(found).toEqual([expectedSurface]);
-      }
-    }
-  );
+  it('no pinned call site has disappeared (the table describes the live tree)', () => {
+    // The other direction: a stale row would silently stop guarding anything,
+    // and would also keep the surface-coverage assertion below green off a
+    // function that no longer exists.
+    const live = new Set(sites.map(keyOf));
+    const missing = Object.keys(EXPECTED_SURFACE_BY_CALL_SITE).filter((k) => !live.has(k));
+    expect(missing).toEqual([]);
+  });
+
+  it('🔴 every call site passes the surface its pinned function must declare', () => {
+    const wrong = sites
+      .filter((c) => keyOf(c) in EXPECTED_SURFACE_BY_CALL_SITE)
+      .filter((c) => {
+        const expected = EXPECTED_SURFACE_BY_CALL_SITE[keyOf(c)];
+        return c.surfaceLiterals.length !== 1 || c.surfaceLiterals[0] !== expected;
+      })
+      .map(
+        (c) =>
+          `${c.file}:${c.line} inside ${c.fn}() passes [${c.surfaceLiterals.join(', ')}], ` +
+          `expected exactly ['${EXPECTED_SURFACE_BY_CALL_SITE[keyOf(c)]}']`
+      );
+    expect(wrong).toEqual([]);
+  });
 
   /**
    * 🔴 THE TEST-CODE HOLE. "Required, not defaulted, so a new entry point is a
@@ -204,31 +294,23 @@ describe('generation-context surface wiring', () => {
    * test, but a test HELPER that wraps `buildGenerationContext` would propagate
    * unlabelled collectors with nothing catching it.
    *
-   * Deliberately an ARITY check, NOT a surface-value check. Pinning WHICH
-   * surface a test must pass would false-alarm on legitimate fixtures — a
-   * table-driven test sweeping `GENERATION_SURFACES`, or one passing the value
-   * through a variable, are both perfectly valid and neither carries a literal
-   * this file could predict. Arity is exactly the guarantee `tsc` gives the
-   * production tree, extended to the part of the tree `tsc` never reads, and it
-   * constrains nothing else.
+   * Deliberately an ARITY check, NOT a surface-value or enclosing-function
+   * check. Pinning either of those for a test would false-alarm on legitimate
+   * fixtures — a table-driven test sweeping `GENERATION_SURFACES`, one passing
+   * the value through a variable, and a call sitting directly in an `it(...)`
+   * body (no named enclosing function at all) are all perfectly valid. Arity is
+   * exactly the guarantee `tsc` gives the production tree, extended to the part
+   * of the tree `tsc` never reads, and it constrains nothing else.
    */
   it('🔴 EVERY call site — test code included — passes the 4th `surface` argument', () => {
-    const allFiles = findCallSiteFiles({ includeTests: true });
-    const offenders: string[] = [];
-    let totalCalls = 0;
-
-    for (const file of allFiles) {
-      const source = stripComments(readFileSync(path.join(REPO_ROOT, file), 'utf8'));
-      for (const args of argumentListsOf(source, 'buildGenerationContext(')) {
-        totalCalls += 1;
-        const arity = topLevelArgs(args).length;
-        if (arity !== 4) offenders.push(`${file}: ${arity} args`);
-      }
-    }
+    const allSites = collectCallSites({ includeTests: true });
+    const offenders = allSites
+      .filter((c) => c.arity !== 4)
+      .map((c) => `${c.file}:${c.line}: ${c.arity} args`);
 
     // Guard the guard: a broken enumeration must not pass vacuously.
-    expect(allFiles.length).toBeGreaterThanOrEqual(Object.keys(EXPECTED_SURFACE_BY_FILE).length);
-    expect(totalCalls).toBeGreaterThanOrEqual(allFiles.length);
+    expect(allSites.length).toBeGreaterThanOrEqual(sites.length);
+    expect(sites.length).toBeGreaterThan(0);
     expect(offenders).toEqual([]);
   });
 
@@ -236,7 +318,7 @@ describe('generation-context surface wiring', () => {
     // A surface value with no call site would be a series that can never be
     // emitted — an alert keyed on it would then be structurally silent, which is
     // the exact failure class this counter exists to avoid.
-    expect([...new Set(Object.values(EXPECTED_SURFACE_BY_FILE))].sort()).toEqual(
+    expect([...new Set(Object.values(EXPECTED_SURFACE_BY_CALL_SITE))].sort()).toEqual(
       [...GENERATION_SURFACES].sort()
     );
   });


### PR DESCRIPTION
Follow-ups to the adversarial audit of #3535 (#3520 phase 1), rebased on `main` after #3538 landed the `kind:'step'` registry. **No behaviour change** — one doc comment, one test guard, three tests. No production logic touched.

---

## FIX 1 — the wire-contract comment was over-broad

`src/server/schema/blocks/workflow.schema.ts` said `modelSubstitutions` appears on *"EVERY reply from `submitWorkflow` that quotes a cost without submitting"*. Verified against current `main` — the audit's line numbers are still exact:

| path | cost-quoting exits (`cost: { total: … }`, no workflow) | carries `modelSubstitutions` |
|---|---|---|
| `textToImage` | `blocks.router.ts:4119, 4210, 4266, 4337` | yes |
| `customComfy` | `:6072, 6129, 6157, 6215` | no |
| `step` (#3538) | `:6775, 6829, 6862, 6901` (+ `:6752`, the no-quote exit) | no |

So 4 of 13 carry it. The claim is scoped to `kind: 'textToImage'`, and a paragraph is added for the reader the audit named — someone extending a registered step to resolve a checkpoint through the graph. It states that the READ half is kind-agnostic (the poll recovers the record from `workflow.metadata` for any workflow) while the WRITE half is per-handler, and that `submitStepWorkflow` does neither today.

## FIX 2 — the surface guard was FILE-scoped where the property is CALL-SITE-scoped

`EXPECTED_SURFACE_BY_FILE` keyed on the file, and `blocks.router.ts` already claims `'block'`. A `buildGenerationContext(..., 'block')` added inside `submitStepWorkflow` — same file — passed, so `surface="block"` incidence would rise while `submitStepWorkflow`'s `snapshotFromWorkflow(submitted)` (no `extra`, no metadata key) leaves every block unable to see which generation was substituted.

**Mechanism: pin `file::enclosingFunction`, derived from the TypeScript AST.** Why the AST rather than the previous regex:

- **Identifier equality, not a substring needle.** `buildGenerationContext(` is a substring of nothing today, but the repo already contains `mockBuildGenerationContext(...)`; only capitalisation kept the old guard honest.
- **Arity from `node.arguments.length`** — no hand-rolled paren/quote balancer, so no formatting dependency.
- **Comments and string literals are excluded by construction** — `stripComments` and the guard's own `GUARD_FILE` self-exclusion become belt-and-braces rather than load-bearing.
- **Enclosing name by parent-walk**, handling all four shapes in the tree, including a tRPC arrow passed to `.mutation(...)` resolving to its procedure key (`generateFromGraph`).

Deliberately **not** made stricter: the `__tests__`-tree check stays an **arity** check (that tree is excluded from `tsconfig.json`, so `tsc` never sees it). A table-driven sweep over `GENERATION_SURFACES`, a surface passed through a variable, and a call with no named enclosing function all stay green — probed explicitly.

## FIX 3 — the disclosed-missing cross-PR test

Neither PR's suite covered the `kind:'step'` × `modelSubstitutions` interaction. Added, in `blocks.router.workflow.test.ts`:

- a step **submit** builds no generation context (`buildGenerationContext` not called even with a substitution-bearing context planted) and its reply + submitted `body.metadata` carry nothing;
- the subsequent **poll** carries nothing either;
- 🔴 **the negative control** — the same step workflow with the key planted in `workflow.metadata` **does** surface the field, next to the step's extracted `imageUrls`. Without it the two assertions above pass equally well against a structurally blind reader;
- a **mixed** `textToImage` + registered-step workflow, both orders: both outputs appear in `workflow.steps` order and the record still surfaces.

---

## Mutation table

Every mutation was applied to the tree, run, and reverted. "Own assertion" = the message the intended guard itself printed.

| # | Mutation | Test that failed | Exact assertion text |
|---|---|---|---|
| **M1** 🔴 | `await buildGenerationContext('free', undefined, {…}, 'block')` added inside `submitStepWorkflow` | `🔴 every FUNCTION that builds a generation context is a pinned call site` | `AssertionError: expected [ Array(1) ] to deeply equal []` → received `[ "src/server/routers/blocks.router.ts:6607 inside submitStepWorkflow()" ]` |
| **M1** (control) | same mutation, **old file-scoped guard** from `origin/main` | *none* — **7/7 passed** | — |
| **M1** (behavioural) | same mutation, FIX 3 test | `🔴 a step SUBMIT builds no generation context and plumbs no record` | `AssertionError: expected "vi.fn()" to not be called at all, but actually been called 1 times` |
| **M2** | `'block'` → `'onsite'` at `blocks.router.ts:993` | `🔴 every call site passes the surface its pinned function must declare` | `expected [ Array(1) ] to deeply equal []` → `[ "src/server/routers/blocks.router.ts:993 inside createBlockTextToImageStep() passes [onsite], expected exactly ['block']" ]` |
| **M3** | 4th arg dropped from a **test-tree** call (`orchestration-new.getGenerationStatus.sysredis-soft.test.ts:82`) | `🔴 EVERY call site — test code included — passes the 4th surface argument` | `expected [ Array(1) ] to deeply equal []` → `[ "…sysredis-soft.test.ts:82: 3 args" ]` |
| **M4** | `createBlockTextToImageStep` renamed to `createBlockTxt2ImgStep` (7 sites) | `no pinned call site has disappeared` (+ the population guard) | `expected [ Array(1) ] to deeply equal []` → `[ "src/server/routers/blocks.router.ts::createBlockTextToImageStep" ]` |
| **M5** 🔴 | `readModelSubstitutionsFromMetadata` returns `undefined` (blind reader) | `🔴 NEGATIVE CONTROL — a step workflow WITH the key planted DOES surface it` | `AssertionError: expected undefined to deeply equal [ { requested: 2558804, …(2) } ]` |
| **M6** | registered-step extraction `push` → `unshift` in `snapshotFromWorkflow` | `a MIXED workflow (textToImage first) surfaces both outputs in steps order AND the record` (**the only failure in 297**) | `expected [ 'https://cdn/conv.webp', …(1) ] to deeply equal [ 'https://cdn/t2i.png', …(1) ]` |
| **M7** | `snapshotFromWorkflow(submitted, { modelSubstitutions: […] })` in `submitStepWorkflow` | `🔴 a step SUBMIT builds no generation context and plumbs no record` | `AssertionError: expected true to be false // Object.is equality` |
| **M8** | reader over-reports (`?? [{…}]` fallback) | `the subsequent POLL of that step workflow carries no record either` + 3 siblings | `AssertionError: expected true to be false // Object.is equality` |

**M5 is the point of the negative control:** with the reader blinded, the two *absence* assertions stayed **green**. Only the planted-metadata control caught it.

**M4** trips two guards (the population guard and the disappearance guard); both fire with their own message. **M8** kills the "poll carries no record" test alongside the pre-existing `pollWorkflow OMITS the field…` sibling — that assertion is a companion covering the same predicate on a registered `$type`, not independent coverage, and is labelled as such.

### Honest labelling
The `kind:'step'` **absence** assertions are **characterization / contract guards**, not regression coverage of a fixed bug — nothing was broken. Their job is to fail when someone plumbs the step path (M7) so FIX 1's contract text is revisited in the same PR. The mixed-workflow test (M6) *is* real coverage: it is the only test in the file that catches a step/txt2img output-ordering break.

---

## Verification

| gate | baseline (`origin/main`) | HEAD | delta |
|---|---|---|---|
| `generation-surface-wiring.test.ts` | 7 tests | 6 tests | −1 (the per-file `it.each` became one per-call-site test) |
| `blocks.router.workflow.test.ts` | 292 tests | 297 tests | +5 |
| affected 8-file set | 576 / 8 files | **580 passed / 8 files** | +4 |
| sweep: `orchestrator` + `routers` + `services/blocks` + `data-graph` + `metrics` | — | **169 files, 3394 tests passed** | consistent with +5/−1 |
| `tsc --noEmit` (repo) | 1 error | 1 error | **0** — only the known pre-existing `cosmetic-phash.service.ts` TS2353 |
| `tsc` over the two test files (via a temp tsconfig; `src/**/__tests__/**` is excluded from the repo config, so CI never typechecks them) | 69 errors in `blocks.router.workflow.test.ts` | 69 | **0**; `generation-surface-wiring.test.ts` = **0 errors** |
| `eslint` on the 3 changed files | 16 (all `blocks.router.workflow.test.ts`, lines ≤ 3622) | 16 | **0** |
| `prettier --list-different` | `workflow.schema.ts` and `blocks.router.workflow.test.ts` already non-conforming; `generation-surface-wiring.test.ts` conforming | only the two pre-existing hunks remain (`workflow.schema.ts:139`, and 11 hunks ≤ line 5703 in the test file) | my regions conform; the guard file was formatted |

Baselines were measured by running `origin/main`'s copy of each file in the same worktree, not inferred. The 2 reported errors in the wide sweep are the known pre-existing `ecosystems.test.ts` unhandled Prisma rejection (present on both trees; `prisma generate` cannot run on this host).

**Not verified:** nothing in this PR is runtime-observable, so there is no live path to exercise — the whole diff is a comment plus tests. CI is the remaining gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
