### PR TITLE
fix(test): anchor the Generations locator so the analytics component suite stops oscillating

### DIFF
--- a/src/components/AppBlocks/AppAnalyticsPanel.browser.test.tsx
+++ b/src/components/AppBlocks/AppAnalyticsPanel.browser.test.tsx
@@ -102,14 +102,96 @@ describe('AppAnalyticsPanel — top-N cards are humanised, not raw tokens', () =
     };
     renderWithProviders(<AppAnalyticsPanel scopedAppBlockId="apb_1" />);
 
-    await expect.element(page.getByText('Generations')).toBeInTheDocument();
+    // Await the panel's always-rendered heading first, so a regression that stops
+    // rendering the table fails on an assertion below with a legible message rather
+    // than on a locator timeout here.
+    await expect.element(page.getByText('Top endpoints')).toBeInTheDocument();
+
+    // 🔴 `{ exact: true }` IS LOAD-BEARING, and its absence is what turned
+    // `preview / component-tests` red at this PR's audit-fix round.
+    //
+    // `getByText` is substring + case-insensitive, and the "Runs (range)" stat's own
+    // tooltip copy begins *"Generations run through your app within the selected
+    // range…"* (AppAnalyticsPanel.tsx). Mantine mounts that tooltip only while the
+    // pointer rests on the stat (hover-only), and vitest browser mode shares ONE
+    // browser page across every `.browser.test.tsx` file — so the pointer position
+    // left behind by an earlier file can already sit over the stat at mount. The
+    // locator then resolves to 2 elements and this dies with a strict-mode violation
+    // after the matcher timeout.
+    //
+    // 🔴 The failure mode is OSCILLATION, not a permanent red, which is worse:
+    // vitest's BaseSequencer sorts failed-first from a cache persisted on the preview
+    // workspace's reused volume, so a run where this file times out promotes it to
+    // run FIRST next time — pointer still at (0,0), nothing hovered, and it passes.
+    // Green on some PRs and red on others off the same base is the signature.
+    //
+    // 🔴 This collision was INTRODUCED by renaming the label. The previous value,
+    // 'Generation submits', does not substring-match that tooltip sentence; 'Generations'
+    // does. Verified by computation, not by eye. Same defect class as #3593.
+    const generationsRows = page.getByText('Generations', { exact: true }).elements();
+    expect(generationsRows).toHaveLength(1);
     await expect.element(page.getByText('App-local storage writes')).toBeInTheDocument();
-    // The raw tokens must not survive anywhere in the rendered output.
+    // The raw tokens must not survive anywhere in the rendered output. These stay
+    // SUBSTRING on purpose — that makes a negative assertion stronger, since
+    // `getByText('workflow:submit')` also catches a leaked `workflow:submit:wf_x`.
     expect(page.getByText('workflow:submit').elements()).toHaveLength(0);
     expect(page.getByText('storage:set').elements()).toHaveLength(0);
     // And must not have degraded to either Activity-panel labeller's output.
     expect(page.getByText('(no workflow id)').elements()).toHaveLength(0);
     expect(page.getByText('Generated an image').elements()).toHaveLength(0);
+  });
+
+  /**
+   * 🔴 REGRESSION GUARD for the `{ exact: true }` above — reproduces the exact state that
+   * broke `preview / component-tests`, so reverting the anchor fails a test rather than
+   * merely contradicting a comment.
+   *
+   * The condition is: the "Runs (range)" stat's hover-only tooltip is MOUNTED (its copy
+   * begins "Generations run through your app…"), which a shared browser page can carry in
+   * from an earlier `.browser.test.tsx` file. Here it is produced deliberately by hovering
+   * the tooltip's real target.
+   *
+   * Note the target is the 14px `IconInfoCircle`, NOT the label — hovering the "Runs (range)"
+   * text does not mount it, which is why this never reproduced by hovering the obvious thing.
+   *
+   * Measured: with the tooltip mounted, `getByText('Generations')` (no anchor) resolves to 2
+   * elements and dies with `strict mode violation`; the anchored form resolves to 1.
+   */
+  test('the Generations label stays unambiguous even with the Runs tooltip mounted', async () => {
+    mocks.analytics.current = {
+      ...ZEROED,
+      engagement: {
+        ...ZEROED.engagement,
+        apiCalls: 245,
+        topEndpoints: [{ endpoint: 'workflow:submit', count: 245 }],
+      },
+    };
+    renderWithProviders(<AppAnalyticsPanel scopedAppBlockId="apb_1" />);
+    await expect.element(page.getByText('Top endpoints')).toBeInTheDocument();
+
+    // Park the pointer on the tooltip's target: the info icon inside the Runs stat.
+    const runsLabel = Array.from(document.querySelectorAll('*')).find(
+      (e) => e.textContent?.trim() === 'Runs (range)' && e.children.length === 0
+    );
+    let icon: Element | null = null;
+    let node: Element | null = runsLabel ?? null;
+    for (let i = 0; node && i < 5 && !icon; i++, node = node.parentElement) {
+      icon = node.querySelector('svg');
+    }
+    expect(icon, 'the Runs stat should have an info icon to hover').not.toBeNull();
+    await page.elementLocator(icon as Element).hover();
+
+    // 🔴 POSITIVE CONTROL, and it is what stops this test passing vacuously. If the hover
+    // silently stops working — a markup change, a Mantine upgrade, a renamed tooltip — the
+    // ambiguity below can no longer arise and the anchor assertion would pass while testing
+    // nothing. Fail loudly on that instead.
+    await expect
+      .element(page.getByText('Generations run through your app', { exact: false }))
+      .toBeInTheDocument();
+
+    // The whole point: with that tooltip mounted, the anchored locator still finds exactly
+    // one element. Drop `{ exact: true }` and this is a strict-mode violation.
+    expect(page.getByText('Generations', { exact: true }).elements()).toHaveLength(1);
   });
 
   test('a legacy tailed bucket keeps its tail so two such rows stay distinguishable', async () => {


### PR DESCRIPTION
#3574 turned `preview / component-tests` red and **I merged through it**, having convinced myself CI didn't run that tier. It does. The root cause is mine, and this fixes it.

## The bug

`AppAnalyticsPanel.browser.test.tsx` asserted `page.getByText('Generations')`. `getByText` is **substring + case-insensitive**, and the "Runs (range)" stat's own tooltip copy begins:

> *"Generations run through your app within the selected range, and the viewer Buzz burned doing so."*

Mantine mounts that tooltip only while the pointer rests on its target, and **vitest browser mode shares one browser page across every `.browser.test.tsx` file** — so the pointer position left behind by an earlier file can already sit there at mount. The locator then resolves to 2 elements and the assertion dies with a strict-mode violation after the matcher timeout.

**The label rename in #3574 is what introduced it.** The previous value, `'Generation submits'`, does *not* substring-match that tooltip sentence; `'Generations'` does — verified by computation, not by eye. The check history matches exactly:

| commit | `preview / component-tests` |
|---|---|
| `075519d380` (before the rename) | success |
| `8e75826616` (after) | **failure** |
| `928273e4dd` (after) | **failure** |

Same defect class as #3593, which fixed it for `AppAnalyticsInline`. That PR also documents the mechanism I was missing — the shared page, and the **oscillation**: vitest's `BaseSequencer` sorts failed-first from a cache on the reused preview volume, so a run that times out promotes the file to run *first* next time, where nothing is hovered and it passes. That's why the check was green on some PRs and red on others off the same base — including PR 3591 green with the #3574 merge in its base, which had me wrongly leaning toward "not mine".

## The fix

1. **Anchor with `{ exact: true }`** and assert exactly one match. Also await the always-rendered "Top endpoints" heading first, so a regression that stops rendering the table fails on an assertion rather than a locator timeout. The **negative** assertions stay substring deliberately — that makes them stronger, since `getByText('workflow:submit')` also catches a leaked `workflow:submit:wf_x`.

2. **A regression guard that reproduces the breaking state** rather than describing it, so reverting the anchor fails a test instead of merely contradicting a comment. It hovers the tooltip's real target and asserts the anchored locator still finds one element.

## Proof

Every mutation checksum-verified as applied, file restored byte-identical afterwards:

| mutation | result |
|---|---|
| old assertion + pointer on the icon | **FAILS** — `strict mode violation: getByText('Generations') resolved to 2 elements` |
| new assertion + pointer on the icon | passes |
| drop the anchor from the new guard | **FAILS** — locator resolves to `[<p>, <div>]` |
| hover a target that does NOT mount the tooltip | the guard's **positive control** fails — it refuses to pass vacuously |

⚠️ **The target is the 14px `IconInfoCircle`, not the label.** Hovering the "Runs (range)" text does *not* mount the tooltip. My first reproduction attempt hovered the label, saw the old assertion pass, and would have shipped an unproven fix — a probe positive control (`tooltip_mounted=false`) is what caught that. Worth knowing for anyone reproducing this class.

## Scope check

Ran the same programmatic check — every `getByText` argument in the file against every copy string the component can render — rather than fixing only the one I happened to spot. `'Generations'` was the sole collision here, and `RevenuePanel.browser.test.tsx` has none: its three tooltips contain no "pending", so its `getByText('Pending')` resolves to 1 even with them open.

`tsc --noEmit` 0 errors; prettier clean on the changed file (positive-controlled against `AppAnalyticsInline.tsx`, which violates on main). The full `component` project still cannot complete on a NixOS host in either direction, so the single-file run plus the mutation matrix is the local evidence — **the preview pipeline remains the authority for the suite**, and its result on this branch is what should be read before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
