### PR TITLE
fix(rewards): grant the first-daily-post reward when scheduled posts go live

### DIFF
--- a/src/server/controllers/post.controller.ts
+++ b/src/server/controllers/post.controller.ts
@@ -474,16 +474,18 @@ export const updatePostHandler = async ({
         }
       }
 
-      // Give reward for first post of the day
-      await firstDailyPostReward.apply(
-        {
-          postId: updatedPost.id,
-          posterId: updatedPost.userId,
-        },
-        { ip: ctx.ip }
-      );
-
       if (!isScheduled) {
+        // Scheduled posts are rewarded by process-scheduled-publishing when they
+        // actually go live. Granting here would spend the daily cap on the day the
+        // post was scheduled and leave the publish day unrewarded.
+        await firstDailyPostReward.apply(
+          {
+            postId: updatedPost.id,
+            posterId: updatedPost.userId,
+          },
+          { ip: ctx.ip }
+        );
+
         await eventEngine.processEngagement({
           userId: updatedPost.userId,
           type: 'published',

--- a/src/server/jobs/__tests__/process-scheduled-publishing.rewards.test.ts
+++ b/src/server/jobs/__tests__/process-scheduled-publishing.rewards.test.ts
@@ -1,7 +1,7 @@
 import { Prisma } from '@prisma/client';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { mockDbWrite, mockApply, mockSetLastRun, jobDate } = vi.hoisted(() => ({
+const { mockDbWrite, mockApply, mockSetLastRun, mockLogToAxiom, jobDate } = vi.hoisted(() => ({
   mockDbWrite: {
     $queryRaw: vi.fn(),
     $executeRaw: vi.fn(),
@@ -11,10 +11,16 @@ const { mockDbWrite, mockApply, mockSetLastRun, jobDate } = vi.hoisted(() => ({
   },
   mockApply: vi.fn(),
   mockSetLastRun: vi.fn(),
+  mockLogToAxiom: vi.fn(() => Promise.resolve()),
   jobDate: { lastRun: new Date(0) },
 }));
 
+vi.mock('~/server/logging/client', () => ({ logToAxiom: mockLogToAxiom }));
+
 vi.mock('~/server/db/client', () => ({ dbWrite: mockDbWrite }));
+// Hand-listed rather than spread via importOriginal: the rewards barrel reaches
+// modules that build query caches from the db client at import time, so pulling the
+// real one in drops this suite to zero collected tests.
 vi.mock('~/server/rewards', () => ({ firstDailyPostReward: { apply: mockApply } }));
 vi.mock('~/server/events', () => ({ eventEngine: { processEngagement: vi.fn() } }));
 vi.mock('~/server/redis/caches', () => ({
@@ -38,8 +44,7 @@ import { processScheduledPublishing } from '~/server/jobs/process-scheduled-publ
 
 type Row = { id: number; userId: number };
 
-// The job fires five tagged-template reads; route on the SQL text so the test
-// doesn't break when their order changes.
+// Routed on SQL text rather than call order so adding a read doesn't shift these.
 const stubReads = ({ scheduled = [], newlyLive = [] }: { scheduled?: Row[]; newlyLive?: Row[] }) => {
   mockDbWrite.$queryRaw.mockImplementation(async (...args: unknown[]) => {
     const sql = (args[0] as string[]).join(' ');
@@ -84,31 +89,53 @@ describe('processScheduledPublishing :: first daily post reward', () => {
     expect(mockApply).toHaveBeenCalledWith({ postId: 2, posterId: 20 });
   });
 
+  // The two reads can't overlap today — the flip happens after both — so this pins
+  // the guard that keeps that true if either query moves.
   it('rewards a post once when both queries return it', async () => {
     stubReads({ scheduled: [{ id: 3, userId: 30 }], newlyLive: [{ id: 3, userId: 30 }] });
     await runJob();
     expect(mockApply).toHaveBeenCalledTimes(1);
   });
 
-  it('keeps publishing when a reward fails', async () => {
+  it('reports a failed reward to Axiom and keeps publishing', async () => {
     mockApply.mockRejectedValueOnce(new Error('buzz down'));
-    vi.spyOn(console, 'error').mockImplementation(() => undefined);
-    stubReads({ newlyLive: [{ id: 4, userId: 40 }, { id: 5, userId: 50 }] });
+    stubReads({
+      newlyLive: [
+        { id: 4, userId: 40 },
+        { id: 5, userId: 50 },
+      ],
+    });
     await runJob();
     expect(mockApply).toHaveBeenCalledTimes(2);
+    expect(mockLogToAxiom).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'error', postId: 4 })
+    );
     expect(mockSetLastRun).toHaveBeenCalled();
+  });
+
+  it('warns instead of silently truncating when the sweep hits its row limit', async () => {
+    stubReads({ newlyLive: Array.from({ length: 5000 }, (_, i) => ({ id: i, userId: i })) });
+    await runJob();
+    expect(mockLogToAxiom).toHaveBeenCalledWith(
+      expect.objectContaining({ type: 'warning', message: expect.stringContaining('row limit') })
+    );
   });
 });
 
 describe('processScheduledPublishing :: standalone sweep window', () => {
-  it('clamps an epoch job date so a fresh env does not sweep every post ever published', async () => {
+  // The reward's dedup entry expires at UTC midnight, so a window reaching back past
+  // it would re-grant yesterday's posts on today's cap.
+  it('never reaches back past the start of the UTC day', async () => {
     await runJob();
-    const [, windowStart, now] = standaloneCall() as [unknown, Date, Date];
-    expect(now.getTime() - windowStart.getTime()).toBe(60 * 60 * 1000);
+    const [, windowStart] = standaloneCall() as [unknown, Date];
+    expect(windowStart.toISOString()).toBe(
+      new Date(new Date().setUTCHours(0, 0, 0, 0)).toISOString()
+    );
   });
 
-  it('starts at the previous run when that is inside the lookback limit', async () => {
-    jobDate.lastRun = new Date(Date.now() - 60 * 1000);
+  it('starts at the previous run when that is inside the current UTC day', async () => {
+    const startOfDay = new Date().setUTCHours(0, 0, 0, 0);
+    jobDate.lastRun = new Date(Math.max(Date.now() - 60 * 1000, startOfDay + 1));
     await runJob();
     const [, windowStart] = standaloneCall() as [unknown, Date];
     expect(windowStart).toEqual(jobDate.lastRun);
@@ -118,7 +145,9 @@ describe('processScheduledPublishing :: standalone sweep window', () => {
   // takes int4, so the query fails to resolve the function (42883) on every run.
   it('inlines the schedule offset rather than binding it', async () => {
     await runJob();
-    const interval = standaloneCall().at(-1) as Prisma.Sql;
+    const interval = standaloneCall().find(
+      (value) => typeof (value as Prisma.Sql)?.sql === 'string'
+    ) as Prisma.Sql;
     expect(interval.sql).toBe('make_interval(mins => 60)');
     expect(interval.values).toEqual([]);
   });

--- a/src/server/jobs/__tests__/process-scheduled-publishing.rewards.test.ts
+++ b/src/server/jobs/__tests__/process-scheduled-publishing.rewards.test.ts
@@ -1,27 +1,21 @@
 import type { Prisma } from '@prisma/client';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const {
-  mockDbWrite,
-  mockApply,
-  mockSetLastRun,
-  mockLogToAxiom,
-  mockProcessEngagement,
-  jobDate,
-} = vi.hoisted(() => ({
-  mockDbWrite: {
-    $queryRaw: vi.fn(),
-    $executeRaw: vi.fn(),
-    $transaction: vi.fn(),
-    image: { findMany: vi.fn() },
-    comicProject: { updateMany: vi.fn() },
-  },
-  mockApply: vi.fn(),
-  mockSetLastRun: vi.fn(),
-  mockLogToAxiom: vi.fn(() => Promise.resolve()),
-  mockProcessEngagement: vi.fn(),
-  jobDate: { lastRun: new Date(0) },
-}));
+const { mockDbWrite, mockApply, mockSetLastRun, mockLogToAxiom, mockProcessEngagement, jobDate } =
+  vi.hoisted(() => ({
+    mockDbWrite: {
+      $queryRaw: vi.fn(),
+      $executeRaw: vi.fn(),
+      $transaction: vi.fn(),
+      image: { findMany: vi.fn() },
+      comicProject: { updateMany: vi.fn() },
+    },
+    mockApply: vi.fn(),
+    mockSetLastRun: vi.fn(),
+    mockLogToAxiom: vi.fn(() => Promise.resolve()),
+    mockProcessEngagement: vi.fn(),
+    jobDate: { lastRun: new Date(0) },
+  }));
 
 vi.mock('~/server/logging/client', () => ({ logToAxiom: mockLogToAxiom }));
 
@@ -53,7 +47,13 @@ import { processScheduledPublishing } from '~/server/jobs/process-scheduled-publ
 type Row = { id: number; userId: number };
 
 // Routed on SQL text rather than call order so adding a read doesn't shift these.
-const stubReads = ({ scheduled = [], newlyLive = [] }: { scheduled?: Row[]; newlyLive?: Row[] }) => {
+const stubReads = ({
+  scheduled = [],
+  newlyLive = [],
+}: {
+  scheduled?: Row[];
+  newlyLive?: Row[];
+}) => {
   mockDbWrite.$queryRaw.mockImplementation(async (...args: unknown[]) => {
     const sql = (args[0] as string[]).join(' ');
     if (sql.includes('"ComicChapter"')) return [];

--- a/src/server/jobs/__tests__/process-scheduled-publishing.rewards.test.ts
+++ b/src/server/jobs/__tests__/process-scheduled-publishing.rewards.test.ts
@@ -1,4 +1,4 @@
-import { Prisma } from '@prisma/client';
+import type { Prisma } from '@prisma/client';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const {

--- a/src/server/jobs/__tests__/process-scheduled-publishing.rewards.test.ts
+++ b/src/server/jobs/__tests__/process-scheduled-publishing.rewards.test.ts
@@ -1,7 +1,14 @@
 import { Prisma } from '@prisma/client';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const { mockDbWrite, mockApply, mockSetLastRun, mockLogToAxiom, jobDate } = vi.hoisted(() => ({
+const {
+  mockDbWrite,
+  mockApply,
+  mockSetLastRun,
+  mockLogToAxiom,
+  mockProcessEngagement,
+  jobDate,
+} = vi.hoisted(() => ({
   mockDbWrite: {
     $queryRaw: vi.fn(),
     $executeRaw: vi.fn(),
@@ -12,6 +19,7 @@ const { mockDbWrite, mockApply, mockSetLastRun, mockLogToAxiom, jobDate } = vi.h
   mockApply: vi.fn(),
   mockSetLastRun: vi.fn(),
   mockLogToAxiom: vi.fn(() => Promise.resolve()),
+  mockProcessEngagement: vi.fn(),
   jobDate: { lastRun: new Date(0) },
 }));
 
@@ -22,7 +30,7 @@ vi.mock('~/server/db/client', () => ({ dbWrite: mockDbWrite }));
 // modules that build query caches from the db client at import time, so pulling the
 // real one in drops this suite to zero collected tests.
 vi.mock('~/server/rewards', () => ({ firstDailyPostReward: { apply: mockApply } }));
-vi.mock('~/server/events', () => ({ eventEngine: { processEngagement: vi.fn() } }));
+vi.mock('~/server/events', () => ({ eventEngine: { processEngagement: mockProcessEngagement } }));
 vi.mock('~/server/redis/caches', () => ({
   dataForModelsCache: { refresh: vi.fn() },
   userImageVideoCountCaches: { refresh: vi.fn() },
@@ -87,6 +95,17 @@ describe('processScheduledPublishing :: first daily post reward', () => {
     stubReads({ newlyLive: [{ id: 2, userId: 20 }] });
     await runJob();
     expect(mockApply).toHaveBeenCalledWith({ postId: 2, posterId: 20 });
+  });
+
+  it('registers the published engagement for standalone scheduled posts too', async () => {
+    stubReads({ newlyLive: [{ id: 6, userId: 60 }] });
+    await runJob();
+    expect(mockProcessEngagement).toHaveBeenCalledWith({
+      userId: 60,
+      type: 'published',
+      entityType: 'post',
+      entityId: 6,
+    });
   });
 
   // The two reads can't overlap today — the flip happens after both — so this pins

--- a/src/server/jobs/__tests__/process-scheduled-publishing.rewards.test.ts
+++ b/src/server/jobs/__tests__/process-scheduled-publishing.rewards.test.ts
@@ -1,0 +1,125 @@
+import { Prisma } from '@prisma/client';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockDbWrite, mockApply, mockSetLastRun, jobDate } = vi.hoisted(() => ({
+  mockDbWrite: {
+    $queryRaw: vi.fn(),
+    $executeRaw: vi.fn(),
+    $transaction: vi.fn(),
+    image: { findMany: vi.fn() },
+    comicProject: { updateMany: vi.fn() },
+  },
+  mockApply: vi.fn(),
+  mockSetLastRun: vi.fn(),
+  jobDate: { lastRun: new Date(0) },
+}));
+
+vi.mock('~/server/db/client', () => ({ dbWrite: mockDbWrite }));
+vi.mock('~/server/rewards', () => ({ firstDailyPostReward: { apply: mockApply } }));
+vi.mock('~/server/events', () => ({ eventEngine: { processEngagement: vi.fn() } }));
+vi.mock('~/server/redis/caches', () => ({
+  dataForModelsCache: { refresh: vi.fn() },
+  userImageVideoCountCaches: { refresh: vi.fn() },
+}));
+vi.mock('~/server/services/image.service', () => ({ queueImageSearchIndexUpdate: vi.fn() }));
+vi.mock('~/server/search-index', () => ({ modelsSearchIndex: { queueUpdate: vi.fn() } }));
+vi.mock('~/server/services/model-version.service', () => ({
+  bustMvCache: vi.fn(),
+  publishModelVersionsWithEarlyAccess: vi.fn(),
+}));
+vi.mock('~/server/services/notification.service', () => ({ createNotification: vi.fn() }));
+vi.mock('~/server/services/nsfwLevels.service', () => ({ updateComicNsfwLevels: vi.fn() }));
+vi.mock('~/server/jobs/job', () => ({
+  createJob: (_n: string, _c: string, fn: unknown) => fn,
+  getJobDate: async () => [jobDate.lastRun, mockSetLastRun] as const,
+}));
+
+import { processScheduledPublishing } from '~/server/jobs/process-scheduled-publishing';
+
+type Row = { id: number; userId: number };
+
+// The job fires five tagged-template reads; route on the SQL text so the test
+// doesn't break when their order changes.
+const stubReads = ({ scheduled = [], newlyLive = [] }: { scheduled?: Row[]; newlyLive?: Row[] }) => {
+  mockDbWrite.$queryRaw.mockImplementation(async (...args: unknown[]) => {
+    const sql = (args[0] as string[]).join(' ');
+    if (sql.includes('"ComicChapter"')) return [];
+    if (sql.includes('JOIN "ModelVersion" mv ON mv.id = p."modelVersionId"')) return scheduled;
+    if (sql.includes('FROM "Post" p')) return newlyLive;
+    return [];
+  });
+};
+
+const standaloneCall = () =>
+  mockDbWrite.$queryRaw.mock.calls.find(
+    (args) =>
+      (args[0] as string[]).join(' ').includes('FROM "Post" p') &&
+      !(args[0] as string[]).join(' ').includes('JOIN "ModelVersion"')
+  ) as unknown[];
+
+const runJob = () => (processScheduledPublishing as unknown as () => Promise<void>)();
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  jobDate.lastRun = new Date(0);
+  mockApply.mockResolvedValue(undefined);
+  mockDbWrite.$transaction.mockImplementation(async (fn: (tx: unknown) => Promise<unknown>) =>
+    fn({ $executeRaw: vi.fn(), $queryRaw: vi.fn().mockResolvedValue([]) })
+  );
+  mockDbWrite.image.findMany.mockResolvedValue([]);
+  stubReads({});
+});
+
+describe('processScheduledPublishing :: first daily post reward', () => {
+  it('rewards posts published by the ModelVersion schedule, which never reach the inline path', async () => {
+    stubReads({ scheduled: [{ id: 1, userId: 10 }] });
+    await runJob();
+    expect(mockApply).toHaveBeenCalledTimes(1);
+    expect(mockApply).toHaveBeenCalledWith({ postId: 1, posterId: 10 });
+  });
+
+  it('rewards standalone scheduled posts on the day they go live', async () => {
+    stubReads({ newlyLive: [{ id: 2, userId: 20 }] });
+    await runJob();
+    expect(mockApply).toHaveBeenCalledWith({ postId: 2, posterId: 20 });
+  });
+
+  it('rewards a post once when both queries return it', async () => {
+    stubReads({ scheduled: [{ id: 3, userId: 30 }], newlyLive: [{ id: 3, userId: 30 }] });
+    await runJob();
+    expect(mockApply).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps publishing when a reward fails', async () => {
+    mockApply.mockRejectedValueOnce(new Error('buzz down'));
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    stubReads({ newlyLive: [{ id: 4, userId: 40 }, { id: 5, userId: 50 }] });
+    await runJob();
+    expect(mockApply).toHaveBeenCalledTimes(2);
+    expect(mockSetLastRun).toHaveBeenCalled();
+  });
+});
+
+describe('processScheduledPublishing :: standalone sweep window', () => {
+  it('clamps an epoch job date so a fresh env does not sweep every post ever published', async () => {
+    await runJob();
+    const [, windowStart, now] = standaloneCall() as [unknown, Date, Date];
+    expect(now.getTime() - windowStart.getTime()).toBe(60 * 60 * 1000);
+  });
+
+  it('starts at the previous run when that is inside the lookback limit', async () => {
+    jobDate.lastRun = new Date(Date.now() - 60 * 1000);
+    await runJob();
+    const [, windowStart] = standaloneCall() as [unknown, Date];
+    expect(windowStart).toEqual(jobDate.lastRun);
+  });
+
+  // Bound as a parameter the minute count arrives as int8 and make_interval only
+  // takes int4, so the query fails to resolve the function (42883) on every run.
+  it('inlines the schedule offset rather than binding it', async () => {
+    await runJob();
+    const interval = standaloneCall().at(-1) as Prisma.Sql;
+    expect(interval.sql).toBe('make_interval(mins => 60)');
+    expect(interval.values).toEqual([]);
+  });
+});

--- a/src/server/jobs/process-scheduled-publishing.ts
+++ b/src/server/jobs/process-scheduled-publishing.ts
@@ -301,7 +301,13 @@ export const processScheduledPublishing = createJob(
       });
       await bustMvCache(modelVersion.id, modelVersion.extras?.modelId);
     }
-    for (const post of scheduledPosts) {
+    // Neither scheduled path reaches the inline side effects in post.controller, so
+    // they land here on the day the post actually goes live. The sweep half of this
+    // set also carries normally-published drafts, so anything driven off it has to
+    // tolerate being handed the same post id twice.
+    const publishedPosts = uniqBy([...scheduledPosts, ...newlyLivePosts], 'id');
+
+    for (const post of publishedPosts) {
       await eventEngine.processEngagement({
         userId: post.userId,
         type: 'published',
@@ -310,8 +316,6 @@ export const processScheduledPublishing = createJob(
       });
     }
 
-    // Neither scheduled path reaches the inline reward in post.controller, so the
-    // grant lands here on the day the post actually goes live.
     if (newlyLivePosts.length === REWARD_SWEEP_LIMIT) {
       await logToAxiom({
         name: 'process-scheduled-publishing',
@@ -320,7 +324,7 @@ export const processScheduledPublishing = createJob(
         windowStart: rewardWindowStart.toISOString(),
       }).catch(() => undefined);
     }
-    for (const post of uniqBy([...scheduledPosts, ...newlyLivePosts], 'id')) {
+    for (const post of publishedPosts) {
       // Caught per post so one failure can't abort the job — but routed to Axiom
       // rather than swallowed, since base.reward rethrows genuine ClickHouse schema
       // breaks precisely so they stay visible.

--- a/src/server/jobs/process-scheduled-publishing.ts
+++ b/src/server/jobs/process-scheduled-publishing.ts
@@ -2,8 +2,10 @@ import { Prisma } from '@prisma/client';
 import { dbWrite } from '~/server/db/client';
 import { eventEngine } from '~/server/events';
 import { NotificationCategory, SearchIndexUpdateQueueAction } from '~/server/common/enums';
-import { uniq } from 'lodash-es';
+import { POST_MINIMUM_SCHEDULE_MINUTES } from '~/server/common/constants';
+import { uniq, uniqBy } from 'lodash-es';
 import { dataForModelsCache, userImageVideoCountCaches } from '~/server/redis/caches';
+import { firstDailyPostReward } from '~/server/rewards';
 import { queueImageSearchIndexUpdate } from '~/server/services/image.service';
 import { modelsSearchIndex } from '~/server/search-index';
 import {
@@ -21,11 +23,16 @@ type ScheduledEntity = {
   extras?: { modelId: number; hasEarlyAccess?: boolean; earlyAccessEndsAt?: Date } & MixedObject;
 };
 
+// Ceiling on how far back the standalone-post reward sweep will look. The stored
+// job date defaults to the epoch when the KeyValue row is missing (fresh env),
+// which would otherwise sweep every post ever published.
+const REWARD_LOOKBACK_LIMIT_MS = 60 * 60 * 1000;
+
 export const processScheduledPublishing = createJob(
   'process-scheduled-publishing',
   '*/1 * * * *',
   async () => {
-    const [, setLastRun] = await getJobDate('process-scheduled-publishing');
+    const [lastRun, setLastRun] = await getJobDate('process-scheduled-publishing');
     const now = new Date();
 
     // Get things to publish
@@ -76,6 +83,26 @@ export const processScheduledPublishing = createJob(
         (p."publishedAt" IS NULL)
       AND mv.status = 'Scheduled' AND mv."publishedAt" <=  ${now}
       AND (m.meta IS NULL OR (m.meta->>'cannotPublish')::boolean IS NOT TRUE);
+    `;
+
+    // Standalone scheduled posts go live passively once feeds stop filtering on
+    // "publishedAt" — no status flips, so this window is the only publish-time hook.
+    // The createdAt offset can't exclude a scheduled post (it's enforced at schedule
+    // time); the instant publishes it lets through were already rewarded inline and
+    // dedup by postId makes those a no-op.
+    const rewardWindowStart = new Date(
+      Math.max(lastRun.getTime(), now.getTime() - REWARD_LOOKBACK_LIMIT_MS)
+    );
+    const newlyLivePosts = await dbWrite.$queryRaw<{ id: number; userId: number }[]>`
+      SELECT
+        p.id,
+        p."userId"
+      FROM "Post" p
+      WHERE p."publishedAt" > ${rewardWindowStart}
+        AND p."publishedAt" <= ${now}
+        AND p."publishedAt" >= p."createdAt" + ${Prisma.raw(
+          `make_interval(mins => ${POST_MINIMUM_SCHEDULE_MINUTES})`
+        )};
     `;
 
     // Get scheduled comic chapters
@@ -272,6 +299,17 @@ export const processScheduledPublishing = createJob(
         entityType: 'post',
         entityId: post.id,
       });
+    }
+
+    // Neither scheduled path reaches the inline reward in post.controller: the posts
+    // flipped above had no publishedAt for it to fire on, and standalone ones skip it
+    // at schedule time so the grant lands on the day they actually go live.
+    for (const post of uniqBy([...scheduledPosts, ...newlyLivePosts], 'id')) {
+      await firstDailyPostReward
+        .apply({ postId: post.id, posterId: post.userId })
+        .catch((error) =>
+          console.error(`Failed to apply first daily post reward for post ${post.id}:`, error)
+        );
     }
 
     // Reindex the just-published posts' images so the metrics_images feed picks

--- a/src/server/jobs/process-scheduled-publishing.ts
+++ b/src/server/jobs/process-scheduled-publishing.ts
@@ -4,6 +4,7 @@ import { eventEngine } from '~/server/events';
 import { NotificationCategory, SearchIndexUpdateQueueAction } from '~/server/common/enums';
 import { POST_MINIMUM_SCHEDULE_MINUTES } from '~/server/common/constants';
 import { uniq, uniqBy } from 'lodash-es';
+import { logToAxiom } from '~/server/logging/client';
 import { dataForModelsCache, userImageVideoCountCaches } from '~/server/redis/caches';
 import { firstDailyPostReward } from '~/server/rewards';
 import { queueImageSearchIndexUpdate } from '~/server/services/image.service';
@@ -23,10 +24,9 @@ type ScheduledEntity = {
   extras?: { modelId: number; hasEarlyAccess?: boolean; earlyAccessEndsAt?: Date } & MixedObject;
 };
 
-// Ceiling on how far back the standalone-post reward sweep will look. The stored
-// job date defaults to the epoch when the KeyValue row is missing (fresh env),
-// which would otherwise sweep every post ever published.
-const REWARD_LOOKBACK_LIMIT_MS = 60 * 60 * 1000;
+// Blast-radius guard on the reward sweep: any bulk write that stamps "publishedAt"
+// across a large batch would otherwise be reward-applied row by row in one run.
+const REWARD_SWEEP_LIMIT = 5000;
 
 export const processScheduledPublishing = createJob(
   'process-scheduled-publishing',
@@ -82,17 +82,24 @@ export const processScheduledPublishing = createJob(
       WHERE
         (p."publishedAt" IS NULL)
       AND mv.status = 'Scheduled' AND mv."publishedAt" <=  ${now}
+      AND m."userId" = p."userId"
       AND (m.meta IS NULL OR (m.meta->>'cannotPublish')::boolean IS NOT TRUE);
     `;
 
     // Standalone scheduled posts go live passively once feeds stop filtering on
     // "publishedAt" — no status flips, so this window is the only publish-time hook.
-    // The createdAt offset can't exclude a scheduled post (it's enforced at schedule
-    // time); the instant publishes it lets through were already rewarded inline and
-    // dedup by postId makes those a no-op.
-    const rewardWindowStart = new Date(
-      Math.max(lastRun.getTime(), now.getTime() - REWARD_LOOKBACK_LIMIT_MS)
-    );
+    // The createdAt offset can't exclude a scheduled post (the offset is enforced at
+    // schedule time) but it does let through drafts that sat over an hour before
+    // being published normally — roughly a sixth of all publishes. They're harmless
+    // to the reward, which dedups per post, but any further side effect added to this
+    // sweep fires on them too.
+    //
+    // Never widen the window past the start of the UTC day: the reward's dedup entry
+    // expires then, so a window spanning midnight re-grants yesterday's posts. That
+    // also bounds a fresh environment, where the stored job date reads as the epoch.
+    const startOfUtcDay = new Date(now);
+    startOfUtcDay.setUTCHours(0, 0, 0, 0);
+    const rewardWindowStart = new Date(Math.max(lastRun.getTime(), startOfUtcDay.getTime()));
     const newlyLivePosts = await dbWrite.$queryRaw<{ id: number; userId: number }[]>`
       SELECT
         p.id,
@@ -102,7 +109,9 @@ export const processScheduledPublishing = createJob(
         AND p."publishedAt" <= ${now}
         AND p."publishedAt" >= p."createdAt" + ${Prisma.raw(
           `make_interval(mins => ${POST_MINIMUM_SCHEDULE_MINUTES})`
-        )};
+        )}
+      ORDER BY p."publishedAt"
+      LIMIT ${REWARD_SWEEP_LIMIT};
     `;
 
     // Get scheduled comic chapters
@@ -301,15 +310,29 @@ export const processScheduledPublishing = createJob(
       });
     }
 
-    // Neither scheduled path reaches the inline reward in post.controller: the posts
-    // flipped above had no publishedAt for it to fire on, and standalone ones skip it
-    // at schedule time so the grant lands on the day they actually go live.
+    // Neither scheduled path reaches the inline reward in post.controller, so the
+    // grant lands here on the day the post actually goes live.
+    if (newlyLivePosts.length === REWARD_SWEEP_LIMIT) {
+      await logToAxiom({
+        name: 'process-scheduled-publishing',
+        type: 'warning',
+        message: 'Reward sweep hit its row limit; the remainder of this window is dropped',
+        windowStart: rewardWindowStart.toISOString(),
+      }).catch(() => undefined);
+    }
     for (const post of uniqBy([...scheduledPosts, ...newlyLivePosts], 'id')) {
-      await firstDailyPostReward
-        .apply({ postId: post.id, posterId: post.userId })
-        .catch((error) =>
-          console.error(`Failed to apply first daily post reward for post ${post.id}:`, error)
-        );
+      // Caught per post so one failure can't abort the job — but routed to Axiom
+      // rather than swallowed, since base.reward rethrows genuine ClickHouse schema
+      // breaks precisely so they stay visible.
+      await firstDailyPostReward.apply({ postId: post.id, posterId: post.userId }).catch((error) =>
+        logToAxiom({
+          name: 'process-scheduled-publishing',
+          type: 'error',
+          message: 'Failed to apply first daily post reward',
+          postId: post.id,
+          error: (error as Error)?.message,
+        }).catch(() => undefined)
+      );
     }
 
     // Reindex the just-published posts' images so the metrics_images feed picks


### PR DESCRIPTION
Closes [CU-868kdwy72](https://app.clickup.com/t/8459928/868kdwy72) — reported via Freshdesk #68057.

## Problem

A post published manually earns the daily "first post of the day" Buzz reward. The same post published via scheduling earns nothing. There are two distinct causes.

**ModelVersion-linked scheduled posts** keep `publishedAt = NULL` until `process-scheduled-publishing` flips them (`process-scheduled-publishing.ts:195-213`). `updatePostHandler`'s `wasPublished` check (`post.controller.ts:346`) is therefore never true for them, and the job had no reward call — so the reward was never applied at all.

**Standalone scheduled posts** (post editor "Schedule") get a future `publishedAt` written immediately, so `wasPublished` fires *at schedule time*. The `firstDailyPostReward.apply` call sat outside the existing `if (!isScheduled)` guard, so the grant landed on the day the post was scheduled rather than the day it went live. Schedule Tue–Sat in one Monday sitting and all five `apply` calls hit Monday's Redis field: the first awards 25, the other four are capped at 0, and Tue–Sat get nothing. If the user had already posted manually that Monday, all five are capped and they get nothing at all. This is what the reporter hit.

There's a third case the sweep picks up for free: a post created directly with a future `publishedAt` was rewarded by *neither* handler — `createPostHandler` skips it via `isPublished && !isScheduled` (`post.controller.ts:111`), and `updatePostHandler` never sees a null→non-null transition for it.

## Fix

- `post.controller.ts` — move the inline grant under the existing `!isScheduled` guard, alongside the event-engine call that was already skipped for scheduled posts.
- `process-scheduled-publishing.ts` — apply the reward for the posts the job flips (fixes path 1) and for standalone posts whose `publishedAt` crossed since the last run (fixes path 2).

Standalone posts have no status to flip — they go live passively once feeds stop filtering on `publishedAt` — so a window on the job's stored run date is the only publish-time hook available.

## Known transitional over-payment — accepted

**The already-scheduled backlog will be granted a second time.** Every post scheduled *before* this deploys already received the inline grant at schedule time. Once this ships, the sweep grants it again on its go-live day. There is no post-level marker to tell those apart.

Measured on the prod replica:

```
future-scheduled backlog:  11,853 posts / 585 users / 4,342 distinct user-days
furthest scheduled:        2026-11-05  (~3 months of drip)
```

Upper bound ≈ 4,342 × 25 = **~108K blue Buzz**, one-time, decaying over three months. The real figure is well below that — the 25/day cap means any user who publishes anything else that day gets 0 from the sweep.

Framing: this is not two grants on the same day. It's the buggy schedule-day grant (already paid, can't be unpaid) plus the correct publish-day grant. Each day's cap is still respected, and the affected users are exactly the ones the bug had been shortchanging.

Decision: accept it rather than backfill. The alternative was a one-time manual migration stamping `metadata->'rewardedAtSchedule'` on `WHERE "publishedAt" > now()` (~11.8K rows) plus a permanent extra predicate on a per-minute query, for a marker that becomes dead weight after November.

## Notes for review

- **Same-run overlap between the two paths is safe.** The reward dedups on `hashify({toUserId, forId: postId, byUserId, type})` and caps at 25/user/day (`base.reward.ts:46-70`), so a post appearing in both reads applies once.
- **The sweep window never reaches back past the start of the UTC day.** The dedup entry `EXPIREAT`s at UTC midnight (`base.reward.ts:197`), so a window spanning it would re-grant yesterday's posts against today's cap. The day boundary also recovers from job outages longer than an hour, and bounds a fresh environment where `getJobDate` returns the epoch.
- **Reward failures go to Axiom, not `console.error`.** `base.reward.ts:290-296` deliberately rethrows genuine ClickHouse schema breaks so they can't hide; the job must not abort on one bad grant, but it must not swallow that signal either.
- **The sweep is capped at 5000 rows and warns when it hits the cap**, so a bulk `publishedAt` write can't be reward-applied row by row in one run.
- **The `createdAt` offset can't exclude a scheduled post** — `POST_MINIMUM_SCHEDULE_MINUTES` is enforced at schedule time, so `publishedAt >= createdAt + 60min` always holds for one. It does let through long-drafted normal publishes (~1 in 6 of all publishes), which were already rewarded inline and so dedup to a no-op. Worth knowing before adding any other side effect to that loop.
- **`make_interval` is inlined, not bound** — same trap as #3650. `mins` is `int4` and Prisma binds JS numbers as `int8`, which would fail to resolve the function (42883) on every run. Pinned by a test.
- **The ModelVersion post SELECT now matches the UPDATE it feeds** (`m."userId" = p."userId"`). Without it a post could be selected and rewarded without actually being published. 0 rows affected on prod today.
- Plans on the prod replica: steady-state one-minute window is an index scan on `Post_feed_covering_idx`, 18 buffers, 0.34ms. Worst case (cold watermark, full day) is 2,538 rows, 66ms.

## Also fixed: the matching engagement gap

`eventEngine.processEngagement` had the identical bug — same `!isScheduled` guard (`post.controller.ts:489`), same job loop covering only the posts it flips — so standalone scheduled posts never registered a `published` engagement either. Both side effects now run off one deduped set.

This is **inert in production today**: `activeEvents` filters on `endDate >= now` (`events/index.ts:29`) and the only registered event ended 2025-01-01, so `processEngagement` iterates an empty list. It would have resurfaced with the next holiday event. Safe to extend to the sweep's wider set because the handler contract already tolerates a repeated `entityId` — `holiday2024.event.ts:53` checks its `earned` list before crediting, on top of a per-day Redis guard, and ignores non-`challenge` entity types entirely.

`imagePostedToModelReward` has the same structural gap on the ModelVersion path but no reward was owed — `getKey` returns `false` when the poster is the model owner (`imagePostedToModel.reward.ts:42`), and scheduled ModelVersion posts are the owner's own showcase.

## Testing

`src/server/jobs/__tests__/process-scheduled-publishing.rewards.test.ts` — 9 tests covering both publish paths, engagement on the standalone path, dedup across the two reads, Axiom reporting on failure, the sweep cap warning, the UTC-day window clamp, and the inlined interval. All pass; full `src/server/jobs/__tests__/` + `src/server/events/__tests__/` run is 313 passing, 0 failing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
