### PR TITLE
fix(apps): drop 36px of vertical chrome from /apps without breaking the header band

### DIFF
--- a/src/components/Apps/AppsPageLayout.browser.test.tsx
+++ b/src/components/Apps/AppsPageLayout.browser.test.tsx
@@ -108,9 +108,18 @@ describe('AppsPageLayout — exactly ONE rule under the tabs', () => {
     expect(band.style.getPropertyValue('--stack-gap')).toBe('var(--mantine-spacing-md)');
     expect(outer.style.getPropertyValue('--stack-gap')).toBe('var(--mantine-spacing-xl)');
 
-    // …and the band's own BOTTOM padding is gone, so the header group hugs the
-    // tabs it belongs to instead of sitting equidistant. (`pt="sm"`, no `pb`.)
-    expect(band.style.paddingTop).not.toBe('');
+    // …and the band carries NO vertical padding of its own, so the header group
+    // hugs the tabs it belongs to instead of sitting equidistant.
+    //
+    // UPDATED (vertical-padding pass): the first line used to be
+    // `expect(band.style.paddingTop).not.toBe('')`, pinning the `pt="sm"` that
+    // has now been deliberately removed. That pad sat ABOVE the tabs — outside
+    // the tabs↔title relationship — so it never contributed to the grouping this
+    // test is about; the two `--stack-gap` assertions above are the grouping, and
+    // they are untouched. The `paddingBottom` assertion is UNCHANGED in force: a
+    // bottom pad here would sit between the title and the body and re-centre the
+    // title, which is the exact float the removed rule left behind.
+    expect(band.style.paddingTop).toBe('');
     expect(band.style.paddingBottom).toBe('');
   });
 });

--- a/src/components/Apps/AppsPageLayout.geometry.browser.test.tsx
+++ b/src/components/Apps/AppsPageLayout.geometry.browser.test.tsx
@@ -1,0 +1,192 @@
+/**
+ * `/apps` chrome — RENDERED VERTICAL GEOMETRY.
+ *
+ * 🔴 READ THIS BEFORE TRUSTING IT AS A GATE: it is not one. This file is in the
+ * Vitest browser-mode `component` project, which CI runs only as the preview
+ * pipeline's `preview / component-tests` — REPORT-ONLY, non-blocking, and red
+ * repo-wide at time of writing for an unrelated pre-existing failure in
+ * `AppBlockChrome.browser.test.tsx`. So nothing here can block a regression. The
+ * enforceable half of this change lives as source guards in the blocking `unit`
+ * project (`__tests__/appsPageLayout.test.ts`); this file exists because the
+ * SOURCE guards pin token names and only a real render can pin PIXELS — and the
+ * layout's own comments record that token math already overstated a visual
+ * difference once (a Title's line box eats part of the nominal gap).
+ *
+ * 🔴 WHY THIS FILE LOADS `@mantine/core/styles.css` AND THE OTHERS MUST NOT.
+ * The shared component scaffold deliberately omits Mantine's stylesheet, so the
+ * sibling browser tests assert only inline styles / ARIA (see the note in
+ * `AppsPageLayout.browser.test.tsx`). But every number this file is about —
+ * `Stack`'s `gap` (a stylesheet rule consuming `--stack-gap`), the tab row's
+ * padding, the rule under the tabs — comes FROM that stylesheet. Without the
+ * import each of them computes to 0 and every assertion below passes while
+ * measuring nothing. Vitest browser mode runs each test file in its own iframe,
+ * so the import does not leak into the sibling suites (verified by running them
+ * together and confirming their results are unchanged).
+ *
+ * Numbers below were measured at a 1440x900 viewport, before and after the
+ * vertical-padding pass:
+ *
+ *                                   before    after
+ *   container top -> tab row           28        0
+ *   tab row height                     37       29
+ *   tabs rule -> title box             16       16   <- grouping, unchanged
+ *   band -> page body                  32       32   <- grouping, unchanged
+ *   store index: top -> body           97       61   (-36)
+ *   hasHeader:   top -> body       172.39   136.39   (-36)
+ */
+import '@mantine/core/styles.css';
+import { describe, expect, test, vi } from 'vitest';
+import type { ReactElement } from 'react';
+import { page } from 'vitest/browser';
+// `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
+import { renderWithProviders } from '../../../test/component-setup';
+import type * as TrpcMod from '~/utils/trpc';
+
+vi.mock('~/providers/FeatureFlagsProvider', () => ({
+  useFeatureFlags: () => ({ appBlocks: true }),
+}));
+vi.mock('~/providers/IsClientProvider', () => ({ useIsClient: () => true }));
+vi.mock('~/hooks/useCurrentUser', () => ({ useCurrentUser: () => null }));
+// Spread the REAL module and override only `trpc` (local-rules/no-wholesale-
+// module-mock) — see the sibling browser test for why.
+vi.mock('~/utils/trpc', async (importOriginal) => ({
+  ...(await importOriginal<typeof TrpcMod>()),
+  trpc: { blocks: { getNavSummary: { useQuery: () => ({ data: undefined }) } } },
+}));
+
+const { AppsPageLayout } = await import('./AppsPageLayout');
+
+const pad = (el: Element, side: 'Top' | 'Bottom' | 'Left' | 'Right') =>
+  Math.round(parseFloat(getComputedStyle(el)[`padding${side}` as 'paddingTop']) * 100) / 100;
+
+type Geometry = ReturnType<typeof measure>;
+
+function measure() {
+  const nav = document.querySelector('nav[aria-label="App sections"]') as HTMLElement;
+  const band = nav.parentElement as HTMLElement;
+  const container = band.parentElement?.parentElement as HTMLElement;
+  const firstTab = document.querySelector('[role="tab"]') as HTMLElement;
+  const title = document.querySelector('h2') as HTMLElement | null;
+  const body = document.querySelector('[data-testid="body"]') as HTMLElement;
+
+  const tabRect = firstTab.getBoundingClientRect();
+  const containerTop = container.getBoundingClientRect().top;
+  const bandRect = band.getBoundingClientRect();
+  const bodyTop = body.getBoundingClientRect().top;
+  const titleTop = title?.getBoundingClientRect().top ?? null;
+
+  return {
+    // Guard-the-guard: if the stylesheet failed to load, the tab collapses and
+    // every gap below reads 0. Asserted in each test before anything else.
+    styleSheetLoaded: pad(firstTab, 'Left') > 0,
+    containerTopToTabs: Math.round((nav.getBoundingClientRect().top - containerTop) * 100) / 100,
+    tabHeight: Math.round(tabRect.height * 100) / 100,
+    tabPadBlock: [pad(firstTab, 'Top'), pad(firstTab, 'Bottom')] as const,
+    tabPadInline: [pad(firstTab, 'Left'), pad(firstTab, 'Right')] as const,
+    tabWidth: Math.round(tabRect.width * 100) / 100,
+    containerPadInline: [pad(container, 'Left'), pad(container, 'Right')] as const,
+    containerPadTop: pad(container, 'Top'),
+    containerPadBottom: pad(container, 'Bottom'),
+    // 🔴 THE REMAINING RULE LIVES ON `Tabs.List::before`, NOT ON THE TAB.
+    // Probed directly, because the obvious reading is wrong in a way that makes a
+    // guard vacuous: `getComputedStyle(tab).borderBottomWidth` is also `2px`, but
+    // its COLOR is `rgba(0, 0, 0, 0)` — a transparent slot Mantine fills in only
+    // on the ACTIVE tab. Asserting that width is >0 therefore passes with the
+    // real hairline deleted. The visible rule is the list's `::before`: an
+    // absolutely-positioned 2px `rgb(222, 226, 230)` bar at the list's bottom
+    // edge. Colour is captured alongside width so the assertion can require the
+    // rule to be VISIBLE, not merely declared.
+    listRule: (() => {
+      const before = getComputedStyle(nav.querySelector('[role="tablist"]') as Element, '::before');
+      return {
+        width: Math.round(parseFloat(before.borderBottomWidth) * 100) / 100,
+        color: before.borderBottomColor,
+      };
+    })(),
+    tabsRuleToTitle: titleTop != null ? Math.round((titleTop - tabRect.bottom) * 100) / 100 : null,
+    bandToBody: Math.round((bodyTop - bandRect.bottom) * 100) / 100,
+    topToBody: Math.round((bodyTop - containerTop) * 100) / 100,
+  };
+}
+
+async function renderAndMeasure(ui: ReactElement): Promise<Geometry> {
+  await page.viewport(1440, 900);
+  renderWithProviders(ui);
+  await expect.element(page.getByTestId('body')).toBeInTheDocument();
+  // Two frames so layout + the injected stylesheet have both settled.
+  await new Promise((res) => requestAnimationFrame(() => requestAnimationFrame(res)));
+  return measure();
+}
+
+const body = (
+  <div data-testid="body" style={{ height: 200 }}>
+    body
+  </div>
+);
+
+describe('/apps chrome vertical geometry', () => {
+  test('store index (no header): 61px of chrome above the body', async () => {
+    const g = await renderAndMeasure(<AppsPageLayout>{body}</AppsPageLayout>);
+    expect(g.styleSheetLoaded).toBe(true);
+
+    // REGRESSION coverage — each of these was different before the pass.
+    expect(g.containerPadTop).toBe(0); // was 16 (`py="md"`)
+    expect(g.containerTopToTabs).toBe(0); // was 28 (16 container + 12 band `pt="sm"`)
+    expect(g.tabHeight).toBe(29); // was 37
+    // 0 + 29 (tabs) + 32 (band->body) = 61. Every term is an integer, so unlike
+    // the `hasHeader` total this does NOT drift with font metrics.
+    expect(g.topToBody).toBe(61); // was 97
+
+    // The bottom pad is kept ON PURPOSE — this Container is the outermost element
+    // on every apps page, so it is the only thing holding the last grid row off
+    // whatever follows. A bare `<Container size={size}>` would zero it.
+    expect(g.containerPadBottom).toBe(16);
+  });
+
+  test('hasHeader page: the grouping pair survives the pass unchanged', async () => {
+    const g = await renderAndMeasure(
+      <AppsPageLayout
+        title="Your installed apps"
+        subtitle="Manage them"
+        actions={<button>Act</button>}
+      >
+        {body}
+      </AppsPageLayout>
+    );
+    expect(g.styleSheetLoaded).toBe(true);
+
+    // 🔴 INVARIANT GUARD — these two are IDENTICAL before and after the pass, so
+    // they are NOT regression coverage for it. They are the point of the test:
+    // with the duplicate rule gone, this 16-vs-32 ratio is the ONLY thing
+    // grouping the header band, and the pass moved everything around it. Pinning
+    // them is what makes "the padding is free to move, these are not" checkable.
+    expect(g.tabsRuleToTitle).toBe(16);
+    expect(g.bandToBody).toBe(32);
+    expect(g.bandToBody).toBe(2 * (g.tabsRuleToTitle as number));
+
+    // The one remaining rule is still drawn AND still visible. Both halves are
+    // needed: a transparent 2px border satisfies a width-only check (which is
+    // exactly what the tab's own border-bottom is), so the colour is asserted to
+    // be opaque rather than merely present.
+    expect(g.listRule.width).toBeGreaterThan(0);
+    expect(g.listRule.color).not.toMatch(/rgba\([^)]*,\s*0\)$/);
+
+    // REGRESSION: the chrome above the title collapsed by 28px (16 + 12).
+    expect(g.containerTopToTabs).toBe(0);
+  });
+
+  test('HORIZONTAL geometry is byte-identical to before the pass', async () => {
+    // INVARIANT GUARD — green before and after. The brief was vertical-only, and
+    // the natural failure mode of the tab edit (a `padding` shorthand instead of
+    // `paddingBlock`) shows up HERE, as a narrower tab, not in any vertical
+    // number. Measured 133.27px / 16px inline on both sides of the change.
+    const g = await renderAndMeasure(<AppsPageLayout>{body}</AppsPageLayout>);
+    expect(g.styleSheetLoaded).toBe(true);
+
+    expect(g.tabPadInline).toEqual([16, 16]);
+    expect(g.tabWidth).toBeCloseTo(133.27, 1);
+    expect(g.containerPadInline).toEqual([16, 16]);
+    // …while the block axis DID move.
+    expect(g.tabPadBlock).toEqual([6, 6]);
+  });
+});

--- a/src/components/Apps/AppsPageLayout.tsx
+++ b/src/components/Apps/AppsPageLayout.tsx
@@ -48,8 +48,14 @@ export function AppsPageLayout({
   children: ReactNode;
 }) {
   const hasHeader = Boolean(title || subtitle || actions);
+  // `pb` only — NO `py`. The top pad is deliberately gone so `/apps/*` starts
+  // directly under the global header instead of 16px below it; the BOTTOM pad
+  // stays because this Container is the outermost element on every apps page, so
+  // its `pb` is the only thing keeping the last grid row / table row off whatever
+  // follows. Horizontal padding is untouched (Container's own responsive gutter)
+  // — this pass is vertical-only, so `size` and the side gutters are unchanged.
   return (
-    <Container size={size} py="md">
+    <Container size={size} pb="md">
       {/* `xl` (32px), not `lg` (20px). With the band's own rule removed, the ONLY
           thing telling a viewer where the header ends and the page begins is the
           size of this gap relative to the `md` (16px) gap INSIDE the band. At
@@ -81,17 +87,26 @@ export function AppsPageLayout({
           thing separating the title from the page content, so dropping it alone
           would leave the title floating between the tab border and the body.
           The band is therefore held together by PROXIMITY instead of a rule:
-            - `pt="sm"` (was `py="sm"`): the bottom pad is gone, so the header
-              group hugs the tabs it belongs to rather than sitting equidistant.
+            - NO vertical padding of its own (was `pt="sm"`, and `py="sm"` before
+              that). 🔴 Neither pad ever participated in the grouping: `pt` sits
+              ABOVE the tabs, i.e. OUTSIDE the tabs↔title relationship entirely,
+              so it only pushed the whole band down the page. `pb` was already
+              removed because it DID matter — it sat between the title and the
+              body and made the title equidistant. Dropping `pt` therefore moves
+              the band up without touching what holds it together; measured on a
+              1440 render, the two gaps below are byte-identical before and after
+              (16px / 32px).
             - `gap="md"` (16px) INSIDE the band, vs the parent `Stack gap="xl"`
               (32px) from the band to the content — the title is measurably
               closer to the tabs than to the body, which is what makes them read
               as one unit without a second line. (See the note on that parent
-              Stack for why `lg` was not enough.)
+              Stack for why `lg` was not enough.) 🔴 THIS PAIR IS THE GROUPING.
+              Change either number and the title starts floating; the vertical
+              padding around the band is free to move, these two are not.
           A no-header page (the store) is unaffected apart from losing the
           duplicate rule.
         */}
-        <Stack gap="md" pt="sm">
+        <Stack gap="md">
           <AppsSubNav />
           {hasHeader && (
             <Group justify="space-between" align="flex-end" wrap="nowrap" gap="md">

--- a/src/components/Apps/AppsSubNav.tsx
+++ b/src/components/Apps/AppsSubNav.tsx
@@ -1,4 +1,4 @@
-import { Box, ScrollArea, Tabs } from '@mantine/core';
+import { Box, rem, ScrollArea, Tabs } from '@mantine/core';
 import {
   IconBuildingStore,
   IconCurrencyDollar,
@@ -135,7 +135,31 @@ export function AppsSubNavView({
   return (
     <Box component="nav" aria-label="App sections" w="100%">
       <ScrollArea type="never" w="100%">
-        <Tabs value={active} variant="default" w="100%" activateTabWithKeyboard={false}>
+        <Tabs
+          value={active}
+          variant="default"
+          w="100%"
+          activateTabWithKeyboard={false}
+          // VERTICAL padding only. Mantine's default Tab padding is the shorthand
+          // `var(--mantine-spacing-xs) var(--mantine-spacing-md)` = 10px block /
+          // 16px inline, giving a 37px tab row. `paddingBlock` overrides ONLY the
+          // block axis, so the 16px inline padding from that shorthand survives
+          // untouched and the tabs keep their horizontal hit area and rhythm.
+          // 6px → a 29px row (measured, 1440 render): still clears WCAG 2.5.8
+          // Target Size (Minimum, AA) — 24×24 CSS px — with the anchor's full
+          // width as the horizontal target.
+          //
+          // 🔴 This does NOT touch the grouping below the tabs. The separator is
+          // `Tabs.List::before` (a 2px bar pinned to the LIST's bottom edge — not
+          // the tab's own border-bottom, which is a transparent active-indicator
+          // slot). The list is exactly as tall as its tabs, so shrinking the tab
+          // shrinks the list and the rule travels UP with it, while
+          // `AppsPageLayout`'s `Stack gap="md"` holds the rule↔title gap at a
+          // fixed 16px. If anything it tightens the band: the tab LABEL sits 6px
+          // above the rule instead of 10px, so label↔title goes 26px → 22px
+          // against an unchanged 32px band↔body.
+          styles={{ tab: { paddingBlock: rem(6) } }}
+        >
           <Tabs.List style={{ flexWrap: 'nowrap' }}>
             {links.map((link) => {
               const Icon = link.icon;

--- a/src/components/Apps/__tests__/appsPageLayout.test.ts
+++ b/src/components/Apps/__tests__/appsPageLayout.test.ts
@@ -47,16 +47,64 @@ describe('AppsPageLayout draws no rule of its own', () => {
     expect(layoutSrc()).toMatch(/export function AppsPageLayout/);
   });
 
-  it('the header band keeps its TOP padding and drops its bottom one', () => {
-    // The proximity grouping that replaced the rule: the header group hugs the
-    // tabs above it (`pt="sm"`, no `pb`) and the parent `Stack gap="xl"` supplies
-    // the larger separation to the page body. Reverting to `py="sm"` re-centres
-    // the title between the two and the band stops reading as a band.
+  it('the header band carries NO vertical padding of its own', () => {
+    // UPDATED (vertical-padding pass): this used to pin `pt="sm"` on the band.
+    // That pad was dropped deliberately — it sat ABOVE the tabs, i.e. outside the
+    // tabs↔title relationship, so it only pushed the band down the page and was
+    // never part of the grouping (measured: the two gaps below are identical at
+    // 16px/32px with and without it).
+    //
+    // The `pb` half of the original assertion is UNCHANGED in force and is what
+    // still matters: a `pb` sits BETWEEN the title and the body and would make
+    // the title equidistant, which is exactly the float the removed rule left
+    // behind. `py` would reintroduce it, so both are still banned.
     const src = layoutSrc();
-    expect(src).toMatch(/<Stack\s+gap="md"\s+pt="sm">/);
+    expect(src).toMatch(/<Stack\s+gap="md">/);
     // Scoped to a `<Stack …>` TAG, not the whole file — the prose above mentions
-    // the reverted form, and a whole-file regex would match its own explanation.
+    // the reverted forms, and a whole-file regex would match its own explanation.
     expect(src).not.toMatch(/<Stack[^>]*\bpy=/s);
+    expect(src).not.toMatch(/<Stack[^>]*\bpb=/s);
+  });
+
+  it('🔴 the PROXIMITY PAIR that groups the band is intact (16px in / 32px out)', () => {
+    // INVARIANT GUARD — passes both before and after the vertical-padding pass;
+    // it is NOT regression coverage for that change. It exists because the pair
+    // below is the ONLY thing grouping the header band since the duplicate rule
+    // was removed, and the padding pass deliberately moved everything AROUND it.
+    // Pinning it makes "the padding is free to move, these two are not" (the
+    // comment in AppsPageLayout) enforceable rather than advisory.
+    const src = layoutSrc();
+    // Band-internal gap: tabs -> title.
+    expect(src).toMatch(/<Stack\s+gap="md">/);
+    // Parent gap: band -> page body. Was `lg` once; 20-vs-16 grouped nothing.
+    expect(src).toMatch(/<Stack\s+gap="xl">/);
+    expect(src).not.toMatch(/<Stack\s+gap="lg">/);
+  });
+
+  it('the layout Container drops its TOP pad but keeps a bottom one', () => {
+    // Regression coverage for the vertical-padding pass: FAILS on pre-change
+    // source, which carried `py="md"` (a 16px top pad under the global header).
+    //
+    // `pb` is asserted PRESENT, not merely "no py": this Container is the
+    // outermost element on every `/apps/*` page, so its bottom pad is the only
+    // thing keeping the last grid/table row off whatever follows. Dropping to a
+    // bare `<Container size={size}>` would satisfy a "no py" check alone.
+    const src = layoutSrc();
+    expect(src).toMatch(/<Container\s+size=\{size\}\s+pb="md">/);
+    expect(src).not.toMatch(/<Container[^>]*\bpy=/s);
+    expect(src).not.toMatch(/<Container[^>]*\bpt=/s);
+  });
+
+  it('HORIZONTAL geometry is untouched by the vertical pass', () => {
+    // INVARIANT GUARD — green before and after. The pass was scoped to vertical
+    // padding; these pin the things it was explicitly not allowed to move, so a
+    // future "tighten the apps chrome" edit can't quietly take the side gutters
+    // or the container width with it.
+    const src = layoutSrc();
+    // Width still comes from the caller's `size` prop, not a hardcoded value.
+    expect(src).toMatch(/<Container\s+size=\{size\}/);
+    // No horizontal padding override of any kind on the Container.
+    expect(src).not.toMatch(/<Container[^>]*\b(px|pl|pr)=/s);
   });
 });
 
@@ -65,5 +113,31 @@ describe('the sub-nav still supplies the ONE remaining rule', () => {
     const src = subNavSrc();
     expect(src).toMatch(/<Tabs\b[^>]*variant="default"/s);
     expect(src).toMatch(/<Tabs\.List\b/);
+  });
+});
+
+describe('the sub-nav tab row is tightened on the BLOCK axis only', () => {
+  it('the tab padding override exists and is block-axis', () => {
+    // Regression coverage for the vertical-padding pass: FAILS on pre-change
+    // source, which had no `styles` prop on `<Tabs>` at all (the row ran at
+    // Mantine's default 10px block padding = a 37px row; it is 29px now).
+    const src = subNavSrc();
+    expect(src).toMatch(/styles=\{\{\s*tab:\s*\{\s*paddingBlock:/);
+  });
+
+  it('🔴 the tab override can NEVER touch the inline (horizontal) axis', () => {
+    // The load-bearing half. `paddingBlock` overrides only the block axis, so the
+    // 16px inline padding from Mantine's `padding: xs md` shorthand survives and
+    // the tabs keep their horizontal hit area. Swapping it for a `padding`
+    // shorthand — the single most natural "cleanup" edit here — would silently
+    // reset that inline padding to whatever the shorthand says and shrink every
+    // tab's click target. Measured: tab width 133.27px before AND after.
+    //
+    // Scoped to the `styles={{ tab: … }}` block so the surrounding prose (which
+    // names the shorthand it is warning about) can't satisfy or trip the check.
+    const styleBlock = subNavSrc().match(/styles=\{\{\s*tab:\s*\{([^}]*)\}/)?.[1];
+    expect(styleBlock).toBeTruthy();
+    expect(styleBlock).not.toMatch(/\bpadding\s*:/);
+    expect(styleBlock).not.toMatch(/paddingInline|paddingLeft|paddingRight/);
   });
 });


### PR DESCRIPTION
Vertical-padding-only pass on the `/apps` chrome: the pages started 28px below the global header and ran a 37px tab row. **Horizontal geometry is untouched** — side gutters, container width and the `size` prop are unchanged, and pinned as such.

## What changed

| file | change |
|---|---|
| `AppsPageLayout.tsx` | `<Container … py="md">` → `pb="md"` (top pad dropped, bottom pad kept) |
| `AppsPageLayout.tsx` | header band `<Stack gap="md" pt="sm">` → `<Stack gap="md">` |
| `AppsSubNav.tsx` | `<Tabs styles={{ tab: { paddingBlock: rem(6) } }}>` (was Mantine's default 10px) |

**Why `pb="md"` and not dropping `py` outright.** This `Container` is the outermost element on every `/apps/*` page, so its bottom pad is the only thing holding the last grid/table row off whatever follows. The stated goal is entirely about the top, so I kept the bottom pad rather than take an unmotivated second change. Flagging it as a judgement call — going to zero is a one-token edit if you'd rather have it.

## Measured geometry

Real render, 1440×900, Mantine's stylesheet loaded (the shared component scaffold deliberately omits it, so gaps otherwise compute to 0 and any measurement is fiction).

| | before | after | Δ |
|---|---|---|---|
| container top → tab row | 28 | 0 | **−28** |
| tab row height | 37 | 29 | **−8** |
| store index: top → body | 97 | 61 | **−36** |
| `hasHeader`: top → body | 172.39 | 136.39 | **−36** |
| **tabs rule → title (band internal)** | **16** | **16** | **0** |
| **band → page body (parent gap)** | **32** | **32** | **0** |
| tab width / padding-inline | 133.27 / 16,16 | 133.27 / 16,16 | **0** |

## How the header-band grouping is preserved

It is **preserved, not re-derived** — I did not change the ratio.

Since #3539 removed the duplicate rule, proximity is the only thing grouping the band, and it's carried by two gaps: `gap="md"` (16px) tabs→title *inside* the band vs the parent `Stack gap="xl"` (32px) band→body. **Neither pad removed here participates in either gap.** The container's `py` and the band's `pt` both sit *above* the tabs — outside the tabs↔title relationship entirely — so they only pushed the whole band down the page. The band's `pb`, which *did* sit between title and body and made the title equidistant, was already absent and remains banned by test.

Measured: 16px and 32px, byte-identical before and after.

The tab change actually **tightens** the band rather than loosening it. The separator is `Tabs.List::before`, pinned to the list's bottom edge; the list is exactly as tall as its tabs, so it travels up with them while the 16px rule→title gap is held by the Stack. Tab-label→title therefore goes 26px → 22px against an unchanged 32px band→body.

Two details worth recording, both measured rather than assumed:
- The separator is **`Tabs.List::before`** (2px, `rgb(222,226,230)`). The *tab's* own `border-bottom` is also 2px but **transparent** (`rgba(0,0,0,0)`) — an inactive active-indicator slot. My first version of the rule assertion read the tab's border and would have passed with the real hairline deleted; it now reads the list's `::before` and asserts the colour is opaque.
- `paddingBlock`, not a `padding` shorthand — the shorthand would silently reset the 16px inline padding and shrink every tab's click target. Guarded.

Accessibility: the 29px row still clears WCAG 2.5.8 Target Size (Minimum, AA) at 24×24 CSS px, with the anchor's full width as the horizontal target.

The `useIsClient()` hydration guard in `AppsSubNav` is untouched.

## Tests

**Updated (2), both because they pinned a value this change intentionally moves:**

1. `__tests__/appsPageLayout.test.ts` — `expect(src).toMatch(/<Stack\s+gap="md"\s+pt="sm">/)` pinned the band's `pt`. Now asserts `<Stack gap="md">`. **The `pb` half of that test is unchanged in force** and still bans both `py` and `pb` on a `Stack` — that's the assertion protecting the title from re-centring, and it was not weakened.
2. `AppsPageLayout.browser.test.tsx` — `expect(band.style.paddingTop).not.toBe('')` → `.toBe('')`. Same reasoning; the two `--stack-gap` assertions in that test (the actual grouping) are untouched, as is the `paddingBottom` assertion.

Nothing protecting the hydration guard or the no-double-rule invariant was touched.

**New coverage, classified honestly:**

*Blocking `unit` project — regression coverage (fails on pre-change source):*
- Container drops its top pad but keeps a bottom one
- the tab padding override exists and is block-axis

*Blocking `unit` project — INVARIANT GUARDS (green before AND after; not proof of this change):*
- the proximity pair is intact (16px in / 32px out)
- the tab override can never touch the inline axis
- horizontal geometry is untouched

*Browser-mode `component` project — see the CI caveat below:*
- `AppsPageLayout.geometry.browser.test.tsx` (new): the pixel measurements above. Mixed regression + invariant, labelled per-assertion in the file.

**Mutation results — every guard broken deliberately, each failing for its own reason:**

| mutation | killed by | failure |
|---|---|---|
| `pb="md"` → `py="md"` | Container top-pad guard | `to match /<Container\s+size=\{size\}\s+pb="md">/` |
| re-add `pt="sm"` | band vertical-padding guard | `to match /<Stack\s+gap="md">/` |
| `paddingBlock` → `padding` | inline-axis guard | `expected ' padding: rem(6) ' not to match /\bpadding\s*:/` |
| `rem(6)` → `rem(10)` | geometry | `expected 37 to be 29`; `[10,10]` vs `[6,6]` |
| band `gap="md"` → `gap="lg"` | geometry grouping guard | `expected 20 to be 16` |
| remove the stylesheet import | harness negative control | all 3 red on `styleSheetLoaded` |
| `variant="default"` → `"pills"` | list-rule guard | `expected 0 to be greater than 0` |

The last two matter most. Removing the stylesheet import turns the geometry file **red rather than green-on-zeros**, so the numbers are real measurements. And the `pills` mutation is what proved the *corrected* rule assertion is reachable — the original one survived it.

## Test counts

| gate | result |
|---|---|
| Typecheck (`tsc --noEmit`) | clean, exit 0 |
| ESLint (changed files) | exit 0 |
| Prettier `--check` | exit 0 |
| **Unit tests (full blocking suite)** | **749 files, 10,805 passed, 1 skipped, 0 failed** |
| Browser-mode (4 relevant files) | 31 passed |

## 🔴 CI caveat — the geometry test cannot gate anything

The Vitest browser-mode `component` project runs only as the preview pipeline's `preview / component-tests`, which is **report-only / non-blocking**, and it is **currently red repo-wide** for a pre-existing unrelated failure in `AppBlockChrome.browser.test.tsx` (red on merged #3546 and #3547 too). So `AppsPageLayout.geometry.browser.test.tsx` **cannot block a future regression** — treat it as documentation-as-code that a human can run locally, not as protection. The enforceable half of this change is the source guards in the blocking `unit` project.

The pixel geometry is *only* coverable there. Stating that plainly rather than implying the numbers are defended.

## Not verified

The measurements are of `AppsPageLayout`'s own box in a component render. I did **not** drive the real running app, so "pages start higher under the global header" is measured as 36px removed from the layout's own chrome — not confirmed against the live app shell with the global header above it.
