### PR TITLE
docs(blocks): correct six stale/contradicting comments in the step subsystem

### DIFF
--- a/src/server/services/blocks/steps/index.ts
+++ b/src/server/services/blocks/steps/index.ts
@@ -86,13 +86,26 @@ export const STEP_BILLING_MODES: readonly StepBillingMode[] = [
 // with no implemented handler fails at registry LOAD (a build-time error), not
 // at request time on a Friday.
 //
-// 🔴 THE FREE-TEXT-INPUT HALF OF THAT QUESTION IS NOW ANSWERED (#3527): mature
-// content is permitted for App Blocks, bounded by the token's server-minted
-// maturity ceiling — so a free-text INPUT needs the same prompt audit
-// `textToImage` / `customComfy` already run, not a new policy. `'promptAudit'`
-// is therefore IMPLEMENTED; its handler lives in `./moderation` and runs
-// `auditPromptServer` host-side, before the orchestrator submit. The free-text
-// OUTPUT half (`'textOutput'`) is still unanswered and still fails at load.
+// 🔴 BOTH HALVES OF THAT QUESTION ARE NOW ANSWERED, AND ALL THREE POSTURES ARE
+// IMPLEMENTED — nothing in this union fails at load today. The INPUT half
+// (#3527): mature content is permitted for App Blocks, bounded by the token's
+// server-minted maturity ceiling, so a free-text INPUT needs the same prompt
+// audit `textToImage` / `customComfy` already run, not a new policy —
+// `'promptAudit'`'s handler lives in `./moderation` and runs `auditPromptServer`
+// host-side, before the orchestrator submit. The OUTPUT half is answered too:
+// `'textOutput'` scans the generated text with the orchestrator's
+// `xGuardModeration` step (`mode: 'text'`) at the READ boundary and withholds on
+// a policy hit AND on any scanner failure. Evidence, not intent:
+// `isModerationPostureImplemented` returns true for all three values, its output
+// handler is in `./moderation`, and the registered `chat-completion` entry
+// declares `'textOutput'` — a load-time failure would take the module down.
+//
+// 🔴 AN EARLIER REVISION OF THIS PARAGRAPH ENDED "The free-text OUTPUT half
+// (`'textOutput'`) is still unanswered and still fails at load." That was FALSE,
+// and it was the FIRST thing a reader hit when opening this union — twenty lines
+// ahead of the `'textOutput'` member's own doc, which said the opposite. When a
+// posture ships, correct THIS block in the same change; a stale summary above a
+// correct member doc is read as the summary.
 // ─────────────────────────────────────────────────────────────────────────────
 export type StepModerationPosture =
   /**

--- a/src/server/services/blocks/steps/index.ts
+++ b/src/server/services/blocks/steps/index.ts
@@ -95,10 +95,41 @@ export const STEP_BILLING_MODES: readonly StepBillingMode[] = [
 // host-side, before the orchestrator submit. The OUTPUT half is answered too:
 // `'textOutput'` scans the generated text with the orchestrator's
 // `xGuardModeration` step (`mode: 'text'`) at the READ boundary and withholds on
-// a policy hit AND on any scanner failure. Evidence, not intent:
-// `isModerationPostureImplemented` returns true for all three values, its output
-// handler is in `./moderation`, and the registered `chat-completion` entry
-// declares `'textOutput'` — a load-time failure would take the module down.
+// a policy-label hit. Evidence, not intent: `isModerationPostureImplemented`
+// returns true for all three values, its output handler is in `./moderation`,
+// and the registered `chat-completion` entry declares `'textOutput'` — a
+// load-time failure would take the module down.
+//
+// 🔴 DO NOT SUMMARISE THE FAILURE BEHAVIOUR AS "withholds on ANY scanner
+// failure". An earlier revision of this paragraph said exactly that and it is
+// NOT true of this tree. What withholds is a specific set — in
+// `./text-output-moderation` unless noted, named by symbol rather than line so
+// this list does not rot the moment that file moves:
+//   - the scan call throwing, or exceeding the hard deadline (`stage: 'error'`)
+//   - no scan output at all — the submit failed, or the workflow was still
+//     running when `SCAN_WAIT_SECONDS` elapsed (`stage: 'no-verdict'`)
+//   - joined text over `MAX_SCANNED_CONTENT_CHARS`, checked before the network
+//     call AND before the memo, so no over-cap payload is answered from a hit
+//     (`stage: 'over-cap'`)
+//   - a requested label absent from `results[]` (`missingRequestedLabels` →
+//     `stage: 'label-drift'`)
+//   - `extractText` returning a non-array, or an array with a non-string entry
+//     (guarded in `./moderation`'s `textOutput.output` handler)
+// That module is authoritative; this list is a summary and must be re-read
+// against it, not trusted over it.
+//
+// 🔴 KNOWN GAP, OPEN IN THIS TREE: A LABEL THE SCANNER ATTEMPTED AND FAILED ON
+// RELEASES. The generated `XGuardLabelResult` carries `error?: null | string`,
+// but `XGuardLabelResultLike` — the shape this policy actually reads — declares
+// only `label` / `score` / `triggered`, and `decideTextOutputVerdict` reads only
+// those three. So an errored label contributes nothing to the trigger set, and
+// it ALSO suppresses the drift guard, because `missingRequestedLabels` counts an
+// entry as "evaluated" on a non-empty `label` alone. A scan in which all 15
+// `TEXT_OUTPUT_SCAN_LABELS` errored is therefore indistinguishable from
+// all-clean and RELEASES. This is stated as OPEN because it is open here; it is
+// a live fail-open, not a hypothetical. Re-read `decideTextOutputVerdict` before
+// relying on this paragraph in EITHER direction — do not assume from its
+// presence that it is still open, nor from its absence that it was ever closed.
 //
 // 🔴 AN EARLIER REVISION OF THIS PARAGRAPH ENDED "The free-text OUTPUT half
 // (`'textOutput'`) is still unanswered and still fails at load." That was FALSE,

--- a/src/server/services/blocks/steps/moderation.ts
+++ b/src/server/services/blocks/steps/moderation.ts
@@ -124,7 +124,31 @@ export type StepOutputModerationRequest = {
   isGreen: boolean;
   /** The OauthClient id off the verified block token — the per-app trigger key. */
   appId: string;
-  /** The block instance id, when the caller has one. */
+  /**
+   * The per-block identifier this scan's telemetry is keyed on. It reaches
+   * exactly one consumer — `logScan`'s Axiom event in
+   * `./text-output-moderation` — and is never written to a column, so nothing
+   * FK-resolves it and a wrong value fails silently.
+   *
+   * 🔴 THE TWO LIVE CALLERS PASS `claims.blockId`, NOT `claims.appBlockId`, AND
+   * THOSE ARE DIFFERENT NAMESPACES. `blocks.router.ts` `pollWorkflow` (:3108)
+   * and `cancelWorkflow` (:3252) are the only 2 of that router's ~15
+   * `appBlockId:` assignments reading `claims.blockId`; the rest read
+   * `claims.appBlockId`. The token carries both:
+   * `block-scope.middleware.ts:42-49` documents `appBlockId` as `AppBlock.id`,
+   * the `apb_<ulid>` PK, while `blockId` is `AppBlock.blockId` — the publish
+   * request's SLUG (`publish-request.service.ts:2392-2398` writes
+   * `id: apb_<ulid>` and `blockId: request.slug` onto the same row). So the
+   * value logged under this name does NOT join to `AppBlock.id` or to
+   * `BlockScopeInvocation.app_block_id`, which is what the per-app trigger-rate
+   * aggregation in `./text-output-moderation` assumes it can key on.
+   *
+   * Recorded rather than papered over: the defect is at the two router call
+   * sites, not in this field's name — renaming it to match what is passed would
+   * make the log self-consistent and still un-joinable. An earlier revision of
+   * this line read "The block instance id", which matches NEITHER claim:
+   * `blockInstanceId` is a third, separate claim on the same token.
+   */
   appBlockId?: string;
 };
 
@@ -387,8 +411,9 @@ assertModerationHandlerTable(moderationPostureHandlers);
 //   1. every REGISTERED entry's declared posture/billing agrees with the derived
 //      policy for the `$type` it submits, and
 //   2. every `$type` the registry's own posture map licenses derives a posture
-//      that map accepts — a wider population than (1), which sees only the one
-//      `$type` a registered entry currently claims.
+//      that map accepts — a wider population than (1), which sees only the
+//      `$type`s a registered entry currently claims (two: `convertImage` and
+//      `chatCompletion`; the map licenses seven).
 // A disagreement is a BUILD failure, not a Friday surprise on a spend path.
 // ─────────────────────────────────────────────────────────────────────────────
 assertPolicyAgreesWithRegistryMap(STEP_TYPE_ACCEPTABLE_POSTURES);

--- a/src/server/services/blocks/steps/request-time-policy.ts
+++ b/src/server/services/blocks/steps/request-time-policy.ts
@@ -244,14 +244,24 @@ const STEP_TYPE_POLICY_TABLE = {
     // stand in front of.
     //
     // 🔴 THE REGISTRY CANNOT EXPRESS THIS STEP. Its output surface is MEDIA
-    // **XOR** TEXT (`stepOutputShape`), and `index.ts` states the limit
-    // explicitly: "A future orchestrator step that emits BOTH media and free
-    // text cannot register at all under this rule — it fails at load rather than
-    // half-registering... Nothing in the currently-licensed `$type` set has that
-    // shape." That last sentence is FALSE as of `@civitai/client`
-    // 0.2.0-beta.83 — `chatCompletion` is in the licensed set and has exactly
-    // that shape. Recorded here rather than silently worked around; closing it
-    // is a design decision, not an edit.
+    // **XOR** TEXT (`stepOutputShape`), so a `$type` that emits BOTH fails at
+    // load rather than half-registering — and as of `@civitai/client`
+    // 0.2.0-beta.83 `chatCompletion` IS one: it is in the licensed set and it
+    // has that shape.
+    //
+    // 🔴 DO NOT RE-ADD A REBUTTAL OF "nothing licensed has that shape" HERE.
+    // This comment used to quote that sentence out of `index.ts` in order to
+    // call it false; #3605 deleted the sentence and replaced it with the
+    // correction itself, so the quote now points at text that no longer exists
+    // and a reader following the pointer lands on the OPPOSITE of what the quote
+    // sets up. `stepOutputShape`'s doc is the single place that finding lives —
+    // its closing paragraph opens "AND THE LICENSED SET ALREADY CONTAINS ONE"
+    // and records the superseded claim itself. Read it, don't restate it.
+    //
+    // What holds the XOR true today is NOT the `$type` set: it is that the
+    // `chatCompletion` ENTRY's `.strict()` `paramSchema` omits `modalities`, so
+    // the media arm is unreachable through it. Closing this properly is a design
+    // decision, not an edit.
     emitsMedia: true,
     // `ChatCompletionInput.model` is a plain provider id ("gpt-4o"), NOT an AIR —
     // matching what `index.ts` already records. It still needs binding, but by a
@@ -903,6 +913,23 @@ export function postureForTextSurface(surface: StepTextSurface): StepModerationP
  * entry's DECLARATION to a request-time lookup on what was actually sent.
  *
  * FAILS CLOSED on an unlisted `$type` and on an undecided classification.
+ *
+ * 🔴 "GUARD" NAMES THE ROLE AFTER THE PIVOT, NOT WHAT RUNS TODAY — READ THIS
+ * BEFORE CONCLUDING ANYTHING IS REDUNDANT WITH IT. Nothing on the request path
+ * calls this function, or either of the other two guards. Enumerated over
+ * `src/**`, not sampled: the only non-test importers of this module are
+ * `./index` (a doc reference) and `./moderation`, and `./moderation` imports
+ * exactly two names — `assertRegistryEntryAgreesWithPolicy` and
+ * `assertPolicyAgreesWithRegistryMap`, both defined below, both invoked at
+ * `./moderation`'s MODULE LOAD. Those two are this guard's only live callers.
+ *
+ * So all three "guards" are today a BUILD-TIME CONSISTENCY CHECK between the
+ * registry's per-entry declarations and this table — they reject nothing at
+ * request time, and a registry clause that looks duplicated by one of them is
+ * still the only thing enforcing that rule on a live submit. Deleting a registry
+ * clause because "the request-time guard covers it" would remove the enforcement
+ * and leave the assert. The module header states the same thing about the module
+ * as a whole; it is repeated here because the section names do not carry it.
  */
 export function requiredPostureForSubmittedType(
   orchestratorType: string
@@ -966,6 +993,14 @@ export function requiredPostureForSubmittedType(
  * 🔴 IT IS ALSO TOTAL — it cannot throw. The scan carries a depth cap and
  * returns "contains an AIR" (i.e. this rejection) when it is hit, so a deeply
  * nested body is a decided rejection rather than an unhandled `RangeError`.
+ *
+ * 🔴 NOT ON THE REQUEST PATH — AND THIS ONE HAS NO LIVE CALLER AT ALL, unlike
+ * guards 1 and 3. Neither load-time assert calls it; outside `__tests__/` its
+ * only caller is `evaluateSubmittedStep`, which itself has no production caller.
+ * It is exercised by tests only until the pivot wires it in. See GUARD 1's note
+ * for the enumeration. The entitlement scan that DOES run on live submits is the
+ * registry's own clause-7 load probe plus the router's re-assert, both of which
+ * call the same `containsAirReference` helper.
  */
 export function screenSubmittedStepResources(submitted: {
   orchestratorType: string;
@@ -1003,6 +1038,12 @@ export function screenSubmittedStepResources(submitted: {
  * Re-homes the registry's per-entry `billingMode` declaration. FAILS CLOSED on
  * an unlisted type AND on a listed type whose mode is not established — the
  * common case today, deliberately (see `StepTypePolicy.billingMode`).
+ *
+ * 🔴 NOT ON THE REQUEST PATH. Like GUARD 1, its only live caller is
+ * `assertRegistryEntryAgreesWithPolicy`, at `./moderation`'s module load. No
+ * money path dispatches on this function's result today; the registry's own
+ * per-entry `billingMode` is still what estimate/reservation/settle read. See
+ * GUARD 1's note for the enumeration.
  */
 export function billingModeForSubmittedType(
   orchestratorType: string
@@ -1051,6 +1092,14 @@ export type SubmittedStepDecision = {
  * function of the submitted `$type` and `input` only. That is what makes it
  * unit-testable without a request context, and what lets the registry path call
  * it at module load.
+ *
+ * 🔴 NO PRODUCTION CALLER TODAY — INCLUDING NOT AT LOAD. Enumerated over
+ * `src/**`: every reference outside this file is in `__tests__/`. The registry
+ * path reaches this module through the two `assert*` functions below, which call
+ * guards 1 and 3 directly and never call this composite — which is why GUARD 2
+ * (`screenSubmittedStepResources`) has no live caller at all. That is the
+ * "landed AHEAD of the widening" state the module header describes; it is NOT
+ * evidence that a submit path is gated by these three.
  */
 export function evaluateSubmittedStep(submitted: {
   orchestratorType: string;
@@ -1145,11 +1194,16 @@ export function assertRegistryEntryAgreesWithPolicy(entry: {
  * `$type` → acceptable-postures map, for every `$type` BOTH cover.
  *
  * 🔴 WHY A SEPARATE ASSERT. `assertRegistryEntryAgreesWithPolicy` only sees
- * `$type`s that a registered ENTRY claims — exactly one today (`convertImage`).
- * The registry's map licenses seven `$type`s no entry has yet claimed, and those
- * seven are the ones this module's classification is most likely to get wrong.
- * This walks that whole map instead, so the agreement is checked over the
- * population that matters rather than over the single shipped entry.
+ * `$type`s that a registered ENTRY claims — two today (`convertImage` from
+ * `convert-image`, `chatCompletion` from `chat-completion`). The registry's map
+ * licenses seven `$type`s for `'textOutput'`, six of which no entry has claimed,
+ * and those six are the ones this module's classification is most likely to get
+ * wrong. This walks that whole map instead, so the agreement is checked over the
+ * population that matters rather than over the shipped entries.
+ *
+ * (Counts track `stepRegistry` — an earlier revision said "exactly one today
+ * (`convertImage`)" and "seven no entry has yet claimed", which went stale the
+ * moment `chat-completion` registered. Update them with the registry.)
  *
  * Takes the map as an argument so a test can drive it with a DISAGREEING
  * fixture — a guard only exercised by the shipped constant is a guard nobody has

--- a/src/server/services/blocks/steps/request-time-policy.ts
+++ b/src/server/services/blocks/steps/request-time-policy.ts
@@ -917,9 +917,10 @@ export function postureForTextSurface(surface: StepTextSurface): StepModerationP
  * 🔴 "GUARD" NAMES THE ROLE AFTER THE PIVOT, NOT WHAT RUNS TODAY — READ THIS
  * BEFORE CONCLUDING ANYTHING IS REDUNDANT WITH IT. Nothing on the request path
  * calls this function, or either of the other two guards. Enumerated over
- * `src/**`, not sampled: the only non-test importers of this module are
- * `./index` (a doc reference) and `./moderation`, and `./moderation` imports
- * exactly two names — `assertRegistryEntryAgreesWithPolicy` and
+ * `src/**`, not sampled: outside `__tests__/`, the ONLY file that imports this
+ * module is `./moderation` (`./index` names it in prose only — an actual import
+ * would be the cycle `./moderation` was created to avoid), and `./moderation`
+ * imports exactly two names — `assertRegistryEntryAgreesWithPolicy` and
  * `assertPolicyAgreesWithRegistryMap`, both defined below, both invoked at
  * `./moderation`'s MODULE LOAD. Those two are this guard's only live callers.
  *
@@ -998,9 +999,12 @@ export function requiredPostureForSubmittedType(
  * guards 1 and 3. Neither load-time assert calls it; outside `__tests__/` its
  * only caller is `evaluateSubmittedStep`, which itself has no production caller.
  * It is exercised by tests only until the pivot wires it in. See GUARD 1's note
- * for the enumeration. The entitlement scan that DOES run on live submits is the
- * registry's own clause-7 load probe plus the router's re-assert, both of which
- * call the same `containsAirReference` helper.
+ * for the enumeration. What DOES gate entitlement on a LIVE submit is the
+ * router's re-assert in `blocks.router.ts`'s step submit branch (it throws a
+ * `TRPCError`, so it is request-time); the registry's clause-7 probe runs at
+ * module LOAD, over canonical params only. Both call the same
+ * `containsAirReference` helper this function calls — do not read this
+ * function's dormancy as an unguarded entitlement path.
  */
 export function screenSubmittedStepResources(submitted: {
   orchestratorType: string;
@@ -1094,7 +1098,9 @@ export type SubmittedStepDecision = {
  * it at module load.
  *
  * 🔴 NO PRODUCTION CALLER TODAY — INCLUDING NOT AT LOAD. Enumerated over
- * `src/**`: every reference outside this file is in `__tests__/`. The registry
+ * `src/**`: every CALL outside this file is in `__tests__/`; the only other
+ * mention anywhere is a prose reference in `./index`, which does not import this
+ * module at all. The registry
  * path reaches this module through the two `assert*` functions below, which call
  * guards 1 and 3 directly and never call this composite — which is why GUARD 2
  * (`screenSubmittedStepResources`) has no live caller at all. That is the


### PR DESCRIPTION
Comment-only sweep of the App Blocks step subsystem. Four stale/contradicting comments were reported; verifying them turned up two more of the same class in the same files, so six are fixed here.

**No executable line changed.** Proven structurally, not by inspection: both sides were transpiled with `--removeComments` and the emitted JS diffed — byte-identical across all three files (42.5 KB total). The detector was validated with a positive control (a planted one-token change to a `return` was caught). `pnpm typecheck` produces the **identical 135-error set** before and after (see Verification below), and zero of those errors are in these files.

---

## C1 — `request-time-policy.ts` rebutted a sentence that no longer exists

**Claimed:** the `chatCompletion` row quoted `index.ts` — *"A future orchestrator step that emits BOTH media and free text cannot register at all... Nothing in the currently-licensed `$type` set has that shape."* — and then called that last sentence FALSE.

**What the code actually does:** #3605 (`fce7b918b5`) **deleted** that sentence and replaced it with the correction itself. `stepOutputShape`'s doc now opens *"🔴 AND THE LICENSED SET ALREADY CONTAINS ONE — DO NOT READ THIS AS A FUTURE PROBLEM"* and records the superseded claim in its own words. So the comment quoted text that exists nowhere except inside the retraction, and a reader following the pointer landed on the opposite of what the quote set up.

**Corrected to:** state the finding directly (`chatCompletion` is in the licensed set and is dual-shaped as of `@civitai/client` 0.2.0-beta.83), point at `stepOutputShape` as the single place that finding lives, and add an explicit *do not re-add a rebuttal here* so the loop does not reopen. Also carries forward the load-bearing part: what keeps the XOR true is the entry's `.strict()` `paramSchema` omitting `modalities`, not the `$type` set.

## C2 — `index.ts` posture union claimed `'textOutput'` was unimplemented

**Claimed** (block comment at the head of `StepModerationPosture`): *"The free-text OUTPUT half (`'textOutput'`) is still unanswered and still fails at load."*

**What the code actually does — four independent contradictions:**
- `isModerationPostureImplemented` returns `true` for `'textOutput'`
- the `'textOutput'` member's own docstring, **20 lines below**, says "IMPLEMENTED, in the OUTPUT phase"
- the output handler exists in `moderation.ts`
- `chat-completion` is registered (`stepRegistry`) declaring `moderationPosture: 'textOutput'` — if the posture failed at load, the module would not load

This mattered because it sits in the block a reader reaches **first** when opening the union, while the correct statement is 20 lines further down. A stale summary above a correct member doc is read as the summary.

**Corrected to:** both halves answered, all three postures implemented, nothing in the union fails at load — each claim tied to the specific thing that proves it. Retains a note recording the false claim so the next person editing does not re-derive it.

> **Second commit — my own replacement text overclaimed.** The first draft said `'textOutput'` "withholds on a policy hit **AND on any scanner failure**". That universal is false on this tree, and it was caught in review. See "Self-correction" below.

## C3 — 🔴 `moderation.ts` `appBlockId` — **VERDICT: a real telemetry defect, not a doc defect**

**This is the one that needs a decision from you.** The comment was wrong *and* the call sites are wrong, independently.

**Claimed:** `/** The block instance id, when the caller has one. */`

**What the code actually does:**

The token carries **three** distinct identifiers, and the doc named a fourth reading that matches none of them:

| claim | value | source |
|---|---|---|
| `appId` | `OauthClient.id` | — |
| `appBlockId` | `AppBlock.id` — the `apb_<ulid>` PK | `block-scope.middleware.ts:42-49` |
| `blockId` | `AppBlock.blockId` — the publish request's **slug** | `publish-request.service.ts:2392-2398` |
| `blockInstanceId` | the per-render instance — *what the comment described* | separate claim |

`publish-request.service.ts:2392-2398` writes `id: apb_${newUlid()}` and `blockId: request.slug` onto the **same row**, so these are provably different namespaces, not aliases.

**The defect:** `blocks.router.ts` `pollWorkflow` (`:3108`) and `cancelWorkflow` (`:3252`) both pass `appBlockId: claims.blockId`. These are the **only 2 of that router's ~15 `appBlockId:` assignments** that read `claims.blockId`; the other ~13 read `claims.appBlockId`.

**Consequence:** the value flows to exactly one consumer — `logScan`'s Axiom event `block-step-text-output-moderation` in `text-output-moderation.ts`. No DB write, no FK, so nothing rejects it and it fails silently. But `text-output-moderation.ts:595` documents that log as *"THE PER-APP TRIGGER LOG. `(userId, appBlockId, model, triggeredLabels, scores)` per the approved policy"* — i.e. the field is there to key per-app trigger-rate aggregation. **A slug logged under `appBlockId` does not join to `AppBlock.id` or `BlockScopeInvocation.app_block_id`.** Text-output moderation trigger rates aggregated on that field are therefore not joinable to the app they came from.

**Severity:** telemetry/analytics only. No moderation decision, spend decision, or user-visible behaviour reads this field — the withhold verdict is computed entirely without it. Not urgent, but it is a real bug and it silently degrades the exact per-app signal the field was added for.

**Not fixed here** — the fix is a two-line change in `blocks.router.ts`, which is outside this PR's ownership and is being touched by other work. This PR only makes the comment describe reality and records the mismatch at the field, explicitly noting that renaming the field to match what is passed would make the log self-consistent and *still* un-joinable. **Wants a follow-up PR changing `claims.blockId` → `claims.appBlockId` at `:3108` and `:3252`.**

## C4 — `request-time-policy.ts` "GUARD" headers read as live request-path gates

**Claimed:** section headers "GUARD 1 — MODERATION POSTURE", "GUARD 2 — RESOURCE / ENTITLEMENT POLICY", "GUARD 3 — BILLING MODE", in a module named `request-time-policy`.

**What the code actually does** — enumerated over `src/**`, not sampled:

- The **only** non-test importer of this module is `moderation.ts`. (`index.ts` mentions it in prose only; an actual import would be a cycle, which `moderation.ts:372-379` explains is why the asserts live there.)
- `moderation.ts` imports exactly two names: `assertRegistryEntryAgreesWithPolicy` and `assertPolicyAgreesWithRegistryMap`, both invoked at **module load** (`moderation.ts:394-402`).
- `requiredPostureForSubmittedType` (GUARD 1) and `billingModeForSubmittedType` (GUARD 3): live callers are those two load-time asserts only.
- `screenSubmittedStepResources` (GUARD 2): **no live caller at all** — neither assert calls it; outside `__tests__/` its only caller is `evaluateSubmittedStep`.
- `evaluateSubmittedStep` (the composite gate): **zero production callers** — every reference outside the file is in `__tests__/`.

> Note: the original report said the two load-time asserts were the live consumers of all four functions. Guard 2 and the composite gate are actually stricter than that — they have no live consumer whatsoever. The corrected comments say so.

The module header at `:21-26` was already honest about this, but the section names are what a reader scanning the file sees. The risk is a future reviewer concluding the registry's own clauses are redundant with guards that never run — deleting a registry clause on that basis would remove the only live enforcement and leave the assert.

**Corrected to:** one authoritative note on GUARD 1 carrying the enumeration and the "do not treat registry clauses as redundant" warning, with short pointers on guards 2 and 3 and on the composite gate. Function names unchanged (renaming exports is a wider change). Each header now also names what *does* enforce that rule on a live submit — e.g. for entitlement, the registry's clause-7 load probe plus `blocks.router.ts:6942`, both calling the same `containsAirReference` helper.

## C5 + C6 — two registered-entry counts went stale when `chat-completion` landed

Found while verifying C4; same defect class, same files.

- `request-time-policy.ts` `assertPolicyAgreesWithRegistryMap` said `assertRegistryEntryAgreesWithPolicy` sees *"exactly one today (`convertImage`)"* and that the map licenses *"seven `$type`s no entry has yet claimed"*. `stepRegistry` now holds **two** entries (`convert-image` → `convertImage`, `chat-completion` → `chatCompletion`), and of the 7 licensed `$type`s, `chatCompletion` is now claimed — so **six** are unclaimed.
- `moderation.ts:390-391` carried the same "only the one `$type`" claim.

Both corrected, with a note that the counts track `stepRegistry` and must move with it.

---

## Self-correction (commit 2) — three overclaims in commit 1's own new text

Flagged in review and verified against the code before fixing. Same defect class this PR exists to fix, so they are corrected here rather than shipped.

**1. 🔴 "withholds on any scanner failure" was FALSE — there is a live fail-open.**

`XGuardLabelResult` (generated client) carries `error?: null | string`. But `XGuardLabelResultLike` — the shape the policy actually reads — declares only `label` / `score` / `triggered`, and `decideTextOutputVerdict` reads only those three. So a label the scanner **attempted and failed on**:
- contributes nothing to the trigger set (`triggered` is not `true`), **and**
- suppresses the drift guard, because `missingRequestedLabels` counts an entry as "evaluated" on a non-empty `label` alone

⇒ a scan in which all 15 `TEXT_OUTPUT_SCAN_LABELS` errored is **indistinguishable from all-clean and RELEASES**.

Replaced the universal with the set that genuinely withholds today — scan throw / hard deadline (`stage: 'error'`), no scan output incl. `SCAN_WAIT_SECONDS` elapsed (`stage: 'no-verdict'`), over `MAX_SCANNED_CONTENT_CHARS` (`stage: 'over-cap'`, checked before both the network call and the memo), a requested label absent from `results[]` (`stage: 'label-drift'`), and a non-array / non-string `extractText` return (guarded in `moderation.ts`). Each named **by symbol, not line number**, so the list does not rot when that file moves.

The errored-label fail-open is recorded as a **KNOWN GAP, open in this tree**. Deliberately *not* written as fixed, and *not* written as pending on any other change — a comment whose truth depends on another PR's merge order is the same defect one level up. A separate PR is addressing the fail-open itself; this PR does not touch `text-output-moderation.ts`. The note tells the reader to re-read `decideTextOutputVerdict` before trusting it in **either** direction.

**2. GUARD 2 conflated two phases.** It said the live-submit entitlement scan is "the registry's clause-7 load probe plus the router's re-assert". The clause-7 probe (`index.ts`) runs at **module load** over canonical params; only the router's re-assert is request-time — it throws `TRPCError`, which is what distinguishes it. Corrected.

**3. Two enumeration claims were wider than what I measured.** I called `./index` a non-test "importer" of `request-time-policy` (it does not import it at all — that would be the cycle `moderation.ts` exists to avoid; it only names it in prose), and said every reference to `evaluateSubmittedStep` outside the file is in `__tests__/` (there is also a prose mention at `index.ts:405`). Both narrowed to the measured claim: every *call* is in `__tests__/`.

## Verification

- **Comment-only:** base (`0ec1c4b9bc`) and HEAD transpiled with `tsc --removeComments`, emitted JS diffed → **identical** (42,500 bytes both sides). Positive control: a planted `return posture === 'promptAudit'` → `'textOutput'` change was caught by the same detector. A second, independent line-shape check found zero changed lines that are not comments (its detector was likewise control-tested against real code lines). **Both re-run after the second commit.**
- **Typecheck:** `pnpm typecheck` run on the unmodified base and on HEAD. **135 errors both times, identical sets** (compared after stripping control bytes — the raw logs carry NULs that make `diff` report "binary files differ", and `cmp` was used as a differently-failing cross-check). **Zero** errors name any file in this PR. To be explicit: `pnpm typecheck` does **not** exit 0 in this environment, at base or at HEAD — the 135 pre-existing errors are all `CosmeticType` / `"Sticker"` Prisma enum drift between the generated client and `packages/civitai-db-schema`, unrelated to this change and present before it.
- **Prettier:** clean on all three files. Checked with a real shell array; the instrument was validated first — a deliberately misformatted copy was flagged, and the quoted-space-separated-string form was confirmed to match zero files while printing "All matched files use Prettier code style!".
- **No tests run.** Nothing executable changed, so there is no behaviour to exercise; that is a deliberate omission, not an oversight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R7ZCxbgcsv3WfsSJrYdSCi
