### PR TITLE
test(user-settings): pin the SQL shape setUserSetting emits, not just where values land

### DIFF
--- a/src/server/services/__tests__/set-user-setting.sql.service.test.ts
+++ b/src/server/services/__tests__/set-user-setting.sql.service.test.ts
@@ -18,6 +18,12 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 // Both statements are now parameterised tagged templates, so values are bound rather
 // than pasted into the statement text. These tests assert exactly that: user data must
 // appear in the bound values and never in the statement text.
+//
+// Where a value lives is only half of it, though. A statement can bind every value
+// correctly and still be rejected by Postgres if the operator, the cast, or the
+// placeholder's position is wrong — and an assertion that only reads `values`, or only
+// asserts a negative on the text, cannot see that. So each statement additionally pins
+// the shape it emits.
 
 const { statements, mockDb } = vi.hoisted(() => {
   const statements: { text: string; values: unknown[] }[] = [];
@@ -143,6 +149,18 @@ describe('setUserSetting — the merge statement', () => {
     expect(merge.text).toContain('||');
     expect(merge.values).toContainEqual(JSON.stringify({ allowAds: true }));
   });
+
+  // The payload has to sit next to the cast as a bare `$N`. Re-wrapping it in quotes
+  // (`'$N'::jsonb`) still binds the value, so every values-based assertion above stays
+  // green — but Postgres then casts the literal two-character text `$N` and rejects it.
+  // That is the original defect in a new costume, so pin the emitted shape too.
+  it('places the payload beside the jsonb cast as a bare placeholder', async () => {
+    await setUserSetting(USER_ID, { allowAds: true });
+
+    const [merge] = statements;
+    expect(merge.text).toMatch(/\|\|\s*\$\d+::jsonb/);
+    expect(merge.text).not.toMatch(/'\$\d+'/);
+  });
 });
 
 describe('setUserSetting — the key-removal statement', () => {
@@ -179,5 +197,27 @@ describe('setUserSetting — the key-removal statement', () => {
     await setUserSetting(USER_ID, { allowAds: true });
 
     expect(statements).toHaveLength(1);
+  });
+
+  // `jsonb - text[]` is the only form that accepts a bound array of key names; any other
+  // cast on that operand is rejected outright. The assertions above read `values` or
+  // assert a negative on the text, so a wrong cast would leave all of them green.
+  it('casts the bound key array to text[]', async () => {
+    await setUserSetting(USER_ID, { allowAds: true, hideDonationGoals: undefined });
+
+    const removal = statements[1];
+    expect(removal.text).toContain('::text[]');
+    expect(removal.text).toMatch(/\$\d+::text\[\]/);
+  });
+
+  // Delete, not merge. Swapping `-` for `||` is both an operator Postgres has no
+  // definition for at these operand types and the opposite meaning from the one this
+  // branch exists to express — and nothing above would notice the swap.
+  it('subtracts the key array from settings rather than concatenating it', async () => {
+    await setUserSetting(USER_ID, { allowAds: true, hideDonationGoals: undefined });
+
+    const removal = statements[1];
+    expect(removal.text).toMatch(/settings\s*-\s*\$\d+::text\[\]/);
+    expect(removal.text).not.toContain('||');
   });
 });


### PR DESCRIPTION
The seven existing tests in `set-user-setting.sql.service.test.ts` assert that user data reaches the database as a bound parameter and never appears in the statement text. That property is the reason the file exists, and it holds. But it says nothing about whether the statement *around* those parameters is well-formed — so a wrong operator or a wrong cast would ship green.

Every key-removal assertion reads `values`, or asserts a negative on the text (`not.toContain('}')`). Nothing pins the operator, the cast, or the merge placeholder's position.

## What survives the suite today

Three edits to `setUserSetting` leave **all seven tests green** while making the statement fail outright at the database. Measured, not assumed — each was applied, run, and reverted:

| edit to `user.service.ts` | result at the database | current suite |
|---|---|---|
| removal operand `::text[]` → `::jsonb` | `cannot cast type text[] to jsonb` | 7 passed (7) |
| removal `settings - $1` → `settings \|\| $1` | `operator does not exist` — and the opposite meaning | 7 passed (7) |
| merge payload re-wrapped as `'$1'::jsonb` | `invalid input syntax for type json` | 7 passed (7) |

The third is the original defect in a new costume: it still binds the value, so every values-based assertion stays green, but Postgres casts the literal two characters `$1`.

## What this adds

Three tests that pin the emitted shape rather than only where the value lands:

- `places the payload beside the jsonb cast as a bare placeholder`
- `casts the bound key array to text[]`
- `subtracts the key array from settings rather than concatenating it`

## Measured matrix

All runs in a clean worktree off `origin/main`, target suite counted per test.

| state | target suite |
|---|---|
| clean `origin/main` (before) | 7 passed (7) |
| clean `origin/main` (after) | **10 passed (10)** |
| `::jsonb` cast | 2 failed \| 8 passed — both removal-shape tests, each on its own assertion's message |
| `\|\|` operator | 1 failed \| 9 passed — the subtract test |
| quoted merge payload | 1 failed \| 9 passed — the merge-placeholder test |

Harness was validated against a known-bad first (breaking `COALESCE(settings` → 1 failed \| 6 passed, 7 tests still collected) so a zero-collection result could not be mistaken for a kill.

A fourth edit — quoting the bound id as `'${userId}'` — was run only to show the merge test's second assertion (`not.toMatch(/'\$\d+'/)`) is reachable and killing rather than decorative. It fails there and nowhere else.

## Gate

- Target suite: **10 passed (10)**, 0 failed, 0 skipped.
- Sibling service suite (`src/server/services/__tests__/`): **2142 passed, 9 failed (2151)** across 164 files. All 9 failures are in `get-models-raw.transient-503.test.ts` and are **pre-existing** — reproduced identically with the tree byte-identical to `origin/main`.
- `tsc --noEmit`: 1 error, the pre-existing `TS2769` in the generated `packages/civitai-db-schema/src/kysely/updated-at-tables.ts:7` from #3575. **0 added errors**; none reference this file.
- Prettier: clean.

Test-only. `user.service.ts` is byte-identical to `origin/main`.
