### PR TITLE
feat(app-blocks): implement the 'promptAudit' moderation posture for the step registry

### DIFF
--- a/src/server/routers/__tests__/blocks.router.workflow.test.ts
+++ b/src/server/routers/__tests__/blocks.router.workflow.test.ts
@@ -1,5 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { TRPCError } from '@trpc/server';
+// Type-only: names the shape `importOriginal()` returns for the step registry
+// mock below. A `typeof import(...)` annotation there is an eslint error
+// (`consistent-type-imports`), so the type is imported up here instead.
+import type * as BlockStepsModule from '~/server/services/blocks/steps';
 
 /**
  * Coverage for the three workflow procedures on blocksRouter. Each procedure
@@ -265,6 +269,66 @@ vi.mock('~/server/services/orchestrator/orchestration-new.service', () => ({
 vi.mock('~/server/services/orchestrator/promptAuditing', () => ({
   auditPromptServer: mockAuditPromptServer,
 }));
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 🔴 A `'promptAudit'` FIXTURE ENTRY, injected into the step registry.
+//
+// WHY THIS EXISTS. The moderation posture `'promptAudit'` is implemented but NO
+// shipped entry declares it (Tranche 1 is `convert-image`, posture `'none'`).
+// A test written against the real population could therefore only assert
+// "nothing audits", which is green whatever the router does — a test whose
+// condition cannot vary. Widening the registry POPULATION (and nothing else)
+// makes the real router branch reachable, so the assertions below have a way to
+// fail.
+//
+// PASS-THROUGH BY CONSTRUCTION: every other export is `actual`, and `getStep`
+// falls back to `actual.getStep` for every id but this one — so the
+// `convert-image` tests in this file exercise exactly the shipped entry. The
+// unchanged pass count for the rest of the suite is the evidence.
+// ─────────────────────────────────────────────────────────────────────────────
+const { AUDITED_STEP_ID } = vi.hoisted(() => ({ AUDITED_STEP_ID: 'fixture-audited-step' }));
+vi.mock('~/server/services/blocks/steps', async (importOriginal) => {
+  const actual = await importOriginal<typeof BlockStepsModule>();
+  const z = await import('zod');
+  const auditedFixtureStep = {
+    id: AUDITED_STEP_ID,
+    orchestratorType: 'fixtureAuditedType',
+    billingMode: 'prepaidFixed' as const,
+    moderationPosture: 'promptAudit' as const,
+    resourcePolicy: { kind: 'none' as const },
+    // `.strict()`, like every registered entry: an unknown param is REJECTED.
+    paramSchema: z.object({ prompt: z.string().min(1) }).strict(),
+    variants: ['default'],
+    resolveVariant: () => 'default',
+    canonicalParamsFor: () => ({ prompt: 'canonical' }),
+    auditableText: (p: { prompt: string }) => ({
+      prompt: p.prompt,
+      negativePrompt: 'fixture-negative',
+    }),
+    priceForVariant: () => 1,
+    estimateBuzz: () => 1,
+    buildStep: (p: { prompt: string }) => ({
+      $type: 'fixtureAuditedType',
+      input: { prompt: p.prompt },
+    }),
+    extractOutput: () => [
+      { url: 'https://blobs.example/f.webp', width: null, height: null, nsfwLevel: null },
+    ],
+    canonicalOutputFor: () => ({}),
+  };
+  // The fixture must itself satisfy every load-time invariant — otherwise these
+  // tests would be exercising a shape the registry would never accept, and a
+  // green result would say nothing about a real entry.
+  actual.assertStepInvariants(AUDITED_STEP_ID, auditedFixtureStep as never);
+  return {
+    ...actual,
+    // The wire `step` enum is DERIVED from this, so widening it is what lets the
+    // fixture id past `blockStepBodySchema` and into the handler.
+    REGISTERED_STEP_IDS: [...actual.REGISTERED_STEP_IDS, AUDITED_STEP_ID],
+    getStep: (id: string) =>
+      id === AUDITED_STEP_ID ? (auditedFixtureStep as never) : actual.getStep(id),
+  };
+});
 vi.mock('~/server/services/user.service', () => ({
   getUserById: mockGetUserById,
 }));
@@ -6640,6 +6704,126 @@ describe("step-type registry bridge (kind: 'step')", () => {
         caller().submitWorkflow({ blockToken: 'tok', body: stepBody() })
       ).rejects.toMatchObject({ code: 'FORBIDDEN' });
       expect(mockReserveAppSpend).not.toHaveBeenCalled();
+    });
+  });
+
+  // ───────────────────────────────────────────────────────────────────────────
+  // 🔴 THE `'promptAudit'` MODERATION POSTURE, THROUGH THE ROUTER.
+  //
+  // No SHIPPED entry declares this posture (Tranche 1 is `convert-image`, which
+  // is `'none'`), so the router branch is unreachable over the real population.
+  // These tests reach it with a fixture entry injected through the mocked
+  // registry (`AUDITED_STEP_ID`) — the REAL router code runs, only the registry
+  // population is widened. Without that, every assertion below would be green
+  // because its condition cannot vary, which proves nothing.
+  //
+  // WHAT ONLY THIS LEVEL CAN PROVE, and the handler unit tests cannot:
+  //   - the router calls the moderation dispatch AT ALL;
+  //   - it passes the `isGreen` DERIVED FROM THE TOKEN's maturity ceiling — not
+  //     a body field, not a constant;
+  //   - the audit runs BEFORE the orchestrator quote and before every spend
+  //     reservation, so a rejection costs nothing and has nothing to refund.
+  // ───────────────────────────────────────────────────────────────────────────
+  describe("🔴 submitWorkflow — moderation posture 'promptAudit'", () => {
+    function auditedBody(prompt = 'a cat in a hat') {
+      return { kind: 'step' as const, step: AUDITED_STEP_ID, params: { prompt } };
+    }
+
+    it('runs auditPromptServer host-side with the SUBMITTED text', async () => {
+      // 🔴 MUTATION TARGET (a), router half: delete the `await runStepModeration(
+      // ... )` call in `submitStepWorkflow` and this fails on
+      // `toHaveBeenCalledTimes(1)`.
+      mockVerifyBlockToken.mockResolvedValue(stepClaims());
+      happyUser();
+      stepSubmitQuoting(1, 1);
+      await caller().submitWorkflow({ blockToken: 'tok', body: auditedBody('a purple dog') });
+      expect(mockAuditPromptServer).toHaveBeenCalledTimes(1);
+      expect(mockAuditPromptServer).toHaveBeenCalledWith({
+        prompt: 'a purple dog',
+        negativePrompt: 'fixture-negative',
+        userId: 42,
+        // No maxBrowsingLevel claim → FAILS CLOSED to the SFW ceiling → the
+        // stricter SFW prompt audit.
+        isGreen: true,
+        isModerator: true,
+      });
+    });
+
+    // 🔴 MUTATION TARGET (c): `isGreen` must be DERIVED from the token's
+    // server-minted `maxBrowsingLevel` claim — the same source `allowMatureContent`
+    // uses — never hardcoded. Hardcoding `true` fails the red case below;
+    // hardcoding `false` fails the green/blue/legacy cases. No constant passes
+    // all four, and this is the exact derivation `textToImage` and `customComfy`
+    // already use (`resolveBlockMaturity(claims).isGreen`).
+    it.each([
+      ['green domain, SFW ceiling', { domain: 'green', maxBrowsingLevel: SFW_CEILING }, true],
+      ['blue domain, SFW ceiling', { domain: 'blue', maxBrowsingLevel: SFW_CEILING }, true],
+      ['red domain, mature ceiling', { domain: 'red', maxBrowsingLevel: ALL_CEILING }, false],
+      ['legacy token, no claim (fails closed)', {}, true],
+    ])('derives isGreen from the TOKEN maturity claim — %s', async (_label, over, expected) => {
+      mockVerifyBlockToken.mockResolvedValue(stepClaims(over));
+      happyUser();
+      stepSubmitQuoting(1, 1);
+      await caller().submitWorkflow({ blockToken: 'tok', body: auditedBody() });
+      expect(mockAuditPromptServer.mock.calls[0][0].isGreen).toBe(expected);
+    });
+
+    it('a CLIENT-SUPPLIED maturity hint is REJECTED outright, never honoured', async () => {
+      // The complement of the derivation tests: an untrusted iframe cannot even
+      // GET a maturity field to the handler. `isGreen` is not in the entry's
+      // `.strict()` schema, so it is rejected one layer earlier — same
+      // fail-closed direction, and nothing is audited or submitted.
+      mockVerifyBlockToken.mockResolvedValue(
+        stepClaims({ domain: 'green', maxBrowsingLevel: SFW_CEILING })
+      );
+      happyUser();
+      stepSubmitQuoting(1, 1);
+      await expect(
+        caller().submitWorkflow({
+          blockToken: 'tok',
+          body: { ...auditedBody(), params: { prompt: 'x', isGreen: false } } as never,
+        })
+      ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+      expect(mockAuditPromptServer).not.toHaveBeenCalled();
+      expect(mockSubmitWorkflow).not.toHaveBeenCalled();
+    });
+
+    it('a FLAGGED prompt aborts BEFORE the orchestrator quote and before any spend', async () => {
+      // 🔴 Placement, not merely presence. If the audit ran after the quote or
+      // after a reservation, a flagged prompt would still cost an orchestrator
+      // round-trip and leave a reservation to unwind.
+      mockVerifyBlockToken.mockResolvedValue(stepClaims());
+      happyUser();
+      stepSubmitQuoting(1, 1);
+      mockAuditPromptServer.mockRejectedValue(
+        new TRPCError({ code: 'BAD_REQUEST', message: 'Your prompt was flagged: minor' })
+      );
+      await expect(
+        caller().submitWorkflow({ blockToken: 'tok', body: auditedBody('blocked text') })
+      ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+      expect(mockSubmitWorkflow).not.toHaveBeenCalled();
+      expect(mockReserveAppSpend).not.toHaveBeenCalled();
+      expect(mockRefundAppSpend).not.toHaveBeenCalled();
+    });
+
+    it('an ESTIMATE does not audit — matching textToImage and customComfy exactly', async () => {
+      // Neither existing kind audits on the estimate path; the estimate makes no
+      // orchestrator call and spends nothing. Pinned so "audit everywhere" does
+      // not creep in as an unreviewed behaviour change to the shared procedure.
+      mockVerifyBlockToken.mockResolvedValue(stepClaims());
+      happyUser();
+      await caller().estimateWorkflow({ blockToken: 'tok', body: auditedBody() });
+      expect(mockAuditPromptServer).not.toHaveBeenCalled();
+    });
+
+    it("a 'none'-posture step still runs NO audit (the shipped entry is unchanged)", async () => {
+      // The regression half: adding the posture must not start auditing
+      // `convert-image`, which has no free-text surface at all.
+      mockVerifyBlockToken.mockResolvedValue(stepClaims());
+      happyUser();
+      stepSubmitQuoting(1, 1);
+      await caller().submitWorkflow({ blockToken: 'tok', body: stepBody() });
+      expect(mockAuditPromptServer).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -153,6 +153,12 @@ import {
   getStep,
   planStepSpend,
 } from '~/server/services/blocks/steps';
+// Moderation dispatch for the same registry. A SEPARATE module because it pulls
+// `auditPromptServer` (Redis + ClickHouse + DB + notifications) and the registry
+// itself is imported by `workflow.schema` for the wire enum, which must stay
+// import-light. Dispatches on the entry's declared `moderationPosture`, so this
+// router keeps no per-posture branch either.
+import { runStepModeration } from '~/server/services/blocks/steps/moderation';
 // Instrument-only: records EVERY prepaidFixed step price check at submit —
 // `exact` / `over` / `absent` — so a flat "no divergence" line can be told apart
 // from a detector that never ran. Never throws.
@@ -6609,29 +6615,43 @@ async function submitStepWorkflow(opts: {
   // load. An invalid param is a BAD_REQUEST → fail-closed.
   const params = parseStepParams(step, body.params);
 
-  // ── Moderation posture. Tranche 1 declares 'none' (no free-text input, no
-  // free-text output → no new moderation surface), and the registry's load-time
-  // invariant REJECTS any entry declaring a posture whose handler is not
-  // implemented. So there is nothing to run here today, and a future
-  // text-producing step cannot reach this line without someone having
-  // implemented — and reviewed — its posture. Re-asserted rather than assumed:
-  // this is the seam a policy mistake would arrive through.
-  if (step.moderationPosture !== 'none') {
-    throw new TRPCError({
-      code: 'INTERNAL_SERVER_ERROR',
-      message: `step '${step.id}' declares an unimplemented moderation posture`,
-    });
-  }
-
-  // NOTE: no `getBlockSessionUser` call here. A registry step carries no model
-  // binding, no checkpoint resolution and no entitlement belt, so nothing on
-  // this path reads the session user — fetching one cost a `getUserById` per
-  // submit for a value that was never used (and an unused-var eslint warning).
+  // NOTE: no UNCONDITIONAL `getBlockSessionUser` call here. A registry step
+  // carries no model binding, no checkpoint resolution and no entitlement belt,
+  // so a `'none'`-posture step reads nothing about the session user — fetching
+  // one cost a `getUserById` per submit for a value that was never used. A
+  // posture that DOES audit needs `isModerator`, so it is passed below as a
+  // THUNK: only a handler that reads it pays for the round-trip, and this
+  // function keeps no per-posture branch.
   const { allowMatureContent, isGreen } = resolveBlockMaturity(claims);
   // A registry step has no `accountType` field on its wire body (params are the
   // step's own bounded contract), so currency selection is Auto — the
   // domain-allowed set, drained blue-first.
   const currencies = resolveBlockCurrenciesForAccount(isGreen, undefined);
+
+  // ── MODERATION POSTURE — dispatched on the entry's DECLARED posture, the same
+  // way spend dispatches on its declared billing mode. No per-step and no
+  // per-posture branch here; `runStepModeration` owns the table.
+  //
+  // 🔴 HOST-SIDE, AND BEFORE SUBMISSION. The audit cannot live on the block
+  // side: a block is untrusted sandboxed code that can decline to call it or
+  // ignore its verdict, and `extModeration` being fail-soft does not make the
+  // call optional. Placed here it runs before the orchestrator quote and before
+  // every spend reservation — so a rejection costs no orchestrator call and has
+  // nothing to refund, matching where `textToImage` and `customComfy` put theirs.
+  //
+  // 🔴 `isGreen` IS THE TOKEN'S MATURITY CLAIM, not a request field and not a
+  // constant. It comes from `resolveBlockMaturity(claims)` above — the same
+  // server-minted `maxBrowsingLevel` ceiling `allowMatureContent` is derived
+  // from — so a SFW-domain (green/blue) block gets the stricter SFW audit even
+  // if its own code is wrong or malicious. Byte-identical derivation to the two
+  // existing kinds.
+  await runStepModeration({
+    step,
+    params,
+    userId,
+    isGreen,
+    loadIsModerator: async () => !!(await getBlockSessionUser(userId)).isModerator,
+  });
 
   const token = await getOrchestratorToken(userId, ctx);
 

--- a/src/server/services/blocks/steps/__tests__/step-moderation.test.ts
+++ b/src/server/services/blocks/steps/__tests__/step-moderation.test.ts
@@ -171,6 +171,51 @@ describe("step moderation — the 'promptAudit' handler", () => {
     expect(mockAuditPromptServer).not.toHaveBeenCalled();
   });
 
+  // 🔴 THE `negativePrompt` TYPE CLAUSE. `./index` clause 5a checks this at
+  // registry LOAD against canonical params; this checks the params actually
+  // submitted. Without it a non-string reaches `stripBenignPhrases` inside
+  // `auditPromptServer`'s own try (`text.replace is not a function`), the catch
+  // treats it as a moderation hit, and on the non-green path it writes a
+  // `BlockedPromptEntry` and increments the AUTO-MUTE counter before rethrowing
+  // "Your prompt was flagged". Innocent users would take a mute-counter hit on
+  // every submit, so "the audit was not called" is the assertion that matters.
+  it.each([
+    ['a number', 42],
+    ['an object', { toString: () => 'sneaky' }],
+    ['null', null],
+  ])(
+    'REJECTS %s as negativePrompt BEFORE auditPromptServer is called',
+    async (_label, negativePrompt) => {
+      const error = await runStepModeration(
+        request({
+          step: makeStep({
+            auditableText: () => ({ prompt: 'a cat', negativePrompt }),
+          } as unknown as Partial<AnyBlockStep>),
+        })
+      ).then(
+        () => undefined,
+        (e) => e
+      );
+
+      expect(
+        mockAuditPromptServer,
+        'auditPromptServer must not be reached with a negativePrompt it cannot read — its ' +
+          'internal catch would record a BlockedPromptEntry and bump the auto-mute counter'
+      ).not.toHaveBeenCalled();
+      expect(error).toMatchObject({
+        code: 'BAD_REQUEST',
+        message: expect.stringContaining('non-string negativePrompt'),
+      });
+    }
+  );
+
+  it('still passes a legitimate string negativePrompt straight through', async () => {
+    // The negative control for the clause above: it must reject a bad type, not
+    // every negativePrompt.
+    await runStepModeration(request());
+    expect(mockAuditPromptServer.mock.calls[0][0].negativePrompt).toBe('blurry');
+  });
+
   it('PROPAGATES a flagged prompt — the audit is never wrapped in a catch', async () => {
     // 🔴 Fail-soft is `auditPromptServer`'s OWN behaviour for a moderation-service
     // outage (it catches the extModeration error internally and continues). A
@@ -218,6 +263,69 @@ describe('step moderation — dispatch over the posture table', () => {
     });
     expect(mockAuditPromptServer).not.toHaveBeenCalled();
   });
+
+  // 🔴 THE PROTOTYPE-KEY ATTACK. A plain object literal inherits from
+  // `Object.prototype`, so `handlers['toString']` returns
+  // `Object.prototype.toString` — TRUTHY. `!handler` would then be false,
+  // `await handler(req)` would RESOLVE, and `runStepModeration` would return
+  // cleanly having audited nothing and thrown nothing: the fail-closed guard
+  // failing OPEN, for the exact keys an attacker would pick. Verified by
+  // execution before the fix. The table's null prototype is what makes these
+  // read `undefined`.
+  //
+  // These are the two keys that produce the SILENT ALLOW: reverting the table to
+  // a plain object literal fails both on `promise resolved "undefined" instead
+  // of rejecting`, because `Object.prototype.toString.call(undefined)` returns a
+  // string and `Object(req)` returns `req` — neither throws. A plain unknown
+  // string like `'nope'` does NOT cover this; that key misses the prototype too,
+  // which is why the pre-fix code already handled it.
+  it.each([['toString'], ['constructor']])(
+    "FAILS CLOSED on the Object.prototype key '%s' — it must not resolve to an inherited method",
+    async (posture) => {
+      await expect(
+        runStepModeration(
+          request({
+            step: makeStep({
+              moderationPosture: posture,
+              auditableText: undefined,
+            } as unknown as Partial<AnyBlockStep>),
+          })
+        )
+      ).rejects.toMatchObject({
+        code: 'INTERNAL_SERVER_ERROR',
+        message: "step 'fixture-step' declares an unimplemented moderation posture",
+      });
+      expect(mockAuditPromptServer).not.toHaveBeenCalled();
+    }
+  );
+
+  // The remaining inherited keys, kept separate and NOT counted as clean kills.
+  // ⚠️ DISCLOSED: with the null prototype reverted these do not silently allow —
+  // `Object.prototype.valueOf` / `.hasOwnProperty` invoked with `this ===
+  // undefined` (ESM is strict) and `__proto__` resolving to a non-callable
+  // `Object.prototype` all throw a raw `TypeError`. So a mutation dies here to
+  // JavaScript's error, not to this guard's. They are asserted because the named
+  // 500 is the behaviour we want on every prototype key, not because they
+  // demonstrate the fail-open.
+  it.each([['valueOf'], ['hasOwnProperty'], ['__proto__']])(
+    "also fails closed on '%s' (a raw TypeError pre-fix, not a silent allow)",
+    async (posture) => {
+      await expect(
+        runStepModeration(
+          request({
+            step: makeStep({
+              moderationPosture: posture,
+              auditableText: undefined,
+            } as unknown as Partial<AnyBlockStep>),
+          })
+        )
+      ).rejects.toMatchObject({
+        code: 'INTERNAL_SERVER_ERROR',
+        message: "step 'fixture-step' declares an unimplemented moderation posture",
+      });
+      expect(mockAuditPromptServer).not.toHaveBeenCalled();
+    }
+  );
 
   it('is TOTAL over every declared posture — no key reads as undefined', async () => {
     for (const posture of STEP_MODERATION_POSTURES) {

--- a/src/server/services/blocks/steps/__tests__/step-moderation.test.ts
+++ b/src/server/services/blocks/steps/__tests__/step-moderation.test.ts
@@ -1,0 +1,275 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import * as z from 'zod';
+
+/**
+ * Coverage for the step-registry MODERATION dispatch (`./moderation`).
+ *
+ * 🔴 WHAT THIS SUITE HAS TO PROVE, and why each one is not obvious:
+ *
+ *  1. The `'promptAudit'` handler REALLY CALLS `auditPromptServer`. Deleting the
+ *     call must fail a test on its own assertion — not merely leave a mock
+ *     unasserted.
+ *  2. `isGreen` is PASSED THROUGH from the caller, never constant. Hardcoding it
+ *     either way must fail.
+ *  3. An empty/whitespace prompt at REQUEST time is REJECTED, not audited.
+ *     `auditPromptServer` returns early on an empty prompt, so "call it anyway"
+ *     is indistinguishable from a clean audit.
+ *  4. A flagged prompt PROPAGATES. No try/catch may be added around the audit:
+ *     fail-soft is `auditPromptServer`'s own behaviour for a moderation-service
+ *     outage, not a licence to swallow a block.
+ *  5. The handler table and `isModerationPostureImplemented` cannot drift.
+ *
+ * `auditPromptServer` is mocked at the module boundary (it pulls Redis,
+ * ClickHouse, the DB client and the notification service).
+ */
+
+const { mockAuditPromptServer } = vi.hoisted(() => ({ mockAuditPromptServer: vi.fn() }));
+vi.mock('~/server/services/orchestrator/promptAuditing', () => ({
+  auditPromptServer: mockAuditPromptServer,
+}));
+
+import {
+  mediaFromBlobs,
+  STEP_MODERATION_POSTURES,
+  type AnyBlockStep,
+  type BlockStep,
+  type StepModerationPosture,
+} from '~/server/services/blocks/steps';
+import type { OrchestratorBlobLike } from '~/server/services/blocks/steps/output';
+import {
+  assertModerationHandlerTable,
+  runStepModeration,
+  type StepModerationRequest,
+} from '~/server/services/blocks/steps/moderation';
+
+type FixtureParams = { prompt: string };
+
+const fixtureParamSchema = z.object({ prompt: z.string() }).strict();
+
+function makeStep(overrides: Partial<AnyBlockStep> = {}): AnyBlockStep {
+  const base = {
+    id: 'fixture-step',
+    orchestratorType: 'fixtureType',
+    billingMode: 'prepaidFixed',
+    moderationPosture: 'promptAudit',
+    resourcePolicy: { kind: 'none' },
+    paramSchema: fixtureParamSchema,
+    variants: ['default'],
+    resolveVariant: () => 'default',
+    canonicalParamsFor: (): FixtureParams => ({ prompt: 'a cat' }),
+    auditableText: (p: FixtureParams) => ({ prompt: p.prompt, negativePrompt: 'blurry' }),
+    priceForVariant: () => 7,
+    estimateBuzz: () => 7,
+    buildStep: (p: FixtureParams) => ({ $type: 'fixtureType', input: { prompt: p.prompt } }),
+    extractOutput: (step: unknown) =>
+      mediaFromBlobs(
+        (step as { output?: { blob?: OrchestratorBlobLike | null } } | null | undefined)?.output
+          ?.blob
+      ),
+    canonicalOutputFor: (): unknown => ({
+      output: { blob: { url: 'https://blobs.example/f.webp', available: true } },
+    }),
+  } satisfies BlockStep<FixtureParams>;
+  return { ...base, ...overrides } as AnyBlockStep;
+}
+
+function request(over: Partial<StepModerationRequest> = {}): StepModerationRequest {
+  return {
+    step: makeStep(),
+    params: { prompt: 'a cat' },
+    userId: 42,
+    isGreen: false,
+    loadIsModerator: async () => false,
+    ...over,
+  };
+}
+
+beforeEach(() => {
+  mockAuditPromptServer.mockReset();
+  mockAuditPromptServer.mockResolvedValue(undefined);
+});
+
+describe("step moderation — the 'promptAudit' handler", () => {
+  it('runs auditPromptServer with the entry-declared text', async () => {
+    // 🔴 MUTATION TARGET (a): delete the `await auditPromptServer({...})` call in
+    // the handler and this assertion fails on `toHaveBeenCalledTimes(1)`.
+    await runStepModeration(request());
+    expect(mockAuditPromptServer).toHaveBeenCalledTimes(1);
+    expect(mockAuditPromptServer).toHaveBeenCalledWith({
+      prompt: 'a cat',
+      negativePrompt: 'blurry',
+      userId: 42,
+      isGreen: false,
+      isModerator: false,
+    });
+  });
+
+  it('audits the SUBMITTED params, not the canonical ones', async () => {
+    // The params an untrusted iframe actually sent are what must be audited — a
+    // handler that read `canonicalParamsFor()` would audit a constant forever.
+    await runStepModeration(request({ params: { prompt: 'something else entirely' } }));
+    expect(mockAuditPromptServer.mock.calls[0][0]).toMatchObject({
+      prompt: 'something else entirely',
+    });
+  });
+
+  it('PASSES THROUGH isGreen in both directions — it is never a constant', async () => {
+    // 🔴 MUTATION TARGET (c), handler half: hardcoding `isGreen: true` fails the
+    // first assertion, hardcoding `false` fails the second. Neither can pass both.
+    await runStepModeration(request({ isGreen: false }));
+    expect(mockAuditPromptServer.mock.calls[0][0].isGreen).toBe(false);
+
+    mockAuditPromptServer.mockClear();
+    await runStepModeration(request({ isGreen: true }));
+    expect(mockAuditPromptServer.mock.calls[0][0].isGreen).toBe(true);
+  });
+
+  it('resolves isModerator through the caller-supplied thunk', async () => {
+    const loadIsModerator = vi.fn().mockResolvedValue(true);
+    await runStepModeration(request({ loadIsModerator }));
+    expect(loadIsModerator).toHaveBeenCalledTimes(1);
+    expect(mockAuditPromptServer.mock.calls[0][0].isModerator).toBe(true);
+  });
+
+  it('omits negativePrompt when the entry declares none', async () => {
+    await runStepModeration(
+      request({
+        step: makeStep({
+          auditableText: () => ({ prompt: 'only positive' }),
+        } as Partial<AnyBlockStep>),
+      })
+    );
+    expect(mockAuditPromptServer.mock.calls[0][0].negativePrompt).toBeUndefined();
+  });
+
+  // 🔴 THE FAIL-CLOSED CLAUSE. `auditPromptServer` returns early on an empty
+  // prompt, so calling it with one is a posture that audits NOTHING and reports
+  // success. These reject instead.
+  it.each([
+    ['an empty string', ''],
+    ['whitespace only', '   \n\t '],
+  ])('REJECTS %s as unauditable rather than submitting it unaudited', async (_label, prompt) => {
+    await expect(
+      runStepModeration(
+        request({ step: makeStep({ auditableText: () => ({ prompt }) } as Partial<AnyBlockStep>) })
+      )
+    ).rejects.toMatchObject({
+      code: 'BAD_REQUEST',
+      message: expect.stringContaining('carry no auditable text'),
+    });
+    expect(mockAuditPromptServer).not.toHaveBeenCalled();
+  });
+
+  it('REJECTS a promptAudit entry whose auditableText is missing at request time', async () => {
+    // Registry load already blocks this shape; the handler re-asserts it because
+    // this is the seam a policy mistake arrives through.
+    await expect(
+      runStepModeration(
+        request({ step: makeStep({ auditableText: undefined } as Partial<AnyBlockStep>) })
+      )
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+    expect(mockAuditPromptServer).not.toHaveBeenCalled();
+  });
+
+  it('PROPAGATES a flagged prompt — the audit is never wrapped in a catch', async () => {
+    // 🔴 Fail-soft is `auditPromptServer`'s OWN behaviour for a moderation-service
+    // outage (it catches the extModeration error internally and continues). A
+    // catch HERE would turn a genuinely flagged prompt into a silent pass.
+    const flagged = Object.assign(new Error('Your prompt was flagged: x'), {
+      code: 'BAD_REQUEST',
+    });
+    mockAuditPromptServer.mockRejectedValue(flagged);
+    await expect(runStepModeration(request())).rejects.toThrow('Your prompt was flagged: x');
+  });
+});
+
+describe('step moderation — dispatch over the posture table', () => {
+  it("the 'none' posture runs nothing and does not resolve the viewer", async () => {
+    // The zero-cost property the step path deliberately has today: no audit call,
+    // and no `getUserById` round-trip behind the thunk.
+    const loadIsModerator = vi.fn();
+    await runStepModeration(
+      request({
+        step: makeStep({
+          moderationPosture: 'none',
+          auditableText: undefined,
+        } as Partial<AnyBlockStep>),
+        loadIsModerator,
+      })
+    );
+    expect(mockAuditPromptServer).not.toHaveBeenCalled();
+    expect(loadIsModerator).not.toHaveBeenCalled();
+  });
+
+  it("the unimplemented 'textOutput' posture FAILS CLOSED with a named error", async () => {
+    // Never `undefined is not a function`: a deliberate, named 500 on the seam.
+    await expect(
+      runStepModeration(
+        request({
+          step: makeStep({
+            moderationPosture: 'textOutput',
+            auditableText: undefined,
+          } as Partial<AnyBlockStep>),
+        })
+      )
+    ).rejects.toMatchObject({
+      code: 'INTERNAL_SERVER_ERROR',
+      message: "step 'fixture-step' declares an unimplemented moderation posture",
+    });
+    expect(mockAuditPromptServer).not.toHaveBeenCalled();
+  });
+
+  it('is TOTAL over every declared posture — no key reads as undefined', async () => {
+    for (const posture of STEP_MODERATION_POSTURES) {
+      const step = makeStep({
+        moderationPosture: posture,
+        ...(posture === 'promptAudit' ? {} : { auditableText: undefined }),
+      } as Partial<AnyBlockStep>);
+      let error: unknown;
+      try {
+        await runStepModeration(request({ step }));
+      } catch (e) {
+        error = e;
+      }
+      if (posture === 'textOutput') {
+        expect(String((error as { message?: string })?.message)).toContain(
+          'unimplemented moderation posture'
+        );
+      } else {
+        expect(error, `posture '${posture}' should have an implemented handler`).toBeUndefined();
+      }
+    }
+  });
+});
+
+describe('step moderation — the handler table cannot drift from the declaration', () => {
+  const noop = async () => undefined;
+
+  it('the SHIPPED table passes (it is asserted at module load; this pins it)', () => {
+    expect(() =>
+      assertModerationHandlerTable({ none: noop, promptAudit: noop, textOutput: null })
+    ).not.toThrow();
+  });
+
+  it('rejects an IMPLEMENTED posture whose handler is absent (a 500 on a spend path)', () => {
+    expect(() =>
+      assertModerationHandlerTable({ none: noop, promptAudit: null, textOutput: null })
+    ).toThrow(/posture 'promptAudit' is declared IMPLEMENTED but its handler is absent/);
+  });
+
+  it('rejects an UNIMPLEMENTED posture that has a handler (the gate would be a lie)', () => {
+    expect(() =>
+      assertModerationHandlerTable({ none: noop, promptAudit: noop, textOutput: noop })
+    ).toThrow(/posture 'textOutput' is declared UNIMPLEMENTED but its handler is present/);
+  });
+
+  it('checks EVERY declared posture, not just the first', () => {
+    // A loop that broke early would pass the previous two tests and still miss a
+    // drifted posture further down the list.
+    const postures = [...STEP_MODERATION_POSTURES] as StepModerationPosture[];
+    expect(postures).toEqual(['none', 'promptAudit', 'textOutput']);
+    expect(() =>
+      assertModerationHandlerTable({ none: null, promptAudit: noop, textOutput: null })
+    ).toThrow(/posture 'none' is declared IMPLEMENTED but its handler is absent/);
+  });
+});

--- a/src/server/services/blocks/steps/__tests__/step-registry.test.ts
+++ b/src/server/services/blocks/steps/__tests__/step-registry.test.ts
@@ -14,6 +14,7 @@ import {
   mediaFromBlobs,
   NATIVELY_EXTRACTED_STEP_TYPES,
   planStepSpend,
+  postureRequiresAuditableText,
   REGISTERED_STEP_IDS,
   STEP_BILLING_MODES,
   STEP_MODERATION_POSTURES,
@@ -77,6 +78,25 @@ function makeFixtureStep(overrides: Partial<AnyBlockStep> = {}): AnyBlockStep {
     canonicalOutputFor: (): unknown => FIXTURE_OUTPUT_STEP,
   } satisfies BlockStep<FixtureParams>;
   return { ...base, ...overrides } as AnyBlockStep;
+}
+
+/**
+ * A minimal VALID `'promptAudit'` fixture — the same base, plus the two fields
+ * that posture requires.
+ *
+ * 🔴 It is asserted to pass unmutated (first test in the mutation block), which
+ * is what makes every mutation below provably die to the clause its assertion
+ * names rather than to some earlier clause rejecting the whole shape.
+ */
+function makeAuditedFixtureStep(overrides: Partial<AnyBlockStep> = {}): AnyBlockStep {
+  return makeFixtureStep({
+    moderationPosture: 'promptAudit',
+    auditableText: (p: FixtureParams) => ({
+      prompt: `fixture prompt ${p.value}`,
+      negativePrompt: 'fixture negative',
+    }),
+    ...overrides,
+  } as Partial<AnyBlockStep>);
 }
 
 describe('block step registry — the shipped population', () => {
@@ -196,13 +216,49 @@ describe('block step registry — the shipped population', () => {
     expect(isBillingModeImplemented('tokenMetered')).toBe(false);
   });
 
-  it('a step with a free-text surface has NO implemented moderation posture', () => {
-    // 🔴 The mechanism that makes `chatCompletion` / captioning impossible to
-    // register without an explicit, reviewed policy answer in code. If this ever
-    // flips to true, someone made that policy decision — make sure they meant to.
+  it('free-text INPUT is implemented; free-text OUTPUT still is not', () => {
+    // 🔴 The mechanism that makes a text-producing step impossible to register
+    // without an explicit, reviewed policy answer in code.
+    //
+    // `'promptAudit'` (free-text INPUT) is now implemented: #3527 answered that
+    // half — mature content is permitted for App Blocks, bounded by the token's
+    // server-minted maturity ceiling, so a free-text input needs the SAME
+    // `auditPromptServer` pass `textToImage`/`customComfy` run, not a new policy.
+    //
+    // `'textOutput'` is unchanged and deliberately so: generated text is scanned
+    // by nothing on any current path. If THAT ever flips to true, someone made a
+    // content-policy decision — make sure they meant to.
     expect(isModerationPostureImplemented('none')).toBe(true);
-    expect(isModerationPostureImplemented('promptAudit')).toBe(false);
+    expect(isModerationPostureImplemented('promptAudit')).toBe(true);
     expect(isModerationPostureImplemented('textOutput')).toBe(false);
+  });
+
+  // 🔴 LABELLED HONESTLY: an INVARIANT GUARD, not regression coverage. Every
+  // registered entry today declares `'none'`, so the `'promptAudit'` branch of
+  // this loop cannot currently execute — no mutation of the posture↔auditableText
+  // rule can fail it over the shipped population. It becomes real coverage the
+  // day a `'promptAudit'` entry is registered. The guard itself is
+  // mutation-proven below against fixtures, which is where its evidence lives.
+  it('every registered entry agrees with the posture ↔ auditableText rule', () => {
+    for (const [id, step] of listRegisteredSteps()) {
+      if (postureRequiresAuditableText(step.moderationPosture)) {
+        expect(typeof step.auditableText, `step '${id}' must name its auditable text`).toBe(
+          'function'
+        );
+        for (const variant of step.variants) {
+          const params = step.paramSchema.parse(step.canonicalParamsFor(variant));
+          expect(
+            step.auditableText!(params).prompt.trim().length,
+            `step '${id}' variant '${variant}' would audit NOTHING`
+          ).toBeGreaterThan(0);
+        }
+      } else {
+        expect(
+          step.auditableText,
+          `step '${id}' declares auditable text its posture never audits`
+        ).toBeUndefined();
+      }
+    }
   });
 });
 
@@ -241,6 +297,89 @@ describe('block step registry — load-time invariants (each guard, mutation-pro
     expect(() =>
       assertStepInvariants('fixture-step', makeFixtureStep({ moderationPosture: 'textOutput' }))
     ).toThrow(/moderationPosture 'textOutput' has no implemented handler/);
+  });
+
+  // ── 🔴 THE `'promptAudit'` POSTURE — "audits nothing" must be impossible ────
+  //
+  // The defect class this guards is the one #3538 had to fix for `extractOutput`:
+  // a REQUIRED field that a new entry can satisfy vacuously. `auditPromptServer`
+  // RETURNS EARLY on an empty prompt, so `() => ({ prompt: '' })` would be a
+  // declared posture that runs, audits nothing, and reports success. Both
+  // directions of the declaration rule and the non-vacuity probe are below.
+
+  it('the promptAudit fixture PASSES unmutated — every failure below is the mutation', () => {
+    // 🔴 REACHABILITY. Without this, each mutation below could be dying to a
+    // clause that rejects the whole `'promptAudit'` shape rather than to the one
+    // named in its assertion.
+    expect(() => assertStepInvariants('fixture-step', makeAuditedFixtureStep())).not.toThrow();
+  });
+
+  it("rejects a 'promptAudit' entry that declares NO auditableText (a posture with no input)", () => {
+    expect(() =>
+      assertStepInvariants(
+        'fixture-step',
+        makeFixtureStep({ moderationPosture: 'promptAudit' } as Partial<AnyBlockStep>)
+      )
+    ).toThrow(
+      /moderationPosture 'promptAudit' requires an auditableText\(\) declaration naming the params that carry user text/
+    );
+  });
+
+  it('rejects an entry that declares auditableText under a posture that never audits it', () => {
+    // The reverse direction. Text that LOOKS covered and is not: the field is
+    // never called, so it reaches the orchestrator unaudited.
+    expect(() =>
+      assertStepInvariants(
+        'fixture-step',
+        makeFixtureStep({
+          moderationPosture: 'none',
+          auditableText: () => ({ prompt: 'a cat' }),
+        } as Partial<AnyBlockStep>)
+      )
+    ).toThrow(/declares auditableText\(\) but moderationPosture 'none' never audits it/);
+  });
+
+  it('rejects auditableText that returns an EMPTY prompt (the vacuous-posture case)', () => {
+    expect(() =>
+      assertStepInvariants(
+        'fixture-step',
+        makeAuditedFixtureStep({ auditableText: () => ({ prompt: '' }) } as Partial<AnyBlockStep>)
+      )
+    ).toThrow(/auditableText\(\) returned no prompt text for canonicalParamsFor\(\)/);
+  });
+
+  it('rejects auditableText that returns WHITESPACE (auditPromptServer trims and returns early)', () => {
+    // 🔴 Not a nit: the early return in `auditPromptServer` is
+    // `if (!prompt || !prompt.trim()) return;` — whitespace is exactly as vacuous
+    // as an empty string, and a `.length > 0` check would have accepted it.
+    expect(() =>
+      assertStepInvariants(
+        'fixture-step',
+        makeAuditedFixtureStep({
+          auditableText: () => ({ prompt: '   \n\t ' }),
+        } as Partial<AnyBlockStep>)
+      )
+    ).toThrow(/auditableText\(\) returned no prompt text for canonicalParamsFor\(\)/);
+  });
+
+  it('rejects auditableText that omits prompt entirely', () => {
+    expect(() =>
+      assertStepInvariants(
+        'fixture-step',
+        makeAuditedFixtureStep({ auditableText: () => ({}) } as unknown as Partial<AnyBlockStep>)
+      )
+    ).toThrow(/auditableText\(\) returned no prompt text for canonicalParamsFor\(\)/);
+  });
+
+  it('rejects a non-string negativePrompt (auditPromptServer could not read it)', () => {
+    expect(() =>
+      assertStepInvariants(
+        'fixture-step',
+        makeAuditedFixtureStep({
+          auditableText: () => ({ prompt: 'a cat', negativePrompt: 42 }),
+        } as unknown as Partial<AnyBlockStep>)
+      )
+    ).toThrow(/auditableText\(\) returned a non-string negativePrompt/);
   });
 
   // ── 🔴 FIX 3 — the ENTITLEMENT axis ────────────────────────────────────────

--- a/src/server/services/blocks/steps/index.ts
+++ b/src/server/services/blocks/steps/index.ts
@@ -83,23 +83,35 @@ export const STEP_BILLING_MODES: readonly StepBillingMode[] = [
 // text-producing step later is impossible without someone explicitly answering
 // the policy question in code — it cannot be quietly skipped, because a posture
 // with no implemented handler fails at registry LOAD (a build-time error), not
-// at request time on a Friday. That policy decision is deliberately NOT made
-// here.
+// at request time on a Friday.
+//
+// 🔴 THE FREE-TEXT-INPUT HALF OF THAT QUESTION IS NOW ANSWERED (#3527): mature
+// content is permitted for App Blocks, bounded by the token's server-minted
+// maturity ceiling — so a free-text INPUT needs the same prompt audit
+// `textToImage` / `customComfy` already run, not a new policy. `'promptAudit'`
+// is therefore IMPLEMENTED; its handler lives in `./moderation` and runs
+// `auditPromptServer` host-side, before the orchestrator submit. The free-text
+// OUTPUT half (`'textOutput'`) is still unanswered and still fails at load.
 // ─────────────────────────────────────────────────────────────────────────────
 export type StepModerationPosture =
   /**
    * No free-text input and no free-text output — the step introduces no new
-   * moderation surface. The ONLY posture with an implemented handler today.
+   * moderation surface, so there is nothing to run.
    */
   | 'none'
   /**
-   * Free-text INPUT that must go through the existing server prompt audit
+   * Free-text INPUT that goes through the existing server prompt audit
    * (`auditPromptServer`), as `textToImage` / `customComfy` do.
-   * NOT IMPLEMENTED — registering an entry with this posture fails at load.
+   *
+   * IMPLEMENTED. An entry declaring it MUST also declare `auditableText` (see
+   * that field) — a posture that can be satisfied by auditing nothing is not a
+   * posture, so both the declaration and its non-emptiness are enforced at
+   * registry LOAD, and again per-request in the handler.
    */
   | 'promptAudit'
   /**
    * Free-text OUTPUT — a moderation surface the prompt audit does not cover.
+   * Generated text is scanned by NOTHING on any current path.
    * NOT IMPLEMENTED — registering an entry with this posture fails at load.
    */
   | 'textOutput';
@@ -109,6 +121,33 @@ export const STEP_MODERATION_POSTURES: readonly StepModerationPosture[] = [
   'promptAudit',
   'textOutput',
 ] as const;
+
+/**
+ * The free text a `'promptAudit'` entry hands to `auditPromptServer`.
+ *
+ * Deliberately the EXACT two fields `textToImage` and `customComfy` already
+ * pass, so the posture runs the same audit with the same inputs rather than a
+ * parallel one. An entry with several user-text params joins them into `prompt`
+ * itself — explicitly, in its own file, where a reviewer can see which params
+ * are covered — rather than the registry guessing from field names.
+ */
+export type StepAuditableText = {
+  /** The user-authored text. MUST be non-empty (enforced at load AND per request). */
+  prompt: string;
+  /** Optional second field, matching `auditPromptServer`'s own signature. */
+  negativePrompt?: string;
+};
+
+/**
+ * True iff the posture's handler needs the entry to declare `auditableText`.
+ *
+ * 🔴 The one place that relationship is written down. The load-time invariant,
+ * the request-time handler and the tests all read THIS — a second copy is how
+ * the guard and the thing it guards drift apart.
+ */
+export function postureRequiresAuditableText(posture: StepModerationPosture): boolean {
+  return posture === 'promptAudit';
+}
 
 /**
  * The orchestrator step template a step builder emits: the `$type` discriminator
@@ -241,6 +280,32 @@ interface BlockStepBase<P> {
   billingMode: StepBillingMode;
   /** 🔴 REQUIRED. See `StepModerationPosture`. */
   moderationPosture: StepModerationPosture;
+  /**
+   * 🔴 REQUIRED IFF `moderationPosture` requires it (`'promptAudit'`), and
+   * FORBIDDEN otherwise. PURE: bounded params → the free text to audit.
+   *
+   * WHY THIS IS A DECLARED FIELD AND NOT AN INFERENCE. A step's params are
+   * arbitrary per entry — there is no universal `prompt` key, and sniffing for
+   * string-valued fields would audit a Civitai image URL while missing
+   * `messages[].content`. So the entry NAMES its user text, exactly as
+   * `canonicalOutputFor` makes the output shape explicit rather than inferred.
+   *
+   * 🔴 AND IT CANNOT BE SATISFIED BY RETURNING NOTHING. `auditPromptServer`
+   * RETURNS EARLY on an empty prompt, so `() => ({ prompt: '' })` would be a
+   * declared posture that audits nothing and reports success — the same defect
+   * class as an `extractOutput` satisfiable by `() => []`, which is why that
+   * field got a probe. This one gets the same treatment: the load-time invariant
+   * evaluates it against `canonicalParamsFor(variant)` and REJECTS an empty
+   * result, and the request-time handler rejects an empty result again on the
+   * params actually submitted.
+   *
+   * HONEST LIMIT, stated so nobody over-trusts it: this proves the entry audits
+   * SOMETHING, not that it audits EVERYTHING. Nothing structural can know which
+   * of an arbitrary param object's strings are user-authored. The load-bearing
+   * guard for coverage is the same one `resourcePolicy` relies on — a required,
+   * reviewed declaration in a code-reviewed trust root.
+   */
+  auditableText?(params: P): StepAuditableText;
   /**
    * 🔴 REQUIRED. See `StepResourcePolicy`. The entitlement axis — the one this
    * PR's own triage identified as the real bypass risk, and the one a
@@ -502,12 +567,21 @@ export function planStepSpend(step: AnyBlockStep, params: unknown): StepSpendPla
 // union, and every posture without an implemented handler is rejected at load.
 // ─────────────────────────────────────────────────────────────────────────────
 
-/** True iff the posture has an implemented handler. */
+/**
+ * True iff the posture has an implemented handler.
+ *
+ * 🔴 THE SINGLE DECLARATION. `./moderation` asserts at ITS module load that its
+ * handler table agrees with this function for every posture, so "declared
+ * implemented" and "has a handler" cannot drift into a posture that registers
+ * cleanly and then has nothing to run.
+ */
 export function isModerationPostureImplemented(posture: StepModerationPosture): boolean {
   // 'none' is implemented by construction: a step with no free-text input and
-  // no free-text output introduces no surface, so there is nothing to run. Both
-  // other postures need a real, policy-reviewed implementation.
-  return posture === 'none';
+  // no free-text output introduces no surface, so there is nothing to run.
+  // 'promptAudit' runs `auditPromptServer` — the SAME audit `textToImage` and
+  // `customComfy` run, host-side and before submission (see `./moderation`).
+  // 'textOutput' still has no answer and still fails at load.
+  return posture === 'none' || posture === 'promptAudit';
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -620,6 +694,32 @@ export function assertStepInvariants(id: string, step: AnyBlockStep): void {
     );
   }
 
+  // (1a) POSTURE ↔ `auditableText` AGREEMENT, both directions.
+  //
+  // Forward: a posture that audits free text must SAY WHERE THE TEXT IS. Without
+  // this, an entry could declare `'promptAudit'`, omit the field entirely, and
+  // register cleanly — a step that announces a moderation surface and has no
+  // handler input, i.e. a posture satisfied by auditing nothing.
+  //
+  // Reverse: an entry that declares audit text while declaring a posture that
+  // does not audit is a CONTRADICTION its author is best placed to resolve. It
+  // reads as covered and is not: the field is never called, so the text reaches
+  // the orchestrator unaudited. Rejecting it is the fail-closed direction.
+  if (postureRequiresAuditableText(step.moderationPosture)) {
+    if (typeof step.auditableText !== 'function') {
+      throw new Error(
+        `${where}: moderationPosture '${step.moderationPosture}' requires an auditableText() ` +
+          'declaration naming the params that carry user text — a posture that can be ' +
+          'satisfied by auditing nothing is not a posture'
+      );
+    }
+  } else if (step.auditableText !== undefined) {
+    throw new Error(
+      `${where}: declares auditableText() but moderationPosture '${step.moderationPosture}' ` +
+        'never audits it — the text would reach the orchestrator unaudited'
+    );
+  }
+
   // (2) At least one variant, or nothing below can be enumerated.
   if (step.variants.length === 0) {
     throw new Error(`${where}: must declare at least one variant`);
@@ -659,6 +759,31 @@ export function assertStepInvariants(id: string, step: AnyBlockStep): void {
       throw new Error(
         `${vWhere}: canonicalParamsFor() resolves to variant '${resolved}', not '${variant}'`
       );
+    }
+
+    // (5a) THE NON-VACUITY PROBE for `auditableText`, the moderation analogue of
+    // clause 8's extraction probe. `auditPromptServer` RETURNS EARLY on an empty
+    // prompt, so an entry that declares `'promptAudit'` and returns `''` would
+    // pass clause 1a, run the audit, and audit nothing — reporting success. The
+    // declaration alone is therefore not enough; it has to produce real text for
+    // params the entry itself calls canonical.
+    if (postureRequiresAuditableText(step.moderationPosture)) {
+      // 1a proved this is a function; the non-null assertion is that guard's
+      // result, not an assumption.
+      const text = step.auditableText!(parsed.data);
+      if (typeof text?.prompt !== 'string' || text.prompt.trim().length === 0) {
+        throw new Error(
+          `${vWhere}: auditableText() returned no prompt text for canonicalParamsFor() — ` +
+            'auditPromptServer returns early on an empty prompt, so this posture would ' +
+            'audit NOTHING while reporting success'
+        );
+      }
+      if (text.negativePrompt !== undefined && typeof text.negativePrompt !== 'string') {
+        throw new Error(
+          `${vWhere}: auditableText() returned a non-string negativePrompt — ` +
+            'auditPromptServer would audit a value it cannot read'
+        );
+      }
     }
 
     // (6) Per-mode budget invariant. Runs BEFORE the implemented-handler gate

--- a/src/server/services/blocks/steps/index.ts
+++ b/src/server/services/blocks/steps/index.ts
@@ -694,17 +694,27 @@ export function assertStepInvariants(id: string, step: AnyBlockStep): void {
     );
   }
 
-  // (1a) POSTURE ↔ `auditableText` AGREEMENT, both directions.
+  // (1a) POSTURE ↔ `auditableText` AGREEMENT, both directions. 🔴 THE TWO
+  // DIRECTIONS ARE NOT OF EQUAL WEIGHT, and labelling that is the point of this
+  // note — one is a control, the other is diagnostics.
   //
-  // Forward: a posture that audits free text must SAY WHERE THE TEXT IS. Without
-  // this, an entry could declare `'promptAudit'`, omit the field entirely, and
-  // register cleanly — a step that announces a moderation surface and has no
-  // handler input, i.e. a posture satisfied by auditing nothing.
+  // Forward (posture requires the field, entry omits it) — 🔴 DIAGNOSTICS ONLY,
+  // NOT A CONTROL. Do not count it among the guards that make the fail-closed
+  // property hold. Clause 5a below is gated on the IDENTICAL predicate
+  // (`postureRequiresAuditableText`), and clause 2 guarantees at least one
+  // variant, so 5a is ALWAYS reached for a `'promptAudit'` entry and rejects
+  // this same shape on its own — via a raw `TypeError: step.auditableText is not
+  // a function` out of its `step.auditableText!(...)` call. Registration fails
+  // closed with or without this branch; its entire contribution is a NAMED,
+  // actionable error in place of that TypeError. Worth keeping for exactly that,
+  // and worth being honest that a mutation removing it degrades the message
+  // rather than opening a hole.
   //
-  // Reverse: an entry that declares audit text while declaring a posture that
-  // does not audit is a CONTRADICTION its author is best placed to resolve. It
-  // reads as covered and is not: the field is never called, so the text reaches
-  // the orchestrator unaudited. Rejecting it is the fail-closed direction.
+  // Reverse (field declared under a posture that never audits) — 🔴 A GENUINE
+  // CONTROL, and the ONLY clause that catches this shape: nothing else below
+  // runs for a non-auditing posture, so without it the entry registers cleanly,
+  // reads as covered, and its text reaches the orchestrator unaudited. Rejecting
+  // is the fail-closed direction. Leave this branch exactly as it is.
   if (postureRequiresAuditableText(step.moderationPosture)) {
     if (typeof step.auditableText !== 'function') {
       throw new Error(

--- a/src/server/services/blocks/steps/moderation.ts
+++ b/src/server/services/blocks/steps/moderation.ts
@@ -1,0 +1,174 @@
+import { TRPCError } from '@trpc/server';
+import { auditPromptServer } from '~/server/services/orchestrator/promptAuditing';
+import { throwBadRequestError } from '~/server/utils/errorHandling';
+import {
+  isModerationPostureImplemented,
+  STEP_MODERATION_POSTURES,
+  type AnyBlockStep,
+  type StepModerationPosture,
+} from './index';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// MODERATION DISPATCH for the App Blocks step-type registry (`kind: 'step'`).
+//
+// 🔴 WHY THIS IS A SEPARATE MODULE FROM `./index`. Same reason `./output` is:
+// `index.ts` is imported by `workflow.schema` for the wire enum, and the wire
+// schema must stay import-light. `auditPromptServer` drags in Redis, ClickHouse,
+// the DB client and the notification service. Keeping the dispatch here means
+// declaring a posture costs the schema nothing, and only the ROUTER — which
+// already imports all of that — pays for the handler.
+//
+// 🔴 WHY THE AUDIT RUNS HERE AND NOT IN THE BLOCK. A block is untrusted,
+// sandboxed, third-party code. It can decline to call an audit, or call it and
+// ignore the verdict, and `extModeration.moderatePrompt` being fail-soft does
+// not make the call optional — fail-soft describes what happens when the
+// moderation SERVICE is unavailable, not who is allowed to skip it. An audit the
+// caller can skip is not a control. This mirrors the rule the block-token mint
+// already states for maturity: the host derives the constraint from a claim IT
+// minted and never from anything the block sends
+// (`src/pages/api/v1/block-tokens/index.ts`).
+//
+// So the handler runs SERVER-SIDE, in the step submit path, BEFORE the
+// orchestrator quote and before any spend reservation — the same position
+// `textToImage` (`blocks.router.ts`, the txt2img submit branch) and
+// `customComfy` (`submitCustomComfyWorkflow`) already put their audit in.
+//
+// 🔴 FAIL-SOFT SEMANTICS ARE `auditPromptServer`'s, NOT OURS. It already
+// swallows an `extModeration` outage internally (`.catch(… flagged: false)`) and
+// throws a BAD_REQUEST when a prompt is actually flagged. This module adds NO
+// try/catch around it: wrapping one would turn a flagged prompt into a silent
+// pass, and matching the existing kinds exactly is the requirement.
+// ─────────────────────────────────────────────────────────────────────────────
+
+export type StepModerationRequest = {
+  /** The registry entry being submitted. */
+  step: AnyBlockStep;
+  /** Params ALREADY parsed by the entry's own `.strict()` schema. */
+  params: unknown;
+  /** The token subject. */
+  userId: number;
+  /**
+   * 🔴 The prompt audit's SFW toggle. MUST come from `resolveBlockMaturity(claims)`
+   * — the token's server-minted `maxBrowsingLevel` ceiling, the same source
+   * `allowMatureContent` is derived from — never from a request body field and
+   * never a constant. A SFW-domain (green/blue) block therefore gets the stricter
+   * audit even if its own code asks otherwise.
+   */
+  isGreen: boolean;
+  /**
+   * Lazily resolves the viewer's moderator flag.
+   *
+   * A THUNK on purpose. The `'none'` path deliberately makes no
+   * `getUserById` call per submit (it had nothing to read), and a posture that
+   * does not audit must not silently re-add that round-trip. Only a handler that
+   * needs the flag pays for it, and the router keeps no per-posture branch.
+   */
+  loadIsModerator: () => Promise<boolean>;
+};
+
+type StepModerationHandler = (req: StepModerationRequest) => Promise<void>;
+
+/**
+ * The posture → handler table. TOTAL over `StepModerationPosture`; `null` means
+ * "declared, deliberately not implemented", which is a fail-closed gate rather
+ * than a missing key that would read as `undefined` at runtime.
+ */
+const moderationPostureHandlers: Record<StepModerationPosture, StepModerationHandler | null> = {
+  // Nothing to run, by construction: no free-text input, no free-text output.
+  none: async () => {
+    /* no surface */
+  },
+
+  /**
+   * The posture `textToImage` and `customComfy` already implement inline. Same
+   * function, same two text fields, same `isGreen` source, same fail-closed
+   * throw — declared by a step instead of hardcoded in a router branch.
+   */
+  promptAudit: async ({ step, params, userId, isGreen, loadIsModerator }) => {
+    const text = step.auditableText?.(params);
+
+    // 🔴 FAIL CLOSED ON "NOTHING TO AUDIT", per request.
+    //
+    // `auditPromptServer` RETURNS EARLY on an empty prompt. Passing it one would
+    // therefore be a declared moderation posture that runs, audits nothing, and
+    // reports success — indistinguishable from a clean audit at every call site.
+    // The registry's load-time probe proves the entry produces text for its
+    // CANONICAL params; this proves it for the params actually submitted, which
+    // is the only input an untrusted iframe controls.
+    if (typeof text?.prompt !== 'string' || text.prompt.trim().length === 0) {
+      throwBadRequestError(
+        `step '${step.id}' declares moderation posture '${step.moderationPosture}' but the ` +
+          'submitted params carry no auditable text — the request is rejected rather than ' +
+          'submitted unaudited'
+      );
+      return; // unreachable; `throwBadRequestError` throws. Narrows `text` below.
+    }
+
+    await auditPromptServer({
+      prompt: text.prompt,
+      negativePrompt: text.negativePrompt,
+      userId,
+      isGreen,
+      isModerator: await loadIsModerator(),
+    });
+  },
+
+  // Free-text OUTPUT. Generated text is scanned by nothing on any current path,
+  // and answering that is a content-policy decision, not a code one.
+  textOutput: null,
+};
+
+/**
+ * Cross-check that the handler table agrees with `isModerationPostureImplemented`
+ * for every declared posture.
+ *
+ * 🔴 WHY THIS EXISTS. `isModerationPostureImplemented` is what the registry's
+ * LOAD-TIME gate reads, and this table is what the REQUEST path reads. If they
+ * disagreed in one direction an entry would register cleanly and then have no
+ * handler at submit (a 500 on a spend path); in the other, a posture would be
+ * unregisterable while its handler sat there working. Asserted at module load so
+ * the drift is a build failure, not a Friday surprise.
+ *
+ * Exported over an arbitrary table so a test can mutation-prove it rather than
+ * only observing that the shipped one happens to pass.
+ */
+export function assertModerationHandlerTable(
+  table: Record<StepModerationPosture, StepModerationHandler | null>
+): void {
+  for (const posture of STEP_MODERATION_POSTURES) {
+    const hasHandler = table[posture] != null;
+    if (hasHandler !== isModerationPostureImplemented(posture)) {
+      throw new Error(
+        `block step moderation: posture '${posture}' is declared ` +
+          `${isModerationPostureImplemented(posture) ? 'IMPLEMENTED' : 'UNIMPLEMENTED'} but its ` +
+          `handler is ${hasHandler ? 'present' : 'absent'} — the registry's load-time gate and ` +
+          'the request path would disagree'
+      );
+    }
+  }
+}
+
+assertModerationHandlerTable(moderationPostureHandlers);
+
+/**
+ * Run the declared moderation posture for a step submit.
+ *
+ * Throws (TRPCError) to reject; returns normally to allow. Called by
+ * `submitStepWorkflow` BEFORE the orchestrator quote and before every spend
+ * reservation, so a rejection costs no orchestrator call and has nothing to
+ * refund.
+ */
+export async function runStepModeration(req: StepModerationRequest): Promise<void> {
+  const handler = moderationPostureHandlers[req.step.moderationPosture];
+  if (!handler) {
+    // Defense in depth: the registry's load-time gate already rejects an entry
+    // whose posture has no handler, so this is unreachable for a registered
+    // step. Kept — and kept fail-closed — because this is the seam a policy
+    // mistake would arrive through.
+    throw new TRPCError({
+      code: 'INTERNAL_SERVER_ERROR',
+      message: `step '${req.step.id}' declares an unimplemented moderation posture`,
+    });
+  }
+  await handler(req);
+}

--- a/src/server/services/blocks/steps/moderation.ts
+++ b/src/server/services/blocks/steps/moderation.ts
@@ -72,51 +72,101 @@ type StepModerationHandler = (req: StepModerationRequest) => Promise<void>;
  * The posture → handler table. TOTAL over `StepModerationPosture`; `null` means
  * "declared, deliberately not implemented", which is a fail-closed gate rather
  * than a missing key that would read as `undefined` at runtime.
+ *
+ * 🔴 NULL PROTOTYPE, AND THAT IS A CONTROL RATHER THAN A STYLE CHOICE. A plain
+ * object literal inherits from `Object.prototype`, so indexing it with an
+ * arbitrary string falls through: `handlers['toString']` returns
+ * `Object.prototype.toString` — TRUTHY — which makes the `!handler` guard in
+ * `runStepModeration` below evaluate `false`, lets `await handler(req)` resolve,
+ * and returns from the whole submit path HAVING AUDITED NOTHING AND THROWN
+ * NOTHING. The one guard whose job is to fail closed on an unimplemented posture
+ * would fail OPEN, for the exact key an attacker would reach for. The registry's
+ * load-time gate makes that unreachable for a REGISTERED step today, but this
+ * seam exists precisely for the day the posture value stops coming from a
+ * code-reviewed literal (a DB column, a manifest field) — and defence in depth
+ * that inverts under a chosen input is worse than none. With a null prototype
+ * every non-own key reads `undefined` and the guard fails closed. It also covers
+ * `assertModerationHandlerTable`, which walks the same table.
+ *
+ * `satisfies` (in addition to the annotation) is what keeps the literal TOTAL
+ * over the posture union — a missing posture is exactly the drift this table
+ * exists to make impossible. Verified by typecheck mutation rather than assumed:
+ * deleting `textOutput` from the literal WITH `satisfies` present is a `TS1360`
+ * build error; deleting `satisfies` as well makes that error disappear, because
+ * `Object.assign`'s inferred result type absorbs the shortfall and the
+ * annotation alone does not reject it (it also costs the handlers their
+ * contextual typing — 5×`TS7031`).
  */
-const moderationPostureHandlers: Record<StepModerationPosture, StepModerationHandler | null> = {
-  // Nothing to run, by construction: no free-text input, no free-text output.
-  none: async () => {
-    /* no surface */
-  },
+const moderationPostureHandlers: Record<StepModerationPosture, StepModerationHandler | null> =
+  Object.assign(
+    Object.create(null) as Record<StepModerationPosture, StepModerationHandler | null>,
+    {
+      // Nothing to run, by construction: no free-text input, no free-text output.
+      none: async () => {
+        /* no surface */
+      },
 
-  /**
-   * The posture `textToImage` and `customComfy` already implement inline. Same
-   * function, same two text fields, same `isGreen` source, same fail-closed
-   * throw — declared by a step instead of hardcoded in a router branch.
-   */
-  promptAudit: async ({ step, params, userId, isGreen, loadIsModerator }) => {
-    const text = step.auditableText?.(params);
+      /**
+       * The posture `textToImage` and `customComfy` already implement inline. Same
+       * function, same two text fields, same `isGreen` source, same fail-closed
+       * throw — declared by a step instead of hardcoded in a router branch.
+       */
+      promptAudit: async ({ step, params, userId, isGreen, loadIsModerator }) => {
+        const text = step.auditableText?.(params);
 
-    // 🔴 FAIL CLOSED ON "NOTHING TO AUDIT", per request.
-    //
-    // `auditPromptServer` RETURNS EARLY on an empty prompt. Passing it one would
-    // therefore be a declared moderation posture that runs, audits nothing, and
-    // reports success — indistinguishable from a clean audit at every call site.
-    // The registry's load-time probe proves the entry produces text for its
-    // CANONICAL params; this proves it for the params actually submitted, which
-    // is the only input an untrusted iframe controls.
-    if (typeof text?.prompt !== 'string' || text.prompt.trim().length === 0) {
-      throwBadRequestError(
-        `step '${step.id}' declares moderation posture '${step.moderationPosture}' but the ` +
-          'submitted params carry no auditable text — the request is rejected rather than ' +
-          'submitted unaudited'
-      );
-      return; // unreachable; `throwBadRequestError` throws. Narrows `text` below.
-    }
+        // 🔴 FAIL CLOSED ON "NOTHING TO AUDIT", per request.
+        //
+        // `auditPromptServer` RETURNS EARLY on an empty prompt. Passing it one would
+        // therefore be a declared moderation posture that runs, audits nothing, and
+        // reports success — indistinguishable from a clean audit at every call site.
+        // The registry's load-time probe proves the entry produces text for its
+        // CANONICAL params; this proves it for the params actually submitted, which
+        // is the only input an untrusted iframe controls.
+        if (typeof text?.prompt !== 'string' || text.prompt.trim().length === 0) {
+          throwBadRequestError(
+            `step '${step.id}' declares moderation posture '${step.moderationPosture}' but the ` +
+              'submitted params carry no auditable text — the request is rejected rather than ' +
+              'submitted unaudited'
+          );
+          return; // unreachable; `throwBadRequestError` throws. Narrows `text` below.
+        }
 
-    await auditPromptServer({
-      prompt: text.prompt,
-      negativePrompt: text.negativePrompt,
-      userId,
-      isGreen,
-      isModerator: await loadIsModerator(),
-    });
-  },
+        // 🔴 FAIL CLOSED ON A NON-STRING `negativePrompt`, mirroring the load-time
+        // check in `./index` clause 5a on the params actually submitted. Load time
+        // proves the shape for CANONICAL params only; an entry carrying a lying
+        // `as unknown as string` cast satisfies neither the compiler nor that probe
+        // and would otherwise reach the audit unchecked.
+        //
+        // 🔴 WHY THIS CANNOT BE LEFT TO `auditPromptServer` TO NOTICE. A non-string
+        // reaches `stripBenignPhrases` and throws `text.replace is not a function`
+        // INSIDE that function's own try block. Its catch treats the throw as a
+        // moderation hit: on the non-green path it writes a `BlockedPromptEntry` and
+        // increments the auto-mute counter before rethrowing "Your prompt was
+        // flagged". So the failure mode is not a 500 a reviewer would notice — it is
+        // innocent users accruing mute-counter hits on every submit because of a
+        // registry-entry bug.
+        if (text.negativePrompt !== undefined && typeof text.negativePrompt !== 'string') {
+          throwBadRequestError(
+            `step '${step.id}' declares moderation posture '${step.moderationPosture}' but the ` +
+              'submitted params produced a non-string negativePrompt — the request is rejected ' +
+              'rather than audited with a value auditPromptServer cannot read'
+          );
+        }
 
-  // Free-text OUTPUT. Generated text is scanned by nothing on any current path,
-  // and answering that is a content-policy decision, not a code one.
-  textOutput: null,
-};
+        await auditPromptServer({
+          prompt: text.prompt,
+          negativePrompt: text.negativePrompt,
+          userId,
+          isGreen,
+          isModerator: await loadIsModerator(),
+        });
+      },
+
+      // Free-text OUTPUT. Generated text is scanned by nothing on any current path,
+      // and answering that is a content-policy decision, not a code one.
+      textOutput: null,
+    } satisfies Record<StepModerationPosture, StepModerationHandler | null>
+  );
 
 /**
  * Cross-check that the handler table agrees with `isModerationPostureImplemented`


### PR DESCRIPTION
Implements the `'promptAudit'` moderation posture in the App Blocks step-type registry, so a step with free-text input can be registered. **It registers no step.** `chatCompletion` stays out of scope — that needs its own allowlist, param schema and token-metered billing work.

Refs #3527, #3515, #3538.

## Why this is unblocked

#3538 made `moderationPosture` required and left only `'none'` implemented, so any other value threw at registry load. That was deliberate: it forced the policy question into code rather than letting it be skipped.

The free-text **input** half of that question is answered. Mature content is permitted for App Blocks, and it already was — the block token carries a maturity ceiling minted from the request host (green/blue → SFW ceiling, red-capable host → full mature ceiling, unknown/missing host → fail closed to SFW; `src/pages/api/v1/block-tokens/index.ts`). The submit path derives `allowMatureContent` from that claim and never from a client body field. So a free-text input does not need a new policy; it needs the prompt audit `textToImage` and `customComfy` already run.

The free-text **output** half is not answered here. `'textOutput'` still fails at registry load.

## What changed

| | |
|---|---|
| Posture value | `'promptAudit'` — the value #3538 already declared, documented as "what `textToImage` / `customComfy` do" |
| Handler | `runStepModeration` in the new leaf module `src/server/services/blocks/steps/moderation.ts`, which calls `auditPromptServer` |
| Where it runs | `submitStepWorkflow` (`blocks.router.ts`), after `resolveBlockMaturity(claims)`, **before** the orchestrator `whatif` quote and before every spend reservation |

`'promptAudit'` was chosen over a new synonym because #3538 already declared it for exactly this handler. Two names for one behaviour in a code-reviewed trust root is worse than reusing the one that is already there. `moderationPosture` is internal to the registry — it is not on the wire — so there is no compatibility cost either way.

### Placement is host-side, and that is load-bearing

The audit does **not** live on the block side. A block is untrusted, sandboxed, third-party code: it can decline to call an audit, or call it and ignore the result. An audit the caller can skip is not a control. `extModeration.moderatePrompt` being fail-soft describes what happens when the moderation *service* is unavailable — it does not make the call optional.

This mirrors what the token-mint code already states for maturity: the host derives the constraint from a claim it minted, never from anything the block sends.

Fail-soft semantics are `auditPromptServer`'s own and are unchanged — it swallows an `extModeration` outage internally and throws BAD_REQUEST on a flagged prompt. No try/catch is added around it; a test asserts a flagged prompt propagates.

### Separate module, not the registry

`services/blocks/steps/index.ts` is imported by `workflow.schema.ts` for the wire enum and must stay import-light; `auditPromptServer` pulls Redis, ClickHouse, the DB client and the notification service. Same reasoning that put `mediaFromBlobs` in `./output`. `index.ts` declares which postures are implemented; `moderation.ts` asserts **at its own module load** that its handler table agrees with that declaration, so the load-time gate and the request path cannot drift.

### How "audits nothing" was made impossible

A step's params are arbitrary — there is no universal `prompt` field, and sniffing string-valued fields would audit a Civitai image URL while missing `messages[].content`. So the entry **declares** its user text:

```ts
auditableText?(params: P): { prompt: string; negativePrompt?: string };
```

Required iff the posture audits, forbidden otherwise — the same "make the shape explicit rather than inferred" move as `canonicalOutputFor`. The two returned fields are exactly what `textToImage` / `customComfy` pass, so the posture runs the same audit with the same inputs. An entry with several user-text params joins them itself, in its own file, where a reviewer can see which params are covered.

`auditPromptServer` **returns early on an empty prompt** (`if (!prompt || !prompt.trim()) return;`), so `() => ({ prompt: '' })` would be a declared posture that runs, audits nothing and reports success — the same defect class as an `extractOutput` satisfiable by `() => []`, which #3538 had to fix with a probe. Closed in both places:

1. **Registry load** — for every variant, `auditableText(canonicalParamsFor(variant))` must return a non-empty *trimmed* prompt (`clause 5a`). An entry declaring the posture with no auditable text fails at load.
2. **Request time** — the handler rejects an empty/whitespace prompt as BAD_REQUEST rather than calling the audit, because the canonical-params probe says nothing about the params an untrusted iframe actually sent.

**Honest limit, stated so nobody over-trusts it:** this proves an entry audits *something*, not *everything*. Nothing structural can know which of an arbitrary param object's strings are user-authored. Coverage rests on the same thing `resourcePolicy` rests on — a required, reviewed declaration in a code-reviewed trust root.

### `isGreen`

Derived from `resolveBlockMaturity(claims).isGreen` — the token's server-minted `maxBrowsingLevel` ceiling, the same source `allowMatureContent` uses. Not a body field, not a constant, not `ctx.domain`. This is byte-identical to the derivation at the two existing call sites (`blocks.router.ts` txt2img submit and `submitCustomComfyWorkflow`), which both read the same destructure. Verified by test at four points: green+SFW → `true`, blue+SFW → `true`, red+mature → `false`, legacy token with no claim → `true` (fail closed).

`isModerator` is passed as a thunk, so the `'none'` path keeps the property #3538 gave it — no `getUserById` round-trip per submit — while an auditing posture still gets the real value.

---

## 🔴 Text output is scanned by nothing

Recording this rather than assuming it is covered. Prompts are audited (this PR, and the two existing kinds) and images are orchestrator-scanned. **Generated text has no scan on any path.** The exposure is small — a step's text output is ephemeral, returned in the workflow snapshot rather than persisted as Civitai content — but it is unscanned, and `'textOutput'` remains unimplemented precisely because that is an open content-policy question, not a code one.

---

## Verification

### Mutation table

Every mutation was applied to a single exact occurrence, run, and reverted with a sha256 equality assertion. All 17 die.

| # | Mutation | Test that failed | Exact assertion text |
|---|---|---|---|
| M1 | delete the `auditPromptServer(...)` call in the handler | `step moderation … > runs auditPromptServer with the entry-declared text` (+11 more) | `expected "vi.fn()" to be called 1 times, but got 0 times` |
| M2 | delete `await runStepModeration({...})` from `submitStepWorkflow` | `submitWorkflow — moderation posture 'promptAudit' > runs auditPromptServer host-side with the SUBMITTED text` (+5) | `expected "vi.fn()" to be called 1 times, but got 0 times` |
| M3 | router passes `isGreen: true` (hardcoded) | `… derives isGreen from the TOKEN maturity claim — red domain, mature ceiling` | `expected true to be false // Object.is equality` |
| M4 | router passes `isGreen: false` (hardcoded) | `… green domain / blue domain / legacy token` (+the arg-shape test) | `expected false to be true // Object.is equality` |
| M5 | handler hardcodes `isGreen: true` | `… PASSES THROUGH isGreen in both directions — it is never a constant` | `expected true to be false // Object.is equality` |
| M6 | drop the request-time empty-text guard | `… REJECTS an empty string / whitespace only as unauditable` | `promise resolved "undefined" instead of rejecting` |
| M7 | request-time guard loses `.trim()` | `… REJECTS whitespace only as unauditable` | `promise resolved "undefined" instead of rejecting` |
| M8 | drop the `textOutput` fail-closed throw | `… the unimplemented 'textOutput' posture FAILS CLOSED with a named error` | `expected TypeError: handler is not a function to match object { code: 'INTERNAL_SERVER_ERROR', …(1) }` |
| M9 | handler-table cross-check loops over nothing | `… rejects an IMPLEMENTED posture whose handler is absent` (+2) | `expected [Function] to throw an error` |
| M10 | drop clause 1a forward (`auditableText` must be declared) — **⚠️ NOT A CONTROL, see below; listed for completeness only** | `… rejects a 'promptAudit' entry that declares NO auditableText` | `expected [Function] to throw error matching /moderationPosture 'promptAudit' requi…/ but got 'step.auditableText is not a function'` |
| M11 | drop clause 1a reverse (`auditableText` under a non-auditing posture) | `… rejects an entry that declares auditableText under a posture that never audits it` | `expected [Function] to throw an error` |
| M12 | drop clause 5a (the non-vacuity probe) | `… rejects auditableText that returns an EMPTY prompt / WHITESPACE / omits prompt entirely` | `expected [Function] to throw an error` |
| M13 | clause 5a loses `.trim()` | `… rejects auditableText that returns WHITESPACE` | `expected [Function] to throw an error` |
| M14 | drop clause 5a's `negativePrompt` type check | `… rejects a non-string negativePrompt` | `expected [Function] to throw an error` |
| M15 | `isModerationPostureImplemented` reverts to `'none'` only | `free-text INPUT is implemented; free-text OUTPUT still is not` (+6) | `expected false to be true // Object.is equality` |
| M16 | `postureRequiresAuditableText` always returns false | `the promptAudit fixture PASSES unmutated` (+5) | `expected [Function] to not throw an error but 'Error: block step \'fixture-step\': d…' was thrown` |
| M17 | handler hardcodes `isModerator: false` | `… resolves isModerator through the caller-supplied thunk` | `expected "vi.fn()" to be called 1 times, but got 0 times` |

**Two mutants die to a NEIGHBOUR's error, disclosed rather than counted as clean kills:**

- **M10 — 🔴 clause 1a-forward is DIAGNOSTICS, not a control, and must not be counted among the guards that make the fail-closed property hold.** Clause 5a is gated on the *identical* predicate (`postureRequiresAuditableText`) and clause 2 guarantees ≥1 variant, so 5a is ALWAYS reached for a `'promptAudit'` entry and rejects the same shape on its own — via a raw `TypeError: step.auditableText is not a function` from its `step.auditableText!(...)` call. Registration fails closed with or without 1a's forward branch; its entire contribution is a *named, actionable* error in place of that `TypeError`. The mutation is listed because it was run, not because it kills. The code now says so in a comment. (The **reverse** branch — `auditableText` declared under a non-auditing posture, M11 — *is* a genuine control: nothing else runs for a non-auditing posture, so without it the text reaches the orchestrator unaudited. It is unchanged.)
- **M8.** With the `!handler` throw disabled, `await handler(req)` throws `TypeError: handler is not a function`. Fail-closed either way; the guard's contribution is the named 500 instead of `undefined is not a function`.

**Reachability.** Each new guard is reached by an input no earlier clause rejects. A valid `'promptAudit'` fixture is asserted to pass `assertStepInvariants` **unmutated** (`the promptAudit fixture PASSES unmutated — every failure below is the mutation`), so every mutation below it provably dies to the clause its assertion names rather than to an earlier clause rejecting the whole shape.

### A test whose condition could not vary, and what was done about it

No shipped entry declares `'promptAudit'` (Tranche 1 is `convert-image`, posture `'none'`), so the router branch is unreachable over the real population. A router test written against the real registry could only assert "nothing audits" — green whatever the router does.

So the router tests inject a `'promptAudit'` fixture entry through a pass-through mock of `~/server/services/blocks/steps` that widens only `REGISTERED_STEP_IDS` and `getStep`. The real router code runs. The fixture is itself put through `assertStepInvariants` inside the mock factory, so it is a shape the registry would actually accept. Evidence the widening perturbs nothing else: all 297 pre-existing tests in that file still pass, by name.

**One test is labelled an INVARIANT GUARD, not regression coverage:** `every registered entry agrees with the posture ↔ auditableText rule` iterates the shipped population, where every entry is `'none'`, so its `'promptAudit'` branch cannot currently execute. It becomes real coverage the day such an entry is registered. The guard's evidence lives in the fixture mutations above.

### No behaviour change to `textToImage` / `customComfy`

Proven by comparing serialized results over a population rather than by reading the diff. A throwaway harness (not committed) drove both kinds through `estimateWorkflow` and `submitWorkflow` over **240 cases** — 5 maturity/domain settings × 4 `accountType` picks × 4 prompts × 2 procedures for txt2img, and 5 × 2 engines × 4 prompts × 2 procedures for customComfy — and serialized every argument that reached `auditPromptServer` (**100 calls**) and the orchestrator `submitWorkflow` (**240 calls**), plus each call's result or error code.

Run in a clean `origin/main` worktree and in this branch's worktree from a byte-identical harness file:

- Raw diff: 280 changed lines, all in two nondeterministic fields — the server-minted idempotency `externalId` UUID (120 lines) and the generation graph's random `seed` (160 lines).
- After normalizing those two: **byte-identical**, sha256 `cc6ba09d06492fd2…` on both sides.
- **Negative control** (the harness is not vacuous): flipping a single token in the *existing* txt2img audit call (`isGreen` → `isGreen: false`) at head produced **96 differing lines** against base.

### Counts

| | base (`origin/main`) | head | delta |
|---|---|---|---|
| `steps/__tests__/` + `schema/blocks/__tests__/workflow.schema.step` | 2 files / 51 tests | 3 files / 75 tests | +1 file / +24 |
| `blocks.router.workflow.test.ts` | 1 file / 297 tests | 1 file / 306 tests | +9, all 297 preserved by name |
| broad sweep (`services/blocks`, `routers/__tests__`, `schema/blocks`) | 149 files / 3272 passed | 150 files / 3305 passed | +1 file / +33, 0 failures |

Counted from `--reporter=verbose` `✓`/`×` lines, not from an exit code. No `test timed out` panic in any run. The broad sweep exits 1 at **both** base and head from one pre-existing unhandled `PrismaClientInitializationError` (the known NixOS query-engine issue); it is identical on both sides.

### tsc / eslint / prettier

- `tsc --noEmit` (repo-local 5.9.2, `NODE_OPTIONS=--max_old_space_size=8192`): **0 errors at base, 0 at head**. Verified the new module is actually typechecked by a negative control — injecting `const __probe: number = handler;` produced `moderation.ts(164,9): error TS2322`.
- `tsconfig.json` excludes `src/**/__tests__/**`, so CI does not typecheck test files. Ran a config that includes them: **560 pre-existing errors at base, 560 at head, identical error sets**. The first pass introduced 2 `TS2352` in the new test code (the exact class flagged as having shipped to CI before); both fixed with `as unknown as`.
- `eslint` on the 6 changed files: **16 errors at base, 16 at head**, all pre-existing in `blocks.router.workflow.test.ts` (`no-explicit-any`, one `consistent-type-imports`). The first pass added one new `consistent-type-imports` error; fixed with a type-only namespace import.
- `prettier --list-different`: `blocks.router.ts` and `blocks.router.workflow.test.ts` are listed at **base and head alike** (43 and 60 pre-existing formatting objections, content-identical on both sides — 0 new). The new files are clean.

### Follow-up commit — two fail-open seams in this PR's own code (`c299364f`)

Both were found after the audit, both are in code this PR adds, and neither is
reachable over the real population today (no registered step declares
`'promptAudit'`) — which is why they were fixes rather than blockers. Both sit in
guards that exist to fail closed, and both failed OPEN in the case they were
written for.

**Fix 1 — the handler lookup silently ALLOWED on a prototype key.**
`moderationPostureHandlers` was a plain object literal, so
`moderationPostureHandlers[req.step.moderationPosture]` fell through to
`Object.prototype`. Verified by execution: with `moderationPosture: 'toString'`
the lookup returned `Object.prototype.toString` — **truthy** — so `!handler` was
`false`, `await handler(req)` **resolved**, and `runStepModeration` returned
cleanly **having audited nothing and thrown nothing**. `'constructor'` behaves
the same way (`Object(req)` returns `req`). Fixed with
`Object.assign(Object.create(null), {…} satisfies Record<…>)`: every non-own key
now reads `undefined` and the guard fails closed, and the null prototype also
covers `assertModerationHandlerTable`, which walks the same table. The
`satisfies` is load-bearing and was verified by typecheck mutation — dropping a
posture from the literal is `TS1360` with it, and **not an error** without it.

**Fix 2 — `negativePrompt`'s type was checked at load but not at request time.**
`index.ts:781` (clause 5a) checks it against *canonical* params; the request-time
guard checked only `text.prompt`. A non-string `negativePrompt` — from an entry
carrying a lying `as unknown as string` cast — reaches `stripBenignPhrases` and
throws `text.replace is not a function` **inside `auditPromptServer`'s own try**
(`promptAuditing.ts:291-294`). The catch at `:339` treats that as a moderation
hit and, on the non-green path, **writes a `BlockedPromptEntry` and increments
the auto-mute counter** (`:368-383`) before rethrowing a bogus "Your prompt was
flagged". The failure mode is not a visible 500 — it is innocent users taking
mute-counter hits on every submit. The handler now rejects BAD_REQUEST before
`auditPromptServer` is called, matching clause 5a.

**Fix 3 — clause 1a-forward relabelled** (comment only; 28 changed lines in
`index.ts`, **all** of them comment lines, zero executable change). See the M10
note above.

#### Mutation table for the follow-up — each dies to its OWN guard's assertion

| Mutation | Test that failed | Exact assertion text |
|---|---|---|
| table reverted to a plain object literal | `FAILS CLOSED on the Object.prototype key 'toString'` and `… 'constructor'` | `promise resolved "undefined" instead of rejecting` |
| drop the request-time `negativePrompt` guard | `REJECTS a number / an object / null as negativePrompt BEFORE auditPromptServer is called` (×3) | `auditPromptServer must not be reached with a negativePrompt it cannot read — its internal catch would record a BlockedPromptEntry and bump the auto-mute counter: expected "vi.fn()" to not be called at all, but actually been called 1 times` |

**Disclosed rather than counted as clean kills.** The first mutation also fails
the `'valueOf'` / `'hasOwnProperty'` / `'__proto__'` cases, but those die to a
raw `TypeError` from JavaScript (`Object.prototype.valueOf` invoked with `this
=== undefined`; `Object.prototype` being non-callable) rather than to this
guard's named error. They are kept in a **separate, separately-labelled**
`it.each` for exactly that reason — only `'toString'` and `'constructor'`
demonstrate the silent allow.

#### No behaviour change to `textToImage` / `customComfy`, re-proven for this commit

Same method as above, over the repo's own matrix rather than a bespoke one: a
temporary (uncommitted) recorder serialized **every** argument reaching
`auditPromptServer` (**144 calls**) and the orchestrator `submitWorkflow`
(**287 calls**) across all **306** `blocks.router.workflow` tests, at `b897575c`
and at `c299364f`.

- Raw diff: **312 changed lines**, and a key census shows they are *only*
  `externalId` (240), `seed` (68) and `noise_seed` (4) — the nondeterministic
  fields, nothing else.
- After normalizing those three: **0 changed lines, byte-identical**, sha256
  `d6e2c7408230aeed9ad1b76083ec10289c68d26087612480534e0a5edbedc477` on both
  sides.
- **Negative control** (the harness is not vacuous): flipping `isGreen` →
  `isGreen: false` in the **live txt2img** audit call, measured the same way
  (normalized, vs the same normalized base), produced **210 changed lines** and
  one test failure — against **0** for this commit.

Independently, `index.ts`'s diff is **28 changed lines, all comment lines** —
so Fix 3 cannot change behaviour at all, and `moderation.ts` is reachable only
from `submitStepWorkflow`.

#### Counts, tsc, eslint, prettier for the follow-up

| | `b897575c` | `c299364f` | delta |
|---|---|---|---|
| `steps/__tests__/` + `blocks.router.workflow` + `schema/blocks/__tests__/` | 12 files / 565 passed | 12 files / 574 passed | **+9**, 0 failures and 0 collection failures on both sides |
| `step-moderation.test.ts` alone | 16 | 25 | +9 |
| `step-registry.test.ts` / `blocks.router.workflow.test.ts` | 50 / 306 | 50 / 306 | unchanged |

Counted from `--reporter=verbose` `✓`/`×` lines and file counts, not exit codes;
no `test timed out` panic in any run. **File count checked on every run** —
drifting this handler table makes `step-moderation.test.ts` fail to *collect*
via the module-load assert, which reports as a green-looking suite with zero
tests.

- `tsc --noEmit` (repo-local 5.9.2): **0 errors at both** revisions.
- Test-inclusive tsconfig (CI excludes `src/**/__tests__/**`): **560 errors at
  both**, and the sorted error *sets* are identical (`diff` = 0 lines).
- `eslint` and `prettier --list-different` on all three changed files:
  **0 and 0 at both** revisions.

### Not verified

- **No live orchestrator call.** No registered entry declares this posture, so there is nothing to submit end-to-end. Everything here is mocked at the module boundary.
- **`auditPromptServer` internals are unchanged and untested here.** Its fail-soft behaviour is exercised only through a mock; this PR asserts the handler adds no catch of its own, not that the underlying function behaves as documented.
- **Coverage of an entry's user text is a review property, not a proven one** — see the honest limit above.

---

## 🔴 GATE FOR THE PR THAT REGISTERS THE FIRST `'promptAudit'` ENTRY

Recorded here so it is not lost. These are **out of scope for this PR**, which
registers no step and therefore cannot exercise them — but they are a **hard
gate on the PR that registers the first entry declaring this posture**, and that
PR must not be merged until both are closed.

- **🟡-1 — `auditableText` need not depend on the params it claims to audit.**
  Nothing structural forces the returned `prompt` to be derived from the
  submitted params. `auditableText: () => ({ prompt: 'x' })` passes clause 5a's
  non-vacuity probe *and* the request-time guard, runs the audit, and audits a
  constant — the "audits nothing" hole reopened one level up. The probe proves
  the entry produces text, not that the text is the *user's* text.
- **🟡-2 — silent widening when a new free-text param is added.** An entry's
  `auditableText` names the params it covers *at the time it was written*.
  Adding a new user-text param later, without extending `auditableText`, leaves
  that param unaudited and every existing guard still green. Nothing fails; the
  coverage just silently narrows.

Both are the same limit the body already states honestly ("this proves an entry
audits *something*, not *everything*"), made concrete. The registering PR needs
a real answer — a differential probe over varied params, a per-param declaration
the schema enforces, or an explicit reviewed opt-out per param — not a restated
disclaimer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

