### PR TITLE
test(pgDb-parity): finish the retraction — a false figure was still printing into CI logs

### DIFF
--- a/src/test-utils/__tests__/pgDbMock.parity.test.ts
+++ b/src/test-utils/__tests__/pgDbMock.parity.test.ts
@@ -159,9 +159,9 @@ describe('pgDb mock parity', () => {
         `FIX: add the missing key(s) to that file's factory, e.g. \`pgDbReadLong: {}\`. The full required ` +
         `set is: ${required.join(', ')}.\n\n` +
         `NOTE: the factory is deliberately an inline SYNC object literal, not a shared runtime helper. ` +
-        `A vi.mock factory is hoisted above imports, so sharing one requires an async dynamic import — ` +
-        `measured in-pod at +36% on a 44s suite (pushing it past the 60s per-test timeout) and +64% on a ` +
-        `15s one. The single-sourcing lives in THIS test plus the compile-time canary, at zero runtime cost.`
+        `A vi.mock factory is hoisted above imports, so sharing one would require an async dynamic import ` +
+        `in every mocked suite. The single-sourcing lives in THIS test plus the compile-time canary in ` +
+        `src/test-utils/pgDbMock.ts.`
     ).toEqual([]);
   });
 


### PR DESCRIPTION
## What

One-line-ish follow-up to #3604. That PR retracted a false performance claim in the file **header** but left the identical claim in the assertion's failure **message**, 130 lines lower — so whenever the guard fired, CI printed a measurement the same file labels as false 130 lines above.

## How it was found

A deliberate CI probe (opened, observed, closed unmerged) broke the invariant and read the real job output. The guard fired correctly and its message ended with:

> `…sharing one requires an async dynamic import — measured in-pod at +36% on a 44s suite (pushing it past the 60s per-test timeout) and +64% on a 15s one.`

That figure is false. It came from comparing two CI runs on different machines with no control for ambient speed. Normalised across ~193 files, the two runs are indistinguishable (global median 1.43× vs baseline, target file 1.36×, identical in both) — the async factory cost nothing measurable. The real cause was a marginal test file, fixed separately in #3612.

## Why it survived the first retraction

`grep -c` for the figure returns **2**; only one was fixed. The retraction was verified by re-reading the header, not by re-grepping the file — the classic "a `count=1` replace on a pattern that occurs more than once" trap.

## What changed

The performance justification is removed from the message entirely. It now states only what is true and actionable at the point of failure: the factory is an inline sync literal, sharing one would require an async dynamic import in every mocked suite, and the single-sourcing lives in this test plus the compile-time canary.

The header keeps the full retraction — recording that the claim was made and why it was wrong is worth keeping; the CI message doesn't need to relitigate it.

After this, the figure appears **exactly once** in the repo, inside the block whose next sentence is "That is false."

## Verification

Not verified locally — this worktree has no `node_modules`, and symlinking them from another checkout yields a misleading `Cannot find package 'kysely'` (a known artifact, hit again while trying). The change is a template literal in an `expect` message parameter and cannot affect test logic, so CI is the verification here. Flagging that explicitly rather than implying a local green.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>