### PR TITLE
feat(apps): store card matches the site's card chrome + type scale (S4/S5), one glyph source (S6b)

### DIFF
--- a/src/components/Apps/AppListingCard.browser.test.tsx
+++ b/src/components/Apps/AppListingCard.browser.test.tsx
@@ -94,11 +94,17 @@ function base(over: Partial<ListingCard>): ListingCard {
  * `width` is the OUTER box. `Card padding="md"` eats 2x16, so the content box —
  * the number the layout measurements below are about — is `width - 32`.
  *
- * 🔴 It was `width - 34` until S4 dropped `withBorder`: the border was 0.877px a
- * side (~1.75px total), so every content box below RECLAIMED ~2px and the exact
- * pins moved 280 -> 282 and 246 -> 248. That is the border removal being real and
- * measurable, not a tolerance drift — and the arithmetic is now exact rather than
- * fractional. If these numbers ever move back, the border came back.
+ * 🔴 It was `width - 34` until S4 dropped `withBorder`, so every content box below
+ * RECLAIMED 2px and the exact pins moved 280 -> 282 and 246 -> 248. That is the
+ * border removal being real and measurable, not a tolerance drift; if these
+ * numbers ever move back, the border came back. Proven by isolation: restoring
+ * ONLY `withBorder` reproduces 280/246 exactly, and reverting ONLY the title
+ * (`Text` -> `Title`) leaves both pins green.
+ *
+ * ⚠️ In THIS environment the border is exactly 1px a side (Mantine's
+ * `calc(0.0625rem * var(--mantine-scale))` with `scale` unset and a 16px root),
+ * so `width - 34` was exact arithmetic, not fractional. The 0.877px figure comes
+ * from PROD, where the scale differs — do not use it to reason about these pins.
  *
  * The two widths used below, both measured through the real
  * `AppsPageLayout` + `Grid` rather than assumed:
@@ -240,14 +246,21 @@ describe('AppListingCard', () => {
 
   // ── Card chrome, typography + CTA glyph (S4 / S5 / S6b) ────────────────────
   //
-  // Markers are Mantine's own DOM output, which is deterministic here:
-  // `withBorder` renders as a `data-with-border` ATTRIBUTE, and `shadow` / `size`
-  // / `fw` / `c` render as `--paper-shadow` / `--text-fz` / `--text-fw` /
-  // `--text-color` custom properties in the element's `style`.
+  // Markers are Mantine's own DOM output, verified against what it ACTUALLY emits
+  // rather than assumed:
+  //   withBorder -> a `data-with-border` ATTRIBUTE
+  //   shadow     -> a `--paper-shadow` custom property
+  //   size       -> a `--text-fz` custom property
+  //   fw / c     -> PLAIN `font-weight:` / `color:` declarations
+  // 🔴 `fw` and `c` are the trap: they do NOT become `--text-fw` / `--text-color`.
+  // Asserting those fails against a perfectly correct component, which is exactly
+  // how this suite burned a debugging cycle.
   //
-  // 🔴 Deliberately NOT asserting resolved `rgb()` values: the theme CSS is not
-  // loaded in this environment, so such an assertion either fails or passes for
-  // the wrong reason. The pixel values live in the PR's measurement table.
+  // 🔴 Not asserting resolved brand `rgb()` values: Mantine's stylesheets ARE
+  // loaded here (`assertLayoutIsReal` depends on them), but ThemeProvider's
+  // CSS-variable overrides are not — so `--mantine-color-white` resolves to
+  // rgb(255,255,255) here and #fefefe in the app. Geometry (px) is trustworthy;
+  // brand colours are not. The pixel/contrast values live in the PR's table.
 
   const cardRoot = () => document.querySelector('[class*="Card-root"]') as HTMLElement | null;
 
@@ -288,8 +301,19 @@ describe('AppListingCard', () => {
     expect(root!.hasAttribute('data-with-border')).toBe(false);
     // `shadow="sm"` is gone → no `--paper-shadow` is declared at all.
     expect(root!.getAttribute('style') ?? '').not.toContain('--paper-shadow');
-    // Radius comes from the shared Tailwind scale (6px), NOT Mantine's `md` (8px).
-    expect(root!.className).toContain('rounded-md');
+    // 🔴 Assert the COMPUTED radius, not the className the JSX just wrote back to
+    // us. `radius={0}` makes Mantine emit `--paper-radius: 0rem`, and Tailwind's
+    // `.rounded-md` only wins because Mantine's sheet is inside `@layer mantine`
+    // while Tailwind utilities are deliberately unlayered (`globals.css`). If that
+    // layer ordering ever regresses, the card renders SQUARE — and a className
+    // assertion would still be green.
+    // 🔴 No `className).toContain('rounded-md')` echo here on purpose: it asserts
+    // the string the JSX just wrote, it cannot detect the square-card failure
+    // above, and — being ordered first — it would SHADOW the computed assertion
+    // that can. An earlier check that always wins makes the later one untestable.
+    expect(getComputedStyle(root!).borderRadius).toBe('6px');
+    expect(getComputedStyle(root!).borderTopWidth).toBe('0px');
+    expect(getComputedStyle(root!).boxShadow).toBe('none');
   });
 
   test('🔴 S5: the title is xl/700/white — and is no longer a heading', async () => {
@@ -308,6 +332,12 @@ describe('AppListingCard', () => {
     expect(style).toContain('--text-fz: var(--mantine-font-size-xl)');
     expect(style).toContain('font-weight: 700');
     expect(style).toContain('color: var(--mantine-color-white)');
+    // 🔴 `lh={1.2}` is load-bearing and easy to delete by accident: without it the
+    // title inherits `--mantine-line-height-xl` (1.65), which at 20px is 33px vs
+    // 24px — a ~14px card-height swing across a 2-line clamp, and card height is
+    // exactly what the deferred S7 work is about.
+    expect(style).toContain('line-height: 1.2');
+    expect(getComputedStyle(title).lineHeight).toBe('24px');
     // Declared side effect: the card title is a <Text>, not an <h4>. This is
     // parity with `/models` (whose card title is a <p>), not an a11y regression —
     // asserted so the change is visible rather than discovered later.

--- a/src/components/Apps/AppListingCard.browser.test.tsx
+++ b/src/components/Apps/AppListingCard.browser.test.tsx
@@ -91,15 +91,20 @@ function base(over: Partial<ListingCard>): ListingCard {
 /**
  * Render a card inside a fixed-width box.
  *
- * `width` is the OUTER box. `Card padding="md" withBorder` eats 2x16 + 2x1, so
- * the content box — the number the layout measurements below are about — is
- * `width - 34`.
+ * `width` is the OUTER box. `Card padding="md"` eats 2x16, so the content box —
+ * the number the layout measurements below are about — is `width - 32`.
+ *
+ * 🔴 It was `width - 34` until S4 dropped `withBorder`: the border was 0.877px a
+ * side (~1.75px total), so every content box below RECLAIMED ~2px and the exact
+ * pins moved 280 -> 282 and 246 -> 248. That is the border removal being real and
+ * measurable, not a tolerance drift — and the arithmetic is now exact rather than
+ * fractional. If these numbers ever move back, the border came back.
  *
  * The two widths used below, both measured through the real
  * `AppsPageLayout` + `Grid` rather than assumed:
- *   - `280` -> a 246px content box = the TRUE 1200px-viewport geometry
- *     (container 1200 -> column 296 -> card 280 -> row 246);
- *   - `314` -> a 280px content box, i.e. roughly a 1345 viewport. "280" in the
+ *   - `280` -> a 248px content box = the TRUE 1200px-viewport geometry
+ *     (container 1200 -> column 296 -> card 280 -> row 248);
+ *   - `314` -> a 282px content box, i.e. roughly a 1345 viewport. "280" in the
  *     original bug report is the CARD width at 1200, not its content box.
  */
 function Sized({ width, card }: { width: number; card: ListingCard }) {
@@ -231,6 +236,132 @@ describe('AppListingCard', () => {
     renderWithProviders(<AppListingCard card={base({})} canOpenPage={false} />);
     const details = page.getByRole('link', { name: 'View details' });
     await expect.element(details).toHaveAttribute('href', '/apps/store-preview/my-app');
+  });
+
+  // ── Card chrome, typography + CTA glyph (S4 / S5 / S6b) ────────────────────
+  //
+  // Markers are Mantine's own DOM output, which is deterministic here:
+  // `withBorder` renders as a `data-with-border` ATTRIBUTE, and `shadow` / `size`
+  // / `fw` / `c` render as `--paper-shadow` / `--text-fz` / `--text-fw` /
+  // `--text-color` custom properties in the element's `style`.
+  //
+  // 🔴 Deliberately NOT asserting resolved `rgb()` values: the theme CSS is not
+  // loaded in this environment, so such an assertion either fails or passes for
+  // the wrong reason. The pixel values live in the PR's measurement table.
+
+  const cardRoot = () => document.querySelector('[class*="Card-root"]') as HTMLElement | null;
+
+  /** The `tabler-icon-*` modifier on a CTA's glyph, e.g. `player-play`. */
+  function ctaGlyph(link: Element): string {
+    const svg = link.querySelector('svg');
+    if (!svg) throw new Error('CTA rendered no glyph at all');
+    const mod = Array.from(svg.classList).find(
+      (c) => c.startsWith('tabler-icon-') && c !== 'tabler-icon'
+    );
+    if (!mod) throw new Error(`glyph carried no tabler-icon-* class: ${svg.getAttribute('class')}`);
+    return mod.replace('tabler-icon-', '');
+  }
+
+  /**
+   * Poll for the CTA BUTTON by href — the render is async, so a bare query races it.
+   *
+   * 🔴 Scoped to `[class*="Button-root"]`: more than one anchor on the card can
+   * carry the same href (the title and the cover link to the detail, and the card
+   * body can link to the run route), and a bare `a[href=...]` grabs whichever comes
+   * first in document order — a wrapper with no glyph in it. That reads as
+   * "the CTA rendered no glyph" when the CTA is fine.
+   */
+  async function waitForCta(href: string): Promise<Element> {
+    const el = await vi.waitUntil(
+      () => document.body.querySelector(`a[href="${href}"][class*="Button-root"]`),
+      { timeout: 10000, interval: 25 }
+    );
+    return el as Element;
+  }
+
+  test('🔴 S4: the card has NO border and NO shadow, and takes its radius from Tailwind', async () => {
+    renderWithProviders(<AppListingCard card={base({})} canOpenPage />);
+    await expect.element(page.getByText('My App')).toBeInTheDocument();
+    const root = cardRoot();
+    expect(root, 'the Mantine Card root').toBeTruthy();
+    // `withBorder` is gone → Mantine emits no `data-with-border`.
+    expect(root!.hasAttribute('data-with-border')).toBe(false);
+    // `shadow="sm"` is gone → no `--paper-shadow` is declared at all.
+    expect(root!.getAttribute('style') ?? '').not.toContain('--paper-shadow');
+    // Radius comes from the shared Tailwind scale (6px), NOT Mantine's `md` (8px).
+    expect(root!.className).toContain('rounded-md');
+  });
+
+  test('🔴 S5: the title is xl/700/white — and is no longer a heading', async () => {
+    renderWithProviders(<AppListingCard card={base({})} canOpenPage />);
+    // 🔴 Render barrier. `renderWithProviders` is async and `.element()` does NOT
+    // retry, so reading it directly throws on the pre-commit DOM — and the throw
+    // poisons every test after this one. `expect.element` polls; `.element()` does
+    // not. (This is the same trap the S4 test above avoids by awaiting first.)
+    await expect.element(page.getByText('My App')).toBeInTheDocument();
+    const title = page.getByText('My App').element() as HTMLElement;
+    const style = title.getAttribute('style') ?? '';
+    // 🔴 Marker shapes verified against Mantine's ACTUAL output, not assumed:
+    // `size` becomes a `--text-fz` custom property, but `fw`/`c` become PLAIN
+    // `font-weight` / `color` declarations. Asserting `--text-fw` / `--text-color`
+    // fails against a correctly-rendered component.
+    expect(style).toContain('--text-fz: var(--mantine-font-size-xl)');
+    expect(style).toContain('font-weight: 700');
+    expect(style).toContain('color: var(--mantine-color-white)');
+    // Declared side effect: the card title is a <Text>, not an <h4>. This is
+    // parity with `/models` (whose card title is a <p>), not an a11y regression —
+    // asserted so the change is visible rather than discovered later.
+    expect(title.tagName).not.toBe('H4');
+    expect(cardRoot()!.querySelector('h1,h2,h3,h4,h5,h6')).toBeNull();
+  });
+
+  test('🔴 S5: the author line is sm/500 and STAYS dimmed (accepted contrast residual)', async () => {
+    renderWithProviders(<AppListingCard card={base({})} canOpenPage />);
+    await expect.element(page.getByText('by alice')).toBeInTheDocument();
+    const author = page.getByText('by alice').element() as HTMLElement;
+    const style = author.getAttribute('style') ?? '';
+    expect(style).toContain('--text-fz: var(--mantine-font-size-sm)');
+    expect(style).toContain('font-weight: 500');
+    // 🔴 The accepted trade (decision 3): size + weight only. Taking the author to
+    // white too would flatten the title-over-author hierarchy on a dark-6 body.
+    // If this ever starts asserting white, decision 3 was changed without notice.
+    expect(style).not.toContain('color: var(--mantine-color-white)');
+  });
+
+  // 🔴 ONE render per test. An earlier version rendered all three variants in a
+  // single body and called `.unmount()` between them; that fights the scaffold's
+  // global `afterEach(cleanup)` over the shared container and left EVERY
+  // subsequent test in the file timing out at 15s. Separate tests also let each
+  // glyph mutation be observed independently instead of the first short-circuiting
+  // the rest.
+
+  test('🔴 S6b: the in-site Open CTA carries the launch glyph', async () => {
+    renderWithProviders(<AppListingCard card={base({})} canOpenPage />);
+    expect(ctaGlyph(await waitForCta('/apps/run/my-app'))).toBe('player-play');
+  });
+
+  test('🔴 S6b: the off-site Visit CTA carries the external glyph', async () => {
+    renderWithProviders(
+      <AppListingCard
+        card={base({
+          kind: 'offsite',
+          name: 'External App',
+          kindData: { kind: 'offsite', subKind: 'external-link', externalUrl: 'https://ext.app' },
+        })}
+      />
+    );
+    expect(ctaGlyph(await waitForCta('https://ext.app'))).toBe('external-link');
+  });
+
+  test('🔴 S6b: the View-details CTA carries the view glyph, distinct from the other two', async () => {
+    renderWithProviders(<AppListingCard card={base({})} canOpenPage={false} />);
+    // `eye`, NOT `info-circle`. #3539 shipped IconEye here and the shared glyph
+    // module was reconciled to match; asserting the value (not just "different")
+    // is what stops a future wiring change from silently repainting it.
+    expect(ctaGlyph(await waitForCta('/apps/store-preview/my-app'))).toBe('eye');
+    // The in-site branch used to render NO icon at all — that silence was the half
+    // of #3391's premise the card was failing. All three glyphs are distinct:
+    // player-play / external-link / eye, pinned across the three tests above.
   });
 
   test('owner sees the Edit deep-link → on-site manifest editor', async () => {
@@ -609,7 +740,7 @@ describe('AppListingCard', () => {
 
         const { row, rollup } = actionRow('View details');
         assertLayoutIsReal(row);
-        expect(Math.round(row.clientWidth)).toBe(280);
+        expect(Math.round(row.clientWidth)).toBe(282); // 314 - 2x16 padding (no border since S4)
 
         // 80px is grounded in the measurements above, not invented: the glyph is
         // 13px + a 4px gap, so 80 leaves ~63px of text — enough for "91% recom…"
@@ -650,7 +781,7 @@ describe('AppListingCard', () => {
           .toBeInTheDocument();
         const { row, rollup } = actionRow('View details');
         assertLayoutIsReal(row);
-        expect(Math.round(row.clientWidth)).toBe(246);
+        expect(Math.round(row.clientWidth)).toBe(248); // 280 - 2x16 padding (no border since S4)
         /**
          * Measured: 3.6px before the fix, 52.1px after — the glyph (13) + gap (4)
          * + ~35px of text, i.e. "91%…". Floor set at 50 from that measurement.

--- a/src/components/Apps/AppListingCard.tsx
+++ b/src/components/Apps/AppListingCard.tsx
@@ -10,17 +10,9 @@ import {
   Image,
   Stack,
   Text,
-  Title,
   Tooltip,
 } from '@mantine/core';
-import {
-  IconApps,
-  IconExternalLink,
-  IconEye,
-  IconPencil,
-  IconPlayerPlay,
-  IconThumbUp,
-} from '@tabler/icons-react';
+import { IconApps, IconPencil, IconThumbUp } from '@tabler/icons-react';
 import type { Icon } from '@tabler/icons-react';
 import Link from 'next/link';
 import { type MouseEvent, useState } from 'react';
@@ -33,6 +25,7 @@ import {
   getOwnerEditHref,
   getRecommendLabel,
 } from '~/components/Apps/appListingCardView';
+import { ACTION_GLYPH_ICONS, cardActionGlyph } from '~/components/Apps/appListingActionGlyph';
 import { TruncatedText } from '~/components/Apps/AppListingTruncate';
 import { toRecentAppFromListing } from '~/components/Apps/recentAppsRail';
 import { recordRecentlyOpenedApp } from '~/components/Apps/recentlyOpenedAppsStore';
@@ -198,8 +191,19 @@ function CreatorChip({ creator }: { creator: ListingCard['creator'] }) {
         </Avatar>
         {/* Tuned to fit in the common case; the Tooltip reveals a long username
             only when it would still clip. */}
+        {/* 🔴 S5 — AUTHOR is size + weight ONLY: 12px/400 -> 14px/500, matching the
+            `/models` author line. `c="dimmed"` is KEPT deliberately (Zach's call):
+            taking BOTH title and author to white flattens the title-over-author
+            hierarchy on a `dark-6` card body, and `/models` needs white there only
+            because its author line is overlaid on media.
+
+            🔴 ACCEPTED RESIDUAL, on the record rather than an oversight: this leaves
+            the author line at contrast 4.73 — AA pass by 0.23, AAA fail. Do not
+            "fix" it to white in a later PR without revisiting that decision; the
+            verification asserts the colour did NOT change. */}
         <TruncatedText
-          size="xs"
+          size="sm"
+          fw={500}
           c="dimmed"
           lineClamp={1}
           tooltipLabel={creator.username}
@@ -225,6 +229,13 @@ export interface AppListingCardProps {
 export function AppListingCard({ card, canOpenPage = false }: AppListingCardProps) {
   const currentUser = useCurrentUser();
   const cta = getListingCta(card, { canOpenPage });
+  // 🔴 S6b — ONE glyph vocabulary, read from the shared module rather than a
+  // second inline copy. #3539 already gave each CTA its own icon; what was still
+  // missing is a single SOURCE, so the card, the listing detail and the recents
+  // rail could not drift apart silently. This substitution renders exactly the
+  // same three icons it did before (open → IconPlayerPlay, visit →
+  // IconExternalLink, detail → IconEye) — it is a consolidation, not a restyle.
+  const CtaGlyph = ACTION_GLYPH_ICONS[cardActionGlyph(cta.action)];
   const detailHref = getListingDetailHref(card.slug);
   const recommendLabel = getRecommendLabel(card.recommend, card.reviewCount);
 
@@ -251,8 +262,32 @@ export function AppListingCard({ card, canOpenPage = false }: AppListingCardProp
   // the action row below (see the long note there). It is
   // `container-type: inline-size`, i.e. inline-axis containment only, so the
   // card's height still follows its content and `h-full` is unaffected.
+  // 🔴 S4 — CHROME MATCHES THE SITE'S CARD, and every property below is
+  // load-bearing. Measured against a `/models` card in the same session (dark),
+  // and re-measured at 394px mobile where all four values are identical:
+  //   border-radius  8px           -> 6px   (`rounded-md`)
+  //   border         0.877px solid -> 0px   (drop `withBorder`)
+  //   box-shadow     3-layer       -> none  (drop `shadow="sm"`)
+  //   background     rgb(37,38,43) -> unchanged
+  // The site baseline is `TwCard`'s `rounded-md border-gray-3 bg-gray-0
+  // shadow-gray-4`, where the absent border/shadow is EMERGENT: those classes set
+  // only a COLOUR, with no width/shadow utility, so both resolve to 0/none.
+  //
+  // 🔴 `radius={0}` + `rounded-md`, NOT `radius="md"`. Mantine's `md` is 8px and
+  // Tailwind's `rounded-md` is 6px — the two `md`s are different values, which is
+  // exactly how this drifted. Taking it from the Tailwind scale pins it to the same
+  // token the rest of the site's cards use.
+  //
+  // 🔴 PADDING STAYS 16px. The review's "zero padding" is about the MEDIA, and the
+  // cover is already full-bleed via `<Card.Section>`. Unlike `/models`, this card's
+  // text sits BELOW the media rather than overlaid on it, so the body needs padding.
+  //
+  // Losing the border is safe at 1-per-row mobile, where the card is effectively
+  // full-bleed: the card's own fill (rgb(37,38,43)) separates it from the page
+  // (rgb(26,27,30)) with every ancestor transparent — the same separation `/models`
+  // already relies on at `border: 0`. Measured, not assumed.
   return (
-    <Card shadow="sm" padding="md" radius="md" withBorder className="h-full @container">
+    <Card padding="md" radius={0} className="h-full rounded-md @container">
       <ListingCover
         coverUrl={card.coverUrl}
         category={card.category}
@@ -299,9 +334,27 @@ export function AppListingCard({ card, canOpenPage = false }: AppListingCardProp
               c="inherit"
               style={{ minWidth: 0 }}
             >
-              <Title order={4} className="line-clamp-2">
+              {/* 🔴 S5 — TITLE matches the `/models` card: 18px/700/rgb(193,194,197)
+                  (contrast 8.48) -> 20px/700/#fefefe (contrast 14.97). `c="white"`
+                  is `--mantine-color-white`, which ThemeProvider sets to #fefefe
+                  deliberately to match the Tailwind value — it is the token the
+                  site's own card components use, so prefer it over the review's
+                  suggested `--mantine-primary-color-contrast` (same rendered value,
+                  wrong token).
+
+                  🔴 Do NOT add `cardClasses.dropShadow`. The `/models` title carries
+                  a text-shadow because it sits OVER media; this one sits on the card
+                  body. Confirmed still true at 394px mobile.
+
+                  ⚠️ SEMANTIC SIDE EFFECT, declared not hidden: dropping `<Title
+                  order={4}>` removes the `h4` from each card. `/apps` has no page
+                  heading today and its first heading IS this card title, so
+                  afterwards it has none — which is exactly what `/models` does (its
+                  card title is a `<p>`). Baseline parity, not an a11y regression;
+                  the broader heading-hierarchy finding (S13) stays out of scope. */}
+              <Text size="xl" fw={700} lh={1.2} c="white" className="line-clamp-2">
                 {card.name}
-              </Title>
+              </Text>
             </Anchor>
             <CreatorChip creator={card.creator} />
             {showOwnerIncomplete && (
@@ -441,14 +494,14 @@ export function AppListingCard({ card, canOpenPage = false }: AppListingCardProp
 
                 ICONS (product-feedback pass). Each action carries its own glyph so
                 the three CTAs are distinguishable at a glance in a dense grid
-                rather than three same-shaped buttons differing only in wording:
-                  open   → IconPlayerPlay   (run the app here)
-                  visit  → IconExternalLink (leaves Civitai — already the case)
-                  detail → IconEye          (read about it)
-                The rail tile's icon button uses the SAME vocabulary
-                (`RECENT_ACTION_ICONS` in `RecentlyOpenedApps.tsx`, driven by
-                `getRecentRailAction`) so one action reads identically on both
-                surfaces.
+                rather than three same-shaped buttons differing only in wording.
+                🔴 The mapping itself is NOT restated here — it lives in
+                `appListingActionGlyph.ts` and is read above via `CtaGlyph`. A copy
+                of it in this comment is exactly how the card and the detail page
+                drifted apart in the first place. The rail tile's icon button still
+                carries its own copy (`RECENT_ACTION_ICONS` in
+                `RecentlyOpenedApps.tsx`, driven by `getRecentRailAction`); folding
+                that third one in is the remaining consolidation.
 
                 🔴 The icon is DECORATIVE — the label text stays the accessible
                 name. Tabler icons render `<svg>` with no `<title>`, so they
@@ -471,7 +524,7 @@ export function AppListingCard({ card, canOpenPage = false }: AppListingCardProp
                 rel="noopener noreferrer"
                 size="sm"
                 variant="light"
-                rightSection={<IconExternalLink size={16} />}
+                rightSection={<CtaGlyph size={16} />}
                 // "Opened" = actually opened. An OFF-SITE app is opened the
                 // moment this Visit CTA is followed — there is no on-platform
                 // route afterwards that could record it (the on-site path is
@@ -487,9 +540,7 @@ export function AppListingCard({ card, canOpenPage = false }: AppListingCardProp
                 href={cta.href}
                 size="sm"
                 variant={cta.action === 'open' ? 'filled' : 'light'}
-                leftSection={
-                  cta.action === 'open' ? <IconPlayerPlay size={16} /> : <IconEye size={16} />
-                }
+                leftSection={<CtaGlyph size={16} />}
               >
                 {cta.label}
               </Button>

--- a/src/components/Apps/AppListingCard.tsx
+++ b/src/components/Apps/AppListingCard.tsx
@@ -347,11 +347,14 @@ export function AppListingCard({ card, canOpenPage = false }: AppListingCardProp
                   body. Confirmed still true at 394px mobile.
 
                   ⚠️ SEMANTIC SIDE EFFECT, declared not hidden: dropping `<Title
-                  order={4}>` removes the `h4` from each card. `/apps` has no page
-                  heading today and its first heading IS this card title, so
-                  afterwards it has none — which is exactly what `/models` does (its
-                  card title is a `<p>`). Baseline parity, not an a11y regression;
-                  the broader heading-hierarchy finding (S13) stays out of scope. */}
+                  order={4}>` removes the `h4` from each card — parity with
+                  `/models`, whose card title is a `<p>`. Grepped: nothing depends
+                  on a heading inside the card (no `getByRole('heading')`, no
+                  snapshot). 🔴 It does NOT leave `/apps` heading-less, as an
+                  earlier draft of this comment claimed: `RecentlyOpenedApps`
+                  ("Recently opened") and `RelatedListings` both render their own
+                  `Title` on those surfaces. The broader heading-hierarchy finding
+                  (S13) stays out of scope. */}
               <Text size="xl" fw={700} lh={1.2} c="white" className="line-clamp-2">
                 {card.name}
               </Text>

--- a/src/components/Apps/__tests__/appListingActionGlyph.test.ts
+++ b/src/components/Apps/__tests__/appListingActionGlyph.test.ts
@@ -63,8 +63,14 @@ describe('cardActionGlyph', () => {
     expect(cardActionGlyph('open')).toBe('launch');
     expect(cardActionGlyph('visit')).toBe('external');
     expect(cardActionGlyph('connect')).toBe('connect');
-    // "View details" → the unified listing detail. Informational, not a launch.
-    expect(cardActionGlyph('detail')).toBe('info');
+    // 🔴 "View details" → `view` (IconEye), NOT `info`. This arm shipped as `info`
+    // in #3540 while it had no caller, and #3539 had meanwhile shipped IconEye on
+    // the card's real View-details CTA — so wiring the card to the module would
+    // have silently repainted every one of them. Pinned to the value, and to the
+    // DISTINCTION from `info`, so the two can't be collapsed again.
+    expect(cardActionGlyph('detail')).toBe('view');
+    expect(cardActionGlyph('detail')).not.toBe(detailActionGlyph('info'));
+    expect(ACTION_GLYPH_ICONS.view).not.toBe(ACTION_GLYPH_ICONS.info);
   });
 
   test('every card action gets a distinct glyph', () => {

--- a/src/components/Apps/appListingActionGlyph.ts
+++ b/src/components/Apps/appListingActionGlyph.ts
@@ -1,5 +1,6 @@
 import {
   IconExternalLink,
+  IconEye,
   IconInfoCircle,
   IconPlayerPlay,
   IconPlugConnected,
@@ -28,7 +29,7 @@ import type { DetailActionMode } from '~/components/Apps/appListingDetailView';
  * mapping, and the invariant worth pinning is that the in-site and off-site
  * glyphs are DIFFERENT.
  */
-export type PrimaryActionGlyph = 'launch' | 'external' | 'connect' | 'info';
+export type PrimaryActionGlyph = 'launch' | 'external' | 'connect' | 'info' | 'view';
 
 /**
  * Glyph → Tabler icon.
@@ -46,8 +47,19 @@ export const ACTION_GLYPH_ICONS: Record<PrimaryActionGlyph, Icon> = {
   external: IconExternalLink,
   /** OAuth connect affordance (stubbed until the cutover wires it). */
   connect: IconPlugConnected,
-  /** Informational — no launch, no navigation off-site. */
+  /** Informational — no launch, no navigation off-site, and no target to go to. */
   info: IconInfoCircle,
+  /**
+   * "Read about it" — an in-site hop to the unified listing detail.
+   *
+   * 🔴 Distinct from `info`, and it must stay `IconEye`. #3539's product-feedback
+   * pass shipped `IconEye` for the card's "View details" CTA and for the recents
+   * rail's `view` action (`RECENT_ACTION_ICONS` in `RecentlyOpenedApps.tsx`), so
+   * this is the SITE's established vocabulary, not a fresh choice. `info` is the
+   * detail page's *inert* affordance ("Runs on model pages" — no href at all);
+   * collapsing the two would silently repaint every card's View-details CTA.
+   */
+  view: IconEye,
 };
 
 /**
@@ -82,17 +94,13 @@ export function detailActionGlyph(mode: DetailActionMode): PrimaryActionGlyph {
  * Store-card CTA action → glyph. Same vocabulary as the detail page, so a card
  * and the detail it links to can never disagree about what an app's CTA means.
  *
- * `detail` ("View details" — the unified listing detail) is informational, so it
- * shares the `info` glyph with the detail page's own informational mode.
+ * `detail` ("View details" — the unified listing detail) maps to `view`
+ * (`IconEye`), NOT `info`. See the `view` entry above: `IconEye` is what the site
+ * already ships for this action, on both the card and the recents rail.
  *
- * 🔴 NO LIVE CALLER YET. This half is consumed by the store-card PR that follows
- * (the card CTA collapse); it ships here so that PR imports this module rather
- * than editing it — the two changes are otherwise the same-file collision that
- * silently dropped a hunk from `GetStartedBody.tsx`. Its tests are therefore a
- * contract pin, not a regression gate, until the card reads through it.
- * Separately, `getListingCta` does not currently emit `'connect'` at all (the
- * off-site OAuth case routes to `'detail'`), so that arm is unreachable from
- * live data even after the card lands; it is mapped for totality over the type.
+ * `AppListingCard` is the live caller. `getListingCta` still does not emit
+ * `'connect'` (the off-site OAuth case routes to `'detail'`), so that arm remains
+ * unreachable from live data; it is mapped for totality over the type.
  */
 export function cardActionGlyph(action: ListingCtaAction): PrimaryActionGlyph {
   switch (action) {
@@ -103,6 +111,12 @@ export function cardActionGlyph(action: ListingCtaAction): PrimaryActionGlyph {
     case 'connect':
       return 'connect';
     case 'detail':
-      return 'info';
+      // 🔴 'view' (IconEye), NOT 'info'. This arm shipped as 'info' in #3540 while
+      // it had no caller; #3539 had meanwhile shipped IconEye on the card's real
+      // "View details" CTA. Wiring the card to the old mapping would have silently
+      // repainted every such CTA — a regression against a deliberate product call,
+      // introduced by a module written to be wired up. Corrected before its first
+      // caller (this file's own card) exists.
+      return 'view';
   }
 }


### PR DESCRIPTION
## What

The `/apps` store card is the only content card on the site wearing a border, a shadow and a non-standard radius, with the smallest and dimmest title/author text. This brings it to the `/models` baseline and collapses the CTA icon mapping to one source.

## Measured, at two viewports

Against a `/models` card **in the same session** (dark), and re-measured at **394 px mobile**, where every value below is identical — so this design is not desktop-only.

| | `/apps` before | `/models` | after |
|---|---|---|---|
| `border-radius` | 8 px | **6 px** | 6 px |
| `border` | 0.877px solid rgb(55,58,64) | **0** | 0 |
| `box-shadow` | 3-layer | **none** | none |
| `background` | rgb(37,38,43) | rgb(37,38,43) | unchanged |
| title | 18/700/rgb(193,194,197) — contrast 8.48 | 20/700/#fefefe — 14.97 | 20/700/#fefefe |
| author | 12/400/rgb(140,143,163) | 14/500/white | 14/**500**, still dimmed |

**Radius comes from Tailwind's `rounded-md`, not Mantine's `md`** — the two `md`s are 6 px and 8 px, which is exactly how this drifted.

**Padding stays 16 px.** The review's "zero padding" is about the *media*, already full-bleed via `Card.Section`; this card's text sits *below* the media rather than overlaid on it.

**The mobile-specific risk was checked, not assumed.** At 1 card per row the card is effectively full-bleed, so dropping the border could have made it vanish. It doesn't — the card's own fill (rgb(37,38,43)) separates it from the page (rgb(26,27,30)) with every ancestor transparent, the same separation `/models` already relies on at `border: 0`.

## The author line stays dimmed — deliberately

Size + weight only. Taking *both* title and author to white flattens the title-over-author hierarchy on a `dark-6` body; `/models` needs white there only because its author line is overlaid on media. **This leaves the author at contrast 4.73 — AA pass by 0.23, AAA fail.** An accepted trade, and now asserted, so it can't be "fixed" later without revisiting the decision.

## 🔴 A trap this closes

`cardActionGlyph('detail')` shipped in **#3540** returning `'info'` (`IconInfoCircle`) while it had **no caller**. **#3539** had meanwhile shipped **`IconEye`** on the card's real "View details" CTA.

The module existed *precisely* so this PR would wire the card to it — and doing that naively would have **silently repainted every View-details CTA**, regressing a deliberate product call. Reconciled to a new `view` glyph (`IconEye`) **before its first caller exists**, and pinned both to the value and to its distinction from `info`.

S6b's remaining half was never "add icons" — #3539 did that. It was **one source**: the card now reads `ACTION_GLYPH_ICONS[cardActionGlyph(...)]` instead of a second inline mapping, and the comment that *restated* the mapping is deleted (a copy in prose is how the card and detail drifted apart to begin with). Same three icons render as before.

## Two geometry pins moved — on purpose

`280 → 282` and `246 → 248`. That is the border removal being **real and measurable**: 0.877 px a side, ~1.75 px reclaimed, and the arithmetic is now exact (`width − 32`) rather than fractional (`width − 34`). **If those numbers ever move back, the border came back.** The derivation comment is updated to say so.

## Verification

**Component 40/40**, stable over 3 consecutive runs. **Node 9/9.** `tsc`: 16 pre-existing errors, none in these files. `eslint` 0. `prettier` clean — note `AppListingCard.tsx` is prettier-*clean* on `main`, so this PR keeps it that way rather than leaving drift.

### Break-it matrix

| Mutation | Result |
|---|---|
| restore `shadow="sm" radius="md" withBorder` | **3 red** — the S4 guard **plus both geometry pins**, which are an independent detector |
| `cardActionGlyph('detail')` back to `'info'` | **1 red** — `expected 'info-circle' to be 'eye'` |
| revert the title to `<Title order={4}>` | ⚠️ **not verified** — the run timed out before producing a verdict; I am not claiming a kill I did not watch |

## Two things I got wrong, recorded because they cost real time

1. **My test assertions were wrong about Mantine's DOM, not the component.** `fw` renders as a plain `font-weight:` declaration and `c` as `color:` — *not* `--text-fw` / `--text-color`. The scope doc's marker guidance was half wrong, and I asserted it without checking. The component was correct the whole time.
2. **A pristine-`main` control is what caught a real breakage I'd have dismissed.** My first runs failed with `useState`/`useContext` nulls — the documented dual-React cache cascade. Pristine `main` in the same worktree passed **34/34**, mine converged to a stable **28/10**. A cache artifact keeps *moving*; convergence is the discriminator. The real causes were mine: a missing render barrier, an over-broad `a[href]` selector that grabbed a wrapper instead of the CTA, and a manual `.unmount()` fighting the scaffold's `afterEach(cleanup)` over the shared container — which timed out every test after it.

## Scope note

S7 (the description-less dead band) was briefly folded into this PR and then **removed**. Measurement showed it is `h-full` equal-height-row stretching, not a stray spacer — so "fixing" it trades the dead band for ragged rows. That is a product call needing its own desktop measurement (the symptom is absent at 1-per-row mobile), not a free ride-along in the wave's most collision-prone file.

## Still owed

No live re-measurement on prod — the numbers above are from prod *before* this change plus a Chromium component run after it. The store is mod-gated and `deIndex`-ed, so this is low-risk to land unverified, but it is not the same as having looked.
