### PR TITLE
fix(creator-shop): stop truncating seller username in resell UI

### DIFF
--- a/src/components/CreatorShop/Manage/ListExistingModal.tsx
+++ b/src/components/CreatorShop/Manage/ListExistingModal.tsx
@@ -73,8 +73,12 @@ function PublicShopItemCard({
           )}
           <Text size="xs" c="dimmed" lineClamp={1}>
             {getDisplayName(item.cosmetic.type)}
-            {item.addedBy?.username ? ` · by @${item.addedBy.username}` : ''}
           </Text>
+          {item.addedBy?.username && (
+            <Text size="xs" c="dimmed" className="break-words">
+              by @{item.addedBy.username}
+            </Text>
+          )}
           <Text size="xs">
             {numberWithCommas(item.unitAmount)} Buzz · you keep{' '}
             <Text span c="green" fw={600}>
@@ -118,8 +122,12 @@ function ResoldListRow({
           </Text>
           <Text size="xs" c="dimmed" lineClamp={1}>
             {getDisplayName(item.cosmetic.type)}
-            {item.addedBy?.username ? ` · by @${item.addedBy.username}` : ''}
           </Text>
+          {item.addedBy?.username && (
+            <Text size="xs" c="dimmed" className="break-words">
+              by @{item.addedBy.username}
+            </Text>
+          )}
         </Stack>
         <ActionIcon
           color="red"


### PR DESCRIPTION
Move the `by @username` attribution out of the `lineClamp={1}` cosmetic-type line and into its own wrapping `Text` in both `PublicShopItemCard` and `ResoldListRow`. Long usernames were being clipped by the single-line clamp shared with the cosmetic type label.