### PR TITLE
fix(freshdesk-agent): enforce the query_database timeout server-side and scope it to the tables it needs

### DIFF
--- a/src/server/freshdesk-agent/__tests__/freshdesk-query-scope.test.ts
+++ b/src/server/freshdesk-agent/__tests__/freshdesk-query-scope.test.ts
@@ -1,0 +1,262 @@
+import { describe, expect, it } from 'vitest';
+import {
+  FRESHDESK_QUERY_TABLES,
+  checkQueryScope,
+} from '~/server/freshdesk-agent/freshdesk-query-scope';
+
+/**
+ * `checkQueryScope` bounds which relations the model-authored `query_database`
+ * statement may read. Two properties matter and both are pinned below:
+ *   - an allowed table is confirmed and passes, and
+ *   - anything the check cannot positively confirm is refused, including the
+ *     shapes it is not built to read (CTEs, schema prefixes, table functions,
+ *     FROM-as-function-call). A refusal it did not intend is a false rejection
+ *     with a documented rewrite; a pass it did not intend is a hole.
+ *
+ * Expectations are literal. The allowed-table list in particular is written out
+ * by hand rather than derived from the export, so widening the export cannot
+ * quietly widen the test.
+ */
+describe('checkQueryScope — the allowed table list', () => {
+  it('is exactly the relations the agent already reads', () => {
+    expect([...FRESHDESK_QUERY_TABLES]).toEqual([
+      'BuzzWithdrawalRequest',
+      'Challenge',
+      'ChallengeWinner',
+      'Changelog',
+      'Cosmetic',
+      'CryptoDeposit',
+      'CryptoWallet',
+      'CustomerSubscription',
+      'Image',
+      'ImageReport',
+      'Model',
+      'ModelReport',
+      'Post',
+      'PostReport',
+      'Price',
+      'Product',
+      'Purchase',
+      'Report',
+      'User',
+      'UserCosmetic',
+      'UserCosmeticShopPurchases',
+      'UserProfile',
+      'UserReport',
+      'UserRestriction',
+      'UserStat',
+      'UserStrike',
+    ]);
+  });
+});
+
+describe('checkQueryScope — statements it confirms', () => {
+  it.each([
+    ['a plain single-table read', 'SELECT id, username, email FROM "User" WHERE id = 7 LIMIT 1'],
+    [
+      'an explicit join',
+      'SELECT c.name FROM "UserCosmetic" uc JOIN "Cosmetic" c ON c.id = uc."cosmeticId" LIMIT 5',
+    ],
+    ['a comma join', 'SELECT * FROM "User" u, "Model" m WHERE m."userId" = u.id LIMIT 5'],
+    [
+      'a comma join after an ON clause',
+      'SELECT * FROM "User" u JOIN "Model" m ON m."userId" = u.id, "Post" p LIMIT 5',
+    ],
+    ['a sub-select in the FROM list', 'SELECT * FROM (SELECT id FROM "User" LIMIT 5) x'],
+    [
+      'a sub-select in the FROM list followed by another relation',
+      'SELECT * FROM (SELECT id FROM "User" LIMIT 5) x, "Model" m',
+    ],
+    [
+      'a sub-select in the target list',
+      'SELECT (SELECT count(*) FROM "Image" WHERE "userId" = u.id) FROM "User" u LIMIT 1',
+    ],
+    [
+      'a sub-select in an IN predicate',
+      'SELECT id FROM "Post" WHERE "userId" IN (SELECT id FROM "User")',
+    ],
+    ['both branches of a UNION', 'SELECT id FROM "Model" UNION SELECT id FROM "Image"'],
+    ['a trailing semicolon', 'SELECT id FROM "User" LIMIT 1;'],
+    ['no FROM clause at all', 'SELECT 1'],
+    ['a string literal containing SQL-looking text', `SELECT id FROM "User" WHERE email = 'a@b.c'`],
+    [
+      'a string literal containing a doubled quote',
+      `SELECT id FROM "User" WHERE username = 'O''Brien'`,
+    ],
+  ])('allows %s', (_label, sql) => {
+    expect(checkQueryScope(sql)).toEqual({ ok: true });
+  });
+});
+
+describe('checkQueryScope — relations outside the allowed set', () => {
+  it('refuses a table that is not on the list, and names it', () => {
+    const result = checkQueryScope('SELECT "key" FROM "KeyValue" LIMIT 1');
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('unreachable');
+    expect(result.error).toMatch(
+      /^Error: query_database cannot read "KeyValue"\. It is limited to these tables: /
+    );
+    expect(result.error).toContain('"User"');
+    expect(result.error).toContain('"UserStrike"');
+  });
+
+  it('refuses a disallowed table reached through a join', () => {
+    const result = checkQueryScope(
+      'SELECT * FROM "User" u JOIN "Session" s ON s."userId" = u.id LIMIT 1'
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('unreachable');
+    expect(result.error).toContain('cannot read "Session"');
+  });
+
+  it('refuses a disallowed table reached through a comma join', () => {
+    const result = checkQueryScope('SELECT * FROM "User" u, "Account" a LIMIT 1');
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('unreachable');
+    expect(result.error).toContain('cannot read "Account"');
+  });
+
+  it('refuses a disallowed table reached through a comma after an ON clause', () => {
+    const result = checkQueryScope(
+      'SELECT * FROM "User" u JOIN "Model" m ON m."userId" = u.id, "ApiKey" k LIMIT 1'
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('unreachable');
+    expect(result.error).toContain('cannot read "ApiKey"');
+  });
+
+  it('refuses a disallowed table inside a nested sub-select', () => {
+    const result = checkQueryScope(
+      'SELECT * FROM "User" WHERE id IN (SELECT "userId" FROM (SELECT "userId" FROM "Session") s)'
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('unreachable');
+    expect(result.error).toContain('cannot read "Session"');
+  });
+
+  it('refuses a disallowed table in the second branch of a UNION', () => {
+    const result = checkQueryScope('SELECT id FROM "User" UNION SELECT id FROM "Session"');
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('unreachable');
+    expect(result.error).toContain('cannot read "Session"');
+  });
+
+  it('is case sensitive — the folded spelling is a different relation', () => {
+    const result = checkQueryScope('SELECT id FROM "user" LIMIT 1');
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('unreachable');
+    expect(result.error).toContain('cannot read "user"');
+  });
+});
+
+describe('checkQueryScope — shapes it cannot read, and therefore refuses', () => {
+  it('refuses a bare (unquoted) relation name', () => {
+    const result = checkQueryScope('SELECT id FROM users LIMIT 1');
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('unreachable');
+    expect(result.error).toMatch(
+      /^Error: query_database expected a double-quoted table name after FROM\/JOIN and got users\./
+    );
+  });
+
+  it('refuses a schema-qualified name', () => {
+    expect(checkQueryScope('SELECT id FROM "public"."User" LIMIT 1').ok).toBe(false);
+  });
+
+  it('refuses the catalog', () => {
+    expect(checkQueryScope('SELECT * FROM pg_stat_activity LIMIT 1').ok).toBe(false);
+    expect(checkQueryScope('SELECT * FROM information_schema.tables LIMIT 1').ok).toBe(false);
+  });
+
+  it('refuses a bare pg_* identifier even with no FROM clause', () => {
+    const result = checkQueryScope('SELECT pg_sleep(60)');
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('unreachable');
+    expect(result.error).toMatch(/^Error: query_database reads application tables only\./);
+  });
+
+  it('refuses a nested CTE, whose name is not a real relation', () => {
+    expect(
+      checkQueryScope('SELECT * FROM (WITH t AS (SELECT 1 AS id) SELECT id FROM t) x').ok
+    ).toBe(false);
+  });
+
+  it('refuses a table function in relation position', () => {
+    expect(checkQueryScope('SELECT * FROM generate_series(1, 10)').ok).toBe(false);
+  });
+
+  it('refuses FROM used as function-call syntax (a documented false rejection)', () => {
+    // `EXTRACT(EPOCH FROM col)` reads as a relation position. The rewrite is
+    // `date_part('epoch', col)`, which the tool description tells the model.
+    const result = checkQueryScope('SELECT EXTRACT(EPOCH FROM "createdAt") FROM "User"');
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('unreachable');
+    expect(result.error).toContain('cannot read "createdAt"');
+    expect(checkQueryScope(`SELECT date_part('epoch', "createdAt") FROM "User"`)).toEqual({
+      ok: true,
+    });
+  });
+
+  it('refuses comments rather than stripping them', () => {
+    expect(checkQueryScope('SELECT id FROM "User" -- WHERE id = 1')).toEqual({
+      ok: false,
+      error: 'Error: SQL comments are not supported by query_database. Remove them.',
+    });
+    expect(checkQueryScope('SELECT id /* note */ FROM "User"')).toEqual({
+      ok: false,
+      error: 'Error: SQL comments are not supported by query_database. Remove them.',
+    });
+  });
+
+  it('refuses a second statement after a semicolon', () => {
+    expect(checkQueryScope('SELECT 1; SELECT id FROM "Session"')).toEqual({
+      ok: false,
+      error: 'Error: query_database runs exactly one statement. Remove the extra ";".',
+    });
+  });
+
+  it('refuses dollar quoting and bind-parameter syntax', () => {
+    expect(checkQueryScope('SELECT $$x$$ FROM "User"')).toEqual({
+      ok: false,
+      error:
+        'Error: $ (dollar quoting / bind parameters) is not supported by query_database. Inline plain literals.',
+    });
+    expect(checkQueryScope('SELECT id FROM "User" WHERE username = $1').ok).toBe(false);
+  });
+
+  it('refuses backslashes', () => {
+    expect(checkQueryScope('SELECT 1 \\ FROM "User"')).toEqual({
+      ok: false,
+      error: 'Error: backslashes are not supported by query_database.',
+    });
+  });
+
+  it('refuses an unterminated string literal', () => {
+    expect(checkQueryScope(`SELECT id FROM "User" WHERE username = 'a`)).toEqual({
+      ok: false,
+      error: 'Error: unterminated string literal in query.',
+    });
+  });
+
+  it('refuses prefixed literal forms whose quoting rules differ', () => {
+    expect(checkQueryScope(`SELECT id FROM "User" WHERE username = E'a\\'' AND id = 1`).ok).toBe(
+      false
+    );
+  });
+
+  it('refuses a statement that ends where a table name was expected', () => {
+    expect(checkQueryScope('SELECT id FROM')).toEqual({
+      ok: false,
+      error: 'Error: query is incomplete — a table name was expected after FROM/JOIN.',
+    });
+  });
+
+  it('refuses a write verb even when the statement opens with SELECT', () => {
+    const result = checkQueryScope('SELECT id INTO "Report" FROM "User"');
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('unreachable');
+    expect(result.error).toBe(
+      'Error: query_database runs read-only SELECT statements. "INTO" is not available.'
+    );
+  });
+});

--- a/src/server/freshdesk-agent/__tests__/freshdesk-tools.query-database.test.ts
+++ b/src/server/freshdesk-agent/__tests__/freshdesk-tools.query-database.test.ts
@@ -1,0 +1,141 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type * as DbHelpersModule from '~/server/db/db-helpers';
+import type * as PgDbModule from '~/server/db/pgDb';
+import type * as DbClientModule from '~/server/db/client';
+
+/**
+ * `query_database` runs SQL the model wrote, so the tool carries the bounds:
+ * it must go through `queryWithTimeout` (BEGIN READ ONLY + a server-side
+ * `SET LOCAL statement_timeout`) rather than straight at the app-wide read
+ * client, and it must refuse a relation it is not scoped to before it takes a
+ * connection at all.
+ *
+ * These tests drive the exported `executeToolCall` — the same entry point the
+ * agent loop calls — so they exercise the real dispatch, not a shortcut.
+ */
+
+const h = vi.hoisted(() => ({
+  // A sentinel rather than a real Pool: the assertion is "the bounded helper
+  // was handed the READ pool", and identity makes that unambiguous.
+  readPool: { __testDouble: 'pgDbRead' },
+  queryWithTimeout: vi.fn(),
+  prismaQueryRaw: vi.fn(),
+}));
+
+// Narrow overrides that keep every other export real. A hand-written
+// replacement object would pin these modules' export surface to today's shape
+// and silently collect zero tests the day one of them grows an export.
+vi.mock('~/server/db/db-helpers', async (importOriginal) => ({
+  ...(await importOriginal<typeof DbHelpersModule>()),
+  queryWithTimeout: h.queryWithTimeout,
+}));
+
+vi.mock('~/server/db/pgDb', async (importOriginal) => ({
+  ...(await importOriginal<typeof PgDbModule>()),
+  pgDbRead: h.readPool,
+}));
+
+// The app-wide Prisma read client. Stubbed so that "the tool never touches it"
+// is an assertion this file can make rather than an inference.
+vi.mock('~/server/db/client', async (importOriginal) => ({
+  ...(await importOriginal<typeof DbClientModule>()),
+  dbRead: { $queryRaw: h.prismaQueryRaw },
+}));
+
+// These two build a singleton at module load and throw without their env vars,
+// so `importOriginal` cannot be used on them. Each has exactly one export, and
+// no test here reaches either.
+vi.mock('~/server/http/freshdesk/freshdesk.caller', () => ({ freshdeskCaller: {} }));
+vi.mock('~/server/http/nowpayments/nowpayments.caller', () => ({ default: {} }));
+
+import { executeToolCall } from '~/server/freshdesk-agent/freshdesk-tools';
+
+const ALLOWED_SQL = 'SELECT id, username FROM "User" WHERE id = 7 LIMIT 1';
+
+describe('query_database', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('runs an allowed query through the read-only / statement-timeout helper', async () => {
+    h.queryWithTimeout.mockResolvedValue({ rows: [{ id: 7, username: 'ada' }] });
+
+    const result = await executeToolCall('query_database', { sql: ALLOWED_SQL });
+
+    expect(h.queryWithTimeout).toHaveBeenCalledTimes(1);
+    expect(h.queryWithTimeout).toHaveBeenCalledWith(h.readPool, 30000, ALLOWED_SQL);
+    expect(h.prismaQueryRaw).not.toHaveBeenCalled();
+    expect(result).toBe(JSON.stringify([{ id: 7, username: 'ada' }], null, 2));
+  });
+
+  it('harness check: the double records the real call, not a tagged-template call', async () => {
+    // A tagged template handed to a vi.fn arrives as (TemplateStringsArray,
+    // ...values) — the SQL would show up as an array of fragments and an
+    // arity-3 (pool, ms, string) assertion would be vacuously unreachable. Pin
+    // the shape here so the assertions above cannot pass on a mis-capture,
+    // and pin a value the call did NOT make so the matcher is shown to
+    // discriminate.
+    h.queryWithTimeout.mockResolvedValue({ rows: [] });
+
+    await executeToolCall('query_database', { sql: ALLOWED_SQL });
+
+    const call = h.queryWithTimeout.mock.calls[0];
+    expect(call).toHaveLength(3);
+    expect(Array.isArray(call[2])).toBe(false);
+    expect(typeof call[2]).toBe('string');
+    expect(call[2]).toBe(ALLOWED_SQL);
+    expect(call[2]).not.toBe('SELECT id, username FROM "Session" WHERE id = 7 LIMIT 1');
+  });
+
+  it('refuses a relation outside the allowed set without taking a connection', async () => {
+    const result = await executeToolCall('query_database', {
+      sql: 'SELECT "key" FROM "KeyValue" LIMIT 1',
+    });
+
+    expect(h.queryWithTimeout).not.toHaveBeenCalled();
+    expect(h.prismaQueryRaw).not.toHaveBeenCalled();
+    expect(result).toMatch(
+      /^Error: query_database cannot read "KeyValue"\. It is limited to these tables: /
+    );
+  });
+
+  // Invariant guard, not regression coverage: this check predates the change
+  // and is here so a later edit cannot drop it.
+  it('refuses a non-SELECT statement', async () => {
+    const result = await executeToolCall('query_database', {
+      sql: 'UPDATE "User" SET "muted" = true WHERE id = 7',
+    });
+
+    expect(result).toBe('Error: Only SELECT queries are allowed.');
+    expect(h.queryWithTimeout).not.toHaveBeenCalled();
+    expect(h.prismaQueryRaw).not.toHaveBeenCalled();
+  });
+
+  it('reports a database-side cancellation in terms the model can act on', async () => {
+    h.queryWithTimeout.mockRejectedValue(
+      Object.assign(new Error('canceling statement due to statement timeout'), { code: '57014' })
+    );
+
+    const result = await executeToolCall('query_database', { sql: ALLOWED_SQL });
+
+    expect(result).toBe(
+      'Query error: cancelled after 30s. Narrow the query — add a LIMIT and filter on indexed columns.'
+    );
+  });
+
+  it('passes other database errors through', async () => {
+    h.queryWithTimeout.mockRejectedValue(new Error('relation "User" does not exist'));
+
+    const result = await executeToolCall('query_database', { sql: ALLOWED_SQL });
+
+    expect(result).toBe('Query error: relation "User" does not exist');
+  });
+
+  it('returns a plain message for an empty result set', async () => {
+    h.queryWithTimeout.mockResolvedValue({ rows: [] });
+
+    const result = await executeToolCall('query_database', { sql: ALLOWED_SQL });
+
+    expect(result).toBe('No results found.');
+  });
+});

--- a/src/server/freshdesk-agent/freshdesk-query-scope.ts
+++ b/src/server/freshdesk-agent/freshdesk-query-scope.ts
@@ -1,0 +1,378 @@
+/**
+ * Scope check for the `query_database` support tool.
+ *
+ * `query_database` is the one tool whose SQL is written by the model rather
+ * than by us, so the tool — not the SQL text — has to carry two bounds:
+ *
+ *   1. WHICH relations the statement may read (this file), and
+ *   2. how long it may hold a pooled connection — enforced server-side by
+ *      `queryWithTimeout`'s `SET LOCAL statement_timeout` inside a
+ *      `BEGIN READ ONLY` transaction (see `freshdesk-tools.ts`).
+ *
+ * The check below is deliberately CONSERVATIVE: it confirms a statement is
+ * built only out of shapes it fully understands, and rejects everything else
+ * with an actionable message. It is not a SQL parser and does not try to be
+ * one — a check that pattern-matches its way to a "looks fine" verdict on a
+ * shape it cannot actually read would be worse than no check at all. Known
+ * false rejections are listed in `checkQueryScope`'s docblock; each one has a
+ * documented rewrite the model can apply.
+ */
+
+/**
+ * Relations `query_database` may read.
+ *
+ * Derived, not guessed: this is every relation referenced by the `Prisma.sql`
+ * queries in `freshdesk-investigation-tools.ts` (the agent's purpose-built
+ * lookups), plus `"User"` for the email lookup that `freshdesk-prompts.ts`
+ * spells out inline. `query_database` is documented in those prompts as the
+ * fallback for the same investigations, so that is its working set.
+ *
+ * These are physical Postgres relation names. All 26 are plain `model`s in
+ * `prisma/schema.prisma` — none is a view and none carries an `@@map`, so the
+ * Prisma name IS the table name. Matching is case-SENSITIVE and requires
+ * double quotes, because that is how Postgres itself distinguishes `"User"`
+ * from the folded `user`.
+ *
+ * `buzzTransactions` is deliberately absent: it lives in ClickHouse, which
+ * `query_database` does not reach.
+ */
+export const FRESHDESK_QUERY_TABLES = [
+  'BuzzWithdrawalRequest',
+  'Challenge',
+  'ChallengeWinner',
+  'Changelog',
+  'Cosmetic',
+  'CryptoDeposit',
+  'CryptoWallet',
+  'CustomerSubscription',
+  'Image',
+  'ImageReport',
+  'Model',
+  'ModelReport',
+  'Post',
+  'PostReport',
+  'Price',
+  'Product',
+  'Purchase',
+  'Report',
+  'User',
+  'UserCosmetic',
+  'UserCosmeticShopPurchases',
+  'UserProfile',
+  'UserReport',
+  'UserRestriction',
+  'UserStat',
+  'UserStrike',
+] as const;
+
+const ALLOWED_TABLES: ReadonlySet<string> = new Set(FRESHDESK_QUERY_TABLES);
+
+/** Rendered into rejection messages so the model can retarget without guessing. */
+const TABLE_LIST = FRESHDESK_QUERY_TABLES.map((t) => `"${t}"`).join(', ');
+
+/** Keywords that introduce a relation reference in a `FROM` list. */
+const RELATION_KEYWORDS: ReadonlySet<string> = new Set(['from', 'join']);
+
+/**
+ * Keywords that end a `FROM` list at its own paren depth. `on` and `using` are
+ * intentionally NOT here: `FROM a JOIN b ON a.id = b.id, c` is valid, so the
+ * comma after an `ON` clause still has to be read as a new relation position.
+ */
+const FROM_LIST_TERMINATORS: ReadonlySet<string> = new Set([
+  'where',
+  'group',
+  'having',
+  'order',
+  'limit',
+  'offset',
+  'window',
+  'union',
+  'intersect',
+  'except',
+  'fetch',
+  'for',
+]);
+
+/**
+ * Statement verbs that have no place in a read. The `BEGIN READ ONLY`
+ * transaction is the real backstop for all of these; rejecting them here just
+ * turns a Postgres error into a message the model can act on. Reserved words
+ * in Postgres cannot appear as bare identifiers, so this cannot collide with a
+ * column or alias in a well-formed statement.
+ */
+const NON_READ_KEYWORDS: ReadonlySet<string> = new Set([
+  'insert',
+  'update',
+  'delete',
+  'drop',
+  'alter',
+  'truncate',
+  'create',
+  'grant',
+  'revoke',
+  'copy',
+  'into',
+  'call',
+  'vacuum',
+  'reindex',
+  'refresh',
+  'listen',
+  'notify',
+  'lock',
+  'begin',
+  'commit',
+  'rollback',
+  'savepoint',
+]);
+
+type Token =
+  | { kind: 'ident'; value: string } // bare identifier/keyword, folded to lower case
+  | { kind: 'quoted'; value: string } // double-quoted identifier, quotes removed
+  | { kind: 'literal' } // single-quoted string; contents intentionally discarded
+  | { kind: 'punct'; value: string };
+
+type TokenizeResult = { ok: true; tokens: Token[] } | { ok: false; error: string };
+
+const IDENT_START = /[A-Za-z_]/;
+const IDENT_CHAR = /[A-Za-z0-9_]/;
+/** A quote directly after one of these is a prefixed literal (E'', U&'', B'', X'', U&""). */
+const QUOTE_PREFIX_CHAR = /[A-Za-z0-9_&]/;
+
+function reject(error: string): { ok: false; error: string } {
+  return { ok: false, error };
+}
+
+/**
+ * Split the statement into the four token shapes this check understands.
+ *
+ * Everything that would let a relation reference hide from a structural read —
+ * comments, prefixed/escaped string forms, dollar quoting, backslashes, a
+ * second statement after a semicolon — is refused here rather than stripped,
+ * so no later stage has to reason about text it cannot see.
+ */
+function tokenize(sql: string): TokenizeResult {
+  const tokens: Token[] = [];
+  const n = sql.length;
+  let i = 0;
+
+  while (i < n) {
+    const c = sql[i];
+
+    if (/\s/.test(c)) {
+      i++;
+      continue;
+    }
+
+    if (c === '-' && sql[i + 1] === '-') {
+      return reject('Error: SQL comments are not supported by query_database. Remove them.');
+    }
+    if (c === '/' && sql[i + 1] === '*') {
+      return reject('Error: SQL comments are not supported by query_database. Remove them.');
+    }
+
+    if (c === '"') {
+      if (i > 0 && QUOTE_PREFIX_CHAR.test(sql[i - 1])) {
+        return reject(
+          'Error: prefixed identifier forms (e.g. U&"...") are not supported by query_database.'
+        );
+      }
+      let j = i + 1;
+      let value = '';
+      for (;;) {
+        if (j >= n) return reject('Error: unterminated quoted identifier in query.');
+        if (sql[j] === '"') {
+          if (sql[j + 1] === '"') {
+            value += '"';
+            j += 2;
+            continue;
+          }
+          j++;
+          break;
+        }
+        value += sql[j];
+        j++;
+      }
+      tokens.push({ kind: 'quoted', value });
+      i = j;
+      continue;
+    }
+
+    if (c === "'") {
+      if (i > 0 && QUOTE_PREFIX_CHAR.test(sql[i - 1])) {
+        return reject(
+          "Error: prefixed string forms (e.g. E'...') are not supported by query_database. Use a plain '...' literal."
+        );
+      }
+      let j = i + 1;
+      for (;;) {
+        if (j >= n) return reject('Error: unterminated string literal in query.');
+        if (sql[j] === "'") {
+          if (sql[j + 1] === "'") {
+            j += 2;
+            continue;
+          }
+          j++;
+          break;
+        }
+        j++;
+      }
+      tokens.push({ kind: 'literal' });
+      i = j;
+      continue;
+    }
+
+    if (IDENT_START.test(c)) {
+      let j = i;
+      while (j < n && IDENT_CHAR.test(sql[j])) j++;
+      tokens.push({ kind: 'ident', value: sql.slice(i, j).toLowerCase() });
+      i = j;
+      continue;
+    }
+
+    if (/[0-9]/.test(c)) {
+      let j = i;
+      while (j < n && /[0-9.]/.test(sql[j])) j++;
+      // Numeric value is irrelevant to scope; record a placeholder so the
+      // token stream stays positional.
+      tokens.push({ kind: 'punct', value: '0' });
+      i = j;
+      continue;
+    }
+
+    if (c === '$') {
+      return reject(
+        'Error: $ (dollar quoting / bind parameters) is not supported by query_database. Inline plain literals.'
+      );
+    }
+    if (c === '\\') {
+      return reject('Error: backslashes are not supported by query_database.');
+    }
+    if (c === ';') {
+      if (sql.slice(i + 1).trim() !== '') {
+        return reject('Error: query_database runs exactly one statement. Remove the extra ";".');
+      }
+      i++;
+      continue;
+    }
+
+    tokens.push({ kind: 'punct', value: c });
+    i++;
+  }
+
+  return { ok: true, tokens };
+}
+
+export type QueryScopeResult = { ok: true } | { ok: false; error: string };
+
+/**
+ * Confirm every relation the statement reads is one `query_database` is
+ * allowed to reach.
+ *
+ * What it DOES cover, because the walk is positional rather than textual:
+ *   - relations behind `FROM` / any `JOIN` flavour, at any nesting depth
+ *   - relations in a comma-separated `FROM` list, including a comma that
+ *     follows a join's `ON` clause (tracked per paren depth, so an inner
+ *     sub-select's `FROM` list cannot be confused with the outer one)
+ *   - relations inside sub-selects in the target list, `WHERE`, `IN (...)`
+ *   - each branch of a `UNION` / `INTERSECT` / `EXCEPT`
+ *   - text hidden in comments or a second statement — refused outright
+ *
+ * What it does NOT do, and rejects rather than guesses at:
+ *   - CTEs. `WITH` cannot lead (the caller's `SELECT` check already refuses
+ *     that) and a nested CTE's name is a bare identifier in relation position,
+ *     which is refused.
+ *   - schema-qualified names (`"public"."User"`), `ONLY`, table functions, and
+ *     any bare/unquoted relation name — including `information_schema` and the
+ *     `pg_*` catalog. Relation position accepts a double-quoted identifier or
+ *     an opening paren, nothing else.
+ *   - `FROM` used as function-call syntax: `EXTRACT(EPOCH FROM col)`,
+ *     `SUBSTRING(x FROM 1)`, `TRIM(BOTH ' ' FROM x)`. These read as a relation
+ *     position and are rejected. Rewrite with `date_part(...)` / `substr(...)`
+ *     / `btrim(...)`.
+ *
+ * What it deliberately does NOT bound at all:
+ *   - columns and rows. Any column of an allowed table is readable, for every
+ *     row. Narrowing the projection is the prompt's job, not this check's.
+ *   - functions in the target list, which need no `FROM`. Bare `pg_*` and
+ *     `information_schema` identifiers are refused anywhere in the statement,
+ *     but that is a named-prefix refusal, not an allowlist — the read-only
+ *     transaction and the statement timeout are what actually bound this case.
+ */
+export function checkQueryScope(sql: string): QueryScopeResult {
+  const tokenized = tokenize(sql);
+  if (!tokenized.ok) return tokenized;
+
+  const { tokens } = tokenized;
+  /** `fromListAtDepth[d]` — is a `FROM` list currently open at paren depth d? */
+  const fromListAtDepth: boolean[] = [];
+  let depth = 0;
+  let expectRelation = false;
+
+  for (const token of tokens) {
+    if (token.kind === 'punct' && token.value === '(') {
+      depth++;
+      // A paren in relation position is a sub-select; its own `FROM` is walked
+      // by this same loop.
+      expectRelation = false;
+      continue;
+    }
+
+    if (token.kind === 'punct' && token.value === ')') {
+      fromListAtDepth[depth] = false;
+      depth = Math.max(0, depth - 1);
+      expectRelation = false;
+      continue;
+    }
+
+    if (expectRelation) {
+      if (token.kind === 'quoted') {
+        if (!ALLOWED_TABLES.has(token.value)) {
+          return reject(
+            `Error: query_database cannot read "${token.value}". It is limited to these tables: ${TABLE_LIST}.`
+          );
+        }
+        expectRelation = false;
+        continue;
+      }
+      // `LATERAL` sits between the keyword and the relation itself.
+      if (token.kind === 'ident' && token.value === 'lateral') continue;
+      const shown = token.kind === 'ident' ? token.value : 'the value here';
+      return reject(
+        `Error: query_database expected a double-quoted table name after FROM/JOIN and got ${shown}. Reference tables directly by their quoted name — CTEs, schema prefixes, table functions, and FROM-inside-a-function-call (EXTRACT/SUBSTRING/TRIM) are not supported. Allowed tables: ${TABLE_LIST}.`
+      );
+    }
+
+    if (token.kind === 'ident') {
+      if (token.value.startsWith('pg_') || token.value === 'information_schema') {
+        return reject(
+          `Error: query_database reads application tables only. Allowed tables: ${TABLE_LIST}.`
+        );
+      }
+      if (RELATION_KEYWORDS.has(token.value)) {
+        expectRelation = true;
+        if (token.value === 'from') fromListAtDepth[depth] = true;
+        continue;
+      }
+      if (NON_READ_KEYWORDS.has(token.value)) {
+        return reject(
+          `Error: query_database runs read-only SELECT statements. "${token.value.toUpperCase()}" is not available.`
+        );
+      }
+      if (fromListAtDepth[depth] && FROM_LIST_TERMINATORS.has(token.value)) {
+        fromListAtDepth[depth] = false;
+      }
+      continue;
+    }
+
+    if (token.kind === 'punct' && token.value === ',' && fromListAtDepth[depth]) {
+      expectRelation = true;
+      continue;
+    }
+  }
+
+  if (expectRelation) {
+    return reject('Error: query is incomplete — a table name was expected after FROM/JOIN.');
+  }
+
+  return { ok: true };
+}

--- a/src/server/freshdesk-agent/freshdesk-tools.ts
+++ b/src/server/freshdesk-agent/freshdesk-tools.ts
@@ -1,10 +1,11 @@
 import type { ToolDefinitionJson } from '@openrouter/sdk/models';
-import { Prisma } from '@prisma/client';
 import { env } from '~/env/server';
-import { dbRead } from '~/server/db/client';
+import { queryWithTimeout } from '~/server/db/db-helpers';
+import { pgDbRead } from '~/server/db/pgDb';
 import { freshdeskCaller } from '~/server/http/freshdesk/freshdesk.caller';
 import type { FreshdeskWebhookPhase } from '~/server/http/freshdesk/freshdesk.schema';
 import { agentLog, getDebugContext } from './freshdesk-debug';
+import { FRESHDESK_QUERY_TABLES, checkQueryScope } from './freshdesk-query-scope';
 import {
   investigateUserAccount,
   investigateCosmetics,
@@ -14,6 +15,15 @@ import {
   checkSiteStatus,
   investigateCryptoPayments,
 } from './freshdesk-investigation-tools';
+
+/**
+ * Ceiling for a single `query_database` statement. Applied as a Postgres
+ * `statement_timeout` inside the query's own transaction, so the database
+ * cancels the backend and releases the pooled connection. The tool
+ * description states this as a guarantee, so it has to be the real mechanism.
+ */
+const DB_QUERY_TIMEOUT_MS = 30_000;
+const DB_QUERY_TIMEOUT_SECONDS = DB_QUERY_TIMEOUT_MS / 1000;
 
 // --- Tool definitions ---
 
@@ -256,15 +266,24 @@ const queryDatabaseTool: ToolDefinitionJson = {
   type: 'function',
   function: {
     name: 'query_database',
-    description:
-      'Execute a read-only SQL query against the Civitai database. Use this to verify facts, look up user info, check system data, etc. Only SELECT queries are allowed. Queries have a 30 second timeout.',
+    description: [
+      'Execute a SELECT query against the Civitai database. Use this to verify facts, look up user info, or check system data when the purpose-built investigation tools do not cover what you need.',
+      'The following are enforced by the server, not by convention — a query that breaks any of them is rejected or cancelled, so write to them up front:',
+      `- It can only read these tables: ${FRESHDESK_QUERY_TABLES.map((t) => `"${t}"`).join(', ')}.`,
+      '- It runs inside a read-only transaction, so nothing can be written.',
+      `- The database cancels the statement after ${DB_QUERY_TIMEOUT_SECONDS} seconds. Always use LIMIT and filter on indexed columns.`,
+      '- One statement only. No comments, no CTEs (WITH), no schema prefixes, no table functions.',
+      '- Reference tables by their exact double-quoted name, e.g. FROM "User".',
+      "- FROM-inside-a-function-call is not supported: use date_part('epoch', col) rather than EXTRACT(EPOCH FROM col), and substr(...) rather than SUBSTRING(x FROM 1).",
+      'At most 50 rows are returned.',
+    ].join('\n'),
     parameters: {
       type: 'object',
       properties: {
         sql: {
           type: 'string',
           description:
-            'A read-only SQL SELECT query. Must start with SELECT. Keep results small — use LIMIT.',
+            'A single SELECT statement over the allowed tables. Must start with SELECT. Keep results small — use LIMIT.',
         },
       },
       required: ['sql'],
@@ -382,7 +401,8 @@ const investigateCryptoPaymentsTool: ToolDefinitionJson = {
 
 // --- Tool execution ---
 
-const DB_QUERY_TIMEOUT_MS = 30_000;
+/** Postgres `query_canceled` — what `statement_timeout` raises. */
+const PG_QUERY_CANCELED = '57014';
 
 async function executeQueryDatabase(sql: string): Promise<string> {
   // Safety: only allow SELECT queries
@@ -391,14 +411,31 @@ async function executeQueryDatabase(sql: string): Promise<string> {
     return 'Error: Only SELECT queries are allowed.';
   }
 
+  // Bound WHICH relations the statement can reach before it touches a connection.
+  const scope = checkQueryScope(sql);
+  if (!scope.ok) return scope.error;
+
   try {
-    const results = await dbRead.$queryRaw(Prisma.raw(sql));
-    const rows = results as Record<string, unknown>[];
+    // `queryWithTimeout` wraps the statement in BEGIN READ ONLY + SET LOCAL
+    // statement_timeout, so both bounds are the database's to enforce. A
+    // `Promise.race` here would only abandon the promise — the backend would
+    // keep running and keep holding its pooled connection.
+    const { rows } = await queryWithTimeout<Record<string, unknown>>(
+      pgDbRead,
+      DB_QUERY_TIMEOUT_MS,
+      sql
+    );
     if (rows.length === 0) return 'No results found.';
     // Limit output size
     const truncated = rows.slice(0, 50);
     return JSON.stringify(truncated, null, 2);
   } catch (err) {
+    if (
+      typeof err === 'object' &&
+      err !== null &&
+      (err as { code?: string }).code === PG_QUERY_CANCELED
+    )
+      return `Query error: cancelled after ${DB_QUERY_TIMEOUT_SECONDS}s. Narrow the query — add a LIMIT and filter on indexed columns.`;
     return `Query error: ${err instanceof Error ? err.message : String(err)}`;
   }
 }
@@ -543,12 +580,7 @@ export async function executeToolCall(
         break;
       }
       case 'query_database': {
-        result = await Promise.race([
-          executeQueryDatabase(args.sql as string),
-          new Promise<string>((_, reject) =>
-            setTimeout(() => reject(new Error('Query timed out after 30s')), DB_QUERY_TIMEOUT_MS)
-          ),
-        ]);
+        result = await executeQueryDatabase(args.sql as string);
         break;
       }
       default:


### PR DESCRIPTION
## What

`query_database` is the one support-agent tool whose SQL is written by the model rather than by us, and it is handed the app-wide read client with a single `startsWith('SELECT')` check. Three things about that are not what they look like:

1. **The advertised 30s timeout was not enforced.** It was a `Promise.race` against a `setTimeout`, which rejects the wrapper but does not cancel the query — the backend keeps running and keeps holding its pooled connection. The repo already documents this exact failure mode (`src/server/services/ai/openrouter.ts:157-159`). The tool description promised a guarantee the server never made.
2. **No bound on which relations it could read.** `dbRead` is the app-wide read client, and `packages/civitai-db/src/client.ts:24` aliases it to `dbWrite` whenever `DATABASE_REPLICA_URL === DATABASE_URL`, so on a single-DB deployment the tool's connection is the write connection.
3. **Fan-out.** `openrouter.ts:322-338` `Promise.all`s every tool call in a turn, so one turn can issue several `query_database` calls in parallel. Combined with (1), an expensive query could pin several connections for as long as it liked.

## Change

**Route the query through the primitive the repo already has.** `packages/civitai-db/src/db-helpers.ts:303` `queryWithTimeout` does `BEGIN READ ONLY` → `SET LOCAL statement_timeout` → `COMMIT`, and is documented as PgBouncer-safe. The statement now runs there, on `pgDbRead`. The timeout is the database's to enforce: it cancels the backend and frees the connection, which is what bounds (3) as well. The `Promise.race` wrapper is gone rather than kept alongside — two mechanisms where one is real is how the description drifted in the first place. Postgres' `57014` (`query_canceled`) is mapped to a message the model can act on.

**Add a table allowlist** (`freshdesk-query-scope.ts`). 26 relations, derived rather than guessed: every relation referenced by the `Prisma.sql` queries in `freshdesk-investigation-tools.ts`, plus `"User"` for the email lookup `freshdesk-prompts.ts` spells out inline. All 26 are plain `model`s in `prisma/schema.prisma` — no views, no `@@map`, so the Prisma name is the table name. `buzzTransactions` is deliberately absent: it is ClickHouse, which this tool does not reach.

**Make the tool description describe what is actually enforced**, including the table list, so the model writes to the real contract instead of discovering it through rejections.

The `startsWith('SELECT')` check is unchanged and still runs first.

## How the table check works, and what it cannot do

Parsing SQL with a regex is a trap, so this does not. It is a small scanner over four token shapes (bare identifier, double-quoted identifier, string literal, punctuation) feeding a positional walk of the `FROM` list that tracks paren depth. It is **conservative by construction**: relation position accepts a double-quoted allowlisted name or an opening paren, and refuses everything else rather than pattern-matching its way to a pass.

Covered, with a test each:

- relations behind `FROM` and every `JOIN` flavour, at any nesting depth
- comma-separated `FROM` lists — including a comma that follows a join's `ON` clause, which is why `ON`/`USING` are deliberately not treated as clause terminators
- sub-selects in the target list, in `WHERE`, in `IN (...)`, and in the `FROM` list itself (per-depth tracking, so an inner sub-select's `FROM` list is not confused with the outer one)
- each branch of a `UNION` / `INTERSECT` / `EXCEPT`
- case sensitivity — `"user"` is not `"User"`
- comments, a second statement after `;`, dollar quoting, bind-parameter syntax, backslashes, and prefixed literal forms (`E'…'`, `U&"…"`) — all refused at the scanner rather than stripped, since each is a way for a relation reference to sit outside a structural read

Refused because it cannot confirm them, i.e. **known false rejections**, each with a rewrite the tool description gives the model up front:

- CTEs. `WITH` cannot lead (the `SELECT` check refuses that already); a nested one's name is a bare identifier in relation position, which is refused.
- schema-qualified names (`"public"."User"`), `ONLY`, table functions, and any bare relation name — which is also how `information_schema` and `pg_catalog` are refused.
- `FROM` used as function-call syntax: `EXTRACT(EPOCH FROM col)`, `SUBSTRING(x FROM 1)`, `TRIM(BOTH ' ' FROM x)`. Special-casing these would mean treating a call paren as exempt, which reopens the hole; refusing them is the cheaper trade. Use `date_part('epoch', col)` / `substr(...)` / `btrim(...)`.

Not bounded at all, stated plainly:

- **columns and rows.** Every column of an allowed table is readable, for every row. This is a relation-level bound only.
- **functions in the target list**, which need no `FROM` at all. Bare `pg_*` and `information_schema` identifiers are refused anywhere in the statement, but that is a named-prefix refusal, not an allowlist. The read-only transaction and the statement timeout are what actually bound this case.

## Also

Prisma returned `bigint` columns as JS `BigInt`, which `JSON.stringify` throws on — so a `SELECT count(*)` used to come back as `Query error: Do not know how to serialize a BigInt`. `pg` returns those as strings, so that shape now works.

## Out of scope, deliberately

Unchanged, but worth a look separately: the fan-out itself (`toolCallsExecuted` is counted at `openrouter.ts:324` and never enforced), the prompts, and the fact that the agent runs automatically per ticket with no flag.

## Tests

`vitest --project unit src/server/freshdesk-agent/__tests__/` — **43 passed, 0 failed, 0 skipped** across 2 files.

`freshdesk-tools.query-database.test.ts` drives the exported `executeToolCall`, so it exercises the real dispatch. Run against pre-change `freshdesk-tools.ts` in the same tree it is **6 failed / 1 passed**, each on its own assertion, no import error:

| test | pre-change | post |
|---|---|---|
| routes through the read-only/timeout helper | RED — `expected "vi.fn()" to be called 1 times, but got 0 times` | PASS |
| harness check (real call, not a tagged-template call) | RED — `Target cannot be null or undefined` (no call recorded) | PASS |
| refuses a relation outside the set without taking a connection | RED — `expected "vi.fn()" to not be called at all, but actually been called 1 times` (the Prisma client) | PASS |
| refuses a non-SELECT statement | PASS — **invariant guard, not regression coverage** | PASS |
| reports a database-side cancellation | RED — own assertion on the message | PASS |
| passes other database errors through | RED — own assertion on the message | PASS |
| empty result set | RED — own assertion on the message | PASS |

The harness-check test is there because a tagged template handed to a `vi.fn` arrives as `(TemplateStringsArray, ...values)` — a naive capture records nothing and fails identically to pre-change. It pins arity, that the SQL arrived as a string and not an array, the exact value, and a value the call did *not* make, so the matcher is shown to discriminate.

`freshdesk-query-scope.test.ts` covers brand-new code, so a revert would only produce an import error and prove nothing. Instead: an **11-mutation sweep, 11 killed, 0 survivors**, against a clean 36/36 baseline. M1 (make the check accept everything) is the negative control and turns 22 of 36 red, so the suite is demonstrably reachable. Each other mutant kills a specific test — dropping comma-in-`FROM`-list tracking kills exactly the two comma-join refusals; dropping one table from the list kills both the pinned-list test and the "names the table" test, which also shows the pinned list is written by hand rather than derived from the export.

## Gate

- `pnpm typecheck` — **1 error, added-vs-main: 0.** The one error is the pre-existing `TS2769` in the generated `packages/civitai-db-schema/src/kysely/updated-at-tables.ts:7` from #3575. Confirmed pre-existing by typechecking the same tree with this change reverted: same 1 error, same location.
- `eslint src/server/freshdesk-agent --ext .ts` — clean.
- `prettier --check` — clean.
