### PR TITLE
fix(mod): make ModActivity inserts survive the pending unique-index drop

### DIFF
--- a/apps/auth/src/lib/server/auth/mod-activity.ts
+++ b/apps/auth/src/lib/server/auth/mod-activity.ts
@@ -1,9 +1,14 @@
 import { sql } from 'kysely';
 import { db } from '../db/db';
 
-// Moderator-impersonation audit, written by the HUB (it owns the impersonation logic now). Mirrors the main
-// app's trackModActivity upsert: one row per (entityType, activity, entityId), refreshed each time — so it
-// records the LATEST moderator who impersonated a given user, with a timestamp. Shared `ModActivity` table.
+// Moderator-impersonation audit, written by the HUB (it owns the impersonation logic now) into the shared
+// `ModActivity` table.
+//
+// `ON CONFLICT DO NOTHING` carries NO conflict target on purpose: a targetless clause is valid whether or
+// not a unique index exists, so this survives the pending migration that drops ModActivity's
+// (activity, entityType, entityId) unique index and makes the table append-only. Naming the target would
+// fail with 42P10 the moment that index goes; omitting the clause entirely would fail with 23505 until it
+// does. Do not add a target back.
 export async function trackImpersonation(
   moderatorId: number,
   targetUserId: number,
@@ -12,7 +17,6 @@ export async function trackImpersonation(
   await sql`
     INSERT INTO "ModActivity" ("userId", "entityType", activity, "entityId")
     VALUES (${moderatorId}, 'impersonate', ${activity}, ${targetUserId})
-    ON CONFLICT ("entityType", activity, "entityId")
-    DO UPDATE SET "createdAt" = NOW(), "userId" = ${moderatorId}
+    ON CONFLICT DO NOTHING
   `.execute(db);
 }

--- a/src/server/services/moderator.service.ts
+++ b/src/server/services/moderator.service.ts
@@ -61,12 +61,17 @@ type ModActivity = {
   | ComicProjectModActivity
 );
 
+// `ON CONFLICT DO NOTHING` carries NO conflict target on purpose: a targetless clause is valid whether or
+// not a unique index exists, so this survives the pending migration that drops ModActivity's
+// (activity, entityType, entityId) unique index and makes the table append-only. Naming the target would
+// fail with 42P10 the moment that index goes; omitting the clause entirely would fail with 23505 until it
+// does. Do not add a target back.
 export async function trackModActivity(userId: number, input: ModActivity) {
   if (!input.entityId) {
     await dbWrite.$executeRaw`
       INSERT INTO "ModActivity" ("userId", "entityType", activity)
       VALUES (${userId}, ${input.entityType}, ${input.activity})
-      ON CONFLICT ("entityType", activity, "entityId") DO UPDATE SET "createdAt" = NOW(), "userId" = ${userId}
+      ON CONFLICT DO NOTHING
     `;
     return;
   }
@@ -75,6 +80,6 @@ export async function trackModActivity(userId: number, input: ModActivity) {
   await dbWrite.$executeRaw`
     INSERT INTO "ModActivity" ("userId", "entityType", activity, "entityId")
     SELECT ${userId}, ${input.entityType}, ${input.activity}, UNNEST(${input.entityId})
-    ON CONFLICT ("entityType", activity, "entityId") DO UPDATE SET "createdAt" = NOW(), "userId" = ${userId}
+    ON CONFLICT DO NOTHING
   `;
 }


### PR DESCRIPTION
ModActivity is becoming append-only: its (activity, entityType, entityId) unique index is being dropped so repeat actions on the same entity are kept as separate events instead of collapsing to the most recent actor.

That migration cannot ship safely against the current code. Both writers name a conflict target, which fails with 42P10 ("no unique or exclusion constraint matching the ON CONFLICT specification") the moment the index goes — breaking every mod action that records activity, plus moderator impersonation. Removing the clause outright fails the other way, with 23505 on any repeat action until the migration lands.

A targetless ON CONFLICT DO NOTHING is valid with or without a unique index, so it is correct on both sides of the migration and gives us a deploy order with no broken window: ship this, then run the migration.

One behaviour change while the index still exists: a duplicate no longer refreshes createdAt/userId, since DO UPDATE requires a conflict target and cannot survive the transition. The row keeps its original actor and timestamp — which is the append semantics we are moving toward anyway.