### PR TITLE
test(browser): single-source the loadable image fixture + lint the unloadable-URL trap

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -178,6 +178,51 @@ module.exports = {
         'local-rules/no-module-scope-cache': 'error',
       },
     },
+    {
+      // Browser-mode component tests must not use an http(s) URL as an image
+      // source. Nothing serves it to the test browser, so the <img> fires a real
+      // `error` event a few ms after mount and the component's own onError
+      // fallback destroys it — Mantine 7.17.8's Avatar is `useState(!src)` +
+      // `onError -> setError(true)`, measured at ~11 ms from mount to swap. Any
+      // "the <img> exists" assertion against such a fixture is racing that
+      // window: green locally, intermittently red on a loaded CI box. It sat red
+      // on `main` across five PRs before #3551, and the data: URI that fixed it
+      // was a second copy of one another test file already had — the convention
+      // existed and was invisible. Hence a rule, and hence the single shared
+      // `LOADABLE_IMAGE_DATA_URI` in test/component-setup.tsx.
+      //
+      // 'error', matching no-wholesale-module-mock / no-module-scope-cache and
+      // for the same reason spelled out above: the only BLOCKING ESLint step in
+      // .github/workflows/lint.yml ("ESLint (added files)") runs without
+      // --max-warnings, so at 'warn' this would gate nothing — and a brand-new
+      // browser test is exactly the authoring path the rule exists to close.
+      //
+      // Blast radius on the existing tree is bounded and, by lint.yml's split,
+      // zero in the blocking step. Population measured by instrumenting all 117
+      // *.browser.test.tsx files with a document-level capture listener for
+      // <img> `error` events: 14 distinct external image URLs really do mount as
+      // broken images today, across 6 files. The rule reports 16 sites in 5
+      // files, ALL pre-existing, so a PR touching one reaches only the
+      // report-only modified-files step. (The 6th file, AppListingCard, is fixed
+      // in this change: its positive assertion uses the shared fixture and its
+      // deliberate broken-cover test carries a disable comment with a reason.)
+      // They are latent, not harmless — each becomes a flake the moment someone
+      // adds an <img> assertion beside it, which is what happened to
+      // AppBlockChrome.
+      //
+      // Scope is deliberately narrow so it cannot reach a non-image URL: the
+      // literal must be http(s) AND sit in an image-source position, where the
+      // ambiguous `src` additionally has to prove it is an image (file
+      // extension, or an <img>-family JSX element). That is what keeps
+      // OnsiteReviewModal's `iframe: { src: 'https://example.com/block' }` and
+      // AgentReviewChat's markdown `![tracking](https://example.com/pixel.png)`
+      // clean — neither can mount an <img> from a fixture. Full reasoning, the
+      // key list, and the escape hatch are in eslint-local-rules.js.
+      files: ['**/*.browser.test.tsx'],
+      rules: {
+        'local-rules/no-unloadable-image-fixture': 'error',
+      },
+    },
   ],
 
   // No type-aware linting: `parserOptions.project` costs ~40s of program build plus

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -198,7 +198,17 @@ module.exports = {
       // browser test is exactly the authoring path the rule exists to close.
       //
       // Blast radius on the existing tree is bounded and, by lint.yml's split,
-      // zero in the blocking step. Population measured by instrumenting all 117
+      // zero in the blocking step TODAY — with two named caveats, because
+      // "zero" is not the same as "permanently zero":
+      //   1. `--diff-filter=A` classifies a rename-with-heavy-edit as ADDED, so
+      //      MOVING one of the 5 backlog files lands it in the BLOCKING step.
+      //      Same caveat the sibling rule documents at the top of this file.
+      //   2. lint.yml's own header records that the report-only steps are
+      //      planned to flip to blocking once the backlog clears. On that day
+      //      these 16 sites block anyone touching those 5 files. The debt is
+      //      small and mechanical (9 distinct URLs, nearly all
+      //      'https://cdn/x.png' -> LOADABLE_IMAGE_DATA_URI).
+      // Population measured by instrumenting all 117
       // *.browser.test.tsx files with a document-level capture listener for
       // <img> `error` events: 14 distinct external image URLs really do mount as
       // broken images today, across 6 files. The rule reports 16 sites in 5

--- a/eslint-local-rules.js
+++ b/eslint-local-rules.js
@@ -946,8 +946,215 @@ const noModuleScopeCache = {
   },
 };
 
+/**
+ * no-unloadable-image-fixture
+ *
+ * Flags an http(s) URL string LITERAL used as an image source in a browser-mode
+ * component test (`*.browser.test.tsx`).
+ *
+ * Nothing serves an external URL to the test browser, so such an `<img>` never
+ * loads: the element's real `error` event fires a few milliseconds after mount
+ * and every image-rendering component in this codebase has an `onError` fallback
+ * that then DESTROYS the `<img>` and swaps in a placeholder. Mantine 7.17.8's
+ * `Avatar` is the sharpest case — `useState(!src)` + `onError -> setError(true)`,
+ * measured at ~11 ms from mount to swap. Any assertion that the `<img>` EXISTS is
+ * therefore racing that window: green on a fast local machine, intermittently red
+ * on a loaded CI box. That exact defect sat red on `main` across five PRs before
+ * #3551 fixed it, and the fixture it fixed was a duplicate of one that already
+ * existed in another test file — a convention nobody could see was not enough.
+ *
+ * Fix: use the shared `LOADABLE_IMAGE_DATA_URI` from `test/component-setup`. It
+ * is a 1x1 transparent PNG `data:` URI, so it resolves locally and synchronously
+ * and the `<img>` survives the whole test.
+ *
+ * Measured population at the time of writing (all 117 `*.browser.test.tsx`
+ * instrumented with a document-level capture listener that records every `<img>`
+ * firing a real `error` event with an http(s) src): 14 distinct external image
+ * URLs across 6 files really do mount as broken images today. They are latent,
+ * not theoretical — each becomes a flake the day someone adds an `<img>`
+ * assertion beside it, which is precisely what happened to AppBlockChrome.
+ *
+ * SCOPE / false-positive control. Two independent conditions must hold, so the
+ * rule cannot reach a non-image URL:
+ *   1. the literal must start `http://` or `https://`, AND
+ *   2. it must sit in an image-source position:
+ *      - a property / JSX attribute / variable named as an unambiguous image
+ *        source (`iconUrl`, `coverUrl`, `iconImageUrl`, `coverImageUrl`,
+ *        `imageUrl`, `avatarUrl`, `thumbnailUrl`, `logoUrl`, `posterUrl`,
+ *        `bannerUrl`, `backgroundImageUrl`) — these can only ever be an image; or
+ *      - the AMBIGUOUS `src`, which is additionally required to point at an
+ *        image file extension, or to sit on an `<img>`-family JSX element.
+ * `src` is gated that way on purpose: `iframe: { src: 'https://example.com/block' }`
+ * in OnsiteReviewModal.browser.test.tsx is an iframe document, not an image, and
+ * must not be reported. A URL that merely *appears* in a test (`liveUrl`,
+ * `externalUrl`, `reviewRepoUrl`, a markdown body such as AgentReviewChat's
+ * `![tracking](https://example.com/pixel.png)`) is likewise untouched — it is not
+ * in an image-source position, so it can never mount an `<img>` this way.
+ *
+ * Not covered, deliberately: a same-origin RELATIVE path that 404s
+ * (`/api/blocks/screenshot/app-1/0.png` in AppBlockCard / AppDetailsModal) is
+ * also unloadable, but "relative path that happens not to be served" is not
+ * decidable from the source text, and treating every relative image path as
+ * suspect would flag the many that a component genuinely renders from fixtures.
+ * The http(s) form is the one that is unloadable BY CONSTRUCTION.
+ *
+ * ESCAPE HATCH. An unloadable image is sometimes the point — testing an
+ * `onError` fallback needs a URL that really fails. Opt out per line, with a
+ * reason, matching the convention the repo's other local rules use:
+ *   // eslint-disable-next-line local-rules/no-unloadable-image-fixture -- <reason>
+ * There is one such site in the repo today: the deliberate broken-cover test in
+ * AppListingCard.browser.test.tsx.
+ */
+const IMAGE_URL_KEYS = new Set([
+  'iconUrl',
+  'coverUrl',
+  'iconImageUrl',
+  'coverImageUrl',
+  'imageUrl',
+  'avatarUrl',
+  'thumbnailUrl',
+  'logoUrl',
+  'posterUrl',
+  'bannerUrl',
+  'backgroundImageUrl',
+]);
+
+/** Keys that MIGHT be an image but are also used for iframes/scripts/media. */
+const AMBIGUOUS_SRC_KEYS = new Set(['src']);
+
+/** JSX elements whose `src` is unambiguously an image. */
+const IMAGE_ELEMENTS = new Set(['img', 'Img', 'Image', 'Avatar', 'EdgeMedia']);
+
+const HTTP_URL_RE = /^https?:\/\//i;
+const IMAGE_EXT_RE = /\.(png|jpe?g|gif|webp|avif|svg|bmp|ico|apng|tiff?)(?:[?#]|$)/i;
+
+/** The literal's string value, or null if it isn't a plain string literal. */
+function plainStringValue(node) {
+  if (node.type === 'Literal' && typeof node.value === 'string') return node.value;
+  if (
+    node.type === 'TemplateLiteral' &&
+    node.expressions.length === 0 &&
+    node.quasis.length === 1
+  ) {
+    return node.quasis[0].value.cooked;
+  }
+  return null;
+}
+
+/** Property / JSX-attribute / variable name a literal is bound to, plus its JSX element. */
+function bindingFor(node) {
+  const parent = node.parent;
+  if (!parent) return null;
+
+  // { iconUrl: 'https://…' }  /  { 'icon-url': 'https://…' }
+  if (parent.type === 'Property' && parent.value === node && !parent.computed) {
+    const key = parent.key;
+    const name =
+      key.type === 'Identifier' ? key.name : key.type === 'Literal' ? String(key.value) : null;
+    return name ? { name, element: null } : null;
+  }
+
+  // <img src="https://…" />  /  <Avatar src={'https://…'} />
+  let attr = null;
+  if (parent.type === 'JSXAttribute' && parent.value === node) attr = parent;
+  else if (
+    parent.type === 'JSXExpressionContainer' &&
+    parent.parent &&
+    parent.parent.type === 'JSXAttribute' &&
+    parent.parent.value === parent
+  ) {
+    attr = parent.parent;
+  }
+  if (attr && attr.name && attr.name.type === 'JSXIdentifier') {
+    const opening = attr.parent;
+    const elName =
+      opening && opening.name && opening.name.type === 'JSXIdentifier' ? opening.name.name : null;
+    return { name: attr.name.name, element: elName };
+  }
+
+  // const iconUrl = 'https://…'
+  if (
+    parent.type === 'VariableDeclarator' &&
+    parent.init === node &&
+    parent.id.type === 'Identifier'
+  ) {
+    return { name: parent.id.name, element: null };
+  }
+
+  // obj.iconUrl = 'https://…'
+  if (
+    parent.type === 'AssignmentExpression' &&
+    parent.right === node &&
+    parent.left.type === 'MemberExpression' &&
+    !parent.left.computed &&
+    parent.left.property.type === 'Identifier'
+  ) {
+    return { name: parent.left.property.name, element: null };
+  }
+
+  return null;
+}
+
+const noUnloadableImageFixture = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Disallow an http(s) URL literal as an image source in a *.browser.test.tsx fixture — nothing serves it to the test browser, so the <img> errors and every onError fallback in this codebase destroys it a few ms after mount, making any "the <img> exists" assertion an intermittent CI flake. Use LOADABLE_IMAGE_DATA_URI from test/component-setup.',
+      recommended: true,
+    },
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          extraKeys: { type: 'array', items: { type: 'string' } },
+        },
+        additionalProperties: false,
+      },
+    ],
+    messages: {
+      unloadableImageFixture:
+        "`{{key}}: '{{url}}'` is an http(s) image source in a browser test — nothing serves it to the test browser, so the <img> fires a real `error` event a few ms after mount and the component's onError fallback replaces it with a placeholder (Mantine Avatar: measured ~11 ms). Any assertion that the <img> EXISTS then races that window — green locally, intermittently red on a loaded CI box. This exact defect sat red on `main` across five PRs (fixed in #3551). Use the shared fixture instead: `import { LOADABLE_IMAGE_DATA_URI } from '<relative>/test/component-setup';` — a 1x1 transparent PNG data: URI that resolves locally, so the <img> survives the whole test. If the image is MEANT to fail to load (you are testing the onError/placeholder path), say so explicitly: // eslint-disable-next-line local-rules/no-unloadable-image-fixture -- <reason>",
+    },
+  },
+  create(context) {
+    const options = context.options[0] || {};
+    const keys = new Set([...IMAGE_URL_KEYS, ...(options.extraKeys || [])]);
+
+    function check(node) {
+      const url = plainStringValue(node);
+      if (url === null || !HTTP_URL_RE.test(url)) return;
+
+      const binding = bindingFor(node);
+      if (!binding) return;
+
+      const { name, element } = binding;
+      if (!keys.has(name)) {
+        // `src` only counts when we can prove it is an image: either the URL
+        // names an image file, or the JSX element is an image component. That
+        // is what keeps `iframe: { src: 'https://example.com/block' }` clean.
+        if (!AMBIGUOUS_SRC_KEYS.has(name)) return;
+        const provablyImage = IMAGE_EXT_RE.test(url) || (element && IMAGE_ELEMENTS.has(element));
+        if (!provablyImage) return;
+      }
+
+      context.report({
+        node,
+        messageId: 'unloadableImageFixture',
+        data: { key: name, url },
+      });
+    }
+
+    return {
+      Literal: check,
+      TemplateLiteral: check,
+    };
+  },
+};
+
 module.exports = {
   'no-io-in-transaction': noIoInTransaction,
   'no-module-scope-cache': noModuleScopeCache,
+  'no-unloadable-image-fixture': noUnloadableImageFixture,
   'no-wholesale-module-mock': noWholesaleModuleMock,
 };

--- a/eslint-local-rules.js
+++ b/eslint-local-rules.js
@@ -953,15 +953,30 @@ const noModuleScopeCache = {
  * component test (`*.browser.test.tsx`).
  *
  * Nothing serves an external URL to the test browser, so such an `<img>` never
- * loads: the element's real `error` event fires a few milliseconds after mount
- * and every image-rendering component in this codebase has an `onError` fallback
- * that then DESTROYS the `<img>` and swaps in a placeholder. Mantine 7.17.8's
- * `Avatar` is the sharpest case — `useState(!src)` + `onError -> setError(true)`,
- * measured at ~11 ms from mount to swap. Any assertion that the `<img>` EXISTS is
- * therefore racing that window: green on a fast local machine, intermittently red
- * on a loaded CI box. That exact defect sat red on `main` across five PRs before
- * #3551 fixed it, and the fixture it fixed was a duplicate of one that already
- * existed in another test file — a convention nobody could see was not enough.
+ * loads: the element's real `error` event fires a few milliseconds after mount.
+ * What happens NEXT depends on the component, and the distinction is the whole
+ * reason this rule is narrow rather than a blanket ban — each clause below was
+ * read off the installed `@mantine/core`, not assumed:
+ *
+ *   - DESTROYS the `<img>`: Mantine `Avatar` (`Avatar.mjs:70,91` — `useState(!src)`
+ *     + `onError -> setError(true)`, then renders a `<span>` placeholder INSTEAD
+ *     of the `<img>`), measured at ~11 ms from mount to swap. Same for a bespoke
+ *     `onError -> placeholder` handler, e.g. `src/components/Apps/AppListingCard.tsx:135`.
+ *   - KEEPS the `<img>`: Mantine `Image` (`Image.mjs:58` — `if (error && fallbackSrc)`
+ *     swaps to a DIFFERENT `<img>`; with no `fallbackSrc` it re-renders the SAME
+ *     one, so the element survives with a failed src). `fallbackSrc` appears ZERO
+ *     times in `src/`, so in this repo Mantine `Image` never destroys anything.
+ *
+ * So only the first group can flake an `<img>`-existence assertion, by racing that
+ * ~11 ms window: green on a fast local machine, intermittently red on a loaded CI
+ * box. That exact defect sat red on `main` across five PRs before #3551 fixed it,
+ * and the fixture it fixed was a duplicate of one that already existed in another
+ * test file — a convention nobody could see was not enough.
+ *
+ * 🔴 An earlier draft of this header claimed "every image-rendering component in
+ * this codebase" destroys the `<img>`. That was false, and it mattered: it is the
+ * rationale a future maintainer reads when deciding whether to widen or delete
+ * this rule, and it overstated how much of the codebase is actually at risk.
  *
  * Fix: use the shared `LOADABLE_IMAGE_DATA_URI` from `test/component-setup`. It
  * is a 1x1 transparent PNG `data:` URI, so it resolves locally and synchronously
@@ -973,6 +988,20 @@ const noModuleScopeCache = {
  * URLs across 6 files really do mount as broken images today. They are latent,
  * not theoretical — each becomes a flake the day someone adds an `<img>`
  * assertion beside it, which is precisely what happened to AppBlockChrome.
+ *
+ * 🔴 COVERAGE IS PARTIAL — do not read the two numbers above and below as a pair.
+ * This rule reports 9 distinct URLs of those 14, so AT LEAST 5 (~36%) of the
+ * measured mounting fixtures are OUTSIDE it. The gap has a known shape: `url` is
+ * the single most common http-literal binding in the browser suite (36
+ * occurrences) and is deliberately NOT in `IMAGE_URL_KEYS`, because `url` is also
+ * the overwhelmingly common name for non-image URLs. That leaves ~38 uncovered
+ * http literals carrying an image extension across 12 files — including 8 more
+ * sites in `ListingAssetStep.browser.test.tsx`, a file this rule already flags
+ * elsewhere. Widening to `url` behind the existing `IMAGE_EXT_RE` proof would be
+ * a one-line change with identical false-positive discipline; it is deferred, not
+ * overlooked. Most of those feed Mantine `Image`, which per the mechanism note
+ * above does NOT destroy the `<img>`, so the latent risk is lower than the raw
+ * count suggests — but it is not zero, and it is not covered.
  *
  * SCOPE / false-positive control. Two independent conditions must hold, so the
  * rule cannot reach a non-image URL:

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "test:unit": "vitest --project unit",
     "test:unit:run": "vitest run --project unit",
     "test:unit:coverage": "vitest run --project unit --coverage",
-    "test:lint-rules": "vitest run --project unit src/server/services/__tests__/no-io-in-transaction.test.ts src/server/services/__tests__/no-module-scope-cache.test.ts src/server/services/__tests__/no-wholesale-module-mock.test.ts",
+    "test:lint-rules": "vitest run --project unit src/server/services/__tests__/no-io-in-transaction.test.ts src/server/services/__tests__/no-module-scope-cache.test.ts src/server/services/__tests__/no-unloadable-image-fixture.test.ts src/server/services/__tests__/no-wholesale-module-mock.test.ts",
     "test:component": "vitest run --project component",
     "test:component:watch": "vitest --project component",
     "meilisearch:migrate": "NODE_ENV=development tsx scripts/oneoffs/meilisearch-migration.ts",

--- a/src/components/AppBlocks/AppBlockChrome.browser.test.tsx
+++ b/src/components/AppBlocks/AppBlockChrome.browser.test.tsx
@@ -19,7 +19,7 @@ import {
 } from '~/components/Apps/recentlyOpenedAppsStore';
 // `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
 // eslint-disable-next-line import/first
-import { renderWithProviders } from '../../../test/component-setup';
+import { LOADABLE_IMAGE_DATA_URI, renderWithProviders } from '../../../test/component-setup';
 
 // H2: the host-rendered "trust frame" around an in-model app block must NAME the
 // app (host-side, spoof-proof) — not just carry it in the invisible iframe
@@ -299,12 +299,6 @@ describe('AppBlockChrome "Recently run" section (platform-nav dropdown)', () => 
     clearRecentlyOpenedApps();
   });
 
-  // A data: URI that actually loads — an http URL fails in-browser (Mantine Avatar
-  // fires onError and swaps the <img> for a placeholder span ~11 ms after mount),
-  // making the `expect(img).not.toBeNull()` assertion race the error path.
-  const LOADABLE_ICON =
-    'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';
-
   // The platform-nav Menu mounts its dropdown lazily — open it first (its trigger
   // is "Apps menu", distinct from the ⋯ "App menu").
   async function openPlatformNav() {
@@ -320,7 +314,7 @@ describe('AppBlockChrome "Recently run" section (platform-nav dropdown)', () => 
       id: 'other',
       blockId: 'other-block',
       name: 'Other App',
-      iconUrl: LOADABLE_ICON,
+      iconUrl: LOADABLE_IMAGE_DATA_URI,
     });
 
     renderWithProviders(
@@ -342,7 +336,7 @@ describe('AppBlockChrome "Recently run" section (platform-nav dropdown)', () => 
     expect(other.getAttribute('href')).toBe('/apps/run/other-block');
     const otherImg = other.querySelector('img');
     expect(otherImg).not.toBeNull();
-    expect(otherImg?.getAttribute('src')).toBe(LOADABLE_ICON);
+    expect(otherImg?.getAttribute('src')).toBe(LOADABLE_IMAGE_DATA_URI);
 
     // Icon-less entry falls back to a generic app icon (an <svg>, no <img>).
     const noicon = page.getByRole('menuitem', { name: 'No Icon App' }).element() as HTMLElement;

--- a/src/components/Apps/AppListingCard.browser.test.tsx
+++ b/src/components/Apps/AppListingCard.browser.test.tsx
@@ -523,9 +523,11 @@ describe('AppListingCard', () => {
     // An unfetchable URL — the browser fires the <img>'s real `error` event, which
     // is the component's own onError → placeholder path. This is the ONE shape the
     // shared LOADABLE_IMAGE_DATA_URI cannot express: the whole point is that the
-    // fetch must FAIL. Every assertion below is on the post-error state (guarded by
-    // a `vi.waitFor` on the placeholder), so nothing here races the swap the way an
-    // "<img> exists" assertion would.
+    // fetch must FAIL. Nothing here races the swap the way an "<img> exists"
+    // assertion would: the one assertion that runs BEFORE the `vi.waitFor` is on
+    // `apps-listing-cover`, the ratio box, which survives the error swap; the
+    // placeholder assertion — the only one that depends on the post-error state —
+    // is inside the `vi.waitFor`.
     renderWithProviders(
       <AppListingCard
         // eslint-disable-next-line local-rules/no-unloadable-image-fixture -- testing the onError → placeholder path; this URL MUST fail to load

--- a/src/components/Apps/AppListingCard.browser.test.tsx
+++ b/src/components/Apps/AppListingCard.browser.test.tsx
@@ -38,7 +38,7 @@ import { page } from 'vitest/browser';
 import '~/styles/globals.css';
 import '@mantine/core/styles.layer.css';
 // `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
-import { renderWithProviders } from '../../../test/component-setup';
+import { LOADABLE_IMAGE_DATA_URI, renderWithProviders } from '../../../test/component-setup';
 import type { ListingCard } from '~/server/schema/blocks/app-listing-read.schema';
 
 /**
@@ -439,7 +439,7 @@ describe('AppListingCard', () => {
     mocks.currentUser = { id: 5, username: 'alice' };
     renderWithProviders(
       <AppListingCard
-        card={base({ iconUrl: 'https://edge/icon.png', coverUrl: 'https://edge/cover.png' })}
+        card={base({ iconUrl: LOADABLE_IMAGE_DATA_URI, coverUrl: LOADABLE_IMAGE_DATA_URI })}
         canOpenPage
       />
     );
@@ -474,14 +474,10 @@ describe('AppListingCard', () => {
   // art is inside it) rather than measured pixels — measured geometry would be
   // meaningless without the stylesheet.
 
-  // A 1x1 transparent PNG. A real (non-network) src that LOADS, so the <img>
-  // survives — any http(s) URL fails to fetch in the test browser and trips the
-  // component's own onError → placeholder path (exercised separately below).
-  const LOADABLE_PNG =
-    'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==';
-
   test('cover image renders INSIDE the 16:9 aspect box', async () => {
-    renderWithProviders(<AppListingCard card={base({ coverUrl: LOADABLE_PNG })} canOpenPage />);
+    renderWithProviders(
+      <AppListingCard card={base({ coverUrl: LOADABLE_IMAGE_DATA_URI })} canOpenPage />
+    );
     await expect.element(page.getByTestId('apps-listing-cover')).toBeInTheDocument();
     const box = page.getByTestId('apps-listing-cover').element() as HTMLElement;
     // 16:9 — this is what derives the box height from the fluid column width, so
@@ -492,7 +488,7 @@ describe('AppListingCard', () => {
     // it would not be bounded by the reserved geometry.
     const img = box.querySelector('img');
     expect(img).not.toBeNull();
-    expect(img?.getAttribute('src')).toBe(LOADABLE_PNG);
+    expect(img?.getAttribute('src')).toBe(LOADABLE_IMAGE_DATA_URI);
     expect(img?.getAttribute('alt')).toBe('My App cover image');
     // Absolutely filling the box — NOT a percentage height, which would have to
     // resolve against a ratio-derived block size and could silently crop the art
@@ -525,9 +521,14 @@ describe('AppListingCard', () => {
 
   test('a BROKEN cover URL falls back to the placeholder in the SAME box (no reflow, still aria-hidden)', async () => {
     // An unfetchable URL — the browser fires the <img>'s real `error` event, which
-    // is the component's own onError → placeholder path.
+    // is the component's own onError → placeholder path. This is the ONE shape the
+    // shared LOADABLE_IMAGE_DATA_URI cannot express: the whole point is that the
+    // fetch must FAIL. Every assertion below is on the post-error state (guarded by
+    // a `vi.waitFor` on the placeholder), so nothing here races the swap the way an
+    // "<img> exists" assertion would.
     renderWithProviders(
       <AppListingCard
+        // eslint-disable-next-line local-rules/no-unloadable-image-fixture -- testing the onError → placeholder path; this URL MUST fail to load
         card={base({ coverUrl: 'https://edge.invalid/does-not-exist.png' })}
         canOpenPage
       />

--- a/src/server/services/__tests__/no-unloadable-image-fixture.test.ts
+++ b/src/server/services/__tests__/no-unloadable-image-fixture.test.ts
@@ -1,0 +1,123 @@
+import path from 'path';
+import { RuleTester } from 'eslint';
+// The rule lives at the repo root (loaded in prod via eslint-plugin-local-rules).
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const localRules = require(path.resolve(__dirname, '../../../../eslint-local-rules.js'));
+
+const rule = localRules['no-unloadable-image-fixture'];
+
+// Same harness shape as no-module-scope-cache.test.ts: RuleTester drives the test
+// framework's globals, so `ruleTester.run(...)` must be called at the top level of
+// the module (NOT nested inside a vitest `it()`). `parser` is a valid top-level
+// RuleTester option in ESLint 8 (eslintrc mode) but @types/eslint's config type
+// omits it — build untyped and cast so `tsc --noEmit` stays green.
+//
+// `ecmaFeatures.jsx` is required here and not in the sibling rule tests: this rule
+// inspects JSX attributes, so the invalid/valid cases below contain real JSX.
+const ruleTesterConfig: Record<string, unknown> = {
+  parser: require.resolve('@typescript-eslint/parser'),
+  parserOptions: { ecmaVersion: 'latest', sourceType: 'module', ecmaFeatures: { jsx: true } },
+};
+const ruleTester = new RuleTester(ruleTesterConfig as ConstructorParameters<typeof RuleTester>[0]);
+
+const errors = [{ messageId: 'unloadableImageFixture' }];
+
+ruleTester.run('no-unloadable-image-fixture', rule, {
+  valid: [
+    // ================================================================
+    // The canonical fix — the shared data: URI fixture
+    // ================================================================
+    `renderWithProviders(<Card card={base({ coverUrl: LOADABLE_IMAGE_DATA_URI })} />);`,
+    `const card = { iconUrl: LOADABLE_IMAGE_DATA_URI, coverUrl: LOADABLE_IMAGE_DATA_URI };`,
+    // An inline data: URI (not the shared constant) is still loadable.
+    `const card = { coverUrl: 'data:image/png;base64,iVBORw0KGg==' };`,
+    // A same-origin relative path is deliberately NOT covered — see the rule
+    // header. AppBlockCard / AppDetailsModal both use this shape today.
+    `const card = { coverUrl: '/api/blocks/screenshot/app-1/0.png' };`,
+    `const s = { url: '/api/blocks/screenshot/app-1/1.webp' };`,
+
+    // ================================================================
+    // 🔴 The false-positive boundary. Every case below is a REAL shape that
+    // exists in src/**/*.browser.test.tsx today and must stay clean; each one
+    // is an http(s) URL that cannot become an <img> from a fixture.
+    // ================================================================
+    // OnsiteReviewModal.browser.test.tsx:37 — an IFRAME document, not an image.
+    // This is why the ambiguous `src` key must prove it is an image.
+    `const props = { iframe: { src: 'https://example.com/block', sandbox: 'allow-scripts' } };`,
+    // …and a bare non-image `src` anywhere else.
+    `const cfg = { src: 'https://example.com/some/route' };`,
+    `const el = <iframe src="https://example.com/block" />;`,
+    `const el = <script src="https://cdn.example.com/analytics" />;`,
+    // AgentReviewChat.browser.test.tsx:387 — an http image URL inside a MARKDOWN
+    // body. The test's whole point is asserting NO <img> is produced from it
+    // (`expect(bubble.querySelector('img')).toBeNull()`), and it is not in an
+    // image-source position, so it can never mount a broken <img>.
+    "mocks.chatReply = 'Look here: ![tracking](https://example.com/pixel.png)';",
+    // AppDetailsModal.browser.test.tsx:127 / CombinedReviewModal:41 /
+    // recents-helper:138 — link targets, not image sources.
+    `const block = { liveUrl: 'https://my-block.example.com' };`,
+    `const req = { reviewRepoUrl: 'https://forgejo.example/repo' };`,
+    `const app = { externalUrl: 'https://ext.example/app' };`,
+    // OnsiteReviewModal.browser.test.tsx:397 — a block PREVIEW page, not an image.
+    `const r = { previewUrl: 'https://my-onsite-block.civit.ai/my-onsite-block?mr=tok' };`,
+    // ExternalSubmitForm.browser.test.tsx — a URL typed into a form field.
+    `await page.getByTestId('apps-offsite-submit-url').fill('https://vitrine.civitai.com');`,
+    `async function advanceFromUrl(url = 'https://vitrine.civitai.com') {}`,
+
+    // A non-string literal, and an interpolated template, are both out of scope.
+    `const card = { coverUrl: null };`,
+    'const card = { coverUrl: `${base}/cover.png` };',
+    // A computed key is not a name we can trust.
+    `const card = { [key]: 'https://edge/cover.png' };`,
+  ],
+
+  invalid: [
+    // ================================================================
+    // The shape that actually bit us — an unloadable icon behind a Mantine
+    // Avatar, asserted with `expect(img).not.toBeNull()` (#3551).
+    // ================================================================
+    {
+      code: `recordRecentlyOpenedApp({ id: 'other', name: 'Other App', iconUrl: 'https://edge/icon.png' });`,
+      errors,
+    },
+    // AppListingCard.browser.test.tsx:442 (fixed in this change) — two on one line.
+    {
+      code: `const card = base({ iconUrl: 'https://edge/icon.png', coverUrl: 'https://edge/cover.png' });`,
+      errors: [...errors, ...errors],
+    },
+    // AppListingCard.browser.test.tsx:531 — the deliberate error-path fixture.
+    // It IS reported; the escape hatch (a disable comment with a reason) is what
+    // makes it legal, and that is asserted separately below.
+    {
+      code: `const card = base({ coverUrl: 'https://edge.invalid/does-not-exist.png' });`,
+      errors,
+    },
+    // The remaining real key spellings in the repo's browser tests.
+    {
+      code: `const meta = { coverImageUrl: 'https://cdn/og-cover.png', iconImageUrl: 'https://cdn/og-icon.png' };`,
+      errors: [...errors, ...errors],
+    },
+    // http, not just https.
+    { code: `const card = { avatarUrl: 'http://cdn.example/a.png' };`, errors },
+    // An unambiguous image key does NOT need a file extension — the key alone
+    // proves it is an image, so an extensionless CDN URL is still caught.
+    { code: `const card = { iconUrl: 'https://cdn.example/icon' };`, errors },
+
+    // ================================================================
+    // The ambiguous `src` key — reported only where we can PROVE it is an image
+    // ================================================================
+    // (a) proven by the file extension …
+    { code: `const cfg = { src: 'https://cdn.example/pic.jpeg' };`, errors },
+    { code: `const cfg = { src: 'https://cdn.example/pic.webp?v=2' };`, errors },
+    // (b) … or by the JSX element being an image component.
+    { code: `const el = <img src="https://cdn.example/no-extension" />;`, errors },
+    { code: `const el = <Avatar src={'https://cdn.example/no-extension'} />;`, errors },
+    { code: `const el = <EdgeMedia src="https://cdn.example/no-extension" />;`, errors },
+
+    // Other binding forms that reach the same hazard.
+    { code: `const iconUrl = 'https://edge/icon.png';`, errors },
+    { code: `mocks.coverUrl = 'https://edge/cover.png';`, errors },
+    { code: 'const card = { coverUrl: `https://edge/cover.png` };', errors },
+    { code: `const el = <Card iconUrl="https://edge/icon.png" />;`, errors },
+  ],
+});

--- a/test/component-setup.tsx
+++ b/test/component-setup.tsx
@@ -91,6 +91,30 @@ afterEach(() => {
   cleanup();
 });
 
+/**
+ * A 1x1 transparent PNG — the canonical image fixture for browser tests.
+ *
+ * 🔴 Use this ANY time a browser test needs an image source it will then assert
+ * on. A `data:` URI resolves synchronously and locally, so the `<img>` LOADS and
+ * survives for the whole test.
+ *
+ * An http(s) URL does NOT. Nothing serves it in the test browser, so the fetch
+ * fails and the element's real `error` event fires ~11 ms after mount — and every
+ * image-rendering component in this codebase has an `onError` fallback that then
+ * DESTROYS the `<img>` and swaps in a placeholder. Mantine 7.17.8's `Avatar` is
+ * the sharpest case: it is `useState(!src)` + `onError -> setError(true)`, so the
+ * `<img>` renders at mount and is gone a few frames later. Any
+ * `expect(...querySelector('img')).not.toBeNull()` against such a fixture is
+ * racing that ~11 ms window — it passes on a fast local machine and fails on a
+ * loaded CI box. That defect sat red on `main` across five PRs before #3551.
+ *
+ * Deliberately testing the error path (an image that must FAIL to load) is a
+ * legitimate exception — see the escape hatch documented on the
+ * `local-rules/no-unloadable-image-fixture` ESLint rule.
+ */
+export const LOADABLE_IMAGE_DATA_URI =
+  'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==';
+
 function Providers({ children }: { children: React.ReactNode }) {
   // Fresh client per render so cache never leaks between tests.
   const queryClient = new QueryClient({

--- a/test/component-setup.tsx
+++ b/test/component-setup.tsx
@@ -99,14 +99,18 @@ afterEach(() => {
  * survives for the whole test.
  *
  * An http(s) URL does NOT. Nothing serves it in the test browser, so the fetch
- * fails and the element's real `error` event fires ~11 ms after mount — and every
- * image-rendering component in this codebase has an `onError` fallback that then
- * DESTROYS the `<img>` and swaps in a placeholder. Mantine 7.17.8's `Avatar` is
- * the sharpest case: it is `useState(!src)` + `onError -> setError(true)`, so the
- * `<img>` renders at mount and is gone a few frames later. Any
- * `expect(...querySelector('img')).not.toBeNull()` against such a fixture is
- * racing that ~11 ms window — it passes on a fast local machine and fails on a
- * loaded CI box. That defect sat red on `main` across five PRs before #3551.
+ * fails and the element's real `error` event fires ~11 ms after mount. Whether
+ * that BREAKS a test depends on the component, and only the first case below can:
+ *   - Mantine `Avatar` (and any bespoke `onError -> placeholder`, e.g.
+ *     `src/components/Apps/AppListingCard.tsx:135`) renders a placeholder INSTEAD
+ *     of the `<img>` — the element is DESTROYED ~11 ms after mount.
+ *   - Mantine `Image` does NOT: it only swaps when `fallbackSrc` is set (and that
+ *     prop appears zero times in `src/`), otherwise it re-renders the same `<img>`.
+ * So `expect(...querySelector('img')).not.toBeNull()` against an Avatar-backed
+ * fixture races that ~11 ms window — passing on a fast local machine and failing
+ * on a loaded CI box. That defect sat red on `main` across five PRs before #3551.
+ * (An earlier draft of this note said EVERY image-rendering component destroys
+ * the `<img>`; that was false — checked against the installed `@mantine/core`.)
  *
  * Deliberately testing the error path (an image that must FAIL to load) is a
  * legitimate exception — see the escape hatch documented on the


### PR DESCRIPTION
## Why

[#3551](https://github.com/civitai/civitai/pull/3551) fixed an `AppBlockChrome` test that had been **red on `main` across five PRs**. Its icon fixture was an http URL, which cannot load in the test browser, so the `<img>` fired a real `error` event and Mantine 7.17.8's `Avatar` — `useState(!src)` + `onError -> setError(true)` — destroyed it ~11 ms after mount. The `expect(img).not.toBeNull()` assertion was racing that window: green locally, red under CI load.

The fix was a `data:` URI. It was the **second copy** of that constant, with the same explanatory comment — `AppListingCard` already had one. The convention existed and was invisible, which is why it took five PRs to spot.

## What

**1. One fixture.** `LOADABLE_IMAGE_DATA_URI` now lives in `test/component-setup.tsx` — the shared browser-test scaffold that **115 of the 117** `*.browser.test.tsx` files already import for `renderWithProviders`, so this adds no new convention and no new import site. `AppBlockChrome`'s `LOADABLE_ICON` and `AppListingCard`'s `LOADABLE_PNG` both import it, and the explanation lives with the constant rather than at each use site.

**2. A deterministic guard.** New `local-rules/no-unloadable-image-fixture` in the repo's existing `eslint-local-rules.js`, scoped to `**/*.browser.test.tsx`. It flags an http(s) URL literal in an image-source position. Escape hatch is the convention the repo's other three local rules already use:

```
// eslint-disable-next-line local-rules/no-unloadable-image-fixture -- <reason>
```

## Survey — measured, not assumed

All 117 browser tests were run with a document-level capture listener recording every `<img>` that fires a real `error` event with an http(s) src (the probe was removed before commit).

| | |
|---|---|
| `*.browser.test.tsx` files | **117** |
| …containing any http(s) string literal | **39** |
| …distinct external image URLs that really do mount as broken `<img>`s today | **14**, across **6** files |
| …files with BOTH an http image fixture AND an `<img>`-existence assertion | **1** (`AppListingCard`, fixed here) |

Positive control for the probe: it recorded exactly the 3 URLs `AppListingCard` is known to mount, so a zero elsewhere means "nothing mounted", not "listener wired to nothing".

So the other fixtures are **latent, not harmless** — each becomes a flake the day someone adds an `<img>` assertion beside it, which is precisely what happened to `AppBlockChrome`.

## Proportionality — why a lint rule, and why this severity

The rule reports **16 sites in 5 files, all pre-existing**. That is survivable for exactly the reason already written on `no-wholesale-module-mock`: `lint.yml` gates **ADDED** files blocking and **MODIFIED** files report-only. The backlog can therefore only ever reach the report-only step, while a **newly added** browser test is blocked — the authoring path the rule exists to close. Severity is `'error'` for the same reason: the blocking step runs without `--max-warnings`, so `'warn'` would gate nothing anywhere.

No pre-existing file is touched, so there is no diff in anyone else's blast radius.

## False-positive control

Two independent conditions must both hold — the literal must be http(s) **and** sit in an image-source position — and the ambiguous `src` key additionally has to prove it is an image (file extension, or an `<img>`-family JSX element). Verified clean against every real non-image http URL in the browser suite:

- `OnsiteReviewModal`'s `iframe: { src: 'https://example.com/block' }` — an iframe document, not an image. This is the case that forces the `src` proof requirement.
- `AgentReviewChat`'s markdown `![tracking](https://example.com/pixel.png)` — whose test asserts **no** `<img>` is produced (`expect(bubble.querySelector('img')).toBeNull()`). Not an image-source position, so it cannot mount a broken `<img>` and needs no escape hatch.
- `liveUrl` / `externalUrl` / `previewUrl` / `reviewRepoUrl`, and URLs typed into form fields.
- The relative `/api/blocks/screenshot/...` paths in `AppBlockCard` / `AppDetailsModal`. Deliberately out of scope — a relative path that happens not to be served is not decidable from source text; the http(s) form is unloadable *by construction*.

## Mutation evidence

Every claim below was run, not reasoned about.

- **34 RuleTester cases** (18 valid / 16 invalid), wired into `pnpm test:lint-rules`. All 4 local-rule suites: **186 passed**.
- Rule made a no-op → invalid cases fail (`Should have 1 error but had 0`). *The harness can go red.*
- `src` image-proof removed → **4 valid cases fail** (iframe/script `src` false-positive).
- http matcher widened to `/./` → **2 valid cases fail** (`data:` URI and relative path).
- Key-membership check removed → the extensionless `iconUrl` case **stops firing**.
- Real `eslint` on a synthetic browser test: **7 reports** covering every supported shape, **0** on every legitimate shape.
- `AppListingCard`'s disable comment removed → **1 report**; restored → **0**. The hatch is load-bearing, not decorative.

## Escape hatch — one use

`AppListingCard`'s deliberate broken-cover test needs a URL that really fails, so it can exercise the component's `onError -> placeholder` path. Its assertions all run on the **post-error** state behind a `vi.waitFor`, so it never races the swap the way an "`<img>` exists" assertion would. Behaviour is unchanged: only comments and the disable directive were added around an identical fixture URL.

## Verification

- `AppBlockChrome` + `AppListingCard`: **63 passed** — identical to the pristine `origin/main` baseline (**63 passed**, 16.09 s vs 16.55 s).
- **112 passed** across those two plus two untouched browser tests (`AppBlockCard`, `recents-helper`), confirming the shared-scaffold change is inert for files that don't use it.
- ESLint on all touched files: 0 findings. Prettier: `AppListingCard` stays clean; `AppBlockChrome` was already Prettier-dirty on `main` and was deliberately **not** reformatted, to keep the diff at 3 lines instead of ~60.

**Not claimed:** swapping `AppBlockChrome`'s fixture back to an http URL did **not** turn the test red on my machine. That is consistent with the defect being a race that manifests under CI load rather than locally — and it is exactly why a written convention was never going to hold — but it means the original symptom was not reproduced here.

Typecheck in the worktree reports 16 pre-existing errors, all module-resolution failures from an uninitialized `event-engine-common` submodule and a `kysely` package absent from `node_modules` in the base clone too. None are in files this PR touches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
