### PR TITLE
DO NOT MERGE: deliberate CI probe for the pgDb mock type canary

### DIFF
--- a/src/server/db/pgDb.ts
+++ b/src/server/db/pgDb.ts
@@ -20,6 +20,9 @@ declare global {
 export let pgDbWrite: AugmentedPool;
 export let pgDbRead: AugmentedPool;
 export let pgDbReadLong: AugmentedPool;
+// DO NOT MERGE — deliberate CI probe: a new export added WITHOUT updating
+// src/test-utils/pgDbMock.ts, to confirm the type canary reddens `Typecheck`.
+export let pgDbProbeOnly: AugmentedPool;
 
 if (!env.IS_BUILD) {
   const singleClient = env.DATABASE_REPLICA_URL === env.DATABASE_URL;


### PR DESCRIPTION
## 🔴 DO NOT MERGE — deliberate CI probe

This PR intentionally breaks an invariant so we can watch a guard fail. It has no
value as a change and **must be closed, not merged**. It will be closed as soon as
the CI result has been read.

### What it does

Adds an export (`pgDbProbeOnly`) to `src/server/db/pgDb.ts` and deliberately does
**not** add it to the `stubs` object in `src/test-utils/pgDbMock.ts`.

### Why

#3604 typed that stub object as `Record<keyof typeof import('~/server/db/pgDb'), unknown>`
— a total record, so an export added to `pgDb` should fail `tsc` and name it. That
canary was only ever verified on a dev host. This is the companion probe to #3614
(which exercises the runtime scan); this one exercises the compile-time canary and
the **blocking** `Typecheck` job.

### Expected result

`Typecheck` fails with:

```
src/test-utils/pgDbMock.ts(87,9): error TS2741: Property 'pgDbProbeOnly' is missing
in type '{ pgDbRead: {}; pgDbReadLong: {}; pgDbWrite: {}; }' but required in type 'PgDbStubs'.
```

Reproduced locally first (that exact error, single error, at this commit); this PR
is to confirm the same in CI.
