### PR TITLE
feat(membership-gift): email both parties when a gift is fulfilled

### DIFF
--- a/src/server/email/templates/index.ts
+++ b/src/server/email/templates/index.ts
@@ -10,4 +10,6 @@ export { moderationActionEmail } from './moderation/moderationAction.email';
 export { tipaltiTaxFormRequiredEmail } from './tipaltiTaxFormRequired.email';
 export { merchClaimInviteEmail } from './merchClaimInvite.email';
 export { merchBuzzCreditedEmail } from './merchBuzzCredited.email';
+export { membershipGiftReceivedEmail } from './membershipGiftReceived.email';
+export { membershipGiftSentEmail } from './membershipGiftSent.email';
 export type { Email } from './base.email';

--- a/src/server/email/templates/membershipGiftReceived.email.ts
+++ b/src/server/email/templates/membershipGiftReceived.email.ts
@@ -1,0 +1,62 @@
+import { escape as escapeHtml } from 'he';
+import { createEmail } from '~/server/email/templates/base.email';
+import { simpleEmailWithTemplate } from '~/server/email/templates/util';
+import { titleCase } from '~/utils/string-helpers';
+import { getBaseUrl } from '~/server/utils/url-helpers';
+
+type MembershipGiftReceivedData = {
+  to: string;
+  username: string;
+  tier: string;
+  months: number;
+  /** Gifter's username, or null when the gift was sent anonymously */
+  from: string | null;
+  message?: string | null;
+};
+
+const describeGift = ({ tier, months }: Pick<MembershipGiftReceivedData, 'tier' | 'months'>) =>
+  `${months} month${months === 1 ? '' : 's'} of ${titleCase(tier)} membership`;
+
+const describeGifter = (from: string | null) => (from ? `@${from}` : 'Someone');
+
+export const membershipGiftReceivedEmail = createEmail({
+  header: ({ to, from, tier, months }: MembershipGiftReceivedData) => ({
+    subject: `${describeGifter(from)} gifted you ${describeGift({ tier, months })}! 🎁`,
+    to,
+  }),
+  html({ username, tier, months, from, message }: MembershipGiftReceivedData) {
+    const note = message ? `<p><strong>They said:</strong><br/>${escapeHtml(message)}</p>` : '';
+
+    return simpleEmailWithTemplate({
+      header: `Hi ${escapeHtml(username)}, you've received a gift! 🎁`,
+      body: `
+        <p>
+          <strong>${escapeHtml(describeGifter(from))}</strong> gifted you
+          <strong>${describeGift({ tier, months })}</strong> on Civitai.
+        </p>
+        ${note}
+        <p>
+          It's already active on your account — nothing to do but enjoy it. When the gifted months
+          run out your membership simply ends; you won't be charged unless you choose to keep it.
+        </p>
+      `,
+      btnLabel: 'View My Membership',
+      btnUrl: `${getBaseUrl()}/user/membership`,
+    });
+  },
+  text({ username, tier, months, from, message }: MembershipGiftReceivedData) {
+    const note = message ? ` They said: "${message}"` : '';
+    return `Hi ${username}, ${describeGifter(from)} gifted you ${describeGift({
+      tier,
+      months,
+    })} on Civitai!${note} It's already active on your account. View it at ${getBaseUrl()}/user/membership`;
+  },
+  testData: async () => ({
+    to: 'test@tester.com',
+    username: 'Testerson',
+    tier: 'gold',
+    months: 3,
+    from: 'GenerousGifter',
+    message: 'Happy birthday! Go make something cool.',
+  }),
+});

--- a/src/server/email/templates/membershipGiftSent.email.ts
+++ b/src/server/email/templates/membershipGiftSent.email.ts
@@ -1,0 +1,71 @@
+import { escape as escapeHtml } from 'he';
+import { createEmail } from '~/server/email/templates/base.email';
+import { simpleEmailWithTemplate } from '~/server/email/templates/util';
+import { getBaseUrl } from '~/server/utils/url-helpers';
+import { titleCase } from '~/utils/string-helpers';
+
+type MembershipGiftSentData = {
+  to: string;
+  username: string;
+  tier: string;
+  months: number;
+  recipient: string | null;
+  anonymous?: boolean;
+};
+
+const describeGift = ({ tier, months }: Pick<MembershipGiftSentData, 'tier' | 'months'>) =>
+  `${months} month${months === 1 ? '' : 's'} of ${titleCase(tier)} membership`;
+
+const describeRecipient = (recipient: string | null) =>
+  recipient ? `@${recipient}` : 'your recipient';
+
+export const membershipGiftSentEmail = createEmail({
+  header: ({ to, recipient, tier, months }: MembershipGiftSentData) => ({
+    subject: `Your gift of ${describeGift({ tier, months })} was delivered to ${describeRecipient(
+      recipient
+    )}`,
+    to,
+  }),
+  html({ username, tier, months, recipient, anonymous }: MembershipGiftSentData) {
+    const anonymousNote = anonymous
+      ? `<p>You sent this anonymously, so ${escapeHtml(
+          describeRecipient(recipient)
+        )} wasn't told who it came from.</p>`
+      : '';
+
+    return simpleEmailWithTemplate({
+      header: `Thanks ${escapeHtml(username)}, your gift has been delivered!`,
+      body: `
+        <p>
+          Your gift of <strong>${describeGift({ tier, months })}</strong> has been delivered to
+          <strong>${escapeHtml(describeRecipient(recipient))}</strong> and is active on their
+          account.
+        </p>
+        ${anonymousNote}
+        <p>
+          If something doesn't look right, contact
+          <a href="mailto:hello@civitai.com">hello@civitai.com</a>.
+        </p>
+      `,
+      btnLabel: 'View My Gifts',
+      btnUrl: `${getBaseUrl()}/user/membership`,
+    });
+  },
+  text({ username, tier, months, recipient, anonymous }: MembershipGiftSentData) {
+    const anonymousNote = anonymous ? ' It was sent anonymously.' : '';
+    return `Thanks ${username}! Your gift of ${describeGift({
+      tier,
+      months,
+    })} has been delivered to ${describeRecipient(
+      recipient
+    )} and is active on their account.${anonymousNote} See your gifts at ${getBaseUrl()}/user/membership`;
+  },
+  testData: async () => ({
+    to: 'test@tester.com',
+    username: 'Testerson',
+    tier: 'gold',
+    months: 3,
+    recipient: 'LuckyRecipient',
+    anonymous: false,
+  }),
+});

--- a/src/server/services/__tests__/membership-gift.service.test.ts
+++ b/src/server/services/__tests__/membership-gift.service.test.ts
@@ -1,60 +1,69 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import dayjs from 'dayjs';
 
-const { mockDbWrite, mockStripe, mockCreateCustomer, mockGetPlans, mockCreateNotification } =
-  vi.hoisted(() => {
-    const mockMembershipGift = {
-      findUnique: vi.fn(),
-      create: vi.fn(),
-      update: vi.fn(),
-      delete: vi.fn(),
-      findMany: vi.fn(),
-    };
-    const mockCustomerSubscription = {
-      findUnique: vi.fn(),
-    };
-    const mockUser = {
-      findUnique: vi.fn(),
-    };
+const {
+  mockDbWrite,
+  mockStripe,
+  mockCreateCustomer,
+  mockGetPlans,
+  mockCreateNotification,
+  mockSendReceivedEmail,
+  mockSendSentEmail,
+} = vi.hoisted(() => {
+  const mockMembershipGift = {
+    findUnique: vi.fn(),
+    create: vi.fn(),
+    update: vi.fn(),
+    delete: vi.fn(),
+    findMany: vi.fn(),
+  };
+  const mockCustomerSubscription = {
+    findUnique: vi.fn(),
+  };
+  const mockUser = {
+    findUnique: vi.fn(),
+  };
 
-    return {
-      mockDbWrite: {
-        membershipGift: mockMembershipGift,
-        customerSubscription: mockCustomerSubscription,
-        user: mockUser,
+  return {
+    mockDbWrite: {
+      membershipGift: mockMembershipGift,
+      customerSubscription: mockCustomerSubscription,
+      user: mockUser,
+    },
+    mockStripe: {
+      subscriptions: {
+        retrieve: vi.fn(),
+        update: vi.fn(),
+        create: vi.fn(),
+        del: vi.fn(),
+        deleteDiscount: vi.fn(),
       },
-      mockStripe: {
-        subscriptions: {
-          retrieve: vi.fn(),
-          update: vi.fn(),
+      coupons: {
+        create: vi.fn(),
+        retrieve: vi.fn(),
+        del: vi.fn(),
+      },
+      checkout: {
+        sessions: {
           create: vi.fn(),
-          del: vi.fn(),
-          deleteDiscount: vi.fn(),
-        },
-        coupons: {
-          create: vi.fn(),
-          retrieve: vi.fn(),
-          del: vi.fn(),
-        },
-        checkout: {
-          sessions: {
-            create: vi.fn(),
-          },
-        },
-        billingPortal: {
-          sessions: {
-            create: vi.fn(),
-          },
-        },
-        paymentMethods: {
-          list: vi.fn(),
         },
       },
-      mockCreateCustomer: vi.fn().mockResolvedValue('cus_recipient'),
-      mockGetPlans: vi.fn(),
-      mockCreateNotification: vi.fn().mockResolvedValue(undefined),
-    };
-  });
+      billingPortal: {
+        sessions: {
+          create: vi.fn(),
+        },
+      },
+      paymentMethods: {
+        list: vi.fn(),
+      },
+    },
+    mockCreateCustomer: vi.fn().mockResolvedValue('cus_recipient'),
+    mockGetPlans: vi.fn(),
+    mockCreateNotification: vi.fn().mockResolvedValue(undefined),
+    mockSendReceivedEmail: vi.fn().mockResolvedValue(undefined),
+    mockSendSentEmail: vi.fn().mockResolvedValue(undefined),
+  };
+});
 
 vi.mock('~/server/db/client', () => ({
   dbWrite: mockDbWrite,
@@ -75,6 +84,14 @@ vi.mock('~/server/services/subscriptions.service', () => ({
 
 vi.mock('~/server/services/notification.service', () => ({
   createNotification: mockCreateNotification,
+}));
+
+vi.mock('~/server/email/templates/membershipGiftReceived.email', () => ({
+  membershipGiftReceivedEmail: { send: mockSendReceivedEmail },
+}));
+
+vi.mock('~/server/email/templates/membershipGiftSent.email', () => ({
+  membershipGiftSentEmail: { send: mockSendSentEmail },
 }));
 
 vi.mock('~/server/utils/subscription.utils', () => ({
@@ -130,7 +147,7 @@ const baseGift = {
   stripePaymentIntentId: 'pi_1',
   stripeCouponId: null,
   stripeSubscriptionId: null,
-  gifter: { id: 1, username: 'gifter' },
+  gifter: { id: 1, username: 'gifter', email: 'g@x.com' },
   recipient: { id: 2, username: 'recipient', email: 'r@x.com' },
 };
 
@@ -315,6 +332,74 @@ describe('fulfillMembershipGift', () => {
     const result = await fulfillMembershipGift({ giftId: 'gift_1' });
     expect(result).toEqual({ alreadyProcessed: true });
     expect(mockStripe.coupons.create).not.toHaveBeenCalled();
+    expect(mockSendReceivedEmail).not.toHaveBeenCalled();
+    expect(mockSendSentEmail).not.toHaveBeenCalled();
+  });
+
+  it('emails both parties on fulfillment', async () => {
+    mockDbWrite.membershipGift.findUnique.mockResolvedValue({
+      ...baseGift,
+      message: 'Enjoy!',
+    });
+    mockDbWrite.customerSubscription.findUnique.mockResolvedValue(activeMonthlySub);
+    mockStripe.subscriptions.retrieve.mockResolvedValue(stripeActiveSub());
+
+    await fulfillMembershipGift({ giftId: 'gift_1' });
+
+    expect(mockSendReceivedEmail).toHaveBeenCalledWith({
+      to: 'r@x.com',
+      username: 'recipient',
+      tier: 'gold',
+      months: 3,
+      from: 'gifter',
+      message: 'Enjoy!',
+    });
+    expect(mockSendSentEmail).toHaveBeenCalledWith({
+      to: 'g@x.com',
+      username: 'gifter',
+      tier: 'gold',
+      months: 3,
+      recipient: 'recipient',
+      anonymous: false,
+    });
+  });
+
+  it('omits the gifter name from the recipient email for anonymous gifts', async () => {
+    mockDbWrite.membershipGift.findUnique.mockResolvedValue({ ...baseGift, anonymous: true });
+    mockDbWrite.customerSubscription.findUnique.mockResolvedValue(activeMonthlySub);
+    mockStripe.subscriptions.retrieve.mockResolvedValue(stripeActiveSub());
+
+    await fulfillMembershipGift({ giftId: 'gift_1' });
+
+    expect(mockSendReceivedEmail).toHaveBeenCalledWith(expect.objectContaining({ from: null }));
+    expect(mockSendSentEmail).toHaveBeenCalledWith(expect.objectContaining({ anonymous: true }));
+  });
+
+  it('still fulfills when an email fails to send', async () => {
+    mockDbWrite.membershipGift.findUnique.mockResolvedValue({ ...baseGift });
+    mockDbWrite.customerSubscription.findUnique.mockResolvedValue(activeMonthlySub);
+    mockStripe.subscriptions.retrieve.mockResolvedValue(stripeActiveSub());
+    mockSendReceivedEmail.mockRejectedValueOnce(new Error('smtp down'));
+
+    const result = await fulfillMembershipGift({ giftId: 'gift_1' });
+
+    expect(result).toMatchObject({ fulfilled: true });
+    expect(mockSendSentEmail).toHaveBeenCalled();
+  });
+
+  it('skips emails for users without an address', async () => {
+    mockDbWrite.membershipGift.findUnique.mockResolvedValue({
+      ...baseGift,
+      gifter: { ...baseGift.gifter, email: null },
+      recipient: { ...baseGift.recipient, email: null },
+    });
+    mockDbWrite.customerSubscription.findUnique.mockResolvedValue(activeMonthlySub);
+    mockStripe.subscriptions.retrieve.mockResolvedValue(stripeActiveSub());
+
+    await fulfillMembershipGift({ giftId: 'gift_1' });
+
+    expect(mockSendReceivedEmail).not.toHaveBeenCalled();
+    expect(mockSendSentEmail).not.toHaveBeenCalled();
   });
 
   it('extends an active monthly subscription with a 100%-off repeating coupon', async () => {

--- a/src/server/services/membership-gift.service.ts
+++ b/src/server/services/membership-gift.service.ts
@@ -2,6 +2,8 @@ import type { Stripe } from 'stripe';
 import dayjs from '~/shared/utils/dayjs';
 import { NotificationCategory } from '~/server/common/enums';
 import { dbWrite } from '~/server/db/client';
+import { membershipGiftReceivedEmail } from '~/server/email/templates/membershipGiftReceived.email';
+import { membershipGiftSentEmail } from '~/server/email/templates/membershipGiftSent.email';
 import { logToAxiom } from '~/server/logging/client';
 import type {
   CreateMembershipGiftCheckoutInput,
@@ -223,7 +225,7 @@ export async function fulfillMembershipGift({
   const gift = await dbWrite.membershipGift.findUnique({
     where: { id: giftId },
     include: {
-      gifter: { select: { id: true, username: true } },
+      gifter: { select: { id: true, username: true, email: true } },
       recipient: { select: { id: true, username: true, email: true } },
     },
   });
@@ -372,6 +374,46 @@ export async function fulfillMembershipGift({
       to: gift.recipient.username,
     },
   });
+
+  // Mail is best-effort: the gift is already applied, and throwing here would make the
+  // Stripe webhook retry a fulfillment that's done.
+  const sendGiftEmail = (label: string, send: () => Promise<void>) =>
+    send().catch((error) =>
+      log({
+        type: 'error',
+        stage: 'fulfillment-email',
+        giftId: gift.id,
+        message: `Failed to send ${label} email: ${String(error)}`,
+      })
+    );
+
+  const recipientEmail = gift.recipient.email;
+  if (recipientEmail) {
+    await sendGiftEmail('membership-gift-received', () =>
+      membershipGiftReceivedEmail.send({
+        to: recipientEmail,
+        username: gift.recipient.username ?? 'there',
+        tier: gift.tier,
+        months: gift.months,
+        from: gift.anonymous ? null : gift.gifter.username,
+        message: gift.message,
+      })
+    );
+  }
+
+  const gifterEmail = gift.gifter.email;
+  if (gifterEmail) {
+    await sendGiftEmail('membership-gift-sent', () =>
+      membershipGiftSentEmail.send({
+        to: gifterEmail,
+        username: gift.gifter.username ?? 'there',
+        tier: gift.tier,
+        months: gift.months,
+        recipient: gift.recipient.username,
+        anonymous: gift.anonymous,
+      })
+    );
+  }
 
   await log({
     type: 'info',


### PR DESCRIPTION
Adds `membershipGiftReceived` and `membershipGiftSent` email templates and sends them at the end of `fulfillMembershipGift`, respecting anonymous gifts and skipping users without an address. Sends are best-effort — a mail failure is logged rather than thrown, so the Stripe webhook doesn't retry an already-applied fulfillment.