### PR TITLE
test(apps): remove the wall-clock race from the app-search debounce guard

### DIFF
--- a/src/components/Apps/AppListingsMarketplaceBody.browser.test.tsx
+++ b/src/components/Apps/AppListingsMarketplaceBody.browser.test.tsx
@@ -1,5 +1,6 @@
-import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { page, userEvent } from 'vitest/browser';
+import { act as reactAct } from 'react';
 import { useRouter } from 'next/router';
 // `test/` lives outside `src`, so the `~` alias doesn't reach it — relative import.
 import { renderWithProviders } from '../../../test/component-setup';
@@ -48,6 +49,29 @@ function generatedCssFor(el: HTMLElement): string {
     .join('\n')
     .replace(/\s+/g, '');
 }
+
+/**
+ * React 18.3 exposes `act` on the `react` export, but the pinned
+ * `@types/react` (18.0.x) does not declare it. The repo fills that gap with a
+ * `declare module 'react'` augmentation in
+ * `src/tests/components/TrackView/useTrackEvent.wiring.test.ts` — but it
+ * declares only the SYNC form, `(callback: () => void) => void`.
+ *
+ * That augmentation is global, so it is what an `import { act } from 'react'`
+ * resolves to here, and it under-describes the async form this file needs:
+ * with an async callback `act` really returns a thenable, and awaiting it is
+ * the whole point (it is what flushes the setState + effect the advanced timer
+ * schedules). Against the sync-only declaration TypeScript sees `await void`
+ * and reports "'await' has no effect on the type of this expression" — a real
+ * hint about a real typing gap, not a phantom.
+ *
+ * Rather than widen a module augmentation that another test owns, narrow the
+ * repair to this file: alias the async overload that React actually implements.
+ * Verified behaviourally, not just typed — removing the `advanceTimersByTime`
+ * call leaves ZERO writes recorded, which is only observable if the await here
+ * genuinely flushes.
+ */
+const act = reactAct as unknown as <T>(callback: () => T | Promise<T>) => Promise<T>;
 
 const mocks = vi.hoisted(() => ({
   items: [] as ListingCard[],
@@ -141,6 +165,13 @@ beforeEach(() => {
   clearRecentlyOpenedApps();
 });
 
+// Unconditional restore: the debounce test installs fake timers, and a throw
+// between install and restore would otherwise leak the fake clock into every
+// following test in this file (where an un-advanced `setTimeout` reads as a hang).
+afterEach(() => {
+  vi.useRealTimers();
+});
+
 /** Open the collapsed Filters dropdown — kind/category live inside it now. */
 async function openFilters() {
   await userEvent.click(page.getByRole('button', { name: 'Filters' }));
@@ -202,30 +233,71 @@ describe('AppListingsMarketplaceBody', () => {
   test('🔴 the search box does NOT write the URL per keystroke — only the debounced value', async () => {
     renderWithProviders(<AppListingsMarketplaceBody />);
     const search = page.getByLabelText('Search');
+    // Anchor on a real mount before touching the clock — a locator query issued
+    // against an unmounted tree would burn its retry budget on a fake clock.
+    await expect.element(search).toBeInTheDocument();
 
     /**
-     * ⚠️ TWO fills, not six. The original version did six sequential
-     * `fill()`s and asserted ZERO writes afterwards — but each awaited `fill()`
-     * measured ~66ms, so the six took ~396ms against a 300ms debounce. It passed
-     * only because the assertion ran before the timer's callback; one slow fill
-     * and the debounce elapses mid-loop, a write lands, and the test goes red on
-     * a machine hiccup rather than on a regression. Two fills is well inside the
-     * window on any machine, and still distinguishes per-keystroke writes (which
-     * would be 2) from debounced ones (0 so far).
+     * ⚠️ THE CLOCK IS CONTROLLED, NOT RACED. Earlier revisions of this test
+     * asserted "zero writes so far" after N awaited `fill()`s and relied on the
+     * real 300ms debounce not having elapsed yet — first with six fills (~396ms
+     * of real time, i.e. already past the window and passing only because the
+     * assertion beat the timer callback), then with two. Both are the same bug:
+     * the assertion's truth depended on how fast the machine happened to be, so
+     * a loaded runner turned a machine hiccup into a red test. It duly failed in
+     * CI — a single `fill()` exceeded 300ms, the debounce fired between the two
+     * fills, and a write carrying the FIRST value ('mat') landed.
+     *
+     * Cutting the fill count only lowers the probability; it leaves the
+     * wall-clock dependency in place. So instead the debounce timer is driven
+     * explicitly: `setTimeout`/`clearTimeout` are faked, so NO amount of real
+     * elapsed time can fire the debounce, and `advanceTimersByTime(300)` is the
+     * only thing that can. The zero-writes assertion is then a statement about
+     * the component, not about the machine.
+     *
+     * `toFake` is scoped to just those two primitives on purpose: Playwright's
+     * real `fill()` interaction and the browser-runner channel still need real
+     * `queueMicrotask`/`requestAnimationFrame`/`Date`/`performance`, and faking
+     * the whole set wedges them. Real timers are restored in the `afterEach`
+     * below so a throw here can't leak the fake clock into the next test.
      */
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
+
     await search.fill('mat');
     await search.fill('matrix');
 
-    // Nothing written yet — the debounce has not elapsed. This is the assertion
-    // that fails if the input is wired straight through to the URL.
+    // Nothing written yet — the debounce timer has NOT been advanced. This is
+    // the assertion that fails if the input is wired straight through to the
+    // URL, and it is now timing-independent: with `setTimeout` faked the
+    // debounce cannot fire on its own no matter how slow the fills were.
     expect(replacedQueries().filter((q) => 'query' in q)).toHaveLength(0);
 
-    // …and after it does, exactly ONE write, carrying the FINAL value.
-    await vi.waitFor(() => {
-      const writes = replacedQueries().filter((q) => 'query' in q);
-      expect(writes).toHaveLength(1);
-      expect(writes[0]).toMatchObject({ query: 'matrix' });
-    });
+    // Advance past the 300ms debounce window. `act` flushes the resulting
+    // setState + the URL-echo effect before the assertions below, so this stays
+    // a single deterministic step rather than a retry loop (a retried "expect
+    // exactly 1 write" would happily succeed in the window before a second,
+    // buggy write landed).
+    //
+    // `IS_REACT_ACT_ENVIRONMENT` is set for the duration: browser mode does not
+    // set it, and without it React 18 logs "The current testing environment is
+    // not configured to support act(...)" and falls back to a plain call —
+    // which happens to flush here via the `await`, but only incidentally. Set
+    // it, and the flush is the documented contract instead of a coincidence.
+    const priorActEnv = (globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT;
+    (globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true;
+    try {
+      await act(async () => {
+        vi.advanceTimersByTime(300);
+      });
+    } finally {
+      (globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = priorActEnv;
+    }
+
+    // …exactly ONE write, carrying the FINAL value — not one per keystroke, and
+    // not the intermediate 'mat'.
+    const writes = replacedQueries().filter((q) => 'query' in q);
+    expect(writes).toHaveLength(1);
+    expect(writes[0]).toMatchObject({ query: 'matrix' });
   });
 
   test('a `?query=` param seeds the search box and filters the grid', async () => {


### PR DESCRIPTION
## The flake

`src/components/Apps/AppListingsMarketplaceBody.browser.test.tsx` →
`🔴 the search box does NOT write the URL per keystroke — only the debounced value`

Observed intermittently on a loaded CI runner (1 failed / 1258 passed, on a PR
touching none of this code):

```
AssertionError: expected [ { query: 'mat' } ] to have a length of +0 but got 1
  at src/components/Apps/AppListingsMarketplaceBody.browser.test.tsx:221:58
```

## Root cause — a wall-clock race

The component debounces the search box before echoing it to the URL:

```ts
const [debouncedSearch] = useDebouncedValue(searchInput, 300);
```

The test did two awaited `search.fill()` calls and then asserted that **zero**
URL writes had happened yet. That assertion is only true if both fills complete
inside the real 300 ms window — so its truth depended on how fast the machine
happened to be, not on the component. Under load a single `fill()` can exceed
300 ms, the debounce fires *between* the two fills, and a write carrying the
intermediate value (`'mat'`) lands.

## Why the previous mitigation was not enough

The test had already been mitigated once: six fills cut to two, on the stated
reasoning that "two fills is well inside the window on any machine". That
reduced the probability but left the wall-clock dependency completely intact —
and the assumption was duly falsified. Re-tuning the fill count would just
reset the same clock.

## The fix — control the clock instead of racing it

```ts
vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
await search.fill('mat');
await search.fill('matrix');
expect(writes).toHaveLength(0);          // now timing-independent
await act(async () => vi.advanceTimersByTime(300));
expect(writes).toEqual([{ query: 'matrix' }]);
```

With `setTimeout` faked, **no amount of real elapsed time can fire the
debounce** — `advanceTimersByTime(300)` is the only thing that can, so the
zero-writes assertion becomes a statement about the component rather than about
the machine. `toFake` is deliberately scoped to the two timer primitives:
Playwright's real `fill()` interaction and the browser-runner channel still need
real `queueMicrotask`/`requestAnimationFrame`/`Date`/`performance`. An
unconditional `afterEach(() => vi.useRealTimers())` keeps a throw from leaking
the fake clock into the next test.

The trailing assertion also stops being a `vi.waitFor` retry loop — a retried
"expect exactly 1 write" would happily succeed in the window *before* a second,
buggy write landed. It is now a single deterministic check after the flush.

The stale comment block describing the six-fills/two-fills reasoning has been
replaced with one describing what the test actually does now.

### Incidental: a real typing gap

`@types/react` (18.0.x) does not declare `act`; the repo fills that gap with a
global `declare module 'react'` augmentation in
`src/tests/components/TrackView/useTrackEvent.wiring.test.ts` that declares only
the **sync** form, `(callback: () => void) => void`. Against that declaration
`await act(async …)` is `await void`, and TypeScript reports *"'await' has no
effect on the type of this expression"*. Rather than widen an augmentation
another test owns, this aliases the async overload React actually implements, in
this file only.

## Verification

| Check | Result |
|---|---|
| Target file | **12/12 passed** |
| Determinism | **10/10** consecutive runs, all 12/12 |
| Under load | **5/5** at 2× CPU oversubscription — the test took 891 ms (well past 300 ms) and still passed; this is the condition that used to break it |
| Typecheck | no errors in this file (only pre-existing unrelated ones in my env) |
| ESLint / Prettier | clean for this file |
| React `act(...)` warnings | 0 |

**Positive control** — removing `advanceTimersByTime(300)` leaves the write
count at **zero** (`expected [] to have a length of 1 but got +0`), proving the
fake clock is genuinely installed and that real elapsed time can no longer fire
the debounce. Without this control a green run could not distinguish "fake
timers working" from "fills happened to be fast".

**Mutation check** — the guard still has teeth. Rewiring the component's URL-echo
effect to use `searchInput` (per keystroke) instead of `debouncedSearch`:

```
AssertionError: expected [ { query: 'mat' }, …(1) ] to have a length of +0 but got 2
 ❯ src/components/Apps/AppListingsMarketplaceBody.browser.test.tsx:273:58
   Tests  1 failed | 11 passed (12)
```

It fails on **this guard's own** zero-writes assertion, naming the unexpected
writes, and nothing else in the file fails. Mutation fully reverted — the diff
in this PR touches the test file only.
