### PR TITLE
test: unbreak the 2 baseline-red unit suites (incomplete `~/server/db/pgDb` mock)

### DIFF
--- a/src/__tests__/pages/api/mod/adjust-tag-level.test.ts
+++ b/src/__tests__/pages/api/mod/adjust-tag-level.test.ts
@@ -9,8 +9,17 @@ const { mockQuery, mockTagCache, mockTagCacheByName } = vi.hoisted(() => {
   };
 });
 
+// This factory must export EVERY binding `~/server/db/pgDb` really exports that
+// a transitively-imported module destructures at load time. `~/server/db/kyselyDb`
+// does `import { pgDbRead, pgDbReadLong, pgDbWrite } from '~/server/db/pgDb'`, and
+// Vitest throws `No "<name>" export is defined on the ... mock` for any omitted
+// binding — a module-load error that fails the whole FILE (0 tests collected), not
+// a single assertion. Only `pgDbWrite.query` is actually exercised here; the other
+// two are inert placeholders that just satisfy the destructure.
 vi.mock('~/server/db/pgDb', () => ({
   pgDbWrite: { query: mockQuery },
+  pgDbRead: {},
+  pgDbReadLong: {},
 }));
 
 vi.mock('~/server/redis/caches', () => ({

--- a/src/server/services/__tests__/get-models-raw.transient-503.test.ts
+++ b/src/server/services/__tests__/get-models-raw.transient-503.test.ts
@@ -69,7 +69,16 @@ vi.mock('~/server/services/blocked-browsing-tags.service', () => ({
 // linux-nixos query engine) — a false-positive vector Vitest flags. Stubbing
 // them keeps the run clean without touching the code under test.
 vi.mock('~/server/db/client', () => ({ dbRead: {}, dbWrite: {} }));
-vi.mock('~/server/db/pgDb', () => ({ pgDbRead: {}, pgDbWrite: {} }));
+// NOTE: this factory must export EVERY binding `~/server/db/pgDb` really
+// exports that a transitively-imported module destructures at load time.
+// `~/server/db/kyselyDb` (reached via model.service -> db-lag-helpers) does
+// `import { pgDbRead, pgDbReadLong, pgDbWrite } from '~/server/db/pgDb'`, and
+// Vitest throws `No "<name>" export is defined on the ... mock` for any binding
+// the factory omits — which surfaces as EVERY test in this file failing with an
+// error that has nothing to do with the Meili catch under test. `pgDbReadLong`
+// was added to kyselyDb.ts on 2026-07-15 (b96b7c7772) and silently broke this
+// suite. Keep this list in sync with pgDb.ts's exports.
+vi.mock('~/server/db/pgDb', () => ({ pgDbRead: {}, pgDbReadLong: {}, pgDbWrite: {} }));
 // Keep the REAL REDIS_KEYS (the ~/server/redis/caches module reads nested keys
 // like REDIS_KEYS.*.RESOURCE_DATA at module load), but stub the redis/sysRedis
 // CLIENTS so no real connection opens. importOriginal here does not connect


### PR DESCRIPTION
## What

Two unit suites are red on `main` and reproduce on every open PR (#3588, #3591, #3593 — all unrelated). They are the **only** two failures: the last `Unit tests` run was **2 failed / 775 passed (777)**. This fixes both.

Neither is a source regression. Both fail for the same reason: their `vi.mock('~/server/db/pgDb', …)` factory omits bindings that a transitively-imported module destructures at load time.

`src/server/db/kyselyDb.ts` does:

```ts
import { pgDbRead, pgDbReadLong, pgDbWrite } from '~/server/db/pgDb';
```

Vitest throws ``No "<name>" export is defined on the "~/server/db/pgDb" mock`` for any binding the factory leaves out.

| File | Missing binding | Symptom |
|---|---|---|
| `get-models-raw.transient-503.test.ts` | `pgDbReadLong` | module-load error became the rejection value every assertion inspected → **all 9 tests fail** against intact production code |
| `adjust-tag-level.test.ts` | `pgDbRead` | file-level failure, **0 tests collected** |

## Why it broke

- `pgDbReadLong` was added to `kyselyDb.ts` on **2026-07-15** (`b96b7c7772`, the `@civitai/db-queries` Phase-0 port).
- `kyselyDb` became reachable from these suites through `db-lag-helpers` on **2026-07-16** (`14532b073f`).

Neither PR touched the mocks. The suites were last confirmed green on 2026-07-10 (#3054), so they regressed silently — invisible because the job is `continue-on-error`.

## What this is NOT

The transient-Meili **widening** these tests specify (`model.service.ts` → `if (isTransientMeiliError(err))`, from #3049) is **still present and correct on `main`**. It was not reverted and this PR does not touch it. The test names read "fails against the narrow instanceof-only catch", which invites the reading that they were written for an unimplemented fix — they were not. Production code is unchanged here; only the two mock factories are.

## The fix

Additive, confined to the two `vi.mock` factories: declare the missing bindings as inert placeholders. Only `pgDbWrite.query` is actually exercised.

## Verification

Local run with submodules initialised to match CI's `submodules: true`.

**Red → green**

| | Files | Tests |
|---|---|---|
| Base (`main`) | 2 failed | **9 failed** — same errors CI reports |
| With fix | 2 passed | **12 passed** (9 + 3) |

**Coverage proven, not assumed.** The risk with "make the red suite green" is producing a suite that loads cleanly and asserts nothing. Two mutations of the production guard, run against the fixed suite:

| Mutation | Result |
|---|---|
| narrow back to `err instanceof MeiliCallTimeoutError` | exactly the **6 widening tests** fail, each with `expected MeiliSearchCommunicationError … to match object { name: 'TRPCError' }` (raw error rethrown). Timeout case + both negatives stay green. |
| widen to `if (true)` | exactly the **2 `does NOT convert` tests** fail, with `expected TRPCError … to be Error: cannot read properties of undefined` |

The second matters most: those two negatives are what stop an over-broad `catch` masking a genuine app bug (a null deref) as a transient 503 and hiding it from alerting. They are reachable and discriminating.

Production code was restored to its exact original state after both mutations (`git diff` on `model.service.ts` is empty).

## Why this matters

The `Unit tests` job is `continue-on-error: true` (`.github/workflows/lint.yml`), with the comment:

> FLIP TO BLOCKING once a couple of weeks of runs show a clean pass rate. Remove `continue-on-error` and this comment together.

With 9 hard failures on every PR that flip could never happen. This clears both blockers.

## Note (not fixed here)

`adjust-tag-level.test.ts` fails `prettier --check` on `main` **already** — pre-existing, unrelated, and in the report-only modified-file bucket. Deliberately not reformatted, to keep the diff reviewable.

Follow-up worth considering separately: 17 test files wholesale-mock `~/server/db/pgDb`, so adding another export to that module can silently red any of them again. A shared mock factory (or a test asserting factory/module export parity) would close the class.
