### PR TITLE
docs(app-blocks,ci): record the owns-nothing analytics decision, and correct a stale flake claim

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -187,8 +187,14 @@ jobs:
     runs-on: ubuntu-latest
     # ~8,000 tests that until now only ran on whoever remembered to run them.
     # Node env, no browser — component tests (`*.browser.test.tsx`) are not here
-    # on purpose: they need Chromium and carry the cold-optimizeDeps flake
-    # documented at vitest.config.mts:98-124.
+    # on purpose: they need Chromium, which this job does not install. That is
+    # the whole reason. This comment used to add "and carry the cold-optimizeDeps
+    # flake documented at vitest.config.mts:98-124", which was wrong: those lines
+    # document the FIX for that flake, not an open one. vitest.config.mts:109-127
+    # dedupes React and pre-bundles `vitest-browser-react` + the JSX runtimes so
+    # the optimize pass happens BEFORE the run instead of reloading mid-run, and
+    # calls itself the canonical fix; 98-102 is a separate hookTimeout fix.
+    # Don't cite a cold-cache flake as a reason to keep this job Chromium-free.
     #
     # REPORT-ONLY to start, deliberately. A full local run passed 8,937/8,943 but
     # timed out 5 tests under machine load; every one of them passed in isolation

--- a/src/server/services/blocks/__tests__/app-analytics.service.test.ts
+++ b/src/server/services/blocks/__tests__/app-analytics.service.test.ts
@@ -249,6 +249,27 @@ describe('getMyAppAnalytics (ownership enforcement)', () => {
     expect(result.installs.total).toBe(0);
     expect(mockDbRead.blockSpendAttribution.aggregate).not.toHaveBeenCalled();
   });
+
+  // The RECORDED DECISION, pinned at the service boundary so it cannot drift
+  // back: owning no apps is a truthful measured zero, so the payload carries no
+  // `unavailable` discriminator. `notEntitled` / `notOwned` mean "we never ran
+  // the query"; this path skips the aggregates only because their answer over
+  // an empty owned set is already known to be zero. The sibling case lives in
+  // `emptyAnalytics` above — this one pins that getMyAppAnalytics actually
+  // reaches it, which the helper tests cannot show.
+  it('does NOT flag the owns-nothing payload as unavailable', async () => {
+    mockDbRead.appBlock.findMany.mockResolvedValue([]);
+
+    const result = await getMyAppAnalytics({ userId: OWNER_ID });
+
+    expect(result.unavailable).toBeUndefined();
+    expect('unavailable' in result).toBe(false);
+    // `views` has its own flag and tracks the payload's (#3613), so it stays
+    // unflagged here too — an author who owns nothing has genuinely had zero
+    // impressions, not unmeasurable ones.
+    expect(result.views.unavailable).toBeUndefined();
+    expect('unavailable' in result.views).toBe(false);
+  });
 });
 
 describe('emptyAnalytics (measurement vs placeholder discriminator)', () => {

--- a/src/server/services/blocks/app-analytics.service.ts
+++ b/src/server/services/blocks/app-analytics.service.ts
@@ -45,6 +45,36 @@ export type AppAnalytics = {
    * even when every counter is 0 — without this a real "no activity yet" app
    * and a never-queried one are byte-identical, and a client renders fabricated
    * zeros as data.
+   *
+   * DECIDED — a caller who owns NO apps is deliberately NOT flagged, and
+   * "ownsNothing" is deliberately not a third value. (Raised twice in review as
+   * "defensible but wants a recorded decision"; this is that record.)
+   *
+   * The discriminator's test is whether the zeros were MEASURED, not whether
+   * they are interesting. `notEntitled` and `notOwned` are both cases where we
+   * ran no aggregate at all, so their zeros are fabricated. Owning nothing is
+   * not that case: an aggregate over an empty owned set genuinely IS zero, so
+   * `getMyAppAnalytics` short-circuits only because the answer is already
+   * knowable — "you have no apps, so you have no installs" is a true statement
+   * about the world, and it is one the caller can already see without a flag.
+   * Flagging it would put every honest new author behind an `unavailable`
+   * branch on their first visit and teach clients to skip the flag that exists
+   * to stop them believing a fabricated zero.
+   *
+   * PRECEDENT — #3581 settled the shape of this answer for the sibling
+   * `getMyRevenue`: ONE value, not two, because `getRevenueForOwner` never
+   * *computes* ownership (it scopes by `appOwnerUserId` in the WHERE clause),
+   * so a not-owned request there returns a truthful zero-row aggregate and
+   * `notOwned` is unproducible — declaring it would force an unreachable branch
+   * into every renderer. Analytics DOES compute ownership up front, which is
+   * why it has the second value revenue cannot have; the rule ("flag only what
+   * was never measured") is identical, and it is what holds this union at two.
+   *
+   * SETTLED BY IMPLEMENTATION — #3613 applied the same rule one level down:
+   * `views` carries its own flag and tracks this one, so the owns-nothing path
+   * leaves views unflagged (`emptyViews()`, never `unavailableViews()`), with a
+   * test pinning it. A third value here would have to move that section and
+   * every renderer branch with it.
    */
   unavailable?: 'notEntitled' | 'notOwned';
   installs: {
@@ -200,8 +230,11 @@ export async function getMyAppAnalytics({
   if (appBlockId && ownedIds.length === 0) {
     return emptyAnalytics(range, true);
   }
-  // The caller owns nothing — nothing to report (but not "notOwned", since
-  // they didn't ask for a specific foreign id).
+  // The caller owns nothing — nothing to report, and deliberately NOT flagged
+  // `unavailable`: they didn't ask for a specific foreign id, and an aggregate
+  // over an empty owned set is a truthful measured zero rather than a
+  // placeholder. See the DECIDED note on the `unavailable` field before
+  // "fixing" this into a third discriminator value.
   if (ownedIds.length === 0) {
     return emptyAnalytics(range, false);
   }


### PR DESCRIPTION
Two comments asserted something the code does not do. No behaviour change — one added test, one corrected CI comment.

## 1. Record the owns-nothing analytics decision (follow-up #3)

`getMyAppAnalytics` returns an **unflagged** all-zero payload when the caller owns no apps, while a caller who requests an app they do not own gets `unavailable: 'notOwned'`. Two reviewers flagged that asymmetry as "defensible but wants a recorded decision"; it was still unrecorded.

Verified against current `main` before writing it down:

- `app-analytics.service.ts` — the owns-nothing branch is `return emptyAnalytics(range, false)`, and `emptyAnalytics`'s `unavailable` default is `notOwned ? 'notOwned' : undefined`, so the key is genuinely absent (spread as `...(unavailable ? { unavailable } : {})`). **Confirmed unflagged today.**
- The views test added by #3613 — `leaves views UNflagged when the payload is a genuine zero` — asserts `views.unavailable` is undefined, `'unavailable' in views` is false, and `views` deep-equals `{ count: 0, uniqueViewers: 0, anonCount: 0 }`. **Confirmed it asserts what the follow-up claims.**
- #3581's mechanism — `getRevenueForOwner` scopes by `appOwnerUserId` in the WHERE clause and never computes ownership, so a not-owned request is a zero-row aggregate and `notOwned` is unproducible. **Confirmed** in both the implementation and the recorded note above `RevenueUnavailableReason`.

The reasoning is now written at the `unavailable` field, where a reader of the contract will hit it, with a one-line pointer at the branch itself so someone about to "fix" it sees it first. The rule: **flag only what was never measured**. `notEntitled` and `notOwned` ran no aggregate, so their zeros are fabricated; an aggregate over an empty owned set genuinely *is* zero, so the short-circuit only skips work whose answer is already known.

### One correction to the framing

The #3613 views test is a unit test on the **`emptyAnalytics` helper**, not on the owns-nothing path through `getMyAppAnalytics`. Checking the existing coverage: **every** `unavailable` assertion in the suite is against the helper, and the one owns-nothing test that goes through `getMyAppAnalytics` asserts only `notOwned === false` and `installs.total`. So nothing pinned that the service branch actually reaches the unflagged helper call — the gap was real, and the new test closes it rather than restating the implementation.

### Mutation results

Both mutations restored byte-identically, `sha256sum`-verified, `git status` clean.

| Mutation | Result |
| --- | --- |
| owns-nothing branch to `emptyAnalytics(range, false, 'notOwned')` | **KILLED**, and *only* by the new test: `expected 'notOwned' to be undefined`. 1 failed / 25 passed — no pre-existing test caught it. |
| `emptyAnalytics` to `views: unavailableViews()` unconditionally | **KILLED** by the new test's views assertion (`expected true to be undefined`), alongside the existing #3613 helper test. 2 failed / 24 passed. |

## 2. Correct a stale CI comment

`.github/workflows/lint.yml` said component tests are excluded because they *"need Chromium and carry the cold-optimizeDeps flake documented at vitest.config.mts:98-124."*

Read the cited lines: they document the **fix**, not an open flake. Quoting `vitest.config.mts`:

> `// optimizeDeps cache (fresh CI runs). Canonical fix; protects every` / `// component test from this class of dual-React crash.` (109-113)

> `// Pre-bundling them here makes the optimize pass happen BEFORE the run starts, so there's no mid-run reload.` (115-127)

The cited range is also off by a block: **98-102** is a separate `hookTimeout: 60000` fix for cold `await import()` in `beforeAll`/`beforeEach` — a different problem, and also a fix. The optimizeDeps narrative is at **109-127**.

The Chromium half is true and stays — this job installs no browser. Comment-only; no job, trigger or step changes.

## Why one PR

Both items are the same defect class: a comment claiming something the code contradicts. Neither changes behaviour. Splitting them would mean two review threads for two comment corrections.

## Verification

- `vitest run --project unit src/server/services/blocks/__tests__ src/server/routers/__tests__` — **140 files, 3113 tests, 0 failed** (counted, not read off an exit code; no timeout panic).
- Typecheck: **0 errors** under `NODE_OPTIONS=--max_old_space_size=8192`. Positive control: appending `const x: number = "not a number"` to the changed service produced exactly **1** `error TS`, so the run was genuinely typechecking rather than OOM-ing to a silent zero.
- Prettier: clean on all three changed files. Positive control: purpose-built badly-formatted `.yml` and `.ts` files were both correctly reported as violations (the file #3613 used as a control no longer violates), so the YAML parser is engaged for the workflow change too.
- Component tier not run — no component code changed, and this host is single-file-only on a non-canonical browser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aj1HosDFkP6LgxMAtJdDmJ
