### PR TITLE
DO NOT MERGE: deliberate CI probe for the pgDb mock parity guard

### DIFF
--- a/src/server/services/__tests__/contest-entry-base-model-gate.test.ts
+++ b/src/server/services/__tests__/contest-entry-base-model-gate.test.ts
@@ -59,7 +59,7 @@ vi.mock('@civitai/db', () => ({
 }));
 
 vi.mock('~/server/db/client', () => ({ dbRead: mockDbRead, dbWrite: {} }));
-vi.mock('~/server/db/pgDb', () => ({ pgDbReadLong: {},  pgDbRead: {}, pgDbWrite: {} }));
+vi.mock('~/server/db/pgDb', () => ({ pgDbRead: {}, pgDbWrite: {} }));
 vi.mock('~/server/db/db-lag-helpers', () => ({
   getDbWithoutLag: vi.fn(),
   preventReplicationLag: vi.fn(),


### PR DESCRIPTION
## 🔴 DO NOT MERGE — deliberate CI probe

This PR intentionally breaks an invariant so we can watch a guard fail. It has no
value as a change and **must be closed, not merged**. It will be closed as soon as
the CI result has been read.

### What it does

Deletes the `pgDbReadLong` key from one suite's inline
`vi.mock('~/server/db/pgDb', ...)` factory
(`src/server/services/__tests__/contest-entry-base-model-gate.test.ts`).

### Why

#3604 added two guards against the "incomplete pgDb mock factory" defect class.
Both were only ever verified on a dev host — the runtime scan in
`src/test-utils/__tests__/pgDbMock.parity.test.ts` has never been observed going
red in the actual CI runner. A guard nobody has watched fail is a claim, not a gate.

### Expected result

`pgDbMock.parity.test.ts` → `every suite mocking pgDb lists the complete export set
in its inline factory` fails, naming the offending file and the missing export.

Reproduced locally first (red at this commit, green at `origin/main`); this PR is
to confirm the same in CI and to record which check surfaces it to a reviewer.
