### PR TITLE
feat(collections): surface AI-escalated items, stop rejecting videos on frame one

### DIFF
--- a/src/pages/collections/[collectionId]/review.tsx
+++ b/src/pages/collections/[collectionId]/review.tsx
@@ -115,17 +115,19 @@ const ReviewCollection = () => {
   const [statuses, setStatuses] = useState<CollectionItemStatus[]>([CollectionItemStatus.REVIEW]);
   const [sort, setSort] = useState<CollectionReviewSort>(CollectionReviewSort.Newest);
   const [collectionTagId, setCollectionTagId] = useState<number | undefined>(undefined);
+  const [awaitingHumanReview, setAwaitingHumanReview] = useState(false);
 
   const filters = useMemo(
     () => ({
       collectionId,
       statuses,
       forReview: true,
+      awaitingHumanReview: awaitingHumanReview || undefined,
       reviewSort: sort,
       collectionTagId,
       browsingLevel: allBrowsingLevelsFlag,
     }),
-    [collectionId, statuses, sort, collectionTagId]
+    [collectionId, statuses, sort, collectionTagId, awaitingHumanReview]
   );
 
   const { collection, permissions, isLoading: loadingCollection } = useCollection(collectionId);
@@ -216,6 +218,15 @@ const ReviewCollection = () => {
                     </Chip>
                   </Group>
                 </Chip.Group>
+                <Chip
+                  checked={awaitingHumanReview}
+                  onChange={() => {
+                    setAwaitingHumanReview((v) => !v);
+                    deselectAll();
+                  }}
+                >
+                  <span>Needs human review</span>
+                </Chip>
 
                 <SelectMenuV2
                   label="Sort by"

--- a/src/server/jobs/collection-ai-review.ts
+++ b/src/server/jobs/collection-ai-review.ts
@@ -7,6 +7,7 @@ import { logToAxiom } from '~/server/logging/client';
 import type { CollectionAiReviewSchema } from '~/server/schema/collection.schema';
 import { collectionAiReviewSchema } from '~/server/schema/collection.schema';
 import {
+  AI_REVIEW_SYSTEM_USER_ID as SYSTEM_USER_ID,
   COLLECTION_AI_REVIEW_KEY_PREFIX,
   updateCollectionItemsStatus,
 } from '~/server/services/collection.service';
@@ -24,7 +25,6 @@ import { withDistributedLock } from '~/server/utils/distributed-lock';
 import { getEdgeUrl } from '~/client-utils/cf-images-utils';
 import { createJob } from './job';
 
-const SYSTEM_USER_ID = -1;
 // Chunks are barriers waiting on the slowest call (~3s median, 13-20s tail), so they must be wide
 // enough to absorb stragglers. Chunk size is also the crash-safety granularity. See the feature doc.
 const BATCH_SIZE = 300;
@@ -153,7 +153,7 @@ async function classifyItem({
       if (!result) return undefined;
 
       ({ usage } = result);
-      decision = decideFromObservations(result.observations);
+      decision = decideFromObservations(result.observations, { isVideo: item.type === 'video' });
       reason = (result.observations as { reason?: string } | null)?.reason?.slice(0, 500) ?? '';
     } catch (error) {
       logToAxiom({

--- a/src/server/schema/collection.schema.ts
+++ b/src/server/schema/collection.schema.ts
@@ -256,6 +256,9 @@ export const getAllCollectionItemsSchema = baseQuerySchema.extend({
   collectionId: z.number(),
   statuses: z.array(z.enum(CollectionItemStatus)).optional(),
   forReview: z.boolean().optional(),
+  // Items AI review handed to a human: still REVIEW, but already stamped by the system user, so
+  // the job will not pick them up again.
+  awaitingHumanReview: z.boolean().optional(),
   reviewSort: z.enum(CollectionReviewSort).optional(),
   collectionTagId: z.number().optional(),
 });

--- a/src/server/services/ai/__tests__/collection-review.service.test.ts
+++ b/src/server/services/ai/__tests__/collection-review.service.test.ts
@@ -89,6 +89,15 @@ describe('decideFromObservations', () => {
     expect(result.violations).toContain('sexual/adult content');
   });
 
+  // Only the first frame reaches the model, so a reference later in the video is invisible.
+  it('escalates rather than rejects a video with no buzz reference in frame one', () => {
+    const result = decideFromObservations({ ...clean, hasBuzzReference: false }, { isVideo: true });
+    expect(result.decision).toBe('escalate');
+    expect(result.escalations).toContain('no buzz reference in first frame');
+    expect(result.violations).not.toContain('no buzz reference');
+    expect(result.neverReject).toBe(true);
+  });
+
   it('rejects a missing buzz reference', () => {
     const result = decideFromObservations({ ...clean, hasBuzzReference: false });
     expect(result.decision).toBe('reject');

--- a/src/server/services/ai/collection-review.service.ts
+++ b/src/server/services/ai/collection-review.service.ts
@@ -66,7 +66,10 @@ export type AiReviewDecision = {
 
 // Takes `unknown` because a refusal, a provider fallback, or schema drift all arrive as parseable
 // JSON with the wrong shape.
-export function decideFromObservations(raw: unknown): AiReviewDecision {
+export function decideFromObservations(
+  raw: unknown,
+  { isVideo = false }: { isVideo?: boolean } = {}
+): AiReviewDecision {
   const parsed = aiReviewObservationsSchema.safeParse(raw);
   if (!parsed.success)
     return {
@@ -108,14 +111,19 @@ export function decideFromObservations(raw: unknown): AiReviewDecision {
     else escalations.push(`unrecognized category: ${entry}`);
   }
 
-  if (!o.hasBuzzReference) violations.push('no buzz reference');
+  if (!o.hasBuzzReference) {
+    // Only the first frame is sent, so a reference that appears later in a video — or is spoken —
+    // is invisible to the model. Not enough to reject a submission on.
+    if (isVideo) escalations.push('no buzz reference in first frame');
+    else violations.push('no buzz reference');
+  }
 
   const decision = escalations.length ? 'escalate' : violations.length ? 'reject' : 'approve';
   return {
     decision,
     violations,
     escalations,
-    neverReject: uncertainAge || undefined,
+    neverReject: uncertainAge || (isVideo && !o.hasBuzzReference) || undefined,
   };
 }
 

--- a/src/server/services/collection.service.ts
+++ b/src/server/services/collection.service.ts
@@ -1216,6 +1216,9 @@ export type CollectionItemsResult = {
   nextCursor?: string;
 };
 
+// The AI review job stamps this as the reviewer on items it hands to a human.
+export const AI_REVIEW_SYSTEM_USER_ID = -1;
+
 export const getCollectionItemsByCollectionId = async ({
   input,
   user,
@@ -1230,6 +1233,7 @@ export const getCollectionItemsByCollectionId = async ({
     collectionId,
     cursor,
     forReview,
+    awaitingHumanReview,
     reviewSort,
     collectionTagId,
   } = input;
@@ -1264,6 +1268,12 @@ export const getCollectionItemsByCollectionId = async ({
   });
 
   const useRandomSort = !forReview && collection.mode === CollectionMode.Contest;
+
+  // AI review leaves items it will not decide in REVIEW, stamped by the system user, so this is
+  // exactly the set waiting on a person.
+  const awaitingHumanCondition = awaitingHumanReview
+    ? Prisma.sql`AND ci."reviewedById" = ${AI_REVIEW_SYSTEM_USER_ID}`
+    : Prisma.sql``;
 
   // For contest mode, use hash-based random ordering with cursor support
   let collectionItems: {
@@ -1338,6 +1348,7 @@ export const getCollectionItemsByCollectionId = async ({
       WHERE ci."collectionId" = ${collectionId}
         AND ci."status" IN (${Prisma.raw(statusArray)})
         ${tagCondition}
+        ${awaitingHumanCondition}
         ${imageIngestionCondition}
         ${cursorCondition}
       ORDER BY "sortKey" DESC, ci.id DESC
@@ -1415,6 +1426,7 @@ export const getCollectionItemsByCollectionId = async ({
       WHERE ci."collectionId" = ${collectionId}
         AND ci."status" IN (${Prisma.raw(statusArray)})
         ${tagCondition}
+        ${awaitingHumanCondition}
         ${imageIngestionCondition}
         ${cursorCondition}
       ORDER BY ci."createdAt" ${Prisma.raw(sortDirection)}, ci.id DESC

--- a/src/server/services/collection.service.ts
+++ b/src/server/services/collection.service.ts
@@ -1269,10 +1269,10 @@ export const getCollectionItemsByCollectionId = async ({
 
   const useRandomSort = !forReview && collection.mode === CollectionMode.Contest;
 
-  // AI review leaves items it will not decide in REVIEW, stamped by the system user, so this is
-  // exactly the set waiting on a person.
+  // The system user stamps every item it touches, accept and reject included, so the stamp alone
+  // means "the AI saw this". Only a stamped item still sitting in REVIEW is waiting on a person.
   const awaitingHumanCondition = awaitingHumanReview
-    ? Prisma.sql`AND ci."reviewedById" = ${AI_REVIEW_SYSTEM_USER_ID}`
+    ? Prisma.sql`AND ci."reviewedById" = ${AI_REVIEW_SYSTEM_USER_ID} AND ci.status = 'REVIEW'::"CollectionItemStatus"`
     : Prisma.sql``;
 
   // For contest mode, use hash-based random ordering with cursor support


### PR DESCRIPTION
Two follow-ups from the first live AI review run on the Buzz Beggars Board (#3543).

## Videos were being rejected on incomplete evidence

Only a video's first frame reaches the model, so a Buzz reference appearing later — or spoken — is invisible. Measured on the first live run:

| | rejected for "no buzz reference" | share of that media type |
|---|---|---|
| Images | 15 | 3% of 508 |
| Videos | 3 | **12.5% of 24** |

A missing buzz reference on a **video** now escalates instead of rejecting, flagged `neverReject` so it reaches a person. Images are unchanged.

Rejected the alternative of sampling multiple frames: it multiplies cost across every video to fix ~3 items.

## You couldn't tell what was waiting on a human

Escalated items stay in `REVIEW` stamped by the system user, which made them indistinguishable from genuinely unreviewed submissions. Adds a **"Needs human review"** filter to the collection review page.

## Why not a new `CollectionItemStatus`

This was the obvious shape and it's the wrong one. There are 10+ hardcoded `status IN ('ACCEPTED','REVIEW')` allowlists — challenge prizes (`challenge-prize.ts:58`), notifications (`challenge.notifications.ts:170`), engagement (`challenge-engagement.service.ts:135`), and the submitter's own view of their entry (`collection.service.ts:2199`). A new `ESCALATED` value silently drops out of every one of them, failing closed with no error.

Meanwhile `image.service.ts:1715` is a *denylist* (`status <> 'REJECTED'`), so the same value would be treated as visible there. Two incompatible conventions, 24 files to audit, and a manual migration.

`status = 'REVIEW' AND reviewedById = -1` already means exactly "AI escalated, awaiting human" — AI-decided items leave `REVIEW`, and humans have real user ids. Not a proxy; exact. So the filter needs no enum and no migration.

## Test plan

- [x] `pnpm typecheck` — clean (one pre-existing `minimax.handler.ts` failure, present on `main`)
- [x] `pnpm exec eslint` on changed files — clean (one pre-existing `exhaustive-deps` warning on an untouched `useMemo`)
- [x] 49 unit tests, including the new video-escalation case
- [ ] Verify the chip returns exactly the AI-escalated set on the beggars board

🤖 Generated with [Claude Code](https://claude.com/claude-code)