### PR TITLE
fix(apps): give the owner card's recommend rollup a floor instead of crushing it; /apps/review to 1400

### DIFF
--- a/src/components/Apps/AppListingCard.browser.test.tsx
+++ b/src/components/Apps/AppListingCard.browser.test.tsx
@@ -761,6 +761,29 @@ describe('AppListingCard', () => {
         } satisfies ListingCard['kindData'],
       };
 
+      /**
+       * 🔴 THE SAME WIDEST-CTA CARD BUT WITH **NO REVIEWS** — deliberately a second
+       * fixture rather than a tweak of the one above, because `OFFSITE_CONNECT`
+       * spreads `REVIEWED` and that is easy to miss: a test that reads as "the
+       * no-reviews case" while passing `OFFSITE_CONNECT` is silently measuring
+       * "91% recommend (100)" (122px of text) instead of "No reviews yet" (79px).
+       * That mistake was made and caught here by a red baseline, not by review.
+       *
+       * "No reviews yet" is the SHORT label — the least the rollup can ever say —
+       * which is exactly why it is the right fixture for the truncation floor: if
+       * even this does not fit, the deficit is structural.
+       */
+      const OFFSITE_CONNECT_NO_REVIEWS = {
+        kind: 'offsite' as const,
+        recommend: { recommendedCount: 0, notRecommendedCount: 0, recommendPct: null },
+        reviewCount: 0,
+        kindData: {
+          kind: 'offsite',
+          subKind: 'connect',
+          externalUrl: null,
+        } satisfies ListingCard['kindData'],
+      };
+
       test('🔴 owner + "View details" keeps a LEGIBLE recommend rollup', async () => {
         mocks.currentUser = { id: 5, username: 'alice' };
         renderWithProviders(<Sized width={314} card={base(OFFSITE_CONNECT)} />);
@@ -797,37 +820,109 @@ describe('AppListingCard', () => {
        *
        * Measured through the real `AppsPageLayout` + `Grid` at a 1200 viewport:
        * container 1200 -> grid column 296 -> CARD 280 -> action-row content box
-       * **246**. So "280px" in the original report is the card's OUTER width; the
-       * box the action row actually gets is 246, and a 314px wrapper (content box
-       * 280) corresponds to roughly a 1345 viewport. Testing only at 280 would
-       * have left the real 1200 case unguarded and 34px tighter than anything
-       * asserted.
+       * **248**. So "280px" in the original report is the card's OUTER width; the
+       * box the action row actually gets is 248, and a 314px wrapper (content box
+       * 282) corresponds to roughly a 1345 viewport.
+       *
+       * 🔴 THIS TEST'S EXPECTATION WAS INVERTED (rollup-floor pass, on main+#3547).
+       * It used to assert the rollup SURVIVES here at >= 50px, and it passed: the
+       * measured value on this tree is 54.1px. That IS the defect. At 54px the
+       * rollup is a 13px thumb glyph, a 4px gap and 37px of 12px text, so the
+       * shortest label it can carry — "No reviews yet", 79px natural — renders as a
+       * ~5-character stub. A stub is strictly worse than nothing: it holds the
+       * slot, reads as a rendering bug, and communicates nothing. Below a 264px
+       * container the rollup is now HIDDEN instead, and the actions keep the right
+       * edge.
+       *
+       * Measured on main+#3547 (owner, widest CTA, no reviews), pre-change:
+       *   container 248 -> rollup 54 (text 37 / 79 natural, TRUNCATED)
+       *   container 268 -> rollup 74 (text 57 / 79, truncated)
+       *   container 282 -> rollup 88 (text 71 / 79, truncated)
+       *   container 298 -> rollup 96 (text 79 / 79, full)
        */
-      test('🔴 at the REAL 1200 geometry (246px content box) the rollup still survives', async () => {
+      test('🔴 at the REAL 1200 geometry an owner card DROPS the rollup instead of crushing it', async () => {
         mocks.currentUser = { id: 5, username: 'alice' };
-        renderWithProviders(<Sized width={280} card={base(OFFSITE_CONNECT)} />);
+        // 🔴 NO reviews — the label the live report caught, and the SHORT one (79px
+        // of text vs 122px for "91% recommend (100)"). Using the short label is
+        // what makes this structural rather than an artefact of a long string:
+        // even the least the rollup can ever say does not fit here.
+        renderWithProviders(<Sized width={280} card={base(OFFSITE_CONNECT_NO_REVIEWS)} />);
+        await expect
+          .element(page.getByRole('link', { name: 'View details', exact: true }))
+          .toBeInTheDocument();
+        await expect.element(page.getByText('No reviews yet')).toBeInTheDocument();
+        const { row, actions, rollup } = actionRow('View details');
+        assertLayoutIsReal(row);
+        expect(Math.round(row.clientWidth)).toBe(248); // 280 - 2x16 padding (no border since S4)
+
+        // 🔴 THE GUARD. Pre-change this element measured 54.1px and computed
+        // `display: flex`. Asserted FIRST, so a mutation that re-shrinks the rollup
+        // fails HERE on this guard's own assertion rather than being killed by the
+        // alignment check below (which passes either way while the rollup exists).
+        expect(getComputedStyle(rollup).display).toBe('none');
+        expect(rollup.getBoundingClientRect().width).toBe(0);
+
+        // 🔴 A SEPARATE failure mode, deliberately in the same test because only
+        // this geometry exposes it: with the rollup out of layout the row holds ONE
+        // flex item, and `justify="space-between"` puts a lone item at flex-START.
+        // The actions group carries `marginLeft: 'auto'` for exactly that; delete
+        // the margin and the assertions above stay green while the whole CTA
+        // cluster jumps to the card's left edge.
+        expect(actions.getBoundingClientRect().right).toBeCloseTo(
+          row.getBoundingClientRect().right,
+          0
+        );
+        expect(row.scrollWidth).toBeLessThanOrEqual(row.clientWidth + 1);
+      });
+
+      /**
+       * ⚠️ INVARIANT GUARD, NOT regression coverage — it passes on pre-change code
+       * too (the rollup measured 88.1px here before and after). It earns its place
+       * by BOUNDING the hide above: the fix must remove the rollup only where it is
+       * debris, and this is the first real store geometry above the threshold.
+       * Without it, widening the threshold to "hide it on any narrow owner card"
+       * would pass unnoticed.
+       */
+      test('⚠️ INVARIANT: just ABOVE the 264px threshold the owner rollup is back and legible', async () => {
+        mocks.currentUser = { id: 5, username: 'alice' };
+        renderWithProviders(<Sized width={314} card={base(OFFSITE_CONNECT)} />);
         await expect
           .element(page.getByRole('link', { name: 'View details', exact: true }))
           .toBeInTheDocument();
         const { row, rollup } = actionRow('View details');
         assertLayoutIsReal(row);
-        expect(Math.round(row.clientWidth)).toBe(248); // 280 - 2x16 padding (no border since S4)
-        /**
-         * Measured: 3.6px before the fix, 52.1px after — the glyph (13) + gap (4)
-         * + ~35px of text, i.e. "91%…". Floor set at 50 from that measurement.
-         *
-         * 🔴 STATED HONESTLY: at this, the tightest geometry the store actually
-         * produces, the figure is HARD TRUNCATED. That is a real limitation, not
-         * a clean win — but it is truncation (the documented, designed behaviour
-         * of the flexible side) rather than the total disappearance the icons
-         * caused. Recovering the full "91% recommend (100)" here would mean
-         * shrinking the PRIMARY CTA too, which changes non-owner cards and is out
-         * of scope for this fix.
-         */
-        expect(rollup.getBoundingClientRect().width).toBeGreaterThanOrEqual(50);
+        expect(Math.round(row.clientWidth)).toBe(282); // 282 >= the 264 threshold
+        expect(getComputedStyle(rollup).display).toBe('flex');
+        // 80px is the literal floor from the pre-existing measured table.
+        expect(rollup.getBoundingClientRect().width).toBeGreaterThanOrEqual(80);
         const glyph = rollup.querySelector('svg') as SVGElement;
         expect(glyph.getBoundingClientRect().width).toBeGreaterThan(0);
         expect(row.scrollWidth).toBeLessThanOrEqual(row.clientWidth + 1);
+      });
+
+      /**
+       * ⚠️ INVARIANT GUARD, NOT regression coverage — a non-owner card measured
+       * 95.7px here before the change and measures 95.7px after. It is here because
+       * the whole fix is owner-scoped (`showEdit`), and a version that dropped that
+       * condition would delete the rollup from every public shopper's card at the
+       * single most common desktop geometry — a failure no other test in this file
+       * could see.
+       */
+      test('⚠️ INVARIANT: at the SAME 1200 geometry a NON-owner card keeps its full rollup', async () => {
+        mocks.currentUser = null;
+        renderWithProviders(<Sized width={280} card={base(OFFSITE_CONNECT_NO_REVIEWS)} />);
+        await expect
+          .element(page.getByRole('link', { name: 'View details', exact: true }))
+          .toBeInTheDocument();
+        const { row, rollup } = actionRow('View details');
+        assertLayoutIsReal(row);
+        expect(Math.round(row.clientWidth)).toBe(248);
+        expect(getComputedStyle(rollup).display).toBe('flex');
+        // Literal pin from the measured table: 95.7px, i.e. the full natural width,
+        // because a non-owner action set is 138px rather than 184px.
+        expect(rollup.getBoundingClientRect().width).toBeGreaterThanOrEqual(95);
+        const text = rollup.querySelector('[data-truncate]') as HTMLElement;
+        expect(text.scrollWidth).toBeLessThanOrEqual(text.clientWidth);
       });
 
       test('owner + "Open" (the narrower CTA) also keeps the rollup legible', async () => {

--- a/src/components/Apps/AppListingCard.tsx
+++ b/src/components/Apps/AppListingCard.tsx
@@ -404,8 +404,68 @@ export function AppListingCard({ card, canOpenPage = false }: AppListingCardProp
             of who is looking at it. */}
         <Group justify="space-between" mt="auto" pt="xs" gap="xs" wrap="nowrap">
           {/* Recommend rollup — "N% recommend (M)" or "No reviews yet". This is the
-              flexible side: it may truncate so the actions never do. */}
-          <Group gap={4} wrap="nowrap" style={{ minWidth: 0 }}>
+              flexible side: it may truncate so the actions never do.
+
+              🔴 …but ONLY DOWN TO A FLOOR. Truncation is the designed behaviour and
+              stays; what this container query removes is the state BELOW it, where
+              the rollup is squeezed so hard that the surviving glyphs say nothing.
+              Measured on this tree (main + #3547), OWNER card, the widest CTA
+              ("View details"), the store's real 4-column geometry:
+
+                | card | container | actions | rollup | text px / natural | truncated |
+                |------|-----------|---------|--------|-------------------|-----------|
+                |  280 |       248 |     184 |     54 |          37 / 79  | YES       |
+                |  300 |       268 |     184 |     74 |          57 / 79  | yes       |
+                |  314 |       282 |     184 |     88 |          71 / 79  | yes       |
+                |  330 |       298 |     184 |     96 |          79 / 79  | no        |
+
+              (Widths are `getBoundingClientRect`; "truncated" is `scrollWidth >
+              clientWidth` on the `<Text truncate>`. Character counts below are
+              DERIVED from the text px at 12px, not read off a screenshot — the
+              live report is what confirmed the top row renders as "No ...".)
+
+              A 37px stub of "No reviews yet" is strictly worse than no rollup: it
+              occupies the slot, reads as a rendering bug, and carries no
+              information. 54px is the state the live 1200px-viewport store is in
+              today: card 280 is `(1200 − 32 container padding − 3×16 gutter) / 4`,
+              i.e. the 4-column `lg` span at a 1200px viewport.
+
+              🔴 THRESHOLD 264px, DERIVED NOT GUESSED. The floor we want is a rollup
+              box of ~70px = the 13px thumb glyph + its 4px gap + ~53px of 12px text,
+              which is ~9 characters — enough for "No reviews…" / "91% recom…" to
+              read as a phrase rather than as debris. The owner action set at its
+              WIDEST (icon-only Edit + "View details") measures 184px, and the row
+              gap is 8px, so the container width at which the rollup hits that floor
+              is 184 + 8 + 70 = 262 → 264. The model predicts the measured table
+              above to within ~2px at every row, which is why it is stated as
+              arithmetic instead of as a round number that happened to look right.
+
+              🔴 A CONTAINER query, for the same reason the owner-Edit swap below is
+              one: card width is NOT monotonic in viewport width (at `base` the grid
+              is ONE column, so a 390px phone gives a ~356px card — wider than the
+              280px a 1200px laptop gets at four columns). A `max-width` media query
+              would hide the rollup on exactly the viewports with the most room.
+
+              🔴 OWNER CARDS ONLY (`showEdit`). A non-owner card has no Edit control,
+              so its actions are 138px and the rollup never drops below 96px at any
+              width the store produces — it is byte-unchanged by this and must stay
+              that way.
+
+              ⚠️ ACCEPTED COLLATERAL, on the record rather than discovered later: the
+              query cannot see WHICH CTA rendered, and the narrow "Open" CTA (actions
+              140px) leaves the rollup its full 96px even at container 248 — measured,
+              untruncated at every width in the sweep. So an owner card
+              whose CTA is "Open"/"Visit" loses a rollup that would have fit, across
+              container 248–264 (viewport ~1200–1264 at four columns). Encoding a
+              second per-CTA threshold to reclaim that 64px band buys a second magic
+              number and a CTA-width classification in the render path; one rule that
+              is occasionally conservative is the better trade. */}
+          <Group
+            gap={4}
+            wrap="nowrap"
+            style={{ minWidth: 0 }}
+            className={showEdit ? 'hidden @[264px]:flex' : undefined}
+          >
             <IconThumbUp
               size={13}
               style={{ flexShrink: 0 }}
@@ -416,7 +476,18 @@ export function AppListingCard({ card, canOpenPage = false }: AppListingCardProp
             </Text>
           </Group>
 
-          <Group gap="xs" wrap="nowrap" style={{ flexShrink: 0 }}>
+          {/* 🔴 `marginLeft: 'auto'` is what keeps the actions RIGHT-ALIGNED when the
+              rollup above is `display: none`. `justify="space-between"` distributes
+              a SINGLE remaining flex item to flex-START, so without this the whole
+              action group jumps to the left edge of the card the moment the rollup
+              is hidden — the exact left-alignment failure the block comment above
+              warns wrapping would cause, reintroduced by a different mechanism.
+              With BOTH children present it is a no-op: auto margins absorb free
+              space before `justify-content` is applied, and one auto margin on the
+              second of two items lands them in precisely the space-between
+              positions. Verified by measurement at both container widths, not
+              assumed. */}
+          <Group gap="xs" wrap="nowrap" style={{ flexShrink: 0, marginLeft: 'auto' }}>
             {/* Owner-only "Edit" deep-link — subtle secondary action, gated by
                 owner + editable status (mod-removed listings hide it). Routes by
                 kind (manifest editor for on-site, submit editor for off-site).

--- a/src/components/Apps/__tests__/appsPageWidths.test.ts
+++ b/src/components/Apps/__tests__/appsPageWidths.test.ts
@@ -3,6 +3,7 @@ import path from 'path';
 import { describe, expect, test } from 'vitest';
 import {
   APPS_FULL_BLEED_PAGES,
+  APPS_NARROW_TABLE_PAGE_WIDTH,
   APPS_PAGE_WIDTHS,
   APPS_READABLE_PAGE_WIDTH,
   APPS_REDIRECT_ONLY_PAGES,
@@ -26,9 +27,24 @@ describe('APPS_PAGE_WIDTHS — the decided value per route', () => {
     expect(APPS_PAGE_WIDTHS['/apps']).toBe(1920);
     expect(APPS_PAGE_WIDTHS['/apps/installed']).toBe(1920);
     expect(APPS_PAGE_WIDTHS['/apps/my-submissions']).toBe(1920);
-    expect(APPS_PAGE_WIDTHS['/apps/review']).toBe(1920);
     expect(APPS_PAGE_WIDTHS['/apps/review/[publishRequestId]']).toBe(1920);
     expect(APPS_PAGE_WIDTHS['/apps/revenue']).toBe(1920);
+  });
+
+  test('the /apps/review QUEUE is the narrow-table width (1400), not the wide one', () => {
+    // Four short columns (Kind / App / Submitter / Submitted) + a Review button
+    // cannot spend 1920: the table pads Submitter out to ~380px for a short
+    // username and opens a large dead gap before the action. Literal values, not
+    // derived from the module's own constant arithmetic.
+    expect(APPS_NARROW_TABLE_PAGE_WIDTH).toBe(1400);
+    expect(APPS_PAGE_WIDTHS['/apps/review']).toBe(1400);
+    // 🔴 The DETAIL route is deliberately NOT moved with it — it renders
+    // side-by-side diff panels + a live preview, which do use the width. If a
+    // later pass narrows the queue further, this is the pin that stops the detail
+    // page being dragged along by association.
+    expect(APPS_PAGE_WIDTHS['/apps/review/[publishRequestId]']).toBe(1920);
+    // …and my-submissions keeps 1920: its table has a real 1424px scroll floor.
+    expect(APPS_PAGE_WIDTHS['/apps/my-submissions']).toBe(1920);
   });
 
   test('the form/detail surfaces are all the READABLE width (1100)', () => {
@@ -50,13 +66,22 @@ describe('APPS_PAGE_WIDTHS — the decided value per route', () => {
     expect(APPS_REDIRECT_ONLY_PAGES).toContain('/apps/[appBlockId]');
   });
 
-  test('every width is one of the TWO decided values — no third hand-picked number', () => {
-    // The whole point of the module is that there are two classes of apps page,
+  test('every width is one of the THREE decided values — no fourth hand-picked number', () => {
+    // The whole point of the module is that there are a few CLASSES of apps page,
     // not eleven bespoke widths. A new page must join a class (or the class list
-    // must grow deliberately, failing here first).
+    // must grow deliberately, failing here first — which is exactly what happened
+    // when `/apps/review` needed the narrow-table class).
     for (const [route, width] of Object.entries(APPS_PAGE_WIDTHS)) {
-      expect([APPS_WIDE_PAGE_WIDTH, APPS_READABLE_PAGE_WIDTH], `${route}`).toContain(width);
+      expect(
+        [APPS_WIDE_PAGE_WIDTH, APPS_NARROW_TABLE_PAGE_WIDTH, APPS_READABLE_PAGE_WIDTH],
+        `${route}`
+      ).toContain(width);
     }
+    // Pin the class list itself, as literals. Without this the check above is
+    // satisfied by ANY set of constants, including a fourth one added silently.
+    expect([APPS_WIDE_PAGE_WIDTH, APPS_NARROW_TABLE_PAGE_WIDTH, APPS_READABLE_PAGE_WIDTH]).toEqual([
+      1920, 1400, 1100,
+    ]);
   });
 
   test('a route is classified exactly once (no overlap between the three lists)', () => {

--- a/src/components/Apps/appsPageWidths.ts
+++ b/src/components/Apps/appsPageWidths.ts
@@ -48,6 +48,30 @@ export const APPS_WIDE_PAGE_WIDTH = 1920;
 export const APPS_READABLE_PAGE_WIDTH = 1100;
 
 /**
+ * The NARROW-TABLE width — a table surface with few, short columns, where 1920 is
+ * not "full width" but "stretched".
+ *
+ * `/apps/review` is the case this exists for. It renders FOUR narrow columns
+ * (Kind / App / Submitter / Submitted) plus a Review button. At 1920 the columns
+ * cannot spend the space, so the table distributes it as padding: Submitter grows
+ * to ~380px to hold a short username, and a large dead gap opens between the last
+ * column and the Review button, which is the action the moderator is actually
+ * aiming at. The same table reads well at 1200.
+ *
+ * 1400 rather than 1200: it keeps the page wider than the readable/form width and
+ * still fills a 1440 laptop edge-to-edge, while stopping short of the width where
+ * the row's two ends stop reading as one row.
+ *
+ * 🔴 This is a THIRD class, deliberately — not a one-off number. The module's rule
+ * is "a page joins a class, or the class list grows on purpose"; the guard in
+ * `__tests__/appsPageWidths.test.ts` enumerates the classes, so adding a fourth
+ * bespoke width still fails there first. `/apps/my-submissions` is NOT moved here:
+ * its table is genuinely wide (a 1424px scroll floor), so 1920 is load-bearing for
+ * it in a way it is not for `/apps/review`.
+ */
+export const APPS_NARROW_TABLE_PAGE_WIDTH = 1400;
+
+/**
  * Container width per `/apps/*` route, keyed by the NEXT ROUTE PATHNAME (the
  * `src/pages` path, `[param]` segments included) so a reader can map an entry to
  * a file without guessing.
@@ -87,7 +111,13 @@ export const APPS_PAGE_WIDTHS = {
    * remains the safety net below 1424 + chrome.
    */
   '/apps/my-submissions': APPS_WIDE_PAGE_WIDTH,
-  '/apps/review': APPS_WIDE_PAGE_WIDTH,
+  /**
+   * NARROW TABLE, not wide. Four short columns (Kind / App / Submitter /
+   * Submitted) cannot spend 1920 — see {@link APPS_NARROW_TABLE_PAGE_WIDTH}. The
+   * DETAIL route below stays wide: it renders side-by-side diff panels + a live
+   * preview, which do use the space.
+   */
+  '/apps/review': APPS_NARROW_TABLE_PAGE_WIDTH,
   '/apps/review/[publishRequestId]': APPS_WIDE_PAGE_WIDTH,
   '/apps/revenue': APPS_WIDE_PAGE_WIDTH,
 


### PR DESCRIPTION
Two independent `/apps` fixes found by a live pass over the store. Both were reported against a build 2 commits behind `main`; **#3547 restyled this exact card in between, so every number below was re-measured on `main` + #3547 before any code was touched.**

---

## A — the owner card's recommend rollup truncates into debris (primary)

### Step 1: re-measurement (the gate)

Issue A **still reproduces**. Measured with the repo's Vitest browser-mode harness, driving the **container** width (the collapse is container-query driven, so viewport is the wrong lever), owner card + the widest CTA ("View details") + **no reviews**:

| card | action-row content box | actions | rollup box | rollup natural | text px | text natural | truncated |
|-----:|-----:|-----:|-----:|-----:|-----:|-----:|:--|
| 280 | **248** | 184 | **54.1** | **96** | **37.1** | **79** | **YES** |
| 300 | 268 | 184 | 74.1 | 96 | 57.1 | 79 | yes |
| 314 | 282 | 184 | 88.1 | 96 | 71.1 | 79 | yes |
| 330 | 298 | 184 | 95.7 | 96 | 78.7 | 79 | no |

Widths are `getBoundingClientRect()`; "truncated" is `scrollWidth > clientWidth` on the `<Text truncate>`.

Card 280 is the store's real 4-column `lg` geometry at a 1200px viewport: `(1200 − 32 container padding − 3×16 gutter) / 4`. So the top row is the most common laptop width there is.

**Controls run in the same sweep**, so the numbers above are attributable rather than just present:
- **non-owner**, same card, same widths → rollup **95.7px at every width, never truncated** (its action set is 138px, not 184px).
- **owner + the narrow "Open" CTA** → rollup **95.7px at every width, never truncated** (actions 140px).

The reported live figures were rollup 50.3 / natural 95.6 on the deployed build; this tree measures 54.1 / 96. #3547 moved it by ~4px (border removal reclaimed 2px, plus prod's different `--mantine-scale`) and did **not** resolve it.

### Step 2: what changed

Below a **264px container**, the recommend rollup is now **hidden** on owner cards rather than shrunk. Truncation stays — it is the designed behaviour of the flexible side — but it now has a floor. A 37px stub of "No reviews yet" is strictly worse than absence: it holds the slot, reads as a rendering bug, and communicates nothing.

**The threshold is arithmetic, not a guess.** The floor we want is a ~70px rollup box = 13px thumb glyph + 4px gap + ~53px of 12px text (~9 characters), enough for `No reviews…` / `91% recom…` to read as a phrase. The widest owner action set (icon-only Edit + "View details") measures 184px and the row gap is 8px, so `184 + 8 + 70 = 262 → 264`. That model predicts every row of the measured table to within ~2px.

A **container** query, not a media query, for the same reason the existing owner-Edit swap is one: card width is not monotonic in viewport width (at `base` the grid is one column, so a 390px phone yields a ~356px card — wider than the 280px a 1200px laptop gets at four columns).

The actions group also gains **`marginLeft: 'auto'`**. With the rollup out of layout the row holds one flex item, and `justify="space-between"` puts a lone item at **flex-start** — without this the whole CTA cluster jumps to the card's left edge. It is a no-op while both children are present (auto margins absorb free space before `justify-content`, landing two items in exactly the space-between positions).

Scoped to `showEdit`, so **non-owner cards are byte-unchanged**.

**Accepted collateral, recorded in the code rather than discovered later:** the container query cannot see *which* CTA rendered, and the narrow "Open"/"Visit" CTA leaves the rollup its full 96px even at container 248. An owner card with that CTA therefore loses a rollup that would have fit, across container 248–264 (viewport ~1200–1264 at four columns). Encoding a second per-CTA threshold to reclaim that band buys a second magic number and a CTA-width classification in the render path; one rule that is occasionally conservative looked like the better trade. Happy to revisit.

---

## B — `/apps/review` is stretched at 1920 (secondary, independent of #3547)

`/apps/review` was classified fluid→1920 alongside the genuinely wide tables. Its four short columns (Kind / App / Submitter / Submitted) cannot spend that width: Submitter pads out to ~380px to hold a short username, and a large dead gap opens before the Review button — the control the moderator is actually aiming at.

Adds a **third** width class, `APPS_NARROW_TABLE_PAGE_WIDTH = 1400`, and moves **only the queue** onto it:
- `/apps/review/[publishRequestId]` **stays 1920** — it renders side-by-side diff panels + a live preview, which do use the space.
- `/apps/my-submissions` **stays 1920** — its table has a real 1424px scroll floor.

The existing fs-walking guard in `__tests__/appsPageWidths.test.ts` still passes and was extended: it pinned "every width is one of the TWO decided values", which is now three, with the class list itself pinned as literals `[1920, 1400, 1100]` so a fourth bespoke number still fails there first.

---

## Step 3 — test coverage, and what it is honestly worth

**Red → green matrix**, verbatim. Run by restoring `AppListingCard.tsx` to its `HEAD` content (`git show HEAD:…`) with the new tests in place, then restoring the fix:

```
base 77cce6c4f5 (component unchanged, new tests present):
  Tests  1 failed | 41 passed (42)
  FAIL … > 🔴 at the REAL 1200 geometry an owner card DROPS the rollup instead of crushing it
  AssertionError: expected 'flex' to be 'none' // Object.is equality

HEAD (fix applied):
  Tests  42 passed (42)
```

The one red test fails on **this guard's own assertion**, not a collateral one.

It **replaces** a test that asserted the opposite — `expect(rollup…width).toBeGreaterThanOrEqual(50)` at this exact geometry — and passed, at 54.1px. That inverted expectation is why #3539 shipped believing the case was handled; the old test and its reasoning are quoted in the new one's docstring.

**Two of the three new tests are labelled in-file as ⚠️ INVARIANT GUARDS, not regression coverage** — they pass before and after the change, and are not counted as proof of the fix. They earn their place by bounding it: one pins that the rollup returns and is legible just above the threshold (so the hide cannot silently widen), one pins that a non-owner card at the identical geometry keeps its full 96px rollup (so the fix cannot lose its `showEdit` scoping). Mutation M3 and M4 below are what show they are not decorative.

**Mutation check** — four mutations, each killed, each by the intended assertion:

| mutation | test that failed | assertion |
|---|---|---|
| M1 — remove the container query entirely | 🔴 the regression test | `expected 'flex' to be 'none'` |
| M2 — remove `marginLeft: 'auto'` | 🔴 the *same* test, **alignment** assertion only | `expected 199.90625 to be close to 264, received difference is 64.09375` |
| M3 — drop the `showEdit` scoping | ⚠️ the NON-owner invariant | `expected 'none' to be 'flex'` |
| M4 — widen the threshold to `@[600px]` | ⚠️ the above-threshold invariant + 3 pre-existing tests | `expected 'none' to be 'flex'`, `expected 0 to be greater than or equal to 80` |

M1 and M2 breaking *different assertions of the same test* is the point: the hide and the re-alignment are independently guarded, so neither can regress behind the other's green.

Expected values are pinned as literals from the measured sweep, not derived from the implementation. Every geometry test sets the container width explicitly.

**A fixture trap worth flagging, caught by the red baseline and not by review:** the file's existing `OFFSITE_CONNECT` fixture spreads `REVIEWED`, so a test that reads as "the no-reviews case" while passing it silently measures `91% recommend (100)` (122px of text) instead of `No reviews yet` (79px). The first draft of these tests made exactly that mistake. A separate `OFFSITE_CONNECT_NO_REVIEWS` fixture is added with a docstring saying why.

## Step 4 — gates run

Flake toolchain (Node 22.22.2, pnpm 10.28.1), counted rather than read off an exit code:

| gate | result |
|---|---|
| `pnpm typecheck` (`tsc --noEmit`) | rc=0, **0 `error TS`** |
| `eslint` on the 4 changed files | clean, no output |
| `vitest --project unit src/components/Apps/` | **44 files, 732 tests passed** |
| `vitest --project component` (card + store surfaces) | **6 files, 89 tests passed** |
| `vitest --project component AppListingCard.browser.test.tsx` | **42 passed** (re-run after the final comment edits) |

## 🔴 CI caveat — read this before treating the new guards as protection

> **CORRECTION (edited after the preview pipeline finished).** An earlier version of this section said the browser-mode project "is NOT run in CI". **That was wrong**, and the `preview / component-tests` check below is the proof. The corrected version is what follows — the conclusion survives, but for a different and worse reason than I originally gave.

**The `component` (Vitest browser-mode) project is not run by GitHub Actions, but it IS run by the preview pipeline as `preview / component-tests` — an explicitly report-only, non-blocking check. That check is currently RED on this PR, and it is red for a pre-existing flake that has nothing to do with this change.**

The single failure is `src/components/AppBlocks/AppBlockChrome.browser.test.tsx > … renders recents (icon + name), EXCLUDES the current app…` — `AssertionError: expected null not to be null`. Nothing in this PR touches that file or its import graph. Evidence it is pre-existing and flaky, gathered instead of asserted:

| PR | preview component-tests |
|---|---|
| **#3547, run A** | **0 failed / 1189 passed** — fully green |
| **#3547, run B** | 2 failed / 1187 passed — **the identical `AppBlockChrome` failure** |
| **#3546** | 1 failed / 1182 passed — **the identical failure** |
| **#3550 (this PR)** | 1 failed / **1190 passed** — the identical failure |

**#3547 produced both verdicts from the same commit**, which is what makes this a flake rather than a regression. The likely mechanism (stated as a hypothesis, not a finding): the test asserts on a Mantine `Avatar`'s `<img>` for an unfetchable `https://cdn.example/…` URL, and Mantine removes that `<img>` from the DOM once the load error fires — so the assertion races DNS failure speed. That is the same unfetchable-URL behaviour `AppListingCard.browser.test.tsx` already documents and deliberately exercises.

The passing count moved 1189 → 1190 with one file's worth of my edits (+3 new tests, −1 replaced, and the pre-existing flake still counted as the 1 failure), which is the arithmetic confirming my additions actually ran in that tier.

**What this means for the guards in this PR — the conclusion is unchanged and slightly worse than I first wrote:** the three new geometry tests do execute in the preview tier, but that tier is **non-blocking and has been red across multiple recent merged PRs**, so it cannot stop a regression and in practice trains reviewers to skip it. A permanently-red non-blocking gate is weaker than no gate. Do not read the green boxes above as protection for Issue A.

The blocking coverage this PR adds is the `unit`-project half: the `/apps/review` width pins and the class-list pin in `__tests__/appsPageWidths.test.ts`. Issue A's fix is CSS geometry and has **no blocking test**.

## Not verified

- **Not verified against production.** Every number here is from the browser-mode harness on `main` + #3547, in headless Chromium at a scale where Mantine's border is exactly 1px/side. Prod runs a different `--mantine-scale` (the 0.877px border in the original report), so the absolute pixel values will differ by a few px there. The *sign* of the effect — hidden vs 54px — does not depend on that, but the exact widths do.
- **The rendered glyph count is inferred, not read.** "37px of text ≈ a 5-character stub" is derived from the measured text width at 12px; I did not screenshot-diff the rendered string. The live report's "No ..." is what corroborates it.
- **Issue B's stretched appearance was not re-measured** — no owner-visible `/apps/review` fixture was rendered at 1920 in this pass. The 1400 value is a judgement about column count and measure, taken from the reported observation, not from a measurement I made.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

