### PR TITLE
docs(app-blocks): treat App loads as untrusted input, and log unknown-app beacons

### DIFF
--- a/src/pages/api/track/block-render.ts
+++ b/src/pages/api/track/block-render.ts
@@ -7,6 +7,7 @@ import {
   normalizeSlotId,
   observeAppBlockLaunch,
 } from '~/server/metrics/app-block-runtime.metrics';
+import { logToAxiom } from '~/server/logging/client';
 import { boundAppBlockIdLabel } from '~/server/services/blocks/known-app-blocks.service';
 import { blockRenderSchema, blockRenderTrackerPayload } from '~/server/schema/track.schema';
 import { PublicEndpoint } from '~/server/utils/endpoint-helpers';
@@ -92,6 +93,37 @@ export default PublicEndpoint(
     // metrics failure break the beacon.
     try {
       const appBlockIdLabel = await boundAppBlockIdLabel(result.data.appBlockId);
+
+      // ── UNKNOWN-APP DETECTION (observe, NEVER gate) ───────────────────────
+      // `other` means the id is not in the TTL-cached approved-app set. This
+      // endpoint is unauthenticated and `appBlockId` comes from the request
+      // body, so an unknown id is worth seeing — see the trust caveat on
+      // `app-views.service.ts`. Surfacing it costs nothing: the lookup already
+      // ran for the prom label.
+      //
+      // 🔴 It stays a LOG, not a gate, for two independent reasons.
+      // (1) `other` is ALSO the honest value for a genuinely new app inside
+      //     the cache's <=5-minute TTL window — and for EVERY app if
+      //     `loadKnownAppBlockIds` fails, because it fails to an empty set and
+      //     caches that, so a brief DB blip would make every id look unknown.
+      // (2) `blockRenders` is a fire-and-forget beacon with no status column,
+      //     so a wrongly-rejected beacon makes App loads UNDER-report silently
+      //     and permanently — strictly worse than over-reporting, because
+      //     nothing surfaces the loss.
+      // Read a rise here as a prompt to investigate, not as a count of attacks.
+      if (appBlockIdLabel === 'other') {
+        logToAxiom(
+          {
+            name: 'block-render-unknown-app',
+            type: 'warning',
+            message: 'block-render beacon for an id outside the approved-app set',
+            slotId: result.data.slotId,
+            status,
+          },
+          'clickhouse'
+        ).catch(() => undefined);
+      }
+
       const { rendersTotal } = ensureRegisterAppBlockRuntimeMetrics();
       rendersTotal.inc({
         app_block_id: appBlockIdLabel,

--- a/src/server/services/blocks/app-views.service.ts
+++ b/src/server/services/blocks/app-views.service.ts
@@ -45,15 +45,36 @@ import { logToAxiom } from '~/server/logging/client';
  * table carries no status column, so this reader cannot exclude them. An app
  * that fails to load for everyone still reports loads.
  *
- * ⚠️ TRUST CAVEAT — this number is not adversary-proof, and reading it here is
- * what makes that matter. The writer, `/api/track/block-render`, is a
- * `PublicEndpoint` whose only gate is an Origin/Referer host comparison, which
- * any non-browser client can forge, and `appBlockId` arrives from the client.
- * So anyone can inflate an arbitrary author's load count. That is a pre-existing
- * WRITER-side weakness, deliberately not fixed in the change that added this
- * reader (it needs its own change to the ingest path) — but do not build
- * payouts, ranking, or anything else with an incentive to cheat on top of this
- * figure until the writer is authenticated.
+ * ⚠️ TRUST CAVEAT — TREAT THESE NUMBERS AS UNTRUSTED INPUT.
+ *
+ * The rows this reads are produced by an UNAUTHENTICATED write path, and the
+ * app they are attributed to is chosen by the caller. Both counters below are
+ * therefore influenceable from outside — and note that `uniqueViewers` is NOT
+ * the safer of the two: for signed-out viewers it is derived from request
+ * metadata that the origin does not independently verify, so it is at least as
+ * influenceable as the raw count. Do not reason about it as a harder-to-game
+ * number just because it is a distinct-count.
+ *
+ * (Specifics of the write path have been reported to security@civitai.com per
+ * SECURITY.md, and are deliberately not restated here. If you are changing the
+ * ingest path or the IP derivation, ask them for the report first — the
+ * mechanism matters and this comment is not sufficient to design against.)
+ *
+ * This is a pre-existing WRITER-side weakness, deliberately not fixed in the
+ * change that added this reader: an ingest gate that wrongly rejects beacons
+ * would make these counts UNDER-report silently and permanently, because the
+ * beacon is fire-and-forget and this table has no status column — so a wrongly
+ * dropped beacon leaves no trace anywhere. Fixing it well means adding
+ * provenance to the row so the READER can filter, which needs a coordinated
+ * change to the out-of-repo tracker service and the ClickHouse schema (there is
+ * no DDL for this table in this repo).
+ *
+ * Until then: do NOT build payouts, revenue share, ranking, discovery, or
+ * author-visible leaderboards on these figures. Present-day exposure is low in
+ * absolute terms (~3 rows/day platform-wide; both feature flags are mod-only),
+ * but there is no provenance column, so rows written now cannot later be sorted
+ * into trusted and untrusted. If inflation happens first the history is
+ * unrecoverable rather than repairable — which is the real cost of waiting.
  */
 
 /** Impressions for a set of owned app blocks over a bounded range. */

--- a/src/tests/api/track/block-render.test.ts
+++ b/src/tests/api/track/block-render.test.ts
@@ -16,12 +16,15 @@ import type { NextApiRequest, NextApiResponse } from 'next';
  *  - dev short-circuits to 200 with no insert.
  */
 
-const { mockBlockRender, mockGetSession, devStore, sessionStore } = vi.hoisted(() => ({
-  mockBlockRender: vi.fn(),
-  mockGetSession: vi.fn(),
-  devStore: { isDev: false },
-  sessionStore: { session: null as { user?: { id: number } } | null },
-}));
+const { mockBlockRender, mockGetSession, devStore, sessionStore, mockLogToAxiom } = vi.hoisted(
+  () => ({
+    mockLogToAxiom: vi.fn((_payload: unknown, _datastream?: unknown) => Promise.resolve()),
+    mockBlockRender: vi.fn(),
+    mockGetSession: vi.fn(),
+    devStore: { isDev: false },
+    sessionStore: { session: null as { user?: { id: number } } | null },
+  })
+);
 
 // PublicEndpoint wraps the handler with CORS/metrics we don't exercise here —
 // pass it through so the route's own logic (origin guard, parse, session ->
@@ -55,6 +58,11 @@ vi.mock('~/server/clickhouse/client', () => ({
   Tracker: class {
     blockRender = mockBlockRender;
   },
+}));
+
+// Detection log for an unknown appBlockId — asserted in both directions below.
+vi.mock('~/server/logging/client', () => ({
+  logToAxiom: (payload: unknown, datastream?: unknown) => mockLogToAxiom(payload, datastream),
 }));
 
 // Known-app clamp: control which appBlockIds count as "approved" so the render
@@ -261,7 +269,9 @@ async function renderCounterValue(
   const metric = client.register.getSingleMetric('civitai_app_block_renders_total');
   if (!metric) return 0;
   const data = await (
-    metric as { get(): Promise<{ values: Array<{ labels: Record<string, string>; value: number }> }> }
+    metric as {
+      get(): Promise<{ values: Array<{ labels: Record<string, string>; value: number }> }>;
+    }
   ).get();
   const match = data.values.find(
     (v) =>
@@ -376,9 +386,9 @@ describe('POST /api/track/block-render — civitai_app_block_renders_total count
     );
 
     // The observability signal still fires — this is what the alert reads.
-    expect(
-      await renderCounterValue('apb_test', 'app.page', 'error', 'token_lost_midsession')
-    ).toBe(before + 1);
+    expect(await renderCounterValue('apb_test', 'app.page', 'error', 'token_lost_midsession')).toBe(
+      before + 1
+    );
     // …but the impression table is untouched.
     expect(mockBlockRender).not.toHaveBeenCalled();
     // And the request still succeeds (fire-and-forget beacon).
@@ -619,7 +629,10 @@ describe('POST /api/track/block-render — launch-latency histograms', () => {
     // POSITIVE CONTROL: identical body minus `secondary` DOES move it by 1, so
     // the zero above is the gate and not a dead metric.
     await handler(
-      makeReq({ origin: 'https://civitai.com', body: { ...validInput, status: 'ok', timings } }) as any,
+      makeReq({
+        origin: 'https://civitai.com',
+        body: { ...validInput, status: 'ok', timings },
+      }) as any,
       makeRes()
     );
     expect(await histCount(LAUNCH_TOTAL, { app_block_id: 'apb_test' })).toBe(before + 1);
@@ -688,5 +701,53 @@ describe('POST /api/track/block-render — launch-latency histograms', () => {
     expect(mockBlockRender).toHaveBeenCalledWith({ ...validInput, isAnon: true });
     expect(await renderCounterValue('apb_test', 'app.page', 'ok', 'none')).toBe(beforeRender + 1);
     expect(await histCount(LAUNCH_TOTAL, { app_block_id: 'apb_test' })).toBe(beforeLaunch);
+  });
+
+  /*
+   * UNKNOWN-APP DETECTION. This endpoint is unauthenticated and `appBlockId` is
+   * client-supplied and publicly discoverable, so a beacon can name an app that
+   * does not exist. We LOG that and still record the impression.
+   *
+   * Both directions are pinned on purpose. Only asserting the log fires would
+   * let it degrade into a gate (drop the beacon) without failing, and only
+   * asserting the beacon survives would let the log quietly never fire. The
+   * "known id logs nothing" case is the one that catches a log wired to every
+   * request, which would bury the signal it exists to surface.
+   */
+  it('LOGS an unknown appBlockId but still records the impression', async () => {
+    mockLogToAxiom.mockClear();
+    const handler = (await import('~/pages/api/track/block-render')).default;
+    const unknown = { ...validInput, appBlockId: 'apb_not_a_real_app' };
+    const res = makeRes();
+
+    await handler(makeReq({ origin: 'https://civitai.com', body: unknown }) as any, res);
+
+    // Detection, never a gate: the beacon is fire-and-forget and the table has
+    // no status column, so a dropped beacon under-reports App loads silently
+    // and permanently.
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(mockBlockRender).toHaveBeenCalledWith({ ...unknown, isAnon: true });
+
+    expect(mockLogToAxiom).toHaveBeenCalledTimes(1);
+    const [payload, datastream] = mockLogToAxiom.mock.calls[0] as unknown as [
+      Record<string, unknown>,
+      string
+    ];
+    expect(payload.name).toBe('block-render-unknown-app');
+    expect(datastream).toBe('clickhouse');
+    // The raw id is deliberately NOT logged — it is attacker-controlled and up
+    // to 256 chars, and the point is the RATE, not the value.
+    expect(JSON.stringify(payload)).not.toContain('apb_not_a_real_app');
+  });
+
+  it('logs NOTHING for a known appBlockId', async () => {
+    mockLogToAxiom.mockClear();
+    const handler = (await import('~/pages/api/track/block-render')).default;
+    const res = makeRes();
+
+    await handler(makeReq({ origin: 'https://civitai.com', body: validInput }) as any, res);
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(mockLogToAxiom).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Follow-up to #3613, which gave the ClickHouse `blockRenders` table its first reader. Reading those rows in an author-facing surface turned a dormant writer-side weakness into a consequential one.

> **Note on scope.** Specifics of the write path have been reported to **security@civitai.com** per `SECURITY.md` and are deliberately not restated here or in the code. This PR changes **nothing** about what the ingest path accepts — it is documentation plus a log line. If you are reviewing with an eye to changing ingest or the IP derivation, please get the report from security first; the mechanism matters and the comment is not sufficient to design against.

## The claim being recorded

The rows come from an **unauthenticated** write path, and the app they're attributed to is **chosen by the caller**. So both counters are influenceable from outside.

Worth stating explicitly because the intuition runs the other way: **`uniqueViewers` is not the safer number.** For signed-out viewers it is derived from request metadata the origin does not independently verify, so it is at least as influenceable as the raw count. A distinct-count is not automatically a harder-to-game count, and treating it as one is the mistake this comment exists to prevent.

## Why this changes nothing about what is accepted

The beacon is fire-and-forget and `blockRenders` has **no status column**, so a gate that wrongly rejects beacons makes App loads **under-report silently and permanently** — strictly worse than over-reporting, because a dropped beacon leaves no trace anywhere.

The durable fix is **provenance on the row so the reader can filter**, which needs a coordinated change to the out-of-repo tracker service and the ClickHouse schema (there is no DDL for this table in this repo). Detection before enforcement.

## What ships

- **Trust caveat** on `app-views.service.ts`, stating the operational rule plainly: do not build payouts, revenue share, ranking, discovery, or author-visible leaderboards on these figures. It also records the real cost of waiting — with no provenance column, rows written now can't later be sorted into trusted/untrusted, so if inflation happens first the history is *unrecoverable* rather than repairable.
- **Unknown-app beacons are logged, never dropped.** Free — the lookup already ran for the prom label. The comment gives the two independent reasons it must stay a log: `other` is also the honest value for a new app inside the cache's ≤5-min TTL, **and** for *every* app if `loadKnownAppBlockIds` fails, since it fails to an empty set and caches that (a brief DB blip would make every id look unknown). The raw id is deliberately not logged — caller-supplied, up to 256 chars, and the signal is the **rate**, not the value.

Present-day exposure is low and I'm not inflating it: ~3 rows/day platform-wide, both feature flags mod-only, nothing paid or ranked on it.

## Verification

**4 mutants, 4/4 KILLED**, tree restored byte-identically:

| mutant | result |
|---|---|
| G1 detection becomes a **gate** (drops the beacon) | KILLED |
| G2 logs on **every** request (signal buried) | KILLED |
| G3 **never** logs (detection silently dead) | KILLED |
| G4 leaks the raw caller-supplied id | KILLED |

G1 and G2 are why the tests pin **both** directions: asserting only that the log fires would let it degrade into a gate without failing, and asserting only that the beacon survives would let the log quietly never fire.

43 tests pass across the touched files; typecheck **0 errors**; prettier clean (positive control: my own test file was flagged before `--write`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017vvMdxcMKJP9ripQLEiPm9
