### PR TITLE
feat(app-blocks/steps): bound the resolved variant at request time + record the step/variant usage dimensions

### DIFF
--- a/src/server/routers/__tests__/blocks.router.workflow.test.ts
+++ b/src/server/routers/__tests__/blocks.router.workflow.test.ts
@@ -6558,6 +6558,34 @@ describe("step-type registry bridge (kind: 'step')", () => {
       );
     });
 
+    // 🔴 THE USAGE DIMENSIONS. Every OTHER field on this row is identical to the
+    // one the txt2img path writes — same `ai:write:budgeted` scope, same
+    // `workflow:submit:<id>` endpoint shape — so without `detail.step` a step
+    // submit and a txt2img submit are indistinguishable in
+    // `block_scope_invocations`, and two step types are indistinguishable from
+    // each other. `detail` is a nullable JSON column, so this needs no migration.
+    //
+    // `variant` is the registry's resolved variant, BOUNDED by
+    // `resolveStepVariant`. For `convert-image` it is `'default'` — real, if
+    // uninformative, so this assertion is genuine coverage of the shipped
+    // population rather than a guard waiting on a future entry.
+    it('records the step id and the resolved variant on the audit row (per-(user, app, capability) usage)', async () => {
+      vi.mocked(recordScopeInvocation).mockClear();
+      mockVerifyBlockToken.mockResolvedValue(stepClaims());
+      happyUser();
+      happyStepSubmit();
+      await caller().submitWorkflow({ blockToken: 'tok', body: stepBody() });
+      await new Promise((r) => setTimeout(r, 0)); // fire-and-forget writes
+      await vi.waitFor(() => expect(vi.mocked(recordScopeInvocation)).toHaveBeenCalled());
+      const auditArg = vi.mocked(recordScopeInvocation).mock.calls[0][0];
+      expect(auditArg.detail).toMatchObject({
+        action: 'workflow.submit',
+        outcome: 'ok',
+        step: STEP_ID,
+        variant: 'default',
+      });
+    });
+
     it('emits the step id (never txt2img) as the workflow-type tag, preserving app-block provenance', async () => {
       mockVerifyBlockToken.mockResolvedValue(stepClaims());
       happyUser();

--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -6515,6 +6515,14 @@ async function assertStepRequestAllowed(claims: BlockClaims): Promise<number> {
  *
  * Fail-closed on an out-of-bounds param (BAD_REQUEST via `parseStepParams`),
  * exactly as submit does — the same `.strict()` schema runs on both paths.
+ *
+ * 🔴 AND fail-closed on an out-of-set VARIANT, which it previously was not.
+ * `estimateStepBuzz` resolves through `resolveStepVariant` before dispatching, so
+ * a resolution outside the entry's declared `variants` throws here exactly as it
+ * does on submit. Before that bound existed the two paths disagreed: for an entry
+ * whose variant is its model, an out-of-set model returned HTTP 200 with
+ * `cost: { total: undefined }` here while the submit threw — estimate/submit
+ * drift on the surface whose entire job is to predict the submit.
  */
 async function estimateStepWorkflow(opts: { claims: BlockClaims; body: StepBody }) {
   const { claims, body } = opts;
@@ -6614,10 +6622,31 @@ async function submitStepWorkflow(opts: {
 
   const token = await getOrchestratorToken(userId, ctx);
 
+  // ── THE RESOLVED VARIANT — derived ONCE, HERE, before any reservation exists.
+  //
+  // 🔴 WHY IT IS HOISTED RATHER THAN CALLED AT EACH USE. Three consumers key off
+  // this value (the price lookup below, the settle `engine`, and the usage audit
+  // row), and it used to be re-derived at each of them — against the registry's
+  // own stated invariant that there is a SINGLE source of truth for "which
+  // variant did this submit resolve to?". Re-deriving is not merely wasteful: a
+  // resolver that is not a pure function of `params` could answer differently at
+  // each site, so the row would record a variant the caller was not charged for.
+  //
+  // 🔴 AND WHY THE POSITION MATTERS. `resolveStepVariant` THROWS on an out-of-set
+  // resolution. Resolved here, that throw lands before the orchestrator quote and
+  // before every reservation — nothing to refund. The audit-row derivation it
+  // replaces sits inside a `void (async () => …)().catch(() => {})` AFTER the
+  // submit is billed, where the same throw would have been silently swallowed
+  // with the money already committed.
+  //
+  // Order-preserving: `planStepSpend` resolved this internally, as its first act,
+  // at exactly this point in the sequence.
+  const variant = resolveStepVariant(step, params);
+
   // ── SPEND PLAN — dispatched on the entry's declared BILLING MODE. This is the
   // single place the money shape is decided; the rest of this function is
   // mode-agnostic and never re-inspects `billingMode`.
-  const plan = planStepSpend(step, params);
+  const plan = planStepSpend(step, params, variant);
   const declaredBuzz = Math.ceil(plan.reserveBuzz);
 
   // Built ONCE, then used for the quote and the real submit, so the two can
@@ -7057,8 +7086,10 @@ async function submitStepWorkflow(opts: {
       appSpendKey: appSpendReserve?.key ?? null,
       ...(devSessionReserve ? { devSessionId: devSessionReserve.sessionId } : {}),
       ceiling: reserveBuzz,
-      // Bounded to the entry's declared `variants` — see `resolveStepVariant`.
-      engine: resolveStepVariant(step, params),
+      // The ONE derivation hoisted to the top of this function — bounded to the
+      // entry's declared `variants` by `resolveStepVariant`, and the same value
+      // the reservation was priced from.
+      engine: variant,
       recipe: step.id,
       submittedAt,
     });
@@ -7129,11 +7160,16 @@ async function submitStepWorkflow(opts: {
           amount: typeof invocationCost === 'number' ? -Math.abs(invocationCost) : undefined,
           outcome: snapshot.status === 'failed' ? 'failed' : 'ok',
           step: step.id,
-          // Bounded to the entry's declared `variants` — that wrapper, not the
-          // entry's promise, is what makes this safe to persist. For an entry
-          // that makes its model its variant this IS the model; for
+          // 🔴 THE HOISTED VALUE, not a fresh resolution. Bounded to the entry's
+          // declared `variants` by `resolveStepVariant` — that wrapper, not the
+          // entry's promise, is what makes it safe to persist — and identical by
+          // construction to the one the reservation was priced from, which is the
+          // only thing that makes this row a usable billing dimension. Resolving
+          // it HERE would also put a throwing call inside this swallowed
+          // fire-and-forget block, after the submit is already billed. For an
+          // entry that makes its model its variant this IS the model; for
           // `convert-image` it is always `'default'`.
-          variant: resolveStepVariant(step, params),
+          variant,
         },
         dev: claims.dev === true,
       });

--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -152,6 +152,7 @@ import {
   estimateStepBuzz,
   getStep,
   planStepSpend,
+  resolveStepVariant,
 } from '~/server/services/blocks/steps';
 // Moderation dispatch for the same registry. A SEPARATE module because it pulls
 // `auditPromptServer` (Redis + ClickHouse + DB + notifications) and the registry
@@ -7056,7 +7057,8 @@ async function submitStepWorkflow(opts: {
       appSpendKey: appSpendReserve?.key ?? null,
       ...(devSessionReserve ? { devSessionId: devSessionReserve.sessionId } : {}),
       ceiling: reserveBuzz,
-      engine: step.resolveVariant(params),
+      // Bounded to the entry's declared `variants` — see `resolveStepVariant`.
+      engine: resolveStepVariant(step, params),
       recipe: step.id,
       submittedAt,
     });
@@ -7106,10 +7108,32 @@ async function submitStepWorkflow(opts: {
         scope: 'ai:write:budgeted',
         endpoint: `workflow:submit:${snapshot.workflowId || 'pending'}`,
         statusCode: snapshot.status === 'failed' ? 500 : 200,
+        // 🔴 THE TWO STEP DIMENSIONS. Everything else on this row is identical
+        // to what the txt2img path writes — same `scope`, same
+        // `workflow:submit:<id>` endpoint shape — so WITHOUT these a step submit
+        // and a txt2img submit are indistinguishable in `block_scope_invocations`,
+        // and two different step types are indistinguishable from each other.
+        // That is the gap: per-(user, app, capability) usage was not answerable
+        // from the table that exists to answer it.
+        //
+        // 🔴 NO SCHEMA CHANGE. `detail` is a nullable JSON column, so these are
+        // additive keys on new rows; existing rows and every other writer are
+        // untouched, and `describeBlockAction` ignores keys it does not read.
+        //
+        // 🔴 NOT A PER-STEP BRANCH — this stays inside the dispatch rule at the
+        // top of this section. Both values are read off the registry entry
+        // generically (`step.id`, and the entry's own variant resolver); nothing
+        // here tests WHICH step it is.
         detail: {
           action: 'workflow.submit',
           amount: typeof invocationCost === 'number' ? -Math.abs(invocationCost) : undefined,
           outcome: snapshot.status === 'failed' ? 'failed' : 'ok',
+          step: step.id,
+          // Bounded to the entry's declared `variants` — that wrapper, not the
+          // entry's promise, is what makes this safe to persist. For an entry
+          // that makes its model its variant this IS the model; for
+          // `convert-image` it is always `'default'`.
+          variant: resolveStepVariant(step, params),
         },
         dev: claims.dev === true,
       });

--- a/src/server/services/blocks/steps/__tests__/step-registry.test.ts
+++ b/src/server/services/blocks/steps/__tests__/step-registry.test.ts
@@ -891,6 +891,162 @@ describe('block step registry — resolveStepVariant bounds the resolved variant
     const params = step.paramSchema.parse({ model: 'model-a' });
     expect(resolveStepVariant(step, params)).toBe('model-b');
   });
+
+  // 🔴 THE `NaN` HOLE IN A MEMBERSHIP CHECK. `Array.prototype.includes` uses
+  // SameValueZero, under which `NaN` matches `NaN` — so `[NaN].includes(NaN)` is
+  // `true` and a membership check ALONE would have admitted `NaN`, handing it to
+  // `priceForVariant` and reopening the identical `undefined` → `Math.ceil` →
+  // `NaN > budget === false` bypass. Latent, not live: TypeScript rejects the
+  // entry below without the casts, exactly like the fail-open itself.
+  it('REJECTS a non-string resolution that a membership check alone would ADMIT', () => {
+    // The control, pinned rather than asserted in prose: this is why `includes`
+    // is not sufficient on its own.
+    expect([NaN].includes(NaN)).toBe(true);
+
+    const step = makeModelVariantStep({
+      variants: [NaN as unknown as string],
+      resolveVariant: () => NaN as unknown as string,
+    } as Partial<AnyBlockStep>);
+    const params = step.paramSchema.parse({ model: 'model-a' });
+
+    let error: unknown;
+    try {
+      resolveStepVariant(step, params);
+    } catch (e) {
+      error = e;
+    }
+    // Pinned to the TYPE guard's own wording — not the membership guard's, which
+    // would not have fired at all, and not a neighbour's.
+    expect(String(error)).toContain('resolveVariant() returned a non-string (number: NaN)');
+    expect(String(error)).not.toContain('is not one of the declared variants');
+    expect(String(error)).not.toContain('has no money-path handler');
+
+    // And it is a THROW on the money path, not a `NaN` price.
+    expect(() => planStepSpend(step, params)).toThrow(/returned a non-string/);
+  });
+
+  // 🔴 THE NEGATIVE CONTROL FOR THE TYPE GUARD. Same fixture shape, same casts,
+  // only the resolved VALUE changes — a declared string sails through. So the
+  // rejection above is caused by the resolution's type and by nothing else about
+  // that fixture.
+  it('admits a declared STRING through the same fixture shape the non-string test uses', () => {
+    const step = makeModelVariantStep({
+      variants: ['model-a' as unknown as string],
+      resolveVariant: () => 'model-a' as unknown as string,
+    } as Partial<AnyBlockStep>);
+    const params = step.paramSchema.parse({ model: 'model-a' });
+    expect(resolveStepVariant(step, params)).toBe('model-a');
+    expect(planStepSpend(step, params).reserveBuzz).toBe(PRICES['model-a']);
+  });
+
+  // 🔴 THE ESTIMATE PATH IS BOUND BY THE SAME WRAPPER — the fix for an
+  // estimate/submit split. `estimateBuzz` never receives the variant (it is
+  // computed from params), so before the dispatcher resolved it this call
+  // returned `PRICES['model-not-declared']` = `undefined`, i.e. the router's
+  // estimate answered HTTP 200 with `cost: { total: undefined }` for input the
+  // submit rejected. Both throw now, with the same message.
+  it('fails IDENTICALLY on estimate and on submit for an out-of-set resolution', () => {
+    const step = makeModelVariantStep();
+    const rogue = step.paramSchema.parse({ model: 'model-not-declared' });
+
+    // The pre-fix estimate value, pinned so a regression is visible as a value
+    // and not only as a missing throw.
+    expect(step.estimateBuzz(rogue)).toBeUndefined();
+
+    expect(() => estimateStepBuzz(step, rogue)).toThrow(/is not one of the declared variants/);
+    expect(() => planStepSpend(step, rogue)).toThrow(/is not one of the declared variants/);
+    // And still agree, on a declared variant.
+    const ok = step.paramSchema.parse({ model: 'model-b' });
+    expect(estimateStepBuzz(step, ok)).toBe(PRICES['model-b']);
+    expect(planStepSpend(step, ok).reserveBuzz).toBe(PRICES['model-b']);
+  });
+
+  // 🔴 THE BOUND LIVES IN THE DISPATCHER, NOT IN A HANDLER — which is what stops
+  // a future mode from reopening the hole. A `tokenMetered` fixture has NO
+  // money-path handler at all, so if the resolution happened inside a handler
+  // this would die with "has no money-path handler". It dies with the VARIANT
+  // error instead: every mode passes through the bound before its handler is
+  // reached, including the modes nobody has written yet.
+  it('bounds the variant BEFORE billing-mode dispatch, for a mode with no handler', () => {
+    const step = makeModelVariantStep({
+      billingMode: 'tokenMetered',
+      maxBuzzForVariant: () => 500,
+    } as Partial<AnyBlockStep>);
+    const rogue = step.paramSchema.parse({ model: 'model-not-declared' });
+    let error: unknown;
+    try {
+      planStepSpend(step, rogue);
+    } catch (e) {
+      error = e;
+    }
+    expect(String(error)).toContain('is not one of the declared variants');
+    expect(String(error)).not.toContain('has no money-path handler');
+  });
+
+  // 🔴 THE THREADED DERIVATION IS THE ONE THAT PRICES. `submitStepWorkflow`
+  // resolves the variant ONCE and passes it down; this pins that the passed value
+  // is what `priceForVariant` receives, rather than the handler quietly
+  // re-resolving from params. The fixture is chosen so the two DISAGREE — params
+  // say `model-a` (3), the threaded variant says `model-b` (9) — so a
+  // re-resolution scores 3 and cannot pass.
+  it('prices off the THREADED variant, not a re-resolution from params', () => {
+    const step = makeModelVariantStep();
+    const params = step.paramSchema.parse({ model: 'model-a' });
+    const threaded = resolveStepVariant(
+      makeModelVariantStep({ resolveVariant: () => 'model-b' } as Partial<AnyBlockStep>),
+      params
+    );
+    expect(threaded).toBe('model-b');
+    expect(PRICES['model-a']).not.toBe(PRICES['model-b']);
+    expect(planStepSpend(step, params, threaded).reserveBuzz).toBe(PRICES['model-b']);
+    // Omitted → resolved from params, the default path the tests above exercise.
+    expect(planStepSpend(step, params).reserveBuzz).toBe(PRICES['model-a']);
+  });
+
+  // 🔴 BEHAVIOUR-NEUTRALITY FOR THE SHIPPED POPULATION, executed rather than
+  // argued. The bound and the hoist are a refactor on a live money path, so the
+  // question that matters is not "does the guard work" (above) but "does any
+  // REGISTERED entry now answer differently". The pre-change expressions are
+  // written out literally on the left and compared against what the current
+  // pipeline returns — for every registered entry and every declared variant, so
+  // an entry added tomorrow is covered by this test today.
+  //
+  // Scope, stated at what was measured: this is the REGISTRY level with each
+  // variant's canonical params. The REQUEST level — real, non-canonical params
+  // through `submitWorkflow` — is covered by the step suite in
+  // `blocks.router.workflow.test.ts`, which drives the same entry end to end.
+  it('is behaviour-NEUTRAL over the registered population: no value changes', () => {
+    const entries = listRegisteredSteps();
+    // Positive control for this loop: a population of zero would make every
+    // assertion below vacuously true and the test would still be green.
+    expect(entries.length).toBeGreaterThan(0);
+    let checked = 0;
+    for (const [id, step] of entries) {
+      for (const declared of step.variants) {
+        const params = step.paramSchema.parse(step.canonicalParamsFor(declared));
+        // The exact expressions this change replaced.
+        const legacyVariant = step.resolveVariant(params);
+        const legacyEstimate = step.estimateBuzz(params);
+
+        expect(resolveStepVariant(step, params), `step '${id}' variant`).toBe(legacyVariant);
+        expect(estimateStepBuzz(step, params), `step '${id}' estimate`).toBe(legacyEstimate);
+
+        if (step.billingMode === 'prepaidFixed') {
+          const legacyReserve = step.priceForVariant(legacyVariant);
+          expect(planStepSpend(step, params).reserveBuzz, `step '${id}' reserve`).toBe(
+            legacyReserve
+          );
+          // And the THREADED call the router now makes is identical to the
+          // un-threaded one it used to make — the hoist's whole claim.
+          expect(planStepSpend(step, params, resolveStepVariant(step, params))).toEqual(
+            planStepSpend(step, params)
+          );
+        }
+        checked++;
+      }
+    }
+    expect(checked).toBeGreaterThan(0);
+  });
 });
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/src/server/services/blocks/steps/__tests__/step-registry.test.ts
+++ b/src/server/services/blocks/steps/__tests__/step-registry.test.ts
@@ -18,6 +18,7 @@ import {
   planStepSpend,
   postureRequiresAuditableText,
   REGISTERED_STEP_IDS,
+  resolveStepVariant,
   STEP_BILLING_MODES,
   STEP_MODERATION_POSTURES,
   STEP_TYPE_ACCEPTABLE_POSTURES,
@@ -785,6 +786,110 @@ describe('block step registry — billing-mode dispatch', () => {
         expect(String(error)).toContain(`billing mode '${mode}' has no money-path handler`);
       }
     }
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// `resolveStepVariant` — the REQUEST-TIME bound on the resolved variant.
+//
+// 🔴 WHAT THESE TESTS ARE. The fixture here is the shape a MODEL-ALLOWLISTED
+// entry would have: `resolveVariant` derives the variant from a param instead of
+// returning a constant. No registered entry has that shape today
+// (`convert-image` returns `() => 'default'`), so these are NOT regression
+// coverage for a live bug — they pin a guard against a shape that arrives with
+// the next entry. Labelled here rather than left to read as coverage of the
+// shipped population.
+//
+// 🔴 WHAT WAS MEASURED ON UNMODIFIED `main`, and why the guard is worth its
+// keep. With this exact fixture, `planStepSpend(entry, { model: <not
+// declared> })` returned `reserveBuzz: undefined`. The router then computes
+// `Math.ceil(undefined)` → `NaN`, and its per-call gate `reserveBuzz >
+// claims.buzzBudget` evaluates **false** for `NaN` — i.e. the budget gate lets
+// it through. That sequence was executed, not reasoned about.
+// ─────────────────────────────────────────────────────────────────────────────
+describe('block step registry — resolveStepVariant bounds the resolved variant', () => {
+  /** Params-derived variant: the model-allowlist shape. */
+  type ModelParams = { model: string };
+  const DECLARED = ['model-a', 'model-b'] as const;
+  const PRICES: Record<string, number> = { 'model-a': 3, 'model-b': 9 };
+
+  function makeModelVariantStep(overrides: Partial<AnyBlockStep> = {}): AnyBlockStep {
+    return makeFixtureStep({
+      // 🔴 DELIBERATELY WIDER THAN `variants`. A correctly-written entry pins the
+      // schema to the same set (`z.enum(DECLARED)`), which is what makes the
+      // out-of-set case unreachable — the point of this fixture is that the
+      // registry must not DEPEND on the entry having done that.
+      paramSchema: z.object({ model: z.string() }).strict(),
+      variants: [...DECLARED],
+      resolveVariant: (p: ModelParams) => p.model,
+      canonicalParamsFor: (v: string): ModelParams => ({ model: v }),
+      priceForVariant: (v: string) => PRICES[v],
+      estimateBuzz: (p: ModelParams) => PRICES[p.model],
+      ...overrides,
+    } as Partial<AnyBlockStep>);
+  }
+
+  // 🔴 THE NEGATIVE CONTROL. The fixture is valid and prices correctly for BOTH
+  // declared variants — so every rejection below is caused by the one field the
+  // test changes, not by the fixture being malformed.
+  it('returns the resolved variant unchanged when it IS declared, and prices off it', () => {
+    const step = makeModelVariantStep();
+    expect(() => assertStepInvariants('fixture-step', step)).not.toThrow();
+    for (const model of DECLARED) {
+      const params = step.paramSchema.parse({ model });
+      expect(resolveStepVariant(step, params)).toBe(model);
+      expect(planStepSpend(step, params).reserveBuzz).toBe(PRICES[model]);
+    }
+  });
+
+  it('REJECTS a resolution outside the declared variants, naming THIS guard', () => {
+    const step = makeModelVariantStep();
+    const rogue = step.paramSchema.parse({ model: 'model-not-declared' });
+    let error: unknown;
+    try {
+      resolveStepVariant(step, rogue);
+    } catch (e) {
+      error = e;
+    }
+    // Pinned to this guard's own wording, so the test cannot pass because a
+    // neighbouring guard threw first.
+    expect(String(error)).toContain(
+      "resolveVariant() returned 'model-not-declared', which is not one of the declared variants"
+    );
+    expect(String(error)).toContain('[model-a, model-b]');
+    // NOT a billing-mode failure, NOT a load-time clause — the two nearest
+    // neighbours on this path.
+    expect(String(error)).not.toContain('has no money-path handler');
+    expect(String(error)).not.toContain('canonicalParamsFor');
+  });
+
+  // 🔴 THE MONEY-PATH CONSEQUENCE, which is the reason the wrapper exists rather
+  // than a lint. Before it, this call RETURNED `{ reserveBuzz: undefined }` and
+  // the router's budget gate passed on the resulting `NaN` (see the block header
+  // — measured). Now the same call throws, before any reservation exists.
+  it('makes an out-of-set resolution a THROW on the spend path, not an undefined price', () => {
+    const step = makeModelVariantStep();
+    const rogue = step.paramSchema.parse({ model: 'model-not-declared' });
+    expect(() => planStepSpend(step, rogue)).toThrow(/is not one of the declared variants/);
+
+    // The precise thing that used to happen, pinned so a future refactor that
+    // reintroduces it fails here: an unbounded variant reaching `priceForVariant`
+    // yields `undefined`, whose `Math.ceil` is `NaN`, and `NaN > budget` is FALSE
+    // — a budget gate that admits everything.
+    expect(PRICES['model-not-declared']).toBeUndefined();
+    expect(Math.ceil(undefined as unknown as number)).toBeNaN();
+    expect(Math.ceil(undefined as unknown as number) > 1).toBe(false);
+  });
+
+  // The bound is on MEMBERSHIP in `variants` — nothing more. Stated as a test so
+  // the limit is visible rather than inferred from the implementation.
+  it('bounds membership only — it does not re-derive or second-guess the variant', () => {
+    const step = makeModelVariantStep({
+      // Ignores its params entirely and always answers with a DECLARED variant.
+      resolveVariant: () => 'model-b',
+    } as Partial<AnyBlockStep>);
+    const params = step.paramSchema.parse({ model: 'model-a' });
+    expect(resolveStepVariant(step, params)).toBe('model-b');
   });
 });
 

--- a/src/server/services/blocks/steps/index.ts
+++ b/src/server/services/blocks/steps/index.ts
@@ -542,14 +542,33 @@ interface BlockStepBase<P> {
   variants: readonly string[];
   /**
    * The SINGLE source of truth for "which variant did this submit resolve to?".
-   * The price/budget, the built step, and the display estimate MUST all agree on
-   * this one value, so they all derive it here. Returns a bounded id from
-   * `variants` — never a client-raw string.
+   * Returns a bounded id from `variants` — never a client-raw string.
+   *
+   * 🔴 WHAT ACTUALLY DERIVES FROM IT — stated exactly, because the previous
+   * wording ("the price/budget, the built step, and the display estimate MUST
+   * all agree on this one value, so they all derive it here") over-claimed and a
+   * reader who trusted it would have looked for a bound that was not there. Only
+   * the PRICE/BUDGET is computed FROM this value (`priceForVariant(variant)`);
+   * the settle `engine` and the usage audit row RECORD it. The BUILT STEP
+   * (`buildStep(params)`) and the DISPLAY ESTIMATE (`estimateBuzz(params)`) are
+   * computed from the PARAMS and never receive the variant at all — they are
+   * only required to be CONSISTENT with it, which registry load checks for the
+   * canonical params of each variant (clause 5, and the price-equals-estimate
+   * clause) and nothing re-checks at request time.
+   *
+   * What estimate and submit DO share is the BOUND: `estimateStepBuzz` and
+   * `planStepSpend` both resolve through `resolveStepVariant` before dispatching
+   * to a billing-mode handler, so an out-of-set resolution fails identically on
+   * both. Before that they did not, and an entry whose variant is its model
+   * would have answered an out-of-set model with HTTP 200 and
+   * `cost: { total: undefined }` on estimate while the submit threw.
    *
    * 🔴 CALL IT THROUGH `resolveStepVariant`, NEVER DIRECTLY. "Returns a bounded
    * id" is a promise the ENTRY makes about a function that receives untrusted
    * params; the wrapper is what checks it. Clause 5 below only checks the
-   * canonical params, i.e. one author-chosen input per variant.
+   * canonical params, i.e. one author-chosen input per variant. The return type
+   * of the wrapper (`BoundedStepVariant`) is what carries that proof into every
+   * downstream consumer.
    */
   resolveVariant(params: P): string;
   /**
@@ -716,10 +735,52 @@ export type StepSpendPlan = {
   stepTimeoutSeconds: number | null;
 };
 
-type BillingModeHandler = {
-  estimateBuzz(step: AnyBlockStep, params: unknown): number;
-  planSpend(step: AnyBlockStep, params: unknown): StepSpendPlan;
+/**
+ * Everything a billing-mode handler is allowed to see.
+ *
+ * 🔴 THE VARIANT IS PASSED IN, ALREADY BOUNDED. The previous shape handed a
+ * handler `(step, params)` and asked, in a comment, that it route its own
+ * resolution through `resolveStepVariant`. A comment is not a choke point — a
+ * future `timeBounded` handler written as
+ * `budgetForVariant(entry.resolveVariant(params))` would have reopened the
+ * budget-gate fail-open verbatim while reading as ordinary code, because nothing
+ * would have been there to stop it. Now the bound happens ONCE in the dispatcher
+ * below, for every mode, before any handler runs.
+ *
+ * 🔴 BE EXACT ABOUT THE STRENGTH OF THAT. A handler still receives `step` and
+ * `params`, so it CAN call `step.resolveVariant` — no type prevents it. What
+ * changed is that doing so is now visibly a second, unbounded re-derivation of a
+ * value the handler was already handed, rather than the only way to obtain one.
+ * The type system's part is narrower and exact: a handler cannot pass its own
+ * re-derivation to anything that takes a `BoundedStepVariant` without an explicit
+ * cast.
+ */
+type StepSpendContext = {
+  step: AnyBlockStep;
+  /** The entry's own `.strict()`-parsed params. Still untrusted CONTENT. */
+  params: unknown;
+  /** Proven a member of `step.variants` — see `resolveStepVariant`. */
+  variant: BoundedStepVariant;
 };
+
+type BillingModeHandler = {
+  estimateBuzz(ctx: StepSpendContext): number;
+  planSpend(ctx: StepSpendContext): StepSpendPlan;
+};
+
+/**
+ * A variant string PROVEN to be a member of its entry's declared `variants`.
+ *
+ * 🔴 THE BRAND IS THE ENFORCEMENT. `resolveStepVariant` is the only function
+ * that produces one, so every consumer that declares this type — the
+ * billing-mode handlers, and through them the price lookup — cannot be handed a
+ * raw `step.resolveVariant(params)` without an explicit cast that a reviewer
+ * will see. The alternative was a prose instruction to use the wrapper, which is
+ * exactly the class of guarantee this file has repeatedly failed to keep.
+ *
+ * It is a `string` at runtime; the brand exists only in the type system.
+ */
+export type BoundedStepVariant = string & { readonly __boundedStepVariant: 'bounded' };
 
 /**
  * `step.resolveVariant(params)`, BOUNDED to the entry's declared `variants`.
@@ -763,9 +824,40 @@ type BillingModeHandler = {
  * it should surface as a 500 the way any other broken invariant does. A plain
  * `Error` also keeps this module import-light, which `workflow.schema` depends
  * on.
+ *
+ * 🔴 THE MESSAGE IS ECHOED TO THE UNTRUSTED IFRAME. `trpc.ts`'s `errorFormatter`
+ * is pass-through (`({ shape }) => shape`), and `getTRPCErrorFromUnknown`
+ * preserves an unrecognized throw's `message`, so everything below reaches the
+ * block's own JS — INCLUDING `step.variants.join(', ')`, i.e. the entry's ENTIRE
+ * declared allowlist. For `convert-image` that is the single word `default` and
+ * discloses nothing. For the model-allowlisted entry this is groundwork for, it
+ * would be the full model list, which may name a model that is not public yet.
+ * 🔴 So an entry whose `variants` are not all public information must choose
+ * this message deliberately — either by keeping unreleased ids out of
+ * `variants`, or by making the resolution unreachable (a `z.enum` paramSchema
+ * over the same set turns an out-of-set value into a BAD_REQUEST at parse,
+ * before this guard is ever reached).
  */
-export function resolveStepVariant(step: AnyBlockStep, params: unknown): string {
-  const variant = step.resolveVariant(params);
+export function resolveStepVariant(step: AnyBlockStep, params: unknown): BoundedStepVariant {
+  // Deliberately typed `unknown`: `resolveVariant`'s declared `string` return is
+  // the entry's CLAIM, and this function exists precisely because the entry's
+  // claims are not checked anywhere else.
+  const variant: unknown = step.resolveVariant(params);
+  // 🔴 THE TYPE CHECK IS NOT REDUNDANT WITH THE MEMBERSHIP CHECK BELOW.
+  // `Array.prototype.includes` uses SameValueZero, under which `NaN` matches
+  // `NaN` — so an entry declaring `variants: [NaN as any]` with
+  // `resolveVariant: () => NaN` would PASS `includes` and hand `NaN` to
+  // `priceForVariant`, reopening the exact `undefined` → `Math.ceil` → `NaN` →
+  // `NaN > buzzBudget === false` budget-gate bypass this wrapper exists to
+  // close. TypeScript rejects that entry without the cast, so it is latent, not
+  // live — the same posture as the fail-open itself.
+  if (typeof variant !== 'string') {
+    throw new Error(
+      `block step '${step.id}': resolveVariant() returned a non-string ` +
+        `(${typeof variant}: ${String(variant)}) — the price lookup keys off this value, and a ` +
+        'non-string resolution is a money-path input nobody reviewed'
+    );
+  }
   if (!step.variants.includes(variant)) {
     throw new Error(
       `block step '${step.id}': resolveVariant() returned '${variant}', which is not one of the ` +
@@ -774,7 +866,7 @@ export function resolveStepVariant(step: AnyBlockStep, params: unknown): string 
         'nobody reviewed'
     );
   }
-  return variant;
+  return variant as BoundedStepVariant;
 }
 
 /**
@@ -800,16 +892,22 @@ function unimplementedMode(mode: StepBillingMode): BillingModeHandler {
 
 const billingModeHandlers: Record<StepBillingMode, BillingModeHandler> = {
   prepaidFixed: {
-    estimateBuzz: (step, params) => step.estimateBuzz(params),
-    planSpend: (step, params) => {
+    // The display estimate is computed from the PARAMS — the variant is not an
+    // input to it, and this handler deliberately does not destructure one. What
+    // the bound buys this path is that `estimateStepBuzz` already threw on an
+    // out-of-set resolution before reaching here, so estimate can no longer
+    // answer 200 where submit throws.
+    estimateBuzz: ({ step, params }) => step.estimateBuzz(params),
+    planSpend: ({ step, variant }) => {
       const entry = step as PrepaidFixedStep<unknown>;
       return {
-        // 🔴 `resolveStepVariant`, NOT `entry.resolveVariant` — the price lookup
-        // is the money-path consumer that made an unbounded resolution a
-        // budget-gate bypass (see that function's header for the measured
-        // sequence). Every other consumer of the resolved variant must use the
-        // same wrapper; one rule, one place.
-        reserveBuzz: entry.priceForVariant(resolveStepVariant(entry, params)),
+        // 🔴 A `BoundedStepVariant`, resolved ONCE by the dispatcher. The price
+        // lookup is the money-path consumer that made an unbounded resolution a
+        // budget-gate bypass (see `resolveStepVariant`'s header for the measured
+        // sequence), so it takes the value it was handed — substituting a fresh
+        // `entry.resolveVariant(params)` here is what the bound exists to stop
+        // being the normal way to write this line.
+        reserveBuzz: entry.priceForVariant(variant),
         // Exact price → the reservation is final; never touch the post-paid
         // settle machinery.
         postPaidSettle: false,
@@ -828,14 +926,39 @@ export function isBillingModeImplemented(mode: StepBillingMode): boolean {
   return mode === 'prepaidFixed';
 }
 
-/** The display estimate for a step, dispatched on its declared billing mode. */
-export function estimateStepBuzz(step: AnyBlockStep, params: unknown): number {
-  return billingModeHandlers[step.billingMode].estimateBuzz(step, params);
+/**
+ * The display estimate for a step, dispatched on its declared billing mode.
+ *
+ * Resolves the variant through `resolveStepVariant` before dispatching — see
+ * `planStepSpend` below for why the resolution lives in the dispatcher, and note
+ * that this is what makes an out-of-set resolution fail IDENTICALLY on estimate
+ * and on submit.
+ */
+export function estimateStepBuzz(
+  step: AnyBlockStep,
+  params: unknown,
+  variant: BoundedStepVariant = resolveStepVariant(step, params)
+): number {
+  return billingModeHandlers[step.billingMode].estimateBuzz({ step, params, variant });
 }
 
-/** The spend plan for a step submit, dispatched on its declared billing mode. */
-export function planStepSpend(step: AnyBlockStep, params: unknown): StepSpendPlan {
-  return billingModeHandlers[step.billingMode].planSpend(step, params);
+/**
+ * The spend plan for a step submit, dispatched on its declared billing mode.
+ *
+ * 🔴 THE VARIANT IS RESOLVED HERE, NOT IN A HANDLER. Every billing mode keys its
+ * price/budget off a variant, so the bound belongs at the one place all modes
+ * pass through rather than being re-applied (or forgotten) per handler. `variant`
+ * is a parameter so a caller that has ALREADY resolved it — `submitStepWorkflow`
+ * does, once, before any reservation — threads that single derivation down
+ * instead of recomputing it; omitting it resolves here. Either way the value is
+ * a `BoundedStepVariant`, which only `resolveStepVariant` can produce.
+ */
+export function planStepSpend(
+  step: AnyBlockStep,
+  params: unknown,
+  variant: BoundedStepVariant = resolveStepVariant(step, params)
+): StepSpendPlan {
+  return billingModeHandlers[step.billingMode].planSpend({ step, params, variant });
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/src/server/services/blocks/steps/index.ts
+++ b/src/server/services/blocks/steps/index.ts
@@ -181,6 +181,35 @@ export type OrchestratorStepTemplate = {
 // included — a checkpoint IS an AIR, so it is a `staticAllowlist` case, not a
 // separate field), and until one exists it fails at registry LOAD. Same
 // unskippable property moderation already had.
+//
+// 🔴 THIS AXIS IS AIR-SPECIFIC, AND READING IT WIDER IS THE MISTAKE TO AVOID.
+// Both policy kinds are about AIR URNs and nothing else: `staticAllowlist`'s
+// only field is `airs`, clause 7's enforcement is `containsAirReference` (a
+// `urn:air:` substring scan), and the harm it names is the generation-graph
+// ENTITLEMENT belt — reaching a gated / early-access / Private model version.
+// So `resourcePolicy: 'none'` means "no AIR reference", NOT "this entry's model
+// surface is bounded", and a reviewer who reads it as the latter has stopped
+// checking the thing that matters.
+//
+// The concrete case, because it is coming: the orchestrator's `chatCompletion`
+// input takes `model: string` — a plain provider id ("gpt-4o"), NOT an AIR
+// (`ChatCompletionInput` in the generated `@civitai/client` types). Such an
+// entry would declare `'none'` TRUTHFULLY and pass clause 7, while forwarding
+// an arbitrary model name from an untrusted iframe. There is also no
+// orchestrator-side model validation to catch it — a fabricated name quotes
+// fine and fails only at execution.
+//
+// 🔴 DO NOT FORCE A NON-AIR MODEL ALLOWLIST INTO `staticAllowlist`. Putting
+// "gpt-4o" in a field named `airs` would make the eventual AIR-allowlist
+// implementation (which has to compare against the entitlement belt) wrong for
+// whichever entries lied to it. The smallest honest shape is the one the
+// registry ALREADY provides, with no new field: put the permitted models in the
+// entry's own `.strict()` `paramSchema` as a `z.enum`, AND declare them as the
+// entry's `variants` with `resolveVariant` returning the chosen one. That gets
+// the pinning from the schema (a non-member is a BAD_REQUEST at parse), the
+// bound from `resolveStepVariant`, and per-model pricing from
+// `priceForVariant` — which a flat price today does not need but a rate card
+// eventually will.
 // ─────────────────────────────────────────────────────────────────────────────
 export type StepResourcePolicy =
   /**
@@ -516,6 +545,11 @@ interface BlockStepBase<P> {
    * The price/budget, the built step, and the display estimate MUST all agree on
    * this one value, so they all derive it here. Returns a bounded id from
    * `variants` — never a client-raw string.
+   *
+   * 🔴 CALL IT THROUGH `resolveStepVariant`, NEVER DIRECTLY. "Returns a bounded
+   * id" is a promise the ENTRY makes about a function that receives untrusted
+   * params; the wrapper is what checks it. Clause 5 below only checks the
+   * canonical params, i.e. one author-chosen input per variant.
    */
   resolveVariant(params: P): string;
   /**
@@ -688,6 +722,62 @@ type BillingModeHandler = {
 };
 
 /**
+ * `step.resolveVariant(params)`, BOUNDED to the entry's declared `variants`.
+ *
+ * 🔴 WHY A WRAPPER RATHER THAN THE RAW CALL. `resolveVariant` is documented as
+ * returning "a bounded id from `variants` — never a client-raw string", and
+ * until now that was a PROSE promise the entry made: nothing checked it, and
+ * clause 5 only checks it for `canonicalParamsFor(v)` — one fixed input per
+ * variant, chosen by the entry author. At REQUEST time the argument is the
+ * untrusted iframe's `.strict()`-parsed params, and the return value is fed
+ * straight into `priceForVariant` on the money path.
+ *
+ * 🔴 THE FAILURE THAT MOTIVATES IT, MEASURED RATHER THAN REASONED. With an
+ * entry whose `resolveVariant` returns a param (`(p) => p.model`) and whose
+ * `priceForVariant` is a record lookup, an out-of-set value made
+ * `priceForVariant` return `undefined` → `planStepSpend().reserveBuzz`
+ * `undefined` → the router's `Math.ceil(...)` `NaN` → and `NaN > buzzBudget`
+ * evaluates **false**, so the per-call budget gate PASSES. Executed on
+ * unmodified `main` before this wrapper existed; the numbers are from that run,
+ * not from reading the code.
+ *
+ * 🔴 BE EXACT ABOUT REACHABILITY — this is a LATENT fail-open, not a live one.
+ * The sole registered entry today (`convert-image`) returns a CONSTANT
+ * (`() => 'default'`), so no params can steer it and the shape above cannot be
+ * reached by any shipped code path. It becomes reachable the moment an entry
+ * derives its variant FROM params — which is exactly what a model-allowlisted
+ * entry wants to do, since per-model pricing has to key off the variant. This
+ * wrapper is therefore a prerequisite for that shape, not a fix for a live bug,
+ * and the test that pins it says so.
+ *
+ * 🔴 AND BE EXACT ABOUT WHAT IT BINDS. It proves the resolved value is a MEMBER
+ * of `step.variants`. It does NOT prove `variants` itself is a sensible set —
+ * that stays what it always was, a reviewed declaration in a code-reviewed
+ * trust root. What it buys is that everything downstream (the price lookup, the
+ * settle `engine`, the audit row) receives a value from a fixed, reviewed,
+ * enumerable set rather than whatever the entry chose to return.
+ *
+ * Throws a plain `Error` (not a TRPC caller error) on purpose: the params were
+ * already accepted by the entry's own `.strict()` schema, so a resolution
+ * outside the declared set is a REGISTRY-ENTRY bug, not a caller mistake, and
+ * it should surface as a 500 the way any other broken invariant does. A plain
+ * `Error` also keeps this module import-light, which `workflow.schema` depends
+ * on.
+ */
+export function resolveStepVariant(step: AnyBlockStep, params: unknown): string {
+  const variant = step.resolveVariant(params);
+  if (!step.variants.includes(variant)) {
+    throw new Error(
+      `block step '${step.id}': resolveVariant() returned '${variant}', which is not one of the ` +
+        `declared variants [${step.variants.join(', ')}] — the price lookup, the settle record ` +
+        'and the audit row all key off this value, so an unbounded one is a money-path input ' +
+        'nobody reviewed'
+    );
+  }
+  return variant;
+}
+
+/**
  * A mode that is DECLARED (so the type + wire surface is stable and future
  * additions are additive) but whose money path is not implemented yet.
  *
@@ -714,7 +804,12 @@ const billingModeHandlers: Record<StepBillingMode, BillingModeHandler> = {
     planSpend: (step, params) => {
       const entry = step as PrepaidFixedStep<unknown>;
       return {
-        reserveBuzz: entry.priceForVariant(entry.resolveVariant(params)),
+        // 🔴 `resolveStepVariant`, NOT `entry.resolveVariant` — the price lookup
+        // is the money-path consumer that made an unbounded resolution a
+        // budget-gate bypass (see that function's header for the measured
+        // sequence). Every other consumer of the resolved variant must use the
+        // same wrapper; one rule, one place.
+        reserveBuzz: entry.priceForVariant(resolveStepVariant(entry, params)),
         // Exact price → the reservation is final; never touch the post-paid
         // settle machinery.
         postPaidSettle: false,

--- a/src/shared/constants/block-action-detail.ts
+++ b/src/shared/constants/block-action-detail.ts
@@ -52,6 +52,40 @@ export type BlockActionDetail = {
   key?: string;
   /** Terminal outcome of the action. */
   outcome?: 'ok' | 'failed';
+  /**
+   * The App Blocks STEP-TYPE registry id this `workflow.submit` ran
+   * (`~/server/services/blocks/steps`) — e.g. `'convert-image'`. Written ONLY by
+   * the `kind: 'step'` submit path; ABSENT on a `textToImage` / `customComfy`
+   * submit, which is what distinguishes them in the row.
+   *
+   * 🔴 WHY IT IS HERE AND NOT DERIVED. Nothing else on the row carries it:
+   * `scope` is `'ai:write:budgeted'` for every spending kind and `endpoint` is
+   * `workflow:submit:<workflowId>`, so before this field a step submit and a
+   * txt2img submit were INDISTINGUISHABLE in `block_scope_invocations`, and two
+   * different step types were indistinguishable from each other. Per-(user, app,
+   * capability) usage accounting was therefore not answerable from this table at
+   * all.
+   *
+   * Bounded by construction: the value is a registry KEY, which the wire schema
+   * derives its `step` enum from (`REGISTERED_STEP_IDS`) — never client text.
+   */
+  step?: string;
+  /**
+   * The variant that `workflow.submit` resolved to, for a `kind: 'step'` submit.
+   *
+   * Bounded to the entry's declared `variants` by `resolveStepVariant` — that
+   * wrapper is what makes this safe to persist, not a promise from the entry.
+   *
+   * 🔴 WHAT THIS IS AND IS NOT, because the obvious reading over-claims. It is
+   * the registry's "which variant did this resolve to?" value. It is the MODEL
+   * only for an entry that makes its model its variant — the shape recommended
+   * for a model-allowlisted entry, and the one per-model pricing forces anyway,
+   * but NOT something this field can guarantee about an arbitrary future entry.
+   * For `convert-image` today it is always `'default'` and carries no
+   * information; it is recorded uniformly so the dimension exists on every step
+   * row rather than appearing only once some entry opts in.
+   */
+  variant?: string;
 };
 
 /**


### PR DESCRIPTION
Groundwork for a future registry entry whose variant is derived from params (a model-allowlisted step). Both changes are additive and behaviour-neutral for `convert-image`, the sole registered entry today.

## 1. `resolveStepVariant` — a request-time bound on the resolved variant

`resolveVariant` is documented as returning *"a bounded id from `variants` — never a client-raw string"*. That was a promise the **entry** made about a function that receives untrusted params; nothing checked it. Load-time clause 5 only checks `canonicalParamsFor(v)` — one author-chosen input per variant.

**Measured on unmodified `main`**, with a fixture whose `resolveVariant` is `(p) => p.model` and whose `priceForVariant` is a record lookup:

| step | value |
|---|---|
| `priceForVariant('<not declared>')` | `undefined` |
| `planStepSpend(...).reserveBuzz` | `undefined` |
| router's `Math.ceil(reserveBuzz)` | `NaN` |
| router's gate `reserveBuzz > claims.buzzBudget` | **`false`** — the per-call budget gate passes |

🔴 **This is latent, not live.** `convert-image` resolves a constant (`() => 'default'`), so no params can steer it and no shipped path reaches the shape above. It becomes reachable the moment an entry derives its variant from params — which per-model pricing forces, since `priceForVariant` keys off the variant. The wrapper is now the single way the money path, the settle `engine` and the audit row read that value.

It bounds **membership in `variants` and nothing more** — it does not claim `variants` is itself a sensible set. That stays a reviewed declaration in a code-reviewed trust root. It throws a plain `Error` (→ 500) rather than a caller error, because the params were already accepted by the entry's own `.strict()` schema, so an out-of-set resolution is an entry bug; a plain `Error` also keeps the module import-light for `workflow.schema`.

## 2. `detail.step` + `detail.variant` on the step-submit audit row

Every other field a `kind: 'step'` submit writes to `block_scope_invocations` is identical to what the txt2img path writes — same `ai:write:budgeted` scope, same `workflow:submit:<workflowId>` endpoint shape. So a step submit and a txt2img submit were **indistinguishable** in that table, and two different step types indistinguishable from each other: per-(user, app, capability) usage was not answerable from the table that exists to answer it.

- **No migration.** `detail` is a nullable JSON column — additive keys on new rows only. Existing rows, every other writer, and `describeBlockAction` (which ignores keys it does not read) are untouched.
- **No per-step branch.** Both values are read generically off the entry (`step.id`, and the entry's own resolver through the wrapper), so the router's dispatch rule holds.
- `variant` is `'default'` for `convert-image` — real, if uninformative. It is the **model** only for an entry that makes its model its variant; the doc comment says exactly that rather than implying more.

## 3. A comment correction

`resourcePolicy` is **AIR-specific**: its only allowlist field is `airs`, its enforcement is a `urn:air:` substring scan, and the harm it names is the generation-graph entitlement belt. So `'none'` means *"no AIR reference"*, **not** *"this entry's model surface is bounded"* — and a step whose model is a plain provider string (`model: string`, e.g. `"gpt-4o"`) would declare `'none'` **truthfully** and still forward an arbitrary name from an untrusted iframe. There is no orchestrator-side model validation to catch that either.

The comment now says so, and names the smallest honest shape — a `z.enum` in the entry's own `.strict()` `paramSchema` **plus** the permitted models as `variants` — instead of leaving `staticAllowlist` looking like the answer. Putting non-AIRs in a field named `airs` would make the eventual AIR-allowlist implementation wrong for whichever entries lied to it.

## Verification

**Mutation tests** (each pinned to the guard's own message, so a neighbour throwing first cannot make one pass):

| mutation | tests killed |
|---|---|
| `if (!step.variants.includes(variant))` → `if (false)` | **2** — the rejection test (asserting this guard's exact wording) and the money-path test |
| `planSpend` reverted to the raw `entry.resolveVariant(params)` | **1** — only the money-path test, proving the wrapper is wired in and not merely exported |
| drop `step: step.id` from the audit detail | **1** |
| drop `variant: resolveStepVariant(...)` from the audit detail | **1** |

Each rejection is paired with a **negative control** that passes when only the offending field changes: the fixture is asserted valid and correctly priced for *both* declared variants before any mutation.

**Suites:** 155 files / 3379 tests pass across `services/blocks`, `routers/__tests__`, `shared/constants/__tests__`, `middleware/__tests__`. The one unhandled error in that run is a pre-existing local Prisma query-engine issue in an unrelated file, which still passes its test.

**Typecheck:** `tsc --noEmit` clean — instrument validated by injecting a deliberate type error and confirming it went red with the exact same invocation first (a `0 errors` run turned out to be a false clean where the compiler had not run at all).

`prettier --write` + `eslint` run on all changed files; the 16 eslint errors reported in `blocks.router.workflow.test.ts` are pre-existing, all at lines far above these additions.

## Not in this PR

- **A `maxTokens` bound** is entry-local — one line in a future entry's zod schema. Nothing reusable belongs in the registry for it, and inventing a compute-bound concept for a single unbuilt consumer would be exactly the speculative surface this module warns against.
- **Implementing `staticAllowlist`** (the real AIR allowlist) is a separate, reviewable change on the entitlement axis; it is not a prerequisite for a non-AIR model allowlist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
