### PR TITLE
test: list every pgDb export in the two vi.mock factories (unreds the Unit tests gate)

### DIFF
--- a/src/__tests__/pages/api/mod/adjust-tag-level.test.ts
+++ b/src/__tests__/pages/api/mod/adjust-tag-level.test.ts
@@ -9,7 +9,11 @@ const { mockQuery, mockTagCache, mockTagCacheByName } = vi.hoisted(() => {
   };
 });
 
+// This factory is EXHAUSTIVE: it replaces the module wholesale, so it must list
+// every export ~/server/db/kyselyDb.ts imports. Add to it when pgDb.ts gains one.
 vi.mock('~/server/db/pgDb', () => ({
+  pgDbRead: { query: mockQuery },
+  pgDbReadLong: { query: mockQuery },
   pgDbWrite: { query: mockQuery },
 }));
 

--- a/src/server/services/__tests__/get-models-raw.transient-503.test.ts
+++ b/src/server/services/__tests__/get-models-raw.transient-503.test.ts
@@ -69,7 +69,9 @@ vi.mock('~/server/services/blocked-browsing-tags.service', () => ({
 // linux-nixos query engine) — a false-positive vector Vitest flags. Stubbing
 // them keeps the run clean without touching the code under test.
 vi.mock('~/server/db/client', () => ({ dbRead: {}, dbWrite: {} }));
-vi.mock('~/server/db/pgDb', () => ({ pgDbRead: {}, pgDbWrite: {} }));
+// This factory is EXHAUSTIVE: it replaces the module wholesale, so it must list
+// every export ~/server/db/kyselyDb.ts imports. Add to it when pgDb.ts gains one.
+vi.mock('~/server/db/pgDb', () => ({ pgDbRead: {}, pgDbReadLong: {}, pgDbWrite: {} }));
 // Keep the REAL REDIS_KEYS (the ~/server/redis/caches module reads nested keys
 // like REDIS_KEYS.*.RESOURCE_DATA at module load), but stub the redis/sysRedis
 // CLIENTS so no real connection opens. importOriginal here does not connect


### PR DESCRIPTION
Unreds the repo-wide `Unit tests` gate. Test-only — no production code is touched.

## The bug

`src/server/db/pgDb.ts` exports three pools:

```ts
export let pgDbWrite: AugmentedPool;
export let pgDbRead: AugmentedPool;
export let pgDbReadLong: AugmentedPool;
```

`src/server/db/kyselyDb.ts:5` imports all three:

```ts
import { pgDbRead, pgDbReadLong, pgDbWrite } from '~/server/db/pgDb';
```

Two test files mock `~/server/db/pgDb` with a factory that does not list them all. A `vi.mock` factory **replaces the module wholesale**, so any export it omits does not exist for anything downstream — and Vitest fails the import with `No "<name>" export is defined on the "~/server/db/pgDb" mock`:

| File | Mocked | Missing |
|---|---|---|
| `src/server/services/__tests__/get-models-raw.transient-503.test.ts:72` | `pgDbRead`, `pgDbWrite` | `pgDbReadLong` |
| `src/__tests__/pages/api/mod/adjust-tag-level.test.ts:12` | `pgDbWrite` | `pgDbRead`, `pgDbReadLong` |

The error surfaces as a mismatched assertion rather than an obvious import failure, which is why it reads as a test-logic problem:

```
AssertionError: expected Error: [vitest] No "pgDbReadLong" export … to match object { name: 'TRPCError', … }
```

This is a latent-mock break: the tests were correct when written and `pgDbReadLong` was added to `kyselyDb.ts` later. **10 of 11 open PRs fail the gate identically**, so it is not attributable to any one branch.

## The fix

Add the missing exports to each factory, plus a one-line comment at each site noting the factory is exhaustive and must be updated when `pgDb.ts` gains an export.

## Verification

Red/green in a clean worktree off `main`, in that order — the failure was watched before the fix was applied:

| | Test Files | Tests | Exit |
|---|---|---|---|
| Before (unmodified `main`) | 2 failed | **9 failed** | 1 |
| After | 2 passed | **12 passed** | 0 |

The red run's failures are attributable to this cause specifically, not just "red": every one names the missing export (`[vitest] No "pgDbReadLong" export …`).

**Full unit suite with the fix: `781 files passed, 11,538 tests passed, 1 skipped, exit 0` — zero failures.** For comparison, the same suite on `main` reports 2 files / 9 tests failed. That is the whole gate green.

`pnpm run typecheck` also passes. Local runs need `git submodule update --init event-engine-common`; without it `adjust-tag-level.test.ts` fails on `Cannot find module '../../../event-engine-common/feeds'`, which is a checkout artifact unrelated to this change (CI checks out with `submodules: true`).

## Follow-up, deliberately not done here

These factories stay exhaustive, so the *next* export added to `pgDb.ts` breaks them again — the comments are a speed bump, not a fix. The durable version replaces the object literals with an `importOriginal` spread (or a shared `mockPgDb()` helper) so the mock tracks the real module's surface. That is a wider change touching how these suites stub the DB layer and deserves its own review; tracked separately rather than bundled into a gate unblock.
