### PR TITLE
feat(app-blocks): let a block ANNOUNCE readiness (BLOCK_HELLO) — half 1 of 2

### DIFF
--- a/src/components/AppBlocks/IframeHost.browser.test.tsx
+++ b/src/components/AppBlocks/IframeHost.browser.test.tsx
@@ -97,6 +97,8 @@ vi.mock('~/components/BrowsingLevel/BrowsingLevelProvider', () => ({
 import { IframeHost } from '~/components/AppBlocks/IframeHost';
 // eslint-disable-next-line import/first
 import type { BlockInstall, ModelSlotContext } from '~/components/AppBlocks/types';
+// eslint-disable-next-line import/first
+import { IframeInitController } from '~/components/AppBlocks/iframeInitController';
 
 /**
  * Analytics Phase 2 — block render/impression beacon on the MODEL slot host.
@@ -359,5 +361,47 @@ describe('IframeHost GET_BUZZ_BALANCE handler (Phase 3, model.sidebar_top)', () 
     expect(mocks.balance).not.toHaveBeenCalled();
     expect(replies.last('BUZZ_BALANCE_RESULT')).toBeUndefined();
     replies.stop();
+  });
+});
+
+/**
+ * The readiness-announce SEAM on the model-slot host — the one link no pure
+ * unit test can reach, because it is a claim about how the COMPONENT is wired
+ * rather than about what the controller computes.
+ *
+ * What `notifyHello` DOES (and, crucially, does not do — it never cancels the
+ * retry loop or the readiness timeout) is pinned deterministically in
+ * `__tests__/iframeInitController.test.ts`. Asserting the CALL here rather than
+ * counting BLOCK_INIT posts is deliberate: a count would race the host's own
+ * 400ms retry tick and could pass for the wrong reason.
+ */
+describe('IframeHost readiness announce (BLOCK_HELLO)', () => {
+  test('a BLOCK_HELLO from the frame reaches IframeInitController.notifyHello', async () => {
+    const helloSpy = vi.spyOn(IframeInitController.prototype, 'notifyHello');
+    renderWithProviders(<IframeHost {...baseProps} />);
+    await vi.waitFor(() => {
+      const el = page.getByTestId('block-iframe').element() as HTMLIFrameElement;
+      if (!el.contentWindow) throw new Error('not mounted yet');
+    });
+    expect(helloSpy).not.toHaveBeenCalled(); // positive control: nothing yet
+
+    postFromBlock('BLOCK_HELLO');
+
+    await vi.waitFor(() => expect(helloSpy).toHaveBeenCalled());
+    helloSpy.mockRestore();
+  });
+
+  test('an unrelated message type does NOT reach notifyHello (negative control)', async () => {
+    const helloSpy = vi.spyOn(IframeInitController.prototype, 'notifyHello');
+    renderWithProviders(<IframeHost {...baseProps} />);
+    await vi.waitFor(() => {
+      const el = page.getByTestId('block-iframe').element() as HTMLIFrameElement;
+      if (!el.contentWindow) throw new Error('not mounted yet');
+    });
+
+    postFromBlock('BLOCK_HELLO_NOT_REALLY');
+    await new Promise((r) => setTimeout(r, 150));
+    expect(helloSpy).not.toHaveBeenCalled();
+    helloSpy.mockRestore();
   });
 });

--- a/src/components/AppBlocks/IframeHost.tsx
+++ b/src/components/AppBlocks/IframeHost.tsx
@@ -885,6 +885,32 @@ export function IframeHost({
     return () => clearTimeout(t);
   }, [status, token]);
 
+  // INVERTED HANDSHAKE: the block announces that its message listener is
+  // attached (`BLOCK_HELLO`) and we push BLOCK_INIT in response, instead of
+  // relying purely on the blind retry tick to eventually land after the
+  // listener exists.
+  //
+  // 🔴 PURELY ADDITIVE. `IframeInitController` still posts init immediately on
+  // start() and re-posts every INIT_RETRY_INTERVAL_MS until BLOCK_READY, and
+  // still arms the readiness timeout. A block on an older SDK never sends this
+  // message and is served exactly as it is today; a block that announces but
+  // never acks still times out. `notifyHello()` is a once-per-controller
+  // accelerator (see its doc comment), and a hello arriving before the
+  // controller exists is a no-op because `start()` posts init immediately
+  // anyway.
+  //
+  // 🔴 THE RETRY LOOP IS NOT REMOVED AND MUST NOT BE. As of 2026-08-05 NO
+  // deployed block sends BLOCK_HELLO (a full enumeration of the 20 live bundles
+  // found `BLOCK_HELLO` x0) because the SDK half is merged but unpublished, so
+  // the retry loop is currently doing 100% of the work. It stays as the bounded
+  // fallback for every block that never announces.
+  useEffect(() => {
+    const off = onMessage<unknown>('BLOCK_HELLO', () => {
+      controllerRef.current?.notifyHello();
+    });
+    return off;
+  }, [onMessage]);
+
   useEffect(() => {
     const off = onMessage<unknown>('BLOCK_READY', (raw) => {
       // Validate the shape — payload comes from cross-origin iframe code and

--- a/src/components/AppBlocks/PageBlockHost.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHost.browser.test.tsx
@@ -89,6 +89,8 @@ vi.mock('~/utils/trpc', () => ({
 
 // eslint-disable-next-line import/first
 import { PageBlockHost } from '~/components/AppBlocks/PageBlockHost';
+// eslint-disable-next-line import/first
+import { IframeInitController } from '~/components/AppBlocks/iframeInitController';
 
 /**
  * W10 lazy-consent gap regression (page surface).
@@ -912,5 +914,41 @@ describe('PageBlockHost block render/impression (Analytics Phase 2)', () => {
 
     // The new mount emitted a 2nd, independent impression → total 2.
     await vi.waitFor(() => expect(beaconCalls()).toHaveLength(2));
+  });
+});
+
+/**
+ * The readiness-announce SEAM on the PAGE host. Mirrors the model-slot coverage
+ * in IframeHost.browser.test.tsx — each host is a separate call site, so each
+ * needs its own proof that a real postMessage reaches the controller.
+ */
+describe('PageBlockHost readiness announce (BLOCK_HELLO)', () => {
+  async function mountAndWait() {
+    renderWithProviders(<PageBlockHost {...baseProps} />);
+    await vi.waitFor(() => {
+      const el = page.getByTestId('app-page-iframe').element() as HTMLIFrameElement;
+      if (!el.contentWindow) throw new Error('not mounted yet');
+    });
+  }
+
+  test('a BLOCK_HELLO from the frame reaches IframeInitController.notifyHello', async () => {
+    const helloSpy = vi.spyOn(IframeInitController.prototype, 'notifyHello');
+    await mountAndWait();
+    expect(helloSpy).not.toHaveBeenCalled(); // positive control
+
+    postFromBlock('BLOCK_HELLO');
+
+    await vi.waitFor(() => expect(helloSpy).toHaveBeenCalled());
+    helloSpy.mockRestore();
+  });
+
+  test('an unrelated message type does NOT reach notifyHello (negative control)', async () => {
+    const helloSpy = vi.spyOn(IframeInitController.prototype, 'notifyHello');
+    await mountAndWait();
+
+    postFromBlock('BLOCK_HELLO_NOT_REALLY');
+    await new Promise((r) => setTimeout(r, 150));
+    expect(helloSpy).not.toHaveBeenCalled();
+    helloSpy.mockRestore();
   });
 });

--- a/src/components/AppBlocks/PageBlockHost.tsx
+++ b/src/components/AppBlocks/PageBlockHost.tsx
@@ -859,6 +859,23 @@ export function PageBlockHost({
     return off;
   }, [token, expiresAt, grantedScopes, send, onMessage]);
 
+  // INVERTED HANDSHAKE: the block announces that its message listener is
+  // attached (`BLOCK_HELLO`) and we push BLOCK_INIT in response rather than
+  // waiting out the current retry tick.
+  //
+  // 🔴 PURELY ADDITIVE — see `IframeInitController.notifyHello`. The immediate
+  // post on start(), the retry interval and the readiness timeout are all
+  // unchanged, so a block that never announces (older SDK) behaves exactly as
+  // today and a block that announces but never acks still times out. The retry
+  // loop is NOT removed: as of 2026-08-05 no deployed block sends BLOCK_HELLO,
+  // so it is still doing all of the work.
+  useEffect(() => {
+    const off = onMessage<unknown>('BLOCK_HELLO', () => {
+      controllerRef.current?.notifyHello();
+    });
+    return off;
+  }, [onMessage]);
+
   // BLOCK_READY → ready.
   useEffect(() => {
     const off = onMessage<unknown>('BLOCK_READY', () => {

--- a/src/components/AppBlocks/__tests__/iframeInitController.test.ts
+++ b/src/components/AppBlocks/__tests__/iframeInitController.test.ts
@@ -187,4 +187,105 @@ describe('IframeInitController', () => {
       expect(controller.hasStarted()).toBe(true);
     });
   });
+
+  /**
+   * THE INVERTED HANDSHAKE — and its COMPATIBILITY MATRIX.
+   *
+   * The block now announces that its listener is attached (`BLOCK_HELLO`) and
+   * the host pushes BLOCK_INIT in response. These tests pin the property that
+   * makes that safe to ship against already-deployed third-party blocks: the
+   * announce is an ACCELERATOR layered on the existing schedule, never a gate.
+   * The two cells that matter here are the ones the SDK's own tests structurally
+   * cannot cover, because they are claims about the HOST:
+   *
+   *   - OLD SDK + NEW HOST — a deployed block that never sends BLOCK_HELLO.
+   *   - A BLOCK THAT NEVER ANNOUNCES AND NEVER ACKS — must not hang the host.
+   */
+  describe('BLOCK_HELLO: the inverted handshake is an accelerator, not a gate', () => {
+    it('OLD SDK + NEW HOST: a block that never announces gets the unchanged schedule', () => {
+      // The whole old-SDK compatibility claim in one assertion: with no
+      // BLOCK_HELLO ever delivered, the immediate post + every retry tick
+      // happen exactly as before this change.
+      const { controller, sendInit, onReadyTimeout } = makeController({ readyTimeoutMs: 10_000 });
+      controller.start();
+      expect(sendInit).toHaveBeenCalledTimes(1); // immediate post
+
+      vi.advanceTimersByTime(INIT_RETRY_INTERVAL_MS * 5);
+      expect(sendInit).toHaveBeenCalledTimes(6); // 1 + 5 retries
+      expect(onReadyTimeout).not.toHaveBeenCalled();
+    });
+
+    it('NEVER ANNOUNCES AND NEVER ACKS: the readiness timeout still fires — no hang', () => {
+      const { controller, sendInit, onReadyTimeout } = makeController({ readyTimeoutMs: 10_000 });
+      controller.start();
+      vi.advanceTimersByTime(60_000);
+      expect(onReadyTimeout).toHaveBeenCalledTimes(1);
+      // …and the retry loop stopped with it, rather than re-posting forever.
+      const atTimeout = sendInit.mock.calls.length;
+      vi.advanceTimersByTime(60_000);
+      expect(sendInit).toHaveBeenCalledTimes(atTimeout);
+    });
+
+    it('NEW SDK + NEW HOST: an announce posts BLOCK_INIT immediately, not at the next tick', () => {
+      const { controller, sendInit } = makeController();
+      controller.start();
+      expect(sendInit).toHaveBeenCalledTimes(1);
+
+      // Half a tick in — the retry loop would not have fired yet.
+      vi.advanceTimersByTime(INIT_RETRY_INTERVAL_MS / 2);
+      expect(sendInit).toHaveBeenCalledTimes(1);
+
+      controller.notifyHello();
+      expect(sendInit).toHaveBeenCalledTimes(2);
+    });
+
+    it('the announce does NOT cancel the retry loop or the readiness timeout', () => {
+      // 🔴 An announce means "I am listening", NOT "I got the payload". Only
+      // BLOCK_READY may stop the loop; treating hello as an ack would
+      // reintroduce the blank-iframe bug this controller exists to fix.
+      const { controller, sendInit, onReadyTimeout } = makeController({ readyTimeoutMs: 10_000 });
+      controller.start();
+      controller.notifyHello();
+      const afterHello = sendInit.mock.calls.length;
+
+      vi.advanceTimersByTime(INIT_RETRY_INTERVAL_MS * 3);
+      expect(sendInit.mock.calls.length).toBe(afterHello + 3);
+
+      vi.advanceTimersByTime(10_000);
+      expect(onReadyTimeout).toHaveBeenCalledTimes(1);
+    });
+
+    it('is honored at most ONCE — a chatty block cannot amplify host work', () => {
+      const { controller, sendInit } = makeController();
+      controller.start();
+      for (let i = 0; i < 50; i += 1) controller.notifyHello();
+      expect(sendInit).toHaveBeenCalledTimes(2); // the immediate post + one hello
+    });
+
+    it('an announce BEFORE start() sends nothing, and start() still posts immediately', () => {
+      // The host registers its BLOCK_HELLO listener before the controller
+      // exists (token/checkpoint may still be resolving). A hello landing then
+      // must not post — there is no payload yet — and must not suppress the
+      // immediate post start() owes.
+      const { controller, sendInit } = makeController();
+      controller.notifyHello();
+      expect(sendInit).not.toHaveBeenCalled();
+      controller.start();
+      expect(sendInit).toHaveBeenCalledTimes(1);
+    });
+
+    it('an announce after notifyReady()/dispose() sends nothing', () => {
+      const { controller, sendInit } = makeController();
+      controller.start();
+      controller.notifyReady();
+      controller.notifyHello();
+      expect(sendInit).toHaveBeenCalledTimes(1);
+
+      const second = makeController();
+      second.controller.start();
+      second.controller.dispose();
+      second.controller.notifyHello();
+      expect(second.sendInit).toHaveBeenCalledTimes(1);
+    });
+  });
 });

--- a/src/components/AppBlocks/hostHandlerParity.ts
+++ b/src/components/AppBlocks/hostHandlerParity.ts
@@ -83,6 +83,22 @@ export const INLINE_STUB =
 export const INVENTORY = {
   // ── Lifecycle / fire-and-forget (no reply ⇒ unhandled never HANGS, but a
   //    page that ignores them just no-ops; documented per host) ───────────────
+  //
+  // The block's readiness ANNOUNCE — posted by the SDK transport the moment its
+  // message listener is attached, so the host can push BLOCK_INIT in response
+  // instead of waiting out a retry tick. Fire-and-forget and, uniquely in this
+  // table, an ACCELERATOR rather than a bridge: an unhandled BLOCK_HELLO costs
+  // only latency, because every host keeps its own immediate-post + bounded
+  // retry + readiness-timeout schedule. Marked `required` on the two live hosts
+  // anyway — the whole point of the parity gate is that a message the SDK sends
+  // has a named answer on every host that could receive it.
+  BLOCK_HELLO: {
+    request: false,
+    reply: '',
+    IframeHost: 'required',
+    PageBlockHost: 'required',
+    InlineHost: INLINE_STUB,
+  },
   BLOCK_READY: {
     request: false,
     reply: '',

--- a/src/components/AppBlocks/iframeInitController.ts
+++ b/src/components/AppBlocks/iframeInitController.ts
@@ -104,6 +104,8 @@ export class IframeInitController {
   private readonly opts: Required<IframeInitControllerOptions>;
   private started = false;
   private stopped = false;
+  /** One-shot latch for `notifyHello()` — see its doc comment. */
+  private helloHandled = false;
   private intervalId: ReturnType<typeof setInterval> | null = null;
   private timeoutId: ReturnType<typeof setTimeout> | null = null;
 
@@ -151,6 +153,32 @@ export class IframeInitController {
   /** Whether start() has run (i.e. at least one BLOCK_INIT was posted). */
   hasStarted(): boolean {
     return this.started;
+  }
+
+  /**
+   * The block announced it is listening (`BLOCK_HELLO` — the inverted
+   * handshake). Push BLOCK_INIT NOW rather than waiting out the remainder of
+   * the current retry tick.
+   *
+   * 🔴 THIS IS AN ACCELERATOR, NOT A GATE. The retry interval and the readiness
+   * timeout armed by `start()` are untouched, so:
+   *   - a block on an OLDER SDK, which never sends `BLOCK_HELLO`, is served by
+   *     the unchanged retry loop exactly as it is today;
+   *   - a block that never announces AND never acks still hits `onReadyTimeout`
+   *     at `readyTimeoutMs` — it cannot hang the host.
+   * Nothing here may ever become a precondition for sending init.
+   *
+   * Honored AT MOST ONCE per controller: an announce is a one-shot signal from
+   * the block's transport, so a repeat is either a duplicate or noise, and
+   * answering every one would let a chatty frame amplify host work. An announce
+   * that lands BEFORE `start()` is recorded and costs nothing — `start()` posts
+   * init immediately on its own.
+   */
+  notifyHello(): void {
+    if (this.helloHandled) return;
+    this.helloHandled = true;
+    if (!this.started || this.stopped) return;
+    this.opts.sendInit();
   }
 
   /**


### PR DESCRIPTION
**Half 1 of 2.** Split out of #3631 after a live-block enumeration and an adversarial audit. The other half — the URL-fragment fast path — is #3635, which ships **gated off**. SDK counterpart: civitai/civitai-app-starters#212 (merged, **not yet published**).

The block's transport posts a contentless `BLOCK_HELLO` the moment its message listener is attached. Both hosts answer by pushing `BLOCK_INIT` immediately, instead of waiting out the remainder of the current 400 ms retry tick.

## 🔴 The retry loop is NOT removed, and must not be

The split proposal described this as "the half that removes the 400 ms retry loop". It does not, and it must not:

- A full enumeration of the **20 live block bundles** on 2026-08-05 found **`BLOCK_HELLO` × 0**. The SDK half is merged but unpublished (npm latest is still `@civitai/app-sdk@0.30.0`), so **nothing announces today** and the retry loop is doing **100 % of the work**.
- Removing it would break every deployed block immediately, not eventually.

So `notifyHello()` is an **accelerator layered on the existing schedule**: it never cancels the retry interval and never disarms the readiness timeout. This PR is therefore *behaviourally inert in production today* — it becomes valuable the day the SDK publishes and blocks rebuild. That is the honest reason to land it now: it is free, and it is on the critical path for nothing else.

## Compatibility

| Cell | How it holds | Evidence |
|---|---|---|
| **old SDK + new host** (every block today) | existing paths byte-unchanged: immediate post on `start()`, re-post every `INIT_RETRY_INTERVAL_MS`, timeout armed at `start()` | `OLD SDK + NEW HOST: a block that never announces gets the unchanged schedule` — asserts 1 immediate + 5 retries at 5 ticks |
| **block announces but never acks** | announce ≠ ack; only `BLOCK_READY` may stop the loop | `the announce does NOT cancel the retry loop or the readiness timeout` |
| **block never announces and never acks** | bounded fallback still terminates | `NEVER ANNOUNCES AND NEVER ACKS: the readiness timeout still fires — no hang` (also asserts the loop stops with it) |
| **chatty block** | honored at most once per controller | `is honored at most ONCE` (51 sends → still 2) |
| **announce lands before `start()`** | recorded, sends nothing; `start()` posts immediately anyway | `an announce BEFORE start() sends nothing, and start() still posts immediately` |

An unhandled `BLOCK_HELLO` costs only latency, so this cannot regress a host that ignores it either.

## Tests

**Node tier** — `iframeInitController.test.ts` (+8 cases). **Component tier** — the seam that no unit test can reach: does a *real* postMessage over the *real* bridge reach the controller? Asserted via `vi.spyOn(IframeInitController.prototype, 'notifyHello')` rather than by counting `BLOCK_INIT` posts, deliberately — a count would race the 400 ms tick and could pass for the wrong reason. Each has a positive control (spy not called before the message) and a negative control (`BLOCK_HELLO_NOT_REALLY` must not reach it).

`hostHandlerParity.ts` gains a `BLOCK_HELLO` inventory entry, which makes "both live hosts register a handler" a **gated** claim rather than a hope.

**Mutation-verified** (from the pre-split sweep, all still applicable — each killed by its *own named* test, not merely turning the suite red):

| Mutation | Killed by |
|---|---|
| `IframeHost` drops the handler | parity: `IframeHost.tsx is missing onMessage('BLOCK_HELLO')` |
| `PageBlockHost` drops the handler | parity: `PageBlockHost.tsx is missing onMessage('BLOCK_HELLO')` |
| `notifyHello()` becomes a no-op | `an announce posts BLOCK_INIT immediately, not at the next tick` |
| `notifyHello()` stops the retry loop | `the announce does NOT cancel the retry loop or the readiness timeout` |
| `notifyHello()` loses its once-only latch | `is honored at most ONCE` |
| `notifyHello()` sends before `start()` | `an announce BEFORE start() sends nothing` |
| retry loop no longer re-posts | `a block that never announces gets the unchanged schedule` |

Suites at this branch: **unit 29 files / 536 tests**, **component 27 files / 322 tests**, both green.

## What this PR does NOT contain

Everything the audit flagged is in the other half, by construction — the URL fragment, the NO-STOMP claim, the mount-time freeze, the frozen-`theme` "auto" cohort, and `blockInstanceId` in `location.href` are all properties of the fragment, not the handshake.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R7ZCxbgcsv3WfsSJrYdSCi
