### PR TITLE
feat(app-blocks): iframe init-fragment fast path, shipped GATED OFF — half 2 of 2

### DIFF
--- a/src/components/AppBlocks/BlockInitFragmentFreeze.browser.test.tsx
+++ b/src/components/AppBlocks/BlockInitFragmentFreeze.browser.test.tsx
@@ -64,6 +64,17 @@ function FreezeProbe({ enabled = true }: { enabled?: boolean }) {
       <button data-testid="change-base" onClick={() => setBaseSrc('https://demo.civit.ai/other')}>
         change base
       </button>
+      {/* Soft-nav appA -> appB: BOTH the src and the instance id change, with no
+          remount — the real `/apps/run` "Recently run" path. */}
+      <button
+        data-testid="soft-nav"
+        onClick={() => {
+          setBaseSrc('https://appb.civit.ai/');
+          setInstanceId('bi_second');
+        }}
+      >
+        soft nav
+      </button>
     </div>
   );
 }
@@ -116,15 +127,67 @@ describe('useBlockIframeSrc — the mount-time FREEZE', () => {
     expect(await readSrc()).toBe(before);
   });
 
-  test('🔴 a blockInstanceId change also leaves the src byte-identical', async () => {
+  test('🔴 a blockInstanceId change RE-CAPTURES — the freeze is per-INSTANCE, not per-mount', async () => {
+    // ⚠️ THIS TEST WAS INVERTED. It previously asserted that changing
+    // `blockInstanceId` left the src byte-identical — i.e. it pinned the LEAK
+    // as intended behaviour. A per-mount freeze is wrong precisely because
+    // `PageBlockHost` outlives a block instance (soft nav, no `key`), so the
+    // correct invariant is: frozen WITHIN an instance, re-captured ACROSS one.
     renderWithProviders(<FreezeProbe />);
     const before = await readSrc();
     expect(before).toContain('blockInstanceId=bi_first');
 
     await page.getByTestId('change-instance').click();
 
-    expect(await readSrc()).toBe(before);
-    expect(await readSrc()).not.toContain('bi_second');
+    const after = await readSrc();
+    expect(after).not.toBe(before);
+    expect(after).toContain('blockInstanceId=bi_second');
+    expect(after).not.toContain('bi_first');
+  });
+
+  test('🔴 THE DISCRIMINATING CASE: toggle theme, THEN move baseSrc — theme must not follow', async () => {
+    // This is the case that actually pins the REF, and it exists because the
+    // earlier mutation table overstated its row 1. That row's mutant changed
+    // BOTH `frozenFields.current` -> `fields` AND the dep array; the dep-array
+    // half is what the other tests detect. The SINGLE mutant — live `fields`
+    // with the deps left alone — passes every other test in this file, because
+    // nothing else forces a recompute AFTER a theme change.
+    //
+    // Moving `baseSrc` forces exactly that recompute. At head it re-reads the
+    // FROZEN fields; under the single mutant it re-reads the LIVE ones and the
+    // new theme leaks in.
+    renderWithProviders(<FreezeProbe />);
+    expect(await readSrc()).toContain('theme=light');
+
+    await page.getByTestId('toggle-theme').click(); // now dark, src unmoved
+    await page.getByTestId('change-base').click(); // forces a recompute
+
+    const after = await readSrc();
+    expect(after).toContain('https://demo.civit.ai/other#');
+    expect(after).toContain('theme=light'); // the FROZEN theme, not the live one
+    expect(after).not.toContain('theme=dark');
+  });
+
+  test('🔴 SOFT-NAV appA→appB re-captures — no leak of the previous app’s identity', async () => {
+    // `PageBlockHost` is rendered with NO `key`, and `_app.tsx` renders
+    // `<Component>` with none either, so a soft navigation between two apps
+    // reuses the component instance: same mount, different `blockInstanceId`.
+    // A per-MOUNT freeze leaked app A's id (and mount-time theme) into app B's
+    // document while BLOCK_INIT delivered B's — two contradicting identities.
+    // The freeze is scoped to the block INSTANCE for this reason.
+    renderWithProviders(<FreezeProbe />);
+    expect(await readSrc()).toContain('blockInstanceId=bi_first');
+
+    await page.getByTestId('toggle-theme').click(); // dark, while still on app A
+    await page.getByTestId('soft-nav').click();
+
+    const after = await readSrc();
+    expect(after).toContain('https://appb.civit.ai/#');
+    // App B gets its OWN id…
+    expect(after).toContain('blockInstanceId=bi_second');
+    expect(after).not.toContain('bi_first');
+    // …and the CURRENT theme, because it is a fresh capture for a new instance.
+    expect(after).toContain('theme=dark');
   });
 
   test('baseSrc is deliberately NOT frozen — it still re-navigates', async () => {
@@ -132,6 +195,13 @@ describe('useBlockIframeSrc — the mount-time FREEZE', () => {
     // stale manifest src, which is a behaviour CHANGE, not a safety property.
     // The audit noted that freezing it also survives the suites; this is the
     // test that stops it.
+    //
+    // 🔴 SCOPE OF THE `bi_first` ASSERTION BELOW: it holds because ONLY the src
+    // moved — the block INSTANCE is unchanged, so carrying its captured fields
+    // is correct. Do NOT read it as "the id is always carried onto a new base":
+    // when the instance changes too (a soft nav), the capture is REDONE — see
+    // the soft-nav test above. An earlier revision of this file asserted the
+    // carry without that boundary case, which read as blessing the leak.
     renderWithProviders(<FreezeProbe />);
     const before = await readSrc();
     expect(before).toContain('https://demo.civit.ai/#');

--- a/src/components/AppBlocks/BlockInitFragmentFreeze.browser.test.tsx
+++ b/src/components/AppBlocks/BlockInitFragmentFreeze.browser.test.tsx
@@ -1,0 +1,156 @@
+import { useState } from 'react';
+import { describe, expect, test, vi } from 'vitest';
+import { page } from 'vitest/browser';
+// `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
+import { renderWithProviders } from '../../../test/component-setup';
+
+// eslint-disable-next-line import/first
+import { useBlockIframeSrc } from '~/components/AppBlocks/useBlockIframeSrc';
+
+/**
+ * 🔴 THE FREEZE INVARIANT — the property the init-fragment fast path names as
+ * its safety argument, and which an adversarial audit found had ZERO coverage
+ * in either tier.
+ *
+ * The claim: `useBlockIframeSrc` captures its fragment fields at MOUNT, so a
+ * later `theme` change cannot move the rendered `src`. That matters because
+ * `theme` genuinely does change while a block is mounted (the viewer toggles
+ * dark mode), and a changing `src` ATTRIBUTE navigates a third-party iframe —
+ * at best a `hashchange` inside the block, at worst a reload that discards its
+ * in-progress state. Today the host does not propagate live theme changes to
+ * blocks at all, so the fast path must not introduce that.
+ *
+ * The audit's finding, reproduced before this file existed: replacing the
+ * frozen ref with live `fields` (and full deps) survived BOTH suites — node
+ * 31/31 and browser 38/38. So the invariant was asserted only in prose.
+ *
+ * WHY THIS TESTS THE HOOK AND NOT A HOST. The fast path ships GATED OFF (the
+ * allowlist in `blockInitFragmentGate.ts` is empty), so a host-level test would
+ * render a `src` with no fragment at all and could not observe the freeze —
+ * it would be vacuous by construction. Driving the hook with `enabled: true`
+ * exercises the invariant that the gate will eventually expose.
+ *
+ * WHY THE COMPONENT TIER. `useBlockIframeSrc` is a React hook; civitai's unit
+ * project runs `environment: 'node'` with no renderer, so a hook cannot be
+ * mounted there.
+ */
+
+const BASE_SRC = 'https://demo.civit.ai/';
+
+/** Renders the hook's output and exposes levers to change each input. */
+function FreezeProbe({ enabled = true }: { enabled?: boolean }) {
+  const [theme, setTheme] = useState<'light' | 'dark'>('light');
+  const [instanceId, setInstanceId] = useState('bi_first');
+  const [baseSrc, setBaseSrc] = useState(BASE_SRC);
+
+  const src = useBlockIframeSrc(
+    baseSrc,
+    { theme, renderMode: 'iframe', blockInstanceId: instanceId },
+    enabled
+  );
+
+  return (
+    <div>
+      <output data-testid="src">{src}</output>
+      <button
+        data-testid="toggle-theme"
+        onClick={() => setTheme((t) => (t === 'light' ? 'dark' : 'light'))}
+      >
+        toggle theme
+      </button>
+      <button data-testid="change-instance" onClick={() => setInstanceId('bi_second')}>
+        change instance
+      </button>
+      <button data-testid="change-base" onClick={() => setBaseSrc('https://demo.civit.ai/other')}>
+        change base
+      </button>
+    </div>
+  );
+}
+
+/**
+ * Read the probe's output, waiting for the commit first.
+ *
+ * React 18 renders through `createRoot`, which commits ASYNCHRONOUSLY, so a
+ * synchronous DOM read straight after `renderWithProviders` finds an empty
+ * container — which is exactly how this file failed on its first run (an empty
+ * `<div />` and "Cannot find element with locator"). Every other browser suite
+ * in this repo awaits before asserting for the same reason.
+ */
+async function readSrc(): Promise<string> {
+  let text = '';
+  await vi.waitFor(() => {
+    const el = page.getByTestId('src').element();
+    if (!el) throw new Error('probe not mounted yet');
+    text = (el.textContent ?? '').trim();
+    if (!text) throw new Error('probe rendered empty');
+  });
+  return text;
+}
+
+describe('useBlockIframeSrc — the mount-time FREEZE', () => {
+  test('🔴 a theme change leaves the src BYTE-IDENTICAL', async () => {
+    renderWithProviders(<FreezeProbe />);
+
+    const before = await readSrc();
+    // Positive control: the fragment really is present, so "unchanged" below is
+    // a statement about the freeze and not about an empty string.
+    expect(before).toContain('#civitai-block=v1');
+    expect(before).toContain('theme=light');
+
+    await page.getByTestId('toggle-theme').click();
+
+    const after = await readSrc();
+    expect(after).toBe(before);
+    // …and specifically still says the MOUNT-time theme, not the current one.
+    expect(after).toContain('theme=light');
+    expect(after).not.toContain('theme=dark');
+  });
+
+  test('survives repeated theme toggles', async () => {
+    renderWithProviders(<FreezeProbe />);
+    const before = await readSrc();
+
+    for (let i = 0; i < 4; i += 1) await page.getByTestId('toggle-theme').click();
+
+    expect(await readSrc()).toBe(before);
+  });
+
+  test('🔴 a blockInstanceId change also leaves the src byte-identical', async () => {
+    renderWithProviders(<FreezeProbe />);
+    const before = await readSrc();
+    expect(before).toContain('blockInstanceId=bi_first');
+
+    await page.getByTestId('change-instance').click();
+
+    expect(await readSrc()).toBe(before);
+    expect(await readSrc()).not.toContain('bi_second');
+  });
+
+  test('baseSrc is deliberately NOT frozen — it still re-navigates', async () => {
+    // The counterpart guarantee. Freezing `baseSrc` too would silently pin a
+    // stale manifest src, which is a behaviour CHANGE, not a safety property.
+    // The audit noted that freezing it also survives the suites; this is the
+    // test that stops it.
+    renderWithProviders(<FreezeProbe />);
+    const before = await readSrc();
+    expect(before).toContain('https://demo.civit.ai/#');
+
+    await page.getByTestId('change-base').click();
+
+    const after = await readSrc();
+    expect(after).not.toBe(before);
+    expect(after).toContain('https://demo.civit.ai/other#');
+    // The FRAGMENT carried across is still the frozen one.
+    expect(after).toContain('theme=light');
+    expect(after).toContain('blockInstanceId=bi_first');
+  });
+
+  test('when the gate is OFF the src is the bare base, with no fragment at all', async () => {
+    renderWithProviders(<FreezeProbe enabled={false} />);
+
+    const src = await readSrc();
+    expect(src).toBe(BASE_SRC);
+    expect(src).not.toContain('civitai-block');
+  });
+});

--- a/src/components/AppBlocks/IframeHost.tsx
+++ b/src/components/AppBlocks/IframeHost.tsx
@@ -37,6 +37,8 @@ import {
   projectBlockInitViewer,
 } from './projectBlockInit';
 import { IframeInitController, shouldStartInit } from './iframeInitController';
+import { blockInitFragmentEnabled } from './blockInitFragmentGate';
+import { useBlockIframeSrc } from './useBlockIframeSrc';
 import { usePostMessage } from './usePostMessage';
 import type { BlockInitPayload, BlockInstall, ModelSlotContext, SlotContext } from './types';
 import { dialogStore } from '~/components/Dialog/dialogStore';
@@ -606,14 +608,28 @@ export function IframeHost({
   // used everywhere else modelCtx.slotId is read in this component.
   const slotId = modelCtx.slotId ?? 'model.sidebar_top';
 
-  const iframeSrc = install.manifest.iframe?.src ?? '';
+  // The publisher's declared src. The rendered `src` adds the init-fragment
+  // fast path on top ONLY when this block is gated on for it (see
+  // blockInitFragmentGate.ts — off by default for every block). The ORIGIN is
+  // derived from the BASE so the postMessage target can never be affected by
+  // the fragment.
+  const baseIframeSrc = install.manifest.iframe?.src ?? '';
+  const iframeSrc = useBlockIframeSrc(
+    baseIframeSrc,
+    {
+      theme: modelCtx.theme ?? 'light',
+      renderMode: install.renderMode,
+      blockInstanceId: install.blockInstanceId,
+    },
+    blockInitFragmentEnabled({ surface: 'model-slot', blockId: install.blockId })
+  );
   const expectedOrigin = useMemo(() => {
     try {
-      return new URL(iframeSrc).origin;
+      return new URL(baseIframeSrc).origin;
     } catch {
       return '';
     }
-  }, [iframeSrc]);
+  }, [baseIframeSrc]);
 
   // The EFFECTIVE sandbox handed to the iframe attribute below. Derive the
   // transport's opaque-origin mode from the SAME string so they can never

--- a/src/components/AppBlocks/PageBlockHost.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHost.browser.test.tsx
@@ -148,6 +148,8 @@ const baseProps = {
   blockInstanceId: 'page_apb_test',
   appName: 'Budgeted Generator',
   iframeSrc: SAME_ORIGIN_SRC,
+  // The public run surface. Required since the init-fragment gate keys on it.
+  surface: 'page-run' as const,
   sandbox: 'allow-scripts',
   trustTier: 'internal' as const,
   slug: 'my-page-app',

--- a/src/components/AppBlocks/PageBlockHost.tsx
+++ b/src/components/AppBlocks/PageBlockHost.tsx
@@ -8,6 +8,8 @@ import { BlockFallback } from './BlockFallback';
 import { failureSnapshot } from './failureSnapshot';
 import { AppBlockChrome } from './IframeHost';
 import { IframeInitController, shouldStartInit } from './iframeInitController';
+import { blockInitFragmentEnabled, type BlockHostSurface } from './blockInitFragmentGate';
+import { useBlockIframeSrc } from './useBlockIframeSrc';
 import { resolveBuzzPurchaseRequest } from './openBuzzPurchaseGate';
 import {
   BLOCK_READY_TIMEOUT_MS,
@@ -211,6 +213,14 @@ export interface PageBlockHostProps {
   appName: string;
   /** The `<slug>.civit.ai` bundle URL (manifest.iframe.src), server-resolved. */
   iframeSrc: string;
+  /**
+   * Which surface mounted this host. REQUIRED, and passed explicitly by each
+   * call site rather than inferred, because it is one of the two axes the
+   * init-fragment gate keys on — and the axis that refuses the DEV TUNNEL
+   * unconditionally, which an allowlist keyed on blockId/slug structurally
+   * cannot do (the tunnel serves the same blockId the author will publish).
+   */
+  surface: BlockHostSurface;
   /** manifest.iframe.sandbox, server-resolved. */
   sandbox: string;
   trustTier: 'unverified' | 'verified' | 'internal';
@@ -335,6 +345,7 @@ export function PageBlockHost({
   blockInstanceId,
   appName,
   iframeSrc,
+  surface,
   sandbox,
   trustTier,
   slug,
@@ -615,6 +626,20 @@ export function PageBlockHost({
       return '';
     }
   }, [iframeSrc]);
+
+  // The `src` actually rendered: the publisher's src plus the init-fragment
+  // fast path, but ONLY when this block+surface is gated on for it. Off by
+  // default for every block, and unconditionally off for `dev-tunnel`.
+  // `expectedOrigin` above is deliberately derived from the BASE src so the
+  // postMessage target can never be influenced by the fragment.
+  //
+  // The page host's render mode is `'iframe'` by construction — the literal
+  // this component already puts in its BLOCK_INIT payload below.
+  const renderedIframeSrc = useBlockIframeSrc(
+    iframeSrc,
+    { theme, renderMode: 'iframe', blockInstanceId },
+    blockInitFragmentEnabled({ surface, blockId, slug })
+  );
 
   // The EFFECTIVE sandbox handed to the iframe attribute below. Derive the
   // transport's opaque-origin mode from the SAME string so the two can never
@@ -3221,7 +3246,7 @@ export function PageBlockHost({
             // re-armed init handshake then talks to a clean frame.
             key={reloadNonce}
             ref={iframeRef}
-            src={iframeSrc}
+            src={renderedIframeSrc}
             sandbox={effectiveSandbox}
             referrerPolicy="no-referrer"
             // Sanitize the publisher-controlled appName for the iframe title too

--- a/src/components/AppBlocks/PageBlockHostAutoRetry.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostAutoRetry.browser.test.tsx
@@ -143,6 +143,8 @@ const baseProps = {
   blockInstanceId: 'page_apb_test',
   appName: 'Budgeted Generator',
   iframeSrc: SAME_ORIGIN_SRC,
+  // The public run surface. Required since the init-fragment gate keys on it.
+  surface: 'page-run' as const,
   sandbox: 'allow-scripts',
   trustTier: 'internal' as const,
   slug: 'my-page-app',

--- a/src/components/AppBlocks/PageBlockHostBenchmarkGrid.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostBenchmarkGrid.browser.test.tsx
@@ -112,6 +112,8 @@ const baseProps = {
   blockInstanceId: 'page_apb_test',
   appName: 'Benchmark App',
   iframeSrc: SAME_ORIGIN_SRC,
+  // The public run surface. Required since the init-fragment gate keys on it.
+  surface: 'page-run' as const,
   sandbox: 'allow-scripts',
   trustTier: 'internal' as const,
   slug: 'benchmark-app',

--- a/src/components/AppBlocks/PageBlockHostCheckpointPicker.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostCheckpointPicker.browser.test.tsx
@@ -182,6 +182,8 @@ const baseProps = {
   blockInstanceId: 'page_apb_test',
   appName: 'Gen Matrix',
   iframeSrc: SAME_ORIGIN_SRC,
+  // The public run surface. Required since the init-fragment gate keys on it.
+  surface: 'page-run' as const,
   sandbox: 'allow-scripts',
   trustTier: 'internal' as const,
   slug: 'my-page-app',

--- a/src/components/AppBlocks/PageBlockHostImageUpload.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostImageUpload.browser.test.tsx
@@ -134,6 +134,8 @@ const baseProps = {
   blockInstanceId: 'page_apb_test',
   appName: 'Gen App',
   iframeSrc: SAME_ORIGIN_SRC,
+  // The public run surface. Required since the init-fragment gate keys on it.
+  surface: 'page-run' as const,
   sandbox: 'allow-scripts',
   trustTier: 'internal' as const,
   slug: 'my-page-app',

--- a/src/components/AppBlocks/PageBlockHostImageUploadAsync.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostImageUploadAsync.browser.test.tsx
@@ -129,6 +129,8 @@ const baseProps = {
   blockInstanceId: 'page_apb_test',
   appName: 'Gen App',
   iframeSrc: SAME_ORIGIN_SRC,
+  // The public run surface. Required since the init-fragment gate keys on it.
+  surface: 'page-run' as const,
   sandbox: 'allow-scripts',
   trustTier: 'internal' as const,
   slug: 'my-page-app',

--- a/src/components/AppBlocks/PageBlockHostLaunchReveal.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostLaunchReveal.browser.test.tsx
@@ -118,6 +118,8 @@ const baseProps = {
   blockInstanceId: 'page_apb_test',
   appName: 'Budgeted Generator',
   iframeSrc: SAME_ORIGIN_SRC,
+  // The public run surface. Required since the init-fragment gate keys on it.
+  surface: 'page-run' as const,
   sandbox: 'allow-scripts',
   trustTier: 'internal' as const,
   slug: 'my-page-app',

--- a/src/components/AppBlocks/PageBlockHostResourcePicker.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostResourcePicker.browser.test.tsx
@@ -183,6 +183,8 @@ const baseProps = {
   blockInstanceId: 'page_apb_test',
   appName: 'Gen Matrix',
   iframeSrc: SAME_ORIGIN_SRC,
+  // The public run surface. Required since the init-fragment gate keys on it.
+  surface: 'page-run' as const,
   sandbox: 'allow-scripts',
   trustTier: 'internal' as const,
   slug: 'my-page-app',

--- a/src/components/AppBlocks/PageBlockHostReviewMode.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostReviewMode.browser.test.tsx
@@ -155,6 +155,8 @@ const baseProps = {
   blockInstanceId: 'page_pubreq_TEST',
   appName: 'Reviewed App',
   iframeSrc: SAME_ORIGIN_SRC,
+  // The public run surface. Required since the init-fragment gate keys on it.
+  surface: 'page-run' as const,
   sandbox: 'allow-scripts',
   // Pinned transport (internal) for deterministic delivery — reviewMode is
   // independent of trust tier. The opaque-origin path has its own test below.

--- a/src/components/AppBlocks/PageBlockHostSetUserCheckpoint.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostSetUserCheckpoint.browser.test.tsx
@@ -138,6 +138,8 @@ const baseProps = {
   blockInstanceId: 'page_apb_test',
   appName: 'Gen Matrix',
   iframeSrc: SAME_ORIGIN_SRC,
+  // The public run surface. Required since the init-fragment gate keys on it.
+  surface: 'page-run' as const,
   sandbox: 'allow-scripts',
   trustTier: 'internal' as const,
   slug: 'my-page-app',

--- a/src/components/AppBlocks/PageBlockHostSharedStorage.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostSharedStorage.browser.test.tsx
@@ -177,6 +177,8 @@ const baseProps = {
   blockInstanceId: 'page_apb_test',
   appName: 'Requests',
   iframeSrc: SAME_ORIGIN_SRC,
+  // The public run surface. Required since the init-fragment gate keys on it.
+  surface: 'page-run' as const,
   sandbox: 'allow-scripts',
   trustTier: 'internal' as const,
   slug: 'my-page-app',

--- a/src/components/AppBlocks/PageBlockHostSignIn.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostSignIn.browser.test.tsx
@@ -122,6 +122,8 @@ const baseProps = {
   blockInstanceId: 'page_apb_test',
   appName: 'Budgeted Generator',
   iframeSrc: SAME_ORIGIN_SRC,
+  // The public run surface. Required since the init-fragment gate keys on it.
+  surface: 'page-run' as const,
   sandbox: 'allow-scripts',
   trustTier: 'internal' as const,
   slug: 'my-page-app',

--- a/src/components/AppBlocks/PageBlockHostStorage.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostStorage.browser.test.tsx
@@ -150,6 +150,8 @@ const baseProps = {
   blockInstanceId: 'page_apb_test',
   appName: 'Notepad',
   iframeSrc: SAME_ORIGIN_SRC,
+  // The public run surface. Required since the init-fragment gate keys on it.
+  surface: 'page-run' as const,
   sandbox: 'allow-scripts',
   trustTier: 'internal' as const,
   slug: 'my-page-app',

--- a/src/components/AppBlocks/PageBlockHostTokenTerminal.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostTokenTerminal.browser.test.tsx
@@ -97,6 +97,8 @@ const baseProps = {
   blockInstanceId: 'page_apb_test',
   appName: 'Budgeted Generator',
   iframeSrc: SAME_ORIGIN_SRC,
+  // The public run surface. Required since the init-fragment gate keys on it.
+  surface: 'page-run' as const,
   sandbox: 'allow-scripts',
   trustTier: 'internal' as const,
   slug: 'my-page-app',

--- a/src/components/AppBlocks/PageBlockHostWildcardPack.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostWildcardPack.browser.test.tsx
@@ -129,6 +129,8 @@ const baseProps = {
   blockInstanceId: 'page_apb_test',
   appName: 'Wildcard Importer',
   iframeSrc: SAME_ORIGIN_SRC,
+  // The public run surface. Required since the init-fragment gate keys on it.
+  surface: 'page-run' as const,
   sandbox: 'allow-scripts',
   trustTier: 'internal' as const,
   slug: 'wildcard-app',

--- a/src/components/AppBlocks/PageBlockHostWorkflow.browser.test.tsx
+++ b/src/components/AppBlocks/PageBlockHostWorkflow.browser.test.tsx
@@ -157,6 +157,8 @@ const baseProps = {
   blockInstanceId: 'page_apb_test',
   appName: 'Budgeted Generator',
   iframeSrc: SAME_ORIGIN_SRC,
+  // The public run surface. Required since the init-fragment gate keys on it.
+  surface: 'page-run' as const,
   sandbox: 'allow-scripts',
   trustTier: 'internal' as const,
   slug: 'my-page-app',

--- a/src/components/AppBlocks/__tests__/blockIframeUrl.test.ts
+++ b/src/components/AppBlocks/__tests__/blockIframeUrl.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildBlockIframeSrc, encodeBlockInitFragment } from '../blockIframeUrl';
+
+/**
+ * 🔴 THE LITERAL BELOW IS THE WIRE CONTRACT, and this test is the ONLY thing
+ * holding the two repos together.
+ *
+ * civitai cannot import the SDK's decoder — it consumes the PUBLISHED
+ * `@civitai/app-sdk` dist and the decoder ships in a version that is not
+ * published when this lands — so `blockIframeUrl.ts` carries a mirrored
+ * encoder. `civitai-app-starters`'
+ * `packages/civitai-app-sdk/test/initFragment.test.ts` pins this SAME string
+ * from the decoder's side. Change one and you must change the other.
+ *
+ * Deliberately a literal, NOT `encodeBlockInitFragment(...)` compared against
+ * itself: an expectation derived from the implementation cannot detect a
+ * format change, which is the exact failure this pin exists to catch.
+ */
+const WIRE_LITERAL = 'civitai-block=v1&theme=dark&renderMode=iframe&blockInstanceId=bi_abc';
+
+describe('encodeBlockInitFragment', () => {
+  it('produces the exact pinned wire literal', () => {
+    expect(
+      encodeBlockInitFragment({ theme: 'dark', renderMode: 'iframe', blockInstanceId: 'bi_abc' })
+    ).toBe(WIRE_LITERAL);
+  });
+
+  it('percent-encodes a blockInstanceId so it cannot smuggle extra fragment keys', () => {
+    const encoded = encodeBlockInitFragment({
+      theme: 'light',
+      renderMode: 'iframe',
+      blockInstanceId: 'x&theme=dark',
+    });
+    expect(encoded).toBe(
+      'civitai-block=v1&theme=light&renderMode=iframe&blockInstanceId=x%26theme%3Ddark'
+    );
+  });
+});
+
+describe('buildBlockIframeSrc', () => {
+  const FIELDS = { theme: 'dark', renderMode: 'iframe', blockInstanceId: 'bi_abc' } as const;
+
+  it('appends the fragment to a plain publisher src', () => {
+    expect(buildBlockIframeSrc('https://demo.civit.ai/', FIELDS)).toBe(
+      `https://demo.civit.ai/#${WIRE_LITERAL}`
+    );
+  });
+
+  it('leaves an existing query string intact and does not touch it', () => {
+    // The dev-tunnel route ships `?dev=<token>`; the fragment must be additive
+    // and must not disturb the query.
+    expect(buildBlockIframeSrc('https://tunnel.example.com/?dev=abc123', FIELDS)).toBe(
+      `https://tunnel.example.com/?dev=abc123#${WIRE_LITERAL}`
+    );
+  });
+
+  it('NO-STOMP: returns the src UNCHANGED when the publisher already uses the fragment', () => {
+    // 🔴 A CORRECTNESS property, NOT a mitigation — and an earlier version of
+    // this comment wrongly called it "the compatibility guard for hash-routing
+    // block apps". `stampCanonicalIframeSrc` unconditionally overwrites
+    // `manifest.iframe.src` server-side, and the manifest schema rejects a
+    // dev-set value, so no production block's src can EVER arrive carrying a
+    // fragment: this branch cannot fire for one. The real protection is the
+    // gate (see blockInitFragmentGate.ts). Kept because it is cheap and correct
+    // if such an src ever does arrive.
+    const hashRouted = 'https://demo.civit.ai/#/dashboard';
+    expect(buildBlockIframeSrc(hashRouted, FIELDS)).toBe(hashRouted);
+
+    const anchored = 'https://demo.civit.ai/page#section-2';
+    expect(buildBlockIframeSrc(anchored, FIELDS)).toBe(anchored);
+  });
+
+  it('claims a BARE trailing hash (it carries no publisher state)', () => {
+    expect(buildBlockIframeSrc('https://demo.civit.ai/#', FIELDS)).toBe(
+      `https://demo.civit.ai/#${WIRE_LITERAL}`
+    );
+  });
+
+  it('returns an empty src unchanged (malformed manifest — the host collapses on it)', () => {
+    expect(buildBlockIframeSrc('', FIELDS)).toBe('');
+  });
+
+  it('returns an unparseable src unchanged rather than throwing', () => {
+    expect(buildBlockIframeSrc('not a url', FIELDS)).toBe('not a url');
+    expect(buildBlockIframeSrc('/relative/path', FIELDS)).toBe('/relative/path');
+  });
+
+  it('returns the src unchanged when there is no blockInstanceId to state', () => {
+    expect(buildBlockIframeSrc('https://demo.civit.ai/', { ...FIELDS, blockInstanceId: '' })).toBe(
+      'https://demo.civit.ai/'
+    );
+  });
+
+  it('🔴 never puts a token, viewer or context in the URL', () => {
+    // Belt on the security property: the ONLY three fields this function can
+    // emit are the ones it takes. If a future edit widens the input, this
+    // enumeration of the produced fragment keys fails.
+    const out = buildBlockIframeSrc('https://demo.civit.ai/', FIELDS);
+    const keys = [...new URLSearchParams(new URL(out).hash.slice(1)).keys()].sort();
+    expect(keys).toEqual(['blockInstanceId', 'civitai-block', 'renderMode', 'theme']);
+  });
+
+  it('preserves the origin, so the postMessage target is unaffected', () => {
+    const out = buildBlockIframeSrc('https://demo.civit.ai/app', FIELDS);
+    expect(new URL(out).origin).toBe(new URL('https://demo.civit.ai/app').origin);
+  });
+});

--- a/src/components/AppBlocks/__tests__/blockInitFragmentGate.test.ts
+++ b/src/components/AppBlocks/__tests__/blockInitFragmentGate.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  BLOCK_INIT_FRAGMENT_ALLOWLIST,
+  BLOCK_INIT_FRAGMENT_DENYLIST,
+  blockInitFragmentEnabled,
+  blockInitFragmentEnabledWith,
+  type BlockHostSurface,
+} from '../blockInitFragmentGate';
+
+const ALL_SURFACES: BlockHostSurface[] = ['model-slot', 'page-run', 'dev-tunnel', 'review-preview'];
+
+/**
+ * A NON-EMPTY allowlist, used to make the ordering guarantees observable.
+ *
+ * 🔴 Testing the production binding alone would be vacuous. Its allowlist is
+ * empty, so every call returns `false`, and `false` cannot distinguish "the dev
+ * tunnel was refused first" from "nothing was allowlisted" — a guard only ever
+ * seen returning false is an untested guard. Driving the injectable form with
+ * entries present is what makes each branch REACHABLE.
+ */
+const TEST_ALLOW: ReadonlySet<string> = new Set([
+  'apb_allowed',
+  'allowed-slug',
+  'playable-collections',
+]);
+const TEST_DENY: ReadonlySet<string> = new Set(['playable-collections']);
+
+describe('blockInitFragmentEnabledWith — positive control', () => {
+  it('🔴 CAN return true — otherwise every other assertion here is vacuous', () => {
+    // If this ever fails, the predicate has been reduced to a constant `false`
+    // and the rest of this file proves nothing.
+    expect(
+      blockInitFragmentEnabledWith(
+        { surface: 'page-run', blockId: 'apb_allowed' },
+        TEST_ALLOW,
+        TEST_DENY
+      )
+    ).toBe(true);
+    expect(
+      blockInitFragmentEnabledWith(
+        { surface: 'model-slot', slug: 'allowed-slug' },
+        TEST_ALLOW,
+        TEST_DENY
+      )
+    ).toBe(true);
+  });
+});
+
+describe('blockInitFragmentEnabledWith — the dev tunnel is refused BY CONSTRUCTION', () => {
+  it('🔴 refuses dev-tunnel even for a block that IS allowlisted', () => {
+    // The gap an allowlist cannot close. `resolveDevPageBlockForAuthor` applies
+    // no status filter, so the tunnel mounts arbitrary UNPUBLISHED code under
+    // the SAME blockId the author will eventually publish. Were the surface not
+    // an independent axis checked FIRST, allowlisting a block for production
+    // would silently enable it on the author's draft too.
+    //
+    // The sibling assertion is what gives this teeth: the identical id on
+    // another surface returns TRUE, so the only thing producing `false` here is
+    // the surface check.
+    expect(
+      blockInitFragmentEnabledWith(
+        { surface: 'dev-tunnel', blockId: 'apb_allowed' },
+        TEST_ALLOW,
+        TEST_DENY
+      )
+    ).toBe(false);
+    expect(
+      blockInitFragmentEnabledWith(
+        { surface: 'page-run', blockId: 'apb_allowed' },
+        TEST_ALLOW,
+        TEST_DENY
+      )
+    ).toBe(true);
+  });
+
+  it('refuses dev-tunnel for every id shape, allowlisted or not', () => {
+    for (const args of [
+      { blockId: 'apb_allowed' },
+      { slug: 'allowed-slug' },
+      { blockId: 'apb_allowed', slug: 'allowed-slug' },
+      { blockId: 'apb_unknown' },
+      {},
+    ]) {
+      expect(
+        blockInitFragmentEnabledWith({ surface: 'dev-tunnel', ...args }, TEST_ALLOW, TEST_DENY)
+      ).toBe(false);
+    }
+  });
+});
+
+describe('blockInitFragmentEnabledWith — the denylist beats the allowlist', () => {
+  it('🔴 refuses a block present in BOTH lists', () => {
+    // `playable-collections` is deliberately in TEST_ALLOW as well as
+    // TEST_DENY. If the order were flipped, this would return true.
+    expect(TEST_ALLOW.has('playable-collections')).toBe(true);
+    expect(
+      blockInitFragmentEnabledWith(
+        { surface: 'page-run', slug: 'playable-collections' },
+        TEST_ALLOW,
+        TEST_DENY
+      )
+    ).toBe(false);
+    expect(
+      blockInitFragmentEnabledWith(
+        { surface: 'model-slot', blockId: 'playable-collections' },
+        TEST_ALLOW,
+        TEST_DENY
+      )
+    ).toBe(false);
+  });
+
+  it('refuses a denylisted block on every surface', () => {
+    for (const surface of ALL_SURFACES) {
+      expect(
+        blockInitFragmentEnabledWith(
+          { surface, slug: 'playable-collections' },
+          TEST_ALLOW,
+          TEST_DENY
+        )
+      ).toBe(false);
+    }
+  });
+});
+
+describe('blockInitFragmentEnabledWith — opt-in only', () => {
+  it('refuses a block that is in neither list', () => {
+    for (const surface of ALL_SURFACES) {
+      expect(
+        blockInitFragmentEnabledWith(
+          { surface, blockId: 'apb_stranger', slug: 'stranger' },
+          TEST_ALLOW,
+          TEST_DENY
+        )
+      ).toBe(false);
+    }
+  });
+
+  it('refuses when neither a blockId nor a slug is known', () => {
+    for (const surface of ALL_SURFACES) {
+      expect(blockInitFragmentEnabledWith({ surface }, TEST_ALLOW, TEST_DENY)).toBe(false);
+      expect(
+        blockInitFragmentEnabledWith({ surface, blockId: null, slug: null }, TEST_ALLOW, TEST_DENY)
+      ).toBe(false);
+      // Empty strings must not match an empty-string allowlist entry either.
+      expect(
+        blockInitFragmentEnabledWith({ surface, blockId: '', slug: '' }, TEST_ALLOW, TEST_DENY)
+      ).toBe(false);
+    }
+  });
+});
+
+describe('blockInitFragmentEnabled — the PRODUCTION binding is OFF', () => {
+  it('🔴 ships with an EMPTY allowlist, so the fast path is inert everywhere', () => {
+    // A live-block enumeration on 2026-08-05 found that NO deployed block can
+    // decode the fragment (`civitai-block=v1` x0 across 20 bundles) because the
+    // SDK half is merged but unpublished. Shipping it enabled would be pure
+    // risk for zero benefit.
+    expect(BLOCK_INIT_FRAGMENT_ALLOWLIST.size).toBe(0);
+    for (const surface of ALL_SURFACES) {
+      expect(blockInitFragmentEnabled({ surface, blockId: 'anything', slug: 'anything' })).toBe(
+        false
+      );
+    }
+  });
+
+  it('pins playable-collections in the real denylist', () => {
+    // It reads `location.hash` on first load and fails closed against our
+    // fragment only BY LUCK — it looks for a `c` key we do not carry. Pinning
+    // the entry means widening the allowlist later cannot silently re-enable it.
+    expect(BLOCK_INIT_FRAGMENT_DENYLIST.has('playable-collections')).toBe(true);
+  });
+});

--- a/src/components/AppBlocks/__tests__/blockInitFragmentGate.test.ts
+++ b/src/components/AppBlocks/__tests__/blockInitFragmentGate.test.ts
@@ -89,6 +89,37 @@ describe('blockInitFragmentEnabledWith — the dev tunnel is refused BY CONSTRUC
   });
 });
 
+describe('blockInitFragmentEnabledWith — review-preview is refused too', () => {
+  it('🔴 refuses review-preview even for a block that IS allowlisted', () => {
+    // Same argument as the dev tunnel, and it transfers wholesale: the review
+    // surface mints `page_<pubreq_…>` for a PENDING, UN-APPROVED submission, so
+    // allowlisting a PUBLISHED app would enable the fragment on a moderator's
+    // preview of that app's next unreviewed code. The sibling assertion is what
+    // gives this teeth — the same id on page-run returns TRUE.
+    expect(
+      blockInitFragmentEnabledWith(
+        { surface: 'review-preview', blockId: 'apb_allowed' },
+        TEST_ALLOW,
+        TEST_DENY
+      )
+    ).toBe(false);
+    expect(
+      blockInitFragmentEnabledWith(
+        { surface: 'page-run', blockId: 'apb_allowed' },
+        TEST_ALLOW,
+        TEST_DENY
+      )
+    ).toBe(true);
+  });
+
+  it('leaves exactly two eligible surfaces: model-slot and page-run', () => {
+    const eligible = ALL_SURFACES.filter((surface) =>
+      blockInitFragmentEnabledWith({ surface, blockId: 'apb_allowed' }, TEST_ALLOW, TEST_DENY)
+    );
+    expect(eligible).toEqual(['model-slot', 'page-run']);
+  });
+});
+
 describe('blockInitFragmentEnabledWith — the denylist beats the allowlist', () => {
   it('🔴 refuses a block present in BOTH lists', () => {
     // `playable-collections` is deliberately in TEST_ALLOW as well as
@@ -162,6 +193,29 @@ describe('blockInitFragmentEnabled — the PRODUCTION binding is OFF', () => {
         false
       );
     }
+  });
+
+  it('🔴 the PRODUCTION binding passes allow/deny in the RIGHT ORDER', () => {
+    // The gap the injectable form leaves, and one the COMPILER CANNOT CATCH:
+    // `blockInitFragmentEnabledWith(args, allowlist, denylist)` takes two
+    // arguments of the SAME type, so swapping them type-checks cleanly. An
+    // audit swapped them at the binding and ALL NINE of the tests above stayed
+    // green, because they drive the injectable form directly — while
+    // `blockInitFragmentEnabled({surface:'page-run', slug:'playable-collections'})`
+    // started returning TRUE. The one block named as must-never-receive would
+    // have received it.
+    //
+    // Neither `ALLOWLIST.size === 0` nor `DENYLIST.has(...)` nor a lookup of an
+    // unknown id can see that swap: with the lists exchanged, the (empty)
+    // allowlist becomes the denylist and the denylist becomes the allowlist, so
+    // a denylisted slug is "allowed". Only asserting a DENYLISTED id through the
+    // production binding distinguishes the two wirings.
+    expect(blockInitFragmentEnabled({ surface: 'page-run', slug: 'playable-collections' })).toBe(
+      false
+    );
+    expect(
+      blockInitFragmentEnabled({ surface: 'model-slot', blockId: 'playable-collections' })
+    ).toBe(false);
   });
 
   it('pins playable-collections in the real denylist', () => {

--- a/src/components/AppBlocks/blockIframeUrl.ts
+++ b/src/components/AppBlocks/blockIframeUrl.ts
@@ -1,0 +1,154 @@
+// App Blocks — the iframe URL FRAGMENT fast path.
+//
+// WHAT THIS IS
+// ------------
+// `theme`, `renderMode` and `blockInstanceId` ship in the `BLOCK_INIT`
+// postMessage payload. That payload cannot be posted until the host has a
+// block token AND the effective-checkpoint query has resolved, so a block
+// cannot paint its own loading state in the right theme, nor key any
+// per-instance bootstrap, until the handshake completes. Repeating the same
+// three values in the iframe URL's FRAGMENT makes them readable by the block
+// synchronously at document-parse time, before a single message is exchanged.
+//
+// 🔴 THE PAYLOAD REMAINS AUTHORITATIVE. This is an additive FAST PATH:
+//   - `BLOCK_INIT` still carries all three fields, and the SDK's
+//     `snapshotFromInit` replaces the whole snapshot when it lands, so the
+//     payload always wins over the fragment.
+//   - A block is only `ready` after `BLOCK_INIT`. The fragment never makes a
+//     block ready.
+//   - A NEW block against an OLD host sees no fragment and falls back to
+//     waiting for the payload — i.e. today's behaviour.
+//
+// 🔴 THE TOKEN IS NEVER PUT IN THE URL. Only these three non-secret fields
+// are. URLs leak into `document.referrer`, browser history, proxy logs and
+// screenshots; a bearer token must not. `token`, `viewer`, `settings` and
+// `context` stay in the postMessage payload.
+//
+// WHY A FRAGMENT AND NOT A QUERY ARG
+// ----------------------------------
+// A fragment is never transmitted to the block's origin server, so it cannot
+// perturb caching, server-side routing, or a strict query-param validator on
+// the publisher's side. It is also the only part of a URL that can be changed
+// WITHOUT re-navigating the document, which is what makes a future
+// no-reload update of `renderMode`/`theme` possible at all. See
+// "PROPAGATING A CHANGE" below for what is and is not implemented today.
+//
+// WIRE FORMAT (v1) — mirrored by `@civitai/app-sdk`'s `parseBlockInitFragment`:
+//
+//   #civitai-block=v1&theme=dark&renderMode=iframe&blockInstanceId=bi_abc
+//
+// The body is a standard `URLSearchParams` string; `civitai-block=v1` is both
+// the namespace marker and the format version, so a reader can tell OUR
+// fragment from a block app's own hash state without guessing.
+//
+// 🔴 THIS IS A MIRRORED CONTRACT, NOT A SHARED IMPORT. civitai consumes the
+// PUBLISHED `@civitai/app-sdk` dist, and the decoder lands in a version that
+// is not published yet, so the encoder cannot import it. `__tests__/blockIframeUrl.test.ts`
+// pins the exact literal output string — change the format on one side and that
+// literal must be changed here AND in the SDK's `initFragment.test.ts`, which
+// pins the same literal from the decoder's side.
+//
+// NO-STOMP RULE — 🔴 A CORRECTNESS PROPERTY, *NOT* A MITIGATION
+// -------------------------------------------------------------
+// If the publisher's `iframe.src` ALREADY carries a fragment, we append
+// nothing and return the src untouched.
+//
+// 🔴 THIS BRANCH CANNOT FIRE FOR A PRODUCTION BLOCK, AND AN EARLIER VERSION OF
+// THIS COMMENT WAS WRONG TO CALL IT "the compatibility guard for hash-routing
+// block apps". `stampCanonicalIframeSrc`
+// (`src/server/services/blocks/manifest-normalize.ts`) UNCONDITIONALLY
+// overwrites `manifest.iframe.src` with `https://<slug>.<appsDomain>/` — its
+// own doc comment says "Any developer-supplied `iframe.src` is overwritten" —
+// and the manifest schema independently rejects a dev-set `iframe.src`. The
+// dev-tunnel URL is server-derived too. So no src reaching this function can
+// carry a publisher fragment, and a hash-routing block is NOT protected here.
+//
+// The real protection is the GATE (`blockInitFragmentGate.ts`): off by default
+// for every block, and unconditionally off for the dev tunnel. This branch is
+// kept because it is cheap and correct if a fragment-bearing src ever does
+// arrive — but it must not be counted as a mitigation, and the hazard it was
+// once claimed to cover is the entire deployed population, not a tail case.
+//
+// PROPAGATING A CHANGE
+// --------------------
+// Today nothing changes these three values for a MOUNTED block:
+//   - `renderMode` is a per-install constant (`'iframe'` at every iframe call
+//     site) and cannot change without a remount;
+//   - `theme` CAN change (the viewer toggles dark mode) but the host has never
+//     propagated that to a live block — `BLOCK_INIT` is deduped by the SDK, so
+//     a later theme value never reaches it;
+//   - `blockInstanceId` is immutable per mount.
+// So the hosts FREEZE the fragment at mount (see `useBlockIframeSrc.ts`) and
+// the observable behaviour of a running block is unchanged by this module. The
+// alternative — recomputing the fragment from live values — would make the
+// iframe's `src` attribute change on a theme toggle, which is a navigation
+// where today there is none. That is a behaviour change nobody asked for and
+// is deliberately not made here.
+//
+// When a live update IS wanted, the mechanism the fragment buys is: the host
+// rewrites ONLY the fragment of the existing `src` (a same-document fragment
+// navigation, no reload) and the block observes it via a `hashchange`
+// listener. That needs an SDK-side listener that does not exist yet, so it is
+// explicitly out of scope here — and note the freeze above means shipping it
+// later is purely additive.
+
+/** Fragment key that both namespaces and versions the payload. */
+export const BLOCK_INIT_FRAGMENT_MARKER_KEY = 'civitai-block';
+
+/** Current fragment format version. */
+export const BLOCK_INIT_FRAGMENT_VERSION = 'v1';
+
+export interface BlockInitFragmentFields {
+  theme: 'light' | 'dark';
+  renderMode: 'iframe' | 'inline';
+  blockInstanceId: string;
+}
+
+/**
+ * Encode the fast-path fields into a fragment BODY (no leading `#`).
+ *
+ * Key order is fixed (marker first) so the output is deterministic and can be
+ * pinned by a literal-valued test on both sides of the wire.
+ */
+export function encodeBlockInitFragment(fields: BlockInitFragmentFields): string {
+  const params = new URLSearchParams();
+  params.set(BLOCK_INIT_FRAGMENT_MARKER_KEY, BLOCK_INIT_FRAGMENT_VERSION);
+  params.set('theme', fields.theme);
+  params.set('renderMode', fields.renderMode);
+  params.set('blockInstanceId', fields.blockInstanceId);
+  return params.toString();
+}
+
+/**
+ * Append the init fragment to a publisher-supplied iframe `src`.
+ *
+ * Returns `baseSrc` UNCHANGED when:
+ *   - `blockInstanceId` is empty (nothing useful to say), or
+ *   - it does not parse as an absolute URL — which covers BOTH the empty-string
+ *     src of a malformed manifest and a relative one. There is deliberately no
+ *     separate `if (!baseSrc)` early return: `new URL('')` throws, so the catch
+ *     below already returns the input, and a second guard for the same case
+ *     would be one no mutation can kill.
+ *   - it already carries a fragment (the no-stomp rule above).
+ *
+ * Never throws: a bad `src` returns the input, and the caller's existing
+ * `new URL(src).origin` guard is what rejects it.
+ */
+export function buildBlockIframeSrc(baseSrc: string, fields: BlockInitFragmentFields): string {
+  if (!fields.blockInstanceId) return baseSrc;
+
+  let url: URL;
+  try {
+    url = new URL(baseSrc);
+  } catch {
+    return baseSrc;
+  }
+
+  // NO-STOMP: the publisher is already using the fragment. `URL#hash` is the
+  // empty string when there is no fragment, and `'#'` for a bare trailing
+  // hash — treat the bare hash as "unused" and claim it.
+  if (url.hash && url.hash !== '#') return baseSrc;
+
+  url.hash = encodeBlockInitFragment(fields);
+  return url.toString();
+}

--- a/src/components/AppBlocks/blockInitFragmentGate.ts
+++ b/src/components/AppBlocks/blockInitFragmentGate.ts
@@ -1,0 +1,156 @@
+// App Blocks — the GATE on the iframe init-fragment fast path.
+//
+// WHY THIS EXISTS
+// ---------------
+// The fragment fast path (see `blockIframeUrl.ts`) appends
+// `#civitai-block=v1&…` to a third-party block's iframe URL. A live-block
+// enumeration on 2026-08-05 established two facts that together make an
+// UNCONDITIONAL append the wrong default:
+//
+//   1. 🔴 NO DEPLOYED BLOCK CAN DECODE IT. Across all 20 live bundles,
+//      `civitai-block=v1` x0 and `BLOCK_HELLO` x0. The SDK half is merged but
+//      NOT published (npm latest is still `@civitai/app-sdk@0.30.0`). So the
+//      fast path currently buys exactly nothing, and "zero benefit" is the
+//      decisive argument, not the risk level.
+//   2. 🔴 THE `iframe.src` NO-STOMP GUARD PROTECTS AN EMPTY SET.
+//      `stampCanonicalIframeSrc` (server-side) UNCONDITIONALLY overwrites
+//      `manifest.iframe.src` with `https://<slug>.<appsDomain>/`, and the
+//      manifest schema independently rejects a dev-set `iframe.src`. So no
+//      production block's src can ever arrive carrying a fragment, and the
+//      no-stomp branch in `buildBlockIframeSrc` cannot fire for one. It is
+//      retained as a cheap correctness property, NOT counted as a mitigation.
+//
+// So the fast path is OFF by default, everywhere, and turns on per block only
+// once that block ships an SDK that decodes it.
+//
+// 🔴 THIS IS AN OPT-IN ALLOWLIST, NOT A RUNTIME KILL SWITCH. Enabling or
+// disabling a block is a deploy. That is an honest limitation and it is stated
+// here rather than in a commit message: with `ALLOWLIST` empty the feature is
+// inert, so there is nothing to revoke in a hurry, but if a runtime switch is
+// wanted the right home is a feature flag in the flags service — outside this
+// module and deliberately not added here.
+
+/**
+ * The surfaces that can mount an iframe block host. Passed explicitly by each
+ * call site rather than inferred, so that adding a new surface is a
+ * type error until someone decides what it should do.
+ */
+export type BlockHostSurface =
+  /** `IframeHost` in a model-page slot (`model.sidebar_top`, …). */
+  | 'model-slot'
+  /** The full-page run host, `/apps/run/<slug>`. */
+  | 'page-run'
+  /** The author's dev tunnel, `/apps/dev/<blockId>`. 🔴 Never eligible. */
+  | 'dev-tunnel'
+  /** Moderator review surfaces (review modal + full-page preview). */
+  | 'review-preview';
+
+/**
+ * Blocks permitted the fragment fast path, keyed by `blockId` OR `slug`
+ * (whichever the surface knows — the model slot has a `blockId`, the page host
+ * has both).
+ *
+ * 🔴 KEYING ASYMMETRY — READ BEFORE ADDING AN ENTRY. The page host knows BOTH
+ * a `blockId` and a `slug`; the MODEL SLOT knows only a `blockId` (`BlockInstall`
+ * has no `slug` field at all). So an entry written as a slug silently does
+ * NOTHING on the model slot. When enabling a block, add its `blockId` — or add
+ * both — and verify on the surface you actually care about.
+ *
+ * 🔴 EMPTY MEANS THE FEATURE IS OFF EVERYWHERE. That is the intended state
+ * until blocks rebuild against an SDK that decodes the fragment. Adding an
+ * entry is a deliberate, per-block decision that should be made only once THAT
+ * block is known to ship a decoding SDK — the fragment is inert to a block that
+ * does not read it, but a block that reads `location.hash` for its OWN purposes
+ * can be perturbed by it (see DENYLIST).
+ */
+export const BLOCK_INIT_FRAGMENT_ALLOWLIST: ReadonlySet<string> = new Set<string>([]);
+
+/**
+ * Blocks that must NEVER receive the fragment, whatever the allowlist says.
+ *
+ * `playable-collections` reads `location.hash` on first load and strips it
+ * afterwards. It fails closed against our fragment only BY LUCK — it looks for
+ * a `c` key that `civitai-block=v1&theme=…` does not carry. That is a
+ * coincidence, not a contract, and it would be silently re-broken by any future
+ * change to either side's key set. The denylist is checked BEFORE the
+ * allowlist so that whoever eventually widens the allowlist cannot
+ * accidentally re-enable it.
+ */
+export const BLOCK_INIT_FRAGMENT_DENYLIST: ReadonlySet<string> = new Set<string>([
+  'playable-collections',
+]);
+
+/**
+ * May this host append the init fragment to its iframe URL?
+ *
+ * Order is load-bearing:
+ *   1. `dev-tunnel` is refused UNCONDITIONALLY — see below.
+ *   2. DENYLIST beats the allowlist.
+ *   3. Otherwise, the block must be explicitly allowlisted.
+ * Anything unrecognised falls through to `false`.
+ *
+ * 🔴 WHY `dev-tunnel` IS REFUSED BY CONSTRUCTION AND NOT BY OMISSION.
+ * `resolveDevPageBlockForAuthor` applies NO status filter at all — deliberately,
+ * so an author can iterate on a draft. The repo says so itself in
+ * `src/pages/api/v1/block-tokens/index.ts`: the SSR dev route "mounts an OWNED
+ * app at ANY status". It mounts the same real `PageBlockHost` as production, so
+ * the fragment would reach ARBITRARY UNPUBLISHED CODE that no query can
+ * enumerate — and the PWA starters' own docs (`starters/{react,svelte}-pwa`
+ * README / AGENTS.md / `.claude/commands/add-route.md`, five places) steer
+ * authors toward exactly the `location.hash` routing this would perturb. It is
+ * the one surface where the hazard is live today and structurally unmeasurable.
+ *
+ * An allowlist keyed on blockId/slug CANNOT cover that case: a block whose id
+ * is allowlisted for production is the SAME id the author iterates on through
+ * the tunnel. So the surface is a second, independent axis, and it is checked
+ * first.
+ */
+export function blockInitFragmentEnabledWith(
+  args: {
+    surface: BlockHostSurface;
+    blockId?: string | null;
+    slug?: string | null;
+  },
+  allowlist: ReadonlySet<string>,
+  denylist: ReadonlySet<string>
+): boolean {
+  const { surface, blockId, slug } = args;
+
+  // (1) Unconditional: no allowlist entry can enable the dev tunnel.
+  if (surface === 'dev-tunnel') return false;
+
+  // (2) Denylist beats everything below it.
+  if (blockId && denylist.has(blockId)) return false;
+  if (slug && denylist.has(slug)) return false;
+
+  // (3) Explicit opt-in only. Empty allowlist ⇒ false for every block.
+  if (blockId && allowlist.has(blockId)) return true;
+  if (slug && allowlist.has(slug)) return true;
+
+  return false;
+}
+
+/**
+ * Production binding of {@link blockInitFragmentEnabledWith} against the real
+ * module constants. This is what the hosts call.
+ *
+ * The lists are injected in the `…With` form rather than read from module
+ * scope so the ORDERING guarantees above can actually be TESTED. With the real
+ * allowlist empty, every outcome is `false`, and a test written against it
+ * cannot distinguish "the dev tunnel was refused first" from "nothing is
+ * allowlisted" — a guard that can only ever be observed returning false is an
+ * untested guard. See `__tests__/blockInitFragmentGate.test.ts`, which drives
+ * the injectable form with a NON-EMPTY allowlist and includes a positive
+ * control proving the predicate can return `true` at all.
+ */
+export function blockInitFragmentEnabled(args: {
+  surface: BlockHostSurface;
+  blockId?: string | null;
+  slug?: string | null;
+}): boolean {
+  return blockInitFragmentEnabledWith(
+    args,
+    BLOCK_INIT_FRAGMENT_ALLOWLIST,
+    BLOCK_INIT_FRAGMENT_DENYLIST
+  );
+}

--- a/src/components/AppBlocks/blockInitFragmentGate.ts
+++ b/src/components/AppBlocks/blockInitFragmentGate.ts
@@ -32,8 +32,12 @@
 
 /**
  * The surfaces that can mount an iframe block host. Passed explicitly by each
- * call site rather than inferred, so that adding a new surface is a
- * type error until someone decides what it should do.
+ * `PageBlockHost` call site rather than inferred, so that adding a new PAGE
+ * host is a type error until someone decides what it should do.
+ *
+ * ⚠️ That type-error guarantee covers `PageBlockHost` ONLY. `IframeHost`
+ * hard-codes `surface: 'model-slot'` internally, so a new MODEL-slot host would
+ * inherit that literal silently rather than being forced to choose.
  */
 export type BlockHostSurface =
   /** `IframeHost` in a model-page slot (`model.sidebar_top`, …). */
@@ -89,7 +93,20 @@ export const BLOCK_INIT_FRAGMENT_DENYLIST: ReadonlySet<string> = new Set<string>
  *   3. Otherwise, the block must be explicitly allowlisted.
  * Anything unrecognised falls through to `false`.
  *
- * 🔴 WHY `dev-tunnel` IS REFUSED BY CONSTRUCTION AND NOT BY OMISSION.
+ * 🔴 WHY `dev-tunnel` AND `review-preview` ARE REFUSED BY CONSTRUCTION.
+ *
+ * Both mount code that has NOT been reviewed, under an identity an allowlist
+ * cannot distinguish from the reviewed one:
+ *
+ *   - `review-preview` mints `page_<pubreq_…>` for a PENDING, UN-APPROVED
+ *     publish request (`publish-request.service.ts`), i.e. a moderator opening
+ *     the next unreviewed submission of an app — with a moderator's session, on
+ *     a surface every other layer treats as maximum-hazard. And on page-run
+ *     `slug === blockId`, so allowlisting a PUBLISHED app would necessarily
+ *     enable the fragment on the moderator's preview of that same app's next
+ *     unreviewed submission. The dev-tunnel argument transfers wholesale; there
+ *     is no version of it that stops at the tunnel.
+ *
  * `resolveDevPageBlockForAuthor` applies NO status filter at all — deliberately,
  * so an author can iterate on a draft. The repo says so itself in
  * `src/pages/api/v1/block-tokens/index.ts`: the SSR dev route "mounts an OWNED
@@ -116,8 +133,10 @@ export function blockInitFragmentEnabledWith(
 ): boolean {
   const { surface, blockId, slug } = args;
 
-  // (1) Unconditional: no allowlist entry can enable the dev tunnel.
-  if (surface === 'dev-tunnel') return false;
+  // (1) Unconditional: no allowlist entry can enable a surface that mounts
+  //     UNREVIEWED code. See the doc comment above for why identity-keying
+  //     cannot express this.
+  if (surface === 'dev-tunnel' || surface === 'review-preview') return false;
 
   // (2) Denylist beats everything below it.
   if (blockId && denylist.has(blockId)) return false;

--- a/src/components/AppBlocks/useBlockIframeSrc.ts
+++ b/src/components/AppBlocks/useBlockIframeSrc.ts
@@ -1,0 +1,49 @@
+import { useMemo, useRef } from 'react';
+
+import { buildBlockIframeSrc, type BlockInitFragmentFields } from './blockIframeUrl';
+
+/**
+ * The `src` an App Blocks iframe host should render: the publisher's
+ * `manifest.iframe.src`, plus the init-fragment fast path when — and only when
+ * — this block is gated ON for it (see `blockInitFragmentGate.ts`).
+ *
+ * `enabled` is a REQUIRED parameter, not an optional one with a permissive
+ * default. Every call site must state its answer, so adding a new host is a
+ * type error rather than a silent opt-in.
+ *
+ * 🔴 THE FRAGMENT FIELDS ARE FROZEN AT MOUNT, ON PURPOSE.
+ *
+ * `theme` can change while a block is mounted (the viewer toggles dark mode).
+ * If the fragment tracked it, the iframe's `src` ATTRIBUTE would change on a
+ * theme toggle — a navigation of a third-party frame where today there is
+ * none. At best that is a `hashchange` inside the block; at worst a reload that
+ * discards its in-progress state. In exchange for nothing: the host does not
+ * propagate live theme changes to blocks today either, because the SDK dedupes
+ * `BLOCK_INIT` and no theme-change message exists. Freezing keeps the rendered
+ * `src` exactly as stable as it is today.
+ *
+ * This invariant is the safety argument for the whole fast path, so it is
+ * pinned directly by `BlockInitFragmentFreeze.browser.test.tsx` — mount, change
+ * `theme`, assert the produced string is byte-identical. That test exists
+ * because an audit found the freeze had NO coverage in either tier: swapping
+ * the frozen ref for live `fields` (with full deps) survived both suites.
+ *
+ * `baseSrc` is deliberately NOT frozen: if the publisher's manifest src really
+ * changes mid-mount, the iframe should re-navigate exactly as it does today.
+ */
+export function useBlockIframeSrc(
+  baseSrc: string,
+  fields: BlockInitFragmentFields,
+  enabled: boolean
+): string {
+  // First-render capture. A ref (not state) because there is no update path —
+  // the value is written once, at mount, and read forever after.
+  const frozenFields = useRef<BlockInitFragmentFields>(fields);
+
+  return useMemo(
+    () => (enabled ? buildBlockIframeSrc(baseSrc, frozenFields.current) : baseSrc),
+    // frozenFields.current is stable for the component's lifetime, so baseSrc
+    // and the gate are the only real inputs. Listed explicitly for the linter.
+    [baseSrc, enabled]
+  );
+}

--- a/src/components/AppBlocks/useBlockIframeSrc.ts
+++ b/src/components/AppBlocks/useBlockIframeSrc.ts
@@ -36,14 +36,42 @@ export function useBlockIframeSrc(
   fields: BlockInitFragmentFields,
   enabled: boolean
 ): string {
-  // First-render capture. A ref (not state) because there is no update path —
-  // the value is written once, at mount, and read forever after.
+  // The captured fields, and WHICH block instance they describe.
   const frozenFields = useRef<BlockInitFragmentFields>(fields);
+  const frozenFor = useRef<string>(fields.blockInstanceId);
+
+  // 🔴 SCOPED TO THE BLOCK INSTANCE, NOT TO THE MOUNT.
+  //
+  // A per-MOUNT ref is wrong here, and `PageBlockHost` says so itself: it is
+  // rendered with no `key`, and `_app.tsx` renders `<Component>` with no key
+  // either, so a SOFT navigation between two apps (appA → appB via the
+  // "Recently run" menu) REUSES the component instance — same mount, different
+  // `blockInstanceId`. Every other per-mount latch in that file was
+  // deliberately re-scoped to the instance for exactly this reason (see its
+  // `launchInstanceRef` / `shouldResetLaunchMarks` pair); this one was not, and
+  // the measured result was app B's document receiving app A's id and app A's
+  // mount-time theme while `BLOCK_INIT` delivered B's — a block seeing two
+  // contradicting identities.
+  //
+  // Re-capturing on an instance change keeps BOTH properties: within one block
+  // instance the fields are frozen (so a theme toggle cannot move the `src`
+  // attribute of a live third-party iframe), and across a soft-nav the new app
+  // gets its OWN id and the CURRENT theme.
+  //
+  // Assigning a ref during render is safe here because it is idempotent and
+  // derived purely from props — the same "reset derived state when a prop
+  // changes" pattern the sibling latch uses.
+  if (frozenFor.current !== fields.blockInstanceId) {
+    frozenFor.current = fields.blockInstanceId;
+    frozenFields.current = fields;
+  }
 
   return useMemo(
     () => (enabled ? buildBlockIframeSrc(baseSrc, frozenFields.current) : baseSrc),
-    // frozenFields.current is stable for the component's lifetime, so baseSrc
-    // and the gate are the only real inputs. Listed explicitly for the linter.
-    [baseSrc, enabled]
+    // `blockInstanceId` IS a dependency: on a soft-nav the capture above
+    // changes, and the memo must recompute to publish the new instance's
+    // fragment. `theme` and `renderMode` are deliberately absent — that
+    // absence is the freeze.
+    [baseSrc, enabled, fields.blockInstanceId]
   );
 }

--- a/src/components/Apps/ReviewBlockPreviewHost.tsx
+++ b/src/components/Apps/ReviewBlockPreviewHost.tsx
@@ -227,6 +227,9 @@ export function ReviewBlockPreviewHost({
         blockInstanceId={mintData.blockInstanceId}
         appName={mintData.appName}
         iframeSrc={iframeSrc}
+        // Moderator review surfaces (the review modal and the full-page
+        // preview both mount PageBlockHost through this component).
+        surface="review-preview"
         // Clamp the manifest sandbox to the review render-only set: drop
         // allow-popups / allow-downloads / allow-modals / allow-pointer-lock (+ the
         // top-nav / escape tokens intersectSandbox already strips) so an untrusted

--- a/src/pages/apps/dev/[blockId].tsx
+++ b/src/pages/apps/dev/[blockId].tsx
@@ -249,6 +249,11 @@ export default function DevTunnelPage(props: DevTunnelProps) {
             blockInstanceId={blockInstanceId}
             appName={appName}
             iframeSrc={iframeSrc}
+            // 🔴 The author dev tunnel. `resolveDevPageBlockForAuthor` applies NO
+            // status filter, so this mounts ARBITRARY UNPUBLISHED code that no
+            // query can enumerate. `blockInitFragmentEnabled` refuses this
+            // surface unconditionally — no allowlist entry can turn it on.
+            surface="dev-tunnel"
             sandbox={sandbox}
             trustTier={trustTier}
             slug={blockId}

--- a/src/pages/apps/run/[slug]/[[...path]].tsx
+++ b/src/pages/apps/run/[slug]/[[...path]].tsx
@@ -207,6 +207,8 @@ export default function AppPage(props: PageProps) {
           blockInstanceId={blockInstanceId}
           appName={appName}
           iframeSrc={iframeSrc}
+          // The public full-page run surface.
+          surface="page-run"
           sandbox={sandbox}
           trustTier={trustTier}
           slug={slug}


### PR DESCRIPTION
**Half 2 of 2.** Split out of #3631 after a live-block enumeration and an adversarial audit, both of which are on that PR. Handshake half: #3634. SDK counterpart: civitai/civitai-app-starters#212 (merged, **not yet published**).

# 🔴 This ships GATED OFF and is inert in production

`BLOCK_INIT_FRAGMENT_ALLOWLIST` is **empty**. No block on any surface gets the fragment. That is the intended state until blocks rebuild against an SDK that decodes it, and it is pinned by a test.

The reason is not risk tolerance, it is that **the fast path currently buys nothing**: a full enumeration of the 20 live bundles found `civitai-block=v1` × 0 and `BLOCK_HELLO` × 0, because the SDK half is merged but unpublished (npm latest is still `@civitai/app-sdk@0.30.0`). Shipping it enabled would take on risk for zero benefit.

---

# Two corrections to #3631's body

Both were mine, both were wrong, and together they inverted that PR's risk assessment. They are corrected here in the source comments as well as in this body.

### 1. NO-STOMP protected an empty set

#3631 called the no-stomp branch "the compatibility guard for hash-routing block apps … an existing fragment is the signal that we are looking at one."

**That signal is structurally unreachable.** `stampCanonicalIframeSrc` (`src/server/services/blocks/manifest-normalize.ts`) does:

```ts
manifest.iframe = { ...existing, src: canonicalIframeSrc(slug, appsDomain) };
```

— unconditional, and its own doc comment says *"Any developer-supplied `iframe.src` is overwritten."* The manifest schema independently rejects a dev-set `iframe.src`, and the dev-tunnel URL is server-derived too. So **no** src reaching `buildBlockIframeSrc` can carry a publisher fragment, the branch cannot fire for a production block, and the hazard it was claimed to cover is **the entire deployed population, not a tail case**.

The branch is retained — it is cheap and correct if such an src ever does arrive — but it is no longer counted as a mitigation anywhere. The real protection is the gate below.

### 2. The `0 hits` grep was wrong, and I can show exactly how

#3631 claimed: *"grep for `HashRouter|createHashRouter|useHashLocation|location.hash` across `packages/` + `starters/` = 0 hits"*, with a "positive control".

The invocation passed `--include=*.ts --include=*.tsx --include=*.js --include=*.jsx --include=*.svelte`, **which excludes `.md`** — and every real hit is in Markdown. My "positive control" then checked that the pattern shape could match entries in `package.json`, i.e. **a different file set than the claim**. That is the failure mode of validating an instrument other than the one you intend to trust: the control passed and told me nothing.

Re-run without the filter, against `civitai-app-starters@main`, this is **five** locations — more than the audit reported:

```
starters/svelte-pwa/README.md:71                      "drop in `svelte-spa-router` or a hash router"
starters/svelte-pwa/AGENTS.md:65                      "Hash router or `svelte-spa-router`"
starters/svelte-pwa/.claude/commands/add-route.md:16  "track `window.location.hash` with a Svelte effect"
starters/svelte-pwa/.claude/commands/add-route.md:17  "`svelte-spa-router`"  (hash-based)
starters/react-pwa/.claude/commands/add-route.md:16   "read `window.location.hash`; swap rendered component"
```

So the starters actively steer authors toward the one pattern the fragment perturbs — across README, AGENTS.md **and** the slash-command docs.

---

# The gate

`src/components/AppBlocks/blockInitFragmentGate.ts`. Two independent axes, checked in this order:

1. **Surface** — `dev-tunnel` **and `review-preview`** are refused **unconditionally**. Eligible surfaces are `model-slot` and `page-run` only.
2. **Denylist** — beats the allowlist.
3. **Allowlist** — explicit opt-in only; **empty today**.

### How it is keyed, and why the surface is a separate axis

Keyed on `blockId` **or** `slug` (whichever the surface knows). But an allowlist keyed on block identity **structurally cannot** cover the dev tunnel, which is exactly what was asked:

`resolveDevPageBlockForAuthor` applies **no status filter at all** — deliberately, so authors can iterate on drafts. The repo states this itself in `src/pages/api/v1/block-tokens/index.ts`: the SSR dev route *"mounts an OWNED app at ANY status"*. It mounts the same real `PageBlockHost` as production. And critically, **the tunnel serves the same `blockId` the author will eventually publish** — so allowlisting a block for production would silently enable it on that author's unpublished draft, which is precisely the code the PWA starters steer toward hash routing.

So the surface is passed explicitly by each of the three `PageBlockHost` call sites as a **required prop**, and the refused surfaces return `false` before the allowlist is ever consulted.

⚠️ **Correction:** the type-error guarantee covers `PageBlockHost` **only**. `IframeHost` hard-codes `surface: 'model-slot'` internally (`IframeHost.tsx:624`), so a new *model-slot* host would inherit that literal silently rather than being forced to choose. The earlier prose generalised this and was wrong.

| Call site | `surface` |
|---|---|
| `pages/apps/run/[slug]/[[...path]].tsx` | `page-run` |
| `pages/apps/dev/[blockId].tsx` | `dev-tunnel` → **always refused** |
| `components/Apps/ReviewBlockPreviewHost.tsx` (serves both review entry points) | `review-preview` → **also always refused** (see below) |
| `IframeHost` (model slot) | `model-slot`, hard-coded |

**Answer to the question asked: yes, the gate excludes the dev tunnel specifically, by construction rather than by omission** — and there is a mutation proving it (removing the check is killed by a test where the same `blockId` returns `true` on another surface).

### Denylist

`playable-collections` — it reads `location.hash` on first load and fails closed against our fragment **only by luck** (it wants a `c` key we do not carry). That is a coincidence, not a contract. The denylist is checked **before** the allowlist so a future widening cannot silently re-enable it.

### 🔴 Honest limitation: this is an opt-in allowlist, not a runtime kill switch

Enabling or disabling a block is a **deploy**. With the allowlist empty there is nothing to revoke in a hurry, so the practical exposure is nil — but if a genuine runtime switch is wanted, its home is a flag in the feature-flags service, which is outside this module's ownership and deliberately not added here. Say the word and I'll wire it.

---

# The freeze test (F4) — added regardless of gating

`BlockInitFragmentFreeze.browser.test.tsx`. The audit's finding was that the mount-time freeze — **the property #3631 named as its safety argument** — had zero coverage in either tier.

Reproduced and now closed. **Red-at-base evidence**, i.e. the exact mutations the audit reported as surviving:

| Mutation | Before | Now killed by |
|---|---|---|
| frozen ref → live `fields` **+ full deps** | survived both tiers pre-PR | `🔴 a theme change leaves the src BYTE-IDENTICAL` |
| 🔴 frozen ref → live `fields`, **deps UNCHANGED** | ⚠️ **survived this PR's own tests** | `🔴 THE DISCRIMINATING CASE: toggle theme, THEN move baseSrc` |
| `baseSrc` frozen too | survived both tiers pre-PR | `baseSrc is deliberately NOT frozen — it still re-navigates` |
| gate ignored (always append) | n/a (new) | `when the gate is OFF the src is the bare base` |
| 🔴 per-instance re-capture removed | n/a (the C fix) | `🔴 SOFT-NAV appA→appB re-captures` + `a blockInstanceId change RE-CAPTURES` |
| `blockInstanceId` dropped from memo deps | n/a (the C fix) | `🔴 a blockInstanceId change RE-CAPTURES` |
| 🔴 production binding args **swapped** | ⚠️ **survived all 9 gate tests** | `🔴 the PRODUCTION binding passes allow/deny in the RIGHT ORDER` |
| 🔴 `review-preview` refusal removed | n/a (the D fix) | `🔴 refuses review-preview even for a block that IS allowlisted` |

⚠️ **The earlier version of this table overstated row 1.** Its mutant changed *both* the ref and the dep array, and the dep-array half is what the other tests detect — so **the ref itself was uncovered**. Row 2 is the single mutant that isolates it, and it passed every test in this PR until an audit found it. Corrected rather than deleted, because the overstatement is the thing worth remembering.

One mutant **survived and should**: adding `theme` to the memo deps. The memo body reads `frozenFields.current`, so the forced recompute produces a byte-identical string — an **equivalent mutant**, not a coverage gap. The 7/7 pass is itself the proof of equivalence.

Two deliberate design points:

- **It tests the hook, not a host.** With the gate off, a host-level test renders a `src` with *no fragment at all* and could not observe the freeze — vacuous by construction. The probe drives the hook with `enabled: true`, exercising the invariant the gate will eventually expose.
- **Component tier, not node.** `useBlockIframeSrc` is a hook; the unit project runs `environment: 'node'` with no renderer.

Worth recording: this file **failed on its first run** — all 5 cases, `Cannot find element with locator` against an empty `<div />`. Not a freeze failure: React 18 commits asynchronously through `createRoot`, and I read the DOM synchronously after render. Every other browser suite here awaits first. Fixed in the helper, with the reason written down.

The gate predicate is separately mutation-tested via an **injectable** form (`blockInitFragmentEnabledWith`). Testing only the production binding would be vacuous — its allowlist is empty, so every call returns `false`, and `false` cannot distinguish "dev tunnel refused first" from "nothing allowlisted". The suite drives it with a **non-empty** allowlist and opens with an explicit **positive control** that the predicate can return `true` at all.

---

# Fixed in response to the audit (not deferred)

- **🔴 Soft-nav `appA→appB` leaked the previous app's identity.** `PageBlockHost` is rendered with **no `key`** (and `_app.tsx` renders `<Component>` with none), so a soft nav reuses the component instance: same mount, new `blockInstanceId`. The freeze was per-*mount*, so app B's document received app A's id **and** app A's mount-time theme while `BLOCK_INIT` delivered B's — the block seeing two contradicting identities. Every other per-mount latch in that file had already been re-scoped to the instance for exactly this reason; this one had not. Now frozen **within** an instance, re-captured **across** one. Model slot was never affected (`BlockSlotClient.tsx:145` keys by `blockInstanceId`).
- **🔴 Two tests were asserting the leak as intended behaviour** and have been **inverted**, not annotated. A test that blesses a bug is worse than no test — the next reader takes it as the contract.
- **🔴 `review-preview` now refused** alongside `dev-tunnel`.

# Deferred by gating (documented, not fixed)

Both are properties of the fragment and are unreachable while the allowlist is empty:

- **Frozen `theme` is wrong for "auto" viewers.** All **four** theme sources use `useComputedColorScheme('dark')` with no options — the run page (`:98`), the dev tunnel (`:143`), the review host (`:68`) and the model slot (`ModelVersionDetails.tsx:176`), one more than the audit reported; so Mantine's DEFAULT `getInitialValueInEffect: true` applies (other call sites in this repo pass `false` explicitly when they need the true value at first render, which confirms the default), and it returns `'dark'` on first render and commits the OS value in an effect. The freeze captures first render, so an auto + light-OS viewer would get `theme=dark` in the fragment while `BLOCK_INIT` says `light` — the fast path would *create* the flash it exists to remove. Not a correctness break (payload wins), and the cookie default is `'dark'` rather than `'auto'`, so the cohort is limited to viewers who explicitly chose Auto. **Must be fixed before any block is allowlisted.**
- **`blockInstanceId` lands in `location.href`** inside the block document, where an error/analytics SDK the block loads will auto-capture it. ⚠️ **Correction — this is weaker than #3631 claimed.** It is **not** a per-user-per-install identifier on the page surfaces: page-run uses `page_${appBlockId}` (`[[...path]].tsx:132`), a per-*app* constant identical for every viewer, and review-preview uses `page_${pubReqId}`. The genuine per-viewer case is the model slot. Network side is clean (fragments aren't sent to servers; `referrerPolicy="no-referrer"` on both iframes). Still worth resolving before allowlisting, but it is not the leak it was described as.

# Still open / not closed

- `who-am-i` (suspended, NXDOMAIN) is **undetermined**, not scored safe.
- `sensei` has a pending publish request and would become block #10.
- The dev-tunnel surface is structurally unenumerable — which is why it is refused unconditionally rather than assessed.
- The enumeration is a **point-in-time read (2026-08-05)**; two of the nine live blocks were approved within eight days, so the population moves. Any future allowlisting needs a fresh read, not this one.

# Suggested sequencing

1. Land #3634 (handshake) — carries none of this.
2. Land this PR **gated off** — it is inert, and it puts the gate, the freeze test and the corrected reasoning in the tree before anyone is tempted to enable it.
3. Publish the SDK.
4. Fix the two deferred items above.
5. Re-enumerate, then allowlist blocks one at a time as they rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R7ZCxbgcsv3WfsSJrYdSCi
