### PR TITLE
test(apps): make the dark-flag analytics test fail loudly, and pin its loose locators

### DIFF
--- a/src/components/Apps/AppAnalyticsInline.browser.test.tsx
+++ b/src/components/Apps/AppAnalyticsInline.browser.test.tsx
@@ -58,7 +58,35 @@ describe('AppAnalyticsInline — unavailable vs genuine zero', () => {
     };
     renderWithProviders(<AppAnalyticsInline appBlockId="apb_1" appLabel="My App" />);
 
-    await expect.element(page.getByText('Analytics unavailable')).toBeInTheDocument();
+    // Await the "Analytics" trigger rather than "Analytics unavailable" — the same
+    // reason the sibling below does it. It is the ONE element this component renders
+    // in EVERY branch, so the exact regression this test exists to catch (the
+    // unavailable branch falling through to the stat) fails on the assertions below
+    // with a legible message. Awaiting "Analytics unavailable" instead makes that
+    // regression surface as a ~15s "Matcher did not succeed in time" locator timeout
+    // — measured, by rendering the fabricated stat in this branch — which reads like
+    // CI flake rather than the value regression it actually is.
+    await expect.element(page.getByRole('button', { name: /^analytics$/i })).toBeInTheDocument();
+
+    expect(page.getByText('Analytics unavailable').elements()).toHaveLength(1);
+
+    // 🔴 These two stay NON-exact ON PURPOSE. Do NOT "fix" them to `{ exact: true }`
+    // for consistency with the sibling — the sibling needs `exact` because it resolves
+    // a SINGLE element and a substring match there collides with the stat's own hover
+    // tooltip ("Runs and unique users in the last 30 days…"). This branch renders
+    // neither the stat nor that tooltip, so there is nothing to collide with: verified
+    // by parking the pointer on the "Analytics unavailable" text and re-querying —
+    // 0 matches for both words, hovered and unhovered.
+    //
+    // Here `exact` would COST sensitivity. These are ABSENCE assertions, so a looser
+    // matcher is a STRICTER test. Measured: against a consolidated single text node
+    // `<span>0 runs · 0 users</span>` — a plausible markup simplification of the stat —
+    // `getByText('runs')` matches 1 but `getByText('runs', { exact: true })` matches 0.
+    // The exact form would silently stop catching the fabricated stat.
+    //
+    // The failure direction is safe either way: `.elements()` is `querySelectorAll`
+    // with no strict mode (that applies to `.element()`/`.query()`), so a spurious
+    // extra match fails loudly with "expected length 0 to be 1", never by hanging.
     expect(page.getByText('runs').elements()).toHaveLength(0);
     expect(page.getByText('users').elements()).toHaveLength(0);
   });


### PR DESCRIPTION
## What

`src/components/Apps/AppAnalyticsInline.browser.test.tsx`, the `dark flag: renders "Analytics unavailable", never a fabricated 0 runs / 0 users` test. Test-only change; the component is untouched.

## Why

**1. The regression it guards surfaced as a timeout, not an assertion.**

The test awaited `getByText('Analytics unavailable')` — text that *only the branch under test* renders. So when that branch regresses and falls through to the fabricated `0 runs / 0 users` stat, the await never settles and the test dies on a ~15s `Matcher did not succeed in time`, with the two absence assertions never reached. That reads like CI flake rather than the value regression it is.

Measured by mutating the component so the dark-flag branch renders the stat:

| | before | after |
|---|---|---|
| failure mode | `Matcher did not succeed in time` at the await | `AssertionError: expected [] to have a length of 1 but got +0` |
| time to fail | 15.11s | 0.21s |

The fix mirrors what the sibling test already does: await the **"Analytics" trigger**, the one element rendered in every branch, then assert the label's presence explicitly.

**2. The loose `getByText('runs')` / `getByText('users')` locators are correct here — and now say so.**

The sibling uses `{ exact: true }` because it resolves a *single* element and a substring match collides with the stat's own hover-tooltip copy. The obvious "consistency" cleanup is to make this test match. That would be a regression, for two independent reasons, both measured:

- **The collision cannot occur in this branch.** It renders neither the stat nor that tooltip. Parking the pointer on the "Analytics unavailable" label and re-querying gives 0 matches for both words, hovered and unhovered.
- **`exact` would cost sensitivity.** These are *absence* assertions, so a looser matcher is a *stricter* test. Against a regression that renders the fabricated stat as one consolidated text node, the loose form **fails** and the `{ exact: true }` form **passes** — a false green.

Failure direction was already safe (`.elements()` is `querySelectorAll`, no strict mode — that applies to `.element()`/`.query()`), so an extra match fails loudly rather than hanging. That is why this is a diagnostic-quality fix, not a correctness one.

The reasoning is captured in a comment at the call site so the cleanup does not get made later.

## Verification

- `pnpm test:component src/components/Apps/AppAnalyticsInline.browser.test.tsx` → **2 passed**.
- Mutation matrix (component mutated, then restored and re-verified clean via `git diff`):
  - dark-flag branch falls through to the stat → **1 failed | 1 passed**, crisp assertion, 0.21s.
  - fabricated stat rendered *alongside* the label as one text node → **1 failed | 1 passed**, failing on the `runs` absence assertion itself, which proves those guards are reachable and not shadowed by the earlier check.
  - same mutation with `{ exact: true }` → **2 passed** (the false green this PR documents against).
