### PR TITLE
fix(app-blocks): make a dark-flag analytics response distinguishable from a genuine zero

### DIFF
--- a/src/components/AppBlocks/AppAnalyticsPanel.browser.test.tsx
+++ b/src/components/AppBlocks/AppAnalyticsPanel.browser.test.tsx
@@ -46,9 +46,7 @@ describe('AppAnalyticsPanel — unavailable vs genuine zero', () => {
     renderWithProviders(<AppAnalyticsPanel scopedAppBlockId="apb_1" />);
 
     await expect.element(page.getByText('Analytics unavailable')).toBeInTheDocument();
-    await expect
-      .element(page.getByText(/not a report of zero activity/i))
-      .toBeInTheDocument();
+    await expect.element(page.getByText(/not a report of zero activity/i)).toBeInTheDocument();
     // The fabricated dashboard must be gone entirely.
     expect(page.getByText('Active installs').elements()).toHaveLength(0);
     expect(page.getByText('Runs (range)').elements()).toHaveLength(0);

--- a/src/components/AppBlocks/AppAnalyticsPanel.browser.test.tsx
+++ b/src/components/AppBlocks/AppAnalyticsPanel.browser.test.tsx
@@ -1,0 +1,78 @@
+import { describe, expect, test, vi } from 'vitest';
+import { page } from 'vitest/browser';
+// `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
+import { renderWithProviders } from '../../../test/component-setup';
+import type * as TrpcModule from '~/utils/trpc';
+
+/**
+ * The panel must never render a dashboard out of counters that were never
+ * measured. `getMyAppAnalytics` returns all-zero counters both for a real app
+ * with no activity and for a caller who was never allowed to query (dark
+ * `appBlocks` flag) — only `unavailable` separates them, and rendering the
+ * former shape for the latter fabricates a clean zero dashboard.
+ */
+
+const mocks = vi.hoisted(() => ({ analytics: { current: undefined as unknown } }));
+
+vi.mock('~/utils/trpc', async (importOriginal) => ({
+  ...(await importOriginal<typeof TrpcModule>()),
+  trpc: {
+    blocks: {
+      getMyApps: { useQuery: () => ({ data: [], isLoading: false }) },
+      getMyAppAnalytics: {
+        useQuery: () => ({ data: mocks.analytics.current, isLoading: false, error: null }),
+      },
+    },
+  },
+}));
+
+// Chart.js needs a real canvas + sizing; the series rendering isn't under test.
+vi.mock('react-chartjs-2', () => ({ Line: () => <div data-testid="chart" /> }));
+
+const { AppAnalyticsPanel } = await import('./AppAnalyticsPanel');
+
+const ZEROED = {
+  range: { from: new Date(0), to: new Date(0), granularity: 'day' as const },
+  notOwned: false,
+  installs: { total: 0, active: 0, series: [] },
+  runs: { count: 0, buzzSpent: 0, series: [] },
+  buzzPurchased: { count: 0, buzzAmount: 0, grossCents: 0 },
+  engagement: { apiCalls: 0, activeUsers: 0, errorRate: 0, topScopes: [], topEndpoints: [] },
+};
+
+describe('AppAnalyticsPanel — unavailable vs genuine zero', () => {
+  test('dark flag (notEntitled): shows an honest unavailable state, NOT a zero dashboard', async () => {
+    mocks.analytics.current = { ...ZEROED, notOwned: true, unavailable: 'notEntitled' };
+    renderWithProviders(<AppAnalyticsPanel scopedAppBlockId="apb_1" />);
+
+    await expect.element(page.getByText('Analytics unavailable')).toBeInTheDocument();
+    await expect
+      .element(page.getByText(/not a report of zero activity/i))
+      .toBeInTheDocument();
+    // The fabricated dashboard must be gone entirely.
+    expect(page.getByText('Active installs').elements()).toHaveLength(0);
+    expect(page.getByText('Runs (range)').elements()).toHaveLength(0);
+  });
+
+  test('notOwned: shows the ownership message rather than zeroed metrics', async () => {
+    mocks.analytics.current = { ...ZEROED, notOwned: true, unavailable: 'notOwned' };
+    renderWithProviders(<AppAnalyticsPanel scopedAppBlockId="apb_1" />);
+
+    await expect.element(page.getByText('Analytics unavailable')).toBeInTheDocument();
+    await expect.element(page.getByText(/do not own this app/i)).toBeInTheDocument();
+    expect(page.getByText('Active installs').elements()).toHaveLength(0);
+  });
+
+  test('DISCRIMINATOR: a genuine owned-but-empty result still renders the real dashboard', async () => {
+    // Byte-identical counters to the two cases above — only `unavailable` is
+    // absent. If a later change flags this path too, the author loses a
+    // dashboard they are entitled to; if it stops flagging the others, the
+    // fabricated zero comes back.
+    mocks.analytics.current = { ...ZEROED };
+    renderWithProviders(<AppAnalyticsPanel scopedAppBlockId="apb_1" />);
+
+    await expect.element(page.getByText('Active installs')).toBeInTheDocument();
+    await expect.element(page.getByText('Runs (range)')).toBeInTheDocument();
+    expect(page.getByText('Analytics unavailable').elements()).toHaveLength(0);
+  });
+});

--- a/src/components/AppBlocks/AppAnalyticsPanel.tsx
+++ b/src/components/AppBlocks/AppAnalyticsPanel.tsx
@@ -36,6 +36,7 @@ type TimePoint = { bucket: string; value: number };
 type AnalyticsData = {
   range: { from: string | Date; to: string | Date; granularity: 'day' | 'week' };
   notOwned: boolean;
+  unavailable?: 'notEntitled' | 'notOwned';
   installs: { total: number; active: number; series: TimePoint[] };
   runs: { count: number; buzzSpent: number; series: TimePoint[] };
   buzzPurchased: { count: number; buzzAmount: number; grossCents: number };
@@ -184,6 +185,7 @@ export function AppAnalyticsPanel({ scopedAppBlockId }: { scopedAppBlockId?: str
     appBlockId: appBlockId ?? undefined,
   });
   const analytics = analyticsRaw as AnalyticsData | undefined;
+  const unavailable = analytics?.unavailable;
 
   const appOptions = [
     { value: '', label: 'All my apps' },
@@ -207,7 +209,7 @@ export function AppAnalyticsPanel({ scopedAppBlockId }: { scopedAppBlockId?: str
             comboboxProps={{ withinPortal: true }}
           />
         )}
-        {analytics && (
+        {analytics && !unavailable && (
           <Text size="xs" c="dimmed">
             {dayjs(analytics.range.from).format('MMM D, YYYY')} –{' '}
             {dayjs(analytics.range.to).format('MMM D, YYYY')} ({analytics.range.granularity})
@@ -226,7 +228,22 @@ export function AppAnalyticsPanel({ scopedAppBlockId }: { scopedAppBlockId?: str
         </Text>
       )}
 
-      {analytics && (
+      {unavailable && (
+        <Alert
+          variant="light"
+          color="yellow"
+          icon={<IconInfoCircle size={16} />}
+          title="Analytics unavailable"
+        >
+          <Text size="sm">
+            {unavailable === 'notEntitled'
+              ? 'Your account does not have access to app analytics yet. No metrics were measured for this app — this is not a report of zero activity.'
+              : 'You do not own this app, so its analytics are not available to you. No metrics were measured — this is not a report of zero activity.'}
+          </Text>
+        </Alert>
+      )}
+
+      {analytics && !unavailable && (
         <>
           <SimpleGrid cols={{ base: 1, sm: 2, lg: 4 }} spacing="md">
             <MetricCard

--- a/src/components/Apps/AppAnalyticsInline.browser.test.tsx
+++ b/src/components/Apps/AppAnalyticsInline.browser.test.tsx
@@ -1,0 +1,57 @@
+import { describe, expect, test, vi } from 'vitest';
+import { page } from 'vitest/browser';
+// `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
+import { renderWithProviders } from '../../../test/component-setup';
+import type * as TrpcModule from '~/utils/trpc';
+
+/**
+ * The inline stat read `runs.count` / `engagement.activeUsers` straight off the
+ * payload, so a never-measured (dark-flag) response rendered a confident
+ * "0 runs · 0 users" on every approved app row. It must show the counters only
+ * when they are an actual measurement.
+ */
+
+const mocks = vi.hoisted(() => ({ analytics: { current: undefined as unknown } }));
+
+vi.mock('~/utils/trpc', async (importOriginal) => ({
+  ...(await importOriginal<typeof TrpcModule>()),
+  trpc: {
+    blocks: {
+      getMyAppAnalytics: {
+        useQuery: () => ({ data: mocks.analytics.current, isLoading: false, error: null }),
+      },
+    },
+  },
+}));
+
+vi.mock('~/components/AppBlocks/AppAnalyticsPanel', () => ({
+  AppAnalyticsPanel: () => <div data-testid="analytics-panel" />,
+}));
+
+const { AppAnalyticsInline } = await import('./AppAnalyticsInline');
+
+describe('AppAnalyticsInline — unavailable vs genuine zero', () => {
+  test('dark flag: renders "Analytics unavailable", never a fabricated 0 runs / 0 users', async () => {
+    mocks.analytics.current = {
+      runs: { count: 0 },
+      engagement: { activeUsers: 0 },
+      unavailable: 'notEntitled',
+    };
+    renderWithProviders(<AppAnalyticsInline appBlockId="apb_1" appLabel="My App" />);
+
+    await expect.element(page.getByText('Analytics unavailable')).toBeInTheDocument();
+    expect(page.getByText('runs').elements()).toHaveLength(0);
+    expect(page.getByText('users').elements()).toHaveLength(0);
+  });
+
+  test('DISCRIMINATOR: a genuine measured zero still renders the 0 runs / 0 users stat', async () => {
+    // Identical counters to the case above — only `unavailable` differs. A real
+    // app with no activity yet must keep showing its (accurate) zeros.
+    mocks.analytics.current = { runs: { count: 0 }, engagement: { activeUsers: 0 } };
+    renderWithProviders(<AppAnalyticsInline appBlockId="apb_1" appLabel="My App" />);
+
+    await expect.element(page.getByText('runs')).toBeInTheDocument();
+    await expect.element(page.getByText('users')).toBeInTheDocument();
+    expect(page.getByText('Analytics unavailable').elements()).toHaveLength(0);
+  });
+});

--- a/src/components/Apps/AppAnalyticsInline.tsx
+++ b/src/components/Apps/AppAnalyticsInline.tsx
@@ -11,6 +11,7 @@ import { trpc } from '~/utils/trpc';
 type InlineAnalytics = {
   runs: { count: number };
   engagement: { activeUsers: number };
+  unavailable?: 'notEntitled' | 'notOwned';
 };
 
 /**
@@ -51,6 +52,21 @@ export function AppAnalyticsInline({
     <Group gap={8} wrap="nowrap" align="center">
       {statQuery.isLoading ? (
         <Loader size="xs" />
+      ) : data?.unavailable ? (
+        <Tooltip
+          label={
+            data.unavailable === 'notEntitled'
+              ? 'Your account does not have access to app analytics yet — these metrics were not measured.'
+              : 'You do not own this app — its analytics were not measured.'
+          }
+          multiline
+          maw={260}
+          withinPortal
+        >
+          <Text size="xs" c="dimmed">
+            Analytics unavailable
+          </Text>
+        </Tooltip>
       ) : data ? (
         <Tooltip
           label="Runs and unique users in the last 30 days. Anonymous / no-scope runs are undercounted until render-event tracking ships."

--- a/src/server/routers/__tests__/blocks.router.getMyAppAnalytics.test.ts
+++ b/src/server/routers/__tests__/blocks.router.getMyAppAnalytics.test.ts
@@ -56,9 +56,14 @@ vi.mock('~/server/services/blocks/app-analytics.service', () => ({
   getMyAppAnalytics: (...a: unknown[]) => mockGetMyAppAnalytics(...a),
   // emptyAnalytics + resolveRange are pure (no DB) — use the real ones so the
   // flag-off short-circuit returns the genuine zeroed shape.
-  emptyAnalytics: (range: unknown, notOwned: boolean) => ({
+  emptyAnalytics: (
+    range: unknown,
+    notOwned: boolean,
+    unavailable: string | undefined = notOwned ? 'notOwned' : undefined
+  ) => ({
     range,
     notOwned,
+    ...(unavailable ? { unavailable } : {}),
     installs: { total: 0, active: 0, series: [] },
     runs: { count: 0, buzzSpent: 0, series: [] },
     buzzPurchased: { count: 0, buzzAmount: 0, grossCents: 0 },
@@ -209,11 +214,59 @@ describe('getMyAppAnalytics — gate', () => {
     mockIsAppBlocksEnabled.mockResolvedValue(false);
     const caller = blocksRouter.createCaller(fakeCtx(modUser) as never);
     const result = await caller.getMyAppAnalytics({ appBlockId: 'apb_1' });
-    expect(result.notOwned).toBe(false);
     expect(result.installs).toEqual({ total: 0, active: 0, series: [] });
     expect(result.runs).toEqual({ count: 0, buzzSpent: 0, series: [] });
     expect(result.buzzPurchased).toEqual({ count: 0, buzzAmount: 0, grossCents: 0 });
     expect(mockGetMyAppAnalytics).not.toHaveBeenCalled();
+  });
+
+  it('flag OFF: the zeroed payload is FLAGGED unavailable, not passed off as data', async () => {
+    mockIsAppBlocksEnabled.mockResolvedValue(false);
+    const caller = blocksRouter.createCaller(fakeCtx(modUser) as never);
+    const result = await caller.getMyAppAnalytics({ appBlockId: 'apb_1' });
+    expect(result.unavailable).toBe('notEntitled');
+    // Fail-closed on the legacy field too: a client that only guards on
+    // `notOwned` (civitai/cli#190) must refuse to render this payload.
+    expect(result.notOwned).toBe(true);
+  });
+
+  it('DISCRIMINATOR: a dark-flag zero is distinguishable from a genuine owned-but-empty zero', async () => {
+    // Both payloads have byte-identical all-zero counters and the same range —
+    // that is exactly the confusion this proc used to ship. The ONLY thing a
+    // client can branch on is the discriminator, so pin it from both sides.
+    const range = { from: new Date(0), to: new Date(0), granularity: 'day' as const };
+    const genuineZero = {
+      range,
+      notOwned: false,
+      installs: { total: 0, active: 0, series: [] },
+      runs: { count: 0, buzzSpent: 0, series: [] },
+      buzzPurchased: { count: 0, buzzAmount: 0, grossCents: 0 },
+      engagement: { apiCalls: 0, activeUsers: 0, errorRate: 0, topScopes: [], topEndpoints: [] },
+    };
+    mockGetMyAppAnalytics.mockResolvedValue(genuineZero);
+
+    const owned = await blocksRouter
+      .createCaller(fakeCtx(modUser) as never)
+      .getMyAppAnalytics({ appBlockId: 'apb_1' });
+
+    mockIsAppBlocksEnabled.mockResolvedValue(false);
+    const dark = await blocksRouter
+      .createCaller(fakeCtx(modUser) as never)
+      .getMyAppAnalytics({ appBlockId: 'apb_1' });
+
+    // Precondition: the counters really are identical, so nothing else could
+    // tell these apart.
+    expect(dark.installs).toEqual(owned.installs);
+    expect(dark.runs).toEqual(owned.runs);
+    expect(dark.buzzPurchased).toEqual(owned.buzzPurchased);
+    expect(dark.engagement).toEqual(owned.engagement);
+
+    // A genuinely-measured empty app is NOT flagged; the dark-flag one is.
+    expect(owned.unavailable).toBeUndefined();
+    expect(dark.unavailable).toBe('notEntitled');
+    expect(owned.notOwned).toBe(false);
+    expect(dark.notOwned).toBe(true);
+    expect(dark).not.toEqual(owned);
   });
 });
 

--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -5159,10 +5159,12 @@ export const blocksRouter = router({
       const from = input.from ? new Date(input.from) : undefined;
       const to = input.to ? new Date(input.to) : undefined;
       // Dark-flag fail-closed: while the appBlocks flag is off the middleware
-      // marks the ctx → return the zeroed analytics shape (with the resolved
-      // range, so the UI still has a window) WITHOUT running any aggregate.
+      // marks the ctx → return the zeroed shape WITHOUT running any aggregate.
+      // It MUST carry `unavailable` (and the fail-closed `notOwned`) or the
+      // all-zero counters are indistinguishable from a real app with no
+      // activity, and clients render fabricated zeros as a measurement.
       if ((ctx as { _appBlocksDisabled?: boolean })._appBlocksDisabled) {
-        return emptyAnalytics(resolveRange({ from, to }), false);
+        return emptyAnalytics(resolveRange({ from, to }), true, 'notEntitled');
       }
       const user = ctx.user as SessionUser;
       return getMyAppAnalytics({

--- a/src/server/services/blocks/__tests__/app-analytics.service.test.ts
+++ b/src/server/services/blocks/__tests__/app-analytics.service.test.ts
@@ -43,6 +43,7 @@ vi.mock('@prisma/client', () => ({
 import {
   DEFAULT_RANGE_DAYS,
   MAX_RANGE_DAYS,
+  emptyAnalytics,
   getMyAppAnalytics,
   getOwnedAppBlockIds,
   resolveRange,
@@ -235,5 +236,63 @@ describe('getMyAppAnalytics (ownership enforcement)', () => {
     expect(result.notOwned).toBe(false);
     expect(result.installs.total).toBe(0);
     expect(mockDbRead.blockSpendAttribution.aggregate).not.toHaveBeenCalled();
+  });
+});
+
+describe('emptyAnalytics (measurement vs placeholder discriminator)', () => {
+  const range = { from: new Date(0), to: new Date(0), granularity: 'day' as const };
+
+  it('flags a non-owned placeholder', () => {
+    expect(emptyAnalytics(range, true).unavailable).toBe('notOwned');
+  });
+
+  it('flags an explicit not-entitled placeholder (the dark-flag caller)', () => {
+    expect(emptyAnalytics(range, false, 'notEntitled').unavailable).toBe('notEntitled');
+  });
+
+  it('leaves a genuine zero UNflagged', () => {
+    expect(emptyAnalytics(range, false).unavailable).toBeUndefined();
+    expect('unavailable' in emptyAnalytics(range, false)).toBe(false);
+  });
+});
+
+describe('getMyAppAnalytics (fabricated-zero discriminator)', () => {
+  it('a non-owned id is flagged unavailable; a measured empty app is not', async () => {
+    const notOwned = await getMyAppAnalytics({ userId: OWNER_ID, appBlockId: FOREIGN_ID });
+    expect(notOwned.unavailable).toBe('notOwned');
+
+    // Owned app, every aggregate legitimately returns zero — a REAL measurement
+    // of "no activity yet". It must stay unflagged, otherwise the UI hides a
+    // dashboard the author is entitled to see.
+    // mockReset first: the beforeEach queues `mockResolvedValueOnce` values that
+    // the short-circuiting notOwned call above never consumed, and a queued
+    // Once wins over mockResolvedValue.
+    mockDbRead.blockUserSubscription.count.mockReset();
+    mockDbRead.blockUserSubscription.count.mockResolvedValue(0);
+    mockDbRead.blockSpendAttribution.aggregate.mockReset();
+    mockDbRead.blockSpendAttribution.aggregate.mockResolvedValue({
+      _count: 0,
+      _sum: { buzzAmount: null },
+    });
+    mockDbRead.blockBuzzAttribution.aggregate.mockReset();
+    mockDbRead.blockBuzzAttribution.aggregate.mockResolvedValue({
+      _count: 0,
+      _sum: { buzzAmount: null, usdAmountCents: null },
+    });
+    mockDbRead.blockScopeInvocation.count.mockReset();
+    mockDbRead.blockScopeInvocation.count.mockResolvedValue(0);
+    mockDbRead.blockScopeInvocation.groupBy.mockReset();
+    mockDbRead.blockScopeInvocation.groupBy.mockResolvedValue([]);
+    mockDbRead.$queryRaw.mockReset();
+    mockDbRead.$queryRaw.mockResolvedValue([]);
+
+    const measured = await getMyAppAnalytics({ userId: OWNER_ID, appBlockId: OWNED_ID });
+    expect(measured.unavailable).toBeUndefined();
+    expect(measured.notOwned).toBe(false);
+
+    // Same all-zero counters on both sides — the discriminator is the only signal.
+    expect(measured.installs).toEqual(notOwned.installs);
+    expect(measured.runs).toEqual(notOwned.runs);
+    expect(measured.engagement).toEqual(notOwned.engagement);
   });
 });

--- a/src/server/services/blocks/app-analytics.service.ts
+++ b/src/server/services/blocks/app-analytics.service.ts
@@ -37,6 +37,15 @@ export type AppAnalytics = {
   range: { from: Date; to: Date; granularity: 'day' | 'week' };
   /** True when the caller does not own `appBlockId` — all metrics are zeroed. */
   notOwned: boolean;
+  /**
+   * Present ONLY when the zeroed counters are a placeholder rather than a
+   * measurement: `notEntitled` (the appBlocks flag is off for this caller, so
+   * nothing was queried) or `notOwned`. A genuinely-measured result omits it
+   * even when every counter is 0 — without this a real "no activity yet" app
+   * and a never-queried one are byte-identical, and a client renders fabricated
+   * zeros as data.
+   */
+  unavailable?: 'notEntitled' | 'notOwned';
   installs: {
     /** All-time installs for this app (subscription rows ever created). */
     total: number;
@@ -83,10 +92,15 @@ export type AppAnalytics = {
   };
 };
 
-export function emptyAnalytics(range: AppAnalytics['range'], notOwned: boolean): AppAnalytics {
+export function emptyAnalytics(
+  range: AppAnalytics['range'],
+  notOwned: boolean,
+  unavailable: AppAnalytics['unavailable'] = notOwned ? 'notOwned' : undefined
+): AppAnalytics {
   return {
     range,
     notOwned,
+    ...(unavailable ? { unavailable } : {}),
     installs: { total: 0, active: 0, series: [] },
     runs: { count: 0, buzzSpent: 0, series: [] },
     buzzPurchased: { count: 0, buzzAmount: 0, grossCents: 0 },


### PR DESCRIPTION
## The problem: a fabricated zero presented as a measurement

`getMyAppAnalytics` (`blocks.router.ts`) fails closed when the `appBlocks` flag is dark for the caller — it skips every aggregate and returns a zeroed payload. It did that with:

```ts
return emptyAnalytics(resolveRange({ from, to }), false);
```

`notOwned: false` + every counter at `0` is **byte-identical** to a legitimate *"you own this app and it genuinely has no activity yet"* response. There was nothing a client could branch on, so any consumer rendered a clean, plausible, **entirely fabricated** zero dashboard: 0 installs, 0 runs, 0 Buzz, 0 active users — presented as a real measurement of the author's app.

This is not a display nit. The numbers are wrong *and* indistinguishable from correct ones. `appBlocksAuthor` defaults to moderators only, so the affected population is exactly the beta app authors the feature targets.

## The fix

Add an explicit discriminator to the `AppAnalytics` payload:

```ts
unavailable?: 'notEntitled' | 'notOwned';
```

Present **only** when the zeros are a placeholder rather than a measurement. A genuinely-measured result omits it even when every counter is `0`.

The dark-flag branch now returns `emptyAnalytics(range, true, 'notEntitled')`.

### Why a discriminator rather than just `emptyAnalytics(range, true)`

The minimal one-word change (flip `notOwned` to `true`) was considered and is *included* — but it is not sufficient on its own, for a reason that only shows up when you read the consumers: **no consumer read `notOwned` at all.** `AppAnalyticsPanel` declared `notOwned: boolean` in its local type and never branched on it, so even the *pre-existing* non-owned case already rendered a zeroed dashboard. Flipping the flag alone would have changed nothing on screen.

So this PR does both:

- **`notOwned: true` on the dark-flag path** — every existing/planned guard that keys on `notOwned` starts working with **zero client changes**, fail-closed.
- **`unavailable` reason enum** — lets the UI say the *right* thing, because "the flag is off for you" and "you don't own this app" are genuinely different conditions and deserve different copy.

`emptyAnalytics` derives `unavailable` from `notOwned` by default (`notOwned ? 'notOwned' : undefined`), so the existing non-owned path is self-describing and the "caller owns nothing" path stays a genuine, unflagged zero — that one *is* a real measurement.

## Consumers checked

Every call site of `getMyAppAnalytics` (grep-verified):

| Consumer | Before | After |
|---|---|---|
| `src/components/AppBlocks/AppAnalyticsPanel.tsx` | Declared `notOwned`, **never branched on it** -> full zeroed dashboard | Renders an "Analytics unavailable" alert with reason-specific copy; metric grid, charts and range label suppressed |
| `src/components/Apps/AppAnalyticsInline.tsx` | Read `runs.count` / `engagement.activeUsers` straight off the payload -> confident **"0 runs · 0 users"** on every approved app row | Renders "Analytics unavailable" with an explanatory tooltip |

Both now state plainly that no metrics were measured — *"this is not a report of zero activity."*

## How the discriminating test works

The risk this fix must survive is someone later making the two paths identical again. So the tests pin **both sides**, and each asserts the counters really are identical first — proving nothing *else* could tell them apart — before asserting the discriminator differs:

- `blocks.router.getMyAppAnalytics.test.ts` -> *"DISCRIMINATOR: a dark-flag zero is distinguishable from a genuine owned-but-empty zero"*. Drives the real proc twice (flag on with a genuinely-empty service result, flag off), asserts `installs`/`runs`/`buzzPurchased`/`engagement` are deep-equal across both, then `owned.unavailable === undefined` vs `dark.unavailable === 'notEntitled'` and `expect(dark).not.toEqual(owned)`.
- `app-analytics.service.test.ts` -> same shape at the service layer for the non-owned vs measured-empty pair, plus direct `emptyAnalytics` cases.
- `AppAnalyticsPanel.browser.test.tsx` / `AppAnalyticsInline.browser.test.tsx` -> the rendering counterpart: identical zeroed payloads, one flagged and one not; the flagged one must **not** render the dashboard, the unflagged one **must**.

That last pairing matters in both directions — over-correcting (treating every zero as unavailable) would hide a dashboard an author is entitled to see, and the discriminator tests fail on that too.

### Mutation matrix

Every test was watched fail for its own specific reason, then restored:

| # | Mutation | Result |
|---|---|---|
| M1 | Revert router to `emptyAnalytics(range, false)` (the original bug) | 2 router tests red — `expected undefined to be 'notEntitled'` |
| M2 | `emptyAnalytics` flags the genuine zero too | *"leaves a genuine zero UNflagged"* red — `expected 'notOwned' to be undefined` |
| M2b | Measured path sets `unavailable` | service discriminator red — `expected 'notEntitled' to be undefined` (proves the assertion is reachable, not vacuous) |
| M3 | Drop the panel's `!unavailable` guard | 2 panel tests red on the metric-card assertions; discriminator stayed green (correct) |
| M4 | Panel treats every result as unavailable | **only** the panel discriminator red |
| M5 | Drop the inline `unavailable` branch | **only** the inline dark-flag test red; discriminator stayed green |

## Gate

- `pnpm typecheck` — clean
- `pnpm test:unit` — **751 files, 10848 passed, 1 skipped, 0 failed**; no timeout panics
- component project (the two new files run alongside `MySubmissionsList.browser`) — **3 files, 44 passed**
- `pnpm lint` — repo-wide 400 errors / 3580 warnings, **all pre-existing**. My 8 touched files contribute **0 new errors**; the one error reported inside a file I edited (`blocks.router.getMyAppAnalytics.test.ts:115`) is byte-identical to line 110 on `main`, only shifted by my additions, and the two `blocks.router.ts` errors (5125, 7231) sit outside my only hunk (5192–5197).

## Notes

- **civitai/cli#190 depends on this signal.** The new `civitai app metrics <slug>` command guards on `notOwned` to refuse rendering a fake dashboard; this branch defeated that guard completely. Setting `notOwned: true` here makes that guard work with no CLI change, and `unavailable` gives it a precise reason to print.
- **`AppsSubNav.tsx:72-79` left alone.** That entitlement mismatch (a non-mod owner sees a Revenue tab and gets 404'd by the page) is documented as intentional — the tab is an ownership affordance, the page is the access boundary. It is about tab visibility, not the analytics payload, so this fix does not address it and I did not expand scope into it.
- Rebased onto `ed6e17ac7d` (#3556) rather than the older `a6e6f4c76c`. That commit — "await the async `cleanup()` in the component-setup afterEach" — turned out to be the real cause of a cross-file hang I hit between the two new browser tests. My first diagnosis (shared module registry) was wrong; with #3556 in the base the files pass together unchanged, so the workaround and its incorrect comment were removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
