### PR TITLE
feat(blocks): opt-in long poll on blocks.pollWorkflow

### DIFF
--- a/src/server/routers/__tests__/blocks.router.pollWorkflowLongPoll.test.ts
+++ b/src/server/routers/__tests__/blocks.router.pollWorkflowLongPoll.test.ts
@@ -1,0 +1,417 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * ROUTER-LEVEL proof that `blocks.pollWorkflow`'s long poll is WIRED, not merely
+ * implemented.
+ *
+ * `workflow.service.test.ts` proves `resolveBlockPollWaitSeconds` clamps
+ * correctly — that is a statement about a function. It says nothing about
+ * whether the procedure a block calls actually hands the resolved value to the
+ * orchestrator, and "the clamp is correct but nothing calls it" is the exact
+ * shape of an inert feature. So these drive the real tRPC procedure and assert
+ * on the ARGUMENT `getWorkflow` received.
+ *
+ * The four cases the design review named are covered here end-to-end: a
+ * workflow that completes inside the hold, one that does NOT (the orchestrator's
+ * 202 → a non-terminal snapshot the caller re-arms on), a terminal failure, and
+ * a cancellation.
+ *
+ * Mock strategy mirrors `blocks.router.textOutputModeration.test.ts`: every
+ * dependency at the module boundary, so the router runs in-process.
+ */
+
+const {
+  mockVerifyBlockToken,
+  mockParseSubjectUserId,
+  mockGetOrchestratorToken,
+  mockQueryWorkflows,
+  mockGetWorkflow,
+  mockCancelWorkflow,
+  mockSubmitWorkflow,
+  mockGetUserById,
+  mockGetSessionUser,
+  mockCheckBlockCatalogRateLimit,
+  mockDbRead,
+  mockRedis,
+  mockSysRedis,
+  mockIsAppBlocksEnabled,
+  mockIsAppBlocksAuthorEnabled,
+  mockUpdateBlockWorkflowStatus,
+  mockSettleCustomComfySpend,
+} = vi.hoisted(() => ({
+  mockVerifyBlockToken: vi.fn(),
+  mockParseSubjectUserId: vi.fn(),
+  mockGetOrchestratorToken: vi.fn(),
+  mockQueryWorkflows: vi.fn(),
+  mockGetWorkflow: vi.fn(),
+  mockCancelWorkflow: vi.fn(),
+  mockSubmitWorkflow: vi.fn(),
+  mockGetUserById: vi.fn(),
+  mockGetSessionUser: vi.fn(),
+  mockCheckBlockCatalogRateLimit: vi.fn(async () => ({ allowed: true })),
+  mockDbRead: {
+    modelVersion: { findUnique: vi.fn(), findFirst: vi.fn(), findMany: vi.fn() },
+    modelBlockInstall: { findUnique: vi.fn() },
+    blockUserSettings: { findUnique: vi.fn() },
+    modelMetric: { findFirst: vi.fn() },
+  },
+  mockRedis: {
+    get: vi.fn(async () => null),
+    set: vi.fn(async () => undefined),
+    del: vi.fn(async () => 0),
+    incr: vi.fn(async () => 1),
+    incrBy: vi.fn(async () => 1),
+    decrBy: vi.fn(async () => 0),
+    expire: vi.fn(async () => true),
+    ttl: vi.fn(async () => -1),
+    exists: vi.fn(async () => 0),
+  },
+  mockSysRedis: {
+    get: vi.fn(async () => null),
+    incrBy: vi.fn(async () => 0),
+    decrBy: vi.fn(async () => 0),
+    expire: vi.fn(async () => true),
+    ttl: vi.fn(async () => -1),
+  },
+  mockIsAppBlocksEnabled: vi.fn(async () => true),
+  mockIsAppBlocksAuthorEnabled: vi.fn(async () => true),
+  mockUpdateBlockWorkflowStatus: vi.fn(async () => undefined),
+  mockSettleCustomComfySpend: vi.fn(async () => undefined),
+}));
+
+vi.mock('~/server/middleware/block-scope.middleware', () => ({
+  verifyBlockToken: mockVerifyBlockToken,
+  parseSubjectUserId: (...args: unknown[]) => mockParseSubjectUserId(...args),
+}));
+vi.mock('~/server/orchestrator/get-orchestrator-token', () => ({
+  getOrchestratorToken: mockGetOrchestratorToken,
+}));
+vi.mock('~/server/services/orchestrator/workflows', () => ({
+  queryWorkflows: mockQueryWorkflows,
+  getWorkflow: mockGetWorkflow,
+  cancelWorkflow: mockCancelWorkflow,
+  submitWorkflow: mockSubmitWorkflow,
+}));
+vi.mock('~/server/services/blocks/block-workflows.service', () => ({
+  blockWorkflowOwnedByAppUser: vi.fn(async () => true),
+  upsertBlockWorkflowOnSubmit: vi.fn(async () => undefined),
+  updateBlockWorkflowStatus: mockUpdateBlockWorkflowStatus,
+  listMyBlockWorkflows: vi.fn(async () => ({ items: [], nextCursor: null })),
+}));
+vi.mock('~/server/services/blocks/custom-comfy-settle.service', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return { ...actual, settleCustomComfySpend: mockSettleCustomComfySpend };
+});
+vi.mock('~/server/services/blocks/user-app-surface.service', () => ({
+  recordScopeInvocation: vi.fn(async () => undefined),
+}));
+vi.mock('~/server/services/user.service', () => ({ getUserById: mockGetUserById }));
+vi.mock('~/server/auth/session-client', () => ({
+  sessionClient: { getSessionUserById: (...args: unknown[]) => mockGetSessionUser(...args) },
+}));
+vi.mock('~/server/db/client', () => ({
+  dbRead: mockDbRead,
+  dbWrite: {
+    modelBlockInstall: { findUnique: vi.fn() },
+    model: { findUnique: vi.fn() },
+    user: { findUnique: vi.fn() },
+  },
+}));
+
+const { completeKeys } = vi.hoisted(() => {
+  const group = (explicit: Record<string, string>, name: string): Record<string, string> =>
+    new Proxy(explicit, {
+      get: (t, k) =>
+        k in t
+          ? (t as Record<string, string>)[k as string]
+          : typeof k === 'string'
+          ? `mock:${name}:${k}`
+          : (t as Record<string, string>)[k as string],
+    });
+  const completeKeys = (explicit: Record<string, Record<string, string>>) =>
+    new Proxy(explicit, {
+      get: (t, g) =>
+        g in t
+          ? group((t as Record<string, Record<string, string>>)[g as string], g as string)
+          : typeof g === 'string'
+          ? group({}, g)
+          : (t as Record<string, Record<string, string>>)[g as string],
+    });
+  return { completeKeys };
+});
+vi.mock('~/server/redis/client', () => ({
+  redis: mockRedis,
+  sysRedis: mockSysRedis,
+  REDIS_KEYS: completeKeys({ BLOCKS: { POPULAR_CHECKPOINT: 'blocks:popular-checkpoint' } }),
+  REDIS_SYS_KEYS: completeKeys({ BLOCKS: { BUZZ_CAP: 'system:blocks:buzz-cap' } }),
+}));
+vi.mock('~/server/services/app-blocks-flag', () => ({
+  isAppBlocksEnabled: mockIsAppBlocksEnabled,
+  isAppBlocksAuthorEnabled: mockIsAppBlocksAuthorEnabled,
+}));
+vi.mock('~/server/utils/block-catalog-rate-limit', () => ({
+  checkBlockCatalogRateLimit: (...args: unknown[]) => mockCheckBlockCatalogRateLimit(...args),
+}));
+vi.mock('~/server/middleware.trpc', async () => {
+  const { middleware } = await import('~/server/trpc');
+  return { rateLimit: () => middleware(({ next }) => next()) };
+});
+
+import { blocksRouter } from '../blocks.router';
+import { TokenScope } from '~/shared/constants/token-scope.constants';
+import { sfwBrowsingLevelsFlag } from '~/shared/constants/browsingLevel.constants';
+import { MAX_BLOCK_POLL_WAIT_SECONDS } from '~/server/services/blocks/workflow.service';
+
+// 🔴 PAIRWISE-DISTINCT FIXTURE FIELDS. Every workflow below differs in id,
+// status AND cost, so a wiring bug that returns the wrong workflow — or a stub
+// that returns a constant — cannot pass by coincidence.
+const RUNNING = { id: 'wf_running', status: 'processing', cost: { total: 11 }, steps: [] };
+const SUCCEEDED = { id: 'wf_succeeded', status: 'succeeded', cost: { total: 22 }, steps: [] };
+const FAILED = { id: 'wf_failed', status: 'failed', cost: { total: 33 }, steps: [] };
+const CANCELED = { id: 'wf_canceled', status: 'canceled', cost: { total: 44 }, steps: [] };
+
+/** The `query` argument of the Nth `getWorkflow` call (undefined if none). */
+function queryArg(n = 0): { wait?: number } | undefined {
+  return (mockGetWorkflow.mock.calls[n]?.[0] as { query?: { wait?: number } } | undefined)?.query;
+}
+
+function validClaims() {
+  return {
+    iss: 'civitai',
+    aud: 'civitai-app-block',
+    sub: 'user:42',
+    iat: 0,
+    exp: 0,
+    jti: 'jti_test',
+    blockId: 'pixel-poet',
+    appId: 'oac_01JQ8XG7YV2K4M6P8R0T2W4Y6B',
+    appBlockId: 'apb_01JQ8XG7YV2K4M6P8R0T2W4Y6A',
+    blockInstanceId: 'bki_01JQ8XG7YV2K4M6P8R0T2W4Y6C',
+    ctx: { slotId: 'none', entityType: 'none' },
+    scopes: ['ai:write:budgeted'],
+    buzzBudget: 50,
+    maxBrowsingLevel: sfwBrowsingLevelsFlag,
+  };
+}
+
+function fakeCtx() {
+  return {
+    acceptableOrigin: true,
+    user: undefined,
+    apiKeyId: null,
+    tokenScope: TokenScope.Full,
+    req: { headers: {} } as never,
+    res: { setHeader: () => undefined } as never,
+    cache: { edgeTTL: 0 },
+    features: { canViewNsfw: false, isBlue: false, isGreen: false, isGreenSession: false } as never,
+    track: undefined,
+  };
+}
+
+const caller = () => blocksRouter.createCaller(fakeCtx() as never);
+
+beforeEach(() => {
+  for (const fn of [
+    mockVerifyBlockToken,
+    mockParseSubjectUserId,
+    mockGetOrchestratorToken,
+    mockGetWorkflow,
+    mockCancelWorkflow,
+    mockGetUserById,
+    mockGetSessionUser,
+    mockCheckBlockCatalogRateLimit,
+    mockIsAppBlocksEnabled,
+    mockIsAppBlocksAuthorEnabled,
+    mockUpdateBlockWorkflowStatus,
+    mockSettleCustomComfySpend,
+  ]) {
+    fn.mockReset();
+  }
+  mockIsAppBlocksEnabled.mockImplementation(async () => true);
+  mockIsAppBlocksAuthorEnabled.mockImplementation(async () => true);
+  mockGetUserById.mockResolvedValue({ id: 42, isModerator: true, tier: 'free' });
+  mockGetSessionUser.mockResolvedValue({ id: 42, isModerator: true, tier: 'free' });
+  mockParseSubjectUserId.mockImplementation((sub: string) => (sub === 'anon' ? null : 42));
+  mockGetOrchestratorToken.mockResolvedValue('orch_token');
+  mockCheckBlockCatalogRateLimit.mockResolvedValue({ allowed: true });
+  mockVerifyBlockToken.mockResolvedValue(validClaims());
+  mockUpdateBlockWorkflowStatus.mockResolvedValue(undefined);
+  mockSettleCustomComfySpend.mockResolvedValue(undefined);
+  mockCancelWorkflow.mockResolvedValue(undefined);
+});
+
+describe('blocks.pollWorkflow — long poll wiring', () => {
+  it('BACK-COMPAT: without waitSeconds the orchestrator read carries NO query at all', async () => {
+    mockGetWorkflow.mockResolvedValue(RUNNING);
+
+    const result = await caller().pollWorkflow({ blockToken: 'tok', workflowId: 'wf_running' });
+
+    // Not `{ wait: 0 }` — absent. Every already-deployed block sends exactly
+    // this input, and its request must remain byte-identical.
+    expect(queryArg()).toBeUndefined();
+    expect(result.snapshot.status).toBe('processing');
+  });
+
+  it('forwards waitSeconds to the orchestrator as ?wait=<seconds>', async () => {
+    mockGetWorkflow.mockResolvedValue(SUCCEEDED);
+
+    const result = await caller().pollWorkflow({
+      blockToken: 'tok',
+      workflowId: 'wf_succeeded',
+      waitSeconds: 9,
+    });
+
+    expect(queryArg()).toEqual({ wait: 9 });
+    expect(result.snapshot.status).toBe('succeeded');
+  });
+
+  it('CLAMPS an over-large waitSeconds rather than failing the poll', async () => {
+    mockGetWorkflow.mockResolvedValue(SUCCEEDED);
+
+    await caller().pollWorkflow({
+      blockToken: 'tok',
+      workflowId: 'wf_succeeded',
+      waitSeconds: 60,
+    });
+
+    expect(queryArg()).toEqual({ wait: MAX_BLOCK_POLL_WAIT_SECONDS });
+  });
+
+  it('drops waitSeconds: 0 back to a plain read', async () => {
+    mockGetWorkflow.mockResolvedValue(RUNNING);
+
+    await caller().pollWorkflow({
+      blockToken: 'tok',
+      workflowId: 'wf_running',
+      waitSeconds: 0,
+    });
+
+    expect(queryArg()).toBeUndefined();
+  });
+
+  it('rejects a nonsensical waitSeconds at the wire schema without calling the orchestrator', async () => {
+    mockGetWorkflow.mockResolvedValue(RUNNING);
+
+    await expect(
+      caller().pollWorkflow({ blockToken: 'tok', workflowId: 'wf_running', waitSeconds: 99_999 })
+    ).rejects.toThrow();
+    await expect(
+      caller().pollWorkflow({ blockToken: 'tok', workflowId: 'wf_running', waitSeconds: -3 })
+    ).rejects.toThrow();
+
+    expect(mockGetWorkflow).not.toHaveBeenCalled();
+  });
+
+  it('COMPLETES INSIDE THE HOLD: terminal snapshot + terminal side effects fire', async () => {
+    mockGetWorkflow.mockResolvedValue(SUCCEEDED);
+
+    const result = await caller().pollWorkflow({
+      blockToken: 'tok',
+      workflowId: 'wf_succeeded',
+      waitSeconds: 12,
+    });
+
+    expect(result.snapshot.status).toBe('succeeded');
+    expect(result.snapshot.cost).toEqual({ total: 22 });
+    expect(mockUpdateBlockWorkflowStatus).toHaveBeenCalledWith({
+      workflowId: 'wf_succeeded',
+      status: 'succeeded',
+    });
+    expect(mockSettleCustomComfySpend).toHaveBeenCalledWith({
+      workflowId: 'wf_succeeded',
+      actualCost: 22,
+    });
+  });
+
+  it('🔴 HOLD ELAPSED (202): a still-running workflow is a NORMAL non-terminal reply', async () => {
+    // The generated client surfaces a 202 as an ordinary `data` result carrying
+    // the still-running workflow, so it reaches the block as a non-terminal
+    // snapshot to re-arm on — NOT as an error, and NOT as a terminal status.
+    mockGetWorkflow.mockResolvedValue(RUNNING);
+
+    const result = await caller().pollWorkflow({
+      blockToken: 'tok',
+      workflowId: 'wf_running',
+      waitSeconds: MAX_BLOCK_POLL_WAIT_SECONDS,
+    });
+
+    expect(result.snapshot.status).toBe('processing');
+    expect(result.snapshot.cost).toEqual({ total: 11 });
+    // 🔴 The terminal side effects must NOT fire on a 202. Mirroring a
+    // still-running workflow into the durable read-model as finished, or
+    // settling its post-paid spend, would be a real defect — and the hold
+    // makes this branch far more frequently reached than a 2s timer poll did.
+    expect(mockUpdateBlockWorkflowStatus).not.toHaveBeenCalled();
+    expect(mockSettleCustomComfySpend).not.toHaveBeenCalled();
+  });
+
+  it('RE-ARM: a second poll after a 202 returns the later, terminal snapshot', async () => {
+    mockGetWorkflow.mockResolvedValueOnce(RUNNING).mockResolvedValueOnce(SUCCEEDED);
+
+    const first = await caller().pollWorkflow({
+      blockToken: 'tok',
+      workflowId: 'wf_x',
+      waitSeconds: 5,
+    });
+    const second = await caller().pollWorkflow({
+      blockToken: 'tok',
+      workflowId: 'wf_x',
+      waitSeconds: 5,
+    });
+
+    // Distinct costs: a poll that replayed the first read would report 11 twice.
+    expect(first.snapshot.cost).toEqual({ total: 11 });
+    expect(second.snapshot.cost).toEqual({ total: 22 });
+    expect(second.snapshot.status).toBe('succeeded');
+    expect(queryArg(0)).toEqual({ wait: 5 });
+    expect(queryArg(1)).toEqual({ wait: 5 });
+  });
+
+  it('TERMINAL FAILURE under a hold is returned as a snapshot, not thrown', async () => {
+    mockGetWorkflow.mockResolvedValue(FAILED);
+
+    const result = await caller().pollWorkflow({
+      blockToken: 'tok',
+      workflowId: 'wf_failed',
+      waitSeconds: 8,
+    });
+
+    expect(result.snapshot.status).toBe('failed');
+    expect(result.snapshot.cost).toEqual({ total: 33 });
+    expect(mockUpdateBlockWorkflowStatus).toHaveBeenCalledWith({
+      workflowId: 'wf_failed',
+      status: 'failed',
+    });
+  });
+
+  it('CANCELLATION: a canceled workflow polled under a hold returns terminal at once', async () => {
+    mockGetWorkflow.mockResolvedValue(CANCELED);
+
+    const result = await caller().pollWorkflow({
+      blockToken: 'tok',
+      workflowId: 'wf_canceled',
+      waitSeconds: MAX_BLOCK_POLL_WAIT_SECONDS,
+    });
+
+    expect(result.snapshot.status).toBe('canceled');
+    expect(mockUpdateBlockWorkflowStatus).toHaveBeenCalledWith({
+      workflowId: 'wf_canceled',
+      status: 'canceled',
+    });
+  });
+
+  it('blocks.cancelWorkflow is UNCHANGED — it never asks for a hold', async () => {
+    // A cancel has nothing to wait for: the read after it is a confirmation,
+    // and holding it open would just delay the reply by up to 15s.
+    mockGetWorkflow.mockResolvedValue(CANCELED);
+
+    const result = await caller().cancelWorkflow({
+      blockToken: 'tok',
+      workflowId: 'wf_canceled',
+    });
+
+    expect(mockCancelWorkflow).toHaveBeenCalled();
+    expect(queryArg()).toBeUndefined();
+    expect(result.snapshot.status).toBe('canceled');
+  });
+});

--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -130,6 +130,7 @@ import {
   formatStepTimeout,
   isPageLoraResource,
   projectAppWorkflow,
+  resolveBlockPollWaitSeconds,
   resolveBlockVersionContext,
   resolvePageResourceContext,
   snapshotFromWorkflow,
@@ -3046,6 +3047,33 @@ export const blocksRouter = router({
    * Ownership: we fetch with the user's orchestrator token (`getOrchestratorToken`),
    * so the orchestrator returns 404/403 for workflows the user doesn't own.
    * That's the gate — we don't need a second client-side ownership check.
+   *
+   * OPTIONALLY A LONG POLL. With `waitSeconds`, the orchestrator holds the read
+   * open until the workflow reaches a terminal status instead of answering with
+   * whatever it is right now (its `?wait=` parameter; see
+   * `resolveBlockPollWaitSeconds` for the bound and why the DEFAULT is no hold).
+   * Omitted → byte-identical to the pre-existing request.
+   *
+   * 🔴 A 202 IS A NORMAL OUTCOME, NOT AN ERROR. When the hold elapses first the
+   * orchestrator answers 202 with the current, still-running workflow — which
+   * the generated client surfaces as an ordinary `data` result, so it flows
+   * through the exact same mapping below and reaches the block as a
+   * non-terminal snapshot. The caller re-arms. Nothing here needs to branch on
+   * the status code, and adding a branch that treated 202 as a failure would
+   * turn the normal timeout into a broken generation.
+   *
+   * 🔴 WHAT THIS DOES TO SCAN COST — the direction is FAVOURABLE, and it is
+   * worth stating because the moderation wrapper below runs on EVERY poll.
+   * `screenGeneratedText` memoizes a decided CONTENT verdict for 5 minutes but
+   * deliberately does NOT memoize an operational fault (scanner error, timeout,
+   * label drift, per-label error), so during such a fault the same text is
+   * re-scanned once per poll. A long poll REDUCES the poll rate — ~1 per 15s
+   * instead of ~1 per 2s — so it shrinks that blast radius by the same factor
+   * rather than enlarging it. The trade it makes is the other way round: a held
+   * request occupies an in-flight request slot for its whole duration, so
+   * concurrent in-flight polls rise even as total polls fall. That is why the
+   * hold is opt-in and capped, and why the SDK only requests it from a
+   * sequential, non-overlapping loop.
    */
   pollWorkflow: publicProcedure
     // No `enforceAppBlocksFlag` middleware here: block-token procs are
@@ -3055,6 +3083,14 @@ export const blocksRouter = router({
       z.object({
         blockToken: z.string().min(1),
         workflowId: z.string().min(1).max(64),
+        /**
+         * Orchestrator-side hold, in SECONDS. Untrusted (it comes from a block
+         * via the host) — bounded here by the wire schema AND clamped again by
+         * `resolveBlockPollWaitSeconds`, which owns the real ceiling. The zod
+         * `.max()` is deliberately the LOOSER of the two: it rejects nonsense,
+         * the resolver decides policy, and the policy lives in one place.
+         */
+        waitSeconds: z.number().int().min(0).max(60).optional(),
       })
     )
     .mutation(async ({ ctx, input }) => {
@@ -3074,7 +3110,14 @@ export const blocksRouter = router({
       await assertAppBlocksEnabledForTokenUser(userId);
       await assertViewerIsAppDeveloper(userId);
       const token = await getOrchestratorToken(userId, ctx);
-      const workflow = await getWorkflow({ token, path: { workflowId: input.workflowId } });
+      const waitSeconds = resolveBlockPollWaitSeconds(input.waitSeconds);
+      const workflow = await getWorkflow({
+        token,
+        path: { workflowId: input.workflowId },
+        // `undefined` when there is no hold, so the request is byte-identical
+        // to the pre-long-poll one rather than carrying a `?wait=0`.
+        ...(waitSeconds !== undefined ? { query: { wait: waitSeconds } } : {}),
+      });
       // 🔴 THE OUTPUT-MODERATION BOUNDARY. `snapshotFromWorkflow` cannot emit
       // generated text: it publishes `imageUrls` off `extractOutput`, which a
       // text-posture entry may not declare (`TextOutputSurface.extractOutput?:

--- a/src/server/services/blocks/__tests__/workflow.service.test.ts
+++ b/src/server/services/blocks/__tests__/workflow.service.test.ts
@@ -19,6 +19,8 @@ vi.mock('~/server/db/client', () => ({ dbRead: mockDbRead }));
 import {
   appBlockTag,
   assertCheckpointVersionSupportsWorkflow,
+  MAX_BLOCK_POLL_WAIT_SECONDS,
+  resolveBlockPollWaitSeconds,
   buildCustomComfyWorkflowInput,
   buildImageWorkflowInput,
   buildTextToImageInput,
@@ -2589,5 +2591,53 @@ describe('sourceImages[] — normalization + per-ecosystem cap', () => {
     // Guard the guard: if the enumeration ever silently matches nothing, an
     // empty `missing` would look like a pass.
     expect(checked).toBeGreaterThan(15);
+  });
+});
+
+describe('resolveBlockPollWaitSeconds', () => {
+  /**
+   * The clamp that decides how long `blocks.pollWorkflow` asks the orchestrator
+   * to hold a read open. Pure, so it is tested directly rather than through the
+   * router — the router test proves it is WIRED, this one proves it is RIGHT.
+   */
+  it('returns undefined (no hold) for an absent / zero / negative / non-finite value', () => {
+    // `undefined` and not `0`, so the caller omits the query entirely and the
+    // request stays byte-identical to the pre-long-poll one.
+    for (const input of [undefined, 0, -1, -0.5, Number.NaN, Number.POSITIVE_INFINITY]) {
+      expect(resolveBlockPollWaitSeconds(input), `input=${String(input)}`).toBeUndefined();
+    }
+  });
+
+  it('passes a value inside the bound through unchanged', () => {
+    expect(resolveBlockPollWaitSeconds(1)).toBe(1);
+    expect(resolveBlockPollWaitSeconds(7)).toBe(7);
+    expect(resolveBlockPollWaitSeconds(MAX_BLOCK_POLL_WAIT_SECONDS)).toBe(
+      MAX_BLOCK_POLL_WAIT_SECONDS
+    );
+  });
+
+  it('CLAMPS anything above the bound instead of rejecting it', () => {
+    // A block asking for more than we allow is not an error — failing the poll
+    // would break a generation over a tuning value.
+    expect(resolveBlockPollWaitSeconds(MAX_BLOCK_POLL_WAIT_SECONDS + 1)).toBe(
+      MAX_BLOCK_POLL_WAIT_SECONDS
+    );
+    expect(resolveBlockPollWaitSeconds(3600)).toBe(MAX_BLOCK_POLL_WAIT_SECONDS);
+  });
+
+  it('FLOORS a fractional value, so 0.9 reads as no hold rather than a hold', () => {
+    expect(resolveBlockPollWaitSeconds(0.9)).toBeUndefined();
+    expect(resolveBlockPollWaitSeconds(2.9)).toBe(2);
+  });
+
+  it('🔴 stays strictly BELOW the shared getWorkflow abort backstop (20s)', () => {
+    // ORCHESTRATOR_GET_TIMEOUT_MS in ~/server/services/orchestrator/workflows is
+    // applied unconditionally to every single-workflow read. A bound at or above
+    // it makes every long poll die as a TimeoutError → 503, i.e. the feature
+    // would look like an orchestrator outage. Deliberately hard-coded here
+    // rather than imported: this test's job is to fail if EITHER number moves.
+    expect(MAX_BLOCK_POLL_WAIT_SECONDS).toBeLessThan(20);
+    // …and to leave real slack for connect + response, not just one second.
+    expect(20 - MAX_BLOCK_POLL_WAIT_SECONDS).toBeGreaterThanOrEqual(5);
   });
 });

--- a/src/server/services/blocks/workflow.service.ts
+++ b/src/server/services/blocks/workflow.service.ts
@@ -1088,3 +1088,68 @@ export function createBlockCustomComfyStep(
     input,
   };
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// LONG-POLL BOUNDS for `blocks.pollWorkflow`.
+//
+// The orchestrator's `GET /v2/consumer/workflows/{id}` accepts `?wait=<seconds>`
+// and holds the response until the workflow reaches a terminal status, replying
+// 202 with the current snapshot if the hold elapses first
+// (`GetWorkflowData.query.wait`, `@civitai/client`). civitai already uses it on
+// four non-blocks paths (`orchestrator.service.ts`, `comics/orchestrator-chat`,
+// `product-badge.service`, `training.service`); the blocks poll did not.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * The longest hold `blocks.pollWorkflow` will ask the orchestrator for.
+ *
+ * 🔴 THIS CEILING IS SET BY A CONSTANT IN ANOTHER FILE, NOT BY TASTE.
+ * `getWorkflow` (`~/server/services/orchestrator/workflows`) applies
+ * `AbortSignal.timeout(ORCHESTRATOR_GET_TIMEOUT_MS)` — 20_000 — UNCONDITIONALLY
+ * to every single-workflow read. A hold at or above 20s is therefore killed by
+ * our own backstop before the orchestrator can answer, and it fails as a
+ * `TimeoutError` mapped to a retry-able 503 — i.e. it would look like an
+ * orchestrator outage rather than a misconfigured bound. 15 leaves 5s of slack
+ * for connect + the response itself.
+ *
+ * 🔴 RAISING THIS REQUIRES CHANGING THAT BACKSTOP FIRST, and that backstop is
+ * shared with the whole generation status-update path (#2883, added to stop a
+ * parked orchestrator read from pinning an api-pool slot). Do not raise it here
+ * alone: the result is silently ineffective.
+ *
+ * The second ceiling, further out: the poll runs an inline output-moderation
+ * scan (`screenGeneratedText`, ~12s hard deadline) AFTER this read,
+ * sequentially — so the procedure's own worst case is 15 + 12 = 27s. That is
+ * the number to check against the edge/proxy response budgets before raising
+ * this bound; both were verified to sit well above it at the time of writing.
+ */
+export const MAX_BLOCK_POLL_WAIT_SECONDS = 15;
+
+/**
+ * Normalize a caller-supplied `waitSeconds` into a value safe to hand the
+ * orchestrator.
+ *
+ * 🔴 THE INPUT IS UNTRUSTED — it originates in an app block's iframe, forwarded
+ * by the host. It is clamped rather than rejected because a block asking for a
+ * hold longer than we allow is not an error, it is a request we satisfy less
+ * generously; failing the poll would break a generation over a tuning value.
+ *
+ * 🔴 THE DEFAULT IS 0 — NO HOLD — AND THAT IS DELIBERATE, NOT AN OVERSIGHT.
+ * Enabling long polling for every caller would change the CONCURRENCY profile of
+ * every already-deployed block, whose poll loops we do not control and cannot
+ * assume are sequential. A block driving `setInterval(poll, 2000)` against a
+ * 15s hold stacks ~7 concurrent requests per workflow instead of one — the
+ * opposite of the intended effect. So the hold is opt-in per request, and the
+ * SDK only sends it from `useBuzzWorkflow().watch()`, whose loop awaits each
+ * poll before issuing the next.
+ *
+ * Returns `undefined` (rather than 0) when there is no hold, so the caller can
+ * omit the `query` entirely and keep the request byte-identical to today's.
+ */
+export function resolveBlockPollWaitSeconds(waitSeconds?: number): number | undefined {
+  if (typeof waitSeconds !== 'number' || !Number.isFinite(waitSeconds)) return undefined;
+  // Floor before the bounds check: 0.9 must read as "no hold", not as a hold.
+  const floored = Math.floor(waitSeconds);
+  if (floored <= 0) return undefined;
+  return Math.min(floored, MAX_BLOCK_POLL_WAIT_SECONDS);
+}


### PR DESCRIPTION
## The current arrangement

The App Blocks workflow status path is a **timer poll driven by the app**, not by the host.

- `blocks.pollWorkflow` calls `getWorkflow({ token, path: { workflowId } })` — **no query at all**. It is an immediate read of whatever the status is right now.
- The host (`IframeHost.tsx` / `PageBlockHost.tsx`) is a pure one-shot request/reply bridge: one inbound `POLL_WORKFLOW` postMessage → one `blocks.pollWorkflow` mutation → one `WORKFLOW_STATUS` reply. It has no interval, no retry, no backoff.
- The loop therefore lives in **untrusted block code**. `@civitai/blocks-react`'s `useBuzzWorkflow` docstring told authors in so many words to write a `useEffect` that calls `poll(workflowId)` on a backoff. The in-repo cadence figure is ~2s.

So a block learns its generation finished on the *next tick after* it finished.

Meanwhile the orchestrator has supported a server-side long poll all along: `GET /v2/consumer/workflows/{workflowId}?wait=<seconds>` holds the response until the workflow reaches a terminal status and answers **202 with the current snapshot** if the hold elapses first (`GetWorkflowData.query.wait` in the generated client). Four non-blocks call sites in this repo already use it — `orchestrator.service.ts` (`wait: 30`), `comics/orchestrator-chat.ts`, `product-badge.service.ts`, `training.service.ts`. It was simply absent from the blocks path.

## What changed

**`blocks.pollWorkflow` accepts an optional `waitSeconds` and forwards it as `query: { wait }`.**

- Omitted → the `query` key is **absent**, not `{ wait: 0 }`. The request is byte-identical to today's.
- `resolveBlockPollWaitSeconds` (new, in `workflow.service.ts`) owns the clamp: floor, drop ≤ 0, cap at `MAX_BLOCK_POLL_WAIT_SECONDS = 15`. Pure, so it is unit-tested and mutation-swept directly.
- The zod `.max(60)` on the wire is deliberately **looser** than the real ceiling: the schema rejects nonsense, the resolver decides policy, and the policy lives in one place.

**Why the bound is 15 and not 30.** `getWorkflow` applies `AbortSignal.timeout(ORCHESTRATOR_GET_TIMEOUT_MS)` — 20 000 — **unconditionally** to every single-workflow read (the #2883 backstop). A hold at or above 20s is killed by our own backstop before the orchestrator can answer, and it fails as a `TimeoutError` mapped to a retry-able 503 — i.e. a misconfigured bound would present as an orchestrator outage. 15 leaves 5s of slack. Raising it requires changing that backstop first, and that backstop is shared with the whole generation status-update path — so this is called out in the constant's own doc rather than left for someone to rediscover. A test asserts `MAX_BLOCK_POLL_WAIT_SECONDS < 20` with ≥5s of margin, and fails if either number moves.

**A 202 needs no branch.** The generated client surfaces `202 Accepted` as an ordinary `data` result carrying the still-running workflow, so it flows through the exact same mapping and reaches the block as a non-terminal snapshot to re-arm on. Adding a branch that treated 202 as a failure would turn the normal timeout into a broken generation. A test pins that the terminal side effects — the durable read-model mirror and the customComfy post-paid settle — do **not** fire on a 202. That branch is reached far more often under a hold than under a 2s timer, so it is worth a guard rather than an assumption.

`blocks.cancelWorkflow` is untouched and asserted to still issue a plain read: a cancel has nothing to wait for, and holding its confirmation read open would only delay the reply.

## Back-compat story

The default is **off**, and that is a design decision, not an oversight.

Every already-deployed block sends `{ blockToken, workflowId }`. That input produces a request identical to today's, byte for byte. Nothing about an existing block's behaviour changes.

Turning the hold on by default would have changed the **concurrency profile of every deployed block**, and we do not control or know their loop shapes. A block driving `setInterval(poll, 2000)` against a 15s hold stacks ~7 concurrent requests per workflow instead of one — the opposite of the intended effect, and a much worse outcome than the timer poll it replaced. A hold is only safe from a loop that awaits each poll before issuing the next, so it is requested per-request by a caller that can guarantee that. `useBuzzWorkflow().watch()` in the companion PR is sequential and non-overlapping by construction and is the intended sender.

**Companion PR:** https://github.com/civitai/civitai-app-starters/pull/211

**Remaining wiring, and it is not mine.** The host handlers own the iframe wire contract and are outside this PR's scope. Until they read `waitSeconds` off the `POLL_WORKFLOW` payload and pass it into the tRPC input, this capability is reachable but unused — one line in each of `IframeHost.tsx` and `PageBlockHost.tsx`. Stating that plainly rather than claiming a cadence improvement this PR does not by itself deliver.

## Cost / cadence analysis

**Scan cost: the direction is favourable, and this is the part worth checking carefully.**

`attachModeratedStepTextOutputs` runs on **every** `pollWorkflow`. `screenGeneratedText` memoizes a decided *content* verdict for 5 minutes (`VERDICT_CACHE_TTL_MS`), but **deliberately does not memoize an operational fault**. Concretely, these five branches all sit *above* `writeCachedVerdict` and re-scan on the next poll by design — `stage: 'error'` (scanner throw / hard deadline), `stage: 'no-verdict'`, `stage: 'over-cap'`, **`stage: 'label-drift'`**, and **`stage: 'label-error'`** (a per-label scanner backend failure). The reasoning is in that file and is correct: caching a withhold that an operational fix can clear would pin a blip into a five-minute outage of the capability. The consequence is that while such a fault lasts, the same text is re-scanned **once per poll**.

So the poll cadence *is* the blast radius multiplier for `label-error`, and that is exactly what this change reduces.

Long polling **reduces the poll rate** — roughly 1 per 15s instead of 1 per 2s — so it shrinks that blast radius by about 7.5×. It does not make it worse. The `MAX_SCANNED_CONTENT_CHARS` cap that bounds a single scan is untouched.

**What it does cost: concurrency, not volume.** Requests per in-flight workflow fall ~7.5×, but each held request occupies an in-flight request slot for its whole duration. Duty cycle per watched workflow goes from roughly 10% (a ~200ms read every 2s) to ~100%. Concurrent in-flight polls therefore rise even as total polls fall. What I checked before accepting that:

- `blocks.pollWorkflow` is a **mutation**, and the batch gate requires `op.type === 'query'` — so a held poll can never stall unrelated calls in a batch. Batching is additionally flag-gated off by default, and the batch link streams per-op anyway.
- There is **no server-side request-duration cap** in this repo: `pages/api/trpc/[trpc].ts` sets only `bodyParser.sizeLimit`, and there is no `maxDuration`, no custom server, no `server.timeout`/`headersTimeout`.
- There is **no client-side tRPC timeout**, and mutations default to 0 React Query retries, so a slow poll cannot self-amplify.
- No DB connection is held across the orchestrator await — the DB work completes first.
- A request parked on `await fetch` consumes ~0 event-loop CPU, which is the failure model `request-bulkhead.ts` is actually built around.
- The edge/proxy response budgets were checked against the 27s worst case (15s hold + the ≤12s inline moderation scan) and sit well above it.

The residual I could **not** close: the comment on `ORCHESTRATOR_GET_TIMEOUT_MS` asserts that a parked read "pins an api-pool connection" and head-of-line-blocks cheap endpoints. I could not find a connection-layer cap in this repo that produces that mechanism, and the only in-process limiter does not cover this procedure. The observation it cites is real; the mechanism is not stated anywhere I could verify. **That unresolved question is exactly why the hold is opt-in and capped at 15s rather than defaulted on at 30s.** Whoever turns it on for the host should watch in-flight request counts on the first rollout.

## Test matrix

`red at origin/main` / `green at HEAD`. Tests green on both are labelled **invariant guards** and are not counted as regression coverage.

**`blocks.router.pollWorkflowLongPoll.test.ts`** (11 new; 4 red at base)

| Test | base | HEAD | base failure |
|---|---|---|---|
| forwards `waitSeconds` as `?wait=<seconds>` | 🔴 | ✅ | `expected undefined to deeply equal { wait: 9 }` |
| CLAMPS an over-large `waitSeconds` | 🔴 | ✅ | `expected undefined to deeply equal { wait: 15 }` |
| rejects nonsense at the wire schema, no orchestrator call | 🔴 | ✅ | `promise resolved instead of rejecting` (base zod strips the unknown key) |
| RE-ARM: second poll after a 202 returns the later snapshot | 🔴 | ✅ | `expected undefined to deeply equal { wait: 5 }` |
| BACK-COMPAT: no `waitSeconds` → no query at all | ✅ | ✅ | *invariant guard* |
| drops `waitSeconds: 0` back to a plain read | ✅ | ✅ | *invariant guard* |
| completes inside the hold → terminal + side effects fire | ✅ | ✅ | *invariant guard* |
| 🔴 hold elapsed (202) → non-terminal, side effects do NOT fire | ✅ | ✅ | *invariant guard* |
| terminal failure returned as a snapshot, not thrown | ✅ | ✅ | *invariant guard* |
| cancellation: canceled workflow returns terminal at once | ✅ | ✅ | *invariant guard* |
| `blocks.cancelWorkflow` never asks for a hold | ✅ | ✅ | *invariant guard* |

The four design-review cases — completes in the window, does not (202 → re-arm), terminal failure, cancellation — are all covered end-to-end through the real tRPC caller. Fixture workflows are pairwise distinct in id, status **and** cost (11/22/33/44), so a wiring bug that returns the wrong workflow, or a stub returning a constant, cannot pass by coincidence.

**`workflow.service.test.ts`** (5 new for `resolveBlockPollWaitSeconds`). The function does not exist at base, so "red at base" would only ever be an import error. Mutation sweep instead — **6/6 killed**, each by a test whose name matches the mutation's semantics:

| Mutant | killed by |
|---|---|
| M1 null-impl (always no hold) | 6 tests, incl. `forwards waitSeconds…` |
| M2 clamp removed | `CLAMPS anything above the bound…` + the router clamp test |
| M3 floor removed | `FLOORS a fractional value…` |
| M4 zero becomes a hold | `drops waitSeconds: 0…`, `returns undefined (no hold)…` |
| M5 bound raised above the 20s backstop | `🔴 stays strictly BELOW the shared getWorkflow abort backstop` |
| M6 non-finite guard removed | `returns undefined … for non-finite` (`expected NaN to be undefined`) |

**Gates**
- `pnpm typecheck`: error **sets** compared base-vs-HEAD, not counts. 151 pre-existing on both; `diff` of the sets is empty. Zero new.
- Blocks area regression: `src/server/services/blocks/__tests__/` + `blocks.router.textOutputModeration.test.ts` — 103 files / **2148 tests passed**, counted from the runner summary, not an exit code.

## What I deliberately did not do

- **Did not default the hold on.** Reasoning above; it is the single most consequential decision here and I would rather it be reviewed than inherited.
- **Did not touch `getWorkflow` / `ORCHESTRATOR_GET_TIMEOUT_MS`.** Making the backstop conditional on `wait` would let the bound go to 30s, but that helper is shared with the whole generation status-update path and the backstop exists for a load incident. Out of scope; noted in the constant's doc as the prerequisite for raising the bound.
- **Did not add `waitSeconds` to `cancelWorkflow`, `queryAppWorkflows`, or `cancelAppWorkflow`.** None of them is waiting for a state change.
- **Did not touch the host handlers, `iframeTransport.ts`, the manifest schema, scaffolds, or the developer docs** — another agent owns the iframe wire contract.
- **Did not copy `text-output-moderation.ts`'s `withHardDeadline`.** It is a `Promise.race` against a timer with no `AbortController`, so the underlying fetch is never cancelled. `getWorkflow`'s existing `AbortSignal.timeout` already cancels for real, which is the right shape; the SDK side of this change uses a real `AbortController` for the same reason.
- **Did not fix `comics/orchestrator-chat.ts:45`**, which passes `wait: 60000` where every other call site treats the unit as **seconds** (`wait: 30` paired with a 45 000 ms abort). It is either a ~16-hour ask that the orchestrator clamps, or a genuine unit bug. Outside this PR's files — flagging it rather than silently changing a billing-adjacent path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R7ZCxbgcsv3WfsSJrYdSCi
