### PR TITLE
feat(blocks): request-time enforcement core for app-composed orchestrator steps

### DIFF
--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -6816,6 +6816,12 @@ async function submitStepWorkflow(opts: {
   // too. That is a false positive, and it is the direction we want — refusing a
   // pathological url costs a caller one bounced request; forwarding an
   // unentitled AIR costs the entitlement belt.
+  //
+  // "Anywhere" covers object KEYS as well as values — the orchestrator's own
+  // `additionalNetworks` / `WorkflowCost.fees` shapes are AIR-KEYED maps, and
+  // the scan used to recurse over `Object.values` only. See
+  // `containsAirReference` for the mechanism and the depth cap that keeps the
+  // scan total.
   if (step.resourcePolicy.kind === 'none' && containsAirReference(built.input)) {
     throw new TRPCError({
       code: 'FORBIDDEN',

--- a/src/server/services/blocks/steps/__tests__/step-registry.test.ts
+++ b/src/server/services/blocks/steps/__tests__/step-registry.test.ts
@@ -1397,6 +1397,45 @@ describe('containsAirReference — the entitlement probe', () => {
     expect(containsAirReference(null)).toBe(false);
     expect(containsAirReference(42)).toBe(false);
   });
+
+  // 🔴 KEYS, NOT JUST VALUES. The scan recursed over `Object.values` only and
+  // every assertion in this block returned `false` — a clean "no AIR here" for
+  // the shape the orchestrator's generated types actually prescribe
+  // (`additionalNetworks` is documented "Use the AIR of the network as the key";
+  // `WorkflowCost.fees` is keyed by resource AIR). This helper is the shared
+  // choke point, so the miss was simultaneously a request-time entitlement hole
+  // (`screenSubmittedStepResources`) and a weakened registry clause-7 load probe.
+  it('finds an AIR carried in an object KEY, at every depth', () => {
+    const air = 'urn:air:sd1:lora:civitai:1234@5678';
+    // the literal orchestrator shape
+    expect(containsAirReference({ additionalNetworks: { [air]: { strength: 1 } } })).toBe(true);
+    // top level
+    expect(containsAirReference({ [air]: 1 })).toBe(true);
+    // nested through an array, upper-cased (the scan is case-insensitive)
+    expect(containsAirReference({ a: [{ b: { [air.toUpperCase()]: null } }] })).toBe(true);
+    // WorkflowCost.fees
+    expect(containsAirReference({ cost: { fees: { [air]: 0.02 } } })).toBe(true);
+    // an AIR-keyed map whose VALUES are all primitives — nothing for a
+    // values-only scan to even recurse into
+    expect(containsAirReference({ [air]: 'ok', other: 'ok' })).toBe(true);
+  });
+
+  it('is TOTAL — a pathologically nested value fails closed instead of throwing', () => {
+    // Unbounded recursion threw `RangeError: Maximum call stack size exceeded`
+    // at ~5k nesting, reachable with a ~10 KB `[[[[…]]]]` request body. The
+    // declared contract is `boolean`, never "may throw"; at the depth cap the
+    // scan answers "could not prove there is no AIR here" = true = fail-closed.
+    let deep: unknown = 'leaf';
+    for (let i = 0; i < 20000; i++) deep = [deep];
+    let out: boolean | undefined;
+    expect(() => {
+      out = containsAirReference(deep);
+    }).not.toThrow();
+    expect(out).toBe(true);
+
+    // …and the cap must not swallow the ordinary shallow negative case.
+    expect(containsAirReference({ a: { b: { c: 'plain' } } })).toBe(false);
+  });
 });
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/src/server/services/blocks/steps/__tests__/step-request-time-policy.test.ts
+++ b/src/server/services/blocks/steps/__tests__/step-request-time-policy.test.ts
@@ -1,0 +1,448 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+import { describe, expect, it } from 'vitest';
+import { STEP_TYPE_ACCEPTABLE_POSTURES, type StepModerationPosture } from '../index';
+import {
+  assertPolicyAgreesWithRegistryMap,
+  assertRegistryEntryAgreesWithPolicy,
+  billingModeForSubmittedType,
+  evaluateSubmittedStep,
+  lookupStepTypePolicy,
+  POLICIED_STEP_TYPES,
+  postureForTextSurface,
+  requiredPostureForSubmittedType,
+  screenSubmittedStepResources,
+  STEP_TYPE_POLICY,
+} from '../request-time-policy';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// The AUTHORITATIVE `$type` population, read from the generated
+// `@civitai/client` types at TEST time.
+//
+// 🔴 WHY READ THE FILE RATHER THAN HARDCODE A LIST. The whole point of the
+// policy table is that a `$type` with no row is not submittable. A hardcoded
+// expectation would be a copy of the table checked against the table — it would
+// pass forever and could never observe the event it exists for: the orchestrator
+// spec gaining a `$type` and a regenerated client bringing it in. Reading the
+// generated file makes this a real drift guard.
+//
+// The generated types export no runtime union of every `$type` (only individual
+// `<Name>Step` aliases), which is why this is a text scan rather than an import.
+// ─────────────────────────────────────────────────────────────────────────────
+function generatedStepTypes(): string[] {
+  const require = createRequire(import.meta.url);
+  const pkg = require.resolve('@civitai/client/package.json');
+  const decl = path.join(path.dirname(pkg), 'dist/generated/types.gen.d.ts');
+  const src = fs.readFileSync(decl, 'utf8');
+  const found = [...src.matchAll(/\$type:\s*'([^']+)'/g)].map((m) => m[1]);
+  return [...new Set(found)].sort();
+}
+
+describe('request-time policy: coverage of the generated $type population', () => {
+  it('reads a non-empty $type population from the generated client (POSITIVE CONTROL)', () => {
+    // 🔴 THE POSITIVE CONTROL FOR THE DRIFT GUARD BELOW. The guard's reassuring
+    // answer is a ZERO ("no uncovered types"), and a zero is indistinguishable
+    // from a scan wired to nothing — a moved file, a changed literal style, a
+    // bad regex all produce an empty list and a green test. This asserts the
+    // scan actually observes types, and pins a floor well under the real count
+    // so it fails on an empty/near-empty read rather than tracking the number.
+    const types = generatedStepTypes();
+    expect(types.length).toBeGreaterThan(30);
+    // Spot-anchor a few the scan MUST see, so a regex that matches nothing
+    // meaningful cannot pass the count check with garbage.
+    expect(types).toContain('chatCompletion');
+    expect(types).toContain('textToImage');
+    expect(types).toContain('convertImage');
+  });
+
+  it('every generated $type has a policy row', () => {
+    const uncovered = generatedStepTypes().filter((t) => lookupStepTypePolicy(t) === undefined);
+    expect(uncovered).toEqual([]);
+  });
+
+  it('every policy row corresponds to a real generated $type (no invented rows)', () => {
+    const generated = new Set(generatedStepTypes());
+    const invented = POLICIED_STEP_TYPES.filter((t) => !generated.has(t));
+    expect(invented).toEqual([]);
+  });
+
+  it('a row classified `none` declares no text fields, and every other row declares some', () => {
+    // Pins the column that carries the PROVENANCE. A row asserting "no free
+    // text" while listing text fields (or vice versa) is a self-contradicting
+    // classification, and the field list is what review checks against.
+    for (const [type, policy] of Object.entries(STEP_TYPE_POLICY)) {
+      if (policy.textSurface === 'none') {
+        expect(policy.textFields, `${type} declares 'none' but lists text fields`).toEqual([]);
+      } else {
+        expect(
+          policy.textFields.length,
+          `${type} declares '${policy.textSurface}' but lists no text fields`
+        ).toBeGreaterThan(0);
+      }
+    }
+  });
+});
+
+describe('request-time policy: GUARD 1 — moderation posture from the submitted $type', () => {
+  it('derives `textOutput` for a model-generated text type', () => {
+    const d = requiredPostureForSubmittedType('chatCompletion');
+    expect(d).toEqual({ ok: true, value: 'textOutput' });
+  });
+
+  it('derives `none` for a media-only type', () => {
+    const d = requiredPostureForSubmittedType('convertImage');
+    expect(d).toEqual({ ok: true, value: 'none' });
+  });
+
+  it('FAILS CLOSED on an unlisted $type', () => {
+    const d = requiredPostureForSubmittedType('someFutureOrchestratorStep');
+    expect(d.ok).toBe(false);
+    if (d.ok) throw new Error('unreachable');
+    expect(d.code).toBe('unknownStepType');
+    expect(d.reason).toContain('no declared moderation policy');
+  });
+
+  it('FAILS CLOSED on a type whose text surface is an open policy question', () => {
+    const d = requiredPostureForSubmittedType('modelParseMetadata');
+    expect(d.ok).toBe(false);
+    if (d.ok) throw new Error('unreachable');
+    expect(d.code).toBe('undecidedTextSurface');
+    expect(d.reason).toContain('open policy question');
+  });
+
+  it.each(['toString', 'constructor', 'valueOf', '__proto__', 'hasOwnProperty'])(
+    'FAILS CLOSED on the Object.prototype key %s',
+    (key) => {
+      // 🔴 THE FAIL-OPEN INVERSION THIS PINS. The lookup key is a `$type` an
+      // UNTRUSTED app chose. On a plain object literal `STEP_TYPE_POLICY['toString']`
+      // resolves to `Object.prototype.toString` — TRUTHY — so `if (!policy)`
+      // evaluates false and the submit proceeds with a function as its "policy".
+      // The null prototype is what makes these read `undefined`.
+      expect(lookupStepTypePolicy(key)).toBeUndefined();
+      const d = requiredPostureForSubmittedType(key);
+      expect(d.ok).toBe(false);
+      if (d.ok) throw new Error('unreachable');
+      expect(d.code).toBe('unknownStepType');
+    }
+  );
+
+  it('maps every text surface to a posture, or to an explicit refusal', () => {
+    expect(postureForTextSurface('none')).toBe('none');
+    expect(postureForTextSurface('generatedText')).toBe('textOutput');
+    // 🔴 Echoed input gets the SAME answer as generated text, deliberately.
+    expect(postureForTextSurface('echoedInput')).toBe('textOutput');
+    // 🔴 Not a posture — a refusal.
+    expect(postureForTextSurface('undecidedNeedsDomainOwner')).toBeNull();
+  });
+});
+
+describe('request-time policy: GUARD 2 — resource / AIR entitlement on the submitted input', () => {
+  it('allows an input with no resource reference', () => {
+    const d = screenSubmittedStepResources({
+      orchestratorType: 'convertImage',
+      input: { sourceImage: 'https://example.com/a.png', format: 'jpeg' },
+    });
+    expect(d).toEqual({ ok: true, value: 'noResourceReference' });
+  });
+
+  it('FAILS CLOSED on an AIR URN in a top-level field', () => {
+    const d = screenSubmittedStepResources({
+      orchestratorType: 'convertImage',
+      input: { model: 'urn:air:sdxl:checkpoint:civitai:4384@128713' },
+    });
+    expect(d.ok).toBe(false);
+    if (d.ok) throw new Error('unreachable');
+    expect(d.code).toBe('unentitledResourceReference');
+  });
+
+  it('FAILS CLOSED on an AIR URN buried DEEP in a field nobody declared', () => {
+    // 🔴 THE POINT OF A DEEP SCAN. Under the pivot an app builds the whole input
+    // object, so an AIR can arrive through any field — including one the
+    // generated schema calls a caption. A known-field check would miss this.
+    const d = screenSubmittedStepResources({
+      orchestratorType: 'convertImage',
+      input: {
+        harmless: 'ok',
+        nested: { deeper: [{ note: 'see urn:air:sdxl:lora:civitai:1@2 for details' }] },
+      },
+    });
+    expect(d.ok).toBe(false);
+    if (d.ok) throw new Error('unreachable');
+    expect(d.code).toBe('unentitledResourceReference');
+  });
+
+  it('scans a type whose generated input is NOT air-bearing (the flag must not gate the scan)', () => {
+    // `chatCompletion.model` is a plain provider id, so `airBearingInput` is
+    // false — but the flag describes the SCHEMA, and what arrives is an object
+    // the app built. Gating the scan on the flag would trust the schema to
+    // constrain the payload, which is the assumption the pivot removes.
+    expect(lookupStepTypePolicy('chatCompletion')?.airBearingInput).toBe(false);
+    const d = screenSubmittedStepResources({
+      orchestratorType: 'chatCompletion',
+      input: { model: 'gpt-4o', messages: [{ role: 'user', content: 'urn:air:flux:lora:x:1@2' }] },
+    });
+    expect(d.ok).toBe(false);
+    if (d.ok) throw new Error('unreachable');
+    expect(d.code).toBe('unentitledResourceReference');
+  });
+
+  it('FAILS CLOSED on an unlisted $type even when the input is clean', () => {
+    const d = screenSubmittedStepResources({
+      orchestratorType: 'someFutureOrchestratorStep',
+      input: { totally: 'fine' },
+    });
+    expect(d.ok).toBe(false);
+    if (d.ok) throw new Error('unreachable');
+    expect(d.code).toBe('unknownStepType');
+  });
+});
+
+describe('request-time policy: GUARD 3 — billing mode from the submitted $type', () => {
+  it('returns the established mode for the one evidenced type', () => {
+    expect(billingModeForSubmittedType('convertImage')).toEqual({
+      ok: true,
+      value: 'prepaidFixed',
+    });
+  });
+
+  it('FAILS CLOSED on a listed type with no established mode', () => {
+    const d = billingModeForSubmittedType('chatCompletion');
+    expect(d.ok).toBe(false);
+    if (d.ok) throw new Error('unreachable');
+    expect(d.code).toBe('billingModeNotEstablished');
+    expect(d.reason).toContain('no established billing mode');
+  });
+
+  it('FAILS CLOSED on an unlisted $type', () => {
+    const d = billingModeForSubmittedType('someFutureOrchestratorStep');
+    expect(d.ok).toBe(false);
+    if (d.ok) throw new Error('unreachable');
+    expect(d.code).toBe('unknownStepType');
+  });
+
+  it('never reports a mode for a type the table leaves null', () => {
+    // Pins the fail-closed default over the WHOLE population rather than one
+    // sampled row: every row whose `billingMode` is null must reject.
+    for (const [type, policy] of Object.entries(STEP_TYPE_POLICY)) {
+      const d = billingModeForSubmittedType(type);
+      if (policy.billingMode === null) {
+        expect(d.ok, `${type} has a null mode but was accepted`).toBe(false);
+      } else {
+        expect(d).toEqual({ ok: true, value: policy.billingMode });
+      }
+    }
+  });
+});
+
+describe('request-time policy: the composite gate', () => {
+  it('accepts a fully-policied, clean submit', () => {
+    const d = evaluateSubmittedStep({
+      orchestratorType: 'convertImage',
+      input: { sourceImage: 'https://example.com/a.png' },
+    });
+    expect(d.ok).toBe(true);
+    if (!d.ok) throw new Error('unreachable');
+    expect(d.value.posture).toBe('none');
+    expect(d.value.billingMode).toBe('prepaidFixed');
+    expect(d.value.orchestratorType).toBe('convertImage');
+  });
+
+  it('rejects on the POSTURE axis before the others', () => {
+    // An undecided type with an AIR AND no billing mode: the posture rejection
+    // is the one reported, which pins the documented order.
+    const d = evaluateSubmittedStep({
+      orchestratorType: 'modelParseMetadata',
+      input: { model: 'urn:air:sdxl:checkpoint:civitai:1@2' },
+    });
+    expect(d.ok).toBe(false);
+    if (d.ok) throw new Error('unreachable');
+    expect(d.code).toBe('undecidedTextSurface');
+  });
+
+  it('rejects on the RESOURCE axis before billing', () => {
+    // `chatCompletion` derives a posture fine, has no billing mode, and here
+    // carries an AIR — the resource rejection must win.
+    const d = evaluateSubmittedStep({
+      orchestratorType: 'chatCompletion',
+      input: { model: 'urn:air:sdxl:checkpoint:civitai:1@2' },
+    });
+    expect(d.ok).toBe(false);
+    if (d.ok) throw new Error('unreachable');
+    expect(d.code).toBe('unentitledResourceReference');
+  });
+
+  it('rejects on the BILLING axis when posture and resources both pass', () => {
+    const d = evaluateSubmittedStep({
+      orchestratorType: 'chatCompletion',
+      input: { model: 'gpt-4o', messages: [{ role: 'user', content: 'hello' }] },
+    });
+    expect(d.ok).toBe(false);
+    if (d.ok) throw new Error('unreachable');
+    expect(d.code).toBe('billingModeNotEstablished');
+  });
+
+  it('rejects an unlisted $type on every axis', () => {
+    const d = evaluateSubmittedStep({ orchestratorType: 'nope', input: {} });
+    expect(d.ok).toBe(false);
+    if (d.ok) throw new Error('unreachable');
+    expect(d.code).toBe('unknownStepType');
+  });
+});
+
+describe('request-time policy: the table is immutable', () => {
+  it('the container is frozen', () => {
+    expect(Object.isFrozen(STEP_TYPE_POLICY)).toBe(true);
+  });
+
+  it('every row is frozen, and so is its textFields array', () => {
+    // 🔴 A SHALLOW FREEZE WOULD LEAVE EVERY ROW MUTABLE, and `readonly` is a
+    // compile-time fiction a runtime assignment walks straight through — after
+    // which `chatCompletion` could be flipped to `textSurface: 'none'` and its
+    // output published unscanned.
+    for (const [type, policy] of Object.entries(STEP_TYPE_POLICY)) {
+      expect(Object.isFrozen(policy), `${type} row not frozen`).toBe(true);
+      expect(Object.isFrozen(policy.textFields), `${type} textFields not frozen`).toBe(true);
+    }
+  });
+
+  it('a write to a row does not take effect', () => {
+    // 🔴 THIS TEST RESTORES WHAT IT BREAKS, AND THAT IS NOT TIDINESS. Written
+    // the obvious way — assign, then assert the value is unchanged — it is
+    // SAFE only while the freeze works. The moment the freeze is removed the
+    // assignment LANDS, and because the table is module-level it stays landed
+    // for every test that runs after: a mutation sweep then shows unrelated
+    // tests going red on polluted state rather than on their own guard, which
+    // reads as coverage those guards do not have. Measured, not hypothesised —
+    // an unfreeze mutation killed six tests, only two of them legitimately.
+    const original = STEP_TYPE_POLICY.chatCompletion.textSurface;
+    try {
+      expect(() => {
+        (STEP_TYPE_POLICY.chatCompletion as { textSurface: string }).textSurface = 'none';
+      }).toThrow(); // strict mode (ESM) — a write to a frozen object throws
+      expect(STEP_TYPE_POLICY.chatCompletion.textSurface).toBe('generatedText');
+    } finally {
+      // No-op when the freeze holds (the write never landed). Only does
+      // anything when the guard under test is broken — which is exactly when
+      // the isolation matters.
+      if (STEP_TYPE_POLICY.chatCompletion.textSurface !== original) {
+        (STEP_TYPE_POLICY.chatCompletion as { textSurface: string }).textSurface = original;
+      }
+    }
+  });
+});
+
+describe('request-time policy: cross-check against the registry', () => {
+  const goodEntry = {
+    id: 'convert-image',
+    orchestratorType: 'convertImage',
+    moderationPosture: 'none' as StepModerationPosture,
+    billingMode: 'prepaidFixed' as const,
+  };
+
+  it('accepts the shipped entry shape (THE CONTROL)', () => {
+    // 🔴 THE CONTROL. If this throws, every negative case below is meaningless —
+    // they would "pass" because the base shape is rejected, not because the
+    // field under test is wrong.
+    expect(() => assertRegistryEntryAgreesWithPolicy(goodEntry)).not.toThrow();
+  });
+
+  it('rejects an entry whose declared posture disagrees with the derived one', () => {
+    expect(() =>
+      assertRegistryEntryAgreesWithPolicy({
+        ...goodEntry,
+        moderationPosture: 'promptAudit' as StepModerationPosture,
+      })
+    ).toThrow(/requires 'none'/);
+  });
+
+  it('rejects an entry whose $type has no policy row', () => {
+    expect(() =>
+      assertRegistryEntryAgreesWithPolicy({ ...goodEntry, orchestratorType: 'notAThing' })
+    ).toThrow(/no request-time policy row/);
+  });
+
+  it('rejects an entry whose declared billing mode contradicts an established one', () => {
+    expect(() =>
+      assertRegistryEntryAgreesWithPolicy({ ...goodEntry, billingMode: 'timeBounded' })
+    ).toThrow(/establishes 'prepaidFixed'/);
+  });
+
+  it('does NOT reject an entry whose $type has no established billing mode', () => {
+    // The documented asymmetry: a `null` row means "not ratified for
+    // app-composed submission", which is a different question from the
+    // registry's own clause-10 gate. Only a contradiction is an error.
+    expect(() =>
+      assertRegistryEntryAgreesWithPolicy({
+        id: 'hypothetical',
+        orchestratorType: 'chatCompletion',
+        moderationPosture: 'textOutput' as StepModerationPosture,
+        billingMode: 'prepaidFixed',
+      })
+    ).not.toThrow();
+  });
+
+  it('agrees with the registry posture map over its WHOLE population (THE CONTROL)', () => {
+    expect(() => assertPolicyAgreesWithRegistryMap(STEP_TYPE_ACCEPTABLE_POSTURES)).not.toThrow();
+  });
+
+  it('the registry map covers more than one $type (POSITIVE CONTROL for the check above)', () => {
+    // 🔴 Without this, the agreement assertion could be vacuously green over an
+    // empty or single-entry map and nobody would know — the loop would simply
+    // not execute. Pins that the population it walks is real.
+    expect(Object.keys(STEP_TYPE_ACCEPTABLE_POSTURES).length).toBeGreaterThanOrEqual(7);
+  });
+
+  it('detects a map that licenses a $type this module refuses', () => {
+    expect(() => assertPolicyAgreesWithRegistryMap({ modelParseMetadata: ['textOutput'] })).toThrow(
+      /derives none/
+    );
+  });
+
+  it('detects a map whose accepted postures exclude the derived one', () => {
+    expect(() => assertPolicyAgreesWithRegistryMap({ chatCompletion: ['none'] })).toThrow(
+      /derives posture 'textOutput'/
+    );
+  });
+
+  it('detects a map naming a $type with no policy row at all', () => {
+    expect(() => assertPolicyAgreesWithRegistryMap({ notAThing: ['none'] })).toThrow(
+      /derives none/
+    );
+  });
+});
+
+describe('request-time policy: the findings this table records', () => {
+  it('flags chatCompletion as BOTH text-producing and media-emitting', () => {
+    // 🔴 The cross-axis case the registry's MEDIA-XOR-TEXT model cannot express.
+    // `modalities: ['image']` makes this $type return images on
+    // `choices[].message.images[]`, so a purely text-posture treatment hands an
+    // app a media channel the text scan does not stand in front of.
+    const p = lookupStepTypePolicy('chatCompletion');
+    expect(p?.textSurface).toBe('generatedText');
+    expect(p?.emitsMedia).toBe(true);
+  });
+
+  it('records the transcript`s SECOND copy on transcription', () => {
+    expect(lookupStepTypePolicy('transcription')?.textFields).toContain('timeStamps[].text');
+  });
+
+  it('records that xGuardModeration echoes caller text back, not just modelReason', () => {
+    const fields = lookupStepTypePolicy('xGuardModeration')?.textFields ?? [];
+    expect(fields).toContain('results[].modelReason');
+    expect(fields.some((f) => f.startsWith('results[].matchedTerms.'))).toBe(true);
+  });
+
+  it('leaves every domain-owner question unsubmittable', () => {
+    const undecided = Object.entries(STEP_TYPE_POLICY)
+      .filter(([, p]) => p.textSurface === 'undecidedNeedsDomainOwner')
+      .map(([t]) => t);
+    // There ARE open questions — a zero here would mean the classification
+    // silently decided them all.
+    expect(undecided.length).toBeGreaterThan(0);
+    for (const type of undecided) {
+      const d = requiredPostureForSubmittedType(type);
+      expect(d.ok, `${type} is submittable but its classification is undecided`).toBe(false);
+    }
+  });
+});

--- a/src/server/services/blocks/steps/__tests__/step-request-time-policy.test.ts
+++ b/src/server/services/blocks/steps/__tests__/step-request-time-policy.test.ts
@@ -196,6 +196,96 @@ describe('request-time policy: GUARD 2 — resource / AIR entitlement on the sub
     if (d.ok) throw new Error('unreachable');
     expect(d.code).toBe('unknownStepType');
   });
+
+  // ───────────────────────────────────────────────────────────────────────────
+  // 🔴 AIR CARRIED IN AN OBJECT **KEY**.
+  //
+  // The scan recursed over `Object.values` only, so every case below returned
+  // `{ ok: true, value: 'noResourceReference' }` and the composite gate
+  // ACCEPTED the submit. This is not a contrived shape: the orchestrator's own
+  // generated types prescribe it. `ImageJobParams.additionalNetworks` is
+  // `{ [key: string]: ImageJobNetworkParams }` documented "Use the AIR of the
+  // network as the key", and `WorkflowCost.fees` is keyed by resource AIR the
+  // same way. An AIR-keyed map is the MOST likely real placement, not the least.
+  //
+  // Each case is paired with the value-carried equivalent as a positive control,
+  // so a scan that silently stopped scanning anything at all cannot pass.
+  // ───────────────────────────────────────────────────────────────────────────
+  const KEY_AIR = 'urn:air:sd1:lora:civitai:1234@5678';
+
+  it('FAILS CLOSED on the literal `additionalNetworks` AIR-keyed map shape', () => {
+    const control = screenSubmittedStepResources({
+      orchestratorType: 'textToImage',
+      input: { additionalNetworks: { theKey: { air: KEY_AIR, strength: 1 } } },
+    });
+    expect(control.ok).toBe(false); // positive control: AIR in a VALUE
+
+    const d = screenSubmittedStepResources({
+      orchestratorType: 'textToImage',
+      input: { additionalNetworks: { [KEY_AIR]: { strength: 1, triggerWord: 'x' } } },
+    });
+    expect(d.ok).toBe(false);
+    if (d.ok) throw new Error('unreachable');
+    expect(d.code).toBe('unentitledResourceReference');
+  });
+
+  it('FAILS CLOSED on an AIR key at the TOP level of the input', () => {
+    const d = screenSubmittedStepResources({
+      orchestratorType: 'convertImage',
+      input: { [KEY_AIR]: 1 },
+    });
+    expect(d.ok).toBe(false);
+    if (d.ok) throw new Error('unreachable');
+    expect(d.code).toBe('unentitledResourceReference');
+  });
+
+  it('FAILS CLOSED on an AIR key buried in a nested / array-wrapped position', () => {
+    const d = screenSubmittedStepResources({
+      orchestratorType: 'convertImage',
+      input: { a: { b: [{ c: { [KEY_AIR.toUpperCase()]: { strength: 0.8 } } }] } },
+    });
+    expect(d.ok).toBe(false);
+    if (d.ok) throw new Error('unreachable');
+    expect(d.code).toBe('unentitledResourceReference');
+  });
+
+  it('FAILS CLOSED on the `WorkflowCost.fees` AIR-keyed shape', () => {
+    const d = screenSubmittedStepResources({
+      orchestratorType: 'convertImage',
+      input: { cost: { fees: { [KEY_AIR]: 0.02 } } },
+    });
+    expect(d.ok).toBe(false);
+    if (d.ok) throw new Error('unreachable');
+    expect(d.code).toBe('unentitledResourceReference');
+  });
+
+  it('the COMPOSITE gate rejects an AIR-keyed submit end to end', () => {
+    // The full accept was the actual exposure: `evaluateSubmittedStep` returned
+    // `{ ok: true, value: { posture: 'none', billingMode: 'prepaidFixed', … } }`
+    // for this exact payload.
+    const d = evaluateSubmittedStep({
+      orchestratorType: 'convertImage',
+      input: { additionalNetworks: { [KEY_AIR]: { strength: 1 } } },
+    });
+    expect(d.ok).toBe(false);
+    if (d.ok) throw new Error('unreachable');
+    expect(d.code).toBe('unentitledResourceReference');
+  });
+
+  it('IS TOTAL — a pathologically nested input is a DECISION, not a RangeError', () => {
+    // ~10 KB of `[[[[…]]]]` blows an unbounded recursion's call stack. The
+    // declared contract is `PolicyDecision`, never "may throw", and
+    // `evaluateSubmittedStep` does not wrap this call.
+    let deep: unknown = 'leaf';
+    for (let i = 0; i < 20000; i++) deep = [deep];
+    let d: ReturnType<typeof screenSubmittedStepResources>;
+    expect(() => {
+      d = screenSubmittedStepResources({ orchestratorType: 'convertImage', input: deep });
+    }).not.toThrow();
+    expect(d!.ok).toBe(false);
+    if (d!.ok) throw new Error('unreachable');
+    expect(d!.code).toBe('unentitledResourceReference');
+  });
 });
 
 describe('request-time policy: GUARD 3 — billing mode from the submitted $type', () => {
@@ -444,5 +534,279 @@ describe('request-time policy: the findings this table records', () => {
       const d = requiredPostureForSubmittedType(type);
       expect(d.ok, `${type} is submittable but its classification is undecided`).toBe(false);
     }
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// `platformDiagnosticFields` — the DRIFT GUARD, derived from the generated types
+// rather than restated from the table.
+//
+// 🔴 WHAT WENT WRONG AND WHY A REVIEW-ONLY COLUMN WOULD NOT HAVE CAUGHT IT.
+// 22 rows declared `textSurface: 'none'` + `textFields: []` — whose own
+// definition is "structural strings (urls, ids, hashes) only" — while every one
+// of them reached `Blob.blockedReason?: null | string`, generated doc "Get an
+// optional reason for why the blob was blocked". The single row that DID record
+// the field (`mediaRating`) proved the table already regarded it as text, which
+// is what made the other 22 self-contradicting rather than merely terse.
+//
+// 🔴 THE WALK BELOW MUST FOLLOW INTERSECTION/EXTENSION TYPES, AND THAT IS THE
+// SECOND HALF OF THE DEFECT. `composeMedia`'s declared `ComposeMediaOutput` is
+// `{ type; elements[] }` and reaches no `Blob` at all — a one-level walk calls
+// it clean. Its runtime value is `AudioComposeMediaOutput` /
+// `VideoComposeMediaOutput`, both `Omit<ComposeMediaOutput,'type'> & { …Blob }`.
+// A guard written without extension-awareness would therefore report
+// `composeMedia` as NOT carrying the field and fail against a correct table —
+// so the walk's extension handling is load-bearing, not incidental.
+// ─────────────────────────────────────────────────────────────────────────────
+describe('request-time policy: platformDiagnosticFields is derived, not asserted', () => {
+  /** Every `export type NAME = <rhs>` in the generated declaration file. */
+  function generatedDecls(): Map<string, string> {
+    const require = createRequire(import.meta.url);
+    const pkg = require.resolve('@civitai/client/package.json');
+    const decl = path.join(path.dirname(pkg), 'dist/generated/types.gen.d.ts');
+    const lines = fs.readFileSync(decl, 'utf8').split('\n');
+    const out = new Map<string, string>();
+    for (let i = 0; i < lines.length; i++) {
+      const m = /^export type ([A-Za-z0-9_]+) = (.*)$/.exec(lines[i]);
+      if (!m) continue;
+      let depth = (m[2].match(/\{/g) ?? []).length - (m[2].match(/\}/g) ?? []).length;
+      const buf = [m[2]];
+      let j = i;
+      while (depth > 0 && j + 1 < lines.length) {
+        j++;
+        buf.push(lines[j]);
+        depth += (lines[j].match(/\{/g) ?? []).length - (lines[j].match(/\}/g) ?? []).length;
+      }
+      out.set(m[1], buf.join('\n'));
+      i = j;
+    }
+    return out;
+  }
+
+  const decls = generatedDecls();
+
+  /** Named types referenced anywhere inside a declaration body. */
+  function referenced(body: string): string[] {
+    return [...new Set(body.replace(/'[^']*'/g, '').match(/\b[A-Z][A-Za-z0-9_]*\b/g) ?? [])];
+  }
+
+  /** True when `name`, or anything it reaches, declares a `blockedReason` field. */
+  const memo = new Map<string, boolean>();
+  function carries(name: string, seen = new Set<string>()): boolean {
+    const hit = memo.get(name);
+    if (hit !== undefined) return hit;
+    if (seen.has(name) || !decls.has(name)) return false;
+    seen.add(name);
+    const body = decls.get(name)!;
+    let result = /^\s*blockedReason\??:/m.test(body);
+    if (!result) {
+      for (const ref of referenced(body)) {
+        if (ref !== name && carries(ref, seen)) {
+          result = true;
+          break;
+        }
+      }
+    }
+    if (seen.size === 1) memo.set(name, result);
+    return result;
+  }
+
+  /** `X & {…}` / `Omit<X,…> & {…}` types that extend `base`. */
+  function extensionsOf(base: string): string[] {
+    const out: string[] = [];
+    for (const [name, body] of decls) {
+      if (!body.includes('&')) continue;
+      const head = body.split('&')[0].trim();
+      if (head === base || new RegExp(`^Omit<\\s*${base}\\s*,`).test(head)) out.push(name);
+    }
+    return out;
+  }
+
+  function outputTypeFor(type: string): string | undefined {
+    const want = `${type}output`.toLowerCase();
+    for (const name of decls.keys()) if (name.toLowerCase() === want) return name;
+    return undefined;
+  }
+
+  it('reads the generated declarations at all (POSITIVE CONTROL)', () => {
+    // 🔴 The guard's reassuring answer is a ZERO, which a parser wired to
+    // nothing produces just as readily as a correct table. Pin that the parse
+    // observes real declarations, that the walk can answer BOTH ways, and that
+    // extension resolution finds the `composeMedia` variants — otherwise the
+    // "every row agrees" assertion below is vacuous.
+    expect(decls.size).toBeGreaterThan(500);
+    expect(decls.has('Blob')).toBe(true);
+    expect(carries('Blob')).toBe(true); // declares it directly
+    expect(carries('ImageBlob')).toBe(true); // reaches it through `Omit<Blob,'type'> & …`
+    expect(carries('ConvertImageOutput')).toBe(true); // reaches it one level down
+    expect(carries('ComposeMediaOutput')).toBe(false); // NEGATIVE: the declared type is clean
+    expect(carries('TranscriptionOutput')).toBe(false); // NEGATIVE: no blob anywhere
+    expect(extensionsOf('ComposeMediaOutput').sort()).toEqual([
+      'AudioComposeMediaOutput',
+      'VideoComposeMediaOutput',
+    ]);
+    expect(extensionsOf('VideoGenOutput')).toEqual(['HaiperVideoGenOutput']);
+  });
+
+  it('every $type whose output reaches blockedReason declares it, and no other row does', () => {
+    const derived: string[] = [];
+    for (const type of Object.keys(STEP_TYPE_POLICY)) {
+      const out = outputTypeFor(type);
+      expect(out, `no <Name>Output resolved for ${type}`).toBeDefined();
+      const candidates = [out!, ...extensionsOf(out!)];
+      if (candidates.some((c) => carries(c))) derived.push(type);
+    }
+    // A floor, so an empty derivation cannot pass as "the table is right".
+    expect(derived.length).toBeGreaterThan(20);
+
+    const declaredRows = Object.entries(STEP_TYPE_POLICY)
+      .filter(([, p]) => p.platformDiagnosticFields.length > 0)
+      .map(([t]) => t);
+    expect(declaredRows.sort()).toEqual(derived.sort());
+  });
+
+  it('pins the paths for the cases the enumeration got wrong the first time', () => {
+    // The plainest `'none'` row, and the one shipped registry entry's $type.
+    expect(STEP_TYPE_POLICY.convertImage.platformDiagnosticFields).toEqual(['blob.blockedReason']);
+    // Reachable ONLY through the two intersection subtypes.
+    expect(STEP_TYPE_POLICY.composeMedia.platformDiagnosticFields).toEqual([
+      'audioBlob.blockedReason',
+      'videoBlob.blockedReason',
+    ]);
+    // A `null | Array<VideoBlob>` element path — the `[]` must survive the
+    // `null |` prefix, which a naive `^Array<` match drops.
+    expect(STEP_TYPE_POLICY.videoGen.platformDiagnosticFields).toEqual([
+      'video.blockedReason',
+      'additionalVideos[].blockedReason',
+    ]);
+    // The widest row — 13 paths across 7 optional blob slots plus a nested
+    // `basicAnimations` group. A truncated walk shows up here first.
+    expect(STEP_TYPE_POLICY.polyGen.platformDiagnosticFields).toHaveLength(13);
+    // Three separate raw `Blob`s on one result element.
+    expect(STEP_TYPE_POLICY.comfyNodepackSnapshot.platformDiagnosticFields).toEqual([
+      'results[].layer.blockedReason',
+      'results[].objectInfo.blockedReason',
+      'results[].web.blockedReason',
+    ]);
+    // NEGATIVE anchors: rows whose outputs genuinely carry no blob.
+    expect(STEP_TYPE_POLICY.transcription.platformDiagnosticFields).toEqual([]);
+    expect(STEP_TYPE_POLICY.blobArchive.platformDiagnosticFields).toEqual([]);
+    expect(STEP_TYPE_POLICY.wdTagging.platformDiagnosticFields).toEqual([]);
+  });
+
+  it('keeps the two provenance columns disjoint in meaning', () => {
+    // 🔴 `blockedReason` used to live in `mediaRating.textFields` and NOWHERE
+    // else, which is precisely how one field ended up called text on one row and
+    // absent on 22. No row may list it as `textFields` again.
+    for (const [type, p] of Object.entries(STEP_TYPE_POLICY)) {
+      expect(
+        p.textFields.filter((f) => f.includes('blockedReason')),
+        `${type} lists blockedReason in textFields; it belongs in platformDiagnosticFields`
+      ).toEqual([]);
+    }
+    // …and mediaRating still fails closed on its OWN merits, not on that field:
+    // its remaining `textFields` are all model output.
+    expect(STEP_TYPE_POLICY.mediaRating.textSurface).toBe('undecidedNeedsDomainOwner');
+    expect(STEP_TYPE_POLICY.mediaRating.textFields).toContain('labels[]');
+    expect(STEP_TYPE_POLICY.mediaRating.textFields).toContain('ageClassification.error');
+    expect(STEP_TYPE_POLICY.mediaRating.textFields.length).toBeGreaterThan(1);
+    expect(requiredPostureForSubmittedType('mediaRating').ok).toBe(false);
+  });
+
+  it('every row declares the column (it cannot be forgotten on a new row)', () => {
+    for (const [type, p] of Object.entries(STEP_TYPE_POLICY)) {
+      expect(Array.isArray(p.platformDiagnosticFields), `${type} missing the column`).toBe(true);
+      expect(Object.isFrozen(p.platformDiagnosticFields), `${type} column not frozen`).toBe(true);
+    }
+  });
+});
+
+describe('request-time policy: videoGen carries a THIRD-PARTY provider message', () => {
+  it('is refused rather than published, because HaiperVideoGenOutput adds `message`', () => {
+    // `VideoGenStep.output` is typed `VideoGenOutput` ({ video, additionalVideos }
+    // — no text), but `HaiperVideoGenOutput = VideoGenOutput & { …;
+    // externalTOSViolation?; message?: null | string }` is the shape a
+    // `videoGen` step with `engine: 'haiper'` produces. That `message` is the
+    // provider's moderation explanation — third-party free text, the same class
+    // as `modelClamScan`'s raw output, which is already undecided.
+    expect(STEP_TYPE_POLICY.videoGen.textSurface).toBe('undecidedNeedsDomainOwner');
+    expect(STEP_TYPE_POLICY.videoGen.textFields).toEqual(['message']);
+
+    const d = requiredPostureForSubmittedType('videoGen');
+    expect(d.ok).toBe(false);
+    if (d.ok) throw new Error('unreachable');
+    expect(d.code).toBe('undecidedTextSurface');
+
+    // The whole gate refuses it, not just guard 1.
+    const gate = evaluateSubmittedStep({
+      orchestratorType: 'videoGen',
+      input: { prompt: 'a cat' },
+    });
+    expect(gate.ok).toBe(false);
+  });
+
+  it('records the text fields a first pass missed on ALREADY-text rows', () => {
+    // 🟡 These rows were already `generatedText` / `undecidedNeedsDomainOwner`,
+    // so nothing was ever licensed by the omission — but `textFields` is the
+    // column a reviewer checks a classification against and a scan would be
+    // written from, and an incomplete one reads as a complete one.
+    const x = STEP_TYPE_POLICY.xGuardModeration.textFields;
+    // Plain `string` on `XGuardLabelResult`, no doc, no enum — `topToken` is the
+    // guard model's highest-probability token.
+    expect(x).toContain('results[].topToken');
+    expect(x).toContain('results[].finishReason');
+    expect(x).toContain('signalMetadata.customSignals[].name');
+
+    // "Optional name for the participant", on the ASSISTANT message.
+    expect(STEP_TYPE_POLICY.chatCompletion.textFields).toContain('choices[].message.name');
+
+    // `null | string`, not numbers — nothing in the generated type bounds them.
+    expect(STEP_TYPE_POLICY.audioCaptioning.textFields).toContain('results[].bpm');
+    expect(STEP_TYPE_POLICY.audioCaptioning.textFields).toContain('results[].duration');
+
+    // Four classifier labels; `aiRecognition.label` is documented as coming from
+    // "the model's own id2label", so the example lists are not closed sets.
+    const m = STEP_TYPE_POLICY.mediaRating.textFields;
+    for (const f of [
+      'ageClassification.detections[].ageLabel',
+      'aiRecognition.label',
+      'animeRecognition.label',
+      'humanRecognition.label',
+    ]) {
+      expect(m, `mediaRating missing ${f}`).toContain(f);
+    }
+
+    // 🔴 `QwenImageBenchScoreNode.children: Array<QwenImageBenchScoreNode>` is
+    // self-referential, so a `scores[].name` path names ONLY the root level.
+    expect(STEP_TYPE_POLICY.qwenImageBench.textFields).toContain('results[].scores[]**.name');
+    expect(STEP_TYPE_POLICY.qwenImageBench.textFields).not.toContain('results[].scores[].name');
+  });
+
+  it('pins the recursion that the qwenImageBench path notation stands for', () => {
+    // A path string is a claim about the generated types; this checks the claim
+    // rather than trusting the notation. If `children` ever stops being
+    // self-referential the `**` is wrong and should come back out.
+    const require = createRequire(import.meta.url);
+    const pkg = require.resolve('@civitai/client/package.json');
+    const src = fs.readFileSync(
+      path.join(path.dirname(pkg), 'dist/generated/types.gen.d.ts'),
+      'utf8'
+    );
+    const decl = /export type QwenImageBenchScoreNode = \{([\s\S]*?)\n\};/.exec(src);
+    expect(decl, 'QwenImageBenchScoreNode not found — the pin below proves nothing').not.toBeNull();
+    expect(decl![1]).toMatch(/name:\s*string/);
+    expect(decl![1]).toMatch(/children:\s*Array<QwenImageBenchScoreNode>/);
+  });
+
+  it('does not disturb the one shipped registry entry (THE CONTROL)', () => {
+    // convertImage is the only registered step; the F2/F3 corrections must not
+    // have made it unsubmittable.
+    expect(requiredPostureForSubmittedType('convertImage')).toEqual({ ok: true, value: 'none' });
+    expect(
+      evaluateSubmittedStep({
+        orchestratorType: 'convertImage',
+        input: { sourceImage: 'https://example.com/a.png', format: 'jpeg' },
+      }).ok
+    ).toBe(true);
   });
 });

--- a/src/server/services/blocks/steps/index.ts
+++ b/src/server/services/blocks/steps/index.ts
@@ -379,17 +379,47 @@ export function isResourcePolicyImplemented(policy: StepResourcePolicy): boolean
 const AIR_URN_PREFIX = 'urn:air:';
 
 /**
- * True when any string ANYWHERE in the value is (or embeds) an AIR URN.
+ * Recursion budget for {@link containsAirReference}.
+ *
+ * 🔴 THE SCAN IS TOTAL, NOT PARTIAL — it must never throw. Its declared contract
+ * is a `boolean` (and, one layer up, a `PolicyDecision`), never "may throw", and
+ * `evaluateSubmittedStep` does not wrap it. An unbounded recursion over
+ * attacker-shaped JSON hits `RangeError: Maximum call stack size exceeded` at
+ * roughly 5k nesting levels, which a ~10 KB `[[[[…]]]]` request body reaches
+ * trivially — a free 500 from a value the guard was supposed to *decide* on.
+ *
+ * At the cap the scan returns TRUE (fail-closed): "I could not prove this input
+ * carries no AIR." No legitimate orchestrator step input nests anywhere near
+ * this deep, so the cap costs nothing real and turns a crash into a rejection.
+ */
+const AIR_SCAN_MAX_DEPTH = 128;
+
+/**
+ * True when any string ANYWHERE in the value — a leaf, an array element, an
+ * object VALUE, **or an object KEY** — is (or embeds) an AIR URN.
  *
  * Deliberately a deep scan rather than a check of a known field name: the point
  * is to catch an AIR arriving through a field NOBODY thought to look at, which
  * is the only way the `'none'` declaration can become a lie.
+ *
+ * 🔴 KEYS ARE SCANNED, AND THAT IS NOT DEFENSIVE PARANOIA — IT IS THE
+ * ORCHESTRATOR'S OWN SCHEMA. `ImageJobParams.additionalNetworks` is typed
+ * `{ [key: string]: ImageJobNetworkParams }` and its doc comment reads "Use the
+ * AIR of the network as the key"; `WorkflowCost.fees` is likewise keyed by
+ * resource AIR (both in the generated `@civitai/client` types). A scan over
+ * `Object.values` alone therefore misses the single most likely real-world
+ * placement of an AIR in a submitted step, and returns a confident
+ * `noResourceReference` for `{ additionalNetworks: { 'urn:air:…': {…} } }` — a
+ * LoRA reaching the entitlement belt through the gate's blind spot.
  */
-export function containsAirReference(value: unknown): boolean {
+export function containsAirReference(value: unknown, depth = 0): boolean {
+  if (depth > AIR_SCAN_MAX_DEPTH) return true;
   if (typeof value === 'string') return value.toLowerCase().includes(AIR_URN_PREFIX);
-  if (Array.isArray(value)) return value.some(containsAirReference);
+  if (Array.isArray(value)) return value.some((v) => containsAirReference(v, depth + 1));
   if (value !== null && typeof value === 'object') {
-    return Object.values(value as Record<string, unknown>).some(containsAirReference);
+    return Object.entries(value as Record<string, unknown>).some(
+      ([key, v]) => containsAirReference(key, depth + 1) || containsAirReference(v, depth + 1)
+    );
   }
   return false;
 }

--- a/src/server/services/blocks/steps/index.ts
+++ b/src/server/services/blocks/steps/index.ts
@@ -411,6 +411,21 @@ const AIR_SCAN_MAX_DEPTH = 128;
  * placement of an AIR in a submitted step, and returns a confident
  * `noResourceReference` for `{ additionalNetworks: { 'urn:air:…': {…} } }` — a
  * LoRA reaching the entitlement belt through the gate's blind spot.
+ *
+ * 🔴 "ANYWHERE" IS SCOPED TO JSON-SHAPED INPUT, AND THE ONE EXCEPTION IS
+ * `toJSON`-BEARING INSTANCES. What makes the totality claim hold in general is
+ * that `Object.entries` visibility ≈ `JSON.stringify` visibility: `Map`, `Set`
+ * and non-enumerable own properties are invisible to BOTH, so an AIR hidden in
+ * one cannot reach the orchestrator either. A class with a `toJSON` breaks that
+ * equivalence — measured: `containsAirReference(new URL('https://x/urn:air:…'))`
+ * returns FALSE while `JSON.stringify` of it CONTAINS the AIR.
+ *
+ * NOT reachable today: `parseStepParams` runs the entry's `.strict()`
+ * `paramSchema` before `buildStep`, and no registered entry admits a class
+ * instance. It becomes reachable the first time an entry declares a
+ * `z.unknown()` / `z.any()` / `z.custom()` param — superjson DOES reconstruct a
+ * `URL` across the tRPC boundary. An entry doing that owes either a stricter
+ * schema or a pre-scan `JSON.parse(JSON.stringify(input))` normalisation.
  */
 export function containsAirReference(value: unknown, depth = 0): boolean {
   if (depth > AIR_SCAN_MAX_DEPTH) return true;
@@ -523,7 +538,7 @@ export const NATIVELY_EXTRACTED_STEP_TYPES: readonly string[] = [
  * "complete" and review disproved it. Uncovered types whose OUTPUT carries free
  * text include `imageResourceTraining` (`sampleImagesPrompts[]` — echoed user
  * prompts, the SAME rationale used to list `echo` below, which is a live
- * inconsistency), `mediaRating.blockedReason`, `modelParseMetadata.metadata`
+ * inconsistency), `modelParseMetadata.metadata`
  * (a `__metadata__` header out of a user-uploaded safetensors), the
  * `modelClamScan` / `modelPickleScan` `output` + `skipReason` fields, and
  * `qwenImageBench.errors`. They are NOT listed because whether each is really
@@ -531,6 +546,15 @@ export const NATIVELY_EXTRACTED_STEP_TYPES: readonly string[] = [
  * make, not one to settle silently in this commit. Listing the candidates is
  * the honest middle: the next person to add a text-producing entry starts from
  * a named set rather than from "complete".
+ *
+ * 🔴 `mediaRating.blockedReason` USED TO BE ON THAT LIST AND WAS REMOVED, not
+ * overlooked. `blockedReason` is platform-AUTHORED moderation copy, not
+ * external free text, and it is now recorded per-row in
+ * `platformDiagnosticFields` (`./request-time-policy`) across the 24 `$type`s
+ * whose output carries it — a `Blob` field, so it reaches far more rows than
+ * `mediaRating` alone. `mediaRating` remains `undecidedNeedsDomainOwner` on its
+ * own merits (`labels[]`, `ageClassification.error`), which is why deleting it
+ * from this list licenses nothing.
  *
  * An unlisted text-IN type registering as `'none'` skips an
  * audit it should run — a real gap, RECORDED AND NOT CLOSED, and a different

--- a/src/server/services/blocks/steps/moderation.ts
+++ b/src/server/services/blocks/steps/moderation.ts
@@ -5,11 +5,17 @@ import { throwBadRequestError } from '~/server/utils/errorHandling';
 import {
   getStepByOrchestratorType,
   isModerationPostureImplemented,
+  listRegisteredSteps,
   posturePhaseRequirements,
   STEP_MODERATION_POSTURES,
+  STEP_TYPE_ACCEPTABLE_POSTURES,
   type AnyBlockStep,
   type StepModerationPosture,
 } from './index';
+import {
+  assertPolicyAgreesWithRegistryMap,
+  assertRegistryEntryAgreesWithPolicy,
+} from './request-time-policy';
 import { screenGeneratedText, TEXT_OUTPUT_WITHHELD_MESSAGE } from './text-output-moderation';
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -359,6 +365,41 @@ export function assertModerationHandlerTable(
 }
 
 assertModerationHandlerTable(moderationPostureHandlers);
+
+// ─────────────────────────────────────────────────────────────────────────────
+// REQUEST-TIME POLICY CROSS-CHECK — asserted HERE rather than in `./index`.
+//
+// 🔴 WHY THIS FILE. `./request-time-policy` imports `containsAirReference` and
+// the posture/billing types FROM `./index`, so asserting there would create an
+// import CYCLE between two modules that both run load-time invariants — the
+// shape where one module observes the other half-initialised. This file already
+// imports `./index`, already owns a load-time assert, and is on the router's
+// step submit path, so the cross-check runs in production rather than only under
+// test. Same layering reason `./output` and `./text-output-moderation` are leaf
+// modules.
+//
+// 🔴 WHAT IT PINS. `./request-time-policy` derives the same three decisions
+// (posture, entitlement, billing mode) from the SUBMITTED `$type` instead of
+// from a registered entry's declaration — which is what the App Blocks →
+// orchestrator-types pivot needs, because the declarations disappear with
+// registration. Two tables answering the same question is exactly the setup that
+// drifts, so both directions are pinned at load:
+//   1. every REGISTERED entry's declared posture/billing agrees with the derived
+//      policy for the `$type` it submits, and
+//   2. every `$type` the registry's own posture map licenses derives a posture
+//      that map accepts — a wider population than (1), which sees only the one
+//      `$type` a registered entry currently claims.
+// A disagreement is a BUILD failure, not a Friday surprise on a spend path.
+// ─────────────────────────────────────────────────────────────────────────────
+assertPolicyAgreesWithRegistryMap(STEP_TYPE_ACCEPTABLE_POSTURES);
+for (const [id, step] of listRegisteredSteps()) {
+  assertRegistryEntryAgreesWithPolicy({
+    id,
+    orchestratorType: step.orchestratorType,
+    moderationPosture: step.moderationPosture,
+    billingMode: step.billingMode,
+  });
+}
 
 /**
  * Run the declared moderation posture for a step submit.

--- a/src/server/services/blocks/steps/request-time-policy.ts
+++ b/src/server/services/blocks/steps/request-time-policy.ts
@@ -1,0 +1,940 @@
+import type { StepBillingMode, StepModerationPosture } from './index';
+import { containsAirReference } from './index';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// REQUEST-TIME ENFORCEMENT CORE for app-composed orchestrator steps.
+//
+// WHAT THIS IS. The step registry (`./index`) makes three decisions —
+// MODERATION POSTURE, RESOURCE/ENTITLEMENT POLICY and BILLING MODE — by reading
+// a DECLARATION off a registered entry, and it makes them at REGISTRATION time
+// (module load, a build error). The App Blocks → orchestrator-types pivot
+// removes registration: an app composes real orchestrator workflow steps and the
+// host submits them, so there is no entry to declare anything.
+//
+// 🔴 THE THREE GUARDS DO NOT SURVIVE THAT MOVE ON THEIR OWN. Each one is keyed
+// on a field (`step.moderationPosture`, `step.resourcePolicy`,
+// `step.billingMode`) that only exists because an entry was written and
+// reviewed. With arbitrary steps the ONLY trustworthy input is the `$type` the
+// app submitted and the `input` object it built. So this module re-homes all
+// three onto that pair, and every one of them FAILS CLOSED.
+//
+// 🔴 IT IS NOT THE WIRE CONTRACT AND IT DOES NOT REPLACE THE REGISTRY. Nothing
+// here widens what may be submitted today; `blockStepBodySchema`'s `step` enum
+// is still derived from the registry keys and is still the gate. This module is
+// the enforcement core the widening will need, landed AHEAD of it and wired into
+// the registry path (see `assertRegistryEntryAgreesWithPolicy`) so it is
+// exercised rather than dead.
+//
+// ─────────────────────────────────────────────────────────────────────────────
+// PROVENANCE OF THE TABLE BELOW — READ THIS BEFORE EDITING A ROW.
+//
+// Every `textFields` path was ENUMERATED from the generated `@civitai/client`
+// types (`dist/generated/types.gen.d.ts`, v0.2.0-beta.83) by walking each
+// `$type`'s `<Name>Output` transitively and collecting every string-valued
+// field. It was NOT derived from `src/**` usage — that enumerates what is
+// CALLED, not what EXISTS, and the registry's own Tranche-1 note records the
+// same correction.
+//
+// 🔴 TWO MEASURED CORRECTIONS THAT THE OBVIOUS METHOD GETS WRONG, recorded
+// because both produce a CONFIDENT WRONG ANSWER rather than an error:
+//
+//   1. A NAME-BASED filter silently drops real text. Filtering "structural"
+//      string fields by name pattern dropped `TranscriptionOutput.text` — "The
+//      full transcribed text" — because `text` ends in `ext`. A text surface
+//      filtered out reads as "this type produces no text", which is the
+//      fail-OPEN direction. The table is therefore built from the enumerated
+//      field list plus its generated DOC COMMENT, never from a name heuristic.
+//
+//   2. `$type` → type-name casing is NOT a plain capitalisation.
+//      `model3DPreview` resolves to `Model3dPreviewOutput` (lowercase `d`), so a
+//      naive `$type[0].toUpperCase()` lookup finds NOTHING and the type silently
+//      drops out of the population entirely — again fail-open. Resolution is
+//      case-insensitive.
+//
+// 43 `$type` values exist in the generated types; all 43 are covered below.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * What FREE TEXT a `$type`'s output carries, and therefore what the host owes
+ * before that output may reach an app.
+ *
+ * 🔴 THE DISTINCTION THAT MATTERS IS *NOT* "has a string field". Almost every
+ * type has one — ids, blob urls, expiry timestamps, format enums, hashes.
+ * `convertImage` has two (`blob.previewUrl`, `blob.previewUrlExpiresAt`) and
+ * produces no free text at all. Classifying on "has a string" would put every
+ * type behind the text scan, which is not a stricter policy — it is a policy
+ * nobody can ship, and it would be relaxed wholesale the first time it bit.
+ */
+export type StepTextSurface =
+  /** No free text in the output. Structural strings (urls, ids, hashes) only. */
+  | 'none'
+  /**
+   * MODEL-GENERATED free text. The surface the prompt audit cannot cover,
+   * because the text does not exist when the prompt audit runs. Requires the
+   * `'textOutput'` posture and its scan.
+   */
+  | 'generatedText'
+  /**
+   * Caller-supplied text ECHOED back out. Distinguished from `generatedText`
+   * because the whole surface is auditable at INPUT — but it is deliberately
+   * NOT given a weaker treatment here (see `postureForTextSurface`).
+   */
+  | 'echoedInput'
+  /**
+   * 🔴 TEXT LIFTED OUT OF AN UNTRUSTED ARTIFACT, or a tool's raw diagnostic
+   * output. NOT model-generated and NOT caller-echoed — a third category the
+   * registry's two-posture model does not have a slot for.
+   *
+   * Examples in the table: the `__metadata__` JSON header of a user-uploaded
+   * safetensors (`modelParseMetadata`), raw ClamAV / picklescan console output
+   * and the Python import paths they discovered (`modelClamScan`,
+   * `modelPickleScan`).
+   *
+   * 🔴 THIS VALUE IS A REFUSAL, NOT A CLASSIFICATION. Whether such a surface is
+   * something an App Block may publish is a policy question with a real answer
+   * either way, and it is a DOMAIN OWNER's to make — so the type is NOT
+   * submittable while it holds this value (`postureForTextSurface` returns no
+   * posture). That is the fail-closed direction and it is deliberate: the
+   * alternative is to guess, and a guess here either blocks a legitimate
+   * capability or publishes an attacker-controlled string.
+   */
+  | 'undecidedNeedsDomainOwner';
+
+/** The policy facts derived for one orchestrator `$type`. */
+export type StepTypePolicy = {
+  /** See `StepTextSurface`. */
+  textSurface: StepTextSurface;
+  /**
+   * The generated-type field paths that carry the text, relative to the step's
+   * `output`. PROVENANCE for review — this is what a reviewer checks a
+   * classification against, and what a regenerated client is diffed against.
+   * Empty iff `textSurface` is `'none'`.
+   */
+  textFields: readonly string[];
+  /**
+   * 🔴 TRUE when the `$type` can return MEDIA — including a type whose PRIMARY
+   * surface is text. See `chatCompletion` below; this flag exists because of it.
+   */
+  emitsMedia: boolean;
+  /**
+   * TRUE when the type's INPUT can carry an AIR URN (or a model reference that
+   * resolves like one), so a submit must be screened against the entitlement
+   * belt rather than trusted.
+   *
+   * 🔴 ADVISORY ONLY — it does NOT gate anything. The actual guard
+   * (`screenSubmittedStepResources`) deep-scans the SUBMITTED input for every
+   * type unconditionally, because a `false` here is a claim about the generated
+   * schema and the schema is not what arrives at request time. This field exists
+   * so a reviewer can see which types NEED an allowlist designed, not so the
+   * scan can be skipped for the others.
+   */
+  airBearingInput: boolean;
+  /**
+   * The billing mode, or `null` when it is NOT ESTABLISHED.
+   *
+   * 🔴 `null` IS THE HONEST DEFAULT AND IT FAILS CLOSED. Deriving a billing mode
+   * for a `$type` requires the orchestrator's rate card, which is not in this
+   * repo and was not measured. Guessing one is the failure this field exists to
+   * prevent: a type wrongly called `prepaidFixed` reserves a fixed amount for
+   * something whose cost is not fixed. Only rows with real evidence carry a
+   * value, and the evidence is named on the row.
+   */
+  billingMode: StepBillingMode | null;
+};
+
+/**
+ * The per-`$type` policy table. TOTAL over the 43 `$type` values the generated
+ * client declares.
+ *
+ * 🔴 A `$type` ABSENT FROM THIS TABLE IS NOT SUBMITTABLE. That is the whole
+ * fail-closed mechanism, and it is why the table is an ALLOWLIST keyed by the
+ * submitted `$type` rather than a set of denied types. When the orchestrator
+ * adds a `$type`, apps cannot reach it until someone adds a row — which is the
+ * reviewed-decision property the registry bought with registration, re-homed to
+ * the only input that survives the pivot.
+ */
+const STEP_TYPE_POLICY_TABLE = {
+  // ── TEXT-PRODUCING (model-generated) ──────────────────────────────────────
+  // These seven are exactly the set `ACCEPTABLE_POSTURES_BY_TYPE` already
+  // licenses for `'textOutput'`. The independent enumeration CONFIRMS that list
+  // is correct as far as it goes — see `assertPolicyAgreesWithRegistryMap`,
+  // which pins the agreement so the two cannot drift.
+  chatCompletion: {
+    textSurface: 'generatedText',
+    textFields: [
+      'choices[].message.content',
+      'choices[].message.refusal',
+      'choices[].message.tool_calls[].function.arguments',
+      'choices[].finishReason',
+    ],
+    // 🔴 THE CROSS-AXIS CASE, AND THE REASON `emitsMedia` EXISTS AT ALL.
+    // `ChatCompletionInput.modalities` ("Output modalities the model should
+    // produce. Defaults to text-only when omitted.") makes this `$type` return
+    // IMAGES on `choices[].message.images[].image_url.url` — a base64 data URI,
+    // per the generated doc comment. So a purely text-posture treatment of
+    // `chatCompletion` hands an app a MEDIA channel that the text scan does not
+    // stand in front of.
+    //
+    // 🔴 THE REGISTRY CANNOT EXPRESS THIS STEP. Its output surface is MEDIA
+    // **XOR** TEXT (`stepOutputShape`), and `index.ts` states the limit
+    // explicitly: "A future orchestrator step that emits BOTH media and free
+    // text cannot register at all under this rule — it fails at load rather than
+    // half-registering... Nothing in the currently-licensed `$type` set has that
+    // shape." That last sentence is FALSE as of `@civitai/client`
+    // 0.2.0-beta.83 — `chatCompletion` is in the licensed set and has exactly
+    // that shape. Recorded here rather than silently worked around; closing it
+    // is a design decision, not an edit.
+    emitsMedia: true,
+    // `ChatCompletionInput.model` is a plain provider id ("gpt-4o"), NOT an AIR —
+    // matching what `index.ts` already records. It still needs binding, but by a
+    // model allowlist rather than by the AIR entitlement belt.
+    airBearingInput: false,
+    billingMode: null, // see `chatCompletion` note in the module footer
+  },
+  mediaCaptioning: {
+    textSurface: 'generatedText',
+    textFields: ['caption'],
+    emitsMedia: false,
+    airBearingInput: false,
+    billingMode: null,
+  },
+  audioCaptioning: {
+    textSurface: 'generatedText',
+    textFields: [
+      'results[].text',
+      'results[].caption',
+      'results[].lyrics',
+      'results[].keyScale',
+      'results[].timeSignature',
+      'results[].language',
+    ],
+    emitsMedia: false,
+    airBearingInput: false,
+    billingMode: null,
+  },
+  transcription: {
+    textSurface: 'generatedText',
+    // 🔴 `timeStamps[].text` IS A SECOND, INDEPENDENT COPY of the transcript,
+    // word by word. An extractor that returns only `text` scans the transcript
+    // once and leaves the per-word copy unscanned — and the registry's
+    // `extractText` contract makes "not returned" mean "not published", so the
+    // safe reading is that BOTH must be returned or the capability is partial.
+    textFields: ['text', 'timeStamps[].text'],
+    emitsMedia: false,
+    airBearingInput: false,
+    billingMode: null,
+  },
+  promptEnhancement: {
+    textSurface: 'generatedText',
+    textFields: [
+      'enhancedPrompt',
+      'enhancedNegativePrompt',
+      'recommendations[]',
+      'issues[].description',
+    ],
+    emitsMedia: false,
+    // `PromptEnhancementInput.images[]` are reference images, not AIRs.
+    airBearingInput: false,
+    billingMode: null,
+  },
+  xGuardModeration: {
+    textSurface: 'generatedText',
+    // 🔴 WIDER THAN THE REGISTRY'S NOTE. `index.ts` justifies listing this type
+    // by `modelReason` alone. The enumeration finds the output ALSO echoes the
+    // caller's own text back through `matchedTerms` — so this row is both
+    // model-generated AND caller-echoed, and an extractor written to the
+    // registry's stated rationale would cover only the first.
+    textFields: [
+      'results[].modelReason',
+      'results[].postprocess',
+      'results[].error',
+      'results[].matchedTerms.text[]',
+      'results[].matchedTerms.positivePrompt[]',
+      'results[].matchedTerms.negativePrompt[]',
+      'triggeredLabels[]',
+    ],
+    emitsMedia: false,
+    airBearingInput: false,
+    billingMode: null,
+  },
+  echo: {
+    // Caller text straight back out. Classified `echoedInput` rather than
+    // `generatedText` because that is what it IS — but note
+    // `postureForTextSurface` gives the two the SAME answer, deliberately.
+    textSurface: 'echoedInput',
+    textFields: ['message'],
+    emitsMedia: false,
+    airBearingInput: false,
+    billingMode: null,
+  },
+
+  // ── UNDECIDED — a domain owner must rule before these are submittable ──────
+  // Each was named as an uncovered candidate by `index.ts` itself, or found by
+  // this enumeration. They are NOT classified `'none'` (that would license
+  // them) and NOT classified `'generatedText'` (that would assert a policy
+  // nobody has set). They fail closed.
+  imageResourceTraining: {
+    // `sampleImagesPrompts[]` are the user's OWN prompts echoed back — the same
+    // rationale `index.ts` uses to list `echo`, which it flags as "a live
+    // inconsistency". This row records the inconsistency rather than resolving
+    // it by fiat.
+    //
+    // 🔴 ONLY `sampleImagesPrompts[]` IS TEXT. The sibling string arrays
+    // `epochs[].sampleImages[]` and `sampleInputImages[]` are BLOB NAMES per
+    // their generated doc comments ("the names of the blobs that represent
+    // sample images"), not prose — listing them here would overstate the
+    // surface, and an over-broad `textFields` is how a reviewer stops trusting
+    // the column.
+    textSurface: 'undecidedNeedsDomainOwner',
+    textFields: ['sampleImagesPrompts[]'],
+    emitsMedia: true,
+    airBearingInput: true, // `model` — "The primary model to train upon."
+    billingMode: null,
+  },
+  mediaRating: {
+    textSurface: 'undecidedNeedsDomainOwner',
+    textFields: ['blockedReason', 'labels[]', 'ageClassification.error'],
+    emitsMedia: false,
+    airBearingInput: false,
+    billingMode: null,
+  },
+  modelParseMetadata: {
+    // 🔴 THE `__metadata__` JSON header OF A USER-UPLOADED SAFETENSORS. Wholly
+    // attacker-controlled text, from a file the uploader chose, surfaced as one
+    // string.
+    textSurface: 'undecidedNeedsDomainOwner',
+    textFields: ['metadata'],
+    emitsMedia: false,
+    airBearingInput: true, // `model` — "The AIR of the model file to read metadata from."
+    billingMode: null,
+  },
+  modelClamScan: {
+    textSurface: 'undecidedNeedsDomainOwner',
+    textFields: ['output'],
+    emitsMedia: false,
+    airBearingInput: true,
+    billingMode: null,
+  },
+  modelPickleScan: {
+    // `globalImports` / `dangerousImports` are Python import paths read out of a
+    // user-uploaded pickle — attacker-chosen strings, published verbatim.
+    textSurface: 'undecidedNeedsDomainOwner',
+    textFields: ['output', 'skipReason', 'globalImports[]', 'dangerousImports[]'],
+    emitsMedia: false,
+    airBearingInput: true,
+    billingMode: null,
+  },
+  qwenImageBench: {
+    // 🔴 TWO error surfaces, not one: a per-item `error` AND an `errors` MAP
+    // keyed by benchmark dimension. `index.ts` names only "`qwenImageBench.errors`";
+    // the map's VALUES are the strings, and the scalar `error` is a separate
+    // field. Both are recorded because an extractor written from the registry's
+    // wording would miss one of them.
+    textSurface: 'undecidedNeedsDomainOwner',
+    textFields: ['results[].error', 'results[].errors[]', 'results[].scores[].name'],
+    emitsMedia: false,
+    airBearingInput: true, // `model` — "The AIR model to use for the benchmark judge."
+    billingMode: null,
+  },
+  imageGen: {
+    // 🔴 NOT NAMED BY `index.ts`. `errors[]` is "An optional list of errors
+    // related to generation failures" — free-form provider strings on an
+    // otherwise media-only type.
+    textSurface: 'undecidedNeedsDomainOwner',
+    textFields: ['errors[]'],
+    emitsMedia: true,
+    airBearingInput: false,
+    billingMode: null,
+  },
+  ageClassification: {
+    // `labels[<imageKey>][].age` — a classifier label ("adult"/"child"), i.e. a
+    // bounded vocabulary rather than prose. Classified UNDECIDED not because the
+    // string is free-form but because publishing per-image age classifications
+    // to an app is a disclosure question, which is a domain owner's to answer.
+    textSurface: 'undecidedNeedsDomainOwner',
+    textFields: ['labels[][].age'],
+    emitsMedia: false,
+    airBearingInput: true,
+    billingMode: null,
+  },
+
+  // ── NO FREE-TEXT OUTPUT ───────────────────────────────────────────────────
+  // Structural strings only (blob urls, expiry timestamps, ids, hashes, format
+  // enums). Each was checked against its enumerated field list; the paths are
+  // recorded as empty because `textFields` means FREE TEXT, not "strings".
+  convertImage: {
+    textSurface: 'none',
+    textFields: [],
+    emitsMedia: true,
+    airBearingInput: false,
+    // 🔴 THE ONE EVIDENCED BILLING MODE, and the evidence is the shipped
+    // registry entry: `convert-image.step.ts` declares `prepaidFixed`, and the
+    // registry's clause-6 load-time invariant proves price and estimate agree
+    // for every variant. This row therefore agrees with a value that is already
+    // enforced elsewhere rather than asserting a new one.
+    billingMode: 'prepaidFixed',
+  },
+  aceStepAudio: {
+    textSurface: 'none',
+    textFields: [],
+    emitsMedia: true,
+    airBearingInput: true,
+    billingMode: null,
+  },
+  blobArchive: {
+    textSurface: 'none',
+    textFields: [],
+    emitsMedia: true,
+    airBearingInput: false,
+    billingMode: null,
+  },
+  comfy: {
+    textSurface: 'none',
+    textFields: [],
+    emitsMedia: true,
+    airBearingInput: false,
+    billingMode: null,
+  },
+  comfyNodepackSnapshot: {
+    // `nodepack` / `layerAir` are AIRs, not prose — structural identifiers.
+    textSurface: 'none',
+    textFields: [],
+    emitsMedia: false,
+    airBearingInput: true,
+    billingMode: null,
+  },
+  composeMedia: {
+    textSurface: 'none',
+    textFields: [],
+    emitsMedia: true,
+    airBearingInput: false,
+    billingMode: null,
+  },
+  customComfy: {
+    textSurface: 'none',
+    textFields: [],
+    emitsMedia: true,
+    airBearingInput: true,
+    billingMode: null,
+  },
+  imageBackgroundRemoval: {
+    textSurface: 'none',
+    textFields: [],
+    emitsMedia: true,
+    airBearingInput: false,
+    billingMode: null,
+  },
+  imageToSvg: {
+    textSurface: 'none',
+    textFields: [],
+    emitsMedia: true,
+    airBearingInput: false,
+    billingMode: null,
+  },
+  imageUpload: {
+    textSurface: 'none',
+    textFields: [],
+    emitsMedia: true,
+    airBearingInput: false,
+    billingMode: null,
+  },
+  imageUpscaler: {
+    textSurface: 'none',
+    textFields: [],
+    emitsMedia: true,
+    // The named bypass case in `index.ts`: `model` takes an arbitrary AIR URN.
+    airBearingInput: true,
+    billingMode: null,
+  },
+  mediaHash: {
+    textSurface: 'none',
+    textFields: [],
+    emitsMedia: false,
+    airBearingInput: false,
+    billingMode: null,
+  },
+  model3DPreview: {
+    textSurface: 'none',
+    textFields: [],
+    emitsMedia: true,
+    airBearingInput: true,
+    billingMode: null,
+  },
+  modelHash: {
+    textSurface: 'none',
+    textFields: [],
+    emitsMedia: false,
+    airBearingInput: true,
+    billingMode: null,
+  },
+  polyGen: {
+    textSurface: 'none',
+    textFields: [],
+    emitsMedia: true,
+    airBearingInput: false,
+    billingMode: null,
+  },
+  preprocessImage: {
+    textSurface: 'none',
+    textFields: [],
+    emitsMedia: true,
+    airBearingInput: false,
+    billingMode: null,
+  },
+  textToImage: {
+    textSurface: 'none',
+    textFields: [],
+    emitsMedia: true,
+    airBearingInput: true,
+    billingMode: null,
+  },
+  textToSpeech: {
+    // `modelType` / `speaker` are bounded labels ("base" | "custom_voice", a
+    // speaker name), not free text. The FREE-TEXT INPUT axis of this type is a
+    // separate, still-open question `index.ts` documents at length.
+    textSurface: 'none',
+    textFields: [],
+    emitsMedia: true,
+    airBearingInput: false,
+    billingMode: null,
+  },
+  training: {
+    textSurface: 'none',
+    textFields: [],
+    emitsMedia: true,
+    airBearingInput: true,
+    billingMode: null,
+  },
+  transcode: {
+    textSurface: 'none',
+    textFields: [],
+    emitsMedia: true,
+    airBearingInput: false,
+    billingMode: null,
+  },
+  videoBackgroundRemoval: {
+    textSurface: 'none',
+    textFields: [],
+    emitsMedia: true,
+    airBearingInput: false,
+    billingMode: null,
+  },
+  videoEnhancement: {
+    textSurface: 'none',
+    textFields: [],
+    emitsMedia: true,
+    airBearingInput: true,
+    billingMode: null,
+  },
+  videoFrameExtraction: {
+    textSurface: 'none',
+    textFields: [],
+    emitsMedia: true,
+    airBearingInput: false,
+    billingMode: null,
+  },
+  videoGen: {
+    textSurface: 'none',
+    textFields: [],
+    emitsMedia: true,
+    airBearingInput: false,
+    billingMode: null,
+  },
+  videoInterpolation: {
+    textSurface: 'none',
+    textFields: [],
+    emitsMedia: true,
+    airBearingInput: true,
+    billingMode: null,
+  },
+  videoMetadata: {
+    textSurface: 'none',
+    textFields: [],
+    emitsMedia: false,
+    airBearingInput: false,
+    billingMode: null,
+  },
+  videoUpscaler: {
+    textSurface: 'none',
+    textFields: [],
+    emitsMedia: true,
+    airBearingInput: false,
+    billingMode: null,
+  },
+  wdTagging: {
+    textSurface: 'none',
+    textFields: [],
+    emitsMedia: false,
+    airBearingInput: true,
+    billingMode: null,
+  },
+} satisfies Record<string, StepTypePolicy>;
+
+/**
+ * The policy table, frozen and NULL-PROTOTYPED.
+ *
+ * 🔴 THE NULL PROTOTYPE IS A CONTROL, NOT A STYLE CHOICE, and this module is
+ * exactly where it matters: the key is the `$type` an UNTRUSTED app submitted.
+ * On a plain object literal, `lookupStepTypePolicy('toString')` returns
+ * `Object.prototype.toString` — TRUTHY — so every `if (!policy) reject` guard
+ * below would evaluate `false` and the submit would proceed with a "policy" that
+ * is a function. That is the fail-OPEN inversion, reachable by a chosen input,
+ * and it is the same defect this codebase already fixed twice (the registry's
+ * `STEP_TYPE_ACCEPTABLE_POSTURES`, and `./moderation`'s handler table). With a
+ * null prototype every non-own key reads `undefined` and every guard fails
+ * closed.
+ *
+ * Frozen at BOTH levels for the same reason the registry freezes its map: a
+ * shallow freeze leaves each row mutable, and `readonly` is a compile-time
+ * fiction a runtime assignment walks straight through.
+ */
+export const STEP_TYPE_POLICY: Readonly<Record<string, StepTypePolicy>> = Object.freeze(
+  Object.assign(
+    Object.create(null) as Record<string, StepTypePolicy>,
+    Object.fromEntries(
+      Object.entries(STEP_TYPE_POLICY_TABLE).map(([type, policy]) => [
+        type,
+        Object.freeze({ ...policy, textFields: Object.freeze([...policy.textFields]) }),
+      ])
+    )
+  )
+);
+
+/** The `$type` values this module has a policy row for. */
+export const POLICIED_STEP_TYPES: readonly string[] = Object.freeze(
+  Object.keys(STEP_TYPE_POLICY_TABLE)
+);
+
+/**
+ * The policy for a submitted `$type`, or `undefined` when there is none.
+ *
+ * 🔴 `undefined` MEANS "REJECT", NEVER "UNCONSTRAINED". That is the inversion of
+ * the registry's `acceptablePosturesFor`, which returns `undefined` for "no
+ * declared constraint — every posture is acceptable". That reading is correct
+ * THERE (the population is a reviewed registry, so an unlisted type still went
+ * through review) and would be catastrophic HERE (the population is whatever an
+ * untrusted app sends). Callers below encode the reject; this accessor is
+ * deliberately the only place the raw `undefined` is visible.
+ */
+export function lookupStepTypePolicy(orchestratorType: string): StepTypePolicy | undefined {
+  return STEP_TYPE_POLICY[orchestratorType];
+}
+
+/**
+ * A fail-closed decision. `ok: false` carries a `code` a caller can branch on
+ * and a `reason` safe to surface.
+ *
+ * 🔴 THE MESSAGE REACHES THE UNTRUSTED IFRAME. `trpc.ts`'s `errorFormatter` is
+ * pass-through, so every `reason` below is echoed to the app's own JS. They name
+ * the `$type` the app itself sent and the policy class — never an internal
+ * allowlist, a model id, or another app's data.
+ */
+export type PolicyDecision<T> =
+  | { ok: true; value: T }
+  | { ok: false; code: PolicyRejectionCode; reason: string };
+
+export type PolicyRejectionCode =
+  /** No policy row for the submitted `$type`. */
+  | 'unknownStepType'
+  /** The row exists but its classification is an open domain-owner question. */
+  | 'undecidedTextSurface'
+  /** The submitted input carries an AIR and the type has no entitlement gate. */
+  | 'unentitledResourceReference'
+  /** No billing mode is established for the type. */
+  | 'billingModeNotEstablished';
+
+/**
+ * The moderation posture REQUIRED for a text surface, or `null` when the surface
+ * is not one this host is prepared to publish.
+ *
+ * 🔴 `'echoedInput'` AND `'generatedText'` GET THE SAME ANSWER, AND THAT IS A
+ * DELIBERATE COST. It is defensible to argue an echoed surface is fully covered
+ * by auditing the input — for `echo` the output IS the input. `index.ts` already
+ * considered exactly this for `echo` and chose the conservative answer, because
+ * the relaxation asserts that auditing input suffices for a text-EMITTING step,
+ * which is a subsumption judgment the posture model declines to make anywhere
+ * else. Making the same choice here keeps the two layers consistent; changing it
+ * is a policy decision and should change both.
+ */
+export function postureForTextSurface(surface: StepTextSurface): StepModerationPosture | null {
+  switch (surface) {
+    case 'none':
+      return 'none';
+    case 'generatedText':
+    case 'echoedInput':
+      return 'textOutput';
+    case 'undecidedNeedsDomainOwner':
+      // 🔴 NOT A POSTURE. Returning `'none'` here would license the surface;
+      // returning `'textOutput'` would assert the scan is the right answer for
+      // a raw ClamAV dump or a safetensors header. Both are decisions this
+      // module is not entitled to make, so it makes neither.
+      return null;
+  }
+}
+
+/**
+ * GUARD 1 — MODERATION POSTURE, derived from the SUBMITTED `$type`.
+ *
+ * Re-homes `ACCEPTABLE_POSTURES_BY_TYPE` from a registration-time check of an
+ * entry's DECLARATION to a request-time lookup on what was actually sent.
+ *
+ * FAILS CLOSED on an unlisted `$type` and on an undecided classification.
+ */
+export function requiredPostureForSubmittedType(
+  orchestratorType: string
+): PolicyDecision<StepModerationPosture> {
+  const policy = lookupStepTypePolicy(orchestratorType);
+  if (!policy) {
+    return {
+      ok: false,
+      code: 'unknownStepType',
+      reason:
+        `orchestrator step type '${orchestratorType}' has no declared moderation policy — ` +
+        'a step type must be classified before an app may submit it, so the request is ' +
+        'rejected rather than submitted with no posture',
+    };
+  }
+  const posture = postureForTextSurface(policy.textSurface);
+  if (posture === null) {
+    return {
+      ok: false,
+      code: 'undecidedTextSurface',
+      reason:
+        `orchestrator step type '${orchestratorType}' carries an output text surface whose ` +
+        'moderation treatment is an open policy question — the request is rejected rather ' +
+        'than publishing text under a guessed posture',
+    };
+  }
+  return { ok: true, value: posture };
+}
+
+/**
+ * GUARD 2 — RESOURCE / ENTITLEMENT POLICY, run on the APP-SUPPLIED step input.
+ *
+ * Re-homes the registry's `resourcePolicy` + clause-7 deep AIR scan. Under the
+ * registry the scan proved a DECLARATION ('none') was not a lie; here there is
+ * no declaration, so the scan IS the policy.
+ *
+ * 🔴 THE SCAN RUNS FOR EVERY `$type`, INCLUDING `airBearingInput: false` ONES.
+ * That flag describes the generated SCHEMA; what arrives at request time is a
+ * JSON object an app built, and an app is free to put a `urn:air:` string in a
+ * field the schema calls a caption. Gating the scan on the flag would trust the
+ * schema to constrain the payload, which is precisely the assumption the pivot
+ * removes.
+ *
+ * FAIL-CLOSED DIRECTION, stated honestly and unchanged from the router's
+ * existing re-assert: `containsAirReference` is a substring test for `urn:air:`
+ * anywhere in the input, so a value that merely EMBEDS that literal (a
+ * Civitai-hosted url whose path contains it) is rejected too. Refusing a
+ * pathological url costs one bounced request; forwarding an unentitled AIR costs
+ * the entitlement belt.
+ */
+export function screenSubmittedStepResources(submitted: {
+  orchestratorType: string;
+  input: unknown;
+}): PolicyDecision<'noResourceReference'> {
+  const policy = lookupStepTypePolicy(submitted.orchestratorType);
+  if (!policy) {
+    return {
+      ok: false,
+      code: 'unknownStepType',
+      reason:
+        `orchestrator step type '${submitted.orchestratorType}' has no declared resource ` +
+        'policy — the request is rejected rather than submitted with no entitlement gate',
+    };
+  }
+  // 🔴 THE SAME `containsAirReference` THE REGISTRY USES, imported rather than
+  // re-implemented. A second copy of a deep scan is a second thing to get wrong,
+  // and this one is on the entitlement path.
+  if (containsAirReference(submitted.input)) {
+    return {
+      ok: false,
+      code: 'unentitledResourceReference',
+      reason:
+        `the submitted '${submitted.orchestratorType}' step carries an AIR resource ` +
+        'reference, and no entitlement allowlist is implemented for app-composed steps — a ' +
+        'step that reaches an AIR resource bypasses the generation-graph entitlement belt',
+    };
+  }
+  return { ok: true, value: 'noResourceReference' };
+}
+
+/**
+ * GUARD 3 — BILLING MODE, derived from the SUBMITTED `$type`.
+ *
+ * Re-homes the registry's per-entry `billingMode` declaration. FAILS CLOSED on
+ * an unlisted type AND on a listed type whose mode is not established — the
+ * common case today, deliberately (see `StepTypePolicy.billingMode`).
+ */
+export function billingModeForSubmittedType(
+  orchestratorType: string
+): PolicyDecision<StepBillingMode> {
+  const policy = lookupStepTypePolicy(orchestratorType);
+  if (!policy) {
+    return {
+      ok: false,
+      code: 'unknownStepType',
+      reason:
+        `orchestrator step type '${orchestratorType}' has no declared billing mode — the ` +
+        'request is rejected rather than reserved against a guessed money path',
+    };
+  }
+  if (policy.billingMode === null) {
+    return {
+      ok: false,
+      code: 'billingModeNotEstablished',
+      reason:
+        `orchestrator step type '${orchestratorType}' has no established billing mode — ` +
+        'estimate, reservation and settle all dispatch on it, so the request is rejected ' +
+        'rather than riding another mode’s reservation logic',
+    };
+  }
+  return { ok: true, value: policy.billingMode };
+}
+
+/** Everything the three guards decided for one submitted step. */
+export type SubmittedStepDecision = {
+  orchestratorType: string;
+  posture: StepModerationPosture;
+  billingMode: StepBillingMode;
+  policy: StepTypePolicy;
+};
+
+/**
+ * THE COMPOSITE GATE — all three guards, in the order a submit path wants them.
+ *
+ * 🔴 ORDER IS CHOSEN, NOT INCIDENTAL. Posture first (it rejects the widest class
+ * and its message is the most actionable), then resources (a cheap pure scan),
+ * then billing. Every one of them must pass; there is no partial success. A
+ * caller that wants a single call is expected to use this rather than
+ * re-composing the three, because re-composing is where a caller forgets one.
+ *
+ * 🔴 PURE AND SYNCHRONOUS. It performs no IO and reads no session — it is a
+ * function of the submitted `$type` and `input` only. That is what makes it
+ * unit-testable without a request context, and what lets the registry path call
+ * it at module load.
+ */
+export function evaluateSubmittedStep(submitted: {
+  orchestratorType: string;
+  input: unknown;
+}): PolicyDecision<SubmittedStepDecision> {
+  const posture = requiredPostureForSubmittedType(submitted.orchestratorType);
+  if (!posture.ok) return posture;
+
+  const resources = screenSubmittedStepResources(submitted);
+  if (!resources.ok) return resources;
+
+  const billing = billingModeForSubmittedType(submitted.orchestratorType);
+  if (!billing.ok) return billing;
+
+  // `lookupStepTypePolicy` cannot be `undefined` here — all three guards above
+  // return `unknownStepType` first. Re-read rather than threaded through so
+  // there is one lookup site per guard and no shared mutable state.
+  const policy = lookupStepTypePolicy(submitted.orchestratorType) as StepTypePolicy;
+  return {
+    ok: true,
+    value: {
+      orchestratorType: submitted.orchestratorType,
+      posture: posture.value,
+      billingMode: billing.value,
+      policy,
+    },
+  };
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// WIRING INTO THE CURRENT REGISTRY PATH — so this module is EXERCISED, not dead
+// code waiting for a widening that has not shipped.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Cross-check a REGISTERED entry's declarations against the request-time policy
+ * derived for the `$type` it submits.
+ *
+ * 🔴 WHAT THIS BUYS, STATED NARROWLY. It does NOT re-enforce the registry's
+ * clauses; those still run and still fail at load. It pins the two layers to
+ * ONE answer, so the request-time table cannot quietly drift away from the
+ * declarations the registry is enforcing — which is the failure mode a
+ * parallel policy table has. When the pivot removes the declarations, this
+ * function's callers disappear and the table it validates becomes the only
+ * copy; until then it is the thing keeping them honest.
+ *
+ * Deliberately takes the three fields rather than an `AnyBlockStep`, so a test
+ * can drive it with a fixture that no registry entry could legally hold.
+ */
+export function assertRegistryEntryAgreesWithPolicy(entry: {
+  id: string;
+  orchestratorType: string;
+  moderationPosture: StepModerationPosture;
+  billingMode: StepBillingMode;
+}): void {
+  const where = `block step '${entry.id}'`;
+  const posture = requiredPostureForSubmittedType(entry.orchestratorType);
+  if (!posture.ok) {
+    throw new Error(
+      `${where}: orchestratorType '${entry.orchestratorType}' has no request-time policy row ` +
+        `(${posture.code}) — a registered entry must be submittable under the same policy that ` +
+        'will govern app-composed steps, or the two layers disagree about the same $type'
+    );
+  }
+  if (posture.value !== entry.moderationPosture) {
+    throw new Error(
+      `${where}: declares moderationPosture '${entry.moderationPosture}' but the request-time ` +
+        `policy for '${entry.orchestratorType}' requires '${posture.value}' — the registry and ` +
+        'the request-time gate would treat the same $type differently'
+    );
+  }
+  const billing = billingModeForSubmittedType(entry.orchestratorType);
+  // 🔴 A `billingModeNotEstablished` row is NOT a failure here, and that
+  // asymmetry is deliberate. The registry's own clause 10 already proves the
+  // entry's mode has an implemented money-path handler; this table's `null`
+  // means "not established for APP-COMPOSED submission", which is a stricter
+  // question with a different answer. Failing on it would block the shipped
+  // `convert-image` entry for having a mode the pivot has not yet ratified.
+  // Only a CONTRADICTION — both sides state a mode and they differ — is an
+  // error.
+  if (billing.ok && billing.value !== entry.billingMode) {
+    throw new Error(
+      `${where}: declares billingMode '${entry.billingMode}' but the request-time policy for ` +
+        `'${entry.orchestratorType}' establishes '${billing.value}' — estimate, reservation and ` +
+        'settle dispatch on this value, so two answers is a money-path ambiguity'
+    );
+  }
+}
+
+/**
+ * Cross-check this module's derived postures against the registry's own
+ * `$type` → acceptable-postures map, for every `$type` BOTH cover.
+ *
+ * 🔴 WHY A SEPARATE ASSERT. `assertRegistryEntryAgreesWithPolicy` only sees
+ * `$type`s that a registered ENTRY claims — exactly one today (`convertImage`).
+ * The registry's map licenses seven `$type`s no entry has yet claimed, and those
+ * seven are the ones this module's classification is most likely to get wrong.
+ * This walks that whole map instead, so the agreement is checked over the
+ * population that matters rather than over the single shipped entry.
+ *
+ * Takes the map as an argument so a test can drive it with a DISAGREEING
+ * fixture — a guard only exercised by the shipped constant is a guard nobody has
+ * seen fail.
+ */
+export function assertPolicyAgreesWithRegistryMap(
+  registryMap: Readonly<Record<string, readonly StepModerationPosture[]>>
+): void {
+  for (const [orchestratorType, acceptable] of Object.entries(registryMap)) {
+    const derived = requiredPostureForSubmittedType(orchestratorType);
+    if (!derived.ok) {
+      throw new Error(
+        `request-time policy: the registry licenses postures for '${orchestratorType}' but this ` +
+          `module derives none (${derived.code}) — the two layers disagree about whether that ` +
+          '$type may be submitted at all'
+      );
+    }
+    if (!acceptable.includes(derived.value)) {
+      throw new Error(
+        `request-time policy: derives posture '${derived.value}' for '${orchestratorType}', but ` +
+          `the registry accepts only ${acceptable.map((p) => `'${p}'`).join(' or ')} — a ` +
+          'registered entry and an app-composed step would be moderated differently'
+      );
+    }
+  }
+}

--- a/src/server/services/blocks/steps/request-time-policy.ts
+++ b/src/server/services/blocks/steps/request-time-policy.ts
@@ -51,6 +51,24 @@ import { containsAirReference } from './index';
 //      drops out of the population entirely — again fail-open. Resolution is
 //      case-insensitive.
 //
+//   3. 🔴 A ONE-LEVEL WALK OF THE DECLARED `<Name>Output` IS NOT THE POPULATION.
+//      Three generated types EXTEND another output with an intersection, and a
+//      walk that stops at the declared type reports "clean" for all three:
+//        - `AudioComposeMediaOutput = Omit<ComposeMediaOutput,'type'> & { audioBlob: AudioBlob; … }`
+//        - `VideoComposeMediaOutput = Omit<ComposeMediaOutput,'type'> & { videoBlob: VideoBlob; … }`
+//        - `HaiperVideoGenOutput = VideoGenOutput & { …; externalTOSViolation?; message?: null | string }`
+//      `ComposeMediaOutput`'s own doc says the runtime value IS one of the first
+//      two, discriminated on `type`; `composeMedia` therefore reaches a
+//      `blockedReason` that its declared type does not mention at all. The
+//      Haiper case is what reclassified the `videoGen` row (see it). Those three
+//      are the COMPLETE set of `*Output` intersection types in
+//      v0.2.0-beta.83 — enumerated over the generated file, not sampled.
+//
+// 🔴 THERE ARE TWO PROVENANCE COLUMNS, NOT ONE — `textFields` (text from outside
+// the platform's control) and `platformDiagnosticFields` (text the orchestrator
+// itself authored, i.e. `Blob.blockedReason`). See `StepTypePolicy` for why the
+// split exists and what it deliberately does NOT close.
+//
 // 43 `$type` values exist in the generated types; all 43 are covered below.
 // ─────────────────────────────────────────────────────────────────────────────
 
@@ -112,6 +130,52 @@ export type StepTypePolicy = {
    */
   textFields: readonly string[];
   /**
+   * 🔴 PLATFORM-AUTHORED DIAGNOSTIC STRINGS reachable in the output — today,
+   * every `Blob.blockedReason` the type can surface. Enumerated from the
+   * generated types exactly like `textFields`, and required on every row (`[]`
+   * when there are none) so it cannot be silently omitted.
+   *
+   * WHY THIS IS A SEPARATE COLUMN AND NOT PART OF `textFields`. Both columns
+   * record free text, but they answer different questions and a reviewer needs
+   * to be able to tell them apart at a glance:
+   *
+   *   - `textFields` is text whose CONTENT ORIGINATES OUTSIDE the platform's
+   *     control — a model's output, a caller's echo, a string lifted out of a
+   *     user-uploaded artifact, a third-party provider's message. It is what the
+   *     `textSurface` classification and its posture are ABOUT.
+   *   - This column is text the CIVITAI ORCHESTRATOR ITSELF authored. `Blob`'s
+   *     generated doc reads "Get an optional reason for why the blob was
+   *     blocked" — it is our own moderation pipeline explaining its own
+   *     decision, not a surface an app or a model can write into.
+   *
+   * 🔴 WHY THE COLUMN HAD TO EXIST AT ALL — AND WHAT IT DOES NOT FIX. Before it,
+   * 22 rows classified `textSurface: 'none'` / `textFields: []` — whose own
+   * definition is "structural strings (urls, ids, hashes) only" — each reached a
+   * `blockedReason?: null | string`. `convertImage.blob.blockedReason` is the
+   * plainest case. That made those rows SELF-CONTRADICTING, and in the
+   * fail-OPEN direction: the same class as the `TranscriptionOutput.text`
+   * near-miss recorded in the header above.
+   *
+   * This column makes the surface RECORDED. It does NOT scan it, and no posture
+   * covers it — the rows keep `textSurface: 'none'` deliberately, because the
+   * alternative considered was reclassifying all 22 to
+   * `undecidedNeedsDomainOwner`, which would make `convertImage` — the ONLY
+   * shipped registry entry — unsubmittable and take the capability down over a
+   * first-party moderation string. Naming the residue is the honest half of the
+   * fix; whether the host should scan, redact, or simply STRIP `blockedReason`
+   * at the output-extraction boundary (the cheap deterministic close, since no
+   * app has been promised the field) is a domain-owner call this module is not
+   * entitled to make silently.
+   *
+   * 🔴 IT IS ENUMERATED THROUGH INTERSECTION/EXTENSION TYPES, NOT A ONE-LEVEL
+   * WALK. `composeMedia`'s declared output is `ComposeMediaOutput`, which
+   * carries no blob at all — but its generated doc says the runtime value is
+   * discriminated on `type` into `AudioComposeMediaOutput` (`audioBlob`) or
+   * `VideoComposeMediaOutput` (`videoBlob`), both `Omit<ComposeMediaOutput,
+   * 'type'> & { … }`. A walk of the declared type alone reports "clean" for it.
+   */
+  platformDiagnosticFields: readonly string[];
+  /**
    * 🔴 TRUE when the `$type` can return MEDIA — including a type whose PRIMARY
    * surface is text. See `chatCompletion` below; this flag exists because of it.
    */
@@ -164,9 +228,13 @@ const STEP_TYPE_POLICY_TABLE = {
     textFields: [
       'choices[].message.content',
       'choices[].message.refusal',
+      // "Optional name for the participant" — a free string on the ASSISTANT
+      // message, so it is model-side output, not a role enum.
+      'choices[].message.name',
       'choices[].message.tool_calls[].function.arguments',
       'choices[].finishReason',
     ],
+    platformDiagnosticFields: [],
     // 🔴 THE CROSS-AXIS CASE, AND THE REASON `emitsMedia` EXISTS AT ALL.
     // `ChatCompletionInput.modalities` ("Output modalities the model should
     // produce. Defaults to text-only when omitted.") makes this `$type` return
@@ -194,6 +262,7 @@ const STEP_TYPE_POLICY_TABLE = {
   mediaCaptioning: {
     textSurface: 'generatedText',
     textFields: ['caption'],
+    platformDiagnosticFields: [],
     emitsMedia: false,
     airBearingInput: false,
     billingMode: null,
@@ -204,10 +273,19 @@ const STEP_TYPE_POLICY_TABLE = {
       'results[].text',
       'results[].caption',
       'results[].lyrics',
+      // 🔴 `bpm` AND `duration` ARE `null | string`, NOT NUMBERS. Every field on
+      // `AudioCaptioningOutputItem` is an unconstrained string with no doc
+      // comment, so there is no evidence these two are more bounded than
+      // `keyScale` / `timeSignature`, which the row already lists. Excluding
+      // them on the ASSUMPTION that a field named `bpm` holds a number is the
+      // name-heuristic mistake the header records.
+      'results[].bpm',
       'results[].keyScale',
       'results[].timeSignature',
+      'results[].duration',
       'results[].language',
     ],
+    platformDiagnosticFields: [],
     emitsMedia: false,
     airBearingInput: false,
     billingMode: null,
@@ -220,6 +298,7 @@ const STEP_TYPE_POLICY_TABLE = {
     // `extractText` contract makes "not returned" mean "not published", so the
     // safe reading is that BOTH must be returned or the capability is partial.
     textFields: ['text', 'timeStamps[].text'],
+    platformDiagnosticFields: [],
     emitsMedia: false,
     airBearingInput: false,
     billingMode: null,
@@ -232,6 +311,7 @@ const STEP_TYPE_POLICY_TABLE = {
       'recommendations[]',
       'issues[].description',
     ],
+    platformDiagnosticFields: [],
     emitsMedia: false,
     // `PromptEnhancementInput.images[]` are reference images, not AIRs.
     airBearingInput: false,
@@ -248,11 +328,21 @@ const STEP_TYPE_POLICY_TABLE = {
       'results[].modelReason',
       'results[].postprocess',
       'results[].error',
+      // 🔴 `topToken` AND `finishReason` ARE THE MODEL'S OWN OUTPUT, and both
+      // are plain `string` on `XGuardLabelResult` with no doc and no enum —
+      // `topToken` is literally the guard model's highest-probability token.
+      // Reading `finishReason` as a bounded enum is an assumption the generated
+      // type does not support.
+      'results[].topToken',
+      'results[].finishReason',
       'results[].matchedTerms.text[]',
       'results[].matchedTerms.positivePrompt[]',
       'results[].matchedTerms.negativePrompt[]',
+      // Caller-named custom signals echoed back on the moderation result.
+      'signalMetadata.customSignals[].name',
       'triggeredLabels[]',
     ],
+    platformDiagnosticFields: [],
     emitsMedia: false,
     airBearingInput: false,
     billingMode: null,
@@ -263,6 +353,7 @@ const STEP_TYPE_POLICY_TABLE = {
     // `postureForTextSurface` gives the two the SAME answer, deliberately.
     textSurface: 'echoedInput',
     textFields: ['message'],
+    platformDiagnosticFields: [],
     emitsMedia: false,
     airBearingInput: false,
     billingMode: null,
@@ -279,21 +370,58 @@ const STEP_TYPE_POLICY_TABLE = {
     // inconsistency". This row records the inconsistency rather than resolving
     // it by fiat.
     //
-    // 🔴 ONLY `sampleImagesPrompts[]` IS TEXT. The sibling string arrays
-    // `epochs[].sampleImages[]` and `sampleInputImages[]` are BLOB NAMES per
-    // their generated doc comments ("the names of the blobs that represent
-    // sample images"), not prose — listing them here would overstate the
-    // surface, and an over-broad `textFields` is how a reviewer stops trusting
-    // the column.
+    // 🔴 ONLY `sampleImagesPrompts[]` IS TEXT — but the two sibling string
+    // arrays are excluded on DIFFERENT evidence, and the earlier version of this
+    // comment cited one doc for both:
+    //
+    //   - `epochs[].sampleImages[]` is blob names, and its own generated doc
+    //     says so verbatim: "Get a list of the names of the blobs that represent
+    //     sample images".
+    //   - `sampleInputImages[]` has NO such doc. Its generated comment reads
+    //     only "The selected images for sample images" — which does not say
+    //     names, urls, or anything else. It is excluded because it is a
+    //     REFERENCE LIST (the images the user picked as training samples, echoed
+    //     back), not because a doc comment classified it. Under either reading —
+    //     blob names or urls — it is not prose.
+    //
+    // Listing either here would overstate the surface, and an over-broad
+    // `textFields` is how a reviewer stops trusting the column. Nothing is
+    // licensed by the distinction: this row is `undecidedNeedsDomainOwner`
+    // regardless.
     textSurface: 'undecidedNeedsDomainOwner',
     textFields: ['sampleImagesPrompts[]'],
+    platformDiagnosticFields: [],
     emitsMedia: true,
     airBearingInput: true, // `model` — "The primary model to train upon."
     billingMode: null,
   },
   mediaRating: {
+    // 🔴 `blockedReason` MOVED OUT OF `textFields` INTO
+    // `platformDiagnosticFields`, and that move is the whole reason the second
+    // column exists. This row was the ONLY place `blockedReason` was recorded as
+    // text, while the same field reached 22 rows classified `'none'` — one
+    // field, called text here and absent there. The row's classification is
+    // UNCHANGED and does not depend on the move: `labels[]` and
+    // `ageClassification.error` are model output and keep it undecided on their
+    // own.
+    //
+    // 🔴 THE FOUR CLASSIFIER LABELS ARE MODEL OUTPUT, NOT AN ENUM. All four are
+    // plain `string`, and `aiRecognition.label`'s own doc says it is "taken from
+    // the model's own id2label" — i.e. whatever labels the deployed checkpoint
+    // happens to define, which changes with the model and is not pinned by the
+    // generated type. The parenthesised examples in the other three docs
+    // ("adult"/"child"/"teen", "anime"/"real", "human"/"no_human") are EXAMPLES,
+    // and reading an example list as a closed set is the fail-open direction.
     textSurface: 'undecidedNeedsDomainOwner',
-    textFields: ['blockedReason', 'labels[]', 'ageClassification.error'],
+    textFields: [
+      'labels[]',
+      'ageClassification.detections[].ageLabel',
+      'ageClassification.error',
+      'aiRecognition.label',
+      'animeRecognition.label',
+      'humanRecognition.label',
+    ],
+    platformDiagnosticFields: ['blockedReason'],
     emitsMedia: false,
     airBearingInput: false,
     billingMode: null,
@@ -304,6 +432,7 @@ const STEP_TYPE_POLICY_TABLE = {
     // string.
     textSurface: 'undecidedNeedsDomainOwner',
     textFields: ['metadata'],
+    platformDiagnosticFields: [],
     emitsMedia: false,
     airBearingInput: true, // `model` — "The AIR of the model file to read metadata from."
     billingMode: null,
@@ -311,6 +440,7 @@ const STEP_TYPE_POLICY_TABLE = {
   modelClamScan: {
     textSurface: 'undecidedNeedsDomainOwner',
     textFields: ['output'],
+    platformDiagnosticFields: [],
     emitsMedia: false,
     airBearingInput: true,
     billingMode: null,
@@ -320,6 +450,7 @@ const STEP_TYPE_POLICY_TABLE = {
     // user-uploaded pickle — attacker-chosen strings, published verbatim.
     textSurface: 'undecidedNeedsDomainOwner',
     textFields: ['output', 'skipReason', 'globalImports[]', 'dangerousImports[]'],
+    platformDiagnosticFields: [],
     emitsMedia: false,
     airBearingInput: true,
     billingMode: null,
@@ -331,7 +462,13 @@ const STEP_TYPE_POLICY_TABLE = {
     // field. Both are recorded because an extractor written from the registry's
     // wording would miss one of them.
     textSurface: 'undecidedNeedsDomainOwner',
-    textFields: ['results[].error', 'results[].errors[]', 'results[].scores[].name'],
+    // 🔴 `scores[]` IS A TREE, NOT A LIST. `QwenImageBenchScoreNode` is
+    // `{ name: string; score?; children: Array<QwenImageBenchScoreNode> }` —
+    // self-referential, so `results[].scores[].name` names only the ROOT level
+    // and every nested `name` below it was uncounted. The `**` marks the
+    // recursive descent; there is no depth bound in the generated type.
+    textFields: ['results[].error', 'results[].errors[]', 'results[].scores[]**.name'],
+    platformDiagnosticFields: [],
     emitsMedia: false,
     airBearingInput: true, // `model` — "The AIR model to use for the benchmark judge."
     billingMode: null,
@@ -342,6 +479,7 @@ const STEP_TYPE_POLICY_TABLE = {
     // otherwise media-only type.
     textSurface: 'undecidedNeedsDomainOwner',
     textFields: ['errors[]'],
+    platformDiagnosticFields: ['images[].blockedReason'],
     emitsMedia: true,
     airBearingInput: false,
     billingMode: null,
@@ -353,6 +491,7 @@ const STEP_TYPE_POLICY_TABLE = {
     // to an app is a disclosure question, which is a domain owner's to answer.
     textSurface: 'undecidedNeedsDomainOwner',
     textFields: ['labels[][].age'],
+    platformDiagnosticFields: [],
     emitsMedia: false,
     airBearingInput: true,
     billingMode: null,
@@ -365,6 +504,7 @@ const STEP_TYPE_POLICY_TABLE = {
   convertImage: {
     textSurface: 'none',
     textFields: [],
+    platformDiagnosticFields: ['blob.blockedReason'],
     emitsMedia: true,
     airBearingInput: false,
     // 🔴 THE ONE EVIDENCED BILLING MODE, and the evidence is the shipped
@@ -377,6 +517,7 @@ const STEP_TYPE_POLICY_TABLE = {
   aceStepAudio: {
     textSurface: 'none',
     textFields: [],
+    platformDiagnosticFields: ['blob.blockedReason'],
     emitsMedia: true,
     airBearingInput: true,
     billingMode: null,
@@ -384,6 +525,7 @@ const STEP_TYPE_POLICY_TABLE = {
   blobArchive: {
     textSurface: 'none',
     textFields: [],
+    platformDiagnosticFields: [],
     emitsMedia: true,
     airBearingInput: false,
     billingMode: null,
@@ -391,6 +533,7 @@ const STEP_TYPE_POLICY_TABLE = {
   comfy: {
     textSurface: 'none',
     textFields: [],
+    platformDiagnosticFields: ['blobs[].blockedReason'],
     emitsMedia: true,
     airBearingInput: false,
     billingMode: null,
@@ -399,13 +542,27 @@ const STEP_TYPE_POLICY_TABLE = {
     // `nodepack` / `layerAir` are AIRs, not prose — structural identifiers.
     textSurface: 'none',
     textFields: [],
+    platformDiagnosticFields: [
+      'results[].layer.blockedReason',
+      'results[].objectInfo.blockedReason',
+      'results[].web.blockedReason',
+    ],
     emitsMedia: false,
     airBearingInput: true,
     billingMode: null,
   },
   composeMedia: {
+    // 🔴 THE DIAGNOSTIC PATHS BELOW EXIST ON NEITHER FIELD OF THE DECLARED
+    // OUTPUT TYPE. `ComposeMediaOutput` is `{ type; elements[] }` and reaches no
+    // `Blob` whatsoever — a walk of it alone says "clean". Its own generated doc
+    // says the runtime value is discriminated on `type` into
+    // `AudioComposeMediaOutput` (`audioBlob: AudioBlob`) or
+    // `VideoComposeMediaOutput` (`videoBlob: VideoBlob`), and both blobs carry
+    // `blockedReason`. Paths are given per-variant; exactly one is present on
+    // any given response.
     textSurface: 'none',
     textFields: [],
+    platformDiagnosticFields: ['audioBlob.blockedReason', 'videoBlob.blockedReason'],
     emitsMedia: true,
     airBearingInput: false,
     billingMode: null,
@@ -413,6 +570,7 @@ const STEP_TYPE_POLICY_TABLE = {
   customComfy: {
     textSurface: 'none',
     textFields: [],
+    platformDiagnosticFields: ['blobs[].blockedReason', 'tempBlobs[].blockedReason'],
     emitsMedia: true,
     airBearingInput: true,
     billingMode: null,
@@ -420,6 +578,7 @@ const STEP_TYPE_POLICY_TABLE = {
   imageBackgroundRemoval: {
     textSurface: 'none',
     textFields: [],
+    platformDiagnosticFields: ['image.blockedReason'],
     emitsMedia: true,
     airBearingInput: false,
     billingMode: null,
@@ -427,6 +586,7 @@ const STEP_TYPE_POLICY_TABLE = {
   imageToSvg: {
     textSurface: 'none',
     textFields: [],
+    platformDiagnosticFields: ['svg.blockedReason'],
     emitsMedia: true,
     airBearingInput: false,
     billingMode: null,
@@ -434,6 +594,7 @@ const STEP_TYPE_POLICY_TABLE = {
   imageUpload: {
     textSurface: 'none',
     textFields: [],
+    platformDiagnosticFields: ['blob.blockedReason'],
     emitsMedia: true,
     airBearingInput: false,
     billingMode: null,
@@ -441,6 +602,7 @@ const STEP_TYPE_POLICY_TABLE = {
   imageUpscaler: {
     textSurface: 'none',
     textFields: [],
+    platformDiagnosticFields: ['blob.blockedReason'],
     emitsMedia: true,
     // The named bypass case in `index.ts`: `model` takes an arbitrary AIR URN.
     airBearingInput: true,
@@ -449,6 +611,7 @@ const STEP_TYPE_POLICY_TABLE = {
   mediaHash: {
     textSurface: 'none',
     textFields: [],
+    platformDiagnosticFields: [],
     emitsMedia: false,
     airBearingInput: false,
     billingMode: null,
@@ -456,6 +619,7 @@ const STEP_TYPE_POLICY_TABLE = {
   model3DPreview: {
     textSurface: 'none',
     textFields: [],
+    platformDiagnosticFields: ['images[].blockedReason'],
     emitsMedia: true,
     airBearingInput: true,
     billingMode: null,
@@ -463,6 +627,7 @@ const STEP_TYPE_POLICY_TABLE = {
   modelHash: {
     textSurface: 'none',
     textFields: [],
+    platformDiagnosticFields: [],
     emitsMedia: false,
     airBearingInput: true,
     billingMode: null,
@@ -470,6 +635,21 @@ const STEP_TYPE_POLICY_TABLE = {
   polyGen: {
     textSurface: 'none',
     textFields: [],
+    platformDiagnosticFields: [
+      'model.blockedReason',
+      'fbxModel.blockedReason',
+      'thumbnail.blockedReason',
+      'riggedModel.blockedReason',
+      'riggedFbxModel.blockedReason',
+      'animatedModel.blockedReason',
+      'animatedFbxModel.blockedReason',
+      'basicAnimations.walkingModel.blockedReason',
+      'basicAnimations.walkingFbxModel.blockedReason',
+      'basicAnimations.walkingArmatureModel.blockedReason',
+      'basicAnimations.runningModel.blockedReason',
+      'basicAnimations.runningFbxModel.blockedReason',
+      'basicAnimations.runningArmatureModel.blockedReason',
+    ],
     emitsMedia: true,
     airBearingInput: false,
     billingMode: null,
@@ -477,6 +657,7 @@ const STEP_TYPE_POLICY_TABLE = {
   preprocessImage: {
     textSurface: 'none',
     textFields: [],
+    platformDiagnosticFields: ['blob.blockedReason'],
     emitsMedia: true,
     airBearingInput: false,
     billingMode: null,
@@ -484,6 +665,7 @@ const STEP_TYPE_POLICY_TABLE = {
   textToImage: {
     textSurface: 'none',
     textFields: [],
+    platformDiagnosticFields: ['images[].blockedReason'],
     emitsMedia: true,
     airBearingInput: true,
     billingMode: null,
@@ -494,6 +676,7 @@ const STEP_TYPE_POLICY_TABLE = {
     // separate, still-open question `index.ts` documents at length.
     textSurface: 'none',
     textFields: [],
+    platformDiagnosticFields: ['audioBlob.blockedReason'],
     emitsMedia: true,
     airBearingInput: false,
     billingMode: null,
@@ -501,6 +684,7 @@ const STEP_TYPE_POLICY_TABLE = {
   training: {
     textSurface: 'none',
     textFields: [],
+    platformDiagnosticFields: ['epochs[].model.blockedReason', 'epochs[].samples[].blockedReason'],
     emitsMedia: true,
     airBearingInput: true,
     billingMode: null,
@@ -508,6 +692,7 @@ const STEP_TYPE_POLICY_TABLE = {
   transcode: {
     textSurface: 'none',
     textFields: [],
+    platformDiagnosticFields: [],
     emitsMedia: true,
     airBearingInput: false,
     billingMode: null,
@@ -515,6 +700,7 @@ const STEP_TYPE_POLICY_TABLE = {
   videoBackgroundRemoval: {
     textSurface: 'none',
     textFields: [],
+    platformDiagnosticFields: ['video.blockedReason'],
     emitsMedia: true,
     airBearingInput: false,
     billingMode: null,
@@ -522,6 +708,7 @@ const STEP_TYPE_POLICY_TABLE = {
   videoEnhancement: {
     textSurface: 'none',
     textFields: [],
+    platformDiagnosticFields: ['video.blockedReason'],
     emitsMedia: true,
     airBearingInput: true,
     billingMode: null,
@@ -529,13 +716,39 @@ const STEP_TYPE_POLICY_TABLE = {
   videoFrameExtraction: {
     textSurface: 'none',
     textFields: [],
+    platformDiagnosticFields: ['frames[].blockedReason'],
     emitsMedia: true,
     airBearingInput: false,
     billingMode: null,
   },
   videoGen: {
-    textSurface: 'none',
-    textFields: [],
+    // 🔴 RECLASSIFIED FROM `'none'` — A THIRD-PARTY PROVIDER MESSAGE THAT A
+    // ONE-LEVEL WALK OF THE DECLARED OUTPUT TYPE CANNOT SEE.
+    //
+    // `VideoGenStep.output` is typed `VideoGenOutput`, which holds only
+    // `video` + `additionalVideos` and no text at all. But the generated types
+    // also declare
+    //   `HaiperVideoGenOutput = VideoGenOutput & { progress?; externalTOSViolation?; message?: null | string }`
+    // and its input sibling `HaiperVideoGenInput = Omit<VideoGenInput,'engine'>
+    // & { engine: 'haiper'; … }` — i.e. `videoGen` submitted with
+    // `engine: 'haiper'` is served by the Haiper provider, and `message`
+    // alongside `externalTOSViolation` is that provider's MODERATION EXPLANATION.
+    // Third-party free text, published verbatim: the same class as
+    // `modelClamScan`'s raw scanner output, which is already undecided.
+    //
+    // 🔴 HONEST LIMIT ON THE EVIDENCE. Unlike `composeMedia` — whose generated
+    // doc names its two runtime subtypes explicitly — nothing in the generated
+    // types wires `HaiperVideoGenOutput` into a union or a step declaration; it
+    // is referenced nowhere else in the file. The inference is from the
+    // engine-keyed input/output naming pair. That is why this row goes to
+    // `undecidedNeedsDomainOwner` (a refusal pending a ruling) rather than to
+    // `generatedText` (an assertion about what the scan should do to it).
+    //
+    // Costs nothing today: `convertImage` is the only registry entry, so no
+    // shipped capability submits `videoGen`.
+    textSurface: 'undecidedNeedsDomainOwner',
+    textFields: ['message'],
+    platformDiagnosticFields: ['video.blockedReason', 'additionalVideos[].blockedReason'],
     emitsMedia: true,
     airBearingInput: false,
     billingMode: null,
@@ -543,6 +756,7 @@ const STEP_TYPE_POLICY_TABLE = {
   videoInterpolation: {
     textSurface: 'none',
     textFields: [],
+    platformDiagnosticFields: ['video.blockedReason'],
     emitsMedia: true,
     airBearingInput: true,
     billingMode: null,
@@ -550,6 +764,7 @@ const STEP_TYPE_POLICY_TABLE = {
   videoMetadata: {
     textSurface: 'none',
     textFields: [],
+    platformDiagnosticFields: [],
     emitsMedia: false,
     airBearingInput: false,
     billingMode: null,
@@ -557,6 +772,7 @@ const STEP_TYPE_POLICY_TABLE = {
   videoUpscaler: {
     textSurface: 'none',
     textFields: [],
+    platformDiagnosticFields: ['video.blockedReason'],
     emitsMedia: true,
     airBearingInput: false,
     billingMode: null,
@@ -564,6 +780,7 @@ const STEP_TYPE_POLICY_TABLE = {
   wdTagging: {
     textSurface: 'none',
     textFields: [],
+    platformDiagnosticFields: [],
     emitsMedia: false,
     airBearingInput: true,
     billingMode: null,
@@ -594,7 +811,14 @@ export const STEP_TYPE_POLICY: Readonly<Record<string, StepTypePolicy>> = Object
     Object.fromEntries(
       Object.entries(STEP_TYPE_POLICY_TABLE).map(([type, policy]) => [
         type,
-        Object.freeze({ ...policy, textFields: Object.freeze([...policy.textFields]) }),
+        Object.freeze({
+          ...policy,
+          textFields: Object.freeze([...policy.textFields]),
+          // Both provenance columns are frozen. `Object.freeze` on the row is
+          // SHALLOW, so an array left unfrozen stays push-able through a frozen
+          // row — which is the same hole `textFields` was closed against.
+          platformDiagnosticFields: Object.freeze([...policy.platformDiagnosticFields]),
+        }),
       ])
     )
   )
@@ -728,6 +952,20 @@ export function requiredPostureForSubmittedType(
  * Civitai-hosted url whose path contains it) is rejected too. Refusing a
  * pathological url costs one bounced request; forwarding an unentitled AIR costs
  * the entitlement belt.
+ *
+ * 🔴 "ANYWHERE" INCLUDES OBJECT KEYS, and that had to be made true rather than
+ * merely asserted. The scan originally recursed over `Object.values` only, so
+ * `{ additionalNetworks: { 'urn:air:sd1:lora:civitai:1234@5678': { strength: 1 } } }`
+ * returned `noResourceReference` and the composite gate ACCEPTED it — which is
+ * not a hypothetical payload but the shape the orchestrator's own generated
+ * schema prescribes (`additionalNetworks` is documented "Use the AIR of the
+ * network as the key"; `WorkflowCost.fees` is keyed by resource AIR the same
+ * way). Fixed at the shared helper, which also strengthens the registry's
+ * load-time clause-7 probe that calls it.
+ *
+ * 🔴 IT IS ALSO TOTAL — it cannot throw. The scan carries a depth cap and
+ * returns "contains an AIR" (i.e. this rejection) when it is hit, so a deeply
+ * nested body is a decided rejection rather than an unhandled `RangeError`.
  */
 export function screenSubmittedStepResources(submitted: {
   orchestratorType: string;


### PR DESCRIPTION
## Why

The App Blocks → orchestrator-types pivot replaces the step-type registry: an app composes real orchestrator workflow steps and the host submits them. The registry's three guards — **moderation posture**, **resource/AIR entitlement**, **billing mode** — all fire at **registration** and all read a **declaration** off a registered entry.

Registration is exactly what disappears under the pivot. Without re-homing, the pivot trades three build-time guards for zero.

This lands the request-time enforcement core **ahead of** the surface widening, derived from the only inputs that survive: the **submitted `$type`** and the **`input` the app built**.

## What

`src/server/services/blocks/steps/request-time-policy.ts` — pure, synchronous, no IO, unit-testable without a request context.

| Guard | Function | Fails closed on |
|---|---|---|
| Moderation posture | `requiredPostureForSubmittedType` | unlisted `$type`; an unresolved policy question |
| Resource / entitlement | `screenSubmittedStepResources` | any `urn:air:` anywhere in the submitted input |
| Billing mode | `billingModeForSubmittedType` | unlisted `$type`; a type with no established mode |

Plus `evaluateSubmittedStep`, the composite gate in a fixed, tested order (posture → resources → billing).

**A `$type` with no policy row is not submittable.** That allowlist is the fail-closed mechanism, and it re-homes the reviewed-decision property registration used to provide.

### Not a wire-contract change

Nothing here widens what may be submitted today. `blockStepBodySchema`'s `step` enum is still derived from the registry keys and is still the gate. **No behaviour change for `textToImage` / `customComfy` / `convert-image`** — proven by the full blocks + schema + router suites staying green (3515 tests, 0 failures) and by the diff being additive-only.

### Wired in, not dead code

`./moderation` asserts at module load that:
1. every **registered entry's** declared posture/billing agrees with the derived policy for the `$type` it submits, and
2. every `$type` the registry's **own posture map** licenses derives a posture that map accepts — a wider population than (1), which sees only the one `$type` a registered entry currently claims.

Asserted there rather than in `./index` to avoid an import cycle between two modules that both run load-time invariants. This assert was mutation-proven **reachable**, not merely present.

## The `$type` enumeration

All **43** `$type` values the generated `@civitai/client` types declare (v0.2.0-beta.83) have a row. Enumerated from the **generated types**, not from `src/**` usage — usage enumerates what is *called*, not what *exists*.

Two methodological traps are recorded in the module header because both produce a **confident wrong answer** rather than an error:

- A **name-based** "structural string" filter dropped `TranscriptionOutput.text` ("The full transcribed text") because `text` ends in `ext`. A text surface filtered out reads as "produces no text" — the fail-**open** direction.
- `$type` → type-name casing is not plain capitalisation: `model3DPreview` → `Model3dPreviewOutput`. A naive lookup finds nothing and the type silently drops out of the population.

### Three findings the registry's own notes do not have

- 🔴 **`chatCompletion` is BOTH text-producing and media-emitting.** `modalities: ['image']` returns images on `choices[].message.images[].image_url.url`, so a purely text-posture treatment hands an app a media channel the text scan does not stand in front of. `index.ts` currently states *"Nothing in the currently-licensed `$type` set has that shape"* — that is **false** at this client version, and the registry's MEDIA-XOR-TEXT model cannot express this step at all.
- **`transcription` carries a second full copy of the transcript** on `timeStamps[].text`. An extractor returning only `text` leaves it unscanned.
- **`xGuardModeration` echoes caller text back** through `matchedTerms.*`, not just the `modelReason` the registry's note cites.

Separately: **17 of 43 types take an AIR or model reference on input**, a much wider entitlement surface than the single named `imageUpscaler` case.

## Open questions for a domain owner (deliberately not decided here)

Nine `$type`s are classified `undecidedNeedsDomainOwner` and are **not submittable** until someone rules. `undecidedNeedsDomainOwner` is a **refusal, not a classification** — guessing either way is a policy decision this module is not entitled to make.

The sharpest are the surfaces that lift text out of an **untrusted artifact**: `modelParseMetadata.metadata` (the `__metadata__` header of a user-uploaded safetensors) and `modelPickleScan.globalImports[]` / `dangerousImports[]` (Python import paths read out of a user-uploaded pickle) — attacker-chosen strings that would be published verbatim.

**Billing mode is `null` for 42 of 43 rows, and that is the honest state.** Deriving a mode needs the orchestrator's rate card, which is not in this repo and was not measured. Only `convertImage` carries a value, and only because the shipped registry entry already declares and enforces it.

## Verification

- **45 new tests.** 3515 tests / 153 files green across blocks + schema + routers, exit 0, no timeout truncation.
- **Harness validated in both directions before any green was trusted** — a deliberate failing probe reported `1 failed | 1 passed`.
- **7 mutations, all killed**, each on its own guard's specific error: dropped policy row · `chatCompletion` reclassified · undecided-fails-open · null prototype removed · AIR scan gated on the advisory flag · billing default · table unfrozen.
- The coverage test reads the generated `.d.ts` **at test time**, so it is a real drift guard against a regenerated client rather than a copy of the table checked against the table. It has a **positive control** (the reassuring answer is a zero, and a zero is indistinguishable from a scan wired to nothing).
- **Typecheck: 134 errors on branch, 134 on the pristine `origin/main` baseline, 0 in the new files.** `main` is red repo-wide from an unrelated `feat/db-queries-kysely` merge; attribution is base-vs-head, not head alone.

## What I could not verify

- The billing-mode mapping for the other 42 types — needs the rate card.
- The nine `undecided` classifications are *classifications*, not decisions; they need a domain owner.
- Runtime behaviour of the guards against a live orchestrator submit: nothing calls them on the request path yet, by design — that lands with the surface widening.
