### PR TITLE
fix(app-blocks): scope-annotate `getMyAppAnalytics` so the CLI login token can read its own analytics

### DIFF
--- a/src/server/routers/__tests__/blocks.router.getMyAppAnalytics.test.ts
+++ b/src/server/routers/__tests__/blocks.router.getMyAppAnalytics.test.ts
@@ -208,7 +208,8 @@ describe('getMyAppAnalytics — gate', () => {
   });
 
   it('flag OFF (even for a moderator): returns zeroed analytics + runs NO aggregate', async () => {
-    // moderatorProcedure passes (mod), but the appBlocks flag is OFF →
+    // appDeveloperProcedure passes (fakePerUserFlag keys the author capability off
+    // isModerator, hence the "moderator" test names), but the appBlocks flag is OFF →
     // enforceAppBlocksFlag marks _appBlocksDisabled on the query ctx → the proc
     // short-circuits to the empty shape and never touches the aggregate service.
     mockIsAppBlocksEnabled.mockResolvedValue(false);
@@ -338,17 +339,19 @@ describe('getMyRevenue — dark-flag short-circuit', () => {
  * scope for this action", enforce-token-scope.ts:84) — the exact 403 this change
  * fixes.
  *
- * Everything else in this describe block stays GREEN on pre-change code: the three
- * BEHAVIOURAL cases below plus the enum-only bitmask sanity test, i.e. FOUR green
- * tests, only one of which is regression coverage. They are INVARIANT guards, not
- * regression guards:
+ * EVERY other test in this describe block stays GREEN on pre-change code — currently
+ * the three behavioural cases below, the enum-only bitmask sanity test, and the
+ * schema-cap test at the end. Count them at the source rather than trusting a number
+ * written here; a previous revision of this comment said "four" and was made stale by
+ * a later round appending a fifth. Exactly ONE test in this block is regression
+ * coverage. The rest are INVARIANT guards:
  *   - NO_SUBMIT was already FORBIDDEN before, because an un-annotated proc implicitly
  *     requires `Full` and that token lacks Full too. It pins that narrowing the gate
  *     did not accidentally WIDEN it — a different property, worth keeping, but it
  *     would not have caught the original bug.
  *   - the Full-key and session cases pin no-regression, and passed before by
  *     construction.
- * Do not read four green tests here as four tests of the fix.
+ * Do not read a block of green tests here as a block of tests OF THE FIX.
  */
 const FULL = 33554431; // TokenScope.Full — a Full personal API key
 const CLI = 1 | (1 << 25) | (1 << 26); // UserRead|AppBlocksSubmit|AppBlocksDevTunnel = 100663297
@@ -412,12 +415,25 @@ describe('getMyAppAnalytics — OAuth scope gate', () => {
    * enforceTokenScope's bypass is exact equality (`ctx.tokenScope !== TokenScope.Full`),
    * NOT `hasFlag`. So a mask that is a strict SUPERSET of Full but lacks bit 25 —
    * `Full|AppBlocksDevTunnel` = 100663295 — satisfied the un-annotated gate before and
-   * is FORBIDDEN after. That is a real allow→deny flip, harmless only because no such
-   * credential can be created. The caps that make it unreachable are pinned here: if
-   * either is raised, the flip becomes reachable and every `requiredScope` in this
-   * router needs re-examining.
+   * is FORBIDDEN after. A real allow→deny flip.
+   *
+   * 🔴 SCOPE OF THIS TEST — it does NOT prove the flip is globally unreachable, and an
+   * earlier revision of this comment wrongly implied it did. It pins the two PUBLIC
+   * (zod-validated) surfaces only:
+   *   - a personal API key's `tokenScope`, and
+   *   - an OAuth client's `allowedScopes` via tRPC create/update.
+   * It does NOT and cannot cover: OAuth ACCESS tokens (the hub bounds a requested scope
+   * against `ALL_SCOPES`, not Full — deliberately, so an opt-in bit is not dropped, so a
+   * token's real ceiling is its client's allowedScopes), or `allowedScopes` written by
+   * RAW SQL MIGRATION, which is exactly how the one client exceeding Full got its value
+   * (civitai-cli, 100663297 — not a superset of Full, since it carries bit 0 and none of
+   * 1..24, which is why the flip is unreachable in practice).
+   *
+   * So: if either cap below is raised, this test goes red. If a MIGRATION grants some
+   * client `Full | <opt-in bit>`, nothing here will notice — that case is held only by
+   * inspection.
    */
-  it('no creatable credential can hold a superset-of-Full mask (the flip is unreachable)', async () => {
+  it('the two zod-validated credential surfaces reject a superset-of-Full mask', async () => {
     const { addApiKeyInputSchema } = await import('~/server/schema/api-key.schema');
     const { createOauthClientSchema, updateOauthClientSchema } = await import(
       '~/server/schema/oauth-client.schema'
@@ -443,13 +459,19 @@ describe('getMyAppAnalytics — OAuth scope gate', () => {
     expect(updateOauthClientSchema.safeParse({ id: 'c', allowedScopes: SUPERSET }).success).toBe(
       false
     );
-    // Boundary: the caps still ADMIT Full itself, so they are not vacuously rejecting
-    // everything (which would make the three assertions above prove nothing).
+    // Boundary controls: each cap must still ADMIT Full, or the rejections above prove
+    // nothing (a fixture missing a required field would reject regardless of the scope,
+    // and the test would still pass with the cap removed). One per assertion above —
+    // the fixtures differ ONLY in the scope field, so a green here isolates the cap as
+    // the cause.
     expect(addApiKeyInputSchema.safeParse({ name: 'k', tokenScope: TokenScope.Full }).success).toBe(
       true
     );
     expect(
       createOauthClientSchema.safeParse({ ...clientBase, allowedScopes: TokenScope.Full }).success
+    ).toBe(true);
+    expect(
+      updateOauthClientSchema.safeParse({ id: 'c', allowedScopes: TokenScope.Full }).success
     ).toBe(true);
   });
 });

--- a/src/server/routers/__tests__/blocks.router.getMyAppAnalytics.test.ts
+++ b/src/server/routers/__tests__/blocks.router.getMyAppAnalytics.test.ts
@@ -8,8 +8,8 @@ import { TRPCError } from '@trpc/server';
  * stubbed so importing the router doesn't drag in the stale generated
  * Prisma client). The analytics SERVICE is mocked at the boundary — this
  * test asserts the ROUTER wiring:
- *   - moderatorProcedure + enforceAppBlocksFlag gate (non-mod / anon rejected,
- *     dark behind the appBlocks flag);
+ *   - appDeveloperProcedure (the `appBlocksAuthor` capability) + enforceAppBlocksFlag
+ *     gate (non-author / anon rejected, dark behind the appBlocks flag);
  *   - the caller's session user id is threaded into the service (ownership is
  *     enforced inside the service, covered by app-analytics.service.test.ts);
  *   - the zod input is validated (appBlockId length cap, from/to datetime).
@@ -336,7 +336,11 @@ describe('getMyRevenue — dark-flag short-circuit', () => {
  * `.meta` line deleted, ONLY 'CLI OAuth login token … reaches the service' goes red,
  * and it fails with this gate's own error ("Your API key does not have the required
  * scope for this action", enforce-token-scope.ts:84) — the exact 403 this change
- * fixes. The other three stay GREEN on pre-change code and are INVARIANT guards, not
+ * fixes.
+ *
+ * Everything else in this describe block stays GREEN on pre-change code: the three
+ * BEHAVIOURAL cases below plus the enum-only bitmask sanity test, i.e. FOUR green
+ * tests, only one of which is regression coverage. They are INVARIANT guards, not
  * regression guards:
  *   - NO_SUBMIT was already FORBIDDEN before, because an un-annotated proc implicitly
  *     requires `Full` and that token lacks Full too. It pins that narrowing the gate
@@ -400,5 +404,52 @@ describe('getMyAppAnalytics — OAuth scope gate', () => {
     const caller = blocksRouter.createCaller(fakeCtx(modUser) as never);
     await expect(caller.getMyAppAnalytics({ appBlockId: 'apb_1' })).resolves.toBe(SENTINEL);
     expect(mockGetMyAppAnalytics).toHaveBeenCalledTimes(1);
+  });
+
+  /**
+   * 🔴 The no-regression property is CONDITIONAL, and this is what it rests on.
+   *
+   * enforceTokenScope's bypass is exact equality (`ctx.tokenScope !== TokenScope.Full`),
+   * NOT `hasFlag`. So a mask that is a strict SUPERSET of Full but lacks bit 25 —
+   * `Full|AppBlocksDevTunnel` = 100663295 — satisfied the un-annotated gate before and
+   * is FORBIDDEN after. That is a real allow→deny flip, harmless only because no such
+   * credential can be created. The caps that make it unreachable are pinned here: if
+   * either is raised, the flip becomes reachable and every `requiredScope` in this
+   * router needs re-examining.
+   */
+  it('no creatable credential can hold a superset-of-Full mask (the flip is unreachable)', async () => {
+    const { addApiKeyInputSchema } = await import('~/server/schema/api-key.schema');
+    const { createOauthClientSchema, updateOauthClientSchema } = await import(
+      '~/server/schema/oauth-client.schema'
+    );
+
+    const SUPERSET = TokenScope.Full | TokenScope.AppBlocksDevTunnel;
+    expect(SUPERSET).toBe(100663295);
+    // Sanity: this really is the allow→deny case — it satisfies Full by hasFlag (so it
+    // passed the un-annotated gate) yet does not carry bit 25.
+    expect((SUPERSET & TokenScope.Full) === TokenScope.Full).toBe(true);
+    expect((SUPERSET & TokenScope.AppBlocksSubmit) === TokenScope.AppBlocksSubmit).toBe(false);
+
+    // A personal API key cannot be created with it...
+    expect(addApiKeyInputSchema.safeParse({ name: 'k', tokenScope: SUPERSET }).success).toBe(false);
+    // ...nor an OAuth client be granted it, on create or update.
+    const clientBase = {
+      name: 'c',
+      redirectUris: ['https://example.com/cb'],
+    };
+    expect(
+      createOauthClientSchema.safeParse({ ...clientBase, allowedScopes: SUPERSET }).success
+    ).toBe(false);
+    expect(updateOauthClientSchema.safeParse({ id: 'c', allowedScopes: SUPERSET }).success).toBe(
+      false
+    );
+    // Boundary: the caps still ADMIT Full itself, so they are not vacuously rejecting
+    // everything (which would make the three assertions above prove nothing).
+    expect(addApiKeyInputSchema.safeParse({ name: 'k', tokenScope: TokenScope.Full }).success).toBe(
+      true
+    );
+    expect(
+      createOauthClientSchema.safeParse({ ...clientBase, allowedScopes: TokenScope.Full }).success
+    ).toBe(true);
   });
 });

--- a/src/server/routers/__tests__/blocks.router.getMyAppAnalytics.test.ts
+++ b/src/server/routers/__tests__/blocks.router.getMyAppAnalytics.test.ts
@@ -208,8 +208,12 @@ describe('getMyAppAnalytics — gate', () => {
   });
 
   it('flag OFF (even for a moderator): returns zeroed analytics + runs NO aggregate', async () => {
-    // appDeveloperProcedure passes (fakePerUserFlag keys the author capability off
-    // isModerator, hence the "moderator" test names), but the appBlocks flag is OFF →
+    // Two DIFFERENT gates, both keyed off isModerator by different code — hence the
+    // "moderator" test names. appDeveloperProcedure passes because `hasAppBlocksAuthor`
+    // reads `getFeatureFlags(ctx).appBlocksAuthor`, which this file does NOT mock, so it
+    // resolves from the static `availability: ['mod']` fallback against
+    // `modUser.isModerator`. Separately `fakePerUserFlag` mocks `isAppBlocksEnabled` —
+    // the DARK flag — and here it is forced OFF →
     // enforceAppBlocksFlag marks _appBlocksDisabled on the query ctx → the proc
     // short-circuits to the empty shape and never touches the aggregate service.
     mockIsAppBlocksEnabled.mockResolvedValue(false);
@@ -336,7 +340,7 @@ describe('getMyRevenue — dark-flag short-circuit', () => {
  * 🔴 WHICH OF THESE IS ACTUAL REGRESSION COVERAGE — measured, not assumed. With the
  * `.meta` line deleted, ONLY 'CLI OAuth login token … reaches the service' goes red,
  * and it fails with this gate's own error ("Your API key does not have the required
- * scope for this action", enforce-token-scope.ts:84) — the exact 403 this change
+ * scope for this action", thrown by runEnforceTokenScope) — the exact 403 this change
  * fixes.
  *
  * EVERY other test in this describe block stays GREEN on pre-change code — currently
@@ -422,12 +426,17 @@ describe('getMyAppAnalytics — OAuth scope gate', () => {
    * (zod-validated) surfaces only:
    *   - a personal API key's `tokenScope`, and
    *   - an OAuth client's `allowedScopes` via tRPC create/update.
-   * It does NOT and cannot cover: OAuth ACCESS tokens (the hub bounds a requested scope
-   * against `ALL_SCOPES`, not Full — deliberately, so an opt-in bit is not dropped, so a
-   * token's real ceiling is its client's allowedScopes), or `allowedScopes` written by
-   * RAW SQL MIGRATION, which is exactly how the one client exceeding Full got its value
-   * (civitai-cli, 100663297 — not a superset of Full, since it carries bit 0 and none of
-   * 1..24, which is why the flip is unreachable in practice).
+   * It does NOT cover the non-zod writers, of which there are at least three — treat this
+   * list as "the ones known when this was written", not a partition:
+   *   - OAuth ACCESS tokens: the hub bounds a requested scope against `ALL_SCOPES`, not
+   *     Full (deliberately, so an opt-in bit is not dropped), so a token's real ceiling is
+   *     its client's `allowedScopes | UserRead`.
+   *   - `allowedScopes` written by RAW SQL MIGRATION — exactly how the one client
+   *     exceeding Full got its value (civitai-cli, 100663297, which is NOT a superset of
+   *     Full: bit 0 and none of 1..24, which is why the flip is unreachable in practice).
+   *   - `allowedScopes` written by publish-request.service for `appblk-*` clients. Safe
+   *     by construction (mapped bits are all below 25, and `grants: []` means no bearer
+   *     token) rather than by any cap this test can assert on.
    *
    * So: if either cap below is raised, this test goes red. If a MIGRATION grants some
    * client `Full | <opt-in bit>`, nothing here will notice — that case is held only by

--- a/src/server/routers/__tests__/blocks.router.getMyAppAnalytics.test.ts
+++ b/src/server/routers/__tests__/blocks.router.getMyAppAnalytics.test.ts
@@ -319,3 +319,86 @@ describe('getMyRevenue — dark-flag short-circuit', () => {
     expect(mockGetRecentAttributionsForOwner).not.toHaveBeenCalled();
   });
 });
+
+/**
+ * OAuth token-scope gate on getMyAppAnalytics — the proc `civitai app metrics`
+ * calls. It was UN-annotated, so `enforceTokenScope` implicitly required
+ * `TokenScope.Full`: a personal API key worked but the `civitai login` OAuth token
+ * (the CLI's default auth path) 403'd. Now
+ * `.meta({ requiredScope: TokenScope.AppBlocksSubmit })` — the same bit
+ * `GET /api/v1/blocks/submissions` requires, which the same command already calls
+ * to resolve slug → appBlockId. Mirrors app-listings.router.cli-scope.test.ts.
+ *
+ * Bitmasks are hard-coded so an enum drift trips the sanity test rather than
+ * silently re-pointing the gate.
+ *
+ * 🔴 WHICH OF THESE IS ACTUAL REGRESSION COVERAGE — measured, not assumed. With the
+ * `.meta` line deleted, ONLY 'CLI OAuth login token … reaches the service' goes red,
+ * and it fails with this gate's own error ("Your API key does not have the required
+ * scope for this action", enforce-token-scope.ts:84) — the exact 403 this change
+ * fixes. The other three stay GREEN on pre-change code and are INVARIANT guards, not
+ * regression guards:
+ *   - NO_SUBMIT was already FORBIDDEN before, because an un-annotated proc implicitly
+ *     requires `Full` and that token lacks Full too. It pins that narrowing the gate
+ *     did not accidentally WIDEN it — a different property, worth keeping, but it
+ *     would not have caught the original bug.
+ *   - the Full-key and session cases pin no-regression, and passed before by
+ *     construction.
+ * Do not read four green tests here as four tests of the fix.
+ */
+const FULL = 33554431; // TokenScope.Full — a Full personal API key
+const CLI = 1 | (1 << 25) | (1 << 26); // UserRead|AppBlocksSubmit|AppBlocksDevTunnel = 100663297
+const NO_SUBMIT = 1 | (1 << 26); // UserRead|AppBlocksDevTunnel = 67108865 — lacks AppBlocksSubmit
+
+// A token-authenticated caller (apiKeyId set) carrying `scope`. The user stays a
+// moderator so the author/flag gates are satisfied and the ONLY variable is scope.
+function tokenCtx(scope: number) {
+  return { ...fakeCtx(modUser), apiKeyId: 999, tokenScope: scope };
+}
+
+describe('getMyAppAnalytics — OAuth scope gate', () => {
+  it('the hard-coded bitmasks match the enum', () => {
+    expect(TokenScope.Full).toBe(FULL);
+    expect(TokenScope.AppBlocksSubmit).toBe(1 << 25);
+    expect(TokenScope.UserRead | TokenScope.AppBlocksSubmit | TokenScope.AppBlocksDevTunnel).toBe(
+      CLI
+    );
+    expect(TokenScope.UserRead | TokenScope.AppBlocksDevTunnel).toBe(NO_SUBMIT);
+    // Full deliberately EXCLUDES AppBlocksSubmit — so it is enforceTokenScope's
+    // early-return on Full, NOT hasFlag(Full, AppBlocksSubmit), that preserves the
+    // existing personal-API-key path. If someone ever folds bit 25 into Full, this
+    // fails and the reasoning above has to be revisited.
+    expect((TokenScope.Full & TokenScope.AppBlocksSubmit) === TokenScope.AppBlocksSubmit).toBe(
+      false
+    );
+  });
+
+  it('CLI OAuth login token (carries AppBlocksSubmit) reaches the service', async () => {
+    const caller = blocksRouter.createCaller(tokenCtx(CLI) as never);
+    await expect(caller.getMyAppAnalytics({ appBlockId: 'apb_1' })).resolves.toBe(SENTINEL);
+    expect(mockGetMyAppAnalytics).toHaveBeenCalledTimes(1);
+  });
+
+  it('Full personal API key still reaches the service (no regression)', async () => {
+    const caller = blocksRouter.createCaller(tokenCtx(FULL) as never);
+    await expect(caller.getMyAppAnalytics({ appBlockId: 'apb_1' })).resolves.toBe(SENTINEL);
+    expect(mockGetMyAppAnalytics).toHaveBeenCalledTimes(1);
+  });
+
+  it('a scoped token WITHOUT AppBlocksSubmit is FORBIDDEN and never reaches the service', async () => {
+    const caller = blocksRouter.createCaller(tokenCtx(NO_SUBMIT) as never);
+    await expect(caller.getMyAppAnalytics({ appBlockId: 'apb_1' })).rejects.toMatchObject({
+      code: 'FORBIDDEN',
+      message: expect.stringContaining('scope'),
+    });
+    // The denial must come from the SCOPE gate, before any aggregate runs — not from
+    // the author/flag gate, which this ctx satisfies.
+    expect(mockGetMyAppAnalytics).not.toHaveBeenCalled();
+  });
+
+  it('a session (no bearer token) is unaffected — the web panel path', async () => {
+    const caller = blocksRouter.createCaller(fakeCtx(modUser) as never);
+    await expect(caller.getMyAppAnalytics({ appBlockId: 'apb_1' })).resolves.toBe(SENTINEL);
+    expect(mockGetMyAppAnalytics).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/server/routers/__tests__/blocks.router.getMyForgejoCloneInfo.test.ts
+++ b/src/server/routers/__tests__/blocks.router.getMyForgejoCloneInfo.test.ts
@@ -202,3 +202,81 @@ describe('blocks.getMyForgejoCloneInfo — Phase 2 CLI pull credential', () => {
     });
   });
 });
+
+/**
+ * OAuth token-scope gate. This proc was un-annotated, so `enforceTokenScope` fell back
+ * to its default of `TokenScope.Full` and the OAuth token minted by `civitai login`
+ * (the CLI's default auth path) was rejected — so `civitai app pull` 403'd. Worse, the
+ * CLI reports that as "not permitted (are you the app owner, and is Apps enabled for
+ * your account?)", pointing the developer at an ownership problem they do not have.
+ *
+ * Annotated with `AppBlocksSubmit` — the bit that token already carries, and the same
+ * one `GET /api/v1/blocks/submissions` and `getMyAppAnalytics` use.
+ *
+ * 🔴 Only the CLI-token case is REGRESSION coverage. The Full-key case passes on
+ * pre-change code too (exact-equality early-return) and is an invariant guard; the
+ * NO_SUBMIT case was already FORBIDDEN before, because an un-annotated proc implicitly
+ * required Full and that token lacks Full as well. Bitmasks are hard-coded so an enum
+ * drift trips a test rather than silently re-pointing the gate.
+ */
+const FULL = 33554431; // TokenScope.Full — a Full personal API key
+const CLI = 1 | (1 << 25) | (1 << 26); // UserRead|AppBlocksSubmit|AppBlocksDevTunnel
+const NO_SUBMIT = 1 | (1 << 26); // UserRead|AppBlocksDevTunnel — lacks AppBlocksSubmit
+
+// A token-authenticated caller. The user stays the OWNER so the ownership check is
+// satisfied and the only variable under test is the scope.
+function tokenCtx(scope: number) {
+  return { ...fakeCtx(ownerUser), apiKeyId: 999, tokenScope: scope };
+}
+
+const APPROVED_OWNED = {
+  blockId: 'my-app',
+  status: 'approved',
+  app: { userId: ownerUser.id },
+};
+
+describe('blocks.getMyForgejoCloneInfo — OAuth scope gate', () => {
+  it('the hard-coded bitmasks match the enum', () => {
+    expect(TokenScope.Full).toBe(FULL);
+    expect(TokenScope.UserRead | TokenScope.AppBlocksSubmit | TokenScope.AppBlocksDevTunnel).toBe(
+      CLI
+    );
+    expect(TokenScope.UserRead | TokenScope.AppBlocksDevTunnel).toBe(NO_SUBMIT);
+    // Full EXCLUDES AppBlocksSubmit, so it is the early-return — not hasFlag — that
+    // preserves the personal-API-key path.
+    expect((TokenScope.Full & TokenScope.AppBlocksSubmit) === TokenScope.AppBlocksSubmit).toBe(
+      false
+    );
+  });
+
+  it('CLI OAuth login token (carries AppBlocksSubmit) reaches the proc', async () => {
+    findFirst.mockResolvedValue(APPROVED_OWNED);
+    const res = await blocksRouter
+      .createCaller(tokenCtx(CLI) as never)
+      .getMyForgejoCloneInfo({ slug: 'my-app' });
+    expect(res.notYetAvailable).toBe(false);
+    expect(mockEnsureForgejoIdentity).toHaveBeenCalledWith(7);
+  });
+
+  it('Full personal API key still reaches the proc (no regression)', async () => {
+    findFirst.mockResolvedValue(APPROVED_OWNED);
+    const res = await blocksRouter
+      .createCaller(tokenCtx(FULL) as never)
+      .getMyForgejoCloneInfo({ slug: 'my-app' });
+    expect(res.notYetAvailable).toBe(false);
+    expect(mockEnsureForgejoIdentity).toHaveBeenCalledWith(7);
+  });
+
+  it('a scoped token WITHOUT AppBlocksSubmit is FORBIDDEN and provisions nothing', async () => {
+    findFirst.mockResolvedValue(APPROVED_OWNED);
+    await expect(
+      blocksRouter
+        .createCaller(tokenCtx(NO_SUBMIT) as never)
+        .getMyForgejoCloneInfo({ slug: 'my-app' })
+    ).rejects.toMatchObject({ code: 'FORBIDDEN', message: expect.stringContaining('scope') });
+    // The denial must come from the SCOPE gate, before any Forgejo identity is minted —
+    // and this ctx IS the owner, so it cannot be the ownership check refusing.
+    expect(mockEnsureForgejoIdentity).not.toHaveBeenCalled();
+    expect(mockAddCollaborator).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -5147,6 +5147,31 @@ export const blocksRouter = router({
    * non-owned id, so an author can never read another author's metrics.
    */
   getMyAppAnalytics: appDeveloperProcedure
+    // 🔴 AppBlocksSubmit, NOT DevTunnel and NOT UserRead. With no `.meta` this proc
+    // implicitly required `TokenScope.Full` (enforceTokenScope defaults to it), so a
+    // personal API key worked but the `civitai login` OAuth token — the CLI's DEFAULT
+    // auth path — 403'd, which made `civitai app metrics` unusable for most users.
+    // Why this bit specifically:
+    //   - It is the same bit `GET /api/v1/blocks/submissions` already requires, and
+    //     `civitai app metrics <slug>` calls BOTH (submissions to resolve slug →
+    //     appBlockId, then this proc). Any other choice would leave one hop of one
+    //     command needing a scope the other does not.
+    //   - It keeps that route's established rule: the same credential that could
+    //     submit can read its own app data, and nothing weaker.
+    //   - NOT UserRead: UserRead is inside `Full`, i.e. what every third-party
+    //     "log in with Civitai" client asks for. This proc exposes install counts,
+    //     Buzz spend, endpoint names and active-user counts, so gating it on UserRead
+    //     would hand a developer's app economics to any such client. AppBlocksSubmit
+    //     is opt-in and deliberately EXCLUDED from `Full`.
+    //   - NOT AppBlocksDevTunnel: that bit means "open an on-site dev tunnel" (its
+    //     consent label is literally "Open on-site dev tunnels"). Reusing it would
+    //     force analytics readers to grant tunnel-opening, and vice versa.
+    // A Full personal API key still passes — enforceTokenScope early-returns on
+    // `ctx.tokenScope === TokenScope.Full`, and createContext defaults a session (the
+    // web /apps/revenue panel) to Full — so this is not a regression for any caller
+    // that works today. No allowedScopes migration either: the civitai-cli client is
+    // already provisioned with this bit and the login token already carries it.
+    .meta({ requiredScope: TokenScope.AppBlocksSubmit })
     .use(enforceAppBlocksFlag)
     .input(
       z.object({

--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -5104,6 +5104,13 @@ export const blocksRouter = router({
    * Auth is enforced by appDeveloperProcedure (the `appBlocksAuthor`
    * capability); no need to also assert ownership of the requested appBlockId
    * (the join filter does it).
+   *
+   * NO `.meta({ requiredScope })` — deliberate, and NOT an oversight left behind by
+   * the getMyAppAnalytics annotation below. No CLI command calls this proc (nor
+   * `getMyApps`), so it is reached only by the web panel, which is session-authed and
+   * therefore takes enforceTokenScope's Full early-return regardless. Annotate it the
+   * day something token-authed needs it — at which point AppBlocksSubmit is the
+   * consistent choice, for the reasons spelled out on getMyAppAnalytics.
    */
   getMyRevenue: appDeveloperProcedure
     .use(enforceAppBlocksFlag)
@@ -5167,10 +5174,24 @@ export const blocksRouter = router({
     //     consent label is literally "Open on-site dev tunnels"). Reusing it would
     //     force analytics readers to grant tunnel-opening, and vice versa.
     // A Full personal API key still passes — enforceTokenScope early-returns on
-    // `ctx.tokenScope === TokenScope.Full`, and createContext defaults a session (the
-    // web /apps/revenue panel) to Full — so this is not a regression for any caller
-    // that works today. No allowedScopes migration either: the civitai-cli client is
-    // already provisioned with this bit and the login token already carries it.
+    // `ctx.tokenScope === TokenScope.Full` — and createContext defaults a session (the
+    // web /apps/revenue panel) to Full.
+    //
+    // 🔴 That early return is EXACT EQUALITY, so the no-regression claim is CONDITIONAL,
+    // not universal: a mask that is a strict SUPERSET of Full but lacks bit 25 (e.g.
+    // `Full|AppBlocksDevTunnel` = 100663295) passed before and is FORBIDDEN now.
+    // No such credential can exist today, and that is enforced by schema caps rather
+    // than luck — `api-key.schema.ts` caps a personal key's tokenScope at `.max(Full)`
+    // and `oauth-client.schema.ts` caps `allowedScopes` at `.max(Full)`, so bit 25/26
+    // are unreachable through either public surface (the civitai-cli client's
+    // 100663297 comes from a migration, not the API). Those caps are pinned by a test
+    // below; if one is ever raised, re-check this gate.
+    //
+    // Scope provisioning: the civitai-cli client's allowedScopes migration sets bit 25
+    // and the login token requests it, so no NEW migration is needed here. Note the
+    // repo cannot prove prod state — those migrations are manual-apply and the device
+    // flow lives on the auth hub. If bit 25 were somehow absent in prod the failure
+    // mode is "this fix does not take effect", never "a working path breaks".
     .meta({ requiredScope: TokenScope.AppBlocksSubmit })
     .use(enforceAppBlocksFlag)
     .input(
@@ -5709,6 +5730,13 @@ export const blocksRouter = router({
    * as getMyAppRepo does (the CLI documents the token-in-URL leakage caveat).
    */
   getMyForgejoCloneInfo: protectedProcedure
+    // Same gate, same bit, same reason as getMyAppAnalytics above: un-annotated meant
+    // an implicit `TokenScope.Full`, so `civitai app pull` 403'd the OAuth login token
+    // — and the CLI reports that failure as "not permitted (are you the app owner, and
+    // is Apps enabled for your account?)", which sends the developer looking for an
+    // ownership problem they do not have. A Full personal API key is unaffected
+    // (enforceTokenScope early-returns on Full).
+    .meta({ requiredScope: TokenScope.AppBlocksSubmit })
     .use(enforceAppBlocksFlag)
     // Accept EITHER the appBlockId (ab_…) OR the slug (blockId / repo name) — the
     // CLI `civitai app pull --app <slug|appBlockId>` lets a developer pass the

--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -5740,10 +5740,19 @@ export const blocksRouter = router({
    * restricted per-user Forgejo identity (ensureForgejoIdentity) and grants it
    * read on the app's own civitai-apps/<slug> repo.
    *
-   * Distinct from getMyAppRepo only in intent (pull/sync vs push instructions);
-   * it returns the raw { forgejoUsername, token, cloneUrl } the CLI assembles
-   * its git command from. The token is embedded in the returned cloneUrl exactly
-   * as getMyAppRepo does (the CLI documents the token-in-URL leakage caveat).
+   * Close to getMyAppRepo but no longer identical to it — three differences, and the
+   * first is easy to miss now that only one of them carries a scope annotation:
+   *   - TOKEN SCOPE: this proc is `.meta({ requiredScope: AppBlocksSubmit })` (below),
+   *     because the CLI drives it. getMyAppRepo is deliberately NOT annotated — it is
+   *     web-only (AuthorViaGit / git-access.ts), so it is session-authed and takes
+   *     enforceTokenScope's Full early-return regardless.
+   *   - INTENT: pull/sync here vs push instructions there.
+   *   - COLLABORATOR PERMISSION: `read` here vs `write` there (see the note at the
+   *     addCollaborator call below).
+   * Ownership gating IS identical (owner check + bannedAt + `approved`). It returns the
+   * raw { forgejoUsername, token, cloneUrl } the CLI assembles its git command from; the
+   * token is embedded in the returned cloneUrl exactly as getMyAppRepo does (the CLI
+   * documents the token-in-URL leakage caveat).
    */
   getMyForgejoCloneInfo: protectedProcedure
     // Same SCOPE gate and same bit as getMyAppAnalytics above — but note the base

--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -5180,12 +5180,23 @@ export const blocksRouter = router({
     // 🔴 That early return is EXACT EQUALITY, so the no-regression claim is CONDITIONAL,
     // not universal: a mask that is a strict SUPERSET of Full but lacks bit 25 (e.g.
     // `Full|AppBlocksDevTunnel` = 100663295) passed before and is FORBIDDEN now.
-    // No such credential can exist today, and that is enforced by schema caps rather
-    // than luck — `api-key.schema.ts` caps a personal key's tokenScope at `.max(Full)`
-    // and `oauth-client.schema.ts` caps `allowedScopes` at `.max(Full)`, so bit 25/26
-    // are unreachable through either public surface (the civitai-cli client's
-    // 100663297 comes from a migration, not the API). Those caps are pinned by a test
-    // below; if one is ever raised, re-check this gate.
+    //
+    // The invariant that makes this unreachable is: NO issuable credential holds a
+    // superset of Full that omits bit 25. Be precise about what enforces it, because
+    // it is NOT one uniform cap:
+    //   - Personal API keys: `api-key.schema.ts` caps `tokenScope` at `.max(Full)`.
+    //   - OAuth clients via tRPC: `oauth-client.schema.ts` caps `allowedScopes` at
+    //     `.max(Full)`. Both are pinned by the test below.
+    //   - OAuth ACCESS TOKENS are NOT bounded by Full at all — the hub decodes the
+    //     requested scope against `ALL_SCOPES` on purpose (clamping to Full would drop
+    //     a legitimately-requested opt-in bit), so a token's ceiling is its client's
+    //     `allowedScopes`, not Full.
+    //   - And the one client exceeding Full (civitai-cli, 100663297) was written by a
+    //     RAW SQL migration, which no zod schema governs.
+    // 100663297 is not a superset of Full (it carries bit 0 and none of 1..24), so the
+    // flip is unreachable — but that last part rests on INSPECTION of that migration,
+    // not on a cap. If a future migration grants a client `Full | <some opt-in bit>`,
+    // this gate flips for it and no test will catch it.
     //
     // Scope provisioning: the civitai-cli client's allowedScopes migration sets bit 25
     // and the login token requests it, so no NEW migration is needed here. Note the
@@ -5730,12 +5741,34 @@ export const blocksRouter = router({
    * as getMyAppRepo does (the CLI documents the token-in-URL leakage caveat).
    */
   getMyForgejoCloneInfo: protectedProcedure
-    // Same gate, same bit, same reason as getMyAppAnalytics above: un-annotated meant
-    // an implicit `TokenScope.Full`, so `civitai app pull` 403'd the OAuth login token
-    // — and the CLI reports that failure as "not permitted (are you the app owner, and
-    // is Apps enabled for your account?)", which sends the developer looking for an
-    // ownership problem they do not have. A Full personal API key is unaffected
-    // (enforceTokenScope early-returns on Full).
+    // Same gate and same bit as getMyAppAnalytics above: un-annotated meant an implicit
+    // `TokenScope.Full`, so `civitai app pull` 403'd the OAuth login token — and the CLI
+    // reports that failure as "not permitted (are you the app owner, and is Apps enabled
+    // for your account?)", which sends the developer looking for an ownership problem
+    // they do not have. A Full personal API key is unaffected (enforceTokenScope
+    // early-returns on Full).
+    //
+    // 🔴 But NOT the same STAKE, so the bit choice is argued separately here rather than
+    // inherited. Analytics is a pure read; this proc MINTS A CREDENTIAL — it lazily
+    // provisions a per-user Forgejo identity whose token carries `write:repository`
+    // (dev-git-access.service) and returns it embedded in `cloneUrl`. So annotating
+    // widens who can trigger that mint from {session, Full personal key} to also
+    // include the civitai-cli OAuth login token.
+    //
+    // Accepted, deliberately: AppBlocksSubmit is opt-in, excluded from `Full`, and
+    // carried only by the first-party civitai-cli client; the caller must still own the
+    // app, not be banned, and the app must be `approved`; the collaborator grant is
+    // `read` on that one repo; and this is already the established meaning of the bit
+    // for CLI-facing procs, several of which are outright mutations (see
+    // `listingMediaCliScope` in app-listings.router.ts). A dedicated bit would be
+    // stricter but would recreate the "one command needs two different scopes" problem
+    // the analytics note above argues against.
+    //
+    // 🟡 Consequence worth knowing: the consent string for this bit is "Submit Apps for
+    // review", which does not mention minting a git credential. That copy lives in
+    // @civitai/auth and is a product decision, not a drive-by edit — but if an
+    // `AppBlocksRead` bit is ever introduced, THIS proc is the one that should not move
+    // to it (it is not a read), while getMyAppAnalytics is.
     .meta({ requiredScope: TokenScope.AppBlocksSubmit })
     .use(enforceAppBlocksFlag)
     // Accept EITHER the appBlockId (ab_…) OR the slug (blockId / repo name) — the

--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -5186,13 +5186,18 @@ export const blocksRouter = router({
     // it is NOT one uniform cap:
     //   - Personal API keys: `api-key.schema.ts` caps `tokenScope` at `.max(Full)`.
     //   - OAuth clients via tRPC: `oauth-client.schema.ts` caps `allowedScopes` at
-    //     `.max(Full)`. Both are pinned by the test below.
+    //     `.max(Full)` on create AND update. Both of these are pinned by a test in
+    //     `blocks.router.getMyAppAnalytics.test.ts`.
     //   - OAuth ACCESS TOKENS are NOT bounded by Full at all — the hub decodes the
     //     requested scope against `ALL_SCOPES` on purpose (clamping to Full would drop
     //     a legitimately-requested opt-in bit), so a token's ceiling is its client's
-    //     `allowedScopes`, not Full.
-    //   - And the one client exceeding Full (civitai-cli, 100663297) was written by a
-    //     RAW SQL migration, which no zod schema governs.
+    //     `allowedScopes | UserRead`, not Full.
+    //   - The one client exceeding Full (civitai-cli, 100663297) was written by a RAW SQL
+    //     migration, which no zod schema governs.
+    //   - `appblk-*` clients get `allowedScopes` written directly by
+    //     publish-request.service (also bypassing zod). Safe by construction, not by cap:
+    //     `deriveOauthBitmaskFromBlockScopes` maps only bits below 25, and those clients
+    //     carry `grants: []` so they cannot mint an account bearer token at all.
     // 100663297 is not a superset of Full (it carries bit 0 and none of 1..24), so the
     // flip is unreachable — but that last part rests on INSPECTION of that migration,
     // not on a cap. If a future migration grants a client `Full | <some opt-in bit>`,
@@ -5741,7 +5746,11 @@ export const blocksRouter = router({
    * as getMyAppRepo does (the CLI documents the token-in-URL leakage caveat).
    */
   getMyForgejoCloneInfo: protectedProcedure
-    // Same gate and same bit as getMyAppAnalytics above: un-annotated meant an implicit
+    // Same SCOPE gate and same bit as getMyAppAnalytics above — but note the base
+    // procedures differ: that one is `appDeveloperProcedure` (author cohort), this one is
+    // `protectedProcedure` plus an inline appBlocks-feature check below, so its audience
+    // is any Apps-enabled logged-in owner. Relevant to the "who can trigger the mint"
+    // reasoning further down. Un-annotated meant an implicit
     // `TokenScope.Full`, so `civitai app pull` 403'd the OAuth login token — and the CLI
     // reports that failure as "not permitted (are you the app owner, and is Apps enabled
     // for your account?)", which sends the developer looking for an ownership problem
@@ -5766,9 +5775,13 @@ export const blocksRouter = router({
     //
     // 🟡 Consequence worth knowing: the consent string for this bit is "Submit Apps for
     // review", which does not mention minting a git credential. That copy lives in
-    // @civitai/auth and is a product decision, not a drive-by edit — but if an
-    // `AppBlocksRead` bit is ever introduced, THIS proc is the one that should not move
-    // to it (it is not a read), while getMyAppAnalytics is.
+    // @civitai/auth and is a product decision, not a drive-by edit.
+    //
+    // If an `AppBlocksRead` bit is ever introduced, THIS proc must not move to it — it is
+    // not a read. getMyAppAnalytics could, but only TOGETHER WITH the REST route
+    // `GET /api/v1/blocks/submissions`: `civitai app metrics` calls both hops, so moving
+    // one alone recreates the very "two scopes for one command" problem the note on that
+    // proc argues against.
     .meta({ requiredScope: TokenScope.AppBlocksSubmit })
     .use(enforceAppBlocksFlag)
     // Accept EITHER the appBlockId (ab_…) OR the slug (blockId / repo name) — the


### PR DESCRIPTION
## The bug

`blocks.getMyAppAnalytics` carried no `.meta({ requiredScope })`, so `enforceTokenScope` fell back to its default of `TokenScope.Full`:

```ts
const requiredScope = meta?.requiredScope ?? TokenScope.Full;
```

A Full personal API key therefore worked, but the OAuth token minted by `civitai login` — the CLI's **default** auth path, and the only credential most users have — was rejected with `FORBIDDEN: Your API key does not have the required scope for this action`. So `civitai app metrics <slug>` ([cli#190](https://github.com/civitai/cli/pull/190)) would not work over the CLI's default auth path. Scope note, corrected from an earlier draft of this description: that command is on the CLI's `main` but in **no released tag** yet (latest is v0.1.89), and its audience is moderators plus the `app-blocks-author` Flipt cohort — so this is a fix-before-release, not a live outage for most users.

## The scope choice

Annotated with **`TokenScope.AppBlocksSubmit`**. This was picked deliberately rather than copied from the nearest precedent:

| Candidate | Verdict |
|---|---|
| **`AppBlocksSubmit`** | ✅ Already required by `GET /api/v1/blocks/submissions`, which **the same command already calls** to resolve `slug → appBlockId`. Opt-in, excluded from `Full`. |
| `UserRead` | ❌ Inside `Full` — what every third-party "log in with Civitai" client requests. Would expose install counts, Buzz spend, endpoint names and active-user counts to all of them. |
| `AppBlocksDevTunnel` | ❌ The `stopDevTunnel` precedent, but semantically unrelated — its consent label is literally "Open on-site dev tunnels". Would force analytics readers to grant tunnel-opening and vice versa. |
| a new `AppBlocksRead` bit | ❌ Correct in the abstract, but needs a prod `allowedScopes` migration **plus** a CLI `DeviceScope` bump with release ordering. The device flow's `validateScope` is all-or-nothing, so a bit outside the client's `allowedScopes` breaks login entirely. |

`AppBlocksSubmit` also keeps the rule that route already states: *"the same credential that could submit can read its own submissions, and nothing weaker."* With any other bit, the two hops of one command would need different scopes.

This is the same bug class, same bit, and same test shape as `app-listings.router.cli-scope.test.ts` (for civitai/cli#186) — another set of un-annotated procs that 403'd this same token.

## No regression, no migration

- `enforceTokenScope` early-returns on `ctx.tokenScope === TokenScope.Full`, so **Full personal API keys still pass** (note `Full` deliberately *excludes* bit 25, so it is the early-return — not `hasFlag` — doing the work).
- ⚠️ **That early return is exact equality, so this property is conditional, not universal.** A strict *superset* of Full lacking bit 25 (`Full|AppBlocksDevTunnel` = 100663295) passed before and is FORBIDDEN after. No such credential can be created — `api-key.schema.ts` and `oauth-client.schema.ts` both cap at `.max(Full)` — and those caps are now **pinned by a test**, with a boundary assertion that they still admit Full. See the correction comment below.
- `createContext` defaults a session to `Full`, so the web `/apps/revenue` panel is unaffected.
- The `civitai-cli` OAuth client's migration sets this bit and the login token requests it, so **no new `allowedScopes` change is needed**. This repo cannot prove prod state (those migrations are manual-apply and the device flow lives on the auth hub); if bit 25 were absent in prod the failure mode is "this fix does not take effect", never "a working path breaks".

## Verification

Of the five tests added, **only one is regression coverage** — this is measured, not assumed. With the `.meta` line deleted:

- `CLI OAuth login token (carries AppBlocksSubmit) reaches the service` → **red**, failing with this gate's own error at `enforce-token-scope.ts:84` (the exact 403 being fixed).
- The three other **behavioural** tests stay **green** on pre-change code, as does the enum-only bitmask sanity test — four green, one regression guard. They are labelled in the file as **invariant guards, not regression guards**. In particular the `NO_SUBMIT` case was already FORBIDDEN before, because an un-annotated proc implicitly required `Full` and that token lacks `Full` too — it pins that narrowing the gate did not accidentally *widen* it, a different (worthwhile) property.

Please don't read the green tests here as multiple tests of the fix; the file says so too.

**A later round added a second proc** — `blocks.getMyForgejoCloneInfo` had the identical live defect (`civitai app pull` drives it) and is annotated with the same bit, with its own 3-case matrix. `getMyRevenue`/`getMyApps` stay un-annotated deliberately, now documented. Details in the correction comment.

Gate:

- Full unit suite: **755 files / 10994 passed / 1 skipped / 0 failed** (at the current tip, i.e. including the fix round's tests).
- `tsc --noEmit`: **0 errors**, no OOM — harness validated by injecting a type error and confirming tsc reports exactly 1 (a bare `tsc` without `--max_old_space_size=8192` OOMs and reports a *false* 0).
- Prettier: the added regions are clean. Remaining violations in both test files are pre-existing on `main` (classified by hunk position, with the invocation positive-controlled against a known violator — `--check` prints its all-clean message even when it matched *zero* files, so a bare green isn't trustworthy).
- Mutation-tested: dropping either `.meta` line, or raising either schema cap, each turns the corresponding guard red on its own specific error. Every mutation was verified to have actually applied before its result was read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
