### PR TITLE
fix(app-blocks): installs is a category error for page apps, not a zero

### DIFF
--- a/src/components/AppBlocks/AppAnalyticsPanel.browser.test.tsx
+++ b/src/components/AppBlocks/AppAnalyticsPanel.browser.test.tsx
@@ -235,6 +235,138 @@ describe('AppAnalyticsPanel — impressions: measured vs unmeasured', () => {
 });
 
 /**
+ * INSTALLS: a page app CANNOT be installed (stateless — Decision 2), so its
+ * `Installs 0` is a CATEGORY ERROR sitting next to genuinely-measured run and
+ * Buzz numbers. Same defect class as the impressions card above, different
+ * cause: there the store could not be asked, here the question is meaningless.
+ *
+ * THREE states, and the whole value of this block is that it pins all three:
+ *   1. measured non-zero — render the number;
+ *   2. measured zero     — render `0`. A model-slot app with no installs yet is
+ *                          a real, actionable answer;
+ *   3. not applicable    — render an em dash.
+ * (2) is the one that would regress SILENTLY: every visible symptom of "the fix
+ * works" looks identical if a truthful zero starts hiding too.
+ *
+ * Em dashes are asserted by COUNT, not by `expect.element`. The impressions card
+ * renders the same glyph in its own unavailable state, so an unanchored
+ * single-element assertion would be ambiguous the moment both fire — and,
+ * worse, would pass while attributing the wrong card's dash to installs.
+ */
+describe('AppAnalyticsPanel — installs: measured vs not applicable', () => {
+  const emDashCount = () => page.getByText('—', { exact: true }).elements().length;
+
+  test('(3) a PAGE app renders an em dash and says why — never a 0', async () => {
+    mocks.analytics.current = {
+      ...ZEROED,
+      installs: { total: 0, active: 0, series: [], notApplicable: true },
+      // Measured impressions, so any em dash on the page belongs to installs.
+      views: { count: 124, uniqueViewers: 12, anonCount: 40 },
+    };
+    renderWithProviders(<AppAnalyticsPanel scopedAppBlockId="apb_1" />);
+
+    await expect.element(page.getByText('Active installs')).toBeInTheDocument();
+    await expect
+      .element(page.getByText('Not applicable to page apps', { exact: true }))
+      .toBeInTheDocument();
+    expect(emDashCount()).toBe(1);
+    // The fabricated "0 total (all time)" sub-line must be gone entirely.
+    expect(page.getByText('total (all time)').elements()).toHaveLength(0);
+
+    // PER-SECTION: everything else on the panel is measured and still renders.
+    await expect.element(page.getByText('Runs (range)')).toBeInTheDocument();
+    await expect.element(page.getByText('App loads (range)', { exact: true })).toBeInTheDocument();
+    await expect.element(page.getByText('124', { exact: true })).toBeInTheDocument();
+    expect(page.getByText('Analytics unavailable').elements()).toHaveLength(0);
+  });
+
+  // The runs series is deliberately NON-empty in this pair. With both series
+  // empty, MiniLineChart's own "No data in this range." fires for both cards and
+  // the two states become indistinguishable by that string — the assertion below
+  // would then be measuring the runs card, not installs.
+  const RUNS_WITH_DATA = {
+    count: 7,
+    buzzSpent: 7000,
+    series: [{ bucket: '2026-06-01T00:00:00.000Z', value: 7 }],
+  };
+
+  test('(3) the installs CHART is replaced by the explanation, not left empty', async () => {
+    mocks.analytics.current = {
+      ...ZEROED,
+      installs: { total: 0, active: 0, series: [], notApplicable: true },
+      runs: RUNS_WITH_DATA,
+    };
+    renderWithProviders(<AppAnalyticsPanel scopedAppBlockId="apb_1" />);
+
+    await expect.element(page.getByText('New installs over time')).toBeInTheDocument();
+    await expect
+      .element(page.getByText('Not applicable — page apps are not installed.', { exact: true }))
+      .toBeInTheDocument();
+    // "No data in this range." reads as a measurement of a quiet month, which is
+    // exactly the claim a page app cannot make. The runs card has data, so the
+    // only card that could emit this string is installs.
+    expect(page.getByText('No data in this range.').elements()).toHaveLength(0);
+    // Structural: the runs chart survives, the installs chart does not.
+    await expect.element(page.getByText('Runs over time')).toBeInTheDocument();
+    expect(document.querySelectorAll('[data-testid="chart"]')).toHaveLength(1);
+  });
+
+  // 🔴 THE SILENT REGRESSION. Byte-identical counters to the case above — only
+  // the flag differs. If the em dash is ever driven by `active === 0` instead of
+  // the server's flag, this is the only test that goes red.
+  test('(2) a measured ZERO still renders 0 — a model-slot app with none yet', async () => {
+    mocks.analytics.current = {
+      ...ZEROED,
+      installs: { total: 0, active: 0, series: [] },
+      runs: RUNS_WITH_DATA,
+      views: { count: 124, uniqueViewers: 12, anonCount: 40 },
+    };
+    renderWithProviders(<AppAnalyticsPanel scopedAppBlockId="apb_1" />);
+
+    await expect.element(page.getByText('Active installs')).toBeInTheDocument();
+    await expect.element(page.getByText('0 total (all time)', { exact: true })).toBeInTheDocument();
+    expect(page.getByText('Not applicable to page apps').elements()).toHaveLength(0);
+    // No em dash ANYWHERE — installs is measured and so are impressions.
+    expect(emDashCount()).toBe(0);
+    // Same fixture as (3) apart from the flag, so the chart card is the
+    // structural discriminator: the empty installs series renders the CHART's
+    // own empty-state ("no installs this month"), never the n/a explanation.
+    await expect.element(page.getByText('No data in this range.')).toBeInTheDocument();
+    expect(page.getByText('Not applicable — page apps are not installed.').elements()).toHaveLength(
+      0
+    );
+  });
+
+  test('(1) a measured non-zero count renders the number', async () => {
+    mocks.analytics.current = {
+      ...ZEROED,
+      installs: { total: 3, active: 1, series: [] },
+      views: { count: 124, uniqueViewers: 12, anonCount: 40 },
+    };
+    renderWithProviders(<AppAnalyticsPanel scopedAppBlockId="apb_1" />);
+
+    await expect.element(page.getByText('3 total (all time)', { exact: true })).toBeInTheDocument();
+    expect(emDashCount()).toBe(0);
+  });
+
+  test('an ABSENT notApplicable key (old pod, rolling deploy) takes the measured branch', async () => {
+    // tRPC output is not zod-validated on the client, so a new bundle can be
+    // handed an old pod's payload. Absent must behave exactly as today does —
+    // this is the no-ordering-hazard claim, asserted rather than assumed.
+    mocks.analytics.current = {
+      ...ZEROED,
+      installs: { total: 7, active: 5, series: [] },
+      views: { count: 124, uniqueViewers: 12, anonCount: 40 },
+    };
+    renderWithProviders(<AppAnalyticsPanel scopedAppBlockId="apb_1" />);
+
+    await expect.element(page.getByText('5', { exact: true })).toBeInTheDocument();
+    await expect.element(page.getByText('7 total (all time)', { exact: true })).toBeInTheDocument();
+    expect(emDashCount()).toBe(0);
+  });
+});
+
+/**
  * The two "top N" cards render the aggregates' GROUP BY keys. #3561 bounded the endpoint
  * column, which promoted the internal tokens to the TOP rows — so those cards became the
  * most prominent place raw internal strings appear on the panel.

--- a/src/components/AppBlocks/AppAnalyticsPanel.tsx
+++ b/src/components/AppBlocks/AppAnalyticsPanel.tsx
@@ -58,10 +58,12 @@ type AnalyticsData = {
    * never sets it for an installable app); this renderer must not second-guess
    * it by inferring anything from the number itself.
    *
-   * Read through `?.` for the same reason `views` is optional: tRPC output is
-   * not zod-validated on the client, so a rolling deploy can hand this bundle an
-   * older pod's payload with no `notApplicable` key. Absent → falsy → the
-   * measured branch, which is exactly today's behaviour and therefore safe.
+   * `installs` itself is REQUIRED (unlike `views`), so it is read directly — do
+   * not "restore" optional chaining on it. Only `notApplicable` is optional,
+   * for the same reason `views` is: tRPC output is not zod-validated on the
+   * client, so a rolling deploy can hand this bundle an older pod's payload
+   * with no `notApplicable` key. Absent → falsy → the measured branch, which is
+   * exactly today's behaviour and therefore safe.
    */
   installs: { total: number; active: number; series: TimePoint[]; notApplicable?: boolean };
   runs: { count: number; buzzSpent: number; series: TimePoint[] };
@@ -422,10 +424,12 @@ export function AppAnalyticsPanel({ scopedAppBlockId }: { scopedAppBlockId?: str
             <Text size="sm">
               Active users, API calls, and error rate reflect only{' '}
               <strong>authenticated, scope-gated API calls</strong> your app makes. A static block
-              (or one with no scoped API surface) will show installs and revenue but flat
-              engagement. <strong>Views</strong> is the exception — it is measured on every load, so
-              it counts signed-out visitors and static blocks that the engagement figures cannot
-              see. Installs, runs, and Buzz figures are unaffected.
+              (or one with no scoped API surface) will show revenue but flat engagement.{' '}
+              <strong>App loads</strong> is the exception — it is measured on every load, so it
+              counts signed-out visitors and static blocks that the engagement figures cannot see.
+              Runs and Buzz figures are unaffected. The installs figure is blanked out for apps that
+              cannot be installed at all (a page app has no install slot), which is different from a
+              real zero.
             </Text>
           </Alert>
 

--- a/src/components/AppBlocks/AppAnalyticsPanel.tsx
+++ b/src/components/AppBlocks/AppAnalyticsPanel.tsx
@@ -41,7 +41,29 @@ type AnalyticsData = {
   range: { from: string | Date; to: string | Date; granularity: 'day' | 'week' };
   notOwned: boolean;
   unavailable?: 'notEntitled' | 'notOwned';
-  installs: { total: number; active: number; series: TimePoint[] };
+  /**
+   * Installs (`block_user_subscriptions`). `notApplicable` is a PER-SECTION
+   * flag: a page app is STATELESS by decision, so an install row cannot exist
+   * for it and the zeros are a category error, not "nobody installed me".
+   *
+   * DISTINCT from `views.unavailable` — that one means "we could not ask", this
+   * one means "we asked and the question is meaningless here". Both render an
+   * em dash rather than a number, but for different reasons, so they get
+   * different copy.
+   *
+   * 🔴 A measured zero (a model-slot app with no installs YET) arrives with the
+   * flag ABSENT and MUST still render `0` — hiding it behind "n/a" would be a
+   * new fabricated-zero bug pointing the other way. The server is what makes
+   * that distinction (it never sets the flag when a counter is non-zero, and
+   * never sets it for an installable app); this renderer must not second-guess
+   * it by inferring anything from the number itself.
+   *
+   * Read through `?.` for the same reason `views` is optional: tRPC output is
+   * not zod-validated on the client, so a rolling deploy can hand this bundle an
+   * older pod's payload with no `notApplicable` key. Absent → falsy → the
+   * measured branch, which is exactly today's behaviour and therefore safe.
+   */
+  installs: { total: number; active: number; series: TimePoint[]; notApplicable?: boolean };
   runs: { count: number; buzzSpent: number; series: TimePoint[] };
   buzzPurchased: { count: number; buzzAmount: number; grossCents: number };
   engagement: {
@@ -300,11 +322,34 @@ export function AppAnalyticsPanel({ scopedAppBlockId }: { scopedAppBlockId?: str
             cols={{ base: 1, '48em': 2, '62em': 3, '75em': 5 }}
             spacing="md"
           >
+            {/*
+              A page app CANNOT be installed — it is stateless by design, so no
+              `block_user_subscriptions` row ever exists for it. Rendering "0"
+              there is the same fabricated-zero defect as #3557/#3581, just with
+              a different cause: the author reads "nobody installed my app" from
+              a number that could never have been anything else.
+
+              🔴 The em dash is driven ONLY by the server's `notApplicable`
+              flag, never by `active === 0`. A model-slot app with no installs
+              yet is a TRUTHFUL zero and must keep rendering `0` — that is the
+              case that would regress silently if this branch ever grew a
+              "…|| active === 0" convenience.
+            */}
             <MetricCard
               label="Active installs"
-              value={analytics.installs.active.toLocaleString()}
-              sub={`${analytics.installs.total.toLocaleString()} total (all time)`}
-              tooltip="Currently-enabled installs. Total counts every install ever created."
+              value={
+                analytics.installs.notApplicable ? '—' : analytics.installs.active.toLocaleString()
+              }
+              sub={
+                analytics.installs.notApplicable
+                  ? 'Not applicable to page apps'
+                  : `${analytics.installs.total.toLocaleString()} total (all time)`
+              }
+              tooltip={
+                analytics.installs.notApplicable
+                  ? 'Page apps run standalone and are not installed onto a model, so there is nothing to count here — this is NOT a report of zero installs. Your runs, Buzz and App loads figures are unaffected.'
+                  : 'Currently-enabled installs. Total counts every install ever created.'
+              }
             />
             <MetricCard
               label="Runs (range)"
@@ -387,10 +432,22 @@ export function AppAnalyticsPanel({ scopedAppBlockId }: { scopedAppBlockId?: str
           <SimpleGrid type="container" cols={{ base: 1, '62em': 2 }} spacing="md">
             <Card padding="md" radius="md" withBorder>
               <Title order={5}>New installs over time</Title>
-              <MiniLineChart
-                points={analytics.installs.series}
-                granularity={analytics.range.granularity}
-              />
+              {/*
+                Same discriminator as the card above. An empty series would
+                otherwise render MiniLineChart's "No data in this range." —
+                which reads as a measurement ("nobody installed you this
+                month") for an app that has no install path at all.
+              */}
+              {analytics.installs.notApplicable ? (
+                <Text c="dimmed" size="xs" py="sm">
+                  Not applicable — page apps are not installed.
+                </Text>
+              ) : (
+                <MiniLineChart
+                  points={analytics.installs.series}
+                  granularity={analytics.range.granularity}
+                />
+              )}
             </Card>
             <Card padding="md" radius="md" withBorder>
               <Title order={5}>Runs over time</Title>

--- a/src/server/routers/__tests__/blocks.router.subscriptions.test.ts
+++ b/src/server/routers/__tests__/blocks.router.subscriptions.test.ts
@@ -78,7 +78,9 @@ vi.mock('~/server/db/client', () => ({
 // tree, so no hand-trimmed subset can go stale. (Replaces the old completeKeys Proxy,
 // which covered REDIS_KEYS but not REDIS_SYS_KEYS.)
 vi.mock('~/server/redis/client', async () => {
-  const actual = await vi.importActual<typeof import('@civitai/redis/client')>('@civitai/redis/client');
+  const actual = await vi.importActual<typeof import('@civitai/redis/client')>(
+    '@civitai/redis/client'
+  );
   return { ...actual, redis: { get: vi.fn(async () => null), set: vi.fn(async () => undefined) } };
 });
 vi.mock('~/server/middleware/block-scope.middleware', () => ({
@@ -455,9 +457,9 @@ describe('soft-launch — developer + mod-review procs reject a plain non-mod (F
   });
 
   it('approveRequest (mod-only review/curation, unchanged) → FORBIDDEN', async () => {
-    await expect(
-      nonMod().approveRequest({ publishRequestId: 'pubreq_x' })
-    ).rejects.toMatchObject({ code: 'FORBIDDEN' });
+    await expect(nonMod().approveRequest({ publishRequestId: 'pubreq_x' })).rejects.toMatchObject({
+      code: 'FORBIDDEN',
+    });
   });
 
   it('getMyRevenue (author-gated) → FORBIDDEN for a non-cohort non-mod', async () => {
@@ -615,10 +617,10 @@ describe('Layer 1 — install procs widened to protectedProcedure (owner-scoped,
       settings: {},
     };
 
-    // PAGE-ONLY LAUNCH GATE: a subscription only ever attaches a MODEL-slot app
-    // (manifest has no page) — a non-launch app — so a non-mod is now rejected
-    // even with the flag ON. This supersedes the pre-launch-gate "(a) non-mod
-    // OWNER upserts".
+    // PAGE-ONLY LAUNCH GATE: a MODEL-slot app (manifest has no page) is a
+    // non-launch app, so a non-mod is rejected even with the flag ON. This
+    // supersedes the pre-launch-gate "(a) non-mod OWNER upserts". See the
+    // page-app sibling below for what the gate does NOT reject.
     it('(a) non-mod + flag ON + MODEL-slot app → FORBIDDEN (non-launch app), never upserts', async () => {
       mockDbReadAppBlockFindUnique.mockResolvedValue({
         blockId: 'g',
@@ -650,6 +652,56 @@ describe('Layer 1 — install procs widened to protectedProcedure (owner-scoped,
       );
     });
 
+    /**
+     * 🔴 CHARACTERISATION TEST — pins what the gate ACTUALLY does, which is not
+     * what its comment used to claim. `assertLaunchAppForCaller` reduces to
+     * `if (declaresPage) return`, because `app.page` is in `LAUNCH_SLOT_IDS` and
+     * so `isLaunchSlot(PAGE_SLOT_ID)` is a constant `true`. Every approved app
+     * in production declares `page.path`, so a non-mod is ADMITTED for all of
+     * them — and `BlockRegistry.upsertSubscription` applies no slot check of its
+     * own, so a `block_user_subscriptions` row is written against an app that is
+     * STATELESS by decision and has no UI for managing one.
+     *
+     * This is currently unreachable in production only because
+     * `enforceAppBlocksFlag` is mod-only. Widening `app-blocks-enabled` past
+     * moderators would make it reachable. The behaviour is deliberately left
+     * ALONE here; this test exists so a later change to it is a visible,
+     * intentional edit rather than a silent one.
+     */
+    it('(a-page) non-mod + flag ON + PAGE app → ADMITTED and UPSERTS (the latent write hole)', async () => {
+      mockDbReadAppBlockFindUnique.mockResolvedValue({
+        blockId: 'g',
+        status: 'approved',
+        approvedScopes: [],
+        // The prod shape: declares a page, no targets at all.
+        manifest: { page: { path: '/' } },
+      });
+      mockUpsertSubscription.mockResolvedValue({ id: 'bus_new' });
+      const caller = blocksRouter.createCaller(authedCtx(OWNER_ID, false) as never);
+
+      await caller.upsertSubscription(input);
+
+      expect(mockUpsertSubscription).toHaveBeenCalledWith(
+        expect.objectContaining({ userId: OWNER_ID, appBlockId: 'ab_x' })
+      );
+    });
+
+    // The page gate reads `page.path` specifically — an empty path is not a
+    // declaration, so this app is non-launch and a non-mod is rejected. Pins
+    // that the admit branch is the PAGE one and not "any manifest at all".
+    it('(a-page-empty) non-mod + flag ON + empty page.path → FORBIDDEN, never upserts', async () => {
+      mockDbReadAppBlockFindUnique.mockResolvedValue({
+        blockId: 'g',
+        status: 'approved',
+        approvedScopes: [],
+        manifest: { page: { path: '' } },
+      });
+      mockUpsertSubscription.mockResolvedValue({ id: 'bus_new' });
+      const caller = blocksRouter.createCaller(authedCtx(OWNER_ID, false) as never);
+      await expect(caller.upsertSubscription(input)).rejects.toMatchObject({ code: 'FORBIDDEN' });
+      expect(mockUpsertSubscription).not.toHaveBeenCalled();
+    });
+
     it('(b) non-mod + flag ON + app NOT approved → BAD_REQUEST, never upserts', async () => {
       // The "owner" boundary for a per-user subscription is the approved-app gate
       // + the session-stamped userId; a non-approved app is rejected outright.
@@ -662,7 +714,9 @@ describe('Layer 1 — install procs widened to protectedProcedure (owner-scoped,
     it('(c) flag OFF (live for a non-mod) → UNAUTHORIZED before the body', async () => {
       mockIsAppBlocksEnabled.mockImplementation(fakePerUserFlag);
       const caller = blocksRouter.createCaller(authedCtx(OWNER_ID, false) as never);
-      await expect(caller.upsertSubscription(input)).rejects.toMatchObject({ code: 'UNAUTHORIZED' });
+      await expect(caller.upsertSubscription(input)).rejects.toMatchObject({
+        code: 'UNAUTHORIZED',
+      });
       expect(mockDbReadAppBlockFindUnique).not.toHaveBeenCalled();
       expect(mockUpsertSubscription).not.toHaveBeenCalled();
     });
@@ -700,7 +754,9 @@ describe('Layer 1 — install procs widened to protectedProcedure (owner-scoped,
     it('(c) flag OFF (live for a non-mod) → UNAUTHORIZED before the body', async () => {
       mockIsAppBlocksEnabled.mockImplementation(fakePerUserFlag);
       const caller = blocksRouter.createCaller(authedCtx(OWNER_ID, false) as never);
-      await expect(caller.deleteSubscription(input)).rejects.toMatchObject({ code: 'UNAUTHORIZED' });
+      await expect(caller.deleteSubscription(input)).rejects.toMatchObject({
+        code: 'UNAUTHORIZED',
+      });
       expect(mockDeleteSubscription).not.toHaveBeenCalled();
     });
   });

--- a/src/server/routers/blocks.router.ts
+++ b/src/server/routers/blocks.router.ts
@@ -962,12 +962,35 @@ function isRedCapableRequest(ctx: { req?: { headers?: { host?: string } } }): bo
 /**
  * Manifest-level variant of {@link assertLaunchSlotForCaller} for the
  * subscription path, where the slot isn't an input — it's implied by the app's
- * manifest targets. A model-slot app (the only kind that takes a subscription;
- * page apps are stateless and never subscribed) is non-launch, so a non-mod is
- * rejected. A moderator is grandfathered. An app is launch-eligible iff it
- * declares a page AND `app.page` is a launch slot (mirrors the service's
- * isAppLaunchEligible / the public-read filter, keeping the allowlist the single
- * source of truth).
+ * manifest. A moderator is grandfathered. Everyone else passes iff the app is
+ * launch-eligible: it declares a page AND `app.page` is a launch slot (mirrors
+ * the service's isAppLaunchEligible / the public-read filter, keeping the
+ * allowlist the single source of truth).
+ *
+ * 🔴 WHAT THIS DOES NOT DO — read before relying on it. An earlier version of
+ * this comment claimed a non-mod is "always rejected" here, on the reasoning
+ * that only a MODEL-slot app takes a subscription and model slots are
+ * non-launch. That is not what the code does. `app.page` IS in
+ * `LAUNCH_SLOT_IDS`, so `isLaunchSlot(PAGE_SLOT_ID)` is a compile-time-constant
+ * `true` and the predicate below reduces to `if (declaresPage) return`. Every
+ * approved app in production declares `page.path`, so this gate ADMITS all of
+ * them for a non-mod caller.
+ *
+ * That is currently harmless only because `enforceAppBlocksFlag` is mod-only —
+ * the flag, not this function, is what keeps non-mods off the path. Neither
+ * this gate nor `BlockRegistry.upsertSubscription` (which applies no slot check
+ * at all) stops a `block_user_subscriptions` row being written against a PAGE
+ * app, which is stateless by decision (`src/pages/apps/run/[slug]/
+ * [[...path]].tsx` — "STATELESS (Decision 2): no `block_user_subscriptions`
+ * row, no migration") and has no UI for managing one. So widening
+ * `app-blocks-enabled` past moderators would start writing invisible
+ * subscription rows for stateless apps unless a slot check is added first.
+ *
+ * Behaviour is deliberately UNCHANGED here — this is a comment correction plus
+ * the test that pins what actually happens (`blocks.router.subscriptions.test.
+ * ts`, "non-mod + PAGE app → ADMITTED"). If you intend to close the hole, the
+ * fix is a `hasInstallSlot(manifest)` check on the subscription path, not an
+ * edit to this doc block.
  */
 function assertLaunchAppForCaller(
   ctx: { user?: { id: number; isModerator?: boolean } },
@@ -3011,11 +3034,14 @@ export const blocksRouter = router({
       if (block.status !== 'approved') {
         throw new TRPCError({ code: 'BAD_REQUEST', message: 'App block is not approved' });
       }
-      // PAGE-ONLY LAUNCH GATE: a subscription only ever attaches a MODEL-slot
-      // app (page apps are stateless — Decision 2 — and never subscribed), so
-      // for the public (non-mod) audience this is always a non-launch app and is
-      // rejected. Moderators are grandfathered. Resolves launch-eligibility from
-      // the app's manifest (declares a page) since the slot isn't an input here.
+      // PAGE-ONLY LAUNCH GATE: resolves launch-eligibility from the app's
+      // manifest (declares a page) since the slot isn't an input here.
+      // Moderators are grandfathered; a non-mod is rejected for a MODEL-slot
+      // app. It does NOT reject a non-mod for a page app — see the 🔴 note on
+      // assertLaunchAppForCaller, and note that nothing below applies a slot
+      // check either, so a page app CAN take a subscription row today. What
+      // keeps non-mods off this path is `enforceAppBlocksFlag` (mod-only), not
+      // this call.
       assertLaunchAppForCaller(ctx, block.manifest);
       // Manifest-driven settings validation. The 4KB cap from the router-
       // level settingsSchema has already fired; this pass enforces the

--- a/src/server/services/blocks/__tests__/app-analytics.service.test.ts
+++ b/src/server/services/blocks/__tests__/app-analytics.service.test.ts
@@ -56,6 +56,8 @@ import {
   emptyAnalytics,
   getMyAppAnalytics,
   getOwnedAppBlockIds,
+  getOwnedAppBlocks,
+  installsNotApplicable,
   resolveRange,
 } from '../app-analytics.service';
 
@@ -63,6 +65,17 @@ const OWNER_ID = 42;
 const OWNED_ID = 'apb_owned';
 const OWNED_ID_2 = 'apb_owned2';
 const FOREIGN_ID = 'apb_someone_else';
+
+/**
+ * Manifest fixtures for the installs applicability discriminator. Shapes are
+ * copied from PROD (measured 2026-08-05 against `app_blocks.manifest`): every
+ * approved app declares `page.path` and carries NO `targets` key at all, while
+ * the model-slot apps carry a `targets` array and no `page`.
+ */
+const MODEL_MANIFEST = { targets: [{ slotId: 'model.sidebar_top', priority: 100 }] };
+const PAGE_MANIFEST = { page: { path: '/' } };
+/** A page app that DOES list its page slot as a target — same verdict. */
+const PAGE_TARGET_MANIFEST = { page: { path: '/' }, targets: [{ slotId: 'app.page' }] };
 
 function routeQueryRaw() {
   // The three raw queries are distinguished by a unique table token in
@@ -87,8 +100,13 @@ function routeQueryRaw() {
 
 beforeEach(() => {
   vi.clearAllMocks();
-  // Default: caller owns one app.
-  mockDbRead.appBlock.findMany.mockResolvedValue([{ id: OWNED_ID }, { id: OWNED_ID_2 }]);
+  // Default: caller owns two INSTALLABLE (model-slot) apps, so the installs
+  // counters in every generic test below are a real measurement and the
+  // applicability discriminator stays off. The page-app cases override this.
+  mockDbRead.appBlock.findMany.mockResolvedValue([
+    { id: OWNED_ID, manifest: MODEL_MANIFEST },
+    { id: OWNED_ID_2, manifest: MODEL_MANIFEST },
+  ]);
   mockDbRead.blockUserSubscription.count
     .mockResolvedValueOnce(20) // installs total
     .mockResolvedValueOnce(12); // installs active
@@ -163,7 +181,10 @@ describe('getOwnedAppBlockIds (ownership resolution)', () => {
     expect(ids).toEqual([OWNED_ID, OWNED_ID_2]);
     expect(mockDbRead.appBlock.findMany).toHaveBeenCalledWith({
       where: { app: { userId: OWNER_ID } },
-      select: { id: true },
+      // `manifest` rides along on this one query — the installs applicability
+      // discriminator needs it, and getMyAppAnalytics is on a per-app fan-out
+      // path where a second round trip would be paid N times per page load.
+      select: { id: true, manifest: true },
     });
   });
 
@@ -419,5 +440,234 @@ describe('getMyAppAnalytics (fabricated-zero discriminator)', () => {
     expect(measured.installs).toEqual(notOwned.installs);
     expect(measured.runs).toEqual(notOwned.runs);
     expect(measured.engagement).toEqual(notOwned.engagement);
+  });
+});
+
+/**
+ * INSTALLS APPLICABILITY — the THIRD state, kept distinct from the other two.
+ *
+ * 1. measured non-zero — a model-slot app with installs;
+ * 2. measured zero     — a model-slot app with none YET. Must still render 0;
+ * 3. not applicable    — a page app, where an install row CANNOT exist.
+ *
+ * (3) collapsing into (2) is the defect this fixes. (2) collapsing into (3) is
+ * the regression it must not introduce, and is the one that would go silent:
+ * every visible symptom would look like the fix working.
+ */
+describe('installsNotApplicable (the three-state predicate)', () => {
+  it('(3) flags a set whose every app is page-only', () => {
+    expect(
+      installsNotApplicable({ ownedApps: [{ manifest: PAGE_MANIFEST }], total: 0, active: 0 })
+    ).toBe(true);
+  });
+
+  it('(3) flags a page app that lists app.page as an explicit target', () => {
+    expect(
+      installsNotApplicable({
+        ownedApps: [{ manifest: PAGE_TARGET_MANIFEST }],
+        total: 0,
+        active: 0,
+      })
+    ).toBe(true);
+  });
+
+  it('(2) does NOT flag a model-slot app with a truthful zero', () => {
+    expect(
+      installsNotApplicable({ ownedApps: [{ manifest: MODEL_MANIFEST }], total: 0, active: 0 })
+    ).toBe(false);
+  });
+
+  it('(1) does NOT flag a model-slot app with installs', () => {
+    expect(
+      installsNotApplicable({ ownedApps: [{ manifest: MODEL_MANIFEST }], total: 3, active: 1 })
+    ).toBe(false);
+  });
+
+  // The state-(1) guard. Not hypothetical: upsertSubscription applies no slot
+  // check and assertLaunchAppForCaller admits any page-declaring app, so a row
+  // CAN exist against a stateless app. If one does, the author must see the
+  // number rather than an "n/a" that hides it.
+  it('(1) NEVER hides a non-zero count behind "not applicable", even for a page app', () => {
+    expect(
+      installsNotApplicable({ ownedApps: [{ manifest: PAGE_MANIFEST }], total: 2, active: 0 })
+    ).toBe(false);
+    // `active` alone is enough — a disabled-but-present install is still a row.
+    expect(
+      installsNotApplicable({ ownedApps: [{ manifest: PAGE_MANIFEST }], total: 0, active: 2 })
+    ).toBe(false);
+  });
+
+  // "All my apps": one installable app makes the aggregate a real measurement.
+  it('does NOT flag a MIXED set (one page app + one model app)', () => {
+    expect(
+      installsNotApplicable({
+        ownedApps: [{ manifest: PAGE_MANIFEST }, { manifest: MODEL_MANIFEST }],
+        total: 0,
+        active: 0,
+      })
+    ).toBe(false);
+    // Order-independent — `some`, not "look at the first one".
+    expect(
+      installsNotApplicable({
+        ownedApps: [{ manifest: MODEL_MANIFEST }, { manifest: PAGE_MANIFEST }],
+        total: 0,
+        active: 0,
+      })
+    ).toBe(false);
+  });
+
+  it('flags a set of SEVERAL page apps (every one inapplicable)', () => {
+    expect(
+      installsNotApplicable({
+        ownedApps: [{ manifest: PAGE_MANIFEST }, { manifest: PAGE_TARGET_MANIFEST }],
+        total: 0,
+        active: 0,
+      })
+    ).toBe(true);
+  });
+
+  // An empty set is not a claim about anything. The owns-nothing / notOwned
+  // payloads carry their own honesty (see emptyAnalytics); asserting
+  // inapplicability on top of them would fabricate a different claim.
+  it('does NOT flag an empty owned set', () => {
+    expect(installsNotApplicable({ ownedApps: [], total: 0, active: 0 })).toBe(false);
+  });
+
+  // Manifest shapes that are absent or junk are page-app-shaped in the only way
+  // that matters: no model target ⇒ no install affordance ⇒ no row can exist.
+  it('treats a missing / malformed manifest as inapplicable', () => {
+    expect(installsNotApplicable({ ownedApps: [{ manifest: null }], total: 0, active: 0 })).toBe(
+      true
+    );
+    expect(installsNotApplicable({ ownedApps: [{}], total: 0, active: 0 })).toBe(true);
+    expect(
+      installsNotApplicable({ ownedApps: [{ manifest: { targets: [] } }], total: 0, active: 0 })
+    ).toBe(true);
+  });
+});
+
+describe('getOwnedAppBlocks (manifest resolution)', () => {
+  it('returns id + manifest for every owned app', async () => {
+    await expect(getOwnedAppBlocks({ ownerUserId: OWNER_ID })).resolves.toEqual([
+      { id: OWNED_ID, manifest: MODEL_MANIFEST },
+      { id: OWNED_ID_2, manifest: MODEL_MANIFEST },
+    ]);
+  });
+
+  it('narrows to the requested id and drops a foreign one (no cross-owner leak)', async () => {
+    await expect(
+      getOwnedAppBlocks({ ownerUserId: OWNER_ID, appBlockId: OWNED_ID })
+    ).resolves.toEqual([{ id: OWNED_ID, manifest: MODEL_MANIFEST }]);
+    await expect(
+      getOwnedAppBlocks({ ownerUserId: OWNER_ID, appBlockId: FOREIGN_ID })
+    ).resolves.toEqual([]);
+  });
+});
+
+describe('getMyAppAnalytics (installs applicability wiring)', () => {
+  /** Zero every counter so `installs` is all-zero regardless of the fixture. */
+  function zeroInstalls() {
+    mockDbRead.blockUserSubscription.count.mockReset();
+    mockDbRead.blockUserSubscription.count.mockResolvedValue(0);
+    mockDbRead.$queryRaw.mockReset();
+    mockDbRead.$queryRaw.mockResolvedValue([]);
+  }
+
+  it('(3) flags a PAGE app whose installs are structurally impossible', async () => {
+    mockDbRead.appBlock.findMany.mockResolvedValue([{ id: OWNED_ID, manifest: PAGE_MANIFEST }]);
+    zeroInstalls();
+
+    const result = await getMyAppAnalytics({ userId: OWNER_ID, appBlockId: OWNED_ID });
+
+    expect(result.installs.notApplicable).toBe(true);
+    // The counters still ride along (a client may want them) — the flag is what
+    // says not to read them as behaviour.
+    expect(result.installs.total).toBe(0);
+    expect(result.installs.active).toBe(0);
+    // PER-SECTION: the rest of the payload is genuinely measured and unflagged.
+    expect(result.unavailable).toBeUndefined();
+    expect(result.notOwned).toBe(false);
+    expect(result.views.unavailable).toBeUndefined();
+  });
+
+  // 🔴 The regression that would go silent. A model-slot app with no installs
+  // yet is a REAL zero and must arrive with NO flag at all — not `false`, so a
+  // client cannot tell it apart from an old server only by the key's absence.
+  it('(2) leaves a model-slot app with a truthful zero UNflagged', async () => {
+    mockDbRead.appBlock.findMany.mockResolvedValue([{ id: OWNED_ID, manifest: MODEL_MANIFEST }]);
+    zeroInstalls();
+
+    const result = await getMyAppAnalytics({ userId: OWNER_ID, appBlockId: OWNED_ID });
+
+    expect(result.installs.total).toBe(0);
+    expect(result.installs.active).toBe(0);
+    expect(result.installs.notApplicable).toBeUndefined();
+    expect('notApplicable' in result.installs).toBe(false);
+  });
+
+  it('(1) leaves a model-slot app WITH installs unflagged and reports the count', async () => {
+    mockDbRead.appBlock.findMany.mockResolvedValue([{ id: OWNED_ID, manifest: MODEL_MANIFEST }]);
+
+    const result = await getMyAppAnalytics({ userId: OWNER_ID, appBlockId: OWNED_ID });
+
+    expect(result.installs.total).toBe(20);
+    expect(result.installs.active).toBe(12);
+    expect('notApplicable' in result.installs).toBe(false);
+  });
+
+  it('(1) reports a page app that somehow HAS rows, rather than hiding them', async () => {
+    // The write hole is real (see assertLaunchAppForCaller): a page app can take
+    // a block_user_subscriptions row. If one exists the author sees the number.
+    mockDbRead.appBlock.findMany.mockResolvedValue([{ id: OWNED_ID, manifest: PAGE_MANIFEST }]);
+
+    const result = await getMyAppAnalytics({ userId: OWNER_ID, appBlockId: OWNED_ID });
+
+    expect(result.installs.total).toBe(20);
+    expect(result.installs.active).toBe(12);
+    expect('notApplicable' in result.installs).toBe(false);
+  });
+
+  it('does not flag the "All my apps" read when ONE owned app is installable', async () => {
+    mockDbRead.appBlock.findMany.mockResolvedValue([
+      { id: OWNED_ID, manifest: PAGE_MANIFEST },
+      { id: OWNED_ID_2, manifest: MODEL_MANIFEST },
+    ]);
+    zeroInstalls();
+
+    const result = await getMyAppAnalytics({ userId: OWNER_ID });
+
+    expect('notApplicable' in result.installs).toBe(false);
+  });
+
+  it('flags the "All my apps" read when EVERY owned app is page-only', async () => {
+    mockDbRead.appBlock.findMany.mockResolvedValue([
+      { id: OWNED_ID, manifest: PAGE_MANIFEST },
+      { id: OWNED_ID_2, manifest: PAGE_MANIFEST },
+    ]);
+    zeroInstalls();
+
+    const result = await getMyAppAnalytics({ userId: OWNER_ID });
+
+    expect(result.installs.notApplicable).toBe(true);
+  });
+
+  // The two placeholder payloads make a DIFFERENT claim ("we never asked"), and
+  // neither resolved a manifest, so neither may assert inapplicability on top.
+  it('never flags the notOwned / owns-nothing placeholders', async () => {
+    const notOwned = await getMyAppAnalytics({ userId: OWNER_ID, appBlockId: FOREIGN_ID });
+    expect(notOwned.unavailable).toBe('notOwned');
+    expect('notApplicable' in notOwned.installs).toBe(false);
+
+    mockDbRead.appBlock.findMany.mockResolvedValue([]);
+    const ownsNothing = await getMyAppAnalytics({ userId: OWNER_ID });
+    expect(ownsNothing.unavailable).toBeUndefined();
+    expect('notApplicable' in ownsNothing.installs).toBe(false);
+  });
+
+  it('never flags the notEntitled placeholder', () => {
+    const range = { from: new Date(0), to: new Date(0), granularity: 'day' as const };
+    const notEntitled = emptyAnalytics(range, false, 'notEntitled');
+    expect(notEntitled.unavailable).toBe('notEntitled');
+    expect('notApplicable' in notEntitled.installs).toBe(false);
   });
 });

--- a/src/server/services/blocks/app-analytics.service.ts
+++ b/src/server/services/blocks/app-analytics.service.ts
@@ -275,9 +275,19 @@ export async function getOwnedAppBlockIds(args: {
  *
  * `hasInstallSlot` is the SHARED predicate — the same one the marketplace card
  * (`components/Apps/AppBlockCard.tsx`) and the app detail page use to decide
- * whether to show the Install CTA. Reusing it is the point: "the panel says
- * installs are n/a" and "the product offers no way to install this" can then
- * never disagree, because they are the same function over the same manifest.
+ * whether to show the Install CTA. Reusing it keeps the manifest half of that
+ * question in one place.
+ *
+ * 🔴 It is NOT the whole CTA predicate, so do not read this as "the panel and
+ * the product can never disagree". Both CTA sites gate on
+ * `!isExternal && hasInstallSlot(...)`, and this function deliberately omits
+ * BOTH extra conditions: it ignores `isExternal`, and `getOwnedAppBlocks`
+ * applies no `status` filter. So an EXTERNAL listing with model targets, or a
+ * model-slot app that is not yet approved, gets no Install CTA while this
+ * reports a measurement. Both are latent today (prod holds zero external and
+ * zero pending rows) and both are strictly today's behaviour rather than a
+ * regression — but if you widen this, widen it deliberately and say which of
+ * the three axes you are adding.
  *
  * The `total`/`active` guard is not belt-and-braces, it is the state-(1) guard —
  * a real count is ALWAYS reported, even for an app whose slots say it should not

--- a/src/server/services/blocks/app-analytics.service.ts
+++ b/src/server/services/blocks/app-analytics.service.ts
@@ -1,5 +1,6 @@
 import { Prisma } from '@prisma/client';
 import { dbRead } from '~/server/db/client';
+import { hasInstallSlot, type InstallSlotManifest } from '~/shared/constants/slot-registry';
 import { type AppViews, emptyViews, getAppViews, unavailableViews } from './app-views.service';
 
 /**
@@ -84,6 +85,42 @@ export type AppAnalytics = {
     active: number;
     /** New installs per bucket within the range. */
     series: AnalyticsTimePoint[];
+    /**
+     * TRUE when an install row CANNOT EXIST for the app(s) in scope — every one
+     * of them is page-only, and a page app is stateless by explicit decision
+     * (`src/pages/apps/run/[slug]/[[...path]].tsx`: "STATELESS (Decision 2): no
+     * `block_user_subscriptions` row, no migration"). The zeros above are then a
+     * CATEGORY ERROR, not a measurement of user behaviour.
+     *
+     * This is a THIRD state, and the whole point is that it stays distinct from
+     * the other two:
+     *   1. measured non-zero — a model-slot app with installs;
+     *   2. measured zero — a model-slot app that genuinely has none YET. This
+     *      MUST still render `0`; it is a real, actionable number.
+     *   3. not applicable — this flag.
+     * Collapsing 3 into 2 is the defect (a page author reads `Installs 0` as
+     * "nobody installed me" when nobody CAN). Collapsing 2 into 3 would be a NEW
+     * defect — it would hide a truthful zero behind an excuse.
+     *
+     * PER-SECTION, exactly like `views.unavailable`, and for the same reason:
+     * inapplicability of installs says nothing about the runs / Buzz / loads
+     * counters in the same response, which are genuinely measured for a page
+     * app. A payload-level flag would discard that good data. Distinct NAME on
+     * purpose — `views.unavailable` means "we could not ask"; this means "we
+     * asked, and the question is meaningless for this app".
+     *
+     * 🔴 NEVER set when a counter is non-zero. A `block_user_subscriptions` row
+     * for a page app is not merely hypothetical: `upsertSubscription` applies no
+     * slot check, and `assertLaunchAppForCaller` (blocks.router.ts) admits ANY
+     * page-declaring app — so if `app-blocks-enabled` is ever widened past mods,
+     * rows can appear against a stateless app. If that happens the author must
+     * SEE the number, not an "n/a" that hides it. See `installsNotApplicable`.
+     *
+     * MIXED OWNERSHIP: on the "All my apps" (no `appBlockId`) read the flag is
+     * set only when EVERY owned app is page-only. One installable app in the set
+     * makes the aggregate a real measurement, so it is reported as one.
+     */
+    notApplicable?: boolean;
   };
   runs: {
     /** Generations/runs through the app within the range. */
@@ -143,6 +180,15 @@ export function emptyAnalytics(
     range,
     notOwned,
     ...(unavailable ? { unavailable } : {}),
+    // `installs.notApplicable` is deliberately NOT set on any of these paths.
+    // It is a claim about the app's MANIFEST (page-only ⇒ no install row can
+    // exist), and on every path that reaches here we either never resolved a
+    // manifest (notEntitled / notOwned — the payload-level `unavailable` above
+    // is what tells the client those zeros are fabricated) or the caller owns no
+    // apps at all, where "you have no apps, so you have no installs" is a
+    // truthful measured zero (see the DECIDED note on `unavailable`). Asserting
+    // inapplicability without having read a manifest would fabricate a
+    // DIFFERENT claim in place of the one this payload already makes.
     installs: { total: 0, active: 0, series: [] },
     runs: { count: 0, buzzSpent: 0, series: [] },
     buzzPurchased: { count: 0, buzzAmount: 0, grossCents: 0 },
@@ -181,25 +227,77 @@ export function resolveRange(input: { from?: Date; to?: Date; now?: Date }): App
   return { from, to, granularity };
 }
 
+/** The owned-app fields analytics reads: the id, plus the manifest that decides
+ *  whether an install row is even possible (see `installsNotApplicable`). */
+export type OwnedAppBlock = { id: string; manifest: unknown };
+
 /**
- * The app_block ids the caller owns, optionally narrowed to a single
- * requested id. Returns [] when the requested id isn't theirs (or they
- * own nothing) — the callers then fail closed to an empty result.
+ * The app_blocks the caller owns, optionally narrowed to a single requested id.
+ * Returns [] when the requested id isn't theirs (or they own nothing) — the
+ * callers then fail closed to an empty result.
+ *
+ * The manifest rides along on this ONE query rather than a second round trip:
+ * `getMyAppAnalytics` fans out per approved app row (see the note on
+ * VIEWS_QUERY_TIMEOUT_SECONDS), so an extra query here is paid N times per page
+ * load for a value the same `findMany` already has in hand.
  */
-export async function getOwnedAppBlockIds({
+export async function getOwnedAppBlocks({
   ownerUserId,
   appBlockId,
 }: {
   ownerUserId: number;
   appBlockId?: string;
-}): Promise<string[]> {
+}): Promise<OwnedAppBlock[]> {
   const owned = await dbRead.appBlock.findMany({
     where: { app: { userId: ownerUserId } },
-    select: { id: true },
+    select: { id: true, manifest: true },
   });
-  const ownedIds = owned.map((a) => a.id);
-  if (!appBlockId) return ownedIds;
-  return ownedIds.includes(appBlockId) ? [appBlockId] : [];
+  if (!appBlockId) return owned;
+  return owned.filter((a) => a.id === appBlockId);
+}
+
+/**
+ * The app_block ids the caller owns, optionally narrowed to a single
+ * requested id. Returns [] when the requested id isn't theirs (or they
+ * own nothing) — the callers then fail closed to an empty result.
+ */
+export async function getOwnedAppBlockIds(args: {
+  ownerUserId: number;
+  appBlockId?: string;
+}): Promise<string[]> {
+  return (await getOwnedAppBlocks(args)).map((a) => a.id);
+}
+
+/**
+ * Is the installs section a CATEGORY ERROR for this set of apps? See
+ * `AppAnalytics['installs'].notApplicable` for the three states this keeps
+ * apart. Exported so the rule has exactly one home and one test target.
+ *
+ * `hasInstallSlot` is the SHARED predicate — the same one the marketplace card
+ * (`components/Apps/AppBlockCard.tsx`) and the app detail page use to decide
+ * whether to show the Install CTA. Reusing it is the point: "the panel says
+ * installs are n/a" and "the product offers no way to install this" can then
+ * never disagree, because they are the same function over the same manifest.
+ *
+ * The `total`/`active` guard is not belt-and-braces, it is the state-(1) guard —
+ * a real count is ALWAYS reported, even for an app whose slots say it should not
+ * have one. Getting this backwards hides data behind an excuse.
+ */
+export function installsNotApplicable({
+  ownedApps,
+  total,
+  active,
+}: {
+  ownedApps: Array<{ manifest?: unknown }>;
+  total: number;
+  active: number;
+}): boolean {
+  // No apps resolved: nothing to make a claim about. The caller's own
+  // owns-nothing / notOwned handling covers this; see emptyAnalytics.
+  if (ownedApps.length === 0) return false;
+  // Never hide a measured count behind "not applicable".
+  if (total > 0 || active > 0) return false;
+  return !ownedApps.some((a) => hasInstallSlot(a.manifest as InstallSlotManifest | null));
 }
 
 /**
@@ -223,7 +321,8 @@ export async function getMyAppAnalytics({
   now?: Date;
 }): Promise<AppAnalytics> {
   const range = resolveRange({ from, to, now });
-  const ownedIds = await getOwnedAppBlockIds({ ownerUserId: userId, appBlockId });
+  const ownedApps = await getOwnedAppBlocks({ ownerUserId: userId, appBlockId });
+  const ownedIds = ownedApps.map((a) => a.id);
 
   // Fail closed: a specifically-requested id that the caller does not own
   // yields zeroed analytics flagged notOwned (never another owner's data).
@@ -347,6 +446,14 @@ export async function getMyAppAnalytics({
   const apiCalls = invocationsAgg;
   const activeUsers = Number(distinctUsers[0]?.value ?? 0);
   const errorRate = apiCalls > 0 ? errorCount / apiCalls : 0;
+  // Page-only app(s): an install row cannot exist, so the zeros below are a
+  // category error rather than a measurement. Omitted (not `false`) when the
+  // number IS a measurement, matching `views.unavailable`.
+  const notApplicable = installsNotApplicable({
+    ownedApps,
+    total: installsTotal,
+    active: installsActive,
+  });
 
   return {
     range,
@@ -358,6 +465,7 @@ export async function getMyAppAnalytics({
         bucket: r.bucket.toISOString(),
         value: Number(r.value),
       })),
+      ...(notApplicable ? { notApplicable: true } : {}),
     },
     runs: {
       count: runsAgg._count ?? 0,


### PR DESCRIPTION
## The problem

App analytics renders **`Installs 0`** for every approved app on the platform. That number is not a measurement of user behaviour — it is a **category error**.

Measured against prod (2026-08-05, read-only `SELECT`s):

| status | app | `manifest.page.path` | `manifest.targets` | subscription rows |
|---|---|---|---|---|
| approved | all 9 (`gen-matrix`, `buzz`, `prompt-vault`, …) | `/` | *(key absent)* | **0** |
| suspended | `generate-from-model` | — | `[model.sidebar_top]` | **3** |
| suspended | `who-am-i` | — | `[model.sidebar_top]` | **1** |
| suspended | `hello-world`, `model-notes` | — | `[model.sidebar_top]` | **0** |

The populations are **disjoint by design**. Only a model-slot app can get a `block_user_subscriptions` row; every *approved* app is a page app, and a page app is stateless by explicit decision — `src/pages/apps/run/[slug]/[[...path]].tsx`: *"STATELESS (Decision 2): no `block_user_subscriptions` row, no migration."* `LAUNCH_SLOT_IDS = ['app.page']` is the single source of truth for the public launch and contains no `model.*` slot.

So a page author reads *"nobody installed my app"* off a counter that could never have been anything else — sitting next to genuinely-measured run and Buzz numbers. The counter itself is **not broken**: a positive control against prod returned non-zero (3 installs for one owner, 1 for another), cross-checked against `app_listing_metrics.install_count`, which is computed by a separate production job with its own SQL and also reads 3. Confirmed end-to-end through the real CLI: `civitai app metrics who-am-i` prints `Installs Total 1 / Active 1` while `gen-matrix` prints `0 / 0`, both on the default window.

This is the same defect class as `notOwned` (#3557) and `views.unavailable` (#3613).

## The three states

The whole value of the change is that these stay apart:

1. **measured non-zero** — a model-slot app with installs → render the number;
2. **measured zero** — a model-slot app with none *yet* → **still render `0`**. It is a real, actionable answer;
3. **not applicable** — a page app → render an em dash and say why.

Collapsing **3 into 2** is the bug. Collapsing **2 into 3** would be a *new* bug, and the one that would regress **silently** — every visible symptom of "the fix works" looks identical if a truthful zero starts hiding too. All three states exist in prod today (table above), so all three have real fixtures.

## Mechanism, and why

**Server-side, per-section flag: `installs.notApplicable?: boolean`.**

- **Server-side** because two consumers need it — this panel and `civitai app metrics`. A client-side rule would have to be written twice and drift once.
- **Per-section**, exactly like `views.unavailable`: installs being inapplicable says nothing about the runs / Buzz / App-loads counters in the same response, which are genuinely measured for a page app. A payload-level flag would throw away good data — the reason `views` got its own flag rather than a third value on `unavailable`.
- **Different name on purpose.** `views.unavailable` = *"we could not ask"*. `installs.notApplicable` = *"we asked, and the question is meaningless for this app"*. Both render an em dash; they are not the same claim and get different copy.
- **Computed from the existing shared predicate**, `hasInstallSlot(manifest)` (`shared/constants/slot-registry.ts`) — the same function `components/Apps/AppBlockCard.tsx` and `pages/apps/[appBlockId]` already use to decide whether to show the Install CTA. Reusing it rather than inventing a parallel rule means *"the panel says installs are n/a"* and *"the product offers no way to install this"* cannot disagree: they are one function over one manifest.
- **No extra query.** The manifest rides along on the ownership `findMany` (`select: { id: true, manifest: true }`). `getMyAppAnalytics` fans out per approved app row in the submissions list, so a second round trip would be paid N times per page load — the same cost argument as `VIEWS_QUERY_TIMEOUT_SECONDS`.
- **Absent, not `false`, when it does not apply** — matching `views.unavailable`, so a client cannot distinguish "measured" from "old server" by key presence alone and is nudged to treat absent as measured (which is exactly today's behaviour).

### 🔴 The flag is never set when a counter is non-zero

Not defensive padding — it is the state-(1) guard, and it is not hypothetical. See the comment fix below: `BlockRegistry.upsertSubscription` applies **no** slot check, and `assertLaunchAppForCaller` admits **any** page-declaring app. A `block_user_subscriptions` row can exist against a stateless app. If one does, the author sees the number rather than an "n/a" that hides it.

### Mixed ownership

On the "All my apps" read the flag is set only when **every** owned app is page-only. One installable app in the set makes the aggregate a real measurement, so it is reported as one.

### Where it is deliberately *not* set

The `notOwned` / `notEntitled` / owns-nothing payloads never carry it. It is a claim about the app's **manifest**, and on those paths either no manifest was resolved (the payload-level `unavailable` is what says those zeros are fabricated) or the caller owns no apps, where "you have no apps, so you have no installs" is a truthful measured zero. Asserting inapplicability there would fabricate a *different* claim in place of the one the payload already makes.

## Second change: a stale comment hiding a latent write hole

`assertLaunchAppForCaller` (`blocks.router.ts`) claimed the subscription path *"is always a non-launch app and is rejected"* for non-mods, on the reasoning that only a model-slot app takes a subscription. **That is not what the code does.** The predicate is:

```ts
if (isLaunchSlot(PAGE_SLOT_ID) && declaresPage) return; // a launch page app
```

`PAGE_SLOT_ID === 'app.page'` **is** in `LAUNCH_SLOT_IDS`, so `isLaunchSlot(PAGE_SLOT_ID)` is a compile-time-constant `true` and this reduces to `if (declaresPage) return`. Every approved app in prod declares `page.path` (table above), so the gate **admits all of them** for a non-mod caller — and nothing downstream applies a slot check either.

Currently harmless only because `enforceAppBlocksFlag` is mod-only: **the flag, not this function, is what keeps non-mods off the path.** Widening `app-blocks-enabled` beyond moderators would start writing invisible `block_user_subscriptions` rows against stateless apps with no UI to manage them.

**Behaviour is deliberately unchanged.** This PR corrects the comment (both copies — the doc block and the inline one at the call site) and adds a **characterisation test** pinning what actually happens, so a later change to it is a visible, intentional edit rather than a silent one. The note names the fix if someone decides to close it (`hasInstallSlot(manifest)` on the subscription path).

## Verification

- **17 mutants, all killed, each at its own assertion** (not by a neighbour's error). Every one deletes nothing — they flip logic:

  | # | mutation | killed by |
  |---|---|---|
  | M1 | discriminator always-ON | `(2) does NOT flag a model-slot app with a truthful zero` + 9 more |
  | M2 | discriminator always-OFF | `(3) flags a set whose every app is page-only` + 5 more |
  | M3 | slot predicate inverted | both (2) and (3) families, 11 tests |
  | M4 | drop the non-zero guard (collapse 1 into 3) | `(1) NEVER hides a non-zero count behind "not applicable"` |
  | M5 | drop the empty-set guard | `does NOT flag an empty owned set` |
  | M6 | `some` → `every` | `does NOT flag a MIXED set` |
  | M7 | wiring: never emit the flag | `(3) flags a PAGE app whose installs are structurally impossible` |
  | M8 | wiring: always emit the flag | `(2) leaves a model-slot app with a truthful zero UNflagged` |
  | M9 | drop `manifest` from the `select` | `getOwnedAppBlockIds` select assertion |
  | M10 | renderer: em dash off `active === 0` | `(2) a measured ZERO still renders 0` |
  | M11 | renderer: card sub-line ignores the flag | `(3) a PAGE app renders an em dash and says why` |
  | M12 | renderer: chart card ignores the flag | `(3) the installs CHART is replaced by the explanation` |
  | M13 | router: page apps no longer admitted | `(a-page) non-mod + PAGE app → ADMITTED and UPSERTS` |
  | M14 | renderer: value ternary ignores the flag | `(3) a PAGE app renders an em dash…` |
  | M15 | `\|\|` → `&&` in the non-zero guard | `(1) NEVER hides a non-zero count…` |
  | M16 | ownership filter inverted | 12 tests incl. the cross-owner-leak pins |
  | M17 | ownership filter ignores the requested id | 9 tests |

  Every file restored byte-identically, `sha256`-verified by the harness; `git status` clean afterwards.

- **Counted, not exit-coded:** node tier `138 passed / 0 failed` across `app-analytics.service`, `app-views.service`, `blocks.router.subscriptions`, `blocks.router.getMyAppAnalytics`, `slot-registry`. Component tier run one file at a time: `AppAnalyticsPanel` 19/19, `AppAnalyticsInline` 2/2, `AppBlockCard` 32/32.
- **Typecheck 0 errors** — with a positive control: injecting one deliberate type error made the same invocation report exactly 1, so the zero is a fact about the code and not about a silently-OOMing tsc.
- **Prettier clean** on every changed file (the check flagged 3 files before `--write` and 0 after, so it demonstrably can go red).
- Re-verified after rebasing onto current `origin/main`.
- Local browser is non-canonical (`PLAYWRIGHT_BROWSERS_PATH=/tmp/…`); CI's `component-tests` job is the authority.

## Follow-up (not in this PR)

`civitai app metrics` renders the same number and needs a matching change in **`civitai/cli`** — `printAppMetrics` should branch on `installs.notApplicable` exactly as it already branches on `notOwned` and `views.unavailable`, and `--json` should pass the field through while still exiting 0. **No ordering hazard:** the field is optional, and an older CLI that ignores it renders exactly as it does today (pinned by the `an ABSENT notApplicable key (old pod, rolling deploy)` test here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aj1HosDFkP6LgxMAtJdDmJ
