### PR TITLE
fix(articles): never parse article content as JSON

### DIFF
--- a/src/components/RichTextEditor/RenderRichText.tsx
+++ b/src/components/RichTextEditor/RenderRichText.tsx
@@ -7,6 +7,7 @@ import { TextStyleKit } from '@tiptap/extension-text-style';
 import ImageExtension from '@tiptap/extension-image';
 import { ConsentBlockedEmbed } from '~/components/Consent/ConsentBlockedEmbed';
 import { useThirdPartyConsent } from '~/components/Consent/consent.context';
+import { RenderHtml } from '~/components/RenderHtml/RenderHtml';
 import { EdgeMediaComponent } from '~/components/TipTap/EdgeMediaNode';
 import classes from './RichTextEditorComponent.module.scss';
 import { CustomHeading } from '~/shared/tiptap/custom-heading.node';
@@ -31,33 +32,52 @@ const extensions = [
   TimestampNode,
 ];
 
-export function RenderRichText({ content }: { content: Record<string, any> }) {
+export function RenderRichText({
+  content,
+  fallbackHtml,
+}: {
+  content: Record<string, any>;
+  fallbackHtml?: string;
+}) {
   const { allowed } = useThirdPartyConsent();
   const memoized = useMemo(() => {
-    return renderToReactElement({
-      content,
-      extensions,
-      options: {
-        nodeMapping: {
-          media: ({ node }) => <EdgeMediaComponent {...(node.attrs as any)} />,
-          timestamp: ({ node }) => (
-            <LocalTimestamp value={node.attrs.value} style={node.attrs.style} />
-          ),
-          // For unconsented CA visitors, replace third-party embed nodes with a
-          // placeholder so the iframe is never inserted in the DOM.
-          ...(!allowed && {
-            youtube: () => <ConsentBlockedEmbed kind="youtube" />,
-            instagram: () => <ConsentBlockedEmbed kind="instagram" />,
-            strawPoll: () => <ConsentBlockedEmbed kind="strawpoll" />,
-          }),
+    try {
+      const el = renderToReactElement({
+        content,
+        extensions,
+        options: {
+          nodeMapping: {
+            media: ({ node }) => <EdgeMediaComponent {...(node.attrs as any)} />,
+            timestamp: ({ node }) => (
+              <LocalTimestamp value={node.attrs.value} style={node.attrs.style} />
+            ),
+            // For unconsented CA visitors, replace third-party embed nodes with a
+            // placeholder so the iframe is never inserted in the DOM.
+            ...(!allowed && {
+              youtube: () => <ConsentBlockedEmbed kind="youtube" />,
+              instagram: () => <ConsentBlockedEmbed kind="instagram" />,
+              strawPoll: () => <ConsentBlockedEmbed kind="strawpoll" />,
+            }),
+          },
         },
-      },
-    });
+      });
+      // The flag is load-bearing: a legitimate doc can render to `null`, so the element
+      // alone can't distinguish "rendered empty" from "threw".
+      return { ok: true as const, el };
+    } catch {
+      // A node or mark type outside `extensions` throws while the doc is built, before
+      // `nodeMapping` is ever consulted — so an extra mapping entry cannot absorb it, and
+      // with no ErrorBoundary in the tree it blanks the whole page. `extensions` is kept in
+      // sync with `tiptapExtensions` by hand, so treat drift as reachable.
+      return { ok: false as const };
+    }
   }, [content, allowed]);
+
+  if (!memoized.ok) return fallbackHtml ? <RenderHtml html={fallbackHtml} /> : null;
 
   return (
     <TypographyStylesWrapper className={classes.htmlRenderer}>
-      <div>{memoized}</div>
+      <div>{memoized.el}</div>
     </TypographyStylesWrapper>
   );
 }

--- a/src/components/RichTextEditor/__tests__/RenderRichText.browser.test.tsx
+++ b/src/components/RichTextEditor/__tests__/RenderRichText.browser.test.tsx
@@ -1,0 +1,50 @@
+import { describe, expect, test, vi } from 'vitest';
+import { page } from 'vitest/browser';
+// `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
+import { renderWithProviders } from '../../../../test/component-setup';
+import type * as RenderHtmlModule from '~/components/RenderHtml/RenderHtml';
+
+// The fallback path is what's under test, not RenderHtml's own rendering — the real
+// component resolves sticker artwork over tRPC and reads browsing settings, neither of
+// which this scaffold provides.
+vi.mock('~/components/RenderHtml/RenderHtml', async (importOriginal) => ({
+  ...(await importOriginal<typeof RenderHtmlModule>()),
+  RenderHtml: ({ html }: { html: string }) => <div data-testid="fallback">{html}</div>,
+}));
+
+const { RenderRichText } = await import('~/components/RichTextEditor/RenderRichText');
+
+const paragraph = (text: string) => ({
+  type: 'doc',
+  content: [{ type: 'paragraph', content: [{ type: 'text', text }] }],
+});
+
+// Node types outside the component's `extensions` throw while the doc is built, before
+// `nodeMapping` is consulted — so no mapping entry can absorb them.
+const unknownNode = { type: 'doc', content: [{ type: 'sticker', attrs: { id: '1' } }] };
+
+describe('RenderRichText', () => {
+  test('renders a valid document', async () => {
+    renderWithProviders(<RenderRichText content={paragraph('a real article')} />);
+
+    await expect.element(page.getByText('a real article')).toBeInTheDocument();
+  });
+
+  test('falls back to the sanitized HTML when the document cannot be rendered', async () => {
+    renderWithProviders(
+      <RenderRichText content={unknownNode} fallbackHtml="<p>the original body</p>" />
+    );
+
+    await expect.element(page.getByTestId('fallback')).toHaveTextContent('the original body');
+  });
+
+  test('renders nothing rather than throwing when there is no fallback', async () => {
+    renderWithProviders(
+      <div data-testid="host">
+        <RenderRichText content={unknownNode} />
+      </div>
+    );
+
+    await expect.element(page.getByTestId('host')).toBeEmptyDOMElement();
+  });
+});

--- a/src/pages/articles/[id]/[[...slug]].tsx
+++ b/src/pages/articles/[id]/[[...slug]].tsx
@@ -514,7 +514,7 @@ function ArticleDetailsPage({ id }: InferGetServerSidePropsType<typeof getServer
 
               {article.contentJson && (
                 <article>
-                  <RenderRichText content={article.contentJson} />
+                  <RenderRichText content={article.contentJson} fallbackHtml={article.content} />
                 </article>
               )}
               <Divider />

--- a/src/server/services/__tests__/article-content-cleanup.service.test.ts
+++ b/src/server/services/__tests__/article-content-cleanup.service.test.ts
@@ -6,85 +6,69 @@ const UUID_1 = 'f1f87d35-81ca-4c55-a705-5d518f59d2ce';
 const UUID_2 = 'a2b3c4d5-6789-0abc-def1-234567890abc';
 const UUID_3 = 'c3d4e5f6-7890-1bcd-ef23-456789012345';
 
-// Helper to build tiptap JSON
-function tiptapDoc(...nodes: object[]) {
-  return JSON.stringify({ type: 'doc', content: nodes });
+// `Article.content` is sanitized HTML — both callers (`linkArticleContentImages` and the
+// migrate-article-images admin endpoint) pass the column straight through.
+function edgeMedia(url: string, type: 'image' | 'video' | 'audio' = 'image', filename?: string) {
+  const name = filename ? ` filename="${filename}"` : '';
+  return `<edge-media url="${url}" type="${type}"${name}></edge-media>`;
 }
 
-function mediaNode(url: string, type: 'image' | 'video' = 'image', filename?: string) {
-  return { type: 'media', attrs: { url, type, filename: filename ?? null } };
+function img(src: string, alt?: string) {
+  return `<img src="${src}"${alt ? ` alt="${alt}"` : ''} />`;
 }
 
-function imageNode(src: string, alt?: string) {
-  return { type: 'image', attrs: { src, alt: alt ?? null } };
-}
+const cloudflareUrl = (uuid: string) =>
+  `https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/${uuid}/original=true/img.jpeg`;
 
 describe('getContentMedia', () => {
   describe('media nodes (edge-media)', () => {
     it('extracts an image media node', () => {
-      const content = tiptapDoc(mediaNode(UUID_1, 'image', 'photo.jpg'));
-      expect(getContentMedia(content)).toEqual([
+      expect(getContentMedia(edgeMedia(UUID_1, 'image', 'photo.jpg'))).toEqual([
         { url: UUID_1, type: 'image', alt: 'photo.jpg' },
       ]);
     });
 
     it('extracts a video media node', () => {
-      const content = tiptapDoc(mediaNode(UUID_1, 'video', 'clip.mp4'));
-      expect(getContentMedia(content)).toEqual([
+      expect(getContentMedia(edgeMedia(UUID_1, 'video', 'clip.mp4'))).toEqual([
         { url: UUID_1, type: 'video', alt: 'clip.mp4' },
       ]);
     });
 
     it('defaults to image when type is not video', () => {
-      const doc = JSON.stringify({
-        type: 'doc',
-        content: [{ type: 'media', attrs: { url: UUID_1, type: 'audio', filename: null } }],
-      });
-      expect(getContentMedia(doc)).toEqual([
+      expect(getContentMedia(edgeMedia(UUID_1, 'audio'))).toEqual([
         { url: UUID_1, type: 'image', alt: undefined },
       ]);
     });
 
     it('skips media nodes with empty url', () => {
-      const doc = JSON.stringify({
-        type: 'doc',
-        content: [{ type: 'media', attrs: { url: '', type: 'image', filename: null } }],
-      });
-      expect(getContentMedia(doc)).toEqual([]);
+      expect(getContentMedia(edgeMedia('', 'image'))).toEqual([]);
     });
   });
 
   describe('image nodes (img tags)', () => {
     it('extracts UUID from a full Cloudflare image URL', () => {
-      const src = `https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/${UUID_2}/original=true/img.jpeg`;
-      const content = tiptapDoc(imageNode(src, 'A cool image'));
-      expect(getContentMedia(content)).toEqual([
+      expect(getContentMedia(img(cloudflareUrl(UUID_2), 'A cool image'))).toEqual([
         { url: UUID_2, type: 'image', alt: 'A cool image' },
       ]);
     });
 
     it('skips image nodes with non-Civitai URLs', () => {
-      const content = tiptapDoc(imageNode('https://external.com/photo.jpg'));
-      expect(getContentMedia(content)).toEqual([]);
+      expect(getContentMedia(img('https://external.com/photo.jpg'))).toEqual([]);
     });
 
     it('skips image nodes with empty src', () => {
-      const doc = JSON.stringify({
-        type: 'doc',
-        content: [{ type: 'image', attrs: { src: '', alt: null } }],
-      });
-      expect(getContentMedia(doc)).toEqual([]);
+      expect(getContentMedia(img(''))).toEqual([]);
     });
   });
 
   describe('mixed content', () => {
     it('extracts both media and image nodes', () => {
-      const src = `https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/${UUID_2}/original=true/img.jpeg`;
-      const content = tiptapDoc(
-        mediaNode(UUID_1, 'image', 'photo.jpg'),
-        imageNode(src, 'alt text'),
-        mediaNode(UUID_3, 'video')
-      );
+      const content = [
+        edgeMedia(UUID_1, 'image', 'photo.jpg'),
+        `<p>${img(cloudflareUrl(UUID_2), 'alt text')}</p>`,
+        edgeMedia(UUID_3, 'video'),
+      ].join('');
+
       expect(getContentMedia(content)).toEqual([
         { url: UUID_1, type: 'image', alt: 'photo.jpg' },
         { url: UUID_2, type: 'image', alt: 'alt text' },
@@ -93,48 +77,34 @@ describe('getContentMedia', () => {
     });
   });
 
-  describe('HTML input', () => {
-    it('extracts media from edge-media HTML tags', () => {
-      const html = `<edge-media url="${UUID_1}" type="image" filename="test.jpg"></edge-media>`;
-      const result = getContentMedia(html);
-      expect(result).toEqual([{ url: UUID_1, type: 'image', alt: 'test.jpg' }]);
-    });
-
-    it('extracts media from img HTML tags', () => {
-      const src = `https://image.civitai.com/xG1nkqKTMzGDvpLrqFT7WA/${UUID_1}/original=true/img.jpeg`;
-      const html = `<img src="${src}" alt="my image" />`;
-      const result = getContentMedia(html);
-      expect(result).toEqual([{ url: UUID_1, type: 'image', alt: 'my image' }]);
-    });
-  });
-
   describe('edge cases', () => {
     it('returns empty array for empty string', () => {
       expect(getContentMedia('')).toEqual([]);
     });
 
-    it('returns empty array for invalid JSON', () => {
-      expect(getContentMedia('{not valid json')).toEqual([]);
-    });
-
     it('returns empty array for content with no media', () => {
-      const content = tiptapDoc({ type: 'paragraph', content: [] });
-      expect(getContentMedia(content)).toEqual([]);
+      expect(getContentMedia('<p>just words</p>')).toEqual([]);
     });
 
     it('finds media in nested content', () => {
-      const content = JSON.stringify({
+      const content = `<blockquote><p>${edgeMedia(UUID_1, 'image', 'nested.jpg')}</p></blockquote>`;
+
+      expect(getContentMedia(content)).toEqual([{ url: UUID_1, type: 'image', alt: 'nested.jpg' }]);
+    });
+
+    // Content is never parsed as JSON — a crafted body would otherwise let an author link
+    // arbitrary CDN uuids to their own article through `linkArticleContentImages`.
+    it('ignores media declared in a JSON body', () => {
+      const doc = JSON.stringify({
         type: 'doc',
-        content: [
-          {
-            type: 'blockquote',
-            content: [mediaNode(UUID_1, 'image', 'nested.jpg')],
-          },
-        ],
+        content: [{ type: 'media', attrs: { url: UUID_1, type: 'image', filename: null } }],
       });
-      expect(getContentMedia(content)).toEqual([
-        { url: UUID_1, type: 'image', alt: 'nested.jpg' },
-      ]);
+
+      expect(getContentMedia(doc)).toEqual([]);
+    });
+
+    it('returns empty array for malformed JSON', () => {
+      expect(getContentMedia('{not valid json')).toEqual([]);
     });
   });
 });

--- a/src/server/services/__tests__/article-content-json.test.ts
+++ b/src/server/services/__tests__/article-content-json.test.ts
@@ -1,6 +1,5 @@
 import { generateJSON } from '@tiptap/html/server';
 import { describe, expect, it } from 'vitest';
-import { getContentMedia } from '~/server/services/article-content-cleanup.service';
 import { tiptapExtensions } from '~/shared/tiptap/extensions';
 
 // `upsertArticleInput.content` runs through sanitize-html, which only strips markup — a JSON
@@ -42,25 +41,5 @@ describe('article content is interpreted as HTML, never as JSON', () => {
     const doc = generateJSON('<p>hello <strong>world</strong></p>', tiptapExtensions);
 
     expect(nodeTypes(doc)).toContain('paragraph');
-  });
-});
-
-describe('getContentMedia', () => {
-  it('extracts media from HTML content', () => {
-    const media = getContentMedia(
-      '<edge-media url="7ac0a1b8-0000-4000-8000-000000000000" type="image"></edge-media>'
-    );
-
-    expect(media).toEqual([
-      { url: '7ac0a1b8-0000-4000-8000-000000000000', type: 'image', alt: undefined },
-    ]);
-  });
-
-  it('ignores media declared in a crafted JSON body', () => {
-    const media = getContentMedia(
-      '{"type":"doc","content":[{"type":"media","attrs":{"url":"7ac0a1b8-0000-4000-8000-000000000000","type":"image"}}]}'
-    );
-
-    expect(media).toEqual([]);
   });
 });

--- a/src/server/services/__tests__/article-content-json.test.ts
+++ b/src/server/services/__tests__/article-content-json.test.ts
@@ -1,0 +1,66 @@
+import { generateJSON } from '@tiptap/html/server';
+import { describe, expect, it } from 'vitest';
+import { getContentMedia } from '~/server/services/article-content-cleanup.service';
+import { tiptapExtensions } from '~/shared/tiptap/extensions';
+
+// `upsertArticleInput.content` runs through sanitize-html, which only strips markup — a JSON
+// body carries no tags and survives byte-identical. So anything here is storable in
+// `Article.content` by any author and reaches the read path verbatim.
+const CRAFTED = {
+  'a node type the renderer has no schema entry for':
+    '{"type":"doc","content":[{"type":"sticker","attrs":{"id":"1"}}]}',
+  'a mark type the renderer has no schema entry for':
+    '{"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"hi","marks":[{"type":"sparkle"}]}]}]}',
+  'a text node carrying no text':
+    '{"type":"doc","content":[{"type":"paragraph","content":[{"type":"text"}]}]}',
+  'malformed JSON': '{oops',
+};
+
+type Doc = { type?: string; text?: string; content?: Doc[] };
+
+function nodeTypes(node: Doc): string[] {
+  return [node.type, ...(node.content ?? []).flatMap(nodeTypes)].filter((t): t is string => !!t);
+}
+
+function textOf(node: Doc): string {
+  return (node.text ?? '') + (node.content ?? []).map(textOf).join('');
+}
+
+describe('article content is interpreted as HTML, never as JSON', () => {
+  for (const [description, content] of Object.entries(CRAFTED)) {
+    it(`treats ${description} as literal text`, () => {
+      const doc = generateJSON(content, tiptapExtensions) as Doc;
+
+      expect(doc.type).toBe('doc');
+      // The payload is shown, not executed — no node the renderer's schema lacks.
+      expect(nodeTypes(doc)).not.toContain('sticker');
+      expect(textOf(doc)).toContain(content.slice(0, 20));
+    });
+  }
+
+  it('keeps real HTML working', () => {
+    const doc = generateJSON('<p>hello <strong>world</strong></p>', tiptapExtensions);
+
+    expect(nodeTypes(doc)).toContain('paragraph');
+  });
+});
+
+describe('getContentMedia', () => {
+  it('extracts media from HTML content', () => {
+    const media = getContentMedia(
+      '<edge-media url="7ac0a1b8-0000-4000-8000-000000000000" type="image"></edge-media>'
+    );
+
+    expect(media).toEqual([
+      { url: '7ac0a1b8-0000-4000-8000-000000000000', type: 'image', alt: undefined },
+    ]);
+  });
+
+  it('ignores media declared in a crafted JSON body', () => {
+    const media = getContentMedia(
+      '{"type":"doc","content":[{"type":"media","attrs":{"url":"7ac0a1b8-0000-4000-8000-000000000000","type":"image"}}]}'
+    );
+
+    expect(media).toEqual([]);
+  });
+});

--- a/src/server/services/article-content-cleanup.service.ts
+++ b/src/server/services/article-content-cleanup.service.ts
@@ -8,16 +8,12 @@ type TiptapNode = {
   content?: TiptapNode[];
 };
 
-/** Extracts all media (images and videos) from article tiptap/HTML content.
+/** Extracts all media (images and videos) from article HTML content.
  *  Handles `media` nodes (edge-media), `image` nodes (img tags). */
 export function getContentMedia(content: string): ExtractedMedia[] {
   let doc: { content?: TiptapNode[] };
   try {
-    if (content.startsWith('{')) {
-      doc = JSON.parse(content);
-    } else {
-      doc = generateJSON(content, tiptapExtensions);
-    }
+    doc = generateJSON(content, tiptapExtensions);
   } catch {
     return [];
   }

--- a/src/server/services/article.service.ts
+++ b/src/server/services/article.service.ts
@@ -727,11 +727,14 @@ export const getArticleById = async ({
       userId === article.userId ||
       (coverImage?.ingestion === 'Scanned' && !coverImage?.needsReview);
 
+    // `content` is always sanitized HTML — the editor only ever emits `editor.getHTML()`.
+    // Never parse it as JSON: sanitize-html passes a JSON body through untouched, so that
+    // branch let any author store a doc with node types the renderer has no schema entry for
+    // (blank page for every reader) or malformed JSON (500 → NotFound for everyone, owner
+    // included). `generateJSON` is total over arbitrary text.
     let contentJson: MixedObject | undefined;
     if (article.content) {
-      contentJson = article.content.startsWith('{')
-        ? JSON.parse(article.content)
-        : generateJSON(article.content, tiptapExtensions);
+      contentJson = generateJSON(article.content, tiptapExtensions);
     }
 
     return {


### PR DESCRIPTION
[CU 868kk5ahg](https://app.clickup.com/t/868kk5ahg) — *Any user can break their own article page for all readers via crafted contentJson*

## The bug

`Article.content` is a free-text column, and `getArticleById` decided how to interpret it with a single check:

```ts
contentJson = article.content.startsWith('{')
  ? JSON.parse(article.content)
  : generateJSON(article.content, tiptapExtensions);
```

`upsertArticleInput.content` runs through `getSanitizedStringSchema()`, but sanitize-html only strips markup — a JSON body carries no tags and passes through **byte-identical** (verified). So any authenticated user could store arbitrary ProseMirror JSON in their own article.

**Two failure modes**, both reproduced against `@tiptap/static-renderer@3.16.0`:

**A. Client render throw.** `renderToReactElement` calls `Node.fromJSON(schema, content)` *before* it consults `nodeMapping`:

| crafted `contentJson` | throw |
|---|---|
| `{type:'doc',content:[{type:'sticker',…}]}` | `RangeError: Unknown node type: sticker` |
| text node with `marks:[{type:'sparkle'}]` | `RangeError: There is no mark type sparkle in this schema` |
| `{type:'text'}` with no `text` | `RangeError: Invalid text node in JSON` |
| `null` | `RangeError: Invalid input for Node.fromJSON` |

There is no `ErrorBoundary` anywhere in `src/`, so the throw unmounts the whole tree — blank page for every reader.

Worth flagging for anyone who read the ticket: **a fallback `nodeMapping` entry does not fix this.** Passing `{ nodeMapping: { sticker: () => null } }` still throws `Unknown node type: sticker`, because the throw originates upstream of the mapping.

**B. Server 500 → article bricked (not in the report, worse).** Content of `{oops` starts with `{` but is not valid JSON → `JSON.parse` throws in `getArticleById` → `throwDbError` → 500. The SSR prefetch swallows it (`.catch(() => null)`), the client query 500s, `article` is undefined, and the page renders **NotFound for readers, the owner and moderators alike**. The owner cannot open the editor to undo it; recovery needs a DB write.

## Why the JSON branch is deleted rather than guarded

- **Nothing stores JSON.** Prod `Article`, 25,912 rows: `content LIKE '{%'` → 0; `ltrim(content) LIKE '{%'` → 0; `content LIKE '%"type":%"doc"%'` → 0; `content LIKE '%"content":[%'` → 0. Exactly one row doesn't start with `<` (id 32507) and it's `\n<h1>…`.
- **Nothing can write JSON.** No `editor.getJSON()` in `src/`; `InputRTE name="content"` → `RichTextEditorComponent.tsx:269` `onUpdate: ({ editor }) => onChange(editor.getHTML())`. No raw SQL writes `"Article"`. The only path in is a hand-crafted tRPC payload — the attack.
- **It was speculative.** Added in `0f80bbd90b` ("check in", 2025-07-16), the Tiptap v3 / static-renderer migration that also introduced `RenderRichText.tsx` and `shared/tiptap/extensions.ts`. The write half was never built; one commit has touched it since (a type rename).
- **It's unreusable as written.** A real JSON-storage migration needs parse guarding and schema validation — the very things whose absence is this bug.

## Changes

1. **`article.service.ts`** — always `generateJSON(article.content, tiptapExtensions)`. Total over arbitrary text, so crafted JSON now renders as its own literal text. Kills both failure modes.
2. **`article-content-cleanup.service.ts`** — `getContentMedia` carried the same branch. It never crashed (already try/catch'd) but it did trust crafted JSON's `media` nodes, and leaving it invites the parse back onto the read path.
3. **`RenderRichText.tsx`** — `try`/`catch` around construction; on failure render the raw sanitized HTML via `RenderHtml` instead of blanking. The article page passes `fallbackHtml={article.content}`.

Change 3 stays necessary after change 1: `generateJSON` only emits types from `tiptapExtensions`, and those names match `RenderRichText`'s own list today — but that parity is an unenforced invariant maintained by hand across two files. Adding `StickerNode` to `tiptapExtensions` alone would bring the crash back, which is exactly the hazard `sticker.node.ts:22-25` documents.

The `{ ok }` sentinel in the `useMemo` is load-bearing: a legitimate doc can render to `null`, so the element alone can't distinguish "rendered empty" from "threw".

## Scope limit

The guard covers throws raised while the element tree is **constructed**, where every reproduced crafted-content failure lives. It does **not** cover a throw inside a custom node component (`EdgeMediaComponent`, `LocalTimestamp`, …) during React's render pass — that's a component defect, and catching it needs an `ErrorBoundary` the repo doesn't have. Worth its own ticket.

## Testing

- `src/server/services/__tests__/article-content-json.test.ts` — 7 passing.
- `src/components/RichTextEditor/__tests__/RenderRichText.browser.test.tsx` — 3 passing.
- Both verified to **fail** against pre-fix code: `getContentMedia ignores media declared in a crafted JSON body` returned the injected media, and the `RenderRichText` fallback tests threw.
- `pnpm run typecheck` — 0 errors.

Note that the four "treats X as literal text" cases document the post-fix behaviour rather than pin it — they exercise `generateJSON` directly, which the old code never reached for those inputs. The `getContentMedia` case and the browser tests are the ones that actually fail on `main`.

No migration, no backfill — 0 affected rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Verified in a browser against the dev DB

Created all three payloads through the real `article.upsert` tRPC endpoint as their author — **all returned 200**, confirming end-to-end that sanitize-html does not block a JSON body. Then loaded the same three articles on a pre-fix server and on this branch, as the logged-in owner:

| article content | pre-fix | this branch |
|---|---|---|
| `<p>ordinary article body</p>` | renders (474 chars) | renders |
| `{"type":"doc","content":[{"type":"sticker",…}]}` | **blank page** — 0 root children, 0 chars, no `<article>` element | renders the JSON as literal text |
| `{oops` | **"Page Not Found"** — as the article's own owner | renders as literal text |

Test articles deleted afterwards. Nothing written to prod (verified: 0 rows).

## Follow-up commit

The first push broke `article-content-cleanup.service.test.ts`: 9 of its 13 cases drove `getContentMedia` with tiptap JSON, so removing the branch failed them. Those cases encoded the same premise the branch did — both production callers (`linkArticleContentImages`, `migrate-article-images`) pass `Article.content`, which is sanitized HTML. Rewritten with HTML inputs, preserving every scenario, and the two JSON cases kept as negative assertions.

Full unit suite: **11,759 passing, 0 failing**. All 4 CI checks green.


## Correction: which database the counts came from

The row counts above were originally measured against the **dev clone**, not production — the postgres-query skill's `.env` pointed at `localhost:6546` (`pgbouncer-pooler-dev.cnpg-database-dev`) at the time. Re-measured against prod (`localhost:6543`, `server_addr 10.244.18.16`, `max(ModelVersion.id)` 3,198,813 — dev is `10.244.18.70` / 3,190,441):

| check | prod, 25,914 articles |
|---|---|
| `content LIKE '{%'` — the only rows that can reach the branch | **0** |
| `{` after leading whitespace | 0 |
| `"type":…"doc"` anywhere in content | 0 |
| content not starting with `<` | 0 |

Same conclusion, now verified on the right database. (The commit message says "0 of 25,912", which was the dev figure; prod is 0 of 25,914.)

## Why not "keep the branch and validate it"

Worth recording, since it was the live alternative. Validating the parsed doc against the ProseMirror schema would stop the crashes but not the injection, because `getSanitizedStringSchema()` sanitizes **HTML** and never sees inside a stored JSON body:

```
<a href="javascript:alert(1)">click</a>   ->  <a>click</a>            (sanitized)
{"type":"doc",…"href":"javascript:alert(1)"…}  ->  byte-identical      (untouched)
```

The same gap covers `image` `src`, `edge-media` `url`, and the iframe hostname allowlist (`www.youtube.com`, `www.instagram.com`, `www.strawpoll.com`) that sanitize-html enforces. A validated branch would be crash-safe, injection-unsafe, and look finished.

Storing JSON is still a reasonable future direction — `generateJSON` already handles HTML→JSON, so what it buys is skipping that conversion per read plus round-trip fidelity. Building it means designing JSON-level attribute sanitization first; re-adding a guarded parse is the small part of that job.
