### PR TITLE
ci: run the four apps/* vitest suites, and let the ledger see them

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -227,31 +227,50 @@ jobs:
         run: pnpm run test:unit:run
 
   packages:
-    name: Package unit tests
+    name: Workspace unit tests
     runs-on: ubuntu-latest
-    # The nine `packages/*` suites — 616 tests that, until this job existed, NO CI job ran.
-    # The `unit` job above runs `vitest run --project unit`, whose `include` is root-relative
-    # (`src/**`, `scripts/**`), so nothing in this repo ever invoked a workspace package's
-    # suite. That is not a small gap: the schema-drift detector shipped 81 tests into it,
-    # and two of them had been RED on `main` since #3592 corrected the schema out from under
-    # their assertions, with nothing to say so.
+    # Every workspace suite that is not the root app: the nine `packages/*` projects and the
+    # four `apps/*` ones — 13 projects, 114 files, 1318 tests (1314 executed, 4 skipped).
+    # Neither group had ever been run by CI. The `unit` job above runs
+    # `vitest run --project unit`, whose `include` is root-relative (`src/**`, `scripts/**`),
+    # so nothing in this repo ever invoked a workspace package's suite. That is not a small
+    # gap: the schema-drift detector shipped 81 tests into it, and two of them had been RED on
+    # `main` since #3592 corrected the schema out from under their assertions, with nothing to
+    # say so.
+    #
+    # ONE job rather than a second one for `apps/*`. This job is dominated by checkout +
+    # install; the apps add ~12s of test time to it (11.6s -> 23.9s measured locally) against
+    # the ~1-2min a duplicate install would cost. The usual argument for splitting —
+    # attribution — does not apply here, because vitest's reporter already prefixes every file
+    # and every failure with its project name (`FAIL @civitai/storage-app src/...`) and the
+    # ledger step below prints a per-package table.
     #
     # NOT `continue-on-error`, unlike `unit`. Be precise about what that does and does not
-    # buy: `main` has branch protection but NO required_status_checks, so a red check here
-    # does not prevent a merge. The difference from `unit` is that this renders RED rather
-    # than red-but-ignored — a signal someone has to look at and dismiss, not one the UI
-    # hides. Making it an actual interlock means adding "Package unit tests" to the required
+    # buy: `main` has branch protection but NO required_status_checks (and the one active
+    # ruleset only forbids deletion), so a red check here does NOT prevent a merge — it is
+    # advisory. The difference from `unit` is that this renders RED rather than
+    # red-but-ignored — a signal someone has to look at and dismiss, not one the UI hides.
+    # Making it an actual interlock means adding "Workspace unit tests" to the required
     # checks, which is a repo-settings change, not a workflow one.
     #
     # The reasoning that made `unit` report-only still does not transfer, which is why this
     # one is not marked ignorable: `unit` is ~12,000 tests whose cost is a ~33s
-    # import/transform phase per file, and it timed out five tests under load. This is 616
-    # tests with no browser, no database and no Next module graph — ~15s locally.
+    # import/transform phase per file, and it timed out five tests under load. These 1318
+    # tests have no browser, no database and no Next module graph — ~24s locally.
+    #
+    # The four app suites clear the same bar as the packages, which is why they were allowed
+    # into a blocking job: `apps/{orchestrator-gateway,storage,notifications}` exercise their
+    # Fastify apps through `app.inject()` (an in-process request — no port is bound, so no
+    # port collision on a shared runner), their backends/DB/redis clients are `vi.mock`ed,
+    # `apps/auth` stubs SvelteKit's `$env`/`$app` virtual modules in its own vitest config, and
+    # the tests that care about environment set and delete their own `process.env` keys rather
+    # than reading ambient ones. Nothing reaches the network, a real clock, or a real database.
     #
     # DB-backed tiers self-skip: `@civitai/db-queries` sources DATABASE_URL from the root
     # `.env`, which does not exist on a runner, so its 4 DB-backed tests across two files
     # (3 in tag.db.explain, 1 in enum-array-parsers.explain) report as skipped. They are
-    # visible as skips in the summary rather than as a silent absence.
+    # visible as skips in the summary rather than as a silent absence. The `apps/*` suites
+    # contribute zero skips.
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
@@ -268,14 +287,16 @@ jobs:
       - name: Install
         run: pnpm install --frozen-lockfile
 
-      - name: Package unit tests
+      - name: Workspace unit tests
         run: pnpm run test:packages:run --reporter=default --reporter=json --outputFile=packages-report.json
 
       # A green vitest run is a claim, not evidence: `--project` matching nothing exits 0,
       # and so does a config whose globs stopped resolving. This asserts the LEDGER — every
-      # workspace package with a vitest config and a test file on disk must appear in the
-      # results — so the job fails when the executed set shrinks, which is the regression the
-      # totals cannot see.
-      - name: Assert every package suite actually ran
+      # workspace package under `packages/` AND `apps/` with a vitest config and a test file on
+      # disk must appear in the results with at least one EXECUTED test — so the job fails when
+      # the executed set shrinks, which is the regression the totals cannot see. Until the
+      # `apps/*` suites were brought in, the ledger scanned only `packages/`, which means it
+      # could not have observed an `apps/*` dropout even once those suites were running.
+      - name: Assert every workspace suite actually ran
         if: always()
         run: node scripts/ci/assert-package-suites-ran.mjs packages-report.json

--- a/.gitignore
+++ b/.gitignore
@@ -163,5 +163,5 @@ mockups/
 # superpowers skill scratch (specs/plans) — implementation detail, not shipped to main
 docs/superpowers/
 
-# vitest JSON report written by the Package unit tests CI job
+# vitest JSON report written by the Workspace unit tests CI job
 packages-report.json

--- a/packages/civitai-db-schema/src/schema-drift/README.md
+++ b/packages/civitai-db-schema/src/schema-drift/README.md
@@ -255,11 +255,11 @@ The root `unit` Vitest project globs `src/**` and `scripts/**` — both root-rel
 package's suite, or any of the eight other `packages/*` suites. 616 tests, 81 of them this
 tool's, ran only for whoever remembered `pnpm --filter <pkg> test` by hand.
 
-They now run in the `Package unit tests` job, from the `packages/*/vitest.config.*` entries in
-the root `vitest.config.mts`:
+They now run in the `Workspace unit tests` job, from the `packages/*/vitest.config.*` and
+`apps/*/vitest.config.*` entries in the root `vitest.config.mts`:
 
 ```bash
-pnpm run test:packages:run          # all nine package suites
+pnpm run test:packages:run          # all 13 workspace suites (9 packages/* + 4 apps/*)
 pnpm --filter @civitai/db-schema test   # just this one
 ```
 
@@ -270,14 +270,16 @@ so does a suite that skips itself entirely.
 
 Two things it is worth being precise about, because both are easy to overstate:
 
-- **It is not an interlock.** `main` has branch protection but no `required_status_checks`, so
-  a red `Package unit tests` does not prevent a merge. It renders red rather than
-  red-but-ignored, which is the real difference from the `Unit tests` job.
-- **The workspace gap is not closed, only the `packages/*` part of it.** `apps/*` has four
-  more vitest configs and ~43 test files that still no CI job runs. Same one-line fix — another
-  glob in the same `projects` array — plus teaching the ledger script about `apps/`, which
-  currently hardcodes `packages/`. Deliberately left to a follow-up rather than widened into
-  the change that closed the first part.
+- **It is not an interlock.** `main` has branch protection but no `required_status_checks`
+  (and its one active ruleset only forbids branch deletion), so a red `Workspace unit tests`
+  does not prevent a merge. It renders red rather than red-but-ignored, which is the real
+  difference from the `Unit tests` job.
+- **The workspace gap is now closed on both roots.** The `apps/*` half followed in a second
+  change: four more vitest configs, 42 files and 361 tests
+  (`apps/{auth,notifications,orchestrator-gateway,storage}`), brought in by two more globs in
+  the same `projects` array, and the ledger script — which hardcoded `packages/` and so could
+  not have observed an `apps/*` dropout — now scans both roots from a single `WORKSPACE_ROOTS`
+  list. The run is 13 projects / 114 files / 1318 tests.
 
 ## Gating a pull request
 

--- a/scripts/ci/assert-package-suites-ran.mjs
+++ b/scripts/ci/assert-package-suites-ran.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /**
- * Positive control for the `Package unit tests` CI job.
+ * Positive control for the `Workspace unit tests` CI job.
  *
  * A green vitest run is not evidence that anything ran. Three ways this job could report
  * success having tested nothing, all of which produce exit code 0:
@@ -8,15 +8,21 @@
  *   - the `--project '@civitai/*'` filter matches no project (a rename, a quoting change,
  *     a Vitest version that reads the pattern differently) — vitest exits 0 on an empty
  *     selection;
- *   - the `packages/<pkg>/vitest.config.*` globs in the root config stop resolving, so the
- *     projects are simply absent;
- *   - one package quietly drops out — its config is renamed or its `include` stops matching
- *     — while the other eight keep the totals looking healthy.
+ *   - the `packages/<pkg>/vitest.config.*` / `apps/<app>/vitest.config.*` globs in the root
+ *     config stop resolving, so the projects are simply absent;
+ *   - one workspace package quietly drops out — its config is renamed or its `include` stops
+ *     matching — while the other twelve keep the totals looking healthy.
  *
  * So this reads the run's JSON report and asserts a LEDGER rather than a floor: every
  * workspace package that has a vitest config AND at least one test file on disk must appear
  * in the results with at least one test. The check fails when that set SHRINKS, which is the
- * regression, and adapts on its own when a tenth package is added.
+ * regression, and adapts on its own when a fourteenth package is added.
+ *
+ * "Workspace package" means BOTH roots `pnpm-workspace.yaml` declares — `packages/*` and
+ * `apps/*`. Scanning only `packages/` (which is what this did until the `apps/*` suites were
+ * brought into CI) is not a loud failure: it is a ledger that structurally CANNOT observe an
+ * `apps/*` regression, so the four app suites could have silently dropped back out of the run
+ * and this check would still have printed OK. The roots are listed once, in WORKSPACE_ROOTS.
  *
  * Usage:  node scripts/ci/assert-package-suites-ran.mjs <vitest-json-report>
  */
@@ -31,7 +37,11 @@ if (!reportPath) {
 }
 
 const repoRoot = resolve(fileURLToPath(new URL('../..', import.meta.url)));
-const packagesDir = join(repoRoot, 'packages');
+
+// The two workspace roots from `pnpm-workspace.yaml` (`.` is the app itself, covered by the
+// separate `unit` project). Adding a third root here is the whole change needed to extend the
+// ledger to it — the scan, the report matcher and the printed table all read this list.
+const WORKSPACE_ROOTS = ['packages', 'apps'];
 
 /**
  * Any test file anywhere under a package, recursively.
@@ -61,23 +71,36 @@ function hasTestFile(dir) {
   return false;
 }
 
-const expected = readdirSync(packagesDir, { withFileTypes: true })
-  .filter((e) => e.isDirectory())
-  .map((e) => e.name)
-  .filter((name) => {
-    const dir = join(packagesDir, name);
-    const hasConfig = ['vitest.config.ts', 'vitest.config.mts'].some((f) =>
-      existsSync(join(dir, f))
-    );
-    return hasConfig && hasTestFile(dir);
-  })
-  .sort();
+// Keyed `<root>/<dir>` (e.g. `packages/civitai-redis`, `apps/auth`) so the two roots cannot
+// collide on a shared basename and so the printed table says which root a suite came from.
+const expected = WORKSPACE_ROOTS.flatMap((root) => {
+  const rootDir = join(repoRoot, root);
+  if (!existsSync(rootDir)) return [];
+  return readdirSync(rootDir, { withFileTypes: true })
+    .filter((e) => e.isDirectory())
+    .map((e) => e.name)
+    .filter((name) => {
+      const dir = join(rootDir, name);
+      const hasConfig = ['vitest.config.ts', 'vitest.config.mts'].some((f) =>
+        existsSync(join(dir, f))
+      );
+      return hasConfig && hasTestFile(dir);
+    })
+    .map((name) => `${root}/${name}`);
+}).sort();
 
-if (expected.length === 0) {
+// Per-root, not just overall: an `apps/` root that scans to zero is exactly the silent
+// coverage hole this extension exists to close, and an overall non-zero total would hide it
+// behind the nine `packages/` entries.
+const emptyRoots = WORKSPACE_ROOTS.filter(
+  (root) => !expected.some((key) => key.startsWith(`${root}/`))
+);
+if (emptyRoots.length > 0) {
   console.error(
-    'FAIL: found no workspace package with both a vitest config and a test file. This check ' +
-      'cannot have measured anything — it is running from the wrong directory, or the ' +
-      'packages/ layout changed.'
+    `FAIL: workspace root(s) ${emptyRoots.join(', ')} scanned to zero packages with both a ` +
+      'vitest config and a test file. This check cannot have measured them — it is running ' +
+      "from the wrong directory, or that root's layout changed. Fix the scan or drop the " +
+      'root from WORKSPACE_ROOTS deliberately; do not leave it silently unmeasured.'
   );
   process.exit(1);
 }
@@ -99,30 +122,35 @@ try {
 // visible rather than merely absent from the arithmetic.
 const EXECUTED = new Set(['passed', 'failed']);
 
-const ran = new Map(); // package name -> { files, executed, skipped }
+// Built from WORKSPACE_ROOTS so the matcher and the scan can never disagree about which roots
+// count — a hardcoded `packages/` here was the whole reason an `apps/*` dropout was invisible.
+const ROOT_MATCH = new RegExp(`(?:^|/)(${WORKSPACE_ROOTS.join('|')})/([^/]+)/`);
+
+const ran = new Map(); // `<root>/<dir>` -> { files, executed, skipped }
 for (const result of report.testResults ?? []) {
-  const match = /(?:^|\/)packages\/([^/]+)\//.exec(result.name ?? '');
+  const match = ROOT_MATCH.exec(result.name ?? '');
   if (!match) continue;
-  const entry = ran.get(match[1]) ?? { files: 0, executed: 0, skipped: 0 };
+  const key = `${match[1]}/${match[2]}`;
+  const entry = ran.get(key) ?? { files: 0, executed: 0, skipped: 0 };
   entry.files += 1;
   for (const assertion of result.assertionResults ?? []) {
     if (EXECUTED.has(assertion.status)) entry.executed += 1;
     else entry.skipped += 1;
   }
-  ran.set(match[1], entry);
+  ran.set(key, entry);
 }
 
 const missing = expected.filter((name) => !ran.has(name) || ran.get(name).executed === 0);
 
-console.log(`packages with a vitest config and tests on disk : ${expected.length}`);
-console.log(`packages that appear in the run                 : ${ran.size}`);
+console.log(`workspace packages with a vitest config and tests on disk : ${expected.length}`);
+console.log(`workspace packages that appear in the run                 : ${ran.size}`);
 for (const name of expected) {
   const entry = ran.get(name);
   const detail = entry
     ? `${entry.files} file(s), ${entry.executed} executed` +
       (entry.skipped > 0 ? `, ${entry.skipped} skipped` : '')
     : 'did not run';
-  console.log(`  ${missing.includes(name) ? 'MISSING' : '     ok'}  ${name.padEnd(28)} ${detail}`);
+  console.log(`  ${missing.includes(name) ? 'MISSING' : '     ok'}  ${name.padEnd(34)} ${detail}`);
 }
 console.log(
   `totals: ${report.numTotalTestSuites ?? '?'} suite(s), ${report.numTotalTests ?? 0} test(s), ` +
@@ -131,18 +159,25 @@ console.log(
 
 if (missing.length > 0) {
   console.error(
-    `\nFAIL: ${missing.length} package suite(s) executed no tests: ${missing.join(', ')}.\n` +
+    `\nFAIL: ${missing.length} workspace suite(s) executed no tests: ${missing.join(', ')}.\n` +
       'The job reported success without running them. Either the project was not selected ' +
-      '(check the `packages/*/vitest.config.*` globs in the root vitest.config.mts and the ' +
-      "--project '@civitai/*' filter), or the suite skipped itself in its entirety — a " +
-      'wholly-skipped package is not a package that ran.'
+      '(check the `packages/*/vitest.config.*` AND `apps/*/vitest.config.*` globs in the root ' +
+      "vitest.config.mts and the --project '@civitai/*' filter — an app whose package.json " +
+      '`name` stops being `@civitai/`-scoped drops out of that filter silently), or the suite ' +
+      'skipped itself in its entirety — a wholly-skipped package is not a package that ran.'
   );
   process.exit(1);
 }
 
 // A floor as well as the ledger: the ledger passes if every package contributes one test,
 // which is not the same as the suites being intact.
-const MIN_TESTS = 500;
+//
+// 1000 against 1314 executed today (957 from `packages/*`, 361 from `apps/*`). Deliberately
+// set ABOVE the packages-only total, so if every `apps/*` project vanished at once the floor
+// fires even in the case where the ledger somehow did not — two independent tripwires on the
+// regression this change exists to prevent, rather than one. Raise it when the corpus grows;
+// do not lower it to make a red run green.
+const MIN_TESTS = 1000;
 const totalExecuted = [...ran.values()].reduce((sum, e) => sum + e.executed, 0);
 if (totalExecuted < MIN_TESTS) {
   console.error(
@@ -152,4 +187,4 @@ if (totalExecuted < MIN_TESTS) {
   process.exit(1);
 }
 
-console.log('\nOK: every package suite with tests on disk executed.');
+console.log('\nOK: every workspace suite with tests on disk executed.');

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -82,6 +82,22 @@ export default defineConfig({
       // DATABASE_URL from the root `.env` so its DB-backed tier self-skips without one.
       'packages/*/vitest.config.ts',
       'packages/*/vitest.config.mts',
+      // The `apps/*` suites, for exactly the same reason and by exactly the same mechanism.
+      // `pnpm-workspace.yaml` has included `apps/*` all along, and four of the seven apps
+      // carry a vitest config — but the globs above only ever reached `packages/`, so 42
+      // files / 361 tests across apps/{auth,notifications,orchestrator-gateway,storage} were
+      // run by nobody: not the `unit` project (root-relative `include`), not this job.
+      //
+      // They land in the SAME `--project '@civitai/*'` selection because every one of those
+      // four package.json `name`s is already `@civitai/`-scoped (`@civitai/auth-app`,
+      // `@civitai/notifications-app`, `@civitai/orchestrator-gateway`, `@civitai/storage-app`)
+      // — no filter change, and no name collision with the `packages/` projects.
+      //
+      // Same config-file glob rather than a directory glob, same reason: `apps/creator-studio`,
+      // `apps/event-engine` and `apps/moderator` have no vitest config and must not be adopted
+      // under a default `include` they were never written against.
+      'apps/*/vitest.config.ts',
+      'apps/*/vitest.config.mts',
       {
         resolve: { alias },
         test: {


### PR DESCRIPTION
Closes the other half of the CI coverage gap #3642 opened on. `pnpm-workspace.yaml` declares two roots — `packages/*` and `apps/*`. #3642 brought the first into CI. The second was still run by nobody: four apps carry a vitest config (`apps/{auth,notifications,orchestrator-gateway,storage}`), 42 files and 361 tests that neither the `unit` project (its `include` is root-relative) nor the packages job ever invoked.

## What changed

**Two globs** in the same `projects` array of `vitest.config.mts`. No filter change is needed — all four `package.json` `name`s are already `@civitai/`-scoped (`@civitai/auth-app`, `@civitai/notifications-app`, `@civitai/orchestrator-gateway`, `@civitai/storage-app`), so `--project '@civitai/*'` selects them, and none collides with a `packages/` project name. Globbed on the config file rather than the directory, same reason as the packages: `creator-studio`, `event-engine` and `moderator` have no vitest config and must not be adopted under a default `include` they were never written against.

**The ledger.** `scripts/ci/assert-package-suites-ran.mjs` hardcoded `packages` in *two* places — the on-disk scan and the report matcher — so it could not have observed an `apps/*` dropout even once those suites were running. Both now derive from one `WORKSPACE_ROOTS` list; entries are keyed `<root>/<dir>`; a root that scans to zero fails on its own rather than hiding behind the other root's nine entries. The floor moves 500 → 1000, deliberately set *above* the packages-only total of 957 so a wholesale `apps/*` disappearance trips two independent tripwires rather than one.

Both of #3642's ledger fixes are preserved and re-verified by mutation: it still scans the whole package rather than only `src/`, and still requires a non-zero **executed** count so a wholly-skipped package fails.

## Before / after

Measured in a clean worktree off `main` (`ebe9aa278b`), node 22.22.2 / pnpm 10.28.1, no root `.env`, `DATABASE_URL` and the S3 vars unset to match a runner:

| | files | tests | executed | skipped | wall |
|---|---|---|---|---|---|
| before | 72 | 957 | 953 | 4 | 11.6s |
| after | 114 | 1318 | 1314 | 4 | 16–24s |

+42 files / +361 tests. **Zero failures, zero pre-existing failures surfaced, zero new skips** — the 4 skips are `@civitai/db-queries`' DB-backed tier in both columns. The added file count equals the corpus on disk (42 test files under the four apps' `src/`), and the run's own summary line is present in both, so neither number is derived from a truncated run.

`vitest list --project unit` still resolves 12,603 tests with the new globs in place, so the existing `unit` job is unaffected.

## Verification

**Red on purpose.** A deliberately failing test injected into each of the four apps: 4 FAILs, each attributed to its project (`FAIL @civitai/storage-app src/__tests__/app.test.ts > …`), vitest exit 1, then reverted to byte-identical files. Proves all four projects genuinely execute rather than merely collect.

**The ledger change is load-bearing.** On the *same real* packages-only JSON report, `main`'s ledger prints `OK: every package suite with tests on disk executed.` and exits 0; this one exits 1 and names `apps/auth, apps/notifications, apps/orchestrator-gateway, apps/storage`.

**8 controls over a synthetic fixture**, each mutant verified to have actually applied before its result was read:

| variant × report | rc | meaning |
|---|---|---|
| shipped × FULL | 0 | positive control — everything present passes |
| shipped × NO_APPS | 1 | an `apps/*` dropout fails |
| mutant `packages`-only × NO_APPS | 0 | `main`'s ledger cannot see it — the gap |
| shipped × APP_ALL_SKIPPED | 1 | a wholly-skipped app is not an app that ran |
| mutant counting skips × APP_ALL_SKIPPED | 0 | that guard is load-bearing |
| shipped × NO_PKG_A | 1 | a package whose tests live in a top-level `__tests__/` is expected |
| mutant `src/`-only scan × NO_PKG_A | 0 | that guard is load-bearing |
| shipped × FULL | — | a package with tests but *no* vitest config is correctly not expected |

## Judgement calls

**One job, not two.** The job is dominated by checkout + install; the apps add ~12s of test time against the ~1–2 min a duplicate install would cost. The usual argument for splitting is attribution, and vitest already prefixes every file and every failure with its project name, plus the ledger step prints a per-package table.

**Kept blocking (not `continue-on-error`).** The four suites clear the same bar the packages did: `apps/{orchestrator-gateway,storage,notifications}` drive their Fastify apps through `app.inject()` — an in-process request, so no port is bound and no port can collide on a shared runner — their backends/DB/redis clients are `vi.mock`ed, `apps/auth` stubs SvelteKit's `$env`/`$app` virtual modules in its own config, and the env-sensitive tests set and delete their own `process.env` keys rather than reading ambient ones. Nothing reaches the network, a real clock, or a real database.

**Renamed to `Workspace unit tests`** (job display name, step name, and the three stale references in `.gitignore` and the schema-drift README), since it is no longer packages-only. Nothing depends on the old name.

⚠️ **This check is advisory, not a merge gate.** `main` has branch protection but no `required_status_checks`, and its one active ruleset (`protect-deploy-branches-from-deletion`) only forbids deletion — verified against the API on this branch. A PR can merge with this red. What the change buys is that it renders **red** rather than red-but-ignored. Making it an interlock is a repo-settings change, not a workflow one.

## Not verified

Everything above was measured locally in a worktree, not on a GitHub runner. Two axes differ and I did not vary them: node (22.22.2 from the flake vs `.nvmrc`'s 24.18.0 in CI) and the runner OS. The suites are hermetic enough that I do not expect either to matter, but the first CI run on this PR is the actual evidence for that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
