### PR TITLE
feat(cosmetic-shop): add wishlist for shop items

### DIFF
--- a/packages/civitai-db-schema/prisma/migrations/20260804120000_add_user_cosmetic_shop_item_wishlist/migration.sql
+++ b/packages/civitai-db-schema/prisma/migrations/20260804120000_add_user_cosmetic_shop_item_wishlist/migration.sql
@@ -1,0 +1,17 @@
+-- Cosmetic shop wishlist: per-user saved shop listings, surfaced back on /shop.
+-- Keys off CosmeticShopItem (the listing) rather than Cosmetic, matching how
+-- purchases and the shop grid are keyed.
+-- Applied manually (we do NOT use prisma migrate deploy).
+
+CREATE TABLE "UserCosmeticShopItemWishlist" (
+    "userId" INTEGER NOT NULL,
+    "shopItemId" INTEGER NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "UserCosmeticShopItemWishlist_pkey" PRIMARY KEY ("userId", "shopItemId")
+);
+
+CREATE INDEX "UserCosmeticShopItemWishlist_shopItemId_idx" ON "UserCosmeticShopItemWishlist"("shopItemId");
+
+ALTER TABLE "UserCosmeticShopItemWishlist" ADD CONSTRAINT "UserCosmeticShopItemWishlist_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+ALTER TABLE "UserCosmeticShopItemWishlist" ADD CONSTRAINT "UserCosmeticShopItemWishlist_shopItemId_fkey" FOREIGN KEY ("shopItemId") REFERENCES "CosmeticShopItem"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/civitai-db-schema/prisma/schema.full.prisma
+++ b/packages/civitai-db-schema/prisma/schema.full.prisma
@@ -533,6 +533,7 @@ model User {
   addedCosmeticShopSections  CosmeticShopSection[]
   addedCosmeticShopItems     CosmeticShopItem[]
   purchasedCosmetics         UserCosmeticShopPurchases[]
+  wishlistedCosmeticShopItems UserCosmeticShopItemWishlist[]
   createdCosmetics           Cosmetic[]                  @relation("CosmeticCreator")
   donationGoals              DonationGoal[]
   donations                  Donation[]
@@ -4025,6 +4026,18 @@ model CosmeticShopItem {
 
   purchases UserCosmeticShopPurchases[]
   sections  CosmeticShopSectionItem[]
+  wishlists UserCosmeticShopItemWishlist[]
+}
+
+model UserCosmeticShopItemWishlist {
+  userId     Int
+  user       User             @relation(fields: [userId], references: [id], onDelete: Cascade)
+  shopItemId Int
+  shopItem   CosmeticShopItem @relation(fields: [shopItemId], references: [id], onDelete: Cascade)
+  createdAt  DateTime         @default(now())
+
+  @@id([userId, shopItemId])
+  @@index([shopItemId])
 }
 
 model CosmeticShopSectionItem {

--- a/packages/civitai-db-schema/src/kysely/types.ts
+++ b/packages/civitai-db-schema/src/kysely/types.ts
@@ -3629,6 +3629,11 @@ export type UserCosmetic = {
   forType: CosmeticEntity | null;
   remaining: number | null;
 };
+export type UserCosmeticShopItemWishlist = {
+  userId: number;
+  shopItemId: number;
+  createdAt: Generated<Timestamp>;
+};
 export type UserCosmeticShopPurchases = {
   userId: number;
   cosmeticId: number;
@@ -4191,6 +4196,7 @@ export type DB = {
   TrustedSpokeDomain: TrustedSpokeDomain;
   User: User;
   UserCosmetic: UserCosmetic;
+  UserCosmeticShopItemWishlist: UserCosmeticShopItemWishlist;
   UserCosmeticShopPurchases: UserCosmeticShopPurchases;
   UserEngagement: UserEngagement;
   UserLink: UserLink;

--- a/packages/civitai-db-schema/src/models.ts
+++ b/packages/civitai-db-schema/src/models.ts
@@ -592,6 +592,7 @@ export interface User {
   addedCosmeticShopSections?: CosmeticShopSection[];
   addedCosmeticShopItems?: CosmeticShopItem[];
   purchasedCosmetics?: UserCosmeticShopPurchases[];
+  wishlistedCosmeticShopItems?: UserCosmeticShopItemWishlist[];
   createdCosmetics?: Cosmetic[];
   donationGoals?: DonationGoal[];
   donations?: Donation[];
@@ -2679,6 +2680,15 @@ export interface CosmeticShopItem {
   listed: boolean;
   purchases?: UserCosmeticShopPurchases[];
   sections?: CosmeticShopSectionItem[];
+  wishlists?: UserCosmeticShopItemWishlist[];
+}
+
+export interface UserCosmeticShopItemWishlist {
+  userId: number;
+  user?: User;
+  shopItemId: number;
+  shopItem?: CosmeticShopItem;
+  createdAt: Date;
 }
 
 export interface CosmeticShopSectionItem {

--- a/src/components/CosmeticShop/CommunityCosmeticsSection.tsx
+++ b/src/components/CosmeticShop/CommunityCosmeticsSection.tsx
@@ -2,6 +2,7 @@ import { Center, Loader } from '@mantine/core';
 import { useState } from 'react';
 import { useDebouncedValue } from '@mantine/hooks';
 import { ShopFiltersDropdown } from '~/components/CosmeticShop/ShopFiltersDropdown';
+import { useQueryWishlistedShopItems } from '~/components/CosmeticShop/cosmetic-shop.util';
 import { useQueryCommunityCosmetics } from '~/components/CreatorShop/creator-shop.util';
 import { useOwnedCosmeticIds } from '~/components/CreatorShop/Storefront/storefront.util';
 import { creatorShopFilterTypes } from '~/components/CreatorShop/Submit/submit.constants';
@@ -34,6 +35,7 @@ export function CommunityCosmeticsSection({
     { cosmeticTypes: debouncedTypes?.length ? debouncedTypes : undefined }
   );
   const ownedCosmeticIds = useOwnedCosmeticIds();
+  const { wishlistedIds } = useQueryWishlistedShopItems();
 
   // Nothing published yet — keep /shop clean rather than showing an empty hub.
   if (!isLoading && !items.length && !filters.cosmeticTypes?.length) return null;
@@ -61,14 +63,14 @@ export function CommunityCosmeticsSection({
           </Center>
         ) : items.length ? (
           <>
-            <div className="grid gap-4 [grid-template-columns:repeat(auto-fill,minmax(240px,1fr))]">
+            <div className="grid gap-4 [grid-template-columns:repeat(auto-fill,minmax(280px,1fr))]">
               {items.map((item) => (
                 <ShopItem
                   key={item.id}
-                  layout="storefront"
                   item={item as unknown as CosmeticShopItemGetById}
                   sectionItemCreatedAt={item.createdAt}
                   alreadyOwned={ownedCosmeticIds.has(item.cosmeticId)}
+                  wishlisted={wishlistedIds.has(item.id)}
                   // Attribute the purchase to the owner's shop so the creator
                   // keeps their full pool (never the platform-reseller split).
                   viaShopUserId={item.addedById ?? undefined}

--- a/src/components/CosmeticShop/ShopFiltersDropdown.tsx
+++ b/src/components/CosmeticShop/ShopFiltersDropdown.tsx
@@ -19,9 +19,22 @@ import { CosmeticType } from '~/shared/utils/prisma/enums';
 import type { GetShopInput } from '~/server/schema/cosmetic-shop.schema';
 import classes from './ShopFiltersDropdown.module.scss';
 
-type Filters = GetShopInput & { modifier?: 'owned' | 'notOwned' };
+// `wishlisted` is deliberately not folded into `modifier`: the modifiers are a
+// single-select group, and wishlisted has to be combinable with owned/notOwned.
+export type ShopFilters = GetShopInput & {
+  modifier?: 'owned' | 'notOwned';
+  wishlisted?: boolean;
+};
 
-export function ShopFiltersDropdown({ filters, setFilters, availableTypes, hideModifiers }: Props) {
+type Filters = ShopFilters;
+
+export function ShopFiltersDropdown({
+  filters,
+  setFilters,
+  availableTypes,
+  hideModifiers,
+  showWishlist,
+}: Props) {
   const colorScheme = useComputedColorScheme('dark');
   const mobile = useIsMobile();
 
@@ -30,7 +43,8 @@ export function ShopFiltersDropdown({ filters, setFilters, availableTypes, hideM
   const [opened, setOpened] = useState(false);
   const filterLength =
     (filters.cosmeticTypes ? filters.cosmeticTypes.length : 0) +
-    (!hideModifiers && !!filters.modifier ? 1 : 0);
+    (!hideModifiers && !!filters.modifier ? 1 : 0) +
+    (showWishlist && filters.wishlisted ? 1 : 0);
 
   const clearFilters = useCallback(() => setFilters({}), [setFilters]);
 
@@ -102,6 +116,20 @@ export function ShopFiltersDropdown({ filters, setFilters, availableTypes, hideM
           </Chip.Group>
         </Stack>
       )}
+      {showWishlist && (
+        <Stack gap="md">
+          <Divider label="Wishlist" className="text-sm font-bold" />
+          <Group gap={8}>
+            <Chip
+              checked={!!filters.wishlisted}
+              onChange={(checked) => setFilters((prev) => ({ ...prev, wishlisted: checked }))}
+              {...chipProps}
+            >
+              Wishlisted
+            </Chip>
+          </Group>
+        </Stack>
+      )}
       {filterLength > 0 && (
         <Button
           color="gray"
@@ -164,4 +192,6 @@ type Props = {
   availableTypes?: CosmeticType[];
   // Hide the Owned / Not Owned modifiers (Creator Shop storefront).
   hideModifiers?: boolean;
+  // Show the Wishlisted toggle (only /shop renders wishlist controls today).
+  showWishlist?: boolean;
 };

--- a/src/components/CosmeticShop/cosmetic-shop.util.ts
+++ b/src/components/CosmeticShop/cosmetic-shop.util.ts
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import { withPlaceholderData } from '~/hooks/trpcHelpers';
 import { CosmeticType } from '~/shared/utils/prisma/enums';
 import * as z from 'zod';
@@ -10,6 +11,7 @@ import type {
   GetPaginatedCosmeticShopItemInput,
   GetShopInput,
   PurchaseCosmeticShopItemInput,
+  ToggleWishlistShopItemInput,
   UpdateCosmeticShopSectionsOrderInput,
   UpsertCosmeticInput,
   UpsertCosmeticShopItemInput,
@@ -277,6 +279,53 @@ export const useQueryShop = (
   );
 
   return { cosmeticShopSections: data, ...rest };
+};
+
+export const useQueryWishlistedShopItems = (options?: { enabled?: boolean }) => {
+  const currentUser = useCurrentUser();
+
+  const { data, ...rest } = trpc.cosmeticShop.getWishlistedShopItemIds.useQuery(undefined, {
+    enabled: (options?.enabled ?? true) && !!currentUser,
+  });
+
+  const wishlistedIds = useMemo(() => new Set(data ?? []), [data]);
+
+  return { wishlistedIds, ...rest };
+};
+
+export const useToggleWishlistShopItem = () => {
+  const queryUtils = trpc.useUtils();
+
+  const toggleMutation = trpc.cosmeticShop.toggleWishlistShopItem.useMutation({
+    async onMutate({ shopItemId, wishlisted }) {
+      await queryUtils.cosmeticShop.getWishlistedShopItemIds.cancel();
+      const previous = queryUtils.cosmeticShop.getWishlistedShopItemIds.getData();
+
+      queryUtils.cosmeticShop.getWishlistedShopItemIds.setData(undefined, (old) => {
+        const ids = old ?? [];
+        const shouldWishlist = wishlisted ?? !ids.includes(shopItemId);
+        if (!shouldWishlist) return ids.filter((id) => id !== shopItemId);
+        return ids.includes(shopItemId) ? ids : [shopItemId, ...ids];
+      });
+
+      return { previous };
+    },
+    onError(error, _payload, context) {
+      queryUtils.cosmeticShop.getWishlistedShopItemIds.setData(undefined, context?.previous);
+      showErrorNotification({
+        title: 'Failed to update your wishlist',
+        error: new Error(error.message),
+      });
+    },
+    async onSettled() {
+      await queryUtils.cosmeticShop.getWishlistedShopItemIds.invalidate();
+    },
+  });
+
+  return {
+    toggleWishlist: (data: ToggleWishlistShopItemInput) => toggleMutation.mutate(data),
+    togglingWishlist: toggleMutation.isPending,
+  };
 };
 
 export const useShopLastViewed = () => {

--- a/src/components/CreatorShop/Storefront/ShopItemGrid.tsx
+++ b/src/components/CreatorShop/Storefront/ShopItemGrid.tsx
@@ -1,3 +1,4 @@
+import { useQueryWishlistedShopItems } from '~/components/CosmeticShop/cosmetic-shop.util';
 import type { CreatorShopItem } from '~/components/CreatorShop/creator-shop.util';
 import { ShopItem } from '~/components/Shop/ShopItem';
 import type { CosmeticShopItemGetById } from '~/types/router';
@@ -23,17 +24,21 @@ export function ShopItemGrid({
   // When set, purchases are attributed to this shop owner (cross-creator resale).
   viaShopUserId?: number;
 }) {
+  // A storefront renders several of these grids; they share one query key, so
+  // React Query still issues a single request for the viewer's wishlist.
+  const { wishlistedIds } = useQueryWishlistedShopItems();
+
   return (
-    <div className="grid gap-4 [grid-template-columns:repeat(auto-fill,minmax(240px,1fr))]">
+    <div className="grid gap-4 [grid-template-columns:repeat(auto-fill,minmax(280px,1fr))]">
       {items.map((item) => {
         const creator = item.cosmetic.creator;
         return (
           <ShopItem
             key={item.id}
-            layout="storefront"
             item={item as unknown as CosmeticShopItemGetById}
             sectionItemCreatedAt={item.createdAt}
             alreadyOwned={ownedCosmeticIds.has(item.cosmeticId)}
+            wishlisted={wishlistedIds.has(item.id)}
             viaShopUserId={viaShopUserId}
             creator={creator?.id === ownerUserId ? null : creator}
           />

--- a/src/components/Profile/Sections/ShopSection.tsx
+++ b/src/components/Profile/Sections/ShopSection.tsx
@@ -1,6 +1,7 @@
 import { Button, Text } from '@mantine/core';
 import { IconArrowRight, IconShoppingBag } from '@tabler/icons-react';
 import React from 'react';
+import { useQueryWishlistedShopItems } from '~/components/CosmeticShop/cosmetic-shop.util';
 import { useQueryCreatorShop } from '~/components/CreatorShop/creator-shop.util';
 import { useOwnedCosmeticIds } from '~/components/CreatorShop/Storefront/storefront.util';
 import { useInViewDynamic } from '~/components/IntersectionObserver/IntersectionObserverProvider';
@@ -20,6 +21,7 @@ export const ShopSection = ({ user }: ProfileSectionProps) => {
   const [ref, inView] = useInViewDynamic({ id: 'profile-shop-section' });
   const { shop, isLoading } = useQueryCreatorShop(features.creatorShop ? user.id : undefined);
   const ownedCosmeticIds = useOwnedCosmeticIds();
+  const { wishlistedIds } = useQueryWishlistedShopItems();
 
   if (!features.creatorShop) return null;
 
@@ -64,6 +66,7 @@ export const ShopSection = ({ user }: ProfileSectionProps) => {
                     item={item as unknown as CosmeticShopItemGetById}
                     sectionItemCreatedAt={item.createdAt}
                     alreadyOwned={ownedCosmeticIds.has(item.cosmeticId)}
+                    wishlisted={wishlistedIds.has(item.id)}
                     creator={item.cosmetic.creator}
                   />
                 </div>

--- a/src/components/Shop/ShopItem.module.scss
+++ b/src/components/Shop/ShopItem.module.scss
@@ -41,46 +41,6 @@
   z-index: 4;
 }
 
-// Storefront cards flow in an auto-fill grid at a smaller min width, so the
-// artwork panel and paddings shrink to keep the cards compact. The exterior
-// border + inset highlight + soft shadow give the depth that keeps the card
-// from blending into the page background.
-.cardStorefront {
-  padding: var(--mantine-spacing-sm);
-  border: 1px solid light-dark(var(--mantine-color-gray-3), var(--mantine-color-dark-4));
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.18),
-    inset 0 0 0 1px light-dark(rgba(255, 255, 255, 0.55), rgba(255, 255, 255, 0.04));
-}
-
-.cardHeaderCompact {
-  margin: calc(-1 * var(--mantine-spacing-sm));
-  padding: var(--mantine-spacing-sm);
-  margin-bottom: var(--mantine-spacing-sm);
-  height: 170px;
-}
-
-.titleStorefront {
-  font-size: var(--mantine-font-size-md);
-  line-height: 1.25;
-}
-
-// Label on the left, a dark Buzz pill on the right — mirrors the buzz buttons.
-.buyButtonInner {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  width: 100%;
-  gap: 8px;
-}
-
-// The label ellipsizes so a long action never squeezes the price pill.
-.buyButtonLabel {
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
 // Soft blurred white light-spots sitting behind the cosmetic sample.
 .cardHeader::before {
   content: '';
@@ -162,6 +122,11 @@
   }
 }
 
+// Keeps the badge's centred text clear of the wishlist puck, which sits above it.
+.availability.availabilityInset {
+  right: 48px;
+}
+
 .countdown {
   position: absolute;
   left: var(--mantine-spacing-md);
@@ -196,11 +161,26 @@
   outline: 1px solid var(--mantine-color-yellow-4);
 }
 
-.newBadge {
+// One row for the top-right corner. The New! badge and the wishlist button have
+// different heights, so they're centred against each other here rather than
+// each being pinned to the card's top edge.
+.cardControls {
   position: absolute;
   top: 8px;
   right: 8px;
-  z-index: 8;
+  z-index: 9;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+// The artwork panel behind it is arbitrary, so the control carries its own
+// translucent puck to stay legible over any cosmetic.
+.wishlist {
+  display: flex;
+  border-radius: var(--mantine-radius-xl);
+  background: light-dark(rgba(255, 255, 255, 0.75), rgba(0, 0, 0, 0.5));
+  backdrop-filter: blur(4px);
 }
 
 // Warm Buzz gradient buy button (yellow by default, green in the green domain).
@@ -228,20 +208,4 @@
   --button-hover: linear-gradient(135deg, #7ee592, #34af4c);
   --button-color: #051f0d;
   box-shadow: 0 4px 16px -5px rgba(47, 158, 68, 0.55);
-}
-
-// Flat buzz-gold fill (no gradient) so the dark label stays legible edge to
-// edge — modeled on the Buzz purchase button.
-.buyButtonSolid {
-  --button-bg: #fab005;
-  --button-hover: #f59f00;
-  --button-color: #1a1403;
-  box-shadow: none;
-}
-
-.buyButtonSolidGreen {
-  --button-bg: #2f9e44;
-  --button-hover: #2b8a3e;
-  --button-color: #051f0d;
-  box-shadow: none;
 }

--- a/src/components/Shop/ShopItem.tsx
+++ b/src/components/Shop/ShopItem.tsx
@@ -9,22 +9,24 @@ import {
   Stack,
   Text,
   Title,
+  Tooltip,
   UnstyledButton,
 } from '@mantine/core';
 import { NextLink } from '~/components/NextLink/NextLink';
 import type { MouseEvent } from 'react';
 import { CosmeticType, Currency } from '~/shared/utils/prisma/enums';
 import dayjs from '~/shared/utils/dayjs';
-import { useShopLastViewed } from '~/components/CosmeticShop/cosmetic-shop.util';
+import {
+  useShopLastViewed,
+  useToggleWishlistShopItem,
+} from '~/components/CosmeticShop/cosmetic-shop.util';
 import { CosmeticShopItemPreviewModal } from '~/components/CosmeticShop/CosmeticShopItemPreviewModal';
 import { Countdown } from '~/components/Countdown/Countdown';
 import { CurrencyBadge } from '~/components/Currency/CurrencyBadge';
 import { dialogStore } from '~/components/Dialog/dialogStore';
 import { LoginRedirect } from '~/components/LoginRedirect/LoginRedirect';
 import { RenderHtml } from '~/components/RenderHtml/RenderHtml';
-import { BuzzPill } from '~/components/Shop/BuzzPill';
 import { CosmeticSample } from '~/components/Shop/CosmeticSample';
-import { UserAvatar } from '~/components/UserAvatar/UserAvatar';
 import type { UserWithCosmetics } from '~/server/selectors/user.selector';
 import { useCurrentUser } from '~/hooks/useCurrentUser';
 import { useDomainColor } from '~/hooks/useDomainColor';
@@ -33,35 +35,36 @@ import type { CosmeticShopItemGetById } from '~/types/router';
 import { formatDate, isFutureDate } from '~/utils/date-helpers';
 import { getDisplayName } from '~/utils/string-helpers';
 import classes from './ShopItem.module.scss';
-import { IconCheck } from '@tabler/icons-react';
+import { IconCheck, IconHeart, IconHeartFilled } from '@tabler/icons-react';
 import clsx from 'clsx';
+import { LegacyActionIcon } from '~/components/LegacyActionIcon/LegacyActionIcon';
 
 export const ShopItem = ({
   item,
   sectionItemCreatedAt,
   alreadyOwned = false,
+  wishlisted,
   viaShopUserId,
   creator,
-  layout = 'shop',
 }: {
   item: CosmeticShopItemGetById;
   sectionItemCreatedAt?: Date;
   alreadyOwned?: boolean;
+  // Undefined (not false) hides the wishlist control, for surfaces that don't
+  // fetch the viewer's wishlist.
+  wishlisted?: boolean;
   // Attributes the purchase to this shop owner (Creator Shop cross-creator resale).
   viaShopUserId?: number;
   // The cosmetic's original creator, shown as attribution (Creator Shop only).
   creator?: UserWithCosmetics | null;
-  // 'shop' = the official /shop cards (default). 'storefront' = the leaner
-  // creator-shop cards: compact artwork, creator avatar attribution, and the
-  // Buzz price on the button instead of beside the title.
-  layout?: 'shop' | 'storefront';
 }) => {
-  const isStorefront = layout === 'storefront';
+  const showWishlist = wishlisted !== undefined;
   const cosmetic = item.cosmetic;
   const isAvailable =
     (item.availableQuantity ?? null) === null || (item.availableQuantity ?? 0) > 0;
   const currentUser = useCurrentUser();
   const { lastViewed } = useShopLastViewed();
+  const { toggleWishlist, togglingWishlist } = useToggleWishlistShopItem();
   const domain = useDomainColor();
   const itemMeta = item.meta as CosmeticShopItemMeta;
 
@@ -83,20 +86,42 @@ export const ShopItem = ({
     dayjs(sectionItemCreatedAt).isAfter(dayjs(lastViewed));
 
   return (
-    <Paper
-      className={clsx(
-        classes.card,
-        isStorefront && classes.cardStorefront,
-        isNew && !isStorefront && classes.newItem
-      )}
-    >
-      {isNew && !isStorefront && (
-        <Badge color="yellow.7" className={classes.newBadge} variant="filled">
-          New!
-        </Badge>
+    <Paper className={clsx(classes.card, isNew && classes.newItem)}>
+      {(isNew || showWishlist) && (
+        <div className={classes.cardControls}>
+          {isNew && (
+            <Badge color="yellow.7" variant="filled">
+              New!
+            </Badge>
+          )}
+          {showWishlist && (
+            <div className={classes.wishlist}>
+              <LoginRedirect reason="shop">
+                <LegacyActionIcon
+                  radius="xl"
+                  color={wishlisted ? 'red' : 'gray'}
+                  loading={togglingWishlist}
+                  aria-label={wishlisted ? 'Remove from wishlist' : 'Add to wishlist'}
+                  onClick={() => toggleWishlist({ shopItemId: item.id, wishlisted: !wishlisted })}
+                >
+                  <Tooltip
+                    label={wishlisted ? 'Remove from wishlist' : 'Add to wishlist'}
+                    withArrow
+                  >
+                    {wishlisted ? <IconHeartFilled size={18} /> : <IconHeart size={18} />}
+                  </Tooltip>
+                </LegacyActionIcon>
+              </LoginRedirect>
+            </div>
+          )}
+        </div>
       )}
       {(available !== null || availableTo) && (
-        <Badge color="grape" className={classes.availability} px={6}>
+        <Badge
+          color="grape"
+          className={clsx(classes.availability, showWishlist && classes.availabilityInset)}
+          px={6}
+        >
           <Group justify="space-between" wrap="nowrap" gap={4}>
             {outOfStock ? (
               <Text inherit>Out of Stock</Text>
@@ -151,9 +176,9 @@ export const ShopItem = ({
             }}
             disabled={!isAvailable || outOfStock}
           >
-            <div className={clsx(classes.cardHeader, isStorefront && classes.cardHeaderCompact)}>
+            <div className={classes.cardHeader}>
               <div className={clsx(classes.sampleWrapper, outOfStock && classes.dim)}>
-                <CosmeticSample cosmetic={cosmetic} size={isStorefront ? 'md' : 'lg'} />
+                <CosmeticSample cosmetic={cosmetic} size="lg" />
               </div>
               <Text size="xs" c="dimmed" px={6} component="div" className={classes.type}>
                 {getDisplayName(item.cosmetic.type)}
@@ -168,45 +193,35 @@ export const ShopItem = ({
               )}
             </div>
           </UnstyledButton>
-          <Stack gap={isStorefront ? 6 : 2}>
+          <Stack gap={2}>
             <div className={classes.titleRow}>
-              <Title
-                order={isStorefront ? 4 : 3}
-                className={clsx(classes.title, isStorefront && classes.titleStorefront)}
-              >
+              <Title order={3} className={classes.title}>
                 {item.title}
               </Title>
-              {!isStorefront && (
-                <CurrencyBadge
-                  currency={Currency.BUZZ}
-                  type={domain === 'green' ? 'green' : 'yellow'}
-                  unitAmount={item.unitAmount}
-                  variant="transparent"
-                  className={clsx('!px-0', classes.price)}
-                />
-              )}
+              <CurrencyBadge
+                currency={Currency.BUZZ}
+                type={domain === 'green' ? 'green' : 'yellow'}
+                unitAmount={item.unitAmount}
+                variant="transparent"
+                className={clsx('!px-0', classes.price)}
+              />
             </div>
-            {creator?.username &&
-              (isStorefront ? (
-                <div onClick={(e: MouseEvent) => e.stopPropagation()}>
-                  <UserAvatar user={creator} withUsername size="sm" linkToProfile />
-                </div>
-              ) : (
-                <Text size="xs" c="dimmed">
-                  by{' '}
-                  <Anchor
-                    component={NextLink}
-                    href={`/user/${creator.username}`}
-                    c="blue.4"
-                    fw={500}
-                    underline="always"
-                    // Don't trigger the card's purchase modal.
-                    onClick={(e: MouseEvent) => e.stopPropagation()}
-                  >
-                    @{creator.username}
-                  </Anchor>
-                </Text>
-              ))}
+            {creator?.username && (
+              <Text size="xs" c="dimmed">
+                by{' '}
+                <Anchor
+                  component={NextLink}
+                  href={`/user/${creator.username}`}
+                  c="blue.4"
+                  fw={500}
+                  underline="always"
+                  // Don't trigger the card's purchase modal.
+                  onClick={(e: MouseEvent) => e.stopPropagation()}
+                >
+                  @{creator.username}
+                </Anchor>
+              </Text>
+            )}
           </Stack>
           {!!item.description && (
             <div className={classes.description}>
@@ -217,17 +232,8 @@ export const ShopItem = ({
         <Stack mt="auto" gap={4}>
           <LoginRedirect reason="shop">
             <Button
-              radius={isStorefront ? 'sm' : 'xl'}
-              px={isStorefront ? 10 : undefined}
-              className={
-                isStorefront
-                  ? clsx(
-                      classes.buyButton,
-                      domain === 'green' ? classes.buyButtonSolidGreen : classes.buyButtonSolid
-                    )
-                  : clsx(classes.buyButton, domain === 'green' && classes.buyButtonGreen)
-              }
-              styles={isStorefront ? { label: { width: '100%' } } : undefined}
+              radius="xl"
+              className={clsx(classes.buyButton, domain === 'green' && classes.buyButtonGreen)}
               onClick={() => {
                 dialogStore.trigger({
                   component: CosmeticShopItemPreviewModal,
@@ -236,17 +242,7 @@ export const ShopItem = ({
               }}
               disabled={!isAvailable || outOfStock}
             >
-              {isStorefront ? (
-                <span className={classes.buyButtonInner}>
-                  <span className={classes.buyButtonLabel}>Preview</span>
-                  <BuzzPill
-                    amount={item.unitAmount}
-                    variant={domain === 'green' ? 'green' : 'yellow'}
-                  />
-                </span>
-              ) : (
-                'Preview'
-              )}
+              Preview
             </Button>
           </LoginRedirect>
         </Stack>

--- a/src/pages/shop/index.tsx
+++ b/src/pages/shop/index.tsx
@@ -18,10 +18,12 @@ import { createServerSideProps } from '~/server/utils/server-side-helpers';
 import {
   useCosmeticShopQueryParams,
   useQueryShop,
+  useQueryWishlistedShopItems,
   useShopLastViewed,
 } from '~/components/CosmeticShop/cosmetic-shop.util';
-import type { CosmeticShopSectionMeta, GetShopInput } from '~/server/schema/cosmetic-shop.schema';
+import type { CosmeticShopSectionMeta } from '~/server/schema/cosmetic-shop.schema';
 import { CIVITAI_SHOP_ATTRIBUTION } from '~/server/schema/cosmetic-shop.schema';
+import type { ShopFilters } from '~/components/CosmeticShop/ShopFiltersDropdown';
 import { ShopFiltersDropdown } from '~/components/CosmeticShop/ShopFiltersDropdown';
 import { useDebouncedValue, useDisclosure } from '@mantine/hooks';
 import { useEffect } from 'react';
@@ -73,12 +75,13 @@ export const getServerSideProps = createServerSideProps({
 
 export default function CosmeticShopMain() {
   const { query } = useCosmeticShopQueryParams();
-  const [filters, setFilters] = useState<GetShopInput & { modifier?: 'owned' | 'notOwned' }>({
+  const [filters, setFilters] = useState<ShopFilters>({
     ...(query ?? {}),
   });
   const [debouncedFilters] = useDebouncedValue({ cosmeticTypes: filters.cosmeticTypes }, 500);
   const { cosmeticShopSections, isLoading } = useQueryShop(debouncedFilters);
   const { data: userCosmetics, isFetching: loadingOwnedCosmetics } = useQueryUserCosmetics();
+  const { wishlistedIds } = useQueryWishlistedShopItems();
   const features = useFeatureFlags();
 
   const { updateLastViewed, isFetched } = useShopLastViewed();
@@ -146,7 +149,7 @@ export default function CosmeticShopMain() {
             </Text>
           </Stack>
           <div className="ml-auto">
-            <ShopFiltersDropdown filters={filters} setFilters={setFilters} />
+            <ShopFiltersDropdown filters={filters} setFilters={setFilters} showWishlist />
           </div>
           <div className="flex flex-col gap-6">
             {isLoading || loadingOwnedCosmetics ? (
@@ -186,6 +189,10 @@ export default function CosmeticShopMain() {
                     );
                   }
                 }
+                if (filters.wishlisted)
+                  filteredItems = filteredItems.filter((item) =>
+                    wishlistedIds.has(item.shopItem.id)
+                  );
 
                 if (!filteredItems.length) return null;
 
@@ -211,6 +218,7 @@ export default function CosmeticShopMain() {
                             item={shopItem}
                             sectionItemCreatedAt={item.createdAt}
                             alreadyOwned={alreadyOwned}
+                            wishlisted={wishlistedIds.has(shopItem.id)}
                             creator={shopItem.cosmetic.creator}
                             viaShopUserId={CIVITAI_SHOP_ATTRIBUTION}
                           />

--- a/src/server/routers/cosmetic-shop.router.ts
+++ b/src/server/routers/cosmetic-shop.router.ts
@@ -6,6 +6,7 @@ import {
   getPreviewImagesInput,
   getShopInput,
   purchaseCosmeticShopItemInput,
+  toggleWishlistShopItemInput,
   updateCosmeticShopSectionsOrderInput,
   upsertCosmeticInput,
   upsertCosmeticShopItemInput,
@@ -20,8 +21,10 @@ import {
   getShopSections,
   getShopSectionsWithItems,
   getUserPreviewImagesForCosmetics,
+  getWishlistedShopItemIds,
   purchaseCosmeticShopItem,
   reorderCosmeticShopSections,
+  toggleWishlistShopItem,
   upsertCosmetic,
   upsertCosmeticShopItem,
   upsertCosmeticShopSection,
@@ -122,6 +125,17 @@ export const cosmeticShopRouter = router({
         userId: ctx.user.id,
         buzzType,
       });
+    }),
+  getWishlistedShopItemIds: protectedProcedure
+    .meta({ requiredScope: TokenScope.CollectionsRead })
+    .query(({ ctx }) => {
+      return getWishlistedShopItemIds({ userId: ctx.user.id });
+    }),
+  toggleWishlistShopItem: protectedProcedure
+    .meta({ requiredScope: TokenScope.CollectionsWrite })
+    .input(toggleWishlistShopItemInput)
+    .mutation(({ input, ctx }) => {
+      return toggleWishlistShopItem({ ...input, userId: ctx.user.id });
     }),
   getPreviewImages: protectedProcedure
     .meta({ requiredScope: TokenScope.CollectionsRead })

--- a/src/server/schema/cosmetic-shop.schema.ts
+++ b/src/server/schema/cosmetic-shop.schema.ts
@@ -156,6 +156,15 @@ export const purchaseCosmeticShopItemInput = z.object({
   payWith: z.enum(['default', 'blue-first']).optional(),
 });
 
+export type ToggleWishlistShopItemInput = z.infer<typeof toggleWishlistShopItemInput>;
+export const toggleWishlistShopItemInput = z.object({
+  shopItemId: z.number(),
+  // Desired end state rather than a blind flip, so a rapid double-click settles
+  // on what the last click asked for instead of racing to an arbitrary value.
+  // Omitted = flip whatever is currently stored.
+  wishlisted: z.boolean().optional(),
+});
+
 export type GetPreviewImagesInput = z.infer<typeof getPreviewImagesInput>;
 export const getPreviewImagesInput = z.object({
   browsingLevel: z.number(),

--- a/src/server/services/__tests__/cosmetic-shop-wishlist.service.test.ts
+++ b/src/server/services/__tests__/cosmetic-shop-wishlist.service.test.ts
@@ -1,0 +1,103 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mocks } = vi.hoisted(() => ({
+  mocks: {
+    wishlistFindUnique: vi.fn(),
+    wishlistFindMany: vi.fn(),
+    wishlistCreateMany: vi.fn(),
+    wishlistDeleteMany: vi.fn(),
+    shopItemFindUnique: vi.fn(),
+  },
+}));
+
+vi.mock('~/server/db/client', () => ({
+  dbRead: {
+    userCosmeticShopItemWishlist: { findMany: mocks.wishlistFindMany },
+    cosmeticShopItem: { findUnique: mocks.shopItemFindUnique },
+  },
+  dbWrite: {
+    userCosmeticShopItemWishlist: {
+      findUnique: mocks.wishlistFindUnique,
+      createMany: mocks.wishlistCreateMany,
+      deleteMany: mocks.wishlistDeleteMany,
+    },
+  },
+}));
+vi.mock('sharp', () => ({ default: vi.fn() }));
+
+import { getWishlistedShopItemIds, toggleWishlistShopItem } from '../cosmetic-shop.service';
+
+describe('toggleWishlistShopItem', () => {
+  beforeEach(() => {
+    Object.values(mocks).forEach((m) => m.mockReset());
+    mocks.wishlistFindUnique.mockResolvedValue(null);
+    mocks.wishlistCreateMany.mockResolvedValue({ count: 1 });
+    mocks.wishlistDeleteMany.mockResolvedValue({ count: 1 });
+    mocks.shopItemFindUnique.mockResolvedValue({ id: 42 });
+  });
+
+  it('adds with ON CONFLICT DO NOTHING so a racing double-click cannot duplicate', async () => {
+    const result = await toggleWishlistShopItem({ userId: 1, shopItemId: 42, wishlisted: true });
+
+    expect(result).toEqual({ shopItemId: 42, wishlisted: true });
+    expect(mocks.wishlistCreateMany).toHaveBeenCalledWith({
+      data: [{ userId: 1, shopItemId: 42 }],
+      skipDuplicates: true,
+    });
+  });
+
+  it('is a no-op when re-wishlisting something already wishlisted', async () => {
+    mocks.wishlistFindUnique.mockResolvedValue({ shopItemId: 42 });
+
+    const result = await toggleWishlistShopItem({ userId: 1, shopItemId: 42, wishlisted: true });
+
+    expect(result).toEqual({ shopItemId: 42, wishlisted: true });
+    expect(mocks.wishlistCreateMany).not.toHaveBeenCalled();
+  });
+
+  it('removes by userId + shopItemId, and removing twice does not error', async () => {
+    mocks.wishlistDeleteMany.mockResolvedValue({ count: 0 });
+
+    const result = await toggleWishlistShopItem({ userId: 1, shopItemId: 42, wishlisted: false });
+
+    expect(result).toEqual({ shopItemId: 42, wishlisted: false });
+    expect(mocks.wishlistDeleteMany).toHaveBeenCalledWith({ where: { userId: 1, shopItemId: 42 } });
+    expect(mocks.wishlistCreateMany).not.toHaveBeenCalled();
+  });
+
+  it('flips the stored state when no desired state is given', async () => {
+    mocks.wishlistFindUnique.mockResolvedValue({ shopItemId: 42 });
+
+    const result = await toggleWishlistShopItem({ userId: 1, shopItemId: 42 });
+
+    expect(result).toEqual({ shopItemId: 42, wishlisted: false });
+    expect(mocks.wishlistDeleteMany).toHaveBeenCalled();
+  });
+
+  it('rejects a shop item that does not exist instead of hitting the FK', async () => {
+    mocks.shopItemFindUnique.mockResolvedValue(null);
+
+    await expect(
+      toggleWishlistShopItem({ userId: 1, shopItemId: 999, wishlisted: true })
+    ).rejects.toThrow();
+    expect(mocks.wishlistCreateMany).not.toHaveBeenCalled();
+  });
+});
+
+describe('getWishlistedShopItemIds', () => {
+  beforeEach(() => {
+    Object.values(mocks).forEach((m) => m.mockReset());
+  });
+
+  it('scopes to the viewer and returns ids in one query', async () => {
+    mocks.wishlistFindMany.mockResolvedValue([{ shopItemId: 3 }, { shopItemId: 1 }]);
+
+    const result = await getWishlistedShopItemIds({ userId: 7 });
+
+    expect(result).toEqual([3, 1]);
+    expect(mocks.wishlistFindMany).toHaveBeenCalledTimes(1);
+    expect(mocks.wishlistFindMany).toHaveBeenCalledWith(
+      expect.objectContaining({ where: { userId: 7 } })
+    );
+  });
+});

--- a/src/server/services/cosmetic-shop.service.ts
+++ b/src/server/services/cosmetic-shop.service.ts
@@ -14,6 +14,7 @@ import type {
   GetPreviewImagesInput,
   GetShopInput,
   PurchaseCosmeticShopItemInput,
+  ToggleWishlistShopItemInput,
   UpdateCosmeticShopSectionsOrderInput,
   UpsertCosmeticInput,
   UpsertCosmeticShopItemInput,
@@ -41,7 +42,7 @@ import {
   getCosmeticArtworkUrl,
   queueCosmeticPerceptualHash,
 } from '~/server/services/cosmetic-phash.service';
-import { withRetries } from '~/server/utils/errorHandling';
+import { throwNotFoundError, withRetries } from '~/server/utils/errorHandling';
 import { DEFAULT_PAGE_SIZE, getPagination, getPagingData } from '~/server/utils/pagination-helpers';
 import {
   CollectionType,
@@ -595,6 +596,50 @@ export const getShopSectionsWithItems = async ({
           : section.image,
       }))
   );
+};
+
+export const getWishlistedShopItemIds = async ({ userId }: { userId: number }) => {
+  const wishlisted = await dbRead.userCosmeticShopItemWishlist.findMany({
+    where: { userId },
+    select: { shopItemId: true },
+    orderBy: { createdAt: 'desc' },
+  });
+
+  return wishlisted.map((w) => w.shopItemId);
+};
+
+export const toggleWishlistShopItem = async ({
+  userId,
+  shopItemId,
+  wishlisted,
+}: ToggleWishlistShopItemInput & { userId: number }) => {
+  const existing = await dbWrite.userCosmeticShopItemWishlist.findUnique({
+    where: { userId_shopItemId: { userId, shopItemId } },
+    select: { shopItemId: true },
+  });
+  const shouldWishlist = wishlisted ?? !existing;
+
+  if (!shouldWishlist) {
+    await dbWrite.userCosmeticShopItemWishlist.deleteMany({ where: { userId, shopItemId } });
+    return { shopItemId, wishlisted: false };
+  }
+
+  if (!existing) {
+    const shopItem = await dbRead.cosmeticShopItem.findUnique({
+      where: { id: shopItemId },
+      select: { id: true },
+    });
+    if (!shopItem) throw throwNotFoundError('Shop item not found');
+
+    // skipDuplicates emits ON CONFLICT DO NOTHING, so two clicks racing past the
+    // read above settle on one row instead of a unique violation.
+    await dbWrite.userCosmeticShopItemWishlist.createMany({
+      data: [{ userId, shopItemId }],
+      skipDuplicates: true,
+    });
+  }
+
+  return { shopItemId, wishlisted: true };
 };
 
 export const purchaseCosmeticShopItem = async ({


### PR DESCRIPTION
Adds a `UserCosmeticShopItemWishlist` table with tRPC endpoints and client hooks to toggle and read a viewer's wishlisted shop items, surfaced as a puck on every shop item card and a "Wishlisted" filter chip on /shop. Shop item cards were consolidated onto a single wider layout (280px grid columns) now that the storefront variant no longer needs its own compact styling.