### PR TITLE
perf(cache): decouple the metric-privacy defaults TTL from membership (10m -> 1h) + hit/miss metric

### DIFF
--- a/src/server/services/__tests__/creator-membership.service.test.ts
+++ b/src/server/services/__tests__/creator-membership.service.test.ts
@@ -35,6 +35,9 @@ vi.mock('~/server/redis/client', () => ({
   },
 }));
 
+// Stubbed by the global setup (src/__tests__/setup.ts) — `.inc` is a vi.fn(), so these
+// are the assertion handles for the cache hit/miss instrumentation.
+import { cacheHitCounter, cacheMissCounter } from '~/server/prom/client';
 import {
   bustCreatorMembershipValidCache,
   bustUserMetricPrivacyDefaultsCache,
@@ -46,6 +49,16 @@ import {
 const keyFor = (id: number) => `packed:caches:creator-membership-valid:${id}`;
 const defaultsKeyFor = (id: number) => `packed:caches:user-metric-privacy-defaults:${id}`;
 const ALL_FALSE = { hideModelBuzz: false, hideModelDownloads: false, hideModelGenerations: false };
+
+// LITERAL expected TTLs, in seconds. Deliberately NOT `CacheTTL.*` — the point of these
+// pins is to fail if the two caches are ever re-merged onto one constant, and a
+// `CacheTTL`-derived expectation would silently follow such a change.
+const MEMBERSHIP_TTL_SECONDS = 600; // 10 minutes — membership validity, unchanged
+const METRIC_PRIVACY_TTL_SECONDS = 3600; // 1 hour — metric-privacy defaults
+const PRIVACY_CACHE_LABELS = {
+  cache_name: 'user-metric-privacy-defaults',
+  cache_type: 'redisPacked',
+};
 
 type SubRow = {
   userId: number;
@@ -276,11 +289,12 @@ describe('getUserMetricPrivacyDefaultsMap — derived read-through cache', () =>
       hideModelDownloads: false,
       hideModelGenerations: true,
     });
-    // Backfilled with exactly the tiny triple + TTL.
+    // Backfilled with exactly the tiny triple + this cache's own TTL (see the
+    // "cache TTLs are decoupled per cache" block for the decoupling guard).
     expect(mockRedis.packed.set).toHaveBeenCalledWith(
       defaultsKeyFor(1),
       { hideModelBuzz: true, hideModelDownloads: false, hideModelGenerations: true },
-      { EX: CacheTTL.md }
+      { EX: METRIC_PRIVACY_TTL_SECONDS }
     );
   });
 
@@ -405,5 +419,132 @@ describe('bustUserMetricPrivacyDefaultsCache', () => {
     expect(mockRedis.del).not.toHaveBeenCalled();
     mockRedis.del.mockRejectedValue(new Error('redis down'));
     await expect(bustUserMetricPrivacyDefaultsCache(5)).resolves.toBeUndefined();
+  });
+});
+
+/**
+ * The two caches in this module used to share ONE `MEMBERSHIP_CACHE_TTL`, so raising the
+ * TTL of either silently raised the other — bumping the metric-privacy TTL would have
+ * extended membership staleness with nothing to catch it.
+ *
+ * These pins are the regression guard for exactly that. They assert LITERAL second
+ * values, not `CacheTTL.*`, so re-merging the constants (or repointing one at the
+ * other's value) fails here instead of shipping. They are also the reason the two
+ * expectations live in one describe: the guard is the RELATIONSHIP between them, not
+ * either number alone.
+ */
+describe('cache TTLs are decoupled per cache', () => {
+  it('writes the metric-privacy defaults with its own 1h TTL', async () => {
+    mockRedis.packed.mGet.mockResolvedValue([null]);
+    mockDbRead.user.findMany.mockResolvedValue([{ id: 1, settings: { hideModelBuzz: true } }]);
+
+    await getUserMetricPrivacyDefaultsMap([1]);
+
+    expect(mockRedis.packed.set).toHaveBeenCalledWith(defaultsKeyFor(1), expect.anything(), {
+      EX: METRIC_PRIVACY_TTL_SECONDS,
+    });
+  });
+
+  // INVARIANT GUARD, not regression coverage: this is green on pre-change code too,
+  // because the membership TTL is exactly what this PR did NOT change. Its job is to go
+  // red if a future edit raises `MEMBERSHIP_CACHE_TTL` in place — verified by mutation:
+  // setting it to `CacheTTL.hour` fails this test.
+  it('leaves the membership-validity cache on its unchanged 10m TTL', async () => {
+    mockRedis.packed.mGet.mockResolvedValue([null]);
+    mockDbRead.customerSubscription.findMany.mockResolvedValue([sub(1, 'gold')]);
+
+    await getValidCreatorMembershipMap([1]);
+
+    expect(mockRedis.packed.set).toHaveBeenCalledWith(keyFor(1), true, {
+      EX: MEMBERSHIP_TTL_SECONDS,
+    });
+  });
+
+  it('uses two DIFFERENT TTLs for the two caches in one run', async () => {
+    // Membership first, then privacy defaults — both miss, both backfill.
+    mockDbRead.customerSubscription.findMany.mockResolvedValue([sub(1, 'gold')]);
+    mockDbRead.user.findMany.mockResolvedValue([{ id: 1, settings: {} }]);
+    await getValidCreatorMembershipMap([1]);
+    await getUserMetricPrivacyDefaultsMap([1]);
+
+    const ttlByKey = Object.fromEntries(
+      mockRedis.packed.set.mock.calls.map((c: unknown[]) => [
+        c[0] as string,
+        (c[2] as { EX: number }).EX,
+      ])
+    );
+    expect(ttlByKey[keyFor(1)]).toBe(MEMBERSHIP_TTL_SECONDS);
+    expect(ttlByKey[defaultsKeyFor(1)]).toBe(METRIC_PRIVACY_TTL_SECONDS);
+    // The whole point: they are not the same number.
+    expect(ttlByKey[keyFor(1)]).not.toBe(ttlByKey[defaultsKeyFor(1)]);
+  });
+});
+
+/**
+ * Hit/miss instrumentation for the metric-privacy defaults cache. Counted per USER ID,
+ * not per call, so the exported ratio is a true per-entry hit rate over a batched
+ * lookup. Without this the TTL change is unverifiable in production — the hit rate is
+ * the only signal that says whether raising it actually removed re-fetches.
+ */
+describe('getUserMetricPrivacyDefaultsMap — hit/miss instrumentation', () => {
+  it('counts a full cache hit and never touches the miss counter', async () => {
+    mockRedis.packed.mGet.mockResolvedValue([
+      { hideModelBuzz: true, hideModelDownloads: false, hideModelGenerations: false },
+    ]);
+
+    await getUserMetricPrivacyDefaultsMap([1]);
+
+    expect(cacheHitCounter.inc).toHaveBeenCalledWith(PRIVACY_CACHE_LABELS, 1);
+    expect(cacheMissCounter.inc).not.toHaveBeenCalled();
+  });
+
+  it('counts a full cache miss and never touches the hit counter', async () => {
+    mockRedis.packed.mGet.mockResolvedValue([null]);
+    mockDbRead.user.findMany.mockResolvedValue([{ id: 1, settings: {} }]);
+
+    await getUserMetricPrivacyDefaultsMap([1]);
+
+    expect(cacheMissCounter.inc).toHaveBeenCalledWith(PRIVACY_CACHE_LABELS, 1);
+    expect(cacheHitCounter.inc).not.toHaveBeenCalled();
+  });
+
+  it('counts per id, not per call, on a mixed batch (2 hits / 3 misses)', async () => {
+    // Distinct hit and miss counts, so a transposed or per-call implementation
+    // cannot produce this pair by accident.
+    mockRedis.packed.mGet.mockResolvedValue([
+      { hideModelBuzz: true, hideModelDownloads: false, hideModelGenerations: false },
+      null,
+      { hideModelBuzz: false, hideModelDownloads: true, hideModelGenerations: false },
+      null,
+      null,
+    ]);
+    mockDbRead.user.findMany.mockResolvedValue([{ id: 2, settings: {} }]);
+
+    await getUserMetricPrivacyDefaultsMap([1, 2, 3, 4, 5]);
+
+    expect(cacheHitCounter.inc).toHaveBeenCalledWith(PRIVACY_CACHE_LABELS, 2);
+    expect(cacheMissCounter.inc).toHaveBeenCalledWith(PRIVACY_CACHE_LABELS, 3);
+    expect(cacheHitCounter.inc).toHaveBeenCalledTimes(1);
+    expect(cacheMissCounter.inc).toHaveBeenCalledTimes(1);
+  });
+
+  it('counts a redis read failure as all-miss (the ids really do go to the db)', async () => {
+    mockRedis.packed.mGet.mockRejectedValue(new Error('redis down'));
+    mockDbRead.user.findMany.mockResolvedValue([{ id: 1, settings: {} }]);
+
+    await getUserMetricPrivacyDefaultsMap([1, 2]);
+
+    expect(cacheMissCounter.inc).toHaveBeenCalledWith(PRIVACY_CACHE_LABELS, 2);
+    expect(cacheHitCounter.inc).not.toHaveBeenCalled();
+  });
+
+  // INVARIANT GUARD, not regression coverage: trivially green pre-change (nothing was
+  // counted at all). It pins that the early-return for an empty batch stays ahead of the
+  // counting, so a caller passing no ids can never inflate the hit rate with a 0-hit,
+  // 0-miss sample.
+  it('records nothing at all for an empty input', async () => {
+    await getUserMetricPrivacyDefaultsMap([]);
+    expect(cacheHitCounter.inc).not.toHaveBeenCalled();
+    expect(cacheMissCounter.inc).not.toHaveBeenCalled();
   });
 });

--- a/src/server/services/creator-membership.service.ts
+++ b/src/server/services/creator-membership.service.ts
@@ -173,11 +173,21 @@ export type UserMetricPrivacyDefaults = {
  * Derived from an audit of every writer of the `User.settings` JSONB column, since that
  * is the only thing this cache derives from. The three `hideModel*` booleans are
  * written by exactly ONE path — `setUserSetting`, reached from the account
- * Creator-Controls toggles — and that path busts this key in the same call. The two
- * writers that touch `settings` WITHOUT going through `setUserSetting` provably cannot
- * move these flags: `setDismissedAlerts` uses a `jsonb_set` scoped to the
- * `{dismissedAlerts}` path, and `updateCreatorShopSettings` read-merge-writes the blob
- * from a fresh in-transaction row read, overriding only `creatorShop`.
+ * Creator-Controls toggles — and that path busts this key in the same call. The THREE
+ * writers that touch `settings` WITHOUT going through `setUserSetting` do not move
+ * these flags: `setDismissedAlerts` uses a `jsonb_set` scoped to the
+ * `{dismissedAlerts}` path; `updateCreatorShopSettings` and
+ * `copyGallerySettingsToAllModelsByUser` (`model.service.ts`) each read-merge-write the
+ * blob from a fresh in-transaction row read, overriding only their own key
+ * (`creatorShop` / `gallerySettings` respectively).
+ *
+ * One caveat on those last two, so nobody reads this as a stronger guarantee than it
+ * is: both are whole-blob read-modify-writes at READ COMMITTED with no `FOR UPDATE`,
+ * so a `setUserSetting` landing between their read and their update is silently
+ * reverted. That is a lost update on the ROW, not a stale cache — no TTL at any value
+ * helps, because the cache would then be faithfully reporting a wrong row. It is a
+ * real pre-existing bug and deliberately out of scope here; it just means the correct
+ * claim is "cannot move these flags absent a lost-update race", not "provably cannot".
  *
  * So the TTL is NOT bounding a bypassing writer. What it bounds is two ways a CORRECT
  * write can still leave a wrong value cached, and in both the TTL is the only thing
@@ -196,11 +206,16 @@ export type UserMetricPrivacyDefaults = {
  * short enough to be a blip rather than a support ticket, which rules out a multi-hour
  * value however clean the writer audit is.
  *
- * An hour is the balance. Going 10min -> 1h removes 5/6 of the periodic re-fetches; the
- * next step up to a day would remove only a further ~4% of the original churn, so nearly
- * all of the available win is already banked at an hour, at 1/24th the worst-case
- * staleness. Memory does not enter into it — the cached working set is a rounding error
- * against the total keyspace, and each entry is three booleans.
+ * An hour is the balance. Periodic re-fetch rate is proportional to 1/TTL, so per entry
+ * per hour: 10min = 6, 1h = 1, 1day = 0.0417. Going 10min -> 1h removes (6-1)/6 = 83%
+ * of the periodic re-fetches; the next step up to a day would remove a further
+ * (1-0.0417)/6 = ~16% of the original churn, reaching ~99% cumulative. So an hour banks
+ * most — not almost all — of the available win, at 1/24th the worst-case staleness, and
+ * that trade is what the privacy-control argument above decides. (An earlier revision of
+ * this comment said "~4%" for that second step; that is 1/24, the fraction of churn
+ * REMAINING at a day, not the additional fraction removed. Do not re-derive it that way.)
+ * Memory does not enter into it — the cached working set is a rounding error against the
+ * total keyspace, and each entry is three booleans.
  *
  * If the bust is ever made durable (retry / outbox), this can go up. Until then, do not
  * raise it without re-running the `User.settings` writer audit above.
@@ -212,12 +227,24 @@ const METRIC_PRIVACY_DEFAULTS_TTL = CacheTTL.hour;
  * counters. Counted PER USER ID (not per call) so the ratio is a true per-entry hit
  * rate over a batched lookup, matching how `createCachedArray` reports.
  *
- * NOTE FOR WHOEVER BUILDS THE DASHBOARD/ALERT: these are LABELLED counters, so a label
- * child does not exist in the registry until its first `.inc()` — at which point it is
- * already 1. A `rate()`/`increase()` can therefore never observe the 0->1 step. That is
- * harmless here because both children materialize on the first request a process
- * serves, but it does mean a freshly-started process reports nothing for this cache
- * until it has served one, and a query must not treat that gap as a real zero.
+ * 🔴 NOTE FOR WHOEVER BUILDS THE DASHBOARD/ALERT: these are LABELLED counters, so a
+ * label child does not exist in the registry until its first `.inc()` — at which point
+ * it is already 1. A `rate()`/`increase()` can therefore never observe the 0->1 step.
+ *
+ * It is NOT true that both children materialize on the first request (an earlier
+ * revision of this comment claimed that). Both increments below are conditional, so a
+ * single request can only create ONE child: an all-hits batch never touches the miss
+ * child, and an all-misses batch never touches the hit child. Redis is shared rather
+ * than per-pod, so a freshly-rolled pod starts against a WARM cache and can serve many
+ * requests before its first miss.
+ *
+ * The exposed side is therefore the MISS child, and it gets more exposed exactly as
+ * this cache succeeds — a longer TTL makes misses rarer, which is the whole point of
+ * the TTL above. The loss is bounded (one scrape interval of accumulation, once per pod
+ * per child, per pod lifetime) so it is small, but it is a systematic DOWNWARD bias on
+ * the series you would use to prove the TTL change worked. Read the miss series by
+ * VALUE (e.g. `max_over_time`) rather than by `rate()` if you need it to be exact, and
+ * never read a fresh pod's silence as a real zero.
  */
 const METRIC_PRIVACY_CACHE_NAME = 'user-metric-privacy-defaults';
 const METRIC_PRIVACY_CACHE_TYPE = 'redisPacked';

--- a/src/server/services/creator-membership.service.ts
+++ b/src/server/services/creator-membership.service.ts
@@ -1,6 +1,7 @@
 import { CacheTTL, constants } from '~/server/common/constants';
 import { env } from '~/env/server';
 import { dbRead } from '~/server/db/client';
+import { cacheHitCounter, cacheMissCounter } from '~/server/prom/client';
 import { redis, REDIS_KEYS } from '~/server/redis/client';
 import { subscriptionProductMetadataSchema } from '~/server/schema/subscriptions.schema';
 
@@ -35,6 +36,15 @@ import { subscriptionProductMetadataSchema } from '~/server/schema/subscriptions
 // missed path — including the one leak-direction gap, a referral-granted member who
 // also sets a metric-hide flag — self-heals quickly while still absorbing effectively
 // all hot-path read repetition (a creator's models are read many times per 10 min).
+//
+// 🔴 SCOPE: this constant is for the membership-validity cache ONLY. The
+// metric-privacy-defaults cache further down has its own `METRIC_PRIVACY_DEFAULTS_TTL`
+// and the two are deliberately DIFFERENT — do not re-merge them into one shared value.
+// Why they differ: a membership can go invalid on its OWN, with no write anywhere in
+// this app (a subscription simply lapses at its period end), so nothing can bust the
+// key at the moment its value stops being true — only a short TTL bounds that. The
+// privacy defaults, by contrast, only ever change via an explicit `settings` write,
+// which busts the key; its TTL is a backstop for a failed bust, not for silent decay.
 const MEMBERSHIP_CACHE_TTL = CacheTTL.md;
 
 const getMembershipValidCacheKey = (userId: number) =>
@@ -156,6 +166,62 @@ export type UserMetricPrivacyDefaults = {
   hideModelGenerations?: boolean;
 };
 
+/**
+ * TTL for the metric-privacy-defaults cache. DELIBERATELY NOT `MEMBERSHIP_CACHE_TTL` —
+ * see the scope note on that constant for why the two must stay separate.
+ *
+ * Derived from an audit of every writer of the `User.settings` JSONB column, since that
+ * is the only thing this cache derives from. The three `hideModel*` booleans are
+ * written by exactly ONE path — `setUserSetting`, reached from the account
+ * Creator-Controls toggles — and that path busts this key in the same call. The two
+ * writers that touch `settings` WITHOUT going through `setUserSetting` provably cannot
+ * move these flags: `setDismissedAlerts` uses a `jsonb_set` scoped to the
+ * `{dismissedAlerts}` path, and `updateCreatorShopSettings` read-merge-writes the blob
+ * from a fresh in-transaction row read, overriding only `creatorShop`.
+ *
+ * So the TTL is NOT bounding a bypassing writer. What it bounds is two ways a CORRECT
+ * write can still leave a wrong value cached, and in both the TTL is the only thing
+ * that ever restores correctness:
+ *
+ *   1. A FAILED BUST. `bustUserMetricPrivacyDefaultsCache` is best-effort and swallows
+ *      its own error so a cache problem can never fail the user's mutation — so a
+ *      dropped delete leaves the pre-write triple in place with nothing to retry it.
+ *   2. A REPLICA-LAG REFILL. The write goes to the primary and the key is deleted, but
+ *      the refill below reads `dbRead` (a replica). A refill that lands inside the
+ *      replication window re-caches the OLD triple, and this is not a rare interleaving
+ *      — it is exactly what happens when a user toggles the setting and immediately
+ *      reloads to check it took.
+ *
+ * Because these flags are a user-facing privacy control, that worst case has to stay
+ * short enough to be a blip rather than a support ticket, which rules out a multi-hour
+ * value however clean the writer audit is.
+ *
+ * An hour is the balance. Going 10min -> 1h removes 5/6 of the periodic re-fetches; the
+ * next step up to a day would remove only a further ~4% of the original churn, so nearly
+ * all of the available win is already banked at an hour, at 1/24th the worst-case
+ * staleness. Memory does not enter into it — the cached working set is a rounding error
+ * against the total keyspace, and each entry is three booleans.
+ *
+ * If the bust is ever made durable (retry / outbox), this can go up. Until then, do not
+ * raise it without re-running the `User.settings` writer audit above.
+ */
+const METRIC_PRIVACY_DEFAULTS_TTL = CacheTTL.hour;
+
+/**
+ * Cache-observability labels for the shared `civitai_app_cache_{hit,miss}_total`
+ * counters. Counted PER USER ID (not per call) so the ratio is a true per-entry hit
+ * rate over a batched lookup, matching how `createCachedArray` reports.
+ *
+ * NOTE FOR WHOEVER BUILDS THE DASHBOARD/ALERT: these are LABELLED counters, so a label
+ * child does not exist in the registry until its first `.inc()` — at which point it is
+ * already 1. A `rate()`/`increase()` can therefore never observe the 0->1 step. That is
+ * harmless here because both children materialize on the first request a process
+ * serves, but it does mean a freshly-started process reports nothing for this cache
+ * until it has served one, and a query must not treat that gap as a real zero.
+ */
+const METRIC_PRIVACY_CACHE_NAME = 'user-metric-privacy-defaults';
+const METRIC_PRIVACY_CACHE_TYPE = 'redisPacked';
+
 const getUserMetricPrivacyDefaultsCacheKey = (userId: number) =>
   `${REDIS_KEYS.CACHES.USER_METRIC_PRIVACY_DEFAULTS}:${userId}` as `${typeof REDIS_KEYS.CACHES.USER_METRIC_PRIVACY_DEFAULTS}:${string}`;
 
@@ -219,6 +285,21 @@ export async function getUserMetricPrivacyDefaultsMap(userIds: number[]) {
     else misses.push(id);
   });
 
+  // Per-id hit/miss so the hit rate is observable. A Redis read error lands entirely in
+  // `misses` (every id was reset to null above), which is the honest accounting — those
+  // ids do go to the DB.
+  const hits = unique.length - misses.length;
+  if (hits > 0)
+    cacheHitCounter.inc(
+      { cache_name: METRIC_PRIVACY_CACHE_NAME, cache_type: METRIC_PRIVACY_CACHE_TYPE },
+      hits
+    );
+  if (misses.length > 0)
+    cacheMissCounter.inc(
+      { cache_name: METRIC_PRIVACY_CACHE_NAME, cache_type: METRIC_PRIVACY_CACHE_TYPE },
+      misses.length
+    );
+
   if (misses.length === 0) return result;
 
   const fresh = await queryUserMetricPrivacyDefaults(misses);
@@ -233,7 +314,7 @@ export async function getUserMetricPrivacyDefaultsMap(userIds: number[]) {
       result.set(id, value);
       try {
         await redis.packed.set(getUserMetricPrivacyDefaultsCacheKey(id), value, {
-          EX: MEMBERSHIP_CACHE_TTL,
+          EX: METRIC_PRIVACY_DEFAULTS_TTL,
         });
       } catch {
         // Best-effort cache write; the TTL bounds any residual staleness.
@@ -246,8 +327,14 @@ export async function getUserMetricPrivacyDefaultsMap(userIds: number[]) {
 
 /**
  * Bust the cached metric-privacy defaults for one or more users. Wired into
- * `setUserSetting` so any change to a user's `hideModel*` defaults takes effect on the
- * next read; the TTL backstops any writer that bypasses `setUserSetting`.
+ * `setUserSetting`, which is the ONLY path that writes the `hideModel*` flags, so a
+ * change to a user's defaults takes effect on the next read.
+ *
+ * 🔴 This is best-effort by design — it swallows Redis errors so a cache problem can
+ * never fail the user's settings mutation. That makes it a non-guaranteed invalidation,
+ * and `METRIC_PRIVACY_DEFAULTS_TTL` the only bound on how long a swallowed delete can
+ * leave a user's privacy choice un-applied. Read the derivation on that constant before
+ * changing either side.
  */
 export async function bustUserMetricPrivacyDefaultsCache(userId: number | number[]) {
   const ids = (Array.isArray(userId) ? userId : [userId]).filter((id) => !!id);


### PR DESCRIPTION
## What

`getUserMetricPrivacyDefaultsMap` read-through caches the three `hideModel*` booleans so the hot model-read paths (feed, v1 list, associated models) stop fetching and deserializing every owner's full `User.settings` JSON blob per request — the fix from #3331, which is working.

Its TTL was `MEMBERSHIP_CACHE_TTL` — a constant it **shared** with the creator-membership-validity cache in the same module. That coupling made the TTL both too short for what it actually guards and impossible to tune without silently moving the other cache's staleness window too.

Three changes:

1. **Decoupled TTL** — new `METRIC_PRIVACY_DEFAULTS_TTL = CacheTTL.hour`. The membership cache stays on `CacheTTL.md` (10 min), unchanged. Both constants now carry a comment explaining why they differ, so nobody re-merges them.
2. **Hit/miss metric** — on the shared `civitai_app_cache_{hit,miss}_total` counters under `cache_name="user-metric-privacy-defaults"`, so the TTL change is actually verifiable instead of taken on faith.
3. **Tests** — pin both TTLs as literal seconds, and cover the hit/miss accounting.

## Why an hour — the `User.settings` writer audit

The value is derived from an audit, not picked by feel. This cache derives from exactly one column, so the question is: what can change `User.settings` without busting the key?

**The three `hideModel*` flags are written by exactly one path** — `setUserSetting`, reached from the account Creator-Controls toggles — and that path busts this cache in the same call. The other writers that touch `settings` without going through `setUserSetting` provably cannot move these three flags:

| Writer | Touches `settings` how | Can it move `hideModel*`? |
|---|---|---|
| `setUserSetting` | jsonb merge of the patch | Yes — **and it busts this cache** |
| `setDismissedAlerts` | `jsonb_set` scoped to `{dismissedAlerts}` | No — path-scoped |
| `updateCreatorShopSettings` | whole-blob read-merge-write, fresh in-transaction row read, overrides only `creatorShop` | No — preserves the other keys |
| `copyGallerySettingsToAllModelsByUser` | whole-blob read-merge-write, fresh in-transaction row read, overrides only its own key | No — same shape |

So **nothing bypasses the bust**, which by the usual reasoning would justify a very long TTL (a day). I don't think that follows here, for two reasons that are about the *invalidation*, not the writers:

1. **The bust is best-effort and swallows its own error.** `bustUserMetricPrivacyDefaultsCache` catches and discards Redis failures by design, so a settings mutation can never be failed by a cache problem. That also means a dropped delete never retries — the TTL is the only thing that restores correctness.
2. **The refill reads a replica.** The write lands on the primary and the key is deleted, but the miss-fill below reads `dbRead`. A refill inside the replication window re-caches the **old** triple. This isn't an exotic interleaving — it's what happens when a user toggles the setting and immediately reloads to check it took.

These flags are a user-facing privacy control, so the worst case has to stay a blip rather than a support ticket. That rules out a multi-hour value however clean the writer audit is.

An hour is where the curve flattens anyway: **10 min → 1 h removes 5/6 of the periodic re-fetches; 1 h → 1 day would remove only ~4% more of the original churn while multiplying the worst case by 24.** Nearly all the available win is banked at an hour. Memory doesn't enter into it — the cached working set is a rounding error against the total keyspace and each entry is three booleans.

If the bust is ever made durable (retry/outbox) and the refill reads the primary, this can go up. The comment on the constant says so.

## Labelled vs unlabelled counter

Used the **existing labelled** `cacheHitCounter`/`cacheMissCounter` rather than adding two new unlabelled ones.

The known trap with labelled counters is real: a label child doesn't exist in the registry until its first `.inc()`, at which point it's already `1`, so `rate()`/`increase()` can never observe the `0→1` step. That bites **rare** counters — one that first fires minutes or hours into a process's life.

This is a per-request counter on a hot read path, so both children materialize on the first request a process serves and `rate()` is well-defined from the next scrape onward. Against that, the labelled counters are what six other caches in the codebase already use, so this cache shows up in any existing `civitai_app_cache_*` query for free instead of fragmenting the family. The residual caveat — a freshly-started process reports nothing for this cache until it has served one request, and a query must not read that gap as a real zero — is written into a comment next to the label constants for whoever builds the dashboard.

Counted **per user id, not per call**, so the ratio is a true per-entry hit rate over a batched lookup (matching how `createCachedArray` reports).

## Tests — red→green

Every new test was watched fail against pre-change code. Reverting only the service file to `origin/main` and rerunning: **7 failed / 30 passed**.

| Test | at `origin/main` | at HEAD |
|---|---|---|
| `derives only the three hideModel* flags…` (existing, TTL expectation updated) | 🔴 | ✅ |
| `writes the metric-privacy defaults with its own 1h TTL` | 🔴 | ✅ |
| `uses two DIFFERENT TTLs for the two caches in one run` | 🔴 | ✅ |
| `counts a full cache hit and never touches the miss counter` | 🔴 | ✅ |
| `counts a full cache miss and never touches the hit counter` | 🔴 | ✅ |
| `counts per id, not per call, on a mixed batch (2 hits / 3 misses)` | 🔴 | ✅ |
| `counts a redis read failure as all-miss` | 🔴 | ✅ |
| `leaves the membership-validity cache on its unchanged 10m TTL` | ✅ **invariant guard** | ✅ |
| `records nothing at all for an empty input` | ✅ **invariant guard** | ✅ |

The last two are green on both sides — they're labelled in the file as invariant guards, not counted as regression coverage. They're still load-bearing, and mutation-tested rather than assumed:

- **M1** — re-merge the constants (`METRIC_PRIVACY_DEFAULTS_TTL = MEMBERSHIP_CACHE_TTL`) → 3 failed. The decoupling guard fires.
- **M2** — bump `MEMBERSHIP_CACHE_TTL` to `CacheTTL.hour` in place, i.e. exactly the trap this PR exists to prevent → 3 failed, including `leaves the membership-validity cache on its unchanged 10m TTL`. That's the proof the invariant guard is reachable and discriminating, not vacuous.
- **M3** — corrupt the hit count (`const hits = misses.length`) → 4 instrumentation tests failed.

## Gate

- **Typecheck** — `tsc --noEmit`: **0 errors**, exit 0.
- **Lint** — eslint on both changed files via `--format json` to confirm the files were actually processed (an empty text report is indistinguishable from a no-op): `files linted: 2`, **0 errors, 0 warnings** each.
- **Unit suite** — full `unit` project: **749 test files passed (749); 10813 passed | 1 skipped (10814)**; 0 failed. Grepped the output for `test timed out` / `panic` / unhandled errors: 0 hits, so no silent truncation.
- Target suite alone: **37 passed** (29 pre-existing + 8 new).

## Out of scope, noted while auditing

`updateCreatorShopSettings` writes `User.settings` but busts neither `userSettingsCache` nor anything else, so a shop-settings write can be served stale from `userSettingsCache` until its own TTL. Harmless for *this* cache (it can't move the `hideModel*` flags), but it looks like a real gap in the settings cache. Not touched here to keep this PR to one concern.
