### PR TITLE
docs(blocks): correct the fourth site claiming 'textOutput' withholds on any scanner failure

### DIFF
--- a/src/server/services/blocks/steps/index.ts
+++ b/src/server/services/blocks/steps/index.ts
@@ -1353,7 +1353,17 @@ export function isModerationPostureImplemented(posture: StepModerationPosture): 
   // 'promptAudit' runs `auditPromptServer` in the SUBMIT phase — the SAME audit
   // `textToImage` and `customComfy` run, host-side and before submission.
   // 'textOutput' runs an xGuardModeration text scan in the OUTPUT phase, at the
-  // read boundary, and withholds on a hit or on any scanner failure.
+  // read boundary, and withholds on a policy hit. It ALSO withholds on most —
+  // 🔴 not all — scanner failures: scan threw or the hard deadline fired, no
+  // output (submit failed, or the workflow was still running when the scan wait
+  // elapsed), content over the scanned-character cap, and a requested label
+  // absent from `results[]`. NOT on a per-label `error`, which currently
+  // RELEASES; `./text-output-moderation` documents that gap at the verdict
+  // function. Do not restate this as "any scanner failure" — three separate
+  // comments said exactly that, it was false in all three, and a safety claim
+  // stronger than the code is what a maintainer deletes a guard on the strength
+  // of. Re-derive from `decideTextOutputVerdict` before trusting this summary in
+  // EITHER direction.
   // Both handlers live in `./moderation`, which asserts at ITS load that each
   // posture has a handler in exactly the phases `posturePhaseRequirements` names.
   return posture === 'none' || posture === 'promptAudit' || posture === 'textOutput';


### PR DESCRIPTION
## What

A fourth site claiming `'textOutput'` "withholds on a hit or on any scanner failure" — `steps/index.ts:1356`, inside `isModerationPostureImplemented`'s body.

#3607 corrected this claim in the posture-union header of the same file; #3608 corrected two instances in `chat-completion.step.ts`. This one survived both, because it is in a different region of `index.ts` from the header and a different file from the other two. Found by enumerating the claim across the subsystem after those merged, rather than by checking the sites already known.

## Why it's false

`'textOutput'` withholds on a policy hit and on **most** scanner failures:

- scan threw, or the hard deadline fired
- no output — submit failed, or the workflow was still running when the scan wait elapsed
- content over the scanned-character cap (checked ahead of both the network call and the memo)
- a requested label absent from `results[]` (drift)

It does **not** withhold on a per-label `error`. Such an entry still carries a `label`, so it counts as evaluated and suppresses the drift guard; it contributes nothing to `triggered`; and the verdict releases. A scan where every requested label errored is indistinguishable from all-clean.

That gap is real on this tree. #3609 is in flight to close it; this PR does **not** depend on that, and deliberately describes the tree it produces standing alone.

## Why a fourth PR for one comment

A safety claim stronger than the implementation is what a maintainer deletes a guard on the strength of. This one sits directly above the function that decides whether a posture may register at all — the first thing a reader consults when adding a posture.

The replacement enumerates what genuinely withholds, names the gap, and tells the reader to re-derive from `decideTextOutputVerdict` before trusting the summary **in either direction** — so it cannot rot into a false "still broken" claim once #3609 lands.

## Scope

Comment-only. Verified zero non-comment changed lines (same detector scored 245 on a known code-changing commit, so it is not wired to nothing). Longest changed line 89 chars against `printWidth: 100`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R7ZCxbgcsv3WfsSJrYdSCi
