### PR TITLE
fix(creator-studio): net un-reactions out of analytics reaction counts

### DIFF
--- a/apps/creator-studio/src/lib/date-range.ts
+++ b/apps/creator-studio/src/lib/date-range.ts
@@ -147,10 +147,11 @@ export function resolveCompareMonth(cmp: string | null, range: DateRange): Compa
   return { key, label: cmpMonthFmt.format(Date.UTC(y, m - 1, 1)), range: monthKeyToRange(key) };
 }
 
-/** Percent change of `current` vs `previous`; null when there's no baseline (previous = 0) — "% of zero" is
- *  undefined, so callers show a "new" badge instead. */
+/** Percent change of `current` vs `previous`; null when there's no usable baseline — "% of zero" is undefined, and a
+ *  negative baseline inverts the sign, so a period that improved renders as a decline. Reaction totals are a net of
+ *  creates and deletes and do go negative. Callers show a "new" badge instead. */
 export function pctChange(current: number, previous: number): number | null {
-  if (previous === 0) return null;
+  if (previous <= 0) return null;
   return ((current - previous) / previous) * 100;
 }
 

--- a/apps/creator-studio/src/lib/server/analytics.ts
+++ b/apps/creator-studio/src/lib/server/analytics.ts
@@ -40,16 +40,19 @@ export type ContentAnalytics = {
 export type AllTimeTotals = { reactions: number; comments: number };
 
 // Cached read-through wrappers. The named args double as the cache key; the TTL scales with the range span
-// (span-based, capped at 30 min) so reloads/back-nav hit Redis, not ClickHouse (fail-open).
+// (span-based, capped at 30 min) so reloads/back-nav hit Redis, not ClickHouse (fail-open). The `name` carries a
+// version suffix because the args alone don't distinguish a change in what the numbers *mean* — bump it whenever one
+// of these queries changes, or warm keys keep serving the old shape past the deploy. These four expire independently,
+// so a stale one next to a fresh one puts contradictory reaction totals on /dashboard and /analytics at once.
 export const getContentAnalytics = createCache({
-  name: 'analytics:content',
+  name: 'analytics:content:v2',
   fetch: ({ userId, from, to }: { userId: number; from: string; to: string }) =>
     fetchContentAnalytics(userId, from, to),
   ttlSeconds: ({ from, to }) => rangeTtlSeconds({ from, to }),
 }).get;
 
 export const getContentTotals = createCache({
-  name: 'analytics:totals',
+  name: 'analytics:totals:v2',
   fetch: ({ userId, from, to }: { userId: number; from: string; to: string }) =>
     fetchContentTotals(userId, from, to),
   ttlSeconds: ({ from, to }) => rangeTtlSeconds({ from, to }),
@@ -57,14 +60,14 @@ export const getContentTotals = createCache({
 
 // Top reacted media over the range (images + videos, split by `type` on each page).
 export const getTopMedia = createCache({
-  name: 'analytics:top-media',
+  name: 'analytics:top-media:v2',
   fetch: ({ userId, from, to }: { userId: number; from: string; to: string }) =>
     fetchTopMedia(userId, from, to),
   ttlSeconds: ({ from, to }) => rangeTtlSeconds({ from, to }),
 }).get;
 
 export const getAllTimeTotals = createCache({
-  name: 'analytics:alltime',
+  name: 'analytics:alltime:v2',
   fetch: async ({ userId }: { userId: number }): Promise<AllTimeTotals> => {
     const uid = Number(userId);
     const ch = getClickhouse();

--- a/apps/creator-studio/src/lib/server/analytics.ts
+++ b/apps/creator-studio/src/lib/server/analytics.ts
@@ -34,8 +34,9 @@ export type ContentAnalytics = {
   totals: ContentTotals;
 };
 
-// All-time reactions + comments on the creator's images, from the per-creator `image_metrics_user` rollup (a cheap
-// point lookup — comments have no fast period-scoped source, so this is the one place we surface them).
+// All-time reactions + comments on the creator's content. Reactions come from `reactions_owner_scores` (the same
+// owner-keyed rollup behind `UserMetric.reactionCount`, so this tile agrees with the creator's profile). Comments are
+// still the `image_metrics_user` backfill, which nothing writes any more — see the note on the fetch below.
 export type AllTimeTotals = { reactions: number; comments: number };
 
 // Cached read-through wrappers. The named args double as the cache key; the TTL scales with the range span
@@ -66,13 +67,21 @@ export const getAllTimeTotals = createCache({
   name: 'analytics:alltime',
   fetch: async ({ userId }: { userId: number }): Promise<AllTimeTotals> => {
     const uid = Number(userId);
-    const rows = await getClickhouse().$query<{
-      reactions: number | string;
-      comments: number | string;
-    }>(
-      `SELECT sumMerge(reactions) AS reactions, sumMerge(comments) AS comments FROM image_metrics_user WHERE userId = ${uid}`
-    );
-    return { reactions: Number(rows[0]?.reactions ?? 0), comments: Number(rows[0]?.comments ?? 0) };
+    const ch = getClickhouse();
+    // `image_metrics_user` is a dead one-off backfill — nothing writes it and its max userId is 9.66M against
+    // current ids past 12.5M, so this comments number is frozen and reads 0 for newer creators. Needs a real source.
+    const [reactionRows, commentRows] = await Promise.all([
+      ch.$query<{ reactions: number | string }>(
+        `SELECT sum(score) AS reactions FROM reactions_owner_scores WHERE ownerId = ${uid}`
+      ),
+      ch.$query<{ comments: number | string }>(
+        `SELECT sumMerge(comments) AS comments FROM image_metrics_user WHERE userId = ${uid}`
+      ),
+    ]);
+    return {
+      reactions: Number(reactionRows[0]?.reactions ?? 0),
+      comments: Number(commentRows[0]?.comments ?? 0),
+    };
   },
   ttlSeconds: 3600,
 }).get;
@@ -90,10 +99,12 @@ function seriesSql(
   return `SELECT toDate(${timeCol}) AS date, count() AS value FROM ${table} WHERE ${filter} AND toDate(${timeCol}) >= toDate('${from}') AND toDate(${timeCol}) <= toDate('${to}') GROUP BY date ORDER BY date WITH FILL FROM toDate('${from}') TO toDate('${to}') + 1 STEP 1`;
 }
 
-// `reactions` is append-only: reacting writes `<Entity>_Create`, un-reacting writes `<Entity>_Delete`. Counting only
-// the creates makes every react/un-react cycle a permanent +1, so we net the deletes out instead. Clamped per day
-// because a reaction added before the window and removed inside it would otherwise push a bucket negative.
-const netReactions = `greatest(sum(if(endsWith(toString(type), '_Create'), 1, -1)), 0)`;
+// `reactions` is append-only: un-reacting writes a `<Entity>_Delete` row rather than removing the `_Create`, so a
+// count filtered to `_Create` makes every react/un-react cycle a permanent +1. Must stay unclamped — clamping a
+// negative bucket makes the period total depend on bucket width. Kept in sync with `reactions_owner_scores_mv`; a
+// new entity type in the `type` enum has to be added to both or it counts as a delete here.
+const reactionCreateTypes = `('Image_Create', 'Comment_Create', 'CommentV2_Create', 'Review_Create', 'Question_Create', 'Answer_Create', 'BountyEntry_Create', 'Article_Create')`;
+const netReactions = `sum(if(type IN ${reactionCreateTypes}, 1, -1))`;
 
 function netReactionsDailySql(uid: number, from: string, to: string): string {
   return `SELECT toDate(time) AS date, ${netReactions} AS value FROM reactions WHERE ownerId = ${uid} AND toDate(time) >= toDate('${from}') AND toDate(time) <= toDate('${to}') GROUP BY date`;
@@ -154,7 +165,7 @@ async function fetchTopMedia(userId: number, from: string, to: string): Promise<
     imageId: number | string;
     reactions: number | string;
   }>(
-    `SELECT entityId AS imageId, ${netReactions} AS reactions FROM reactions WHERE ownerId = ${uid} AND toString(type) IN ('Image_Create', 'Image_Delete') AND toDate(time) >= toDate('${from}') AND toDate(time) <= toDate('${to}') GROUP BY imageId HAVING reactions > 0 ORDER BY reactions DESC LIMIT 100`
+    `SELECT entityId AS imageId, ${netReactions} AS reactions FROM reactions WHERE ownerId = ${uid} AND type IN ('Image_Create', 'Image_Delete') AND toDate(time) >= toDate('${from}') AND toDate(time) <= toDate('${to}') GROUP BY imageId HAVING reactions > 0 ORDER BY reactions DESC LIMIT 100`
   );
   return enrichTopImages(raw);
 }
@@ -205,7 +216,6 @@ async function fetchContentTotals(
     return Number(rows[0]?.value ?? 0);
   };
 
-  // Sums the same per-day clamped buckets the series uses, so the dashboard total always matches the chart.
   const netReactionsTotal = async (): Promise<number> => {
     const rows = await ch.$query<{ value: number | string }>(
       `SELECT sum(value) AS value FROM (${netReactionsDailySql(uid, from, to)})`

--- a/apps/creator-studio/src/lib/server/analytics.ts
+++ b/apps/creator-studio/src/lib/server/analytics.ts
@@ -90,6 +90,15 @@ function seriesSql(
   return `SELECT toDate(${timeCol}) AS date, count() AS value FROM ${table} WHERE ${filter} AND toDate(${timeCol}) >= toDate('${from}') AND toDate(${timeCol}) <= toDate('${to}') GROUP BY date ORDER BY date WITH FILL FROM toDate('${from}') TO toDate('${to}') + 1 STEP 1`;
 }
 
+// `reactions` is append-only: reacting writes `<Entity>_Create`, un-reacting writes `<Entity>_Delete`. Counting only
+// the creates makes every react/un-react cycle a permanent +1, so we net the deletes out instead. Clamped per day
+// because a reaction added before the window and removed inside it would otherwise push a bucket negative.
+const netReactions = `greatest(sum(if(endsWith(toString(type), '_Create'), 1, -1)), 0)`;
+
+function netReactionsDailySql(uid: number, from: string, to: string): string {
+  return `SELECT toDate(time) AS date, ${netReactions} AS value FROM reactions WHERE ownerId = ${uid} AND toDate(time) >= toDate('${from}') AND toDate(time) <= toDate('${to}') GROUP BY date`;
+}
+
 async function fetchContentAnalytics(
   userId: number,
   from: string,
@@ -105,13 +114,11 @@ async function fetchContentAnalytics(
 
   const [reactions, followers, images, posts, profileViews] = await Promise.all([
     series(
-      seriesSql(
-        'reactions',
-        'time',
-        `ownerId = ${uid} AND endsWith(toString(type), '_Create')`,
+      `${netReactionsDailySql(
+        uid,
         from,
         to
-      )
+      )} ORDER BY date WITH FILL FROM toDate('${from}') TO toDate('${to}') + 1 STEP 1`
     ),
     series(
       seriesSql('userEngagements', 'time', `targetUserId = ${uid} AND type = 'Follow'`, from, to)
@@ -147,7 +154,7 @@ async function fetchTopMedia(userId: number, from: string, to: string): Promise<
     imageId: number | string;
     reactions: number | string;
   }>(
-    `SELECT entityId AS imageId, count() AS reactions FROM reactions WHERE ownerId = ${uid} AND type = 'Image_Create' AND toDate(time) >= toDate('${from}') AND toDate(time) <= toDate('${to}') GROUP BY imageId ORDER BY reactions DESC LIMIT 100`
+    `SELECT entityId AS imageId, ${netReactions} AS reactions FROM reactions WHERE ownerId = ${uid} AND toString(type) IN ('Image_Create', 'Image_Delete') AND toDate(time) >= toDate('${from}') AND toDate(time) <= toDate('${to}') GROUP BY imageId HAVING reactions > 0 ORDER BY reactions DESC LIMIT 100`
   );
   return enrichTopImages(raw);
 }
@@ -198,8 +205,16 @@ async function fetchContentTotals(
     return Number(rows[0]?.value ?? 0);
   };
 
+  // Sums the same per-day clamped buckets the series uses, so the dashboard total always matches the chart.
+  const netReactionsTotal = async (): Promise<number> => {
+    const rows = await ch.$query<{ value: number | string }>(
+      `SELECT sum(value) AS value FROM (${netReactionsDailySql(uid, from, to)})`
+    );
+    return Number(rows[0]?.value ?? 0);
+  };
+
   const [reactions, followers, images, posts, profileViews] = await Promise.all([
-    count('reactions', 'time', `ownerId = ${uid} AND endsWith(toString(type), '_Create')`),
+    netReactionsTotal(),
     count('userEngagements', 'time', `targetUserId = ${uid} AND type = 'Follow'`),
     count('images_created', 'createdAt', `userId = ${uid}`),
     count('posts', 'time', `userId = ${uid} AND type = 'Publish'`),

--- a/src/server/clickhouse/tracker.ts
+++ b/src/server/clickhouse/tracker.ts
@@ -72,10 +72,12 @@ export type ModelActivty =
   | 'Transfer';
 export type ResourceReviewType = 'Create' | 'Delete' | 'Exclude' | 'Include' | 'Update';
 export type ReactionType =
-  | 'Images_Create'
-  | 'Images_Delete'
+  | 'Image_Create'
+  | 'Image_Delete'
   | 'Comment_Create'
   | 'Comment_Delete'
+  | 'CommentV2_Create'
+  | 'CommentV2_Delete'
   | 'Review_Create'
   | 'Review_Delete'
   | 'Question_Create'


### PR DESCRIPTION
## The bug

Creator Studio Analytics over-reports reactions. Reported on image `120233601`: Analytics showed **447**, the image page showed 152, and Postgres `ImageReaction` — the ground truth — has **434**.

The ClickHouse `reactions` table is append-only. Reacting writes `<Entity>_Create`; un-reacting writes `<Entity>_Delete`. Every analytics query filtered on `_Create`, which *excludes* the deletes rather than *netting* them, so each react/un-react cycle left a permanent +1.

Verified in prod for image `120233601`: 449 `Image_Create`, 15 `Image_Delete`.

**On the numbers, precisely** — 449 − 15 = **434**, and that figure only appears over an all-time window. In the Feb-2026 range the issue was filed against, the query returns **432**; the two straggler reactions land in May and June. `apps/creator-studio/src/lib/date-range.ts` offers only `7d`, `30d`, and `recentMonths()`, so **no range in the product reproduces 434** for this image. The 447 the reporter saw was creates-only within their selected range.

## The semantic tradeoff — read this first

The chart now shows **net change in reactions during the period**, not **reactions received during the period**. For a creator who was mass-unreacted, that renders as a negative bar. Owner `988123` over 30d: 92 creates, 408 deletes, so the chart reads **−316** where it previously read 92.

The alternative — creates-only on the chart, netting only on the standing tile — is a legitimate choice, and we consciously did not take it. We chose **consistency**: every number on the page nets the same way, and the top-media figures reconcile with what the image page shows. A reviewer who weighs "the chart should be monotone" above that consistency should push back here, and this is the paragraph to push back on.

## Why there is no clamp

The first revision clamped each daily bucket at zero. That was wrong, and the review caught it. Clamping makes the period total **a property of the bucket width rather than of the data**. Owner `9384618`, `2026-07-06..2026-08-04`, identical rows:

| bucketing | clamped total |
|---|---|
| hourly | 822 |
| daily | 753 |
| weekly | 626 |
| whole window | 574 (true net) |

Nothing in the data selects 753. Unclamped, all four widths return **574** — verified. The clamp also discarded real signal at every width: owner `583956` all-time came out 51,656 clamped against a true net of 51,586, over by 70, because nine days net negative on their own (e.g. `2026-07-21` at −55 — deletes whose creates aren't in the table).

So: no `greatest(..., 0)` anywhere. Values go negative when the data does.

## Final SQL

Shared expression. The create list mirrors `reactions_owner_scores_mv` and compares the `Enum8` directly rather than materializing a String per row across an 824M-row table:

```sql
sum(if(type IN ('Image_Create','Comment_Create','CommentV2_Create','Review_Create',
                'Question_Create','Answer_Create','BountyEntry_Create','Article_Create'), 1, -1))
```

**1. `fetchTopMedia`**
```sql
-- before
SELECT entityId AS imageId, count() AS reactions FROM reactions
WHERE ownerId = ? AND type = 'Image_Create' AND toDate(time) BETWEEN ? AND ?
GROUP BY imageId ORDER BY reactions DESC LIMIT 100
-- after
SELECT entityId AS imageId, <net> AS reactions FROM reactions
WHERE ownerId = ? AND type IN ('Image_Create','Image_Delete') AND toDate(time) BETWEEN ? AND ?
GROUP BY imageId HAVING reactions > 0 ORDER BY reactions DESC LIMIT 100
```

**2. Reactions series** — per-day unclamped net, `WITH FILL` unchanged
```sql
-- before
SELECT toDate(time) AS date, count() AS value FROM reactions
WHERE ownerId = ? AND endsWith(toString(type),'_Create') AND toDate(time) BETWEEN ? AND ?
GROUP BY date ORDER BY date WITH FILL ...
-- after
SELECT toDate(time) AS date, <net> AS value FROM reactions
WHERE ownerId = ? AND toDate(time) BETWEEN ? AND ?
GROUP BY date ORDER BY date WITH FILL ...
```

**3. Period total** — sum of those same unclamped daily nets
```sql
SELECT sum(value) AS value FROM (<the per-day subquery from #2>)
```

**4. All-time tile** — off the dead rollup
```sql
-- before
SELECT sumMerge(reactions) AS reactions, sumMerge(comments) AS comments
FROM image_metrics_user WHERE userId = ?
-- after (reactions half only)
SELECT sum(score) AS reactions FROM reactions_owner_scores WHERE ownerId = ?
```

## `HAVING reactions > 0` on top-media is deliberate, and it shrinks the grid

A net-negative image shouldn't rank in a "top" grid, so it's filtered out. This visibly removes content. Owner `2690310` over 30d goes from **59 images shown to 26** — verified. Image `104075964` (53 creates, 56 deletes in-window, net −3) **disappears entirely**. That is a consequence we accepted, not an oversight.

## The all-time tile was reading a dead table

`image_metrics_user` is a one-off backfill that **no materialized view writes**. Its `max(userId)` is **9,659,529** against current user ids past 12.5M, and it holds only 324,689 rows — so every newer creator read 0 and everyone else was frozen at backfill time. For owner `583956` it reported 14,924 all-time reactions.

Reactions now read `reactions_owner_scores`. I verified the engine before writing the query: it is a **`SharedSummingMergeTree`** with a plain `Int64 score` column, so `sum(score)` is correct and no `-Merge` applies. Its MV nets (`multiIf(type IN (…_Create), 1, -1)`), is owner-keyed, and excludes self-reactions after 2024-04-27. Sanity numbers:

| ownerId | old (frozen) | new |
|---|---|---|
| `583956` | 14,924 | 51,528 |
| `988123` | — | 67,132 |
| `2690310` | — | 18,431 |
| `9384618` | — | 9,136 |

This is the same rollup `UserMetric.reactionCount` already uses (`src/server/metrics/user.metrics.ts:281`), so the Studio tile now agrees with the creator's profile number. It will *not* equal a raw event net — the self-reaction exclusion is intentional and is what makes it match the profile.

**The `comments` half of that tile is still frozen.** I found no clean equivalent source and did not invent one. It stays on `image_metrics_user` and needs a follow-up.

## Cache purge needed on deploy

`analytics:content`, `analytics:totals`, `analytics:top-media`, and `analytics:alltime` all hold values computed the old way. Purge them rather than waiting out the TTL.

Note that the totals tile and the analytics chart sit on **different pages behind different cache entries** (`analytics:totals` vs `analytics:content`) with independent TTL jitter — 300s for 7d, 1200s for 30d. They are computed from the same subquery, but that does **not** guarantee a viewer sees them agree; the two can be observed up to ~20 minutes apart.

## Also fixed: misleading `ReactionType` union

`src/server/clickhouse/tracker.ts` declared `'Images_Create' | 'Images_Delete'` (plural). Those values do not exist in the ClickHouse enum; the controller emits singular `Image_*`. The union also omitted `CommentV2_*`, which the controller does emit. It now matches the prod enum exactly — all 16 values, no extras, no omissions — and the removed plural strings had zero references repo-wide.

## Known, not fixed

- **`reaction.controller.ts:66` emits `Post_Create`/`Post_Delete`, which are not in the ClickHouse enum.** Zero `Post_*` rows exist in prod — post reactions have never landed. I tried removing the `as ReactionType` cast at `reaction.controller.ts:238` to surface this at compile time. It does not surface it usefully: `getTrackerEvent` builds `type` from a template literal that widens to `string`, so removing the cast yields a blanket `Type 'string' is not assignable to type 'ReactionType'` rather than pointing at `Post_*`. Making it pinpoint the real bug needs `as const` at eight return sites, and *then* forces a product/migration decision about whether post reactions should work at all. Out of scope; cast restored.
- **`image_metrics_user` comments**, above.

`Refs #3651` rather than `Fixes` — this closes the Creator Studio side only. The image page showing 152 against a true 434 is a separate bug still outstanding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
