### PR TITLE
fix(tests): unbreak the AppBlockChrome recents-icon test (unloadable fixture URL raced Mantine Avatar's error swap)

### DIFF
--- a/src/components/AppBlocks/AppBlockChrome.browser.test.tsx
+++ b/src/components/AppBlocks/AppBlockChrome.browser.test.tsx
@@ -299,6 +299,12 @@ describe('AppBlockChrome "Recently run" section (platform-nav dropdown)', () => 
     clearRecentlyOpenedApps();
   });
 
+  // A data: URI that actually loads — an http URL fails in-browser (Mantine Avatar
+  // fires onError and swaps the <img> for a placeholder span ~11 ms after mount),
+  // making the `expect(img).not.toBeNull()` assertion race the error path.
+  const LOADABLE_ICON =
+    'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';
+
   // The platform-nav Menu mounts its dropdown lazily — open it first (its trigger
   // is "Apps menu", distinct from the ⋯ "App menu").
   async function openPlatformNav() {
@@ -314,7 +320,7 @@ describe('AppBlockChrome "Recently run" section (platform-nav dropdown)', () => 
       id: 'other',
       blockId: 'other-block',
       name: 'Other App',
-      iconUrl: 'https://cdn.example/icon.png',
+      iconUrl: LOADABLE_ICON,
     });
 
     renderWithProviders(
@@ -336,7 +342,7 @@ describe('AppBlockChrome "Recently run" section (platform-nav dropdown)', () => 
     expect(other.getAttribute('href')).toBe('/apps/run/other-block');
     const otherImg = other.querySelector('img');
     expect(otherImg).not.toBeNull();
-    expect(otherImg?.getAttribute('src')).toBe('https://cdn.example/icon.png');
+    expect(otherImg?.getAttribute('src')).toBe(LOADABLE_ICON);
 
     // Icon-less entry falls back to a generic app icon (an <svg>, no <img>).
     const noicon = page.getByRole('menuitem', { name: 'No Icon App' }).element() as HTMLElement;


### PR DESCRIPTION
## What was red

`src/components/AppBlocks/AppBlockChrome.browser.test.tsx:338` — *"renders recents (icon + name), EXCLUDES the current app, links to `/apps/run/<blockId>`"* — failed with:

```
AssertionError: expected null not to be null
 ❯ src/components/AppBlocks/AppBlockChrome.browser.test.tsx:338:25
```

**This was pre-existing on `main`, not caused by any PR.** The identical failure at the identical line appeared on PRs #3545, #3546, #3547 and #3549 — four unrelated changes. The `component-tests` run for #3550 (now main's tip) reports `1 failed | 1190 passed (1191)`, and that one failure *is* this test.

It is **not** a screenshot test — the `__screenshots__/*.png` path in the log is just vitest browser-mode's auto-captured failure artifact. This is a plain DOM assertion.

## Root cause

The fixture seeded a **non-resolvable URL**:

```ts
iconUrl: 'https://cdn.example/icon.png'
```

The component renders it through Mantine's `Avatar` (`IframeHost.tsx`). Mantine v7.17.8's Avatar is:

```js
const [error, setError] = useState(!src);
…
error ? <span {...placeholder}/> : <img src={src} onError={() => setError(true)} … />
```

So in a real Chromium the load fails → `setError(true)` → the `<img>` is **replaced by a placeholder `<span>`**.

Measured in-browser with a probe (positive control included — a `data:` URI polled for 5 s, never removed):

| fixture | `<img>` at mount | `<img>` removed after |
|---|---|---|
| `https://cdn.example/icon.png` | yes | **11 ms** |
| `data:image/gif;base64,…` (control) | yes | never |

The assertion was racing an ~11 ms window. It won on a dev box and lost in the CI pod — which is why it looked intermittent-but-always-red-in-CI rather than simply broken.

**This is a test defect, not a product defect** — the product correctly falls back to a placeholder for an icon that won't load. No product code is touched by this PR.

## The fix

Replace the fixture with an inline 1x1 GIF `data:` URI that loads with no network, hoisted into a named const with a comment recording *why* an http URL must not be reintroduced. Both the seeding call and the `src` assertion use it.

`expect(otherImg).not.toBeNull()` is **unchanged** — it still proves a real `<img>` rendered. Nothing was skipped, weakened, or given a timeout.

## Evidence

**RED → GREEN, same worktree, same 150 ms delay inserted before the assertion:**

| | fixture | result |
|---|---|---|
| pre-fix | `https://cdn.example/icon.png` | **FAIL** — `expected null not to be null` at `:339:25` |
| post-fix | `data:` URI | **21/21 pass** |

Same timing, different fixture — so the fix removes the race rather than moving it.

**Mutation check** — forcing the icon branch off in `IframeHost.tsx` (`r.iconUrl ?` → `false ?`):

```
PASS=20 FAIL=1
 ×  … renders recents (icon + name), EXCLUDES the current app, links to /apps/run/<blockId>
AssertionError: expected null not to be null
 ❯ src/components/AppBlocks/AppBlockChrome.browser.test.tsx:344:25   ← expect(otherImg).not.toBeNull()
```

Exactly one test dies, at exactly this assertion, for exactly its own reason. The guard is live and reachable, not vacuous.

**Suite results (local, real Chromium):**
- `AppBlockChrome.browser.test.tsx` — 21 passed / 0 failed
- `src/components/AppBlocks/` sweep — **301 passed / 0 failed** (293 in the serial sweep + 8 in `PageBlockHostWildcardPack`, which hit the known cold-`optimizeDeps` *"Vitest failed to find the runner"* artifact in the sweep and passes warm — environmental, unrelated to this change)

**No new formatting debt:** the file is not prettier-clean on `main`; running prettier over both the pristine and the patched copy and diffing shows *only* these three hunks, so this PR introduces zero new violations.