### PR TITLE
docs(blocks): correct a false claim in the MEDIA-XOR-TEXT note — chatCompletion already has the dual shape

### DIFF
--- a/src/server/services/blocks/steps/index.ts
+++ b/src/server/services/blocks/steps/index.ts
@@ -203,8 +203,26 @@ export function postureRequiresAuditableText(posture: StepModerationPosture): bo
  * direction and it is the intended answer for now: such an entry needs a real
  * decision about whether its media is scanned too (the text scan here does not
  * look at media at all), and it should be blocked until someone makes it, not
- * admitted with one axis silently uncovered. Nothing in the currently-licensed
- * `$type` set has that shape.
+ * admitted with one axis silently uncovered.
+ *
+ * 🔴 AND THE LICENSED SET ALREADY CONTAINS ONE — DO NOT READ THIS AS A FUTURE
+ * PROBLEM. This paragraph used to end "Nothing in the currently-licensed
+ * `$type` set has that shape", and that was FALSE. `chatCompletion` has exactly
+ * that shape: `ChatCompletionInput.modalities` accepts `['image']`, and with it
+ * the orchestrator returns generated images on
+ * `choices[].message.images[].image_url.url` as base64 data URIs — bytes that
+ * never reach image ingestion, never become moderated `Image` rows, and are not
+ * seen by the text scan either.
+ *
+ * What keeps the XOR true today is NOT the `$type` set. It is that the
+ * `chatCompletion` ENTRY's `.strict()` `paramSchema` omits `modalities`, so the
+ * media arm is unreachable through it — a load-bearing omission, not a tidy
+ * one. Read `./chat-completion.step`'s note before touching that schema: adding
+ * `modalities` (or its companion `image_config`) turns a text-posture entry
+ * into a media-producing one and opens precisely the half-covered channel this
+ * rule exists to refuse. The invariant to defend is per-ENTRY schema
+ * discipline; do not infer from the XOR that the licensed `$type`s are
+ * single-natured.
  */
 export function stepOutputShape(posture: StepModerationPosture): 'media' | 'text' {
   switch (posture) {


### PR DESCRIPTION
## What

`stepOutputShape`'s doc block in `src/server/services/blocks/steps/index.ts` ended with:

> Nothing in the currently-licensed `$type` set has that shape.

— framing a step that emits **both** media and free text as a future problem. It isn't. `chatCompletion` has exactly that shape today.

## Why it's false

`ChatCompletionInput.modalities` accepts `['image']`. With it present, the orchestrator routes to the image pipeline and returns generated images on `choices[].message.images[].image_url.url` as **base64 data URIs**. Those bytes never reach image ingestion, so they never become moderated `Image` rows and never get an `nsfwLevel` — and the text scan does not look at media at all.

What keeps the MEDIA-XOR-TEXT model true for `chatCompletion` is **not** the `$type` set. It is that the entry's `.strict()` `paramSchema` omits `modalities`, so the media arm is unreachable through it. `chat-completion.step.ts` already documents this at length and correctly — under a header that calls it "THE SINGLE MOST IMPORTANT LINE IN THIS FILE". The registry-level note contradicted it.

## Why it's worth a PR

The comment is the control here. Someone registering a media+text step reads "nothing has that shape", concludes the licensed `$type`s are single-natured, and misses that the invariant they actually need to defend is **per-entry schema discipline** — specifically, that adding `modalities` or `image_config` to a text-posture entry silently opens an unscanned media channel.

The replacement states the true position, names `chatCompletion` explicitly, and points at `./chat-completion.step`'s existing note.

## Scope

Comment-only. No behaviour, no API surface, no test changes. Nothing to reproduce; the claim is verifiable by reading `chat-completion.step.ts:213-237` against the line this removes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R7ZCxbgcsv3WfsSJrYdSCi
