### PR TITLE
feat(blocks): register the chat-completion step — the first 'textOutput' adopter

### DIFF
--- a/src/server/services/blocks/__tests__/workflow.service.test.ts
+++ b/src/server/services/blocks/__tests__/workflow.service.test.ts
@@ -386,9 +386,7 @@ describe('snapshotFromWorkflow', () => {
     });
 
     it('omits spentAccountType when the transactions list is empty', () => {
-      const snap = snapshotFromWorkflow(
-        fakeWorkflow({ transactions: { list: [] } }) as never
-      );
+      const snap = snapshotFromWorkflow(fakeWorkflow({ transactions: { list: [] } }) as never);
       expect(snap.spentAccountType).toBeUndefined();
     });
 
@@ -1173,9 +1171,7 @@ describe('block input yields populated workflow metadata params (real graph path
     // The checkpoint anchor shows up in the resources snapshot (this is the part
     // of `workflowMetadata.resources` the graph resolves without enrichment).
     expect(resources).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({ id: 99, model: { type: 'Checkpoint' } }),
-      ])
+      expect.arrayContaining([expect.objectContaining({ id: 99, model: { type: 'Checkpoint' } })])
     );
   });
 
@@ -1279,7 +1275,11 @@ describe('block input yields populated workflow metadata params (real graph path
       if (!result.success) {
         throw new Error(`img2img:edit graph validation failed: ${JSON.stringify(result.errors)}`);
       }
-      const data = result.data as { workflow: string; ecosystem: string; images?: Array<{ url: string }> };
+      const data = result.data as {
+        workflow: string;
+        ecosystem: string;
+        images?: Array<{ url: string }>;
+      };
       expect(data.workflow).toBe('img2img:edit');
       expect(data.ecosystem).toBe(ecoKey);
       // The bounded source image rides into the graph's reference `images` node.
@@ -1667,10 +1667,7 @@ describe('edit-only checkpoint version + no sourceImage', () => {
 
   // ── NO REGRESSION ──────────────────────────────────────────────────────────
   it('still accepts an edit-only version WITH a sourceImage (img2img:edit)', () => {
-    const out = buildImageWorkflowInput(
-      body({ sourceImage }) as never,
-      resolved(QWEN_EDIT_V2511)
-    );
+    const out = buildImageWorkflowInput(body({ sourceImage }) as never, resolved(QWEN_EDIT_V2511));
     expect(out.workflow).toBe('img2img:edit');
     expect(out.ecosystem).toBe('Qwen');
     // The version the caller asked for is the one that anchors the graph.
@@ -1994,7 +1991,11 @@ describe('buildCustomComfyWorkflowInput (translator)', () => {
   const recipe = getRecipe('seamless-pano-360')!;
 
   it('applies the recipe param schema then runs its pure builder', () => {
-    const input = buildCustomComfyWorkflowInput(recipe, { prompt: 'a lake', seed: 1, engine: 'zimage-turbo' });
+    const input = buildCustomComfyWorkflowInput(recipe, {
+      prompt: 'a lake',
+      seed: 1,
+      engine: 'zimage-turbo',
+    });
     expect(input.trace).toBe('binary');
     expect(input.resources[0]).toContain('z_image_turbo');
     expect(input.workflow['1'].class_type).toBe('UNETLoader');
@@ -2028,12 +2029,16 @@ describe('createBlockCustomComfyStep (step wrapper)', () => {
   it('formats the timeout per engine: zimage 90s → 00:01:30, flux2 150s → 00:02:30', () => {
     const input = buildCustomComfyWorkflowInput(recipe, { prompt: 'a lake', seed: 1 });
     expect(
-      createBlockCustomComfyStep(input, recipe.budgetFor({ prompt: 'a lake', engine: 'zimage-turbo' }).stepTimeoutSeconds)
-        .timeout
+      createBlockCustomComfyStep(
+        input,
+        recipe.budgetFor({ prompt: 'a lake', engine: 'zimage-turbo' }).stepTimeoutSeconds
+      ).timeout
     ).toBe('00:01:30');
     expect(
-      createBlockCustomComfyStep(input, recipe.budgetFor({ prompt: 'a lake', engine: 'flux2-klein' }).stepTimeoutSeconds)
-        .timeout
+      createBlockCustomComfyStep(
+        input,
+        recipe.budgetFor({ prompt: 'a lake', engine: 'flux2-klein' }).stepTimeoutSeconds
+      ).timeout
     ).toBe('00:02:30');
   });
 });
@@ -2077,7 +2082,13 @@ describe('projectAppWorkflow: customComfy blobs', () => {
           metadata: {},
           output: {
             blobs: [
-              { id: 'p1', type: 'image', url: 'https://cdn/pano.png', available: true, nsfwLevel: 'pg' },
+              {
+                id: 'p1',
+                type: 'image',
+                url: 'https://cdn/pano.png',
+                available: true,
+                nsfwLevel: 'pg',
+              },
               { id: 'p2', type: 'image', url: 'https://blocked/', available: false },
             ],
           },
@@ -2202,10 +2213,14 @@ describe('🔴 registered step output — surfaced on the snapshot AND the proje
   // one-sided test behind.
   it('the registered population contains BOTH a media entry and a text entry', () => {
     const shapes = listRegisteredSteps().map(([, s]) => postureProducesMedia(s.moderationPosture));
-    expect(shapes.filter(Boolean).length, 'no MEDIA entry — the media branch above is vacuous')
-      .toBeGreaterThan(0);
-    expect(shapes.filter((m) => !m).length, 'no TEXT entry — the text branch above is vacuous')
-      .toBeGreaterThan(0);
+    expect(
+      shapes.filter(Boolean).length,
+      'no MEDIA entry — the media branch above is vacuous'
+    ).toBeGreaterThan(0);
+    expect(
+      shapes.filter((m) => !m).length,
+      'no TEXT entry — the text branch above is vacuous'
+    ).toBeGreaterThan(0);
   });
 
   // The concrete shape, pinned literally rather than derived from the extractor
@@ -2398,7 +2413,10 @@ describe('sourceImages[] — normalization + per-ecosystem cap', () => {
 
   // ── the emitted graph input ────────────────────────────────────────────────
   it('emits EVERY array element into the graph images[] (order preserved)', () => {
-    const out = buildImageWorkflowInput(body({ sourceImages: images(3) }) as never, resolved('Qwen'));
+    const out = buildImageWorkflowInput(
+      body({ sourceImages: images(3) }) as never,
+      resolved('Qwen')
+    );
     expect(out.workflow).toBe('img2img:edit');
     expect(out.images).toEqual([
       { url: 'https://image.civitai.com/abc/0.jpeg', width: 1024, height: 1024 },

--- a/src/server/services/blocks/__tests__/workflow.service.test.ts
+++ b/src/server/services/blocks/__tests__/workflow.service.test.ts
@@ -40,6 +40,7 @@ import {
   getStepByOrchestratorType,
   listRegisteredSteps,
   NATIVELY_EXTRACTED_STEP_TYPES,
+  postureProducesMedia,
   type AnyBlockStep,
 } from '../steps';
 import { nsfwLevelFromContentRating } from '~/shared/constants/browsingLevel.constants';
@@ -2125,12 +2126,40 @@ describe('🔴 registered step output — surfaced on the snapshot AND the proje
     });
   }
 
+  // 🔴 POSTURE-GATED, ON THE REGISTRY'S OWN PREDICATE — not on
+  // `extractOutput != null`. Both loops below used to call `step.extractOutput`
+  // for EVERY entry, which was silently fine only while every registered entry
+  // produced media. The first `'textOutput'` entry made it a raw
+  // `TypeError: step.extractOutput is not a function`, because a text entry has
+  // no media extractor BY CONSTRUCTION (`TextOutputSurface.extractOutput?: never`
+  // plus load-time clause 8-ii).
+  //
+  // 🔴 THE GATE MUST NOT MAKE THE TEXT HALF VACUOUS. Skipping text entries would
+  // turn a population test into one that covers only the population it already
+  // covered. So each loop asserts the MIRROR property for a text entry: it
+  // contributes NOTHING to the media channel. That is the read-path half of the
+  // anti-smuggling rule — `StepOutputMedia.url` is a bare string that reaches
+  // `imageUrls` / `images[].url` without ever meeting
+  // `attachModeratedStepTextOutputs`, so a text step appearing there at all
+  // would be generated text published unscanned.
+  //
+  // Keyed on `postureProducesMedia` because that is what `snapshotFromWorkflow`
+  // and `projectAppWorkflow` themselves key on — one rule, one predicate, and
+  // the test cannot drift from the code by asking a different question.
   it('EVERY registered step surfaces its output on snapshotFromWorkflow.imageUrls', () => {
     for (const [id, step] of listRegisteredSteps()) {
       for (const variant of step.variants) {
-        const expected = step.extractOutput(step.canonicalOutputFor(variant)).map((m) => m.url);
-        expect(expected.length, `step '${id}' produced no expected urls`).toBeGreaterThan(0);
         const snap = snapshotFromWorkflow(workflowWithRegisteredStep(step, variant) as never);
+        if (!postureProducesMedia(step.moderationPosture)) {
+          expect(
+            snap.imageUrls ?? [],
+            `step '${id}' variant '${variant}': a TEXT-posture step reached the media channel, ` +
+              'which does not pass through the output scan — that is unscanned generated text'
+          ).toEqual([]);
+          continue;
+        }
+        const expected = step.extractOutput!(step.canonicalOutputFor(variant)).map((m) => m.url);
+        expect(expected.length, `step '${id}' produced no expected urls`).toBeGreaterThan(0);
         expect(
           snap.imageUrls,
           `step '${id}' variant '${variant}': the caller is CHARGED for this step and its ` +
@@ -2143,8 +2172,16 @@ describe('🔴 registered step output — surfaced on the snapshot AND the proje
   it('EVERY registered step surfaces its output on projectAppWorkflow.images', () => {
     for (const [id, step] of listRegisteredSteps()) {
       for (const variant of step.variants) {
-        const expected = step.extractOutput(step.canonicalOutputFor(variant));
         const projected = projectAppWorkflow(workflowWithRegisteredStep(step, variant) as never);
+        if (!postureProducesMedia(step.moderationPosture)) {
+          expect(
+            projected.images,
+            `step '${id}' variant '${variant}': a TEXT-posture step reached the media channel, ` +
+              'which does not pass through the output scan — that is unscanned generated text'
+          ).toEqual([]);
+          continue;
+        }
+        const expected = step.extractOutput!(step.canonicalOutputFor(variant));
         expect(
           projected.images.map((i) => i.url),
           `step '${id}' variant '${variant}': queryAppWorkflows returns images: [] for a ` +
@@ -2155,6 +2192,20 @@ describe('🔴 registered step output — surfaced on the snapshot AND the proje
         );
       }
     }
+  });
+
+  // 🔴 A POSITIVE CONTROL ON THE GATE ITSELF. The two loops above now `continue`
+  // on a text entry, and a gate that skips everything is indistinguishable from
+  // a gate that works. This asserts the population actually contains BOTH
+  // shapes, so neither branch above is vacuous — and it fails loudly if the last
+  // entry of either kind is ever removed, rather than leaving a silently
+  // one-sided test behind.
+  it('the registered population contains BOTH a media entry and a text entry', () => {
+    const shapes = listRegisteredSteps().map(([, s]) => postureProducesMedia(s.moderationPosture));
+    expect(shapes.filter(Boolean).length, 'no MEDIA entry — the media branch above is vacuous')
+      .toBeGreaterThan(0);
+    expect(shapes.filter((m) => !m).length, 'no TEXT entry — the text branch above is vacuous')
+      .toBeGreaterThan(0);
   });
 
   // The concrete shape, pinned literally rather than derived from the extractor

--- a/src/server/services/blocks/steps/__tests__/chat-completion.step.test.ts
+++ b/src/server/services/blocks/steps/__tests__/chat-completion.step.test.ts
@@ -1,0 +1,470 @@
+import { describe, expect, it } from 'vitest';
+import {
+  CHAT_COMPLETION_ASSUMED_CHARS_PER_TOKEN,
+  CHAT_COMPLETION_MAX_OUTPUT_TOKENS,
+  CHAT_COMPLETION_MODELS,
+  CHAT_COMPLETION_PRICE_BUZZ,
+  chatCompletionStep,
+  type ChatCompletionStepParams,
+} from '~/server/services/blocks/steps/chat-completion.step';
+import {
+  assertStepInvariants,
+  containsAirReference,
+  estimateStepBuzz,
+  getStep,
+  getStepByOrchestratorType,
+  planStepSpend,
+  REGISTERED_STEP_IDS,
+  resolveStepVariant,
+  type AnyBlockStep,
+} from '~/server/services/blocks/steps';
+import { MAX_SCANNED_CONTENT_CHARS } from '~/server/services/blocks/steps/text-output-moderation';
+
+/**
+ * Coverage for the `chat-completion` registry entry — the first `'textOutput'`
+ * adopter.
+ *
+ * The registry's own population tests (`step-registry.test.ts`) already run
+ * every load-time clause over every registered entry, so this file does NOT
+ * repeat them. What it covers is the part of the entry no generic clause can
+ * see: the model allowlist, the `maxTokens` ceiling and its derivation from the
+ * scan cap, the deliberately-absent `modalities` surface, and an `extractText`
+ * pinned against the REAL orchestrator response rather than against itself.
+ */
+
+const STEP_ID = 'chat-completion';
+
+/** Params that parse. Every negative case below is this, with ONE thing broken. */
+const VALID_PARAMS: ChatCompletionStepParams = {
+  model: 'deepseek/deepseek-chat',
+  messages: [{ role: 'user', content: 'hello' }],
+  maxTokens: 128,
+};
+
+/**
+ * 🔴 THE REAL ORCHESTRATOR RESPONSE, captured from a live `succeeded` workflow.
+ *
+ * Copied here independently of `canonicalOutputFor` so that this file's
+ * assertions are not simply re-reading the entry's own sample. Note what it does
+ * NOT contain: `choices[0].message` carries only `content` — no `role`.
+ */
+const REAL_COMPLETED_STEP = {
+  $type: 'chatCompletion',
+  name: 'block-step',
+  status: 'succeeded',
+  output: {
+    id: 'gen-1785782779-5cBM39ztiT9kC93qr5kf',
+    object: 'chat.completion',
+    created: 1785782779,
+    model: 'openai/gpt-4o-mini',
+    choices: [{ index: 0, message: { content: 'OK' }, finishReason: 'stop' }],
+    usage: { promptTokens: 12, completionTokens: 1, totalTokens: 13 },
+    systemFingerprint: 'fp_5259353f0d',
+  },
+};
+
+const parse = (params: unknown) => chatCompletionStep.paramSchema.safeParse(params);
+const withParam = (key: string, value: unknown) => ({ ...VALID_PARAMS, [key]: value });
+
+describe('chat-completion — registration', () => {
+  it('is registered under its own id, and the id equals step.id', () => {
+    expect(REGISTERED_STEP_IDS).toContain(STEP_ID);
+    expect(getStep(STEP_ID)).toBe(chatCompletionStep as unknown as AnyBlockStep);
+    expect(chatCompletionStep.id).toBe(STEP_ID);
+  });
+
+  it('does not disturb the existing wire enum ordering', () => {
+    // Existing tests use `REGISTERED_STEP_IDS[0]` as "a valid id"; a new entry
+    // must be appended, never prepended.
+    expect(REGISTERED_STEP_IDS[0]).toBe('convert-image');
+  });
+
+  it('declares the four axes the registry dispatches on', () => {
+    expect(chatCompletionStep.orchestratorType).toBe('chatCompletion');
+    expect(chatCompletionStep.billingMode).toBe('prepaidFixed');
+    expect(chatCompletionStep.moderationPosture).toBe('textOutput');
+    expect(chatCompletionStep.resourcePolicy).toEqual({ kind: 'none' });
+  });
+
+  it('is resolvable by the $type the workflow extractors see', () => {
+    expect(getStepByOrchestratorType('chatCompletion')).toBe(
+      chatCompletionStep as unknown as AnyBlockStep
+    );
+  });
+
+  it('satisfies every load-time invariant (re-asserted for THIS entry by name)', () => {
+    expect(() =>
+      assertStepInvariants(STEP_ID, chatCompletionStep as unknown as AnyBlockStep)
+    ).not.toThrow();
+  });
+
+  it('🔴 declares NO extractOutput — a text entry has no media channel at all', () => {
+    // The anti-smuggling property: `StepOutputMedia.url` is a bare string that
+    // reaches `snapshot.imageUrls` without meeting the output scan, so a text
+    // entry must not have one. Clause 8-ii rejects it; this pins the entry.
+    expect(
+      (chatCompletionStep as unknown as { extractOutput?: unknown }).extractOutput
+    ).toBeUndefined();
+    expect(
+      (chatCompletionStep as unknown as { auditableText?: unknown }).auditableText
+    ).toBeUndefined();
+  });
+});
+
+describe('chat-completion — the model allowlist', () => {
+  it('exposes exactly the three v1 models, as BOTH the enum and the variants', () => {
+    expect(CHAT_COMPLETION_MODELS).toEqual([
+      'deepseek/deepseek-chat',
+      'cognitivecomputations/dolphin-mistral-24b-venice-edition',
+      'openai/gpt-4o-mini',
+    ]);
+    // 🔴 The two must be the same set. The enum is the parse-time bound and
+    // `variants` is the money-path bound; a divergence means one of them is
+    // guarding nothing.
+    expect([...chatCompletionStep.variants]).toEqual([...CHAT_COMPLETION_MODELS]);
+  });
+
+  it('accepts every declared model', () => {
+    for (const model of CHAT_COMPLETION_MODELS) {
+      expect(parse(withParam('model', model)).success).toBe(true);
+    }
+  });
+
+  it('🔴 REJECTS a model outside the allowlist — at PARSE, before the variant guard', () => {
+    // The measured failure this closes: a fabricated model is quoted 1 Buzz,
+    // CHARGED 1 Buzz, and then fails at execution with no output and no refund.
+    const result = parse(withParam('model', 'openai/gpt-5-turbo-fictional'));
+    expect(result.success).toBe(false);
+  });
+
+  it('resolves each model to itself as the bounded variant, and prices off it', () => {
+    for (const model of CHAT_COMPLETION_MODELS) {
+      const params = withParam('model', model);
+      const step = chatCompletionStep as unknown as AnyBlockStep;
+      const variant = resolveStepVariant(step, params);
+      expect(variant).toBe(model);
+      expect(planStepSpend(step, params, variant).reserveBuzz).toBe(CHAT_COMPLETION_PRICE_BUZZ);
+    }
+  });
+});
+
+describe('chat-completion — the bounded param surface', () => {
+  it('accepts the valid shape', () => {
+    expect(parse(VALID_PARAMS).success).toBe(true);
+  });
+
+  it('🔴 REJECTS `modalities` — the field that would return unmoderated base64 images', () => {
+    // `modalities: ['image']` routes the request to the image pipeline and
+    // returns images on `choices[].message.images[].image_url.url` as base64
+    // data URIs, which never become moderated `Image` rows. Not exposing it is
+    // what makes this entry honestly text-only.
+    expect(parse(withParam('modalities', ['image'])).success).toBe(false);
+    expect(parse(withParam('modalities', ['text'])).success).toBe(false);
+  });
+
+  it('🔴 REJECTS `image_config` — modalities’ companion', () => {
+    expect(parse(withParam('image_config', { aspect_ratio: '1:1' })).success).toBe(false);
+  });
+
+  it('REJECTS every other orchestrator input field this entry does not expose', () => {
+    // `.strict()` in action. Each of these is a real `ChatCompletionInput`
+    // field; forwarding any of them from an untrusted iframe is a widening
+    // nobody reviewed.
+    for (const [key, value] of [
+      ['tools', []],
+      ['tool_choice', 'auto'],
+      ['n', 4],
+      ['stop', ['x']],
+      ['seed', 1],
+      ['topP', 0.5],
+      ['presencePenalty', 1],
+      ['frequencyPenalty', 1],
+      ['logprobs', true],
+      ['chatTemplateKwargs', {}],
+      ['responseFormat', { type: 'json_object' }],
+      ['user', 'someone'],
+    ] as [string, unknown][]) {
+      expect(parse(withParam(key, value)).success, `expected '${key}' to be rejected`).toBe(false);
+    }
+  });
+
+  describe('maxTokens', () => {
+    it('🔴 REJECTS an OMITTED maxTokens — an unbounded default is unbounded compute at a flat price', () => {
+      const { maxTokens: _dropped, ...withoutMaxTokens } = VALID_PARAMS;
+      expect(parse(withoutMaxTokens).success).toBe(false);
+    });
+
+    it('accepts the boundary values and rejects just outside them', () => {
+      expect(parse(withParam('maxTokens', 1)).success).toBe(true);
+      expect(parse(withParam('maxTokens', CHAT_COMPLETION_MAX_OUTPUT_TOKENS)).success).toBe(true);
+      expect(parse(withParam('maxTokens', 0)).success).toBe(false);
+      expect(parse(withParam('maxTokens', CHAT_COMPLETION_MAX_OUTPUT_TOKENS + 1)).success).toBe(
+        false
+      );
+      expect(parse(withParam('maxTokens', 1.5)).success).toBe(false);
+      expect(parse(withParam('maxTokens', 200_000)).success).toBe(false);
+    });
+
+    it('🔴 THE DERIVATION: the ceiling cannot produce more than the scan will accept', () => {
+      // The two constants live in different modules on purpose — importing the
+      // cap into the entry would drag `orchestrator.service` onto the registry's
+      // module-load path. THIS is the link between them, and it goes red if
+      // either number moves.
+      //
+      // Over the cap is a WITHHOLD, not a truncation, so a ceiling that can
+      // exceed it designs a guaranteed "paid for nothing" into the capability.
+      const worstCaseChars =
+        CHAT_COMPLETION_MAX_OUTPUT_TOKENS * CHAT_COMPLETION_ASSUMED_CHARS_PER_TOKEN;
+      expect(worstCaseChars).toBeLessThan(MAX_SCANNED_CONTENT_CHARS);
+      // And with real headroom, not by one character: the nominal ~4 chars/token
+      // is an average, and whitespace/repetition merges push the real ratio up.
+      expect(worstCaseChars * 3).toBeLessThanOrEqual(MAX_SCANNED_CONTENT_CHARS);
+      // The literals, pinned. A test that only compares the two constants to
+      // each other passes if BOTH are changed together, which is exactly the
+      // change that needs a human to look at it.
+      expect(CHAT_COMPLETION_MAX_OUTPUT_TOKENS).toBe(4_000);
+      expect(CHAT_COMPLETION_ASSUMED_CHARS_PER_TOKEN).toBe(4);
+      expect(MAX_SCANNED_CONTENT_CHARS).toBe(50_000);
+    });
+  });
+
+  describe('messages', () => {
+    it('requires at least one message', () => {
+      expect(parse(withParam('messages', [])).success).toBe(false);
+    });
+
+    it('accepts the three roles and rejects any other', () => {
+      for (const role of ['system', 'user', 'assistant']) {
+        expect(parse(withParam('messages', [{ role, content: 'x' }])).success).toBe(true);
+      }
+      expect(parse(withParam('messages', [{ role: 'tool', content: 'x' }])).success).toBe(false);
+      expect(parse(withParam('messages', [{ role: 'developer', content: 'x' }])).success).toBe(
+        false
+      );
+    });
+
+    it('🔴 REJECTS a content-part ARRAY — the shape that carries an orchestrator-fetched imageUrl', () => {
+      // `ChatCompletionContentPart` has an `imageUrl` the orchestrator FETCHES.
+      // Accepting the array form would put an arbitrary remote URL on the wire
+      // from an untrusted iframe — the SSRF primitive `convert-image` bounds
+      // with `civitaiHostedImageUrlSchema`.
+      const partArray = [{ type: 'imageUrl', imageUrl: { url: 'http://169.254.169.254/' } }];
+      expect(parse(withParam('messages', [{ role: 'user', content: partArray }])).success).toBe(
+        false
+      );
+    });
+
+    it('rejects empty content, over-long content, and unknown message keys', () => {
+      expect(parse(withParam('messages', [{ role: 'user', content: '' }])).success).toBe(false);
+      expect(
+        parse(withParam('messages', [{ role: 'user', content: 'x'.repeat(8_001) }])).success
+      ).toBe(false);
+      expect(
+        parse(withParam('messages', [{ role: 'user', content: 'x'.repeat(8_000) }])).success
+      ).toBe(true);
+      expect(
+        parse(withParam('messages', [{ role: 'user', content: 'x', name: 'bob' }])).success
+      ).toBe(false);
+      expect(
+        parse(withParam('messages', [{ role: 'assistant', content: 'x', tool_calls: [] }])).success
+      ).toBe(false);
+    });
+
+    it('bounds the conversation length', () => {
+      const msg = { role: 'user' as const, content: 'x' };
+      expect(parse(withParam('messages', Array(32).fill(msg))).success).toBe(true);
+      expect(parse(withParam('messages', Array(33).fill(msg))).success).toBe(false);
+    });
+  });
+
+  describe('temperature', () => {
+    it('is optional and bounded to the documented 0-2 range', () => {
+      expect(parse(withParam('temperature', 0)).success).toBe(true);
+      expect(parse(withParam('temperature', 2)).success).toBe(true);
+      expect(parse(withParam('temperature', -0.1)).success).toBe(false);
+      expect(parse(withParam('temperature', 2.1)).success).toBe(false);
+      expect(parse(VALID_PARAMS).success).toBe(true);
+    });
+  });
+});
+
+describe('chat-completion — buildStep', () => {
+  it('emits the declared $type', () => {
+    expect(chatCompletionStep.buildStep(VALID_PARAMS).$type).toBe('chatCompletion');
+  });
+
+  it('🔴 emits an EXACT key set — nothing may be added without failing this test', () => {
+    // The guard against a future edit quietly re-introducing `modalities`,
+    // `image_config`, `tools` or `n`. An allow-list assertion, not a
+    // "does not contain modalities" one: the next dangerous field is the one
+    // nobody thought to name here.
+    expect(Object.keys(chatCompletionStep.buildStep(VALID_PARAMS)).sort()).toEqual([
+      '$type',
+      'input',
+    ]);
+    expect(Object.keys(chatCompletionStep.buildStep(VALID_PARAMS).input).sort()).toEqual([
+      'maxTokens',
+      'messages',
+      'model',
+    ]);
+    expect(
+      Object.keys(chatCompletionStep.buildStep({ ...VALID_PARAMS, temperature: 0.7 }).input).sort()
+    ).toEqual(['maxTokens', 'messages', 'model', 'temperature']);
+  });
+
+  it('forwards the parsed params verbatim', () => {
+    const built = chatCompletionStep.buildStep(VALID_PARAMS);
+    expect(built.input).toEqual({
+      model: 'deepseek/deepseek-chat',
+      messages: [{ role: 'user', content: 'hello' }],
+      maxTokens: 128,
+    });
+  });
+
+  it('omits temperature entirely when it was not supplied (never sends undefined)', () => {
+    expect('temperature' in chatCompletionStep.buildStep(VALID_PARAMS).input).toBe(false);
+  });
+
+  it('carries NO AIR reference, for every variant (clause 7, re-pinned)', () => {
+    for (const variant of CHAT_COMPLETION_MODELS) {
+      const built = chatCompletionStep.buildStep(chatCompletionStep.canonicalParamsFor(variant));
+      expect(containsAirReference(built.input)).toBe(false);
+    }
+  });
+});
+
+describe('chat-completion — price and estimate', () => {
+  it('is a flat 1 Buzz, and the estimate equals the price for every variant', () => {
+    expect(CHAT_COMPLETION_PRICE_BUZZ).toBe(1);
+    for (const variant of CHAT_COMPLETION_MODELS) {
+      const params = chatCompletionStep.canonicalParamsFor(variant);
+      expect(chatCompletionStep.priceForVariant()).toBe(CHAT_COMPLETION_PRICE_BUZZ);
+      expect(chatCompletionStep.estimateBuzz()).toBe(CHAT_COMPLETION_PRICE_BUZZ);
+      expect(estimateStepBuzz(chatCompletionStep as unknown as AnyBlockStep, params)).toBe(
+        CHAT_COMPLETION_PRICE_BUZZ
+      );
+    }
+  });
+
+  it('does not vary with maxTokens — the measured flat rate, pinned', () => {
+    const step = chatCompletionStep as unknown as AnyBlockStep;
+    for (const maxTokens of [1, 128, CHAT_COMPLETION_MAX_OUTPUT_TOKENS]) {
+      expect(estimateStepBuzz(step, withParam('maxTokens', maxTokens))).toBe(
+        CHAT_COMPLETION_PRICE_BUZZ
+      );
+    }
+  });
+});
+
+describe('chat-completion — extractText, against the REAL response', () => {
+  it('🔴 returns the assistant content from the captured live response', () => {
+    expect(chatCompletionStep.extractText(REAL_COMPLETED_STEP)).toEqual(['OK']);
+  });
+
+  it('🔴 does NOT depend on `role` — the real response has none, the generated type requires one', () => {
+    // If the extractor keyed off `role`, this returns [] and the capability is
+    // inert for every real reply while clause 8a stays green (the entry's own
+    // sample would just have been written WITH a role).
+    const withRole = {
+      output: { choices: [{ message: { role: 'assistant', content: 'with role' } }] },
+    };
+    const withoutRole = { output: { choices: [{ message: { content: 'without role' } }] } };
+    expect(chatCompletionStep.extractText(withRole)).toEqual(['with role']);
+    expect(chatCompletionStep.extractText(withoutRole)).toEqual(['without role']);
+  });
+
+  it('returns a `refusal` — model-generated free text is scanned on the same terms', () => {
+    const refused = {
+      output: { choices: [{ message: { content: null, refusal: 'I cannot help with that.' } }] },
+    };
+    expect(chatCompletionStep.extractText(refused)).toEqual(['I cannot help with that.']);
+  });
+
+  it('returns BOTH content and refusal when both are present', () => {
+    const both = { output: { choices: [{ message: { content: 'a', refusal: 'b' } }] } };
+    expect(chatCompletionStep.extractText(both)).toEqual(['a', 'b']);
+  });
+
+  it('returns every choice, in order', () => {
+    const multi = {
+      output: { choices: [{ message: { content: 'one' } }, { message: { content: 'two' } }] },
+    };
+    expect(chatCompletionStep.extractText(multi)).toEqual(['one', 'two']);
+  });
+
+  it('drops null, empty and whitespace-only pieces (clause 8a rejects them)', () => {
+    const noisy = {
+      output: {
+        choices: [
+          { message: { content: null } },
+          { message: { content: '' } },
+          { message: { content: '   \n\t ' } },
+          { message: { content: 'real' } },
+        ],
+      },
+    };
+    expect(chatCompletionStep.extractText(noisy)).toEqual(['real']);
+  });
+
+  it('🔴 does NOT read `message.images[]` — base64 image data URIs are never published as text', () => {
+    // They cannot appear (this entry never sets `modalities`), and if they did
+    // they would be DROPPED, not published: a text entry has no `extractOutput`.
+    const withImages = {
+      output: {
+        choices: [
+          {
+            message: {
+              content: 'here you go',
+              images: [{ type: 'image_url', image_url: { url: 'data:image/png;base64,AAAA' } }],
+            },
+          },
+        ],
+      },
+    };
+    expect(chatCompletionStep.extractText(withImages)).toEqual(['here you go']);
+  });
+
+  it('does NOT read `tool_calls[].function.arguments`', () => {
+    const withTools = {
+      output: {
+        choices: [
+          {
+            message: {
+              content: 'calling',
+              tool_calls: [{ id: '1', type: 'function', function: { name: 'f', arguments: '{}' } }],
+            },
+          },
+        ],
+      },
+    };
+    expect(chatCompletionStep.extractText(withTools)).toEqual(['calling']);
+  });
+
+  it('is total over absent, null and malformed input', () => {
+    expect(chatCompletionStep.extractText(undefined)).toEqual([]);
+    expect(chatCompletionStep.extractText(null)).toEqual([]);
+    expect(chatCompletionStep.extractText({})).toEqual([]);
+    expect(chatCompletionStep.extractText({ output: null })).toEqual([]);
+    expect(chatCompletionStep.extractText({ output: {} })).toEqual([]);
+    expect(chatCompletionStep.extractText({ output: { choices: null } })).toEqual([]);
+    expect(chatCompletionStep.extractText({ output: { choices: 'nope' } })).toEqual([]);
+    expect(chatCompletionStep.extractText({ output: { choices: [null] } })).toEqual([]);
+    expect(chatCompletionStep.extractText({ output: { choices: [{}] } })).toEqual([]);
+    expect(chatCompletionStep.extractText({ output: { choices: [{ message: null }] } })).toEqual([]);
+    expect(
+      chatCompletionStep.extractText({ output: { choices: [{ message: { content: 42 } }] } })
+    ).toEqual([]);
+  });
+
+  it('🔴 the entry’s own canonical sample is the SAME real response, for every variant', () => {
+    // Clause 8a probes `extractText(canonicalOutputFor(v))`. This asserts the
+    // sample was not quietly re-written to suit the extractor: it must still
+    // equal the captured response held independently at the top of this file.
+    for (const variant of CHAT_COMPLETION_MODELS) {
+      expect(chatCompletionStep.canonicalOutputFor(variant)).toEqual(REAL_COMPLETED_STEP);
+      expect(chatCompletionStep.extractText(chatCompletionStep.canonicalOutputFor(variant))).toEqual(
+        ['OK']
+      );
+    }
+  });
+});

--- a/src/server/services/blocks/steps/__tests__/chat-completion.step.test.ts
+++ b/src/server/services/blocks/steps/__tests__/chat-completion.step.test.ts
@@ -450,7 +450,9 @@ describe('chat-completion — extractText, against the REAL response', () => {
     expect(chatCompletionStep.extractText({ output: { choices: 'nope' } })).toEqual([]);
     expect(chatCompletionStep.extractText({ output: { choices: [null] } })).toEqual([]);
     expect(chatCompletionStep.extractText({ output: { choices: [{}] } })).toEqual([]);
-    expect(chatCompletionStep.extractText({ output: { choices: [{ message: null }] } })).toEqual([]);
+    expect(chatCompletionStep.extractText({ output: { choices: [{ message: null }] } })).toEqual(
+      []
+    );
     expect(
       chatCompletionStep.extractText({ output: { choices: [{ message: { content: 42 } }] } })
     ).toEqual([]);
@@ -462,9 +464,9 @@ describe('chat-completion — extractText, against the REAL response', () => {
     // equal the captured response held independently at the top of this file.
     for (const variant of CHAT_COMPLETION_MODELS) {
       expect(chatCompletionStep.canonicalOutputFor(variant)).toEqual(REAL_COMPLETED_STEP);
-      expect(chatCompletionStep.extractText(chatCompletionStep.canonicalOutputFor(variant))).toEqual(
-        ['OK']
-      );
+      expect(
+        chatCompletionStep.extractText(chatCompletionStep.canonicalOutputFor(variant))
+      ).toEqual(['OK']);
     }
   });
 });

--- a/src/server/services/blocks/steps/chat-completion.step.ts
+++ b/src/server/services/blocks/steps/chat-completion.step.ts
@@ -1,0 +1,394 @@
+import type { ChatCompletionInput } from '@civitai/client';
+import * as z from 'zod';
+import type { BlockStep, OrchestratorStepTemplate } from './index';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tranche 2, entry 1 — `chatCompletion`. The first `'textOutput'` adopter.
+//
+// WHY THIS ONE QUALIFIES, against the same bars `convert-image` was checked on:
+//
+//  1. A GENUINE STANDALONE `$type`. `ChatCompletionStep` /
+//     `ChatCompletionStepTemplate` with `$type: 'chatCompletion'` are first-class
+//     in the generated `@civitai/client` types, and the orchestrator runs the
+//     step standalone (Civitai's own `xGuardModeration` scanning is implemented
+//     as `chatCompletion` jobs).
+//
+//  2. FLAT, MEASURED COST. A real submit was quoted and charged **1 Buzz**, and
+//     that held across every model below AND across `maxTokens` 1 → 200,000 — so
+//     the price is knowable before execution → `prepaidFixed`. See
+//     `CHAT_COMPLETION_PRICE_BUZZ`.
+//
+//  3. A FREE-TEXT OUTPUT, WITH A POSTURE THAT COVERS IT. This is the whole
+//     reason the entry could not be written until `'textOutput'` existed. The
+//     generated reply is scanned at the READ boundary by `./moderation`'s output
+//     phase and withheld on a policy hit or on any scanner failure.
+//
+//  4. NO AIR RESOURCE. `ChatCompletionInput.model` is a plain provider id
+//     ("gpt-4o"), NOT an AIR URN, so there is nothing for the entitlement belt
+//     to gate → `resourcePolicy: { kind: 'none' }`, which clause 7's deep AIR
+//     scan verifies against the step this entry actually BUILDS.
+//
+// 🔴 THE MODEL ALLOWLIST IS LOAD-BEARING, AND IT IS NOT IN `resourcePolicy`.
+// `staticAllowlist` is AIR-only — its single field is `airs` and clause 7's
+// enforcement is a `urn:air:` substring scan — so putting "deepseek/deepseek-chat"
+// in it would be a lie that makes the eventual real AIR-allowlist implementation
+// wrong for this entry. `'none'` is therefore TRUTHFUL here, and the model bound
+// lives where the registry already provides one: the `z.enum` in this entry's own
+// `.strict()` `paramSchema`, declared as the entry's `variants` and resolved
+// through `resolveStepVariant`.
+//
+// 🔴 WHY THAT BOUND MATTERS RATHER THAN BEING TIDINESS: there is NO
+// ORCHESTRATOR-SIDE MODEL VALIDATION. Measured against the live orchestrator — a
+// fabricated model name is quoted 1 Buzz, **CHARGED** 1 Buzz, and then fails at
+// execution with `workflow status: failed` and no output and no refund. Without
+// the enum, an app typo burns a viewer's Buzz on a guaranteed failure.
+//
+// 🔴 KNOWN GAP, STATED RATHER THAN PAPERED OVER — THE INPUT IS NOT AUDITED.
+// `messages` is free text from an untrusted iframe, and this entry runs NO
+// prompt audit over it. That is not an oversight and it is not fixable in this
+// file: `ACCEPTABLE_POSTURES_BY_TYPE` constrains `chatCompletion` to exactly
+// `['textOutput']` and is deliberately A SET, NOT A LADDER (see `./index`), so
+// declaring `'promptAudit'` is rejected at load; and clause 1a's REVERSE
+// direction rejects an entry that declares `auditableText` under a posture that
+// never audits it. The registry models ONE posture per entry, so an entry with
+// free text on BOTH sides cannot express both today. What IS covered: everything
+// this step publishes goes through the output scan. What is NOT: the input text
+// never meets `auditPromptServer`, so it produces no `BlockedPromptEntry` and no
+// violation counter. Closing it needs a registry-level decision about
+// multi-surface postures, not a workaround here.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * The declared exact price, in Buzz.
+ *
+ * MEASURED, not declared: real submits against the live orchestrator returned
+ * `cost.total = 1` for every model in `CHAT_COMPLETION_MODELS` and for
+ * `maxTokens` from 1 to 200,000. `estimateBuzz` returns this same constant —
+ * the registry's load-time invariant forces the two to agree, because the block
+ * is SHOWN the estimate and CHARGED the price.
+ *
+ * 🔴 It is NOT the enforced ceiling. The step submit path runs its own `whatif`
+ * before the per-call `buzzBudget` gate and reserves `max(declared, quoted)`, so
+ * a rate-card change is caught at submit rather than by a human reading a
+ * counter later. See the ORCHESTRATOR QUOTE section in `blocks.router.ts`.
+ */
+export const CHAT_COMPLETION_PRICE_BUZZ = 1;
+
+/**
+ * The models this entry may reach — the allowlist, the variant set, and the
+ * per-model pricing key, all one declaration.
+ *
+ * 🔴 A NON-MEMBER IS REJECTED AT PARSE (`z.enum` below), before
+ * `resolveStepVariant` is ever reached. That ordering is deliberate: the
+ * variant guard's error message echoes `variants.join(', ')` to the untrusted
+ * iframe, so an entry whose model list is not public information would be
+ * disclosing it. Every id here IS public, and the schema makes the guard
+ * unreachable anyway — but the next person adding an unreleased model to this
+ * list should know both facts.
+ *
+ * v1 is deliberately three. All three were driven to `succeeded` against the
+ * live orchestrator; adding a fourth later is a one-line additive change.
+ *
+ * 🔴 `cognitivecomputations/dolphin-mistral-24b-venice-edition` IS AN UNCENSORED
+ * MODEL, and it is listed on purpose. Its output is not trusted — it is scanned
+ * exactly like every other model's, by the posture: `NSFW` / `Suggestive` /
+ * `Explicit` withhold on a SFW maturity ceiling and release above it, while the
+ * always-withhold labels (`Young`, `Grooming`, `Sex Trafficking`,
+ * `Exploitation`, `Bestiality`, `Extremism`, `Impersonating Civitai Staff`)
+ * apply at every ceiling. That is the designed behaviour of `'textOutput'`, not
+ * a gap this entry is exploiting.
+ */
+export const CHAT_COMPLETION_MODELS = [
+  'deepseek/deepseek-chat',
+  'cognitivecomputations/dolphin-mistral-24b-venice-edition',
+  'openai/gpt-4o-mini',
+] as const;
+
+export type ChatCompletionModel = (typeof CHAT_COMPLETION_MODELS)[number];
+
+/**
+ * The hard ceiling on generated tokens.
+ *
+ * 🔴 DERIVED FROM THE SCAN CAP, NOT PICKED. `MAX_SCANNED_CONTENT_CHARS` in
+ * `./text-output-moderation` is **50,000**, and content ABOVE that cap is a
+ * WITHHOLD, not a truncation — so any `maxTokens` ceiling that can produce more
+ * than 50,000 characters designs a guaranteed withhold into the capability: the
+ * app pays 1 Buzz, the model generates, and the reader gets nothing.
+ *
+ * At the nominal ~4 characters per token, 4,000 tokens is ~16,000 characters —
+ * about a third of the cap, leaving ~3× headroom for content whose real
+ * characters-per-token runs far above the nominal (long whitespace runs and
+ * repeated substrings merge into single BPE tokens). The cap would only be
+ * reached at ~12.5 chars/token sustained across the whole reply.
+ *
+ * 🔴 THE TWO NUMBERS ARE PINNED TOGETHER BY A TEST, DELIBERATELY NOT BY AN
+ * IMPORT. Importing `MAX_SCANNED_CONTENT_CHARS` here would drag
+ * `./text-output-moderation` — and through it `orchestrator.service` — onto the
+ * registry's module-load path, which `workflow.schema` depends on staying light.
+ * So the link is asserted in `__tests__/chat-completion.step.test.ts`, which
+ * imports both and goes RED if either constant moves. If you change one, that
+ * test is what tells you about the other.
+ */
+export const CHAT_COMPLETION_MAX_OUTPUT_TOKENS = 4_000;
+
+/** The nominal characters-per-token used in the derivation above. Exported so the test can pin it. */
+export const CHAT_COMPLETION_ASSUMED_CHARS_PER_TOKEN = 4;
+
+/**
+ * Input bounds on the conversation.
+ *
+ * These bound PREFILL compute, which the flat 1-Buzz price does not. They are
+ * generous enough for a real chat block and small enough that an app cannot
+ * turn a 1-Buzz call into an arbitrarily large prompt. Widening later is
+ * additive; narrowing is breaking.
+ */
+const MAX_MESSAGES = 32;
+const MAX_MESSAGE_CHARS = 8_000;
+
+/** Sampling temperature bounds, taken from `ChatCompletionInput.temperature`'s own documented range. */
+const TEMPERATURE_MIN = 0;
+const TEMPERATURE_MAX = 2;
+
+/**
+ * One conversation turn.
+ *
+ * 🔴 `content` IS A PLAIN STRING, and that is measured rather than read off the
+ * generated type. `UserMessage.content` is typed `Array<ChatCompletionContentPart>`
+ * in `@civitai/client`, but the orchestrator accepts a bare string and converts
+ * it to a single text part — its own doc string on that field says so ("can be a
+ * simple string or array of content parts"), and a live submit with string
+ * content returned HTTP 200 and polled to `succeeded`. A string is also the only
+ * shape this entry WANTS: `ChatCompletionContentPart` carries `imageUrl`, which
+ * would put an arbitrary remote URL the orchestrator FETCHES onto the wire from
+ * an untrusted iframe — the SSRF primitive `convert-image` bounds with
+ * `civitaiHostedImageUrlSchema`. Not exposing the part array avoids the question
+ * entirely.
+ *
+ * `.strict()`, so `name`, `tool_calls` and `images` are rejected rather than
+ * forwarded.
+ */
+const chatMessageSchema = z
+  .object({
+    role: z.enum(['system', 'user', 'assistant']),
+    content: z.string().min(1).max(MAX_MESSAGE_CHARS),
+  })
+  .strict();
+
+const chatCompletionParamsSchema = z
+  .object({
+    /**
+     * 🔴 THE ALLOWLIST. A `z.enum` over `CHAT_COMPLETION_MODELS`, which is also
+     * the entry's `variants` — so membership is enforced twice, at parse and
+     * again by `resolveStepVariant`, and the resolved value is what the audit
+     * row records as `detail.variant`.
+     */
+    model: z.enum(CHAT_COMPLETION_MODELS),
+    messages: z.array(chatMessageSchema).min(1).max(MAX_MESSAGES),
+    /**
+     * 🔴 REQUIRED, NEVER `.optional()`, AND THAT IS THE POINT OF THE FIELD.
+     * `.strict()` rejects params it does not know about; it does NOT bound a
+     * param the caller simply OMITS. An omitted `maxTokens` falls through to the
+     * orchestrator's own default, which nothing on this side bounds — and since
+     * the price is FLAT at 1 Buzz from 1 token to 200,000 (measured), an
+     * unbounded token count is unbounded compute at a fixed price, plus a
+     * guaranteed `over-cap` withhold once the reply passes 50,000 characters.
+     *
+     * Required rather than `.default(...)` because a default is a compute budget
+     * the app author never chose and — the price being flat — would never see a
+     * cost signal for. Making it explicit is the narrower surface; adding a
+     * default later is additive, removing one is breaking.
+     */
+    maxTokens: z.number().int().min(1).max(CHAT_COMPLETION_MAX_OUTPUT_TOKENS),
+    /**
+     * Optional, and that is NOT in tension with the `maxTokens` rule above — the
+     * hazard there is unbounded RESOURCE consumption behind an omitted value,
+     * and an omitted temperature falls through to a provider default that is a
+     * sampling knob inside this same 0–2 range. It consumes nothing.
+     */
+    temperature: z.number().min(TEMPERATURE_MIN).max(TEMPERATURE_MAX).optional(),
+  })
+  .strict();
+
+export type ChatCompletionStepParams = z.infer<typeof chatCompletionParamsSchema>;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 🔴 THE SINGLE MOST IMPORTANT LINE IN THIS FILE: `modalities` IS NOT EXPOSED,
+// AND `buildStep` NEVER SETS IT.
+//
+// `ChatCompletionInput.modalities` accepts `['image']`, and when it is present
+// the orchestrator routes the request to the IMAGE pipeline and returns
+// generated images on `choices[].message.images[].image_url.url` as **base64
+// data URIs** (`ChatCompletionGeneratedImage` / `ChatCompletionGeneratedImageUrl`
+// in the generated types). Those bytes never touch image ingestion, so they
+// never become moderated `Image` rows, never get an `nsfwLevel`, and never meet
+// any media gate — and the text scan does not look at media at all.
+//
+// Omitting the field is what makes this entry HONESTLY text-only, and it is what
+// keeps the registry's MEDIA-XOR-TEXT model (`stepOutputShape`) true for it: a
+// `'textOutput'` entry has no `extractOutput` by construction, so anything the
+// step produced that is not text has no channel to the block at all. Adding
+// `modalities` (or its companion `image_config`) to the schema would silently
+// make this a media-producing step wearing a text posture — the exact
+// half-covered shape `./index`'s XOR note says must fail at load rather than
+// half-register.
+//
+// The schema is `.strict()`, so a block passing `modalities` today gets a
+// BAD_REQUEST at parse. `buildStep` below emits an EXACT key set, pinned by a
+// test, so a future edit that adds the field fails a test rather than shipping.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * The bounded input this entry submits, ANCHORED to the generated
+ * `ChatCompletionInput`.
+ *
+ * Declaring the return type is what makes the field NAMES load-bearing: a
+ * renamed or retyped field on the orchestrator's own input contract is a build
+ * failure here rather than a request the orchestrator ignores. `messages` is
+ * anchored to `ChatCompletionInput`'s own `Array<ChatCompletionMessage>` (the
+ * `{ role: string }` base) rather than to `UserMessage`, because that alias's
+ * `content: Array<ChatCompletionContentPart>` contradicts the measured wire
+ * behaviour — see `chatMessageSchema`.
+ */
+function buildChatCompletionInput(params: ChatCompletionStepParams): ChatCompletionInput {
+  return {
+    model: params.model,
+    messages: params.messages,
+    maxTokens: params.maxTokens,
+    ...(params.temperature !== undefined ? { temperature: params.temperature } : {}),
+  };
+}
+
+/**
+ * One assistant message, as this entry READS it.
+ *
+ * 🔴 `role` IS DELIBERATELY ABSENT, and that is a measured decision rather than
+ * an omission. `AssistantMessage` in `@civitai/client` declares `role: 'assistant'`
+ * as REQUIRED, but the real orchestrator response carries **only `content`** on
+ * `choices[].message` — no `role` at all. An extractor that keyed off `role`
+ * would return nothing for every real reply: the step would charge 1 Buzz, reach
+ * `succeeded`, scan nothing and publish nothing. `./type-contract` pins both
+ * halves of this — that the generated step satisfies the shape, and that a
+ * message with no `role` still satisfies it.
+ *
+ * `content` is `null | string` and `refusal` may be set instead (a model refusal
+ * is free text the model generated, so it is scanned and published on the same
+ * terms as any other reply).
+ */
+export type ChatCompletionMessageOutputLike = {
+  content?: string | null;
+  refusal?: string | null;
+};
+
+/** One completion choice, as this entry reads it. */
+export type ChatCompletionChoiceOutputLike = {
+  message?: ChatCompletionMessageOutputLike | null;
+};
+
+/**
+ * The orchestrator's completed-step shape for `chatCompletion`.
+ *
+ * 🔴 EXPORTED SO IT CAN BE ANCHORED TO THE GENERATED CONTRACT. `extractText`
+ * takes `unknown` and reaches this shape through a cast, so nothing at the call
+ * site links it to the orchestrator's own types. `type-contract.ts` asserts that
+ * a real `ChatCompletionStep` satisfies it and that every key it reads exists on
+ * the generated `ChatCompletionOutput` / `ChatCompletionChoice` /
+ * `AssistantMessage` — which moves the anchor off the author and onto a type
+ * Civitai does not hand-write. Clause 8a's own docstring says the first
+ * `'textOutput'` entry owes exactly this, because that clause is a
+ * self-consistent pair (extractor + sample, same author, same file) and cannot
+ * catch a pair that agrees with itself while both are wrong.
+ */
+export type ChatCompletionOutputStepLike = {
+  output?: {
+    choices?: readonly (ChatCompletionChoiceOutputLike | null)[] | null;
+  } | null;
+};
+
+export const chatCompletionStep = {
+  id: 'chat-completion',
+  orchestratorType: 'chatCompletion',
+  billingMode: 'prepaidFixed',
+  // The free-text OUTPUT posture. Scanned at the read boundary by
+  // `./moderation`'s output phase, withheld on a hit and on any scanner failure.
+  // See the KNOWN GAP note in the header for what this posture does NOT cover.
+  moderationPosture: 'textOutput',
+  // `ChatCompletionInput.model` is a plain provider id, never an AIR URN, so
+  // there is no way to reach a gated / early-access / Private model version
+  // through this step. ENFORCED, not just declared: clause 7 deep-scans the
+  // BUILT step for an AIR reference.
+  resourcePolicy: { kind: 'none' },
+  paramSchema: chatCompletionParamsSchema,
+  // Models AS variants: the allowlist, the price key and the audit row's
+  // `detail.variant` in one declaration.
+  variants: CHAT_COMPLETION_MODELS,
+  resolveVariant: (params: ChatCompletionStepParams): string => params.model,
+  canonicalParamsFor: (variant: string): ChatCompletionStepParams => ({
+    // The `as` is checked, not assumed: clause 3 safeParses these params against
+    // the `z.enum` above, so a `variants` entry that is not a real model fails at
+    // registry LOAD rather than producing an unparseable canonical object.
+    model: variant as ChatCompletionModel,
+    messages: [{ role: 'user', content: 'ping' }],
+    maxTokens: 256,
+  }),
+  priceForVariant: () => CHAT_COMPLETION_PRICE_BUZZ,
+  estimateBuzz: () => CHAT_COMPLETION_PRICE_BUZZ,
+  buildStep: (params: ChatCompletionStepParams): OrchestratorStepTemplate => ({
+    $type: 'chatCompletion',
+    input: { ...buildChatCompletionInput(params) },
+  }),
+  /**
+   * The generated free text, handed to the output scan AND published verbatim on
+   * release — the read path emits exactly these strings and never `step.output`.
+   * So anything this does not return is never scanned AND never published; the
+   * two move together by construction.
+   *
+   * 🔴 IT DOES NOT READ `message.images[]` OR `message.tool_calls[]`, and both
+   * omissions are safe in the same direction. Neither can appear — this entry
+   * never sets `modalities` and never exposes `tools` — and if one somehow did,
+   * it would be DROPPED rather than published, because a `'textOutput'` entry has
+   * no `extractOutput` to carry it. The fail-closed direction.
+   */
+  extractText: (step: unknown): string[] => {
+    const choices = (step as ChatCompletionOutputStepLike | null | undefined)?.output?.choices;
+    if (!Array.isArray(choices)) return [];
+    const texts: string[] = [];
+    for (const choice of choices) {
+      const message = choice?.message;
+      if (message === null || message === undefined) continue;
+      // `content` may be null; `refusal` is set instead when the model declines.
+      // Both are model-generated free text and both are scanned.
+      for (const value of [message.content, message.refusal]) {
+        // Empty and whitespace-only pieces are dropped rather than handed to the
+        // scan: clause 8a rejects them, and there is nothing in them to scan or
+        // to publish.
+        if (typeof value === 'string' && value.trim().length > 0) texts.push(value);
+      }
+    }
+    return texts;
+  },
+  /**
+   * A canonical COMPLETED step, for the load-time extraction probe (clause 8a).
+   *
+   * 🔴 COPIED VERBATIM FROM A REAL ORCHESTRATOR RESPONSE, not invented to match
+   * `extractText`. A sample written from the extractor would make the probe
+   * assert only that the code agrees with itself — the both-wrong-blind shape
+   * clause 8a's own docstring names as the thing it cannot catch. Note what the
+   * real response does NOT contain: `choices[0].message` carries **only
+   * `content`** — no `role`, despite the generated `AssistantMessage` declaring
+   * it required. That absence is the reason `extractText` does not key off it.
+   */
+  canonicalOutputFor: (): unknown => ({
+    $type: 'chatCompletion',
+    name: 'block-step',
+    status: 'succeeded',
+    output: {
+      id: 'gen-1785782779-5cBM39ztiT9kC93qr5kf',
+      object: 'chat.completion',
+      created: 1785782779,
+      model: 'openai/gpt-4o-mini',
+      choices: [{ index: 0, message: { content: 'OK' }, finishReason: 'stop' }],
+      usage: { promptTokens: 12, completionTokens: 1, totalTokens: 13 },
+      systemFingerprint: 'fp_5259353f0d',
+    },
+  }),
+} satisfies BlockStep<ChatCompletionStepParams>;

--- a/src/server/services/blocks/steps/index.ts
+++ b/src/server/services/blocks/steps/index.ts
@@ -1,4 +1,5 @@
 import type * as z from 'zod';
+import { chatCompletionStep } from './chat-completion.step';
 import { convertImageStep } from './convert-image.step';
 import type { StepOutputMedia } from './output';
 
@@ -1279,8 +1280,13 @@ export function isModerationPostureImplemented(posture: StepModerationPosture): 
 // recurse into an entry's nested values — those include zod schemas, which
 // populate internal caches lazily and must stay mutable. A deep freeze here
 // would trade a consistency nicety for a runtime failure mode.
+// 🔴 ORDER IS OBSERVABLE: `REGISTERED_STEP_IDS` is `Object.keys(...)`, so a new
+// entry goes at the END. Prepending would renumber the wire enum's iteration
+// order for no reason and shift `REGISTERED_STEP_IDS[0]`, which existing tests
+// use as "a valid id".
 const stepRegistry = Object.freeze({
   'convert-image': Object.freeze(convertImageStep),
+  'chat-completion': Object.freeze(chatCompletionStep),
 });
 
 export type RegisteredStepId = keyof typeof stepRegistry & string;

--- a/src/server/services/blocks/steps/type-contract.ts
+++ b/src/server/services/blocks/steps/type-contract.ts
@@ -4,8 +4,21 @@
  * checking the file, and a violated contract fails the build. "Using" them
  * somewhere would add runtime weight and prove nothing extra.
  */
-import type { ConvertImageOutput, ConvertImageStep, ImageBlob } from '@civitai/client';
+import type {
+  AssistantMessage,
+  ChatCompletionChoice,
+  ChatCompletionOutput,
+  ChatCompletionStep,
+  ConvertImageOutput,
+  ConvertImageStep,
+  ImageBlob,
+} from '@civitai/client';
 import type * as z from 'zod';
+import type {
+  ChatCompletionChoiceOutputLike,
+  ChatCompletionMessageOutputLike,
+  ChatCompletionOutputStepLike,
+} from './chat-completion.step';
 import type { ConvertImageOutputStepLike } from './convert-image.step';
 import type { BlockStep } from './index';
 import type { OrchestratorBlobLike, StepOutputMedia } from './output';
@@ -219,8 +232,11 @@ type _RequiresCanonicalOutput = Expect<
 //
 // 🔴 HONEST LIMIT: this does NOT make clause 8 a general guard. A FUTURE entry
 // still supplies its own read shape and its own sample, and nothing here forces
-// it to add an assertion of its own — the escape stays open for entry #2. What
-// is anchored is the one registered entry. Making the anchoring REQUIRED for
+// it to add an assertion of its own — the escape stays open for entry #3. Entry
+// #2 (`chat-completion`) DID add one, at the bottom of this file, because clause
+// 8a's docstring says the first `'textOutput'` entry owes it; that is a
+// convention held by review, not by the type system. What is anchored is the
+// registered entries that chose to. Making the anchoring REQUIRED for
 // every entry needs a `$type` → generated-step-type mapping the registry can
 // consult at the type level; `@civitai/client` exports no discriminated union of
 // all step types (only the individual `<Name>Step` aliases), so that map would
@@ -272,4 +288,89 @@ type _ConvertImageBlobReadKeysExist = Expect<
  */
 type _MediaFromBlobsAcceptsGeneratedImageBlob = Expect<
   ImageBlob extends OrchestratorBlobLike ? true : false
+>;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// `chat-completion` — the TEXT-axis anchoring, owed by the first `'textOutput'`
+// entry (clause 8a's own docstring says so).
+//
+// 🔴 WHY IT IS OWED, RESTATED SO IT IS NOT READ AS CEREMONY. Clause 8a probes
+// `extractText(canonicalOutputFor(v))` and rejects an empty result — but the
+// extractor and the sample are written by the same person in the same file, so
+// the probe is a SELF-CONSISTENT PAIR. An extractor reading `output.messages[]`
+// paired with a sample that also encodes `output.messages[]` passes clause 8a
+// and returns NOTHING for every real orchestrator response: a step that charges
+// Buzz, reaches `succeeded`, scans nothing and publishes nothing. Only the
+// generated types — which Civitai does not hand-write — can catch that.
+//
+// The read path is `output.choices[].message.{content,refusal}`; every hop below
+// is derived FROM `ChatCompletionOutputStepLike` itself rather than from the
+// exported per-hop aliases, so the assertions cannot drift away from the shape
+// the extractor actually casts to.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** The element type of a (readonly) array type. */
+type ElementOf<T> = T extends readonly (infer E)[] ? E : never;
+
+type ChatChoicesRead = NonNullable<NonNullable<ChatCompletionOutputStepLike['output']>['choices']>;
+type ChatChoiceRead = NonNullable<ElementOf<ChatChoicesRead>>;
+type ChatMessageRead = NonNullable<ChatChoiceRead['message']>;
+
+/**
+ * A REAL `ChatCompletionStep` must satisfy the hand-written shape `extractText`
+ * casts to — the twin of `_RealConvertImageStepSatisfiesReadShape`, on the text
+ * axis. Fails if the generated output type changes in a way the read would not
+ * survive.
+ */
+type _RealChatCompletionStepSatisfiesReadShape = Expect<
+  ChatCompletionStep extends ChatCompletionOutputStepLike ? true : false
+>;
+
+/**
+ * Every key the read shape declares under `output` must EXIST on the generated
+ * `ChatCompletionOutput`.
+ *
+ * 🔴 `keyof` is what makes the key NAME load-bearing. Assignability alone does
+ * not: a read shape whose properties are all optional is satisfied by anything,
+ * so renaming `choices` → `messages` would still compile against the assertion
+ * above while returning nothing for every real response.
+ */
+type _ChatCompletionReadKeysExist = Expect<
+  keyof NonNullable<ChatCompletionOutputStepLike['output']> extends keyof ChatCompletionOutput
+    ? true
+    : false
+>;
+
+/** Same, one level down: the choice key the extractor reads is a real `ChatCompletionChoice` field. */
+type _ChatCompletionChoiceReadKeysExist = Expect<
+  keyof ChatChoiceRead extends keyof ChatCompletionChoice ? true : false
+>;
+
+/**
+ * Same, two levels down: `content` and `refusal` are real `AssistantMessage`
+ * fields. This is the assertion that catches an extractor reading `text` or
+ * `message` where the orchestrator returns `content`.
+ */
+type _ChatCompletionMessageReadKeysExist = Expect<
+  keyof ChatMessageRead extends keyof AssistantMessage ? true : false
+>;
+
+/**
+ * 🔴 THE READ MUST NOT REQUIRE `role`, and this pins it.
+ *
+ * `AssistantMessage` declares `role: 'assistant'` as REQUIRED, but the real
+ * orchestrator response carries only `content` on `choices[].message` — measured
+ * against a live `succeeded` workflow. An extractor that keyed off `role` would
+ * therefore return nothing for every real reply while every other assertion
+ * here stayed green (a required `role` is still assignable FROM the generated
+ * type, so `_RealChatCompletionStepSatisfiesReadShape` would not notice).
+ *
+ * 🔴 BE EXACT ABOUT ITS STRENGTH: an all-optional shape is satisfied by almost
+ * anything, so this assertion is weak in general. It is not vacuous for the one
+ * mutation it exists for — adding a required `role` to the read shape makes
+ * `{ content: string }` stop being assignable and this fails, which is verified
+ * by mutation rather than assumed.
+ */
+type _ChatCompletionReadDoesNotRequireRole = Expect<
+  { content: string } extends ChatMessageRead ? true : false
 >;


### PR DESCRIPTION
Closes #3527.

## What

Registers `chat-completion` — the second step-registry entry, and the **first `'textOutput'` adopter**. It is the capability the Sensei app has been blocked on.

```
id:                'chat-completion'
orchestratorType:  'chatCompletion'
billingMode:       'prepaidFixed'      // measured flat 1 Buzz
moderationPosture: 'textOutput'
resourcePolicy:    { kind: 'none' }
variants:          the three allowlisted models
```

Plus the type-contract anchor the registry's own clause 8a says the first `'textOutput'` entry owes, and a test file for the parts no generic clause can see.

## The three decisions worth reviewing

### 1. `resourcePolicy: 'none'` is truthful, not a dodge

`staticAllowlist` is **AIR-only** — its single field is `airs`, and clause 7's enforcement is a `urn:air:` substring scan. `ChatCompletionInput.model` is a plain provider id (`"gpt-4o"`), never an AIR. Putting a model name in a field called `airs` would make the eventual real AIR-allowlist implementation wrong for whichever entries lied to it, so `'none'` is the honest declaration and clause 7's deep scan passes on the step this entry actually builds.

The model bound lives where the registry already provides one: a `z.enum` in the entry's own `.strict()` `paramSchema`, declared as the entry's `variants`. One mechanism, three results — the allowlist (enforced at parse *and* by `resolveStepVariant`), per-model pricing, and the model on the audit row as `detail.variant`.

🔴 **That bound is load-bearing, not tidiness: there is no orchestrator-side model validation.** A fabricated model name is quoted 1 Buzz, **charged** 1 Buzz, and then fails at execution with no output and no refund. Without the enum, an app typo burns a viewer's Buzz on a guaranteed failure.

### 2. `modalities` is not exposed, and `buildStep` never sets it

This is the most important line in the file. `ChatCompletionInput.modalities: ['image']` routes the request to the image pipeline and returns images on `choices[].message.images[].image_url.url` as **base64 data URIs**. Those bytes never touch image ingestion, so they never become moderated `Image` rows, never get an `nsfwLevel`, and never meet any media gate — and the text scan does not look at media at all.

Omitting the field is what makes this entry honestly text-only and keeps the registry's MEDIA-XOR-TEXT model true for it. Guarded three ways: `.strict()` rejects the param at parse; `buildStep` emits an **exact key set** pinned by a test (an allow-list assertion, not a "does not contain modalities" one — the next dangerous field is the one nobody thought to name); and `extractText` does not read `images[]`, so even if one appeared it would be dropped rather than published.

### 3. The `maxTokens` ceiling is derived from the scan cap

`maxTokens` is **required**, never `.optional()`. `.strict()` rejects params it does not know about; it does not bound a param the caller simply omits, and an omitted value falls through to the orchestrator's own default. Since the price is flat at 1 Buzz from 1 token to 200,000 (measured), an unbounded token count is unbounded compute at a fixed price.

The ceiling itself comes from `MAX_SCANNED_CONTENT_CHARS = 50_000`, above which the posture **withholds** rather than truncating — so a ceiling that can produce more than 50,000 characters designs a guaranteed "paid for nothing" into the capability:

```
4,000 tokens × ~4 chars/token ≈ 16,000 chars  →  32% of the 50,000-char cap
```

~3× headroom for content whose real chars-per-token runs above the nominal (long whitespace runs and repeated substrings merge into single BPE tokens); the cap is only reached at ~12.5 chars/token sustained.

The two constants are pinned together by a test rather than by an import, deliberately — importing `MAX_SCANNED_CONTENT_CHARS` here would drag `text-output-moderation` and through it `orchestrator.service` onto the registry's module-load path, which `workflow.schema` depends on staying light. The test imports both and goes red if either moves, and it pins the literals too, because a test comparing only the two constants to each other passes when both are changed together — which is exactly the change a human should look at.

## Measured facts this entry encodes

- **Flat 1 Buzz**, across every model and across `maxTokens` 1 → 200,000. `estimateBuzz` returns the same constant; clause 6 rejects any divergence.
- **A user message accepts a plain string `content`**, despite `UserMessage.content` being typed `Array<ChatCompletionContentPart>` in the generated client. Its own doc comment corroborates it ("can be a simple string or array of content parts"), and a live submit returned 200 and polled to `succeeded`. The part-array form is *rejected* here on purpose: `ChatCompletionContentPart` carries an `imageUrl` the orchestrator **fetches**, which is the SSRF primitive `convert-image` bounds with `civitaiHostedImageUrlSchema`. Not exposing it avoids the question.
- 🔴 **The real response's `choices[].message` carries only `content` — no `role`**, despite `AssistantMessage` declaring `role: 'assistant'` required. An extractor keyed off `role` would return nothing for every real reply: charged, `succeeded`, scanning nothing and publishing nothing, with clause 8a still green (the entry's own sample would just have been written *with* a role). `canonicalOutputFor` is the captured response verbatim, and both halves are pinned — by a runtime test and by a type assertion.
- **All three v1 models were driven to `succeeded` live.** The uncensored `dolphin-mistral-24b-venice-edition` is listed on purpose: its output is scanned exactly like every other model's, `NSFW`/`Suggestive`/`Explicit` withholding on a SFW ceiling and releasing above it, with the always-withhold labels applying at every ceiling. That is the posture's designed behaviour, not a gap being exploited.

## The type-contract anchor

Clause 8a is a **self-consistent pair** — extractor and sample, same author, same file — so it catches an extractor that surfaces nothing for its own sample but not one that agrees with a sample while both are wrong about the orchestrator. `type-contract.ts` gains five assertions deriving every hop from `ChatCompletionOutputStepLike` itself (not from the per-hop aliases, so they cannot drift from the shape the extractor casts to): the real generated step satisfies the read shape; each hop's keys exist on `ChatCompletionOutput` / `ChatCompletionChoice` / `AssistantMessage` (`keyof`, which is what makes the key *name* load-bearing — assignability alone is satisfied by anything when every property is optional); and the read does **not** require `role`.

`buildChatCompletionInput` declares `ChatCompletionInput` as its return type, so the write side is anchored too — a renamed or retyped field on the orchestrator's own input contract is a build failure here rather than a request the orchestrator quietly ignores.

## 🔴 Known gap, stated rather than papered over: the INPUT is not audited

`messages` is free text from an untrusted iframe and this entry runs **no** prompt audit over it. That is not an oversight and it is not fixable in this file. `ACCEPTABLE_POSTURES_BY_TYPE` constrains `chatCompletion` to exactly `['textOutput']` and is deliberately *a set, not a ladder*, so declaring `'promptAudit'` is rejected at load; and clause 1a's reverse direction rejects an entry that declares `auditableText` under a posture that never audits it. The registry models one posture per entry, so an entry with free text on both sides cannot express both today.

What **is** covered: everything this step publishes goes through the output scan. What is **not**: the input never meets `auditPromptServer`, so it produces no `BlockedPromptEntry` and no violation counter. Closing it is a registry-level decision about multi-surface postures, not a workaround here. It is written into the entry header so the next reader does not have to rediscover it.

## Verification

`pnpm typecheck`: **133 errors at base, 133 at head, identical 47-file set, zero in the touched files.** (`main` is red repo-wide from the `feat/db-queries-kysely` merge; what matters is that this change adds none. The count was 146 at the earlier tip this branch was first cut from, which is the baseline the mutation sweep's numbers are relative to.) Bare `tsc --noEmit` was not used — it OOMs at the default heap and exits 134, coincidentally near the error count.

Unit tests over `services/blocks/` + `schema/blocks/` + `blocks.router.workflow`: **2832 → 2873**, 116 → 117 files, all passing. The steps directory alone: **205 → 245**.

### One real regression, found by the broad run

Two population tests in `workflow.service.test.ts` called `step.extractOutput` for **every** registered entry. That was silently fine only while every entry produced media; a text entry has no media extractor by construction, so the first `'textOutput'` registration turns it into a raw `TypeError: step.extractOutput is not a function`. They are now gated on `postureProducesMedia` — the same predicate `snapshotFromWorkflow` and `projectAppWorkflow` themselves key on, so the test cannot drift from the code by asking a different question.

🔴 Gating alone would have made the text half **vacuous**, so each loop now asserts the mirror property for a text entry: it must contribute **nothing** to the media channel, which is the read-path half of the anti-smuggling rule (`StepOutputMedia.url` reaches `imageUrls` / `images[].url` without ever meeting `attachModeratedStepTextOutputs`). A third test is a positive control that the population still contains **both** shapes, so neither branch can quietly become dead.

### Mutation sweep — 16 mutants, 16 killed, each by its own error

Every guard was broken on purpose and the specific killing error recorded, not just the fact of a failure. Highlights:

| mutant | killed by | error |
|---|---|---|
| model enum → `z.string()` | *REJECTS a model outside the allowlist* | `expected true to be false` |
| `maxTokens` → `.optional()` | *REJECTS an OMITTED maxTokens* | `expected true to be false` |
| ceiling 4,000 → 20,000 | *THE DERIVATION* | `expected 80000 to be less than 50000` |
| `modalities` added to schema | *REJECTS `modalities`* | `expected true to be false` |
| `buildStep` sets `modalities:['image']` | *emits an EXACT key set* | `expected [ 'maxTokens', 'messages', …(2) ] to deeply equal [ 'maxTokens', 'messages', 'model' ]` |
| `.strict()` removed | registry **load**, clause 4 | `paramSchema must be .strict() — it accepted an unknown param` |
| `estimateBuzz` ≠ price | registry **load**, clause 6 | `estimateBuzz (2) must equal the declared price (1)` |
| `variants` decoupled from the enum | `resolveStepVariant` | `resolveVariant() returned 'deepseek/deepseek-chat', which is not one of the declared variants` |
| read shape gains a key the orchestrator lacks | `tsc` | `type-contract.ts: Type 'false' does not satisfy the constraint 'true'` |
| read shape requires `role` | `tsc` | `type-contract.ts: Type 'false' does not satisfy the constraint 'true'` |

🔴 **The one that matters most is the pair mutant:** `extractText` made to require `role` **and** `canonicalOutputFor` given a `role` to match. That is the both-wrong-blind shape clause 8a cannot catch — it passes the load-time probe cleanly — and it is killed by 9 runtime tests, including the dedicated role test. That is the evidence the new test file is doing work the existing clauses do not.

🔴 **A harness defect was found and fixed mid-sweep, and is reported rather than buried.** The first typecheck sweep returned `rc=127` with `total_errors: 0` for all four type mutants — the runner was missing `direnv exec`, so `pnpm` was not on `PATH` and "command not found" read as *zero type errors*, i.e. four false survivals presented as four clean runs. The sweep now asserts a **positive control** (`total_errors >= 146`, the known baseline) before any verdict is believed; the results above are from the re-run.

## Interaction with #3578

#3578 (request-time enforcement) adds `STEP_TYPE_POLICY`, keyed on orchestrator `$type`, with a `chatCompletion` row. Both PRs touch `steps/index.ts` and `git merge-tree` is clean, but the interaction is semantic, so it was checked rather than assumed:

- Its `assertRegistryEntryAgreesWithPolicy` requires a registered entry's posture to equal the posture its policy row derives. `chatCompletion` is `textSurface: 'generatedText'` → requires `'textOutput'`, which is what this entry declares. ✅
- Its `billingMode: null` for `chatCompletion` is `billingModeNotEstablished`, which that assert deliberately does not treat as a failure. ✅
- Its row sets `emitsMedia: true` for `chatCompletion` and notes that a purely text-posture treatment "hands an app a MEDIA channel that the text scan does not stand in front of". **That is true of the `$type` and not of this entry**: the channel is reachable only through `modalities`, which this entry does not expose, `.strict()` rejects, and `buildStep` never sets. `emitsMedia` is a documentation column — no code reads it — so nothing blocks either way, but the narrower claim is worth recording where the two meet.
- Its `textFields` for `chatCompletion` lists three surfaces this extractor does not read: `message.name`, `tool_calls[].function.arguments`, `finishReason`. None can appear (this entry exposes no `tools`, sends no `name`, and `.strict()` blocks both), and if one did it would be **dropped, not published** — a text entry has no `extractOutput`. Fail-closed in the right direction, and covered by tests.

Whichever lands second should re-run the steps suite on the merged tree.

## Co-requisite (does NOT block this PR, but does block Sensei)

The published `@civitai/app-sdk` — every version including current `latest` — has no `kind: 'step'` arm on `WorkflowBody`, so there is no typed client for the step bridge at all. Filed as **civitai-app-starters#208** with a changeset; it needs a release before an app can call this entry through the SDK.
