### PR TITLE
fix(tests): make seven server suites' exit codes describe their tests

### DIFF
--- a/src/server/__tests__/update-user-score-image-score.test.ts
+++ b/src/server/__tests__/update-user-score-image-score.test.ts
@@ -1,4 +1,13 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
+
+// 🔴 NOT ABOUT THIS FILE'S ASSERTIONS — it is about its EXIT CODE. The code
+// under test is pure, but it is reached through a module that imports
+// `~/server/db/client` at module scope, which instantiates Prisma and leaves an
+// UNHANDLED rejection. That rejection fails no test; it only makes the runner
+// exit non-zero, so `rc` here did not describe the tests and any mutation sweep
+// reading it reported every mutant killed. Nothing below touches a database.
+vi.mock('~/server/db/client', () => ({ dbRead: {}, dbWrite: {} }));
+
 import {
   rollupImageScoreDeltas,
   foldImageDeltasOntoStored,

--- a/src/server/__tests__/update-user-score-image-score.test.ts
+++ b/src/server/__tests__/update-user-score-image-score.test.ts
@@ -1,11 +1,10 @@
 import { describe, expect, it, vi } from 'vitest';
 
-// 🔴 NOT ABOUT THIS FILE'S ASSERTIONS — it is about its EXIT CODE. The code
-// under test is pure, but it is reached through a module that imports
-// `~/server/db/client` at module scope, which instantiates Prisma and leaves an
-// UNHANDLED rejection. That rejection fails no test; it only makes the runner
-// exit non-zero, so `rc` here did not describe the tests and any mutation sweep
-// reading it reported every mutant killed. Nothing below touches a database.
+// Mocked for the EXIT CODE, not the assertions. Reached transitively, this
+// module instantiates Prisma — and in a worktree without the repo's flake
+// dev-shell that leaves an unhandled rejection which fails no test but still
+// sets rc=1, so a mutation sweep reading rc scores every mutant as killed.
+// Nothing below touches a database. See civitai#3576.
 vi.mock('~/server/db/client', () => ({ dbRead: {}, dbWrite: {} }));
 
 import {

--- a/src/server/games/daily-challenge/challenge-currency.test.ts
+++ b/src/server/games/daily-challenge/challenge-currency.test.ts
@@ -1,11 +1,10 @@
 import { describe, it, expect, vi } from 'vitest';
 
-// 🔴 NOT ABOUT THIS FILE'S ASSERTIONS — it is about its EXIT CODE. The code
-// under test is pure, but it is reached through a module that imports
-// `~/server/db/client` at module scope, which instantiates Prisma and leaves an
-// UNHANDLED rejection. That rejection fails no test; it only makes the runner
-// exit non-zero, so `rc` here did not describe the tests and any mutation sweep
-// reading it reported every mutant killed. Nothing below touches a database.
+// Mocked for the EXIT CODE, not the assertions. Reached transitively, this
+// module instantiates Prisma — and in a worktree without the repo's flake
+// dev-shell that leaves an unhandled rejection which fails no test but still
+// sets rc=1, so a mutation sweep reading rc scores every mutant as killed.
+// Nothing below touches a database. See civitai#3576.
 vi.mock('~/server/db/client', () => ({ dbRead: {}, dbWrite: {} }));
 
 import { NsfwLevel } from '~/server/common/enums';

--- a/src/server/games/daily-challenge/challenge-currency.test.ts
+++ b/src/server/games/daily-challenge/challenge-currency.test.ts
@@ -1,4 +1,13 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
+
+// 🔴 NOT ABOUT THIS FILE'S ASSERTIONS — it is about its EXIT CODE. The code
+// under test is pure, but it is reached through a module that imports
+// `~/server/db/client` at module scope, which instantiates Prisma and leaves an
+// UNHANDLED rejection. That rejection fails no test; it only makes the runner
+// exit non-zero, so `rc` here did not describe the tests and any mutation sweep
+// reading it reported every mutant killed. Nothing below touches a database.
+vi.mock('~/server/db/client', () => ({ dbRead: {}, dbWrite: {} }));
+
 import { NsfwLevel } from '~/server/common/enums';
 import { nsfwBrowsingLevelsFlag, sfwBrowsingLevelsFlag } from '~/shared/constants/browsingLevel.constants';
 import { ChallengeSource } from '~/shared/utils/prisma/enums';

--- a/src/server/games/new-order/__tests__/consensus-backfill.test.ts
+++ b/src/server/games/new-order/__tests__/consensus-backfill.test.ts
@@ -1,11 +1,10 @@
 import { describe, it, expect, vi } from 'vitest';
 
-// 🔴 NOT ABOUT THIS FILE'S ASSERTIONS — it is about its EXIT CODE. The code
-// under test is pure, but it is reached through a module that imports
-// `~/server/db/client` at module scope, which instantiates Prisma and leaves an
-// UNHANDLED rejection. That rejection fails no test; it only makes the runner
-// exit non-zero, so `rc` here did not describe the tests and any mutation sweep
-// reading it reported every mutant killed. Nothing below touches a database.
+// Mocked for the EXIT CODE, not the assertions. Reached transitively, this
+// module instantiates Prisma — and in a worktree without the repo's flake
+// dev-shell that leaves an unhandled rejection which fails no test but still
+// sets rc=1, so a mutation sweep reading rc scores every mutant as killed.
+// Nothing below touches a database. See civitai#3576.
 vi.mock('~/server/db/client', () => ({ dbRead: {}, dbWrite: {} }));
 
 import { classifyDecision } from '~/server/games/new-order/consensus-backfill';

--- a/src/server/games/new-order/__tests__/consensus-backfill.test.ts
+++ b/src/server/games/new-order/__tests__/consensus-backfill.test.ts
@@ -1,4 +1,13 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
+
+// 🔴 NOT ABOUT THIS FILE'S ASSERTIONS — it is about its EXIT CODE. The code
+// under test is pure, but it is reached through a module that imports
+// `~/server/db/client` at module scope, which instantiates Prisma and leaves an
+// UNHANDLED rejection. That rejection fails no test; it only makes the runner
+// exit non-zero, so `rc` here did not describe the tests and any mutation sweep
+// reading it reported every mutant killed. Nothing below touches a database.
+vi.mock('~/server/db/client', () => ({ dbRead: {}, dbWrite: {} }));
+
 import { classifyDecision } from '~/server/games/new-order/consensus-backfill';
 
 describe('classifyDecision', () => {

--- a/src/server/jobs/__tests__/dedupe-official-uploads.test.ts
+++ b/src/server/jobs/__tests__/dedupe-official-uploads.test.ts
@@ -1,11 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-// 🔴 NOT ABOUT THIS FILE'S ASSERTIONS — it is about its EXIT CODE. The code
-// under test is pure, but it is reached through a module that imports
-// `~/server/db/client` at module scope, which instantiates Prisma and leaves an
-// UNHANDLED rejection. That rejection fails no test; it only makes the runner
-// exit non-zero, so `rc` here did not describe the tests and any mutation sweep
-// reading it reported every mutant killed. Nothing below touches a database.
+// Mocked for the EXIT CODE, not the assertions. Reached transitively, this
+// module instantiates Prisma — and in a worktree without the repo's flake
+// dev-shell that leaves an unhandled rejection which fails no test but still
+// sets rc=1, so a mutation sweep reading rc scores every mutant as killed.
+// Nothing below touches a database. See civitai#3576.
 vi.mock('~/server/db/client', () => ({ dbRead: {}, dbWrite: {} }));
 
 const { mockAddLinked } = vi.hoisted(() => ({ mockAddLinked: vi.fn() }));

--- a/src/server/jobs/__tests__/dedupe-official-uploads.test.ts
+++ b/src/server/jobs/__tests__/dedupe-official-uploads.test.ts
@@ -1,5 +1,13 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
+// 🔴 NOT ABOUT THIS FILE'S ASSERTIONS — it is about its EXIT CODE. The code
+// under test is pure, but it is reached through a module that imports
+// `~/server/db/client` at module scope, which instantiates Prisma and leaves an
+// UNHANDLED rejection. That rejection fails no test; it only makes the runner
+// exit non-zero, so `rc` here did not describe the tests and any mutation sweep
+// reading it reported every mutant killed. Nothing below touches a database.
+vi.mock('~/server/db/client', () => ({ dbRead: {}, dbWrite: {} }));
+
 const { mockAddLinked } = vi.hoisted(() => ({ mockAddLinked: vi.fn() }));
 vi.mock('~/server/services/model-version.service', () => ({ addLinkedComponent: mockAddLinked }));
 

--- a/src/server/routers/__tests__/model-file.official-lookup.router.test.ts
+++ b/src/server/routers/__tests__/model-file.official-lookup.router.test.ts
@@ -1,5 +1,13 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
+// 🔴 NOT ABOUT THIS FILE'S ASSERTIONS — it is about its EXIT CODE. The code
+// under test is pure, but it is reached through a module that imports
+// `~/server/db/client` at module scope, which instantiates Prisma and leaves an
+// UNHANDLED rejection. That rejection fails no test; it only makes the runner
+// exit non-zero, so `rc` here did not describe the tests and any mutation sweep
+// reading it reported every mutant killed. Nothing below touches a database.
+vi.mock('~/server/db/client', () => ({ dbRead: {}, dbWrite: {} }));
+
 const { mockFindBySize } = vi.hoisted(() => ({
   mockFindBySize: vi.fn(),
 }));

--- a/src/server/routers/__tests__/model-file.official-lookup.router.test.ts
+++ b/src/server/routers/__tests__/model-file.official-lookup.router.test.ts
@@ -1,11 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-// 🔴 NOT ABOUT THIS FILE'S ASSERTIONS — it is about its EXIT CODE. The code
-// under test is pure, but it is reached through a module that imports
-// `~/server/db/client` at module scope, which instantiates Prisma and leaves an
-// UNHANDLED rejection. That rejection fails no test; it only makes the runner
-// exit non-zero, so `rc` here did not describe the tests and any mutation sweep
-// reading it reported every mutant killed. Nothing below touches a database.
+// Mocked for the EXIT CODE, not the assertions. Reached transitively, this
+// module instantiates Prisma — and in a worktree without the repo's flake
+// dev-shell that leaves an unhandled rejection which fails no test but still
+// sets rc=1, so a mutation sweep reading rc scores every mutant as killed.
+// Nothing below touches a database. See civitai#3576.
 vi.mock('~/server/db/client', () => ({ dbRead: {}, dbWrite: {} }));
 
 const { mockFindBySize } = vi.hoisted(() => ({

--- a/src/server/services/__tests__/bitdex-model3did.test.ts
+++ b/src/server/services/__tests__/bitdex-model3did.test.ts
@@ -1,11 +1,10 @@
 import { describe, expect, it, vi } from 'vitest';
 
-// 🔴 NOT ABOUT THIS FILE'S ASSERTIONS — it is about its EXIT CODE. The code
-// under test is pure, but it is reached through a module that imports
-// `~/server/db/client` at module scope, which instantiates Prisma and leaves an
-// UNHANDLED rejection. That rejection fails no test; it only makes the runner
-// exit non-zero, so `rc` here did not describe the tests and any mutation sweep
-// reading it reported every mutant killed. Nothing below touches a database.
+// Mocked for the EXIT CODE, not the assertions. Reached transitively, this
+// module instantiates Prisma — and in a worktree without the repo's flake
+// dev-shell that leaves an unhandled rejection which fails no test but still
+// sets rc=1, so a mutation sweep reading rc scores every mutant as killed.
+// Nothing below touches a database. See civitai#3576.
 vi.mock('~/server/db/client', () => ({ dbRead: {}, dbWrite: {} }));
 
 import { mapBitdexDoc } from '~/server/services/image.service';

--- a/src/server/services/__tests__/bitdex-model3did.test.ts
+++ b/src/server/services/__tests__/bitdex-model3did.test.ts
@@ -1,4 +1,13 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
+
+// 🔴 NOT ABOUT THIS FILE'S ASSERTIONS — it is about its EXIT CODE. The code
+// under test is pure, but it is reached through a module that imports
+// `~/server/db/client` at module scope, which instantiates Prisma and leaves an
+// UNHANDLED rejection. That rejection fails no test; it only makes the runner
+// exit non-zero, so `rc` here did not describe the tests and any mutation sweep
+// reading it reported every mutant killed. Nothing below touches a database.
+vi.mock('~/server/db/client', () => ({ dbRead: {}, dbWrite: {} }));
+
 import { mapBitdexDoc } from '~/server/services/image.service';
 
 // mapBitdexDoc must emit model3dId only when the doc carries a number, and must

--- a/src/server/services/orchestrator/__tests__/ecosystems.test.ts
+++ b/src/server/services/orchestrator/__tests__/ecosystems.test.ts
@@ -1,4 +1,13 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
+
+// 🔴 NOT ABOUT THIS FILE'S ASSERTIONS — it is about its EXIT CODE. The code
+// under test is pure, but it is reached through a module that imports
+// `~/server/db/client` at module scope, which instantiates Prisma and leaves an
+// UNHANDLED rejection. That rejection fails no test; it only makes the runner
+// exit non-zero, so `rc` here did not describe the tests and any mutation sweep
+// reading it reported every mutant killed. Nothing below touches a database.
+vi.mock('~/server/db/client', () => ({ dbRead: {}, dbWrite: {} }));
+
 import { createEcosystemStepInput } from '../ecosystems';
 import type { GenerationHandlerCtx } from '../orchestration-new.service';
 

--- a/src/server/services/orchestrator/__tests__/ecosystems.test.ts
+++ b/src/server/services/orchestrator/__tests__/ecosystems.test.ts
@@ -1,11 +1,10 @@
 import { describe, it, expect, vi } from 'vitest';
 
-// 🔴 NOT ABOUT THIS FILE'S ASSERTIONS — it is about its EXIT CODE. The code
-// under test is pure, but it is reached through a module that imports
-// `~/server/db/client` at module scope, which instantiates Prisma and leaves an
-// UNHANDLED rejection. That rejection fails no test; it only makes the runner
-// exit non-zero, so `rc` here did not describe the tests and any mutation sweep
-// reading it reported every mutant killed. Nothing below touches a database.
+// Mocked for the EXIT CODE, not the assertions. Reached transitively, this
+// module instantiates Prisma — and in a worktree without the repo's flake
+// dev-shell that leaves an unhandled rejection which fails no test but still
+// sets rc=1, so a mutation sweep reading rc scores every mutant as killed.
+// Nothing below touches a database. See civitai#3576.
 vi.mock('~/server/db/client', () => ({ dbRead: {}, dbWrite: {} }));
 
 import { createEcosystemStepInput } from '../ecosystems';


### PR DESCRIPTION
> **Body corrected after an adversarial audit falsified the original premise.** The first version claimed a repo-level defect; it is environment-scoped. Full before/after and the measurement matrix are in [this comment](https://github.com/civitai/civitai/pull/3576#issuecomment-5170883899).

Seven suites under `src/server` exit non-zero while 100% of their tests pass — **in a worktree without the repo's flake dev-shell**. Each tests a pure function but reaches it through a module importing `~/server/db/client` at module scope, which instantiates Prisma. When `PRISMA_QUERY_ENGINE_LIBRARY` is unset, that leaves an unhandled `PrismaClientInitializationError` which fails no test and only sets the exit code.

## Scope — read this before the rest

`flake.nix:62` exports `PRISMA_QUERY_ENGINE_LIBRARY` and `.envrc` is `use flake`, but **`.envrc` is gitignored, so a bare `git worktree` never receives it.** Measured, all 7 suites run individually:

| | base `b83efe4dcd` | head `3bd37856ee` |
|---|---|---|
| **no engine env** (bare worktree) | `rc=1` ×7 | `rc=0` ×7 |
| **with flake dev-shell** | **`rc=0` ×7** | `rc=0` ×7 |

Test counts identical in all four cells: 8/15/6/2/1/3/4 = 39.

**CI is unaffected** — `grep -c PrismaClientInitializationError` over this PR's `Unit tests` log is 0 across 768 files, because `postinstall` runs `prisma generate`.

So the root-cause fix for anyone running suites in a worktree is to provision it (`cp <repo>/.envrc <worktree>/ && direnv allow <worktree>`). **This PR is hardening on top of that, not a substitute** — and it covers these 7 suites, not the class.

## Why it is still worth landing

Mutation sweeps certify spend-path guards here by reading `rc`, and tooling routinely runs in bare worktrees — which is how this symptom was observed twice, independently. In that environment `rc` was already 1 before any mutant, so every mutant read as "killed". The change is free, additive, and makes these suites robust to an environment the repo does not guarantee.

## The fix

One `vi.mock('~/server/db/client', () => ({ dbRead: {}, dbWrite: {} }))` per file, matching the **300** sibling suites (~120 factory shapes) that already do it; this exact idiom has 27 prior uses.

`dbRead` and `dbWrite` are the **only** names any module imports from that path — all 446 import/export-from statements enumerated, no namespace import, no destructuring, no side-effect import — so the two-key factory is complete rather than merely sufficient. The 13 importers using the relative `../db/client` collapse to the same resolved mock-registry key.

The clients are left empty deliberately: nothing here touches a database. Note the precise property — an empty object makes a **call-shaped** use throw (`dbRead.user.findMany()`), but a bare property read yields `undefined` silently.

## Verification

**Each mock is load-bearing.** The `base × no-env` row *is* the seven-way mutation: with the `vi.mock` absent all seven return `rc=1` with exactly one `PrismaClientInitializationError` each while their tests still pass — each dies for *this* guard's specific reason, not incidentally.

**Nothing is masked.** Head-with-env runs these suites against the **real** Prisma client and head-without-env against `{}`; both produce byte-identical pass counts, so nothing in the graphs distinguishes them. Per-file review confirmed no assertion depends on the client.

**Safe under `{}`.** Of 24 module-scope `dbRead`/`dbWrite` references repo-wide, only 2 fall inside the union of the seven import graphs (`db-helpers.ts:18` `makeDbKV(dbWrite)`, `tag.service.ts:50` `queryCache(dbRead, …)`), both lazy by construction. The 11 genuinely eager reads in `jobs/entity-moderation.ts:185-233` are outside all seven graphs.

**Gates.** Typecheck delta base→head is **zero** (134 errors at base, 134 at head, identical sets under `diff`). ESLint: `ecosystems.test.ts` 9 pre-existing `no-explicit-any` at both base and head; other six clean. Prettier diffs on two files are pre-existing at base.

**CI redness is pre-existing**, from the `feat/db-queries-kysely` merge: `packages/civitai-db-schema/src/kysely/updated-at-tables.ts(7,38): error TS2769` plus a `@prisma/client` postinstall schema-path failure. PR #3574 fails identically; pre-merge #3572 passes both.

## Known forward-risk (not introduced here)

This is a wholesale mock, so adding any new export to `~/server/db/client` breaks every file using the shape — probed, and **5 of 7 collapse to 0 tests collected**. `local-rules/no-wholesale-module-mock` is scoped to `['~/utils/trpc']` and does not cover this path, and `importOriginal` cannot be used (the spread re-evaluates the real module and the rejection returns). Recorded rather than solved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
