### PR TITLE
fix(jobs): stop binding the purge grace period as a bigint

### DIFF
--- a/src/server/jobs/__tests__/purge-replaced-files.test.ts
+++ b/src/server/jobs/__tests__/purge-replaced-files.test.ts
@@ -9,9 +9,23 @@ vi.mock('~/utils/s3-utils', () => ({ deleteModelFileObject: mockDeleteObj }));
 vi.mock('~/server/logging/client', () => ({ logToAxiom: () => ({ catch: () => {} }) }));
 vi.mock('~/server/jobs/job', () => ({ createJob: (_n: string, _c: string, fn: unknown) => fn }));
 
-import { processReplacedFiles } from '~/server/jobs/purge-replaced-files';
+import { buildReplacedFilesQuery, processReplacedFiles } from '~/server/jobs/purge-replaced-files';
 
 beforeEach(() => vi.clearAllMocks());
+
+describe('buildReplacedFilesQuery', () => {
+  // Bound as a parameter the day count arrives as int8 and make_interval only takes
+  // int4, so the query fails to resolve the function (42883) on every run.
+  it('inlines the grace period rather than binding it', () => {
+    const query = buildReplacedFilesQuery();
+    expect(query.sql).toContain('make_interval(days => 30)');
+    expect(query.values).toEqual([]);
+  });
+
+  it('skips rows already purged', () => {
+    expect(buildReplacedFilesQuery().sql).toContain('"dataPurged" IS NOT TRUE');
+  });
+});
 
 describe('processReplacedFiles', () => {
   it('purges S3 (refcount-guarded) then marks dataPurged for each row', async () => {

--- a/src/server/jobs/purge-replaced-files.ts
+++ b/src/server/jobs/purge-replaced-files.ts
@@ -1,3 +1,4 @@
+import { Prisma } from '@prisma/client';
 import { dbWrite } from '~/server/db/client';
 import { logToAxiom } from '~/server/logging/client';
 import { deleteModelFileObject } from '~/utils/s3-utils';
@@ -31,19 +32,22 @@ export async function processReplacedFiles(rows: ReplacedRow[]) {
   return { purged, failed };
 }
 
-export const purgeReplacedFilesJob = createJob(
-  'purge-replaced-files',
-  '15 11 * * *',
-  async () => {
-    const rows = await dbWrite.$queryRaw<ReplacedRow[]>`
-      SELECT id, url
-      FROM "ModelFile"
-      WHERE "replacedAt" < now() - make_interval(days => ${GRACE_DAYS})
-        AND "dataPurged" IS NOT TRUE
-    `;
-    if (rows.length === 0) return { status: 'ok' };
-    const { purged, failed } = await processReplacedFiles(rows);
-    logJob({ type: 'info', message: 'finished', data: { purged, failed } });
-    return { status: 'ok' };
-  }
-);
+// The grace period is inlined as a literal: Prisma binds a JS number as int8 and
+// `make_interval` only takes int4, so an interpolated parameter fails to resolve the
+// function (42883) at plan time — the statement throws before any row is examined.
+export function buildReplacedFilesQuery(): Prisma.Sql {
+  return Prisma.sql`
+    SELECT id, url
+    FROM "ModelFile"
+    WHERE "replacedAt" < now() - make_interval(days => ${Prisma.raw(String(GRACE_DAYS))})
+      AND "dataPurged" IS NOT TRUE
+  `;
+}
+
+export const purgeReplacedFilesJob = createJob('purge-replaced-files', '15 11 * * *', async () => {
+  const rows = await dbWrite.$queryRaw<ReplacedRow[]>(buildReplacedFilesQuery());
+  if (rows.length === 0) return { status: 'ok' };
+  const { purged, failed } = await processReplacedFiles(rows);
+  logJob({ type: 'info', message: 'finished', data: { purged, failed } });
+  return { status: 'ok' };
+});


### PR DESCRIPTION
Fixes [CU-868kmpvw2](https://app.clickup.com/t/8459928/868kmpvw2).

## The bug

`purge-replaced-files` throws on **every** run in production:

```
Raw query failed. Code: `42883`.
ERROR: function make_interval(days => bigint) does not exist
HINT: No function matches the given name and argument types. You might need to add explicit type casts.
```

Prisma binds a JS number as `int8`, and `make_interval`'s `days` argument is an `int4`. There is no implicit `int8 -> int4` resolution, so the function fails to resolve at **plan time** — the statement errors before a single row is examined. An empty candidate set does not spare it.

Confirmed from the prod jobs pod (`civitai-dp-prod-jobs-7c74d49556-5gsjk`) as a `P2010` wrapping `42883`, bottoming out in `prisma.$queryRaw()`.

## Impact

128 `ModelFile` rows carry a `replacedAt`; **zero** have ever been purged. They all land between 2026-07-08 and 2026-07-09, so with a 30-day grace period the first of them crosses the boundary around **2026-08-07** — at which point real purges start being silently skipped and replaced-file data stops being cleaned out of storage.

## The fix

Inline the day count as a literal instead of binding it. `GRACE_DAYS` is a module-level integer constant, so `Prisma.raw` carries no injection risk. Same shape as `fd54a5e919`, which fixed the three identical sites in `minor-hash.service.ts`.

The statement is extracted into `buildReplacedFilesQuery()` so it can actually be asserted on — the existing test only covered `processReplacedFiles` and never touched the query.

## `reemit-bitdex-ops` is a false positive — left untouched

The task listed `reemit-bitdex-ops.ts:78,80` as broken the same way. It is not. `make_interval`'s signature is:

```
make_interval(years int, months int, weeks int, days int, hours int, mins int, secs double precision)
```

`secs` is **double precision**, not `int4`, and `int8 -> float8` *is* an implicit cast. Verified both directions against PostgreSQL 16:

```sql
PREPARE d(int8) AS SELECT now() - make_interval(days => $1);  -- ERROR 42883
PREPARE r(int8) AS SELECT now() - make_interval(secs => $1);  -- OK, returns a row
```

So the bound parameters at lines 78/80 resolve fine and that job has never been throwing for this reason. I reverted the changes I had made there rather than churn a working query and drop its parameterization for no benefit. If `reemit-bitdex-ops` turns out to be failing in prod, it is a different cause and wants its own investigation.

## Why CI never caught it

The `minor-hash` sibling test asserted only the SQL *text*, which stays green whether or not the query runs. Same class of gap here — there was no query-level test at all. The new test pins the specific regression: the day count must appear **inlined** in `query.sql`, and `query.values` must be empty.

## Verification

- `pnpm vitest run src/server/jobs/__tests__/purge-replaced-files.test.ts src/server/jobs/__tests__/reemit-bitdex-ops.test.ts` — **20 passed** (4 + 16), both files collected non-zero.
- SQL behavior confirmed against a real PostgreSQL 16 instance (bound-vs-inlined, both `days` and `secs`, as above).
- Inlined `make_interval(days => 30)` returns a cutoff of 2026-07-06, matching the expected grace boundary.

## Post-merge

Run the job once via the `run-jobs` webhook and confirm a non-error result, then check that the eligible rows actually purge:

```sql
SELECT count(*) FILTER (WHERE "dataPurged" IS TRUE)     AS purged,
       count(*) FILTER (WHERE "dataPurged" IS NOT TRUE) AS not_purged
FROM "ModelFile" WHERE "replacedAt" IS NOT NULL;
```

Worth doing before 2026-08-07, when the first rows become eligible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
