### PR TITLE
test(pgdb-parity): exempt a factory that spreads the real module — the gate's advice broke correct files

### DIFF
--- a/src/test-utils/__tests__/pgDbMock.parity.test.ts
+++ b/src/test-utils/__tests__/pgDbMock.parity.test.ts
@@ -54,6 +54,29 @@ vi.mock('~/env/server', () => ({
   }),
 }));
 
+/**
+ * A `vi.mock` factory that SPREADS the real module supplies every export by construction, so the
+ * key-by-key scan is inapplicable to it and it is exempt.
+ *
+ * 🔴 THIS IS A CORRECTNESS FIX, NOT A LOOSENING. The scan is a regex for `name:`, so it read
+ * `...(await importOriginal<typeof PgDbModule>())` as supplying NOTHING and reported a suite using
+ * it as "missing: pgDbReadLong, pgDbWrite". That suite was not missing them — it had the REAL ones.
+ * Worse, the assertion message's own advice ("add `pgDbReadLong: {}`") would have REPLACED a real
+ * export with an empty stub, turning a correct file into a broken one. Reproduced on PR #3584's
+ * freshdesk suite, whose own tests collected and PASSED in the same CI run that this gate failed —
+ * which is the proof the spread resolves.
+ *
+ * The hazard this gate exists for is `kyselyDb.ts` destructuring every export at module-eval time
+ * and Vitest throwing on an omitted name. A spread omits no name, so the hazard is absent. The
+ * spread form is also strictly SAFER than an inline literal: it cannot go stale the day the module
+ * grows an export, which is the exact defect (#3579) that motivated this file.
+ *
+ * Not an endorsement of the async form everywhere — the NOTE in the assertion below still holds,
+ * and an `importOriginal` factory is async, so prefer the sync literal where suite runtime matters.
+ * This only stops reporting a safe pattern as a defect.
+ */
+export const SPREADS_ORIGINAL = /\.\.\.\s*\(?\s*await\s+importOriginal\s*[(<]/;
+
 describe('pgDb mock parity', () => {
   it('provides every export the real ~/server/db/pgDb module declares', async () => {
     const actual = await vi.importActual<Record<string, unknown>>('~/server/db/pgDb');
@@ -135,12 +158,14 @@ describe('pgDb mock parity', () => {
 
     const required = pgDbMockExportNames();
 
+    // See `SPREADS_ORIGINAL` at module scope for why a spreading factory is exempt.
     const offenders = testFiles
       .map((file) => {
         const body = fs.readFileSync(file, 'utf8');
         const m = MOCK_CALL.exec(body);
         if (!m) return null;
         const span = factorySpan(body, m.index);
+        if (SPREADS_ORIGINAL.test(span)) return null;
         const missing = required.filter((name) => !new RegExp(`\\b${name}\\s*:`).test(span));
         return missing.length
           ? `${path.relative(srcRoot, file)} (missing: ${missing.join(', ')})`
@@ -173,5 +198,43 @@ describe('pgDb mock parity', () => {
     // Untouched tiers still exist (that is the point) and stay inert rather than being auto-stubbed.
     expect(mock.pgDbRead).toEqual({});
     expect(mock.pgDbReadLong).toEqual({});
+  });
+
+  // Pins the exemption BOTH ways. Widening it re-opens #3579 (a stale literal scans as compliant);
+  // narrowing it re-breaks a correct suite AND hands out advice that would stub a real export.
+  // Verified by execution against the scan itself: the ACCEPT case below was reported as
+  // "missing: pgDbReadLong, pgDbWrite" before this exemption existed, and the REJECT cases were
+  // still reported after it.
+  it('exempts a factory that spreads the real module, and nothing else', () => {
+    // ACCEPT — supplies every export by construction. Both the shape PR #3584 uses and its
+    // whitespace/paren variants.
+    for (const accept of [
+      '...(await importOriginal<typeof PgDbModule>()),\n  pgDbRead: h.readPool,',
+      '...(await importOriginal()),',
+      '... await importOriginal(),',
+      '...(\n    await importOriginal<typeof M>()\n  ),',
+    ]) {
+      expect(SPREADS_ORIGINAL.test(accept), `should be exempt: ${accept}`).toBe(true);
+    }
+
+    // REJECT — the real defect class, plus near-misses that must NOT buy an exemption.
+    for (const reject of [
+      'pgDbRead: {}', //                          the incomplete literal #3579 was about
+      '...somethingElse,', //                     a spread of anything but the original module
+      '...(await import("~/server/db/pgDb")),', // a bare dynamic import, not importOriginal
+      'importOriginal', //                        the bare identifier, no spread
+      '// ...(await importOriginal())', //        NOTE: a commented-out spread still matches; the
+      //                                          scan is textual, so this stays a known limit
+      //                                          rather than a silent claim (see below).
+    ].slice(0, 4)) {
+      expect(SPREADS_ORIGINAL.test(reject), `should NOT be exempt: ${reject}`).toBe(false);
+    }
+
+    // 🔴 STATED LIMIT, NOT PAPERED OVER: this is a TEXT scan, so a spread inside a comment or a
+    // string would buy an exemption it should not. Same class as the `--`/`/* */` blind spot any
+    // regex gate has. Accepted because the failure direction is a false GREEN on a file someone
+    // deliberately commented out — far narrower than the false RED it replaces, which actively
+    // told authors to break correct code.
+    expect(SPREADS_ORIGINAL.test('// ...(await importOriginal())')).toBe(true);
   });
 });


### PR DESCRIPTION
## What

The `pgDb mock parity` gate reports a **false positive** on any suite whose `vi.mock` factory spreads the real module, and the advice in its own failure message would **break** such a file.

Found by rebasing #3584 onto current `main` — it failed this gate with:

```
server/freshdesk-agent/__tests__/freshdesk-tools.query-database.test.ts
  (missing: pgDbReadLong, pgDbWrite)
FIX: add the missing key(s) to that file's factory, e.g. `pgDbReadLong: {}`.
```

That file is not missing them. It has the **real** ones:

```ts
vi.mock('~/server/db/pgDb', async (importOriginal) => ({
  ...(await importOriginal<typeof PgDbModule>()),
  pgDbRead: h.readPool,
}));
```

The scan is a regex for `` `\bname\s*:` `` over the factory span, so it reads the spread as supplying nothing.

## Why this is a correctness fix, not a loosening

- **The hazard is absent.** The gate exists because `kyselyDb.ts` destructures every `pgDb` export at module-eval time and Vitest throws on an omitted name — killing the suite at collection, which reports **zero tests** rather than a failure. A spread omits no name.
- **The proof it resolves:** in the same CI run where this gate failed, #3584's own freshdesk suite **collected and passed**.
- **The suggested fix was actively harmful.** Adding `pgDbReadLong: {}` would have replaced a real export with an empty stub — turning a correct file into a broken one, on the gate's own instruction.
- **The spread form is strictly safer than a literal.** It cannot go stale the day the module grows an export — which is precisely the defect (#3579) that motivated this file. The gate was penalising the pattern most immune to the bug it guards.

This does **not** endorse the async form everywhere. The existing NOTE still holds: an `importOriginal` factory is async, and a shared async helper measured +36%/+64% on real suites, so the sync literal remains right where suite runtime matters. This only stops reporting a safe pattern as a defect.

## Verification — reproduced, fixed, and controlled both ways

| Step | Result |
|---|---|
| Gate on unmodified `main` | passes (the offending file lives on #3584's branch) |
| Probe file using the spread, **before** fix | **flagged** — `missing: pgDbReadLong, pgDbWrite`, reproducing #3584 exactly |
| Same probe, **after** fix | accepted |
| Genuinely incomplete literal (`{ pgDbRead: {} }`), **after** fix | **still flagged** — the gate is not blinded |
| #3584's **real file** copied in, after fix | accepted, `4 passed (4)` |

The new test `exempts a factory that spreads the real module, and nothing else` pins the exemption in **both** directions: 4 accept cases (including #3584's exact shape and whitespace/paren variants) and 4 reject cases (the incomplete literal, a spread of something else, a bare dynamic import, the bare identifier). Widening it re-opens #3579; narrowing it re-breaks correct suites.

## Stated limit

The scan is textual, so a spread inside a comment or string buys an exemption it should not. That is asserted explicitly in the test rather than left implicit. Accepted because the failure direction is a false **green** on a file someone deliberately commented out — far narrower than the false **red** it replaces, which told authors to break working code.

## Scope

One file, +63 lines, test-only. No production code. #3584 needs no change and should go green on its next run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R7ZCxbgcsv3WfsSJrYdSCi
