### PR TITLE
feat(apps): refuse go-live for an off-site listing whose primary CTA is non-actionable

### DIFF
--- a/src/server/services/blocks/__tests__/app-listing-actionable.service.test.ts
+++ b/src/server/services/blocks/__tests__/app-listing-actionable.service.test.ts
@@ -120,33 +120,32 @@ describe('the gate is scoped to off-site, and delegates rather than re-deriving'
       }
     }
     // 🔴 ANTI-VACUITY: without these the loop passes if the gate blocked
-    // everything, or nothing. 10 cases = 5 URL shapes x 2 client values.
+    // everything, or nothing. 10 cases = 5 URL shapes x 2 client values; exactly the
+    // 2 https rows (one per client value) are navigable.
     expect(blocked + allowed).toBe(10);
-    expect(allowed).toBeGreaterThanOrEqual(1);
-    // The 4 no-destination URL shapes x 2 client values are non-actionable under
-    // ANY version of the view-model — a listing with no reachable address cannot
-    // become navigable. Bounded rather than pinned exactly because the connect +
-    // https case is the one #3585 moves (see the dedicated test below); pinning
-    // `allowed` to today's value would turn this suite red the moment that lands.
-    expect(blocked).toBeGreaterThanOrEqual(8);
+    expect(allowed).toBe(2);
+    expect(blocked).toBe(8);
   });
 
-  it('connect + https: the gate agrees with the view-model in BOTH #3585 worlds', () => {
-    // 🔴 The case the CTA fix (#3585) changes, and the reason this suite asserts a
-    // relationship instead of a value.
-    //   - pre-#3585  the connect arm returns the stub unconditionally → no href →
-    //                the gate BLOCKS, which is correct: on this code such a listing
-    //                genuinely renders a dead button, exactly the three that shipped.
-    //   - post-#3585 the destination decides → Visit ↗ → the gate ALLOWS.
-    // Either way the gate must return whatever the store would actually render, so
-    // that is what is asserted. This test is deliberately version-agnostic and must
-    // stay green across the merge in both orders.
-    const listing = offsite({ externalUrl: 'https://demo.app', connectClientId: 'client-123' });
-    const action = getDetailPrimaryAction(
-      { slug: listing.slug, kind: 'offsite', kindData: expectedKindData(listing) },
-      { canOpenPage: true }
+  it('🔴 connect + https → ALLOWED: a linked OAuth client does not remove the address', () => {
+    // The positive case at the heart of the incident. #3585 made the DESTINATION
+    // decide the action, so a connect listing with a real address is navigable and
+    // must publish. Pinned explicitly because the inverse — a gate that blocks every
+    // connect listing — would be indistinguishable from a working gate if only the
+    // refusal cases were asserted, while quietly making connect apps unpublishable.
+    const result = checkOffsiteListingActionable(
+      offsite({ externalUrl: 'https://demo.app', connectClientId: 'client-123' })
     );
-    expect(checkOffsiteListingActionable(listing).ok).toBe(!!action.href);
+    expect(result.ok).toBe(true);
+    expect(result.action?.href).toBe('https://demo.app');
+  });
+
+  it('connect and external-link with the SAME address get the SAME verdict', () => {
+    // Structural: the gate must not reintroduce a sub-kind branch of its own.
+    const url = 'https://demo.app';
+    expect(checkOffsiteListingActionable(offsite({ externalUrl: url })).ok).toBe(
+      checkOffsiteListingActionable(offsite({ externalUrl: url, connectClientId: 'c1' })).ok
+    );
   });
 
   it('canOpenPage is unread on every off-site branch, so the gate may hardcode it', () => {

--- a/src/server/services/blocks/__tests__/app-listing-actionable.service.test.ts
+++ b/src/server/services/blocks/__tests__/app-listing-actionable.service.test.ts
@@ -1,0 +1,244 @@
+/**
+ * Go-live ACTIONABILITY gate — correctness coverage.
+ *
+ * The invariant under test: an OFF-SITE listing may not go live while the store
+ * would render it a primary CTA the viewer cannot click. The gate delegates its
+ * verdict to the real `getDetailPrimaryAction` view-model, so these tests pin the
+ * CONTRACT ("blocked ⟺ the rendered action has no href") rather than any
+ * particular CTA copy — the copy is #3585's business and must be free to move
+ * without touching this file.
+ */
+import { TRPCError } from '@trpc/server';
+import { describe, expect, it } from 'vitest';
+
+import { getDetailPrimaryAction } from '~/components/Apps/appListingDetailView';
+import {
+  assertOffsiteListingActionable,
+  buildActionabilityError,
+  checkOffsiteListingActionable,
+  type ListingActionabilitySource,
+} from '~/server/services/blocks/app-listing-actionable.service';
+
+const offsite = (over: Partial<ListingActionabilitySource> = {}): ListingActionabilitySource => ({
+  kind: 'offsite',
+  slug: 'demo-app',
+  externalUrl: 'https://demo.app',
+  connectClientId: null,
+  ...over,
+});
+
+/** Every way an off-site listing can end up with no reachable destination. */
+const NO_DESTINATION: { name: string; url: string | null }[] = [
+  { name: 'null', url: null },
+  { name: 'empty string', url: '' },
+  { name: 'http (not https)', url: 'http://insecure.app' },
+  { name: 'javascript: scheme', url: 'javascript:alert(1)' },
+];
+
+describe('checkOffsiteListingActionable — the verdict', () => {
+  it('passes an off-site external-link listing with an https destination', () => {
+    const result = checkOffsiteListingActionable(offsite());
+    expect(result.ok).toBe(true);
+    expect(result.skipped).toBe(false);
+    expect(result.action?.href).toBe('https://demo.app');
+  });
+
+  for (const { name, url } of NO_DESTINATION) {
+    it(`BLOCKS an off-site external-link listing whose externalUrl is ${name}`, () => {
+      const result = checkOffsiteListingActionable(offsite({ externalUrl: url }));
+      expect(result.ok).toBe(false);
+      expect(result.action?.href).toBeUndefined();
+    });
+  }
+
+  for (const { name, url } of NO_DESTINATION) {
+    it(`BLOCKS an off-site CONNECT listing whose externalUrl is ${name}`, () => {
+      // client_id present → `resolveOffsiteSubKind` routes this to the connect arm.
+      const result = checkOffsiteListingActionable(
+        offsite({ externalUrl: url, connectClientId: 'client-123' })
+      );
+      expect(result.ok).toBe(false);
+      expect(result.action?.href).toBeUndefined();
+    });
+  }
+
+  it('treats an ABSENT externalUrl the same as an explicit null (Prisma create input)', () => {
+    const { externalUrl: _drop, ...withoutUrl } = offsite();
+    expect(checkOffsiteListingActionable(withoutUrl).ok).toBe(false);
+  });
+
+  it('is uppercase-scheme strict — HTTPS:// is not accepted as a destination', () => {
+    // 🔴 Deliberate, and a real divergence worth pinning: the server projection's
+    // `safeExternalUrl` is case-INsensitive (/^https:\/\//i) while the render
+    // boundary's `safeExternalHref` is case-SENSITIVE. The gate must agree with
+    // what the USER's browser is handed — the render boundary — so such a row is
+    // correctly refused rather than published to a button that renders no anchor.
+    expect(checkOffsiteListingActionable(offsite({ externalUrl: 'HTTPS://demo.app' })).ok).toBe(
+      false
+    );
+  });
+});
+
+describe('the gate is scoped to off-site, and delegates rather than re-deriving', () => {
+  it('SKIPS an on-site listing entirely — a model-slot app is legitimately non-navigable', () => {
+    // An on-site listing with no backing page renders "Runs on model pages":
+    // informational, no href, and a perfectly valid live listing. Gating it would
+    // fire on a valid shape, so the check must not evaluate on-site at all.
+    const result = checkOffsiteListingActionable({
+      kind: 'onsite',
+      slug: 'slot-app',
+      externalUrl: null,
+      connectClientId: null,
+    });
+    expect(result).toEqual({ ok: true, skipped: true, action: null });
+  });
+
+  it('verdict === "the real view-model produced no href", for every off-site shape', () => {
+    // 🔴 The structural restatement of the contract. This is what makes the gate
+    // track #3585 (and any later re-branch) with no edit here: it never asserts a
+    // label, a mode, or a sub-kind — only that the gate agrees with the view-model
+    // the detail page actually renders.
+    let blocked = 0;
+    let allowed = 0;
+    for (const externalUrl of [
+      'https://demo.app',
+      'http://insecure.app',
+      '',
+      null,
+      'javascript:alert(1)',
+    ]) {
+      for (const connectClientId of [null, 'client-123']) {
+        const listing = offsite({ externalUrl, connectClientId });
+        const action = getDetailPrimaryAction(
+          { slug: listing.slug, kind: 'offsite', kindData: expectedKindData(listing) },
+          { canOpenPage: true }
+        );
+        const result = checkOffsiteListingActionable(listing);
+        expect(result.ok).toBe(!!action.href);
+        if (result.ok) allowed += 1;
+        else blocked += 1;
+      }
+    }
+    // 🔴 ANTI-VACUITY: without these the loop passes if the gate blocked
+    // everything, or nothing. 10 cases = 5 URL shapes x 2 client values.
+    expect(blocked + allowed).toBe(10);
+    expect(allowed).toBeGreaterThanOrEqual(1);
+    // The 4 no-destination URL shapes x 2 client values are non-actionable under
+    // ANY version of the view-model — a listing with no reachable address cannot
+    // become navigable. Bounded rather than pinned exactly because the connect +
+    // https case is the one #3585 moves (see the dedicated test below); pinning
+    // `allowed` to today's value would turn this suite red the moment that lands.
+    expect(blocked).toBeGreaterThanOrEqual(8);
+  });
+
+  it('connect + https: the gate agrees with the view-model in BOTH #3585 worlds', () => {
+    // 🔴 The case the CTA fix (#3585) changes, and the reason this suite asserts a
+    // relationship instead of a value.
+    //   - pre-#3585  the connect arm returns the stub unconditionally → no href →
+    //                the gate BLOCKS, which is correct: on this code such a listing
+    //                genuinely renders a dead button, exactly the three that shipped.
+    //   - post-#3585 the destination decides → Visit ↗ → the gate ALLOWS.
+    // Either way the gate must return whatever the store would actually render, so
+    // that is what is asserted. This test is deliberately version-agnostic and must
+    // stay green across the merge in both orders.
+    const listing = offsite({ externalUrl: 'https://demo.app', connectClientId: 'client-123' });
+    const action = getDetailPrimaryAction(
+      { slug: listing.slug, kind: 'offsite', kindData: expectedKindData(listing) },
+      { canOpenPage: true }
+    );
+    expect(checkOffsiteListingActionable(listing).ok).toBe(!!action.href);
+  });
+
+  it('canOpenPage is unread on every off-site branch, so the gate may hardcode it', () => {
+    // The gate passes `canOpenPage: true`. That is only safe while no off-site
+    // branch consults it — assert that against the view-model directly, since the
+    // gate itself gives no way to vary the flag. If a future re-branch makes an
+    // off-site action depend on it, this fails and the hardcode must be revisited.
+    for (const externalUrl of ['https://demo.app', 'http://insecure.app', null]) {
+      for (const connectClientId of [null, 'client-123']) {
+        const listing = offsite({ externalUrl, connectClientId });
+        const args = {
+          slug: listing.slug,
+          kind: 'offsite' as const,
+          kindData: expectedKindData(listing),
+        };
+        expect(getDetailPrimaryAction(args, { canOpenPage: true })).toEqual(
+          getDetailPrimaryAction(args, { canOpenPage: false })
+        );
+      }
+    }
+  });
+});
+
+describe('assertOffsiteListingActionable — fails CLOSED with mod-actionable copy', () => {
+  it('does not throw for a navigable off-site listing', () => {
+    expect(() => assertOffsiteListingActionable(offsite())).not.toThrow();
+  });
+
+  it('does not throw for an on-site listing', () => {
+    expect(() =>
+      assertOffsiteListingActionable({
+        kind: 'onsite',
+        slug: 'slot-app',
+        externalUrl: null,
+        connectClientId: null,
+      })
+    ).not.toThrow();
+  });
+
+  it('throws BAD_REQUEST naming the listing, the rendered button, and the fix', () => {
+    let thrown: unknown;
+    try {
+      assertOffsiteListingActionable(offsite({ externalUrl: null, connectClientId: 'client-123' }));
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(TRPCError);
+    const trpc = thrown as TRPCError;
+    expect(trpc.code).toBe('BAD_REQUEST');
+    // Names the listing…
+    expect(trpc.message).toContain('demo-app');
+    // …quotes what the moderator would have seen on the button…
+    expect(trpc.message).toContain('Connecting this app will be available soon.');
+    // …and states the remedy.
+    expect(trpc.message).toContain('https external URL');
+  });
+
+  it('quotes the OTHER non-actionable shape too (no valid link), not just the connect stub', () => {
+    let message = '';
+    try {
+      assertOffsiteListingActionable(offsite({ externalUrl: 'http://insecure.app' }));
+    } catch (err) {
+      message = (err as TRPCError).message;
+    }
+    expect(message).toContain('This app has no valid external link.');
+  });
+});
+
+describe('buildActionabilityError', () => {
+  it('omits the em-dash note clause when the action carries no note', () => {
+    const msg = buildActionabilityError('some-app', {
+      label: 'Nowhere',
+      mode: 'info',
+      external: false,
+    });
+    expect(msg).toContain('"Nowhere"');
+    expect(msg).not.toContain('—');
+  });
+});
+
+/**
+ * Local restatement of the off-site projection, used ONLY as the oracle in the
+ * structural test above. Deliberately NOT imported from the gate: an oracle that
+ * shares the code under test cannot discriminate.
+ */
+function expectedKindData(listing: ListingActionabilitySource) {
+  const subKind = listing.connectClientId ? ('connect' as const) : ('external-link' as const);
+  return {
+    kind: 'offsite' as const,
+    subKind,
+    externalUrl:
+      listing.externalUrl && /^https:\/\//i.test(listing.externalUrl) ? listing.externalUrl : null,
+    connectClientId: subKind === 'connect' ? listing.connectClientId ?? null : null,
+  };
+}

--- a/src/server/services/blocks/__tests__/app-listing-backfill.service.test.ts
+++ b/src/server/services/blocks/__tests__/app-listing-backfill.service.test.ts
@@ -150,6 +150,42 @@ describe('backfillAppListings — mapping', () => {
     expect(data.contentRating).toBe('r');
   });
 
+  it('🔴 REFUSES to mint a live off-site listing with a non-https destination', async () => {
+    // `mapAppBlockToListing` hardcodes `status: 'approved'`, so this loop writes rows
+    // DIRECTLY LIVE — it is a go-live path. It also derives `kind: 'offsite'` from a
+    // merely NON-EMPTY externalUrl with no https requirement, while the public
+    // projection null-guards anything that is not https. So an `http://` block would
+    // otherwise mint an approved listing whose store CTA has nothing to click.
+    mockDb.appBlock.findMany.mockResolvedValue([
+      { ...offsite, externalUrl: 'http://insecure.example.com/launch' },
+    ]);
+    const { backfillAppListings } = await import('../app-listing-backfill.service');
+    const res = await backfillAppListings();
+
+    // Nothing minted, and the moderator gets a per-row diagnostic rather than a 500.
+    expect(res.created).toBe(0);
+    expect(mockDb.appListing.create).not.toHaveBeenCalled();
+    expect(res.failed).toHaveLength(1);
+    expect(res.failed[0].appBlockId).toBe('ab_2');
+    expect(res.failed[0].error).toContain('needs a working link before it can go live');
+  });
+
+  it('PER-ROW ISOLATION: one unpublishable block does not stop the others', async () => {
+    // 🔴 Anti-vacuity for the test above: proves the refusal is scoped to the bad row
+    // rather than aborting the batch (which would look identical if only the bad row
+    // were staged).
+    mockDb.appBlock.findMany.mockResolvedValue([
+      { ...offsite, externalUrl: 'http://insecure.example.com/launch' },
+      onsite,
+    ]);
+    const { backfillAppListings } = await import('../app-listing-backfill.service');
+    const res = await backfillAppListings();
+
+    expect(res.failed).toHaveLength(1);
+    expect(res.created).toBe(1);
+    expect(res.byKind).toEqual({ onsite: 1, offsite: 0 });
+  });
+
   it('leaves assets NULL (no mandatory-asset enforcement in P0)', async () => {
     mockDb.appBlock.findMany.mockResolvedValue([onsite]);
     const { backfillAppListings } = await import('../app-listing-backfill.service');

--- a/src/server/services/blocks/__tests__/offsite-listing.connect.approve.service.test.ts
+++ b/src/server/services/blocks/__tests__/offsite-listing.connect.approve.service.test.ts
@@ -298,6 +298,72 @@ describe('approveExternalRequest — CONNECT revision copies updated scopes to l
     });
   });
 
+  it('🔴 a REVISION that would strip the live listing\'s destination is REFUSED — nothing copied', async () => {
+    // The "break an already-live listing" case. A revision writes NO status, so the
+    // status-transition gates never see it — but it copies `externalUrl` /
+    // `connectClientId` straight onto an approved parent. A shadow with no
+    // destination would therefore turn a working live listing into a dead CTA.
+    //
+    // 🔴 This also pins WHERE the gate is asserted. It must run on the POST-COPY
+    // projection (parent kind/slug + SHADOW url/client). A gate that re-read the
+    // PARENT instead would see the parent's still-valid URL, pass, and then
+    // overwrite it — passing this scenario while permitting exactly the regression.
+    mockRead.appListingPublishRequest.findUnique.mockResolvedValue({
+      id: 'alpr_r',
+      status: 'pending',
+      kind: 'offsite',
+      slug: 'parent-slug',
+      appListingId: 'apl_shadow',
+    });
+    mockRead.appListing.findUnique.mockImplementation(async (args: { where: { id: string } }) => {
+      if (args.where.id === 'apl_shadow') {
+        return {
+          id: 'apl_shadow',
+          status: 'draft',
+          externalUrl: null, // the revision REMOVES the destination
+          iconId: 1,
+          coverId: 2,
+          revisionOfId: 'apl_parent',
+          connectClientId: CLIENT_ID,
+          connectRequestedScopes: REQUESTED,
+          connectScopeJustifications: JUSTIFIED,
+          userId: CALLER,
+          name: 'Connect App',
+          slug: 'parent-slug',
+        };
+      }
+      // The LIVE parent still has a perfectly good destination.
+      return {
+        id: 'apl_parent',
+        slug: 'parent-slug',
+        status: 'approved',
+        kind: 'offsite',
+        externalUrl: CONNECT_URL,
+      };
+    });
+    mockWrite.appListing.findUnique.mockResolvedValue({
+      id: 'apl_shadow',
+      status: 'draft',
+      revisionOfId: 'apl_parent',
+      externalUrl: null,
+      connectClientId: CLIENT_ID,
+      connectRequestedScopes: REQUESTED,
+      connectScopeJustifications: JUSTIFIED,
+      connectClient: { allowedScopes: CEILING },
+      iconId: 1,
+      coverId: 2,
+    });
+
+    await expect(
+      approveExternalRequest({ publishRequestId: 'alpr_r', reviewerUserId: MOD })
+    ).rejects.toMatchObject({
+      code: 'BAD_REQUEST',
+      message: expect.stringContaining('needs a working link before it can go live'),
+    });
+    // Nothing was copied onto the live parent — it keeps serving its old, working content.
+    expect(mockWrite.appListing.update).not.toHaveBeenCalled();
+  });
+
   it('in-tx subset-of-ceiling on the REVISION: a shadow requesting a scope beyond the (shrunk) client ceiling → REJECT inside the tx, NO copy', async () => {
     // N2: mirror the first-time approve's in-tx subset re-assert on the revision path.
     // The revision's scopes are all justified, so this is caught ONLY by the

--- a/src/server/services/blocks/__tests__/offsite-listing.connect.approve.service.test.ts
+++ b/src/server/services/blocks/__tests__/offsite-listing.connect.approve.service.test.ts
@@ -57,6 +57,9 @@ vi.mock('~/server/services/blocks/app-listing-notify', () => ({
 const MOD = 7;
 const CALLER = 42;
 const CLIENT_ID = 'oauth-client-1';
+/** The app's own address — where the store sends a viewer so the app can start its
+ *  own OAuth flow. A connect listing without one has nowhere to send anybody. */
+const CONNECT_URL = 'https://connect.example.com/app';
 // A sensitive scope (ModelsWrite) + a normal read (ModelsRead).
 const REQUESTED = TokenScope.ModelsWrite | TokenScope.ModelsRead;
 const JUSTIFIED = { ModelsWrite: 'We edit models on the user behalf.' };
@@ -102,6 +105,8 @@ function stageConnectApprove(overrides: {
   primaryRequestedScopes?: number;
   primaryJustifications?: Record<string, string>;
   primaryAllowedScopes?: number;
+  /** The listing's destination. `null` → the actionability gate refuses go-live. */
+  externalUrl?: string | null;
 } = {}) {
   mockRead.appListingPublishRequest.findUnique.mockResolvedValue({
     id: 'alpr_c',
@@ -114,8 +119,16 @@ function stageConnectApprove(overrides: {
   const justifications = overrides.justifications ?? JUSTIFIED;
   const listing = {
     id: 'apl_c',
+    // 🔴 `kind` is load-bearing: the go-live actionability gate is off-site-only, so
+    // a fixture without it makes that gate a silent no-op and these tests would pass
+    // with the guard deleted.
+    kind: 'offsite',
     status: 'draft',
-    externalUrl: null, // CONNECT: no external URL by construction
+    // CONNECT listings may carry no external URL in the DB model — but a listing with
+    // no reachable address renders a store button with nothing to click, which is
+    // what the actionability gate now refuses. `externalUrl` is therefore part of the
+    // publishable-connect-listing fixture; see the reversed test below.
+    externalUrl: overrides.externalUrl === undefined ? CONNECT_URL : overrides.externalUrl,
     iconId: 1,
     coverId: 2,
     revisionOfId: null,
@@ -131,7 +144,9 @@ function stageConnectApprove(overrides: {
   // ceiling so the AUTHORITATIVE connect gates run row-consistent with the flip. By
   // default it mirrors the replica; a TOCTOU test overrides the `primary*` fields.
   mockWrite.appListing.findUnique.mockResolvedValue({
-    externalUrl: null,
+    kind: 'offsite',
+    slug: 'connect-app',
+    externalUrl: listing.externalUrl,
     iconId: 1,
     coverId: 2,
     connectClientId: CLIENT_ID,
@@ -142,12 +157,29 @@ function stageConnectApprove(overrides: {
 }
 
 describe('approveExternalRequest — CONNECT approve→live (validateExternalUrl skip)', () => {
-  it('approves a connect listing with a NULL externalUrl (URL gate skipped) → draft→approved', async () => {
+  /**
+   * 🔴 REVERSED INTENT — called out rather than left in the diff.
+   *
+   * This test used to stage `externalUrl: null` and assert the approve SUCCEEDED,
+   * encoding "a connect listing needs no destination". That rule is what let three
+   * connect listings go live with a disabled button and no way to open the app.
+   *
+   * A connect listing's OAuth flow starts at the APP's own site (confidential
+   * clients own their redirect_uri / state / PKCE) — the store's only job is to get
+   * the viewer there, and `externalUrl` is the only address it has. So a connect
+   * listing with no destination is not a valid shape that happens to render poorly;
+   * it is a listing no user can act on, under every version of the view-model.
+   *
+   * What this test still pins, unchanged, is the ORIGINAL subject: `validateExternalUrl`
+   * is skipped for connect. The listing now carries an https URL so the approve
+   * reaches the flip, and the null-destination case is asserted below as a refusal.
+   */
+  it('approves a connect listing (URL gate skipped) → draft→approved', async () => {
     stageConnectApprove();
     const res = await approveExternalRequest({ publishRequestId: 'alpr_c', reviewerUserId: MOD });
     expect(res).toEqual({ publishRequestId: 'alpr_c', listingId: 'apl_c', slug: 'connect-app' });
     // The listing flip fired (draft/pending → approved) — proves approve reached the
-    // flip rather than throwing on the null URL.
+    // flip rather than throwing on either URL gate.
     expect(mockWrite.appListing.updateMany).toHaveBeenCalledWith({
       where: { id: 'apl_c', status: { in: ['draft', 'pending'] } },
       data: { status: 'approved', contentRating: 'g' },
@@ -156,6 +188,23 @@ describe('approveExternalRequest — CONNECT approve→live (validateExternalUrl
     expect(mockNotify).toHaveBeenCalledWith(
       expect.objectContaining({ type: 'app-listing-approved', userId: CALLER })
     );
+  });
+
+  it('🔴 REFUSES a connect listing with NO destination — the shape that shipped a dead CTA', async () => {
+    // The reversal, pinned positively. `validateExternalUrl` is still skipped (a null
+    // URL is not an *invalid* URL) — it is the ACTIONABILITY gate that refuses, and
+    // the message must be the one a moderator can act on.
+    stageConnectApprove({ externalUrl: null });
+    await expect(
+      approveExternalRequest({ publishRequestId: 'alpr_c', reviewerUserId: MOD })
+    ).rejects.toMatchObject({
+      code: 'BAD_REQUEST',
+      message: expect.stringContaining('needs a working link before it can go live'),
+    });
+    // Fails CLOSED — nothing flipped, and the owner is NOT told their app went live.
+    expect(mockWrite.appListing.updateMany).not.toHaveBeenCalled();
+    expect(mockWrite.appListingPublishRequest.updateMany).not.toHaveBeenCalled();
+    expect(mockNotify).not.toHaveBeenCalled();
   });
 
   it('the LIVE connect listing carries the reviewed scopes (flip does not clobber the connect fields)', async () => {
@@ -191,7 +240,7 @@ describe('approveExternalRequest — CONNECT revision copies updated scopes to l
         return {
           id: 'apl_shadow',
           status: 'draft',
-          externalUrl: null,
+          externalUrl: CONNECT_URL,
           iconId: 1,
           coverId: 2,
           revisionOfId: 'apl_parent',
@@ -204,7 +253,7 @@ describe('approveExternalRequest — CONNECT revision copies updated scopes to l
         };
       }
       if (args.where.id === 'apl_parent') {
-        return { id: 'apl_parent', slug: 'parent-slug', status: 'approved' };
+        return { id: 'apl_parent', slug: 'parent-slug', status: 'approved', kind: 'offsite' };
       }
       return null;
     });
@@ -220,7 +269,7 @@ describe('approveExternalRequest — CONNECT revision copies updated scopes to l
           description: null,
           category: 'utility',
           contentRating: 'g',
-          externalUrl: null,
+          externalUrl: CONNECT_URL,
           connectClientId: CLIENT_ID,
           connectRequestedScopes: UPDATED,
           connectScopeJustifications: UPDATED_JUST,
@@ -267,7 +316,7 @@ describe('approveExternalRequest — CONNECT revision copies updated scopes to l
         return {
           id: 'apl_shadow',
           status: 'draft',
-          externalUrl: null,
+          externalUrl: CONNECT_URL,
           iconId: 1,
           coverId: 2,
           revisionOfId: 'apl_parent',
@@ -280,7 +329,7 @@ describe('approveExternalRequest — CONNECT revision copies updated scopes to l
         };
       }
       if (args.where.id === 'apl_parent') {
-        return { id: 'apl_parent', slug: 'parent-slug', status: 'approved' };
+        return { id: 'apl_parent', slug: 'parent-slug', status: 'approved', kind: 'offsite' };
       }
       return null;
     });
@@ -297,7 +346,7 @@ describe('approveExternalRequest — CONNECT revision copies updated scopes to l
           description: null,
           category: 'utility',
           contentRating: 'g',
-          externalUrl: null,
+          externalUrl: CONNECT_URL,
           connectClientId: CLIENT_ID,
           connectRequestedScopes: REQ,
           connectScopeJustifications: JUST,
@@ -432,7 +481,7 @@ describe('approveExternalRequest — external-link revision still validates its 
         };
       }
       if (args.where.id === 'apl_parent') {
-        return { id: 'apl_parent', slug: 'parent-slug', status: 'approved' };
+        return { id: 'apl_parent', slug: 'parent-slug', status: 'approved', kind: 'offsite' };
       }
       return null;
     });

--- a/src/server/services/blocks/__tests__/offsite-listing.edit.service.test.ts
+++ b/src/server/services/blocks/__tests__/offsite-listing.edit.service.test.ts
@@ -642,7 +642,18 @@ describe('approveExternalRequest (revision apply)', () => {
     mockRead.appListing.findUnique.mockImplementation(
       findUniqueById({
         apl_shadow: shadowListing as Row,
-        apl_parent: { id: 'apl_parent', slug: 'cool-app', status: 'approved' } as Row,
+        // 🔴 `kind` IS LOAD-BEARING HERE, not decoration. It is NOT NULL in the
+        // DB, so a row without it cannot exist — and omitting it made the
+        // actionable-CTA gate a silent no-op: the gate skips a non-offsite
+        // listing, so these tests passed with the guard DELETED. It was also
+        // internally inconsistent, since `applyApprovedRevision` took the
+        // off-site copy branch while the off-site gate skipped.
+        apl_parent: {
+          id: 'apl_parent',
+          slug: 'cool-app',
+          status: 'approved',
+          kind: 'offsite',
+        } as Row,
       })
     );
     // In-tx authoritative shadow re-read (dbWrite) — full scalars to copy.

--- a/src/server/services/blocks/__tests__/offsite-listing.onsite-revision.service.test.ts
+++ b/src/server/services/blocks/__tests__/offsite-listing.onsite-revision.service.test.ts
@@ -346,6 +346,7 @@ describe('approveExternalRequest — supersede scopes by the REQUEST kind (no on
     mockRead.appListing.findUnique.mockResolvedValue({
       id: 'apl_ft',
       status: 'draft',
+      kind,
       externalUrl: kind === 'offsite' ? 'https://example.com/' : null,
       iconId: 1,
       coverId: 2,

--- a/src/server/services/blocks/__tests__/offsite-listing.service.test.ts
+++ b/src/server/services/blocks/__tests__/offsite-listing.service.test.ts
@@ -570,9 +570,11 @@ function stageApproveScenario(listing: {
   iconId?: number | null;
   coverId?: number | null;
   screenshotCount?: number;
-  externalUrl?: string;
+  externalUrl?: string | null;
   status?: string;
   submittedByUserId?: number;
+  /** Off-site sub-kind discriminator — non-null routes the CTA to the connect arm. */
+  connectClientId?: string | null;
 }) {
   mockRead.appListingPublishRequest.findUnique.mockResolvedValue({
     id: 'alpr_1',
@@ -585,7 +587,7 @@ function stageApproveScenario(listing: {
   const listingRow = {
     id: 'apl_1',
     status: listing.status ?? 'draft',
-    externalUrl: listing.externalUrl ?? 'https://cool.example.com/app',
+    externalUrl: listing.externalUrl === undefined ? 'https://cool.example.com/app' : listing.externalUrl,
     iconId: listing.iconId === undefined ? 1 : listing.iconId,
     coverId: listing.coverId === undefined ? 2 : listing.coverId,
     // Owner fields the approve path reads for the post-commit owner notification.
@@ -593,6 +595,12 @@ function stageApproveScenario(listing: {
     name: 'Cool App',
     slug: 'cool-app',
     revisionOfId: null,
+    // 🔴 `kind` is REQUIRED in this fixture, not decoration. The go-live actionability
+    // gate is off-site-only, so a row without a `kind` makes that gate a silent no-op
+    // and every approve test would pass with the guard deleted. Off-site is what this
+    // suite exercises.
+    kind: 'offsite',
+    connectClientId: listing.connectClientId ?? null,
   };
   const count = listing.screenshotCount === undefined ? 1 : listing.screenshotCount;
   const screenshotRows = Array.from({ length: count }, (_, i) => ({ imageId: 1000 + i }));
@@ -610,6 +618,68 @@ function stageApproveScenario(listing: {
   mockRead.image.findMany.mockImplementation(scanned as never);
   mockWrite.image.findMany.mockImplementation(scanned as never);
 }
+
+describe('approveExternalRequest — go-live ACTIONABILITY gate', () => {
+  /**
+   * 🔴 The gate that was MISSING when three connect listings were approved onto a
+   * dead CTA (07-24 → 07-28). An off-site listing may not be flipped live while the
+   * store would render it a primary button with nothing to click.
+   */
+  it('REFUSES approve when the off-site listing has NO destination — no flip at all', async () => {
+    stageApproveScenario({ externalUrl: null });
+    await expect(
+      approveExternalRequest({ publishRequestId: 'alpr_1', reviewerUserId: MOD })
+    ).rejects.toMatchObject({
+      code: 'BAD_REQUEST',
+      message: expect.stringContaining('needs a working link before it can go live'),
+    });
+    // Fails CLOSED: neither the request nor the listing is flipped.
+    expect(mockWrite.appListing.updateMany).not.toHaveBeenCalled();
+    expect(mockWrite.appListingPublishRequest.updateMany).not.toHaveBeenCalled();
+  });
+
+  it('REFUSES approve when the destination is not https (http:// is not a destination)', async () => {
+    stageApproveScenario({ externalUrl: 'http://insecure.example.com/app' });
+    await expect(
+      approveExternalRequest({ publishRequestId: 'alpr_1', reviewerUserId: MOD })
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+    expect(mockWrite.appListing.updateMany).not.toHaveBeenCalled();
+  });
+
+  it('🔴 REFUSES a CONNECT listing whose CTA would be the dead stub', async () => {
+    // A linked OAuth client with no reachable address — non-actionable under both
+    // the current view-model and #3585's, so this pin is stable across that merge.
+    stageApproveScenario({ externalUrl: null, connectClientId: 'client-123' });
+    await expect(
+      approveExternalRequest({ publishRequestId: 'alpr_1', reviewerUserId: MOD })
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+    expect(mockWrite.appListing.updateMany).not.toHaveBeenCalled();
+  });
+
+  it('the gate is AUTHORITATIVE on the primary: replica has a URL, primary does not → BLOCKED', async () => {
+    // TOCTOU — `externalUrl` is owner-editable in place while the request sits
+    // pending, so the replica fail-fast can pass on a stale row. The in-tx re-read
+    // must catch it and roll the whole tx back before anything is approved.
+    stageApproveScenario({ iconId: 1, coverId: 2, screenshotCount: 1 });
+    mockWrite.appListing.findUnique.mockResolvedValue({
+      id: 'apl_1',
+      status: 'draft',
+      externalUrl: null, // primary: the owner cleared it after the replica read
+      connectClientId: null,
+      iconId: 1,
+      coverId: 2,
+      kind: 'offsite',
+      slug: 'cool-app',
+    });
+    await expect(
+      approveExternalRequest({ publishRequestId: 'alpr_1', reviewerUserId: MOD })
+    ).rejects.toMatchObject({
+      code: 'BAD_REQUEST',
+      message: expect.stringContaining('needs a working link before it can go live'),
+    });
+    expect(mockWrite.appListing.updateMany).not.toHaveBeenCalled();
+  });
+});
 
 describe('approveExternalRequest', () => {
   it('happy path: pending + assets-complete → listing draft→approved + request approved w/ reviewedBy*/approvalNotes', async () => {
@@ -713,6 +783,10 @@ describe('approveExternalRequest', () => {
         connectRequestedScopes: true,
         connectScopeJustifications: true,
         connectClient: { select: { allowedScopes: true } },
+        // `kind` + `slug` feed the AUTHORITATIVE go-live actionability gate, which is
+        // off-site-only and names the listing in its moderator-facing error.
+        kind: true,
+        slug: true,
       },
     });
     // The screenshot imageIds (for the floor count + the scan gate) are read from

--- a/src/server/services/blocks/__tests__/offsite-listing.service.test.ts
+++ b/src/server/services/blocks/__tests__/offsite-listing.service.test.ts
@@ -638,6 +638,19 @@ describe('approveExternalRequest — go-live ACTIONABILITY gate', () => {
     expect(mockWrite.appListingPublishRequest.updateMany).not.toHaveBeenCalled();
   });
 
+  it('the pre-tx fail-fast rejects BEFORE any transaction is opened', async () => {
+    // 🔴 The observable that distinguishes the (4c) REPLICA fail-fast from the (5)
+    // in-tx authoritative re-assert: with only the in-tx gate the transaction still
+    // opens and rolls back, so `rejects` alone cannot tell the two apart and the
+    // pre-tx guard would be untested. `$transaction` never being called is the only
+    // signal that proves this specific guard ran.
+    stageApproveScenario({ externalUrl: null });
+    await expect(
+      approveExternalRequest({ publishRequestId: 'alpr_1', reviewerUserId: MOD })
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+    expect(mockWrite.$transaction).not.toHaveBeenCalled();
+  });
+
   it('REFUSES approve when the destination is not https (http:// is not a destination)', async () => {
     stageApproveScenario({ externalUrl: 'http://insecure.example.com/app' });
     await expect(

--- a/src/server/services/blocks/__tests__/offsite-moderation.service.mod-actions.test.ts
+++ b/src/server/services/blocks/__tests__/offsite-moderation.service.mod-actions.test.ts
@@ -122,10 +122,31 @@ const GOOD_REASON = 'impersonates a real vendor';
 
 const OWNER = 500;
 const BLOCK_ID = 'blk_backing';
+/** A valid https destination — what makes an off-site listing publishable. */
+const EXTERNAL_URL = 'https://cool.app';
 
-/** Replica classify shape — carries userId + name + appBlockId (dual-action classify). */
+/**
+ * Replica classify shape — carries userId + name + appBlockId (dual-action classify).
+ *
+ * 🔴 `externalUrl` is part of the fixture because relist/republish are GO-LIVE
+ * transitions and now run the off-site actionability gate: an off-site listing with
+ * no https destination would render a store button with nothing to click and is
+ * refused. A fixture without a URL does not represent a publishable off-site
+ * listing at all, so the default carries one; the tests that exercise the gate
+ * override it explicitly.
+ */
 function offsiteListing(status: string, kind = 'offsite') {
-  return { id: APP_ID, kind, status, slug: SLUG, name: 'Cool App', userId: OWNER, appBlockId: null };
+  return {
+    id: APP_ID,
+    kind,
+    status,
+    slug: SLUG,
+    name: 'Cool App',
+    userId: OWNER,
+    appBlockId: null,
+    externalUrl: EXTERNAL_URL,
+    connectClientId: null,
+  };
 }
 /** An on-site listing carries a backing AppBlock id (dual-table flip target). */
 function onsiteListing(status: string) {
@@ -137,6 +158,9 @@ function onsiteListing(status: string) {
     name: 'Cool App',
     userId: OWNER,
     appBlockId: BLOCK_ID,
+    // On-site listings never carry an off-site destination; the gate skips them.
+    externalUrl: null,
+    connectClientId: null,
   };
 }
 
@@ -399,6 +423,81 @@ const withAssets = <T extends object>(listing: T): T & { iconId: number; coverId
 const injectIngestion = (byId: Record<number, string>) =>
   (async (args: { where?: { id?: { in?: number[] } } }) =>
     (args?.where?.id?.in ?? []).map((id) => ({ id, ingestion: byId[id] ?? 'Scanned' }))) as never;
+
+describe('relistListing / republishOwnListing — go-live ACTIONABILITY gate', () => {
+  /** An off-site listing whose store CTA would have nothing to click. */
+  const deadCta = (over: Record<string, unknown> = {}) => ({
+    ...offsiteListing('removed'),
+    externalUrl: null,
+    ...over,
+  });
+
+  it('🔴 MOD relist REFUSES an off-site listing with no https destination — no flip, no event', async () => {
+    mockRead.appListing.findUnique.mockResolvedValueOnce(offsiteListing('removed'));
+    mockWrite.appListing.findUnique.mockResolvedValue(deadCta());
+    await expect(
+      relistListing({ input: { appListingId: APP_ID, reason: 'appeal upheld' }, reviewerUserId: REVIEWER })
+    ).rejects.toMatchObject({
+      code: 'BAD_REQUEST',
+      message: expect.stringContaining('needs a working link before it can go live'),
+    });
+    expect(mockWrite.appListing.updateMany).not.toHaveBeenCalled();
+    expect(mockWrite.appListingModerationEvent.create).not.toHaveBeenCalled();
+  });
+
+  it('🔴 MOD relist REFUSES a CONNECT listing whose CTA is the dead stub (the shipped bug)', async () => {
+    // The exact shape of the three listings that went live with a disabled
+    // "Connecting this app will be available soon." button. Pre-#3585 the connect
+    // arm is non-actionable regardless of the URL, so the gate refuses; post-#3585
+    // a connect listing WITH an https URL becomes navigable and this case moves to
+    // the allowed set — which is why the URL is null here, a shape that is
+    // non-actionable under BOTH versions of the view-model.
+    mockRead.appListing.findUnique.mockResolvedValueOnce(offsiteListing('removed'));
+    mockWrite.appListing.findUnique.mockResolvedValue(
+      deadCta({ connectClientId: 'client-123' })
+    );
+    await expect(
+      relistListing({ input: { appListingId: APP_ID, reason: 'appeal upheld' }, reviewerUserId: REVIEWER })
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+    expect(mockWrite.appListing.updateMany).not.toHaveBeenCalled();
+  });
+
+  it('MOD relist ALLOWS an off-site listing with a valid https destination', async () => {
+    mockRead.appListing.findUnique.mockResolvedValueOnce(offsiteListing('removed'));
+    mockWrite.appListing.findUnique.mockResolvedValue(offsiteListing('removed'));
+    await expect(
+      relistListing({ input: { appListingId: APP_ID, reason: 'appeal upheld' }, reviewerUserId: REVIEWER })
+    ).resolves.toEqual({ appListingId: APP_ID, status: 'approved' });
+    expect(mockWrite.appListing.updateMany).toHaveBeenCalled();
+  });
+
+  it('MOD relist does NOT gate an ON-SITE listing (a model-slot app is legitimately non-navigable)', async () => {
+    mockRead.appListing.findUnique.mockResolvedValueOnce(onsiteListing('removed'));
+    // No destination at all — an on-site listing never has one, and must still relist.
+    mockWrite.appListing.findUnique.mockResolvedValue(onsiteListing('removed'));
+    await expect(
+      relistListing({ input: { appListingId: APP_ID, reason: 'appeal upheld' }, reviewerUserId: REVIEWER })
+    ).resolves.toEqual({ appListingId: APP_ID, status: 'approved' });
+    expect(mockWrite.appListing.updateMany).toHaveBeenCalled();
+  });
+
+  it('🔴 OWNER republish REFUSES an off-site listing with no https destination — no flip', async () => {
+    // The owner-driven half of the same hazard: a removed listing stays directly
+    // editable, so an owner can clear the URL and then self-restore.
+    mockWrite.appListing.findUnique.mockResolvedValue(deadCta());
+    mockWrite.appListingModerationEvent.findFirst.mockResolvedValueOnce({
+      action: 'owner-unpublish',
+    });
+    await expect(
+      republishOwnListing({ input: { appListingId: APP_ID }, userId: OWNER })
+    ).rejects.toMatchObject({
+      code: 'BAD_REQUEST',
+      message: expect.stringContaining('needs a working link before it can go live'),
+    });
+    expect(mockWrite.appListing.updateMany).not.toHaveBeenCalled();
+    expect(mockWrite.appListingModerationEvent.create).not.toHaveBeenCalled();
+  });
+});
 
 describe('relistListing — go-live scan-clean gate', () => {
   it('REFUSES a listing whose icon is still scanning (no flip, no event)', async () => {
@@ -928,7 +1027,18 @@ describe('resetListingToPending', () => {
 
 describe('unpublishOwnListing', () => {
   function ownerPrimary(status: string, kind = 'offsite', userId = OWNER, appBlockId: string | null = null) {
-    return { userId, status, kind, slug: SLUG, name: 'Cool App', appBlockId };
+    // `externalUrl` present for the same reason as `offsiteListing` above: republish
+    // is a go-live and runs the off-site actionability gate.
+    return {
+      userId,
+      status,
+      kind,
+      slug: SLUG,
+      name: 'Cool App',
+      appBlockId,
+      externalUrl: kind === 'offsite' ? EXTERNAL_URL : null,
+      connectClientId: null,
+    };
   }
 
   it('OWNER hides their approved OFF-SITE listing (approved → removed) + one owner-unpublish event, no notif/publish-request/block-flip', async () => {
@@ -1004,7 +1114,18 @@ describe('unpublishOwnListing', () => {
 
 describe('republishOwnListing (🔴 the last-event safety guard)', () => {
   function ownerPrimary(status: string, kind = 'offsite', userId = OWNER, appBlockId: string | null = null) {
-    return { userId, status, kind, slug: SLUG, name: 'Cool App', appBlockId };
+    // `externalUrl` present for the same reason as `offsiteListing` above: republish
+    // is a go-live and runs the off-site actionability gate.
+    return {
+      userId,
+      status,
+      kind,
+      slug: SLUG,
+      name: 'Cool App',
+      appBlockId,
+      externalUrl: kind === 'offsite' ? EXTERNAL_URL : null,
+      connectClientId: null,
+    };
   }
 
   it('OWNER restores their OWN owner-unpublished OFF-SITE listing (removed → approved) + owner-republish event, no block-flip', async () => {

--- a/src/server/services/blocks/app-listing-actionable.service.ts
+++ b/src/server/services/blocks/app-listing-actionable.service.ts
@@ -1,0 +1,166 @@
+/**
+ * App Store Listings — the OFF-SITE **go-live actionability gate**.
+ *
+ * ## What this exists to stop
+ *
+ * Three approved, live, moderator-visible off-site listings shipped with a DEAD
+ * primary call-to-action — a disabled affordance reading *"Connecting this app
+ * will be available soon."* with no `href`. Users had no way to open those apps
+ * from the store at all. The stub landed 2026-07-01 (#2874); all three listings
+ * were approved AFTER it, 07-24 → 07-28. Nothing on the approval path noticed it
+ * was publishing a listing onto a route that had never worked.
+ *
+ * This module is the missing gate: an off-site listing may not be flipped live
+ * while the store would render it a primary CTA the viewer cannot click.
+ *
+ * ## One rule, one place — this file computes NOTHING
+ *
+ * 🔴 The verdict is delegated, not re-derived. There is deliberately no second
+ * "is this listing actionable?" predicate here to drift out of sync with the
+ * store: the check runs the SAME `getDetailPrimaryAction` view-model the detail
+ * page renders, over the SAME `detailKindData` projection the public DTO is built
+ * from, and asks one question of the result — **did it produce an `href`?**
+ *
+ * A duplicated predicate would regenerate this exact bug at a second site the
+ * moment either copy moved. So when the view-model's off-site branches change
+ * (e.g. #3585, which makes the destination rather than the sub-kind decide the
+ * action), this gate tracks that change with no edit here — which is the whole
+ * point. Nothing about the CTA's shape is encoded below.
+ *
+ * ## Scoped to OFF-SITE, on purpose
+ *
+ * 🔴 The gate is `kind === 'offsite'` ONLY, and that scoping is load-bearing
+ * rather than incidental. An ON-SITE listing has a *legitimate* non-actionable
+ * primary action: a model-slot app (no launch page) correctly renders the
+ * informational "Runs on model pages" affordance with NO href by design, because
+ * it installs from a model page and there is nothing to open from the store. A
+ * hard gate that fired on that shape would block a valid listing, which is worse
+ * than no gate at all. An off-site listing has no such shape — it is by
+ * definition an app that lives at another address, so "live in the store with
+ * nowhere to send the user" is unambiguously broken, never a valid state.
+ *
+ * ## Fails CLOSED, and only on a transition
+ *
+ * A failed check throws `BAD_REQUEST` and rolls back the surrounding transaction,
+ * so nothing is flipped. It runs ONLY on the transitions that put a listing (or
+ * new listing content) live — never on read, never as a backfill over existing
+ * rows. Already-approved listings are therefore GRANDFATHERED and are not
+ * re-validated or taken down by this change; see the callers for the full
+ * enumeration of gated vs. deliberately-excluded go-live paths.
+ *
+ * Sibling of {@link assertListingMeetsFloor} in `app-listing-assets.service.ts`,
+ * which gates the same go-live moments on the icon+cover asset floor and whose
+ * error copy this one deliberately mirrors. ⚠️ Not to be confused with
+ * `assertListingAssetsComplete` in that file, which is ADVISORY-ONLY with no live
+ * caller — do not wire anything new into it.
+ */
+
+import { TRPCError } from '@trpc/server';
+import type { Prisma } from '@prisma/client';
+
+import type { DetailPrimaryAction } from '~/components/Apps/appListingDetailView';
+import { getDetailPrimaryAction } from '~/components/Apps/appListingDetailView';
+import type { ListingKind } from '~/server/schema/blocks/app-listing-read.schema';
+import { detailKindData } from '~/server/services/blocks/app-listing.service';
+
+/**
+ * The listing columns the check needs — exactly the ones `detailKindData`'s
+ * off-site arm reads, plus `slug`/`kind`. Narrow on purpose so every call site
+ * can satisfy it from a read it already performs (or a four-column `select`),
+ * mirroring `ListingAssetCompleteness`.
+ */
+export type ListingActionabilitySource = {
+  kind: string;
+  slug: string;
+  /** `| undefined` so a Prisma create input satisfies this unchanged — see
+   *  `DetailKindDataSource`, which treats absent and null identically. */
+  externalUrl?: string | null;
+  connectClientId?: string | null;
+};
+
+export type ListingActionabilityResult =
+  /** ON-SITE — out of scope by design (see the module docstring). Not evaluated. */
+  | { ok: true; skipped: true; action: null }
+  /** OFF-SITE with a navigable primary CTA. */
+  | { ok: true; skipped: false; action: DetailPrimaryAction }
+  /** OFF-SITE whose primary CTA would render with nothing to click. */
+  | { ok: false; skipped: false; action: DetailPrimaryAction };
+
+/**
+ * Pure core: would this listing's store detail render a primary CTA the viewer
+ * can actually act on? Returns the rendered action alongside the verdict so the
+ * caller can quote the real copy a moderator would have seen.
+ *
+ * 🔴 `canOpenPage` is passed but provably unread: the on-site listing kinds are
+ * the only branches that consult it, and those return above via the `skipped`
+ * path. Pinned by a test asserting the verdict is identical for `true` and
+ * `false`, so this stays true if the view-model is re-branched.
+ */
+export function checkOffsiteListingActionable(
+  listing: ListingActionabilitySource
+): ListingActionabilityResult {
+  if (listing.kind !== 'offsite') return { ok: true, skipped: true, action: null };
+
+  const action = getDetailPrimaryAction(
+    {
+      slug: listing.slug,
+      kind: listing.kind as ListingKind,
+      // The SAME projection the public detail DTO is built from — not a copy.
+      kindData: detailKindData(listing),
+    },
+    { canOpenPage: true }
+  );
+
+  // The single question this gate asks. `href` is what the renderer turns into a
+  // link/anchor; every non-actionable affordance (the connect stub, the
+  // no-valid-link `Unavailable` state) is precisely the case where it is absent.
+  return { ok: !!action.href, skipped: false, action };
+}
+
+/**
+ * Throwing wrapper — the go-live gate proper. Use this at call sites that already
+ * hold the four columns (they are re-read on the primary inside the flip's
+ * transaction anyway); use {@link assertOffsiteListingActionableInTx} where the
+ * row must be re-read authoritatively.
+ *
+ * The message names what a moderator would have seen AND what fixes it, matching
+ * the asset floor's tone — a mod who trips this must not have to read the code to
+ * understand it.
+ */
+export function assertOffsiteListingActionable(listing: ListingActionabilitySource): void {
+  const result = checkOffsiteListingActionable(listing);
+  if (result.ok) return;
+  throw new TRPCError({
+    code: 'BAD_REQUEST',
+    message: buildActionabilityError(listing.slug, result.action),
+  });
+}
+
+/** The moderator-facing failure copy (shared so every call site reads identically). */
+export function buildActionabilityError(slug: string, action: DetailPrimaryAction): string {
+  const seen = action.note ? `"${action.label}" — ${action.note}` : `"${action.label}"`;
+  return (
+    `Listing "${slug}" needs a working link before it can go live: its store button would ` +
+    `render as ${seen} with nothing for the viewer to open. Give the listing a valid ` +
+    `https external URL (that is the address the store sends people to), then try again.`
+  );
+}
+
+/**
+ * AUTHORITATIVE in-transaction variant — re-reads the row on the PRIMARY (`tx`)
+ * so the verdict is row-consistent with the status flip that follows, exactly as
+ * `assertListingAssetsScanCleanInTx` does for the scan gate. A missing row is a
+ * no-op (the caller's own status-guarded `updateMany` is what fails in that case,
+ * with its own clearer message) — same contract as the scan-clean helper.
+ */
+export async function assertOffsiteListingActionableInTx(
+  db: Prisma.TransactionClient,
+  appListingId: string
+): Promise<void> {
+  const listing = await db.appListing.findUnique({
+    where: { id: appListingId },
+    select: { kind: true, slug: true, externalUrl: true, connectClientId: true },
+  });
+  if (!listing) return;
+  assertOffsiteListingActionable(listing);
+}

--- a/src/server/services/blocks/app-listing-backfill.service.ts
+++ b/src/server/services/blocks/app-listing-backfill.service.ts
@@ -9,6 +9,10 @@ import {
   resolveListingName,
   type SourceAppBlock,
 } from './app-listing-mapper';
+import {
+  buildActionabilityError,
+  checkOffsiteListingActionable,
+} from '~/server/services/blocks/app-listing-actionable.service';
 
 export { mapAppBlockToListing, resolveListingDescription, resolveListingName };
 export type { SourceAppBlock };
@@ -118,6 +122,29 @@ export async function backfillAppListings(
     }
 
     const data = mapAppBlockToListing(ab);
+
+    // 🔴 GO-LIVE ACTIONABILITY gate. `mapAppBlockToListing` hardcodes
+    // `status: 'approved'`, so every row this loop writes is minted DIRECTLY LIVE —
+    // this is a go-live path, not merely a data migration. It also derives
+    // `kind: 'offsite'` from a merely NON-EMPTY `externalUrl`, with no https
+    // requirement, while the public projection null-guards anything that is not
+    // https. An AppBlock carrying e.g. an `http://` URL therefore mints an approved
+    // off-site listing whose store CTA renders "Unavailable" with no link — the
+    // exact defect class this gate exists to stop, arrived at from a different
+    // direction than the connect stub.
+    //
+    // PER-ROW ISOLATION, not a batch abort: one unpublishable block must not wedge
+    // every other block on every re-run, so the failure is collected as a per-row
+    // diagnostic exactly like the poison-row handling below. Runs BEFORE the dryRun
+    // branch so a preview reports the same verdict the real run would produce.
+    const actionable = checkOffsiteListingActionable(data);
+    if (!actionable.ok) {
+      result.failed.push({
+        appBlockId: ab.id,
+        error: buildActionabilityError(data.slug, actionable.action),
+      });
+      continue;
+    }
 
     if (dryRun) {
       result.created += 1;

--- a/src/server/services/blocks/app-listing.service.ts
+++ b/src/server/services/blocks/app-listing.service.ts
@@ -286,7 +286,30 @@ export function projectListingCard(row: HydratedListing): ListingCard {
   };
 }
 
-function detailKindData(row: HydratedListing): ListingDetailKindData {
+/**
+ * The listing columns `detailKindData` actually reads. Widened from
+ * `HydratedListing` (which still satisfies it structurally — this is a pure
+ * relaxation, no behaviour change) so a caller holding only the four off-site
+ * columns can reuse the REAL projection instead of re-deriving it.
+ *
+ * 🔴 That reuse is the point: `app-listing-actionable.service` runs the go-live
+ * actionability gate through this exact function, so the gate and the store can
+ * never disagree about what a listing's detail renders. The on-site inputs are
+ * optional because the on-site arm is the only consumer of them.
+ */
+export type DetailKindDataSource = {
+  kind: string;
+  slug: string;
+  // `| undefined` so a Prisma *create input* (whose nullable columns are optional)
+  // satisfies this as-is. Both consumers below (`safeExternalUrl`,
+  // `resolveOffsiteSubKind`) already accept `undefined` identically to `null`.
+  externalUrl?: string | null;
+  connectClientId?: string | null;
+  appBlockId?: string | null;
+  appBlock?: { manifest: Prisma.JsonValue } | null;
+};
+
+export function detailKindData(row: DetailKindDataSource): ListingDetailKindData {
   if (row.kind === 'offsite') {
     const subKind = resolveOffsiteSubKind(row.connectClientId);
     return {

--- a/src/server/services/blocks/offsite-listing.service.ts
+++ b/src/server/services/blocks/offsite-listing.service.ts
@@ -28,6 +28,7 @@ import {
   assertAssetsScanClean,
   assertListingMeetsFloor,
 } from '~/server/services/blocks/app-listing-assets.service';
+import { assertOffsiteListingActionable } from '~/server/services/blocks/app-listing-actionable.service';
 import { computeListingProblems } from '~/server/services/blocks/listing-problems';
 import { notifyAppListingOwner } from '~/server/services/blocks/app-listing-notify';
 import {
@@ -1974,6 +1975,9 @@ export async function approveExternalRequest(opts: {
       userId: true,
       name: true,
       slug: true,
+      // `kind` + `slug` also feed the go-live ACTIONABILITY gate in (4c) — the
+      // check is off-site-only, so it needs the discriminator, not just the URL.
+      kind: true,
     },
   });
   if (!listing) {
@@ -2044,6 +2048,19 @@ export async function approveExternalRequest(opts: {
   // row (`connectClientId == null`); runs for every OAuth-linked external listing.
   assertConnectSensitiveScopesJustified(listing);
 
+  // (4c) 🔴 GO-LIVE ACTIONABILITY gate — an off-site listing may not be published
+  // while the store would render it a primary CTA with nothing to click. This is
+  // the gate that was MISSING when three connect listings were approved onto the
+  // dead "Connecting this app will be available soon." stub (07-24 → 07-28), each
+  // one going live with no way for a user to open the app.
+  //
+  // It re-runs the REAL detail view-model rather than re-deriving a second
+  // "is this actionable?" rule — see `app-listing-actionable.service`. On-site
+  // requests are a no-op (a model-slot app is legitimately non-navigable).
+  // Fail-fast copy on the replica; re-asserted AUTHORITATIVELY on the primary in
+  // (5), same TOCTOU discipline as the floor + scan gates above.
+  assertOffsiteListingActionable(listing);
+
   // (5) One transaction: RE-ASSERT the asset gate on the PRIMARY (row-consistent
   // with the flip) + guarded request flip + guarded listing flip + supersede.
   await dbWrite.$transaction(async (tx) => {
@@ -2068,6 +2085,10 @@ export async function approveExternalRequest(opts: {
         connectRequestedScopes: true,
         connectScopeJustifications: true,
         connectClient: { select: { allowedScopes: true } },
+        // Go-live ACTIONABILITY gate (re-asserted below) — off-site-only, so it
+        // needs the kind discriminator; `slug` names the listing in the error.
+        kind: true,
+        slug: true,
       },
     });
     if (!primaryListing) {
@@ -2098,6 +2119,13 @@ export async function approveExternalRequest(opts: {
       },
       tx
     );
+    // AUTHORITATIVE go-live ACTIONABILITY gate on the PRIMARY (`tx`) — row-consistent
+    // with the flip below. `externalUrl` / `connectClientId` are owner-editable in
+    // place while the request sits pending, so an owner who cleared the URL (or
+    // linked an OAuth client) after the replica read in (4c) is caught HERE and the
+    // whole tx rolls back BEFORE anything is approved. Upholds the invariant: no
+    // approved off-site listing may render a primary CTA the viewer cannot click.
+    assertOffsiteListingActionable(primaryListing);
     // Validate the stored externalUrl ONLY WHEN present (it's optional in the merged
     // model); a null URL approves fine. See step (4).
     if (primaryListing.externalUrl != null) {
@@ -2389,6 +2417,24 @@ async function applyApprovedRevision(opts: {
         'cannot approve — the request is no longer pending'
       );
     }
+
+    // (2c) 🔴 GO-LIVE ACTIONABILITY gate on the POST-COPY state. A revision is a
+    // CONTENT go-live: it writes no `status`, but the off-site branch below copies
+    // the shadow's `externalUrl` + `connectClientId` straight onto an ALREADY-LIVE
+    // parent — so a revision that clears the URL (or links an OAuth client) is
+    // precisely how a working listing becomes a dead CTA without any status write.
+    //
+    // 🔴 Asserted on the PROJECTED result of the copy — the parent's `kind`/`slug`
+    // (neither is copied) with the SHADOW's URL/client (which are) — NOT on the
+    // parent as it stands. Re-reading the parent here would gate the state we are
+    // about to overwrite and would pass every regression this is meant to stop.
+    // On-site revisions are a no-op: they copy assets only, never these columns.
+    assertOffsiteListingActionable({
+      kind: parent.kind,
+      slug: parent.slug,
+      externalUrl: shadow.externalUrl,
+      connectClientId: shadow.connectClientId,
+    });
 
     // (3) Copy the shadow's contents onto the parent (id / slug / appBlockId / status
     // untouched). KIND-AWARE:

--- a/src/server/services/blocks/offsite-moderation.service.ts
+++ b/src/server/services/blocks/offsite-moderation.service.ts
@@ -21,6 +21,7 @@ import {
 } from '~/server/schema/blocks/offsite-moderation.schema';
 import { notifyAppListingOwner } from '~/server/services/blocks/app-listing-notify';
 import { assertListingAssetsScanCleanInTx } from '~/server/services/blocks/app-listing-assets.service';
+import { assertOffsiteListingActionableInTx } from '~/server/services/blocks/app-listing-actionable.service';
 import {
   newAppListingModerationEventId,
   newAppListingPublishRequestId,
@@ -507,6 +508,13 @@ export async function relistListing(opts: {
     // (the removed listing was directly asset-editable). No-op for a normally-scanned
     // listing. Runs BEFORE the flip so a scan-dirty listing is never made live.
     await assertListingAssetsScanCleanInTx(tx, input.appListingId);
+    // 🔴 GO-LIVE ACTIONABILITY gate — a relist (removed → approved) puts the listing
+    // back on the store, so it is a go-live like any other and gets the same check:
+    // an off-site listing may not become visible while its primary CTA would render
+    // with nothing to click. Read on the PRIMARY (`tx`) so the verdict is
+    // row-consistent with the flip; a removed listing stays owner-editable, so its
+    // URL/OAuth-client can have changed since the takedown. On-site relists no-op.
+    await assertOffsiteListingActionableInTx(tx, input.appListingId);
     const flipped = await tx.appListing.updateMany({
       where: { id: input.appListingId, kind: listing.kind, status: 'removed' },
       data: { status: 'approved' },
@@ -1397,6 +1405,12 @@ export async function republishOwnListing(opts: {
     // owner could attach a Pending/later-Blocked image then self-restore. No-op for a
     // normally-scanned listing; runs BEFORE the flip.
     await assertListingAssetsScanCleanInTx(tx, input.appListingId);
+    // 🔴 GO-LIVE ACTIONABILITY gate — republish (removed → approved) is an OWNER-driven
+    // go-live, and a removed listing is directly owner-editable, so this is the path
+    // where an owner can clear the external URL (or link an OAuth client) and then
+    // self-restore a listing the store cannot send anyone to. Read on the PRIMARY
+    // (`tx`), row-consistent with the flip. On-site republishes no-op.
+    await assertOffsiteListingActionableInTx(tx, input.appListingId);
     const isOnsite = listing.kind === 'onsite';
     const flipped = await tx.appListing.updateMany({
       where: { id: input.appListingId, kind: listing.kind, status: 'removed' },


### PR DESCRIPTION
## The gap

#3585 fixed the dead CTA. It did not fix the reason a dead CTA reached production: **nothing on the approval path checked whether the listing it was publishing was openable at all.**

The connect stub landed 2026-07-01 (#2874). All three affected listings were approved *after* it, 07-24 → 07-28, each flipped to `approved` by a moderator looking at a review queue that never rendered the button the user would get. The asset floor (`assertListingMeetsFloor`) already gates go-live on "does this listing have an icon and a cover". Nothing gated "can anyone actually open it".

This adds that sibling check.

## The predicate — delegated, not re-derived

`checkOffsiteListingActionable` computes nothing of its own. It runs the **real `getDetailPrimaryAction` view-model** over the **real `detailKindData` projection** the public DTO is built from, and asks one question of the result:

```ts
return { ok: !!action.href, skipped: false, action };
```

`href` is what the renderer turns into a link. Every non-actionable affordance — the connect stub, the `Unavailable` no-valid-link state — is exactly the case where it is absent.

A second "is this actionable?" rule would regenerate this bug at a second site the moment either copy moved. Because the gate delegates, it tracked #3585 automatically: it needed no edit when the destination started deciding the action, and will need none the next time that logic moves. The only supporting change is widening `detailKindData`'s parameter from `HydratedListing` to a structural `DetailKindDataSource` (a pure relaxation — `HydratedListing` still satisfies it) and exporting it, so a caller holding four columns can reuse the real projection instead of copying it.

## Every path that can make a listing live, and the decision for each

Enumerated from the write side (`status: 'approved'`), not from a handed list:

| # | Path | Transition | Gated? | Why |
|---|---|---|---|---|
| P1 | `approveExternalRequest` | `draft\|pending → approved` | ✅ **twice** | The main mod approve. Replica fail-fast at (4c), authoritative re-assert on the primary inside the tx — same TOCTOU discipline as the floor/scan gates, because `externalUrl`/`connectClientId` stay owner-editable while the request is pending |
| P2 | `applyApprovedRevision` | *(no status write)* | ✅ | A **content** go-live. Writes no status, but copies the shadow's `externalUrl`/`connectClientId` onto an already-live parent — the one way a working listing silently becomes a dead CTA. Asserted on the **post-copy projection** (parent `kind`/`slug` + shadow URL/client), not on the parent, which would gate the state being overwritten |
| P3 | `relistListing` (mod) | `removed → approved` | ✅ | Restores store visibility; a removed listing stays owner-editable, so its destination can have changed since the takedown |
| P4 | `republishOwnListing` (owner) | `removed → approved` | ✅ | Owner-driven, and a removed listing is directly editable — the path where an owner clears the URL and self-restores |
| P5 | `backfillAppListings` | *(none)* → **created `approved`** | ✅ | **Not on the original list — found by enumeration.** `mapAppBlockToListing` hardcodes `status: 'approved'`, so this mints rows *directly live*; it also derives `kind: 'offsite'` from a merely **non-empty** `externalUrl` with no https requirement, while the projection null-guards non-https. An `http://` block mints an approved off-site listing whose CTA is `Unavailable`. Gated as a **per-row skip** into `result.failed`, matching the file's existing poison-row isolation, and placed before the `dryRun` branch so a preview reports the same verdict |
| P6 | `approveRequest` — onsite draft transition | `draft → approved` | ❌ | **On-site.** See below |
| P7 | `approveRequest` — legacy create | *(none)* → `approved` | ❌ | On-site (the mapper's docstring records this path only ever passes hosted, `externalUrl: null` blocks). Also inside a log-and-continue `try` — a throw would not block the approve, it would silently skip the listing, which is worse than the status quo |
| P8 | `approveRequest` — reset-to-pending restore | `pending → approved` | ❌ | Explicitly `kind: 'onsite'`-guarded in its `where` |

**Why on-site is excluded, and why that scoping is load-bearing:** an on-site listing has a *legitimate* non-actionable primary action. A model-slot app with no launch page correctly renders the informational "Runs on model pages" affordance with no `href` — it installs from a model page, and there is nothing for the store to open. A gate that fired on that shape would block a valid listing, which is worse than no gate. An off-site listing has no equivalent: it is by definition an app that lives at another address, so "live in the store with nowhere to send the viewer" is never valid. The `kind !== 'offsite'` early return is a design decision, not an optimisation, and it is mutation-tested (M3).

Also considered and deliberately excluded: `submitListingRevision` / `submitExternalListing`. Those enter *review*, not production. Blocking submission would stop an owner getting a moderator to look at the listing at all, and the mod-facing gate already catches it at the moment that matters.

## Hard block, not a warning

A warning is effectively what moderators already had — the review queue showed them these listings and the defect went through three times. The question worth asking is whether any legitimate shape trips a hard block, and one candidate looked real: the DB model permits a connect listing with `externalUrl: null`, and an existing test asserted that shape approves fine.

It is not legitimate. A connect app's OAuth flow starts at the **app's own site** — confidential clients own their `redirect_uri`/`state`/PKCE — so the store's only job is to get the viewer there, and `externalUrl` is the only address it has. A connect listing with no destination cannot start the flow from anywhere. Post-#3585 it renders the stub; pre-#3585 it rendered the stub. It is dead in both worlds.

So that test's intent is **reversed** here, flagged rather than left to be found in the diff:

- was: `approves a connect listing with a NULL externalUrl` → asserted success
- now: the same scenario carries a real https address (the original subject — *`validateExternalUrl` is skipped for connect* — is unchanged and still pinned), and a new test asserts the null-destination case is **refused**, fails closed, and does not notify the owner that their app went live.

Fails closed with `BAD_REQUEST`, rolling back the surrounding transaction. The message names the listing, quotes the button the moderator would have shipped, and states the remedy:

> Listing "cool-app" needs a working link before it can go live: its store button would render as "Connect" — Connecting this app will be available soon. with nothing for the viewer to open. Give the listing a valid https external URL (that is the address the store sends people to), then try again.

## Grandfathering

**The gate runs only on transitions.** No backfill over existing rows, no read-path filter, no re-validation of anything already `approved`. Existing approved listings — including the three from the incident, which all have valid addresses and are navigable post-#3585 — are untouched and cannot be taken down by this change.

Two consequences are intentional: a **revision** to a live listing, and a **delist → relist**, both re-run the gate, because each is a fresh decision to put content in front of users.

## Verification

**Mutation — 11 mutants, 11 killed, 0 survived**, each confirmed to die with *its own* specific error, on an input no earlier check rejects:

| Mutant | Died on |
|---|---|
| M1 core fails OPEN | 24 tests — `expected true to be false`, `expected undefined to be an instance of TRPCError` |
| M2 core verdict INVERTED | 35 tests — `expected false to be true` |
| M3 scope removed (gate on-site too) | 3 — `expected { ok: false, skipped: false } to deeply equal { ok: true, skipped: true }`; `expected [Function] to not throw but 'TRPCError: Listing "slot-app" needs a…' was thrown` |
| M4 assert swallows the failure | 11 — `expected undefined to be an instance of TRPCError` |
| M5 delegation drift (hardcode external-link, ignore `connectClientId`) | 1 — `expected 'Listing "demo-app" needs a working li…' to contain 'Connecting this app will be available…'` |
| M6 drop the in-tx authoritative approve gate | 1 — `the gate is AUTHORITATIVE on the primary` → `promise resolved instead of rejecting` |
| M7 drop the pre-tx fail-fast | 1 — `expected "vi.fn()" to not be called at all, but actually been called 1 times` |
| M8 drop the revision post-copy gate | 1 — `a REVISION that would strip the live listing's destination` → `promise resolved instead of rejecting` |
| M9 drop the relist gate | 2 — `promise resolved "{ appListingId: 'apl_target' }" instead of rejecting` |
| M10 drop the republish gate | 1 — same, owner path |
| M11 drop the backfill gate | 2 — `expected 1 to be +0`, `expected [] to have a length of 1` |

M7 **survived the first sweep** and is the reason there is a `$transaction` assertion: the in-tx gate catches everything the pre-tx one does, so `rejects` alone cannot distinguish them and the fail-fast was untested. "The transaction never opened" is the only observable that isolates it.

**Reachability.** Three fixtures silently made the gate a no-op because they omitted `kind` (`stageApproveScenario`, `stageConnectApprove`, and the revision parent). Every approve test would have passed with the guard deleted. `kind` is now part of those fixtures, with a comment saying why.

**Gates, base-vs-head** (base = `f596de51c6`, the #3585 merge commit):

- **Typecheck** — 133 errors at base, 133 at head, error sets **identical** on (file, code). **0** in any file this PR touches. Positive control: `tsc --listFilesOnly` confirms all three new/changed service files are in the compilation, so the clean verdict is about them rather than their absence.
- **Unit suite** — base `9 failed / 11481 passed`; head `9 failed / 11515 passed`. **Identical failing set** (`get-models-raw.transient-503`, `adjust-tag-level` — both pre-existing on main). +34 tests, all passing.
- **ESLint** — 0 errors; 25 warnings at head and 25 at base across the same files (pre-existing `_a` unused-param warnings in mock signatures). The new module adds zero.

The harness was validated against a known-bad input before any verdict was read (a deliberate `expect(1).toBe(2)` produced 1 failed / 1 passed) — which also showed the runner reports `rc=0` through a pipeline, so every count above is a line count, not an exit code.

## Not verified

- No production database was read or written.
- The browser (`component`) project was not run; this change is server-side only and adds no rendering path.
- `backfillAppListings` is exercised through its unit suite only — it has not been run against real `AppBlock` rows, so **how many existing blocks would now be refused is unknown**. It is mod-triggered and per-row isolated, so a refusal surfaces as a diagnostic rather than a failure, but the first real run may report rows that previously minted silently.

## Follow-up, not fixed here

`cosmetic-studio` is linked to the wrong OAuth client (found in #3585: the linked client has 3 consents, the one the app uses has 301). It is a data fix, and now that the gate reads `connectClientId` it is worth doing before anything else starts trusting that field.
