### PR TITLE
fix(cache): confine the admin cache-clear endpoint to its own key namespace

### DIFF
--- a/src/pages/api/admin/clear-cache-by-pattern.ts
+++ b/src/pages/api/admin/clear-cache-by-pattern.ts
@@ -1,6 +1,10 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
 import * as z from 'zod';
-import { clearCacheByPattern, clearCacheByPatterns } from '~/server/utils/cache-helpers';
+import {
+  clearCacheByPattern,
+  clearCacheByPatterns,
+  scopeCachePatternToNamespace,
+} from '~/server/utils/cache-helpers';
 import { WebhookEndpoint } from '~/server/utils/endpoint-helpers';
 
 const schema = z.object({
@@ -15,7 +19,7 @@ const schema = z.object({
 export default WebhookEndpoint(async function (req: NextApiRequest, res: NextApiResponse) {
   const parsed = schema.parse(req.query);
   const target = parsed.target ?? 'main';
-  const patterns = parsed.patterns
+  const rawPatterns = parsed.patterns
     ? parsed.patterns
         .split(',')
         .map((p) => p.trim())
@@ -23,6 +27,17 @@ export default WebhookEndpoint(async function (req: NextApiRequest, res: NextApi
     : parsed.pattern
     ? [parsed.pattern]
     : [];
+
+  // 🔴 A cache-clear glob is written against the PRODUCTION key shape (`packed:caches:*`), and
+  // every deployment shares one cache instance. On a deployment whose cache keys are namespaced
+  // that glob matches production's keys and none of this deployment's own, so an unscoped clear
+  // from here would purge production while leaving the environment it was aimed at untouched.
+  // Scoping it to this deployment's namespace makes the endpoint able to address ONLY its own
+  // keyspace. Identity in production (no namespace ⇒ no prefix ⇒ the exact patterns as typed).
+  //
+  // `target: 'sys'` is deliberately NOT scoped — that keyspace is a separate per-deployment
+  // instance whose keys are unprefixed by construction; see `scopeCachePatternToNamespace`.
+  const patterns = rawPatterns.map((p) => scopeCachePatternToNamespace(p, target));
 
   if (patterns.length === 0) {
     res.status(400).json({ error: 'Provide either ?pattern= or ?patterns=a,b,c' });

--- a/src/pages/api/admin/clear-cache-by-pattern.ts
+++ b/src/pages/api/admin/clear-cache-by-pattern.ts
@@ -35,8 +35,14 @@ export default WebhookEndpoint(async function (req: NextApiRequest, res: NextApi
   // Scoping it to this deployment's namespace makes the endpoint able to address ONLY its own
   // keyspace. Identity in production (no namespace ⇒ no prefix ⇒ the exact patterns as typed).
   //
-  // `target: 'sys'` is deliberately NOT scoped — that keyspace is a separate per-deployment
-  // instance whose keys are unprefixed by construction; see `scopeCachePatternToNamespace`.
+  // 🔴 THIS CONFINEMENT COVERS `target: 'main'` ONLY. `target: 'sys'` is deliberately NOT scoped,
+  // because system keys are never namespaced on any deployment — prefixing one would match
+  // nothing. That is a fact about the KEYS, not a safety property of the keyspace: a deployment's
+  // system-Redis instance is not guaranteed to be distinct from production's, so a
+  // `?target=sys` clear issued from a non-production deployment CAN delete production data, and
+  // this endpoint does not stop it. Unlike cache entries, system values are not regenerable from
+  // the database. Treat any `?target=sys` call as a production operation.
+  // See `scopeCachePatternToNamespace` / `cacheNamespacePrefix`.
   const patterns = rawPatterns.map((p) => scopeCachePatternToNamespace(p, target));
 
   if (patterns.length === 0) {

--- a/src/server/utils/__tests__/cache-helpers-clear-namespace-preview.test.ts
+++ b/src/server/utils/__tests__/cache-helpers-clear-namespace-preview.test.ts
@@ -1,0 +1,324 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type * as RedisClientModule from '@civitai/redis/client';
+
+/**
+ * NAMESPACED half of the coverage for namespace-scoping the admin cache-clear path (the
+ * production half is cache-helpers-clear-namespace-prod.test.ts — the two cannot share a file
+ * because a `vi.mock` factory is evaluated once per file, so `CACHE_KEY_NAMESPACE` cannot be
+ * flipped between cases; same split as the cache-helpers-key-prefix-*.test.ts pair).
+ *
+ * 🔴 The hazard being pinned: a cache-clear glob is written by hand against the PRODUCTION key
+ * shape (`packed:caches:*`), and every deployment shares ONE cache instance. Unscoped, such a glob
+ * run from a namespaced deployment matches production's keys and NONE of its own — the single
+ * environment it can clear is the one it must never touch. Every case below therefore seeds a
+ * production-shaped key alongside the namespaced one and asserts the production key SURVIVES.
+ *
+ * Each guard is exercised through the path where it is the ONLY thing standing between the input
+ * and a foreign `del`, so a test cannot go green on a neighbouring guard's behalf: the endpoint
+ * cases pin the scoping of a caller glob, the direct-helper cases pass a DELIBERATELY UNSCOPED
+ * pattern to pin the helper-side containment.
+ */
+
+vi.hoisted(() => {
+  process.env.CACHE_KEY_NAMESPACE = 'preview';
+  delete process.env.IS_PREVIEW;
+});
+
+/**
+ * Stand-in for a Redis client. `scanIterator` models the SERVER-side semantics of `SCAN MATCH`
+ * (only keys matching the glob are ever returned to the client) — that is what makes a `MATCH`
+ * confinement structural rather than cosmetic, so the fake has to honour it. The glob→regex here
+ * is deliberately its own hand-written implementation: it models Redis, not the helper under test.
+ */
+const { mainFake, sysFake } = vi.hoisted(() => {
+  const globToRegExp = (glob: string) =>
+    new RegExp('^' + glob.replace(/[.+^${}()|[\]\\]/g, '\\$&').replace(/\*/g, '.*') + '$');
+
+  const makeFake = () => {
+    const store = new Set<string>();
+    const deleted: string[] = [];
+    const scanMatches: string[] = [];
+    const enumerated: string[] = [];
+    return {
+      store,
+      deleted,
+      scanMatches,
+      enumerated,
+      reset() {
+        store.clear();
+        deleted.length = 0;
+        scanMatches.length = 0;
+        enumerated.length = 0;
+      },
+      client: {
+        del: async (key: string) => {
+          deleted.push(key);
+          return store.delete(key) ? 1 : 0;
+        },
+        scanIterator: ({ MATCH }: { MATCH: string; COUNT?: number }) => {
+          scanMatches.push(MATCH);
+          const re = globToRegExp(MATCH);
+          const batch = [...store].filter((k) => re.test(k));
+          enumerated.push(...batch);
+          return (async function* () {
+            yield batch;
+          })();
+        },
+      },
+    };
+  };
+
+  return { mainFake: makeFake(), sysFake: makeFake() };
+});
+
+vi.mock('~/server/redis/client', async () => {
+  const pkg = await vi.importActual<typeof RedisClientModule>('@civitai/redis/client');
+  return { ...pkg, redis: mainFake.client, sysRedis: sysFake.client };
+});
+
+vi.mock('~/server/redis/fail-open-log', () => ({ logSysRedisFailOpen: vi.fn() }));
+vi.mock('~/server/prom/client', () => ({
+  cacheHitCounter: { inc: vi.fn() },
+  cacheMissCounter: { inc: vi.fn() },
+  cacheRevalidateCounter: { inc: vi.fn() },
+  cacheFailOpenDegradedCounter: { inc: vi.fn() },
+  cacheFailOpenOriginFetchCounter: { inc: vi.fn() },
+}));
+vi.mock('~/server/logging/client', () => ({ logToAxiom: vi.fn().mockResolvedValue(undefined) }));
+
+vi.mock('~/server/utils/endpoint-helpers', () => ({
+  WebhookEndpoint: (handler: unknown) => handler,
+}));
+
+type JsonRes = {
+  statusCode?: number;
+  body?: unknown;
+  status: (code: number) => JsonRes;
+  json: (body: unknown) => JsonRes;
+  setHeader: () => void;
+  flushHeaders: () => void;
+  write: (chunk: string) => void;
+  end: () => void;
+  chunks: string[];
+};
+function makeRes(): JsonRes {
+  const res: JsonRes = {
+    chunks: [],
+    status(code) {
+      res.statusCode = code;
+      return res;
+    },
+    json(body) {
+      res.body = body;
+      return res;
+    },
+    setHeader: vi.fn(),
+    flushHeaders: vi.fn(),
+    write(chunk) {
+      res.chunks.push(chunk);
+    },
+    end: vi.fn(),
+  };
+  return res;
+}
+
+const loadEndpoint = async () =>
+  (await import('~/pages/api/admin/clear-cache-by-pattern')).default as (
+    req: unknown,
+    res: unknown
+  ) => Promise<void>;
+
+// Production-shaped keys — what this deployment must never be able to delete.
+const FOREIGN_KEYS = [
+  'packed:caches:user-cosmetics:1',
+  'packed:caches:user-cosmetics:2',
+  'packed:caches:tag-ids-for-images:7',
+];
+// This deployment's own keys, as `applyCacheKeyPrefix` mints them.
+const OWN_KEYS = [
+  'preview:packed:caches:user-cosmetics:1',
+  'preview:packed:caches:tag-ids-for-images:7',
+];
+
+describe('admin cache-clear namespace scoping — namespaced deployment', () => {
+  beforeEach(() => {
+    mainFake.reset();
+    sysFake.reset();
+    for (const k of [...FOREIGN_KEYS, ...OWN_KEYS]) mainFake.store.add(k);
+    // The system keyspace is a separate per-deployment instance: its keys are UNPREFIXED even
+    // here. Seeded exactly as they arrive in reality.
+    sysFake.store.add('device:accounts:1');
+    sysFake.store.add('device:accounts:2');
+  });
+
+  it('scopes a main-cache pattern and leaves a sys pattern alone', async () => {
+    const { scopeCachePatternToNamespace } = await import('~/server/utils/cache-helpers');
+
+    expect(scopeCachePatternToNamespace('packed:caches:*')).toBe('preview:packed:caches:*');
+    expect(scopeCachePatternToNamespace('packed:caches:*', 'main')).toBe('preview:packed:caches:*');
+    // 🔴 Deliberate asymmetry — the sys keyspace is never namespaced.
+    expect(scopeCachePatternToNamespace('device:accounts:*', 'sys')).toBe('device:accounts:*');
+  });
+
+  it('the endpoint scopes the caller glob and cannot reach a production key', async () => {
+    const handler = await loadEndpoint();
+    const res = makeRes();
+
+    await handler({ query: { pattern: 'packed:caches:*' } }, res);
+
+    expect(mainFake.scanMatches).toEqual(['preview:packed:caches:*']);
+    // Positive control: it really cleared its OWN keys (a zero here would be indistinguishable
+    // from a clear that silently did nothing).
+    expect(res.body).toEqual({ ok: true, cleared: 2, target: 'main' });
+    expect([...mainFake.deleted].sort()).toEqual([...OWN_KEYS].sort());
+    for (const k of FOREIGN_KEYS) expect(mainFake.store.has(k)).toBe(true);
+  });
+
+  it('the endpoint scopes every pattern on the multi-pattern path', async () => {
+    const handler = await loadEndpoint();
+    const res = makeRes();
+
+    await handler(
+      { query: { patterns: 'packed:caches:user-cosmetics:*,packed:caches:tag-ids-for-images:*' } },
+      res
+    );
+
+    expect(res.body).toEqual({
+      ok: true,
+      cleared: 2,
+      target: 'main',
+      perPattern: [
+        { pattern: 'preview:packed:caches:user-cosmetics:*', cleared: 1 },
+        { pattern: 'preview:packed:caches:tag-ids-for-images:*', cleared: 1 },
+      ],
+    });
+    for (const k of FOREIGN_KEYS) expect(mainFake.store.has(k)).toBe(true);
+  });
+
+  it('clearCacheByPattern deletes nothing when handed an UNSCOPED glob', async () => {
+    const { clearCacheByPattern } = await import('~/server/utils/cache-helpers');
+
+    // No endpoint in front of it: the helper's own containment filter is the only guard here.
+    const cleared = await clearCacheByPattern('packed:caches:*');
+
+    expect(cleared).toEqual([]);
+    expect(mainFake.deleted).toEqual([]);
+    for (const k of FOREIGN_KEYS) expect(mainFake.store.has(k)).toBe(true);
+  });
+
+  it('clearCacheByPattern deletes nothing when handed an UNSCOPED exact key', async () => {
+    const { clearCacheByPattern } = await import('~/server/utils/cache-helpers');
+
+    const cleared = await clearCacheByPattern('packed:caches:user-cosmetics:1');
+
+    expect(cleared).toEqual([]);
+    expect(mainFake.deleted).toEqual([]);
+    expect(mainFake.store.has('packed:caches:user-cosmetics:1')).toBe(true);
+  });
+
+  it('clearCacheByPattern still clears the deployment’s own keys', async () => {
+    const { clearCacheByPattern } = await import('~/server/utils/cache-helpers');
+
+    const cleared = await clearCacheByPattern('preview:packed:caches:*');
+
+    expect([...cleared].sort()).toEqual([...OWN_KEYS].sort());
+    for (const k of FOREIGN_KEYS) expect(mainFake.store.has(k)).toBe(true);
+  });
+
+  it('clearCacheByPatterns confines its SCAN so a production key is never even enumerated', async () => {
+    const { clearCacheByPatterns } = await import('~/server/utils/cache-helpers');
+
+    const results = await clearCacheByPatterns(['preview:packed:caches:user-cosmetics:*']);
+
+    expect(mainFake.scanMatches).toEqual(['preview:*']);
+    // The scan saw ONLY this deployment's keys. Positive control on the same assertion: it did
+    // see them, so an empty enumeration cannot pass as confinement.
+    expect([...mainFake.enumerated].sort()).toEqual([...OWN_KEYS].sort());
+    expect(results).toEqual([{ pattern: 'preview:packed:caches:user-cosmetics:*', cleared: 1 }]);
+    for (const k of FOREIGN_KEYS) expect(mainFake.store.has(k)).toBe(true);
+  });
+
+  it('clearCacheByPatterns deletes nothing when handed UNSCOPED globs', async () => {
+    const { clearCacheByPatterns } = await import('~/server/utils/cache-helpers');
+
+    const results = await clearCacheByPatterns(['packed:caches:*', 'packed:caches:*:7']);
+
+    expect(results).toEqual([
+      { pattern: 'packed:caches:*', cleared: 0 },
+      { pattern: 'packed:caches:*:7', cleared: 0 },
+    ]);
+    expect(mainFake.deleted).toEqual([]);
+    for (const k of FOREIGN_KEYS) expect(mainFake.store.has(k)).toBe(true);
+  });
+
+  it('clearCacheByPatterns deletes nothing on the exact-key fast path when UNSCOPED', async () => {
+    const { clearCacheByPatterns } = await import('~/server/utils/cache-helpers');
+
+    const results = await clearCacheByPatterns([
+      'packed:caches:user-cosmetics:1',
+      'packed:caches:user-cosmetics:2',
+    ]);
+
+    expect(results).toEqual([
+      { pattern: 'packed:caches:user-cosmetics:1', cleared: 0 },
+      { pattern: 'packed:caches:user-cosmetics:2', cleared: 0 },
+    ]);
+    expect(mainFake.deleted).toEqual([]);
+    expect(mainFake.scanMatches).toEqual([]);
+    for (const k of FOREIGN_KEYS) expect(mainFake.store.has(k)).toBe(true);
+  });
+
+  it('clearCacheByPatterns still clears own keys on the exact-key fast path', async () => {
+    const { clearCacheByPatterns } = await import('~/server/utils/cache-helpers');
+
+    const results = await clearCacheByPatterns(['preview:packed:caches:user-cosmetics:1']);
+
+    expect(results).toEqual([{ pattern: 'preview:packed:caches:user-cosmetics:1', cleared: 1 }]);
+    expect(mainFake.deleted).toEqual(['preview:packed:caches:user-cosmetics:1']);
+  });
+
+  // 🔴 The sys target must behave EXACTLY as it does in production — its keys are unprefixed by
+  // construction, so any scoping here would make every sys clear match nothing.
+  it('leaves the sys target completely unaffected by the namespace', async () => {
+    const handler = await loadEndpoint();
+    const res = makeRes();
+
+    await handler({ query: { pattern: 'device:accounts:*', target: 'sys' } }, res);
+
+    expect(sysFake.scanMatches).toEqual(['device:accounts:*']);
+    expect([...sysFake.deleted].sort()).toEqual(['device:accounts:1', 'device:accounts:2']);
+    expect(res.body).toEqual({ ok: true, cleared: 2, target: 'sys' });
+    expect(mainFake.deleted).toEqual([]);
+  });
+
+  it('scans the whole sys keyspace on the multi-pattern sys path', async () => {
+    const handler = await loadEndpoint();
+    const res = makeRes();
+
+    await handler(
+      { query: { patterns: 'device:accounts:*,device:sessions:*', target: 'sys' } },
+      res
+    );
+
+    expect(sysFake.scanMatches).toEqual(['*']);
+    expect(res.body).toEqual({
+      ok: true,
+      cleared: 2,
+      target: 'sys',
+      perPattern: [
+        { pattern: 'device:accounts:*', cleared: 2 },
+        { pattern: 'device:sessions:*', cleared: 0 },
+      ],
+    });
+  });
+
+  it('deletes an exact sys key without a namespace prefix', async () => {
+    const { clearCacheByPattern } = await import('~/server/utils/cache-helpers');
+
+    const cleared = await clearCacheByPattern('device:accounts:1', undefined, 'sys');
+
+    expect(cleared).toEqual(['device:accounts:1']);
+    expect(sysFake.deleted).toEqual(['device:accounts:1']);
+    expect(sysFake.store.has('device:accounts:1')).toBe(false);
+  });
+});

--- a/src/server/utils/__tests__/cache-helpers-clear-namespace-preview.test.ts
+++ b/src/server/utils/__tests__/cache-helpers-clear-namespace-preview.test.ts
@@ -145,8 +145,8 @@ describe('admin cache-clear namespace scoping — namespaced deployment', () => 
     mainFake.reset();
     sysFake.reset();
     for (const k of [...FOREIGN_KEYS, ...OWN_KEYS]) mainFake.store.add(k);
-    // The system keyspace is a separate per-deployment instance: its keys are UNPREFIXED even
-    // here. Seeded exactly as they arrive in reality.
+    // System keys are UNPREFIXED on every deployment — they are never run through
+    // `applyCacheKeyPrefix`. Seeded exactly as they appear anywhere.
     sysFake.store.add('device:accounts:1');
     sysFake.store.add('device:accounts:2');
   });
@@ -156,7 +156,9 @@ describe('admin cache-clear namespace scoping — namespaced deployment', () => 
 
     expect(scopeCachePatternToNamespace('packed:caches:*')).toBe('preview:packed:caches:*');
     expect(scopeCachePatternToNamespace('packed:caches:*', 'main')).toBe('preview:packed:caches:*');
-    // 🔴 Deliberate asymmetry — the sys keyspace is never namespaced.
+    // 🔴 Deliberate asymmetry: system keys are never namespaced, so prefixing one would match
+    // nothing. This pins the mechanism — it is NOT an assertion that the sys target is contained.
+    // See the `cacheNamespacePrefix` doc block: a sys clear can reach production data.
     expect(scopeCachePatternToNamespace('device:accounts:*', 'sys')).toBe('device:accounts:*');
   });
 
@@ -277,9 +279,114 @@ describe('admin cache-clear namespace scoping — namespaced deployment', () => 
     expect(mainFake.deleted).toEqual(['preview:packed:caches:user-cosmetics:1']);
   });
 
-  // 🔴 The sys target must behave EXACTLY as it does in production — its keys are unprefixed by
-  // construction, so any scoping here would make every sys clear match nothing.
-  it('leaves the sys target completely unaffected by the namespace', async () => {
+  // 🔴 THE SSE BRANCH IS A SEPARATE CALL SITE, and it is the one used for large clears. It reads
+  // `patterns` independently of the non-streaming branch below it, so scoping can regress on this
+  // path alone while every non-streaming case stays green. Covering it only in the production
+  // suite proves nothing about scoping, because there scoping is the identity function.
+  it('scopes the caller patterns on the SSE path and reports the scoped patterns', async () => {
+    const handler = await loadEndpoint();
+    const res = makeRes();
+
+    await handler(
+      {
+        query: {
+          patterns: 'packed:caches:user-cosmetics:*,packed:caches:tag-ids-for-images:*',
+          stream: '1',
+        },
+      },
+      res
+    );
+
+    const events = res.chunks
+      .filter((c) => c.startsWith('event: '))
+      .map((c) => {
+        const [eventLine, dataLine] = c.split('\n');
+        return { event: eventLine.slice('event: '.length), data: JSON.parse(dataLine.slice(6)) };
+      });
+
+    // 🔴 ASSERTION ORDER IS LOAD-BEARING — the SCOPING assertions come first, and events are
+    // looked up BY NAME rather than by index.
+    //
+    // An unscoped SSE branch matches nothing, and `clearCacheByPatterns` skips its `onProgress`
+    // callback on a batch that deletes nothing (`if (toDelete.length === 0) continue`), so the
+    // `progress` event disappears entirely. An event-sequence assertion placed first therefore
+    // fails on the SHAPE of the stream — a true failure, but one that says nothing about
+    // scoping — and an `events[2]` index would read `undefined` and throw instead of asserting.
+    // Verified: ordered that way, the mutant failed with
+    // `expected [ 'start', 'done' ] to deeply equal [ 'start', 'progress', 'done' ]`.
+    const byName = (name: string) => events.find((e) => e.event === name);
+
+    // The clear reports the SCOPED patterns, and the counts are NON-ZERO. Both halves matter: an
+    // unscoped glob reports the raw patterns and clears 0, and a bare "production survived" check
+    // cannot tell that apart from a clear that silently did nothing.
+    expect(byName('done')?.data).toEqual({
+      total: 2,
+      perPattern: [
+        { pattern: 'preview:packed:caches:user-cosmetics:*', cleared: 1 },
+        { pattern: 'preview:packed:caches:tag-ids-for-images:*', cleared: 1 },
+      ],
+    });
+
+    // The announced patterns are the SCOPED ones — what the clear will actually address.
+    expect(byName('start')?.data).toEqual({
+      patterns: [
+        'preview:packed:caches:user-cosmetics:*',
+        'preview:packed:caches:tag-ids-for-images:*',
+      ],
+      target: 'main',
+    });
+
+    expect(byName('progress')?.data).toEqual({
+      total: 2,
+      perPattern: [
+        { pattern: 'preview:packed:caches:user-cosmetics:*', cleared: 1 },
+        { pattern: 'preview:packed:caches:tag-ids-for-images:*', cleared: 1 },
+      ],
+    });
+
+    expect([...mainFake.deleted].sort()).toEqual([...OWN_KEYS].sort());
+    for (const k of FOREIGN_KEYS) expect(mainFake.store.has(k)).toBe(true);
+
+    // Stream shape last: a real property, but it must not be what a scoping regression trips on.
+    expect(events.map((e) => e.event)).toEqual(['start', 'progress', 'done']);
+  });
+
+  it('scopes a single caller pattern on the SSE path', async () => {
+    const handler = await loadEndpoint();
+    const res = makeRes();
+
+    await handler({ query: { pattern: 'packed:caches:*', stream: '1' } }, res);
+
+    const events = res.chunks
+      .filter((c) => c.startsWith('event: '))
+      .map((c) => {
+        const [eventLine, dataLine] = c.split('\n');
+        return { event: eventLine.slice('event: '.length), data: JSON.parse(dataLine.slice(6)) };
+      });
+
+    // Scoping first, by name — see the ordering note on the multi-pattern SSE case above.
+    const byName = (name: string) => events.find((e) => e.event === name);
+
+    expect(byName('done')?.data).toEqual({
+      total: 2,
+      perPattern: [{ pattern: 'preview:packed:caches:*', cleared: 2 }],
+    });
+    expect(byName('start')?.data).toEqual({
+      patterns: ['preview:packed:caches:*'],
+      target: 'main',
+    });
+    expect([...mainFake.deleted].sort()).toEqual([...OWN_KEYS].sort());
+    for (const k of FOREIGN_KEYS) expect(mainFake.store.has(k)).toBe(true);
+  });
+
+  // 🔴 The sys target must behave EXACTLY as it does in production, because system keys are
+  // unprefixed everywhere and scoping one would make the clear match nothing.
+  //
+  // 🔴 READ THIS AS A MECHANISM TEST, NOT A SAFETY TEST. It pins that the namespace does not
+  // reach the sys pattern. It does NOT show that a sys clear is confined to this deployment —
+  // a deployment's system-Redis instance is not guaranteed to be distinct from production's, so
+  // this call can delete production data. See `cacheNamespacePrefix`.
+  it('does not apply the namespace to a sys pattern (mechanism, not containment)', async () => {
     const handler = await loadEndpoint();
     const res = makeRes();
 

--- a/src/server/utils/__tests__/cache-helpers-clear-namespace-prod.test.ts
+++ b/src/server/utils/__tests__/cache-helpers-clear-namespace-prod.test.ts
@@ -1,0 +1,284 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type * as RedisClientModule from '@civitai/redis/client';
+
+/**
+ * PRODUCTION half of the coverage for namespace-scoping the admin cache-clear path (the
+ * namespaced half is cache-helpers-clear-namespace-preview.test.ts — the two cannot share a file
+ * because a `vi.mock` factory is evaluated once per file, so `CACHE_KEY_NAMESPACE` cannot be
+ * flipped between cases; same split as the cache-helpers-key-prefix-*.test.ts pair).
+ *
+ * 🔴 This file is the one that pins "production behaviour does not move". With no namespace
+ * configured, the pattern that reaches Redis, the `MATCH` the SCAN is issued with, and the set of
+ * keys that gets deleted must be byte-identical to what they were before scoping existed. Every
+ * expectation is a hand-written literal, never a value recomputed from the code under test.
+ */
+
+vi.hoisted(() => {
+  delete process.env.CACHE_KEY_NAMESPACE;
+});
+
+/**
+ * Stand-in for a Redis client. `scanIterator` models the SERVER-side semantics of `SCAN MATCH`
+ * (only keys matching the glob are ever returned to the client) — that is what makes a `MATCH`
+ * confinement structural rather than cosmetic, so the fake has to honour it. The glob→regex here
+ * is deliberately its own hand-written implementation: it models Redis, not the helper under test.
+ */
+const { mainFake, sysFake } = vi.hoisted(() => {
+  const globToRegExp = (glob: string) =>
+    new RegExp('^' + glob.replace(/[.+^${}()|[\]\\]/g, '\\$&').replace(/\*/g, '.*') + '$');
+
+  const makeFake = () => {
+    const store = new Set<string>();
+    const deleted: string[] = [];
+    const scanMatches: string[] = [];
+    const enumerated: string[] = [];
+    return {
+      store,
+      deleted,
+      scanMatches,
+      enumerated,
+      reset() {
+        store.clear();
+        deleted.length = 0;
+        scanMatches.length = 0;
+        enumerated.length = 0;
+      },
+      client: {
+        del: async (key: string) => {
+          deleted.push(key);
+          return store.delete(key) ? 1 : 0;
+        },
+        scanIterator: ({ MATCH }: { MATCH: string; COUNT?: number }) => {
+          scanMatches.push(MATCH);
+          const re = globToRegExp(MATCH);
+          const batch = [...store].filter((k) => re.test(k));
+          enumerated.push(...batch);
+          return (async function* () {
+            yield batch;
+          })();
+        },
+      },
+    };
+  };
+
+  return { mainFake: makeFake(), sysFake: makeFake() };
+});
+
+vi.mock('~/server/redis/client', async () => {
+  const pkg = await vi.importActual<typeof RedisClientModule>('@civitai/redis/client');
+  return { ...pkg, redis: mainFake.client, sysRedis: sysFake.client };
+});
+
+vi.mock('~/server/redis/fail-open-log', () => ({ logSysRedisFailOpen: vi.fn() }));
+vi.mock('~/server/prom/client', () => ({
+  cacheHitCounter: { inc: vi.fn() },
+  cacheMissCounter: { inc: vi.fn() },
+  cacheRevalidateCounter: { inc: vi.fn() },
+  cacheFailOpenDegradedCounter: { inc: vi.fn() },
+  cacheFailOpenOriginFetchCounter: { inc: vi.fn() },
+}));
+vi.mock('~/server/logging/client', () => ({ logToAxiom: vi.fn().mockResolvedValue(undefined) }));
+
+// The endpoint's only non-trivial dependency besides cache-helpers. Replaced with a pass-through
+// so the real handler body runs; the auth wrapper is not what this file is about.
+vi.mock('~/server/utils/endpoint-helpers', () => ({
+  WebhookEndpoint: (handler: unknown) => handler,
+}));
+
+type JsonRes = {
+  statusCode?: number;
+  body?: unknown;
+  status: (code: number) => JsonRes;
+  json: (body: unknown) => JsonRes;
+  setHeader: () => void;
+  flushHeaders: () => void;
+  write: (chunk: string) => void;
+  end: () => void;
+  chunks: string[];
+};
+function makeRes(): JsonRes {
+  const res: JsonRes = {
+    chunks: [],
+    status(code) {
+      res.statusCode = code;
+      return res;
+    },
+    json(body) {
+      res.body = body;
+      return res;
+    },
+    setHeader: vi.fn(),
+    flushHeaders: vi.fn(),
+    write(chunk) {
+      res.chunks.push(chunk);
+    },
+    end: vi.fn(),
+  };
+  return res;
+}
+
+describe('admin cache-clear namespace scoping — production (no namespace)', () => {
+  const PROD_KEYS = [
+    'packed:caches:user-cosmetics:1',
+    'packed:caches:user-cosmetics:2',
+    'packed:caches:tag-ids-for-images:7',
+    'unrelated:thing:1',
+  ];
+
+  beforeEach(() => {
+    mainFake.reset();
+    sysFake.reset();
+    for (const k of PROD_KEYS) mainFake.store.add(k);
+    sysFake.store.add('device:accounts:1');
+    sysFake.store.add('device:accounts:2');
+  });
+
+  it('leaves a pattern untouched — main and sys alike', async () => {
+    const { scopeCachePatternToNamespace } = await import('~/server/utils/cache-helpers');
+
+    expect(scopeCachePatternToNamespace('packed:caches:*')).toBe('packed:caches:*');
+    expect(scopeCachePatternToNamespace('packed:caches:*', 'main')).toBe('packed:caches:*');
+    expect(scopeCachePatternToNamespace('device:accounts:*', 'sys')).toBe('device:accounts:*');
+  });
+
+  it('clearCacheByPattern scans with the caller pattern verbatim and clears the same keys', async () => {
+    const { clearCacheByPattern } = await import('~/server/utils/cache-helpers');
+
+    const cleared = await clearCacheByPattern('packed:caches:*');
+
+    expect(mainFake.scanMatches).toEqual(['packed:caches:*']);
+    expect([...cleared].sort()).toEqual([
+      'packed:caches:tag-ids-for-images:7',
+      'packed:caches:user-cosmetics:1',
+      'packed:caches:user-cosmetics:2',
+    ]);
+    expect([...mainFake.deleted].sort()).toEqual([
+      'packed:caches:tag-ids-for-images:7',
+      'packed:caches:user-cosmetics:1',
+      'packed:caches:user-cosmetics:2',
+    ]);
+    expect(mainFake.store.has('unrelated:thing:1')).toBe(true);
+  });
+
+  it('clearCacheByPattern still deletes an exact (glob-free) key', async () => {
+    const { clearCacheByPattern } = await import('~/server/utils/cache-helpers');
+
+    const cleared = await clearCacheByPattern('packed:caches:user-cosmetics:1');
+
+    expect(cleared).toEqual(['packed:caches:user-cosmetics:1']);
+    expect(mainFake.deleted).toEqual(['packed:caches:user-cosmetics:1']);
+    expect(mainFake.store.has('packed:caches:user-cosmetics:1')).toBe(false);
+    expect(mainFake.scanMatches).toEqual([]);
+  });
+
+  it("clearCacheByPatterns still scans the whole keyspace with MATCH '*'", async () => {
+    const { clearCacheByPatterns } = await import('~/server/utils/cache-helpers');
+
+    const results = await clearCacheByPatterns([
+      'packed:caches:user-cosmetics:*',
+      'unrelated:thing:*',
+    ]);
+
+    expect(mainFake.scanMatches).toEqual(['*']);
+    // Positive control: the scan must have SEEN the whole keyspace, not an empty one.
+    expect([...mainFake.enumerated].sort()).toEqual([...PROD_KEYS].sort());
+    expect(results).toEqual([
+      { pattern: 'packed:caches:user-cosmetics:*', cleared: 2 },
+      { pattern: 'unrelated:thing:*', cleared: 1 },
+    ]);
+    expect(mainFake.store.has('packed:caches:tag-ids-for-images:7')).toBe(true);
+  });
+
+  it('clearCacheByPatterns still deletes exact keys on the no-scan fast path', async () => {
+    const { clearCacheByPatterns } = await import('~/server/utils/cache-helpers');
+
+    const results = await clearCacheByPatterns(['packed:caches:user-cosmetics:1']);
+
+    expect(results).toEqual([{ pattern: 'packed:caches:user-cosmetics:1', cleared: 1 }]);
+    expect(mainFake.deleted).toEqual(['packed:caches:user-cosmetics:1']);
+    expect(mainFake.scanMatches).toEqual([]);
+  });
+
+  it('the endpoint passes the caller glob through unchanged', async () => {
+    const handler = (await import('~/pages/api/admin/clear-cache-by-pattern')).default as (
+      req: unknown,
+      res: unknown
+    ) => Promise<void>;
+    const res = makeRes();
+
+    await handler({ query: { pattern: 'packed:caches:*' } }, res);
+
+    expect(mainFake.scanMatches).toEqual(['packed:caches:*']);
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toEqual({ ok: true, cleared: 3, target: 'main' });
+  });
+
+  it('the endpoint reports the caller patterns verbatim on the multi-pattern path', async () => {
+    const handler = (await import('~/pages/api/admin/clear-cache-by-pattern')).default as (
+      req: unknown,
+      res: unknown
+    ) => Promise<void>;
+    const res = makeRes();
+
+    await handler({ query: { patterns: 'packed:caches:user-cosmetics:*,unrelated:thing:*' } }, res);
+
+    expect(mainFake.scanMatches).toEqual(['*']);
+    expect(res.body).toEqual({
+      ok: true,
+      cleared: 3,
+      target: 'main',
+      perPattern: [
+        { pattern: 'packed:caches:user-cosmetics:*', cleared: 2 },
+        { pattern: 'unrelated:thing:*', cleared: 1 },
+      ],
+    });
+  });
+
+  it('the endpoint leaves the sys target alone and hits the sys client', async () => {
+    const handler = (await import('~/pages/api/admin/clear-cache-by-pattern')).default as (
+      req: unknown,
+      res: unknown
+    ) => Promise<void>;
+    const res = makeRes();
+
+    await handler({ query: { pattern: 'device:accounts:*', target: 'sys' } }, res);
+
+    expect(sysFake.scanMatches).toEqual(['device:accounts:*']);
+    expect(mainFake.scanMatches).toEqual([]);
+    expect(mainFake.deleted).toEqual([]);
+    expect(res.body).toEqual({ ok: true, cleared: 2, target: 'sys' });
+  });
+
+  it('preserves the SSE event sequence and payload shape', async () => {
+    const handler = (await import('~/pages/api/admin/clear-cache-by-pattern')).default as (
+      req: unknown,
+      res: unknown
+    ) => Promise<void>;
+    const res = makeRes();
+
+    await handler(
+      { query: { patterns: 'packed:caches:user-cosmetics:*,unrelated:thing:*', stream: '1' } },
+      res
+    );
+
+    const events = res.chunks
+      .filter((c) => c.startsWith('event: '))
+      .map((c) => {
+        const [eventLine, dataLine] = c.split('\n');
+        return { event: eventLine.slice('event: '.length), data: JSON.parse(dataLine.slice(6)) };
+      });
+
+    expect(events.map((e) => e.event)).toEqual(['start', 'progress', 'done']);
+    expect(events[0].data).toEqual({
+      patterns: ['packed:caches:user-cosmetics:*', 'unrelated:thing:*'],
+      target: 'main',
+    });
+    expect(events[2].data).toEqual({
+      total: 3,
+      perPattern: [
+        { pattern: 'packed:caches:user-cosmetics:*', cleared: 2 },
+        { pattern: 'unrelated:thing:*', cleared: 1 },
+      ],
+    });
+  });
+});

--- a/src/server/utils/__tests__/cache-helpers-clear-namespace-prod.test.ts
+++ b/src/server/utils/__tests__/cache-helpers-clear-namespace-prod.test.ts
@@ -234,6 +234,8 @@ describe('admin cache-clear namespace scoping — production (no namespace)', ()
     });
   });
 
+  // Mechanism only: system keys are unprefixed everywhere, so there is nothing for the namespace
+  // to do here. Not a containment claim for the sys target — see `cacheNamespacePrefix`.
   it('the endpoint leaves the sys target alone and hits the sys client', async () => {
     const handler = (await import('~/pages/api/admin/clear-cache-by-pattern')).default as (
       req: unknown,

--- a/src/server/utils/cache-helpers.ts
+++ b/src/server/utils/cache-helpers.ts
@@ -3,7 +3,7 @@ import { chunk } from 'lodash-es';
 // `prefixCacheKey` comes from the package rather than the `~/server/redis/client` shim on
 // purpose: it is a pure helper with no client state, and importing it through the shim would
 // force every suite that mocks the shim to add it to its mock factory.
-import { createCacheBuilders, prefixCacheKey } from '@civitai/redis';
+import { CACHE_KEY_PREFIX, createCacheBuilders, prefixCacheKey } from '@civitai/redis';
 import { CacheTTL } from '~/server/common/constants';
 import { logToAxiom } from '~/server/logging/client';
 import {
@@ -26,12 +26,64 @@ export type CacheTarget = 'main' | 'sys';
 function getCacheClient(target: CacheTarget = 'main'): any {
   return target === 'sys' ? sysRedis : redis;
 }
+
 import { sleep } from '~/server/utils/concurrency-helpers';
 import { createLogger } from '~/utils/logging';
 import { hashifyObject } from '~/utils/string-helpers';
 import { isDefined } from '~/utils/type-guards';
 
 const log = createLogger('cache-helpers', 'cyan');
+
+/**
+ * The prefix every key of `target`'s keyspace carries on this deployment — `''` in production.
+ *
+ * 🔴 THE ASYMMETRY IS DELIBERATE: `'sys'` is ALWAYS `''`, even on a namespaced deployment.
+ * Environment namespacing is CACHE-ONLY (see packages/civitai-redis/src/cache-key-prefix.ts): the
+ * main cache is one instance shared by every deployment, so its keys must be separated by a
+ * prefix. The system keyspace is a SEPARATE per-deployment instance seeded by replication, so its
+ * keys arrive UNPREFIXED by construction and `REDIS_SYS_KEYS` is never run through
+ * `applyCacheKeyPrefix`. Prefixing a sys pattern would therefore match nothing at all. Do not
+ * "fix" this into consistency.
+ */
+function cacheNamespacePrefix(target: CacheTarget): string {
+  return target === 'sys' ? '' : CACHE_KEY_PREFIX;
+}
+
+/**
+ * Scope a caller-supplied cache-key GLOB (or exact key) to this deployment's cache namespace.
+ *
+ * 🔴 WHY THIS EXISTS. The admin cache-clear endpoint takes a glob from its caller and hands it to
+ * `clearCacheByPattern*`, which SCAN the shared cache instance with it. That glob is written by
+ * hand against the PRODUCTION key shape (`packed:caches:*`). Run from a namespaced deployment,
+ * an unscoped glob matches production's keys and NOTHING of the caller's own (whose keys live at
+ * `<namespace>:packed:caches:*`) — i.e. the one environment it can clear is the one it must never
+ * touch. Scoping the glob inverts that: it can only ever address its own namespace.
+ *
+ * Identity in production (empty prefix) and identity for `target: 'sys'` — see
+ * `cacheNamespacePrefix`.
+ *
+ * 🔴 Call this ONLY on a pattern that was built from scratch by a caller. A pattern derived from
+ * `REDIS_KEYS` already carries the prefix from the key table itself, and scoping it again yields
+ * `<namespace>:<namespace>:…` — the same rule that governs `prefixCacheKey`.
+ */
+export function scopeCachePatternToNamespace(pattern: string, target: CacheTarget = 'main') {
+  const prefix = cacheNamespacePrefix(target);
+  return prefix ? `${prefix}${pattern}` : pattern;
+}
+
+/**
+ * Containment invariant for the clear helpers: on a namespaced deployment EVERY key of the main
+ * cache carries the namespace prefix — the key table is prefixed wholesale by
+ * `applyCacheKeyPrefix`, and on-the-fly keys go through `prefixCacheKey`. So a key without the
+ * prefix belongs to another environment (production, in the damaging case) and must never be
+ * deleted from here, whatever pattern reached this function.
+ *
+ * Always true in production and for `target: 'sys'`, where the prefix is empty.
+ */
+function isInCacheNamespace(key: string, target: CacheTarget) {
+  const prefix = cacheNamespacePrefix(target);
+  return !prefix || key.startsWith(prefix);
+}
 
 type cachedQueryOptions = {
   ttl: number;
@@ -382,6 +434,13 @@ export async function clearCacheByPattern(
   const cleared: string[] = [];
 
   if (!pattern.includes('*')) {
+    // Namespace containment (see `isInCacheNamespace`). No scan happens on this path, so this is
+    // the only thing standing between an out-of-namespace exact key and a `del` of another
+    // environment's entry. No-op in production and for `target: 'sys'`.
+    if (!isInCacheNamespace(pattern, target)) {
+      log('Skipping out-of-namespace key:', pattern, 'target:', target);
+      return cleared;
+    }
     await client.del(pattern);
     cleared.push(pattern);
     onProgress?.(cleared.length);
@@ -393,7 +452,12 @@ export async function clearCacheByPattern(
   const stream = client.scanIterator({ MATCH: pattern, COUNT: 10000 });
 
   for await (const keys of stream) {
-    const newKeys = (keys as RedisKeyTemplates[]).filter((key) => !cleared.includes(key));
+    // Namespace containment. A scoped pattern already confines the SCAN server-side; this filter
+    // is what makes the confinement structural rather than a property of the call site, so a
+    // caller that forgets to scope its glob clears NOTHING instead of another environment's keys.
+    const newKeys = (keys as RedisKeyTemplates[]).filter(
+      (key) => isInCacheNamespace(key, target) && !cleared.includes(key)
+    );
     log('Total keys:', cleared.length, 'Adding:', newKeys.length);
     if (newKeys.length === 0) continue;
 
@@ -446,13 +510,26 @@ export async function clearCacheByPatterns(
 
   // Fast path for exact keys — no scan needed.
   for (const p of exact) {
+    // Namespace containment (see `isInCacheNamespace`) — same reasoning as the exact-key path of
+    // `clearCacheByPattern`: nothing else guards a bare `del` here.
+    if (!isInCacheNamespace(p.pattern, target)) {
+      log('Skipping out-of-namespace key:', p.pattern, 'target:', target);
+      continue;
+    }
     await client.del(p.pattern as RedisKeyTemplates);
     p.cleared.push(p.pattern);
   }
 
   if (globbed.length > 0) {
     log('Scanning cache for', globbed.length, 'patterns in a single pass, target:', target);
-    const stream = client.scanIterator({ MATCH: '*', COUNT: 10000 });
+    // 🔴 This path enumerates the keyspace itself and regex-tests each key, so scoping the
+    // caller's patterns is NOT enough on its own — with `MATCH: '*'` it would walk every other
+    // environment's keys (production's included) and rely entirely on the regexes to spare them.
+    // Confining the SCAN to the namespace makes that structural: on a namespaced deployment a
+    // foreign key is never even enumerated, so no pattern — scoped, unscoped or malformed — can
+    // reach one. `'*'` in production and for `target: 'sys'`, i.e. byte-identical to before.
+    const scanPrefix = cacheNamespacePrefix(target);
+    const stream = client.scanIterator({ MATCH: `${scanPrefix}*`, COUNT: 10000 });
 
     for await (const keys of stream) {
       const toDelete: RedisKeyTemplates[] = [];

--- a/src/server/utils/cache-helpers.ts
+++ b/src/server/utils/cache-helpers.ts
@@ -37,13 +37,22 @@ const log = createLogger('cache-helpers', 'cyan');
 /**
  * The prefix every key of `target`'s keyspace carries on this deployment — `''` in production.
  *
- * 🔴 THE ASYMMETRY IS DELIBERATE: `'sys'` is ALWAYS `''`, even on a namespaced deployment.
- * Environment namespacing is CACHE-ONLY (see packages/civitai-redis/src/cache-key-prefix.ts): the
- * main cache is one instance shared by every deployment, so its keys must be separated by a
- * prefix. The system keyspace is a SEPARATE per-deployment instance seeded by replication, so its
- * keys arrive UNPREFIXED by construction and `REDIS_SYS_KEYS` is never run through
- * `applyCacheKeyPrefix`. Prefixing a sys pattern would therefore match nothing at all. Do not
- * "fix" this into consistency.
+ * 🔴 THE ASYMMETRY IS DELIBERATE — AND IT IS NOT A SAFETY CLAIM. `'sys'` is ALWAYS `''`, even on
+ * a namespaced deployment. Environment namespacing is CACHE-ONLY (see
+ * packages/civitai-redis/src/cache-key-prefix.ts): `REDIS_SYS_KEYS` is never run through
+ * `applyCacheKeyPrefix`, so system keys are unprefixed on EVERY deployment. Prefixing a sys
+ * pattern would therefore match nothing at all. Do not "fix" this into consistency, and do not
+ * gate it on a namespace being set — the keys are unprefixed either way.
+ *
+ * 🔴 WHAT THIS DOES NOT MEAN. A deployment's system-Redis instance is NOT guaranteed to be
+ * distinct from production's; some non-production deployments share it. So `target: 'sys'` is
+ * exempt because its keys CANNOT be namespaced, not because the keyspace is isolated. A
+ * `target: 'sys'` clear issued from a non-production deployment can reach PRODUCTION data, and
+ * nothing in this file stands in its way.
+ *
+ * That makes sys the more dangerous of the two targets, not the safer one: cache entries are
+ * regenerable from the database, system values are not — a deleted one is simply gone. Treat any
+ * `target: 'sys'` clear as a production operation regardless of where it is run from.
  */
 function cacheNamespacePrefix(target: CacheTarget): string {
   return target === 'sys' ? '' : CACHE_KEY_PREFIX;
@@ -59,8 +68,9 @@ function cacheNamespacePrefix(target: CacheTarget): string {
  * `<namespace>:packed:caches:*`) — i.e. the one environment it can clear is the one it must never
  * touch. Scoping the glob inverts that: it can only ever address its own namespace.
  *
- * Identity in production (empty prefix) and identity for `target: 'sys'` — see
- * `cacheNamespacePrefix`.
+ * Identity in production (empty prefix). Also identity for `target: 'sys'`, which is a mechanical
+ * consequence of system keys never being namespaced — NOT a containment guarantee for that
+ * target. See `cacheNamespacePrefix`.
  *
  * 🔴 Call this ONLY on a pattern that was built from scratch by a caller. A pattern derived from
  * `REDIS_KEYS` already carries the prefix from the key table itself, and scoping it again yields
@@ -78,7 +88,8 @@ export function scopeCachePatternToNamespace(pattern: string, target: CacheTarge
  * prefix belongs to another environment (production, in the damaging case) and must never be
  * deleted from here, whatever pattern reached this function.
  *
- * Always true in production and for `target: 'sys'`, where the prefix is empty.
+ * Always true in production and for `target: 'sys'`, where the prefix is empty — so this provides
+ * NO containment on the sys target, which cannot be namespaced at all. See `cacheNamespacePrefix`.
  */
 function isInCacheNamespace(key: string, target: CacheTarget) {
   const prefix = cacheNamespacePrefix(target);


### PR DESCRIPTION
> **Note:** this description was corrected after review — see the comment below for what changed and why. Three claims in the original were wrong, one of them a safety claim about `target=sys`.

## The hazard

`src/pages/api/admin/clear-cache-by-pattern.ts` takes a caller-supplied glob and passes it **raw** into `clearCacheByPattern` / `clearCacheByPatterns`. Those run a `SCAN` across the whole cache keyspace and delete every key the glob matches.

Non-production environments share the cache instance with production. A cache-clear glob is written against the production key shape (`packed:caches:*`), because that is the shape the keys have had forever.

## Why namespacing made it sharper, not safer

Cache keys are now namespaced per environment (`CACHE_KEY_NAMESPACE`, see `packages/civitai-redis/src/cache-key-prefix.ts`): unset in production, set elsewhere. The prefix is applied in two places, neither of which is the clear path:

- **the key table** — `REDIS_KEYS = applyCacheKeyPrefix(REDIS_KEYS_UNPREFIXED)` (`packages/civitai-redis/src/client.ts:2289`), which is where the cache **builders** (`createCachedArray` / `createCachedObject`) get their prefix, since every builder's `key` comes from that table;
- **on-the-fly key minting** — the two `prefixCacheKey` calls in `queryCache` / `queryCacheRaw` (`src/server/utils/cache-helpers.ts`), for keys built from a free-form string rather than derived from the table.

So on a namespaced environment, `?pattern=packed:caches:*`:

- **matches production's keys** — they are the ones that live at that exact shape, and
- **matches none of the caller's own** — those live at `<namespace>:packed:caches:*`.

The one keyspace that endpoint could clear was the one it must never touch, and the environment the operator was actually aiming at was left completely untouched. Before namespacing every environment's keys were interleaved at the same shape, so the same call at least hit what it was aimed at. Namespacing turned a blunt instrument into one pointed exclusively at production.

`clearCacheByPatterns` is worse still: it scans with `MATCH: '*'` and regex-tests every key, so scoping only the caller's glob would leave it enumerating the entire keyspace — including production's — and relying purely on the regexes to spare it.

## The fix

**1. Scope the caller's patterns at the endpoint** (`scopeCachePatternToNamespace`), on **both** the streaming and non-streaming branches. The endpoint is the boundary where a hand-written, unprefixed glob enters. A pattern built from `REDIS_KEYS` already carries the prefix from the key table, which is why the scoping lives here rather than inside the helpers — doing it there would double-prefix every internal caller.

**2. Namespace containment inside both helpers.** On a namespaced environment every main-cache key carries the prefix, so a key without it belongs to another environment. Both helpers now filter enumerated keys and refuse out-of-namespace exact keys. This is what makes the confinement structural rather than a property of the call site: a caller that forgets to scope its glob clears **nothing** instead of another environment's entries.

**3. Confine `clearCacheByPatterns`' SCAN to `<namespace>:*`.** A foreign key is now never even enumerated, so no pattern — scoped, unscoped, or malformed — can reach one.

## The deliberate main-vs-sys asymmetry — and what it is NOT

The endpoint accepts `target: 'main' | 'sys'`. **`sys` is deliberately NOT namespaced, and that exemption stays.**

The reason is a fact about the **keys**: namespacing is cache-only, `REDIS_SYS_KEYS` is never run through `applyCacheKeyPrefix`, so system keys are unprefixed on every environment. Prefixing a sys pattern would make the clear match nothing at all. Gating the exemption on a namespace being set would be wrong for the same reason.

🔴 **That is not a containment property, and this PR does not give `sys` one.** An environment's system-Redis instance is **not guaranteed to be distinct from production's**. A `?target=sys` clear issued from a non-production environment can delete **production** data, and nothing in this change stands in its way.

It is in fact the more dangerous of the two targets: cache entries are regenerable from the database, system values are not — a deleted one is simply gone. Treat any `?target=sys` call as a production operation regardless of where it is run from. Confining that target is out of scope here and wants its own change.

## Production is unchanged

With no namespace configured every prefix is `''`, so `scopeCachePatternToNamespace` returns its argument, `isInCacheNamespace` is unconditionally true, and the SCAN `MATCH` is `'*'`. The pattern sent to Redis, the `MATCH`, and the set of deleted keys are all identical to before.

That is asserted rather than reasoned: `cache-helpers-clear-namespace-prod.test.ts` pins the literal `MATCH` strings (`'packed:caches:*'`, `'*'`) and the exact deleted-key sets, and mutation G7 below confirms those assertions actually catch a prefix leaking into production.

The SSE/streaming event sequence and the response shape are unchanged, and are covered in **both** the production and the namespaced suite. (In the original version of this PR they were covered in the production suite only — where scoping is the identity function, so those tests proved nothing about scoping. See G8.)

## Verification

New tests, mirroring the existing `cache-helpers-key-prefix-{prod,preview}` split (a `vi.mock` factory is evaluated once per file, so `CACHE_KEY_NAMESPACE` cannot be flipped within one file):

- `src/server/utils/__tests__/cache-helpers-clear-namespace-prod.test.ts` — 9 tests
- `src/server/utils/__tests__/cache-helpers-clear-namespace-preview.test.ts` — 15 tests

Both drive the real endpoint handler through the real helpers into a fake Redis whose `scanIterator` honours `MATCH` server-side, so a `MATCH` confinement is tested as the real thing rather than as a recorded argument.

```
# new + existing cache-helpers suites
 Test Files  5 passed (5)
      Tests  43 passed (43)

# full unit suite
 Test Files  809 passed (809)
      Tests  11965 passed | 1 skipped (11966)
```

`node scripts/typecheck.mjs` → `typecheck: OK — 0 type errors`. ESLint on the four changed files: 0 errors (2 pre-existing `no-explicit-any` warnings on lines this PR does not touch). Prettier clean.

### Does the containment filter break any existing caller?

No — checked by enumerating the defining surface rather than sampling:

- **Direct `clearCacheByPattern` callers**: 5 in `creator-program.service.ts`, all `` `${REDIS_KEYS.CREATOR_PROGRAM.X}:*` ``, plus the endpoint (now scoped) — and `clearCacheByPatterns` has no caller but the endpoint.
- **`clearByPattern` via the cache builders** (`cached-array.ts` `flush()` → `` `${key}:*` ``): every `createCachedArray` / `createCachedObject` call site in the repo — 25 in `redis/caches.ts` plus 9 elsewhere — takes its `key` from `REDIS_KEYS`.

`REDIS_KEYS` is `applyCacheKeyPrefix(REDIS_KEYS_UNPREFIXED)`, so every one of those patterns already carries the namespace and passes containment unchanged. That is also why the caller-glob scoping lives at the endpoint rather than inside the helpers: applying it in the helpers would double-prefix all of the above.

### Mutation checks

Every guard was broken individually, the suite run, and the failure confirmed to be that guard's own assertion. The harness prints the applied diff before each run, so a silently-unapplied patch cannot masquerade as a survivor, and it carries a **comment-only negative control** that must survive — otherwise "no survivors" would be a fact about the harness rather than about the guards.

| # | Guard broken | Failure |
|---|---|---|
| C0 | *(negative control — comment only)* | **survived, as required** |
| G1 | endpoint drops the scoping call | `expected [ 'packed:caches:*' ] to deeply equal [ 'preview:packed:caches:*' ]` (+3 more, incl. both SSE cases) |
| G2 | sys exemption removed | `expected 'preview:device:accounts:*' to be 'device:accounts:*'` |
| G3 | `clearCacheByPattern` exact-key containment removed | `expected [ 'packed:caches:user-cosmetics:1' ] to deeply equal []` |
| G4 | `clearCacheByPattern` scan filter removed | `expected [ …(3) ] to deeply equal []` — the 3 being production-shaped keys |
| G5 | `clearCacheByPatterns` exact-key containment removed | `"cleared": 0` → `"cleared": 1` on two production-shaped keys |
| G6 | `clearCacheByPatterns` SCAN confinement removed | `expected [ '*' ] to deeply equal [ 'preview:*' ]` |
| G7 | production identity broken (non-empty prefix when unset) | 8 of 9 production tests; `expected 'zz:packed:caches:*' to be 'packed:caches:*'` |
| G8 | **SSE branch only** passes unscoped patterns | `expected { total: +0, perPattern: […] } to deeply equal { total: 2, … }` — received the raw patterns with `cleared: 0` |

G4 is the headline: with that one filter removed, an unscoped glob deletes three production-shaped keys, which is exactly the defect this PR closes.

G8 is worth reading closely. Its first form failed on the *event sequence* (`expected [ 'start', 'done' ] to deeply equal [ 'start', 'progress', 'done' ]`) rather than on scoping — an unscoped clear matches nothing, and `clearCacheByPatterns` skips its progress callback on an empty batch, so the `progress` event disappears. That is a true failure that says nothing about the thing under test. The tests now look events up by name and assert scoping first, so the mutant dies on the scoping assertion; the ordering constraint is commented in the test so it is not silently undone.

Each mutant is killed by a test written to exercise that guard on a path where it is the only thing in the way — the endpoint cases pin the scoping, the direct-helper cases pass a deliberately unscoped pattern to pin helper-side containment — so no mutant died on a neighbouring guard's behalf.

### Not verified

- No live Redis and no deployed environment: all verification is unit-level against a fake client. The `MATCH` confinement rests on `SCAN MATCH` being evaluated server-side.
- `WebhookEndpoint` is stubbed to a pass-through in the tests; token auth is not exercised.
