### PR TITLE
feat(app-blocks): iframe init-fragment fast path + BLOCK_HELLO readiness announce

### DIFF
--- a/src/components/AppBlocks/IframeHost.browser.test.tsx
+++ b/src/components/AppBlocks/IframeHost.browser.test.tsx
@@ -97,6 +97,10 @@ vi.mock('~/components/BrowsingLevel/BrowsingLevelProvider', () => ({
 import { IframeHost } from '~/components/AppBlocks/IframeHost';
 // eslint-disable-next-line import/first
 import type { BlockInstall, ModelSlotContext } from '~/components/AppBlocks/types';
+// eslint-disable-next-line import/first
+import { IframeInitController } from '~/components/AppBlocks/iframeInitController';
+// eslint-disable-next-line import/first
+import { encodeBlockInitFragment } from '~/components/AppBlocks/blockIframeUrl';
 
 /**
  * Analytics Phase 2 — block render/impression beacon on the MODEL slot host.
@@ -359,5 +363,91 @@ describe('IframeHost GET_BUZZ_BALANCE handler (Phase 3, model.sidebar_top)', () 
     expect(mocks.balance).not.toHaveBeenCalled();
     expect(replies.last('BUZZ_BALANCE_RESULT')).toBeUndefined();
     replies.stop();
+  });
+});
+
+/**
+ * The iframe WIRE CONTRACT on the model-slot host — the two seams that no pure
+ * unit test can reach, because they are claims about how the COMPONENT is
+ * wired rather than about what the helpers compute:
+ *
+ *   A. the rendered `src` really carries the init fragment, and
+ *   B. a real `BLOCK_HELLO` arriving over the real postMessage bridge really
+ *      reaches `IframeInitController.notifyHello`.
+ *
+ * The behaviour behind each seam is pinned separately and deterministically:
+ * `__tests__/blockIframeUrl.test.ts` for the URL format, and
+ * `__tests__/iframeInitController.test.ts` for what `notifyHello` does (and,
+ * crucially, does NOT do — it never cancels the retry loop or the readiness
+ * timeout). Asserting the CALL here rather than counting BLOCK_INIT posts is
+ * deliberate: a count would race the host's own 400ms retry tick and could
+ * pass for the wrong reason.
+ */
+describe('IframeHost iframe wire contract (init fragment + readiness announce)', () => {
+  test('renders the iframe src with the init fragment appended to the manifest src', async () => {
+    renderWithProviders(<IframeHost {...baseProps} />);
+    await vi.waitFor(() => {
+      const el = page.getByTestId('block-iframe').element() as HTMLIFrameElement;
+      if (!el.contentWindow) throw new Error('not mounted yet');
+    });
+
+    const el = page.getByTestId('block-iframe').element() as HTMLIFrameElement;
+    const src = el.getAttribute('src') ?? '';
+    const url = new URL(src);
+
+    // The publisher's origin + path are untouched; only the fragment is added.
+    expect(url.origin).toBe(new URL(SAME_ORIGIN_SRC).origin);
+    expect(url.pathname).toBe(new URL(SAME_ORIGIN_SRC).pathname);
+    expect(url.hash.slice(1)).toBe(
+      encodeBlockInitFragment({
+        // `context.theme` is 'light' and the install renders in iframe mode.
+        theme: 'light',
+        renderMode: 'iframe',
+        blockInstanceId: install.blockInstanceId,
+      })
+    );
+  });
+
+  test('🔴 the rendered src carries NO token — only the three declared fields', async () => {
+    renderWithProviders(<IframeHost {...baseProps} />);
+    await vi.waitFor(() => {
+      const el = page.getByTestId('block-iframe').element() as HTMLIFrameElement;
+      if (!el.contentWindow) throw new Error('not mounted yet');
+    });
+
+    const src = page.getByTestId('block-iframe').element().getAttribute('src') ?? '';
+    // baseProps.token is the block bearer token. It must appear nowhere in the URL.
+    expect(src).not.toContain(baseProps.token);
+    const keys = [...new URLSearchParams(new URL(src).hash.slice(1)).keys()].sort();
+    expect(keys).toEqual(['blockInstanceId', 'civitai-block', 'renderMode', 'theme']);
+  });
+
+  test('a BLOCK_HELLO from the frame reaches IframeInitController.notifyHello', async () => {
+    const helloSpy = vi.spyOn(IframeInitController.prototype, 'notifyHello');
+    renderWithProviders(<IframeHost {...baseProps} />);
+    await vi.waitFor(() => {
+      const el = page.getByTestId('block-iframe').element() as HTMLIFrameElement;
+      if (!el.contentWindow) throw new Error('not mounted yet');
+    });
+    expect(helloSpy).not.toHaveBeenCalled(); // positive control: nothing yet
+
+    postFromBlock('BLOCK_HELLO');
+
+    await vi.waitFor(() => expect(helloSpy).toHaveBeenCalled());
+    helloSpy.mockRestore();
+  });
+
+  test('an unrelated message type does NOT reach notifyHello (negative control)', async () => {
+    const helloSpy = vi.spyOn(IframeInitController.prototype, 'notifyHello');
+    renderWithProviders(<IframeHost {...baseProps} />);
+    await vi.waitFor(() => {
+      const el = page.getByTestId('block-iframe').element() as HTMLIFrameElement;
+      if (!el.contentWindow) throw new Error('not mounted yet');
+    });
+
+    postFromBlock('BLOCK_HELLO_NOT_REALLY');
+    await new Promise((r) => setTimeout(r, 150));
+    expect(helloSpy).not.toHaveBeenCalled();
+    helloSpy.mockRestore();
   });
 });

--- a/src/components/AppBlocks/IframeHost.tsx
+++ b/src/components/AppBlocks/IframeHost.tsx
@@ -37,6 +37,7 @@ import {
   projectBlockInitViewer,
 } from './projectBlockInit';
 import { IframeInitController, shouldStartInit } from './iframeInitController';
+import { useBlockIframeSrc } from './useBlockIframeSrc';
 import { usePostMessage } from './usePostMessage';
 import type { BlockInitPayload, BlockInstall, ModelSlotContext, SlotContext } from './types';
 import { dialogStore } from '~/components/Dialog/dialogStore';
@@ -606,14 +607,22 @@ export function IframeHost({
   // used everywhere else modelCtx.slotId is read in this component.
   const slotId = modelCtx.slotId ?? 'model.sidebar_top';
 
-  const iframeSrc = install.manifest.iframe?.src ?? '';
+  // The publisher's declared src. The rendered `src` adds the init-fragment
+  // fast path on top (see blockIframeUrl.ts); the ORIGIN is derived from the
+  // base so the postMessage target can never be affected by the fragment.
+  const baseIframeSrc = install.manifest.iframe?.src ?? '';
+  const iframeSrc = useBlockIframeSrc(baseIframeSrc, {
+    theme: modelCtx.theme ?? 'light',
+    renderMode: install.renderMode,
+    blockInstanceId: install.blockInstanceId,
+  });
   const expectedOrigin = useMemo(() => {
     try {
-      return new URL(iframeSrc).origin;
+      return new URL(baseIframeSrc).origin;
     } catch {
       return '';
     }
-  }, [iframeSrc]);
+  }, [baseIframeSrc]);
 
   // The EFFECTIVE sandbox handed to the iframe attribute below. Derive the
   // transport's opaque-origin mode from the SAME string so they can never
@@ -884,6 +893,26 @@ export function IframeHost({
     }, TOKEN_WAIT_TIMEOUT_MS);
     return () => clearTimeout(t);
   }, [status, token]);
+
+  // INVERTED HANDSHAKE: the block announces that its message listener is
+  // attached (`BLOCK_HELLO`) and we push BLOCK_INIT in response, instead of
+  // relying purely on the blind retry tick to eventually land after the
+  // listener exists.
+  //
+  // 🔴 PURELY ADDITIVE. `IframeInitController` still posts init immediately on
+  // start() and re-posts every INIT_RETRY_INTERVAL_MS until BLOCK_READY, and
+  // still arms the readiness timeout. A block on an older SDK never sends this
+  // message and is served exactly as it is today; a block that announces but
+  // never acks still times out. `notifyHello()` is a once-per-controller
+  // accelerator (see its doc comment), and a hello arriving before the
+  // controller exists is a no-op because `start()` posts init immediately
+  // anyway.
+  useEffect(() => {
+    const off = onMessage<unknown>('BLOCK_HELLO', () => {
+      controllerRef.current?.notifyHello();
+    });
+    return off;
+  }, [onMessage]);
 
   useEffect(() => {
     const off = onMessage<unknown>('BLOCK_READY', (raw) => {

--- a/src/components/AppBlocks/PageBlockHost.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHost.browser.test.tsx
@@ -89,6 +89,10 @@ vi.mock('~/utils/trpc', () => ({
 
 // eslint-disable-next-line import/first
 import { PageBlockHost } from '~/components/AppBlocks/PageBlockHost';
+// eslint-disable-next-line import/first
+import { IframeInitController } from '~/components/AppBlocks/iframeInitController';
+// eslint-disable-next-line import/first
+import { encodeBlockInitFragment } from '~/components/AppBlocks/blockIframeUrl';
 
 /**
  * W10 lazy-consent gap regression (page surface).
@@ -912,5 +916,70 @@ describe('PageBlockHost block render/impression (Analytics Phase 2)', () => {
 
     // The new mount emitted a 2nd, independent impression → total 2.
     await vi.waitFor(() => expect(beaconCalls()).toHaveLength(2));
+  });
+});
+
+/**
+ * The iframe WIRE CONTRACT on the PAGE host. Mirrors the model-slot coverage in
+ * IframeHost.browser.test.tsx — these are the two seams a pure unit test cannot
+ * reach (the rendered `src`, and the real postMessage bridge reaching
+ * `IframeInitController.notifyHello`). Both hosts need their own, because each
+ * is a separate call site: the model host derives its fragment fields from the
+ * install + slot context, the page host from its props.
+ */
+describe('PageBlockHost iframe wire contract (init fragment + readiness announce)', () => {
+  async function mountAndWait() {
+    renderWithProviders(<PageBlockHost {...baseProps} />);
+    await vi.waitFor(() => {
+      const el = page.getByTestId('app-page-iframe').element() as HTMLIFrameElement;
+      if (!el.contentWindow) throw new Error('not mounted yet');
+    });
+    return page.getByTestId('app-page-iframe').element() as HTMLIFrameElement;
+  }
+
+  test('renders the iframe src with the init fragment appended', async () => {
+    const el = await mountAndWait();
+    const url = new URL(el.getAttribute('src') ?? '');
+
+    expect(url.origin).toBe(new URL(SAME_ORIGIN_SRC).origin);
+    expect(url.pathname).toBe(new URL(SAME_ORIGIN_SRC).pathname);
+    expect(url.hash.slice(1)).toBe(
+      encodeBlockInitFragment({
+        theme: baseProps.theme,
+        // The page host is iframe-mode by construction — the same literal it
+        // puts in its BLOCK_INIT payload.
+        renderMode: 'iframe',
+        blockInstanceId: baseProps.blockInstanceId,
+      })
+    );
+  });
+
+  test('🔴 the rendered src carries NO token — only the three declared fields', async () => {
+    const el = await mountAndWait();
+    const src = el.getAttribute('src') ?? '';
+    expect(src).not.toContain(baseProps.token);
+    const keys = [...new URLSearchParams(new URL(src).hash.slice(1)).keys()].sort();
+    expect(keys).toEqual(['blockInstanceId', 'civitai-block', 'renderMode', 'theme']);
+  });
+
+  test('a BLOCK_HELLO from the frame reaches IframeInitController.notifyHello', async () => {
+    const helloSpy = vi.spyOn(IframeInitController.prototype, 'notifyHello');
+    await mountAndWait();
+    expect(helloSpy).not.toHaveBeenCalled(); // positive control
+
+    postFromBlock('BLOCK_HELLO');
+
+    await vi.waitFor(() => expect(helloSpy).toHaveBeenCalled());
+    helloSpy.mockRestore();
+  });
+
+  test('an unrelated message type does NOT reach notifyHello (negative control)', async () => {
+    const helloSpy = vi.spyOn(IframeInitController.prototype, 'notifyHello');
+    await mountAndWait();
+
+    postFromBlock('BLOCK_HELLO_NOT_REALLY');
+    await new Promise((r) => setTimeout(r, 150));
+    expect(helloSpy).not.toHaveBeenCalled();
+    helloSpy.mockRestore();
   });
 });

--- a/src/components/AppBlocks/PageBlockHost.tsx
+++ b/src/components/AppBlocks/PageBlockHost.tsx
@@ -8,6 +8,7 @@ import { BlockFallback } from './BlockFallback';
 import { failureSnapshot } from './failureSnapshot';
 import { AppBlockChrome } from './IframeHost';
 import { IframeInitController, shouldStartInit } from './iframeInitController';
+import { useBlockIframeSrc } from './useBlockIframeSrc';
 import { resolveBuzzPurchaseRequest } from './openBuzzPurchaseGate';
 import {
   BLOCK_READY_TIMEOUT_MS,
@@ -616,6 +617,20 @@ export function PageBlockHost({
     }
   }, [iframeSrc]);
 
+  // The `src` actually rendered: the publisher's src plus the init-fragment
+  // fast path (see blockIframeUrl.ts — payload stays authoritative, token is
+  // never in the URL, and an src that already has a fragment is left alone).
+  // `expectedOrigin` above is deliberately derived from the BASE src so the
+  // postMessage target can never be influenced by the fragment.
+  //
+  // The page host's render mode is `'iframe'` by construction — it is the
+  // literal this component already puts in its BLOCK_INIT payload below.
+  const renderedIframeSrc = useBlockIframeSrc(iframeSrc, {
+    theme,
+    renderMode: 'iframe',
+    blockInstanceId,
+  });
+
   // The EFFECTIVE sandbox handed to the iframe attribute below. Derive the
   // transport's opaque-origin mode from the SAME string so the two can never
   // drift: unverified (no allow-same-origin) → opaque frame → opaque transport;
@@ -858,6 +873,21 @@ export function PageBlockHost({
     });
     return off;
   }, [token, expiresAt, grantedScopes, send, onMessage]);
+
+  // INVERTED HANDSHAKE: the block announces that its message listener is
+  // attached (`BLOCK_HELLO`) and we push BLOCK_INIT in response rather than
+  // waiting out the current retry tick.
+  //
+  // 🔴 PURELY ADDITIVE — see `IframeInitController.notifyHello`. The immediate
+  // post on start(), the retry interval and the readiness timeout are all
+  // unchanged, so a block that never announces (older SDK) behaves exactly as
+  // today and a block that announces but never acks still times out.
+  useEffect(() => {
+    const off = onMessage<unknown>('BLOCK_HELLO', () => {
+      controllerRef.current?.notifyHello();
+    });
+    return off;
+  }, [onMessage]);
 
   // BLOCK_READY → ready.
   useEffect(() => {
@@ -3221,7 +3251,7 @@ export function PageBlockHost({
             // re-armed init handshake then talks to a clean frame.
             key={reloadNonce}
             ref={iframeRef}
-            src={iframeSrc}
+            src={renderedIframeSrc}
             sandbox={effectiveSandbox}
             referrerPolicy="no-referrer"
             // Sanitize the publisher-controlled appName for the iframe title too

--- a/src/components/AppBlocks/__tests__/blockIframeUrl.test.ts
+++ b/src/components/AppBlocks/__tests__/blockIframeUrl.test.ts
@@ -32,7 +32,9 @@ describe('encodeBlockInitFragment', () => {
       renderMode: 'iframe',
       blockInstanceId: 'x&theme=dark',
     });
-    expect(encoded).toBe('civitai-block=v1&theme=light&renderMode=iframe&blockInstanceId=x%26theme%3Ddark');
+    expect(encoded).toBe(
+      'civitai-block=v1&theme=light&renderMode=iframe&blockInstanceId=x%26theme%3Ddark'
+    );
   });
 });
 
@@ -80,9 +82,9 @@ describe('buildBlockIframeSrc', () => {
   });
 
   it('returns the src unchanged when there is no blockInstanceId to state', () => {
-    expect(
-      buildBlockIframeSrc('https://demo.civit.ai/', { ...FIELDS, blockInstanceId: '' })
-    ).toBe('https://demo.civit.ai/');
+    expect(buildBlockIframeSrc('https://demo.civit.ai/', { ...FIELDS, blockInstanceId: '' })).toBe(
+      'https://demo.civit.ai/'
+    );
   });
 
   it('🔴 never puts a token, viewer or context in the URL', () => {

--- a/src/components/AppBlocks/__tests__/blockIframeUrl.test.ts
+++ b/src/components/AppBlocks/__tests__/blockIframeUrl.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildBlockIframeSrc, encodeBlockInitFragment } from '../blockIframeUrl';
+
+/**
+ * 🔴 THE LITERAL BELOW IS THE WIRE CONTRACT, and this test is the ONLY thing
+ * holding the two repos together.
+ *
+ * civitai cannot import the SDK's decoder — it consumes the PUBLISHED
+ * `@civitai/app-sdk` dist and the decoder ships in a version that is not
+ * published when this lands — so `blockIframeUrl.ts` carries a mirrored
+ * encoder. `civitai-app-starters`'
+ * `packages/civitai-app-sdk/test/initFragment.test.ts` pins this SAME string
+ * from the decoder's side. Change one and you must change the other.
+ *
+ * Deliberately a literal, NOT `encodeBlockInitFragment(...)` compared against
+ * itself: an expectation derived from the implementation cannot detect a
+ * format change, which is the exact failure this pin exists to catch.
+ */
+const WIRE_LITERAL = 'civitai-block=v1&theme=dark&renderMode=iframe&blockInstanceId=bi_abc';
+
+describe('encodeBlockInitFragment', () => {
+  it('produces the exact pinned wire literal', () => {
+    expect(
+      encodeBlockInitFragment({ theme: 'dark', renderMode: 'iframe', blockInstanceId: 'bi_abc' })
+    ).toBe(WIRE_LITERAL);
+  });
+
+  it('percent-encodes a blockInstanceId so it cannot smuggle extra fragment keys', () => {
+    const encoded = encodeBlockInitFragment({
+      theme: 'light',
+      renderMode: 'iframe',
+      blockInstanceId: 'x&theme=dark',
+    });
+    expect(encoded).toBe('civitai-block=v1&theme=light&renderMode=iframe&blockInstanceId=x%26theme%3Ddark');
+  });
+});
+
+describe('buildBlockIframeSrc', () => {
+  const FIELDS = { theme: 'dark', renderMode: 'iframe', blockInstanceId: 'bi_abc' } as const;
+
+  it('appends the fragment to a plain publisher src', () => {
+    expect(buildBlockIframeSrc('https://demo.civit.ai/', FIELDS)).toBe(
+      `https://demo.civit.ai/#${WIRE_LITERAL}`
+    );
+  });
+
+  it('leaves an existing query string intact and does not touch it', () => {
+    // The dev-tunnel route ships `?dev=<token>`; the fragment must be additive
+    // and must not disturb the query.
+    expect(buildBlockIframeSrc('https://tunnel.example.com/?dev=abc123', FIELDS)).toBe(
+      `https://tunnel.example.com/?dev=abc123#${WIRE_LITERAL}`
+    );
+  });
+
+  it('NO-STOMP: returns the src UNCHANGED when the publisher already uses the fragment', () => {
+    // 🔴 The compatibility guard for hash-routing block apps. A publisher whose
+    // src carries a fragment is the one population an appended fragment could
+    // break, so they keep today's URL exactly and simply forgo the fast path.
+    const hashRouted = 'https://demo.civit.ai/#/dashboard';
+    expect(buildBlockIframeSrc(hashRouted, FIELDS)).toBe(hashRouted);
+
+    const anchored = 'https://demo.civit.ai/page#section-2';
+    expect(buildBlockIframeSrc(anchored, FIELDS)).toBe(anchored);
+  });
+
+  it('claims a BARE trailing hash (it carries no publisher state)', () => {
+    expect(buildBlockIframeSrc('https://demo.civit.ai/#', FIELDS)).toBe(
+      `https://demo.civit.ai/#${WIRE_LITERAL}`
+    );
+  });
+
+  it('returns an empty src unchanged (malformed manifest — the host collapses on it)', () => {
+    expect(buildBlockIframeSrc('', FIELDS)).toBe('');
+  });
+
+  it('returns an unparseable src unchanged rather than throwing', () => {
+    expect(buildBlockIframeSrc('not a url', FIELDS)).toBe('not a url');
+    expect(buildBlockIframeSrc('/relative/path', FIELDS)).toBe('/relative/path');
+  });
+
+  it('returns the src unchanged when there is no blockInstanceId to state', () => {
+    expect(
+      buildBlockIframeSrc('https://demo.civit.ai/', { ...FIELDS, blockInstanceId: '' })
+    ).toBe('https://demo.civit.ai/');
+  });
+
+  it('🔴 never puts a token, viewer or context in the URL', () => {
+    // Belt on the security property: the ONLY three fields this function can
+    // emit are the ones it takes. If a future edit widens the input, this
+    // enumeration of the produced fragment keys fails.
+    const out = buildBlockIframeSrc('https://demo.civit.ai/', FIELDS);
+    const keys = [...new URLSearchParams(new URL(out).hash.slice(1)).keys()].sort();
+    expect(keys).toEqual(['blockInstanceId', 'civitai-block', 'renderMode', 'theme']);
+  });
+
+  it('preserves the origin, so the postMessage target is unaffected', () => {
+    const out = buildBlockIframeSrc('https://demo.civit.ai/app', FIELDS);
+    expect(new URL(out).origin).toBe(new URL('https://demo.civit.ai/app').origin);
+  });
+});

--- a/src/components/AppBlocks/__tests__/iframeInitController.test.ts
+++ b/src/components/AppBlocks/__tests__/iframeInitController.test.ts
@@ -187,4 +187,105 @@ describe('IframeInitController', () => {
       expect(controller.hasStarted()).toBe(true);
     });
   });
+
+  /**
+   * THE INVERTED HANDSHAKE — and its COMPATIBILITY MATRIX.
+   *
+   * The block now announces that its listener is attached (`BLOCK_HELLO`) and
+   * the host pushes BLOCK_INIT in response. These tests pin the property that
+   * makes that safe to ship against already-deployed third-party blocks: the
+   * announce is an ACCELERATOR layered on the existing schedule, never a gate.
+   * The two cells that matter here are the ones the SDK's own tests structurally
+   * cannot cover, because they are claims about the HOST:
+   *
+   *   - OLD SDK + NEW HOST — a deployed block that never sends BLOCK_HELLO.
+   *   - A BLOCK THAT NEVER ANNOUNCES AND NEVER ACKS — must not hang the host.
+   */
+  describe('BLOCK_HELLO: the inverted handshake is an accelerator, not a gate', () => {
+    it('OLD SDK + NEW HOST: a block that never announces gets the unchanged schedule', () => {
+      // The whole old-SDK compatibility claim in one assertion: with no
+      // BLOCK_HELLO ever delivered, the immediate post + every retry tick
+      // happen exactly as before this change.
+      const { controller, sendInit, onReadyTimeout } = makeController({ readyTimeoutMs: 10_000 });
+      controller.start();
+      expect(sendInit).toHaveBeenCalledTimes(1); // immediate post
+
+      vi.advanceTimersByTime(INIT_RETRY_INTERVAL_MS * 5);
+      expect(sendInit).toHaveBeenCalledTimes(6); // 1 + 5 retries
+      expect(onReadyTimeout).not.toHaveBeenCalled();
+    });
+
+    it('NEVER ANNOUNCES AND NEVER ACKS: the readiness timeout still fires — no hang', () => {
+      const { controller, sendInit, onReadyTimeout } = makeController({ readyTimeoutMs: 10_000 });
+      controller.start();
+      vi.advanceTimersByTime(60_000);
+      expect(onReadyTimeout).toHaveBeenCalledTimes(1);
+      // …and the retry loop stopped with it, rather than re-posting forever.
+      const atTimeout = sendInit.mock.calls.length;
+      vi.advanceTimersByTime(60_000);
+      expect(sendInit).toHaveBeenCalledTimes(atTimeout);
+    });
+
+    it('NEW SDK + NEW HOST: an announce posts BLOCK_INIT immediately, not at the next tick', () => {
+      const { controller, sendInit } = makeController();
+      controller.start();
+      expect(sendInit).toHaveBeenCalledTimes(1);
+
+      // Half a tick in — the retry loop would not have fired yet.
+      vi.advanceTimersByTime(INIT_RETRY_INTERVAL_MS / 2);
+      expect(sendInit).toHaveBeenCalledTimes(1);
+
+      controller.notifyHello();
+      expect(sendInit).toHaveBeenCalledTimes(2);
+    });
+
+    it('the announce does NOT cancel the retry loop or the readiness timeout', () => {
+      // 🔴 An announce means "I am listening", NOT "I got the payload". Only
+      // BLOCK_READY may stop the loop; treating hello as an ack would
+      // reintroduce the blank-iframe bug this controller exists to fix.
+      const { controller, sendInit, onReadyTimeout } = makeController({ readyTimeoutMs: 10_000 });
+      controller.start();
+      controller.notifyHello();
+      const afterHello = sendInit.mock.calls.length;
+
+      vi.advanceTimersByTime(INIT_RETRY_INTERVAL_MS * 3);
+      expect(sendInit.mock.calls.length).toBe(afterHello + 3);
+
+      vi.advanceTimersByTime(10_000);
+      expect(onReadyTimeout).toHaveBeenCalledTimes(1);
+    });
+
+    it('is honored at most ONCE — a chatty block cannot amplify host work', () => {
+      const { controller, sendInit } = makeController();
+      controller.start();
+      for (let i = 0; i < 50; i += 1) controller.notifyHello();
+      expect(sendInit).toHaveBeenCalledTimes(2); // the immediate post + one hello
+    });
+
+    it('an announce BEFORE start() sends nothing, and start() still posts immediately', () => {
+      // The host registers its BLOCK_HELLO listener before the controller
+      // exists (token/checkpoint may still be resolving). A hello landing then
+      // must not post — there is no payload yet — and must not suppress the
+      // immediate post start() owes.
+      const { controller, sendInit } = makeController();
+      controller.notifyHello();
+      expect(sendInit).not.toHaveBeenCalled();
+      controller.start();
+      expect(sendInit).toHaveBeenCalledTimes(1);
+    });
+
+    it('an announce after notifyReady()/dispose() sends nothing', () => {
+      const { controller, sendInit } = makeController();
+      controller.start();
+      controller.notifyReady();
+      controller.notifyHello();
+      expect(sendInit).toHaveBeenCalledTimes(1);
+
+      const second = makeController();
+      second.controller.start();
+      second.controller.dispose();
+      second.controller.notifyHello();
+      expect(second.sendInit).toHaveBeenCalledTimes(1);
+    });
+  });
 });

--- a/src/components/AppBlocks/blockIframeUrl.ts
+++ b/src/components/AppBlocks/blockIframeUrl.ts
@@ -1,0 +1,142 @@
+// App Blocks — the iframe URL FRAGMENT fast path.
+//
+// WHAT THIS IS
+// ------------
+// `theme`, `renderMode` and `blockInstanceId` ship in the `BLOCK_INIT`
+// postMessage payload. That payload cannot be posted until the host has a
+// block token AND the effective-checkpoint query has resolved, so a block
+// cannot paint its own loading state in the right theme, nor key any
+// per-instance bootstrap, until the handshake completes. Repeating the same
+// three values in the iframe URL's FRAGMENT makes them readable by the block
+// synchronously at document-parse time, before a single message is exchanged.
+//
+// 🔴 THE PAYLOAD REMAINS AUTHORITATIVE. This is an additive FAST PATH:
+//   - `BLOCK_INIT` still carries all three fields, and the SDK's
+//     `snapshotFromInit` replaces the whole snapshot when it lands, so the
+//     payload always wins over the fragment.
+//   - A block is only `ready` after `BLOCK_INIT`. The fragment never makes a
+//     block ready.
+//   - A NEW block against an OLD host sees no fragment and falls back to
+//     waiting for the payload — i.e. today's behaviour.
+//
+// 🔴 THE TOKEN IS NEVER PUT IN THE URL. Only these three non-secret fields
+// are. URLs leak into `document.referrer`, browser history, proxy logs and
+// screenshots; a bearer token must not. `token`, `viewer`, `settings` and
+// `context` stay in the postMessage payload.
+//
+// WHY A FRAGMENT AND NOT A QUERY ARG
+// ----------------------------------
+// A fragment is never transmitted to the block's origin server, so it cannot
+// perturb caching, server-side routing, or a strict query-param validator on
+// the publisher's side. It is also the only part of a URL that can be changed
+// WITHOUT re-navigating the document, which is what makes a future
+// no-reload update of `renderMode`/`theme` possible at all. See
+// "PROPAGATING A CHANGE" below for what is and is not implemented today.
+//
+// WIRE FORMAT (v1) — mirrored by `@civitai/app-sdk`'s `parseBlockInitFragment`:
+//
+//   #civitai-block=v1&theme=dark&renderMode=iframe&blockInstanceId=bi_abc
+//
+// The body is a standard `URLSearchParams` string; `civitai-block=v1` is both
+// the namespace marker and the format version, so a reader can tell OUR
+// fragment from a block app's own hash state without guessing.
+//
+// 🔴 THIS IS A MIRRORED CONTRACT, NOT A SHARED IMPORT. civitai consumes the
+// PUBLISHED `@civitai/app-sdk` dist, and the decoder lands in a version that
+// is not published yet, so the encoder cannot import it. `__tests__/blockIframeUrl.test.ts`
+// pins the exact literal output string — change the format on one side and that
+// literal must be changed here AND in the SDK's `initFragment.test.ts`, which
+// pins the same literal from the decoder's side.
+//
+// NO-STOMP RULE
+// -------------
+// If the publisher's `iframe.src` ALREADY carries a fragment, we append
+// nothing and return the src untouched. A block that puts state in its own
+// hash (a hash router, a deep link) is the one population a fragment could
+// break, and an existing fragment is the signal that we are looking at one.
+// Those blocks keep working exactly as they do today; they simply do not get
+// the fast path.
+//
+// PROPAGATING A CHANGE
+// --------------------
+// Today nothing changes these three values for a MOUNTED block:
+//   - `renderMode` is a per-install constant (`'iframe'` at every iframe call
+//     site) and cannot change without a remount;
+//   - `theme` CAN change (the viewer toggles dark mode) but the host has never
+//     propagated that to a live block — `BLOCK_INIT` is deduped by the SDK, so
+//     a later theme value never reaches it;
+//   - `blockInstanceId` is immutable per mount.
+// So the hosts FREEZE the fragment at mount (see `useBlockIframeSrc.ts`) and
+// the observable behaviour of a running block is unchanged by this module. The
+// alternative — recomputing the fragment from live values — would make the
+// iframe's `src` attribute change on a theme toggle, which is a navigation
+// where today there is none. That is a behaviour change nobody asked for and
+// is deliberately not made here.
+//
+// When a live update IS wanted, the mechanism the fragment buys is: the host
+// rewrites ONLY the fragment of the existing `src` (a same-document fragment
+// navigation, no reload) and the block observes it via a `hashchange`
+// listener. That needs an SDK-side listener that does not exist yet, so it is
+// explicitly out of scope here — and note the freeze above means shipping it
+// later is purely additive.
+
+/** Fragment key that both namespaces and versions the payload. */
+export const BLOCK_INIT_FRAGMENT_MARKER_KEY = 'civitai-block';
+
+/** Current fragment format version. */
+export const BLOCK_INIT_FRAGMENT_VERSION = 'v1';
+
+export interface BlockInitFragmentFields {
+  theme: 'light' | 'dark';
+  renderMode: 'iframe' | 'inline';
+  blockInstanceId: string;
+}
+
+/**
+ * Encode the fast-path fields into a fragment BODY (no leading `#`).
+ *
+ * Key order is fixed (marker first) so the output is deterministic and can be
+ * pinned by a literal-valued test on both sides of the wire.
+ */
+export function encodeBlockInitFragment(fields: BlockInitFragmentFields): string {
+  const params = new URLSearchParams();
+  params.set(BLOCK_INIT_FRAGMENT_MARKER_KEY, BLOCK_INIT_FRAGMENT_VERSION);
+  params.set('theme', fields.theme);
+  params.set('renderMode', fields.renderMode);
+  params.set('blockInstanceId', fields.blockInstanceId);
+  return params.toString();
+}
+
+/**
+ * Append the init fragment to a publisher-supplied iframe `src`.
+ *
+ * Returns `baseSrc` UNCHANGED when:
+ *   - `blockInstanceId` is empty (nothing useful to say), or
+ *   - it does not parse as an absolute URL — which covers BOTH the empty-string
+ *     src of a malformed manifest and a relative one. There is deliberately no
+ *     separate `if (!baseSrc)` early return: `new URL('')` throws, so the catch
+ *     below already returns the input, and a second guard for the same case
+ *     would be one no mutation can kill.
+ *   - it already carries a fragment (the no-stomp rule above).
+ *
+ * Never throws: a bad `src` returns the input, and the caller's existing
+ * `new URL(src).origin` guard is what rejects it.
+ */
+export function buildBlockIframeSrc(baseSrc: string, fields: BlockInitFragmentFields): string {
+  if (!fields.blockInstanceId) return baseSrc;
+
+  let url: URL;
+  try {
+    url = new URL(baseSrc);
+  } catch {
+    return baseSrc;
+  }
+
+  // NO-STOMP: the publisher is already using the fragment. `URL#hash` is the
+  // empty string when there is no fragment, and `'#'` for a bare trailing
+  // hash — treat the bare hash as "unused" and claim it.
+  if (url.hash && url.hash !== '#') return baseSrc;
+
+  url.hash = encodeBlockInitFragment(fields);
+  return url.toString();
+}

--- a/src/components/AppBlocks/hostHandlerParity.ts
+++ b/src/components/AppBlocks/hostHandlerParity.ts
@@ -83,6 +83,22 @@ export const INLINE_STUB =
 export const INVENTORY = {
   // ── Lifecycle / fire-and-forget (no reply ⇒ unhandled never HANGS, but a
   //    page that ignores them just no-ops; documented per host) ───────────────
+  //
+  // The block's readiness ANNOUNCE — posted by the SDK transport the moment its
+  // message listener is attached, so the host can push BLOCK_INIT in response
+  // instead of waiting out a retry tick. Fire-and-forget and, uniquely in this
+  // table, an ACCELERATOR rather than a bridge: an unhandled BLOCK_HELLO costs
+  // only latency, because every host keeps its own immediate-post + bounded
+  // retry + readiness-timeout schedule. Marked `required` on the two live hosts
+  // anyway — the whole point of the parity gate is that a message the SDK sends
+  // has a named answer on every host that could receive it.
+  BLOCK_HELLO: {
+    request: false,
+    reply: '',
+    IframeHost: 'required',
+    PageBlockHost: 'required',
+    InlineHost: INLINE_STUB,
+  },
   BLOCK_READY: {
     request: false,
     reply: '',

--- a/src/components/AppBlocks/iframeInitController.ts
+++ b/src/components/AppBlocks/iframeInitController.ts
@@ -104,6 +104,8 @@ export class IframeInitController {
   private readonly opts: Required<IframeInitControllerOptions>;
   private started = false;
   private stopped = false;
+  /** One-shot latch for `notifyHello()` — see its doc comment. */
+  private helloHandled = false;
   private intervalId: ReturnType<typeof setInterval> | null = null;
   private timeoutId: ReturnType<typeof setTimeout> | null = null;
 
@@ -151,6 +153,32 @@ export class IframeInitController {
   /** Whether start() has run (i.e. at least one BLOCK_INIT was posted). */
   hasStarted(): boolean {
     return this.started;
+  }
+
+  /**
+   * The block announced it is listening (`BLOCK_HELLO` — the inverted
+   * handshake). Push BLOCK_INIT NOW rather than waiting out the remainder of
+   * the current retry tick.
+   *
+   * 🔴 THIS IS AN ACCELERATOR, NOT A GATE. The retry interval and the readiness
+   * timeout armed by `start()` are untouched, so:
+   *   - a block on an OLDER SDK, which never sends `BLOCK_HELLO`, is served by
+   *     the unchanged retry loop exactly as it is today;
+   *   - a block that never announces AND never acks still hits `onReadyTimeout`
+   *     at `readyTimeoutMs` — it cannot hang the host.
+   * Nothing here may ever become a precondition for sending init.
+   *
+   * Honored AT MOST ONCE per controller: an announce is a one-shot signal from
+   * the block's transport, so a repeat is either a duplicate or noise, and
+   * answering every one would let a chatty frame amplify host work. An announce
+   * that lands BEFORE `start()` is recorded and costs nothing — `start()` posts
+   * init immediately on its own.
+   */
+  notifyHello(): void {
+    if (this.helloHandled) return;
+    this.helloHandled = true;
+    if (!this.started || this.stopped) return;
+    this.opts.sendInit();
   }
 
   /**

--- a/src/components/AppBlocks/useBlockIframeSrc.ts
+++ b/src/components/AppBlocks/useBlockIframeSrc.ts
@@ -1,0 +1,37 @@
+import { useMemo, useRef } from 'react';
+
+import { buildBlockIframeSrc, type BlockInitFragmentFields } from './blockIframeUrl';
+
+/**
+ * The `src` an App Blocks iframe host should render: the publisher's
+ * `manifest.iframe.src` plus the init-fragment fast path (see
+ * `blockIframeUrl.ts` for the format, the no-stomp rule, and why the token is
+ * NOT in there).
+ *
+ * 🔴 THE FRAGMENT FIELDS ARE FROZEN AT MOUNT, ON PURPOSE.
+ *
+ * `theme` can change while a block is mounted (the viewer toggles dark mode).
+ * If the fragment tracked it, the iframe's `src` ATTRIBUTE would change on a
+ * theme toggle — a navigation of a third-party frame where today there is
+ * none. That is a behaviour change with real blast radius (at best a
+ * `hashchange` in the block, at worst a reload that discards its in-progress
+ * state) in exchange for nothing: the host does not propagate live theme
+ * changes to blocks today either, because the SDK dedupes `BLOCK_INIT` and no
+ * theme-change message exists. Freezing keeps the rendered `src` exactly as
+ * stable as it is today.
+ *
+ * `baseSrc` is deliberately NOT frozen: if the publisher's manifest src really
+ * changes mid-mount, the iframe should re-navigate exactly as it does today.
+ */
+export function useBlockIframeSrc(baseSrc: string, fields: BlockInitFragmentFields): string {
+  // First-render capture. A ref (not state) because there is no update path —
+  // the value is written once, at mount, and read forever after.
+  const frozenFields = useRef<BlockInitFragmentFields>(fields);
+
+  return useMemo(
+    () => buildBlockIframeSrc(baseSrc, frozenFields.current),
+    // frozenFields.current is stable for the component's lifetime, so baseSrc
+    // is the only real input. Listed explicitly for the linter.
+    [baseSrc]
+  );
+}


### PR DESCRIPTION
Host half of a two-repo wire-contract change. SDK side: **civitai/civitai-app-starters#212**.

**A.** `theme` / `renderMode` / `blockInstanceId` are also carried in the iframe URL **fragment**, so a block has them at document-parse time instead of after the handshake. **The token stays in the payload** — a URL leaks into referrers, history, proxy logs and screenshots, and must never carry a bearer credential.

**B.** The block **announces readiness** (`BLOCK_HELLO`) and the host pushes `BLOCK_INIT` in response, instead of relying purely on the blind 400 ms retry tick.

---

## 🔴 Compatibility matrix

Blocks are third-party code **already deployed**. Every cell is covered by a named test that was watched to fail under a deliberate mutation of the code it guards.

| Cell | What must hold | How it is satisfied | Evidence (test name) |
|---|---|---|---|
| **old SDK + new host** | a deployed block that reads no fragment and never announces still inits, on the schedule it gets today | `IframeInitController` is **untouched** on its existing paths: immediate post on `start()`, re-post every `INIT_RETRY_INTERVAL_MS` (400 ms), readiness timeout armed at `start()`. The fragment is inert to a block that does not read it — a fragment is never sent to the block's origin server, so it cannot perturb caching, routing or a param validator either | `OLD SDK + NEW HOST: a block that never announces gets the unchanged schedule` (asserts 1 immediate + 5 retries at 5 ticks, timeout not fired) |
| **new SDK + old host** | no fragment appended, announce unanswered ⇒ block behaves as today | *SDK-side claim.* An absent fragment decodes to `{}` and leaves the sentinel snapshot; the announce is fire-and-forget and expects no reply | SDK PR: `no fragment → sentinel snapshot, and BLOCK_INIT still works unchanged`; `the announce is not a precondition: BLOCK_INIT still resolves if the parent ignores it` |
| **new SDK + new host** | fragment read as a hint only; **payload stays authoritative** | Host emits the fragment; SDK seeds it into the **pre-init** snapshot. `BLOCK_INIT` then calls `snapshotFromInit`, which **replaces the whole snapshot**, overwriting all three fields | Host: `renders the iframe src with the init fragment appended`. SDK PR: `BLOCK_INIT OVERRIDES the fragment — the payload is authoritative`; `a failing history.replaceState … and the payload still wins` |
| **block never announces readiness** | must **not hang** the host — bounded fallback required | `notifyHello()` is an *accelerator*, not a gate. It never cancels the retry loop and never disarms the readiness timeout, so a block that neither announces nor acks still hits `onReadyTimeout` and surfaces the `timeout` fallback | `NEVER ANNOUNCES AND NEVER ACKS: the readiness timeout still fires — no hang` (also asserts the retry loop stops with it, rather than re-posting forever); `the announce does NOT cancel the retry loop or the readiness timeout` |

Three further properties that carry most of the real risk:

- **🔴 No credential in the URL.** Both hosts are asserted to render an `src` that does not contain the block bearer token, and whose fragment key set is *exactly* `blockInstanceId, civitai-block, renderMode, theme` — an enumeration, so a future edit that widens the input fails the test rather than silently leaking. (`the rendered src carries NO token — only the three declared fields`, on both hosts.)
- **🔴 NO-STOMP: a publisher already using the fragment is left alone.** `buildBlockIframeSrc` returns the src **unchanged** when it already carries a fragment. A block that puts state in its own hash — a hash router, a deep link — is the one population an appended fragment could break, and an existing fragment is the signal that we are looking at one. Those blocks keep today's exact URL and simply forgo the fast path. (`NO-STOMP: returns the src UNCHANGED when the publisher already uses the fragment`, covering both `#/dashboard` and `#section-2`.) See *Residual risk* below for the case this does **not** cover.
- **The origin is derived from the BASE src**, never from the fragmented one, so the `postMessage` target and the `expectedOrigin` pin cannot be influenced by anything this change adds.

## Fragment format (v1)

```
#civitai-block=v1&theme=dark&renderMode=iframe&blockInstanceId=bi_abc
```

A standard `URLSearchParams` body. `civitai-block=v1` is **both** the namespace marker and the format version: it lets a reader distinguish our fragment from a block app's own hash state, and an unknown version decodes to `{}` so a future v2 degrades to "no fast path" rather than to garbage.

🔴 **This is a MIRRORED contract, not a shared import.** civitai consumes the *published* `@civitai/app-sdk` dist, and the decoder ships in a version that is not published when this lands — so `blockIframeUrl.ts` carries its own encoder. Both repos pin the **same literal string** in a test, deliberately as a literal rather than a round-trip, because an expectation derived from the implementation cannot detect a format change. **Ship order is SDK first** (an unknown version is safe; a missing decoder just means no fast path).

## Handshake change

`IframeInitController` gains `notifyHello()`, wired in both hosts via `onMessage('BLOCK_HELLO', …)`. It posts `BLOCK_INIT` immediately rather than waiting out the current retry tick, and is **honored at most once per controller** — an announce is a one-shot signal from the block's transport, so answering every repeat would let a chatty frame amplify host work. An announce landing *before* `start()` is recorded and costs nothing, because `start()` posts init immediately on its own.

`hostHandlerParity.ts` gains a `BLOCK_HELLO` inventory entry, which is what makes "both live hosts register a handler" a **gated** claim rather than a hope.

## Where the change lives (and why not in the five supplier files)

The five iframe-URL suppliers are **untouched**. They hand a base `src` to a host; the host appends the fragment from values it already holds (`IframeHost` from the install + slot context, `PageBlockHost` from its props). One shared helper (`buildBlockIframeSrc`) behind one shared hook (`useBlockIframeSrc`) means the rule lives in one place instead of five — a predicate open-coded at five sites is the shape that gets fixed four times and stays wrong at the fifth.

### 🔴 The fragment fields are FROZEN at mount

`theme` **can** change while a block is mounted (the viewer toggles dark mode). If the fragment tracked it, the iframe's `src` **attribute** would change on a theme toggle — a navigation of a third-party frame where today there is none. At best that is a `hashchange` inside the block; at worst a reload that discards its in-progress state. In exchange for nothing: the host does not propagate live theme changes to blocks today either, because the SDK dedupes `BLOCK_INIT` and no theme-change message exists.

So `useBlockIframeSrc` captures the three fields on first render and memoizes on `baseSrc` alone. `baseSrc` is deliberately **not** frozen — if a publisher's manifest src genuinely changes mid-mount, the iframe re-navigates exactly as it does today.

## Propagating a *change* to render mode

Deliberately **not implemented**, and worth recording because the no-reload property is why a fragment was chosen over a query arg.

Nothing changes these three values for a mounted block today: `renderMode` is a per-install constant (`'iframe'` at every iframe call site — `[slug]/[[...path]].tsx:150`, `dev/[blockId].tsx:168`, `PageBlockHost.tsx:694`), `blockInstanceId` is immutable per mount, and `theme` changes are already not propagated. So freezing changes no observable behaviour.

The mechanism a fragment buys, when it is wanted: the host rewrites **only** the fragment of the existing `src` — a same-document fragment navigation, no reload — and the block observes it via a `hashchange` listener. That listener does not exist in the SDK yet. Because the fields are frozen today, adding it later is purely additive: nothing has to be un-done first.

## On `?dev=<token>` — left as-is, deliberately

`pages/apps/dev/[blockId].tsx:110` puts a token in a URL, which is exactly what this PR argues against. It stays, and here is why it is a different thing:

- It is **not** the block bearer token. It is an **edge forwardAuth entry token** that authenticates the *document navigation itself* — the `*.civit.ai` edge verifies it before the document is served. At that moment the frame does not exist, so there is no postMessage channel to carry it. Moving it out of the URL is not a refactor; it requires a different auth mechanism (a cross-site cookie on the dev host, `SameSite=None`, plus its own flow).
- The existing mitigations are real: it is **freshly minted on every SSR render** (never stale), **author-bound and host-bound**, short-TTL, and that route sets a **route-scoped CSP pinning `frame-src` to the exact dev host**.
- It is a **dev-tunnel-only** path, not a production block surface.

Changing it is a cross-repo protocol break (the tunnel edge is the consumer) with no bearing on this change. Flagging it as a standalone security item rather than smuggling it in here.

## Test matrix

🔴 **Every new test was watched to fail**, and required to fail via **its own named test** — not merely to turn the suite red. Two mutation sweeps, one per tier.

**Node ("unit") tier — 13 mutants, 13 killed:**

| Mutation | Killed by |
|---|---|
| `IframeHost` drops the `BLOCK_HELLO` handler | parity: `IframeHost.tsx is missing onMessage('BLOCK_HELLO')` |
| `PageBlockHost` drops the `BLOCK_HELLO` handler | parity: `PageBlockHost.tsx is missing onMessage('BLOCK_HELLO')` |
| `notifyHello()` becomes a no-op | `an announce posts BLOCK_INIT immediately, not at the next tick` |
| `notifyHello()` stops the retry loop (treats hello as an ack) | `the announce does NOT cancel the retry loop or the readiness timeout` |
| `notifyHello()` loses its once-only latch | `is honored at most ONCE` (51 sends observed vs 2 expected) |
| `notifyHello()` sends before `start()` | `an announce BEFORE start() sends nothing` |
| retry loop no longer re-posts | `a block that never announces gets the unchanged schedule` |
| NO-STOMP removed | `returns the src UNCHANGED when the publisher already uses the fragment` |
| fragment written as a **query arg** instead | `appends the fragment to a plain publisher src` (+3 more) |
| an extra field leaks into the URL | `never puts a token, viewer or context in the URL` (+5 more) |
| encoder stops escaping values | `percent-encodes a blockInstanceId so it cannot smuggle extra fragment keys` |
| `blockInstanceId` guard removed | `returns the src unchanged when there is no blockInstanceId` |
| URL parse failure throws instead of degrading | `returns an unparseable src unchanged rather than throwing` |

**Component ("browser") tier — 6 mutants, 6 killed.** These cover the two seams no pure unit test can reach, because they are claims about how the *component* is wired rather than what a helper computes:

| Mutation | Killed by |
|---|---|
| `IframeHost` renders the BASE src (fragment never reaches the DOM) | `renders the iframe src with the init fragment appended to the manifest src` |
| `IframeHost` hello handler no longer calls `notifyHello` | `a BLOCK_HELLO from the frame reaches IframeInitController.notifyHello` |
| `PageBlockHost` renders the BASE src | `renders the iframe src with the init fragment appended` |
| `PageBlockHost` hello handler no longer calls `notifyHello` | `a BLOCK_HELLO from the frame reaches IframeInitController.notifyHello` |
| `PageBlockHost` fragment built from the WRONG instance id | `renders the iframe src with the init fragment appended` |
| `IframeHost` fragment built from the WRONG theme | `renders the iframe src with the init fragment appended to the manifest src` |

The seam test asserts the **call** (`vi.spyOn(IframeInitController.prototype, 'notifyHello')`) rather than counting `BLOCK_INIT` posts, deliberately: a count would race the host's own 400 ms retry tick and could pass for the wrong reason. Each has a positive control (spy not called before the message) and a negative control (an adjacent message type `BLOCK_HELLO_NOT_REALLY` must not reach it).

**Two escapes in the first sweep, both fixed rather than explained away:**

1. *"empty-src guard removed"* **survived** — because `new URL('')` throws and the `catch` already returns the input, so `if (!baseSrc) return baseSrc` was genuinely dead code. **Removed the redundant guard** rather than adding a test for an unreachable branch. (The two escapes on the SDK side are documented in #212.)
2. Two parity mutants reported `RED-WRONG-TEST` purely because my expectation string omitted the `.tsx` the assertion actually prints. Re-run with the correct string: both KILLED.

**Suite results, post-rebase onto `42833e3b04`:**

| Gate | Result |
|---|---|
| `vitest --project unit src/components/AppBlocks` | 30 files / **547 tests** pass |
| `vitest --project component src/components/AppBlocks` | 27 files / **326 tests** pass |
| `pnpm typecheck` | **151 at base `42833e3b04`, 151 at HEAD — error SETS identical** (compared by `file(line,col) + TSxxxx`, since Prisma type-expansion text is not stable run-to-run). Zero new, zero gone, zero count changes. |

Test counts are **counted**, not read from an exit code; ANSI was stripped before grepping and all runs were redirected to files.

## 🔴 Residual risk I could not close

The NO-STOMP rule covers a publisher whose `iframe.src` **already carries** a fragment. It does **not** cover a hash-routing block whose declared src has *no* initial hash (e.g. `https://demo.civit.ai/` with a router that reads `location.hash` at import time and treats `#civitai-block=v1&…` as an unknown route).

What I established: neither the SDK, `blocks-react`, nor any of the six starter templates uses hash routing, and none declares a hash-router dependency (`grep` for `HashRouter|createHashRouter|useHashLocation|location.hash` across `packages/` + `starters/` = 0 hits; no `react-router`/`wouter`/`@tanstack/react-router` in any manifest). What I did **not** do: enumerate the live deployed block set and confirm none of them hash-routes. That is a query against production install data, outside this change's blast radius, and I did not want to generalise from a sample.

**Recommended sequencing:**
1. Merge #212, publish the SDK (decoder first — harmless on its own).
2. Before merging this PR, spot-check the live block URLs (< a dozen apps) for a hash router. It is a one-off read.
3. If any block hash-routes, the mitigation is one line in `blockIframeUrl.ts` — an allowlist/denylist by `blockId`, or making the fragment opt-in — and the SDK-side strip already covers new-SDK blocks that read the hash after first render (**not** at import time; do not read it as a guarantee).

Rollback is a one-line revert: `useBlockIframeSrc` returning `baseSrc`. The handshake half (`BLOCK_HELLO`) is independent of the fragment half and carries none of this risk — it is additive on both sides and cannot make a block fail to init.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R7ZCxbgcsv3WfsSJrYdSCi
