### PR TITLE
fix(apps): reconcile legacy recents against loaded listings so the rail stops showing an eye for apps you run

### DIFF
--- a/src/components/Apps/AppListingsMarketplaceBody.recentsReconcile.browser.test.tsx
+++ b/src/components/Apps/AppListingsMarketplaceBody.recentsReconcile.browser.test.tsx
@@ -1,0 +1,280 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { page } from 'vitest/browser';
+import { useRouter } from 'next/router';
+// `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
+import { renderWithProviders } from '../../../test/component-setup';
+import type * as TrpcMod from '~/utils/trpc';
+import type { ListingCard } from '~/server/schema/blocks/app-listing-read.schema';
+import { RECENTLY_OPENED_APPS_KEY } from '~/components/Apps/recentlyOpenedAppsStore';
+
+/**
+ * LEGACY-RECENTS RECONCILIATION — the `/apps` rail's stale-icon defect.
+ *
+ * 🔴 WHY THIS FILE EXISTS AT ALL, AND WHY IT SEEDS RAW JSON.
+ *
+ * The rail's icon is DERIVED from where the tile navigates
+ * (`getRecentRailAction` → `getRecentRailTarget`), and the target for an on-site
+ * entry needs `hasPage`. `resolveRecentApp` reads `entry.hasPage === true`, so an
+ * entry that never RECORDED the field resolves to `hasPage: false` and routes to
+ * `/apps/store-preview/<slug>` under an EYE — "read about it" — for an app the
+ * viewer has already been running. That is a stale-data artifact, not a signal.
+ *
+ * The entries that hit it are the ones `MarketplaceBody.recordRecent` wrote:
+ * `{id, blockId, name, iconUrl}` — no `kind`, no `hasPage`, and NO `slug`. A real
+ * viewer's `localStorage.recentlyOpenedApps` was read while diagnosing this: 7 of
+ * its 8 entries were exactly that shape. So the fixture below is that shape,
+ * seeded as RAW JSON through `localStorage.setItem` rather than built by calling
+ * `recordRecentlyOpenedApp` with a fully-populated object.
+ *
+ * That choice is the whole point of the file. A fixture assembled from the
+ * CURRENT `RecentApp` shape encodes the same assumption the bug is made of — that
+ * these fields are present — so it would exercise a path the defect never takes
+ * and pass while proving nothing. Seeding the bytes that are actually on disk is
+ * the only version of this test that can fail for the real reason.
+ *
+ * Its OWN FILE (not a case appended to `AppListingsMarketplaceBody.browser.test.tsx`)
+ * because it needs `appBlocksPages: true` — the run route's flag — where that file
+ * pins the flag dark for every one of its tests. Same reason the mobile-drawer and
+ * pre-hydration paths get their own files.
+ */
+
+/**
+ * A card in the exact projection the store read returns. `hasPage` and the
+ * on-site `appBlockId` are the two fields reconciliation actually consumes.
+ */
+function makeOnsiteCard(args: {
+  id: string;
+  slug: string;
+  name: string;
+  hasPage: boolean;
+  appBlockId?: string | null;
+}): ListingCard {
+  return {
+    id: args.id,
+    slug: args.slug,
+    kind: 'onsite',
+    name: args.name,
+    tagline: null,
+    category: null,
+    contentRating: null,
+    iconUrl: null,
+    coverUrl: null,
+    creator: null,
+    recommend: { recommendedCount: 0, notRecommendedCount: 0, recommendPct: null },
+    reviewCount: 0,
+    kindData: {
+      kind: 'onsite',
+      appBlockId: args.appBlockId === undefined ? `blk_${args.slug}` : args.appBlockId,
+      hasPage: args.hasPage,
+      liveUrl: `https://${args.slug}.civit.ai`,
+    },
+  };
+}
+
+const mocks = vi.hoisted(() => ({
+  items: [] as ListingCard[],
+}));
+
+vi.mock('~/hooks/useCurrentUser', () => ({ useCurrentUser: () => null }));
+
+// Spread the REAL module and override only `trpc` (local-rules/no-wholesale-
+// module-mock): a hand-written replacement silently breaks every importer the day
+// '~/utils/trpc' grows an export this factory omits — the whole FILE then fails to
+// load with 0 tests collected and no failing assertion.
+vi.mock('~/utils/trpc', async (importOriginal) => ({
+  ...(await importOriginal<typeof TrpcMod>()),
+  trpc: {
+    appListings: {
+      listAvailable: {
+        useInfiniteQuery: () => ({
+          data: { pages: [{ items: mocks.items, nextCursor: undefined }] },
+          isLoading: false,
+          isFetchingNextPage: false,
+          fetchNextPage: vi.fn(),
+          hasNextPage: false,
+        }),
+      },
+    },
+  },
+}));
+
+// 🔴 `appBlocksPages: true` — the run route's flag. `getRecentRailTarget` only
+// returns `/apps/run/<blockId>` when it is on, so with the flag dark EVERY tile
+// resolves to the detail page and this file's central assertion would pass on the
+// broken build for the wrong reason.
+vi.mock('~/providers/FeatureFlagsProvider', () => ({
+  useFeatureFlags: () => ({ appBlocks: true, appBlocksPages: true }),
+}));
+
+// Both throw rather than defaulting when their provider is absent, taking the
+// whole body down with an empty <body> — see the sibling file's note.
+vi.mock('~/providers/IsClientProvider', () => ({ useIsClient: () => true }));
+vi.mock('~/hooks/useIsMobile', () => ({ useIsMobile: () => false, isMobileDevice: () => false }));
+
+// Import AFTER mocks (vi.mock is hoisted, static imports are not).
+const { AppListingsMarketplaceBody } = await import('./AppListingsMarketplaceBody');
+
+// Not a real hook: the scaffold mocks `next/router` with `useRouter: () => router`,
+// a plain function returning a singleton, so module scope is fine (and a per-file
+// `vi.mock('next/router')` silently LOSES to the setup-file mock).
+// eslint-disable-next-line react-hooks/rules-of-hooks
+const router = useRouter();
+
+/**
+ * THE LEGACY PAYLOAD, verbatim in shape: `name` + `blockId` (+ the `id` that is
+ * the store's de-dup key). No `kind`, no `hasPage`, no `slug`.
+ */
+function seedLegacyRecents(entries: { id: string; blockId: string; name: string }[]) {
+  window.localStorage.setItem(RECENTLY_OPENED_APPS_KEY, JSON.stringify(entries));
+}
+
+beforeEach(() => {
+  mocks.items = [];
+  router.query = {};
+  window.localStorage.removeItem(RECENTLY_OPENED_APPS_KEY);
+});
+
+/** The `tabler-icon-*` modifier on a glyph, e.g. `player-play`. Stable across a
+ *  patch bump in a way the raw path `d` is not. */
+function glyphOf(el: Element): string {
+  const svg = el.querySelector('svg');
+  if (!svg) throw new Error('rail action rendered no glyph at all');
+  const modifier = Array.from(svg.classList).find(
+    (c) => c.startsWith('tabler-icon-') && c !== 'tabler-icon'
+  );
+  if (!modifier)
+    throw new Error(`glyph carried no tabler-icon-* class: ${svg.getAttribute('class')}`);
+  return modifier.replace('tabler-icon-', '');
+}
+
+describe('the /apps rail reconciles LEGACY recents against the loaded listings', () => {
+  /**
+   * 🔴 THE REGRESSION TEST. Red on pre-change source: the entry resolves
+   * `hasPage: false`, so the tile renders an EYE pointing at
+   * `/apps/store-preview/gen-matrix` labelled "View details for Gen Matrix".
+   *
+   * All THREE are asserted, not just the icon, because they are one decision:
+   * `getRecentRailAction` derives the label from the same target that produces
+   * the href, and the icon from that action. Asserting the glyph alone would
+   * still pass if a future edit hard-coded a play icon onto a tile that navigates
+   * to the detail page — the exact "lie in the accessible name" the derivation
+   * exists to prevent.
+   */
+  test('a {name, blockId}-only entry whose app IS on a loaded page → play + /apps/run/ + "Open"', async () => {
+    mocks.items = [
+      makeOnsiteCard({ id: 'lst_gm', slug: 'gen-matrix', name: 'Gen Matrix', hasPage: true }),
+    ];
+    seedLegacyRecents([{ id: 'blk_gen-matrix', blockId: 'gen-matrix', name: 'Gen Matrix' }]);
+
+    renderWithProviders(<AppListingsMarketplaceBody />);
+
+    const action = page.getByTestId('apps-recent-rail-action');
+    await expect.element(action).toBeInTheDocument();
+
+    // The href — reconciliation's actual effect. Pre-change: /apps/store-preview/gen-matrix.
+    await expect.element(action).toHaveAttribute('href', '/apps/run/gen-matrix');
+    // The accessible name, by ROLE. `getByRole('link')` also proves the CTA is a
+    // real anchor rather than a <button href> (that build shipped once).
+    await expect.element(page.getByRole('link', { name: 'Open Gen Matrix' })).toBeInTheDocument();
+    // …and the glyph the viewer actually sees. Pre-change: `eye`.
+    expect(glyphOf(action.element())).toBe('player-play');
+  });
+
+  /**
+   * The NON-REGRESSION half, and the reason reconciliation UPGRADES rather than
+   * FILTERS. A recents entry for an app that is simply not on a loaded page —
+   * page 2, a different `kind`/`category` filter, a listing that no longer exists —
+   * must keep working exactly as it does today. Dropping it would silently empty a
+   * returning viewer's rail, which is the failure the whole resolve-don't-drop
+   * design exists to avoid.
+   */
+  test('an UNMATCHED legacy entry keeps its current behaviour — never dropped, never upgraded', async () => {
+    mocks.items = [
+      makeOnsiteCard({ id: 'lst_gm', slug: 'gen-matrix', name: 'Gen Matrix', hasPage: true }),
+    ];
+    seedLegacyRecents([
+      { id: 'blk_prompt-vault', blockId: 'prompt-vault', name: 'Prompt Vault' },
+      { id: 'blk_gen-matrix', blockId: 'gen-matrix', name: 'Gen Matrix' },
+    ]);
+
+    renderWithProviders(<AppListingsMarketplaceBody />);
+
+    await expect.element(page.getByTestId('apps-recent-rail')).toBeInTheDocument();
+    const actions = page.getByTestId('apps-recent-rail-action').elements();
+    // BOTH tiles still render — the unmatched one was not filtered out.
+    expect(actions).toHaveLength(2);
+
+    // Newest-first order is preserved, so [0] is the unmatched Prompt Vault: it
+    // keeps the conservative detail target it has today.
+    expect(actions[0].getAttribute('href')).toBe('/apps/store-preview/prompt-vault');
+    expect(glyphOf(actions[0])).toBe('eye');
+    expect(actions[0].getAttribute('aria-label')).toBe('View details for Prompt Vault');
+
+    // …and the matched one is upgraded alongside it.
+    expect(actions[1].getAttribute('href')).toBe('/apps/run/gen-matrix');
+    expect(glyphOf(actions[1])).toBe('player-play');
+  });
+
+  /**
+   * 🔴 RECONCILIATION IS A CORRECTION, NOT A PROMOTION. The card is the server's
+   * truth in BOTH directions: an app that has LOST its page must lose the play
+   * glyph too, or the rail offers a guaranteed 404 under an "Open" label.
+   *
+   * This is the mutation-sensitive direction. A reconcile implemented as "fill in
+   * missing fields only" (`hasPage: entry.hasPage ?? card.hasPage`) passes the two
+   * tests above and fails here.
+   */
+  test('a persisted hasPage:true is CORRECTED DOWN when the card says the app has no page', async () => {
+    mocks.items = [
+      makeOnsiteCard({ id: 'lst_pv', slug: 'prompt-vault', name: 'Prompt Vault', hasPage: false }),
+    ];
+    // A fully-populated, NON-legacy entry that went stale the other way.
+    window.localStorage.setItem(
+      RECENTLY_OPENED_APPS_KEY,
+      JSON.stringify([
+        {
+          id: 'blk_prompt-vault',
+          blockId: 'prompt-vault',
+          slug: 'prompt-vault',
+          kind: 'onsite',
+          hasPage: true,
+          name: 'Prompt Vault',
+        },
+      ])
+    );
+
+    renderWithProviders(<AppListingsMarketplaceBody />);
+
+    const action = page.getByTestId('apps-recent-rail-action');
+    await expect.element(action).toBeInTheDocument();
+    await expect.element(action).toHaveAttribute('href', '/apps/store-preview/prompt-vault');
+    expect(glyphOf(action.element())).toBe('eye');
+  });
+
+  /**
+   * The store's de-dup key is `id`, and BOTH on-site writers key it on the
+   * AppBlock id. Matching by that key (not only by `blockId`) is what lets an
+   * entry whose `blockId` was never written still reconcile.
+   */
+  test('an entry with NO blockId reconciles via its id against the card appBlockId', async () => {
+    mocks.items = [
+      makeOnsiteCard({
+        id: 'lst_gm',
+        slug: 'gen-matrix',
+        name: 'Gen Matrix',
+        hasPage: true,
+        appBlockId: 'blk_gen-matrix',
+      }),
+    ];
+    window.localStorage.setItem(
+      RECENTLY_OPENED_APPS_KEY,
+      JSON.stringify([{ id: 'blk_gen-matrix', slug: 'gen-matrix', name: 'Gen Matrix' }])
+    );
+
+    renderWithProviders(<AppListingsMarketplaceBody />);
+
+    const action = page.getByTestId('apps-recent-rail-action');
+    await expect.element(action).toBeInTheDocument();
+    await expect.element(action).toHaveAttribute('href', '/apps/run/gen-matrix');
+  });
+});

--- a/src/components/Apps/AppListingsMarketplaceBody.tsx
+++ b/src/components/Apps/AppListingsMarketplaceBody.tsx
@@ -8,7 +8,11 @@ import { AppsStoreFiltersDropdown } from '~/components/Apps/AppsStoreFiltersDrop
 import { hasActiveAppsStoreFilters } from '~/components/Apps/appsStoreQueryParams';
 import { useAppsStoreQueryParams } from '~/components/Apps/useAppsStoreQueryParams';
 import { RecentlyOpenedListingsView } from '~/components/Apps/RecentlyOpenedApps';
-import { selectRecentRailEntries, type ResolvedRecentApp } from '~/components/Apps/recentAppsRail';
+import {
+  reconcileRecentApps,
+  selectRecentRailEntries,
+  type ResolvedRecentApp,
+} from '~/components/Apps/recentAppsRail';
 import {
   getRecentlyOpenedApps,
   recordRecentlyOpenedApp,
@@ -141,7 +145,9 @@ export function AppListingsMarketplaceBody() {
   useEffect(() => {
     setRecents(getRecentlyOpenedApps());
   }, []);
-  const recentEntries = useMemo(() => selectRecentRailEntries(recents), [recents]);
+  // The rail's ENTRIES are derived further down — `recentEntries` needs the
+  // loaded listings (`items`) to reconcile stale persisted entries against, and
+  // those are not available until after the query below. See it there.
 
   // Re-opening from the rail moves that app back to the front of the store. For
   // an OFF-SITE entry this is the only chance to record it (following the link
@@ -181,6 +187,57 @@ export function AppListingsMarketplaceBody() {
     );
 
   const items = useMemo(() => (data?.pages ?? []).flatMap((p) => p.items as ListingCard[]), [data]);
+
+  /**
+   * RECONCILE the persisted recents against the listings already on this page.
+   *
+   * 🔴 WHY THE RAIL NEEDS THIS. A recents entry written by the legacy
+   * `MarketplaceBody.recordRecent` carries `{id, blockId, name, iconUrl}` — no
+   * `hasPage` — and `resolveRecentApp` reads a missing `hasPage` as `false`. So a
+   * viewer's most-run apps rendered an EYE pointing at the detail page instead of
+   * a PLAY pointing at `/apps/run/…`, and no amount of clicking healed it:
+   * `handleOpenRecent` re-persists the resolved `false`. `reconcileRecentApps`
+   * takes the server's answer from the matching card. Entries with no match on
+   * the loaded pages pass through UNTOUCHED — never dropped.
+   *
+   * 🔴 NO EFFECT, NO WRITE, NO LOOP. This is a pure derivation, deliberately not
+   * an effect that re-persists the repaired list. An effect writing the store on
+   * every `/apps` load would need a whole-list writer (`recordRecentlyOpenedApp`
+   * prepends, so looping it would REVERSE the rail) and would risk a write/render
+   * loop against state this component also reads. It buys nothing: the derivation
+   * re-runs on every load, and the store's other consumer — the app-chrome
+   * "Recently run" menu — filters on `kind`/`blockId`, which legacy entries
+   * already carry.
+   *
+   * The repair still PERSISTS on the natural interaction: `handleOpenRecent`
+   * receives the RECONCILED entry, so the first click on a healed tile writes the
+   * corrected `kind`/`hasPage`/`slug` back to localStorage.
+   */
+  const reconciledRecents = useMemo(() => reconcileRecentApps(recents, items), [recents, items]);
+  /**
+   * ⚠️ ACCEPTED: a SECOND post-paint update. The rail already hydrates one frame
+   * late (localStorage is client-only, seeded empty for SSR parity); this adds an
+   * update when the query resolves, so a tile's glyph can flip eye→play after
+   * paint and its `aria-label` change may be re-announced by some assistive tech.
+   * Accepted rather than mitigated, on three grounds:
+   *   - NO LAYOUT SHIFT. The CTA is a fixed `ActionIcon size="md"` and both
+   *     glyphs render at 16px, so the flip is a repaint, not a reflow — nothing
+   *     moves, which is the CLS hazard the rail's placement already guards.
+   *   - NEVER MISLEADING AT ANY INSTANT. The icon, the label and the href are all
+   *     derived from one `getRecentRailAction` call, and that coupling is pinned
+   *     ("NEVER disagrees with getRecentRailTarget"). So the pre-flip state is a
+   *     correct "view details" control, and the post-flip state is a correct
+   *     "open" one — a viewer can never be shown a play glyph on a control that
+   *     navigates to the detail page.
+   *   - The alternative — withholding the rail until the query settles — delays
+   *     the "jump back in" shortcut behind a network round-trip and hides the rail
+   *     entirely when the query ERRORS, which is a worse regression than a glyph
+   *     correcting itself.
+   */
+  const recentEntries = useMemo(
+    () => selectRecentRailEntries(reconciledRecents),
+    [reconciledRecents]
+  );
 
   // Client-side search over loaded pages (name + tagline). See the ⚠️ gap note:
   // this is complete only while the catalog fits in the loaded pages.

--- a/src/components/Apps/__tests__/recentAppsRail.test.ts
+++ b/src/components/Apps/__tests__/recentAppsRail.test.ts
@@ -5,6 +5,7 @@ import {
   getRecentRailAction,
   getRecentRailTarget,
   RECENT_RAIL_LIMIT,
+  reconcileRecentApps,
   resolveRecentApp,
   selectChromeRecentApps,
   selectRecentRailEntries,
@@ -740,5 +741,222 @@ describe('getRecentRailAction', () => {
             expect(action === 'visit').toBe(target.external);
             expect(action === 'open').toBe(target.href.startsWith('/apps/run/'));
           }
+  });
+});
+
+/**
+ * RECONCILIATION — repairing persisted recents from the loaded listings.
+ *
+ * The defect: `resolveRecentApp` reads a MISSING `hasPage` as `false`, so the
+ * legacy `{id, blockId, name, iconUrl}` entries `MarketplaceBody.recordRecent`
+ * wrote render an EYE at `/apps/store-preview/<slug>` for apps the viewer runs.
+ * A real viewer's localStorage had 7 of 8 entries in that shape.
+ */
+describe('reconcileRecentApps', () => {
+  const onsiteCard = (over: Partial<ListingCard> = {}): ListingCard =>
+    ({
+      id: 'lst_gm',
+      slug: 'gen-matrix',
+      kind: 'onsite',
+      name: 'Gen Matrix',
+      tagline: null,
+      category: null,
+      contentRating: null,
+      iconUrl: null,
+      coverUrl: null,
+      creator: null,
+      recommend: { recommendedCount: 0, notRecommendedCount: 0, recommendPct: null },
+      reviewCount: 0,
+      kindData: {
+        kind: 'onsite',
+        appBlockId: 'ab_gm',
+        hasPage: true,
+        liveUrl: 'https://gen-matrix.civit.ai',
+      },
+      ...over,
+    } as ListingCard);
+
+  /** The EXACT legacy shape: no `kind`, no `hasPage`, no `slug`. */
+  const legacy = (over: Partial<RecentApp> = {}): RecentApp => ({
+    id: 'ab_gm',
+    blockId: 'gen-matrix',
+    name: 'Gen Matrix',
+    ...over,
+  });
+
+  it('🔴 upgrades a {id, blockId} legacy entry from the matching card', () => {
+    const [out] = reconcileRecentApps([legacy()], [onsiteCard()]);
+    expect(out).toEqual({
+      id: 'ab_gm',
+      slug: 'gen-matrix',
+      blockId: 'gen-matrix',
+      kind: 'onsite',
+      hasPage: true,
+      name: 'Gen Matrix',
+    });
+  });
+
+  it('🔴 THE WHOLE POINT: that entry now derives a PLAY action, not an eye', () => {
+    // The end-to-end read, through the real resolver + the real action
+    // derivation — the icon, the href and the accessible label all come from
+    // here, so this is the assertion that maps to what a viewer sees.
+    const before = resolveRecentApp(legacy())!;
+    expect(getRecentRailAction(before, { canOpenPage: true })).toEqual({
+      action: 'view',
+      label: 'View details for Gen Matrix',
+    });
+
+    const [reconciled] = reconcileRecentApps([legacy()], [onsiteCard()]);
+    const after = resolveRecentApp(reconciled)!;
+    expect(getRecentRailAction(after, { canOpenPage: true })).toEqual({
+      action: 'open',
+      label: 'Open Gen Matrix',
+    });
+    expect(getRecentRailTarget(after, { canOpenPage: true }).href).toBe('/apps/run/gen-matrix');
+  });
+
+  it('🔴 NEVER DROPS an unmatched entry — it is returned untouched', () => {
+    const stranger = legacy({ id: 'ab_pv', blockId: 'prompt-vault', name: 'Prompt Vault' });
+    const out = reconcileRecentApps([stranger], [onsiteCard()]);
+    expect(out).toHaveLength(1);
+    // Same VALUE and same reference: an unmatched entry is not rebuilt at all.
+    expect(out[0]).toBe(stranger);
+  });
+
+  it('🔴 CORRECTS DOWN too — a stale hasPage:true loses its page when the card says so', () => {
+    // The mutation-sensitive direction. A `entry.hasPage ?? card.hasPage`
+    // implementation passes every test above and fails this one, having left the
+    // rail offering a guaranteed-404 `/apps/run/…` under an "Open" label.
+    const stale = onsite({ id: 'ab_gm', blockId: 'gen-matrix', slug: 'gen-matrix', hasPage: true });
+    const [out] = reconcileRecentApps(
+      [stale],
+      [
+        onsiteCard({
+          kindData: {
+            kind: 'onsite',
+            appBlockId: 'ab_gm',
+            hasPage: false,
+            liveUrl: 'https://gen-matrix.civit.ai',
+          },
+        }),
+      ]
+    );
+    expect(out.hasPage).toBe(false);
+    expect(getRecentRailTarget(resolveRecentApp(out)!, { canOpenPage: true }).href).toBe(
+      '/apps/store-preview/gen-matrix'
+    );
+  });
+
+  it('🔴 matches on blockId→card.slug when the id matches NOTHING', () => {
+    // 🔴 THE KEY THIS FIX TURNS ON. Every other test here happens to have an
+    // `id` equal to the card's `appBlockId`, so they ALL pass with the
+    // `blockId`→`slug` lookup deleted — they would certify a reconcile that
+    // cannot join the one shape the defect is made of. This entry's `id` matches
+    // no card by either id namespace, so ONLY the blockId→slug path can upgrade
+    // it, and deleting that path fails exactly here.
+    //
+    // The join works because for an ON-SITE app the AppListing slug IS the
+    // AppBlock `block_id` (`app-listing-mapper.ts` → `slug: ab.blockId`). Note the
+    // card side of the join is `card.slug`; the ENTRY side is `blockId`, because a
+    // legacy entry HAS no `slug` — keying both sides on `slug` matches zero rows.
+    const [out] = reconcileRecentApps(
+      [{ id: 'legacy-key-that-matches-no-card', blockId: 'gen-matrix', name: 'Gen Matrix' }],
+      [onsiteCard()]
+    );
+    expect(out.hasPage).toBe(true);
+    expect(out.kind).toBe('onsite');
+    expect(out.slug).toBe('gen-matrix');
+    // …and the id is still NOT rewritten, even on a slug-path match.
+    expect(out.id).toBe('legacy-key-that-matches-no-card');
+  });
+
+  it('matches on the AppBlock id when the entry has no blockId', () => {
+    const out = reconcileRecentApps([{ id: 'ab_gm', slug: 'gen-matrix' }], [onsiteCard()]);
+    expect(out[0].hasPage).toBe(true);
+  });
+
+  it('🔴 the appBlockId join carries an entry whose recorded slug is STALE', () => {
+    // The case that makes the `entry.id → card.kindData.appBlockId` lookup
+    // load-bearing rather than redundant. Every other fixture's `blockId` already
+    // equals the card `slug`, so they all still reconcile with that join deleted.
+    // Here the app's `block_id` has MOVED since the entry was written, so the
+    // slug join misses and only the AppBlock id — the store's de-dup key, and the
+    // one identifier both on-site writers agree on — can still find the card.
+    const [out] = reconcileRecentApps(
+      [{ id: 'ab_gm', blockId: 'the-old-block-id', name: 'Gen Matrix' }],
+      [onsiteCard()]
+    );
+    expect(out.hasPage).toBe(true);
+    // …and the STALE handle is replaced by the card's current one, so the tile
+    // links to where the app lives now rather than to a 404.
+    expect(out.slug).toBe('gen-matrix');
+    expect(out.blockId).toBe('gen-matrix');
+  });
+
+  it('🔴 an unmatched entry is passed through byte-for-byte, not rebuilt', () => {
+    // Guards the pass-through against a mutation that RETURNS something for an
+    // unmatched entry instead of the entry itself. Asserted on a list where the
+    // unmatched entry is NOT the first element, so a `return entries[0]`-shaped
+    // bug cannot coincidentally return the right object.
+    const matched = legacy();
+    const unmatched: RecentApp = { id: 'ab_pv', blockId: 'prompt-vault', name: 'Prompt Vault' };
+    const out = reconcileRecentApps([matched, unmatched], [onsiteCard()]);
+    expect(out[1]).toBe(unmatched);
+    expect(out[1]).toEqual({ id: 'ab_pv', blockId: 'prompt-vault', name: 'Prompt Vault' });
+    // No `kind`/`hasPage` invented for an app we know nothing about.
+    expect(out[1].kind).toBeUndefined();
+    expect(out[1].hasPage).toBeUndefined();
+  });
+
+  it('matches an OFF-SITE entry on the listing id, and strips a stray blockId', () => {
+    // A stray `blockId` on an off-site entry would point the app-chrome
+    // "Recently run" menu at a DIFFERENT app (`selectChromeRecentApps` filters on
+    // `!!blockId`), so reconciliation must remove it, not merge around it.
+    const card = onsiteCard({
+      id: 'lst_ext',
+      slug: 'ext-app',
+      kind: 'offsite',
+      name: 'Ext App',
+      kindData: { kind: 'offsite', subKind: 'external-link', externalUrl: 'https://ext.example/a' },
+    });
+    const [out] = reconcileRecentApps([{ id: 'lst_ext', blockId: 'stale-block' }], [card]);
+    expect(out.blockId).toBeUndefined();
+    expect(out).toMatchObject({
+      kind: 'offsite',
+      slug: 'ext-app',
+      externalUrl: 'https://ext.example/a',
+    });
+    expect(selectChromeRecentApps([out], { canOpenPage: true, limit: 6 })).toEqual([]);
+  });
+
+  it('keeps the entry id — the de-dup key must not churn', () => {
+    // `id` is the store's de-dup key AND the rail's ordering handle. Rewriting it
+    // could split one app into two entries or collide with another.
+    const [out] = reconcileRecentApps([legacy({ id: 'ab_gm' })], [onsiteCard()]);
+    expect(out.id).toBe('ab_gm');
+  });
+
+  it('preserves a recorded iconUrl the card cannot supply', () => {
+    const [out] = reconcileRecentApps(
+      [legacy({ iconUrl: 'https://cdn.example/old.png' })],
+      [onsiteCard({ iconUrl: null })]
+    );
+    expect(out.iconUrl).toBe('https://cdn.example/old.png');
+  });
+
+  it('is IDEMPOTENT — reconciling a reconciled list changes nothing', () => {
+    const once = reconcileRecentApps([legacy()], [onsiteCard()]);
+    expect(reconcileRecentApps(once, [onsiteCard()])).toEqual(once);
+  });
+
+  it('is a no-op with no cards loaded (the query has not resolved yet)', () => {
+    const entries = [legacy()];
+    expect(reconcileRecentApps(entries, [])).toBe(entries);
+  });
+
+  it('preserves order and length across a mixed list', () => {
+    const entries = [legacy({ id: 'ab_pv', blockId: 'prompt-vault' }), legacy()];
+    const out = reconcileRecentApps(entries, [onsiteCard()]);
+    expect(out.map((e) => e.id)).toEqual(['ab_pv', 'ab_gm']);
   });
 });

--- a/src/components/Apps/recentAppsRail.ts
+++ b/src/components/Apps/recentAppsRail.ts
@@ -189,6 +189,105 @@ export function selectChromeRecentApps(
     .slice(0, opts.limit);
 }
 
+/**
+ * The card fields reconciliation reads. A `Pick` rather than the whole
+ * `ListingCard` so a caller can pass anything listing-shaped and so this stays
+ * honest about what it consumes.
+ */
+export type RecentReconcileCard = Pick<
+  ListingCard,
+  'id' | 'slug' | 'name' | 'iconUrl' | 'kindData'
+>;
+
+/**
+ * Repair persisted recents from the listings the page has ALREADY loaded.
+ *
+ * 🔴 THE DEFECT THIS FIXES. `resolveRecentApp` reads `hasPage: entry.hasPage ===
+ * true`, so an entry that never RECORDED the field is `false` — and a `false`
+ * routes to `/apps/store-preview/<slug>` under an EYE ("read about it") for an
+ * app the viewer has been RUNNING. The entries that hit it are the ones
+ * `MarketplaceBody.recordRecent` wrote — `{id, blockId, name, iconUrl}`, with no
+ * `kind`, no `hasPage` and no `slug`. A real viewer's localStorage was read while
+ * diagnosing this: 7 of 8 entries were exactly that shape, so the eye was the
+ * rail's DEFAULT rendering, not an edge case.
+ *
+ * Nothing heals it on its own. `handleOpenRecent` re-persists whatever
+ * `resolveRecentApp` produced, so the resolved `false` is written straight back —
+ * clicking the tile CANNOT fix it. Only a real visit to `/apps/run/<slug>` ever
+ * writes `hasPage: true`.
+ *
+ * So: the store page already holds the server's answer for every card on screen.
+ * Match the persisted entries against it and take the card's values.
+ *
+ * 🔴 MATCH KEYS — why THREE, and why none of them is `entry.slug` alone. A legacy
+ * entry HAS NO `slug`, so a slug-keyed join matches zero rows, upgrades nothing,
+ * and ships a change that passes every gate while altering nothing on screen.
+ * Each key below is looked up in its OWN namespace, in this order:
+ *   1. `entry.id` → `card.kindData.appBlockId`. The on-site de-dup contract: BOTH
+ *      on-site writers key `id` on the AppBlock id (see `toRecentAppFromListing`).
+ *   2. `entry.id` → `card.id`. The off-site contract — an off-site listing has no
+ *      AppBlock, so the AppListing id is its only key.
+ *   3. `entry.blockId` (else `entry.slug`) → `card.slug`. For an on-site app the
+ *      listing slug IS the AppBlock `block_id` (`app-listing-mapper.ts` →
+ *      `slug: ab.blockId`), which is what makes the legacy `{id, blockId}` shape
+ *      joinable at all.
+ *
+ * 🔴 UPGRADE, NEVER DROP. An entry that matches nothing is returned UNTOUCHED.
+ * A recents entry is not evidence a listing is missing — it is far more likely on
+ * page 2, behind a `kind`/`category` filter, or simply not in the loaded set.
+ * Filtering on a failed match would silently empty a returning viewer's rail,
+ * which is the exact failure the resolve-don't-drop design exists to avoid.
+ *
+ * 🔴 A CORRECTION, IN BOTH DIRECTIONS — not a promotion. The card is the server's
+ * current truth, so an app that has LOST its page loses the play glyph too. A
+ * fill-in-the-blanks variant (`entry.hasPage ?? card.hasPage`) would leave the
+ * rail offering `/apps/run/<slug>` — a guaranteed 404 — under an "Open" label.
+ * That is why the card's values WIN rather than merely filling gaps, and why a
+ * stale `blockId` cannot survive on an entry the card says is off-site (it would
+ * point the app-chrome menu at the WRONG app).
+ *
+ * Built by delegating to `toRecentAppFromListing`, so a reconciled entry is
+ * byte-identical to what a fresh open of that card would persist — one rule, one
+ * place. Two properties follow and are pinned by tests: `id` is preserved (it is
+ * the de-dup key and the rail's ordering handle, so reconciliation must not churn
+ * it), and the function is IDEMPOTENT — reconciling a reconciled list is a no-op.
+ */
+export function reconcileRecentApps(
+  entries: RecentApp[],
+  cards: RecentReconcileCard[]
+): RecentApp[] {
+  if (entries.length === 0 || cards.length === 0) return entries;
+
+  const byAppBlockId = new Map<string, RecentReconcileCard>();
+  const byListingId = new Map<string, RecentReconcileCard>();
+  const bySlug = new Map<string, RecentReconcileCard>();
+  for (const card of cards) {
+    // First card wins per key — `listAvailable` is already de-duplicated, and a
+    // stable rule beats a last-write-wins race across pages.
+    if (!byListingId.has(card.id)) byListingId.set(card.id, card);
+    if (card.slug && !bySlug.has(card.slug)) bySlug.set(card.slug, card);
+    if (card.kindData.kind === 'onsite') {
+      const appBlockId = card.kindData.appBlockId;
+      if (appBlockId && !byAppBlockId.has(appBlockId)) byAppBlockId.set(appBlockId, card);
+    }
+  }
+
+  return entries.map((entry) => {
+    const handle = entry.blockId ?? entry.slug;
+    const card =
+      byAppBlockId.get(entry.id) ??
+      byListingId.get(entry.id) ??
+      (handle ? bySlug.get(handle) : undefined);
+    if (!card) return entry;
+
+    const upgraded: RecentApp = { ...toRecentAppFromListing(card), id: entry.id };
+    // The card's `iconUrl` is nullable; a previously-recorded icon is better than
+    // none, so it is the one field the entry can still contribute.
+    if (!upgraded.iconUrl && entry.iconUrl) upgraded.iconUrl = entry.iconUrl;
+    return upgraded;
+  });
+}
+
 export type RecentRailTarget = {
   href: string;
   /** True → render as a new-tab anchor (rel="noopener noreferrer"). */


### PR DESCRIPTION
## The problem

The `/apps` "Recently opened" rail derives each tile's icon from where the tile navigates — play = `/apps/run/<id>`, external-link = off-site, eye = the detail page. For most viewers that eye was **a stale-data artifact, not a signal**.

`resolveRecentApp` reads `hasPage: entry.hasPage === true`, so an entry that never *recorded* the field becomes `false` and routes to `/apps/store-preview/<slug>` under an eye. The entries that hit this are the ones the legacy `MarketplaceBody.recordRecent` wrote — `{id, blockId, name, iconUrl}`, with no `kind`, no `hasPage` and **no `slug`**.

Reading a real viewer's `localStorage.recentlyOpenedApps` while diagnosing this found **7 of 8 entries in exactly that shape** — so the eye was the rail's *default* rendering, not an edge case.

And nothing healed it. `handleOpenRecent` re-persists whatever `resolveRecentApp` produced, so the resolved `false` was written straight back — **clicking a tile could never fix it**. Only a real visit to `/apps/run/<slug>` ever wrote `hasPage: true`.

## The fix

The store page already holds the server's answer for every card on screen. `reconcileRecentApps` matches the persisted entries against the loaded listings and takes the card's `kind`/`hasPage`/`slug`.

**Three join keys — and none of them is the entry's `slug`.** A legacy entry has no `slug` at all, so a slug-keyed join matches zero rows, upgrades nothing, and would ship a change that passes every gate while altering nothing on screen:

1. `entry.id` → `card.kindData.appBlockId` — the on-site de-dup contract (both on-site writers key `id` on the AppBlock id). Also the only key that survives a `block_id` rename.
2. `entry.id` → `card.id` — the off-site contract.
3. `entry.blockId` → `card.slug` — for an on-site app the listing slug **is** the AppBlock `block_id` (`app-listing-mapper.ts` → `slug: ab.blockId`). This is the key that makes the legacy shape joinable at all.

Two properties the tests pin:

- **Upgrade, never drop.** An entry matching nothing is returned untouched. A recents entry is far more likely on page 2 or behind a filter than genuinely gone, and filtering would silently empty a returning viewer's rail.
- **A correction in both directions.** An app that has *lost* its page also loses the play glyph — a fill-in-the-blanks variant (`entry.hasPage ?? card.hasPage`) would leave the rail offering a guaranteed 404 under an "Open" label.

`getRecentRailAction`'s derivation is **deliberately untouched**. The icon, the accessible label and the href all flow from it, and keeping them coupled is what prevents a play glyph on a control named "View details for X". This fixes the *data* and lets the existing derivation produce the right icon on its own. The `"🔴 NEVER disagrees with getRecentRailTarget"` invariant still passes.

## Before / after, on a real legacy-shaped seed

Entry `{id, blockId: 'gen-matrix', name: 'Gen Matrix'}` — no `kind`, no `hasPage`, no `slug` — with that app on a loaded page (`hasPage: true`):

| | icon | href | accessible name |
|---|---|---|---|
| before | `eye` | `/apps/store-preview/gen-matrix` | "View details for Gen Matrix" |
| after | `player-play` | `/apps/run/gen-matrix` | "Open Gen Matrix" |

An entry whose app is **not** on a loaded page keeps the before row exactly — asserted in the same test file.

## Accepted trade-off: a second post-paint update

The rail already hydrates one frame late (localStorage is client-only, seeded empty for SSR parity). Reconciliation adds an update when the query resolves, so a glyph can flip eye→play after paint and the `aria-label` change may be re-announced by some assistive tech. Accepted, on three grounds:

- **No layout shift** — fixed `ActionIcon size="md"`, both glyphs 16px, so it is a repaint, not a reflow.
- **Never misleading at any instant** — icon, label and href come from one `getRecentRailAction` call, so the pre-flip state is a correct "view details" control and the post-flip state a correct "open" one. A viewer can never see a play glyph on a control that navigates to the detail page.
- Withholding the rail until the query settles was rejected: it delays the "jump back in" shortcut behind a round-trip and hides the rail entirely when the query **errors**.

No change to the SSR seeding pattern, the CSS-module-import ban in `RecentlyOpenedApps.tsx`, or its `type`/`renderRoot` block.

## Verification

**The regression test seeds RAW legacy JSON** through `localStorage.setItem` rather than building a fixture from the current `RecentApp` shape — a fully-populated fixture would encode the same assumption the bug is made of and pass while proving nothing.

Red → green matrix, same command both sides:

- **pre-change source:** `Tests 4 failed (4)` — first failure `expected '/apps/store-preview/gen-matrix' to be '/apps/run/gen-matrix'`
- **post-change:** `Tests 4 passed (4)`

Counts (all run locally):

| suite | result |
|---|---|
| unit — `src/components/Apps/__tests__/` + the 4 repo lint-rule suites | **909 passed** (46 files) |
| browser — 8 suites incl. the new one, `AppListingsMarketplaceBody`, `RecentlyOpenedApps`, `recents-helper`, `MarketplaceBody`, `AppBlockChrome` | **91 passed** |
| Typecheck (`pnpm typecheck`) | clean |
| ESLint + Prettier on all 4 changed/added files | clean |

**Mutation results** — 9 mutations of `reconcileRecentApps`, each killed by a test naming that specific guard. The harness was validated in both directions first (unmutated → 58 passed; reconcile neutered → 7 killed), and the source verified byte-identical afterwards.

| mutation | killed by |
|---|---|
| entry values win over card values (`?? fill-only`) | corrects-down; off-site stray-`blockId` |
| `blockId`→`card.slug` join deleted | blockId→slug-when-id-matches-nothing |
| entry side keyed on `slug` only | same |
| `appBlockId` join deleted | stale-recorded-slug |
| unmatched entry rebuilt instead of passed through | never-drops; passed-through-byte-for-byte |
| unmatched entries dropped | those two + order/length |
| entry `id` churned | blockId→slug (id assertion) |
| `iconUrl` preservation removed | preserves-recorded-iconUrl |

Two of these mutations **survived a first sweep** and are the reason the test set grew: the `appBlockId` join was genuinely untested (every fixture's `blockId` already equalled the card `slug`), and the first "unmatched" mutation was vacuous. Both now have dedicated tests.

## CI expectations

Blocking: **event-engine-common pin**, **Typecheck**, **ESLint + Prettier (added files)** — the added file is the new browser test, checked clean locally.

Not blocking: **Unit tests** (`continue-on-error: true`, `.github/workflows/lint.yml:198`), lint on modified files, and the whole `preview / component-tests` project.

On the pre-existing repo-wide component-test failure: `AppBlockChrome.browser.test.tsx` passes **21/21** locally on this base, so #3553 appears to have fixed it. That is a local observation, not a read of a CI run.
