### PR TITLE
fix(apps): an off-site listing with an OAuth client no longer renders a dead CTA

### DIFF
--- a/src/components/Apps/AppListingCard.browser.test.tsx
+++ b/src/components/Apps/AppListingCard.browser.test.tsx
@@ -220,11 +220,14 @@ describe('AppListingCard', () => {
     await expect.element(visit).toHaveAttribute('rel', 'noopener noreferrer');
   });
 
-  test('off-site connect → View details → unified detail (P2c)', async () => {
-    // P2c: cards route to the unified detail; the Connect action itself lives on
-    // the detail page (the connect flow needs a P2a authorize-URL DTO addition),
-    // so the card's CTA is "View details", not an inert Connect button. The
-    // former "Connect app" kind badge is gone — no longer asserted here.
+  test('off-site connect with NO external target → View details → unified detail', async () => {
+    // 🔴 `externalUrl: null` is what makes this the View-details case, NOT the
+    // sub-kind. The comment here used to say cards route connect listings to the
+    // detail because "the connect flow needs a P2a authorize-URL DTO addition" —
+    // that premise was wrong and produced a dead end (the detail's Connect
+    // affordance was an inert stub). A connect listing WITH an https
+    // `externalUrl` now gets a direct Visit ↗; see the test below. The former
+    // "Connect app" kind badge is gone — no longer asserted here.
     renderWithProviders(
       <AppListingCard
         card={base({
@@ -236,6 +239,27 @@ describe('AppListingCard', () => {
     );
     const details = page.getByRole('link', { name: 'View details' });
     await expect.element(details).toHaveAttribute('href', '/apps/store-preview/my-app');
+  });
+
+  test('🔴 off-site connect WITH an https externalUrl → Visit ↗ external anchor', async () => {
+    // The rendered counterpart of the view-model reversal: a linked OAuth client
+    // no longer strands the card on "View details". Asserted on the real anchor
+    // (href + target + rel), not just the label, because the whole defect was an
+    // affordance that looked present and went nowhere.
+    renderWithProviders(
+      <AppListingCard
+        card={base({
+          kind: 'offsite',
+          name: 'Connect App',
+          kindData: { kind: 'offsite', subKind: 'connect', externalUrl: 'https://connect.app' },
+        })}
+      />
+    );
+    await expect.element(page.getByRole('link', { name: 'View details' })).not.toBeInTheDocument();
+    const visit = page.getByRole('link', { name: 'Visit' });
+    await expect.element(visit).toHaveAttribute('href', 'https://connect.app');
+    await expect.element(visit).toHaveAttribute('target', '_blank');
+    await expect.element(visit).toHaveAttribute('rel', 'noopener noreferrer');
   });
 
   test('on-site page app WITHOUT canOpenPage → View details → unified detail (P2c)', async () => {

--- a/src/components/Apps/AppListingDetailBody.browser.test.tsx
+++ b/src/components/Apps/AppListingDetailBody.browser.test.tsx
@@ -483,8 +483,42 @@ describe('AppListingDetailBody', () => {
   // mutation and an info-branch mutation each be observed on the same run
   // instead of the first one short-circuiting the second.
 
+  test('🔴 a connect listing WITH an https externalUrl renders a real Visit ↗ anchor', async () => {
+    // The rendered reproduction of the bug this change fixes: an approved
+    // off-site listing with a linked OAuth client used to render an INERT
+    // disabled "Connect" button reading "Connecting this app will be available
+    // soon." — the viewer had no way to open the app at all. It now takes the
+    // same `visit` branch as any other off-site listing.
+    //
+    // Asserted through `renderAndSettle`, which keys on the CTA's href: this
+    // test cannot pass unless a real anchor to the app's address exists.
+    const visitBtn = await renderAndSettle(
+      <AppListingDetailBody
+        detail={base({
+          kind: 'offsite',
+          kindData: {
+            kind: 'offsite',
+            subKind: 'connect',
+            externalUrl: 'https://connect.app',
+            connectClientId: 'oauth-client-1',
+          },
+        })}
+      />,
+      'https://connect.app'
+    );
+    expect(visitBtn.textContent?.trim()).toBe('Visit');
+    expect(visitBtn.getAttribute('target')).toBe('_blank');
+    expect(visitBtn.getAttribute('rel')).toBe('noopener noreferrer');
+    expect(glyphOf(visitBtn)).toBe('external-link');
+    // The stub copy must be GONE from this state — it is the exact string a user
+    // reported as a dead end.
+    expect(document.body.textContent).not.toContain('Connecting this app will be available soon');
+  });
+
   test('the connect branch keeps its own glyph', async () => {
-    // off-site OAuth → the `connect` stub (disabled button + note).
+    // off-site OAuth with NO destination (`externalUrl: null`) → the `connect`
+    // stub (disabled button + note). 🔴 The null url is what selects this branch
+    // now, not the sub-kind — see the test above.
     await renderWithProviders(
       <AppListingDetailBody
         detail={base({

--- a/src/components/Apps/AppListingDetailBody.tsx
+++ b/src/components/Apps/AppListingDetailBody.tsx
@@ -379,8 +379,15 @@ function PrimaryAction({ detail, canOpenPage }: { detail: ListingDetail; canOpen
   }
 
   if (action.mode === 'connect') {
-    // Honest stub — no derivable OAuth authorize URL from the public DTO. Inert
-    // button + a note so the affordance is never a dead 404 link.
+    // Honest stub for a connect listing with NO destination at all: inert button
+    // + a note, so the affordance is never a dead 404 link.
+    //
+    // 🔴 This is NOT the ordinary connect case any more. A connect listing that
+    // carries an https `externalUrl` — which is every one in production — takes
+    // the `visit` branch above and renders a real `Visit ↗`. The mode used to be
+    // returned unconditionally for the sub-kind, which made this inert button
+    // the ONLY thing a viewer ever saw for an app with a linked OAuth client.
+    // See `getDetailPrimaryAction`.
     const GlyphIcon = glyphFor('connect');
     return (
       <Stack gap={4}>

--- a/src/components/Apps/__tests__/appListingCardView.test.ts
+++ b/src/components/Apps/__tests__/appListingCardView.test.ts
@@ -189,13 +189,43 @@ describe('getListingCta — off-site (P2c: View details → unified detail)', ()
       external: false,
     });
   });
-  it('connect → View details → unified detail (Connect affordance lives on the detail page)', () => {
-    expect(getListingCta(offsiteCard('connect', null), { canOpenPage: true })).toEqual({
-      label: 'View details',
-      action: 'detail',
-      href: '/apps/store-preview/ext-app',
-      external: false,
+  /**
+   * 🔴 INTENT CHANGED alongside the detail view-model. Connect used to route to
+   * "View details" unconditionally, on the premise that the Connect affordance
+   * lived on the detail page — but that affordance was a dead stub, so the card
+   * sent the viewer to a page with no way to open the app. The detail now
+   * renders a real `Visit ↗` whenever an off-site listing carries an https
+   * `externalUrl`; the card matches, so the two cannot disagree about whether an
+   * app is reachable.
+   */
+  it('🔴 connect + https externalUrl → Visit ↗ (matches the detail, was View details)', () => {
+    expect(
+      getListingCta(offsiteCard('connect', 'https://connect.app'), { canOpenPage: true })
+    ).toEqual({
+      label: 'Visit',
+      action: 'visit',
+      href: 'https://connect.app',
+      external: true,
     });
+  });
+  it('🔴 connect and external-link with the SAME url produce the SAME CTA', () => {
+    const url = 'https://same-target.app';
+    expect(getListingCta(offsiteCard('connect', url), { canOpenPage: true })).toEqual(
+      getListingCta(offsiteCard('external-link', url), { canOpenPage: true })
+    );
+  });
+  it('connect with no usable target → View details → unified detail (fails safe)', () => {
+    for (const externalUrl of [null, '', 'http://insecure.app', 'javascript:alert(1)']) {
+      expect(
+        getListingCta(offsiteCard('connect', externalUrl), { canOpenPage: true }),
+        String(externalUrl)
+      ).toEqual({
+        label: 'View details',
+        action: 'detail',
+        href: '/apps/store-preview/ext-app',
+        external: false,
+      });
+    }
   });
 });
 

--- a/src/components/Apps/__tests__/appListingDetailView.test.ts
+++ b/src/components/Apps/__tests__/appListingDetailView.test.ts
@@ -302,16 +302,21 @@ describe('getDetailPrimaryAction — off-site', () => {
     );
   });
   /**
-   * 🔴 INTENT REVERSED, DELIBERATELY. This block previously passed a real
-   * `connectClientId: 'client-123'` and asserted `href` was UNDEFINED — it
-   * encoded "even with a client_id, produce nothing", which is exactly the
-   * behaviour that shipped three approved, live listings with a dead
-   * "Connecting this app will be available soon." CTA and no way to open them.
+   * COVERAGE ADDED, NOTHING REVERSED — and the distinction matters, because an
+   * earlier version of this comment claimed the opposite and was wrong.
    *
-   * The new intent: a linked OAuth client does not remove the app's address.
-   * `resolveOffsiteSubKind` flips the sub-kind on `connectClientId != null`
-   * alone, so under the old rule linking a client was the SOLE cause of the
-   * dead CTA. The destination decides now — the sub-kind does not.
+   * The test replaced here passed `connectClientId: 'client-123'` and asserted
+   * `href` was undefined. It read like "even with a client_id, produce
+   * nothing", but the fixture defaults `externalUrl` to `null`, so what it
+   * actually pinned was the destination-LESS case: connect + no address → stub.
+   * That behaviour is UNCHANGED — every one of its assertions still holds, and
+   * they are re-pinned below over four absence shapes instead of one.
+   *
+   * What this case adds is the shape nothing covered: connect WITH a valid
+   * https address. `resolveOffsiteSubKind` flips the sub-kind on
+   * `connectClientId != null` alone, so linking an OAuth client was the sole
+   * cause of the dead CTA on three approved, live listings. The destination
+   * decides now — the sub-kind does not.
    */
   it('🔴 connect + https externalUrl → Visit ↗ (a client_id no longer kills the CTA)', () => {
     const action = getDetailPrimaryAction(

--- a/src/components/Apps/__tests__/appListingDetailView.test.ts
+++ b/src/components/Apps/__tests__/appListingDetailView.test.ts
@@ -301,15 +301,107 @@ describe('getDetailPrimaryAction — off-site', () => {
       'info'
     );
   });
-  it('connect → Connect stub (mode connect, no dead href, note set)', () => {
-    const action = getDetailPrimaryAction(offsiteDetail('connect', { connectClientId: 'client-123' }), {
-      canOpenPage: true,
+  /**
+   * 🔴 INTENT REVERSED, DELIBERATELY. This block previously passed a real
+   * `connectClientId: 'client-123'` and asserted `href` was UNDEFINED — it
+   * encoded "even with a client_id, produce nothing", which is exactly the
+   * behaviour that shipped three approved, live listings with a dead
+   * "Connecting this app will be available soon." CTA and no way to open them.
+   *
+   * The new intent: a linked OAuth client does not remove the app's address.
+   * `resolveOffsiteSubKind` flips the sub-kind on `connectClientId != null`
+   * alone, so under the old rule linking a client was the SOLE cause of the
+   * dead CTA. The destination decides now — the sub-kind does not.
+   */
+  it('🔴 connect + https externalUrl → Visit ↗ (a client_id no longer kills the CTA)', () => {
+    const action = getDetailPrimaryAction(
+      offsiteDetail('connect', {
+        connectClientId: 'client-123',
+        externalUrl: 'https://connect.app',
+      }),
+      { canOpenPage: true }
+    );
+    // Byte-identical to the external-link result for the same URL — the point of
+    // the fix is that connect REUSES that path rather than growing a second one.
+    expect(action).toEqual({
+      label: 'Visit',
+      mode: 'visit',
+      href: 'https://connect.app',
+      external: true,
     });
-    expect(action.mode).toBe('connect');
-    expect(action.label).toBe('Connect');
-    expect(action.href).toBeUndefined();
-    expect(action.external).toBe(false);
-    expect(action.note).toBeTruthy();
+  });
+
+  it('🔴 connect and external-link with the SAME url produce the SAME action', () => {
+    // Structural restatement of the rule, independent of the literals above: if
+    // a future change re-branches on sub-kind before the href guard, these two
+    // diverge and this fails — even if it picks copy that satisfies the pins.
+    const url = 'https://same-target.app';
+    expect(
+      getDetailPrimaryAction(
+        offsiteDetail('connect', { connectClientId: 'c1', externalUrl: url }),
+        {
+          canOpenPage: true,
+        }
+      )
+    ).toEqual(
+      getDetailPrimaryAction(offsiteDetail('external-link', { externalUrl: url }), {
+        canOpenPage: true,
+      })
+    );
+  });
+
+  it('🔴 connect with NO usable destination → the stub still fails safe', () => {
+    // The stub must stay REACHABLE and must stay hrefless. Enumerated over every
+    // way a destination can be absent, with the client_id present in each — so
+    // this cannot pass by accident of the sub-kind being mis-resolved.
+    // (`undefined` is deliberately absent: the DTO types `externalUrl` as
+    // `string | null`, and the fixture's destructuring default would silently
+    // rewrite it to `null` anyway — a row whose label lied about its input.)
+    for (const externalUrl of [null, '', 'http://insecure.app', 'javascript:alert(1)']) {
+      const key = `externalUrl=${String(externalUrl)}`;
+      const action = getDetailPrimaryAction(
+        offsiteDetail('connect', { connectClientId: 'client-123', externalUrl }),
+        { canOpenPage: true }
+      );
+      expect(action.mode, key).toBe('connect');
+      expect(action.label, key).toBe('Connect');
+      expect(action.href, key).toBeUndefined();
+      expect(action.external, key).toBe(false);
+      expect(action.note, key).toBeTruthy();
+    }
+  });
+
+  it('🔴 no off-site listing with an https target is ever left un-navigable', () => {
+    // The off-site analogue of the on-site "no state strands the viewer" matrix.
+    // Anti-vacuity is explicit: count the rows that MUST be navigable and assert
+    // the count, so a change that stopped producing hrefs everywhere cannot make
+    // this green by having nothing to check.
+    const stranded: string[] = [];
+    let navigable = 0;
+    for (const subKind of ['connect', 'external-link'] as const) {
+      for (const externalUrl of ['https://ok.app', 'http://insecure.app', null]) {
+        for (const connectClientId of ['client-123', null]) {
+          const key = `subKind=${subKind} url=${String(externalUrl)} client=${
+            connectClientId ?? 'null'
+          }`;
+          const action = getDetailPrimaryAction(
+            offsiteDetail(subKind, { externalUrl, connectClientId }),
+            { canOpenPage: true }
+          );
+          // `visit` is the only external mode and may only carry an https target.
+          expect(action.external, key).toBe(action.mode === 'visit');
+          if (action.mode === 'visit') {
+            expect(action.href, key).toMatch(/^https:\/\//);
+            navigable++;
+          } else if (externalUrl?.startsWith('https://')) {
+            stranded.push(key);
+          }
+        }
+      }
+    }
+    expect(stranded).toEqual([]);
+    // 2 sub-kinds × 2 client values, all with the https url → 4 navigable rows.
+    expect(navigable).toBe(4);
   });
 });
 

--- a/src/components/Apps/appListingActionGlyph.ts
+++ b/src/components/Apps/appListingActionGlyph.ts
@@ -46,7 +46,9 @@ export const ACTION_GLYPH_ICONS: Record<PrimaryActionGlyph, Icon> = {
   launch: IconPlayerPlay,
   /** Leaves civitai.com in a new tab (`target="_blank"` + `rel="noopener noreferrer"`). */
   external: IconExternalLink,
-  /** OAuth connect affordance (stubbed until the cutover wires it). */
+  /** OAuth connect affordance — the inert stub for a connect listing with NO
+   *  destination. A connect listing WITH an https `externalUrl` takes the
+   *  `external` glyph via `visit`, like any other off-site app. */
   connect: IconPlugConnected,
   /** Informational — no launch, no navigation off-site, and no target to go to. */
   info: IconInfoCircle,
@@ -101,8 +103,11 @@ export function detailActionGlyph(mode: DetailActionMode): PrimaryActionGlyph {
  * already ships for this action, on both the card and the recents rail.
  *
  * `AppListingCard` is the live caller. `getListingCta` still does not emit
- * `'connect'` (the off-site OAuth case routes to `'detail'`), so that arm remains
- * unreachable from live data; it is mapped for totality over the type.
+ * `'connect'` at all: an off-site connect listing now takes the `'visit'` arm
+ * when it carries an https `externalUrl` and `'detail'` when it does not, so the
+ * `'connect'` arm remains unreachable from live data and is mapped for totality
+ * over the type. (The DETAIL view-model does still emit `connect`, for a connect
+ * listing with no destination — `detailActionGlyph`'s arm is live.)
  */
 export function cardActionGlyph(action: ListingCtaAction): PrimaryActionGlyph {
   switch (action) {

--- a/src/components/Apps/appListingCardView.ts
+++ b/src/components/Apps/appListingCardView.ts
@@ -21,13 +21,22 @@
  *     there when the viewer can actually open it) — the direct primary action.
  *   - on-site otherwise (no page, or page but no `appBlocksPages`) → **View
  *     details** → `/apps/store-preview/<slug>` (the unified P2c detail).
- *   - off-site external-link (https) → **Visit ↗** → external anchor (direct
- *     primary action).
- *   - off-site external-link (missing / non-https url) → **View details** →
- *     the unified detail (the DTO already null-guards non-https — we re-guard;
- *     the detail page shows the informational state).
- *   - off-site connect → **View details** → the unified detail (the Connect
- *     affordance lives on the detail page).
+ *   - off-site, EITHER sub-kind, with an https `externalUrl` → **Visit ↗** →
+ *     external anchor (direct primary action). 🔴 The sub-kind does NOT decide
+ *     this; the presence of a destination does — see below.
+ *   - off-site with no usable target (missing / non-https url, either sub-kind)
+ *     → **View details** → the unified detail (the DTO already null-guards
+ *     non-https — we re-guard; the detail page shows the informational state).
+ *
+ * 🔴 Connect used to route to "View details" UNCONDITIONALLY, on the premise
+ * that "the Connect affordance lives on the detail page". That affordance was a
+ * dead stub, so the card handed the viewer a detail page with nothing on it —
+ * the card half of the same defect. The detail now renders a real `Visit ↗` for
+ * any off-site listing carrying an https `externalUrl` (see
+ * `appListingDetailView`), so the card matches it: a connect listing with a
+ * destination gets the direct Visit, and only a listing with NO destination
+ * falls back to the detail. Card and detail must not disagree about whether an
+ * app is reachable.
  * Every CTA now has a working `href` (never actionless). The card ALSO links its
  * title to the detail (via `getListingDetailHref`) so the detail is reachable
  * even when the primary CTA is a direct Open / Visit.
@@ -128,17 +137,17 @@ export function getListingCta(
     return { label: 'View details', action: 'detail', href: detailHref, external: false };
   }
 
-  // Off-site.
-  if (card.kindData.subKind === 'external-link') {
-    const href = safeExternalHref(card.kindData.externalUrl);
-    if (href) {
-      return { label: 'Visit', action: 'visit', href, external: true };
-    }
-    // No usable external target (missing / non-https) → the unified detail.
-    return { label: 'View details', action: 'detail', href: detailHref, external: false };
+  // Off-site — BOTH sub-kinds. The destination decides, not the sub-kind: a
+  // connect app is reached at its own address exactly like a plain external
+  // link (it starts its own OAuth flow from there). Mirrors
+  // `getDetailPrimaryAction`; do NOT reintroduce a sub-kind test above this
+  // line, or the card and the detail disagree again.
+  const href = safeExternalHref(card.kindData.externalUrl);
+  if (href) {
+    return { label: 'Visit', action: 'visit', href, external: true };
   }
-
-  // Off-site connect (OAuth) — the Connect affordance lives on the detail page.
+  // No usable external target (missing / non-https, either sub-kind) → the
+  // unified detail, which shows the informational / connect-stub state.
   return { label: 'View details', action: 'detail', href: detailHref, external: false };
 }
 

--- a/src/components/Apps/appListingDetailView.ts
+++ b/src/components/Apps/appListingDetailView.ts
@@ -56,13 +56,31 @@
  *     explicitly in the "no on-site state strands the viewer" matrix test — but
  *     the branch is vacuous today: every approved on-site listing declares a
  *     page, so nothing takes it.
- *   - off-site external-link (https) → **Visit ↗** → external anchor.
- *   - off-site external-link (missing / non-https) → **informational** (guarded
- *     out; no target).
- *   - off-site connect (OAuth) → **Connect** STUB: a complete OAuth authorize
- *     URL is NOT derivable from the public DTO (needs redirect_uri /
- *     response_type / scope), so the connect flow is an honest stub with a note
- *     until the cutover wires it — no dead 404 nav.
+ *   - off-site, EITHER sub-kind, with an https `externalUrl` → **Visit ↗** →
+ *     external anchor. 🔴 The sub-kind does NOT decide this; the presence of a
+ *     destination does. See the connect note below.
+ *   - off-site external-link with no usable target (missing / non-https) →
+ *     **informational** (guarded out; no target).
+ *   - off-site connect (OAuth) with no usable target → **Connect** STUB with a
+ *     note — the only remaining state with nowhere to send the viewer.
+ *
+ * 🔴 THE CONNECT STUB USED TO BE UNCONDITIONAL, AND THAT WAS THE BUG. Every
+ * off-site listing with a linked OAuth client rendered a dead
+ * "Connecting this app will be available soon." affordance — no href, disabled
+ * button — because `resolveOffsiteSubKind` routes on `connectClientId != null`
+ * alone (`app-listing.service.ts`), so linking a client was the ONLY thing that
+ * moved a listing off the working `Visit ↗` path. Three approved, live listings
+ * were in that state; a fourth, with no client, worked.
+ *
+ * The stub's stated premise — "a complete OAuth authorize URL is NOT derivable
+ * from the public DTO" — is true and irrelevant. These are CONFIDENTIAL clients
+ * that own their own `redirect_uri` / `state` / PKCE and start the flow from
+ * their own site; the store never needed to build an authorize URL, only to get
+ * the viewer to the app. That destination is already on the public DTO as
+ * `externalUrl`, https-guarded, and the external-link branch has always
+ * rendered it correctly. So connect now reuses that same proven path rather
+ * than growing a second one, and the stub survives only for a connect listing
+ * with genuinely no destination — where it still fails safe.
  */
 
 import { safeExternalHref } from '~/components/Apps/appListingCardView';
@@ -171,10 +189,17 @@ export function getDetailPrimaryAction(
     };
   }
 
-  // Off-site.
+  // Off-site — BOTH sub-kinds. An off-site app lives at its own address, and
+  // that address is the only thing this page can route to; a connect app then
+  // runs its own confidential-client OAuth flow from there. So the destination,
+  // not the sub-kind, decides the action: one https-guarded path
+  // (`safeExternalHref`), shared with the external-link case that has always
+  // worked. Do NOT reintroduce a sub-kind test above this line — that is
+  // precisely what made a linked OAuth client the sole cause of a dead CTA.
+  const href = safeExternalHref(kd.externalUrl);
+  if (href) return { label: 'Visit', mode: 'visit', href, external: true };
+
   if (kd.subKind === 'external-link') {
-    const href = safeExternalHref(kd.externalUrl);
-    if (href) return { label: 'Visit', mode: 'visit', href, external: true };
     return {
       label: 'Unavailable',
       mode: 'info',
@@ -183,7 +208,8 @@ export function getDetailPrimaryAction(
     };
   }
 
-  // Off-site connect (OAuth) — honest stub (see docstring: no derivable authorize URL).
+  // Off-site connect with NO usable destination — the honest stub, now reached
+  // only in that genuinely-nowhere-to-go state. Fails safe: no dead nav.
   return {
     label: 'Connect',
     mode: 'connect',


### PR DESCRIPTION
## The bug

Three approved, live, moderator-visible off-site listings render a **dead primary CTA** reading *"Connecting this app will be available soon."* — a disabled button with no `href`. Users have no way to open those apps from the store at all.

**Mechanism.** `getDetailPrimaryAction`'s final fallthrough (`src/components/Apps/appListingDetailView.ts`) returned the connect **stub unconditionally**. The branch just above it handles `subKind === 'external-link'` and returns a working `Visit ↗` built from `externalUrl`. Which branch you land on is decided by `resolveOffsiteSubKind` (`src/server/services/blocks/app-listing.service.ts`), which is `connectClientId ? 'connect' : 'external-link'`.

So **linking an OAuth client was the only thing that routed a listing onto the dead path.** All four off-site listings were enumerated (not sampled): the three with a linked client were dead; the one without a client rendered a working `Visit ↗`.

**The stub's stated premise was false.** Its docstring justified itself with *"a complete OAuth authorize URL is NOT derivable from the public DTO"*. True, and irrelevant: connecting already works and is in heavy daily use (~7,100 consents on Comfy Cloud, ~300 on Cosmetic Studio, ~230 on AI Radio, with activity today). These are **confidential clients** that own their own `redirect_uri` / `state` / PKCE and start the flow from their own site — the store never needed to build an authorize URL, only to get the viewer to the app. That destination is already on the public DTO as `externalUrl` (https-guarded at the projection *and* re-guarded at the render boundary), already 200-serving. The connect branch simply never read it.

## The fix

In **both** view-models, the **destination** decides the action, not the sub-kind:

```ts
// off-site, both sub-kinds
const href = safeExternalHref(kd.externalUrl);
if (href) return { label: 'Visit', mode: 'visit', href, external: true };
// …then, and only then, the sub-kind-specific no-destination fallbacks
```

- **Detail** (`appListingDetailView.ts`): a connect listing with an https `externalUrl` now returns the **byte-identical action** the external-link case has always returned for the same URL — `Visit ↗`, external anchor, `target=_blank` + `rel="noopener noreferrer"`. Copy is exactly what the existing branch used; nothing new was invented. The app then runs its own connect flow from its own site.
- **Card** (`appListingCardView.ts`) — the "also in scope" coherence item, **done, not deferred**: `getListingCta` used to give every connect card `View details`, pointing at a detail page whose affordance was the dead stub. It now mirrors the detail — direct `Visit ↗` when there is a destination, `View details` when there is not. Card and detail can no longer disagree about whether an app is reachable.
- **The stub stays reachable and fails safe**: a connect listing with a missing / blank / non-https `externalUrl` still gets the inert `Connect` + note, with no href and no dead nav. Only `https` qualifies, via the existing `safeExternalHref` — no new predicate was written.

Deliberately **not** touched: `resolveOffsiteSubKind`, any server/DTO shape, `ConnectScopesPanel`, `OffsiteReviewQueue.tsx`. No server-side connect redirect was built.

Comment/docstring claims that only the old behaviour made true were rewritten in the same commit rather than left standing — the module docstrings on both view-models, the `connect` arms in `appListingActionGlyph.ts`, and the `connect`-branch comment in `AppListingDetailBody.tsx`.

## 🔴 A deliberately-pinned test was REVERSED — this is the substance of the change

`src/components/Apps/__tests__/appListingDetailView.test.ts` previously passed a real `connectClientId: 'client-123'` and asserted:

```ts
expect(action.href).toBeUndefined();
```

That test did not merely *describe* the behaviour, it **encoded the intent**: *"even with a client_id, produce nothing."* Reversing it is the actual decision in this PR, not an incidental test edit — so it is called out here rather than left to be discovered in the diff.

The new intent, pinned in its place: **a linked OAuth client does not remove the app's address.** Since `resolveOffsiteSubKind` flips the sub-kind on `connectClientId != null` alone, the old rule made linking a client the *sole* cause of the dead CTA. `note` was only ever asserted `toBeTruthy()`, so copy was free.

The stub's own coverage was kept and strengthened rather than deleted — it is now enumerated over every way a destination can be absent (`null`, `''`, `http://…`, `javascript:…`), each with the `client_id` present, so it cannot pass by accident of a mis-resolved sub-kind.

## Tests

Node `unit` project (where the real correctness coverage for these view-models lives): **49 → 54** across the two suites; the whole `src/components/Apps/__tests__/` directory is **749 passed / 43 files**. New coverage:

- connect + https `externalUrl` → `Visit ↗` (the reversal, value-pinned).
- connect and external-link with the **same URL produce the same action** — a structural restatement that fails even if a future re-branch picks copy satisfying the literal pins.
- connect with no usable destination → the stub still fails safe, over 4 absence shapes.
- an off-site matrix (2 sub-kinds × 3 URL shapes × 2 client values) asserting no listing with an https target is left un-navigable, with an **explicit anti-vacuity count** (`navigable === 4`) so it cannot go green by producing no hrefs at all.
- card equivalents of the first three.

Browser (`component`) project — not run by CI, run here anyway because it exercises the render path that produced the user-visible symptom: `AppListingCard.browser.test.tsx` **43 passed**, `AppListingDetailBody.browser.test.tsx` **29 passed**. The new detail test asserts a real anchor to the app's address exists and that the string *"Connecting this app will be available soon"* is **gone** from that state.

### Mutation results

Every mutant was applied to the real source, run, and confirmed to die **with its own specific error** — not merely to turn something red:

| Mutant | Died on |
|---|---|
| Detail: re-gate the href on sub-kind (the exact pre-fix behaviour) | 3 unit tests — `expected { label: 'Connect', … } to deeply equal { label: 'Visit', mode: 'visit', … }`, and the matrix's `expected [ …(2) ] to deeply equal []` |
| Detail: drop the https guard (`safeExternalHref` → raw `externalUrl`) | 3 unit tests — `externalUrl=http://insecure.app: expected 'visit' to be 'connect'`, plus `expected 'http://insecure.app' to match /^https:\/\//` |
| Detail: invent new copy on the shared path (`Visit` → `Connect`) | 2 unit tests — `expected { label: 'Connect', … } to deeply equal { label: 'Visit', mode: 'visit', … }` |
| Card: re-gate the CTA on sub-kind (the pre-fix card behaviour) | 2 unit tests — `expected { label: 'View details', … } to deeply equal { label: 'Visit', … }` |
| Detail: let the connect stub swallow the external-link no-target case | 2 unit tests — `expected { label: 'Connect', … } to deeply equal { label: 'Unavailable', … }` and `expected 'connect' to be 'info'` |
| Detail re-gate, against the **browser** suite | `🔴 a connect listing WITH an https externalUrl renders a real Visit ↗ anchor` — `Timed out in waitUntil!` (the anchor keyed on the app's href never appears) |
| Card re-gate, against the **browser** suite | `🔴 off-site connect WITH an https externalUrl → Visit ↗ external anchor` — `Cannot find element with locator: getByRole('link', { name: 'Visit' })` |

The harness itself was validated against a known-bad input before any of its verdicts were read (a `Connect` → `ConnectXX` label mutation produced `expected 'ConnectXX' to be 'Connect'`, 1 failed / 18 passed).

## Base-vs-head gate attribution

`main` is red repo-wide on `Typecheck`, so a head-only reading says nothing:

- **Typecheck** — **146 errors at base, 146 at head, and the two error sets are byte-identical** (`diff` of the sorted error lines is empty). **Zero** of them are in `src/components/Apps/`. Positive control on the instrument: `tsc --listFilesOnly` confirms all four changed source files are actually in the compilation, so the clean verdict is about them and not about their absence.
- **Prettier** — measured per file, head vs base. Every changed file is `head <= base` in unformatted-line count: 4 were already unformatted at base by identical amounts, `appListingDetailView.test.ts` **improved** 36 → 27, and the files I added content to gained **zero** new formatting debt.
- **ESLint** — 0 errors across all 8 changed files; 1 pre-existing warning (`'ThemeIcon' is defined but never used` in `AppListingDetailBody.tsx`), untouched here.

## Two separate findings — flagged, NOT fixed here

1. **`cosmetic-studio` is linked to the wrong OAuth client.** Two near-identical clients share a redirect URI: the one the listing points at has **3** consents; the one the app actually uses has **301**. This is inert today *only* because the sub-kind check tests non-null — but it would authorize against an effectively abandoned client the moment anything reads `connectClientId`. It is a **data fix**, not a code fix, and is out of scope for this PR. Worth doing before any future work reads that field.
2. **Missing gate: nothing prevents approving an off-site listing whose CTA is a stub.** The stub landed 2026-07-01 (#2874); all three affected listings were approved 07-24 → 07-28, straight past it. A moderator-facing check — or simply surfacing the rendered CTA in the review queue — would have caught all three at approval time. Worth a follow-up.

## Not verified

- No production database was read or written by this change, and nothing above required it.
- The `component` (browser) suites are not run by CI and were run locally against a NixOS-substituted Chromium (the repo-pinned Playwright download is dynamically linked and cannot execute on this host). The two files were run **individually** — running both in one invocation trips an unrelated, pre-existing `vi.mock` registry error.
