### PR TITLE
fix(creator-shop): scope review-queue creator filter to actual submit…

### DIFF
--- a/src/components/CreatorShop/creator-shop.util.ts
+++ b/src/components/CreatorShop/creator-shop.util.ts
@@ -124,6 +124,15 @@ export const useQueryCreatorShopReviewQueue = ({
     { enabled, getNextPageParam: (lastPage) => lastPage.nextCursor }
   );
 
+// Everyone who has ever submitted a shop item — the option list for the review
+// queue's creator filter.
+export const useQueryCreatorShopReviewQueueCreators = (enabled = true) => {
+  const { data = [], ...rest } = trpc.creatorShop.getReviewQueueCreators.useQuery(undefined, {
+    enabled,
+  });
+  return { creators: data, ...rest };
+};
+
 export const useMutateCreatorShop = () => {
   const queryUtils = trpc.useUtils();
 

--- a/src/pages/moderator/creator-shop.tsx
+++ b/src/pages/moderator/creator-shop.tsx
@@ -18,7 +18,6 @@ import {
   Title,
   UnstyledButton,
 } from '@mantine/core';
-import { useDebouncedValue } from '@mantine/hooks';
 import {
   IconAlertTriangle,
   IconArrowBackUp,
@@ -48,6 +47,7 @@ import { NextLink } from '~/components/NextLink/NextLink';
 import {
   useMutateCreatorShop,
   useQueryCreatorShopReviewQueue,
+  useQueryCreatorShopReviewQueueCreators,
 } from '~/components/CreatorShop/creator-shop.util';
 import { InViewLoader } from '~/components/InView/InViewLoader';
 import { CheckRow, ChecksCard } from '~/components/CreatorShop/ChecksCard';
@@ -171,32 +171,17 @@ function CreatorShopReviewPage() {
     CosmeticShopItemStatus.PendingReview
   );
   const [typeFilter, setTypeFilter] = useState<CosmeticType[]>([]);
-  // Creator filter: a searchable dropdown of real users — the queue filters by
-  // the selected user's id. Typing an all-digits term looks the user up by id.
-  const [creatorSearch, setCreatorSearch] = useState('');
-  const [debouncedCreatorSearch] = useDebouncedValue(creatorSearch, 300);
   const [selectedCreator, setSelectedCreator] = useState<{ id: number; username: string } | null>(
     null
   );
 
-  const creatorSearchTerm = debouncedCreatorSearch.trim();
-  const creatorSearchId = /^\d+$/.test(creatorSearchTerm) ? Number(creatorSearchTerm) : undefined;
-  const { data: userOptions, isFetching: searchingUsers } = trpc.user.getAll.useQuery(
-    creatorSearchId
-      ? { ids: [creatorSearchId], limit: 10 }
-      : { query: creatorSearchTerm, limit: 10 },
-    { enabled: !!currentUser?.isModerator && !!creatorSearchTerm }
+  const { creators, isLoading: loadingCreators } = useQueryCreatorShopReviewQueueCreators(
+    !!currentUser?.isModerator
   );
-  const creatorOptions = useMemo(() => {
-    const opts = (userOptions ?? [])
-      .filter((u) => !!u.username)
-      .map((u) => ({ value: String(u.id), label: u.username as string }));
-    // Keep the current selection in the option list so its label stays visible
-    // after the search results change.
-    if (selectedCreator && !opts.some((o) => o.value === String(selectedCreator.id)))
-      opts.unshift({ value: String(selectedCreator.id), label: selectedCreator.username });
-    return opts;
-  }, [userOptions, selectedCreator]);
+  const creatorOptions = useMemo(
+    () => creators.map((c) => ({ value: String(c.id), label: c.username })),
+    [creators]
+  );
 
   const { data, isLoading, fetchNextPage, hasNextPage, isFetchingNextPage } =
     useQueryCreatorShopReviewQueue({
@@ -410,19 +395,8 @@ function CreatorShopReviewPage() {
               const opt = creatorOptions.find((o) => o.value === v);
               setSelectedCreator(opt ? { id: Number(v), username: opt.label } : null);
             }}
-            searchValue={creatorSearch}
-            onSearchChange={setCreatorSearch}
             data={creatorOptions}
-            // Options already come filtered from the search endpoint — and an
-            // id search would never match its username label.
-            filter={({ options }) => options}
-            nothingFoundMessage={
-              searchingUsers
-                ? 'Searching…'
-                : creatorSearchTerm
-                ? 'No users found'
-                : 'Type a username or user id'
-            }
+            nothingFoundMessage={loadingCreators ? 'Loading…' : 'No creators found'}
             leftSection={<IconSearch size={16} />}
             comboboxProps={{ withinPortal: true }}
           />

--- a/src/server/routers/creator-shop.router.ts
+++ b/src/server/routers/creator-shop.router.ts
@@ -31,6 +31,7 @@ import {
   getResoldItemsForManage,
   removeResoldItem,
   getCreatorShopReviewQueue,
+  getCreatorShopReviewQueueCreators,
   getCreatorShopSettings,
   reviewCreatorShopItem,
   submitCreatorShopItem,
@@ -181,6 +182,9 @@ export const creatorShopRouter = router({
     .use(isFlagProtected('creatorShop'))
     .input(getReviewQueueSchema)
     .query(({ input }) => getCreatorShopReviewQueue(input)),
+  getReviewQueueCreators: moderatorProcedure
+    .use(isFlagProtected('creatorShop'))
+    .query(() => getCreatorShopReviewQueueCreators()),
   reviewItem: moderatorProcedure
     .use(isFlagProtected('creatorShop'))
     .input(reviewCreatorShopItemSchema)

--- a/src/server/services/creator-shop.service.ts
+++ b/src/server/services/creator-shop.service.ts
@@ -1167,6 +1167,23 @@ export const getCreatorShopReviewQueue = async ({
   return { items, nextCursor };
 };
 
+// Backs the review queue's creator filter: every user who has ever submitted a
+// shop item, mirroring the queue's own creator predicate (a creator-owned
+// cosmetic with at least one shop item). Deliberately not scoped to the active
+// status/type filters so the selection survives flipping between them. The set
+// is small enough to send whole — no cursor.
+export const getCreatorShopReviewQueueCreators = async () => {
+  const creators = await dbRead.user.findMany({
+    where: {
+      username: { not: null },
+      createdCosmetics: { some: { cosmeticShopItems: { some: {} } } },
+    },
+    select: { id: true, username: true },
+    orderBy: { username: 'asc' },
+  });
+  return creators.map(({ id, username }) => ({ id, username: username as string }));
+};
+
 export const reviewCreatorShopItem = async ({
   reviewerId,
   id,


### PR DESCRIPTION
…ters

The moderator review queue's creator filter searched all users via `user.getAll`, so moderators could pick creators with nothing in the queue. It now pulls its options from a new `creatorShop.getReviewQueueCreators` endpoint that returns only users who have submitted a shop item, dropping the debounced search and id-lookup handling in favor of a single loaded list.