### PR TITLE
fix(apps): make recents reconciliation monotonic so healed tiles stop un-healing

### DIFF
--- a/src/components/Apps/AppListingsMarketplaceBody.tsx
+++ b/src/components/Apps/AppListingsMarketplaceBody.tsx
@@ -1,7 +1,7 @@
 import { Button, Center, Grid, Group, Loader, Select, Stack, Text, TextInput } from '@mantine/core';
 import { useDebouncedValue } from '@mantine/hooks';
 import { IconSearch } from '@tabler/icons-react';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { AppListingCard } from '~/components/Apps/AppListingCard';
 import { LISTING_GRID_SPAN } from '~/components/Apps/appListingGrid';
 import { AppsStoreFiltersDropdown } from '~/components/Apps/AppsStoreFiltersDropdown';
@@ -11,6 +11,7 @@ import { RecentlyOpenedListingsView } from '~/components/Apps/RecentlyOpenedApps
 import {
   reconcileRecentApps,
   selectRecentRailEntries,
+  type RecentHealMemo,
   type ResolvedRecentApp,
 } from '~/components/Apps/recentAppsRail';
 import {
@@ -200,25 +201,59 @@ export function AppListingsMarketplaceBody() {
    * takes the server's answer from the matching card. Entries with no match on
    * the loaded pages pass through UNTOUCHED — never dropped.
    *
-   * 🔴 NO EFFECT, NO WRITE, NO LOOP. This is a pure derivation, deliberately not
-   * an effect that re-persists the repaired list. An effect writing the store on
-   * every `/apps` load would need a whole-list writer (`recordRecentlyOpenedApp`
-   * prepends, so looping it would REVERSE the rail) and would risk a write/render
-   * loop against state this component also reads. It buys nothing: the derivation
-   * re-runs on every load, and the store's other consumer — the app-chrome
-   * "Recently run" menu — filters on `kind`/`blockId`, which legacy entries
-   * already carry.
+   * 🔴 MONOTONIC, because the card set is FILTER- AND PAGE-SCOPED. `items` is
+   * `data.pages.flatMap(…)` from a query keyed on `{kind, category, sort, limit}`
+   * with no `keepPreviousData`/`placeholderData`, so every sort/filter change
+   * empties it for a beat. Reconciling against that raw would flip every healed
+   * tile play→eye→play on a control the viewer touched for an unrelated reason.
+   * The third argument below is a per-mount memo (the ref) of the last
+   * card-backed result per entry id, which makes a match a one-way ratchet: only
+   * ANOTHER card can change a healed entry, and the mere absence of one cannot.
+   * The memo is bounded to the ids currently in `recents` (≤ `MAX_RECENTS_TOTAL`).
+   * 🔴 It is not optional in practice — dropping it silently restores the
+   * un-healing bug, so a test in `__tests__/recentAppsRail.test.ts` scans this
+   * file and fails if the call goes back to two arguments.
+   *
+   * 🔴 NO EFFECT, NO WRITE, NO LOOP. This is a pure derivation over a ref-held
+   * cache, deliberately not an effect that re-persists the repaired list. An
+   * effect writing the store on every `/apps` load would need a whole-list writer
+   * (`recordRecentlyOpenedApp` prepends, so looping it would REVERSE the rail) and
+   * would risk a write/render loop against state this component also reads. It
+   * buys little: the derivation re-runs on every load.
+   *
+   * 🔴 AND IT WOULD NOT BUY THE CHROME MENU ANYTHING EITHER. The store's other
+   * consumer — the app-chrome "Recently run" menu — filters on `kind`/`blockId`,
+   * and a legacy entry carries `blockId` but NOT `kind`: `MarketplaceBody`'s
+   * `recordRecent` writes only `{id, blockId, name, iconUrl}`. Such entries are
+   * admitted by ABSENCE (`undefined !== 'offsite'` is true), not by carrying the
+   * field — see the 🔴 note on `selectChromeRecentApps`, which is the authority
+   * on that gate. So persisting `kind` would not change what that menu shows;
+   * what it would change is `hasPage`, which that menu deliberately never reads.
    *
    * The repair still PERSISTS on the natural interaction: `handleOpenRecent`
    * receives the RECONCILED entry, so the first click on a healed tile writes the
    * corrected `kind`/`hasPage`/`slug` back to localStorage.
    */
-  const reconciledRecents = useMemo(() => reconcileRecentApps(recents, items), [recents, items]);
+  const healedRecentsRef = useRef<RecentHealMemo>(new Map());
+  const reconciledRecents = useMemo(
+    () => reconcileRecentApps(recents, items, healedRecentsRef.current),
+    [recents, items]
+  );
   /**
-   * ⚠️ ACCEPTED: a SECOND post-paint update. The rail already hydrates one frame
-   * late (localStorage is client-only, seeded empty for SSR parity); this adds an
-   * update when the query resolves, so a tile's glyph can flip eye→play after
+   * ⚠️ ACCEPTED: ONE post-paint update per tile, and only ever in the healing
+   * direction. The rail already hydrates one frame late (localStorage is
+   * client-only, seeded empty for SSR parity); this adds an update when the query
+   * first resolves a matching card, so a tile's glyph can flip eye→play after
    * paint and its `aria-label` change may be re-announced by some assistive tech.
+   *
+   * What it is NOT is a flip-flop. Monotonic reconciliation means the emptying of
+   * `items` on a sort/filter change cannot un-heal a tile, so the glyph does not
+   * round-trip play→eye→play under a control the viewer touched for an unrelated
+   * reason. A healed tile can still change ONCE MORE, in exactly one case: its
+   * card reappears saying something DIFFERENT (the app lost its page). That is
+   * the server correcting us, and it is the whole point of correcting in both
+   * directions — not churn.
+   *
    * Accepted rather than mitigated, on three grounds:
    *   - NO LAYOUT SHIFT. The CTA is a fixed `ActionIcon size="md"` and both
    *     glyphs render at 16px, so the flip is a repaint, not a reflow — nothing

--- a/src/components/Apps/__tests__/recentAppsRail.test.ts
+++ b/src/components/Apps/__tests__/recentAppsRail.test.ts
@@ -10,6 +10,7 @@ import {
   selectChromeRecentApps,
   selectRecentRailEntries,
   toRecentAppFromListing,
+  type RecentHealMemo,
 } from '~/components/Apps/recentAppsRail';
 import type { RecentApp } from '~/components/Apps/recentlyOpenedAppsStore';
 import type { ListingCard } from '~/server/schema/blocks/app-listing-read.schema';
@@ -958,5 +959,200 @@ describe('reconcileRecentApps', () => {
     const entries = [legacy({ id: 'ab_pv', blockId: 'prompt-vault' }), legacy()];
     const out = reconcileRecentApps(entries, [onsiteCard()]);
     expect(out.map((e) => e.id)).toEqual(['ab_pv', 'ab_gm']);
+  });
+
+  it('🔴 an OFF-SITE entry does NOT consult the slug join — it would heal to the WRONG app', () => {
+    // An off-site listing has no AppBlock, so its `blockId` names nothing. No
+    // writer produces this shape today, but `coerce` accepts it, so a future one
+    // reopens the hole. Every value here is pairwise distinct EXCEPT the
+    // collision under test: the entry's stray `blockId` equals the ON-SITE
+    // card's slug, and the entry's own listing is not on the loaded pages.
+    const ghost: RecentApp = {
+      id: 'lst_ghost',
+      kind: 'offsite',
+      blockId: 'gen-matrix', // ← the collision: an on-site card's slug
+      slug: 'ghost-app',
+      name: 'Ghost App',
+      externalUrl: 'https://ghost.example/a',
+    };
+    const out = reconcileRecentApps([ghost], [onsiteCard()]);
+
+    // Untouched — not merged, not partially overwritten, not rebuilt.
+    expect(out[0]).toBe(ghost);
+    // The specific harm the gate prevents: taking the other app's identity.
+    expect(out[0].slug).toBe('ghost-app');
+    expect(out[0].name).toBe('Ghost App');
+    expect(out[0].kind).toBe('offsite');
+    // …and therefore never offering the on-site app's run link under this tile.
+    const resolved = resolveRecentApp(out[0])!;
+    expect(getRecentRailTarget(resolved, { canOpenPage: true }).href).toBe(
+      'https://ghost.example/a'
+    );
+  });
+
+  /**
+   * 🔴 MONOTONIC HEALING. Everything above reconciles against ONE card set. The
+   * caller's card set is filter- and page-scoped (`listAvailable` is keyed on
+   * `{kind, category, sort, limit}` with no `keepPreviousData`), so it EMPTIES on
+   * every sort/filter change and NARROWS whenever the viewer's app is on page 2
+   * or behind the active filter. These pin that neither can un-heal a tile.
+   */
+  describe('the `healed` memo — a match is a one-way ratchet across renders', () => {
+    /** The action a viewer sees for `entry`, through the real resolver. */
+    const actionOf = (entry: RecentApp) =>
+      getRecentRailAction(resolveRecentApp(entry)!, { canOpenPage: true }).action;
+
+    it('🔴 a healed entry SURVIVES the card set emptying (the sort/filter flip)', () => {
+      const healed: RecentHealMemo = new Map();
+      const [first] = reconcileRecentApps([legacy()], [onsiteCard()], healed);
+      expect(first).toMatchObject({ kind: 'onsite', hasPage: true, slug: 'gen-matrix' });
+
+      // The viewer changed `sort`. `data` goes undefined, so the caller passes
+      // []. WITHOUT the memo the `cards.length === 0` early return hands back the
+      // raw legacy entry and the tile reverts to an eye.
+      const [second] = reconcileRecentApps([legacy()], [], healed);
+      expect(second).toEqual(first);
+      expect(actionOf(second)).toBe('open');
+    });
+
+    it('🔴 THE ROUND-TRIP THE VIEWER SEES: play→eye→play never happens', () => {
+      const healed: RecentHealMemo = new Map();
+      const step = (cards: ListingCard[]) =>
+        actionOf(reconcileRecentApps([legacy()], cards, healed)[0]);
+
+      expect(step([])).toBe('view'); // first paint — the query has not resolved
+      expect(step([onsiteCard()])).toBe('open'); // heals
+      expect(step([])).toBe('open'); // sort change — pre-fix this was 'view'
+      expect(step([onsiteCard()])).toBe('open'); // the new page resolves
+    });
+
+    it('🔴 …and the card set merely NARROWING cannot un-heal either (page 2 / filtered out)', () => {
+      // Distinct from the empty case above: here cards ARE loaded, just not this
+      // app's, so no early return is involved — the entry simply matches nothing.
+      const healed: RecentHealMemo = new Map();
+      const other = onsiteCard({
+        id: 'lst_pv',
+        slug: 'prompt-vault',
+        name: 'Prompt Vault',
+        kindData: {
+          kind: 'onsite',
+          appBlockId: 'ab_pv',
+          hasPage: false,
+          liveUrl: 'https://prompt-vault.civit.ai',
+        },
+      });
+      reconcileRecentApps([legacy()], [onsiteCard()], healed);
+      const [out] = reconcileRecentApps([legacy()], [other], healed);
+      expect(actionOf(out)).toBe('open');
+      expect(out.slug).toBe('gen-matrix');
+      // Emphatically NOT the other app's identity.
+      expect(out.name).toBe('Gen Matrix');
+    });
+
+    it('🔴 a MATCH still BEATS the memo — correcting DOWN survives monotonicity', () => {
+      // The mutation-sensitive direction. An implementation where the memo wins
+      // passes every test above and fails this one, having pinned a play glyph on
+      // an app that has since lost its page — a guaranteed 404 under "Open".
+      const healed: RecentHealMemo = new Map();
+      reconcileRecentApps([legacy()], [onsiteCard()], healed);
+      const lostItsPage = onsiteCard({
+        kindData: {
+          kind: 'onsite',
+          appBlockId: 'ab_gm',
+          hasPage: false,
+          liveUrl: 'https://gen-matrix.civit.ai',
+        },
+      });
+      const [out] = reconcileRecentApps([legacy()], [lostItsPage], healed);
+      expect(out.hasPage).toBe(false);
+      expect(actionOf(out)).toBe('view');
+    });
+
+    it('🔴 THE BOUND: the memo holds one value per RECENTS entry, never the catalog', () => {
+      // 50 filter changes, each loading a different page of cards. If the
+      // implementation accumulated CARDS this would grow without limit.
+      const healed: RecentHealMemo = new Map();
+      const entries = [legacy(), legacy({ id: 'ab_pv', blockId: 'prompt-vault' })];
+      for (let i = 0; i < 50; i++) {
+        const page = onsiteCard({
+          id: `lst_${i}`,
+          slug: `app-${i}`,
+          kindData: {
+            kind: 'onsite',
+            appBlockId: `ab_${i}`,
+            hasPage: true,
+            liveUrl: 'https://x.civit.ai',
+          },
+        });
+        reconcileRecentApps(entries, [page, onsiteCard()], healed);
+        expect(healed.size).toBeLessThanOrEqual(entries.length);
+      }
+      // Only the entry that actually matched is remembered — one, not 51.
+      expect([...healed.keys()]).toEqual(['ab_gm']);
+    });
+
+    it('🔴 THE BOUND: an id the recents no longer contain is DROPPED, not retained', () => {
+      const healed: RecentHealMemo = new Map();
+      reconcileRecentApps([legacy()], [onsiteCard()], healed);
+      expect([...healed.keys()]).toEqual(['ab_gm']);
+
+      // The viewer ran 8 other apps; `ab_gm` rolled off the capped store. It can
+      // never be consulted again, so keeping it is pure leak.
+      reconcileRecentApps([legacy({ id: 'ab_pv', blockId: 'prompt-vault' })], [], healed);
+      expect(healed.has('ab_gm')).toBe(false);
+      expect(healed.size).toBe(0);
+    });
+
+    it('the memo is only ever WRITTEN from a card — an unmatched entry seeds nothing', () => {
+      const healed: RecentHealMemo = new Map();
+      reconcileRecentApps(
+        [legacy({ id: 'ab_pv', blockId: 'prompt-vault' })],
+        [onsiteCard()],
+        healed
+      );
+      expect(healed.size).toBe(0);
+    });
+
+    it('OMITTING the memo is exactly the old behaviour (the 2-arg calls above still hold)', () => {
+      // Invariant guard, not a regression test: it pins that adding the
+      // parameter changed nothing for a caller that does not pass it.
+      const entries = [legacy()];
+      expect(reconcileRecentApps(entries, [])).toBe(entries);
+      expect(reconcileRecentApps(entries, [onsiteCard()])).toEqual(
+        reconcileRecentApps(entries, [onsiteCard()], new Map())
+      );
+    });
+  });
+
+  /**
+   * 🔴 The memo is an OPTIONAL parameter, so the un-healing bug is one deleted
+   * argument away and would pass every test above. This scans the one production
+   * call site, the same way the chrome-mount gate is scanned earlier in this file.
+   */
+  describe('the /apps store is actually WIRED to the monotonic form', () => {
+    const source = fs
+      .readFileSync(
+        path.resolve(__dirname, '../../..', 'components/Apps/AppListingsMarketplaceBody.tsx'),
+        'utf8'
+      )
+      // Strip comments — that file's prose names these symbols repeatedly, and
+      // matching prose would scope the assertion to a doc-comment, not to code.
+      .replace(/\/\*[\s\S]*?\*\//g, '')
+      .replace(/^[ \t]*\/\/.*$/gm, '');
+
+    it('found the call site (the scan itself must not silently match nothing)', () => {
+      expect(source.length).toBeGreaterThan(1000);
+      expect(source).toMatch(/reconcileRecentApps\(/);
+    });
+
+    it('🔴 passes a cross-render memo — a two-arg call restores the un-healing bug', () => {
+      expect(source).toMatch(/reconcileRecentApps\(\s*recents,\s*items,\s*[A-Za-z0-9_.]+\s*\)/);
+    });
+
+    it('🔴 holds that memo in a REF — module state would leak across mounts', () => {
+      // `useState`/a module-level Map would either not survive re-render or would
+      // outlive the mount and be shared between two stores.
+      expect(source).toMatch(/useRef<RecentHealMemo>\(\s*new Map\(\)\s*\)/);
+    });
   });
 });

--- a/src/components/Apps/recentAppsRail.ts
+++ b/src/components/Apps/recentAppsRail.ts
@@ -244,10 +244,23 @@ export type RecentReconcileCard = Pick<
  *      on-site writers key `id` on the AppBlock id (see `toRecentAppFromListing`).
  *   2. `entry.id` → `card.id`. The off-site contract — an off-site listing has no
  *      AppBlock, so the AppListing id is its only key.
- *   3. `entry.blockId` (else `entry.slug`) → `card.slug`. For an on-site app the
- *      listing slug IS the AppBlock `block_id` (`app-listing-mapper.ts` →
- *      `slug: ab.blockId`), which is what makes the legacy `{id, blockId}` shape
- *      joinable at all.
+ *   3. `entry.blockId` (else `entry.slug`) → `card.slug`, **ON-SITE ENTRIES
+ *      ONLY**. For an on-site app the listing slug IS the AppBlock `block_id`
+ *      (`app-listing-mapper.ts` → `slug: ab.blockId`), which is what makes the
+ *      legacy `{id, blockId}` shape joinable at all.
+ *
+ *      🔴 WHY IT IS GATED ON `kind !== 'offsite'`. An off-site listing has no
+ *      AppBlock, so an off-site entry's `blockId` is meaningless BY
+ *      CONSTRUCTION — there is no app it could name. Consulting it anyway means
+ *      an off-site entry carrying a stray `blockId` (hand-edited localStorage,
+ *      or a future writer — `coerce` accepts the shape even though none of
+ *      today's four writers produces it), whose own listing is not on the loaded
+ *      pages, falls through both id joins and `bySlug`-matches a DIFFERENT,
+ *      ON-SITE app. Reconciliation replaces an entry wholesale, so that is not a
+ *      cosmetic mismatch: the tile takes the other app's name, slug and
+ *      `/apps/run/…` href. `undefined` is the only honest handle here. (Note the
+ *      asymmetry with key 2, which is deliberately NOT gated: an off-site entry
+ *      SHOULD still join its own listing by id.)
  *
  * 🔴 UPGRADE, NEVER DROP. An entry that matches nothing is returned UNTOUCHED.
  * A recents entry is not evidence a listing is missing — it is far more likely on
@@ -268,13 +281,108 @@ export type RecentReconcileCard = Pick<
  * place. Two properties follow and are pinned by tests: `id` is preserved (it is
  * the de-dup key and the rail's ordering handle, so reconciliation must not churn
  * it), and the function is IDEMPOTENT — reconciling a reconciled list is a no-op.
+ *
+ * ────────────────────────────────────────────────────────────────────────────
+ * 🔴 `healed` — PASS IT. It is what makes the repair MONOTONIC across renders,
+ * and the one production caller (`AppListingsMarketplaceBody`) is pinned to pass
+ * it by a test in this module's suite.
+ *
+ * THE DEFECT IT FIXES — healed tiles UN-HEAL. Everything above is scoped to the
+ * cards the caller has loaded, and that set is FILTER- AND PAGE-SCOPED: `items`
+ * is `data.pages.flatMap(…)` off a `listAvailable` infinite query keyed on
+ * `{kind, category, sort, limit}`, with no `keepPreviousData`/`placeholderData`
+ * anywhere in that component or `~/utils/trpc`. So EVERY sort/filter change
+ * takes `data` to `undefined` for a beat → the caller passes `[]` → without a
+ * memo the `cards.length === 0` early return hands back the raw legacy entries →
+ * every healed tile reverts to an eye and an `/apps/store-preview/…` href, then
+ * flips back when the new page resolves. The rail's glyphs became a function of
+ * an unrelated control below them, round-tripping play→eye→play. The same
+ * scoping strands a recents app that is on page 2, or excluded by the active
+ * `kind`/`category`, on an eye until "Load more".
+ *
+ * THE REPAIR — remember the RESULT, not the cards. An entry that matches a card
+ * is reconciled exactly as above and its result recorded in `healed`; an entry
+ * that matches NOTHING falls back to its remembered result, and only then to
+ * itself. Healing is a one-way ratchet: only ANOTHER card can change a healed
+ * entry, and the mere absence of one — which is a fact about the QUERY, never
+ * about the app — cannot.
+ *
+ * 🔴 WHY MEMOISE THE RESULT RATHER THAN ACCUMULATE THE CARDS. Accumulating every
+ * card seen across the mount also works and is the obvious move, but its
+ * footprint is the CATALOG (every page loaded × every filter visited, unbounded
+ * and almost entirely irrelevant), and pruning it back down needs the match
+ * information anyway. The result memo is bounded BY CONSTRUCTION: one value per
+ * recents entry, and the loop below deletes every key not in `entries`, so
+ * `healed.size <= entries.length`. `entries` is `getRecentlyOpenedApps()`, which
+ * caps per kind on READ as well as on write, so the ceiling is
+ * `MAX_RECENTS_TOTAL` (16) small objects, living only as long as one mount.
+ *
+ * 🔴 STILL NO WRITE, NO EFFECT, NO LOOP. A pure derivation over a caller-held
+ * cache; nothing here touches `localStorage`. Persistence stays exactly where it
+ * was — `handleOpenRecent`, on a real click.
+ *
+ * 🔴 WHY A REMEMBERED VALUE CANNOT BE STALER THAN THE ENTRY. The memo is
+ * per-mount, and within one mount `recents` changes by exactly one path:
+ * `handleOpenRecent`, which re-persists the ALREADY-RECONCILED entry it was
+ * handed. So an entry can never carry fresher server truth than its own memo
+ * hit. The only other writer of `hasPage` is a real visit to `/apps/run/<slug>`,
+ * which is a navigation — it remounts the store and starts the memo empty.
+ *
+ * Correction-in-both-directions is UNAFFECTED: a match always beats the memo, so
+ * an app that has lost its page still loses the play glyph the instant its card
+ * is on screen.
  */
 export function reconcileRecentApps(
   entries: RecentApp[],
-  cards: RecentReconcileCard[]
+  cards: RecentReconcileCard[],
+  healed?: RecentHealMemo
 ): RecentApp[] {
-  if (entries.length === 0 || cards.length === 0) return entries;
+  if (entries.length === 0) return entries;
+  // Without a memo there is nothing to fall back to, so no cards means no work.
+  // (With one, an empty card set is exactly the case the memo exists to cover.)
+  if (!healed && cards.length === 0) return entries;
 
+  const index = buildRecentCardIndex(cards);
+  const live = new Set<string>();
+
+  const out = entries.map((entry) => {
+    live.add(entry.id);
+    const card = matchRecentCard(entry, index);
+    if (card) {
+      const upgraded = upgradeRecentFromCard(entry, card);
+      healed?.set(entry.id, upgraded);
+      return upgraded;
+    }
+    return healed?.get(entry.id) ?? entry;
+  });
+
+  // THE BOUND. An id the viewer's recents no longer contain can never be
+  // consulted again, so it is dropped rather than accumulated.
+  if (healed) {
+    for (const id of healed.keys()) {
+      if (!live.has(id)) healed.delete(id);
+    }
+  }
+
+  return out;
+}
+
+/**
+ * The caller-owned, cross-render cache `reconcileRecentApps` reads and writes:
+ * entry `id` → the last card-backed reconciliation of that entry. Deliberately a
+ * plain `Map` the caller holds in a `useRef`, not module state — two mounted
+ * stores must not share a cache, and it must die with the mount.
+ */
+export type RecentHealMemo = Map<string, RecentApp>;
+
+/** The three join namespaces `matchRecentCard` looks in. */
+type RecentCardIndex = {
+  byAppBlockId: Map<string, RecentReconcileCard>;
+  byListingId: Map<string, RecentReconcileCard>;
+  bySlug: Map<string, RecentReconcileCard>;
+};
+
+function buildRecentCardIndex(cards: RecentReconcileCard[]): RecentCardIndex {
   const byAppBlockId = new Map<string, RecentReconcileCard>();
   const byListingId = new Map<string, RecentReconcileCard>();
   const bySlug = new Map<string, RecentReconcileCard>();
@@ -288,21 +396,35 @@ export function reconcileRecentApps(
       if (appBlockId && !byAppBlockId.has(appBlockId)) byAppBlockId.set(appBlockId, card);
     }
   }
+  return { byAppBlockId, byListingId, bySlug };
+}
 
-  return entries.map((entry) => {
-    const handle = entry.blockId ?? entry.slug;
-    const card =
-      byAppBlockId.get(entry.id) ??
-      byListingId.get(entry.id) ??
-      (handle ? bySlug.get(handle) : undefined);
-    if (!card) return entry;
+/**
+ * The join itself — the three keys documented on `reconcileRecentApps`, in
+ * order. Split out so WHICH card an entry matches is one decision in one place,
+ * separate from what is then done with it.
+ */
+function matchRecentCard(
+  entry: RecentApp,
+  index: RecentCardIndex
+): RecentReconcileCard | undefined {
+  // 🔴 ON-SITE ONLY — see match key 3. An off-site listing has no AppBlock, so an
+  // off-site entry's `blockId` names nothing; consulting it would `bySlug`-match
+  // a DIFFERENT, on-site app and replace the entry with it.
+  const handle = entry.kind === 'offsite' ? undefined : entry.blockId ?? entry.slug;
+  return (
+    index.byAppBlockId.get(entry.id) ??
+    index.byListingId.get(entry.id) ??
+    (handle ? index.bySlug.get(handle) : undefined)
+  );
+}
 
-    const upgraded: RecentApp = { ...toRecentAppFromListing(card), id: entry.id };
-    // The card's `iconUrl` is nullable; a previously-recorded icon is better than
-    // none, so it is the one field the entry can still contribute.
-    if (!upgraded.iconUrl && entry.iconUrl) upgraded.iconUrl = entry.iconUrl;
-    return upgraded;
-  });
+function upgradeRecentFromCard(entry: RecentApp, card: RecentReconcileCard): RecentApp {
+  const upgraded: RecentApp = { ...toRecentAppFromListing(card), id: entry.id };
+  // The card's `iconUrl` is nullable; a previously-recorded icon is better than
+  // none, so it is the one field the entry can still contribute.
+  if (!upgraded.iconUrl && entry.iconUrl) upgraded.iconUrl = entry.iconUrl;
+  return upgraded;
 }
 
 export type RecentRailTarget = {


### PR DESCRIPTION
Three follow-ups to #3559, found by an adversarial audit of that PR. Each was re-verified against the source before acting.

## 1. 🟡 Reconciliation was filter- and page-scoped, so healed tiles UN-healed

`AppListingsMarketplaceBody` reconciles against `items` — `data.pages.flatMap(...)` from a `listAvailable` infinite query keyed on `{kind, category, sort, limit}`. There is no `keepPreviousData` / `placeholderData` in that component or in `~/utils/trpc` (verified). So on **any** sort or filter change:

`data` → `undefined` → `items` → `[]` → `reconcileRecentApps` hits its `cards.length === 0` early return → **every healed tile reverts to an eye + `/apps/store-preview/…`**, then flips back when the new page resolves.

Net effect: the rail's icons were a function of an unrelated control below them, and a sort change caused a play → eye → play round-trip. The same scoping stranded a recents app that was on page 2, or excluded by the active `kind`/`category`, on an eye until "Load more".

**The fix — a one-way ratchet.** `reconcileRecentApps` takes an optional `healed` memo (entry `id` → the last card-backed reconciliation of that entry). A match is recorded there; an entry that matches nothing falls back to its remembered result and only then to itself. Only *another card* can change a healed entry — the *absence* of one is a fact about the query, never about the app. Correcting DOWN is unaffected: a live match always beats the memo, so an app that has lost its page still loses its play glyph the instant its card is on screen.

**How it is bounded** — by construction, and deliberately *not* by accumulating cards. Accumulating every card seen across the mount also works and is the obvious move, but its footprint is the **catalog** (every page loaded × every filter visited), and pruning it back down needs the match information anyway. The result memo holds **one value per recents entry**, and every key not in `entries` is deleted on each call, so `healed.size <= entries.length`. `entries` is `getRecentlyOpenedApps()`, which caps per kind on READ as well as on write, so the ceiling is `MAX_RECENTS_TOTAL` (16) small objects, for the lifetime of one mount.

Constraints held: **no store write, no effect, no loop** — persistence stays exactly where it was, in `handleOpenRecent` on a real click. `getRecentRailAction` / `getRecentRailTarget` are **untouched**, so icon, accessible label and href stay derived from one call.

The memo is an *optional* parameter, which means the bug is one deleted argument away, so a source-scan test (same idiom as the existing chrome-mount scan in this suite) fails if the call site goes back to two arguments or stops holding the memo in a ref.

The `⚠️ ACCEPTED` note now describes what actually happens: one post-paint update per tile, in the healing direction only, with the play→eye→play round-trip explicitly ruled out — and the one remaining second change (a card reappearing to say the app lost its page) named as the server correcting us rather than churn.

## 2. 🟡 A comment that was factually wrong and contradicted its neighbour

`AppListingsMarketplaceBody` claimed the app-chrome "Recently run" menu *"filters on `kind`/`blockId`, which legacy entries already carry."*

Legacy entries carry `blockId` but **not** `kind` — `MarketplaceBody.recordRecent` writes only `{id, blockId, name, iconUrl}` (verified at the source). They are admitted by **absence** (`undefined !== 'offsite'`). That directly contradicted the paragraph #3555 added to `selectChromeRecentApps`, which spells this out.

Corrected on this side only, and pointed at that docstring as the authority. The `recentAppsRail.ts` docstring is untouched.

## 3. 🟡 The slug join was consulted for off-site entries (one line)

`const handle = entry.blockId ?? entry.slug` ran unconditionally. An off-site entry carrying a stray `blockId`, whose own listing was not on the loaded pages, fell through both id joins and `bySlug`-matched a **different, on-site app** — which then replaced it wholesale (name, slug, href).

No current writer produces `{kind:'offsite', blockId}` (all four were traced), but `coerce()` accepts the shape, so a future writer reopens it. An off-site listing has no AppBlock, so its `blockId` is meaningless by construction. The join is now gated on `kind !== 'offsite'`.

Key 2 (`entry.id` → `card.id`) is deliberately **not** gated — an off-site entry should still join its own listing by id. The existing test that pins that is the positive control, and mutating the gate to `!== 'onsite'` (which would silently kill every legacy entry) is caught.

Also splits the join out of `reconcileRecentApps` into `buildRecentCardIndex` / `matchRecentCard` / `upgradeRecentFromCard`, so *which card an entry matches* is one decision in one place.

## Tests — red→green matrix

+12 tests in the node `unit` project (70 total in this file, was 58). Run against `dd888989fb`'s source with this test file in place:

| | pre-change | here |
|---|---|---|
| **8 regression tests** | **RED** | green |
| 4 invariant guards (labelled) | green | green |

The 8 red ones failed for the right reason, not incidentally:

- off-site mis-heal → `expected { slug: 'gen-matrix', … } to be { id: 'lst_ghost', … }`
- monotonic (emptying, narrowing, round-trip) → `expected 'view' to be 'open'`
- the two bound tests → `expected [] to deeply equal [ 'ab_gm' ]`
- the two wiring scans → regex did not match the 2-arg call site

The 4 green-on-both are **invariant guards, labelled as such in the test names/comments, and are not counted as regression coverage**: "a MATCH still BEATS the memo" (the mutation-killer for a memo-wins implementation), "the memo is only ever WRITTEN from a card", "OMITTING the memo is exactly the old behaviour", and the source scan's own positive control.

Fixtures are pairwise distinct (`lst_gm` / `gen-matrix` / `ab_gm`) — the only shared value is the deliberate collision under test in the off-site case, which is the whole point of that test.

**Mutation matrix — 8 mutants, 8 killed, 0 survivors**, each by its own guard's test:

| mutant | killed by |
|---|---|
| drop the off-site gate | off-site mis-heal test |
| over-gate it (`!== 'onsite'`) | the legacy `blockId → card.slug` join test |
| never READ the memo | 3 monotonic tests |
| never WRITE the memo | 3 monotonic + 2 bound tests |
| let the memo win over a live match | "a MATCH still BEATS the memo" |
| never prune the memo | "an id the recents no longer contain is DROPPED" |
| restore the unconditional empty-cards early return | 2 monotonic + 1 bound test |
| call site drops the memo argument | the wiring scan |

The harness ran an unmutated control first (70/70 green), asserted each patch actually applied (a no-op patch would masquerade as a survivor), and asserted each run still totalled 70 tests (a truncated run would read as a pass).

`recentAppsRail.test.ts`'s `🔴 NEVER disagrees with getRecentRailTarget, across the whole matrix` still passes unweakened.

## Verification

- `pnpm typecheck` — clean.
- Unit project (full): **752 files, 10898 passed, 1 skipped, 0 failed**.
- Browser/component suites touching this surface, run locally: **98/98** across `AppListingsMarketplaceBody{,.recentsReconcile,.hydration,.urlState}`, `RecentlyOpenedApps{,.reducedMotion}`, `recents-helper`, `MarketplaceBody`, `AppBlockChrome`.
- Prettier + ESLint clean on all three files.

## CI reality — please don't read the board as coverage

Blocking: `event-engine-common pin`, `Typecheck`, `ESLint + Prettier (added files)` (this PR adds no files, so that job is vacuous here). **Not** blocking: `Unit tests` (`continue-on-error: true`, `.github/workflows/lint.yml:198`), lint on modified files, and `preview / component-tests` — which is additionally flaky, with a failing subset that differs run to run. The unit and browser numbers above are from local runs, which is where the actual evidence for this change is.

## Not verified

I did not drive the real `/apps` page in a browser and change the sort with a legacy entry in `localStorage`. The defect and the fix are pinned at the view-model layer plus a source scan of the wiring; the end-to-end click path is unconfirmed.
