### PR TITLE
refactor(apps): single-source the recents-rail glyph (S6b) + correct a false doc claim

### DIFF
--- a/src/components/Apps/AppListingCard.tsx
+++ b/src/components/Apps/AppListingCard.tsx
@@ -572,10 +572,11 @@ export function AppListingCard({ card, canOpenPage = false }: AppListingCardProp
                 🔴 The mapping itself is NOT restated here — it lives in
                 `appListingActionGlyph.ts` and is read above via `CtaGlyph`. A copy
                 of it in this comment is exactly how the card and the detail page
-                drifted apart in the first place. The rail tile's icon button still
-                carries its own copy (`RECENT_ACTION_ICONS` in
-                `RecentlyOpenedApps.tsx`, driven by `getRecentRailAction`); folding
-                that third one in is the remaining consolidation.
+                drifted apart in the first place. The rail tile's icon button used
+                to carry a third copy (`RECENT_ACTION_ICONS` in
+                `RecentlyOpenedApps.tsx`); it now resolves through the same module
+                via `recentRailActionGlyph`, so all three surfaces are single-
+                sourced and the consolidation is complete.
 
                 🔴 The icon is DECORATIVE — the label text stays the accessible
                 name. Tabler icons render `<svg>` with no `<title>`, so they

--- a/src/components/Apps/RecentlyOpenedApps.tsx
+++ b/src/components/Apps/RecentlyOpenedApps.tsx
@@ -12,10 +12,10 @@ import {
   Tooltip,
 } from '@mantine/core';
 import { useReducedMotion } from '@mantine/hooks';
-import { IconExternalLink, IconEye, IconPlayerPlay } from '@tabler/icons-react';
 import Link from 'next/link';
 import clsx from 'clsx';
 import { AppBlockCard } from '~/components/Apps/AppBlockCard';
+import { ACTION_GLYPH_ICONS, recentRailActionGlyph } from '~/components/Apps/appListingActionGlyph';
 import {
   getRecentRailAction,
   getRecentRailTarget,
@@ -202,13 +202,6 @@ export interface RecentlyOpenedListingsViewProps {
   onOpenRecent?: (entry: ResolvedRecentApp) => void;
 }
 
-/** Icon per action — the SAME vocabulary the store card's CTA row uses. */
-const RECENT_ACTION_ICONS = {
-  open: IconPlayerPlay,
-  visit: IconExternalLink,
-  view: IconEye,
-} as const;
-
 /**
  * One compact recents tile: app icon + name + an icon CTA. Kept deliberately
  * smaller than `AppListingCard` (no cover, no CTA row, no recommend rollup) —
@@ -266,7 +259,14 @@ function RecentTile({
   const reduceMotion = useReducedMotion();
   const target = getRecentRailTarget(entry, { canOpenPage });
   const { action, label: actionLabel } = getRecentRailAction(entry, { canOpenPage });
-  const ActionGlyph = RECENT_ACTION_ICONS[action];
+  // 🔴 SINGLE-SOURCED. This tile used to carry its own private
+  // `RECENT_ACTION_ICONS` record — the third copy of a glyph mapping
+  // `appListingActionGlyph.ts` already owned for the store card and the listing
+  // detail, and the one `AppListingCard`'s CTA comment named as the outstanding
+  // consolidation. Resolve through `recentRailActionGlyph` so the rail, the card
+  // and the detail page cannot drift: an eye here and an eye there are now the
+  // same lookup, not two literals that happen to agree today.
+  const ActionGlyph = ACTION_GLYPH_ICONS[recentRailActionGlyph(action)];
   const label = entry.name ?? entry.slug;
   // External targets are https-guarded upstream (`safeExternalHref`) and get the
   // standard new-tab hardening; internal ones route through next/link. `Anchor`

--- a/src/components/Apps/__tests__/recent-rail-glyph-single-source.test.ts
+++ b/src/components/Apps/__tests__/recent-rail-glyph-single-source.test.ts
@@ -1,0 +1,155 @@
+import { readFileSync } from 'fs';
+import path from 'path';
+import { describe, expect, test } from 'vitest';
+
+import { IconExternalLink, IconEye, IconPlayerPlay } from '@tabler/icons-react';
+import {
+  ACTION_GLYPH_ICONS,
+  cardActionGlyph,
+  detailActionGlyph,
+  recentRailActionGlyph,
+} from '~/components/Apps/appListingActionGlyph';
+import type { PrimaryActionGlyph } from '~/components/Apps/appListingActionGlyph';
+import type { RecentRailAction } from '~/components/Apps/recentAppsRail';
+
+/**
+ * S6b — the primary-action glyph mapping is a SINGLE shared source, for all
+ * THREE surfaces that render it.
+ *
+ * Before this, `appListingActionGlyph.ts` owned the mapping for the store card
+ * (`cardActionGlyph`) and the listing detail (`detailActionGlyph`), while
+ * `RecentlyOpenedApps.tsx` kept a private `RECENT_ACTION_ICONS` record for the
+ * recents-rail tile — a third, drift-capable copy. `AppListingCard.tsx`'s CTA
+ * comment named folding it in as the outstanding consolidation. This file is the
+ * gate that keeps it folded in.
+ *
+ * ── HOW TO READ THE COVERAGE BELOW ─────────────────────────────────────────
+ * The consolidation was PROVEN to be a pure refactor before it was made: the
+ * private map's three entries resolved, BY REFERENCE, to the same Tabler
+ * components `ACTION_GLYPH_ICONS` reaches via `launch`/`external`/`view`
+ * (measured with a deliberately mis-mapped source as the positive control, so
+ * the check was shown able to observe a disagreement — it reported exactly one
+ * for the mutant and zero for the real source).
+ *
+ * A consequence of that: MOST of what follows is an INVARIANT GUARD, not
+ * regression coverage. `recentRailActionGlyph` is new, so its value tests had no
+ * pre-change code to go red against, and the icon-identity tests passed before
+ * the change too (that is the whole point — nothing rendered differently). They
+ * are pins against a FUTURE remap, and are labelled as such per test. The two
+ * genuinely change-detecting tests are the structural ones in the last describe
+ * block: they read the source and fail on the pre-change file.
+ */
+
+const APPS_DIR = path.resolve(__dirname, '..');
+
+function read(file: string): string {
+  return readFileSync(path.join(APPS_DIR, file), 'utf8');
+}
+
+// 🔴 GENUINELY exhaustive, the `satisfies Record<K, true>` idiom this repo's
+// sibling `appListingActionGlyph.test.ts` established: a missing key fails to
+// typecheck HERE, so adding a 4th `RecentRailAction` cannot silently escape the
+// distinctness test below. A `readonly RecentRailAction[]` would accept a subset.
+const RAIL_ACTIONS = Object.keys({
+  open: true,
+  visit: true,
+  view: true,
+} satisfies Record<RecentRailAction, true>) as RecentRailAction[];
+
+describe('recentRailActionGlyph — the mapping itself', () => {
+  test('INVARIANT GUARD: maps each rail action to its named glyph', () => {
+    // Value-pinned to literals, NOT derived from the implementation. These are
+    // the glyphs the rail shipped with before the fold-in, carried forward. The
+    // `Record<…, PrimaryActionGlyph>` annotation makes a typo here a typecheck
+    // failure rather than a confidently-wrong expectation.
+    const expected: Record<RecentRailAction, PrimaryActionGlyph> = {
+      open: 'launch',
+      visit: 'external',
+      view: 'view',
+    };
+    for (const action of RAIL_ACTIONS) {
+      expect(recentRailActionGlyph(action)).toBe(expected[action]);
+    }
+  });
+
+  test('INVARIANT GUARD: every rail action gets a DISTINCT glyph', () => {
+    const glyphs = RAIL_ACTIONS.map(recentRailActionGlyph);
+    expect(new Set(glyphs).size).toBe(RAIL_ACTIONS.length);
+  });
+
+  test('INVARIANT GUARD: the in-site and off-site glyphs are DIFFERENT (the #3391 premise)', () => {
+    // Same invariant the card and the detail page are held to. On the rail it is
+    // if anything sharper: the tile's glyph is the ONLY visual difference between
+    // "re-opens here" and "leaves Civitai" — the accessible name is a tooltip.
+    expect(recentRailActionGlyph('open')).not.toBe(recentRailActionGlyph('visit'));
+    expect(ACTION_GLYPH_ICONS[recentRailActionGlyph('open')]).not.toBe(
+      ACTION_GLYPH_ICONS[recentRailActionGlyph('visit')]
+    );
+  });
+
+  test('INVARIANT GUARD: agrees with the card and the detail page on every shared action name', () => {
+    // 'open' and 'visit' are spelled identically in all three vocabularies and
+    // MUST resolve identically — a rail tile and the card it came from disagreeing
+    // about what "open" looks like is exactly the drift this module prevents.
+    for (const shared of ['open', 'visit'] as const) {
+      expect(recentRailActionGlyph(shared)).toBe(cardActionGlyph(shared));
+      expect(recentRailActionGlyph(shared)).toBe(detailActionGlyph(shared));
+    }
+    // The rail's 'view' is the card's 'detail' — same meaning, different word.
+    expect(recentRailActionGlyph('view')).toBe(cardActionGlyph('detail'));
+  });
+});
+
+describe('recents rail — the RENDERED icons are unchanged by the consolidation', () => {
+  test('INVARIANT GUARD: each rail action resolves to the icon component it shipped with', () => {
+    // 🔴 This is the "zero rendered change" pin. The three components on the
+    // right are exactly what the deleted `RECENT_ACTION_ICONS` held, measured by
+    // reference before the fold-in — not copied out of the new implementation.
+    // It passed before the change and passes after; it exists to fail on a
+    // FUTURE remap, and is not evidence that this change was correct.
+    expect(ACTION_GLYPH_ICONS[recentRailActionGlyph('open')]).toBe(IconPlayerPlay);
+    expect(ACTION_GLYPH_ICONS[recentRailActionGlyph('visit')]).toBe(IconExternalLink);
+    expect(ACTION_GLYPH_ICONS[recentRailActionGlyph('view')]).toBe(IconEye);
+  });
+
+  test('CONTROL: the three pinned icon components are pairwise distinct', () => {
+    // Without this, the identity assertions above could all hold while the rail
+    // rendered one glyph for everything — the test would be green for the wrong
+    // reason. Pins that the discriminator exists at all.
+    const icons = [IconPlayerPlay, IconExternalLink, IconEye];
+    expect(new Set(icons).size).toBe(3);
+  });
+});
+
+describe('the private copy is GONE (structural — these fail on the pre-change source)', () => {
+  test('RecentlyOpenedApps.tsx no longer declares RECENT_ACTION_ICONS', () => {
+    const src = read('RecentlyOpenedApps.tsx');
+    expect(src).not.toMatch(/const RECENT_ACTION_ICONS\b/);
+  });
+
+  test('RecentlyOpenedApps.tsx resolves the glyph through the shared module', () => {
+    const src = read('RecentlyOpenedApps.tsx');
+    expect(src).toMatch(/from '~\/components\/Apps\/appListingActionGlyph'/);
+    // The exact read the tile performs — not merely "the identifier appears".
+    expect(src).toMatch(/ACTION_GLYPH_ICONS\[recentRailActionGlyph\(action\)\]/);
+    // 🔴 And it must not reach for raw Tabler icons to hand-roll a map again.
+    // The file has no other use for them, so "imports no icons directly" is the
+    // cleanest form of that guard — a re-added `RECENT_ACTION_ICONS` needs them.
+    expect(src).not.toMatch(/from '@tabler\/icons-react'/);
+  });
+
+  test('appListingActionGlyph.ts exports the rail mapping with NO default arm', () => {
+    const src = read('appListingActionGlyph.ts');
+    expect(src).toMatch(/export function recentRailActionGlyph\b/);
+    // 🔴 THE ENFORCEMENT. `Typecheck` is one of only two merge-blocking gates in
+    // this repo (`Unit tests` is `continue-on-error`), so an exhaustive switch
+    // returning a non-optional `PrimaryActionGlyph` is the ONLY mechanism that
+    // turns "someone added a 4th RecentRailAction" into a build failure rather
+    // than a tile that renders no glyph at all. A `default:` arm — or a `??`
+    // fallback at the call site — would defeat it silently, which is precisely
+    // why it is asserted structurally instead of trusted to review.
+    const body = src.slice(src.indexOf('export function recentRailActionGlyph'));
+    expect(body).not.toMatch(/\bdefault:/);
+    expect(body).not.toMatch(/\?\?/);
+  });
+});

--- a/src/components/Apps/appListingActionGlyph.ts
+++ b/src/components/Apps/appListingActionGlyph.ts
@@ -8,6 +8,7 @@ import {
 import type { Icon } from '@tabler/icons-react';
 import type { ListingCtaAction } from '~/components/Apps/appListingCardView';
 import type { DetailActionMode } from '~/components/Apps/appListingDetailView';
+import type { RecentRailAction } from '~/components/Apps/recentAppsRail';
 
 /**
  * The primary-action GLYPH vocabulary — the single source of truth for "which
@@ -54,7 +55,8 @@ export const ACTION_GLYPH_ICONS: Record<PrimaryActionGlyph, Icon> = {
    *
    * 🔴 Distinct from `info`, and it must stay `IconEye`. #3539's product-feedback
    * pass shipped `IconEye` for the card's "View details" CTA and for the recents
-   * rail's `view` action (`RECENT_ACTION_ICONS` in `RecentlyOpenedApps.tsx`), so
+   * rail's `view` action (then a private `RECENT_ACTION_ICONS` map in
+   * `RecentlyOpenedApps.tsx`, since folded into `recentRailActionGlyph` below), so
    * this is the SITE's established vocabulary, not a fresh choice. `info` is the
    * detail page's *inert* affordance ("Runs on model pages" — no href at all);
    * collapsing the two would silently repaint every card's View-details CTA.
@@ -117,6 +119,48 @@ export function cardActionGlyph(action: ListingCtaAction): PrimaryActionGlyph {
       // repainted every such CTA — a regression against a deliberate product call,
       // introduced by a module written to be wired up. Corrected before its first
       // caller (this file's own card) exists.
+      return 'view';
+  }
+}
+
+/**
+ * Recents-rail tile CTA action → glyph. The THIRD and last consumer of the
+ * vocabulary; `AppListingCard`'s CTA comment named folding it in as the
+ * outstanding consolidation.
+ *
+ * `RecentlyOpenedApps.tsx` used to carry its own private `RECENT_ACTION_ICONS`
+ * record — a third, drift-capable copy of a mapping this module already owned.
+ * It is deleted; the rail now reads `ACTION_GLYPH_ICONS` through here.
+ *
+ * 🔴 PROVEN, not assumed, to be a pure refactor. Before the fold-in, the private
+ * map resolved `open → IconPlayerPlay`, `visit → IconExternalLink`,
+ * `view → IconEye`, which are the byte-same components this function reaches via
+ * `launch` / `external` / `view`. That equality was measured by reference (with a
+ * deliberately mis-mapped source as the positive control, to prove the check
+ * could observe a disagreement at all) rather than asserted from reading the two
+ * literals side by side.
+ *
+ * 🔴 NO `default` ARM, deliberately — that is the enforcement, not a style
+ * choice. This repo's only merge-blocking gates are `Typecheck` and
+ * ESLint/Prettier on added files (`Unit tests` is `continue-on-error`), so a
+ * `switch` with no fallback, whose return type forbids `undefined`, is the ONE
+ * mechanism that makes a newly added `RecentRailAction` a BUILD failure here
+ * instead of a tile that silently renders no glyph. A `default` — or a
+ * `?? someFallback` at the call site — would trade a compile error for a
+ * production defect nothing in CI can catch.
+ *
+ * Note `RecentRailAction`'s names are the RAIL's ('open'/'visit'/'view'), not the
+ * glyph vocabulary's ('launch'/'external'/'view'); the two agree on `view` and
+ * differ on the other two, which is exactly why the translation belongs in a
+ * named function rather than being spelled as an index.
+ */
+export function recentRailActionGlyph(action: RecentRailAction): PrimaryActionGlyph {
+  switch (action) {
+    case 'open':
+      return 'launch';
+    case 'visit':
+      return 'external';
+    case 'view':
       return 'view';
   }
 }

--- a/src/components/Apps/recentAppsRail.ts
+++ b/src/components/Apps/recentAppsRail.ts
@@ -162,13 +162,30 @@ export type ChromeRecentApp = RecentApp & { blockId: string };
  *     `appBlocks` is the block-runtime kill-switch, so pages-on/blocks-off is a
  *     reachable state that still 404s). 🔴 THIS IS THE LOAD-BEARING ONE.
  *     `/apps/run/<slug>` 404s fail-closed for a viewer missing either flag
- *     (`src/pages/apps/run/[slug]/[[...path]].tsx`), yet BOTH writers that
- *     feed this menu — the detail page's "Open live" CTA and the legacy
- *     `MarketplaceBody.recordRecent` — record on-site `{hasPage:true}` entries
- *     flag-blind. Without this gate a dark-flag viewer is offered a menu of
- *     guaranteed-404 links. Dark → the whole section is hidden (the menu has no
- *     second link shape to fall back to; the `/apps` rail, which does, keeps
- *     showing the same entries via `getRecentRailTarget`).
+ *     (`src/pages/apps/run/[slug]/[[...path]].tsx`), and NOTHING upstream of
+ *     this filter carries flag state: every writer of `recordRecentlyOpenedApp`
+ *     records what the app IS, never what the viewer is currently allowed to
+ *     open. So an entry reaches this menu with `blockId` set and no evidence
+ *     whatsoever that `/apps/run/<blockId>` will resolve for THIS viewer — and
+ *     a viewer's flags can go dark after the entry was written in any case.
+ *     Without this gate that viewer is offered a menu of guaranteed-404 links.
+ *
+ *     🔴 NOTE WHAT THE FILTER BELOW ACTUALLY READS — `kind` and `blockId`, NOT
+ *     `hasPage`. That matters because the writers do not agree on what they
+ *     record. `toRecentAppFromListing` (the detail page's "Open live" CTA, the
+ *     card's new-tab CTA) and the run page both write `kind` AND `hasPage`; the
+ *     legacy `MarketplaceBody.recordRecent` writes only
+ *     `{id, blockId, name, iconUrl}` — NEITHER field. Its entries are therefore
+ *     admitted here by ABSENCE (`undefined !== 'offsite'` is true), carrying no
+ *     page evidence at all, which makes them the strongest case for the gate
+ *     rather than an exception to it. Do not "tighten" this by adding a
+ *     `hasPage` test: that would silently drop every legacy entry, which is the
+ *     empty-a-returning-viewer's-list failure `resolveRecentApp` exists to
+ *     avoid.
+ *
+ *     Dark → the whole section is hidden (the menu has no second link shape to
+ *     fall back to; the `/apps` rail, which does, keeps showing the same entries
+ *     via `getRecentRailTarget`).
  *  2. not the app currently being viewed (nothing to "return" to).
  *  3. on-site with a `blockId`. Off-site listings have no AppBlock at all, so
  *     they would render `/apps/run/undefined`; an off-site entry carrying a


### PR DESCRIPTION
Folds the **third and last** copy of the primary-action glyph mapping into `appListingActionGlyph.ts`, finishing the consolidation `AppListingCard.tsx`'s CTA comment named as outstanding.

Before: `appListingActionGlyph.ts` owned `cardActionGlyph` (store card) and `detailActionGlyph` (listing detail), while `RecentlyOpenedApps.tsx` kept a private `RECENT_ACTION_ICONS` record for the recents-rail tile — a drift-capable copy of a mapping the module already owned.

After: `recentRailActionGlyph(action)` lives in the module; the rail reads `ACTION_GLYPH_ICONS[recentRailActionGlyph(action)]`; the private map is deleted.

## Proven a pure refactor — not asserted

"The two maps already agree, so nothing renders differently" is the kind of claim that is usually just restated from reading the literals side by side. It was **measured** instead, before the change:

A throwaway harness parsed the `RECENT_ACTION_ICONS` literal out of the source, resolved each identifier against the real `@tabler/icons-react` exports, and compared **by reference** against `ACTION_GLYPH_ICONS` under the intended mapping.

| check | result |
|---|---|
| parser control — keys extracted | exactly `open`, `view`, `visit`; `IconEye !== IconInfoCircle` (so a reference comparison *can* discriminate) |
| **positive control** — source mutated to `view: IconInfoCircle` | reported **1** disagreement (`['view']`) |
| **the measurement** — real source | **0** disagreements |

The positive control is what makes the zero meaningful: without a run that produced a non-zero count through the same code path, "0 disagreements" is indistinguishable from a harness wired to nothing.

Resolved pairs: `open → IconPlayerPlay`, `visit → IconExternalLink`, `view → IconEye` — byte-same components `ACTION_GLYPH_ICONS` reaches via `launch` / `external` / `view`. **Zero rendered change.**

## The absent `default` is the enforcement, not style

`recentRailActionGlyph` is an exhaustive `switch` with no `default` and a return type that forbids `undefined`. Measured, both directions:

| mutation | Typecheck |
|---|---|
| drop the `view` arm | **RED** — `TS2366: Function lacks ending return statement and return type does not include 'undefined'` at `appListingActionGlyph.ts(157,66)` |
| drop the `view` arm **and add `default: return 'info'`** | **GREEN** — 0 errors |

The second row is the point: a `default` arm makes the identical missing-arm bug compile clean, and the rail would render `IconInfoCircle` for `view` in production. Since `Typecheck` is one of only two merge-blocking gates here, the absent default is the only thing that turns a newly added `RecentRailAction` into a build failure rather than a silent mis-glyph. Same reasoning forbids a `?? fallback` at the call site.

## Also: a load-bearing false comment corrected

`recentAppsRail.ts` justified the `canOpenPage` gate in `selectChromeRecentApps` by claiming **both** writers feeding the app-chrome menu record on-site `{hasPage:true}` entries flag-blind, naming the detail page's "Open live" CTA and `MarketplaceBody.recordRecent`.

That is false for the second. `MarketplaceBody.recordRecent` writes `{id, blockId, name, iconUrl}` — **neither `hasPage` nor `kind`**. Verified against the source; also consistent with real persisted data, where 7 of 8 stored recents carry only `{name, blockId}`.

The correction also records something the original obscured: the filter reads `kind` and `blockId` and **never** `hasPage`. So `MarketplaceBody` entries are admitted by *absence* (`undefined !== 'offsite'` is true), carrying no page evidence at all — which makes them the strongest case for the gate, not an exception to it. The new comment warns against "tightening" it with a `hasPage` test, which would silently drop every legacy entry.

**Comment only — the gate's behaviour is untouched.**

## Coverage — classified honestly

New: `src/components/Apps/__tests__/recent-rail-glyph-single-source.test.ts` (9 tests), modelled on the existing `marketplace-category-icons-single-source.test.ts`.

For a pure refactor most coverage legitimately *is* invariant guards, and they are labelled as such in the file rather than dressed up as regression coverage:

- **6 invariant guards** — value pins, distinctness, cross-surface agreement, and the "renders the icon it shipped with" identity pins. These passed **before** the change too. They exist to fail on a *future* remap; they are not evidence this change was correct.
- **2 genuine regression guards** (structural) — assert `RecentlyOpenedApps.tsx` no longer declares `RECENT_ACTION_ICONS` and does resolve through the shared module. These fail on the pre-change source.
- **1 enforcement guard** — asserts `recentRailActionGlyph`'s body contains no `default:` and no `??`.

Mutation results, each confirmed to fail for *that* guard's own reason:

| mutation | outcome |
|---|---|
| drop the `view` arm | Typecheck RED, TS2366 |
| add a `default` arm | 4/9 unit tests fail, incl. the no-`default` guard failing on `not to match /\bdefault:/` |
| reintroduce the private map | both structural guards fail, on their own matchers |
| re-add a raw `@tabler/icons-react` import only | that single assertion fails in isolation |

## CI

**Blocking:** `event-engine-common pin`, `Typecheck`, `ESLint + Prettier (added files)`.
**Not blocking:** `Unit tests` (`continue-on-error: true`, `lint.yml`), `ESLint/Prettier (modified files)`, and the whole `preview / component-tests` project.

Local results (repo's own runner, pinned Node 22, submodule initialised):

| gate | result |
|---|---|
| Typecheck | RC=0, 0 `error TS` |
| ESLint (5 touched files) | RC=0 |
| Prettier (5 touched files) | 0 different |
| Unit project (full) | **751/751 files, 10848 passed, 1 skipped** |
| Unit — `Apps/__tests__/` | 43 files, 718 passed |
| Browser — `AppBlockChrome.browser.test.tsx` | **21/21 passed** |
| Browser — `RecentlyOpenedApps.browser.test.tsx` | 18/18 passed |
| Browser — `RecentlyOpenedApps.reducedMotion.browser.test.tsx` (alone) | 5/5 passed |

### `preview / component-tests` — read off this PR's own run

**Result on this PR: `fail` (report-only) — 1 failed / 1193, 117 of 118 files passing.** The single failure is `AppListingDetailBody.browser.test.tsx > the "Browse all apps" link is present even when the rail is empty` — a file this PR does not touch.

Not caused by this branch, established from other PRs' runs rather than argued:

| preview run | component-tests |
|---|---|
| #3552 | 3 failed — `AppBlockChrome` + **2× `AppListingDetailBody`** |
| #3553 | **0 failed** (117/117) |
| #3554 | 2 failed — **2× `AppListingDetailBody`** |
| **#3555 (this PR)** | 1 failed — **1× `AppListingDetailBody`** |

`AppBlockChrome.browser.test.tsx` — the failure that had been red repo-wide — is **fixed**: absent from #3554 and #3555, and green locally (21/21). #3553 did address it.

The `AppListingDetailBody` failures are **pre-existing and intermittent**: present on #3552 and #3554 (neither touches these files), absent on #3553, and the file passes 19/19 locally on this branch. Different subsets fail run to run, which is the signature of a flake rather than a real break. Worth a follow-up on its own.

**A local measurement I am retracting rather than leaving in:** on this NixOS host the component project cannot launch its bundled Chromium, so I ran it against a nixpkgs Chromium (rev 1228) shimmed under the expected 1200 name. In *that* environment, `RecentlyOpenedApps.browser.test.tsx` + `RecentlyOpenedApps.reducedMotion.browser.test.tsx` run together made the second fail to import — and a clean-HEAD control reproduced it identically, so it was correctly attributed as not-mine. But **CI ran both files fine** (they are among the 117 passing). So that failure is an artifact of the mismatched local Chromium, not a property of the repo. The CI run above is the authority.

## Not touched

The CSS-module-import ban in `RecentlyOpenedApps.tsx`, the `type`/`renderRoot` block, `AppListingsMarketplaceBody.tsx`, and the recents store.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
