### PR TITLE
fix(env): decouple "runs against a non-production database" from IS_PREVIEW

### DIFF
--- a/src/env/__tests__/database-target.test.ts
+++ b/src/env/__tests__/database-target.test.ts
@@ -31,7 +31,9 @@ describe('env/database-target — resolveDatabaseEnvironment', () => {
   });
 
   it('trims and lowercases', () => {
-    expect(resolveDatabaseEnvironment({ DATABASE_ENVIRONMENT: '  Production ' })).toBe('production');
+    expect(resolveDatabaseEnvironment({ DATABASE_ENVIRONMENT: '  Production ' })).toBe(
+      'production'
+    );
     expect(resolveDatabaseEnvironment({ DATABASE_ENVIRONMENT: 'NON-PRODUCTION' })).toBe(
       'non-production'
     );
@@ -87,7 +89,9 @@ describe('env/database-target — isNonProductionDatabase', () => {
   });
 
   it('transitional: an unrecognised value falls back to the legacy reading, not to a guess', () => {
-    expect(isNonProductionDatabase({ IS_PREVIEW: 'true', DATABASE_ENVIRONMENT: 'prod' })).toBe(true);
+    expect(isNonProductionDatabase({ IS_PREVIEW: 'true', DATABASE_ENVIRONMENT: 'prod' })).toBe(
+      true
+    );
     expect(isNonProductionDatabase({ DATABASE_ENVIRONMENT: 'prod' })).toBe(false);
   });
 

--- a/src/env/__tests__/database-target.test.ts
+++ b/src/env/__tests__/database-target.test.ts
@@ -1,0 +1,220 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  DATABASE_ENVIRONMENT_VAR,
+  isDatabaseEnvironmentConfigured,
+  isNonProductionDatabase,
+  resolveDatabaseEnvironment,
+} from '~/env/database-target';
+
+/**
+ * The decision table for "does this deployment write to a non-production database".
+ *
+ * Every expectation below is a HAND-WRITTEN LITERAL chosen from the deployment matrix, not a
+ * value recomputed from the module under test. The three rows that matter:
+ *
+ *   production                              → nothing set                                → false
+ *   non-production env, PRODUCTION database → IS_PREVIEW=true, DATABASE_ENVIRONMENT unset → false
+ *                                             once configured with 'production'
+ *   non-production env, scratch database    → IS_PREVIEW=true + 'non-production'          → true
+ *
+ * plus the transitional row that this change must not disturb: IS_PREVIEW=true with the new
+ * variable UNSET must keep answering `true`, because that is today's behaviour and the
+ * configuration half of the fix ships separately.
+ */
+
+describe('env/database-target — resolveDatabaseEnvironment', () => {
+  it('reads the two documented spellings', () => {
+    expect(resolveDatabaseEnvironment({ DATABASE_ENVIRONMENT: 'production' })).toBe('production');
+    expect(resolveDatabaseEnvironment({ DATABASE_ENVIRONMENT: 'non-production' })).toBe(
+      'non-production'
+    );
+  });
+
+  it('trims and lowercases', () => {
+    expect(resolveDatabaseEnvironment({ DATABASE_ENVIRONMENT: '  Production ' })).toBe('production');
+    expect(resolveDatabaseEnvironment({ DATABASE_ENVIRONMENT: 'NON-PRODUCTION' })).toBe(
+      'non-production'
+    );
+  });
+
+  it('is unknown when unset, empty, or unrecognised', () => {
+    expect(resolveDatabaseEnvironment({})).toBe('unknown');
+    expect(resolveDatabaseEnvironment({ DATABASE_ENVIRONMENT: '' })).toBe('unknown');
+    expect(resolveDatabaseEnvironment({ DATABASE_ENVIRONMENT: '   ' })).toBe('unknown');
+    // 🔴 A typo must NOT round to one of the two real answers.
+    expect(resolveDatabaseEnvironment({ DATABASE_ENVIRONMENT: 'prod' })).toBe('unknown');
+    expect(resolveDatabaseEnvironment({ DATABASE_ENVIRONMENT: 'nonproduction' })).toBe('unknown');
+    expect(resolveDatabaseEnvironment({ DATABASE_ENVIRONMENT: 'preview' })).toBe('unknown');
+  });
+
+  it('names its own variable', () => {
+    expect(DATABASE_ENVIRONMENT_VAR).toBe('DATABASE_ENVIRONMENT');
+  });
+});
+
+describe('env/database-target — isNonProductionDatabase', () => {
+  it('production: neither variable set → false', () => {
+    expect(isNonProductionDatabase({})).toBe(false);
+  });
+
+  it('explicit production database wins over IS_PREVIEW=true', () => {
+    // The already-live falsifying case: a non-production environment on the production database.
+    expect(
+      isNonProductionDatabase({ IS_PREVIEW: 'true', DATABASE_ENVIRONMENT: 'production' })
+    ).toBe(false);
+  });
+
+  it('explicit non-production database → true', () => {
+    expect(
+      isNonProductionDatabase({ IS_PREVIEW: 'true', DATABASE_ENVIRONMENT: 'non-production' })
+    ).toBe(true);
+  });
+
+  it('explicit non-production database → true even without IS_PREVIEW', () => {
+    // The variable is the sole authority once set; it does not need IS_PREVIEW's agreement.
+    expect(isNonProductionDatabase({ DATABASE_ENVIRONMENT: 'non-production' })).toBe(true);
+  });
+
+  it('explicit production database → false even without IS_PREVIEW', () => {
+    expect(isNonProductionDatabase({ DATABASE_ENVIRONMENT: 'production' })).toBe(false);
+  });
+
+  it('🔴 transitional: IS_PREVIEW=true with the variable UNSET keeps answering true', () => {
+    // This is the whole safe-when-absent guarantee. If this flips to false, every ephemeral
+    // deployment starts writing scratch-database rows into production-shared sinks the moment
+    // the app ships and before any configuration lands.
+    expect(isNonProductionDatabase({ IS_PREVIEW: 'true' })).toBe(true);
+  });
+
+  it('transitional: an unrecognised value falls back to the legacy reading, not to a guess', () => {
+    expect(isNonProductionDatabase({ IS_PREVIEW: 'true', DATABASE_ENVIRONMENT: 'prod' })).toBe(true);
+    expect(isNonProductionDatabase({ DATABASE_ENVIRONMENT: 'prod' })).toBe(false);
+  });
+
+  it('IS_PREVIEW is matched exactly, as the string "true"', () => {
+    expect(isNonProductionDatabase({ IS_PREVIEW: 'false' })).toBe(false);
+    expect(isNonProductionDatabase({ IS_PREVIEW: '1' })).toBe(false);
+    expect(isNonProductionDatabase({ IS_PREVIEW: 'TRUE' })).toBe(false);
+  });
+
+  it('defaults to the live process env', () => {
+    const original = process.env;
+    try {
+      process.env = { ...original, IS_PREVIEW: 'true', DATABASE_ENVIRONMENT: 'production' };
+      expect(isNonProductionDatabase()).toBe(false);
+      process.env = { ...original, IS_PREVIEW: 'true', DATABASE_ENVIRONMENT: 'non-production' };
+      expect(isNonProductionDatabase()).toBe(true);
+    } finally {
+      process.env = original;
+    }
+  });
+});
+
+describe('env/database-target — differential vs the behaviour it replaces', () => {
+  /**
+   * 🔴 The safe-when-absent constraint, pinned STRUCTURALLY rather than case by case.
+   *
+   * `LEGACY` is a hand-written copy of the predicate the call sites used before this change
+   * (`IS_PREVIEW === 'true'`) — written out here, not imported, so it cannot drift with the code
+   * under test. Over the full cross product of the inputs that existed BEFORE the new variable,
+   * the new predicate must agree with it EXACTLY. Any disagreement is a behaviour change shipped
+   * ahead of the configuration that justifies it.
+   */
+  const LEGACY = (env: NodeJS.ProcessEnv) => env.IS_PREVIEW === 'true';
+
+  const IS_PREVIEW_VALUES = [undefined, 'true', 'false', 'TRUE', '1', ''];
+
+  it('agrees with the pre-change predicate on every input, while the variable is UNSET', () => {
+    for (const IS_PREVIEW of IS_PREVIEW_VALUES) {
+      const env: NodeJS.ProcessEnv = IS_PREVIEW === undefined ? {} : { IS_PREVIEW };
+      expect({ IS_PREVIEW, answer: isNonProductionDatabase(env) }).toEqual({
+        IS_PREVIEW,
+        answer: LEGACY(env),
+      });
+    }
+  });
+
+  it('agrees with the pre-change predicate on every input, for an UNRECOGNISED value', () => {
+    // A typo must not be a behaviour change either — it routes to the legacy reading.
+    for (const IS_PREVIEW of IS_PREVIEW_VALUES) {
+      const env: NodeJS.ProcessEnv = {
+        DATABASE_ENVIRONMENT: 'prod',
+        ...(IS_PREVIEW === undefined ? {} : { IS_PREVIEW }),
+      };
+      expect({ IS_PREVIEW, answer: isNonProductionDatabase(env) }).toEqual({
+        IS_PREVIEW,
+        answer: LEGACY(env),
+      });
+    }
+  });
+
+  it('positive control: the differential CAN disagree once the variable is set', () => {
+    // Without this, the two cases above are indistinguishable from a comparison wired to
+    // nothing. Set the variable and the predicates must part company — that is the whole point
+    // of the change.
+    const onProdDb: NodeJS.ProcessEnv = { IS_PREVIEW: 'true', DATABASE_ENVIRONMENT: 'production' };
+    expect(LEGACY(onProdDb)).toBe(true);
+    expect(isNonProductionDatabase(onProdDb)).toBe(false);
+
+    const onScratchDb: NodeJS.ProcessEnv = { DATABASE_ENVIRONMENT: 'non-production' };
+    expect(LEGACY(onScratchDb)).toBe(false);
+    expect(isNonProductionDatabase(onScratchDb)).toBe(true);
+  });
+
+  it('production is unchanged: nothing set → false under both predicates', () => {
+    expect(LEGACY({})).toBe(false);
+    expect(isNonProductionDatabase({})).toBe(false);
+  });
+});
+
+describe('env/database-target — isDatabaseEnvironmentConfigured', () => {
+  it('distinguishes configured from legacy-fallback', () => {
+    expect(isDatabaseEnvironmentConfigured({})).toBe(false);
+    expect(isDatabaseEnvironmentConfigured({ IS_PREVIEW: 'true' })).toBe(false);
+    expect(isDatabaseEnvironmentConfigured({ DATABASE_ENVIRONMENT: 'prod' })).toBe(false);
+    expect(isDatabaseEnvironmentConfigured({ DATABASE_ENVIRONMENT: 'production' })).toBe(true);
+    expect(isDatabaseEnvironmentConfigured({ DATABASE_ENVIRONMENT: 'non-production' })).toBe(true);
+  });
+});
+
+describe('env/database-target — warnIfDatabaseEnvironmentUnset', () => {
+  let consoleError: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.resetModules(); // fresh module → fresh once-per-process `warned` latch
+    consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    consoleError.mockRestore();
+  });
+
+  it('warns once when IS_PREVIEW=true and the variable is unset', async () => {
+    const { warnIfDatabaseEnvironmentUnset } = await import('~/env/database-target');
+
+    warnIfDatabaseEnvironmentUnset({ IS_PREVIEW: 'true' });
+    warnIfDatabaseEnvironmentUnset({ IS_PREVIEW: 'true' });
+    warnIfDatabaseEnvironmentUnset({ IS_PREVIEW: 'true' });
+
+    expect(consoleError).toHaveBeenCalledTimes(1);
+    expect(String(consoleError.mock.calls[0][0])).toContain('DATABASE_ENVIRONMENT');
+  });
+
+  it('stays silent in production', async () => {
+    const { warnIfDatabaseEnvironmentUnset } = await import('~/env/database-target');
+    warnIfDatabaseEnvironmentUnset({});
+    expect(consoleError).not.toHaveBeenCalled();
+  });
+
+  it('stays silent once the variable is configured', async () => {
+    const { warnIfDatabaseEnvironmentUnset } = await import('~/env/database-target');
+    warnIfDatabaseEnvironmentUnset({ IS_PREVIEW: 'true', DATABASE_ENVIRONMENT: 'production' });
+    warnIfDatabaseEnvironmentUnset({ IS_PREVIEW: 'true', DATABASE_ENVIRONMENT: 'non-production' });
+    expect(consoleError).not.toHaveBeenCalled();
+  });
+
+  it('never throws', async () => {
+    const { warnIfDatabaseEnvironmentUnset } = await import('~/env/database-target');
+    expect(() => warnIfDatabaseEnvironmentUnset({ IS_PREVIEW: 'true' })).not.toThrow();
+  });
+});

--- a/src/env/database-target.ts
+++ b/src/env/database-target.ts
@@ -66,7 +66,9 @@ export const DATABASE_ENVIRONMENT_VAR = 'DATABASE_ENVIRONMENT';
  * `env` is injectable so the matrix can be exercised as literal input/output pairs without
  * mutating the process.
  */
-export function resolveDatabaseEnvironment(env: NodeJS.ProcessEnv = process.env): DatabaseEnvironment {
+export function resolveDatabaseEnvironment(
+  env: NodeJS.ProcessEnv = process.env
+): DatabaseEnvironment {
   const raw = env[DATABASE_ENVIRONMENT_VAR]?.trim().toLowerCase();
   if (raw === 'production') return 'production';
   if (raw === 'non-production') return 'non-production';

--- a/src/env/database-target.ts
+++ b/src/env/database-target.ts
@@ -1,0 +1,125 @@
+// Which CLASS of database this deployment is pointed at.
+//
+// WHY THIS EXISTS: `IS_PREVIEW` was being asked to mean two unrelated things —
+//
+//   (a) "this is a non-production environment"      ← it does mean this
+//   (b) "this runs against a non-production database" ← it does NOT mean this
+//
+// The falsifying case is already deployed. At least two distinct deployment classes set
+// `IS_PREVIEW=true`, and they run against DIFFERENT databases: the ephemeral per-change
+// deployments use a scratch database, while a standing non-production deployment runs against
+// the PRODUCTION database. Any code that branches on `IS_PREVIEW` to decide database-write
+// behaviour is therefore already wrong for the latter — it withholds or mislabels rows that
+// are going into the real database.
+//
+// It is not even stable within one deployment class: an ephemeral deployment can be pointed at
+// either database by configuration, so the database target is a genuinely independent axis and
+// cannot be derived from any environment-identity flag. It has to be stated.
+//
+// PRECEDENT: the same conflation for redis cache keys was resolved the same way — an explicit,
+// separately-set `CACHE_KEY_NAMESPACE` rather than an overload of `IS_PREVIEW`. See
+// packages/civitai-redis/src/cache-key-prefix.ts, whose header documents that decision at
+// length. This module is the database-side counterpart.
+//
+// 🔴 UNSET IS "UNKNOWN", NOT "PRODUCTION". The configuration half of this change lands
+// separately, so for a while deployments will not carry `DATABASE_ENVIRONMENT` at all. An
+// unset value therefore falls back to the LEGACY `IS_PREVIEW` heuristic, which reproduces
+// today's behaviour byte-for-byte everywhere:
+//
+//   * production sets neither variable      → unknown → legacy → NOT a non-production database
+//   * ephemeral deployments set IS_PREVIEW  → unknown → legacy → IS a non-production database
+//
+// Defaulting an unset value to "production database" instead would flip the ephemeral
+// deployments the moment this shipped and start writing their scratch-database rows into
+// production-shared sinks — the damaging direction. Defaulting it to "non-production database"
+// would flip production. Only the legacy fallback is a no-op, so that is the default.
+//
+// The consequence is that setting `DATABASE_ENVIRONMENT` is REQUIRED to complete the fix: until
+// the standing non-production deployment carries `DATABASE_ENVIRONMENT=production`, it keeps
+// today's (wrong) behaviour. That is deliberate — a wrong-but-unchanged behaviour is a smaller
+// harm than an unreviewed behaviour change on every environment at once.
+//
+// WHY `process.env` DIRECTLY AND NOT `~/env/server`: same reason as the cache-key module — this
+// is one optional string with a total parse and no failure mode, and it is read from code that
+// must not acquire a dependency on the validated server schema (or on it having been loaded).
+// Reading it cannot throw.
+//
+// 🔴 SCOPE: this describes the DATABASE, and nothing else. It is not a general "is this
+// production" flag and must not become one. `IS_PREVIEW` remains correct for what it actually
+// means — environment identity — and still gates auth (src/server/auth/get-server-auth-session.ts)
+// and page access (src/server/auth/route-guard.ts). Do not repoint those at this variable.
+
+/** The three states of `DATABASE_ENVIRONMENT`. `unknown` means "not configured", not "neither". */
+export type DatabaseEnvironment = 'production' | 'non-production' | 'unknown';
+
+/** The environment variable that carries the signal. Exported so tests name it once. */
+export const DATABASE_ENVIRONMENT_VAR = 'DATABASE_ENVIRONMENT';
+
+/**
+ * Parse `DATABASE_ENVIRONMENT` into its three states.
+ *
+ * Strict: only the two documented spellings are recognised (after trim + lowercase). Anything
+ * else — a typo, a legacy value, an empty string — is `unknown`, which routes to the legacy
+ * fallback rather than to a guessed answer. A misconfigured value must never be silently read
+ * as one of the two real answers.
+ *
+ * `env` is injectable so the matrix can be exercised as literal input/output pairs without
+ * mutating the process.
+ */
+export function resolveDatabaseEnvironment(env: NodeJS.ProcessEnv = process.env): DatabaseEnvironment {
+  const raw = env[DATABASE_ENVIRONMENT_VAR]?.trim().toLowerCase();
+  if (raw === 'production') return 'production';
+  if (raw === 'non-production') return 'non-production';
+  return 'unknown';
+}
+
+/**
+ * `true` when this deployment writes to a database that is NOT production.
+ *
+ * This is the predicate call sites want: it answers "are the ids and rows I am about to emit
+ * from a throwaway dataset?". Read it at CALL time (not module-eval) so a value can be set in a
+ * test without a module-graph reset; environment variables do not change at runtime, so there is
+ * no behavioural difference in the app.
+ *
+ * When `DATABASE_ENVIRONMENT` is unset or unrecognised this falls back to `IS_PREVIEW === 'true'`
+ * — see the header. That fallback is the ONLY reason production is unaffected by this change, so
+ * do not "simplify" it to `false`.
+ */
+export function isNonProductionDatabase(env: NodeJS.ProcessEnv = process.env): boolean {
+  const resolved = resolveDatabaseEnvironment(env);
+  if (resolved !== 'unknown') return resolved === 'non-production';
+  return env.IS_PREVIEW === 'true';
+}
+
+/**
+ * Whether the answer came from the explicit variable or from the legacy fallback. Exported for
+ * diagnostics and for the misconfiguration warning below; call sites should prefer
+ * `isNonProductionDatabase`.
+ */
+export function isDatabaseEnvironmentConfigured(env: NodeJS.ProcessEnv = process.env): boolean {
+  return resolveDatabaseEnvironment(env) !== 'unknown';
+}
+
+// Misconfiguration reminder. A deployment that announces itself as non-production but does not
+// say which database it is pointed at is running on the legacy heuristic — which is right for the
+// ephemeral deployments and wrong for the standing one, and nothing about the process can tell
+// which it is. Warn so the pending configuration change stays visible.
+//
+// 🔴 LOG-ONLY, NEVER THROW, and at most once per process. This module is imported from request
+// paths; throwing would fail boot for exactly the deployments that are legitimately mid-migration,
+// and warning per call would flood the log.
+let warned = false;
+export function warnIfDatabaseEnvironmentUnset(env: NodeJS.ProcessEnv = process.env) {
+  if (warned) return;
+  if (isDatabaseEnvironmentConfigured(env)) return;
+  if (env.IS_PREVIEW !== 'true') return;
+  warned = true;
+  // eslint-disable-next-line no-console
+  console.error(
+    `🔴 ${DATABASE_ENVIRONMENT_VAR} IS UNSET on a deployment with IS_PREVIEW=true. Database-write ` +
+      'behaviour is falling back to the legacy IS_PREVIEW heuristic, which assumes a ' +
+      'non-production database — wrong for any non-production deployment that runs against the ' +
+      `production database. Set ${DATABASE_ENVIRONMENT_VAR} to "production" or "non-production" ` +
+      'on this deployment. See src/env/database-target.ts.'
+  );
+}

--- a/src/server/services/__tests__/contest-snapshot-source.test.ts
+++ b/src/server/services/__tests__/contest-snapshot-source.test.ts
@@ -1,0 +1,157 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * `snapshotSource()` stamps a contest snapshot as describing THROWAWAY DATA — in the stored
+ * value and in the KeyValue key, where the docblock advertises it as a prefix-delete handle.
+ *
+ * It used to fire on `IS_PREVIEW`, which is a claim about environment identity, not about which
+ * database the rows land in. A non-production deployment running against the PRODUCTION database
+ * therefore stamped `preview` onto snapshots of REAL entries, badged them as disposable in the
+ * moderator UI, and filed them under the deletable prefix. These cases pin the corrected matrix.
+ *
+ * Every expected key/marker below is a hand-written literal. `takenAt` is a fixed string rather
+ * than a clock read, so the composed key is fully literal too.
+ */
+
+// Module-load scaffold: the service reaches Prisma, redis and ClickHouse at import time. None of
+// them are on `snapshotSource`/`snapshotKey`'s path — both are pure functions of the environment
+// and their arguments — so they only need to exist.
+vi.mock('~/server/db/client', () => ({
+  dbRead: { $queryRaw: vi.fn(), keyValue: { findUnique: vi.fn() } },
+  dbWrite: { $queryRaw: vi.fn(), keyValue: { create: vi.fn() } },
+}));
+vi.mock('~/server/db/db-helpers', () => ({ dbKV: { get: vi.fn(), set: vi.fn() } }));
+vi.mock('~/server/redis/client', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>();
+  return { ...actual, redis: { packed: { get: vi.fn(), set: vi.fn() }, del: vi.fn() } };
+});
+
+const COLLECTION_ID = 4242;
+const TAKEN_AT = '2026-08-05T11:22:33.444Z';
+
+describe('contest snapshotSource — database-target gate', () => {
+  const originalEnv = process.env;
+  let consoleError: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    delete process.env.IS_PREVIEW;
+    delete process.env.DATABASE_ENVIRONMENT;
+    delete process.env.NEXT_PUBLIC_IS_PR_PREVIEW;
+    delete process.env.NEXT_PUBLIC_PR_NUMBER;
+    // The transitional cases trip the misconfiguration warning by design.
+    consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    consoleError.mockRestore();
+  });
+
+  const source = async () => {
+    const { snapshotSource } = await import('~/server/services/contest-score.service');
+    return snapshotSource();
+  };
+
+  const key = async () => {
+    const svc = await import('~/server/services/contest-score.service');
+    return svc.snapshotKey(COLLECTION_ID, TAKEN_AT, svc.snapshotSource());
+  };
+
+  it('production (nothing set): no marker, unprefixed key', async () => {
+    expect(await source()).toBe(null);
+    expect(await key()).toBe('contestSnapshot:4242:2026-08-05T11:22:33.444Z');
+  });
+
+  it('🔴 non-production environment on the PRODUCTION database: no marker', async () => {
+    // The bug this change exists to fix. Before it, this returned 'preview' and filed the row
+    // under the deletable prefix.
+    process.env.IS_PREVIEW = 'true';
+    process.env.DATABASE_ENVIRONMENT = 'production';
+
+    expect(await source()).toBe(null);
+    expect(await key()).toBe('contestSnapshot:4242:2026-08-05T11:22:33.444Z');
+  });
+
+  it('non-production environment on a NON-PRODUCTION database: marked', async () => {
+    process.env.IS_PREVIEW = 'true';
+    process.env.DATABASE_ENVIRONMENT = 'non-production';
+
+    expect(await source()).toBe('preview');
+    expect(await key()).toBe('contestSnapshot:4242:preview:2026-08-05T11:22:33.444Z');
+  });
+
+  it('non-production database with a change number: marked with the number', async () => {
+    process.env.IS_PREVIEW = 'true';
+    process.env.DATABASE_ENVIRONMENT = 'non-production';
+    process.env.NEXT_PUBLIC_PR_NUMBER = '3712';
+
+    expect(await source()).toBe('preview-3712');
+    expect(await key()).toBe('contestSnapshot:4242:preview-3712:2026-08-05T11:22:33.444Z');
+  });
+
+  it('🔴 transitional — IS_PREVIEW=true with DATABASE_ENVIRONMENT unset: marked', async () => {
+    // Today's behaviour, preserved until the configuration half lands.
+    process.env.IS_PREVIEW = 'true';
+
+    expect(await source()).toBe('preview');
+    expect(await key()).toBe('contestSnapshot:4242:preview:2026-08-05T11:22:33.444Z');
+  });
+
+  it('🔴 transitional — the ephemeral-deployment flag alone, variable unset: marked', async () => {
+    // The second legacy spelling. It must keep working while the variable is unconfigured.
+    process.env.NEXT_PUBLIC_IS_PR_PREVIEW = 'true';
+    process.env.NEXT_PUBLIC_PR_NUMBER = '3712';
+
+    expect(await source()).toBe('preview-3712');
+    expect(await key()).toBe('contestSnapshot:4242:preview-3712:2026-08-05T11:22:33.444Z');
+  });
+
+  it('the configured variable overrides the legacy ephemeral-deployment flag', async () => {
+    // Once set, DATABASE_ENVIRONMENT is the sole authority — an ephemeral deployment pointed at
+    // the production database must not mark its rows.
+    process.env.NEXT_PUBLIC_IS_PR_PREVIEW = 'true';
+    process.env.NEXT_PUBLIC_PR_NUMBER = '3712';
+    process.env.DATABASE_ENVIRONMENT = 'production';
+
+    expect(await source()).toBe(null);
+    expect(await key()).toBe('contestSnapshot:4242:2026-08-05T11:22:33.444Z');
+  });
+
+  it('non-production database without any environment-identity flag: marked', async () => {
+    process.env.DATABASE_ENVIRONMENT = 'non-production';
+
+    expect(await source()).toBe('preview');
+    expect(await key()).toBe('contestSnapshot:4242:preview:2026-08-05T11:22:33.444Z');
+  });
+
+  it('a change number alone does not mark a production-database snapshot', async () => {
+    // The number is a label, never the trigger.
+    process.env.NEXT_PUBLIC_PR_NUMBER = '3712';
+
+    expect(await source()).toBe(null);
+    expect(await key()).toBe('contestSnapshot:4242:2026-08-05T11:22:33.444Z');
+  });
+
+  it('a marked key round-trips through the reader that authorises snapshot fetches', async () => {
+    // The key is parsed back on read; a marker that the parser cannot recover would make the
+    // row unfetchable. Pinned as a literal on both sides.
+    process.env.DATABASE_ENVIRONMENT = 'non-production';
+    const { listContestSnapshots } = await import('~/server/services/contest-score.service');
+    const { dbRead } = await import('~/server/db/client');
+
+    const marked = await key();
+    (dbRead.$queryRaw as ReturnType<typeof vi.fn>).mockResolvedValue([
+      { key: marked, partial: false },
+    ]);
+
+    expect(await listContestSnapshots({ collectionId: COLLECTION_ID })).toEqual([
+      {
+        key: 'contestSnapshot:4242:preview:2026-08-05T11:22:33.444Z',
+        source: 'preview',
+        takenAt: '2026-08-05T11:22:33.444Z',
+        partial: false,
+      },
+    ]);
+  });
+});

--- a/src/server/services/__tests__/sticker-usage-database-target.test.ts
+++ b/src/server/services/__tests__/sticker-usage-database-target.test.ts
@@ -1,0 +1,166 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type * as EnvOther from '~/env/other';
+
+/**
+ * `recordStickerUsage` withholds usage-history rows when the deployment's ids come from a
+ * throwaway database. The condition used to be `isPreview`, which is a claim about ENVIRONMENT
+ * IDENTITY and not about which database is behind it — so a non-production deployment running
+ * against the PRODUCTION database dropped real usage history while still charging for the
+ * placements. These cases pin the corrected matrix.
+ *
+ * Expectations are literal (`toHaveBeenCalledTimes(0 | 1)` plus a hand-written row array), and
+ * the environment is driven through `process.env` rather than through the module under test.
+ *
+ * `isProd` is forced true because every deployment in the matrix — production and non-production
+ * alike — runs NODE_ENV=production; that is exactly why `isProd` alone was never sufficient. The
+ * `!isProd` half of the guard gets its own case below.
+ */
+
+const isProdRef = vi.hoisted(() => ({ value: true }));
+
+vi.mock('~/env/other', async (importOriginal) => ({
+  ...(await importOriginal<typeof EnvOther>()),
+  get isProd() {
+    return isProdRef.value;
+  },
+}));
+
+// Module-load scaffold: `sticker.service` reaches Prisma clients, redis caches and the buzz
+// service at import time. None of them are on `recordStickerUsage`'s path (it is a pure
+// env-guard + array build + fire-and-forget call), so they only need to exist.
+vi.mock('~/server/db/client', () => ({
+  dbRead: { $queryRaw: vi.fn() },
+  dbWrite: { $queryRaw: vi.fn(), $transaction: vi.fn() },
+}));
+vi.mock('~/server/redis/caches', () => ({ refreshOwnedStickerCache: vi.fn() }));
+vi.mock('~/server/services/buzz.service', () => ({
+  createBuzzTransaction: vi.fn(),
+  createMultiAccountBuzzTransaction: vi.fn(),
+  refundMultiAccountTransaction: vi.fn(),
+}));
+vi.mock('~/server/services/user-preferences.service', () => ({ getBlockedPairIds: vi.fn() }));
+
+const USER_ID = 77;
+const COSMETIC_ID = 12;
+const ENTITY_ID = 9001;
+
+describe('recordStickerUsage — database-target gate', () => {
+  const originalEnv = process.env;
+  let stickerUsage: ReturnType<typeof vi.fn>;
+  let track: { stickerUsage: ReturnType<typeof vi.fn> };
+
+  beforeEach(() => {
+    isProdRef.value = true;
+    process.env = { ...originalEnv };
+    delete process.env.IS_PREVIEW;
+    delete process.env.DATABASE_ENVIRONMENT;
+    stickerUsage = vi.fn().mockResolvedValue(undefined);
+    track = { stickerUsage };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  const record = async () => {
+    const { recordStickerUsage } = await import('~/server/services/sticker.service');
+    recordStickerUsage({
+      track,
+      userId: USER_ID,
+      charged: new Map([[COSMETIC_ID, 2]]),
+      entityType: 'comment',
+      entityId: ENTITY_ID,
+    });
+  };
+
+  it('production (neither variable set): emits', async () => {
+    await record();
+
+    // Positive control for the whole file: the emit path really is reachable here, so a `0`
+    // in any case below is a decision and not a harness that is wired to nothing.
+    expect(stickerUsage).toHaveBeenCalledTimes(1);
+    expect(stickerUsage).toHaveBeenCalledWith([
+      { userId: 77, cosmeticId: 12, entityType: 'comment', entityId: 9001 },
+      { userId: 77, cosmeticId: 12, entityType: 'comment', entityId: 9001 },
+    ]);
+  });
+
+  it('🔴 non-production environment on the PRODUCTION database: emits', async () => {
+    // The bug this change exists to fix. Before it, this dropped the rows.
+    process.env.IS_PREVIEW = 'true';
+    process.env.DATABASE_ENVIRONMENT = 'production';
+
+    await record();
+
+    expect(stickerUsage).toHaveBeenCalledTimes(1);
+    expect(stickerUsage).toHaveBeenCalledWith([
+      { userId: 77, cosmeticId: 12, entityType: 'comment', entityId: 9001 },
+      { userId: 77, cosmeticId: 12, entityType: 'comment', entityId: 9001 },
+    ]);
+  });
+
+  it('non-production environment on a NON-PRODUCTION database: withholds', async () => {
+    process.env.IS_PREVIEW = 'true';
+    process.env.DATABASE_ENVIRONMENT = 'non-production';
+
+    await record();
+
+    expect(stickerUsage).toHaveBeenCalledTimes(0);
+  });
+
+  it('🔴 transitional — IS_PREVIEW=true with DATABASE_ENVIRONMENT unset: withholds', async () => {
+    // Today's behaviour, and it must not change before the configuration half lands. If this
+    // flips, ephemeral deployments start writing scratch-database ids into the shared sink.
+    process.env.IS_PREVIEW = 'true';
+
+    await record();
+
+    expect(stickerUsage).toHaveBeenCalledTimes(0);
+  });
+
+  it('non-production database without IS_PREVIEW: withholds', async () => {
+    process.env.DATABASE_ENVIRONMENT = 'non-production';
+
+    await record();
+
+    expect(stickerUsage).toHaveBeenCalledTimes(0);
+  });
+
+  it('non-production NODE_ENV: withholds regardless of the database', async () => {
+    // The `!isProd` half of the guard, exercised on an input the database test cannot reject —
+    // so it is reached rather than shadowed.
+    isProdRef.value = false;
+    process.env.DATABASE_ENVIRONMENT = 'production';
+
+    await record();
+
+    expect(stickerUsage).toHaveBeenCalledTimes(0);
+  });
+
+  it('no charged placements: withholds even on production', async () => {
+    // The privacy path (DMs are free, so `charged` is empty). Pinned so a rewrite of the
+    // database gate cannot absorb it.
+    const { recordStickerUsage } = await import('~/server/services/sticker.service');
+    recordStickerUsage({
+      track,
+      userId: USER_ID,
+      charged: new Map(),
+      entityType: 'chat',
+      entityId: ENTITY_ID,
+    });
+
+    expect(stickerUsage).toHaveBeenCalledTimes(0);
+  });
+
+  it('no tracker: withholds', async () => {
+    const { recordStickerUsage } = await import('~/server/services/sticker.service');
+    recordStickerUsage({
+      userId: USER_ID,
+      charged: new Map([[COSMETIC_ID, 2]]),
+      entityType: 'comment',
+      entityId: ENTITY_ID,
+    });
+
+    expect(stickerUsage).toHaveBeenCalledTimes(0);
+  });
+});

--- a/src/server/services/contest-score.service.ts
+++ b/src/server/services/contest-score.service.ts
@@ -27,6 +27,11 @@
 import type { Prisma } from '@prisma/client';
 import { v4 as uuid } from 'uuid';
 import {
+  isDatabaseEnvironmentConfigured,
+  isNonProductionDatabase,
+  warnIfDatabaseEnvironmentUnset,
+} from '~/env/database-target';
+import {
   CacheTTL,
   CONTEST_SCORE_CODE_VERSION,
   CONTEST_SNAPSHOT_KEY_PREFIX,
@@ -1168,13 +1173,35 @@ export async function getContestCandidates(input: GetContestCandidatesInput) {
 // ---------------------------------------------------------------------------
 
 /**
- * Which deployment produced a snapshot, derived from the ENVIRONMENT and never from
- * mutation input — an operator cannot forget it and a client cannot spoof it.
- * Preview namespaces carry these vars; production carries none of them.
+ * The marker that says a snapshot describes THROWAWAY DATA. Derived from the environment
+ * and never from mutation input — an operator cannot forget it and a client cannot spoof it.
+ *
+ * 🔴 IT MARKS THE DATABASE, NOT THE DEPLOYMENT. This used to fire on `IS_PREVIEW`, which is
+ * a claim about environment identity, not about which database is behind it. A non-production
+ * deployment that runs against the PRODUCTION database was therefore stamping `preview` onto
+ * rows computed from REAL production entries — rows that are legitimate judging artifacts, are
+ * badged as disposable in the moderator UI, and sort into a key namespace the docblock below
+ * advertises as safe to prefix-delete. Deleting them would destroy real evidence.
+ *
+ * So the marker is now gated on the database, via `isNonProductionDatabase()` — which falls back
+ * to the legacy `IS_PREVIEW` / `NEXT_PUBLIC_IS_PR_PREVIEW` reading until `DATABASE_ENVIRONMENT`
+ * is configured, so nothing moves before then. See src/env/database-target.ts.
+ *
+ * A snapshot taken from a non-production deployment against the PRODUCTION database gets NO
+ * marker, the same as one taken from production. That is the correct answer for what this field
+ * means: its data is real and it must survive a cleanup of scratch rows. If "which deployment
+ * took this" is ever wanted, it needs its OWN field — do not re-overload this one.
+ *
+ * Exported for tests: it is the whole decision, and the alternative is exercising it through a
+ * distributed lock and a full scoring run.
  */
-function snapshotSource() {
-  if (process.env.IS_PREVIEW !== 'true' && process.env.NEXT_PUBLIC_IS_PR_PREVIEW !== 'true')
-    return null;
+export function snapshotSource() {
+  warnIfDatabaseEnvironmentUnset();
+  // The PR-preview flag is a second spelling of the same legacy heuristic, so it only gets a
+  // say while `DATABASE_ENVIRONMENT` is unconfigured. Once it is set, it is the sole authority.
+  const legacyPrPreview =
+    !isDatabaseEnvironmentConfigured() && process.env.NEXT_PUBLIC_IS_PR_PREVIEW === 'true';
+  if (!isNonProductionDatabase() && !legacyPrPreview) return null;
   const pr = process.env.NEXT_PUBLIC_PR_NUMBER;
   return pr ? `preview-${pr}` : 'preview';
 }
@@ -1244,7 +1271,8 @@ export type ContestSnapshotSummary = Omit<StoredContestSnapshot, 'config' | 'sco
   entryCount: number;
 };
 
-const snapshotKey = (collectionId: number, takenAt: string, source: string | null) =>
+/** Exported for tests: pairs with `snapshotSource` to pin the stored key literally. */
+export const snapshotKey = (collectionId: number, takenAt: string, source: string | null) =>
   [CONTEST_SNAPSHOT_KEY_PREFIX, collectionId, ...(source ? [source] : []), takenAt].join(':');
 
 function toSnapshotSummary(key: string, snapshot: StoredContestSnapshot): ContestSnapshotSummary {

--- a/src/server/services/sticker.service.ts
+++ b/src/server/services/sticker.service.ts
@@ -1,7 +1,8 @@
 import type { Prisma } from '@prisma/client';
 import { randomUUID } from 'node:crypto';
 import { dbRead, dbWrite } from '~/server/db/client';
-import { isPreview, isProd } from '~/env/other';
+import { isNonProductionDatabase, warnIfDatabaseEnvironmentUnset } from '~/env/database-target';
+import { isProd } from '~/env/other';
 import { logToAxiom } from '~/server/logging/client';
 import { refreshOwnedStickerCache } from '~/server/redis/caches';
 import { computeCreatorShopSplit } from '~/server/schema/creator-shop.schema';
@@ -155,13 +156,20 @@ export function recordStickerUsage({
   // must not be "fixed" by logging uncharged placements.
   if (!track || !charged.size) return;
 
-  // Preview deploys share CLICKHOUSE_TRACKER_URL with production but run against
-  // the DEV database, so their `entityId`s are ids from a different database —
-  // they'd land in the prod table pointing at unrelated comments, with no column
-  // to tell them apart afterwards. Skipping the emit is deliberate: consumption
-  // still happens, so stickers are fully testable in preview; only the history
-  // is withheld. `isProd` alone is not enough — a preview IS NODE_ENV=production.
-  if (!isProd || isPreview) return;
+  // A deployment that shares the analytics sink with production but runs against a
+  // NON-PRODUCTION database emits `entityId`s from a different database — they'd land
+  // in the shared table pointing at unrelated comments, with no column to tell them
+  // apart afterwards. Skipping the emit is deliberate: consumption still happens, so
+  // stickers stay fully testable there; only the history is withheld. `isProd` alone
+  // is not enough — those deployments are also NODE_ENV=production.
+  //
+  // 🔴 THE TEST IS THE DATABASE, NOT THE ENVIRONMENT. This used to read `isPreview`,
+  // which is a claim about environment identity and NOT about which database is behind
+  // it. A non-production deployment that runs against the PRODUCTION database was
+  // therefore dropping REAL usage history — silently, while still charging for the
+  // placements. See src/env/database-target.ts for why the two cannot be conflated.
+  warnIfDatabaseEnvironmentUnset();
+  if (!isProd || isNonProductionDatabase()) return;
 
   const rows: StickerUsageRow[] = [];
   for (const [cosmeticId, count] of charged)


### PR DESCRIPTION
## The conflation

`IS_PREVIEW` is being asked to mean two unrelated things:

- **"this is a non-production environment"** — it does mean this, and it correctly gates the auth path and page-level access.
- **"this runs against a non-production database"** — it does **not** mean this.

The second reading is false today. At least two distinct deployment classes set `IS_PREVIEW=true`, and they run against **different databases**: the ephemeral per-change deployments use a scratch database, while a standing non-production deployment runs against the **production** database. The database target is also configurable per deployment, so it is a genuinely independent axis and cannot be derived from any environment-identity flag — it has to be stated.

So any code branching on `IS_PREVIEW` to decide *database-write* behaviour is already wrong for at least one live deployment.

## The already-live consequence

Two sites did exactly that, and both are reached by a deployment that writes to the production database:

**1. `src/server/services/sticker.service.ts` — `recordStickerUsage`**

`if (!isProd || isPreview) return;` skipped emitting sticker usage-history rows. The comment justified the skip on the grounds that such deployments run against a scratch database and their entity ids are meaningless in the shared analytics table — true for the ephemeral deployments, false for the standing one. There, **real usage history was being silently dropped while the placements were still consumed and charged.** Silent in both directions: no error, and the balance side of the transaction behaved normally.

**2. `src/server/services/contest-score.service.ts` — `snapshotSource()`**

Returned `preview` / `preview-<n>` whenever `IS_PREVIEW === 'true'`. On a deployment running against the production database, that stamped the marker onto contest snapshots **computed from real entries and stored in the production database**. Those rows are the artifact that defends a disputed prize. The marker:

- badges them as disposable in the moderator UI (the badge is the only place `source` is surfaced), and
- files them under a key prefix that this file's own docblock advertises as safe to bulk-delete.

Nothing performs that delete today, so no data has been lost — but the rows are mislabelled in the damaging direction, and the labelling is what a cleanup would key on.

## The fix

An **explicit** signal for the database axis, following the `CACHE_KEY_NAMESPACE` precedent (`packages/civitai-redis/src/cache-key-prefix.ts`), which resolved exactly this conflation for cache keys by introducing a separately-set variable rather than overloading `IS_PREVIEW`.

New module `src/env/database-target.ts` exposing `DATABASE_ENVIRONMENT`:

| value | meaning |
|---|---|
| `production` | this deployment writes to the production database |
| `non-production` | this deployment writes to a scratch/clone database |
| unset / unrecognised | **unknown** — fall back to the legacy `IS_PREVIEW` reading |

Both guards now ask `isNonProductionDatabase()` instead of `isPreview`. Parsing is strict: a typo resolves to `unknown` and routes to the fallback rather than rounding to one of the two real answers.

`IS_PREVIEW` is untouched and still means what it actually means. The auth (`get-server-auth-session.ts`), route-guard, and tRPC rate-limit-bypass uses of it are environment-identity questions and are deliberately **not** repointed.

## Safe when the new variable is absent

The configuration half lands separately, so for a while no deployment will carry `DATABASE_ENVIRONMENT`. **Unset is treated as "unknown" and falls back to the legacy `IS_PREVIEW === 'true'` reading**, which reproduces today's behaviour exactly:

- **production** sets neither variable → unknown → legacy → *not* a non-production database → both sites behave exactly as today.
- **ephemeral deployments** set `IS_PREVIEW` → unknown → legacy → *is* a non-production database → they keep withholding usage history and keep marking snapshots, exactly as today.

Defaulting unset to "production database" instead would flip the ephemeral deployments the moment this shipped and start writing scratch-database ids into the shared analytics sink — the damaging direction. Only the legacy fallback is a no-op, so that is the default.

This is pinned structurally, not just case-by-case: `database-target.test.ts` contains a **differential test** that re-implements the pre-change predicate as a hand-written literal and asserts the new predicate agrees with it across the full cross-product of pre-change inputs whenever `DATABASE_ENVIRONMENT` is unset or unrecognised — plus a positive control proving the two predicates *can* disagree once it is set.

A log-only, once-per-process warning fires on a deployment that sets `IS_PREVIEW=true` without `DATABASE_ENVIRONMENT`, so the pending configuration stays visible. It never throws.

## 🔴 Required follow-up — this fix is INERT until the deployment configuration is updated

**This PR alone changes nothing on any environment.** It only makes the correct behaviour *expressible*. Completing it requires setting `DATABASE_ENVIRONMENT` in the deployment configuration (a separate repository):

- On every deployment that runs against the **production** database but is not production itself → `DATABASE_ENVIRONMENT=production`. **This is the one that fixes the two live bugs above** — until it is set, that deployment keeps dropping usage history and keeps mislabelling snapshots.
- On deployments that run against a **scratch/clone** database → `DATABASE_ENVIRONMENT=non-production`. Behaviour is unchanged by this either way (the fallback already answers the same), but setting it removes the reliance on the legacy heuristic and silences the warning.
- **Production itself needs no change.** It sets neither variable and must keep setting neither.

Because the ephemeral deployments can be pointed at either database by configuration, whatever sets that target should set `DATABASE_ENVIRONMENT` alongside it, so the two cannot drift apart.

## Verification

- `Test Files 7 passed (7)` / `Tests 98 passed (98)` — the 3 new suites (40 tests) plus the existing sticker suite, the `env/other` suite and both `cache-helpers` key-prefix suites as regression checks.
- Each site is tested across the matrix that matters — production (nothing set), a non-production environment on the **production** database, and a non-production environment on a **non-production** database — with hand-written literal expectations (exact row arrays, exact `source` values, exact composed KeyValue keys). No expectation is derived from the implementation under test.
- **9 mutation checks**, each broken deliberately and watched go red for that guard's own reason before being reverted — including reintroducing the original `isPreview` test at both sites, which fails precisely the case that names the bug. The harness was itself validated with an inert comment-only mutation (stays green) before any verdict was read.
- `pnpm typecheck`: 0 errors. Validated with a positive control — a deliberate type error planted in each touched file — which confirmed the three **source** files are compiled by that gate. It also showed the three **test** files are not: `src/**/__tests__/**` is excluded by the project's own `tsconfig.json`, repo-wide and pre-existing. Their types are therefore only exercised at test runtime, where they run green.
- ESLint clean on all six files.

### Not verified

- Nothing was exercised against a live deployment — the behavioural change only becomes observable once `DATABASE_ENVIRONMENT` is actually set, which is the follow-up above.
- The claim that no cleanup currently prefix-deletes marked snapshot rows is from a repo-wide search (no `keyValue.delete*`, no `DELETE FROM "KeyValue"`, no job or script referencing the key prefix). It is a statement about this repository only.
- The full unit suite was not run end-to-end; the suites above were selected as the ones reaching the changed modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EzTiXgK87YTy7PftYni8RQ
