### PR TITLE
docs(apps): record why `hasPage !== false` is NOT the safe narrowing for the chrome recents gate

### DIFF
--- a/src/components/Apps/recentAppsRail.ts
+++ b/src/components/Apps/recentAppsRail.ts
@@ -178,10 +178,32 @@ export type ChromeRecentApp = RecentApp & { blockId: string };
  *     `{id, blockId, name, iconUrl}` — NEITHER field. Its entries are therefore
  *     admitted here by ABSENCE (`undefined !== 'offsite'` is true), carrying no
  *     page evidence at all, which makes them the strongest case for the gate
- *     rather than an exception to it. Do not "tighten" this by adding a
- *     `hasPage` test: that would silently drop every legacy entry, which is the
- *     empty-a-returning-viewer's-list failure `resolveRecentApp` exists to
- *     avoid.
+ *     rather than an exception to it.
+ *
+ *     🔴 DO NOT ADD A `hasPage` TEST — NEITHER FORM, AND THE SECOND IS THE TRAP.
+ *     `hasPage === true` drops every legacy entry outright (they never recorded
+ *     the field), which is the empty-a-returning-viewer's-list failure
+ *     `resolveRecentApp` exists to avoid. `hasPage !== false` LOOKS like the
+ *     sound narrowing — it keeps the unhealed `undefined` and hides only apps
+ *     positively known to be page-less — but a STORED `false` does not mean what
+ *     it says. `handleOpenRecent` (`AppListingsMarketplaceBody`) persists
+ *     `resolveRecentApp`'s lossy `hasPage: entry.hasPage === true` straight back
+ *     into localStorage, so a stored `false` CONFLATES "the server says no page"
+ *     with "we had no evidence and discarded it". #3559's reconciliation heals
+ *     only the entries it MATCHES against the listings already loaded; a legacy
+ *     PAGE app outside that set (one `listAvailable` page, limit 24, narrowed
+ *     further by any kind/category filter) passes through untouched, resolves to
+ *     `false`, and the first rail click persists it — after which `!== false`
+ *     would hide a menu entry whose `/apps/run/<blockId>` still resolves
+ *     perfectly. Measured by executing the real functions, not by inspection.
+ *
+ *     The prerequisite that would make the narrowing sound: carry the TRI-STATE
+ *     through the rail so an unknown `hasPage` is persisted as `undefined`
+ *     rather than coerced to `false`. Until that lands the gate stays on `kind`
+ *     + `blockId`. And note what `!== false` would NOT have bought even then:
+ *     the legacy model-slot entry (no `hasPage`, no page, `undefined !== false`)
+ *     is admitted either way — closing that one needs the server's answer, not a
+ *     stricter read of the store.
  *
  *     Dark → the whole section is hidden (the menu has no second link shape to
  *     fall back to; the `/apps` rail, which does, keeps showing the same entries


### PR DESCRIPTION
## What

**Comment-only. Zero behaviour change** — every changed line in the diff is a `*`-prefixed doc line inside `selectChromeRecentApps`'s docstring. No code, no tests, no exports touched.

## Why

That docstring already said "do not tighten this by adding a `hasPage` test", but gave only the `=== true` reason: legacy entries never recorded the field, so `=== true` drops all of them.

After #3559 added reconciliation of legacy entries against loaded listings, that reason reads as obsolete — and `hasPage !== false` looks like the obvious narrowing that #3559 unlocked. It admits an unhealed `undefined` and hides only apps positively known to have no page, which would close the "menu offers a guaranteed-404 `/apps/run/<blockId>`" gap.

**It is not safe, and this PR writes down why** so the next person doesn't ship it.

`handleOpenRecent` (`AppListingsMarketplaceBody`) persists `resolveRecentApp`'s lossy `hasPage: entry.hasPage === true` straight back into localStorage. So a **stored** `false` conflates two different facts:

- the server says this app has no page, and
- we had no evidence and discarded it.

Reconciliation only heals the entries it *matches* against the listings already loaded (one `listAvailable` page, limit 24, narrowed further by any kind/category filter). A legacy **page** app outside that set passes through untouched, resolves to `false`, and the first rail click persists that `false`. After that, `!== false` would hide a menu entry whose `/apps/run/<blockId>` **still resolves perfectly** — a live regression, hiding something that works today.

The docstring now also records the prerequisite that would make the narrowing sound (carry the tri-state through the rail so an unknown `hasPage` persists as `undefined` rather than being coerced to `false`), and what it still would not buy: the legacy model-slot entry carries no `hasPage` at all, so `undefined !== false` admits it either way. Closing *that* one needs the server's answer, not a stricter read of the store.

## Provenance

The finding came out of an adversarial audit of #3559. The regression case was confirmed by **executing the real functions** (`reconcileRecentApps` → `selectRecentRailEntries` → `handleOpenRecent`'s exact payload), not by reading the code — the unmatched path persisted `hasPage: false` for an app that genuinely has a page.

## Testing

**No regression test is possible for a comment-only change, and none was invented.** There is deliberately no red→green matrix and no mutation results in this PR — a documentation change has no behaviour to mutate, and manufacturing either would be a false signal.

Gates actually run:

| Gate | Result |
|---|---|
| `pnpm typecheck` | **rc=0, 0 errors** — harness validated first with a deliberate type error (rc=2, correctly named the file) |
| `eslint` (changed file) | rc=0 |
| `prettier --check` (changed file) | clean |
| `vitest --project unit src/components/Apps/__tests__/` | **732 passed / 43 files, 0 failed** |

Those unit tests are green on **both** sides of this change, so they are an **invariant check, not evidence** for it. They are worth reporting only because `recentAppsRail.test.ts` (58 tests) and `recent-rail-glyph-single-source.test.ts` (9 tests) assert against the module's **source text**, so a docstring edit could plausibly have tripped them. It did not.

CI reality: `Typecheck`, `ESLint + Prettier (added files)` and the `event-engine-common` pin are the blocking gates. `Unit tests` is `continue-on-error` and `preview / component-tests` is both non-blocking and flaky — a green board on those is not coverage.
