### PR TITLE
fix(generation): split `api` out of the `onsite` model-substitution surface (#3665)

### DIFF
--- a/src/pages/api/metrics.ts
+++ b/src/pages/api/metrics.ts
@@ -6,7 +6,20 @@ import { instrumentationRegistry } from '~/server/prom/client';
 // Side-effect import: registers the challenge state gauges (collect()-based) on the default
 // registry so they are present + scraped even before the first challenge op runs this session.
 import '~/server/prom/challenge.metrics';
+// Same reason (#3665): seeds all 12 (reason, surface) series of
+// civitai_generation_model_substitutions_total at 0. Without this call the
+// counter is registered only by the FIRST substitution on this pod, so
+// `…{surface="api"}` read `no data` until then — indistinguishable from an
+// unwired instrument, on a metric whose entire job is to be read as a gate.
+//
+// Next.js loads an API route lazily, so this runs on the first REQUEST to
+// /api/metrics rather than at pod start — which is exactly soon enough: the
+// only consumer is the scrape, and this module is what serves it, so the series
+// are present in every response that could ever observe them.
+import { ensureRegisterGenerationModelSubstitutionMetrics } from '~/server/metrics/generation-model-substitution.metrics';
 import { WebhookEndpoint } from '~/server/utils/endpoint-helpers';
+
+ensureRegisterGenerationModelSubstitutionMetrics();
 
 const labels: Record<string, string> = {};
 if (process.env.PODNAME) {

--- a/src/server/metrics/__tests__/generation-model-substitution.metrics.test.ts
+++ b/src/server/metrics/__tests__/generation-model-substitution.metrics.test.ts
@@ -31,12 +31,13 @@ import {
  *      500 — observability causing the outage.
  *
  * 🔴 CARDINALITY is the other load-bearing property: `reason` (3 values) x
- * `surface` (3 values) = 9 series, total, forever, across ~130 scraped pods
+ * `surface` (4 values) = 12 series, total, across ~130 scraped pods
  * where prom-client retains every distinct label set in the Node heap for the
  * process lifetime. Widening it has to get past these tests.
  *
  * 🔴 SURFACE is load-bearing for a different reason: `validateInput` is shared
- * by the on-site generator, the App Blocks bridge and preset generation, and
+ * by the on-site generator, bearer-token API callers, the App Blocks bridge and
+ * preset generation, and
  * #3520 calls the substitution CORRECT on-site and unobservable through the
  * bridge. Summed into one series the counter measures a contaminated quantity,
  * which is exactly what phase 2 is supposed to produce a clean number for.
@@ -74,6 +75,63 @@ describe('civitai_generation_model_substitutions_total', () => {
   it('is registered on the default registry that /api/metrics scrapes', () => {
     ensureRegisterGenerationModelSubstitutionMetrics();
     expect(client.register.getSingleMetric(METRIC)).toBeDefined();
+  });
+
+  it('🔴 the help string documents EVERY declared surface and reason', async () => {
+    // The help text is what Grafana's metric browser shows, i.e. the definition
+    // a phase-3 consumer actually reads before writing a query. `api` was added
+    // to the union in #3665 and initially NOT to the help string, so the label
+    // this metric exists to expose was undocumented where it is consumed.
+    // Derived from the unions rather than hardcoded, so a future 5th surface
+    // cannot be added without describing it.
+    //
+    // 🔴 WHAT THIS DOES NOT CHECK: that each description is CORRECT, or even
+    // attached to the right label. `toContain` is satisfied by any occurrence of
+    // `<surface> = `, so a help string reading `api = block; block = …` passes
+    // (verified). It catches the regression it was written for — a surface added
+    // to the union and not to the help — and nothing more. Do not cite it as
+    // evidence that the help text is right.
+    ensureRegisterGenerationModelSubstitutionMetrics();
+    const metric = client.register.getSingleMetric(METRIC) as unknown as { help: string };
+    for (const surface of GENERATION_SURFACES) expect(metric.help).toContain(`${surface} = `);
+    for (const reason of MODEL_SUBSTITUTION_REASONS) expect(metric.help).toContain(`${reason} = `);
+  });
+
+  it('🔴 registration SEEDS all 12 series at 0 — an absent series must not read as a real zero', async () => {
+    // A pod only materialises a prom-client child on its first inc(), so before
+    // seeding `…{surface="api"}` simply did not exist until that pod happened to
+    // serve an API substitution — and PromQL returns `no data`, which looks
+    // exactly like "the instrument was never wired". This counter exists to be
+    // read as a GATE, so that ambiguity is the same defect the `api` split was
+    // made to fix (#3665), one level down.
+    ensureRegisterGenerationModelSubstitutionMetrics();
+    const metric = client.register.getSingleMetric(METRIC) as unknown as {
+      get(): Promise<{ values: Array<{ labels: Record<string, string>; value: number }> }>;
+    };
+    const { values } = await metric.get();
+
+    expect(values).toHaveLength(MODEL_SUBSTITUTION_REASONS.length * GENERATION_SURFACES.length);
+    expect(values.every((v) => v.value === 0)).toBe(true);
+    // Named explicitly: `api` is the surface this PR adds and the one a phase-3
+    // read will query first, so its presence-at-zero is the point.
+    expect(await readSeries('unrecognized', 'api')).toBe(0);
+    // Every declared combination, not just the one we thought of.
+    for (const reason of MODEL_SUBSTITUTION_REASONS)
+      for (const surface of GENERATION_SURFACES) expect(await readSeries(reason, surface)).toBe(0);
+  });
+
+  it('seeding is idempotent — re-registering does not reset or double-count a live series', async () => {
+    // `ensureRegister…` is documented as safe to call on every request, and
+    // `recordGenerationModelSubstitution` does call it every time. If seeding
+    // reset the counters, the metric would read ~0 forever under real traffic —
+    // a failure that a single-shot test would never show.
+    recordGenerationModelSubstitution('unrecognized', 'api');
+    recordGenerationModelSubstitution('unrecognized', 'api');
+    expect(await readSeries('unrecognized', 'api')).toBe(2);
+
+    ensureRegisterGenerationModelSubstitutionMetrics();
+    ensureRegisterGenerationModelSubstitutionMetrics();
+    expect(await readSeries('unrecognized', 'api')).toBe(2);
   });
 
   it.each(
@@ -159,16 +217,17 @@ describe('civitai_generation_model_substitutions_total', () => {
     for (const v of values) expect(Object.keys(v.labels).sort()).toEqual(['reason', 'surface']);
   });
 
-  it('🔴 both unions are EXACTLY these values — 3 x 3 = 9 series is the whole budget', () => {
+  it('🔴 both unions are EXACTLY these values — 3 x 4 = 12 series is the whole budget', () => {
     // Literal, not derived: the reason union is simultaneously the metric label
     // AND the `BlockWorkflowSnapshot.modelSubstitutions[].reason` wire contract,
     // so a fourth value added on either side has to come through here. The
-    // surface union bounds the other axis.
+    // surface union bounds the other axis — it went 3 → 4 in #3665, which is what
+    // this assertion is for: the widening had to be written down, not noticed later.
     expect([...MODEL_SUBSTITUTION_REASONS]).toEqual(['wrong-workflow', 'unrecognized', 'gated']);
-    expect([...GENERATION_SURFACES]).toEqual(['block', 'onsite', 'preset']);
+    expect([...GENERATION_SURFACES]).toEqual(['api', 'block', 'onsite', 'preset']);
   });
 
-  it('🔴 emits AT MOST 9 series no matter how many substitutions land', async () => {
+  it('🔴 emits AT MOST 12 series no matter how many substitutions land', async () => {
     for (let i = 0; i < 100; i++) {
       for (const reason of MODEL_SUBSTITUTION_REASONS) {
         for (const surface of GENERATION_SURFACES) {
@@ -180,7 +239,7 @@ describe('civitai_generation_model_substitutions_total', () => {
       get(): Promise<{ values: Array<{ labels: Record<string, string> }> }>;
     };
     const { values } = await metric.get();
-    expect(values).toHaveLength(9);
+    expect(values).toHaveLength(12);
     expect(await readSeries('wrong-workflow', 'block')).toBe(100);
   });
 
@@ -246,8 +305,8 @@ describe('emitModelSubstitutions — the drain the generation path calls', () =>
   });
 
   it("🔴 labels every increment with the COLLECTOR's surface, not a guess", async () => {
-    // The emitter sits inside `validateInput`, which is shared by all three
-    // surfaces; the only surface information that exists at that point is the one
+    // The emitter sits inside `validateInput`, which is shared by every
+    // surface; the only surface information that exists at that point is the one
     // the caller fixed when it built the context. Two collectors, two surfaces,
     // same reason — they must not merge.
     await emitModelSubstitutions(collectorWith('onsite', 'unrecognized'));

--- a/src/server/metrics/__tests__/metrics-endpoint-seeds-substitutions.test.ts
+++ b/src/server/metrics/__tests__/metrics-endpoint-seeds-substitutions.test.ts
@@ -1,0 +1,70 @@
+import client from 'prom-client';
+import { describe, expect, it, vi } from 'vitest';
+
+/**
+ * 🔴 THE SEAM: does loading the module that SERVES the scrape actually register
+ * and seed `civitai_generation_model_substitutions_total`? (#3665)
+ *
+ * Seeding all 12 `(reason, surface)` series is inert on its own.
+ * `ensureRegisterGenerationModelSubstitutionMetrics` has no caller outside its
+ * own module, and the only production path in is
+ * `recordGenerationModelSubstitution` — which by definition runs only AFTER a
+ * substitution has happened. So without a module-scope call from
+ * `src/pages/api/metrics.ts`, `…{surface="api"}` reads `no data` on a pod until
+ * its first API substitution: indistinguishable from an unwired instrument, on a
+ * metric whose entire job is to be read as a gate. Two components, each fine
+ * alone, broken together.
+ *
+ * 🔴 THIS IS BEHAVIOURAL ON PURPOSE, AND AN EARLIER REVISION WAS NOT. That
+ * revision asserted the seam by PARSING `metrics.ts` for a module-scope call,
+ * with a comment claiming the behavioural route was unavailable because
+ * importing the page throws `env.TRPC_ORIGINS is not iterable`. That claim was
+ * wrong: the repo already has the pattern for exactly this
+ * (`src/server/utils/__tests__/public-endpoint-maxage.test.ts` stubs the
+ * heavy module-load imports), and an audit used it to load the real page. The
+ * source check also false-failed at least six CORRECT refactors — `void f()`,
+ * a module-scope helper, a locally-aliased import, a relative specifier — while
+ * passing an `import type` + call, which only `tsc` would catch. It is replaced
+ * by this, which asks the question that actually matters: after the module
+ * loads, are the series there?
+ */
+
+// `endpoint-helpers` spreads `env.TRPC_ORIGINS` at module load; stub the wrapper
+// itself so none of that graph is needed.
+vi.mock('~/server/utils/endpoint-helpers', () => ({
+  WebhookEndpoint: (handler: unknown) => handler,
+}));
+vi.mock('~/server/db/client', () => ({ dbRead: {}, dbWrite: {} }));
+
+const METRIC = 'civitai_generation_model_substitutions_total';
+
+describe('/api/metrics registers + seeds the substitution counter at module load', () => {
+  it('NEGATIVE CONTROL: the counter is absent before the page module is loaded', () => {
+    expect(client.register.getSingleMetric(METRIC)).toBeUndefined();
+  });
+
+  it('🔴 after loading the page module, all 12 series exist at 0', async () => {
+    await import('~/pages/api/metrics');
+
+    const metric = client.register.getSingleMetric(METRIC) as unknown as
+      | { get(): Promise<{ values: Array<{ labels: Record<string, string>; value: number }> }> }
+      | undefined;
+    expect(metric).toBeDefined();
+
+    const { values } = await metric!.get();
+    // Derived from the unions, not hardcoded: a 5th surface must be seeded too.
+    const { GENERATION_SURFACES, MODEL_SUBSTITUTION_REASONS } = await import(
+      '~/shared/data-graph/generation/model-substitution'
+    );
+    expect(values).toHaveLength(GENERATION_SURFACES.length * MODEL_SUBSTITUTION_REASONS.length);
+    expect(values.every((v) => v.value === 0)).toBe(true);
+
+    // Named explicitly — `api` is the surface #3665 adds and the one a phase-3
+    // read queries first, so its presence-at-zero is the whole point.
+    for (const reason of MODEL_SUBSTITUTION_REASONS) {
+      expect(values.some((v) => v.labels.surface === 'api' && v.labels.reason === reason)).toBe(
+        true
+      );
+    }
+  });
+});

--- a/src/server/metrics/__tests__/metrics-endpoint-seeds-substitutions.test.ts
+++ b/src/server/metrics/__tests__/metrics-endpoint-seeds-substitutions.test.ts
@@ -17,16 +17,22 @@ import { describe, expect, it, vi } from 'vitest';
  *
  * 🔴 THIS IS BEHAVIOURAL ON PURPOSE, AND AN EARLIER REVISION WAS NOT. That
  * revision asserted the seam by PARSING `metrics.ts` for a module-scope call,
- * with a comment claiming the behavioural route was unavailable because
- * importing the page throws `env.TRPC_ORIGINS is not iterable`. That claim was
- * wrong: the repo already has the pattern for exactly this
- * (`src/server/utils/__tests__/public-endpoint-maxage.test.ts` stubs the
- * heavy module-load imports), and an audit used it to load the real page. The
- * source check also false-failed at least six CORRECT refactors — `void f()`,
+ * justified by a comment saying the behavioural route was unavailable because
+ * importing the page throws `env.TRPC_ORIGINS is not iterable`.
+ *
+ * 🔴 BE EXACT ABOUT WHICH HALF OF THAT WAS WRONG, since this file exists to stop
+ * comments overstating things. The MEASUREMENT was right — an unmocked import of
+ * the page really does throw exactly that. The CONCLUSION drawn from it ("so a
+ * behavioural test is not possible") was wrong: the repo already had the pattern
+ * for precisely this case, `src/server/utils/__tests__/public-endpoint-maxage.test.ts`,
+ * which stubs the heavy module-load imports. "My first attempt failed" is not
+ * "it cannot be done", and that is the whole error.
+ *
+ * The source check also false-failed at least six CORRECT refactors — `void f()`,
  * a module-scope helper, a locally-aliased import, a relative specifier — while
- * passing an `import type` + call, which only `tsc` would catch. It is replaced
- * by this, which asks the question that actually matters: after the module
- * loads, are the series there?
+ * PASSING an `import type` + call, which only `tsc` would catch. So it was both
+ * stricter and weaker than the property it stood for. This asks the question
+ * that actually matters instead: after the module loads, are the series there?
  */
 
 // `endpoint-helpers` spreads `env.TRPC_ORIGINS` at module load; stub the wrapper

--- a/src/server/metrics/emit-model-substitutions.ts
+++ b/src/server/metrics/emit-model-substitutions.ts
@@ -31,9 +31,9 @@ export async function emitModelSubstitutions(
     if (!pending.length) return;
     // The SURFACE comes off the collector, which got it from whoever built this
     // request's context (`buildGenerationContext(..., surface)`) — never guessed
-    // here. `validateInput` is shared by the on-site generator, the App Blocks
-    // bridge and preset generation, so this function structurally cannot tell
-    // them apart and must not try.
+    // here. `validateInput` is shared by the on-site generator, bearer-token API
+    // callers, the App Blocks bridge and preset generation, so this function
+    // structurally cannot tell them apart and must not try.
     const { surface } = collector;
     const { recordGenerationModelSubstitution } = await import(
       '~/server/metrics/generation-model-substitution.metrics'

--- a/src/server/metrics/generation-model-substitution.metrics.ts
+++ b/src/server/metrics/generation-model-substitution.metrics.ts
@@ -48,7 +48,8 @@
 // get-or-create guard against the DEFAULT global registry.
 //
 // 🔴 SURFACE, and why it is not optional. `validateInput` is shared by the
-// on-site generator, the App Blocks bridge, and comics/preset generation. #3520
+// on-site generator, bearer-token API callers (#3665), the App Blocks bridge,
+// and comics/preset generation. #3520
 // defends the on-site substitution as CORRECT (a stale localStorage id after an
 // ecosystem switch, visibly corrected in the picker) and indicts the bridge one
 // as unobservable — opposite verdicts, and without a `surface` label they land
@@ -58,8 +59,11 @@
 // time (`buildGenerationContext(..., surface)`), never inferred here.
 //
 // 🔴 CARDINALITY: exactly two labels, each over a code-owned union declared once
-// in `model-substitution.ts` → 3 reasons × 3 surfaces = 9 series, TOTAL,
-// forever. Deliberately NO version id, model id, ecosystem, workflow, app id, or
+// in `model-substitution.ts` → 3 reasons × 4 surfaces = 12 series, TOTAL.
+// (Was 9; #3665 split `api` out of `onsite`, which had been assigned by a
+// hardcoded literal on two tRPC procedures that also serve bearer-token callers.
+// Widening the union is deliberate and gated by tests on both unions.)
+// Deliberately NO version id, model id, ecosystem, workflow, app id, or
 // user id: this fires once per substituted parse with nothing caching it, the
 // requested version id is caller-controlled and effectively unbounded, and
 // prom-client retains every distinct label set in the Node heap forever (the
@@ -71,11 +75,52 @@
 import client, { type Counter, type Registry } from 'prom-client';
 
 import {
+  GENERATION_SURFACES,
   isGenerationSurface,
   isModelSubstitutionReason,
+  MODEL_SUBSTITUTION_REASONS,
   type GenerationSurface,
   type ModelSubstitutionReason,
 } from '~/shared/data-graph/generation/model-substitution';
+
+/**
+ * Initialise all 12 `(reason, surface)` series to 0 at registration.
+ *
+ * 🔴 WHY, AND WHY IT IS NOT COSMETIC. prom-client only materialises a child
+ * series on its first `inc()`, so before this a pod exposed NOTHING for a
+ * surface until that surface substituted on that pod. A PromQL read of
+ * `…{surface="api"}` then returns `no data`, which is indistinguishable from
+ * "the instrument is not wired" — and this counter exists specifically to be
+ * read as a gate. That is the same defect the `api` split was made to fix
+ * (#3665: a bucket that reads zero cannot gate a decision); leaving the new
+ * bucket unreadable on day 0 would reproduce it one level down. A real zero and
+ * an absent series must be distinguishable.
+ *
+ * Free by construction: 12 series is the counter's whole cardinality budget, so
+ * seeding costs exactly what a fully-exercised pod already costs and cannot
+ * grow.
+ *
+ * 🔴 SEEDING ALONE IS NOT ENOUGH, AND AN EARLIER VERSION OF THIS COMMENT SAID
+ * IT WAS. It claimed `rate()`/`increase()` become "well-defined from the first
+ * scrape". They do not, unless something CALLS this at pod start:
+ * `ensureRegister…` has no caller outside this module, and the only production
+ * path in is `recordGenerationModelSubstitution`, which by definition runs only
+ * once a substitution has already happened. So the metric was absent until the
+ * first event on that pod — exactly the ambiguity the seeding exists to remove.
+ * The missing half is the side-effect call in `src/pages/api/metrics.ts`
+ * (mirroring `~/server/prom/challenge.metrics` two lines above it, which is
+ * there for the same reason). Both halves are required; neither works alone.
+ *
+ * Idempotent — `getOrCreateCounter` returns the EXISTING counter on re-entry and
+ * `inc(…, 0)` is a no-op on an already-materialised series, so calling this on
+ * every request (which `ensureRegister…` is documented to allow) cannot reset or
+ * double-count anything.
+ */
+function seedAllSeries(counter: Counter<string>): void {
+  for (const reason of MODEL_SUBSTITUTION_REASONS) {
+    for (const surface of GENERATION_SURFACES) counter.inc({ reason, surface }, 0);
+  }
+}
 
 function getOrCreateCounter(
   reg: Registry,
@@ -102,9 +147,10 @@ export function ensureRegisterGenerationModelSubstitutionMetrics(reg: Registry =
     'Server-side generation GRAPH VALIDATIONS in which a modelLocked ecosystem SILENTLY replaced the requested checkpoint version with the workflow default. ' +
       'NOT a count of user-visible generations: the ratio is VARIABLE — a block submit normally validates twice (whatIf preflight + real submit), once if the preflight exceeds the buzz budget, plus one per estimateWorkflow call (unbounded) and one per idempotency replay. Use as a rate/trend per surface; attribute individual cases from the snapshot. ' +
       'reason (wrong-workflow = the version is scoped to a different workflow of the same ecosystem; unrecognized = the version is in no scoped list at all; gated = the version IS offered for this workflow but a gate rule hid it from this user). ' +
-      'surface (block = the App Blocks bridge, where the id was deliberate and the correction was unobservable; onsite = the on-site generator, where this substitution is the intended graceful degradation and is visible to the user; preset = comics/preset server-composed generation)',
+      'surface (api = the same two tRPC generation procedures reached with a bearer token — a CLI, script or external integration, where the id was deliberate and nothing reports the correction; block = the App Blocks bridge, where the id was deliberate and the correction was unobservable; onsite = the on-site generator under a COOKIE SESSION, where this substitution is the intended graceful degradation and is visible to the user; preset = comics/preset server-composed generation)',
     ['reason', 'surface']
   );
+  seedAllSeries(modelSubstitutionsTotal);
   return { modelSubstitutionsTotal };
 }
 
@@ -130,8 +176,8 @@ export function recordGenerationModelSubstitution(
   try {
     // 🔴 The cardinality bound rests HERE, on code, not on the erased types
     // above. An unknown reason or surface is DROPPED, not passed through and not
-    // relabelled to a plausible default — either would make the "9 series
-    // forever" claim a wish. Reachable today only by defeating the types.
+    // relabelled to a plausible default — either would make the "12 series"
+    // claim a wish. Reachable today only by defeating the types.
     if (!isModelSubstitutionReason(reason) || !isGenerationSurface(surface)) return;
     const { modelSubstitutionsTotal } = ensureRegisterGenerationModelSubstitutionMetrics();
     modelSubstitutionsTotal.inc({ reason, surface });

--- a/src/server/routers/orchestrator.router.ts
+++ b/src/server/routers/orchestrator.router.ts
@@ -10,6 +10,7 @@ import {
   updateWorkflow,
   whatIfFromGraph,
 } from '~/server/services/orchestrator/orchestration-new.service';
+import { generationSurfaceForRequest } from '~/server/services/orchestrator/generation-surface';
 import { getWorkflow as clientGetWorkflow } from '@civitai/client';
 import { internalOrchestratorClient } from '~/server/services/orchestrator/client';
 import {
@@ -349,13 +350,17 @@ export const orchestratorRouter = router({
         userTier,
         ctx.features,
         { id: ctx.user.id, isModerator: ctx.user.isModerator },
-        // #3520: the ON-SITE generator. A substitution here is the DELIBERATE,
-        // correct graceful degradation the issue defends — a stale localStorage
-        // version id after an ecosystem switch, with the picker visibly snapping
-        // back. Labelling it keeps it out of the App Blocks incidence number that
-        // gates the phase-3 policy decision, instead of inflating it with the one
-        // case everyone agrees is working as intended.
-        'onsite'
+        // #3665: `onsite` for a cookie session, `api` for a bearer token. This
+        // procedure serves BOTH — `AIServicesWrite` is a user-grantable scope, so
+        // a CLI or any external integration reaches this exact code path.
+        //
+        // It was a hardcoded `'onsite'`, which meant every API substitution was
+        // recorded as the DELIBERATE, correct graceful degradation #3520 defends
+        // (a stale localStorage id after an ecosystem switch, picker visibly
+        // snapping back) — and therefore excluded from the incidence number that
+        // gates the phase-3 policy decision. An API caller has neither property:
+        // the id is deliberate and there is no picker to snap.
+        generationSurfaceForRequest(ctx)
       );
 
       // Workflow-level feature-flag gate. `filterWorkflowsByFeatureFlags` only
@@ -431,13 +436,12 @@ export const orchestratorRouter = router({
         userTier,
         ctx.features,
         { id: ctx.user.id, isModerator: ctx.user.isModerator },
-        // #3520: the ON-SITE generator. A substitution here is the DELIBERATE,
-        // correct graceful degradation the issue defends — a stale localStorage
-        // version id after an ecosystem switch, with the picker visibly snapping
-        // back. Labelling it keeps it out of the App Blocks incidence number that
-        // gates the phase-3 policy decision, instead of inflating it with the one
-        // case everyone agrees is working as intended.
-        'onsite'
+        // #3665: `onsite` for a cookie session, `api` for a bearer token — see
+        // the sibling call in `generateFromGraph`. This one matters MORE, not
+        // less: `whatIfFromGraph` is the read-only, zero-spend estimate an
+        // external caller makes BEFORE committing buzz, so it is where a
+        // substitution is both most detectable and most worth counting.
+        generationSurfaceForRequest(ctx)
       );
 
       // Mirror of the gate in `generateFromGraph`. Reject what-if costing for

--- a/src/server/services/orchestrator/__tests__/generation-surface-wiring.test.ts
+++ b/src/server/services/orchestrator/__tests__/generation-surface-wiring.test.ts
@@ -5,6 +5,7 @@ import { execFileSync } from 'child_process';
 import ts from 'typescript';
 
 import { GENERATION_SURFACES } from '~/shared/data-graph/generation/model-substitution';
+import { REQUEST_RESOLVED_GENERATION_SURFACES } from '~/server/services/orchestrator/generation-surface';
 
 /**
  * 🔴 POPULATION GUARD for the `surface` label of
@@ -91,9 +92,75 @@ interface CallSite {
   line: number;
   /** Number of top-level arguments actually passed. */
   arity: number;
-  /** Every `GENERATION_SURFACES` member passed as a bare string literal. */
-  surfaceLiterals: string[];
+  /** What sits in the surface slot (argument index 3). */
+  surfaceArg: SurfaceArg;
+  /** Whether this FILE imports the approved resolver from the module defining it. */
+  importsResolver: boolean;
 }
+
+type SurfaceArg =
+  | { kind: 'literal'; value: string }
+  | { kind: 'call'; callee: string }
+  | { kind: 'other'; text: string };
+
+const describeArg = (a: SurfaceArg): string =>
+  a.kind === 'literal' ? `literal '${a.value}'` : a.kind === 'call' ? `${a.callee}(...)` : a.text;
+
+/**
+ * What a pinned call site must pass as its surface.
+ *
+ * A bare string is the original, strictest form: that call site is that surface,
+ * always, checked against the AST.
+ *
+ * 🔴 THE RESOLVED FORM, AND WHY IT IS NOT A HOLE (#3665). One call site cannot
+ * be pinned to a literal: `orchestrator.router`'s two procedures each serve BOTH
+ * the on-site generator and every bearer-token caller, because `AIServicesRead`/
+ * `AIServicesWrite` are user-grantable scopes. Its surface is a property of the
+ * REQUEST, so the honest pin is "resolved by exactly this function, whose range
+ * is exactly these surfaces".
+ *
+ * What it keeps:
+ *   - a NEW call site anywhere still fails (`EXPECTED_SURFACE_BY_CALL_SITE`
+ *     membership is checked first, and is unchanged);
+ *   - a DIFFERENT expression in the surface slot — a variable, a ternary, an
+ *     inlined `ctx.subject ? 'api' : 'onsite'`, a cast, a second resolver — fails;
+ *   - a LITERAL where a resolver is pinned (i.e. re-hardcoding the bug #3665
+ *     fixes) fails, and vice versa;
+ *   - a MODULE-SCOPE local function or alias named `generationSurfaceForRequest`
+ *     fails, via the import-provenance check — see
+ *     {@link importsResolverFromDefiningModule}. 🔴 Read "module-scope"
+ *     literally: the check is per FILE, so a BLOCK-scoped shadow declared inside
+ *     ONE procedure, while the real import stays at the top and is still used by
+ *     the sibling procedure, satisfies it and reinstates #3665 for that
+ *     procedure alone (measured: guard 6/6 green, `tsc` 0 errors, eslint clean).
+ *     Closing that would need real scope resolution; it is left open deliberately
+ *     because it is an adversarial shape, not a refactor anyone reaches for — but
+ *     it is written down rather than implied away, because an earlier revision of
+ *     this list said "a LOCAL function or alias fails" full stop, which was false.
+ *
+ * 🔴 WHAT IT GENUINELY GIVES UP, STATED HONESTLY BECAUSE AN EARLIER REVISION OF
+ * THIS COMMENT DID NOT. It claimed to keep "every mutation this guard exists to
+ * catch". An audit disproved that with three measured mutants that passed 84/84
+ * plus a clean `tsc`: the resolver called with `{}` instead of `ctx`, a local
+ * shadowing function, and an alias binding. The first is now a compile error
+ * (`GenerationSurfaceRequest` was made non-weak) and the other two are caught
+ * here; the general point survives — a name-matching AST guard cannot verify
+ * that the ARGUMENT is the real request, only that the callee is the approved
+ * name from the approved module. `tsc` is what checks the argument, and it only
+ * has teeth because the parameter type is non-weak. If you relax that type back
+ * to all-optional fields, THIS guard silently stops covering the argument.
+ *
+ * It also cannot know WHICH of the resolver's two surfaces a given request
+ * produces — not knowable statically, covered by execution in
+ * `generation-surface.test.ts`. `REQUEST_RESOLVED_GENERATION_SURFACES` is
+ * imported here rather than restated, so the range cannot drift.
+ */
+type SurfacePin = string | { readonly resolvedBy: string; readonly range: readonly string[] };
+
+/** The ONE approved resolver. Anything else in the surface slot fails. */
+const SURFACE_RESOLVER = 'generationSurfaceForRequest';
+/** …and the ONE module it may be imported from. See {@link importsResolverFromDefiningModule}. */
+const SURFACE_RESOLVER_MODULE = '~/server/services/orchestrator/generation-surface';
 
 /**
  * Every PRODUCTION call site allowed to build a generation context, keyed by
@@ -105,12 +172,24 @@ interface CallSite {
  * `src/server/schema/blocks/workflow.schema.ts`'s `modelSubstitutions` contract).
  * A row added without that is the failure described above, just made official.
  */
-const EXPECTED_SURFACE_BY_CALL_SITE: Record<CallSiteKey, string> = {
-  // The on-site generator. #3520 calls this substitution CORRECT: the only way
-  // the form holds an out-of-list id is a stale localStorage value after an
-  // ecosystem switch, and the user visibly sees the picker snap back.
-  'src/server/routers/orchestrator.router.ts::generateFromGraph': 'onsite',
-  'src/server/routers/orchestrator.router.ts::whatIfFromGraph': 'onsite',
+const EXPECTED_SURFACE_BY_CALL_SITE: Record<CallSiteKey, SurfacePin> = {
+  // 🔴 RESOLVED, NOT LITERAL (#3665). These two procedures serve the on-site
+  // generator AND every bearer-token caller — same code path, opposite meanings.
+  // On-site, #3520 calls the substitution CORRECT (a stale localStorage id after
+  // an ecosystem switch, picker visibly snapping back). Via a CLI or any API
+  // integration, neither property holds: the id is deliberate and nothing snaps.
+  //
+  // They were pinned to a hardcoded `'onsite'`, which meant every API
+  // substitution was filed under the one case everyone agrees is working as
+  // intended — and thereby excluded from the incidence number gating phase 3.
+  'src/server/routers/orchestrator.router.ts::generateFromGraph': {
+    resolvedBy: SURFACE_RESOLVER,
+    range: REQUEST_RESOLVED_GENERATION_SURFACES,
+  },
+  'src/server/routers/orchestrator.router.ts::whatIfFromGraph': {
+    resolvedBy: SURFACE_RESOLVER,
+    range: REQUEST_RESOLVED_GENERATION_SURFACES,
+  },
   // The App Blocks bridge — the surface the issue is about. The id was written
   // by an app author and the correction was unobservable. This ONE function is
   // also the only place the block wire contract's `modelSubstitutions` field
@@ -192,6 +271,78 @@ function enclosingFunctionName(node: ts.Node): string {
   return '<module scope>';
 }
 
+/**
+ * What sits in the surface slot: a `GENERATION_SURFACES` string literal, a call
+ * and its callee name, or neither. Anything not in these two shapes — a bare
+ * variable, a ternary, an `as` cast, an `await` — is `{ kind: 'other' }` and
+ * fails every pin, which is the intended conservatism.
+ */
+function describeSurfaceArg(arg: ts.Expression | undefined): SurfaceArg {
+  if (!arg) return { kind: 'other', text: '<missing>' };
+  if (ts.isStringLiteral(arg)) {
+    return (GENERATION_SURFACES as readonly string[]).includes(arg.text)
+      ? { kind: 'literal', value: arg.text }
+      : { kind: 'other', text: `literal '${arg.text}' (not a surface)` };
+  }
+  if (ts.isCallExpression(arg)) {
+    const callee = arg.expression;
+    const name = ts.isIdentifier(callee)
+      ? callee.text
+      : ts.isPropertyAccessExpression(callee) && ts.isIdentifier(callee.name)
+      ? callee.name.text
+      : null;
+    return name ? { kind: 'call', callee: name } : { kind: 'other', text: 'call of an expression' };
+  }
+  return { kind: 'other', text: ts.SyntaxKind[arg.kind] };
+}
+
+/**
+ * Does `file` import {@link SURFACE_RESOLVER} from the module that DEFINES it?
+ *
+ * 🔴 WHY NAME EQUALITY IS NOT ENOUGH. The resolved pin matches on the callee's
+ * identifier, and an identifier is just a name in scope. THREE measured mutants
+ * reinstated the #3665 defect with the guard green AND a clean `tsc`: a LOCAL
+ * `function generationSurfaceForRequest(_ctx: unknown) { return 'onsite'; }`
+ * shadowing the import, `const generationSurfaceForRequest = alwaysOnsite`, and
+ * — found only after the first two were closed — `import { alwaysOnsite as
+ * generationSurfaceForRequest }` from THIS module, which defeated a check that
+ * read the local binding instead of the exported name.
+ *
+ * A full symbol resolution would need a Program (slow, and this guard runs off
+ * plain source files); requiring the EXPORTED name {@link SURFACE_RESOLVER} to
+ * be imported from {@link SURFACE_RESOLVER_MODULE} closes all three without one.
+ *
+ * 🔴 IT FAILS CLOSED, AND TWO LEGITIMATE SHAPES ARE COLLATERAL. A namespace
+ * import (`import * as gs` → `gs.generationSurfaceForRequest(ctx)`) and a
+ * RELATIVE specifier for the same module (`'../services/orchestrator/…'`, a
+ * shape used ~358× elsewhere in `src/server`) both fail this check even though
+ * both are correct code. That is deliberate — a false RED costs one confused
+ * minute and a green mutant costs the metric — but if you are adding a 5th call
+ * site and hit it, the fix is to use the `~/`-aliased named import, not to
+ * loosen this. The failure message says so.
+ */
+function importsResolverFromDefiningModule(source: ts.SourceFile): boolean {
+  return source.statements.some((st) => {
+    if (!ts.isImportDeclaration(st)) return false;
+    if (!ts.isStringLiteral(st.moduleSpecifier)) return false;
+    if (st.moduleSpecifier.text !== SURFACE_RESOLVER_MODULE) return false;
+    const named = st.importClause?.namedBindings;
+    if (!named || !ts.isNamedImports(named)) return false;
+    // 🔴 THE EXPORTED NAME, NOT THE LOCAL BINDING. On an `import { a as b }`,
+    // `el.propertyName` is `a` (what the module exports) and `el.name` is `b`
+    // (the local alias); on a plain `import { a }`, `propertyName` is undefined
+    // and `name` is `a`. An earlier revision read `el.name` and a comment here
+    // asserted that an alias "would still be this module's export, which is
+    // fine" — that was WRONG, and a delta audit produced the mutant that proves
+    // it: `import { alwaysOnsite as generationSurfaceForRequest }` from this
+    // very module resolved every request to 'onsite' — the exact #3665 defect —
+    // with the guard suite 6/6 GREEN and `tsc` at 0 errors. *This module's
+    // export* is not the same claim as *the approved resolver*. Reading
+    // `propertyName ?? name` asks the question that was always meant.
+    return named.elements.some((el) => (el.propertyName ?? el.name).text === SURFACE_RESOLVER);
+  });
+}
+
 /** Every real `buildGenerationContext(...)` call in `file`, with its context. */
 function callSitesIn(file: string): CallSite[] {
   const text = readFileSync(path.join(REPO_ROOT, file), 'utf8');
@@ -219,10 +370,16 @@ function callSitesIn(file: string): CallSite[] {
           fn: enclosingFunctionName(node),
           line: source.getLineAndCharacterOfPosition(node.getStart(source)).line + 1,
           arity: node.arguments.length,
-          surfaceLiterals: node.arguments
-            .filter((a): a is ts.StringLiteral => ts.isStringLiteral(a))
-            .map((a) => a.text)
-            .filter((v) => (GENERATION_SURFACES as readonly string[]).includes(v)),
+          // 🔴 THE SURFACE ARGUMENT BY POSITION, not "any argument that looks
+          // like one". An earlier revision scanned ALL arguments for a string
+          // literal / a call, which was wrong in both directions: it accepted a
+          // resolver call passed in the WRONG SLOT, and it false-failed the
+          // moment any OTHER argument became a call (measured: changing arg 0 to
+          // `resolveTier(user)` at a `'preset'` site failed with a message about
+          // surfaces). `buildGenerationContext(userTier, flags, user, surface)`
+          // — the surface is index 3, and tsc already pins the signature.
+          surfaceArg: describeSurfaceArg(node.arguments[3]),
+          importsResolver: importsResolverFromDefiningModule(source),
         });
       }
     }
@@ -273,15 +430,37 @@ describe('generation-context surface wiring', () => {
   it('🔴 every call site passes the surface its pinned function must declare', () => {
     const wrong = sites
       .filter((c) => keyOf(c) in EXPECTED_SURFACE_BY_CALL_SITE)
-      .filter((c) => {
-        const expected = EXPECTED_SURFACE_BY_CALL_SITE[keyOf(c)];
-        return c.surfaceLiterals.length !== 1 || c.surfaceLiterals[0] !== expected;
+      .map((c) => {
+        const pin = EXPECTED_SURFACE_BY_CALL_SITE[keyOf(c)];
+        const at = `${c.file}:${c.line} inside ${c.fn}()`;
+        const got = describeArg(c.surfaceArg);
+        if (typeof pin === 'string') {
+          // Literal pin: the surface slot holds exactly that literal. Swapping a
+          // hardcoded surface for a resolved one without amending the table
+          // fails here rather than passing quietly.
+          if (c.surfaceArg.kind === 'literal' && c.surfaceArg.value === pin) return null;
+          return `${at} passes ${got} in the surface slot, expected the literal '${pin}'`;
+        }
+        // Resolved pin: the slot holds a call to the ONE approved resolver, AND
+        // this file imports that name from the module that defines it. Both
+        // halves are load-bearing — re-hardcoding `'onsite'` fails the first
+        // (even though 'onsite' is a legitimate value of the range), and a local
+        // function or alias of the same name fails the second.
+        if (c.surfaceArg.kind === 'call' && c.surfaceArg.callee === pin.resolvedBy) {
+          if (c.importsResolver) return null;
+          return (
+            `${at} calls ${pin.resolvedBy}(...), but ${c.file} has no ` +
+            `\`import { ${pin.resolvedBy} } from '${SURFACE_RESOLVER_MODULE}'\`. ` +
+            `Either the name is bound to something else locally (a shadowing function, ` +
+            `an alias of a DIFFERENT export) — which is the bug this checks for — or the ` +
+            `import is written in a shape this guard deliberately does not accept ` +
+            `(a namespace import, or a relative specifier for the same module). ` +
+            `If it is the latter, switch to the '~/'-aliased named import above; do not loosen this check.`
+          );
+        }
+        return `${at} passes ${got} in the surface slot, expected a call to ${pin.resolvedBy}(...)`;
       })
-      .map(
-        (c) =>
-          `${c.file}:${c.line} inside ${c.fn}() passes [${c.surfaceLiterals.join(', ')}], ` +
-          `expected exactly ['${EXPECTED_SURFACE_BY_CALL_SITE[keyOf(c)]}']`
-      );
+      .filter((m): m is string => m !== null);
     expect(wrong).toEqual([]);
   });
 
@@ -318,8 +497,18 @@ describe('generation-context surface wiring', () => {
     // A surface value with no call site would be a series that can never be
     // emitted — an alert keyed on it would then be structurally silent, which is
     // the exact failure class this counter exists to avoid.
-    expect([...new Set(Object.values(EXPECTED_SURFACE_BY_CALL_SITE))].sort()).toEqual(
-      [...GENERATION_SURFACES].sort()
-    );
+    //
+    // A resolved pin contributes its whole RANGE, because any of those values can
+    // reach the counter from that one call site. The range is imported from
+    // beside the resolver, and `generation-surface.test.ts` proves by execution
+    // that the resolver actually produces every value in it — without that, a
+    // range could list a surface nothing emits and this assertion would certify
+    // the orphan instead of catching it.
+    const covered = new Set<string>();
+    for (const pin of Object.values(EXPECTED_SURFACE_BY_CALL_SITE)) {
+      if (typeof pin === 'string') covered.add(pin);
+      else for (const s of pin.range) covered.add(s);
+    }
+    expect([...covered].sort()).toEqual([...GENERATION_SURFACES].sort());
   });
 });

--- a/src/server/services/orchestrator/__tests__/generation-surface.test.ts
+++ b/src/server/services/orchestrator/__tests__/generation-surface.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  generationSurfaceForRequest,
+  REQUEST_RESOLVED_GENERATION_SURFACES,
+  type GenerationSurfaceRequest,
+} from '~/server/services/orchestrator/generation-surface';
+import { isGenerationSurface } from '~/shared/data-graph/generation/model-substitution';
+
+/**
+ * The request→surface mapping behind the `api` / `onsite` split (#3665).
+ *
+ * WHAT THIS OWNS, AND WHAT IT DOES NOT. `generation-surface-wiring` pins, from
+ * the AST, that `orchestrator.router`'s two procedures pass THIS resolver and
+ * nothing else. It structurally cannot check which surface a given request
+ * produces — that is a runtime property, and it is this file's whole job.
+ *
+ * 🔴 THE SEAM IS CHECKED BY THE PRODUCTION CALL, NOT HERE. `tsconfig.json`
+ * EXCLUDES `src/[**]/__tests__/[**]`, so a type-level assertion written in this
+ * file would be checked by nothing (vitest transpiles without typechecking) —
+ * the same hole the wiring guard's arity check documents. The real guarantee
+ * that the tRPC `Context` still satisfies `GenerationSurfaceRequest` is the
+ * `generationSurfaceForRequest(ctx)` call in `orchestrator.router.ts`: that IS
+ * production code, tsc reads it, and it stops compiling the day `ctx.subject`
+ * changes shape. Do not "strengthen" this file with a type assertion and count
+ * it as coverage.
+ */
+describe('generationSurfaceForRequest', () => {
+  // Every shape `createContext` can actually produce. `subject` and `apiKeyId`
+  // are assigned INDEPENDENTLY in `get-server-auth-session` (`result.apiKeyId ??
+  // null`, `result.subject ?? null`), which is why the one-field-only rows are
+  // real cases and not paranoia.
+  // 🔴 EVERY ROW SPELLS BOTH KEYS, including the `undefined` ones. That is not
+  // noise: `GenerationSurfaceRequest` deliberately REQUIRES both keys (an
+  // all-optional version is a weak type, which is what let
+  // `generationSurfaceForRequest({})` type-check and silently resolve
+  // everything to `onsite`). A fixture written as `{ apiKeyId: 7 }` therefore
+  // does not satisfy the type — and `tsconfig.json` EXCLUDES `__tests__`, so
+  // nothing here would tell you. Spelling both keys keeps this table honest
+  // against the real type, and keeps it green if the test tree is ever added to
+  // the typecheck (which the guard's own docblock argues for).
+  const CASES: Array<{ name: string; req: GenerationSurfaceRequest; expected: string }> = [
+    {
+      name: 'cookie session (both fields undefined — what createContext returns)',
+      req: { subject: undefined, apiKeyId: undefined },
+      expected: 'onsite',
+    },
+    {
+      name: 'cookie session (both fields explicitly null)',
+      req: { subject: null, apiKeyId: null },
+      expected: 'onsite',
+    },
+    {
+      name: 'personal API key',
+      req: { subject: { type: 'apiKey', id: 42 }, apiKeyId: 42 },
+      expected: 'api',
+    },
+    {
+      name: 'OAuth app token',
+      req: { subject: { type: 'oauth', id: 'client-abc' }, apiKeyId: null },
+      expected: 'api',
+    },
+    {
+      name: 'bearer with apiKeyId but no subject',
+      req: { subject: undefined, apiKeyId: 7 },
+      expected: 'api',
+    },
+    {
+      name: 'bearer with subject but no apiKeyId',
+      req: { subject: { type: 'apiKey', id: 7 }, apiKeyId: undefined },
+      expected: 'api',
+    },
+    // `apiKeyId: 0` is the one numerically-falsy id. A `!req.apiKeyId` test would
+    // read it as a browser session; the implementation uses `!= null`.
+    {
+      name: 'apiKeyId of 0 (falsy, still bearer)',
+      req: { subject: undefined, apiKeyId: 0 },
+      expected: 'api',
+    },
+  ];
+
+  it.each(CASES)('$name → $expected', ({ req, expected }) => {
+    expect(generationSurfaceForRequest(req)).toBe(expected);
+  });
+
+  it('🔴 no bearer-authenticated request is ever labelled onsite (the #3665 regression)', () => {
+    // The bug being fixed was a hardcoded 'onsite' on a procedure that serves
+    // both. Stated as its own assertion so a future change that reintroduces it
+    // for ANY bearer shape fails on the property, not on one table row.
+    const bearer = CASES.filter((c) => c.expected === 'api');
+    expect(bearer.length).toBeGreaterThan(0);
+    for (const c of bearer) expect(generationSurfaceForRequest(c.req)).not.toBe('onsite');
+  });
+
+  it('🔴 produces every surface in its declared range, and only those', () => {
+    // `generation-surface-wiring` credits this resolver's call sites with the
+    // WHOLE of REQUEST_RESOLVED_GENERATION_SURFACES when it checks that no
+    // declared surface is an orphan. That credit is only sound if the resolver
+    // really can produce each one — otherwise a value listed here but never
+    // returned would be certified as covered while nothing emits it.
+    const produced = new Set(CASES.map((c) => generationSurfaceForRequest(c.req)));
+    expect([...produced].sort()).toEqual([...REQUEST_RESOLVED_GENERATION_SURFACES].sort());
+  });
+
+  it('every produced value survives the runtime surface narrowing', () => {
+    // The collector drops an unrecognised surface rather than putting it on the
+    // counter, so a resolver returning something outside GENERATION_SURFACES
+    // would silently emit nothing at all.
+    for (const c of CASES)
+      expect(isGenerationSurface(generationSurfaceForRequest(c.req))).toBe(true);
+  });
+});

--- a/src/server/services/orchestrator/generation-surface.ts
+++ b/src/server/services/orchestrator/generation-surface.ts
@@ -1,0 +1,90 @@
+import type { GenerationSurface } from '~/shared/data-graph/generation/model-substitution';
+
+/**
+ * HOW A REQUEST WAS AUTHENTICATED — the only two fields that distinguish a
+ * browser session from a bearer token. Structural, not an import of `Context`,
+ * so this module stays free of the tRPC context's transitive graph (redis /
+ * clickhouse / prom-client) and is unit-testable on its own.
+ *
+ * 🔴 BOTH KEYS ARE REQUIRED, THOUGH EITHER VALUE MAY BE `undefined`. That looks
+ * pedantic and is load-bearing: with both optional this is a WEAK type, and TS's
+ * weak-type check passes any object sharing at least one property name — so a
+ * bare `generationSurfaceForRequest({})` type-checks clean and silently resolves
+ * every request to `onsite`, i.e. reinstates the exact #3665 defect with a green
+ * build and a green guard suite. (Measured: `{}` produced 0 tsc errors and 84/84
+ * guard tests passing before this change.) Requiring the keys makes `{}` a
+ * compile error while still accepting the real `ctx`, whose two fields are always
+ * PRESENT and merely `undefined` under cookie auth (`createContext` returns them
+ * unconditionally).
+ */
+export type GenerationSurfaceRequest = {
+  /** Set only for bearer auth — `{ type: 'apiKey' | 'oauth', id }`; `undefined` under a session. */
+  subject: { type: 'apiKey'; id: number } | { type: 'oauth'; id: string } | null | undefined;
+  /** Set only for bearer auth; `undefined` under a session. */
+  apiKeyId: number | null | undefined;
+};
+
+/**
+ * Which {@link GenerationSurface} a shared tRPC generation procedure is serving
+ * on THIS request (#3665).
+ *
+ * 🔴 WHY THIS EXISTS AS A FUNCTION AT ALL. Every other surface is a property of
+ * its CALL SITE — `blocks.router`'s bridge is always `block`, preset generation
+ * is always `preset` — so those pass a literal and `generation-surface-wiring`
+ * pins it statically. `orchestrator.router`'s two procedures are the exception:
+ * ONE procedure serves both the on-site generator and every external caller,
+ * because `AIServicesRead`/`AIServicesWrite` are user-grantable scopes and the
+ * procedures carry them deliberately. The surface there is a property of the
+ * REQUEST, and no static pin can express it.
+ *
+ * 🔴 THE DISCRIMINATOR IS `subject`/`apiKeyId`, AND IT IS NOT NEGOTIABLE.
+ * `createContext` sets both ONLY for bearer auth (`get-server-auth-session`
+ * populates them off the token result); cookie-session auth leaves both absent.
+ * Two nearby fields look usable and are NOT:
+ *   - `tokenScope` is `TokenScope.Full` for a cookie session AND for a
+ *     full-access personal API key, so it cannot separate them at all.
+ *   - a `user-agent` / `origin` sniff is caller-controlled, i.e. exactly the
+ *     "guessed at the clamp" failure the surface label was introduced to avoid.
+ *
+ * Both fields are read because `get-server-auth-session` assigns them
+ * independently (`result.apiKeyId ?? null`, `result.subject ?? null`) — a token
+ * result carrying one but not the other is bearer auth either way, and must not
+ * fall through to `onsite`. `onsite` is the DEFAULT only in the sense that
+ * "no bearer evidence" is what a browser session looks like.
+ *
+ * 🔴 SAME INPUT AS `Tracker.setProvenance`, DELIBERATELY DIFFERENT OUTPUT.
+ * That reads the same two fields to tag content-creation events `'web' |
+ * 'api-key' | 'oauth'`. This does not import it (the Tracker drags in the
+ * ClickHouse client) and does not reuse its vocabulary, because this label feeds
+ * one question — was the correction observable to the caller? — for which a
+ * personal key and an OAuth app are the same answer. The shared thing is the
+ * DISCRIMINATOR (`ctx.subject`), which is declared once in `createContext`; the
+ * two mappings off it are per-consumer by design.
+ */
+export function generationSurfaceForRequest(
+  req: GenerationSurfaceRequest
+): RequestResolvedGenerationSurface {
+  return req.subject != null || req.apiKeyId != null ? 'api' : 'onsite';
+}
+
+/**
+ * The surfaces {@link generationSurfaceForRequest} can actually return.
+ *
+ * 🔴 DECLARED HERE SO IT IS NOT DECLARED TWICE. `generation-surface-wiring`
+ * pins every call site to the surface it must produce; for a literal call site
+ * that is one string it can read off the AST, but a RESOLVED call site has a
+ * RANGE, and a range hand-copied into the guard would be a second source of
+ * truth that drifts silently the day this function learns a third answer.
+ * The guard imports this; `generation-surface.test.ts` proves the set is
+ * exhaustive by execution rather than trusting the annotation.
+ *
+ * Subset of `GENERATION_SURFACES` — `block` and `preset` are properties of
+ * their call sites and can never be produced from a request.
+ */
+export const REQUEST_RESOLVED_GENERATION_SURFACES = [
+  'api',
+  'onsite',
+] as const satisfies readonly GenerationSurface[];
+
+export type RequestResolvedGenerationSurface =
+  (typeof REQUEST_RESOLVED_GENERATION_SURFACES)[number];

--- a/src/server/services/orchestrator/orchestration-new.service.ts
+++ b/src/server/services/orchestrator/orchestration-new.service.ts
@@ -273,8 +273,11 @@ async function getGenerationStatus(): Promise<GenerationStatus> {
  * @param flags - Feature access flags
  * @param user - User info used to resolve mod-only / testing gating
  * @param surface - 🔴 REQUIRED, and deliberately not defaulted (issue #3520).
- *   Which caller is validating: `onsite` (the on-site generator), `block` (the
- *   App Blocks bridge) or `preset` (comics / preset generation). It becomes the
+ *   Which caller is validating: `onsite` (the on-site generator under a cookie
+ *   session), `api` (the same tRPC procedures reached with a bearer token —
+ *   #3665; resolve it with `generationSurfaceForRequest(ctx)`, never a literal),
+ *   `block` (the App Blocks bridge) or `preset` (comics / preset generation).
+ *   It becomes the
  *   `surface` label on `civitai_generation_model_substitutions_total`, and the
  *   split is load-bearing: #3520 calls the substitution CORRECT on-site and
  *   unobservable through the bridge, so one un-split series measures a

--- a/src/shared/data-graph/generation/model-substitution.test.ts
+++ b/src/shared/data-graph/generation/model-substitution.test.ts
@@ -473,11 +473,13 @@ describe('runtime narrowing helpers', () => {
     }
   });
 
-  it('the surface union is exactly the three wired call sites', () => {
-    // 3 reasons x 3 surfaces = 9 series. Adding a value here is a deliberate,
+  it('the surface union is exactly the four wired call sites', () => {
+    // 3 reasons x 4 surfaces = 12 series. Adding a value here is a deliberate,
     // reviewable widening of the counter's cardinality, so it has to fail a test
-    // rather than land silently.
-    expect([...GENERATION_SURFACES]).toEqual(['block', 'onsite', 'preset']);
+    // rather than land silently. `api` (#3665) was exactly that: it was split out
+    // of `onsite`, which had been assigned by a hardcoded literal on two tRPC
+    // procedures that also serve every bearer-token caller.
+    expect([...GENERATION_SURFACES]).toEqual(['api', 'block', 'onsite', 'preset']);
     expect([...MODEL_SUBSTITUTION_REASONS]).toEqual(['wrong-workflow', 'unrecognized', 'gated']);
   });
 });

--- a/src/shared/data-graph/generation/model-substitution.ts
+++ b/src/shared/data-graph/generation/model-substitution.ts
@@ -113,13 +113,17 @@ export function isModelSubstitutionReason(value: unknown): value is ModelSubstit
  * `civitai_generation_model_substitutions_total`.
  *
  * 🔴 WHY THIS LABEL EXISTS. `validateInput` is the choke point for EVERY
- * server-side `generationGraph.safeParse`, so without it the counter mixes three
+ * server-side `generationGraph.safeParse`, so without it the counter mixes four
  * populations whose meanings are opposite:
  *
- *   - `onsite`  — the on-site generator, where the substitution is the DELIBERATE,
- *                 CORRECT graceful degradation (#3520 defends it: a stale
- *                 localStorage id after an ecosystem switch, and the user visibly
- *                 sees the picker snap back).
+ *   - `onsite`  — the on-site generator driven by a COOKIE SESSION, where the
+ *                 substitution is the DELIBERATE, CORRECT graceful degradation
+ *                 (#3520 defends it: a stale localStorage id after an ecosystem
+ *                 switch, and the user visibly sees the picker snap back).
+ *   - `api`     — the SAME two tRPC procedures reached with a bearer token
+ *                 (personal API key or OAuth app) — a CLI, a script, any external
+ *                 integration. See below: this is `onsite`'s opposite, not its
+ *                 variant.
  *   - `block`   — the App Blocks bridge, where the id was written by an app author
  *                 and the correction is unobservable. This is the population
  *                 phase 3's policy decision is actually about.
@@ -129,14 +133,38 @@ export function isModelSubstitutionReason(value: unknown): value is ModelSubstit
  * on-site's correct behaviour into the bridge's incorrect behaviour measures a
  * contaminated quantity, so the split is load-bearing, not decoration.
  *
- * 🔴 BOUNDED, AND KEPT THAT WAY: 3 reasons × 3 surfaces = 9 series, total,
- * forever. This is the ONLY dimension added; version id / ecosystem / workflow /
- * app id / user id are all caller-controlled or high-cardinality and stay out
- * (prom-client retains every distinct label set in the Node heap forever, across
- * ~130 scraped pods). Attribution belongs in the snapshot the caller already
- * receives.
+ * 🔴 WHY `api` WAS SPLIT OUT OF `onsite` (#3665). `onsite` was assigned by a
+ * hardcoded literal at the two `orchestrator.router` procedures, so it meant
+ * "these procedures" — but both are deliberately reachable by bearer token
+ * (`AIServicesRead`/`AIServicesWrite` are user-grantable scopes with the consent
+ * label "Generate, train & scan"). Every CLI/API substitution was therefore
+ * counted as the one case everyone agrees is working as intended, and it is
+ * counted into the bucket phase 3 EXCLUDES. That inverts the label's purpose:
+ * an API caller has neither of the two properties that make degradation correct
+ * — the id is deliberate, and there is no picker to visibly snap.
+ *
+ * The split was prompted by a measurement, not a hunch: over the counter's life
+ * so far, `surface="block"` — the population phase 3 is about — had recorded no
+ * substitutions at all, because App Blocks is mod-gated, while `surface="onsite"`
+ * carried the whole signal. A gate that reads zero on the only bucket it consults
+ * cannot gate anything; splitting `api` out is what gives the phase-3 decision a
+ * population with both real volume AND the invisibility property.
+ * (🔴 Figures deliberately omitted — this repo is PUBLIC. The measurement lives in
+ * the private infra repo's handoff notes.)
+ *
+ * 🔴 BOUNDED, AND KEPT THAT WAY: 3 reasons × 4 surfaces = 12 series, total.
+ * This is still the ONLY dimension; version id / ecosystem / workflow / app id /
+ * user id are all caller-controlled or high-cardinality and stay out (prom-client
+ * retains every distinct label set in the Node heap forever, across ~130 scraped
+ * pods). Attribution belongs in the snapshot the caller already receives.
+ *
+ * 🔴 `api` IS ONE VALUE, NOT TWO. A personal API key and an OAuth app differ in
+ * WHO is calling, not in whether the correction is observable — which is the only
+ * thing this label feeds. Splitting them would buy 3 more series and no decision.
+ * The actor distinction already exists, with its own vocabulary, on
+ * `Tracker.setProvenance` (`'web' | 'api-key' | 'oauth'`); use that if you need it.
  */
-export const GENERATION_SURFACES = ['block', 'onsite', 'preset'] as const;
+export const GENERATION_SURFACES = ['api', 'block', 'onsite', 'preset'] as const;
 
 export type GenerationSurface = (typeof GENERATION_SURFACES)[number];
 
@@ -209,10 +237,10 @@ function keyOf(event: ModelSubstitutionEvent): string {
  * Build a fresh per-request collector. 🔴 Call this per request and attach the
  * result to a freshly constructed context object — see the module note.
  *
- * `surface` names the caller (block / onsite / preset) and becomes the second
- * label on the counter. It is supplied by whoever builds the request context —
- * never guessed from the parse — because `validateInput` is shared by all three
- * and cannot tell them apart.
+ * `surface` names the caller (api / block / onsite / preset) and becomes the
+ * second label on the counter. It is supplied by whoever builds the request
+ * context — never guessed from the parse — because `validateInput` is shared by
+ * all of them and cannot tell them apart.
  */
 export function createModelSubstitutionCollector(
   classify: ModelSubstitutionClassifier,


### PR DESCRIPTION
Closes #3665 (item 2 of its ask). Refs #3520.

## What's wrong

`orchestrator.router`'s `generateFromGraph` / `whatIfFromGraph` hardcode `'onsite'` as the `surface` label on `civitai_generation_model_substitutions_total`.

Both procedures are deliberately reachable by bearer token — `AIServicesRead` / `AIServicesWrite` are user-grantable scopes carrying the consent label *"Generate, train & scan"*. So a CLI, a script, or any external integration hits this exact code path, and every silent model substitution it suffers is filed under the one case #3520 defends as **correct**: a stale `localStorage` id after an ecosystem switch, with the picker visibly snapping back.

An API caller has neither property that makes degradation correct — the id is deliberate, and there is no picker to snap. Worse, `'onsite'` is precisely the bucket phase 3's policy decision *excludes*, so these cases were being counted into the noise floor.

## Why now

Over the counter's life so far, `surface="block"` — the population phase 3 is actually about — has recorded **zero** substitutions, because App Blocks is mod-gated. The entire signal sits in `surface="onsite"`, at an incidence on the order of 1 in 10⁴ calls.

A gate that reads zero on the only bucket it consults cannot gate anything. Splitting `api` out is what gives the phase-3 decision a population with both real volume *and* the invisibility property that makes substitution harmful.

**Behaviour is unchanged.** This is a label, not a policy. Which model runs, what is billed, and what any caller receives are all identical. The reject-vs-degrade question stays open and stays gated — this just makes it gateable.

## How

- **`generationSurfaceForRequest(ctx)`** derives the surface from `ctx.subject` / `ctx.apiKeyId` — the same discriminator `Tracker.setProvenance` already uses to tag content-creation events as `web` / `api-key` / `oauth`. Both fields are read because `get-server-auth-session` assigns them independently. `tokenScope` cannot serve here: it is `Full` for a cookie session *and* for a full-access personal API key.
- **`api` is one value, not two.** A personal key and an OAuth app differ in *who* is calling, not in whether the correction is observable — the only thing this label feeds.
- **`GENERATION_SURFACES` 3 → 4**, cardinality 9 → 12 series. Deliberate and gated: the exact-union assertions and the at-most-N-series test all had to be edited by hand, which is the intended friction.

## The guard change, stated plainly

`generation-surface-wiring` pinned every `buildGenerationContext` call site to a **string literal**. One call site now genuinely cannot be pinned that way, so the table learns a *resolved* pin: "resolved by exactly this function, whose range is exactly these surfaces."

It still rejects a new call site, a different expression (variable, ternary, second resolver), and a re-hardcoded literal. What it gives up is knowing *which* of the two a given request yields — not knowable statically — which is covered by execution instead. The resolver's range is imported from beside the resolver rather than restated in the guard, so it cannot drift.

## Verification

`pnpm typecheck` → **0 errors**, and watched go **red** on a deliberate seam break (narrowing `GenerationSurfaceRequest['subject']` to `string` produced 2 errors at exactly the two router call sites) — so the green is a fact about the code, not about the command line. That break is also the proof that the production `generationSurfaceForRequest(ctx)` call *is* the compile-time guarantee that the tRPC `Context` still satisfies the resolver's input.

276 tests pass across the 24 affected suites. Each new guard was watched fail on the mutation it exists to catch:

| mutation | killed by | failed with |
|---|---|---|
| re-hardcode `'onsite'` at both call sites | wiring guard | `passes literals [onsite] … expected exactly one call to generationSurfaceForRequest(...)`, naming both sites |
| inline `ctx.subject ? 'api' : 'onsite'` at the call sites | wiring guard | same assertion, `passes literals [] / calls []` |
| resolver always returns `'onsite'` | `generation-surface.test.ts` | 7 tests, incl. the named `#3665 regression` assertion |
| resolver range padded with an unreachable surface | `generation-surface.test.ts` | `expected [ 'api', 'onsite' ] to deeply equal [ 'api', 'onsite', 'preset' ]` |

## Not in this PR

The other half of #3665 — surfacing the substitution record on the tRPC replies — is deliberately separate. Note for whoever takes it: `formatGenerationResponse2` builds `normalizedWfMeta` from an **allowlist** (`params`, `resources`, `remixOfId`, `isPrivateGeneration`), so copying the App Blocks trick of persisting under `WORKFLOW_METADATA_MODEL_SUBSTITUTIONS_KEY` will be silently dropped on read-back unless the normalizer gains an explicit passthrough.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
