### PR TITLE
fix(blocks): an errored XGuard label is a NON-ANSWER, not a clean one

### DIFF
--- a/src/server/services/blocks/steps/__tests__/step-text-output-moderation.test.ts
+++ b/src/server/services/blocks/steps/__tests__/step-text-output-moderation.test.ts
@@ -1325,6 +1325,39 @@ describe('textOutput — an ERRORED label FAILS CLOSED', () => {
     ).toEqual([ERRORED_LABEL]);
   });
 
+  it.each([['extremism'], ['EXTREMISM'], ['  Extremism  ']])(
+    '🔴 matches the errored label CASE-INSENSITIVELY — result spelled %p, requested "Extremism"',
+    (resultLabel) => {
+      // 🔴 THE REAL SHAPE, NOT A HYPOTHETICAL. The orchestrator matches the
+      // requested list case-insensitively but answers with its OWN canonical
+      // spelling, so "we asked for `Extremism`, it answered about `extremism`"
+      // is what actually arrives. A case-SENSITIVE guard finds no match, reports
+      // no errored label, and RELEASES — the identical silent fail-open
+      // `normalizeLabel` exists to remove, reintroduced one function over.
+      //
+      // 🔴 THIS TEST EXISTS BECAUSE A MUTANT SURVIVED WITHOUT IT. Replacing BOTH
+      // `normalizeLabel(...)` calls in `erroredRequestedLabels` with `.trim()`
+      // left the entire 98-test suite green: every other fixture here spells the
+      // result label exactly as it spells the requested one, so the two sides
+      // agreed and nothing could distinguish a normalized comparison from a raw
+      // one. Only a case DIFFERENCE discriminates — an asymmetric mutant (one
+      // side only) dies for the wrong reason, because the sides stop agreeing.
+      // `missingRequestedLabels` has had its own version of this test all along.
+      const output = {
+        triggeredLabels: [],
+        results: [{ label: resultLabel, triggered: false, error: SCANNER_ERROR }],
+      };
+      // The REQUESTED spelling comes back, not the scanner's.
+      expect(TextOutputModeration.erroredRequestedLabels(output, ['Extremism'])).toEqual([
+        'Extremism',
+      ]);
+      // …and it reaches the VERDICT, not just the helper.
+      expect(
+        decideTextOutputVerdict(output, { isGreen: false, requestedLabels: ['Extremism'] })
+      ).toMatchObject({ released: false, erroredLabels: ['Extremism'] });
+    }
+  );
+
   it('🔴 ONE label errored, every other label clean → WITHHOLDS', () => {
     // 🔴 THE DEFECT, IN ONE ASSERTION. Nothing triggered, every requested label
     // came back, and one of them came back with an error instead of a verdict.

--- a/src/server/services/blocks/steps/__tests__/step-text-output-moderation.test.ts
+++ b/src/server/services/blocks/steps/__tests__/step-text-output-moderation.test.ts
@@ -115,6 +115,16 @@ import {
   VERDICT_CACHE_MAX_ENTRIES,
   __clearTextOutputVerdictCacheForTests,
 } from '~/server/services/blocks/steps/text-output-moderation';
+// 🔴 A NAMESPACE IMPORT, ON PURPOSE, AND ONLY FOR `erroredRequestedLabels`.
+// A NAMED import of a symbol the module does not export is a LINK-TIME failure
+// under vitest's ESM transform: the whole file fails to COLLECT and reports
+// `Tests no tests`, which reads as "nothing to see" rather than as a failure.
+// That would destroy the red-at-base measurement these cases exist to produce —
+// nobody could re-run this file against the pre-fix commit and see the
+// erroring-label cases go red, because none of the other 81 would run either.
+// Through the namespace the missing export is merely `undefined`, so each case
+// fails on its own assertion and the rest of the suite still executes. Keep it.
+import * as TextOutputModeration from '~/server/services/blocks/steps/text-output-moderation';
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Fixtures
@@ -1214,5 +1224,339 @@ describe('textOutput — a dropped label FAILS CLOSED', () => {
     expect(mockCreateXGuardModerationRequest.mock.calls[0][0].labels).toEqual([
       ...TEXT_OUTPUT_SCAN_LABELS,
     ]);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 🔴 AN ERRORED LABEL — the scanner ATTEMPTED a label and FAILED on it.
+//
+// `XGuardLabelResult` carries `error?: null | string` (generated client,
+// `types.gen.d.ts`). A label the scanner tried and failed on comes back as a
+// PRESENT `results[]` entry with `triggered: false` and an `error` string. Before
+// the fix that entry (a) satisfied the drift guard, because the guard's only
+// question is whether a `label` came back at all, and (b) contributed nothing to
+// `triggered` — so it read as a CLEAN ANSWER and the verdict RELEASED. A scan
+// where all fifteen labels errored was byte-indistinguishable, to this policy,
+// from a scan where all fifteen came back clean.
+//
+// That is the same "'no answer' must never read as 'clean'" invariant the drift
+// guard's own comment states, failing on a different axis: drift is a label that
+// was never EVALUATED, an error is a label whose evaluation FAILED. Both are
+// non-answers; every other branch in this file (scanner throw, hard deadline,
+// no-verdict, over-cap, drift) withholds on one.
+//
+// 🔴 THE FIXTURES BELOW ARE DELIBERATELY NOT `scanOutput(...)`-SHAPED. The
+// existing fixture builds `results[]` by mapping ONE shape over
+// `TEXT_OUTPUT_SCAN_LABELS`, so every entry covaries: a case built that way
+// cannot tell "the errored label withheld" from "some label withheld". Here the
+// errored label, the triggered label and the clean label are three DIFFERENT
+// labels with three pairwise-distinct scores, and a test below asserts that
+// distinctness so it cannot rot into a covarying fixture.
+// ─────────────────────────────────────────────────────────────────────────────
+describe('textOutput — an ERRORED label FAILS CLOSED', () => {
+  /** Errored in the fixtures below. An ALWAYS-withhold label, so losing it matters. */
+  const ERRORED_LABEL = 'Extremism';
+  /** Genuinely triggers. A DIFFERENT always-withhold label. */
+  const TRIGGERED_LABEL = 'Young';
+  /** Neither errored nor triggered. A THIRD label, from the not-acted-on tier. */
+  const CLEAN_LABEL = 'Celebrity';
+  /**
+   * The scanner-supplied error text. Asserted ABSENT from the trigger log: it is
+   * an untrusted string from the other side of a network boundary and may quote
+   * the very content this posture is withholding.
+   */
+  const SCANNER_ERROR = 'label backend timed out: upstream 504 on the-secret-content';
+
+  /**
+   * All fifteen results (which the drift guard genuinely requires — that is the
+   * CODE's demand, not the fixture's assumption), with per-label overrides
+   * applied on top so the fields do NOT covary.
+   */
+  function scanOutputWith(overrides: Record<string, Record<string, unknown>>) {
+    const base = scanOutput([]);
+    const results = base.results.map((r, i) => ({
+      ...r,
+      // Pairwise-distinct scores, so no assertion below can pass by matching the
+      // wrong entry.
+      score: 0.01 * (i + 1),
+      ...(overrides[r.label] ?? {}),
+    }));
+    const triggeredLabels = results.filter((r) => r.triggered === true).map((r) => r.label);
+    return { ...base, results, triggeredLabels };
+  }
+
+  /** The three subject labels, with an error on one and a trigger on another. */
+  function erroredAndTriggered() {
+    return scanOutputWith({
+      [ERRORED_LABEL]: { error: SCANNER_ERROR, triggered: false, score: 0 },
+      [TRIGGERED_LABEL]: { triggered: true, score: 0.97 },
+    });
+  }
+
+  it('🔴 VALIDATES THE FIXTURE — the three subject labels and their scores are pairwise distinct', () => {
+    // Without this, every case below could be green because one label happened
+    // to stand in for another. It also pins that the three are really drawn from
+    // three different policy tiers.
+    expect(new Set([ERRORED_LABEL, TRIGGERED_LABEL, CLEAN_LABEL]).size).toBe(3);
+    expect(ALWAYS_WITHHOLD_LABELS).toContain(ERRORED_LABEL);
+    expect(ALWAYS_WITHHOLD_LABELS).toContain(TRIGGERED_LABEL);
+    expect(NOT_ACTED_ON_LABELS).toContain(CLEAN_LABEL);
+
+    const results = erroredAndTriggered().results;
+    const byLabel = (l: string) => results.find((r) => r.label === l)!;
+    expect(new Set(results.map((r) => r.score)).size).toBe(results.length);
+    expect(byLabel(ERRORED_LABEL).triggered).toBe(false);
+    expect(byLabel(TRIGGERED_LABEL).triggered).toBe(true);
+    expect(byLabel(CLEAN_LABEL).triggered).toBe(false);
+    expect(byLabel(CLEAN_LABEL)).not.toHaveProperty('error');
+  });
+
+  it('erroredRequestedLabels names exactly the requested labels whose entry carries an error', () => {
+    const output = scanOutputWith({
+      [ERRORED_LABEL]: { error: SCANNER_ERROR },
+      [TRIGGERED_LABEL]: { triggered: true },
+    });
+    expect(
+      TextOutputModeration.erroredRequestedLabels(output, [
+        ERRORED_LABEL,
+        TRIGGERED_LABEL,
+        CLEAN_LABEL,
+      ])
+    ).toEqual([ERRORED_LABEL]);
+  });
+
+  it('🔴 ONE label errored, every other label clean → WITHHOLDS', () => {
+    // 🔴 THE DEFECT, IN ONE ASSERTION. Nothing triggered, every requested label
+    // came back, and one of them came back with an error instead of a verdict.
+    // The pre-fix policy released this.
+    const verdict = decideTextOutputVerdict(
+      scanOutputWith({ [ERRORED_LABEL]: { error: SCANNER_ERROR } }),
+      { isGreen: false, requestedLabels: ALL }
+    );
+    expect(verdict.released).toBe(false);
+    expect(verdict.erroredLabels).toEqual([ERRORED_LABEL]);
+    // 🔴 AND IT IS NOT MISATTRIBUTED. An errored label is present in `results[]`,
+    // so it is NOT drift, and it is not a content hit either. Reporting it as
+    // either would send an operator to the wrong remedy and poison that stage's
+    // rates with a fault of a different kind.
+    expect(verdict.missingLabels).toEqual([]);
+    expect(verdict.withholdingLabels).toEqual([]);
+  });
+
+  it('🔴 POSITIVE CONTROL — the IDENTICAL scan with `error: null` RELEASES', () => {
+    // Only the one field differs. Without this, "released: false" above is what a
+    // policy that withholds everything also reports.
+    const verdict = decideTextOutputVerdict(scanOutputWith({ [ERRORED_LABEL]: { error: null } }), {
+      isGreen: false,
+      requestedLabels: ALL,
+    });
+    expect(verdict.released).toBe(true);
+    expect(verdict.erroredLabels).toEqual([]);
+  });
+
+  it('🔴 POSITIVE CONTROL — with the `error` field ABSENT entirely it RELEASES', () => {
+    const verdict = decideTextOutputVerdict(scanOutputWith({}), {
+      isGreen: false,
+      requestedLabels: ALL,
+    });
+    expect(verdict.released).toBe(true);
+    expect(verdict.erroredLabels).toEqual([]);
+  });
+
+  it('🔴 ALL FIFTEEN labels errored → WITHHOLDS, and names all fifteen', () => {
+    // The shape a whole-scanner fault produces. Pre-fix this was
+    // indistinguishable from fifteen clean answers — the single worst case,
+    // because it is the one where the scan did nothing at all.
+    const overrides = Object.fromEntries(
+      TEXT_OUTPUT_SCAN_LABELS.map((l) => [l, { error: `${SCANNER_ERROR} (${l})` }])
+    );
+    const verdict = decideTextOutputVerdict(scanOutputWith(overrides), {
+      isGreen: false,
+      requestedLabels: ALL,
+    });
+    expect(verdict.released).toBe(false);
+    expect(verdict.erroredLabels).toEqual([...TEXT_OUTPUT_SCAN_LABELS]);
+    expect(verdict.missingLabels).toEqual([]);
+  });
+
+  it('🔴 an errored label that WOULD have been a withhold label still withholds', () => {
+    // `Extremism` is an always-withhold label. If the scanner failed on it, we do
+    // not know whether the text trips it — which is exactly the case the policy
+    // must not resolve in the text's favour. Note `withholdingLabels` is empty:
+    // we are not claiming it triggered, we are claiming we never found out.
+    const verdict = decideTextOutputVerdict(
+      scanOutputWith({ [ERRORED_LABEL]: { error: SCANNER_ERROR, triggered: false } }),
+      { isGreen: false, requestedLabels: ALL }
+    );
+    expect(verdict.released).toBe(false);
+    expect(verdict.erroredLabels).toEqual([ERRORED_LABEL]);
+    expect(verdict.withholdingLabels).toEqual([]);
+  });
+
+  it('🔴 an error alongside `triggered: true` on the SAME label withholds on BOTH signals', () => {
+    // A partial failure that still reported a trigger. Fail-closed in both
+    // directions: the trigger is honoured (it is a policy label) AND the error is
+    // recorded, so neither signal is dropped in favour of the other.
+    const verdict = decideTextOutputVerdict(
+      scanOutputWith({ [TRIGGERED_LABEL]: { error: SCANNER_ERROR, triggered: true } }),
+      { isGreen: false, requestedLabels: ALL }
+    );
+    expect(verdict.released).toBe(false);
+    expect(verdict.erroredLabels).toEqual([TRIGGERED_LABEL]);
+    expect(verdict.triggeredLabels).toContain(TRIGGERED_LABEL);
+    expect(verdict.withholdingLabels).toEqual([TRIGGERED_LABEL]);
+  });
+
+  it('an error on ONE label and a genuine trigger on ANOTHER reports both, separately', () => {
+    const verdict = decideTextOutputVerdict(erroredAndTriggered(), {
+      isGreen: false,
+      requestedLabels: ALL,
+    });
+    expect(verdict.released).toBe(false);
+    expect(verdict.erroredLabels).toEqual([ERRORED_LABEL]);
+    expect(verdict.withholdingLabels).toEqual([TRIGGERED_LABEL]);
+  });
+
+  it('🔴 a non-string, non-null `error` value withholds too (fail closed on a shape we did not expect)', () => {
+    // `error` is `null | string` in the generated client, but this is untrusted
+    // data off a network boundary and the `Like` types read it as `unknown`. A
+    // value we cannot interpret is a non-answer, not a clean one.
+    for (const value of [42, {}, [], true]) {
+      const verdict = decideTextOutputVerdict(
+        scanOutputWith({ [ERRORED_LABEL]: { error: value } }),
+        { isGreen: false, requestedLabels: ALL }
+      );
+      expect(verdict.released).toBe(false);
+      expect(verdict.erroredLabels).toEqual([ERRORED_LABEL]);
+    }
+  });
+
+  it('an EMPTY-STRING error is NOT an error (documented; the alternative is a total outage)', () => {
+    // 🔴 INVARIANT GUARD, NOT REGRESSION COVERAGE — this passes pre-fix too, and
+    // it is here to pin a decision rather than to catch the defect. `modelReason`
+    // came back EMPTY on every probe against the deployed scanner, so a scanner
+    // that populates `error: ''` on the healthy path is a live possibility.
+    // Treating `''` as a fault would withhold 100% of output on day one — the
+    // same day-one capability outage the drift guard's pre-adoption gate warns
+    // about. The PRESENCE of a non-empty error is the signal.
+    const verdict = decideTextOutputVerdict(scanOutputWith({ [ERRORED_LABEL]: { error: '   ' } }), {
+      isGreen: false,
+      requestedLabels: ALL,
+    });
+    expect(verdict.released).toBe(true);
+    expect(verdict.erroredLabels).toEqual([]);
+  });
+
+  it('`finishReason` alone does NOT withhold', () => {
+    // 🔴 INVARIANT GUARD, NOT REGRESSION COVERAGE — green pre-fix and post-fix.
+    // It pins a DELIBERATE non-decision so a later reader does not quietly make
+    // the opposite one. `finishReason?: null | string` sits next to `error` in
+    // the same generated type and plausibly carries a comparable signal (a
+    // truncated judge output is also a degraded answer), but unlike `error` it
+    // cannot be read by PRESENCE: a finishReason is emitted on the healthy path
+    // too, so acting on it requires knowing which VALUES mean "fine". That value
+    // set is orchestrator-side configuration this codebase does not control and
+    // has never observed — the same category `normalizeLabel`'s comment warns
+    // about for label strings. Guessing it wrong in the strict direction
+    // withholds everything; guessing it wrong in the loose direction is the
+    // fail-open we are already fixing. So: no action until a live probe
+    // establishes the distribution. See the source comment for the gate.
+    const verdict = decideTextOutputVerdict(
+      scanOutputWith({
+        [ERRORED_LABEL]: { finishReason: 'length' },
+        [CLEAN_LABEL]: { finishReason: 'stop' },
+      }),
+      { isGreen: false, requestedLabels: ALL }
+    );
+    expect(verdict.released).toBe(true);
+    expect(verdict.erroredLabels).toEqual([]);
+  });
+
+  it('an error on a label we did NOT request is ignored (the guard is scoped to what we asked)', () => {
+    // 🔴 INVARIANT GUARD / SCOPING PIN — green pre-fix and post-fix. Symmetric
+    // with `missingRequestedLabels`: this policy makes claims only about the
+    // labels it sent. Unreachable from `screenGeneratedText`, which always sends
+    // the full list; pinned so the scoping is a decision rather than an accident.
+    const verdict = decideTextOutputVerdict(
+      scanOutputWith({ [ERRORED_LABEL]: { error: SCANNER_ERROR } }),
+      { isGreen: false, requestedLabels: [TRIGGERED_LABEL, CLEAN_LABEL] }
+    );
+    expect(verdict.released).toBe(true);
+    expect(verdict.erroredLabels).toEqual([]);
+  });
+
+  it('🔴 END TO END — an errored label WITHHOLDS the text and logs stage "label-error"', async () => {
+    scannerReturns(scanOutputWith({ [ERRORED_LABEL]: { error: SCANNER_ERROR } }));
+    const snapshot = await attachModeratedStepTextOutputs(
+      { workflowId: 'wf-1', status: 'succeeded' as const },
+      workflowWith(chatStep()),
+      CTX
+    );
+    expect(snapshot.textOutputs).toBeUndefined();
+    expect(JSON.stringify(snapshot)).not.toContain(GENERATED_TEXT);
+    expect(snapshot.textOutputWithheld).toEqual({ reason: TEXT_OUTPUT_WITHHELD_MESSAGE });
+    expect(mockLogToAxiom.mock.calls[0][0]).toMatchObject({
+      stage: 'label-error',
+      erroredLabels: [ERRORED_LABEL],
+    });
+  });
+
+  it('🔴 POSITIVE CONTROL — the SAME path publishes when no label errored', async () => {
+    // ONLY the `error` field differs from the case above.
+    scannerReturns(scanOutputWith({}));
+    const snapshot = await attachModeratedStepTextOutputs(
+      { workflowId: 'wf-1', status: 'succeeded' as const },
+      workflowWith(chatStep()),
+      CTX
+    );
+    expect(snapshot.textOutputs).toEqual([GENERATED_TEXT]);
+    expect(mockLogToAxiom).not.toHaveBeenCalled();
+  });
+
+  it('🔴 the log carries NEITHER the withheld text NOR the scanner-supplied error string', async () => {
+    // The error string comes from the other side of a network boundary and can
+    // quote the content being scanned. The label NAMES are this file's own
+    // constants and are safe; the message is not, and a store that must never
+    // hold the withheld text must not hold a string that may embed it.
+    scannerReturns(scanOutputWith({ [ERRORED_LABEL]: { error: SCANNER_ERROR } }));
+    await screenGeneratedText({
+      texts: [GENERATED_TEXT],
+      userId: 42,
+      isGreen: false,
+      appId: 'app-1',
+      stepId: 'fixture-chat',
+      model: CHAT_TYPE,
+    });
+    const logged = JSON.stringify(mockLogToAxiom.mock.calls);
+    expect(logged).not.toContain(GENERATED_TEXT);
+    expect(logged).not.toContain(SCANNER_ERROR);
+    expect(logged).not.toContain('the-secret-content');
+    // …and the actionable part IS there.
+    expect(logged).toContain(ERRORED_LABEL);
+  });
+
+  it('🔴 a LABEL-ERROR withhold is NOT memoized — a scanner recovery must not be pinned shut', async () => {
+    // Same reasoning the error / no-verdict / drift branches already carry: a
+    // per-label scanner fault is OPERATIONAL and clears on its own, so caching
+    // the withhold would pin a blip into a five-minute outage of the capability
+    // — and, because a memo HIT logs nothing, would emit the `label-error` line
+    // for the first observation only and then go silent.
+    const opts = {
+      userId: 42,
+      isGreen: false,
+      appId: 'app-1',
+      stepId: 'fixture-chat',
+      model: CHAT_TYPE,
+    };
+    scannerReturns(scanOutputWith({ [ERRORED_LABEL]: { error: SCANNER_ERROR } }));
+    const errored = await screenGeneratedText({ ...opts, texts: [GENERATED_TEXT] });
+    expect(errored).toEqual({ released: false, reason: TEXT_OUTPUT_WITHHELD_MESSAGE });
+
+    // The fault clears. The very next call must reach the scanner again, and
+    // release.
+    scannerReturns(scanOutputWith({}));
+    const recovered = await screenGeneratedText({ ...opts, texts: [GENERATED_TEXT] });
+    expect(recovered).toEqual({ released: true, texts: [GENERATED_TEXT] });
+    expect(mockCreateXGuardModerationRequest).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/server/services/blocks/steps/index.ts
+++ b/src/server/services/blocks/steps/index.ts
@@ -1353,17 +1353,25 @@ export function isModerationPostureImplemented(posture: StepModerationPosture): 
   // 'promptAudit' runs `auditPromptServer` in the SUBMIT phase — the SAME audit
   // `textToImage` and `customComfy` run, host-side and before submission.
   // 'textOutput' runs an xGuardModeration text scan in the OUTPUT phase, at the
-  // read boundary, and withholds on a policy hit. It ALSO withholds on most —
-  // 🔴 not all — scanner failures: scan threw or the hard deadline fired, no
-  // output (submit failed, or the workflow was still running when the scan wait
-  // elapsed), content over the scanned-character cap, and a requested label
-  // absent from `results[]`. NOT on a per-label `error`, which currently
-  // RELEASES; `./text-output-moderation` documents that gap at the verdict
-  // function. Do not restate this as "any scanner failure" — three separate
-  // comments said exactly that, it was false in all three, and a safety claim
-  // stronger than the code is what a maintainer deletes a guard on the strength
-  // of. Re-derive from `decideTextOutputVerdict` before trusting this summary in
-  // EITHER direction.
+  // read boundary, and withholds on a policy hit. It ALSO withholds on every
+  // scanner failure THIS SIDE CAN OBSERVE: scan threw or the hard deadline
+  // fired, no output (submit failed, or the workflow was still running when the
+  // scan wait elapsed), content over the scanned-character cap, a requested
+  // label absent from `results[]`, and — since the per-label error fix — a
+  // requested label the scanner evaluated and FAILED on (a populated
+  // `results[].error`). That last one previously RELEASED; this comment said so,
+  // and that sentence is now stale in the opposite direction, which is why it is
+  // rewritten rather than left.
+  //
+  // 🔴 STILL DO NOT RESTATE THIS AS "any scanner failure". Three separate
+  // comments said exactly that while it was false, and it remains false for a
+  // DIFFERENT reason now: a failure in one SEGMENT of a multi-segment scan is
+  // discarded upstream by max-score result selection before it ever reaches
+  // this codebase, so it cannot be withheld on here at all. Reachable above
+  // ~16,000 characters. `./text-output-moderation` documents that masking path
+  // on `screenGeneratedText`. A safety claim stronger than the code is what a
+  // maintainer deletes a guard on the strength of — re-derive from
+  // `decideTextOutputVerdict` before trusting this summary in EITHER direction.
   // Both handlers live in `./moderation`, which asserts at ITS load that each
   // posture has a handler in exactly the phases `posturePhaseRequirements` names.
   return posture === 'none' || posture === 'promptAudit' || posture === 'textOutput';

--- a/src/server/services/blocks/steps/text-output-moderation.ts
+++ b/src/server/services/blocks/steps/text-output-moderation.ts
@@ -135,11 +135,24 @@ const SFW_ONLY_WITHHOLD_KEYS: ReadonlySet<string> = new Set(
   SFW_ONLY_WITHHOLD_LABELS.map(normalizeLabel)
 );
 
-/** The per-label result shape this policy reads off an XGuard scan. */
+/**
+ * The per-label result shape this policy reads off an XGuard scan.
+ *
+ * 🔴 `error` IS PART OF THE READ SHAPE, AND ITS ABSENCE HERE WAS A FAIL-OPEN.
+ * See {@link erroredRequestedLabels}. `finishReason` is declared so the field is
+ * visible to a reader of this type rather than invisible — it is deliberately
+ * NOT acted on; the reasoning is on that function.
+ *
+ * Every field is `unknown` because this is untrusted data off a network
+ * boundary: the generated client's declared types describe the contract, not
+ * what actually arrives.
+ */
 export type XGuardLabelResultLike = {
   label?: unknown;
   score?: unknown;
   triggered?: unknown;
+  error?: unknown;
+  finishReason?: unknown;
 };
 
 /** The scan output shape this policy reads. */
@@ -164,6 +177,16 @@ export type TextOutputScanVerdict = {
    * {@link missingRequestedLabels}.
    */
   missingLabels: string[];
+  /**
+   * 🔴 REQUESTED labels the scanner ATTEMPTED and FAILED on. NON-EMPTY FORCES A
+   * WITHHOLD, regardless of what did come back. See
+   * {@link erroredRequestedLabels}.
+   *
+   * DISJOINT FROM `missingLabels` for any one label, and that is the point of
+   * having two fields: an errored label IS present in `results[]`, so it is not
+   * drift, and its remedy is not drift's remedy.
+   */
+  erroredLabels: string[];
 };
 
 /**
@@ -247,6 +270,106 @@ export function missingRequestedLabels(
 }
 
 /**
+ * Does this `results[]` entry report that the scanner FAILED on its label?
+ *
+ * 🔴 READ BY PRESENCE, NOT BY VALUE. `error` is `null | string` in the generated
+ * client, but this is untrusted data off a network boundary — so anything
+ * present and non-null that is not an empty string is a failure, INCLUDING a
+ * shape we did not expect. A value we cannot interpret is a non-answer, and the
+ * whole point of this guard is that a non-answer never reads as clean.
+ *
+ * 🔴 THE ONE DELIBERATE LOOSENING: an EMPTY (or whitespace) string is NOT a
+ * failure. `modelReason` — the field immediately beside this one in the same
+ * type — came back EMPTY on every probe against the deployed scanner, so a
+ * scanner that populates `error: ''` on the HEALTHY path is a live possibility,
+ * not a hypothetical. Treating `''` as a fault would withhold 100% of generated
+ * output from the first adopting entry: the same day-one capability outage the
+ * pre-adoption gate on `missingRequestedLabels` warns about, arrived at from the
+ * other direction. A scanner that reports failures at all will populate a
+ * message.
+ */
+function labelResultErrored(entry: XGuardLabelResultLike): boolean {
+  const err = entry.error;
+  if (err === null || err === undefined) return false;
+  if (typeof err === 'string') return err.trim().length > 0;
+  return true;
+}
+
+/**
+ * The requested labels the scan came back with an ERROR on.
+ *
+ * 🔴 THIS CLOSES A SECOND FAIL-OPEN OF EXACTLY THE SHAPE
+ * {@link missingRequestedLabels} CLOSES, ON A DIFFERENT AXIS — and the drift
+ * guard cannot see it. `XGuardLabelResult` carries `error?: null | string`. A
+ * label the scanner ATTEMPTED and FAILED on comes back as a PRESENT `results[]`
+ * entry with `triggered: false` and an `error` string. That entry:
+ *
+ *   (a) satisfies the drift guard — whose only question is whether a `label`
+ *       came back at all, so the entry lands in its `evaluated` set and
+ *       `missingLabels` stays empty; and
+ *   (b) contributes nothing to `triggered`, because `triggered` is false.
+ *
+ * So the pre-fix policy read it as a CLEAN ANSWER and RELEASED. A scan where all
+ * fifteen labels errored was indistinguishable, to this policy, from a scan
+ * where all fifteen came back clean — which is precisely the invariant
+ * `missingRequestedLabels` states in so many words: *"we did not get the answer
+ * we asked for, and 'no answer' must never read as 'clean'"*. Drift is a label
+ * that was never EVALUATED; an error is a label whose evaluation FAILED. Both
+ * are non-answers, and every other branch in this file (scanner throw, hard
+ * deadline, no-verdict, over-cap, drift) already withholds on one.
+ *
+ * 🔴 WHY THIS IS A SEPARATE SIGNAL FROM `missingLabels` RATHER THAN FOLDED INTO
+ * IT. Folding it in is one line shorter and produces WORSE telemetry, which is
+ * the whole cost of the choice. `stage: 'label-drift'` means "a label in
+ * `TEXT_OUTPUT_SCAN_LABELS` is not one the scanner knows about" — the remedy is
+ * to fix this file's constant or the orchestrator's label config, and it is a
+ * deploy. `stage: 'label-error'` means "the scanner knows the label and its
+ * backend failed" — the remedy is to look at scanner health, and it typically
+ * clears by itself. Aggregating the two would send whoever reads the alert to
+ * the wrong place and would make each stage's rate a mix of two unrelated
+ * faults. This file already made exactly this call once, for exactly this
+ * reason, when it gave drift its own stage instead of reusing `'error'`.
+ *
+ * 🔴 `finishReason` IS DELIBERATELY NOT TREATED THE SAME WAY. It sits beside
+ * `error` in the same generated type, it is also `null | string`, and it
+ * plausibly carries a comparable signal — an LLM-judged label whose output was
+ * truncated has also produced a degraded answer. It is excluded because, unlike
+ * `error`, it CANNOT BE READ BY PRESENCE: a `finishReason` is emitted on the
+ * healthy path too, so acting on it requires knowing which VALUES mean "fine".
+ * That value set is orchestrator-side configuration this codebase does not
+ * control and has never observed — the same category `normalizeLabel`'s own
+ * comment warns about for label strings. Guessing it too strictly (say, "only
+ * `'stop'` is fine") withholds 100% of output the moment the scanner spells the
+ * healthy value differently; guessing it too loosely reintroduces the fail-open
+ * this function exists to close. THE GATE, if someone wants to act on it: probe
+ * the deployed scanner over benign content and read the `finishReason`
+ * distribution across all fifteen labels; if a healthy value is established,
+ * `labelResultErrored` is the one place to extend, and the extension belongs in
+ * the `'label-error'` stage rather than a third one.
+ *
+ * Compared on the NORMALIZED key, and scoped to the REQUESTED labels, both for
+ * the same reasons `missingRequestedLabels` gives: casing is orchestrator-side,
+ * and this policy makes claims only about the labels it actually sent. (The
+ * scoping is unreachable from `screenGeneratedText`, which always sends the full
+ * list; it is pinned by a test so it stays a decision rather than an accident.)
+ */
+export function erroredRequestedLabels(
+  output: XGuardScanOutputLike | null | undefined,
+  requestedLabels: readonly string[]
+): string[] {
+  const errored = new Set<string>();
+  const rawResults = output?.results;
+  if (Array.isArray(rawResults)) {
+    for (const entry of rawResults as XGuardLabelResultLike[]) {
+      if (!entry || typeof entry !== 'object') continue;
+      if (typeof entry.label !== 'string' || entry.label.trim().length === 0) continue;
+      if (labelResultErrored(entry)) errored.add(normalizeLabel(entry.label));
+    }
+  }
+  return requestedLabels.filter((label) => errored.has(normalizeLabel(label)));
+}
+
+/**
  * The scan → verdict decision. PURE: no IO, no throws, fully mutation-testable
  * without an orchestrator.
  *
@@ -318,12 +441,20 @@ export function decideTextOutputVerdict(
   // client documents ("silently ignored"); see `missingRequestedLabels`.
   const missingLabels = missingRequestedLabels(output, opts.requestedLabels);
 
+  // 🔴 A LABEL WE ASKED FOR AND THE SCANNER FAILED ON WITHHOLDS, on its own, for
+  // the same reason a missing one does: it is a NON-ANSWER, and the entry it
+  // comes back as (`triggered: false` plus an `error`) is otherwise
+  // indistinguishable from a clean answer. See `erroredRequestedLabels`.
+  const erroredLabels = erroredRequestedLabels(output, opts.requestedLabels);
+
   return {
-    released: withholdingLabels.length === 0 && missingLabels.length === 0,
+    released:
+      withholdingLabels.length === 0 && missingLabels.length === 0 && erroredLabels.length === 0,
     withholdingLabels,
     triggeredLabels,
     scores,
     missingLabels,
+    erroredLabels,
   };
 }
 
@@ -400,9 +531,13 @@ export type TextOutputScreenResult =
 /**
  * Scan generated text and decide whether it may be released.
  *
- * 🔴 FAIL CLOSED. A scanner error, a timeout, a submit that returns no workflow,
- * a workflow that returns no `xGuardModeration` output — every one of these
- * WITHHOLDS.
+ * 🔴 FAIL CLOSED, ON EVERY BRANCH THAT IS NOT A CLEAN ANSWER. A scanner error, a
+ * timeout, a submit that returns no workflow, a workflow that returns no
+ * `xGuardModeration` output, content over the size cap, a requested label the
+ * scan never evaluated (`'label-drift'`), and a requested label the scanner
+ * evaluated and FAILED on (`'label-error'`) — every one of these WITHHOLDS. The
+ * unifying rule, and the one to apply to any branch added later: "no answer"
+ * must never read as "clean".
  *
  * 🔴 THIS IS THE EXACT OPPOSITE OF `auditPromptServer`, AND THE ASYMMETRY IS
  * DELIBERATE — DO NOT "FIX" IT FOR CONSISTENCY. `auditPromptServer` fails SOFT:
@@ -475,11 +610,12 @@ export async function screenGeneratedText(opts: {
   //     and including them would defeat the memo across the poll loop of a
   //     multi-tab viewer for no safety gain. Nothing leaks: a hit requires
   //     presenting the identical content, which the caller already holds.
-  // Only CONTENT verdicts are stored — never an error, timeout, missing output
-  // or label drift. Caching those would be fail-closed but would also pin a
-  // withhold through a recovery, turning a blip into a five-minute outage of the
-  // capability. (The drift case is the one that was inconsistent until the
-  // ordering fix below; see the `stage: 'label-drift'` branch.)
+  // Only CONTENT verdicts are stored — never an error, timeout, missing output,
+  // label drift or per-label scanner error. Caching those would be fail-closed
+  // but would also pin a withhold through a recovery, turning a blip into a
+  // five-minute outage of the capability. (The drift case is the one that was
+  // inconsistent until the ordering fix below; see the `stage: 'label-drift'`
+  // and `stage: 'label-error'` branches, both of which sit ABOVE the write.)
   //
   // 🔴 KNOWN COST OF THE KEY, RECORDED RATHER THAN LEFT FOR SOMEONE TO
   // DISCOVER: dropping `appId` also drops PER-APP TELEMETRY on a hit. A hit logs
@@ -588,6 +724,37 @@ export async function screenGeneratedText(opts: {
   // guard's own comment claims. Not caching keeps one line per observation.
   if (verdict.missingLabels.length > 0) {
     logScan({ ...opts, stage: 'label-drift', missingLabels: verdict.missingLabels });
+    return { released: false, reason: TEXT_OUTPUT_WITHHELD_MESSAGE };
+  }
+
+  // 🔴 A PER-LABEL SCANNER FAILURE, TREATED EXACTLY LIKE DRIFT AND FOR THE
+  // IDENTICAL REASONS — its own stage, and NOT MEMOIZED, checked here rather
+  // than after `writeCachedVerdict`.
+  //
+  // It is an OPERATIONAL fault, not a content hit, so it must not be aggregated
+  // into the per-app trigger rates; and it is recoverable in precisely the way
+  // the error branch's comment describes — a label backend that fails on one
+  // call answers on the next — so caching the withhold would pin a blip into a
+  // five-minute outage of the capability. The second-order argument is the same
+  // too: a memo HIT logs nothing at all, so caching this would emit the
+  // `'label-error'` line for the FIRST observation only and then go silent,
+  // exactly when a rate is what tells you a label backend is degraded.
+  //
+  // 🔴 ORDERED AFTER DRIFT, AND THE ORDER IS ARBITRARY BUT DETERMINISTIC. The
+  // two sets are disjoint for any ONE label (an errored entry is present in
+  // `results[]`, so it is never also missing), but a single scan can exhibit
+  // both across DIFFERENT labels. Drift is checked first only because it was
+  // here first; either fault alone is enough to withhold, and both log a label
+  // list, so nothing actionable is lost by the one that does not fire.
+  //
+  // 🔴 THE ERROR MESSAGES THEMSELVES ARE NOT LOGGED — only the label NAMES. The
+  // names are this file's own constants and carry nothing. An error STRING is
+  // scanner-supplied text from the other side of a network boundary and may
+  // quote the content being scanned, and this log store must never hold the text
+  // this posture is in the act of withholding. Which label failed is the
+  // actionable half; the message lives in the scanner's own logs.
+  if (verdict.erroredLabels.length > 0) {
+    logScan({ ...opts, stage: 'label-error', erroredLabels: verdict.erroredLabels });
     return { released: false, reason: TEXT_OUTPUT_WITHHELD_MESSAGE };
   }
 

--- a/src/server/services/blocks/steps/text-output-moderation.ts
+++ b/src/server/services/blocks/steps/text-output-moderation.ts
@@ -257,10 +257,12 @@ export type TextOutputScanVerdict = {
  * problem. That is the correct DIRECTION to fail in, and it is still an outage
  * — so re-probe whenever anything on the scanner side moves.
  *
- * 🔴 STILL UNPROBED, AND THIS IS THE HALF THAT IS GENUINELY OPEN: the
- * 2026-08-03 probe did NOT read `error` or `finishReason`. The `error`
- * population behaviour that {@link erroredRequestedLabels} depends on is
- * therefore unverified against the deployed scanner. Same one call answers it.
+ * ON `error` AND `finishReason`: the 2026-08-03 probe did not read either, but
+ * they no longer need a probe to be understood — both are assigned in
+ * `XGuardScoring.BuildLabelResult` and the behaviour is read off the
+ * orchestration source in {@link erroredRequestedLabels}. A probe would still
+ * confirm the DEPLOYED build matches that source; it is no longer the only way
+ * to answer the question.
  *
  * TO (RE-)PROBE, ONE CALL: submit a text scan through
  * `createXGuardModerationRequest` with `labels: [...TEXT_OUTPUT_SCAN_LABELS]`
@@ -305,22 +307,41 @@ export function missingRequestedLabels(
  * shape we did not expect. A value we cannot interpret is a non-answer, and the
  * whole point of this guard is that a non-answer never reads as clean.
  *
- * 🔴 THE ONE DELIBERATE LOOSENING: an EMPTY (or whitespace) string is NOT a
- * failure. `modelReason` — the field immediately beside this one in the same
- * type — came back EMPTY on every probe against the deployed scanner, so a
- * scanner that populates `error: ''` on the HEALTHY path is a live possibility,
- * not a hypothetical. Treating `''` as a fault would withhold 100% of generated
- * output from the registered `'chat-completion'` entry: the same capability
- * outage the probe note on `missingRequestedLabels` describes, arrived at from
- * the other direction. A scanner that reports failures at all will populate a
- * message.
+ * 🔴 WHAT THE PRODUCER ACTUALLY DOES — read from the orchestration source
+ * rather than assumed, because an earlier draft of this comment guessed and
+ * guessed wrong. In `XGuardScoring.BuildLabelResult`, `Error` is assigned from a
+ * three-way switch (`XGuardScoring.cs:223-227`): the literal
+ * `"Step output was missing."` when the scored blob is absent,
+ * `"Step completed without output choices."` when it is present but empty, and
+ * `null` otherwise. So the producer emits `null` on the healthy path and a
+ * non-empty sentence on a failure — never `''`.
  *
- * 🔴 UNVERIFIED AGAINST THE DEPLOYED SCANNER, AND SAY SO RATHER THAN ASSUME.
- * The 2026-08-03 live probe that settled the `results[]`-completeness question
- * did NOT read `error`, so whether the deployed scanner populates it on a
- * per-label failure — and whether it emits `error: ''` when healthy — is still
- * open. If it never populates `error`, this guard is INERT rather than wrong: it
- * adds a withhold path, it removes none.
+ * 🔴 THIS GUARD IS THEREFORE NOT INERT: it fires on a genuinely reachable path.
+ * A per-label entry whose blob is missing or unreadable really does arrive with
+ * `Error` set — and, because `ParseScore(null)` returns a score of 0
+ * (`XGuardScoring.cs:354-358`), which is below every threshold, that same entry
+ * arrives with `triggered: false`. That is exactly the "looks clean, answered
+ * nothing" shape this function exists to catch.
+ *
+ * 🔴 AND THE COUNTER-RISK IS REFUTED AT THE SOURCE: `results[]` always carries
+ * one entry per RESOLVED label (`XGuardModerationHandler.cs:170-182` builds one
+ * per label and falls back to a synthesized entry when no blob was read), so
+ * treating a populated `error` as a withhold cannot degenerate into withholding
+ * everything.
+ *
+ * THE EMPTY-STRING LOOSENING IS KEPT ANYWAY, as cheap defence rather than as a
+ * reasoned necessity — `Error` is `string?` (`XGuardModerationModels.cs:64`)
+ * and so is `null`, not `''`, when healthy. (The earlier rationale here reasoned
+ * by analogy from `ModelReason` coming back empty on probes; that analogy is
+ * WRONG — `ModelReason` is a `required string`, `XGuardModerationModels.cs:52`,
+ * which is precisely why it is `""` and `Error` is `null`.) Treating `''` as a
+ * fault would cost nothing today and would withhold everything if the producer
+ * ever switched to an empty-string default, so the loosening stays.
+ *
+ * 🔴 CAVEAT ON ALL OF THE ABOVE: read from a local `civitai-orchestration`
+ * clone that was slightly behind its origin, and the label set itself is
+ * runtime grain state rather than source. Re-read before relying on the exact
+ * strings.
  */
 function labelResultErrored(entry: XGuardLabelResultLike): boolean {
   const err = entry.error;
@@ -565,13 +586,32 @@ export type TextOutputScreenResult =
 /**
  * Scan generated text and decide whether it may be released.
  *
- * 🔴 FAIL CLOSED, ON EVERY BRANCH THAT IS NOT A CLEAN ANSWER. A scanner error, a
- * timeout, a submit that returns no workflow, a workflow that returns no
- * `xGuardModeration` output, content over the size cap, a requested label the
- * scan never evaluated (`'label-drift'`), and a requested label the scanner
- * evaluated and FAILED on (`'label-error'`) — every one of these WITHHOLDS. The
- * unifying rule, and the one to apply to any branch added later: "no answer"
- * must never read as "clean".
+ * 🔴 FAIL CLOSED ON EVERY BRANCH *THIS FUNCTION CAN SEE* THAT IS NOT A CLEAN
+ * ANSWER. A scanner error, a timeout, a submit that returns no workflow, a
+ * workflow that returns no `xGuardModeration` output, content over the size cap,
+ * a requested label the scan never evaluated (`'label-drift'`), and a requested
+ * label the scanner evaluated and FAILED on (`'label-error'`) — every one of
+ * these WITHHOLDS. The unifying rule, and the one to apply to any branch added
+ * later: "no answer" must never read as "clean".
+ *
+ * 🔴 THAT IS NOT AN END-TO-END GUARANTEE, AND MUST NOT BE READ AS ONE. It is a
+ * claim about what THIS side does with what it RECEIVES; there is a masking path
+ * UPSTREAM that this function is structurally blind to. The scanner splits
+ * content into segments (`XGuardScoring.DefaultMaxInputCharsPerSegment`, 16,000
+ * chars) and then picks ONE result per label as the highest-scoring segment
+ * (`XGuardModerationHandler.cs:174-181`, `result.Score > bestResult.Score`). A
+ * segment that FAILED scores 0 (`ParseScore(null)`), so whenever any other
+ * segment for that label scored above 0, the failed segment — and its `Error` —
+ * is DISCARDED before the response is built. The label then arrives here looking
+ * cleanly evaluated while part of the content was never scanned, and no guard on
+ * this side can detect it: the evidence was dropped upstream.
+ *
+ * Reachable for any generated output longer than one segment, i.e. above ~16,000
+ * characters, which `MAX_SCANNED_CONTENT_CHARS` (50,000) permits. NOT introduced
+ * by this file and NOT fixable here — the fix belongs in the producer, which
+ * would need to propagate a segment-level failure instead of letting max-score
+ * selection swallow it. Recorded so nobody reads the paragraph above as covering
+ * it.
  *
  * 🔴 THIS IS THE EXACT OPPOSITE OF `auditPromptServer`, AND THE ASYMMETRY IS
  * DELIBERATE — DO NOT "FIX" IT FOR CONSISTENCY. `auditPromptServer` fails SOFT:

--- a/src/server/services/blocks/steps/text-output-moderation.ts
+++ b/src/server/services/blocks/steps/text-output-moderation.ts
@@ -220,54 +220,63 @@ export type TextOutputScanVerdict = {
  * and what comes back is not mistaken for a drop.
  *
  * ─────────────────────────────────────────────────────────────────────────────
- * 🔴 AN OVERDUE LIVE PROBE — THIS WAS WRITTEN AS A PRE-ADOPTION GATE AND THE
- * ADOPTION HAS ALREADY HAPPENED. Do not skip it because the tests are green,
- * and do not weaken the guard to hedge it.
+ * 🔴 WHAT THIS GUARD ASSUMES, AND EXACTLY HOW MUCH OF IT HAS BEEN MEASURED.
+ * Two questions live here with two DIFFERENT answers — one is measured, one is
+ * open. Do not collapse them, and do not weaken the guard to hedge either.
  *
- * 🔴 CORRECTED: this note used to read "RUN ONE LIVE PROBE BEFORE THE FIRST
- * `'textOutput'` ENTRY REGISTERS" and to close with "the posture is dormant
- * until then, which is why this is a gate note rather than a defect." Both are
- * FALSE. `stepRegistry` carries `'chat-completion':
- * Object.freeze(chatCompletionStep)` (`./index`), and that entry declares
- * `moderationPosture: 'textOutput'` (`./chat-completion.step`). The posture is
- * REGISTERED and this guard is live on a real read path — so the probe below is
- * not a precondition someone still has time to satisfy, it is a verification
- * that is outstanding on shipped code.
+ * (This note used to be a "PRE-ADOPTION GATE — run the probe BEFORE the first
+ * `'textOutput'` entry registers … the posture is dormant until then". Both
+ * halves were stale. `stepRegistry` carries `'chat-completion'` (`./index`),
+ * which declares `moderationPosture: 'textOutput'` (`./chat-completion.step`),
+ * so the posture is REGISTERED and this guard is live on a real read path — and
+ * the probe has since been run. Nothing here is pending adoption.)
  *
  * THE ASSUMPTION: that the deployed scanner returns a `results[]` entry for
  * EVERY requested label — including the ones that did NOT trigger. The whole
  * guard rests on it, because "requested but absent from `results[]`" is read
  * here as drift.
  *
- * WHY IT IS NOT YET EVIDENCE: the only thing that currently exhibits the shape
- * is this file's own test fixture, which builds `results[]` by mapping over
- * `TEXT_OUTPUT_SCAN_LABELS` — i.e. the fake encodes the same assumption the code
- * does, so the suite cannot disagree with it. That is a both-wrong-blind pair,
- * not a verification.
+ * ✅ MEASURED, AND IT HOLDS — verified by live probe against the production
+ * orchestrator, 2026-08-03: 15 labels requested, 15 returned, every one
+ * `triggered: false`, names matching 15 of 15. POSITIVE CONTROL in the same
+ * probe: a BOGUS label came back ABSENT — so `results[]` genuinely omits what
+ * the scanner did not evaluate, and this guard can actually FIRE rather than
+ * being a branch nothing reaches. That refutes the "every clean scan reads as
+ * total drift, the entry withholds 100% of its output" scenario this note was
+ * originally written to gate against.
  *
- * WHAT HAPPENS IF THE ASSUMPTION IS WRONG: if the scanner returns only
- * TRIGGERED labels, then every clean scan comes back with an empty (or partial)
- * `results[]`, every clean scan reads as total drift, and the registered entry
- * withholds 100% of its output. That is loud, safe and fail-closed — but it is a
- * capability outage, and it will present as "the feature does not work" rather
- * than as a scanner problem.
+ * 🔴 ONE PROBE ON ONE DATE IS A POINT MEASUREMENT, NOT A STANDING GUARANTEE. It
+ * says nothing about the scanner's behaviour after a redeploy, a label-config
+ * change or a model swap, and NOTHING IN THIS REPO CAN DETECT SUCH A CHANGE: the
+ * suite cannot disagree with the assumption, because this file's own fixture
+ * builds `results[]` by mapping over `TEXT_OUTPUT_SCAN_LABELS` and so encodes
+ * the very shape it would need to falsify — a both-wrong-blind pair. If the
+ * behaviour ever does change, the symptom is the loud fail-closed one: every
+ * clean scan reads as total drift and the registered entry withholds all of its
+ * output, presenting as "the feature does not work" rather than as a scanner
+ * problem. That is the correct DIRECTION to fail in, and it is still an outage
+ * — so re-probe whenever anything on the scanner side moves.
  *
- * THE PROBE (one call): submit a text scan through
+ * 🔴 STILL UNPROBED, AND THIS IS THE HALF THAT IS GENUINELY OPEN: the
+ * 2026-08-03 probe did NOT read `error` or `finishReason`. The `error`
+ * population behaviour that {@link erroredRequestedLabels} depends on is
+ * therefore unverified against the deployed scanner. Same one call answers it.
+ *
+ * TO (RE-)PROBE, ONE CALL: submit a text scan through
  * `createXGuardModerationRequest` with `labels: [...TEXT_OUTPUT_SCAN_LABELS]`
  * over benign content that triggers NOTHING, and read the returned step's
- * `output.results`. Expect 15 entries with `triggered: false`. If instead it
- * comes back empty or short, the drift guard needs a different signal for
- * "evaluated" — the fix is to find one the scanner actually emits, NOT to
- * loosen the withhold.
- *
- * 🔴 AND WHILE YOU ARE THERE, READ `error` AND `finishReason` ON THE SAME
- * RESPONSE. The same one call answers all three questions, and the other two are
- * open for the same reason this one is; see {@link erroredRequestedLabels}.
+ * `output.results`. Expect 15 entries with `triggered: false`. Include a BOGUS
+ * label as the positive control and confirm it comes back ABSENT — without that
+ * half, "15 came back" cannot distinguish a scanner that echoes every label it
+ * is handed. Read `error` and `finishReason` on the same response while you are
+ * there. If `results[]` ever comes back empty or short, the drift guard needs a
+ * different signal for "evaluated" — the fix is to find one the scanner actually
+ * emits, NOT to loosen the withhold.
  *
  * 🔴 DO NOT TREAT "the feature seems to work" AS THE PROBE. That inference is
- * only as good as the traffic behind it, and nobody has measured either the
- * traffic or the withhold rate on this path. An unrun probe is unrun in both
- * directions.
+ * only as good as the traffic behind it, and the traffic and withhold rate on
+ * this path have not been measured. It is not a substitute for the call above,
+ * in either direction.
  * ─────────────────────────────────────────────────────────────────────────────
  */
 export function missingRequestedLabels(
@@ -302,9 +311,16 @@ export function missingRequestedLabels(
  * scanner that populates `error: ''` on the HEALTHY path is a live possibility,
  * not a hypothetical. Treating `''` as a fault would withhold 100% of generated
  * output from the registered `'chat-completion'` entry: the same capability
- * outage the overdue-probe note on `missingRequestedLabels` warns about,
- * arrived at from the other direction. A scanner that reports failures at all
- * will populate a message.
+ * outage the probe note on `missingRequestedLabels` describes, arrived at from
+ * the other direction. A scanner that reports failures at all will populate a
+ * message.
+ *
+ * 🔴 UNVERIFIED AGAINST THE DEPLOYED SCANNER, AND SAY SO RATHER THAN ASSUME.
+ * The 2026-08-03 live probe that settled the `results[]`-completeness question
+ * did NOT read `error`, so whether the deployed scanner populates it on a
+ * per-label failure — and whether it emits `error: ''` when healthy — is still
+ * open. If it never populates `error`, this guard is INERT rather than wrong: it
+ * adds a withhold path, it removes none.
  */
 function labelResultErrored(entry: XGuardLabelResultLike): boolean {
   const err = entry.error;

--- a/src/server/services/blocks/steps/text-output-moderation.ts
+++ b/src/server/services/blocks/steps/text-output-moderation.ts
@@ -220,9 +220,19 @@ export type TextOutputScanVerdict = {
  * and what comes back is not mistaken for a drop.
  *
  * ─────────────────────────────────────────────────────────────────────────────
- * 🔴 PRE-ADOPTION GATE — RUN ONE LIVE PROBE BEFORE THE FIRST `'textOutput'`
- * ENTRY REGISTERS. Do not skip this because the tests are green, and do not
- * weaken the guard to hedge it.
+ * 🔴 AN OVERDUE LIVE PROBE — THIS WAS WRITTEN AS A PRE-ADOPTION GATE AND THE
+ * ADOPTION HAS ALREADY HAPPENED. Do not skip it because the tests are green,
+ * and do not weaken the guard to hedge it.
+ *
+ * 🔴 CORRECTED: this note used to read "RUN ONE LIVE PROBE BEFORE THE FIRST
+ * `'textOutput'` ENTRY REGISTERS" and to close with "the posture is dormant
+ * until then, which is why this is a gate note rather than a defect." Both are
+ * FALSE. `stepRegistry` carries `'chat-completion':
+ * Object.freeze(chatCompletionStep)` (`./index`), and that entry declares
+ * `moderationPosture: 'textOutput'` (`./chat-completion.step`). The posture is
+ * REGISTERED and this guard is live on a real read path — so the probe below is
+ * not a precondition someone still has time to satisfy, it is a verification
+ * that is outstanding on shipped code.
  *
  * THE ASSUMPTION: that the deployed scanner returns a `results[]` entry for
  * EVERY requested label — including the ones that did NOT trigger. The whole
@@ -237,19 +247,27 @@ export type TextOutputScanVerdict = {
  *
  * WHAT HAPPENS IF THE ASSUMPTION IS WRONG: if the scanner returns only
  * TRIGGERED labels, then every clean scan comes back with an empty (or partial)
- * `results[]`, every clean scan reads as total drift, and the first adopting
- * entry withholds 100% of its output. That is loud, safe and fail-closed — but
- * it is a day-one capability outage, and it will present as "the feature does
- * not work" rather than as a scanner problem.
+ * `results[]`, every clean scan reads as total drift, and the registered entry
+ * withholds 100% of its output. That is loud, safe and fail-closed — but it is a
+ * capability outage, and it will present as "the feature does not work" rather
+ * than as a scanner problem.
  *
- * THE PROBE (one call, before registering an entry): submit a text scan through
+ * THE PROBE (one call): submit a text scan through
  * `createXGuardModerationRequest` with `labels: [...TEXT_OUTPUT_SCAN_LABELS]`
  * over benign content that triggers NOTHING, and read the returned step's
  * `output.results`. Expect 15 entries with `triggered: false`. If instead it
  * comes back empty or short, the drift guard needs a different signal for
  * "evaluated" — the fix is to find one the scanner actually emits, NOT to
- * loosen the withhold. The posture is dormant until then, which is why this is a
- * gate note rather than a defect.
+ * loosen the withhold.
+ *
+ * 🔴 AND WHILE YOU ARE THERE, READ `error` AND `finishReason` ON THE SAME
+ * RESPONSE. The same one call answers all three questions, and the other two are
+ * open for the same reason this one is; see {@link erroredRequestedLabels}.
+ *
+ * 🔴 DO NOT TREAT "the feature seems to work" AS THE PROBE. That inference is
+ * only as good as the traffic behind it, and nobody has measured either the
+ * traffic or the withhold rate on this path. An unrun probe is unrun in both
+ * directions.
  * ─────────────────────────────────────────────────────────────────────────────
  */
 export function missingRequestedLabels(
@@ -283,10 +301,10 @@ export function missingRequestedLabels(
  * type — came back EMPTY on every probe against the deployed scanner, so a
  * scanner that populates `error: ''` on the HEALTHY path is a live possibility,
  * not a hypothetical. Treating `''` as a fault would withhold 100% of generated
- * output from the first adopting entry: the same day-one capability outage the
- * pre-adoption gate on `missingRequestedLabels` warns about, arrived at from the
- * other direction. A scanner that reports failures at all will populate a
- * message.
+ * output from the registered `'chat-completion'` entry: the same capability
+ * outage the overdue-probe note on `missingRequestedLabels` warns about,
+ * arrived at from the other direction. A scanner that reports failures at all
+ * will populate a message.
  */
 function labelResultErrored(entry: XGuardLabelResultLike): boolean {
   const err = entry.error;
@@ -639,6 +657,9 @@ export async function screenGeneratedText(opts: {
   // `chat-completion` is a registered `'textOutput'` entry (see `./index`'s
   // `stepRegistry`), so this log is live. An earlier revision of this line said
   // no such entry existed yet, which stopped being true when that entry landed.
+  // So whoever reads those rates is reading an undercount; if exact per-app
+  // attribution is ever needed, build the payload fix above rather than
+  // rediscover this.
   const cacheKey = verdictCacheKey(content, opts.isGreen);
   const cached = readCachedVerdict(cacheKey);
   if (cached !== undefined) {


### PR DESCRIPTION
## The defect

`XGuardLabelResult` in the generated client (`node_modules/@civitai/client/dist/generated/types.gen.d.ts:8713-8728`) carries `error?: null | string`. The `'textOutput'` policy's read shape declared only `label`/`score`/`triggered`, and `decideTextOutputVerdict` read only those three.

**The exact failure scenario.** The scanner attempts a label and its backend fails. That label comes back as a *present* `results[]` entry:

```jsonc
{ "label": "Extremism", "triggered": false, "score": 0, "error": "upstream 504" }
```

Two independent things then go wrong, and they compound:

1. **The label-drift guard does not fire.** `missingRequestedLabels` asks only whether a `label` string came back at all, so the errored entry lands in its `evaluated` set and `missingLabels` stays empty.
2. **Nothing is contributed to `triggered`,** because `triggered` is `false`.

So the verdict **RELEASES**. A scan in which all fifteen labels errored was byte-indistinguishable, to this policy, from a scan in which all fifteen came back clean — and the generated text reached the block unscanned.

That directly violates the invariant the file states in so many words on `missingRequestedLabels`: *"we did not get the answer we asked for, and 'no answer' must never read as 'clean'"*. Drift is a label that was never **evaluated**; an error is a label whose evaluation **failed**. Both are non-answers, and every other branch in this file — scanner throw, hard deadline, no-verdict, over-cap, drift — already withholds on one.

No fixture anywhere set `error`, so none of the 81 pre-existing tests in this suite could see it. The end-to-end regression test added here fails at base with `expected [ 'the model wrote this sentence' ] to be undefined` — i.e. the block really does receive the text.

## The fix

`erroredRequestedLabels(output, requestedLabels)`, sitting beside `missingRequestedLabels` and mirroring it: normalized-key comparison, scoped to the labels actually requested. A non-empty result forces a withhold on its own, exactly like `missingLabels`.

Three judgement calls, all documented at length in the source:

**A separate signal, not folded into `missingLabels`.** Folding it in is one line shorter and produces worse telemetry, which is the entire cost of the choice. `stage: 'label-drift'` means *"a label in `TEXT_OUTPUT_SCAN_LABELS` is not one the scanner knows about"* — the remedy is a deploy fixing our constant or the orchestrator's label config. `stage: 'label-error'` means *"the scanner knows the label and its backend failed"* — the remedy is scanner health, and it typically clears by itself. Aggregating them sends whoever reads the alert to the wrong place and makes each stage's rate a mix of two unrelated faults. This file already made exactly this call once, for exactly this reason, when it gave drift its own stage instead of reusing `'error'`.

**Not memoized, checked *above* `writeCachedVerdict`** — same position and same reasoning as the drift branch. A per-label scanner fault is operational and clears on its own, so caching the withhold would pin a blip into a five-minute outage of the capability; and because a memo *hit* logs nothing, caching it would emit the `'label-error'` line for the first observation only and then go silent — precisely when a rate is what tells you a label backend is degraded.

**Read by presence, not by value.** Anything present and non-null that is not an empty string is a failure, *including a shape we did not expect* (`42`, `{}`, `[]`) — a value we cannot interpret is a non-answer. An empty/whitespace string is deliberately **not** a failure; see the producer-behaviour section below for why my original justification of that loosening was wrong and what it rests on now.

The user-facing `reason` is unchanged (`TEXT_OUTPUT_WITHHELD_MESSAGE`); no label name reaches the block.

## Test matrix — red at `0ec1c4b9bc` (base), green at HEAD

Measured by running the *identical* test file against unmodified source, then against the fix. Base: `81 passed (81)`. With the new tests against unmodified source: **`15 failed | 83 passed (98)`**. At HEAD: **`98 passed (98)`**.

*(This measurement was taken at `0ec1c4b9bc`, before the rebase onto `dc977dc0c0`. The suite is now **101** — three casing variants were added in the audit round below, after the red-at-base run. I have not re-run the red-at-base matrix against the new base, and the three new tests are pinning tests rather than regression coverage for the original defect; they are accounted for separately in the mutation section.)*

I have split the 15 by *why* they failed at base, because that distinction is the difference between regression coverage and a shape pin. Six fail at base on the **released-vs-withheld behaviour itself** — these are the ones that prove the fail-open:

| Test | Base failure | Class |
|---|---|---|
| ONE label errored, every other clean → WITHHOLDS | `expected true to be false` (released) | 🔴 behavioural |
| ALL FIFTEEN labels errored → WITHHOLDS | `expected true to be false` | 🔴 behavioural |
| an errored label that WOULD have been a withhold label still withholds | `expected true to be false` | 🔴 behavioural |
| a non-string, non-null `error` withholds too | `expected true to be false` | 🔴 behavioural |
| **END TO END — errored label withholds the text, logs `label-error`** | `expected [ 'the model wrote this sentence' ] to be undefined` | 🔴 behavioural (read path) |
| a LABEL-ERROR withhold is NOT memoized | `expected { released: true } to deeply equal { released: false }` | 🔴 behavioural |
| the log carries neither the text nor the error string | `expected '[]' to contain 'Extremism'` | 🔴 behavioural (nothing was logged at base) |

The remaining eight are red at base only because `erroredLabels` / `erroredRequestedLabels` do not exist there. **They are attribution and shape pins, not regression coverage, and I am not counting them as such:**

| Test | Base failure | Class |
|---|---|---|
| `erroredRequestedLabels` names exactly the errored requested labels | `TypeError: … is not a function` | shape pin |
| error alongside `triggered: true` withholds on BOTH signals | `expected undefined to deeply equal [ 'Young' ]` | attribution pin — base already withholds via the genuine trigger |
| error on one label + genuine trigger on another, reported separately | `expected undefined to deeply equal [ 'Extremism' ]` | attribution pin — same |
| POSITIVE CONTROL — identical scan with `error: null` RELEASES | `expected undefined to deeply equal []` | positive control (releases at base *and* HEAD) |
| POSITIVE CONTROL — `error` field absent entirely RELEASES | `expected undefined to deeply equal []` | positive control |
| empty-string error is NOT an error | `expected undefined to deeply equal []` | invariant guard |
| `finishReason` alone does NOT withhold | `expected undefined to deeply equal []` | invariant guard |
| an error on a label we did NOT request is ignored | `expected undefined to deeply equal []` | invariant guard / scoping pin |

Two more tests are **green at base and at HEAD** and are labelled as such in the file: the fixture-validation test, and `POSITIVE CONTROL — the SAME path publishes when no label errored`.

**Fixtures are deliberately discriminating.** The existing `scanOutput` builds `results[]` by mapping one shape over `TEXT_OUTPUT_SCAN_LABELS`, so every field covaries and the fake encodes the same assumption the code does. The new cases use a per-label override table where the errored label (`Extremism`), the triggered label (`Young`) and the clean label (`Celebrity`) are three *different* labels drawn from three different policy tiers, with pairwise-distinct scores — and a dedicated test asserts that distinctness so it cannot rot back into a covarying fixture.

### Mutation sweep — CORRECTED after audit: my M7 and M8 were both one-sided

🔴 **My original M8 row in this PR body was wrong, and I am correcting it rather than editing it away.** I claimed "M8 case-sensitive comparison in the guard — killed by 10 tests" and read that as the guard's case-insensitivity being pinned. It was not. My mutant replaced `normalizeLabel(...)` on the **read side only**, so it died because the two sides stopped *agreeing* — not because any test exercised a casing difference. The **symmetric** mutant (`.trim()` on **both** sides, `:400` and `:403`) is not equivalent, and I reproduced the auditor's result before changing anything: **it survived 0 failed / 98 total.**

That is a live gap, not a technicality. The orchestrator matches the requested list case-insensitively but answers with its **own** canonical spelling, so "we asked for `Extremism`, it answered about `extremism`" is the shape that actually arrives — and a case-sensitive guard finds no match, reports no errored label, and **releases**. `missingRequestedLabels` has had a dedicated test for exactly this all along; my new function had none. **Added** (3 casing variants).

The auditor's suspicion about M7 also **reproduced**: my `return [...errored]` mutant returns *lowercased* labels, so most of its 10 kills were incidental output-casing rather than scoping. A casing-preserving scoping-only mutant (M7b) dies to **1** test — the dedicated scoping test — exactly as the auditor predicted.

Battery re-run after the rebase and these edits. Control: **0 failed / 101 total** (counted, not an exit code).

| Mutant | Killed by |
|---|---|
| M1 drop the `erroredLabels` clause from `released` | 7 |
| M2 `labelResultErrored` always false | 13 |
| M3 unexpected-shape error reads as clean (`return true` → `false`) | **1 — the non-string-error test alone** |
| M4 empty-string counts as a failure (`> 0` → `>= 0`) | **1 — the empty-string test alone** |
| M5 stage renamed to `label-drift` (telemetry collision) | **1 — the end-to-end stage test alone** |
| M6 log the raw scanner error strings | **1 — the log-hygiene test alone** |
| M7a drop scoping via `return [...errored]` *(also lowercases — one-sided)* | 13 |
| **M7b scoping-only, original casing preserved** *(re-derived)* | **3 — of which the genuine scoping kill is 1** |
| M8a case-sensitive on the **read side only** *(one-sided, my original)* | 13 |
| **M8b case-sensitive on BOTH sides** *(the auditor's; survived before this round)* | **2 — the two case-DIFFERENCE variants** |
| M9 delete the `label-error` branch | 2 — including the non-memoization test |

M8b dies to exactly the two variants where the casing genuinely *differs* (`extremism`, `EXTREMISM`) and not to the whitespace variant — which is correct, since `.trim()` already handles whitespace and only a case difference can discriminate.

**The lesson, stated because it generalises:** a mutant that breaks *one side* of a two-sided comparison tests that the sides agree, not that the comparison is normalized. Both of my original mutants had that defect, and both looked strongly killed (10 tests each).

### Other gates

- Rebased onto `main` at `dc977dc0c0` (after #3607/#3608/#3610/#3611). One conflict, in the verdict-memo paragraph: **#3611 had already corrected the same stale "no `'textOutput'` entry registered" claim**, more concisely than my version — I took upstream's wording and kept only the one sentence of mine it did not already cover, rather than reintroducing my duplicate.
- `pnpm typecheck` post-rebase: **135 errors total, 0 in any file this PR touches** (measured). Earlier in this PR I measured base and HEAD at 135/135 with a positive control — injecting a deliberate type error gave **136, one of them in the changed file** — which is what makes "0 in my files" a meaningful reading rather than a claim about a file tsc never loaded.
- Wider suites post-rebase: `src/server/services/blocks` + the router suite — **109 files / 2498 tests passed**. My own suite: **101** (98 + 3 new casing variants).
- `eslint` clean on both files; `prettier --check` passes (it named the one file it initially flagged, so that check was discriminating and not a zero-file false pass).

## What I chose NOT to do, and why

**`finishReason` is not acted on.** It sits beside `error` in the same generated type, is also `null | string`, and plausibly carries a comparable signal — a truncated LLM-judge output is also a degraded answer. It is excluded because, unlike `error`, it **cannot be read by presence**: a `finishReason` is emitted on the healthy path too, so acting on it means knowing which *values* mean "fine". That value set is orchestrator-side configuration this codebase does not control and has never observed. Guessing too strictly ("only `'stop'` is fine") withholds 100% of output the moment the scanner spells the healthy value differently; guessing too loosely reintroduces the fail-open being fixed. The probe gate is written on the function: read the `finishReason` distribution across all fifteen labels against benign content on the deployed scanner, and if a healthy value is established, `labelResultErrored` is the single place to extend. Pinned by an explicitly-labelled invariant guard so nobody quietly makes the opposite decision.

**The raw error strings are not logged** — only the label names. The names are this file's own constants and carry nothing; an error *string* is scanner-supplied text from the other side of a network boundary and may quote the content being scanned, and this log store must never hold the text the posture is withholding. The message remains available in the scanner's own logs. Asserted by a test, and mutant M6 confirms the assertion bites.

**`missingRequestedLabels` was not changed.** An errored entry genuinely *is* present in `results[]`, so it is not drift; leaving that function alone keeps the drift signal meaning exactly one thing and keeps the blast radius to additions.

**Files outside `text-output-moderation.ts` and its test were not touched.** No change was needed in `moderation.ts`, `steps/index.ts`, `blocks.router.ts`, `chat-completion.step.ts` or `request-time-policy.ts` — `TextOutputScanVerdict` gained a field but is only constructed in the one place, which typecheck confirms.

## Reachability — and a correction I have to make about my own first draft

**This fail-open was on a reachable path, not a dormant one.** `stepRegistry` carries `'chat-completion': Object.freeze(chatCompletionStep)` (`src/server/services/blocks/steps/index.ts:1361`) and that entry declares `moderationPosture: 'textOutput'` (`chat-completion.step.ts:314`) — verified on `origin/main` at `0ec1c4b9bc`. A `'textOutput'` entry **is** registered, so this policy is live on a real read path today.

My first draft of this PR said the opposite — *"the posture has no registered entry yet, so it's dormant in production either way"*. That was wrong, and it is worth saying exactly how I got it wrong, because **it is the same defect class this PR exists to fix**: I read a stale comment in the file, believed it, and repeated its claim as my own finding without checking it against the registry. A comment asserted something the implementation contradicted, and it propagated straight into a severity assessment that would have told a reviewer to deprioritize this. That is precisely the "no answer read as clean" failure mode, one layer up.

Two comments in this file carried that false claim, and the follow-up commit corrects both:

1. **The verdict-memo paragraph** deferred a per-app-attribution fix partly on *"no `'textOutput'` entry is registered yet, so the rate has no data to be wrong about."* The per-app trigger-rate undercount it describes is **live**, not hypothetical. The deferral still stands — the undercount is bounded and one-directional and the obvious fix is worse — but it now rests on that argument alone, and whoever reads those rates needs to know they are reading an undercount.
2. **The drift guard's "PRE-ADOPTION GATE"** — *"run one live probe BEFORE the first `'textOutput'` entry registers … the posture is dormant until then, which is why this is a gate note rather than a defect"* — is a gate whose precondition has already passed. Rewritten to split what is measured from what is open (see below), with an explicit warning not to substitute "the feature seems to work" for the probe.

(That second comment was outside the one line I was asked to correct, but it is in this file, it is the same false claim, and my own new documentation cross-references it — leaving it would have made this PR's docs internally inconsistent.)

### The drift guard's assumption is measured; the `error` behaviour is not

My first rewrite of that note called its central assumption *"unverified on a live path."* **That was also wrong** — the third instance of this same defect class in this PR, and worth recording as such rather than quietly fixed. I asserted a verification state without checking it, which is what the other two comments did to me.

The `results[]`-completeness assumption — that the scanner returns an entry for **every** requested label, including untriggered ones — **was verified by live probe against the production orchestrator on 2026-08-03**: 15 labels requested, 15 returned, all `triggered: false`, names matching 15 of 15. The probe carried a **positive control**: a *bogus* label came back **absent**, which is what proves `results[]` genuinely omits what the scanner did not evaluate — i.e. the drift guard can actually fire, rather than being a branch nothing reaches. That refutes the "every clean scan reads as total drift, the entry withholds 100% of its output" scenario the note was written to gate against.

The note now records this as a **point measurement, not a standing guarantee**: it says nothing about behaviour after a redeploy, a label-config change or a model swap — and nothing in this repo can detect such a change, because the suite's own fixture builds `results[]` by mapping over `TEXT_OUTPUT_SCAN_LABELS` and so encodes the very shape it would need to falsify. The re-probe recipe now includes the bogus-label positive control, since "15 came back" alone cannot distinguish a scanner that echoes every label it is handed.

**What that probe did not do is read `error` or `finishReason`** — so the behaviour *this PR's fix* depends on is the half that is genuinely still open. That split is now stated in both affected comments.

## The producer's actual behaviour — read from source, and it changes two of my earlier claims

I previously wrote that the `error` behaviour was unprobed and that the guard might be **inert**. Both are now answered from the producing repo (`civitai-orchestration`), and both were more pessimistic than reality:

- **`Error` is populated on a real, reachable failure path.** `XGuardScoring.cs:223-227` assigns it from a three-way switch: the literal `"Step output was missing."` when the scored blob is absent, `"Step completed without output choices."` when it is present but empty, and `null` otherwise. **The guard is not inert — it fires.**
- **And that entry really does look clean.** `ParseScore(null)` returns a score of 0 (`XGuardScoring.cs:354-358`), below every threshold, so the failed entry arrives with `triggered: false`. That is precisely the "looks clean, answered nothing" shape this fix catches.
- **The withhold-everything counter-risk is refuted at source.** `results[]` always carries one entry per resolved label (`XGuardModerationHandler.cs:170-182`), so treating a populated `error` as a withhold cannot degenerate into withholding everything.
- **My empty-string rationale was wrong.** I argued by analogy from `ModelReason` coming back empty on probes. That analogy does not hold: `ModelReason` is a `required string` and `Error` is `string?` (`XGuardModerationModels.cs:52,64`) — which is exactly why one is `""` and the other is `null`. The loosening is kept as cheap defence against a future default change, and is now labelled as that rather than as a reasoned necessity.

*Caveat, recorded in the source comment too: these reads come from a local clone slightly behind its origin, and the label set itself is runtime grain state rather than source.*

## 🔴 A pre-existing upstream masking path — the fail-closed claim is not end-to-end

Not introduced here and not fixable here, but the claim must not read as a guarantee it does not provide, so `screenGeneratedText` now says so explicitly.

The scanner segments content at 16,000 chars (`XGuardScoring.DefaultMaxInputCharsPerSegment`) and then picks **one** result per label as the **highest-scoring segment** (`XGuardModerationHandler.cs:174-181`). A segment that *failed* scores 0 — so whenever any other segment for that label scored above 0, the failed segment **and its `Error` are discarded before the response is built**. The label then arrives here looking cleanly evaluated while part of the content went unscanned, and no guard on this side can detect it: the evidence was dropped upstream.

Reachable for any generated output longer than one segment (~16,000 chars), which the 50,000-char cap permits. The fix belongs in the producer, which would need to propagate a segment-level failure rather than let max-score selection swallow it.

## 🔴 Load consequence of not memoizing the label-error verdict

Stated rather than designed around, because it is a real trade this PR makes. `attachModeratedStepTextOutputs` runs on **every** `pollWorkflow`, at a cadence **untrusted block code chooses**. Because a label-error verdict is deliberately not memoized (so a scanner recovery is not pinned shut for five minutes), a scanner blip now produces an **unbounded rescan of the degraded dependency for as long as the fault lasts** — i.e. the retry rate against a struggling scanner is set by the caller, not by us.

My source comment justifies this as "bounded by `MAX_SCANNED_CONTENT_CHARS`". That bounds per-scan **size**, not **rate**, and I should not have let it stand as though it bounded both. The same is already true of the pre-existing `'error'` and `'label-drift'` branches, so this PR widens an existing behaviour rather than introducing one — which is why I am not changing the design here. **Recommendation: read the `stage:'label-error'` rate after merge**; if it is non-trivial, the fix is a short negative-cache (seconds, not the 5-minute content TTL) rather than reinstating the full memo.

## What I did NOT verify

- **I take the 2026-08-03 drift-probe result on report, not from my own measurement.** It was handed to me; I could not have found it from this repo, and I did not re-run it. Its scope is one call on one date.
- **I did not probe the deployed scanner myself.** The producer behaviour above is read from source, which is stronger than my earlier guess but is still not a check that the *deployed build* matches that source.
- **I did not measure traffic or withhold rate on this path**, so I cannot quantify the exposure the fail-open created, nor how much load the point above actually implies.
- The `Unit tests` CI job is red repo-wide for unrelated reasons (the `pgDbRead`/`pgDbReadLong` mock gap, #3579) and is `continue-on-error: true`. I did not fix it and make no claim about it.
- **I have not measured traffic or withhold rate on this path.** "Registered and reachable" is a fact about the registry, which I checked. It is *not* a claim about how much production traffic actually flows through `chat-completion`, which I did not measure — so I can neither quantify the exposure this fail-open created nor infer from the feature apparently working that the drift guard's assumption holds.
- The `Unit tests` CI job is red repo-wide for unrelated reasons (the `pgDbRead`/`pgDbReadLong` mock gap, #3579) and is `continue-on-error: true`. I did not fix it and make no claim about it; the counts above are from targeted runs of the affected suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R7ZCxbgcsv3WfsSJrYdSCi
