### PR TITLE
docs(app-blocks): buzzBudgetPerGen is a SAFETY CEILING, not a cost estimate

### DIFF
--- a/public/schemas/app-block/v1.json
+++ b/public/schemas/app-block/v1.json
@@ -197,7 +197,7 @@
         },
         "buzzBudgetPerGen": {
           "type": "integer",
-          "description": "Optional per-generation Buzz budget for ai:write:budgeted tokens. Positive integer; server-clamped to the per-gen cap.",
+          "description": "Optional per-generation Buzz SAFETY CEILING for `ai:write:budgeted` tokens — the most a SINGLE generation this app requests is allowed to cost. It is a ceiling against a malicious or compromised app draining the viewer's Buzz, NOT a cost forecast: size it WELL ABOVE your worst-case generation (a good rule of thumb is several times your expected cost — e.g. 1000 when a run costs ~100), never at your estimate. Setting it to an estimate is the common mistake. The server re-prices every submit and compares that real price against this budget BEFORE anything runs, so a generation that comes in over budget is REJECTED outright with `insufficient buzz budget` — no workflow is created and no Buzz is spent, but the user gets nothing, and it stays broken for EVERY user until you ship a new manifest version and it is re-approved. So any upward drift in real cost (more steps, a bigger resolution, a pricier model or recipe, a colder cache) turns a budget sized to today's estimate into a hard outage. Positive integer. Omit it and the token is minted with a 10 Buzz default, which is below almost any real generation. Server-clamped to the platform per-gen cap (1000 today), so a generous value is safe. This bounds ONE generation only — cumulative spend is separately capped per viewer per day and per app, so a high per-gen ceiling does not widen total exposure.",
           "exclusiveMinimum": 0
         }
       }


### PR DESCRIPTION
## The defect

An app author used a coding agent to build an App Block. The agent read our docs,
estimated one generation at ~50 Buzz, and set the manifest budget to **50**.

That is backwards. The per-generation budget is a **safety ceiling** — the bound on
what a *single* generation an app requests may cost, so a buggy or compromised app
cannot drain the viewer's Buzz. It is not a cost forecast. An audit of all four
App Blocks repos found safety-ceiling framing appears **nowhere in a budget
context**, and one surface (the CLI's `page-money` scaffold README) actively
invited *lowering* the value.

## The real consequence (read out of the enforcement code, not assumed)

`page.buzzBudgetPerGen` is mapped onto the block token's `buzzBudget` claim at
mint time, clamped to `BUZZ_BUDGET_CAP = 1000` (`src/pages/api/v1/block-tokens/index.ts`).
Both submit paths in `src/server/routers/blocks.router.ts` compare the **real**
price against that claim **before anything runs**:

- **`textToImage`** — runs a real `whatif` submit, then `if (cost > claims.buzzBudget)`
  returns a `status: 'failed'` snapshot.
- **`customComfy`** — static `if (ceiling > claims.buzzBudget)` against the recipe's
  `budgetFor(params).maxBuzz`.

Both reject **before** the gen-idempotency claim, before `reserveBlockBuzzSpendForClaims`,
and before the orchestrator submit. So an over-budget generation is **refused
outright**: no workflow is created, nothing is reserved, **no Buzz is spent**.

The damage is therefore not a partial charge — it is that **the app is simply
broken**. The user clicks Generate and gets `insufficient buzz budget`, and it
stays broken for **every** user until the author ships a new manifest version and
it is re-approved. Any upward drift in real cost — more steps, a bigger
resolution, a pricier model, a costlier recipe, a colder cache — flips a budget
sized to today's estimate into a hard outage.

Meanwhile a *generous* ceiling costs nobody anything: the server re-prices every
submit and charges the real price, the budget is clamped at 1000 regardless, and
cumulative spend is separately bounded by the per-viewer daily cap
(`BLOCK_BUZZ_CAP_PER_DAY`) and the per-app aggregate cap. A high per-gen ceiling
does **not** widen total exposure. Hence the rule of thumb we now document:
**several times your worst-case run.**

### Correction to the original report

The complaint assumed an over-budget workflow is *killed part-way, consuming the
Buzz and delivering nothing*. It is not — it is rejected at a pre-submit gate and
nothing is charged. Mid-run billing does exist (a `customComfy` job is physically
bounded by the recipe's own step `timeout`, and a mid-run cancel bills the accrued
orchestrator cost, which `settleCustomComfySpend` settles ceiling→actual), but
that timeout comes from the server-side recipe registry, **not** from the
manifest budget. The guidance in this PR is written to the behaviour the code
actually has.

## What this PR changes

**`public/schemas/app-block/v1.json`** — the `page.buzzBudgetPerGen` description.

This is the **canonical single source**: it is served verbatim at
`https://civitai.com/schemas/app-block/v1.json`, byte-mirrored by the Go CLI and
`@civitai/app-sdk`, and it is what the generated manifest-reference table on
developer.civitai.com renders. Fixing it here is what propagates the framing
everywhere else.

Old:

> Optional per-generation Buzz budget for ai:write:budgeted tokens. Positive integer; server-clamped to the per-gen cap.

New: states the *purpose* (a ceiling against a malicious/compromised app, not a
forecast), gives the rule of thumb (several times your worst case), names the
failure mode (hard `insufficient buzz budget` reject — nothing charged, nothing
delivered, broken until re-approval), and records the 10-Buzz omit-default, the
1000 clamp, and the fact that per-gen headroom does not widen total exposure.

## Deliberately not done

- **The two byte-mirrors are not touched here** (`civitai/cli`
  `schema/app-block.manifest.schema.json`, `civitai-app-starters`
  `packages/civitai-app-sdk/schemas/app-block/v1.json`). Their drift-guards
  (`scripts/check-canonical-schema.sh`, run on `pull_request` in both repos)
  diff against the **live published URL**, not against this repo — so editing a
  mirror ahead of this PR deploying would turn those repos' CI red immediately.
  Both repos have a `revendor-canonical-schema` workflow that re-vendors from the
  live canonical and opens a PR; **after this merges and deploys, dispatch it in
  both repos** (`gh workflow run revendor-canonical-schema.yml`) rather than
  hand-editing.
- No change to enforcement, clamps, defaults, or any code path. Description text
  only.

## Verification

- `public/schemas/app-block/v1.json` still parses; `manifest-schema-endpoint.test.ts`
  ("serves the canonical `public/schemas/app-block/v1.json` verbatim") passes.
- `pnpm typecheck`: **151 errors at `origin/main` and 151 at HEAD, byte-identical
  error sets** (`diff` clean). All pre-existing.
- Targeted suites: 171 tests passed / 0 failed
  (`block-manifest-validator.service.test.ts` 169, `manifest-schema-endpoint.test.ts` 2).

## Related

- `civitai/cli` — CLI validator warning + `page-money` scaffold README: https://github.com/civitai/cli/pull/199
- `civitai/civitai-developer-docs` — manifest reference + both guides: https://github.com/civitai/civitai-developer-docs/pull/30
- `civitai/civitai-app-starters` — starter `AGENTS.md` (read by coding agents): https://github.com/civitai/civitai-app-starters/pull/210

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R7ZCxbgcsv3WfsSJrYdSCi
