### PR TITLE
docs(challenge): correct an overstated remaining-work note from #3511 (comments only)

### DIFF
--- a/src/server/prom/challenge.metrics.ts
+++ b/src/server/prom/challenge.metrics.ts
@@ -483,13 +483,25 @@ const COMPLETING_STUCK_MINUTES = 30;
  * read. Neither can strand a row in `Completing` any more, so this gauge should no longer see a
  * stampless `Completing` row from those paths.
  *
- * 🔴 It does NOT follow that the class is gone. `upsertChallenge` still writes the WHOLE metadata
+ * It does NOT follow that the whole class is gone. `upsertChallenge` still writes the WHOLE metadata
  * column from its replica snapshot (`{ ...existingMetadata, themeElements }`) — the predicate only
- * stops it landing on a DIFFERENT status, not on a same-status racing write. That is no longer a
- * wedge, but it still silently drops concurrent metadata (e.g. the `reviewedAt` watermark, which
- * rewinds incremental review to the challenge start), and a declared-key type violation still makes
- * `parseChallengeMetadata` return `{}` and wipe the column. Converting that write to the same jsonb
- * `||` merge is the remaining work.
+ * stops it landing on a DIFFERENT status, not on a same-status racing write — and a declared-key
+ * type violation still makes `parseChallengeMetadata` return `{}` and wipe the column. Converting
+ * that write to the same jsonb `||` merge would close it.
+ *
+ * That was assessed on 2026-08-03 and DELIBERATELY LEFT — the residue is not worth a second raw-SQL
+ * write inside that transaction. 🔴 The assessment corrects an earlier version of this note, which
+ * said losing the `reviewedAt` watermark "rewinds incremental review to the challenge start" as
+ * though that re-judged the backlog at LLM cost. It does not: the same WHERE clause in
+ * `daily-challenge-processing.ts` carries `notYetReviewedByJudge` (a NOT EXISTS on the judge's
+ * comment for that image), which drops every already-scored entry no matter what the watermark says.
+ * The watermark is a SCAN optimisation, not the dedupe — losing it costs a wider index scan.
+ * Probability is near zero too: the only concurrent writer of this column is that watermark, which
+ * runs every 10 minutes against the ONE current challenge, so a save of that specific challenge must
+ * straddle a 600-second-cadence instantaneous UPDATE within a sub-second window on the common
+ * (no-LLM) path. Revisit only with evidence of a real loss.
+ * (Cron expressions are spelled out in words in this block on purpose — a literal slash-star-ten
+ * would close the comment.)
  *
  * So the design is not merely the cheap direction to be wrong in — it is load-bearing. A legacy or
  * malformed stamp lands here too, and treating such rows as "not stuck" would make the gauge

--- a/src/server/services/challenge.service.ts
+++ b/src/server/services/challenge.service.ts
@@ -1432,19 +1432,31 @@ export async function upsertChallenge({
             ? (data.prizeDistribution as unknown as Prisma.InputJsonValue)
             : Prisma.JsonNull,
           judgingCategories: effectiveJudgingCategories,
-          // 🔴 REMAINING WORK: this is still a stale full-column replace. `existingMetadata` comes
-          // from the REPLICA read above, so any SAME-status write that commits between that read
-          // and this one is silently dropped — notably the `reviewedAt` watermark, whose loss
-          // rewinds incremental review to the challenge start and re-judges the whole backlog at
-          // LLM cost. The status predicate on this updateMany does NOT cover that; only converting
-          // this to the jsonb `||` merge used by backfill-theme-elements.ts does.
+          // KNOWN, MEASURED, AND DELIBERATELY NOT FIXED: this is a stale full-column replace.
+          // `existingMetadata` comes from the REPLICA read above, so a SAME-status write committing
+          // between that read and this one is dropped. The status predicate on this updateMany does
+          // not cover that; only a jsonb `||` merge (as backfill-theme-elements.ts uses) would.
           //
-          // Two branches reach here, with very different windows — do not conflate them:
-          //   - themeElements supplied by the caller (the edit form pre-fills them, so this is the
-          //     common save): NO LLM call, window is replica lag plus the request itself.
-          //   - auto-generate (theme set, no stored elements): `tryGenerateThemeElements` puts a
-          //     multi-second LLM call in the window. Rarer, but far wider.
-          // See the long note in server/prom/challenge.metrics.ts.
+          // It is not worth the second raw-SQL write inside this transaction, because both the
+          // probability and the consequence are near zero:
+          //   - The only concurrent writer of this column is the `reviewedAt` watermark in
+          //     daily-challenge-processing.ts (`*/10 * * * *`, and only for the ONE current
+          //     challenge). To lose it, a save of that specific challenge must straddle a
+          //     600-second-cadence instantaneous UPDATE. On the common path (the edit form
+          //     pre-fills themeElements, so no LLM call runs) the window is replica lag plus the
+          //     request — sub-second. The auto-generate branch's multi-second LLM window is wider
+          //     but only fires when a theme is set and no elements are stored.
+          //   - Losing it costs a WIDER SCAN, not re-judging. 🔴 An earlier version of this note
+          //     claimed it "re-judges the whole backlog at LLM cost" — that is WRONG. The same
+          //     WHERE clause carries `notYetReviewedByJudge` (a NOT EXISTS on the judge's comment
+          //     for that image), which excludes every already-scored entry regardless of the
+          //     watermark. The watermark is a scan optimisation, not the dedupe.
+          //   - The other fields are self-protecting: `reconciliation.paidUserIds` cannot cause a
+          //     double-pay (participation prizes use a deterministic
+          //     `challenge-entry-prize-{cid}-{uid}` id and the ledger dedupes), and
+          //     `completingClaimedAt` is the DIFFERENT-status case the predicate above already
+          //     closes.
+          // Revisit only with evidence of an actual loss. See server/prom/challenge.metrics.ts.
           ...(themeElements && {
             metadata: { ...existingMetadata, themeElements },
           }),


### PR DESCRIPTION
Comments only — **zero non-comment lines in the diff.**

## What was wrong

#3511 left notes (in `challenge.service.ts` and `challenge.metrics.ts`) saying its remaining work — converting `upsertChallenge`'s stale full-column metadata write to a jsonb merge — mattered because losing the `reviewedAt` watermark **"rewinds incremental review to the challenge start and re-judges the whole backlog at LLM cost"**, uncapped for paid user challenges.

That is wrong. The consuming query in `daily-challenge-processing.ts` carries, in the **same `WHERE` clause** as the watermark:

```sql
AND ci."reviewedAt" >= ${lastReviewedAt}
AND NOT EXISTS (SELECT 1 FROM "Thread" th JOIN "CommentV2" cm ON cm."threadId" = th.id
                WHERE th."imageId" = ci."imageId" AND cm."userId" = <judge>)
```

`notYetReviewedByJudge` drops every already-scored entry **regardless of the watermark**. So losing the watermark widens an index scan — it re-judges nothing and costs no LLM calls. The watermark is a scan optimisation, not the dedupe.

The probability was overstated too. The only concurrent writer of that column is that watermark, running **every 10 minutes against the one current challenge**. Losing it needs a save of that specific challenge to straddle a 600-second-cadence instantaneous `UPDATE`, inside a sub-second window on the common path (the edit form pre-fills `themeElements`, so no LLM call runs).

And the neighbouring fields are self-protecting:
- `reconciliation.paidUserIds` can't cause a double-pay — participation prizes use a deterministic `challenge-entry-prize-{cid}-{uid}` id and the ledger dedupes.
- `completingClaimedAt` is the *different*-status case, which #3511's predicate already closes.

## What this changes

The jsonb-merge conversion is now recorded as **assessed and deliberately declined**, with the reopen condition being evidence of an actual loss — rather than sitting there as pending work carrying an alarming price tag that would have justified a second raw-SQL write inside a transaction on a mod write path.

Nothing about #3511's shipped behaviour changes. The guards it added are unaffected.

## Provenance

The claim originated in an adversarial audit of #3511 and I propagated it without checking the consuming query — into the PR body, a public PR comment, and both code comments. The audit did verify that the watermark falls back to challenge start and that the predicate uses it; neither of us checked that the same clause independently dedupes. Correcting it here rather than quietly dropping it, since the note is what a future reader would size the work from.

## Gotcha hit while writing this

A literal cron `*/10 * * * *` inside a `/** … */` block comment **closes the comment** at the `*/`. That broke parsing and took 37 test files down before I caught it. The metrics-file note now spells the cadence out in words and says why. Line comments (`//`) are unaffected, so the `challenge.service.ts` note keeps the literal.

## Verification

- `vitest --project unit challenge` → **648/648** (71 files)
- `eslint` clean on both files
- `prettier` clean on `challenge.metrics.ts`; `challenge.service.ts` is unformatted on `main` and its hunk count is **unchanged at 6**
- `tsc --noEmit` **fully clean** (the `ModelVersionUpsertForm` baseline error that was red during #3511 has since been fixed on `main`)
