### PR TITLE
fix(app-blocks): make the AIR-scan rejection legible for chat-completion prose (no enforcement change)

### DIFF
--- a/src/server/routers/__tests__/blocks.router.workflow.test.ts
+++ b/src/server/routers/__tests__/blocks.router.workflow.test.ts
@@ -7004,7 +7004,8 @@ describe("step-type registry bridge (kind: 'step')", () => {
         // so a code-only assertion would be satisfied by the wrong guard and
         // would survive deleting this one.
         message: expect.stringContaining(
-          "declares resourcePolicy 'none' but the submitted step carries an AIR reference"
+          "declares resourcePolicy 'none' but the submitted step contains the literal text " +
+            "'urn:air:'"
         ),
       });
       // Rejected BEFORE the free quote, so not even the whatIf round-trip fired.
@@ -7026,6 +7027,111 @@ describe("step-type registry bridge (kind: 'step')", () => {
           params: {
             image: 'https://image.civitai.com/sdxl:checkpoint:civitai:4384@128713.png',
             output: { format: 'webp' },
+          },
+        }),
+      });
+      expect(result.snapshot.status).toBe('processing');
+      expect(realSubmitCalls()).toHaveLength(1);
+    });
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // 🔴 THE SAME GUARD, REACHED THROUGH PROSE — `chat-completion`.
+    //
+    // WHY THIS PAIR EXISTS. `convert-image` (above) scans urls the APP builds;
+    // `chat-completion` submits `messages[].content`, free text an END USER
+    // typed, and that is the ONLY string in its built input a caller controls
+    // (`model` is `z.enum`-bounded, `maxTokens`/`temperature` are numbers, every
+    // key is a fixed literal). So for that entry the guard is exactly "reject a
+    // chat message containing the literal `urn:air:`" — a user asking what an
+    // AIR is gets a hard FORBIDDEN. That is a genuine false positive, and these
+    // tests PIN IT AS DELIBERATE rather than fixing it: see the FALSE-POSITIVE
+    // SURFACE section in `chat-completion.step.ts` for the orchestrator-side
+    // evidence that such prose is inert today and for why that evidence is not
+    // sufficient to scope the scan.
+    //
+    // 🔴 LABELLING, HONESTLY. The REJECTION is an invariant guard — it was
+    // FORBIDDEN before this change too, and it stays green if the guard's
+    // scoping is left alone. What is regression coverage is the MESSAGE: the
+    // old one asserted the step "carries an AIR reference", which is false for
+    // prose, and this assertion is RED against that wording. Do not read the
+    // first test as proof the scan changed; read it as the intent being written
+    // down where the next person to touch this guard will see it.
+    // ─────────────────────────────────────────────────────────────────────────
+    it('PROSE containing the literal is rejected — the chat-completion false positive, pinned as deliberate', async () => {
+      mockVerifyBlockToken.mockResolvedValue(stepClaims());
+      happyUser();
+      happyStepSubmit();
+      await expect(
+        caller().submitWorkflow({
+          blockToken: 'tok',
+          body: stepBody({
+            step: 'chat-completion',
+            params: {
+              model: 'openai/gpt-4o-mini',
+              // Not an AIR. A question ABOUT the scheme — the shape of message
+              // a chat block's user actually types.
+              messages: [{ role: 'user', content: 'what does urn:air: mean?' }],
+              maxTokens: 128,
+            },
+          }),
+        })
+      ).rejects.toMatchObject({
+        code: 'FORBIDDEN',
+        // 🔴 The MESSAGE, not just the code — several other seams on this path
+        // also reject with FORBIDDEN, so a code-only assertion would be
+        // satisfied by the wrong guard. It must also say the check is a
+        // SUBSTRING scan, which is the part that makes the rejection
+        // self-diagnosable by the app rather than reading as a platform bug.
+        message: expect.stringContaining(
+          "step 'chat-completion' declares resourcePolicy 'none' but the submitted step " +
+            "contains the literal text 'urn:air:'"
+        ),
+      });
+      await expect(
+        caller().submitWorkflow({
+          blockToken: 'tok',
+          body: stepBody({
+            step: 'chat-completion',
+            params: {
+              model: 'openai/gpt-4o-mini',
+              messages: [{ role: 'user', content: 'what does urn:air: mean?' }],
+              maxTokens: 128,
+            },
+          }),
+        })
+      ).rejects.toMatchObject({ message: expect.stringContaining('SUBSTRING scan') });
+      // Rejected BEFORE the free quote, so not even the whatIf round-trip fired.
+      expect(mockSubmitWorkflow).not.toHaveBeenCalled();
+      expect(mockReserveAppSpend).not.toHaveBeenCalled();
+      expect(mockRefundAppSpend).not.toHaveBeenCalled();
+    });
+
+    it('the SAME chat message without the literal is accepted (it is the literal, not the entry)', async () => {
+      // 🔴 The NEGATIVE CONTROL. Without it, a harness in which EVERY
+      // `chat-completion` submit failed — a bad fixture, a mis-set token, an
+      // unregistered id — would pass the test above just as well, and the pair
+      // would prove nothing about the literal being what was detected.
+      mockVerifyBlockToken.mockResolvedValue(stepClaims());
+      happyUser();
+      mockSubmitWorkflow.mockImplementation(async (opts: { query?: { whatif?: boolean } }) =>
+        opts?.query?.whatif === true
+          ? { id: 'wf_quote', status: 'unassigned', steps: [], cost: { total: 1 } }
+          : {
+              id: 'wf_chat_1',
+              status: 'processing',
+              steps: [{ $type: 'chatCompletion', output: {} }],
+              cost: { total: 1 },
+            }
+      );
+      const result = await caller().submitWorkflow({
+        blockToken: 'tok',
+        body: stepBody({
+          step: 'chat-completion',
+          params: {
+            model: 'openai/gpt-4o-mini',
+            // Byte-identical to the rejected message minus the literal.
+            messages: [{ role: 'user', content: 'what does air mean?' }],
+            maxTokens: 128,
           },
         }),
       });

--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -148,6 +148,7 @@ import { getRecipe, recipeCivitaiVersionIds } from '~/server/services/blocks/rec
 // runs; imported (not re-implemented) so the request-time re-assertion below can
 // never drift from the load-time one — one rule, one place.
 import {
+  AIR_URN_PREFIX,
   containsAirReference,
   estimateStepBuzz,
   getStep,
@@ -6934,6 +6935,22 @@ async function submitStepWorkflow(opts: {
   // pathological url costs a caller one bounced request; forwarding an
   // unentitled AIR costs the entitlement belt.
   //
+  // 🔴 THAT COST SENTENCE WAS WRITTEN WHEN EVERY SCANNED STRING WAS A URL THE
+  // APP CONSTRUCTS, AND IT NO LONGER DESCRIBES EVERY ENTRY. `chat-completion`
+  // (registered later) submits `messages[].content` — free prose an END USER
+  // typed — and that prose is the ONLY attacker-controlled string in its built
+  // input; `model` is `z.enum`-bounded and every key is a fixed literal. So for
+  // that entry this guard reduces exactly to "reject any chat message
+  // containing the literal `urn:air:`", and the bounced request is the user's
+  // message rather than the app's own url. The guard is KEPT anyway — see the
+  // FALSE-POSITIVE SURFACE section in `chat-completion.step.ts` for the
+  // orchestrator-side evidence that such prose is inert today, why that
+  // evidence is not sufficient to scope the scan, and the app-side workaround.
+  // What changed here is only the MESSAGE: it used to assert the submitted step
+  // "carries an AIR reference", which is FALSE for prose — the caller typed a
+  // fragment, not a reference — so the rejection read as a platform bug rather
+  // than as something the app can fix in its own payload.
+  //
   // "Anywhere" covers object KEYS as well as values — the orchestrator's own
   // `additionalNetworks` / `WorkflowCost.fees` shapes are AIR-KEYED maps, and
   // the scan used to recurse over `Object.values` only. See
@@ -6943,9 +6960,13 @@ async function submitStepWorkflow(opts: {
     throw new TRPCError({
       code: 'FORBIDDEN',
       message:
-        `step '${step.id}' declares resourcePolicy 'none' but the submitted step carries an ` +
-        'AIR reference — a step that reaches an AIR resource bypasses the generation-graph ' +
-        'entitlement belt',
+        `step '${step.id}' declares resourcePolicy 'none' but the submitted step contains the ` +
+        `literal text '${AIR_URN_PREFIX}' — a step that reaches an AIR resource bypasses the ` +
+        'generation-graph entitlement belt. The check is a case-insensitive SUBSTRING scan ' +
+        'over every string, array element, object value AND object key in the step input; it ' +
+        'does not parse, so a value that merely EMBEDS that literal — a url whose path ' +
+        'contains it, or free text a user typed — is rejected too. That is the deliberate ' +
+        'fail-closed direction: strip or escape the literal in the params you submit.',
     });
   }
 

--- a/src/server/services/blocks/steps/__tests__/chat-completion.step.test.ts
+++ b/src/server/services/blocks/steps/__tests__/chat-completion.step.test.ts
@@ -331,6 +331,87 @@ describe('chat-completion — buildStep', () => {
       expect(containsAirReference(built.input)).toBe(false);
     }
   });
+
+  // ───────────────────────────────────────────────────────────────────────────
+  // 🔴 `messages[].content` IS THE ONLY AIR-SCANNABLE SURFACE THIS ENTRY HAS,
+  // AND IT IS PROSE.
+  //
+  // The request-time re-assert in `blocks.router.ts` runs `containsAirReference`
+  // over the WHOLE built input. This pins WHICH part of that input a caller can
+  // actually steer, because that is the fact the guard's cost/benefit rests on:
+  // for this entry the guard reduces to "reject a chat message containing the
+  // literal `urn:air:`". The FALSE-POSITIVE SURFACE section in
+  // `../chat-completion.step.ts` carries the evidence and the decision.
+  //
+  // 🔴 LABELLED AS AN INVARIANT GUARD, NOT REGRESSION COVERAGE — it is green
+  // before and after the change that introduced it. It exists so that a future
+  // edit widening the schema (a free-string `user`, a `stop` array, content
+  // PARTS carrying `imageUrl`) fails here and forces the analysis to be redone,
+  // rather than silently invalidating it.
+  // ───────────────────────────────────────────────────────────────────────────
+  it('🔴 prose in messages[].content is the ONLY caller-steerable string the AIR scan sees', () => {
+    const air = 'urn:air:sdxl:checkpoint:civitai:4384@128713';
+
+    // (a) The literal in PROSE trips the scan — a question ABOUT the scheme is
+    //     enough; it does not have to be a well-formed AIR.
+    expect(
+      containsAirReference(
+        chatCompletionStep.buildStep({
+          ...VALID_PARAMS,
+          messages: [{ role: 'user', content: 'what does urn:air: mean?' }],
+        }).input
+      )
+    ).toBe(true);
+    expect(
+      containsAirReference(
+        chatCompletionStep.buildStep({
+          ...VALID_PARAMS,
+          messages: [
+            { role: 'system', content: 'be helpful' },
+            { role: 'user', content: `is ${air} any good?` },
+          ],
+        }).input
+      )
+    ).toBe(true);
+
+    // (b) NEGATIVE CONTROL for (a): the same prose minus the literal does NOT
+    //     trip it, so (a) is about the literal and not about `messages` being
+    //     scanned at all.
+    expect(
+      containsAirReference(
+        chatCompletionStep.buildStep({
+          ...VALID_PARAMS,
+          messages: [{ role: 'user', content: 'what does air mean?' }],
+        }).input
+      )
+    ).toBe(false);
+
+    // (c) NOTHING ELSE in the built input can carry it. The keys are fixed
+    //     literals, `role` is a three-value enum, and the two numeric params
+    //     cannot hold a string — so every remaining field is enumerated here
+    //     with a caller-chosen extreme value and none of them trips the scan.
+    for (const model of CHAT_COMPLETION_MODELS) {
+      expect(
+        containsAirReference(
+          chatCompletionStep.buildStep({
+            model,
+            messages: [{ role: 'assistant', content: 'ok' }],
+            maxTokens: CHAT_COMPLETION_MAX_OUTPUT_TOKENS,
+            temperature: 2,
+          }).input
+        )
+      ).toBe(false);
+    }
+
+    // (d) …and `model` is the one field the ORCHESTRATOR does resolve as an AIR
+    //     (`ChatCompletionHandler.CalculateCostAsync` branches on
+    //     `input.Model.StartsWith("urn:air:")`). The `z.enum` is what keeps that
+    //     branch unreachable, so assert no allowlisted model is an AIR — if one
+    //     ever is, this entry needs a real `resourcePolicy`, not a `'none'`.
+    for (const model of CHAT_COMPLETION_MODELS) {
+      expect(model.toLowerCase().includes('urn:air:')).toBe(false);
+    }
+  });
 });
 
 describe('chat-completion — price and estimate', () => {

--- a/src/server/services/blocks/steps/chat-completion.step.ts
+++ b/src/server/services/blocks/steps/chat-completion.step.ts
@@ -21,7 +21,10 @@ import type { BlockStep, OrchestratorStepTemplate } from './index';
 //  3. A FREE-TEXT OUTPUT, WITH A POSTURE THAT COVERS IT. This is the whole
 //     reason the entry could not be written until `'textOutput'` existed. The
 //     generated reply is scanned at the READ boundary by `./moderation`'s output
-//     phase and withheld on a policy hit or on any scanner failure.
+//     phase and withheld on a policy hit or on one of the specific failure modes
+//     enumerated below — see WHAT ACTUALLY WITHHOLDS. It is NOT withheld on
+//     "any scanner failure"; that phrasing was wrong and one real gap sits
+//     inside it.
 //
 //  4. NO AIR RESOURCE. `ChatCompletionInput.model` is a plain provider id
 //     ("gpt-4o"), NOT an AIR URN, so there is nothing for the entitlement belt
@@ -56,6 +59,49 @@ import type { BlockStep, OrchestratorStepTemplate } from './index';
 // never meets `auditPromptServer`, so it produces no `BlockedPromptEntry` and no
 // violation counter. Closing it needs a registry-level decision about
 // multi-surface postures, not a workaround here.
+//
+// 🔴 WHAT ACTUALLY WITHHOLDS — AN ENUMERATION, BECAUSE THE UNIVERSAL WAS FALSE.
+// This header and the `moderationPosture` field both used to say the reply is
+// withheld "on any scanner failure". That is NOT true of the shipped code, and
+// a comment claiming a stronger safety property than the implementation is the
+// thing a maintainer deletes a guard on the strength of. Read off
+// `./text-output-moderation` and `./moderation` rather than restated from
+// intent, the OUTPUT phase withholds on exactly these:
+//
+//   1. `stage: 'error'` — the scan call THREW, or `withHardDeadline` fired.
+//   2. `stage: 'no-verdict'` — no `xGuardModeration` step output came back:
+//      either the submit itself failed (resolves `undefined`) or the workflow
+//      was still running when the `wait` window elapsed.
+//   3. `stage: 'over-cap'` — the joined content exceeds
+//      `MAX_SCANNED_CONTENT_CHARS` (50,000). Checked BEFORE the network call
+//      and before the memo, so an over-cap payload cannot be answered from a
+//      cache hit either. (This is the constant `CHAT_COMPLETION_MAX_OUTPUT_TOKENS`
+//      below is derived from.)
+//   4. `stage: 'label-drift'` — a REQUESTED label came back with no `results[]`
+//      entry at all (`missingRequestedLabels`), even when nothing triggered.
+//   5. The extractor returned a non-array, or an array containing a non-string
+//      — caught in `./moderation`'s `textOutput.output` phase before any scan.
+//
+//   …plus the ordinary `stage: 'withheld'`: a policy-actioned label triggered
+//   (an always-withhold label at any ceiling, or an SFW-only label under a green
+//   ceiling). Note an EMPTY extraction is a RELEASE of zero texts, not a
+//   withhold — nothing unscanned reaches the block, so there is no hazard in
+//   that direction.
+//
+// 🔴 KNOWN GAP INSIDE THE OLD PHRASE — A PER-LABEL `error` RELEASES. The
+// generated `XGuardLabelResult` carries `error?: null | string`, i.e. the
+// scanner can report that it ATTEMPTED a label and FAILED on it. This side's
+// read shape `XGuardLabelResultLike` declares only `label` / `score` /
+// `triggered`, and `decideTextOutputVerdict` reads only those three. So an
+// errored label: contributes nothing to `triggered`; still carries a `label`,
+// so it lands in the `evaluated` set and the drift guard in (4) does NOT fire;
+// and the verdict RELEASES. A label the scanner could not answer is therefore
+// indistinguishable from a clean one — the fail-OPEN shape that
+// `missingRequestedLabels` closes on the RENAME axis and does not close here.
+// Stated as an OPEN gap on the tree this commit produces. A fix is in flight as
+// #3609 and lives in `./text-output-moderation`; if you are reading this after
+// that merged, re-derive this paragraph from the code rather than assuming it
+// is stale — and delete it only once `error` is actually read.
 //
 // 🔴 THE AIR SCAN'S FALSE-POSITIVE SURFACE — FOR THIS ENTRY IT IS PURE PROSE,
 // AND THE GUARD IS KEPT ANYWAY. READ THIS BEFORE PROPOSING TO SCOPE IT.
@@ -366,8 +412,9 @@ export const chatCompletionStep = {
   orchestratorType: 'chatCompletion',
   billingMode: 'prepaidFixed',
   // The free-text OUTPUT posture. Scanned at the read boundary by
-  // `./moderation`'s output phase, withheld on a hit and on any scanner failure.
-  // See the KNOWN GAP note in the header for what this posture does NOT cover.
+  // `./moderation`'s output phase, withheld on a policy hit and on the five
+  // failure modes enumerated in the header's WHAT ACTUALLY WITHHOLDS section —
+  // NOT on "any scanner failure"; a per-label `error` currently RELEASES.
   moderationPosture: 'textOutput',
   // `ChatCompletionInput.model` is a plain provider id, never an AIR URN, so
   // there is no way to reach a gated / early-access / Private model version

--- a/src/server/services/blocks/steps/chat-completion.step.ts
+++ b/src/server/services/blocks/steps/chat-completion.step.ts
@@ -56,6 +56,63 @@ import type { BlockStep, OrchestratorStepTemplate } from './index';
 // never meets `auditPromptServer`, so it produces no `BlockedPromptEntry` and no
 // violation counter. Closing it needs a registry-level decision about
 // multi-surface postures, not a workaround here.
+//
+// 🔴 THE AIR SCAN'S FALSE-POSITIVE SURFACE — FOR THIS ENTRY IT IS PURE PROSE,
+// AND THE GUARD IS KEPT ANYWAY. READ THIS BEFORE PROPOSING TO SCOPE IT.
+//
+// `resourcePolicy: { kind: 'none' }` is enforced twice: at registry load
+// (clause 7, over `buildStep(canonicalParamsFor(v))`) and again at request time
+// in `blocks.router.ts` over the input this entry actually builds.
+// `containsAirReference` is a case-insensitive SUBSTRING test for `urn:air:`
+// across every string, array element, object value and object KEY.
+//
+// `buildStep` emits exactly `{ model, messages, maxTokens, temperature? }`
+// (pinned by the exact-key-set test in `__tests__/chat-completion.step.test.ts`).
+// `model` is `z.enum`-bounded to `CHAT_COMPLETION_MODELS`, `maxTokens` and
+// `temperature` are numbers, every key is a fixed literal, and `role` is a
+// three-value enum. So **`messages[].content` is the only string in the built
+// input that an untrusted iframe can put arbitrary text into** — and it is
+// human prose, forwarded from whatever an end user typed into a chat block.
+// This entry is the FIRST whose scanned strings are prose; every earlier one
+// (`convert-image`) scanned urls the APP constructs. For this entry the guard
+// therefore reduces exactly to: reject any chat message containing the literal
+// `urn:air:`. A user asking "what does urn:air: mean?" gets a hard FORBIDDEN.
+//
+// WHAT THE ORCHESTRATOR ACTUALLY DOES WITH THAT PROSE — read from
+// `civitai/civitai-orchestration` at `origin/main` e9ce862cb, not assumed:
+//   * `ChatCompletionContentPartJsonConverter.Read` turns a JSON string content
+//     into a single `ChatCompletionContentPart { Text = s, ImageUrl = null }`,
+//     so string content can never enter the image path at all.
+//   * `ChatCompletionInput.OnInitializedAsync` is the only lifecycle hook that
+//     walks `Messages`, and it acts solely on `part.ImageUrl` (handing it to
+//     `ISourceImageProcessor`). It never reads `part.Text`.
+//   * `ChatCompletionHandler.CalculateCostAsync` holds the ONLY `urn:air:` test
+//     in the whole chat step — `input.Model.StartsWith("urn:air:")`, which
+//     selects the AIR-model cost branch. It is a test of `Model`, never of
+//     `Messages`, and this entry's `z.enum` makes that branch unreachable.
+//   * `GenerateJobsAsync` copies `input.Messages` verbatim onto
+//     `ChatCompletionJob` for the worker.
+// i.e. an AIR inside `messages[].content` is inert text on that revision — it
+// resolves no resource and reaches no entitlement-bearing field.
+//
+// 🔴 WHY THAT IS STILL NOT ENOUGH TO SCOPE THE SCAN. That paragraph is a claim
+// about the CURRENT source of a SEPARATELY DEPLOYED service. Nothing in this
+// repo can hold it true: the generated `@civitai/client` types encode the SHAPE
+// of `ChatCompletionInput`, never which of its fields get resolved, so an
+// orchestrator change that started resolving AIRs mentioned in prompt text
+// would turn a per-entry "don't scan `messages`" exemption into a silent
+// entitlement bypass with nothing going red on this side. The worker that
+// finally receives `ChatCompletionJob.Messages` lives outside that repo and was
+// not read at all. The asymmetry decides it: a false positive costs ONE bounced
+// message and is fixable BY THE APP — `messages[].content` is assembled by the
+// block, which can strip or escape the literal before submitting — while an
+// entitlement bypass is not recoverable by anyone. So the scan stays total, and
+// the router's rejection message now says plainly that it matched a literal
+// substring rather than claiming the step "carries an AIR reference".
+//
+// If you do scope it later, the narrow shape is a per-entry declaration that
+// DEFAULTS to scan-everything, and it owes evidence that survives the paragraph
+// above — not a re-reading of the same orchestrator source.
 // ─────────────────────────────────────────────────────────────────────────────
 
 /**

--- a/src/server/services/blocks/steps/index.ts
+++ b/src/server/services/blocks/steps/index.ts
@@ -394,8 +394,16 @@ export function isResourcePolicyImplemented(policy: StepResourcePolicy): boolean
   return policy.kind === 'none';
 }
 
-/** The AIR URN scheme prefix. Lowercase; the scan lowercases its input. */
-const AIR_URN_PREFIX = 'urn:air:';
+/**
+ * The AIR URN scheme prefix. Lowercase; the scan lowercases its input.
+ *
+ * EXPORTED so the request-time rejection in `blocks.router.ts` can NAME the
+ * literal it matched on rather than restating it. That message is the only
+ * diagnostic an app author gets for a bounced submit, and a hardcoded second
+ * copy of this string would eventually name a literal the scan no longer uses —
+ * a diagnostic that is confidently wrong is worse than none.
+ */
+export const AIR_URN_PREFIX = 'urn:air:';
 
 /**
  * Recursion budget for {@link containsAirReference}.


### PR DESCRIPTION
## The defect

`containsAirReference` (`src/server/services/blocks/steps/index.ts`) is a **case-insensitive SUBSTRING** test for `urn:air:` across every string, array element, object value **and object key** of a step's built input. The request-time re-assert in `blocks.router.ts` runs it over `built.input` whenever an entry declares `resourcePolicy: { kind: 'none' }`.

`chat-completion` is the **first registered entry whose scanned strings are prose**. Its `buildStep` emits exactly `{ model, messages, maxTokens, temperature? }` — `model` is `z.enum`-bounded to three provider ids, `maxTokens`/`temperature` are numbers, `role` is a three-value enum, every key is a fixed literal. So **`messages[].content` is the only string in that input a caller can steer**, and it is free text an end user typed into a chat block.

For that entry the guard therefore reduces exactly to *"reject any chat message containing the literal `urn:air:`"*. A user asking **"what does urn:air: mean?"** gets a hard `FORBIDDEN` — and the message asserted the submitted step *"carries an AIR reference"*, which is **false for prose**: the caller typed a fragment, not a reference. The rejection read as a platform bug rather than as something the app can fix in its own payload.

The guard's rationale comments were written when every scanned string was a URL the *app* constructs, where "a bounced request costs a caller one request" is true. It isn't the same trade when the bounced request is the *user's message*.

This is **live on `main` today**, not hypothetical — see the test matrix: the new prose test fails at base carrying this guard's own error text.

## What I investigated, and why I did NOT scope the scan

The crux: *is an AIR inside `messages[].content` resolvable by the orchestrator as a resource reference, or is it inert text forwarded to an LLM?*

Read from `civitai/civitai-orchestration` at `origin/main` `e9ce862cb` (not inferred from the generated client types):

- `ChatCompletionContentPartJsonConverter.Read` turns a JSON **string** content into a single `ChatCompletionContentPart { Text = s, ImageUrl = null }` — string content can never enter the image path.
- `ChatCompletionInput.OnInitializedAsync` is the **only** lifecycle hook that walks `Messages`, and it acts solely on `part.ImageUrl` (handing it to `ISourceImageProcessor`). It never reads `part.Text`.
- `ChatCompletionHandler.CalculateCostAsync` holds the **only** `urn:air:` test in the whole chat step — `input.Model.StartsWith("urn:air:")`, selecting the AIR-model cost branch. It tests `Model`, never `Messages`, and this entry's `z.enum` makes that branch unreachable.
- `GenerateJobsAsync` copies `input.Messages` **verbatim** onto `ChatCompletionJob` for the worker.

So on that revision an AIR in `messages[].content` is inert — it resolves no resource and reaches no entitlement-bearing field.

**That is still not sufficient to scope the guard**, and I deliberately shipped no weakening:

1. It is a claim about the **current source of a separately deployed service**. Nothing in this repo can hold it true — the generated `@civitai/client` types encode the *shape* of `ChatCompletionInput`, never which of its fields get **resolved**. An orchestrator change that started resolving AIRs mentioned in prompt text would turn a per-entry "don't scan `messages`" exemption into a silent entitlement bypass with **nothing going red on this side**.
2. The worker that finally receives `ChatCompletionJob.Messages` lives outside that repo and **was not read at all**.
3. The asymmetry decides it: the false positive costs **one bounced message and is fixable by the app** — `messages[].content` is assembled by the block, which can strip or escape the literal before submitting — while an entitlement bypass is not recoverable by anyone.

I also considered and rejected tightening `containsAirReference` from a substring test to an AIR-grammar parse: that weakens the guard for *every* entry and introduces a parser differential against whatever the orchestrator accepts — strictly the wrong trade.

## The fix (legibility only — enforcement is unchanged)

- **`blocks.router.ts`** — the `FORBIDDEN` message now names the literal it matched, states that the check is a case-insensitive substring scan over every string/array element/object value/object key that **does not parse**, that a value merely *embedding* the literal is rejected too, and that the caller should strip or escape it. The false "carries an AIR reference" claim is gone.
- **`steps/index.ts`** — `AIR_URN_PREFIX` is now exported (one line, plus a docstring) so the message names the literal the scan actually uses instead of keeping a second hardcoded copy that would eventually drift. **No change to `containsAirReference` or to any enforcement.**
- **`chat-completion.step.ts`** — comment-only: a `FALSE-POSITIVE SURFACE` section recording that `messages[].content` is the entry's only scannable surface, the orchestrator-side evidence above, why that evidence is not sufficient to scope the scan, the app-side workaround, and what a future scoping would owe.

## Test matrix

Run with `vitest run --project unit`. **Base** = the same test files against `origin/main` source (the three source files reverted, tests kept).

| Test | Base | HEAD | Label |
|---|---|---|---|
| `a built step that smuggles an AIR is rejected at SUBMIT under resourcePolicy 'none'` (existing; assertion updated) | **RED** | GREEN | message regression coverage |
| `PROSE containing the literal is rejected — the chat-completion false positive, pinned as deliberate` (new, router) | **RED** | GREEN | message regression coverage; the `FORBIDDEN` half is an **invariant guard** |
| `the SAME chat message without the literal is accepted (it is the literal, not the entry)` (new, router) | GREEN | GREEN | **negative control / invariant guard** — not regression coverage |
| `prose in messages[].content is the ONLY caller-steerable string the AIR scan sees` (new, unit) | GREEN | GREEN | **invariant guard** — not regression coverage |

Counts (`Tests` line, ANSI-stripped): base `2 failed | 353 passed (355)` → HEAD `355 passed (355)`. Wider sweep at HEAD (`steps/__tests__` + `blocks.router.workflow` + `blocks.router.textOutputModeration`): `Test Files 7 passed (7)`, `Tests 632 passed (632)`.

**Base failure reason, checked rather than assumed:** the prose test fails at base with `AssertionError: expected TRPCError: step 'chat-completion' declare… to match object` — i.e. this guard is genuinely reached through `chat-completion` on `main`, and only the wording differs. The false positive is real.

**Mutation control:** disabling the guard (`if (false && …)`) makes both rejection tests fail with `promise resolved "{ snapshot: … }" instead of rejecting` — not a message mismatch — so they observe the guard itself, not just its wording. The two invariant guards correctly survive it (the negative control asserts acceptance; the unit test does not touch the router).

Typecheck: `pnpm typecheck` reports 135 pre-existing errors, **none in any file this PR touches** and none mentioning `AIR_URN_PREFIX`. I did not run a base typecheck for a delta count, so the honest claim is the located-in-touched-files one. ESLint on the five changed files: 16 errors, all pre-existing in `blocks.router.workflow.test.ts` at lines 232–3816; the additions here start past line 7000 and add none. Prettier clean (verified with a positive control — the same invocation flagged this file before it was formatted).

## What I deliberately did not do

- **No scoping, exemption, or relaxation of the AIR scan.** No per-entry `airScannedFields`, no `'chat-completion'` special case in the router, no change to `containsAirReference`'s traversal or depth cap. The user-visible bounce still happens; only the explanation changed.
- **No grammar-based AIR matcher.**
- **No prompt-input audit for `chat-completion`** — the pre-existing `KNOWN GAP` in that file's header is untouched and still needs a registry-level multi-surface-posture decision.
- I did not probe the deployed orchestrator live, and did not read the chat worker. Both are named as open in the code comment rather than papered over.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R7ZCxbgcsv3WfsSJrYdSCi
