### PR TITLE
fix(app-blocks): bound block_scope_invocations.endpoint so topEndpoints aggregates

### DIFF
--- a/src/components/AppBlocks/AppPermissionsActivityDrawer.browser.test.tsx
+++ b/src/components/AppBlocks/AppPermissionsActivityDrawer.browser.test.tsx
@@ -94,8 +94,10 @@ describe('AppPermissionsActivityDrawer (Part B — per-app permissions & activit
         // badge is the sole node carrying that string (the Detail column would
         // otherwise echo a matching endpoint verbatim).
         scope: 'ai:write:budgeted',
-        endpoint: 'workflow:submit:wf-123',
+        // Bounded endpoint template; the workflow id is per-row `detail`.
+        endpoint: 'workflow:submit',
         statusCode: 200,
+        detail: { action: 'workflow.submit', outcome: 'ok', workflowId: 'wf-123' },
       },
     ];
     m.buzz = [

--- a/src/components/Apps/AppActivityPanel.browser.test.tsx
+++ b/src/components/Apps/AppActivityPanel.browser.test.tsx
@@ -69,6 +69,9 @@ const SCOPE_ITEMS = [
     appSlug: 'tip-app',
     blockInstanceId: 'bki_1',
     scope: 'ai:write:budgeted',
+    // LEGACY row shape — the per-workflow endpoint the writers emitted before it
+    // was bounded to a template. No backfill was run, so rows like this are still
+    // in the table: their Detail cell must keep resolving from the endpoint tail.
     endpoint: 'workflow:submit:wf_9',
     statusCode: 200,
     detail: null, // pre-W13 mutation row → historical scope · endpoint fallback
@@ -98,6 +101,61 @@ const SCOPE_ITEMS = [
     // Non-ModelVersion entity — the view names only ModelVersions, so this must
     // render a safe generic subject, never a crash or an empty "on ".
     detail: { action: 'tip', amount: 250, toUserId: 7, entityType: 'Image', entityId: 42, outcome: 'ok' },
+  },
+  // ── Bounded-endpoint rows (the shape the writers emit today). The endpoint is
+  // the aggregation TEMPLATE, so the Detail column must come off `detail`.
+  {
+    id: '7',
+    createdAt: new Date('2026-07-16T06:00:00Z'),
+    appBlockId: 'apb_1',
+    appName: 'Tip App',
+    appSlug: 'tip-app',
+    blockInstanceId: 'bki_1',
+    scope: 'ai:write:budgeted',
+    endpoint: 'workflow:submit',
+    statusCode: 200,
+    detail: { action: 'workflow.submit', amount: -120, outcome: 'ok', workflowId: 'wf_new' },
+  },
+  {
+    id: '8',
+    createdAt: new Date('2026-07-16T05:00:00Z'),
+    appBlockId: 'apb_1',
+    appName: 'Tip App',
+    appSlug: 'tip-app',
+    blockInstanceId: 'bki_1',
+    scope: 'ai:write:budgeted',
+    // Same TEMPLATE as row 7 — proves two different submits aggregate to one
+    // endpoint value while keeping distinct per-row detail. No id yet on this
+    // one (the old `workflow:submit:pending` case).
+    endpoint: 'workflow:submit',
+    statusCode: 200,
+    detail: { action: 'workflow.submit', amount: -7, outcome: 'ok' },
+  },
+  {
+    id: '9',
+    createdAt: new Date('2026-07-16T04:00:00Z'),
+    appBlockId: 'apb_1',
+    appName: 'Tip App',
+    appSlug: 'tip-app',
+    blockInstanceId: 'bki_1',
+    scope: 'apps:storage',
+    endpoint: 'storage:set',
+    statusCode: 200,
+    detail: { action: 'storage.set', key: 'prefs', outcome: 'ok' },
+  },
+  {
+    id: '10',
+    createdAt: new Date('2026-07-16T03:00:00Z'),
+    appBlockId: 'apb_1',
+    appName: 'Tip App',
+    appSlug: 'tip-app',
+    blockInstanceId: 'bki_1',
+    scope: 'apps:storage',
+    // LEGACY per-key storage endpoint + no detail — historical rows must keep
+    // rendering both the Action label and the key.
+    endpoint: 'storage:delete:legacy_key',
+    statusCode: 200,
+    detail: null,
   },
 ];
 
@@ -163,12 +221,68 @@ describe('AppActivityPanel — W13 action detail', () => {
 
   test('(c) null-detail mutation row falls back to the historical humanise path', async () => {
     renderWithProviders(<AppActivityPanel />);
-    // scope ai:write:budgeted + workflow:submit endpoint → legacy "Generated an image"
-    await expect.element(page.getByText('Generated an image')).toBeInTheDocument();
+    // scope ai:write:budgeted + workflow:submit endpoint → legacy "Generated an image".
+    // `exact` because getByText is substring-matching by default and the rich
+    // workflow rows below render "Generated an image (spent N Buzz)".
+    await expect
+      .element(page.getByText('Generated an image', { exact: true }))
+      .toBeInTheDocument();
   });
 
   test('(d) unknown action code renders a safe generic line', async () => {
     renderWithProviders(<AppActivityPanel />);
     await expect.element(page.getByText('Performed an app action')).toBeInTheDocument();
+  });
+});
+
+/**
+ * Bounded `endpoint` + per-row `detail`. `block_scope_invocations.endpoint` is
+ * the GROUP BY key of the `topEndpoints` rollup, so the writers now emit a
+ * TEMPLATE (`workflow:submit`, `storage:set`, `storage:delete`) instead of
+ * embedding the workflow id / storage key. The Detail column used to parse that
+ * id back OUT of the endpoint string — these tests are the discriminating ones
+ * for that regression: without reading `detail`, every templated row degrades to
+ * "(no workflow id)" / a bare "storage:set", and no server-side unit test can
+ * see it.
+ */
+describe('AppActivityPanel — Detail column off a BOUNDED endpoint', () => {
+  test('templated workflow row renders the workflow id from detail.workflowId', async () => {
+    renderWithProviders(<AppActivityPanel />);
+    // Row 7: endpoint 'workflow:submit' (no id in it) + detail.workflowId.
+    await expect.element(page.getByText('workflow wf_new')).toBeInTheDocument();
+  });
+
+  test('two submits share ONE endpoint value while keeping distinct detail (aggregation + per-row payload)', async () => {
+    renderWithProviders(<AppActivityPanel />);
+    // Rows 7 and 8 both carry endpoint 'workflow:submit' — that constant must
+    // never leak into the Detail cell, and each row keeps its own Action
+    // sentence off its own detail.
+    await expect
+      .element(page.getByText('Generated an image (spent 120 Buzz)'))
+      .toBeInTheDocument();
+    await expect
+      .element(page.getByText('Generated an image (spent 7 Buzz)'))
+      .toBeInTheDocument();
+    expect(page.getByText('workflow:submit', { exact: true }).elements()).toHaveLength(0);
+  });
+
+  test('templated workflow row with NO id renders the explicit "(no workflow id)"', async () => {
+    renderWithProviders(<AppActivityPanel />);
+    await expect.element(page.getByText('(no workflow id)')).toBeInTheDocument();
+  });
+
+  test('templated storage row renders the key from detail.key', async () => {
+    renderWithProviders(<AppActivityPanel />);
+    // Row 9: endpoint 'storage:set' + detail.key — the bare template must not show.
+    await expect.element(page.getByText('key "prefs"')).toBeInTheDocument();
+    expect(page.getByText('storage:set', { exact: true }).elements()).toHaveLength(0);
+  });
+
+  test('LEGACY per-id rows (no backfill) still resolve from the endpoint tail', async () => {
+    renderWithProviders(<AppActivityPanel />);
+    // Row 4: 'workflow:submit:wf_9', detail null. Row 10: 'storage:delete:legacy_key'.
+    await expect.element(page.getByText('workflow wf_9')).toBeInTheDocument();
+    await expect.element(page.getByText('key "legacy_key"')).toBeInTheDocument();
+    await expect.element(page.getByText('Deleted app-local storage')).toBeInTheDocument();
   });
 });

--- a/src/components/Apps/AppActivityPanel.tsx
+++ b/src/components/Apps/AppActivityPanel.tsx
@@ -98,8 +98,11 @@ export function humaniseScopeInvocation(scope: string, endpoint?: string): strin
   // truth for what the app actually did.
   if (endpoint?.startsWith('workflow:submit')) return 'Generated an image';
   if (endpoint === 'user-settings:write') return 'Saved your block settings';
-  if (endpoint?.startsWith('storage:set:')) return 'Wrote app-local storage';
-  if (endpoint?.startsWith('storage:delete:')) return 'Deleted app-local storage';
+  // Prefix (not `===`) so BOTH the bounded template written today
+  // (`storage:set`) and the historical per-key value (`storage:set:<key>`)
+  // resolve to the same label.
+  if (endpoint?.startsWith('storage:set')) return 'Wrote app-local storage';
+  if (endpoint?.startsWith('storage:delete')) return 'Deleted app-local storage';
   // Passive READS get a friendly label from the scope→label map (W13 — no
   // write-side change for reads). Fall through to the local write labels, then
   // the raw scope string for anything genuinely unknown.
@@ -107,17 +110,39 @@ export function humaniseScopeInvocation(scope: string, endpoint?: string): strin
 }
 
 /**
- * Strip synthetic prefixes off endpoints so the Detail column shows the
- * meaningful tail (workflowId, storage key, etc.). REST endpoints pass
- * through unchanged.
+ * Render the Detail column for a scope-invocation row: the meaningful per-row
+ * ref (workflowId, storage key, …). REST endpoints pass through unchanged.
+ *
+ * 🔴 The per-row id comes from `detail`, NOT from the endpoint string. The
+ * writers now emit a BOUNDED endpoint template (`workflow:submit`,
+ * `storage:set`, `storage:delete`) because `endpoint` is the GROUP BY key of the
+ * `topEndpoints` rollup — a per-operation id there made it unbounded and every
+ * bucket count 1. This column was doing double duty as aggregation key AND UI
+ * payload; `detail` is the column documented for per-row ids, so that is where
+ * the id is read from.
+ *
+ * The legacy endpoint tail is still parsed as a FALLBACK: no data migration was
+ * run, so historical rows keep `workflow:submit:<id>` / `storage:set:<key>` (and
+ * a pre-W13 workflow row has no `detail` at all). Dropping the parse would have
+ * silently degraded every one of those rows to "(no workflow id)".
  */
-export function humaniseScopeEndpoint(endpoint: string): string {
-  const workflow = endpoint.match(/^workflow:submit:(.+)$/);
-  if (workflow) {
-    return workflow[1] === 'pending' ? '(no workflow id)' : `workflow ${workflow[1]}`;
+export function humaniseScopeEndpoint(
+  endpoint: string,
+  detail?: BlockActionDetail | null
+): string {
+  if (endpoint.startsWith('workflow:submit')) {
+    // Legacy tail (`workflow:submit:<id>`); 'pending' was the historical
+    // stand-in for "no id yet" and is not a real workflow id.
+    const legacy = endpoint.match(/^workflow:submit:(.+)$/);
+    const legacyId = legacy && legacy[1] !== 'pending' ? legacy[1] : undefined;
+    const workflowId = detail?.workflowId ?? legacyId;
+    return workflowId ? `workflow ${workflowId}` : '(no workflow id)';
   }
-  const storage = endpoint.match(/^storage:(set|delete):(.+)$/);
-  if (storage) return `key "${storage[2]}"`;
+  if (endpoint.startsWith('storage:set') || endpoint.startsWith('storage:delete')) {
+    const legacy = endpoint.match(/^storage:(?:set|delete):(.+)$/);
+    const key = detail?.key ?? legacy?.[1];
+    return key ? `key "${key}"` : endpoint;
+  }
   if (endpoint === 'user-settings:write') return '';
   return endpoint;
 }
@@ -376,8 +401,10 @@ export function AppActivityPanel({
                   >
                     {/* The Action cell carries the human sentence when a rich
                         detail is present; the Detail cell always shows the raw
-                        technical ref (workflow id / storage key / endpoint). */}
-                    {humaniseScopeEndpoint(item.endpoint)}
+                        technical ref (workflow id / storage key / endpoint) —
+                        read off `detail`, since the endpoint is now a bounded
+                        aggregation template. */}
+                    {humaniseScopeEndpoint(item.endpoint, item.detail)}
                   </Text>
                 )}
               </Table.Td>

--- a/src/server/routers/__tests__/apps.router.storage.test.ts
+++ b/src/server/routers/__tests__/apps.router.storage.test.ts
@@ -424,8 +424,33 @@ describe('apps.storage.set', () => {
     await vi.waitFor(() => expect(mockRecordScopeInvocation).toHaveBeenCalled());
     expect(mockRecordScopeInvocation.mock.calls[0][0]).toMatchObject({
       scope: 'apps:storage',
+      // BOUNDED aggregation key — the key must NOT be interpolated into it.
+      endpoint: 'storage:set',
       detail: { action: 'storage.set', key: 'lastPrompt', outcome: 'ok' },
     });
+  });
+
+  // 🔴 Cardinality: `block_scope_invocations.endpoint` is the GROUP BY key of
+  // the `topEndpoints` rollup, so a per-key endpoint made it unbounded (every
+  // bucket count 1). Two writes to DIFFERENT keys must collapse to one endpoint
+  // value; the key survives in `detail`, which is what the UI reads.
+  it('two different storage keys AGGREGATE to one endpoint value, keys kept in detail', async () => {
+    for (const key of ['alpha', 'beta']) {
+      mockVerifyBlockToken.mockResolvedValueOnce(validClaims());
+      mockPool.query
+        .mockResolvedValueOnce({ rows: [{ used_bytes: '0', row_count: '0' }], rowCount: 1 })
+        .mockResolvedValueOnce({ rows: [], rowCount: 0 });
+      const caller = appsRouter.createCaller(fakeCtx() as never);
+      await caller.storage.set({ blockToken: 't', key, value: 'v' });
+    }
+    await vi.waitFor(() =>
+      expect(mockRecordScopeInvocation.mock.calls.length).toBeGreaterThanOrEqual(2)
+    );
+    const calls = mockRecordScopeInvocation.mock.calls.map(
+      (c) => c[0] as { endpoint: string; detail?: { key?: string } }
+    );
+    expect(new Set(calls.map((c) => c.endpoint))).toEqual(new Set(['storage:set']));
+    expect(calls.map((c) => c.detail?.key)).toEqual(['alpha', 'beta']);
   });
 
   it('uses the net delta from an existing row to size the quota check', async () => {
@@ -481,6 +506,8 @@ describe('apps.storage.delete', () => {
     await vi.waitFor(() => expect(mockRecordScopeInvocation).toHaveBeenCalled());
     expect(mockRecordScopeInvocation.mock.calls[0][0]).toMatchObject({
       scope: 'apps:storage',
+      // BOUNDED aggregation key — the key must NOT be interpolated into it.
+      endpoint: 'storage:delete',
       detail: { action: 'storage.delete', key: 'k', outcome: 'ok' },
     });
   });

--- a/src/server/routers/__tests__/blocks.router.workflow.test.ts
+++ b/src/server/routers/__tests__/blocks.router.workflow.test.ts
@@ -1098,7 +1098,15 @@ describe('blocks.submitWorkflow', () => {
     await vi.waitFor(() => expect(vi.mocked(recordScopeInvocation)).toHaveBeenCalled());
     expect(vi.mocked(recordScopeInvocation).mock.calls[0][0]).toMatchObject({
       scope: 'ai:write:budgeted',
-      detail: { action: 'workflow.submit', amount: -25, outcome: 'ok' },
+      // BOUNDED endpoint — the workflow id must NOT be interpolated into the
+      // `topEndpoints` GROUP BY key; it rides in `detail.workflowId` instead.
+      endpoint: 'workflow:submit',
+      detail: {
+        action: 'workflow.submit',
+        amount: -25,
+        outcome: 'ok',
+        workflowId: 'wf_real',
+      },
     });
   });
 
@@ -5756,11 +5764,72 @@ describe('customComfy bridge (submit/estimate/settle)', () => {
         appBlockId: 'apb_test',
         blockInstanceId: 'bki_test',
         scope: 'ai:write:budgeted',
-        endpoint: 'workflow:submit:wf_cc_1',
+        // BOUNDED template — the workflow id must NOT be in the aggregation key.
+        endpoint: 'workflow:submit',
         statusCode: 200,
-        detail: { action: 'workflow.submit', outcome: 'ok' },
+        // …it rides in `detail` instead, so the Activity panel keeps its Detail cell.
+        detail: { action: 'workflow.submit', outcome: 'ok', workflowId: 'wf_cc_1' },
         dev: false, // non-dev page token
       });
+    });
+
+    // 🔴 Cardinality: `block_scope_invocations.endpoint` is the GROUP BY key of
+    // the `topEndpoints` rollup. It used to be `workflow:submit:<workflowId>`,
+    // so every row was its own bucket and the rollup was pure noise (measured:
+    // all five "top endpoints" for two production apps were count-1 workflow
+    // ids). Two DIFFERENT submits must now collapse to ONE endpoint value while
+    // keeping their distinct ids in `detail`.
+    it('two different workflows AGGREGATE to one endpoint value, ids kept in detail', async () => {
+      vi.mocked(recordScopeInvocation).mockClear();
+      mockVerifyBlockToken.mockResolvedValue(ccPageClaims());
+
+      happyCcResources();
+      mockSubmitWorkflow.mockResolvedValue({
+        id: 'wf_aaa',
+        status: 'processing',
+        steps: [{ $type: 'customComfy', output: { blobs: [] } }],
+        cost: { total: 0 },
+      });
+      await caller().submitWorkflow({ blockToken: 'tok', body: ccBody() });
+
+      happyCcResources();
+      mockSubmitWorkflow.mockResolvedValue({
+        id: 'wf_bbb',
+        status: 'processing',
+        steps: [{ $type: 'customComfy', output: { blobs: [] } }],
+        cost: { total: 0 },
+      });
+      await caller().submitWorkflow({ blockToken: 'tok', body: ccBody() });
+
+      await vi.waitFor(() =>
+        expect(vi.mocked(recordScopeInvocation).mock.calls.length).toBeGreaterThanOrEqual(2)
+      );
+      const calls = vi.mocked(recordScopeInvocation).mock.calls.map((c) => c[0]);
+      // ONE bucket…
+      expect(new Set(calls.map((c) => c.endpoint))).toEqual(new Set(['workflow:submit']));
+      // …two distinct per-row payloads.
+      expect(calls.map((c) => (c.detail as { workflowId?: string } | null)?.workflowId)).toEqual([
+        'wf_aaa',
+        'wf_bbb',
+      ]);
+    });
+
+    it('a submit with NO workflow id still writes the SAME endpoint (no `:pending` variant)', async () => {
+      vi.mocked(recordScopeInvocation).mockClear();
+      mockVerifyBlockToken.mockResolvedValue(ccPageClaims());
+      happyCcResources();
+      mockSubmitWorkflow.mockResolvedValue({
+        id: '',
+        status: 'processing',
+        steps: [{ $type: 'customComfy', output: { blobs: [] } }],
+        cost: { total: 0 },
+      });
+      await caller().submitWorkflow({ blockToken: 'tok', body: ccBody() });
+      await vi.waitFor(() => expect(vi.mocked(recordScopeInvocation)).toHaveBeenCalled());
+      const call = vi.mocked(recordScopeInvocation).mock.calls[0][0];
+      expect(call.endpoint).toBe('workflow:submit');
+      // No id to carry → the key is OMITTED rather than written as 'pending'.
+      expect((call.detail as { workflowId?: string } | null)?.workflowId).toBeUndefined();
     });
 
     it('routes the dev/ephemeral synthetic-app case via dev:true (service writes appBlockId:null + synthetic_app_id)', async () => {
@@ -6544,7 +6613,12 @@ describe("step-type registry bridge (kind: 'step')", () => {
           userId: 42,
           appBlockId: 'apb_test',
           scope: 'ai:write:budgeted',
-          endpoint: 'workflow:submit:wf_step_1',
+          // BOUNDED template; the id moves to `detail.workflowId`.
+          endpoint: 'workflow:submit',
+          detail: expect.objectContaining({
+            action: 'workflow.submit',
+            workflowId: 'wf_step_1',
+          }),
         })
       );
       expect(mockRecordSpendAttribution).toHaveBeenCalledWith(

--- a/src/server/routers/apps.router.ts
+++ b/src/server/routers/apps.router.ts
@@ -422,7 +422,11 @@ export const appsStorageRouter = router({
           appBlockId,
           blockInstanceId,
           scope: 'apps:storage',
-          endpoint: `storage:set:${input.key}`,
+          // Templated, NOT `storage:set:<key>` — `endpoint` is the GROUP BY key
+          // of the `topEndpoints` rollup, so a per-key value makes the column
+          // unbounded and every bucket count 1. The key is already carried as
+          // the per-row payload in `detail` below, so nothing is lost.
+          endpoint: 'storage:set',
           statusCode: 200,
           // W13 richer detail — structured ref for the render-time sentence.
           detail: { action: 'storage.set', key: input.key, outcome: 'ok' },
@@ -486,7 +490,9 @@ export const appsStorageRouter = router({
                 appBlockId,
                 blockInstanceId,
                 scope: 'apps:storage',
-                endpoint: `storage:delete:${input.key}`,
+                // Templated, NOT `storage:delete:<key>` — bounded aggregation
+                // key; the key itself rides in `detail` below (see set above).
+                endpoint: 'storage:delete',
                 statusCode: 200,
                 // W13 richer detail — structured ref for the render-time sentence.
                 detail: { action: 'storage.delete', key: input.key, outcome: 'ok' },

--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -4438,6 +4438,13 @@ export const blocksRouter = router({
       // workflow:submit is a synthetic endpoint string (this path is
       // tRPC, not REST) — the UI's Activity panel humanises it via the
       // 'ai:write:budgeted' scope to "Generated an image".
+      //
+      // 🔴 The endpoint is a TEMPLATE, never `workflow:submit:<workflowId>`.
+      // `endpoint` is the GROUP BY key of the `topEndpoints` rollup
+      // (app-analytics.service), so a per-submit id makes the column unbounded
+      // and every bucket count 1 — the rollup becomes pure noise. Same
+      // cardinality reasoning as `boundAppBlockIdLabel`. The workflow id is the
+      // per-ROW payload and goes in `detail.workflowId` instead.
       void (async () => {
         const { recordScopeInvocation } = await import(
           '~/server/services/blocks/user-app-surface.service'
@@ -4447,17 +4454,20 @@ export const blocksRouter = router({
           appBlockId: claims.appBlockId,
           blockInstanceId: claims.blockInstanceId,
           scope: 'ai:write:budgeted',
-          endpoint: `workflow:submit:${snapshot.workflowId || 'pending'}`,
+          endpoint: 'workflow:submit',
           // Snapshot status is 'pending' / 'failed' / etc — map to an HTTP-
           // ish code so the existing UI badge colors are coherent.
           statusCode: snapshot.status === 'failed' ? 500 : 200,
           // W13 richer detail — the buzz SPEND (negative) + terminal outcome so
           // the activity row reads "Generated an image (spent N Buzz)". `cost`
-          // is the reserved/charged budget for this submit.
+          // is the reserved/charged budget for this submit. `workflowId` is the
+          // per-row id the Activity panel's Detail column renders (it used to be
+          // parsed back out of the endpoint string).
           detail: {
             action: 'workflow.submit',
             amount: typeof cost === 'number' ? -Math.abs(cost) : undefined,
             outcome: snapshot.status === 'failed' ? 'failed' : 'ok',
+            ...(snapshot.workflowId ? { workflowId: snapshot.workflowId } : {}),
           },
           // Phase 2 — App Dev Tunnel: a PRE-APPROVAL dev-tunnel spend carries a
           // synthetic, non-FK appBlockId (`ephemeral-<slug>`). This is the durable
@@ -6326,12 +6336,16 @@ async function submitCustomComfyWorkflow(opts: {
         appBlockId: claims.appBlockId,
         blockInstanceId: claims.blockInstanceId,
         scope: 'ai:write:budgeted',
-        endpoint: `workflow:submit:${snapshot.workflowId || 'pending'}`,
+        // Templated, NOT `workflow:submit:<workflowId>` — `endpoint` is the
+        // topEndpoints GROUP BY key and must stay bounded (see the txt2img call
+        // site's note). The id moves to `detail.workflowId`.
+        endpoint: 'workflow:submit',
         statusCode: snapshot.status === 'failed' ? 500 : 200,
         detail: {
           action: 'workflow.submit',
           amount: typeof invocationCost === 'number' ? -Math.abs(invocationCost) : undefined,
           outcome: snapshot.status === 'failed' ? 'failed' : 'ok',
+          ...(snapshot.workflowId ? { workflowId: snapshot.workflowId } : {}),
         },
         // Dev token → route a synthetic non-FK appBlockId to the nullable-appBlockId
         // + synthetic_app_id path so the pre-approval audit row persists.
@@ -7137,11 +7151,16 @@ async function submitStepWorkflow(opts: {
         appBlockId: claims.appBlockId,
         blockInstanceId: claims.blockInstanceId,
         scope: 'ai:write:budgeted',
-        endpoint: `workflow:submit:${snapshot.workflowId || 'pending'}`,
+        // Templated, NOT `workflow:submit:<workflowId>` — `endpoint` is the
+        // topEndpoints GROUP BY key and must stay bounded (see the txt2img call
+        // site's note). The id moves to `detail.workflowId`.
+        endpoint: 'workflow:submit',
         statusCode: snapshot.status === 'failed' ? 500 : 200,
         // 🔴 THE TWO STEP DIMENSIONS. Everything else on this row is identical
-        // to what the txt2img path writes — same `scope`, same
-        // `workflow:submit:<id>` endpoint shape — so WITHOUT these a step submit
+        // to what the txt2img path writes — same `scope`, and now the same
+        // BOUNDED `workflow:submit` endpoint (this PR templated it; the id moved
+        // to `detail.workflowId`, so the endpoint discriminates even less than
+        // it used to) — so WITHOUT these a step submit
         // and a txt2img submit are indistinguishable in `block_scope_invocations`,
         // and two different step types are indistinguishable from each other.
         // That is the gap: per-(user, app, capability) usage was not answerable
@@ -7170,6 +7189,10 @@ async function submitStepWorkflow(opts: {
           // entry that makes its model its variant this IS the model; for
           // `convert-image` it is always `'default'`.
           variant,
+          // The per-ROW workflow id, moved here from the endpoint string by this
+          // PR (see the `endpoint` note above). Additive alongside the two step
+          // dimensions — same nullable JSON column, no schema change.
+          ...(snapshot.workflowId ? { workflowId: snapshot.workflowId } : {}),
         },
         dev: claims.dev === true,
       });

--- a/src/server/services/blocks/__tests__/record-scope-invocation-detail.test.ts
+++ b/src/server/services/blocks/__tests__/record-scope-invocation-detail.test.ts
@@ -44,6 +44,29 @@ describe('recordScopeInvocation — structured detail', () => {
     expect(data.detail).toEqual(detail);
   });
 
+  // The endpoint is now a bounded TEMPLATE (`workflow:submit`), so the workflow
+  // id lives in `detail` — it must survive the write verbatim or the Activity
+  // panel's Detail column has nothing to render.
+  it('round-trips detail.workflowId (the id the bounded endpoint no longer carries)', async () => {
+    mockDbWrite.blockScopeInvocation.create.mockResolvedValueOnce({});
+    const detail: BlockActionDetail = {
+      action: 'workflow.submit',
+      amount: -25,
+      outcome: 'ok',
+      workflowId: 'wf_1',
+    };
+    await recordScopeInvocation({
+      ...BASE,
+      scope: 'ai:write:budgeted',
+      endpoint: 'workflow:submit',
+      detail,
+    });
+    const data = mockDbWrite.blockScopeInvocation.create.mock.calls[0][0].data;
+    expect(data.endpoint).toBe('workflow:submit');
+    expect(data.detail).toEqual(detail);
+    expect(data.detail.workflowId).toBe('wf_1');
+  });
+
   it('omits detail (plain row) when none is passed', async () => {
     mockDbWrite.blockScopeInvocation.create.mockResolvedValueOnce({});
     await recordScopeInvocation({ ...BASE });
@@ -70,7 +93,7 @@ describe('recordScopeInvocation — structured detail', () => {
       ...BASE,
       appBlockId: 'ephemeral-my-app',
       scope: 'ai:write:budgeted',
-      endpoint: 'workflow:submit:wf_1',
+      endpoint: 'workflow:submit',
       dev: true,
       detail,
     });

--- a/src/server/services/blocks/__tests__/record-scope-invocation-synthetic.test.ts
+++ b/src/server/services/blocks/__tests__/record-scope-invocation-synthetic.test.ts
@@ -31,7 +31,7 @@ const BASE = {
   userId: 99,
   blockInstanceId: 'page_ephemeral-my-app',
   scope: 'ai:write:budgeted',
-  endpoint: 'workflow:submit:wf_1',
+  endpoint: 'workflow:submit',
   statusCode: 200,
 };
 

--- a/src/shared/constants/block-action-detail.ts
+++ b/src/shared/constants/block-action-detail.ts
@@ -50,6 +50,18 @@ export type BlockActionDetail = {
   entityType?: string;
   /** Storage key (already scoped to the user's own namespace). */
   key?: string;
+  /**
+   * Orchestrator workflow id for a `workflow.submit`. Lives HERE, not in the
+   * `endpoint` column: `endpoint` is an AGGREGATION key (the `topEndpoints`
+   * rollup groups on it), so embedding a per-submit id there makes the column
+   * unbounded and every rollup bucket count 1 — the same cardinality reasoning
+   * `boundAppBlockIdLabel` applies to the prom `app_block_id` label. `detail` is
+   * the per-row payload ("stores IDS, not display names"), so the Activity
+   * panel's Detail column reads the id from here instead of parsing it back out
+   * of the endpoint string. Absent when the submit had no id yet (was
+   * `workflow:submit:pending`).
+   */
+  workflowId?: string;
   /** Terminal outcome of the action. */
   outcome?: 'ok' | 'failed';
   /**


### PR DESCRIPTION
## The defect

`block_scope_invocations.endpoint` is the **GROUP BY key** of the `topEndpoints`
rollup:

```ts
// src/server/services/blocks/app-analytics.service.ts:265
dbRead.blockScopeInvocation.groupBy({
  by: ['endpoint'],
  where: { appBlockId: idIn, invokedAt: rangeFilter },
  _count: true,
  orderBy: { _count: { endpoint: 'desc' } },
  take: 5,
}),
```

…but five call sites interpolated a **per-operation id** into it, so every row
became its own bucket and the top-5 became a list of five arbitrary rows.

| Site | Wrote |
|---|---|
| `src/server/routers/blocks.router.ts:4486` (txt2img) | `` `workflow:submit:${snapshot.workflowId \|\| 'pending'}` `` |
| `src/server/routers/blocks.router.ts:6369` (customComfy) | same |
| `src/server/routers/blocks.router.ts:7118` (step) | same |
| `src/server/routers/apps.router.ts:425` | `` `storage:set:${input.key}` `` |
| `src/server/routers/apps.router.ts:489` | `` `storage:delete:${input.key}` `` |

### Before / after against real production data

For `model-benchmarking` and `panorama-360`, **all five** "top endpoints" are
count-1 unique workflow ids — the rollup is pure noise:

| before (measured) | count |
|---|---|
| `workflow:submit:<wf id A>` | 1 |
| `workflow:submit:<wf id B>` | 1 |
| `workflow:submit:<wf id C>` | 1 |
| `workflow:submit:<wf id D>` | 1 |
| `workflow:submit:<wf id E>` | 1 |

A well-behaved app (whose endpoints are REST paths, already bounded) aggregates
properly today:

| control (measured) | count |
|---|---|
| `/api/v1/blocks/collections/:id` | 113 |
| `/api/v1/blocks/collections` | 57 |

After this change a generating app produces one `workflow:submit` bucket whose
count is its real submit volume, and a storage-using app produces
`storage:set` / `storage:delete` buckets — i.e. the same shape the control
already has.

## The fix

All five sites now write a **bounded template**: `workflow:submit`,
`storage:set`, `storage:delete`.

**Precedent.** This is exactly the reasoning `boundAppBlockIdLabel`
(`src/server/services/blocks/known-app-blocks.service.ts:80-82`) applies to the
prom `app_block_id` label, with the rationale written out at
`src/server/metrics/app-block-runtime.metrics.ts:332-346` ("prom-client retains
every distinct label set in the Node heap forever"). That reasoning was applied
to the Prometheus labels and never carried across to this Postgres column.

## What the `detail` change preserves

The per-row id moves to the `detail` Json column — the column documented for
exactly this ("Stores IDS, not display names", `schema.full.prisma:3393`). The
two cases are not symmetric:

- **Storage — free.** The key was **already** in `detail`:
  `detail: { action: 'storage.set', key: input.key, outcome: 'ok' }`. Nothing is
  lost; the UI just reads `detail.key`.
- **Workflow — not free.** `detail` carried `{ action, amount, outcome }` and no
  id, so `workflowId?: string` is **added** to `BlockActionDetail` and emitted at
  all three sites (`...(snapshot.workflowId ? { workflowId } : {})` — omitted,
  not written as the old `'pending'` sentinel, when the submit has no id yet).

The id is not the only copy (`block_spend_attribution.workflow_id` is
`String` NOT NULL with `@@unique([workflowId, appBlockId])`,
`schema.full.prisma:3232`/`:3272`) — but that is a DB-level fact the activity
panel cannot reach without a join it does not do, hence the `detail` change.

## The hidden consumer — why templating alone would have regressed the UI

`humaniseScopeEndpoint` (`src/components/Apps/AppActivityPanel.tsx:114`) rendered
the Detail column by **regexing the id back out of the endpoint string**:

```ts
const workflow = endpoint.match(/^workflow:submit:(.+)$/);
if (workflow) return workflow[1] === 'pending' ? '(no workflow id)' : `workflow ${workflow[1]}`;
const storage = endpoint.match(/^storage:(set|delete):(.+)$/);
if (storage) return `key "${storage[2]}"`;
```

The column was doing double duty: aggregation key **and** per-row UI payload.
Templating the endpoint without touching this would have silently degraded every
row to `(no workflow id)` / a bare `storage:set` — and the whole unit suite would
still have been green.

It now takes `detail` and reads `detail.workflowId` / `detail.key`.
`humaniseScopeInvocation`'s `storage:set:` / `storage:delete:` prefix tests also
lose their trailing colon, which the bounded value would otherwise never match.

**Legacy fallback (deliberate deviation).** No backfill is run, so historical
rows still hold `workflow:submit:<id>` / `storage:set:<key>`, and a pre-W13
workflow row has **no `detail` at all**. `humaniseScopeEndpoint` therefore keeps
the endpoint-tail parse as a *fallback* behind `detail` rather than dropping it —
without that, every historical row would render `(no workflow id)`. Two of the
twelve mutations below exist purely to pin that.

## No data migration

Historical rows keep their old values, as agreed. A backfill is *possible*
(`UPDATE … SET endpoint = 'workflow:submit', detail = jsonb_set(detail, '{workflowId}', …)`
derived from the endpoint tail, or from `block_spend_attribution`), and it would
make the rollup honest for existing rows too — but it rewrites an audit table,
so it is deliberately **not** in this PR. Maintainer's call.

## Tests

Updated (old shape pinned, every other assertion untouched):

- `blocks.router.workflow.test.ts` `:5569`, `:6302` → template + `detail.workflowId`
- `record-scope-invocation-{synthetic,detail}.test.ts` fixtures → `workflow:submit`
- `AppPermissionsActivityDrawer.browser.test.tsx:97`, `AppActivityPanel.browser.test.tsx`
- `apps.router.storage.test.ts` set/delete audit assertions gained an `endpoint` pin
- `blocks.router.workflow.test.ts` `submits the workflow when cost <= budget`
  gained an `endpoint` + `workflowId` pin — it is the **only** test that exercises
  the txt2img site (4486) and it previously asserted no endpoint at all, so that
  site had zero coverage

Added:

- two different workflows / two different storage keys **aggregate to one
  endpoint value** while keeping distinct `detail`
- a submit with **no** workflow id writes the *same* endpoint (no `:pending` variant)
  and omits `workflowId`
- `detail.workflowId` round-trips through `recordScopeInvocation`
- browser: the Detail column renders the id/key for **templated** rows (the
  discriminating test for the UI regression) **and** still resolves **legacy**
  rows from the endpoint tail

### Mutation matrix — 12/12 killed

Baselines first (positive controls): unit 360/360 green, browser 17/17 green.

| # | Mutation | Killed by | Counts |
|---|---|---|---|
| A | site 4486 endpoint → `workflow:submit:${id}` | `submits the workflow when cost <= budget` (diff on `endpoint`) | 1 failed / 359 passed |
| B | site 4486 detail: drop `workflowId` | same test (diff on `workflowId`) | 1 failed / 359 passed |
| C | site 6369 endpoint | 3 customComfy audit tests | 3 failed / 357 passed |
| D | site 6369 detail: drop `workflowId` | 2 customComfy audit tests | 2 failed / 358 passed |
| E | site 7118 endpoint | `still writes the durable audit + attribution trail` | 1 failed / 359 passed |
| F | site 7118 detail: drop `workflowId` | same | 1 failed / 359 passed |
| G | `storage:set` endpoint | happy-path audit + the new aggregation test | 2 failed / 358 passed |
| H | `storage:delete` endpoint | `reports deleted: true when the row existed` | 1 failed / 359 passed |
| I | UI: workflow id from endpoint only (pre-fix consumer) | templated-workflow-row tests | 2 failed / 15 passed |
| J | UI: storage key from endpoint only | templated-storage-row test | 1 failed / 16 passed |
| K | UI: workflow id from `detail` only (no legacy fallback) | LEGACY-rows test | 2 failed / 15 passed |
| L | UI: storage key from `detail` only | LEGACY-rows test | 1 failed / 16 passed |

A and B hit the same test and were checked to fail on their **own** assertion
(`endpoint` vs `workflowId` in the diff), not on each other's. Every mutation was
reverted and the three source files' sha256 re-verified against the pre-sweep
baseline afterwards.

## Gate

| Gate | Result |
|---|---|
| `pnpm typecheck` | rc=0, **0** `error TS` |
| `pnpm test:unit:run` | **750** files passed, **10843** passed / **0** failed / **1** skipped, **0** timeout panics |
| component (browser) tests for the two touched panels | **17** passed / **0** failed |
| `pnpm lint` | repo-wide 398 errors / 3580 warnings — pre-existing. On the 10 touched files: **36 problems at `origin/main`, 36 at HEAD**, identical per-rule counts, **no new rule triggered** (measured by linting the same paths at both refs) |
| `prettier --check` | the same 7 of 10 files are already unformatted on `origin/main`; this PR changes none of that (harness validated with a misformatted + a formatted control) |

`event-engine-common` submodule was checked out first — without it `pnpm typecheck`
and several dozen unit files fail to collect (see CONTRIBUTING).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
