### PR TITLE
feat(apps): make the store listing hero banner click-to-launch

### DIFF
--- a/src/components/Apps/AppListingDetailBody.browser.test.tsx
+++ b/src/components/Apps/AppListingDetailBody.browser.test.tsx
@@ -368,14 +368,20 @@ describe('AppListingDetailBody', () => {
    * mounts and throw on strict mode. Each variant's href is unique, so each wait
    * can only be satisfied by its own mount.
    *
-   * 🔴 `:not([data-testid="apps-listing-hero-launch"])` is load-bearing. The
-   * click-to-launch hero banner is an anchor to the SAME `/apps/run/<slug>`
-   * href and sits EARLIER in the tree, so a bare `a[href=…]` returns the banner
-   * and `glyphOf` then reads the cover placeholder's category icon instead of
-   * the CTA's. That is a real failure for the glyph test — and, worse, a silent
-   * FALSE PASS for the link-semantics test below, whose assertions (no `target`,
-   * no `rel`) the banner happens to satisfy too. These tests are about the
-   * BUTTON; say so in the selector.
+   * 🔴 `[class*="Button-root"]` is load-bearing. The click-to-launch hero banner
+   * is an anchor to the SAME `/apps/run/<slug>` href and sits EARLIER in the
+   * tree, so a bare `a[href=…]` returns the banner and `glyphOf` then reads the
+   * cover placeholder's category icon instead of the CTA's. That is a real
+   * failure for the glyph test — and, worse, a silent FALSE PASS for the
+   * link-semantics test below, whose assertions (no `target`, no `rel`) the
+   * banner happens to satisfy too. These tests are about the BUTTON; say so in
+   * the selector.
+   *
+   * Discriminate on what the CTA IS, not on what it is not: an earlier revision
+   * excluded the banner's `data-testid`, which works here but is a trap to copy —
+   * `next.config.mjs` strips `data-testid` in production builds
+   * (`reactRemoveProperties`), so that shape matches nothing in a prod-build
+   * harness. Mirrors `waitForCta` in AppListingCard.browser.test.tsx.
    *
    * Timeout matches the 10s that `test/component-setup.tsx` deliberately sets as
    * the project-wide `vi.waitFor` default — its comment names the saturated
@@ -389,9 +395,14 @@ describe('AppListingDetailBody', () => {
     await renderWithProviders(ui);
     const cta = await vi.waitUntil(
       () =>
-        document.body.querySelector(
-          `a[href="${ctaHref}"]:not([data-testid="apps-listing-hero-launch"])`
-        ),
+        // 🔴 Discriminate STRUCTURALLY (the CTA is the Button), not by excluding
+        // the banner's `data-testid`. `next.config.mjs` strips `data-testid` in
+        // production builds via `reactRemoveProperties`, so a testid-based
+        // selector is correct in vitest (dev transform) but silently matches
+        // nothing in any prod-build harness. This mirrors the existing precedent
+        // at AppListingCard.browser.test.tsx's `waitForCta`, and it is
+        // self-describing: it says what the CTA IS rather than what it is not.
+        document.body.querySelector(`a[href="${ctaHref}"][class*="Button-root"]`),
       { timeout: 10000, interval: 25 }
     );
     return cta as HTMLAnchorElement;
@@ -651,9 +662,7 @@ describe('AppListingDetailBody', () => {
   test('🔴 a listing with NO cover art still gets the launch affordance', async () => {
     // The placeholder-gradient branch. An owner who has not uploaded a cover yet
     // must not silently lose the way into their own app.
-    const { within } = await renderScoped(
-      <AppListingDetailBody detail={base({ coverUrl: null })} canOpenPage />
-    );
+    const { within } = await renderScoped(<AppListingDetailBody detail={base({ coverUrl: null })} canOpenPage />);
     const hero = within.getByTestId(HERO);
     await expect.element(hero).toBeInTheDocument();
     expect(hero.element().getAttribute('href')).toBe('/apps/run/my-app');
@@ -663,9 +672,7 @@ describe('AppListingDetailBody', () => {
   });
 
   test('🔴 the banner is keyboard focusable and Enter activates it', async () => {
-    const { within } = await renderScoped(
-      <AppListingDetailBody detail={base({})} canOpenPage />
-    );
+    const { within } = await renderScoped(<AppListingDetailBody detail={base({})} canOpenPage />);
     const hero = within.getByTestId(HERO);
     await expect.element(hero).toBeInTheDocument();
     const el = hero.element() as HTMLElement;

--- a/src/components/Apps/AppListingDetailBody.browser.test.tsx
+++ b/src/components/Apps/AppListingDetailBody.browser.test.tsx
@@ -1,8 +1,9 @@
 import { describe, expect, test, vi, beforeEach } from 'vitest';
-import { page } from 'vitest/browser';
+import { page, userEvent } from 'vitest/browser';
 // `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
 import { renderWithProviders } from '../../../test/component-setup';
 import type * as TrpcMod from '~/utils/trpc';
+import type * as RecentsMod from '~/components/Apps/recentlyOpenedAppsStore';
 import type { ListingCard, ListingDetail } from '~/server/schema/blocks/app-listing-read.schema';
 
 /**
@@ -17,11 +18,29 @@ const mocks = vi.hoisted(() => ({
   currentUser: null as null | { id: number; username: string },
   // Items the mocked `appListings.listAvailable` returns to the related rail.
   relatedItems: [] as unknown[],
+  // Every `recordRecentlyOpenedApp(...)` argument seen this test, in order.
+  recorded: [] as unknown[],
 }));
 
 vi.mock('~/hooks/useCurrentUser', () => ({
   useCurrentUser: () => mocks.currentUser,
 }));
+
+// Recents SPY — spread the real module and wrap only the writer, so the store's
+// real behaviour (localStorage, per-kind cap, de-dup) is untouched and every
+// other importer keeps working. Used by the hero-banner "records exactly as the
+// CTA does" tests below, WITH a positive control (see them) — a bare `0` from a
+// counter nobody has proved can count is not evidence.
+vi.mock('~/components/Apps/recentlyOpenedAppsStore', async (importOriginal) => {
+  const actual = await importOriginal<typeof RecentsMod>();
+  return {
+    ...actual,
+    recordRecentlyOpenedApp: (app: Parameters<typeof actual.recordRecentlyOpenedApp>[0]) => {
+      mocks.recorded.push(app);
+      return actual.recordRecentlyOpenedApp(app);
+    },
+  };
+});
 
 // The detail body now renders the discovery rail, which reads the feature flags
 // + `appListings.listAvailable`. Mock both so the suite stays network-free.
@@ -68,6 +87,7 @@ const { AppListingDetailBody } = await import('./AppListingDetailBody');
 beforeEach(() => {
   mocks.currentUser = null;
   mocks.relatedItems = [];
+  mocks.recorded = [];
 });
 
 function base(over: Partial<ListingDetail>): ListingDetail {
@@ -348,6 +368,15 @@ describe('AppListingDetailBody', () => {
    * mounts and throw on strict mode. Each variant's href is unique, so each wait
    * can only be satisfied by its own mount.
    *
+   * 🔴 `:not([data-testid="apps-listing-hero-launch"])` is load-bearing. The
+   * click-to-launch hero banner is an anchor to the SAME `/apps/run/<slug>`
+   * href and sits EARLIER in the tree, so a bare `a[href=…]` returns the banner
+   * and `glyphOf` then reads the cover placeholder's category icon instead of
+   * the CTA's. That is a real failure for the glyph test — and, worse, a silent
+   * FALSE PASS for the link-semantics test below, whose assertions (no `target`,
+   * no `rel`) the banner happens to satisfy too. These tests are about the
+   * BUTTON; say so in the selector.
+   *
    * Timeout matches the 10s that `test/component-setup.tsx` deliberately sets as
    * the project-wide `vi.waitFor` default — its comment names the saturated
    * preview CI box, where these browser tests share a host with the image build.
@@ -358,10 +387,13 @@ describe('AppListingDetailBody', () => {
     ctaHref: string
   ): Promise<HTMLAnchorElement> {
     await renderWithProviders(ui);
-    const cta = await vi.waitUntil(() => document.body.querySelector(`a[href="${ctaHref}"]`), {
-      timeout: 10000,
-      interval: 25,
-    });
+    const cta = await vi.waitUntil(
+      () =>
+        document.body.querySelector(
+          `a[href="${ctaHref}"]:not([data-testid="apps-listing-hero-launch"])`
+        ),
+      { timeout: 10000, interval: 25 }
+    );
     return cta as HTMLAnchorElement;
   }
 
@@ -524,5 +556,229 @@ describe('AppListingDetailBody', () => {
     await expect.element(label).toBeInTheDocument();
     await label.hover();
     await expect.element(page.getByText(longName, { exact: true })).toBeInTheDocument();
+  });
+
+  // ── Hero banner click-to-launch ────────────────────────────────────────────
+  //
+  // The banner is a SECOND affordance for the primary `open` action — an
+  // ordinary `<a href="/apps/run/<slug>">` wrapping the cover art. Not a frame,
+  // not a div-with-onClick.
+  //
+  // 🔴 RED-AT-BASE STATUS, stated per test rather than implied. Measured by
+  // running each test in isolation (`-t`) against the pristine parent commit:
+  //   RED   — "is a real link", "NO cover art still launches", "keyboard
+  //           focusable and Enter activates", "records recents exactly as the
+  //           Open CTA does". These are genuine regression coverage.
+  //   GREEN — the four negative tests (preview, off-site, the on-site "Open
+  //           live" escape hatch, the model-slot info branch) and the positive
+  //           control. Base renders no banner link at all, so the negatives pass
+  //           there VACUOUSLY: they are INVARIANT GUARDS, not coverage. What
+  //           they are worth is mutation-proof against THIS change's own guard —
+  //           drop a clause from `heroLaunchHref` and each goes red for its own
+  //           reason. Do not count them as regression coverage.
+
+  /** The banner's launch anchor, when there is one. */
+  const HERO = 'apps-listing-hero-launch';
+
+  /**
+   * Render, and return a locator scoped to THIS mount's container.
+   *
+   * 🔴 Every query below goes through `within`, never the page-wide `page.*` or
+   * `document.body`. Measured while establishing the red-at-base matrix (on the
+   * pre-#3556 base, where the `afterEach` `cleanup()` was not awaited): a test
+   * that FAILS could leave its mounted tree in `document.body`, so with three
+   * neighbours red the next test saw three extra copies — a body-wide
+   * `getByText('My App')` hit "strict mode violation: resolved to 3 elements"
+   * and a body-wide `querySelectorAll('a[href="/apps/run/my-app"]')` counted the
+   * previous mount's CTA and reported "expected 0, got 1". Both were FALSE reds
+   * about this change: run in isolation the same tests passed. #3556 has since
+   * fixed that root cause; the scoping stays anyway, because whether this test
+   * passes should not depend on whether its neighbours did.
+   *
+   * (`renderWithProviders`'s own returned selectors do NOT do this — vitest-
+   * browser-react binds them to `baseElement`, which defaults to
+   * `document.body`. `page.elementLocator(container)` is the scoped one.)
+   */
+  async function renderScoped(ui: Parameters<typeof renderWithProviders>[0]) {
+    const { container } = await renderWithProviders(ui);
+    return { container, within: page.elementLocator(container) };
+  }
+
+  /**
+   * Swallow a real activation: capture-phase `preventDefault()` on `document`.
+   *
+   * Runs BEFORE React's root-container listeners, so (a) the browser performs no
+   * navigation and opens no tab, and (b) `next/link`'s own handler sees
+   * `e.defaultPrevented` and bails out of `router.push`. A plain `<a onClick>`
+   * (the off-site Visit CTA) still runs its React handler — which is exactly
+   * what the positive control below needs: the side effect fires, the
+   * navigation does not.
+   */
+  async function withoutNavigating<T>(fn: () => Promise<T>): Promise<T> {
+    const stop = (e: Event) => e.preventDefault();
+    document.addEventListener('click', stop, true);
+    try {
+      return await fn();
+    } finally {
+      document.removeEventListener('click', stop, true);
+    }
+  }
+
+  test('🔴 on-site + canOpenPage → the banner is a real link to the SAME target as the Open CTA', async () => {
+    const { container, within } = await renderScoped(
+      <AppListingDetailBody detail={base({})} canOpenPage />
+    );
+    const hero = within.getByTestId(HERO);
+    await expect.element(hero).toBeInTheDocument();
+
+    const el = hero.element() as HTMLElement;
+    // Semantics, not a click handler on a box: a real anchor, same-tab.
+    expect(el.tagName).toBe('A');
+    expect(el.getAttribute('href')).toBe('/apps/run/my-app');
+    expect(el.getAttribute('target')).toBeNull();
+    // Accessible NAME — neither the cover `alt` ("… cover image") nor the
+    // aria-hidden placeholder can supply one, so it is explicit.
+    expect(el.getAttribute('aria-label')).toBe('Open My App');
+    // No nested interactive: the banner wraps art only.
+    expect(el.querySelectorAll('a, button, input, select, textarea')).toHaveLength(0);
+
+    // "Same destination as the CTA" asserted as a fact about the DOM, not by
+    // restating the string: exactly two anchors point at the run route — the
+    // banner and the button. If the banner ever aims somewhere else this is 1.
+    expect(container.querySelectorAll('a[href="/apps/run/my-app"]')).toHaveLength(2);
+  });
+
+  test('🔴 a listing with NO cover art still gets the launch affordance', async () => {
+    // The placeholder-gradient branch. An owner who has not uploaded a cover yet
+    // must not silently lose the way into their own app.
+    const { within } = await renderScoped(
+      <AppListingDetailBody detail={base({ coverUrl: null })} canOpenPage />
+    );
+    const hero = within.getByTestId(HERO);
+    await expect.element(hero).toBeInTheDocument();
+    expect(hero.element().getAttribute('href')).toBe('/apps/run/my-app');
+    // …and it really is the seeded-gradient placeholder inside, not a cover
+    // image — otherwise this test would pass on the wrong branch.
+    expect(hero.element().querySelector('[data-listing-cover-placeholder]')).not.toBeNull();
+  });
+
+  test('🔴 the banner is keyboard focusable and Enter activates it', async () => {
+    const { within } = await renderScoped(
+      <AppListingDetailBody detail={base({})} canOpenPage />
+    );
+    const hero = within.getByTestId(HERO);
+    await expect.element(hero).toBeInTheDocument();
+    const el = hero.element() as HTMLElement;
+
+    const activated: (string | null)[] = [];
+    await withoutNavigating(async () => {
+      el.focus();
+      // A `<div onClick>` is not focusable without an explicit tabIndex, so this
+      // line alone discriminates the real-semantics requirement.
+      expect(document.activeElement).toBe(el);
+      document.addEventListener(
+        'click',
+        (e) => activated.push((e.target as Element).closest('a')?.getAttribute('href') ?? null),
+        { capture: true, once: true }
+      );
+      await userEvent.keyboard('{Enter}');
+    });
+    // The browser synthesised an activation click from the keypress, and it came
+    // from the banner anchor.
+    expect(activated).toEqual(['/apps/run/my-app']);
+  });
+
+  test('preview mode renders NO launchable banner (invariant guard — see the block note)', async () => {
+    // The moderator listing-media review posture. `canOpenPage` is passed TRUE
+    // on purpose: the only thing suppressing the banner here must be `preview`.
+    const { container, within } = await renderScoped(
+      <AppListingDetailBody detail={base({})} canOpenPage preview />
+    );
+    await expect.element(within.getByText('My App')).toBeInTheDocument(); // render barrier
+    expect(container.querySelectorAll(`[data-testid="${HERO}"]`)).toHaveLength(0);
+    // Nothing anywhere in the read-only body links to the run route.
+    expect(container.querySelectorAll('a[href="/apps/run/my-app"]')).toHaveLength(0);
+  });
+
+  test('off-site (Visit) → the banner is NOT interactive (invariant guard)', async () => {
+    // Design call: an off-site destination is never reached from decorative art.
+    const { container, within } = await renderScoped(
+      <AppListingDetailBody detail={offsite()} />
+    );
+    await expect.element(within.getByTestId('apps-listing-open-live')).toBeInTheDocument();
+    expect(container.querySelectorAll(`[data-testid="${HERO}"]`)).toHaveLength(0);
+    // Exactly one route off-platform: the labelled button.
+    expect(container.querySelectorAll('a[href="https://ext.app"]')).toHaveLength(1);
+  });
+
+  test('the on-site raw-origin escape hatch does NOT make the banner interactive (invariant guard)', async () => {
+    // on-site page app, viewer WITHOUT `appBlocksPages` → the action is `visit`
+    // to <slug>.civit.ai. Same off-platform reasoning as the off-site case, and
+    // the branch a `mode !== 'visit'`-shaped guard would most easily get wrong.
+    const { container, within } = await renderScoped(<AppListingDetailBody detail={base({})} />);
+    await expect.element(within.getByTestId('apps-listing-open-live')).toBeInTheDocument();
+    expect(container.querySelectorAll(`[data-testid="${HERO}"]`)).toHaveLength(0);
+    expect(container.querySelectorAll('a[href="https://my-app.civit.ai"]')).toHaveLength(1);
+  });
+
+  test('the model-slot info branch (no href at all) leaves the banner inert (invariant guard)', async () => {
+    const { container, within } = await renderScoped(
+      <AppListingDetailBody
+        detail={base({
+          kindData: {
+            kind: 'onsite',
+            appBlockId: 'blk-1',
+            hasPage: false,
+            liveUrl: 'https://my-app.civit.ai',
+          },
+        })}
+        canOpenPage
+      />
+    );
+    await expect.element(within.getByText('Runs on model pages')).toBeInTheDocument();
+    expect(container.querySelectorAll(`[data-testid="${HERO}"]`)).toHaveLength(0);
+  });
+
+  // ── Recents: exactly once, matching the CTA ────────────────────────────────
+  //
+  // 🔴 The claim under test is a ZERO ("the banner adds no recents write"), and
+  // a zero from a counter that has never been shown to count is indistinguishable
+  // from a counter wired to nothing. So the control comes FIRST and must read 1.
+
+  test('POSITIVE CONTROL — the off-site Visit CTA records exactly 1 through this counter', async () => {
+    const { within } = await renderScoped(<AppListingDetailBody detail={offsite()} />);
+    const cta = within.getByTestId('apps-listing-open-live');
+    await expect.element(cta).toBeInTheDocument();
+    expect(mocks.recorded).toHaveLength(0); // a VIEW records nothing
+    await withoutNavigating(() => userEvent.click(cta));
+    expect(mocks.recorded).toHaveLength(1);
+  });
+
+  test('🔴 the banner records recents exactly as the Open CTA does — i.e. not on click at all', async () => {
+    // `/apps/run/<slug>` records the open in its own mount effect, which is why
+    // the `open` CTA has no onClick. The banner must match it: 0 here, 1 there.
+    // The control above proves this counter CAN observe a write, so these zeros
+    // are evidence rather than an absence of wiring.
+    const { container, within } = await renderScoped(
+      <AppListingDetailBody detail={base({})} canOpenPage />
+    );
+    await expect.element(within.getByTestId(HERO)).toBeInTheDocument();
+
+    const links = Array.from(
+      container.querySelectorAll<HTMLAnchorElement>('a[href="/apps/run/my-app"]')
+    );
+    expect(links).toHaveLength(2);
+    const [heroEl, ctaEl] = links;
+    expect(heroEl.getAttribute('data-testid')).toBe(HERO); // the banner is first in the tree
+
+    await withoutNavigating(async () => {
+      await userEvent.click(ctaEl);
+      const afterCta = mocks.recorded.length;
+      await userEvent.click(heroEl);
+      const afterHero = mocks.recorded.length;
+
+      expect(afterCta).toBe(0); // the CTA's own behaviour, re-measured not assumed
+      expect(afterHero - afterCta).toBe(0); // the banner adds nothing on top of it
+    });
   });
 });

--- a/src/components/Apps/AppListingDetailBody.tsx
+++ b/src/components/Apps/AppListingDetailBody.tsx
@@ -212,6 +212,18 @@ function HeroCover({
       aria-label={`Open ${name}`}
       data-testid="apps-listing-hero-launch"
       underline="never"
+      // 🔴 `c="inherit"` is load-bearing, not cosmetic. Mantine's Anchor root sets
+      // `color: var(--mantine-color-anchor)` (blue-4 `#4DABF7` in dark scheme), and
+      // Tabler icons stroke with `currentColor` — so without this the no-cover
+      // placeholder's 72px category glyph turns link-blue instead of staying the
+      // page's grey `--mantine-color-text`. The cover-IMAGE branch is unaffected
+      // (an `<img>` ignores `color`), which is exactly why this is easy to miss:
+      // it only shows on listings with no cover. `CreatorChip` in AppListingCard
+      // carries `c="dimmed"` for the same reason.
+      // Not covered by the component suite — it loads no CSS (vitest.config.mts
+      // registers only the process shim and component-setup), so every visual
+      // claim here is reasoning, not measurement.
+      c="inherit"
       // Minimal, card-idiom affordance: pointer + a small hover dim + the
       // site's `focus-visible:ring` pattern, so the banner reads as pressable
       // without becoming a redesign. `focus:outline-none` is paired with a ring

--- a/src/components/Apps/AppListingDetailBody.tsx
+++ b/src/components/Apps/AppListingDetailBody.tsx
@@ -99,7 +99,11 @@ import type {
  * To run an on-site app from this page the viewer takes the kind-aware primary
  * action (`getDetailPrimaryAction`): today that is `Open` → `/apps/run/<slug>`
  * for every viewer who can reach this page — see the flag note on
- * `appListingDetailView`. Structurally pinned in the node `unit` project
+ * `appListingDetailView`. The hero banner is a SECOND affordance for that same
+ * action and nothing more: a plain `<a href>` to the identical route (see
+ * `HeroCover`). It is not, and must not become, an embedded runtime.
+ *
+ * Structurally pinned in the node `unit` project
  * (`__tests__/appListingDetailView.test.ts`, "no raw `<iframe>` may return"),
  * because CI does not run the browser `component` suite.
  *
@@ -128,22 +132,52 @@ function categoryIcon(category: string): Icon {
  * gradient (shared with the server-generated cover SVG — see
  * `~/shared/constants/app-listing-placeholder.constants`) when absent OR the
  * image 404s (a coverUrl derived from a first-screenshot fallback can dangle) —
- * never a broken `<img>`. Decorative (aria-hidden placeholder).
+ * never a broken `<img>`. The art itself is decorative (aria-hidden placeholder).
+ *
+ * CLICK-TO-LAUNCH (`launchHref`): when the caller supplies a launch target the
+ * WHOLE banner becomes a real anchor to it — the same destination as the primary
+ * `Open` CTA. It wraps BOTH branches: a listing with no cover art gets the
+ * affordance over its seeded-gradient placeholder exactly like one with a cover,
+ * because "has no art yet" is not a reason to lose the way in. The caller
+ * decides WHEN there is a target (see `heroLaunchHref` in the body) — this
+ * component only decides how it renders.
+ *
+ * 🔴 It is an `<a href>`, never a `<div onClick>`. The banner has to be
+ * tab-reachable, Enter-activatable and middle-/modifier-clickable like any other
+ * link, and it has to expose an accessible NAME — which neither branch can
+ * supply on its own: the cover `alt` describes the PICTURE ("<app> cover image")
+ * and the placeholder is `aria-hidden` with no text at all. Hence the explicit
+ * `aria-label`, worded to match the CTA it mirrors. Nothing inside the banner is
+ * interactive, so this nests no controls.
+ *
+ * 🔴 NO recents side effect here, DELIBERATELY — verified against the CTA rather
+ * than assumed. `/apps/run/<slug>` records the open itself, in a mount effect
+ * (`recordRecentlyOpenedApp` in the run page), which is exactly why the `open`
+ * branch of `PrimaryAction` carries no `onClick` either; only the off-site
+ * `visit` branch records, because following that link leaves the SPA and nothing
+ * downstream could. An `onClick` here would therefore write the entry TWICE per
+ * launch — once from the listing DTO, once from the run page — and silently
+ * diverge the banner from the button it is meant to mirror. Pinned, against a
+ * positive control, in `AppListingDetailBody.browser.test.tsx`.
  */
 function HeroCover({
   coverUrl,
   category,
   name,
   slug,
+  launchHref = null,
 }: {
   coverUrl: string | null;
   category: string | null;
   name: string;
   slug: string;
+  /** Internal launch target; `null` → the banner stays decorative + inert. */
+  launchHref?: string | null;
 }) {
   const [broken, setBroken] = useState(false);
-  if (coverUrl && !broken) {
-    return (
+  const PlaceholderIcon = category ? categoryIcon(category) : IconApps;
+  const art =
+    coverUrl && !broken ? (
       <Image
         src={coverUrl}
         alt={`${name} cover image`}
@@ -152,24 +186,44 @@ function HeroCover({
         radius="md"
         onError={() => setBroken(true)}
       />
+    ) : (
+      // Per-app SEEDED gradient — same seed/stops as the generated cover SVG and
+      // the store card, so one listing reads as one identity across every surface.
+      <Box
+        aria-hidden
+        h={260}
+        className="flex items-center justify-center"
+        data-listing-cover-placeholder=""
+        style={{
+          borderRadius: 'var(--mantine-radius-md)',
+          background: listingPlaceholderGradient({ slug, category, surface: 'cover' }),
+        }}
+      >
+        <PlaceholderIcon size={72} className="opacity-60" />
+      </Box>
     );
-  }
-  const PlaceholderIcon = category ? categoryIcon(category) : IconApps;
-  // Per-app SEEDED gradient — same seed/stops as the generated cover SVG and the
-  // store card, so one listing reads as one identity across every surface.
+
+  if (!launchHref) return art;
+
   return (
-    <Box
-      aria-hidden
-      h={260}
-      className="flex items-center justify-center"
-      data-listing-cover-placeholder=""
-      style={{
-        borderRadius: 'var(--mantine-radius-md)',
-        background: listingPlaceholderGradient({ slug, category, surface: 'cover' }),
-      }}
+    <Anchor
+      component={Link}
+      href={launchHref}
+      aria-label={`Open ${name}`}
+      data-testid="apps-listing-hero-launch"
+      underline="never"
+      // Minimal, card-idiom affordance: pointer + a small hover dim + the
+      // site's `focus-visible:ring` pattern, so the banner reads as pressable
+      // without becoming a redesign. `focus:outline-none` is paired with a ring
+      // (never bare), so keyboard focus stays VISIBLE.
+      className="block transition-opacity hover:opacity-90 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-5"
+      // 🔴 Mantine's `md` radius (8px), not Tailwind's `rounded-md` (6px) — the
+      // inner cover `<Image radius="md">` and the placeholder Box both use the
+      // Mantine token, and mixing the two `md`s leaves a visible corner seam.
+      style={{ display: 'block', borderRadius: 'var(--mantine-radius-md)', overflow: 'hidden' }}
     >
-      <PlaceholderIcon size={72} className="opacity-60" />
-    </Box>
+      {art}
+    </Anchor>
   );
 }
 
@@ -395,6 +449,29 @@ export function AppListingDetailBody({
   const editHref = getOwnerEditHref(detail.kindData, detail.id);
   const showEdit = canOwnerEditListing({ isOwner }) && !!editHref;
 
+  // Hero click-to-launch — the banner is an affordance for the SAME destination
+  // as the primary CTA, derived FROM that CTA (`getDetailPrimaryAction`) rather
+  // than by re-deriving the kind matrix, so the two cannot drift apart.
+  //
+  // 🔴 ON-SITE `open` ONLY. Three deliberate exclusions, each a decision:
+  //   - `visit` — both the off-site listing AND the on-site raw-origin "Open
+  //     live" escape hatch. Silently shipping a viewer off-platform from what
+  //     reads as decorative art is a surprise; an off-site destination deserves
+  //     the labelled, new-tab "Visit ↗" button, so the banner stays inert. The
+  //     `!external` guard says the same thing structurally, in case a future
+  //     `open` ever carries `external: true`.
+  //   - no href (`info` model-slot / `connect` stub) — nothing to launch, and
+  //     `DetailPrimaryAction.href` is optional, so this is a real branch.
+  //   - `preview` — the moderator listing-media review renders this body
+  //     READ-ONLY and omits the entire action column. A clickable banner there
+  //     would put a live launch back onto an UNAPPROVED shadow listing, which is
+  //     precisely what that posture exists to prevent.
+  const primaryAction = getDetailPrimaryAction(detail, { canOpenPage });
+  const heroLaunchHref =
+    !preview && primaryAction.mode === 'open' && !primaryAction.external && primaryAction.href
+      ? primaryAction.href
+      : null;
+
   return (
     <Stack gap="lg">
       {/* Back-to-store nav is a live-surface affordance — omitted in preview. */}
@@ -412,6 +489,7 @@ export function AppListingDetailBody({
         category={detail.category}
         name={detail.name}
         slug={detail.slug}
+        launchHref={heroLaunchHref}
       />
 
       {/* Header: icon + name + tagline + creator + content-rating badge + action. */}


### PR DESCRIPTION
The `/apps/store-preview/<slug>` hero cover is the biggest, most obviously "this is the app" element on the listing detail — and it does nothing. The only way in is the CTA in the far-right action column. This wraps the banner in a real anchor to the same destination as the primary `open` action (`/apps/run/<slug>`).

Deliberately the cheap half: **no screenshot capture, no embedded runtime, and no `<iframe>`.** #3549 removed the bridge-less in-page preview, and the source-level gate in `__tests__/appListingDetailView.test.ts` that pins its absence is correct — this is a link and nothing more. That gate stays green (19/19).

## Design calls

**On-site `open` only.** An off-site listing (`visit`) leaves the banner inert, and so does the on-site raw-origin *"Open live"* escape hatch. Silently shipping a viewer off-platform from what reads as decorative art is a surprise; an off-site destination deserves the labelled, new-tab *"Visit ↗"* button it already has. An action with **no href at all** — the model-slot `info` branch, the `connect` stub — is inert for the obvious reason (`DetailPrimaryAction.href` is optional, so that is a real branch, not a hypothetical).

The target is derived from `getDetailPrimaryAction`, not by re-deriving the kind matrix, so the banner cannot drift from the button it mirrors:

```ts
const primaryAction = getDetailPrimaryAction(detail, { canOpenPage });
const heroLaunchHref =
  !preview && primaryAction.mode === 'open' && !primaryAction.external && primaryAction.href
    ? primaryAction.href
    : null;
```

`!external` is belt-and-braces for a future `open` that ever carries `external: true`.

**`preview` stays inert.** The moderator listing-media review renders this body read-only and omits the whole action column. A clickable banner there would put a live launch back onto an *unapproved* shadow listing — exactly what that posture exists to prevent. The preview test passes `canOpenPage` **true** on purpose, so the only thing that can be suppressing the banner is `preview`.

**Real semantics.** An `<a href>`, not a `<div onClick>`: tab-reachable, Enter-activatable, modifier-clickable, with a visible `focus-visible:ring-2` (paired with `focus:outline-none`, never a bare outline removal). It carries an explicit `aria-label="Open <app>"`, because neither branch can name it otherwise — the cover `alt` describes the *picture* (`"<app> cover image"`) and the placeholder is `aria-hidden` with no text. Nothing inside the banner is interactive, so no controls are nested (asserted).

**No double side effect.** `/apps/run/<slug>` records the recents entry itself, in a mount effect — which is why the `open` CTA has no `onClick` either; only the off-site `visit` branch records, because following that link leaves the SPA and nothing downstream could. The banner matches the CTA exactly: it records **nothing** on click. Verified rather than assumed, and against a positive control, since the claim under test is a zero.

**The art-less case still launches.** A listing whose owner has not uploaded a cover gets the affordance over its seeded-gradient placeholder, and the test asserts it really is the placeholder branch inside — otherwise it would be passing on the wrong branch.

Visually it stays in the card idiom: pointer, a small hover dim, the site's focus ring. The wrapper uses the **Mantine** `md` radius, not Tailwind's `rounded-md` — the two `md`s are 8px and 6px, and mixing them against the inner `<Image radius="md">` leaves a corner seam.

## Tests

`AppListingDetailBody.browser.test.tsx`, red-at-base measured **per test in isolation** (`-t`) against this PR's parent commit `ed6e17ac7d`:

| Test | At base |
|---|---|
| the banner is a real link to the SAME target as the Open CTA | 🔴 **RED** |
| a listing with NO cover art still gets the launch affordance | 🔴 **RED** |
| the banner is keyboard focusable and Enter activates it | 🔴 **RED** |
| the banner records recents exactly as the Open CTA does | 🔴 **RED** |
| preview mode renders NO launchable banner | 🟢 green |
| off-site (Visit) → banner NOT interactive | 🟢 green |
| the on-site raw-origin escape hatch → banner NOT interactive | 🟢 green |
| the model-slot info branch → banner inert | 🟢 green |
| POSITIVE CONTROL: the off-site Visit CTA records exactly 1 | 🟢 green |

**The five green ones are invariant guards, not regression coverage** — base renders no banner link at all, so they pass there vacuously, and I am not counting them. What they are worth is mutation-proof against this change's own guard; each was broken on purpose and each went red *for its own reason*:

| Mutation | Killed |
|---|---|
| M1 — drop the `!preview` clause | preview |
| M2 — accept `mode === 'visit'` too | off-site **+** escape hatch |
| M3 — naive "the banner always opens `/apps/run/<slug>`" | off-site **+** escape hatch **+** model-slot |
| M4 — add a `recordRecentlyOpenedApp` `onClick` to the banner | records-recents |

The recents zero is reported as a pair, never alone: the positive control clicks the off-site Visit CTA and reads **exactly 1** through the same spy the zeros are read from, so those zeros are evidence rather than a counter wired to nothing.

Keyboard activation is a real activation: focus the anchor, press Enter, and observe the browser-synthesised click — with a capture-phase `preventDefault()` on `document` so nothing navigates (which also makes `next/link` bail, since it checks `defaultPrevented`). `document.activeElement === el` on its own discriminates the real-semantics requirement, because a `<div onClick>` is not focusable without an explicit `tabIndex`.

### Latent false pass fixed on the way

The existing glyph tests looked the CTA up as `a[href="/apps/run/<slug>"]`, and the banner now matches that **first**. That made *"the in-site Open CTA and the off-site Visit CTA render DIFFERENT glyphs"* a genuine failure (it read the cover placeholder's category icon instead of the button's `player-play`) — and, worse, made *"the glyph change does NOT touch link semantics"* a **silent false green**, since the banner also has no `target` and no `rel`. Both selectors now exclude the banner explicitly, with a comment saying why.

## Results

- Browser spec: **28 passed (28)**, three consecutive runs on this base (6s, 6s, 6s warm).
- Node `unit`, the suites that can see the changed file: `appListingDetailView` (19, includes the no-raw-`<iframe>` gate), `appListingActionGlyph` (9), `recentAppsRail` (44) — **72 passed (72)**.
- Full node `unit` project: 10050 passed / 7 failed / 50 failed files — **all pre-existing and environmental**, 42 of them the missing private `event-engine-common` module (#1985) and its downstream implicit-`any` fallout. None import or read the changed file.
- `eslint` on both changed files: 0 errors (1 pre-existing `ThemeIcon` unused warning, left alone). `tsc --noEmit`: 12 errors, all the same pre-existing `event-engine-common` chain, none in these files.

## Not in scope

No screenshot capture. No install surface for the model-slot branch (still the gap #3493 tracks — that branch is vacuous today, since every approved on-site listing declares a page).
