### PR TITLE
feat(models): allow unpublishing early access models via refund

### DIFF
--- a/src/pages/models/[id]/[[...slug]].tsx
+++ b/src/pages/models/[id]/[[...slug]].tsx
@@ -517,6 +517,29 @@ export default function ModelDetailsV2({
       showErrorNotification({ error: new Error(error.message) });
     },
   });
+  const handleUnpublishModel = async () => {
+    try {
+      const refund = await queryUtils.model.getEarlyAccessRefundRequirement.fetch({ id });
+      if (refund.purchaseCount > 0) {
+        openConfirmModal({
+          title: 'Refund early access buyers',
+          children: `${
+            refund.buyerCount
+          } member(s) purchased early access to this model. Unpublishing it now will refund them a total of ${refund.totalBuzz.toLocaleString()} Buzz from your account and revoke their early access. Do you want to continue?`,
+          centered: true,
+          labels: { confirm: 'Refund & Unpublish', cancel: 'Cancel' },
+          confirmProps: { color: 'yellow' },
+          onConfirm: () => unpublishModelMutation.mutate({ id, refundEarlyAccess: true }),
+        });
+      } else {
+        unpublishModelMutation.mutate({ id });
+      }
+    } catch (error) {
+      showErrorNotification({
+        error: error instanceof Error ? error : new Error('Could not check early access purchases'),
+      });
+    }
+  };
   const publishModelMutation = trpc.model.publish.useMutation({
     async onSuccess() {
       await queryUtils.model.getById.invalidate({ id });
@@ -1018,7 +1041,7 @@ export default function ModelDetailsV2({
                           <Menu.Item
                             leftSection={<IconBan size={14} stroke={1.5} />}
                             color="yellow"
-                            onClick={() => unpublishModelMutation.mutate({ id })}
+                            onClick={handleUnpublishModel}
                             disabled={unpublishModelMutation.isPending}
                           >
                             Unpublish

--- a/src/server/routers/model.router.ts
+++ b/src/server/routers/model.router.ts
@@ -85,6 +85,7 @@ import {
   getRecentlyBid,
   getRecentlyManuallyAdded,
   getRecentlyRecommended,
+  getModelEarlyAccessRefundRequirement,
   getSimpleModelWithVersions,
   migrateResourceToCollection,
   setAssociatedResources,
@@ -217,6 +218,16 @@ export const modelRouter = router({
     .input(unpublishModelSchema)
     .use(isOwnerOrModerator)
     .mutation(unpublishModelHandler),
+  getEarlyAccessRefundRequirement: protectedProcedure
+    .meta({ requiredScope: TokenScope.ModelsRead })
+    .input(getByIdSchema)
+    .use(isOwnerOrModerator)
+    .query(async ({ input }) => {
+      const { purchases, buyerCount, totalBuzz } = await getModelEarlyAccessRefundRequirement(
+        input
+      );
+      return { purchaseCount: purchases.length, buyerCount, totalBuzz };
+    }),
   // TODO - TEMP HACK for reporting modal
   getModelReportDetails: publicProcedure
     .meta({ requiredScope: TokenScope.ModelsRead })

--- a/src/server/schema/model.schema.ts
+++ b/src/server/schema/model.schema.ts
@@ -252,6 +252,9 @@ export const unpublishModelSchema = z.object({
   id: z.number(),
   reason: z.custom<UnpublishReason>((x) => UnpublishReasons.includes(x as string)).optional(),
   customMessage: z.string().optional(),
+  // Owner's explicit consent to refund all active early access purchases (debited from their
+  // account) as part of unpublishing. Ignored for moderator unpublishes.
+  refundEarlyAccess: z.boolean().optional(),
 });
 
 export type ToggleModelLockInput = z.infer<typeof toggleModelLockSchema>;

--- a/src/server/services/__tests__/model-early-access-refund.service.test.ts
+++ b/src/server/services/__tests__/model-early-access-refund.service.test.ts
@@ -1,0 +1,358 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Unit tests for getModelEarlyAccessRefundRequirement and the refundEarlyAccess gate in
+// unpublishModelById. model.service.ts has a very large import graph, so most of its transitive
+// service/db/search dependencies are stubbed out below to keep this a real unit test rather than
+// an integration test. Mirrors the mock scaffold used in set-model-minor.service.test.ts.
+
+const { mockDbRead, mockDbWrite, mockTx } = vi.hoisted(() => {
+  const mk = () => ({
+    findFirst: vi.fn(),
+    findUnique: vi.fn(),
+    findUniqueOrThrow: vi.fn(),
+    findMany: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    updateMany: vi.fn(),
+    delete: vi.fn(),
+    deleteMany: vi.fn(),
+  });
+  const tx = { model: mk(), $executeRaw: vi.fn() };
+  return {
+    mockTx: tx,
+    mockDbRead: { model: mk(), modelVersion: mk(), $queryRaw: vi.fn() },
+    mockDbWrite: {
+      model: mk(),
+      modelVersion: mk(),
+      paidAccess: mk(),
+      entityAccess: mk(),
+      post: mk(),
+      image: mk(),
+      $queryRaw: vi.fn(),
+      $executeRaw: vi.fn(),
+      $transaction: vi.fn((fn: (tx: typeof tx) => unknown) => fn(tx)),
+    },
+  };
+});
+
+const {
+  mockModelsQueueUpdate,
+  mockQueueImageSearchIndexUpdate,
+  mockLogToAxiom,
+  mockDeleteBidsForModel,
+  mockGetMultiAccountTransactionsByPrefix,
+  mockGetUserBuzzAccountByAccountTypes,
+  mockRefundMultiAccountTransaction,
+} = vi.hoisted(() => ({
+  mockModelsQueueUpdate: vi.fn(),
+  mockQueueImageSearchIndexUpdate: vi.fn(),
+  mockLogToAxiom: vi.fn(),
+  mockDeleteBidsForModel: vi.fn(),
+  mockGetMultiAccountTransactionsByPrefix: vi.fn(),
+  mockGetUserBuzzAccountByAccountTypes: vi.fn(),
+  mockRefundMultiAccountTransaction: vi.fn(),
+}));
+
+vi.mock('~/server/db/client', () => ({ dbRead: mockDbRead, dbWrite: mockDbWrite }));
+vi.mock('~/server/db/db-lag-helpers', () => ({
+  preventReplicationLag: vi.fn(),
+  getDbWithoutLag: vi.fn(async () => mockDbRead),
+  preventModelVersionLagBatch: vi.fn(),
+}));
+vi.mock('~/server/db/pgDb', () => ({ pgDbRead: {}, pgDbWrite: {}, pgDbReadLong: {} }));
+vi.mock('~/server/clickhouse/client', () => ({ clickhouse: null, Tracker: class {} }));
+vi.mock('~/server/flipt/client', () => ({ isFlipt: vi.fn(() => false), FLIPT_FEATURE_FLAGS: {} }));
+vi.mock('~/server/metrics', () => ({ modelMetrics: {} }));
+vi.mock('~/server/redis/caches', () => ({
+  dataForModelsCache: {},
+  modelTagCache: { refresh: vi.fn() },
+  modelVotableTagsCache: { bust: vi.fn() },
+  userBasicCache: {},
+  userModelCountCache: { refresh: vi.fn() },
+}));
+vi.mock('~/server/redis/client', () => ({
+  redis: { del: vi.fn() },
+  REDIS_KEYS: { MODEL: { GALLERY_SETTINGS: 'model:gallery-settings' } },
+}));
+vi.mock('~/server/search-index', () => ({
+  collectionsSearchIndex: { queueUpdate: vi.fn() },
+  imagesMetricsSearchIndex: { queueUpdate: vi.fn() },
+  imagesSearchIndex: { queueUpdate: vi.fn() },
+  modelsSearchIndex: { queueUpdate: mockModelsQueueUpdate },
+}));
+vi.mock('~/server/services/auction.service', () => ({
+  deleteBidsForModel: mockDeleteBidsForModel,
+  getLastAuctionReset: vi.fn(),
+}));
+vi.mock('~/server/services/buzz.service', () => ({
+  getMultiAccountTransactionsByPrefix: mockGetMultiAccountTransactionsByPrefix,
+  getUserBuzzAccountByAccountTypes: mockGetUserBuzzAccountByAccountTypes,
+  refundMultiAccountTransaction: mockRefundMultiAccountTransaction,
+}));
+vi.mock('~/server/services/blocked-browsing-tags.service', () => ({
+  enforceBlockedBrowsingTagsForModels: vi.fn(),
+}));
+vi.mock('~/server/services/blocklist.service', () => ({ throwOnBlockedLinkDomain: vi.fn() }));
+vi.mock('~/server/services/collection.service', () => ({
+  getAvailableCollectionItemsFilterForUser: vi.fn(),
+  getUserCollectionPermissionsById: vi.fn(),
+  saveItemInCollections: vi.fn(),
+}));
+vi.mock('~/server/services/cosmetic.service', () => ({ getCosmeticsForEntity: vi.fn() }));
+vi.mock('~/server/services/creator-program.service', () => ({
+  getValidCreatorMembershipMap: vi.fn(),
+}));
+vi.mock('~/server/services/generation/generation.service', () => ({
+  getUnavailableResources: vi.fn(),
+}));
+vi.mock('~/server/services/image.service', () => ({
+  getImagesForModelVersion: vi.fn(),
+  getImagesForModelVersionCache: {},
+  queueImageSearchIndexUpdate: mockQueueImageSearchIndexUpdate,
+}));
+vi.mock('~/server/services/model-file.service', () => ({ getFilesForModelVersionCache: {} }));
+vi.mock('~/server/services/model-version.service', () => ({
+  bustMvCache: vi.fn(),
+  bustPublicModelResponseCache: vi.fn(),
+  createModelVersionPostFromTraining: vi.fn(),
+  publishModelVersionsWithEarlyAccess: vi.fn(),
+}));
+vi.mock('~/server/services/moderator.service', () => ({ trackModActivity: vi.fn() }));
+vi.mock('~/server/logging/client', () => ({ logToAxiom: mockLogToAxiom }));
+vi.mock('~/server/services/subscriptions.service', () => ({ getHighestTierSubscription: vi.fn() }));
+vi.mock('~/server/services/system-cache', () => ({ getCategoryTags: vi.fn() }));
+vi.mock('~/server/services/user.service', () => ({
+  deleteBasicDataForUser: vi.fn(),
+  getCosmeticsForUsers: vi.fn(),
+  getProfilePicturesForUsers: vi.fn(),
+}));
+vi.mock('~/server/utils/cache-helpers', () => ({
+  bustFetchThroughCache: vi.fn(),
+  fetchThroughCache: vi.fn(),
+}));
+vi.mock('~/utils/s3-utils', () => ({ deleteModelFileObjects: vi.fn() }));
+vi.mock('~/utils/storage-resolver', () => ({ deregisterFileLocationsBatch: vi.fn() }));
+
+import {
+  getModelEarlyAccessRefundRequirement,
+  unpublishModelById,
+} from '~/server/services/model.service';
+
+const MODEL_ID = 42;
+const OWNER_ID = 7;
+const VERSION_ID = 100;
+const OTHER_VERSION_ID = 101;
+const BUYER_ID = 555;
+const OTHER_BUYER_ID = 556;
+
+const HOUR = 60 * 60 * 1000;
+const future = () => new Date(Date.now() + HOUR);
+const past = () => new Date(Date.now() - HOUR);
+
+type VersionRow = { id: number; meta: Record<string, unknown> | null };
+type GateRow = { entityId: number; endsAt: Date | null };
+type AccessRow = { accessToId: number; accessorId: number; meta: Record<string, unknown> | null };
+
+function setupRefundData({
+  versions = [{ id: VERSION_ID, meta: { hadEarlyAccessPurchase: true } }] as VersionRow[],
+  gates = [{ entityId: VERSION_ID, endsAt: null }] as GateRow[],
+  accessRows = [
+    {
+      accessToId: VERSION_ID,
+      accessorId: BUYER_ID,
+      meta: { 'download-buzzTransactionId': 'tx-1' },
+    },
+  ] as AccessRow[],
+  amounts = { 'tx-1': 300 } as Record<string, number>,
+} = {}) {
+  mockDbWrite.modelVersion.findMany.mockResolvedValue(versions);
+  mockDbWrite.paidAccess.findMany.mockResolvedValue(gates);
+  mockDbWrite.entityAccess.findMany.mockResolvedValue(accessRows);
+  mockGetMultiAccountTransactionsByPrefix.mockImplementation(async (prefix: string) => [
+    { amount: amounts[prefix] ?? 0 },
+  ]);
+}
+
+function setupUnpublishWrites() {
+  mockTx.model.update.mockResolvedValue({
+    userId: OWNER_ID,
+    modelVersions: [{ id: VERSION_ID }],
+  });
+  mockDbWrite.model.findUniqueOrThrow.mockResolvedValue({ name: 'Test Model', userId: OWNER_ID });
+  mockDbWrite.post.findMany.mockResolvedValue([]);
+  mockDbWrite.image.findMany.mockResolvedValue([]);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockDbWrite.$transaction.mockImplementation((fn: (tx: typeof mockTx) => unknown) => fn(mockTx));
+});
+
+describe('getModelEarlyAccessRefundRequirement', () => {
+  it('returns nothing and skips the gate lookup when no version was ever purchased', async () => {
+    mockDbWrite.modelVersion.findMany.mockResolvedValue([
+      { id: VERSION_ID, meta: null },
+      { id: OTHER_VERSION_ID, meta: { hadEarlyAccessPurchase: false } },
+    ]);
+
+    const result = await getModelEarlyAccessRefundRequirement({ id: MODEL_ID });
+
+    expect(result).toEqual({ purchases: [], buyerCount: 0, totalBuzz: 0 });
+    expect(mockDbWrite.paidAccess.findMany).not.toHaveBeenCalled();
+  });
+
+  it('ignores versions whose early access window has already lapsed', async () => {
+    setupRefundData({ gates: [{ entityId: VERSION_ID, endsAt: past() }] });
+
+    const result = await getModelEarlyAccessRefundRequirement({ id: MODEL_ID });
+
+    expect(result).toEqual({ purchases: [], buyerCount: 0, totalBuzz: 0 });
+    expect(mockDbWrite.entityAccess.findMany).not.toHaveBeenCalled();
+  });
+
+  it('only looks at grants on versions whose gate is still active', async () => {
+    setupRefundData({
+      versions: [
+        { id: VERSION_ID, meta: { hadEarlyAccessPurchase: true } },
+        { id: OTHER_VERSION_ID, meta: { hadEarlyAccessPurchase: true } },
+      ],
+      gates: [
+        { entityId: VERSION_ID, endsAt: future() },
+        { entityId: OTHER_VERSION_ID, endsAt: past() },
+      ],
+    });
+
+    const result = await getModelEarlyAccessRefundRequirement({ id: MODEL_ID });
+
+    expect(mockDbWrite.entityAccess.findMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({ accessToId: { in: [VERSION_ID] } }),
+      })
+    );
+    expect(result.purchases).toEqual([
+      { modelVersionId: VERSION_ID, buyerId: BUYER_ID, buzzTransactionIds: ['tx-1'] },
+    ]);
+  });
+
+  it('skips grants with no purchase transaction and sums both download and generation purchases', async () => {
+    setupRefundData({
+      versions: [
+        { id: VERSION_ID, meta: { hadEarlyAccessPurchase: true } },
+        { id: OTHER_VERSION_ID, meta: { hadEarlyAccessPurchase: true } },
+      ],
+      gates: [
+        { entityId: VERSION_ID, endsAt: null },
+        { entityId: OTHER_VERSION_ID, endsAt: future() },
+      ],
+      accessRows: [
+        // Owner-granted access: nothing was paid, so nothing to refund.
+        { accessToId: VERSION_ID, accessorId: 999, meta: null },
+        {
+          accessToId: VERSION_ID,
+          accessorId: BUYER_ID,
+          meta: {
+            'download-buzzTransactionId': 'tx-1',
+            'generation-buzzTransactionId': 'tx-2',
+          },
+        },
+        // Same buyer on a second version — one buyer, two purchases.
+        {
+          accessToId: OTHER_VERSION_ID,
+          accessorId: BUYER_ID,
+          meta: { 'download-buzzTransactionId': 'tx-3' },
+        },
+        {
+          accessToId: OTHER_VERSION_ID,
+          accessorId: OTHER_BUYER_ID,
+          meta: { 'download-buzzTransactionId': 'tx-4' },
+        },
+      ],
+      amounts: { 'tx-1': 100, 'tx-2': 200, 'tx-3': 50, 'tx-4': 25 },
+    });
+
+    const result = await getModelEarlyAccessRefundRequirement({ id: MODEL_ID });
+
+    expect(result.purchases).toEqual([
+      { modelVersionId: VERSION_ID, buyerId: BUYER_ID, buzzTransactionIds: ['tx-1', 'tx-2'] },
+      { modelVersionId: OTHER_VERSION_ID, buyerId: BUYER_ID, buzzTransactionIds: ['tx-3'] },
+      { modelVersionId: OTHER_VERSION_ID, buyerId: OTHER_BUYER_ID, buzzTransactionIds: ['tx-4'] },
+    ]);
+    expect(result.buyerCount).toBe(2);
+    expect(result.totalBuzz).toBe(375);
+  });
+});
+
+describe('unpublishModelById — early access refund gate', () => {
+  it('refuses the unpublish when the owner has not consented to refunding', async () => {
+    setupRefundData();
+    setupUnpublishWrites();
+
+    await expect(unpublishModelById({ id: MODEL_ID, userId: OWNER_ID })).rejects.toThrowError(
+      /1 member\(s\) must be refunded a total of 300 Buzz/
+    );
+    expect(mockRefundMultiAccountTransaction).not.toHaveBeenCalled();
+    expect(mockDbWrite.$transaction).not.toHaveBeenCalled();
+  });
+
+  it('refunds every purchase, revokes the grants, then unpublishes when the owner consents', async () => {
+    setupRefundData({
+      accessRows: [
+        {
+          accessToId: VERSION_ID,
+          accessorId: BUYER_ID,
+          meta: {
+            'download-buzzTransactionId': 'tx-1',
+            'generation-buzzTransactionId': 'tx-2',
+          },
+        },
+      ],
+      amounts: { 'tx-1': 300, 'tx-2': 200 },
+    });
+    setupUnpublishWrites();
+    mockGetUserBuzzAccountByAccountTypes.mockResolvedValue({ yellow: 1000 });
+
+    await unpublishModelById({ id: MODEL_ID, userId: OWNER_ID, refundEarlyAccess: true });
+
+    expect(mockRefundMultiAccountTransaction).toHaveBeenCalledTimes(2);
+    expect(mockRefundMultiAccountTransaction).toHaveBeenCalledWith(
+      expect.objectContaining({ externalTransactionIdPrefix: 'tx-1' })
+    );
+    expect(mockRefundMultiAccountTransaction).toHaveBeenCalledWith(
+      expect.objectContaining({ externalTransactionIdPrefix: 'tx-2' })
+    );
+    // deleteMany, not delete: an already-revoked grant must not abort a retry after the money moved.
+    expect(mockDbWrite.entityAccess.deleteMany).toHaveBeenCalledWith({
+      where: {
+        accessToId: VERSION_ID,
+        accessToType: 'ModelVersion',
+        accessorId: BUYER_ID,
+        accessorType: 'User',
+      },
+    });
+    expect(mockDbWrite.entityAccess.delete).not.toHaveBeenCalled();
+    expect(mockTx.model.update).toHaveBeenCalled();
+  });
+
+  it('refuses to refund from an owner account that cannot cover the total', async () => {
+    setupRefundData();
+    setupUnpublishWrites();
+    mockGetUserBuzzAccountByAccountTypes.mockResolvedValue({ yellow: 10 });
+
+    await expect(
+      unpublishModelById({ id: MODEL_ID, userId: OWNER_ID, refundEarlyAccess: true })
+    ).rejects.toThrowError(/requires 300 Buzz but the account only has 10/);
+    expect(mockRefundMultiAccountTransaction).not.toHaveBeenCalled();
+    expect(mockDbWrite.$transaction).not.toHaveBeenCalled();
+  });
+
+  it('does not gate or refund on a moderator unpublish', async () => {
+    setupRefundData();
+    setupUnpublishWrites();
+
+    await unpublishModelById({ id: MODEL_ID, userId: 1, isModerator: true });
+
+    expect(mockDbWrite.paidAccess.findMany).not.toHaveBeenCalled();
+    expect(mockRefundMultiAccountTransaction).not.toHaveBeenCalled();
+    expect(mockTx.model.update).toHaveBeenCalled();
+  });
+});

--- a/src/server/services/__tests__/model-flag-side-effects.service.test.ts
+++ b/src/server/services/__tests__/model-flag-side-effects.service.test.ts
@@ -74,6 +74,11 @@ vi.mock('~/server/services/auction.service', () => ({
   deleteBidsForModel: vi.fn(),
   getLastAuctionReset: vi.fn(),
 }));
+vi.mock('~/server/services/buzz.service', () => ({
+  getMultiAccountTransactionsByPrefix: vi.fn(),
+  getUserBuzzAccountByAccountTypes: vi.fn(),
+  refundMultiAccountTransaction: vi.fn(),
+}));
 vi.mock('~/server/services/blocked-browsing-tags.service', () => ({
   enforceBlockedBrowsingTagsForModels: vi.fn(),
 }));

--- a/src/server/services/__tests__/model-locked-properties.service.test.ts
+++ b/src/server/services/__tests__/model-locked-properties.service.test.ts
@@ -67,6 +67,11 @@ vi.mock('~/server/services/auction.service', () => ({
   deleteBidsForModel: vi.fn(),
   getLastAuctionReset: vi.fn(),
 }));
+vi.mock('~/server/services/buzz.service', () => ({
+  getMultiAccountTransactionsByPrefix: vi.fn(),
+  getUserBuzzAccountByAccountTypes: vi.fn(),
+  refundMultiAccountTransaction: vi.fn(),
+}));
 vi.mock('~/server/services/blocked-browsing-tags.service', () => ({
   enforceBlockedBrowsingTagsForModels: vi.fn(),
 }));

--- a/src/server/services/__tests__/set-model-minor.service.test.ts
+++ b/src/server/services/__tests__/set-model-minor.service.test.ts
@@ -77,6 +77,11 @@ vi.mock('~/server/services/auction.service', () => ({
   deleteBidsForModel: vi.fn(),
   getLastAuctionReset: vi.fn(),
 }));
+vi.mock('~/server/services/buzz.service', () => ({
+  getMultiAccountTransactionsByPrefix: vi.fn(),
+  getUserBuzzAccountByAccountTypes: vi.fn(),
+  refundMultiAccountTransaction: vi.fn(),
+}));
 vi.mock('~/server/services/blocked-browsing-tags.service', () => ({
   enforceBlockedBrowsingTagsForModels: vi.fn(),
 }));

--- a/src/server/services/model.service.ts
+++ b/src/server/services/model.service.ts
@@ -2,6 +2,7 @@ import { Prisma } from '@prisma/client';
 import { TRPCError } from '@trpc/server';
 import type { ManipulateType } from 'dayjs';
 import { isEmpty, uniq } from 'lodash-es';
+import pLimit from 'p-limit';
 import dayjs from '~/shared/utils/dayjs';
 import type { SearchParams, SearchResponse } from 'meilisearch';
 import type { SessionUser } from '~/types/session';
@@ -109,6 +110,11 @@ import {
   createModelVersionPostFromTraining,
   publishModelVersionsWithEarlyAccess,
 } from '~/server/services/model-version.service';
+import {
+  getMultiAccountTransactionsByPrefix,
+  getUserBuzzAccountByAccountTypes,
+  refundMultiAccountTransaction,
+} from '~/server/services/buzz.service';
 import { trackModActivity } from '~/server/services/moderator.service';
 import { getHighestTierSubscription } from '~/server/services/subscriptions.service';
 import { getCategoryTags } from '~/server/services/system-cache';
@@ -136,6 +142,7 @@ import {
   throwAuthorizationError,
   throwBadRequestError,
   throwDbError,
+  throwInsufficientFundsError,
   throwNotFoundError,
 } from '~/server/utils/errorHandling';
 import { enforceLockedProperties } from '~/server/utils/locked-properties';
@@ -2676,10 +2683,154 @@ export const publishModelById = async ({
   return model;
 };
 
+export type ModelEarlyAccessRefundRequirement = {
+  purchases: {
+    modelVersionId: number;
+    buyerId: number;
+    buzzTransactionIds: string[];
+  }[];
+  buyerCount: number;
+  totalBuzz: number;
+};
+
+// Early access is sold per model VERSION, so the refund set is computed version-by-version and each
+// purchase keeps its modelVersionId; this only aggregates because unpublishing acts on the whole
+// model (the owner has no per-version unpublish — that menu item is moderator-only).
+//
+// Refundable = a buzz-purchased EntityAccess grant on a version whose PaidAccess gate is still
+// active (permanent, or a timed window that hasn't lapsed). Lapsed-window buyers already got what
+// they paid for, so they don't block. Gate/grant rows are read fresh from the primary (dbWrite),
+// not the cache/replica — this guard protects buyers' money.
+export const getModelEarlyAccessRefundRequirement = async ({
+  id,
+}: GetByIdInput): Promise<ModelEarlyAccessRefundRequirement> => {
+  const empty: ModelEarlyAccessRefundRequirement = { purchases: [], buyerCount: 0, totalBuzz: 0 };
+  const versions = await dbWrite.modelVersion.findMany({
+    where: { modelId: id },
+    select: { id: true, meta: true },
+  });
+  const flagged = versions.filter(
+    (v) => (v.meta as ModelVersionMeta | null)?.hadEarlyAccessPurchase
+  );
+  if (flagged.length === 0) return empty;
+
+  const gates = await dbWrite.paidAccess.findMany({
+    where: { entityType: 'ModelVersion', entityId: { in: flagged.map((v) => v.id) } },
+    select: { entityId: true, endsAt: true },
+  });
+  const now = new Date();
+  const activeGateVersionIds = gates
+    .filter((gate) => isPaidAccessActive(gate, now))
+    .map((gate) => gate.entityId);
+  if (activeGateVersionIds.length === 0) return empty;
+
+  const accessRows = await dbWrite.entityAccess.findMany({
+    where: {
+      accessToType: 'ModelVersion',
+      accessToId: { in: activeGateVersionIds },
+      accessorType: 'User',
+    },
+    select: { accessToId: true, accessorId: true, meta: true },
+  });
+
+  // Only rows carrying a purchase transaction id count — owner-granted access has nothing to refund.
+  const purchases = accessRows
+    .map((row) => {
+      const rowMeta = (row.meta ?? {}) as Record<string, unknown>;
+      const buzzTransactionIds = ['download-buzzTransactionId', 'generation-buzzTransactionId']
+        .map((key) => rowMeta[key])
+        .filter((value): value is string => typeof value === 'string' && value.length > 0);
+      return { modelVersionId: row.accessToId, buyerId: row.accessorId, buzzTransactionIds };
+    })
+    .filter((purchase) => purchase.buzzTransactionIds.length > 0);
+  if (purchases.length === 0) return empty;
+
+  // Refund amounts come from the ledger, not current terms — prices can change after purchase.
+  const limit = pLimit(5);
+  const amounts = await Promise.all(
+    purchases
+      .flatMap((purchase) => purchase.buzzTransactionIds)
+      .map((prefix) =>
+        limit(async () => {
+          const transactions = await getMultiAccountTransactionsByPrefix(prefix);
+          return transactions.reduce((sum, transaction) => sum + transaction.amount, 0);
+        })
+      )
+  );
+
+  return {
+    purchases,
+    buyerCount: new Set(purchases.map((purchase) => purchase.buyerId)).size,
+    totalBuzz: amounts.reduce((sum, amount) => sum + amount, 0),
+  };
+};
+
+const refundModelEarlyAccessPurchases = async ({
+  modelId,
+  requirement,
+}: {
+  modelId: number;
+  requirement: ModelEarlyAccessRefundRequirement;
+}) => {
+  const model = await dbWrite.model.findUniqueOrThrow({
+    where: { id: modelId },
+    select: { name: true, userId: true },
+  });
+
+  // Refunds debit the owner's yellow account — the account the purchases paid into.
+  const balances = await getUserBuzzAccountByAccountTypes(model.userId, ['yellow']);
+  const balance = balances.yellow ?? 0;
+  if (balance < requirement.totalBuzz) {
+    throw throwInsufficientFundsError(
+      `Refunding early access buyers requires ${requirement.totalBuzz} Buzz but the account only has ${balance}.`
+    );
+  }
+
+  let refundedCount = 0;
+  for (const purchase of requirement.purchases) {
+    try {
+      for (const prefix of purchase.buzzTransactionIds) {
+        await refundMultiAccountTransaction({
+          externalTransactionIdPrefix: prefix,
+          description: `Refund early access purchase: ${model.name} (model unpublished)`,
+        });
+      }
+      // Revoke the now-refunded grant so a retry after a mid-loop failure skips this buyer
+      // instead of refunding them twice.
+      await dbWrite.entityAccess.delete({
+        where: {
+          accessToId_accessToType_accessorId_accessorType: {
+            accessToId: purchase.modelVersionId,
+            accessToType: 'ModelVersion',
+            accessorId: purchase.buyerId,
+            accessorType: 'User',
+          },
+        },
+      });
+      refundedCount++;
+    } catch (error) {
+      logToAxiom({
+        type: 'error',
+        name: 'model-unpublish-early-access-refund',
+        message: `Failed to refund early access purchases for model ${modelId}`,
+        error,
+        modelId,
+        modelVersionId: purchase.modelVersionId,
+        buyerId: purchase.buyerId,
+        refundedCount,
+      });
+      throw throwBadRequestError(
+        `Failed to refund early access buyers (${refundedCount} of ${requirement.purchases.length} refunded). The model was not unpublished — please try again.`
+      );
+    }
+  }
+};
+
 export const unpublishModelById = async ({
   id,
   reason,
   customMessage,
+  refundEarlyAccess,
   meta,
   userId,
   isModerator,
@@ -2689,22 +2840,14 @@ export const unpublishModelById = async ({
   isModerator?: boolean;
 }) => {
   if (!isModerator) {
-    const versions = await dbRead.modelVersion.findMany({
-      where: { modelId: id },
-      select: { id: true, meta: true },
-    });
-
-    if (
-      versions.some((v) => {
-        const meta = v.meta as ModelVersionMeta | null;
-        if (meta?.hadEarlyAccessPurchase) {
-          return true;
-        }
-      })
-    ) {
-      throw throwBadRequestError(
-        'Cannot unpublish a model with early access purchases. You may still unpublish individual versions.'
-      );
+    const requirement = await getModelEarlyAccessRefundRequirement({ id });
+    if (requirement.purchases.length > 0) {
+      if (!refundEarlyAccess) {
+        throw throwBadRequestError(
+          `Cannot unpublish a model with active early access purchases without refunding buyers. ${requirement.buyerCount} member(s) must be refunded a total of ${requirement.totalBuzz} Buzz.`
+        );
+      }
+      await refundModelEarlyAccessPurchases({ modelId: id, requirement });
     }
   }
 

--- a/src/server/services/model.service.ts
+++ b/src/server/services/model.service.ts
@@ -2796,15 +2796,14 @@ const refundModelEarlyAccessPurchases = async ({
         });
       }
       // Revoke the now-refunded grant so a retry after a mid-loop failure skips this buyer
-      // instead of refunding them twice.
-      await dbWrite.entityAccess.delete({
+      // instead of refunding them twice. deleteMany, not delete: the money already moved, so an
+      // already-gone row must not abort the loop.
+      await dbWrite.entityAccess.deleteMany({
         where: {
-          accessToId_accessToType_accessorId_accessorType: {
-            accessToId: purchase.modelVersionId,
-            accessToType: 'ModelVersion',
-            accessorId: purchase.buyerId,
-            accessorType: 'User',
-          },
+          accessToId: purchase.modelVersionId,
+          accessToType: 'ModelVersion',
+          accessorId: purchase.buyerId,
+          accessorType: 'User',
         },
       });
       refundedCount++;


### PR DESCRIPTION
Owners were hard-blocked from unpublishing any model with early access purchases; now `unpublishModelById` computes the still-active purchases, and with the owner's explicit `refundEarlyAccess` consent refunds each buyer from the owner's yellow account and revokes their grant before unpublishing. Adds a `getEarlyAccessRefundRequirement` query so the model page can show buyer count and total Buzz in a confirm modal, and keeps the hard error for owners who haven't consented.