### PR TITLE
test(get-models-raw): hoist model.service import out of the per-test timeout budget

### DIFF
--- a/src/server/services/__tests__/get-models-raw.transient-503.test.ts
+++ b/src/server/services/__tests__/get-models-raw.transient-503.test.ts
@@ -1,5 +1,20 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { TRPCError } from '@trpc/server';
+// 🔴 STATIC imports, deliberately — do NOT move these back to an
+// `await import(...)` inside a test body / helper. `model.service` is a
+// ~4800-line module that transitively pulls the heavy image/search service
+// graph; its cold TS transform + import is the dominant cost of this file and
+// Vitest charges it to whichever test first triggers it. As a per-test dynamic
+// import that put ~99.9% of the file's runtime inside ONE test's `testTimeout`
+// budget (measured: 2726ms of a 2730ms file locally under a 4-CPU quota;
+// ~44.2s of a ~44.3s file on the CI runner) — i.e. a single slow test sitting
+// just under the 60s ceiling, which reddened the suite purely on ambient
+// runner speed. Hoisted to module scope the same work happens during Vitest's
+// COLLECTION phase, which no `testTimeout`/`hookTimeout` bounds, so the cliff
+// is removed rather than moved. `vi.mock` calls below are hoisted above these
+// imports by Vitest's transform, so the mocks still apply.
+import { getModelsRaw } from '~/server/services/model.service';
+import { MeiliCallTimeoutError } from '~/server/meilisearch/client';
 import type * as MeiliClient from '~/server/meilisearch/client';
 import type * as RedisClient from '~/server/redis/client';
 
@@ -101,8 +116,7 @@ const makeCommunicationError = (statusCode: number) => {
 // (!ids || ids.length === 0))`. Only query/take/browsingLevel/ids are read
 // before the throw; the rest are optional. Cast — the full GetAllModelsOutput
 // shape is irrelevant to the catch path.
-async function callGetModelsRaw() {
-  const { getModelsRaw } = await import('~/server/services/model.service');
+function callGetModelsRaw() {
   return getModelsRaw({
     input: { query: 'foo', browsingLevel: 1, take: 10 } as never,
   });
@@ -125,7 +139,6 @@ describe('getModelsRaw — transient Meili error → TRPCError SERVICE_UNAVAILAB
   );
 
   it('preserves civitai MeiliCallTimeoutError → TRPCError SERVICE_UNAVAILABLE', async () => {
-    const { MeiliCallTimeoutError } = await import('~/server/meilisearch/client');
     mockSearch.mockRejectedValue(new MeiliCallTimeoutError('timeout'));
     await expect(callGetModelsRaw()).rejects.toMatchObject({
       name: 'TRPCError',

--- a/src/server/services/__tests__/get-models-raw.transient-503.test.ts
+++ b/src/server/services/__tests__/get-models-raw.transient-503.test.ts
@@ -6,10 +6,14 @@ import { TRPCError } from '@trpc/server';
 // graph; its cold TS transform + import is the dominant cost of this file and
 // Vitest charges it to whichever test first triggers it. As a per-test dynamic
 // import that put ~99.9% of the file's runtime inside ONE test's `testTimeout`
-// budget (measured: 2726ms of a 2730ms file locally under a 4-CPU quota;
-// ~44.2s of a ~44.3s file on the CI runner) — i.e. a single slow test sitting
-// just under the 60s ceiling, which reddened the suite purely on ambient
-// runner speed. Hoisted to module scope the same work happens during Vitest's
+// budget. MEASURED locally: 2726ms of a 2730ms file under a 4-CPU quota, and
+// the share is invariant to CPU (99.86% unconstrained vs 99.85% under quota).
+// PROJECTED, not measured, on the CI runner: applying that invariant share to
+// the observed ~44.3s file total puts the worst test at ~44.2s of a 60s
+// ceiling. The projection is corroborated by the failure signature — ONE test
+// timing out rather than the file being uniformly slow — and by the same file
+// passing at 45.3s on a faster runner and timing out at 60.2s on a slower one
+// with byte-identical code. Hoisted to module scope the same work happens during Vitest's
 // COLLECTION phase, which no `testTimeout`/`hookTimeout` bounds, so the cliff
 // is removed rather than moved. `vi.mock` calls below are hoisted above these
 // imports by Vitest's transform, so the mocks still apply.

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -77,6 +77,19 @@ export default defineConfig({
           // overran the old 10s default — a PASS→FAIL that tracked CI load, not code.
           // 60s absorbs that contention while still bounding a genuine hang (these are
           // mocked-I/O tests; nothing should legitimately approach a minute).
+          //
+          // 🔴 But do NOT treat this ceiling as the place to solve that cost. A cold
+          // `await import(...)` reached from a TEST BODY is charged to that ONE test's
+          // budget, so the file's whole transform lands inside a single 60s clock:
+          // get-models-raw.transient-503 spent 99.9% of its runtime in one test that
+          // way (2726ms of a 2730ms file under a 4-CPU quota) and went red purely on
+          // ambient runner speed. Hoist the import to MODULE SCOPE instead — `vi.mock`
+          // is hoisted above imports, so the mocks still apply, and the transform then
+          // lands in Vitest's COLLECTION phase, which no timeout bounds (Vitest has
+          // only testTimeout / hookTimeout / teardownTimeout). Where a module genuinely
+          // must load per-suite, a `beforeAll` with an explicit long timeout is the
+          // fallback (see prisma-inconsistent-orphan-relations). Raising this number
+          // only moves the cliff.
           testTimeout: 60000,
           // Same cold-`await import()` graph is paid in some suites' beforeAll/beforeEach
           // (e.g. file-download-lookup, listForModel.behavior). Vitest's default


### PR DESCRIPTION
## Problem

`get-models-raw.transient-503.test.ts` has been reddening `preview / unit-tests` with
`Test timed out in 60000ms` on slower CI runners, while passing on faster ones. It is not a
regression — the file is byte-identical to `main`, and normalised across the ~193 files
≥200 ms the slow run's global median was 1.43× the fast run's while this file was 1.36×,
i.e. it slowed slightly *less* than the run-wide trend. It sits close enough to the ceiling
that ambient runner speed decides pass/fail.

## Where the time actually goes

The file loaded the module under test with `await import('~/server/services/model.service')`
**inside a test helper**, so the first test to call it paid the cold TS transform + import of
a ~4,800-line module and its transitive image/search service graph. Vitest charges that to
that test's `testTimeout`.

Per-test durations for the file's 9 tests (file order), measured three ways:

| measurement point | before | after |
|---|---|---|
| isolated, unconstrained (24-core dev host) | **4364**, 1, 0, 0, 0, 0, 0, 1, 0 ms | **2**, 0, 0, 0, 0, 0, 0, 1, 0 ms |
| isolated, 4-CPU quota (`CPUQuota=400%`) | **3685**, 1, 1, 1, 0, 0, …  ms | **4**, 0, 0, 0, 0, 0, … ms |
| full 783-file suite, 4-CPU quota | **2726**, 1, 0, 0, 0, 0, 1, 1, 1 ms | **2**, 1, 0, 0, 0, 0, 0, 1, 0 ms |

So ~99.9% of the file's runtime was one test, and that share is *invariant* to CPU (99.86%
unconstrained, 99.85% under a 4-CPU quota). Applying that invariant share to the ~44.3 s
file total observed on the CI runner puts the worst single test at ~44.2 s against the 60 s
ceiling — which is exactly why the failure presents as **one test timing out** rather than
the file being uniformly slow. (That last figure is a projection from the measured share,
not a number measured on the runner.)

The assertions themselves are ~1 ms. There was nothing to micro-optimise.

## The fix

Hoist the import to module scope. Vitest hoists `vi.mock` calls above static imports, so the
mocks still apply and no test semantics change. The same work now happens during Vitest's
**collection** phase, which no timeout bounds — Vitest exposes only `testTimeout`,
`hookTimeout` and `teardownTimeout`, and none of them covers collection. The `tests` phase for
this file drops from 3.69 s to 8 ms; the cost reappears as `import`/`transform`, unbudgeted.

This **removes** the cliff rather than moving it. The alternatives:

- **Raise `testTimeout` for this file** — legitimate if the cost were irreducible, but it
  only moves the cliff, and the cost is not irreducible-in-place: it does not have to be
  inside a test at all.
- **`beforeAll` + an explicit long hook timeout** — the existing idiom in
  `prisma-inconsistent-orphan-relations.test.ts` (which imports the *same* module). Strictly
  better than the status quo but still re-bounds the cost at 120 s instead of unbounding it.
- **Trim the import graph / mock a heavy transitive dep** — would cut real transform work,
  but the point of this file is that it drives the *real* `getModelsRaw`; stubbing more of the
  graph trades away the thing the tests exist to prove.

## What this does NOT solve

- It does not make the suite faster. Full-suite wall time is unchanged within noise (133.9 s
  before / 146.0 s after under a 4-CPU quota — the after-run was ambiently ~9% slower across
  unrelated files too). The transform cost is still paid, just not against a per-test budget.
- It does not address the underlying ~12–16× dev-host→CI-runner factor.
- It does not change `model.service`'s import graph, which remains the largest single
  transform cost in the suite.

## Tests still discriminate (mutation matrix)

Production code was mutated at the one guard site in `getModelsRaw`, then restored
(`git diff` on `model.service.ts` is empty):

| mutation | expected | result |
|---|---|---|
| `isTransientMeiliError(err)` → `err instanceof MeiliCallTimeoutError` (narrow it back) | the 6 widening tests red | **6 failed / 3 passed** — exactly the 408/429/500/502/503/504 cases |
| `isTransientMeiliError(err)` → `true` (over-broad catch) | the 2 negative tests red | **2 failed / 7 passed** — exactly the two `does NOT convert` cases |

Both fail for *this* guard's reason, not incidentally:
- narrowed: `expected MeiliSearchCommunicationError … to match object { name: 'TRPCError' }` —
  the raw SDK error escapes unconverted.
- widened: `expected TRPCError: Model search is temporarily ov… to be Error: cannot read
  properties of undefined` — i.e. a real app bug (null deref) masked as a retryable 503,
  which is precisely what the negative cases guard.

Unmutated: 9/9 pass. Full unit suite: 783 files, 11588 passed + 1 skipped — identical counts
before and after.

## Is this a class?

Yes, but only this file was acute. Scanning the full-suite run for the deterministic signature
— first-executed test ≥300 ms *and* ≥60% of the file total, i.e. an import charged to one test
— finds **30 of 783 files**. Ranked by that first-test cost: this file **2726 ms**, then
1174, 934, 893, 863, 771 … down to 301 ms. Scaling by the ~16× dev-host→CI-runner factor
(derived independently from three files' file totals: 16.0×, 16.2×, 16.9×) only the top entry
lands near 60 s (~44 s); the second is ~19 s, i.e. a third of budget. After this change the
set is 29 files and this one is out of it.

Worth noting the ranking inverts if you look at file totals instead of per-test worst cases:
`audit-matching-equivalence` is the largest file in the suite (10978 ms locally, ~61.8 s on the
runner) but spreads it over 13 tests for a ~3.5 s worst test, and it is compute-bound (regex),
which scales at only ~5.6× rather than ~16×. It is not at risk. Similarly
`base.reward.failsoft`'s 2502 ms worst test is real retry backoff — wall-clock, so it barely
scales with CPU at all. No shared fix is warranted; the per-file signature above is the thing
to watch.

## Also in this PR

`vitest.config.mts`: a comment beside `testTimeout` pointing at module-scope hoisting. The
existing comment rationalised the 60 s ceiling as the thing that absorbs cold
`await import(...)` cost, which normalises the pattern that caused this. Comment-only.

## Note on verification

`tsc --noEmit` does **not** cover this change: `tsconfig.json` excludes `src/**/__tests__/**`.
Confirmed by injecting a deliberate `const x: number = "…"` into the file and watching a full
typecheck still exit 0. The gates that do cover it are the suite itself (9/9, and 783 files /
11588 tests unchanged) and ESLint (clean). Separately, `tsc` at the repo `typecheck` script's
`--max_old_space_size=8192` OOMs on this tree and exits 1 printing **zero** `error TS` lines;
12288 completes cleanly. Not addressed here, but it means that exit code is worth distrusting.
