### PR TITLE
fix(app-blocks): key step-moderation telemetry on AppBlock.id, not the publish slug

### DIFF
--- a/src/server/routers/__tests__/blocks.router.textOutputModeration.test.ts
+++ b/src/server/routers/__tests__/blocks.router.textOutputModeration.test.ts
@@ -168,9 +168,12 @@ vi.mock('~/server/logging/client', async (importOriginal) => {
   return { ...actual, logToAxiom: mockLogToAxiom };
 });
 
-// 🔴 A `'textOutput'` STEP IS INJECTED INTO THE REGISTRY LOOKUP, because no such
-// entry is registered yet — that is the follow-up PR. Without it, the read path
-// has nothing to dispatch on and these tests would silently assert nothing.
+// 🔴 A `'textOutput'` STEP IS INJECTED INTO THE REGISTRY LOOKUP so these cases
+// own their fixture instead of riding on whichever real entry happens to declare
+// the posture (`chat-completion` does today — this file predates it and asserted
+// none existed yet). Without an entry the read path has nothing to dispatch on
+// and these tests would silently assert nothing; the `assertStepInvariants`
+// control below is what keeps the fixture a genuinely registrable entry.
 // ONLY `getStepByOrchestratorType` is overridden; every gate, invariant and
 // posture declaration is the real one.
 const registryOverride = new Map<string, unknown>();
@@ -199,6 +202,27 @@ import {
 
 const CHAT_TYPE = 'fixtureChat';
 const GENERATED_TEXT = 'the model wrote this exact sentence';
+
+// 🔴 THE FOUR TOKEN IDS, PAIRWISE DISTINCT AND EACH SHAPED LIKE THE REAL THING.
+// The telemetry assertions below discriminate `appBlockId` from `blockId`, and a
+// fixture whose ids were equal (or empty) could not tell a right fix from a wrong
+// one — it would pass with either claim wired in. `APP_BLOCK_ID` is a real
+// `apb_<ulid>` (`AppBlock.id`, the PK); `BLOCK_SLUG` is what `AppBlock.blockId`
+// actually holds — the publish request's SLUG, a human-readable repo name, not an
+// id; `APP_ID` is the OauthClient id; `BLOCK_INSTANCE_ID` the per-render instance.
+const APP_BLOCK_ID = 'apb_01JQ8XG7YV2K4M6P8R0T2W4Y6A';
+const BLOCK_SLUG = 'pixel-poet';
+const APP_ID = 'oac_01JQ8XG7YV2K4M6P8R0T2W4Y6B';
+const BLOCK_INSTANCE_ID = 'bki_01JQ8XG7YV2K4M6P8R0T2W4Y6C';
+
+const TEXT_OUTPUT_SCAN_EVENT = 'block-step-text-output-moderation';
+
+/** Every `block-step-text-output-moderation` payload the run emitted. */
+function scanLogPayloads(): Array<Record<string, unknown>> {
+  return mockLogToAxiom.mock.calls
+    .map(([payload]) => payload as Record<string, unknown>)
+    .filter((p) => p?.name === TEXT_OUTPUT_SCAN_EVENT);
+}
 
 const textStep: AnyBlockStep = {
   id: 'fixture-chat',
@@ -288,10 +312,10 @@ function validClaims(over: Record<string, unknown> = {}) {
     iat: 0,
     exp: 0,
     jti: 'jti_test',
-    blockId: 'blk_test',
-    appId: 'app_test',
-    appBlockId: 'apb_test',
-    blockInstanceId: 'bki_test',
+    blockId: BLOCK_SLUG,
+    appId: APP_ID,
+    appBlockId: APP_BLOCK_ID,
+    blockInstanceId: BLOCK_INSTANCE_ID,
     ctx: { slotId: 'none', entityType: 'none' },
     scopes: ['ai:write:budgeted'],
     buzzBudget: 50,
@@ -465,6 +489,39 @@ describe('blocks.pollWorkflow — textOutput moderation is WIRED', () => {
       'workflowId',
     ]);
   });
+
+  it('🔴 keys the withhold TELEMETRY on AppBlock.id, not the publish slug', async () => {
+    // 🔴 WHAT THIS PINS, AND WHY IT IS NOT COSMETIC. `appBlockId` on the scan
+    // event is the per-app trigger-rate key this posture's design names as the
+    // signal that matters (see `text-output-moderation`'s `logScan` comment). The
+    // token carries THREE ids and they are different namespaces: `appBlockId` is
+    // `AppBlock.id` (`apb_<ulid>`, the PK that `BlockScopeInvocation.app_block_id`
+    // joins to), `blockId` is `AppBlock.blockId` — the publish request's SLUG —
+    // and `blockInstanceId` is a per-render id. Logging the slug under the
+    // `appBlockId` name joins to nothing, and because the value is only ever
+    // logged (no column, no FK), the wrong one fails SILENTLY. So the assertion
+    // has to name the exact value, not merely that the key exists.
+    mockVerifyBlockToken.mockResolvedValue(validClaims());
+    mockGetWorkflow.mockResolvedValue(chatWorkflow());
+    scanReturns(['Grooming']);
+
+    const caller = blocksRouter.createCaller(fakeCtx() as never);
+    await caller.pollWorkflow({ blockToken: 'tok', workflowId: 'wf_1' });
+
+    // POSITIVE CONTROL for the harness itself: a zero here would be
+    // indistinguishable from a probe wired to nothing, and every assertion below
+    // would pass vacuously over an empty array.
+    const withheld = scanLogPayloads().filter((p) => p.stage === 'withheld');
+    expect(withheld).toHaveLength(1);
+
+    expect(withheld[0].appBlockId).toBe(APP_BLOCK_ID);
+    // And explicitly NOT either of the two ids it is confusable with — the fixture
+    // keeps all three distinct precisely so this can discriminate.
+    expect(withheld[0].appBlockId).not.toBe(BLOCK_SLUG);
+    expect(withheld[0].appBlockId).not.toBe(BLOCK_INSTANCE_ID);
+    // The sibling key is unchanged — this fix must not shift `appId` too.
+    expect(withheld[0].appId).toBe(APP_ID);
+  });
 });
 
 describe('blocks.cancelWorkflow — the same boundary', () => {
@@ -513,5 +570,24 @@ describe('blocks.cancelWorkflow — the same boundary', () => {
     );
     const mature = await caller.cancelWorkflow({ blockToken: 'tok', workflowId: 'wf_1' });
     expect(mature.snapshot.textOutputs).toEqual([GENERATED_TEXT]);
+  });
+
+  it('🔴 keys the withhold TELEMETRY on AppBlock.id here too', async () => {
+    // 🔴 TWO CALL SITES NEED TWO TESTS — the same lesson the both-directions
+    // maturity test above records. `cancelWorkflow` passes its own id argument, so
+    // the poll's assertion cannot see a wrong one here.
+    mockVerifyBlockToken.mockResolvedValue(validClaims());
+    mockGetWorkflow.mockResolvedValue({ ...chatWorkflow(), status: 'canceled' });
+    scanReturns(['Extremism']);
+
+    const caller = blocksRouter.createCaller(fakeCtx() as never);
+    await caller.cancelWorkflow({ blockToken: 'tok', workflowId: 'wf_1' });
+
+    const withheld = scanLogPayloads().filter((p) => p.stage === 'withheld');
+    expect(withheld).toHaveLength(1);
+    expect(withheld[0].appBlockId).toBe(APP_BLOCK_ID);
+    expect(withheld[0].appBlockId).not.toBe(BLOCK_SLUG);
+    expect(withheld[0].appBlockId).not.toBe(BLOCK_INSTANCE_ID);
+    expect(withheld[0].appId).toBe(APP_ID);
   });
 });

--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -3106,7 +3106,12 @@ export const blocksRouter = router({
           // submit-phase prompt audit uses. Never a request-body field.
           isGreen: resolveBlockMaturity(claims).isGreen,
           appId: claims.appId,
-          appBlockId: claims.blockId,
+          // 🔴 `claims.appBlockId` (`AppBlock.id`, `apb_<ulid>`), NOT
+          // `claims.blockId` — which is `AppBlock.blockId`, the publish request's
+          // SLUG, and joins to nothing. The value is telemetry-only (no column, no
+          // FK), so the wrong claim fails silently. See the field's doc on
+          // `StepOutputModerationRequest`.
+          appBlockId: claims.appBlockId,
         }
       );
       // G6 — mirror an observed TERMINAL status into the durable read-model.
@@ -3250,7 +3255,8 @@ export const blocksRouter = router({
           userId,
           isGreen: resolveBlockMaturity(claims).isGreen,
           appId: claims.appId,
-          appBlockId: claims.blockId,
+          // Same as `pollWorkflow`: the `apb_<ulid>` PK, never the slug.
+          appBlockId: claims.appBlockId,
         }
       );
       // customComfy post-paid SETTLE (plan §5.3): a mid-run cancel BILLS the

--- a/src/server/services/blocks/steps/moderation.ts
+++ b/src/server/services/blocks/steps/moderation.ts
@@ -130,24 +130,30 @@ export type StepOutputModerationRequest = {
    * `./text-output-moderation` — and is never written to a column, so nothing
    * FK-resolves it and a wrong value fails silently.
    *
-   * 🔴 THE TWO LIVE CALLERS PASS `claims.blockId`, NOT `claims.appBlockId`, AND
-   * THOSE ARE DIFFERENT NAMESPACES. `blocks.router.ts` `pollWorkflow` (:3108)
-   * and `cancelWorkflow` (:3252) are the only 2 of that router's ~15
-   * `appBlockId:` assignments reading `claims.blockId`; the rest read
-   * `claims.appBlockId`. The token carries both:
-   * `block-scope.middleware.ts:42-49` documents `appBlockId` as `AppBlock.id`,
-   * the `apb_<ulid>` PK, while `blockId` is `AppBlock.blockId` — the publish
-   * request's SLUG (`publish-request.service.ts:2392-2398` writes
-   * `id: apb_<ulid>` and `blockId: request.slug` onto the same row). So the
-   * value logged under this name does NOT join to `AppBlock.id` or to
+   * 🔴 IT MUST BE `claims.appBlockId`, AND THE THREE ID CLAIMS ON A BLOCK TOKEN
+   * ARE DIFFERENT NAMESPACES — do not "simplify" this to `claims.blockId`.
+   * `block-scope.middleware.ts` documents `appBlockId` as `AppBlock.id`, the
+   * `apb_<ulid>` PK; `blockId` is `AppBlock.blockId` — the publish request's SLUG
+   * (`publish-request.service.ts` writes `id: apb_<ulid>` and
+   * `blockId: request.slug` onto the SAME row); `blockInstanceId` is a third,
+   * per-render claim. Only the PK joins to `AppBlock.id` /
    * `BlockScopeInvocation.app_block_id`, which is what the per-app trigger-rate
-   * aggregation in `./text-output-moderation` assumes it can key on.
+   * aggregation in `./text-output-moderation` keys on.
    *
-   * Recorded rather than papered over: the defect is at the two router call
-   * sites, not in this field's name — renaming it to match what is passed would
-   * make the log self-consistent and still un-joinable. An earlier revision of
-   * this line read "The block instance id", which matches NEITHER claim:
-   * `blockInstanceId` is a third, separate claim on the same token.
+   * HISTORY, because the failure mode is invisible: both live callers passed
+   * `claims.blockId` until 2026-08-04 — the only 2 of that router's 15
+   * claim-sourced `appBlockId:` assignments doing so — and nothing caught it,
+   * because a wrong value here is neither written nor FK-checked. It is pinned
+   * now by value (not merely by presence) at both call sites in
+   * `routers/__tests__/blocks.router.textOutputModeration.test.ts`, over a
+   * fixture whose three ids are deliberately pairwise distinct.
+   *
+   * On a VERIFIED token this is always a non-empty string (`verifyBlockToken`
+   * rejects a non-string `appBlockId`), so the `?` is for callers that have no
+   * token at all, not for a token that might lack the claim. For a dev-tunnel or
+   * mod-review token the value is a SYNTHETIC non-FK id (`ephemeral-<slug>` /
+   * `pubreq_<ulid>`) — that is still the right key: it is the same id the audit
+   * path records for those tokens.
    */
   appBlockId?: string;
 };

--- a/src/server/services/blocks/steps/text-output-moderation.ts
+++ b/src/server/services/blocks/steps/text-output-moderation.ts
@@ -498,8 +498,11 @@ export async function screenGeneratedText(opts: {
   // If cross-app attribution ever has to be exact, the shape of the fix is to
   // store `appId` (plus the labels/scores) in the entry as a PAYLOAD — never in
   // the key — and log on a hit only when the stored `appId` differs. That keeps
-  // the memo intact and the poll loop silent. Not built today: no `'textOutput'`
-  // entry is registered yet, so the rate has no data to be wrong about.
+  // the memo intact and the poll loop silent. Not built today because the
+  // undercount is bounded as described above — NOT because the rate is unused:
+  // `chat-completion` is a registered `'textOutput'` entry (see `./index`'s
+  // `stepRegistry`), so this log is live. An earlier revision of this line said
+  // no such entry existed yet, which stopped being true when that entry landed.
   const cacheKey = verdictCacheKey(content, opts.isGreen);
   const cached = readCachedVerdict(cacheKey);
   if (cached !== undefined) {


### PR DESCRIPTION
## The bug

`blocks.pollWorkflow` and `blocks.cancelWorkflow` passed `appBlockId: claims.blockId` when calling `attachModeratedStepTextOutputs`. That is the wrong claim.

### Three ids, one token, not aliases

A verified block token carries three separate identifiers:

| claim | is | shape |
|---|---|---|
| `appBlockId` | `AppBlock.id` — the primary key | `apb_<ulid>` |
| `blockId` | `AppBlock.blockId` — the publish request's **slug** | a repo name, e.g. `pixel-poet` |
| `blockInstanceId` | a per-render instance id | `bki_…` / `page_…` |

Evidence they are distinct, not two names for one value:

- `publish-request.service.ts` writes `id: \`apb_${newUlid()}\`` and `blockId: request.slug` onto the **same row**.
- The primary mint site (`pages/api/v1/block-tokens/index.ts`) signs `blockId: block.blockId`, `appId: block.appId`, `appBlockId: block.id` — three separate reads off that one row.
- `block-scope.middleware.ts` documents `appBlockId` as "`AppBlock.id` (`apb_<ulid>`) … used to write `BlockScopeInvocation` rows without a per-request DB lookup".

## What consumes the value

Traced end to end, and it is exactly one consumer:

`blocks.router` → `attachModeratedStepTextOutputs` → `runStepOutputModeration` (the `'textOutput'` posture handler) → `screenGeneratedText` → **`logScan`** → `logToAxiom({ name: 'block-step-text-output-moderation', … })`.

`logScan` strips only `texts` and spreads everything else into the event, so `appBlockId` lands in the Axiom payload verbatim. `text-output-moderation.ts` names that field as the **per-app trigger-rate key** — the signal its own design doc says is "the signal that matters", precisely because this posture deliberately does *not* charge a hit against the user's moderation record (the app's system prompt generated the text, not the user).

- `attachModeratedStepTextOutputs` is the **only** production caller of `runStepOutputModeration`; its only two call sites are the two fixed here.
- Repo-wide, `block-step-text-output-moderation` appears in exactly two files: the emitter and its test.
- **No DB write, no FK, no column.** A slug logged under `appBlockId` joins to neither `AppBlock.id` nor `BlockScopeInvocation.app_block_id` — and fails silently, which is why nothing caught it.

**Severity: telemetry-only.** No user-visible behaviour, no authorization decision, no money path reads this value. The cost is that during a moderation incident the per-app trigger rate would not join to the app records you would be joining it against.

## Was the doc wrong instead of the code?

No — checked explicitly, since "the field is deliberately the slug" would have been a legitimate outcome. Two things rule it out: the consumer is an aggregation that its own comment says keys on `AppBlock.id` / `BlockScopeInvocation.app_block_id`, and the sibling key `appId` on the same event is already the resolvable `OauthClient.id`. A slug alongside it is inconsistent, not a deliberate alternative. Renaming the field instead would make the log self-consistent and still un-joinable.

## Is `appBlockId` ever absent?

No — checked, because a naive swap that logged `undefined` where a slug at least logged *something* would be a regression.

`verifyBlockToken` rejects a token outright when `typeof claims.appBlockId !== 'string'`, so on any token that reaches these procedures the claim is a present string. The `?` on the field's type is for callers that have no token at all, not for a token that might lack the claim. Three token classes, all covered:

- **normal** → a real `apb_<ulid>`;
- **dev-tunnel** (`dev-scoped-mint.service`) → either a real `apb_` id or a synthetic `ephemeral-<slug>`;
- **mod review sandbox** (`mintReviewBlockToken`) → the `pubreq_<ULID>` request id.

The synthetic cases are still the right key: they are the same id the audit path (`recordScopeInvocation`) records for those tokens, via its nullable-`appBlockId` branch. So this change never introduces `undefined`, and never degrades a case relative to the slug.

## The 2-of-15 claim — confirmed

Enumerated every `appBlockId:` assignment in `blocks.router.ts` (50 textual occurrences; the relevant population is the **claim-sourced** ones, the rest being zod input schemas, Prisma `select`s, and `input.*` / `block.id` passthroughs):

- `appBlockId: claims.appBlockId` — **13** sites
- `appBlockId: claims.blockId` — **2** sites (`:3109` pollWorkflow, `:3253` cancelWorkflow)

**15 total, 2 wrong.** The claim held exactly. A repo-wide grep found no other `appBlockId: …blockId` mis-assignment outside this router (the two other hits are correct: they build `{ appBlockId: row.id, blockId/slug: row.blockId }` pairs).

## Test matrix

Added value-pinning coverage to `blocks.router.textOutputModeration.test.ts` — one test per call site, since each procedure passes its own argument and the other's test cannot see a wrong one (the same lesson that file already records for the maturity-tier tests).

The claims fixture was tightened so the ids are **pairwise distinct and realistically shaped**: `apb_01JQ8XG7YV…` vs the slug `pixel-poet` vs `oac_…` vs `bki_…`. With the previous `apb_test`/`blk_test` fixture the assertions would still discriminate, but nothing pinned that they had to.

| | base (`origin/main`, f959487c60) | HEAD |
|---|---|---|
| `…keys the withhold TELEMETRY on AppBlock.id, not the publish slug` (pollWorkflow) | **FAIL** | PASS |
| `…keys the withhold TELEMETRY on AppBlock.id here too` (cancelWorkflow) | **FAIL** | PASS |
| file total | 2 failed / 10 passed (12) | 12 passed |

Both failed at base with the bug's own signature — `AssertionError: expected 'pixel-poet' to be 'apb_01JQ8XG7YV2K4M6P8R0T2W4Y6A'` — i.e. red for **this** reason, not incidentally.

**Positive control (not just a negative one).** Each test first asserts `expect(withheld).toHaveLength(1)` on the emitted-payload array. A reassuring `0` there would be indistinguishable from a probe wired to nothing, and every later assertion would pass vacuously over an empty array. That count was `1` at base, so the harness demonstrably observes the event.

**Per-site mutation sweep.** Reverting *one* call site at a time:

- revert pollWorkflow only → only the pollWorkflow test fails (1 failed / 11 passed)
- revert cancelWorkflow only → only the cancelWorkflow test fails (1 failed / 11 passed)

Each dies to its own assertion, not to the other's — so neither test is green for the wrong reason. Each also asserts `.not.toBe(BLOCK_SLUG)` and `.not.toBe(BLOCK_INSTANCE_ID)`, so a swap to the third confusable claim is caught too.

## Gates

- **Unit:** `blocks.router.textOutputModeration` + `services/blocks/steps/__tests__/` → 6 files, **320 tests, 0 failed**. Wider sweep over `src/server/routers/__tests__/` + `src/server/services/blocks/` → 145 files, **3431 tests, 0 failed**. Counted from the runner's own tally with ANSI stripped, not from an exit code.
- **Typecheck:** `pnpm typecheck` run in two clean worktrees (base and HEAD) and compared as **error SETS** with the worktree path normalised out: **135 at base, 135 at HEAD, empty diff in both directions.** The 135 are the pre-existing `CosmeticType`/`"Sticker"` Prisma enum drift. The set comparison was itself positive-controlled with a synthetic error line to confirm it can surface a difference.
- **Prettier / ESLint:** clean on all four changed files. Prettier was positive-controlled against a deliberately mis-formatted probe file, because `--check` prints a success message when it matches zero files.

## Comments corrected

Three comments asserted things the code no longer (or never) supported:

1. `StepOutputModerationRequest.appBlockId` documented the hazard as **open** ("THE TWO LIVE CALLERS PASS `claims.blockId`"). Left as-is it would tell the next reader the defect is still there. Rewritten to state the invariant, keep the namespace explanation, and record the history plus where it is now pinned.
2. `text-output-moderation.ts` said "no `'textOutput'` entry is registered yet, so the rate has no data to be wrong about." False — `chat-completion` declares `moderationPosture: 'textOutput'` and is in the live `stepRegistry`. This one is load-bearing for the severity of this PR, so leaving it would have contradicted the reasoning above.
3. The test file's registry-injection comment repeated the same stale "no such entry is registered yet" claim.

## Deliberately not done

- **No rename of the field.** `appBlockId` is the right name; the call sites were the defect.
- **No change to the 13 already-correct sites**, and no change to `claims.blockId`'s other, legitimate uses (dev-tunnel lookup, `apps.router` slug derivation, the `app-block:block:<slug>` tag) — those genuinely want the slug.
- **No backfill or reinterpretation of already-emitted events.** Historical `block-step-text-output-moderation` rows carry slugs under `appBlockId`; this PR changes the value going forward only. If anyone queries that event over a window spanning this deploy, the field changes namespace mid-window.
- **Axiom-side consumers could not be enumerated from this repo.** I verified the only *code* consumer, and that no dashboard/alert/query definition for this event exists in-tree — but Axiom saved queries and dashboards live outside the repo, so if one filters on `appBlockId` with a slug literal it will need updating. Given the event is `type: 'warning'` on a recently-adopted posture, I'd expect few or none, but I could not prove that from here.
- **Not verified in production.** This is a log-payload change on a path that requires a live block token, a registered `'textOutput'` step and a scanner hit; I exercised it through the real tRPC procedures in-process, not against a deployed pod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R7ZCxbgcsv3WfsSJrYdSCi
