### PR TITLE
feat(creator-shop): record per-item review history for cosmetics

### DIFF
--- a/docs/features/creator-shop.md
+++ b/docs/features/creator-shop.md
@@ -91,8 +91,26 @@ The creator's **submission fee is never refunded** — a takedown is a terms vio
 
 Money moves are best-effort per buyer: each is retried 3× (1s apart) before it's written off, and failures are collected in `failures` (stage + user + amount) instead of aborting the run. Everything lands in Axiom under `name: 'cosmetic-takedown'` — a start record, one `error` per written-off refund/clawback carrying the ids needed to finish it by hand, and a finish record with the run totals (`error` level if anything failed).
 
+## Review history
+
+An edit-triggered re-review clears `rejectionReason` / `reviewedById` / `reviewedAt`, so without a log a moderator opening a re-queued item can't tell what the creator changed or what was decided last time. `CosmeticShopItemMeta.history` is that log — a capped (25, oldest dropped first) append-only array on the existing JSON column, no migration:
+
+```ts
+{ at, userId, kind: 'submitted' | 'edited' | 'reviewed' | 'takedown', status?, action?, note?, changes?: [{ field, from?, to? }] }
+```
+
+Every writer appends inside the `cosmeticShopItem.update` it was already making (`appendItemHistory` in `creator-shop.data.ts`) — recording history never costs an extra round trip:
+
+- `submitCreatorShopItem` seeds a `submitted` entry.
+- `updateCreatorShopItem` appends `edited` with one `changes` row per moved field (name, description, artwork — carrying the **pre-swap `data.url`** — fit offsets, slug, uses, price-per-use, price, quantity), plus a `note` when the edit forced the item back into review and why. An edit that moves nothing appends nothing.
+- `reviewCreatorShopItem` appends `reviewed` with the action, the reviewer and the note — which is how the note **survives the next edit clearing `rejectionReason`**.
+- `takedownCosmeticShopItem` appends `takedown` alongside the `meta.takedown` record it already writes.
+
+`getCreatorShopReviewQueue` already selects `meta`, so the moderator detail pane renders it (`HistoryCard`, newest-first, previous-vs-current artwork thumbnails on a swap) with no query change. Items predating the feature show an explicit empty state. Moderator-only for now — the creator-facing manage view still shows only the current status + rejection reason.
+
 ## Changelog
 
+- **2026-08-05** — Per-item review history recorded on `CosmeticShopItem.meta.history` (submissions, creator edits with before → after per field, verdicts, takedowns) and surfaced in the moderator review queue.
 - **2026-08-03** — Purchases now record their payout split **and each payout's transaction id** (`UserCosmeticShopPurchases.meta`, migration `20260803220000_add_cosmetic_purchase_payout_meta` — **apply manually**), so takedowns refund those payouts directly.
 - **2026-08-03** — Takedown + refund + clawback path added (`creatorShop.takedownItem`, moderator review-queue "Take down" action).
 - **2026-08-03** — Cosmetic submissions now require (and record) a creator affirmation of the rights to sell the artwork.

--- a/src/components/CreatorShop/HistoryCard.tsx
+++ b/src/components/CreatorShop/HistoryCard.tsx
@@ -1,0 +1,169 @@
+import { Group, Stack, Text } from '@mantine/core';
+import { IconAlertTriangle, IconArrowRight, IconHistory } from '@tabler/icons-react';
+import { ChecksCard } from '~/components/CreatorShop/ChecksCard';
+import { CosmeticThumb } from '~/components/CreatorShop/CosmeticThumb';
+import { CREATOR_SHOP_BORDER } from '~/components/CreatorShop/creator-shop.constants';
+import type {
+  CosmeticShopItemHistoryChange,
+  CosmeticShopItemHistoryEntry,
+} from '~/server/schema/cosmetic-shop.schema';
+import { formatDate } from '~/utils/date-helpers';
+import { numberWithCommas } from '~/utils/number-helpers';
+
+const fieldLabels: Record<string, string> = {
+  name: 'Name',
+  description: 'Description',
+  artwork: 'Artwork',
+  offsets: 'Fit offsets',
+  slug: 'Slug',
+  uses: 'Uses per purchase',
+  pricePerUse: 'Price per extra use',
+  price: 'Price',
+  quantity: 'Quantity',
+};
+
+const actionLabels: Record<string, string> = {
+  approve: 'Approved & published',
+  reject: 'Rejected',
+  'request-changes': 'Requested changes',
+  revert: 'Reverted to pending review',
+};
+
+const valueText = (value: CosmeticShopItemHistoryChange['from'], field: string) => {
+  if (value === undefined || value === null || value === '') return 'none';
+  if (typeof value === 'number')
+    return field === 'price' || field === 'pricePerUse'
+      ? `${numberWithCommas(value)} Buzz`
+      : numberWithCommas(value);
+  if (field === 'slug') return `:${value}:`;
+  // Free text can be paragraphs long; the full value is on the item itself.
+  return value.length > 60 ? `“${value.slice(0, 60)}…”` : `“${value}”`;
+};
+
+const changeText = (change: CosmeticShopItemHistoryChange) => {
+  const label = fieldLabels[change.field] ?? change.field;
+  if (change.field === 'artwork') return 'Artwork replaced';
+  return `${label} ${valueText(change.from, change.field)} → ${valueText(change.to, change.field)}`;
+};
+
+const headline = (entry: CosmeticShopItemHistoryEntry) => {
+  switch (entry.kind) {
+    case 'submitted':
+      return 'Submitted for review';
+    case 'edited':
+      return 'Edited by the creator';
+    case 'takedown':
+      return 'Taken down';
+    default:
+      return (entry.action && actionLabels[entry.action]) ?? 'Reviewed';
+  }
+};
+
+// Artwork swaps carry the pre-swap url, so the previous art can be shown beside
+// the current one — the single most common thing a re-review needs to compare.
+function ArtworkSwap({ change }: { change: CosmeticShopItemHistoryChange }) {
+  return (
+    <Group gap={8} align="center">
+      <Stack gap={2} align="center">
+        <CosmeticThumb data={{ url: change.from }} name="Previous artwork" />
+        <Text size="xs" c="dimmed">
+          Before
+        </Text>
+      </Stack>
+      <IconArrowRight size={14} color="var(--mantine-color-dimmed)" />
+      <Stack gap={2} align="center">
+        <CosmeticThumb data={{ url: change.to }} name="Replacement artwork" />
+        <Text size="xs" c="dimmed">
+          After
+        </Text>
+      </Stack>
+    </Group>
+  );
+}
+
+function HistoryRow({
+  entry,
+  actor,
+  withBorder,
+}: {
+  entry: CosmeticShopItemHistoryEntry;
+  actor: string;
+  withBorder?: boolean;
+}) {
+  const artworkChange = entry.changes?.find((c) => c.field === 'artwork' && (c.from || c.to));
+  return (
+    <Stack
+      gap={6}
+      px="md"
+      py={9}
+      style={{ borderBottom: withBorder ? CREATOR_SHOP_BORDER : undefined }}
+    >
+      <Group gap={8} justify="space-between" wrap="nowrap" align="baseline">
+        <Text size="sm" fw={500}>
+          {headline(entry)}
+        </Text>
+        <Text size="xs" c="dimmed" className="whitespace-nowrap">
+          {actor} · {formatDate(entry.at, 'MMM D, YYYY h:mm A')}
+        </Text>
+      </Group>
+      {!!entry.changes?.length && (
+        <Stack gap={2}>
+          {entry.changes.map((change, i) => (
+            <Text key={`${change.field}-${i}`} size="xs" c="dimmed">
+              {changeText(change)}
+            </Text>
+          ))}
+        </Stack>
+      )}
+      {!!artworkChange && <ArtworkSwap change={artworkChange} />}
+      {!!entry.note && (
+        <Text size="xs" c={entry.kind === 'edited' ? 'yellow' : 'dimmed'}>
+          {entry.note}
+        </Text>
+      )}
+    </Stack>
+  );
+}
+
+/**
+ * Newest-first log of everything that happened to a shop item. `creator` names
+ * the actor when the event was theirs; anyone else (moderators) shows as an id,
+ * matching how the rights affirmation attributes non-creators.
+ */
+export function HistoryCard({
+  history,
+  creator,
+}: {
+  history?: CosmeticShopItemHistoryEntry[];
+  creator?: { id: number; username: string | null } | null;
+}) {
+  const entries = history ? [...history].reverse() : [];
+  return (
+    <ChecksCard
+      icon={<IconHistory size={15} color="var(--mantine-color-dimmed)" />}
+      title="History"
+    >
+      {entries.length ? (
+        entries.map((entry, i) => (
+          <HistoryRow
+            key={`${entry.at}-${i}`}
+            entry={entry}
+            actor={
+              creator && entry.userId === creator.id
+                ? `@${creator.username ?? 'creator'}`
+                : `user #${entry.userId}`
+            }
+            withBorder={i < entries.length - 1}
+          />
+        ))
+      ) : (
+        <Group gap={9} px="md" py={9} align="center">
+          <IconAlertTriangle size={16} color="var(--mantine-color-yellow-5)" />
+          <Text size="sm" c="dimmed">
+            No history recorded — this item predates change tracking.
+          </Text>
+        </Group>
+      )}
+    </ChecksCard>
+  );
+}

--- a/src/pages/moderator/creator-shop.tsx
+++ b/src/pages/moderator/creator-shop.tsx
@@ -54,6 +54,7 @@ import {
 import { InViewLoader } from '~/components/InView/InViewLoader';
 import { CheckRow, ChecksCard } from '~/components/CreatorShop/ChecksCard';
 import { CosmeticThumb } from '~/components/CreatorShop/CosmeticThumb';
+import { HistoryCard } from '~/components/CreatorShop/HistoryCard';
 import { CREATOR_SHOP_BORDER } from '~/components/CreatorShop/creator-shop.constants';
 import { cosmeticTypeOptions } from '~/components/CreatorShop/Submit/submit.constants';
 import { CosmeticPreview } from '~/components/CosmeticShop/CosmeticPreview';
@@ -785,6 +786,11 @@ function CreatorShopReviewPage() {
                         </Group>
                       )}
                     </ChecksCard>
+
+                    <HistoryCard
+                      history={selectedMeta.history}
+                      creator={selected.cosmetic.creator}
+                    />
 
                     <Stack gap={8}>
                       <Text size="sm" fw={600}>

--- a/src/server/schema/cosmetic-shop.schema.ts
+++ b/src/server/schema/cosmetic-shop.schema.ts
@@ -24,6 +24,29 @@ export const getPaginatedCosmeticShopItemInput = paginationSchema.merge(
 // system user (-1); creator storefronts attribute as their owner's user id.
 export const CIVITAI_SHOP_ATTRIBUTION = -1;
 
+// One field a creator edit moved. Values are pre-formatted for display (Buzz
+// amounts stay numeric so the UI can group them) and absent when the field was
+// cleared or was never set.
+export type CosmeticShopItemHistoryChange = z.infer<typeof cosmeticShopItemHistoryChange>;
+export const cosmeticShopItemHistoryChange = z.object({
+  field: z.string(),
+  from: z.union([z.string(), z.number()]).nullish(),
+  to: z.union([z.string(), z.number()]).nullish(),
+});
+
+export type CosmeticShopItemHistoryEntry = z.infer<typeof cosmeticShopItemHistoryEntry>;
+export const cosmeticShopItemHistoryEntry = z.object({
+  at: z.string(),
+  userId: z.number(),
+  kind: z.enum(['submitted', 'edited', 'reviewed', 'takedown']),
+  // Status the item landed in after this event.
+  status: z.string().optional(),
+  // Review verdict for `reviewed` entries: approve | reject | request-changes | revert.
+  action: z.string().optional(),
+  note: z.string().optional(),
+  changes: z.array(cosmeticShopItemHistoryChange).optional(),
+});
+
 export type CosmeticShopItemMeta = z.infer<typeof cosmeticShopItemMeta>;
 export const cosmeticShopItemMeta = z.object({
   paidToUserIds: z.array(z.number()).optional(),
@@ -79,6 +102,11 @@ export const cosmeticShopItemMeta = z.object({
       at: z.string(),
     })
     .optional(),
+  // Append-only (capped) log of submissions, creator edits, review verdicts and
+  // takedowns, so a re-review can see what changed and what was decided before.
+  // Absent on items that predate it — the UI shows an empty state rather than
+  // implying nothing ever happened.
+  history: z.array(cosmeticShopItemHistoryEntry).optional(),
 });
 
 // Recorded on UserCosmeticShopPurchases.meta at purchase time. The 70% pool can
@@ -102,7 +130,7 @@ export const cosmeticPurchaseMeta = z.object({
     .optional(),
   // Kept by the platform (no recipient), so nothing to claw back — recorded for
   // the takedown summary and for reconciliation.
-  platformCut: z.number().optional(),  
+  platformCut: z.number().optional(),
 });
 
 export type UpsertCosmeticInput = z.infer<typeof upsertCosmeticInput>;

--- a/src/server/services/__tests__/creator-shop-history.service.test.ts
+++ b/src/server/services/__tests__/creator-shop-history.service.test.ts
@@ -1,0 +1,203 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type * as Caches from '~/server/redis/caches';
+import type { CosmeticShopItemHistoryEntry } from '~/server/schema/cosmetic-shop.schema';
+import { CREATOR_SHOP_HISTORY_LIMIT, appendItemHistory } from '../creator-shop.data';
+
+const { mocks } = vi.hoisted(() => ({
+  mocks: {
+    shopItemFindUnique: vi.fn(),
+    shopItemUpdate: vi.fn(),
+    userCosmeticCreateMany: vi.fn(),
+    refreshOwnedStickerCache: vi.fn(),
+    createNotification: vi.fn(),
+    sharpMetadata: vi.fn(),
+  },
+}));
+
+vi.mock('~/server/db/client', () => ({
+  dbRead: {
+    cosmeticShopItem: { findUnique: mocks.shopItemFindUnique, findFirst: vi.fn() },
+  },
+  dbWrite: {
+    cosmeticShopItem: { update: mocks.shopItemUpdate },
+    cosmetic: { update: vi.fn() },
+    userCosmetic: { createMany: mocks.userCosmeticCreateMany },
+  },
+}));
+vi.mock('sharp', () => ({ default: () => ({ metadata: mocks.sharpMetadata }) }));
+vi.mock('~/server/services/buzz.service', () => ({
+  createBuzzTransaction: vi.fn(),
+  refundMultiAccountTransaction: vi.fn(),
+  refundTransaction: vi.fn(),
+}));
+vi.mock('~/server/services/notification.service', () => ({
+  createNotification: mocks.createNotification,
+}));
+vi.mock('~/server/redis/caches', async (importOriginal) => ({
+  ...(await importOriginal<typeof Caches>()),
+  refreshOwnedStickerCache: mocks.refreshOwnedStickerCache,
+}));
+
+import { reviewCreatorShopItem, updateCreatorShopItem } from '../creator-shop.service';
+
+// The item as it stands after the moderator asked for changes: approved once at
+// 500 Buzz, currently sitting in RequestedChanges with the mod's note.
+const requestedChangesItem = {
+  id: 42,
+  cosmeticId: 7,
+  unitAmount: 500,
+  status: 'RequestedChanges',
+  title: 'Golden Laurel',
+  description: 'A laurel',
+  availableQuantity: null,
+  addedById: 11,
+  meta: {
+    lastApprovedAmount: 500,
+    history: [
+      { at: '2026-08-01T00:00:00.000Z', userId: 11, kind: 'submitted', status: 'PendingReview' },
+      {
+        at: '2026-08-02T00:00:00.000Z',
+        userId: 99,
+        kind: 'reviewed',
+        status: 'RequestedChanges',
+        action: 'request-changes',
+        note: 'Price is too high for a badge',
+      },
+    ],
+  },
+  cosmetic: {
+    id: 7,
+    createdById: 11,
+    type: 'Badge',
+    data: { url: 'old-art' },
+    creator: { username: 'creator' },
+  },
+  _count: { purchases: 0 },
+};
+
+const historyOf = (call: number): CosmeticShopItemHistoryEntry[] =>
+  mocks.shopItemUpdate.mock.calls[call][0].data.meta.history;
+
+describe('appendItemHistory', () => {
+  it('keeps the newest entries when the cap is hit', () => {
+    const entry = (i: number) =>
+      ({
+        at: `2026-01-01T00:00:${String(i).padStart(2, '0')}.000Z`,
+        userId: 1,
+        kind: 'edited',
+      } as const);
+    const filled = Array.from({ length: CREATOR_SHOP_HISTORY_LIMIT }, (_, i) => entry(i));
+
+    const { history } = appendItemHistory({ purchases: 0, history: filled }, entry(99));
+
+    expect(history).toHaveLength(CREATOR_SHOP_HISTORY_LIMIT);
+    expect(history?.[CREATOR_SHOP_HISTORY_LIMIT - 1]).toEqual(entry(99));
+    expect(history?.[0]).toEqual(entry(1));
+  });
+});
+
+describe('creator shop item history', () => {
+  beforeEach(() => {
+    Object.values(mocks).forEach((m) => m.mockReset());
+    mocks.shopItemFindUnique.mockResolvedValue(requestedChangesItem);
+    mocks.shopItemUpdate.mockImplementation(({ data }: { data: Record<string, unknown> }) => ({
+      id: 42,
+      ...data,
+    }));
+    mocks.sharpMetadata.mockResolvedValue({
+      width: 144,
+      height: 144,
+      format: 'png',
+      hasAlpha: true,
+      pages: 1,
+    });
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({ ok: true, arrayBuffer: async () => new ArrayBuffer(8) })
+    );
+  });
+
+  it('records an edit, its re-review, and the approval as three ordered entries', async () => {
+    await updateCreatorShopItem({ id: 42, userId: 11, price: 900 });
+
+    const afterEdit = historyOf(0);
+    expect(afterEdit).toHaveLength(3);
+    const edit = afterEdit[2];
+    expect(edit).toMatchObject({
+      userId: 11,
+      kind: 'edited',
+      status: 'PendingReview',
+      changes: [{ field: 'price', from: 500, to: 900 }],
+    });
+    // The edit is what pushed it back into the queue; a re-reviewer needs to
+    // see that, not just the new price.
+    expect(edit.note).toMatch(/Resubmitted for review/);
+    // The previous verdict survives the edit that clears `rejectionReason`.
+    expect(afterEdit[1].note).toBe('Price is too high for a badge');
+
+    // The approval builds on the item as the edit left it.
+    mocks.shopItemFindUnique.mockResolvedValue({
+      ...requestedChangesItem,
+      status: 'PendingReview',
+      unitAmount: 900,
+      meta: { ...requestedChangesItem.meta, history: afterEdit },
+    });
+    await reviewCreatorShopItem({ id: 42, reviewerId: 99, action: 'approve' });
+
+    const afterApproval = historyOf(1);
+    expect(afterApproval).toHaveLength(4);
+    expect(afterApproval[3]).toMatchObject({
+      userId: 99,
+      kind: 'reviewed',
+      action: 'approve',
+      status: 'Published',
+    });
+    expect(afterApproval.map((e) => e.kind)).toEqual([
+      'submitted',
+      'reviewed',
+      'edited',
+      'reviewed',
+    ]);
+  });
+
+  it('records the pre-swap artwork url so a swap is identifiable', async () => {
+    await updateCreatorShopItem({
+      id: 42,
+      userId: 11,
+      // A moderator swap doesn't re-affirm the rights, so the edit doesn't need
+      // a `rightsAffirmed` flag it would otherwise be rejected without.
+      isModerator: true,
+      imageUrl: 'new-art',
+    });
+
+    expect(historyOf(0)[2].changes).toContainEqual({
+      field: 'artwork',
+      from: 'old-art',
+      to: 'new-art',
+    });
+  });
+
+  it('leaves history untouched when an edit moves nothing', async () => {
+    await updateCreatorShopItem({ id: 42, userId: 11, price: 500 });
+
+    expect(historyOf(0)).toEqual(requestedChangesItem.meta.history);
+  });
+
+  it('records a rejection with its note and reviewer', async () => {
+    await reviewCreatorShopItem({
+      id: 42,
+      reviewerId: 99,
+      action: 'reject',
+      rejectionReason: 'Traced artwork',
+    });
+
+    const history = historyOf(0);
+    expect(history[history.length - 1]).toMatchObject({
+      userId: 99,
+      kind: 'reviewed',
+      action: 'reject',
+      status: 'Rejected',
+      note: 'Traced artwork',
+    });
+  });
+});

--- a/src/server/services/creator-shop.data.ts
+++ b/src/server/services/creator-shop.data.ts
@@ -1,3 +1,7 @@
+import type {
+  CosmeticShopItemHistoryEntry,
+  CosmeticShopItemMeta,
+} from '~/server/schema/cosmetic-shop.schema';
 import type { CosmeticOffsets } from '~/server/schema/creator-shop.schema';
 import { CosmeticType, MediaType } from '~/shared/utils/prisma/enums';
 import type { StickerEconomics } from '~/shared/utils/sticker-token';
@@ -38,6 +42,25 @@ export const buildCosmeticData = (
   if (type === CosmeticType.Badge) return { url: imageUrl, animated: !!animated };
   return { url: imageUrl };
 };
+
+// Oldest entries are dropped first: a long-lived item's recent edits are what a
+// re-review needs, and meta is a JSON column we don't want growing unbounded.
+export const CREATOR_SHOP_HISTORY_LIMIT = 25;
+
+/**
+ * Appends an event to an item's review history, oldest-first, capped.
+ *
+ * Takes and returns the whole meta so callers can drop it straight into the
+ * `cosmeticShopItem.update` they were already making — recording history must
+ * never cost an extra round trip, or it will get skipped on some path.
+ */
+export const appendItemHistory = (
+  meta: CosmeticShopItemMeta,
+  entry: CosmeticShopItemHistoryEntry
+): CosmeticShopItemMeta => ({
+  ...meta,
+  history: [...(meta.history ?? []), entry].slice(-CREATOR_SHOP_HISTORY_LIMIT),
+});
 
 /**
  * Resolves the `Cosmetic.data` write for an edit. Replaced artwork rebuilds the

--- a/src/server/services/creator-shop.service.ts
+++ b/src/server/services/creator-shop.service.ts
@@ -9,6 +9,7 @@ import {
   validateStickerCosmetic,
 } from '~/server/services/cosmetic.service';
 import {
+  appendItemHistory,
   buildCosmeticData,
   creatorGrantRemaining,
   patchCosmeticData,
@@ -41,6 +42,7 @@ import {
 } from '~/shared/utils/prisma/enums';
 import type {
   CosmeticPurchaseMeta,
+  CosmeticShopItemHistoryChange,
   CosmeticShopItemMeta,
 } from '~/server/schema/cosmetic-shop.schema';
 import { cosmeticShopItemSelect } from '~/server/selectors/cosmetic-shop.selector';
@@ -235,6 +237,9 @@ const buildRightsAffirmation = (userId: number) => ({
   statement: RIGHTS_AFFIRMATION_STATEMENT,
 });
 
+const offsetsLabel = (offsets?: CosmeticOffsets | null) =>
+  offsets ? `T${offsets.top} R${offsets.right} B${offsets.bottom} L${offsets.left}` : undefined;
+
 // ---------------------------------------------------------------------------
 // Creator: submit & manage
 // ---------------------------------------------------------------------------
@@ -350,6 +355,14 @@ export const submitCreatorShopItem = async ({
             sellerShare: sellableByOthers ? sellerShare : 0,
             acceptsBlueBuzz,
             rightsAffirmation: buildRightsAffirmation(userId),
+            history: [
+              {
+                at: new Date().toISOString(),
+                userId,
+                kind: 'submitted',
+                status: CosmeticShopItemStatus.PendingReview,
+              },
+            ],
           } satisfies CosmeticShopItemMeta,
         },
         select: creatorShopItemSelect,
@@ -372,6 +385,10 @@ const getOwnedItemOrThrow = async (id: number, userId: number, isModerator = fal
       status: true,
       meta: true,
       addedById: true,
+      // Prior values, so an edit can record what it moved from.
+      title: true,
+      description: true,
+      availableQuantity: true,
       cosmetic: { select: { id: true, createdById: true, type: true, data: true } },
       _count: { select: { purchases: true } },
     },
@@ -576,6 +593,39 @@ export const updateCreatorShopItem = async ({
     existing.status === CosmeticShopItemStatus.PendingReview;
   const status = backToReview ? CosmeticShopItemStatus.PendingReview : existing.status;
 
+  const changes: CosmeticShopItemHistoryChange[] = [];
+  const recordChange = (
+    field: string,
+    from: string | number | null | undefined,
+    to: string | number | null | undefined
+  ) => {
+    if (from !== to) changes.push({ field, from, to });
+  };
+  if (name !== undefined) recordChange('name', existing.title, name);
+  if (description !== undefined) recordChange('description', existing.description, description);
+  // The pre-swap url, captured before `data` is rebuilt — it's the only way the
+  // queue can show what the artwork used to be.
+  if (artChanged) recordChange('artwork', existingData.url as string | undefined, imageUrl);
+  if (offsetsChange)
+    recordChange('offsets', offsetsLabel(existingData.offsets), offsetsLabel(nextOffsets));
+  if (slugChange) recordChange('slug', existingSlug, nextSlug);
+  if (usesChange) recordChange('uses', existingEconomics.uses, nextEconomics.uses);
+  if (pricePerUseChange)
+    recordChange('pricePerUse', existingEconomics.pricePerUse, nextEconomics.pricePerUse);
+  if (price != null) recordChange('price', existing.unitAmount, price);
+  if (availableQuantity !== undefined)
+    recordChange('quantity', existing.availableQuantity, availableQuantity);
+
+  const reviewNote = !backToReview
+    ? undefined
+    : isPublished
+    ? `Returned to review: price moved more than ${Math.round(
+        PRICE_REVIEW_THRESHOLD * 100
+      )}% from the approved ${base} Buzz`
+    : existing.status === CosmeticShopItemStatus.RequestedChanges
+    ? 'Resubmitted for review after requested changes'
+    : 'Edited while awaiting review';
+
   if (contentChanged) {
     const patchedData = patchCosmeticData({
       existingData,
@@ -597,6 +647,31 @@ export const updateCreatorShopItem = async ({
     });
   }
 
+  const updatedMeta: CosmeticShopItemMeta = {
+    ...meta,
+    ...(acceptsBlueBuzz !== undefined ? { acceptsBlueBuzz } : {}),
+    ...(artwork
+      ? {
+          autoChecks: artwork.checks,
+          imageMeta: artwork.imageMeta,
+          imageHash: artwork.imageHash,
+        }
+      : {}),
+    ...(requiresAffirmation ? { rightsAffirmation: buildRightsAffirmation(userId) } : {}),
+  };
+  // An edit that moved nothing (e.g. a resubmit with identical values) isn't
+  // worth a row in the history.
+  const nextMeta = changes.length
+    ? appendItemHistory(updatedMeta, {
+        at: new Date().toISOString(),
+        userId,
+        kind: 'edited',
+        status,
+        note: reviewNote,
+        changes,
+      })
+    : updatedMeta;
+
   return dbWrite.cosmeticShopItem.update({
     where: { id },
     data: {
@@ -607,18 +682,7 @@ export const updateCreatorShopItem = async ({
       status,
       // Clear the prior verdict whenever it re-enters the review queue.
       ...(backToReview ? { rejectionReason: null, reviewedById: null, reviewedAt: null } : {}),
-      meta: {
-        ...meta,
-        ...(acceptsBlueBuzz !== undefined ? { acceptsBlueBuzz } : {}),
-        ...(artwork
-          ? {
-              autoChecks: artwork.checks,
-              imageMeta: artwork.imageMeta,
-              imageHash: artwork.imageHash,
-            }
-          : {}),
-        ...(requiresAffirmation ? { rightsAffirmation: buildRightsAffirmation(userId) } : {}),
-      } as Prisma.InputJsonValue,
+      meta: nextMeta as Prisma.InputJsonValue,
     },
     select: creatorShopItemSelect,
   });
@@ -1257,6 +1321,29 @@ export const reviewCreatorShopItem = async ({
   const meta = (item.meta ?? {}) as CosmeticShopItemMeta;
   const now = new Date();
   const reviewFields = { reviewedById: reviewerId, reviewedAt: now };
+  const nextStatus =
+    action === 'approve'
+      ? CosmeticShopItemStatus.Published
+      : action === 'reject'
+      ? CosmeticShopItemStatus.Rejected
+      : action === 'revert'
+      ? CosmeticShopItemStatus.PendingReview
+      : CosmeticShopItemStatus.RequestedChanges;
+  // The verdict is recorded on the history too, not just on rejectionReason —
+  // the next edit clears that column, and a re-review needs to see what was
+  // said last time.
+  const reviewedMeta = (extra: Partial<CosmeticShopItemMeta>) =>
+    appendItemHistory(
+      { ...meta, ...extra },
+      {
+        at: now.toISOString(),
+        userId: reviewerId,
+        kind: 'reviewed',
+        status: nextStatus,
+        action,
+        note: rejectionReason ?? undefined,
+      }
+    ) as Prisma.InputJsonValue;
 
   const updated =
     action === 'approve'
@@ -1266,9 +1353,9 @@ export const reviewCreatorShopItem = async ({
           where: { id },
           data: {
             ...reviewFields,
-            status: CosmeticShopItemStatus.Published,
+            status: nextStatus,
             rejectionReason: null,
-            meta: { ...meta, lastApprovedAmount: item.unitAmount } as Prisma.InputJsonValue,
+            meta: reviewedMeta({ lastApprovedAmount: item.unitAmount }),
           },
           select: creatorShopItemSelect,
         })
@@ -1279,13 +1366,9 @@ export const reviewCreatorShopItem = async ({
           where: { id },
           data: {
             ...reviewFields,
-            status:
-              action === 'reject'
-                ? CosmeticShopItemStatus.Rejected
-                : action === 'revert'
-                ? CosmeticShopItemStatus.PendingReview
-                : CosmeticShopItemStatus.RequestedChanges,
+            status: nextStatus,
             rejectionReason: rejectionReason ?? null,
+            meta: reviewedMeta({}),
           },
           select: creatorShopItemSelect,
         });
@@ -1404,10 +1487,16 @@ export const takedownCosmeticShopItem = async ({
       status: CosmeticShopItemStatus.Archived,
       listed: false,
       archivedAt: now,
-      meta: {
-        ...meta,
-        takedown: { reason, moderatorId, at: now.toISOString() },
-      } as Prisma.InputJsonValue,
+      meta: appendItemHistory(
+        { ...meta, takedown: { reason, moderatorId, at: now.toISOString() } },
+        {
+          at: now.toISOString(),
+          userId: moderatorId,
+          kind: 'takedown',
+          status: CosmeticShopItemStatus.Archived,
+          note: reason,
+        }
+      ) as Prisma.InputJsonValue,
     },
     select: creatorShopItemSelect,
   });


### PR DESCRIPTION
Submissions, creator edits (with before → after per changed field), review verdicts and takedowns now append to a capped `CosmeticShopItem.meta.history` array, written inside the update each writer was already making. Moderators re-reviewing an edited item can see what the creator changed and what was decided last time, which the edit-triggered clearing of `rejectionReason` / `reviewedById` / `reviewedAt` would otherwise lose.