### PR TITLE
fix(orchestrator): chat `wait` was 60000 ms in a SECONDS field (general generation path)

### DIFF
--- a/src/server/services/comics/__tests__/orchestrator-chat.wait-unit.test.ts
+++ b/src/server/services/comics/__tests__/orchestrator-chat.wait-unit.test.ts
@@ -1,0 +1,181 @@
+import fs from 'fs';
+import path from 'path';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type * as WorkflowsMod from '~/server/services/orchestrator/workflows';
+
+/**
+ * The orchestrator's `?wait` query param on the v2 workflow API is SECONDS.
+ *
+ * Authority (not inference): `WorkflowsController.cs` binds it as
+ * `[FromQuery] int wait = 0` and applies it as `TimeSpan.FromSeconds(wait)` on
+ * both the submit and the get handler. There is NO server-side clamp — the
+ * generated OpenAPI schema carries no `minimum`/`maximum`, and nothing between
+ * the binding and `FromSeconds` rewrites the value. Whatever we send is held.
+ *
+ * These tests exist because `orchestrator-chat.ts` shipped `wait: 60000` — a
+ * millisecond value in a seconds field, i.e. a request to hold the socket for
+ * ~16.7 hours. The generated contract types it `wait?: number`, so TypeScript
+ * cannot tell 60000 seconds from 60000 milliseconds. Only a bound can.
+ */
+
+/**
+ * Upper bound on any `wait` we send, in seconds.
+ *
+ * Derived, not arbitrary. `submitWorkflow` only bounds an attempt with an
+ * `AbortSignal.timeout` on the whatIf path, so a real submit has no
+ * client-side abort — the practical ceiling is undici's ~300s default headers
+ * timeout. A `wait` above that never gets to return its graceful 202: the
+ * fetch throws first, `submitWorkflowWithRetry` scores that as transient, and
+ * re-submits. Since these bodies carry no `externalId` the orchestrator cannot
+ * dedupe, so exceeding this bound converts one billable job into up to three.
+ *
+ * The repo's own debug endpoint already encodes a stricter version of this
+ * (`src/pages/api/testing/xguard-test.ts` bounds wait with `.max(120)`).
+ */
+const MAX_WAIT_SECONDS = 300;
+
+const { mockSubmitWorkflow } = vi.hoisted(() => ({ mockSubmitWorkflow: vi.fn() }));
+
+// Spread the real module and override only `submitWorkflow` (house rule
+// local-rules/no-wholesale-module-mock): a hand-written factory silently
+// collects 0 tests the day the module gains an export it omits.
+vi.mock('~/server/services/orchestrator/workflows', async (importOriginal) => ({
+  ...(await importOriginal<typeof WorkflowsMod>()),
+  submitWorkflow: mockSubmitWorkflow,
+}));
+
+import { orchestratorChatCompletion } from '~/server/services/comics/orchestrator-chat';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockSubmitWorkflow.mockResolvedValue({
+    id: 'wf-1',
+    steps: [{ output: { choices: [{ message: { content: 'hi' } }] } }],
+  });
+});
+
+const callOnce = async () => {
+  await orchestratorChatCompletion({
+    token: 't',
+    messages: [{ role: 'user', content: 'hello' }],
+  });
+  expect(mockSubmitWorkflow).toHaveBeenCalledTimes(1);
+  return mockSubmitWorkflow.mock.calls[0][0] as { query?: { wait?: unknown } };
+};
+
+describe('orchestratorChatCompletion — the `wait` it sends is a SECONDS value', () => {
+  // THE regression assertion. At base this reads 60000 and fails on the upper
+  // bound. It deliberately asserts an ENVELOPE, not the literal 60 — a test
+  // pinned to the literal would have to be edited to accept a future retune and
+  // would stop expressing the unit, which is the thing that actually regressed.
+  it('sends a wait inside the seconds envelope, not a millisecond value', async () => {
+    const arg = await callOnce();
+    const wait = arg.query?.wait;
+
+    expect(typeof wait).toBe('number');
+    expect(Number.isInteger(wait)).toBe(true);
+    // > 0 matters: the caller reads `workflow.steps[0].output` inline off the
+    // submit response, so `wait: 0` (return immediately) would make every
+    // completion come back empty.
+    expect(wait as number).toBeGreaterThan(0);
+    expect(wait as number).toBeLessThanOrEqual(MAX_WAIT_SECONDS);
+  });
+
+  it('sends a wait long enough for a gpt-4o-mini completion to land', async () => {
+    // The floor is the consuming side, not the protocol. An expired wait yields
+    // a 202 with no step output → `content: ''` → story-plan.ts refunds the
+    // user's Buzz and throws a user-visible error. SCAN_WAIT_SECONDS (10) is the
+    // smallest wait anything in this repo asks for; a chat completion capped at
+    // maxTokens 2048 needs at least that.
+    const arg = await callOnce();
+    expect(arg.query?.wait as number).toBeGreaterThanOrEqual(10);
+  });
+});
+
+/**
+ * Repo-wide seam guard. The behavioural test above pins ONE call site; this
+ * pins the RELATIONSHIP — the set of places that hand a `wait` to the v2
+ * workflow API — so a new site cannot be added below the radar, and an existing
+ * one cannot silently grow a millisecond value.
+ */
+describe('every v2 `query: { wait }` site in src/ passes seconds', () => {
+  const SRC = path.resolve(__dirname, '../../../..'); // -> src/
+  const QUERY_WAIT = /query:\s*\{\s*wait:\s*([A-Za-z0-9_]+)\s*\}/g;
+
+  /** Resolve a `query: { wait: X }` token: a numeric literal, or a same-file `const X = <number>`. */
+  const resolveWait = (token: string, source: string): number | undefined => {
+    if (/^\d+$/.test(token)) return Number(token);
+    const decl = new RegExp(`const\\s+${token}\\s*=\\s*(\\d[\\d_]*)\\s*;`).exec(source);
+    return decl ? Number(decl[1].replace(/_/g, '')) : undefined;
+  };
+
+  const walk = (dir: string, out: string[] = []): string[] => {
+    for (const e of fs.readdirSync(dir, { withFileTypes: true })) {
+      const p = path.join(dir, e.name);
+      if (e.isDirectory()) {
+        if (e.name !== '__tests__' && e.name !== 'node_modules') walk(p, out);
+      } else if (/\.tsx?$/.test(e.name) && !/\.(test|spec)\.tsx?$/.test(e.name)) {
+        out.push(p);
+      }
+    }
+    return out;
+  };
+
+  const sites = walk(SRC).flatMap((file) => {
+    const source = fs.readFileSync(file, 'utf8');
+    return [...source.matchAll(QUERY_WAIT)].map((m) => ({
+      file: path.relative(SRC, file),
+      token: m[1],
+      seconds: resolveWait(m[1], source),
+    }));
+  });
+
+  // POSITIVE CONTROL. A zero here would be indistinguishable from a scanner
+  // wired to nothing — the regex silently not matching would make every
+  // assertion below vacuously pass.
+  it('the scanner actually finds sites (positive control)', () => {
+    expect(sites.length).toBeGreaterThanOrEqual(5);
+  });
+
+  // A site whose value is only known at runtime cannot be bounded statically,
+  // so it must instead make the unit legible at the call site — which is the
+  // root cause this whole file guards. Both current such sites comply
+  // (`waitSeconds`, `PERCEPTUAL_HASH_WAIT_SECONDS`), and each is separately
+  // clamped in its own module (MAX_BLOCK_POLL_WAIT_SECONDS = 15; the perceptual
+  // hash pairs its 30 with a 45s AbortSignal).
+  it('a runtime-valued wait names its unit', () => {
+    const unresolved = sites.filter((s) => s.seconds === undefined);
+    expect(unresolved.filter((s) => !/seconds/i.test(s.token))).toEqual([]);
+  });
+
+  // NEGATIVE CONTROL. Proves the resolver+bound can go red on a known-bad
+  // input, so the green verdict above is a fact about the code and not about a
+  // broken harness.
+  it('the resolver rejects a known-bad millisecond value (negative control)', () => {
+    expect(resolveWait('60000', '')).toBe(60000);
+    expect(resolveWait('60000', '') as number).toBeGreaterThan(MAX_WAIT_SECONDS);
+    expect(resolveWait('X', 'const X = 60_000;')).toBe(60000);
+  });
+
+  it('no statically-known site exceeds the seconds envelope', () => {
+    const offenders = sites.filter(
+      (s) => s.seconds !== undefined && s.seconds > MAX_WAIT_SECONDS
+    );
+    expect(offenders).toEqual([]);
+  });
+
+  // Fails when the set GROWS or SHRINKS. A new v2 wait site is a deliberate
+  // decision about how long an api pod holds a socket, so it should land in a
+  // diff that says so rather than arriving unnoticed.
+  it('matches the known ledger of v2 wait sites', () => {
+    expect(new Set(sites.map((s) => s.file))).toEqual(
+      new Set([
+        'server/routers/blocks.router.ts',
+        'server/services/comics/orchestrator-chat.ts',
+        'server/services/orchestrator/orchestrator.service.ts',
+        'server/services/product-badge.service.ts',
+        'server/services/training.service.ts',
+      ])
+    );
+  });
+});

--- a/src/server/services/comics/__tests__/orchestrator-chat.wait-unit.test.ts
+++ b/src/server/services/comics/__tests__/orchestrator-chat.wait-unit.test.ts
@@ -21,18 +21,29 @@ import type * as WorkflowsMod from '~/server/services/orchestrator/workflows';
 /**
  * Upper bound on any `wait` we send, in seconds.
  *
- * Derived, not arbitrary. `submitWorkflow` only bounds an attempt with an
- * `AbortSignal.timeout` on the whatIf path, so a real submit has no
- * client-side abort — the practical ceiling is undici's ~300s default headers
- * timeout. A `wait` above that never gets to return its graceful 202: the
- * fetch throws first, `submitWorkflowWithRetry` scores that as transient, and
- * re-submits. Since these bodies carry no `externalId` the orchestrator cannot
- * dedupe, so exceeding this bound converts one billable job into up to three.
+ * Derived, not arbitrary: HALF the measured undici headers timeout.
  *
- * The repo's own debug endpoint already encodes a stricter version of this
- * (`src/pages/api/testing/xguard-test.ts` bounds wait with `.max(120)`).
+ * `submitWorkflow` only bounds an attempt with an `AbortSignal.timeout` on the
+ * whatIf path, so a real submit has no client-side abort — the practical
+ * ceiling is undici's default headers timeout, measured at 300.7s against a
+ * server that accepts and never responds. A `wait` at or above that never gets
+ * to return its graceful 202: the fetch throws first, and
+ * `submitWorkflowWithRetry` re-submits (it retries on ANY throw — it is not
+ * gated on an error allow-list). Since these bodies carry no `externalId` the
+ * orchestrator cannot dedupe, so exceeding the timeout converts one billable
+ * job into up to three.
+ *
+ * The bound is half of 300 rather than 300 itself because AT the timeout the
+ * two outcomes are a race — the graceful 202 and the billed retry storm are
+ * decided by jitter. A guard whose ceiling equals the hazard admits the
+ * boundary value: with this at 300, `CHAT_COMPLETION_WAIT_SECONDS = 300`
+ * passed every test in this file. Halving it makes that boundary fail while
+ * still leaving generous room above any real completion.
+ *
+ * The repo's own debug endpoint independently bounds its wait with `.max(120)`
+ * (`src/pages/api/testing/xguard-test.ts`), which sits under this.
  */
-const MAX_WAIT_SECONDS = 300;
+const MAX_WAIT_SECONDS = 150;
 
 const { mockSubmitWorkflow } = vi.hoisted(() => ({ mockSubmitWorkflow: vi.fn() }));
 
@@ -93,18 +104,35 @@ describe('orchestratorChatCompletion — the `wait` it sends is a SECONDS value'
 });
 
 /**
- * Repo-wide seam guard. The behavioural test above pins ONE call site; this
- * pins the RELATIONSHIP — the set of places that hand a `wait` to the v2
- * workflow API — so a new site cannot be added below the radar, and an existing
- * one cannot silently grow a millisecond value.
+ * Repo-wide seam guard.
+ *
+ * SCOPE, stated precisely, because a guard that claims coverage it does not
+ * have is worse than one that admits its limits: this bounds every `wait:`
+ * whose value is a NUMBER RESOLVABLE STATICALLY — a literal, or a same-file
+ * `const`. It is deliberately NOT scoped to `query: { … }`, because the two
+ * `orchestrator.service.ts` wrappers forward an externally-supplied
+ * `wait?: number` in via ES shorthand (`query: wait ? { wait } : undefined`),
+ * and their callers — `text-output-moderation.ts`, `scanner-policies-test`,
+ * `xguard-test`, and `submitTextModeration`, reachable from 5 modules — write
+ * the actual number at THEIR call site under a plain `wait:` key. A scan
+ * anchored on `query:` would miss all of them, so a new caller passing `60000`
+ * through `submitTextModeration` would sail straight past this file.
+ *
+ * What it CANNOT bound is a value only known at runtime. Those are enumerated
+ * separately below and pinned by ledger, not by value.
  */
-describe('every v2 `query: { wait }` site in src/ passes seconds', () => {
+describe('every statically-resolvable `wait:` in src/ is a seconds value', () => {
   const SRC = path.resolve(__dirname, '../../../..'); // -> src/
-  const QUERY_WAIT = /query:\s*\{\s*wait:\s*([A-Za-z0-9_]+)\s*\}/g;
+  // Any `wait:` property, wherever it appears — plus the ES-shorthand `{ wait }`
+  // forward, captured as the sentinel token `wait` so it lands in the runtime
+  // bucket rather than vanishing. Dots are allowed in the token so a forward
+  // like `wait: input.wait` is SEEN and classified, not silently unmatched.
+  const WAIT_SITE = /(?:\bwait:\s*([A-Za-z0-9_.]+)|\{\s*(wait)\s*\})/g;
 
-  /** Resolve a `query: { wait: X }` token: a numeric literal, or a same-file `const X = <number>`. */
+  /** Resolve a `wait` token: a numeric literal, or a same-file `const X = <number>`. */
   const resolveWait = (token: string, source: string): number | undefined => {
     if (/^\d+$/.test(token)) return Number(token);
+    if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(token)) return undefined; // `input.wait` etc.
     const decl = new RegExp(`const\\s+${token}\\s*=\\s*(\\d[\\d_]*)\\s*;`).exec(source);
     return decl ? Number(decl[1].replace(/_/g, '')) : undefined;
   };
@@ -121,58 +149,118 @@ describe('every v2 `query: { wait }` site in src/ passes seconds', () => {
     return out;
   };
 
+  /**
+   * Strip comments before matching. Without this the scan reports prose: this
+   * repo documents waits IN comments (`// A \`wait: 30\` request …`) and keeps a
+   * commented-out `// wait: true,`, all of which were picked up as real sites.
+   * A ledger polluted by prose is one nobody trusts, and a commented example is
+   * exactly where a wrong value hides in plain sight.
+   *
+   * The line-comment rule ignores a `//` preceded by `:` so a URL inside a
+   * string is not mistaken for a comment.
+   */
+  const stripComments = (src: string) =>
+    src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/(^|[^:])\/\/.*$/gm, '$1');
+
+  /**
+   * A zod/schema builder in the value position declares the SHAPE of an inbound
+   * HTTP param on one of our own endpoints — it is not an outbound orchestrator
+   * wait. Excluded so the ledger tracks values we SEND. (The one such endpoint
+   * that does forward to the orchestrator, `xguard-test.ts`, is still tracked
+   * via its actual forward, `wait: input.wait`.)
+   */
+  const isSchemaDecl = (token: string) => /^z(\.|$)/.test(token) || /Schema/.test(token);
+
   const sites = walk(SRC).flatMap((file) => {
-    const source = fs.readFileSync(file, 'utf8');
-    return [...source.matchAll(QUERY_WAIT)].map((m) => ({
-      file: path.relative(SRC, file),
-      token: m[1],
-      seconds: resolveWait(m[1], source),
-    }));
+    const raw = fs.readFileSync(file, 'utf8');
+    const source = stripComments(raw);
+    return [...source.matchAll(WAIT_SITE)]
+      .map((m) => {
+        const token = m[1] ?? m[2];
+        return {
+          file: path.relative(SRC, file),
+          token,
+          seconds: resolveWait(token, source),
+        };
+      })
+      .filter((s) => !isSchemaDecl(s.token));
   });
+  const numeric = sites.filter((s) => s.seconds !== undefined);
+  const runtime = sites.filter((s) => s.seconds === undefined);
 
-  // POSITIVE CONTROL. A zero here would be indistinguishable from a scanner
-  // wired to nothing — the regex silently not matching would make every
-  // assertion below vacuously pass.
-  it('the scanner actually finds sites (positive control)', () => {
-    expect(sites.length).toBeGreaterThanOrEqual(5);
-  });
-
-  // A site whose value is only known at runtime cannot be bounded statically,
-  // so it must instead make the unit legible at the call site — which is the
-  // root cause this whole file guards. Both current such sites comply
-  // (`waitSeconds`, `PERCEPTUAL_HASH_WAIT_SECONDS`), and each is separately
-  // clamped in its own module (MAX_BLOCK_POLL_WAIT_SECONDS = 15; the perceptual
-  // hash pairs its 30 with a 45s AbortSignal).
-  it('a runtime-valued wait names its unit', () => {
-    const unresolved = sites.filter((s) => s.seconds === undefined);
-    expect(unresolved.filter((s) => !/seconds/i.test(s.token))).toEqual([]);
+  // POSITIVE CONTROL. A reassuring zero here would be indistinguishable from a
+  // scanner wired to nothing. This asserts BOTH buckets are non-empty and that
+  // the scanner reaches beyond this test's own neighbourhood — a bound that the
+  // ledger tests below cannot also satisfy trivially, so it carries independent
+  // signal rather than only failing alongside them.
+  it('the scanner actually finds sites in both buckets (positive control)', () => {
+    expect(numeric.length).toBeGreaterThan(0);
+    expect(runtime.length).toBeGreaterThan(0);
+    expect(new Set(sites.map((s) => s.file)).size).toBeGreaterThan(3);
+    // It must see the site this PR fixes, and the forwarding wrappers that the
+    // previous `query:`-anchored regex could not match at all.
+    expect(sites.map((s) => s.file)).toContain('server/services/comics/orchestrator-chat.ts');
+    expect(sites.map((s) => s.file)).toContain(
+      'server/services/orchestrator/orchestrator.service.ts'
+    );
   });
 
   // NEGATIVE CONTROL. Proves the resolver+bound can go red on a known-bad
-  // input, so the green verdict above is a fact about the code and not about a
-  // broken harness.
+  // input, so the green verdicts here are facts about the code and not about a
+  // broken harness. Covers both resolvable shapes.
   it('the resolver rejects a known-bad millisecond value (negative control)', () => {
     expect(resolveWait('60000', '')).toBe(60000);
     expect(resolveWait('60000', '') as number).toBeGreaterThan(MAX_WAIT_SECONDS);
     expect(resolveWait('X', 'const X = 60_000;')).toBe(60000);
+    // and it must NOT pretend to resolve a member expression
+    expect(resolveWait('input.wait', 'const wait = 5;')).toBeUndefined();
   });
 
-  it('no statically-known site exceeds the seconds envelope', () => {
-    const offenders = sites.filter((s) => s.seconds !== undefined && s.seconds > MAX_WAIT_SECONDS);
+  // The comment stripper is itself a harness component, so it gets its own
+  // controls: it must remove a commented site (else the ledger fills with
+  // prose) and must NOT eat a real one hiding behind a URL.
+  it('the comment stripper drops prose but keeps code (controls)', () => {
+    expect(stripComments('// wait: 60000,\nconst a = 1;')).not.toContain('60000');
+    expect(stripComments('/* wait: 60000 */ const a = 1;')).not.toContain('60000');
+    expect(stripComments('const u = "https://x.y"; f({ wait: 30 });')).toContain('wait: 30');
+  });
+
+  // THE bound. Any `wait:` anywhere in src/ that resolves to a number must be a
+  // plausible seconds value — including one written at a caller that forwards
+  // into the orchestrator wrappers rather than calling the client directly.
+  it('no statically-resolvable wait exceeds the seconds envelope', () => {
+    const offenders = numeric.filter((s) => (s.seconds as number) > MAX_WAIT_SECONDS);
     expect(offenders).toEqual([]);
   });
 
-  // Fails when the set GROWS or SHRINKS. A new v2 wait site is a deliberate
+  // Fails when the set GROWS or SHRINKS. A new wait site is a deliberate
   // decision about how long an api pod holds a socket, so it should land in a
   // diff that says so rather than arriving unnoticed.
-  it('matches the known ledger of v2 wait sites', () => {
-    expect(new Set(sites.map((s) => s.file))).toEqual(
+  it('matches the known ledger of numeric wait sites', () => {
+    expect(new Set(numeric.map((s) => `${s.file}:${s.token}`))).toEqual(
       new Set([
-        'server/routers/blocks.router.ts',
-        'server/services/comics/orchestrator-chat.ts',
-        'server/services/orchestrator/orchestrator.service.ts',
-        'server/services/product-badge.service.ts',
-        'server/services/training.service.ts',
+        'server/services/blocks/steps/text-output-moderation.ts:SCAN_WAIT_SECONDS',
+        'server/services/comics/orchestrator-chat.ts:CHAT_COMPLETION_WAIT_SECONDS',
+        'server/services/orchestrator/orchestrator.service.ts:PERCEPTUAL_HASH_WAIT_SECONDS',
+        'server/services/product-badge.service.ts:30',
+        'server/services/training.service.ts:0',
+      ])
+    );
+  });
+
+  // The runtime bucket CANNOT be value-checked here — these forward a number
+  // supplied by a caller (or, for `training.service.ts`, the v1 jobs API's
+  // boolean `wait`, which is a different contract entirely and correctly not a
+  // number). So they are pinned by ledger: a NEW unbounded forwarding path has
+  // to be declared here, which is the point at which someone has to think about
+  // whether it needs a clamp of its own.
+  it('matches the known ledger of runtime-valued wait sites', () => {
+    expect(new Set(runtime.map((s) => `${s.file}:${s.token}`))).toEqual(
+      new Set([
+        'server/routers/blocks.router.ts:waitSeconds',
+        'server/services/orchestrator/orchestrator.service.ts:wait',
+        'server/services/training.service.ts:true',
+        'pages/api/testing/xguard-test.ts:input.wait',
       ])
     );
   });

--- a/src/server/services/comics/__tests__/orchestrator-chat.wait-unit.test.ts
+++ b/src/server/services/comics/__tests__/orchestrator-chat.wait-unit.test.ts
@@ -158,9 +158,7 @@ describe('every v2 `query: { wait }` site in src/ passes seconds', () => {
   });
 
   it('no statically-known site exceeds the seconds envelope', () => {
-    const offenders = sites.filter(
-      (s) => s.seconds !== undefined && s.seconds > MAX_WAIT_SECONDS
-    );
+    const offenders = sites.filter((s) => s.seconds !== undefined && s.seconds > MAX_WAIT_SECONDS);
     expect(offenders).toEqual([]);
   });
 

--- a/src/server/services/comics/__tests__/orchestrator-chat.wait-unit.test.ts
+++ b/src/server/services/comics/__tests__/orchestrator-chat.wait-unit.test.ts
@@ -118,22 +118,61 @@ describe('orchestratorChatCompletion — the `wait` it sends is a SECONDS value'
  * anchored on `query:` would miss all of them, so a new caller passing `60000`
  * through `submitTextModeration` would sail straight past this file.
  *
- * What it CANNOT bound is a value only known at runtime. Those are enumerated
- * separately below and pinned by ledger, not by value.
+ * Values fall in exactly three buckets, and each is handled differently rather
+ * than being quietly folded into "resolvable":
+ *   - LITERAL / same-file `const`  -> bounded by value.
+ *   - identifier or member access  -> runtime forward. CANNOT be bounded here;
+ *     pinned by ledger only, so a new one has to be declared.
+ *   - anything else (arithmetic, a call, a ternary) -> REJECTED outright. This
+ *     bucket exists because a token-shaped scan truncates `60 * 1000` to `60`
+ *     and then reports it as in-envelope — the millisecond bug wearing the
+ *     costume of a fix.
+ *
+ * This scope statement is load-bearing; an earlier revision of this file
+ * claimed to pin "every v2 `query: { wait }` site" while an ES-shorthand
+ * forward and a quoted key both walked past it.
  */
 describe('every statically-resolvable `wait:` in src/ is a seconds value', () => {
   const SRC = path.resolve(__dirname, '../../../..'); // -> src/
-  // Any `wait:` property, wherever it appears — plus the ES-shorthand `{ wait }`
-  // forward, captured as the sentinel token `wait` so it lands in the runtime
-  // bucket rather than vanishing. Dots are allowed in the token so a forward
-  // like `wait: input.wait` is SEEN and classified, not silently unmatched.
-  const WAIT_SITE = /(?:\bwait:\s*([A-Za-z0-9_.]+)|\{\s*(wait)\s*\})/g;
+  /**
+   * Any `wait` property, wherever it appears — plus the ES-shorthand `{ wait }`
+   * forward, captured as the sentinel token `wait` so it lands in the runtime
+   * bucket rather than vanishing.
+   *
+   * The key may be QUOTED. That is not hypothetical tidiness: with an
+   * unquoted-only key pattern, a planted `{ "wait": 60000 }` passed all 8 tests
+   * — a 60,000-SECOND value fully bypassing the guard.
+   *
+   * The value is captured WHOLE (to the next `,`/`}`/newline) rather than as a
+   * token, because a token pattern stops at the first word and silently
+   * TRUNCATES an expression: `wait: 60 * 1000` was read as `60` and blessed as
+   * in-envelope, which is precisely the millisecond-conversion shape this file
+   * exists to catch.
+   *
+   * The key is anchored to an object-KEY position (`{` or `,` or line start).
+   * Without that anchor, allowing a quoted key makes a ternary's colon look
+   * like a key separator, and `cursor: x ? 'wait' : 'pointer'` in
+   * `CandidateImageModal.tsx` reported as a wait site with the value
+   * `'pointer'`.
+   */
+  const WAIT_SITE = /(?:[{,]|^)\s*["']?\bwait["']?\s*:\s*([^,}\n]+)|\{\s*(wait)\s*\}/gm;
 
-  /** Resolve a `wait` token: a numeric literal, or a same-file `const X = <number>`. */
-  const resolveWait = (token: string, source: string): number | undefined => {
-    if (/^\d+$/.test(token)) return Number(token);
-    if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(token)) return undefined; // `input.wait` etc.
-    const decl = new RegExp(`const\\s+${token}\\s*=\\s*(\\d[\\d_]*)\\s*;`).exec(source);
+  type Kind = 'literal' | 'identifier' | 'expression';
+  const classify = (value: string): Kind => {
+    if (/^\d[\d_]*$/.test(value)) return 'literal';
+    // A bare identifier or member access (`input.wait`) — a runtime forward.
+    if (/^[A-Za-z_$][A-Za-z0-9_$.]*$/.test(value)) return 'identifier';
+    // Anything else: arithmetic, a call, a ternary, a template. NOT resolvable,
+    // and deliberately NOT silently truncated to its first number.
+    return 'expression';
+  };
+
+  /** Resolve a `wait` value: an integer literal, or a same-file `const X = <integer>`. */
+  const resolveWait = (value: string, source: string): number | undefined => {
+    const kind = classify(value);
+    if (kind === 'literal') return Number(value.replace(/_/g, ''));
+    if (kind === 'expression') return undefined;
+    const decl = new RegExp(`const\\s+${value}\\s*=\\s*(\\d[\\d_]*)\\s*;`).exec(source);
     return decl ? Number(decl[1].replace(/_/g, '')) : undefined;
   };
 
@@ -176,17 +215,19 @@ describe('every statically-resolvable `wait:` in src/ is a seconds value', () =>
     const source = stripComments(raw);
     return [...source.matchAll(WAIT_SITE)]
       .map((m) => {
-        const token = m[1] ?? m[2];
+        const token = (m[1] ?? m[2]).trim();
         return {
           file: path.relative(SRC, file),
           token,
+          kind: classify(token),
           seconds: resolveWait(token, source),
         };
       })
       .filter((s) => !isSchemaDecl(s.token));
   });
   const numeric = sites.filter((s) => s.seconds !== undefined);
-  const runtime = sites.filter((s) => s.seconds === undefined);
+  const runtime = sites.filter((s) => s.seconds === undefined && s.kind !== 'expression');
+  const expressions = sites.filter((s) => s.kind === 'expression');
 
   // POSITIVE CONTROL. A reassuring zero here would be indistinguishable from a
   // scanner wired to nothing. This asserts BOTH buckets are non-empty and that
@@ -216,6 +257,48 @@ describe('every statically-resolvable `wait:` in src/ is a seconds value', () =>
     expect(resolveWait('input.wait', 'const wait = 5;')).toBeUndefined();
   });
 
+  /**
+   * BYPASS CONTROLS. Each of these shapes was planted in a real source file and
+   * run against this suite; the first two passed 8/8 before this fix, i.e. a
+   * 60,000-second value fully escaped the guard. They are pinned here as unit
+   * cases so the escape cannot silently reopen.
+   */
+  const scan = (src: string) => [...src.matchAll(WAIT_SITE)].map((m) => (m[1] ?? m[2]).trim());
+
+  it('a quoted key is still seen (bypass control)', () => {
+    expect(scan('f({ "wait": 60000 });')).toEqual(['60000']);
+    expect(scan("f({ 'wait': 60000 });")).toEqual(['60000']);
+    expect(resolveWait('60000', '')).toBe(60000);
+    // …and the unquoted and multi-line forms still match.
+    expect(scan('f({ wait: 30 });')).toEqual(['30']);
+    expect(scan('f({\n  wait: 9,\n});')).toEqual(['9']);
+  });
+
+  // The anchor that makes the quoted form safe. A ternary VALUE `'wait'` is not
+  // a key, and treating it as one made a CSS `cursor` rule report as a wait site.
+  it("a ternary value 'wait' is not mistaken for a key (control)", () => {
+    expect(scan("style={{ cursor: busy ? 'wait' : 'pointer' }}")).toEqual([]);
+  });
+
+  it('an arithmetic value is NOT truncated to its first number (bypass control)', () => {
+    // The old token pattern read `60 * 1000` as `60` and blessed it as in-range.
+    // It must now refuse to resolve, so it cannot be bounds-checked into safety.
+    expect(classify('60 * 1000')).toBe('expression');
+    expect(resolveWait('60 * 1000', '')).toBeUndefined();
+    expect(classify('60000')).toBe('literal');
+    expect(classify('input.wait')).toBe('identifier');
+  });
+
+  /**
+   * An expression-valued `wait` is rejected outright rather than ledgered. This
+   * is the one shape that is ALWAYS suspicious here: `N * 1000` is literally the
+   * millisecond conversion, and no legitimate site needs to compute a wait
+   * inline — the repo's convention is a named `*_WAIT_SECONDS` constant.
+   */
+  it('no wait is written as an inline expression', () => {
+    expect(expressions.map((s) => `${s.file}:${s.token}`)).toEqual([]);
+  });
+
   // The comment stripper is itself a harness component, so it gets its own
   // controls: it must remove a commented site (else the ledger fills with
   // prose) and must NOT eat a real one hiding behind a URL.
@@ -228,6 +311,11 @@ describe('every statically-resolvable `wait:` in src/ is a seconds value', () =>
   // THE bound. Any `wait:` anywhere in src/ that resolves to a number must be a
   // plausible seconds value — including one written at a caller that forwards
   // into the orchestrator wrappers rather than calling the client directly.
+  // NOTE on mutation coverage: flipping `>` to `>=` here SURVIVES, because no
+  // live site sits at exactly MAX_WAIT_SECONDS. That is a real gap in the
+  // sweep, recorded rather than papered over with a fixture whose only purpose
+  // is to kill the mutant — the boundary itself is exercised by the
+  // CHAT_COMPLETION_WAIT_SECONDS mutation matrix (150 passes, 151 fails).
   it('no statically-resolvable wait exceeds the seconds envelope', () => {
     const offenders = numeric.filter((s) => (s.seconds as number) > MAX_WAIT_SECONDS);
     expect(offenders).toEqual([]);

--- a/src/server/services/comics/orchestrator-chat.ts
+++ b/src/server/services/comics/orchestrator-chat.ts
@@ -8,6 +8,32 @@ type ChatMessage = {
 };
 
 /**
+ * How long to hold the submit open waiting for the completion, in SECONDS.
+ *
+ * The orchestrator binds `?wait` as `[FromQuery] int` and applies it as
+ * `TimeSpan.FromSeconds(wait)` — seconds, and it applies NO server-side clamp,
+ * so whatever we send is held verbatim. This constant is named for its unit for
+ * the same reason `SCAN_WAIT_SECONDS` / `PERCEPTUAL_HASH_WAIT_SECONDS` are: the
+ * unit is invisible at the call site, and this site previously passed `60000`
+ * (a millisecond value) — a request to hold the socket for ~16.7 hours.
+ *
+ * 60s is chosen to sit in the gap between two hard bounds:
+ *  - ABOVE what a `gpt-4o-mini` completion needs (both consumers cap at
+ *    maxTokens 2048/512, i.e. seconds). Expiring early is not free: the
+ *    orchestrator returns 202 with no step output, which makes `content` empty
+ *    — `prompt-enhance` degrades to its fallback, but `story-plan` throws and
+ *    refunds the user's Buzz.
+ *  - WELL BELOW undici's ~300s default headers timeout. That matters because
+ *    `submitWorkflow` only bounds an attempt with `AbortSignal.timeout` on the
+ *    whatIf path; a real submit like this one is unbounded client-side. If the
+ *    wait outlives the headers timeout, the fetch throws instead of returning a
+ *    202, `submitWorkflowWithRetry` classifies that as transient and re-submits
+ *    — and this body carries no `externalId`, so the orchestrator cannot dedupe
+ *    and the user is billed for up to 3 chat completions.
+ */
+const CHAT_COMPLETION_WAIT_SECONDS = 60;
+
+/**
  * Submit a chat completion via the orchestrator workflow API.
  * The user's Buzz is deducted automatically via the token.
  */
@@ -42,7 +68,7 @@ export async function orchestratorChatCompletion(input: {
       tags: ['comics'],
       currencies: BuzzTypes.toOrchestratorType(currencies ?? ['yellow']),
     },
-    query: { wait: 60000 },
+    query: { wait: CHAT_COMPLETION_WAIT_SECONDS },
   });
 
   const step = workflow.steps?.[0] as ChatCompletionStep | undefined;

--- a/src/server/services/comics/orchestrator-chat.ts
+++ b/src/server/services/comics/orchestrator-chat.ts
@@ -46,9 +46,19 @@ type ChatMessage = {
  * of a percent while holding a Node request open. Day-to-day variance is what
  * decides it: on the two worst of seven days the median moved from <5s into
  * (25,50] and the =<50s fraction fell to ~91%, so 60s degrades materially
- * exactly when the orchestrator is already struggling. That duration INCLUDES
- * queue time (mean claim 7.9s; 27.6% of jobs wait >5s to be claimed), so this
- * wait competes with scheduler backlog, not just token generation.
+ * exactly when the orchestrator is already struggling.
+ *
+ * That duration INCLUDES time before the job was claimed — `JobGrain.cs` sets
+ * `JobDuration = UtcNow - job.CreatedAt`, so the wait competes with scheduler
+ * backlog, not just token generation. HOW MUCH of it is queue is deliberately
+ * NOT quoted here, because it is not cleanly derivable from the metrics we
+ * have: `ClaimDuration = UtcNow - claim.CreatedDate` measures how long a claim
+ * LASTED, not how long the job waited for one, and `IsFinalClaimEvent` also
+ * fires on Rejected/LateRejected/ClaimExpired, so ONE job emits SEVERAL claim
+ * observations against a single duration observation. The two means are over
+ * different populations; subtracting them gives ~5s, while dividing the claim
+ * sum by the job count gives ~0s. A 260x spread between two defensible-looking
+ * estimates is the tell that neither is a measurement.
  *
  * 🔴 CAVEAT: that slice could not be confirmed as this code path. The job
  * metrics carry no `model` or `tags` label, so `gpt-4o-mini` / `tags:['comics']`
@@ -63,6 +73,15 @@ type ChatMessage = {
  * returns its fallback with NO refund — a silent charge for a discarded
  * completion. Money is unchanged in that band (billed 1x either way), so it is
  * a quality/UX risk rather than a billing one.
+ *
+ * ❓ OPEN: civitai.com is Cloudflare-proxied, and CF's non-enterprise origin
+ * read timeout is ~100s (524). If that applies to the browser-driven
+ * `iterateGenerate` caller, it can never observe the last ~20s of a 120s hold,
+ * making 120 worth no more than ~90 for that path. NOT a regression this
+ * introduces — the previous value was strictly worse — and the origin side is
+ * not the constraint (Traefik is configured `readTimeout: 1h`, `writeTimeout:
+ * 0`). Unresolved because the CF plan tier is not recorded in the infra repo
+ * and a 524 is generated at the edge, so it never reaches origin logs.
  *
  * 🔴 A long-poll can never be the ONLY path: ~1% of jobs run past any value
  * that is safe to hold here. Callers must tolerate the empty-content result.

--- a/src/server/services/comics/orchestrator-chat.ts
+++ b/src/server/services/comics/orchestrator-chat.ts
@@ -17,21 +17,57 @@ type ChatMessage = {
  * unit is invisible at the call site, and this site previously passed `60000`
  * (a millisecond value) — a request to hold the socket for ~16.7 hours.
  *
- * 60s is chosen to sit in the gap between two hard bounds:
- *  - ABOVE what a `gpt-4o-mini` completion needs (both consumers cap at
- *    maxTokens 2048/512, i.e. seconds). Expiring early is not free: the
- *    orchestrator returns 202 with no step output, which makes `content` empty
- *    — `prompt-enhance` degrades to its fallback, but `story-plan` throws and
- *    refunds the user's Buzz.
- *  - WELL BELOW undici's ~300s default headers timeout. That matters because
- *    `submitWorkflow` only bounds an attempt with `AbortSignal.timeout` on the
- *    whatIf path; a real submit like this one is unbounded client-side. If the
- *    wait outlives the headers timeout, the fetch throws instead of returning a
- *    202, `submitWorkflowWithRetry` classifies that as transient and re-submits
- *    — and this body carries no `externalId`, so the orchestrator cannot dedupe
- *    and the user is billed for up to 3 chat completions.
+ * This is NOT a comics-only path. `prompt-enhance.ts` is reached from
+ * `orchestrator.router.ts` `iterateGenerate`, a plain `protectedProcedure` with
+ * no flag middleware and `enhance` defaulting to `true` — so any logged-in user
+ * hits it on the general generation surface. Only `comics.router.ts` is
+ * mod-gated. Treat changes here as touching general generation.
+ *
+ * The CEILING is measured. undici's default headers timeout was measured at
+ * 300.7s (`UND_ERR_HEADERS_TIMEOUT`) against a server that accepts and never
+ * responds, and `submitWorkflow` only bounds an attempt with
+ * `AbortSignal.timeout` on the whatIf path — a real submit like this one is
+ * unbounded client-side. If the wait outlives the headers timeout the fetch
+ * throws instead of returning a graceful 202, and `submitWorkflowWithRetry`
+ * re-submits: it retries on ANY throw, it is NOT gated on an error allow-list.
+ * This body carries no `externalId`, so the orchestrator cannot dedupe and the
+ * user is billed for up to 3 chat completions. 120s keeps a 2.5x margin.
+ *
+ * The FLOOR is measured, with a caveat about the population. From
+ * `orchestration_jobs_duration_seconds{job_type="chatCompletion"}` over 7d, on
+ * the `ecosystem=other, provider=Civitai` slice (n=1362) — the closest
+ * available analogue to this path:
+ *
+ *     within 60s   96.3% - 98.8%
+ *     within 120s  99.3% - 99.9%
+ *
+ * (ranges, not points: 60 and 120 fall between OTel default histogram buckets
+ * and were NOT interpolated.) 120s sits at the knee — beyond it you buy tenths
+ * of a percent while holding a Node request open. Day-to-day variance is what
+ * decides it: on the two worst of seven days the median moved from <5s into
+ * (25,50] and the =<50s fraction fell to ~91%, so 60s degrades materially
+ * exactly when the orchestrator is already struggling. That duration INCLUDES
+ * queue time (mean claim 7.9s; 27.6% of jobs wait >5s to be claimed), so this
+ * wait competes with scheduler backlog, not just token generation.
+ *
+ * 🔴 CAVEAT: that slice could not be confirmed as this code path. The job
+ * metrics carry no `model` or `tags` label, so `gpt-4o-mini` / `tags:['comics']`
+ * are not selectable; the slice was identified by component topology
+ * (OpenRouter traffic is fronted by spine-controller and reports as
+ * `provider=Civitai`). There is NO dp-prod-side span for this submit at all, so
+ * nothing measures the long-poll envelope as the Node process experiences it.
+ *
+ * Why the floor matters: an expired wait returns a 202 with no step output and
+ * this function does not check status, so `content` silently becomes ''.
+ * `story-plan.ts` refunds (best-effort) and throws, but `prompt-enhance.ts`
+ * returns its fallback with NO refund — a silent charge for a discarded
+ * completion. Money is unchanged in that band (billed 1x either way), so it is
+ * a quality/UX risk rather than a billing one.
+ *
+ * 🔴 A long-poll can never be the ONLY path: ~1% of jobs run past any value
+ * that is safe to hold here. Callers must tolerate the empty-content result.
  */
-const CHAT_COMPLETION_WAIT_SECONDS = 60;
+const CHAT_COMPLETION_WAIT_SECONDS = 120;
 
 /**
  * Submit a chat completion via the orchestrator workflow API.

--- a/src/server/services/comics/orchestrator-chat.ts
+++ b/src/server/services/comics/orchestrator-chat.ts
@@ -42,23 +42,30 @@ type ChatMessage = {
  *     within 120s  99.3% - 99.9%
  *
  * (ranges, not points: 60 and 120 fall between OTel default histogram buckets
- * and were NOT interpolated.) 120s sits at the knee — beyond it you buy tenths
- * of a percent while holding a Node request open. Day-to-day variance is what
- * decides it: on the two worst of seven days the median moved from <5s into
- * (25,50] and the =<50s fraction fell to ~91%, so 60s degrades materially
- * exactly when the orchestrator is already struggling.
+ * and were NOT interpolated.) The curve is at its knee in here — past ~120s you
+ * buy tenths of a percent while holding a Node request open. Day-to-day
+ * variance is what argues against the low end: on the two worst of seven days
+ * the median moved from <5s into (25,50] and the =<50s fraction fell to ~91%,
+ * so 60s degrades materially exactly when the orchestrator is already
+ * struggling. 90 sits above that degradation and below the edge cut below.
  *
- * That duration INCLUDES time before the job was claimed — `JobGrain.cs` sets
- * `JobDuration = UtcNow - job.CreatedAt`, so the wait competes with scheduler
- * backlog, not just token generation. HOW MUCH of it is queue is deliberately
- * NOT quoted here, because it is not cleanly derivable from the metrics we
- * have: `ClaimDuration = UtcNow - claim.CreatedDate` measures how long a claim
- * LASTED, not how long the job waited for one, and `IsFinalClaimEvent` also
- * fires on Rejected/LateRejected/ClaimExpired, so ONE job emits SEVERAL claim
- * observations against a single duration observation. The two means are over
- * different populations; subtracting them gives ~5s, while dividing the claim
- * sum by the job count gives ~0s. A 260x spread between two defensible-looking
- * estimates is the tell that neither is a measurement.
+ * That duration INCLUDES time before the job was claimed (`JobGrain.cs`:
+ * `JobDuration = UtcNow - job.CreatedAt`), but queue is a SMALL part of it —
+ * so the number above is essentially execution time, not backlog.
+ * `orchestration_jobs_priority_delay_seconds_total` records exactly this
+ * per job (`JobDuration - ClaimDuration`, i.e. job creation -> start of the
+ * claim that finished it): 1166.63s over 1428 jobs = **0.82s mean**, ~6% of
+ * the 13.8s mean job duration, same window and selector.
+ *
+ * Do NOT compute this by subtracting the two duration histograms.
+ * `ClaimDuration = UtcNow - claim.CreatedDate` is how long a claim LASTED, not
+ * how long a job waited for one, and `IsFinalClaimEvent` also fires on
+ * Rejected/LateRejected/ClaimExpired — measured, 2294 claim observations
+ * against 1428 job observations (765 of them rejected claims). The two means
+ * are over different populations, and the two plausible subtractions give ~5s
+ * and ~0s. Use `priority_delay`. (It is time-to-FINAL-claim, so it still
+ * includes time burnt by earlier rejected attempts; pure first-claim queue wait
+ * is not exposed by any current metric.)
  *
  * 🔴 CAVEAT: that slice could not be confirmed as this code path. The job
  * metrics carry no `model` or `tags` label, so `gpt-4o-mini` / `tags:['comics']`
@@ -74,19 +81,36 @@ type ChatMessage = {
  * completion. Money is unchanged in that band (billed 1x either way), so it is
  * a quality/UX risk rather than a billing one.
  *
- * ❓ OPEN: civitai.com is Cloudflare-proxied, and CF's non-enterprise origin
- * read timeout is ~100s (524). If that applies to the browser-driven
- * `iterateGenerate` caller, it can never observe the last ~20s of a 120s hold,
- * making 120 worth no more than ~90 for that path. NOT a regression this
- * introduces — the previous value was strictly worse — and the origin side is
- * not the constraint (Traefik is configured `readTimeout: 1h`, `writeTimeout:
- * 0`). Unresolved because the CF plan tier is not recorded in the infra repo
- * and a 524 is generated at the edge, so it never reaches origin logs.
+ * 🔴 THE EDGE, which is why this is 90 and not 120. `iterateGenerate` is
+ * browser-driven, so its response crosses Cloudflare. The zone's plan is
+ * "Business Website" (read from the CF API) — NOT Enterprise, and
+ * `proxy_read_timeout` is Enterprise-only, so the ~100s default applies and
+ * cannot have been raised. A wait longer than that is not merely wasted: the
+ * browser gets a 524 while the origin keeps holding the socket AND the workflow
+ * keeps running and billing, so the user sees an error for a completion that
+ * was about to succeed. 90 keeps ~10s of margin under it. The cost is small —
+ * between the 60s and 120s rows above, i.e. a fraction of a percent — and it is
+ * a fraction that browser callers could never have collected anyway.
+ *
+ * Two honesty notes. The 100s is inferred from the plan tier, NOT read: the
+ * available token lacks Zone-Settings:Read, so `GET /zones/{id}/settings/
+ * proxy_read_timeout` returns Unauthorized. And origin logs neither confirm nor
+ * refute it — plenty of requests return 200 well past 100s, but CF can 524 the
+ * browser while leaving the origin connection open, which is invisible from
+ * this side. (There IS an unexplained hard abort at ~125.0s: 4,158 status-499s
+ * over 3d clustered at 125.006-125.011s across 256 client IPs. Not attributed —
+ * no evidence names the actor — but 90 sits under it too.)
+ *
+ * The robust fix, if this ever needs to be longer: CF's 524 clock is a READ
+ * timeout that resets on any byte from origin, so a long-poll that flushes
+ * headers early or emits a keepalive never accumulates toward it, and the plan
+ * tier stops mattering. That is a change to the orchestrator's response
+ * behaviour, not to this constant.
  *
  * 🔴 A long-poll can never be the ONLY path: ~1% of jobs run past any value
  * that is safe to hold here. Callers must tolerate the empty-content result.
  */
-const CHAT_COMPLETION_WAIT_SECONDS = 120;
+const CHAT_COMPLETION_WAIT_SECONDS = 90;
 
 /**
  * Submit a chat completion via the orchestrator workflow API.


### PR DESCRIPTION
`src/server/services/comics/orchestrator-chat.ts` passed `query: { wait: 60000 }` to the v2 workflow submit. `wait` is **seconds**, so this asked the orchestrator to hold the connection open for **~16.7 hours**.

> **Not a comics-only path — read §3 first.** Despite the filename, this is reached from `orchestrator.router.ts` `iterateGenerate`, a plain `protectedProcedure` with **no flag middleware**, so it is on the **general generation surface** for any logged-in user.

## 1. The unit — seconds, confirmed from the server, not inferred from call sites

The orchestrator binds and applies it directly, on both handlers:

```csharp
[FromQuery] int wait = 0,                                  // SubmitWorkflow / GetWorkflow
await workflowEventObserver.Task.WaitAsync(TimeSpan.FromSeconds(wait), cancellationToken);
```

The generated contract (`@civitai/client` `types.gen.d.ts`) types it `wait?: number` on exactly two operations — `SubmitWorkflowData` and `GetWorkflowData`, both under `query` — and its prose never states a unit. That is why TypeScript could not catch this: `60000` seconds and `60000` milliseconds are the same type.

Every other v2 site in this repo is already seconds-scale: `SCAN_WAIT_SECONDS = 10`, `PERCEPTUAL_HASH_WAIT_SECONDS = 30`, `product-badge.service.ts` `30`, `training.service.ts` `0`, `MAX_BLOCK_POLL_WAIT_SECONDS = 15`, and `xguard-test.ts` bounds its input with `.max(120)`. The strongest single tell is `PERCEPTUAL_HASH_WAIT_SECONDS = 30` sitting beside `PERCEPTUAL_HASH_ABORT_MS = 45_000` — a 45-second abort guarding a wait of 30.

## 2. Does the orchestrator clamp it? **No.**

`wait` flows from the query binding into `TimeSpan.FromSeconds` with nothing in between. No `[Range]`, no `Math.Clamp`, no bounding config; the generated OpenAPI schema for the param carries no `minimum`/`maximum`. There is no request-timeout middleware and no Kestrel limits configured in that service, and a client disconnect is caught and returns `EmptyResult()` rather than erroring.

(There *is* a 100s `WaitTimeout`, but it governs the **v1 jobs** boolean `wait` — a different API, see §5. It does not bound v2.)

So the value we send is honoured verbatim.

## 3. Blast radius — the general generation surface, not mod-gated comics

**Reachability.** `prompt-enhance.ts` → `orchestratorChatCompletion` is called from `enhanceComicPrompt`, which `orchestrator.router.ts:645` invokes from `iterateGenerate` — a `protectedProcedure` with `enhance: z.boolean().default(true)` and **zero** `isFlagProtected` usages anywhere in that router. Only `comics.router.ts` is behind `comicCreator`. So both the old bug and the new 120s ceiling sit on a path any logged-in user reaches. Whoever deploys this should watch general generation, not comics.

**Why it went unnoticed.** Chat completions normally finish in seconds, so the wait returns immediately and the value acts only as a ceiling. The exposure is entirely in the unhappy path:

- **No client-side timeout here.** `submitWorkflow` scopes the per-attempt `AbortSignal.timeout` to whatIf only (`isWhatif ? { perAttemptTimeoutMs: … } : undefined`), and `submitWorkflowWithRetry` documents `undefined ⇒ unbounded attempts`. This caller passes no `signal`.
- **The real ceiling is undici's headers timeout.** Measured against a server that accepts and never responds: **300.7s**, `UND_ERR_HEADERS_TIMEOUT` (Node 26 locally; runtime image is `node:24-alpine`, same undici default).
- **That turns one billable job into up to three.** Past the headers timeout the fetch throws instead of returning a graceful 202, and `submitWorkflowWithRetry` re-submits — **it retries on ANY throw (`:496-501`) and on `!result.data && status == null` (`:505-506`); it never calls `isUpstreamNetworkError`.** (An earlier revision of this description said the retry was gated on that function's `NETWORK_CODES` list. That was wrong, and the truth is *stronger*: nothing filters the retry. Editing `NETWORK_CODES` would not have contained this — that function is used only later, at `:328`, to map a *final* failure to a 503.) These bodies carry **no `externalId`**, and the retry wrapper explicitly documents that dedupe is the caller's job, so the orchestrator cannot dedupe.

So the realised severity is not "16.7 hours" — undici cuts it — but it is not cosmetic: **the oversized value is what converts a graceful 202 into a billed retry storm.** Keeping `wait` under the headers timeout is what makes the 202 path reachable at all.

## 4. The number: 90s — measured latency, capped by the Cloudflare edge

The ceiling was always measured (300.7s). The floor was originally **asserted** — "chat completions finish in seconds" — and this PR previously shipped 60 on that basis while calling it "bracketed on both sides". That was overclaimed. It is now measured — and then capped separately by the Cloudflare edge (§7), which is what fixes the final value at 90.

From `orchestration_jobs_duration_seconds{job_type="chatCompletion", test_job="false", cluster="dp-1"}` over 7d, on the `ecosystem=other, provider=Civitai` slice (n = 1,362):

| | within 60s | within 120s |
|---|---|---|
| 7d | **96.3% – 98.8%** | **99.3% – 99.9%** |

Ranges rather than points because 60 and 120 fall between OTel default histogram buckets; **not interpolated**. p50 < 5s, p95 ∈ (25,50], p99 ∈ (75,100].

**Day-to-day variance is what rules out the low end.** On the two worst of seven days the median moved from <5s into the (25,50] bucket and the ≤50s fraction fell to ~91–92%. 60s degrades materially exactly when the orchestrator is already struggling. The knee is in the 90-120s region; past ~120s you buy tenths of a percent while holding a Node request open.

That duration **includes queue time** (mean claim 7.9s; 27.6% of jobs wait >5s to be claimed), so this wait competes with scheduler backlog, not just token generation. That the duration includes pre-claim time is established from the source: `JobGrain.cs` sets `JobDuration = UtcNow - job.CreatedAt`. **But queue is only ~6% of it** — `orchestration_jobs_priority_delay_seconds_total` records exactly this per job (`JobDuration − ClaimDuration`): 1166.63s over 1428 jobs = **0.82s mean**. So the 13.8s mean job duration is essentially execution time.

🔴 **Two things in earlier revisions of this description are retracted.** (a) A quoted queue split — "mean claim 7.9s; 27.6% of jobs wait >5s to be claimed" — and the superset argument justifying it. `ClaimDuration = UtcNow - claim.CreatedDate` measures how long a claim **lasted**, not how long a job waited for one, so the figure never described queue time; and the superset claim is refuted by measurement (`count(claim) = 2294 > count(duration) = 1428`, because `IsFinalClaimEvent` also fires on `Rejected`/`LateRejected`/`ClaimExpired` — 765 rejected claims in the window). (b) A subsequent revision then said the split was "not cleanly derivable". **That was also wrong** — `priority_delay` derives it per job, which is where the 0.82s above comes from. Do not subtract the two duration histograms: the two plausible subtractions give ~5s and ~0s, and neither is a measurement. (`priority_delay` is time-to-*final*-claim, so it still includes time burnt by earlier rejected attempts; pure first-claim queue wait is not exposed by any current metric.)

🔴 **Caveat, stated because it bounds the claim:** that slice could **not** be confirmed as this code path. The job metrics carry no `model` or `tags` label, so `gpt-4o-mini` and `tags:['comics']` are not selectable; the slice was identified by component topology (OpenRouter traffic is fronted by spine-controller and reports as `provider=Civitai`). And there is **no dp-prod-side span for this submit at all** — `http_client_request_duration_seconds` exists only on the .NET services — so nothing measures the long-poll envelope as the Node process experiences it. This is a good proxy, not a measurement of comics traffic.

**Why the floor matters at all:** an expired wait returns a 202 with no step output, and this function does not check status, so `content` silently becomes `''`. `story-plan.ts` refunds (best-effort) and throws; `prompt-enhance.ts` returns its fallback with **no refund** — a silent charge for a discarded completion. Money is unchanged in that band (billed 1× either way), so this is a quality/UX risk rather than a billing one.

🔴 **A long-poll can never be the only path.** ~1% of jobs run past any value that is safe to hold here. Callers must tolerate the empty-content result — they currently do, but not gracefully in `prompt-enhance`'s case.

## 5. The `queryParams: { wait: true }` sites are **correct** — deliberately not changed

`training.service.ts:196,248` are not a boolean-against-a-number-contract bug. They call the **legacy v1 jobs API** through `OrchestratorCaller`, whose own type declares `wait` as a boolean:

```ts
export type JobQueryParams = { id?: string; wait?: boolean };
```

The orchestrator's v1 controller binds it as `[FromQuery] bool? wait`. It typechecks exactly and reaches the wire as `?wait=true` on `POST /v1/consumer/jobs`. Two different APIs, used correctly in the same file.

## 6. Test matrix

`src/server/services/comics/__tests__/orchestrator-chat.wait-unit.test.ts` — 8 tests. Base = `origin/main` with the tests applied on top.

| Test | base | HEAD | |
|---|---|---|---|
| sends a wait inside the seconds envelope | 🔴 `expected 60000 to be less than or equal to 150` | ✅ | **regression** |
| no statically-resolvable wait exceeds the envelope | 🔴 offender `orchestrator-chat.ts:60000` | ✅ | **regression** |
| matches the ledger of numeric wait sites | 🔴 `…:60000` vs `…:CHAT_COMPLETION_WAIT_SECONDS` | ✅ | **regression** (pins the named constant, not the value) |
| sends a wait long enough for a completion to land | ✅ | ✅ | invariant guard |
| scanner finds sites in both buckets (positive control) | ✅ | ✅ | control |
| resolver rejects a known-bad ms value (negative control) | ✅ | ✅ | control |
| a quoted key is still seen (bypass control) | ✅ | ✅ | control (pins a closed escape) |
| a ternary value `'wait'` is not mistaken for a key | ✅ | ✅ | control (pins a fixed false positive) |
| an arithmetic value is not truncated (bypass control) | ✅ | ✅ | control (pins a closed escape) |
| no wait is written as an inline expression | ✅ | ✅ | invariant guard |
| comment stripper drops prose but keeps code | ✅ | ✅ | control |
| matches the ledger of runtime-valued wait sites | ✅ | ✅ | invariant guard |

**3 genuine regression tests**, each watched fail at base naming this defect. 9 are green both sides and labelled as invariant/control guards, not counted as coverage.

### Planted-bypass sweep — the guard had a demonstrated escape, now closed

An independent validation planted future-caller shapes in a real source file and ran the suite against each. Two **passed 8/8**, i.e. a 60,000-second value walked straight through. Re-run after the fix:

| planted shape | before | after |
|---|---|---|
| `wait: 60000` | caught | caught |
| `"wait": 60000` | 🔴 **BYPASSED (8/8 passed)** | caught (2 fail) |
| `'wait': 60000` | 🔴 **BYPASSED (8/8 passed)** | caught (2 fail) |
| `wait:\n 60000` (multi-line) | caught | caught (2 fail) |
| same-file `const W = 60_000` | caught | caught (2 fail) |
| `wait: 60 * 1000` | ledger only — **resolved to `60` and blessed as in-envelope** | caught (fails the new expression guard) |
| benign `wait: 90` | — | ledger only (a new site must be declared, not blocked) |

The `60 * 1000` case was the subtler defect: a token-shaped scan stops at the first word, so the millisecond conversion **read as a valid seconds value**. Values are now captured whole and classified `literal` / `identifier` / `expression`, and an expression is rejected outright rather than resolved. Fixing the quoted key also introduced a false positive on the first attempt — a CSS `cursor: busy ? 'wait' : 'pointer'` reported as a wait site — so the key is now anchored to an object-key position, with a control pinning that.

**Boundary mutation matrix** (`CHAT_COMPLETION_WAIT_SECONDS` varied, all 8 tests):

| value | result |
|---|---|
| 60000 | 🔴 2 failed — the original defect |
| 300 | 🔴 2 failed — **the audit's finding; this passed before the envelope was tightened** |
| 151 | 🔴 2 failed |
| 150 | ✅ 12 passed (at the ceiling) |
| 120 | ✅ 12 passed |
| 100 | ✅ 12 passed |
| 90 | ✅ 12 passed (shipped) |
| 0 | 🔴 2 failed — floor guard |

`MAX_WAIT_SECONDS` stays **150 — half the measured 300.7s headers timeout**. It is deliberately NOT tightened to the ~100s Cloudflare figure: CF binds only the browser-reachable callers, while background/server-side sites (`product-badge`, `training`, text-moderation) never cross the edge, so encoding a browser constraint as the repo-wide bound would be wrong. It is set because *at* the timeout the graceful 202 and the retry storm are decided by jitter; a guard whose ceiling equals the hazard admits the boundary value.

### The seam guard was rebuilt, because its old scope claim was false

The previous version scanned `query: { wait: X }` and claimed to pin "every v2 `query: { wait }` site". It did not. `orchestrator.service.ts:201` and `:470` forward an externally-supplied `wait?: number` via **ES shorthand** (`query: wait ? { wait } : undefined`), which that regex cannot match — and those two wrappers are fed by `text-output-moderation.ts`, `scanner-policies-test.service.ts`, `xguard-test.ts` and `submitTextModeration` (reachable from 5 modules). **A new caller passing `60000` through `submitTextModeration` would have sailed past all 7 tests.**

Rather than patch the regex, the scan now bounds **any statically-resolvable `wait:` anywhere in `src/`**, so a bad value is caught at whichever call site writes it, regardless of which wrapper it flows through. Two consequences found immediately:

- It was matching **comments** — this repo documents waits in prose (`// A \`wait: 30\` request …`) and keeps a commented-out `// wait: true,`. Added comment-stripping, with its own controls (must drop a commented site; must not eat a real one hiding behind a `https://` URL).
- The runtime-valued sites (forwards like `wait: input.wait`) **cannot** be value-checked statically. They are pinned by a separate ledger and the describe block now says so, instead of claiming coverage it does not have.

Other gates, all re-run after rebasing onto current `origin/main` (`851f759c20`):
- `pnpm typecheck`: **157 at base, 157 at HEAD, identical sets** by `file(line,col) TSxxxx` — 0 introduced, 0 fixed, none in touched files. `origin/main` had moved 3 commits since the previous baseline, so base was **re-measured at the new tip** rather than reusing it.
- Neighbouring suites: **122 files / 2,343 tests** green (comics, all orchestrator tests, blocks long-poll, all blocks services).
- ESLint: test file clean; `orchestrator-chat.ts`'s 3 `no-explicit-any` verified identical at base. Prettier clean.
- Known mutation gap, recorded not papered over: flipping `>` to `>=` on the envelope check **survives**, because no live site sits at exactly `MAX_WAIT_SECONDS`. The boundary is instead exercised by the mutation matrix above (150 passes, 151 fails).

## 7. The Cloudflare edge — why 90 and not 120

`iterateGenerate` is browser-driven, so its response crosses Cloudflare. Read from the CF API, the zone's plan is **"Business Website"** — not Enterprise. `proxy_read_timeout` is Enterprise-only, so the **~100s default applies and cannot have been raised**.

A wait beyond that is not merely wasted. The browser gets a **524 while the origin keeps holding the socket and the workflow keeps running and billing** — the user sees an error for a completion that was about to succeed. 90 keeps ~10s of margin. The cost is a fraction of a percent (between the 60s and 120s rows in §4), and it is a fraction browser callers could never have collected anyway.

**Two honesty bounds on this:**
- The 100s is **inferred from the plan tier, not read**. The available token lacks `Zone-Settings:Read`, so `GET /zones/{id}/settings/proxy_read_timeout` returns Unauthorized.
- **Origin logs neither confirm nor refute it.** Plenty of requests return 200 well past 100s — but CF can 524 the browser while leaving the origin connection open, which is structurally invisible from the origin side. So the 200s-at-150s prove nothing either way.
- There *is* an unexplained hard abort at **~125.0s**: 4,158 status-499s over 3d clustered at 125.006–125.011s across 256 client IPs. **Deliberately not attributed** — no evidence names the actor. 90 sits under it too.

**The robust fix, if this ever needs to be longer:** CF's 524 clock is a *read* timeout that resets on any byte from origin, so a long-poll that flushes headers early or emits a keepalive never accumulates toward it, and the plan tier stops mattering. That is a change to the orchestrator's response behaviour, not to this constant.

## 8. Deliberately not done

- **No status check added** to `orchestratorChatCompletion`. It reads `steps[0].output` with no `status !== 'succeeded'` guard, so a 202 silently becomes `content: ''` — unlike `product-badge.service.ts` and `orchestrator.service.ts`, which both guard. Given §4's ~1% long tail this is a real second defect, but it is a behaviour change on a Buzz-refund path and deserves its own PR.
- **No refund in `prompt-enhance.ts`** for a discarded completion (§4). Same reasoning.
- **No `externalId`.** The duplicate-billing exposure in §3 is bounded by keeping `wait` under the headers timeout, not closed by dedupe. Worth a follow-up.
- **No clamp added inside the `orchestrator.service.ts` wrappers.** That is the deterministic one-rule-one-place fix for the forwarding paths, and it is the right eventual answer — but it changes behaviour for 5 modules' worth of callers, well beyond this PR. The widened guard is the interim.
- **No client-side `signal`** on the non-whatIf submit path — affects every generation submit.
- **`training.service.ts` untouched** — see §5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R7ZCxbgcsv3WfsSJrYdSCi
