### PR TITLE
fix(app-blocks): raise the starter recipe ceiling 30→90 so it survives a cold worker

### DIFF
--- a/src/server/services/blocks/recipes/__tests__/starter-comfy-txt2img.recipe.test.ts
+++ b/src/server/services/blocks/recipes/__tests__/starter-comfy-txt2img.recipe.test.ts
@@ -185,19 +185,29 @@ describe('starterComfyTxt2imgRecipe contract', () => {
     expect(starterComfyTxt2imgRecipe.resolveEngine(params('y', 7))).toBe('default');
   });
 
-  it('honors the post-paid ceiling contract: maxBuzz === ceil(stepTimeoutSeconds) === 30', () => {
-    expect(STARTER_BUDGET).toEqual({ stepTimeoutSeconds: 30, maxBuzz: 30 });
+  it('honors the post-paid ceiling contract: maxBuzz === ceil(stepTimeoutSeconds) === 90', () => {
+    expect(STARTER_BUDGET).toEqual({ stepTimeoutSeconds: 90, maxBuzz: 90 });
     expect(STARTER_BUDGET.maxBuzz).toBe(Math.ceil(STARTER_BUDGET.stepTimeoutSeconds));
   });
 
-  it('budgetFor / budgetForEngine both return the ceiling-30 budget', () => {
+  // Regression guard for the cold-start expiry: `stepTimeoutSeconds` is wall-clock for
+  // the WHOLE step (worker spin-up + checkpoint download + sampling), not just the few
+  // seconds a warm turbo gen takes. At 30 this recipe expired on a cold worker, so the
+  // first thing a new App developer runs failed on first use with a bare `expired`.
+  // Floor it well clear of a cold start; raising the ceiling is free because billing
+  // settles to actual GPU-seconds. See STARTER_BUDGET's note for the measurement.
+  it('keeps the ceiling clear of a cold start (must not regress toward the 30s expiry)', () => {
+    expect(STARTER_BUDGET.stepTimeoutSeconds).toBeGreaterThanOrEqual(90);
+  });
+
+  it('budgetFor / budgetForEngine both return the ceiling-90 budget', () => {
     expect(starterComfyTxt2imgRecipe.budgetFor(params('x'))).toEqual({
-      maxBuzz: 30,
-      stepTimeoutSeconds: 30,
+      maxBuzz: 90,
+      stepTimeoutSeconds: 90,
     });
     expect(starterComfyTxt2imgRecipe.budgetForEngine('default')).toEqual({
-      maxBuzz: 30,
-      stepTimeoutSeconds: 30,
+      maxBuzz: 90,
+      stepTimeoutSeconds: 90,
     });
   });
 

--- a/src/server/services/blocks/recipes/starter-comfy-txt2img.recipe.ts
+++ b/src/server/services/blocks/recipes/starter-comfy-txt2img.recipe.ts
@@ -64,13 +64,31 @@ export const STARTER_ESTIMATE_BUZZ = 15;
 
 // ── POST-PAID BUDGET (single engine) ──────────────────────────────────────────
 // `maxBuzz` MUST equal `ceil(stepTimeoutSeconds × 1)` (asserted at registry load):
-// the step `timeout` is the PHYSICAL cap (~1 Buzz/GPU-second). A cheap single-step
-// Z-Image turbo gen finishes in seconds, so 30 is generous headroom while keeping a
-// tight blast-radius ceiling. The router reserves this ceiling on every cap and
-// settles-to-actual.
+// the step `timeout` is the PHYSICAL cap (~1 Buzz/GPU-second). The router reserves
+// this ceiling on every cap and settles-to-actual.
+//
+// 🔴 THE CEILING MUST COVER COLD START, NOT JUST EXECUTION. This value was 30 on the
+// reasoning that "a cheap single-step Z-Image turbo gen finishes in seconds" — true
+// of the generation, and irrelevant to the timeout. `stepTimeoutSeconds` is
+// wall-clock for the WHOLE step, so it also spans worker spin-up and checkpoint
+// download. On a cold worker 30s expires before the first sample: measured
+// 2026-08-06, this recipe's own sample body expired cold at 30 and then succeeded
+// for 4 Buzz once weights were warm. That made the starter recipe — the first thing
+// a new App developer runs, and the one most likely to hit a cold worker — fail on
+// first use, reporting a bare `expired` with no message.
+//
+// 90 matches the lowest per-engine ceiling already shipped by seamless-pano
+// (90/150/180) and is ~3× the slowest warm inline run observed (55s). Raising it is
+// free: billing settles to actual GPU-seconds, so the ceiling costs nothing unless
+// it is actually consumed — an over-tight value buys no savings and only converts a
+// slow start into a silent failure.
+//
+// ⚠️ Scope of the evidence: ONE cold-start observation, not a distribution. If cold
+// starts are found to exceed 90s (a larger checkpoint, a colder pool), raise this
+// again rather than concluding the timeout is the wrong mechanism.
 export const STARTER_BUDGET: { stepTimeoutSeconds: number; maxBuzz: number } = {
-  stepTimeoutSeconds: 30,
-  maxBuzz: 30,
+  stepTimeoutSeconds: 90,
+  maxBuzz: 90,
 };
 
 // ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## The bug

`stepTimeoutSeconds` is wall-clock for the **whole** `customComfy` step — worker spin-up and checkpoint download included — not just sampling time. The starter recipe's ceiling was 30, set on the reasoning recorded in its own comment:

> A cheap single-step Z-Image turbo gen finishes in seconds, so 30 is generous headroom

That is true of the generation and irrelevant to the timeout.

**Consequence:** the starter recipe is the first thing a new App developer runs, and the one most likely to hit a cold worker — so it failed on first use, reporting a bare `expired` with no message.

## Evidence

Measured 2026-08-06 during a blind dogfood of the App Blocks platform. A developer working only from public docs hit this as one of their first dead ends. The control is clean: **this recipe's own sample body expired cold at 30, then succeeded for 4 Buzz once weights were warm** — same body, same params, only the worker's warmth differing.

The same 30s value was already found too short elsewhere in this codebase. From `app-block-runtime.metrics.ts`:

> The 30s cap was dropping real slow successes in a slowness-correlated way

## Why 90

- Matches the lowest per-engine ceiling `seamless-pano` already ships (90/150/180), so it introduces no new magnitude.
- ~3× the slowest warm inline run observed in the same session (55s).
- **Raising it is free.** Billing settles to actual GPU-seconds, so the ceiling costs nothing unless actually consumed. An over-tight value buys no savings — it only converts a slow start into a silent failure.

`maxBuzz === ceil(stepTimeoutSeconds)` is asserted at registry load, so both values move together.

⚠️ **Scope of the evidence:** one cold-start observation, not a distribution. If cold starts are found to exceed 90s (larger checkpoint, colder pool), raise this again rather than concluding the timeout is the wrong mechanism. That caveat is recorded in the code comment too.

## Tests

Adds a regression guard flooring the ceiling at 90, written as a separate assertion from the equality checks so it fails for **its own** reason rather than passing on a sibling's failure.

Verified red-then-green, not just green:

- **at 30** — 3 failed / 17 passed; the new guard fails with `expected 30 to be greater than or equal to 90`
- **at 90** — recipes suite **50/50 green** (both `starter-comfy-txt2img` and `seamless-pano`)
- **typecheck** — identical at `origin/main` and at HEAD, none in the touched files; this change introduces none.

> **Correction to the typecheck line.** It originally read "12 errors at `origin/main`, 12 errors at HEAD … all pre-existing in `image.service.ts` / `bitdex-stats.ts`." The differential conclusion stands — identical on both sides, so this change adds nothing — but the characterisation was wrong and worth correcting so nobody carries it forward. **Those 12 were an artefact of an uninitialised `event-engine-common` submodule, not real errors in this repo.** With the submodule initialised the baseline is **0**, confirmed independently on another branch with a positive control (an injected type error reported `1 type error(s)`). `image.service.ts` and `bitdex-stats.ts` do not have pre-existing type errors. Separately worth knowing: `tsconfig.json` excludes `src/**/__tests__/**`, so typecheck never covers test files — a "typecheck clean" claim on a test-only change in this repo proves nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
