### PR TITLE
Check the first table in a parenthesized join

### DIFF
--- a/src/server/freshdesk-agent/__tests__/freshdesk-query-scope.test.ts
+++ b/src/server/freshdesk-agent/__tests__/freshdesk-query-scope.test.ts
@@ -69,6 +69,11 @@ describe('checkQueryScope — statements it confirms', () => {
     ],
     ['an inline VALUES list in the FROM list', 'SELECT x FROM (VALUES (1), (2)) AS t(x)'],
     [
+      'a LATERAL sub-select, whose keyword sits between JOIN and the relation',
+      'SELECT * FROM "User" u, LATERAL (SELECT 1) s',
+    ],
+    ['a LATERAL inline VALUES list', 'SELECT * FROM "User" u, LATERAL (VALUES (1)) AS t(x)'],
+    [
       'an inline VALUES list joined to an allowed table',
       'SELECT * FROM (VALUES (1)) AS t(x) JOIN "User" u ON u.id = t.x',
     ],
@@ -199,6 +204,27 @@ describe('checkQueryScope — relations outside the allowed set', () => {
     ['bare, reached through a join', 'SELECT * FROM "User" u JOIN values v ON true'],
     ['bare, case-folded', 'SELECT * FROM VaLuEs'],
     ['bare, in a sub-select', 'SELECT * FROM "User" WHERE id IN (SELECT id FROM values)'],
+    // The head item of the outer paren is itself a parenthesized group, so a
+    // position-tracking gate can leave a stale "this is the head" state behind
+    // and wave the later join through. The discriminator is the next token, not
+    // the position, so these must refuse at any nesting depth.
+    ['bare, after a nested sub-query head', 'SELECT * FROM ((SELECT 1) s JOIN values v ON true)'],
+    [
+      'bare, after a nested join head',
+      'SELECT * FROM (("User" u JOIN "Image" i ON true) JOIN values v ON true)',
+    ],
+    [
+      'bare, after a LATERAL nested head',
+      'SELECT * FROM (LATERAL (SELECT 1) s JOIN values v ON true)',
+    ],
+    // `values` LEADING a parenthesized joined_table is a relation reference too:
+    // it is followed by an alias, never by `(`.
+    // The next token here is a QUOTED identifier whose text happens to be `(`
+    // (a legal, if perverse, alias). Only the token's kind separates it from a
+    // real `VALUES (` clause.
+    ['bare, aliased with a quoted paren', 'SELECT * FROM values "("'],
+    ['bare, leading a parenthesized CROSS JOIN', 'SELECT * FROM (values v CROSS JOIN "User" u)'],
+    ['bare, leading a parenthesized join', 'SELECT * FROM (values v JOIN "User" u ON true) x'],
   ])('refuses `values` used as a relation name — %s', (_label, sql) => {
     expect(checkQueryScope(sql).ok).toBe(false);
   });

--- a/src/server/freshdesk-agent/__tests__/freshdesk-query-scope.test.ts
+++ b/src/server/freshdesk-agent/__tests__/freshdesk-query-scope.test.ts
@@ -67,6 +67,11 @@ describe('checkQueryScope — statements it confirms', () => {
       'a parenthesized join of allowed tables',
       'SELECT * FROM ("User" JOIN "Model" ON true) LIMIT 5',
     ],
+    ['an inline VALUES list in the FROM list', 'SELECT x FROM (VALUES (1), (2)) AS t(x)'],
+    [
+      'an inline VALUES list joined to an allowed table',
+      'SELECT * FROM (VALUES (1)) AS t(x) JOIN "User" u ON u.id = t.x',
+    ],
     [
       'a sub-select in the FROM list followed by another relation',
       'SELECT * FROM (SELECT id FROM "User" LIMIT 5) x, "Model" m',
@@ -168,6 +173,13 @@ describe('checkQueryScope — relations outside the allowed set', () => {
 
   it('still refuses a disallowed table in the trailing position of a parenthesized join', () => {
     const result = checkQueryScope('SELECT * FROM ("User" JOIN "Session" ON true) LIMIT 1');
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('unreachable');
+    expect(result.error).toContain('cannot read "Session"');
+  });
+
+  it('refuses a disallowed table reached from inside an inline VALUES list', () => {
+    const result = checkQueryScope('SELECT * FROM (VALUES ((SELECT id FROM "Session"))) AS t(x)');
     expect(result.ok).toBe(false);
     if (result.ok) throw new Error('unreachable');
     expect(result.error).toContain('cannot read "Session"');

--- a/src/server/freshdesk-agent/__tests__/freshdesk-query-scope.test.ts
+++ b/src/server/freshdesk-agent/__tests__/freshdesk-query-scope.test.ts
@@ -64,6 +64,10 @@ describe('checkQueryScope — statements it confirms', () => {
     ],
     ['a sub-select in the FROM list', 'SELECT * FROM (SELECT id FROM "User" LIMIT 5) x'],
     [
+      'a parenthesized join of allowed tables',
+      'SELECT * FROM ("User" JOIN "Model" ON true) LIMIT 5',
+    ],
+    [
       'a sub-select in the FROM list followed by another relation',
       'SELECT * FROM (SELECT id FROM "User" LIMIT 5) x, "Model" m',
     ],
@@ -129,6 +133,41 @@ describe('checkQueryScope — relations outside the allowed set', () => {
     const result = checkQueryScope(
       'SELECT * FROM "User" WHERE id IN (SELECT "userId" FROM (SELECT "userId" FROM "Session") s)'
     );
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('unreachable');
+    expect(result.error).toContain('cannot read "Session"');
+  });
+
+  /**
+   * A parenthesized join expression is a relation position, not a sub-select:
+   * `FROM ("A" JOIN "B" ON ...)` is valid Postgres and its FIRST item is a
+   * relation. Every other `FROM (` case in this file is a sub-select, so these
+   * pin the other reading of the same two characters — the leading relation
+   * must still be checked, at any depth and for every join flavour.
+   */
+  it('refuses a disallowed table leading a parenthesized join', () => {
+    const result = checkQueryScope('SELECT * FROM ("Session" JOIN "User" ON true) LIMIT 1');
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('unreachable');
+    expect(result.error).toContain('cannot read "Session"');
+  });
+
+  it('refuses a disallowed table leading a parenthesized CROSS JOIN', () => {
+    const result = checkQueryScope('SELECT * FROM ("ApiKey" CROSS JOIN "User") LIMIT 1');
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('unreachable');
+    expect(result.error).toContain('cannot read "ApiKey"');
+  });
+
+  it('refuses a disallowed table leading a doubly-parenthesized join', () => {
+    const result = checkQueryScope('SELECT * FROM (("Account" JOIN "User" ON true)) LIMIT 1');
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('unreachable');
+    expect(result.error).toContain('cannot read "Account"');
+  });
+
+  it('still refuses a disallowed table in the trailing position of a parenthesized join', () => {
+    const result = checkQueryScope('SELECT * FROM ("User" JOIN "Session" ON true) LIMIT 1');
     expect(result.ok).toBe(false);
     if (result.ok) throw new Error('unreachable');
     expect(result.error).toContain('cannot read "Session"');

--- a/src/server/freshdesk-agent/__tests__/freshdesk-query-scope.test.ts
+++ b/src/server/freshdesk-agent/__tests__/freshdesk-query-scope.test.ts
@@ -185,6 +185,43 @@ describe('checkQueryScope — relations outside the allowed set', () => {
     expect(result.error).toContain('cannot read "Session"');
   });
 
+  /**
+   * `VALUES` is UNRESERVED in Postgres (`pg_get_keywords.catcode = 'C'`), so
+   * `CREATE TABLE values (...)` is legal and a bare `values` in relation
+   * position is a real relation reference — unlike `SELECT`, which is reserved.
+   * It is a from_item only at the head of a parenthesized sub-query, so every
+   * other position must still be refused.
+   */
+  it.each([
+    ['bare, as the only relation', 'SELECT * FROM values'],
+    ['bare, in a comma list', 'SELECT * FROM "User" u, values v'],
+    ['bare, inside a parenthesized join', 'SELECT * FROM ("User" u JOIN values v ON true)'],
+    ['bare, reached through a join', 'SELECT * FROM "User" u JOIN values v ON true'],
+    ['bare, case-folded', 'SELECT * FROM VaLuEs'],
+    ['bare, in a sub-select', 'SELECT * FROM "User" WHERE id IN (SELECT id FROM values)'],
+  ])('refuses `values` used as a relation name — %s', (_label, sql) => {
+    expect(checkQueryScope(sql).ok).toBe(false);
+  });
+
+  it('refuses the double-quoted relation "values", which is not on the list', () => {
+    const result = checkQueryScope('SELECT * FROM "values"');
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('unreachable');
+    expect(result.error).toContain('cannot read "values"');
+  });
+
+  it('refuses a bare identifier that merely starts with a sub-query keyword', () => {
+    expect(checkQueryScope('SELECT * FROM selectfoo').ok).toBe(false);
+    expect(checkQueryScope('SELECT * FROM valuesbar').ok).toBe(false);
+  });
+
+  it('refuses a disallowed table following a sub-select in the FROM list', () => {
+    const result = checkQueryScope('SELECT * FROM (SELECT id FROM "User") x, "Session" m');
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('unreachable');
+    expect(result.error).toContain('cannot read "Session"');
+  });
+
   it('refuses a disallowed table in the second branch of a UNION', () => {
     const result = checkQueryScope('SELECT id FROM "User" UNION SELECT id FROM "Session"');
     expect(result.ok).toBe(false);

--- a/src/server/freshdesk-agent/__tests__/freshdesk-query-scope.test.ts
+++ b/src/server/freshdesk-agent/__tests__/freshdesk-query-scope.test.ts
@@ -194,8 +194,13 @@ describe('checkQueryScope — relations outside the allowed set', () => {
    * `VALUES` is UNRESERVED in Postgres (`pg_get_keywords.catcode = 'C'`), so
    * `CREATE TABLE values (...)` is legal and a bare `values` in relation
    * position is a real relation reference — unlike `SELECT`, which is reserved.
-   * It is a from_item only at the head of a parenthesized sub-query, so every
-   * other position must still be refused.
+   *
+   * What separates the two is the NEXT token, not the position: a `VALUES`
+   * clause is always immediately followed by `(`, and a relation named `values`
+   * never can be (`FROM values (id)` and `FROM values(1)` are both syntax
+   * errors). So each case below is a relation reference and must be refused —
+   * including the last one, where the next token is a quoted identifier whose
+   * TEXT is `(` and only its token KIND distinguishes it from a real clause.
    */
   it.each([
     ['bare, as the only relation', 'SELECT * FROM values'],

--- a/src/server/freshdesk-agent/freshdesk-query-scope.ts
+++ b/src/server/freshdesk-agent/freshdesk-query-scope.ts
@@ -286,8 +286,11 @@ export type QueryScopeResult = { ok: true } | { ok: false; error: string };
  *     which is refused.
  *   - schema-qualified names (`"public"."User"`), `ONLY`, table functions, and
  *     any bare/unquoted relation name — including `information_schema` and the
- *     `pg_*` catalog. Relation position accepts a double-quoted identifier or
- *     an opening paren, nothing else.
+ *     `pg_*` catalog. Relation position accepts a double-quoted identifier, an
+ *     opening paren, a `SELECT` (reserved, so never a relation name), or a
+ *     `VALUES` at the head of a paren that stood in relation position —
+ *     nothing else. `VALUES` is unreserved and so is accepted ONLY in that
+ *     position; a bare `FROM values` is a relation reference and is refused.
  *   - `FROM` used as function-call syntax: `EXTRACT(EPOCH FROM col)`,
  *     `SUBSTRING(x FROM 1)`, `TRIM(BOTH ' ' FROM x)`. These read as a relation
  *     position and are rejected. Rewrite with `date_part(...)` / `substr(...)`
@@ -308,6 +311,12 @@ export function checkQueryScope(sql: string): QueryScopeResult {
   const { tokens } = tokenized;
   /** `fromListAtDepth[d]` — is a `FROM` list currently open at paren depth d? */
   const fromListAtDepth: boolean[] = [];
+  /**
+   * `parenHeadAtDepth[d]` — the paren opening depth d stood in relation
+   * position, and its first relation-position token has not been read yet.
+   * Only `VALUES` needs this; see the `values` branch below.
+   */
+  const parenHeadAtDepth: boolean[] = [];
   let depth = 0;
   let expectRelation = false;
 
@@ -321,22 +330,42 @@ export function checkQueryScope(sql: string): QueryScopeResult {
       // the `SELECT`/`VALUES` below is what marks the sub-query and clears it.
       // Clearing unconditionally here would let a joined_table's first relation
       // through unchecked.
+      parenHeadAtDepth[depth] = expectRelation;
       continue;
     }
 
     if (token.kind === 'punct' && token.value === ')') {
       fromListAtDepth[depth] = false;
+      parenHeadAtDepth[depth] = false;
       depth = Math.max(0, depth - 1);
       expectRelation = false;
       continue;
     }
 
     if (expectRelation) {
-      // `SELECT`/`VALUES` in relation position mean a sub-query rather than a
-      // joined_table, so they resolve the expectation instead of failing it.
-      // Both are reserved words in Postgres and so cannot be a bare relation
-      // name; any relation *inside* the sub-query is still walked by this loop.
-      if (token.kind === 'ident' && (token.value === 'select' || token.value === 'values')) {
+      // `LATERAL` sits between the keyword and the relation itself, so it is
+      // not the relation-position token and must not consume the paren head.
+      if (token.kind === 'ident' && token.value === 'lateral') continue;
+
+      const atParenHead = parenHeadAtDepth[depth];
+      parenHeadAtDepth[depth] = false;
+
+      // `SELECT` in relation position means a sub-query rather than a
+      // joined_table, so it resolves the expectation instead of failing it. It
+      // is a RESERVED word in Postgres (`pg_get_keywords.catcode = 'R'`), so it
+      // can never be a bare relation name. Any relation *inside* the sub-query
+      // is still walked by this loop.
+      if (token.kind === 'ident' && token.value === 'select') {
+        expectRelation = false;
+        continue;
+      }
+      // `VALUES` is UNRESERVED (`catcode = 'C'`) — `CREATE TABLE values (…)` is
+      // legal, so a bare `values` CAN be a real relation name and must not be
+      // waved through on the strength of the word alone. It is a from_item only
+      // as the head of a parenthesized sub-query (`FROM (VALUES …)`); bare
+      // `FROM VALUES (1)` is a syntax error. Gate it on exactly that position,
+      // so `FROM values` and `FROM ("User" JOIN values ON …)` stay refused.
+      if (atParenHead && token.kind === 'ident' && token.value === 'values') {
         expectRelation = false;
         continue;
       }
@@ -349,8 +378,6 @@ export function checkQueryScope(sql: string): QueryScopeResult {
         expectRelation = false;
         continue;
       }
-      // `LATERAL` sits between the keyword and the relation itself.
-      if (token.kind === 'ident' && token.value === 'lateral') continue;
       const shown = token.kind === 'ident' ? token.value : 'the value here';
       return reject(
         `Error: query_database expected a double-quoted table name after FROM/JOIN and got ${shown}. Reference tables directly by their quoted name — CTEs, schema prefixes, table functions, and FROM-inside-a-function-call (EXTRACT/SUBSTRING/TRIM) are not supported. Allowed tables: ${TABLE_LIST}.`

--- a/src/server/freshdesk-agent/freshdesk-query-scope.ts
+++ b/src/server/freshdesk-agent/freshdesk-query-scope.ts
@@ -288,9 +288,9 @@ export type QueryScopeResult = { ok: true } | { ok: false; error: string };
  *     any bare/unquoted relation name — including `information_schema` and the
  *     `pg_*` catalog. Relation position accepts a double-quoted identifier, an
  *     opening paren, a `SELECT` (reserved, so never a relation name), or a
- *     `VALUES` at the head of a paren that stood in relation position —
- *     nothing else. `VALUES` is unreserved and so is accepted ONLY in that
- *     position; a bare `FROM values` is a relation reference and is refused.
+ *     `VALUES` that is immediately followed by `(` — nothing else. `VALUES` is
+ *     unreserved, so a bare `FROM values` is a relation reference and is
+ *     refused; only the `VALUES (` clause form is a sub-query.
  *   - `FROM` used as function-call syntax: `EXTRACT(EPOCH FROM col)`,
  *     `SUBSTRING(x FROM 1)`, `TRIM(BOTH ' ' FROM x)`. These read as a relation
  *     position and are rejected. Rewrite with `date_part(...)` / `substr(...)`
@@ -311,44 +311,33 @@ export function checkQueryScope(sql: string): QueryScopeResult {
   const { tokens } = tokenized;
   /** `fromListAtDepth[d]` — is a `FROM` list currently open at paren depth d? */
   const fromListAtDepth: boolean[] = [];
-  /**
-   * `parenHeadAtDepth[d]` — the paren opening depth d stood in relation
-   * position, and its first relation-position token has not been read yet.
-   * Only `VALUES` needs this; see the `values` branch below.
-   */
-  const parenHeadAtDepth: boolean[] = [];
   let depth = 0;
   let expectRelation = false;
 
-  for (const token of tokens) {
+  for (let i = 0; i < tokens.length; i++) {
+    const token = tokens[i];
+
     if (token.kind === 'punct' && token.value === '(') {
       depth++;
       // A paren in relation position is EITHER a sub-query (`FROM (SELECT …)`,
       // `FROM (VALUES …)`) or a parenthesized joined_table
       // (`FROM ("A" JOIN "B" ON …)`), whose FIRST item is itself a relation.
-      // Carry the expectation inward so that leading relation is still checked;
-      // the `SELECT`/`VALUES` below is what marks the sub-query and clears it.
+      // Carry the expectation inward so that leading relation is still checked.
       // Clearing unconditionally here would let a joined_table's first relation
       // through unchecked.
-      parenHeadAtDepth[depth] = expectRelation;
       continue;
     }
 
     if (token.kind === 'punct' && token.value === ')') {
       fromListAtDepth[depth] = false;
-      parenHeadAtDepth[depth] = false;
       depth = Math.max(0, depth - 1);
       expectRelation = false;
       continue;
     }
 
     if (expectRelation) {
-      // `LATERAL` sits between the keyword and the relation itself, so it is
-      // not the relation-position token and must not consume the paren head.
+      // `LATERAL` sits between the keyword and the relation itself.
       if (token.kind === 'ident' && token.value === 'lateral') continue;
-
-      const atParenHead = parenHeadAtDepth[depth];
-      parenHeadAtDepth[depth] = false;
 
       // `SELECT` in relation position means a sub-query rather than a
       // joined_table, so it resolves the expectation instead of failing it. It
@@ -359,13 +348,27 @@ export function checkQueryScope(sql: string): QueryScopeResult {
         expectRelation = false;
         continue;
       }
-      // `VALUES` is UNRESERVED (`catcode = 'C'`) — `CREATE TABLE values (…)` is
-      // legal, so a bare `values` CAN be a real relation name and must not be
-      // waved through on the strength of the word alone. It is a from_item only
-      // as the head of a parenthesized sub-query (`FROM (VALUES …)`); bare
-      // `FROM VALUES (1)` is a syntax error. Gate it on exactly that position,
-      // so `FROM values` and `FROM ("User" JOIN values ON …)` stay refused.
-      if (atParenHead && token.kind === 'ident' && token.value === 'values') {
+      // `VALUES` is UNRESERVED (`catcode = 'C'`), so `CREATE TABLE values (…)`
+      // is legal and a bare `values` here CAN be a real relation reference. The
+      // word alone therefore decides nothing; the NEXT token does, and it is an
+      // exact one-token discriminator in both directions:
+      //   - a VALUES *clause* is always immediately followed by `(`
+      //     (`VALUES (1), (2)`), and
+      //   - a relation named `values` never can be — `FROM values (id)` and
+      //     `FROM values(1)` are both syntax errors, because a `C`-category
+      //     keyword cannot be a function name. Only `FROM values v (id)` parses,
+      //     and there an alias sits in between.
+      // So `FROM values`, `FROM "User" u, values v` and
+      // `FROM (values v JOIN "User" u ON …)` all stay refused as the relation
+      // references they are, at any nesting depth.
+      const next = tokens[i + 1];
+      if (
+        token.kind === 'ident' &&
+        token.value === 'values' &&
+        next !== undefined &&
+        next.kind === 'punct' &&
+        next.value === '('
+      ) {
         expectRelation = false;
         continue;
       }

--- a/src/server/freshdesk-agent/freshdesk-query-scope.ts
+++ b/src/server/freshdesk-agent/freshdesk-query-scope.ts
@@ -308,21 +308,19 @@ export function checkQueryScope(sql: string): QueryScopeResult {
   const { tokens } = tokenized;
   /** `fromListAtDepth[d]` — is a `FROM` list currently open at paren depth d? */
   const fromListAtDepth: boolean[] = [];
-  /** `parenInRelationPosAtDepth[d]` — was the paren opening depth d itself in relation position? */
-  const parenInRelationPosAtDepth: boolean[] = [];
   let depth = 0;
   let expectRelation = false;
 
   for (const token of tokens) {
     if (token.kind === 'punct' && token.value === '(') {
       depth++;
-      // A paren in relation position is EITHER a sub-select (`FROM (SELECT …)`)
-      // or a parenthesized joined_table (`FROM ("A" JOIN "B" ON …)`), whose
-      // FIRST item is itself a relation. Carry the expectation inward so that
-      // leading relation is still checked; a `SELECT` directly inside is what
-      // marks the sub-select and clears it. Clearing unconditionally here would
-      // let the joined_table's first relation through unchecked.
-      parenInRelationPosAtDepth[depth] = expectRelation;
+      // A paren in relation position is EITHER a sub-query (`FROM (SELECT …)`,
+      // `FROM (VALUES …)`) or a parenthesized joined_table
+      // (`FROM ("A" JOIN "B" ON …)`), whose FIRST item is itself a relation.
+      // Carry the expectation inward so that leading relation is still checked;
+      // the `SELECT`/`VALUES` below is what marks the sub-query and clears it.
+      // Clearing unconditionally here would let a joined_table's first relation
+      // through unchecked.
       continue;
     }
 
@@ -334,10 +332,11 @@ export function checkQueryScope(sql: string): QueryScopeResult {
     }
 
     if (expectRelation) {
-      // Only a `SELECT` immediately inside a paren that stood in relation
-      // position resolves it to a sub-select rather than a joined_table.
-      if (parenInRelationPosAtDepth[depth] && token.kind === 'ident' && token.value === 'select') {
-        parenInRelationPosAtDepth[depth] = false;
+      // `SELECT`/`VALUES` in relation position mean a sub-query rather than a
+      // joined_table, so they resolve the expectation instead of failing it.
+      // Both are reserved words in Postgres and so cannot be a bare relation
+      // name; any relation *inside* the sub-query is still walked by this loop.
+      if (token.kind === 'ident' && (token.value === 'select' || token.value === 'values')) {
         expectRelation = false;
         continue;
       }

--- a/src/server/freshdesk-agent/freshdesk-query-scope.ts
+++ b/src/server/freshdesk-agent/freshdesk-query-scope.ts
@@ -274,6 +274,9 @@ export type QueryScopeResult = { ok: true } | { ok: false; error: string };
  *     follows a join's `ON` clause (tracked per paren depth, so an inner
  *     sub-select's `FROM` list cannot be confused with the outer one)
  *   - relations inside sub-selects in the target list, `WHERE`, `IN (...)`
+ *   - the leading relation of a parenthesized join expression
+ *     (`FROM ("A" JOIN "B" ON ...)`), which is a relation position and not a
+ *     sub-select, at any nesting depth
  *   - each branch of a `UNION` / `INTERSECT` / `EXCEPT`
  *   - text hidden in comments or a second statement — refused outright
  *
@@ -305,15 +308,21 @@ export function checkQueryScope(sql: string): QueryScopeResult {
   const { tokens } = tokenized;
   /** `fromListAtDepth[d]` — is a `FROM` list currently open at paren depth d? */
   const fromListAtDepth: boolean[] = [];
+  /** `parenInRelationPosAtDepth[d]` — was the paren opening depth d itself in relation position? */
+  const parenInRelationPosAtDepth: boolean[] = [];
   let depth = 0;
   let expectRelation = false;
 
   for (const token of tokens) {
     if (token.kind === 'punct' && token.value === '(') {
       depth++;
-      // A paren in relation position is a sub-select; its own `FROM` is walked
-      // by this same loop.
-      expectRelation = false;
+      // A paren in relation position is EITHER a sub-select (`FROM (SELECT …)`)
+      // or a parenthesized joined_table (`FROM ("A" JOIN "B" ON …)`), whose
+      // FIRST item is itself a relation. Carry the expectation inward so that
+      // leading relation is still checked; a `SELECT` directly inside is what
+      // marks the sub-select and clears it. Clearing unconditionally here would
+      // let the joined_table's first relation through unchecked.
+      parenInRelationPosAtDepth[depth] = expectRelation;
       continue;
     }
 
@@ -325,6 +334,13 @@ export function checkQueryScope(sql: string): QueryScopeResult {
     }
 
     if (expectRelation) {
+      // Only a `SELECT` immediately inside a paren that stood in relation
+      // position resolves it to a sub-select rather than a joined_table.
+      if (parenInRelationPosAtDepth[depth] && token.kind === 'ident' && token.value === 'select') {
+        parenInRelationPosAtDepth[depth] = false;
+        expectRelation = false;
+        continue;
+      }
       if (token.kind === 'quoted') {
         if (!ALLOWED_TABLES.has(token.value)) {
           return reject(


### PR DESCRIPTION
Small gap in the `query_database` scope check from #3584.

`FROM ("A" JOIN "B" ON ...)` is a relation position rather than a sub-select, but the walk treated any `(` after FROM/JOIN as a sub-select and dropped its relation expectation. The first table inside then matched no branch and went unchecked against the allowed list. Anything after it — the trailing side of the join, comma items, nested sub-selects — was still checked, so it was just the leading one.

Fix keeps the expectation when entering the paren and lets a `SELECT` directly inside be the thing that marks it a sub-select. Everything else stays in relation position and gets checked. That keeps it conservative instead of teaching it to actually parse joins, which is the trade the file already makes elsewhere.

Tests: 3 new refusal cases (plain join, `CROSS JOIN`, doubled parens) are red on the old implementation, green here. Also added an allowed parenthesized join so this can't pass by just refusing more — that one and the trailing-position case pass either way, so they're invariant guards, not regression coverage.

Mutation check: dropping the carry kills the 3 new tests; dropping the `SELECT` escape kills the 3 existing sub-select tests. Each half is pinned by a different set. A third mutation (resetting the flag on `)`) survived because that line turned out to be unreachable — the flag is rewritten on every `(` — so I removed it rather than ship a line nothing can justify.

Gates: 48/48 in `src/server/freshdesk-agent/__tests__/`, `pnpm typecheck` added-vs-main 0 (12 pre-existing `event-engine-common` TS2307s, identical set with this reverted), eslint and prettier clean.