### PR TITLE
feat(app-blocks): accept an inline ComfyUI graph on the customComfy bridge

### DIFF
--- a/src/server/routers/__tests__/blocks.router.workflow.test.ts
+++ b/src/server/routers/__tests__/blocks.router.workflow.test.ts
@@ -42,6 +42,8 @@ const {
   mockLogToAxiom,
   mockSysRedis,
   mockResolveCanGenerateForVersions,
+  mockGetResourceData,
+  mockGetHighestTierSubscription,
   mockRecordSpendAttribution,
   mockDbWriteUserFindUnique,
 } = vi.hoisted(() => ({
@@ -129,6 +131,10 @@ const {
   // out of the test and we can drive canGenerate per-test. Default = a Map
   // saying the version IS generatable; FORBIDDEN tests override to false / miss.
   mockResolveCanGenerateForVersions: vi.fn(),
+  // The customComfy INLINE arm's entitlement belt calls these two directly.
+  // Stubbed as the belt's DATA SOURCE only — the belt itself runs for real.
+  mockGetResourceData: vi.fn(),
+  mockGetHighestTierSubscription: vi.fn(),
   // W3 flow A — the spend-attribution write the submit path fires
   // best-effort after a resolved submit. Mocked at the module boundary so
   // the test asserts exact (server-derived) args + that a throw here never
@@ -434,8 +440,19 @@ vi.mock('~/server/services/buzz.service', () => ({
 vi.mock('~/server/utils/block-catalog-rate-limit', () => ({
   checkBlockCatalogRateLimit: (...args: unknown[]) => mockCheckBlockCatalogRateLimit(...args),
 }));
+// 🔴 `getResourceData` IS HERE ON PURPOSE, AND IS NOT MOCKED AWAY AT THE SERVICE
+// BOUNDARY. The customComfy INLINE arm's entitlement belt
+// (`services/blocks/inline-comfy.service`) is deliberately left REAL in this
+// suite, with only its data source stubbed. Mocking the belt itself would reduce
+// every inline test below to "the router called a function I replaced", which is
+// exactly the seam a per-component test cannot see: the belt can be perfectly
+// correct in isolation and simply not wired in.
 vi.mock('~/server/services/generation/generation.service', () => ({
   resolveCanGenerateForVersions: (...args: unknown[]) => mockResolveCanGenerateForVersions(...args),
+  getResourceData: (...args: unknown[]) => mockGetResourceData(...args),
+}));
+vi.mock('~/server/services/subscriptions.service', () => ({
+  getHighestTierSubscription: (...args: unknown[]) => mockGetHighestTierSubscription(...args),
 }));
 vi.mock('~/server/logging/client', () => ({
   logToAxiom: (...args: unknown[]) => mockLogToAxiom(...args),
@@ -617,6 +634,8 @@ beforeEach(() => {
     mockSysRedis.expire,
     mockSysRedis.ttl,
     mockResolveCanGenerateForVersions,
+    mockGetResourceData,
+    mockGetHighestTierSubscription,
     mockRecordSpendAttribution,
     mockDbWriteUserFindUnique,
     mockIsAppBlocksAuthorEnabled,
@@ -6154,6 +6173,241 @@ describe('customComfy bridge (submit/estimate/settle)', () => {
         workflowId: 'wf_cc_1',
         actualCost: 12,
       });
+    });
+  });
+
+  // ───────────────────────────────────────────────────────────────────────────
+  // 🔴 THE INLINE ARM, AT THE ROUTER SEAM.
+  //
+  // `inline-comfy.service.test.ts` proves the belt is CORRECT. These prove it is
+  // WIRED — a distinction that matters, because a belt can be hermetically
+  // tested, mutation-swept and audit-clean and simply never called. The belt runs
+  // FOR REAL here (only `getResourceData` / `getHighestTierSubscription` are
+  // stubbed), so a router that forgot to call it fails these.
+  //
+  // The other half is the money path: an inline body must be bounded by the SAME
+  // belt the recipe arm uses, with `maxBuzz` as the ceiling.
+  // ───────────────────────────────────────────────────────────────────────────
+  describe('INLINE arm (mode: inline)', () => {
+    const INLINE_LORA_AIR = 'urn:air:sdxl:lora:civitai:118025@136251';
+
+    function inlineBody(over: Record<string, unknown> = {}) {
+      return {
+        kind: 'customComfy' as const,
+        mode: 'inline' as const,
+        workflow: {
+          '1': { class_type: 'CheckpointLoaderSimple', inputs: { ckpt_name: 'sd_xl.safetensors' } },
+          '2': { class_type: 'CLIPTextEncode', inputs: { text: 'a serene lake', clip: ['1', 1] } },
+        },
+        resources: [],
+        maxBuzz: 60,
+        ...over,
+      };
+    }
+
+    function happyInline() {
+      happyUser();
+      mockGetResourceData.mockResolvedValue([
+        { id: 136251, name: 'a lora', canGenerate: true, availability: 'Public' },
+      ]);
+      mockGetHighestTierSubscription.mockResolvedValue(null);
+      happySubmit();
+    }
+
+    it('estimate quotes the declared maxBuzz as the ceiling, with no orchestrator round-trip', async () => {
+      mockVerifyBlockToken.mockResolvedValue(ccPageClaims());
+      happyUser();
+      const result = await caller().estimateWorkflow({
+        blockToken: 'tok',
+        body: inlineBody({ maxBuzz: 77 }),
+      });
+      expect(result.snapshot).toMatchObject({ status: 'pending', cost: { total: 77 } });
+      expect(mockSubmitWorkflow).not.toHaveBeenCalled();
+    });
+
+    it('happy path: reserves the declared maxBuzz as the CEILING and stamps it as the step timeout', async () => {
+      mockVerifyBlockToken.mockResolvedValue(ccPageClaims());
+      happyInline();
+      await caller().submitWorkflow({ blockToken: 'tok', body: inlineBody({ maxBuzz: 90 }) });
+      // The whole post-paid spend belt is REUSED — same per-app reservation call
+      // the recipe arm makes, with the declared ceiling.
+      expect(mockReserveAppSpend).toHaveBeenCalledWith('apb_test', 90);
+      const step = mockSubmitWorkflow.mock.calls[0][0].body.steps[0];
+      expect(step.$type).toBe('customComfy');
+      // maxBuzz === stepTimeoutSeconds, BY CONSTRUCTION: 90s → '00:01:30'.
+      expect(step.timeout).toBe('00:01:30');
+    });
+
+    it('🔴 the emitted step input carries ONLY resources/trace/workflow — the body is never spread', async () => {
+      // If the router ever spreads the app's body into the step input, an app
+      // gets `sessionOwnerApiToken` (a Civitai API token forwarded to the
+      // claiming worker) and `comfyImage` (an arbitrary container). The wire
+      // schema's `.strict()` is the first belt; this is the second.
+      mockVerifyBlockToken.mockResolvedValue(ccPageClaims());
+      happyInline();
+      await caller().submitWorkflow({ blockToken: 'tok', body: inlineBody() });
+      const input = mockSubmitWorkflow.mock.calls[0][0].body.steps[0].input;
+      expect(Object.keys(input).sort()).toEqual(['resources', 'trace', 'workflow']);
+      expect(input.trace).toBe('binary');
+    });
+
+    it('🔴 GATE 1 IS WIRED: an undeclared AIR in the graph is rejected, with NO reserve and NO submit', async () => {
+      mockVerifyBlockToken.mockResolvedValue(ccPageClaims());
+      happyInline();
+      await expect(
+        caller().submitWorkflow({
+          blockToken: 'tok',
+          body: inlineBody({
+            workflow: {
+              '1': { class_type: 'LoraLoader', inputs: { lora_name: INLINE_LORA_AIR } },
+            },
+            resources: [],
+          }),
+        })
+      ).rejects.toThrow(/not declared in resources/);
+      expect(mockReserveAppSpend).not.toHaveBeenCalled();
+      expect(mockSubmitWorkflow).not.toHaveBeenCalled();
+    });
+
+    it('🔴 GATE 1 IS WIRED: entitlement runs over the app-supplied resources — a non-generatable version is FORBIDDEN', async () => {
+      mockVerifyBlockToken.mockResolvedValue(ccPageClaims());
+      happyInline();
+      mockGetResourceData.mockResolvedValue([
+        { id: 136251, name: 'a lora', canGenerate: false, availability: 'Public' },
+      ]);
+      await expect(
+        caller().submitWorkflow({
+          blockToken: 'tok',
+          body: inlineBody({ resources: [INLINE_LORA_AIR] }),
+        })
+      ).rejects.toMatchObject({ code: 'FORBIDDEN' });
+      // The REAL belt ran, with the version id parsed out of the app's AIR.
+      expect(mockGetResourceData).toHaveBeenCalledWith([136251], expect.anything());
+      expect(mockReserveAppSpend).not.toHaveBeenCalled();
+      expect(mockSubmitWorkflow).not.toHaveBeenCalled();
+    });
+
+    // 🔴 THE PRIVATE-SUBSCRIPTION BRANCH IS NOT REACHABLE AT THIS SEAM TODAY, AND
+    // THAT IS RECORDED RATHER THAN FORCED. App Blocks is moderator-only
+    // pre-GA (`assertViewerIsModerator` — see the "NON-MOD token → 401" tests
+    // above), so every viewer who can reach a submit is a moderator; and the
+    // belt deliberately exempts moderators from the subscription requirement,
+    // matching the onsite belt it is ported from. A router-level test for it
+    // would therefore be green for the wrong reason (the mod exemption), not
+    // because the gate fired. It IS exercised, over both a subscriber and a
+    // non-subscriber, in `inline-comfy.service.test.ts`.
+    //
+    // This becomes reachable the moment App Blocks opens past mod-only; add the
+    // router-level case then, with a non-moderator subject.
+    it('the belt exempts a MODERATOR from the Private subscription requirement (the live path)', async () => {
+      mockVerifyBlockToken.mockResolvedValue(ccPageClaims());
+      happyInline();
+      mockGetResourceData.mockResolvedValue([
+        { id: 136251, name: 'a lora', canGenerate: true, availability: 'Private' },
+      ]);
+      mockGetHighestTierSubscription.mockResolvedValue(null);
+      await caller().submitWorkflow({
+        blockToken: 'tok',
+        body: inlineBody({ resources: [INLINE_LORA_AIR] }),
+      });
+      expect(mockSubmitWorkflow).toHaveBeenCalled();
+      // The exemption is what made it pass — the subscription was never queried.
+      expect(mockGetHighestTierSubscription).not.toHaveBeenCalled();
+    });
+
+    it('🔴 GATE 1 IS WIRED: a nodepack URN is rejected (arbitrary code execution, gated off)', async () => {
+      mockVerifyBlockToken.mockResolvedValue(ccPageClaims());
+      happyInline();
+      await expect(
+        caller().submitWorkflow({
+          blockToken: 'tok',
+          body: inlineBody({
+            resources: ['urn:air:comfy:nodepack:comfyregistry:kijai/comfyui-kjnodes@1.4.0'],
+          }),
+        })
+      ).rejects.toThrow(/nodepack resources are not permitted/);
+      expect(mockSubmitWorkflow).not.toHaveBeenCalled();
+    });
+
+    it('🔴 GATE 2 IS WIRED: the audited text is the SWEPT GRAPH, not the declared prompt', async () => {
+      // The failure this pins is silent: audit the declared field only, and an
+      // inline graph's real prompt is never moderated while every gate stays
+      // green. Assert the audit was handed the graph's leaf text.
+      mockVerifyBlockToken.mockResolvedValue(ccPageClaims());
+      happyInline();
+      await caller().submitWorkflow({
+        blockToken: 'tok',
+        body: inlineBody({
+          prompt: 'a clean declared prompt',
+          workflow: {
+            '2': { class_type: 'CLIPTextEncode', inputs: { text: 'GRAPH_PROMPT_XYZ' } },
+          },
+        }),
+      });
+      expect(mockAuditPromptServer).toHaveBeenCalledTimes(1);
+      const audited = mockAuditPromptServer.mock.calls[0][0].prompt as string;
+      expect(audited).toContain('GRAPH_PROMPT_XYZ');
+      expect(audited).toContain('a clean declared prompt');
+    });
+
+    it('🔴 GATE 2 IS WIRED: a flagged GRAPH prompt blocks the submit even when the declared prompt is clean', async () => {
+      mockVerifyBlockToken.mockResolvedValue(ccPageClaims());
+      happyInline();
+      mockAuditPromptServer.mockRejectedValueOnce(
+        new TRPCError({ code: 'BAD_REQUEST', message: 'Your prompt was flagged' })
+      );
+      await expect(
+        caller().submitWorkflow({
+          blockToken: 'tok',
+          body: inlineBody({
+            prompt: 'a clean declared prompt',
+            workflow: { '2': { class_type: 'CLIPTextEncode', inputs: { text: 'bad' } } },
+          }),
+        })
+      ).rejects.toThrow(/flagged/);
+      expect(mockReserveAppSpend).not.toHaveBeenCalled();
+      expect(mockSubmitWorkflow).not.toHaveBeenCalled();
+    });
+
+    it('the static budget gate still bounds an inline body against the token budget', async () => {
+      mockVerifyBlockToken.mockResolvedValue(ccPageClaims({ buzzBudget: 50 }));
+      happyInline();
+      const result = await caller().submitWorkflow({
+        blockToken: 'tok',
+        body: inlineBody({ maxBuzz: 200 }),
+      });
+      expect(result.snapshot.status).toBe('failed');
+      expect(result.snapshot.error).toMatch(/insufficient buzz budget/);
+      expect(mockSubmitWorkflow).not.toHaveBeenCalled();
+    });
+
+    it('the settle record carries the constant inline labels, not an app-derived one', async () => {
+      mockVerifyBlockToken.mockResolvedValue(ccPageClaims());
+      happyInline();
+      await caller().submitWorkflow({ blockToken: 'tok', body: inlineBody({ maxBuzz: 42 }) });
+      expect(mockPersistCustomComfySettle).toHaveBeenCalledWith(
+        expect.objectContaining({ ceiling: 42, engine: 'inline', recipe: '__inline__' })
+      );
+    });
+
+    it('an inline body is still PAGE-ONLY and still developer-gated', async () => {
+      mockVerifyBlockToken.mockResolvedValue(validClaims()); // model token
+      happyInline();
+      await expect(
+        caller().submitWorkflow({ blockToken: 'tok', body: inlineBody() })
+      ).rejects.toMatchObject({ code: 'FORBIDDEN' });
+      expect(mockSubmitWorkflow).not.toHaveBeenCalled();
+    });
+
+    it('REGRESSION: the RECIPE arm is unaffected — it still runs the recipe entitlement gate', async () => {
+      // The inline belt must not have displaced the recipe path's own gate.
+      mockVerifyBlockToken.mockResolvedValue(ccPageClaims());
+      happyCcResources();
+      happySubmit();
+      await caller().submitWorkflow({ blockToken: 'tok', body: ccBody() });
+      expect(mockResolveCanGenerateForVersions).toHaveBeenCalled();
+      // …and the inline belt was NOT consulted for a recipe body.
+      expect(mockGetResourceData).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/server/routers/__tests__/blocks.router.workflow.test.ts
+++ b/src/server/routers/__tests__/blocks.router.workflow.test.ts
@@ -6409,6 +6409,76 @@ describe('customComfy bridge (submit/estimate/settle)', () => {
       // …and the inline belt was NOT consulted for a recipe body.
       expect(mockGetResourceData).not.toHaveBeenCalled();
     });
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // 🔴 ARM ROUTING — the recipe arm has THREE legal spellings, not one.
+    //
+    // `blockCustomComfyBodySchema` declares `mode: z.literal('recipe').optional()`,
+    // so `{…, mode:'recipe', …}` and `{…, mode:undefined, …}` are BOTH valid
+    // recipe bodies, and both leave `mode` as an OWN KEY on the parsed object the
+    // router receives (measured against the repo's zod, not assumed — the parse
+    // output own-keys are `kind,mode,params,recipe` for both). A router that
+    // narrowed on PRESENCE (`'mode' in body`) therefore sent a valid RECIPE body
+    // down the INLINE path: submit died in the graph walk (no `workflow` field →
+    // a 500 on the block's submit) and estimate silently returned
+    // `cost:{total: undefined}` instead of the recipe's estimate. `undefined`
+    // survives the wire (superjson), so an SDK spreading an optional `mode`
+    // variable reaches this — it is not a hand-crafted body.
+    //
+    // Each case below asserts the RECIPE path was taken by something only the
+    // recipe path produces (the recipe's own estimate; the recipe entitlement
+    // gate + a reserve), never by the absence of an error.
+    // ─────────────────────────────────────────────────────────────────────────
+    describe("🔴 recipe-arm routing — an explicit `mode` must NOT reach the inline path", () => {
+      // The three legal recipe spellings, exercised identically. `no mode` is the
+      // control: it was already covered and must stay green.
+      const RECIPE_SPELLINGS: Array<[string, Record<string, unknown>]> = [
+        ['no `mode` key (every deployed body)', {}],
+        ["explicit `mode:'recipe'`", { mode: 'recipe' }],
+        ['`mode: undefined` (an SDK spreading an unset optional)', { mode: undefined }],
+      ];
+
+      for (const [label, modeSpelling] of RECIPE_SPELLINGS) {
+        it(`estimate — ${label} quotes the RECIPE estimate, not an inline ceiling`, async () => {
+          mockVerifyBlockToken.mockResolvedValue(ccPageClaims());
+          happyUser();
+          const result = await caller().estimateWorkflow({
+            blockToken: 'tok',
+            body: ccBody(modeSpelling),
+          });
+          // 20 = the zimage-turbo DISPLAY estimate. The inline path would have
+          // read `body.maxBuzz` — absent on a recipe body — and quoted
+          // `{ total: undefined }`, so this is the recipe branch's own output.
+          expect(result.snapshot.cost).toEqual({ total: 20 });
+          expect(typeof result.snapshot.cost.total).toBe('number');
+        });
+
+        it(`submit — ${label} runs the RECIPE gates and reserves normally`, async () => {
+          mockVerifyBlockToken.mockResolvedValue(ccPageClaims());
+          happyCcResources();
+          happySubmit();
+          await caller().submitWorkflow({ blockToken: 'tok', body: ccBody(modeSpelling) });
+          // Recipe path: the recipe entitlement gate ran over the recipe's pinned
+          // versions, and the inline entitlement belt was never consulted.
+          expect(mockResolveCanGenerateForVersions).toHaveBeenCalled();
+          expect(mockGetResourceData).not.toHaveBeenCalled();
+          // …and the spend belt reserved the RECIPE's per-engine CEILING (90 for
+          // zimage-turbo). The inline path reserves the body's declared `maxBuzz`,
+          // which a recipe body does not carry — it could never produce 90.
+          expect(mockReserveAppSpend).toHaveBeenCalledWith('apb_test', 90);
+          // The recipe path stamps the NAMED recipe + its engine on the settle
+          // record; the inline path stamps the constants `__inline__` / `inline`.
+          // This is the tell the inline branch cannot fake.
+          expect(mockPersistCustomComfySettle).toHaveBeenCalledWith(
+            expect.objectContaining({
+              ceiling: 90,
+              engine: 'zimage-turbo',
+              recipe: 'seamless-pano-360',
+            })
+          );
+        });
+      }
+    });
   });
 });
 

--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -6161,13 +6161,25 @@ type CustomComfyRecipeBody = Exclude<CustomComfyBody, CustomComfyInlineBody>;
 /**
  * Narrow a `customComfy` body to its INLINE arm, or `null` for the recipe arm.
  *
- * Keyed on the PRESENCE of `mode` rather than its value: the recipe arm has no
- * `mode` property at all, so `body.mode` is not a legal read across the union and
- * `'mode' in body` is what actually narrows. The schema's `mode: z.literal('inline')`
- * means presence and value are the same test at runtime.
+ * 🔴 KEYED ON THE VALUE, NOT ON PRESENCE — `'mode' in body` IS WRONG HERE, AND
+ * THE DIFFERENCE IS A 500. The recipe arm declares `mode: z.literal('recipe')
+ * .optional()` (see `blockCustomComfyBodySchema`), so it is NOT a mode-less arm:
+ * `mode` is a legal read across the union, and THREE bodies parse as recipes —
+ * `{kind,recipe,params}` (no key), `{…, mode:'recipe', …}` and
+ * `{…, mode:undefined, …}`. The latter two set `mode` as an OWN key, so a
+ * presence test routes a valid RECIPE body down the inline path: submit then
+ * dies in the graph walk (the inline body's `workflow` is absent) and estimate
+ * silently quotes `cost.total: undefined` instead of the recipe's estimate.
+ * `undefined` survives the wire (superjson), so an SDK spreading an optional
+ * `mode` variable reaches this. Pinned by the `mode:'recipe'` / `mode:undefined`
+ * routing tests in `blocks.router.workflow.test.ts`.
+ *
+ * The `.optional()` on the recipe arm is itself load-bearing and cannot be
+ * dropped — see the union comment in `schema/blocks/workflow.schema.ts` for why
+ * `.default('recipe')` rejects every deployed body.
  */
 function isInlineComfyBody(body: CustomComfyBody): body is CustomComfyInlineBody {
-  return 'mode' in body;
+  return body.mode === 'inline';
 }
 
 /**

--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -136,6 +136,11 @@ import {
   snapshotFromWorkflow,
   WORKFLOW_METADATA_MODEL_SUBSTITUTIONS_KEY,
 } from '~/server/services/blocks/workflow.service';
+import {
+  assertInlineGraphAirsDeclared,
+  assertViewerEntitledToInlineResources,
+  collectInlineAuditText,
+} from '~/server/services/blocks/inline-comfy.service';
 // App Blocks customComfy bridge (v1). The recipe registry is the code-reviewed
 // trust root; the schema already gated `recipe` to a registered id, so `getRecipe`
 // never returns undefined for a schema-valid body (defensively re-checked).
@@ -458,12 +463,30 @@ function resolveBlockMaturity(claims: { maxBrowsingLevel?: number }): {
 //
 // SCOPE — what this gate does NOT cover: early-access `hasAccess` and the
 // availability=Private subscription requirement are NOT checked here.
-// `resolveCanGenerateForVersions` deliberately omits both. They are enforced
-// downstream by the orchestrator resource belt in `getGenerationResourceData`
-// (server/services/orchestrator/common.ts): `getResourceData` folds
-// `canGenerate = hasAccess && canGenerate` and the Private-resource path
-// throws without an active subscription — and BOTH the whatIf (estimate) and
-// the real (submit) steps run through that belt BEFORE any Buzz reservation.
+// `resolveCanGenerateForVersions` deliberately omits both.
+//
+// 🔴 NAMES CORRECTED. This paragraph used to point at "the orchestrator resource
+// belt in `getGenerationResourceData` (server/services/orchestrator/common.ts)".
+// MEASURED: that file does not exist and that function does not exist anywhere
+// in `src` — the name appeared only in this comment and two copies of it. The
+// belt IS real, so the instruction below still stands; only the address was
+// wrong, and a wrong address on a "DO NOT remove that belt" note is how a
+// maintainer concludes there is no belt to preserve.
+//
+// The belt, by its real names: `validateAndEnrichResources`
+// (server/services/orchestrator/orchestration-new.service) calls
+// `getResourceData` (server/services/generation/generation.service), which folds
+// `applyPaidAccessGating` internally — and that sets
+// `canGenerate = hasAccess && canGenerate` — then throws without an active
+// subscription for a Private/epoch resource. BOTH the whatIf (estimate) and the
+// real (submit) steps run through it BEFORE any Buzz reservation.
+//
+// 🔴 THAT BELT IS ON THE GENERATION-GRAPH PATH ONLY. It runs for `textToImage`,
+// which is what this gate serves. It does NOT run for a raw `customComfy` step,
+// whose `resources` AIR array goes to the orchestrator directly — see
+// `services/blocks/inline-comfy.service`, which is the equivalent belt for the
+// inline arm, and `services/blocks/recipes/index.ts` for the recipe arm.
+//
 // DO NOT remove that belt assuming this pre-spend gate already covers
 // early-access / Private — it does not.
 //
@@ -6130,6 +6153,34 @@ async function getBlockSessionUser(userId: number): Promise<SessionUser> {
 
 type BlockClaims = NonNullable<Awaited<ReturnType<typeof verifyBlockToken>>>;
 type CustomComfyBody = Extract<BlockWorkflowBody, { kind: 'customComfy' }>;
+/** The INLINE arm (`mode:'inline'`) — carries the ComfyUI graph itself. */
+type CustomComfyInlineBody = Extract<CustomComfyBody, { mode: 'inline' }>;
+/** The RECIPE arm — names a server-authored graph. Unchanged from v1. */
+type CustomComfyRecipeBody = Exclude<CustomComfyBody, CustomComfyInlineBody>;
+
+/**
+ * Narrow a `customComfy` body to its INLINE arm, or `null` for the recipe arm.
+ *
+ * Keyed on the PRESENCE of `mode` rather than its value: the recipe arm has no
+ * `mode` property at all, so `body.mode` is not a legal read across the union and
+ * `'mode' in body` is what actually narrows. The schema's `mode: z.literal('inline')`
+ * means presence and value are the same test at runtime.
+ */
+function isInlineComfyBody(body: CustomComfyBody): body is CustomComfyInlineBody {
+  return 'mode' in body;
+}
+
+/**
+ * The settle-time observability labels for an inline submit.
+ *
+ * Constant, NOT derived from the app or the block — `civitai_app_block_customcomfy_*`
+ * is labelled by these, and labelling by `appBlockId` would make the metric's
+ * cardinality grow with the app catalogue. An inline graph has no engine and no
+ * recipe, so both read as the same constant and every inline job aggregates
+ * together, which is the only honest grouping available.
+ */
+const INLINE_RECIPE_LABEL = '__inline__';
+const INLINE_ENGINE_LABEL = 'inline';
 
 /**
  * Resolve the recipe from the (schema-gated) `recipe` id. The wire schema's
@@ -6137,7 +6188,7 @@ type CustomComfyBody = Extract<BlockWorkflowBody, { kind: 'customComfy' }>;
  * union, so this never returns undefined for a schema-valid body — the guard is
  * defense-in-depth against a registry/schema desync. Fail closed.
  */
-function resolveCustomComfyRecipe(body: CustomComfyBody) {
+function resolveCustomComfyRecipe(body: CustomComfyRecipeBody) {
   const recipe = getRecipe(body.recipe);
   if (!recipe) {
     throw new TRPCError({ code: 'BAD_REQUEST', message: 'unknown recipe' });
@@ -6168,6 +6219,30 @@ async function estimateCustomComfyWorkflow(opts: { claims: BlockClaims; body: Cu
   }
   await assertAppBlocksEnabledForTokenUser(userId);
   await assertViewerIsAppDeveloper(userId);
+
+  // ── INLINE arm. There is NO honest per-graph number to quote and no way to
+  // derive one: the orchestrator forwards the graph opaquely and cannot price
+  // it, and a real whatIf returns 0 for customComfy anyway. The declared
+  // `maxBuzz` ceiling IS the honest answer, because it is PHYSICALLY enforced —
+  // the server stamps `stepTimeoutSeconds = maxBuzz` as the step timeout, the
+  // job is cancelled there, and settle-to-actual refunds the difference. The
+  // user is quoted a true upper bound and charged the real cost.
+  //
+  // 🔴 SURFACE THIS AS "UP TO N BUZZ", NOT AS A PRICE. `cost.total` is the same
+  // field the txt2img path fills with a whatIf estimate, so a UI that renders it
+  // as a definite price will overstate an inline job's cost. That is a copy
+  // change in `@civitai/app-sdk` / the block, tracked separately — nothing here
+  // edits another repo.
+  if (isInlineComfyBody(body)) {
+    return {
+      snapshot: {
+        workflowId: 'wf_estimate',
+        status: 'pending' as const,
+        cost: { total: body.maxBuzz },
+      },
+    };
+  }
+
   const recipe = resolveCustomComfyRecipe(body);
   // Parse through the recipe's OWN `.strict()` schema so the engine (which drives
   // the per-engine display estimate) is validated/bounded; an invalid param
@@ -6230,16 +6305,49 @@ async function submitCustomComfyWorkflow(opts: {
   await assertAppBlocksEnabledForTokenUser(userId);
   await assertViewerIsAppDeveloper(userId);
 
-  const recipe = resolveCustomComfyRecipe(body);
+  // Narrow ONCE, into two mutually-exclusive locals. Exactly one is non-null for
+  // any schema-valid body, which is what lets the shared belt below stay a single
+  // code path instead of two forked copies of the spend logic.
+  const inlineBody = isInlineComfyBody(body) ? body : null;
+  const recipeBody = isInlineComfyBody(body) ? null : body;
+  const recipe = recipeBody ? resolveCustomComfyRecipe(recipeBody) : null;
   // The recipe's OWN `.strict()` schema is the real param contract (the wire
   // schema only gated `recipe`); an invalid param throws → fail-closed.
-  const params = recipe.paramSchema.parse(body.params);
+  const params = recipe && recipeBody ? recipe.paramSchema.parse(recipeBody.params) : null;
 
   const user = await getBlockSessionUser(userId);
   const { allowMatureContent, isGreen } = resolveBlockMaturity(claims);
   // Honor a money-page account pick (preferred-first, domain-clamped) as txt2img;
-  // absent → Auto.
-  const currencies = resolveBlockCurrenciesForAccount(isGreen, params.accountType);
+  // absent → Auto. An inline body carries no account pick (its `.strict()` wire
+  // schema has no `accountType`), so it always resolves to Auto.
+  const currencies = resolveBlockCurrenciesForAccount(isGreen, params?.accountType);
+
+  // ── INLINE arm: replace CODE REVIEW with three mechanical gates, in the same
+  // slots the recipe arm uses. Order matters and matches the recipe arm exactly:
+  // every one of these runs BEFORE the orchestrator token, before any spend
+  // reservation and before the submit, so a rejection costs nothing and has
+  // nothing to refund. All three THROW; none returns a verdict a caller can
+  // forget to read. Full reasoning in `services/blocks/inline-comfy.service`.
+  let inlineAuditText = '';
+  if (inlineBody) {
+    // (a) CONTAINMENT — every AIR in the graph must be declared in `resources`,
+    //     which is what makes gating that flat array sufficient.
+    assertInlineGraphAirsDeclared(inlineBody.workflow, inlineBody.resources);
+    // (b) ENTITLEMENT — the real belt (early-access `hasAccess` + Private
+    //     subscription + anti-drop + anti-substitute) over the declared AIRs.
+    await assertViewerEntitledToInlineResources({
+      airs: inlineBody.resources,
+      user: { id: userId, isModerator: !!user.isModerator },
+    });
+    // (c) The MODERATION SWEEP — collected here, audited in the shared audit call
+    //     below. An inline graph carries its prompts inside `CLIPTextEncode`
+    //     nodes, so auditing a declared field alone would make moderation a
+    //     silent no-op.
+    inlineAuditText = collectInlineAuditText({
+      prompt: inlineBody.prompt,
+      graph: inlineBody.workflow,
+    });
+  }
 
   // ── Entitlement gate (plan §6). A raw customComfy step submits its `resources`
   // AIR array DIRECTLY, bypassing the generation-graph path's automatic
@@ -6249,8 +6357,8 @@ async function submitCustomComfyWorkflow(opts: {
   // point at a gated / early-access / Private / unpublished version without the
   // belt catching it. The huggingface staticAirs carry no civitai entitlement
   // (exempt-by-construction). checkpointPolicy:'pinned' → no user checkpoint in v1.
-  const versionIds = recipeCivitaiVersionIds(recipe);
-  if (versionIds.length > 0) {
+  const versionIds = recipe ? recipeCivitaiVersionIds(recipe) : [];
+  if (recipe && versionIds.length > 0) {
     const gates: ReturnType<typeof buildGateVersion>[] = [];
     for (const versionId of versionIds) {
       const resolvedVersion = await resolvePageResourceContext(versionId);
@@ -6271,9 +6379,19 @@ async function submitCustomComfyWorkflow(opts: {
   // quality suffix only INSIDE the builder, AFTER this read) with the
   // domain-derived isGreen strictness, exactly like txt2img, before any
   // orchestrator call.
+  //
+  // 🔴 ON THE INLINE ARM `prompt` IS THE SWEPT GRAPH TEXT, NOT A DECLARED FIELD.
+  // `auditPromptServer` reads exactly one string, and on the recipe arm that
+  // string is guaranteed to be what generates because the recipe's `.strict()`
+  // schema owns the prompt. An inline graph carries its prompts as leaf strings
+  // inside `CLIPTextEncode` nodes, so a declared-field-only audit would scan a
+  // value the generation never uses and moderation would silently become a
+  // no-op — with every gate green. `collectInlineAuditText` (above) joins the
+  // declared prompt AND every distinct string leaf in the graph, so a clean
+  // declared prompt cannot launder a graph prompt.
   await auditPromptServer({
-    prompt: params.prompt,
-    negativePrompt: recipe.negativePrompt,
+    prompt: inlineBody ? inlineAuditText : params!.prompt,
+    negativePrompt: inlineBody ? inlineBody.negativePrompt : recipe!.negativePrompt,
     userId,
     isGreen,
     isModerator: !!user.isModerator,
@@ -6285,7 +6403,17 @@ async function submitCustomComfyWorkflow(opts: {
   // stepTimeoutSeconds)` (enforced per-engine at registry load): the step
   // `timeout` physically caps the job at this many Buzz, so the reservation below
   // and the timeout stamped on the step MUST come from the same budget.
-  const { maxBuzz: ceiling, stepTimeoutSeconds } = recipe.budgetFor(params);
+  //
+  // 🔴 THE INLINE ARM PRESERVES THAT INVARIANT BY CONSTRUCTION. There is no
+  // recipe to declare a per-engine budget, so the app declares ONE number and
+  // the server derives the timeout from it: `stepTimeoutSeconds = maxBuzz`.
+  // `maxBuzz === ceil(stepTimeoutSeconds)` therefore cannot be violated — not
+  // "is asserted at load", but "there is only one number". Everything downstream
+  // (static gate, both reservations, dev-session backstop, settle-to-actual) only
+  // ever consumed `ceiling`, so the entire spend belt is reused UNTOUCHED.
+  const { maxBuzz: ceiling, stepTimeoutSeconds } = inlineBody
+    ? { maxBuzz: inlineBody.maxBuzz, stepTimeoutSeconds: inlineBody.maxBuzz }
+    : recipe!.budgetFor(params);
 
   // Resolve the engine + recipe id purely for per-engine settle-time
   // OBSERVABILITY (persisted in the settle record, read at terminal to emit
@@ -6297,8 +6425,13 @@ async function submitCustomComfyWorkflow(opts: {
   // (engine ∈ 3, recipe ∈ 1) → cardinality-safe. Never affects spend. The
   // `?? 'unknown'` stays as truly-unreachable defense (resolveEngine always
   // returns a bounded engine id).
-  const engine: string = recipe.resolveEngine(params) ?? 'unknown';
-  const recipeId: string = recipe.id;
+  // An inline graph has no engine and no recipe, so both labels are the same
+  // CONSTANT for every inline job — never derived from the app or the block, so
+  // the metric's cardinality cannot grow with the app catalogue.
+  const engine: string = inlineBody
+    ? INLINE_ENGINE_LABEL
+    : recipe!.resolveEngine(params) ?? 'unknown';
+  const recipeId: string = inlineBody ? INLINE_RECIPE_LABEL : recipe!.id;
 
   // (1) STATIC pre-submit gate — the post-paid analog of the txt2img whatIf
   // `cost > buzzBudget` gate. Because the timeout caps the job at `maxBuzz` and we
@@ -6478,13 +6611,29 @@ async function submitCustomComfyWorkflow(opts: {
   // submit→terminal-observation (incl. GPU queue-wait). Observability-only.
   const submittedAt = Date.now();
   try {
-    const stepInput = buildCustomComfyWorkflowInput(recipe, body.params, {});
+    // 🔴 THE STEP INPUT IS CONSTRUCTED SERVER-SIDE FROM AN ALLOWLISTED SET OF
+    // FIELDS — the app's body is NEVER spread into it. `CustomComfyInput` also
+    // carries `sessionOwnerApiToken` (a Civitai API token forwarded to the
+    // claiming worker), `comfyImage` (an arbitrary OCI container), `minVramGb`
+    // (changes the worker tier, and therefore the Buzz/second rate the whole
+    // ceiling argument rests on), `sessionId`, `useSageAttention` and
+    // `minimumDurationSeconds`. A spread would hand every one of those to the
+    // app. Only these three keys are ever emitted; the wire schema's `.strict()`
+    // is the second belt, rejecting a body that names any of them at all.
+    const stepInput = inlineBody
+      ? {
+          resources: inlineBody.resources,
+          trace: 'binary' as const,
+          workflow: inlineBody.workflow,
+        }
+      : buildCustomComfyWorkflowInput(recipe!, recipeBody!.params, {});
     // Stamp the SAME per-engine timeout the ceiling above was reserved against —
-    // the timeout is the physical cap for that reservation (v1.1).
+    // the timeout is the physical cap for that reservation (v1.1). For an inline
+    // body that timeout IS the declared `maxBuzz`.
     const step = createBlockCustomComfyStep(stepInput, stepTimeoutSeconds);
     // Parameterized tags: emit the recipe id + 'customComfy' (NOT 'txt2img'),
     // preserving the `app-block:*` provenance tags the subqueue read depends on.
-    const tags = buildWorkflowTags(claims, recipe.id, 'customComfy');
+    const tags = buildWorkflowTags(claims, recipeId, 'customComfy');
     const submitted = await submitWorkflow({
       token,
       body: {

--- a/src/server/schema/blocks/__tests__/workflow.schema.inline-comfy.test.ts
+++ b/src/server/schema/blocks/__tests__/workflow.schema.inline-comfy.test.ts
@@ -1,0 +1,281 @@
+import { describe, expect, it } from 'vitest';
+import {
+  blockWorkflowBodySchema,
+  INLINE_GRAPH_NODES_MAX,
+  INLINE_MAX_BUZZ,
+  INLINE_RESOURCES_MAX,
+} from '~/server/schema/blocks/workflow.schema';
+import { DEV_BUZZ_BUDGET_CAP } from '~/server/services/blocks/dev-scoped-mint.service';
+import { REGISTERED_RECIPE_IDS } from '~/server/services/blocks/recipes';
+import { REGISTERED_STEP_IDS } from '~/server/services/blocks/steps';
+
+/**
+ * Wire-contract coverage for the customComfy INLINE arm (`mode:'inline'`).
+ *
+ * Two things are expensive to get wrong here and both have tests that go red:
+ *
+ *   1. **BACK-COMPAT.** The arm was added to a union that every deployed app and
+ *      every published `@civitai/app-sdk` body parses through. The first block
+ *      below is the regression guard: it pins that a recipe / textToImage / step
+ *      body still parses. That is not ceremony — the obvious zod spelling for
+ *      this change (nesting a `discriminatedUnion('mode', …)`) CONSTRUCTS fine
+ *      and then rejects every existing recipe body, because zod does not read a
+ *      discriminator value through a `.default()`. These tests are what catches
+ *      that.
+ *   2. **`.strict()` IS A SECURITY GATE, NOT HYGIENE.** `CustomComfyInput` carries
+ *      `sessionOwnerApiToken` (a Civitai API token forwarded to the claiming
+ *      worker), `comfyImage` (an arbitrary OCI container), `minVramGb` (changes
+ *      the worker tier and so the Buzz/second rate the ceiling argument rests
+ *      on), and three more. The step input is built server-side from an
+ *      allowlist, and `.strict()` is the second belt.
+ */
+
+const RECIPE_ID = REGISTERED_RECIPE_IDS[0];
+const STEP_ID = REGISTERED_STEP_IDS[0];
+
+function inlineBody(over: Record<string, unknown> = {}) {
+  return {
+    kind: 'customComfy',
+    mode: 'inline',
+    workflow: {
+      '1': { class_type: 'CheckpointLoaderSimple', inputs: { ckpt_name: 'x.safetensors' } },
+      '2': { class_type: 'CLIPTextEncode', inputs: { text: 'a cat', clip: ['1', 1] } },
+    },
+    resources: [],
+    maxBuzz: 60,
+    ...over,
+  };
+}
+
+describe('blockWorkflowBodySchema — the pre-existing members still parse (back-compat)', () => {
+  it('a RECIPE customComfy body (no `mode` key) parses, unchanged', () => {
+    const parsed = blockWorkflowBodySchema.safeParse({
+      kind: 'customComfy',
+      recipe: RECIPE_ID,
+      params: { prompt: 'a sunset', engine: 'zimage-turbo' },
+    });
+    expect(parsed.success).toBe(true);
+    // 🔴 toStrictEqual, NOT toEqual. The recipe arm's `mode` is an OPTIONAL
+    // literal, and `toEqual` treats `{…, mode: undefined}` as equal to `{…}` —
+    // so it would not notice a `mode` key materialising in the parsed output.
+    // That output is the object the router and the settle record consume, and
+    // `@civitai/app-sdk` mirrors this shape, so "byte-identical" has to be
+    // asserted strictly or it is not being asserted.
+    expect(parsed.success && parsed.data).toStrictEqual({
+      kind: 'customComfy',
+      recipe: RECIPE_ID,
+      params: { prompt: 'a sunset', engine: 'zimage-turbo' },
+    });
+  });
+
+  it('an EXPLICIT `mode: "recipe"` is also accepted (the arm is opt-in, not forbidden)', () => {
+    const parsed = blockWorkflowBodySchema.safeParse({
+      kind: 'customComfy',
+      mode: 'recipe',
+      recipe: RECIPE_ID,
+      params: {},
+    });
+    expect(parsed.success).toBe(true);
+  });
+
+  it('a rejected body still reports the PRECISE field path, not a bare union error', () => {
+    // The union construction is easy to get subtly wrong in a way that keeps
+    // rejection working but collapses every error to `path: []`. That path is
+    // the only diagnostic an app author gets for a bounced submit.
+    const parsed = blockWorkflowBodySchema.safeParse({
+      kind: 'customComfy',
+      recipe: 'not-a-recipe',
+      params: {},
+    });
+    expect(parsed.success).toBe(false);
+    expect(
+      parsed.success === false && parsed.error.issues.some((i) => i.path.includes('recipe'))
+    ).toBe(true);
+  });
+
+  it('a textToImage body parses, unchanged', () => {
+    // Same fixture as workflow.schema.step.test.ts, which pins the SAME property
+    // for the previous union member.
+    const body = {
+      kind: 'textToImage' as const,
+      modelId: 123,
+      modelVersionId: 456,
+      params: { prompt: 'a cat', quantity: 1 },
+    };
+    const parsed = blockWorkflowBodySchema.safeParse(body);
+    expect(parsed.success).toBe(true);
+    expect(parsed.success && parsed.data).toEqual(body);
+  });
+
+  it('a step body parses, unchanged', () => {
+    const parsed = blockWorkflowBodySchema.safeParse({
+      kind: 'step',
+      step: STEP_ID,
+      params: {},
+    });
+    expect(parsed.success).toBe(true);
+  });
+
+  it('an UNREGISTERED recipe id still fails closed', () => {
+    expect(
+      blockWorkflowBodySchema.safeParse({
+        kind: 'customComfy',
+        recipe: 'not-a-recipe',
+        params: {},
+      }).success
+    ).toBe(false);
+  });
+
+  it('an unknown `kind` is still rejected', () => {
+    expect(blockWorkflowBodySchema.safeParse({ kind: 'chatCompletion', model: 'x' }).success).toBe(
+      false
+    );
+  });
+});
+
+describe('blockWorkflowBodySchema — the INLINE arm', () => {
+  it('accepts an inline body carrying a graph', () => {
+    const parsed = blockWorkflowBodySchema.safeParse(inlineBody());
+    expect(parsed.success).toBe(true);
+    expect(parsed.success && parsed.data).toMatchObject({
+      kind: 'customComfy',
+      mode: 'inline',
+      maxBuzz: 60,
+      // Defaults applied so the router never reads undefined.
+      prompt: '',
+      negativePrompt: '',
+    });
+  });
+
+  it('the two arms are MUTUALLY EXCLUSIVE — a body naming both is rejected', () => {
+    expect(
+      blockWorkflowBodySchema.safeParse(inlineBody({ recipe: RECIPE_ID, params: {} })).success
+    ).toBe(false);
+    // …and a recipe body that also carries `mode` is likewise rejected: neither
+    // arm accepts it, so there is no ambiguity for the union to resolve.
+    expect(
+      blockWorkflowBodySchema.safeParse({
+        kind: 'customComfy',
+        recipe: RECIPE_ID,
+        params: {},
+        mode: 'inline',
+      }).success
+    ).toBe(false);
+  });
+
+  it('a node must carry class_type + inputs', () => {
+    expect(
+      blockWorkflowBodySchema.safeParse(inlineBody({ workflow: { '1': { class_type: 'X' } } }))
+        .success
+    ).toBe(false);
+    expect(
+      blockWorkflowBodySchema.safeParse(inlineBody({ workflow: { '1': { inputs: {} } } })).success
+    ).toBe(false);
+    // A node with an EXTRA key is rejected too — the node schema is `.strict()`.
+    expect(
+      blockWorkflowBodySchema.safeParse(
+        inlineBody({ workflow: { '1': { class_type: 'X', inputs: {}, _meta: {} } } })
+      ).success
+    ).toBe(false);
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 🔴 THE NEVER-APP-SETTABLE FIELDS. Each of these is a real capability on
+// `CustomComfyInput`; an app that could set one would get, respectively: a
+// Civitai API token belonging to the session owner, an arbitrary container to
+// run, a different worker tier (and therefore a different Buzz/second rate than
+// the ceiling assumes), worker session affinity, an attention-kernel flag, and a
+// submit-time affordability gate. The router never spreads the body into the
+// step input; this asserts the wire also refuses to carry them.
+// ─────────────────────────────────────────────────────────────────────────────
+describe('blockWorkflowBodySchema — inline arm rejects every CustomComfyInput field an app must not set', () => {
+  const forbidden: Array<[string, unknown]> = [
+    ['sessionOwnerApiToken', 'civitai-api-token'],
+    ['comfyImage', 'urn:air:oci:image:ghcr:evil/comfy@v1'],
+    ['minVramGb', 48],
+    ['sessionId', 'sess_1'],
+    ['useSageAttention', true],
+    ['minimumDurationSeconds', 300],
+    ['trace', 'binary'],
+  ];
+
+  it.each(forbidden)('rejects an inline body setting `%s`', (field, value) => {
+    const parsed = blockWorkflowBodySchema.safeParse(inlineBody({ [field as string]: value }));
+    expect(parsed.success).toBe(false);
+  });
+
+  it('POSITIVE CONTROL — the same body WITHOUT the extra field parses', () => {
+    // Without this, every assertion above could be passing because the fixture
+    // is malformed for some unrelated reason.
+    expect(blockWorkflowBodySchema.safeParse(inlineBody()).success).toBe(true);
+  });
+});
+
+describe('blockWorkflowBodySchema — inline arm bounds', () => {
+  it('maxBuzz is required and bounded to INLINE_MAX_BUZZ', () => {
+    expect(blockWorkflowBodySchema.safeParse(inlineBody({ maxBuzz: undefined })).success).toBe(
+      false
+    );
+    expect(blockWorkflowBodySchema.safeParse(inlineBody({ maxBuzz: 0 })).success).toBe(false);
+    expect(blockWorkflowBodySchema.safeParse(inlineBody({ maxBuzz: -1 })).success).toBe(false);
+    expect(blockWorkflowBodySchema.safeParse(inlineBody({ maxBuzz: 1.5 })).success).toBe(false);
+    expect(
+      blockWorkflowBodySchema.safeParse(inlineBody({ maxBuzz: INLINE_MAX_BUZZ })).success
+    ).toBe(true);
+    expect(
+      blockWorkflowBodySchema.safeParse(inlineBody({ maxBuzz: INLINE_MAX_BUZZ + 1 })).success
+    ).toBe(false);
+  });
+
+  it('🔴 INLINE_MAX_BUZZ is DERIVED from DEV_BUZZ_BUDGET_CAP, not invented', () => {
+    // The constant is spelled as a literal in the schema so the wire layer stays
+    // import-light. This is what stops the derivation drifting silently: if
+    // someone changes the dev per-call cap, this goes red and the reason for
+    // the inline ceiling has to be re-stated rather than quietly diverging.
+    expect(INLINE_MAX_BUZZ).toBe(DEV_BUZZ_BUDGET_CAP);
+  });
+
+  it('an empty graph is rejected', () => {
+    expect(blockWorkflowBodySchema.safeParse(inlineBody({ workflow: {} })).success).toBe(false);
+  });
+
+  it('the node count is bounded', () => {
+    const node = { class_type: 'X', inputs: {} };
+    const atCap = Object.fromEntries(
+      Array.from({ length: INLINE_GRAPH_NODES_MAX }, (_, i) => [String(i), node])
+    );
+    const overCap = Object.fromEntries(
+      Array.from({ length: INLINE_GRAPH_NODES_MAX + 1 }, (_, i) => [String(i), node])
+    );
+    expect(blockWorkflowBodySchema.safeParse(inlineBody({ workflow: atCap })).success).toBe(true);
+    expect(blockWorkflowBodySchema.safeParse(inlineBody({ workflow: overCap })).success).toBe(
+      false
+    );
+  });
+
+  it('the serialized graph size is bounded (payload DoS + audit-sweep bound)', () => {
+    const huge = {
+      '1': { class_type: 'CLIPTextEncode', inputs: { text: 'a'.repeat(300_000) } },
+    };
+    expect(blockWorkflowBodySchema.safeParse(inlineBody({ workflow: huge })).success).toBe(false);
+  });
+
+  it('the declared resource fan-out is bounded', () => {
+    const air = (n: number) => `urn:air:sdxl:lora:civitai:1@${n}`;
+    const atCap = Array.from({ length: INLINE_RESOURCES_MAX }, (_, i) => air(i));
+    expect(blockWorkflowBodySchema.safeParse(inlineBody({ resources: atCap })).success).toBe(true);
+    expect(
+      blockWorkflowBodySchema.safeParse(inlineBody({ resources: [...atCap, air(999)] })).success
+    ).toBe(false);
+  });
+
+  it('prompt / negativePrompt are length-bounded', () => {
+    expect(
+      blockWorkflowBodySchema.safeParse(inlineBody({ prompt: 'a'.repeat(1501) })).success
+    ).toBe(false);
+    expect(
+      blockWorkflowBodySchema.safeParse(inlineBody({ negativePrompt: 'a'.repeat(1501) })).success
+    ).toBe(false);
+  });
+});

--- a/src/server/schema/blocks/workflow.schema.ts
+++ b/src/server/schema/blocks/workflow.schema.ts
@@ -246,13 +246,137 @@ const blockTextToImageBodySchemaChecked = blockTextToImageBodySchema.refine(
 //    in the translator (`buildCustomComfyWorkflowInput`), which is the single
 //    place a recipe's real param contract lives.
 //  - `.strict()` rejects any extra top-level field on the body.
+//  - `mode` is the ARM discriminator, and on this arm it is an OPTIONAL literal
+//    so an existing body that omits it (every deployed app, every published
+//    `@civitai/app-sdk` body) still lands here. See the union at the bottom of
+//    this file for why `.optional()` and not `.default()` — the difference is
+//    load-bearing and was measured, not assumed.
 export const blockCustomComfyBodySchema = z
   .object({
     kind: z.literal('customComfy'),
+    mode: z.literal('recipe').optional(),
     recipe: z.enum(REGISTERED_RECIPE_IDS),
     params: z.record(z.string(), z.unknown()),
   })
   .strict();
+
+// ── App Blocks customComfy INLINE-GRAPH arm (`kind:'customComfy'`, `mode:'inline'`) ──
+//
+// The SECOND arm of the `customComfy` member. Where the recipe arm names one of
+// two server-authored graphs, this one carries the ComfyUI graph ITSELF, so an
+// app can ship a workflow the registry does not contain. The recipe arm above is
+// UNCHANGED and stays the default: a body with no `mode` is a recipe body and
+// parses byte-identically to before.
+//
+// 🔴 WHAT THE RECIPE ARM PROVIDED THAT THIS ONE MUST REPLACE. A recipe is a
+// CODE-REVIEWED in-repo artifact, and that review was the trust root for three
+// separate things. An inline graph has no review, so each is replaced by a
+// mechanical gate — see `services/blocks/inline-comfy.service`:
+//   1. `resourceAllowlist` (only fully-public pinned versions) → a real
+//      entitlement belt over the app-supplied `resources` array, which folds
+//      early-access `hasAccess` and Private-subscription.
+//   2. `paramSchema.prompt` (the field `auditPromptServer` reads) → a sweep of
+//      every string leaf in the graph, audited alongside the declared prompt. An
+//      inline graph carries its prompts inside `CLIPTextEncode` nodes, so
+//      auditing a declared field ALONE would make moderation a silent no-op.
+//   3. `budgetFor()` (the `maxBuzz === ceil(stepTimeoutSeconds)` ceiling) → the
+//      app declares `maxBuzz` and the server derives
+//      `stepTimeoutSeconds = maxBuzz`. The invariant then holds BY CONSTRUCTION
+//      — there is only one number — and the whole post-paid spend belt (static
+//      gate, both reservations, settle-to-actual) is reused untouched.
+//
+// 🔴 `.strict()` IS LOAD-BEARING HERE, NOT HYGIENE. The orchestrator's
+// `CustomComfyInput` carries fields an app must NEVER set — `sessionOwnerApiToken`
+// (a Civitai API token forwarded to the claiming worker), `comfyImage` (an OCI
+// image AIR, i.e. an arbitrary container), `minVramGb` (changes the worker tier
+// and therefore the Buzz/second rate the whole ceiling argument rests on),
+// `sessionId`, `useSageAttention`, `minimumDurationSeconds`. The step input is
+// CONSTRUCTED SERVER-SIDE from an allowlisted set of fields; the app's body is
+// never spread into it. `.strict()` is the second belt: an app that sends one of
+// those names is rejected at the wire rather than silently ignored.
+
+/**
+ * Hard per-job Buzz ceiling an inline body may declare.
+ *
+ * DERIVED, not invented. This surface is developer-only (`assertViewerIsAppDeveloper`
+ * gates every customComfy submit), and the developer path's own per-call budget
+ * ceiling is `DEV_BUZZ_BUDGET_CAP` (250) in `services/blocks/dev-scoped-mint.service`
+ * — a declared `maxBuzz` above that is unreachable through a dev token anyway,
+ * because the router's static gate fail-snapshots on `ceiling > claims.buzzBudget`.
+ * It also sits comfortably above the largest shipped recipe ceiling (180, the
+ * `qwen-image` engine of `seamless-pano-360`) so an inline graph is not more
+ * constrained than a recipe.
+ *
+ * Deliberately a LITERAL here rather than an import: this module is imported by
+ * the wire layer and must stay import-light, while `dev-scoped-mint.service`
+ * pulls in the block-token service. `inline-comfy-budget.test.ts` imports both
+ * and pins them equal, so the derivation cannot drift silently.
+ */
+export const INLINE_MAX_BUZZ = 250;
+
+/** Max AIR URNs an inline body may declare. Bounds the entitlement fan-out. */
+export const INLINE_RESOURCES_MAX = 24;
+/** Max characters in a single declared AIR URN. */
+const INLINE_AIR_MAX_LEN = 512;
+/** Max nodes in an inline graph. */
+export const INLINE_GRAPH_NODES_MAX = 300;
+/**
+ * Max serialized bytes of an inline graph.
+ *
+ * Two jobs. (1) Payload DoS: `workflow` is an unbounded `Record<string, unknown>`
+ * on a submit path, so without this a single request can be arbitrarily large.
+ * (2) It is what BOUNDS THE MODERATION SWEEP — the prompt audit walks every
+ * string leaf in the graph, so an unbounded graph would be an unbounded audit
+ * payload. Real ComfyUI graphs are single-digit to low-tens of KB; 256 KB is
+ * generous for a graph and still a hard bound.
+ */
+export const INLINE_GRAPH_BYTES_MAX = 256 * 1024;
+
+/** A ComfyUI `/prompt` graph node on the wire: `class_type` + `inputs`. */
+const inlineComfyNodeSchema = z
+  .object({
+    class_type: z.string().min(1).max(128),
+    inputs: z.record(z.string(), z.unknown()),
+  })
+  .strict();
+
+export const blockInlineComfyBodySchema = z
+  .object({
+    kind: z.literal('customComfy'),
+    // The arm discriminator. A LITERAL rather than "has a `workflow` key" so the
+    // two arms can never both match, the rejection names the arm, and a future
+    // field addition to either arm cannot silently change which one a body hits.
+    mode: z.literal('inline'),
+    workflow: z.record(z.string(), inlineComfyNodeSchema),
+    // The orchestrator's DECLARED DOWNLOAD MANIFEST. The graph itself is opaque
+    // to the orchestrator ("Forwarded opaquely to the worker; the orchestrator
+    // does not inspect or validate node contents" — `CustomComfyInput.workflow`),
+    // so this flat array is the entire untrusted entitlement surface. Gated by
+    // `assertViewerEntitledToInlineResources`; ALSO cross-checked for containment
+    // against AIRs appearing in the graph, so the "opaque" claim is not
+    // load-bearing.
+    resources: z.array(z.string().min(1).max(INLINE_AIR_MAX_LEN)).max(INLINE_RESOURCES_MAX),
+    // Declared so an app can surface what it asked for. NOT trusted as the
+    // complete moderation surface — the graph is swept too (see above).
+    prompt: z.string().max(PROMPT_MAX).default(''),
+    negativePrompt: z.string().max(NEG_PROMPT_MAX).default(''),
+    // The ONLY spend knob. The server derives `stepTimeoutSeconds = maxBuzz` and
+    // stamps it as the step timeout, which is the PHYSICAL cap.
+    maxBuzz: z.number().int().min(1).max(INLINE_MAX_BUZZ),
+  })
+  .strict()
+  .refine((b) => Object.keys(b.workflow).length > 0, {
+    path: ['workflow'],
+    message: 'inline workflow must contain at least one node',
+  })
+  .refine((b) => Object.keys(b.workflow).length <= INLINE_GRAPH_NODES_MAX, {
+    path: ['workflow'],
+    message: `inline workflow may contain at most ${INLINE_GRAPH_NODES_MAX} nodes`,
+  })
+  .refine((b) => JSON.stringify(b.workflow).length <= INLINE_GRAPH_BYTES_MAX, {
+    path: ['workflow'],
+    message: `inline workflow exceeds the ${INLINE_GRAPH_BYTES_MAX}-byte limit`,
+  });
 
 // ── App Blocks STEP-TYPE bridge (`kind: 'step'`) — RFC #3515 migration step 1 ──
 //
@@ -301,9 +425,52 @@ export function makeBlockStepBodySchema(stepIds: [string, ...string[]]) {
 export const blockStepBodySchema = makeBlockStepBodySchema(REGISTERED_STEP_IDS);
 
 export type BlockWorkflowBody = z.infer<typeof blockWorkflowBodySchema>;
+
+// 🔴 THE `customComfy` MEMBER IS A NESTED DISCRIMINATED UNION ON `mode`, AND THE
+// RECIPE ARM'S `mode` IS `.optional()` — NOT `.default('recipe')`. That
+// distinction is the whole reason this comment exists. MEASURED against zod
+// 4.0.17; each of the three obvious spellings was run, not reasoned about:
+//
+//   1. `blockInlineComfyBodySchema` as a FOURTH option of the outer union throws
+//      at parse time: `Duplicate discriminator value "customComfy"`. zod's
+//      discriminated union is a value→schema MAP, so two members cannot share a
+//      `kind`.
+//   2. Nesting on `mode` with the recipe arm declaring
+//      `mode: z.literal('recipe').default('recipe')` CONSTRUCTS fine — and then
+//      REJECTS EVERY DEPLOYED RECIPE BODY with `No matching discriminator`. zod
+//      reads the discriminator value off the SCHEMA and does not see it through
+//      a `.default()`, so `{kind:'customComfy', recipe, params}` (no `mode` key
+//      — what every shipped app and every published `@civitai/app-sdk` sends)
+//      fails. 🔴 THIS IS THE DANGEROUS ONE: it type-checks, it builds, its own
+//      tests pass, and it breaks production.
+//   3. Wrapping the whole thing in a plain `z.union([discriminatedUnion, inlineArm])`
+//      parses every body correctly, but DEGRADES THE ERROR SHAPE: a rejected body
+//      reports a single top-level `invalid_union` issue with `path: []` instead of
+//      the precise `path: ['step']` / `path: ['recipe']` the discriminated union
+//      produces. That is the diagnostic an app author gets for a bounced submit,
+//      and `workflow.schema.step.test.ts` already pins it.
+//
+// `.optional()` works where `.default()` does not: zod treats `undefined` as a
+// legitimate discriminator value for the arm, so a body with no `mode` key lands
+// on the recipe arm, and the outer union stays a real discriminated union with
+// its per-field error paths intact.
+//
+// Both arms are `.strict()`, so a body naming BOTH `recipe` and `workflow` is
+// rejected by both and there is no ambiguity to resolve.
+//
+// Pinned by `workflow.schema.inline-comfy.test.ts` (recipe / textToImage / step
+// bodies parse unchanged, output byte-identical) and by the existing
+// `workflow.schema.step.test.ts` error-path assertion. Failure mode 2 above is
+// covered by a mutation in the sweep: swapping `.optional()` for `.default()`
+// turns the back-compat test red.
+const blockCustomComfyMemberSchema = z.discriminatedUnion('mode', [
+  blockCustomComfyBodySchema,
+  blockInlineComfyBodySchema,
+]);
+
 export const blockWorkflowBodySchema = z.discriminatedUnion('kind', [
   blockTextToImageBodySchemaChecked,
-  blockCustomComfyBodySchema,
+  blockCustomComfyMemberSchema,
   blockStepBodySchema,
 ]);
 

--- a/src/server/services/blocks/__tests__/inline-comfy.service.test.ts
+++ b/src/server/services/blocks/__tests__/inline-comfy.service.test.ts
@@ -1,0 +1,420 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockGetResourceData = vi.fn();
+const mockGetHighestTierSubscription = vi.fn();
+
+vi.mock('~/server/services/generation/generation.service', () => ({
+  getResourceData: (...args: unknown[]) => mockGetResourceData(...args),
+}));
+vi.mock('~/server/services/subscriptions.service', () => ({
+  getHighestTierSubscription: (...args: unknown[]) => mockGetHighestTierSubscription(...args),
+}));
+
+import {
+  assertInlineGraphAirsDeclared,
+  assertViewerEntitledToInlineResources,
+  collectInlineAuditText,
+  collectInlineGraphStrings,
+  INLINE_NODEPACKS_ENABLED,
+} from '~/server/services/blocks/inline-comfy.service';
+import type { ComfyGraph } from '~/server/services/blocks/recipes';
+
+/**
+ * The inline-graph belt. This module is what REPLACES code review as the trust
+ * root for an app-supplied ComfyUI graph, so the tests that matter here are the
+ * ones for the failure modes a normal test plan omits — the ones that FAIL OPEN
+ * silently rather than throwing.
+ *
+ * Every negative case below has a matched POSITIVE control on the same fixture,
+ * because a negative alone cannot distinguish "the gate fired" from "the fixture
+ * was rejected earlier for an unrelated reason".
+ */
+
+const LORA_AIR = 'urn:air:sdxl:lora:civitai:118025@136251';
+const HF_AIR =
+  'urn:air:zimageturbo:diffusion_model:huggingface:Comfy-Org/z_image_turbo@main/x.safetensors';
+const VIEWER = { id: 7, isModerator: false };
+
+function graph(over: ComfyGraph = {}): ComfyGraph {
+  return {
+    '1': { class_type: 'CheckpointLoaderSimple', inputs: { ckpt_name: 'sd_xl.safetensors' } },
+    '2': {
+      class_type: 'CLIPTextEncode',
+      inputs: { text: 'a serene mountain lake', clip: ['1', 1] },
+    },
+    ...over,
+  };
+}
+
+/** A `getResourceData` row shaped like the real return (see generation.service). */
+function resourceRow(over: Record<string, unknown> = {}) {
+  return {
+    id: 136251,
+    name: 'a lora',
+    canGenerate: true,
+    availability: 'Public',
+    air: LORA_AIR,
+    ...over,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGetResourceData.mockResolvedValue([resourceRow()]);
+  mockGetHighestTierSubscription.mockResolvedValue(null);
+});
+
+describe('collectInlineGraphStrings — the walk', () => {
+  it('collects leaves, array elements, object values AND object KEYS', () => {
+    // Keys are walked because that is the orchestrator's own schema:
+    // `additionalNetworks` is documented "Use the AIR of the network as the key".
+    const found = collectInlineGraphStrings({
+      a: 'leaf',
+      b: ['inArray'],
+      additionalNetworks: { [LORA_AIR]: { strength: 1 } },
+    });
+    expect(found).toContain('leaf');
+    expect(found).toContain('inArray');
+    expect(found).toContain(LORA_AIR); // the KEY
+  });
+
+  it('throws (never recurses to a stack overflow) past the depth cap', () => {
+    let deep: unknown = 'bottom';
+    for (let i = 0; i < 400; i++) deep = [deep];
+    expect(() => collectInlineGraphStrings(deep)).toThrow(/nested too deeply/);
+  });
+
+  it('POSITIVE CONTROL — a legally-nested value does NOT throw', () => {
+    let ok: unknown = 'bottom';
+    for (let i = 0; i < 20; i++) ok = [ok];
+    expect(() => collectInlineGraphStrings(ok)).not.toThrow();
+  });
+});
+
+describe('assertInlineGraphAirsDeclared — containment', () => {
+  it('rejects a graph naming an AIR that `resources` omits', () => {
+    const g = graph({ '3': { class_type: 'LoraLoader', inputs: { lora_name: LORA_AIR } } });
+    expect(() => assertInlineGraphAirsDeclared(g, [])).toThrow(/not declared in resources/);
+  });
+
+  it('accepts it once declared, case-insensitively', () => {
+    const g = graph({ '3': { class_type: 'LoraLoader', inputs: { lora_name: LORA_AIR } } });
+    expect(() => assertInlineGraphAirsDeclared(g, [LORA_AIR.toUpperCase()])).not.toThrow();
+  });
+
+  it('catches an AIR hidden in an object KEY, not just a value', () => {
+    const g = graph({
+      '3': { class_type: 'X', inputs: { additionalNetworks: { [LORA_AIR]: { strength: 1 } } } },
+    });
+    expect(() => assertInlineGraphAirsDeclared(g, [])).toThrow(/not declared in resources/);
+    expect(() => assertInlineGraphAirsDeclared(g, [LORA_AIR])).not.toThrow();
+  });
+
+  it('rejects an AIR EMBEDDED in a longer string even when that AIR is declared', () => {
+    // Whole-string match, deliberately. Extracting a URN out of a longer string
+    // would mean maintaining a second copy of the AIR grammar, and any drift
+    // between that copy and what the worker resolves is the bypass.
+    const g = graph({
+      '3': { class_type: 'X', inputs: { note: `see ${LORA_AIR} for details` } },
+    });
+    expect(() => assertInlineGraphAirsDeclared(g, [LORA_AIR])).toThrow(/not declared in resources/);
+  });
+
+  it('POSITIVE CONTROL — a graph with no AIR at all passes with no declarations', () => {
+    expect(() => assertInlineGraphAirsDeclared(graph(), [])).not.toThrow();
+  });
+});
+
+describe('collectInlineAuditText — the moderation sweep', () => {
+  it('🔴 collects the prompt from inside a CLIPTextEncode node, not just the declared field', () => {
+    // This is the whole point. On the recipe arm the audit reads a schema-owned
+    // `params.prompt`. An inline graph carries prompts as leaf strings, so an
+    // audit of the declared field alone would scan a value the generation never
+    // uses — moderation becomes a silent no-op with every gate green.
+    const text = collectInlineAuditText({
+      prompt: 'a clean declared prompt',
+      graph: graph({ '9': { class_type: 'CLIPTextEncode', inputs: { text: 'GRAPH_PROMPT_XYZ' } } }),
+    });
+    expect(text).toContain('GRAPH_PROMPT_XYZ');
+    expect(text).toContain('a clean declared prompt');
+  });
+
+  it('dedupes repeated leaves (a graph repeats class names on every node)', () => {
+    const text = collectInlineAuditText({
+      prompt: '',
+      graph: {
+        '1': { class_type: 'CLIPTextEncode', inputs: { text: 'same' } },
+        '2': { class_type: 'CLIPTextEncode', inputs: { text: 'same' } },
+      },
+    });
+    expect(text.split('\n').filter((l) => l === 'same')).toHaveLength(1);
+  });
+
+  it('REJECTS rather than truncates when there is more text than can be moderated', () => {
+    // Truncating would be a moderation bypass by construction: put the
+    // disallowed text past the cutoff.
+    const many = Object.fromEntries(
+      Array.from({ length: 250 }, (_, i) => [
+        String(i),
+        { class_type: 'CLIPTextEncode', inputs: { text: `${i}-${'x'.repeat(200)}` } },
+      ])
+    ) as unknown as ComfyGraph;
+    expect(() => collectInlineAuditText({ prompt: '', graph: many })).toThrow(
+      /more text than can be moderated/
+    );
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// AIR SHAPE GATE. Every case here is a MEASURED property of `Air.parseSafe`
+// (@civitai/client 0.2.0-beta.84) that fails OPEN if the gate is naive.
+// ─────────────────────────────────────────────────────────────────────────────
+describe('assertViewerEntitledToInlineResources — AIR shape', () => {
+  it('🔴 rejects a NODEPACK URN while nodepacks are gated off (arbitrary code execution)', async () => {
+    expect(INLINE_NODEPACKS_ENABLED).toBe(false);
+    await expect(
+      assertViewerEntitledToInlineResources({
+        airs: ['urn:air:comfy:nodepack:comfyregistry:kijai/comfyui-kjnodes@1.4.0'],
+        user: VIEWER,
+      })
+    ).rejects.toThrow(/nodepack resources are not permitted/);
+  });
+
+  it('rejects a nodepack from ANY source, not just comfyregistry', async () => {
+    // The gate keys on the AIR `type`, not the source — a `civitai`-sourced
+    // nodepack is the same capability.
+    await expect(
+      assertViewerEntitledToInlineResources({
+        airs: ['urn:air:other:nodepack:civitai:123@456'],
+        user: VIEWER,
+      })
+    ).rejects.toThrow(/nodepack resources are not permitted/);
+  });
+
+  it('rejects an OCI container-image AIR arriving through `resources`', async () => {
+    await expect(
+      assertViewerEntitledToInlineResources({
+        airs: ['urn:air:oci:image:ghcr:evil/comfy@v1'],
+        user: VIEWER,
+      })
+    ).rejects.toThrow(/is not permitted in an inline workflow/);
+  });
+
+  it('🔴 OVER-STRICTNESS CONTROL — accepts every AIR the SHIPPED recipes actually pin', async () => {
+    // The strict reader is a second, deliberately narrower copy of the AIR
+    // grammar. Its failure direction is safe (false reject, never false accept),
+    // but a reader so strict it rejects the platform's own live AIRs is useless.
+    // These are copied verbatim from `recipes/seamless-pano.recipe.ts` — note
+    // the `/`-and-`.`-bearing huggingface versions and the underscored
+    // `diffusion_model` / `text_encoders` types, all of which a naive
+    // `[a-z0-9]+@\d+` reader would reject.
+    const shipped = [
+      'urn:air:zimageturbo:diffusion_model:huggingface:Comfy-Org/z_image_turbo@main/split_files/diffusion_models/z_image_turbo_bf16.safetensors',
+      'urn:air:qwen:clip:huggingface:Comfy-Org/z_image_turbo@main/split_files/text_encoders/qwen_3_4b_fp8_mixed.safetensors',
+      'urn:air:flux1:vae:huggingface:black-forest-labs/FLUX.1-dev@main/ae.safetensors',
+      'urn:air:qwen:diffusion_model:huggingface:unsloth/Qwen-Image-2512-GGUF@main/qwen-image-2512-Q5_K_M.gguf',
+      'urn:air:flux2:text_encoders:huggingface:Comfy-Org/vae-text-encorder-for-flux-klein-9b@main/split_files/text_encoders/qwen_3_8b_fp8mixed.safetensors',
+      'urn:air:zimageturbo:lora:civitai:118025@2702227',
+      'urn:air:qwen:lora:civitai:118025@2702222',
+      'urn:air:flux2:lora:civitai:118025@2702214',
+    ];
+    mockGetResourceData.mockImplementation(async (ids: number[]) =>
+      ids.map((id) => resourceRow({ id }))
+    );
+    await expect(
+      assertViewerEntitledToInlineResources({ airs: shipped, user: VIEWER })
+    ).resolves.toBeUndefined();
+    expect(mockGetResourceData).toHaveBeenCalledWith(
+      [2702227, 2702222, 2702214],
+      expect.anything()
+    );
+  });
+
+  it('🔴 rejects a PREFIX-LESS pseudo-AIR — a lenient reader accepts one', async () => {
+    // Measured: its regex is `^(?:urn:)?(?:air:)?…`, so 'sdxl:lora:civitai:1@2'
+    // parses and even 'foo:bar' parses as {source:'foo', id:'bar'}. parseSafe
+    // returning a value is NOT evidence the string is an AIR.
+    await expect(
+      assertViewerEntitledToInlineResources({
+        airs: ['sdxl:lora:civitai:118025@136251'],
+        user: VIEWER,
+      })
+    ).rejects.toThrow(/is not an AIR URN/);
+    await expect(
+      assertViewerEntitledToInlineResources({ airs: ['foo:bar'], user: VIEWER })
+    ).rejects.toThrow(/is not an AIR URN/);
+  });
+
+  it('🔴 an UPPERCASE `CIVITAI` source is still gated, not routed around the belt', async () => {
+    // Measured: `source` is case-preserving. A case-SENSITIVE
+    // `source === 'civitai'` test would send this down the non-civitai branch
+    // and skip entitlement entirely — a direct bypass.
+    mockGetResourceData.mockResolvedValue([resourceRow({ canGenerate: false })]);
+    await expect(
+      assertViewerEntitledToInlineResources({
+        airs: ['urn:air:sdxl:lora:CIVITAI:118025@136251'],
+        user: VIEWER,
+      })
+    ).rejects.toThrow(/not available for generation/);
+    // The belt was actually consulted, with the parsed version id.
+    expect(mockGetResourceData).toHaveBeenCalledWith([136251], expect.anything());
+  });
+
+  it('🔴 rejects a civitai AIR with no version, or a non-numeric one', async () => {
+    // Measured: `version` is an optional RAW STRING. `Number(undefined)` and
+    // `Number('def')` are both NaN, and a NaN id resolves nothing — which, via
+    // getResourceData's silent-drop, would look like "no gated resources here".
+    await expect(
+      assertViewerEntitledToInlineResources({
+        airs: ['urn:air:sdxl:lora:civitai:118025'],
+        user: VIEWER,
+      })
+    ).rejects.toThrow(/must name a model VERSION id/);
+    await expect(
+      assertViewerEntitledToInlineResources({
+        airs: ['urn:air:sdxl:lora:civitai:abc@def'],
+        user: VIEWER,
+      })
+    ).rejects.toThrow(/must name a model VERSION id/);
+    expect(mockGetResourceData).not.toHaveBeenCalled();
+  });
+
+  it('rejects a duplicate declaration rather than silently deduping', async () => {
+    await expect(
+      assertViewerEntitledToInlineResources({ airs: [LORA_AIR, LORA_AIR], user: VIEWER })
+    ).rejects.toThrow(/duplicate resource declared/);
+  });
+
+  it('a huggingface-only manifest needs no civitai belt call (exempt by construction)', async () => {
+    await expect(
+      assertViewerEntitledToInlineResources({ airs: [HF_AIR], user: VIEWER })
+    ).resolves.toBeUndefined();
+    expect(mockGetResourceData).not.toHaveBeenCalled();
+  });
+
+  it('POSITIVE CONTROL — a well-formed civitai AIR for a generatable resource passes', async () => {
+    await expect(
+      assertViewerEntitledToInlineResources({ airs: [LORA_AIR, HF_AIR], user: VIEWER })
+    ).resolves.toBeUndefined();
+    expect(mockGetResourceData).toHaveBeenCalledWith([136251], expect.anything());
+  });
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 🔴 THE TWO SILENT FAIL-OPENS. Both are cases where a checker that iterates the
+// RETURNED array and asserts `canGenerate` passes VACUOUSLY. These are the two
+// tests a normal plan omits, and they are the entire reason this belt is a
+// dedicated function rather than a call to getResourceData.
+// ─────────────────────────────────────────────────────────────────────────────
+describe('assertViewerEntitledToInlineResources — the silent fail-opens', () => {
+  it('🔴 ANTI-DROP: an id getResourceData silently drops is a REJECT, not an implicit allow', async () => {
+    // getResourceData does `if (!cached) return null` then `.filter(isDefined)`,
+    // so an unresolvable id simply is not in the result. "No bad resources in
+    // the array" is trivially true of an empty array.
+    mockGetResourceData.mockResolvedValue([]);
+    await expect(
+      assertViewerEntitledToInlineResources({ airs: [LORA_AIR], user: VIEWER })
+    ).rejects.toThrow(/model version 136251 is not available for generation/);
+  });
+
+  it('🔴 ANTI-DROP holds when only SOME of several ids come back', async () => {
+    mockGetResourceData.mockResolvedValue([resourceRow({ id: 136251 })]);
+    await expect(
+      assertViewerEntitledToInlineResources({
+        airs: [LORA_AIR, 'urn:air:sdxl:lora:civitai:118025@999999'],
+        user: VIEWER,
+      })
+    ).rejects.toThrow(/model version 999999 is not available for generation/);
+  });
+
+  it('🔴 ANTI-SUBSTITUTE: a resource carrying a `substitute` is a REJECT, never a swap', async () => {
+    // getResourceDataSubstitutes swaps an uncovered/inaccessible version for a
+    // covered sibling of the same model and attaches it as `resource.substitute`.
+    // Onsite that is graceful degradation; here the graph names ONE specific AIR
+    // string in `lora_name` and nothing rewrites the graph — running a different
+    // version silently is a correctness bug.
+    //
+    // Note the returned row KEEPS the requested id (the substitute is a sibling
+    // FIELD, not a replacement element), so an anti-drop check alone does not
+    // catch this — which is why `canGenerate` is left TRUE in this fixture.
+    mockGetResourceData.mockResolvedValue([
+      resourceRow({ canGenerate: true, substitute: { id: 999999, name: 'other version' } }),
+    ]);
+    await expect(
+      assertViewerEntitledToInlineResources({ airs: [LORA_AIR], user: VIEWER })
+    ).rejects.toThrow(/never silently substituted/);
+  });
+
+  it('rejects a resource whose canGenerate is false', async () => {
+    mockGetResourceData.mockResolvedValue([resourceRow({ canGenerate: false })]);
+    await expect(
+      assertViewerEntitledToInlineResources({ airs: [LORA_AIR], user: VIEWER })
+    ).rejects.toThrow(/not available for generation/);
+  });
+
+  it('EARLY ACCESS is covered, because getResourceData folds applyPaidAccessGating', async () => {
+    // applyPaidAccessGating sets `canGenerate = hasAccess && canGenerate`, so a
+    // non-entitled viewer of an early-access version comes back canGenerate:false.
+    // This pins that the belt READS that flag rather than re-deriving a weaker one.
+    mockGetResourceData.mockResolvedValue([
+      resourceRow({
+        canGenerate: false,
+        hasAccess: false,
+        paidAccess: { endsAt: null, terms: {} },
+      }),
+    ]);
+    await expect(
+      assertViewerEntitledToInlineResources({ airs: [LORA_AIR], user: VIEWER })
+    ).rejects.toThrow(/not available for generation/);
+  });
+});
+
+describe('assertViewerEntitledToInlineResources — Private / epoch subscription', () => {
+  it('rejects a Private resource for a viewer with no subscription', async () => {
+    mockGetResourceData.mockResolvedValue([resourceRow({ availability: 'Private' })]);
+    mockGetHighestTierSubscription.mockResolvedValue(null);
+    await expect(
+      assertViewerEntitledToInlineResources({ airs: [LORA_AIR], user: VIEWER })
+    ).rejects.toThrow(/requires an active subscription/);
+  });
+
+  it('POSITIVE CONTROL — the same resource passes for a subscriber', async () => {
+    mockGetResourceData.mockResolvedValue([resourceRow({ availability: 'Private' })]);
+    mockGetHighestTierSubscription.mockResolvedValue({ id: 'sub_1' });
+    await expect(
+      assertViewerEntitledToInlineResources({ airs: [LORA_AIR], user: VIEWER })
+    ).resolves.toBeUndefined();
+  });
+
+  it('an EPOCH resource takes the same subscription path', async () => {
+    mockGetResourceData.mockResolvedValue([
+      resourceRow({ epochDetails: { epochNumber: 3, isExpired: false } }),
+    ]);
+    mockGetHighestTierSubscription.mockResolvedValue(null);
+    await expect(
+      assertViewerEntitledToInlineResources({ airs: [LORA_AIR], user: VIEWER })
+    ).rejects.toThrow(/requires an active subscription/);
+  });
+
+  it('an EXPIRED epoch is rejected even for a subscriber', async () => {
+    mockGetResourceData.mockResolvedValue([
+      resourceRow({ epochDetails: { epochNumber: 3, isExpired: true } }),
+    ]);
+    mockGetHighestTierSubscription.mockResolvedValue({ id: 'sub_1' });
+    await expect(
+      assertViewerEntitledToInlineResources({ airs: [LORA_AIR], user: VIEWER })
+    ).rejects.toThrow(/epoch that has expired/);
+  });
+
+  it('a moderator skips the subscription requirement', async () => {
+    mockGetResourceData.mockResolvedValue([resourceRow({ availability: 'Private' })]);
+    mockGetHighestTierSubscription.mockResolvedValue(null);
+    await expect(
+      assertViewerEntitledToInlineResources({
+        airs: [LORA_AIR],
+        user: { id: 7, isModerator: true },
+      })
+    ).resolves.toBeUndefined();
+    expect(mockGetHighestTierSubscription).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/services/blocks/__tests__/inline-comfy.service.test.ts
+++ b/src/server/services/blocks/__tests__/inline-comfy.service.test.ts
@@ -191,13 +191,58 @@ describe('assertViewerEntitledToInlineResources — AIR shape', () => {
     ).rejects.toThrow(/nodepack resources are not permitted/);
   });
 
+  // ───────────────────────────────────────────────────────────────────────────
+  // 🔴 THE TYPE ALLOWLIST (`INLINE_ALLOWED_AIR_TYPES`) NEEDS AN ASSERTION ONLY
+  // IT CAN SATISFY. `comfyImage` — an arbitrary OCI container the claiming
+  // worker would run — is unsettable via the wire schema's `.strict()`; this
+  // guard is what stops the same capability arriving through `resources`.
+  //
+  // The trap it was written out of: the type guard and the SOURCE guard sit two
+  // lines apart and their messages share the tail `is not permitted in an inline
+  // workflow`. A `/is not permitted in an inline workflow/` assertion is
+  // therefore satisfied by EITHER — so deleting the type guard left the old
+  // version of the first case below still green, because the fixture's `ghcr`
+  // source then tripped the source guard instead. The two cases below fix that
+  // from both directions: each names the token in ITS OWN guard's message, and
+  // the second uses an ALLOWLISTED source so no sibling can stand in for it.
+  // ───────────────────────────────────────────────────────────────────────────
   it('rejects an OCI container-image AIR arriving through `resources`', async () => {
+    // MEASURED ORDER: the type guard runs BEFORE the source guard, so this
+    // fixture is rejected on `type: image`, not on `source: ghcr`. Asserting the
+    // type guard's own message is what makes this case die when that guard is
+    // removed rather than falling through to the source guard's identical tail.
     await expect(
       assertViewerEntitledToInlineResources({
         airs: ['urn:air:oci:image:ghcr:evil/comfy@v1'],
         user: VIEWER,
       })
-    ).rejects.toThrow(/is not permitted in an inline workflow/);
+    ).rejects.toThrow(/AIR type 'image' is not permitted in an inline workflow/);
+  });
+
+  it('🔴 …and from an ALLOWLISTED source too, where NO sibling guard could mask it', async () => {
+    // `huggingface` IS allowlisted, so the source guard cannot reject this AIR:
+    // the type guard is the only thing standing between an app and an arbitrary
+    // container image. Remove it and this case does not merely change its error
+    // — it stops throwing at all.
+    await expect(
+      assertViewerEntitledToInlineResources({
+        airs: ['urn:air:oci:image:huggingface:evil/comfy@v1'],
+        user: VIEWER,
+      })
+    ).rejects.toThrow(/AIR type 'image' is not permitted in an inline workflow/);
+  });
+
+  it('POSITIVE CONTROL — the same AIR with an ALLOWLISTED type is accepted', async () => {
+    // Isolates the `type` token as the cause: same source, same `oci` ecosystem,
+    // same `evil/comfy@v1` id and version — only `image` → `lora` changes, and
+    // the rejection goes away. Without this, the case above is also satisfied by
+    // a guard that rejects every huggingface AIR for some unrelated reason.
+    await expect(
+      assertViewerEntitledToInlineResources({
+        airs: ['urn:air:oci:lora:huggingface:evil/comfy@v1'],
+        user: VIEWER,
+      })
+    ).resolves.toBeUndefined();
   });
 
   it('🔴 OVER-STRICTNESS CONTROL — accepts every AIR the SHIPPED recipes actually pin', async () => {

--- a/src/server/services/blocks/inline-comfy.service.ts
+++ b/src/server/services/blocks/inline-comfy.service.ts
@@ -1,0 +1,443 @@
+import { TRPCError } from '@trpc/server';
+import { getResourceData } from '~/server/services/generation/generation.service';
+import { getHighestTierSubscription } from '~/server/services/subscriptions.service';
+import { Availability } from '~/shared/utils/prisma/enums';
+import { AIR_URN_PREFIX } from '~/server/services/blocks/steps';
+import type { ComfyGraph } from '~/server/services/blocks/recipes';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// App Blocks customComfy INLINE-GRAPH belt.
+//
+// An inline body (`kind:'customComfy'`, `mode:'inline'`) carries the ComfyUI
+// graph itself instead of naming a code-reviewed recipe. Code review WAS the
+// trust root for the recipe path; this module is what replaces it mechanically.
+// Three gates, all fail-closed, all THROWING (never returning a verdict a caller
+// can forget to read):
+//
+//   1. `assertInlineGraphAirsDeclared` — containment. Every AIR appearing
+//      anywhere in the graph must also appear in the declared `resources` array,
+//      so gating that array is gating everything.
+//   2. `assertViewerEntitledToInlineResources` — entitlement over `resources`.
+//   3. `collectInlineAuditText` — the moderation sweep (see below).
+//
+// 🔴 WHY THE ENTITLEMENT SURFACE IS A FLAT `string[]` AND NOT THE GRAPH.
+// `CustomComfyInput.resources` is the orchestrator's DECLARED DOWNLOAD MANIFEST
+// — "All resources the workflow needs, declared explicitly as AIR URNs …
+// Anything the workflow references that isn't listed here will fail at load time
+// inside ComfyUI" — while `CustomComfyInput.workflow` is "Forwarded opaquely to
+// the worker; the orchestrator does not inspect or validate node contents"
+// (both from the generated `@civitai/client` types). So the untrusted
+// entitlement surface is that array, and it does not need graph parsing.
+//
+// 🔴 THAT CLAIM IS TRUSTED BUT NOT DEPENDED ON. It comes from a doc comment on a
+// generated type, not from observed orchestrator behaviour. Gate 1 above is what
+// makes it non-load-bearing: if the orchestrator ever DID resolve an AIR the
+// graph names but `resources` omits, containment has already rejected that body.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * 🔴 NODEPACK AIRs ARE ARBITRARY CODE EXECUTION, AND ARE OFF FOR THIS INCREMENT.
+ *
+ * `CustomComfyInput.resources` accepts `comfy:nodepack` URNs (e.g.
+ * `urn:air:comfy:nodepack:comfyregistry:<owner>/<pack>@<version>`), which install
+ * third-party custom nodes into the ComfyUI container at runtime. Allowing an app
+ * to name one is allowing an app to run code we have not reviewed, sandboxed only
+ * by the worker container. That is a product/security decision with a named owner,
+ * and it has NOT been made — so this ships CLOSED rather than shipping the
+ * decision by default.
+ *
+ * Consequence, stated plainly: inline graphs are limited to STOCK ComfyUI nodes
+ * plus non-nodepack AIRs. An app needing a custom node pack is still blocked.
+ *
+ * Enabling it later is a one-line flip, and the tests for both states already
+ * exist (`inline-comfy.service.test.ts` covers rejection now, and the
+ * allowlist derivation below is keyed off this flag so nothing else moves).
+ */
+export const INLINE_NODEPACKS_ENABLED = false;
+
+/**
+ * AIR `source` values an inline `resources` entry may name. ALLOWLIST, not a
+ * denylist — an unrecognised source is a resource class nobody has reasoned
+ * about, and the fail-closed answer is to reject it.
+ *
+ * `civitai` carries civitai entitlement and is gated below. `huggingface` is the
+ * public-weights source both shipped recipes already pin (see the `staticAirs`
+ * in `recipes/seamless-pano.recipe.ts`), so it is exempt-by-construction: there
+ * is no civitai entitlement to check on a public HF repo.
+ */
+const INLINE_ALLOWED_AIR_SOURCES: ReadonlySet<string> = new Set(
+  INLINE_NODEPACKS_ENABLED
+    ? ['civitai', 'huggingface', 'comfyregistry']
+    : ['civitai', 'huggingface']
+);
+
+/**
+ * AIR `type` values an inline `resources` entry may name — model WEIGHTS only.
+ *
+ * 🔴 THIS IS NOT DERIVED FROM `shared/utils/air.ts`'s `typeUrnMap`, AND THAT IS
+ * DELIBERATE. That map is the civitai `ModelType` → URN direction and does not
+ * cover the URN spellings the orchestrator actually accepts: both shipped
+ * recipes pin `diffusion_model` and `text_encoders` (underscored), which
+ * `typeUrnMap` does not contain (it has `diffusionmodel` / `text_encoders`
+ * inconsistently). Deriving from it would reject the platform's own live AIRs.
+ *
+ * Two exclusions are the point of the list, not incidental:
+ *   - `nodepack` — arbitrary code execution (see INLINE_NODEPACKS_ENABLED).
+ *   - `image`    — an `urn:air:oci:image:…` OCI container image. `comfyImage` is
+ *                  already unsettable via the wire schema's `.strict()`; this
+ *                  stops the same capability arriving through `resources`.
+ */
+const INLINE_ALLOWED_AIR_TYPES: ReadonlySet<string> = new Set([
+  'checkpoint',
+  'diffusion_model',
+  'diffusionmodel',
+  'unet',
+  'lora',
+  'lycoris',
+  'dora',
+  'embedding',
+  'hypernet',
+  'controlnet',
+  'vae',
+  'upscaler',
+  'clip',
+  'clipvision',
+  'text_encoders',
+  'motion',
+  'ag',
+  'visionlanguage',
+  ...(INLINE_NODEPACKS_ENABLED ? ['nodepack'] : []),
+]);
+
+/**
+ * Recursion budget for the graph walk. Same value and the same fail-closed
+ * posture as `AIR_SCAN_MAX_DEPTH` in `services/blocks/steps` (which is module-
+ * private there): an unbounded recursion over attacker-shaped JSON hits
+ * `RangeError: Maximum call stack size exceeded` at ~5k levels, which a small
+ * `[[[[…]]]]` body reaches trivially — a free 500 from a value the guard was
+ * supposed to DECIDE on. At the cap we THROW a BAD_REQUEST, i.e. "I could not
+ * prove this graph is safe to run", never a silent partial walk.
+ */
+const INLINE_GRAPH_MAX_DEPTH = 128;
+
+/**
+ * Max characters of graph-derived text handed to the prompt audit.
+ *
+ * 🔴 EXCEEDING IT REJECTS, IT DOES NOT TRUNCATE. Truncating would be a
+ * moderation bypass by construction — put the disallowed text past the cutoff.
+ * The wire schema's `INLINE_GRAPH_BYTES_MAX` already bounds the graph well below
+ * anything that should reach this, so this is a backstop, not a routine limit.
+ */
+const INLINE_AUDIT_TEXT_MAX = 20_000;
+
+function badRequest(message: string): TRPCError {
+  return new TRPCError({ code: 'BAD_REQUEST', message });
+}
+
+/**
+ * One total walk over the graph, collecting every STRING that appears anywhere —
+ * as a leaf, an array element, an object VALUE, **or an object KEY**.
+ *
+ * 🔴 KEYS ARE WALKED, AND THAT IS THE ORCHESTRATOR'S OWN SCHEMA, NOT PARANOIA.
+ * `ImageJobParams.additionalNetworks` is documented "Use the AIR of the network
+ * as the key" and `WorkflowCost.fees` is likewise AIR-keyed, so a walk over
+ * `Object.values` alone misses the single most likely real placement of an AIR.
+ * This mirrors `containsAirReference` (`services/blocks/steps`) exactly — same
+ * shape, but COLLECTING instead of returning a boolean.
+ *
+ * Both consumers below need this same walk, so it runs ONCE.
+ */
+export function collectInlineGraphStrings(value: unknown, depth = 0, out: string[] = []): string[] {
+  if (depth > INLINE_GRAPH_MAX_DEPTH) {
+    throw badRequest('inline workflow is nested too deeply to inspect');
+  }
+  if (typeof value === 'string') {
+    out.push(value);
+    return out;
+  }
+  if (Array.isArray(value)) {
+    for (const v of value) collectInlineGraphStrings(v, depth + 1, out);
+    return out;
+  }
+  if (value !== null && typeof value === 'object') {
+    for (const [key, v] of Object.entries(value as Record<string, unknown>)) {
+      collectInlineGraphStrings(key, depth + 1, out);
+      collectInlineGraphStrings(v, depth + 1, out);
+    }
+  }
+  return out;
+}
+
+/**
+ * CONTAINMENT: every AIR appearing in the graph must also be declared in
+ * `resources`. Without this, `resources` is not the whole entitlement surface
+ * and gating it proves nothing.
+ *
+ * 🔴 THE MATCH IS WHOLE-STRING, NOT SUBSTRING-EXTRACTION, AND THAT IS STRICTER
+ * ON PURPOSE. A string that merely CONTAINS `urn:air:` must equal a declared AIR
+ * outright (trimmed, case-insensitively). Reconstructing the AIR grammar with a
+ * regex to pull a URN out of a longer string would create a second, drifting
+ * copy of that grammar — and any mismatch between the extractor and what the
+ * worker actually resolves is exactly the bypass this gate exists to close. A
+ * real ComfyUI graph carries the bare AIR as an input value (`unet_name`,
+ * `lora_name`), so whole-string is what the legitimate case already does.
+ */
+export function assertInlineGraphAirsDeclared(graph: ComfyGraph, declared: string[]): void {
+  const declaredSet = new Set(declared.map((a) => a.trim().toLowerCase()));
+  for (const s of collectInlineGraphStrings(graph)) {
+    const lowered = s.toLowerCase();
+    if (!lowered.includes(AIR_URN_PREFIX)) continue;
+    if (!declaredSet.has(lowered.trim())) {
+      throw badRequest(
+        `inline workflow references an AIR that is not declared in resources: '${s.slice(0, 200)}'`
+      );
+    }
+  }
+}
+
+/**
+ * The text handed to `auditPromptServer` for an inline body.
+ *
+ * 🔴 THIS IS THE WHOLE REASON MODERATION STILL WORKS ON THIS PATH. On the recipe
+ * arm the audit reads `params.prompt`, a field the recipe's `.strict()` schema
+ * guarantees exists. An inline graph carries its prompts as leaf strings inside
+ * `CLIPTextEncode` nodes, so auditing a declared field alone would leave the
+ * audit reading a value the generation does not use — moderation would become a
+ * silent no-op while every gate stayed green. The declared prompt is audited
+ * AND the graph is swept, so a clean declared prompt cannot launder a graph
+ * prompt.
+ *
+ * Concatenation is sound here because the audit is a regex + external-classifier
+ * scan over text: adding more text can only ADD triggers, never remove one. Leaves are
+ * newline-joined so a trigger cannot be manufactured across a boundary that
+ * exists in neither string.
+ */
+export function collectInlineAuditText(opts: { prompt: string; graph: ComfyGraph }): string {
+  const leaves = collectInlineGraphStrings(opts.graph);
+  // Deduped: a graph repeats class names and input keys on every node, and the
+  // audit gains nothing from the hundredth 'CLIPTextEncode'.
+  const seen = new Set<string>();
+  const parts: string[] = [];
+  if (opts.prompt.trim()) parts.push(opts.prompt);
+  for (const leaf of leaves) {
+    const t = leaf.trim();
+    if (!t || seen.has(t)) continue;
+    seen.add(t);
+    parts.push(t);
+  }
+  const text = parts.join('\n');
+  if (text.length > INLINE_AUDIT_TEXT_MAX) {
+    throw badRequest(
+      `inline workflow carries more text than can be moderated (${text.length} > ${INLINE_AUDIT_TEXT_MAX} characters)`
+    );
+  }
+  return text;
+}
+
+type ParsedInlineAir = {
+  raw: string;
+  source: string;
+  type: string;
+  /** Present only for `source === 'civitai'` — a positive integer version id. */
+  versionId?: number;
+};
+
+/**
+ * STRICT AIR reader: `urn:air:<ecosystem>:<type>:<source>:<id>[@<version>]`.
+ * All four segments REQUIRED. Case-insensitive on structure; `type` and `source`
+ * are lowercased after extraction, `id`/`version` keep their case (a
+ * huggingface id is case-sensitive, e.g. `black-forest-labs/FLUX.1-dev`).
+ *
+ * 🔴 WHY THIS IS NOT `Air.parseSafe` FROM `@civitai/client`, EVEN THOUGH THAT
+ * EXISTS AND `shared/utils/air.ts` WRAPS IT. That parser is a LENIENT READER for
+ * input we already trust; this is a GATE over input we do not. Measured against
+ * `@civitai/client` 0.2.0-beta.84 by running it, its regex
+ * (`^(?:urn:)?(?:air:)?(?:(?<ecosystem>…):)?(?:(?<type>…):)?(?<source>…):(?<id>…)…`)
+ * has three properties that each fail OPEN here:
+ *
+ *   1. **The `urn:air:` prefix is OPTIONAL, and so are `ecosystem` and `type`.**
+ *      `'sdxl:lora:civitai:118025@136251'` parses, and even `'foo:bar'` parses as
+ *      `{source:'foo', id:'bar'}`. So "parseSafe returned a value" is NOT
+ *      evidence the string is an AIR, and a `type`-based gate reads `undefined`
+ *      for any string that omits it.
+ *   2. **`source` is CASE-PRESERVING.** `'urn:air:sdxl:lora:CIVITAI:118025@136251'`
+ *      parses with `source: 'CIVITAI'`. A case-SENSITIVE `source === 'civitai'`
+ *      test routes that down the non-civitai branch and skips the entitlement
+ *      belt entirely — a direct bypass.
+ *   3. **`version` is an optional RAW STRING, not a number.**
+ *      `'…:civitai:118025'` yields `undefined` and `'…:civitai:abc@def'` yields
+ *      `'def'`; `Number()` on either is `NaN`. A `NaN` id resolves nothing in
+ *      `getResourceData` and — through its silent-drop behaviour — reads as "no
+ *      gated resources here".
+ *
+ * 🔴 A SECOND, STRICTER COPY OF THE GRAMMAR IS SAFE HERE, AND THE DIRECTION IS
+ * WHY. A divergence between this reader and whatever the worker resolves can
+ * only make this reader reject something the worker would have accepted — a
+ * false REJECT, never a false accept. (The containment check deliberately does
+ * NOT parse at all, for exactly the opposite reason: there a divergence would be
+ * a bypass, so it compares whole strings.) `inline-comfy.service.test.ts` pins
+ * this against the AIRs the SHIPPED recipes actually use, so over-strictness has
+ * a test that goes red.
+ */
+const STRICT_AIR_RE =
+  /^urn:air:([a-z0-9_\-/]+):([a-z0-9_\-/]+):([a-z0-9_\-/]+):([^@\s]+)(?:@(\S+))?$/i;
+
+function parseInlineAir(raw: string): ParsedInlineAir {
+  const trimmed = raw.trim();
+  if (!trimmed.toLowerCase().startsWith(AIR_URN_PREFIX)) {
+    throw badRequest(`resource is not an AIR URN: '${trimmed.slice(0, 200)}'`);
+  }
+  const match = STRICT_AIR_RE.exec(trimmed);
+  if (!match) {
+    throw badRequest(
+      `resource is not a well-formed AIR URN: '${trimmed.slice(0, 200)}' — expected ` +
+        'urn:air:<ecosystem>:<type>:<source>:<id>[@<version>]'
+    );
+  }
+  const type = match[2].toLowerCase();
+  const source = match[3].toLowerCase();
+  const rawVersion: string | undefined = match[5];
+
+  if (type === 'nodepack' && !INLINE_NODEPACKS_ENABLED) {
+    throw badRequest(
+      `nodepack resources are not permitted in an inline workflow: '${trimmed.slice(0, 200)}' ` +
+        '— a node pack installs third-party code into the ComfyUI container at runtime'
+    );
+  }
+  if (!INLINE_ALLOWED_AIR_TYPES.has(type)) {
+    throw badRequest(
+      `resource AIR type '${type || '(none)'}' is not permitted in an inline workflow`
+    );
+  }
+  if (!INLINE_ALLOWED_AIR_SOURCES.has(source)) {
+    throw badRequest(
+      `resource AIR source '${source || '(none)'}' is not permitted in an inline workflow`
+    );
+  }
+
+  if (source !== 'civitai') return { raw: trimmed, source, type };
+
+  const version = rawVersion;
+  if (!version || !/^\d+$/.test(version) || Number(version) <= 0) {
+    throw badRequest(
+      `civitai resource AIR must name a model VERSION id: '${trimmed.slice(0, 200)}' ` +
+        '— without one there is no version to check entitlement against'
+    );
+  }
+  return { raw: trimmed, source, type, versionId: Number(version) };
+}
+
+/**
+ * THE ENTITLEMENT BELT for an app-supplied `resources` array. Returns nothing;
+ * THROWS on any failure. Fail-closed throughout.
+ *
+ * 🔴 WHY THIS IS NOT `assertViewerCanGeneratePageResources`. That gate (used by
+ * the recipe arm and the txt2img page path) runs `resolveCanGenerateForVersions`,
+ * which covers baseline generatability — coverage, status, `usageControl`, NSFW
+ * tier, hidden gates — and does NOT cover early-access `hasAccess` NOR
+ * Private-model subscription. On the recipe path that was survivable because a
+ * recipe may only pin fully-public versions and a human reviewed each one. An
+ * inline graph removes exactly that protection, so this path uses
+ * `getResourceData`, which folds `applyPaidAccessGating` internally
+ * (`generation.service.ts`, and `paid-access-gating.ts` does
+ * `canGenerate = hasAccess && canGenerate`) — early-access comes with it — plus
+ * the Private/epoch subscription check, which does NOT live in `getResourceData`
+ * and is ported here from the onsite belt (`validateAndEnrichResources` in
+ * `services/orchestrator/orchestration-new.service`, which is not exported).
+ *
+ * 🔴 TWO SILENT FAIL-OPENS IN `getResourceData` THAT THIS FUNCTION EXISTS TO
+ * CLOSE. A checker that iterates the RETURNED array and asserts `canGenerate`
+ * passes VACUOUSLY on both:
+ *
+ *   A. **It DROPS unresolvable ids.** Its fetch does `if (!cached) return null`
+ *      then `.filter(isDefined)`, so an id that resolves to nothing simply is
+ *      not in the result — and "no bad resources in the array" is trivially true
+ *      of an empty array. We assert PER REQUESTED ID that a row came back.
+ *   B. **It SUBSTITUTES.** `getResourceDataSubstitutes` finds a covered,
+ *      accessible sibling version of the same model for any resource that is
+ *      `!covered || !hasAccess`, and attaches it as `resource.substitute`.
+ *      Onsite that is graceful degradation; HERE it is a correctness bug, because
+ *      the graph names one specific AIR string in `unet_name`/`lora_name` and
+ *      nothing rewrites the graph. A present `substitute` is a REJECT.
+ *      (Note the returned row keeps the REQUESTED id — the substitute is a
+ *      sibling FIELD, not a replacement element. A gate that only checked
+ *      "id came back" would miss this, which is why it is checked separately.)
+ */
+export async function assertViewerEntitledToInlineResources(opts: {
+  airs: string[];
+  user: { id: number; isModerator: boolean };
+}): Promise<void> {
+  const parsed = opts.airs.map(parseInlineAir);
+
+  // Duplicate declarations are pointless and make the per-id accounting below
+  // ambiguous; reject rather than silently dedupe.
+  const rawSeen = new Set<string>();
+  for (const p of parsed) {
+    const key = p.raw.toLowerCase();
+    if (rawSeen.has(key)) throw badRequest(`duplicate resource declared: '${p.raw.slice(0, 200)}'`);
+    rawSeen.add(key);
+  }
+
+  const versionIds = parsed
+    .map((p) => p.versionId)
+    .filter((v): v is number => typeof v === 'number');
+  if (versionIds.length === 0) return;
+
+  const resources = await getResourceData(versionIds, {
+    user: { id: opts.user.id, isModerator: opts.user.isModerator },
+    generation: true,
+  });
+  const byId = new Map(resources.map((r) => [r.id, r]));
+
+  for (const id of versionIds) {
+    const resource = byId.get(id);
+    // (A) anti-drop.
+    if (!resource) {
+      throw new TRPCError({
+        code: 'FORBIDDEN',
+        message: `model version ${id} is not available for generation`,
+      });
+    }
+    // (B) anti-substitute. The graph pins a specific AIR; a different version is
+    // not an acceptable answer here even though it is onsite.
+    if (resource.substitute) {
+      throw new TRPCError({
+        code: 'FORBIDDEN',
+        message:
+          `model version ${id} is not available for generation ` +
+          '(a different version of that model is, but an inline workflow names a specific ' +
+          'resource and is never silently substituted)',
+      });
+    }
+    if (!resource.canGenerate) {
+      throw new TRPCError({
+        code: 'FORBIDDEN',
+        message: `model version ${id} is not available for generation`,
+      });
+    }
+  }
+
+  // Private / epoch resources require an active subscription. Ported from the
+  // onsite belt; NOT covered by `getResourceData`.
+  const hasPrivateOrEpoch = resources.some(
+    (r) => r.availability === Availability.Private || !!r.epochDetails
+  );
+  if (hasPrivateOrEpoch && !opts.user.isModerator) {
+    const subscription = await getHighestTierSubscription(opts.user.id);
+    if (!subscription) {
+      throw new TRPCError({
+        code: 'FORBIDDEN',
+        message: 'Using Private resources requires an active subscription.',
+      });
+    }
+  }
+
+  // Expired epochs — same source, same posture.
+  const expired = resources.find((r) => r.epochDetails?.isExpired);
+  if (expired) {
+    throw new TRPCError({
+      code: 'FORBIDDEN',
+      message: `model version ${expired.id} uses an epoch that has expired`,
+    });
+  }
+}

--- a/src/server/services/blocks/recipes/index.ts
+++ b/src/server/services/blocks/recipes/index.ts
@@ -72,9 +72,13 @@ export type RecipeCivitaiResource = {
 //
 // WHY this is a hard invariant and not just a preference: a raw customComfy step
 // submits its `input.resources` AIR array DIRECTLY to the orchestrator, which
-// BYPASSES `getGenerationResourceData`'s early-access / Private belt — that belt
-// only runs over generation-GRAPH steps (textToImage/comfy), never over a
-// hand-authored customComfy `resources` array. The router-side gate the belt
+// BYPASSES the generation path's early-access / Private belt — that belt
+// (`validateAndEnrichResources` → `getResourceData`, which folds
+// `applyPaidAccessGating`) only runs over generation-GRAPH steps
+// (textToImage/comfy), never over a hand-authored customComfy `resources` array.
+// 🔴 NAME CORRECTED: this used to cite `getGenerationResourceData`, which does
+// not exist anywhere in `src` — the substance was right, the address was not.
+// The router-side gate the belt
 // leans on (`resolveCanGenerateForVersions` → `assertViewerCanGeneratePageResources`
 // in blocks.router.ts `submitCustomComfyWorkflow`) covers baseline generatability
 // (usageControl / covered / NSFW-tier) but does NOT currently cover early-access
@@ -103,6 +107,19 @@ export type RecipeCivitaiResource = {
 // Private-subscription entitlement gate over `recipeCivitaiVersionIds(recipe)` in
 // `submitCustomComfyWorkflow` (blocks.router.ts) so the invariant is ENFORCED at
 // submit, not merely asserted by review — then this comment can relax to "prefer".
+//
+// 🔴 STATUS: THAT GATE NOW EXISTS, BUT ONLY ON THE INLINE ARM — THIS TODO IS
+// STILL OPEN FOR RECIPES. `assertViewerEntitledToInlineResources`
+// (`services/blocks/inline-comfy.service`) is exactly the gate described above:
+// it runs `getResourceData` (early-access `hasAccess` folded in) plus the
+// Private/epoch subscription check, plus anti-drop and anti-substitute asserts.
+// It is wired into `submitCustomComfyWorkflow`'s INLINE branch only, because
+// that branch has no code review behind it and needed a mechanical replacement.
+// The RECIPE branch above still runs `assertViewerCanGeneratePageResources`
+// (the weaker gate), so the invariant in this block remains load-bearing for
+// every recipe. Pointing the recipe branch at the same function is a small,
+// separate change — deliberately not folded in here, because it would alter the
+// behaviour of the two SHIPPED recipes in a PR whose subject is a new arm.
 // ─────────────────────────────────────────────────────────────────────────────
 
 /**


### PR DESCRIPTION
## What changed

An App Block can now submit a `customComfy` body carrying the **ComfyUI workflow graph inline**, instead of naming one of the two pre-registered recipes. The recipe path is untouched.

Wire shape — a **second arm** on the existing `kind:'customComfy'` member, discriminated by `mode`:

```jsonc
{ "kind": "customComfy", "mode": "inline",
  "workflow": { "1": { "class_type": "CLIPTextEncode", "inputs": { "text": "…" } } },
  "resources": ["urn:air:sdxl:lora:civitai:118025@136251"],
  "prompt": "…", "negativePrompt": "…",
  "maxBuzz": 60 }
```

A body with **no `mode` key is a recipe body** and parses byte-identically to before — every deployed app and every published `@civitai/app-sdk` body is unaffected.

`customComfy` already had a working estimate → submit → post-paid billing → output-extraction path. This widens what it accepts; it does not build a pipeline. **The entire spend belt — static gate, per-user daily reservation, per-app aggregate reservation, dev-session backstop, settle-to-actual — is reused untouched**, because it only ever consumed a ceiling number.

### The trust-model change, stated plainly

A recipe is a code-reviewed in-repo artifact, and that review was the trust root for three things at once. An inline graph has no review, so each is replaced by a mechanical gate. The model moves from *"a human reviewed this graph"* to *"the belt gates the resources, the timeout caps the spend, the audit gates the text, and only developers can reach it."*

`assertViewerIsAppDeveloper` + page-only + the mod-only pre-GA flag are **unchanged and load-bearing** — they are what bounds the blast radius of everything below. Nothing here relaxes them.

---

## Gate 1 — entitlement over app-supplied `resources`

`services/blocks/recipes/index.ts` documented that an app-supplied `resources` array bypasses the early-access / Private belt, and that this was safe *only because recipes are code-reviewed*. Inline graphs remove exactly that protection. There was already a `TODO(app-blocks customComfy pre-GA)` naming the fix site.

New `services/blocks/inline-comfy.service.ts` gates the array:

- **`getResourceData`** (exported, context-free) folds `applyPaidAccessGating` internally, and `paid-access-gating.ts` does `canGenerate = hasAccess && canGenerate` — so **early-access comes with it**.
- The **Private/epoch subscription throw** does *not* live in `getResourceData`; it is ported from `validateAndEnrichResources` (`orchestration-new.service`, not exported).
- The onsite belt `validateAndEnrichResources` itself is **not** reusable — not exported, and it reads a `GenerationGraphOutput` an app path never produces.

### The three silent fail-opens, each with its own test

A checker that iterates the **returned** array and asserts `canGenerate` passes **vacuously** on the first two:

| # | Mechanism | Behaviour here |
|---|---|---|
| 1 | `getResourceData` **drops** unresolvable ids (`if (!cached) return null` → `.filter(isDefined)`) — "no bad resources" is trivially true of an empty array | asserted **per requested id**; a dropped id is a REJECT |
| 2 | `getResourceData` **substitutes** — `getResourceDataSubstitutes` attaches a covered sibling as `resource.substitute`. Onsite that is graceful degradation; here the graph names one specific AIR in `lora_name` and nothing rewrites it | a present `substitute` is a REJECT |
| 3 | The gate the recipe arm uses (`resolveCanGenerateForVersions`) is the **weak** one — no `hasAccess`, no Private | inline uses `getResourceData`, not that gate |

Note on #2: the returned row **keeps the requested id** (the substitute is a sibling *field*, not a replacement element), so an anti-drop check alone does not catch it. The test fixture leaves `canGenerate: true` precisely so it can only pass via the substitute check.

### AIR shape — three measured parser properties that each fail open

The gate uses an explicit **strict** reader rather than `Air.parseSafe`. Measured by running `@civitai/client` 0.2.0-beta.84:

1. **The `urn:air:` prefix is optional, and so are `ecosystem`/`type`.** `'sdxl:lora:civitai:118025@136251'` parses; `'foo:bar'` parses as `{source:'foo', id:'bar'}`. "parseSafe returned a value" is not evidence the string is an AIR.
2. **`source` is case-preserving.** `urn:air:sdxl:lora:CIVITAI:118025@136251` yields `source: 'CIVITAI'` — a case-sensitive `=== 'civitai'` test routes it down the non-civitai branch and **skips entitlement entirely**.
3. **`version` is an optional raw string.** `Number(undefined)` and `Number('def')` are both `NaN`; a `NaN` id resolves nothing and, via the silent drop above, reads as "no gated resources here".

A second, stricter copy of the grammar is safe **because of its direction**: divergence can only cause a false *reject*, never a false accept. (The containment check deliberately does not parse at all — there divergence would be a bypass, so it compares whole strings.) A test pins the reader against the AIRs the shipped recipes actually use, so over-strictness goes red.

`resources` also passes an **allowlist** of AIR `type` and `source` (weights only), which rejects `oci:image` arriving through `resources` — the same capability as the blocked `comfyImage` field.

---

## Gate 2 — prompt moderation

`auditPromptServer` reads `params.prompt`, guaranteed on the recipe arm by the recipe's `.strict()` schema. An inline graph carries its prompts as leaf strings inside `CLIPTextEncode` nodes, so **moderation would silently become a no-op with every gate green**.

The graph is swept for string leaves — keys **and** values, mirroring `containsAirReference`, because `additionalNetworks` is documented "Use the AIR of the network as the key" — and the joined text is audited alongside the declared prompt. Same traversal as the containment check.

Two deliberate choices:
- **Over-cap rejects, it does not truncate.** Truncating is a moderation bypass by construction: put the disallowed text past the cutoff.
- **Depth cap throws**, fail-closed, rather than recursing to a `RangeError` on attacker-shaped JSON.

---

## Never-app-settable fields

`sessionOwnerApiToken` (a Civitai API token forwarded to the claiming worker), `comfyImage` (an arbitrary OCI container), `minVramGb` (changes the worker tier and therefore the Buzz/second rate the whole ceiling argument rests on), `sessionId`, `useSageAttention`, `minimumDurationSeconds`.

Two belts: the step input is **constructed server-side from an allowlist** (`{resources, trace, workflow}` — the body is never spread), and the wire arm is `.strict()`. Tested from both directions, including an assertion on the exact emitted key set.

---

## Display estimate

A real `whatIf` returns 0 for `customComfy`, so today the recipe's hand-written per-engine number is what the user sees. An inline graph has no honest per-engine number and none can be derived — the orchestrator forwards the graph opaquely and cannot price it.

The declared `maxBuzz` ceiling **is** the honest answer, because it is physically enforced: the server stamps `stepTimeoutSeconds = maxBuzz` as the step timeout, the job is cancelled there, and settle-to-actual refunds the difference. The user sees a true upper bound and is charged the real cost.

⚠️ **Surface this as "up to N Buzz", not as a price.** `cost.total` is the same field the txt2img path fills with a real estimate, so a UI rendering it as a definite price will overstate an inline job. That is a copy change in `@civitai/app-sdk` / the block — **tracked separately, not done here**, and called out in the code.

---

## Where `INLINE_MAX_BUZZ = 250` came from

Derived, not invented:

| Reference | Value | Where |
|---|---|---|
| `DEV_BUZZ_BUDGET_CAP` | **250** | `services/blocks/dev-scoped-mint.service.ts` — per-call budget cap on the developer path |
| `BUZZ_BUDGET_CAP` | 1000 | `pages/api/v1/block-tokens/index.ts` — platform-wide per-call cap |
| `BUZZ_BUDGET_DEFAULT` | 10 | same file |
| Largest shipped recipe ceiling | 180 | `seamless-pano-360`, `qwen-image` engine |

This surface is developer-only, and the developer path's own per-call ceiling is already 250 — anything above it is unreachable through a dev token anyway, since the static gate fail-snapshots on `ceiling > claims.buzzBudget`. It also sits comfortably above the largest shipped recipe ceiling, so an inline graph is not more constrained than a recipe.

It is spelled as a literal (the wire layer must stay import-light) with **a test pinning `INLINE_MAX_BUZZ === DEV_BUZZ_BUDGET_CAP`**, so the derivation cannot drift silently.

---

## 🔴 What I deliberately did NOT do: nodepacks

`INLINE_NODEPACKS_ENABLED = false`. A `comfy:nodepack` URN in `resources` installs third-party custom nodes into the ComfyUI container at runtime — **arbitrary code execution**, sandboxed only by the worker container. That is a product/security decision with a named owner and it has not been made, so this ships **closed** rather than shipping the decision by default.

**Consequence, stated plainly: inline graphs are limited to stock ComfyUI nodes plus non-nodepack AIRs. An app needing a custom node pack is still blocked.**

Enabling it is a one-line flip of the constant — the source/type allowlists are keyed off it, and tests for the rejecting state already exist. A follow-up PR flips it.

Also deliberately not done: nodepack **snapshot pinning** (`comfyNodepackSnapshot` is not in the step registry); migrating `customComfy` onto the `kind:'step'` registry (explicitly out of scope per `workflow.schema.ts`); retiring the recipe path; relaxing developer-only access; pointing the **recipe** branch at the new belt (that would change the behaviour of two shipped recipes in a PR whose subject is a new arm — the `TODO` is updated to say so rather than silently closed).

---

## 🔴 Two zod findings worth reading before reviewing the union

Both **measured by running zod 4.0.17**, not reasoned about. The obvious spellings fail, and one fails in production only:

1. Adding the inline arm as a **fourth option** of the outer discriminated union throws `Duplicate discriminator value "customComfy"` — zod's discriminated union is a value→schema map.
2. Nesting on `mode` with the recipe arm declaring **`mode: z.literal('recipe').default('recipe')`** constructs fine, type-checks, builds — and then **rejects every deployed recipe body** with `No matching discriminator`. zod reads the discriminator off the schema and does not see it through a `.default()`. This is the dangerous one.
3. Wrapping everything in a flat `z.union([discriminatedUnion, inlineArm])` parses every body correctly **but degrades the error shape**: a rejected body reports one top-level `invalid_union` issue with `path: []` instead of `path: ['step']` / `path: ['recipe']`. That path is the only diagnostic an app author gets for a bounced submit, and it **broke an existing assertion in `workflow.schema.step.test.ts`** — which is how I caught it.

The landed construction uses **`mode: z.literal('recipe').optional()`** on the recipe arm inside a nested discriminated union. `.optional()` works where `.default()` does not: zod treats `undefined` as a legitimate discriminator value, so a body with no `mode` lands on the recipe arm and the outer union stays a real discriminated union with per-field error paths intact.

Failure modes 2 and 3 both have mutations in the sweep below.

---

## Verification

### Typecheck
`pnpm run typecheck` → **`typecheck: OK — 0 type errors in 200s (heap cap 8192 MB)`** — the wrapper's own classification line, not an exit code.

### Test counts

| Suite | Base (`origin/main`) | HEAD |
|---|---|---|
| `blocks.router.workflow.test.ts` | 314 passed | **327 passed** (+13) |
| `inline-comfy.service.test.ts` | — (new) | **31 passed** |
| `workflow.schema.inline-comfy.test.ts` | — (new) | **25 passed** |
| `services/blocks` + `schema/blocks` + router workflow | — | **122 files, 3092 passed, 0 failed, 0 skipped** |

### Lint — before/after comparison, not just "clean"
ESLint on the modified router test reports **1 error + 15 warnings**. The *identical* file at `origin/main` reports **the same 1 error + 15 warnings** (a pre-existing `consistent-type-imports` error on an untouched line). **Zero new lint problems.** Prettier: clean on all 7 changed files — and it reported issues on 3 of them before I ran `--write`, so the pass is not a matched-nothing pass.

### 🔴 Red→green matrix — by mutation, and here is why

Most tests here cover a **feature that did not previously exist**, so "red at base" is not available for them: at `origin/main` the test files do not import, which reports *zero tests collected* rather than a failure — a green-looking non-signal, not evidence. Rather than report a matrix that cannot mean anything, every gate was **mutation-tested at HEAD**: break the gate on purpose, confirm the named test goes red, and read *which* assertion failed.

The sweep has its own controls, run before any verdict was read:
- **Positive control** — every `-t` filter must select >0 tests on the clean tree. This caught a real fault: one filter matched **zero** tests, which would have reported "0 failed" and been indistinguishable from a surviving mutant. The sweep aborted, the filter was fixed, and it was re-run.
- **Negative control** — all selected tests must pass on the clean tree.
- Each mutation's application is verified by occurrence count before running (a non-applying patch is reported, never silently scored as "killed").

**Result: 19/19 mutations killed.**

| # | Mutation | Test that went red |
|---|---|---|
| M1 | `INLINE_NODEPACKS_ENABLED` → `true` | nodepack rejection (×2) |
| M2 | accept a silently-dropped id | ANTI-DROP (×2) |
| M3 | accept a substituted version | ANTI-SUBSTITUTE |
| M4 | drop the `urn:air:` prefix requirement | prefix-less pseudo-AIR |
| M5 | compare AIR source case-sensitively | uppercase `CIVITAI` |
| M6 | skip numeric-version validation | missing/non-numeric version |
| M7 | stop walking object KEYS | AIR-in-a-key (×2) |
| M8 | audit only the declared prompt | `CLIPTextEncode` sweep |
| M9 | drop the Private-subscription requirement | Private (×2) |
| M10 | remove the recursion budget | depth cap |
| M11 | drop `.strict()` from the inline arm | never-settable fields (×7) |
| M12 | raise `INLINE_MAX_BUZZ` past its derivation | derivation pin |
| M13 | `.optional()` → `.default()` on the discriminator | **back-compat (×2)** |
| M13b | flat `z.union` wrapper | precise error path |
| M14 | unwire the containment gate | router: undeclared AIR |
| M15 | unwire the entitlement belt | router: non-generatable → FORBIDDEN |
| M16 | audit the declared prompt, not the graph | router: SWEPT GRAPH |
| M17 | ignore the declared ceiling | router: reserves declared `maxBuzz` |
| M18 | spread the app body into the step input | router: exact key set |

**M13 is the one that matters most for reviewers**: it proves the back-compat tests are not ceremony — the plausible-looking construction really does break every deployed recipe body, and a test catches it.

### 🔴 Honest caveat on the sweep: 3 of 19 died to a *sibling* guard
M4, M5 and M6 each turned the target test red, but with a **different guard's** error message than the one removed:
- M4 → caught by the strict regex (which itself anchors `^urn:air:`), so the `startsWith` check is genuinely redundant; it is kept for the clearer message.
- M5 → caught by the source **allowlist** (lowercase-only, so `CIVITAI` fails it).
- M6 → caught by the **anti-drop** check (`NaN` resolves nothing → dropped).

All three are **fail-closed** redundancies, i.e. the safe direction — but "each mutation died" is a weaker claim than "each died for its own reason", and only the first is true for these three.

### Seam coverage, not just isolation
The router tests leave `inline-comfy.service` **real** and stub only its data source (`getResourceData` / `getHighestTierSubscription`). Mocking the belt itself would reduce them to "the router called a function I replaced" — which is exactly the seam a per-component test cannot see. M14/M15/M16 are the proof that these fail when the belt is correct but not wired.

### 🔴 One branch is NOT reachable at the router seam, and it is recorded rather than forced
The **Private-subscription** branch cannot be exercised through the router today: App Blocks is moderator-only pre-GA, so every viewer who can reach a submit is a moderator, and the belt deliberately exempts moderators (matching the onsite belt it is ported from). A router-level test would be green for the *wrong reason* — the mod exemption, not the gate. It is exercised over both a subscriber and a non-subscriber in `inline-comfy.service.test.ts`, and the router test asserts the **exemption** (the live path) instead, with a comment saying to add the real case when App Blocks opens past mod-only.

---

## What I could NOT verify

- **Nothing in production.** This repo deploys from `release`, not `main`. Deployed ≠ verified — no inline graph has been driven end-to-end on a live cluster. The check that actually closes the original complaint is a developer deploying one of their real blocked apps and generating.
- **The physical ceiling is argued, not observed.** That the step `timeout` cancels the job at `maxBuzz` GPU-seconds is inherited from the recipe path's existing design; I did not submit a deliberately long inline job and read the real Buzz debit.
- **≈1 Buzz/GPU-second is unverified in this codebase.** `CustomComfyUsage.buzzPerSecond` exists in the generated client and is referenced **nowhere** in `src` (measured, zero hits). If any worker tier bills above 1 Buzz/sec the ceiling under-counts. This is a **pre-existing** property of the recipe path, inherited unchanged — and it is exactly why `minVramGb` must stay server-controlled. Confirm the real rate before raising `INLINE_MAX_BUZZ`.
- **Orchestrator behaviour on an undeclared graph AIR** is from the generated client's doc comment, not observed. Gate 1's containment check makes that claim non-load-bearing.
- **Whether the block UI renders `cost.total` as a definite price** — a one-line check in `@civitai/app-sdk`, another repo.
- **Whether `release` matches `main`** for any file cited.

### Environment note for reviewers
A fresh worktree has an **empty `event-engine-common` submodule**, which makes `blocks.router.workflow.test.ts` report `Tests no tests` — an import failure that reads as "nothing to see" rather than as a failure. Populate the submodule before trusting a test count from this file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
