### PR TITLE
refactor(rate-limit): derive anonymous bucket keys from one shared client-IP predicate

### DIFF
--- a/src/server/__tests__/middleware.trpc.rate-limit-key.test.ts
+++ b/src/server/__tests__/middleware.trpc.rate-limit-key.test.ts
@@ -1,0 +1,340 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { NextApiRequest } from 'next';
+import requestIp from 'request-ip';
+
+/**
+ * Guards the BUCKET KEY the generic tRPC `rateLimit()` middleware writes to.
+ *
+ * The relationship under test — stated as a property, not as a spelling, so it
+ * survives any refactor of how the key is computed:
+ *
+ *   For an ANONYMOUS caller, the rate-limit bucket field is a function of the
+ *   EDGE-STAMPED client address alone. Two requests that Cloudflare stamps with
+ *   the same `cf-connecting-ip` MUST land in the same bucket no matter what
+ *   other client-supplied address headers they carry; two requests the edge
+ *   stamps differently MUST land in different buckets.
+ *
+ * Both halves are asserted on purpose. The "same bucket" half alone would pass
+ * against a limiter that had collapsed every anonymous caller onto one constant
+ * — a reassuring answer from a harness wired to nothing. The "different bucket"
+ * half is its positive control: it proves this harness can OBSERVE a key
+ * difference at all, so the invariance result means something.
+ *
+ * The second property, further down: the field is drawn from two namespaces —
+ * user ids and client addresses — written into ONE redis hash, so those two key
+ * spaces must be disjoint for every value either side can take.
+ *
+ * Fixture fidelity: `ctx.ip` is built here with the same call `createContext`
+ * uses (`requestIp.getClientIp(req) ?? ''`, src/server/createContext.ts:30) so
+ * the synthetic context is faithful to the real one rather than to whatever
+ * value would make the test convenient. The `request-ip` dependency edge on
+ * createContext is itself pinned by
+ * `src/server/utils/__tests__/client-ip-ledger.test.ts`.
+ *
+ * Harness shape is copied from `middleware.trpc.test.ts` — intercept
+ * `~/server/trpc`'s `middleware()` to capture the handler the factory passes
+ * in, then invoke it directly. Note `~/env/other` MUST be mocked to a
+ * production-like shape: the middleware short-circuits on `isTest`, so without
+ * this mock the whole body under test never runs and every assertion here would
+ * be vacuous.
+ */
+
+const { mockHSetWithTTL, mockHGet, capturedHandler } = vi.hoisted(() => {
+  const captured: { handler: ((arg: unknown) => Promise<unknown>) | null } = { handler: null };
+  return {
+    mockHSetWithTTL: vi.fn(),
+    mockHGet: vi.fn(),
+    capturedHandler: captured,
+  };
+});
+
+vi.mock('~/server/redis/atomic', () => ({ hSetWithTTL: mockHSetWithTTL }));
+vi.mock('~/server/redis/fail-open-log', () => ({ logSysRedisFailOpen: vi.fn() }));
+
+vi.mock('~/server/redis/client', () => ({
+  redis: { packed: { hGet: mockHGet } },
+  REDIS_KEYS: { TRPC: { LIMIT: { BASE: 'trpc:rate-limit' } } },
+}));
+
+vi.mock('~/server/trpc', () => ({
+  middleware: (fn: (arg: unknown) => Promise<unknown>) => {
+    capturedHandler.handler = fn;
+    return fn;
+  },
+}));
+
+// Pass-throughs for the rest of middleware.trpc's import graph — only touched by
+// sibling middlewares this file never invokes.
+vi.mock('~/server/services/user-preferences.service', () => ({
+  getAllHiddenForUser: vi.fn(async () => ({
+    hiddenImages: [],
+    hiddenTags: [],
+    hiddenModels: [],
+    hiddenUsers: [],
+  })),
+}));
+vi.mock('~/server/cloudflare/client', () => ({ purgeCache: vi.fn(async () => undefined) }));
+vi.mock('~/server/logging/client', () => ({ logToAxiom: vi.fn(async () => undefined) }));
+vi.mock('~/server/utils/server-domain', () => ({
+  getRequestDomainColor: vi.fn(() => 'blue'),
+  getRequestBoardDomainColor: vi.fn(() => 'blue'),
+}));
+vi.mock('~/server/utils/otel-helpers', () => ({
+  withSpan: (_name: string, fn: () => unknown) => fn(),
+}));
+vi.mock('~/env/other', () => ({
+  isDev: false,
+  isProd: true,
+  isTest: false,
+  isPreview: false,
+}));
+vi.mock('~/env/client', () => ({
+  env: {
+    NEXT_PUBLIC_BASE_URL: 'http://localhost:3000',
+    NEXT_PUBLIC_CIVITAI_LINK: 'http://localhost:3000',
+  },
+}));
+
+import { rateLimit } from '../middleware.trpc';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  capturedHandler.handler = null;
+  mockHGet.mockResolvedValue([]);
+  mockHSetWithTTL.mockResolvedValue(undefined);
+});
+
+const SOCKET_PEER = '10.42.0.9';
+
+function reqWith(headers: Record<string, string | string[]>): NextApiRequest {
+  return { headers, socket: { remoteAddress: SOCKET_PEER } } as unknown as NextApiRequest;
+}
+
+/**
+ * Build the context the way `createContext` does, so `ctx.ip` carries exactly
+ * the value the real anonymous request would carry.
+ */
+function anonCtx(headers: Record<string, string | string[]>) {
+  const req = reqWith(headers);
+  return { user: undefined, ip: requestIp.getClientIp(req) ?? '', req };
+}
+
+/**
+ * Drive the real middleware once and return the hash field it addressed in
+ * redis. Reading the argument the limiter actually passed to `hGet` — rather
+ * than re-deriving it — is what makes this a behavioural guard: it holds for any
+ * implementation that ends up keying the bucket correctly.
+ */
+async function bucketFieldFor(ctx: Record<string, unknown>): Promise<string> {
+  rateLimit({ limit: 10, period: 60 });
+  const handler = capturedHandler.handler;
+  if (!handler)
+    throw new Error('harness broken: rateLimit() did not register a middleware handler');
+
+  const before = mockHGet.mock.calls.length;
+  await handler({
+    ctx,
+    input: undefined,
+    path: 'test:procedure',
+    next: vi.fn(async () => ({ ok: true })),
+  });
+  const calls = mockHGet.mock.calls;
+  if (calls.length !== before + 1) {
+    throw new Error(
+      `harness broken: expected exactly one redis hGet for this call, saw ${
+        calls.length - before
+      }. ` +
+        'The middleware short-circuited before computing a bucket key (check the ~/env/other mock).'
+    );
+  }
+  return calls[calls.length - 1][1] as string;
+}
+
+const EDGE_IP = '203.0.113.7';
+
+// EVERY non-edge address header `request-ip` consults, enumerated from the
+// library's own source (`request-ip/lib/index.js`, `getClientIp`) rather than
+// from its README — the README lists fewer than the code reads. The one header
+// it consults that is NOT here is `cf-connecting-ip`, deliberately: that is the
+// edge-stamped header this suite holds FIXED while rotating the rest.
+//
+// Covered as a SET rather than one representative: a derivation that handled
+// some members and not others would otherwise pass, and which member is
+// consulted first is a library detail this suite should not have to know. The
+// enumeration is self-verifying — `is genuinely consulted by the resolver`
+// below fails if a listed header is not actually read, so this list cannot
+// silently drift into claiming coverage it does not have.
+const NON_EDGE_ADDRESS_HEADERS = [
+  'x-client-ip',
+  'x-forwarded-for',
+  'x-real-ip',
+  'true-client-ip',
+  'x-cluster-client-ip',
+  'fastly-client-ip',
+  'x-forwarded',
+  'forwarded-for',
+  'forwarded',
+  'x-appengine-user-ip',
+] as const;
+
+const fill = (headers: readonly string[], value: string) =>
+  Object.fromEntries(headers.map((h) => [h, value]));
+
+describe('rateLimit bucket key — anonymous callers', () => {
+  it('is INVARIANT under every non-edge address header at once', async () => {
+    const a = await bucketFieldFor(
+      anonCtx({ 'cf-connecting-ip': EDGE_IP, ...fill(NON_EDGE_ADDRESS_HEADERS, '198.51.100.1') })
+    );
+    const b = await bucketFieldFor(
+      anonCtx({ 'cf-connecting-ip': EDGE_IP, ...fill(NON_EDGE_ADDRESS_HEADERS, '192.0.2.55') })
+    );
+
+    expect(
+      a,
+      'two anonymous requests with the same edge-stamped client IP must share one rate-limit bucket'
+    ).toBe(b);
+    // Pin WHICH address won AND the namespace it was written under, so this can
+    // pass neither by collapsing onto a constant nor by dropping the prefix that
+    // keeps addresses out of the user-id key space.
+    expect(a).toBe(`ip:${EDGE_IP}`);
+  });
+
+  it('POSITIVE CONTROL: a different edge-stamped IP DOES produce a different bucket', async () => {
+    const a = await bucketFieldFor(anonCtx({ 'cf-connecting-ip': EDGE_IP }));
+    const b = await bucketFieldFor(anonCtx({ 'cf-connecting-ip': '203.0.113.8' }));
+
+    expect(
+      a,
+      'harness must be able to observe a bucket difference — otherwise the invariance test above is vacuous'
+    ).not.toBe(b);
+  });
+
+  // Per-header, so a derivation that covers most of the set but misses one member
+  // still fails — the all-at-once case above cannot distinguish that.
+  it.each(NON_EDGE_ADDRESS_HEADERS)('is INVARIANT under %s rotated on its own', async (header) => {
+    const a = await bucketFieldFor(
+      anonCtx({ 'cf-connecting-ip': EDGE_IP, [header]: '198.51.100.1' })
+    );
+    const b = await bucketFieldFor(
+      anonCtx({ 'cf-connecting-ip': EDGE_IP, [header]: '192.0.2.55' })
+    );
+    expect(a, `rotating ${header} on its own must not move the anon rate-limit bucket`).toBe(b);
+    expect(a).toBe(`ip:${EDGE_IP}`);
+  });
+
+  // POSITIVE CONTROL for the enumeration above. The invariance cases pass for a
+  // header the resolver never reads at all — an inert name would look exactly
+  // like a correctly-ignored one. Each member is therefore also shown to DRIVE
+  // the bucket when the edge header is absent, which is what makes the list an
+  // enumeration of the real set rather than a list of plausible spellings.
+  it.each(NON_EDGE_ADDRESS_HEADERS)('%s is genuinely consulted by the resolver', async (header) => {
+    const field = await bucketFieldFor(anonCtx({ [header]: '198.51.100.1' }));
+    expect(
+      field,
+      `${header} is listed as a consulted address header but did not move the bucket off the socket peer`
+    ).toBe('ip:198.51.100.1');
+  });
+});
+
+describe('rateLimit bucket key — other principals', () => {
+  it('authenticated callers key on the user id, ignoring every address header', async () => {
+    const req = reqWith({ 'cf-connecting-ip': '203.0.113.7', 'x-client-ip': '198.51.100.1' });
+    const field = await bucketFieldFor({
+      user: { id: 42, isModerator: false },
+      ip: requestIp.getClientIp(req) ?? '',
+      req,
+    });
+    // Namespaced: the id is written under `user:`, never bare, so it occupies a
+    // key space disjoint from anything written into the address side.
+    expect(field).toBe('user:42');
+  });
+
+  // INVARIANT GUARD, not regression coverage: the code this replaced used `??`,
+  // which already handled id 0 correctly. It pins that the `!= null` test was
+  // preserved rather than relaxed to a truthiness test — id 0 is a legal
+  // principal, and a truthy check would silently route it to the address branch
+  // and bucket that user alongside anonymous callers on the same IP.
+  it('a user id of 0 keys the user bucket, not the address branch', async () => {
+    const req = reqWith({ 'cf-connecting-ip': EDGE_IP });
+    const field = await bucketFieldFor({
+      user: { id: 0, isModerator: false },
+      ip: requestIp.getClientIp(req) ?? '',
+      req,
+    });
+    expect(
+      field,
+      'id 0 is a valid principal; a truthiness test would route it to the address branch'
+    ).toBe('user:0');
+  });
+
+  // INVARIANT GUARD, not regression coverage: this behaviour is unchanged by the
+  // consolidation. It pins that the non-CF fallback was RETAINED, so a later
+  // "tighten it to CF-only" edit has to face the dev/direct-to-origin case
+  // deliberately instead of silently collapsing those callers into one bucket.
+  it('non-CF requests still fall back to the library resolver rather than collapsing', async () => {
+    const a = await bucketFieldFor(anonCtx({ 'x-forwarded-for': '198.51.100.1' }));
+    const b = await bucketFieldFor(anonCtx({ 'x-forwarded-for': '198.51.100.2' }));
+    expect(a).toBe('ip:198.51.100.1');
+    expect(b).toBe('ip:198.51.100.2');
+  });
+});
+
+/**
+ * REGRESSION COVERAGE — the two key spaces are disjoint.
+ *
+ * The bucket field is drawn from two different namespaces: user ids on one side,
+ * client addresses on the other. Both are written into ONE redis hash, and in a
+ * hash equal strings are the same bucket. The invariant is therefore a property
+ * of the key space itself: a field written from the address side must never be
+ * able to equal a field written from the id side, for any value either side can
+ * take.
+ *
+ * Asserted as that property rather than as one payload. The `authed !== anon`
+ * form holds for any implementation that keeps the two spaces apart — by
+ * namespacing the field, by bounding what the address side may contain, or by
+ * both — so it pins the relationship and not today's spelling.
+ */
+describe('rateLimit bucket key — key-space separation', () => {
+  const SAMPLE_USER_ID = 42;
+
+  async function authedFieldFor(userId: number) {
+    const req = reqWith({});
+    return bucketFieldFor({
+      user: { id: userId, isModerator: false },
+      ip: requestIp.getClientIp(req) ?? '',
+      req,
+    });
+  }
+
+  it('a value well-formed on both sides does not address the same bucket from either', async () => {
+    // A bare integer is the overlap case: it is a legal user id, and it is a
+    // string the address side can also carry. If the two spaces were shared,
+    // this is the shape that would collide.
+    const authed = await authedFieldFor(SAMPLE_USER_ID);
+    const anon = await bucketFieldFor(anonCtx({ 'cf-connecting-ip': String(SAMPLE_USER_ID) }));
+
+    expect(
+      anon,
+      'a field written from the address side must not equal a field written from the id side'
+    ).not.toBe(authed);
+  });
+
+  it('POSITIVE CONTROL: the harness can observe two fields colliding', async () => {
+    // Guards the assertion above against passing for the wrong reason. If the
+    // harness could never produce equal fields, `not.toBe` would be satisfied by
+    // construction and prove nothing. Two reads of the SAME principal must
+    // collide — that is what makes the inequality above a real observation.
+    const a = await authedFieldFor(SAMPLE_USER_ID);
+    const b = await authedFieldFor(SAMPLE_USER_ID);
+    expect(a, 'same principal must map to one stable bucket field').toBe(b);
+  });
+
+  it('separation is not bought by collapsing the address side onto a constant', async () => {
+    // Disjointness is trivially satisfiable by making one side degenerate, which
+    // would replace the shared key space with a single shared bucket for every
+    // anonymous caller — strictly worse. The address side must still vary.
+    const a = await bucketFieldFor(anonCtx({ 'cf-connecting-ip': '203.0.113.7' }));
+    const b = await bucketFieldFor(anonCtx({ 'cf-connecting-ip': '203.0.113.8' }));
+    expect(a).not.toBe(b);
+  });
+});

--- a/src/server/__tests__/middleware.trpc.test.ts
+++ b/src/server/__tests__/middleware.trpc.test.ts
@@ -210,10 +210,13 @@ describe('rateLimit recordAttempt — round-4 fail-open wrapper', () => {
     expect(subtype).toBe('rate-limit-write-degraded');
     expect(fn).toBe('middleware.trpc.recordAttempt');
     expect(err).toBe(synthetic);
-    // The extra payload should carry enough to disambiguate the call.
+    // The extra payload should carry enough to disambiguate the call. The hash
+    // key is namespaced by principal kind (`user:` / `ip:`) so the two key
+    // spaces cannot collide — see middleware.trpc.ts and the dedicated bucket-key
+    // suite in `middleware.trpc.rate-limit-key.test.ts`.
     expect(extra).toMatchObject({
       cacheKey: expect.stringContaining('trpc:rate-limit:'),
-      hashKey: '42',
+      hashKey: 'user:42',
     });
   });
 

--- a/src/server/middleware.trpc.ts
+++ b/src/server/middleware.trpc.ts
@@ -10,6 +10,7 @@ import { logSysRedisFailOpen } from '~/server/redis/fail-open-log';
 import type { UserPreferencesInput } from '~/server/schema/base.schema';
 import { getAllHiddenForUser } from '~/server/services/user-preferences.service';
 import { middleware } from '~/server/trpc';
+import { resolveClientIp } from '~/server/utils/client-ip';
 import { getRequestBoardDomainColor, getRequestDomainColor } from '~/server/utils/server-domain';
 import type { SessionUser } from '~/types/session';
 import { withSpan } from '~/server/utils/otel-helpers';
@@ -176,7 +177,22 @@ export function rateLimit<TInput = any>(
     // quota; otherwise key on the tRPC path.
     const keyName = options?.sharedKey ?? path.replace('.', ':');
     const cacheKey = `${REDIS_KEYS.TRPC.LIMIT.BASE}:${keyName}` as const;
-    const hashKey = ctx.user?.id?.toString() ?? ctx.ip;
+    // Anonymous callers bucket by client IP, authenticated ones by user id. The
+    // IP comes from the SHARED predicate in `~/server/utils/client-ip` rather
+    // than the general-purpose `ctx.ip`, so this limiter and the public REST
+    // limiter derive the bucket the same way — see that module's doc for which
+    // predicate suits which surface.
+    //
+    // NAMESPACE THE FIELD. User ids and addresses are two different namespaces
+    // and both are written into one hash, where equal strings are one bucket.
+    // The prefix makes the two key spaces disjoint by construction rather than
+    // by whichever values happen not to overlap. Same shape as the public REST
+    // limiter (`~/server/utils/public-api-rate-limit`), deliberately.
+    // `!= null` and not a truthiness test: it must match the nullish semantics of
+    // the `??` this replaced, or a user id of 0 would silently route to the IP
+    // branch. Pinned by the id-0 case in
+    // `src/server/__tests__/middleware.trpc.rate-limit-key.test.ts`.
+    const hashKey = ctx.user?.id != null ? `user:${ctx.user.id}` : `ip:${resolveClientIp(ctx.req)}`;
     const attempts = (await redis.packed.hGet<number[]>(cacheKey, hashKey)) ?? [];
 
     // Check if user can proceed and find the failing limit

--- a/src/server/utils/__tests__/client-ip-ledger.test.ts
+++ b/src/server/utils/__tests__/client-ip-ledger.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+
+/**
+ * Structural tripwire for client-IP derivation under `src/server/**`.
+ *
+ * WHAT IT PINS: the exact set of server modules that hold a DIRECT dependency
+ * edge on the `request-ip` package. That edge is state, not a spelling — a
+ * module either imports the library or it does not, and you cannot open-code a
+ * derivation from it without one. The ledger therefore fails in BOTH directions:
+ * it grows when a new module starts deriving an address itself instead of
+ * calling the shared `~/server/utils/client-ip` predicate, and it shrinks when a
+ * listed one stops, which is the prompt to re-read this list.
+ *
+ * WHAT IT DOES NOT PIN — stated so nobody reads a green run as more than it is.
+ * This is a dependency-graph check, so it cannot see a derivation that reaches
+ * the library indirectly (aliasing the import, re-exporting it from a helper) or
+ * one hand-rolled straight off `req.headers`. It is a tripwire that forces a
+ * conscious decision on the common shape, NOT a proof that every bucket key is
+ * correct. The behavioural guard for that is
+ * `src/server/__tests__/middleware.trpc.rate-limit-key.test.ts`, which drives the
+ * real limiter and reads the key it actually used. Neither guard substitutes for
+ * the other.
+ */
+
+const REPO_ROOT = path.resolve(__dirname, '../../../..');
+const SERVER_ROOT = path.join(REPO_ROOT, 'src', 'server');
+
+// A direct dependency edge on the package, in either module syntax.
+const REQUEST_IP_EDGE =
+  /(?:^|\n)\s*(?:import\b[^;\n]*?from\s*|.*\brequire\s*\()\s*['"]request-ip['"]/;
+
+// The same shape, for the edge onto the SHARED predicate. Built from the same
+// construction as REQUEST_IP_EDGE on purpose: it must match a real module edge
+// and NOT a mention of the path, because both modules under test carry comments
+// that name this path in prose. A substring test would be satisfied by those
+// comments, so it would keep reporting green after the import and the call were
+// both deleted — pinning a spelling any line can produce, rather than the edge.
+const CLIENT_IP_EDGE =
+  /(?:^|\n)\s*(?:(?:import|export)\b[^;\n]*?from\s*|.*\brequire\s*\()\s*['"]~\/server\/utils\/client-ip['"]/;
+
+/**
+ * Every module under `src/server` allowed a direct `request-ip` edge, and why.
+ * Adding an entry is a deliberate act: prefer `~/server/utils/client-ip`.
+ */
+const LEDGER: Record<string, string> = {
+  'utils/client-ip.ts':
+    'THE shared predicate. This is the sanctioned home for the library fallback.',
+  'createContext.ts':
+    'Builds the general-purpose ctx.ip consumed by tracking / audit-trail / captcha-binding call sites.',
+  'clickhouse/tracker.ts': 'Analytics actor attribution.',
+  'services/image-search.service.ts': 'Anonymous search actor hashing.',
+};
+
+/** Modules that key a rate-limit bucket and must therefore NOT hold the edge. */
+const MUST_NOT_HOLD_EDGE = ['middleware.trpc.ts', 'utils/public-api-rate-limit.ts'];
+
+function walk(dir: string, out: string[] = []): string[] {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === '__tests__' || entry.name === 'node_modules') continue;
+      walk(full, out);
+    } else if (entry.name.endsWith('.ts') && !entry.name.endsWith('.test.ts')) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+const files = walk(SERVER_ROOT);
+const holders = files
+  .filter((f) => REQUEST_IP_EDGE.test(fs.readFileSync(f, 'utf8')))
+  .map((f) => path.relative(SERVER_ROOT, f).replace(/\\/g, '/'))
+  .sort();
+
+describe('client-IP derivation ledger', () => {
+  // ---------------------------------------------------------------------
+  // Instrument validation FIRST. A ledger check whose reassuring answer is a
+  // small set is indistinguishable from a scanner wired to nothing, so the
+  // detector gets a positive and a negative control before its verdict is read.
+  // ---------------------------------------------------------------------
+  it('CONTROL: the detector matches a real import and rejects a near-miss', () => {
+    expect(REQUEST_IP_EDGE.test(`import requestIp from 'request-ip';`)).toBe(true);
+    expect(REQUEST_IP_EDGE.test(`import requestIp from "request-ip";`)).toBe(true);
+    expect(REQUEST_IP_EDGE.test(`const requestIp = require('request-ip');`)).toBe(true);
+    expect(REQUEST_IP_EDGE.test(`import type { NextApiRequest } from 'next';`)).toBe(false);
+    // Must not fire on prose merely naming the package.
+    expect(REQUEST_IP_EDGE.test(`// falls back to the request-ip library`)).toBe(false);
+    // Must not fire on a DIFFERENT package whose name contains the same token.
+    expect(REQUEST_IP_EDGE.test(`import x from 'request-ip-extra';`)).toBe(false);
+  });
+
+  it('CONTROL: the shared-predicate detector matches an edge and rejects prose', () => {
+    const P = '~/server/utils/client-ip';
+    expect(CLIENT_IP_EDGE.test(`import { resolveClientIp } from '${P}';`)).toBe(true);
+    expect(CLIENT_IP_EDGE.test(`import { resolveClientIp } from "${P}";`)).toBe(true);
+    expect(CLIENT_IP_EDGE.test(`export { resolveClientIp } from '${P}';`)).toBe(true);
+    expect(CLIENT_IP_EDGE.test(`const { resolveClientIp } = require('${P}');`)).toBe(true);
+
+    // THE REGRESSION THIS REPLACED. Every one of these lines occurs, or could
+    // plausibly occur, in the very files the ledger checks — the previous
+    // substring assertion returned true for all of them, so it stayed green
+    // with the import and the call site both removed.
+    expect(CLIENT_IP_EDGE.test(`// that IP comes from the predicate in \`${P}\``)).toBe(false);
+    expect(CLIENT_IP_EDGE.test(` * see the module doc in ${P} for why that matters`)).toBe(false);
+    expect(CLIENT_IP_EDGE.test(`// \`resolveClientIp\` now lives in \`${P}\` so the`)).toBe(false);
+
+    // Must not fire on a neighbouring module whose path extends this one.
+    expect(CLIENT_IP_EDGE.test(`import x from '${P}-trusted';`)).toBe(false);
+  });
+
+  it('CONTROL: the walk actually reaches the server tree', () => {
+    // Guards against a bad REPO_ROOT silently yielding an empty scan, which
+    // would make every assertion below pass for the wrong reason.
+    expect(files.length).toBeGreaterThan(800);
+    expect(holders.length).toBeGreaterThan(0);
+  });
+
+  // ---------------------------------------------------------------------
+  // The ledger itself.
+  // ---------------------------------------------------------------------
+  it('matches the recorded set exactly — no additions, no silent removals', () => {
+    expect(holders).toEqual(Object.keys(LEDGER).sort());
+  });
+
+  it('rate-limit key sites derive the client IP through the shared predicate', () => {
+    for (const rel of MUST_NOT_HOLD_EDGE) {
+      const source = fs.readFileSync(path.join(SERVER_ROOT, rel), 'utf8');
+      expect(REQUEST_IP_EDGE.test(source), `${rel} must not derive a client IP itself`).toBe(false);
+      expect(
+        CLIENT_IP_EDGE.test(source),
+        `${rel} must hold a real import edge on the shared client-IP predicate — a comment naming the path does not count`
+      ).toBe(true);
+    }
+  });
+});

--- a/src/server/utils/__tests__/client-ip.test.ts
+++ b/src/server/utils/__tests__/client-ip.test.ts
@@ -1,0 +1,242 @@
+import { describe, it, expect } from 'vitest';
+import type { NextApiRequest } from 'next';
+import requestIp from 'request-ip';
+
+/**
+ * Unit coverage for the shared client-IP predicate.
+ *
+ * Deliberately imported with NO `vi.mock` of anything: the point of extracting
+ * this out of `public-api-rate-limit.ts` was that keying a bucket must not drag
+ * a redis client into the importer's graph. If this module ever grows a stateful
+ * dependency, this file stops collecting and that is the signal.
+ */
+
+import { resolveClientIp } from '../client-ip';
+
+const SOCKET_PEER = '10.42.0.9';
+
+/**
+ * The longest textual IP address: the fully-expanded IPv4-mapped IPv6 form,
+ * `0000:0000:0000:0000:0000:ffff:255.255.255.255`. Written as a literal here
+ * rather than imported from the module under test — an expectation derived from
+ * the implementation it checks moves with any mutation of it.
+ */
+const MAX_TEXTUAL_ADDRESS_LENGTH = 45;
+
+function reqWith(headers: Record<string, string | string[]>): NextApiRequest {
+  return { headers, socket: { remoteAddress: SOCKET_PEER } } as unknown as NextApiRequest;
+}
+
+describe('resolveClientIp', () => {
+  it('prefers the edge-stamped CF-Connecting-IP over every other address header', () => {
+    const ip = resolveClientIp(
+      reqWith({
+        'cf-connecting-ip': '203.0.113.7',
+        'x-client-ip': '198.51.100.1',
+        'x-forwarded-for': '198.51.100.2',
+        'x-real-ip': '198.51.100.3',
+        'true-client-ip': '198.51.100.4',
+      })
+    );
+    expect(ip).toBe('203.0.113.7');
+  });
+
+  it('is unchanged when the non-edge address headers are rotated', () => {
+    const headersFor = (v: string) => ({
+      'cf-connecting-ip': '203.0.113.7',
+      'x-client-ip': v,
+      'x-forwarded-for': v,
+      'x-real-ip': v,
+    });
+    const a = resolveClientIp(reqWith(headersFor('198.51.100.1')));
+    const b = resolveClientIp(reqWith(headersFor('192.0.2.55')));
+    expect(a).toBe(b);
+    expect(a).toBe('203.0.113.7');
+  });
+
+  it('POSITIVE CONTROL: a different CF-Connecting-IP does change the result', () => {
+    // Without this, the invariance assertion above would also be satisfied by a
+    // function that returned a constant.
+    expect(resolveClientIp(reqWith({ 'cf-connecting-ip': '203.0.113.7' }))).not.toBe(
+      resolveClientIp(reqWith({ 'cf-connecting-ip': '203.0.113.8' }))
+    );
+  });
+
+  it('takes the first element when cf-connecting-ip is an array + trims whitespace', () => {
+    expect(resolveClientIp(reqWith({ 'cf-connecting-ip': [' 203.0.113.9 ', '5.5.5.5'] }))).toBe(
+      '203.0.113.9'
+    );
+  });
+
+  it('ignores an empty / whitespace-only CF header and falls through', () => {
+    expect(
+      resolveClientIp(reqWith({ 'cf-connecting-ip': '   ', 'x-forwarded-for': '198.51.100.1' }))
+    ).toBe('198.51.100.1');
+  });
+
+  it('falls back to the library resolver for non-CF / local requests', () => {
+    expect(resolveClientIp(reqWith({ 'x-forwarded-for': '198.51.100.1' }))).toBe('198.51.100.1');
+    // Nothing usable in headers at all → the socket peer, never an empty string.
+    expect(resolveClientIp(reqWith({}))).toBe(SOCKET_PEER);
+  });
+
+  describe('the unresolvable-caller label', () => {
+    /**
+     * `'unknown'` is not decoration: it is the SHARED bucket every caller with
+     * no resolvable address lands in, so its value is load-bearing and a change
+     * to it silently repartitions that bucket. Pinned as a LITERAL rather than
+     * against a constant imported from the module — asserting a value against
+     * the implementation that produces it moves with any mutation of it and so
+     * proves nothing.
+     *
+     * MICRO-CHANGE, recorded because it was previously unasserted: under the old
+     * `ctx.ip` derivation the unresolvable label was `''` (createContext's
+     * `requestIp.getClientIp(req) ?? ''`); it is now `'unknown'`. Behaviourally
+     * equivalent — one fixed shared bucket either way, and neither is a valid
+     * address so neither can collide with a real client — but it IS a different
+     * string, so the field those callers write to moves once at deploy.
+     */
+    // No headers AND no socket peer, so `request-ip` has nothing to return.
+    const unresolvable = () => ({ headers: {}, socket: {} } as unknown as NextApiRequest);
+
+    it('is the literal "unknown" when nothing resolves', () => {
+      expect(resolveClientIp(unresolvable())).toBe('unknown');
+    });
+
+    it('POSITIVE CONTROL: the fixture really does defeat the library resolver', () => {
+      // Otherwise the assertion above could pass because the socket peer merely
+      // happened to be absent from THIS fixture for some unrelated reason.
+      expect(requestIp.getClientIp(unresolvable())).toBeNull();
+    });
+
+    it('is NOT the empty string the old ctx.ip derivation used', () => {
+      // Pins the direction of the micro-change above, so a "restore the old
+      // value" edit has to be deliberate rather than incidental.
+      expect(resolveClientIp(unresolvable())).not.toBe('');
+    });
+  });
+
+  describe('CF header validation', () => {
+    /**
+     * The CF branch is validated, so the returned value is bounded to the
+     * address grammar. This is what stops a caller-supplied string being used
+     * verbatim as a key — see the module doc. Each case asserts the FALLTHROUGH
+     * target too, not merely "not the malformed value", so a mutation that
+     * returned a constant or an empty string cannot satisfy it.
+     */
+    const MALFORMED = [
+      ['a bare integer that is also a plausible user id', '42'],
+      ['an over-long octet', '999.1.1.1'],
+      ['too many octets', '1.2.3.4.5'],
+      ['an arbitrary token', 'notanip'],
+      ['a redis-field-shaped string', 'user:42'],
+    ] as const;
+
+    it.each(MALFORMED)('ignores %s in cf-connecting-ip and falls through', (_label, value) => {
+      expect(
+        resolveClientIp(reqWith({ 'cf-connecting-ip': value, 'x-forwarded-for': '198.51.100.1' })),
+        `a malformed cf-connecting-ip (${JSON.stringify(value)}) must not be returned verbatim`
+      ).toBe('198.51.100.1');
+    });
+
+    /**
+     * A COMPETING non-edge header is mandatory in the fixtures below, and the
+     * reason is worth stating: `request-ip` ALSO consults `cf-connecting-ip`
+     * (gated by its own `is.ip()`), and it does so AFTER `x-client-ip`. So a
+     * fixture carrying ONLY `cf-connecting-ip` cannot tell "the CF branch
+     * accepted this address" from "the CF branch rejected it and the fallback
+     * happened to recover the same value" — the two paths return an identical
+     * string and the assertion passes either way.
+     *
+     * Measured, not assumed: a mutant narrowing the validator to IPv4
+     * (`isIP(x) === 4`) SURVIVED the single-header version of these tests, and
+     * dies against the version below. `RESCUER` is chosen so the fallback's
+     * answer is visibly different from the CF branch's.
+     */
+    const RESCUER = '198.51.100.77';
+    const withRescuer = (cf: string) => reqWith({ 'cf-connecting-ip': cf, 'x-client-ip': RESCUER });
+
+    it.each(['2400:cb00:2049:1::a29f:1804', '2001:db8::1', '::ffff:1.2.3.4'])(
+      'accepts the IPv6 address %s on the CF branch itself',
+      (v) => {
+        // Load-bearing: if the validator rejected IPv6, every IPv6 client in
+        // production would silently drop to the fallback branch. That is a live
+        // traffic class, not an edge case.
+        expect(
+          resolveClientIp(withRescuer(v)),
+          `IPv6 must be accepted by the CF branch — falling through would have yielded ${RESCUER}`
+        ).toBe(v);
+      }
+    );
+
+    it('still returns a well-formed IPv4 CF header unchanged', () => {
+      // Negative control for the validation: it must reject malformed input
+      // WITHOUT also rejecting the ordinary production case.
+      expect(resolveClientIp(withRescuer('203.0.113.7'))).toBe('203.0.113.7');
+    });
+
+    /**
+     * ZONE IDENTIFIERS — the bound the two branches must agree on.
+     *
+     * `net.isIP` accepts a zone-scoped IPv6 address (`fe80::1%eth0`) and places
+     * no bound on the zone part's length or contents, so `isIP` ALONE does not
+     * bound this function's return value. `request-ip`'s `is.ip()` rejects the
+     * same values, so a validator resting on `isIP` alone lets the two branches
+     * of this function disagree about what counts as an address — and the value
+     * a caller can put through the accepting branch is then arbitrary in both
+     * length and content, which the callers keying on it rely on it not being.
+     *
+     * Measured across both families, the zone suffix is the ENTIRE disagreement
+     * between the two validators: every value they score differently contains a
+     * `%`. These cases pin that, in content and in length, with a control below
+     * proving the rejection is the zone suffix and not IPv6 link-local as such.
+     */
+    describe('zone-scoped addresses are not a bound', () => {
+      it('rejects a zone-scoped IPv6 address and falls through', () => {
+        expect(
+          resolveClientIp(withRescuer('fe80::1%eth0')),
+          'a zone-scoped address must not be returned verbatim'
+        ).toBe(RESCUER);
+      });
+
+      it('rejects an unbounded zone id rather than passing it into the key space', () => {
+        const overlong = `fe80::1%${'a'.repeat(4096)}`;
+        const got = resolveClientIp(withRescuer(overlong));
+        expect(got, 'an arbitrarily long zone id must not be returned verbatim').toBe(RESCUER);
+        // Asserted independently of the fallthrough target: whatever this
+        // function returns is bounded to the address grammar's own maximum, so
+        // no caller-supplied length reaches a key.
+        expect(got.length).toBeLessThanOrEqual(MAX_TEXTUAL_ADDRESS_LENGTH);
+      });
+
+      it('NEGATIVE CONTROL: the same address WITHOUT a zone is still accepted', () => {
+        // Without this, a validator that simply rejected IPv6 link-local — or
+        // rejected more than it should — would satisfy the two cases above.
+        expect(
+          resolveClientIp(withRescuer('fe80::1')),
+          'rejecting the zone suffix must not also reject the bare address'
+        ).toBe('fe80::1');
+      });
+
+      it('NEGATIVE CONTROL: the longest legal address is accepted at the bound', () => {
+        // The length bound must sit at the grammar's maximum, not below it: a
+        // bound that clipped a legal address would silently drop those clients
+        // to the fallback branch.
+        const longest = '0000:0000:0000:0000:0000:ffff:255.255.255.255';
+        expect(longest.length).toBe(MAX_TEXTUAL_ADDRESS_LENGTH);
+        expect(resolveClientIp(withRescuer(longest))).toBe(longest);
+      });
+
+      it('POSITIVE CONTROL: the fallback resolver rejects these too, so the branches agree', () => {
+        // The claim this file makes is agreement between the two branches, so
+        // the fallback's own verdict is asserted rather than assumed. If
+        // `request-ip` ever started accepting zone ids this control goes red and
+        // the agreement claim above has to be re-derived.
+        expect(requestIp.getClientIp(reqWith({ 'cf-connecting-ip': 'fe80::1%eth0' }))).not.toBe(
+          'fe80::1%eth0'
+        );
+        expect(requestIp.getClientIp(reqWith({ 'cf-connecting-ip': 'fe80::1' }))).toBe('fe80::1');
+      });
+    });
+  });
+});

--- a/src/server/utils/client-ip.ts
+++ b/src/server/utils/client-ip.ts
@@ -1,0 +1,105 @@
+import { isIP } from 'net';
+import type { NextApiRequest } from 'next';
+import requestIp from 'request-ip';
+
+/**
+ * THE single client-IP predicate for anything that keys a per-client control
+ * (rate-limit buckets, per-IP quotas) on the caller's address.
+ *
+ * PREFER Cloudflare's `CF-Connecting-IP` (Next lowercases header keys →
+ * `cf-connecting-ip`). CF stamps it at the edge on every proxied request, so for
+ * traffic that transits Cloudflare — which is all of production — it is the one
+ * address in the request the origin did not take on the caller's word. Fall back
+ * to `requestIp.getClientIp` (XFF chain → socket peer) for non-CF / local
+ * requests that never traversed the edge, so dev and direct-to-origin traffic
+ * still bucket sensibly.
+ *
+ * WHY A SHARED PREDICATE: a bucket key is only as good as the value it is
+ * derived from, and a per-call-site derivation drifts — each new limiter picks
+ * whichever header its author reached for first, and the resulting disagreement
+ * is invisible until someone audits all of them at once. Keeping ONE exported
+ * function means the choice is made in one reviewable place and every keyed
+ * control inherits it. If you are adding a limiter, call this rather than
+ * reading headers yourself; `src/server/utils/__tests__/client-ip-ledger.test.ts`
+ * pins the (small) set of modules allowed a direct `request-ip` dependency and
+ * will fail if a new one appears.
+ *
+ * NOT THE ONLY PREDICATE — CHOOSE PER SURFACE. A stricter, fail-closed variant
+ * lives with the token-minting endpoint in `src/pages/api/v1/block-tokens/`.
+ * The two differ deliberately in what they are willing to trust and in what they
+ * hand back, because a credential-minting endpoint and a generic rate limiter do
+ * not want the same trade — strictness is not free in either direction. Pick the
+ * one that matches the surface you are on; do not reach for either by default,
+ * and do not collapse them into one without re-deciding the trade for both.
+ *
+ * WHAT THE RETURN VALUE IS: a BARE, well-formed IPv4/IPv6 address, or the
+ * literal `'unknown'` when the request carries no resolvable address at all.
+ * Both branches validate against the same grammar — see `isBareAddress` — so the
+ * value is bounded in length and in content. That is load-bearing wherever this
+ * is used as a key: an unbounded key space is unbounded storage, and a caller
+ * able to vary the key at will can rotate away from its own bucket. Callers must
+ * still NAMESPACE their keys — see `middleware.trpc.ts` — because a key space
+ * shared between two namespaces is only disjoint by luck.
+ *
+ * Note `'unknown'` is a SHARED bucket for every caller that lands on it, so it
+ * is deliberately a single fixed label rather than something per-request: an
+ * unresolvable caller must not be able to mint itself a fresh empty quota.
+ */
+
+/**
+ * The longest textual IP address: the fully-expanded IPv4-mapped IPv6 form,
+ * `0000:0000:0000:0000:0000:ffff:255.255.255.255`.
+ */
+const MAX_TEXTUAL_ADDRESS_LENGTH = 45;
+
+/**
+ * A BARE address — a well-formed IPv4/IPv6 address with no IPv6 zone identifier,
+ * no longer than the grammar permits.
+ *
+ * `net.isIP` on its own is NOT this check, and the difference matters. It accepts
+ * a zone-scoped address (`fe80::1%eth0`) and bounds neither the zone part's
+ * length nor its contents, while the `request-ip` fallback's own `is.ip()`
+ * rejects exactly those values — so a validator resting on `isIP` alone lets the
+ * two branches of `resolveClientIp` disagree about what counts as an address,
+ * and lets an arbitrary-length caller-supplied suffix through the accepting one.
+ *
+ * Measured across both families, the zone suffix is the ENTIRE disagreement
+ * between the two validators: every value they score differently contains a `%`.
+ * Excluding it is therefore what makes the two branches agree.
+ *
+ * ON THE LENGTH BOUND — it is DEFENCE IN DEPTH, not the working check, and the
+ * distinction is recorded so nobody mistakes it for load-bearing. Once `%` is
+ * excluded, `isIP` cannot accept anything longer than the grammar's own maximum
+ * anyway: probing ~1.4M `%`-free strings of length 46-80, plus every maximal
+ * canonical form, produced ZERO acceptances above 45. So deleting this line is a
+ * provably EQUIVALENT mutation — no input can distinguish it, and the mutation
+ * battery reports it as a survivor for that reason rather than for want of a
+ * test. It is kept as a bound that still holds if `isIP`'s accepted grammar ever
+ * widens. Its VALUE is pinned: tightening it below 45 fails the longest-legal-
+ * address control in `src/server/utils/__tests__/client-ip.test.ts`.
+ *
+ * That file also pins the zone rejection in content and in length, with controls
+ * proving the bare address is still accepted.
+ */
+function isBareAddress(value: string): boolean {
+  if (value.length > MAX_TEXTUAL_ADDRESS_LENGTH) return false;
+  if (value.includes('%')) return false;
+  return isIP(value) !== 0;
+}
+
+export function resolveClientIp(req: NextApiRequest): string {
+  // `req.headers` is optional-chained rather than assumed. This is reached from
+  // middleware with no try/catch, and at least one call path supplies `req`
+  // through an `as any` (`server-side-helpers.ts`), so the type is not the
+  // guarantee it looks like. `requestIp.getClientIp` already guards its own
+  // access the same way.
+  const cfip = req.headers?.['cf-connecting-ip'];
+  const cf = Array.isArray(cfip) ? cfip[0] : cfip;
+  const candidate = cf?.trim();
+  // Validate rather than pass through: an unvalidated edge header is a
+  // caller-controlled string, and every consumer of this uses the result as a
+  // key. A header that does not validate falls through to the fallback, which
+  // yields a real address rather than the value that was presented.
+  if (candidate && isBareAddress(candidate)) return candidate;
+  return requestIp.getClientIp(req) ?? 'unknown';
+}

--- a/src/server/utils/public-api-rate-limit.ts
+++ b/src/server/utils/public-api-rate-limit.ts
@@ -1,10 +1,17 @@
 import type { NextApiRequest } from 'next';
-import requestIp from 'request-ip';
 // From the package rather than the `~/server/redis/client` shim on purpose: it is a pure helper
 // with no client state, and importing it through the shim would force every suite that mocks the
 // shim to add it to its mock factory.
 import { prefixCacheKey } from '@civitai/redis';
 import { redis } from '~/server/redis/client';
+import { resolveClientIp } from '~/server/utils/client-ip';
+
+// Re-exported so existing importers (and this module's own test file) keep their
+// import path. `resolveClientIp` now lives in `~/server/utils/client-ip` so the
+// generic tRPC rate-limit middleware can share the SAME implementation without
+// importing this module's redis-bound public-REST limiter. One function, two
+// consumers — see the module doc in client-ip.ts for why that matters.
+export { resolveClientIp };
 
 /**
  * Conservative per-client fixed-window rate limit for the PUBLIC REST endpoints
@@ -57,26 +64,6 @@ export type PublicApiRateLimitResult =
   | { allowed: true }
   | { allowed: false; retryAfterSeconds: number };
 
-/**
- * Resolve the rate-limit client IP.
- *
- * PREFER Cloudflare's `CF-Connecting-IP` (Next lowercases header keys →
- * `cf-connecting-ip`): CF sets it to the real client IP and — unlike the raw
- * `X-Forwarded-For` chain — a caller CANNOT spoof it through Cloudflare, so it
- * can't be rotated to escape the per-IP bucket. Fall back to
- * `requestIp.getClientIp` (which reads XFF/socket) only for non-CF / local
- * requests that never traversed Cloudflare. Same header the bot-detection
- * middleware and region-blocking trust.
- *
- * Exported for unit testing.
- */
-export function resolveClientIp(req: NextApiRequest): string {
-  const cfip = req.headers['cf-connecting-ip'];
-  const cf = Array.isArray(cfip) ? cfip[0] : cfip;
-  if (cf && cf.trim()) return cf.trim();
-  return requestIp.getClientIp(req) ?? 'unknown';
-}
-
 async function checkFixedWindow(
   key: string,
   max: number,
@@ -109,8 +96,11 @@ async function checkFixedWindow(
  * Records one request against the caller's per-family window and reports whether
  * it is within the conservative ceiling.
  *
- * @param req    the incoming request (client IP is resolved from it for the
- *   unauthenticated bucket via the same `request-ip` resolver createContext uses).
+ * @param req    the incoming request. The unauthenticated bucket keys on the
+ *   client IP resolved from it by the shared `~/server/utils/client-ip`
+ *   predicate — which prefers the edge-stamped header and keeps `request-ip`
+ *   only as the non-edge fallback, so it is NOT the same derivation
+ *   `createContext` uses for `ctx.ip`.
  * @param family `articles` | `collections` — independent bucket per family.
  * @param userId the authenticated user id when present; keys the (higher) authed
  *   bucket. `undefined` → the per-IP unauthenticated bucket.


### PR DESCRIPTION
## What this changes

Two rate limiters key their anonymous bucket on the caller's address:

- the generic tRPC `rateLimit()` middleware (`src/server/middleware.trpc.ts`) — 34 usages across 13 routers at `origin/main`
- the public REST articles/collections limiter (`src/server/utils/public-api-rate-limit.ts`)

They derived that address two different ways. This consolidates them onto one exported predicate, and hardens both the predicate and the key it feeds.

- **New** `src/server/utils/client-ip.ts` — `resolveClientIp`, lifted out of `public-api-rate-limit.ts`. Prefers the edge-stamped `CF-Connecting-IP`; keeps the `request-ip` fallback for non-CF / local traffic.
- `public-api-rate-limit.ts` imports and re-exports it, so existing importers keep their path.
- `middleware.trpc.ts` uses it for the anonymous bucket field, in place of the general-purpose `ctx.ip`, and **namespaces the field by principal kind**.

## The bucket field is namespaced

The limiter writes both principal kinds into one Redis hash — an authenticated caller's user id, and an anonymous caller's address — and in a hash, equal strings are one bucket. Written bare, the two share a single key space.

```ts
const hashKey = ctx.user?.id != null ? `user:${ctx.user.id}` : `ip:${resolveClientIp(ctx.req)}`;
```

The prefix makes the two key spaces disjoint by construction rather than by whichever values happen not to overlap. This is the shape `public-api-rate-limit.ts` already used; the consolidation adopted its resolver, and this brings over the namespacing that goes with it.

`!= null` rather than a truthiness test, so the nullish semantics of the `??` it replaces are preserved — a user id of `0` must not fall through to the address branch. Pinned by a test.

## The CF branch is validated, and the value is bounded

⚠️ **This is a behaviour change, and it reaches the public REST limiter too** — both callers share the function, so it is not confined to the tRPC path.

The `request-ip` fallback validates every header it consults; the CF branch did not, so the function could return its header verbatim. It is now validated, and a header that does not validate falls through to the fallback — which yields a real address rather than the presented value.

**`net.isIP` alone is not enough for that, and this is the substantive correction in the latest round.** `isIP` accepts an IPv6 **zone identifier** and bounds neither its length nor its contents (`isIP('fe80::1%eth0')` → `6`; a 4,096-byte zone id is returned verbatim). `request-ip`'s own `is.ip()` rejects those, so an `isIP`-only check leaves the two branches of the function disagreeing about what counts as an address — and leaves the returned value unbounded in both length and content, which is exactly what the callers keying on it rely on it not being.

Measured across both address families, the zone suffix is the **entire** disagreement between the two validators: every value they score differently contains a `%`. So the predicate excludes it explicitly, and keeps a length bound alongside as defence in depth.

Worth being explicit that this was a **regression this PR would otherwise have introduced**: on `main` the anonymous tRPC bucket keyed on `requestIp.getClientIp`, whose `is.ip` rejects zone ids, so `packed:trpc:limit:*` could not previously receive such a field. (For `public-api-rate-limit.ts` the PR is still an improvement over `main`, which accepted any non-blank string.) An earlier round of this branch had `isIP` alone, together with two comments asserting a bound it did not deliver; the comments and the code have both been fixed, and the mutant that removes the exclusion is now killed rather than surviving.

## Why this seam, and not the shared context value

The context-level value is the deeper seam — one edit there would reach every consumer at once. I deliberately did not take it:

- **The rate-limit key is the only consumer where the value *is* the control.** The rest are attribution and telemetry: a wrong-but-plausible value degrades them, it doesn't gate anything.
- **They don't share fallback semantics.** The context value yields `''` when nothing resolves; `resolveClientIp` yields `'unknown'`, which flips a falsy value to truthy at every `if (ip)` site. Sweeping that into a rate-limit change would alter behaviour at call sites this PR has no business touching.

So: fix the enforcement seam, blast radius two call sites; leave the attribution seams to be reasoned about per consumer. The shared context value is untouched and every existing consumer keeps its current value.

## Two predicates, chosen per surface

`src/pages/api/v1/block-tokens/` has a stricter, fail-closed variant. I did not adopt it here, and the two are deliberately not merged: they differ in what they are willing to trust and in what they return, because a credential-minting endpoint and a generic rate limiter do not want the same trade. Adopting the stricter one here would also change the public REST limiter as a side effect, since they share the function.

Strictness is not free in either direction, so the choice is documented in `client-ip.ts` and made per surface rather than by defaulting to either.

## 🔴 Operational note — one-time counter reset on deploy

**Changing the key changes every live Redis bucket field.** The limiter stores attempts as hash fields under `REDIS_KEYS.TRPC.LIMIT.BASE` (`packed:trpc:limit:*`). Both anonymous *and* authenticated callers are addressed by a new field once this deploys, so in-flight counters reset one time.

This stays bounded: the hash **name** is unchanged, and every field is written through `hSetWithTTL` with a per-field `HPEXPIRE` of one day, so fields under the old shape age out on their own rather than accumulating. Nothing is stranded and no cleanup is required.

One-time and self-correcting within a single window — not a regression — but it does mean limits are briefly relaxed across the deploy. Worth knowing if you watch abuse dashboards.

## Guards

**1. Behavioural** — `src/server/__tests__/middleware.trpc.rate-limit-key.test.ts`

Drives the real `rateLimit()` middleware and reads the hash field it *actually addressed in Redis* rather than re-deriving it, so it holds for any implementation that ends up keying the bucket correctly. Pins:

- same edge-stamped IP → **same** bucket, with every non-edge address header rotated together *and* each one rotated on its own
- different edge-stamped IP → **different** bucket (positive control)
- the address side and the id side occupy **disjoint key spaces**, with a positive control proving the harness can observe two fields colliding, and a third case proving the separation wasn't bought by collapsing anonymous callers onto a constant
- a user id of `0` keys the user bucket, pinning `!= null` against a truthiness mutant

The non-edge header set is now enumerated from `request-ip`'s own source (`getClientIp`) rather than its README — the README lists fewer headers than the code reads, so the previous list was 5 of the 11 consulted. Each member is *also* asserted to genuinely drive the bucket when the edge header is absent, so the list is self-verifying and cannot drift into claiming coverage it does not have.

`~/env/other` is mocked production-like because the middleware short-circuits on `isTest`; without that mock the body under test never runs and every assertion would be vacuous.

**2. Structural ledger** — `src/server/utils/__tests__/client-ip-ledger.test.ts`

Pins the exact set of `src/server` modules holding a direct `request-ip` dependency edge, failing when the set **grows or shrinks**. Ships with a negative control (the detector must reject prose and a near-miss package name) and a positive control (the walk must reach >800 files and find a non-empty set), so a mis-rooted scan can't pass by finding nothing.

Its second assertion — that the rate-limit sites reach the shared predicate — matches a real **import edge** rather than the module path as a substring. Both modules it checks carry comments naming that path, so the substring form was satisfied by prose.

Note the ledger reads code, not prose, so it is structurally unable to catch a false claim in a comment — the stale docstring in `public-api-rate-limit.ts` passed it while being wrong, and was fixed by reading rather than by the gate.

**3.** `client-ip.test.ts` covers the extracted module directly with no mocks at all — which also pins that keying a bucket no longer drags a Redis client into the importer's graph. Includes the zone-identifier cases, a control that the same address *without* a zone is still accepted, a control that the longest legal address (45 chars) is accepted at the bound, and the `'unknown'` fallback label pinned as a literal rather than against the constant that produces it.

## Verification

### Zone-identifier fix — red before, green after

Both new cases were watched failing against this branch's own code before the fix, with the surrounding controls green in the same run (so the red was a real observation, not a broken harness):

| case | before the fix | after |
|---|---|---|
| a zone-scoped address must not be returned verbatim | **FAILED** | passed |
| an unbounded zone id must not be returned verbatim | **FAILED** | passed |
| control: the same address without a zone is still accepted | passed | passed |
| control: the longest legal address is accepted at the bound | passed | passed |
| control: the fallback resolver rejects zone ids too | passed | passed |

### Mutation sweep

18 mutants + 1 harness control, run against the **final** tree after the fix round (not only the mutants for what changed). **18 killed, 1 provably-equivalent survivor, 0 that failed to apply.** Each mutant was applied to a verified-clean tree and reverted after; the tree is re-verified clean before and after every one, and a patch that does not apply — or applies ambiguously — is reported as an error rather than a survivor.

| # | mutant | result |
|---|---|---|
| **M0** | *unmutated tree* (negative control) | — **62/62 green**, as required |
| M1 | revert the fix — key the anon bucket on `ctx.ip` | killed (3) |
| M2 | swap branch order inside `resolveClientIp` | killed (12) |
| M3 | `resolveClientIp` returns a constant | killed (44, incl. both positive controls) |
| M4 | `cfip[0]` → `cfip[1]` | killed (1 — the array/trim case) |
| M5 | drop `.trim()` | killed (1) |
| M6 | `'unknown'` → `''` | killed (2 — the label pin, by literal) |
| M7 | delete the import *and* revert the call site, leaving the comment | killed (4, incl. the ledger's import-edge assertion) |
| M8 | strip both namespace prefixes | killed (25) |
| M9 | drop the CF validation | killed (7) |
| M10 | strip only the `user:` prefix | killed (3) |
| M11 | strip only the `ip:` prefix | killed (22, incl. the new per-header controls) |
| M12 | narrow the validator to IPv4 only | killed (5 — the IPv6 cases) |
| M13 | strip namespaces **and** drop validation | killed (33, incl. the key-space guard) |
| **M14** | **drop the `%` zone-id exclusion** | **killed (1)** — this is the mutant that **survived** before this round |
| M15 | drop the length bound | **survived — provably equivalent, see below** |
| **M16** | `!= null` → truthiness | **killed (1)** — the id-`0` case |
| M17 | `isBareAddress` always true | killed (7) |
| M18 | tighten the length bound below the grammar maximum (45 → 20) | killed (2) |
| **H1** | *harness control*: add a bogus member to the header list | **killed (1)** — the enumeration control is not vacuous |

Every kill was checked to carry **its own** guard's assertion message, not merely to coincide with a red suite. M14 dies to `a zone-scoped address must not be returned verbatim`; M16 to `id 0 is a valid principal; a truthiness test would route it to the address branch`; M13 to `a field written from the address side must not equal a field written from the id side`; H1 to `x-not-a-real-header is listed as a consulted address header but did not move the bucket off the socket peer`.

**On M15.** Removing the length bound is a **provably equivalent mutation**, not a coverage gap: once `%` is excluded, `isIP` cannot accept anything longer than the grammar's own maximum. Probed ~1.4M `%`-free strings of length 46–80 plus every maximal canonical form — **zero** acceptances above 45 characters. No input can distinguish the two versions, so no test can kill it. The bound is kept as defence in depth against a future widening of `isIP`'s accepted grammar, and its *value* is pinned: M18 (tightening it) is killed. This is stated in the module comment so nobody later mistakes it for load-bearing.

### Suites and typecheck

Measured on the **merged tree**. The branch is rebased onto current `main` (`ebe9aa27`), so `HEAD` already contains `main` and the branch tree *is* the merge result — no separate integration branch is needed. Counts parsed from run summaries with ANSI stripped, never from exit codes; no timeout panics.

- **Touched suites** (4 files): **62 passed, 0 failed.** 41 before this round; the +21 are the 10 per-header enumeration controls, 5 additional per-header rotation cases, 5 zone/bound cases, and the id-`0` case.
- **`src/server` sweep**, base vs head in the same environment: failing set **byte-identical** (114 lines each, zero attributable additions), passing **7485 → 7541, exactly +56** — the tests this PR adds relative to `main`.
- **`node scripts/typecheck.mjs`** (never bare `tsc`): 34 errors at head — and **the identical 34 at `origin/main`** in the same environment, error sets byte-identical, **0 in any file this PR touches**. These are a sandbox artifact (`Cannot find module` for `kysely` / `event-engine-common`: a symlinked `node_modules` and an unpopulated submodule), *not* a stale-base effect — they do not clear by rebasing. CI is the authority on the absolute number.
- **Prettier**: all 6 touched files clean. One pre-existing violation in `middleware.trpc.ts` — present at this branch's previous head — is fixed here.
- **ESLint** on the touched files: 4 `no-explicit-any` errors in `middleware.trpc.ts`, **the same 4 at `origin/main`**. Pre-existing, none in the changed region.

### Interaction with #3659

`git merge-tree --write-tree` against #3659's head (`f1044a1446`), branching on the **exit code**: exit **1**, one conflict — the `add/add` on `src/server/utils/client-ip.ts`. Identical to the same check against this branch's previous head, so **the conflict set has not widened**. #3659's `getTrustedClientIp` shares the underlying zone-id issue; that is being handled in its own round, and no file belonging to it was touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
