### PR TITLE
fix(app-blocks): bound the REST half of block_scope_invocations.endpoint too

### DIFF
--- a/src/components/AppBlocks/analytics-bucket-labels.ts
+++ b/src/components/AppBlocks/analytics-bucket-labels.ts
@@ -105,11 +105,15 @@ export function endpointBucketLabel(endpoint: string): string {
   }
 
   // Everything else is a REST path from `normalizeEndpoint(req.url)`. Passed through
-  // verbatim, and NOT claimed to be safe or pretty: that function templates only
-  // numeric and ULID-shaped segments, so a slug/UUID segment survives, the row is
-  // written from `res.on('finish')` regardless of status code, and the value is
-  // therefore partly caller-influenced. React escapes it (no injection) and the cell
-  // clamps to one line. Inventing a name for it would be worse than showing it.
+  // verbatim, and NOT claimed to be pretty. Since `KNOWN_STATIC_ENDPOINT_SEGMENTS` landed
+  // that function is allowlist-first — only the static segments of the wrapped routes
+  // survive, everything else collapses to `:id`/`:ulid`/`:uuid`/`:seg` — so a NEW row's
+  // path is bounded and no longer caller-influenced. Two caveats before you treat it as a
+  // closed set: rows written before that change were not backfilled and still hold
+  // slugs/UUIDs verbatim, and the row is
+  // written from `res.on('finish')` regardless of status code, so 4xx paths appear too.
+  // React escapes it (no injection) and the cell clamps to one line. Inventing a name for
+  // it would be worse than showing it.
   return endpoint;
 }
 

--- a/src/server/middleware/__tests__/block-scope.normalize-endpoint.test.ts
+++ b/src/server/middleware/__tests__/block-scope.normalize-endpoint.test.ts
@@ -1,0 +1,244 @@
+import { readdirSync, readFileSync } from 'fs';
+import path from 'path';
+import { describe, expect, it } from 'vitest';
+// Imported in setup-order so the test RSA env keys are in place before
+// block-token.service evaluates (same posture as block-scope.middleware.test.ts).
+import '~/__tests__/setup';
+import { KNOWN_STATIC_ENDPOINT_SEGMENTS, normalizeEndpoint } from '../block-scope.middleware';
+
+/**
+ * `normalizeEndpoint` writes `block_scope_invocations.endpoint`, which is the
+ * GROUP BY key of the `topEndpoints` rollup in `app-analytics.service.ts`. Both
+ * directions are failure modes and both are tested here:
+ *
+ *   - UNDER-templating fragments one logical route into N count-1 rows and the
+ *     "top 5" becomes noise (the #3561 defect, for the router call sites).
+ *   - OVER-templating collapses every route to the same handful of rows, which
+ *     destroys the aggregate just as thoroughly and is far easier to ship
+ *     unnoticed — nothing looks wrong, the panel just stops saying anything.
+ *
+ * The over-templating half is the reason the rule is allowlist-first: the static
+ * vocabulary of these routes is slug-shaped (`generation-resources`,
+ * `tip-allowance`, `shared-storage`), so a "slugs are high-cardinality" shape
+ * heuristic would eat them.
+ */
+describe('normalizeEndpoint — templates caller-supplied segments', () => {
+  it('templates a numeric id', () => {
+    expect(normalizeEndpoint('/api/v1/blocks/collections/12345')).toBe(
+      '/api/v1/blocks/collections/:id'
+    );
+  });
+
+  it('templates a ULID, bare and prefixed', () => {
+    expect(normalizeEndpoint('/api/v1/blocks/collections/01ARZ3NDEKTSV4RRFFQ69G5FAV')).toBe(
+      '/api/v1/blocks/collections/:ulid'
+    );
+    expect(normalizeEndpoint('/api/v1/blocks/collections/apb_01ARZ3NDEKTSV4RRFFQ69G5FAV')).toBe(
+      '/api/v1/blocks/collections/:ulid'
+    );
+  });
+
+  it('templates a UUID in either case, bare and prefixed', () => {
+    expect(
+      normalizeEndpoint('/api/v1/blocks/collections/3f2504e0-4f89-11d3-9a0c-0305e82c3301')
+    ).toBe('/api/v1/blocks/collections/:uuid');
+    expect(
+      normalizeEndpoint('/api/v1/blocks/collections/3F2504E0-4F89-11D3-9A0C-0305E82C3301')
+    ).toBe('/api/v1/blocks/collections/:uuid');
+    expect(
+      normalizeEndpoint('/api/v1/blocks/collections/col_3f2504e0-4f89-11d3-9a0c-0305e82c3301')
+    ).toBe('/api/v1/blocks/collections/:uuid');
+  });
+
+  it('templates a slug — the case the shape-only rule missed', () => {
+    expect(normalizeEndpoint('/api/v1/blocks/collections/my-cool-collection')).toBe(
+      '/api/v1/blocks/collections/:seg'
+    );
+  });
+
+  it('templates a hash, a filename and percent-encoded junk', () => {
+    expect(
+      normalizeEndpoint('/api/v1/blocks/collections/da39a3ee5e6b4b0d3255bfef95601890afd80709')
+    ).toBe('/api/v1/blocks/collections/:seg');
+    expect(normalizeEndpoint('/api/v1/blocks/collections/report.json')).toBe(
+      '/api/v1/blocks/collections/:seg'
+    );
+    expect(normalizeEndpoint('/api/v1/blocks/collections/%2e%2e%2fetc')).toBe(
+      '/api/v1/blocks/collections/:seg'
+    );
+  });
+
+  /**
+   * The defect itself, stated as the property the column has to satisfy: distinct
+   * caller values must land in ONE bucket. Asserting the templated string alone
+   * would not say this — it is the collapse that makes `groupBy` work.
+   */
+  it('collapses distinct high-cardinality values into ONE bucket', () => {
+    const bucketed = new Set(
+      [
+        '/api/v1/blocks/collections/my-cool-collection',
+        '/api/v1/blocks/collections/another-collection',
+        '/api/v1/blocks/collections/3f2504e0-4f89-11d3-9a0c-0305e82c3301',
+        '/api/v1/blocks/collections/9c858901-8a57-4791-81fe-4c455b099bc9',
+        '/api/v1/blocks/collections/da39a3ee5e6b4b0d3255bfef95601890afd80709',
+      ].map(normalizeEndpoint)
+    );
+    // Two buckets, not five: one per SHAPE (`:seg`, `:uuid`) — never one per value.
+    expect([...bucketed].sort()).toEqual([
+      '/api/v1/blocks/collections/:seg',
+      '/api/v1/blocks/collections/:uuid',
+    ]);
+  });
+
+  it('drops the query string rather than templating it', () => {
+    expect(normalizeEndpoint('/api/v1/blocks/collections/12?cursor=abc&limit=24')).toBe(
+      '/api/v1/blocks/collections/:id'
+    );
+  });
+});
+
+describe('normalizeEndpoint — leaves genuinely static segments intact', () => {
+  /**
+   * The real wrapped routes, with their `[id]` positions filled in. If any of
+   * these loses a segment to a placeholder the panel stops distinguishing routes
+   * — which is the SAME failure as not templating at all, arriving from the
+   * other side.
+   */
+  it.each([
+    ['/api/v1/blocks/me', '/api/v1/blocks/me'],
+    ['/api/v1/blocks/models', '/api/v1/blocks/models'],
+    ['/api/v1/blocks/images', '/api/v1/blocks/images'],
+    ['/api/v1/blocks/tip', '/api/v1/blocks/tip'],
+    ['/api/v1/blocks/tip-allowance', '/api/v1/blocks/tip-allowance'],
+    ['/api/v1/blocks/generation-resources', '/api/v1/blocks/generation-resources'],
+    ['/api/v1/blocks/collections', '/api/v1/blocks/collections'],
+    ['/api/v1/blocks/collections/77', '/api/v1/blocks/collections/:id'],
+    ['/api/v1/blocks/collections/77/follow', '/api/v1/blocks/collections/:id/follow'],
+    ['/api/v1/blocks/shared-storage/top', '/api/v1/blocks/shared-storage/top'],
+    ['/api/v1/blocks/shared-storage/increment', '/api/v1/blocks/shared-storage/increment'],
+    ['/api/v1/models/4201', '/api/v1/models/:id'],
+  ])('%s survives as %s', (url, expected) => {
+    expect(normalizeEndpoint(url)).toBe(expected);
+  });
+
+  /**
+   * Called out separately because these three are the ones a shape heuristic
+   * kills: they are hyphenated, multi-word and indistinguishable by shape from a
+   * user-chosen slug. A rule that templates `my-cool-collection` by its hyphen
+   * templates these too, and this is where that would show up.
+   */
+  it.each(['generation-resources', 'tip-allowance', 'shared-storage'])(
+    'the slug-shaped static segment %s is NOT templated',
+    (seg) => {
+      expect(normalizeEndpoint(`/api/v1/blocks/${seg}`)).toBe(`/api/v1/blocks/${seg}`);
+    }
+  );
+
+  it('keeps the empty segments from a leading/trailing slash', () => {
+    expect(normalizeEndpoint('/api/v1/blocks/me/')).toBe('/api/v1/blocks/me/');
+    expect(normalizeEndpoint('')).toBe('');
+  });
+
+  /**
+   * Pins the claim the ORDER of the arms rests on. The allowlist runs before the
+   * shape tests so a static segment can never be templated whatever it looks
+   * like; today that ordering is behaviour-equivalent to the reverse, because no
+   * static segment matches an id shape. This test is what makes that "today" a
+   * checked fact — add a `/v2` or `/2024` segment and it goes red, telling you
+   * the ordering has started to matter.
+   */
+  it('no static segment collides with an id shape (so the arm order is currently moot)', () => {
+    const colliding = [...KNOWN_STATIC_ENDPOINT_SEGMENTS].filter(
+      (seg) =>
+        /^\d+$/.test(seg) ||
+        /^[A-Za-z]+_[0-9A-HJKMNP-TV-Z]{26}$/.test(seg) ||
+        /^[0-9A-HJKMNP-TV-Z]{26}$/.test(seg) ||
+        /^(?:[A-Za-z]+_)?[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/.test(
+          seg
+        )
+    );
+    expect(colliding).toEqual([]);
+  });
+});
+
+/**
+ * Drift guard: `KNOWN_STATIC_ENDPOINT_SEGMENTS` is only safe while it matches the
+ * routes `withBlockScope` actually wraps. A route added without updating it
+ * records `:seg` where a real segment belongs; an entry left behind after a route
+ * is deleted silently widens the allowlist. Both are invisible to the behaviour
+ * tests above, which assert against hardcoded strings.
+ *
+ * So derive the set from the SOURCE OF TRUTH — the route files — the way
+ * `analytics-bucket-labels.drift.test.ts` greps the `recordScopeInvocation` call
+ * sites rather than trusting a comment.
+ */
+describe('KNOWN_STATIC_ENDPOINT_SEGMENTS ⇄ withBlockScope route files drift guard', () => {
+  const REPO_ROOT = path.resolve(__dirname, '../../../..');
+  const PAGES_API = path.join(REPO_ROOT, 'src/pages/api');
+
+  /** Repo-relative paths under src/pages/api that `export default withBlockScope(...)`. */
+  function wrappedRouteFiles(): string[] {
+    const out: string[] = [];
+    const walk = (abs: string) => {
+      for (const entry of readdirSync(abs, { withFileTypes: true })) {
+        const child = path.join(abs, entry.name);
+        if (entry.isDirectory()) {
+          if (entry.name !== 'node_modules' && entry.name !== '__tests__') walk(child);
+        } else if (entry.name.endsWith('.ts') && !entry.name.endsWith('.test.ts')) {
+          // The wrap must be the DEFAULT EXPORT — `src/pages/api/v1/me.ts` merely
+          // names the middleware in a comment explaining why it is not wrapped.
+          if (/export default withBlockScope\(/.test(readFileSync(child, 'utf8'))) {
+            out.push(path.relative(PAGES_API, child));
+          }
+        }
+      }
+    };
+    walk(PAGES_API);
+    return out.sort();
+  }
+
+  /** The static (non-`[param]`) segments of every wrapped route's URL path. */
+  function staticSegmentsFromRoutes(): string[] {
+    const found = new Set<string>();
+    for (const rel of wrappedRouteFiles()) {
+      const route = rel.replace(/\.ts$/, '').replace(/(^|\/)index$/, '');
+      for (const seg of ['api', ...route.split('/')]) {
+        if (!seg || seg.startsWith('[')) continue;
+        found.add(seg);
+      }
+    }
+    return [...found].sort();
+  }
+
+  it('the walk finds the wrapped routes (positive control)', () => {
+    // Without this, an fs walk that matched nothing would make the set comparison
+    // below a vacuous pass on an empty set.
+    const files = wrappedRouteFiles();
+    expect(files.length).toBeGreaterThanOrEqual(12);
+    expect(files).toContain('v1/blocks/shared-storage/increment.ts');
+    expect(files).toContain('v1/models/[id].ts');
+  });
+
+  it('the allowlist is EXACTLY the static segments of the wrapped routes', () => {
+    expect([...KNOWN_STATIC_ENDPOINT_SEGMENTS].sort()).toEqual(staticSegmentsFromRoutes());
+  });
+
+  it('pins the current set, so adding a route is a deliberate act', () => {
+    expect(staticSegmentsFromRoutes()).toEqual([
+      'api',
+      'blocks',
+      'collections',
+      'follow',
+      'generation-resources',
+      'images',
+      'increment',
+      'me',
+      'models',
+      'shared-storage',
+      'tip',
+      'tip-allowance',
+      'top',
+      'v1',
+    ]);
+  });
+});

--- a/src/server/middleware/__tests__/block-scope.normalize-endpoint.test.ts
+++ b/src/server/middleware/__tests__/block-scope.normalize-endpoint.test.ts
@@ -184,10 +184,22 @@ describe('KNOWN_STATIC_ENDPOINT_SEGMENTS ⇄ withBlockScope route files drift gu
         const child = path.join(abs, entry.name);
         if (entry.isDirectory()) {
           if (entry.name !== 'node_modules' && entry.name !== '__tests__') walk(child);
-        } else if (entry.name.endsWith('.ts') && !entry.name.endsWith('.test.ts')) {
-          // The wrap must be the DEFAULT EXPORT — `src/pages/api/v1/me.ts` merely
-          // names the middleware in a comment explaining why it is not wrapped.
-          if (/export default withBlockScope\(/.test(readFileSync(child, 'utf8'))) {
+          // Match every extension Next treats as a page. `pageExtensions` is NOT
+          // set in next.config.mjs, so the default applies: ['tsx','ts','jsx','js'].
+          // Scanning only `.ts` was not hypothetical under-coverage — this repo
+          // ALREADY ships `.tsx` API routes (src/pages/api/v1/vault/*.tsx), so a
+          // wrapped `.tsx` route added later would have recorded every one of its
+          // static segments as `:seg` with NOTHING going red. Measured: the same
+          // fake wrapped route failed this guard as `.ts` and passed it as `.tsx`.
+        } else if (/\.(t|j)sx?$/.test(entry.name) && !/\.test\.(t|j)sx?$/.test(entry.name)) {
+          const src = readFileSync(child, 'utf8');
+          // The wrap must reach the DEFAULT EXPORT — `src/pages/api/v1/me.ts`
+          // merely names the middleware in a comment explaining why it is not
+          // wrapped. Both spellings count: the direct
+          // `export default withBlockScope(...)`, and the indirect
+          // `const handler = withBlockScope(...); export default handler`, which
+          // is one refactor away and was previously invisible to this walk.
+          if (/export default\s+withBlockScope\(/.test(src) || /=\s*withBlockScope\(/.test(src)) {
             out.push(path.relative(PAGES_API, child));
           }
         }

--- a/src/server/middleware/block-scope.middleware.ts
+++ b/src/server/middleware/block-scope.middleware.ts
@@ -963,9 +963,10 @@ export function withBlockScope(handler: NextApiHandler, opts: WithBlockScopeOpts
  * wrapped handler when the URL matches one of the 12 route files verbatim except
  * for their `[id]` positions, so any segment not listed here arrived in a dynamic
  * position and is caller-supplied. Kept in lockstep with those route files by
- * `block-scope.normalize-endpoint.drift.test.ts`, which derives the set by
- * walking `src/pages/api` for `export default withBlockScope(` rather than
- * trusting this comment.
+ * `block-scope.normalize-endpoint.test.ts`, which derives the set by walking
+ * `src/pages/api` for every page extension Next accepts and matching both the
+ * direct and indirect `withBlockScope(` wrap, rather than trusting this
+ * comment.
  *
  * Not listed on purpose: `submissions`, `submit-version`, `withdraw`,
  * `dev-token`, `block-tokens`. Those routes live under `/api/v1/blocks` too but

--- a/src/server/middleware/block-scope.middleware.ts
+++ b/src/server/middleware/block-scope.middleware.ts
@@ -613,10 +613,7 @@ function readBoundQueryString(req: NextApiRequest, name: string): string | undef
  *
  * Throws ForbiddenError on mismatch.
  */
-export function enforceContextBinding(
-  claims: BlockTokenClaims,
-  req: NextApiRequest
-): void {
+export function enforceContextBinding(claims: BlockTokenClaims, req: NextApiRequest): void {
   for (const scope of claims.scopes) {
     // Deny-by-default: tokens carrying scopes we don't know about are
     // rejected here. The manifest validator is the registration-time gate;
@@ -627,24 +624,17 @@ export function enforceContextBinding(
     }
     switch (scope) {
       case 'models:read:self': {
-        const modelIdStr =
-          readBoundQueryString(req, 'id') ?? readBoundQueryString(req, 'modelId');
+        const modelIdStr = readBoundQueryString(req, 'id') ?? readBoundQueryString(req, 'modelId');
         // M10: decimal-only parse. Number('0x3039') === 12345 — an attacker
         // could otherwise pass the binding with ?id=0x3039 against
         // ctx.modelId=12345. Also reject any non-digit form.
         const modelId =
-          modelIdStr != null && /^[0-9]+$/.test(modelIdStr)
-            ? Number.parseInt(modelIdStr, 10)
-            : NaN;
+          modelIdStr != null && /^[0-9]+$/.test(modelIdStr) ? Number.parseInt(modelIdStr, 10) : NaN;
         const ctxModelId = Number(claims.ctx?.modelId ?? NaN);
         // isInteger over isFinite: '1.5' would parse to 1.5 (finite) and then
         // fail the equality against an integer ctxModelId, so it would 403
         // either way — but rejecting non-integer up front is clearer.
-        if (
-          !Number.isInteger(modelId) ||
-          !Number.isInteger(ctxModelId) ||
-          modelId !== ctxModelId
-        ) {
+        if (!Number.isInteger(modelId) || !Number.isInteger(ctxModelId) || modelId !== ctxModelId) {
           throw forbidden('models:read:self bound to different modelId');
         }
         break;
@@ -729,10 +719,7 @@ export function enforceContextBinding(
   }
 }
 
-export function withBlockScope(
-  handler: NextApiHandler,
-  opts: WithBlockScopeOpts
-): NextApiHandler {
+export function withBlockScope(handler: NextApiHandler, opts: WithBlockScopeOpts): NextApiHandler {
   return async (req, res) => {
     const cors = await setBlockCors(req, res, opts);
     if (cors === 'handled') return;
@@ -914,10 +901,7 @@ export function withBlockScope(
     // the v1 payloads happen to be public, the moment a wrapped route
     // differentiates by claims.sub (e.g., shows drafts to the owner), edge
     // caches would otherwise serve one user's view to another.
-    originalSetHeader(
-      'Cache-Control',
-      'private, no-store, no-cache, must-revalidate, max-age=0'
-    );
+    originalSetHeader('Cache-Control', 'private, no-store, no-cache, must-revalidate, max-age=0');
 
     // W5 v0.5: log a BlockScopeInvocation row when the response finishes.
     // Fires after every successful scope+binding check (the wrapped handler
@@ -944,9 +928,9 @@ export function withBlockScope(
               appBlockId: claims.appBlockId,
               blockInstanceId: claims.blockInstanceId,
               // In "any valid block token" mode there is no required scope; the
-            // audit column is NOT NULL, so record a stable sentinel that
-            // distinguishes these rows from real per-scope invocations.
-            scope: opts.requiredScope ?? '(any-token)',
+              // audit column is NOT NULL, so record a stable sentinel that
+              // distinguishes these rows from real per-scope invocations.
+              scope: opts.requiredScope ?? '(any-token)',
               endpoint: endpointForLog,
               statusCode: res.statusCode,
               ...(actionDetail ? { detail: actionDetail } : {}),
@@ -972,23 +956,102 @@ export function withBlockScope(
 }
 
 /**
- * Reduce req.url to a route-shaped string for the audit log: strip query
- * string + collapse path segments that look like ids/ulids to a placeholder
- * so the cardinality of the `endpoint` column stays bounded.
+ * Every STATIC path segment reachable through a `withBlockScope`-wrapped route,
+ * and nothing else. This is the allowlist `normalizeEndpoint` templates against.
+ *
+ * It is a CLOSED set by construction: Next.js only dispatches a request to a
+ * wrapped handler when the URL matches one of the 12 route files verbatim except
+ * for their `[id]` positions, so any segment not listed here arrived in a dynamic
+ * position and is caller-supplied. Kept in lockstep with those route files by
+ * `block-scope.normalize-endpoint.drift.test.ts`, which derives the set by
+ * walking `src/pages/api` for `export default withBlockScope(` rather than
+ * trusting this comment.
+ *
+ * Not listed on purpose: `submissions`, `submit-version`, `withdraw`,
+ * `dev-token`, `block-tokens`. Those routes live under `/api/v1/blocks` too but
+ * authenticate with an API key, not a block JWT — they never call this
+ * middleware, so listing them would be an unfalsifiable claim about a path this
+ * function cannot see.
  */
-function normalizeEndpoint(rawUrl: string): string {
+export const KNOWN_STATIC_ENDPOINT_SEGMENTS = new Set([
+  'api',
+  'v1',
+  'blocks',
+  'collections',
+  'follow',
+  'generation-resources',
+  'images',
+  'increment',
+  'me',
+  'models',
+  'shared-storage',
+  'tip',
+  'tip-allowance',
+  'top',
+]);
+
+/**
+ * Reduce req.url to a route-shaped string for the audit log: strip the query
+ * string + collapse every per-request path segment to a placeholder so the
+ * cardinality of the `endpoint` column stays bounded.
+ *
+ * WHY THIS MATTERS: `endpoint` is the GROUP BY key of the `topEndpoints` rollup
+ * (`app-analytics.service.ts` — `groupBy(['endpoint']) … take: 5`). An unbounded
+ * value is not merely ugly, it fragments one logical route into N count-1 rows
+ * and pushes the app's real traffic out of the top 5 entirely. #3561 fixed
+ * exactly that for the five ROUTER call sites that interpolated an id into a
+ * bounded literal; this function is the remaining writer to the same column.
+ *
+ * THE RULE IS ALLOWLIST-FIRST, NOT SHAPE-FIRST, and deliberately so. The static
+ * vocabulary of these routes is itself slug-shaped — `generation-resources`,
+ * `tip-allowance`, `shared-storage` — so NO shape heuristic can template
+ * `my-collection-slug` without also templating those, and over-templating
+ * destroys the aggregate just as thoroughly as under-templating (every route
+ * collapses to one row). A segment in `KNOWN_STATIC_ENDPOINT_SEGMENTS` survives
+ * verbatim and that arm wins over every shape test; everything else is a value
+ * and is templated — `:id` / `:ulid` / `:uuid` where the shape is recognisable,
+ * `:seg` otherwise.
+ *
+ * FIDELITY LIMITS — this is a heuristic. It deliberately does NOT cover:
+ *   - Distinguishing a VALUE from a segment that collides with the static
+ *     vocabulary. `/api/v1/blocks/collections/models` records as
+ *     `/api/v1/blocks/collections/models`, not `…/:seg`. Bounded either way (the
+ *     vocabulary is finite), and Next routes it to the `[id]` handler, which
+ *     rejects it — so the row is a bounded 4xx, not a cardinality leak.
+ *   - A NEW wrapped route whose static segments are not added to the set: it
+ *     degrades to `:seg`. That is the safe direction (still bounded, just less
+ *     readable) and the drift test fails until the set is updated.
+ *   - The query string, which is DROPPED rather than templated — `?cursor=…`
+ *     values never reach the column at all, so a cursor cannot fragment it.
+ *   - Historical rows. No backfill is run, so the rollup mixes bounded and
+ *     legacy unbounded values until the old rows age out of the query range.
+ */
+export function normalizeEndpoint(rawUrl: string): string {
   const qIdx = rawUrl.indexOf('?');
   const path = qIdx >= 0 ? rawUrl.slice(0, qIdx) : rawUrl;
   return path
     .split('/')
     .map((seg) => {
       if (!seg) return seg;
-      // Numeric ids (modelId, userId, etc.).
+      // A known static segment is never a caller-supplied value. This arm runs
+      // FIRST so that a future static segment which happens to look like an id
+      // (a `/v2` prefix, a `/2024` archive route) cannot be templated away.
+      if (KNOWN_STATIC_ENDPOINT_SEGMENTS.has(seg)) return seg;
+      // Numeric ids (modelId, collectionId, userId, etc.).
       if (/^\d+$/.test(seg)) return ':id';
       // ULIDs + their prefixed forms (apb_<26 ulid>, mbi_<26 ulid>, etc.).
       if (/^[A-Za-z]+_[0-9A-HJKMNP-TV-Z]{26}$/.test(seg)) return ':ulid';
       if (/^[0-9A-HJKMNP-TV-Z]{26}$/.test(seg)) return ':ulid';
-      return seg;
+      // UUIDs (any version, either case), incl. the same prefixed form.
+      if (
+        /^(?:[A-Za-z]+_)?[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/.test(
+          seg
+        )
+      )
+        return ':uuid';
+      // Anything else in a dynamic position: a slug, a hash, a filename, a
+      // percent-encoded blob, fuzzer junk. Unbounded by definition.
+      return ':seg';
     })
     .join('/');
 }


### PR DESCRIPTION
Follow-up #5 to #3561. That PR bounded the five **router** call sites that interpolated an id into `block_scope_invocations.endpoint`. It left the other writer alone.

`normalizeEndpoint` (`src/server/middleware/block-scope.middleware.ts`) turns `req.url` into the stored `endpoint` for every `withBlockScope` REST call, and templated **numeric segments and ULIDs only**. Any other segment — a slug, a UUID, a hash, percent-encoded junk — passed through verbatim. `endpoint` is the GROUP BY key of the `topEndpoints` rollup (`app-analytics.service.ts`: `groupBy(['endpoint']) … take: 5`), so an unbounded value fragments one logical route into N count-1 rows and pushes the app's real traffic out of the top 5. Same defect class, different door.

**Reachable today, not hypothetical.** Next dispatches `/api/v1/blocks/collections/<anything>` to the `[id]` handler, and the audit row is written from `res.on('finish')` **regardless of status code** — so a caller-supplied non-numeric id is recorded before the handler ever rejects it.

## The rule: allowlist-first, not shape-first

A shape heuristic cannot do this job here, and this is the load-bearing finding. The static vocabulary of these routes is **itself slug-shaped** — `generation-resources`, `tip-allowance`, `shared-storage` — so any rule that templates `my-cool-collection` by its hyphens templates those too. Over-templating destroys the aggregate exactly as thoroughly as under-templating (every route collapses into one row) and is far easier to ship unnoticed, because nothing looks broken; the panel just stops saying anything.

So:

```
seg ∈ KNOWN_STATIC_ENDPOINT_SEGMENTS  → verbatim   (this arm runs FIRST)
/^\d+$/                               → :id       (unchanged)
ULID, bare or prefixed                → :ulid     (unchanged)
UUID, any version/case, bare or `pfx_`→ :uuid     (new)
anything else                         → :seg      (new)
```

`KNOWN_STATIC_ENDPOINT_SEGMENTS` is the 14 static segments of the 12 `export default withBlockScope(...)` route files: `api, v1, blocks, collections, follow, generation-resources, images, increment, me, models, shared-storage, tip, tip-allowance, top`. The set is **closed by construction** — Next only dispatches a request to a wrapped handler when the URL matches a route file verbatim outside its `[id]` positions, so a segment outside the set arrived in a dynamic position and is caller-supplied.

Not listed on purpose: `submissions`, `submit-version`, `withdraw`, `dev-token`, `block-tokens`. Those routes live under `/api/v1/blocks` but authenticate with an API key, not a block JWT — they never reach this middleware, so listing them would be an unfalsifiable claim about a path this function cannot see.

The allowlist is kept honest by a **drift test that derives the set by walking `src/pages/api`** for `export default withBlockScope(`, rather than trusting the comment (same posture as `analytics-bucket-labels.drift.test.ts`). A new wrapped route fails CI instead of silently recording `:seg`.

## What is deliberately NOT covered

Stated in the docstring, not just here:

- **A value that collides with the static vocabulary.** `/api/v1/blocks/collections/models` records as `…/collections/models`, not `…/collections/:seg`. Bounded either way (the vocabulary is finite), and Next routes it to the `[id]` handler which rejects it — a bounded 4xx row, not a cardinality leak.
- **A new wrapped route whose segments were not added.** It degrades to `:seg`: still bounded, just less readable. Safe direction, and the drift test is red until it is fixed.
- **The query string**, which is dropped entirely rather than templated — no `?cursor=…` value reaches the column at all.
- **The arm ORDER**, which is currently moot: no static segment matches an id shape. That is pinned by a test rather than assumed, so a future `/v2` or `/2024` segment turns it red.

## No backfill

Historical rows keep their unbounded values. The `topEndpoints` card will show a **mix** of bounded and legacy values until the old rows age out of the query range — same call as #3561 made.

The now-stale claim in `analytics-bucket-labels.ts` ("templates only numeric and ULID-shaped segments, so a slug/UUID segment survives") is corrected in the same commit; it would otherwise be a comment asserting the opposite of the code.

## Verification

- `tsc --noEmit` (with `--max_old_space_size=8192`): **0 errors**. Harness validated first — a deliberate `const x: number = normalizeEndpoint(...)` produced exactly **1** `error TS`, and the tree was restored byte-identically (sha256 checked).
- Full `unit` project: **796 files, 11774 passed, 1 skipped, 0 failed** (counted, not read off an exit code).
- New file: **27 tests**, covering both directions.
- Prettier clean on all three touched files.

### Mutation sweep — 9 mutants, 8 killed, 1 documented survivor

Each mutant applied by exact single-occurrence replacement, tests re-run, tree restored and sha256-verified after every one. Every kill is listed with the test that went red.

| # | Mutant (deletes nothing) | Verdict | Killed by |
|---|---|---|---|
| M1 | invert the allowlist test (`has` → `!has`) | KILLED | 12 tests, both directions |
| M2 | move the allowlist arm from **first to last** | **SURVIVED** | — behaviour-equivalent today; see below |
| M3 | `:seg` fallback → old verbatim pass-through | KILLED | slug / hash / one-bucket |
| M4 | off-by-one the UUID pattern (`{12}` → `{11}`) | KILLED | UUID / one-bucket |
| M5 | drop the prefixed form from the UUID pattern | KILLED | UUID |
| M6 | remove `shared-storage` from the allowlist | KILLED | 2 static-route tests + slug-shaped-static + drift equality |
| M7 | add `my-cool-collection` **to** the allowlist | KILLED | slug + one-bucket + drift equality |
| M8 | strip on `#` instead of `?` | KILLED | query-string |
| M9 | numeric arm returns the raw segment | KILLED | 3 static-route tests + numeric + query-string |

**M2 survived and that is the honest answer, not a gap I papered over.** Moving the allowlist arm last changes nothing today because no static segment matches an id shape — an equivalent mutant. Rather than assert that in a comment, the suite pins it: `no static segment collides with an id shape (so the arm order is currently moot)` fails the moment someone adds a `/v2` or `/2024` segment, which is exactly when M2 would stop being equivalent.

## Not verified

No live query against production `block_scope_invocations` — the fragmentation claim is carried over from #3561's measurement plus the code path, not re-measured here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017vvMdxcMKJP9ripQLEiPm9
