### PR TITLE
feat(app-blocks): launch-latency instrumentation on the existing render beacon

### DIFF
--- a/src/components/AppBlocks/PageBlockHost.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHost.browser.test.tsx
@@ -833,11 +833,24 @@ describe('PageBlockHost block render/impression (Analytics Phase 2)', () => {
     // keepalive so the beacon survives a page unload/navigation.
     expect((init as RequestInit | undefined)?.keepalive).toBe(true);
     const body = JSON.parse(String((init as RequestInit).body));
-    expect(body).toEqual({
+    expect(body).toMatchObject({
       appBlockId: 'apb_test',
       blockInstanceId: 'page_apb_test',
       slotId: 'app.page',
     });
+    // 🔴 LAUNCH TIMINGS RIDE THIS BEACON — there is still exactly ONE beacon and
+    // the `ok` path still carries no `status`. The allowed key set is pinned so a
+    // future field cannot be added to the wire unnoticed.
+    expect(Object.keys(body).sort()).toEqual(
+      ['appBlockId', 'blockInstanceId', 'slotId', 'timings'].sort()
+    );
+    expect(typeof body.timings.totalMs).toBe('number');
+    expect(body.timings.totalMs).toBeGreaterThan(0);
+    // Never a zero-valued leg on the wire — an unobserved leg is OMITTED.
+    for (const [k, v] of Object.entries(body.timings)) {
+      expect(typeof v, `timings.${k}`).toBe('number');
+      expect(v, `timings.${k}`).toBeGreaterThan(0);
+    }
     // No isAnon/userId from the client — those are server-derived in the route.
     expect(body).not.toHaveProperty('isAnon');
     expect(body).not.toHaveProperty('userId');

--- a/src/components/AppBlocks/PageBlockHost.tsx
+++ b/src/components/AppBlocks/PageBlockHost.tsx
@@ -35,6 +35,15 @@ import type { BlockImageScanResult } from './blockImageScanLogic';
 import { projectBlockInitMaturity } from './projectBlockInit';
 import { sendBlockRender } from './sendBlockRender';
 import {
+  computeLaunchTimings,
+  createLaunchMarks,
+  isDocumentHidden,
+  nowMs,
+  readIframeResourceTiming,
+  resetLaunchMarks,
+  type LaunchMarks,
+} from './launchTimings';
+import {
   classifyWildcardPackError,
   exceedsPreDownloadCap,
   resolveGetWildcardPackRequest,
@@ -410,6 +419,23 @@ export function PageBlockHost({
   // that ever launched has launched).
   const reachedReadyRef = useRef<boolean>(false);
 
+  // ── LAUNCH LATENCY marks ────────────────────────────────────────────────────
+  // Four `performance.now()` stamps + a sticky hidden-tab flag. All the math
+  // (and every correctness rule) lives in the pure, node-tested `launchTimings`
+  // module; the host only records.
+  //
+  // 🔴 t0 IS THE FIRST CLIENT RENDER, not a mount effect. The `<iframe src>` is
+  // an SSR prop rendered inside `showIframe` (true while status === 'loading',
+  // which is the INITIAL status), so the cross-origin frame load starts in this
+  // very commit — before any token exists. A t0 taken in a post-mount effect
+  // would start the clock after the thing it is timing. The lazy-ref pattern
+  // below is the React-blessed way to do once-per-instance work at render time,
+  // and it is SSR-safe (`performance` is undefined there → `mountedAt: null` →
+  // `computeLaunchTimings` returns null and nothing is reported).
+  const launchMarksRef = useRef<LaunchMarks | null>(null);
+  if (launchMarksRef.current === null)
+    launchMarksRef.current = createLaunchMarks(nowMs(), isDocumentHidden());
+
   // 🔴 BOTH REFS ABOVE ARE PER-MOUNT, BUT THIS HOST IS NOT ALWAYS REMOUNTED.
   //
   // `/apps/run/[slug]/[[...path]]` renders <PageBlockHost> with NO `key`, and
@@ -460,7 +486,42 @@ export function PageBlockHost({
   useEffect(() => {
     reachedReadyRef.current = false;
     midSessionLossEmittedRef.current = false;
+    // Same reasoning for the launch marks: under host reuse app A's `mountedAt`
+    // would be attributed to app B's launch, producing a `total` that includes
+    // however long the user spent in app A. (Today app B can never earn a
+    // genuine `ready` after a soft nav — `shouldStartInit` refuses a non-'loading'
+    // status — so this is belt-and-braces against the pre-existing host-reuse
+    // bug being fixed later, not a live defect.)
+    if (launchMarksRef.current) resetLaunchMarks(launchMarksRef.current, nowMs(), isDocumentHidden());
   }, [blockInstanceId]);
+
+  // 🔴 HIDDEN-TAB LATCH — sticky from mount until the beacon reads it.
+  //
+  // A run page opened in a background tab (cmd-click, session restore, a tab
+  // group reopened) gets throttled timers and reports a BLOCK_READY seconds late
+  // at ZERO user-felt cost. Without this the p95 measures tab-switching.
+  //
+  // Deliberately NOT the existing visibilitychange listener further down: that
+  // one is gated on `status === 'ready'`, i.e. it starts listening only AFTER
+  // the launch window it would need to observe has closed. This one is
+  // unconditional and mount-scoped.
+  useEffect(() => {
+    const marks = launchMarksRef.current;
+    if (!marks) return;
+    const handler = () => {
+      if (isDocumentHidden()) marks.wasHidden = true;
+    };
+    document.addEventListener('visibilitychange', handler);
+    return () => document.removeEventListener('visibilitychange', handler);
+  }, []);
+
+  // Launch mark: the END of the token-mint leg (first non-null token). The leg
+  // races the frame load; it does not precede it.
+  useEffect(() => {
+    const marks = launchMarksRef.current;
+    if (!marks || !token || marks.tokenAt !== null) return;
+    marks.tokenAt = nowMs();
+  }, [token]);
 
   // Keep statusRef tracking the live status so handleRetry can branch on the
   // prior terminal state without reading it inside the setStatus updater.
@@ -628,6 +689,11 @@ export function PageBlockHost({
 
   const sendInitOnce = useCallback(() => {
     initSentRef.current = true;
+    // Launch mark: the FIRST BLOCK_INIT post. The controller re-posts every
+    // INIT_RETRY_INTERVAL_MS until acked, so only the first stamp is kept —
+    // `init_wait` is meant to include the re-post quantization, not exclude it.
+    const marks = launchMarksRef.current;
+    if (marks && marks.initSentAt === null) marks.initSentAt = nowMs();
     send('BLOCK_INIT', (buildInitPayloadRef.current ?? (() => undefined as never))());
   }, [send]);
 
@@ -772,6 +838,12 @@ export function PageBlockHost({
   // BLOCK_READY → ready.
   useEffect(() => {
     const off = onMessage<unknown>('BLOCK_READY', () => {
+      // Launch mark: stamped HERE, in the message handler, not in the beacon
+      // effect. The beacon fires on the committed `status`, which is a React
+      // commit later — timing it there would fold an arbitrary amount of React
+      // scheduling into every sample.
+      const marks = launchMarksRef.current;
+      if (marks && marks.readyAt === null) marks.readyAt = nowMs();
       setStatus((current) => (current === 'loading' ? 'ready' : current));
       // Block acked — stop re-posting BLOCK_INIT and cancel the readiness
       // timeout. Called UNCONDITIONALLY (not behind a "did this ack win the
@@ -804,13 +876,34 @@ export function PageBlockHost({
   // was reproduced deterministically the moment the launch-reveal work added one
   // more post-mount state update. Keying off the COMMITTED `status` is immune to
   // batching. Mirrors the failure-beacon effect immediately below.
+  //
+  // 🔴 LAUNCH TIMINGS RIDE THIS BEACON — no second beacon, no second call site,
+  // no second ClickHouse row. `blockRenderEmittedRef` is untouched, `secondary`
+  // is untouched, `error_class` is untouched, and the impression count is
+  // provably unchanged: this is the same one-per-mount emit it always was, with
+  // an optional field attached.
+  //
+  // `timings` is null (and omitted) whenever the sample must not be observed —
+  // a hidden tab, a missing mark, an out-of-range delta. The launch is still
+  // reported as an impression; only the latency observation is skipped. That is
+  // the right asymmetry: an under-counted histogram is honest, a histogram
+  // padded with zeros is not.
   useEffect(() => {
     if (status !== 'ready') return;
     if (blockRenderEmittedRef.current) return;
     blockRenderEmittedRef.current = true;
+    const marks = launchMarksRef.current;
+    const timings = marks
+      ? computeLaunchTimings(marks, readIframeResourceTiming(iframeSrc))
+      : null;
     // Fire-and-forget beacon — failures are a no-op.
-    sendBlockRender({ appBlockId, blockInstanceId, slotId: 'app.page' });
-  }, [status, appBlockId, blockInstanceId]);
+    sendBlockRender({
+      appBlockId,
+      blockInstanceId,
+      slotId: 'app.page',
+      ...(timings ? { timings } : {}),
+    });
+  }, [status, appBlockId, blockInstanceId, iframeSrc]);
 
   // BLOCK_ERROR{fatal:true} → fatal.
   useEffect(() => {

--- a/src/components/AppBlocks/PageBlockHost.tsx
+++ b/src/components/AppBlocks/PageBlockHost.tsx
@@ -39,8 +39,8 @@ import {
   createLaunchMarks,
   isDocumentHidden,
   nowMs,
-  readIframeResourceTiming,
   resetLaunchMarks,
+  shouldResetLaunchMarks,
   type LaunchMarks,
 } from './launchTimings';
 import {
@@ -435,6 +435,12 @@ export function PageBlockHost({
   const launchMarksRef = useRef<LaunchMarks | null>(null);
   if (launchMarksRef.current === null)
     launchMarksRef.current = createLaunchMarks(nowMs(), isDocumentHidden());
+  // Which instance the marks above currently describe. Seeded at RENDER time
+  // with the first `blockInstanceId`, so the `[blockInstanceId]` effect below can
+  // tell "first mount" (no reset — that would throw away the render-time t0)
+  // from "soft nav to another app" (reset).
+  const launchInstanceRef = useRef<string | null>(null);
+  if (launchInstanceRef.current === null) launchInstanceRef.current = blockInstanceId;
 
   // 🔴 BOTH REFS ABOVE ARE PER-MOUNT, BUT THIS HOST IS NOT ALWAYS REMOUNTED.
   //
@@ -492,7 +498,18 @@ export function PageBlockHost({
     // genuine `ready` after a soft nav — `shouldStartInit` refuses a non-'loading'
     // status — so this is belt-and-braces against the pre-existing host-reuse
     // bug being fixed later, not a live defect.)
-    if (launchMarksRef.current) resetLaunchMarks(launchMarksRef.current, nowMs(), isDocumentHidden());
+    //
+    // 🔴 BUT NOT ON FIRST MOUNT. This effect runs on mount as well as on change,
+    // and `mountedAt` was deliberately taken at RENDER time — the commit in which
+    // the iframe actually mounts. Resetting here unconditionally would overwrite
+    // it with a post-commit timestamp and silently shorten EVERY `total` by the
+    // render->effect gap, discarding exactly the window t0 exists to capture, in
+    // the flattering direction. `shouldResetLaunchMarks` is unit-tested.
+    if (shouldResetLaunchMarks(launchInstanceRef.current, blockInstanceId)) {
+      if (launchMarksRef.current)
+        resetLaunchMarks(launchMarksRef.current, nowMs(), isDocumentHidden());
+    }
+    launchInstanceRef.current = blockInstanceId;
   }, [blockInstanceId]);
 
   // 🔴 HIDDEN-TAB LATCH — sticky from mount until the beacon reads it.
@@ -893,9 +910,7 @@ export function PageBlockHost({
     if (blockRenderEmittedRef.current) return;
     blockRenderEmittedRef.current = true;
     const marks = launchMarksRef.current;
-    const timings = marks
-      ? computeLaunchTimings(marks, readIframeResourceTiming(iframeSrc))
-      : null;
+    const timings = marks ? computeLaunchTimings(marks) : null;
     // Fire-and-forget beacon — failures are a no-op.
     sendBlockRender({
       appBlockId,
@@ -903,7 +918,7 @@ export function PageBlockHost({
       slotId: 'app.page',
       ...(timings ? { timings } : {}),
     });
-  }, [status, appBlockId, blockInstanceId, iframeSrc]);
+  }, [status, appBlockId, blockInstanceId]);
 
   // BLOCK_ERROR{fatal:true} → fatal.
   useEffect(() => {

--- a/src/components/AppBlocks/PageBlockHost.tsx
+++ b/src/components/AppBlocks/PageBlockHost.tsx
@@ -10,6 +10,8 @@ import { AppBlockChrome } from './IframeHost';
 import { IframeInitController, shouldStartInit } from './iframeInitController';
 import { resolveBuzzPurchaseRequest } from './openBuzzPurchaseGate';
 import {
+  BLOCK_READY_TIMEOUT_MS,
+  TOKEN_WAIT_TIMEOUT_MS,
   decideAutoRetry,
   advanceReviewConsentLatch,
   buildReviewConsentNotification,
@@ -154,9 +156,14 @@ function storageErrorMessage(err: unknown): string {
  * out for real cost ~99s in one file and was the single largest contributor to the
  * component suite overrunning its CI budget; importing the real constants keeps the
  * tests pinned to the host's actual windows rather than to copies that can drift.
+ *
+ * 🔴 They now LIVE in `pageBlockHostLogic` and are re-exported here. That module
+ * is plain TS with no React graph, so a NODE test can import them — which is what
+ * lets `worstReachableLaunchMs()` derive the launch-sample cap from the real
+ * windows instead of from a hard-coded literal in a comment. Importing them from
+ * this file would drag the whole component graph into the `unit` project.
  */
-export const BLOCK_READY_TIMEOUT_MS = 10_000;
-export const TOKEN_WAIT_TIMEOUT_MS = 15_000;
+export { BLOCK_READY_TIMEOUT_MS, TOKEN_WAIT_TIMEOUT_MS };
 
 /**
  * LAUNCH REVEAL (feedback #3: "launching an app should feel magical … subtly

--- a/src/components/AppBlocks/PageBlockHostAutoRetry.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostAutoRetry.browser.test.tsx
@@ -571,12 +571,20 @@ describe('PageBlockHost auto-retry — beacon semantics (one per mount, the sett
 
     await pollFor('ok beacon', () => beaconCalls().length >= 1);
     const [body] = beaconBodies();
-    // The `ok` beacon carries no `status` field (see sendBlockRender).
-    expect(body).toEqual({
+    // The `ok` beacon carries no `status` field (see sendBlockRender). It MAY
+    // carry `timings` (the launch-latency payload rides this same beacon); no
+    // other key is allowed on the wire.
+    expect(body).toMatchObject({
       appBlockId: 'apb_test',
       blockInstanceId: 'page_apb_test',
       slotId: 'app.page',
     });
+    expect(
+      Object.keys(body).every((k) =>
+        ['appBlockId', 'blockInstanceId', 'slotId', 'timings'].includes(k)
+      )
+    ).toBe(true);
+    expect(body).not.toHaveProperty('status');
     // Give any stray emit a chance to show up before asserting exclusivity — on
     // the virtual clock that can be a generous window for free.
     await advance(LAST_BACKOFF_MS + BLOCK_READY_TIMEOUT_MS);

--- a/src/components/AppBlocks/__tests__/launchSampleBound.test.ts
+++ b/src/components/AppBlocks/__tests__/launchSampleBound.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, it } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+
+import {
+  AUTO_RETRY_BACKOFF_MS,
+  BLOCK_READY_TIMEOUT_MS,
+  MAX_AUTO_REMINTS,
+  MAX_AUTO_RETRIES,
+  TOKEN_WAIT_TIMEOUT_MS,
+  worstReachableLaunchMs,
+} from '../pageBlockHostLogic';
+import { MAX_LAUNCH_SAMPLE_MS } from '../launchTimings';
+import { MAX_APP_BLOCK_LAUNCH_SECONDS } from '~/server/metrics/app-block-runtime.metrics';
+
+/**
+ * 🔴 THE LAUNCH-SAMPLE CAP MUST CLEAR THE AUTO-RETRY BOUND — DERIVED, NOT ASSERTED.
+ *
+ * The launch histograms DROP any sample past a fixed cap. If that cap is below
+ * the longest legitimate success, it silently discards real slow launches, and
+ * the discard is slowness-correlated: it trims exactly the tail the metric exists
+ * to show, in the flattering direction.
+ *
+ * This has already gone wrong twice, both times in a COMMENT that nothing checked:
+ *   - a 30s cap justified by "TOKEN_WAIT_TIMEOUT_MS (15s) is the longest leg",
+ *     which assumed a launch is one attempt — it is not, the host emits one `ok`
+ *     for the whole bounded sequence;
+ *   - a "~47s" bound derived from two consecutive `no_token`s, which
+ *     `MAX_AUTO_REMINTS = 1` makes unreachable.
+ *
+ * So the bound is computed from the five constants that actually govern it, and
+ * both caps are asserted against it. Widening any of them walks the bound up and
+ * turns this red, instead of quietly invalidating a comment.
+ */
+describe('launch-sample cap vs the auto-retry bound', () => {
+  it('🔴 both caps exceed the worst reachable successful launch', () => {
+    const worst = worstReachableLaunchMs();
+    expect(MAX_LAUNCH_SAMPLE_MS).toBeGreaterThan(worst);
+    expect(MAX_APP_BLOCK_LAUNCH_SECONDS * 1000).toBeGreaterThan(worst);
+  });
+
+  it('🔴 the client and server caps agree (a split would drop samples on one side only)', () => {
+    expect(MAX_LAUNCH_SAMPLE_MS).toBe(MAX_APP_BLOCK_LAUNCH_SECONDS * 1000);
+  });
+
+  /**
+   * Recomputes the bound INDEPENDENTLY of `worstReachableLaunchMs`, from the raw
+   * constants, so the two can disagree. Deriving the expectation from the
+   * implementation would make this a tautology.
+   */
+  it('🔴 the bound matches an independent recomputation from the raw constants', () => {
+    const backoffs = AUTO_RETRY_BACKOFF_MS.slice(0, MAX_AUTO_RETRIES).reduce((a, b) => a + b, 0);
+    // attempt 1: no token at all -> `no_token` at the token timeout (auth
+    // terminal, spends the single re-mint).
+    // attempt 2: a re-mint is in flight, so the token wait can be paid AGAIN, and
+    //   the ready timer only arms once a token exists -> the two windows are
+    //   SERIAL within this attempt -> `timeout` (non-auth, spends no re-mint).
+    // attempt 3: the token from attempt 2 persists, so this attempt is bounded by
+    //   the ready timeout alone, and ends in `ok`.
+    const independent =
+      TOKEN_WAIT_TIMEOUT_MS +
+      (TOKEN_WAIT_TIMEOUT_MS + BLOCK_READY_TIMEOUT_MS) +
+      Math.max(0, MAX_AUTO_RETRIES - MAX_AUTO_REMINTS) * BLOCK_READY_TIMEOUT_MS +
+      backoffs;
+
+    expect(worstReachableLaunchMs()).toBe(independent);
+    // Value pin on today's constants, so a silent constant change is visible in
+    // the diff of this file rather than only in a derived comparison.
+    expect(independent).toBe(57_000);
+  });
+
+  /**
+   * 🔴 A NAIVE BOUND IS WRONG IN BOTH DIRECTIONS, and this pins why — the two
+   * facts that make the arithmetic non-obvious are exactly the ones that were
+   * missed. `3 x (token + ready) + backoffs` = 82s OVER-states it (two `no_token`s
+   * are unreachable, and a post-`timeout` attempt already holds a token, so it
+   * cannot re-pay the token wait). `attempts x token` = 37s UNDER-states it (an
+   * attempt whose token arrives late pays BOTH windows serially).
+   */
+  it('sits strictly between the naive over- and under-estimates', () => {
+    const backoffs = AUTO_RETRY_BACKOFF_MS.slice(0, MAX_AUTO_RETRIES).reduce((a, b) => a + b, 0);
+    const attempts = MAX_AUTO_RETRIES + 1;
+    const naiveOver = attempts * (TOKEN_WAIT_TIMEOUT_MS + BLOCK_READY_TIMEOUT_MS) + backoffs;
+    const naiveUnder = attempts * TOKEN_WAIT_TIMEOUT_MS + backoffs;
+
+    expect(worstReachableLaunchMs()).toBeLessThan(naiveOver);
+    expect(worstReachableLaunchMs()).toBeGreaterThan(naiveUnder);
+  });
+
+  /**
+   * The margin is genuinely tight (~3s on today's constants), so say so out loud
+   * rather than letting "it passes" imply comfort. This is documentation with an
+   * assertion attached: if someone pads the cap, the message here stops matching
+   * and they will re-read the reasoning.
+   */
+  it('documents that the margin is thin, not comfortable', () => {
+    const margin = MAX_LAUNCH_SAMPLE_MS - worstReachableLaunchMs();
+    expect(margin).toBeGreaterThan(0);
+    expect(margin).toBeLessThan(10_000);
+  });
+});
+
+/**
+ * 🔴 SOURCE GATE — the first-mount seed must happen at RENDER time.
+ *
+ * `shouldResetLaunchMarks` is unit-tested and correct, but the AUDIT found its
+ * WIRING is what actually carries the fix, and nothing pinned that: move the
+ * `launchInstanceRef` seed out of render and into a `useEffect` and the predicate
+ * stays correct, all three of its tests stay green, and the original bug — every
+ * `total` short by the render->effect gap — returns verbatim.
+ *
+ * WHY A SOURCE GATE RATHER THAN A BROWSER SPY. A spy asserting `resetLaunchMarks`
+ * is not called on first mount would be deterministic and magnitude-free, and it
+ * would be the more direct test. But it can only live in the `component` project,
+ * and that project IS NOT RUN IN CI — so it would be a guard that reports safety
+ * in a tier which never observes it. This gate runs in `unit`, which CI does run.
+ * The trade is real and worth naming: this checks the SHAPE of the source, not
+ * the behaviour, so it can be defeated by a refactor that preserves neither.
+ */
+describe('PageBlockHost: launch-mark seed wiring', () => {
+  const HOST = path.resolve(__dirname, '../PageBlockHost.tsx');
+
+  /**
+   * Collect the character ranges of every `useEffect(` call by brace-matching
+   * from its opening paren. Deliberately not a regex over the whole file: a regex
+   * cannot tell "inside an effect" from "textually after one".
+   */
+  function effectCallSpans(src: string): Array<[number, number]> {
+    const spans: Array<[number, number]> = [];
+    const needle = 'useEffect(';
+    let from = 0;
+    for (;;) {
+      const start = src.indexOf(needle, from);
+      if (start === -1) break;
+      let depth = 0;
+      let i = start + needle.length - 1; // at the '('
+      for (; i < src.length; i++) {
+        if (src[i] === '(') depth++;
+        else if (src[i] === ')') {
+          depth--;
+          if (depth === 0) break;
+        }
+      }
+      spans.push([start, i]);
+      from = start + needle.length;
+    }
+    return spans;
+  }
+
+  function seedIsAtRenderScope(src: string): boolean {
+    const seed = src.indexOf('launchInstanceRef.current = blockInstanceId');
+    if (seed === -1) return false;
+    return !effectCallSpans(src).some(([a, b]) => seed > a && seed < b);
+  }
+
+  /**
+   * 🔴 POSITIVE CONTROL FOR THE CHECKER ITSELF. Without this, a checker whose
+   * brace-matching silently found nothing would report "at render scope" for any
+   * input and this gate would be green while testing nothing.
+   */
+  it('the checker rejects a seed that has been moved into a useEffect', () => {
+    const bad = `
+      const launchInstanceRef = useRef(null);
+      useEffect(() => {
+        if (launchInstanceRef.current === null) launchInstanceRef.current = blockInstanceId;
+      }, []);
+    `;
+    expect(seedIsAtRenderScope(bad)).toBe(false);
+
+    const good = `
+      const launchInstanceRef = useRef(null);
+      if (launchInstanceRef.current === null) launchInstanceRef.current = blockInstanceId;
+      useEffect(() => { doSomethingElse(); }, []);
+    `;
+    expect(seedIsAtRenderScope(good)).toBe(true);
+  });
+
+  it('🔴 the real host seeds launchInstanceRef at render scope, not inside an effect', () => {
+    const src = fs.readFileSync(HOST, 'utf8');
+    // Guard the guard: if the symbol is ever renamed, fail loudly rather than
+    // passing vacuously on a file that no longer contains it.
+    expect(src).toContain('launchInstanceRef');
+    expect(seedIsAtRenderScope(src)).toBe(true);
+  });
+
+  it('the host re-arms the marks through the predicate, not unconditionally', () => {
+    const src = fs.readFileSync(HOST, 'utf8');
+    expect(src).toContain('shouldResetLaunchMarks(launchInstanceRef.current, blockInstanceId)');
+  });
+});

--- a/src/components/AppBlocks/__tests__/launchTimings.test.ts
+++ b/src/components/AppBlocks/__tests__/launchTimings.test.ts
@@ -1,0 +1,271 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  boundedDeltaMs,
+  boundedDurationMs,
+  computeLaunchTimings,
+  createLaunchMarks,
+  matchIframeResourceEntry,
+  MAX_LAUNCH_SAMPLE_MS,
+  resetLaunchMarks,
+  type LaunchMarks,
+} from '../launchTimings';
+
+/**
+ * App Block LAUNCH-LATENCY math.
+ *
+ * These live in the node `unit` project deliberately: the browser (`component`)
+ * project is NOT run in CI, and every rule here fails by producing a *plausible
+ * wrong number* rather than an error — a zero that reads as an instant leg, a
+ * clamped outlier that reads as a 30-second launch, a background-tab sample that
+ * reads as a slow app. None of those would ever surface as a red test elsewhere.
+ */
+
+const BASE_MARKS: LaunchMarks = {
+  mountedAt: 1_000,
+  tokenAt: 1_180,
+  initSentAt: 1_400,
+  readyAt: 2_100,
+  wasHidden: false,
+};
+
+const marks = (over: Partial<LaunchMarks> = {}): LaunchMarks => ({ ...BASE_MARKS, ...over });
+
+describe('boundedDurationMs / boundedDeltaMs — the two gates', () => {
+  it('🔴 NEVER returns a zero (an unobserved leg must not read as an instant one)', () => {
+    expect(boundedDurationMs(0)).toBeUndefined();
+    expect(boundedDurationMs(-5)).toBeUndefined();
+    // Sub-millisecond noise rounds to 0 and is likewise dropped, not emitted.
+    expect(boundedDurationMs(0.4)).toBeUndefined();
+    expect(boundedDeltaMs(1_000, 1_000)).toBeUndefined();
+    expect(boundedDeltaMs(1_000, 999)).toBeUndefined();
+  });
+
+  it('🔴 DROPS an out-of-range sample rather than clamping it to the bound', () => {
+    expect(boundedDurationMs(MAX_LAUNCH_SAMPLE_MS)).toBe(MAX_LAUNCH_SAMPLE_MS);
+    expect(boundedDurationMs(MAX_LAUNCH_SAMPLE_MS + 1)).toBeUndefined();
+    // The failure mode this pins: a clamp would return MAX here and fold junk
+    // onto the +Inf edge, polluting _sum and every tail quantile.
+    expect(boundedDurationMs(9_999_999)).toBeUndefined();
+  });
+
+  it('rejects non-finite and non-numeric inputs', () => {
+    expect(boundedDurationMs(Number.NaN)).toBeUndefined();
+    expect(boundedDurationMs(Number.POSITIVE_INFINITY)).toBeUndefined();
+    expect(boundedDurationMs(null)).toBeUndefined();
+    expect(boundedDurationMs(undefined)).toBeUndefined();
+    expect(boundedDeltaMs(null, 500)).toBeUndefined();
+    expect(boundedDeltaMs(500, null)).toBeUndefined();
+    expect(boundedDeltaMs(Number.NaN, 500)).toBeUndefined();
+  });
+
+  it('rounds to whole milliseconds', () => {
+    expect(boundedDurationMs(12.4)).toBe(12);
+    expect(boundedDurationMs(12.6)).toBe(13);
+    expect(boundedDeltaMs(1_000.2, 1_012.9)).toBe(13);
+  });
+});
+
+describe('createLaunchMarks / resetLaunchMarks', () => {
+  it('starts every mark null except the mount stamp', () => {
+    const m = createLaunchMarks(42, false);
+    expect(m).toEqual({
+      mountedAt: 42,
+      tokenAt: null,
+      initSentAt: null,
+      readyAt: null,
+      wasHidden: false,
+    });
+  });
+
+  it('carries an already-hidden tab through from creation', () => {
+    expect(createLaunchMarks(42, true).wasHidden).toBe(true);
+  });
+
+  it('re-arms IN PLACE for a new block instance (host reuse on soft nav)', () => {
+    const m = createLaunchMarks(0, true);
+    m.tokenAt = 10;
+    m.initSentAt = 20;
+    m.readyAt = 30;
+    const same = m;
+    resetLaunchMarks(m, 500, false);
+    // Same object identity — callers hold this in a ref.
+    expect(same).toBe(m);
+    expect(m).toEqual({
+      mountedAt: 500,
+      tokenAt: null,
+      initSentAt: null,
+      readyAt: null,
+      wasHidden: false,
+    });
+  });
+});
+
+describe('matchIframeResourceEntry', () => {
+  const SRC = 'https://notepad.civit.ai/';
+
+  it('matches the iframe document entry by URL and prefers its own `duration`', () => {
+    expect(
+      matchIframeResourceEntry(SRC, [
+        { name: 'https://civitai.com/_next/static/chunk.js', duration: 900 },
+        { name: SRC, duration: 214, startTime: 100, responseEnd: 999 },
+      ])
+    ).toEqual({ durationMs: 214 });
+  });
+
+  it('falls back to responseEnd - startTime when duration is absent or zero', () => {
+    expect(
+      matchIframeResourceEntry(SRC, [{ name: SRC, startTime: 100, responseEnd: 342 }])
+    ).toEqual({ durationMs: 242 });
+    expect(
+      matchIframeResourceEntry(SRC, [{ name: SRC, duration: 0, startTime: 100, responseEnd: 342 }])
+    ).toEqual({ durationMs: 242 });
+  });
+
+  it('ignores the URL fragment when matching', () => {
+    expect(
+      matchIframeResourceEntry('https://notepad.civit.ai/#/note/1', [{ name: SRC, duration: 50 }])
+    ).toEqual({ durationMs: 50 });
+  });
+
+  it('takes the LAST match (a re-keyed iframe on the Retry path adds a second entry)', () => {
+    expect(
+      matchIframeResourceEntry(SRC, [
+        { name: SRC, duration: 111 },
+        { name: SRC, duration: 222 },
+      ])
+    ).toEqual({ durationMs: 222 });
+  });
+
+  it('returns null when the iframe entry is absent (the ~250-entry buffer overflowed)', () => {
+    expect(matchIframeResourceEntry(SRC, [{ name: 'https://civitai.com/x.js', duration: 5 }])).toBe(
+      null
+    );
+    expect(matchIframeResourceEntry(SRC, [])).toBe(null);
+  });
+
+  it('does not match a DIFFERENT app on the same apex domain', () => {
+    expect(
+      matchIframeResourceEntry(SRC, [{ name: 'https://gen-matrix.civit.ai/', duration: 5 }])
+    ).toBe(null);
+  });
+
+  it('skips malformed entries without throwing', () => {
+    expect(
+      matchIframeResourceEntry(SRC, [
+        { name: 42 as unknown as string },
+        {},
+        { name: SRC, duration: 7 },
+      ])
+    ).toEqual({ durationMs: 7 });
+  });
+});
+
+describe('computeLaunchTimings', () => {
+  it('emits all four legs on a complete, visible launch', () => {
+    expect(computeLaunchTimings(marks(), { durationMs: 320 })).toEqual({
+      totalMs: 1_100, // 2100 - 1000
+      tokenMintMs: 180, // 1180 - 1000
+      frameFetchMs: 320,
+      initWaitMs: 700, // 2100 - 1400
+    });
+  });
+
+  it('🔴 does NOT enforce (or care) that the phases sum to the total — they are PARALLEL', () => {
+    // token_mint (180) + frame_fetch (900) + init_wait (700) = 1780 > total 1100.
+    // That is not a bug: the mint races the cross-origin frame load, because the
+    // iframe mounts on the first client render before any token exists. A guard
+    // that rejected this would silently drop every real sample.
+    const out = computeLaunchTimings(marks(), { durationMs: 900 });
+    expect(out).toEqual({ totalMs: 1_100, tokenMintMs: 180, frameFetchMs: 900, initWaitMs: 700 });
+    const sum = out!.tokenMintMs! + out!.frameFetchMs! + out!.initWaitMs!;
+    expect(sum).toBeGreaterThan(out!.totalMs);
+  });
+
+  it('🔴 drops the WHOLE sample when the tab was ever hidden', () => {
+    // Identical marks, one flag flipped — so this cannot pass for another reason.
+    expect(computeLaunchTimings(marks({ wasHidden: false }), { durationMs: 320 })).not.toBe(null);
+    expect(computeLaunchTimings(marks({ wasHidden: true }), { durationMs: 320 })).toBe(null);
+  });
+
+  it('drops the sample when BLOCK_READY never arrived (a failure has no launch time)', () => {
+    expect(computeLaunchTimings(marks({ readyAt: null }), { durationMs: 320 })).toBe(null);
+  });
+
+  it('drops the sample on the server, where there is no clock (mountedAt null)', () => {
+    expect(computeLaunchTimings(marks({ mountedAt: null }), { durationMs: 320 })).toBe(null);
+  });
+
+  it('🔴 `total` is the ANCHOR: an out-of-range total drops every phase with it', () => {
+    const out = computeLaunchTimings(
+      marks({ mountedAt: 0, readyAt: MAX_LAUNCH_SAMPLE_MS + 1, tokenAt: 180, initSentAt: 400 }),
+      { durationMs: 320 }
+    );
+    expect(out).toBe(null);
+  });
+
+  it('accepts a total exactly AT the bound and rejects one millisecond past it', () => {
+    expect(
+      computeLaunchTimings(
+        {
+          mountedAt: 0,
+          tokenAt: null,
+          initSentAt: null,
+          readyAt: MAX_LAUNCH_SAMPLE_MS,
+          wasHidden: false,
+        },
+        null
+      )
+    ).toEqual({ totalMs: MAX_LAUNCH_SAMPLE_MS });
+    expect(
+      computeLaunchTimings(
+        {
+          mountedAt: 0,
+          tokenAt: null,
+          initSentAt: null,
+          readyAt: MAX_LAUNCH_SAMPLE_MS + 1,
+          wasHidden: false,
+        },
+        null
+      )
+    ).toBe(null);
+  });
+
+  it('🔴 OMITS a zero-length leg instead of emitting 0 (token already present at mount)', () => {
+    const out = computeLaunchTimings(marks({ tokenAt: BASE_MARKS.mountedAt }), { durationMs: 320 });
+    expect(out).not.toBe(null);
+    expect(out).not.toHaveProperty('tokenMintMs');
+    // …and the rest of the sample survives — one missing leg is not a drop.
+    expect(out).toMatchObject({ totalMs: 1_100, frameFetchMs: 320, initWaitMs: 700 });
+  });
+
+  it('🔴 OMITS frame_fetch when there is no resource entry — never a zero', () => {
+    const out = computeLaunchTimings(marks(), null);
+    expect(out).not.toHaveProperty('frameFetchMs');
+    expect(out).toMatchObject({ totalMs: 1_100, tokenMintMs: 180, initWaitMs: 700 });
+  });
+
+  it('🔴 OMITS frame_fetch on a zero/negative duration — never a zero', () => {
+    expect(computeLaunchTimings(marks(), { durationMs: 0 })).not.toHaveProperty('frameFetchMs');
+    expect(computeLaunchTimings(marks(), { durationMs: -3 })).not.toHaveProperty('frameFetchMs');
+  });
+
+  it('drops ONLY the offending phase when a phase is out of range, keeping the total', () => {
+    const out = computeLaunchTimings(marks(), { durationMs: MAX_LAUNCH_SAMPLE_MS + 1 });
+    expect(out).toEqual({ totalMs: 1_100, tokenMintMs: 180, initWaitMs: 700 });
+  });
+
+  it('omits init_wait when BLOCK_INIT was never posted, keeping total and token_mint', () => {
+    const out = computeLaunchTimings(marks({ initSentAt: null }), null);
+    expect(out).toEqual({ totalMs: 1_100, tokenMintMs: 180 });
+  });
+
+  it('emits a bare total when only the mount and ready marks exist', () => {
+    expect(
+      computeLaunchTimings(
+        { mountedAt: 10, tokenAt: null, initSentAt: null, readyAt: 910, wasHidden: false },
+        null
+      )
+    ).toEqual({ totalMs: 900 });
+  });
+});

--- a/src/components/AppBlocks/__tests__/launchTimings.test.ts
+++ b/src/components/AppBlocks/__tests__/launchTimings.test.ts
@@ -5,9 +5,9 @@ import {
   boundedDurationMs,
   computeLaunchTimings,
   createLaunchMarks,
-  matchIframeResourceEntry,
   MAX_LAUNCH_SAMPLE_MS,
   resetLaunchMarks,
+  shouldResetLaunchMarks,
   type LaunchMarks,
 } from '../launchTimings';
 
@@ -17,8 +17,9 @@ import {
  * These live in the node `unit` project deliberately: the browser (`component`)
  * project is NOT run in CI, and every rule here fails by producing a *plausible
  * wrong number* rather than an error — a zero that reads as an instant leg, a
- * clamped outlier that reads as a 30-second launch, a background-tab sample that
- * reads as a slow app. None of those would ever surface as a red test elsewhere.
+ * clamped outlier that reads as a 60-second launch, a background-tab sample that
+ * reads as a slow app, a t0 quietly reset a few milliseconds late. None of those
+ * would ever surface as a red test elsewhere.
  */
 
 const BASE_MARKS: LaunchMarks = {
@@ -47,6 +48,22 @@ describe('boundedDurationMs / boundedDeltaMs — the two gates', () => {
     // The failure mode this pins: a clamp would return MAX here and fold junk
     // onto the +Inf edge, polluting _sum and every tail quantile.
     expect(boundedDurationMs(9_999_999)).toBeUndefined();
+  });
+
+  /**
+   * 🔴 THE BOUND MUST CLEAR THE AUTO-RETRY WORST CASE.
+   *
+   * The host emits ONE `ok` for the whole bounded auto-retry sequence, whichever
+   * attempt produced it — so a legitimate success can be ~47s
+   * (15 no_token + 2 backoff + 15 no_token + 5 backoff + ~10 ready). The
+   * previous 30s bound silently DROPPED those, and the drop was
+   * slowness-correlated: it trimmed exactly the tail the metric exists to show.
+   * A value pin, not a tautology — it goes red if the bound is lowered back.
+   */
+  it('🔴 accepts a slow auto-retry success (~47s), which the old 30s bound dropped', () => {
+    expect(boundedDurationMs(47_000)).toBe(47_000);
+    expect(boundedDurationMs(30_001)).toBe(30_001);
+    expect(MAX_LAUNCH_SAMPLE_MS).toBeGreaterThan(47_000);
   });
 
   it('rejects non-finite and non-numeric inputs', () => {
@@ -101,171 +118,134 @@ describe('createLaunchMarks / resetLaunchMarks', () => {
   });
 });
 
-describe('matchIframeResourceEntry', () => {
-  const SRC = 'https://notepad.civit.ai/';
-
-  it('matches the iframe document entry by URL and prefers its own `duration`', () => {
-    expect(
-      matchIframeResourceEntry(SRC, [
-        { name: 'https://civitai.com/_next/static/chunk.js', duration: 900 },
-        { name: SRC, duration: 214, startTime: 100, responseEnd: 999 },
-      ])
-    ).toEqual({ durationMs: 214 });
+/**
+ * 🔴 THE FIRST-MOUNT GUARD.
+ *
+ * The host's re-arm effect is keyed on `[blockInstanceId]`, and such an effect
+ * ALSO RUNS ON FIRST MOUNT. Resetting unconditionally there overwrites the
+ * render-time `mountedAt` — taken in the commit where the iframe actually mounts
+ * — with a post-commit timestamp, silently shortening EVERY `total` by the
+ * render->effect gap. Nothing breaks and no other test goes red; the number is
+ * just quietly flattering.
+ *
+ * The gap is milliseconds in a harness and much larger on a real cold load, so a
+ * browser test cannot discriminate it by magnitude. This is where it is pinned.
+ */
+describe('shouldResetLaunchMarks', () => {
+  it('🔴 does NOT reset on first mount (there is no previous instance)', () => {
+    expect(shouldResetLaunchMarks(null, 'page_apb_a')).toBe(false);
   });
 
-  it('falls back to responseEnd - startTime when duration is absent or zero', () => {
-    expect(
-      matchIframeResourceEntry(SRC, [{ name: SRC, startTime: 100, responseEnd: 342 }])
-    ).toEqual({ durationMs: 242 });
-    expect(
-      matchIframeResourceEntry(SRC, [{ name: SRC, duration: 0, startTime: 100, responseEnd: 342 }])
-    ).toEqual({ durationMs: 242 });
+  it('does NOT reset when the effect re-runs for the SAME instance', () => {
+    expect(shouldResetLaunchMarks('page_apb_a', 'page_apb_a')).toBe(false);
   });
 
-  it('ignores the URL fragment when matching', () => {
-    expect(
-      matchIframeResourceEntry('https://notepad.civit.ai/#/note/1', [{ name: SRC, duration: 50 }])
-    ).toEqual({ durationMs: 50 });
-  });
-
-  it('takes the LAST match (a re-keyed iframe on the Retry path adds a second entry)', () => {
-    expect(
-      matchIframeResourceEntry(SRC, [
-        { name: SRC, duration: 111 },
-        { name: SRC, duration: 222 },
-      ])
-    ).toEqual({ durationMs: 222 });
-  });
-
-  it('returns null when the iframe entry is absent (the ~250-entry buffer overflowed)', () => {
-    expect(matchIframeResourceEntry(SRC, [{ name: 'https://civitai.com/x.js', duration: 5 }])).toBe(
-      null
-    );
-    expect(matchIframeResourceEntry(SRC, [])).toBe(null);
-  });
-
-  it('does not match a DIFFERENT app on the same apex domain', () => {
-    expect(
-      matchIframeResourceEntry(SRC, [{ name: 'https://gen-matrix.civit.ai/', duration: 5 }])
-    ).toBe(null);
-  });
-
-  it('skips malformed entries without throwing', () => {
-    expect(
-      matchIframeResourceEntry(SRC, [
-        { name: 42 as unknown as string },
-        {},
-        { name: SRC, duration: 7 },
-      ])
-    ).toEqual({ durationMs: 7 });
+  it('DOES reset on a soft nav to a different app instance', () => {
+    expect(shouldResetLaunchMarks('page_apb_a', 'page_apb_b')).toBe(true);
   });
 });
 
 describe('computeLaunchTimings', () => {
-  it('emits all four legs on a complete, visible launch', () => {
-    expect(computeLaunchTimings(marks(), { durationMs: 320 })).toEqual({
+  it('emits both host-side legs plus the total on a complete, visible launch', () => {
+    expect(computeLaunchTimings(marks())).toEqual({
       totalMs: 1_100, // 2100 - 1000
       tokenMintMs: 180, // 1180 - 1000
-      frameFetchMs: 320,
       initWaitMs: 700, // 2100 - 1400
     });
   });
 
   it('🔴 does NOT enforce (or care) that the phases sum to the total — they are PARALLEL', () => {
-    // token_mint (180) + frame_fetch (900) + init_wait (700) = 1780 > total 1100.
-    // That is not a bug: the mint races the cross-origin frame load, because the
-    // iframe mounts on the first client render before any token exists. A guard
-    // that rejected this would silently drop every real sample.
-    const out = computeLaunchTimings(marks(), { durationMs: 900 });
-    expect(out).toEqual({ totalMs: 1_100, tokenMintMs: 180, frameFetchMs: 900, initWaitMs: 700 });
-    const sum = out!.tokenMintMs! + out!.frameFetchMs! + out!.initWaitMs!;
-    expect(sum).toBeGreaterThan(out!.totalMs);
+    // Here token_mint (900) + init_wait (1050) exceeds the total (1100). That is
+    // not a bug: the mint races the cross-origin frame load, because the iframe
+    // mounts on the first client render before any token exists. A guard that
+    // assumed a serial sum would silently drop real samples.
+    const out = computeLaunchTimings(marks({ tokenAt: 1_900, initSentAt: 1_050 }))!;
+    expect(out).toEqual({ totalMs: 1_100, tokenMintMs: 900, initWaitMs: 1_050 });
+    expect(out.tokenMintMs! + out.initWaitMs!).toBeGreaterThan(out.totalMs);
   });
 
   it('🔴 drops the WHOLE sample when the tab was ever hidden', () => {
     // Identical marks, one flag flipped — so this cannot pass for another reason.
-    expect(computeLaunchTimings(marks({ wasHidden: false }), { durationMs: 320 })).not.toBe(null);
-    expect(computeLaunchTimings(marks({ wasHidden: true }), { durationMs: 320 })).toBe(null);
+    expect(computeLaunchTimings(marks({ wasHidden: false }))).not.toBe(null);
+    expect(computeLaunchTimings(marks({ wasHidden: true }))).toBe(null);
   });
 
   it('drops the sample when BLOCK_READY never arrived (a failure has no launch time)', () => {
-    expect(computeLaunchTimings(marks({ readyAt: null }), { durationMs: 320 })).toBe(null);
+    expect(computeLaunchTimings(marks({ readyAt: null }))).toBe(null);
   });
 
   it('drops the sample on the server, where there is no clock (mountedAt null)', () => {
-    expect(computeLaunchTimings(marks({ mountedAt: null }), { durationMs: 320 })).toBe(null);
+    expect(computeLaunchTimings(marks({ mountedAt: null }))).toBe(null);
   });
 
   it('🔴 `total` is the ANCHOR: an out-of-range total drops every phase with it', () => {
-    const out = computeLaunchTimings(
-      marks({ mountedAt: 0, readyAt: MAX_LAUNCH_SAMPLE_MS + 1, tokenAt: 180, initSentAt: 400 }),
-      { durationMs: 320 }
-    );
-    expect(out).toBe(null);
-  });
-
-  it('accepts a total exactly AT the bound and rejects one millisecond past it', () => {
     expect(
       computeLaunchTimings(
-        {
-          mountedAt: 0,
-          tokenAt: null,
-          initSentAt: null,
-          readyAt: MAX_LAUNCH_SAMPLE_MS,
-          wasHidden: false,
-        },
-        null
-      )
-    ).toEqual({ totalMs: MAX_LAUNCH_SAMPLE_MS });
-    expect(
-      computeLaunchTimings(
-        {
-          mountedAt: 0,
-          tokenAt: null,
-          initSentAt: null,
-          readyAt: MAX_LAUNCH_SAMPLE_MS + 1,
-          wasHidden: false,
-        },
-        null
+        marks({ mountedAt: 0, readyAt: MAX_LAUNCH_SAMPLE_MS + 1, tokenAt: 180, initSentAt: 400 })
       )
     ).toBe(null);
   });
 
+  it('accepts a total exactly AT the bound and rejects one millisecond past it', () => {
+    expect(
+      computeLaunchTimings({
+        mountedAt: 0,
+        tokenAt: null,
+        initSentAt: null,
+        readyAt: MAX_LAUNCH_SAMPLE_MS,
+        wasHidden: false,
+      })
+    ).toEqual({ totalMs: MAX_LAUNCH_SAMPLE_MS });
+    expect(
+      computeLaunchTimings({
+        mountedAt: 0,
+        tokenAt: null,
+        initSentAt: null,
+        readyAt: MAX_LAUNCH_SAMPLE_MS + 1,
+        wasHidden: false,
+      })
+    ).toBe(null);
+  });
+
   it('🔴 OMITS a zero-length leg instead of emitting 0 (token already present at mount)', () => {
-    const out = computeLaunchTimings(marks({ tokenAt: BASE_MARKS.mountedAt }), { durationMs: 320 });
+    const out = computeLaunchTimings(marks({ tokenAt: BASE_MARKS.mountedAt }));
     expect(out).not.toBe(null);
     expect(out).not.toHaveProperty('tokenMintMs');
     // …and the rest of the sample survives — one missing leg is not a drop.
-    expect(out).toMatchObject({ totalMs: 1_100, frameFetchMs: 320, initWaitMs: 700 });
-  });
-
-  it('🔴 OMITS frame_fetch when there is no resource entry — never a zero', () => {
-    const out = computeLaunchTimings(marks(), null);
-    expect(out).not.toHaveProperty('frameFetchMs');
-    expect(out).toMatchObject({ totalMs: 1_100, tokenMintMs: 180, initWaitMs: 700 });
-  });
-
-  it('🔴 OMITS frame_fetch on a zero/negative duration — never a zero', () => {
-    expect(computeLaunchTimings(marks(), { durationMs: 0 })).not.toHaveProperty('frameFetchMs');
-    expect(computeLaunchTimings(marks(), { durationMs: -3 })).not.toHaveProperty('frameFetchMs');
-  });
-
-  it('drops ONLY the offending phase when a phase is out of range, keeping the total', () => {
-    const out = computeLaunchTimings(marks(), { durationMs: MAX_LAUNCH_SAMPLE_MS + 1 });
-    expect(out).toEqual({ totalMs: 1_100, tokenMintMs: 180, initWaitMs: 700 });
+    expect(out).toMatchObject({ totalMs: 1_100, initWaitMs: 700 });
   });
 
   it('omits init_wait when BLOCK_INIT was never posted, keeping total and token_mint', () => {
-    const out = computeLaunchTimings(marks({ initSentAt: null }), null);
-    expect(out).toEqual({ totalMs: 1_100, tokenMintMs: 180 });
+    expect(computeLaunchTimings(marks({ initSentAt: null }))).toEqual({
+      totalMs: 1_100,
+      tokenMintMs: 180,
+    });
   });
 
   it('emits a bare total when only the mount and ready marks exist', () => {
     expect(
-      computeLaunchTimings(
-        { mountedAt: 10, tokenAt: null, initSentAt: null, readyAt: 910, wasHidden: false },
-        null
-      )
+      computeLaunchTimings({
+        mountedAt: 10,
+        tokenAt: null,
+        initSentAt: null,
+        readyAt: 910,
+        wasHidden: false,
+      })
     ).toEqual({ totalMs: 900 });
+  });
+
+  /**
+   * Guard on the DELIBERATE ABSENCE of a cross-origin frame phase. Without
+   * `Timing-Allow-Origin` the parent's `responseEnd` for a subframe is the
+   * frame's LOAD event rather than the document response, so a `frame_fetch`
+   * built on it measures roughly what `total` already measures — and the entry
+   * often does not exist yet when the beacon fires. Anyone re-adding the phase
+   * must read the DEFERRED note in launchTimings.ts first; this pins that the
+   * wire shape carries no such field today.
+   */
+  it('never emits a frameFetchMs field (the cross-origin phase is deliberately deferred)', () => {
+    const out = computeLaunchTimings(marks())!;
+    expect(out).not.toHaveProperty('frameFetchMs');
+    expect(Object.keys(out).sort()).toEqual(['initWaitMs', 'tokenMintMs', 'totalMs']);
   });
 });

--- a/src/components/AppBlocks/__tests__/launchTimings.test.ts
+++ b/src/components/AppBlocks/__tests__/launchTimings.test.ts
@@ -132,6 +132,13 @@ describe('createLaunchMarks / resetLaunchMarks', () => {
  * browser test cannot discriminate it by magnitude. This is where it is pinned.
  */
 describe('shouldResetLaunchMarks', () => {
+  /**
+   * INVARIANT GUARD, not regression coverage: the host seeds `launchInstanceRef`
+   * at render time, so `previousInstanceId` is never actually `null` by the time
+   * the effect runs. This pins the predicate's contract for any future caller
+   * that does not seed eagerly; the real first-mount protection is the WIRING,
+   * gated in launchSampleBound.test.ts.
+   */
   it('🔴 does NOT reset on first mount (there is no previous instance)', () => {
     expect(shouldResetLaunchMarks(null, 'page_apb_a')).toBe(false);
   });

--- a/src/components/AppBlocks/launchTimings.ts
+++ b/src/components/AppBlocks/launchTimings.ts
@@ -37,24 +37,28 @@ export type LaunchPhase = (typeof LAUNCH_PHASES)[number];
 /**
  * Upper sanity bound on any single launch sample, in milliseconds.
  *
- * 🔴 60 s IS DERIVED FROM THE AUTO-RETRY BOUND, NOT PICKED. An earlier draft used
- * 30 s, justified as "comfortably above TOKEN_WAIT_TIMEOUT_MS (15 s), the longest
- * leg that can legitimately complete". That justification was WRONG, because a
- * successful launch is not one attempt: `MAX_AUTO_RETRIES = 2` means the host
- * emits ONE `ok` for the whole bounded sequence, whichever attempt produced it.
- * Worst reachable success:
+ * 🔴 DERIVED FROM THE AUTO-RETRY BOUND, NOT PICKED — and the derivation is CODE,
+ * in `worstReachableLaunchMs()` (pageBlockHostLogic), not this comment. A test
+ * asserts this cap exceeds it, so widening any of `MAX_AUTO_RETRIES`,
+ * `MAX_AUTO_REMINTS`, `AUTO_RETRY_BACKOFF_MS`, `TOKEN_WAIT_TIMEOUT_MS` or
+ * `BLOCK_READY_TIMEOUT_MS` fails loudly instead of silently walking past the cap.
  *
- *     15 s (attempt 1 -> no_token at TOKEN_WAIT_TIMEOUT_MS)
- *   +  2 s (AUTO_RETRY_BACKOFF_MS[0])
- *   + 15 s (attempt 2 -> no_token)
- *   +  5 s (AUTO_RETRY_BACKOFF_MS[1])
- *   + ~10 s (attempt 3 finally reaches BLOCK_READY)
- *   = ~47 s
+ * That test exists because the arithmetic has been wrong in a comment TWICE.
+ * First at 30 s, justified as "comfortably above TOKEN_WAIT_TIMEOUT_MS (15 s), the
+ * longest leg that can legitimately complete" — which quietly assumed a launch is
+ * ONE attempt. It is not: the host emits one `ok` for the whole bounded sequence,
+ * whichever attempt produced it. Then at "~47 s", from a sequence with two
+ * consecutive `no_token`s, which `MAX_AUTO_REMINTS = 1` makes UNREACHABLE.
  *
- * A 30 s cap therefore DROPPED real slow successes — and the drop was
- * slowness-correlated, i.e. it silently trimmed exactly the tail the metric
- * exists to show. 60 s clears the computed bound with margin while still
- * rejecting a clock anomaly or a `performance.now()` discontinuity.
+ * The real worst reachable success is 57 s (see `worstReachableLaunchMs` for the
+ * sequence and why the naive `3 x (15 + 10) + backoffs` = 82 s over-states it).
+ * 🔴 So the margin here is ~3 s, not "comfortable" — it is deliberately tight and
+ * test-guarded rather than padded.
+ *
+ * The 30 s cap was therefore DROPPING real slow successes, and the drop was
+ * slowness-correlated: it trimmed exactly the tail the metric exists to show. At
+ * 60 s there is no live drop, while a clock anomaly or a `performance.now()`
+ * discontinuity is still rejected.
  *
  * 🔴 DROPPED, NEVER CLAMPED — mirrors `observeCustomComfyWallclockSeconds`. A
  * clamp folds junk onto the `+Inf` edge and poisons `_sum` and every tail
@@ -219,16 +223,24 @@ export function computeLaunchTimings(marks: LaunchMarks): LaunchTimingsPayload |
 // number its name claimed.
 //
 // 1. WITHOUT `Timing-Allow-Origin`, `responseEnd` FOR A CROSS-ORIGIN SUBFRAME IS
-//    THE FRAME'S `load` EVENT, NOT THE DOCUMENT RESPONSE. The HTML spec's iframe
-//    load steps set the fallback "response end time" to the current time when the
-//    subframe's load event fires, and the TAO check is what selects between that
-//    fallback and the real document timing. So the SAME field carries two
-//    different quantities depending on a header we do not send: with TAO (or
-//    same-origin) it is document-response completion; without, it is the whole
-//    subframe load, including the block's own JS, CSS, fonts and images.
+//    THE FRAME'S `load` EVENT, NOT THE DOCUMENT RESPONSE. The iframe load-event
+//    steps set the fallback "response end time" to the current high resolution
+//    time, and the TAO check is what selects between that fallback and the real
+//    document timing. So the SAME field carries two different quantities
+//    depending on a header we do not send: with TAO (or same-origin) it is
+//    document-response completion; without, it is the whole subframe load,
+//    including the block's own JS, CSS, fonts and images.
+//
+//    Sources — spec-pinned, not folklore:
+//      - WHATWG HTML §4.8.5 (iframe load event steps set the fallback response
+//        end time) and §7.4.6 (a TAO pass skips the fallback);
+//      - Chromium since M111: `HTMLFrameOwnerElement::DispatchLoad()` ->
+//        `ReportFallbackResourceTimingIfNeeded()`;
+//      - WPT `resource-timing/nested-nav-fallback-timing.html`, which asserts
+//        exactly this behaviour.
 //    Measured on Chromium 144 and 150 against a child page holding one
-//    subresource: the no-TAO duration tracked the delay 1:1 (657 / 2053 /
-//    5066 ms for 500 / 2000 / 5000 ms held) while TAO and same-origin stayed at
+//    subresource: the no-TAO duration tracked the delay 1:1 — 657 / 2053 /
+//    5066 ms for 500 / 2000 / 5000 ms held — while TAO and same-origin stayed at
 //    3-9 ms. Practical effect on a real block: the phase reads close to `total`,
 //    seconds not milliseconds, and visually dominates any phase panel while
 //    measuring roughly what `total` already measures.
@@ -248,10 +260,24 @@ export function computeLaunchTimings(marks: LaunchMarks): LaunchTimingsPayload |
 // changes WHICH QUANTITY the field carries, it may be a genuine prerequisite
 // rather than a nice-to-have.
 //
-// If the phase comes back, the seam is small: add the literal to LAUNCH_PHASES
-// here and to APP_BLOCK_LAUNCH_PHASES server-side, add one optional
-// `frameFetchMs` number to the beacon schema, and populate it in
-// `computeLaunchTimings`. Nothing else in this module is shaped around its
-// absence. Whatever is added must state plainly WHICH of the two quantities it
-// measures, and must publish its own coverage denominator rather than being
-// quoted as a fleet number.
+// If the phase comes back, the seam is FIVE edits — and the two easy ones to miss
+// are the last two, because without them the phase is PERMITTED but emits
+// nothing, which is a silent no-op for exactly the reader this note serves:
+//
+//   1. add the literal to `LAUNCH_PHASES` here;
+//   2. add it to `APP_BLOCK_LAUNCH_PHASES` in app-block-runtime.metrics;
+//   3. add an optional `frameFetchMs` number to `blockRenderSchema`
+//      (track.schema.ts) and populate it in `computeLaunchTimings` below;
+//   4. 🔴 add `frameFetchMs?: unknown` to `AppBlockLaunchTimings` in
+//      app-block-runtime.metrics — otherwise the server type has no such field;
+//   5. 🔴 add the `['frame_fetch', timings.frameFetchMs]` tuple to the `phases`
+//      array in `observeAppBlockLaunch` — the array, not the enum, is what
+//      actually observes.
+//
+// Two tests currently pin the absence and will go red as soon as you start
+// (that is intended, not an obstacle): "ignores a client-sent frameFetchMs" in
+// app-block-launch.metrics.test.ts and "never emits a frameFetchMs field" here.
+//
+// Nothing else in this module is shaped around the absence. Whatever is added
+// must state plainly WHICH of the two quantities it measures, and must publish
+// its own coverage denominator rather than being quoted as a fleet number.

--- a/src/components/AppBlocks/launchTimings.ts
+++ b/src/components/AppBlocks/launchTimings.ts
@@ -2,14 +2,14 @@
 // beacon payload.
 //
 // WHY THIS IS A SEPARATE MODULE AND NOT INLINE IN PageBlockHost:
-// every rule below (never-emit-a-zero, drop-don't-clamp, the hidden-tab drop)
-// is a correctness rule whose failure mode is a *plausible wrong number* rather
-// than a crash. Those need node-runnable tests, and the browser (`component`)
-// Vitest project is not run in CI — only the `unit` project is. So the math
-// lives here, and the host only records marks.
+// every rule below (never-emit-a-zero, drop-don't-clamp, the hidden-tab drop,
+// the host-reuse reset) is a correctness rule whose failure mode is a *plausible
+// wrong number* rather than a crash. Those need node-runnable tests, and the
+// browser (`component`) Vitest project is not run in CI — only the `unit`
+// project is. So the math lives here, and the host only records marks.
 //
 // ─── The launch chain this measures ───────────────────────────────────────────
-// Design + measurements: datapacket-talos
+// Design: datapacket-talos
 // claudedocs/app-blocks-launch-latency-instrumentation-and-preload-2026-08-02.md
 //
 // 🔴 THE TOKEN MINT AND THE CROSS-ORIGIN FRAME LOAD RUN IN PARALLEL.
@@ -19,54 +19,48 @@
 // waits on `max(token, block-listener-attached)`, then the BLOCK_INIT re-post
 // cadence, then the block's own render-to-ready.
 //
-// So `token_mint + frame_fetch + init_wait !== total`, BY CONSTRUCTION, and any
-// consumer that sums the phases is reading a fiction. They are three
-// independent legs of one race; `total` is the only end-to-end number.
+// So `token_mint + init_wait !== total`, BY CONSTRUCTION, and any consumer that
+// sums the phases is reading a fiction. They are two independent legs of one
+// race; `total` is the only end-to-end number.
 
-/** Code-owned phase enum. Mirrored server-side in app-block-runtime.metrics. */
-export const LAUNCH_PHASES = ['token_mint', 'frame_fetch', 'init_wait'] as const;
+/**
+ * Code-owned phase enum. Mirrored server-side in app-block-runtime.metrics.
+ *
+ * 🔴 THERE IS DELIBERATELY NO CROSS-ORIGIN `frame_fetch` PHASE — see the
+ * DEFERRED note at the bottom of this file. It is not an oversight, and it is
+ * not cheap to add back: the quantity a naive implementation measures is not the
+ * one its name would claim.
+ */
+export const LAUNCH_PHASES = ['token_mint', 'init_wait'] as const;
 export type LaunchPhase = (typeof LAUNCH_PHASES)[number];
 
 /**
  * Upper sanity bound on any single launch sample, in milliseconds.
  *
- * 30 s sits comfortably above `TOKEN_WAIT_TIMEOUT_MS` (15 s), the longest leg
- * that can legitimately complete — a `total` above 10 s is already structurally
- * impossible on the success path (`BLOCK_READY_TIMEOUT_MS` fires first and no
- * `ok` beacon is sent). Anything past 30 s is a suspended tab, a clock anomaly,
- * or a bug.
+ * 🔴 60 s IS DERIVED FROM THE AUTO-RETRY BOUND, NOT PICKED. An earlier draft used
+ * 30 s, justified as "comfortably above TOKEN_WAIT_TIMEOUT_MS (15 s), the longest
+ * leg that can legitimately complete". That justification was WRONG, because a
+ * successful launch is not one attempt: `MAX_AUTO_RETRIES = 2` means the host
+ * emits ONE `ok` for the whole bounded sequence, whichever attempt produced it.
+ * Worst reachable success:
+ *
+ *     15 s (attempt 1 -> no_token at TOKEN_WAIT_TIMEOUT_MS)
+ *   +  2 s (AUTO_RETRY_BACKOFF_MS[0])
+ *   + 15 s (attempt 2 -> no_token)
+ *   +  5 s (AUTO_RETRY_BACKOFF_MS[1])
+ *   + ~10 s (attempt 3 finally reaches BLOCK_READY)
+ *   = ~47 s
+ *
+ * A 30 s cap therefore DROPPED real slow successes — and the drop was
+ * slowness-correlated, i.e. it silently trimmed exactly the tail the metric
+ * exists to show. 60 s clears the computed bound with margin while still
+ * rejecting a clock anomaly or a `performance.now()` discontinuity.
  *
  * 🔴 DROPPED, NEVER CLAMPED — mirrors `observeCustomComfyWallclockSeconds`. A
  * clamp folds junk onto the `+Inf` edge and poisons `_sum` and every tail
  * quantile with a value that was never real.
  */
-export const MAX_LAUNCH_SAMPLE_MS = 30_000;
-
-/**
- * The iframe-document fetch, as read from the PARENT's resource timeline.
- *
- * ✅ MEASURED (Chromium 151.0.7922.71, two-port loopback harness, 2026-08-03):
- * a cross-origin iframe document navigation DOES appear in the parent's
- * `performance.getEntriesByType('resource')` with `initiatorType: 'iframe'`, and
- * **without `Timing-Allow-Origin` the entry still carries real, non-zero
- * `startTime`, `responseEnd` and `duration`.** Only the DECOMPOSITION is zeroed
- * (`domainLookupStart/End`, `connectStart/End`, `requestStart`, `responseStart`,
- * `transferSize`, `encodedBodySize`, empty `nextHopProtocol`). Controls: a
- * cross-origin `<img>` shows the identical zeroing (so it is the standard
- * cross-origin TAO restriction, not iframe-specific), and a same-origin iframe
- * has every field in both runs (so it is genuinely cross-origin, not "iframes
- * never get timings").
- *
- * 🔴 CONSEQUENCE: `frame_fetch` is available at **100% coverage today**, on every
- * app, with no TAO header and no fleet rebuild. Earlier drafts of the design gated
- * this phase on `connectEnd > 0` and carried a `tao: present|absent` coverage
- * label; the measurement retired both. See the SUB-PHASE SEAM note at the bottom
- * of this file for what TAO would still buy and why it is deferred.
- */
-export type LaunchFrameTiming = {
-  /** `responseEnd - startTime` for the iframe document. */
-  durationMs: number;
-};
+export const MAX_LAUNCH_SAMPLE_MS = 60_000;
 
 /** Mutable per-mount marks, all `performance.now()` values. */
 export type LaunchMarks = {
@@ -91,7 +85,6 @@ export type LaunchMarks = {
 export type LaunchTimingsPayload = {
   totalMs: number;
   tokenMintMs?: number;
-  frameFetchMs?: number;
   initWaitMs?: number;
 };
 
@@ -114,10 +107,32 @@ export function resetLaunchMarks(marks: LaunchMarks, now: number | null, hidden:
 }
 
 /**
+ * 🔴 MUST THE MARKS BE RE-ARMED? Only when the block INSTANCE actually changed.
+ *
+ * This is a named predicate rather than an inline `!==` because getting it wrong
+ * is invisible. An effect keyed on `[blockInstanceId]` ALSO RUNS ON FIRST MOUNT,
+ * so resetting unconditionally overwrites the render-time `mountedAt` with a
+ * post-commit timestamp: nothing breaks, no test goes red, and every `total` is
+ * silently short by the render->effect gap — i.e. it discards precisely the
+ * hydration/first-commit window t0 exists to capture, in the flattering
+ * direction.
+ *
+ * That gap is a few milliseconds in a test harness and much larger on a real
+ * cold page load, so a browser test cannot discriminate it by magnitude. This
+ * predicate is where the rule is pinned instead.
+ */
+export function shouldResetLaunchMarks(
+  previousInstanceId: string | null,
+  nextInstanceId: string
+): boolean {
+  return previousInstanceId !== null && previousInstanceId !== nextInstanceId;
+}
+
+/**
  * A bounded, strictly-positive millisecond delta, or `undefined`.
  *
  * 🔴 THE `> 0` IS THE "NEVER EMIT A ZERO" RULE, and it is why this is one
- * function rather than three inline subtractions. A zero is indistinguishable
+ * function rather than several inline subtractions. A zero is indistinguishable
  * from an instant leg, so emitting one for a leg that simply was not observed
  * drags every percentile down — silently, and in the reassuring direction.
  */
@@ -137,63 +152,6 @@ export function boundedDurationMs(raw: number | null | undefined): number | unde
   if (!(ms > 0)) return undefined;
   if (ms > MAX_LAUNCH_SAMPLE_MS) return undefined;
   return ms;
-}
-
-function normalizeUrl(raw: string): string | null {
-  if (!raw) return null;
-  try {
-    const url = new URL(raw);
-    url.hash = '';
-    return url.toString();
-  } catch {
-    return raw;
-  }
-}
-
-function numberOrZero(value: unknown): number {
-  return typeof value === 'number' && Number.isFinite(value) ? value : 0;
-}
-
-/**
- * Find the parent's `PerformanceResourceTiming` entry for the block iframe.
- *
- * Matched by URL only, deliberately: the parent document has no other reason to
- * fetch `https://<slug>.civit.ai/`, and `initiatorType` for a subframe document
- * is browser-dependent (measured as `iframe` in Chromium 151; Safari has
- * historically not surfaced subframe navigations in the parent timeline at all).
- * Filtering on it would turn a browser quirk into a silently missing phase.
- * Last match wins — a re-keyed iframe (the manual Retry path) adds a second
- * entry.
- *
- * Prefers the entry's own `duration`; falls back to `responseEnd - startTime`
- * (identical by spec) for an entry-like object that only carries the endpoints.
- *
- * Returns `null` when nothing matches — a fully supported state (e.g. the
- * ~250-entry resource buffer overflowed on a heavy page). The caller then emits
- * no `frame_fetch` sample; `token_mint` / `init_wait` / `total` are unaffected.
- */
-export function matchIframeResourceEntry(
-  src: string,
-  entries: ReadonlyArray<{
-    name?: unknown;
-    duration?: unknown;
-    startTime?: unknown;
-    responseEnd?: unknown;
-  }>
-): LaunchFrameTiming | null {
-  const target = normalizeUrl(src);
-  if (!target) return null;
-  let match: LaunchFrameTiming | null = null;
-  for (const entry of entries) {
-    if (typeof entry?.name !== 'string') continue;
-    if (normalizeUrl(entry.name) !== target) continue;
-    const duration =
-      typeof entry.duration === 'number' && Number.isFinite(entry.duration) && entry.duration > 0
-        ? entry.duration
-        : numberOrZero(entry.responseEnd) - numberOrZero(entry.startTime);
-    match = { durationMs: duration };
-  }
-  return match;
 }
 
 /**
@@ -219,20 +177,9 @@ export function isDocumentHidden(): boolean {
   }
 }
 
-/** Browser-side wrapper. Never throws; returns `null` outside a DOM. */
-export function readIframeResourceTiming(src: string): LaunchFrameTiming | null {
-  try {
-    if (typeof performance === 'undefined' || typeof performance.getEntriesByType !== 'function')
-      return null;
-    return matchIframeResourceEntry(src, performance.getEntriesByType('resource'));
-  } catch {
-    return null;
-  }
-}
-
 /**
- * Turn the marks + the (optional) iframe resource entry into the beacon's
- * `timings` object, or `null` when this launch must not be observed at all.
+ * Turn the marks into the beacon's `timings` object, or `null` when this launch
+ * must not be observed at all.
  *
  * 🔴 RETURNS null (no sample) WHEN:
  *   - the tab was ever hidden during the launch window — throttled timers, zero
@@ -248,10 +195,7 @@ export function readIframeResourceTiming(src: string): LaunchFrameTiming | null 
  * nothing to be interpreted against, so the whole sample is dropped rather than
  * emitting orphan phases.
  */
-export function computeLaunchTimings(
-  marks: LaunchMarks,
-  frame: LaunchFrameTiming | null
-): LaunchTimingsPayload | null {
+export function computeLaunchTimings(marks: LaunchMarks): LaunchTimingsPayload | null {
   if (marks.wasHidden) return null;
 
   const totalMs = boundedDeltaMs(marks.mountedAt, marks.readyAt);
@@ -259,34 +203,55 @@ export function computeLaunchTimings(
 
   const tokenMintMs = boundedDeltaMs(marks.mountedAt, marks.tokenAt);
   const initWaitMs = boundedDeltaMs(marks.initSentAt, marks.readyAt);
-  const frameFetchMs = frame ? boundedDurationMs(frame.durationMs) : undefined;
 
   return {
     totalMs,
     ...(tokenMintMs !== undefined ? { tokenMintMs } : {}),
-    ...(frameFetchMs !== undefined ? { frameFetchMs } : {}),
     ...(initWaitMs !== undefined ? { initWaitMs } : {}),
   };
 }
 
-// ─── DEFERRED: the sub-phase (DNS / connect / TTFB) breakdown ─────────────────
+// ─── 🔴 DEFERRED: a cross-origin `frame_fetch` phase ──────────────────────────
 //
-// `frame_fetch` above is the TOTAL iframe-document fetch. Splitting it into
-// DNS vs TCP+TLS vs TTFB needs `domainLookupStart/End`, `connectStart/End` and
-// `responseStart`, which a cross-origin response only discloses when it sends
-// `Timing-Allow-Origin` — and TAO is baked into each block's IMAGE at build
-// time, so it would take a ~20-app rebuild (20 pushes + 20 moderator approvals;
-// `blocks.retriggerBuild` refuses a `live` deploy state outright).
+// An earlier revision of this change shipped a `frame_fetch` phase read from the
+// parent's `PerformanceResourceTiming` entry for the block iframe. IT WAS
+// REMOVED, and not because it needed polish — the number it produced was not the
+// number its name claimed.
 //
-// 🔴 THAT REBUILD IS CANCELLED, deliberately. The decision TAO was meant to
-// serve is "is `preconnect` worth shipping?", and that needs the TOTAL, not the
-// split: ship preconnect and A/B this `frame_fetch` distribution. TAO is
-// explanatory, not decisive.
+// 1. WITHOUT `Timing-Allow-Origin`, `responseEnd` FOR A CROSS-ORIGIN SUBFRAME IS
+//    THE FRAME'S `load` EVENT, NOT THE DOCUMENT RESPONSE. The HTML spec's iframe
+//    load steps set the fallback "response end time" to the current time when the
+//    subframe's load event fires, and the TAO check is what selects between that
+//    fallback and the real document timing. So the SAME field carries two
+//    different quantities depending on a header we do not send: with TAO (or
+//    same-origin) it is document-response completion; without, it is the whole
+//    subframe load, including the block's own JS, CSS, fonts and images.
+//    Measured on Chromium 144 and 150 against a child page holding one
+//    subresource: the no-TAO duration tracked the delay 1:1 (657 / 2053 /
+//    5066 ms for 500 / 2000 / 5000 ms held) while TAO and same-origin stayed at
+//    3-9 ms. Practical effect on a real block: the phase reads close to `total`,
+//    seconds not milliseconds, and visually dominates any phase panel while
+//    measuring roughly what `total` already measures.
 //
-// If the breakdown is ever wanted, the seam is small and lives entirely in this
-// file plus the histogram's label set: read the extra fields in
-// `matchIframeResourceEntry`, gate each sub-phase on `connectEnd > 0` (the
-// direct observable for "this response carried TAO" — a zero there means "not
-// disclosed", never "instant", so it must be DROPPED and never emitted as 0),
-// and carry a `tao: present|absent` label so the coverage denominator is visible
-// on the panel rather than a biased subset being quoted fleet-wide.
+// 2. AND IT IS NOT 100% OBSERVABLE ANYWAY. The entry does not exist until the
+//    subframe's load event fires. An SPA block that posts BLOCK_READY at
+//    app-mount — the normal case, with fonts and images still in flight —
+//    produces NO entry at the moment the beacon reads it, so the phase silently
+//    vanishes. Heavier apps drop out more often, which makes the missing data
+//    slowness-correlated: exactly the bias that makes a percentile lie in the
+//    reassuring direction.
+//
+// Together those leave three honest options: (a) send TAO and measure the
+// document response, (b) measure from inside the block via the SDK, or (c) don't
+// ship the phase. This change takes (c). The `Timing-Allow-Origin` question is
+// being reopened separately and is NOT merely explanatory — because the header
+// changes WHICH QUANTITY the field carries, it may be a genuine prerequisite
+// rather than a nice-to-have.
+//
+// If the phase comes back, the seam is small: add the literal to LAUNCH_PHASES
+// here and to APP_BLOCK_LAUNCH_PHASES server-side, add one optional
+// `frameFetchMs` number to the beacon schema, and populate it in
+// `computeLaunchTimings`. Nothing else in this module is shaped around its
+// absence. Whatever is added must state plainly WHICH of the two quantities it
+// measures, and must publish its own coverage denominator rather than being
+// quoted as a fleet number.

--- a/src/components/AppBlocks/launchTimings.ts
+++ b/src/components/AppBlocks/launchTimings.ts
@@ -1,0 +1,292 @@
+// App Blocks — LAUNCH-LATENCY marks and the pure math that turns them into a
+// beacon payload.
+//
+// WHY THIS IS A SEPARATE MODULE AND NOT INLINE IN PageBlockHost:
+// every rule below (never-emit-a-zero, drop-don't-clamp, the hidden-tab drop)
+// is a correctness rule whose failure mode is a *plausible wrong number* rather
+// than a crash. Those need node-runnable tests, and the browser (`component`)
+// Vitest project is not run in CI — only the `unit` project is. So the math
+// lives here, and the host only records marks.
+//
+// ─── The launch chain this measures ───────────────────────────────────────────
+// Design + measurements: datapacket-talos
+// claudedocs/app-blocks-launch-latency-instrumentation-and-preload-2026-08-02.md
+//
+// 🔴 THE TOKEN MINT AND THE CROSS-ORIGIN FRAME LOAD RUN IN PARALLEL.
+// `showIframe` is true while `status === 'loading'`, and the initial status IS
+// 'loading', so `<iframe src>` (an SSR prop, not derived from the token) mounts
+// on the FIRST client render — before any token exists. The launch therefore
+// waits on `max(token, block-listener-attached)`, then the BLOCK_INIT re-post
+// cadence, then the block's own render-to-ready.
+//
+// So `token_mint + frame_fetch + init_wait !== total`, BY CONSTRUCTION, and any
+// consumer that sums the phases is reading a fiction. They are three
+// independent legs of one race; `total` is the only end-to-end number.
+
+/** Code-owned phase enum. Mirrored server-side in app-block-runtime.metrics. */
+export const LAUNCH_PHASES = ['token_mint', 'frame_fetch', 'init_wait'] as const;
+export type LaunchPhase = (typeof LAUNCH_PHASES)[number];
+
+/**
+ * Upper sanity bound on any single launch sample, in milliseconds.
+ *
+ * 30 s sits comfortably above `TOKEN_WAIT_TIMEOUT_MS` (15 s), the longest leg
+ * that can legitimately complete — a `total` above 10 s is already structurally
+ * impossible on the success path (`BLOCK_READY_TIMEOUT_MS` fires first and no
+ * `ok` beacon is sent). Anything past 30 s is a suspended tab, a clock anomaly,
+ * or a bug.
+ *
+ * 🔴 DROPPED, NEVER CLAMPED — mirrors `observeCustomComfyWallclockSeconds`. A
+ * clamp folds junk onto the `+Inf` edge and poisons `_sum` and every tail
+ * quantile with a value that was never real.
+ */
+export const MAX_LAUNCH_SAMPLE_MS = 30_000;
+
+/**
+ * The iframe-document fetch, as read from the PARENT's resource timeline.
+ *
+ * ✅ MEASURED (Chromium 151.0.7922.71, two-port loopback harness, 2026-08-03):
+ * a cross-origin iframe document navigation DOES appear in the parent's
+ * `performance.getEntriesByType('resource')` with `initiatorType: 'iframe'`, and
+ * **without `Timing-Allow-Origin` the entry still carries real, non-zero
+ * `startTime`, `responseEnd` and `duration`.** Only the DECOMPOSITION is zeroed
+ * (`domainLookupStart/End`, `connectStart/End`, `requestStart`, `responseStart`,
+ * `transferSize`, `encodedBodySize`, empty `nextHopProtocol`). Controls: a
+ * cross-origin `<img>` shows the identical zeroing (so it is the standard
+ * cross-origin TAO restriction, not iframe-specific), and a same-origin iframe
+ * has every field in both runs (so it is genuinely cross-origin, not "iframes
+ * never get timings").
+ *
+ * 🔴 CONSEQUENCE: `frame_fetch` is available at **100% coverage today**, on every
+ * app, with no TAO header and no fleet rebuild. Earlier drafts of the design gated
+ * this phase on `connectEnd > 0` and carried a `tao: present|absent` coverage
+ * label; the measurement retired both. See the SUB-PHASE SEAM note at the bottom
+ * of this file for what TAO would still buy and why it is deferred.
+ */
+export type LaunchFrameTiming = {
+  /** `responseEnd - startTime` for the iframe document. */
+  durationMs: number;
+};
+
+/** Mutable per-mount marks, all `performance.now()` values. */
+export type LaunchMarks = {
+  /** Host mount (first client render). `null` on the server. */
+  mountedAt: number | null;
+  /** First non-null token — the END of the mint leg, not its start. */
+  tokenAt: number | null;
+  /** First BLOCK_INIT posted. */
+  initSentAt: number | null;
+  /** BLOCK_READY received. */
+  readyAt: number | null;
+  /**
+   * 🔴 Sticky: true if the tab was hidden at ANY point from mount to ready.
+   * A run page opened in a background tab gets throttled timers and a
+   * BLOCK_READY seconds late at zero user-felt cost. Without this the p95
+   * measures tab-switching, not launch.
+   */
+  wasHidden: boolean;
+};
+
+/** The optional `timings` object carried on the existing block-render beacon. */
+export type LaunchTimingsPayload = {
+  totalMs: number;
+  tokenMintMs?: number;
+  frameFetchMs?: number;
+  initWaitMs?: number;
+};
+
+export function createLaunchMarks(now: number | null, hidden: boolean): LaunchMarks {
+  return { mountedAt: now, tokenAt: null, initSentAt: null, readyAt: null, wasHidden: hidden };
+}
+
+/**
+ * Re-arm the marks in place for a NEW block instance. `/apps/run/[slug]` renders
+ * <PageBlockHost> with no `key`, so a soft navigation between two apps REUSES
+ * the component instance — app A's `mountedAt` would otherwise be attributed to
+ * app B's launch. Mutates rather than replaces so callers keep a stable ref.
+ */
+export function resetLaunchMarks(marks: LaunchMarks, now: number | null, hidden: boolean): void {
+  marks.mountedAt = now;
+  marks.tokenAt = null;
+  marks.initSentAt = null;
+  marks.readyAt = null;
+  marks.wasHidden = hidden;
+}
+
+/**
+ * A bounded, strictly-positive millisecond delta, or `undefined`.
+ *
+ * 🔴 THE `> 0` IS THE "NEVER EMIT A ZERO" RULE, and it is why this is one
+ * function rather than three inline subtractions. A zero is indistinguishable
+ * from an instant leg, so emitting one for a leg that simply was not observed
+ * drags every percentile down — silently, and in the reassuring direction.
+ */
+export function boundedDeltaMs(
+  from: number | null | undefined,
+  to: number | null | undefined
+): number | undefined {
+  if (typeof from !== 'number' || typeof to !== 'number') return undefined;
+  if (!Number.isFinite(from) || !Number.isFinite(to)) return undefined;
+  return boundedDurationMs(to - from);
+}
+
+/** The same two gates applied to an already-computed duration. */
+export function boundedDurationMs(raw: number | null | undefined): number | undefined {
+  if (typeof raw !== 'number' || !Number.isFinite(raw)) return undefined;
+  const ms = Math.round(raw);
+  if (!(ms > 0)) return undefined;
+  if (ms > MAX_LAUNCH_SAMPLE_MS) return undefined;
+  return ms;
+}
+
+function normalizeUrl(raw: string): string | null {
+  if (!raw) return null;
+  try {
+    const url = new URL(raw);
+    url.hash = '';
+    return url.toString();
+  } catch {
+    return raw;
+  }
+}
+
+function numberOrZero(value: unknown): number {
+  return typeof value === 'number' && Number.isFinite(value) ? value : 0;
+}
+
+/**
+ * Find the parent's `PerformanceResourceTiming` entry for the block iframe.
+ *
+ * Matched by URL only, deliberately: the parent document has no other reason to
+ * fetch `https://<slug>.civit.ai/`, and `initiatorType` for a subframe document
+ * is browser-dependent (measured as `iframe` in Chromium 151; Safari has
+ * historically not surfaced subframe navigations in the parent timeline at all).
+ * Filtering on it would turn a browser quirk into a silently missing phase.
+ * Last match wins — a re-keyed iframe (the manual Retry path) adds a second
+ * entry.
+ *
+ * Prefers the entry's own `duration`; falls back to `responseEnd - startTime`
+ * (identical by spec) for an entry-like object that only carries the endpoints.
+ *
+ * Returns `null` when nothing matches — a fully supported state (e.g. the
+ * ~250-entry resource buffer overflowed on a heavy page). The caller then emits
+ * no `frame_fetch` sample; `token_mint` / `init_wait` / `total` are unaffected.
+ */
+export function matchIframeResourceEntry(
+  src: string,
+  entries: ReadonlyArray<{
+    name?: unknown;
+    duration?: unknown;
+    startTime?: unknown;
+    responseEnd?: unknown;
+  }>
+): LaunchFrameTiming | null {
+  const target = normalizeUrl(src);
+  if (!target) return null;
+  let match: LaunchFrameTiming | null = null;
+  for (const entry of entries) {
+    if (typeof entry?.name !== 'string') continue;
+    if (normalizeUrl(entry.name) !== target) continue;
+    const duration =
+      typeof entry.duration === 'number' && Number.isFinite(entry.duration) && entry.duration > 0
+        ? entry.duration
+        : numberOrZero(entry.responseEnd) - numberOrZero(entry.startTime);
+    match = { durationMs: duration };
+  }
+  return match;
+}
+
+/**
+ * `performance.now()`, or `null` where there is no clock (SSR). A `null` mark
+ * propagates: `boundedDeltaMs` rejects it, so the sample is simply not reported
+ * rather than being reported as a bogus delta from 0.
+ */
+export function nowMs(): number | null {
+  try {
+    if (typeof performance === 'undefined' || typeof performance.now !== 'function') return null;
+    return performance.now();
+  } catch {
+    return null;
+  }
+}
+
+/** True when the tab is currently hidden. Never throws; false outside a DOM. */
+export function isDocumentHidden(): boolean {
+  try {
+    return typeof document !== 'undefined' && document.visibilityState === 'hidden';
+  } catch {
+    return false;
+  }
+}
+
+/** Browser-side wrapper. Never throws; returns `null` outside a DOM. */
+export function readIframeResourceTiming(src: string): LaunchFrameTiming | null {
+  try {
+    if (typeof performance === 'undefined' || typeof performance.getEntriesByType !== 'function')
+      return null;
+    return matchIframeResourceEntry(src, performance.getEntriesByType('resource'));
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Turn the marks + the (optional) iframe resource entry into the beacon's
+ * `timings` object, or `null` when this launch must not be observed at all.
+ *
+ * 🔴 RETURNS null (no sample) WHEN:
+ *   - the tab was ever hidden during the launch window — throttled timers, zero
+ *     user-felt cost, would measure tab-switching;
+ *   - there is no `mountedAt`/`readyAt` — nothing reached BLOCK_READY, so there
+ *     is no launch. (The caller additionally only ever asks on the `ok` beacon:
+ *     a FAILURE beacon has no BLOCK_READY, and observing it would record the
+ *     failure as a *fast* launch; a `secondary` beacon describes a teardown
+ *     minutes later.)
+ *   - `total` is non-positive or past `MAX_LAUNCH_SAMPLE_MS`.
+ *
+ * `total` is the anchor: without a credible end-to-end number the phases have
+ * nothing to be interpreted against, so the whole sample is dropped rather than
+ * emitting orphan phases.
+ */
+export function computeLaunchTimings(
+  marks: LaunchMarks,
+  frame: LaunchFrameTiming | null
+): LaunchTimingsPayload | null {
+  if (marks.wasHidden) return null;
+
+  const totalMs = boundedDeltaMs(marks.mountedAt, marks.readyAt);
+  if (totalMs === undefined) return null;
+
+  const tokenMintMs = boundedDeltaMs(marks.mountedAt, marks.tokenAt);
+  const initWaitMs = boundedDeltaMs(marks.initSentAt, marks.readyAt);
+  const frameFetchMs = frame ? boundedDurationMs(frame.durationMs) : undefined;
+
+  return {
+    totalMs,
+    ...(tokenMintMs !== undefined ? { tokenMintMs } : {}),
+    ...(frameFetchMs !== undefined ? { frameFetchMs } : {}),
+    ...(initWaitMs !== undefined ? { initWaitMs } : {}),
+  };
+}
+
+// ─── DEFERRED: the sub-phase (DNS / connect / TTFB) breakdown ─────────────────
+//
+// `frame_fetch` above is the TOTAL iframe-document fetch. Splitting it into
+// DNS vs TCP+TLS vs TTFB needs `domainLookupStart/End`, `connectStart/End` and
+// `responseStart`, which a cross-origin response only discloses when it sends
+// `Timing-Allow-Origin` — and TAO is baked into each block's IMAGE at build
+// time, so it would take a ~20-app rebuild (20 pushes + 20 moderator approvals;
+// `blocks.retriggerBuild` refuses a `live` deploy state outright).
+//
+// 🔴 THAT REBUILD IS CANCELLED, deliberately. The decision TAO was meant to
+// serve is "is `preconnect` worth shipping?", and that needs the TOTAL, not the
+// split: ship preconnect and A/B this `frame_fetch` distribution. TAO is
+// explanatory, not decisive.
+//
+// If the breakdown is ever wanted, the seam is small and lives entirely in this
+// file plus the histogram's label set: read the extra fields in
+// `matchIframeResourceEntry`, gate each sub-phase on `connectEnd > 0` (the
+// direct observable for "this response carried TAO" — a zero there means "not
+// disclosed", never "instant", so it must be DROPPED and never emitted as 0),
+// and carry a `tao: present|absent` label so the coverage denominator is visible
+// on the panel rather than a biased subset being quoted fleet-wide.

--- a/src/components/AppBlocks/pageBlockHostLogic.ts
+++ b/src/components/AppBlocks/pageBlockHostLogic.ts
@@ -558,6 +558,63 @@ export const MAX_AUTO_REMINTS = 1;
  */
 export const AUTO_RETRY_BACKOFF_MS: readonly number[] = [2_000, 5_000];
 
+/**
+ * How long the host waits for the block to ack `BLOCK_READY` before settling on
+ * the `timeout` terminal, and how long it waits for a token before settling on
+ * `no_token`. Re-exported from `PageBlockHost` (its historical home) so existing
+ * importers are unaffected.
+ *
+ * 🔴 They live HERE, in the pure module, so a NODE test can import them: they are
+ * inputs to `worstReachableLaunchMs()` below, and importing them from the
+ * component would drag the whole React graph into the `unit` project.
+ */
+export const BLOCK_READY_TIMEOUT_MS = 10_000;
+export const TOKEN_WAIT_TIMEOUT_MS = 15_000;
+
+/**
+ * The longest wall-clock a SUCCESSFUL launch can legitimately take, derived from
+ * the constants above rather than asserted.
+ *
+ * 🔴 WHY THIS IS A FUNCTION AND NOT A COMMENT. The launch-latency histograms drop
+ * any sample past a fixed cap, and that cap has to clear this bound or it silently
+ * discards real slow successes — a slowness-correlated drop that trims exactly the
+ * tail the metric exists to show. Two earlier revisions got the arithmetic wrong in
+ * a comment (once by ~27s, once by ~10s) and nothing was red either time. A test
+ * now asserts both caps exceed this value, so widening any input below walks the
+ * bound up and fails loudly.
+ *
+ * 🔴 THE SEQUENCE, and why it is NOT `attempts x (token + ready)`:
+ *
+ *   attempt 1   no token at all -> `no_token` at TOKEN_WAIT_TIMEOUT_MS.
+ *               This is an AUTH terminal, so it spends the re-mint budget.
+ *   + backoff[0]
+ *   attempt 2   a re-mint is in flight, so this attempt can AGAIN pay the full
+ *               token wait; the ready timer only arms once `hasToken` lets
+ *               `shouldStartInit` pass, so the two windows are SERIAL within the
+ *               attempt: TOKEN_WAIT + BLOCK_READY_TIMEOUT -> `timeout`.
+ *               `timeout` is NON-auth, so it spends no re-mint and a third
+ *               attempt is still allowed.
+ *   + backoff[1]
+ *   attempt 3   the token from attempt 2 PERSISTS (nothing cleared it), so the
+ *               token wait cannot be paid again — this attempt is bounded by
+ *               BLOCK_READY_TIMEOUT alone, and ends in `ok`.
+ *
+ * Two consecutive `no_token`s are UNREACHABLE (`MAX_AUTO_REMINTS = 1` stops the
+ * second), and a post-`timeout` attempt cannot re-pay the token wait. Both of
+ * those are why the naive `3 x (15 + 10) + backoffs` = 82s over-states it, and
+ * why treating every attempt as ~15s under-states it.
+ */
+export function worstReachableLaunchMs(): number {
+  const backoffs = AUTO_RETRY_BACKOFF_MS.slice(0, MAX_AUTO_RETRIES).reduce((a, b) => a + b, 0);
+  // attempt 1: the auth terminal that costs the full token wait.
+  const first = TOKEN_WAIT_TIMEOUT_MS;
+  // The one attempt that can pay BOTH windows (a re-mint is in flight).
+  const remintedAttempt = TOKEN_WAIT_TIMEOUT_MS + BLOCK_READY_TIMEOUT_MS;
+  // Every later attempt already holds a token, so it is ready-bounded only.
+  const tokenHoldingAttempts = Math.max(0, MAX_AUTO_RETRIES - MAX_AUTO_REMINTS);
+  return first + remintedAttempt + tokenHoldingAttempts * BLOCK_READY_TIMEOUT_MS + backoffs;
+}
+
 /** Terminal statuses a bounded auto-retry may attempt to recover from. */
 export function isAutoRetryableStatus(status: PageHostStatus): boolean {
   return (

--- a/src/components/AppBlocks/sendBlockRender.ts
+++ b/src/components/AppBlocks/sendBlockRender.ts
@@ -67,9 +67,16 @@ export type BlockRenderBeaconInput = {
   // same rule, but do not rely on that.
   //
   // Server-side these drive `civitai_app_block_launch_total_seconds{app_block_id}`
-  // and `civitai_app_block_launch_phase_seconds{phase,conn,tao}` — and, like
+  // and `civitai_app_block_launch_phase_seconds{phase}` — and, like
   // status/errorClass/secondary, they are STRIPPED from the ClickHouse insert by
   // BOTH writers (`blockRenderTrackerPayload`).
+  //
+  // 🔴 NUMBERS ONLY. The `phase` label is code-owned and mapped server-side from
+  // these field NAMES; nothing here is ever used as a label value, so a public
+  // beacon body cannot touch cardinality. (An earlier draft of this comment
+  // advertised `{phase,conn,tao}`. Those labels never shipped — they belonged to
+  // a TAO-gated frame-fetch phase that was designed and then dropped; see the
+  // DEFERRED note in launchTimings.ts.)
   timings?: LaunchTimingsPayload;
 };
 

--- a/src/components/AppBlocks/sendBlockRender.ts
+++ b/src/components/AppBlocks/sendBlockRender.ts
@@ -1,3 +1,5 @@
+import type { LaunchTimingsPayload } from './launchTimings';
+
 // App Blocks Analytics Phase 2 — block render/impression beacon (client side).
 //
 // Fire a block render/impression at the lightweight /api/track/block-render
@@ -51,6 +53,24 @@ export type BlockRenderBeaconInput = {
   // impossible to de-duplicate later. Omit (or false) for a mount's FIRST
   // beacon, including a launch failure, which must still be recorded.
   secondary?: boolean;
+  // 🔴 OPTIONAL LAUNCH TIMINGS — rides the EXISTING beacon, never a second one.
+  //
+  // There is exactly ONE beacon per host mount (`blockRenderEmittedRef`, with
+  // ok/error mutually exclusive). Adding a second beacon for timing would write
+  // a second `blockRenders` ClickHouse row for one mount — byte-identical to the
+  // first, therefore undedupable — inflating every impression figure. So these
+  // ride along as optional fields: same beacon count, same row count, same
+  // `renders_total` increments.
+  //
+  // Attach ONLY on the `ok` (BLOCK_READY) beacon. A failure beacon never reached
+  // BLOCK_READY and a `secondary` beacon is a teardown; the server enforces the
+  // same rule, but do not rely on that.
+  //
+  // Server-side these drive `civitai_app_block_launch_total_seconds{app_block_id}`
+  // and `civitai_app_block_launch_phase_seconds{phase,conn,tao}` — and, like
+  // status/errorClass/secondary, they are STRIPPED from the ClickHouse insert by
+  // BOTH writers (`blockRenderTrackerPayload`).
+  timings?: LaunchTimingsPayload;
 };
 
 export function sendBlockRender(input: BlockRenderBeaconInput) {

--- a/src/pages/api/track/block-render.ts
+++ b/src/pages/api/track/block-render.ts
@@ -5,9 +5,10 @@ import {
   ensureRegisterAppBlockRuntimeMetrics,
   normalizeErrorClass,
   normalizeSlotId,
+  observeAppBlockLaunch,
 } from '~/server/metrics/app-block-runtime.metrics';
 import { boundAppBlockIdLabel } from '~/server/services/blocks/known-app-blocks.service';
-import { blockRenderSchema } from '~/server/schema/track.schema';
+import { blockRenderSchema, blockRenderTrackerPayload } from '~/server/schema/track.schema';
 import { PublicEndpoint } from '~/server/utils/endpoint-helpers';
 
 // App Blocks Analytics Phase 2 — block render/impression beacon.
@@ -67,17 +68,17 @@ export default PublicEndpoint(
     const result = blockRenderSchema.safeParse(parsed);
     if (!result.success) return res.status(400).send('invalid input');
 
-    // `status`/`errorClass`/`secondary` drive the prom render counter ONLY — they
-    // are NOT forwarded to the ClickHouse insert (the `blockRenders` table is
+    // `status`/`errorClass`/`secondary`/`timings` drive prom ONLY — none is
+    // forwarded to the ClickHouse insert (the `blockRenders` table is
     // provisioned out-of-repo by the tracker service; adding columns is out of
-    // scope here). Strip them so the CH payload stays byte-identical to the
-    // pre-change insert. `errorClass` still drives the prom label below
-    // (normalized), never the CH insert.
+    // scope here). `blockRenderTrackerPayload` is the shared ALLOWLIST that
+    // builds the CH payload, so it stays byte-identical to the pre-change insert
+    // and the OTHER writer (`track.blockRender`) cannot drift from this one.
     //
     // 🔴 `secondary` ALSO GATES THE CH INSERT ENTIRELY (see below). Every beacon
     // increments the prom counter, but only a mount's FIRST beacon writes a
     // `blockRenders` row — that table counts IMPRESSIONS, one per host mount.
-    const { status, errorClass, secondary, ...renderData } = result.data;
+    const { status, errorClass, secondary, timings } = result.data;
 
     // Per-app render/impression outcome (additive + dark). `result` ∈ ok|error.
     // ALL labels are BOUNDED even though the beacon body is client-supplied and
@@ -90,14 +91,29 @@ export default PublicEndpoint(
     // gates so only well-formed beacons count. Fire-and-forget: never let a
     // metrics failure break the beacon.
     try {
-      const appBlockIdLabel = await boundAppBlockIdLabel(renderData.appBlockId);
+      const appBlockIdLabel = await boundAppBlockIdLabel(result.data.appBlockId);
       const { rendersTotal } = ensureRegisterAppBlockRuntimeMetrics();
       rendersTotal.inc({
         app_block_id: appBlockIdLabel,
-        slot_id: normalizeSlotId(renderData.slotId),
+        slot_id: normalizeSlotId(result.data.slotId),
         result: status,
         error_class: normalizeErrorClass(status, errorClass),
       });
+
+      // ── LAUNCH LATENCY ────────────────────────────────────────────────────
+      // Reuses the `appBlockIdLabel` already resolved above (TTL-cached, no
+      // extra DB read) and rides inside the SAME try/catch, so a launch-metric
+      // failure can never affect the beacon response.
+      //
+      // 🔴 GATED ON `ok` AND `!secondary`, and both halves are load-bearing:
+      //   - a launch-FAILURE beacon never saw BLOCK_READY, so its `total` is
+      //     meaningless — and worse, a fast failure would be recorded as a FAST
+      //     LAUNCH, biasing the distribution in the reassuring direction;
+      //   - a `secondary` beacon is a mid-session credential-loss teardown,
+      //     reported minutes after a launch that already succeeded.
+      // The client also only attaches `timings` on the success path; this is the
+      // server-side half of the same rule, because the body is client-supplied.
+      if (status === 'ok' && !secondary) observeAppBlockLaunch(appBlockIdLabel, timings);
     } catch {
       // swallow — observability must not affect the response
     }
@@ -130,7 +146,10 @@ export default PublicEndpoint(
     const tracker = new Tracker(req, res, session);
     // Fire-and-forget: blockRender() dispatches the ClickHouse insert without
     // awaiting the network round-trip (same as the tRPC resolver did).
-    void tracker.blockRender({ ...renderData, isAnon: !session?.user });
+    void tracker.blockRender({
+      ...blockRenderTrackerPayload(result.data),
+      isAnon: !session?.user,
+    });
 
     return res.status(200).end();
   },

--- a/src/server/metrics/__tests__/app-block-launch.metrics.test.ts
+++ b/src/server/metrics/__tests__/app-block-launch.metrics.test.ts
@@ -1,0 +1,254 @@
+import { describe, expect, it } from 'vitest';
+import client from 'prom-client';
+
+/**
+ * App Block LAUNCH-LATENCY histograms — `observeAppBlockLaunch` and its
+ * `launchSampleSeconds` gate, exercised against the REAL default prom-client
+ * registry (the same one /api/metrics scrapes).
+ *
+ * What is pinned here, and why each one matters:
+ *   - the NEVER-EMIT-A-ZERO gate (a zero reads as an instant leg and drags every
+ *     percentile down, in the reassuring direction);
+ *   - DROP-NEVER-CLAMP for an out-of-range sample (a clamp folds junk onto the
+ *     +Inf edge and pollutes _sum and the tail);
+ *   - `total` is the ANCHOR — an invalid total suppresses the phases too, WITH a
+ *     positive control proving the same phase is observed when the total is
+ *     valid (otherwise "0 phase observations" is indistinguishable from a
+ *     histogram wired to nothing);
+ *   - the BUCKET EDGES are the ones the design justified against the real launch
+ *     constants, not prom-client's defaults;
+ *   - the emitter never throws (it runs on a public fire-and-forget beacon).
+ */
+
+import {
+  launchSampleSeconds,
+  MAX_APP_BLOCK_LAUNCH_SECONDS,
+  observeAppBlockLaunch,
+} from '~/server/metrics/app-block-runtime.metrics';
+
+const TOTAL_METRIC = 'civitai_app_block_launch_total_seconds';
+const PHASE_METRIC = 'civitai_app_block_launch_phase_seconds';
+
+type HistPoint = { metricName?: string; labels: Record<string, string>; value: number };
+
+/**
+ * Read one histogram aggregate for a label set. Returns 0 when the series does
+ * not exist yet, so every assertion can be a before/after DELTA — the registry
+ * is process-global and other suites may already have observed samples.
+ */
+async function readHist(
+  name: string,
+  suffix: '_count' | '_sum',
+  labels: Record<string, string>
+): Promise<number> {
+  const metric = client.register.getSingleMetric(name);
+  if (!metric) return 0;
+  const data = await (metric as unknown as { get(): Promise<{ values: HistPoint[] }> }).get();
+  const point = data.values.find(
+    (v) =>
+      v.metricName === `${name}${suffix}` &&
+      Object.entries(labels).every(([k, val]) => v.labels[k] === val)
+  );
+  return point?.value ?? 0;
+}
+
+/** Cumulative count in the `le` bucket for a label set. */
+async function readBucket(
+  name: string,
+  le: string,
+  labels: Record<string, string>
+): Promise<number> {
+  const metric = client.register.getSingleMetric(name);
+  if (!metric) return 0;
+  const data = await (metric as unknown as { get(): Promise<{ values: HistPoint[] }> }).get();
+  const point = data.values.find(
+    (v) =>
+      v.metricName === `${name}_bucket` &&
+      // prom-client stores `le` as a NUMBER on the in-memory point (it is only
+      // stringified at render time), so compare stringified or this silently
+      // matches nothing and every bucket reads 0 — a false PASS on any
+      // assertion whose "before" is also 0.
+      String(v.labels.le) === le &&
+      Object.entries(labels).every(([k, val]) => v.labels[k] === val)
+  );
+  return point?.value ?? 0;
+}
+
+async function bucketEdges(name: string): Promise<number[]> {
+  const metric = client.register.getSingleMetric(name);
+  if (!metric) return [];
+  const data = await (metric as unknown as { get(): Promise<{ values: HistPoint[] }> }).get();
+  const les = new Set<string>();
+  for (const v of data.values) if (v.metricName === `${name}_bucket`) les.add(String(v.labels.le));
+  return [...les]
+    .map((le) => Number(le))
+    .filter((n) => Number.isFinite(n))
+    .sort((a, b) => a - b);
+}
+
+describe('launchSampleSeconds — the shared sample gate', () => {
+  it('🔴 rejects a ZERO, so an unobserved leg can never read as an instant one', () => {
+    expect(launchSampleSeconds(0)).toBe(null);
+    expect(launchSampleSeconds(-1)).toBe(null);
+  });
+
+  it('🔴 DROPS an out-of-range sample rather than clamping it', () => {
+    expect(launchSampleSeconds(MAX_APP_BLOCK_LAUNCH_SECONDS * 1000)).toBe(
+      MAX_APP_BLOCK_LAUNCH_SECONDS
+    );
+    // One millisecond past the bound → dropped. A clamp would return 30 here.
+    expect(launchSampleSeconds(MAX_APP_BLOCK_LAUNCH_SECONDS * 1000 + 1)).toBe(null);
+    expect(launchSampleSeconds(9_999_999)).toBe(null);
+  });
+
+  it('rejects non-finite and non-numeric input (the body is client-supplied)', () => {
+    expect(launchSampleSeconds(Number.NaN)).toBe(null);
+    expect(launchSampleSeconds(Number.POSITIVE_INFINITY)).toBe(null);
+    expect(launchSampleSeconds('900' as unknown)).toBe(null);
+    expect(launchSampleSeconds(undefined)).toBe(null);
+    expect(launchSampleSeconds(null)).toBe(null);
+    expect(launchSampleSeconds({} as unknown)).toBe(null);
+  });
+
+  it('converts milliseconds to seconds', () => {
+    expect(launchSampleSeconds(1)).toBeCloseTo(0.001, 6);
+    expect(launchSampleSeconds(1_234)).toBeCloseTo(1.234, 6);
+  });
+});
+
+describe('observeAppBlockLaunch', () => {
+  it('observes the total on the per-app histogram and each phase on the phase histogram', async () => {
+    const app = 'apb_launch_ok';
+    const beforeTotal = await readHist(TOTAL_METRIC, '_count', { app_block_id: app });
+    const beforeToken = await readHist(PHASE_METRIC, '_count', { phase: 'token_mint' });
+    const beforeFrame = await readHist(PHASE_METRIC, '_count', { phase: 'frame_fetch' });
+    const beforeInit = await readHist(PHASE_METRIC, '_count', { phase: 'init_wait' });
+
+    observeAppBlockLaunch(app, {
+      totalMs: 1_100,
+      tokenMintMs: 180,
+      frameFetchMs: 320,
+      initWaitMs: 700,
+    });
+
+    expect(await readHist(TOTAL_METRIC, '_count', { app_block_id: app })).toBe(beforeTotal + 1);
+    expect(await readHist(PHASE_METRIC, '_count', { phase: 'token_mint' })).toBe(beforeToken + 1);
+    expect(await readHist(PHASE_METRIC, '_count', { phase: 'frame_fetch' })).toBe(beforeFrame + 1);
+    expect(await readHist(PHASE_METRIC, '_count', { phase: 'init_wait' })).toBe(beforeInit + 1);
+  });
+
+  it('records the total in SECONDS on _sum (not milliseconds)', async () => {
+    const app = 'apb_launch_sum';
+    const before = await readHist(TOTAL_METRIC, '_sum', { app_block_id: app });
+    observeAppBlockLaunch(app, { totalMs: 2_500 });
+    expect(await readHist(TOTAL_METRIC, '_sum', { app_block_id: app })).toBeCloseTo(
+      before + 2.5,
+      6
+    );
+  });
+
+  it('🔴 `total` is the ANCHOR — an invalid total suppresses the PHASES too', async () => {
+    const app = 'apb_launch_anchor';
+    const beforeTotal = await readHist(TOTAL_METRIC, '_count', { app_block_id: app });
+    const beforePhase = await readHist(PHASE_METRIC, '_count', { phase: 'init_wait' });
+
+    // A perfectly valid phase, but no usable total.
+    observeAppBlockLaunch(app, { totalMs: 0, initWaitMs: 700 });
+    expect(await readHist(TOTAL_METRIC, '_count', { app_block_id: app })).toBe(beforeTotal);
+    expect(await readHist(PHASE_METRIC, '_count', { phase: 'init_wait' })).toBe(beforePhase);
+
+    // 🔴 POSITIVE CONTROL. Without this, the two zeros above are indistinguishable
+    // from a histogram that is wired to nothing at all. Same phase, same value,
+    // only the total made valid → the counter MUST move by exactly 1.
+    observeAppBlockLaunch(app, { totalMs: 1_100, initWaitMs: 700 });
+    expect(await readHist(TOTAL_METRIC, '_count', { app_block_id: app })).toBe(beforeTotal + 1);
+    expect(await readHist(PHASE_METRIC, '_count', { phase: 'init_wait' })).toBe(beforePhase + 1);
+  });
+
+  it('🔴 omits a ZERO phase while still recording the total', async () => {
+    const app = 'apb_launch_zero_phase';
+    const beforeTotal = await readHist(TOTAL_METRIC, '_count', { app_block_id: app });
+    const beforeFrame = await readHist(PHASE_METRIC, '_count', { phase: 'frame_fetch' });
+
+    observeAppBlockLaunch(app, { totalMs: 1_100, frameFetchMs: 0 });
+
+    expect(await readHist(TOTAL_METRIC, '_count', { app_block_id: app })).toBe(beforeTotal + 1);
+    expect(await readHist(PHASE_METRIC, '_count', { phase: 'frame_fetch' })).toBe(beforeFrame);
+  });
+
+  it('🔴 DROPS an out-of-range phase rather than clamping it onto the top bucket', async () => {
+    const app = 'apb_launch_drop_phase';
+    const beforeToken = await readHist(PHASE_METRIC, '_count', { phase: 'token_mint' });
+    const beforeSum = await readHist(PHASE_METRIC, '_sum', { phase: 'token_mint' });
+
+    observeAppBlockLaunch(app, { totalMs: 1_100, tokenMintMs: 31_000 });
+
+    expect(await readHist(PHASE_METRIC, '_count', { phase: 'token_mint' })).toBe(beforeToken);
+    // The thing a clamp would break: _sum must be untouched, not +30.
+    expect(await readHist(PHASE_METRIC, '_sum', { phase: 'token_mint' })).toBeCloseTo(beforeSum, 6);
+  });
+
+  it('does nothing when `timings` is absent', async () => {
+    const app = 'apb_launch_absent';
+    const before = await readHist(TOTAL_METRIC, '_count', { app_block_id: app });
+    observeAppBlockLaunch(app, undefined);
+    expect(await readHist(TOTAL_METRIC, '_count', { app_block_id: app })).toBe(before);
+  });
+
+  it('never throws on junk input (public fire-and-forget beacon)', () => {
+    expect(() =>
+      observeAppBlockLaunch('apb_x', { totalMs: 'nope', tokenMintMs: {} } as never)
+    ).not.toThrow();
+    expect(() => observeAppBlockLaunch('apb_x', null as never)).not.toThrow();
+  });
+});
+
+describe('launch histogram bucket boundaries', () => {
+  it('uses the launch-specific edges, NOT prom-client defaults', async () => {
+    // Force registration + at least one bucket row.
+    observeAppBlockLaunch('apb_launch_buckets', { totalMs: 300, tokenMintMs: 300 });
+
+    const expected = [0.1, 0.25, 0.4, 0.6, 0.8, 1.2, 1.8, 2.5, 4, 6, 8, 10, 15];
+    expect(await bucketEdges(TOTAL_METRIC)).toEqual(expected);
+    expect(await bucketEdges(PHASE_METRIC)).toEqual(expected);
+
+    // prom-client's defaults top out at 10 with nothing between 5 and 10 and have
+    // no 0.4 edge — assert we are NOT on them, since a silent fallback to the
+    // defaults would still produce a plausible-looking histogram.
+    expect(await bucketEdges(TOTAL_METRIC)).not.toContain(0.005);
+    expect(await bucketEdges(TOTAL_METRIC)).not.toContain(5);
+  });
+
+  it('🔴 resolves the 400ms BLOCK_INIT tick — a 300ms and a 500ms sample land in different buckets', async () => {
+    const app = 'apb_launch_tick';
+    // 🔴 POSITIVE CONTROL FOR THE READER ITSELF. Every "before" here is 0 for a
+    // fresh app label, so a `readBucket` that matched nothing would make the
+    // 0.25 assertion pass for the wrong reason. Prove the reader can observe a
+    // non-zero first.
+    observeAppBlockLaunch(app, { totalMs: 50 });
+    expect(await readBucket(TOTAL_METRIC, '0.1', { app_block_id: app })).toBe(1);
+
+    const before025 = await readBucket(TOTAL_METRIC, '0.25', { app_block_id: app });
+    const before04 = await readBucket(TOTAL_METRIC, '0.4', { app_block_id: app });
+    const before06 = await readBucket(TOTAL_METRIC, '0.6', { app_block_id: app });
+
+    observeAppBlockLaunch(app, { totalMs: 300 });
+    observeAppBlockLaunch(app, { totalMs: 500 });
+
+    // Buckets are cumulative: 300ms is <= 0.4 but > 0.25; 500ms is <= 0.6 only.
+    expect(await readBucket(TOTAL_METRIC, '0.25', { app_block_id: app })).toBe(before025);
+    expect(await readBucket(TOTAL_METRIC, '0.4', { app_block_id: app })).toBe(before04 + 1);
+    expect(await readBucket(TOTAL_METRIC, '0.6', { app_block_id: app })).toBe(before06 + 2);
+  });
+
+  it('places a >10s total above the le=10 edge (structurally impossible on the success path, so a bug signal)', async () => {
+    const app = 'apb_launch_impossible';
+    const before10 = await readBucket(TOTAL_METRIC, '10', { app_block_id: app });
+    const beforeCount = await readHist(TOTAL_METRIC, '_count', { app_block_id: app });
+
+    observeAppBlockLaunch(app, { totalMs: 12_000 });
+
+    expect(await readBucket(TOTAL_METRIC, '10', { app_block_id: app })).toBe(before10);
+    expect(await readHist(TOTAL_METRIC, '_count', { app_block_id: app })).toBe(beforeCount + 1);
+  });
+});

--- a/src/server/metrics/__tests__/app-block-launch.metrics.test.ts
+++ b/src/server/metrics/__tests__/app-block-launch.metrics.test.ts
@@ -96,9 +96,25 @@ describe('launchSampleSeconds — the shared sample gate', () => {
     expect(launchSampleSeconds(MAX_APP_BLOCK_LAUNCH_SECONDS * 1000)).toBe(
       MAX_APP_BLOCK_LAUNCH_SECONDS
     );
-    // One millisecond past the bound → dropped. A clamp would return 30 here.
+    // One millisecond past the bound → dropped. A clamp would return
+    // MAX_APP_BLOCK_LAUNCH_SECONDS here.
     expect(launchSampleSeconds(MAX_APP_BLOCK_LAUNCH_SECONDS * 1000 + 1)).toBe(null);
     expect(launchSampleSeconds(9_999_999)).toBe(null);
+  });
+
+  /**
+   * 🔴 THE BOUND MUST CLEAR THE AUTO-RETRY WORST CASE.
+   *
+   * The host emits ONE `ok` for the whole bounded auto-retry sequence, whichever
+   * attempt produced it, so a legitimate success can be ~47s (15 no_token + 2
+   * backoff + 15 no_token + 5 backoff + ~10 ready). The previous 30s bound
+   * dropped those, and the drop was slowness-correlated — it trimmed exactly the
+   * tail the metric exists to show. A value pin: red if the bound is lowered back.
+   */
+  it('🔴 accepts a slow auto-retry success (~47s), which the old 30s bound dropped', () => {
+    expect(launchSampleSeconds(47_000)).toBeCloseTo(47, 6);
+    expect(launchSampleSeconds(30_001)).toBeCloseTo(30.001, 6);
+    expect(MAX_APP_BLOCK_LAUNCH_SECONDS).toBeGreaterThan(47);
   });
 
   it('rejects non-finite and non-numeric input (the body is client-supplied)', () => {
@@ -121,20 +137,38 @@ describe('observeAppBlockLaunch', () => {
     const app = 'apb_launch_ok';
     const beforeTotal = await readHist(TOTAL_METRIC, '_count', { app_block_id: app });
     const beforeToken = await readHist(PHASE_METRIC, '_count', { phase: 'token_mint' });
-    const beforeFrame = await readHist(PHASE_METRIC, '_count', { phase: 'frame_fetch' });
     const beforeInit = await readHist(PHASE_METRIC, '_count', { phase: 'init_wait' });
 
-    observeAppBlockLaunch(app, {
-      totalMs: 1_100,
-      tokenMintMs: 180,
-      frameFetchMs: 320,
-      initWaitMs: 700,
-    });
+    observeAppBlockLaunch(app, { totalMs: 1_100, tokenMintMs: 180, initWaitMs: 700 });
 
     expect(await readHist(TOTAL_METRIC, '_count', { app_block_id: app })).toBe(beforeTotal + 1);
     expect(await readHist(PHASE_METRIC, '_count', { phase: 'token_mint' })).toBe(beforeToken + 1);
-    expect(await readHist(PHASE_METRIC, '_count', { phase: 'frame_fetch' })).toBe(beforeFrame + 1);
     expect(await readHist(PHASE_METRIC, '_count', { phase: 'init_wait' })).toBe(beforeInit + 1);
+  });
+
+  /**
+   * 🔴 THE CROSS-ORIGIN PHASE IS DELIBERATELY ABSENT, and a stray client field
+   * must not resurrect it. `frame_fetch` was designed, built, and dropped:
+   * without `Timing-Allow-Origin` the parent's `responseEnd` for a subframe is
+   * the frame's LOAD event, not the document response, so it measures roughly
+   * what `total` already measures — and the entry frequently does not exist yet
+   * when the beacon fires, which biases the missing data toward slow apps.
+   *
+   * The phase label is code-owned, so an old or hand-rolled client sending
+   * `frameFetchMs` must produce NO series at all rather than a fourth phase.
+   */
+  it('🔴 ignores a client-sent frameFetchMs — no frame_fetch series is created', async () => {
+    const app = 'apb_launch_no_frame';
+    observeAppBlockLaunch(app, {
+      totalMs: 1_100,
+      initWaitMs: 700,
+      frameFetchMs: 320,
+    } as never);
+
+    // Positive control first: the sample WAS accepted, so a zero below cannot be
+    // "nothing was observed at all".
+    expect(await readHist(TOTAL_METRIC, '_count', { app_block_id: app })).toBe(1);
+    expect(await readHist(PHASE_METRIC, '_count', { phase: 'frame_fetch' })).toBe(0);
   });
 
   it('records the total in SECONDS on _sum (not milliseconds)', async () => {
@@ -168,12 +202,12 @@ describe('observeAppBlockLaunch', () => {
   it('🔴 omits a ZERO phase while still recording the total', async () => {
     const app = 'apb_launch_zero_phase';
     const beforeTotal = await readHist(TOTAL_METRIC, '_count', { app_block_id: app });
-    const beforeFrame = await readHist(PHASE_METRIC, '_count', { phase: 'frame_fetch' });
+    const beforeToken = await readHist(PHASE_METRIC, '_count', { phase: 'token_mint' });
 
-    observeAppBlockLaunch(app, { totalMs: 1_100, frameFetchMs: 0 });
+    observeAppBlockLaunch(app, { totalMs: 1_100, tokenMintMs: 0 });
 
     expect(await readHist(TOTAL_METRIC, '_count', { app_block_id: app })).toBe(beforeTotal + 1);
-    expect(await readHist(PHASE_METRIC, '_count', { phase: 'frame_fetch' })).toBe(beforeFrame);
+    expect(await readHist(PHASE_METRIC, '_count', { phase: 'token_mint' })).toBe(beforeToken);
   });
 
   it('🔴 DROPS an out-of-range phase rather than clamping it onto the top bucket', async () => {
@@ -181,10 +215,10 @@ describe('observeAppBlockLaunch', () => {
     const beforeToken = await readHist(PHASE_METRIC, '_count', { phase: 'token_mint' });
     const beforeSum = await readHist(PHASE_METRIC, '_sum', { phase: 'token_mint' });
 
-    observeAppBlockLaunch(app, { totalMs: 1_100, tokenMintMs: 31_000 });
+    observeAppBlockLaunch(app, { totalMs: 1_100, tokenMintMs: 61_000 });
 
     expect(await readHist(PHASE_METRIC, '_count', { phase: 'token_mint' })).toBe(beforeToken);
-    // The thing a clamp would break: _sum must be untouched, not +30.
+    // The thing a clamp would break: _sum must be untouched, not +60.
     expect(await readHist(PHASE_METRIC, '_sum', { phase: 'token_mint' })).toBeCloseTo(beforeSum, 6);
   });
 
@@ -241,14 +275,32 @@ describe('launch histogram bucket boundaries', () => {
     expect(await readBucket(TOTAL_METRIC, '0.6', { app_block_id: app })).toBe(before06 + 2);
   });
 
-  it('places a >10s total above the le=10 edge (structurally impossible on the success path, so a bug signal)', async () => {
-    const app = 'apb_launch_impossible';
-    const before10 = await readBucket(TOTAL_METRIC, '10', { app_block_id: app });
+  /**
+   * 🔴 A SLOW AUTO-RETRY SUCCESS IS REAL DATA, NOT A BUG SIGNAL.
+   *
+   * An earlier revision of this test asserted that a >10s total was
+   * "structurally impossible on the success path" because BLOCK_READY_TIMEOUT_MS
+   * fires first. That is true of ONE ATTEMPT and false of a LAUNCH: the host
+   * emits one `ok` for the whole bounded auto-retry sequence, so 12-47s `ok`
+   * samples are reachable. They must be COUNTED (above the top bucket), never
+   * dropped and never read as an emitter fault.
+   */
+  it('🔴 counts a slow auto-retry success above the top bucket instead of dropping it', async () => {
+    const app = 'apb_launch_slow_retry';
+    const before15 = await readBucket(TOTAL_METRIC, '15', { app_block_id: app });
     const beforeCount = await readHist(TOTAL_METRIC, '_count', { app_block_id: app });
+    const beforeSum = await readHist(TOTAL_METRIC, '_sum', { app_block_id: app });
 
-    observeAppBlockLaunch(app, { totalMs: 12_000 });
+    // A success on attempt 3 of the bounded sequence.
+    observeAppBlockLaunch(app, { totalMs: 28_000 });
 
-    expect(await readBucket(TOTAL_METRIC, '10', { app_block_id: app })).toBe(before10);
+    // Above every finite edge…
+    expect(await readBucket(TOTAL_METRIC, '15', { app_block_id: app })).toBe(before15);
+    // …but counted, and contributing its REAL value to _sum (not a clamp).
     expect(await readHist(TOTAL_METRIC, '_count', { app_block_id: app })).toBe(beforeCount + 1);
+    expect(await readHist(TOTAL_METRIC, '_sum', { app_block_id: app })).toBeCloseTo(
+      beforeSum + 28,
+      6
+    );
   });
 });

--- a/src/server/metrics/app-block-runtime.metrics.ts
+++ b/src/server/metrics/app-block-runtime.metrics.ts
@@ -72,9 +72,10 @@ export type AppBlockRenderResult = 'ok' | 'error';
  * imported so this module never pulls a client module into the server graph.
  *
  * 🔴 It is also the cardinality bound, and it is CODE-OWNED: the `phase` label
- * is never taken from the beacon body. The client sends three named numeric
- * fields; this module maps them onto these three literals. A client cannot
- * invent a fourth.
+ * is never taken from the beacon body. The client sends named numeric fields;
+ * this module maps them onto these literals. A client cannot invent a third —
+ * including by sending `frameFetchMs`, which is deliberately not mapped (see the
+ * DEFERRED note in launchTimings.ts) and is pinned by a test.
  */
 export const APP_BLOCK_LAUNCH_PHASES = ['token_mint', 'init_wait'] as const;
 export type AppBlockLaunchPhase = (typeof APP_BLOCK_LAUNCH_PHASES)[number];
@@ -207,10 +208,11 @@ export function normalizeErrorClass(
  * 🔴 THE TWO RULES THIS ENCODES, both of which produce a *plausible wrong
  * number* rather than an error when violated:
  *
- *   1. NEVER OBSERVE A ZERO. A leg that was not measured (no
- *      `Timing-Allow-Origin`, no resource entry, a mark never taken) arrives as
- *      0 or absent. A 0 in a latency histogram is indistinguishable from an
- *      instant leg and drags every percentile toward the bottom bucket — in the
+ *   1. NEVER OBSERVE A ZERO. A leg that was not measured — a mark never taken
+ *      (no token ever arrived, BLOCK_INIT never posted), a sub-millisecond delta
+ *      that rounds to 0, or a hand-rolled client sending 0 — arrives as 0 or
+ *      absent. A 0 in a latency histogram is indistinguishable from an instant
+ *      leg and drags every percentile toward the bottom bucket, in the
  *      reassuring direction, which is why nobody notices.
  *   2. DROP, NEVER CLAMP, AN OUT-OF-RANGE SAMPLE. Mirrors
  *      `observeCustomComfyWallclockSeconds`: a clamp folds junk onto the `+Inf`
@@ -304,23 +306,38 @@ type Bundle = {
 // sample above 10s was "structurally impossible on the success path" because the
 // ready timeout fires first. That is true of ONE ATTEMPT and false of a LAUNCH:
 // the host emits exactly one `ok` for the whole bounded auto-retry sequence,
-// whichever attempt produced it (MAX_AUTO_RETRIES = 2, backoffs 2s + 5s), so a
-// success on attempt 3 can legitimately total ~47s. `+Inf − le=15` therefore
-// means "recovered slowly", which is a real and interesting population, not a
-// broken emitter.
+// whichever attempt produced it, so a success can legitimately total up to
+// `worstReachableLaunchMs()` = 57s. `+Inf − le=15` therefore means "recovered
+// slowly", which is a real and interesting population, not a broken emitter.
+//
+// 🟡 KNOWN LIMITATION — the 15-60s tail is ONE undifferentiated bucket. Every
+// auto-retry-recovered launch lands in `+Inf` with no resolution between "16s"
+// and "57s", so the histogram can say THAT a launch was slow-recovered but not
+// how slow. Deliberate: extra edges up there would cost series on every app for
+// a population that is rare by construction (it takes two failed attempts), and
+// `_sum`/`_count` still give a usable mean for it. Revisit only if that bucket
+// turns out to carry real volume.
 const APP_BLOCK_LAUNCH_BUCKETS = [0.1, 0.25, 0.4, 0.6, 0.8, 1.2, 1.8, 2.5, 4, 6, 8, 10, 15];
 
 /**
  * Upper sanity bound on a single launch sample, in seconds.
  *
- * 🔴 DERIVED FROM THE AUTO-RETRY BOUND, NOT PICKED. This was 30s, justified as
- * "well above TOKEN_WAIT_TIMEOUT_MS (15s), the longest leg that can legitimately
- * complete" — a justification that silently assumed a launch is ONE attempt. It
- * is not: the host emits one `ok` for the whole bounded sequence, so the worst
- * reachable success is ~47s (15 + 2 + 15 + 5 + ~10). A 30s cap dropped real slow
- * successes, and did so in a slowness-correlated way — trimming exactly the tail
- * the metric exists to show. 60s clears the computed bound with margin while
- * still rejecting a clock anomaly. Mirrors `MAX_LAUNCH_SAMPLE_MS` client-side.
+ * 🔴 DERIVED FROM THE AUTO-RETRY BOUND, NOT PICKED — and the derivation is CODE,
+ * in `worstReachableLaunchMs()` (`~/components/AppBlocks/pageBlockHostLogic`), not
+ * this comment. A test asserts this cap exceeds it, so widening any of the five
+ * host constants it reads fails loudly instead of silently walking past the cap.
+ *
+ * The arithmetic has been wrong in a comment twice: first at 30s ("well above
+ * TOKEN_WAIT_TIMEOUT_MS (15s), the longest leg that can legitimately complete",
+ * which assumed a launch is ONE attempt — it is not, the host emits one `ok` for
+ * the whole bounded sequence), then at "~47s" (a sequence with two consecutive
+ * `no_token`s, which `MAX_AUTO_REMINTS = 1` makes unreachable). The real worst
+ * reachable success is 57s. 🔴 The margin here is therefore ~3s — deliberately
+ * tight and test-guarded rather than padded.
+ *
+ * The 30s cap was dropping real slow successes in a slowness-correlated way,
+ * trimming exactly the tail the metric exists to show. Mirrors
+ * `MAX_LAUNCH_SAMPLE_MS` client-side.
  *
  * DROPPED, not clamped (see `launchSampleSeconds`).
  */
@@ -508,12 +525,19 @@ export function ensureRegisterAppBlockRuntimeMetrics(reg: Registry = client.regi
 
   // ── LAUNCH LATENCY — TWO histograms, deliberately, not one ──────────────────
   //
-  // 🔴 THE SPLIT IS THE CARDINALITY DESIGN, not a stylistic choice. A single
-  // combined {app_block_id, phase} histogram would be ~51 apps × 2 phases × 15
-  // bucket series ≈ 1,530 series PER POD, across ~130 scraped dp-prod pods — and
+  // 🔴 THE SPLIT IS THE CARDINALITY DESIGN, not a stylistic choice.
+  //
+  // Count a histogram label set as 16 SERIES, not 15: 13 finite bucket edges
+  // + `+Inf` + `_sum` + `_count`. And `app_block_id` spans ~52 values at A=50
+  // approved apps, because `boundAppBlockIdLabel` adds BOTH 'dev' and 'other'.
+  //
+  // A single combined {app_block_id, phase} histogram would then be
+  // 52 × 2 × 16 = 1,664 series PER POD, across ~130 scraped dp-prod pods — and
   // prom-client retains every distinct label set in the Node heap forever (the
-  // --max-old-space-size exit-139 OOM class). Split as below it is ~765 + 30
-  // ≈ 795/pod at full app saturation, in line with the existing
+  // --max-old-space-size exit-139 OOM class). Split as below it is
+  // 52 × 16 = 832 plus 2 × 16 = 32, i.e. ~864/pod at full app saturation
+  // (an earlier revision said 795 — it undercounted both factors), in line with
+  // the existing
   // `civitai_app_block_request_duration_seconds{app_block_id, endpoint}`
   // precedent rather than an order of magnitude past it.
   //

--- a/src/server/metrics/app-block-runtime.metrics.ts
+++ b/src/server/metrics/app-block-runtime.metrics.ts
@@ -76,7 +76,7 @@ export type AppBlockRenderResult = 'ok' | 'error';
  * fields; this module maps them onto these three literals. A client cannot
  * invent a fourth.
  */
-export const APP_BLOCK_LAUNCH_PHASES = ['token_mint', 'frame_fetch', 'init_wait'] as const;
+export const APP_BLOCK_LAUNCH_PHASES = ['token_mint', 'init_wait'] as const;
 export type AppBlockLaunchPhase = (typeof APP_BLOCK_LAUNCH_PHASES)[number];
 
 /**
@@ -295,22 +295,36 @@ type Bundle = {
 //          dropped and the next is a FULL 400ms later. If that quantization is
 //          real it shows up as mass piling immediately above 0.4 — and a generic
 //          0.25→0.5→1 ladder would hide it completely.
-//   10   — BLOCK_READY_TIMEOUT_MS. 🔴 A `launch_total` sample above 10s is
-//          STRUCTURALLY IMPOSSIBLE on the success path: at 10s the controller
-//          fires onReadyTimeout, the status goes 'timeout', and no `ok` beacon
-//          is ever sent. So a non-zero `+Inf − le=10` on launch_total is a BUG
-//          SIGNAL, not a slow launch.
-//   15   — TOKEN_WAIT_TIMEOUT_MS. Only the `token_mint` phase can legitimately
-//          reach here (the ready timeout is armed by start(), gated on hasToken).
+//   10   — BLOCK_READY_TIMEOUT_MS: the ceiling on ONE attempt's wait for
+//          BLOCK_READY once init has started.
+//   15   — TOKEN_WAIT_TIMEOUT_MS: the ceiling on ONE attempt's wait for a token.
+//
+// 🔴 A `launch_total` ABOVE 15s IS REACHABLE AND LEGITIMATE — do not read the
+// top bucket as a bug signal. An earlier revision of this comment claimed a
+// sample above 10s was "structurally impossible on the success path" because the
+// ready timeout fires first. That is true of ONE ATTEMPT and false of a LAUNCH:
+// the host emits exactly one `ok` for the whole bounded auto-retry sequence,
+// whichever attempt produced it (MAX_AUTO_RETRIES = 2, backoffs 2s + 5s), so a
+// success on attempt 3 can legitimately total ~47s. `+Inf − le=15` therefore
+// means "recovered slowly", which is a real and interesting population, not a
+// broken emitter.
 const APP_BLOCK_LAUNCH_BUCKETS = [0.1, 0.25, 0.4, 0.6, 0.8, 1.2, 1.8, 2.5, 4, 6, 8, 10, 15];
 
 /**
- * Upper sanity bound on a single launch sample, in seconds. 30s sits well above
- * TOKEN_WAIT_TIMEOUT_MS (15s), the longest leg that can legitimately complete.
- * Past that it is a suspended tab, a clock anomaly, or a bug — DROPPED, not
- * clamped (see `launchSampleSeconds`).
+ * Upper sanity bound on a single launch sample, in seconds.
+ *
+ * 🔴 DERIVED FROM THE AUTO-RETRY BOUND, NOT PICKED. This was 30s, justified as
+ * "well above TOKEN_WAIT_TIMEOUT_MS (15s), the longest leg that can legitimately
+ * complete" — a justification that silently assumed a launch is ONE attempt. It
+ * is not: the host emits one `ok` for the whole bounded sequence, so the worst
+ * reachable success is ~47s (15 + 2 + 15 + 5 + ~10). A 30s cap dropped real slow
+ * successes, and did so in a slowness-correlated way — trimming exactly the tail
+ * the metric exists to show. 60s clears the computed bound with margin while
+ * still rejecting a clock anomaly. Mirrors `MAX_LAUNCH_SAMPLE_MS` client-side.
+ *
+ * DROPPED, not clamped (see `launchSampleSeconds`).
  */
-export const MAX_APP_BLOCK_LAUNCH_SECONDS = 30;
+export const MAX_APP_BLOCK_LAUNCH_SECONDS = 60;
 
 // ── customComfy per-engine runtime/cost buckets ──────────────────────────────
 // Sized for the 0–200 range that straddles the per-engine Buzz ceilings
@@ -495,11 +509,11 @@ export function ensureRegisterAppBlockRuntimeMetrics(reg: Registry = client.regi
   // ── LAUNCH LATENCY — TWO histograms, deliberately, not one ──────────────────
   //
   // 🔴 THE SPLIT IS THE CARDINALITY DESIGN, not a stylistic choice. A single
-  // combined {app_block_id, phase} histogram would be ~51 apps × 3 phases × 15
-  // bucket series ≈ 2,295 series PER POD, across ~130 scraped dp-prod pods — and
+  // combined {app_block_id, phase} histogram would be ~51 apps × 2 phases × 15
+  // bucket series ≈ 1,530 series PER POD, across ~130 scraped dp-prod pods — and
   // prom-client retains every distinct label set in the Node heap forever (the
-  // --max-old-space-size exit-139 OOM class). Split as below it is ~765 + 45
-  // ≈ 810/pod at full app saturation, in line with the existing
+  // --max-old-space-size exit-139 OOM class). Split as below it is ~765 + 30
+  // ≈ 795/pod at full app saturation, in line with the existing
   // `civitai_app_block_request_duration_seconds{app_block_id, endpoint}`
   // precedent rather than an order of magnitude past it.
   //
@@ -522,15 +536,20 @@ export function ensureRegisterAppBlockRuntimeMetrics(reg: Registry = client.regi
   // max(token, block-listener), not on a sum. Reading these as a serial
   // breakdown is the single most likely misuse of this metric.
   //
-  // All three phases are available at 100% coverage, on every app, today: the
-  // 2026-08-03 Chromium measurement showed the cross-origin iframe entry carries
-  // a real `duration` without `Timing-Allow-Origin` (only the DNS/connect/TTFB
-  // decomposition is TAO-gated, and that breakdown is deferred — see
-  // launchTimings.ts). So there is no coverage caveat and no biased subset.
+  // 🔴 THERE IS NO CROSS-ORIGIN `frame_fetch` PHASE, DELIBERATELY. Both phases
+  // here are HOST-side, measured from the host's own marks, so both are observed
+  // for every successful launch on every app — no header dependency, no coverage
+  // denominator to publish, no biased subset. A phase for the block-frame fetch
+  // was designed and then dropped: without `Timing-Allow-Origin` the parent's
+  // `responseEnd` for a cross-origin subframe is the frame's LOAD event, not the
+  // document response, so it measures roughly what `total` already measures —
+  // and the entry does not exist at all until that load fires, which an SPA
+  // block posting BLOCK_READY at app-mount typically outruns. The full reasoning
+  // and the re-add seam are in launchTimings.ts.
   const launchPhaseSeconds = getOrCreateHistogram(
     reg,
     'civitai_app_block_launch_phase_seconds',
-    'App Block launch PHASE seconds by phase (token_mint = host mount -> first token; frame_fetch = the cross-origin iframe document fetch, from the parent resource-timing entry; init_wait = first BLOCK_INIT -> BLOCK_READY). 🔴 The phases are PARALLEL legs of one race (the iframe mounts before any token exists) and do NOT sum to launch_total.',
+    'App Block launch PHASE seconds by phase (token_mint = host mount -> first token; init_wait = first BLOCK_INIT -> BLOCK_READY). Both are host-side, so both are observed for every successful launch. 🔴 The phases are PARALLEL legs of one race (the iframe mounts before any token exists) and do NOT sum to launch_total. There is deliberately no cross-origin frame-fetch phase — see launchTimings.ts.',
     ['phase'],
     APP_BLOCK_LAUNCH_BUCKETS
   );
@@ -557,7 +576,6 @@ export function ensureRegisterAppBlockRuntimeMetrics(reg: Registry = client.regi
 export type AppBlockLaunchTimings = {
   totalMs?: unknown;
   tokenMintMs?: unknown;
-  frameFetchMs?: unknown;
   initWaitMs?: unknown;
 };
 
@@ -593,7 +611,6 @@ export function observeAppBlockLaunch(
 
     const phases: Array<[AppBlockLaunchPhase, unknown]> = [
       ['token_mint', timings.tokenMintMs],
-      ['frame_fetch', timings.frameFetchMs],
       ['init_wait', timings.initWaitMs],
     ];
     for (const [phase, ms] of phases) {

--- a/src/server/metrics/app-block-runtime.metrics.ts
+++ b/src/server/metrics/app-block-runtime.metrics.ts
@@ -67,6 +67,19 @@ export type AppBlockRequestResult = 'success' | 'client_error' | 'server_error' 
 export type AppBlockRenderResult = 'ok' | 'error';
 
 /**
+ * LAUNCH-LATENCY phase enum. A mirror of the client-side union in
+ * `~/components/AppBlocks/launchTimings`, declared again here rather than
+ * imported so this module never pulls a client module into the server graph.
+ *
+ * 🔴 It is also the cardinality bound, and it is CODE-OWNED: the `phase` label
+ * is never taken from the beacon body. The client sends three named numeric
+ * fields; this module maps them onto these three literals. A client cannot
+ * invent a fourth.
+ */
+export const APP_BLOCK_LAUNCH_PHASES = ['token_mint', 'frame_fetch', 'init_wait'] as const;
+export type AppBlockLaunchPhase = (typeof APP_BLOCK_LAUNCH_PHASES)[number];
+
+/**
  * Why `resolveAppCapLimits` fell back to `STRICTEST_APP_CAP_LIMITS` instead of
  * resolving the app's real ceilings. The two mean DIFFERENT things and an
  * operator responds to them differently, which is the whole reason this is a
@@ -187,6 +200,34 @@ export function normalizeErrorClass(
  * into `forbidden` (auth/scope rejections — the middleware's own 403s land here
  * too); other 4xx → `client_error`; 5xx → `server_error`; else `success`.
  */
+/**
+ * Map one client-reported millisecond leg to a histogram sample in SECONDS, or
+ * `null` if it must not be observed.
+ *
+ * 🔴 THE TWO RULES THIS ENCODES, both of which produce a *plausible wrong
+ * number* rather than an error when violated:
+ *
+ *   1. NEVER OBSERVE A ZERO. A leg that was not measured (no
+ *      `Timing-Allow-Origin`, no resource entry, a mark never taken) arrives as
+ *      0 or absent. A 0 in a latency histogram is indistinguishable from an
+ *      instant leg and drags every percentile toward the bottom bucket — in the
+ *      reassuring direction, which is why nobody notices.
+ *   2. DROP, NEVER CLAMP, AN OUT-OF-RANGE SAMPLE. Mirrors
+ *      `observeCustomComfyWallclockSeconds`: a clamp folds junk onto the `+Inf`
+ *      edge and pollutes `_sum` and the tail with a value that never happened.
+ *
+ * The client applies the same two gates (`boundedDeltaMs`), deliberately — the
+ * guarantee must not rest on either side alone, and this side is the one facing
+ * a public, client-controlled beacon body.
+ */
+export function launchSampleSeconds(ms: unknown): number | null {
+  if (typeof ms !== 'number' || !Number.isFinite(ms)) return null;
+  if (!(ms > 0)) return null;
+  const seconds = ms / 1000;
+  if (seconds > MAX_APP_BLOCK_LAUNCH_SECONDS) return null;
+  return seconds;
+}
+
 export function statusToRequestResult(status: number): AppBlockRequestResult {
   if (status >= 500) return 'server_error';
   if (status === 401 || status === 403) return 'forbidden';
@@ -235,7 +276,41 @@ type Bundle = {
   capLimitsDegradedTotal: Counter<string>;
   spendCapRejectionsTotal: Counter<string>;
   stepPriceCheckTotal: Counter<string>;
+  launchTotalSeconds: Histogram<string>;
+  launchPhaseSeconds: Histogram<string>;
 };
+
+// ── App Block LAUNCH latency ────────────────────────────────────────────────
+// Bucket edges chosen against the REAL constants of the launch path, not from a
+// generic ladder. prom-client's defaults are structurally unable to answer the
+// two questions this metric exists for: their top is 10s with nothing between 5
+// and 10, and they have no edge at 0.4.
+//
+//   0.25 — LAUNCH_REVEAL_MS (260ms, PageBlockHost). Below this edge the launch
+//          is already hidden behind the cross-fade: an "already optimal" bucket.
+//   0.4 / 0.8
+//        — exactly one and two INIT_RETRY_INTERVAL_MS ticks
+//          (iframeInitController). The first BLOCK_INIT is posted synchronously
+//          on start(); if the block's listener has not attached yet that post is
+//          dropped and the next is a FULL 400ms later. If that quantization is
+//          real it shows up as mass piling immediately above 0.4 — and a generic
+//          0.25→0.5→1 ladder would hide it completely.
+//   10   — BLOCK_READY_TIMEOUT_MS. 🔴 A `launch_total` sample above 10s is
+//          STRUCTURALLY IMPOSSIBLE on the success path: at 10s the controller
+//          fires onReadyTimeout, the status goes 'timeout', and no `ok` beacon
+//          is ever sent. So a non-zero `+Inf − le=10` on launch_total is a BUG
+//          SIGNAL, not a slow launch.
+//   15   — TOKEN_WAIT_TIMEOUT_MS. Only the `token_mint` phase can legitimately
+//          reach here (the ready timeout is armed by start(), gated on hasToken).
+const APP_BLOCK_LAUNCH_BUCKETS = [0.1, 0.25, 0.4, 0.6, 0.8, 1.2, 1.8, 2.5, 4, 6, 8, 10, 15];
+
+/**
+ * Upper sanity bound on a single launch sample, in seconds. 30s sits well above
+ * TOKEN_WAIT_TIMEOUT_MS (15s), the longest leg that can legitimately complete.
+ * Past that it is a suspended tab, a clock anomaly, or a bug — DROPPED, not
+ * clamped (see `launchSampleSeconds`).
+ */
+export const MAX_APP_BLOCK_LAUNCH_SECONDS = 30;
 
 // ── customComfy per-engine runtime/cost buckets ──────────────────────────────
 // Sized for the 0–200 range that straddles the per-engine Buzz ceilings
@@ -417,6 +492,49 @@ export function ensureRegisterAppBlockRuntimeMetrics(reg: Registry = client.regi
     ['step', 'outcome']
   );
 
+  // ── LAUNCH LATENCY — TWO histograms, deliberately, not one ──────────────────
+  //
+  // 🔴 THE SPLIT IS THE CARDINALITY DESIGN, not a stylistic choice. A single
+  // combined {app_block_id, phase} histogram would be ~51 apps × 3 phases × 15
+  // bucket series ≈ 2,295 series PER POD, across ~130 scraped dp-prod pods — and
+  // prom-client retains every distinct label set in the Node heap forever (the
+  // --max-old-space-size exit-139 OOM class). Split as below it is ~765 + 45
+  // ≈ 810/pod at full app saturation, in line with the existing
+  // `civitai_app_block_request_duration_seconds{app_block_id, endpoint}`
+  // precedent rather than an order of magnitude past it.
+  //
+  // Per-app PHASE attribution is therefore NOT available from prom. That is the
+  // same alert-on-the-metric / attribute-from-the-log split the degrade and
+  // spend-cap counters above already make.
+  const launchTotalSeconds = getOrCreateHistogram(
+    reg,
+    'civitai_app_block_launch_total_seconds',
+    'App Block end-to-end launch seconds (host mount -> BLOCK_READY) by app. Successful launches only: a failure beacon has no BLOCK_READY, and a mid-session teardown (`secondary`) is not a launch. Answers "which app is slow".',
+    ['app_block_id'],
+    APP_BLOCK_LAUNCH_BUCKETS
+  );
+
+  // 🔴 NO app_block_id LABEL, deliberately (see the cardinality note above).
+  //
+  // 🔴 AND THE PHASES DO NOT SUM TO `launch_total`. The token mint and the
+  // cross-origin frame load run in PARALLEL — the iframe mounts on the first
+  // client render, before any token exists — so the launch waits on
+  // max(token, block-listener), not on a sum. Reading these as a serial
+  // breakdown is the single most likely misuse of this metric.
+  //
+  // All three phases are available at 100% coverage, on every app, today: the
+  // 2026-08-03 Chromium measurement showed the cross-origin iframe entry carries
+  // a real `duration` without `Timing-Allow-Origin` (only the DNS/connect/TTFB
+  // decomposition is TAO-gated, and that breakdown is deferred — see
+  // launchTimings.ts). So there is no coverage caveat and no biased subset.
+  const launchPhaseSeconds = getOrCreateHistogram(
+    reg,
+    'civitai_app_block_launch_phase_seconds',
+    'App Block launch PHASE seconds by phase (token_mint = host mount -> first token; frame_fetch = the cross-origin iframe document fetch, from the parent resource-timing entry; init_wait = first BLOCK_INIT -> BLOCK_READY). 🔴 The phases are PARALLEL legs of one race (the iframe mounts before any token exists) and do NOT sum to launch_total.',
+    ['phase'],
+    APP_BLOCK_LAUNCH_BUCKETS
+  );
+
   return {
     requestsTotal,
     requestDurationSeconds,
@@ -426,7 +544,66 @@ export function ensureRegisterAppBlockRuntimeMetrics(reg: Registry = client.regi
     capLimitsDegradedTotal,
     spendCapRejectionsTotal,
     stepPriceCheckTotal,
+    launchTotalSeconds,
+    launchPhaseSeconds,
   };
+}
+
+/**
+ * The client-reported launch timings, as they arrive on the block-render beacon
+ * (milliseconds; every field optional/unvalidated from this function's point of
+ * view — the zod schema bounds them, this clamps them again).
+ */
+export type AppBlockLaunchTimings = {
+  totalMs?: unknown;
+  tokenMintMs?: unknown;
+  frameFetchMs?: unknown;
+  initWaitMs?: unknown;
+};
+
+/**
+ * Fail-soft emit of ONE App Block launch observation.
+ *
+ * 🔴 CALL ONLY FOR A SUCCESSFUL, NON-SECONDARY RENDER BEACON. A launch-FAILURE
+ * beacon never saw BLOCK_READY, so its `total` is meaningless and observing it
+ * would record the failure as a *fast* launch; a `secondary` beacon describes a
+ * teardown minutes after a launch that already succeeded. Either one poisons the
+ * distribution in the direction that looks healthy.
+ *
+ * 🔴 `total` IS THE ANCHOR. If it does not survive `launchSampleSeconds`, NOTHING
+ * is observed — not even a phase that would have passed on its own. Orphan phase
+ * samples with no end-to-end number to interpret them against are worse than no
+ * samples: they still move the phase percentiles.
+ *
+ * 🔴 TOTAL (never throws), like every emitter in this module: it runs on a
+ * fire-and-forget public telemetry route, and a label/registry error must never
+ * turn a beacon into a 500.
+ */
+export function observeAppBlockLaunch(
+  appBlockIdLabel: string,
+  timings: AppBlockLaunchTimings | undefined
+): void {
+  try {
+    if (!timings) return;
+    const total = launchSampleSeconds(timings.totalMs);
+    if (total === null) return;
+
+    const { launchTotalSeconds, launchPhaseSeconds } = ensureRegisterAppBlockRuntimeMetrics();
+    launchTotalSeconds.observe({ app_block_id: appBlockIdLabel }, total);
+
+    const phases: Array<[AppBlockLaunchPhase, unknown]> = [
+      ['token_mint', timings.tokenMintMs],
+      ['frame_fetch', timings.frameFetchMs],
+      ['init_wait', timings.initWaitMs],
+    ];
+    for (const [phase, ms] of phases) {
+      const seconds = launchSampleSeconds(ms);
+      if (seconds === null) continue;
+      launchPhaseSeconds.observe({ phase }, seconds);
+    }
+  } catch {
+    /* instrument-only — never let a metrics error touch the beacon response */
+  }
 }
 
 /**

--- a/src/server/routers/__tests__/track.router.blockRender.test.ts
+++ b/src/server/routers/__tests__/track.router.blockRender.test.ts
@@ -161,6 +161,75 @@ describe('track.blockRender', () => {
     expect(arg).not.toHaveProperty('secondary');
   });
 
+  /**
+   * 🔴 THE TWO-WRITE-PATH HAZARD, PINNED ON THE PATH THAT IS EASY TO FORGET.
+   *
+   * `blockRenders` has TWO writers: the REST beacon (/api/track/block-render)
+   * and this tRPC procedure. The REST one is also the only PROM writer, which
+   * inverts the intuition: a new observability field added to the shared
+   * `blockRenderSchema` and stripped only in the REST handler does NOT get
+   * caught here by a missing metric — it falls straight through this
+   * procedure's spread into the ClickHouse insert.
+   *
+   * And TypeScript cannot catch it. `ctx.track.blockRender({ ...payload, isAnon })`
+   * is a SPREAD, and spread properties are exempt from excess-property checking,
+   * so an extra field compiles cleanly against `Tracker.blockRender`'s
+   * four-field parameter type.
+   *
+   * MUTATION-CHECKED: restoring this resolver's previous
+   * `const { status, errorClass, secondary, ...renderData } = input` — i.e.
+   * patching ONLY the REST path — makes this test fail with
+   * `expected { …, timings: {…} } to not have property "timings"`.
+   */
+  it('🔴 strips `timings` from the ClickHouse payload on the tRPC path too', async () => {
+    const caller = trackRouter.createCaller(fakeCtx({ id: 5 }) as never);
+    await caller.blockRender({
+      ...validInput(),
+      timings: { totalMs: 1_100, tokenMintMs: 180, frameFetchMs: 320, initWaitMs: 700 },
+    } as never);
+
+    expect(mockBlockRender).toHaveBeenCalledTimes(1);
+    const arg = mockBlockRender.mock.calls[0][0];
+    expect(arg).not.toHaveProperty('timings');
+    // Byte-identical to a timing-less beacon: the CH row is unchanged.
+    expect(arg).toEqual({ ...validInput(), isAnon: false });
+  });
+
+  /**
+   * The companion assertion, and the one that makes the strip above meaningful:
+   * this procedure must ALSO not observe the launch histograms. It is a second
+   * ClickHouse writer, NOT a second metrics writer — only the REST beacon
+   * increments prom. If someone "fixes the asymmetry" by adding an emit here,
+   * every bearer/API-key caller starts contributing launch samples that no host
+   * measured, and the ok-only / non-secondary gating that lives in the REST
+   * route would be bypassed entirely.
+   */
+  it('🔴 does NOT observe the launch histograms (this path is a CH writer, not a metrics writer)', async () => {
+    const client = (await import('prom-client')).default;
+    const readCount = async () => {
+      const metric = client.register.getSingleMetric('civitai_app_block_launch_total_seconds');
+      if (!metric) return 0;
+      const data = await (
+        metric as unknown as {
+          get(): Promise<{
+            values: Array<{ metricName?: string; labels: Record<string, string>; value: number }>;
+          }>;
+        }
+      ).get();
+      return data.values
+        .filter((v) => v.metricName === 'civitai_app_block_launch_total_seconds_count')
+        .reduce((acc, v) => acc + v.value, 0);
+    };
+
+    const before = await readCount();
+    const caller = trackRouter.createCaller(fakeCtx({ id: 5 }) as never);
+    await caller.blockRender({
+      ...validInput(),
+      timings: { totalMs: 1_100 },
+    } as never);
+    expect(await readCount()).toBe(before);
+  });
+
   it('rejects a missing identifier with a BAD_REQUEST and no Tracker call', async () => {
     const caller = trackRouter.createCaller(fakeCtx({ id: 1 }) as never);
     await expect(

--- a/src/server/routers/__tests__/track.router.blockRender.test.ts
+++ b/src/server/routers/__tests__/track.router.blockRender.test.ts
@@ -185,7 +185,7 @@ describe('track.blockRender', () => {
     const caller = trackRouter.createCaller(fakeCtx({ id: 5 }) as never);
     await caller.blockRender({
       ...validInput(),
-      timings: { totalMs: 1_100, tokenMintMs: 180, frameFetchMs: 320, initWaitMs: 700 },
+      timings: { totalMs: 1_100, tokenMintMs: 180, initWaitMs: 700 },
     } as never);
 
     expect(mockBlockRender).toHaveBeenCalledTimes(1);

--- a/src/server/routers/track.router.ts
+++ b/src/server/routers/track.router.ts
@@ -4,6 +4,7 @@ import {
   trackShareSchema,
   addViewSchema,
   blockRenderSchema,
+  blockRenderTrackerPayload,
 } from '~/server/schema/track.schema';
 import { publicProcedure, router } from '~/server/trpc';
 import { TokenScope } from '~/shared/constants/token-scope.constants';
@@ -26,9 +27,21 @@ export const trackRouter = router({
   // for any bearer/API-key (non-cookie) caller, consistent with `addView`.
   blockRender: publicProcedure
     .input(blockRenderSchema)
-    // `status`/`errorClass`/`secondary` are consumed only by the
-    // /api/track/block-render beacon (prom render counter); this legacy tRPC path
-    // keeps the CH insert byte-identical by stripping them before dispatch.
+    // `status`/`errorClass`/`secondary`/`timings` are consumed only by the
+    // /api/track/block-render beacon (prom render counter + launch histograms);
+    // this legacy tRPC path keeps the CH insert byte-identical by stripping them
+    // before dispatch.
+    //
+    // 🔴 THIS IS A SECOND *CLICKHOUSE* WRITER, NOT A SECOND METRICS WRITER — the
+    // asymmetry a designer trips on. This procedure increments no prom counter
+    // and observes no histogram; only the REST beacon does. So the half-fix
+    // hazard runs the OTHER way: a prom-only field stripped in block-render.ts
+    // but not here falls through into the ClickHouse insert, and TypeScript will
+    // NOT catch it — `ctx.track.blockRender({ ...renderData, isAnon })` spreads,
+    // and spread properties are exempt from excess-property checking.
+    //
+    // `blockRenderTrackerPayload` is the shared ALLOWLIST that makes this
+    // impossible to get wrong in one place and not the other.
     //
     // 🔴 `secondary` additionally SUPPRESSES the insert, matching the beacon route
     // exactly. `blockRenders` counts IMPRESSIONS (one row per host mount) and its
@@ -37,9 +50,8 @@ export const trackRouter = router({
     // bearer/API-key caller could reintroduce the double-count the beacon route
     // prevents.
     .mutation(({ input, ctx }) => {
-      const { status: _status, errorClass: _errorClass, secondary, ...renderData } = input;
-      if (secondary) return;
-      return ctx.track.blockRender({ ...renderData, isAnon: !ctx.user });
+      if (input.secondary) return;
+      return ctx.track.blockRender({ ...blockRenderTrackerPayload(input), isAnon: !ctx.user });
     }),
   trackShare: publicProcedure
     .meta({ requiredScope: TokenScope.UserWrite })

--- a/src/server/schema/track.schema.ts
+++ b/src/server/schema/track.schema.ts
@@ -121,7 +121,8 @@ export const blockRenderSchema = z.object({
   //
   // Bounds: every leg is a non-negative millisecond count. `max` is a coarse
   // sanity bound only — the REAL gate is `launchSampleSeconds` server-side
-  // (>0 and <= 30s, DROPPED not clamped), which the client mirrors.
+  // (>0 and <= MAX_APP_BLOCK_LAUNCH_SECONDS, DROPPED not clamped), which the
+  // client mirrors.
   //
   // 🔴 `.catch(undefined)` IS LOAD-BEARING, NOT DEFENSIVE CLUTTER. Without it a
   // malformed `timings` (a client bug producing a NaN, a stale field name, a
@@ -134,7 +135,6 @@ export const blockRenderSchema = z.object({
     .object({
       totalMs: z.number().finite().nonnegative().max(600_000),
       tokenMintMs: z.number().finite().nonnegative().max(600_000).optional(),
-      frameFetchMs: z.number().finite().nonnegative().max(600_000).optional(),
       initWaitMs: z.number().finite().nonnegative().max(600_000).optional(),
     })
     .optional()

--- a/src/server/schema/track.schema.ts
+++ b/src/server/schema/track.schema.ts
@@ -95,7 +95,81 @@ export const blockRenderSchema = z.object({
   // is a real attempted render). What is suppressed is specifically a second
   // beacon for a mount that already reported.
   secondary: z.boolean().optional().default(false),
+  // 🔴 OPTIONAL LAUNCH TIMINGS — carried on the EXISTING beacon, deliberately.
+  //
+  // There is exactly ONE /api/track/block-render beacon per host mount (guarded
+  // by `blockRenderEmittedRef`, with ok/error mutually exclusive). A second
+  // beacon for timing would break that contract and, more concretely, write a
+  // second `blockRenders` ClickHouse row for one mount — byte-identical to the
+  // first and therefore undedupable, inflating every impression figure. So the
+  // timings ride as optional fields on the beacon that already fires, and
+  // impression accounting is provably unchanged: same beacon count, same row
+  // count, same `renders_total` increments.
+  //
+  // 🔴 LIKE status/errorClass/secondary, THIS IS STRIPPED BY *BOTH* WRITERS
+  // BEFORE THE CLICKHOUSE INSERT — see `blockRenderTrackerPayload` below, which
+  // exists precisely so there is one place to strip rather than two that can
+  // drift. TypeScript cannot catch a missed strip here: `ctx.track.blockRender({
+  // ...renderData, isAnon })` spreads, and spread properties are exempt from
+  // excess-property checking, so an extra field compiles cleanly and lands in
+  // the insert payload.
+  //
+  // 🔴 NUMBERS ONLY — no client-supplied strings, so nothing here can become a
+  // prom LABEL. The `phase` label is code-owned: the server maps these three
+  // named fields onto its own three literals. That is what keeps a public,
+  // client-controlled beacon body from touching cardinality at all.
+  //
+  // Bounds: every leg is a non-negative millisecond count. `max` is a coarse
+  // sanity bound only — the REAL gate is `launchSampleSeconds` server-side
+  // (>0 and <= 30s, DROPPED not clamped), which the client mirrors.
+  //
+  // 🔴 `.catch(undefined)` IS LOAD-BEARING, NOT DEFENSIVE CLUTTER. Without it a
+  // malformed `timings` (a client bug producing a NaN, a stale field name, a
+  // future rename) fails the WHOLE `blockRenderSchema.safeParse`, the beacon
+  // route 400s, and the mount's IMPRESSION is lost — an observability add-on
+  // would have broken the analytics series it was bolted onto. With it, junk
+  // timings degrade to "no timings" and the impression is recorded exactly as
+  // before. The add-on must be strictly subordinate to the thing it rides on.
+  timings: z
+    .object({
+      totalMs: z.number().finite().nonnegative().max(600_000),
+      tokenMintMs: z.number().finite().nonnegative().max(600_000).optional(),
+      frameFetchMs: z.number().finite().nonnegative().max(600_000).optional(),
+      initWaitMs: z.number().finite().nonnegative().max(600_000).optional(),
+    })
+    .optional()
+    .catch(undefined),
 });
+
+/**
+ * 🔴 THE SINGLE STRIP POINT FOR THE `blockRenders` CLICKHOUSE PAYLOAD.
+ *
+ * There are TWO writers of that table — the REST beacon
+ * (`src/pages/api/track/block-render.ts`) and the `track.blockRender` tRPC
+ * procedure (`src/server/routers/track.router.ts`) — and every prom-only /
+ * observability field added to `blockRenderSchema` has to be removed on BOTH.
+ * Patching one is a SILENT half-fix: the field falls through the other's
+ * `...renderData` spread straight into the insert, and TypeScript does not
+ * complain because spread properties are exempt from excess-property checking.
+ *
+ * 🔴 IT IS AN ALLOWLIST, NOT A DESTRUCTURE-REST. Both writers previously did
+ * `const { status, errorClass, secondary, ...renderData } = input` — which is a
+ * DENYLIST: every field added to the schema is forwarded to ClickHouse by
+ * DEFAULT and stays silent until someone reads the CH payload. Naming the three
+ * real columns instead inverts that: a new schema field can never reach the
+ * insert, and adding a genuine new column is a deliberate edit here.
+ */
+export function blockRenderTrackerPayload(input: BlockRenderInput): {
+  appBlockId: string;
+  blockInstanceId: string;
+  slotId: string;
+} {
+  return {
+    appBlockId: input.appBlockId,
+    blockInstanceId: input.blockInstanceId,
+    slotId: input.slotId,
+  };
+}
 
 export type TrackShareInput = z.infer<typeof trackShareSchema>;
 export const trackShareSchema = z.object({

--- a/src/tests/api/track/block-render.test.ts
+++ b/src/tests/api/track/block-render.test.ts
@@ -460,3 +460,233 @@ describe('POST /api/track/block-render — civitai_app_block_renders_total count
     expect(await renderCounterValue('apb_test', 'other', 'ok')).toBe(before + 1);
   });
 });
+
+// --- App Blocks LAUNCH LATENCY: the two launch histograms ---------------------
+type HistPoint = { metricName?: string; labels: Record<string, string>; value: number };
+
+async function histCount(name: string, labels: Record<string, string>): Promise<number> {
+  const metric = client.register.getSingleMetric(name);
+  if (!metric) return 0;
+  const data = await (metric as unknown as { get(): Promise<{ values: HistPoint[] }> }).get();
+  const point = data.values.find(
+    (v) =>
+      v.metricName === `${name}_count` &&
+      Object.entries(labels).every(([k, val]) => v.labels[k] === val)
+  );
+  return point?.value ?? 0;
+}
+
+const LAUNCH_TOTAL = 'civitai_app_block_launch_total_seconds';
+const LAUNCH_PHASE = 'civitai_app_block_launch_phase_seconds';
+const timings = { totalMs: 1_100, tokenMintMs: 180, frameFetchMs: 320, initWaitMs: 700 };
+
+describe('POST /api/track/block-render — launch-latency histograms', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    devStore.isDev = false;
+    sessionStore.session = null;
+  });
+
+  it('observes the launch on an `ok` beacon that carries timings', async () => {
+    const beforeTotal = await histCount(LAUNCH_TOTAL, { app_block_id: 'apb_test' });
+    const beforeInit = await histCount(LAUNCH_PHASE, { phase: 'init_wait' });
+    const handler = (await import('~/pages/api/track/block-render')).default;
+
+    await handler(
+      makeReq({ origin: 'https://civitai.com', body: { ...validInput, timings } }) as any,
+      makeRes()
+    );
+
+    expect(await histCount(LAUNCH_TOTAL, { app_block_id: 'apb_test' })).toBe(beforeTotal + 1);
+    expect(await histCount(LAUNCH_PHASE, { phase: 'init_wait' })).toBe(beforeInit + 1);
+  });
+
+  /**
+   * 🔴 IMPRESSION ACCOUNTING IS UNCHANGED — the whole reason the timings ride the
+   * EXISTING beacon instead of a second one. One beacon in: exactly one
+   * `renders_total` increment, exactly one ClickHouse row, and now also exactly
+   * one launch observation. A `2` on any of these means the beacon contract
+   * broke.
+   */
+  it('🔴 one beacon still yields exactly ONE renders_total increment and ONE ClickHouse row', async () => {
+    const beforeRender = await renderCounterValue('apb_test', 'app.page', 'ok', 'none');
+    const beforeLaunch = await histCount(LAUNCH_TOTAL, { app_block_id: 'apb_test' });
+    const handler = (await import('~/pages/api/track/block-render')).default;
+
+    await handler(
+      makeReq({ origin: 'https://civitai.com', body: { ...validInput, timings } }) as any,
+      makeRes()
+    );
+
+    expect(await renderCounterValue('apb_test', 'app.page', 'ok', 'none')).toBe(beforeRender + 1);
+    expect(await histCount(LAUNCH_TOTAL, { app_block_id: 'apb_test' })).toBe(beforeLaunch + 1);
+    expect(mockBlockRender).toHaveBeenCalledTimes(1);
+  });
+
+  /**
+   * 🔴 The CH payload must stay byte-identical. This is the REST half of the
+   * two-write-path pair (the tRPC half lives in
+   * src/server/routers/__tests__/track.router.blockRender.test.ts) — both writers
+   * go through the shared `blockRenderTrackerPayload` allowlist.
+   */
+  it('🔴 never forwards `timings` to the ClickHouse insert', async () => {
+    const handler = (await import('~/pages/api/track/block-render')).default;
+
+    await handler(
+      makeReq({ origin: 'https://civitai.com', body: { ...validInput, timings } }) as any,
+      makeRes()
+    );
+
+    const arg = mockBlockRender.mock.calls[0][0];
+    expect(arg).not.toHaveProperty('timings');
+    expect(arg).toEqual({ ...validInput, isAnon: true });
+  });
+
+  /**
+   * 🔴 A LAUNCH FAILURE MUST NOT BE OBSERVED AS A LAUNCH. It never saw
+   * BLOCK_READY, so its "total" is meaningless — and a fast failure would be
+   * recorded as a FAST LAUNCH, biasing the distribution in exactly the direction
+   * that reads as healthy. Includes the positive control, because a zero delta
+   * here is otherwise indistinguishable from a metric wired to nothing.
+   */
+  it('🔴 does NOT observe a launch for an `error` beacon, even if timings are attached', async () => {
+    const handler = (await import('~/pages/api/track/block-render')).default;
+    const before = await histCount(LAUNCH_TOTAL, { app_block_id: 'apb_test' });
+
+    await handler(
+      makeReq({
+        origin: 'https://civitai.com',
+        body: { ...validInput, status: 'error', errorClass: 'timeout', timings },
+      }) as any,
+      makeRes()
+    );
+    expect(await histCount(LAUNCH_TOTAL, { app_block_id: 'apb_test' })).toBe(before);
+
+    // POSITIVE CONTROL: the identical timings on an `ok` beacon DO move it by 1.
+    await handler(
+      makeReq({ origin: 'https://civitai.com', body: { ...validInput, timings } }) as any,
+      makeRes()
+    );
+    expect(await histCount(LAUNCH_TOTAL, { app_block_id: 'apb_test' })).toBe(before + 1);
+  });
+
+  it('🔴 does NOT observe a launch for a `secondary` teardown beacon', async () => {
+    const handler = (await import('~/pages/api/track/block-render')).default;
+    const before = await histCount(LAUNCH_TOTAL, { app_block_id: 'apb_test' });
+
+    await handler(
+      makeReq({
+        origin: 'https://civitai.com',
+        body: {
+          ...validInput,
+          status: 'error',
+          errorClass: 'token_lost_midsession',
+          secondary: true,
+          timings,
+        },
+      }) as any,
+      makeRes()
+    );
+
+    expect(await histCount(LAUNCH_TOTAL, { app_block_id: 'apb_test' })).toBe(before);
+  });
+
+  /**
+   * 🔴 THE `!secondary` HALF OF THE GATE, REACHED ON ITS OWN.
+   *
+   * The test above uses `status:'error'`, so `status === 'ok'` alone already
+   * rejects it — mutation-checked: deleting `&& !secondary` leaves that test
+   * GREEN, i.e. it proves nothing about this half. Today's only secondary beacon
+   * is an error, but the schema permits `secondary` with `status:'ok'` (a
+   * bearer/API-key caller, or a future follow-up that reports a non-error state
+   * change), and such a beacon is a TEARDOWN report minutes after the launch —
+   * its `total` would be pure noise. This case reaches the second half of the
+   * gate with an input the first half cannot reject.
+   */
+  it('🔴 does NOT observe a launch for a secondary beacon that is also `ok`', async () => {
+    const handler = (await import('~/pages/api/track/block-render')).default;
+    const before = await histCount(LAUNCH_TOTAL, { app_block_id: 'apb_test' });
+
+    await handler(
+      makeReq({
+        origin: 'https://civitai.com',
+        body: { ...validInput, status: 'ok', secondary: true, timings },
+      }) as any,
+      makeRes()
+    );
+    expect(await histCount(LAUNCH_TOTAL, { app_block_id: 'apb_test' })).toBe(before);
+
+    // POSITIVE CONTROL: identical body minus `secondary` DOES move it by 1, so
+    // the zero above is the gate and not a dead metric.
+    await handler(
+      makeReq({ origin: 'https://civitai.com', body: { ...validInput, status: 'ok', timings } }) as any,
+      makeRes()
+    );
+    expect(await histCount(LAUNCH_TOTAL, { app_block_id: 'apb_test' })).toBe(before + 1);
+  });
+
+  it('clamps an unknown app_block_id to "other" on the launch histogram too', async () => {
+    const handler = (await import('~/pages/api/track/block-render')).default;
+    const before = await histCount(LAUNCH_TOTAL, { app_block_id: 'other' });
+
+    await handler(
+      makeReq({
+        origin: 'https://civitai.com',
+        body: { ...validInput, appBlockId: 'apb_attacker_garbage_zz1', timings },
+      }) as any,
+      makeRes()
+    );
+
+    expect(await histCount(LAUNCH_TOTAL, { app_block_id: 'other' })).toBe(before + 1);
+  });
+
+  /**
+   * 🔴 MALFORMED TIMINGS MUST NOT COST THE IMPRESSION. `timings` carries
+   * `.catch(undefined)`, so a client bug (a NaN, a renamed field, a string)
+   * degrades to "no timings" instead of failing the whole
+   * `blockRenderSchema.safeParse` → 400 → a LOST impression. An observability
+   * add-on must be strictly subordinate to the analytics event it rides on.
+   */
+  it('🔴 a malformed `timings` still records the impression — it does not 400 the beacon', async () => {
+    const handler = (await import('~/pages/api/track/block-render')).default;
+    const beforeRender = await renderCounterValue('apb_test', 'app.page', 'ok', 'none');
+    const beforeLaunch = await histCount(LAUNCH_TOTAL, { app_block_id: 'apb_test' });
+    const res = makeRes();
+
+    await handler(
+      makeReq({
+        origin: 'https://civitai.com',
+        body: { ...validInput, timings: { totalMs: 'not-a-number' } },
+      }) as any,
+      res
+    );
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(mockBlockRender).toHaveBeenCalledTimes(1);
+    expect(mockBlockRender.mock.calls[0][0]).toEqual({ ...validInput, isAnon: true });
+    expect(await renderCounterValue('apb_test', 'app.page', 'ok', 'none')).toBe(beforeRender + 1);
+    // …but nothing junk reaches the histogram.
+    expect(await histCount(LAUNCH_TOTAL, { app_block_id: 'apb_test' })).toBe(beforeLaunch);
+  });
+
+  /**
+   * The BACK-COMPAT case, and the reason `timings` is optional rather than
+   * required: IframeHost (the in-page slot host) and any client that has not
+   * been rebuilt send no `timings`. Those beacons must behave exactly as they
+   * did before — impression recorded, counter incremented, no launch sample and
+   * no error.
+   */
+  it('records the impression normally when the beacon carries NO timings at all', async () => {
+    const handler = (await import('~/pages/api/track/block-render')).default;
+    const beforeRender = await renderCounterValue('apb_test', 'app.page', 'ok', 'none');
+    const beforeLaunch = await histCount(LAUNCH_TOTAL, { app_block_id: 'apb_test' });
+    const res = makeRes();
+
+    await handler(makeReq({ origin: 'https://civitai.com', body: validInput }) as any, res);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(mockBlockRender).toHaveBeenCalledWith({ ...validInput, isAnon: true });
+    expect(await renderCounterValue('apb_test', 'app.page', 'ok', 'none')).toBe(beforeRender + 1);
+    expect(await histCount(LAUNCH_TOTAL, { app_block_id: 'apb_test' })).toBe(beforeLaunch);
+  });
+});

--- a/src/tests/api/track/block-render.test.ts
+++ b/src/tests/api/track/block-render.test.ts
@@ -478,7 +478,7 @@ async function histCount(name: string, labels: Record<string, string>): Promise<
 
 const LAUNCH_TOTAL = 'civitai_app_block_launch_total_seconds';
 const LAUNCH_PHASE = 'civitai_app_block_launch_phase_seconds';
-const timings = { totalMs: 1_100, tokenMintMs: 180, frameFetchMs: 320, initWaitMs: 700 };
+const timings = { totalMs: 1_100, tokenMintMs: 180, initWaitMs: 700 };
 
 describe('POST /api/track/block-render — launch-latency histograms', () => {
   beforeEach(() => {


### PR DESCRIPTION
## What

Adds the first **launch-duration** metric for App Blocks. Today `civitai_app_block_renders_total` counts *outcomes* and carries no timing at all, so "is App Block launch slow, and which leg owns the time?" cannot be answered from the platform.

Two histograms, fed by the block-render beacon that already fires:

| Metric | Labels | Answers |
|---|---|---|
| `civitai_app_block_launch_total_seconds` | `app_block_id` | which **app** is slow |
| `civitai_app_block_launch_phase_seconds` | `phase` | which **leg** is slow |

`phase` ∈ `token_mint` (mount → first token) · `init_wait` (first `BLOCK_INIT` → `BLOCK_READY`). Both are **host-side**, so both are observed for every successful launch — no header dependency, no coverage denominator to publish.

> 🔴 **A cross-origin `frame_fetch` phase was designed, built, and then removed** after an adversarial audit. It is not an oversight — see "Why there is no frame_fetch" below.

Design + measurements: `claudedocs/app-blocks-launch-latency-instrumentation-and-preload-2026-08-02.md` in `datapacket-talos` (Part 2 only).

## 🔴 The phases do NOT sum to the total

`showIframe` is true while `status === 'loading'` and the **initial status IS `'loading'`**, so `<iframe src>` — an SSR prop, not derived from the token — mounts on the **first client render, before any token exists**. The mint *races* the cross-origin frame load; the launch waits on `max(token, block-listener)`, then the `BLOCK_INIT` re-post cadence, then the block's own render-to-ready.

Anything that reads these as a serial breakdown is reading a fiction. That is stated in the metric help text, in the module header, and pinned by a test that asserts a sample whose phases *exceed* its total is valid and must not be rejected.

## One beacon, unchanged impression accounting

The timings ride the **existing** `/api/track/block-render` beacon as an optional field. No second beacon, no second ClickHouse row; `blockRenderEmittedRef`, `secondary` and `error_class` are untouched. A test asserts one beacon still yields **exactly one** `renders_total` increment and **exactly one** CH row.

## Both write paths, via one allowlist

`blockRenders` has **two** writers — the REST beacon and the `track.blockRender` tRPC procedure — and only the REST one touches prom. So the half-fix hazard runs *backwards*: a prom-only field stripped in `block-render.ts` alone falls straight through the tRPC path's `...renderData` into the ClickHouse insert, and **TypeScript cannot catch it** (spread properties are exempt from excess-property checking).

Both writers now call `blockRenderTrackerPayload`, which is an **allowlist** rather than the previous destructure-rest **denylist** — a new schema field can no longer reach ClickHouse by default.

## Correctness rules (each mutation-checked, see below)

- **Never observe a zero.** An unobserved leg reads as an *instant* leg and drags every percentile down — in the reassuring direction, which is why nobody notices.
- **Drop, never clamp,** an out-of-range sample (mirrors `observeCustomComfyWallclockSeconds`; a clamp folds junk onto `+Inf` and pollutes `_sum` and the tail).
- **`total` is the anchor** — no credible end-to-end number ⇒ no phase samples either.
- **Observe only on `status === 'ok' && !secondary`.** A failure beacon never saw `BLOCK_READY`, so a *fast failure* would be recorded as a *fast launch*; a `secondary` beacon is a mid-session teardown minutes later.
- **Drop the sample if the tab was ever hidden** during the launch window, on a listener that is deliberately **not** the existing one — that one is gated on `status === 'ready'`, i.e. it starts listening only *after* the window it would need to observe has closed.
- **`timings` carries `.catch(undefined)`** so a malformed payload degrades to "no timings" instead of failing the whole `safeParse`, 400ing the beacon, and **losing the impression**. An observability add-on must be strictly subordinate to the analytics event it rides on.

## Buckets

`[0.1, 0.25, 0.4, 0.6, 0.8, 1.2, 1.8, 2.5, 4, 6, 8, 10, 15]`

`0.25` = `LAUNCH_REVEAL_MS` (below it the launch is already hidden behind the cross-fade) · `0.4`/`0.8` = one and two `INIT_RETRY_INTERVAL_MS` ticks, so the 400 ms quantization shows up as mass piling above `0.4` · `10` = `BLOCK_READY_TIMEOUT_MS` (one attempt's ready wait) · `15` = `TOKEN_WAIT_TIMEOUT_MS` (one attempt's token wait). prom-client's defaults have no `0.4` edge and nothing between 5 and 10 — they cannot resolve either question this metric exists for.

🔴 **A `total` above 15 s is reachable and legitimate — do not read the top bucket as a bug signal.** An earlier revision claimed a sample above 10 s was "structurally impossible on the success path". True of **one attempt**, false of a **launch**: the host emits one `ok` for the whole bounded auto-retry sequence. `+Inf − le=15` means "recovered slowly", a real population.

**The worst reachable success is 57 s, and the arithmetic is subtle enough that it was wrong twice.** Two consecutive `no_token`s are *unreachable* (`no_token` is an auth terminal, so the second hits `MAX_AUTO_REMINTS = 1` and settles). The real sequence is mixed:

```
attempt 1  no_token @15s                       (auth; spends the re-mint)
+ 2s backoff
attempt 2  a re-mint is in flight, so the token wait is paid AGAIN, and the
           ready timer only arms once a token exists → the two windows are
           SERIAL within the attempt → timeout @25s   (non-auth; spends nothing)
+ 5s backoff
attempt 3  the token from attempt 2 PERSISTS, so the token wait cannot be
           re-paid → ready-bounded only → ok @≤10s
                                                       = 57s
```

That is why the naive `3 × (15+10) + backoffs` = 82 s over-states it and `attempts × 15` = 37 s under-states it.

**Fixed structurally, not by editing the number.** `47_000` had been a literal in two comments *and* two value tests, decoupled from the constants it claimed to derive from — so any bump to the five inputs would have walked past the cap with nothing red. `worstReachableLaunchMs()` now computes it in `pageBlockHostLogic`, and `launchSampleBound.test.ts` recomputes it **independently** from the raw constants (deriving the expectation from the implementation would be a tautology), asserts both caps exceed it, asserts the caps agree, brackets it between the two naive estimates, and asserts the margin is *thin* — it is ~3 s, not "comfortable", and saying so is the point.

🟡 **Known limitation:** the 15–60 s tail is one undifferentiated bucket, so the histogram can say *that* a launch was auto-retry-recovered but not how slow. Deliberate — extra edges there cost series on every app for a population that requires two failed attempts.

## Cardinality

Count a histogram label set as **16 series**, not 15: 13 finite edges + `+Inf` + `_sum` + `_count`. And `app_block_id` spans ~**52** values at A=50 approved apps, because `boundAppBlockIdLabel` adds *both* `'dev'` and `'other'`. Two histograms rather than one: a combined `{app_block_id, phase}` would be 52 × 2 × 16 = **1,664** bucket series *per pod* across ~130 dp-prod pods. Split it is 52 × 16 + 2 × 16 = **~864/pod** at full app saturation (an earlier revision of this section said 795 — it undercounted both factors), in line with the existing `civitai_app_block_request_duration_seconds{app_block_id, endpoint}`. `app_block_id` uses the existing `boundAppBlockIdLabel` clamp; `phase` is code-owned and the beacon body carries **only numbers**, so client input cannot touch cardinality at all.

---

## 🔴 Why there is no `frame_fetch`

An earlier revision of this PR shipped a third phase read from the parent's `PerformanceResourceTiming` entry for the block iframe, on the belief that it was available at 100% coverage. **It was removed, and not because it needed polish — the number it produced was not the number its name claimed.**

**1. Without `Timing-Allow-Origin`, `responseEnd` for a cross-origin subframe is the frame's `load` event, not the document response.** The HTML spec's iframe load steps set the fallback "response end time" to the current time when the subframe's load event fires, and the TAO check is what selects between that fallback and the real document timing (WHATWG HTML §4.8.5 + §7.4.6; Chromium since M111 via `HTMLFrameOwnerElement::DispatchLoad()` → `ReportFallbackResourceTimingIfNeeded()`; WPT `resource-timing/nested-nav-fallback-timing.html` asserts exactly this). Measured on Chromium 144 and 150 against a child page holding one subresource: the no-TAO duration tracked the delay **1:1** (657 / 2053 / 5066 ms for 500 / 2000 / 5000 ms held) while TAO and same-origin stayed at 3–9 ms.

So the same field carries **two different quantities selected by a header we do not send**. On a real block the phase reads seconds, close to `total`, and would visually dominate any phase panel while measuring roughly what `total` already measures. That is a *different* trap from the parallel-vs-serial confusion this PR's other comments guard against, and those comments do not cover it.

**2. And it was not 100% observable anyway.** The entry does not exist until the subframe's `load` fires, while the beacon reads it at `BLOCK_READY`. An SPA block that posts `BLOCK_READY` at app-mount — the normal case, with fonts and images still in flight — yields **no entry**, and the phase silently vanishes. Heavier apps drop out more often, so the missing data is **slowness-correlated**: the exact bias that makes a percentile lie in the reassuring direction. The claim "no coverage caveat and no biased subset" in the earlier revision was wrong and is gone.

That leaves three honest options — send TAO and measure the document response, measure from inside the block via the SDK, or don't ship the phase. This PR takes the third. The `Timing-Allow-Origin` question is being reopened separately and is **not merely explanatory**: because the header changes *which quantity* the field carries, it may be a genuine prerequisite. The re-add seam is small and documented in `launchTimings.ts`.

## Two further 🔴s from the same audit

**`mountedAt` was overwritten on first mount.** The re-arm effect keyed on `[blockInstanceId]` also runs on mount, so it replaced the render-time t0 — taken in the commit where the iframe actually mounts — with a post-commit timestamp, shortening **every** `total` by the render→effect gap. No test went red; the number was just quietly flattering. Guarded by a pure `shouldResetLaunchMarks`.

**…and the predicate alone was not enough.** A later audit round found the *wiring* unpinned: move the `launchInstanceRef` seed from render into a `useEffect` and the predicate stays correct, its three tests stay green, and the bug returns verbatim. That is now covered by a **source gate in the `unit` project** which brace-matches every `useEffect(` span and asserts the seed sits outside all of them.

Chosen over a browser spy deliberately: a spy asserting `resetLaunchMarks` is not called on first mount would be the more direct test, but it can only live in the `component` project — **which CI does not run** — so it would report safety from a tier that never observes it. The gate carries its own **positive control** (a synthetic source with the seed moved inside an effect must be rejected), so a checker whose brace-matching silently found nothing cannot pass. The trade is named in the comment: it checks source *shape*, not behaviour.

**The ">10 s is impossible" claim** — covered under Buckets above. Nothing in the bucket or validation logic depended on it; it lived only in comments and one test title, both corrected, and it had silently set the sample cap too low.

---

## 🔴 How to verify after deploy — a scrape proves NOTHING

**Read this before concluding the metric is broken.** These metrics live behind a dynamic `await import(...)` inside a try/catch, and `app-block-runtime.metrics` is *not* force-imported by `/api/metrics` (only `challenge.metrics` is). A brand-new histogram therefore has **no `# TYPE` line at all** on `/api/metrics` until its first real emit, and Prometheus `/api/v1/metadata` returns nothing for it either. **An absent metric is indistinguishable from an unshipped one.**

**1. Verify SHIPMENT structurally, not by scraping.**

```bash
CIV=~/workspace/civit/civitai
git -C "$CIV" fetch origin release
git -C "$CIV" merge-base --is-ancestor <merge-sha> origin/release && echo IN_RELEASE || echo NOT_IN_RELEASE
kubectl -n civitai-dp-prod get deploy civitai-dp-prod-primary \
  -o jsonpath='{.spec.template.spec.containers[0].image}'   # tag is <14-digit-ts>-<shortsha>
```

Both must agree: the sha is an ancestor of `origin/release` **and** the serving image's `<shortsha>` is at or after it.

**2. Verify EMISSION only by forcing a real occurrence.** Open `/apps/run/<slug>` as a mod, wait one scrape interval (15 s), then read through Prometheus — you cannot know which of ~130 pods served the beacon. If you scrape a pod directly instead: `/api/metrics` **requires the `?token=` from the PodMonitor `params`** and binds on the **pod IP**, not localhost.

**3. Both controls.**
- *Positive:* one deliberate launch moves `civitai_app_block_launch_total_seconds_count` by **exactly 1** *and* `civitai_app_block_renders_total{result="ok"}` by **exactly 1** in the same window. A `0` means the wiring is inert; a `2` means the beacon contract broke. The second assertion is the actual proof impression accounting was not perturbed.
- *Negative:* one launch with devtools throttled to Slow 3G must land in a **higher** bucket. A histogram wired to nothing produces a beautiful, plausible, entirely-bottom-bucket distribution that reads as "launch is fast".

**4. Querying it.** Use `max_over_time`, **not** `rate()`. Each beacon lands on a *different* pod, so a per-pod counter series is born at 1 and never increments — `rate()`/`increase()` read as structurally ~0 (this is already documented for `renders_total` in `app-block-alerts-configmap.yaml`). Use `histogram_quantile(0.95, sum by(le)(max_over_time(..._bucket[24h])))`, and note honestly on any panel that this under-counts across a Flagger promotion.

---

## Tests

**Full node `unit` project: 10,857 passed / 0 failed** (the project CI runs).

New/extended:

| Suite | Tests |
|---|---|
| `src/components/AppBlocks/__tests__/launchTimings.test.ts` (new) | 25 |
| `src/components/AppBlocks/__tests__/launchSampleBound.test.ts` (new) | 8 |
| `src/server/metrics/__tests__/app-block-launch.metrics.test.ts` (new) | 16 |
| `src/tests/api/track/block-render.test.ts` | 26 (was 19) |
| `src/server/routers/__tests__/track.router.blockRender.test.ts` | 10 (was 8) |

Browser specs for the touched files (no full component sweep): `PageBlockHost` 25 ✓ · `PageBlockHostAutoRetry` 14 ✓ · `PageBlockHostLaunchReveal` 10 ✓ · `PageBlockHostTokenTerminal` 9 ✓.

### Red-at-base

Ran the HEAD test files against a **pristine `origin/main` worktree** (`bd2c354cd7`), after first confirming that worktree runs an *untouched* file green (8/8) so the harness itself is not the thing failing:

| File at base | Result |
|---|---|
| `launchTimings.test.ts` | **fails to collect** — `Cannot find module '../launchTimings'` |
| `app-block-launch.metrics.test.ts` | **14 / 14 failed** |
| `block-render.test.ts` | **4 failed**, 22 passed |
| `track.router.blockRender.test.ts` | **10 passed** |

**Labelled honestly:** the two new tRPC tests and three of the new REST tests **pass at base** and are therefore **invariant guards, not regression coverage** — at base `blockRenderSchema` has no `timings` field, so zod strips it before the resolver and the assertion is satisfied vacuously. Their value is proven by mutation instead (below), which is the only construction that can express "would fail if only the REST path were patched".

### Mutation sweep — 30 mutants, 30 killed (18 re-run in full against the post-audit code, + 12 for the round-3 guards)

| Mutant | Killed by |
|---|---|
| 🔴 **half-fix: revert the tRPC resolver to `...renderData` (only REST patched)** | `strips \`timings\` from the ClickHouse payload on the tRPC path` |
| 🔴 the "fix the asymmetry" error: make tRPC observe the histograms too | `does NOT observe the launch histograms` |
| drop the whole `ok && !secondary` gate | `does NOT observe a launch for an \`error\` beacon` |
| drop only the `!secondary` half | `does NOT observe a launch for a secondary beacon that is also \`ok\`` |
| server zero-gate `!(ms > 0)` → `ms < 0` | `rejects a ZERO` |
| server clamp instead of drop | `DROPS an out-of-range sample rather than clamping` |
| `total` anchor → default 0 instead of return | `\`total\` is the ANCHOR` |
| client zero-gate → allows zero | `NEVER returns a zero` |
| client clamp instead of drop | `DROPS an out-of-range sample rather than clamping` |
| remove the hidden-tab rule | `drops the WHOLE sample when the tab was ever hidden` |
| client `total` anchor removed | `\`total\` is the ANCHOR` |
| schema `.catch(undefined)` removed | `malformed \`timings\` still records the impression` |
| buckets → prom-client defaults | `resolves the 400ms BLOCK_INIT tick` |
| 🔴 resurrect `frame_fetch` server-side | `ignores a client-sent frameFetchMs` |
| 🔴 re-add `frameFetchMs` to the wire payload | `never emits a frameFetchMs field` |
| 🔴 remove the first-mount reset guard | `does NOT reset on first mount` |
| 🔴 lower the client sample bound back to 30 s | `accepts a slow auto-retry success` / `both caps exceed the worst reachable` |
| 🔴 lower the server sample bound back to 30 s | same |
| 🔴 **move the seed into a `useEffect`** (the mutant a prior round found nothing caught) | `seeds launchInstanceRef at render scope` |
| 🔴 bypass the predicate at the call site | `re-arms the marks through the predicate` |
| widen `MAX_AUTO_RETRIES` 2→4 | `both caps exceed the worst reachable` |
| widen `TOKEN_WAIT_TIMEOUT_MS` 15→30 s | same |
| widen `BLOCK_READY_TIMEOUT_MS` 10→30 s | same |
| widen the backoffs to 30/40 s | same |
| widen `MAX_AUTO_REMINTS` 1→2 | `independent recomputation` |
| drop the serial-window attempt from the derivation | `independent recomputation` |
| split the client/server caps | `client and server caps agree` |
| pad the cap to 5 minutes | `margin is thin` |

Plus a **browser-level** kill proving the whole client chain reaches the wire in real Chromium: stubbing the host's `computeLaunchTimings` call to `null` turns `emits the block-render beacon exactly once at BLOCK_READY` red with `expected [ 'appBlockId', …(2) ] to deeply equal [ 'appBlockId', …(3) ]`.

Two mutants initially **survived** and each exposed a real gap, both since closed:
- dropping `&& !secondary` survived because the existing secondary test uses `status:'error'`, which the `ok` half already rejects — added a `secondary: true, status: 'ok'` case that reaches the second half with an input the first cannot reject;
- the original `total`-anchor mutant was **equivalent** (prom-client absorbed the invalid observe inside the fail-soft catch, so the phases were suppressed anyway) — replaced with a stronger mutant that defaults the total to 0 and lets the phases through.

Every reassuring **zero** in these tests is paired with a **positive control** on the same counter, so a zero can never be a metric that is wired to nothing.

## Not in this change

No preload/preconnect lever. Nothing touching `Timing-Allow-Origin` or the block build recipe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
