### PR TITLE
fix(user): bind setUserSetting's raw SQL values so apostrophes survive and key removal works

### DIFF
--- a/src/server/services/__tests__/set-user-setting.sql.service.test.ts
+++ b/src/server/services/__tests__/set-user-setting.sql.service.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Correctness tests for the two SQL statements `setUserSetting` emits.
+//
+// 1. The merge statement built its jsonb payload by splicing `JSON.stringify(toSet)`
+//    into a single-quoted SQL string literal. `JSON.stringify` escapes `"` and `\`
+//    but NOT `'`, so any setting value holding an apostrophe closed the literal early
+//    and the statement stopped meaning what it says. `preferredFiatCurrency`,
+//    `tosAcceptedHash`, `tosGreenAcceptedHash`, `tosRedAcceptedHash` and every
+//    `tourSettings` key are plain `z.string()` on `setUserSettingsInput`, so an
+//    apostrophe reaches here unaltered.
+//
+// 2. The key-removal statement emitted a trailing `}` (`${toRemove.join(' - ')}}`),
+//    which is not valid SQL — so that branch could never complete. It is reachable:
+//    the tRPC transformer carries an explicit `undefined` property over the wire and
+//    zod keeps the key, so `user.setSettings` can put a key on the removal list.
+//
+// Both statements are now parameterised tagged templates, so values are bound rather
+// than pasted into the statement text. These tests assert exactly that: user data must
+// appear in the bound values and never in the statement text.
+
+const { statements, mockDb } = vi.hoisted(() => {
+  const statements: { text: string; values: unknown[] }[] = [];
+  return {
+    statements,
+    mockDb: {
+      // Parameterised form. Two call shapes reach it: the tagged template
+      // (`$executeRaw`…``) arrives as `(TemplateStringsArray, ...values)`, and a
+      // pre-built `Prisma.sql` passed as an argument arrives as a `Prisma.Sql`
+      // exposing `.sql` (text with $N placeholders) and `.values`. Reduce both to
+      // the same {text, values} pair.
+      $executeRaw: vi.fn(async (first: any, ...rest: unknown[]) => {
+        if (Array.isArray(first) && Array.isArray(first.raw)) {
+          const text = first.reduce(
+            (acc: string, chunk: string, i: number) => acc + (i ? `$${i}` : '') + chunk,
+            ''
+          );
+          statements.push({ text, values: rest });
+        } else {
+          statements.push({
+            text: typeof first?.sql === 'string' ? first.sql : String(first),
+            values: Array.isArray(first?.values) ? first.values : [],
+          });
+        }
+        return 1;
+      }),
+      // Interpolating form: the whole statement arrives as one already-built string.
+      $executeRawUnsafe: vi.fn(async (text: string, ...values: unknown[]) => {
+        statements.push({ text: String(text), values });
+        return 1;
+      }),
+      $queryRaw: vi.fn(async () => []),
+    },
+  };
+});
+
+vi.mock('~/server/db/client', () => ({ dbRead: mockDb, dbWrite: mockDb }));
+// `setUserSetting` busts the user-settings cache after writing; keep Redis out of it.
+vi.mock('~/server/utils/cache-helpers', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  createCachedObject: vi.fn(() => ({
+    fetch: vi.fn(async () => ({})),
+    bust: vi.fn(async () => undefined),
+    refresh: vi.fn(async () => undefined),
+  })),
+}));
+vi.mock('~/server/services/creator-membership.service', () => ({
+  bustUserMetricPrivacyDefaultsCache: vi.fn(async () => undefined),
+}));
+// Stub the module surfaces user.service reaches at import time (mirrors the other
+// user.service unit tests).
+vi.mock('~/server/metrics', () => ({
+  articleMetrics: { queueUpdate: vi.fn() },
+  imageMetrics: { queueUpdate: vi.fn() },
+  modelMetrics: { queueUpdate: vi.fn() },
+  postMetrics: { queueUpdate: vi.fn() },
+  userMetrics: { queueUpdate: vi.fn() },
+}));
+vi.mock('~/server/services/user-preferences.service', () => ({
+  HiddenModels: { refreshCache: vi.fn(async () => undefined) },
+  HiddenModels3D: { refreshCache: vi.fn(async () => undefined) },
+  HiddenUsers: { refreshCache: vi.fn(async () => undefined) },
+  HiddenImages: { refreshCache: vi.fn(async () => undefined) },
+  HiddenTags: { refreshCache: vi.fn(async () => undefined) },
+  BlockedUsers: { refreshCache: vi.fn(async () => undefined), getCached: vi.fn(async () => []) },
+  BlockedByUsers: { refreshCache: vi.fn(async () => undefined) },
+  ImplicitHiddenImages: { refreshCache: vi.fn(async () => undefined) },
+  toggleHidden: vi.fn(async () => ({ added: [], removed: [] })),
+}));
+
+import { setUserSetting } from '~/server/services/user.service';
+
+const USER_ID = 4242;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  statements.length = 0;
+});
+
+describe('setUserSetting — the merge statement', () => {
+  it('preserves an apostrophe in a setting value', async () => {
+    // A currency label a user can legitimately store via `user.setSettings`.
+    const currency = "Côte d'Ivoire franc";
+
+    await setUserSetting(USER_ID, { preferredFiatCurrency: currency });
+
+    expect(statements).toHaveLength(1);
+    const [merge] = statements;
+
+    // The value must reach the database as a bound parameter, byte for byte.
+    expect(merge.values).toContainEqual(JSON.stringify({ preferredFiatCurrency: currency }));
+    // …and must not appear anywhere in the statement text, where an apostrophe
+    // would close the surrounding string literal.
+    expect(merge.text).not.toContain("d'Ivoire");
+    expect(merge.text).not.toContain(currency);
+  });
+
+  it('binds a value holding a quote, a backslash and a brace without altering it', async () => {
+    const hash = `a'b"c\\d}e`;
+
+    await setUserSetting(USER_ID, { tosAcceptedHash: hash });
+
+    const [merge] = statements;
+    expect(merge.values).toContainEqual(JSON.stringify({ tosAcceptedHash: hash }));
+    expect(merge.text).not.toContain(hash);
+  });
+
+  it('binds the user id rather than pasting it into the statement', async () => {
+    await setUserSetting(USER_ID, { allowAds: true });
+
+    const [merge] = statements;
+    expect(merge.values).toContainEqual(USER_ID);
+    expect(merge.text).not.toContain(String(USER_ID));
+  });
+
+  // The merge must stay a jsonb concatenation onto the existing column, so keys the
+  // caller did not send are left alone rather than replaced wholesale.
+  it('merges onto the existing settings column and sends only the given keys', async () => {
+    await setUserSetting(USER_ID, { allowAds: true });
+
+    const [merge] = statements;
+    expect(merge.text).toContain('COALESCE(settings');
+    expect(merge.text).toContain('||');
+    expect(merge.values).toContainEqual(JSON.stringify({ allowAds: true }));
+  });
+});
+
+describe('setUserSetting — the key-removal statement', () => {
+  it('removes settings keys without error', async () => {
+    await setUserSetting(USER_ID, {
+      allowAds: true,
+      // An explicit `undefined` marks a key for removal. This is what the tRPC
+      // transformer delivers for `user.setSettings`.
+      hideDonationGoals: undefined,
+      swipeGalleryCards: undefined,
+    });
+
+    // One merge for `allowAds`, then one removal for the two undefined keys.
+    expect(statements).toHaveLength(2);
+    const removal = statements[1];
+
+    // The stray brace made this statement unparseable; there must be no brace at all.
+    expect(removal.text).not.toContain('}');
+    // The key names are bound as one array, not pasted in and hand-quoted.
+    expect(removal.values).toContainEqual(['hideDonationGoals', 'swipeGalleryCards']);
+    expect(removal.text).not.toContain('hideDonationGoals');
+  });
+
+  it('binds a single removed key as an array too', async () => {
+    await setUserSetting(USER_ID, { allowAds: true, hideDonationGoals: undefined });
+
+    expect(statements).toHaveLength(2);
+    const removal = statements[1];
+    expect(removal.text).not.toContain('}');
+    expect(removal.values).toContainEqual(['hideDonationGoals']);
+  });
+
+  it('emits no removal statement when nothing is marked for removal', async () => {
+    await setUserSetting(USER_ID, { allowAds: true });
+
+    expect(statements).toHaveLength(1);
+  });
+});

--- a/src/server/services/user.service.ts
+++ b/src/server/services/user.service.ts
@@ -2623,22 +2623,28 @@ export async function setUserSetting(userId: number, settings: UserSettingsInput
   const keys = Object.keys(toSet);
   if (!keys.length) return;
 
-  await dbWrite.$executeRawUnsafe(`
+  // Parameterised: the payload is bound, not spliced into a string literal.
+  // `JSON.stringify` escapes `"` and `\` but not `'`, so a setting value holding an
+  // apostrophe used to close the literal early and corrupt the statement.
+  await dbWrite.$executeRaw`
       UPDATE "User"
-      SET settings = COALESCE(settings, '{}') || '${JSON.stringify(toSet)}'::jsonb
+      SET settings = COALESCE(settings, '{}'::jsonb) || ${JSON.stringify(toSet)}::jsonb
       WHERE id = ${userId}
-    `);
+    `;
   userUpdateCounter?.inc({ location: 'user.service:setUserSetting:set' });
 
   const toRemove = Object.entries(settings)
     .filter(([, value]) => value === undefined)
-    .map(([key]) => `'${key}'`);
+    .map(([key]) => key);
   if (toRemove.length) {
-    await dbWrite.$executeRawUnsafe(`
+    // `jsonb - text[]` drops every listed key in one go, so the key names bind as a
+    // single array. The previous form hand-quoted them into a chain of `- 'key'`
+    // and emitted a trailing `}`, which made the statement unparseable.
+    await dbWrite.$executeRaw`
       UPDATE "User"
-      SET settings = settings - ${toRemove.join(' - ')}}
+      SET settings = settings - ${toRemove}::text[]
       WHERE id = ${userId}
-    `);
+    `;
     userUpdateCounter?.inc({ location: 'user.service:setUserSetting:remove' });
   }
 


### PR DESCRIPTION
Two defects in the two SQL statements `setUserSetting` emits (`src/server/services/user.service.ts`).

### 1. A setting value containing an apostrophe corrupts the merge statement

The merge built its jsonb payload by splicing `JSON.stringify(toSet)` into a single-quoted SQL string literal:

```ts
SET settings = COALESCE(settings, '{}') || '${JSON.stringify(toSet)}'::jsonb
```

`JSON.stringify` escapes `"` and `\` but **not** `'`, so any setting value holding an apostrophe closes that literal early and the statement stops meaning what it says.

This is reachable from `user.setSettings`: `preferredFiatCurrency`, `tosAcceptedHash`, `tosGreenAcceptedHash`, `tosRedAcceptedHash` and every `tourSettings` key are plain `z.string()` on `setUserSettingsInput`, and nothing between the schema and the statement constrains or escapes them.

### 2. The key-removal statement has never worked

```ts
SET settings = settings - ${toRemove.join(' - ')}}
```

That trailing `}` is a stray brace — the emitted statement is not valid SQL, so the branch throws every time it is entered.

It *is* entered: the tRPC transformer carries an explicit `undefined` property over the wire and zod keeps the key (verified — `z.object({ allowAds: z.boolean().optional() }).parse({ allowAds: undefined })` returns an object with `allowAds` as an own property), so `user.setSettings` can put a key on the removal list.

## The fix

Both statements are now parameterised tagged templates (`$executeRaw`), so values bind rather than being pasted into the statement text. Removal uses `jsonb - text[]`, which drops every listed key in one statement and needs no hand-quoting — the same `${arr}::text[]` binding already used in `tag.service.ts` and `scanner-policies-dataset.service.ts`.

Raw SQL is kept rather than a typed Prisma `update`: Prisma can only assign a JSON column wholesale, so a typed update would mean a read-modify-write and would lose the atomic server-side merge (and `jsonb - text[]` has no typed equivalent at all).

## 🔶 Behaviour change worth a second look

**Key removal starts working.** Previously the removal branch threw *after* the merge had already been applied, so the merge committed but `userSettingsCache.bust()` and `bustUserMetricPrivacyDefaultsCache()` never ran — the write landed, the caches went stale, and the caller got a 500. With the brace gone:

- keys marked for removal are now actually deleted from `User.settings`;
- both caches are busted on that path for the first time;
- calls that used to 500 now succeed.

So a previously-dead path becomes live. It is small and clearly-intended behaviour, but it is a change, not a pure no-op.

## Tests

7 new cases in `src/server/services/__tests__/set-user-setting.sql.service.test.ts`. They mock `dbWrite` and capture the statement text and bound values, so they need no database.

**6 of the 7 fail on the pre-change code** (measured by restoring `user.service.ts` to `origin/main` with the new test file in place):

| test | pre-change | post-change |
|---|---|---|
| preserves an apostrophe in a setting value | fail | pass |
| binds a value holding a quote, a backslash and a brace without altering it | fail | pass |
| binds the user id rather than pasting it into the statement | fail | pass |
| merges onto the existing settings column and sends only the given keys | fail | pass |
| removes settings keys without error | fail | pass |
| binds a single removed key as an array too | fail | pass |
| emits no removal statement when nothing is marked for removal | pass | pass |

The last one is an invariant guard, green either way — called out rather than counted as regression coverage.

## Gate

- `pnpm typecheck` — clean.
- `eslint` on both changed files — no new problems. The one error on `user.service.ts` (`local-rules/no-module-scope-cache`, line 2561) is pre-existing and identical on unchanged `main`.
- `vitest run --project unit src/server/services/__tests__/` — **159 files, 2103 passed, 0 failed, 0 skipped**, no timeout truncation.
