### PR TITLE
feat(app-blocks): enable comfy:nodepack AIRs in inline ComfyUI graphs

### DIFF
--- a/src/server/routers/__tests__/blocks.router.workflow.test.ts
+++ b/src/server/routers/__tests__/blocks.router.workflow.test.ts
@@ -6315,17 +6315,34 @@ describe('customComfy bridge (submit/estimate/settle)', () => {
       expect(mockGetHighestTierSubscription).not.toHaveBeenCalled();
     });
 
-    it('🔴 GATE 1 IS WIRED: a nodepack URN is rejected (arbitrary code execution, gated off)', async () => {
+    // 🔴 INVERTED, NOT DELETED — see `inline-comfy.service.test.ts`. The kill
+    // switch is on, so a nodepack must now reach the orchestrator INTACT. That
+    // last word is the point: it is not enough that the submit succeeds, the
+    // URN has to actually arrive in the step input the worker reads. A flip that
+    // stopped rejecting but silently dropped the URN would look identical from
+    // the caller's side and fail only at ComfyUI load time.
+    it('🔴 a nodepack URN now reaches the orchestrator INTACT in the step input', async () => {
+      const NODEPACK = 'urn:air:comfy:nodepack:comfyregistry:kijai/comfyui-kjnodes@1.4.0';
+      mockVerifyBlockToken.mockResolvedValue(ccPageClaims());
+      happyInline();
+      await caller().submitWorkflow({
+        blockToken: 'tok',
+        body: inlineBody({ resources: [NODEPACK] }),
+      });
+      expect(mockSubmitWorkflow).toHaveBeenCalledTimes(1);
+      const input = mockSubmitWorkflow.mock.calls[0][0].body.steps[0].input;
+      expect(input.resources).toEqual([NODEPACK]);
+    });
+
+    it('🔴 an OCI container-image AIR is STILL rejected at the router — the flip is nodepack-only', async () => {
       mockVerifyBlockToken.mockResolvedValue(ccPageClaims());
       happyInline();
       await expect(
         caller().submitWorkflow({
           blockToken: 'tok',
-          body: inlineBody({
-            resources: ['urn:air:comfy:nodepack:comfyregistry:kijai/comfyui-kjnodes@1.4.0'],
-          }),
+          body: inlineBody({ resources: ['urn:air:oci:image:ghcr:evil/comfy@v1'] }),
         })
-      ).rejects.toThrow(/nodepack resources are not permitted/);
+      ).rejects.toThrow(/is not permitted in an inline workflow/);
       expect(mockSubmitWorkflow).not.toHaveBeenCalled();
     });
 

--- a/src/server/services/blocks/__tests__/inline-comfy.service.test.ts
+++ b/src/server/services/blocks/__tests__/inline-comfy.service.test.ts
@@ -170,25 +170,66 @@ describe('collectInlineAuditText — the moderation sweep', () => {
 // (@civitai/client 0.2.0-beta.84) that fails OPEN if the gate is naive.
 // ─────────────────────────────────────────────────────────────────────────────
 describe('assertViewerEntitledToInlineResources — AIR shape', () => {
-  it('🔴 rejects a NODEPACK URN while nodepacks are gated off (arbitrary code execution)', async () => {
-    expect(INLINE_NODEPACKS_ENABLED).toBe(false);
+  // 🔴 INVERTED, NOT DELETED. These two used to assert a nodepack URN was
+  // REJECTED. The kill switch is now on, so they assert it is ACCEPTED and
+  // reaches the submit path intact. Keeping them inverted rather than removing
+  // them means flipping `INLINE_NODEPACKS_ENABLED` back is still a one-line
+  // change with live coverage on both sides of the decision.
+  it('🔴 ACCEPTS a comfyregistry NODEPACK URN now that the kill switch is on', async () => {
+    expect(INLINE_NODEPACKS_ENABLED).toBe(true);
     await expect(
       assertViewerEntitledToInlineResources({
         airs: ['urn:air:comfy:nodepack:comfyregistry:kijai/comfyui-kjnodes@1.4.0'],
         user: VIEWER,
       })
-    ).rejects.toThrow(/nodepack resources are not permitted/);
+    ).resolves.toBeUndefined();
+    // A nodepack carries no civitai entitlement, so the belt is not consulted
+    // for it — the same exempt-by-construction path huggingface weights take.
+    expect(mockGetResourceData).not.toHaveBeenCalled();
   });
 
-  it('rejects a nodepack from ANY source, not just comfyregistry', async () => {
-    // The gate keys on the AIR `type`, not the source — a `civitai`-sourced
-    // nodepack is the same capability.
+  it('🔴 the flip opens COMFYREGISTRY nodepacks only — a civitai-sourced one is still rejected', async () => {
+    // MEASURED, and narrower than "nodepacks are on" implies. `type` and
+    // `source` are separate allowlists, and only `comfyregistry` was added to
+    // the source list. A `civitai`-sourced nodepack passes the TYPE check, then
+    // takes the civitai branch and is gated as a model version — which it is
+    // not, so it resolves to nothing and the anti-drop assert rejects it.
+    //
+    // That is fail-CLOSED and it is the behaviour we want: real nodepacks live
+    // in the ComfyUI registry, and no logic was added to carve out a path for a
+    // shape that does not exist. Recorded as a test so the narrowness is a
+    // known property rather than a surprise.
+    mockGetResourceData.mockResolvedValue([]);
     await expect(
       assertViewerEntitledToInlineResources({
         airs: ['urn:air:other:nodepack:civitai:123@456'],
         user: VIEWER,
       })
-    ).rejects.toThrow(/nodepack resources are not permitted/);
+    ).rejects.toThrow(/not available for generation/);
+  });
+
+  it('🔴 enabling nodepacks did NOT widen anything else — a non-nodepack resource is still fully gated', async () => {
+    // The failure this pins: a flag flip that accidentally relaxes the belt for
+    // the rest of `resources`. A nodepack alongside a non-generatable civitai
+    // LoRA must still be rejected, on the LoRA.
+    mockGetResourceData.mockResolvedValue([resourceRow({ canGenerate: false })]);
+    await expect(
+      assertViewerEntitledToInlineResources({
+        airs: ['urn:air:comfy:nodepack:comfyregistry:kijai/comfyui-kjnodes@1.4.0', LORA_AIR],
+        user: VIEWER,
+      })
+    ).rejects.toThrow(/not available for generation/);
+  });
+
+  it('🔴 an OCI container-image AIR is STILL rejected — the flip is nodepack-only', async () => {
+    // `image` was never keyed off the nodepack flag. This is the control that
+    // proves the flip widened one type, not the whole allowlist.
+    await expect(
+      assertViewerEntitledToInlineResources({
+        airs: ['urn:air:oci:image:ghcr:evil/comfy@v1'],
+        user: VIEWER,
+      })
+    ).rejects.toThrow(/is not permitted in an inline workflow/);
   });
 
   // ───────────────────────────────────────────────────────────────────────────

--- a/src/server/services/blocks/inline-comfy.service.ts
+++ b/src/server/services/blocks/inline-comfy.service.ts
@@ -36,24 +36,51 @@ import type { ComfyGraph } from '~/server/services/blocks/recipes';
 // ─────────────────────────────────────────────────────────────────────────────
 
 /**
- * 🔴 NODEPACK AIRs ARE ARBITRARY CODE EXECUTION, AND ARE OFF FOR THIS INCREMENT.
+ * Whether an inline `resources` array may name `comfy:nodepack` AIRs — e.g.
+ * `urn:air:comfy:nodepack:comfyregistry:<publisher>/<pack>@<version>` — which
+ * install third-party ComfyUI custom nodes into the worker's container.
  *
- * `CustomComfyInput.resources` accepts `comfy:nodepack` URNs (e.g.
- * `urn:air:comfy:nodepack:comfyregistry:<owner>/<pack>@<version>`), which install
- * third-party custom nodes into the ComfyUI container at runtime. Allowing an app
- * to name one is allowing an app to run code we have not reviewed, sandboxed only
- * by the worker container. That is a product/security decision with a named owner,
- * and it has NOT been made — so this ships CLOSED rather than shipping the
- * decision by default.
+ * 🔴 ON, BY AN OWNER DECISION. The previous revision shipped this CLOSED and said
+ * the decision had not been made. It has now been made, and the reasoning is
+ * recorded here rather than in a PR description that nobody reads at 3am:
  *
- * Consequence, stated plainly: inline graphs are limited to STOCK ComfyUI nodes
- * plus non-nodepack AIRs. An app needing a custom node pack is still blocked.
+ * Nodepacks are a FIRST-CLASS, OWNED ORCHESTRATOR CAPABILITY, not a hazard
+ * surface this bridge invents. Verified against `civitai-orchestration@main`:
+ *   - `Common/Clients/ComfyRegistry/ComfyRegistryApiClient.cs` resolves
+ *     `urn:air:comfy:nodepack:comfyregistry:<publisher>/<name>@<version>`, with
+ *     `Grains/Resources/ResourceProviders/ComfyRegistryResourceProvider.cs`
+ *     behind it.
+ *   - `Grains.Abstractions/Jobs/ComfyNodepackSnapshotJob.cs` installs a pack onto
+ *     a comfy image and captures a snapshot.
+ *   - `Grains.Abstractions/Jobs/CustomComfyJob.cs` documents carrying
+ *     `comfy:nodepack` URNs for runtime-installable custom nodes, with session
+ *     affinity for the install and a stable fingerprint of the installed
+ *     nodepack set.
+ * The block path is another door to that existing system, not a new one.
  *
- * Enabling it later is a one-line flip, and the tests for both states already
- * exist (`inline-comfy.service.test.ts` covers rejection now, and the
- * allowlist derivation below is keyed off this flag so nothing else moves).
+ * 🔴 BE PRECISE ABOUT WHAT THAT DOES AND DOES NOT BUY, BECAUSE THE SHORT VERSION
+ * OF THIS RATIONALE IS "SECURITY IS HANDLED ORCHESTRATOR-SIDE" AND THAT IS
+ * STRONGER THAN WHAT WAS MEASURED. Searching those files for an allowlist,
+ * blocklist, publisher-trust check or security scan found NONE — the resolver
+ * resolves any pack the public ComfyUI registry serves, and the comment at
+ * `ComfyRegistryResourceProvider.cs` notes it does not even validate that the
+ * publisher matches (a mismatch simply 404s). So the real trust boundary is
+ * **the public registry plus the worker's container sandbox**, and this flag
+ * inherits exactly that — no more. If a per-publisher or per-pack allowlist is
+ * wanted, it does not exist yet and this flag is not it.
+ *
+ * The two gates from the inline arm's own belt are UNAFFECTED and still run over
+ * every non-nodepack entry in `resources`: entitlement
+ * (`assertViewerEntitledToInlineResources`) and the prompt sweep
+ * (`collectInlineAuditText`). Enabling nodepacks widens what `resources` may
+ * NAME; it does not weaken what the rest of it must PASS.
+ *
+ * KEPT AS A CONSTANT DELIBERATELY — this is the one-line kill switch if the
+ * decision is revisited. Do not inline `true` and delete it. Both states are
+ * tested (`inline-comfy.service.test.ts`), and the source/type allowlists below
+ * are keyed off it so flipping it moves nothing else.
  */
-export const INLINE_NODEPACKS_ENABLED = false;
+export const INLINE_NODEPACKS_ENABLED = true;
 
 /**
  * AIR `source` values an inline `resources` entry may name. ALLOWLIST, not a


### PR DESCRIPTION

Flips `INLINE_NODEPACKS_ENABLED` from false to true. An inline `customComfy`
body may now declare `urn:air:comfy:nodepack:comfyregistry:<publisher>/<pack>@<version>`
AIRs in `resources`, which the orchestrator resolves and installs into the
worker's ComfyUI container.

The gate shipped closed because the decision had not been made. It has now been
made: nodepacks are a first-class, owned orchestrator capability, not a hazard
surface this bridge invents. Verified against civitai-orchestration@main —
ComfyRegistryApiClient resolves the URN scheme, ComfyNodepackSnapshotJob installs
a pack onto a comfy image, and CustomComfyJob documents carrying nodepack URNs
for runtime-installable custom nodes with session affinity and a stable
fingerprint of the installed set.

The diff is the constant, its doc comment, and the tests — no logic was needed,
which is the structural claim the previous PR made and this one checks.

Measured and recorded in the code rather than assumed: searching those
orchestrator files for an allowlist, blocklist, publisher-trust check or security
scan found NONE. The real trust boundary is the public ComfyUI registry plus the
worker's container sandbox, and this flag inherits exactly that — no more.

Also measured: the flip opens comfyregistry nodepacks ONLY. `type` and `source`
are separate allowlists, so a nodepack from any other source still takes the
civitai entitlement branch and is rejected fail-closed. Pinned by a test.

The inline arm's other two gates are unaffected and still run over every
non-nodepack entry in `resources`: entitlement and the prompt sweep. Enabling
nodepacks widens what `resources` may NAME, not what the rest of it must PASS —
pinned by a test that mixes a nodepack with a non-generatable LoRA and asserts
the LoRA still rejects. An `oci:image` AIR is still rejected, which is the
control proving the flip widened one type rather than the whole allowlist.

The constant is deliberately retained as the one-line kill switch; both states
stay tested.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>


---

### Sequencing

Rebased onto `main` after #3655 merged (`b1f99ad86f`). It could not be opened earlier without being a stacked PR, which this repo forbids — a squash-merged parent does not retarget its child, so the child lands on the orphaned parent branch and its changes go missing.

The production diff is one line: `INLINE_NODEPACKS_ENABLED` `false` → `true`. Everything else is its doc comment and tests.

### On the audit of #3655

#3655 was adversarially audited, one deploy-blocker was found and fixed, and a delta re-audit came back clean. Two of that audit findings are worth carrying here: the AIR **source** allowlist still has no killing test (pre-existing, same class as the `type` allowlist this PR touches), and the `huggingface` source remains an ungated arbitrary-download surface. Neither is introduced or worsened by this change, but the second is the same capability class the nodepack gate was holding closed and deserves its own decision.
