### PR TITLE
test(apps): pin that every metric-card label resolves to exactly one element

### DIFF
--- a/src/components/AppBlocks/AppAnalyticsPanel.browser.test.tsx
+++ b/src/components/AppBlocks/AppAnalyticsPanel.browser.test.tsx
@@ -540,3 +540,67 @@ describe('AppAnalyticsPanel — top-N cards are humanised, not raw tokens', () =
     expect(page.getByText('ai:write:budgeted').elements()).toHaveLength(0);
   });
 });
+
+/**
+ * 🔴 EVERY METRIC-CARD LABEL MUST RESOLVE TO EXACTLY ONE ELEMENT.
+ *
+ * This is a CLASS guard, not a nit. `getByText` in vitest browser mode is
+ * SUBSTRING + CASE-INSENSITIVE, so any other rendered text containing a card's
+ * label — most easily the coverage note two rows below it — makes that label's
+ * locator resolve to 2 elements, and every assertion using it dies with a
+ * strict-mode violation after the matcher timeout.
+ *
+ * That has now happened three times in this panel's history, twice while
+ * FIXING it:
+ *   - civitai#3606  `getByText('Generations')` collided with a tooltip whose
+ *                   copy contained the word.
+ *   - a later edit   put a literal `<strong>—</strong>` in the alert, which
+ *                   collided with `getByText('—', { exact: true })`.
+ *   - a later edit   put the literal string "Active installs" in the alert,
+ *                   which collided with the card label and killed five tests.
+ *
+ * Each cost a debugging cycle and each was invisible in review, because the
+ * copy reads perfectly and the collision only exists at query time. So the rule
+ * is pinned here rather than written in a comment somebody has to remember:
+ *
+ *   Alert/caption/tooltip copy must NOT contain a metric card's label verbatim.
+ *   Refer to the metric descriptively instead ("the engagement figures below",
+ *   "the installs figure"), or the guard below fails.
+ *
+ * It also caught a LATENT one when written: the coverage note used to open
+ * "Active users, API calls, and error rate…", so `Active users` already
+ * resolved to 2 — harmless only because no test happened to use that locator
+ * yet. Measured before the fix: `Active users=2`, every other label `=1`.
+ */
+describe('AppAnalyticsPanel — metric-card labels stay unambiguous', () => {
+  const CARD_LABELS = [
+    'Active installs',
+    'Runs (range)',
+    'Buzz purchased',
+    'Active users',
+    'App loads (range)',
+  ];
+
+  test('each card label resolves to exactly one element', async () => {
+    mocks.analytics.current = { ...ZEROED };
+    renderWithProviders(<AppAnalyticsPanel scopedAppBlockId="apb_1" />);
+    await expect.element(page.getByText('Active installs', { exact: true })).toBeInTheDocument();
+
+    for (const label of CARD_LABELS) {
+      const n = page.getByText(label).elements().length;
+      expect(
+        n,
+        `"${label}" resolved to ${n} elements. Some other copy on this panel contains it ` +
+          `verbatim — getByText is substring+case-insensitive, so every locator using this ` +
+          `label is now a strict-mode violation. Reword the copy to refer to the metric ` +
+          `descriptively instead of naming it.`
+      ).toBe(1);
+    }
+  });
+
+  test('the label list itself is not silently empty', () => {
+    // Positive control: a guard that iterates an empty list passes vacuously
+    // and would report green while checking nothing.
+    expect(CARD_LABELS.length).toBeGreaterThanOrEqual(5);
+  });
+});

--- a/src/components/AppBlocks/AppAnalyticsPanel.tsx
+++ b/src/components/AppBlocks/AppAnalyticsPanel.tsx
@@ -422,7 +422,7 @@ export function AppAnalyticsPanel({ scopedAppBlockId }: { scopedAppBlockId?: str
             title="What engagement counts"
           >
             <Text size="sm">
-              Active users, API calls, and error rate reflect only{' '}
+              The engagement figures below reflect only{' '}
               <strong>authenticated, scope-gated API calls</strong> your app makes. A static block
               (or one with no scoped API surface) will show revenue but flat engagement.{' '}
               <strong>App loads</strong> is the exception — it is measured on every load, so it


### PR DESCRIPTION
Turns a lesson this panel has now learned **three times** into a guard, and fixes a fourth instance that was already latent on `main`.

## The class

`getByText` in vitest browser mode is **substring + case-insensitive**. So any other rendered text containing a card's label — most easily the coverage note two rows below it — makes that label's locator resolve to **2 elements**, and every assertion using it dies with a strict-mode violation after the matcher timeout.

It is invisible in review: the copy reads perfectly, and the collision only exists at query time.

| when | what collided |
|---|---|
| #3606 | `getByText('Generations')` vs a tooltip containing the word |
| a later edit | a literal `<strong>—</strong>` vs `getByText('—', { exact: true })` |
| a later edit | the literal `"Active installs"` in the alert — **killed five tests** |

Twice of those three happened *while fixing the class*, which is the argument for a guard over a comment.

## The fourth was already on main

The coverage note opened with *"Active users, API calls, and error rate…"*, so **`Active users` already resolved to 2**. Harmless only because no test happened to use that locator yet — the next person to write one would have paid for it.

Measured before the fix: `Active users=2`, every other label `=1`. The note now reads *"The engagement figures below"*, which is also better copy than enumerating three of them.

## The guard

Asserts each card label resolves to exactly **1** element, with a failure message that names the cause and the remedy rather than just the count. It carries a **positive control on the label list itself**, because a guard iterating an empty list passes vacuously and would report green while checking nothing.

## Mutation proof — and the two results together are the argument

| mutation | result |
|---|---|
| **L1** reintroduce the shipped defect (`"Active installs"` in prose) | guard fires, **and 4 unrelated tests die on 15s strict-mode timeouts** |
| **L2** restore the latent one from `main` (`"Active users"`) | **only the new guard fires, in 147ms**, with a diagnostic message |

**L2 is the point.** That case broke nothing else, so it would have shipped and cost a debugging cycle later. The guard converts a silent 15-second mystery into a fast, self-explaining failure at the moment the copy is written.

Component file **21/21**; `AppAnalyticsInline` 2/2; typecheck **0 errors**; prettier clean. Non-canonical browser locally — CI's component job is the authority.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Aj1HosDFkP6LgxMAtJdDmJ
