### PR TITLE
test(apps): hold the copied state still instead of racing its 1s reset

### DIFF
--- a/src/components/Apps/CliSubmitCta.browser.test.tsx
+++ b/src/components/Apps/CliSubmitCta.browser.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, test } from 'vitest';
+import { afterEach, describe, expect, test, vi } from 'vitest';
 import { page, userEvent } from 'vitest/browser';
 import { CliSubmitCta } from '~/components/Apps/CliSubmitCta';
 import {
@@ -18,6 +18,106 @@ import { renderWithProviders } from '../../../test/component-setup';
 //
 // NOTE: this env does not load `@mantine/core/styles.css`, so we assert
 // presence / hrefs / accessible names — never computed styles.
+
+/**
+ * Captured BEFORE any `vi.useFakeTimers()` call so the helpers below can still
+ * yield a REAL macrotask while virtual time stands still — `setTimeout` is faked
+ * inside the copy tests, so the obvious `new Promise((r) => setTimeout(r, 0))`
+ * would never resolve.
+ */
+const realSetTimeout = globalThis.setTimeout.bind(globalThis);
+
+/**
+ * 🔴 The virtual clock must never escape a test. A `finally` inside the test body
+ * does NOT run when a test TIMES OUT (the awaited promise never settles) — and a
+ * timer test is exactly where that happens — which would leave every subsequent
+ * test in this file on a frozen clock. Same hook, same reason as
+ * `src/components/Apps/AppListingsMarketplaceBody.browser.test.tsx` (civitai#3654)
+ * and `src/components/AppBlocks/PageBlockHostAutoRetry.browser.test.tsx`.
+ *
+ * Vitest runs `afterEach` hooks in reverse registration order, so this runs
+ * BEFORE the setup file's `await cleanup()` — the unmount never sees a frozen
+ * clock either.
+ */
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+/**
+ * Install the virtual clock, restricted to the timer functions.
+ *
+ * `Date`, `performance`, `requestAnimationFrame`, `queueMicrotask` and
+ * `MessageChannel` stay REAL, so React's scheduler, Mantine and the Playwright
+ * driver behave exactly as they do under real timers — the copy tests drive the
+ * button through the real driver (`.click()` / `userEvent.keyboard`) while the
+ * clock is frozen. The only thing that becomes virtual is how long a
+ * `setTimeout` takes to fire, which is precisely the copied-state reset below.
+ *
+ * `Date` staying real is load-bearing for `settleCopy()`, which budgets in REAL
+ * time.
+ */
+function useVirtualClock() {
+  vi.useFakeTimers({
+    toFake: ['setTimeout', 'clearTimeout', 'setInterval', 'clearInterval'],
+  });
+}
+
+/**
+ * Move virtual time forward by exactly `ms`, then let React commit whatever the
+ * fired timers scheduled. `advance(0)` is therefore also the "flush pending
+ * renders + effects" primitive: it fires nothing, it only drains the queues.
+ *
+ * The real-macrotask yield is load-bearing — advancing virtual time alone gives
+ * the page only microtasks, so a passive effect scheduled on React's
+ * MessageChannel would not have run by the time the next assertion reads the DOM.
+ */
+async function advance(ms: number) {
+  await vi.advanceTimersByTimeAsync(ms);
+  for (let i = 0; i < 5; i++) {
+    await vi.advanceTimersByTimeAsync(0);
+    await new Promise((resolve) => realSetTimeout(resolve, 0));
+  }
+}
+
+/**
+ * Mantine's `CopyButton` resets `copied` back to `false` after this many ms —
+ * `defaultProps = { timeout: 1e3 }` in
+ * `@mantine/core/esm/components/CopyButton/CopyButton.mjs`, armed by
+ * `useClipboard`'s `window.setTimeout(() => setCopied(false), timeout)`.
+ * `CliSubmitCta` does not override it.
+ *
+ * If a Mantine upgrade moves this default, the boundary assertions below go red
+ * and the number gets updated as a deliberate, reviewed edit — which is the
+ * point of pinning it rather than sleeping past it.
+ */
+const COPIED_RESET_MS = 1000;
+
+/** How many "Copied" labels are on screen, read SYNCHRONOUSLY (no retry loop). */
+function copiedLabels() {
+  return page.getByText('Copied').elements().length;
+}
+
+/**
+ * Give the copy a bounded budget of REAL time to land, then return.
+ *
+ * The copy itself is genuinely async (`navigator.clipboard.writeText(...).then(...)`,
+ * stubbed to a resolving `vi.fn()` in `test/component-setup.tsx`), so *something*
+ * has to wait for it. Waiting is safe here precisely because the clock is frozen:
+ * once "Copied" appears it STAYS, so this is the legitimate "wait for a stable
+ * end-state" pattern, not a race. The budget matches the setup file's
+ * `DEFAULT_WAITFOR_TIMEOUT_MS`.
+ *
+ * It deliberately does NOT throw — the CALLER asserts, so a component that stops
+ * copying goes red at the test's own `expect`, naming the real guard.
+ */
+async function settleCopy() {
+  const deadline = Date.now() + 10_000; // `Date` is not faked — this is real time.
+  do {
+    await advance(0);
+    if (copiedLabels() > 0) return;
+    await new Promise((resolve) => realSetTimeout(resolve, 10));
+  } while (Date.now() < deadline);
+}
 
 describe('CliSubmitCta (CLI-first submit primary CTA)', () => {
   test('promotes the Civitai CLI as the recommended path', async () => {
@@ -94,14 +194,63 @@ describe('CliSubmitCta (CLI-first submit primary CTA)', () => {
   // it reaches the React root). These tests assert the real user-facing
   // guarantee — the button is focusable and copy fires on mouse + keyboard — and
   // document that the fix is canonical-pattern hardening, not a behavior change.
+  /**
+   * 🔴 THE CLOCK IS VIRTUAL, THE BEHAVIOUR IS NOT.
+   *
+   * Both copy tests used to assert `await expect.element(page.getByText('Copied'))`
+   * on the REAL clock. "Copied" is not a settled end-state — it is TRANSIENT.
+   * Mantine's `useClipboard` arms `setTimeout(() => setCopied(false), 1000)` the
+   * moment the clipboard promise resolves, so the label exists for a ~1s window of
+   * WALL-CLOCK time that starts closing before the assertion has read anything.
+   * A retrying assertion cannot recover from missing it: it polls for PRESENCE, so
+   * once the label is gone it just keeps polling an absent element until it times
+   * out. Machine load, not a regression, then decides the verdict — which is
+   * exactly how the keyboard case went red on civitai#3653's preview run after
+   * passing 1280/1280 ten minutes earlier.
+   *
+   * MEASURED here on an idle box, instrumented, three consecutive runs: the label
+   * appeared 0.0–0.1ms after the interaction resolved and was visible for
+   * 976.7 / 995.6 / 999.4 / 1000.5 / 999.8 / 1001.2 ms. So the failure mode is NOT
+   * clipboard permission (`test/component-setup.tsx` stubs `writeText` to a
+   * resolving `vi.fn()`; probed `'clipboard' in navigator === true`,
+   * `document.hasFocus() === true`) and NOT focus settling (`el.focus()` measured
+   * 0.7ms and `document.activeElement === el` held every time). It is a real
+   * timer in the component's dependency, raced by the assertion.
+   *
+   * Freezing `setTimeout` removes the dependency outright: the reset timer is
+   * armed but virtual time never moves, so the label persists however slow the
+   * runner is. Nothing about the component changes — the same `CopyButton` arms
+   * the same `setTimeout`; only the reset's arrival is now under the test's
+   * control, which lets the window be asserted explicitly instead of raced.
+   */
   test('clicking the copy button copies — shows "Copied"', async () => {
     renderWithProviders(<CliSubmitCta />);
     const button = page.getByRole('button', { name: `Copy command: ${CLI_INSTALL_BREW}` });
     await expect.element(button).toBeInTheDocument();
+
+    // Freeze BEFORE the interaction: the reset timer is armed by the copy itself,
+    // and `vi.useFakeTimers()` does not retroactively capture an already-scheduled
+    // real timer, so installing it afterwards would be too late.
+    useVirtualClock();
+
     await button.click();
-    // CopyButton flips its render-prop `copied` → the Code block text becomes
-    // "Copied" iff the activation triggered the `copy()` callback.
-    await expect.element(page.getByText('Copied')).toBeInTheDocument();
+    await settleCopy();
+
+    // (1) THE GUARD. CopyButton flips its render-prop `copied` → the Code block
+    // text becomes "Copied" iff the activation triggered the `copy()` callback.
+    // This is the assertion that fails if the button stops copying.
+    expect(copiedLabels()).toBe(1);
+
+    // (2) 1ms before the reset window closes, still copied — pins that the label
+    // is the live copied STATE and not something that merely rendered once.
+    await advance(COPIED_RESET_MS - 1);
+    expect(copiedLabels()).toBe(1);
+
+    // (3) Crossing the window resets it and the command comes back. Without this
+    // half, (1) and (2) would also be satisfied by a copied state that never ends.
+    await advance(1);
+    expect(copiedLabels()).toBe(0);
+    expect(page.getByText(`$ ${CLI_INSTALL_BREW}`).elements()).toHaveLength(1);
   });
 
   test('the copy button is focusable and keyboard-Enter copies — shows "Copied"', async () => {
@@ -111,7 +260,20 @@ describe('CliSubmitCta (CLI-first submit primary CTA)', () => {
     const el = button.element() as HTMLElement;
     el.focus();
     expect(document.activeElement).toBe(el); // genuinely keyboard-reachable
+
+    // Same reason as the mouse case above — freeze before the copy arms the reset.
+    useVirtualClock();
+
     await userEvent.keyboard('{Enter}');
-    await expect.element(page.getByText('Copied')).toBeInTheDocument();
+    await settleCopy();
+
+    expect(copiedLabels()).toBe(1);
+
+    await advance(COPIED_RESET_MS - 1);
+    expect(copiedLabels()).toBe(1);
+
+    await advance(1);
+    expect(copiedLabels()).toBe(0);
+    expect(page.getByText(`$ ${CLI_SUBMIT_COMMAND}`).elements()).toHaveLength(1);
   });
 });


### PR DESCRIPTION
Follow-up to #3654, same defect class: **an assertion whose truth depends on how fast the runner is.** This fixes the second known instance and reports a survey of the rest of the tier.

## What the `CliSubmitCta` race actually was

Neither clipboard permission nor focus. It is a **real timer in the component's dependency**.

`CliSubmitCta` renders each one-liner in a Mantine `CopyButton`. `useClipboard` arms `window.setTimeout(() => setCopied(false), timeout)` the instant the clipboard promise resolves, and `CopyButton`'s `defaultProps` are `{ timeout: 1e3 }` — which `CliSubmitCta` does not override. So `Copied` is not a settled end-state, it is **transient with a ~1s wall-clock lifetime**, and both tests asserted it with `await expect.element(page.getByText('Copied')).toBeInTheDocument()`.

A retrying assertion cannot recover from missing that window. It polls for *presence*, so once the label is gone it keeps polling an absent element until it times out. Machine load, not a regression, decides the verdict — which is how the keyboard case went red on #3653's preview run after passing 1280/1280 ten minutes earlier.

Instrumented on an idle box, measured rather than assumed:

| probe | measurement |
|---|---|
| `Copied` visible window | **976.7 / 995.6 / 999.4 / 1000.5 / 999.8 / 1001.2 ms** |
| label appears after interaction resolves | 0.0–0.1 ms |
| `el.focus()` | 0.7 ms, `document.activeElement === el` every run |
| `'clipboard' in navigator` / `document.hasFocus()` | `true` / `true` |

The clipboard was never in question — `test/component-setup.tsx` already stubs `writeText` to a resolving `vi.fn()` precisely so this is deterministic. Focus was never in question either. The only wall-clock dependency is the reset timer.

## The fix

The same restricted virtual clock #3654 established, installed **immediately before the interaction**. Ordering is load-bearing: `vi.useFakeTimers` captures nothing retroactively and the reset timer is armed by the copy itself, so installing it afterwards would be too late.

The label then persists however slow the runner is, which lets the window be asserted explicitly instead of raced — copied, still copied at 999 ms, reset at 1000 ms with the command back. Nothing about the component changes: the same `CopyButton` arms the same `setTimeout`; only the reset's *arrival* is now under the test's control.

Everything up to the copy still runs on the real clock, and both driver interactions (`.click()` and `userEvent.keyboard('{Enter}')`) run fine under the frozen clock — worth noting because `PageBlockHostAutoRetry`'s header cautions that "driver interactions must not race a faked clock". That caution turns out to be conservative; #3654 already drove `fill()` this way.

## Verification

**Mutation — the guard is not weaker.** Each mutant red at its own assertion, with its own message:

| mutation | result |
|---|---|
| `copy` → no-op on **both** the Box and the button | red, `expected +0 to be 1`, at the `copiedLabels()).toBe(1)` guard, both tests |
| `CopyButton timeout` 1000 → **500** ms | red at the 999 ms boundary assertion |
| `CopyButton timeout` 1000 → **2000** ms | red at the post-reset assertion |
| remove `onClick={copy}` from the **button only** | **green** — exactly as the file's existing HONEST CAVEAT predicts (both handlers are React-synthetic and share the delegated root). The caveat is still accurate. |

**Freeze control — the clock is frozen, not merely fast.** With 2000 ms of REAL time inserted before the first assertion: green under the virtual clock, **red under real timers** at the same guard.

`afterEach(() => vi.useRealTimers())` rather than a `finally`, which does not run when a test times out.

**Repeat runs:** 8×, 9/9 tests counted green every run, 706–835 ms. Local browser is **non-canonical** (nixpkgs Chrome for Testing); CI's component job is the authority for the tier.

Also clean: `prettier --check` (verified against a positive control that does violate), `eslint`, and a full `typecheck` (0 errors in 100 s under an 8 GB heap cap — not an OOM reporting zero).

## Survey of the rest of the tier — and why nothing else is changed here

All **128** `src/**/*.browser.test.tsx` files were swept for the two-part signature: a real timer in the component under test **and** an assertion positioned so a slow runner changes the verdict. Two candidates survived to a measurement, and **both were measured and left alone**:

- **`PageBlockHostLaunchReveal.browser.test.tsx:303`** — `expect(Date.now() - firedAt).toBeLessThan(LAUNCH_REVEAL_MS)` (260 ms). Structurally the purest form of the defect, but **measured 11–22 ms across 5 runs — a 12–24× margin**, versus the reference case which was already *over* its budget at 338 ms/300 ms. It also has no clean fix: the reveal `setTimeout` is armed during `driveToReady()`, before any point where a clock could be frozen, so converting it would mean restructuring a working, mutation-verified guard. Left as-is deliberately.
- **`PageBlockHostReviewMode.browser.test.tsx:445`** — the theory was that the preceding `vi.waitFor` posts a `REQUEST_CONSENT` per retry and burns the 30-message/1000 ms limiter in `usePostMessage.ts`. **Ruled out by measurement:** the `waitFor` succeeds on its *first* iteration in 5/5 runs (0–1 ms), for 17 of 30 messages, and the retry count is not load-dependent because the notification fires synchronously off the dispatched `MessageEvent`.

A large structural class was ruled out on direction rather than margin: the ~20 `await new Promise(r => setTimeout(r, 150))` + assert-**absence** pairs across `AppBlocks`. Slowness delays the thing further, so those can only go false-**green**, never red. Worth knowing they exist, but they are not this defect.

The honest summary: **of 128 files, exactly one was really racing, and it is the one fixed here.** The tier is in better shape than the two back-to-back flakes suggested.

One thing I could not verify: I do not have the #3653 preview-run log, so the causal link between that specific red and the 1 s window is inferred from the mechanism plus the measured window, not read off the failure output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aj1HosDFkP6LgxMAtJdDmJ
