### PR TITLE
feat(app-blocks): implement the 'textOutput' moderation posture at the read boundary

### DIFF
--- a/src/server/routers/__tests__/blocks.router.textOutputModeration.test.ts
+++ b/src/server/routers/__tests__/blocks.router.textOutputModeration.test.ts
@@ -191,7 +191,11 @@ import {
   sfwBrowsingLevelsFlag,
 } from '~/shared/constants/browsingLevel.constants';
 import { assertStepInvariants, type AnyBlockStep } from '~/server/services/blocks/steps';
-import { TEXT_OUTPUT_WITHHELD_MESSAGE } from '~/server/services/blocks/steps/text-output-moderation';
+import {
+  TEXT_OUTPUT_SCAN_LABELS,
+  TEXT_OUTPUT_WITHHELD_MESSAGE,
+  __clearTextOutputVerdictCacheForTests,
+} from '~/server/services/blocks/steps/text-output-moderation';
 
 const CHAT_TYPE = 'fixtureChat';
 const GENERATED_TEXT = 'the model wrote this exact sentence';
@@ -209,9 +213,9 @@ const textStep: AnyBlockStep = {
   priceForVariant: () => 7,
   estimateBuzz: () => 7,
   buildStep: (p: { value: number }) => ({ $type: CHAT_TYPE, input: { value: p.value } }),
-  extractOutput: () => [
-    { url: 'https://blobs.example/f.webp', width: null, height: null, nsfwLevel: null },
-  ],
+  // 🔴 NO `extractOutput`. A `'textOutput'` entry may not declare one (registry
+  // clause 8-ii + `TextOutputSurface.extractOutput?: never`): `media.url` is a
+  // bare string that reaches `snapshot.imageUrls` without meeting the scan.
   canonicalOutputFor: () => ({
     $type: CHAT_TYPE,
     output: { choices: [{ message: { content: 'canonical reply' } }] },
@@ -256,12 +260,19 @@ function scanReturns(triggeredLabels: string[]) {
           // release everything here.
           blocked: false,
           triggeredLabels,
-          results: triggeredLabels.map((label) => ({
+          // 🔴 ONE `results[]` ENTRY PER REQUESTED LABEL, triggered or not —
+          // which is what the real scanner returns and what the label-drift
+          // guard requires. A fixture that emitted results only for the
+          // TRIGGERED labels would make every release in this file withhold for
+          // the wrong reason, and the positive controls would die without ever
+          // testing the policy. (That the fixture had to change is itself the
+          // reachability proof for that guard.)
+          results: TEXT_OUTPUT_SCAN_LABELS.map((label) => ({
             label,
             action: 'Scan',
             threshold: 0.5,
-            score: 0.98,
-            triggered: true,
+            score: triggeredLabels.includes(label) ? 0.98 : 0.02,
+            triggered: triggeredLabels.includes(label),
           })),
         },
       },
@@ -330,6 +341,13 @@ beforeEach(() => {
   mockCheckBlockCatalogRateLimit.mockResolvedValue({ allowed: true });
   mockLogToAxiom.mockResolvedValue(undefined);
   mockCancelWorkflow.mockResolvedValue(undefined);
+  // 🔴 THE VERDICT MEMO IS MODULE-LIFETIME. Without this reset, a case that
+  // withholds `GENERATED_TEXT` would answer the NEXT case's identical content
+  // from cache — so the positive controls below would be asserting the previous
+  // test's scan, and a broken policy could pass. Every pair in this file uses the
+  // same fixture text on purpose (only the verdict differs), which is exactly
+  // the shape the memo would collapse.
+  __clearTextOutputVerdictCacheForTests();
   registryOverride.clear();
   registryOverride.set(CHAT_TYPE, textStep);
 });

--- a/src/server/routers/__tests__/blocks.router.textOutputModeration.test.ts
+++ b/src/server/routers/__tests__/blocks.router.textOutputModeration.test.ts
@@ -1,0 +1,499 @@
+import type * as StepsModule from '~/server/services/blocks/steps';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * ROUTER-LEVEL proof that the `'textOutput'` posture is wired, not merely
+ * implemented.
+ *
+ * 🔴 WHY THIS FILE EXISTS ON TOP OF THE SERVICE-LEVEL SUITE. The service suite
+ * (`services/blocks/steps/__tests__/step-text-output-moderation.test.ts`) proves
+ * `attachModeratedStepTextOutputs` withholds. That is a statement about a
+ * function. It says nothing about whether any *procedure a block can call*
+ * routes through it — and "the guard is correct but unreachable" is the exact
+ * shape of an inert feature. So these drive the real tRPC procedures
+ * (`blocks.pollWorkflow`, `blocks.cancelWorkflow`), the two surfaces a block
+ * receives a finished generation on, and assert the generated string is not in
+ * the payload they return.
+ *
+ * Every withhold assertion is PAIRED with a positive control that changes ONLY
+ * the scan verdict — otherwise "the text is absent" would be equally consistent
+ * with a harness that never produced any text at all.
+ *
+ * Mock strategy mirrors `blocks.router.appSubqueue.test.ts`: every dependency at
+ * the module boundary, so the router runs in-process.
+ */
+
+const {
+  mockVerifyBlockToken,
+  mockParseSubjectUserId,
+  mockGetOrchestratorToken,
+  mockQueryWorkflows,
+  mockGetWorkflow,
+  mockCancelWorkflow,
+  mockSubmitWorkflow,
+  mockGetUserById,
+  mockCheckBlockCatalogRateLimit,
+  mockGetSessionUser,
+  mockDbRead,
+  mockRedis,
+  mockSysRedis,
+  mockIsAppBlocksEnabled,
+  mockIsAppBlocksAuthorEnabled,
+  mockCreateXGuardModerationRequest,
+  mockLogToAxiom,
+} = vi.hoisted(() => ({
+  mockVerifyBlockToken: vi.fn(),
+  mockParseSubjectUserId: vi.fn(),
+  mockGetOrchestratorToken: vi.fn(),
+  mockQueryWorkflows: vi.fn(),
+  mockGetWorkflow: vi.fn(),
+  mockCancelWorkflow: vi.fn(),
+  mockSubmitWorkflow: vi.fn(),
+  mockGetUserById: vi.fn(),
+  mockCheckBlockCatalogRateLimit: vi.fn(async () => ({ allowed: true })),
+  mockGetSessionUser: vi.fn(),
+  mockDbRead: {
+    modelVersion: { findUnique: vi.fn(), findFirst: vi.fn(), findMany: vi.fn() },
+    modelBlockInstall: { findUnique: vi.fn() },
+    blockUserSettings: { findUnique: vi.fn() },
+    modelMetric: { findFirst: vi.fn() },
+  },
+  mockRedis: {
+    get: vi.fn(async () => null),
+    set: vi.fn(async () => undefined),
+    del: vi.fn(async () => 0),
+    incr: vi.fn(async () => 1),
+    incrBy: vi.fn(async () => 1),
+    decrBy: vi.fn(async () => 0),
+    expire: vi.fn(async () => true),
+    ttl: vi.fn(async () => -1),
+    exists: vi.fn(async () => 0),
+  },
+  mockSysRedis: {
+    get: vi.fn(async () => null),
+    incrBy: vi.fn(async () => 0),
+    decrBy: vi.fn(async () => 0),
+    expire: vi.fn(async () => true),
+    ttl: vi.fn(async () => -1),
+  },
+  mockIsAppBlocksEnabled: vi.fn(async () => true),
+  mockIsAppBlocksAuthorEnabled: vi.fn(
+    async (opts?: { user?: { isModerator?: boolean } }) => !!opts?.user?.isModerator
+  ),
+  mockCreateXGuardModerationRequest: vi.fn(),
+  mockLogToAxiom: vi.fn(async () => undefined),
+}));
+
+vi.mock('~/server/middleware/block-scope.middleware', () => ({
+  verifyBlockToken: mockVerifyBlockToken,
+  parseSubjectUserId: (...args: unknown[]) => mockParseSubjectUserId(...args),
+}));
+vi.mock('~/server/orchestrator/get-orchestrator-token', () => ({
+  getOrchestratorToken: mockGetOrchestratorToken,
+}));
+vi.mock('~/server/services/orchestrator/workflows', () => ({
+  queryWorkflows: mockQueryWorkflows,
+  getWorkflow: mockGetWorkflow,
+  cancelWorkflow: mockCancelWorkflow,
+  submitWorkflow: mockSubmitWorkflow,
+}));
+vi.mock('~/server/services/blocks/block-workflows.service', () => ({
+  blockWorkflowOwnedByAppUser: vi.fn(async () => true),
+  upsertBlockWorkflowOnSubmit: vi.fn(async () => undefined),
+  updateBlockWorkflowStatus: vi.fn(async () => undefined),
+  listMyBlockWorkflows: vi.fn(async () => ({ items: [], nextCursor: null })),
+}));
+vi.mock('~/server/services/blocks/user-app-surface.service', () => ({
+  recordScopeInvocation: vi.fn(async () => undefined),
+}));
+vi.mock('~/server/services/user.service', () => ({ getUserById: mockGetUserById }));
+vi.mock('~/server/auth/session-client', () => ({
+  sessionClient: { getSessionUserById: (...args: unknown[]) => mockGetSessionUser(...args) },
+}));
+vi.mock('~/server/db/client', () => ({
+  dbRead: mockDbRead,
+  dbWrite: {
+    modelBlockInstall: { findUnique: vi.fn() },
+    model: { findUnique: vi.fn() },
+    user: { findUnique: vi.fn() },
+  },
+}));
+
+const { completeKeys } = vi.hoisted(() => {
+  const group = (explicit: Record<string, string>, name: string): Record<string, string> =>
+    new Proxy(explicit, {
+      get: (t, k) =>
+        k in t
+          ? (t as Record<string, string>)[k as string]
+          : typeof k === 'string'
+          ? `mock:${name}:${k}`
+          : (t as Record<string, string>)[k as string],
+    });
+  const completeKeys = (explicit: Record<string, Record<string, string>>) =>
+    new Proxy(explicit, {
+      get: (t, g) =>
+        g in t
+          ? group((t as Record<string, Record<string, string>>)[g as string], g as string)
+          : typeof g === 'string'
+          ? group({}, g)
+          : (t as Record<string, Record<string, string>>)[g as string],
+    });
+  return { completeKeys };
+});
+vi.mock('~/server/redis/client', () => ({
+  redis: mockRedis,
+  sysRedis: mockSysRedis,
+  REDIS_KEYS: completeKeys({ BLOCKS: { POPULAR_CHECKPOINT: 'blocks:popular-checkpoint' } }),
+  REDIS_SYS_KEYS: completeKeys({ BLOCKS: { BUZZ_CAP: 'system:blocks:buzz-cap' } }),
+}));
+vi.mock('~/server/services/app-blocks-flag', () => ({
+  isAppBlocksEnabled: mockIsAppBlocksEnabled,
+  isAppBlocksAuthorEnabled: mockIsAppBlocksAuthorEnabled,
+}));
+vi.mock('~/server/utils/block-catalog-rate-limit', () => ({
+  checkBlockCatalogRateLimit: (...args: unknown[]) => mockCheckBlockCatalogRateLimit(...args),
+}));
+vi.mock('~/server/middleware.trpc', async () => {
+  const { middleware } = await import('~/server/trpc');
+  return { rateLimit: () => middleware(({ next }) => next()) };
+});
+
+// The scanner + its log. Everything else about the moderation path is REAL.
+vi.mock('~/server/services/orchestrator/orchestrator.service', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return { ...actual, createXGuardModerationRequest: mockCreateXGuardModerationRequest };
+});
+vi.mock('~/server/logging/client', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return { ...actual, logToAxiom: mockLogToAxiom };
+});
+
+// 🔴 A `'textOutput'` STEP IS INJECTED INTO THE REGISTRY LOOKUP, because no such
+// entry is registered yet — that is the follow-up PR. Without it, the read path
+// has nothing to dispatch on and these tests would silently assert nothing.
+// ONLY `getStepByOrchestratorType` is overridden; every gate, invariant and
+// posture declaration is the real one.
+const registryOverride = new Map<string, unknown>();
+vi.mock('~/server/services/blocks/steps', async (importOriginal) => {
+  const actual = await importOriginal<StepsModule>();
+  return {
+    ...actual,
+    getStepByOrchestratorType: (t: string) =>
+      registryOverride.get(t) ?? actual.getStepByOrchestratorType(t),
+  };
+});
+
+import * as z from 'zod';
+import { blocksRouter } from '../blocks.router';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
+import {
+  allBrowsingLevelsFlag,
+  sfwBrowsingLevelsFlag,
+} from '~/shared/constants/browsingLevel.constants';
+import { assertStepInvariants, type AnyBlockStep } from '~/server/services/blocks/steps';
+import { TEXT_OUTPUT_WITHHELD_MESSAGE } from '~/server/services/blocks/steps/text-output-moderation';
+
+const CHAT_TYPE = 'fixtureChat';
+const GENERATED_TEXT = 'the model wrote this exact sentence';
+
+const textStep: AnyBlockStep = {
+  id: 'fixture-chat',
+  orchestratorType: CHAT_TYPE,
+  billingMode: 'prepaidFixed',
+  moderationPosture: 'textOutput',
+  resourcePolicy: { kind: 'none' },
+  paramSchema: z.object({ value: z.number().int().min(1).max(10) }).strict(),
+  variants: ['default'],
+  resolveVariant: () => 'default',
+  canonicalParamsFor: () => ({ value: 1 }),
+  priceForVariant: () => 7,
+  estimateBuzz: () => 7,
+  buildStep: (p: { value: number }) => ({ $type: CHAT_TYPE, input: { value: p.value } }),
+  extractOutput: () => [
+    { url: 'https://blobs.example/f.webp', width: null, height: null, nsfwLevel: null },
+  ],
+  canonicalOutputFor: () => ({
+    $type: CHAT_TYPE,
+    output: { choices: [{ message: { content: 'canonical reply' } }] },
+  }),
+  extractText: (step: unknown) =>
+    (
+      (step as { output?: { choices?: Array<{ message?: { content?: string } }> } })?.output
+        ?.choices ?? []
+    )
+      .map((c) => c.message?.content ?? '')
+      .filter((t) => t.length > 0),
+} as AnyBlockStep;
+
+function chatWorkflow(content = GENERATED_TEXT) {
+  return {
+    id: 'wf_1',
+    status: 'succeeded',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    cost: { total: 7 },
+    steps: [
+      {
+        $type: CHAT_TYPE,
+        name: 's',
+        status: 'succeeded',
+        metadata: {},
+        output: { choices: [{ message: { content } }] },
+      },
+    ],
+  };
+}
+
+function scanReturns(triggeredLabels: string[]) {
+  mockCreateXGuardModerationRequest.mockResolvedValue({
+    id: 'scan_wf',
+    status: 'succeeded',
+    steps: [
+      {
+        $type: 'xGuardModeration',
+        output: {
+          // 🔴 `blocked: false` even on a real hit — that is what the deployed
+          // scanner returns for a `Scan`-action label, and reading it would
+          // release everything here.
+          blocked: false,
+          triggeredLabels,
+          results: triggeredLabels.map((label) => ({
+            label,
+            action: 'Scan',
+            threshold: 0.5,
+            score: 0.98,
+            triggered: true,
+          })),
+        },
+      },
+    ],
+  });
+}
+
+function validClaims(over: Record<string, unknown> = {}) {
+  return {
+    iss: 'civitai',
+    aud: 'civitai-app-block',
+    sub: 'user:42',
+    iat: 0,
+    exp: 0,
+    jti: 'jti_test',
+    blockId: 'blk_test',
+    appId: 'app_test',
+    appBlockId: 'apb_test',
+    blockInstanceId: 'bki_test',
+    ctx: { slotId: 'none', entityType: 'none' },
+    scopes: ['ai:write:budgeted'],
+    buzzBudget: 50,
+    ...over,
+  };
+}
+
+function fakeCtx() {
+  return {
+    acceptableOrigin: true,
+    user: undefined,
+    apiKeyId: null,
+    tokenScope: TokenScope.Full,
+    req: { headers: {} } as never,
+    res: { setHeader: () => undefined } as never,
+    cache: { edgeTTL: 0 },
+    features: { canViewNsfw: false, isBlue: false, isGreen: false, isGreenSession: false } as never,
+    track: undefined,
+  };
+}
+
+beforeEach(() => {
+  for (const fn of [
+    mockVerifyBlockToken,
+    mockParseSubjectUserId,
+    mockGetOrchestratorToken,
+    mockGetWorkflow,
+    mockCancelWorkflow,
+    mockGetUserById,
+    mockGetSessionUser,
+    mockCheckBlockCatalogRateLimit,
+    mockIsAppBlocksEnabled,
+    mockIsAppBlocksAuthorEnabled,
+    mockCreateXGuardModerationRequest,
+    mockLogToAxiom,
+  ]) {
+    fn.mockReset();
+  }
+  mockIsAppBlocksEnabled.mockImplementation(async () => true);
+  mockIsAppBlocksAuthorEnabled.mockImplementation(
+    async (opts?: { user?: { isModerator?: boolean } }) => !!opts?.user?.isModerator
+  );
+  mockGetUserById.mockResolvedValue({ id: 42, isModerator: true, tier: 'free' });
+  mockGetSessionUser.mockResolvedValue({ id: 42, isModerator: true, tier: 'free' });
+  mockParseSubjectUserId.mockImplementation((sub: string) => (sub === 'anon' ? null : 42));
+  mockGetOrchestratorToken.mockResolvedValue('orch_token');
+  mockCheckBlockCatalogRateLimit.mockResolvedValue({ allowed: true });
+  mockLogToAxiom.mockResolvedValue(undefined);
+  mockCancelWorkflow.mockResolvedValue(undefined);
+  registryOverride.clear();
+  registryOverride.set(CHAT_TYPE, textStep);
+});
+
+describe('blocks.pollWorkflow — textOutput moderation is WIRED', () => {
+  it('the injected fixture is a genuinely registrable entry (the suite CONTROL)', () => {
+    expect(() => assertStepInvariants('fixture-chat', textStep)).not.toThrow();
+  });
+
+  it('🔴 WITHHOLDS flagged generated text from the poll reply', async () => {
+    mockVerifyBlockToken.mockResolvedValue(validClaims());
+    mockGetWorkflow.mockResolvedValue(chatWorkflow());
+    scanReturns(['Grooming']);
+
+    const caller = blocksRouter.createCaller(fakeCtx() as never);
+    const result = await caller.pollWorkflow({ blockToken: 'tok', workflowId: 'wf_1' });
+
+    // The whole payload the block receives — not just the field we happen to
+    // know about.
+    expect(JSON.stringify(result)).not.toContain(GENERATED_TEXT);
+    expect(result.snapshot.textOutputs).toBeUndefined();
+    expect(result.snapshot.textOutputWithheld).toEqual({ reason: TEXT_OUTPUT_WITHHELD_MESSAGE });
+    // The rest of the snapshot is unaffected.
+    expect(result.snapshot.status).toBe('succeeded');
+    expect(result.snapshot.cost).toEqual({ total: 7 });
+  });
+
+  it('🔴 POSITIVE CONTROL — the same poll DELIVERS the text on a clean scan', async () => {
+    mockVerifyBlockToken.mockResolvedValue(validClaims());
+    mockGetWorkflow.mockResolvedValue(chatWorkflow());
+    scanReturns([]);
+
+    const caller = blocksRouter.createCaller(fakeCtx() as never);
+    const result = await caller.pollWorkflow({ blockToken: 'tok', workflowId: 'wf_1' });
+
+    expect(result.snapshot.textOutputs).toEqual([GENERATED_TEXT]);
+    expect(result.snapshot.textOutputWithheld).toBeUndefined();
+  });
+
+  it('WITHHOLDS when the scanner is down (fails CLOSED on the read path)', async () => {
+    mockVerifyBlockToken.mockResolvedValue(validClaims());
+    mockGetWorkflow.mockResolvedValue(chatWorkflow());
+    mockCreateXGuardModerationRequest.mockRejectedValue(new Error('scanner 503'));
+
+    const caller = blocksRouter.createCaller(fakeCtx() as never);
+    const result = await caller.pollWorkflow({ blockToken: 'tok', workflowId: 'wf_1' });
+
+    expect(JSON.stringify(result)).not.toContain(GENERATED_TEXT);
+    expect(result.snapshot.textOutputWithheld).toBeDefined();
+    // 🔴 And the poll still SUCCEEDS. A scanner outage must not turn every poll
+    // into a 500 — the caller has already paid and still needs status + cost.
+    expect(result.snapshot.status).toBe('succeeded');
+  });
+
+  it('🔴 derives the SFW tier from the TOKEN CEILING, in both directions', async () => {
+    // `Suggestive` is in the maturity-gated tier. A SFW-ceiling token withholds
+    // it; a mature-allowed token does not. Nothing in the REQUEST differs — only
+    // the server-minted claim. A handler reading a body field, or hardcoding
+    // `isGreen`, passes exactly one of these.
+    mockGetWorkflow.mockResolvedValue(chatWorkflow());
+    const caller = blocksRouter.createCaller(fakeCtx() as never);
+
+    scanReturns(['Suggestive']);
+    mockVerifyBlockToken.mockResolvedValue(
+      validClaims({ maxBrowsingLevel: sfwBrowsingLevelsFlag })
+    );
+    const sfw = await caller.pollWorkflow({ blockToken: 'tok', workflowId: 'wf_1' });
+    expect(sfw.snapshot.textOutputs).toBeUndefined();
+
+    scanReturns(['Suggestive']);
+    mockVerifyBlockToken.mockResolvedValue(
+      validClaims({ maxBrowsingLevel: allBrowsingLevelsFlag })
+    );
+    const mature = await caller.pollWorkflow({ blockToken: 'tok', workflowId: 'wf_1' });
+    expect(mature.snapshot.textOutputs).toEqual([GENERATED_TEXT]);
+  });
+
+  it('a token with NO maturity claim gets the STRICT tier (fail closed)', async () => {
+    mockGetWorkflow.mockResolvedValue(chatWorkflow());
+    scanReturns(['NSFW']);
+    mockVerifyBlockToken.mockResolvedValue(validClaims()); // no maxBrowsingLevel
+    const caller = blocksRouter.createCaller(fakeCtx() as never);
+    const result = await caller.pollWorkflow({ blockToken: 'tok', workflowId: 'wf_1' });
+    expect(result.snapshot.textOutputs).toBeUndefined();
+  });
+
+  it('a plain textToImage poll is UNCHANGED — no scan, no new keys', async () => {
+    // 🔴 The regression guard for every existing block. This wiring must be
+    // additive: the pre-existing image path must not gain a scan, a latency hit,
+    // or a wire field.
+    mockVerifyBlockToken.mockResolvedValue(validClaims());
+    mockGetWorkflow.mockResolvedValue({
+      id: 'wf_1',
+      status: 'succeeded',
+      cost: { total: 10 },
+      steps: [
+        {
+          $type: 'textToImage',
+          name: 's',
+          status: 'succeeded',
+          metadata: {},
+          output: { images: [{ id: 'b', url: 'https://cdn/i.png', available: true }] },
+        },
+      ],
+    });
+    const caller = blocksRouter.createCaller(fakeCtx() as never);
+    const result = await caller.pollWorkflow({ blockToken: 'tok', workflowId: 'wf_1' });
+
+    expect(mockCreateXGuardModerationRequest).not.toHaveBeenCalled();
+    expect(result.snapshot.imageUrls).toEqual(['https://cdn/i.png']);
+    expect(Object.keys(result.snapshot).sort()).toEqual([
+      'cost',
+      'imageUrls',
+      'status',
+      'workflowId',
+    ]);
+  });
+});
+
+describe('blocks.cancelWorkflow — the same boundary', () => {
+  it('🔴 WITHHOLDS flagged text from a cancel reply', async () => {
+    mockVerifyBlockToken.mockResolvedValue(validClaims());
+    mockGetWorkflow.mockResolvedValue({ ...chatWorkflow(), status: 'canceled' });
+    scanReturns(['Extremism']);
+
+    const caller = blocksRouter.createCaller(fakeCtx() as never);
+    const result = await caller.cancelWorkflow({ blockToken: 'tok', workflowId: 'wf_1' });
+
+    expect(JSON.stringify(result)).not.toContain(GENERATED_TEXT);
+    expect(result.snapshot.textOutputWithheld).toEqual({ reason: TEXT_OUTPUT_WITHHELD_MESSAGE });
+  });
+
+  it('🔴 POSITIVE CONTROL — the same cancel delivers the text on a clean scan', async () => {
+    mockVerifyBlockToken.mockResolvedValue(validClaims());
+    mockGetWorkflow.mockResolvedValue({ ...chatWorkflow(), status: 'canceled' });
+    scanReturns([]);
+
+    const caller = blocksRouter.createCaller(fakeCtx() as never);
+    const result = await caller.cancelWorkflow({ blockToken: 'tok', workflowId: 'wf_1' });
+
+    expect(result.snapshot.textOutputs).toEqual([GENERATED_TEXT]);
+  });
+
+  it('🔴 derives the SFW tier from the TOKEN CEILING here too, in both directions', async () => {
+    // 🔴 THIS TEST EXISTS BECAUSE THE MUTATION SWEEP FOUND ITS ABSENCE. With
+    // only the always-withhold label asserted on this path, hardcoding
+    // `isGreen: false` in the CANCEL wiring SURVIVED — the poll's equivalent
+    // test could not see it, because each procedure passes its own `isGreen`.
+    // Two call sites need two both-direction tests.
+    mockGetWorkflow.mockResolvedValue({ ...chatWorkflow(), status: 'canceled' });
+    const caller = blocksRouter.createCaller(fakeCtx() as never);
+
+    scanReturns(['Suggestive']);
+    mockVerifyBlockToken.mockResolvedValue(
+      validClaims({ maxBrowsingLevel: sfwBrowsingLevelsFlag })
+    );
+    const sfw = await caller.cancelWorkflow({ blockToken: 'tok', workflowId: 'wf_1' });
+    expect(sfw.snapshot.textOutputs).toBeUndefined();
+
+    scanReturns(['Suggestive']);
+    mockVerifyBlockToken.mockResolvedValue(
+      validClaims({ maxBrowsingLevel: allBrowsingLevelsFlag })
+    );
+    const mature = await caller.cancelWorkflow({ blockToken: 'tok', workflowId: 'wf_1' });
+    expect(mature.snapshot.textOutputs).toEqual([GENERATED_TEXT]);
+  });
+});

--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -159,7 +159,10 @@ import {
 // itself is imported by `workflow.schema` for the wire enum, which must stay
 // import-light. Dispatches on the entry's declared `moderationPosture`, so this
 // router keeps no per-posture branch either.
-import { runStepModeration } from '~/server/services/blocks/steps/moderation';
+import {
+  attachModeratedStepTextOutputs,
+  runStepModeration,
+} from '~/server/services/blocks/steps/moderation';
 // Instrument-only: records EVERY prepaidFixed step price check at submit —
 // `exact` / `over` / `absent` — so a flat "no divergence" line can be told apart
 // from a detector that never ran. Never throws.
@@ -3071,7 +3074,23 @@ export const blocksRouter = router({
       await assertViewerIsAppDeveloper(userId);
       const token = await getOrchestratorToken(userId, ctx);
       const workflow = await getWorkflow({ token, path: { workflowId: input.workflowId } });
-      const snapshot = snapshotFromWorkflow(workflow);
+      // 🔴 THE OUTPUT-MODERATION BOUNDARY. `snapshotFromWorkflow` cannot emit
+      // generated text (it reads `extractOutput`, which returns media), so this
+      // wrapper is the ONLY thing that can — and it scans before it does. The
+      // poll is the surface that matters: it is the snapshot a block renders a
+      // finished generation from.
+      const snapshot = await attachModeratedStepTextOutputs(
+        snapshotFromWorkflow(workflow),
+        workflow,
+        {
+          userId,
+          // 🔴 The token's server-minted maturity ceiling — same source the
+          // submit-phase prompt audit uses. Never a request-body field.
+          isGreen: resolveBlockMaturity(claims).isGreen,
+          appId: claims.appId,
+          appBlockId: claims.blockId,
+        }
+      );
       // G6 — mirror an observed TERMINAL status into the durable read-model.
       // The orchestrator completion callback (`workflow-completed.ts`) is not
       // wired to fire, so `block_workflows` rows otherwise stay `pending`
@@ -3203,7 +3222,19 @@ export const blocksRouter = router({
       const token = await getOrchestratorToken(userId, ctx);
       await cancelWorkflow({ workflowId: input.workflowId, token });
       const workflow = await getWorkflow({ token, path: { workflowId: input.workflowId } });
-      const snapshot = snapshotFromWorkflow(workflow);
+      // Same output-moderation boundary as `pollWorkflow`. A CANCEL still
+      // returns a snapshot of whatever the orchestrator had produced, so it is a
+      // real text-publishing surface and not a formality.
+      const snapshot = await attachModeratedStepTextOutputs(
+        snapshotFromWorkflow(workflow),
+        workflow,
+        {
+          userId,
+          isGreen: resolveBlockMaturity(claims).isGreen,
+          appId: claims.appId,
+          appBlockId: claims.blockId,
+        }
+      );
       // customComfy post-paid SETTLE (plan §5.3): a mid-run cancel BILLS the
       // accrued cost (orchestrator-side, non-refundable), so settle refunds the
       // reserved CEILING down to that accrued `cost.total` on BOTH reservation

--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -3083,11 +3083,19 @@ export const blocksRouter = router({
       //
       // 🔴 IT IS NOT THE ONLY BLOCK-REACHABLE READ OF A WORKFLOW, and an earlier
       // revision of this comment said "the poll is the surface that matters",
-      // which is an overclaim a reviewer would stop checking at.
-      // `queryAppWorkflows` and `cancelAppWorkflow` also return orchestrator
-      // workflow data to a block, unwrapped. What makes THAT safe is stated at
-      // each of them (`AppWorkflow` carries no text field and its `images` are
-      // posture-gated), not this sentence.
+      // which is an overclaim a reviewer would stop checking at. THREE other
+      // procedures reach `projectAppWorkflow` unwrapped:
+      //   - `queryAppWorkflows` — returns up to 50 projections per call.
+      //   - `cancelAppWorkflow` — returns one.
+      //   - `publishGenerationOutputs` — the SHARPEST of the three, and the one
+      //     an enumeration is most likely to miss because it returns no
+      //     projection to the block at all: it reads `projectAppWorkflow(...)
+      //     .images`, then FETCHES each selected `url` server-side and uploads
+      //     it into a public civitai `Image` row. A smuggled url would not just
+      //     be displayed, it would be ingested.
+      // What makes all three safe is stated at each of them (`AppWorkflow`
+      // carries no text field and its `images` are posture-gated, so a text step
+      // contributes nothing — not even a url), not this sentence.
       const snapshot = await attachModeratedStepTextOutputs(
         snapshotFromWorkflow(workflow),
         workflow,
@@ -3544,6 +3552,19 @@ export const blocksRouter = router({
       // The SAME ordered projection queryAppWorkflows hands the block — so the
       // block's `imageIndexes` line up exactly with what it saw. Only `available`
       // outputs with a non-null url are present (dead/pending blobs are dropped).
+      //
+      // 🔴 UNWRAPPED BY `attachModeratedStepTextOutputs`, and this is the
+      // HIGHEST-CONSEQUENCE of the three unwrapped `projectAppWorkflow`
+      // consumers (see the enumeration at `pollWorkflow`): the urls below are
+      // not merely returned, they are FETCHED and re-uploaded into public
+      // civitai `Image` rows. What makes it safe is the same posture gate the
+      // others rely on — `projectAppWorkflow` calls a registered entry's
+      // `extractOutput` only when `postureProducesMedia(...)`, and a
+      // text-posture entry may not declare one at all
+      // (`TextOutputSurface.extractOutput?: never`, registry clause 8-ii) — so a
+      // `'textOutput'` step contributes NO url here to be ingested. If that gate
+      // ever loosens, THIS is the call site that turns a smuggled string into
+      // published content.
       const outputs = projectAppWorkflow(workflow).images;
       if (outputs.length === 0) {
         throw new TRPCError({

--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -3075,10 +3075,19 @@ export const blocksRouter = router({
       const token = await getOrchestratorToken(userId, ctx);
       const workflow = await getWorkflow({ token, path: { workflowId: input.workflowId } });
       // 🔴 THE OUTPUT-MODERATION BOUNDARY. `snapshotFromWorkflow` cannot emit
-      // generated text (it reads `extractOutput`, which returns media), so this
-      // wrapper is the ONLY thing that can — and it scans before it does. The
-      // poll is the surface that matters: it is the snapshot a block renders a
-      // finished generation from.
+      // generated text: it publishes `imageUrls` off `extractOutput`, which a
+      // text-posture entry may not declare (`TextOutputSurface.extractOutput?:
+      // never`, registry clause 8-ii, and the posture gate on the extractor call
+      // itself). So this wrapper is the only producer of `textOutputs`, and it
+      // scans before it produces.
+      //
+      // 🔴 IT IS NOT THE ONLY BLOCK-REACHABLE READ OF A WORKFLOW, and an earlier
+      // revision of this comment said "the poll is the surface that matters",
+      // which is an overclaim a reviewer would stop checking at.
+      // `queryAppWorkflows` and `cancelAppWorkflow` also return orchestrator
+      // workflow data to a block, unwrapped. What makes THAT safe is stated at
+      // each of them (`AppWorkflow` carries no text field and its `images` are
+      // posture-gated), not this sentence.
       const snapshot = await attachModeratedStepTextOutputs(
         snapshotFromWorkflow(workflow),
         workflow,
@@ -3326,6 +3335,26 @@ export const blocksRouter = router({
         cursor: input.cursor ?? undefined,
         hideMatureContent: false,
       });
+      // 🔴 DELIBERATELY *NOT* WRAPPED IN `attachModeratedStepTextOutputs`, and
+      // here is exactly what makes that safe — stated as what it is, so nobody
+      // reads a structural guarantee where there is a narrower one.
+      //
+      //   1. `AppWorkflow` HAS NO TEXT FIELD. The projection's return type is
+      //      `{ workflowId, status, images, cost, createdAt }` — there is no
+      //      `textOutputs`/`textOutputWithheld` to populate, so wrapping would
+      //      have nowhere to put a verdict. A block that wants a text step's
+      //      output polls `pollWorkflow`, which is wrapped.
+      //   2. `images` IS POSTURE-GATED. `projectAppWorkflow` calls a registered
+      //      entry's `extractOutput` only when `postureProducesMedia(...)`, and a
+      //      text-posture entry cannot declare one at all
+      //      (`TextOutputSurface.extractOutput?: never`, registry clause 8-ii).
+      //      So a text step contributes NOTHING here — not even a url.
+      //
+      // 🔴 AND THE COST ARGUMENT, because it is the reason not to "just wrap it
+      // for symmetry": this returns up to 50 workflows per call, so wrapping
+      // would mean up to 50 inline xGuard scans on a rate-limited read path.
+      // If `AppWorkflow` ever GAINS a text field, wrapping stops being optional
+      // and the per-page fan-out has to be solved, not skipped.
       return {
         workflows: items.map(projectAppWorkflow),
         cursor: nextCursor ?? null,
@@ -3420,6 +3449,13 @@ export const blocksRouter = router({
       // Both guards passed — cancel, then re-read + project the terminal state.
       await cancelWorkflow({ workflowId: input.workflowId, token });
       const canceled = await getWorkflow({ token, path: { workflowId: input.workflowId } });
+      // 🔴 UNWRAPPED, for the SAME two reasons `queryAppWorkflows` is (see the
+      // note there): `AppWorkflow` carries no text field, and its `images` are
+      // posture-gated so a text step contributes nothing. The cost argument does
+      // NOT apply here — this is one workflow, not a page — so if `AppWorkflow`
+      // ever gains a text field, THIS is the cheap one to wrap first. (The
+      // sibling `blocks.cancelWorkflow`, which returns a full snapshot rather
+      // than this projection, IS wrapped.)
       return { workflow: projectAppWorkflow(canceled) };
     }),
 

--- a/src/server/schema/blocks/workflow.schema.ts
+++ b/src/server/schema/blocks/workflow.schema.ts
@@ -401,23 +401,57 @@ export type BlockWorkflowSnapshot = {
    * is `'textOutput'` — and which has PASSED an output moderation scan.
    *
    * 🔴 EVERY STRING HERE HAS BEEN SCANNED. That is a property of how the field
-   * is produced, not a promise about who sets it: `snapshotFromWorkflow` and
-   * `projectAppWorkflow` are pure and synchronous and read only `extractOutput`,
-   * which returns MEDIA — neither can put prose in a snapshot at all. The single
-   * producer is `attachModeratedStepTextOutputs`
-   * (`services/blocks/steps/moderation`), which runs the scan and strips any
-   * incoming value of this field before merging its own. Do NOT set it anywhere
-   * else; doing so would be publishing unscanned model output, which is the one
-   * thing the `'textOutput'` posture exists to prevent.
+   * is produced, not a promise about who sets it. The single producer is
+   * `attachModeratedStepTextOutputs` (`services/blocks/steps/moderation`), which
+   * runs the scan and strips any incoming value of this field before merging its
+   * own. Do NOT set it anywhere else; doing so would be publishing unscanned
+   * model output, which is the one thing the `'textOutput'` posture exists to
+   * prevent.
+   *
+   * 🔴 BE EXACT ABOUT WHAT ENFORCES THAT — AN EARLIER REVISION OF THIS COMMENT
+   * WAS WRONG, AND IT IS RECORDED RATHER THAN QUIETLY REPLACED BECAUSE THIS IS
+   * THE WIRE-CONTRACT DOC AN ENTRY AUTHOR AND THE `@civitai/app-sdk`
+   * MIRROR-WRITER READ. It said `snapshotFromWorkflow` and `projectAppWorkflow`
+   * "are pure and synchronous and read only `extractOutput`, which returns MEDIA
+   * — neither can put prose in a snapshot at all". `StepOutputMedia.url` is a
+   * bare `string`, never URL-validated, and it reaches `snapshot.imageUrls` /
+   * `AppWorkflow.images[].url` without meeting the scan — so
+   * `extractOutput: () => [{ url: theModelsReply, … }]` on a text entry WOULD
+   * have published unscanned generated text with every gate green. Anyone
+   * trusting the old sentence would conclude a media extractor on a text entry
+   * is structurally harmless and propose relaxing registry clause 8-ii. It is
+   * not harmless; 8-ii is load-bearing.
+   *
+   * WHAT ACTUALLY HOLDS IT (all three off the one `stepOutputShape` predicate,
+   * and spelled out at `attachModeratedStepTextOutputs`): the TYPE
+   * (`TextOutputSurface.extractOutput?: never`), the LOAD-time registry clause
+   * 8-ii, and the READ path (both `workflow.service` extractors call
+   * `extractOutput` only when `postureProducesMedia(...)`). The original
+   * structural point does still stand on its own — a scan is an async network
+   * call and both projections are pure and synchronous, so neither could perform
+   * one — but it bounds only WHO CAN SCAN, never what a media extractor can
+   * smuggle.
    *
    * WHERE IT APPEARS: `blocks.pollWorkflow` and `blocks.cancelWorkflow` — the
-   * two surfaces a block reads a finished generation from. NOT on the submit
-   * replies, and that is not an oversight: the step submit passes no `wait`, so
-   * the reply is a freshly-queued workflow with no `output` to publish. It is
-   * also not load-bearing — a submit reply is built by `snapshotFromWorkflow`,
-   * which cannot emit this field at all, so an orchestrator that started
-   * answering submits with completed output would degrade to "the block polls
-   * once more", never to "unscanned text ships".
+   * two procedures wrapped by `attachModeratedStepTextOutputs`, and therefore
+   * the only two that can carry THIS FIELD.
+   *
+   * 🔴 THE EARLIER WORDING CALLED THEM "the two surfaces a block reads a
+   * finished generation from", WHICH IS AN OVERCLAIM — corrected at the poll
+   * itself for the same reason, and recorded here too. Three further procedures
+   * read a finished workflow on a block's behalf, UNWRAPPED:
+   * `blocks.queryAppWorkflows`, `blocks.cancelAppWorkflow` and
+   * `blocks.publishGenerationOutputs` (note these are DIFFERENT procedures from
+   * the similarly-named wrapped pair). What makes those three safe is stated at
+   * each of them — `AppWorkflow` has no text field, and its `images` are
+   * posture-gated — not here.
+   *
+   * NOT on the submit replies, and that is not an oversight: the step submit
+   * passes no `wait`, so the reply is a freshly-queued workflow with no `output`
+   * to publish. It is also not load-bearing — a submit reply is built by
+   * `snapshotFromWorkflow`, which does not produce this field, so an
+   * orchestrator that started answering submits with completed output would
+   * degrade to "the block polls once more", never to "unscanned text ships".
    *
    * OMITTED entirely when there is no text, so every existing snapshot stays
    * byte-identical.

--- a/src/server/schema/blocks/workflow.schema.ts
+++ b/src/server/schema/blocks/workflow.schema.ts
@@ -139,7 +139,10 @@ const blockTextToImageBodySchema = z.object({
   // LoRA-type model version that the server entitlement-gates per-resource and
   // base-model-family-matches against the checkpoint before any spend. Capped
   // at MAX_ADDITIONAL_RESOURCES for the iframe posture above.
-  additionalResources: z.array(blockAdditionalResourceSchema).max(MAX_ADDITIONAL_RESOURCES).optional(),
+  additionalResources: z
+    .array(blockAdditionalResourceSchema)
+    .max(MAX_ADDITIONAL_RESOURCES)
+    .optional(),
   // Optional img2img init/source image (App Blocks IMAGE bridge).
   // When present, the block bridge emits an img2img graph workflow whose VARIANT
   // is chosen from the checkpoint's ecosystem (buildImageWorkflowInput /
@@ -393,4 +396,50 @@ export type BlockWorkflowSnapshot = {
     applied: number;
     reason: ModelSubstitutionReason;
   }>;
+  /**
+   * Generated FREE TEXT produced by a registered step whose `moderationPosture`
+   * is `'textOutput'` — and which has PASSED an output moderation scan.
+   *
+   * 🔴 EVERY STRING HERE HAS BEEN SCANNED. That is a property of how the field
+   * is produced, not a promise about who sets it: `snapshotFromWorkflow` and
+   * `projectAppWorkflow` are pure and synchronous and read only `extractOutput`,
+   * which returns MEDIA — neither can put prose in a snapshot at all. The single
+   * producer is `attachModeratedStepTextOutputs`
+   * (`services/blocks/steps/moderation`), which runs the scan and strips any
+   * incoming value of this field before merging its own. Do NOT set it anywhere
+   * else; doing so would be publishing unscanned model output, which is the one
+   * thing the `'textOutput'` posture exists to prevent.
+   *
+   * WHERE IT APPEARS: `blocks.pollWorkflow` and `blocks.cancelWorkflow` — the
+   * two surfaces a block reads a finished generation from. NOT on the submit
+   * replies, and that is not an oversight: the step submit passes no `wait`, so
+   * the reply is a freshly-queued workflow with no `output` to publish. It is
+   * also not load-bearing — a submit reply is built by `snapshotFromWorkflow`,
+   * which cannot emit this field at all, so an orchestrator that started
+   * answering submits with completed output would degrade to "the block polls
+   * once more", never to "unscanned text ships".
+   *
+   * OMITTED entirely when there is no text, so every existing snapshot stays
+   * byte-identical.
+   *
+   * 🔴 WIRE CONTRACT: additive on the type `@civitai/app-sdk`'s `blocks/types.ts`
+   * mirrors, exactly like `modelSubstitutions` above. The SDK's inbound
+   * validator does not know it yet, so a block reads it only once that type is
+   * widened in the SDK repo — tracked separately; nothing here edits another repo.
+   */
+  textOutputs?: string[];
+  /**
+   * Set when generated text WAS produced but is being withheld — a content-policy
+   * hit, or a scanner error/timeout (the scan fails CLOSED).
+   *
+   * `reason` is a user-facing message, deliberately generic: it does not name the
+   * labels that triggered. The triggering labels + scores go to the per-app
+   * trigger log instead, which is where the actionable signal lives (an app whose
+   * outputs trigger constantly is telling you about its system prompt).
+   *
+   * Independent of `textOutputs` rather than mutually exclusive: a workflow with
+   * two text steps can release one and withhold the other, and both fields then
+   * appear.
+   */
+  textOutputWithheld?: { reason: string };
 };

--- a/src/server/services/blocks/steps/__tests__/step-moderation.test.ts
+++ b/src/server/services/blocks/steps/__tests__/step-moderation.test.ts
@@ -23,9 +23,18 @@ import * as z from 'zod';
  * ClickHouse, the DB client and the notification service).
  */
 
-const { mockAuditPromptServer } = vi.hoisted(() => ({ mockAuditPromptServer: vi.fn() }));
+const { mockAuditPromptServer, mockCreateXGuardModerationRequest } = vi.hoisted(() => ({
+  mockAuditPromptServer: vi.fn(),
+  mockCreateXGuardModerationRequest: vi.fn(),
+}));
 vi.mock('~/server/services/orchestrator/promptAuditing', () => ({
   auditPromptServer: mockAuditPromptServer,
+}));
+// The OUTPUT phase reaches `createXGuardModerationRequest`, which pulls the
+// Prisma client and the orchestrator HTTP client at import time. Mocked at the
+// module boundary for the same reason `auditPromptServer` is.
+vi.mock('~/server/services/orchestrator/orchestrator.service', () => ({
+  createXGuardModerationRequest: mockCreateXGuardModerationRequest,
 }));
 
 import {
@@ -246,22 +255,26 @@ describe('step moderation — dispatch over the posture table', () => {
     expect(loadIsModerator).not.toHaveBeenCalled();
   });
 
-  it("the unimplemented 'textOutput' posture FAILS CLOSED with a named error", async () => {
-    // Never `undefined is not a function`: a deliberate, named 500 on the seam.
-    await expect(
-      runStepModeration(
-        request({
-          step: makeStep({
-            moderationPosture: 'textOutput',
-            auditableText: undefined,
-          } as Partial<AnyBlockStep>),
-        })
-      )
-    ).rejects.toMatchObject({
-      code: 'INTERNAL_SERVER_ERROR',
-      message: "step 'fixture-step' declares an unimplemented moderation posture",
-    });
+  it("the 'textOutput' posture runs NOTHING at submit and does not resolve the viewer", async () => {
+    // 🔴 THE INERTNESS TRAP, ASSERTED FROM THE SUBMIT SIDE. `'textOutput'` scans
+    // GENERATED text, which does not exist at submit — the orchestrator has not
+    // been called. So the correct submit-phase behaviour is to do nothing, and
+    // the thing that makes that safe rather than inert is that the posture's
+    // REQUIRED phase is `output` (`posturePhaseRequirements`), asserted at module
+    // load. A submit-phase handler for this posture is a BUILD failure; see the
+    // phase-table suite below.
+    const loadIsModerator = vi.fn();
+    await runStepModeration(
+      request({
+        step: makeStep({
+          moderationPosture: 'textOutput',
+          auditableText: undefined,
+        } as Partial<AnyBlockStep>),
+        loadIsModerator,
+      })
+    );
     expect(mockAuditPromptServer).not.toHaveBeenCalled();
+    expect(loadIsModerator).not.toHaveBeenCalled();
   });
 
   // 🔴 THE PROTOTYPE-KEY ATTACK. A plain object literal inherits from
@@ -339,45 +352,104 @@ describe('step moderation — dispatch over the posture table', () => {
       } catch (e) {
         error = e;
       }
-      if (posture === 'textOutput') {
-        expect(String((error as { message?: string })?.message)).toContain(
-          'unimplemented moderation posture'
-        );
-      } else {
-        expect(error, `posture '${posture}' should have an implemented handler`).toBeUndefined();
-      }
+      expect(error, `posture '${posture}' should have an implemented handler`).toBeUndefined();
     }
   });
 });
 
-describe('step moderation — the handler table cannot drift from the declaration', () => {
-  const noop = async () => undefined;
+describe('step moderation — the PHASE table cannot drift from the declaration', () => {
+  const submitNoop = async () => undefined;
+  const outputNoop = async () => ({ released: true as const, texts: [] });
 
-  it('the SHIPPED table passes (it is asserted at module load; this pins it)', () => {
-    expect(() =>
-      assertModerationHandlerTable({ none: noop, promptAudit: noop, textOutput: null })
-    ).not.toThrow();
+  /** The shape the shipped table has. Every case below mutates exactly one slot. */
+  const shipped = () => ({
+    none: { submit: null, output: null },
+    promptAudit: { submit: submitNoop, output: null },
+    textOutput: { submit: null, output: outputNoop },
   });
 
-  it('rejects an IMPLEMENTED posture whose handler is absent (a 500 on a spend path)', () => {
-    expect(() =>
-      assertModerationHandlerTable({ none: noop, promptAudit: null, textOutput: null })
-    ).toThrow(/posture 'promptAudit' is declared IMPLEMENTED but its handler is absent/);
+  it('the SHIPPED shape passes (it is asserted at module load; this pins it)', () => {
+    // 🔴 THE CONTROL. If this ever throws, every rejection below could be dying
+    // to a clause other than the one it names.
+    expect(() => assertModerationHandlerTable(shipped())).not.toThrow();
   });
 
-  it('rejects an UNIMPLEMENTED posture that has a handler (the gate would be a lie)', () => {
+  it('rejects a posture whose REQUIRED phase has no handler (a 500 on a spend path)', () => {
     expect(() =>
-      assertModerationHandlerTable({ none: noop, promptAudit: noop, textOutput: noop })
-    ).toThrow(/posture 'textOutput' is declared UNIMPLEMENTED but its handler is present/);
+      assertModerationHandlerTable({ ...shipped(), promptAudit: { submit: null, output: null } })
+    ).toThrow(/posture 'promptAudit' is declared IMPLEMENTED but its required phases are MISSING/);
+  });
+
+  it("rejects a 'textOutput' posture with no OUTPUT handler", () => {
+    expect(() =>
+      assertModerationHandlerTable({ ...shipped(), textOutput: { submit: null, output: null } })
+    ).toThrow(/posture 'textOutput' is declared IMPLEMENTED but its required phases are MISSING/);
+  });
+
+  // 🔴 THE CLAUSE THAT MAKES THE POSTURE UN-FAKEABLE, AND THE REASON THE TABLE
+  // IS KEYED BY PHASE AT ALL.
+  //
+  // This is the mutation that WOULD SHIP AN INERT FEATURE if the assert only
+  // counted handlers: `'textOutput'` satisfied by a SUBMIT-phase handler. That
+  // handler runs before the orchestrator call, so there is no generated text to
+  // look at — it scans an empty string, returns cleanly, and reports success.
+  // The registry gate would pass, the posture would read as implemented, and
+  // generated text would reach blocks unscanned.
+  //
+  // Note what the assertion pins: the SUBMIT-PHASE message specifically, not
+  // merely "it threw". A version of this test matching /textOutput/ alone would
+  // also pass against the required-phase clause above and prove nothing about
+  // this one.
+  it("REJECTS 'textOutput' satisfied by a SUBMIT handler — the inert-feature shape", () => {
+    expect(() =>
+      assertModerationHandlerTable({
+        ...shipped(),
+        textOutput: { submit: submitNoop, output: outputNoop },
+      })
+    ).toThrow(
+      /posture 'textOutput' declares a submit-phase handler, but its moderation surface is not in that phase/
+    );
+  });
+
+  it("REJECTS 'promptAudit' carrying an OUTPUT handler — the mirror image", () => {
+    // The same clause in the other direction, so it cannot be satisfied by a
+    // one-sided check. An output handler on an input-only posture is a scan that
+    // never runs, reading as generated-text coverage.
+    expect(() =>
+      assertModerationHandlerTable({
+        ...shipped(),
+        promptAudit: { submit: submitNoop, output: outputNoop },
+      })
+    ).toThrow(
+      /posture 'promptAudit' declares a output-phase handler, but its moderation surface is not in that phase/
+    );
+  });
+
+  it("REJECTS 'none' carrying a handler in either phase", () => {
+    expect(() =>
+      assertModerationHandlerTable({ ...shipped(), none: { submit: submitNoop, output: null } })
+    ).toThrow(/posture 'none' declares a submit-phase handler/);
+    expect(() =>
+      assertModerationHandlerTable({ ...shipped(), none: { submit: null, output: outputNoop } })
+    ).toThrow(/posture 'none' declares a output-phase handler/);
+  });
+
+  it('rejects a posture with NO phase entry at all', () => {
+    expect(() =>
+      assertModerationHandlerTable({
+        ...shipped(),
+        textOutput: undefined as unknown as { submit: null; output: null },
+      })
+    ).toThrow(/posture 'textOutput' has no phase entry/);
   });
 
   it('checks EVERY declared posture, not just the first', () => {
-    // A loop that broke early would pass the previous two tests and still miss a
+    // A loop that broke early would pass the cases above and still miss a
     // drifted posture further down the list.
     const postures = [...STEP_MODERATION_POSTURES] as StepModerationPosture[];
     expect(postures).toEqual(['none', 'promptAudit', 'textOutput']);
     expect(() =>
-      assertModerationHandlerTable({ none: null, promptAudit: noop, textOutput: null })
-    ).toThrow(/posture 'none' is declared IMPLEMENTED but its handler is absent/);
+      assertModerationHandlerTable({ ...shipped(), textOutput: { submit: null, output: null } })
+    ).toThrow(/posture 'textOutput'/);
   });
 });

--- a/src/server/services/blocks/steps/__tests__/step-registry.test.ts
+++ b/src/server/services/blocks/steps/__tests__/step-registry.test.ts
@@ -118,6 +118,35 @@ function makeAuditedFixtureStep(overrides: Partial<AnyBlockStep> = {}): AnyBlock
   } as Partial<AnyBlockStep>);
 }
 
+/** The generated text the `'textOutput'` fixture's extractor reads. */
+const FIXTURE_TEXT_OUTPUT_STEP = {
+  $type: 'fixtureType',
+  output: {
+    blob: { url: 'https://blobs.example/fixture.webp', available: true, width: 4, height: 5 },
+    choices: [{ message: { content: 'a generated reply' } }],
+  },
+};
+
+/**
+ * A minimal VALID `'textOutput'` fixture — the same base, plus the two things
+ * that posture requires: an `extractText` declaration and a canonical output
+ * that actually carries text for it to find.
+ */
+function makeTextOutputFixtureStep(overrides: Partial<AnyBlockStep> = {}): AnyBlockStep {
+  return makeFixtureStep({
+    moderationPosture: 'textOutput',
+    canonicalOutputFor: (): unknown => FIXTURE_TEXT_OUTPUT_STEP,
+    extractText: (step: unknown) =>
+      (
+        (step as { output?: { choices?: Array<{ message?: { content?: string } }> } })?.output
+          ?.choices ?? []
+      )
+        .map((c) => c.message?.content ?? '')
+        .filter((t) => t.length > 0),
+    ...overrides,
+  } as Partial<AnyBlockStep>);
+}
+
 describe('block step registry — the shipped population', () => {
   it('registers at least one step and derives the wire ids from the registry keys', () => {
     const entries = listRegisteredSteps();
@@ -235,21 +264,29 @@ describe('block step registry — the shipped population', () => {
     expect(isBillingModeImplemented('tokenMetered')).toBe(false);
   });
 
-  it('free-text INPUT is implemented; free-text OUTPUT still is not', () => {
+  it('every declared posture now has an implemented handler', () => {
     // 🔴 The mechanism that makes a text-producing step impossible to register
     // without an explicit, reviewed policy answer in code.
     //
-    // `'promptAudit'` (free-text INPUT) is now implemented: #3527 answered that
-    // half — mature content is permitted for App Blocks, bounded by the token's
-    // server-minted maturity ceiling, so a free-text input needs the SAME
-    // `auditPromptServer` pass `textToImage`/`customComfy` run, not a new policy.
+    // `'promptAudit'` (free-text INPUT) was answered by #3527: mature content is
+    // permitted for App Blocks, bounded by the token's server-minted maturity
+    // ceiling, so a free-text input needs the SAME `auditPromptServer` pass
+    // `textToImage`/`customComfy` run, not a new policy.
     //
-    // `'textOutput'` is unchanged and deliberately so: generated text is scanned
-    // by nothing on any current path. If THAT ever flips to true, someone made a
-    // content-policy decision — make sure they meant to.
+    // `'textOutput'` (free-text OUTPUT) is now answered too: an owner-approved
+    // 15-label `xGuardModeration` text scan at the READ boundary, withholding on
+    // a hit in either policy tier and on any scanner failure. The policy lives
+    // in `steps/text-output-moderation`; the phase wiring in `steps/moderation`.
+    //
+    // 🔴 THIS ASSERTION NO LONGER CARRIES THE "un-registrable until someone
+    // answers" PROPERTY FOR ANY EXISTING POSTURE — all three are answered. What
+    // still carries it is `posturePhaseRequirements` + the phase table assert:
+    // a NEW posture added to the union with no handler in its required phase is
+    // still a load-time failure. Do not read a green here as proof that gate is
+    // intact; the phase-table tests are where that evidence lives.
     expect(isModerationPostureImplemented('none')).toBe(true);
     expect(isModerationPostureImplemented('promptAudit')).toBe(true);
-    expect(isModerationPostureImplemented('textOutput')).toBe(false);
+    expect(isModerationPostureImplemented('textOutput')).toBe(true);
   });
 
   // 🔴 LABELLED HONESTLY: an INVARIANT GUARD, not regression coverage. Every
@@ -313,9 +350,18 @@ describe('block step registry — load-time invariants (each guard, mutation-pro
   });
 
   it('rejects a moderation posture with no implemented handler', () => {
+    // 🔴 THE FIXTURE POSTURE IS UNDECLARED ON PURPOSE. Every posture in the
+    // union now HAS a handler, so this clause is no longer reachable with a real
+    // posture value — and a guard nothing can reach is a guard nobody is
+    // testing. An off-union value is what the clause actually defends against
+    // now: a posture added to `StepModerationPosture` (or arriving from a
+    // non-literal source later) before its handler exists.
     expect(() =>
-      assertStepInvariants('fixture-step', makeFixtureStep({ moderationPosture: 'textOutput' }))
-    ).toThrow(/moderationPosture 'textOutput' has no implemented handler/);
+      assertStepInvariants(
+        'fixture-step',
+        makeFixtureStep({ moderationPosture: 'audioOutput' as StepModerationPosture })
+      )
+    ).toThrow(/moderationPosture 'audioOutput' has no implemented handler/);
   });
 
   // ── 🔴 THE `'promptAudit'` POSTURE — "audits nothing" must be impossible ────
@@ -399,6 +445,102 @@ describe('block step registry — load-time invariants (each guard, mutation-pro
         } as unknown as Partial<AnyBlockStep>)
       )
     ).toThrow(/auditableText\(\) returned a non-string negativePrompt/);
+  });
+
+  // ── 🔴 THE `'textOutput'` POSTURE — clauses 1c + 8a ────────────────────────
+  //
+  // The OUTPUT-side twins of the two clauses above, guarding the same defect
+  // class one phase later. `extractText` is what the scan reads AND what a
+  // release publishes, so an entry that satisfies it vacuously is a step that
+  // charges Buzz, succeeds, and can never return a word — the MEDIA version of
+  // which this registry already shipped once (clause 8).
+
+  it('the textOutput fixture PASSES unmutated — every failure below is the mutation', () => {
+    // 🔴 REACHABILITY. Without this, each mutation below could be dying to a
+    // clause that rejects the whole `'textOutput'` shape rather than to the one
+    // named in its assertion.
+    expect(() => assertStepInvariants('fixture-step', makeTextOutputFixtureStep())).not.toThrow();
+  });
+
+  it("rejects a 'textOutput' entry that declares NO extractText (a posture with no output)", () => {
+    expect(() =>
+      assertStepInvariants(
+        'fixture-step',
+        makeFixtureStep({ moderationPosture: 'textOutput' } as Partial<AnyBlockStep>)
+      )
+    ).toThrow(
+      /moderationPosture 'textOutput' requires an extractText\(\) declaration naming the generated text to scan/
+    );
+  });
+
+  it('rejects an entry that declares extractText under a posture that never scans it', () => {
+    // The reverse direction. An extractor that LOOKS like generated-text
+    // coverage and is never called — the read path only invokes it for a
+    // `'textOutput'` entry.
+    expect(() =>
+      assertStepInvariants(
+        'fixture-step',
+        makeFixtureStep({
+          moderationPosture: 'none',
+          extractText: () => ['a generated reply'],
+        } as Partial<AnyBlockStep>)
+      )
+    ).toThrow(/declares extractText\(\) but moderationPosture 'none' never scans it/);
+  });
+
+  it('rejects extractText that returns an EMPTY array (the inert-capability case)', () => {
+    // 🔴 The `() => []` escape clause 8 exists for, on the text axis. Not a
+    // moderation hole — the read path publishes only what the extractor returns,
+    // so nothing unscanned escapes — but a capability that can never speak.
+    expect(() =>
+      assertStepInvariants(
+        'fixture-step',
+        makeTextOutputFixtureStep({ extractText: () => [] } as Partial<AnyBlockStep>)
+      )
+    ).toThrow(/extractText\(\) returned no text for canonicalOutputFor\(\)/);
+  });
+
+  it('rejects extractText that ignores its argument and returns a non-array', () => {
+    expect(() =>
+      assertStepInvariants(
+        'fixture-step',
+        makeTextOutputFixtureStep({
+          extractText: () => 'a generated reply',
+        } as unknown as Partial<AnyBlockStep>)
+      )
+    ).toThrow(/extractText\(\) returned no text for canonicalOutputFor\(\)/);
+  });
+
+  it.each([
+    ['an empty string', ''],
+    ['whitespace only', '  \n\t '],
+    ['a number', 42],
+    ['null', null],
+  ])('rejects extractText returning %s as an entry', (_label, value) => {
+    // Whitespace is as vacuous as empty here for the same reason it is on the
+    // input side — the scan filters blank text, so a whitespace-only "output"
+    // would be scanned by nothing while the entry reports coverage.
+    expect(() =>
+      assertStepInvariants(
+        'fixture-step',
+        makeTextOutputFixtureStep({
+          extractText: () => [value],
+        } as unknown as Partial<AnyBlockStep>)
+      )
+    ).toThrow(/extractText\(\) returned a non-string or empty entry/);
+  });
+
+  it('accepts extractText returning SEVERAL non-empty strings', () => {
+    // The negative control for the clause above: it must reject unusable
+    // entries, not multi-piece output.
+    expect(() =>
+      assertStepInvariants(
+        'fixture-step',
+        makeTextOutputFixtureStep({
+          extractText: () => ['first piece', 'second piece'],
+        } as Partial<AnyBlockStep>)
+      )
+    ).not.toThrow();
   });
 
   // ── 🔴 FIX 3 — the ENTITLEMENT axis ────────────────────────────────────────
@@ -1150,17 +1292,31 @@ describe('block step registry — posture ↔ orchestratorType agreement (clause
     }
   });
 
-  it('the HONEST declaration still reports clause 1, not clause 1b', () => {
-    // `chatCompletion` + `'textOutput'` is the correct declaration; it cannot
-    // register because the posture has no handler yet. The author must see THAT
-    // reason, not a type mismatch — which is the whole point of ordering 1b
-    // after 1. If this flips, the honest entry gets a misleading error.
+  it('the HONEST declaration now REGISTERS — clause 1b does not stand in its way', () => {
+    // `chatCompletion` + `'textOutput'` is the correct declaration, and with the
+    // posture implemented it is a registrable entry rather than a load failure.
+    // 🔴 This is the assertion that would catch `ACCEPTABLE_POSTURES_BY_TYPE`
+    // being wrong about `chatCompletion`: before, a clause-1 rejection masked
+    // whatever clause 1b thought, so 1b was never actually exercised for the
+    // honest shape.
+    expect(() =>
+      assertStepInvariants(
+        'fixture-step',
+        makeTextOutputFixtureStep({ orchestratorType: 'chatCompletion' })
+      )
+    ).not.toThrow();
+  });
+
+  it('an INCOMPLETE textOutput declaration reports the missing extractor, not a type mismatch', () => {
+    // The author who declares the right posture on the right `$type` but forgets
+    // the extractor must be told THAT — the ordering property the previous test
+    // used to cover via clause 1.
     expect(() =>
       assertStepInvariants(
         'fixture-step',
         makeFixtureStep({ orchestratorType: 'chatCompletion', moderationPosture: 'textOutput' })
       )
-    ).toThrow(/has no implemented handler/);
+    ).toThrow(/requires an extractText\(\) declaration/);
   });
 
   it('rejects a text-producing $type declaring promptAudit — the input-only answer', () => {

--- a/src/server/services/blocks/steps/__tests__/step-registry.test.ts
+++ b/src/server/services/blocks/steps/__tests__/step-registry.test.ts
@@ -16,8 +16,11 @@ import {
   mediaFromBlobs,
   NATIVELY_EXTRACTED_STEP_TYPES,
   planStepSpend,
+  postureProducesMedia,
   postureRequiresAuditableText,
+  postureRequiresTextExtraction,
   REGISTERED_STEP_IDS,
+  stepOutputShape,
   resolveStepVariant,
   STEP_BILLING_MODES,
   STEP_MODERATION_POSTURES,
@@ -118,22 +121,37 @@ function makeAuditedFixtureStep(overrides: Partial<AnyBlockStep> = {}): AnyBlock
   } as Partial<AnyBlockStep>);
 }
 
-/** The generated text the `'textOutput'` fixture's extractor reads. */
+/**
+ * The generated text the `'textOutput'` fixture's extractor reads.
+ *
+ * 🔴 NO `blob` KEY, AND THAT IS THE POINT. Every `$type` licensed for
+ * `'textOutput'` is text-producing and none is media-producing, so a canonical
+ * output carrying an image blob would be a fixture no real adopter could
+ * produce — which is exactly the fiction the media-XOR-text fix removed. This
+ * sample is what a `chatCompletion`-shaped completed step actually looks like.
+ */
 const FIXTURE_TEXT_OUTPUT_STEP = {
   $type: 'fixtureType',
   output: {
-    blob: { url: 'https://blobs.example/fixture.webp', available: true, width: 4, height: 5 },
     choices: [{ message: { content: 'a generated reply' } }],
   },
 };
 
 /**
- * A minimal VALID `'textOutput'` fixture — the same base, plus the two things
- * that posture requires: an `extractText` declaration and a canonical output
- * that actually carries text for it to find.
+ * A minimal VALID `'textOutput'` fixture — the same base, plus what that posture
+ * requires (an `extractText` declaration and a canonical output carrying text)
+ * and MINUS what it forbids (`extractOutput`).
+ *
+ * 🔴 THE DELETE IS LOAD-BEARING, NOT TIDINESS. Registry clause 8-ii rejects a
+ * text-posture entry that declares a media extractor, because
+ * `StepOutputMedia.url` is a bare string that reaches `snapshot.imageUrls` and
+ * `AppWorkflow.images[].url` WITHOUT passing the output scan. A fixture that
+ * kept the base's `extractOutput` would not register — and before the fix, the
+ * inverse was true: an honest text entry could not register WITHOUT one, which
+ * is how the media-url smuggle became the path of least resistance.
  */
 function makeTextOutputFixtureStep(overrides: Partial<AnyBlockStep> = {}): AnyBlockStep {
-  return makeFixtureStep({
+  const step = makeFixtureStep({
     moderationPosture: 'textOutput',
     canonicalOutputFor: (): unknown => FIXTURE_TEXT_OUTPUT_STEP,
     extractText: (step: unknown) =>
@@ -145,6 +163,11 @@ function makeTextOutputFixtureStep(overrides: Partial<AnyBlockStep> = {}): AnyBl
         .filter((t) => t.length > 0),
     ...overrides,
   } as Partial<AnyBlockStep>);
+  // Genuinely absent, not present-and-undefined — the shape a real entry has.
+  if (!('extractOutput' in overrides)) {
+    delete (step as { extractOutput?: unknown }).extractOutput;
+  }
+  return step;
 }
 
 describe('block step registry — the shipped population', () => {
@@ -186,7 +209,7 @@ describe('block step registry — the shipped population', () => {
   // BOTH read surfaces. Run over `listRegisteredSteps()` so a step registered
   // tomorrow is covered by this test today — which is the whole reason output
   // extraction became a registry field instead of a fourth hardcoded branch.
-  it('every registered entry is resolvable by $type and surfaces media from its canonical output', () => {
+  it('every registered entry is resolvable by $type and surfaces its OWN declared output shape', () => {
     for (const [id, step] of listRegisteredSteps()) {
       expect(
         getStepByOrchestratorType(step.orchestratorType),
@@ -198,12 +221,30 @@ describe('block step registry — the shipped population', () => {
         `step '${id}' shadows a natively-extracted $type`
       ).not.toContain(step.orchestratorType);
       for (const variant of step.variants) {
-        const media = step.extractOutput(step.canonicalOutputFor(variant));
-        expect(
-          media.length,
-          `step '${id}' variant '${variant}' extracted no media`
-        ).toBeGreaterThan(0);
-        for (const item of media) expect(item.url.length).toBeGreaterThan(0);
+        const sample = step.canonicalOutputFor(variant);
+        // 🔴 POSTURE-GATED, mirroring the read path. A `'textOutput'` entry has
+        // no `extractOutput` at all (media XOR text), so asserting media for it
+        // would be asserting a shape the registry FORBIDS — and this loop runs
+        // over the live population, so it must stay correct for the first text
+        // entry registered.
+        if (postureProducesMedia(step.moderationPosture)) {
+          const media = step.extractOutput!(sample);
+          expect(
+            media.length,
+            `step '${id}' variant '${variant}' extracted no media`
+          ).toBeGreaterThan(0);
+          for (const item of media) expect(item.url.length).toBeGreaterThan(0);
+        } else {
+          expect(
+            step.extractOutput,
+            `step '${id}' publishes TEXT but declares a media extractor — an unscanned channel`
+          ).toBeUndefined();
+          const texts = step.extractText!(sample);
+          expect(
+            texts.length,
+            `step '${id}' variant '${variant}' extracted no text`
+          ).toBeGreaterThan(0);
+        }
       }
     }
   });
@@ -287,6 +328,32 @@ describe('block step registry — the shipped population', () => {
     expect(isModerationPostureImplemented('none')).toBe(true);
     expect(isModerationPostureImplemented('promptAudit')).toBe(true);
     expect(isModerationPostureImplemented('textOutput')).toBe(true);
+  });
+
+  it('🔴 stepOutputShape is TOTAL, and media/text genuinely PARTITION the postures', () => {
+    // 🔴 THE ONE PREDICATE THE WHOLE MEDIA-XOR-TEXT RULE BOTTOMS OUT IN — the
+    // type-level surface union, registry clauses 8/8a, and the posture gate on
+    // BOTH `workflow.service` extractors all read it. If it ever returned
+    // `undefined` for a posture (a new union member with no `case`), the media
+    // branch would silently stop firing and a text step's `extractOutput` would
+    // start reaching `imageUrls` again. Enumerated from the live posture list, so
+    // a posture added tomorrow fails this today.
+    for (const posture of STEP_MODERATION_POSTURES) {
+      const shape = stepOutputShape(posture);
+      expect(['media', 'text'], `posture '${posture}' has no declared output shape`).toContain(
+        shape
+      );
+      // Exact complements, not two independently-maintained lists.
+      expect(postureProducesMedia(posture)).toBe(shape === 'media');
+      expect(postureRequiresTextExtraction(posture)).toBe(shape === 'text');
+      expect(postureProducesMedia(posture)).not.toBe(postureRequiresTextExtraction(posture));
+    }
+    // The concrete assignment, pinned literally — a silent flip of `'textOutput'`
+    // to `'media'` would re-open the smuggling channel while every structural
+    // assertion above still passed.
+    expect(stepOutputShape('none')).toBe('media');
+    expect(stepOutputShape('promptAudit')).toBe('media');
+    expect(stepOutputShape('textOutput')).toBe('text');
   });
 
   // 🔴 LABELLED HONESTLY: an INVARIANT GUARD, not regression coverage. Every
@@ -541,6 +608,85 @@ describe('block step registry — load-time invariants (each guard, mutation-pro
         } as Partial<AnyBlockStep>)
       )
     ).not.toThrow();
+  });
+
+  // ── 🔴 THE OUTPUT SHAPE IS MEDIA **XOR** TEXT (clause 8, posture-gated) ─────
+  //
+  // 🔴 THE DEFECT THESE PIN, BOTH HALVES OF IT. Clause 8 used to demand ≥1 media
+  // item with a non-empty `url` from EVERY entry with no posture gate — while
+  // `ACCEPTABLE_POSTURES_BY_TYPE` licenses `'textOutput'` only for
+  // TEXT-producing `$type`s. So:
+  //   (a) an honest `chatCompletion` + `'textOutput'` entry COULD NOT REGISTER,
+  //       and
+  //   (b) the workaround it pushed an author toward — prose in a fabricated
+  //       `media.url` — DID register and shipped that prose unscanned, because
+  //       `StepOutputMedia.url` is a bare string that reaches
+  //       `snapshot.imageUrls` / `AppWorkflow.images[].url` without ever meeting
+  //       `attachModeratedStepTextOutputs`.
+  // Both directions were reproduced by execution before the fix. (a) is pinned
+  // by the two adoptability tests, (b) by the two rejection tests.
+
+  it('🔴 ADOPTABILITY: a text entry registers with NO extractOutput and NO media at all', () => {
+    // The claim (a) above, stated as the property that failed: an entry whose
+    // canonical output carries text and NOTHING image-shaped is registrable.
+    const step = makeTextOutputFixtureStep();
+    expect(step.extractOutput, 'the fixture must not carry a media extractor').toBeUndefined();
+    expect(
+      JSON.stringify(step.canonicalOutputFor('default')),
+      'the canonical output must carry no blob — a chatCompletion step returns none'
+    ).not.toContain('blob');
+    expect(() => assertStepInvariants('fixture-step', step)).not.toThrow();
+  });
+
+  it('🔴 ADOPTABILITY, the pre-fix shape: the SAME entry with a media extractor is now REJECTED', () => {
+    // The negative control for the test above, and the reachability proof for
+    // clause 8-ii. Only `extractOutput` differs between the two.
+    expect(() =>
+      assertStepInvariants(
+        'fixture-step',
+        makeTextOutputFixtureStep({
+          extractOutput: () => [
+            { url: 'https://blobs.example/f.webp', width: null, height: null, nsfwLevel: null },
+          ],
+        } as unknown as Partial<AnyBlockStep>)
+      )
+    ).toThrow(/declares extractOutput\(\) but moderationPosture 'textOutput' publishes TEXT/);
+  });
+
+  it('🔴 THE SMUGGLE, CONCRETELY: prose in media.url on a text entry is rejected by clause 8-ii', () => {
+    // 🔴 THE EXACT SHAPE THE AUDIT DEMONSTRATED. Nothing validates `media.url`
+    // as a url, and this value reaches a block through `imageUrls` /
+    // `images[].url`, neither of which passes the output scan. The rejection
+    // must name the SMUGGLING clause — if it came from clause 8's "no media" or
+    // "media with no url" branch instead, a text entry could still ship a media
+    // extractor as long as it returned something url-shaped.
+    const prose = 'Sure — here is how you would go about that. First, ';
+    expect(() =>
+      assertStepInvariants(
+        'fixture-step',
+        makeTextOutputFixtureStep({
+          extractOutput: () => [{ url: prose, width: null, height: null, nsfwLevel: null }],
+        } as unknown as Partial<AnyBlockStep>)
+      )
+    ).toThrow(/media extractor on a text step is an unscanned channel to the block/);
+  });
+
+  it('rejects a MEDIA-posture entry that declares NO extractOutput — a NAMED error, not a TypeError', () => {
+    // The other half of the XOR. Making `extractOutput` conditional must not
+    // make it OPTIONAL for a media entry: without it the step is charged for,
+    // reaches `succeeded`, and its result is unreachable on both read surfaces —
+    // the exact inert-capability failure clause 8 was added for. And the error
+    // has to be this clause's, not `step.extractOutput is not a function`.
+    const step = makeFixtureStep();
+    delete (step as { extractOutput?: unknown }).extractOutput;
+    expect(() => assertStepInvariants('fixture-step', step)).toThrow(
+      /publishes MEDIA and requires an extractOutput\(\) declaration/
+    );
+  });
+
+  it('NEGATIVE CONTROL: the same media fixture WITH its extractOutput passes', () => {
+    // Only the deleted field differs from the test above.
+    expect(() => assertStepInvariants('fixture-step', makeFixtureStep())).not.toThrow();
   });
 
   // ── 🔴 FIX 3 — the ENTITLEMENT axis ────────────────────────────────────────

--- a/src/server/services/blocks/steps/__tests__/step-text-output-moderation.test.ts
+++ b/src/server/services/blocks/steps/__tests__/step-text-output-moderation.test.ts
@@ -70,23 +70,32 @@ vi.mock('~/server/services/blocks/steps', async (importOriginal) => {
 
 import {
   assertStepInvariants,
-  mediaFromBlobs,
   type AnyBlockStep,
   type BlockStep,
 } from '~/server/services/blocks/steps';
-import type { OrchestratorBlobLike } from '~/server/services/blocks/steps/output';
 import {
   attachModeratedStepTextOutputs,
   runStepOutputModeration,
 } from '~/server/services/blocks/steps/moderation';
+// 🔴 The two REAL read-path projections, imported so the media-channel tests
+// below drive them rather than re-describing what they do. The registry mock
+// above applies to them too: `workflow.service` imports
+// `getStepByOrchestratorType` from the same module id.
+import {
+  projectAppWorkflow,
+  snapshotFromWorkflow,
+} from '~/server/services/blocks/workflow.service';
 import {
   ALWAYS_WITHHOLD_LABELS,
   decideTextOutputVerdict,
+  MAX_SCANNED_CONTENT_CHARS,
+  missingRequestedLabels,
   NOT_ACTED_ON_LABELS,
   screenGeneratedText,
   SFW_ONLY_WITHHOLD_LABELS,
   TEXT_OUTPUT_SCAN_LABELS,
   TEXT_OUTPUT_WITHHELD_MESSAGE,
+  __clearTextOutputVerdictCacheForTests,
 } from '~/server/services/blocks/steps/text-output-moderation';
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -127,18 +136,15 @@ function makeTextStep(overrides: Partial<AnyBlockStep> = {}): AnyBlockStep {
     priceForVariant: () => 7,
     estimateBuzz: () => 7,
     buildStep: (p: FixtureParams) => ({ $type: CHAT_TYPE, input: { value: p.value } }),
-    extractOutput: (step: unknown) =>
-      mediaFromBlobs(
-        (step as { output?: { blob?: OrchestratorBlobLike | null } } | null | undefined)?.output
-          ?.blob
-      ),
-    canonicalOutputFor: (): unknown => ({
-      ...chatStep(),
-      output: {
-        ...chatStep().output,
-        blob: { url: 'https://blobs.example/f.webp', available: true },
-      },
-    }),
+    // 🔴 NO `extractOutput`, AND NO FABRICATED BLOB IN `canonicalOutputFor`.
+    // Both used to be here, and they were the audit's exhibit: `extractOutput`
+    // was unconditionally required and clause 8 unconditionally demanded ≥1
+    // media item with a url, so the only way to write a `'textOutput'` fixture
+    // was to invent an image a real `chatCompletion` step never returns. A real
+    // adopter reaching for the same workaround would put the model's REPLY in
+    // that url — which reaches `snapshot.imageUrls` without meeting the scan.
+    // The registry now forbids the field on a text entry outright.
+    canonicalOutputFor: (): unknown => chatStep(),
     extractText: (step: unknown) =>
       (
         (step as { output?: { choices?: Array<{ message?: { content?: string } }> } })?.output
@@ -189,10 +195,33 @@ function scannerReturns(output: unknown) {
 
 const CTX = { userId: 42, isGreen: false, appId: 'app-1', appBlockId: 'blk-1' };
 
+/**
+ * `requestedLabels` for a verdict test.
+ *
+ * 🔴 TWO VALUES ON PURPOSE, and picking the wrong one makes a test pass for the
+ * wrong reason. `decideTextOutputVerdict` withholds when a REQUESTED label has
+ * no `results[]` entry (the rename fail-open the generated client documents), so
+ * a POLICY test must ask only for labels its fixture actually answered — else
+ * every assertion below would read `released: false` from label drift and the
+ * tier logic would never be exercised at all.
+ *   ALL  — with a `scanOutput(...)` fixture, which emits all 15 results.
+ *   NONE — with a hand-built minimal fixture (`{ triggeredLabels, results: [] }`),
+ *          where the drift check is deliberately vacuous.
+ * The drift guard gets its own describe block, with both controls.
+ */
+const ALL = TEXT_OUTPUT_SCAN_LABELS;
+const NONE: readonly string[] = [];
+
 beforeEach(() => {
   mockCreateXGuardModerationRequest.mockReset();
   mockLogToAxiom.mockReset();
   mockLogToAxiom.mockResolvedValue(undefined);
+  // 🔴 THE VERDICT MEMO IS MODULE-LIFETIME AND KEYED ON THE CONTENT. Nearly
+  // every case here scans the SAME `GENERATED_TEXT` and varies only the scanner
+  // response, which is precisely what the memo collapses — without this reset a
+  // withhold would be replayed for the next test's positive control and the pair
+  // would stop discriminating anything.
+  __clearTextOutputVerdictCacheForTests();
   registryOverride.clear();
   registryOverride.set(CHAT_TYPE, makeTextStep());
 });
@@ -462,7 +491,10 @@ describe('textOutput — the approved label policy', () => {
     (label) => {
       // The host-independent tier. `isGreen: false` == the ceiling permits mature
       // content, and these must still withhold.
-      const verdict = decideTextOutputVerdict(scanOutput([label]), { isGreen: false });
+      const verdict = decideTextOutputVerdict(scanOutput([label]), {
+        isGreen: false,
+        requestedLabels: ALL,
+      });
       expect(verdict.released).toBe(false);
       expect(verdict.withholdingLabels).toEqual([label]);
     }
@@ -474,8 +506,14 @@ describe('textOutput — the approved label policy', () => {
       // 🔴 BOTH DIRECTIONS ON THE SAME LABEL. A policy that hardcoded `isGreen`
       // either way passes exactly one of these two assertions and fails the
       // other; neither can pass both.
-      expect(decideTextOutputVerdict(scanOutput([label]), { isGreen: true }).released).toBe(false);
-      expect(decideTextOutputVerdict(scanOutput([label]), { isGreen: false }).released).toBe(true);
+      expect(
+        decideTextOutputVerdict(scanOutput([label]), { isGreen: true, requestedLabels: ALL })
+          .released
+      ).toBe(false);
+      expect(
+        decideTextOutputVerdict(scanOutput([label]), { isGreen: false, requestedLabels: ALL })
+          .released
+      ).toBe(true);
     }
   );
 
@@ -483,7 +521,10 @@ describe('textOutput — the approved label policy', () => {
     "'%s' is scanned and reported but never withholds, on EITHER host",
     (label) => {
       for (const isGreen of [true, false]) {
-        const verdict = decideTextOutputVerdict(scanOutput([label]), { isGreen });
+        const verdict = decideTextOutputVerdict(scanOutput([label]), {
+          isGreen,
+          requestedLabels: ALL,
+        });
         expect(verdict.released).toBe(true);
         // …and it is still REPORTED. Dropping these from the scan would lose the
         // telemetry the 15-label choice was made for.
@@ -493,7 +534,10 @@ describe('textOutput — the approved label policy', () => {
   );
 
   it('releases a completely benign scan (the negative control for every case above)', () => {
-    const verdict = decideTextOutputVerdict(scanOutput([]), { isGreen: true });
+    const verdict = decideTextOutputVerdict(scanOutput([]), {
+      isGreen: true,
+      requestedLabels: ALL,
+    });
     expect(verdict.released).toBe(true);
     expect(verdict.withholdingLabels).toEqual([]);
     expect(verdict.triggeredLabels).toEqual([]);
@@ -504,14 +548,18 @@ describe('textOutput — the approved label policy', () => {
     // `Scan`, so `blocked` stays false however high the score. A policy keyed on
     // `blocked` releases this. On a SFW ceiling it must not.
     const output = { ...scanOutput(['Explicit'], { Explicit: 0.99 }), blocked: false };
-    expect(decideTextOutputVerdict(output, { isGreen: true }).released).toBe(false);
+    expect(decideTextOutputVerdict(output, { isGreen: true, requestedLabels: ALL }).released).toBe(
+      false
+    );
   });
 
   it('🔴 IGNORES `blocked` in the other direction too', () => {
     // The complement: `blocked: true` with only a non-actioned label triggering
     // must NOT withhold. A policy that ORed `blocked` in would fail this.
     const output = { ...scanOutput(['Celebrity']), blocked: true };
-    expect(decideTextOutputVerdict(output, { isGreen: true }).released).toBe(true);
+    expect(decideTextOutputVerdict(output, { isGreen: true, requestedLabels: ALL }).released).toBe(
+      true
+    );
   });
 
   it('UNIONS the two trigger signals — either one alone withholds', () => {
@@ -522,8 +570,12 @@ describe('textOutput — the approved label policy', () => {
       triggeredLabels: [],
       results: [{ label: 'Young', score: 0.98, triggered: true }],
     };
-    expect(decideTextOutputVerdict(fromArrayOnly, { isGreen: false }).released).toBe(false);
-    expect(decideTextOutputVerdict(fromResultsOnly, { isGreen: false }).released).toBe(false);
+    expect(
+      decideTextOutputVerdict(fromArrayOnly, { isGreen: false, requestedLabels: NONE }).released
+    ).toBe(false);
+    expect(
+      decideTextOutputVerdict(fromResultsOnly, { isGreen: false, requestedLabels: NONE }).released
+    ).toBe(false);
   });
 
   it('matches labels CASE-INSENSITIVELY', () => {
@@ -532,8 +584,13 @@ describe('textOutput — the approved label policy', () => {
     // An exact-match policy would match nothing and release everything.
     for (const label of ['young', 'YOUNG', ' Young ']) {
       expect(
-        decideTextOutputVerdict({ triggeredLabels: [label], results: [] }, { isGreen: false })
-          .released
+        decideTextOutputVerdict(
+          { triggeredLabels: [label], results: [] },
+          {
+            isGreen: false,
+            requestedLabels: NONE,
+          }
+        ).released
       ).toBe(false);
     }
   });
@@ -541,6 +598,7 @@ describe('textOutput — the approved label policy', () => {
   it('reports per-label SCORES for the trigger log', () => {
     const verdict = decideTextOutputVerdict(scanOutput(['Young'], { Young: 0.96 }), {
       isGreen: false,
+      requestedLabels: ALL,
     });
     expect(verdict.scores.Young).toBe(0.96);
   });
@@ -554,7 +612,10 @@ describe('textOutput — the approved label policy', () => {
     // The DECISION is total. Fail-closed on a missing verdict is
     // `screenGeneratedText`'s job (asserted above) — this function's contract is
     // "never throw on a read path", and a throw here would become a 500 on poll.
-    const verdict = decideTextOutputVerdict(output as never, { isGreen: true });
+    const verdict = decideTextOutputVerdict(output as never, {
+      isGreen: true,
+      requestedLabels: NONE,
+    });
     expect(verdict.released).toBe(true);
   });
 });
@@ -663,4 +724,378 @@ describe('textOutput — the OUTPUT dispatch over the posture table', () => {
       expect(result).toEqual({ released: false, reason: TEXT_OUTPUT_WITHHELD_MESSAGE });
     }
   );
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 🔴 THE MEDIA CHANNEL — a text step must reach NEITHER read surface through it.
+//
+// `StepOutputMedia.url` is a bare string that nothing validates as a url, and it
+// flows to `snapshot.imageUrls` and `AppWorkflow.images[].url` WITHOUT passing
+// through `attachModeratedStepTextOutputs`. Before the media-XOR-text fix,
+// `extractOutput` was unconditionally required of every entry — so an honest
+// `chatCompletion` + `'textOutput'` entry could not register at all, and the
+// workaround it pushed an author toward published the model's reply as a "url"
+// with every moderation gate green.
+//
+// The registry now rejects that declaration (clause 8-ii) and the type forbids
+// writing it (`TextOutputSurface.extractOutput?: never`). These tests cover the
+// THIRD layer: the read path itself keys on the POSTURE, so an extractor that
+// arrived through a cast still contributes nothing.
+// ─────────────────────────────────────────────────────────────────────────────
+describe('textOutput — the media channel is closed at the READ path too', () => {
+  const PROSE = 'Sure — here is exactly how you would do that. Step one, ';
+
+  /** A text-posture entry with a media extractor forced on by a cast. */
+  function smugglingStep() {
+    return makeTextStep({
+      extractOutput: () => [{ url: PROSE, width: null, height: null, nsfwLevel: null }],
+    } as unknown as Partial<AnyBlockStep>);
+  }
+
+  /** The same extractor under a MEDIA posture — the positive control. */
+  function honestMediaStep() {
+    return makeTextStep({
+      moderationPosture: 'none',
+      extractText: undefined,
+      extractOutput: () => [
+        { url: 'https://blobs.example/real.webp', width: 4, height: 5, nsfwLevel: null },
+      ],
+    } as unknown as Partial<AnyBlockStep>);
+  }
+
+  it('snapshotFromWorkflow.imageUrls carries NOTHING from a text-posture step', () => {
+    registryOverride.set(CHAT_TYPE, smugglingStep());
+    const snap = snapshotFromWorkflow(workflowWith(chatStep()));
+    expect(snap.imageUrls).toBeUndefined();
+    expect(JSON.stringify(snap)).not.toContain(PROSE);
+  });
+
+  it('projectAppWorkflow.images carries NOTHING from a text-posture step', () => {
+    // 🔴 This surface matters MORE: `queryAppWorkflows` / `cancelAppWorkflow`
+    // return `AppWorkflow` UNWRAPPED — there is no scan in front of it at all.
+    registryOverride.set(CHAT_TYPE, smugglingStep());
+    const projected = projectAppWorkflow(workflowWith(chatStep()));
+    expect(projected.images).toEqual([]);
+    expect(JSON.stringify(projected)).not.toContain(PROSE);
+  });
+
+  it('🔴 POSITIVE CONTROL — the IDENTICAL extractor under a media posture DOES reach both surfaces', () => {
+    // Without this, "images is empty" is exactly what a harness wired to nothing
+    // reports, and a `snapshotFromWorkflow` that had simply stopped consulting
+    // the registry would pass both tests above. ONLY `moderationPosture` (and
+    // the extractor's return url) differs.
+    registryOverride.set(CHAT_TYPE, honestMediaStep());
+    expect(snapshotFromWorkflow(workflowWith(chatStep())).imageUrls).toEqual([
+      'https://blobs.example/real.webp',
+    ]);
+    expect(projectAppWorkflow(workflowWith(chatStep())).images).toEqual([
+      { url: 'https://blobs.example/real.webp', width: 4, height: 5, nsfwLevel: null },
+    ]);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 🔴 THE CONTENT CAP — bounded, and FAILING CLOSED above the bound.
+// ─────────────────────────────────────────────────────────────────────────────
+describe('textOutput — the content-length cap', () => {
+  function textOfLength(n: number) {
+    return 'x'.repeat(n);
+  }
+
+  it('the cap is 50,000 characters — pinned LITERALLY, not derived', () => {
+    // 🔴 A VALUE PIN, and it is the assertion that a cap RAISE has to walk past.
+    // Every other test in this block derives its input length FROM the constant,
+    // so all of them move with it — raising the cap to something effectively
+    // unbounded would leave them measuring the new number rather than failing.
+    // The cost/latency arithmetic behind this figure (~5 chunks × 15 labels ≈ 75
+    // scan units, ~12.5k tokens) is in the constant's own doc comment; changing
+    // it is a policy decision that must change this line too.
+    expect(MAX_SCANNED_CONTENT_CHARS).toBe(50_000);
+  });
+
+  it('WITHHOLDS over the cap, WITHOUT calling the scanner', async () => {
+    const result = await screenGeneratedText({
+      texts: [textOfLength(MAX_SCANNED_CONTENT_CHARS + 1)],
+      userId: 42,
+      isGreen: false,
+      appId: 'app-1',
+      stepId: 'fixture-chat',
+      model: CHAT_TYPE,
+    });
+    expect(result).toEqual({ released: false, reason: TEXT_OUTPUT_WITHHELD_MESSAGE });
+    // 🔴 Fails closed AND fails CHEAP — the point of the cap is that an
+    // over-large payload costs no scan units, so this assertion is the cap
+    // rather than merely the withhold.
+    expect(mockCreateXGuardModerationRequest).not.toHaveBeenCalled();
+  });
+
+  it('🔴 POSITIVE CONTROL — content EXACTLY at the cap is scanned and released', async () => {
+    // One character apart from the case above. Without this, "withheld" is
+    // indistinguishable from a `screenGeneratedText` that withholds everything,
+    // and a cap of 0 would pass the previous test.
+    scannerReturns(scanOutput([]));
+    const texts = [textOfLength(MAX_SCANNED_CONTENT_CHARS)];
+    const result = await screenGeneratedText({
+      texts,
+      userId: 42,
+      isGreen: false,
+      appId: 'app-1',
+      stepId: 'fixture-chat',
+      model: CHAT_TYPE,
+    });
+    expect(result).toEqual({ released: true, texts });
+    expect(mockCreateXGuardModerationRequest).toHaveBeenCalledTimes(1);
+  });
+
+  it('the cap applies to the JOINED content, not to any one piece', async () => {
+    // The scan is one call over `texts.join('\n\n')`, so N pieces each under the
+    // cap can still exceed it together. A per-piece check would let exactly the
+    // payload the cap exists to bound straight through.
+    const half = Math.ceil(MAX_SCANNED_CONTENT_CHARS / 2);
+    const result = await screenGeneratedText({
+      texts: [textOfLength(half), textOfLength(half)],
+      userId: 42,
+      isGreen: false,
+      appId: 'app-1',
+      stepId: 'fixture-chat',
+      model: CHAT_TYPE,
+    });
+    expect(result.released).toBe(false);
+    expect(mockCreateXGuardModerationRequest).not.toHaveBeenCalled();
+  });
+
+  it('logs the over-cap withhold with its own stage, and never the text', async () => {
+    await screenGeneratedText({
+      texts: [textOfLength(MAX_SCANNED_CONTENT_CHARS + 1)],
+      userId: 42,
+      isGreen: false,
+      appId: 'app-1',
+      stepId: 'fixture-chat',
+      model: CHAT_TYPE,
+    });
+    expect(mockLogToAxiom).toHaveBeenCalledTimes(1);
+    expect(mockLogToAxiom.mock.calls[0][0]).toMatchObject({
+      stage: 'over-cap',
+      capChars: MAX_SCANNED_CONTENT_CHARS,
+    });
+    expect(JSON.stringify(mockLogToAxiom.mock.calls)).not.toContain('xxxxxxxxxx');
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 🔴 THE VERDICT MEMO — the poll loop must not re-scan identical content.
+// ─────────────────────────────────────────────────────────────────────────────
+describe('textOutput — the per-content verdict memo', () => {
+  const opts = {
+    userId: 42,
+    isGreen: false,
+    appId: 'app-1',
+    stepId: 'fixture-chat',
+    model: CHAT_TYPE,
+  };
+
+  it('scans ONCE for repeated identical content, and the verdict is unchanged', async () => {
+    // 🔴 THE DEFECT: `attachModeratedStepTextOutputs` runs on EVERY
+    // `pollWorkflow`, at a cadence untrusted block code chooses, and the
+    // orchestrator's own contentHash dedup is deliberately bypassed on this path
+    // — so without a host-side memo one generation is an unbounded number of
+    // identical scans.
+    scannerReturns(scanOutput([]));
+    const first = await screenGeneratedText({ ...opts, texts: [GENERATED_TEXT] });
+    const second = await screenGeneratedText({ ...opts, texts: [GENERATED_TEXT] });
+    expect(mockCreateXGuardModerationRequest).toHaveBeenCalledTimes(1);
+    expect(first).toEqual({ released: true, texts: [GENERATED_TEXT] });
+    expect(second).toEqual(first);
+  });
+
+  it('🔴 POSITIVE CONTROL — DIFFERENT content scans again', async () => {
+    // Without this, "called once" is what a memo that returns a stale verdict
+    // for EVERYTHING also produces — which would be a moderation hole, not an
+    // optimization.
+    scannerReturns(scanOutput([]));
+    await screenGeneratedText({ ...opts, texts: ['first reply'] });
+    await screenGeneratedText({ ...opts, texts: ['a completely different reply'] });
+    expect(mockCreateXGuardModerationRequest).toHaveBeenCalledTimes(2);
+  });
+
+  it('🔴 the maturity ceiling is part of the key — a mature-host release is NOT reused for a SFW viewer', () => {
+    // `Suggestive` releases on a mature-allowed host and withholds on a SFW one.
+    // A memo keyed on content alone would serve the first verdict to the second
+    // viewer, which is the SFW tier silently disabled.
+    return (async () => {
+      scannerReturns(scanOutput(['Suggestive']));
+      const mature = await screenGeneratedText({
+        ...opts,
+        isGreen: false,
+        texts: [GENERATED_TEXT],
+      });
+      const sfw = await screenGeneratedText({ ...opts, isGreen: true, texts: [GENERATED_TEXT] });
+      expect(mature.released).toBe(true);
+      expect(sfw.released).toBe(false);
+      // Two scans, because the two viewers do not share a key.
+      expect(mockCreateXGuardModerationRequest).toHaveBeenCalledTimes(2);
+    })();
+  });
+
+  it('a WITHHELD verdict is memoized too — the expensive case is the one a block hammers', async () => {
+    scannerReturns(scanOutput(['Young']));
+    const first = await screenGeneratedText({ ...opts, texts: [GENERATED_TEXT] });
+    const second = await screenGeneratedText({ ...opts, texts: [GENERATED_TEXT] });
+    expect(first.released).toBe(false);
+    expect(second).toEqual(first);
+    expect(mockCreateXGuardModerationRequest).toHaveBeenCalledTimes(1);
+  });
+
+  it('🔴 an ERROR is NOT memoized — a scanner recovery must not be pinned shut for 5 minutes', async () => {
+    // Fail-closed is right for the failing call; caching it would turn a blip
+    // into an outage of the capability, and would also mean a fixed scanner is
+    // never retried. So the second call must reach the scanner again — and
+    // succeed.
+    mockCreateXGuardModerationRequest.mockRejectedValueOnce(new Error('orchestrator 503'));
+    const failed = await screenGeneratedText({ ...opts, texts: [GENERATED_TEXT] });
+    expect(failed.released).toBe(false);
+
+    scannerReturns(scanOutput([]));
+    const recovered = await screenGeneratedText({ ...opts, texts: [GENERATED_TEXT] });
+    expect(recovered).toEqual({ released: true, texts: [GENERATED_TEXT] });
+    expect(mockCreateXGuardModerationRequest).toHaveBeenCalledTimes(2);
+  });
+
+  it('a memo HIT returns the CALLER’s own pieces, not the stored ones', async () => {
+    // The key is the JOINED content, so two callers can share a hit having split
+    // their pieces differently. Replaying a stored array would hand one of them
+    // the other's segmentation.
+    scannerReturns(scanOutput([]));
+    const joined = 'alpha\n\nbeta';
+    await screenGeneratedText({ ...opts, texts: [joined] });
+    const split = await screenGeneratedText({ ...opts, texts: ['alpha', 'beta'] });
+    expect(mockCreateXGuardModerationRequest).toHaveBeenCalledTimes(1);
+    expect(split).toEqual({ released: true, texts: ['alpha', 'beta'] });
+  });
+
+  it('the memo does not survive a reset (the seam these tests depend on works)', async () => {
+    // 🔴 VALIDATES THE HARNESS. Every pair above rests on `beforeEach` clearing
+    // the memo; if the reset were a no-op, the second half of each pair would be
+    // reading the first half's verdict and the whole block would be green for
+    // the wrong reason.
+    scannerReturns(scanOutput([]));
+    await screenGeneratedText({ ...opts, texts: [GENERATED_TEXT] });
+    __clearTextOutputVerdictCacheForTests();
+    await screenGeneratedText({ ...opts, texts: [GENERATED_TEXT] });
+    expect(mockCreateXGuardModerationRequest).toHaveBeenCalledTimes(2);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 🔴 LABEL DRIFT — a label we ASKED for and did not get an answer on withholds.
+//
+// The generated client documents the fail-open in so many words
+// (`types.gen.d.ts`, `xGuardModeration.labels`): *"Labels not found in the
+// defaults (or label overrides) are silently ignored."* So a renamed or mistyped
+// entry in `TEXT_OUTPUT_SCAN_LABELS` is never evaluated, comes back absent
+// rather than errored, produces a clean verdict, and RELEASES — with no symptom
+// at all. `normalizeLabel` covers CASING and cannot cover RENAMES.
+// ─────────────────────────────────────────────────────────────────────────────
+describe('textOutput — a dropped label FAILS CLOSED', () => {
+  it('missingRequestedLabels names exactly the labels with no results[] entry', () => {
+    const output = {
+      triggeredLabels: [],
+      results: [{ label: 'Young', score: 0.01, triggered: false }],
+    };
+    expect(missingRequestedLabels(output, ['Young', 'Grooming', 'Extremism'])).toEqual([
+      'Grooming',
+      'Extremism',
+    ]);
+    expect(missingRequestedLabels(output, ['Young'])).toEqual([]);
+  });
+
+  it('matches on the NORMALIZED key — a casing difference is not a drop', () => {
+    // The two sides are orchestrator-side config this codebase does not control;
+    // treating `young` vs `Young` as a drop would withhold everything for a
+    // difference that is already handled elsewhere in this file.
+    const output = { results: [{ label: 'young', triggered: false }] };
+    expect(missingRequestedLabels(output, ['Young'])).toEqual([]);
+  });
+
+  it('WITHHOLDS a verdict that is otherwise clean when a requested label is missing', () => {
+    // 🔴 THE REACHABILITY CASE. Nothing triggered; the pre-fix policy released.
+    const output = scanOutput([]);
+    const dropped = {
+      ...output,
+      results: output.results.filter((r) => r.label !== 'Extremism'),
+    };
+    const verdict = decideTextOutputVerdict(dropped, { isGreen: false, requestedLabels: ALL });
+    expect(verdict.released).toBe(false);
+    expect(verdict.missingLabels).toEqual(['Extremism']);
+    // …and it is NOT reported as a content hit, which would poison the per-app
+    // trigger rates with an operational fault.
+    expect(verdict.withholdingLabels).toEqual([]);
+  });
+
+  it('🔴 POSITIVE CONTROL — the SAME scan with the full results[] releases', () => {
+    // ONLY the presence of the dropped label's result differs. Without this,
+    // "released: false" is what a policy that withholds everything also reports.
+    const verdict = decideTextOutputVerdict(scanOutput([]), {
+      isGreen: false,
+      requestedLabels: ALL,
+    });
+    expect(verdict.released).toBe(true);
+    expect(verdict.missingLabels).toEqual([]);
+  });
+
+  it('an EMPTY results[] withholds even with an empty triggeredLabels (the total fail-open)', () => {
+    // The shape a wholesale label rename produces: the scanner ignores every
+    // label we sent, answers nothing, and the pre-fix policy read that as clean.
+    const verdict = decideTextOutputVerdict(
+      { triggeredLabels: [], results: [] },
+      { isGreen: false, requestedLabels: ALL }
+    );
+    expect(verdict.released).toBe(false);
+    expect(verdict.missingLabels).toEqual([...ALL]);
+  });
+
+  it('end to end: a dropped label WITHHOLDS the text and logs stage "label-drift"', async () => {
+    const output = scanOutput([]);
+    scannerReturns({ ...output, results: output.results.filter((r) => r.label !== 'Bestiality') });
+    const snapshot = await attachModeratedStepTextOutputs(
+      { workflowId: 'wf-1', status: 'succeeded' as const },
+      workflowWith(chatStep()),
+      CTX
+    );
+    expect(snapshot.textOutputs).toBeUndefined();
+    expect(JSON.stringify(snapshot)).not.toContain(GENERATED_TEXT);
+    expect(mockLogToAxiom.mock.calls[0][0]).toMatchObject({
+      stage: 'label-drift',
+      missingLabels: ['Bestiality'],
+    });
+  });
+
+  it('🔴 POSITIVE CONTROL — the same path publishes when every requested label came back', async () => {
+    scannerReturns(scanOutput([]));
+    const snapshot = await attachModeratedStepTextOutputs(
+      { workflowId: 'wf-1', status: 'succeeded' as const },
+      workflowWith(chatStep()),
+      CTX
+    );
+    expect(snapshot.textOutputs).toEqual([GENERATED_TEXT]);
+    expect(mockLogToAxiom).not.toHaveBeenCalled();
+  });
+
+  it('the scan CHECKS exactly the list it SENDS', async () => {
+    // 🔴 `requestedLabels` is deliberately NOT defaulted inside
+    // `decideTextOutputVerdict` — a default is how a caller ends up checking a
+    // list it did not send. This pins that the two are the same expression.
+    scannerReturns(scanOutput([]));
+    await screenGeneratedText({
+      texts: [GENERATED_TEXT],
+      userId: 42,
+      isGreen: false,
+      appId: 'app-1',
+      stepId: 'fixture-chat',
+      model: CHAT_TYPE,
+    });
+    expect(mockCreateXGuardModerationRequest.mock.calls[0][0].labels).toEqual([
+      ...TEXT_OUTPUT_SCAN_LABELS,
+    ]);
+  });
 });

--- a/src/server/services/blocks/steps/__tests__/step-text-output-moderation.test.ts
+++ b/src/server/services/blocks/steps/__tests__/step-text-output-moderation.test.ts
@@ -1,0 +1,666 @@
+import type * as StepsModule from '~/server/services/blocks/steps';
+import type { Workflow } from '@civitai/client';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import * as z from 'zod';
+
+/**
+ * Coverage for the `'textOutput'` moderation posture — the OUTPUT-phase scan
+ * that stands between a registered step's generated text and the block.
+ *
+ * 🔴 WHAT THIS SUITE HAS TO PROVE, and why a lesser test would prove nothing:
+ *
+ *  1. THE HANDLER IS NOT INERT. A test that the posture is DECLARED, or that a
+ *     handler EXISTS, is worthless — the failure this posture exists to prevent
+ *     is precisely a declared, registered, load-time-gated handler that runs and
+ *     scans nothing. So the load-bearing test drives the REAL read-path function
+ *     (`attachModeratedStepTextOutputs`) over a REAL orchestrator-shaped workflow
+ *     and asserts the flagged text is ABSENT from the snapshot the block gets.
+ *
+ *  2. …AND IT IS PAIRED WITH A POSITIVE CONTROL. "the text is absent" is exactly
+ *     what a harness wired to nothing also reports. Every withhold assertion
+ *     below has a sibling that changes ONLY the scan verdict and asserts the
+ *     text IS published — so the absence is a fact about the policy, not about
+ *     the fixture.
+ *
+ *  3. IT FAILS CLOSED. Scanner throw, scanner timeout, submit returning nothing,
+ *     a workflow with no verdict — every one withholds.
+ *
+ *  4. THE POLICY TIERS ARE REAL. Seven labels withhold on any host; three
+ *     withhold only when the token's ceiling is SFW; five are scanned and NOT
+ *     acted on. Each tier is asserted in both directions.
+ *
+ *  5. IT READS `triggeredLabels` + per-label results, NEVER `blocked`. A text
+ *     scoring 0.99 on `Explicit` comes back `blocked: false`, because that
+ *     label's ACTION is `Scan` — measured against the deployed scanner. A policy
+ *     keyed on `blocked` would release it.
+ */
+
+const { mockCreateXGuardModerationRequest, mockLogToAxiom } = vi.hoisted(() => ({
+  mockCreateXGuardModerationRequest: vi.fn(),
+  mockLogToAxiom: vi.fn(),
+}));
+
+vi.mock('~/server/services/orchestrator/orchestrator.service', () => ({
+  createXGuardModerationRequest: mockCreateXGuardModerationRequest,
+}));
+vi.mock('~/server/logging/client', () => ({
+  logToAxiom: mockLogToAxiom,
+}));
+vi.mock('~/server/services/orchestrator/promptAuditing', () => ({
+  auditPromptServer: vi.fn(),
+}));
+
+// 🔴 THE REGISTRY IS OVERRIDDEN FOR `getStepByOrchestratorType` ONLY, and it is
+// the minimum needed to test the read path today: the shipped registry has no
+// `'textOutput'` entry yet (registering `chatCompletion` is the follow-up), so
+// without an injected entry the loop below would have nothing to dispatch on and
+// this whole suite would be the vacuous "it is declared" test it exists to avoid.
+// Every other export — `posturePhaseRequirements`,
+// `isModerationPostureImplemented`, the load-time asserts — is the REAL one, so
+// the module-load phase-table check still runs against the shipped table.
+const registryOverride = new Map<string, unknown>();
+vi.mock('~/server/services/blocks/steps', async (importOriginal) => {
+  const actual = await importOriginal<StepsModule>();
+  return {
+    ...actual,
+    getStepByOrchestratorType: (orchestratorType: string) =>
+      registryOverride.get(orchestratorType) ?? actual.getStepByOrchestratorType(orchestratorType),
+  };
+});
+
+import {
+  assertStepInvariants,
+  mediaFromBlobs,
+  type AnyBlockStep,
+  type BlockStep,
+} from '~/server/services/blocks/steps';
+import type { OrchestratorBlobLike } from '~/server/services/blocks/steps/output';
+import {
+  attachModeratedStepTextOutputs,
+  runStepOutputModeration,
+} from '~/server/services/blocks/steps/moderation';
+import {
+  ALWAYS_WITHHOLD_LABELS,
+  decideTextOutputVerdict,
+  NOT_ACTED_ON_LABELS,
+  screenGeneratedText,
+  SFW_ONLY_WITHHOLD_LABELS,
+  TEXT_OUTPUT_SCAN_LABELS,
+  TEXT_OUTPUT_WITHHELD_MESSAGE,
+} from '~/server/services/blocks/steps/text-output-moderation';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Fixtures
+// ─────────────────────────────────────────────────────────────────────────────
+
+const GENERATED_TEXT = 'the model wrote this sentence';
+const CHAT_TYPE = 'fixtureChat';
+
+type FixtureParams = { value: number };
+const fixtureParamSchema = z.object({ value: z.number().int().min(1).max(10) }).strict();
+
+/** An orchestrator-shaped COMPLETED chat step, as it arrives on a workflow. */
+function chatStep(content = GENERATED_TEXT) {
+  return {
+    $type: CHAT_TYPE,
+    output: { choices: [{ message: { content } }] },
+  };
+}
+
+/**
+ * A registry entry declaring `'textOutput'`. Shaped so the REAL
+ * `assertStepInvariants` accepts it (asserted below) — a fixture the registry
+ * would reject would make every read-path test here a statement about an entry
+ * that could never exist.
+ */
+function makeTextStep(overrides: Partial<AnyBlockStep> = {}): AnyBlockStep {
+  const base = {
+    id: 'fixture-chat',
+    orchestratorType: CHAT_TYPE,
+    billingMode: 'prepaidFixed',
+    moderationPosture: 'textOutput',
+    resourcePolicy: { kind: 'none' },
+    paramSchema: fixtureParamSchema,
+    variants: ['default'],
+    resolveVariant: () => 'default',
+    canonicalParamsFor: (): FixtureParams => ({ value: 1 }),
+    priceForVariant: () => 7,
+    estimateBuzz: () => 7,
+    buildStep: (p: FixtureParams) => ({ $type: CHAT_TYPE, input: { value: p.value } }),
+    extractOutput: (step: unknown) =>
+      mediaFromBlobs(
+        (step as { output?: { blob?: OrchestratorBlobLike | null } } | null | undefined)?.output
+          ?.blob
+      ),
+    canonicalOutputFor: (): unknown => ({
+      ...chatStep(),
+      output: {
+        ...chatStep().output,
+        blob: { url: 'https://blobs.example/f.webp', available: true },
+      },
+    }),
+    extractText: (step: unknown) =>
+      (
+        (step as { output?: { choices?: Array<{ message?: { content?: string } }> } })?.output
+          ?.choices ?? []
+      )
+        .map((c) => c.message?.content ?? '')
+        .filter((t) => t.length > 0),
+  } satisfies BlockStep<FixtureParams>;
+  return { ...base, ...overrides } as AnyBlockStep;
+}
+
+/** A workflow carrying one completed text step. */
+function workflowWith(...steps: unknown[]): Workflow {
+  return {
+    id: 'wf-1',
+    status: 'succeeded',
+    createdAt: '2026-01-01T00:00:00Z',
+    steps,
+  } as unknown as Workflow;
+}
+
+/** A scan output where the named labels triggered. */
+function scanOutput(triggered: string[], scores: Record<string, number> = {}) {
+  return {
+    blocked: false,
+    triggeredLabels: triggered,
+    results: TEXT_OUTPUT_SCAN_LABELS.map((label) => ({
+      label,
+      action: 'Scan',
+      threshold: 0.5,
+      score: scores[label] ?? (triggered.includes(label) ? 0.97 : 0.04),
+      triggered: triggered.includes(label),
+      topToken: '',
+      field: 'text',
+      modelReason: '',
+    })),
+  };
+}
+
+/** Make the mocked scanner return the given step output. */
+function scannerReturns(output: unknown) {
+  mockCreateXGuardModerationRequest.mockResolvedValue({
+    id: 'scan-wf',
+    status: 'succeeded',
+    steps: [{ $type: 'xGuardModeration', output }],
+  });
+}
+
+const CTX = { userId: 42, isGreen: false, appId: 'app-1', appBlockId: 'blk-1' };
+
+beforeEach(() => {
+  mockCreateXGuardModerationRequest.mockReset();
+  mockLogToAxiom.mockReset();
+  mockLogToAxiom.mockResolvedValue(undefined);
+  registryOverride.clear();
+  registryOverride.set(CHAT_TYPE, makeTextStep());
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+describe('textOutput — the fixture is a REGISTRABLE entry', () => {
+  it('the real load-time invariants accept it', () => {
+    // 🔴 THE CONTROL FOR THE WHOLE SUITE. If the registry would reject this
+    // shape, every read-path assertion below would be about an entry that can
+    // never exist, and the suite would prove nothing about anything shippable.
+    expect(() => assertStepInvariants('fixture-chat', makeTextStep())).not.toThrow();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+describe('textOutput — 🔴 THE HANDLER IS NOT INERT (read-path, end to end)', () => {
+  it('WITHHOLDS flagged text — the block never sees it', async () => {
+    scannerReturns(scanOutput(['Young']));
+
+    const snapshot = await attachModeratedStepTextOutputs(
+      { workflowId: 'wf-1', status: 'succeeded' as const },
+      workflowWith(chatStep()),
+      CTX
+    );
+
+    // The assertion that matters. Not "a handler ran", not "a mock was called":
+    // the generated string is absent from the object the block receives.
+    expect(snapshot.textOutputs).toBeUndefined();
+    expect(JSON.stringify(snapshot)).not.toContain(GENERATED_TEXT);
+    expect(snapshot.textOutputWithheld).toEqual({ reason: TEXT_OUTPUT_WITHHELD_MESSAGE });
+  });
+
+  it('🔴 POSITIVE CONTROL — the SAME path publishes the text on a clean scan', async () => {
+    // Without this, "textOutputs is undefined" is indistinguishable from a
+    // harness wired to nothing: a `attachModeratedStepTextOutputs` that always
+    // returned the snapshot untouched would pass the test above and fail this
+    // one. ONLY the scan verdict differs between the two.
+    scannerReturns(scanOutput([]));
+
+    const snapshot = await attachModeratedStepTextOutputs(
+      { workflowId: 'wf-1', status: 'succeeded' as const },
+      workflowWith(chatStep()),
+      CTX
+    );
+
+    expect(snapshot.textOutputs).toEqual([GENERATED_TEXT]);
+    expect(snapshot.textOutputWithheld).toBeUndefined();
+  });
+
+  it('the scan is handed the ACTUAL generated text, and all 15 labels', async () => {
+    scannerReturns(scanOutput([]));
+    await attachModeratedStepTextOutputs(
+      { workflowId: 'wf-1', status: 'succeeded' as const },
+      workflowWith(chatStep('a very specific generated sentence')),
+      CTX
+    );
+    const arg = mockCreateXGuardModerationRequest.mock.calls[0][0];
+    expect(arg.mode).toBe('text');
+    expect(arg.content).toBe('a very specific generated sentence');
+    expect(arg.labels).toEqual([...TEXT_OUTPUT_SCAN_LABELS]);
+    expect(arg.labels).toHaveLength(15);
+  });
+
+  it('passes callbackUrl: null and NO entity fields (no EntityModeration row)', async () => {
+    // 🔴 `EntityModeration` does not exist in the production database, and
+    // OMITTING `callbackUrl` (rather than passing null) makes the request
+    // builder default to the text-moderation webhook, which drives the scanner
+    // audit write. Both are runtime failures on this path, and neither is
+    // visible in a test that only asserts the verdict.
+    scannerReturns(scanOutput([]));
+    await attachModeratedStepTextOutputs(
+      { workflowId: 'wf-1', status: 'succeeded' as const },
+      workflowWith(chatStep()),
+      CTX
+    );
+    const arg = mockCreateXGuardModerationRequest.mock.calls[0][0];
+    expect(arg).toHaveProperty('callbackUrl', null);
+    expect(arg.entityType).toBeUndefined();
+    expect(arg.entityId).toBeUndefined();
+  });
+
+  it('a caller cannot smuggle text past the scan by pre-populating the snapshot', async () => {
+    // The field's guarantee is "everything here was scanned". Merging over an
+    // incoming value rather than stripping it would leave a second, unscanned
+    // producer — which is the whole property this function exists to hold.
+    scannerReturns(scanOutput(['Young']));
+    const snapshot = await attachModeratedStepTextOutputs(
+      {
+        workflowId: 'wf-1',
+        status: 'succeeded' as const,
+        textOutputs: ['smuggled unscanned text'],
+      },
+      workflowWith(chatStep()),
+      CTX
+    );
+    expect(snapshot.textOutputs).toBeUndefined();
+    expect(JSON.stringify(snapshot)).not.toContain('smuggled');
+  });
+
+  it('leaves every other snapshot field byte-identical', async () => {
+    scannerReturns(scanOutput([]));
+    const input = {
+      workflowId: 'wf-1',
+      status: 'succeeded' as const,
+      cost: { total: 12 },
+      imageUrls: ['https://blobs.example/a.webp'],
+    };
+    const snapshot = await attachModeratedStepTextOutputs(input, workflowWith(chatStep()), CTX);
+    expect(snapshot.workflowId).toBe('wf-1');
+    expect(snapshot.cost).toEqual({ total: 12 });
+    expect(snapshot.imageUrls).toEqual(['https://blobs.example/a.webp']);
+  });
+
+  it('does not scan, and adds no field, for a workflow with no registered step', async () => {
+    // The pre-existing txt2img / customComfy paths must be untouched: no
+    // scanner call, no new keys.
+    const snapshot = await attachModeratedStepTextOutputs(
+      { workflowId: 'wf-1', status: 'succeeded' as const },
+      workflowWith({ $type: 'textToImage', output: { images: [] } }),
+      CTX
+    );
+    expect(mockCreateXGuardModerationRequest).not.toHaveBeenCalled();
+    expect(snapshot).toEqual({ workflowId: 'wf-1', status: 'succeeded' });
+  });
+
+  it('publishes the clean step and withholds the flagged one (per-step, not all-or-nothing)', async () => {
+    const cleanType = 'fixtureChatB';
+    registryOverride.set(
+      cleanType,
+      makeTextStep({ id: 'fixture-chat-b', orchestratorType: cleanType } as Partial<AnyBlockStep>)
+    );
+    mockCreateXGuardModerationRequest
+      .mockResolvedValueOnce({
+        steps: [{ $type: 'xGuardModeration', output: scanOutput(['Bestiality']) }],
+      })
+      .mockResolvedValueOnce({
+        steps: [{ $type: 'xGuardModeration', output: scanOutput([]) }],
+      });
+
+    const snapshot = await attachModeratedStepTextOutputs(
+      { workflowId: 'wf-1', status: 'succeeded' as const },
+      workflowWith(
+        { ...chatStep('flagged piece'), $type: CHAT_TYPE },
+        { ...chatStep('clean piece'), $type: cleanType }
+      ),
+      CTX
+    );
+
+    expect(snapshot.textOutputs).toEqual(['clean piece']);
+    expect(JSON.stringify(snapshot)).not.toContain('flagged piece');
+    expect(snapshot.textOutputWithheld).toEqual({ reason: TEXT_OUTPUT_WITHHELD_MESSAGE });
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+describe('textOutput — 🔴 FAILS CLOSED', () => {
+  it.each([
+    [
+      'the scanner THROWS',
+      () => mockCreateXGuardModerationRequest.mockRejectedValue(new Error('orchestrator 503')),
+    ],
+    [
+      'the submit returns nothing (undefined workflow)',
+      () => mockCreateXGuardModerationRequest.mockResolvedValue(undefined),
+    ],
+    [
+      'the workflow carries no xGuardModeration step',
+      () => mockCreateXGuardModerationRequest.mockResolvedValue({ id: 'x', steps: [] }),
+    ],
+    [
+      'the scan step has no output (wait elapsed mid-scan)',
+      () =>
+        mockCreateXGuardModerationRequest.mockResolvedValue({
+          id: 'x',
+          status: 'processing',
+          steps: [{ $type: 'xGuardModeration' }],
+        }),
+    ],
+  ])('WITHHOLDS when %s', async (_label, arrange) => {
+    arrange();
+    const snapshot = await attachModeratedStepTextOutputs(
+      { workflowId: 'wf-1', status: 'succeeded' as const },
+      workflowWith(chatStep()),
+      CTX
+    );
+    expect(snapshot.textOutputs).toBeUndefined();
+    expect(JSON.stringify(snapshot)).not.toContain(GENERATED_TEXT);
+    expect(snapshot.textOutputWithheld).toEqual({ reason: TEXT_OUTPUT_WITHHELD_MESSAGE });
+  });
+
+  it('🔴 this is the OPPOSITE of auditPromptServer, and it must stay that way', async () => {
+    // `auditPromptServer` catches an `extModeration` outage and lets the prompt
+    // THROUGH — the user authored that text. This text is model output nobody has
+    // seen. A future "make the two consistent" refactor would silently ship
+    // unscanned generated output; this test is what stops it.
+    mockCreateXGuardModerationRequest.mockRejectedValue(new Error('extModeration down'));
+    const result = await runStepOutputModeration({
+      step: makeTextStep(),
+      orchestratorStep: chatStep(),
+      ...CTX,
+    });
+    expect(result.released).toBe(false);
+  });
+
+  it('WITHHOLDS when extractText returns a non-array at request time', async () => {
+    registryOverride.set(
+      CHAT_TYPE,
+      makeTextStep({ extractText: () => 'not an array' } as unknown as Partial<AnyBlockStep>)
+    );
+    scannerReturns(scanOutput([]));
+    const snapshot = await attachModeratedStepTextOutputs(
+      { workflowId: 'wf-1', status: 'succeeded' as const },
+      workflowWith(chatStep()),
+      CTX
+    );
+    expect(snapshot.textOutputs).toBeUndefined();
+    expect(snapshot.textOutputWithheld).toBeDefined();
+    expect(mockCreateXGuardModerationRequest).not.toHaveBeenCalled();
+  });
+
+  it('WITHHOLDS when extractText returns a non-string entry', async () => {
+    registryOverride.set(
+      CHAT_TYPE,
+      makeTextStep({ extractText: () => ['ok', 42] } as unknown as Partial<AnyBlockStep>)
+    );
+    scannerReturns(scanOutput([]));
+    const snapshot = await attachModeratedStepTextOutputs(
+      { workflowId: 'wf-1', status: 'succeeded' as const },
+      workflowWith(chatStep()),
+      CTX
+    );
+    expect(snapshot.textOutputs).toBeUndefined();
+    expect(mockCreateXGuardModerationRequest).not.toHaveBeenCalled();
+  });
+
+  it('releases an EMPTY result without scanning when there is no generated text', async () => {
+    // The mirror image of the input-side rule, and deliberately NOT a rejection:
+    // an empty extraction publishes nothing, so no unscanned text escapes. (On
+    // the INPUT side an empty prompt IS rejected — there, "scan nothing" means
+    // the submit proceeds unaudited.)
+    registryOverride.set(CHAT_TYPE, makeTextStep({ extractText: () => ['  ', ''] }));
+    const snapshot = await attachModeratedStepTextOutputs(
+      { workflowId: 'wf-1', status: 'succeeded' as const },
+      workflowWith(chatStep()),
+      CTX
+    );
+    expect(mockCreateXGuardModerationRequest).not.toHaveBeenCalled();
+    expect(snapshot.textOutputs).toBeUndefined();
+    expect(snapshot.textOutputWithheld).toBeUndefined();
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+describe('textOutput — the approved label policy', () => {
+  it('the three tiers PARTITION the scanned labels — none silently drops out', () => {
+    const acted = [...ALWAYS_WITHHOLD_LABELS, ...SFW_ONLY_WITHHOLD_LABELS];
+    expect(ALWAYS_WITHHOLD_LABELS).toHaveLength(7);
+    expect(SFW_ONLY_WITHHOLD_LABELS).toHaveLength(3);
+    expect(NOT_ACTED_ON_LABELS).toHaveLength(5);
+    expect([...acted, ...NOT_ACTED_ON_LABELS].sort()).toEqual([...TEXT_OUTPUT_SCAN_LABELS].sort());
+    // No label may appear in two tiers.
+    expect(new Set([...acted, ...NOT_ACTED_ON_LABELS]).size).toBe(15);
+  });
+
+  it.each(ALWAYS_WITHHOLD_LABELS.map((l) => [l]))(
+    "'%s' withholds on a MATURE-allowed host too",
+    (label) => {
+      // The host-independent tier. `isGreen: false` == the ceiling permits mature
+      // content, and these must still withhold.
+      const verdict = decideTextOutputVerdict(scanOutput([label]), { isGreen: false });
+      expect(verdict.released).toBe(false);
+      expect(verdict.withholdingLabels).toEqual([label]);
+    }
+  );
+
+  it.each(SFW_ONLY_WITHHOLD_LABELS.map((l) => [l]))(
+    "'%s' withholds on SFW and RELEASES on a mature-allowed host",
+    (label) => {
+      // 🔴 BOTH DIRECTIONS ON THE SAME LABEL. A policy that hardcoded `isGreen`
+      // either way passes exactly one of these two assertions and fails the
+      // other; neither can pass both.
+      expect(decideTextOutputVerdict(scanOutput([label]), { isGreen: true }).released).toBe(false);
+      expect(decideTextOutputVerdict(scanOutput([label]), { isGreen: false }).released).toBe(true);
+    }
+  );
+
+  it.each(NOT_ACTED_ON_LABELS.map((l) => [l]))(
+    "'%s' is scanned and reported but never withholds, on EITHER host",
+    (label) => {
+      for (const isGreen of [true, false]) {
+        const verdict = decideTextOutputVerdict(scanOutput([label]), { isGreen });
+        expect(verdict.released).toBe(true);
+        // …and it is still REPORTED. Dropping these from the scan would lose the
+        // telemetry the 15-label choice was made for.
+        expect(verdict.triggeredLabels).toContain(label);
+      }
+    }
+  );
+
+  it('releases a completely benign scan (the negative control for every case above)', () => {
+    const verdict = decideTextOutputVerdict(scanOutput([]), { isGreen: true });
+    expect(verdict.released).toBe(true);
+    expect(verdict.withholdingLabels).toEqual([]);
+    expect(verdict.triggeredLabels).toEqual([]);
+  });
+
+  it('🔴 IGNORES `blocked` — a 0.99 Explicit comes back blocked:false', () => {
+    // Measured against the deployed scanner: the `Explicit` label's ACTION is
+    // `Scan`, so `blocked` stays false however high the score. A policy keyed on
+    // `blocked` releases this. On a SFW ceiling it must not.
+    const output = { ...scanOutput(['Explicit'], { Explicit: 0.99 }), blocked: false };
+    expect(decideTextOutputVerdict(output, { isGreen: true }).released).toBe(false);
+  });
+
+  it('🔴 IGNORES `blocked` in the other direction too', () => {
+    // The complement: `blocked: true` with only a non-actioned label triggering
+    // must NOT withhold. A policy that ORed `blocked` in would fail this.
+    const output = { ...scanOutput(['Celebrity']), blocked: true };
+    expect(decideTextOutputVerdict(output, { isGreen: true }).released).toBe(true);
+  });
+
+  it('UNIONS the two trigger signals — either one alone withholds', () => {
+    // If `triggeredLabels` and `results[].triggered` ever disagree, union
+    // withholds and intersection releases. Union is the fail-closed direction.
+    const fromArrayOnly = { triggeredLabels: ['Young'], results: [] };
+    const fromResultsOnly = {
+      triggeredLabels: [],
+      results: [{ label: 'Young', score: 0.98, triggered: true }],
+    };
+    expect(decideTextOutputVerdict(fromArrayOnly, { isGreen: false }).released).toBe(false);
+    expect(decideTextOutputVerdict(fromResultsOnly, { isGreen: false }).released).toBe(false);
+  });
+
+  it('matches labels CASE-INSENSITIVELY', () => {
+    // The label strings are orchestrator-side config, not a code-owned enum —
+    // the debug endpoint's own docs show `"young"` and `"Young"` in one example.
+    // An exact-match policy would match nothing and release everything.
+    for (const label of ['young', 'YOUNG', ' Young ']) {
+      expect(
+        decideTextOutputVerdict({ triggeredLabels: [label], results: [] }, { isGreen: false })
+          .released
+      ).toBe(false);
+    }
+  });
+
+  it('reports per-label SCORES for the trigger log', () => {
+    const verdict = decideTextOutputVerdict(scanOutput(['Young'], { Young: 0.96 }), {
+      isGreen: false,
+    });
+    expect(verdict.scores.Young).toBe(0.96);
+  });
+
+  it.each([
+    ['null', null],
+    ['undefined', undefined],
+    ['an empty object', {}],
+    ['garbage field types', { triggeredLabels: 'Young', results: 'nope' }],
+  ])('treats %s as no triggers rather than throwing', (_label, output) => {
+    // The DECISION is total. Fail-closed on a missing verdict is
+    // `screenGeneratedText`'s job (asserted above) — this function's contract is
+    // "never throw on a read path", and a throw here would become a 500 on poll.
+    const verdict = decideTextOutputVerdict(output as never, { isGreen: true });
+    expect(verdict.released).toBe(true);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+describe('textOutput — the trigger log', () => {
+  it('logs userId, appId, appBlockId, model, labels and scores on a withhold', async () => {
+    scannerReturns(scanOutput(['Young'], { Young: 0.96 }));
+    await screenGeneratedText({
+      texts: [GENERATED_TEXT],
+      userId: 42,
+      isGreen: false,
+      appId: 'app-1',
+      appBlockId: 'blk-1',
+      stepId: 'fixture-chat',
+      model: CHAT_TYPE,
+    });
+    expect(mockLogToAxiom).toHaveBeenCalledTimes(1);
+    expect(mockLogToAxiom.mock.calls[0][0]).toMatchObject({
+      name: 'block-step-text-output-moderation',
+      stage: 'withheld',
+      userId: 42,
+      appId: 'app-1',
+      appBlockId: 'blk-1',
+      model: CHAT_TYPE,
+      withholdingLabels: ['Young'],
+    });
+    expect(mockLogToAxiom.mock.calls[0][0].scores).toMatchObject({ Young: 0.96 });
+  });
+
+  it('🔴 NEVER logs the withheld text itself', async () => {
+    scannerReturns(scanOutput(['Young']));
+    await screenGeneratedText({
+      texts: [GENERATED_TEXT],
+      userId: 42,
+      isGreen: false,
+      appId: 'app-1',
+      stepId: 'fixture-chat',
+      model: CHAT_TYPE,
+    });
+    expect(JSON.stringify(mockLogToAxiom.mock.calls)).not.toContain(GENERATED_TEXT);
+  });
+
+  it('does not log on a clean release (the log is a trigger signal, not a trace)', async () => {
+    scannerReturns(scanOutput([]));
+    await screenGeneratedText({
+      texts: [GENERATED_TEXT],
+      userId: 42,
+      isGreen: false,
+      appId: 'app-1',
+      stepId: 'fixture-chat',
+      model: CHAT_TYPE,
+    });
+    expect(mockLogToAxiom).not.toHaveBeenCalled();
+  });
+
+  it('a logging failure does not turn a decided verdict into a throw', async () => {
+    mockLogToAxiom.mockRejectedValue(new Error('axiom down'));
+    scannerReturns(scanOutput(['Young']));
+    await expect(
+      screenGeneratedText({
+        texts: [GENERATED_TEXT],
+        userId: 42,
+        isGreen: false,
+        appId: 'app-1',
+        stepId: 'fixture-chat',
+        model: CHAT_TYPE,
+      })
+    ).resolves.toMatchObject({ released: false });
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+describe('textOutput — the OUTPUT dispatch over the posture table', () => {
+  it.each([['none'], ['promptAudit']])(
+    "the '%s' posture releases an EMPTY list and never scans",
+    async (posture) => {
+      const result = await runStepOutputModeration({
+        step: makeTextStep({
+          moderationPosture: posture,
+          extractText: undefined,
+        } as unknown as Partial<AnyBlockStep>),
+        orchestratorStep: chatStep(),
+        ...CTX,
+      });
+      expect(result).toEqual({ released: true, texts: [] });
+      expect(mockCreateXGuardModerationRequest).not.toHaveBeenCalled();
+    }
+  );
+
+  it.each([['toString'], ['constructor'], ['valueOf'], ['__proto__']])(
+    "FAILS CLOSED on the Object.prototype key '%s'",
+    async (posture) => {
+      // The same prototype-key hazard the submit dispatch documents: on a plain
+      // object literal `handlers['toString']` is TRUTHY, and a truthy non-handler
+      // on a READ path would have to be called or coerced. The null prototype
+      // makes it `undefined`; the guard then withholds.
+      const result = await runStepOutputModeration({
+        step: makeTextStep({
+          moderationPosture: posture,
+          extractText: undefined,
+        } as unknown as Partial<AnyBlockStep>),
+        orchestratorStep: chatStep(),
+        ...CTX,
+      });
+      expect(result).toEqual({ released: false, reason: TEXT_OUTPUT_WITHHELD_MESSAGE });
+    }
+  );
+});

--- a/src/server/services/blocks/steps/__tests__/step-text-output-moderation.test.ts
+++ b/src/server/services/blocks/steps/__tests__/step-text-output-moderation.test.ts
@@ -49,6 +49,23 @@ vi.mock('~/server/logging/client', () => ({
 vi.mock('~/server/services/orchestrator/promptAuditing', () => ({
   auditPromptServer: vi.fn(),
 }));
+// 🔴 NOT OPTIONAL, AND NOT COSMETIC — WITHOUT IT THIS FILE LIES VIA ITS EXIT
+// CODE. `workflow.service` (imported below for the two real read-path
+// projections) imports `~/server/db/client` at module scope, which instantiates
+// a real Prisma client. Nothing in this suite queries it, but the instantiation
+// rejects (`PrismaClientInitializationError`), vitest reports the unhandled
+// rejection as a file-level "Errors: 1", and the process EXITS 1 — while every
+// assertion passes and the summary reads `76 passed (76)`.
+//
+// That combination is the exact harness trap this repo has been bitten by: a
+// mutation sweep that reads `rc` sees a non-zero exit for the CONTROL and for
+// every mutant alike, and reports 100% of mutants killed while testing nothing.
+// The sibling suites all mock this module for the same reason. Read the
+// `Tests N failed | M passed` line, and keep this mock so `rc` agrees with it.
+vi.mock('~/server/db/client', () => ({
+  dbRead: {},
+  dbWrite: {},
+}));
 
 // 🔴 THE REGISTRY IS OVERRIDDEN FOR `getStepByOrchestratorType` ONLY, and it is
 // the minimum needed to test the read path today: the shipped registry has no
@@ -95,6 +112,7 @@ import {
   SFW_ONLY_WITHHOLD_LABELS,
   TEXT_OUTPUT_SCAN_LABELS,
   TEXT_OUTPUT_WITHHELD_MESSAGE,
+  VERDICT_CACHE_MAX_ENTRIES,
   __clearTextOutputVerdictCacheForTests,
 } from '~/server/services/blocks/steps/text-output-moderation';
 
@@ -959,6 +977,105 @@ describe('textOutput — the per-content verdict memo', () => {
     const recovered = await screenGeneratedText({ ...opts, texts: [GENERATED_TEXT] });
     expect(recovered).toEqual({ released: true, texts: [GENERATED_TEXT] });
     expect(mockCreateXGuardModerationRequest).toHaveBeenCalledTimes(2);
+  });
+
+  it('🔴 a NO-VERDICT withhold is NOT memoized either — the OTHER uncached branch', async () => {
+    // The memo's comment claims errors, timeouts AND missing outputs are all
+    // excluded; only the error branch was pinned. These are TWO branches, not
+    // three: an error and a timeout both land in the same `catch` (the hard
+    // deadline rejects the same promise), while "the submit resolved but there
+    // is no xGuardModeration output" is its own `if (!output)` exit — and it was
+    // the unpinned one. A `writeCachedVerdict` moved above that exit would pin a
+    // transient no-verdict shut for five minutes.
+    mockCreateXGuardModerationRequest.mockResolvedValueOnce({
+      id: 'scan-wf',
+      status: 'processing',
+      steps: [],
+    });
+    const noVerdict = await screenGeneratedText({ ...opts, texts: [GENERATED_TEXT] });
+    expect(noVerdict).toEqual({ released: false, reason: TEXT_OUTPUT_WITHHELD_MESSAGE });
+
+    scannerReturns(scanOutput([]));
+    const recovered = await screenGeneratedText({ ...opts, texts: [GENERATED_TEXT] });
+    expect(recovered).toEqual({ released: true, texts: [GENERATED_TEXT] });
+    expect(mockCreateXGuardModerationRequest).toHaveBeenCalledTimes(2);
+  });
+
+  it('🔴 a LABEL-DRIFT withhold is NOT memoized — it is an operational fault, like an error', async () => {
+    // 🔴 THE DECISION THIS PINS. Drift is a fault in THIS file's own constant
+    // (or in the scanner's label config), not a content hit, and it clears the
+    // moment the fault does — a mid-deploy scanner fleet answering on some
+    // instances and not others, or a label config being put back. Memoizing it
+    // would pin the withhold through that recovery for five minutes, which is
+    // the exact reason the error branch is not cached. An earlier revision
+    // wrote the cache BEFORE the drift branch and so cached one and not the
+    // other, with nothing asserting either way.
+    const full = scanOutput([]);
+    mockCreateXGuardModerationRequest.mockResolvedValueOnce({
+      id: 'scan-wf',
+      status: 'succeeded',
+      steps: [
+        {
+          $type: 'xGuardModeration',
+          output: { ...full, results: full.results.filter((r) => r.label !== 'Bestiality') },
+        },
+      ],
+    });
+    const drifted = await screenGeneratedText({ ...opts, texts: [GENERATED_TEXT] });
+    expect(drifted).toEqual({ released: false, reason: TEXT_OUTPUT_WITHHELD_MESSAGE });
+    expect(mockLogToAxiom.mock.calls[0][0]).toMatchObject({ stage: 'label-drift' });
+
+    // The fault clears. The very next call must reach the scanner and release.
+    scannerReturns(full);
+    const recovered = await screenGeneratedText({ ...opts, texts: [GENERATED_TEXT] });
+    expect(recovered).toEqual({ released: true, texts: [GENERATED_TEXT] });
+    expect(mockCreateXGuardModerationRequest).toHaveBeenCalledTimes(2);
+  });
+
+  it('🔴 CONTROL FOR THE PAIR ABOVE — a POLICY withhold on the same content IS memoized', async () => {
+    // Without this, "the second call rescanned" is what a memo that stores
+    // nothing at all also produces, and the two exclusions above would be green
+    // for the wrong reason. Same content, same TTL, only the withhold's CAUSE
+    // differs: a content hit is cached, an operational fault is not.
+    scannerReturns(scanOutput(['Young']));
+    await screenGeneratedText({ ...opts, texts: [GENERATED_TEXT] });
+    await screenGeneratedText({ ...opts, texts: [GENERATED_TEXT] });
+    expect(mockCreateXGuardModerationRequest).toHaveBeenCalledTimes(1);
+  });
+
+  it('the entry cap is 1,000 — pinned LITERALLY', () => {
+    // 🔴 A VALUE PIN. The eviction bound was unpinned: collapsing it to 1
+    // disables the memo outright (every write evicts the previous entry) and
+    // nothing observed it, because every other memo test uses one or two
+    // distinct contents and fits inside any cap ≥ 2.
+    expect(VERDICT_CACHE_MAX_ENTRIES).toBe(1_000);
+  });
+
+  it('🔴 evicts the OLDEST entry at the cap, and only at the cap', async () => {
+    // The behavioural half of the pin above: it pins that eviction HAPPENS, at
+    // the cap, oldest-first. Deleting the eviction block kills it (measured).
+    //
+    // 🔴 IT DOES *NOT* PIN THE VALUE, and saying otherwise would be the same
+    // mistake the content-cap block records: this test derives its loop bound
+    // FROM the constant, so it moves with any change to it — a 1000 → 1 mutant
+    // (which disables the memo outright) leaves this test green and is caught
+    // ONLY by the literal pin above. Measured, not assumed. Keep both.
+    scannerReturns(scanOutput([]));
+    const OLDEST = 'reply number 0';
+    for (let i = 0; i < VERDICT_CACHE_MAX_ENTRIES; i++) {
+      await screenGeneratedText({ ...opts, texts: [`reply number ${i}`] });
+    }
+    expect(mockCreateXGuardModerationRequest).toHaveBeenCalledTimes(VERDICT_CACHE_MAX_ENTRIES);
+
+    // Still cached AT the cap — a hit, so no new scan and no re-insertion.
+    await screenGeneratedText({ ...opts, texts: [OLDEST] });
+    expect(mockCreateXGuardModerationRequest).toHaveBeenCalledTimes(VERDICT_CACHE_MAX_ENTRIES);
+
+    // One more distinct content pushes past the cap and evicts the oldest…
+    await screenGeneratedText({ ...opts, texts: ['one over the cap'] });
+    // …so the oldest now MISSES and is rescanned: 1000 + 1 (over-cap) + 1 (miss).
+    await screenGeneratedText({ ...opts, texts: [OLDEST] });
+    expect(mockCreateXGuardModerationRequest).toHaveBeenCalledTimes(VERDICT_CACHE_MAX_ENTRIES + 2);
   });
 
   it('a memo HIT returns the CALLER’s own pieces, not the stored ones', async () => {

--- a/src/server/services/blocks/steps/index.ts
+++ b/src/server/services/blocks/steps/index.ts
@@ -183,8 +183,15 @@ export function postureRequiresAuditableText(posture: StepModerationPosture): bo
  *      whose text member types `extractOutput?: never`. A text entry cannot
  *      even WRITE a media extractor, which is what makes the url-smuggle
  *      structurally impossible rather than merely guarded.
- *   2. AT REGISTRY LOAD — clauses 8/8a below, for the `as`-cast escape hatch a
- *      type cannot close.
+ *   2. AT REGISTRY LOAD — for the `as`-cast escape hatch a type cannot close.
+ *      🔴 NAME THE RIGHT CLAUSES: an earlier revision of this line said
+ *      "clauses 8/8a", which is wrong in both directions and would send someone
+ *      auditing the XOR to the wrong code. The runtime XOR is clause **8-i**
+ *      (a media posture MUST declare `extractOutput`) and clause **8-ii** (a
+ *      text posture MUST NOT) on the `extractOutput` axis, plus clause **1c**
+ *      (both directions) on the `extractText` axis. Clause **8a** is NOT an XOR
+ *      clause at all — it is the non-vacuity probe that a declared `extractText`
+ *      actually returns text.
  *   3. AT THE READ PATH — `snapshotFromWorkflow` / `projectAppWorkflow` consult
  *      THIS predicate before calling `extractOutput`, so a media extractor that
  *      somehow existed on a text entry would still contribute nothing.
@@ -1255,9 +1262,26 @@ export function isModerationPostureImplemented(posture: StepModerationPosture): 
 // commitment. Adding it later is one file plus one line here — which is the
 // entire point of the registry.
 // ─────────────────────────────────────────────────────────────────────────────
-const stepRegistry = {
-  'convert-image': convertImageStep,
-};
+// 🔴 FROZEN, FOR THE SAME REASON `STEP_TYPE_ACCEPTABLE_POSTURES` IS — and BE
+// PRECISE ABOUT WHAT THAT BUYS, because it is less than the freeze above buys.
+// Neither post-load mutation direction is a HOLE today: adding an entry here
+// after load does not make it submittable (`REGISTERED_STEP_IDS` was already
+// snapshotted into `blockStepBodySchema`'s enum, so the id is rejected at the
+// union), and flipping a live entry's `moderationPosture` to `'none'` fails
+// CLOSED at the read path (a text entry has no `extractOutput`, so the media
+// branch yields nothing and the `'none'` dispatch releases an empty list). So
+// this is CONSISTENCY on the discriminant all three enforcement layers read,
+// not a closed vulnerability — recorded as such rather than dressed up.
+//
+// SHALLOW ON PURPOSE, BOTH LEVELS. Freezing the container blocks entry
+// addition/replacement; freezing each entry blocks `entry.moderationPosture =
+// …`, which is the assignment that would matter. It deliberately does NOT
+// recurse into an entry's nested values — those include zod schemas, which
+// populate internal caches lazily and must stay mutable. A deep freeze here
+// would trade a consistency nicety for a runtime failure mode.
+const stepRegistry = Object.freeze({
+  'convert-image': Object.freeze(convertImageStep),
+});
 
 export type RegisteredStepId = keyof typeof stepRegistry & string;
 

--- a/src/server/services/blocks/steps/index.ts
+++ b/src/server/services/blocks/steps/index.ts
@@ -157,14 +157,86 @@ export function postureRequiresAuditableText(posture: StepModerationPosture): bo
 }
 
 /**
+ * WHAT SHAPE a posture's step publishes — MEDIA **XOR** TEXT. The single
+ * declaration every output-shape rule reads.
+ *
+ * 🔴 WHY THIS EXISTS, AND THE DEFECT IT CLOSES. `extractOutput` used to be
+ * unconditionally REQUIRED and clause 8 unconditionally demanded ≥1 media item
+ * with a non-empty `url` — for EVERY entry, with no posture gate, in contrast to
+ * clause 8a which was already gated. But `ACCEPTABLE_POSTURES_BY_TYPE` licenses
+ * `'textOutput'` only for `chatCompletion` / `mediaCaptioning` /
+ * `audioCaptioning` / `transcription` / `promptEnhancement` / `xGuardModeration`
+ * / `echo` — every one of them TEXT-producing and none of them media-producing.
+ * So the posture was UN-ADOPTABLE: an honest `chatCompletion` + `'textOutput'`
+ * entry hit a load-time wall it could not satisfy truthfully, and the obvious
+ * workaround — prose stuffed into a fabricated `media.url` — registered cleanly
+ * and shipped that prose UNSCANNED, because `StepOutputMedia.url` is a bare
+ * string that flows to `snapshot.imageUrls` and `AppWorkflow.images[].url`
+ * WITHOUT passing through `attachModeratedStepTextOutputs`. Proven by execution
+ * in review, both directions.
+ *
+ * 🔴 XOR, NOT "AT LEAST ONE", AND THAT IS DELIBERATE. A `'media'` entry declares
+ * `extractOutput` and MUST NOT declare `extractText`; a `'text'` entry declares
+ * `extractText` and MUST NOT declare `extractOutput`. Enforced three ways off
+ * THIS one predicate:
+ *   1. AT THE TYPE LEVEL — `BlockStep` intersects a `StepOutputSurface` union
+ *      whose text member types `extractOutput?: never`. A text entry cannot
+ *      even WRITE a media extractor, which is what makes the url-smuggle
+ *      structurally impossible rather than merely guarded.
+ *   2. AT REGISTRY LOAD — clauses 8/8a below, for the `as`-cast escape hatch a
+ *      type cannot close.
+ *   3. AT THE READ PATH — `snapshotFromWorkflow` / `projectAppWorkflow` consult
+ *      THIS predicate before calling `extractOutput`, so a media extractor that
+ *      somehow existed on a text entry would still contribute nothing.
+ *
+ * 🔴 HONEST LIMIT, STATED RATHER THAN PAPERED OVER. A future orchestrator step
+ * that emits BOTH media and free text cannot register at all under this rule —
+ * it fails at load rather than half-registering. That is the fail-closed
+ * direction and it is the intended answer for now: such an entry needs a real
+ * decision about whether its media is scanned too (the text scan here does not
+ * look at media at all), and it should be blocked until someone makes it, not
+ * admitted with one axis silently uncovered. Nothing in the currently-licensed
+ * `$type` set has that shape.
+ */
+export function stepOutputShape(posture: StepModerationPosture): 'media' | 'text' {
+  switch (posture) {
+    // No free-text output — whatever this step produces is media, extracted by
+    // the declared `extractOutput` and rated by the orchestrator's own blob
+    // `nsfwLevel` on the existing path.
+    case 'none':
+      return 'media';
+    // Input-side posture. Its RESULT is media (see `posturePhaseRequirements`'s
+    // `'promptAudit'` case: no output-phase surface).
+    case 'promptAudit':
+      return 'media';
+    // The only text-publishing posture, and the only one whose result reaches a
+    // block through the scan.
+    case 'textOutput':
+      return 'text';
+  }
+}
+
+/**
  * True iff the posture's handler needs the entry to declare `extractText`.
  *
- * The OUTPUT-side twin of `postureRequiresAuditableText`, and the same single
- * declaration: the load-time invariant, the read-path handler and the tests all
- * read THIS.
+ * The OUTPUT-side twin of `postureRequiresAuditableText`. 🔴 DERIVED FROM
+ * `stepOutputShape`, not a second copy of the rule: the load-time invariant, the
+ * read-path handler, the type-level surface union and the tests all bottom out
+ * in one predicate, so "which postures publish text" cannot drift between them.
  */
 export function postureRequiresTextExtraction(posture: StepModerationPosture): boolean {
-  return posture === 'textOutput';
+  return stepOutputShape(posture) === 'text';
+}
+
+/**
+ * True iff the posture's step publishes MEDIA — i.e. iff it declares (and the
+ * two `workflow.service` extractors may call) `extractOutput`.
+ *
+ * The exact complement of `postureRequiresTextExtraction`, off the same
+ * predicate.
+ */
+export function postureProducesMedia(posture: StepModerationPosture): boolean {
+  return stepOutputShape(posture) === 'media';
 }
 
 /**
@@ -552,7 +624,15 @@ interface BlockStepBase<P> {
   orchestratorType: string;
   /** 🔴 REQUIRED. Drives estimate/submit/settle dispatch. */
   billingMode: StepBillingMode;
-  /** 🔴 REQUIRED. See `StepModerationPosture`. */
+  /**
+   * 🔴 REQUIRED. See `StepModerationPosture`.
+   *
+   * 🔴 IT IS ALSO THE OUTPUT-SHAPE DISCRIMINANT. `BlockStep` intersects this
+   * base with the `StepOutputSurface` union below, which narrows this field to
+   * `'textOutput'` on the text member and to `'none' | 'promptAudit'` on the
+   * media member — so declaring the posture is the same act as declaring which
+   * extractor the entry supplies. See `stepOutputShape`.
+   */
   moderationPosture: StepModerationPosture;
   /**
    * 🔴 REQUIRED IFF `moderationPosture` requires it (`'promptAudit'`), and
@@ -580,31 +660,6 @@ interface BlockStepBase<P> {
    * reviewed declaration in a code-reviewed trust root.
    */
   auditableText?(params: P): StepAuditableText;
-  /**
-   * 🔴 REQUIRED IFF `moderationPosture` requires it (`'textOutput'`), and
-   * FORBIDDEN otherwise. PURE: the orchestrator's completed step → the generated
-   * FREE TEXT that must be scanned before it can reach the block.
-   *
-   * The OUTPUT-side twin of `auditableText`, and a declared field for the same
-   * reason `extractOutput` is: the output KEY is step-type-specific, so the
-   * entry NAMES its generated text rather than the registry sniffing for
-   * string-valued fields — which would scan a blob url and miss
-   * `choices[].message.content`.
-   *
-   * 🔴 AND IT IS THE OTHER HALF OF THE WITHHOLDING CONTRACT. Whatever this
-   * returns is what the scan sees AND what a release publishes: the read path
-   * emits exactly these strings, never `step.output` directly. So a piece of
-   * generated text this function does not return is a piece of text that is
-   * never scanned AND never published — the two properties move together by
-   * construction, which is what makes an under-inclusive extractor a missing
-   * feature rather than a silent moderation hole.
-   *
-   * MUST return non-empty strings for `canonicalOutputFor(variant)` — enforced
-   * at load (clause 8a), for the same reason `extractOutput` gets clause 8: a
-   * field satisfiable by `() => []` is a declared posture that scans nothing,
-   * publishes nothing, and reports success.
-   */
-  extractText?(step: unknown): string[];
   /**
    * 🔴 REQUIRED. See `StepResourcePolicy`. The entitlement axis — the one this
    * PR's own triage identified as the real bypass risk, and the one a
@@ -676,22 +731,6 @@ interface BlockStepBase<P> {
   /** The Buzz figure `estimateWorkflow` shows the block. */
   estimateBuzz(params: P): number;
   /**
-   * 🔴 REQUIRED. PURE extractor: the orchestrator's completed step object → the
-   * output media the caller gets back. Called by BOTH `snapshotFromWorkflow`
-   * (`imageUrls`) and `projectAppWorkflow` (`images`), so one declaration
-   * surfaces the result on both read surfaces.
-   *
-   * MUST apply the availability filter — use the shared `mediaFromBlobs` helper
-   * rather than reimplementing it.
-   *
-   * Takes the whole step (not `step.output`) because the output KEY is
-   * step-type-specific: `convertImage` returns `{ blob }`, `customComfy`
-   * returns `{ blobs }`, the image steps return `{ images }`. Typed `unknown`
-   * because the orchestrator step union is wider than any one entry knows;
-   * narrow it inside the entry.
-   */
-  extractOutput(step: unknown): StepOutputMedia[];
-  /**
    * A canonical, orchestrator-SHAPED completed step object for the given
    * variant, carrying at least one available output blob.
    *
@@ -704,9 +743,111 @@ interface BlockStepBase<P> {
    * 🔴 Populate it from a REAL observed orchestrator response, not from what the
    * extractor expects. A sample written to match the code proves only that the
    * code matches itself.
+   *
+   * REQUIRED for BOTH output shapes: it is the probe input for clause 8 (media)
+   * AND for clause 8a (text).
    */
   canonicalOutputFor(variant: string): unknown;
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// THE OUTPUT SURFACE — MEDIA **XOR** TEXT, discriminated on `moderationPosture`.
+//
+// 🔴 THIS IS WHERE "a text-posture entry cannot smuggle prose through
+// `media.url`" IS MADE STRUCTURAL RATHER THAN GUARDED. `extractOutput?: never`
+// on the text member means a `'textOutput'` entry cannot DECLARE a media
+// extractor at all — there is no field to put a fabricated url in, so there is
+// nothing for a runtime guard to catch. See `stepOutputShape` for the defect
+// this replaces (an honest text entry could not register; the dishonest
+// media-shaped one could, and its prose reached `snapshot.imageUrls` /
+// `AppWorkflow.images[].url` without ever passing the scan).
+//
+// 🔴 WHY `?: never` AND NOT AN OMITTED FIELD. Omitting `extractOutput` from the
+// text member would make an entry that declares one merely have an EXCESS
+// property — which TypeScript only rejects for a fresh object literal, and
+// silently allows through any variable, spread or `Partial<…>` widening. `never`
+// makes the field unassignable on every path (`satisfies`, a typed const, a
+// spread through a helper), which is the difference between a lint and a rule.
+//
+// 🔴 THE LOAD-TIME CLAUSES ARE NOT REDUNDANT WITH THIS. The registry is reached
+// through `AnyBlockStep` and `as` casts in several places (and a future entry
+// could be constructed dynamically), so clauses 8/8a re-assert the same XOR at
+// runtime, off the same `stepOutputShape` predicate. Type + load + read path,
+// one rule.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** A step whose result is MEDIA — the pre-existing shape, unchanged. */
+type MediaOutputSurface = {
+  /** Narrowed from `BlockStepBase`: every posture whose shape is `'media'`. */
+  moderationPosture: Exclude<StepModerationPosture, 'textOutput'>;
+  /**
+   * 🔴 REQUIRED for a media entry. PURE extractor: the orchestrator's completed
+   * step object → the output media the caller gets back. Called by BOTH
+   * `snapshotFromWorkflow` (`imageUrls`) and `projectAppWorkflow` (`images`), so
+   * one declaration surfaces the result on both read surfaces.
+   *
+   * MUST apply the availability filter — use the shared `mediaFromBlobs` helper
+   * rather than reimplementing it.
+   *
+   * Takes the whole step (not `step.output`) because the output KEY is
+   * step-type-specific: `convertImage` returns `{ blob }`, `customComfy`
+   * returns `{ blobs }`, the image steps return `{ images }`. Typed `unknown`
+   * because the orchestrator step union is wider than any one entry knows;
+   * narrow it inside the entry.
+   */
+  extractOutput(step: unknown): StepOutputMedia[];
+  /**
+   * FORBIDDEN. A posture that never scans generated text must not carry an
+   * extractor that reads as generated-text coverage and is never called
+   * (clause 1c's reverse direction, at the type level).
+   */
+  extractText?: never;
+};
+
+/** A step whose result is generated FREE TEXT, published only through the scan. */
+type TextOutputSurface = {
+  /** Narrowed from `BlockStepBase`: the only posture whose shape is `'text'`. */
+  moderationPosture: 'textOutput';
+  /**
+   * 🔴 REQUIRED for a text entry. PURE: the orchestrator's completed step → the
+   * generated FREE TEXT that must be scanned before it can reach the block.
+   *
+   * The OUTPUT-side twin of `auditableText`, and a declared field for the same
+   * reason `extractOutput` is: the output KEY is step-type-specific, so the
+   * entry NAMES its generated text rather than the registry sniffing for
+   * string-valued fields — which would scan a blob url and miss
+   * `choices[].message.content`.
+   *
+   * 🔴 AND IT IS THE OTHER HALF OF THE WITHHOLDING CONTRACT. Whatever this
+   * returns is what the scan sees AND what a release publishes: the read path
+   * emits exactly these strings, never `step.output` directly. So a piece of
+   * generated text this function does not return is a piece of text that is
+   * never scanned AND never published — the two properties move together by
+   * construction, which is what makes an under-inclusive extractor a missing
+   * feature rather than a silent moderation hole.
+   *
+   * MUST return non-empty strings for `canonicalOutputFor(variant)` — enforced
+   * at load (clause 8a): a field satisfiable by `() => []` is a declared posture
+   * that scans nothing, publishes nothing, and reports success.
+   */
+  extractText(step: unknown): string[];
+  /**
+   * 🔴 FORBIDDEN, AND THIS IS THE ANTI-SMUGGLING CONTROL. `StepOutputMedia.url`
+   * is a bare `string` that is never URL-validated and flows straight to
+   * `snapshot.imageUrls` and `AppWorkflow.images[].url` WITHOUT passing through
+   * `attachModeratedStepTextOutputs`. If a text entry could declare a media
+   * extractor, `extractOutput: () => [{ url: theModelsReply, … }]` would publish
+   * unscanned generated text through the media channel while every moderation
+   * gate stayed green. `never` is what makes that unwritable.
+   */
+  extractOutput?: never;
+};
+
+/**
+ * The output surface a registered step declares. See the block comment above —
+ * MEDIA XOR TEXT, discriminated on `moderationPosture`.
+ */
+type StepOutputSurface = MediaOutputSurface | TextOutputSurface;
 
 /**
  * Deterministic cost, exactly knowable before execution.
@@ -764,8 +905,19 @@ interface TokenMeteredStep<P> extends BlockStepBase<P> {
  * a missing or unknown `billingMode` a COMPILE error rather than a runtime
  * surprise (no union member matches), and what gives each mode its own required
  * price/budget accessor.
+ *
+ * 🔴 INTERSECTED WITH `StepOutputSurface`, a SECOND discriminated union — on
+ * `moderationPosture` — that makes the output shape MEDIA XOR TEXT at compile
+ * time. The two axes are independent (any billing mode may publish either
+ * shape), so an intersection is the honest encoding; spelling out all six
+ * combinations by hand would be the same type with six places to forget.
  */
-export type BlockStep<P = unknown> = PrepaidFixedStep<P> | TimeBoundedStep<P> | TokenMeteredStep<P>;
+export type BlockStep<P = unknown> = (
+  | PrepaidFixedStep<P>
+  | TimeBoundedStep<P>
+  | TokenMeteredStep<P>
+) &
+  StepOutputSurface;
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type AnyBlockStep = BlockStep<any>;
@@ -1494,25 +1646,64 @@ export function assertStepInvariants(id: string, step: AnyBlockStep): void {
       }
     }
 
-    // (8) OUTPUT EXTRACTION must actually surface something. A registered step
-    // whose output nothing can read is a capability the caller is CHARGED for
-    // and can never retrieve — it polls to `succeeded` with an empty result
-    // forever. That failure is invisible to every other invariant here, and it
-    // is exactly what shipped before this clause existed.
+    // (8) OUTPUT EXTRACTION must actually surface something — 🔴 POSTURE-GATED,
+    // on the SHAPE the entry declares (`stepOutputShape`), not unconditionally.
+    //
+    // 🔴 WHAT THE GATE FIXES. This clause used to demand ≥1 media item with a
+    // non-empty `url` from EVERY entry, with no posture gate — in deliberate
+    // contrast to clause 8a below, which was already gated. But every `$type`
+    // that `ACCEPTABLE_POSTURES_BY_TYPE` licenses for `'textOutput'` is
+    // TEXT-producing and none is media-producing, so an honest
+    // `chatCompletion` + `'textOutput'` entry could NOT register: it had no
+    // media to return. The workaround an author reaches for next — prose in a
+    // fabricated `media.url` — DID register, and shipped that prose unscanned
+    // (`snapshot.imageUrls` / `AppWorkflow.images[].url` never pass through
+    // `attachModeratedStepTextOutputs`). Both directions were proven by
+    // execution in review. So the requirement is now the entry's declared
+    // SHAPE, and the smuggling vector is closed at the type level as well
+    // (`TextOutputSurface.extractOutput?: never`).
     const sampleStep = step.canonicalOutputFor(variant);
-    const media = step.extractOutput(sampleStep);
-    if (!Array.isArray(media) || media.length === 0) {
-      throw new Error(
-        `${vWhere}: extractOutput() returned no media for canonicalOutputFor() — the step's ` +
-          'result would be unreachable on both the snapshot and the app-workflow projection'
-      );
-    }
-    for (const item of media) {
-      if (typeof item?.url !== 'string' || item.url.length === 0) {
+    if (postureProducesMedia(step.moderationPosture)) {
+      // 8-i. A media entry MUST declare the extractor. Enforced at runtime as
+      // well as in the type, because the registry is reached through
+      // `AnyBlockStep` and `as` casts — without this the failure would be a bare
+      // `TypeError: step.extractOutput is not a function` out of module load.
+      if (typeof step.extractOutput !== 'function') {
         throw new Error(
-          `${vWhere}: extractOutput() returned media with no url — a block would render a dead link`
+          `${vWhere}: moderationPosture '${step.moderationPosture}' publishes MEDIA and requires ` +
+            'an extractOutput() declaration — without it the step is charged for, reaches ' +
+            'succeeded, and its result is unreachable on both read surfaces'
         );
       }
+      const media = step.extractOutput(sampleStep);
+      if (!Array.isArray(media) || media.length === 0) {
+        throw new Error(
+          `${vWhere}: extractOutput() returned no media for canonicalOutputFor() — the step's ` +
+            'result would be unreachable on both the snapshot and the app-workflow projection'
+        );
+      }
+      for (const item of media) {
+        if (typeof item?.url !== 'string' || item.url.length === 0) {
+          throw new Error(
+            `${vWhere}: extractOutput() returned media with no url — a block would render a dead link`
+          );
+        }
+      }
+    } else if (step.extractOutput !== undefined) {
+      // 8-ii. 🔴 THE ANTI-SMUGGLING CLAUSE, and the runtime half of
+      // `TextOutputSurface.extractOutput?: never`. A text-posture entry that
+      // carries a media extractor has a channel to the block that the scan does
+      // NOT stand in front of: `StepOutputMedia.url` is a bare string, never
+      // URL-validated, and it reaches `snapshot.imageUrls` and
+      // `AppWorkflow.images[].url` directly. Rejecting the DECLARATION is what
+      // makes the channel non-existent rather than merely policed — there is no
+      // "but only if the url looks like prose" heuristic here to get wrong.
+      throw new Error(
+        `${vWhere}: declares extractOutput() but moderationPosture ` +
+          `'${step.moderationPosture}' publishes TEXT — a media extractor on a text step is an ` +
+          'unscanned channel to the block (media urls bypass the output scan entirely), so the ' +
+          'declaration is rejected rather than policed'
+      );
     }
 
     // (8a) THE NON-VACUITY PROBE for `extractText` — clause 8's twin on the

--- a/src/server/services/blocks/steps/index.ts
+++ b/src/server/services/blocks/steps/index.ts
@@ -110,9 +110,16 @@ export type StepModerationPosture =
    */
   | 'promptAudit'
   /**
-   * Free-text OUTPUT — a moderation surface the prompt audit does not cover.
-   * Generated text is scanned by NOTHING on any current path.
-   * NOT IMPLEMENTED — registering an entry with this posture fails at load.
+   * Free-text OUTPUT — a moderation surface the prompt audit does not cover at
+   * all, because the text does not exist yet when the prompt audit runs.
+   *
+   * IMPLEMENTED, in the OUTPUT phase. An entry declaring it MUST also declare
+   * `extractText` (see that field). Its handler lives in `./moderation` and
+   * scans the generated text with the orchestrator's `xGuardModeration` step
+   * (`mode: 'text'`) at the READ boundary — after generation, before the text
+   * reaches the block — withholding it on a policy hit and on any scanner
+   * failure. See `./text-output-moderation` for the label policy and for why it
+   * fails CLOSED where the prompt audit fails soft.
    */
   | 'textOutput';
 
@@ -147,6 +154,63 @@ export type StepAuditableText = {
  */
 export function postureRequiresAuditableText(posture: StepModerationPosture): boolean {
   return posture === 'promptAudit';
+}
+
+/**
+ * True iff the posture's handler needs the entry to declare `extractText`.
+ *
+ * The OUTPUT-side twin of `postureRequiresAuditableText`, and the same single
+ * declaration: the load-time invariant, the read-path handler and the tests all
+ * read THIS.
+ */
+export function postureRequiresTextExtraction(posture: StepModerationPosture): boolean {
+  return posture === 'textOutput';
+}
+
+/**
+ * WHICH PHASES a posture is REQUIRED to run a handler in.
+ *
+ * 🔴 THIS IS THE CONTROL THAT MAKES `'textOutput'` IMPOSSIBLE TO SATISFY WITH AN
+ * INERT HANDLER, and it is the whole reason the posture table in `./moderation`
+ * is keyed by phase instead of being a flat posture → handler map.
+ *
+ * The moderation dispatch has two positions, and they are NOT interchangeable:
+ *
+ *   SUBMIT — `runStepModeration`, in the step submit path, before the
+ *            orchestrator quote and before any spend reservation. The only
+ *            place INPUT can be audited, and the only place a rejection is free.
+ *   OUTPUT — `runStepOutputModeration`, at the read boundary, after the
+ *            orchestrator has produced a result. The only place GENERATED text
+ *            exists at all.
+ *
+ * A `'textOutput'` handler placed in the SUBMIT phase would run before the
+ * generation, scan nothing, and return cleanly — a registered, load-time-gated
+ * posture that is a NO-OP, reporting success on every call. Declaring the
+ * required phase here and asserting the table against it at load makes that
+ * shape a BUILD failure instead of something review has to notice. The assert
+ * is two-directional (`./moderation`): a required phase with no handler fails,
+ * and a handler in a phase the posture does NOT require fails too — because a
+ * handler that never runs reads as coverage.
+ */
+export function posturePhaseRequirements(posture: StepModerationPosture): {
+  submit: boolean;
+  output: boolean;
+} {
+  switch (posture) {
+    // No free-text input and no free-text output — no surface in either phase.
+    case 'none':
+      return { submit: false, output: false };
+    // Input only. The generated media of a `'promptAudit'` step is not text and
+    // is not this posture's concern.
+    case 'promptAudit':
+      return { submit: true, output: false };
+    // Output only. There is no input surface to audit at submit — an entry that
+    // ALSO takes free-text input is declaring the wrong posture for its input,
+    // which `ACCEPTABLE_POSTURES_BY_TYPE` deliberately does not try to model
+    // (see the SET-NOT-A-LADDER note there).
+    case 'textOutput':
+      return { submit: false, output: true };
+  }
 }
 
 /**
@@ -516,6 +580,31 @@ interface BlockStepBase<P> {
    * reviewed declaration in a code-reviewed trust root.
    */
   auditableText?(params: P): StepAuditableText;
+  /**
+   * 🔴 REQUIRED IFF `moderationPosture` requires it (`'textOutput'`), and
+   * FORBIDDEN otherwise. PURE: the orchestrator's completed step → the generated
+   * FREE TEXT that must be scanned before it can reach the block.
+   *
+   * The OUTPUT-side twin of `auditableText`, and a declared field for the same
+   * reason `extractOutput` is: the output KEY is step-type-specific, so the
+   * entry NAMES its generated text rather than the registry sniffing for
+   * string-valued fields — which would scan a blob url and miss
+   * `choices[].message.content`.
+   *
+   * 🔴 AND IT IS THE OTHER HALF OF THE WITHHOLDING CONTRACT. Whatever this
+   * returns is what the scan sees AND what a release publishes: the read path
+   * emits exactly these strings, never `step.output` directly. So a piece of
+   * generated text this function does not return is a piece of text that is
+   * never scanned AND never published — the two properties move together by
+   * construction, which is what makes an under-inclusive extractor a missing
+   * feature rather than a silent moderation hole.
+   *
+   * MUST return non-empty strings for `canonicalOutputFor(variant)` — enforced
+   * at load (clause 8a), for the same reason `extractOutput` gets clause 8: a
+   * field satisfiable by `() => []` is a declared posture that scans nothing,
+   * publishes nothing, and reports success.
+   */
+  extractText?(step: unknown): string[];
   /**
    * 🔴 REQUIRED. See `StepResourcePolicy`. The entitlement axis — the one this
    * PR's own triage identified as the real bypass risk, and the one a
@@ -977,10 +1066,13 @@ export function planStepSpend(
 export function isModerationPostureImplemented(posture: StepModerationPosture): boolean {
   // 'none' is implemented by construction: a step with no free-text input and
   // no free-text output introduces no surface, so there is nothing to run.
-  // 'promptAudit' runs `auditPromptServer` — the SAME audit `textToImage` and
-  // `customComfy` run, host-side and before submission (see `./moderation`).
-  // 'textOutput' still has no answer and still fails at load.
-  return posture === 'none' || posture === 'promptAudit';
+  // 'promptAudit' runs `auditPromptServer` in the SUBMIT phase — the SAME audit
+  // `textToImage` and `customComfy` run, host-side and before submission.
+  // 'textOutput' runs an xGuardModeration text scan in the OUTPUT phase, at the
+  // read boundary, and withholds on a hit or on any scanner failure.
+  // Both handlers live in `./moderation`, which asserts at ITS load that each
+  // posture has a handler in exactly the phases `posturePhaseRequirements` names.
+  return posture === 'none' || posture === 'promptAudit' || posture === 'textOutput';
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -1126,6 +1218,39 @@ export function assertStepInvariants(id: string, step: AnyBlockStep): void {
     throw new Error(
       `${where}: declares auditableText() but moderationPosture '${step.moderationPosture}' ` +
         'never audits it — the text would reach the orchestrator unaudited'
+    );
+  }
+
+  // (1c) POSTURE ↔ `extractText` AGREEMENT, both directions — the OUTPUT-side
+  // twin of 1a, and the weights are the MIRROR IMAGE of 1a's, which is worth
+  // stating because the symmetry is misleading.
+  //
+  // Forward (posture requires the field, entry omits it) — 🔴 A GENUINE CONTROL
+  // here, unlike 1a's forward direction. 1a could delegate to clause 5a because
+  // 5a calls `step.auditableText!(...)` unconditionally for a `'promptAudit'`
+  // entry and dies on the missing function. Clause 8a below is written to the
+  // same shape, so this branch is likewise the NAMED error rather than the only
+  // rejection — but the read path is what makes it matter: a `'textOutput'`
+  // entry with no extractor produces NO text, so the read path would publish
+  // nothing and scan nothing, and nothing downstream would ever complain. The
+  // failure would be a silently mute capability, not an exception.
+  //
+  // Reverse (field declared under a posture that never scans it) — 🔴 A GENUINE
+  // CONTROL, same as 1a's reverse. The read path only calls `extractText` for a
+  // `'textOutput'` entry, so a `'none'` entry declaring one has an extractor
+  // that reads as generated-text coverage and is never called.
+  if (postureRequiresTextExtraction(step.moderationPosture)) {
+    if (typeof step.extractText !== 'function') {
+      throw new Error(
+        `${where}: moderationPosture '${step.moderationPosture}' requires an extractText() ` +
+          'declaration naming the generated text to scan — a posture that can be satisfied by ' +
+          'scanning nothing is not a posture'
+      );
+    }
+  } else if (step.extractText !== undefined) {
+    throw new Error(
+      `${where}: declares extractText() but moderationPosture '${step.moderationPosture}' ` +
+        'never scans it — the generated text would reach the block unscanned'
     );
   }
 
@@ -1387,6 +1512,46 @@ export function assertStepInvariants(id: string, step: AnyBlockStep): void {
         throw new Error(
           `${vWhere}: extractOutput() returned media with no url — a block would render a dead link`
         );
+      }
+    }
+
+    // (8a) THE NON-VACUITY PROBE for `extractText` — clause 8's twin on the
+    // generated-TEXT axis, and clause 5a's twin one phase later.
+    //
+    // 🔴 WHAT IT BUYS, AND WHAT IT DOES NOT. The read path publishes exactly
+    // what this returns, so an extractor that returns `[]` is not a moderation
+    // hole — nothing unscanned escapes. It is an INERT CAPABILITY: a step that
+    // charges Buzz, reaches `succeeded`, declares a text-output posture, and can
+    // never return a word to the caller, with every other invariant green. Same
+    // failure this registry already shipped once on the MEDIA axis, which is why
+    // clause 8 exists; this is that clause on the axis clause 8 cannot see.
+    //
+    // 🔴 HONEST LIMIT, identical in shape to the one the type-contract file
+    // records for clause 8: `extractText` and `canonicalOutputFor` are authored
+    // by the same person in the same file, so this is a SELF-CONSISTENT PAIR,
+    // not a contract check against the orchestrator. It catches an extractor
+    // that surfaces nothing for its own sample; it cannot catch an extractor and
+    // a sample that agree with each other while both being wrong about the real
+    // response shape. The mitigation is the same one `convert-image` uses — a
+    // generated-type assertion in `./type-contract` — and the entry that
+    // registers the first `'textOutput'` step owes one.
+    if (postureRequiresTextExtraction(step.moderationPosture)) {
+      // 1c proved this is a function; the non-null assertion is that guard's
+      // result, not an assumption.
+      const texts = step.extractText!(sampleStep);
+      if (!Array.isArray(texts) || texts.length === 0) {
+        throw new Error(
+          `${vWhere}: extractText() returned no text for canonicalOutputFor() — the step's ` +
+            'generated text would be scanned by nothing AND published to nobody'
+        );
+      }
+      for (const text of texts) {
+        if (typeof text !== 'string' || text.trim().length === 0) {
+          throw new Error(
+            `${vWhere}: extractText() returned a non-string or empty entry — the scan would be ` +
+              'handed a value it cannot read while the entry reports coverage'
+          );
+        }
       }
     }
   }

--- a/src/server/services/blocks/steps/moderation.ts
+++ b/src/server/services/blocks/steps/moderation.ts
@@ -436,14 +436,32 @@ export type ModeratedTextOutputFields = {
 /**
  * Attach a workflow's SCANNED generated text to a snapshot.
  *
- * 🔴 THIS FUNCTION IS THE SOLE PRODUCER OF `snapshot.textOutputs`, AND THAT IS
- * THE ENFORCEMENT MECHANISM — not a convention. `snapshotFromWorkflow` and
- * `projectAppWorkflow` are pure, synchronous, and structurally incapable of
- * emitting generated text: they read `extractOutput`, which returns MEDIA
- * (`{url,width,height,nsfwLevel}`) and cannot carry a string of prose. A scan is
- * an async network call, so it cannot live in either of them. The result is that
- * the only route from `step.output` to a block's `textOutputs` runs through the
- * scan below, and the withhold branch simply never writes the field.
+ * 🔴 THIS FUNCTION IS THE SOLE PRODUCER OF `snapshot.textOutputs`. BE EXACT
+ * ABOUT WHAT ENFORCES THAT — an earlier revision of this comment said
+ * `snapshotFromWorkflow` and `projectAppWorkflow` "read `extractOutput`, which
+ * returns MEDIA and cannot carry a string of prose", and that reasoning was
+ * WRONG: `StepOutputMedia.url` is a bare `string`, never URL-validated, and it
+ * reaches `snapshot.imageUrls` / `AppWorkflow.images[].url` without meeting this
+ * function. `extractOutput: () => [{ url: theModelsReply, … }]` would have
+ * published unscanned generated text with every gate green. It is recorded here
+ * rather than quietly corrected because in a code-reviewed trust root the
+ * comment IS the control.
+ *
+ * WHAT ACTUALLY HOLDS IT, all three off the one `stepOutputShape` predicate:
+ *   1. TYPE — `TextOutputSurface.extractOutput?: never`. A `'textOutput'` entry
+ *      cannot declare a media extractor.
+ *   2. LOAD — registry clause 8-ii rejects the declaration anyway, for the
+ *      `as`-cast path a type cannot close.
+ *   3. READ — both `workflow.service` extractors call `extractOutput` only when
+ *      `postureProducesMedia(entry.moderationPosture)`, so even a cast-in
+ *      extractor contributes nothing.
+ * Plus the original structural point, which does still stand on its own: a scan
+ * is an async network call and both projections are pure and synchronous, so
+ * neither could perform one even if it wanted to.
+ *
+ * The result is that the only route from `step.output` to a block's
+ * `textOutputs` runs through the scan below, and the withhold branch simply
+ * never writes the field.
  *
  * The incoming snapshot's own text fields are STRIPPED before merging, so a
  * caller that somehow arrived carrying text cannot smuggle it past the scan by

--- a/src/server/services/blocks/steps/moderation.ts
+++ b/src/server/services/blocks/steps/moderation.ts
@@ -1,12 +1,16 @@
 import { TRPCError } from '@trpc/server';
+import type { Workflow } from '@civitai/client';
 import { auditPromptServer } from '~/server/services/orchestrator/promptAuditing';
 import { throwBadRequestError } from '~/server/utils/errorHandling';
 import {
+  getStepByOrchestratorType,
   isModerationPostureImplemented,
+  posturePhaseRequirements,
   STEP_MODERATION_POSTURES,
   type AnyBlockStep,
   type StepModerationPosture,
 } from './index';
+import { screenGeneratedText, TEXT_OUTPUT_WITHHELD_MESSAGE } from './text-output-moderation';
 
 // ─────────────────────────────────────────────────────────────────────────────
 // MODERATION DISPATCH for the App Blocks step-type registry (`kind: 'step'`).
@@ -38,6 +42,34 @@ import {
 // throws a BAD_REQUEST when a prompt is actually flagged. This module adds NO
 // try/catch around it: wrapping one would turn a flagged prompt into a silent
 // pass, and matching the existing kinds exactly is the requirement.
+//
+// ─────────────────────────────────────────────────────────────────────────────
+// 🔴 TWO PHASES, AND THE TABLE IS KEYED BY THEM. READ THIS BEFORE ADDING A
+// POSTURE.
+//
+// The dispatch above runs at SUBMIT, before the orchestrator call. That is the
+// right position for `'promptAudit'` — it audits INPUT the caller already sent,
+// and a rejection there costs no orchestrator call and has nothing to refund.
+//
+// It is the WRONG position for an OUTPUT scan, and wrong in the most dangerous
+// way available: a `'textOutput'` handler placed here would run before the
+// generation exists, scan an empty string, return cleanly, and report success.
+// The registry's load-time gate would be satisfied, the posture would be
+// "implemented", every test asserting the posture is declared would pass, and
+// generated text would reach blocks completely unscanned. A feature that passes
+// every check while being inert has shipped in this codebase before.
+//
+// So the table maps each posture to a PHASE RECORD, and
+// `assertModerationHandlerTable` checks it against `posturePhaseRequirements`
+// (`./index`) in BOTH directions: a required phase with no handler fails, AND a
+// handler in a phase the posture does not require fails. The second direction is
+// the one that matters here — it makes "satisfy `'textOutput'` with a submit
+// handler" a BUILD failure rather than something a reviewer has to spot.
+//
+//   SUBMIT — `runStepModeration`, step submit path, pre-quote, pre-reservation.
+//   OUTPUT — `runStepOutputModeration`, the READ boundary, post-generation.
+//            Reached through `attachModeratedStepTextOutputs`, which is the SOLE
+//            producer of a snapshot's `textOutputs` (see that function).
 // ─────────────────────────────────────────────────────────────────────────────
 
 export type StepModerationRequest = {
@@ -68,10 +100,62 @@ export type StepModerationRequest = {
 
 type StepModerationHandler = (req: StepModerationRequest) => Promise<void>;
 
+/** One completed orchestrator step, to be screened before it is published. */
+export type StepOutputModerationRequest = {
+  /** The registry entry whose `orchestratorType` matched the step's `$type`. */
+  step: AnyBlockStep;
+  /** The orchestrator's COMPLETED step object, as returned on the workflow. */
+  orchestratorStep: unknown;
+  /** The token subject. */
+  userId: number;
+  /**
+   * 🔴 From `resolveBlockMaturity(claims).isGreen` — the token's server-minted
+   * maturity ceiling, exactly as the submit phase takes it. It selects the
+   * SFW-only tier of the label policy (`NSFW` / `Suggestive` / `Explicit`), so a
+   * request-body flag here would let a SFW-domain block license its own mature
+   * output. Never a request field.
+   */
+  isGreen: boolean;
+  /** The OauthClient id off the verified block token — the per-app trigger key. */
+  appId: string;
+  /** The block instance id, when the caller has one. */
+  appBlockId?: string;
+};
+
 /**
- * The posture → handler table. TOTAL over `StepModerationPosture`; `null` means
- * "declared, deliberately not implemented", which is a fail-closed gate rather
- * than a missing key that would read as `undefined` at runtime.
+ * The verdict for one step's generated text.
+ *
+ * 🔴 `texts` IS THE ONLY CHANNEL. The read path publishes exactly what a
+ * `released: true` verdict carries and never reads `step.output` itself, so text
+ * that did not come back through here cannot reach a block.
+ */
+export type StepOutputModerationResult =
+  | { released: true; texts: string[] }
+  | { released: false; reason: string };
+
+type StepOutputModerationHandler = (
+  req: StepOutputModerationRequest
+) => Promise<StepOutputModerationResult>;
+
+/**
+ * A posture's handlers, one slot per phase. `null` means "this posture has no
+ * moderation surface in this phase" — which `assertModerationHandlerTable`
+ * cross-checks against `posturePhaseRequirements`, so it can never quietly mean
+ * "nobody got round to it".
+ */
+type StepModerationPhases = {
+  submit: StepModerationHandler | null;
+  output: StepOutputModerationHandler | null;
+};
+
+/**
+ * The posture → phase-handler table. TOTAL over `StepModerationPosture`.
+ *
+ * A phase slot of `null` means "no surface in this phase", NOT "unimplemented":
+ * `assertModerationHandlerTable` pins every slot against the phases the posture
+ * is declared to require, in both directions, so the two readings cannot be
+ * confused. A posture whose REQUIRED phase is `null` is what makes it
+ * unimplemented, and that is a load-time failure.
  *
  * 🔴 NULL PROTOTYPE, AND THAT IS A CONTROL RATHER THAN A STYLE CHOICE. A plain
  * object literal inherits from `Object.prototype`, so indexing it with an
@@ -97,21 +181,26 @@ type StepModerationHandler = (req: StepModerationRequest) => Promise<void>;
  * annotation alone does not reject it (it also costs the handlers their
  * contextual typing — 5×`TS7031`).
  */
-const moderationPostureHandlers: Record<StepModerationPosture, StepModerationHandler | null> =
-  Object.assign(
-    Object.create(null) as Record<StepModerationPosture, StepModerationHandler | null>,
-    {
-      // Nothing to run, by construction: no free-text input, no free-text output.
-      none: async () => {
-        /* no surface */
-      },
+const moderationPostureHandlers: Record<StepModerationPosture, StepModerationPhases> =
+  Object.assign(Object.create(null) as Record<StepModerationPosture, StepModerationPhases>, {
+    // Nothing to run in EITHER phase, by construction: no free-text input, no
+    // free-text output. Both `null`s are load-asserted against
+    // `posturePhaseRequirements('none')`, so this is a stated absence of
+    // surface rather than an unwritten handler.
+    none: { submit: null, output: null },
 
-      /**
-       * The posture `textToImage` and `customComfy` already implement inline. Same
-       * function, same two text fields, same `isGreen` source, same fail-closed
-       * throw — declared by a step instead of hardcoded in a router branch.
-       */
-      promptAudit: async ({ step, params, userId, isGreen, loadIsModerator }) => {
+    /**
+     * The posture `textToImage` and `customComfy` already implement inline. Same
+     * function, same two text fields, same `isGreen` source, same fail-closed
+     * throw — declared by a step instead of hardcoded in a router branch.
+     *
+     * OUTPUT phase is `null`: this posture covers INPUT. A `'promptAudit'`
+     * step's result is media, and media is rated by the orchestrator's own
+     * blob `nsfwLevel` on the existing extraction path — not this scan.
+     */
+    promptAudit: {
+      output: null,
+      submit: async ({ step, params, userId, isGreen, loadIsModerator }) => {
         const text = step.auditableText?.(params);
 
         // 🔴 FAIL CLOSED ON "NOTHING TO AUDIT", per request.
@@ -161,12 +250,44 @@ const moderationPostureHandlers: Record<StepModerationPosture, StepModerationHan
           isModerator: await loadIsModerator(),
         });
       },
+    },
 
-      // Free-text OUTPUT. Generated text is scanned by nothing on any current path,
-      // and answering that is a content-policy decision, not a code one.
-      textOutput: null,
-    } satisfies Record<StepModerationPosture, StepModerationHandler | null>
-  );
+    /**
+     * Free-text OUTPUT — scanned at the READ boundary, never at submit.
+     *
+     * SUBMIT phase is `null` and that is load-asserted, not incidental: a
+     * submit-phase handler for this posture would necessarily scan nothing
+     * (the generation has not run) while satisfying every gate.
+     */
+    textOutput: {
+      submit: null,
+      output: async ({ step, orchestratorStep, userId, isGreen, appId, appBlockId }) => {
+        const texts = step.extractText?.(orchestratorStep);
+
+        // 🔴 FAIL CLOSED ON A MISSING / UNUSABLE EXTRACTOR AT REQUEST TIME.
+        // Registry clause 1c rejects an entry with no `extractText`, and
+        // clause 8a rejects one that returns nothing for its canonical
+        // output — but both probe a CANONICAL sample, so an extractor that
+        // returns a non-array or a non-string entry for a REAL response
+        // reaches here. Withholding is the only safe answer: the alternative
+        // is to publish whatever partial value we could coerce, which is
+        // publishing text the scan never saw.
+        if (!Array.isArray(texts) || texts.some((t) => typeof t !== 'string')) {
+          return { released: false, reason: TEXT_OUTPUT_WITHHELD_MESSAGE };
+        }
+
+        return await screenGeneratedText({
+          texts,
+          userId,
+          isGreen,
+          appId,
+          appBlockId,
+          stepId: step.id,
+          model: step.orchestratorType,
+        });
+      },
+    },
+  } satisfies Record<StepModerationPosture, StepModerationPhases>);
 
 /**
  * Cross-check that the handler table agrees with `isModerationPostureImplemented`
@@ -183,16 +304,55 @@ const moderationPostureHandlers: Record<StepModerationPosture, StepModerationHan
  * only observing that the shipped one happens to pass.
  */
 export function assertModerationHandlerTable(
-  table: Record<StepModerationPosture, StepModerationHandler | null>
+  table: Record<StepModerationPosture, StepModerationPhases>
 ): void {
   for (const posture of STEP_MODERATION_POSTURES) {
-    const hasHandler = table[posture] != null;
-    if (hasHandler !== isModerationPostureImplemented(posture)) {
+    const phases = table[posture];
+    if (!phases) {
+      throw new Error(
+        `block step moderation: posture '${posture}' has no phase entry — the request path would ` +
+          'read undefined for a declared posture'
+      );
+    }
+    const required = posturePhaseRequirements(posture);
+
+    // 🔴 DIRECTION ONE: a handler in a phase the posture does not require.
+    //
+    // THIS IS THE CLAUSE THAT MAKES THE POSTURE UN-FAKEABLE, and it is the one
+    // to leave alone. `'textOutput'` requires the OUTPUT phase; the tempting
+    // shape — put the scan in the SUBMIT phase, where every other posture's
+    // handler already lives — would run before the generation exists, scan an
+    // empty string, and report success. This rejects it at module load. A
+    // handler that never runs, or runs where its subject does not yet exist,
+    // reads as coverage and is worse than an absent one.
+    for (const phase of ['submit', 'output'] as const) {
+      if (!required[phase] && phases[phase] != null) {
+        throw new Error(
+          `block step moderation: posture '${posture}' declares a ${phase}-phase handler, but its ` +
+            `moderation surface is not in that phase — a handler that runs where its subject does ` +
+            'not exist scans nothing and reports success'
+        );
+      }
+    }
+
+    // 🔴 DIRECTION TWO: the registry's load-time gate and the request path must
+    // agree on whether the posture is implemented at all. If they disagreed one
+    // way an entry would register cleanly and then have no handler at request
+    // time (a 500 on a spend path); the other way, a working posture would be
+    // unregisterable.
+    const satisfied =
+      (!required.submit || phases.submit != null) && (!required.output || phases.output != null);
+    if (satisfied !== isModerationPostureImplemented(posture)) {
+      const missing = [
+        required.submit && phases.submit == null ? 'submit' : null,
+        required.output && phases.output == null ? 'output' : null,
+      ].filter(Boolean);
       throw new Error(
         `block step moderation: posture '${posture}' is declared ` +
           `${isModerationPostureImplemented(posture) ? 'IMPLEMENTED' : 'UNIMPLEMENTED'} but its ` +
-          `handler is ${hasHandler ? 'present' : 'absent'} — the registry's load-time gate and ` +
-          'the request path would disagree'
+          `required phases are ${
+            missing.length ? `MISSING (${missing.join(', ')})` : 'all present'
+          } — the registry's load-time gate and the request path would disagree`
       );
     }
   }
@@ -209,16 +369,131 @@ assertModerationHandlerTable(moderationPostureHandlers);
  * refund.
  */
 export async function runStepModeration(req: StepModerationRequest): Promise<void> {
-  const handler = moderationPostureHandlers[req.step.moderationPosture];
-  if (!handler) {
+  const phases = moderationPostureHandlers[req.step.moderationPosture];
+  if (!phases) {
     // Defense in depth: the registry's load-time gate already rejects an entry
     // whose posture has no handler, so this is unreachable for a registered
     // step. Kept — and kept fail-closed — because this is the seam a policy
-    // mistake would arrive through.
+    // mistake would arrive through. The table's NULL PROTOTYPE is what makes an
+    // `Object.prototype` key (`'toString'`, `'constructor'`) land here as
+    // `undefined` rather than resolving to an inherited method.
     throw new TRPCError({
       code: 'INTERNAL_SERVER_ERROR',
       message: `step '${req.step.id}' declares an unimplemented moderation posture`,
     });
   }
-  await handler(req);
+  // A posture that REQUIRES the submit phase but has no handler is rejected at
+  // module load, so this branch is unreachable for a declared posture — it is
+  // the same defense-in-depth as above, one level finer, and it must throw
+  // rather than fall through to "ran nothing, allowed everything".
+  const required = posturePhaseRequirements(req.step.moderationPosture);
+  if (required.submit && !phases.submit) {
+    throw new TRPCError({
+      code: 'INTERNAL_SERVER_ERROR',
+      message: `step '${req.step.id}' declares a posture with no submit-phase handler`,
+    });
+  }
+  if (phases.submit) await phases.submit(req);
+}
+
+/**
+ * Run the declared OUTPUT-phase moderation for one completed orchestrator step.
+ *
+ * Returns a verdict; does NOT throw to reject. That asymmetry with
+ * `runStepModeration` is deliberate: a submit-time rejection is the whole
+ * response (nothing has been generated or charged), whereas at read time the
+ * caller has already paid and a poll must still return a status, a cost and any
+ * media. So a withhold is reported IN the snapshot, not as a failed request.
+ *
+ * 🔴 FAIL CLOSED ON EVERY UNKNOWN. An unregistered posture, or a posture that
+ * requires the output phase but has no handler, WITHHOLDS — it does not fall
+ * through to a release. A posture with no output surface at all (`'none'`,
+ * `'promptAudit'`) releases an EMPTY list, which publishes nothing.
+ */
+export async function runStepOutputModeration(
+  req: StepOutputModerationRequest
+): Promise<StepOutputModerationResult> {
+  const posture = req.step.moderationPosture;
+  const phases = moderationPostureHandlers[posture];
+  if (!phases) return { released: false, reason: TEXT_OUTPUT_WITHHELD_MESSAGE };
+
+  const required = posturePhaseRequirements(posture);
+  if (required.output && !phases.output) {
+    return { released: false, reason: TEXT_OUTPUT_WITHHELD_MESSAGE };
+  }
+  // No output surface declared for this posture — nothing to scan and, because
+  // the caller publishes only what comes back here, nothing to publish either.
+  if (!phases.output) return { released: true, texts: [] };
+  return await phases.output(req);
+}
+
+/** The snapshot fields this module owns. See `attachModeratedStepTextOutputs`. */
+export type ModeratedTextOutputFields = {
+  textOutputs?: string[];
+  textOutputWithheld?: { reason: string };
+};
+
+/**
+ * Attach a workflow's SCANNED generated text to a snapshot.
+ *
+ * 🔴 THIS FUNCTION IS THE SOLE PRODUCER OF `snapshot.textOutputs`, AND THAT IS
+ * THE ENFORCEMENT MECHANISM — not a convention. `snapshotFromWorkflow` and
+ * `projectAppWorkflow` are pure, synchronous, and structurally incapable of
+ * emitting generated text: they read `extractOutput`, which returns MEDIA
+ * (`{url,width,height,nsfwLevel}`) and cannot carry a string of prose. A scan is
+ * an async network call, so it cannot live in either of them. The result is that
+ * the only route from `step.output` to a block's `textOutputs` runs through the
+ * scan below, and the withhold branch simply never writes the field.
+ *
+ * The incoming snapshot's own text fields are STRIPPED before merging, so a
+ * caller that somehow arrived carrying text cannot smuggle it past the scan by
+ * pre-populating them. That is cheap, and it is what turns "nothing else sets
+ * this field today" into "nothing else CAN".
+ *
+ * 🔴 PER-STEP, NOT ALL-OR-NOTHING. A workflow with two text steps where one
+ * trips the policy publishes the clean one and marks the other withheld. Every
+ * string in `textOutputs` has passed a scan either way — that property is what
+ * matters, and suppressing clean output because a sibling failed would withhold
+ * more than the policy asks for.
+ */
+export async function attachModeratedStepTextOutputs<T extends ModeratedTextOutputFields>(
+  snapshot: T,
+  workflow: Workflow,
+  ctx: { userId: number; isGreen: boolean; appId: string; appBlockId?: string }
+): Promise<T> {
+  const {
+    textOutputs: _ignoredIncomingTexts,
+    textOutputWithheld: _ignoredIncomingWithheld,
+    ...rest
+  } = snapshot;
+
+  const released: string[] = [];
+  let withheldReason: string | undefined;
+
+  for (const step of workflow.steps ?? []) {
+    // Only REGISTERED step types have a declared posture. Everything else —
+    // textToImage, customComfy, comfy, imageGen — is media-only on this bridge
+    // and has no text surface to publish, so there is nothing here to withhold.
+    const entry = getStepByOrchestratorType(step.$type);
+    if (!entry) continue;
+    // 🔴 NO PER-POSTURE BRANCH HERE. The dispatch owns that table; this loop
+    // calls it for every registered step and reads the verdict. A `'none'`
+    // entry costs one function call and no IO.
+    const verdict = await runStepOutputModeration({
+      step: entry,
+      orchestratorStep: step,
+      userId: ctx.userId,
+      isGreen: ctx.isGreen,
+      appId: ctx.appId,
+      appBlockId: ctx.appBlockId,
+    });
+    if (verdict.released) released.push(...verdict.texts);
+    else withheldReason ??= verdict.reason;
+  }
+
+  return {
+    ...(rest as T),
+    ...(released.length > 0 ? { textOutputs: released } : {}),
+    ...(withheldReason ? { textOutputWithheld: { reason: withheldReason } } : {}),
+  };
 }

--- a/src/server/services/blocks/steps/output.ts
+++ b/src/server/services/blocks/steps/output.ts
@@ -23,6 +23,14 @@
  * projection's job and stays in exactly one place
  * (`nsfwLevelFromContentRating`) — a registry entry must not be able to invent
  * its own mapping.
+ *
+ * 🔴 `url` IS A BARE STRING AND NOTHING VALIDATES IT AS A URL. It reaches
+ * `snapshot.imageUrls` and `AppWorkflow.images[].url` unfiltered, and NEITHER of
+ * those passes through `attachModeratedStepTextOutputs` — so anything an entry
+ * puts here is published unscanned. That is why the registry forbids a
+ * text-posture entry from declaring `extractOutput` at all
+ * (`TextOutputSurface`, registry clause 8-ii, and the posture gate on both
+ * `workflow.service` extractors) rather than trying to police the string.
  */
 export type StepOutputMedia = {
   url: string;

--- a/src/server/services/blocks/steps/text-output-moderation.ts
+++ b/src/server/services/blocks/steps/text-output-moderation.ts
@@ -161,7 +161,7 @@ export type TextOutputScanVerdict = {
   /**
    * 🔴 REQUESTED labels the scan did NOT come back with a result for. NON-EMPTY
    * FORCES A WITHHOLD, regardless of what did come back. See
-   * `assertEveryRequestedLabelEvaluated`.
+   * {@link missingRequestedLabels}.
    */
   missingLabels: string[];
 };
@@ -195,6 +195,39 @@ export type TextOutputScanVerdict = {
  *
  * Compared on the NORMALIZED key, so a casing difference between what we send
  * and what comes back is not mistaken for a drop.
+ *
+ * ─────────────────────────────────────────────────────────────────────────────
+ * 🔴 PRE-ADOPTION GATE — RUN ONE LIVE PROBE BEFORE THE FIRST `'textOutput'`
+ * ENTRY REGISTERS. Do not skip this because the tests are green, and do not
+ * weaken the guard to hedge it.
+ *
+ * THE ASSUMPTION: that the deployed scanner returns a `results[]` entry for
+ * EVERY requested label — including the ones that did NOT trigger. The whole
+ * guard rests on it, because "requested but absent from `results[]`" is read
+ * here as drift.
+ *
+ * WHY IT IS NOT YET EVIDENCE: the only thing that currently exhibits the shape
+ * is this file's own test fixture, which builds `results[]` by mapping over
+ * `TEXT_OUTPUT_SCAN_LABELS` — i.e. the fake encodes the same assumption the code
+ * does, so the suite cannot disagree with it. That is a both-wrong-blind pair,
+ * not a verification.
+ *
+ * WHAT HAPPENS IF THE ASSUMPTION IS WRONG: if the scanner returns only
+ * TRIGGERED labels, then every clean scan comes back with an empty (or partial)
+ * `results[]`, every clean scan reads as total drift, and the first adopting
+ * entry withholds 100% of its output. That is loud, safe and fail-closed — but
+ * it is a day-one capability outage, and it will present as "the feature does
+ * not work" rather than as a scanner problem.
+ *
+ * THE PROBE (one call, before registering an entry): submit a text scan through
+ * `createXGuardModerationRequest` with `labels: [...TEXT_OUTPUT_SCAN_LABELS]`
+ * over benign content that triggers NOTHING, and read the returned step's
+ * `output.results`. Expect 15 entries with `triggered: false`. If instead it
+ * comes back empty or short, the drift guard needs a different signal for
+ * "evaluated" — the fix is to find one the scanner actually emits, NOT to
+ * loosen the withhold. The posture is dormant until then, which is why this is a
+ * gate note rather than a defect.
+ * ─────────────────────────────────────────────────────────────────────────────
  */
 export function missingRequestedLabels(
   output: XGuardScanOutputLike | null | undefined,
@@ -351,7 +384,14 @@ export const MAX_SCANNED_CONTENT_CHARS = 50_000;
  * SAME text is rescanned tens of times per generation.
  */
 const VERDICT_CACHE_TTL_MS = 5 * 60_000;
-const VERDICT_CACHE_MAX_ENTRIES = 1_000;
+/**
+ * The memory ceiling on the memo, in entries.
+ *
+ * EXPORTED ONLY so the eviction bound can be pinned by a test. It was
+ * unpinned — raising it (or collapsing it to 1, which disables the memo
+ * entirely) changed nothing any test could see.
+ */
+export const VERDICT_CACHE_MAX_ENTRIES = 1_000;
 
 export type TextOutputScreenResult =
   | { released: true; texts: string[] }
@@ -435,10 +475,31 @@ export async function screenGeneratedText(opts: {
   //     and including them would defeat the memo across the poll loop of a
   //     multi-tab viewer for no safety gain. Nothing leaks: a hit requires
   //     presenting the identical content, which the caller already holds.
-  // Only DECIDED verdicts are stored — never an error, timeout or missing
-  // output. Caching those would be fail-closed but would also pin a withhold
-  // through a scanner recovery, turning a blip into a five-minute outage of the
-  // capability.
+  // Only CONTENT verdicts are stored — never an error, timeout, missing output
+  // or label drift. Caching those would be fail-closed but would also pin a
+  // withhold through a recovery, turning a blip into a five-minute outage of the
+  // capability. (The drift case is the one that was inconsistent until the
+  // ordering fix below; see the `stage: 'label-drift'` branch.)
+  //
+  // 🔴 KNOWN COST OF THE KEY, RECORDED RATHER THAN LEFT FOR SOMEONE TO
+  // DISCOVER: dropping `appId` also drops PER-APP TELEMETRY on a hit. A hit logs
+  // NOTHING, so if a second app presents byte-identical withheld content within
+  // the TTL, on the same pod, its withhold produces no `stage: 'withheld'` line
+  // — and per-app trigger RATE is the signal this posture's design names as the
+  // one that matters. The blindness is real; it is accepted here because the
+  // obvious fix is worse, not because it is small:
+  //   - Logging on EVERY hit would make the emitted rate a function of the poll
+  //     CADENCE, which untrusted block code chooses. A skew an attacker sets is
+  //     worse for a rate signal than an undercount.
+  //   - Undercounting is bounded and one-directional: the first observation of
+  //     any distinct content always logs, so an app whose outputs trigger at all
+  //     still shows up; only the DUPLICATE of another app's identical text is
+  //     lost, and only within one pod's 5-minute window.
+  // If cross-app attribution ever has to be exact, the shape of the fix is to
+  // store `appId` (plus the labels/scores) in the entry as a PAYLOAD — never in
+  // the key — and log on a hit only when the stored `appId` differs. That keeps
+  // the memo intact and the poll loop silent. Not built today: no `'textOutput'`
+  // entry is registered yet, so the rate has no data to be wrong about.
   const cacheKey = verdictCacheKey(content, opts.isGreen);
   const cached = readCachedVerdict(cacheKey);
   if (cached !== undefined) {
@@ -496,17 +557,40 @@ export async function screenGeneratedText(opts: {
     // drift from the request.
     requestedLabels: TEXT_OUTPUT_SCAN_LABELS,
   });
-  writeCachedVerdict(cacheKey, verdict.released);
-  if (verdict.released) return { released: true, texts };
 
-  // 🔴 LABEL DRIFT GETS ITS OWN STAGE. A withhold caused by "we asked for a
-  // label the scanner never answered on" is an OPERATIONAL fault in this file's
-  // own constant, not a content hit — the two need different responses and must
-  // not be aggregated together in the trigger rates.
+  // 🔴 LABEL DRIFT GETS ITS OWN STAGE, AND IS DELIBERATELY *NOT* MEMOIZED —
+  // CHECKED BEFORE `writeCachedVerdict`, NOT AFTER. A withhold caused by "we
+  // asked for a label the scanner never answered on" is an OPERATIONAL fault in
+  // this file's own constant, not a content hit; the two need different
+  // responses and must not be aggregated together in the trigger rates.
+  //
+  // 🔴 THE CALL, AND WHY. An earlier revision wrote the cache BEFORE this
+  // branch, so a drift withhold WAS memoized for 5 minutes while a scanner
+  // error was not — two members of the same category treated differently, on no
+  // stated reasoning, and pinned by no test. Drift is now treated exactly like
+  // an error, for the identical reason given at the memo below: caching a
+  // withhold that an OPERATIONAL fix can clear pins it through the recovery,
+  // turning a blip into a five-minute outage of the capability. Drift is
+  // recoverable in precisely that way — a mid-deploy scanner fleet answering on
+  // some instances and not others, or an orchestrator-side label config being
+  // put back, clears on the very next call, and a memoized withhold would
+  // survive it. The cost of not caching is the same cost the error path already
+  // accepts (a rescan per poll while the fault lasts), bounded by
+  // `MAX_SCANNED_CONTENT_CHARS`.
+  //
+  // Second-order, and the reason this ordering is load-bearing rather than
+  // tidy: a memo HIT logs nothing at all, so caching drift would emit the
+  // `stage: 'label-drift'` line for the FIRST observation only and then go
+  // silent — which is exactly the "diagnosable in one query" property the drift
+  // guard's own comment claims. Not caching keeps one line per observation.
   if (verdict.missingLabels.length > 0) {
     logScan({ ...opts, stage: 'label-drift', missingLabels: verdict.missingLabels });
     return { released: false, reason: TEXT_OUTPUT_WITHHELD_MESSAGE };
   }
+
+  // Only a CONTENT verdict — a release, or a policy-label withhold — is stored.
+  writeCachedVerdict(cacheKey, verdict.released);
+  if (verdict.released) return { released: true, texts };
 
   // 🔴 THE PER-APP TRIGGER LOG. `(userId, appBlockId, model, triggeredLabels,
   // scores)` per the approved policy, plus `appId` — the key trigger RATES are

--- a/src/server/services/blocks/steps/text-output-moderation.ts
+++ b/src/server/services/blocks/steps/text-output-moderation.ts
@@ -1,0 +1,381 @@
+import { createXGuardModerationRequest } from '~/server/services/orchestrator/orchestrator.service';
+import { logToAxiom } from '~/server/logging/client';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// THE `'textOutput'` MODERATION POLICY — scanning GENERATED text before it
+// reaches an App Block.
+//
+// 🔴 WHY THIS IS A SEPARATE PHASE FROM `runStepModeration`, AND NOT A HANDLER
+// IN ITS TABLE. `runStepModeration` runs in the step SUBMIT path
+// (`blocks.router.ts` → `submitStepWorkflow`), BEFORE the orchestrator call.
+// That position is right for `'promptAudit'`, which audits INPUT the caller
+// already sent. An OUTPUT scan placed there has nothing to look at: the
+// generation has not happened, `workflow.steps[].output` does not exist, and the
+// handler would scan an empty string, return cleanly, and report success — a
+// declared, registered, load-time-gated posture that is a NO-OP. So the posture
+// declares an OUTPUT-phase handler instead, and `./moderation`'s phase table
+// makes "satisfied by a submit handler" structurally impossible rather than a
+// thing review has to catch.
+//
+// 🔴 WHY `createXGuardModerationRequest` AND NOT `submitTextModeration`.
+// `submitTextModeration` (`~/server/services/text-moderation.service`) requires
+// `entityType` + `entityId` and drives an `EntityModeration` row. Generated
+// output has no persistent entity to key on, and that table does not exist in
+// every environment this runs in — so that path would fail at runtime here.
+// Calling the underlying request builder with `callbackUrl: null` and NO entity
+// fields skips the EM upsert, the audit write, and the contentHash dedup (which
+// is itself gated on the entity fields) in one step. Verified against the
+// function's own branches: every EM/dedup branch is `if (entityType && entityId
+// !== undefined)`-gated.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * The labels submitted on EVERY generated-output scan.
+ *
+ * ALL FIFTEEN ARE SCANNED, INCLUDING THE FIVE NOT ACTED ON. That is a
+ * deliberate, owner-approved trade: cost is ~1 unit per label per ~10k-char
+ * chunk, so the five non-acting labels add ~5 units to a ~15-unit scan, and the
+ * telemetry (which labels generated app output actually trips, per app) is worth
+ * more than the saving on a first ring. Whoever later proposes trimming this
+ * list should first read the per-label trigger rates this scan produces.
+ */
+export const TEXT_OUTPUT_SCAN_LABELS: readonly string[] = [
+  // ── acted on, host-independent ──
+  'Young',
+  'Grooming',
+  'Sex Trafficking',
+  'Exploitation',
+  'Bestiality',
+  'Extremism',
+  'Impersonating Civitai Staff',
+  // ── acted on, only when the viewer's maturity ceiling is SFW ──
+  'NSFW',
+  'Suggestive',
+  'Explicit',
+  // ── scanned for telemetry, NOT acted on ──
+  'Urine',
+  'Diaper',
+  'Scat',
+  'Menstruation',
+  'Celebrity',
+] as const;
+
+/**
+ * Labels that withhold the output REGARDLESS of the viewer's maturity ceiling.
+ * A mature-allowed (red) host does not license these.
+ */
+export const ALWAYS_WITHHOLD_LABELS: readonly string[] = [
+  'Young',
+  'Grooming',
+  'Sex Trafficking',
+  'Exploitation',
+  'Bestiality',
+  'Extremism',
+  'Impersonating Civitai Staff',
+] as const;
+
+/**
+ * Labels that withhold ONLY when the viewer's maturity ceiling is SFW.
+ *
+ * 🔴 THE SFW-NESS SOURCE IS `resolveBlockMaturity(claims).isGreen` — the block
+ * token's SERVER-MINTED `maxBrowsingLevel` ceiling, minted from the request host
+ * at issuance. It is the same source `'promptAudit'`, the txt2img path and the
+ * customComfy path already use, and it is NEVER a request-body field: a block on
+ * a SFW domain cannot opt itself into mature output by sending a flag.
+ */
+export const SFW_ONLY_WITHHOLD_LABELS: readonly string[] = [
+  'NSFW',
+  'Suggestive',
+  'Explicit',
+] as const;
+
+/**
+ * Labels scanned but deliberately NOT acted on — recorded here so the set is
+ * enumerable and the tests can assert the three sets PARTITION the scan list
+ * (no label silently drops out of the policy when someone edits one array).
+ */
+export const NOT_ACTED_ON_LABELS: readonly string[] = [
+  'Urine',
+  'Diaper',
+  'Scat',
+  'Menstruation',
+  'Celebrity',
+] as const;
+
+/**
+ * Normalize a label for comparison.
+ *
+ * 🔴 CASE-INSENSITIVE ON PURPOSE, AND THAT IS NOT TIDINESS. The label strings
+ * that come back on `triggeredLabels` / `results[].label` are orchestrator-side
+ * configuration, not a code-owned enum — the debug endpoint's own documented
+ * example passes `"labels": ["young"]` while its `labelOverrides` example writes
+ * `"label": "Young"`. An exact-match policy would therefore silently match
+ * NOTHING for a casing this side does not control, and a policy that matches
+ * nothing withholds nothing. Comparing on a normalized key removes a fail-OPEN
+ * mode whose only symptom is that everything passes.
+ */
+function normalizeLabel(label: string): string {
+  return label.trim().toLowerCase();
+}
+
+const ALWAYS_WITHHOLD_KEYS: ReadonlySet<string> = new Set(
+  ALWAYS_WITHHOLD_LABELS.map(normalizeLabel)
+);
+const SFW_ONLY_WITHHOLD_KEYS: ReadonlySet<string> = new Set(
+  SFW_ONLY_WITHHOLD_LABELS.map(normalizeLabel)
+);
+
+/** The per-label result shape this policy reads off an XGuard scan. */
+export type XGuardLabelResultLike = {
+  label?: unknown;
+  score?: unknown;
+  triggered?: unknown;
+};
+
+/** The scan output shape this policy reads. */
+export type XGuardScanOutputLike = {
+  triggeredLabels?: unknown;
+  results?: unknown;
+};
+
+/** What the policy decided about one scan. */
+export type TextOutputScanVerdict = {
+  /** True when the text may be released to the block. */
+  released: boolean;
+  /** The POLICY-ACTIONED labels that triggered. Empty on a release. */
+  withholdingLabels: string[];
+  /** Every label that triggered, actioned or not — telemetry, not policy. */
+  triggeredLabels: string[];
+  /** Per-label scores, for the trigger log. */
+  scores: Record<string, number>;
+};
+
+/**
+ * The scan → verdict decision. PURE: no IO, no throws, fully mutation-testable
+ * without an orchestrator.
+ *
+ * 🔴 IT READS `triggeredLabels` + THE PER-LABEL RESULTS, AND DELIBERATELY NOT
+ * `output.blocked`. `blocked` is true only when a label whose configured ACTION
+ * is `Block` triggers, and those action thresholds were tuned for IMAGE
+ * moderation. Measured on this very capability: text scoring **0.99 on
+ * `Explicit`** came back with `blocked: false`, because that label's action is
+ * `Scan`. Keying on `blocked` would therefore release near-certain policy
+ * violations. Each label's own `action` is ignored for the same reason — this
+ * policy decides what to do, not the orchestrator's image-tuned config.
+ *
+ * 🔴 THE TWO TRIGGER SIGNALS ARE UNIONED, NOT PICKED BETWEEN.
+ * `output.triggeredLabels` and `results[].triggered` are two views of the same
+ * fact produced by a service on the other side of a network boundary; if they
+ * ever disagree, the union withholds and the intersection releases. Union is
+ * the fail-closed direction, so union is what this does.
+ *
+ * `modelReason` is NOT read: it came back EMPTY on every probe call against the
+ * deployed scanner, so anything built on it would be built on a constant.
+ */
+export function decideTextOutputVerdict(
+  output: XGuardScanOutputLike | null | undefined,
+  opts: { isGreen: boolean }
+): TextOutputScanVerdict {
+  const triggered = new Set<string>();
+  const scores: Record<string, number> = {};
+
+  const rawTriggered = output?.triggeredLabels;
+  if (Array.isArray(rawTriggered)) {
+    for (const label of rawTriggered) {
+      if (typeof label === 'string' && label.trim().length > 0) triggered.add(label.trim());
+    }
+  }
+
+  const rawResults = output?.results;
+  if (Array.isArray(rawResults)) {
+    for (const entry of rawResults as XGuardLabelResultLike[]) {
+      if (!entry || typeof entry !== 'object') continue;
+      const label = typeof entry.label === 'string' ? entry.label.trim() : '';
+      if (label.length === 0) continue;
+      if (typeof entry.score === 'number' && Number.isFinite(entry.score)) {
+        scores[label] = entry.score;
+      }
+      if (entry.triggered === true) triggered.add(label);
+    }
+  }
+
+  const triggeredLabels = [...triggered];
+  const withholdingLabels = triggeredLabels.filter((label) => {
+    const key = normalizeLabel(label);
+    if (ALWAYS_WITHHOLD_KEYS.has(key)) return true;
+    // 🔴 The maturity-gated tier. `isGreen` true == the token's ceiling is SFW.
+    return opts.isGreen && SFW_ONLY_WITHHOLD_KEYS.has(key);
+  });
+
+  return {
+    released: withholdingLabels.length === 0,
+    withholdingLabels,
+    triggeredLabels,
+    scores,
+  };
+}
+
+/** The message a block receives in place of withheld text. */
+export const TEXT_OUTPUT_WITHHELD_MESSAGE =
+  'This response was withheld because it did not pass Civitai’s content policy.';
+
+/**
+ * How long to wait for the scan before giving up and FAILING CLOSED.
+ *
+ * The scan is inline and blocking on a read path, so this is a user-visible
+ * latency budget, not just a safety net. Measured on the deployed scanner:
+ * ~1.8s median uncached, ~370ms on a repeat (there is a content cache).
+ * `wait` is the orchestrator-side hold; `HARD_DEADLINE_MS` is this side's own
+ * ceiling, and it exists because `wait` cannot cover a hung socket — a request
+ * that never returns would hang the poll forever, not time out.
+ */
+export const SCAN_WAIT_SECONDS = 10;
+const HARD_DEADLINE_MS = 12_000;
+
+export type TextOutputScreenResult =
+  | { released: true; texts: string[] }
+  | { released: false; reason: string };
+
+/**
+ * Scan generated text and decide whether it may be released.
+ *
+ * 🔴 FAIL CLOSED. A scanner error, a timeout, a submit that returns no workflow,
+ * a workflow that returns no `xGuardModeration` output — every one of these
+ * WITHHOLDS.
+ *
+ * 🔴 THIS IS THE EXACT OPPOSITE OF `auditPromptServer`, AND THE ASYMMETRY IS
+ * DELIBERATE — DO NOT "FIX" IT FOR CONSISTENCY. `auditPromptServer` fails SOFT:
+ * it catches an `extModeration` outage internally and lets the prompt through,
+ * because the text there is something the USER AUTHORED and blocking it during a
+ * moderation-service outage would stop people working on their own content. The
+ * text here is MODEL OUTPUT nobody has seen yet. If this failed soft, a scanner
+ * outage would ship unscanned generated text to users, which is the single
+ * outcome the posture exists to prevent. The next reader WILL assume the two
+ * behave the same; they must not.
+ *
+ * 🔴 NO VIOLATION / AUTO-MUTE COUNTER IS TOUCHED, and that is the other reason
+ * `auditPromptServer` is the wrong tool here rather than merely the wrong
+ * failure mode. That function writes a `BlockedPromptEntry` and increments the
+ * user's auto-mute counter on a hit. The user did not author this text — the
+ * app's system prompt and the model did — so charging it against the user's
+ * moderation record would mute people for what an app they installed generated.
+ * The signal that matters is PER-APP, and it goes to the trigger log below: an
+ * app whose outputs trigger constantly is telling you about its system prompt.
+ */
+export async function screenGeneratedText(opts: {
+  /** The generated text pieces to scan. */
+  texts: readonly string[];
+  /** The token subject. */
+  userId: number;
+  /** 🔴 From `resolveBlockMaturity(claims).isGreen`. Never a request field. */
+  isGreen: boolean;
+  /** The OauthClient id off the verified block token — the per-app trigger key. */
+  appId: string;
+  /** The block instance, when the caller has one. */
+  appBlockId?: string;
+  /** The registry step id whose output this is. */
+  stepId: string;
+  /** The orchestrator `$type` that produced it. */
+  model: string;
+}): Promise<TextOutputScreenResult> {
+  const texts = opts.texts.filter((t) => typeof t === 'string' && t.trim().length > 0);
+
+  // Nothing was generated. There is no vacuity hazard in this direction — the
+  // caller gets an EMPTY release, so no unscanned text reaches the block. (The
+  // mirror-image case on the INPUT side is a real hazard, which is why
+  // `'promptAudit'` rejects an empty prompt instead; see `./moderation`.)
+  if (texts.length === 0) return { released: true, texts: [] };
+
+  // One scan over the joined text rather than one per piece: cost is per ~10k
+  // char chunk, so N pieces of a single reply cost the same joined as split,
+  // while a single call has one latency hit instead of N.
+  const content = texts.join('\n\n');
+
+  let output: XGuardScanOutputLike | null | undefined;
+  try {
+    output = await withHardDeadline(
+      createXGuardModerationRequest({
+        mode: 'text',
+        content,
+        userId: opts.userId,
+        labels: [...TEXT_OUTPUT_SCAN_LABELS],
+        // 🔴 `null`, not omitted. Omitting it makes the request builder default
+        // to the standard text-moderation webhook, which drives
+        // `recordXGuardScanFromWorkflow` and the scanner audit store. A
+        // generated-output scan has no persistent entity for those rows to hang
+        // off, so it takes the no-callback path.
+        callbackUrl: null,
+        wait: SCAN_WAIT_SECONDS,
+      }).then((workflow) => {
+        const steps = (workflow as { steps?: Array<Record<string, unknown>> } | undefined)?.steps;
+        const step = (steps ?? []).find((s) => s?.$type === 'xGuardModeration');
+        return (step as { output?: XGuardScanOutputLike } | undefined)?.output;
+      })
+    );
+  } catch (err) {
+    logScan({
+      ...opts,
+      stage: 'error',
+      err: err instanceof Error ? err.message : String(err),
+    });
+    return { released: false, reason: TEXT_OUTPUT_WITHHELD_MESSAGE };
+  }
+
+  // 🔴 A MISSING OUTPUT IS A WITHHOLD, NOT A PASS. `createXGuardModerationRequest`
+  // resolves to `undefined` when the submit itself failed, and resolves to a
+  // still-running workflow when `wait` elapsed before the scan finished — in
+  // both cases there is no verdict, and "no verdict" must never read as "clean".
+  if (!output) {
+    logScan({ ...opts, stage: 'no-verdict' });
+    return { released: false, reason: TEXT_OUTPUT_WITHHELD_MESSAGE };
+  }
+
+  const verdict = decideTextOutputVerdict(output, { isGreen: opts.isGreen });
+  if (verdict.released) return { released: true, texts };
+
+  // 🔴 THE PER-APP TRIGGER LOG. `(userId, appBlockId, model, triggeredLabels,
+  // scores)` per the approved policy, plus `appId` — the key trigger RATES are
+  // aggregated on. The text itself is NOT logged: it is the thing being
+  // withheld, and copying it into a log store would defeat that.
+  logScan({
+    ...opts,
+    stage: 'withheld',
+    withholdingLabels: verdict.withholdingLabels,
+    triggeredLabels: verdict.triggeredLabels,
+    scores: verdict.scores,
+  });
+  return { released: false, reason: TEXT_OUTPUT_WITHHELD_MESSAGE };
+}
+
+function logScan(fields: Record<string, unknown>): void {
+  const { texts: _texts, ...rest } = fields;
+  logToAxiom({ name: 'block-step-text-output-moderation', type: 'warning', ...rest }, 'webhooks')
+    // A telemetry failure must never turn a decided verdict into a thrown error
+    // on a read path.
+    .catch(() => null);
+}
+
+/**
+ * Reject a promise that has not settled within {@link HARD_DEADLINE_MS}.
+ *
+ * 🔴 THE TIMER IS ALWAYS CLEARED. A `setTimeout` left pending after the race
+ * settles keeps the event loop alive — under a test runner that manifests as a
+ * hung file rather than a failure, which is exactly how a race-based timeout
+ * hides its own bugs.
+ */
+async function withHardDeadline<T>(promise: Promise<T>): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_resolve, reject) => {
+        timer = setTimeout(
+          () => reject(new Error(`text-output scan exceeded ${HARD_DEADLINE_MS}ms`)),
+          HARD_DEADLINE_MS
+        );
+      }),
+    ]);
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
+  }
+}

--- a/src/server/services/blocks/steps/text-output-moderation.ts
+++ b/src/server/services/blocks/steps/text-output-moderation.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'crypto';
 import { createXGuardModerationRequest } from '~/server/services/orchestrator/orchestrator.service';
 import { logToAxiom } from '~/server/logging/client';
 
@@ -27,6 +28,15 @@ import { logToAxiom } from '~/server/logging/client';
 // is itself gated on the entity fields) in one step. Verified against the
 // function's own branches: every EM/dedup branch is `if (entityType && entityId
 // !== undefined)`-gated.
+//
+// 🔴 SKIPPING THAT DEDUP HAS A COST, AND IT IS PAID BACK HERE RATHER THAN
+// IGNORED. `attachModeratedStepTextOutputs` runs on EVERY `pollWorkflow`, at a
+// cadence untrusted block code chooses, over content whose length the model
+// chooses — so with no dedup and no cap, one generation was an unbounded number
+// of unbounded scans. Both are bounded on THIS side now:
+// `MAX_SCANNED_CONTENT_CHARS` caps a single scan (fail-CLOSED above it), and the
+// in-process verdict memo at the bottom of this file collapses the poll loop's
+// repeated scans of identical content.
 // ─────────────────────────────────────────────────────────────────────────────
 
 /**
@@ -148,7 +158,60 @@ export type TextOutputScanVerdict = {
   triggeredLabels: string[];
   /** Per-label scores, for the trigger log. */
   scores: Record<string, number>;
+  /**
+   * 🔴 REQUESTED labels the scan did NOT come back with a result for. NON-EMPTY
+   * FORCES A WITHHOLD, regardless of what did come back. See
+   * `assertEveryRequestedLabelEvaluated`.
+   */
+  missingLabels: string[];
 };
+
+/**
+ * The requested labels the scan produced NO `results[]` entry for.
+ *
+ * 🔴 THIS CLOSES A FAIL-OPEN THE GENERATED CLIENT DOCUMENTS IN SO MANY WORDS.
+ * `types.gen.d.ts` on `xGuardModeration`'s `labels` input: *"Labels not found in
+ * the defaults (or label overrides) are silently ignored."* So a renamed or
+ * mistyped entry in `TEXT_OUTPUT_SCAN_LABELS` — an orchestrator-side rename this
+ * codebase does not control, or a typo in a PR — is never evaluated, comes back
+ * absent rather than errored, produces a clean verdict, and RELEASES. There is
+ * no symptom: everything simply passes, which is the exact shape
+ * `normalizeLabel`'s own comment claims to have removed on the CASING axis and
+ * cannot remove on the RENAME axis.
+ *
+ * The only signal available is the one the scan returns: `results[]` carries one
+ * entry per label the scanner actually evaluated. If a label we asked for is not
+ * in there, we did not get the answer we asked for, and "no answer" must never
+ * read as "clean" — the same rule `screenGeneratedText` already applies to a
+ * missing scan output.
+ *
+ * 🔴 CONSEQUENCE, STATED PLAINLY BECAUSE IT IS SHARP: if the orchestrator ever
+ * stops returning per-label results for a label we request, this posture
+ * withholds EVERYTHING until someone updates the list. That is loud and
+ * fail-closed, which is the correct direction for generated model output on a
+ * trust root — and it is the opposite of the current behaviour, which is silent
+ * and fail-open. The `stage: 'label-drift'` trigger log is what makes it
+ * diagnosable in one query rather than a mystery.
+ *
+ * Compared on the NORMALIZED key, so a casing difference between what we send
+ * and what comes back is not mistaken for a drop.
+ */
+export function missingRequestedLabels(
+  output: XGuardScanOutputLike | null | undefined,
+  requestedLabels: readonly string[]
+): string[] {
+  const evaluated = new Set<string>();
+  const rawResults = output?.results;
+  if (Array.isArray(rawResults)) {
+    for (const entry of rawResults as XGuardLabelResultLike[]) {
+      if (!entry || typeof entry !== 'object') continue;
+      if (typeof entry.label === 'string' && entry.label.trim().length > 0) {
+        evaluated.add(normalizeLabel(entry.label));
+      }
+    }
+  }
+  return requestedLabels.filter((label) => !evaluated.has(normalizeLabel(label)));
+}
 
 /**
  * The scan → verdict decision. PURE: no IO, no throws, fully mutation-testable
@@ -174,7 +237,17 @@ export type TextOutputScanVerdict = {
  */
 export function decideTextOutputVerdict(
   output: XGuardScanOutputLike | null | undefined,
-  opts: { isGreen: boolean }
+  opts: {
+    isGreen: boolean;
+    /**
+     * 🔴 The labels the scan was ASKED for. REQUIRED — deliberately not
+     * defaulted to `TEXT_OUTPUT_SCAN_LABELS`, because a default is precisely how
+     * a caller ends up checking a list it did not send. Every requested label
+     * must come back in `results[]` or the verdict withholds; see
+     * `missingRequestedLabels`.
+     */
+    requestedLabels: readonly string[];
+  }
 ): TextOutputScanVerdict {
   const triggered = new Set<string>();
   const scores: Record<string, number> = {};
@@ -207,11 +280,17 @@ export function decideTextOutputVerdict(
     return opts.isGreen && SFW_ONLY_WITHHOLD_KEYS.has(key);
   });
 
+  // 🔴 A LABEL WE ASKED FOR AND DID NOT GET AN ANSWER FOR WITHHOLDS, on its own,
+  // even when nothing triggered. This is the rename/typo fail-open the generated
+  // client documents ("silently ignored"); see `missingRequestedLabels`.
+  const missingLabels = missingRequestedLabels(output, opts.requestedLabels);
+
   return {
-    released: withholdingLabels.length === 0,
+    released: withholdingLabels.length === 0 && missingLabels.length === 0,
     withholdingLabels,
     triggeredLabels,
     scores,
+    missingLabels,
   };
 }
 
@@ -231,6 +310,48 @@ export const TEXT_OUTPUT_WITHHELD_MESSAGE =
  */
 export const SCAN_WAIT_SECONDS = 10;
 const HARD_DEADLINE_MS = 12_000;
+
+/**
+ * The maximum joined content, in characters, this posture will scan.
+ *
+ * 🔴 THE COST/LATENCY THIS BOUNDS IS CALLER-CONTROLLED IN THREE DIMENSIONS AT
+ * ONCE, which is why an unbounded scan on this path was a real defect and not a
+ * tidiness note. `attachModeratedStepTextOutputs` runs on EVERY `pollWorkflow`
+ * call; the poll CADENCE is chosen by untrusted block code; and the CONTENT
+ * length is whatever the model produced. Scan cost is ~1 unit per label per
+ * ~10k-char chunk over 15 labels, so a 200k-char reply was ~300 scan units and
+ * 370ms–12s of inline latency PER POLL, indefinitely.
+ *
+ * 🔴 THE VALUE, AND WHY THIS ONE. 50,000 characters ≈ 5 chunks × 15 labels ≈ 75
+ * scan units for the worst permitted single scan. It is ~12.5k tokens of
+ * generated text — comfortably above any realistic single `chatCompletion`
+ * reply, caption or short transcription, which is the population
+ * `ACCEPTABLE_POSTURES_BY_TYPE` currently licenses — while capping the tail at a
+ * number that will not surprise anyone reading a bill. It is a policy number,
+ * not a physical limit: raise it deliberately, with the ~1-unit-per-label-per-
+ * 10k-chars arithmetic in hand.
+ *
+ * 🔴 OVER THE CAP IS A WITHHOLD, NOT A TRUNCATION AND NOT A RELEASE. Truncating
+ * would scan a prefix and publish the whole thing — the worst option available,
+ * because it reports coverage it does not have. Releasing unscanned is the one
+ * outcome this posture exists to prevent. So the cap fails CLOSED, exactly like
+ * a scanner error, and an adopter that legitimately needs more has to come back
+ * and design chunked scanning rather than discover the limit as a silent gap.
+ */
+export const MAX_SCANNED_CONTENT_CHARS = 50_000;
+
+/**
+ * How long a decided verdict stays reusable for identical content, and how many
+ * such verdicts are held.
+ *
+ * 🔴 WHY MEMOIZE AT ALL: the dedup the orchestrator's own `contentHash` would
+ * give us is DELIBERATELY bypassed on this path (no `entityType`/`entityId` — see
+ * the header note), and the poll loop re-presents byte-identical content every
+ * couple of seconds until the block stops polling. Without a host-side memo the
+ * SAME text is rescanned tens of times per generation.
+ */
+const VERDICT_CACHE_TTL_MS = 5 * 60_000;
+const VERDICT_CACHE_MAX_ENTRIES = 1_000;
 
 export type TextOutputScreenResult =
   | { released: true; texts: string[] }
@@ -291,6 +412,45 @@ export async function screenGeneratedText(opts: {
   // while a single call has one latency hit instead of N.
   const content = texts.join('\n\n');
 
+  // 🔴 THE CAP, CHECKED BEFORE THE NETWORK CALL AND FAILING CLOSED. See
+  // `MAX_SCANNED_CONTENT_CHARS` for the value and the reasoning. Placed here,
+  // ahead of the cache lookup, so an over-cap payload can never be answered from
+  // a hit either.
+  if (content.length > MAX_SCANNED_CONTENT_CHARS) {
+    logScan({
+      ...opts,
+      stage: 'over-cap',
+      contentChars: content.length,
+      capChars: MAX_SCANNED_CONTENT_CHARS,
+    });
+    return { released: false, reason: TEXT_OUTPUT_WITHHELD_MESSAGE };
+  }
+
+  // 🔴 THE PER-CONTENT MEMO. Keyed on (content, isGreen) and NOTHING ELSE, which
+  // is both correct and deliberate:
+  //   - `isGreen` IS in the key because the verdict genuinely depends on it (the
+  //     SFW-only tier). Dropping it would let a mature-allowed host's release be
+  //     served to a SFW one.
+  //   - `userId` / `appId` are NOT, because the verdict does not depend on them
+  //     and including them would defeat the memo across the poll loop of a
+  //     multi-tab viewer for no safety gain. Nothing leaks: a hit requires
+  //     presenting the identical content, which the caller already holds.
+  // Only DECIDED verdicts are stored — never an error, timeout or missing
+  // output. Caching those would be fail-closed but would also pin a withhold
+  // through a scanner recovery, turning a blip into a five-minute outage of the
+  // capability.
+  const cacheKey = verdictCacheKey(content, opts.isGreen);
+  const cached = readCachedVerdict(cacheKey);
+  if (cached !== undefined) {
+    // 🔴 The caller's OWN `texts` are returned, never a stored copy. The key is
+    // the JOINED content, so two callers can share a hit while having split
+    // their pieces differently; replaying a stored array would hand one of them
+    // the other's segmentation.
+    return cached
+      ? { released: true, texts }
+      : { released: false, reason: TEXT_OUTPUT_WITHHELD_MESSAGE };
+  }
+
   let output: XGuardScanOutputLike | null | undefined;
   try {
     output = await withHardDeadline(
@@ -330,8 +490,23 @@ export async function screenGeneratedText(opts: {
     return { released: false, reason: TEXT_OUTPUT_WITHHELD_MESSAGE };
   }
 
-  const verdict = decideTextOutputVerdict(output, { isGreen: opts.isGreen });
+  const verdict = decideTextOutputVerdict(output, {
+    isGreen: opts.isGreen,
+    // The list actually SENT above — one expression, so the check can never
+    // drift from the request.
+    requestedLabels: TEXT_OUTPUT_SCAN_LABELS,
+  });
+  writeCachedVerdict(cacheKey, verdict.released);
   if (verdict.released) return { released: true, texts };
+
+  // 🔴 LABEL DRIFT GETS ITS OWN STAGE. A withhold caused by "we asked for a
+  // label the scanner never answered on" is an OPERATIONAL fault in this file's
+  // own constant, not a content hit — the two need different responses and must
+  // not be aggregated together in the trigger rates.
+  if (verdict.missingLabels.length > 0) {
+    logScan({ ...opts, stage: 'label-drift', missingLabels: verdict.missingLabels });
+    return { released: false, reason: TEXT_OUTPUT_WITHHELD_MESSAGE };
+  }
 
   // 🔴 THE PER-APP TRIGGER LOG. `(userId, appBlockId, model, triggeredLabels,
   // scores)` per the approved policy, plus `appId` — the key trigger RATES are
@@ -345,6 +520,65 @@ export async function screenGeneratedText(opts: {
     scores: verdict.scores,
   });
   return { released: false, reason: TEXT_OUTPUT_WITHHELD_MESSAGE };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// THE VERDICT MEMO — a bounded, TTL'd, in-process map.
+//
+// 🔴 IN-PROCESS AND NOT REDIS, ON PURPOSE. What this has to collapse is a poll
+// LOOP: the same viewer, the same workflow, the same bytes, every couple of
+// seconds, served by one pod for the life of that generation. An in-process map
+// catches essentially all of that for zero new dependencies and no new failure
+// mode on a read path — a Redis outage here would have to fail-closed to be
+// safe, i.e. it would take the capability down. Cross-pod reuse is the residual,
+// and it is worth strictly less than the failure mode it would buy.
+//
+// 🔴 NOT a `cache-helpers` cache (`createCachedObject` &co), which is what the
+// `no-module-scope-cache` lint rule governs — those are Redis-backed and
+// dereference `REDIS_KEYS` at module scope. This is a plain `Map` with no IO.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** `released` per key, with the epoch-ms the entry expires at. */
+const verdictCache = new Map<string, { released: boolean; expiresAt: number }>();
+
+function verdictCacheKey(content: string, isGreen: boolean): string {
+  // 🔴 A HASH, NOT THE TEXT. Holding the full generated text in a
+  // process-lifetime map is a copy of the thing this posture may be about to
+  // WITHHOLD; the digest is enough to answer "same content?" and carries none of
+  // it back out. `sha256` (not a cheap non-cryptographic hash) because a
+  // collision here would serve one text's verdict for another's.
+  return `${isGreen ? 'g' : 'm'}:${createHash('sha256').update(content).digest('hex')}`;
+}
+
+function readCachedVerdict(key: string): boolean | undefined {
+  const hit = verdictCache.get(key);
+  if (!hit) return undefined;
+  if (hit.expiresAt <= Date.now()) {
+    verdictCache.delete(key);
+    return undefined;
+  }
+  return hit.released;
+}
+
+function writeCachedVerdict(key: string, released: boolean): void {
+  // Bounded by eviction of the OLDEST insertion — `Map` preserves insertion
+  // order, so the first key is the least recently WRITTEN. Not a true LRU, and
+  // it does not need to be: entries expire on a 5-minute TTL anyway, so the cap
+  // is a memory ceiling for a burst, not a hit-rate strategy.
+  if (verdictCache.size >= VERDICT_CACHE_MAX_ENTRIES) {
+    const oldest = verdictCache.keys().next();
+    if (!oldest.done) verdictCache.delete(oldest.value);
+  }
+  verdictCache.set(key, { released, expiresAt: Date.now() + VERDICT_CACHE_TTL_MS });
+}
+
+/**
+ * Drop every memoized verdict. TEST-ONLY seam: a module-lifetime cache would
+ * otherwise leak a verdict between test cases and make the second assertion in a
+ * pair a statement about the first one's scan.
+ */
+export function __clearTextOutputVerdictCacheForTests(): void {
+  verdictCache.clear();
 }
 
 function logScan(fields: Record<string, unknown>): void {

--- a/src/server/services/blocks/steps/type-contract.ts
+++ b/src/server/services/blocks/steps/type-contract.ts
@@ -129,14 +129,66 @@ type _RejectsUnknownResourcePolicy = Expect<
   >
 >;
 
-// ── `extractOutput` is REQUIRED ──────────────────────────────────────────────
+// ── `extractOutput` is REQUIRED on a MEDIA-posture entry ─────────────────────
 // 🔴 This is what makes "register a step" and "its result is retrievable" ONE
 // action. Without it, both `workflow.service` extractors `continue` past the new
 // `$type` and the capability is inert AFTER the caller has been charged — which
 // is exactly what shipped. If this assertion ever fails, a new entry can be
 // registered with no way to return its output.
+//
+// `CompleteStep` declares `moderationPosture: 'none'`, so this is the MEDIA
+// member of `StepOutputSurface` — the requirement is unchanged for it.
 type _RequiresExtractOutput = Expect<
   NotAssignable<Omit<CompleteStep, 'extractOutput'>, BlockStep<Params>>
+>;
+
+// ── a MEDIA entry must NOT declare `extractText` ─────────────────────────────
+// The reverse of clause 1c, at the type level: an extractor under a posture that
+// never scans reads as generated-text coverage and is never called.
+type _MediaStepRejectsExtractText = Expect<
+  NotAssignable<CompleteStep & { extractText(step: unknown): string[] }, BlockStep<Params>>
+>;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// THE `'textOutput'` OUTPUT SURFACE — media XOR text, at the type level.
+//
+// 🔴 THESE THREE ASSERTIONS ARE THE STRUCTURAL HALF OF THE ANTI-SMUGGLING FIX.
+// Before it, `extractOutput` was unconditionally required and clause 8
+// unconditionally demanded ≥1 media item with a non-empty url, so an honest
+// text-producing entry COULD NOT REGISTER — while the same entry with prose
+// stuffed into `media.url` registered cleanly and published that prose through
+// `snapshot.imageUrls` / `AppWorkflow.images[].url`, neither of which passes
+// through the output scan. `_TextStepRejectsExtractOutput` is what makes writing
+// that field impossible rather than merely detected.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** A complete, well-formed TEXT-output entry. The CONTROL for the two below. */
+type CompleteTextStep = Omit<CompleteStep, 'moderationPosture' | 'extractOutput'> & {
+  moderationPosture: 'textOutput';
+  extractText(step: unknown): string[];
+};
+
+// 🔴 THE CONTROL, and the assertion that pins "the posture is ADOPTABLE". If
+// this stops compiling, a text-producing step cannot be registered honestly
+// again and the next author reaches for the media-url workaround.
+type _TextControl = Expect<CompleteTextStep extends BlockStep<Params> ? true : false>;
+
+// ── a TEXT entry must declare `extractText` ──────────────────────────────────
+type _TextStepRequiresExtractText = Expect<
+  NotAssignable<Omit<CompleteTextStep, 'extractText'>, BlockStep<Params>>
+>;
+
+// ── 🔴 a TEXT entry must NOT declare `extractOutput` ─────────────────────────
+// `StepOutputMedia.url` is a bare string, never URL-validated, that flows to
+// `snapshot.imageUrls` and `AppWorkflow.images[].url` WITHOUT meeting
+// `attachModeratedStepTextOutputs`. A text entry able to declare a media
+// extractor could therefore publish the model's reply as a "url" with every
+// moderation gate green. If this assertion ever fails, that channel is open.
+type _TextStepRejectsExtractOutput = Expect<
+  NotAssignable<
+    CompleteTextStep & { extractOutput(step: unknown): StepOutputMedia[] },
+    BlockStep<Params>
+  >
 >;
 
 // ── `canonicalOutputFor` is REQUIRED ─────────────────────────────────────────

--- a/src/server/services/blocks/workflow.service.ts
+++ b/src/server/services/blocks/workflow.service.ts
@@ -1,7 +1,7 @@
 import { TRPCError } from '@trpc/server';
 import type { CustomComfyStepTemplate, Workflow, WorkflowStatus } from '@civitai/client';
 import type { AnyBlockRecipe, CustomComfyStepInput, ResolvedRecipeResources } from './recipes';
-import { getStepByOrchestratorType } from './steps';
+import { getStepByOrchestratorType, postureProducesMedia } from './steps';
 import type { BuzzSpendType } from '~/shared/constants/buzz.constants';
 import { dbRead } from '~/server/db/client';
 import { nsfwLevelFromContentRating } from '~/shared/constants/browsingLevel.constants';
@@ -148,8 +148,19 @@ export function snapshotFromWorkflow(
     // that used to fall through to `continue`.
     const registeredStep = getStepByOrchestratorType(step.$type);
     if (registeredStep) {
-      for (const media of registeredStep.extractOutput(step)) {
-        imageUrls.push(media.url);
+      // 🔴 POSTURE-GATED, and this is the THIRD enforcement of the one
+      // media-XOR-text rule (`stepOutputShape`), not a redundant null check. A
+      // text-posture step publishes through `attachModeratedStepTextOutputs`
+      // and ONLY through it; `StepOutputMedia.url` is a bare string that reaches
+      // this array without ever meeting the scan, so reading a media extractor
+      // off a text entry is exactly the smuggling channel the registry's
+      // clause 8-ii and `TextOutputSurface.extractOutput?: never` exist to
+      // close. Keying on the POSTURE rather than on `extractOutput != null`
+      // means this holds even if a future cast puts one there.
+      if (postureProducesMedia(registeredStep.moderationPosture)) {
+        for (const media of registeredStep.extractOutput?.(step) ?? []) {
+          imageUrls.push(media.url);
+        }
       }
       continue;
     }
@@ -288,7 +299,13 @@ export function projectAppWorkflow(workflow: Workflow): AppWorkflow {
     // additive and cannot shadow the native `$type`s below.
     const registeredStep = getStepByOrchestratorType(step.$type);
     if (registeredStep) {
-      for (const media of registeredStep.extractOutput(step)) {
+      // 🔴 Same posture gate as `snapshotFromWorkflow` — see the note there.
+      // This projection matters MORE, not less: `AppWorkflow` has no text field
+      // at all, so it is not wrapped by `attachModeratedStepTextOutputs`, and
+      // `images[].url` would be the only channel a text step could reach it
+      // through.
+      if (!postureProducesMedia(registeredStep.moderationPosture)) continue;
+      for (const media of registeredStep.extractOutput?.(step) ?? []) {
         images.push({
           url: media.url,
           width: media.width,


### PR DESCRIPTION
Implements the `'textOutput'` moderation posture for the App Blocks step-type registry, to the approved policy. Unblocks #3527 (the `chatCompletion` bridge).

**Not in this PR:** no `chatCompletion` entry is registered. That is the follow-up. This is the posture, its hook, and the registry contract it needs.

## The structural problem, and where the hook went

`runStepModeration` runs at **SUBMIT**, before the orchestrator call. That is correct for `'promptAudit'` — it audits input the caller already sent, and a rejection there costs no orchestrator call.

It is the wrong place for an output scan, in the most dangerous way available: there is no generated text yet, so a handler there would scan an empty string, return cleanly, and report success. A declared, registered, load-time-gated posture that is a **no-op**.

The other two candidates were also dead ends. `snapshotFromWorkflow` and `projectAppWorkflow` are pure and synchronous, and `extractOutput` returns **media** (`{url,width,height,nsfwLevel}`) — none of them can carry prose, and a scan is an async network call.

So the posture table is now keyed by **phase**:

- `posturePhaseRequirements(posture)` declares which phase each posture must run a handler in — `'promptAudit'` → submit, `'textOutput'` → output, `'none'` → neither.
- `assertModerationHandlerTable` checks it at module load **in both directions**: a required phase with no handler fails, **and a handler in a phase the posture does not require fails**. The second direction is the control — it makes "satisfy `'textOutput'` with a submit handler" a build error instead of something review has to notice.
- The output phase runs in `attachModeratedStepTextOutputs`, called from `blocks.pollWorkflow` and `blocks.cancelWorkflow` — the two surfaces a block reads a finished generation from.

### Why the text field cannot be set anywhere else

`snapshot.textOutputs` has exactly one producer. That is structural, not a convention: the two synchronous projections are incapable of emitting prose at all, so the only route from `step.output` to a block is through the scan. The attach function additionally **strips any incoming value of the field** before merging its own, which turns "nothing else sets this today" into "nothing else can".

Submit replies deliberately do not carry it: the step submit passes no `wait`, so the reply is a freshly-queued workflow with no output. That is also not load-bearing — a submit reply is built by `snapshotFromWorkflow`, which cannot emit the field, so an orchestrator that started answering submits with completed output would degrade to "the block polls once more", never to "unscanned text ships".

## The policy

Scan **all 15 labels** via `createXGuardModerationRequest({ mode: 'text' })`. The 5 non-acted-on labels cost ~5 units and buy per-app telemetry.

Act on ten, in two tiers:

- **Always withhold (7):** `Young`, `Grooming`, `Sex Trafficking`, `Exploitation`, `Bestiality`, `Extremism`, `Impersonating Civitai Staff`.
- **Withhold only when the viewer's ceiling is SFW (3):** `NSFW`, `Suggestive`, `Explicit`. SFW-ness comes from `resolveBlockMaturity(claims).isGreen` — the token's server-minted ceiling, the same source `'promptAudit'` and the txt2img/customComfy paths use. Never a request-body field.
- **Scanned, not acted on (5):** `Urine`, `Diaper`, `Scat`, `Menstruation`, `Celebrity`.

Reads `triggeredLabels` + the per-label results, and **never `output.blocked`** — `blocked` only flips for a `Block`-action label, and text scoring 0.99 on `Explicit` comes back `blocked: false` because that label's action is `Scan`. Label matching is case-insensitive: the strings are orchestrator-side config, not a code-owned enum, and an exact-match policy that matched nothing would withhold nothing.

Uses `createXGuardModerationRequest` directly with `callbackUrl: null` and no entity fields — not `submitTextModeration`, which requires `entityType`/`entityId` and an `EntityModeration` row.

### Fails CLOSED — and that is the opposite of the prompt audit

Scanner error, timeout, no verdict, or an unusable extractor all **withhold**. `auditPromptServer` fails *soft*. The asymmetry is deliberate and is documented where it is implemented, because the next reader will assume consistency: prompt audit fails soft so a moderation-service outage does not block work the **user authored**; an output scan must fail closed or unscanned **model** output ships.

No violation / auto-mute counter is touched — the user did not author the text, and that is exactly why `auditPromptServer` is the wrong tool here rather than merely the wrong failure mode. Trigger rates are logged **per app** instead (`userId`, `appId`, `appBlockId`, `model`, `triggeredLabels`, `scores`). The withheld text itself is never logged.

## Registry contract

New `extractText(step)` field — REQUIRED iff the posture is `'textOutput'`, FORBIDDEN otherwise (clause 1c), with a non-vacuity probe against `canonicalOutputFor` (clause 8a).

Clause 8a is the text-axis twin of clause 8, which exists because an `extractOutput` satisfiable by `() => []` already shipped once. What the extractor returns is **both** what the scan sees and what a release publishes, so an under-inclusive extractor is a missing feature rather than a silent moderation hole — the two properties move together by construction.

Honest limit, same shape as clause 8's: `extractText` and `canonicalOutputFor` are authored by the same person in the same file, so the probe is a self-consistent pair, not a contract check against the orchestrator. The entry that registers the first `'textOutput'` step owes a generated-type assertion in `type-contract.ts`, as `convert-image` has.

## Evidence

**22/22 mutations killed**, each by a test asserting *that guard's own* message. The sweep verifies every mutation was actually applied (unique pattern + byte diff — one reported APPLY-FAILED after reformatting rather than a false SURVIVED), and re-runs the baseline afterwards to prove nothing leaked. Highlights:

- Declaring `'textOutput'` as a submit-phase posture kills the suite **at module load** — the phase assert fires during import.
- The inert-handler mutation (`screenGeneratedText` always releasing) dies on the primary test's own assertion: `expected [ 'the model wrote this sentence' ] to be undefined`.
- Keying the decision on `output.blocked` kills 23 tests.

**Router-level wiring mutations** — dropping the poll call, dropping the cancel call, and hardcoding `isGreen` either way at either call site — are all killed. The cancel-side `isGreen` mutation **SURVIVED the first sweep**: each procedure passes its own `isGreen`, so the poll's both-directions test could not cover the other call site. The missing test was added and the mutation now dies. Two call sites needed two both-direction tests.

**Every withhold assertion is paired with a positive control** that changes only the scan verdict. "The text is absent" is exactly what a harness wired to nothing reports, so the absence is only evidence next to a run where the same path publishes.

There are two test layers on purpose. The service suite proves the function withholds; the **router** suite drives the real tRPC procedures and asserts the generated string is not in the payload they return — because "the guard is correct but unreachable" is the same inert shape in a different place.

**Gates:** `tsc --noEmit` clean at 8GB heap (the instrument was validated with a deliberate error first — it OOMs and prints zero errors at the default heap, which reads as a false clean). 3129 tests across 148 files green. Prettier + ESLint clean. Also gated on the **merged tree** with the concurrent step-registry branch (`resolveStepVariant` / usage dimensions), which touches three of the same files: clean merge, 0 tsc errors, 2854 tests green.

## What is not verified by execution

- **No live scan was run from this code.** The capability was probed live beforehand (cost, latency, score ranges, the `blocked: false` on a 0.99 `Explicit`) and this PR is written against those measurements, but `createXGuardModerationRequest` is mocked at the module boundary in every test here. The first end-to-end call happens when a `'textOutput'` entry is registered.
- **No registered step declares this posture yet**, so the read-path loop is dormant in production on merge. Both test suites inject a fixture entry into `getStepByOrchestratorType` — without that they would be the vacuous "it is declared" test this posture exists to avoid. Every other registry export in those suites is the real one.
- The exact label **strings** are assumed to match the orchestrator's configured names. Case is handled; a renamed label is not, and would fail open for that label. The 15-label scan's own telemetry is what would surface it.
- **Output length is unbounded.** Cost is ~1 unit per label per ~10k-char chunk, so a very long reply is a proportionally larger scan. No cap is imposed here because withholding a long *benign* reply is a product decision, not a code one — the entry that registers `chatCompletion` owns the output bound.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
