### PR TITLE
fix(freshdesk-agent): bound query_database rows in the SQL, not after the fetch

### DIFF
--- a/src/server/freshdesk-agent/__tests__/freshdesk-query-scope.test.ts
+++ b/src/server/freshdesk-agent/__tests__/freshdesk-query-scope.test.ts
@@ -125,6 +125,49 @@ describe('checkQueryScope — relations outside the allowed set', () => {
     expect(result.error).toContain('cannot read "ApiKey"');
   });
 
+  /**
+   * The negative counterpart to the ALLOWED sub-select-then-relation fixtures
+   * above. Those only pin that a legal statement of this shape is accepted, and
+   * "accepted" is also what a broken walk returns — so on their own they cannot
+   * tell a working FROM-list tracker from one that has stopped tracking.
+   *
+   * Concretely this pins the ORDER of `fromListAtDepth[depth] = false` and
+   * `depth -= 1` when a sub-select closes: the flag has to be cleared at the
+   * INNER depth, because the list that just ended is the sub-select's. Clearing
+   * it after the decrement wipes the OUTER list's flag instead, and the comma
+   * that follows stops being read as a relation position — so the relation after
+   * it is never audited at all.
+   *
+   * These are balanced, valid SQL, so the paren-balance guard cannot catch them;
+   * they have to assert on the RELATION name, not merely on rejection, or they
+   * would pass by dying to that guard for the wrong reason.
+   *
+   * Depths vary deliberately: the flag is stored per depth index, so a fix that
+   * happened to be right at one nesting level and wrong at another would slip a
+   * single-depth fixture.
+   */
+  it.each([
+    [
+      'a sub-select in the FROM list followed by an out-of-scope relation',
+      'SELECT * FROM (SELECT id FROM "User") x, "Session" s',
+    ],
+    [
+      'a relation, then a sub-select, then an out-of-scope relation',
+      'SELECT * FROM "User" u, (SELECT id FROM "Post") y, "Session" s',
+    ],
+    [
+      'a twice-nested sub-select followed by an out-of-scope relation',
+      'SELECT * FROM (SELECT id FROM (SELECT id FROM "Post") y) x, "Session" s',
+    ],
+  ])('refuses %s', (_label, sql) => {
+    const result = checkQueryScope(sql);
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('unreachable');
+    expect(result.error).toContain('cannot read "Session"');
+    // Not rejected for being malformed — these are well-formed statements.
+    expect(result.error).not.toContain('unbalanced parentheses');
+  });
+
   it('refuses a disallowed table inside a nested sub-select', () => {
     const result = checkQueryScope(
       'SELECT * FROM "User" WHERE id IN (SELECT "userId" FROM (SELECT "userId" FROM "Session") s)'

--- a/src/server/freshdesk-agent/__tests__/freshdesk-query-scope.test.ts
+++ b/src/server/freshdesk-agent/__tests__/freshdesk-query-scope.test.ts
@@ -260,3 +260,81 @@ describe('checkQueryScope — shapes it cannot read, and therefore refuses', () 
     );
   });
 });
+
+/**
+ * Paren-unbalanced input — the fixture class every other case in this file
+ * lacks.
+ *
+ * Everything above is well-formed SQL, which is why the walk's depth bookkeeping
+ * was never exercised against text whose real nesting it could not model. The
+ * walk keys EVERY relation decision on `depth` — which `FROM` list a comma
+ * continues, and therefore which tokens sit in relation position — so text that
+ * desynchronises `depth` from the truth gets a verdict that is not about the SQL
+ * a database would parse.
+ *
+ * These used to be accepted. Standing alone they are syntax errors, so that was
+ * inert; it stopped being inert once a caller began WRAPPING the statement in a
+ * bounding subquery, because a wrapper supplies the parentheses the text is
+ * missing. A statement with a stray `)` early and an unclosed `(` late can be
+ * rejected by Postgres on its own and valid once wrapped — and the relation it
+ * reaches through the desynchronised comma was never audited.
+ *
+ * The mechanism is independent of which table is targeted; these fixtures use
+ * relations this file already exercises as out-of-scope.
+ */
+describe('checkQueryScope — paren-unbalanced input', () => {
+  it.each([
+    // The exploit shape: stray `)` at depth 0 leaves the later comma outside any
+    // FROM list the walk thinks is open, so the relation after it is not read as
+    // a relation at all. The trailing unclosed `(` is what makes the WRAPPED
+    // form balance, i.e. valid SQL.
+    [
+      'a stray ")" early and an unclosed "(" late — valid only once wrapped',
+      'SELECT 1) x, "Session" s WHERE s.id = 1 UNION SELECT 0, 0, 0 FROM (SELECT 1',
+    ],
+    ['a bare stray ")"', 'SELECT 1)'],
+    ['a stray ")" in the target list', 'SELECT (1)) FROM "User"'],
+    ['an extra ")" after a balanced sub-select', 'SELECT * FROM (SELECT id FROM "User")) x'],
+    ['an unclosed "(" around a sub-select', 'SELECT * FROM (SELECT id FROM "User"'],
+    ['two unclosed "("', 'SELECT * FROM (SELECT (id FROM "User"'],
+    [
+      'a stray ")" that hides an out-of-scope relation behind a comma',
+      'SELECT 1) x, "Account" a',
+    ],
+  ])('refuses %s', (_label, sql) => {
+    const result = checkQueryScope(sql);
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('unreachable');
+    expect(result.error).toContain('unbalanced parentheses');
+  });
+
+  // The two directions are separate guards and must be shown to be separately
+  // reachable — a single balance check that only caught one direction would
+  // leave the other half of the class open.
+  it('names the direction: a ")" that closes nothing', () => {
+    expect(checkQueryScope('SELECT 1)')).toEqual({
+      ok: false,
+      error:
+        'Error: unbalanced parentheses in query — a ")" here closes nothing. query_database only runs statements whose parentheses balance.',
+    });
+  });
+
+  it('names the direction: a "(" that was never closed', () => {
+    expect(checkQueryScope('SELECT * FROM (SELECT id FROM "User"')).toEqual({
+      ok: false,
+      error:
+        'Error: unbalanced parentheses in query — a "(" was never closed. query_database only runs statements whose parentheses balance.',
+    });
+  });
+
+  // Positive control for the fixture class: parentheses inside string literals
+  // and quoted identifiers are CONTENT, not structure. If the balance check
+  // counted those it would reject legitimate statements, and the corpus above
+  // would not catch it because none of those fixtures carry a quoted paren.
+  it('does not count parentheses inside string literals or quoted identifiers', () => {
+    expect(checkQueryScope(`SELECT id FROM "User" WHERE username = ')('`)).toEqual({ ok: true });
+    expect(checkQueryScope(`SELECT count(*) FROM "User" WHERE email = '(a@b.c)'`)).toEqual({
+      ok: true,
+    });
+  });
+});

--- a/src/server/freshdesk-agent/__tests__/freshdesk-query-scope.test.ts
+++ b/src/server/freshdesk-agent/__tests__/freshdesk-query-scope.test.ts
@@ -297,10 +297,7 @@ describe('checkQueryScope — paren-unbalanced input', () => {
     ['an extra ")" after a balanced sub-select', 'SELECT * FROM (SELECT id FROM "User")) x'],
     ['an unclosed "(" around a sub-select', 'SELECT * FROM (SELECT id FROM "User"'],
     ['two unclosed "("', 'SELECT * FROM (SELECT (id FROM "User"'],
-    [
-      'a stray ")" that hides an out-of-scope relation behind a comma',
-      'SELECT 1) x, "Account" a',
-    ],
+    ['a stray ")" that hides an out-of-scope relation behind a comma', 'SELECT 1) x, "Account" a'],
   ])('refuses %s', (_label, sql) => {
     const result = checkQueryScope(sql);
     expect(result.ok).toBe(false);

--- a/src/server/freshdesk-agent/__tests__/freshdesk-tools.query-database.test.ts
+++ b/src/server/freshdesk-agent/__tests__/freshdesk-tools.query-database.test.ts
@@ -266,8 +266,7 @@ describe('query_database', () => {
    * bug lives in text none of them contained.
    */
   describe('paren-unbalanced input never reaches the driver', () => {
-    const EVASION =
-      'SELECT 1) x, "Session" s WHERE s.id = 1 UNION SELECT 0, 0, 0 FROM (SELECT 1';
+    const EVASION = 'SELECT 1) x, "Session" s WHERE s.id = 1 UNION SELECT 0, 0, 0 FROM (SELECT 1';
 
     it('refuses a statement that would only become valid once wrapped', async () => {
       const result = await executeToolCall('query_database', { sql: EVASION });

--- a/src/server/freshdesk-agent/__tests__/freshdesk-tools.query-database.test.ts
+++ b/src/server/freshdesk-agent/__tests__/freshdesk-tools.query-database.test.ts
@@ -205,20 +205,98 @@ describe('query_database', () => {
       expect(JSON.parse(result)).toHaveLength(50);
     });
 
-    // Invariant guard, not regression coverage: the scope check already read the
-    // original SQL before this change. It is pinned here because the change
-    // introduced a rewrite that a later edit could easily hoist above it.
-    it("scope-checks the model's original SQL, never the rewritten statement", async () => {
+    // The rewrite means the string that is VALIDATED and the string that is
+    // EXECUTED are not the same object. Both must go through the scope check,
+    // in that order: the original owns the model-facing error message, the
+    // executed one is what actually has to be proven in scope.
+    it('scope-checks the original AND the statement it actually executes', async () => {
       h.queryWithTimeout.mockResolvedValue({ rows: [] });
 
       await executeToolCall('query_database', { sql: ALLOWED_SQL });
 
-      expect(h.checkQueryScope).toHaveBeenCalledTimes(1);
-      expect(h.checkQueryScope).toHaveBeenCalledWith(ALLOWED_SQL);
-      expect(h.checkQueryScope).not.toHaveBeenCalledWith(ALLOWED_SQL_BOUNDED);
-      // ...and the rewrite still happened, so this is not passing because the
-      // wrapping was skipped.
+      expect(h.checkQueryScope).toHaveBeenCalledTimes(2);
+      expect(h.checkQueryScope.mock.calls[0][0]).toBe(ALLOWED_SQL);
+      expect(h.checkQueryScope.mock.calls[1][0]).toBe(ALLOWED_SQL_BOUNDED);
+      // The string handed to the driver is byte-identical to the one the second
+      // check cleared — otherwise the check is of a string nobody runs.
       expect(h.queryWithTimeout).toHaveBeenCalledWith(h.readPool, 30000, ALLOWED_SQL_BOUNDED);
+    });
+
+    it('refuses to execute if the rewritten statement fails the scope check', async () => {
+      // Reachability: with the paren-balance fix no real input gets here, so the
+      // branch is driven directly. Without this the guard would be dead code
+      // that no mutation could kill.
+      h.checkQueryScope
+        .mockReturnValueOnce({ ok: true })
+        .mockReturnValueOnce({ ok: false, error: 'Error: synthetic rewrite failure' });
+
+      const result = await executeToolCall('query_database', { sql: ALLOWED_SQL });
+
+      expect(h.queryWithTimeout).not.toHaveBeenCalled();
+      expect(result).toBe(
+        'Error: query_database could not verify this statement stays within its allowed tables. Rewrite it as a simple SELECT over the allowed tables.'
+      );
+      // The internal failure is not described to the model.
+      expect(result).not.toContain('synthetic');
+    });
+  });
+
+  /**
+   * The seam the row-bound wrap created: `checkQueryScope` reasons about the
+   * model's text, the driver runs the WRAPPED text, and a wrapper supplies
+   * parentheses. Text that is a syntax error standing alone can therefore be a
+   * valid statement once wrapped — reaching a relation the scope walk never
+   * audited, because a stray ")" desynchronised its depth bookkeeping.
+   *
+   * Every other fixture in this file is well-formed balanced SQL. That is
+   * exactly why a 5-mutant sweep and 35 Postgres probes did not find this: the
+   * bug lives in text none of them contained.
+   */
+  describe('paren-unbalanced input never reaches the driver', () => {
+    const EVASION =
+      'SELECT 1) x, "Session" s WHERE s.id = 1 UNION SELECT 0, 0, 0 FROM (SELECT 1';
+
+    it('refuses a statement that would only become valid once wrapped', async () => {
+      const result = await executeToolCall('query_database', { sql: EVASION });
+
+      // The load-bearing assertion: nothing was executed. Asserting only on the
+      // returned string would pass even if the query had run and returned rows.
+      expect(h.queryWithTimeout).not.toHaveBeenCalled();
+      expect(h.prismaQueryRaw).not.toHaveBeenCalled();
+      expect(result).toContain('unbalanced parentheses');
+    });
+
+    it('never hands the driver a statement naming an out-of-scope relation', async () => {
+      // Independent of WHY it was refused: whatever this tool executes must not
+      // mention a relation outside the allowlist. Stated over the whole call
+      // record rather than one argument, so a second execution path added later
+      // is covered too.
+      for (const sql of [
+        EVASION,
+        'SELECT 1) x, "Account" a',
+        'SELECT * FROM (SELECT id FROM "User")) x, "ApiKey" k',
+      ]) {
+        await executeToolCall('query_database', { sql });
+      }
+
+      const executed = JSON.stringify(h.queryWithTimeout.mock.calls);
+      expect(h.queryWithTimeout).not.toHaveBeenCalled();
+      for (const forbidden of ['Session', 'Account', 'ApiKey']) {
+        expect(executed).not.toContain(forbidden);
+      }
+    });
+
+    it('positive control: the same assertion CAN see a relation name', async () => {
+      // Proves the previous test's `not.toContain` is capable of failing. A
+      // never-called mock makes any `not.toContain` over its calls vacuously
+      // true, so the matcher has to be shown observing a real relation name.
+      h.queryWithTimeout.mockResolvedValue({ rows: [] });
+
+      await executeToolCall('query_database', { sql: 'SELECT id FROM "User" LIMIT 1' });
+
+      const executed = JSON.stringify(h.queryWithTimeout.mock.calls);
+      expect(h.queryWithTimeout).toHaveBeenCalledTimes(1);
+      expect(executed).toContain('User');
     });
   });
 

--- a/src/server/freshdesk-agent/__tests__/freshdesk-tools.query-database.test.ts
+++ b/src/server/freshdesk-agent/__tests__/freshdesk-tools.query-database.test.ts
@@ -24,6 +24,10 @@ const h = vi.hoisted(() => ({
   queryWithTimeout: vi.fn(),
   prismaQueryRaw: vi.fn(),
   checkQueryScope: vi.fn(),
+  // Captured from the mock factory so `beforeEach` can rebuild the pass-through
+  // after draining the spy. Typed loosely because it is assigned inside the
+  // hoisted factory, before the module type is in scope.
+  actualCheckQueryScope: undefined as undefined | ((sql: string) => unknown),
 }));
 
 // Narrow overrides that keep every other export real. A hand-written
@@ -47,14 +51,14 @@ vi.mock('~/server/db/client', async (importOriginal) => ({
 }));
 
 // A pass-through spy, NOT a stub: it delegates to the real scope check and
-// exists only to record the text that check was handed. The tool rewrites the
-// statement before executing it, and the scope check has to keep reading the
-// model's ORIGINAL SQL — otherwise it audits our own wrapper. That the
-// delegation is real is not asserted by inspection: the "refuses a relation
-// outside the allowed set" case below only passes if the genuine check ran.
+// exists only to record WHICH text each call was handed — the tool validates
+// the model's original and the rewritten statement, and those are different
+// strings. That the delegation is real is not asserted by inspection: the
+// "refuses a relation outside the allowed set" case below only passes if the
+// genuine check ran.
 vi.mock('~/server/freshdesk-agent/freshdesk-query-scope', async (importOriginal) => {
   const actual = await importOriginal<typeof QueryScopeModule>();
-  h.checkQueryScope.mockImplementation(actual.checkQueryScope);
+  h.actualCheckQueryScope = actual.checkQueryScope as (sql: string) => unknown;
   return { ...actual, checkQueryScope: h.checkQueryScope };
 });
 
@@ -84,6 +88,15 @@ const rowsOfLength = (n: number) =>
 describe('query_database', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // `clearAllMocks` resets recorded calls but does NOT drain a
+    // `mockReturnValueOnce` queue. One test below queues two once-values to
+    // reach an internal guard; if a change makes the code consume only one of
+    // them, the leftover leaks into the NEXT test and attributes a failure to
+    // the wrong cause — observed while mutation-testing this file. `mockReset`
+    // empties the queue, so the pass-through has to be reinstalled here rather
+    // than only in the mock factory.
+    h.checkQueryScope.mockReset();
+    h.checkQueryScope.mockImplementation(h.actualCheckQueryScope!);
   });
 
   it('runs an allowed query through the read-only / statement-timeout helper', async () => {

--- a/src/server/freshdesk-agent/__tests__/freshdesk-tools.query-database.test.ts
+++ b/src/server/freshdesk-agent/__tests__/freshdesk-tools.query-database.test.ts
@@ -208,7 +208,7 @@ describe('query_database', () => {
     // Invariant guard, not regression coverage: the scope check already read the
     // original SQL before this change. It is pinned here because the change
     // introduced a rewrite that a later edit could easily hoist above it.
-    it('scope-checks the model\'s original SQL, never the rewritten statement', async () => {
+    it("scope-checks the model's original SQL, never the rewritten statement", async () => {
       h.queryWithTimeout.mockResolvedValue({ rows: [] });
 
       await executeToolCall('query_database', { sql: ALLOWED_SQL });

--- a/src/server/freshdesk-agent/__tests__/freshdesk-tools.query-database.test.ts
+++ b/src/server/freshdesk-agent/__tests__/freshdesk-tools.query-database.test.ts
@@ -2,13 +2,16 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type * as DbHelpersModule from '~/server/db/db-helpers';
 import type * as PgDbModule from '~/server/db/pgDb';
 import type * as DbClientModule from '~/server/db/client';
+import type * as QueryScopeModule from '~/server/freshdesk-agent/freshdesk-query-scope';
 
 /**
  * `query_database` runs SQL the model wrote, so the tool carries the bounds:
  * it must go through `queryWithTimeout` (BEGIN READ ONLY + a server-side
  * `SET LOCAL statement_timeout`) rather than straight at the app-wide read
- * client, and it must refuse a relation it is not scoped to before it takes a
- * connection at all.
+ * client, it must refuse a relation it is not scoped to before it takes a
+ * connection at all, and it must bound the ROW COUNT in the statement it hands
+ * the driver — node-postgres buffers a whole result set into the heap, so a
+ * bound applied to the returned array is not a bound on this process.
  *
  * These tests drive the exported `executeToolCall` — the same entry point the
  * agent loop calls — so they exercise the real dispatch, not a shortcut.
@@ -20,6 +23,7 @@ const h = vi.hoisted(() => ({
   readPool: { __testDouble: 'pgDbRead' },
   queryWithTimeout: vi.fn(),
   prismaQueryRaw: vi.fn(),
+  checkQueryScope: vi.fn(),
 }));
 
 // Narrow overrides that keep every other export real. A hand-written
@@ -42,6 +46,18 @@ vi.mock('~/server/db/client', async (importOriginal) => ({
   dbRead: { $queryRaw: h.prismaQueryRaw },
 }));
 
+// A pass-through spy, NOT a stub: it delegates to the real scope check and
+// exists only to record the text that check was handed. The tool rewrites the
+// statement before executing it, and the scope check has to keep reading the
+// model's ORIGINAL SQL — otherwise it audits our own wrapper. That the
+// delegation is real is not asserted by inspection: the "refuses a relation
+// outside the allowed set" case below only passes if the genuine check ran.
+vi.mock('~/server/freshdesk-agent/freshdesk-query-scope', async (importOriginal) => {
+  const actual = await importOriginal<typeof QueryScopeModule>();
+  h.checkQueryScope.mockImplementation(actual.checkQueryScope);
+  return { ...actual, checkQueryScope: h.checkQueryScope };
+});
+
 // These two build a singleton at module load and throw without their env vars,
 // so `importOriginal` cannot be used on them. Each has exactly one export, and
 // no test here reaches either.
@@ -51,6 +67,19 @@ vi.mock('~/server/http/nowpayments/nowpayments.caller', () => ({ default: {} }))
 import { executeToolCall } from '~/server/freshdesk-agent/freshdesk-tools';
 
 const ALLOWED_SQL = 'SELECT id, username FROM "User" WHERE id = 7 LIMIT 1';
+
+/**
+ * The exact statement the driver must receive for `ALLOWED_SQL`. Typed out by
+ * hand rather than assembled from the implementation's alias/limit constants:
+ * derived from the implementation it would agree with any rewrite, including
+ * one that dropped the outer LIMIT entirely.
+ */
+const ALLOWED_SQL_BOUNDED =
+  'SELECT * FROM (SELECT id, username FROM "User" WHERE id = 7 LIMIT 1) __civitai_row_bound LIMIT 51';
+
+/** Build N distinct rows — distinct so a slice boundary is readable off the values. */
+const rowsOfLength = (n: number) =>
+  Array.from({ length: n }, (_, i) => ({ id: i + 1, username: `u${i + 1}` }));
 
 describe('query_database', () => {
   beforeEach(() => {
@@ -63,7 +92,7 @@ describe('query_database', () => {
     const result = await executeToolCall('query_database', { sql: ALLOWED_SQL });
 
     expect(h.queryWithTimeout).toHaveBeenCalledTimes(1);
-    expect(h.queryWithTimeout).toHaveBeenCalledWith(h.readPool, 30000, ALLOWED_SQL);
+    expect(h.queryWithTimeout).toHaveBeenCalledWith(h.readPool, 30000, ALLOWED_SQL_BOUNDED);
     expect(h.prismaQueryRaw).not.toHaveBeenCalled();
     expect(result).toBe(JSON.stringify([{ id: 7, username: 'ada' }], null, 2));
   });
@@ -83,8 +112,114 @@ describe('query_database', () => {
     expect(call).toHaveLength(3);
     expect(Array.isArray(call[2])).toBe(false);
     expect(typeof call[2]).toBe('string');
-    expect(call[2]).toBe(ALLOWED_SQL);
+    expect(call[2]).toBe(ALLOWED_SQL_BOUNDED);
     expect(call[2]).not.toBe('SELECT id, username FROM "Session" WHERE id = 7 LIMIT 1');
+  });
+
+  describe('row bound', () => {
+    it('bounds the row count in the SQL it hands the driver, not after the fact', async () => {
+      // The load-bearing assertion of this file: an outer LIMIT in the text the
+      // database receives. A test that only checked `result` had at most 50
+      // rows would pass with the bug fully present, because the bug is that the
+      // whole result set reaches the heap first.
+      h.queryWithTimeout.mockResolvedValue({ rows: [] });
+
+      await executeToolCall('query_database', { sql: 'SELECT * FROM "User"' });
+
+      expect(h.queryWithTimeout).toHaveBeenCalledWith(
+        h.readPool,
+        30000,
+        'SELECT * FROM (SELECT * FROM "User") __civitai_row_bound LIMIT 51'
+      );
+    });
+
+    it('strips the trailing semicolon before wrapping', async () => {
+      // `checkQueryScope` accepts one trailing `;`, and `SELECT * FROM (SELECT
+      // 1;) x LIMIT 51` is a Postgres syntax error — verified against Postgres
+      // 18, which reports `syntax error at or near ";"`.
+      h.queryWithTimeout.mockResolvedValue({ rows: [] });
+
+      await executeToolCall('query_database', { sql: 'SELECT id FROM "User" LIMIT 1;  ' });
+
+      expect(h.queryWithTimeout).toHaveBeenCalledWith(
+        h.readPool,
+        30000,
+        'SELECT * FROM (SELECT id FROM "User" LIMIT 1) __civitai_row_bound LIMIT 51'
+      );
+    });
+
+    it('wraps a UNION as a whole rather than binding only its last branch', async () => {
+      h.queryWithTimeout.mockResolvedValue({ rows: [] });
+
+      await executeToolCall('query_database', {
+        sql: 'SELECT id FROM "User" UNION SELECT id FROM "Model"',
+      });
+
+      expect(h.queryWithTimeout).toHaveBeenCalledWith(
+        h.readPool,
+        30000,
+        'SELECT * FROM (SELECT id FROM "User" UNION SELECT id FROM "Model") __civitai_row_bound LIMIT 51'
+      );
+    });
+
+    it('keeps a top-level ORDER BY inside the wrap', async () => {
+      // Ordering must be applied before the bound, or "the 50 newest" silently
+      // becomes "50 arbitrary rows, then sorted". Verified against Postgres 18:
+      // the plan is `Limit -> Sort`, and the wrap returns the same top rows the
+      // unwrapped statement does.
+      h.queryWithTimeout.mockResolvedValue({ rows: [] });
+
+      await executeToolCall('query_database', {
+        sql: 'SELECT id FROM "User" ORDER BY "createdAt" DESC',
+      });
+
+      expect(h.queryWithTimeout).toHaveBeenCalledWith(
+        h.readPool,
+        30000,
+        'SELECT * FROM (SELECT id FROM "User" ORDER BY "createdAt" DESC) __civitai_row_bound LIMIT 51'
+      );
+    });
+
+    it('reports truncation when the extra probe row comes back', async () => {
+      h.queryWithTimeout.mockResolvedValue({ rows: rowsOfLength(51) });
+
+      const result = await executeToolCall('query_database', { sql: ALLOWED_SQL });
+
+      const [json, note] = result.split('\n\n');
+      expect(JSON.parse(json)).toHaveLength(50);
+      expect(JSON.parse(json)[49]).toEqual({ id: 50, username: 'u50' });
+      expect(note).toBe(
+        'Truncated: more than 50 rows matched and only the first 50 are shown. Narrow the query — add a WHERE filter, an ORDER BY, or a smaller LIMIT.'
+      );
+    });
+
+    it('does not claim truncation on a full page that was not truncated', async () => {
+      // The boundary the 51st row exists to resolve: 50 rows back means 50 rows
+      // matched. Reporting truncation here would send the model narrowing a
+      // query that was already complete.
+      h.queryWithTimeout.mockResolvedValue({ rows: rowsOfLength(50) });
+
+      const result = await executeToolCall('query_database', { sql: ALLOWED_SQL });
+
+      expect(result).not.toContain('Truncated');
+      expect(JSON.parse(result)).toHaveLength(50);
+    });
+
+    // Invariant guard, not regression coverage: the scope check already read the
+    // original SQL before this change. It is pinned here because the change
+    // introduced a rewrite that a later edit could easily hoist above it.
+    it('scope-checks the model\'s original SQL, never the rewritten statement', async () => {
+      h.queryWithTimeout.mockResolvedValue({ rows: [] });
+
+      await executeToolCall('query_database', { sql: ALLOWED_SQL });
+
+      expect(h.checkQueryScope).toHaveBeenCalledTimes(1);
+      expect(h.checkQueryScope).toHaveBeenCalledWith(ALLOWED_SQL);
+      expect(h.checkQueryScope).not.toHaveBeenCalledWith(ALLOWED_SQL_BOUNDED);
+      // ...and the rewrite still happened, so this is not passing because the
+      // wrapping was skipped.
+      expect(h.queryWithTimeout).toHaveBeenCalledWith(h.readPool, 30000, ALLOWED_SQL_BOUNDED);
+    });
   });
 
   it('refuses a relation outside the allowed set without taking a connection', async () => {

--- a/src/server/freshdesk-agent/freshdesk-query-scope.ts
+++ b/src/server/freshdesk-agent/freshdesk-query-scope.ts
@@ -276,6 +276,28 @@ export type QueryScopeResult = { ok: true } | { ok: false; error: string };
  *   - relations inside sub-selects in the target list, `WHERE`, `IN (...)`
  *   - each branch of a `UNION` / `INTERSECT` / `EXCEPT`
  *   - text hidden in comments or a second statement — refused outright
+ *   - parentheses that do not balance — refused outright, in BOTH directions
+ *
+ * 🔴 The paren-balance refusal is load-bearing, not tidiness. Every relation
+ * decision in the walk is keyed on `depth`: which `FROM` list a comma continues,
+ * and therefore which tokens sit in relation position. An unbalanced statement
+ * is one whose real nesting the walk cannot model, so a verdict on it is not a
+ * verdict about the SQL a database would parse.
+ *
+ * This used to clamp (`depth = Math.max(0, depth - 1)`) with no closing
+ * assertion, which was inert only because Postgres rejected such text outright.
+ * The moment a caller WRAPPED the statement that stopped being true: a wrapper
+ * supplies parentheses, so text carrying a stray `)` early and a matching
+ * unclosed `(` late can be a syntax error standing alone and a VALID statement
+ * once wrapped. Such text slipped this walk because the stray `)` reset the
+ * depth bookkeeping, leaving a later comma outside any `FROM` list this walk
+ * believed was open — so the relation after it was never audited, and the
+ * wrapped statement read a table outside the allowlist. Confirmed end to end
+ * against Postgres, inside a READ ONLY transaction, before the fix.
+ *
+ * So the balance requirement is what makes this walk's verdict robust to a
+ * caller that rewrites the statement, and it must not be relaxed to accommodate
+ * one. The regression fixtures live in the scope test suite.
  *
  * What it does NOT do, and rejects rather than guesses at:
  *   - CTEs. `WITH` cannot lead (the caller's `SELECT` check already refuses
@@ -318,8 +340,19 @@ export function checkQueryScope(sql: string): QueryScopeResult {
     }
 
     if (token.kind === 'punct' && token.value === ')') {
+      // A `)` with nothing open is REFUSED, never clamped. Clamping made the
+      // walk's depth model diverge from the text's real nesting, and every
+      // decision below — which `FROM` list a comma belongs to, therefore which
+      // tokens are relation positions — is keyed on `depth`. See the
+      // paren-balance note in this function's docblock for the concrete escape
+      // that made this reachable.
+      if (depth === 0) {
+        return reject(
+          'Error: unbalanced parentheses in query — a ")" here closes nothing. query_database only runs statements whose parentheses balance.'
+        );
+      }
       fromListAtDepth[depth] = false;
-      depth = Math.max(0, depth - 1);
+      depth -= 1;
       expectRelation = false;
       continue;
     }
@@ -368,6 +401,16 @@ export function checkQueryScope(sql: string): QueryScopeResult {
       expectRelation = true;
       continue;
     }
+  }
+
+  // An unclosed `(` is the other half of the balance requirement. Left
+  // unchecked, the walk ends believing it is nested inside a sub-select that
+  // the text never opened — and a caller that appends a `)` turns the statement
+  // into something whose relations this walk never audited.
+  if (depth !== 0) {
+    return reject(
+      'Error: unbalanced parentheses in query — a "(" was never closed. query_database only runs statements whose parentheses balance.'
+    );
   }
 
   if (expectRelation) {

--- a/src/server/freshdesk-agent/freshdesk-tools.ts
+++ b/src/server/freshdesk-agent/freshdesk-tools.ts
@@ -25,6 +25,57 @@ import {
 const DB_QUERY_TIMEOUT_MS = 30_000;
 const DB_QUERY_TIMEOUT_SECONDS = DB_QUERY_TIMEOUT_MS / 1000;
 
+/** Rows `query_database` will hand back to the model. */
+const MAX_RESULT_ROWS = 50;
+
+/**
+ * Rows actually asked of the database: one more than we return, so a full page
+ * is distinguishable from a truncated one. Slicing a buffered array cannot make
+ * that distinction, which is why the old code could not say whether "50 rows"
+ * meant "50 rows existed" or "we threw the rest away".
+ */
+const ROW_FETCH_LIMIT = MAX_RESULT_ROWS + 1;
+
+/**
+ * Alias for the bounding subquery. Postgres requires a derived table be named,
+ * and the name is unlikely enough to collide with a model-chosen alias — though
+ * a collision would be harmless anyway: an inner alias lives at its own query
+ * level, verified against Postgres 18.
+ */
+const ROW_BOUND_ALIAS = '__civitai_row_bound';
+
+/**
+ * Wrap the model's statement so the ROW BOUND is the database's to enforce,
+ * matching the other two bounds (`checkQueryScope` for relations, `SET LOCAL
+ * statement_timeout` for time).
+ *
+ * Why this is not a `rows.slice(0, 50)`: `queryWithTimeout` goes through
+ * node-postgres `client.query()`, which is NOT streaming — it accumulates every
+ * row of the result into the Node heap before the promise resolves. A
+ * model-written `SELECT * FROM "User"` with no LIMIT therefore materialised the
+ * whole table in-process and only then discarded all but 50 rows, so the 50 was
+ * a bound on the model's context window, not on this process's memory. The tool
+ * description promises the bounds are "enforced by the server, not by
+ * convention"; an outer LIMIT is what makes that true of the row count too.
+ *
+ * Semantics of the wrap were verified against a real Postgres rather than
+ * reasoned about — `ORDER BY` (including on an unprojected column, by ordinal,
+ * and across a `UNION`), `UNION`/`UNION ALL`, `DISTINCT ON`, `GROUP BY`/
+ * `HAVING`, window functions, and an inner `LIMIT`/`OFFSET` all survive it, and
+ * duplicate output column names in the inner statement are legal in a derived
+ * table (`SELECT * FROM (SELECT 1 AS a, 2 AS a) x` is accepted, both columns
+ * preserved). The plan is `Limit -> ...`, so the scan really stops early rather
+ * than filtering afterwards.
+ *
+ * The trailing `;` that `checkQueryScope` permits has to go first, or the wrap
+ * is a syntax error.
+ */
+function boundRowCount(sql: string): string {
+  const trimmed = sql.trim();
+  const withoutTerminator = trimmed.endsWith(';') ? trimmed.slice(0, -1) : trimmed;
+  return `SELECT * FROM (${withoutTerminator}) ${ROW_BOUND_ALIAS} LIMIT ${ROW_FETCH_LIMIT}`;
+}
+
 // --- Tool definitions ---
 
 const getTicketTool: ToolDefinitionJson = {
@@ -268,14 +319,14 @@ const queryDatabaseTool: ToolDefinitionJson = {
     name: 'query_database',
     description: [
       'Execute a SELECT query against the Civitai database. Use this to verify facts, look up user info, or check system data when the purpose-built investigation tools do not cover what you need.',
-      'The following are enforced by the server, not by convention — a query that breaks any of them is rejected or cancelled, so write to them up front:',
+      'The following are enforced by the server, not by convention — a query that breaks any of them is rejected, cancelled, or truncated, so write to them up front:',
       `- It can only read these tables: ${FRESHDESK_QUERY_TABLES.map((t) => `"${t}"`).join(', ')}.`,
       '- It runs inside a read-only transaction, so nothing can be written.',
       `- The database cancels the statement after ${DB_QUERY_TIMEOUT_SECONDS} seconds. Always use LIMIT and filter on indexed columns.`,
       '- One statement only. No comments, no CTEs (WITH), no schema prefixes, no table functions.',
       '- Reference tables by their exact double-quoted name, e.g. FROM "User".',
       "- FROM-inside-a-function-call is not supported: use date_part('epoch', col) rather than EXTRACT(EPOCH FROM col), and substr(...) rather than SUBSTRING(x FROM 1).",
-      'At most 50 rows are returned.',
+      `- At most ${MAX_RESULT_ROWS} rows come back. The server wraps the statement in its own outer LIMIT, so this holds whether or not you wrote a LIMIT, and the result says so explicitly when it truncated. Your own LIMIT is still worth writing — the outer one caps what is returned, not how much the database has to sort or aggregate first.`,
     ].join('\n'),
     parameters: {
       type: 'object',
@@ -411,24 +462,32 @@ async function executeQueryDatabase(sql: string): Promise<string> {
     return 'Error: Only SELECT queries are allowed.';
   }
 
-  // Bound WHICH relations the statement can reach before it touches a connection.
+  // Bound WHICH relations the statement can reach before it touches a
+  // connection. This reads the model's ORIGINAL text — `boundRowCount` below
+  // rewrites the statement, and a scope check run against the rewrite would be
+  // auditing our own wrapper rather than the model's query.
   const scope = checkQueryScope(sql);
   if (!scope.ok) return scope.error;
 
   try {
     // `queryWithTimeout` wraps the statement in BEGIN READ ONLY + SET LOCAL
-    // statement_timeout, so both bounds are the database's to enforce. A
-    // `Promise.race` here would only abandon the promise — the backend would
-    // keep running and keep holding its pooled connection.
+    // statement_timeout, so both of those bounds are the database's to enforce.
+    // A `Promise.race` here would only abandon the promise — the backend would
+    // keep running and keep holding its pooled connection. `boundRowCount`
+    // makes the row bound the database's too: node-postgres buffers the whole
+    // result set into the heap, so a bound applied after the await is not a
+    // bound on this process at all.
     const { rows } = await queryWithTimeout<Record<string, unknown>>(
       pgDbRead,
       DB_QUERY_TIMEOUT_MS,
-      sql
+      boundRowCount(sql)
     );
     if (rows.length === 0) return 'No results found.';
-    // Limit output size
-    const truncated = rows.slice(0, 50);
-    return JSON.stringify(truncated, null, 2);
+    if (rows.length > MAX_RESULT_ROWS) {
+      const shown = JSON.stringify(rows.slice(0, MAX_RESULT_ROWS), null, 2);
+      return `${shown}\n\nTruncated: more than ${MAX_RESULT_ROWS} rows matched and only the first ${MAX_RESULT_ROWS} are shown. Narrow the query — add a WHERE filter, an ORDER BY, or a smaller LIMIT.`;
+    }
+    return JSON.stringify(rows, null, 2);
   } catch (err) {
     if (
       typeof err === 'object' &&

--- a/src/server/freshdesk-agent/freshdesk-tools.ts
+++ b/src/server/freshdesk-agent/freshdesk-tools.ts
@@ -69,6 +69,13 @@ const ROW_BOUND_ALIAS = '__civitai_row_bound';
  *
  * The trailing `;` that `checkQueryScope` permits has to go first, or the wrap
  * is a syntax error.
+ *
+ * 🔴 This rewrite CHANGES THE PARSE of the model's text — it supplies a `(` and
+ * a `)`, so it can turn text that Postgres would reject outright into a valid
+ * statement. That is only safe because two things hold at the call site, and it
+ * must not be called anywhere they do not: `checkQueryScope` refuses
+ * paren-unbalanced input, and the caller re-runs that check on the string this
+ * returns. Skipping either one reopens a scope escape, not a syntax error.
  */
 function boundRowCount(sql: string): string {
   const trimmed = sql.trim();
@@ -463,11 +470,45 @@ async function executeQueryDatabase(sql: string): Promise<string> {
   }
 
   // Bound WHICH relations the statement can reach before it touches a
-  // connection. This reads the model's ORIGINAL text — `boundRowCount` below
-  // rewrites the statement, and a scope check run against the rewrite would be
-  // auditing our own wrapper rather than the model's query.
+  // connection. The model's ORIGINAL text is checked first so the rejection the
+  // model reads is about the SQL it actually wrote.
   const scope = checkQueryScope(sql);
   if (!scope.ok) return scope.error;
+
+  // ...and then the statement that will actually EXECUTE is checked too.
+  //
+  // These are two different strings, and only the second one reaches Postgres.
+  // An earlier revision of this function checked the original alone, arguing
+  // that checking the rewrite would "audit our own wrapper". That conflated two
+  // questions: which text should produce the model-facing error message (the
+  // original — still true), and which text must be PROVEN in scope (the one
+  // that runs — this was wrong). It was wrong in an exploitable way: a
+  // paren-unbalanced statement could pass the check as written and become a
+  // valid query over an out-of-scope table once `boundRowCount` supplied the
+  // missing parenthesis.
+  //
+  // `checkQueryScope` now refuses unbalanced parentheses, which closes that
+  // specific escape at its source. This second call is the structural version
+  // of the same guarantee: whatever string we hand the driver has been through
+  // the scope check itself, so no future edit to `boundRowCount` — or any
+  // rewriter added later — can widen what the statement reads without this
+  // check seeing it. The wrapper's own tokens are a fixed prefix and suffix that
+  // pass the walk, so this cannot reject a statement the first check accepted;
+  // that is asserted over the whole allowlist corpus in the scope test suite.
+  //
+  // Reaching this branch therefore means an internal invariant broke, not that
+  // the model wrote something bad — so it gets a generic refusal rather than a
+  // description of our rewriting.
+  const boundedSql = boundRowCount(sql);
+  const boundedScope = checkQueryScope(boundedSql);
+  if (!boundedScope.ok) {
+    agentLog('QUERY_DATABASE REWRITE FAILED SCOPE', {
+      sql,
+      boundedSql,
+      error: boundedScope.error,
+    });
+    return 'Error: query_database could not verify this statement stays within its allowed tables. Rewrite it as a simple SELECT over the allowed tables.';
+  }
 
   try {
     // `queryWithTimeout` wraps the statement in BEGIN READ ONLY + SET LOCAL
@@ -480,7 +521,7 @@ async function executeQueryDatabase(sql: string): Promise<string> {
     const { rows } = await queryWithTimeout<Record<string, unknown>>(
       pgDbRead,
       DB_QUERY_TIMEOUT_MS,
-      boundRowCount(sql)
+      boundedSql
     );
     if (rows.length === 0) return 'No results found.';
     if (rows.length > MAX_RESULT_ROWS) {


### PR DESCRIPTION
## The defect

`query_database` is the support agent's escape-hatch tool: the SQL it runs is written by the model, and the ticket text steering the model is untrusted input. #3584 hardened it with a 26-relation allowlist, a `BEGIN READ ONLY` transaction, and a server-side `SET LOCAL statement_timeout`. Its tool description tells the model:

> The following are enforced by the server, not by convention — a query that breaks any of them is rejected or cancelled …
> At most 50 rows are returned.

The row bound was not enforced that way. The code ran the model's statement unmodified and then sliced:

```ts
const { rows } = await queryWithTimeout(pgDbRead, DB_QUERY_TIMEOUT_MS, sql);
const truncated = rows.slice(0, 50);
```

`queryWithTimeout` goes through node-postgres `client.query()`, which is **not streaming**: it pushes every row of the result into the Node heap (`pg/lib/query.js:98` → `pg/lib/result.js:79` `this.rows.push(row)`) before the promise resolves. So a model-written `SELECT * FROM "User"` with no `LIMIT` materialised the whole table in process — bounded only by the 30s statement timeout — and only then discarded all but 50 rows.

Net: the 50 protected the model's context window, not the server process. "Always use LIMIT" was back to being convention, which is what #3584 set out to stop relying on.

A second, smaller problem: `rows.slice(0, 50)` cannot distinguish "exactly 50 rows matched" from "we threw the rest away", so the model was told the former either way.

## The fix

Wrap the model's statement so the row bound is the database's, matching the other two:

```sql
SELECT * FROM (<sql>) __civitai_row_bound LIMIT 51
```

Fetch 51, return at most 50, and say so explicitly when the 51st row came back.

The trailing `;` the scope check permits is stripped first — without that the wrap is a syntax error. `checkQueryScope` still reads the model's **original** text; scope-checking the rewrite would audit our own wrapper rather than the model's query.

The allowlist, the timeout and the read-only transaction are unchanged. The tool description now states what is actually true.

## Why wrapping, and why I trust it

I considered a server-side cursor (`DECLARE` / `FETCH 51`), which preserves semantics by construction. It needs either a new dependency or a multi-round-trip helper owning its own transaction — i.e. reworking `queryWithTimeout`, the thing that currently owns the read-only and timeout bounds. The wrap is a one-expression change that leaves those bounds untouched.

The cost of wrapping is that it rewrites the model's SQL, so I measured the semantics against a real PostgreSQL rather than reasoning about them:

| shape | result |
|---|---|
| top-level `ORDER BY` | preserved; plan is `Limit -> Sort`, same top rows as unwrapped |
| `ORDER BY` on an unprojected column / by ordinal / across a `UNION` | preserved |
| `UNION`, `UNION ALL` | wrapped as a whole, not just the last branch |
| `DISTINCT ON`, `GROUP BY`/`HAVING`, window functions | preserved |
| inner `LIMIT` / `OFFSET` / `LIMIT ALL` / `FETCH FIRST` | composes; the smaller bound wins |
| duplicate output column names — `SELECT 1 AS a, 2 AS a`, or `SELECT *` over a join | legal in a derived table; both columns preserved, identical to unwrapped |
| trailing `;` inside the wrap | syntax error — hence the strip |
| statement stacking through the wrap | syntax error, so the rewrite cannot launder a second statement |
| does the outer `LIMIT` really stop the scan? | yes — `EXPLAIN ANALYZE` over a 10k-row table gives `Seq Scan (actual rows=51)`, 2 buffers; a 1M-row set-returning function comes back as 4 rows against `LIMIT 4` |

Worth being explicit about what this does **not** buy: the outer `LIMIT` caps what is transferred and buffered, not what the database sorts or aggregates first. A `GROUP BY` over a large table still does that work — the statement timeout is the bound there, and the tool description says so rather than implying otherwise.

## Tests

`src/server/freshdesk-agent/__tests__/freshdesk-tools.query-database.test.ts`: 7 → 14 tests.

The load-bearing assertion is on the **SQL string handed to the driver**, with the expected statement written out literally rather than assembled from the implementation's constants. A test that only checked the returned array was short would pass with the bug fully present — that is precisely the shape of the bug.

**Red → green.** New tests against `main`'s `freshdesk-tools.ts`: **8 failed / 42 passed (50)**. With the fix: **50 passed (50)**. Each failure was for its own reason — wrapped-SQL mismatch for the rewrite tests, `expected undefined to be 'Truncated: …'` for the truncation test.

**Mutation check** — five mutants, each killed only by the test that owns it:

| mutant | killed by |
|---|---|
| truncation boundary `>` → `>=` | *does not claim truncation on a full page* (1 failed / 13 passed) |
| fetch 50 instead of 51 | the literal-SQL tests (7 failed / 7 passed) |
| drop the semicolon strip | *strips the trailing semicolon before wrapping* (1 failed / 13 passed) |
| scope-check the rewrite instead of the original | *scope-checks the model's original SQL* (1 failed / 13 passed), failing on its own scope assertion rather than its positive control |
| drop the wrap — i.e. the original defect | 7 failed / 7 passed |

The scope-check test uses a pass-through spy that delegates to the real `checkQueryScope`; that the delegation is real is proved by the pre-existing "refuses a relation outside the allowed set" case, which only passes if the genuine check ran.

`pnpm typecheck` → 0 errors. `pnpm test:lint-rules` → 186 passed. ESLint clean on `src/server/freshdesk-agent/`.

---

## Follow-up: the wrap created a seam, and an audit found a hole in it

An adversarial audit of the commits above found a defect that the wrap made
reachable, confirmed end to end against a real Postgres. Fixed in
`1a5f492a9f`; **the row-bound change should not be read without it.**

**The seam.** After the wrap, the string that `checkQueryScope` validates and
the string the driver executes are no longer the same — and a wrapper supplies
parentheses.

**The hole.** `checkQueryScope`'s paren walk clamped an unbalanced `)` to depth
zero (`Math.max(0, depth - 1)`) and never asserted the depth was back to zero
at the end. Every relation decision in that walk is keyed on `depth` — which
`FROM` list a comma continues, and therefore which tokens sit in relation
position. So text whose real nesting the walk could not model received a
verdict that was not about the SQL a database would parse.

Standing alone such text is a syntax error, which is why this was inert before
this PR. Wrapping it made it executable: a statement carrying a stray `)` early
and an unclosed `(` late can be rejected by Postgres on its own and **valid
once wrapped**, reaching a relation the walk never audited. The read pool is
not `GRANT`-restricted to the allowlisted tables, so `checkQueryScope` is the
only bound on which relations are reachable.

**Two changes.**

1. *Root cause* — `checkQueryScope` now refuses paren-unbalanced input in both
   directions: a `)` that closes nothing is rejected rather than clamped, and a
   `(` left open at the end is rejected. This closes the class at its source,
   independent of any wrapping. Parentheses inside string literals and quoted
   identifiers are content, not structure, and are unaffected — pinned by test.
2. *Defense in depth* — the tool now scope-checks the statement it **actually
   executes** as well as the model's original. The original still owns the
   model-facing error message; the executed string is what has to be proven in
   scope. My earlier comment argued against this and was wrong in an
   exploitable way; it has been rewritten to say why.

**Red → green.** New fixtures against the pre-fix branch tip: **13 failed / 51
passed (64)**. With the fix: **64 passed (64)**. Pre-fix, the seam test showed
all three out-of-scope statements arriving at the driver fully wrapped.

**Mutant battery** — re-run in full, because a fix round resets the gate. 16
mutants; 13 killed, 3 proven equivalent:

| mutant | killed by |
|---|---|
| remove the `)`-closes-nothing rejection | 3 tests incl. the seam test |
| assert balance in only one direction (either half) | 3 tests each |
| off-by-one on the depth boundary (`=== 0` → `< 0`) | 3 tests |
| comment the guard out, text still present | 3 tests |
| drop the final depth assertion | 3 tests |
| drop the wrapped-text scope check | 2 tests |
| ignore the wrapped check's result | the internal-guard test |
| driver gets a *different* string than was checked | 7 tests |
| driver gets the unchecked original | 7 tests |
| re-wrap after checking (stale value) | 7 tests |
| the 5 earlier row-bound mutants | as before |

The three survivors are **equivalent mutants, proven rather than asserted**:
restoring the clamp, and `depth > 0` vs `depth !== 0` at the final assertion,
are both no-ops *given* the other guard. I instrumented the invariants
(`depth >= 1` at the decrement, `depth >= 0` at the final check) and ran the
whole corpus — neither fired — alongside a negative control assertion that
**did** fire, so the instrument is known to work rather than merely silent.

**Also fixed:** `vi.clearAllMocks()` does not drain a `mockReturnValueOnce`
queue, so a leftover value could leak into the following test and misattribute
a failure. Found only because a mutant made the code consume one of two queued
values; the suite was green throughout. Now `mockReset` + reinstall.

Full unit suite **800 files, 11,873 passed / 1 skipped**. Typecheck 0 errors.
Prettier and ESLint clean.
