### PR TITLE
feat(auction): move recurring bid to the latest model version

### DIFF
--- a/src/components/Auction/AuctionPlacementCard.tsx
+++ b/src/components/Auction/AuctionPlacementCard.tsx
@@ -647,6 +647,11 @@ export const ModelMyRecurringBidCard = memo(function ModelMyRecurringBidCard({
     });
   };
 
+  const moveToLatestLabel =
+    data.moveToLatest?.status === 'available'
+      ? `Move to latest version: ${data.moveToLatest.targetName}`
+      : 'You already have a recurring bid on the latest version';
+
   const handleMoveToLatest = () => {
     if (data.moveToLatest?.status !== 'available') return;
     const { targetName } = data.moveToLatest;
@@ -695,11 +700,7 @@ export const ModelMyRecurringBidCard = memo(function ModelMyRecurringBidCard({
                 {!!data.moveToLatest && (
                   <Tooltip
                     className={!mobile ? 'opacity-0 group-hover:opacity-100' : ''}
-                    label={
-                      data.moveToLatest.status === 'available'
-                        ? `Move to latest version: ${data.moveToLatest.targetName}`
-                        : 'You already have a recurring bid on the latest version'
-                    }
+                    label={moveToLatestLabel}
                   >
                     {/* Wrapper so the tooltip still fires when the icon is disabled */}
                     <div>
@@ -707,6 +708,7 @@ export const ModelMyRecurringBidCard = memo(function ModelMyRecurringBidCard({
                         size="sm"
                         color="blue"
                         variant="filled"
+                        aria-label={moveToLatestLabel}
                         disabled={data.moveToLatest.status !== 'available'}
                         loading={movingRecurringBid}
                         onClick={handleMoveToLatest}

--- a/src/components/Auction/AuctionPlacementCard.tsx
+++ b/src/components/Auction/AuctionPlacementCard.tsx
@@ -14,6 +14,7 @@ import {
 } from '@mantine/core';
 import { openConfirmModal } from '@mantine/modals';
 import {
+  IconArrowUp,
   IconCircle,
   IconCrown,
   IconEye,
@@ -592,6 +593,22 @@ export const ModelMyRecurringBidCard = memo(function ModelMyRecurringBidCard({
       });
     },
   });
+  const { mutate: moveRecurringBid, isPending: movingRecurringBid } =
+    trpc.auction.moveRecurringBidToLatest.useMutation({
+      onSuccess: async (res) => {
+        showSuccessNotification({
+          message: `Recurring bid moved to "${res.name}"!`,
+        });
+
+        await queryUtils.auction.getMyRecurringBids.invalidate();
+      },
+      onError(error) {
+        showErrorNotification({
+          title: 'Failed to move recurring bid',
+          error: new Error(error.message),
+        });
+      },
+    });
   const { mutate: togglePauseRecurringBid } = trpc.auction.togglePauseRecurringBid.useMutation({
     onSuccess: (res) => {
       showSuccessNotification({
@@ -630,6 +647,20 @@ export const ModelMyRecurringBidCard = memo(function ModelMyRecurringBidCard({
     });
   };
 
+  const handleMoveToLatest = () => {
+    if (data.moveToLatest?.status !== 'available') return;
+    const { targetName } = data.moveToLatest;
+    openConfirmModal({
+      title: 'Move bid to latest version',
+      children: `Are you sure you want to move this recurring bid to "${targetName}"? Today's bid is not affected — the new version will be used starting tomorrow.`,
+      centered: true,
+      labels: { confirm: 'Move', cancel: 'No, keep it' },
+      onConfirm: () => {
+        moveRecurringBid({ bidId: data.id });
+      },
+    });
+  };
+
   const handleTogglePause = () => {
     openConfirmModal({
       title: `${data.isPaused ? 'Resume' : 'Pause'} bid`,
@@ -661,6 +692,30 @@ export const ModelMyRecurringBidCard = memo(function ModelMyRecurringBidCard({
             aboveThreshold={false}
             top={
               <Group gap={4} className="absolute right-1 top-1 z-10">
+                {!!data.moveToLatest && (
+                  <Tooltip
+                    className={!mobile ? 'opacity-0 group-hover:opacity-100' : ''}
+                    label={
+                      data.moveToLatest.status === 'available'
+                        ? `Move to latest version: ${data.moveToLatest.targetName}`
+                        : 'You already have a recurring bid on the latest version'
+                    }
+                  >
+                    {/* Wrapper so the tooltip still fires when the icon is disabled */}
+                    <div>
+                      <LegacyActionIcon
+                        size="sm"
+                        color="blue"
+                        variant="filled"
+                        disabled={data.moveToLatest.status !== 'available'}
+                        loading={movingRecurringBid}
+                        onClick={handleMoveToLatest}
+                      >
+                        <IconArrowUp size={16} />
+                      </LegacyActionIcon>
+                    </div>
+                  </Tooltip>
+                )}
                 <Tooltip
                   className={!mobile ? 'opacity-0 group-hover:opacity-100' : ''}
                   label={data.isPaused ? 'Resume' : 'Pause'}

--- a/src/server/routers/auction.router.ts
+++ b/src/server/routers/auction.router.ts
@@ -15,6 +15,7 @@ import {
   getAuctionBySlug,
   getMyBids,
   getMyRecurringBids,
+  moveRecurringBidToLatest,
   togglePauseRecurringBid,
   updateAuctionBase,
 } from '~/server/services/auction.service';
@@ -62,6 +63,10 @@ export const auctionRouter = router({
     .meta({ requiredScope: TokenScope.BountiesWrite })
     .input(deleteBidInput)
     .mutation(({ input, ctx }) => deleteRecurringBid({ ...input, userId: ctx.user.id })),
+  moveRecurringBidToLatest: auctionProcedure
+    .meta({ requiredScope: TokenScope.BountiesWrite })
+    .input(deleteBidInput)
+    .mutation(({ input, ctx }) => moveRecurringBidToLatest({ ...input, userId: ctx.user.id })),
   togglePauseRecurringBid: auctionProcedure
     .meta({ requiredScope: TokenScope.BountiesWrite })
     .input(togglePauseRecurringBidInput)

--- a/src/server/services/__tests__/auction-move-recurring-bid.test.ts
+++ b/src/server/services/__tests__/auction-move-recurring-bid.test.ts
@@ -1,0 +1,254 @@
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+
+// `moveRecurringBidToLatest` re-targets an unfunded standing instruction (BidRecurring)
+// at the newest eligible published version. These pin the eligibility walk — a copy of
+// createBid's inline gates, deliberately not shared — and that the swap never touches
+// today's charged Bid (delete+create only, no refunds).
+const {
+  bidRecurringFindFirst,
+  bidRecurringFindMany,
+  bidRecurringDelete,
+  bidRecurringCreate,
+  modelVersionFindFirst,
+  modelVersionFindMany,
+  transaction,
+  imagesFetch,
+} = vi.hoisted(() => ({
+  bidRecurringFindFirst: vi.fn(),
+  bidRecurringFindMany: vi.fn(),
+  bidRecurringDelete: vi.fn(async () => ({})),
+  bidRecurringCreate: vi.fn(async () => ({ id: 999 })),
+  modelVersionFindFirst: vi.fn(),
+  modelVersionFindMany: vi.fn(async () => [] as unknown[]),
+  transaction: vi.fn(async (ops: Promise<unknown>[]) => Promise.all(ops)),
+  imagesFetch: vi.fn(async () => ({} as Record<number, unknown>)),
+}));
+
+vi.mock('~/server/db/client', () => ({
+  dbWrite: {
+    $transaction: transaction,
+    bidRecurring: {
+      findFirst: bidRecurringFindFirst,
+      findMany: bidRecurringFindMany,
+      delete: bidRecurringDelete,
+      create: bidRecurringCreate,
+    },
+    modelVersion: { findFirst: modelVersionFindFirst, findMany: modelVersionFindMany },
+  },
+  dbRead: {},
+}));
+
+// image.service's real import graph (-> event-engine-common) is heavy; only the cache the
+// entity hydration reads is needed here.
+vi.mock('~/server/services/image.service', () => ({
+  imagesForModelVersionsCache: { fetch: imagesFetch },
+}));
+vi.mock('~/server/services/notification.service', () => ({ createNotification: vi.fn() }));
+vi.mock('~/utils/signal-client', () => ({ signalClient: { send: vi.fn(), topicSend: vi.fn() } }));
+// Pins the type/ecosystem gate to a known shape instead of the real basemodel constants.
+vi.mock('~/components/Auction/auction.utils', () => ({
+  getModelTypesForAuction: vi.fn(() => [{ type: 'Checkpoint', baseModels: ['SDXL 1.0'] }]),
+  miscAuctionName: 'Misc',
+}));
+
+import { getMyRecurringBids, moveRecurringBidToLatest } from '~/server/services/auction.service';
+
+const auctionBase = {
+  id: 10,
+  type: 'Model',
+  ecosystem: 'sd1',
+  name: 'SD1',
+  slug: 'sd1',
+  description: null,
+};
+
+const recurringBid = (overrides: Partial<Record<string, unknown>> = {}) => ({
+  id: 100,
+  userId: 1,
+  entityId: 5,
+  amount: 200,
+  startAt: new Date('2026-07-01T00:00:00Z'),
+  endAt: new Date('2026-09-01T00:00:00Z'),
+  isPaused: true,
+  accountType: 'yellow',
+  auctionBase,
+  ...overrides,
+});
+
+// Ordered newest-first, as the service's `orderBy: { index: 'asc' }` would return them.
+const version = (overrides: Partial<Record<string, unknown>> = {}) => ({
+  id: 5,
+  name: 'v1',
+  baseModel: 'SDXL 1.0',
+  availability: 'Public',
+  status: 'Published',
+  model: {
+    type: 'Checkpoint',
+    meta: null,
+    poi: false,
+    minor: false,
+    status: 'Published',
+    nsfw: false,
+  },
+  ...overrides,
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  modelVersionFindFirst.mockResolvedValue({ modelId: 50 });
+});
+
+describe('moveRecurringBidToLatest', () => {
+  it('moves the bid to the newest eligible version, preserving its terms', async () => {
+    const bid = recurringBid();
+    bidRecurringFindFirst.mockResolvedValueOnce(bid).mockResolvedValueOnce(null);
+    modelVersionFindMany.mockResolvedValue([version({ id: 9, name: 'v2' }), version()]);
+
+    const res = await moveRecurringBidToLatest({ userId: 1, bidId: 100 });
+
+    expect(res).toEqual({ id: 999, entityId: 9, name: 'v2' });
+    expect(bidRecurringDelete).toHaveBeenCalledWith({ where: { id: 100 } });
+    expect(bidRecurringCreate).toHaveBeenCalledWith({
+      data: {
+        userId: 1,
+        entityId: 9,
+        amount: 200,
+        startAt: bid.startAt,
+        endAt: bid.endAt,
+        isPaused: true,
+        auctionBaseId: 10,
+        accountType: 'yellow',
+      },
+      select: { id: true },
+    });
+  });
+
+  it('skips newer versions that fail the eligibility gates', async () => {
+    bidRecurringFindFirst.mockResolvedValueOnce(recurringBid()).mockResolvedValueOnce(null);
+    modelVersionFindMany.mockResolvedValue([
+      version({ id: 9, status: 'Draft' }),
+      version({ id: 8, availability: 'Private' }),
+      version({ id: 7, baseModel: 'Other Base' }),
+      version({ id: 6, name: 'eligible' }),
+      version(),
+    ]);
+
+    const res = await moveRecurringBidToLatest({ userId: 1, bidId: 100 });
+    expect(res.entityId).toBe(6);
+  });
+
+  it('errors without writing when the bid is already on the latest eligible version', async () => {
+    bidRecurringFindFirst.mockResolvedValueOnce(recurringBid());
+    modelVersionFindMany.mockResolvedValue([version(), version({ id: 4 })]);
+
+    await expect(moveRecurringBidToLatest({ userId: 1, bidId: 100 })).rejects.toThrow(
+      'already on the latest'
+    );
+    expect(bidRecurringDelete).not.toHaveBeenCalled();
+    expect(bidRecurringCreate).not.toHaveBeenCalled();
+  });
+
+  it('blocks when the user already holds a recurring bid on the target version', async () => {
+    bidRecurringFindFirst.mockResolvedValueOnce(recurringBid()).mockResolvedValueOnce({ id: 55 });
+    modelVersionFindMany.mockResolvedValue([version({ id: 9, name: 'v2' }), version()]);
+
+    await expect(moveRecurringBidToLatest({ userId: 1, bidId: 100 })).rejects.toThrow(
+      'already have a recurring bid'
+    );
+    expect(bidRecurringDelete).not.toHaveBeenCalled();
+    expect(bidRecurringCreate).not.toHaveBeenCalled();
+  });
+
+  it("rejects another user's bid", async () => {
+    bidRecurringFindFirst.mockResolvedValueOnce(recurringBid({ userId: 2 }));
+
+    await expect(moveRecurringBidToLatest({ userId: 1, bidId: 100 })).rejects.toThrow(
+      'Bid not found'
+    );
+  });
+});
+
+describe('getMyRecurringBids moveToLatest hint', () => {
+  const activeRow = {
+    id: 100,
+    entityId: 5,
+    amount: 200,
+    createdAt: new Date('2026-07-20T09:00:00Z'),
+    endAt: null,
+    isPaused: false,
+    accountType: 'yellow',
+    auctionBase,
+  };
+  const hydratedVersion = {
+    id: 5,
+    name: 'v1',
+    baseModel: 'SDXL 1.0',
+    nsfwLevel: 1,
+    model: {
+      id: 50,
+      name: 'A model',
+      type: 'Checkpoint',
+      nsfw: false,
+      poi: false,
+      minor: false,
+      meta: null,
+      user: { id: 7, username: 'creator', profilePicture: null },
+    },
+  };
+  const candidates = [
+    { id: 9, name: 'v2', modelId: 50, baseModel: 'SDXL 1.0' },
+    { id: 5, name: 'v1', modelId: 50, baseModel: 'SDXL 1.0' },
+  ];
+
+  // Call order: active bids -> entity hydration -> [candidate versions, all recurring rows].
+  const arrange = ({
+    candidateVersions = candidates,
+    allRecurring = [{ auctionBaseId: 10, entityId: 5, accountType: 'yellow' }],
+  }: {
+    candidateVersions?: unknown[];
+    allRecurring?: unknown[];
+  }) => {
+    bidRecurringFindMany.mockResolvedValueOnce([activeRow]).mockResolvedValueOnce(allRecurring);
+    modelVersionFindMany
+      .mockResolvedValueOnce([hydratedVersion])
+      .mockResolvedValueOnce(candidateVersions);
+  };
+
+  it('offers the newest published version of the model', async () => {
+    arrange({});
+
+    const [bid] = await getMyRecurringBids({ userId: 1 });
+    expect(bid.moveToLatest).toEqual({ status: 'available', targetId: 9, targetName: 'v2' });
+  });
+
+  it('reports the target as taken when another recurring bid already covers it', async () => {
+    arrange({
+      allRecurring: [
+        { auctionBaseId: 10, entityId: 5, accountType: 'yellow' },
+        { auctionBaseId: 10, entityId: 9, accountType: 'yellow' },
+      ],
+    });
+
+    const [bid] = await getMyRecurringBids({ userId: 1 });
+    expect(bid.moveToLatest).toEqual({ status: 'targetTaken', targetName: 'v2' });
+  });
+
+  it('offers nothing when the bid is already on the latest version', async () => {
+    arrange({ candidateVersions: [candidates[1]] });
+
+    const [bid] = await getMyRecurringBids({ userId: 1 });
+    expect(bid.moveToLatest).toBeNull();
+  });
+
+  it('ignores newer versions outside the auction ecosystem', async () => {
+    arrange({
+      candidateVersions: [
+        { id: 9, name: 'v2', modelId: 50, baseModel: 'Other Base' },
+        candidates[1],
+      ],
+    });
+
+    const [bid] = await getMyRecurringBids({ userId: 1 });
+    expect(bid.moveToLatest).toBeNull();
+  });
+});

--- a/src/server/services/__tests__/auction-move-recurring-bid.test.ts
+++ b/src/server/services/__tests__/auction-move-recurring-bid.test.ts
@@ -3,35 +3,29 @@ import { vi, describe, it, expect, beforeEach } from 'vitest';
 // `moveRecurringBidToLatest` re-targets an unfunded standing instruction (BidRecurring)
 // at the newest eligible published version. These pin the eligibility walk — a copy of
 // createBid's inline gates, deliberately not shared — and that the swap never touches
-// today's charged Bid (delete+create only, no refunds).
+// today's charged Bid (an in-place entityId rewrite, no refunds).
 const {
   bidRecurringFindFirst,
   bidRecurringFindMany,
-  bidRecurringDelete,
-  bidRecurringCreate,
+  bidRecurringUpdate,
   modelVersionFindFirst,
   modelVersionFindMany,
-  transaction,
   imagesFetch,
 } = vi.hoisted(() => ({
   bidRecurringFindFirst: vi.fn(),
   bidRecurringFindMany: vi.fn(),
-  bidRecurringDelete: vi.fn(async () => ({})),
-  bidRecurringCreate: vi.fn(async () => ({ id: 999 })),
+  bidRecurringUpdate: vi.fn(async () => ({ id: 100 })),
   modelVersionFindFirst: vi.fn(),
   modelVersionFindMany: vi.fn(async () => [] as unknown[]),
-  transaction: vi.fn(async (ops: Promise<unknown>[]) => Promise.all(ops)),
   imagesFetch: vi.fn(async () => ({} as Record<number, unknown>)),
 }));
 
 vi.mock('~/server/db/client', () => ({
   dbWrite: {
-    $transaction: transaction,
     bidRecurring: {
       findFirst: bidRecurringFindFirst,
       findMany: bidRecurringFindMany,
-      delete: bidRecurringDelete,
-      create: bidRecurringCreate,
+      update: bidRecurringUpdate,
     },
     modelVersion: { findFirst: modelVersionFindFirst, findMany: modelVersionFindMany },
   },
@@ -99,26 +93,16 @@ beforeEach(() => {
 });
 
 describe('moveRecurringBidToLatest', () => {
-  it('moves the bid to the newest eligible version, preserving its terms', async () => {
-    const bid = recurringBid();
-    bidRecurringFindFirst.mockResolvedValueOnce(bid).mockResolvedValueOnce(null);
+  it('moves the bid to the newest eligible version in place, preserving the row', async () => {
+    bidRecurringFindFirst.mockResolvedValueOnce(recurringBid()).mockResolvedValueOnce(null);
     modelVersionFindMany.mockResolvedValue([version({ id: 9, name: 'v2' }), version()]);
 
     const res = await moveRecurringBidToLatest({ userId: 1, bidId: 100 });
 
-    expect(res).toEqual({ id: 999, entityId: 9, name: 'v2' });
-    expect(bidRecurringDelete).toHaveBeenCalledWith({ where: { id: 100 } });
-    expect(bidRecurringCreate).toHaveBeenCalledWith({
-      data: {
-        userId: 1,
-        entityId: 9,
-        amount: 200,
-        startAt: bid.startAt,
-        endAt: bid.endAt,
-        isPaused: true,
-        auctionBaseId: 10,
-        accountType: 'yellow',
-      },
+    expect(res).toEqual({ id: 100, entityId: 9, name: 'v2' });
+    expect(bidRecurringUpdate).toHaveBeenCalledWith({
+      where: { id: 100 },
+      data: { entityId: 9 },
       select: { id: true },
     });
   });
@@ -144,8 +128,7 @@ describe('moveRecurringBidToLatest', () => {
     await expect(moveRecurringBidToLatest({ userId: 1, bidId: 100 })).rejects.toThrow(
       'already on the latest'
     );
-    expect(bidRecurringDelete).not.toHaveBeenCalled();
-    expect(bidRecurringCreate).not.toHaveBeenCalled();
+    expect(bidRecurringUpdate).not.toHaveBeenCalled();
   });
 
   it('blocks when the user already holds a recurring bid on the target version', async () => {
@@ -155,8 +138,7 @@ describe('moveRecurringBidToLatest', () => {
     await expect(moveRecurringBidToLatest({ userId: 1, bidId: 100 })).rejects.toThrow(
       'already have a recurring bid'
     );
-    expect(bidRecurringDelete).not.toHaveBeenCalled();
-    expect(bidRecurringCreate).not.toHaveBeenCalled();
+    expect(bidRecurringUpdate).not.toHaveBeenCalled();
   });
 
   it("rejects another user's bid", async () => {
@@ -219,6 +201,20 @@ describe('getMyRecurringBids moveToLatest hint', () => {
 
     const [bid] = await getMyRecurringBids({ userId: 1 });
     expect(bid.moveToLatest).toEqual({ status: 'available', targetId: 9, targetName: 'v2' });
+  });
+
+  it('restricts candidates to published versions of published models', async () => {
+    arrange({});
+
+    await getMyRecurringBids({ userId: 1 });
+
+    const [candidateQuery] = modelVersionFindMany.mock.calls[1] as unknown as [
+      { where: Record<string, unknown> }
+    ];
+    expect(candidateQuery.where).toMatchObject({
+      status: 'Published',
+      model: { status: 'Published' },
+    });
   });
 
   it('reports the target as taken when another recurring bid already covers it', async () => {

--- a/src/server/services/auction.service.ts
+++ b/src/server/services/auction.service.ts
@@ -38,7 +38,6 @@ import {
   throwNotFoundError,
 } from '~/server/utils/errorHandling';
 import { AuctionType, Availability, ModelStatus } from '~/shared/utils/prisma/enums';
-import { getBuzzTransactionSupportedAccountTypes } from '~/utils/buzz';
 import { formatDate } from '~/utils/date-helpers';
 import { withRetries } from '~/utils/errorHandling';
 import { signalClient } from '~/utils/signal-client';
@@ -427,6 +426,11 @@ export const getMyBids = async ({ userId }: { userId: number }) => {
   }
 };
 
+type MoveToLatestInfo =
+  | { status: 'available'; targetId: number; targetName: string }
+  | { status: 'targetTaken'; targetName: string }
+  | null;
+
 export type GetMyRecurringBidsReturn = AsyncReturnType<typeof getMyRecurringBids>;
 export const getMyRecurringBids = async ({ userId }: { userId: number }) => {
   try {
@@ -455,7 +459,65 @@ export const getMyRecurringBids = async ({ userId }: { userId: number }) => {
 
     const enhancedBids = await getAuctionMVData(bids);
 
-    return enhancedBids.sort(
+    const modelIds = uniq(enhancedBids.map((b) => b.entityData?.model.id).filter(isDefined));
+    const [candidateVersions, allRecurring] = modelIds.length
+      ? await Promise.all([
+          dbWrite.modelVersion.findMany({
+            where: {
+              modelId: { in: modelIds },
+              status: ModelStatus.Published,
+              availability: { not: Availability.Private },
+            },
+            orderBy: { index: 'asc' },
+            select: { id: true, name: true, modelId: true, baseModel: true },
+          }),
+          // The unique constraint also spans inactive/expired rows, so the taken-check
+          // can't reuse the active-filtered `bids` above.
+          dbWrite.bidRecurring.findMany({
+            where: { userId },
+            select: { auctionBaseId: true, entityId: true, accountType: true },
+          }),
+        ])
+      : [[], []];
+
+    // Display hint only; moveRecurringBidToLatest re-validates with the full gates.
+    const withMoveTarget = enhancedBids.map((bid) => {
+      const model = bid.entityData?.model;
+      let moveToLatest: MoveToLatestInfo = null;
+      if (
+        model &&
+        bid.auctionBase.type === AuctionType.Model &&
+        !model.cannotPromote &&
+        !model.poi &&
+        !(bid.accountType === 'green' && (model.nsfw || model.minor))
+      ) {
+        const matchAllowed = getModelTypesForAuction(bid.auctionBase).find(
+          (a) => a.type === model.type
+        );
+        const checkEcosystem =
+          !!bid.auctionBase.ecosystem && bid.auctionBase.ecosystem !== miscAuctionName;
+        const target = matchAllowed
+          ? candidateVersions.find(
+              (v) =>
+                v.modelId === model.id &&
+                (!checkEcosystem || (matchAllowed.baseModels ?? []).includes(v.baseModel))
+            )
+          : undefined;
+        if (target && target.id !== bid.entityId) {
+          moveToLatest = allRecurring.some(
+            (r) =>
+              r.auctionBaseId === bid.auctionBase.id &&
+              r.entityId === target.id &&
+              r.accountType === bid.accountType
+          )
+            ? { status: 'targetTaken', targetName: target.name }
+            : { status: 'available', targetId: target.id, targetName: target.name };
+        }
+      }
+      return { ...bid, moveToLatest };
+    });
+
+    return withMoveTarget.sort(
       (a, b) => b.createdAt.getTime() - a.createdAt.getTime() || b.amount - a.amount
     );
   } catch (error) {
@@ -1115,6 +1177,116 @@ export const deleteRecurringBid = async ({
   await dbWrite.bidRecurring.delete({
     where: { id: bidId },
   });
+};
+
+export const moveRecurringBidToLatest = async ({
+  userId,
+  bidId,
+}: DeleteBidInput & { userId: number }) => {
+  const bid = await dbWrite.bidRecurring.findFirst({
+    where: { id: bidId },
+    select: {
+      id: true,
+      userId: true,
+      entityId: true,
+      amount: true,
+      startAt: true,
+      endAt: true,
+      isPaused: true,
+      accountType: true,
+      auctionBase: { select: auctionBaseSelect },
+    },
+  });
+  if (!bid || bid.userId !== userId) throw throwNotFoundError('Bid not found.');
+  if (bid.auctionBase.type !== AuctionType.Model)
+    throw throwBadRequestError('Only model bids can be moved to a latest version.');
+
+  const currentMv = await dbWrite.modelVersion.findFirst({
+    where: { id: bid.entityId },
+    select: { modelId: true },
+  });
+  if (!currentMv) throw throwNotFoundError('Model version not found.');
+
+  const versions = await dbWrite.modelVersion.findMany({
+    where: { modelId: currentMv.modelId },
+    orderBy: { index: 'asc' },
+    select: {
+      id: true,
+      name: true,
+      baseModel: true,
+      availability: true,
+      status: true,
+      model: {
+        select: { type: true, meta: true, poi: true, minor: true, status: true, nsfw: true },
+      },
+    },
+  });
+
+  // Keep in sync with createBid's inline eligibility gates (deliberately not shared —
+  // extracting them would touch the live charging path).
+  const allowedTypeData = getModelTypesForAuction(bid.auctionBase);
+  const target = versions.find((mv) => {
+    if (mv.availability === Availability.Private) return false;
+    if (mv.status !== ModelStatus.Published) return false;
+    if (mv.model.status !== ModelStatus.Published) return false;
+    if ((mv.model.meta as ModelMeta | null)?.cannotPromote === true) return false;
+    if (mv.model.poi) return false;
+    const matchAllowed = allowedTypeData.find((a) => a.type === mv.model.type);
+    if (!matchAllowed) return false;
+    if (!!bid.auctionBase.ecosystem && bid.auctionBase.ecosystem !== miscAuctionName) {
+      if (!(matchAllowed.baseModels ?? []).includes(mv.baseModel)) return false;
+    }
+    if (bid.accountType === 'green' && (mv.model.nsfw || mv.model.poi || mv.model.minor))
+      return false;
+    return true;
+  });
+
+  if (!target) throw throwBadRequestError('No eligible version was found for this model.');
+  if (target.id === bid.entityId)
+    throw throwBadRequestError('This recurring bid is already on the latest eligible version.');
+
+  const existing = await dbWrite.bidRecurring.findFirst({
+    where: {
+      auctionBaseId: bid.auctionBase.id,
+      userId,
+      entityId: target.id,
+      accountType: bid.accountType,
+    },
+    select: { id: true },
+  });
+  if (existing)
+    throw throwBadRequestError(
+      'You already have a recurring bid on the latest version of this model.'
+    );
+
+  // Today's already-charged Bid is deliberately untouched — the nightly job picks up
+  // the new target tomorrow, which keeps this off the refund path.
+  try {
+    const [, created] = await dbWrite.$transaction([
+      dbWrite.bidRecurring.delete({ where: { id: bid.id } }),
+      dbWrite.bidRecurring.create({
+        data: {
+          userId,
+          entityId: target.id,
+          amount: bid.amount,
+          startAt: bid.startAt,
+          endAt: bid.endAt,
+          isPaused: bid.isPaused,
+          auctionBaseId: bid.auctionBase.id,
+          accountType: bid.accountType,
+        },
+        select: { id: true },
+      }),
+    ]);
+
+    return { id: created.id, entityId: target.id, name: target.name };
+  } catch (e) {
+    if (e instanceof Prisma.PrismaClientKnownRequestError && e.code === 'P2002')
+      throw throwBadRequestError(
+        'You already have a recurring bid on the latest version of this model.'
+      );
+    throw e;
+  }
 };
 
 export const togglePauseRecurringBid = async ({

--- a/src/server/services/auction.service.ts
+++ b/src/server/services/auction.service.ts
@@ -467,6 +467,7 @@ export const getMyRecurringBids = async ({ userId }: { userId: number }) => {
               modelId: { in: modelIds },
               status: ModelStatus.Published,
               availability: { not: Availability.Private },
+              model: { status: ModelStatus.Published },
             },
             orderBy: { index: 'asc' },
             select: { id: true, name: true, modelId: true, baseModel: true },
@@ -1262,24 +1263,13 @@ export const moveRecurringBidToLatest = async ({
   // Today's already-charged Bid is deliberately untouched — the nightly job picks up
   // the new target tomorrow, which keeps this off the refund path.
   try {
-    const [, created] = await dbWrite.$transaction([
-      dbWrite.bidRecurring.delete({ where: { id: bid.id } }),
-      dbWrite.bidRecurring.create({
-        data: {
-          userId,
-          entityId: target.id,
-          amount: bid.amount,
-          startAt: bid.startAt,
-          endAt: bid.endAt,
-          isPaused: bid.isPaused,
-          auctionBaseId: bid.auctionBase.id,
-          accountType: bid.accountType,
-        },
-        select: { id: true },
-      }),
-    ]);
+    const updated = await dbWrite.bidRecurring.update({
+      where: { id: bid.id },
+      data: { entityId: target.id },
+      select: { id: true },
+    });
 
-    return { id: created.id, entityId: target.id, name: target.name };
+    return { id: updated.id, entityId: target.id, name: target.name };
   } catch (e) {
     if (e instanceof Prisma.PrismaClientKnownRequestError && e.code === 'P2002')
       throw throwBadRequestError(


### PR DESCRIPTION
Adds a `moveRecurringBidToLatest` mutation plus a hint on `getMyRecurringBids` so creators can re-target a standing recurring bid at the newest eligible published version of a model without deleting and re-creating it. The swap only rewrites the BidRecurring row — today's already-charged bid is untouched, so the new version takes effect with tomorrow's nightly run and nothing hits the refund path.