### PR TITLE
feat(app-blocks): tie a step's moderation posture to its orchestrator $type

### DIFF
--- a/src/server/routers/__tests__/blocks.router.workflow.test.ts
+++ b/src/server/routers/__tests__/blocks.router.workflow.test.ts
@@ -287,6 +287,9 @@ vi.mock('~/server/services/orchestrator/promptAuditing', () => ({
 // unchanged pass count for the rest of the suite is the evidence.
 // ─────────────────────────────────────────────────────────────────────────────
 const { AUDITED_STEP_ID } = vi.hoisted(() => ({ AUDITED_STEP_ID: 'fixture-audited-step' }));
+const { DIVERGENT_STEP_ID } = vi.hoisted(() => ({
+  DIVERGENT_STEP_ID: 'fixture-divergent-step',
+}));
 vi.mock('~/server/services/blocks/steps', async (importOriginal) => {
   const actual = await importOriginal<typeof BlockStepsModule>();
   const z = await import('zod');
@@ -319,14 +322,49 @@ vi.mock('~/server/services/blocks/steps', async (importOriginal) => {
   // The fixture must itself satisfy every load-time invariant — otherwise these
   // tests would be exercising a shape the registry would never accept, and a
   // green result would say nothing about a real entry.
+  // 🔴 A PARAMS-DEPENDENT BUILDER — the shape the router's request-time $type
+  // re-assert exists for. Its CANONICAL params build the declared type, so it
+  // satisfies every load-time invariant (asserted below, which is the point:
+  // this entry REGISTERS CLEANLY). Only a request supplying `flip: true`
+  // diverges, and only the router can see that.
+  const divergentFixtureStep = {
+    id: DIVERGENT_STEP_ID,
+    orchestratorType: 'fixtureDivergentType',
+    billingMode: 'prepaidFixed' as const,
+    moderationPosture: 'none' as const,
+    resourcePolicy: { kind: 'none' as const },
+    paramSchema: z.object({ flip: z.boolean() }).strict(),
+    variants: ['default'],
+    resolveVariant: () => 'default',
+    canonicalParamsFor: () => ({ flip: false }),
+    priceForVariant: () => 1,
+    estimateBuzz: () => 1,
+    buildStep: (p: { flip: boolean }) => ({
+      // Declared type for canonical params; a TEXT-PRODUCING type when flipped.
+      $type: p.flip ? 'chatCompletion' : 'fixtureDivergentType',
+      input: { flip: p.flip },
+    }),
+    extractOutput: () => [
+      { url: 'https://blobs.example/d.webp', width: null, height: null, nsfwLevel: null },
+    ],
+    canonicalOutputFor: () => ({}),
+  };
   actual.assertStepInvariants(AUDITED_STEP_ID, auditedFixtureStep as never);
+  // 🔴 THIS ASSERTION IS THE EXPLOIT, WRITTEN DOWN. It passes — a
+  // params-dependent builder is registrable — which is precisely why the
+  // load-time gate alone is not sufficient.
+  actual.assertStepInvariants(DIVERGENT_STEP_ID, divergentFixtureStep as never);
   return {
     ...actual,
     // The wire `step` enum is DERIVED from this, so widening it is what lets the
     // fixture id past `blockStepBodySchema` and into the handler.
-    REGISTERED_STEP_IDS: [...actual.REGISTERED_STEP_IDS, AUDITED_STEP_ID],
+    REGISTERED_STEP_IDS: [...actual.REGISTERED_STEP_IDS, AUDITED_STEP_ID, DIVERGENT_STEP_ID],
     getStep: (id: string) =>
-      id === AUDITED_STEP_ID ? (auditedFixtureStep as never) : actual.getStep(id),
+      id === AUDITED_STEP_ID
+        ? (auditedFixtureStep as never)
+        : id === DIVERGENT_STEP_ID
+        ? (divergentFixtureStep as never)
+        : actual.getStep(id),
   };
 });
 vi.mock('~/server/services/user.service', () => ({
@@ -356,11 +394,17 @@ vi.mock('~/server/db/client', () => ({
 const { completeKeys } = vi.hoisted(() => {
   const group = (explicit: Record<string, string>, name: string): Record<string, string> =>
     new Proxy(explicit, {
-      get: (t, k) => (k in t ? (t as any)[k] : typeof k === 'string' ? `mock:${name}:${k}` : (t as any)[k]),
+      get: (t, k) =>
+        k in t ? (t as any)[k] : typeof k === 'string' ? `mock:${name}:${k}` : (t as any)[k],
     });
   const completeKeys = (explicit: Record<string, Record<string, string>>) =>
     new Proxy(explicit, {
-      get: (t, g) => (g in t ? group((t as any)[g], g as string) : typeof g === 'string' ? group({}, g) : (t as any)[g]),
+      get: (t, g) =>
+        g in t
+          ? group((t as any)[g], g as string)
+          : typeof g === 'string'
+          ? group({}, g)
+          : (t as any)[g],
     });
   return { completeKeys };
 });
@@ -391,8 +435,7 @@ vi.mock('~/server/utils/block-catalog-rate-limit', () => ({
   checkBlockCatalogRateLimit: (...args: unknown[]) => mockCheckBlockCatalogRateLimit(...args),
 }));
 vi.mock('~/server/services/generation/generation.service', () => ({
-  resolveCanGenerateForVersions: (...args: unknown[]) =>
-    mockResolveCanGenerateForVersions(...args),
+  resolveCanGenerateForVersions: (...args: unknown[]) => mockResolveCanGenerateForVersions(...args),
 }));
 vi.mock('~/server/logging/client', () => ({
   logToAxiom: (...args: unknown[]) => mockLogToAxiom(...args),
@@ -1111,7 +1154,9 @@ describe('blocks.submitWorkflow', () => {
       // same-key submit REPLAYS the first's cached snapshot and NEVER reserves or
       // re-submits (no 2nd cap-INCR, no 2nd orchestrator round-trip). The externalId
       // dedupe remains threaded on the (single) real submit as the 2nd defense layer.
-      mockVerifyBlockToken.mockResolvedValue(validClaims({ buzzBudget: 100, appBlockId: 'apb_gate' }));
+      mockVerifyBlockToken.mockResolvedValue(
+        validClaims({ buzzBudget: 100, appBlockId: 'apb_gate' })
+      );
       happyVersionLookup();
       happyUser();
       const orch = installDedupingOrchestrator();
@@ -1153,16 +1198,26 @@ describe('blocks.submitWorkflow', () => {
     });
 
     it('CONTROL: two DIFFERENT keys → two externalIds → TWO charges (distinct gens are not deduped)', async () => {
-      mockVerifyBlockToken.mockResolvedValue(validClaims({ buzzBudget: 100, appBlockId: 'apb_gate' }));
+      mockVerifyBlockToken.mockResolvedValue(
+        validClaims({ buzzBudget: 100, appBlockId: 'apb_gate' })
+      );
       happyVersionLookup();
       happyUser();
       const orch = installDedupingOrchestrator();
 
       const caller = blocksRouter.createCaller(fakeCtx() as never);
-      await caller.submitWorkflow({ blockToken: 'tok', body: validBody(), idempotencyKey: 'key-A' });
+      await caller.submitWorkflow({
+        blockToken: 'tok',
+        body: validBody(),
+        idempotencyKey: 'key-A',
+      });
       happyVersionLookup();
       happyUser();
-      await caller.submitWorkflow({ blockToken: 'tok', body: validBody(), idempotencyKey: 'key-B' });
+      await caller.submitWorkflow({
+        blockToken: 'tok',
+        body: validBody(),
+        idempotencyKey: 'key-B',
+      });
 
       expect(orch.chargeCount()).toBe(2);
       const bodies = orch.realSubmitBodies();
@@ -1181,7 +1236,9 @@ describe('blocks.submitWorkflow', () => {
     // CALLER must set `body.externalId`". So the server now MINTS one when the client
     // sends none.
     it('🔴 UNKEYED submit MINTS a server-side externalId (a client key is NOT the gate)', async () => {
-      mockVerifyBlockToken.mockResolvedValue(validClaims({ buzzBudget: 100, appBlockId: 'apb_gate' }));
+      mockVerifyBlockToken.mockResolvedValue(
+        validClaims({ buzzBudget: 100, appBlockId: 'apb_gate' })
+      );
       happyVersionLookup();
       happyUser();
       const orch = installDedupingOrchestrator();
@@ -1209,7 +1266,9 @@ describe('blocks.submitWorkflow', () => {
     });
 
     it('🔴 UNKEYED: two DISTINCT submits get DISTINCT minted ids -> two charges (no over-dedupe)', async () => {
-      mockVerifyBlockToken.mockResolvedValue(validClaims({ buzzBudget: 100, appBlockId: 'apb_gate' }));
+      mockVerifyBlockToken.mockResolvedValue(
+        validClaims({ buzzBudget: 100, appBlockId: 'apb_gate' })
+      );
       happyVersionLookup();
       happyUser();
       const orch = installDedupingOrchestrator();
@@ -1268,7 +1327,9 @@ describe('blocks.submitWorkflow', () => {
     }
 
     it('🔴 UNKEYED + 2 LOST RESPONSES: ONE charge, not three (the double-spend this closes)', async () => {
-      mockVerifyBlockToken.mockResolvedValue(validClaims({ buzzBudget: 100, appBlockId: 'apb_gate' }));
+      mockVerifyBlockToken.mockResolvedValue(
+        validClaims({ buzzBudget: 100, appBlockId: 'apb_gate' })
+      );
       happyVersionLookup();
       happyUser();
       const orch = installLossyRetryingOrchestrator({ lostResponses: 2 });
@@ -1285,7 +1346,9 @@ describe('blocks.submitWorkflow', () => {
 
     // ---- audit 🔴-1: civitai-side in-flight / replay guard ----
     it('CONCURRENT same-key: a 2nd submit while the 1st is IN-FLIGHT → 409, NO 2nd reserve/submit', async () => {
-      mockVerifyBlockToken.mockResolvedValue(validClaims({ buzzBudget: 100, appBlockId: 'apb_gate' }));
+      mockVerifyBlockToken.mockResolvedValue(
+        validClaims({ buzzBudget: 100, appBlockId: 'apb_gate' })
+      );
       happyVersionLookup();
       happyUser();
 
@@ -1342,7 +1405,9 @@ describe('blocks.submitWorkflow', () => {
       // that THROWS moved no money and left no reservation standing, so the claim
       // must be dropped; otherwise the sentinel 409s every retry with the same key
       // for its full 10-minute TTL and the generation becomes unlandable.
-      mockVerifyBlockToken.mockResolvedValue(validClaims({ buzzBudget: 100, appBlockId: 'apb_gate' }));
+      mockVerifyBlockToken.mockResolvedValue(
+        validClaims({ buzzBudget: 100, appBlockId: 'apb_gate' })
+      );
       happyVersionLookup();
       happyUser();
       mockSubmitWorkflow.mockImplementation(async (arg: any) => {
@@ -1380,7 +1445,9 @@ describe('blocks.submitWorkflow', () => {
     });
 
     it('CHARSET (audit 🟢): an idempotencyKey with a space/control char is REJECTED at the input (no claim, no submit)', async () => {
-      mockVerifyBlockToken.mockResolvedValue(validClaims({ buzzBudget: 100, appBlockId: 'apb_gate' }));
+      mockVerifyBlockToken.mockResolvedValue(
+        validClaims({ buzzBudget: 100, appBlockId: 'apb_gate' })
+      );
       happyVersionLookup();
       happyUser();
       const caller = blocksRouter.createCaller(fakeCtx() as never);
@@ -1393,7 +1460,9 @@ describe('blocks.submitWorkflow', () => {
     });
 
     it('FAIL-CLOSED: a redis error at claim time → INTERNAL_SERVER_ERROR, NO reserve, NO real submit', async () => {
-      mockVerifyBlockToken.mockResolvedValue(validClaims({ buzzBudget: 100, appBlockId: 'apb_gate' }));
+      mockVerifyBlockToken.mockResolvedValue(
+        validClaims({ buzzBudget: 100, appBlockId: 'apb_gate' })
+      );
       happyVersionLookup();
       happyUser();
       installDedupingOrchestrator();
@@ -1408,7 +1477,9 @@ describe('blocks.submitWorkflow', () => {
     });
 
     it('RELEASE on a pre-money cap reject → a genuine retry can re-run (claim not stranded)', async () => {
-      mockVerifyBlockToken.mockResolvedValue(validClaims({ buzzBudget: 100, appBlockId: 'apb_gate' }));
+      mockVerifyBlockToken.mockResolvedValue(
+        validClaims({ buzzBudget: 100, appBlockId: 'apb_gate' })
+      );
       happyVersionLookup();
       happyUser();
       installDedupingOrchestrator();
@@ -1438,7 +1509,12 @@ describe('blocks.submitWorkflow', () => {
       happyUser();
       mockSubmitWorkflow
         .mockResolvedValueOnce({ id: '', status: 'succeeded', cost: { total: 25 }, steps: [] })
-        .mockResolvedValueOnce({ id: workflowId, status: 'unassigned', cost: { total: 25 }, steps: [] });
+        .mockResolvedValueOnce({
+          id: workflowId,
+          status: 'unassigned',
+          cost: { total: 25 },
+          steps: [],
+        });
     }
 
     it('reserves against the app cap keyed on the TOKEN appBlockId (server-derived)', async () => {
@@ -1449,7 +1525,12 @@ describe('blocks.submitWorkflow', () => {
       happyUser();
       mockSubmitWorkflow
         .mockResolvedValueOnce({ id: '', status: 'succeeded', cost: { total: 25 }, steps: [] })
-        .mockResolvedValueOnce({ id: 'wf_real', status: 'unassigned', cost: { total: 25 }, steps: [] });
+        .mockResolvedValueOnce({
+          id: 'wf_real',
+          status: 'unassigned',
+          cost: { total: 25 },
+          steps: [],
+        });
 
       const caller = blocksRouter.createCaller(fakeCtx() as never);
       await caller.submitWorkflow({ blockToken: 'tok', body: validBody() });
@@ -1510,10 +1591,13 @@ describe('blocks.submitWorkflow', () => {
         .mockRejectedValueOnce(new Error('orchestrator down'));
 
       const caller = blocksRouter.createCaller(fakeCtx() as never);
-      await expect(
-        caller.submitWorkflow({ blockToken: 'tok', body: validBody() })
-      ).rejects.toThrow(/orchestrator down/);
-      expect(mockRefundAppSpend).toHaveBeenCalledWith('system:blocks:app-spend-cap:apb_test:day', 25);
+      await expect(caller.submitWorkflow({ blockToken: 'tok', body: validBody() })).rejects.toThrow(
+        /orchestrator down/
+      );
+      expect(mockRefundAppSpend).toHaveBeenCalledWith(
+        'system:blocks:app-spend-cap:apb_test:day',
+        25
+      );
     });
 
     it('is EXCLUDED for dev tokens (claims.dev === true → reserve never called)', async () => {
@@ -1522,7 +1606,12 @@ describe('blocks.submitWorkflow', () => {
       happyUser();
       mockSubmitWorkflow
         .mockResolvedValueOnce({ id: '', status: 'succeeded', cost: { total: 25 }, steps: [] })
-        .mockResolvedValueOnce({ id: 'wf_real', status: 'unassigned', cost: { total: 25 }, steps: [] });
+        .mockResolvedValueOnce({
+          id: 'wf_real',
+          status: 'unassigned',
+          cost: { total: 25 },
+          steps: [],
+        });
 
       const caller = blocksRouter.createCaller(fakeCtx() as never);
       const result = await caller.submitWorkflow({ blockToken: 'tok', body: validBody() });
@@ -1541,7 +1630,12 @@ describe('blocks.submitWorkflow', () => {
     function happySubmit(workflowId = 'wf_real') {
       mockSubmitWorkflow
         .mockResolvedValueOnce({ id: '', status: 'succeeded', cost: { total: 25 }, steps: [] })
-        .mockResolvedValueOnce({ id: workflowId, status: 'unassigned', cost: { total: 25 }, steps: [] });
+        .mockResolvedValueOnce({
+          id: workflowId,
+          status: 'unassigned',
+          cost: { total: 25 },
+          steps: [],
+        });
     }
 
     it('writes a queue row with SERVER-DERIVED args after a resolved submit', async () => {
@@ -1616,7 +1710,12 @@ describe('blocks.submitWorkflow', () => {
       happyUser();
       mockSubmitWorkflow
         .mockResolvedValueOnce({ id: '', status: 'succeeded', cost: { total: 25 }, steps: [] })
-        .mockResolvedValueOnce({ id: 'wf_real', status: 'unassigned', cost: { total: 25 }, steps: [] });
+        .mockResolvedValueOnce({
+          id: 'wf_real',
+          status: 'unassigned',
+          cost: { total: 25 },
+          steps: [],
+        });
     }
 
     it('rejects (fail-closed) when the dev session ceiling is exceeded — no real submit', async () => {
@@ -1663,9 +1762,9 @@ describe('blocks.submitWorkflow', () => {
         .mockRejectedValueOnce(new Error('orchestrator down'));
 
       const caller = blocksRouter.createCaller(fakeCtx() as never);
-      await expect(
-        caller.submitWorkflow({ blockToken: 'tok', body: validBody() })
-      ).rejects.toThrow(/orchestrator down/);
+      await expect(caller.submitWorkflow({ blockToken: 'tok', body: validBody() })).rejects.toThrow(
+        /orchestrator down/
+      );
       // both the daily cap AND the dev session reservation were refunded.
       expect(mockSysRedis.decrBy).toHaveBeenCalled();
       expect(mockRefundDevSessionBuzz).toHaveBeenCalledWith('bki_dev', 25);
@@ -2053,7 +2152,12 @@ describe('blocks.submitWorkflow', () => {
       mockSysRedis.incrBy.mockResolvedValue(125); // under the 5000 session cap
       mockSubmitWorkflow
         .mockResolvedValueOnce({ id: '', status: 'succeeded', cost: { total: 25 }, steps: [] })
-        .mockResolvedValueOnce({ id: 'wf_real', status: 'unassigned', cost: { total: 25 }, steps: [] });
+        .mockResolvedValueOnce({
+          id: 'wf_real',
+          status: 'unassigned',
+          cost: { total: 25 },
+          steps: [],
+        });
       const caller = blocksRouter.createCaller(fakeCtx() as never);
       const result = await caller.submitWorkflow({ blockToken: 'tok', body: validBody() });
       expect(result.snapshot.workflowId).toBe('wf_real');
@@ -2099,7 +2203,12 @@ describe('blocks.submitWorkflow', () => {
       mockSysRedis.incrBy.mockResolvedValue(5001);
       mockSubmitWorkflow
         .mockResolvedValueOnce({ id: '', status: 'succeeded', cost: { total: 25 }, steps: [] })
-        .mockResolvedValueOnce({ id: 'wf_real', status: 'unassigned', cost: { total: 25 }, steps: [] });
+        .mockResolvedValueOnce({
+          id: 'wf_real',
+          status: 'unassigned',
+          cost: { total: 25 },
+          steps: [],
+        });
       const caller = blocksRouter.createCaller(fakeCtx() as never);
       const result = await caller.submitWorkflow({ blockToken: 'tok', body: validBody() });
       expect(result.snapshot.workflowId).toBe('wf_real');
@@ -2222,8 +2331,8 @@ describe('blocks.submitWorkflow', () => {
   // the supplied user is a moderator; no user (global eval) → false.
   describe('flag is evaluated against the block-token subject (no session)', () => {
     function faithfulModSegmentedFlag() {
-      mockIsAppBlocksEnabled.mockImplementation(async (opts?: { user?: { isModerator?: boolean } }) =>
-        !!opts?.user?.isModerator
+      mockIsAppBlocksEnabled.mockImplementation(
+        async (opts?: { user?: { isModerator?: boolean } }) => !!opts?.user?.isModerator
       );
     }
 
@@ -2239,7 +2348,12 @@ describe('blocks.submitWorkflow', () => {
         username: 'u',
       });
       happyVersionLookup();
-      mockSubmitWorkflow.mockResolvedValue({ id: '', status: 'succeeded', cost: { total: 12 }, steps: [] });
+      mockSubmitWorkflow.mockResolvedValue({
+        id: '',
+        status: 'succeeded',
+        cost: { total: 12 },
+        steps: [],
+      });
       const caller = blocksRouter.createCaller(fakeCtx() as never);
       const result = await caller.estimateWorkflow({ blockToken: 'tok', body: validBody() });
       // Got past the flag gate → the orchestrator whatif ran and produced a cost.
@@ -2265,7 +2379,12 @@ describe('blocks.submitWorkflow', () => {
       mockSysRedis.incrBy.mockResolvedValue(125);
       mockSubmitWorkflow
         .mockResolvedValueOnce({ id: '', status: 'succeeded', cost: { total: 25 }, steps: [] })
-        .mockResolvedValueOnce({ id: 'wf_real', status: 'unassigned', cost: { total: 25 }, steps: [] });
+        .mockResolvedValueOnce({
+          id: 'wf_real',
+          status: 'unassigned',
+          cost: { total: 25 },
+          steps: [],
+        });
       const caller = blocksRouter.createCaller(fakeCtx() as never);
       const result = await caller.submitWorkflow({ blockToken: 'tok', body: validBody() });
       expect(result.snapshot.workflowId).toBe('wf_real');
@@ -2335,7 +2454,12 @@ describe('blocks.submitWorkflow', () => {
       mockSysRedis.incrBy.mockResolvedValue(125);
       mockSubmitWorkflow
         .mockResolvedValueOnce({ id: '', status: 'succeeded', cost: { total: 25 }, steps: [] })
-        .mockResolvedValueOnce({ id: 'wf_real', status: 'unassigned', cost: { total: 25 }, steps: [] });
+        .mockResolvedValueOnce({
+          id: 'wf_real',
+          status: 'unassigned',
+          cost: { total: 25 },
+          steps: [],
+        });
       // Session user present (page-host), same mod as the token subject.
       const ctxWithSession = {
         ...fakeCtx(),
@@ -2355,7 +2479,12 @@ describe('blocks.submitWorkflow', () => {
       mockVerifyBlockToken.mockResolvedValue(validClaims());
       mockGetUserById.mockResolvedValue({ id: 42, isModerator: true });
       mockGetSessionUser.mockResolvedValue({ id: 42, isModerator: true, tier: 'free' });
-      mockGetWorkflow.mockResolvedValue({ id: 'wf_1', status: 'succeeded', cost: { total: 0 }, steps: [] });
+      mockGetWorkflow.mockResolvedValue({
+        id: 'wf_1',
+        status: 'succeeded',
+        cost: { total: 0 },
+        steps: [],
+      });
       let caller = blocksRouter.createCaller(fakeCtx() as never);
       const ok = await caller.pollWorkflow({ blockToken: 'tok', workflowId: 'wf_1' });
       expect(ok.snapshot.workflowId).toBe('wf_1');
@@ -3308,7 +3437,12 @@ describe('soft-launch — block-token runtime procedures reject non-author viewe
     const cohortAuthor = { id: 42, isModerator: false, tier: 'free', username: 'u' };
     mockGetSessionUser.mockResolvedValue(cohortAuthor);
     mockIsAppBlocksAuthorEnabled.mockResolvedValue(true);
-    mockGetWorkflow.mockResolvedValue({ id: 'wf_1', status: 'succeeded', cost: { total: 0 }, steps: [] });
+    mockGetWorkflow.mockResolvedValue({
+      id: 'wf_1',
+      status: 'succeeded',
+      cost: { total: 0 },
+      steps: [],
+    });
     const caller = blocksRouter.createCaller(fakeCtx() as never);
     const ok = await caller.pollWorkflow({ blockToken: 'tok', workflowId: 'wf_1' });
     expect(ok.snapshot.workflowId).toBe('wf_1');
@@ -3397,9 +3531,7 @@ describe('blocks workflow — W10 page token (entityType:none)', () => {
       // blue block had sfwOnly:false → could pick a mature resource. Now a blue
       // token mints a SFW ceiling (maxBrowsingLevel = 3) so the resource gate is
       // SFW too, unified with the generation-output clamp.
-      mockVerifyBlockToken.mockResolvedValue(
-        pageClaims({ domain: 'blue', maxBrowsingLevel: 3 })
-      );
+      mockVerifyBlockToken.mockResolvedValue(pageClaims({ domain: 'blue', maxBrowsingLevel: 3 }));
       happyVersionLookup();
       happyUser();
       mockSubmitWorkflow.mockResolvedValue({
@@ -3415,9 +3547,7 @@ describe('blocks workflow — W10 page token (entityType:none)', () => {
     });
 
     it('a RED token (mature ceiling) derives sfwOnly:false (mature resource selection allowed)', async () => {
-      mockVerifyBlockToken.mockResolvedValue(
-        pageClaims({ domain: 'red', maxBrowsingLevel: 31 })
-      );
+      mockVerifyBlockToken.mockResolvedValue(pageClaims({ domain: 'red', maxBrowsingLevel: 31 }));
       happyVersionLookup();
       happyUser();
       mockSubmitWorkflow.mockResolvedValue({
@@ -3466,9 +3596,7 @@ describe('blocks workflow — W10 page token (entityType:none)', () => {
       mockVerifyBlockToken.mockResolvedValue(pageClaims());
       happyVersionLookup();
       happyUser();
-      mockResolveCanGenerateForVersions.mockResolvedValue(
-        new Map([[99, { canGenerate: false }]])
-      );
+      mockResolveCanGenerateForVersions.mockResolvedValue(new Map([[99, { canGenerate: false }]]));
       const caller = blocksRouter.createCaller(fakeCtx() as never);
       await expect(
         caller.estimateWorkflow({ blockToken: 'tok', body: validBody() })
@@ -3521,9 +3649,7 @@ describe('blocks workflow — W10 page token (entityType:none)', () => {
       mockVerifyBlockToken.mockResolvedValue(pageClaims({ buzzBudget: 100 }));
       happyVersionLookup();
       happyUser();
-      mockResolveCanGenerateForVersions.mockResolvedValue(
-        new Map([[99, { canGenerate: false }]])
-      );
+      mockResolveCanGenerateForVersions.mockResolvedValue(new Map([[99, { canGenerate: false }]]));
       const caller = blocksRouter.createCaller(fakeCtx() as never);
       await expect(
         caller.submitWorkflow({ blockToken: 'tok', body: validBody() })
@@ -3614,9 +3740,7 @@ describe('blocks workflow — W10 page token (entityType:none)', () => {
       happyUser();
       // Pre-spend gate PASSES (default canGenerate:true) — modelling that the
       // gate does NOT see early-access / Private entitlement.
-      mockResolveCanGenerateForVersions.mockResolvedValue(
-        new Map([[99, { canGenerate: true }]])
-      );
+      mockResolveCanGenerateForVersions.mockResolvedValue(new Map([[99, { canGenerate: true }]]));
       // The orchestrator resource belt (inside createTextToImageStep) rejects an
       // un-entitled early-access / Private resource. The whatIf step is the FIRST
       // belt call in submit, and it is BEFORE the reservation.
@@ -3641,9 +3765,7 @@ describe('blocks workflow — W10 page token (entityType:none)', () => {
       mockVerifyBlockToken.mockResolvedValue(pageClaims());
       happyVersionLookup();
       happyUser();
-      mockResolveCanGenerateForVersions.mockResolvedValue(
-        new Map([[99, { canGenerate: true }]])
-      );
+      mockResolveCanGenerateForVersions.mockResolvedValue(new Map([[99, { canGenerate: true }]]));
       mockCreateStepsFromGraph.mockRejectedValueOnce(
         new TRPCError({ code: 'FORBIDDEN', message: 'this model requires a subscription' })
       );
@@ -3718,23 +3840,25 @@ describe('blocks workflow — W10 page token (entityType:none)', () => {
     // on the (un-reset) resolveBlockInstance mock — clear both override sources
     // so these tests deterministically reach the platform-popular fallback.
     function clearCheckpointOverrides() {
-      (BlockRegistry.resolveBlockInstance as unknown as ReturnType<typeof vi.fn>).mockResolvedValue({
-        source: 'install',
-        modelId: 7,
-        slotId: 'app.page',
-        enabled: true,
-        settings: {},
-        installedByUserId: 42,
-        appBlock: {
-          id: 'ab_x',
-          blockId: 'gen-from-model',
-          appId: 'app',
-          status: 'approved',
-          manifest: { targets: [{ slotId: 'app.page' }] },
-          approvedScopes: ['ai:write:budgeted'],
-          app: { allowedScopes: 33554431 },
-        },
-      });
+      (BlockRegistry.resolveBlockInstance as unknown as ReturnType<typeof vi.fn>).mockResolvedValue(
+        {
+          source: 'install',
+          modelId: 7,
+          slotId: 'app.page',
+          enabled: true,
+          settings: {},
+          installedByUserId: 42,
+          appBlock: {
+            id: 'ab_x',
+            blockId: 'gen-from-model',
+            appId: 'app',
+            status: 'approved',
+            manifest: { targets: [{ slotId: 'app.page' }] },
+            approvedScopes: ['ai:write:budgeted'],
+            app: { allowedScopes: 33554431 },
+          },
+        }
+      );
       mockDbRead.blockUserSettings.findUnique.mockResolvedValue(null);
     }
 
@@ -3745,7 +3869,12 @@ describe('blocks workflow — W10 page token (entityType:none)', () => {
       mockSysRedis.incrBy.mockResolvedValue(25);
       mockSubmitWorkflow
         .mockResolvedValueOnce({ id: '', status: 'succeeded', cost: { total: 25 }, steps: [] })
-        .mockResolvedValueOnce({ id: 'wf_real', status: 'unassigned', cost: { total: 25 }, steps: [] });
+        .mockResolvedValueOnce({
+          id: 'wf_real',
+          status: 'unassigned',
+          cost: { total: 25 },
+          steps: [],
+        });
       const caller = blocksRouter.createCaller(fakeCtx() as never);
       const result = await caller.submitWorkflow({
         blockToken: 'tok',
@@ -3755,9 +3884,9 @@ describe('blocks workflow — W10 page token (entityType:none)', () => {
       // The gate ran ONCE with checkpoint + both LoRAs in a single array.
       expect(mockResolveCanGenerateForVersions).toHaveBeenCalledTimes(1);
       const [versions] = mockResolveCanGenerateForVersions.mock.calls[0];
-      expect(versions.map((v: { id: number }) => v.id).sort((a: number, b: number) => a - b)).toEqual([
-        99, 201, 202,
-      ]);
+      expect(
+        versions.map((v: { id: number }) => v.id).sort((a: number, b: number) => a - b)
+      ).toEqual([99, 201, 202]);
     });
 
     it('SECURITY: an un-entitled LoRA (canGenerate:false) → FORBIDDEN, no spend, no reservation', async () => {
@@ -3851,7 +3980,10 @@ describe('blocks workflow — W10 page token (entityType:none)', () => {
       );
       const caller = blocksRouter.createCaller(fakeCtx() as never);
       await expect(
-        caller.estimateWorkflow({ blockToken: 'tok', body: bodyWithLoras([{ modelVersionId: 201 }]) })
+        caller.estimateWorkflow({
+          blockToken: 'tok',
+          body: bodyWithLoras([{ modelVersionId: 201 }]),
+        })
       ).rejects.toMatchObject({ code: 'FORBIDDEN' });
       expect(mockSubmitWorkflow).not.toHaveBeenCalled();
     });
@@ -3871,7 +4003,10 @@ describe('blocks workflow — W10 page token (entityType:none)', () => {
         ])
       );
       mockCreateStepsFromGraph.mockRejectedValueOnce(
-        new TRPCError({ code: 'BAD_REQUEST', message: 'Using Private resources require an active subscription.' })
+        new TRPCError({
+          code: 'BAD_REQUEST',
+          message: 'Using Private resources require an active subscription.',
+        })
       );
       const caller = blocksRouter.createCaller(fakeCtx() as never);
       await expect(
@@ -3976,7 +4111,12 @@ describe('blocks workflow — W10 page token (entityType:none)', () => {
       mockSysRedis.incrBy.mockResolvedValue(25);
       mockSubmitWorkflow
         .mockResolvedValueOnce({ id: '', status: 'succeeded', cost: { total: 25 }, steps: [] })
-        .mockResolvedValueOnce({ id: 'wf_real', status: 'unassigned', cost: { total: 25 }, steps: [] });
+        .mockResolvedValueOnce({
+          id: 'wf_real',
+          status: 'unassigned',
+          cost: { total: 25 },
+          steps: [],
+        });
       const caller = blocksRouter.createCaller(fakeCtx() as never);
       // The SDXL LoRA is compatible with the SDXL *resolved checkpoint* (it would
       // have been rejected if the match used the SD 1.5 body model).
@@ -3989,9 +4129,9 @@ describe('blocks workflow — W10 page token (entityType:none)', () => {
       // checkpoint-anchored family match).
       expect(mockResolveCanGenerateForVersions).toHaveBeenCalledTimes(1);
       const [versions] = mockResolveCanGenerateForVersions.mock.calls[0];
-      expect(versions.map((v: { id: number }) => v.id).sort((a: number, b: number) => a - b)).toEqual([
-        99, 201,
-      ]);
+      expect(
+        versions.map((v: { id: number }) => v.id).sort((a: number, b: number) => a - b)
+      ).toEqual([99, 201]);
       // The graph input's `model` anchor is the RESOLVED checkpoint (500), not
       // the body version (99). (In the graph shape the checkpoint is `model`,
       // not `resources[0]` — the additional LoRA lives in `resources`.)
@@ -4168,7 +4308,12 @@ describe('blocks workflow — W10 page token (entityType:none)', () => {
       mockSysRedis.incrBy.mockResolvedValue(25);
       mockSubmitWorkflow
         .mockResolvedValueOnce({ id: '', status: 'succeeded', cost: { total: 25 }, steps: [] })
-        .mockResolvedValueOnce({ id: 'wf_real', status: 'unassigned', cost: { total: 25 }, steps: [] });
+        .mockResolvedValueOnce({
+          id: 'wf_real',
+          status: 'unassigned',
+          cost: { total: 25 },
+          steps: [],
+        });
       const caller = blocksRouter.createCaller(fakeCtx() as never);
       const result = await caller.submitWorkflow({
         blockToken: 'tok',
@@ -4180,9 +4325,9 @@ describe('blocks workflow — W10 page token (entityType:none)', () => {
       // BAD_REQUEST.
       expect(mockResolveCanGenerateForVersions).toHaveBeenCalledTimes(1);
       const [versions] = mockResolveCanGenerateForVersions.mock.calls[0];
-      expect(versions.map((v: { id: number }) => v.id).sort((a: number, b: number) => a - b)).toEqual([
-        99, 201,
-      ]);
+      expect(
+        versions.map((v: { id: number }) => v.id).sort((a: number, b: number) => a - b)
+      ).toEqual([99, 201]);
     });
 
     // ── GA: a genuinely-incompatible cross-ecosystem LoRA is STILL rejected ────
@@ -4224,7 +4369,10 @@ describe('blocks workflow — W10 page token (entityType:none)', () => {
       happyUser();
       const caller = blocksRouter.createCaller(fakeCtx() as never);
       await expect(
-        caller.estimateWorkflow({ blockToken: 'tok', body: bodyWithLoras([{ modelVersionId: 201 }]) })
+        caller.estimateWorkflow({
+          blockToken: 'tok',
+          body: bodyWithLoras([{ modelVersionId: 201 }]),
+        })
       ).rejects.toMatchObject({ code: 'FORBIDDEN' });
       expect(mockSubmitWorkflow).not.toHaveBeenCalled();
     });
@@ -4244,7 +4392,9 @@ describe('blocks workflow — W10 page token (entityType:none)', () => {
     });
 
     it('submit: a MODEL token with a mismatched body.modelId → FORBIDDEN (binding unchanged)', async () => {
-      mockVerifyBlockToken.mockResolvedValue(validClaims({ buzzBudget: 100, ctx: { modelId: 999 } }));
+      mockVerifyBlockToken.mockResolvedValue(
+        validClaims({ buzzBudget: 100, ctx: { modelId: 999 } })
+      );
       const caller = blocksRouter.createCaller(fakeCtx() as never);
       await expect(
         caller.submitWorkflow({ blockToken: 'tok', body: validBody() })
@@ -4308,7 +4458,12 @@ describe('blocks workflow — color-domain maturity enforcement', () => {
       );
       happyVersionLookup();
       happyUser();
-      mockSubmitWorkflow.mockResolvedValue({ id: '', status: 'succeeded', cost: { total: 5 }, steps: [] });
+      mockSubmitWorkflow.mockResolvedValue({
+        id: '',
+        status: 'succeeded',
+        cost: { total: 5 },
+        steps: [],
+      });
       const caller = blocksRouter.createCaller(fakeCtx() as never);
       await caller.estimateWorkflow({ blockToken: 'tok', body: validBody() });
       expect(firstSubmitBody().allowMatureContent).toBe(false);
@@ -4320,7 +4475,12 @@ describe('blocks workflow — color-domain maturity enforcement', () => {
       );
       happyVersionLookup();
       happyUser();
-      mockSubmitWorkflow.mockResolvedValue({ id: '', status: 'succeeded', cost: { total: 5 }, steps: [] });
+      mockSubmitWorkflow.mockResolvedValue({
+        id: '',
+        status: 'succeeded',
+        cost: { total: 5 },
+        steps: [],
+      });
       const caller = blocksRouter.createCaller(fakeCtx() as never);
       await caller.estimateWorkflow({ blockToken: 'tok', body: validBody() });
       expect(firstSubmitBody().allowMatureContent).toBe(false);
@@ -4332,7 +4492,12 @@ describe('blocks workflow — color-domain maturity enforcement', () => {
       );
       happyVersionLookup();
       happyUser();
-      mockSubmitWorkflow.mockResolvedValue({ id: '', status: 'succeeded', cost: { total: 5 }, steps: [] });
+      mockSubmitWorkflow.mockResolvedValue({
+        id: '',
+        status: 'succeeded',
+        cost: { total: 5 },
+        steps: [],
+      });
       const caller = blocksRouter.createCaller(fakeCtx() as never);
       await caller.estimateWorkflow({ blockToken: 'tok', body: validBody() });
       expect(firstSubmitBody()).not.toHaveProperty('allowMatureContent');
@@ -4343,7 +4508,12 @@ describe('blocks workflow — color-domain maturity enforcement', () => {
       mockVerifyBlockToken.mockResolvedValue(validClaims());
       happyVersionLookup();
       happyUser();
-      mockSubmitWorkflow.mockResolvedValue({ id: '', status: 'succeeded', cost: { total: 5 }, steps: [] });
+      mockSubmitWorkflow.mockResolvedValue({
+        id: '',
+        status: 'succeeded',
+        cost: { total: 5 },
+        steps: [],
+      });
       const caller = blocksRouter.createCaller(fakeCtx() as never);
       await caller.estimateWorkflow({ blockToken: 'tok', body: validBody() });
       expect(firstSubmitBody().allowMatureContent).toBe(false);
@@ -4354,7 +4524,12 @@ describe('blocks workflow — color-domain maturity enforcement', () => {
     function happySubmit(cost = 10) {
       mockSubmitWorkflow
         .mockResolvedValueOnce({ id: '', status: 'succeeded', cost: { total: cost }, steps: [] })
-        .mockResolvedValueOnce({ id: 'wf_real', status: 'unassigned', cost: { total: cost }, steps: [] });
+        .mockResolvedValueOnce({
+          id: 'wf_real',
+          status: 'unassigned',
+          cost: { total: cost },
+          steps: [],
+        });
     }
 
     it('green-domain token forces allowMatureContent=false on BOTH whatif and real submit', async () => {
@@ -4469,7 +4644,12 @@ describe('blocks workflow — buzz-type parity + spend-attribution currency', ()
   function happySubmit(cost = 10) {
     mockSubmitWorkflow
       .mockResolvedValueOnce({ id: '', status: 'succeeded', cost: { total: cost }, steps: [] })
-      .mockResolvedValueOnce({ id: 'wf_real', status: 'unassigned', cost: { total: cost }, steps: [] });
+      .mockResolvedValueOnce({
+        id: 'wf_real',
+        status: 'unassigned',
+        cost: { total: cost },
+        steps: [],
+      });
   }
   function bodyOf(callIdx: number) {
     return (mockSubmitWorkflow.mock.calls[callIdx][0] as { body: Record<string, unknown> }).body;
@@ -4491,7 +4671,12 @@ describe('blocks workflow — buzz-type parity + spend-attribution currency', ()
       mockVerifyBlockToken.mockResolvedValue(validClaims({ maxBrowsingLevel: SFW_CEILING }));
       happyVersionLookup();
       happyUser();
-      mockSubmitWorkflow.mockResolvedValue({ id: '', status: 'succeeded', cost: { total: 5 }, steps: [] });
+      mockSubmitWorkflow.mockResolvedValue({
+        id: '',
+        status: 'succeeded',
+        cost: { total: 5 },
+        steps: [],
+      });
       const caller = blocksRouter.createCaller(fakeCtx() as never);
       await caller.estimateWorkflow({ blockToken: 'tok', body: validBody() });
       const currencies = bodyOf(0).currencies as unknown[];
@@ -5034,9 +5219,7 @@ describe('blocks.getMyBuzzAccounts', () => {
     ]);
     const caller = blocksRouter.createCaller(fakeCtx() as never);
     const result = await caller.getMyBuzzAccounts({ blockToken: 'tok' });
-    expect(mockGetUserBuzzAccount).toHaveBeenCalledWith(
-      expect.objectContaining({ accountId: 42 })
-    );
+    expect(mockGetUserBuzzAccount).toHaveBeenCalledWith(expect.objectContaining({ accountId: 42 }));
     expect(result.accounts).toEqual([
       { accountType: 'yellow', balance: 100 },
       { accountType: 'cashSettled', balance: 5 },
@@ -5162,17 +5345,19 @@ describe('customComfy bridge (submit/estimate/settle)', () => {
   // entitlement belt passes on the happy path. Tests override the canGenerate map.
   function happyCcResources() {
     happyUser(); // moderator subject for the developer gate + getBlockSessionUser
-    mockDbRead.modelVersion.findUnique.mockImplementation(async (args: { where: { id: number } }) => ({
-      id: args.where.id,
-      baseModel: 'Flux.1 D',
-      modelId: 118025,
-      status: 'Published',
-      availability: 'Public',
-      usageControl: 'Allow',
-      meta: {},
-      generationCoverage: { covered: true },
-      model: { id: 118025, type: 'LORA', userId: 999 },
-    }));
+    mockDbRead.modelVersion.findUnique.mockImplementation(
+      async (args: { where: { id: number } }) => ({
+        id: args.where.id,
+        baseModel: 'Flux.1 D',
+        modelId: 118025,
+        status: 'Published',
+        availability: 'Public',
+        usageControl: 'Allow',
+        meta: {},
+        generationCoverage: { covered: true },
+        model: { id: 118025, type: 'LORA', userId: 999 },
+      })
+    );
     mockResolveCanGenerateForVersions.mockResolvedValue(
       new Map(CC_LORA_VERSION_IDS.map((id) => [id, { canGenerate: true }]))
     );
@@ -5382,14 +5567,17 @@ describe('customComfy bridge (submit/estimate/settle)', () => {
       mockVerifyBlockToken.mockResolvedValue(ccPageClaims());
       happyCcResources();
       mockSubmitWorkflow.mockRejectedValue(new Error('orchestrator down'));
-      await expect(
-        caller().submitWorkflow({ blockToken: 'tok', body: ccBody() })
-      ).rejects.toThrow(/orchestrator down/);
+      await expect(caller().submitWorkflow({ blockToken: 'tok', body: ccBody() })).rejects.toThrow(
+        /orchestrator down/
+      );
       expect(mockSysRedis.decrBy).toHaveBeenCalledWith(
         expect.stringMatching(/^system:blocks:buzz-cap:42:/),
         90
       );
-      expect(mockRefundAppSpend).toHaveBeenCalledWith('system:blocks:app-spend-cap:apb_test:day', 90);
+      expect(mockRefundAppSpend).toHaveBeenCalledWith(
+        'system:blocks:app-spend-cap:apb_test:day',
+        90
+      );
       // never persisted a settle record for a submit that threw.
       expect(mockPersistCustomComfySettle).not.toHaveBeenCalled();
     });
@@ -5518,7 +5706,9 @@ describe('customComfy bridge (submit/estimate/settle)', () => {
       expect(step.input.workflow['1'].class_type).toBe('GGUFLoaderKJ');
       expect((step.input.resources as string[]).some((r) => r.includes('Qwen-Image'))).toBe(true);
       // And it is NOT zimage's graph/resources (guards against a mismatched pairing).
-      expect((step.input.resources as string[]).some((r) => r.includes('z_image_turbo'))).toBe(false);
+      expect((step.input.resources as string[]).some((r) => r.includes('z_image_turbo'))).toBe(
+        false
+      );
     });
 
     it('the concrete new behavior: at buzzBudget 100, cheap zimage (90) RUNS but qwen (180) is REJECTED', async () => {
@@ -5767,9 +5957,9 @@ describe('customComfy bridge (submit/estimate/settle)', () => {
       mockReserveDevSessionBuzz.mockResolvedValue({ allowed: true, total: 90 });
       mockSubmitWorkflow.mockRejectedValue(new Error('orchestrator down'));
 
-      await expect(
-        caller().submitWorkflow({ blockToken: 'tok', body: ccBody() })
-      ).rejects.toThrow(/orchestrator down/);
+      await expect(caller().submitWorkflow({ blockToken: 'tok', body: ccBody() })).rejects.toThrow(
+        /orchestrator down/
+      );
       // Daily + dev-session ceiling (zimage 90) both refunded on the throw.
       expect(mockSysRedis.decrBy).toHaveBeenCalledWith(
         expect.stringMatching(/^system:blocks:buzz-cap:42:/),
@@ -6057,6 +6247,61 @@ describe("step-type registry bridge (kind: 'step')", () => {
       await expect(
         caller().estimateWorkflow({ blockToken: 'tok', body: stepBody() })
       ).rejects.toMatchObject({ code: 'FORBIDDEN' });
+    });
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // REQUEST-TIME $type RE-ASSERT.
+    //
+    // 🔴 WHY THIS CANNOT BE COVERED AT REGISTRY LOAD. `assertStepInvariants`
+    // probes CANONICAL params, and the divergent fixture's canonical params
+    // build its DECLARED type — the mock asserts it registers cleanly. The
+    // divergence exists only for request params the untrusted iframe chooses.
+    // Without the router clause the orchestrator receives `chatCompletion`
+    // while `runStepModeration` dispatched on the DECLARED posture ('none'),
+    // i.e. free text generated with no audit.
+    // ─────────────────────────────────────────────────────────────────────────
+    it('REJECTS a submit whose BUILT $type diverges from the declared one', async () => {
+      mockVerifyBlockToken.mockResolvedValue(stepClaims());
+      happyUser();
+      happyStepSubmit();
+      await expect(
+        caller().submitWorkflow({
+          blockToken: 'tok',
+          body: { kind: 'step', step: DIVERGENT_STEP_ID, params: { flip: true } },
+        })
+      ).rejects.toMatchObject({ code: 'FORBIDDEN' });
+    });
+
+    it('the divergent submit reaches NO orchestrator call and spends nothing', async () => {
+      // 🔴 The assertion that makes the one above worth having: rejecting after
+      // the quote or after a reservation would still be a bug. Placement is
+      // before both, so the orchestrator is never called AT ALL — not even the
+      // free whatIf.
+      mockVerifyBlockToken.mockResolvedValue(stepClaims());
+      happyUser();
+      happyStepSubmit();
+      mockSubmitWorkflow.mockClear();
+      await expect(
+        caller().submitWorkflow({
+          blockToken: 'tok',
+          body: { kind: 'step', step: DIVERGENT_STEP_ID, params: { flip: true } },
+        })
+      ).rejects.toMatchObject({ code: 'FORBIDDEN' });
+      expect(mockSubmitWorkflow).not.toHaveBeenCalled();
+    });
+
+    it('NEGATIVE CONTROL: the SAME fixture submits fine when the types agree', async () => {
+      // Same entry, same path, only `flip` differs — so the rejection above is
+      // provably the $type divergence and not the fixture being unusable.
+      mockVerifyBlockToken.mockResolvedValue(stepClaims());
+      happyUser();
+      happyStepSubmit();
+      await expect(
+        caller().submitWorkflow({
+          blockToken: 'tok',
+          body: { kind: 'step', step: DIVERGENT_STEP_ID, params: { flip: false } },
+        })
+      ).resolves.toBeDefined();
     });
   });
 

--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -1227,9 +1227,7 @@ export const blocksRouter = router({
     .use(enforceAppBlocksFlag)
     .input(withdrawRequestSchema)
     .mutation(async ({ ctx, input }) => {
-      const { withdrawRequest } = await import(
-        '~/server/services/blocks/publish-request.service'
-      );
+      const { withdrawRequest } = await import('~/server/services/blocks/publish-request.service');
       if (!ctx.user) throw throwAuthorizationError('Not authenticated');
       try {
         await withdrawRequest({
@@ -1575,9 +1573,7 @@ export const blocksRouter = router({
       if (!ctx.user?.isModerator) {
         throw throwAuthorizationError('Review previews are restricted to civitai team');
       }
-      const { isAppBlocksReviewSandboxEnabled } = await import(
-        '~/server/services/app-blocks-flag'
-      );
+      const { isAppBlocksReviewSandboxEnabled } = await import('~/server/services/app-blocks-flag');
       if (!(await isAppBlocksReviewSandboxEnabled({ user: ctx.user }))) {
         throw throwAuthorizationError('The review sandbox is not enabled');
       }
@@ -1604,9 +1600,7 @@ export const blocksRouter = router({
       if (!ctx.user?.isModerator) {
         throw throwAuthorizationError('Review previews are restricted to civitai team');
       }
-      const { isAppBlocksReviewSandboxEnabled } = await import(
-        '~/server/services/app-blocks-flag'
-      );
+      const { isAppBlocksReviewSandboxEnabled } = await import('~/server/services/app-blocks-flag');
       if (!(await isAppBlocksReviewSandboxEnabled({ user: ctx.user }))) {
         throw throwAuthorizationError('The review sandbox is not enabled');
       }
@@ -1644,9 +1638,7 @@ export const blocksRouter = router({
       if (!ctx.user?.isModerator) {
         throw throwAuthorizationError('Review previews are restricted to civitai team');
       }
-      const { isAppBlocksReviewSandboxEnabled } = await import(
-        '~/server/services/app-blocks-flag'
-      );
+      const { isAppBlocksReviewSandboxEnabled } = await import('~/server/services/app-blocks-flag');
       if (!(await isAppBlocksReviewSandboxEnabled({ user: ctx.user }))) {
         throw throwAuthorizationError('The review sandbox is not enabled');
       }
@@ -1702,9 +1694,7 @@ export const blocksRouter = router({
       if (!ctx.user?.isModerator) {
         throw throwAuthorizationError('Agentic review is restricted to civitai team');
       }
-      const { isAppBlocksAgenticReviewEnabled } = await import(
-        '~/server/services/app-blocks-flag'
-      );
+      const { isAppBlocksAgenticReviewEnabled } = await import('~/server/services/app-blocks-flag');
       if (!(await isAppBlocksAgenticReviewEnabled({ user: ctx.user }))) {
         throw throwAuthorizationError('Agentic review is not enabled');
       }
@@ -1740,15 +1730,11 @@ export const blocksRouter = router({
       if (!ctx.user?.isModerator) {
         throw throwAuthorizationError('Agentic review is restricted to civitai team');
       }
-      const { isAppBlocksAgenticReviewEnabled } = await import(
-        '~/server/services/app-blocks-flag'
-      );
+      const { isAppBlocksAgenticReviewEnabled } = await import('~/server/services/app-blocks-flag');
       if (!(await isAppBlocksAgenticReviewEnabled({ user: ctx.user }))) {
         throw throwAuthorizationError('Agentic review is not enabled');
       }
-      const { getAgentReport } = await import(
-        '~/server/services/blocks/app-review-report.service'
-      );
+      const { getAgentReport } = await import('~/server/services/blocks/app-review-report.service');
       return getAgentReport(input.publishRequestId);
     }),
 
@@ -1773,9 +1759,7 @@ export const blocksRouter = router({
       if (!ctx.user?.isModerator) {
         throw throwAuthorizationError('Agentic review is restricted to civitai team');
       }
-      const { isAppBlocksAgenticReviewEnabled } = await import(
-        '~/server/services/app-blocks-flag'
-      );
+      const { isAppBlocksAgenticReviewEnabled } = await import('~/server/services/app-blocks-flag');
       if (!(await isAppBlocksAgenticReviewEnabled({ user: ctx.user }))) {
         throw throwAuthorizationError('Agentic review is not enabled');
       }
@@ -1809,9 +1793,7 @@ export const blocksRouter = router({
       if (!ctx.user?.isModerator) {
         throw throwAuthorizationError('Review previews are restricted to civitai team');
       }
-      const { isAppBlocksReviewSandboxEnabled } = await import(
-        '~/server/services/app-blocks-flag'
-      );
+      const { isAppBlocksReviewSandboxEnabled } = await import('~/server/services/app-blocks-flag');
       if (!(await isAppBlocksReviewSandboxEnabled({ user: ctx.user }))) {
         throw throwAuthorizationError('The review sandbox is not enabled');
       }
@@ -1828,27 +1810,23 @@ export const blocksRouter = router({
    * all mods) + the cap, for the "Active previews (N / cap)" panel. Same mod-only
    * flag gate as previewRequest; no input.
    */
-  listActivePreviews: moderatorProcedure
-    .use(enforceAppBlocksFlag)
-    .query(async ({ ctx }) => {
-      if (!ctx.user?.isModerator) {
-        throw throwAuthorizationError('Review previews are restricted to civitai team');
-      }
-      const { isAppBlocksReviewSandboxEnabled } = await import(
-        '~/server/services/app-blocks-flag'
-      );
-      if (!(await isAppBlocksReviewSandboxEnabled({ user: ctx.user }))) {
-        throw throwAuthorizationError('The review sandbox is not enabled');
-      }
-      const { listActiveReviewPreviews } = await import(
-        '~/server/services/blocks/publish-request.service'
-      );
-      try {
-        return await listActiveReviewPreviews();
-      } catch (err) {
-        throw new TRPCError({ code: 'BAD_REQUEST', message: (err as Error).message });
-      }
-    }),
+  listActivePreviews: moderatorProcedure.use(enforceAppBlocksFlag).query(async ({ ctx }) => {
+    if (!ctx.user?.isModerator) {
+      throw throwAuthorizationError('Review previews are restricted to civitai team');
+    }
+    const { isAppBlocksReviewSandboxEnabled } = await import('~/server/services/app-blocks-flag');
+    if (!(await isAppBlocksReviewSandboxEnabled({ user: ctx.user }))) {
+      throw throwAuthorizationError('The review sandbox is not enabled');
+    }
+    const { listActiveReviewPreviews } = await import(
+      '~/server/services/blocks/publish-request.service'
+    );
+    try {
+      return await listActiveReviewPreviews();
+    } catch (err) {
+      throw new TRPCError({ code: 'BAD_REQUEST', message: (err as Error).message });
+    }
+  }),
 
   /**
    * Approve a pending publish request: pre-creates the OauthClient +
@@ -1860,9 +1838,7 @@ export const blocksRouter = router({
     .use(enforceAppBlocksFlag)
     .input(approveRequestSchema)
     .mutation(async ({ ctx, input }) => {
-      const { approveRequest } = await import(
-        '~/server/services/blocks/publish-request.service'
-      );
+      const { approveRequest } = await import('~/server/services/blocks/publish-request.service');
       if (!ctx.user?.isModerator) {
         throw throwAuthorizationError('Approving publish requests is restricted to civitai team');
       }
@@ -2006,9 +1982,7 @@ export const blocksRouter = router({
     .use(enforceAppBlocksFlag)
     .input(rejectRequestSchema)
     .mutation(async ({ ctx, input }) => {
-      const { rejectRequest } = await import(
-        '~/server/services/blocks/publish-request.service'
-      );
+      const { rejectRequest } = await import('~/server/services/blocks/publish-request.service');
       if (!ctx.user?.isModerator) {
         throw throwAuthorizationError('Rejecting publish requests is restricted to civitai team');
       }
@@ -2066,8 +2040,8 @@ export const blocksRouter = router({
             : serviceCode === 'RATE_LIMITED'
             ? 'TOO_MANY_REQUESTS'
             : // A build-service outage is OUR fault, not a malformed request —
-              // reporting it as a 400 mislabels an incident as user error (and
-              // keeps it off the server-fault error board).
+            // reporting it as a 400 mislabels an incident as user error (and
+            // keeps it off the server-fault error board).
             serviceCode === 'TRIGGER_FAILED'
             ? 'INTERNAL_SERVER_ERROR'
             : 'BAD_REQUEST';
@@ -2081,195 +2055,193 @@ export const blocksRouter = router({
    * Returns the rejection reason inline so the dev sees mod feedback
    * without a second round-trip.
    */
-  listMyPublishRequests: appDeveloperProcedure
-    .use(enforceAppBlocksFlag)
-    .query(async ({ ctx }) => {
-      if (!ctx.user) return [];
-      const rows = await dbRead.appBlockPublishRequest.findMany({
-        where: { submittedByUserId: ctx.user.id },
-        orderBy: { submittedAt: 'desc' },
-        take: 100,
+  listMyPublishRequests: appDeveloperProcedure.use(enforceAppBlocksFlag).query(async ({ ctx }) => {
+    if (!ctx.user) return [];
+    const rows = await dbRead.appBlockPublishRequest.findMany({
+      where: { submittedByUserId: ctx.user.id },
+      orderBy: { submittedAt: 'desc' },
+      take: 100,
+      select: {
+        id: true,
+        appBlockId: true,
+        slug: true,
+        version: true,
+        status: true,
+        submittedAt: true,
+        reviewedAt: true,
+        rejectionReason: true,
+        approvalNotes: true,
+        // Phase 2 build/deploy lifecycle, surfaced on /apps/my-submissions.
+        deployState: true,
+        deployDetail: true,
+        deployUpdatedAt: true,
+        fileSummary: true,
+        manifestDiffSummary: true,
+        appBlock: {
+          select: {
+            id: true,
+            // W13 P4: `hasPage` for the Open-live run-page link (does the manifest
+            // declare a launchable page). PUBLIC subset only — never the raw manifest.
+            manifest: true,
+            _count: { select: { userSubscriptions: true } },
+          },
+        },
+      },
+    });
+    // Flatten _count onto each row so the UI doesn't have to dig through
+    // the relation. Pending-first-version + withdrawn-first-version rows
+    // have no appBlock (FK is set on approve) — surface null so the UI
+    // can render "—".
+    //
+    // Post kill_per_model_installs: model installs are subscription rows
+    // with target_model_ids populated. Compute the pinned-install count
+    // via a second targeted query rather than over-fetching subs.
+    type RawRow = (typeof rows)[number];
+    const appBlockIds = rows
+      .map((r: RawRow) => r.appBlock?.id)
+      .filter((id: string | undefined): id is string => !!id);
+    const pinnedCounts = appBlockIds.length
+      ? (
+          (await dbRead.blockUserSubscription.groupBy({
+            by: ['appBlockId'],
+            where: {
+              appBlockId: { in: appBlockIds },
+              scope: 'publisher_all_my_models',
+              slotId: { not: null },
+            },
+            _count: { _all: true },
+          })) as unknown as Array<{ appBlockId: string; _count: { _all: number } }>
+        ).reduce<Record<string, number>>((acc, row) => {
+          acc[row.appBlockId] = row._count._all;
+          return acc;
+        }, {})
+      : {};
+
+    // W13 P4 (owner controls): resolve the backing on-site `AppListing` (1:1 with
+    // the AppBlock — `AppListing.appBlockId`) for each row so the UI reads the TRUE
+    // live/removed listing state. A publish request stays `approved` after an owner
+    // unpublish, so the request status alone can't tell live from owner-hidden. One
+    // batched findMany (NOT per-row) keyed by appBlockId.
+    // Additive projection (advisory listing-completeness warning on
+    // /apps/my-submissions): the asset ids + key text fields + a screenshot
+    // COUNT (via `_count`, not the rows) feed the pure `computeListingProblems`
+    // helper below. Purely additive — the owner-controls fields are unchanged.
+    const listingByBlockId = new Map<
+      string,
+      {
+        id: string;
+        status: string;
+        iconId: number | null;
+        coverId: number | null;
+        description: string | null;
+        tagline: string | null;
+        category: string | null;
+        screenshotCount: number;
+      }
+    >();
+    if (appBlockIds.length) {
+      const listings = await dbRead.appListing.findMany({
+        where: { appBlockId: { in: appBlockIds }, kind: 'onsite' },
         select: {
           id: true,
           appBlockId: true,
-          slug: true,
-          version: true,
           status: true,
-          submittedAt: true,
-          reviewedAt: true,
-          rejectionReason: true,
-          approvalNotes: true,
-          // Phase 2 build/deploy lifecycle, surfaced on /apps/my-submissions.
-          deployState: true,
-          deployDetail: true,
-          deployUpdatedAt: true,
-          fileSummary: true,
-          manifestDiffSummary: true,
-          appBlock: {
-            select: {
-              id: true,
-              // W13 P4: `hasPage` for the Open-live run-page link (does the manifest
-              // declare a launchable page). PUBLIC subset only — never the raw manifest.
-              manifest: true,
-              _count: { select: { userSubscriptions: true } },
-            },
-          },
+          iconId: true,
+          coverId: true,
+          description: true,
+          tagline: true,
+          category: true,
+          // Filtered COUNT — only screenshots whose Image is still live. A row
+          // whose Image was deleted (imageId → null via onDelete: SetNull) has
+          // no displayable asset, so it must not inflate the count, else the
+          // `no-screenshots` warning is a false-negative. Matches the
+          // authoritative asset gate: `screenshots.filter(s => s.imageId != null)`
+          // in app-listing-assets.service.ts (buildAssetStatus).
+          _count: { select: { screenshots: { where: { imageId: { not: null } } } } },
         },
       });
-      // Flatten _count onto each row so the UI doesn't have to dig through
-      // the relation. Pending-first-version + withdrawn-first-version rows
-      // have no appBlock (FK is set on approve) — surface null so the UI
-      // can render "—".
-      //
-      // Post kill_per_model_installs: model installs are subscription rows
-      // with target_model_ids populated. Compute the pinned-install count
-      // via a second targeted query rather than over-fetching subs.
-      type RawRow = (typeof rows)[number];
-      const appBlockIds = rows
-        .map((r: RawRow) => r.appBlock?.id)
-        .filter((id: string | undefined): id is string => !!id);
-      const pinnedCounts = appBlockIds.length
-        ? (
-            (await dbRead.blockUserSubscription.groupBy({
-              by: ['appBlockId'],
-              where: {
-                appBlockId: { in: appBlockIds },
-                scope: 'publisher_all_my_models',
-                slotId: { not: null },
-              },
-              _count: { _all: true },
-            })) as unknown as Array<{ appBlockId: string; _count: { _all: number } }>
-          ).reduce<Record<string, number>>((acc, row) => {
-            acc[row.appBlockId] = row._count._all;
-            return acc;
-          }, {})
-        : {};
-
-      // W13 P4 (owner controls): resolve the backing on-site `AppListing` (1:1 with
-      // the AppBlock — `AppListing.appBlockId`) for each row so the UI reads the TRUE
-      // live/removed listing state. A publish request stays `approved` after an owner
-      // unpublish, so the request status alone can't tell live from owner-hidden. One
-      // batched findMany (NOT per-row) keyed by appBlockId.
-      // Additive projection (advisory listing-completeness warning on
-      // /apps/my-submissions): the asset ids + key text fields + a screenshot
-      // COUNT (via `_count`, not the rows) feed the pure `computeListingProblems`
-      // helper below. Purely additive — the owner-controls fields are unchanged.
-      const listingByBlockId = new Map<
-        string,
-        {
-          id: string;
-          status: string;
-          iconId: number | null;
-          coverId: number | null;
-          description: string | null;
-          tagline: string | null;
-          category: string | null;
-          screenshotCount: number;
-        }
-      >();
-      if (appBlockIds.length) {
-        const listings = await dbRead.appListing.findMany({
-          where: { appBlockId: { in: appBlockIds }, kind: 'onsite' },
-          select: {
-            id: true,
-            appBlockId: true,
-            status: true,
-            iconId: true,
-            coverId: true,
-            description: true,
-            tagline: true,
-            category: true,
-            // Filtered COUNT — only screenshots whose Image is still live. A row
-            // whose Image was deleted (imageId → null via onDelete: SetNull) has
-            // no displayable asset, so it must not inflate the count, else the
-            // `no-screenshots` warning is a false-negative. Matches the
-            // authoritative asset gate: `screenshots.filter(s => s.imageId != null)`
-            // in app-listing-assets.service.ts (buildAssetStatus).
-            _count: { select: { screenshots: { where: { imageId: { not: null } } } } },
-          },
-        });
-        for (const l of listings) {
-          if (l.appBlockId)
-            listingByBlockId.set(l.appBlockId, {
-              id: l.id,
-              status: l.status,
-              iconId: l.iconId,
-              coverId: l.coverId,
-              description: l.description,
-              tagline: l.tagline,
-              category: l.category,
-              screenshotCount: l._count.screenshots,
-            });
-        }
+      for (const l of listings) {
+        if (l.appBlockId)
+          listingByBlockId.set(l.appBlockId, {
+            id: l.id,
+            status: l.status,
+            iconId: l.iconId,
+            coverId: l.coverId,
+            description: l.description,
+            tagline: l.tagline,
+            category: l.category,
+            screenshotCount: l._count.screenshots,
+          });
       }
+    }
 
-      // For every REMOVED backing listing, its MOST-RECENT moderation-event action —
-      // so the UI distinguishes an owner-hidden listing (last event `owner-unpublish`
-      // → Republish-eligible) from a moderator takedown (last event `delist`/`purge` →
-      // Republish FORBIDDEN, shown as "removed by a moderator"). Batched `distinct` +
-      // `orderBy desc` (ONE query, latest per listing), only over removed listings —
-      // mirrors the off-site `listMySubmissions` approach.
-      const removedListingIds = [...listingByBlockId.values()]
-        .filter((l) => l.status === 'removed')
-        .map((l) => l.id);
-      const lastEvents = removedListingIds.length
-        ? await dbRead.appListingModerationEvent.findMany({
-            where: { appListingId: { in: removedListingIds } },
-            orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
-            distinct: ['appListingId'],
-            select: { appListingId: true, action: true },
-          })
-        : [];
-      const lastActionByListingId = new Map(
-        lastEvents
-          .filter((e): e is { appListingId: string; action: string } => e.appListingId != null)
-          .map((e) => [e.appListingId, e.action])
-      );
+    // For every REMOVED backing listing, its MOST-RECENT moderation-event action —
+    // so the UI distinguishes an owner-hidden listing (last event `owner-unpublish`
+    // → Republish-eligible) from a moderator takedown (last event `delist`/`purge` →
+    // Republish FORBIDDEN, shown as "removed by a moderator"). Batched `distinct` +
+    // `orderBy desc` (ONE query, latest per listing), only over removed listings —
+    // mirrors the off-site `listMySubmissions` approach.
+    const removedListingIds = [...listingByBlockId.values()]
+      .filter((l) => l.status === 'removed')
+      .map((l) => l.id);
+    const lastEvents = removedListingIds.length
+      ? await dbRead.appListingModerationEvent.findMany({
+          where: { appListingId: { in: removedListingIds } },
+          orderBy: [{ createdAt: 'desc' }, { id: 'desc' }],
+          distinct: ['appListingId'],
+          select: { appListingId: true, action: true },
+        })
+      : [];
+    const lastActionByListingId = new Map(
+      lastEvents
+        .filter((e): e is { appListingId: string; action: string } => e.appListingId != null)
+        .map((e) => [e.appListingId, e.action])
+    );
 
-      type RowWithCount = (typeof rows)[number];
-      return rows.map((r: RowWithCount) => {
-        const counts = r.appBlock?._count;
-        const appBlockId = r.appBlock?.id;
-        const manifest = r.appBlock?.manifest;
-        const { appBlock: _drop, ...rest } = r;
-        // userSubscriptionCount keeps the historical meaning ("blanket +
-        // pinned subscriptions for this app"); modelInstallCount is the
-        // pinned-subscription subset, mirroring what the pre-migration
-        // model_block_installs row count meant.
-        const totalSubs = counts?.userSubscriptions ?? null;
-        const pinnedCount = appBlockId ? pinnedCounts[appBlockId] ?? 0 : null;
-        const listing = appBlockId ? listingByBlockId.get(appBlockId) : undefined;
-        return {
-          ...rest,
-          modelInstallCount: pinnedCount,
-          userSubscriptionCount: totalSubs,
-          // The backing on-site listing id (owner unpublish/republish/history target)
-          // + its TRUE lifecycle status, and — for a removed listing — the last mod
-          // action (owner-hidden vs mod-removed). Null when no backing listing exists
-          // (e.g. a pending first-version request, or a pre-W13 backfill gap).
-          appListingId: listing?.id ?? null,
-          listingStatus: listing?.status ?? null,
-          lastModerationAction: listing ? lastActionByListingId.get(listing.id) ?? null : null,
-          // Advisory listing-completeness problems (missing assets + empty key
-          // fields). Empty when there's no backing listing yet (a pending first
-          // version) — nothing to flag until a listing row exists.
-          problems: listing
-            ? computeListingProblems({
-                iconId: listing.iconId,
-                coverId: listing.coverId,
-                screenshotCount: listing.screenshotCount,
-                description: listing.description,
-                tagline: listing.tagline,
-                category: listing.category,
-              }).problems
-            : [],
-          // Whether the manifest declares a launchable page (drives the Open-live →
-          // /apps/run/<slug> vs standalone-origin vs model-slot branching). PUBLIC
-          // subset only.
-          hasPage: !!toPublicBlockManifest(manifest).hasPage,
-        };
-      });
-    }),
+    type RowWithCount = (typeof rows)[number];
+    return rows.map((r: RowWithCount) => {
+      const counts = r.appBlock?._count;
+      const appBlockId = r.appBlock?.id;
+      const manifest = r.appBlock?.manifest;
+      const { appBlock: _drop, ...rest } = r;
+      // userSubscriptionCount keeps the historical meaning ("blanket +
+      // pinned subscriptions for this app"); modelInstallCount is the
+      // pinned-subscription subset, mirroring what the pre-migration
+      // model_block_installs row count meant.
+      const totalSubs = counts?.userSubscriptions ?? null;
+      const pinnedCount = appBlockId ? pinnedCounts[appBlockId] ?? 0 : null;
+      const listing = appBlockId ? listingByBlockId.get(appBlockId) : undefined;
+      return {
+        ...rest,
+        modelInstallCount: pinnedCount,
+        userSubscriptionCount: totalSubs,
+        // The backing on-site listing id (owner unpublish/republish/history target)
+        // + its TRUE lifecycle status, and — for a removed listing — the last mod
+        // action (owner-hidden vs mod-removed). Null when no backing listing exists
+        // (e.g. a pending first-version request, or a pre-W13 backfill gap).
+        appListingId: listing?.id ?? null,
+        listingStatus: listing?.status ?? null,
+        lastModerationAction: listing ? lastActionByListingId.get(listing.id) ?? null : null,
+        // Advisory listing-completeness problems (missing assets + empty key
+        // fields). Empty when there's no backing listing yet (a pending first
+        // version) — nothing to flag until a listing row exists.
+        problems: listing
+          ? computeListingProblems({
+              iconId: listing.iconId,
+              coverId: listing.coverId,
+              screenshotCount: listing.screenshotCount,
+              description: listing.description,
+              tagline: listing.tagline,
+              category: listing.category,
+            }).problems
+          : [],
+        // Whether the manifest declares a launchable page (drives the Open-live →
+        // /apps/run/<slug> vs standalone-origin vs model-slot branching). PUBLIC
+        // subset only.
+        hasPage: !!toPublicBlockManifest(manifest).hasPage,
+      };
+    });
+  }),
 
   /**
    * W5 v0 — reflection surface for /apps/installed. One row per app the
@@ -2281,16 +2253,12 @@ export const blocksRouter = router({
   // to ctx.user.id. moderator→protected + the appBlocks flag below. The
   // /apps/installed page already gates per-user on features.appBlocks, so the
   // old moderator gate just broke this tab for non-mods on flag-public surfaces.
-  listMyScopeGrants: protectedProcedure
-    .use(enforceAppBlocksFlag)
-    .query(async ({ ctx }) => {
-      if ((ctx as { _appBlocksDisabled?: boolean })._appBlocksDisabled) return [];
-      if (!ctx.user) return [];
-      const { listMyScopeGrants } = await import(
-        '~/server/services/blocks/user-app-surface.service'
-      );
-      return listMyScopeGrants(ctx.user.id);
-    }),
+  listMyScopeGrants: protectedProcedure.use(enforceAppBlocksFlag).query(async ({ ctx }) => {
+    if ((ctx as { _appBlocksDisabled?: boolean })._appBlocksDisabled) return [];
+    if (!ctx.user) return [];
+    const { listMyScopeGrants } = await import('~/server/services/blocks/user-app-surface.service');
+    return listMyScopeGrants(ctx.user.id);
+  }),
 
   /**
    * W5 v0 — chronological feed of `block_buzz_attribution` rows where the
@@ -2409,9 +2377,9 @@ export const blocksRouter = router({
       // Ceiling = manifest.scopes ∩ approvedScopes. The user may only consent
       // to scopes inside that ceiling; anything else is dropped.
       const manifestScopes = Array.isArray((block.manifest as { scopes?: unknown }).scopes)
-        ? ((block.manifest as { scopes: unknown[] }).scopes.filter(
+        ? (block.manifest as { scopes: unknown[] }).scopes.filter(
             (s): s is string => typeof s === 'string'
-          ))
+          )
         : [];
       const approved = new Set(block.approvedScopes ?? []);
       const ceiling = new Set(manifestScopes.filter((s) => approved.has(s)));
@@ -2472,12 +2440,10 @@ export const blocksRouter = router({
    */
   // GA-relax (gotcha #66): returns only the caller's own subscriptions
   // (listUserSubscriptions(ctx.user.id)). moderator→protected + flag below.
-  listMySubscriptions: protectedProcedure
-    .use(enforceAppBlocksFlag)
-    .query(async ({ ctx }) => {
-      if ((ctx as { _appBlocksDisabled?: boolean })._appBlocksDisabled) return [];
-      return BlockRegistry.listUserSubscriptions(ctx.user!.id);
-    }),
+  listMySubscriptions: protectedProcedure.use(enforceAppBlocksFlag).query(async ({ ctx }) => {
+    if ((ctx as { _appBlocksDisabled?: boolean })._appBlocksDisabled) return [];
+    return BlockRegistry.listUserSubscriptions(ctx.user!.id);
+  }),
 
   /**
    * Lightweight booleans that drive the conditional links in the apps
@@ -2495,41 +2461,39 @@ export const blocksRouter = router({
    * `ctx.user.id`; returns the all-false shape when the flag is dark so
    * the sub-nav degrades to just the always-on tabs.
    */
-  getNavSummary: protectedProcedure
-    .use(enforceAppBlocksFlag)
-    .query(async ({ ctx }) => {
-      const allFalse = {
-        hasInstalls: false,
-        hasSubmissions: false,
-        hasApprovedApps: false,
-        isReviewer: false,
-      };
-      if ((ctx as { _appBlocksDisabled?: boolean })._appBlocksDisabled) return allFalse;
-      const user = ctx.user;
-      if (!user) return allFalse;
+  getNavSummary: protectedProcedure.use(enforceAppBlocksFlag).query(async ({ ctx }) => {
+    const allFalse = {
+      hasInstalls: false,
+      hasSubmissions: false,
+      hasApprovedApps: false,
+      isReviewer: false,
+    };
+    if ((ctx as { _appBlocksDisabled?: boolean })._appBlocksDisabled) return allFalse;
+    const user = ctx.user;
+    if (!user) return allFalse;
 
-      const [install, submission, approvedApp] = await Promise.all([
-        dbRead.blockUserSubscription.findFirst({
-          where: { userId: user.id },
-          select: { id: true },
-        }),
-        dbRead.appBlockPublishRequest.findFirst({
-          where: { submittedByUserId: user.id },
-          select: { id: true },
-        }),
-        dbRead.appBlock.findFirst({
-          where: { app: { userId: user.id }, status: 'approved' },
-          select: { id: true },
-        }),
-      ]);
+    const [install, submission, approvedApp] = await Promise.all([
+      dbRead.blockUserSubscription.findFirst({
+        where: { userId: user.id },
+        select: { id: true },
+      }),
+      dbRead.appBlockPublishRequest.findFirst({
+        where: { submittedByUserId: user.id },
+        select: { id: true },
+      }),
+      dbRead.appBlock.findFirst({
+        where: { app: { userId: user.id }, status: 'approved' },
+        select: { id: true },
+      }),
+    ]);
 
-      return {
-        hasInstalls: install !== null,
-        hasSubmissions: submission !== null,
-        hasApprovedApps: approvedApp !== null,
-        isReviewer: isAppReviewer(user),
-      };
-    }),
+    return {
+      hasInstalls: install !== null,
+      hasSubmissions: submission !== null,
+      hasApprovedApps: approvedApp !== null,
+      isReviewer: isAppReviewer(user),
+    };
+  }),
 
   /**
    * Marketplace listing — approved app blocks, optionally filtered by slot
@@ -4214,13 +4178,14 @@ export const blocksRouter = router({
             workflowId: 'failed',
             status: 'failed' as const,
             cost: { total: cost },
-            error: claims.reviewRunForReal === true
-              ? `review run-for-real Buzz cap reached: ${total - Math.ceil(cost)} already ` +
-                `spent this review session, this generation costs ${cost}, ` +
-                `session cap is ${buzzCap}`
-              : `daily Buzz cap reached: ${total - Math.ceil(cost)} already spent today ` +
-                `across your installed apps, this generation costs ${cost}, ` +
-                `daily cap is ${buzzCap}`,
+            error:
+              claims.reviewRunForReal === true
+                ? `review run-for-real Buzz cap reached: ${total - Math.ceil(cost)} already ` +
+                  `spent this review session, this generation costs ${cost}, ` +
+                  `session cap is ${buzzCap}`
+                : `daily Buzz cap reached: ${total - Math.ceil(cost)} already spent today ` +
+                  `across your installed apps, this generation costs ${cost}, ` +
+                  `daily cap is ${buzzCap}`,
             // #3520 exit 2 — quotes `cost` with no workflow. Additive + omitted
             // when empty, so this reply is byte-identical whenever nothing was
             // substituted.
@@ -4277,7 +4242,7 @@ export const blocksRouter = router({
                   ? 'app generation rate limit reached: this app has run too many generations in a short window — please retry shortly'
                   : appSpend.reason === 'unavailable'
                   ? 'generation temporarily unavailable — please retry shortly'
-                  : "app daily spend cap reached: this app has hit its aggregate daily generation-spend ceiling — please try again later",
+                  : 'app daily spend cap reached: this app has hit its aggregate daily generation-spend ceiling — please try again later',
               // #3520 exit 3 — quotes `cost` with no workflow. Carries only the
               // caller's own requested/applied version ids, so it does NOT
               // weaken the deliberately number-free message above.
@@ -4432,9 +4397,7 @@ export const blocksRouter = router({
         // failed submit doesn't permanently burn the app's daily ceiling.
         // Best-effort; present only for non-dev tokens.
         if (appSpendReserve) {
-          const { refundAppSpend } = await import(
-            '~/server/services/blocks/app-spend-cap.service'
-          );
+          const { refundAppSpend } = await import('~/server/services/blocks/app-spend-cap.service');
           await refundAppSpend(appSpendReserve.key, appSpendReserve.cost);
         }
         // F4 — mirror the daily refund for the dev-session reservation so a failed
@@ -4640,9 +4603,7 @@ export const blocksRouter = router({
           const hasPaidDebit = distinctPaidTypes.size === 1 && netPaidAmount > 0;
           // `isPayoutEligibleBuzz` already narrowed accountType to green|yellow,
           // both valid `BuzzSpendType`s; size===1 ⇒ every paid entry shares it.
-          const paidType = hasPaidDebit
-            ? (paidEntries[0].accountType as BuzzSpendType)
-            : undefined;
+          const paidType = hasPaidDebit ? (paidEntries[0].accountType as BuzzSpendType) : undefined;
 
           // paidType is set iff hasPaidDebit; otherwise fall to the conservative
           // free floor (getBlockAllowedAccountTypes[0] === 'blue' in both branches).
@@ -4773,16 +4734,14 @@ export const blocksRouter = router({
    * spendable types PLUS the creator payout pools the spendable-only
    * getMyBuzzBalance omits). MUTATION + `buzz:read:self` consent, self-bound.
    */
-  getMyBuzzAccounts: publicProcedure
-    .input(getMyBuzzAccountsInput)
-    .mutation(async ({ input }) => {
-      const { userId } = await authorizeBlockBuzzRead(input.blockToken);
-      const accounts = await getUserBuzzAccount({
-        accountId: userId, // SELF-BOUND — never client input.
-        accountTypes: [...blockBuzzAccountTypes],
-      });
-      return { accounts: accounts.map(({ accountType, balance }) => ({ accountType, balance })) };
-    }),
+  getMyBuzzAccounts: publicProcedure.input(getMyBuzzAccountsInput).mutation(async ({ input }) => {
+    const { userId } = await authorizeBlockBuzzRead(input.blockToken);
+    const accounts = await getUserBuzzAccount({
+      accountId: userId, // SELF-BOUND — never client input.
+      accountTypes: [...blockBuzzAccountTypes],
+    });
+    return { accounts: accounts.map(({ accountType, balance }) => ({ accountType, balance })) };
+  }),
 
   /**
    * HOST-MEDIATED per-modelVersion generation-compensation read for the
@@ -5208,68 +5167,66 @@ export const blocksRouter = router({
    * the per-app dropdown on /apps/revenue. OauthClient.userId is the
    * single source of truth for app ownership in v1.
    */
-  getMyApps: appDeveloperProcedure
-    .use(enforceAppBlocksFlag)
-    .query(async ({ ctx }) => {
-      const user = ctx.user as SessionUser;
-      const apps = await dbRead.appBlock.findMany({
-        where: { app: { userId: user.id } },
-        select: {
-          id: true,
-          blockId: true,
-          appId: true,
-          status: true,
-          manifest: true,
-          app: { select: { name: true } },
-        },
-        orderBy: { createdAt: 'desc' },
-      });
+  getMyApps: appDeveloperProcedure.use(enforceAppBlocksFlag).query(async ({ ctx }) => {
+    const user = ctx.user as SessionUser;
+    const apps = await dbRead.appBlock.findMany({
+      where: { app: { userId: user.id } },
+      select: {
+        id: true,
+        blockId: true,
+        appId: true,
+        status: true,
+        manifest: true,
+        app: { select: { name: true } },
+      },
+      orderBy: { createdAt: 'desc' },
+    });
 
-      // One groupBy across all of the user's apps so the request
-      // doesn't N+1 against the attribution table. Skip when there
-      // are no apps — pointless query.
-      const lifetimeByApp = apps.length
-        ? await dbRead.blockBuzzAttribution.groupBy({
-            by: ['appBlockId'],
-            where: {
-              appOwnerUserId: user.id,
-              status: { in: ['confirmed', 'paid_out'] },
-            },
-            _sum: { appOwnerShareCents: true },
-            _count: true,
-          })
-        : [];
-      type LifetimeRow = {
-        appBlockId: string;
-        _sum: { appOwnerShareCents: number | null };
-        _count: number;
-      };
-      const lifetimeMap = new Map<string, { shareCents: number; count: number }>(
-        (lifetimeByApp as LifetimeRow[]).map((r) => [
-          r.appBlockId,
-          { shareCents: r._sum.appOwnerShareCents ?? 0, count: r._count },
-        ])
-      );
+    // One groupBy across all of the user's apps so the request
+    // doesn't N+1 against the attribution table. Skip when there
+    // are no apps — pointless query.
+    const lifetimeByApp = apps.length
+      ? await dbRead.blockBuzzAttribution.groupBy({
+          by: ['appBlockId'],
+          where: {
+            appOwnerUserId: user.id,
+            status: { in: ['confirmed', 'paid_out'] },
+          },
+          _sum: { appOwnerShareCents: true },
+          _count: true,
+        })
+      : [];
+    type LifetimeRow = {
+      appBlockId: string;
+      _sum: { appOwnerShareCents: number | null };
+      _count: number;
+    };
+    const lifetimeMap = new Map<string, { shareCents: number; count: number }>(
+      (lifetimeByApp as LifetimeRow[]).map((r) => [
+        r.appBlockId,
+        { shareCents: r._sum.appOwnerShareCents ?? 0, count: r._count },
+      ])
+    );
 
-      type AppRow = {
-        id: string;
-        blockId: string;
-        appId: string;
-        status: string;
-        manifest: unknown;
-        app: { name: string } | null;
-      };
-      return (apps as AppRow[]).map((a) => ({
-        id: a.id,
-        blockId: a.blockId,
-        appId: a.appId,
-        status: a.status,
-        appName: a.app?.name ?? null,
-        manifest: a.manifest as Record<string, unknown>,
-        lifetimeShareCents: lifetimeMap.get(a.id)?.shareCents ?? 0,
-        lifetimeCount: lifetimeMap.get(a.id)?.count ?? 0,
-      }));
-    }),
+    type AppRow = {
+      id: string;
+      blockId: string;
+      appId: string;
+      status: string;
+      manifest: unknown;
+      app: { name: string } | null;
+    };
+    return (apps as AppRow[]).map((a) => ({
+      id: a.id,
+      blockId: a.blockId,
+      appId: a.appId,
+      status: a.status,
+      appName: a.app?.name ?? null,
+      manifest: a.manifest as Record<string, unknown>,
+      lifetimeShareCents: lifetimeMap.get(a.id)?.shareCents ?? 0,
+      lifetimeCount: lifetimeMap.get(a.id)?.count ?? 0,
+    }));
+  }),
 
   /**
    * Phase 3 (git-push self-service) — return the developer's clone URL +
@@ -5356,7 +5313,9 @@ export const blocksRouter = router({
       // the embedded basic-auth credential, which Forgejo accepts for git).
       const publicHost = env.FORGEJO_PUBLIC_URL.replace(/^https?:\/\//, '').replace(/\/$/, '');
       const httpUrl = `https://${publicHost}/${FORGEJO_ORG}/${slug}.git`;
-      const cloneUrl = `https://${encodeURIComponent(forgejoUsername)}:${token}@${publicHost}/${FORGEJO_ORG}/${slug}.git`;
+      const cloneUrl = `https://${encodeURIComponent(
+        forgejoUsername
+      )}:${token}@${publicHost}/${FORGEJO_ORG}/${slug}.git`;
 
       const instructions = [
         `# Clone your app repo (credential is embedded in the URL):`,
@@ -5494,7 +5453,9 @@ export const blocksRouter = router({
             // BlockManifestValidator re-checks it below (keys must be declared
             // scopes, values non-empty ≤500 chars) — this bound is just a coarse
             // request-size guard.
-            scopeJustifications: z.record(z.string().min(1).max(128), z.string().max(500)).optional(),
+            scopeJustifications: z
+              .record(z.string().min(1).max(128), z.string().max(500))
+              .optional(),
             publicSettingsKeys: z.array(z.string().min(1).max(64)).max(32).optional(),
             targets: z
               .array(z.object({ slotId: z.string().min(1).max(64) }).passthrough())
@@ -5771,7 +5732,9 @@ export const blocksRouter = router({
 
       const publicHost = env.FORGEJO_PUBLIC_URL.replace(/^https?:\/\//, '').replace(/\/$/, '');
       const httpUrl = `https://${publicHost}/${FORGEJO_ORG}/${slug}.git`;
-      const cloneUrl = `https://${encodeURIComponent(forgejoUsername)}:${token}@${publicHost}/${FORGEJO_ORG}/${slug}.git`;
+      const cloneUrl = `https://${encodeURIComponent(
+        forgejoUsername
+      )}:${token}@${publicHost}/${FORGEJO_ORG}/${slug}.git`;
 
       return {
         notYetAvailable: false as const,
@@ -5930,7 +5893,10 @@ async function estimateCustomComfyWorkflow(opts: { claims: BlockClaims; body: Cu
   }
   const userId = parseSubjectUserId(claims.sub);
   if (userId == null) {
-    throw new TRPCError({ code: 'UNAUTHORIZED', message: 'estimate requires authenticated viewer' });
+    throw new TRPCError({
+      code: 'UNAUTHORIZED',
+      message: 'estimate requires authenticated viewer',
+    });
   }
   await assertAppBlocksEnabledForTokenUser(userId);
   await assertViewerIsAppDeveloper(userId);
@@ -6133,13 +6099,14 @@ async function submitCustomComfyWorkflow(opts: {
         workflowId: 'failed',
         status: 'failed' as const,
         cost: { total: ceiling },
-        error: claims.reviewRunForReal === true
-          ? `review run-for-real Buzz cap reached: ${total - Math.ceil(ceiling)} already ` +
-            `spent this review session, this generation may cost up to ${ceiling}, ` +
-            `session cap is ${buzzCap}`
-          : `daily Buzz cap reached: ${total - Math.ceil(ceiling)} already spent today ` +
-            `across your installed apps, this generation may cost up to ${ceiling}, ` +
-            `daily cap is ${buzzCap}`,
+        error:
+          claims.reviewRunForReal === true
+            ? `review run-for-real Buzz cap reached: ${total - Math.ceil(ceiling)} already ` +
+              `spent this review session, this generation may cost up to ${ceiling}, ` +
+              `session cap is ${buzzCap}`
+            : `daily Buzz cap reached: ${total - Math.ceil(ceiling)} already spent today ` +
+              `across your installed apps, this generation may cost up to ${ceiling}, ` +
+              `daily cap is ${buzzCap}`,
       },
     };
   }
@@ -6207,9 +6174,7 @@ async function submitCustomComfyWorkflow(opts: {
         // `dev !== true` can still have an active dev tunnel). Then fail-snapshot.
         await refundBlockBuzzSpend(buzzCapKey, ceiling);
         if (appSpendReserve) {
-          const { refundAppSpend } = await import(
-            '~/server/services/blocks/app-spend-cap.service'
-          );
+          const { refundAppSpend } = await import('~/server/services/blocks/app-spend-cap.service');
           await refundAppSpend(appSpendReserve.key, appSpendReserve.cost);
         }
         // No money moved → release the idempotency claim so a genuine retry runs.
@@ -6278,9 +6243,7 @@ async function submitCustomComfyWorkflow(opts: {
     // submit doesn't permanently burn the session ceiling. Best-effort; present
     // only when an active dev tunnel was reserved above.
     if (devSessionReserve) {
-      const { refundDevSessionBuzz } = await import(
-        '~/server/services/blocks/dev-tunnel.service'
-      );
+      const { refundDevSessionBuzz } = await import('~/server/services/blocks/dev-tunnel.service');
       await refundDevSessionBuzz(devSessionReserve.sessionId, devSessionReserve.cost);
     }
     // No resolved submit → no money moved; release the idempotency claim so a
@@ -6302,11 +6265,7 @@ async function submitCustomComfyWorkflow(opts: {
   // orchestrator id (never the failed/whatif sentinels). The dev-session id is
   // included ONLY when a dev tunnel was reserved above (spread) — so a non-dev
   // submit persists the SAME record shape it did before (settle no-ops that leg).
-  if (
-    snapshot.workflowId &&
-    snapshot.workflowId !== 'failed' &&
-    snapshot.workflowId !== 'whatif'
-  ) {
+  if (snapshot.workflowId && snapshot.workflowId !== 'failed' && snapshot.workflowId !== 'whatif') {
     await persistCustomComfySettle({
       workflowId: snapshot.workflowId,
       buzzCapKey,
@@ -6370,8 +6329,7 @@ async function submitCustomComfyWorkflow(opts: {
         statusCode: snapshot.status === 'failed' ? 500 : 200,
         detail: {
           action: 'workflow.submit',
-          amount:
-            typeof invocationCost === 'number' ? -Math.abs(invocationCost) : undefined,
+          amount: typeof invocationCost === 'number' ? -Math.abs(invocationCost) : undefined,
           outcome: snapshot.status === 'failed' ? 'failed' : 'ok',
         },
         // Dev token → route a synthetic non-FK appBlockId to the nullable-appBlockId
@@ -6667,6 +6625,37 @@ async function submitStepWorkflow(opts: {
   // a timeout on a fixed-price step would be a liveness knob and stamping one
   // here would imply a Buzz-cap relationship that does not exist.
   const built = step.buildStep(params);
+
+  // ── STEP IDENTITY, re-asserted at REQUEST time on the value actually
+  // submitted. Same shape and same reason as the entitlement re-assert below,
+  // on the axis every `$type`-keyed guard depends on.
+  //
+  // 🔴 WHY IT IS NEEDED DESPITE CLAUSE 7a. The registry's load-time check
+  // asserts `buildStep(canonicalParamsFor(v)).$type === orchestratorType` for
+  // each variant — the CANONICAL params. A `buildStep` that switches its
+  // `$type` ON PARAMS therefore registers cleanly and diverges only at request
+  // time, when the untrusted iframe supplies the params that flip it. That is
+  // not hypothetical: it was demonstrated by execution in review against the
+  // load-time check alone.
+  //
+  // What that buys an attacker without this clause is the whole point:
+  // `runStepModeration` (above) dispatches on the DECLARED posture, so a step
+  // declaring `'none'` that builds a text-producing `$type` reaches the
+  // orchestrator with no audit — the exact shape the registry's posture gate
+  // exists to prevent. Load time proved a property of one fixed input; this
+  // proves it of THIS input.
+  //
+  // Placed before the quote and before every reservation, so a rejection costs
+  // no orchestrator call and has nothing to refund.
+  if (built.$type !== step.orchestratorType) {
+    throw new TRPCError({
+      code: 'FORBIDDEN',
+      message:
+        `step '${step.id}' declares orchestratorType '${step.orchestratorType}' but the ` +
+        `submitted step is '${built.$type}' — every $type-keyed guard, including the ` +
+        'moderation-posture constraint, was evaluated against a type this step does not submit',
+    });
+  }
 
   // ── ENTITLEMENT posture, re-asserted at REQUEST time on the value actually
   // submitted. Mirrors the `moderationPosture` re-assertion above, on the axis

--- a/src/server/services/blocks/steps/__tests__/step-registry.test.ts
+++ b/src/server/services/blocks/steps/__tests__/step-registry.test.ts
@@ -1053,6 +1053,19 @@ describe('block step registry — declared $type vs built $type (clause 7a)', ()
     ).toThrow(/but buildStep\(\) emits 'textToImage'/);
   });
 
+  it('rejects a buildStep that returns a non-object — a NAMED error, not a TypeError', () => {
+    // 🔴 `buildStep` now runs for EVERY entry (7a needs it), so a bad return
+    // crashes module load for any entry. Both shapes fail closed; this pins the
+    // guard so the failure carries a clause name instead of a bare
+    // `TypeError: Cannot read properties of undefined`.
+    expect(() =>
+      assertStepInvariants(
+        'fixture-step',
+        makeFixtureStep({ buildStep: (() => undefined) as never })
+      )
+    ).toThrow(/buildStep\(\) must return an orchestrator step template/);
+  });
+
   it('NEGATIVE CONTROL: an agreeing entry passes', () => {
     expect(() => assertStepInvariants('fixture-step', makeFixtureStep())).not.toThrow();
   });

--- a/src/server/services/blocks/steps/__tests__/step-registry.test.ts
+++ b/src/server/services/blocks/steps/__tests__/step-registry.test.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from 'fs';
 import { describe, expect, it } from 'vitest';
 import * as z from 'zod';
 import {
@@ -24,6 +25,7 @@ import {
   type AnyBlockStep,
   type BlockStep,
   type StepBillingMode,
+  type StepModerationPosture,
 } from '~/server/services/blocks/steps';
 import type { OrchestratorBlobLike } from '~/server/services/blocks/steps/output';
 
@@ -79,7 +81,21 @@ function makeFixtureStep(overrides: Partial<AnyBlockStep> = {}): AnyBlockStep {
       ),
     canonicalOutputFor: (): unknown => FIXTURE_OUTPUT_STEP,
   } satisfies BlockStep<FixtureParams>;
-  return { ...base, ...overrides } as AnyBlockStep;
+  const merged = { ...base, ...overrides } as AnyBlockStep;
+  // 🔴 THE FIXTURE MUST BE INTERNALLY CONSISTENT. Clause 7a requires
+  // `buildStep().$type === orchestratorType`, and most tests below vary
+  // `orchestratorType` alone to exercise the $type-keyed clauses (1b, 9). With
+  // a hardcoded built `$type` those fixtures would all die to 7a instead —
+  // testing nothing they claim to test. So the built type FOLLOWS the declared
+  // one unless a test overrides `buildStep` explicitly, which is precisely what
+  // the clause-7a tests do.
+  if (!('buildStep' in overrides)) {
+    merged.buildStep = (p: unknown) => ({
+      $type: merged.orchestratorType,
+      input: { value: (p as FixtureParams).value },
+    });
+  }
+  return merged;
 }
 
 /**
@@ -886,18 +902,58 @@ describe('block step registry — posture ↔ orchestratorType agreement (clause
     ).toThrow(/has no implemented handler/);
   });
 
-  it('accepts EITHER acceptable posture for a multi-valued type, and rejects the others', () => {
-    // textToSpeech takes free text IN and emits audio, so promptAudit is the
-    // floor rather than the only answer.
+  it('rejects a text-producing $type declaring promptAudit — the input-only answer', () => {
+    // The whole shape this clause exists for: auditing the input while the
+    // output ships unscanned.
     expect(() =>
       assertStepInvariants(
         'fixture-step',
-        makeAuditedFixtureStep({ orchestratorType: 'textToSpeech' })
+        makeAuditedFixtureStep({ orchestratorType: 'promptEnhancement' })
       )
-    ).not.toThrow();
-    expect(() =>
-      assertStepInvariants('fixture-step', makeFixtureStep({ orchestratorType: 'textToSpeech' }))
-    ).toThrow(/requires moderationPosture 'promptAudit' or 'textOutput'/);
+    ).toThrow(/requires moderationPosture 'textOutput'/);
+  });
+
+  it('EVERY entry is single-valued — the map must encode no posture subsumption', () => {
+    // 🔴 Pins the inclusion criterion (free-text OUTPUT only). A multi-valued
+    // entry would mean some type accepts two postures, which is the ladder
+    // claim the map's own doc-comment disclaims — and it is exactly what a
+    // `textToSpeech: ['promptAudit','textOutput']` entry did before review
+    // caught it. If a future type genuinely needs two, that is a design
+    // decision that must change the doc-comment, not slip in under this test.
+    for (const [type, postures] of Object.entries(STEP_TYPE_ACCEPTABLE_POSTURES)) {
+      expect(postures, `${type} is multi-valued`).toEqual(['textOutput']);
+    }
+  });
+
+  it('the posture ARRAYS are frozen, not just the map — freeze is shallow', () => {
+    // 🔴 Without freezing the values, `readonly` is compile-time-only and
+    // `arr.push('none')` at runtime makes a chatCompletion entry declaring
+    // 'none' register cleanly. Demonstrated by execution in review.
+    for (const [type, postures] of Object.entries(STEP_TYPE_ACCEPTABLE_POSTURES)) {
+      expect(Object.isFrozen(postures), `${type} postures not frozen`).toBe(true);
+      expect(() => (postures as StepModerationPosture[]).push('none')).toThrow();
+    }
+    expect(Object.isFrozen(STEP_TYPE_ACCEPTABLE_POSTURES)).toBe(true);
+  });
+
+  it('every map KEY is a real orchestrator $type in the generated client', () => {
+    // 🔴 `satisfies Record<string, …>` constrains the VALUES, not the keys — a
+    // typo'd key (`chatCompletions`) compiles clean and constrains nothing,
+    // silently covering no type at all. The generated client is the
+    // authoritative enumeration; this is the only thing that can catch it.
+    const generated = readFileSync(
+      require.resolve('@civitai/client/dist/generated/types.gen.d.ts'),
+      'utf8'
+    );
+    const declared = new Set(
+      [...generated.matchAll(/\$type\??: '([A-Za-z0-9_]+)'/g)].map((m) => m[1])
+    );
+    expect(declared.size, 'parsed no $type literals — the regex or the file moved').toBeGreaterThan(
+      10
+    );
+    for (const key of Object.keys(STEP_TYPE_ACCEPTABLE_POSTURES)) {
+      expect(declared, `'${key}' is not a $type in the generated client`).toContain(key);
+    }
   });
 
   it('a non-own key reads as UNCONSTRAINED, not as data (prototype seam)', () => {
@@ -931,13 +987,79 @@ describe('block step registry — posture ↔ orchestratorType agreement (clause
     }
   });
 
-  it('every SHIPPED entry satisfies the constraint for its own $type', () => {
+  // 🔴 AN INVARIANT GUARD, NOT REGRESSION COVERAGE — labelled so nobody counts
+  // it as the latter. Today the sole entry (`convertImage`) carries an
+  // unconstrained `$type`, so the loop body `continue`s and this test survives
+  // deleting clause 1b entirely. It earns its place only for the day a
+  // constrained entry is registered.
+  it('every SHIPPED entry satisfies the constraint for its own $type (vacuous today)', () => {
     for (const [id, step] of listRegisteredSteps()) {
       const acceptable = acceptablePosturesFor(step.orchestratorType);
       if (acceptable === undefined) continue;
       expect(acceptable, `${id} declares ${step.moderationPosture}`).toContain(
         step.moderationPosture
       );
+    }
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Clause 7a — the declared `$type` must be the one `buildStep()` actually emits.
+//
+// 🔴 THIS IS WHAT MAKES CLAUSE 1b A CONTROL. `orchestratorType` is author-
+// declared and the router submits `buildStep(...).$type`, so without 7a an
+// entry declares a benign type, builds `chatCompletion`, and the posture
+// constraint reads the wrong axis. Review demonstrated that bypass by
+// execution before this clause existed.
+// ─────────────────────────────────────────────────────────────────────────────
+describe('block step registry — declared $type vs built $type (clause 7a)', () => {
+  it('REACHABILITY: rejects an entry whose buildStep emits a DIFFERENT $type', () => {
+    expect(() =>
+      assertStepInvariants(
+        'fixture-step',
+        makeFixtureStep({
+          buildStep: () => ({ $type: 'somethingElse', input: {} }),
+        })
+      )
+    ).toThrow(/declares orchestratorType 'fixtureType' but buildStep\(\) emits 'somethingElse'/);
+  });
+
+  it('THE BYPASS IT CLOSES: benign declared type + chatCompletion built type', () => {
+    // Before 7a this registered cleanly with moderationPosture 'none' and the
+    // router submitted a chatCompletion step.
+    expect(() =>
+      assertStepInvariants(
+        'fixture-step',
+        makeFixtureStep({
+          orchestratorType: 'fixtureType',
+          moderationPosture: 'none',
+          buildStep: () => ({ $type: 'chatCompletion', input: {} }),
+        })
+      )
+    ).toThrow(/but buildStep\(\) emits 'chatCompletion'/);
+  });
+
+  it('also closes the clause-9 variant — declaring benign while building a native $type', () => {
+    expect(() =>
+      assertStepInvariants(
+        'fixture-step',
+        makeFixtureStep({ buildStep: () => ({ $type: 'textToImage', input: {} }) })
+      )
+    ).toThrow(/but buildStep\(\) emits 'textToImage'/);
+  });
+
+  it('NEGATIVE CONTROL: an agreeing entry passes', () => {
+    expect(() => assertStepInvariants('fixture-step', makeFixtureStep())).not.toThrow();
+  });
+
+  it('every SHIPPED entry agrees, on every variant', () => {
+    for (const [id, step] of listRegisteredSteps()) {
+      for (const variant of step.variants) {
+        const params = step.paramSchema.parse(step.canonicalParamsFor(variant));
+        expect(step.buildStep(params).$type, `${id} variant '${variant}'`).toBe(
+          step.orchestratorType
+        );
+      }
     }
   });
 });

--- a/src/server/services/blocks/steps/__tests__/step-registry.test.ts
+++ b/src/server/services/blocks/steps/__tests__/step-registry.test.ts
@@ -89,7 +89,7 @@ function makeFixtureStep(overrides: Partial<AnyBlockStep> = {}): AnyBlockStep {
   // testing nothing they claim to test. So the built type FOLLOWS the declared
   // one unless a test overrides `buildStep` explicitly, which is precisely what
   // the clause-7a tests do.
-  if (!('buildStep' in overrides)) {
+  if (overrides.buildStep === undefined) {
     merged.buildStep = (p: unknown) => ({
       $type: merged.orchestratorType,
       input: { value: (p as FixtureParams).value },
@@ -948,9 +948,14 @@ describe('block step registry — posture ↔ orchestratorType agreement (clause
     const declared = new Set(
       [...generated.matchAll(/\$type\??: '([A-Za-z0-9_]+)'/g)].map((m) => m[1])
     );
-    expect(declared.size, 'parsed no $type literals — the regex or the file moved').toBeGreaterThan(
-      10
-    );
+    // 🔴 A LOOSE FLOOR HERE IS THE WHOLE RISK: a regex that half-matches would
+    // still clear a small threshold, and every key would still be found, so the
+    // test would pass while observing a fraction of the enumeration. The real
+    // count is ~43; 30 is tight enough that a half-broken regex fails loudly.
+    expect(
+      declared.size,
+      'parsed too few $type literals — the regex or the generated file moved'
+    ).toBeGreaterThan(30);
     for (const key of Object.keys(STEP_TYPE_ACCEPTABLE_POSTURES)) {
       expect(declared, `'${key}' is not a $type in the generated client`).toContain(key);
     }
@@ -1052,7 +1057,11 @@ describe('block step registry — declared $type vs built $type (clause 7a)', ()
     expect(() => assertStepInvariants('fixture-step', makeFixtureStep())).not.toThrow();
   });
 
-  it('every SHIPPED entry agrees, on every variant', () => {
+  // 🔴 REDUNDANT WITH THE LOAD-TIME GATE, labelled rather than left to look
+  // like independent coverage: `assertStepInvariants` runs at module import, so
+  // an entry violating 7a crashes the import before this test can collect. It
+  // documents the invariant; it cannot independently fail.
+  it('every SHIPPED entry agrees, on every variant (redundant with load-time gate)', () => {
     for (const [id, step] of listRegisteredSteps()) {
       for (const variant of step.variants) {
         const params = step.paramSchema.parse(step.canonicalParamsFor(variant));

--- a/src/server/services/blocks/steps/__tests__/step-registry.test.ts
+++ b/src/server/services/blocks/steps/__tests__/step-registry.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import * as z from 'zod';
 import {
+  acceptablePosturesFor,
   assertOrchestratorTypesUnique,
   assertStepInvariants,
   containsAirReference,
@@ -18,6 +19,7 @@ import {
   REGISTERED_STEP_IDS,
   STEP_BILLING_MODES,
   STEP_MODERATION_POSTURES,
+  STEP_TYPE_ACCEPTABLE_POSTURES,
   STRICTNESS_PROBE_KEY,
   type AnyBlockStep,
   type BlockStep,
@@ -829,5 +831,113 @@ describe('containsAirReference — the entitlement probe', () => {
     ).toBe(false);
     expect(containsAirReference(null)).toBe(false);
     expect(containsAirReference(42)).toBe(false);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Clause 1b — posture ↔ orchestrator `$type` agreement.
+//
+// 🔴 WHY THIS BLOCK EXISTS AT ALL. Every other moderation clause checks the
+// declared posture against ITSELF. This one is the only check that reads it
+// against something the entry author did not also write, so it is the only one
+// that can catch a `chatCompletion` entry declaring `'promptAudit'` — a
+// declaration that audits the input and ships the output unscanned while
+// passing clauses 1, 1a and 5a.
+//
+// Every rejection below is paired with a NEGATIVE CONTROL asserting the SAME
+// fixture passes when only the `$type` changes, so each failure is provably the
+// `$type` constraint rather than the fixture being broken some other way.
+// ─────────────────────────────────────────────────────────────────────────────
+describe('block step registry — posture ↔ orchestratorType agreement (clause 1b)', () => {
+  it('REACHABILITY: a chatCompletion entry declaring promptAudit is rejected by THIS clause', () => {
+    // The fixture is otherwise fully valid — it passes clause 1 (promptAudit IS
+    // implemented) and clause 1a (auditableText is declared and non-empty), so
+    // reaching this rejection proves no earlier clause wins first.
+    expect(() =>
+      assertStepInvariants(
+        'fixture-step',
+        makeAuditedFixtureStep({ orchestratorType: 'chatCompletion' })
+      )
+    ).toThrow(/requires moderationPosture 'textOutput'.*declares 'promptAudit'/s);
+  });
+
+  it('NEGATIVE CONTROL: the identical fixture passes on an unconstrained $type', () => {
+    expect(() => assertStepInvariants('fixture-step', makeAuditedFixtureStep())).not.toThrow();
+  });
+
+  it('rejects a text-producing $type declaring the no-surface posture', () => {
+    for (const orchestratorType of ['chatCompletion', 'mediaCaptioning', 'transcription']) {
+      expect(() =>
+        assertStepInvariants('fixture-step', makeFixtureStep({ orchestratorType }))
+      ).toThrow(/does not cover the moderation surface this step actually produces/);
+    }
+  });
+
+  it('the HONEST declaration still reports clause 1, not clause 1b', () => {
+    // `chatCompletion` + `'textOutput'` is the correct declaration; it cannot
+    // register because the posture has no handler yet. The author must see THAT
+    // reason, not a type mismatch — which is the whole point of ordering 1b
+    // after 1. If this flips, the honest entry gets a misleading error.
+    expect(() =>
+      assertStepInvariants(
+        'fixture-step',
+        makeFixtureStep({ orchestratorType: 'chatCompletion', moderationPosture: 'textOutput' })
+      )
+    ).toThrow(/has no implemented handler/);
+  });
+
+  it('accepts EITHER acceptable posture for a multi-valued type, and rejects the others', () => {
+    // textToSpeech takes free text IN and emits audio, so promptAudit is the
+    // floor rather than the only answer.
+    expect(() =>
+      assertStepInvariants(
+        'fixture-step',
+        makeAuditedFixtureStep({ orchestratorType: 'textToSpeech' })
+      )
+    ).not.toThrow();
+    expect(() =>
+      assertStepInvariants('fixture-step', makeFixtureStep({ orchestratorType: 'textToSpeech' }))
+    ).toThrow(/requires moderationPosture 'promptAudit' or 'textOutput'/);
+  });
+
+  it('a non-own key reads as UNCONSTRAINED, not as data (prototype seam)', () => {
+    // A bare index would return `Object.prototype.toString` — truthy, and
+    // `.includes` on a function would throw rather than fail closed.
+    expect(acceptablePosturesFor('toString')).toBeUndefined();
+    expect(acceptablePosturesFor('constructor')).toBeUndefined();
+    expect(acceptablePosturesFor('__proto__')).toBeUndefined();
+    expect(() =>
+      assertStepInvariants('fixture-step', makeFixtureStep({ orchestratorType: 'toString' }))
+    ).not.toThrow();
+  });
+
+  it('the map is NON-EMPTY and covers chatCompletion — emptying it silently disables the gate', () => {
+    const keys = Object.keys(STEP_TYPE_ACCEPTABLE_POSTURES);
+    expect(keys.length).toBeGreaterThan(0);
+    expect(keys).toContain('chatCompletion');
+    // Every listed posture must be a DECLARED posture, or the constraint names
+    // a value no entry could ever satisfy.
+    for (const postures of Object.values(STEP_TYPE_ACCEPTABLE_POSTURES)) {
+      expect(postures.length).toBeGreaterThan(0);
+      for (const p of postures) expect(STEP_MODERATION_POSTURES).toContain(p);
+    }
+  });
+
+  it('no constrained $type is natively extracted — that would make the constraint unreachable', () => {
+    // Clause 9 rejects a natively-extracted `$type` outright, so listing one
+    // here would be a constraint no entry could ever reach.
+    for (const t of Object.keys(STEP_TYPE_ACCEPTABLE_POSTURES)) {
+      expect(NATIVELY_EXTRACTED_STEP_TYPES).not.toContain(t);
+    }
+  });
+
+  it('every SHIPPED entry satisfies the constraint for its own $type', () => {
+    for (const [id, step] of listRegisteredSteps()) {
+      const acceptable = acceptablePosturesFor(step.orchestratorType);
+      if (acceptable === undefined) continue;
+      expect(acceptable, `${id} declares ${step.moderationPosture}`).toContain(
+        step.moderationPosture
+      );
+    }
   });
 });

--- a/src/server/services/blocks/steps/index.ts
+++ b/src/server/services/blocks/steps/index.ts
@@ -267,6 +267,98 @@ export const NATIVELY_EXTRACTED_STEP_TYPES: readonly string[] = [
 ] as const;
 
 /**
+ * ORCHESTRATOR `$type` → the moderation postures ACCEPTABLE for that type.
+ *
+ * 🔴 WHY THIS EXISTS. `moderationPosture` is SELF-DECLARED by the entry, and
+ * every other clause only checks the declaration against ITSELF: clause 1 asks
+ * "does the declared posture have a handler", clauses 1a/5a ask "does the
+ * declared posture's own field exist and return something". Nothing asked
+ * whether the declaration MATCHES WHAT THE STEP ACTUALLY DOES. So a
+ * `chatCompletion` entry declaring `'promptAudit'` — auditing its input,
+ * emitting unscanned free text — registered cleanly and passed every check.
+ * The gate whose entire purpose is "a text-producing step cannot register until
+ * someone answers the policy question" was satisfiable by answering a DIFFERENT
+ * question.
+ *
+ * This is the same defect class as `auditableText` returning `''` (clause 5a)
+ * and `extractOutput` returning `[]` (clause 8), one level up: there the field
+ * was satisfiable by a no-op, here the FIELD ITSELF was satisfiable by naming
+ * the wrong axis. In each case the fix is to anchor the check to something the
+ * entry author did not also write — here, the orchestrator's own `$type`.
+ *
+ * 🔴 A SET, NOT A LADDER, AND DELIBERATELY SO. Modelling postures as a
+ * strength ordering (`none` < `promptAudit` < `textOutput`) would bake in a
+ * claim nobody has made — that `'textOutput'`, once implemented, also audits
+ * input. It might; that is a design decision for whoever implements it, and
+ * encoding it here as an ordering would hide it. Membership states only what is
+ * acceptable, per type, with no transitive claim.
+ *
+ * 🔴 RESIDUAL GAP, STATED RATHER THAN PAPERED OVER. This constrains the types
+ * LISTED. A text-producing `$type` nobody listed is unconstrained, exactly as
+ * before. The alternative — inferring text-production from the output shape —
+ * is the sniffing this file already rejects for `auditableText` ("sniffing for
+ * string-valued fields would audit a Civitai image URL"), and it would be
+ * *more* fragile here because it would run against a sample the entry author
+ * also wrote. The mitigation is that adding an entry is a reviewed PR and this
+ * map is the place review looks.
+ *
+ * Enumerated from the generated `@civitai/client` `$type` literals, not from
+ * `src/**` usage — the same correction the registry's Tranche 1 note records:
+ * grepping usage enumerates what is CALLED, not what EXISTS.
+ */
+/**
+ * 🔴 `satisfies`, NOT a cast, and that distinction is load-bearing. The literal
+ * has to be CONTEXTUALLY TYPED for a mistyped posture (`'textOputput'`) to be a
+ * compile error. Writing it as `Object.create(null) as Record<…>` — the obvious
+ * way to get the null prototype below — removes that context and a typo
+ * compiles clean, which was measured, not assumed. Declaring the literal here
+ * with `satisfies` keeps the check; `Object.assign` then carries it onto a
+ * null-prototype target without widening it back.
+ */
+const ACCEPTABLE_POSTURES_BY_TYPE = {
+  // Free-text OUT. The prompt audit does not cover generated text at all, so
+  // `'promptAudit'` is not an acceptable answer for these — declaring it would
+  // audit the input and ship the output unscanned.
+  chatCompletion: ['textOutput'],
+  mediaCaptioning: ['textOutput'],
+  audioCaptioning: ['textOutput'],
+  transcription: ['textOutput'],
+  // Free-text IN, audio out: the user's text is the moderation surface and the
+  // audio is a rendering of already-audited text. A stricter posture is also
+  // acceptable; `'none'` is not.
+  textToSpeech: ['promptAudit', 'textOutput'],
+} satisfies Record<string, readonly StepModerationPosture[]>;
+
+export const STEP_TYPE_ACCEPTABLE_POSTURES: Readonly<
+  Record<string, readonly StepModerationPosture[]>
+> = Object.freeze(
+  Object.assign(
+    Object.create(null) as Record<string, readonly StepModerationPosture[]>,
+    ACCEPTABLE_POSTURES_BY_TYPE
+  )
+);
+
+/**
+ * The postures acceptable for an orchestrator `$type`, or `undefined` when the
+ * type carries no declared constraint (every posture is acceptable, which is
+ * the pre-existing behaviour).
+ */
+export function acceptablePosturesFor(
+  orchestratorType: string
+): readonly StepModerationPosture[] | undefined {
+  // 🔴 THE NULL PROTOTYPE ON THE MAP IS WHAT MAKES THIS BARE INDEX SAFE, and it
+  // is a control rather than a style choice — the same one `./moderation`
+  // documents on its handler table. A plain object literal inherits from
+  // `Object.prototype`, so an entry declaring `orchestratorType: 'toString'`
+  // would index to `Object.prototype.toString` — TRUTHY — and the clause below
+  // would then call `.includes` on a FUNCTION and throw a raw TypeError out of
+  // registry load, or under any other comparison read as a satisfied
+  // constraint. With a null prototype every non-own key reads `undefined` and
+  // the type is treated as unconstrained, which is the pre-existing behaviour.
+  return STEP_TYPE_ACCEPTABLE_POSTURES[orchestratorType];
+}
+
+/**
  * Fields every registered step declares, regardless of billing mode.
  *
  * `P` is the step's bounded param type (inferred from `paramSchema`).
@@ -727,6 +819,28 @@ export function assertStepInvariants(id: string, step: AnyBlockStep): void {
     throw new Error(
       `${where}: declares auditableText() but moderationPosture '${step.moderationPosture}' ` +
         'never audits it — the text would reach the orchestrator unaudited'
+    );
+  }
+
+  // (1b) POSTURE ↔ ORCHESTRATOR `$type` AGREEMENT. 🔴 A GENUINE CONTROL, and
+  // the only clause that reads the declaration against something the entry
+  // author did not also write. Clauses 1/1a/5a all check the declared posture
+  // against ITSELF; this one checks it against the `$type` the step actually
+  // submits as. Without it, a `chatCompletion` entry declaring `'promptAudit'`
+  // registers cleanly, reads as covered, and emits unscanned free text.
+  //
+  // Placed AFTER clause 1 on purpose. For the honest declaration
+  // (`chatCompletion` + `'textOutput'`) clause 1 fires first with the accurate
+  // "no implemented handler" message; this clause is what catches the DISHONEST
+  // one. Reversing the order would report both shapes as a type mismatch and
+  // hide the real reason the honest entry cannot register yet.
+  const acceptablePostures = acceptablePosturesFor(step.orchestratorType);
+  if (acceptablePostures !== undefined && !acceptablePostures.includes(step.moderationPosture)) {
+    throw new Error(
+      `${where}: orchestratorType '${step.orchestratorType}' requires moderationPosture ` +
+        `${acceptablePostures.map((p) => `'${p}'`).join(' or ')}, but the entry declares ` +
+        `'${step.moderationPosture}' — the declared posture does not cover the moderation ` +
+        'surface this step actually produces'
     );
   }
 

--- a/src/server/services/blocks/steps/index.ts
+++ b/src/server/services/blocks/steps/index.ts
@@ -283,8 +283,13 @@ export const NATIVELY_EXTRACTED_STEP_TYPES: readonly string[] = [
  * This is the same defect class as `auditableText` returning `''` (clause 5a)
  * and `extractOutput` returning `[]` (clause 8), one level up: there the field
  * was satisfiable by a no-op, here the FIELD ITSELF was satisfiable by naming
- * the wrong axis. In each case the fix is to anchor the check to something the
- * entry author did not also write — here, the orchestrator's own `$type`.
+ * the wrong axis.
+ *
+ * 🔴 THIS MAP IS ONLY HALF THE CONTROL. It is keyed on `orchestratorType`,
+ * which the entry author also writes, so on its own it checks one declaration
+ * against another. CLAUSE 7a — `buildStep(...).$type === orchestratorType` —
+ * is what ties that key to the type actually submitted. Weaken 7a and this map
+ * becomes advisory.
  *
  * 🔴 A SET, NOT A LADDER, AND DELIBERATELY SO. Modelling postures as a
  * strength ordering (`none` < `promptAudit` < `textOutput`) would bake in a
@@ -302,6 +307,19 @@ export const NATIVELY_EXTRACTED_STEP_TYPES: readonly string[] = [
  * also wrote. The mitigation is that adding an entry is a reviewed PR and this
  * map is the place review looks.
  *
+ * 🔴 THE FREE-TEXT-*INPUT* AXIS IS DELIBERATELY OUT OF SCOPE, and saying so is
+ * the point. An earlier revision listed `textToSpeech` (free text in, audio
+ * out) with `['promptAudit', 'textOutput']`. That was wrong twice: the second
+ * value was exactly the subsumption claim the SET-NOT-A-LADDER note above
+ * disclaims, and the criterion was half-applied — if text-IN qualifies, so do
+ * `aceStepAudio` (`lyrics`), `imageGen`, `videoGen`, `polyGen`, `wdTagging`
+ * and roughly a dozen more, none of which were listed. A partially-applied
+ * rule gives false comfort, so the rule here is the narrow, complete one:
+ * free-text OUTPUT. An unlisted text-IN type registering as `'none'` skips an
+ * audit it should run — a real gap, RECORDED AND NOT CLOSED, and a different
+ * shape of problem because `'promptAudit'` is implemented and so that entry
+ * would at least be registrable once someone notices.
+ *
  * Enumerated from the generated `@civitai/client` `$type` literals, not from
  * `src/**` usage — the same correction the registry's Tranche 1 note records:
  * grepping usage enumerates what is CALLED, not what EXISTS.
@@ -316,25 +334,46 @@ export const NATIVELY_EXTRACTED_STEP_TYPES: readonly string[] = [
  * null-prototype target without widening it back.
  */
 const ACCEPTABLE_POSTURES_BY_TYPE = {
-  // Free-text OUT. The prompt audit does not cover generated text at all, so
-  // `'promptAudit'` is not an acceptable answer for these — declaring it would
-  // audit the input and ship the output unscanned.
+  // 🔴 THE INCLUSION CRITERION, and it is exactly one thing: this type's OUTPUT
+  // carries free text. The prompt audit does not cover generated text at all,
+  // so `'promptAudit'` is never an acceptable answer here — declaring it would
+  // audit the input and ship the output unscanned. Every entry is therefore a
+  // single value, which is what keeps this map free of any claim that one
+  // posture subsumes another (see the SET-NOT-A-LADDER note above).
   chatCompletion: ['textOutput'],
   mediaCaptioning: ['textOutput'],
   audioCaptioning: ['textOutput'],
   transcription: ['textOutput'],
-  // Free-text IN, audio out: the user's text is the moderation surface and the
-  // audio is a rendering of already-audited text. A stricter posture is also
-  // acceptable; `'none'` is not.
-  textToSpeech: ['promptAudit', 'textOutput'],
+  // An LLM prompt rewriter: free text in AND out (`enhancedPrompt`,
+  // `recommendations[]`, `issues[].description` on its output type).
+  promptEnhancement: ['textOutput'],
+  // Returns `modelReason` — a free-text rationale — alongside its verdict.
+  xGuardModeration: ['textOutput'],
+  // Echoes caller-supplied `message` back out.
+  echo: ['textOutput'],
 } satisfies Record<string, readonly StepModerationPosture[]>;
 
+/**
+ * 🔴 THE ARRAYS ARE FROZEN TOO, AND THAT IS NOT BELT-AND-BRACES.
+ * `Object.freeze` is SHALLOW: freezing only the outer object leaves every
+ * posture array mutable, and `readonly` is a compile-time fiction that a plain
+ * `arr.push('none')` walks straight through at runtime — after which a
+ * `chatCompletion` entry declaring `'none'` registers cleanly. That was
+ * demonstrated by execution in review, not hypothesised. This module loads
+ * before any request context, so the window is small, but "small window on a
+ * spend-path trust root" is not a reason to leave a mutable allowlist.
+ */
 export const STEP_TYPE_ACCEPTABLE_POSTURES: Readonly<
   Record<string, readonly StepModerationPosture[]>
 > = Object.freeze(
   Object.assign(
     Object.create(null) as Record<string, readonly StepModerationPosture[]>,
-    ACCEPTABLE_POSTURES_BY_TYPE
+    Object.fromEntries(
+      Object.entries(ACCEPTABLE_POSTURES_BY_TYPE).map(([type, postures]) => [
+        type,
+        Object.freeze([...postures]),
+      ])
+    ) as Record<string, readonly StepModerationPosture[]>
   )
 );
 
@@ -822,18 +861,39 @@ export function assertStepInvariants(id: string, step: AnyBlockStep): void {
     );
   }
 
-  // (1b) POSTURE ↔ ORCHESTRATOR `$type` AGREEMENT. 🔴 A GENUINE CONTROL, and
-  // the only clause that reads the declaration against something the entry
-  // author did not also write. Clauses 1/1a/5a all check the declared posture
-  // against ITSELF; this one checks it against the `$type` the step actually
-  // submits as. Without it, a `chatCompletion` entry declaring `'promptAudit'`
-  // registers cleanly, reads as covered, and emits unscanned free text.
+  // (1b) POSTURE ↔ ORCHESTRATOR `$type` AGREEMENT. Without it, a
+  // `chatCompletion` entry declaring `'promptAudit'` registers cleanly, reads
+  // as covered, and emits unscanned free text.
+  //
+  // 🔴 WHAT THIS CLAUSE IS AND IS NOT — READ BEFORE TRUSTING IT. It reads the
+  // posture against `orchestratorType`, which the entry author ALSO WRITES. On
+  // its own that makes it a check against a second declaration, not against
+  // reality: an author could declare a benign `orchestratorType`, build
+  // `$type: 'chatCompletion'`, and walk straight past it. An earlier revision
+  // of this comment claimed the opposite — that this was "the only clause that
+  // reads the declaration against something the entry author did not also
+  // write" — and that claim was FALSE and was caught in review. It is recorded
+  // here rather than quietly deleted because in a code-reviewed trust root the
+  // comment IS the control: a reviewer who reads "already anchored" is a
+  // reviewer who stops checking.
+  //
+  // What makes it a real control is CLAUSE 7a, which asserts
+  // `buildStep(...).$type === orchestratorType` per variant. 1b + 7a together
+  // tie the posture to the type actually submitted. Neither is sufficient
+  // alone; if 7a is ever weakened, this clause degrades to a speed bump.
   //
   // Placed AFTER clause 1 on purpose. For the honest declaration
   // (`chatCompletion` + `'textOutput'`) clause 1 fires first with the accurate
   // "no implemented handler" message; this clause is what catches the DISHONEST
   // one. Reversing the order would report both shapes as a type mismatch and
   // hide the real reason the honest entry cannot register yet.
+  //
+  // 🟢 Known rough edge, deliberately not reordered: a `$type`-constrained
+  // entry declaring `'promptAudit'` WITHOUT `auditableText` fires clause 1a
+  // first, telling the author to add a field that this clause then rejects
+  // anyway. Moving 1b above 1a would fix the two-step, but 1a's reverse
+  // direction is a genuine control for a different shape, and splitting the
+  // moderation clauses around it costs more clarity than the dead end does.
   const acceptablePostures = acceptablePosturesFor(step.orchestratorType);
   if (acceptablePostures !== undefined && !acceptablePostures.includes(step.moderationPosture)) {
     throw new Error(
@@ -977,8 +1037,40 @@ export function assertStepInvariants(id: string, step: AnyBlockStep): void {
     // the unimplemented `staticAllowlist` gate (clause 11): an entry whose
     // params can carry an AIR cannot honestly declare `'none'`, and declaring
     // `'staticAllowlist'` fails at load until someone implements and reviews it.
+    const built = step.buildStep(parsed.data);
+
+    // (7a) THE DECLARED `$type` MUST BE THE ONE ACTUALLY BUILT.
+    //
+    // 🔴 THIS IS WHAT ANCHORS CLAUSE 1b, AND WITHOUT IT THAT CLAUSE IS A SPEED
+    // BUMP RATHER THAN A CONTROL. `orchestratorType` is a self-declared field
+    // and the router submits `buildStep(...).$type` (`blocks.router.ts`, the
+    // step submit branch) — NOT the declared one. So before this clause an
+    // entry could declare a benign, unconstrained `orchestratorType`, build
+    // `$type: 'chatCompletion'`, and register cleanly with
+    // `moderationPosture: 'none'`: clause 1b saw the benign declaration, and
+    // the orchestrator got the chat step. Verified by execution against this
+    // file, not reasoned about.
+    //
+    // It hardens clause 9 for free by the same argument — that clause also
+    // reads the DECLARED type, so a divergent entry could shadow a natively
+    // extracted `$type` while declaring something else.
+    //
+    // 🔴 HONEST LIMIT, same shape as clause 7's: this probes the CANONICAL
+    // params, so a `buildStep` that switches `$type` ON PARAMS can still
+    // diverge at request time. It is a floor, not a proof. Closing that
+    // completely means re-asserting at the router on the real submitted value,
+    // exactly as the resource-policy scan already does — recorded, not done
+    // here, because it belongs with the router's own submit-path guards.
+    if (built.$type !== step.orchestratorType) {
+      throw new Error(
+        `${vWhere}: declares orchestratorType '${step.orchestratorType}' but buildStep() emits ` +
+          `'${built.$type}' — the router submits the BUILT type, so every $type-keyed guard ` +
+          '(the moderation-posture constraint, the natively-extracted check) would be reading ' +
+          'a type this step does not actually submit, and output extraction would never resolve'
+      );
+    }
+
     if (step.resourcePolicy.kind === 'none') {
-      const built = step.buildStep(parsed.data);
       if (containsAirReference(built.input)) {
         throw new Error(
           `${vWhere}: resourcePolicy 'none' is contradicted — buildStep() emitted an AIR ` +

--- a/src/server/services/blocks/steps/index.ts
+++ b/src/server/services/blocks/steps/index.ts
@@ -401,11 +401,23 @@ export const STEP_TYPE_ACCEPTABLE_POSTURES: Readonly<
     //
     // So the `satisfies` above protects the LITERAL, and nothing at compile
     // time protects the transform between that literal and the exported
-    // allowlist. What actually catches a bad transform is the RUNTIME pair in
-    // the tests — "every listed posture is a DECLARED posture" and "every entry
-    // is single-valued" — which turn 4 red on exactly that mutation. If someone
-    // later normalizes values in here (case-fold, dedupe, append a default),
-    // those tests are the guard, not the type system.
+    // allowlist. The RUNTIME pair in the tests — "every listed posture is a
+    // DECLARED posture" and "every entry is single-valued" — is the guard.
+    //
+    // 🔴 BE EXACT ABOUT WHAT IT COVERS; an earlier revision of this very
+    // comment said those tests "turn 4 red on exactly that mutation", naming
+    // the type-widening one, and that was FALSE. Measured, three ways:
+    //
+    //   `[...postures] as string[]`      → 0 red  (a PURE TYPE widening; the
+    //                                      runtime values are unchanged, so
+    //                                      there is nothing for a runtime test
+    //                                      to see, and nothing to catch)
+    //   `[...postures, 'nope']`          → 2 red
+    //   `postures.map(x => x.toUpperCase())` → 4 red
+    //
+    // i.e. a transform that changes VALUES is caught; one that only widens the
+    // TYPE is caught by nothing and needs nothing. That is a narrower claim
+    // than the one it replaces, and it is the true one.
     Object.fromEntries(
       Object.entries(ACCEPTABLE_POSTURES_BY_TYPE).map(([type, postures]) => [
         type,
@@ -1113,11 +1125,13 @@ export function assertStepInvariants(id: string, step: AnyBlockStep): void {
     // extracted `$type` while declaring something else.
     //
     // 🔴 HONEST LIMIT, same shape as clause 7's: this probes the CANONICAL
-    // params, so a `buildStep` that switches `$type` ON PARAMS can still
-    // diverge at request time. It is a floor, not a proof. Closing that
-    // completely means re-asserting at the router on the real submitted value,
-    // exactly as the resource-policy scan already does — recorded, not done
-    // here, because it belongs with the router's own submit-path guards.
+    // params, so a `buildStep` that switches `$type` ON PARAMS satisfies this
+    // clause and still diverges at request time. It is a floor, not a proof.
+    // That gap IS closed — by the request-time re-assert of the same equality
+    // in `blocks.router.ts`'s step submit path, beside the resource-policy
+    // re-assert that set the precedent, and covered by a router test using a
+    // params-dependent fixture that passes THIS clause. Do not read the limit
+    // above as an open hole; read it as the reason the router clause exists.
     if (built.$type !== step.orchestratorType) {
       throw new Error(
         `${vWhere}: declares orchestratorType '${step.orchestratorType}' but buildStep() emits ` +

--- a/src/server/services/blocks/steps/index.ts
+++ b/src/server/services/blocks/steps/index.ts
@@ -314,8 +314,23 @@ export const NATIVELY_EXTRACTED_STEP_TYPES: readonly string[] = [
  * disclaims, and the criterion was half-applied — if text-IN qualifies, so do
  * `aceStepAudio` (`lyrics`), `imageGen`, `videoGen`, `polyGen`, `wdTagging`
  * and roughly a dozen more, none of which were listed. A partially-applied
- * rule gives false comfort, so the rule here is the narrow, complete one:
- * free-text OUTPUT. An unlisted text-IN type registering as `'none'` skips an
+ * rule gives false comfort, so the rule here is the narrower one: free-text
+ * OUTPUT.
+ *
+ * 🔴 THAT RULE IS NARROWER, NOT COMPLETE — an earlier revision called it
+ * "complete" and review disproved it. Uncovered types whose OUTPUT carries free
+ * text include `imageResourceTraining` (`sampleImagesPrompts[]` — echoed user
+ * prompts, the SAME rationale used to list `echo` below, which is a live
+ * inconsistency), `mediaRating.blockedReason`, `modelParseMetadata.metadata`
+ * (a `__metadata__` header out of a user-uploaded safetensors), the
+ * `modelClamScan` / `modelPickleScan` `output` + `skipReason` fields, and
+ * `qwenImageBench.errors`. They are NOT listed because whether each is really
+ * a free-text surface a block could publish is a judgment a domain owner should
+ * make, not one to settle silently in this commit. Listing the candidates is
+ * the honest middle: the next person to add a text-producing entry starts from
+ * a named set rather than from "complete".
+ *
+ * An unlisted text-IN type registering as `'none'` skips an
  * audit it should run — a real gap, RECORDED AND NOT CLOSED, and a different
  * shape of problem because `'promptAudit'` is implemented and so that entry
  * would at least be registrable once someone notices.
@@ -349,7 +364,14 @@ const ACCEPTABLE_POSTURES_BY_TYPE = {
   promptEnhancement: ['textOutput'],
   // Returns `modelReason` — a free-text rationale — alongside its verdict.
   xGuardModeration: ['textOutput'],
-  // Echoes caller-supplied `message` back out.
+  // Echoes caller-supplied `message` back out. 🔴 NOTE THE RATIONALE DOES NOT
+  // FIT THIS ONE CLEANLY, and pretending otherwise is how `textToSpeech` got in:
+  // for `echo` the output IS the input, so `'promptAudit'` would in fact cover
+  // the whole surface. It is constrained to `'textOutput'` as the conservative
+  // choice — that is a real cost (an `echo` entry cannot register until
+  // `'textOutput'` is implemented) accepted deliberately, because relaxing it
+  // means asserting that auditing the input suffices for a text-emitting step,
+  // which is the subsumption judgment this map declines to make anywhere else.
   echo: ['textOutput'],
 } satisfies Record<string, readonly StepModerationPosture[]>;
 
@@ -368,12 +390,28 @@ export const STEP_TYPE_ACCEPTABLE_POSTURES: Readonly<
 > = Object.freeze(
   Object.assign(
     Object.create(null) as Record<string, readonly StepModerationPosture[]>,
+    // 🔴 NO `as` CAST HERE — it was unnecessary, and removing dead type
+    // assertions off a spend-path allowlist is worth doing. But BE PRECISE
+    // ABOUT WHAT THAT BOUGHT, because the obvious reading is wrong and was
+    // measured: removing the cast does NOT restore element-type checking on
+    // this transform. `Object.assign`'s intersection result swallows it either
+    // way — changing this `.map` to produce `readonly string[]` instead of
+    // `readonly StepModerationPosture[]` compiles clean WITH the cast and
+    // WITHOUT it, verified both ways.
+    //
+    // So the `satisfies` above protects the LITERAL, and nothing at compile
+    // time protects the transform between that literal and the exported
+    // allowlist. What actually catches a bad transform is the RUNTIME pair in
+    // the tests — "every listed posture is a DECLARED posture" and "every entry
+    // is single-valued" — which turn 4 red on exactly that mutation. If someone
+    // later normalizes values in here (case-fold, dedupe, append a default),
+    // those tests are the guard, not the type system.
     Object.fromEntries(
       Object.entries(ACCEPTABLE_POSTURES_BY_TYPE).map(([type, postures]) => [
         type,
         Object.freeze([...postures]),
       ])
-    ) as Record<string, readonly StepModerationPosture[]>
+    )
   )
 );
 
@@ -878,9 +916,18 @@ export function assertStepInvariants(id: string, step: AnyBlockStep): void {
   // reviewer who stops checking.
   //
   // What makes it a real control is CLAUSE 7a, which asserts
-  // `buildStep(...).$type === orchestratorType` per variant. 1b + 7a together
-  // tie the posture to the type actually submitted. Neither is sufficient
-  // alone; if 7a is ever weakened, this clause degrades to a speed bump.
+  // `buildStep(...).$type === orchestratorType` per variant, TOGETHER WITH the
+  // request-time re-assert of the same equality in the router's step submit
+  // path. Neither is sufficient alone; if either is weakened, this clause
+  // degrades to a speed bump.
+  //
+  // 🔴 BE PRECISE ABOUT WHICH ONE BUYS WHAT — an earlier revision of this
+  // comment said "1b + 7a together tie the posture to the type actually
+  // submitted" and that was ALSO an overclaim, in the same shape as the one
+  // above it: 7a probes CANONICAL params only, so a `buildStep` that switches
+  // its `$type` ON PARAMS satisfies 7a at load and diverges at request time.
+  // Review demonstrated exactly that by execution. The load-time pair binds
+  // the DECLARED shape; only the router's re-assert binds the SUBMITTED one.
   //
   // Placed AFTER clause 1 on purpose. For the honest declaration
   // (`chatCompletion` + `'textOutput'`) clause 1 fires first with the accurate
@@ -1037,7 +1084,17 @@ export function assertStepInvariants(id: string, step: AnyBlockStep): void {
     // the unimplemented `staticAllowlist` gate (clause 11): an entry whose
     // params can carry an AIR cannot honestly declare `'none'`, and declaring
     // `'staticAllowlist'` fails at load until someone implements and reviews it.
+    // 🔴 BUILT FOR EVERY ENTRY, not just `'none'`-policy ones as before, because
+    // clause 7a below needs it unconditionally. That widens the blast radius of
+    // a `buildStep` that throws or returns a non-object — it now crashes module
+    // load for ANY entry — so the shape is checked here, with a clause name
+    // attached, rather than surfacing as a bare `TypeError` on `built.$type`.
     const built = step.buildStep(parsed.data);
+    if (built === null || typeof built !== 'object') {
+      throw new Error(
+        `${vWhere}: buildStep() must return an orchestrator step template, got ${typeof built}`
+      );
+    }
 
     // (7a) THE DECLARED `$type` MUST BE THE ONE ACTUALLY BUILT.
     //


### PR DESCRIPTION
## The gap

`moderationPosture` is **self-declared**, and every existing clause checks the declaration against *itself*: clause 1 asks whether the declared posture has a handler; clauses 1a/5a ask whether that posture's own field exists and returns something. **Nothing asked whether the declaration matches what the step actually does.**

So a `chatCompletion` entry declaring `'promptAudit'` — auditing its input, emitting unscanned free text — registers cleanly and passes every check. The gate whose entire purpose is *"a text-producing step cannot register until someone answers the policy question"* was satisfiable by answering a **different** question.

Same defect class as `auditableText` returning `''` (clause 5a) and `extractOutput` returning `[]` (clause 8), one level up: there the field was satisfiable by a no-op; here the field itself named the wrong axis.

## The change

`STEP_TYPE_ACCEPTABLE_POSTURES` (orchestrator `$type` → acceptable postures) + **clause 1b**, rejecting an entry whose declared posture is not acceptable for the `$type` it submits as.

**Behaviour-neutral for the shipped population** — `convertImage`'s `$type` carries no constraint, so no registered entry changes.

## Shape decisions, each measured rather than assumed

- **A set per type, not a strength ladder.** A ladder would bake in a claim nobody has made — that `'textOutput'`, once implemented, also audits input. That is a decision for whoever implements it; encoding it as an ordering would hide it.
- **Clause 1b sits *after* clause 1, deliberately.** The honest declaration (`chatCompletion` + `'textOutput'`) must still fail with *"no implemented handler"* — the accurate reason. 1b catches the dishonest one. A test pins that ordering.
- **Null prototype on the map** — the control `./moderation` already documents on its handler table. With a plain literal, an entry declaring `orchestratorType: 'toString'` indexes to `Object.prototype.toString` (truthy) and `.includes` on a function throws out of registry load.
- **`satisfies`, not a cast.** Writing it as `Object.create(null) as Record<…>` removes contextual typing and a mistyped posture (`'textOputput'`) **compiles clean** — I verified that, then fixed it. With `satisfies` it is `error TS2820`.
- **`$type`s enumerated from the generated `@civitai/client` literals**, not `src/**` usage — grepping usage enumerates what is *called*, not what *exists*. `textToSpeech` takes free text **in** and emits audio, so it accepts `'promptAudit'` as a floor rather than requiring `'textOutput'`.

## Residual gap, stated rather than papered over

This constrains the types **listed**. A text-producing `$type` nobody listed is unconstrained, exactly as before. Inferring text-production from the output shape is the sniffing this file already rejects for `auditableText`, and would be worse here because it would run against a sample the entry author also wrote. Mitigation: adding an entry is a reviewed PR, and this map is where review looks.

## Verification

- **84 tests green** across `step-registry` + `step-moderation`; 9 new.
- Every rejection is paired with a **negative control** asserting the same fixture passes when only the `$type` changes.
- **Mutation-tested**, three ways:
  - disabling clause 1b → **3 red** (reachability included), every control still green;
  - emptying the map → **4 red** (the non-empty guard exists precisely to catch a silently-disabled gate);
  - removing the null prototype → **exactly 1 red**, the prototype-seam test.
- **Typecheck: 0 errors in the changed area.** 🔴 Worth flagging for anyone else running it locally — `npx tsc --noEmit` **OOMs at the default heap** (exit 134, core dumped) and prints no `error TS` lines, so a naive read scores it as a clean 0. It needs `NODE_OPTIONS=--max_old_space_size=8192` (what the repo's own `typecheck` script sets). I only caught it by feeding the harness a known-bad file and getting silence back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)